### PR TITLE
notebooks: persist compute block

### DIFF
--- a/client/web/src/integration/notebook.test.ts
+++ b/client/web/src/integration/notebook.test.ts
@@ -116,6 +116,12 @@ const GQLBlockInputToResponse = (block: CreateNotebookBlockInput): NotebookBlock
                     symbolKind: block.symbolInput?.symbolKind ?? SymbolKind.UNKNOWN,
                 },
             }
+        case NotebookBlockType.COMPUTE:
+            return {
+                __typename: 'ComputeBlock',
+                id: block.id,
+                computeInput: block.computeInput ?? '',
+            }
     }
 }
 

--- a/client/web/src/notebooks/backend.ts
+++ b/client/web/src/notebooks/backend.ts
@@ -89,6 +89,11 @@ const notebooksFragment = gql`
                     symbolKind
                 }
             }
+            ... on ComputeBlock {
+                __typename
+                id
+                computeInput
+            }
         }
     }
 `

--- a/client/web/src/notebooks/listPage/ImportMarkdownNotebookButton.tsx
+++ b/client/web/src/notebooks/listPage/ImportMarkdownNotebookButton.tsx
@@ -47,8 +47,8 @@ export const ImportMarkdownNotebookButton: React.FunctionComponent<ImportMarkdow
                 setImportState(INVALID_IMPORT_FILE_ERROR)
                 return
             }
-            const blocks = convertMarkdownToBlocks(event.target.result).flatMap(block =>
-                block.type === 'compute' ? [] : [blockToGQLInput({ id: uuid.v4(), ...block })]
+            const blocks = convertMarkdownToBlocks(event.target.result).map(block =>
+                blockToGQLInput({ id: uuid.v4(), ...block })
             )
             const title = fileName.split('.snb.md')[0].trim() || 'New Notebook'
             importNotebook({ title, blocks, public: false, namespace: authenticatedUser.id })

--- a/client/web/src/notebooks/notebook/index.ts
+++ b/client/web/src/notebooks/notebook/index.ts
@@ -28,7 +28,7 @@ export function copyNotebook({ title, blocks, namespace }: CopyNotebookProps): O
     return createNotebook({
         notebook: {
             title,
-            blocks: blocks.flatMap(block => (block.type === 'compute' ? [] : [blockToGQLInput(block)])),
+            blocks: blocks.map(blockToGQLInput),
             namespace,
             public: false,
         },
@@ -209,6 +209,8 @@ export class Notebook {
                 this.blocks.set(block.id, { ...block, output })
                 break
             }
+            case 'compute':
+                this.blocks.set(block.id, { ...block, output: null })
         }
     }
 
@@ -231,6 +233,8 @@ export class Notebook {
                 observables.push(block.output.pipe(mapTo(DONE)))
             } else if (block.type === 'symbol') {
                 observables.push(block.output.pipe(mapTo(DONE)))
+            } else if (block.type === 'compute') {
+                // Noop: Compute block does not currently emit an output observable.
             }
         }
         // We store output observables and join them into a single observable,

--- a/client/web/src/notebooks/notebookPage/NotebookContent.tsx
+++ b/client/web/src/notebooks/notebookPage/NotebookContent.tsx
@@ -62,6 +62,12 @@ export const NotebookContent: React.FunctionComponent<NotebookContentProps> = ({
                             type: 'symbol',
                             input: { ...block.symbolInput, revision: block.symbolInput.revision ?? '' },
                         }
+                    case 'ComputeBlock':
+                        return {
+                            id: block.id,
+                            type: 'compute',
+                            input: block.computeInput,
+                        }
                 }
             }),
         [blocks]

--- a/client/web/src/notebooks/notebookPage/NotebookPage.tsx
+++ b/client/web/src/notebooks/notebookPage/NotebookPage.tsx
@@ -149,12 +149,7 @@ export const NotebookPage: React.FunctionComponent<NotebookPageProps> = ({
     }, [updateQueue, latestNotebook, onUpdateNotebook, setUpdateQueue])
 
     const onUpdateBlocks = useCallback(
-        (blocks: Block[]) =>
-            setUpdateQueue(queue =>
-                queue.concat([
-                    { blocks: blocks.flatMap(block => (block.type === 'compute' ? [] : [blockToGQLInput(block)])) },
-                ])
-            ),
+        (blocks: Block[]) => setUpdateQueue(queue => queue.concat([{ blocks: blocks.map(blockToGQLInput) }])),
         [setUpdateQueue]
     )
 

--- a/client/web/src/notebooks/serialize/index.ts
+++ b/client/web/src/notebooks/serialize/index.ts
@@ -168,7 +168,7 @@ export function blockToGQLInput(block: BlockInit): CreateNotebookBlockInput {
         case 'symbol':
             return { id: block.id, type: NotebookBlockType.SYMBOL, symbolInput: block.input }
         case 'compute':
-            throw new Error('Unreachable: Compute block deserialization not supported yet.')
+            return { id: block.id, type: NotebookBlockType.COMPUTE, computeInput: block.input }
     }
 }
 
@@ -189,6 +189,12 @@ export function GQLBlockToGQLInput(block: NotebookBlock): CreateNotebookBlockInp
                 id: block.id,
                 type: NotebookBlockType.SYMBOL,
                 symbolInput: block.symbolInput,
+            }
+        case 'ComputeBlock':
+            return {
+                id: block.id,
+                type: NotebookBlockType.COMPUTE,
+                computeInput: block.computeInput,
             }
     }
 }

--- a/cmd/frontend/graphqlbackend/notebooks.go
+++ b/cmd/frontend/graphqlbackend/notebooks.go
@@ -66,6 +66,7 @@ type NotebookBlockResolver interface {
 	ToQueryBlock() (QueryBlockResolver, bool)
 	ToFileBlock() (FileBlockResolver, bool)
 	ToSymbolBlock() (SymbolBlockResolver, bool)
+	ToComputeBlock() (ComputeBlockResolver, bool)
 }
 
 type MarkdownBlockResolver interface {
@@ -105,6 +106,11 @@ type SymbolBlockInputResolver interface {
 	SymbolKind() string
 }
 
+type ComputeBlockResolver interface {
+	ID() string
+	ComputeInput() string
+}
+
 type FileBlockLineRangeResolver interface {
 	StartLine() int32
 	EndLine() int32
@@ -117,6 +123,7 @@ const (
 	NotebookQueryBlockType    NotebookBlockType = "QUERY"
 	NotebookFileBlockType     NotebookBlockType = "FILE"
 	NotebookSymbolBlockType   NotebookBlockType = "SYMBOL"
+	NotebookComputeBlockType  NotebookBlockType = "COMPUTE"
 )
 
 type CreateNotebookInputArgs struct {
@@ -146,6 +153,7 @@ type CreateNotebookBlockInputArgs struct {
 	QueryInput    *string                 `json:"queryInput"`
 	FileInput     *CreateFileBlockInput   `json:"fileInput"`
 	SymbolInput   *CreateSymbolBlockInput `json:"symbolInput"`
+	ComputeInput  *string                 `json:"computeInput"`
 }
 
 type CreateFileBlockInput struct {

--- a/cmd/frontend/graphqlbackend/notebooks.graphql
+++ b/cmd/frontend/graphqlbackend/notebooks.graphql
@@ -232,9 +232,23 @@ type SymbolBlock {
 }
 
 """
-Notebook blocks are represented as a union between four distinct block types: Markdown, Query, File, and Symbol.
+Compute block runs compute queries in a notebook.
 """
-union NotebookBlock = MarkdownBlock | QueryBlock | FileBlock | SymbolBlock
+type ComputeBlock {
+    """
+    ID of the block.
+    """
+    id: String!
+    """
+    An value encoding compute inputs.
+    """
+    computeInput: String!
+}
+
+"""
+Notebook blocks are a union of distinct block types: Markdown, Query, File, Symbol, and Compute.
+"""
+union NotebookBlock = MarkdownBlock | QueryBlock | FileBlock | SymbolBlock | ComputeBlock
 
 """
 A notebook with an array of blocks.
@@ -412,6 +426,7 @@ enum NotebookBlockType {
     QUERY
     FILE
     SYMBOL
+    COMPUTE
 }
 
 """
@@ -443,6 +458,10 @@ input CreateNotebookBlockInput {
     Symbol input.
     """
     symbolInput: CreateSymbolBlockInput
+    """
+    Compute input.
+    """
+    computeInput: String
 }
 
 """

--- a/enterprise/cmd/frontend/internal/notebooks/resolvers/apitest/convert.go
+++ b/enterprise/cmd/frontend/internal/notebooks/resolvers/apitest/convert.go
@@ -30,6 +30,8 @@ func BlockToAPIResponse(block notebooks.NotebookBlock) NotebookBlock {
 			SymbolContainerName: block.SymbolInput.SymbolContainerName,
 			SymbolKind:          block.SymbolInput.SymbolKind,
 		}}
+	case notebooks.NotebookComputeBlockType:
+		return NotebookBlock{Typename: "ComputeBlock", ID: block.ID, ComputeInput: block.ComputeInput.Value}
 	}
 	panic("unknown block type")
 }
@@ -75,6 +77,8 @@ func BlockToAPIInput(block notebooks.NotebookBlock) graphqlbackend.CreateNoteboo
 			SymbolContainerName: block.SymbolInput.SymbolContainerName,
 			SymbolKind:          block.SymbolInput.SymbolKind,
 		}}
+	case notebooks.NotebookComputeBlockType:
+		return graphqlbackend.CreateNotebookBlockInputArgs{ID: block.ID, Type: graphqlbackend.NotebookComputeBlockType, ComputeInput: &block.ComputeInput.Value}
 	}
 	panic("unknown block type")
 }

--- a/enterprise/cmd/frontend/internal/notebooks/resolvers/apitest/types.go
+++ b/enterprise/cmd/frontend/internal/notebooks/resolvers/apitest/types.go
@@ -23,6 +23,7 @@ type NotebookBlock struct {
 	QueryInput    string
 	FileInput     FileInput
 	SymbolInput   SymbolInput
+	ComputeInput  string
 }
 
 type FileInput struct {

--- a/enterprise/cmd/frontend/internal/notebooks/resolvers/resolvers.go
+++ b/enterprise/cmd/frontend/internal/notebooks/resolvers/resolvers.go
@@ -106,6 +106,12 @@ func convertNotebookBlockInput(inputBlock graphqlbackend.CreateNotebookBlockInpu
 			SymbolContainerName: inputBlock.SymbolInput.SymbolContainerName,
 			SymbolKind:          inputBlock.SymbolInput.SymbolKind,
 		}
+	case graphqlbackend.NotebookComputeBlockType:
+		if inputBlock.ComputeInput == nil {
+			return nil, errors.Errorf("query block with id %s is missing input", inputBlock.ID)
+		}
+		block.Type = notebooks.NotebookComputeBlockType
+		block.ComputeInput = &notebooks.NotebookComputeBlockInput{Value: *inputBlock.ComputeInput}
 	default:
 		return nil, errors.Newf("invalid block type: %s", inputBlock.Type)
 	}
@@ -491,6 +497,13 @@ func (r *notebookBlockResolver) ToSymbolBlock() (graphqlbackend.SymbolBlockResol
 	return nil, false
 }
 
+func (r *notebookBlockResolver) ToComputeBlock() (graphqlbackend.ComputeBlockResolver, bool) {
+	if r.block.Type == notebooks.NotebookComputeBlockType {
+		return &computeBlockResolver{r.block}, true
+	}
+	return nil, false
+}
+
 type markdownBlockResolver struct {
 	// block.type == NotebookMarkdownBlockType
 	block notebooks.NotebookBlock
@@ -608,4 +621,17 @@ func (r *symbolBlockInputResolver) SymbolContainerName() string {
 
 func (r *symbolBlockInputResolver) SymbolKind() string {
 	return r.input.SymbolKind
+}
+
+type computeBlockResolver struct {
+	// block.type == NotebookComputeBlockType
+	block notebooks.NotebookBlock
+}
+
+func (r *computeBlockResolver) ID() string {
+	return r.block.ID
+}
+
+func (r *computeBlockResolver) ComputeInput() string {
+	return r.block.ComputeInput.Value
 }

--- a/enterprise/cmd/frontend/internal/notebooks/resolvers/resolvers_test.go
+++ b/enterprise/cmd/frontend/internal/notebooks/resolvers/resolvers_test.go
@@ -72,6 +72,11 @@ const notebookFields = `
 				symbolKind
 			}
 		}
+		... on ComputeBlock {
+			__typename
+			id
+			computeInput
+		}
 	}
 `
 
@@ -144,6 +149,9 @@ func notebookFixture(creatorID int32, namespaceUserID int32, namespaceOrgID int3
 			SymbolContainerName: "container",
 			SymbolKind:          "FUNCTION",
 		}},
+		{ID: "5", Type: notebooks.NotebookComputeBlockType, ComputeInput: &notebooks.NotebookComputeBlockInput{
+			Value: "github.com/sourcegraph/sourcegraph"},
+		},
 	}
 	return &notebooks.Notebook{Title: "Notebook Title", Blocks: blocks, Public: public, CreatorUserID: creatorID, UpdaterUserID: creatorID, NamespaceUserID: namespaceUserID, NamespaceOrgID: namespaceOrgID}
 }

--- a/enterprise/internal/notebooks/store_test.go
+++ b/enterprise/internal/notebooks/store_test.go
@@ -63,6 +63,9 @@ func TestCreateAndGetNotebook(t *testing.T) {
 			SymbolContainerName: "container",
 			SymbolKind:          "FUNCTION",
 		}},
+		{ID: "5", Type: NotebookComputeBlockType, ComputeInput: &NotebookComputeBlockInput{
+			Value: "github.com/sourcegraph/sourcegraph"},
+		},
 	}
 	notebook := notebookByUser(&Notebook{Title: "Notebook Title", Blocks: blocks, Public: true}, user.ID)
 	createdNotebook, err := n.CreateNotebook(ctx, notebook)

--- a/enterprise/internal/notebooks/types.go
+++ b/enterprise/internal/notebooks/types.go
@@ -11,6 +11,7 @@ const (
 	NotebookMarkdownBlockType NotebookBlockType = "md"
 	NotebookFileBlockType     NotebookBlockType = "file"
 	NotebookSymbolBlockType   NotebookBlockType = "symbol"
+	NotebookComputeBlockType  NotebookBlockType = "compute"
 )
 
 type NotebookQueryBlockInput struct {
@@ -46,6 +47,10 @@ type NotebookSymbolBlockInput struct {
 	SymbolKind          string  `json:"symbolKind"`
 }
 
+type NotebookComputeBlockInput struct {
+	Value string `json:"value"`
+}
+
 type NotebookBlock struct {
 	ID            string                      `json:"id"`
 	Type          NotebookBlockType           `json:"type"`
@@ -53,6 +58,7 @@ type NotebookBlock struct {
 	MarkdownInput *NotebookMarkdownBlockInput `json:"markdownInput,omitempty"`
 	FileInput     *NotebookFileBlockInput     `json:"fileInput,omitempty"`
 	SymbolInput   *NotebookSymbolBlockInput   `json:"symbolInput,omitempty"`
+	ComputeInput  *NotebookComputeBlockInput  `json:"computeInput,omitempty"`
 }
 
 type NotebookBlocks []NotebookBlock

--- a/enterprise/internal/notebooks/validate.go
+++ b/enterprise/internal/notebooks/validate.go
@@ -3,7 +3,11 @@ package notebooks
 import "github.com/sourcegraph/sourcegraph/lib/errors"
 
 func validateNotebookBlock(block NotebookBlock) error {
-	if block.Type != NotebookQueryBlockType && block.Type != NotebookMarkdownBlockType && block.Type != NotebookFileBlockType && block.Type != NotebookSymbolBlockType {
+	if block.Type != NotebookQueryBlockType &&
+		block.Type != NotebookMarkdownBlockType &&
+		block.Type != NotebookFileBlockType &&
+		block.Type != NotebookSymbolBlockType &&
+		block.Type != NotebookComputeBlockType {
 		return errors.Errorf("invalid block type: %s", string(block.Type))
 	}
 
@@ -15,6 +19,8 @@ func validateNotebookBlock(block NotebookBlock) error {
 		return errors.Errorf("invalid file block with id: %s", block.ID)
 	} else if block.Type == NotebookSymbolBlockType && block.SymbolInput == nil {
 		return errors.Errorf("invalid symbol block with id: %s", block.ID)
+	} else if block.Type == NotebookComputeBlockType && block.ComputeInput == nil {
+		return errors.Errorf("invalid compute block with id: %s", block.ID)
 	}
 
 	if block.Type == NotebookSymbolBlockType && block.SymbolInput != nil && block.SymbolInput.LineContext < 0 {

--- a/enterprise/internal/notebooks/validate_test.go
+++ b/enterprise/internal/notebooks/validate_test.go
@@ -22,6 +22,7 @@ func TestNotebookBlocksValidation(t *testing.T) {
 		{blocks: NotebookBlocks{
 			{ID: "id1", SymbolInput: &NotebookSymbolBlockInput{LineContext: -10}, Type: NotebookSymbolBlockType},
 		}, wantErr: "symbol block line context cannot be negative, block id: id1"},
+		{blocks: NotebookBlocks{{ID: "id1", Type: NotebookComputeBlockType}}, wantErr: "invalid compute block with id: id1"},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
This persists the presence of compute blocks. It does not yet persist the values like the query string yet, I will add that in a follow up since the interop can happen separately and is probably a relatively small change compared to this boiler code.

## Test plan
Frontend/backend tests updated for resolvers and pipeline. Tested manually adding/removing cells in web app.

