### PR TITLE
user invitations: exclude 'user public repos', forks, archived repos from collab discovery

### DIFF
--- a/cmd/frontend/graphqlbackend/user_collaborators.go
+++ b/cmd/frontend/graphqlbackend/user_collaborators.go
@@ -32,7 +32,9 @@ func (r *UserResolver) InvitableCollaborators(ctx context.Context) ([]*invitable
 	pickedRepos, err := backend.NewRepos(r.db.Repos()).List(ctx, database.ReposListOptions{
 		// SECURITY: This must be the authenticated user's ID.
 		UserID:                 a.UID,
-		IncludeUserPublicRepos: true,
+		IncludeUserPublicRepos: false,
+		NoForks:                true,
+		NoArchived:             true,
 		OrderBy: database.RepoListOrderBy{{
 			Field:      "stars",
 			Descending: true,


### PR DESCRIPTION
collaborator discovery prior to this commit came from the user's repos which was including:

* 'user public repos' which apparently "are not repos owned by this user, just ones they are interested in."
    * this is very confusing to me, I don't know exactly what these are, I'm asking for clarity https://sourcegraph.slack.com/archives/C07KZF47K/p1647308895326289
    * for now I'm removing them from collab. discovery, if they're not owned by the user they're a bad source to find collaborators most likely.
* forks / archived repos, obviously these are bad sources to find collaborators from.

Should help improve the results that e.g. Tomas got here: https://sourcegraph.slack.com/archives/C01LZKLRF0C/p1647115816296369

Signed-off-by: Stephen Gutekanst <stephen@sourcegraph.com>

## Test plan

Manually tested, we have unit tests covering much of the logic in this endpoint but not mocking out the repository listing behavior. May be worth investing in later if this feature remains worthwhile / after the experiment is over.
