### PR TITLE
CLOUD-290 CLOUD-214 Handle GitHub App installation callbacks

### DIFF
--- a/client/web/src/org/settings/codeHosts/InstallGitHubAppSuccessPage.tsx
+++ b/client/web/src/org/settings/codeHosts/InstallGitHubAppSuccessPage.tsx
@@ -1,0 +1,27 @@
+import GithubIcon from 'mdi-react/GithubIcon'
+import React from 'react'
+
+import { Card, CardBody, PageHeader } from '@sourcegraph/wildcard'
+
+import { Page } from '../../../components/Page'
+import { PageTitle } from '../../../components/PageTitle'
+
+export const InstallGithubAppSuccessPage: React.FunctionComponent<{}> = () => (
+    <Page>
+        <PageTitle>Success!</PageTitle>
+        <PageHeader
+            path={[
+                {
+                    icon: GithubIcon,
+                    text: 'Success!',
+                },
+            ]}
+            className="mb-3"
+        />
+        <Card>
+            <CardBody>
+                <p>The Sourcegraph GitHub App has been successfully installed!</p>
+            </CardBody>
+        </Card>
+    </Page>
+)

--- a/client/web/src/org/settings/codeHosts/InstallGitHubAppSuccessPage.tsx
+++ b/client/web/src/org/settings/codeHosts/InstallGitHubAppSuccessPage.tsx
@@ -6,7 +6,7 @@ import { Card, CardBody, PageHeader } from '@sourcegraph/wildcard'
 import { Page } from '../../../components/Page'
 import { PageTitle } from '../../../components/PageTitle'
 
-export const InstallGithubAppSuccessPage: React.FunctionComponent<{}> = () => (
+export const InstallGitHubAppSuccessPage: React.FunctionComponent<{}> = () => (
     <Page>
         <PageTitle>Success!</PageTitle>
         <PageHeader

--- a/client/web/src/routes.constants.ts
+++ b/client/web/src/routes.constants.ts
@@ -22,6 +22,7 @@ export enum PageRoutes {
     Notebook = '/notebooks/:id',
     Notebooks = '/notebooks',
     RepoContainer = '/:repoRevAndRest+',
+    InstallGitHubAppSuccess = '/install-github-app-success',
 }
 
 export enum EnterprisePageRoutes {

--- a/client/web/src/routes.tsx
+++ b/client/web/src/routes.tsx
@@ -11,6 +11,7 @@ import { BreadcrumbsProps, BreadcrumbSetters } from './components/Breadcrumbs'
 import type { LayoutProps } from './Layout'
 import { CreateNotebookPage } from './notebooks/createPage/CreateNotebookPage'
 import { NotebooksListPage } from './notebooks/listPage/NotebooksListPage'
+import { InstallGithubAppSuccessPage } from './org/settings/codeHosts/InstallGitHubAppSuccessPage'
 import type { ExtensionAlertProps } from './repo/actions/InstallIntegrationsAlert'
 import { PageRoutes } from './routes.constants'
 import { SearchPageWrapper } from './search/SearchPageWrapper'
@@ -168,6 +169,10 @@ export const routes: readonly LayoutRouteProps<any>[] = [
             ),
 
         exact: true,
+    },
+    {
+        path: PageRoutes.InstallGitHubAppSuccess,
+        render: () => <InstallGithubAppSuccessPage />,
     },
     {
         path: PageRoutes.Settings,

--- a/client/web/src/routes.tsx
+++ b/client/web/src/routes.tsx
@@ -11,7 +11,7 @@ import { BreadcrumbsProps, BreadcrumbSetters } from './components/Breadcrumbs'
 import type { LayoutProps } from './Layout'
 import { CreateNotebookPage } from './notebooks/createPage/CreateNotebookPage'
 import { NotebooksListPage } from './notebooks/listPage/NotebooksListPage'
-import { InstallGithubAppSuccessPage } from './org/settings/codeHosts/InstallGitHubAppSuccessPage'
+import { InstallGitHubAppSuccessPage } from './org/settings/codeHosts/InstallGitHubAppSuccessPage'
 import type { ExtensionAlertProps } from './repo/actions/InstallIntegrationsAlert'
 import { PageRoutes } from './routes.constants'
 import { SearchPageWrapper } from './search/SearchPageWrapper'
@@ -172,7 +172,7 @@ export const routes: readonly LayoutRouteProps<any>[] = [
     },
     {
         path: PageRoutes.InstallGitHubAppSuccess,
-        render: () => <InstallGithubAppSuccessPage />,
+        render: () => <InstallGitHubAppSuccessPage />,
     },
     {
         path: PageRoutes.Settings,

--- a/client/web/src/user/settings/codeHosts/CodeHostItem.tsx
+++ b/client/web/src/user/settings/codeHosts/CodeHostItem.tsx
@@ -4,7 +4,7 @@ import CheckCircleIcon from 'mdi-react/CheckCircleIcon'
 import React, { useState, useCallback } from 'react'
 
 import { ErrorLike } from '@sourcegraph/common'
-import { Button, Icon } from '@sourcegraph/wildcard'
+import { Button, Badge, Icon } from '@sourcegraph/wildcard'
 
 import { CircleDashedIcon } from '../../../components/CircleDashedIcon'
 import { LoaderButton } from '../../../components/LoaderButton'
@@ -35,10 +35,12 @@ interface CodeHostItemProps {
     onDidError: (error: ErrorLike) => void
     loading?: boolean
     useGitHubApp?: boolean
+    reloadComponent?: (reason: string | null) => void
+    pending?: boolean
 }
 
 export interface ParentWindow extends Window {
-    onSuccess?: () => void
+    onSuccess?: (reason: string | null) => void
 }
 
 export const CodeHostItem: React.FunctionComponent<CodeHostItemProps> = ({
@@ -57,6 +59,8 @@ export const CodeHostItem: React.FunctionComponent<CodeHostItemProps> = ({
     onDidUpsert,
     loading = false,
     useGitHubApp = false,
+    reloadComponent,
+    pending,
 }) => {
     const [isAddConnectionModalOpen, setIsAddConnectionModalOpen] = useState(false)
     const toggleAddConnectionModal = useCallback(() => setIsAddConnectionModalOpen(!isAddConnectionModalOpen), [
@@ -132,7 +136,9 @@ export const CodeHostItem: React.FunctionComponent<CodeHostItemProps> = ({
                 <Icon className="mb-0 mr-1" as={ItemIcon} />
             </div>
             <div className="flex-1 align-self-center">
-                <h3 className="m-0">{name}</h3>
+                <h3 className="m-0">
+                    {name} {pending ? <Badge color="secondary">Pending</Badge> : null}
+                </h3>
             </div>
             <div className="align-self-center">
                 {/* Show one of: update, updating, connect, connecting buttons */}

--- a/client/web/src/user/settings/codeHosts/UserAddCodeHostsPage.tsx
+++ b/client/web/src/user/settings/codeHosts/UserAddCodeHostsPage.tsx
@@ -212,8 +212,8 @@ export const UserAddCodeHostsPage: React.FunctionComponent<UserAddCodeHostsPageP
     const getRequestSuccessBanner = (requestSuccess: boolean): JSX.Element | null =>
         requestSuccess ? (
             <Alert className="mb-4" role="alert" key="update-gitlab" variant="info">
-                An installation request has been sent to your GitHub organization administrators. Once the installation
-                has been approved, click on Connect again to finish connecting your code host connection.
+                <h4>GitHub code host connection pending</h4>
+                An installation request was sent to your GitHub organization’s owners. After the request is approved, finish connecting with GitHub to choose repositories to sync with Sourcegraph.
             </Alert>
         ) : null
 

--- a/client/web/src/user/settings/codeHosts/UserAddCodeHostsPage.tsx
+++ b/client/web/src/user/settings/codeHosts/UserAddCodeHostsPage.tsx
@@ -213,7 +213,8 @@ export const UserAddCodeHostsPage: React.FunctionComponent<UserAddCodeHostsPageP
         requestSuccess ? (
             <Alert className="mb-4" role="alert" key="update-gitlab" variant="info">
                 <h4>GitHub code host connection pending</h4>
-                An installation request was sent to your GitHub organization’s owners. After the request is approved, finish connecting with GitHub to choose repositories to sync with Sourcegraph.
+                An installation request was sent to your GitHub organization’s owners. After the request is approved,
+                finish connecting with GitHub to choose repositories to sync with Sourcegraph.
             </Alert>
         ) : null
 

--- a/enterprise/cmd/frontend/internal/app/app.go
+++ b/enterprise/cmd/frontend/internal/app/app.go
@@ -17,6 +17,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/enterprise"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
+	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
@@ -100,6 +101,14 @@ func newGitHubAppCloudSetupHandler(db database.DB, apiURL *url.URL, client githu
 		}
 
 		setupAction := r.URL.Query().Get("setup_action")
+
+		a := actor.FromContext(r.Context())
+
+		if !a.IsAuthenticated() {
+			if setupAction == "install" {
+				http.Redirect(w, r, "/install_success", http.StatusFound)
+			}
+		}
 
 		state := r.URL.Query().Get("state")
 		orgID, err := graphqlbackend.UnmarshalOrgID(graphql.ID(state))

--- a/enterprise/cmd/frontend/internal/app/app.go
+++ b/enterprise/cmd/frontend/internal/app/app.go
@@ -113,7 +113,6 @@ func newGitHubAppCloudSetupHandler(db database.DB, apiURL *url.URL, client githu
 				http.Redirect(w, r, "/install-github-app-request", http.StatusFound)
 				return
 			}
-
 		}
 
 		state := r.URL.Query().Get("state")

--- a/enterprise/cmd/frontend/internal/app/app.go
+++ b/enterprise/cmd/frontend/internal/app/app.go
@@ -168,13 +168,6 @@ func newGitHubAppCloudSetupHandler(db database.DB, apiURL *url.URL, client githu
 			return
 		}
 
-		err = backend.CheckOrgAccess(r.Context(), db, orgID)
-		if err != nil {
-			w.WriteHeader(http.StatusBadRequest)
-			_, _ = w.Write([]byte("the authenticated user does not belong to the organization requested"))
-			return
-		}
-
 		err = checkIfOrgCanInstallGitHubApp(r.Context(), db, orgID)
 		if err != nil {
 			w.WriteHeader(http.StatusForbidden)
@@ -182,11 +175,17 @@ func newGitHubAppCloudSetupHandler(db database.DB, apiURL *url.URL, client githu
 			return
 		}
 
-		var svc *types.ExternalService
-		if setupAction == "request" {
+		err = backend.CheckOrgAccess(r.Context(), db, orgID)
+		if err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte("the authenticated user does not belong to the organization requested"))
+			return
+		}
 
-			displayName := "GitHub"
-			now := time.Now()
+		var svc *types.ExternalService
+		displayName := "GitHub"
+		now := time.Now()
+		if setupAction == "request" {
 
 			if len(svcs) == 0 {
 				svc = &types.ExternalService{
@@ -243,11 +242,9 @@ func newGitHubAppCloudSetupHandler(db database.DB, apiURL *url.URL, client githu
 			return
 		}
 
-		displayName := "GitHub"
 		if ins.Account.Login != nil {
 			displayName = fmt.Sprintf("GitHub (%s)", *ins.Account.Login)
 		}
-		now := time.Now()
 
 		if len(svcs) == 0 {
 			svc = &types.ExternalService{

--- a/enterprise/cmd/frontend/internal/app/app.go
+++ b/enterprise/cmd/frontend/internal/app/app.go
@@ -192,10 +192,10 @@ func newGitHubAppCloudSetupHandler(db database.DB, apiURL *url.URL, client githu
 				DisplayName: displayName,
 				Config: fmt.Sprintf(`
 {
-"url": "%s",
-"repos": []
+  "url": "%s",
+  "repos": []
 }
-	`, apiURL.String()),
+`, apiURL.String()),
 				NamespaceOrgID: org.ID,
 				CreatedAt:      now,
 				UpdatedAt:      now,

--- a/enterprise/cmd/frontend/internal/app/app_test.go
+++ b/enterprise/cmd/frontend/internal/app/app_test.go
@@ -57,11 +57,21 @@ func TestNewGitHubAppCloudSetupHandler(t *testing.T) {
 	)
 
 	req, err := http.NewRequest(http.MethodGet, "/.setup/github-app-cloud?installation_id=21994992&setup_action=install&state=T3JnOjE%3D", nil)
-	ctx := a.WithActor(req.Context(), &a.Actor{UID: 1})
-	req = req.WithContext(ctx)
+
 	require.Nil(t, err)
 
 	h := newGitHubAppCloudSetupHandler(db, apiURL, client)
+
+	t.Run("user not logged in (no actor in context)", func(t *testing.T) {
+		resp := httptest.NewRecorder()
+		h.ServeHTTP(resp, req)
+
+		assert.Equal(t, http.StatusFound, resp.Code)
+		assert.Equal(t, "/install-github-app-success", resp.Header().Get("Location"))
+	})
+
+	ctx := a.WithActor(req.Context(), &a.Actor{UID: 1})
+	req = req.WithContext(ctx)
 
 	t.Run("feature flag not enabled", func(t *testing.T) {
 		resp := httptest.NewRecorder()

--- a/enterprise/cmd/frontend/internal/app/app_test.go
+++ b/enterprise/cmd/frontend/internal/app/app_test.go
@@ -70,6 +70,17 @@ func TestNewGitHubAppCloudSetupHandler(t *testing.T) {
 		assert.Equal(t, "/install-github-app-success", resp.Header().Get("Location"))
 	})
 
+	t.Run("invalid setup action", func(t *testing.T) {
+		resp := httptest.NewRecorder()
+		badReq, err := http.NewRequest(http.MethodGet, "/.setup/github-app-cloud?installation_id=21994992&setup_action=incorrect&state=T3JnOjE%3D", nil)
+		require.Nil(t, err)
+
+		h.ServeHTTP(resp, badReq)
+
+		assert.Equal(t, http.StatusBadRequest, resp.Code)
+		assert.Equal(t, "Invalid setup action 'incorrect'", resp.Body.String())
+	})
+
 	ctx := a.WithActor(req.Context(), &a.Actor{UID: 1})
 	req = req.WithContext(ctx)
 

--- a/enterprise/cmd/frontend/internal/app/app_test.go
+++ b/enterprise/cmd/frontend/internal/app/app_test.go
@@ -115,8 +115,9 @@ func TestNewGitHubAppCloudSetupHandler(t *testing.T) {
 			wantConfig := `
 {
   "url": "https://github.com",
+  "repos": [],
   "githubAppInstallationID": "21994992",
-  "repos": []
+  "pending": false
 }
 `
 			assert.Equal(t, wantConfig, svc.Config)
@@ -159,7 +160,8 @@ func TestNewGitHubAppCloudSetupHandler(t *testing.T) {
 {
   "url": "https://github.com",
   "repos": [],
-  "githubAppInstallationID": "21994992"
+  "githubAppInstallationID": "21994992",
+  "pending": false
 }
 `
 			assert.Equal(t, wantConfig, svc.Config)

--- a/enterprise/cmd/frontend/internal/app/app_test.go
+++ b/enterprise/cmd/frontend/internal/app/app_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
+	a "github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/types"
@@ -56,6 +57,8 @@ func TestNewGitHubAppCloudSetupHandler(t *testing.T) {
 	)
 
 	req, err := http.NewRequest(http.MethodGet, "/.setup/github-app-cloud?installation_id=21994992&setup_action=install&state=T3JnOjE%3D", nil)
+	ctx := a.WithActor(req.Context(), &a.Actor{UID: 1})
+	req = req.WithContext(ctx)
 	require.Nil(t, err)
 
 	h := newGitHubAppCloudSetupHandler(db, apiURL, client)

--- a/enterprise/cmd/frontend/internal/auth/oauth/middleware.go
+++ b/enterprise/cmd/frontend/internal/auth/oauth/middleware.go
@@ -108,6 +108,9 @@ func newOAuthFlowHandler(db database.DB, serviceType string) http.Handler {
 
 		http.Redirect(w, req, appInstallURL, http.StatusFound)
 	}))
+	mux.Handle("/install-github-app-success", http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+
+	}))
 	return mux
 }
 

--- a/enterprise/cmd/frontend/internal/auth/oauth/middleware.go
+++ b/enterprise/cmd/frontend/internal/auth/oauth/middleware.go
@@ -108,9 +108,6 @@ func newOAuthFlowHandler(db database.DB, serviceType string) http.Handler {
 
 		http.Redirect(w, req, appInstallURL, http.StatusFound)
 	}))
-	mux.Handle("/install-github-app-success", http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-
-	}))
 	return mux
 }
 


### PR DESCRIPTION
This PR implements both CLOUD-290 and CLOUD-214. It handlese GitHub App installation callbacks for install requests as well as cases where no state variable is supplied or the user is not logged in (such as a GitHub admin approving an install).

## Test plan

Unit tests and e2e testing

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


