### PR TITLE
search: separate Zoekt query construction functions

### DIFF
--- a/internal/search/query_converter.go
+++ b/internal/search/query_converter.go
@@ -303,7 +303,10 @@ func QueryToZoektQuery(p *TextPatternInfo, feat *Features, typ IndexedRequestTyp
 	if err != nil {
 		return nil, err
 	}
+	return WithZoektParameters(q, p, feat, typ)
+}
 
+func WithZoektParameters(q zoekt.Q, p *TextPatternInfo, feat *Features, typ IndexedRequestType) (zoekt.Q, error) {
 	if typ == SymbolRequest {
 		// Tell zoekt q must match on symbols
 		q = &zoekt.Symbol{


### PR DESCRIPTION
Separating a function so that I can reuse parts of it in a different context when constructing optimized Zoekt queries.

## Test plan
Semantics-preserving.


