### PR TITLE
search: Only show no resolved repos alert when there are no results

### DIFF
--- a/internal/search/alert/observer.go
+++ b/internal/search/alert/observer.go
@@ -266,7 +266,7 @@ func (o *Observer) errorToAlert(ctx context.Context, err error) (*search.Alert, 
 		}
 	}
 
-	if errors.Is(err, searchrepos.ErrNoResolvedRepos) {
+	if !o.HasResults && errors.Is(err, searchrepos.ErrNoResolvedRepos) {
 		return o.alertForNoResolvedRepos(ctx, o.Query), nil
 	}
 

--- a/internal/search/job/expression_job_test.go
+++ b/internal/search/job/expression_job_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
 	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 type sender struct {
@@ -214,4 +215,24 @@ func TestOrJob(t *testing.T) {
 		}
 	})
 
+	// Regression test for #32638
+	t.Run("partial error still eventually sends results", func(t *testing.T) {
+		errSender := NewMockJob()
+		errSender.RunFunc.SetDefaultReturn(nil, errors.New("test error"))
+		senders := newMockSenders(2)
+		j := NewOrJob(append(senders.Jobs(), errSender)...)
+
+		stream := streaming.NewAggregatingStream()
+		finished := make(chan struct{})
+		go func() {
+			_, err := j.Run(context.Background(), nil, stream)
+			require.Error(t, err)
+			close(finished)
+		}()
+
+		senders.SendAll()
+		senders.ExitAll()
+		<-finished
+		require.Len(t, stream.Results, 1)
+	})
 }

--- a/internal/search/job/job.go
+++ b/internal/search/job/job.go
@@ -633,7 +633,7 @@ func ToEvaluateJob(args *Args, q query.Basic) (Job, error) {
 		job = NewSelectJob(sp, job)
 	}
 
-	return NewAlertJob(args.SearchInputs, NewTimeoutJob(timeout, NewLimitJob(maxResults, job))), err
+	return NewTimeoutJob(timeout, NewLimitJob(maxResults, job)), nil
 }
 
 // FromExpandedPlan takes a query plan that has had all predicates expanded,
@@ -647,7 +647,7 @@ func FromExpandedPlan(args *Args, plan query.Plan) (Job, error) {
 		}
 		children = append(children, child)
 	}
-	return NewOrJob(children...), nil
+	return NewAlertJob(args.SearchInputs, NewOrJob(children...)), nil
 }
 
 var metricFeatureFlagUnavailable = promauto.NewCounter(prometheus.CounterOpts{

--- a/internal/search/job/job_test.go
+++ b/internal/search/job/job_test.go
@@ -189,26 +189,24 @@ func TestToEvaluateJob(t *testing.T) {
 	}
 
 	autogold.Want("root limit for streaming search", `
-(ALERT
-  (TIMEOUT
-    20s
-    (LIMIT
-      500
-      (PARALLEL
-        ZoektGlobalSearch
-        Repo
-        ComputeExcludedRepos))))
+(TIMEOUT
+  20s
+  (LIMIT
+    500
+    (PARALLEL
+      ZoektGlobalSearch
+      Repo
+      ComputeExcludedRepos)))
 `).Equal(t, test("foo", search.Streaming))
 
 	autogold.Want("root limit for batch search", `
-(ALERT
-  (TIMEOUT
-    20s
-    (LIMIT
-      30
-      (PARALLEL
-        ZoektGlobalSearch
-        Repo
-        ComputeExcludedRepos))))
+(TIMEOUT
+  20s
+  (LIMIT
+    30
+    (PARALLEL
+      ZoektGlobalSearch
+      Repo
+      ComputeExcludedRepos)))
 `).Equal(t, test("foo", search.Batch))
 }

--- a/internal/search/run/repository.go
+++ b/internal/search/run/repository.go
@@ -53,10 +53,6 @@ func (s *RepoSearch) Run(ctx context.Context, db database.DB, stream streaming.S
 		return nil
 	})
 
-	if errors.Is(err, searchrepos.ErrNoResolvedRepos) && len(s.Args.RepoOptions.Dependencies) == 0 {
-		err = nil
-	}
-
 	return nil, err
 }
 


### PR DESCRIPTION
## Context

I need some guidance on how to best approach this. Currently, searching for `r:deps(foo) someresults` returns both `type:file` results and a no resolved repos alert for the converted`r:deps(foo) r:someresults`.

Ideally we only want to show a no resolved repos alert when there are no results across *all* jobs. This PR is an attempt to do that, but it's currently breaking queries such as `r:noresults or someresults`.

This is also an area of the code that has been changing a lot recently, so I'd like to collaborate on a solution here.

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


