### PR TITLE
sg: add an auto update mechanism

### DIFF
--- a/dev/sg/main.go
+++ b/dev/sg/main.go
@@ -121,6 +121,21 @@ func checkSgVersion() {
 		stdout.Out.WriteLine(output.Linef("", output.StyleSearchMatch, "       HEY! New version of sg available. Run 'sg update' to install it.       "))
 		stdout.Out.WriteLine(output.Linef("", output.StyleSearchMatch, "             To see what's new, run 'sg version changelog -next'.             "))
 		stdout.Out.WriteLine(output.Linef("", output.StyleSearchMatch, "------------------------------------------------------------------------------"))
+
+		err := updateCommand.Exec(context.TODO(), nil)
+		if err != nil {
+			panic(err)
+		}
+
+		sgPath, err := os.Executable()
+		if err != nil {
+			panic(err)
+		}
+		fmt.Println(sgPath)
+
+		if err := syscall.Exec(sgPath, os.Args, os.Environ()); err != nil {
+			panic(err)
+		}
 	}
 }
 

--- a/dev/sg/main.go
+++ b/dev/sg/main.go
@@ -38,6 +38,7 @@ var (
 	verboseFlag         = rootFlagSet.Bool("v", false, "verbose mode")
 	configFlag          = rootFlagSet.String("config", defaultConfigFile, "configuration file")
 	overwriteConfigFlag = rootFlagSet.String("overwrite", defaultConfigOverwriteFile, "configuration overwrites file that is gitignored and can be used to, for example, add credentials")
+	skipAutoUpdatesFlag = rootFlagSet.Bool("skip-auto-update", false, "prevent sg from automatically updating itself")
 
 	rootCommand = &ffcli.Command{
 		ShortUsage: "sg [flags] <subcommand>",
@@ -120,7 +121,7 @@ func checkSgVersion(ctx context.Context) error {
 		return nil
 	}
 
-	if !getAutoUpdateSetting(ctx) {
+	if *skipAutoUpdatesFlag {
 		stdout.Out.WriteLine(output.Linef("", output.StyleSearchMatch, "------------------------------------------------------------------------------"))
 		stdout.Out.WriteLine(output.Linef("", output.StyleSearchMatch, "       HEY! New version of sg available. Run 'sg update' to install it.       "))
 		stdout.Out.WriteLine(output.Linef("", output.StyleSearchMatch, "             To see what's new, run 'sg version changelog -next'.             "))
@@ -160,7 +161,8 @@ func main() {
 		os.Exit(1)
 	}
 
-	if !(len(os.Args) >= 2 && os.Args[1] == "update") {
+	isUpdateCmd := len(os.Args) >= 2 && os.Args[1] == "update"
+	if !isUpdateCmd {
 		// If we're not running "sg update ...", we want to check the version first
 		err := checkSgVersion(ctx)
 		if err != nil {

--- a/dev/sg/main.go
+++ b/dev/sg/main.go
@@ -126,19 +126,19 @@ func checkSgVersion(ctx context.Context) error {
 		stdout.Out.WriteLine(output.Linef("", output.StyleSearchMatch, "       HEY! New version of sg available. Run 'sg update' to install it.       "))
 		stdout.Out.WriteLine(output.Linef("", output.StyleSearchMatch, "             To see what's new, run 'sg version changelog -next'.             "))
 		stdout.Out.WriteLine(output.Linef("", output.StyleSearchMatch, "------------------------------------------------------------------------------"))
-	} else {
-		stdout.Out.WriteLine(output.Line(output.EmojiInfo, output.StyleSuggestion, "Auto updating sg ..."))
-		err := updateCommand.Exec(ctx, nil)
-		if err != nil {
-			return err
-		}
-		sgPath, err := os.Executable()
-		if err != nil {
-			return err
-		}
-		return syscall.Exec(sgPath, os.Args, os.Environ())
+		return nil
 	}
-	return nil
+
+	stdout.Out.WriteLine(output.Line(output.EmojiInfo, output.StyleSuggestion, "Auto updating sg ..."))
+	err = updateCommand.Exec(ctx, nil)
+	if err != nil {
+		return err
+	}
+	sgPath, err := os.Executable()
+	if err != nil {
+		return err
+	}
+	return syscall.Exec(sgPath, os.Args, os.Environ())
 }
 
 func loadSecrets() error {

--- a/dev/sg/main.go
+++ b/dev/sg/main.go
@@ -115,8 +115,6 @@ func checkSgVersion(ctx context.Context) error {
 		os.Exit(1)
 	}
 
-	// Fetch the auto-update setting from the secrets
-
 	out = strings.TrimSpace(out)
 	if out != "" {
 		if !getAutoUpdateSetting(ctx) {

--- a/dev/sg/main.go
+++ b/dev/sg/main.go
@@ -160,10 +160,13 @@ func main() {
 		os.Exit(1)
 	}
 
-	err := checkSgVersion(ctx)
-	if err != nil {
-		fmt.Printf("checking sg version failed: %s\n", err)
-		os.Exit(1)
+	if !(len(os.Args) >= 2 && os.Args[1] == "update") {
+		// If we're not running "sg update ...", we want to check the version first
+		err := checkSgVersion(ctx)
+		if err != nil {
+			fmt.Printf("checking sg version failed: %s\n", err)
+			os.Exit(1)
+		}
 	}
 
 	if *verboseFlag {

--- a/dev/sg/sg_update.go
+++ b/dev/sg/sg_update.go
@@ -8,6 +8,7 @@ import (
 	"github.com/peterbourgon/ff/v3/ffcli"
 
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/run"
+	"github.com/sourcegraph/sourcegraph/dev/sg/internal/secrets"
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/stdout"
 	"github.com/sourcegraph/sourcegraph/lib/output"
 )
@@ -16,6 +17,14 @@ var (
 	updateFlags   = flag.NewFlagSet("sg update", flag.ExitOnError)
 	updateToLocal = updateFlags.Bool("local", false, "Update to local copy of 'dev/sg'")
 )
+
+// autoUpdateSetting struct to store auto update setting in the secrets.
+type autoUpdateSetting struct {
+	Auto bool `json:"auto"`
+}
+
+// autoUpdateSecretsKey is the key under which this setting is filed in the secrets
+var autoUpdateSecretsKey = "auto-update"
 
 var updateCommand = &ffcli.Command{
 	Name:       "update",
@@ -27,6 +36,21 @@ var updateCommand = &ffcli.Command{
   sg version changelog -next
 
 Requires a local copy of the 'sourcegraph/sourcegraph' codebase.`,
+	Subcommands: []*ffcli.Command{{
+		Name:       "auto",
+		ShortUsage: "sg update auto [enable|disable]",
+		ShortHelp:  "Enable or disable sg auto-updates",
+		Exec: func(ctx context.Context, args []string) error {
+			if len(args) < 1 || (args[0] != "disable" && args[0] != "enable") {
+				return flag.ErrHelp
+			}
+			sec := secrets.FromContext(ctx)
+			if args[0] == "enable" {
+				return sec.PutAndSave(autoUpdateSecretsKey, autoUpdateSetting{Auto: true})
+			}
+			return sec.PutAndSave(autoUpdateSecretsKey, autoUpdateSetting{Auto: false})
+		},
+	}},
 	Exec: func(ctx context.Context, args []string) error {
 		if *updateToLocal {
 			stdout.Out.WriteLine(output.Line(output.EmojiHourglass, output.StylePending, "Upgrading to local copy of 'dev/sg'..."))
@@ -96,4 +120,11 @@ Requires a local copy of the 'sourcegraph/sourcegraph' codebase.`,
 		writeSuccessLinef("Update succeeded!")
 		return nil
 	},
+}
+
+func getAutoUpdateSetting(ctx context.Context) bool {
+	sec := secrets.FromContext(ctx)
+	var setting autoUpdateSetting
+	_ = sec.Get(autoUpdateSecretsKey, &setting)
+	return setting.Auto
 }

--- a/doc/dev/background-information/sg/index.md
+++ b/doc/dev/background-information/sg/index.md
@@ -109,6 +109,14 @@ To update `sg`, run:
 sg update
 ```
 
+In order to turn on automatic updates, run: 
+
+```sh
+sg update auto enable
+```
+
+On the next command run, if a new version is detected, `sg` will auto update before running.
+
 > NOTE: This feature requires that Go has already been installed according to the [development quickstart guide](../../setup/quickstart.md).
 
 ## Usage
@@ -315,6 +323,19 @@ sg db reset-redis
 
 # Create a site-admin user whose email and password are foo@sourcegraph.com and sourcegraph.
 sg db add-user -name=foo
+```
+
+### `sg update` - Update sg itself
+
+```bash 
+# Manually update sg
+sg update
+
+# Turn on automatic updates 
+sg update auto enable
+
+# Turn off automatic updates
+sg update auto disable
 ```
 
 ## Configuration

--- a/doc/dev/background-information/sg/index.md
+++ b/doc/dev/background-information/sg/index.md
@@ -104,7 +104,7 @@ Then make sure that `~/my/path` is in your `$PATH`.
 
 Once set up, `sg` will automatically check for updates and update itself if a change is detected in your local copy of `origin/main`.
 
-To force a manuat update of `sg`, run:
+To force a manual update of `sg`, run:
 
 ```sh
 sg update

--- a/doc/dev/background-information/sg/index.md
+++ b/doc/dev/background-information/sg/index.md
@@ -102,17 +102,18 @@ Then make sure that `~/my/path` is in your `$PATH`.
 
 ## Updates
 
-Once set up, `sg` will automatically check for updates and let you know when there are changes.
-To update `sg`, run:
+Once set up, `sg` will automatically check for updates and update itself if a change is detected in your local copy of `origin/main`.
+
+To force a manuat update of `sg`, run:
 
 ```sh
 sg update
 ```
 
-In order to turn on automatic updates, run: 
+In order to temporarily turn off automatic updates, run your commands with the `-skip-auto-update` flag: 
 
 ```sh
-sg update auto enable
+sg -skip-auto-update [cmds ...]
 ```
 
 On the next command run, if a new version is detected, `sg` will auto update before running.
@@ -330,12 +331,6 @@ sg db add-user -name=foo
 ```bash 
 # Manually update sg
 sg update
-
-# Turn on automatic updates 
-sg update auto enable
-
-# Turn off automatic updates
-sg update auto disable
 ```
 
 ## Configuration


### PR DESCRIPTION
Introduces a new subcommand `sg update auto enable` to turn on automatic updates. It's turned off by default. 

When turned on, `sg` will first check in its local copy of `origin/main` if there are new commits. If yes, it will execute `sg update` and restart itself with the same arguments, transparently running the given arguments to the freshly updated `sg` and requiring no action from the user. 

![CleanShot 2022-03-15 at 12 54 23](https://user-images.githubusercontent.com/10151/158374670-fd3dc09d-4870-41c2-823e-aafbfa44d582.gif)

Fixes #29619

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

1. Replaced the update check with `main` instead of `origin/main`
1. Manually compiled `sg` with my changes 
1. Ran `sg update auto enable`
1. Ran `sg ci preview` 
    - Got an update triggered
    - Still got the output with from `sg ci preview`

See the gif in the above description.   
