### PR TITLE
bext: set svg dimensions defined in `rem` using CSS

### DIFF
--- a/client/shared/src/hover/HoverOverlayLogo/HoverOverlayLogo.module.scss
+++ b/client/shared/src/hover/HoverOverlayLogo/HoverOverlayLogo.module.scss
@@ -9,3 +9,8 @@
     justify-content: center;
     align-items: center;
 }
+
+.icon {
+    width: 1rem;
+    height: 1rem;
+}

--- a/client/shared/src/hover/HoverOverlayLogo/HoverOverlayLogo.tsx
+++ b/client/shared/src/hover/HoverOverlayLogo/HoverOverlayLogo.tsx
@@ -7,6 +7,6 @@ import styles from './HoverOverlayLogo.module.scss'
 
 export const HoverOverlayLogo: React.FunctionComponent<{ className?: string }> = ({ className }) => (
     <span className={classNames(styles.container, className)}>
-        <SourcegraphIcon width="1rem" height="1rem" />
+        <SourcegraphIcon className={styles.icon} />
     </span>
 )


### PR DESCRIPTION
Closes: #32443

## Test plan
- `sg run bext`
- open file on code host (for example, [this one](https://github.com/sourcegraph/sourcegraph/blob/main/client/browser/src/browser-extension/web-extension-api/ExtensionStorageSubject.ts))
- ensure there are no styling `svg` warnings in console

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


