### PR TITLE
search: share() streamSearch observable

### DIFF
--- a/client/web/src/search/results/SearchResultsCacheProvider.tsx
+++ b/client/web/src/search/results/SearchResultsCacheProvider.tsx
@@ -3,7 +3,7 @@ import { isEqual } from 'lodash'
 import React, { createContext, Dispatch, SetStateAction, useContext, useEffect, useMemo, useState } from 'react'
 import { useHistory } from 'react-router'
 import { merge, of } from 'rxjs'
-import { last, throttleTime } from 'rxjs/operators'
+import { last, share, throttleTime } from 'rxjs/operators'
 
 import { transformSearchQuery } from '@sourcegraph/shared/src/api/client/search'
 import { FlatExtensionHostAPI } from '@sourcegraph/shared/src/api/contract'
@@ -55,7 +55,7 @@ export function useCachedSearchResults(
                 return of(cachedResults?.results)
             }
 
-            const stream = streamSearch(transformedQuery, options)
+            const stream = streamSearch(transformedQuery, options).pipe(share())
 
             // If the throttleTime option `trailing` is set, we will return the
             // final value, but it also removes the guarantee that the output events


### PR DESCRIPTION
This PR fixes the search stream being initiated twice. Since the streamSearch observable is being subscribed twice, we have to share() it.

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

* Open a search results page
* Open the network tab
* Verify only one /search/stream event is recorded

