### PR TITLE
New reference panel: fix wrong name for matching function

### DIFF
--- a/client/web/src/repo/blob/panel/BlobPanel.tsx
+++ b/client/web/src/repo/blob/panel/BlobPanel.tsx
@@ -243,7 +243,7 @@ export function useBlobPanelViews({
                             locationProvider: undefined,
                             // The new reference panel contains definitoins, references, and implementations. We need it to
                             // match all these IDs so it shows up when one of the IDs is used as `#tab=<ID>` in the URL.
-                            matches: (id: string): boolean =>
+                            matchesTabID: (id: string): boolean =>
                                 id === 'def' || id === 'references' || id.startsWith('implementations_'),
                             // This panel doesn't need a wrapper
                             noWrapper: true,


### PR DESCRIPTION
Hmm, I don't understand why TypeScript didn't flag this.

## Test plan

- Tested it locally to confirm that it's working now and panel opens for `#tab=def` and `#tab=references` after renaming the function.


