### PR TITLE
Swap codeinsights-db docker image to be based off postgres instead of Timescale

### DIFF
--- a/docker-images/codeinsights-db/Dockerfile
+++ b/docker-images/codeinsights-db/Dockerfile
@@ -1,7 +1,0 @@
-FROM timescale/timescaledb:2.0.0-pg12-oss
-
-# hadolint ignore=DL3017
-RUN apk -U upgrade && apk add --no-cache \
-    busybox \
-    wget
-

--- a/docker-images/codeinsights-db/build.sh
+++ b/docker-images/codeinsights-db/build.sh
@@ -3,4 +3,6 @@
 set -ex
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
-docker build -t "${IMAGE:-sourcegraph/codeinsights-db}" .
+# This image is identical to our "sourcegraph/postgres-12-alpine" image,
+# but runs with a different uid to avoid migration issues
+IMAGE="${IMAGE:-sourcegraph/codeinsights-db}" POSTGRES_UID=70 PING_UID=700 ../postgres-12-alpine/build.sh

--- a/docker-images/postgres-12-alpine/Dockerfile
+++ b/docker-images/postgres-12-alpine/Dockerfile
@@ -1,11 +1,14 @@
 FROM postgres:12.7-alpine@sha256:b815f145ef6311e24e4bc4d165dad61b2d8e4587c96cea2944297419c5c93054
 
+ARG PING_UID=99
+ARG POSTGRES_UID=999
+
 # We modify the postgres user/group to reconcile with our previous debian based images
 # and avoid issues with customers migrating.
 RUN apk add --no-cache nss su-exec shadow &&\
-    groupmod -g 99 ping &&\
-    usermod -u 999 postgres &&\
-    groupmod -g 999 postgres &&\
+    groupmod -g $PING_UID ping &&\
+    usermod -u $POSTGRES_UID postgres &&\
+    groupmod -g $POSTGRES_UID postgres &&\
     mkdir -p /data/pgdata-12 && chown -R postgres:postgres /data &&\
     chown -R postgres:postgres /var/lib/postgresql &&\
     chown -R postgres:postgres /var/run/postgresql

--- a/docker-images/postgres-12-alpine/build.sh
+++ b/docker-images/postgres-12-alpine/build.sh
@@ -3,4 +3,7 @@
 set -ex
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
+POSTGRES_UID=${POSTGRES_UID:-999}
+PING_UID=${PING_UID:-99}
+
 docker build -t "${IMAGE:-index.docker.io/sourcegraph/postgres-12-alpine}" --build-arg POSTGRES_UID="$POSTGRES_UID" --build-arg PING_UID="$PING_UID" .

--- a/docker-images/postgres-12-alpine/build.sh
+++ b/docker-images/postgres-12-alpine/build.sh
@@ -3,4 +3,4 @@
 set -ex
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
-docker build -t "${IMAGE:-index.docker.io/sourcegraph/postgres-12-alpine}" .
+docker build -t "${IMAGE:-index.docker.io/sourcegraph/postgres-12-alpine}" --build-arg POSTGRES_UID=$POSTGRES_UID --build-arg PING_UID=$PING_UID .

--- a/docker-images/postgres-12-alpine/build.sh
+++ b/docker-images/postgres-12-alpine/build.sh
@@ -3,4 +3,4 @@
 set -ex
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
-docker build -t "${IMAGE:-index.docker.io/sourcegraph/postgres-12-alpine}" --build-arg POSTGRES_UID=$POSTGRES_UID --build-arg PING_UID=$PING_UID .
+docker build -t "${IMAGE:-index.docker.io/sourcegraph/postgres-12-alpine}" --build-arg POSTGRES_UID="$POSTGRES_UID" --build-arg PING_UID="$PING_UID" .


### PR DESCRIPTION
Switches the base for codeinsights-db to Postgres, away from Timescale. This swap preserves the existing postgres uid used by the container, to avoid requiring users to migrate file permissions.

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

Build all three images (postgres, codeintel, codeinsights) and confirm uid assignments are still correct.
Confirm codeinsights successfully starts with new image.