### PR TITLE
fixup: Handle when we have empty json passed

### DIFF
--- a/client/web/src/repo/blob/BlobPage.tsx
+++ b/client/web/src/repo/blob/BlobPage.tsx
@@ -159,7 +159,7 @@ export const BlobPage: React.FunctionComponent<Props> = props => {
                         }
 
                         // Replace html with lsif generated HTML, if available
-                        if (blob.highlight.lsif) {
+                        if (blob.highlight.lsif && blob.highlight.lsif != '{}') {
                             blob.highlight.html = renderLsifHtml(blob.highlight.lsif, blob.content)
                         }
 

--- a/client/web/src/repo/blob/BlobPage.tsx
+++ b/client/web/src/repo/blob/BlobPage.tsx
@@ -159,7 +159,7 @@ export const BlobPage: React.FunctionComponent<Props> = props => {
                         }
 
                         // Replace html with lsif generated HTML, if available
-                        if (blob.highlight.lsif && blob.highlight.lsif != '{}') {
+                        if (blob.highlight.lsif && blob.highlight.lsif !== '{}') {
                             blob.highlight.html = renderLsifHtml(blob.highlight.lsif, blob.content)
                         }
 

--- a/cmd/frontend/graphqlbackend/highlight.go
+++ b/cmd/frontend/graphqlbackend/highlight.go
@@ -53,7 +53,7 @@ func (h *highlightedFileResolver) HTML() string {
 }
 func (h *highlightedFileResolver) LSIF() string {
 	if h.response == nil {
-		return ""
+		return "{}"
 	}
 
 	marshaller := &jsonpb.Marshaler{

--- a/cmd/frontend/internal/highlight/language.go
+++ b/cmd/frontend/internal/highlight/language.go
@@ -51,7 +51,10 @@ type SyntaxEngineQuery struct {
 	LanguageOverride bool
 }
 
-var highlightConfig = syntaxHighlightConfig{}
+var highlightConfig = syntaxHighlightConfig{
+	Extensions: map[string]string{},
+	Patterns:   []languagePattern{},
+}
 
 var engineConfig = syntaxEngineConfig{
 	// This sets the default syntax engine for the sourcegraph server.


### PR DESCRIPTION
After implementing a change in the https://github.com/sourcegraph/sourcegraph/pull/32084 I realized that we weren't handling this in the frontend correctly.

This solves the problem (I will do a better fix later)

## Test plan

Load up sg w/ a syntect language and make sure it loads now.

