### PR TITLE
gomod: update zoekt to include new libxml

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -408,7 +408,7 @@ require (
 // or intentional forks.
 replace (
 	// We maintain our own fork of Zoekt. Update with ./dev/zoekt/update
-	github.com/google/zoekt => github.com/sourcegraph/zoekt v0.0.0-20220309143736-eba22ccc3c61
+	github.com/google/zoekt => github.com/sourcegraph/zoekt v0.0.0-20220315092637-acf74e5fb08a
 	// We use a fork of Alertmanager to allow prom-wrapper to better manipulate Alertmanager configuration.
 	// See https://docs.sourcegraph.com/dev/background-information/observability/prometheus
 	github.com/prometheus/alertmanager => github.com/sourcegraph/alertmanager v0.21.1-0.20211110092431-863f5b1ee51b

--- a/go.sum
+++ b/go.sum
@@ -2037,8 +2037,8 @@ github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e h1:qpG
 github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e/go.mod h1:HuIsMU8RRBOtsCgI77wP899iHVBQpCmg4ErYMZB+2IA=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152 h1:z/MpntplPaW6QW95pzcAR/72Z5TWDyDnSo0EOcyij9o=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152/go.mod h1:GIjDIg/heH5DOkXY3YJ/wNhfHsQHoXGjl8G8amsYQ1I=
-github.com/sourcegraph/zoekt v0.0.0-20220309143736-eba22ccc3c61 h1:YezmyZjol7hYoBu2NUvCbKm40ZWjqNz6BQV1yfQfh+M=
-github.com/sourcegraph/zoekt v0.0.0-20220309143736-eba22ccc3c61/go.mod h1:SfsXv9hUd4wJv9/h4J16OxEv7k0r/6YtoLLePkKIQZI=
+github.com/sourcegraph/zoekt v0.0.0-20220315092637-acf74e5fb08a h1:GxJOutmRFxPe3BLyiYRA2Tsh2nEh6tCwL31clscn4kc=
+github.com/sourcegraph/zoekt v0.0.0-20220315092637-acf74e5fb08a/go.mod h1:SfsXv9hUd4wJv9/h4J16OxEv7k0r/6YtoLLePkKIQZI=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=
 github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=


### PR DESCRIPTION
Our docker images include libxml2. Recently CVE-2022-23308 was released
which affects it. By rebuilding our images we get the latest libxml2
which resolves the CVE. So as a side-effect of including the latest
zoekt changes we will get docker images without the bad libxml2.

- acf74e5 indexserver: remove DownloadLimitMBPS
- e68ec97 bump ctags

Test Plan: CI. Both included commits are low risk to no risk.