### PR TITLE
graphqlbackend: Pass around URLs instead of strings.

### DIFF
--- a/cmd/frontend/graphqlbackend/git_commit.go
+++ b/cmd/frontend/graphqlbackend/git_commit.go
@@ -183,11 +183,15 @@ func (r *GitCommitResolver) Parents(ctx context.Context) ([]*GitCommitResolver, 
 }
 
 func (r *GitCommitResolver) URL() string {
-	return r.repoResolver.URL() + "/-/commit/" + r.inputRevOrImmutableRev()
+	url := r.repoResolver.url()
+	url.Path += "/-/commit/" + r.inputRevOrImmutableRev()
+	return url.String()
 }
 
 func (r *GitCommitResolver) CanonicalURL() string {
-	return r.repoResolver.URL() + "/-/commit/" + string(r.oid)
+	url := r.repoResolver.url()
+	url.Path += "/-/commit/" + string(r.oid)
+	return url.String()
 }
 
 func (r *GitCommitResolver) ExternalURLs(ctx context.Context) ([]*externallink.Resolver, error) {
@@ -326,7 +330,7 @@ func (r *behindAheadCountsResolver) Ahead() int32  { return r.ahead }
 // canonical OID for the revision.
 func (r *GitCommitResolver) inputRevOrImmutableRev() string {
 	if r.inputRev != nil && *r.inputRev != "" {
-		return escapePathForURL(*r.inputRev)
+		return *r.inputRev
 	}
 	return string(r.oid)
 }

--- a/cmd/frontend/graphqlbackend/git_commit.go
+++ b/cmd/frontend/graphqlbackend/git_commit.go
@@ -336,6 +336,8 @@ func (r *GitCommitResolver) inputRevOrImmutableRev() string {
 // given. This is because the convention in the frontend is for repo-rev URLs to omit the "@rev"
 // portion (unlike for commit page URLs, which must include some revspec in
 // "/REPO/-/commit/REVSPEC").
+//
+// The returned string is not guaranteed to be URL-safe and must be escaped by the caller.
 func (r *GitCommitResolver) repoRevURL() *url.URL {
 	// Dereference to copy to avoid mutation
 	url := *r.repoResolver.RepoMatch.URL()

--- a/cmd/frontend/graphqlbackend/git_commit.go
+++ b/cmd/frontend/graphqlbackend/git_commit.go
@@ -336,8 +336,6 @@ func (r *GitCommitResolver) inputRevOrImmutableRev() string {
 // given. This is because the convention in the frontend is for repo-rev URLs to omit the "@rev"
 // portion (unlike for commit page URLs, which must include some revspec in
 // "/REPO/-/commit/REVSPEC").
-//
-// The returned string is not guaranteed to be URL-safe and must be escaped by the caller.
 func (r *GitCommitResolver) repoRevURL() *url.URL {
 	// Dereference to copy to avoid mutation
 	url := *r.repoResolver.RepoMatch.URL()

--- a/cmd/frontend/graphqlbackend/git_commit_test.go
+++ b/cmd/frontend/graphqlbackend/git_commit_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/internal/api"
@@ -36,6 +37,19 @@ func TestGitCommitResolver(t *testing.T) {
 			Date:  time.Now(),
 		},
 	}
+
+	t.Run("URL Escaping", func(t *testing.T) {
+		repo := NewRepositoryResolver(db, &types.Repo{Name: "xyz"})
+		commitResolver := NewGitCommitResolver(db, repo, "c1", commit)
+		inputRev := "master^1"
+		commitResolver.inputRev = &inputRev
+		require.Equal(t, "/xyz/-/commit/master%5E1", commitResolver.URL())
+
+		treeResolver := NewGitTreeEntryResolver(db, commitResolver, CreateFileInfo("a/b", false))
+		url, err := treeResolver.URL(ctx)
+		require.Nil(t, err)
+		require.Equal(t, "/xyz@master%5E1/-/blob/a/b", url)
+	})
 
 	t.Run("Lazy loading", func(t *testing.T) {
 		git.Mocks.GetCommit = func(api.CommitID) (*gitdomain.Commit, error) {

--- a/cmd/frontend/graphqlbackend/git_commit_test.go
+++ b/cmd/frontend/graphqlbackend/git_commit_test.go
@@ -41,14 +41,21 @@ func TestGitCommitResolver(t *testing.T) {
 	t.Run("URL Escaping", func(t *testing.T) {
 		repo := NewRepositoryResolver(db, &types.Repo{Name: "xyz"})
 		commitResolver := NewGitCommitResolver(db, repo, "c1", commit)
-		inputRev := "master^1"
-		commitResolver.inputRev = &inputRev
-		require.Equal(t, "/xyz/-/commit/master%5E1", commitResolver.URL())
+		{
+			inputRev := "master^1"
+			commitResolver.inputRev = &inputRev
+			require.Equal(t, "/xyz/-/commit/master%5E1", commitResolver.URL())
 
-		treeResolver := NewGitTreeEntryResolver(db, commitResolver, CreateFileInfo("a/b", false))
-		url, err := treeResolver.URL(ctx)
-		require.Nil(t, err)
-		require.Equal(t, "/xyz@master%5E1/-/blob/a/b", url)
+			treeResolver := NewGitTreeEntryResolver(db, commitResolver, CreateFileInfo("a/b", false))
+			url, err := treeResolver.URL(ctx)
+			require.Nil(t, err)
+			require.Equal(t, "/xyz@master%5E1/-/blob/a/b", url)
+		}
+		{
+			inputRev := "refs/heads/main"
+			commitResolver.inputRev = &inputRev
+			require.Equal(t, "/xyz/-/commit/refs/heads/main", commitResolver.URL())
+		}
 	})
 
 	t.Run("Lazy loading", func(t *testing.T) {

--- a/cmd/frontend/graphqlbackend/git_ref.go
+++ b/cmd/frontend/graphqlbackend/git_ref.go
@@ -132,5 +132,7 @@ func (r *GitRefResolver) Target() interface {
 func (r *GitRefResolver) Repository() *RepositoryResolver { return r.repo }
 
 func (r *GitRefResolver) URL() string {
-	return r.repo.URL() + "@" + escapePathForURL(r.AbbrevName())
+	url := r.repo.url()
+	url.Path += "@" + r.AbbrevName()
+	return url.String()
 }

--- a/cmd/frontend/graphqlbackend/git_tree_entry.go
+++ b/cmd/frontend/graphqlbackend/git_tree_entry.go
@@ -127,14 +127,10 @@ func (r *GitTreeEntryResolver) Repository() *RepositoryResolver { return r.commi
 func (r *GitTreeEntryResolver) IsRecursive() bool { return r.isRecursive }
 
 func (r *GitTreeEntryResolver) URL(ctx context.Context) (string, error) {
-	url, err := r.url(ctx)
-	if err != nil {
-		return "", err
-	}
-	return url.String(), nil
+	return r.url(ctx).String(), nil
 }
 
-func (r *GitTreeEntryResolver) url(ctx context.Context) (*url.URL, error) {
+func (r *GitTreeEntryResolver) url(ctx context.Context) *url.URL {
 	span, ctx := ot.StartSpanFromContext(ctx, "treeentry.URL")
 	defer span.Finish()
 
@@ -147,11 +143,11 @@ func (r *GitTreeEntryResolver) url(ctx context.Context) (*url.URL, error) {
 		repoName, err := cloneURLToRepoName(ctx, r.db, submoduleURL)
 		if err != nil {
 			log15.Error("Failed to resolve submodule repository name from clone URL", "cloneURL", submodule.URL(), "err", err)
-			return &url.URL{}, nil
+			return &url.URL{}
 		}
-		return &url.URL{Path: "/" + repoName + "@" + submodule.Commit()}, nil
+		return &url.URL{Path: "/" + repoName + "@" + submodule.Commit()}
 	}
-	return r.urlPath(r.commit.repoRevURL()), nil
+	return r.urlPath(r.commit.repoRevURL())
 }
 
 func (r *GitTreeEntryResolver) CanonicalURL() string {

--- a/cmd/frontend/graphqlbackend/git_tree_entry.go
+++ b/cmd/frontend/graphqlbackend/git_tree_entry.go
@@ -147,9 +147,9 @@ func (r *GitTreeEntryResolver) url(ctx context.Context) (*url.URL, error) {
 		repoName, err := cloneURLToRepoName(ctx, r.db, submoduleURL)
 		if err != nil {
 			log15.Error("Failed to resolve submodule repository name from clone URL", "cloneURL", submodule.URL(), "err", err)
-			return url.Parse("")
+			return &url.URL{}, nil
 		}
-		return url.Parse("/" + repoName + "@" + submodule.Commit())
+		return &url.URL{Path: "/" + repoName + "@" + submodule.Commit()}, nil
 	}
 	return r.urlPath(r.commit.repoRevURL()), nil
 }

--- a/cmd/frontend/graphqlbackend/git_tree_entry.go
+++ b/cmd/frontend/graphqlbackend/git_tree_entry.go
@@ -127,24 +127,31 @@ func (r *GitTreeEntryResolver) Repository() *RepositoryResolver { return r.commi
 func (r *GitTreeEntryResolver) IsRecursive() bool { return r.isRecursive }
 
 func (r *GitTreeEntryResolver) URL(ctx context.Context) (string, error) {
+	url, err := r.url(ctx)
+	if err != nil {
+		return "", err
+	}
+	return url.String(), nil
+}
+
+func (r *GitTreeEntryResolver) url(ctx context.Context) (*url.URL, error) {
 	span, ctx := ot.StartSpanFromContext(ctx, "treeentry.URL")
 	defer span.Finish()
 
 	if submodule := r.Submodule(); submodule != nil {
 		span.SetTag("Submodule", "true")
-		url := submodule.URL()
-		if strings.HasPrefix(url, "../") {
-			url = path.Join(r.Repository().Name(), url)
+		submoduleURL := submodule.URL()
+		if strings.HasPrefix(submoduleURL, "../") {
+			submoduleURL = path.Join(r.Repository().Name(), submoduleURL)
 		}
-		repoName, err := cloneURLToRepoName(ctx, r.db, url)
+		repoName, err := cloneURLToRepoName(ctx, r.db, submoduleURL)
 		if err != nil {
 			log15.Error("Failed to resolve submodule repository name from clone URL", "cloneURL", submodule.URL(), "err", err)
-			return "", nil
+			return url.Parse("")
 		}
-		return "/" + repoName + "@" + submodule.Commit(), nil
+		return url.Parse("/" + repoName + "@" + submodule.Commit())
 	}
-	url := r.commit.repoRevURL()
-	return r.urlPath(url).String(), nil
+	return r.urlPath(r.commit.repoRevURL()), nil
 }
 
 func (r *GitTreeEntryResolver) CanonicalURL() string {

--- a/cmd/frontend/graphqlbackend/repository.go
+++ b/cmd/frontend/graphqlbackend/repository.go
@@ -3,6 +3,7 @@ package graphqlbackend
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"sync"
 	"time"
 
@@ -250,7 +251,11 @@ func (r *RepositoryResolver) UpdatedAt() *DateTime {
 }
 
 func (r *RepositoryResolver) URL() string {
-	return r.RepoMatch.URL().String()
+	return r.url().String()
+}
+
+func (r *RepositoryResolver) url() *url.URL {
+	return r.RepoMatch.URL()
 }
 
 func (r *RepositoryResolver) ExternalURLs(ctx context.Context) ([]*externallink.Resolver, error) {


### PR DESCRIPTION
Added some tests for URL escaping and tweaked some code
to handle concatenation before converting the URL to a string.
This removes some calls to `escapePathForURL`.

## Test plan

Added tests + existing test coverage.