### PR TITLE
notebooks: persist compute block queries

### DIFF
--- a/client/web/src/notebooks/blocks/compute/elm.d.ts
+++ b/client/web/src/notebooks/blocks/compute/elm.d.ts
@@ -1,5 +1,5 @@
 declare module '*.elm' {
-    export const Elm: any
+    export const Elm: { Main: HTMLElement }
 }
 
 declare module 'react-elm-components'

--- a/client/web/src/notebooks/notebook/NotebookAddBlockButtons.tsx
+++ b/client/web/src/notebooks/notebook/NotebookAddBlockButtons.tsx
@@ -95,7 +95,7 @@ export const NotebookAddBlockButtons: React.FunctionComponent<NotebookAddBlockBu
                         onClick={() =>
                             onAddBlock(index, {
                                 type: 'compute',
-                                input: 'placeholder',
+                                input: '',
                             })
                         }
                         data-testid="add-compute-button"


### PR DESCRIPTION
This adds support to persist the query string in compute blocks.

## Test plan
Tested manually, would need end-to-end test to automate. I'm comfortable putting up for review and merging without e2e since this is still feature flags. @novoselrok are there end-to-end tests for persistence on the client side, could you point me to them?


