### PR TITLE
docs: clarifies difference in glob pattern syntax between site config and .sourcegraph/ignore

### DIFF
--- a/doc/code_search/explanations/search_details.md
+++ b/doc/code_search/explanations/search_details.md
@@ -8,7 +8,7 @@ Unscoped search results over large repository sets may trail latest default bran
 
 ## Max file size
 
-By default, files larger than 1 MB are excluded from search results. Use the [search.largeFiles](../../../admin/config/site_config.md#search-largeFiles) keyword to specify files to be indexed and searched regardless of size.
+By default, files larger than 1 MB are excluded from search results. Use the [search.largeFiles](../../../admin/config/site_config.md#search-largeFiles) keyword to specify files to be indexed and searched regardless of size. The glob pattern syntax for site configuration can be found [here](https://pkg.go.dev/path/filepath#Match).
 
 ## Exclude files and directories
 


### PR DESCRIPTION
As currently laid out, noting the glob pattern syntax in the `Exclude files and directories` section, which directly follows instructions for searching large files, accidentally implies that the same rules apply to site config. I just added the link to the config syntax here to make the difference explicit.



## Test plan
No test required, just a docs update
<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


