### PR TITLE
Update minimum version of docker compose supported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Code Insights will now periodically clean up data series that are not in use. There is a 1 hour grace period where the series can be reattached to a view, after which all of the time series data and metadata will be deleted. [#32094](https://github.com/sourcegraph/sourcegraph/pull/32094)
 - The Phabricator integration with Gitolite code hosts has been deprecated, the fields have been kept to not break existing systems, but the integration does not work anymore
 - The SSH library used to push Batch Change branches to code hosts has been updated to prevent issues pushing to github.com or GitHub Enterprise releases after March 15, 2022. [#32641](https://github.com/sourcegraph/sourcegraph/issues/32641)
+- Bumped the minimum supported version of Docker Compose from `1.22.0` to `1.29.0` [#32631](https://github.com/sourcegraph/sourcegraph/pull/32631)
 
 ### Fixed
 

--- a/doc/admin/install/docker-compose/index.md
+++ b/doc/admin/install/docker-compose/index.md
@@ -71,7 +71,7 @@ Docker Compose is a tool for defining and running multi-[container](https://www.
 Our Docker Compose support also has the following requirements:
 
 - Minimum Docker version: [v20.10.0](https://docs.docker.com/engine/release-notes/#20100)
-- Minimum version of Docker Compose: [v1.22.0](https://docs.docker.com/compose/release-notes/#1220) (this is first version that supports Docker Compose format `2.4`)
+- Minimum version of Docker Compose: [v1.29.0](https://docs.docker.com/compose/release-notes/#1290) (this is the first version that supports the `service_completed_successfully` dependency condition)
 - Docker Compose deployments should only be deployed with [one of our supported installation methods](#installation), and *not* Docker Swarm
 
 ### Reference repository


### PR DESCRIPTION
Update the minimum version requirements for docker-compose to 1.29.0. This version was released 2021-04 and enables us to use the `service_completed_successfully` dependency condition to improve reliability of deployments.

If customers cannot upgrade their versions, they can remove any service_completed_successfully dependencies in their docker-compose file, but will experience a degraded experience. We don't want to recommend this approach so I'm not documenting it officially.

Closes https://github.com/sourcegraph/sourcegraph/issues/32077.

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

N/A, trivial doc change
