### PR TITLE
notebooks: clean compute block JSON inputs

### DIFF
--- a/client/web/src/notebooks/blocks/compute/NotebookComputeBlock.tsx
+++ b/client/web/src/notebooks/blocks/compute/NotebookComputeBlock.tsx
@@ -122,8 +122,7 @@ export const NotebookComputeBlock: React.FunctionComponent<ComputeBlockProps> = 
                     ports={setupPorts(updateBlockInput(id, onBlockInputChange))}
                     flags={{
                         sourcegraphURL: platformContext.sourcegraphURL,
-                        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-                        computeInput: input === '' ? null : JSON.parse(input),
+                        computeInput: input === '' ? null : (JSON.parse(input) as ComputeInput),
                     }}
                 />
             </div>


### PR DESCRIPTION
Stacked on https://github.com/sourcegraph/sourcegraph/pull/32626

Just finesses some JSON handling of the compute data we persist and gets rid of a lint disable. Basically, it helps a bit with by making experimental features optional to preempt that annoying issue where we can't ever remove and clean up fields in a schema because an app expects it to exist.

## Test plan
Manual testing of experimental feature
