### PR TITLE
gitserver: Pass pathspecs to git archive

### DIFF
--- a/cmd/frontend/internal/app/ui/raw.go
+++ b/cmd/frontend/internal/app/ui/raw.go
@@ -183,7 +183,7 @@ func serveRaw(db database.DB) handlerFunc {
 			// internet, so we use default compression levels on zips (instead of no
 			// compression).
 			f, err := git.ArchiveReaderWithSubRepo(r.Context(), authz.DefaultSubRepoPermsChecker, common.Repo,
-				gitserver.ArchiveOptions{Format: format, Treeish: string(common.CommitID), Pathspecs: []gitserver.Pathspec{gitserver.Literal(relativePath)}})
+				gitserver.ArchiveOptions{Format: format, Treeish: string(common.CommitID), Pathspecs: []gitserver.Pathspec{gitserver.PathspecLiteral(relativePath)}})
 			if err != nil {
 				return err
 			}

--- a/cmd/frontend/internal/app/ui/raw.go
+++ b/cmd/frontend/internal/app/ui/raw.go
@@ -178,12 +178,17 @@ func serveRaw(db database.DB) handlerFunc {
 			metricRunning.Inc()
 			defer metricRunning.Dec()
 
+			// Use the ":(literal)" syntax to ensure that the path is not treated as a glob-like pattern.
+			//
+			// https://git-scm.com/docs/gitglossary#Documentation/gitglossary.txt-aiddefpathspecapathspec
+			pathspec := ":(literal)" + relativePath
+
 			// NOTE: we do not use vfsutil since most archives are just streamed once so
 			// caching locally is not useful. Additionally we transfer the output over the
 			// internet, so we use default compression levels on zips (instead of no
 			// compression).
 			f, err := git.ArchiveReaderWithSubRepo(r.Context(), authz.DefaultSubRepoPermsChecker, common.Repo,
-				gitserver.ArchiveOptions{Format: format, Treeish: string(common.CommitID), Paths: []string{relativePath}})
+				gitserver.ArchiveOptions{Format: format, Treeish: string(common.CommitID), Pathspecs: []string{pathspec}})
 			if err != nil {
 				return err
 			}

--- a/cmd/frontend/internal/app/ui/raw.go
+++ b/cmd/frontend/internal/app/ui/raw.go
@@ -178,17 +178,12 @@ func serveRaw(db database.DB) handlerFunc {
 			metricRunning.Inc()
 			defer metricRunning.Dec()
 
-			// Use the ":(literal)" syntax to ensure that the path is not treated as a glob-like pattern.
-			//
-			// https://git-scm.com/docs/gitglossary#Documentation/gitglossary.txt-aiddefpathspecapathspec
-			pathspec := ":(literal)" + relativePath
-
 			// NOTE: we do not use vfsutil since most archives are just streamed once so
 			// caching locally is not useful. Additionally we transfer the output over the
 			// internet, so we use default compression levels on zips (instead of no
 			// compression).
 			f, err := git.ArchiveReaderWithSubRepo(r.Context(), authz.DefaultSubRepoPermsChecker, common.Repo,
-				gitserver.ArchiveOptions{Format: format, Treeish: string(common.CommitID), Pathspecs: []string{pathspec}})
+				gitserver.ArchiveOptions{Format: format, Treeish: string(common.CommitID), Pathspecs: []gitserver.Pathspec{gitserver.Literal(relativePath)}})
 			if err != nil {
 				return err
 			}

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -864,7 +864,7 @@ func (s *Server) handleArchive(w http.ResponseWriter, r *http.Request) {
 		treeish   = q.Get("treeish")
 		repo      = q.Get("repo")
 		format    = q.Get("format")
-		pathspecs = q["pathspec"]
+		pathspecs = q["path"]
 	)
 
 	if err := checkSpecArgSafety(treeish); err != nil {

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -860,11 +860,11 @@ func (s *Server) handleRepoUpdate(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) handleArchive(w http.ResponseWriter, r *http.Request) {
 	var (
-		q       = r.URL.Query()
-		treeish = q.Get("treeish")
-		repo    = q.Get("repo")
-		format  = q.Get("format")
-		paths   = q["path"]
+		q         = r.URL.Query()
+		treeish   = q.Get("treeish")
+		repo      = q.Get("repo")
+		format    = q.Get("format")
+		pathspecs = q["pathspec"]
 	)
 
 	if err := checkSpecArgSafety(treeish); err != nil {
@@ -903,7 +903,7 @@ func (s *Server) handleArchive(w http.ResponseWriter, r *http.Request) {
 	}
 
 	req.Args = append(req.Args, treeish, "--")
-	req.Args = append(req.Args, paths...)
+	req.Args = append(req.Args, pathspecs...)
 
 	s.exec(w, r, req)
 }

--- a/cmd/symbols/gitserver/client.go
+++ b/cmd/symbols/gitserver/client.go
@@ -49,10 +49,18 @@ func (c *gitserverClient) FetchTar(ctx context.Context, repo api.RepoName, commi
 	}})
 	defer endObservation(1, observation.Args{})
 
+	pathSpecs := []string{}
+	for _, path := range paths {
+		// Use the ":(literal)" syntax to ensure that the path is not treated as a glob-like pattern.
+		//
+		// https://git-scm.com/docs/gitglossary#Documentation/gitglossary.txt-aiddefpathspecapathspec
+		pathSpecs = append(pathSpecs, ":(literal)"+path)
+	}
+
 	opts := gitserver.ArchiveOptions{
-		Treeish: string(commit),
-		Format:  "tar",
-		Paths:   paths,
+		Treeish:   string(commit),
+		Format:    "tar",
+		Pathspecs: pathSpecs,
 	}
 
 	return git.ArchiveReader(ctx, repo, opts)

--- a/cmd/symbols/gitserver/client.go
+++ b/cmd/symbols/gitserver/client.go
@@ -49,12 +49,9 @@ func (c *gitserverClient) FetchTar(ctx context.Context, repo api.RepoName, commi
 	}})
 	defer endObservation(1, observation.Args{})
 
-	pathSpecs := []string{}
+	pathSpecs := []gitserver.Pathspec{}
 	for _, path := range paths {
-		// Use the ":(literal)" syntax to ensure that the path is not treated as a glob-like pattern.
-		//
-		// https://git-scm.com/docs/gitglossary#Documentation/gitglossary.txt-aiddefpathspecapathspec
-		pathSpecs = append(pathSpecs, ":(literal)"+path)
+		pathSpecs = append(pathSpecs, gitserver.Literal(path))
 	}
 
 	opts := gitserver.ArchiveOptions{

--- a/cmd/symbols/gitserver/client.go
+++ b/cmd/symbols/gitserver/client.go
@@ -51,7 +51,7 @@ func (c *gitserverClient) FetchTar(ctx context.Context, repo api.RepoName, commi
 
 	pathSpecs := []gitserver.Pathspec{}
 	for _, path := range paths {
-		pathSpecs = append(pathSpecs, gitserver.Literal(path))
+		pathSpecs = append(pathSpecs, gitserver.PathspecLiteral(path))
 	}
 
 	opts := gitserver.ArchiveOptions{

--- a/internal/codeintel/lockfiles/parser.go
+++ b/internal/codeintel/lockfiles/parser.go
@@ -2,9 +2,9 @@ package lockfiles
 
 import (
 	"io"
-	"sort"
 
 	"github.com/sourcegraph/sourcegraph/internal/conf/reposource"
+	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 )
 
 type parser func(io.Reader) ([]reposource.PackageDependency, error)
@@ -17,12 +17,10 @@ var parsers = map[string]parser{
 // lockfilePathspecs is the list of git pathspecs that match lockfiles.
 //
 // https://git-scm.com/docs/gitglossary#Documentation/gitglossary.txt-aiddefpathspecapathspec
-var lockfilePathspecs = func() []string {
-	paths := make([]string, 0, len(parsers))
+var lockfilePathspecs = func() []gitserver.Pathspec {
+	pathspecs := make([]gitserver.Pathspec, 0, len(parsers))
 	for filename := range parsers {
-		paths = append(paths, "*"+filename)
+		pathspecs = append(pathspecs, gitserver.Suffix(filename))
 	}
-	sort.Strings(paths)
-
-	return paths
+	return pathspecs
 }()

--- a/internal/codeintel/lockfiles/parser.go
+++ b/internal/codeintel/lockfiles/parser.go
@@ -20,7 +20,7 @@ var parsers = map[string]parser{
 var lockfilePathspecs = func() []gitserver.Pathspec {
 	pathspecs := make([]gitserver.Pathspec, 0, len(parsers))
 	for filename := range parsers {
-		pathspecs = append(pathspecs, gitserver.Suffix(filename))
+		pathspecs = append(pathspecs, gitserver.PathspecSuffix(filename))
 	}
 	return pathspecs
 }()

--- a/internal/codeintel/lockfiles/parser.go
+++ b/internal/codeintel/lockfiles/parser.go
@@ -14,7 +14,10 @@ var parsers = map[string]parser{
 	"yarn.lock":         parseYarnLockFile,
 }
 
-var lockfilePaths = func() []string {
+// lockfilePathspecs is the list of git pathspecs that match lockfiles.
+//
+// https://git-scm.com/docs/gitglossary#Documentation/gitglossary.txt-aiddefpathspecapathspec
+var lockfilePathspecs = func() []string {
 	paths := make([]string, 0, len(parsers))
 	for filename := range parsers {
 		paths = append(paths, "*"+filename)

--- a/internal/codeintel/lockfiles/service.go
+++ b/internal/codeintel/lockfiles/service.go
@@ -52,19 +52,10 @@ func (s *Service) StreamDependencies(ctx context.Context, repo api.RepoName, rev
 	}})
 	defer endObservation(1, observation.Args{})
 
-	paths, err := s.gitSvc.LsFiles(ctx, repo, api.CommitID(rev), lockfilePaths...)
-	if err != nil {
-		return err
-	}
-
-	if len(paths) == 0 {
-		return nil
-	}
-
 	opts := gitserver.ArchiveOptions{
-		Treeish: rev,
-		Format:  "zip",
-		Paths:   paths,
+		Treeish:   rev,
+		Format:    "zip",
+		Pathspecs: lockfilePathspecs,
 	}
 
 	rc, err := s.gitSvc.Archive(ctx, repo, opts)

--- a/internal/codeintel/lockfiles/service_test.go
+++ b/internal/codeintel/lockfiles/service_test.go
@@ -19,27 +19,8 @@ import (
 func TestListDependencies(t *testing.T) {
 	ctx := context.Background()
 
-	t.Run("empty ls-files return", func(t *testing.T) {
-		gitSvc := NewMockGitService()
-		gitSvc.LsFilesFunc.SetDefaultReturn([]string{}, nil)
-
-		got, err := TestService(gitSvc).ListDependencies(ctx, "foo", "")
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		if len(got) != 0 {
-			t.Fatalf("expected no dependencies")
-		}
-	})
-
 	t.Run("npm", func(t *testing.T) {
 		gitSvc := NewMockGitService()
-		gitSvc.LsFilesFunc.SetDefaultReturn([]string{
-			"client/package-lock.json",
-			"package-lock.json",
-			"yarn.lock",
-		}, nil)
 
 		yarnLock, err := os.Open("testdata/parse/yarn.lock/yarn_normal.lock")
 		if err != nil {

--- a/internal/codeintel/lockfiles/service_test.go
+++ b/internal/codeintel/lockfiles/service_test.go
@@ -19,6 +19,20 @@ import (
 func TestListDependencies(t *testing.T) {
 	ctx := context.Background()
 
+	t.Run("empty ls-files return", func(t *testing.T) {
+		gitSvc := NewMockGitService()
+		gitSvc.ArchiveFunc.SetDefaultHook(zipArchive(t, map[string]io.Reader{}))
+
+		got, err := TestService(gitSvc).ListDependencies(ctx, "foo", "")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if len(got) != 0 {
+			t.Fatalf("expected no dependencies")
+		}
+	})
+
 	t.Run("npm", func(t *testing.T) {
 		gitSvc := NewMockGitService()
 

--- a/internal/gitserver/client.go
+++ b/internal/gitserver/client.go
@@ -267,11 +267,13 @@ type ArchiveOptions struct {
 // https://git-scm.com/docs/gitglossary#Documentation/gitglossary.txt-aiddefpathspecapathspec
 type Pathspec string
 
-// Literal matches a path without interpreting "*" or "?" as special characters.
-func Literal(s string) Pathspec { return Pathspec(":(literal)" + s) }
+// PathspecLiteral constructs a pathspec that matches a path without interpreting "*" or "?" as special
+// characters.
+func PathspecLiteral(s string) Pathspec { return Pathspec(":(literal)" + s) }
 
-// Suffix matches paths ending with the given suffix (useful for matching paths by basename).
-func Suffix(s string) Pathspec { return Pathspec("*" + s) }
+// PathspecSuffix constructs a pathspec that matches paths ending with the given suffix (useful for
+// matching paths by basename).
+func PathspecSuffix(s string) Pathspec { return Pathspec("*" + s) }
 
 // archiveReader wraps the StdoutReader yielded by gitserver's
 // Cmd.StdoutReader with one that knows how to report a repository-not-found

--- a/internal/gitserver/client.go
+++ b/internal/gitserver/client.go
@@ -258,9 +258,17 @@ func addrForKey(key string, addrs []string) string {
 
 // ArchiveOptions contains options for the Archive func.
 type ArchiveOptions struct {
-	Treeish string   // the tree or commit to produce an archive for
-	Format  string   // format of the resulting archive (usually "tar" or "zip")
-	Paths   []string // if nonempty, only include these paths
+	Treeish string // the tree or commit to produce an archive for
+	Format  string // format of the resulting archive (usually "tar" or "zip")
+
+	// If nonempty, only include these pathspecs.
+	//
+	// ⚠️ Pathspecs have glob-like syntax. To match exact paths, use the magic word "literal":
+	//
+	//     ":(literal)some/path/with/an/aster*sk.go"
+	//
+	// https://git-scm.com/docs/gitglossary#Documentation/gitglossary.txt-aiddefpathspecapathspec
+	Pathspecs []string
 }
 
 // archiveReader wraps the StdoutReader yielded by gitserver's
@@ -297,8 +305,8 @@ func (c *ClientImplementor) ArchiveURL(repo api.RepoName, opt ArchiveOptions) *u
 		"format":  {opt.Format},
 	}
 
-	for _, path := range opt.Paths {
-		q.Add("path", path)
+	for _, path := range opt.Pathspecs {
+		q.Add("pathspec", path)
 	}
 
 	return &url.URL{

--- a/internal/gitserver/client.go
+++ b/internal/gitserver/client.go
@@ -308,7 +308,7 @@ func (c *ClientImplementor) ArchiveURL(repo api.RepoName, opt ArchiveOptions) *u
 	}
 
 	for _, pathspec := range opt.Pathspecs {
-		q.Add("pathspec", string(pathspec))
+		q.Add("path", string(pathspec))
 	}
 
 	return &url.URL{

--- a/internal/vcs/git/archive_test.go
+++ b/internal/vcs/git/archive_test.go
@@ -30,9 +30,9 @@ func TestArchiveReaderForRepoWithSubRepoPermissions(t *testing.T) {
 	repo := &types.Repo{Name: repoName, ID: 1}
 
 	opts := gitserver.ArchiveOptions{
-		Format:  ArchiveFormatZip,
-		Treeish: commitID,
-		Paths:   []string{"."},
+		Format:    ArchiveFormatZip,
+		Treeish:   commitID,
+		Pathspecs: []string{"."},
 	}
 	if _, err := ArchiveReaderWithSubRepo(context.Background(), checker, repo, opts); err == nil {
 		t.Error("Error should not be null because ArchiveReader is invoked for a repo with sub-repo permissions")
@@ -59,9 +59,9 @@ func TestArchiveReaderForRepoWithoutSubRepoPermissions(t *testing.T) {
 	repo := &types.Repo{Name: repoName, ID: 1}
 
 	opts := gitserver.ArchiveOptions{
-		Format:  ArchiveFormatZip,
-		Treeish: commitID,
-		Paths:   []string{"."},
+		Format:    ArchiveFormatZip,
+		Treeish:   commitID,
+		Pathspecs: []string{"."},
 	}
 	readCloser, err := ArchiveReaderWithSubRepo(context.Background(), checker, repo, opts)
 	if err != nil {

--- a/internal/vcs/git/archive_test.go
+++ b/internal/vcs/git/archive_test.go
@@ -32,7 +32,7 @@ func TestArchiveReaderForRepoWithSubRepoPermissions(t *testing.T) {
 	opts := gitserver.ArchiveOptions{
 		Format:    ArchiveFormatZip,
 		Treeish:   commitID,
-		Pathspecs: []string{"."},
+		Pathspecs: []gitserver.Pathspec{"."},
 	}
 	if _, err := ArchiveReaderWithSubRepo(context.Background(), checker, repo, opts); err == nil {
 		t.Error("Error should not be null because ArchiveReader is invoked for a repo with sub-repo permissions")
@@ -61,7 +61,7 @@ func TestArchiveReaderForRepoWithoutSubRepoPermissions(t *testing.T) {
 	opts := gitserver.ArchiveOptions{
 		Format:    ArchiveFormatZip,
 		Treeish:   commitID,
-		Pathspecs: []string{"."},
+		Pathspecs: []gitserver.Pathspec{"."},
 	}
 	readCloser, err := ArchiveReaderWithSubRepo(context.Background(), checker, repo, opts)
 	if err != nil {


### PR DESCRIPTION
Keegan [discovered](https://sourcegraph.slack.com/archives/CHXHX7XAS/p1647331744501559) that the "paths" passed to `git archive` are actually "pathspecs" with glob-like syntax. Git docs:

https://git-scm.com/docs/gitglossary#Documentation/gitglossary.txt-aiddefpathspecapathspec

This PR:

- Renames `Paths` to `Pathspecs` to more accurately reflect that reality
- Adds a nominal type `type Pathspec string` to help avoid footgunning ourselves
- Prefixes pathspecs with `:(literal)` where appropriate to prevent `*` and `?` from being interpreted as special characters

CC

- @keegancsmith who discovered it
- @tsenart who worked on lockfile detection
- @mollylogue who has been working on sub-repo perms and git archive recently

## Test plan

Ran locally, did search-based code intel on a couple commits to exercise the `git archive` calls in the symbols service.