### PR TITLE
Search backend; fix sending partial matches in an errored OR job

### DIFF
--- a/internal/search/job/expression_job_test.go
+++ b/internal/search/job/expression_job_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
 	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 type sender struct {
@@ -214,4 +215,24 @@ func TestOrJob(t *testing.T) {
 		}
 	})
 
+	// Regression test for #32638
+	t.Run("partial error still eventually sends results", func(t *testing.T) {
+		errSender := NewMockJob()
+		errSender.RunFunc.SetDefaultReturn(nil, errors.New("test error"))
+		senders := newMockSenders(2)
+		j := NewOrJob(append(senders.Jobs(), errSender)...)
+
+		stream := streaming.NewAggregatingStream()
+		finished := make(chan struct{})
+		go func() {
+			_, err := j.Run(context.Background(), nil, stream)
+			require.Error(t, err)
+			close(finished)
+		}()
+
+		senders.SendAll()
+		senders.ExitAll()
+		<-finished
+		require.Len(t, stream.Results, 1)
+	})
 }

--- a/internal/search/job/job_test.go
+++ b/internal/search/job/job_test.go
@@ -189,26 +189,24 @@ func TestToEvaluateJob(t *testing.T) {
 	}
 
 	autogold.Want("root limit for streaming search", `
-(ALERT
-  (TIMEOUT
-    20s
-    (LIMIT
-      500
-      (PARALLEL
-        ZoektGlobalSearch
-        Repo
-        ComputeExcludedRepos))))
+(TIMEOUT
+  20s
+  (LIMIT
+    500
+    (PARALLEL
+      ZoektGlobalSearch
+      Repo
+      ComputeExcludedRepos)))
 `).Equal(t, test("foo", search.Streaming))
 
 	autogold.Want("root limit for batch search", `
-(ALERT
-  (TIMEOUT
-    20s
-    (LIMIT
-      30
-      (PARALLEL
-        ZoektGlobalSearch
-        Repo
-        ComputeExcludedRepos))))
+(TIMEOUT
+  20s
+  (LIMIT
+    30
+    (PARALLEL
+      ZoektGlobalSearch
+      Repo
+      ComputeExcludedRepos)))
 `).Equal(t, test("foo", search.Batch))
 }


### PR DESCRIPTION
This fixes an issue where we would return early when one of the children
of an OR job returned an error. This would cause us to not send our
final set of results that were not matched by all children.

Stacked on #32600
Fixes issues described in #32600

## Test plan

Added a new test to cover this.

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


