### PR TITLE
flake: disable code monitoring submit disabled test

### DIFF
--- a/client/web/src/integration/code-monitoring.test.ts
+++ b/client/web/src/integration/code-monitoring.test.ts
@@ -182,7 +182,7 @@ describe('Code monitoring', () => {
             await driver.page.waitForSelector('.test-action-form-email')
         })
 
-        // TODO: Disabled because it's flaky:
+        // TODO: Disabled because it's flaky: https://github.com/sourcegraph/sourcegraph/issues/32643
         it.skip('disables submitting the code monitor area until trigger and action are complete', async () => {
             await driver.page.goto(driver.sourcegraphBaseUrl + '/code-monitoring/new')
             await driver.page.waitForSelector('.test-name-input')

--- a/client/web/src/integration/code-monitoring.test.ts
+++ b/client/web/src/integration/code-monitoring.test.ts
@@ -182,7 +182,8 @@ describe('Code monitoring', () => {
             await driver.page.waitForSelector('.test-action-form-email')
         })
 
-        it('disables submitting the code monitor area until trigger and action are complete', async () => {
+        // TODO: Disabled because it's flaky:
+        it.skip('disables submitting the code monitor area until trigger and action are complete', async () => {
             await driver.page.goto(driver.sourcegraphBaseUrl + '/code-monitoring/new')
             await driver.page.waitForSelector('.test-name-input')
             await driver.page.type('.test-name-input', 'test monitor')


### PR DESCRIPTION
See https://github.com/sourcegraph/sourcegraph/issues/32643.

## Test plan

Just disabling a test.


