### PR TITLE
flake: disable code monitoring actions area disabled test

### DIFF
--- a/client/web/src/integration/code-monitoring.test.ts
+++ b/client/web/src/integration/code-monitoring.test.ts
@@ -145,7 +145,7 @@ describe('Code monitoring', () => {
             ).toBeGreaterThan(0)
         })
 
-        // TODO: Disabled because it's flaky:
+        // TODO: Disabled because it's flaky: https://github.com/sourcegraph/sourcegraph/issues/32643
         it.skip('disables the actions area until trigger is complete', async () => {
             await driver.page.goto(driver.sourcegraphBaseUrl + '/code-monitoring/new')
             await driver.page.waitForSelector('.test-name-input')

--- a/client/web/src/integration/code-monitoring.test.ts
+++ b/client/web/src/integration/code-monitoring.test.ts
@@ -145,7 +145,8 @@ describe('Code monitoring', () => {
             ).toBeGreaterThan(0)
         })
 
-        it('disables the actions area until trigger is complete', async () => {
+        // TODO: Disabled because it's flaky:
+        it.skip('disables the actions area until trigger is complete', async () => {
             await driver.page.goto(driver.sourcegraphBaseUrl + '/code-monitoring/new')
             await driver.page.waitForSelector('.test-name-input')
             await driver.page.type('.test-name-input', 'test monitor')


### PR DESCRIPTION
See https://github.com/sourcegraph/sourcegraph/issues/32643.

Could be the same underlying issue as https://github.com/sourcegraph/sourcegraph/issues/32643?

## Test plan

Just disabling a test.

