### PR TITLE
compute: support emit $lang for file matches

### DIFF
--- a/enterprise/internal/compute/output_command_test.go
+++ b/enterprise/internal/compute/output_command_test.go
@@ -53,7 +53,7 @@ func fileMatch(content string) result.Match {
 		return []byte(content), nil
 	}
 	return &result.FileMatch{
-		File: result.File{Path: "my/awesome/path"},
+		File: result.File{Path: "my/awesome/path.ml"},
 	}
 }
 
@@ -98,4 +98,8 @@ func TestRun(t *testing.T) {
 		">bar<").
 		Equal(t, test(`content:output.structural(foo(:[arg]) -> >:[arg]<)`, fileMatch("foo(bar)")))
 
+	autogold.Want(
+		"substitute language",
+		"OCaml\n").
+		Equal(t, test(`content:output((.|\n)* -> $lang)`, fileMatch("anything")))
 }

--- a/enterprise/internal/compute/template.go
+++ b/enterprise/internal/compute/template.go
@@ -6,6 +6,8 @@ import (
 	"text/template"
 	"unicode/utf8"
 
+	"github.com/go-enry/go-enry/v2"
+
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
 )
 
@@ -188,6 +190,7 @@ type MetaEnvironment struct {
 	Author  string
 	Date    string
 	Email   string
+	Lang    string
 }
 
 var empty = struct{}{}
@@ -200,6 +203,7 @@ var builtinVariables = map[string]struct{}{
 	"author":  empty,
 	"date":    empty,
 	"email":   empty,
+	"lang":    empty,
 }
 
 func templatize(pattern string) string {
@@ -241,11 +245,13 @@ func substituteMetaVariables(pattern string, env *MetaEnvironment) (string, erro
 func NewMetaEnvironment(r result.Match, content string) *MetaEnvironment {
 	switch m := r.(type) {
 	case *result.FileMatch:
+		lang, _ := enry.GetLanguageByExtension(m.Path)
 		return &MetaEnvironment{
 			Repo:    string(m.Repo.Name),
 			Path:    m.Path,
 			Commit:  string(m.CommitID),
 			Content: content,
+			Lang:    lang,
 		}
 	case *result.CommitMatch:
 		return &MetaEnvironment{


### PR DESCRIPTION
As in title. 

Because compute language statistics. See [context](https://sourcegraph.slack.com/archives/C02QG5A2N31/p1647404951389659?thread_ts=1647398496.948889&cid=C02QG5A2N31).

<sup><sup><sup>It feels weird being this efficient in this code base lol but _hey_ this is how things should've been in the first place</sup></sup></sup>


## Test plan
Added test


