### PR TITLE
insights: add more specific docs link to limited access banner

### DIFF
--- a/client/web/src/enterprise/insights/components/limit-access-banner/CodeInsightsLimitAccessBanner.tsx
+++ b/client/web/src/enterprise/insights/components/limit-access-banner/CodeInsightsLimitAccessBanner.tsx
@@ -24,7 +24,7 @@ export const CodeInsightsLimitAccessBanner: React.FunctionComponent<CodeInsights
                     reach out to us
                 </Link>{' '}
                 to upgrade your Sourcegraph license to unlock Code Insights for unlimited insights and dashboards.{' '}
-                <Link to="/help/code_insights" rel="noopener noreferrer" target="_blank">
+                <Link to="/help/code_insights/references/license" rel="noopener noreferrer" target="_blank">
                     Learn more
                 </Link>
             </p>


### PR DESCRIPTION
This should link to the licensing page [per the figma](https://www.figma.com/file/38cMCA2pOScKIqzt3ZNuiz/Limited-access-mode-RFC-Private-567-%2330165-%5BREADY-FOR-DEV%5D?node-id=1114%3A3903) :) 

## Test plan

This is a quick docs link change, the page url was verified. 


