### PR TITLE
Fix link to 'How-tos' in setup docs page

### DIFF
--- a/doc/dev/setup/index.md
+++ b/doc/dev/setup/index.md
@@ -31,7 +31,7 @@ body.theme-dark .markdown-body ul li:before {
 
 <div class="cta-group">
 <a class="btn btn-primary" href="quickstart">★ Quickstart with <code>sg</code></a>
-<a class="btn" href="#how-tos">How-tos</a>
+<a class="btn" href="../how-to">How-tos</a>
 <a class="btn" href="#troubleshooting">Troubleshooting</a>
 </div>
 


### PR DESCRIPTION
### Description

Fix a broken link to 'How-tos' in setup docs page.

## Test plan

Verified locally running `sg start` and navigating to http://localhost:5080/dev/setup


