### PR TITLE
web: Remove dependencies button from repo page

### DIFF
--- a/client/web/src/repo/tree/TreePage.tsx
+++ b/client/web/src/repo/tree/TreePage.tsx
@@ -7,7 +7,6 @@ import AccountIcon from 'mdi-react/AccountIcon'
 import BookOpenBlankVariantIcon from 'mdi-react/BookOpenBlankVariantIcon'
 import BrainIcon from 'mdi-react/BrainIcon'
 import FolderIcon from 'mdi-react/FolderIcon'
-import GraphOutlineIcon from 'mdi-react/GraphOutlineIcon'
 import HistoryIcon from 'mdi-react/HistoryIcon'
 import SettingsIcon from 'mdi-react/SettingsIcon'
 import SourceBranchIcon from 'mdi-react/SourceBranchIcon'
@@ -42,7 +41,7 @@ import { Settings } from '@sourcegraph/shared/src/schema/settings.schema'
 import { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
-import { toURIWithPath, toPrettyBlobURL, buildSearchURLQuery } from '@sourcegraph/shared/src/util/url'
+import { toURIWithPath, toPrettyBlobURL } from '@sourcegraph/shared/src/util/url'
 import { Container, PageHeader, LoadingSpinner, Button, useObservable, ButtonGroup, Link } from '@sourcegraph/wildcard'
 
 import { getFileDecorations } from '../../backend/features'
@@ -53,8 +52,7 @@ import { CodeIntelligenceProps } from '../../codeintel'
 import { BreadcrumbSetters } from '../../components/Breadcrumbs'
 import { FilteredConnection } from '../../components/FilteredConnection'
 import { PageTitle } from '../../components/PageTitle'
-import { SearchPatternType, GitCommitFields, Scalars, TreePageRepositoryFields } from '../../graphql-operations'
-import { repoFilterForRepoRevision } from '../../search'
+import { GitCommitFields, Scalars, TreePageRepositoryFields } from '../../graphql-operations'
 import { useExperimentalFeatures } from '../../stores'
 import { basename } from '../../util/path'
 import { fetchTreeEntries } from '../backend'
@@ -326,13 +324,6 @@ export const TreePage: React.FunctionComponent<Props> = ({
         </div>
     )
 
-    const dependenciesSearchEnabled = window.context?.experimentalFeatures?.dependenciesSearch !== 'disabled'
-    const repoDepsSearchQueryURL = buildSearchURLQuery(
-        `repo:deps(${repoFilterForRepoRevision(repo.name, false, revision)})`,
-        SearchPatternType.literal,
-        false
-    )
-
     return (
         <div className={styles.treePage}>
             <Container className={styles.container}>
@@ -424,16 +415,6 @@ export const TreePage: React.FunctionComponent<Props> = ({
                                                 as={Link}
                                             >
                                                 <BrainIcon className="icon-inline" /> Code Intelligence
-                                            </Button>
-                                        )}
-                                        {dependenciesSearchEnabled && (
-                                            <Button
-                                                to={`/search?${repoDepsSearchQueryURL}`}
-                                                variant="secondary"
-                                                outline={true}
-                                                as={Link}
-                                            >
-                                                <GraphOutlineIcon className="icon-inline" /> Dependencies{' '}
                                             </Button>
                                         )}
                                         {batchChangesEnabled && <RepoBatchChangesButton repoName={repo.name} />}


### PR DESCRIPTION
This row is too crowded, and we need a better design solution before adding yet another button here. [Slack thread.](https://sourcegraph.slack.com/archives/C0HMGV90V/p1647358382609159)



## Test plan

Visual testing.

