### PR TITLE
Postgres exporter is now installed on docker-compose deployments

### DIFF
--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -5466,7 +5466,7 @@ Query: `sum by(app) (up{app=~".*github-proxy"}) / count by (app) (up{app=~".*git
 
 ## Postgres
 
-<p class="subtitle">Postgres metrics, exported from postgres_exporter (only available on Kubernetes).</p>
+<p class="subtitle">Postgres metrics, exported from postgres_exporter (not available on server).</p>
 
 To see this dashboard, visit `/-/debug/grafana/d/postgres/postgres` on your Sourcegraph instance.
 

--- a/monitoring/definitions/postgres.go
+++ b/monitoring/definitions/postgres.go
@@ -18,7 +18,7 @@ func Postgres() *monitoring.Container {
 	return &monitoring.Container{
 		Name:                     "postgres",
 		Title:                    "Postgres",
-		Description:              "Postgres metrics, exported from postgres_exporter (only available on Kubernetes).",
+		Description:              "Postgres metrics, exported from postgres_exporter (not available on server).",
 		NoSourcegraphDebugServer: true, // This is third-party service
 		Groups: []monitoring.Group{
 			{


### PR DESCRIPTION
Postgres exporter was added to docker-compose in https://github.com/sourcegraph/deploy-sourcegraph-docker/pull/770, so we can update the heading to reflect that.

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

Confirm header is correct on dashboard
