### PR TITLE
vscode: ignore vscode in Codecov

### DIFF
--- a/dev/codecov.yml
+++ b/dev/codecov.yml
@@ -49,6 +49,7 @@ coverage:
 comment: false
 ignore:
   - '**/bindata.go'
+  - 'client/vscode/**/*'
 
 flags:
   typescript:


### PR DESCRIPTION
This is a temporary measure to allow us to merge the VS Code extension feature branch without tanking code coverage metrics. The VS Code extension package should have no effect on correctness/reliability of the core product, so we can safely [ignore](https://docs.codecov.com/docs/ignoring-paths) it until we add integration tests. See the plan at #32674.


## Test plan

This change does not need testing since it's purely within `dev/*`

