### PR TITLE
web: add new packages to client readme

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -4,6 +4,7 @@
 
 - **web**: The web application deployed to http://sourcegraph.com/
 - **browser**: The Sourcegraph browser extension adds tooltips to code on different code hosts.
+- **vscode**: The Sourcegraph [VS Code extension](https://marketplace.visualstudio.com/items?itemName=sourcegraph.sourcegraph).
 - **eslint-plugin-sourcegraph**: Not published package with custom ESLint rules for Sourcegraph. Isn't intended for reuse by other repositories in the Sourcegraph org.
 - **extension-api**: The Sourcegraph extension API types for the _Sourcegraph extensions_. Published as `sourcegraph`.
 - **extension-api-types**: The Sourcegraph extension API types for _client applications_ that embed Sourcegraph extensions and need to communicate with them. Published as `@sourcegraph/extension-api-types`.
@@ -11,6 +12,8 @@
 - **shared**: Contains common TypeScript/React/SCSS client code shared between the browser extension and the web app. Everything in this package is code-host agnostic.
 - **branded**: Contains React components and implements the visual design language we use across our web app and e.g. in the options menu of the browser extension. Over time, components from `shared` and `branded` packages should be moved into the `wildcard` package.
 - **wildcard**: Package that encapsulates storybook configuration and contains our Wildcard design system components. If we're using a component in two or more different areas (e.g. `web-app` and `browser-extension`) then it should live in the `wildcard` package. Otherwise the components should be better colocated with the code where they're actually used.
+- **search**: Search-related code that may be shared between all clients, both branded (e.g. web, VS Code extension) and unbranded (e.g. browser extension)
+- **search-ui**: Search UI components with branded styling that are shared between clients. For example, the `<SearchBox>` component that is used in both the web application and VS Code extension.
 - **storybook**: Storybook configuration.
 
 ## Further migration plan


### PR DESCRIPTION
Update `client` readme with new packages added while developing the VS Code extension.

## Test plan

No test plan because I've only changed a markdown file.
