### PR TITLE
Ignore incorrect file permissions in tarballs.

### DIFF
--- a/internal/unpack/unpack_test.go
+++ b/internal/unpack/unpack_test.go
@@ -138,6 +138,24 @@ func TestUnpack(t *testing.T) {
 					{path: "foo", link: "bar", mode: fs.ModeSymlink},
 				},
 			},
+			{
+				packer: p,
+				name:   "dir-permissions",
+				in: []*fileInfo{
+					{path: "dir", mode: fs.ModeDir},
+					{path: "dir/file1", contents: "x", mode: 0000},
+					{path: "dir/file2", contents: "x", mode: 0200},
+					{path: "dir/file3", contents: "x", mode: 0400},
+					{path: "dir/file4", contents: "x", mode: 0600},
+				},
+				out: []*fileInfo{
+					{path: "dir", mode: fs.ModeDir | 0700},
+					{path: "dir/file1", contents: "x", mode: 0600, size: 1},
+					{path: "dir/file2", contents: "x", mode: 0600, size: 1},
+					{path: "dir/file3", contents: "x", mode: 0600, size: 1},
+					{path: "dir/file4", contents: "x", mode: 0600, size: 1},
+				},
+			},
 		}...)
 	}
 


### PR DESCRIPTION
Resolution for permission denied errors when exploring tarball contents:

```
[gitserver] ERROR failed to clone repo, repo: npm/pngjs, error: get clone command: failed to fetch repo for [file://npm/pngjs](file:///pngjs): error pushing dependency "pngjs@4.0.1": failed to decompress gzipped tarball for pngjs@4.0.1: open /var/folders/m9/8lyqvm9115s3dn551zm26ps40000gn/T/npm-1733821758/package/.eslintrc.json: permission denied
```

## Test plan

Added test cases.