### PR TITLE
docker: Update alpine packages with security fixes on build

### DIFF
--- a/docker-images/alpine-3.12/Dockerfile
+++ b/docker-images/alpine-3.12/Dockerfile
@@ -36,4 +36,4 @@ RUN apk update && apk add --no-cache \
 # Issue: https://github.com/sourcegraph/sourcegraph/issues/32679
 # PR: https://github.com/sourcegraph/sourcegraph/pull/32682
 # @TODO: Remove this with the next release of Alpine
-RUN apk add --no-cache libcrypto1.1>=1.1.1n-r0 libssl1.1>=1.1.1n-r0
+RUN apk add --upgrade --no-cache libcrypto1.1>=1.1.1n-r0 libssl1.1>=1.1.1n-r0

--- a/docker-images/alpine-3.12/Dockerfile
+++ b/docker-images/alpine-3.12/Dockerfile
@@ -30,4 +30,5 @@ RUN apk update && apk add --no-cache \
     curl \
     mailcap \
     tini \
-    wget
+    wget && \
+apk upgrade

--- a/docker-images/alpine-3.12/Dockerfile
+++ b/docker-images/alpine-3.12/Dockerfile
@@ -36,4 +36,4 @@ RUN apk update && apk add --no-cache \
 # Issue: https://github.com/sourcegraph/sourcegraph/issues/32679
 # PR: https://github.com/sourcegraph/sourcegraph/pull/32682
 # @TODO: Remove this with the next release of Alpine
-RUN apk add --no-cache libcrypto1.1=1.1.1n-r0 libssl1.1=1.1.1n-r0
+RUN apk add --no-cache libcrypto1.1>=1.1.1n-r0 libssl1.1>=1.1.1n-r0

--- a/docker-images/alpine-3.12/Dockerfile
+++ b/docker-images/alpine-3.12/Dockerfile
@@ -30,5 +30,10 @@ RUN apk update && apk add --no-cache \
     curl \
     mailcap \
     tini \
-    wget && \
-apk upgrade
+    wget
+
+# Patch CVE 2022-0778
+# Issue: https://github.com/sourcegraph/sourcegraph/issues/32679
+# PR: https://github.com/sourcegraph/sourcegraph/pull/32682
+# @TODO: Remove this with the next release of Alpine
+RUN apk add --no-cache libcrypto1.1=1.1.1n-r0 libssl1.1=1.1.1n-r0

--- a/docker-images/alpine-3.14/Dockerfile
+++ b/docker-images/alpine-3.14/Dockerfile
@@ -36,4 +36,4 @@ RUN apk update && apk add --no-cache \
 # Issue: https://github.com/sourcegraph/sourcegraph/issues/32679
 # PR: https://github.com/sourcegraph/sourcegraph/pull/32682
 # @TODO: Remove this with the next release of Alpine
-RUN apk add --no-cache libcrypto1.1>=1.1.1n-r0 libssl1.1>=1.1.1n-r0
+RUN apk add --upgrade --no-cache libcrypto1.1>=1.1.1n-r0 libssl1.1>=1.1.1n-r0

--- a/docker-images/alpine-3.14/Dockerfile
+++ b/docker-images/alpine-3.14/Dockerfile
@@ -30,4 +30,5 @@ RUN apk update && apk add --no-cache \
     curl \
     mailcap \
     tini \
-    wget
+    wget && \
+apk upgrade

--- a/docker-images/alpine-3.14/Dockerfile
+++ b/docker-images/alpine-3.14/Dockerfile
@@ -32,9 +32,8 @@ RUN apk update && apk add --no-cache \
     tini \
     wget
 
-
 # Patch CVE 2022-0778
 # Issue: https://github.com/sourcegraph/sourcegraph/issues/32679
 # PR: https://github.com/sourcegraph/sourcegraph/pull/32682
 # @TODO: Remove this with the next release of Alpine
-RUN apk add --no-cache libcrypto1.1=1.1.1n-r0 libssl1.1=1.1.1n-r0
+RUN apk add --no-cache libcrypto1.1>=1.1.1n-r0 libssl1.1>=1.1.1n-r0

--- a/docker-images/alpine-3.14/Dockerfile
+++ b/docker-images/alpine-3.14/Dockerfile
@@ -30,5 +30,11 @@ RUN apk update && apk add --no-cache \
     curl \
     mailcap \
     tini \
-    wget && \
-apk upgrade
+    wget
+
+
+# Patch CVE 2022-0778
+# Issue: https://github.com/sourcegraph/sourcegraph/issues/32679
+# PR: https://github.com/sourcegraph/sourcegraph/pull/32682
+# @TODO: Remove this with the next release of Alpine
+RUN apk add --no-cache libcrypto1.1=1.1.1n-r0 libssl1.1=1.1.1n-r0


### PR DESCRIPTION
In response to: https://github.com/sourcegraph/sourcegraph/issues/32679
We need an updated version of the OpenSSL packages. `apk update` only refreshes the repository information. It does not enforce the latest package installed. Adding `apk upgrade` ensures that we are receiving the most critical security fixes.

## Test plan
Running through CI smoke tests. Verified the build locally on my workstation and kicking off a dry-run.

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


