### PR TITLE
search: Show no resolved repos alert when there are no results across all jobs

### DIFF
--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -1101,7 +1101,6 @@ func testSearchClient(t *testing.T, client searchClient) {
 			name   string
 			query  string
 			counts counts
-			err    string
 		}{
 			{
 				name:   `repo contains file`,
@@ -1157,7 +1156,6 @@ func testSearchClient(t *testing.T, client searchClient) {
 				name:   `repo contains with non-matching repo filter`,
 				query:  `repo:nonexist repo:contains(file:diff.proto)`,
 				counts: counts{Repo: 0},
-				err:    `request GraphQL: no resolved repositories`,
 			},
 			{
 				name:   `repo contains respects parameters that affect repo search (fork)`,
@@ -1199,14 +1197,9 @@ func testSearchClient(t *testing.T, client searchClient) {
 		for _, test := range tests {
 			t.Run(test.name, func(t *testing.T) {
 				results, err := client.SearchAll(test.query)
-
-				if test.err == "" {
-					test.err = "<nil>"
-				}
-
-				if test.err != fmt.Sprint(err) {
-					t.Fatalf("error mismatch, have %q, want %q", fmt.Sprint(err), test.err)
-				}
+        if err != nil {
+          t.Fatal(err)
+        }
 
 				count := countResults(results)
 				if diff := cmp.Diff(test.counts, count); diff != "" {

--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -1205,10 +1205,10 @@ func testSearchClient(t *testing.T, client searchClient) {
 				}
 
 				if test.err != fmt.Sprint(err) {
-					t.Fatalf("error mismatch, have %q, want %q", err, test.err)
+					t.Fatalf("error mismatch, have %q, want %q", fmt.Sprint(err), test.err)
 				}
 
-				count := countResults(results.Results)
+				count := countResults(results)
 				if diff := cmp.Diff(test.counts, count); diff != "" {
 					t.Fatalf("mismatch (-want +got):\n%s", diff)
 				}

--- a/internal/search/alert/observer.go
+++ b/internal/search/alert/observer.go
@@ -62,14 +62,6 @@ func (o *Observer) alertForNoResolvedRepos(ctx context.Context, q query.Q) *sear
 	archived := q.Archived()
 	archivedNotSet := archived == nil
 
-	if len(repoFilters) == 0 && len(minusRepoFilters) == 0 && len(dependencies) == 0 {
-		return &search.Alert{
-			PrometheusType: "no_resolved_repos__no_repositories",
-			Title:          "Add repositories or connect repository hosts",
-			Description:    "There are no repositories to search. Add an external service connection to your code host.",
-		}
-	}
-
 	if len(contextFilters) == 1 && !searchcontexts.IsGlobalSearchContextSpec(contextFilters[0]) && len(repoFilters) > 0 {
 		withoutContextFilter := query.OmitField(q, query.FieldContext)
 		proposedQueries := []*search.ProposedQuery{
@@ -169,7 +161,7 @@ func (o *Observer) alertForNoResolvedRepos(ctx context.Context, q query.Q) *sear
 		return &search.Alert{
 			PrometheusType:  "no_resolved_repos__repos_exist_when_altered",
 			Title:           "No repositories found",
-			Description:     "Try alter the query or use a different `repo:<regexp>` filter to see results",
+			Description:     "Try altering the query or use a different `repo:<regexp>` filter to see results",
 			ProposedQueries: proposedQueries,
 		}
 	}
@@ -266,7 +258,7 @@ func (o *Observer) errorToAlert(ctx context.Context, err error) (*search.Alert, 
 		}
 	}
 
-	if errors.Is(err, searchrepos.ErrNoResolvedRepos) {
+	if !o.HasResults && errors.Is(err, searchrepos.ErrNoResolvedRepos) {
 		return o.alertForNoResolvedRepos(ctx, o.Query), nil
 	}
 

--- a/internal/search/job/job.go
+++ b/internal/search/job/job.go
@@ -601,7 +601,7 @@ func ToEvaluateJob(args *Args, q query.Basic) (Job, error) {
 		job = NewSelectJob(sp, job)
 	}
 
-	return NewAlertJob(args.SearchInputs, NewTimeoutJob(timeout, NewLimitJob(maxResults, job))), err
+	return NewTimeoutJob(timeout, NewLimitJob(maxResults, job)), nil
 }
 
 // FromExpandedPlan takes a query plan that has had all predicates expanded,
@@ -615,7 +615,7 @@ func FromExpandedPlan(args *Args, plan query.Plan) (Job, error) {
 		}
 		children = append(children, child)
 	}
-	return NewOrJob(children...), nil
+	return NewAlertJob(args.SearchInputs, NewOrJob(children...)), nil
 }
 
 var metricFeatureFlagUnavailable = promauto.NewCounter(prometheus.CounterOpts{

--- a/internal/search/job/job_test.go
+++ b/internal/search/job/job_test.go
@@ -189,26 +189,24 @@ func TestToEvaluateJob(t *testing.T) {
 	}
 
 	autogold.Want("root limit for streaming search", `
-(ALERT
-  (TIMEOUT
-    20s
-    (LIMIT
-      500
-      (PARALLEL
-        ZoektGlobalSearch
-        Repo
-        ComputeExcludedRepos))))
+(TIMEOUT
+  20s
+  (LIMIT
+    500
+    (PARALLEL
+      ZoektGlobalSearch
+      Repo
+      ComputeExcludedRepos)))
 `).Equal(t, test("foo", search.Streaming))
 
 	autogold.Want("root limit for batch search", `
-(ALERT
-  (TIMEOUT
-    20s
-    (LIMIT
-      30
-      (PARALLEL
-        ZoektGlobalSearch
-        Repo
-        ComputeExcludedRepos))))
+(TIMEOUT
+  20s
+  (LIMIT
+    30
+    (PARALLEL
+      ZoektGlobalSearch
+      Repo
+      ComputeExcludedRepos)))
 `).Equal(t, test("foo", search.Batch))
 }

--- a/internal/search/run/repository.go
+++ b/internal/search/run/repository.go
@@ -53,7 +53,7 @@ func (s *RepoSearch) Run(ctx context.Context, db database.DB, stream streaming.S
 		return nil
 	})
 
-	if errors.Is(err, searchrepos.ErrNoResolvedRepos) && len(s.Args.RepoOptions.Dependencies) == 0 {
+	if errors.Is(err, searchrepos.ErrNoResolvedRepos) && s.Args.PatternInfo.Pattern != "" {
 		err = nil
 	}
 

--- a/internal/search/run/repository.go
+++ b/internal/search/run/repository.go
@@ -53,9 +53,9 @@ func (s *RepoSearch) Run(ctx context.Context, db database.DB, stream streaming.S
 		return nil
 	})
 
-	if errors.Is(err, searchrepos.ErrNoResolvedRepos) && s.Args.PatternInfo.Pattern != "" {
-		err = nil
-	}
+if s.Args.PatternInfo.Pattern != "" {
+    err = errors.Ignore(err, errors.IsPred(searchrepos.ErrNoResolvedRepos))
+}
 
 	return nil, err
 }

--- a/internal/search/run/repository.go
+++ b/internal/search/run/repository.go
@@ -53,9 +53,9 @@ func (s *RepoSearch) Run(ctx context.Context, db database.DB, stream streaming.S
 		return nil
 	})
 
-if s.Args.PatternInfo.Pattern != "" {
-    err = errors.Ignore(err, errors.IsPred(searchrepos.ErrNoResolvedRepos))
-}
+	if s.Args.PatternInfo.Pattern != "" {
+		err = errors.Ignore(err, errors.IsPred(searchrepos.ErrNoResolvedRepos))
+	}
 
 	return nil, err
 }


### PR DESCRIPTION
## Context

Successor to #32600. We tweak the logic to only show no resolved repos alert when there are no results across all jobs, and, for repo search specifically, when there's no pattern in the search (which gets converted into a repo filter for repo search).

## Test plan

Integration tests and manual testing.