### PR TITLE
search-ui: add forceButton prop to sidebar for VS Code

### DIFF
--- a/client/search-ui/src/results/sidebar/SearchSidebar.tsx
+++ b/client/search-ui/src/results/sidebar/SearchSidebar.tsx
@@ -49,6 +49,12 @@ export interface SearchSidebarProps
     prefixContent?: JSX.Element
 
     buildSearchURLQueryFromQueryState: (queryParameters: BuildSearchQueryURLParameters) => string
+
+    /**
+     * Force search type links to be rendered as buttons.
+     * Used e.g. in the VS Code extension to update search query state.
+     */
+    forceButton?: boolean
 }
 
 const selectFromQueryState = ({
@@ -151,6 +157,7 @@ export const SearchSidebar: React.FunctionComponent<SearchSidebarProps> = props 
                         query,
                         selectedSearchContextSpec: props.selectedSearchContextSpec,
                         buildSearchURLQueryFromQueryState: props.buildSearchURLQueryFromQueryState,
+                        forceButton: props.forceButton,
                     })}
                 </SearchSidebarSection>
                 <SearchSidebarSection

--- a/client/search-ui/src/results/sidebar/SearchTypeLink.tsx
+++ b/client/search-ui/src/results/sidebar/SearchTypeLink.tsx
@@ -22,6 +22,11 @@ export interface SearchTypeLinksProps extends Pick<SearchContextProps, 'selected
     query: string
     onNavbarQueryChange: (queryState: QueryState) => void
     buildSearchURLQueryFromQueryState: (queryParameters: BuildSearchQueryURLParameters) => string
+    /**
+     * Force search type links to be rendered as buttons.
+     * Used e.g. in the VS Code extension to update search query state.
+     */
+    forceButton?: boolean
 }
 
 interface SearchTypeLinkProps extends SearchTypeLinksProps {
@@ -88,7 +93,7 @@ const SearchSymbol: React.FunctionComponent<Omit<SearchTypeLinkProps, 'type'>> =
         })
     }, [query, onNavbarQueryChange])
 
-    if (containsLiteralOrPattern(query)) {
+    if (!props.forceButton && containsLiteralOrPattern(query)) {
         return (
             <SearchTypeLink {...props} type={type}>
                 {props.children}
@@ -132,6 +137,15 @@ export const getSearchTypeLinks = (props: SearchTypeLinksProps): ReactElement[] 
         })
     }
 
+    const SearchTypeLinkOrButton = props.forceButton ? SearchTypeButton : SearchTypeLink
+
+    /** Click handler for `SearchTypeLinkOrButton` (when rendered as button) */
+    function updateQueryWithType(type: string): void {
+        props.onNavbarQueryChange({
+            query: updateFilter(props.query, FilterType.type, type),
+        })
+    }
+
     return [
         <SearchTypeButton onClick={updateQueryWithRepoExample} key="repo">
             Search repos by org or name
@@ -142,11 +156,11 @@ export const getSearchTypeLinks = (props: SearchTypeLinksProps): ReactElement[] 
         <SearchSymbol {...props} key="symbol">
             Find a symbol
         </SearchSymbol>,
-        <SearchTypeLink {...props} type="diff" key="diff">
+        <SearchTypeLinkOrButton {...props} type="diff" key="diff" onClick={() => updateQueryWithType('diff')}>
             Search diffs
-        </SearchTypeLink>,
-        <SearchTypeLink {...props} type="commit" key="commit">
+        </SearchTypeLinkOrButton>,
+        <SearchTypeLinkOrButton {...props} type="commit" key="commit" onClick={() => updateQueryWithType('commit')}>
             Search commit messages
-        </SearchTypeLink>,
+        </SearchTypeLinkOrButton>,
     ]
 }


### PR DESCRIPTION
We need the search sidebar to only render buttons in VS Code so that query changes are committed to the zustand store directly, as opposed to through URL change on link click. We communicate query changes from the sidebar to the main search webview, which understandably do not share the same history. 

To accomplish this, we need a prop to force search sidebar links to be rendered as buttons. 

## Test plan

- `sg start web-standalone`
- Execute a search
- Observe that some sidebar suggestions are links by default (we do not use the `forceButton` prop in the web app)
  - ![sidebar-link-button-1](https://user-images.githubusercontent.com/37420160/158637951-b61aac97-9f47-4be1-ba2c-76a1bcd6d462.png)
- Click on a link to confirm that it still works (updates URL, executes search)
  - ![sidebar-link-button-2](https://user-images.githubusercontent.com/37420160/158638339-4f26e854-b340-424b-9bd7-9da88833c643.png)
- Hardcode `forceButton` to `true`
- Observe that links are now buttons, update query on click
  - ![sidebar-link-button-3](https://user-images.githubusercontent.com/37420160/158638236-8b5ac63d-b668-41eb-8eb0-d7b1afca533b.png)


<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


