### PR TITLE
insights: Fix license check for freezing insights

### DIFF
--- a/enterprise/internal/insights/background/license_check_test.go
+++ b/enterprise/internal/insights/background/license_check_test.go
@@ -2,13 +2,14 @@ package background
 
 import (
 	"context"
-	"errors"
+
 	"testing"
 
 	"github.com/hexops/autogold"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/licensing"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 
 	insightsdbtesting "github.com/sourcegraph/sourcegraph/enterprise/internal/insights/dbtesting"
 )

--- a/enterprise/internal/insights/background/license_check_test.go
+++ b/enterprise/internal/insights/background/license_check_test.go
@@ -2,11 +2,11 @@ package background
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/hexops/autogold"
 
-	"github.com/sourcegraph/sourcegraph/enterprise/internal/license"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/licensing"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 
@@ -26,16 +26,13 @@ func TestCheckAndEnforceLicense(t *testing.T) {
 		licensing.MockParseProductLicenseKeyWithBuiltinOrGenerationKey = nil
 	}()
 
-	setMockLicense := func(hasCodeInsights bool) {
-		licensing.MockGetConfiguredProductLicenseInfo = func() (*license.Info, string, error) {
-			tag := "starter"
+	setMockLicenseCheck := func(hasCodeInsights bool) {
+		licensing.MockCheckFeature = func(feature licensing.Feature) error {
+			err := errors.New("error")
 			if hasCodeInsights {
-				tag = "dev"
+				err = nil
 			}
-
-			return &license.Info{
-				Tags: []string{tag},
-			}, "", nil
+			return err
 		}
 	}
 
@@ -86,7 +83,7 @@ func TestCheckAndEnforceLicense(t *testing.T) {
 		}
 		autogold.Want("NumFrozen", numFrozen).Equal(t, 4)
 
-		setMockLicense(true)
+		setMockLicenseCheck(true)
 		checkAndEnforceLicense(ctx, timescale)
 		numFrozen, err = getNumFrozenInsights()
 		if err != nil {
@@ -102,7 +99,7 @@ func TestCheckAndEnforceLicense(t *testing.T) {
 		}
 		autogold.Want("NumFrozen", numFrozen).Equal(t, 0)
 
-		setMockLicense(false)
+		setMockLicenseCheck(false)
 		checkAndEnforceLicense(ctx, timescale)
 		numFrozen, err = getNumFrozenInsights()
 		if err != nil {
@@ -117,7 +114,7 @@ func TestCheckAndEnforceLicense(t *testing.T) {
 		}
 		autogold.Want("NumFrozen", numFrozen).Equal(t, 4)
 
-		setMockLicense(false)
+		setMockLicenseCheck(false)
 		checkAndEnforceLicense(ctx, timescale)
 		numFrozen, err = getNumFrozenInsights()
 		if err != nil {


### PR DESCRIPTION
## Description

This is a bug fix for [the license check](https://github.com/sourcegraph/sourcegraph/pull/32418). Previously I was using `licensing.GetConfiguredProductLicenseInfo()` and checking the plan's features for `code-insights`. For the real license I generated for `k8s`, this didn't pick up on the `code-insights` tag. (It did for the `dev` license I was using to test with locally though, which is why I had originally thought it was working.)

So this fix is to use `licensing.Check(licensing.FeatureCodeInsights)` instead, which is working with a license generated with all the tags I used for the `k8s` license.

[More info on licenses here. ](https://handbook.sourcegraph.com/departments/ce/process/license_keys/#license-key-tags)

## Test plan

Follow the same steps as in https://github.com/sourcegraph/sourcegraph/pull/32418 except that the license should be generated as follows:
```
go run ./enterprise/internal/license/generate-license.go -private-key ../dev-private/enterprise/dev/test-license-generation-key.pem -tags=plan:enterprise-0,acls,private-extension-registry,remote-extensions-allow-disallow,monitoring,true-up,batch-changes,code-insights,distro,internal -users=10 -expires=8784h 
```


