### PR TITLE
Revert codeinsights-db image swap

### DIFF
--- a/docker-images/codeinsights-db/Dockerfile
+++ b/docker-images/codeinsights-db/Dockerfile
@@ -1,0 +1,7 @@
+FROM timescale/timescaledb:2.0.0-pg12-oss
+
+# hadolint ignore=DL3017
+RUN apk -U upgrade && apk add --no-cache \
+    busybox \
+    wget
+

--- a/docker-images/codeinsights-db/build.sh
+++ b/docker-images/codeinsights-db/build.sh
@@ -3,6 +3,4 @@
 set -ex
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
-# This image is identical to our "sourcegraph/postgres-12-alpine" image,
-# but runs with a different uid to avoid migration issues
-IMAGE="${IMAGE:-sourcegraph/codeinsights-db}" POSTGRES_UID=70 PING_UID=700 ../postgres-12-alpine/build.sh
+docker build -t "${IMAGE:-sourcegraph/codeinsights-db}" .

--- a/docker-images/postgres-12-alpine/Dockerfile
+++ b/docker-images/postgres-12-alpine/Dockerfile
@@ -1,14 +1,11 @@
 FROM postgres:12.7-alpine@sha256:b815f145ef6311e24e4bc4d165dad61b2d8e4587c96cea2944297419c5c93054
 
-ARG PING_UID=99
-ARG POSTGRES_UID=999
-
 # We modify the postgres user/group to reconcile with our previous debian based images
 # and avoid issues with customers migrating.
 RUN apk add --no-cache nss su-exec shadow &&\
-    groupmod -g $PING_UID ping &&\
-    usermod -u $POSTGRES_UID postgres &&\
-    groupmod -g $POSTGRES_UID postgres &&\
+    groupmod -g 99 ping &&\
+    usermod -u 999 postgres &&\
+    groupmod -g 999 postgres &&\
     mkdir -p /data/pgdata-12 && chown -R postgres:postgres /data &&\
     chown -R postgres:postgres /var/lib/postgresql &&\
     chown -R postgres:postgres /var/run/postgresql

--- a/docker-images/postgres-12-alpine/build.sh
+++ b/docker-images/postgres-12-alpine/build.sh
@@ -3,7 +3,4 @@
 set -ex
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
-POSTGRES_UID=${POSTGRES_UID:-999}
-PING_UID=${PING_UID:-99}
-
-docker build -t "${IMAGE:-index.docker.io/sourcegraph/postgres-12-alpine}" --build-arg POSTGRES_UID="$POSTGRES_UID" --build-arg PING_UID="$PING_UID" .
+docker build -t "${IMAGE:-index.docker.io/sourcegraph/postgres-12-alpine}" .


### PR DESCRIPTION
Reverts #32616 - I foolishly did not run a dry-run build and all the insights tests are now broken. Reverting in order to unblock main while we investigate what needs to be fixed.

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->
Tests should pass

