### PR TITLE
search-ui: add props to SearchBox for VS Code

### DIFF
--- a/client/search-ui/src/input/MonacoQueryInput.tsx
+++ b/client/search-ui/src/input/MonacoQueryInput.tsx
@@ -19,7 +19,7 @@ import { KeyboardShortcut } from '@sourcegraph/shared/src/keyboardShortcuts'
 import { KEYBOARD_SHORTCUT_FOCUS_SEARCHBAR } from '@sourcegraph/shared/src/keyboardShortcuts/keyboardShortcuts'
 import { toMonacoRange } from '@sourcegraph/shared/src/search/query/monaco'
 import { appendContextFilter } from '@sourcegraph/shared/src/search/query/transformer'
-import { fetchStreamSuggestions } from '@sourcegraph/shared/src/search/suggestions'
+import { fetchStreamSuggestions as defaultFetchStreamSuggestions } from '@sourcegraph/shared/src/search/suggestions'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
 
 import { IEditor } from './LazyMonacoQueryInput'
@@ -73,6 +73,7 @@ export interface MonacoQueryInputProps
     onCompletionItemSelected?: () => void
     onSuggestionsInitialized?: (actions: { trigger: () => void }) => void
     onEditorCreated?: (editor: IEditor) => void
+    fetchStreamSuggestions?: typeof defaultFetchStreamSuggestions // Alternate implementation is used in the VS Code extension.
     autoFocus?: boolean
     keyboardShortcutForFocus?: KeyboardShortcut
     onHandleFuzzyFinder?: React.Dispatch<React.SetStateAction<boolean>>
@@ -160,6 +161,7 @@ export const MonacoQueryInput: React.FunctionComponent<MonacoQueryInputProps> = 
     onSubmit = noop,
     onSuggestionsInitialized,
     onCompletionItemSelected,
+    fetchStreamSuggestions = defaultFetchStreamSuggestions,
     autoFocus,
     selectedSearchContextSpec,
     patternType,
@@ -203,7 +205,7 @@ export const MonacoQueryInput: React.FunctionComponent<MonacoQueryInputProps> = 
 
     const fetchSuggestionsWithContext = useCallback(
         (query: string) => fetchStreamSuggestions(appendContextFilter(query, selectedSearchContextSpec)),
-        [selectedSearchContextSpec]
+        [selectedSearchContextSpec, fetchStreamSuggestions]
     )
 
     const sourcegraphSearchLanguageId = useQueryIntelligence(fetchSuggestionsWithContext, {

--- a/client/search-ui/src/input/SearchBox.tsx
+++ b/client/search-ui/src/input/SearchBox.tsx
@@ -37,6 +37,8 @@ export interface SearchBoxProps
     onSuggestionsInitialized?: (actions: { trigger: () => void }) => void
     autoFocus?: boolean
     keyboardShortcutForFocus?: KeyboardShortcut
+    className?: string
+    containerClassName?: string
 
     /** Whether globbing is enabled for filters. */
     globbing: boolean
@@ -79,8 +81,20 @@ export const SearchBox: React.FunctionComponent<SearchBoxProps> = props => {
     )
 
     return (
-        <div className={classNames(styles.searchBox, props.hideHelpButton ? styles.searchBoxShadow : null)}>
-            <div className={classNames(styles.searchBoxBackgroundContainer, 'flex-shrink-past-contents')}>
+        <div
+            className={classNames(
+                styles.searchBox,
+                props.containerClassName,
+                props.hideHelpButton ? styles.searchBoxShadow : null
+            )}
+        >
+            <div
+                className={classNames(
+                    styles.searchBoxBackgroundContainer,
+                    props.className,
+                    'flex-shrink-past-contents'
+                )}
+            >
                 {props.searchContextsEnabled && props.showSearchContext && (
                     <>
                         <SearchContextDropdown

--- a/client/search-ui/src/input/SearchBox.tsx
+++ b/client/search-ui/src/input/SearchBox.tsx
@@ -51,13 +51,32 @@ export interface SearchBoxProps
 
     /** Set in JSContext only available to the web app. */
     isExternalServicesUserModeAll?: boolean
+
+    /** Called with the underlying editor instance on creation. */
+    onEditorCreated?: (editor: SearchEditor) => void
+}
+
+/**
+ * Interface to the search box editor.
+ * The underlying editor can be either Monaco or Codemirror.
+ */
+interface SearchEditor {
+    focus: () => void
 }
 
 export const SearchBox: React.FunctionComponent<SearchBoxProps> = props => {
-    const { queryState } = props
+    const { queryState, onEditorCreated: onEditorCreatedCallback } = props
 
-    const [editor, setEditor] = useState<{ focus: () => void }>()
+    const [editor, setEditor] = useState<SearchEditor>()
     const focusEditor = useCallback(() => editor?.focus(), [editor])
+
+    const onEditorCreated = useCallback(
+        (editor: SearchEditor) => {
+            setEditor(editor)
+            onEditorCreatedCallback?.(editor)
+        },
+        [onEditorCreatedCallback]
+    )
 
     return (
         <div className={classNames(styles.searchBox, props.hideHelpButton ? styles.searchBoxShadow : null)}>
@@ -79,7 +98,7 @@ export const SearchBox: React.FunctionComponent<SearchBoxProps> = props => {
                         {...props}
                         onHandleFuzzyFinder={props.onHandleFuzzyFinder}
                         className={styles.searchBoxInput}
-                        onEditorCreated={setEditor}
+                        onEditorCreated={onEditorCreated}
                         placeholder="Enter search query..."
                     />
                     <Toggles

--- a/client/search-ui/src/input/SearchBox.tsx
+++ b/client/search-ui/src/input/SearchBox.tsx
@@ -6,10 +6,11 @@ import { SearchContextInputProps, QueryState, SubmitSearchProps } from '@sourceg
 import { AuthenticatedUser } from '@sourcegraph/shared/src/auth'
 import { KeyboardShortcut } from '@sourcegraph/shared/src/keyboardShortcuts'
 import { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
+import { fetchStreamSuggestions as defaultFetchStreamSuggestions } from '@sourcegraph/shared/src/search/suggestions'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
 
-import { LazyMonacoQueryInput, LazyMonacoQueryInputProps } from './LazyMonacoQueryInput'
+import { IEditor, LazyMonacoQueryInput, LazyMonacoQueryInputProps } from './LazyMonacoQueryInput'
 import { SearchButton } from './SearchButton'
 import { SearchContextDropdown } from './SearchContextDropdown'
 import { Toggles, TogglesProps } from './toggles'
@@ -33,6 +34,7 @@ export interface SearchBoxProps
     submitSearchOnSearchContextChange?: SubmitSearchProps['submitSearch']
     submitSearchOnToggle?: SubmitSearchProps['submitSearch']
     onFocus?: () => void
+    fetchStreamSuggestions?: typeof defaultFetchStreamSuggestions // Alternate implementation is used in the VS Code extension.
     onCompletionItemSelected?: () => void
     onSuggestionsInitialized?: (actions: { trigger: () => void }) => void
     autoFocus?: boolean
@@ -55,25 +57,17 @@ export interface SearchBoxProps
     isExternalServicesUserModeAll?: boolean
 
     /** Called with the underlying editor instance on creation. */
-    onEditorCreated?: (editor: SearchEditor) => void
-}
-
-/**
- * Interface to the search box editor.
- * The underlying editor can be either Monaco or Codemirror.
- */
-interface SearchEditor {
-    focus: () => void
+    onEditorCreated?: (editor: IEditor) => void
 }
 
 export const SearchBox: React.FunctionComponent<SearchBoxProps> = props => {
     const { queryState, onEditorCreated: onEditorCreatedCallback } = props
 
-    const [editor, setEditor] = useState<SearchEditor>()
+    const [editor, setEditor] = useState<IEditor>()
     const focusEditor = useCallback(() => editor?.focus(), [editor])
 
     const onEditorCreated = useCallback(
-        (editor: SearchEditor) => {
+        (editor: IEditor) => {
             setEditor(editor)
             onEditorCreatedCallback?.(editor)
         },


### PR DESCRIPTION
Add props to `SearchBox` used in the VS Code extension.
- `onEditorCreated`: Used to get a reference to the underlying Monaco instance. We use this in the extension to focus the search box on events such as sidebar suggestion clicks or search tab focus.
- `className` and `containerClassName`: Self-explanatory, enables variable styling across clients now that we use CSS modules (unable to reference class to override) 
- `fetchStreamSuggestions`: We use a different implementation of this in the extension (we call the "default" implementation in node, send result in message back to UI)

## Test plan

- `sg start web-standalone`
- Observe that the search box still works.
- We don't seem to have unit tests for Monaco, so I added a temporary `onEditorCreated` callback in `SearchNavbarItem` to ensure that everything is wired up correctly (just logged editor instance to console). 