### PR TITLE
move RevList functionality to git package

### DIFF
--- a/enterprise/cmd/symbols/main.go
+++ b/enterprise/cmd/symbols/main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
+	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
@@ -189,19 +190,7 @@ func (g Gitserver) LogReverseEach(repo string, commit string, n int, onLogEntry 
 }
 
 func (g Gitserver) RevListEach(repo string, commit string, onCommit func(commit string) (shouldContinue bool, err error)) error {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	command := gitserver.DefaultClient.Command("git", rockskip.RevListArgs(commit)...)
-	command.Repo = api.RepoName(repo)
-	command.DisableTimeout()
-	stdout, err := gitserver.StdoutReader(ctx, command)
-	if err != nil {
-		return err
-	}
-	defer stdout.Close()
-
-	return rockskip.RevListEach(stdout, onCommit)
+	return git.RevList(repo, commit, onCommit)
 }
 
 func (g Gitserver) ArchiveEach(repo string, commit string, paths []string, onFile func(path string, contents []byte) error) error {

--- a/enterprise/internal/rockskip/git.go
+++ b/enterprise/internal/rockskip/git.go
@@ -200,27 +200,3 @@ func ParseLogReverseEach(stdout io.Reader, onLogEntry func(entry LogEntry) error
 
 	return nil
 }
-
-func RevListArgs(givenCommit string) []string {
-	return []string{"rev-list", "--first-parent", givenCommit}
-}
-
-func RevListEach(stdout io.Reader, onCommit func(commit string) (shouldContinue bool, err error)) error {
-	reader := bufio.NewReader(stdout)
-
-	for {
-		commit, err := reader.ReadString('\n')
-		if err == io.EOF {
-			break
-		} else if err != nil {
-			return err
-		}
-		commit = commit[:len(commit)-1] // Drop the trailing newline
-		shouldContinue, err := onCommit(commit)
-		if !shouldContinue {
-			return err
-		}
-	}
-
-	return nil
-}


### PR DESCRIPTION
See https://github.com/sourcegraph/sourcegraph/issues/32124 for context. This is part of an effort to move away from calls to the gitserver `Command` endpoint outside of the `git` package 

## Test plan

Validate unit tests still pass

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


