### PR TITLE
Code monitors: fix error for nil results

### DIFF
--- a/enterprise/internal/database/code_monitor_last_searched_test.go
+++ b/enterprise/internal/database/code_monitor_last_searched_test.go
@@ -6,34 +6,18 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
-	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
 func TestCodeMonitorStoreLastSearched(t *testing.T) {
 	t.Parallel()
 
-	type testFixtures struct {
-		User    *types.User
-		Monitor *Monitor
-	}
-	populateFixtures := func(db EnterpriseDB) testFixtures {
-		ctx := context.Background()
-		u, err := db.Users().Create(ctx, database.NewUser{Email: "test", Username: "test", EmailVerificationCode: "test"})
-		require.NoError(t, err)
-		ctx = actor.WithActor(ctx, actor.FromUser(u.ID))
-		m, err := db.CodeMonitors().CreateMonitor(ctx, MonitorArgs{NamespaceUserID: &u.ID})
-		require.NoError(t, err)
-		return testFixtures{User: u, Monitor: m}
-	}
-
 	t.Run("insert get upsert get", func(t *testing.T) {
 		t.Parallel()
 		ctx := context.Background()
 		db := NewEnterpriseDB(database.NewDB(dbtest.NewDB(t)))
-		fixtures := populateFixtures(db)
+		fixtures := populateCodeMonitorFixtures(t, db)
 		cm := db.CodeMonitors()
 
 		// Insert
@@ -61,7 +45,7 @@ func TestCodeMonitorStoreLastSearched(t *testing.T) {
 		t.Parallel()
 		ctx := context.Background()
 		db := NewEnterpriseDB(database.NewDB(dbtest.NewDB(t)))
-		fixtures := populateFixtures(db)
+		fixtures := populateCodeMonitorFixtures(t, db)
 		cm := db.CodeMonitors()
 
 		// GetLastSearched should not return an error for a monitor that hasn't
@@ -75,7 +59,7 @@ func TestCodeMonitorStoreLastSearched(t *testing.T) {
 		t.Parallel()
 		ctx := context.Background()
 		db := NewEnterpriseDB(database.NewDB(dbtest.NewDB(t)))
-		fixtures := populateFixtures(db)
+		fixtures := populateCodeMonitorFixtures(t, db)
 		cm := db.CodeMonitors()
 
 		// Insert with nil last searched

--- a/enterprise/internal/database/code_monitor_trigger_jobs.go
+++ b/enterprise/internal/database/code_monitor_trigger_jobs.go
@@ -71,6 +71,11 @@ WHERE id = %s
 `
 
 func (s *codeMonitorStore) UpdateTriggerJobWithResults(ctx context.Context, triggerJobID int32, queryString string, results []*result.CommitMatch) error {
+	if results == nil {
+		// appease db non-null constraint
+		results = []*result.CommitMatch{}
+	}
+
 	resultsJSON, err := json.Marshal(results)
 	if err != nil {
 		return err


### PR DESCRIPTION
The DB requires that the results column is non-null, but this fails when
we have an empty array. Elsewhere, we just check for `nil`ness and instantiate
an empty array instead, but I missed this spot. 

This was causing runs with no results to show errors. Runs with results will
still work as expected.

## Test plan

Added a test to cover regressions. 

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


