### PR TITLE
Swap codeinsights-db docker image to be based off postgres instead of Timescale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ All notable changes to Sourcegraph are documented in this file.
 - The SSH library used to push Batch Change branches to code hosts has been updated to prevent issues pushing to github.com or GitHub Enterprise releases after March 15, 2022. [#32641](https://github.com/sourcegraph/sourcegraph/issues/32641)
 - Bumped the minimum supported version of Docker Compose from `1.22.0` to `1.29.0`. [#32631](https://github.com/sourcegraph/sourcegraph/pull/32631)
 - [Code host API rate limit configuration](https://docs.sourcegraph.com/admin/repo/update_frequency#code-host-api-rate-limiting) no longer based on code host URLs but only takes effect on each individual external services. To enforce API rate limit, please add configuration to all external services that are intended to be rate limited. [#32768](https://github.com/sourcegraph/sourcegraph/pull/32768)
+- The Code Insights database is now based on Postgres 12, removing the dependency on TimescaleDB. [#32697](https://github.com/sourcegraph/sourcegraph/pull/32697)
 
 ### Fixed
 

--- a/dev/codeinsights-db.sh
+++ b/dev/codeinsights-db.sh
@@ -59,7 +59,9 @@ docker run --rm \
   --name=${CONTAINER} \
   --cpus=1 \
   --memory=1g \
+  -e POSTGRES_DB=postgres \
   -e POSTGRES_PASSWORD=password \
+  -e POSTGRES_USER=postgres \
   -p 0.0.0.0:${PORT}:5432 \
   -v "${DISK}":/var/lib/postgresql/data \
   ${IMAGE} >"${LOG_FILE}" 2>&1 || finish

--- a/docker-images/codeinsights-db/Dockerfile
+++ b/docker-images/codeinsights-db/Dockerfile
@@ -1,7 +1,0 @@
-FROM timescale/timescaledb:2.0.0-pg12-oss
-
-# hadolint ignore=DL3017
-RUN apk -U upgrade && apk add --no-cache \
-    busybox \
-    wget
-

--- a/docker-images/codeinsights-db/build.sh
+++ b/docker-images/codeinsights-db/build.sh
@@ -3,4 +3,6 @@
 set -ex
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
-docker build -t "${IMAGE:-sourcegraph/codeinsights-db}" .
+# This image is identical to our "sourcegraph/postgres-12-alpine" image,
+# but runs with a different uid to avoid migration issues
+IMAGE="${IMAGE:-sourcegraph/codeinsights-db}" POSTGRES_UID=70 PING_UID=700 ../postgres-12-alpine/build.sh

--- a/docker-images/postgres-12-alpine/Dockerfile
+++ b/docker-images/postgres-12-alpine/Dockerfile
@@ -1,11 +1,14 @@
 FROM postgres:12.7-alpine@sha256:b815f145ef6311e24e4bc4d165dad61b2d8e4587c96cea2944297419c5c93054
 
+ARG PING_UID=99
+ARG POSTGRES_UID=999
+
 # We modify the postgres user/group to reconcile with our previous debian based images
 # and avoid issues with customers migrating.
 RUN apk add --no-cache nss su-exec shadow &&\
-    groupmod -g 99 ping &&\
-    usermod -u 999 postgres &&\
-    groupmod -g 999 postgres &&\
+    groupmod -g $PING_UID ping &&\
+    usermod -u $POSTGRES_UID postgres &&\
+    groupmod -g $POSTGRES_UID postgres &&\
     mkdir -p /data/pgdata-12 && chown -R postgres:postgres /data &&\
     chown -R postgres:postgres /var/lib/postgresql &&\
     chown -R postgres:postgres /var/run/postgresql

--- a/docker-images/postgres-12-alpine/build.sh
+++ b/docker-images/postgres-12-alpine/build.sh
@@ -3,4 +3,7 @@
 set -ex
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
-docker build -t "${IMAGE:-index.docker.io/sourcegraph/postgres-12-alpine}" .
+POSTGRES_UID=${POSTGRES_UID:-999}
+PING_UID=${PING_UID:-99}
+
+docker build -t "${IMAGE:-index.docker.io/sourcegraph/postgres-12-alpine}" --build-arg POSTGRES_UID="$POSTGRES_UID" --build-arg PING_UID="$PING_UID" .

--- a/enterprise/internal/insights/dbtesting/insights.go
+++ b/enterprise/internal/insights/dbtesting/insights.go
@@ -71,6 +71,9 @@ func TimescaleDB(t testing.TB) (db *sql.DB, cleanup func()) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	// Some tests that exercise concurrency need lots of connections or they block forever.
+	// e.g. TestIntegration/DBStore/Syncer/MultipleServices
+	db.SetMaxOpenConns(10)
 
 	// Perform DB migrations.
 	cleanup = func() {

--- a/enterprise/internal/insights/store/testdata/TestAddViewsToDashboard/create_and_add_view_to_dashboard.golden
+++ b/enterprise/internal/insights/store/testdata/TestAddViewsToDashboard/create_and_add_view_to_dashboard.golden
@@ -1,7 +1,7 @@
 &types.Dashboard{
 	ID: 1, Title: "test dashboard 1", InsightIDs: []string{
-		"view1234567-2",
 		"view1234567",
+		"view1234567-2",
 	},
 	UserIdGrants: []int64{},
 	OrgIdGrants:  []int64{},

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -523,6 +523,8 @@ commands:
         --cpus=1 \
         --memory=1g \
         -e POSTGRES_PASSWORD=password \
+        -e POSTGRES_DATABASE=postgres \
+        -e POSTGRES_USER=postgres \
         -p 0.0.0.0:$PORT:5432 \
         -v $DISK:/var/lib/postgresql/data \
         $IMAGE >$LOG_FILE 2>&1


### PR DESCRIPTION
Switches the base for codeinsights-db to Postgres, away from Timescale. This swap preserves the existing postgres uid used by the container, to avoid requiring users to migrate file permissions.

This PR restores the changes from https://github.com/sourcegraph/sourcegraph/pull/32616, with fixes for the tests that were failing before.

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->
Tests should pass