### PR TITLE
Revert "gitserver: Pass pathspecs to git archive"

### DIFF
--- a/cmd/frontend/internal/app/ui/raw.go
+++ b/cmd/frontend/internal/app/ui/raw.go
@@ -183,7 +183,7 @@ func serveRaw(db database.DB) handlerFunc {
 			// internet, so we use default compression levels on zips (instead of no
 			// compression).
 			f, err := git.ArchiveReaderWithSubRepo(r.Context(), authz.DefaultSubRepoPermsChecker, common.Repo,
-				gitserver.ArchiveOptions{Format: format, Treeish: string(common.CommitID), Pathspecs: []gitserver.Pathspec{gitserver.PathspecLiteral(relativePath)}})
+				gitserver.ArchiveOptions{Format: format, Treeish: string(common.CommitID), Paths: []string{relativePath}})
 			if err != nil {
 				return err
 			}

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -860,11 +860,11 @@ func (s *Server) handleRepoUpdate(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) handleArchive(w http.ResponseWriter, r *http.Request) {
 	var (
-		q         = r.URL.Query()
-		treeish   = q.Get("treeish")
-		repo      = q.Get("repo")
-		format    = q.Get("format")
-		pathspecs = q["path"]
+		q       = r.URL.Query()
+		treeish = q.Get("treeish")
+		repo    = q.Get("repo")
+		format  = q.Get("format")
+		paths   = q["path"]
 	)
 
 	if err := checkSpecArgSafety(treeish); err != nil {
@@ -903,7 +903,7 @@ func (s *Server) handleArchive(w http.ResponseWriter, r *http.Request) {
 	}
 
 	req.Args = append(req.Args, treeish, "--")
-	req.Args = append(req.Args, pathspecs...)
+	req.Args = append(req.Args, paths...)
 
 	s.exec(w, r, req)
 }

--- a/cmd/symbols/gitserver/client.go
+++ b/cmd/symbols/gitserver/client.go
@@ -49,15 +49,10 @@ func (c *gitserverClient) FetchTar(ctx context.Context, repo api.RepoName, commi
 	}})
 	defer endObservation(1, observation.Args{})
 
-	pathSpecs := []gitserver.Pathspec{}
-	for _, path := range paths {
-		pathSpecs = append(pathSpecs, gitserver.PathspecLiteral(path))
-	}
-
 	opts := gitserver.ArchiveOptions{
-		Treeish:   string(commit),
-		Format:    "tar",
-		Pathspecs: pathSpecs,
+		Treeish: string(commit),
+		Format:  "tar",
+		Paths:   paths,
 	}
 
 	return git.ArchiveReader(ctx, repo, opts)

--- a/internal/codeintel/lockfiles/parser.go
+++ b/internal/codeintel/lockfiles/parser.go
@@ -2,9 +2,9 @@ package lockfiles
 
 import (
 	"io"
+	"sort"
 
 	"github.com/sourcegraph/sourcegraph/internal/conf/reposource"
-	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 )
 
 type parser func(io.Reader) ([]reposource.PackageDependency, error)
@@ -14,13 +14,12 @@ var parsers = map[string]parser{
 	"yarn.lock":         parseYarnLockFile,
 }
 
-// lockfilePathspecs is the list of git pathspecs that match lockfiles.
-//
-// https://git-scm.com/docs/gitglossary#Documentation/gitglossary.txt-aiddefpathspecapathspec
-var lockfilePathspecs = func() []gitserver.Pathspec {
-	pathspecs := make([]gitserver.Pathspec, 0, len(parsers))
+var lockfilePaths = func() []string {
+	paths := make([]string, 0, len(parsers))
 	for filename := range parsers {
-		pathspecs = append(pathspecs, gitserver.PathspecSuffix(filename))
+		paths = append(paths, "*"+filename)
 	}
-	return pathspecs
+	sort.Strings(paths)
+
+	return paths
 }()

--- a/internal/codeintel/lockfiles/service.go
+++ b/internal/codeintel/lockfiles/service.go
@@ -52,10 +52,19 @@ func (s *Service) StreamDependencies(ctx context.Context, repo api.RepoName, rev
 	}})
 	defer endObservation(1, observation.Args{})
 
+	paths, err := s.gitSvc.LsFiles(ctx, repo, api.CommitID(rev), lockfilePaths...)
+	if err != nil {
+		return err
+	}
+
+	if len(paths) == 0 {
+		return nil
+	}
+
 	opts := gitserver.ArchiveOptions{
-		Treeish:   rev,
-		Format:    "zip",
-		Pathspecs: lockfilePathspecs,
+		Treeish: rev,
+		Format:  "zip",
+		Paths:   paths,
 	}
 
 	rc, err := s.gitSvc.Archive(ctx, repo, opts)

--- a/internal/codeintel/lockfiles/service_test.go
+++ b/internal/codeintel/lockfiles/service_test.go
@@ -21,7 +21,7 @@ func TestListDependencies(t *testing.T) {
 
 	t.Run("empty ls-files return", func(t *testing.T) {
 		gitSvc := NewMockGitService()
-		gitSvc.ArchiveFunc.SetDefaultHook(zipArchive(t, map[string]io.Reader{}))
+		gitSvc.LsFilesFunc.SetDefaultReturn([]string{}, nil)
 
 		got, err := TestService(gitSvc).ListDependencies(ctx, "foo", "")
 		if err != nil {
@@ -35,6 +35,11 @@ func TestListDependencies(t *testing.T) {
 
 	t.Run("npm", func(t *testing.T) {
 		gitSvc := NewMockGitService()
+		gitSvc.LsFilesFunc.SetDefaultReturn([]string{
+			"client/package-lock.json",
+			"package-lock.json",
+			"yarn.lock",
+		}, nil)
 
 		yarnLock, err := os.Open("testdata/parse/yarn.lock/yarn_normal.lock")
 		if err != nil {

--- a/internal/gitserver/client.go
+++ b/internal/gitserver/client.go
@@ -258,22 +258,10 @@ func addrForKey(key string, addrs []string) string {
 
 // ArchiveOptions contains options for the Archive func.
 type ArchiveOptions struct {
-	Treeish   string     // the tree or commit to produce an archive for
-	Format    string     // format of the resulting archive (usually "tar" or "zip")
-	Pathspecs []Pathspec // if nonempty, only include these pathspecs.
+	Treeish string   // the tree or commit to produce an archive for
+	Format  string   // format of the resulting archive (usually "tar" or "zip")
+	Paths   []string // if nonempty, only include these paths
 }
-
-// Pathspec is a git term for a pattern that matches paths using glob-like syntax.
-// https://git-scm.com/docs/gitglossary#Documentation/gitglossary.txt-aiddefpathspecapathspec
-type Pathspec string
-
-// PathspecLiteral constructs a pathspec that matches a path without interpreting "*" or "?" as special
-// characters.
-func PathspecLiteral(s string) Pathspec { return Pathspec(":(literal)" + s) }
-
-// PathspecSuffix constructs a pathspec that matches paths ending with the given suffix (useful for
-// matching paths by basename).
-func PathspecSuffix(s string) Pathspec { return Pathspec("*" + s) }
 
 // archiveReader wraps the StdoutReader yielded by gitserver's
 // Cmd.StdoutReader with one that knows how to report a repository-not-found
@@ -309,8 +297,8 @@ func (c *ClientImplementor) ArchiveURL(repo api.RepoName, opt ArchiveOptions) *u
 		"format":  {opt.Format},
 	}
 
-	for _, pathspec := range opt.Pathspecs {
-		q.Add("path", string(pathspec))
+	for _, path := range opt.Paths {
+		q.Add("path", path)
 	}
 
 	return &url.URL{

--- a/internal/vcs/git/archive_test.go
+++ b/internal/vcs/git/archive_test.go
@@ -30,9 +30,9 @@ func TestArchiveReaderForRepoWithSubRepoPermissions(t *testing.T) {
 	repo := &types.Repo{Name: repoName, ID: 1}
 
 	opts := gitserver.ArchiveOptions{
-		Format:    ArchiveFormatZip,
-		Treeish:   commitID,
-		Pathspecs: []gitserver.Pathspec{"."},
+		Format:  ArchiveFormatZip,
+		Treeish: commitID,
+		Paths:   []string{"."},
 	}
 	if _, err := ArchiveReaderWithSubRepo(context.Background(), checker, repo, opts); err == nil {
 		t.Error("Error should not be null because ArchiveReader is invoked for a repo with sub-repo permissions")
@@ -59,9 +59,9 @@ func TestArchiveReaderForRepoWithoutSubRepoPermissions(t *testing.T) {
 	repo := &types.Repo{Name: repoName, ID: 1}
 
 	opts := gitserver.ArchiveOptions{
-		Format:    ArchiveFormatZip,
-		Treeish:   commitID,
-		Pathspecs: []gitserver.Pathspec{"."},
+		Format:  ArchiveFormatZip,
+		Treeish: commitID,
+		Paths:   []string{"."},
 	}
 	readCloser, err := ArchiveReaderWithSubRepo(context.Background(), checker, repo, opts)
 	if err != nil {


### PR DESCRIPTION
Reverts sourcegraph/sourcegraph#32637

This might have broken the build

Test failure details: https://buildkite.com/sourcegraph/sourcegraph/builds/137447#c4ce0d73-4257-4384-957a-3c8a76215594/409

## Test plan
It's a revert


<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

