### PR TITLE
gitserver: Pass pathspecs to git archive (2)

### DIFF
--- a/cmd/frontend/internal/app/ui/raw.go
+++ b/cmd/frontend/internal/app/ui/raw.go
@@ -183,7 +183,7 @@ func serveRaw(db database.DB) handlerFunc {
 			// internet, so we use default compression levels on zips (instead of no
 			// compression).
 			f, err := git.ArchiveReader(r.Context(), db, authz.DefaultSubRepoPermsChecker, common.Repo.Name,
-				gitserver.ArchiveOptions{Format: format, Treeish: string(common.CommitID), Paths: []string{relativePath}})
+				gitserver.ArchiveOptions{Format: format, Treeish: string(common.CommitID), Pathspecs: []gitserver.Pathspec{gitserver.PathspecLiteral(relativePath)}})
 			if err != nil {
 				return err
 			}

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -870,11 +870,11 @@ func (s *Server) handleRepoUpdate(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) handleArchive(w http.ResponseWriter, r *http.Request) {
 	var (
-		q       = r.URL.Query()
-		treeish = q.Get("treeish")
-		repo    = q.Get("repo")
-		format  = q.Get("format")
-		paths   = q["path"]
+		q         = r.URL.Query()
+		treeish   = q.Get("treeish")
+		repo      = q.Get("repo")
+		format    = q.Get("format")
+		pathspecs = q["path"]
 	)
 
 	if err := checkSpecArgSafety(treeish); err != nil {
@@ -913,7 +913,7 @@ func (s *Server) handleArchive(w http.ResponseWriter, r *http.Request) {
 	}
 
 	req.Args = append(req.Args, treeish, "--")
-	req.Args = append(req.Args, paths...)
+	req.Args = append(req.Args, pathspecs...)
 
 	s.exec(w, r, req)
 }

--- a/cmd/symbols/gitserver/client.go
+++ b/cmd/symbols/gitserver/client.go
@@ -51,10 +51,15 @@ func (c *gitserverClient) FetchTar(ctx context.Context, repo api.RepoName, commi
 	}})
 	defer endObservation(1, observation.Args{})
 
+	pathSpecs := []gitserver.Pathspec{}
+	for _, path := range paths {
+		pathSpecs = append(pathSpecs, gitserver.PathspecLiteral(path))
+	}
+
 	opts := gitserver.ArchiveOptions{
-		Treeish: string(commit),
-		Format:  "tar",
-		Paths:   paths,
+		Treeish:   string(commit),
+		Format:    "tar",
+		Pathspecs: pathSpecs,
 	}
 
 	// Note: the sub-repo perms checker is nil here because we do the sub-repo filtering at a higher level

--- a/internal/codeintel/lockfiles/iface.go
+++ b/internal/codeintel/lockfiles/iface.go
@@ -12,7 +12,7 @@ import (
 )
 
 type GitService interface {
-	LsFiles(ctx context.Context, repo api.RepoName, commits api.CommitID, paths ...string) ([]string, error)
+	LsFiles(ctx context.Context, repo api.RepoName, commits api.CommitID, pathspecs ...gitserver.Pathspec) ([]string, error)
 	Archive(ctx context.Context, repo api.RepoName, opts gitserver.ArchiveOptions) (io.ReadCloser, error)
 }
 
@@ -32,8 +32,8 @@ func NewDefaultGitService(checker authz.SubRepoPermissionChecker, db database.DB
 	}
 }
 
-func (s *gitService) LsFiles(ctx context.Context, repo api.RepoName, commits api.CommitID, paths ...string) ([]string, error) {
-	return git.LsFiles(ctx, s.db, s.checker, repo, commits, paths...)
+func (s *gitService) LsFiles(ctx context.Context, repo api.RepoName, commits api.CommitID, pathspecs ...gitserver.Pathspec) ([]string, error) {
+	return git.LsFiles(ctx, s.db, s.checker, repo, commits, pathspecs...)
 }
 
 func (s *gitService) Archive(ctx context.Context, repo api.RepoName, opts gitserver.ArchiveOptions) (io.ReadCloser, error) {

--- a/internal/codeintel/lockfiles/parser.go
+++ b/internal/codeintel/lockfiles/parser.go
@@ -2,9 +2,9 @@ package lockfiles
 
 import (
 	"io"
-	"sort"
 
 	"github.com/sourcegraph/sourcegraph/internal/conf/reposource"
+	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 )
 
 type parser func(io.Reader) ([]reposource.PackageDependency, error)
@@ -15,12 +15,13 @@ var parsers = map[string]parser{
 	"go.sum":            parseGoSumFile,
 }
 
-var lockfilePaths = func() []string {
-	paths := make([]string, 0, len(parsers))
+// lockfilePathspecs is the list of git pathspecs that match lockfiles.
+//
+// https://git-scm.com/docs/gitglossary#Documentation/gitglossary.txt-aiddefpathspecapathspec
+var lockfilePathspecs = func() []gitserver.Pathspec {
+	pathspecs := make([]gitserver.Pathspec, 0, len(parsers))
 	for filename := range parsers {
-		paths = append(paths, "*"+filename)
+		pathspecs = append(pathspecs, gitserver.PathspecSuffix(filename))
 	}
-	sort.Strings(paths)
-
-	return paths
+	return pathspecs
 }()

--- a/internal/codeintel/lockfiles/service.go
+++ b/internal/codeintel/lockfiles/service.go
@@ -52,19 +52,10 @@ func (s *Service) StreamDependencies(ctx context.Context, repo api.RepoName, rev
 	}})
 	defer endObservation(1, observation.Args{})
 
-	paths, err := s.gitSvc.LsFiles(ctx, repo, api.CommitID(rev), lockfilePaths...)
-	if err != nil {
-		return err
-	}
-
-	if len(paths) == 0 {
-		return nil
-	}
-
 	opts := gitserver.ArchiveOptions{
-		Treeish: rev,
-		Format:  "zip",
-		Paths:   paths,
+		Treeish:   rev,
+		Format:    "zip",
+		Pathspecs: lockfilePathspecs,
 	}
 
 	rc, err := s.gitSvc.Archive(ctx, repo, opts)

--- a/internal/codeintel/lockfiles/service_test.go
+++ b/internal/codeintel/lockfiles/service_test.go
@@ -21,7 +21,7 @@ func TestListDependencies(t *testing.T) {
 
 	t.Run("empty ls-files return", func(t *testing.T) {
 		gitSvc := NewMockGitService()
-		gitSvc.ArchiveFunc.SetDefaultHook(zipArchive(t, map[string]io.Reader{}))
+		gitSvc.LsFilesFunc.SetDefaultReturn([]string{}, nil)
 
 		got, err := TestService(gitSvc).ListDependencies(ctx, "foo", "")
 		if err != nil {
@@ -35,6 +35,11 @@ func TestListDependencies(t *testing.T) {
 
 	t.Run("npm", func(t *testing.T) {
 		gitSvc := NewMockGitService()
+		gitSvc.LsFilesFunc.SetDefaultReturn([]string{
+			"client/package-lock.json",
+			"package-lock.json",
+			"yarn.lock",
+		}, nil)
 
 		yarnLock, err := os.Open("testdata/parse/yarn.lock/yarn_normal.lock")
 		if err != nil {

--- a/internal/codeintel/lockfiles/service_test.go
+++ b/internal/codeintel/lockfiles/service_test.go
@@ -21,7 +21,7 @@ func TestListDependencies(t *testing.T) {
 
 	t.Run("empty ls-files return", func(t *testing.T) {
 		gitSvc := NewMockGitService()
-		gitSvc.LsFilesFunc.SetDefaultReturn([]string{}, nil)
+		gitSvc.ArchiveFunc.SetDefaultHook(zipArchive(t, map[string]io.Reader{}))
 
 		got, err := TestService(gitSvc).ListDependencies(ctx, "foo", "")
 		if err != nil {
@@ -35,11 +35,6 @@ func TestListDependencies(t *testing.T) {
 
 	t.Run("npm", func(t *testing.T) {
 		gitSvc := NewMockGitService()
-		gitSvc.LsFilesFunc.SetDefaultReturn([]string{
-			"client/package-lock.json",
-			"package-lock.json",
-			"yarn.lock",
-		}, nil)
 
 		yarnLock, err := os.Open("testdata/parse/yarn.lock/yarn_normal.lock")
 		if err != nil {

--- a/internal/gitserver/client.go
+++ b/internal/gitserver/client.go
@@ -313,10 +313,22 @@ func addrForKey(key string, addrs []string) string {
 
 // ArchiveOptions contains options for the Archive func.
 type ArchiveOptions struct {
-	Treeish string   // the tree or commit to produce an archive for
-	Format  string   // format of the resulting archive (usually "tar" or "zip")
-	Paths   []string // if nonempty, only include these paths
+	Treeish   string     // the tree or commit to produce an archive for
+	Format    string     // format of the resulting archive (usually "tar" or "zip")
+	Pathspecs []Pathspec // if nonempty, only include these pathspecs.
 }
+
+// Pathspec is a git term for a pattern that matches paths using glob-like syntax.
+// https://git-scm.com/docs/gitglossary#Documentation/gitglossary.txt-aiddefpathspecapathspec
+type Pathspec string
+
+// PathspecLiteral constructs a pathspec that matches a path without interpreting "*" or "?" as special
+// characters.
+func PathspecLiteral(s string) Pathspec { return Pathspec(":(literal)" + s) }
+
+// PathspecSuffix constructs a pathspec that matches paths ending with the given suffix (useful for
+// matching paths by basename).
+func PathspecSuffix(s string) Pathspec { return Pathspec("*" + s) }
 
 // archiveReader wraps the StdoutReader yielded by gitserver's
 // Cmd.StdoutReader with one that knows how to report a repository-not-found
@@ -352,8 +364,8 @@ func (c *ClientImplementor) ArchiveURL(ctx context.Context, repo api.RepoName, o
 		"format":  {opt.Format},
 	}
 
-	for _, path := range opt.Paths {
-		q.Add("path", path)
+	for _, pathspec := range opt.Pathspecs {
+		q.Add("path", string(pathspec))
 	}
 
 	addrForRepo, err := c.AddrForRepo(ctx, repo)

--- a/internal/vcs/git/archive_test.go
+++ b/internal/vcs/git/archive_test.go
@@ -38,9 +38,9 @@ func TestArchiveReaderForRepoWithSubRepoPermissions(t *testing.T) {
 	repo := &types.Repo{Name: repoName, ID: 1}
 
 	opts := gitserver.ArchiveOptions{
-		Format:  ArchiveFormatZip,
-		Treeish: commitID,
-		Paths:   []string{"."},
+		Format:    ArchiveFormatZip,
+		Treeish:   commitID,
+		Pathspecs: []gitserver.Pathspec{"."},
 	}
 	if _, err := ArchiveReader(context.Background(), database.NewMockDB(), checker, repo.Name, opts); err == nil {
 		t.Error("Error should not be null because ArchiveReader is invoked for a repo with sub-repo permissions")
@@ -72,9 +72,9 @@ func TestArchiveReaderForRepoWithoutSubRepoPermissions(t *testing.T) {
 	repo := &types.Repo{Name: repoName, ID: 1}
 
 	opts := gitserver.ArchiveOptions{
-		Format:  ArchiveFormatZip,
-		Treeish: commitID,
-		Paths:   []string{"."},
+		Format:    ArchiveFormatZip,
+		Treeish:   commitID,
+		Pathspecs: []gitserver.Pathspec{"."},
 	}
 	readCloser, err := ArchiveReader(context.Background(), database.NewMockDB(), checker, repo.Name, opts)
 	if err != nil {

--- a/internal/vcs/git/tree.go
+++ b/internal/vcs/git/tree.go
@@ -98,7 +98,7 @@ func ReadDir(
 }
 
 // LsFiles returns the output of `git ls-files`
-func LsFiles(ctx context.Context, db database.DB, checker authz.SubRepoPermissionChecker, repo api.RepoName, commit api.CommitID, pathspecs ...string) ([]string, error) {
+func LsFiles(ctx context.Context, db database.DB, checker authz.SubRepoPermissionChecker, repo api.RepoName, commit api.CommitID, pathspecs ...gitserver.Pathspec) ([]string, error) {
 	if Mocks.LsFiles != nil {
 		return Mocks.LsFiles(repo, commit)
 	}
@@ -111,7 +111,9 @@ func LsFiles(ctx context.Context, db database.DB, checker authz.SubRepoPermissio
 
 	if len(pathspecs) > 0 {
 		args = append(args, "--")
-		args = append(args, pathspecs...)
+		for _, pathspec := range pathspecs {
+			args = append(args, string(pathspec))
+		}
 	}
 
 	cmd := gitserver.NewClient(db).Command("git", args...)


### PR DESCRIPTION
Reverts the revert sourcegraph/sourcegraph#32698

Re-applies https://github.com/sourcegraph/sourcegraph/pull/32637

The build failed last time. Rijnard recommended pushing to `backend-integration/whatever` to test it before merging this time, so that's what I'll do.