### PR TITLE
search: remove result.Types type from text parameter bundle

### DIFF
--- a/internal/search/job/printers_test.go
+++ b/internal/search/job/printers_test.go
@@ -322,7 +322,6 @@ func TestPrettyJSON(t *testing.T) {
           "Features": {
             "ContentBasedLangFilters": false
           },
-          "ResultTypes": 13,
           "Timeout": 20000000000,
           "Repos": null,
           "Mode": 0,

--- a/internal/search/types.go
+++ b/internal/search/types.go
@@ -12,7 +12,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/endpoint"
 	"github.com/sourcegraph/sourcegraph/internal/search/filter"
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
-	"github.com/sourcegraph/sourcegraph/internal/search/result"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
@@ -131,7 +130,6 @@ type TextParameters struct {
 	PatternInfo *TextPatternInfo
 	RepoOptions RepoOptions
 	Features    Features
-	ResultTypes result.Types
 	Timeout     time.Duration
 
 	Repos []*RepositoryRevisions


### PR DESCRIPTION
Still on the road to (cleanly) introduce optimized search queries.

This PR: Since search logic is concentrated in `job.go`, we can start reducing the state bundled in `TextParameters`. This removes the need to track `result.Types` in it.

## Test plan
Semantics-preserving.


