### PR TITLE
search: expose PatternString method on basic query

### DIFF
--- a/internal/search/job/job.go
+++ b/internal/search/job/job.go
@@ -53,7 +53,7 @@ func ToSearchJob(jargs *Args, q query.Q) (Job, error) {
 		return nil, err
 	}
 	types, _ := q.StringValues(query.FieldType)
-	resultTypes := search.ComputeResultTypes(types, search.ToPatternString(b), jargs.SearchInputs.PatternType)
+	resultTypes := search.ComputeResultTypes(types, b.PatternString(), jargs.SearchInputs.PatternType)
 
 	args := toTextParameters(jargs, b, q, resultTypes)
 	repoOptions := toRepoOptions(q, jargs.SearchInputs.UserSettings)

--- a/internal/search/query/types.go
+++ b/internal/search/query/types.go
@@ -212,6 +212,20 @@ func (b Basic) Index() YesNoOnly {
 	return *v
 }
 
+// PatternString returns the simple string pattern of a basic query. It assumes
+// there is only on pattern atom.
+func (b Basic) PatternString() string {
+	if p, ok := b.Pattern.(Pattern); ok {
+		if b.IsLiteral() {
+			// Escape regexp meta characters if this pattern should be treated literally.
+			return regexp.QuoteMeta(p.Value)
+		} else {
+			return p.Value
+		}
+	}
+	return ""
+}
+
 // A query is a tree of Nodes. We choose the type name Q so that external uses like query.Q do not stutter.
 type Q []Node
 

--- a/internal/search/query_converter.go
+++ b/internal/search/query_converter.go
@@ -114,20 +114,6 @@ const (
 	Batch
 )
 
-// ToPatternString returns the simple string pattern of a basic query. It
-// assumes there is only on pattern atom.
-func ToPatternString(q query.Basic) string {
-	if p, ok := q.Pattern.(query.Pattern); ok {
-		if q.IsLiteral() {
-			// Escape regexp meta characters if this pattern should be treated literally.
-			return regexp.QuoteMeta(p.Value)
-		} else {
-			return p.Value
-		}
-	}
-	return ""
-}
-
 // ToTextPatternInfo converts a an atomic query to internal values that drive
 // text search. An atomic query is a Basic query where the Pattern is either
 // nil, or comprises only one Pattern node (hence, an atom, and not an
@@ -165,7 +151,7 @@ func ToTextPatternInfo(q query.Basic, resultTypes result.Types, p Protocol) *Tex
 		IsStructuralPat: q.IsStructural(),
 		IsCaseSensitive: q.IsCaseSensitive(),
 		FileMatchLimit:  int32(count),
-		Pattern:         ToPatternString(q),
+		Pattern:         q.PatternString(),
 		IsNegated:       negated,
 
 		// Values dependent on parameters.

--- a/internal/search/query_converter_test.go
+++ b/internal/search/query_converter_test.go
@@ -261,7 +261,7 @@ func TestToTextPatternInfo(t *testing.T) {
 		mode := Batch
 		resultTypes := ComputeResultTypes(
 			types,
-			ToPatternString(b),
+			b.PatternString(),
 			query.SearchTypeLiteral,
 		)
 		p := ToTextPatternInfo(b, resultTypes, mode)


### PR DESCRIPTION
Stacked on https://github.com/sourcegraph/sourcegraph/pull/32704.

As in title. Prep for bigger things.

## Test plan
Semantics-preserving.


