### PR TITLE
search: simplify computing presence of time filter

### DIFF
--- a/internal/search/commit/commit.go
+++ b/internal/search/commit/commit.go
@@ -224,17 +224,6 @@ func expandUsernamesToEmails(ctx context.Context, db database.DB, values []strin
 	return expandedValues, nil
 }
 
-func HasTimeFilter(q query.Q) bool {
-	hasTimeFilter := false
-	if _, afterPresent := q.Fields()["after"]; afterPresent {
-		hasTimeFilter = true
-	}
-	if _, beforePresent := q.Fields()["before"]; beforePresent {
-		hasTimeFilter = true
-	}
-	return hasTimeFilter
-}
-
 func QueryToGitQuery(q query.Q, diff bool) gitprotocol.Node {
 	return gitprotocol.Reduce(gitprotocol.NewAnd(queryNodesToPredicates(q, q.IsCaseSensitive(), diff)...))
 }

--- a/internal/search/job/job.go
+++ b/internal/search/job/job.go
@@ -222,7 +222,7 @@ func ToSearchJob(jargs *Args, q query.Q) (Job, error) {
 				Query:                commit.QueryToGitQuery(args.Query, diff),
 				RepoOpts:             repoOptions,
 				Diff:                 diff,
-				HasTimeFilter:        commit.HasTimeFilter(args.Query),
+				HasTimeFilter:        b.Exists("after") || b.Exists("before"),
 				Limit:                int(args.PatternInfo.FileMatchLimit),
 				IncludeModifiedFiles: authz.SubRepoEnabled(authz.DefaultSubRepoPermsChecker),
 				Gitserver:            gitserver.DefaultClient,


### PR DESCRIPTION
Stacked on https://github.com/sourcegraph/sourcegraph/pull/32707.

I want to get rid of the `Fields()` method. If the dict lookup matters here we can implement a more efficient way to check whether a value exists than `b.Exists(...)` but the perf hit here is negligible. `Fields()` is a very gross method right now on query, because it uses the gross Values* method I added long ago to preserve value compatibility.

## Test plan
Semantics-preserving.


