### PR TITLE
sg: sg start enterprise starts enterprise-symbols

### DIFF
--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -761,7 +761,7 @@ commandsets:
       - enterprise-web
       - gitserver
       - searcher
-      - symbols
+      - enterprise-symbols
       - caddy
       - docsite
       - syntax-highlighter


### PR DESCRIPTION
The base `enterprise` target does not run `enterprise-symbols` but `symbols` instead. We stepped up on this with @vrto while debugging some deadlock with the conf and thought for a moment that we could not reproduce it locally, until we noticed the wrong symbols app was launched. 

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

- Running `sg start enterprise locally` 
- Checking that the app is starting properly.
