### PR TITLE
Bump src-cli version for 3.38 release

### DIFF
--- a/doc/cli/references/lsif/upload.md
+++ b/doc/cli/references/lsif/upload.md
@@ -11,6 +11,7 @@
 | `-github-token` | A GitHub access token with 'public_repo' scope that Sourcegraph uses to verify you have access to the repository. |  |
 | `-ignore-upload-failure` | Exit with status code zero on upload failure. | `false` |
 | `-indexer` | The name of the indexer that generated the dump. This will override the 'toolInfo.name' field in the metadata vertex of the LSIF dump file. This must be supplied if the indexer does not set this field (in which case the upload will fail with an explicit message). |  |
+| `-indexerVersion` | The version of the indexer that generated the dump. This will override the 'toolInfo.version' field in the metadata vertex of the LSIF dump file. This must be supplied if the indexer does not set this field (in which case the upload will fail with an explicit message). |  |
 | `-insecure-skip-verify` | Skip validation of TLS certificates against trusted chains | `false` |
 | `-json` | Output relevant state in JSON on success. | `false` |
 | `-max-payload-size` | The maximum upload size (in megabytes). Indexes exceeding this limit will be uploaded over multiple HTTP requests. | `100` |
@@ -38,6 +39,8 @@ Usage of 'src lsif upload':
     	Exit with status code zero on upload failure.
   -indexer string
     	The name of the indexer that generated the dump. This will override the 'toolInfo.name' field in the metadata vertex of the LSIF dump file. This must be supplied if the indexer does not set this field (in which case the upload will fail with an explicit message).
+  -indexerVersion string
+    	The version of the indexer that generated the dump. This will override the 'toolInfo.version' field in the metadata vertex of the LSIF dump file. This must be supplied if the indexer does not set this field (in which case the upload will fail with an explicit message).
   -insecure-skip-verify
     	Skip validation of TLS certificates against trusted chains
   -json

--- a/internal/src-cli/consts.go
+++ b/internal/src-cli/consts.go
@@ -6,4 +6,4 @@ package srccli
 // as the suggested download with this instance.
 //
 // At the time of a Sourcegraph release, this is always the latest src-cli version.
-const MinimumVersion = "3.37.0"
+const MinimumVersion = "3.38.0"


### PR DESCRIPTION
Bumps src-cli for 3.38.

## Test plan

This is a pure mechanical change that will only affect an executor build later, once triggered. As part of that we will validate that it still works as expected.