### PR TITLE
Add tracking to org invitations

### DIFF
--- a/client/web/src/org/invitations/OrgInvitationPage.tsx
+++ b/client/web/src/org/invitations/OrgInvitationPage.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react'
+import React, { useCallback, useEffect } from 'react'
 
 import classNames from 'classnames'
 import { RouteComponentProps } from 'react-router-dom'
@@ -13,6 +13,7 @@ import { orgURL } from '..'
 import { AuthenticatedUser } from '../../auth'
 import { ModalPage } from '../../components/ModalPage'
 import { PageTitle } from '../../components/PageTitle'
+import { eventLogger } from '../../tracking/eventLogger'
 import { userURL } from '../../user'
 import { UserAvatar } from '../../user/UserAvatar'
 import { OrgAvatar } from '../OrgAvatar'
@@ -87,8 +88,14 @@ export const OrgInvitationPage: React.FunctionComponent<Props> = ({ authenticate
 
     const data = inviteData?.invitationByToken
     const orgName = data?.organization.name
+    const orgId = data?.organization.id
     const sender = data?.sender
     const orgDisplayName = data?.organization.displayName || orgName
+    const willVerifyEmail = data?.recipientEmail && !data?.isVerifiedEmail
+
+    useEffect(() => {
+        eventLogger.logViewEvent('OrganizationInvitation', { organizationId: orgId, invitationId: data?.id })
+    }, [orgId, data?.id])
 
     const [respondToInvitation, { loading: respondLoading, error: respondError }] = useMutation<
         RespondToOrgInvitationResult,
@@ -100,28 +107,49 @@ export const OrgInvitationPage: React.FunctionComponent<Props> = ({ authenticate
     })
 
     const acceptInvitation = useCallback(async () => {
-        await respondToInvitation({
-            variables: {
-                id: data?.id || '',
-                response: OrganizationInvitationResponseType.ACCEPT,
-            },
+        eventLogger.log('OrganizationInvitationAcceptClicked', {
+            organizationId: orgId,
+            invitationId: data?.id,
+            willVerifyEmail,
         })
+        try {
+            await respondToInvitation({
+                variables: {
+                    id: data?.id || '',
+                    response: OrganizationInvitationResponseType.ACCEPT,
+                },
+            })
+            eventLogger.log('OrganizationInvitationAcceptSucceeded', { organizationId: orgId, invitationId: data?.id })
+        } catch {
+            eventLogger.log('OrganizationInvitationAcceptFailed', { organizationId: orgId, invitationId: data?.id })
+            return
+        }
 
         if (orgName) {
             history.push(orgURL(orgName))
         }
-    }, [data?.id, history, orgName, respondToInvitation])
+    }, [data?.id, history, orgId, orgName, respondToInvitation, willVerifyEmail])
 
     const declineInvitation = useCallback(async () => {
-        await respondToInvitation({
-            variables: {
-                id: data?.id || '',
-                response: OrganizationInvitationResponseType.REJECT,
-            },
+        eventLogger.log('OrganizationInvitationDeclineClicked', {
+            organizationId: orgId,
+            invitationId: data?.id,
+            willVerifyEmail,
         })
+        try {
+            await respondToInvitation({
+                variables: {
+                    id: data?.id || '',
+                    response: OrganizationInvitationResponseType.REJECT,
+                },
+            })
+            eventLogger.log('OrganizationInvitationDeclineSucceeded', { organizationId: orgId, invitationId: data?.id })
+        } catch {
+            eventLogger.log('OrganizationInvitationDeclineFailed', { organizationId: orgId, invitationId: data?.id })
+        }
 
         history.push(userURL(authenticatedUser.username))
-    }, [authenticatedUser.username, data?.id, history, respondToInvitation])
+    }, [authenticatedUser.username, data?.id, history, orgId, respondToInvitation, willVerifyEmail])
 
     const loading = inviteLoading || respondLoading
     const error = inviteError?.message || respondError?.message

--- a/client/web/src/org/members/OrgPendingInvites.tsx
+++ b/client/web/src/org/members/OrgPendingInvites.tsx
@@ -96,12 +96,14 @@ const PendingInvitesHeader: React.FunctionComponent = () => (
 )
 
 interface InvitationItemProps {
+    orgId: string
     invite: OrganizationInvitation
     viewerCanAdminister: boolean
     onInviteResentRevoked: (recipient: string, revoked?: boolean) => void
 }
 
 const InvitationItem: React.FunctionComponent<InvitationItemProps> = ({
+    orgId,
     invite,
     viewerCanAdminister,
     onInviteResentRevoked,
@@ -118,25 +120,34 @@ const InvitationItem: React.FunctionComponent<InvitationItemProps> = ({
 
     const onCopyInviteLink = useCallback(() => {
         copy(`${window.location.origin}${invite.respondURL}`)
+        eventLogger.log('OrganizationInviteCopied', { organizationId: orgId })
         alert('invite url copied to clipboard!')
-    }, [invite.respondURL])
+    }, [invite.respondURL, orgId])
 
     const onRevokeInvite = useCallback(async () => {
+        eventLogger.log('OrganizationInviteRevokeClicked', { organizationId: orgId })
+
         const inviteToText = invite.recipient ? invite.recipient.username : (invite.recipientEmail as string)
         if (window.confirm(`Revoke invitation from ${inviteToText}?`)) {
+            eventLogger.log('OrganizationInviteRevokeConfirmed', { organizationId: orgId })
             try {
                 await revokeInvite({ variables: { id: invite.id } })
-                eventLogger.logViewEvent('OrgRevokeInvitation', { id: invite.id })
+                eventLogger.log('OrgRevokeInvitation', { id: invite.id })
                 onInviteResentRevoked(inviteToText, true)
             } catch {
-                eventLogger.logViewEvent('OrgRevokeInvitationError', { id: invite.id })
+                eventLogger.log('OrgRevokeInvitationError', { id: invite.id })
             }
+        } else {
+            eventLogger.log('OrganizationInviteRevokeDismissed', { organizationId: orgId })
         }
-    }, [revokeInvite, onInviteResentRevoked, invite.id, invite.recipientEmail, invite.recipient])
+    }, [revokeInvite, onInviteResentRevoked, invite.id, invite.recipientEmail, invite.recipient, orgId])
 
     const onResendInvite = useCallback(async () => {
+        eventLogger.log('OrganizationInviteResendClicked', { organizationId: orgId })
+
         const inviteToText = invite.recipient ? invite.recipient.username : (invite.recipientEmail as string)
         if (window.confirm(`Resend invitation to ${inviteToText}?`)) {
+            eventLogger.log('OrganizationInviteResendConfirmed', { organizationId: orgId })
             try {
                 await resendInvite({ variables: { id: invite.id } })
                 eventLogger.logViewEvent('OrgResendInvitation', { id: invite.id })
@@ -144,6 +155,8 @@ const InvitationItem: React.FunctionComponent<InvitationItemProps> = ({
             } catch {
                 eventLogger.logViewEvent('OrgResendInvitationError', { id: invite.id })
             }
+        } else {
+            eventLogger.log('OrganizationInviteResendDismissed', { organizationId: orgId })
         }
     }, [resendInvite, onInviteResentRevoked, invite.id, invite.recipientEmail, invite.recipient])
 
@@ -250,7 +263,7 @@ export const OrgPendingInvitesPage: React.FunctionComponent<Props> = ({
     const query = useQueryStringParameters()
     const openInviteModal = !!query.get('openInviteModal')
     useEffect(() => {
-        eventLogger.logViewEvent('OrgPendingInvites', { orgId })
+        eventLogger.logViewEvent('OrganizationPendingInvites', { organizationId: orgId })
     }, [orgId])
 
     const [invite, setInvite] = useState<IModalInviteResult>()
@@ -315,6 +328,7 @@ export const OrgPendingInvitesPage: React.FunctionComponent<Props> = ({
                                 orgName={org.name}
                                 orgId={org.id}
                                 onInviteSent={onInviteSent}
+                                eventLoggerEventName="InviteMemberButtonClicked"
                                 variant="success"
                                 initiallyOpened={openInviteModal}
                             />
@@ -368,6 +382,7 @@ export const OrgPendingInvitesPage: React.FunctionComponent<Props> = ({
                                     triggerLabel="Invite a teammate"
                                     orgId={org.id}
                                     onInviteSent={onInviteSent}
+                                    eventLoggerEventName="InviteMemberCTAClicked"
                                     className={styles.inviteMemberLink}
                                     as="a"
                                     variant="link"

--- a/client/web/src/org/members/OrgPendingInvites.tsx
+++ b/client/web/src/org/members/OrgPendingInvites.tsx
@@ -158,7 +158,7 @@ const InvitationItem: React.FunctionComponent<InvitationItemProps> = ({
         } else {
             eventLogger.log('OrganizationInviteResendDismissed', { organizationId: orgId })
         }
-    }, [resendInvite, onInviteResentRevoked, invite.id, invite.recipientEmail, invite.recipient])
+    }, [orgId, invite.recipient, invite.recipientEmail, invite.id, resendInvite, onInviteResentRevoked])
 
     const loading = revokeLoading || resendLoading
     const error = resendError || revokeError
@@ -353,6 +353,7 @@ export const OrgPendingInvitesPage: React.FunctionComponent<Props> = ({
                                     invite={item}
                                     viewerCanAdminister={true}
                                     onInviteResentRevoked={onInviteResentRevoked}
+                                    orgId={org.id}
                                 />
                             ))}
                         </ul>

--- a/client/web/src/org/members/SearchUserAutocomplete.tsx
+++ b/client/web/src/org/members/SearchUserAutocomplete.tsx
@@ -164,11 +164,14 @@ export const AutocompleteSearchUsers: React.FunctionComponent<AutocompleteSearch
         [firstResult]
     )
 
-    const onSelectUser = useCallback((user: IUserItem) => {
-        eventLogger.logViewEvent('AutocompleteUsersSearchSelected', { user: user.username })
-        setOpenResults(false)
-        setUsernameOrEmail(user.username)
-    }, [])
+    const onSelectUser = useCallback(
+        (user: IUserItem) => {
+            eventLogger.logViewEvent('InviteAutocompleteUserSelected', { organizationId: orgId, user: user.username })
+            setOpenResults(false)
+            setUsernameOrEmail(user.username)
+        },
+        [orgId]
+    )
 
     const onMenuKeyDown = useCallback((event: React.KeyboardEvent): void => {
         if (event.key === 'Escape') {


### PR DESCRIPTION
## Related
https://sourcegraph.atlassian.net/browse/CLOUD-315

## Test plan

tested locally. I don't think we need too much testing here. The code is behind feature flags and it's only adding user tracking.

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


