### PR TITLE
database: Restrict site-admin affiliated errors

### DIFF
--- a/internal/database/external_services.go
+++ b/internal/database/external_services.go
@@ -1202,7 +1202,11 @@ FROM external_services es
                    ON es.id = essj.external_service_id
                        AND essj.state IN ('completed', 'errored', 'failed')
                        AND essj.finished_at IS NOT NULL
-WHERE ((es.namespace_user_id = %s) OR (%s AND es.namespace_user_id IS NULL))
+WHERE
+  (
+    (es.namespace_user_id = %s) OR
+    (%s AND es.namespace_user_id IS NULL AND es.namespace_org_id IS NULL)
+  )
   AND es.deleted_at IS NULL
   AND NOT es.cloud_default
 ORDER BY es.id, essj.finished_at DESC


### PR DESCRIPTION
Site admins were so far loading errors for all org owned external services, not only their own and site-level.

This caused additional load in the DB as per this [Slack thread](https://sourcegraph.slack.com/archives/CMBA8F926/p1647518650685719).



## Test plan

Integration test.

---

Jira: CLOUD-278