### PR TITLE
insights: Return dataSeries for frozen insights

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,6 @@ All notable changes to Sourcegraph are documented in this file.
 - Timestamps in the webapp will now display local time on hover instead of UTC time [#31672](https://github.com/sourcegraph/sourcegraph/pull/31672)
 - Updated Postgres version from 12.6 to 12.7 [#31933](https://github.com/sourcegraph/sourcegraph/pull/31933)
 - Code Insights will now periodically clean up data series that are not in use. There is a 1 hour grace period where the series can be reattached to a view, after which all of the time series data and metadata will be deleted. [#32094](https://github.com/sourcegraph/sourcegraph/pull/32094)
-- Code Insights critical telemetry total count now only includes insights that are not frozen (limited by trial mode restrictions). [#32529](https://github.com/sourcegraph/sourcegraph/pull/32529)
 - The Phabricator integration with Gitolite code hosts has been deprecated, the fields have been kept to not break existing systems, but the integration does not work anymore
 - The SSH library used to push Batch Change branches to code hosts has been updated to prevent issues pushing to github.com or GitHub Enterprise releases after March 15, 2022. [#32641](https://github.com/sourcegraph/sourcegraph/issues/32641)
 - Bumped the minimum supported version of Docker Compose from `1.22.0` to `1.29.0` [#32631](https://github.com/sourcegraph/sourcegraph/pull/32631)

--- a/enterprise/internal/insights/background/pings/insights_ping_aggregators.go
+++ b/enterprise/internal/insights/background/pings/insights_ping_aggregators.go
@@ -257,5 +257,5 @@ SELECT
 `
 
 const insightsCriticalCountQuery = `
-SELECT COUNT(*) FROM insight_view WHERE is_frozen = false
+SELECT COUNT(*) FROM insight_view
 `

--- a/enterprise/internal/insights/resolvers/insight_view_resolvers.go
+++ b/enterprise/internal/insights/resolvers/insight_view_resolvers.go
@@ -78,12 +78,6 @@ func (i *insightViewResolver) AppliedFilters(ctx context.Context) (graphqlbacken
 
 func (i *insightViewResolver) DataSeries(ctx context.Context) ([]graphqlbackend.InsightSeriesResolver, error) {
 	var resolvers []graphqlbackend.InsightSeriesResolver
-	if i.view.IsFrozen {
-		// if the view is frozen, we do not show time series data. This is just a basic limitation to prevent
-		// easy mis-use of unlicensed features.
-		return nil, nil
-	}
-
 	var filters *types.InsightViewFilters
 	if i.overrideFilters != nil {
 		filters = i.overrideFilters

--- a/enterprise/internal/insights/resolvers/insight_view_resolvers_test.go
+++ b/enterprise/internal/insights/resolvers/insight_view_resolvers_test.go
@@ -76,10 +76,48 @@ func TestFilterRepositories(t *testing.T) {
 func TestFrozenInsightDataSeriesResolver(t *testing.T) {
 	ctx := context.Background()
 
-	t.Run("insight_is_frozen_returns_nil_resolvers", func(t *testing.T) {
-		ivr := insightViewResolver{view: &types.Insight{IsFrozen: true}}
+	t.Run("insight_is_frozen_returns_real_resolvers", func(t *testing.T) {
+		timescale, cleanup := insightsdbtesting.TimescaleDB(t)
+		defer cleanup()
+		base := baseInsightResolver{
+			insightStore:   store.NewInsightStore(timescale),
+			dashboardStore: store.NewDashboardStore(timescale),
+			insightsDB:     timescale,
+		}
+
+		series, err := base.insightStore.CreateSeries(ctx, types.InsightSeries{
+			SeriesID:            "series1234",
+			Query:               "supercoolseries",
+			SampleIntervalUnit:  string(types.Month),
+			SampleIntervalValue: 1,
+			GenerationMethod:    types.Search,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		view, err := base.insightStore.CreateView(ctx, types.InsightView{
+			Title:            "frozen view",
+			UniqueID:         "super frozen",
+			PresentationType: types.Line,
+			IsFrozen:         true,
+		}, []store.InsightViewGrant{store.GlobalGrant()})
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = base.insightStore.AttachSeriesToView(ctx, series, view, types.InsightViewSeriesMetadata{
+			Label:  "label1",
+			Stroke: "blue",
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		viewWithSeries, err := base.insightStore.GetMapped(ctx, store.InsightQueryArgs{UniqueID: view.UniqueID})
+		if err != nil || len(viewWithSeries) == 0 {
+			t.Fatal(err)
+		}
+		ivr := insightViewResolver{view: &viewWithSeries[0], baseInsightResolver: base}
 		resolvers, err := ivr.DataSeries(ctx)
-		if err != nil || resolvers != nil {
+		if err != nil || resolvers == nil {
 			t.Errorf("unexpected results from frozen data series resolver")
 		}
 	})


### PR DESCRIPTION
## Description

For 3.38 we're going to ignore the `isFrozen` flag and want to return `dataSeries` points for all insights, regardless of whether or not they are frozen. The eventual plan will be to add this functionality back in.

Also returning all insights to critical telemetry instead of just frozen insights, again because we are ignoring the `isFrozen` flag for this release.

## Test plan
For the API change, make sure to have some frozen BE insights in the database, then query for them and verify that the `dataSeries` points are showing up even for the frozen ones:
```
query {
    insightViews {
    nodes {
        isFrozen,
        id,
        dataSeries {
            points {
                value,
                dateTime
            }
        }
     }            
    }
}
```

For testing the critical telemetry, make sure to have some frozen insights in the database, then check the `site-admin/pings` page locally to see that the `codeInsightsCriticalTelemetry` value is what you expect.
