### PR TITLE
insights: Disable the code insights license check

### DIFF
--- a/enterprise/internal/insights/background/background.go
+++ b/enterprise/internal/insights/background/background.go
@@ -82,7 +82,6 @@ func GetBackgroundJobs(ctx context.Context, mainAppDB *sql.DB, insightsDB *sql.D
 	}
 	routines = append(routines, pings.NewInsightsPingEmitterJob(ctx, mainAppDB, insightsDB))
 	routines = append(routines, NewInsightsDataPrunerJob(ctx, mainAppDB, insightsDB))
-	routines = append(routines, NewLicenseCheckJob(ctx, mainAppDB, insightsDB))
 
 	return routines
 }

--- a/enterprise/internal/insights/background/background.go
+++ b/enterprise/internal/insights/background/background.go
@@ -83,6 +83,12 @@ func GetBackgroundJobs(ctx context.Context, mainAppDB *sql.DB, insightsDB *sql.D
 	routines = append(routines, pings.NewInsightsPingEmitterJob(ctx, mainAppDB, insightsDB))
 	routines = append(routines, NewInsightsDataPrunerJob(ctx, mainAppDB, insightsDB))
 
+	// I suspect the linter doesn't like this not being used when I delete it. So let's try this.
+	enableLicneseCheck := false
+	if enableLicneseCheck {
+		routines = append(routines, NewLicenseCheckJob(ctx, mainAppDB, insightsDB))
+	}
+
 	return routines
 }
 


### PR DESCRIPTION
## Description

We're not going to freeze insights for 3.38, so this PR simply turns off the background process that does the license check and freezes/unfreezes insights. 

## Test plan

Run this locally without a `code-insights` license and verify that it doesn't freeze anything.