### PR TITLE
Revert "Support diffing for unrelated commits. (#32015)"

### DIFF
--- a/cmd/frontend/graphqlbackend/repository_comparison.go
+++ b/cmd/frontend/graphqlbackend/repository_comparison.go
@@ -100,17 +100,13 @@ func NewRepositoryComparison(ctx context.Context, db database.DB, r *RepositoryR
 	// Find the common merge-base for the diff. That's the revision the diff applies to,
 	// not the baseRevspec.
 	mergeBaseCommit, err := git.MergeBase(ctx, r.RepoName(), api.CommitID(baseRevspec), api.CommitID(headRevspec))
-
-	// If possible, use the merge-base as the base commit, as the diff will only be guaranteed to be
-	// applicable to the file from that revision.
-	commitString := strings.TrimSpace(string(mergeBaseCommit))
-	rangeType := "..."
 	if err != nil {
-		// Fallback option which should work even if there is no merge base.
-		commitString = baseRevspec
-		rangeType = ".."
+		return nil, err
 	}
 
+	// We use the merge-base as the base commit here, as the diff will only be guaranteed to be
+	// applicable to the file from that revision.
+	commitString := strings.TrimSpace(string(mergeBaseCommit))
 	base, err := getCommit(ctx, r.RepoName(), commitString)
 	if err != nil {
 		return nil, err
@@ -123,7 +119,6 @@ func NewRepositoryComparison(ctx context.Context, db database.DB, r *RepositoryR
 		base:        base,
 		head:        head,
 		repo:        r,
-		rangeType:   rangeType,
 	}, nil
 }
 
@@ -135,7 +130,6 @@ type RepositoryComparisonResolver struct {
 	db                       database.DB
 	baseRevspec, headRevspec string
 	base, head               *GitCommitResolver
-	rangeType                string
 	repo                     *RepositoryResolver
 }
 
@@ -225,10 +219,9 @@ func computeRepositoryComparisonDiff(cmp *RepositoryComparisonResolver) ComputeD
 
 			var iter *git.DiffFileIterator
 			iter, err = git.Diff(ctx, git.DiffOptions{
-				Repo:      cmp.repo.RepoName(),
-				Base:      base,
-				Head:      string(cmp.head.OID()),
-				RangeType: cmp.rangeType,
+				Repo: cmp.repo.RepoName(),
+				Base: base,
+				Head: string(cmp.head.OID()),
 			})
 			if err != nil {
 				return

--- a/cmd/frontend/graphqlbackend/repository_comparison_test.go
+++ b/cmd/frontend/graphqlbackend/repository_comparison_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/sourcegraph/go-diff/diff"
-	"github.com/stretchr/testify/require"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/externallink"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
@@ -23,41 +22,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
-
-func TestRepositoryComparisonNoMergeBase(t *testing.T) {
-	ctx := context.Background()
-	db := database.NewDB(nil)
-
-	wantBaseRevision := "ba5e"
-	wantHeadRevision := "1ead"
-
-	repo := &types.Repo{
-		ID:        api.RepoID(1),
-		Name:      api.RepoName("test"),
-		CreatedAt: time.Now(),
-	}
-
-	t.Cleanup(git.ResetMocks)
-	git.Mocks.ResolveRevision = func(spec string, opt git.ResolveRevisionOptions) (api.CommitID, error) {
-		if spec != wantBaseRevision && spec != wantHeadRevision {
-			t.Fatalf("ResolveRevision received wrong spec: %s", spec)
-		}
-		return api.CommitID(spec), nil
-	}
-	git.Mocks.MergeBase = func(repo api.RepoName, a, b api.CommitID) (api.CommitID, error) {
-		return "", errors.Errorf("merge base doesn't exist!")
-	}
-
-	input := &RepositoryComparisonInput{Base: &wantBaseRevision, Head: &wantHeadRevision}
-	repoResolver := NewRepositoryResolver(db, repo)
-
-	// There shouldn't be any error even when there is no merge base.
-	comp, err := NewRepositoryComparison(ctx, db, repoResolver, input)
-	require.Nil(t, err)
-	require.Equal(t, wantBaseRevision, comp.baseRevspec)
-	require.Equal(t, wantHeadRevision, comp.headRevspec)
-	require.Equal(t, "..", comp.rangeType)
-}
 
 func TestRepositoryComparison(t *testing.T) {
 	ctx := context.Background()

--- a/internal/vcs/git/diff.go
+++ b/internal/vcs/git/diff.go
@@ -22,25 +22,19 @@ type DiffOptions struct {
 	// These fields must be valid <commit> inputs as defined by gitrevisions(7).
 	Base string
 	Head string
-
-	// RangeType to be used for computing the diff: one of ".." or "..." (or unset: "").
-	// For a nice visual explanation of ".." vs "...", see https://stackoverflow.com/a/46345364/2682729
-	RangeType string
 }
 
 // Diff returns an iterator that can be used to access the diff between two
 // commits on a per-file basis. The iterator must be closed with Close when no
 // longer required.
 func Diff(ctx context.Context, opts DiffOptions) (*DiffFileIterator, error) {
+	rangeType := "..."
 	// Rare case: the base is the empty tree, in which case we must use ..
 	// instead of ... as the latter only works for commits.
 	if opts.Base == DevNullSHA {
-		opts.RangeType = ".."
-	} else if opts.RangeType == "" {
-		opts.RangeType = "..."
+		rangeType = ".."
 	}
-
-	rangeSpec := opts.Base + opts.RangeType + opts.Head
+	rangeSpec := opts.Base + rangeType + opts.Head
 	if strings.HasPrefix(rangeSpec, "-") || strings.HasPrefix(rangeSpec, ".") {
 		// We don't want to allow user input to add `git diff` command line
 		// flags or refer to a file.


### PR DESCRIPTION
This reverts commit 6661e4e12aeb26ad9f6eae4a59b9ee84ddb868a3.

## Test plan

This broke back-compat tests. https://buildkite.com/sourcegraph/sourcegraph/builds/137653