### PR TITLE
Install golangci-lint from source instead of downloading a pre-built binary

### DIFF
--- a/dev/golangci-lint.sh
+++ b/dev/golangci-lint.sh
@@ -9,15 +9,12 @@ mkdir -p .bin
 version="1.43.0"
 suffix="${version}-$(go env GOOS)-$(go env GOARCH)"
 target="$PWD/.bin/golangci-lint-${suffix}"
-url="https://github.com/golangci/golangci-lint/releases/download/v${version}/golangci-lint-${suffix}.tar.gz"
 
 if [ ! -f "${target}" ]; then
-  echo "downloading ${url}" 1>&2
-  curl -sS -L -f "${url}" -o "${target}.tar.gz"
-  tar xzf "${target}.tar.gz"
-  mv "golangci-lint-${suffix}/golangci-lint" "${target}"
-  rm -f "${target}.tar.gz"
-  rm -rf "golangci-lint-${suffix}"
+  # Workaround for https://github.com/golangci/golangci-lint/issues/2374
+  echo "installing golangci-lint" 1>&2
+  go install "github.com/golangci/golangci-lint/cmd/golangci-lint@v${version}" 1>&2
+  mv "$(which golangci-lint)" "${target}"
 fi
 
 chmod +x "${target}"


### PR DESCRIPTION
According to the discussion in golangci-lint issue 2374,
this works around a panic. We've been seeing that panic
randomly in CI.

## Test plan

N/A since this is a lint check.