### PR TITLE
dev/sg: include buildkite queue metadata if available

### DIFF
--- a/dev/sg/internal/loki/loki.go
+++ b/dev/sg/internal/loki/loki.go
@@ -53,6 +53,7 @@ type StreamLabels struct {
 	// Additional metadata for CI when pushing
 
 	Branch string `json:"branch"`
+	Queue  string `json:"queue"`
 }
 
 // NewStreamFromJobLogs cleans the given log data, splits it into log entries, merges

--- a/dev/sg/sg_ci.go
+++ b/dev/sg/sg_ci.go
@@ -446,9 +446,12 @@ From there, you can start exploring logs with the Grafana explore panel.
 							continue
 						}
 
-						// Set buildkite branch if available
+						// Set buildkite metadata if available
 						if ciBranch := os.Getenv("BUILDKITE_BRANCH"); ciBranch != "" {
 							stream.Stream.Branch = ciBranch
+						}
+						if ciQueue := os.Getenv("BUILDKITE_AGENT_META_DATA_QUEUE"); ciQueue != "" {
+							stream.Stream.Queue = ciQueue
 						}
 
 						err = lokiClient.PushStreams(ctx, []*loki.Stream{stream})


### PR DESCRIPTION
Adds queue data for us to query on as part of https://github.com/sourcegraph/sourcegraph/issues/31724

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

n/a
