### PR TITLE
dev/ci: remove stateless runtype override, enable caching

### DIFF
--- a/enterprise/dev/ci/gen-pipeline.go
+++ b/enterprise/dev/ci/gen-pipeline.go
@@ -42,13 +42,6 @@ func main() {
 
 	config := ci.NewConfig(time.Now())
 
-	// For the time being, we are running main builds in // of the normal builds in
-	// the stateless agents queue, in order to observe its stability.
-	if buildkite.FeatureFlags.StatelessBuild {
-		// We do not want to trigger any deployment.
-		config.RunType = runtype.MainDryRun
-	}
-
 	pipeline, err := ci.GeneratePipeline(config)
 	if err != nil {
 		panic(err)

--- a/enterprise/dev/ci/internal/buildkite/agents.go
+++ b/enterprise/dev/ci/internal/buildkite/agents.go
@@ -4,4 +4,5 @@ const (
 	AgentQueueStandard  = "standard"
 	AgentQueueBaremetal = "baremetal"
 	AgentQueueJob       = "job"
+	AgentQueueStateful  = "stateful"
 )

--- a/enterprise/dev/ci/internal/buildkite/buildkite.go
+++ b/enterprise/dev/ci/internal/buildkite/buildkite.go
@@ -30,7 +30,10 @@ type featureFlags struct {
 
 // FeatureFlags are for experimenting with CI pipeline features. Use sparingly!
 var FeatureFlags = featureFlags{
-	StatelessBuild: strings.Contains(os.Getenv("BUILDKITE_AGENT_META_DATA_QUEUE"), "job"),
+	StatelessBuild: os.Getenv("CI_FEATURE_FLAG_STATELESS") == "true" ||
+		// Always process retries on stateless agents.
+		// TODO: remove when we switch over entirely to stateless agents
+		os.Getenv("BUILDKITE_REBUILT_FROM_BUILD_NUMBER") != "",
 }
 
 type Pipeline struct {

--- a/enterprise/dev/ci/internal/buildkite/buildkite.go
+++ b/enterprise/dev/ci/internal/buildkite/buildkite.go
@@ -30,7 +30,7 @@ type featureFlags struct {
 
 // FeatureFlags are for experimenting with CI pipeline features. Use sparingly!
 var FeatureFlags = featureFlags{
-	StatelessBuild: os.Getenv("CI_FEATURE_FLAG_STATELESS") == "true",
+	StatelessBuild: strings.Contains(os.Getenv("BUILDKITE_AGENT_META_DATA_QUEUE"), "job"),
 }
 
 type Pipeline struct {

--- a/enterprise/dev/ci/internal/buildkite/buildkite.go
+++ b/enterprise/dev/ci/internal/buildkite/buildkite.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"math/rand"
 	"os"
 	"strconv"
 	"strings"
@@ -33,7 +34,9 @@ var FeatureFlags = featureFlags{
 	StatelessBuild: os.Getenv("CI_FEATURE_FLAG_STATELESS") == "true" ||
 		// Always process retries on stateless agents.
 		// TODO: remove when we switch over entirely to stateless agents
-		os.Getenv("BUILDKITE_REBUILT_FROM_BUILD_NUMBER") != "",
+		os.Getenv("BUILDKITE_REBUILT_FROM_BUILD_NUMBER") != "" ||
+		// Roll out to 75% of builds
+		rand.Uint32()%100 < uint32(75),
 }
 
 type Pipeline struct {

--- a/enterprise/dev/ci/internal/buildkite/buildkite.go
+++ b/enterprise/dev/ci/internal/buildkite/buildkite.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/ghodss/yaml"
 	"github.com/grafana/regexp"
@@ -36,7 +37,7 @@ var FeatureFlags = featureFlags{
 		// TODO: remove when we switch over entirely to stateless agents
 		os.Getenv("BUILDKITE_REBUILT_FROM_BUILD_NUMBER") != "" ||
 		// Roll out to 75% of builds
-		rand.Uint32()%100 < uint32(75),
+		rand.NewSource(time.Now().UnixNano()).Int63()%100 < 75,
 }
 
 type Pipeline struct {

--- a/enterprise/dev/ci/internal/ci/pipeline.go
+++ b/enterprise/dev/ci/internal/ci/pipeline.go
@@ -313,7 +313,7 @@ func withAgentQueueDefaults(s *bk.Step) {
 		if bk.FeatureFlags.StatelessBuild {
 			s.Agents["queue"] = bk.AgentQueueJob
 		} else {
-			s.Agents["queue"] = bk.AgentQueueStandard
+			s.Agents["queue"] = bk.AgentQueueStateful
 		}
 	}
 

--- a/enterprise/dev/ci/internal/ci/pipeline.go
+++ b/enterprise/dev/ci/internal/ci/pipeline.go
@@ -312,10 +312,6 @@ func withAgentQueueDefaults(s *bk.Step) {
 	if len(s.Agents) == 0 || s.Agents["queue"] == "" {
 		if bk.FeatureFlags.StatelessBuild {
 			s.Agents["queue"] = bk.AgentQueueJob
-		} else if os.Getenv("BUILDKITE_REBUILT_FROM_BUILD_NUMBER") != "" {
-			// Always process retries on stateless agents.
-			// TODO: remove when we switch over entirely to stateless agents
-			s.Agents["queue"] = bk.AgentQueueJob
 		} else {
 			s.Agents["queue"] = bk.AgentQueueStandard
 		}


### PR DESCRIPTION
Before we merge this, we must disable the stateless agent testing pipeline to avoid duplicated main runs. From what I understand this will allow us to properly use the caching features

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

https://github.com/sourcegraph/sourcegraph/pull/32751#issuecomment-1072521750