### PR TITLE
batches: remove pre-selected filters for batch changes list

### DIFF
--- a/client/web/src/enterprise/batches/list/BatchChangeListPage.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangeListPage.tsx
@@ -36,7 +36,7 @@ import {
 } from '../../../graphql-operations'
 
 import { BATCH_CHANGES, BATCH_CHANGES_BY_NAMESPACE, GET_LICENSE_AND_USAGE_INFO } from './backend'
-import { BatchChangeListFilters, DRAFT_STATUS, OPEN_STATUS } from './BatchChangeListFilters'
+import { BatchChangeListFilters } from './BatchChangeListFilters'
 import { BatchChangeNode } from './BatchChangeNode'
 import { BatchChangesListIntro } from './BatchChangesListIntro'
 import { GettingStarted } from './GettingStarted'
@@ -59,11 +59,6 @@ type SelectedTab = 'batchChanges' | 'gettingStarted'
 
 const BATCH_CHANGES_PER_PAGE_COUNT = 15
 
-// Drafts are a new feature of severside execution that for now should not be shown if
-// execution is not enabled.
-const getInitialFilters = (isExecutionEnabled: boolean): MultiSelectState<BatchChangeState> =>
-    isExecutionEnabled ? [OPEN_STATUS, DRAFT_STATUS] : [OPEN_STATUS]
-
 /**
  * A list of all batch changes on the Sourcegraph instance.
  */
@@ -81,9 +76,7 @@ export const BatchChangeListPage: React.FunctionComponent<BatchChangeListPagePro
     const isExecutionEnabled = isBatchChangesExecutionEnabled(settingsCascade)
 
     const [selectedTab, setSelectedTab] = useState<SelectedTab>(openTab ?? 'batchChanges')
-    const [selectedFilters, setSelectedFilters] = useState<MultiSelectState<BatchChangeState>>(
-        getInitialFilters(isExecutionEnabled)
-    )
+    const [selectedFilters, setSelectedFilters] = useState<MultiSelectState<BatchChangeState>>([])
     // We keep state to track to the last total count of batch changes in the connection
     // to avoid the display flickering as the connection is loading more data or a
     // different set of filtered data.


### PR DESCRIPTION
Removes the default filters selected on the batch changes list, restoring the initial behavior where all batch changes are shown (none are filtered).

This has the additional effect that for instances without server-side execution enabled (aka all current customer instances), all batch changes will also be shown there. This is different from the original behavior with the radio buttons (only open), but based on the discussion in Slack, I see no reason to treat pre-SSBC customers any differently.

I didn't bother to make a ticket for this one since it's so tiny of a change, and something we've gone back and forth on.

## Test plan

Very limited scope of change. Verified manually that adding and removing a filter works as expected.


