### PR TITLE
dev/ci: temporary patch to always retry on stateless agents

### DIFF
--- a/enterprise/dev/ci/internal/ci/pipeline.go
+++ b/enterprise/dev/ci/internal/ci/pipeline.go
@@ -312,6 +312,10 @@ func withAgentQueueDefaults(s *bk.Step) {
 	if len(s.Agents) == 0 || s.Agents["queue"] == "" {
 		if bk.FeatureFlags.StatelessBuild {
 			s.Agents["queue"] = bk.AgentQueueJob
+		} else if os.Getenv("BUILDKITE_RETRY_COUNT") != "0" {
+			// Always process retries on stateless agents.
+			// TODO: remove when we switch over entirely to stateless agents
+			s.Agents["queue"] = bk.AgentQueueJob
 		} else {
 			s.Agents["queue"] = bk.AgentQueueStandard
 		}


### PR DESCRIPTION
All dev efforts going forward should be focused on making stateless agents stable, so on retries we'll always want to use job-based agents directly.

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


n/a