### PR TITLE
dev/ci: assign to job agents on rebuilds instead of retries

### DIFF
--- a/enterprise/dev/ci/internal/ci/pipeline.go
+++ b/enterprise/dev/ci/internal/ci/pipeline.go
@@ -312,7 +312,7 @@ func withAgentQueueDefaults(s *bk.Step) {
 	if len(s.Agents) == 0 || s.Agents["queue"] == "" {
 		if bk.FeatureFlags.StatelessBuild {
 			s.Agents["queue"] = bk.AgentQueueJob
-		} else if os.Getenv("BUILDKITE_RETRY_COUNT") != "0" {
+		} else if os.Getenv("BUILDKITE_REBUILT_FROM_BUILD_NUMBER") != "" {
 			// Always process retries on stateless agents.
 			// TODO: remove when we switch over entirely to stateless agents
 			s.Agents["queue"] = bk.AgentQueueJob


### PR DESCRIPTION
Another pass at https://github.com/sourcegraph/sourcegraph/pull/32755 - retried builds don't count as incrementing retry counts, and there's no way to change the pipeline step on the fly to target a new queue for specific job retries, so we cant change the behaviour based on retry count. However, I confirmed this variable is set on a rebuild, so we can use this instead to re-run entire builds on job-based agents

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

n/a