### PR TITLE
batches: move place-in-queue label to front

### DIFF
--- a/client/web/src/enterprise/batches/execution/WorkspaceDetails.tsx
+++ b/client/web/src/enterprise/batches/execution/WorkspaceDetails.tsx
@@ -118,6 +118,15 @@ export const WorkspaceDetails: React.FunctionComponent<WorkspaceDetailsProps> = 
                 </Button>
             </div>
             <div className="text-muted">
+                {typeof workspace.placeInQueue === 'number' && (
+                    <>
+                        <Icon as={SyncIcon} />{' '}
+                        <strong>
+                            <NumberInQueue number={workspace.placeInQueue} />
+                        </strong>{' '}
+                        in queue |{' '}
+                    </>
+                )}
                 {workspace.path && <>{workspace.path} | </>}
                 <Icon as={SourceBranchIcon} /> base: <strong>{workspace.branch.abbrevName}</strong>
                 {workspace.startedAt && (
@@ -127,16 +136,6 @@ export const WorkspaceDetails: React.FunctionComponent<WorkspaceDetailsProps> = 
                         <strong>
                             <Duration start={workspace.startedAt} end={workspace.finishedAt ?? undefined} />
                         </strong>
-                    </>
-                )}
-                {typeof workspace.placeInQueue === 'number' && (
-                    <>
-                        {' '}
-                        | <Icon as={SyncIcon} />{' '}
-                        <strong>
-                            <NumberInQueue number={workspace.placeInQueue} />
-                        </strong>{' '}
-                        in queue
                     </>
                 )}
                 {!workspace.cachedResultFound && workspace.state !== BatchSpecWorkspaceState.SKIPPED && (


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/28031.

I thought there was more left to update here to match the designs, and it's still kinda unclear from the Figma screen if this is the final state or not, but it seems like this was actually the only piece left, based on [this Figma comment](https://www.figma.com/file/cTKjwbvWqU6xAykZmCTTqy?node-id=2013:70650#152243104). So uh, here's a tiny PR! @eseliger if you have a better recollection of anything else we wanted to do with this place-in-queue label, let me know. 😅

## Test plan

This is just a tiny shift in the order of elements and spacing, on a screen behind a feature flag.

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


