### PR TITLE
notebooks: add download button for data in compute blocks

### DIFF
--- a/client/web/src/notebooks/blocks/compute/component/elm.json
+++ b/client/web/src/notebooks/blocks/compute/component/elm.json
@@ -7,6 +7,7 @@
       "NoRedInk/elm-json-decode-pipeline": "1.0.0",
       "elm/browser": "1.0.2",
       "elm/core": "1.0.5",
+      "elm/file": "1.0.5",
       "elm/html": "1.0.0",
       "elm/json": "1.1.3",
       "elm/svg": "1.0.1",
@@ -18,6 +19,7 @@
     "indirect": {
       "danhandrea/elm-time-extra": "1.1.0",
       "debois/elm-dom": "1.3.0",
+      "elm/bytes": "1.0.8",
       "elm/parser": "1.1.0",
       "elm/virtual-dom": "1.0.2",
       "justinmimbs/date": "3.2.1",


### PR DESCRIPTION
Adds a download button for data. Just generally useful. See [internal example](https://sourcegraph.slack.com/archives/C020S8AT3LN/p1647565850040269)

## Test plan
Tested manually for experimental feature.


