### PR TITLE
batches: fix execution preview button URL

### DIFF
--- a/client/web/src/enterprise/batches/execution/BatchSpecExecutionDetailsPage.tsx
+++ b/client/web/src/enterprise/batches/execution/BatchSpecExecutionDetailsPage.tsx
@@ -116,7 +116,7 @@ export const BatchSpecExecutionDetailsPage: React.FunctionComponent<BatchSpecExe
                         </LinkOrSpan>
                     </>
                 }
-                actions={<BatchSpecActions batchSpec={batchSpec} />}
+                actions={<BatchSpecActions batchSpec={batchSpec} executionURL={match.url} />}
                 className="mb-3"
             />
 
@@ -202,9 +202,10 @@ const TabBar: React.FunctionComponent<{ url: string; batchSpec: BatchSpecExecuti
 
 interface BatchSpecActionsProps {
     batchSpec: BatchSpecExecutionFields
+    executionURL: string
 }
 
-const BatchSpecActions: React.FunctionComponent<BatchSpecActionsProps> = ({ batchSpec }) => {
+const BatchSpecActions: React.FunctionComponent<BatchSpecActionsProps> = ({ batchSpec, executionURL }) => {
     const location = useLocation()
 
     const [isCanceling, setIsCanceling] = useState<boolean | Error>(false)
@@ -279,7 +280,7 @@ const BatchSpecActions: React.FunctionComponent<BatchSpecActionsProps> = ({ batc
                     {!location.pathname.endsWith('preview') &&
                         batchSpec.applyURL &&
                         batchSpec.state === BatchSpecState.COMPLETED && (
-                            <Button to="preview" variant="primary" as={Link}>
+                            <Button to={`${executionURL}/preview`} variant="primary" as={Link}>
                                 Preview
                             </Button>
                         )}
@@ -305,7 +306,7 @@ const BatchSpecActions: React.FunctionComponent<BatchSpecActionsProps> = ({ batc
                         batchSpec.applyURL &&
                         batchSpec.state === BatchSpecState.FAILED && (
                             <Button
-                                to="preview"
+                                to={`${executionURL}/preview`}
                                 data-tooltip="Execution didn't finish successfully in all workspaces. The batch spec might have less changeset specs than expected."
                                 variant="warning"
                                 outline={true}


### PR DESCRIPTION
Oops I didn't notice the preview button links were relative and broke them with https://github.com/sourcegraph/sourcegraph/pull/32587 if you try to click it while you have a workspace selected. 👀


## Test plan

Just fixes a bug, for a component that's behind a feature flag that no one has access to yet anyway.


