### PR TITLE
batches: persist last-selected filters to temporary settings

### DIFF
--- a/client/shared/src/settings/temporary/TemporarySettings.ts
+++ b/client/shared/src/settings/temporary/TemporarySettings.ts
@@ -1,5 +1,9 @@
 import { Optional } from 'utility-types'
 
+import { MultiSelectState } from '@sourcegraph/wildcard'
+
+import { BatchChangeState } from '../../graphql-operations'
+
 import { SectionID, NoResultsSectionID } from './searchSidebar'
 
 /**
@@ -25,6 +29,7 @@ export interface TemporarySettingsSchema {
     'integrations.jetbrains.lastDetectionTimestamp': number
     'cta.browserExtensionAlertDismissed': boolean
     'cta.ideExtensionAlertDismissed': boolean
+    'batches.defaultListFilters': MultiSelectState<BatchChangeState>
 }
 
 /**

--- a/client/web/src/enterprise/batches/list/BatchChangeListFilters.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangeListFilters.tsx
@@ -8,7 +8,7 @@ export const OPEN_STATUS: MultiSelectOption<BatchChangeState> = { label: 'Open',
 export const DRAFT_STATUS: MultiSelectOption<BatchChangeState> = { label: 'Draft', value: BatchChangeState.DRAFT }
 export const CLOSED_STATUS: MultiSelectOption<BatchChangeState> = { label: 'Closed', value: BatchChangeState.CLOSED }
 
-const STATUS_OPTIONS: MultiSelectOption<BatchChangeState>[] = [OPEN_STATUS, DRAFT_STATUS, CLOSED_STATUS]
+export const STATUS_OPTIONS: MultiSelectOption<BatchChangeState>[] = [OPEN_STATUS, DRAFT_STATUS, CLOSED_STATUS]
 // Drafts are a new feature of severside execution that for now should not be shown if
 // execution is not enabled.
 const STATUS_OPTIONS_NO_DRAFTS: MultiSelectOption<BatchChangeState>[] = [OPEN_STATUS, CLOSED_STATUS]

--- a/client/web/src/enterprise/batches/list/BatchChangeListFilters.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangeListFilters.tsx
@@ -14,7 +14,7 @@ const STATUS_OPTIONS: MultiSelectOption<BatchChangeState>[] = [OPEN_STATUS, DRAF
 const STATUS_OPTIONS_NO_DRAFTS: MultiSelectOption<BatchChangeState>[] = [OPEN_STATUS, CLOSED_STATUS]
 
 interface BatchChangeListFiltersProps
-    extends Required<Pick<MultiSelectProps<MultiSelectOption<BatchChangeState>>, 'onChange' | 'defaultValue'>> {
+    extends Required<Pick<MultiSelectProps<MultiSelectOption<BatchChangeState>>, 'onChange' | 'value'>> {
     className?: string
     isExecutionEnabled: boolean
 }

--- a/client/web/src/enterprise/batches/list/useBatchChangeListFilters.ts
+++ b/client/web/src/enterprise/batches/list/useBatchChangeListFilters.ts
@@ -42,7 +42,6 @@ export const useBatchChangeListFilters = (): UseBatchChangeListFiltersResult => 
 
     useEffect(() => {
         if (defaultFilters && !hasModifiedFilters) {
-            console.log('setting defaults', { defaultFilters })
             setSelectedFiltersRaw(defaultFilters)
         }
     }, [defaultFilters, hasModifiedFilters])

--- a/client/web/src/enterprise/batches/list/useBatchChangeListFilters.ts
+++ b/client/web/src/enterprise/batches/list/useBatchChangeListFilters.ts
@@ -1,9 +1,20 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 
+import { lowerCase } from 'lodash'
+import { useHistory } from 'react-router'
+
 import { useTemporarySetting } from '@sourcegraph/shared/src/settings/temporary/useTemporarySetting'
 import { MultiSelectState } from '@sourcegraph/wildcard'
 
 import { BatchChangeState } from '../../../graphql-operations'
+
+import { STATUS_OPTIONS } from './BatchChangeListFilters'
+
+const statesToFilters = (states: string[]): MultiSelectState<BatchChangeState> =>
+    STATUS_OPTIONS.filter(option => states.map(lowerCase).includes(option.value.toLowerCase()))
+
+const filtersToStates = (filters: MultiSelectState<BatchChangeState>): BatchChangeState[] =>
+    filters.map(filter => filter.value)
 
 interface UseBatchChangeListFiltersResult {
     /** State representing the different filters selected in the `MultiSelect` UI. */
@@ -22,13 +33,21 @@ interface UseBatchChangeListFiltersResult {
  * the `MultiSelect` UI to filter a list of batch changes.
  */
 export const useBatchChangeListFilters = (): UseBatchChangeListFiltersResult => {
+    const history = useHistory()
+
     // NOTE: Fetching this setting is an async operation, so we can't use it as the
     // initial value for `useState`. Instead, we will set the value of the filter state in
-    // a `useEffect` hook once we've loaded it, but only if the user has not changed the
-    // filter state in the meantime.
+    // a `useEffect` hook once we've loaded it.
     const [defaultFilters, setDefaultFilters] = useTemporarySetting('batches.defaultListFilters', [])
 
-    const [selectedFilters, setSelectedFiltersRaw] = useState<MultiSelectState<BatchChangeState>>([])
+    const [selectedFilters, setSelectedFiltersRaw] = useState<MultiSelectState<BatchChangeState>>(() => {
+        const searchParameters = new URLSearchParams(history.location.search).get('states')
+        if (searchParameters) {
+            return statesToFilters(searchParameters.split(','))
+        }
+        return []
+    })
+
     const [hasModifiedFilters, setHasModifiedFilters] = useState(false)
 
     const setSelectedFilters = useCallback(
@@ -36,19 +55,33 @@ export const useBatchChangeListFilters = (): UseBatchChangeListFiltersResult => 
             setHasModifiedFilters(true)
             setSelectedFiltersRaw(filters)
             setDefaultFilters(filters)
+
+            const searchParameters = new URLSearchParams(history.location.search)
+            if (filters.length > 0) {
+                searchParameters.set('states', filtersToStates(filters).join(',').toLowerCase())
+            } else {
+                searchParameters.delete('states')
+            }
+
+            if (history.location.search !== searchParameters.toString()) {
+                history.replace({ ...history.location, search: searchParameters.toString() })
+            }
         },
-        [setDefaultFilters]
+        [setDefaultFilters, history]
     )
 
+    // Once we've loaded the default filters from temporary settings, we will set them in
+    // state, but if the user has already modified the filters before then, or we read a
+    // different set of filters from the URL search params, those will take precedence.
     useEffect(() => {
-        if (defaultFilters && !hasModifiedFilters) {
+        const searchParameters = new URLSearchParams(history.location.search).get('states')
+
+        if (defaultFilters && !hasModifiedFilters && !searchParameters) {
             setSelectedFiltersRaw(defaultFilters)
         }
-    }, [defaultFilters, hasModifiedFilters])
+    }, [defaultFilters, hasModifiedFilters, history.location.search])
 
-    const selectedStates = useMemo<BatchChangeState[]>(() => selectedFilters.map(filter => filter.value), [
-        selectedFilters,
-    ])
+    const selectedStates = useMemo<BatchChangeState[]>(() => filtersToStates(selectedFilters), [selectedFilters])
 
     return {
         selectedFilters,

--- a/client/web/src/enterprise/batches/list/useBatchChangeListFilters.ts
+++ b/client/web/src/enterprise/batches/list/useBatchChangeListFilters.ts
@@ -1,0 +1,59 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+
+import { useTemporarySetting } from '@sourcegraph/shared/src/settings/temporary/useTemporarySetting'
+import { MultiSelectState } from '@sourcegraph/wildcard'
+
+import { BatchChangeState } from '../../../graphql-operations'
+
+interface UseBatchChangeListFiltersResult {
+    /** State representing the different filters selected in the `MultiSelect` UI. */
+    selectedFilters: MultiSelectState<BatchChangeState>
+    /** Method to set the filters selected in the `MultiSelect`. */
+    setSelectedFilters: (filters: MultiSelectState<BatchChangeState>) => void
+    /**
+     * Array of raw `BatchChangeState`s corresponding to `selectedFilters`, i.e. for
+     * passing in GraphQL connection query parameters.
+     */
+    selectedStates: BatchChangeState[]
+}
+
+/**
+ * Custom hook for managing, persisting, and transforming the state options selected from
+ * the `MultiSelect` UI to filter a list of batch changes.
+ */
+export const useBatchChangeListFilters = (): UseBatchChangeListFiltersResult => {
+    // NOTE: Fetching this setting is an async operation, so we can't use it as the
+    // initial value for `useState`. Instead, we will set the value of the filter state in
+    // a `useEffect` hook once we've loaded it, but only if the user has not changed the
+    // filter state in the meantime.
+    const [defaultFilters, setDefaultFilters] = useTemporarySetting('batches.defaultListFilters', [])
+
+    const [selectedFilters, setSelectedFiltersRaw] = useState<MultiSelectState<BatchChangeState>>([])
+    const [hasModifiedFilters, setHasModifiedFilters] = useState(false)
+
+    const setSelectedFilters = useCallback(
+        (filters: MultiSelectState<BatchChangeState>) => {
+            setHasModifiedFilters(true)
+            setSelectedFiltersRaw(filters)
+            setDefaultFilters(filters)
+        },
+        [setDefaultFilters]
+    )
+
+    useEffect(() => {
+        if (defaultFilters && !hasModifiedFilters) {
+            console.log('setting defaults', { defaultFilters })
+            setSelectedFiltersRaw(defaultFilters)
+        }
+    }, [defaultFilters, hasModifiedFilters])
+
+    const selectedStates = useMemo<BatchChangeState[]>(() => selectedFilters.map(filter => filter.value), [
+        selectedFilters,
+    ])
+
+    return {
+        selectedFilters,
+        setSelectedFilters,
+        selectedStates,
+    }
+}


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/32754.

Uses [Temporary Settings](https://docs.sourcegraph.com/dev/background-information/web/temporary_settings) to persist the last-selected set of state filters chosen in the `MultiSelect` for the batch changes list:

https://user-images.githubusercontent.com/8942601/158947087-d660c283-0dd3-4d1c-a008-bfe5f4f54f99.mov

In doing so, I packaged up all of the logic related to these filters into its own hook to reduce complexity inline with the BC list page component.

The persistent filters work for existing customers (without server-side execution enabled), as well. Of course, with only OPEN and CLOSED to choose from, the benefits are fewer for them.

## Test plan

Verified manually both with and without server-side execution enabled that filters a) default to ALL, b) retain expected filtering behavior, and c) persist last-selected options between visits.


