### PR TITLE
gitserver: add db connections which are needed for future instantiation of gitserver clients with db connections

### DIFF
--- a/cmd/frontend/backend/inventory.go
+++ b/cmd/frontend/backend/inventory.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/inventory"
 	"github.com/sourcegraph/sourcegraph/internal/rcache"
@@ -27,7 +28,7 @@ var inventoryCache = rcache.New(fmt.Sprintf("inv:v2:enhanced_%v", useEnhancedLan
 
 // InventoryContext returns the inventory context for computing the inventory for the repository at
 // the given commit.
-func InventoryContext(repo api.RepoName, commitID api.CommitID, forceEnhancedLanguageDetection bool) (inventory.Context, error) {
+func InventoryContext(repo api.RepoName, db database.DB, commitID api.CommitID, forceEnhancedLanguageDetection bool) (inventory.Context, error) {
 	if !git.IsAbsoluteRevision(string(commitID)) {
 		return inventory.Context{}, errors.Errorf("refusing to compute inventory for non-absolute commit ID %q", commitID)
 	}
@@ -43,10 +44,10 @@ func InventoryContext(repo api.RepoName, commitID api.CommitID, forceEnhancedLan
 		ReadTree: func(ctx context.Context, path string) ([]fs.FileInfo, error) {
 			// TODO: As a perf optimization, we could read multiple levels of the Git tree at once
 			// to avoid sequential tree traversal calls.
-			return git.ReadDir(ctx, authz.DefaultSubRepoPermsChecker, repo, commitID, path, false)
+			return git.ReadDir(ctx, db, authz.DefaultSubRepoPermsChecker, repo, commitID, path, false)
 		},
 		NewFileReader: func(ctx context.Context, path string) (io.ReadCloser, error) {
-			return git.NewFileReader(ctx, repo, commitID, path, authz.DefaultSubRepoPermsChecker)
+			return git.NewFileReader(ctx, db, repo, commitID, path, authz.DefaultSubRepoPermsChecker)
 		},
 		CacheGet: func(e fs.FileInfo) (inventory.Inventory, bool) {
 			cacheKey := cacheKey(e)

--- a/cmd/frontend/backend/repos_vcs.go
+++ b/cmd/frontend/backend/repos_vcs.go
@@ -29,7 +29,7 @@ func (s *repos) ResolveRev(ctx context.Context, repo *types.Repo, rev string) (c
 	ctx, done := trace(ctx, "Repos", "ResolveRev", map[string]interface{}{"repo": repo.Name, "rev": rev}, &err)
 	defer done()
 
-	return git.ResolveRevision(ctx, repo.Name, rev, git.ResolveRevisionOptions{})
+	return git.ResolveRevision(ctx, s.db, repo.Name, rev, git.ResolveRevisionOptions{})
 }
 
 func (s *repos) GetCommit(ctx context.Context, repo *types.Repo, commitID api.CommitID) (res *gitdomain.Commit, err error) {
@@ -46,5 +46,5 @@ func (s *repos) GetCommit(ctx context.Context, repo *types.Repo, commitID api.Co
 		return nil, errors.Errorf("non-absolute CommitID for Repos.GetCommit: %v", commitID)
 	}
 
-	return git.GetCommit(ctx, repo.Name, commitID, git.ResolveRevisionOptions{}, authz.DefaultSubRepoPermsChecker)
+	return git.GetCommit(ctx, s.db, repo.Name, commitID, git.ResolveRevisionOptions{}, authz.DefaultSubRepoPermsChecker)
 }

--- a/cmd/frontend/backend/repos_vcs_test.go
+++ b/cmd/frontend/backend/repos_vcs_test.go
@@ -39,7 +39,7 @@ func TestRepos_ResolveRev_noRevSpecified_getsDefaultBranch(t *testing.T) {
 	defer git.ResetMocks()
 
 	// (no rev/branch specified)
-	commitID, err := NewRepos(database.NewMockRepoStore()).ResolveRev(ctx, &types.Repo{Name: "a"}, "")
+	commitID, err := NewRepos(database.NewMockDB()).ResolveRev(ctx, &types.Repo{Name: "a"}, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -78,7 +78,7 @@ func TestRepos_ResolveRev_noCommitIDSpecified_resolvesRev(t *testing.T) {
 	}
 	defer git.ResetMocks()
 
-	commitID, err := NewRepos(database.NewMockRepoStore()).ResolveRev(ctx, &types.Repo{Name: "a"}, "b")
+	commitID, err := NewRepos(database.NewMockDB()).ResolveRev(ctx, &types.Repo{Name: "a"}, "b")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -117,7 +117,7 @@ func TestRepos_ResolveRev_commitIDSpecified_resolvesCommitID(t *testing.T) {
 	}
 	defer git.ResetMocks()
 
-	commitID, err := NewRepos(database.NewMockRepoStore()).ResolveRev(ctx, &types.Repo{Name: "a"}, strings.Repeat("a", 40))
+	commitID, err := NewRepos(database.NewMockDB()).ResolveRev(ctx, &types.Repo{Name: "a"}, strings.Repeat("a", 40))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -156,7 +156,7 @@ func TestRepos_ResolveRev_commitIDSpecified_failsToResolve(t *testing.T) {
 	}
 	defer git.ResetMocks()
 
-	_, err := NewRepos(database.NewMockRepoStore()).ResolveRev(ctx, &types.Repo{Name: "a"}, strings.Repeat("a", 40))
+	_, err := NewRepos(database.NewMockDB()).ResolveRev(ctx, &types.Repo{Name: "a"}, strings.Repeat("a", 40))
 	if !errors.Is(err, want) {
 		t.Fatalf("got err %v, want %v", err, want)
 	}
@@ -190,7 +190,7 @@ func TestRepos_GetCommit_repoupdaterError(t *testing.T) {
 	}
 	defer git.ResetMocks()
 
-	commit, err := NewRepos(database.NewMockRepoStore()).GetCommit(ctx, &types.Repo{Name: "a"}, want)
+	commit, err := NewRepos(database.NewMockDB()).GetCommit(ctx, &types.Repo{Name: "a"}, want)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/frontend/graphqlbackend/external_service_collaborators.go
+++ b/cmd/frontend/graphqlbackend/external_service_collaborators.go
@@ -63,7 +63,7 @@ func (r *externalServiceResolver) InvitableCollaborators(ctx context.Context) ([
 	if len(possibleRepos) == 0 {
 		// External service is describing "sync all repos" instead of a specific set. Query a few of
 		// those that we'll look for collaborators in.
-		repos, err := backend.NewRepos(r.db.Repos()).List(ctx, database.ReposListOptions{
+		repos, err := backend.NewRepos(r.db).List(ctx, database.ReposListOptions{
 			// SECURITY: This must be the authenticated user's external service ID.
 			ExternalServiceIDs: []int64{r.externalService.ID},
 			OrderBy: database.RepoListOrderBy{{

--- a/cmd/frontend/graphqlbackend/externallink/repository.go
+++ b/cmd/frontend/graphqlbackend/externallink/repository.go
@@ -43,7 +43,7 @@ func FileOrDir(ctx context.Context, db database.DB, repo *types.Repo, rev, path 
 	phabRepo, link, serviceType := linksForRepository(ctx, db, repo)
 	if phabRepo != nil {
 		// We need a branch name to construct the Phabricator URL.
-		branchName, _, err := git.GetDefaultBranchShort(ctx, repo.Name)
+		branchName, _, err := git.GetDefaultBranchShort(ctx, db, repo.Name)
 		if err == nil && branchName != "" {
 			links = append(links, NewResolver(
 				fmt.Sprintf("%s/source/%s/browse/%s/%s;%s", strings.TrimSuffix(phabRepo.URL, "/"), phabRepo.Callsign, url.PathEscape(branchName), path, rev),

--- a/cmd/frontend/graphqlbackend/git_blob.go
+++ b/cmd/frontend/graphqlbackend/git_blob.go
@@ -13,7 +13,7 @@ func (r *GitTreeEntryResolver) Blame(ctx context.Context,
 		StartLine int32
 		EndLine   int32
 	}) ([]*hunkResolver, error) {
-	hunks, err := git.BlameFile(ctx, r.commit.repoResolver.RepoName(), r.Path(), &git.BlameOptions{
+	hunks, err := git.BlameFile(ctx, r.db, r.commit.repoResolver.RepoName(), r.Path(), &git.BlameOptions{
 		NewestCommit: api.CommitID(r.commit.OID()),
 		StartLine:    int(args.StartLine),
 		EndLine:      int(args.EndLine),

--- a/cmd/frontend/graphqlbackend/git_commit.go
+++ b/cmd/frontend/graphqlbackend/git_commit.go
@@ -81,7 +81,7 @@ func (r *GitCommitResolver) resolveCommit(ctx context.Context) (*gitdomain.Commi
 		}
 
 		opts := git.ResolveRevisionOptions{}
-		r.commit, r.commitErr = git.GetCommit(ctx, r.gitRepo, api.CommitID(r.oid), opts, authz.DefaultSubRepoPermsChecker)
+		r.commit, r.commitErr = git.GetCommit(ctx, r.db, r.gitRepo, api.CommitID(r.oid), opts, authz.DefaultSubRepoPermsChecker)
 	})
 	return r.commit, r.commitErr
 }
@@ -211,7 +211,7 @@ func (r *GitCommitResolver) Tree(ctx context.Context, args *struct {
 	defer span.Finish()
 	span.SetTag("path", args.Path)
 
-	stat, err := git.Stat(ctx, authz.DefaultSubRepoPermsChecker, r.gitRepo, api.CommitID(r.oid), args.Path)
+	stat, err := git.Stat(ctx, r.db, authz.DefaultSubRepoPermsChecker, r.gitRepo, api.CommitID(r.oid), args.Path)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, nil
@@ -230,7 +230,7 @@ func (r *GitCommitResolver) Tree(ctx context.Context, args *struct {
 func (r *GitCommitResolver) Blob(ctx context.Context, args *struct {
 	Path string
 }) (*GitTreeEntryResolver, error) {
-	stat, err := git.Stat(ctx, authz.DefaultSubRepoPermsChecker, r.gitRepo, api.CommitID(r.oid), args.Path)
+	stat, err := git.Stat(ctx, r.db, authz.DefaultSubRepoPermsChecker, r.gitRepo, api.CommitID(r.oid), args.Path)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, nil
@@ -250,7 +250,7 @@ func (r *GitCommitResolver) File(ctx context.Context, args *struct {
 }
 
 func (r *GitCommitResolver) FileNames(ctx context.Context) ([]string, error) {
-	return git.LsFiles(ctx, authz.DefaultSubRepoPermsChecker, r.gitRepo, api.CommitID(r.oid))
+	return git.LsFiles(ctx, r.db, authz.DefaultSubRepoPermsChecker, r.gitRepo, api.CommitID(r.oid))
 }
 
 func (r *GitCommitResolver) Languages(ctx context.Context) ([]string, error) {
@@ -259,7 +259,7 @@ func (r *GitCommitResolver) Languages(ctx context.Context) ([]string, error) {
 		return nil, err
 	}
 
-	inventory, err := backend.NewRepos(r.db.Repos()).GetInventory(ctx, repo, api.CommitID(r.oid), false)
+	inventory, err := backend.NewRepos(r.db).GetInventory(ctx, repo, api.CommitID(r.oid), false)
 	if err != nil {
 		return nil, err
 	}
@@ -277,7 +277,7 @@ func (r *GitCommitResolver) LanguageStatistics(ctx context.Context) ([]*language
 		return nil, err
 	}
 
-	inventory, err := backend.NewRepos(r.db.Repos()).GetInventory(ctx, repo, api.CommitID(r.oid), false)
+	inventory, err := backend.NewRepos(r.db).GetInventory(ctx, repo, api.CommitID(r.oid), false)
 	if err != nil {
 		return nil, err
 	}
@@ -310,7 +310,7 @@ func (r *GitCommitResolver) Ancestors(ctx context.Context, args *struct {
 func (r *GitCommitResolver) BehindAhead(ctx context.Context, args *struct {
 	Revspec string
 }) (*behindAheadCountsResolver, error) {
-	counts, err := git.GetBehindAhead(ctx, r.gitRepo, args.Revspec, string(r.oid))
+	counts, err := git.GetBehindAhead(ctx, r.db, r.gitRepo, args.Revspec, string(r.oid))
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/graphqlbackend/git_commits.go
+++ b/cmd/frontend/graphqlbackend/git_commits.go
@@ -52,7 +52,7 @@ func (r *gitCommitConnectionResolver) compute(ctx context.Context) ([]*gitdomain
 		if r.after != nil {
 			after = *r.after
 		}
-		return git.Commits(ctx, r.repo.RepoName(), git.CommitsOptions{
+		return git.Commits(ctx, r.db, r.repo.RepoName(), git.CommitsOptions{
 			Range:        r.revisionRange,
 			N:            uint(n),
 			MessageQuery: query,

--- a/cmd/frontend/graphqlbackend/git_revision.go
+++ b/cmd/frontend/graphqlbackend/git_revision.go
@@ -16,7 +16,7 @@ type gitRevSpecExpr struct {
 func (r *gitRevSpecExpr) Expr() string { return r.expr }
 
 func (r *gitRevSpecExpr) Object(ctx context.Context) (*gitObject, error) {
-	oid, err := git.ResolveRevision(ctx, r.repo.RepoName(), r.expr, git.ResolveRevisionOptions{})
+	oid, err := git.ResolveRevision(ctx, r.repo.db, r.repo.RepoName(), r.expr, git.ResolveRevisionOptions{})
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/graphqlbackend/git_tree.go
+++ b/cmd/frontend/graphqlbackend/git_tree.go
@@ -45,6 +45,7 @@ func (r *GitTreeEntryResolver) entries(ctx context.Context, args *gitTreeEntryCo
 
 	entries, err := git.ReadDir(
 		ctx,
+		r.db,
 		authz.DefaultSubRepoPermsChecker,
 		r.commit.repoResolver.RepoName(),
 		api.CommitID(r.commit.OID()),

--- a/cmd/frontend/graphqlbackend/git_tree_entry.go
+++ b/cmd/frontend/graphqlbackend/git_tree_entry.go
@@ -82,6 +82,7 @@ func (r *GitTreeEntryResolver) Content(ctx context.Context) (string, error) {
 
 		r.content, r.contentErr = git.ReadFile(
 			ctx,
+			r.db,
 			r.commit.repoResolver.RepoName(),
 			api.CommitID(r.commit.OID()),
 			r.Path(),
@@ -222,6 +223,7 @@ func (r *GitTreeEntryResolver) IsSingleChild(ctx context.Context, args *gitTreeE
 	}
 	entries, err := git.ReadDir(
 		ctx,
+		r.db,
 		authz.DefaultSubRepoPermsChecker,
 		r.commit.repoResolver.RepoName(),
 		api.CommitID(r.commit.OID()),

--- a/cmd/frontend/graphqlbackend/graphqlbackend.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend.go
@@ -644,7 +644,7 @@ func (r *schemaResolver) RepositoryRedirect(ctx context.Context, args *repositor
 		return nil, errors.New("neither name nor cloneURL given")
 	}
 
-	repo, err := backend.NewRepos(r.db.Repos()).GetByName(ctx, name)
+	repo, err := backend.NewRepos(r.db).GetByName(ctx, name)
 	if err != nil {
 		var e backend.ErrRepoSeeOther
 		if errors.As(err, &e) {

--- a/cmd/frontend/graphqlbackend/repositories.go
+++ b/cmd/frontend/graphqlbackend/repositories.go
@@ -171,7 +171,7 @@ func (r *repositoryConnectionResolver) compute(ctx context.Context) ([]*types.Re
 			if opt2.LimitOffset != nil {
 				opt2.LimitOffset.Limit++
 			}
-			repos, err := backend.NewRepos(r.db.Repos()).List(ctx, opt2)
+			repos, err := backend.NewRepos(r.db).List(ctx, opt2)
 			if err != nil {
 				r.err = err
 				return

--- a/cmd/frontend/graphqlbackend/repository_contributors.go
+++ b/cmd/frontend/graphqlbackend/repository_contributors.go
@@ -52,7 +52,7 @@ func (r *repositoryContributorConnectionResolver) compute(ctx context.Context) (
 		if r.args.After != nil {
 			opt.After = *r.args.After
 		}
-		r.results, r.err = git.ShortLog(ctx, r.repo.RepoName(), opt)
+		r.results, r.err = git.ShortLog(ctx, r.db, r.repo.RepoName(), opt)
 	})
 	return r.results, r.err
 }

--- a/cmd/frontend/graphqlbackend/repository_mirror.go
+++ b/cmd/frontend/graphqlbackend/repository_mirror.go
@@ -221,7 +221,7 @@ func (r *schemaResolver) CheckMirrorRepositoryConnection(ctx context.Context, ar
 		if err != nil {
 			return nil, err
 		}
-		repo, err = backend.NewRepos(r.db.Repos()).Get(ctx, repoID)
+		repo, err = backend.NewRepos(r.db).Get(ctx, repoID)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/frontend/graphqlbackend/repository_stats.go
+++ b/cmd/frontend/graphqlbackend/repository_stats.go
@@ -22,11 +22,12 @@ func (r *repositoryStatsResolver) IndexedLinesCount() BigInt {
 
 func (r *schemaResolver) RepositoryStats(ctx context.Context) (*repositoryStatsResolver, error) {
 	// 🚨 SECURITY: Only site admins may query repository statistics for the site.
-	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
+	db := r.db
+	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, db); err != nil {
 		return nil, err
 	}
 
-	stats, err := usagestats.GetRepositories(ctx)
+	stats, err := usagestats.GetRepositories(ctx, db)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -252,7 +252,7 @@ func (sr *SearchResultsResolver) blameFileMatch(ctx context.Context, fm *result.
 		return time.Time{}, nil
 	}
 	lm := fm.LineMatches[0]
-	hunks, err := git.BlameFile(ctx, fm.Repo.Name, fm.Path, &git.BlameOptions{
+	hunks, err := git.BlameFile(ctx, sr.db, fm.Repo.Name, fm.Path, &git.BlameOptions{
 		NewestCommit: fm.CommitID,
 		StartLine:    int(lm.LineNumber),
 		EndLine:      int(lm.LineNumber),
@@ -595,7 +595,7 @@ func (r *searchResolver) Stats(ctx context.Context) (stats *searchResultsStats, 
 	for {
 		// Query search results.
 		var err error
-		j, err := job.ToSearchJob(args, r.SearchInputs.Query)
+		j, err := job.ToSearchJob(args, r.SearchInputs.Query, r.db)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/frontend/internal/app/editor.go
+++ b/cmd/frontend/internal/app/editor.go
@@ -26,7 +26,7 @@ func editorRev(ctx context.Context, db database.DB, repoName api.RepoName, rev s
 	if rev == "HEAD" {
 		return ""
 	}
-	repos := backend.NewRepos(db.Repos())
+	repos := backend.NewRepos(db)
 	repo, err := repos.GetByName(ctx, repoName)
 	if err != nil {
 		// We weren't able to fetch the repo. This means it either doesn't

--- a/cmd/frontend/internal/app/ui/handlers.go
+++ b/cmd/frontend/internal/app/ui/handlers.go
@@ -378,7 +378,7 @@ func redirectTreeOrBlob(routeName, path string, common *Common, w http.ResponseW
 		}
 		return false, nil
 	}
-	stat, err := git.Stat(r.Context(), authz.DefaultSubRepoPermsChecker, common.Repo.Name, common.CommitID, path)
+	stat, err := git.Stat(r.Context(), db, authz.DefaultSubRepoPermsChecker, common.Repo.Name, common.CommitID, path)
 	if err != nil {
 		if os.IsNotExist(err) {
 			serveError(w, r, db, err, http.StatusNotFound)

--- a/cmd/frontend/internal/app/ui/raw.go
+++ b/cmd/frontend/internal/app/ui/raw.go
@@ -182,7 +182,7 @@ func serveRaw(db database.DB) handlerFunc {
 			// caching locally is not useful. Additionally we transfer the output over the
 			// internet, so we use default compression levels on zips (instead of no
 			// compression).
-			f, err := git.ArchiveReaderWithSubRepo(r.Context(), authz.DefaultSubRepoPermsChecker, common.Repo,
+			f, err := git.ArchiveReaderWithSubRepo(r.Context(), db, authz.DefaultSubRepoPermsChecker, common.Repo,
 				gitserver.ArchiveOptions{Format: format, Treeish: string(common.CommitID), Paths: []string{relativePath}})
 			if err != nil {
 				return err
@@ -234,7 +234,7 @@ func serveRaw(db database.DB) handlerFunc {
 			w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 			w.Header().Set("X-Content-Type-Options", "nosniff")
 
-			fi, err := git.Stat(r.Context(), authz.DefaultSubRepoPermsChecker, common.Repo.Name, common.CommitID, requestedPath)
+			fi, err := git.Stat(r.Context(), db, authz.DefaultSubRepoPermsChecker, common.Repo.Name, common.CommitID, requestedPath)
 			if err != nil {
 				if os.IsNotExist(err) {
 					requestType = "404"
@@ -246,7 +246,7 @@ func serveRaw(db database.DB) handlerFunc {
 
 			if fi.IsDir() {
 				requestType = "dir"
-				infos, err := git.ReadDir(r.Context(), authz.DefaultSubRepoPermsChecker, common.Repo.Name, common.CommitID, requestedPath, false)
+				infos, err := git.ReadDir(r.Context(), db, authz.DefaultSubRepoPermsChecker, common.Repo.Name, common.CommitID, requestedPath, false)
 				if err != nil {
 					return err
 				}
@@ -269,7 +269,7 @@ func serveRaw(db database.DB) handlerFunc {
 			// File
 			requestType = "file"
 			size = fi.Size()
-			f, err := git.NewFileReader(r.Context(), common.Repo.Name, common.CommitID, requestedPath, authz.DefaultSubRepoPermsChecker)
+			f, err := git.NewFileReader(r.Context(), db, common.Repo.Name, common.CommitID, requestedPath, authz.DefaultSubRepoPermsChecker)
 			if err != nil {
 				return err
 			}

--- a/cmd/frontend/internal/app/ui/raw_test.go
+++ b/cmd/frontend/internal/app/ui/raw_test.go
@@ -23,7 +23,7 @@ import (
 // by httpStatusCode and a body as set by resp. It also ensures that the server is closed during
 // test cleanup, thus ensuring that the caller does not have to remember to close the server.
 //
-// Finally, initHTTPTestGitServer patches the gitserver.DefaultClient.Addrs to the URL of the test
+// Finally, initHTTPTestGitServer patches the gitserver.Client.Addrs to the URL of the test
 // HTTP server, so that API calls to the gitserver are received by the test HTTP server.
 //
 // TL;DR: This function helps us to mock the gitserver without having to define mock functions for
@@ -72,7 +72,7 @@ func Test_serveRawWithHTTPRequestMethodHEAD(t *testing.T) {
 	}()
 
 	t.Run("success response for HEAD request", func(t *testing.T) {
-		// httptest server will return a 200 OK, so gitserver.DefaultClient.RepoInfo will not return
+		// httptest server will return a 200 OK, so gitserver.Client.RepoInfo will not return
 		// an error.
 		initHTTPTestGitServer(t, http.StatusOK, "{}")
 
@@ -90,7 +90,7 @@ func Test_serveRawWithHTTPRequestMethodHEAD(t *testing.T) {
 	})
 
 	t.Run("failure response for HEAD request", func(t *testing.T) {
-		// httptest server will return a 404 Not Found, so gitserver.DefaultClient.RepoInfo will
+		// httptest server will return a 404 Not Found, so gitserver.Client.RepoInfo will
 		// return an error.
 		initHTTPTestGitServer(t, http.StatusNotFound, "{}")
 
@@ -124,7 +124,7 @@ func Test_serveRawWithContentArchive(t *testing.T) {
 	mockGitServerResponse := "this is a gitserver archive response"
 
 	t.Run("success response for format=zip", func(t *testing.T) {
-		// httptest server will return a 200 OK, so gitserver.DefaultClient.RepoInfo will not return an error.
+		// httptest server will return a 200 OK, so gitserver.Client.RepoInfo will not return an error.
 
 		initHTTPTestGitServer(t, http.StatusOK, mockGitServerResponse)
 
@@ -163,7 +163,7 @@ func Test_serveRawWithContentArchive(t *testing.T) {
 	})
 
 	t.Run("success response for format=tar", func(t *testing.T) {
-		// httptest server will return a 200 OK, so gitserver.DefaultClient.RepoInfo will not return an error.
+		// httptest server will return a 200 OK, so gitserver.Client.RepoInfo will not return an error.
 
 		initHTTPTestGitServer(t, http.StatusOK, mockGitServerResponse)
 
@@ -236,7 +236,7 @@ func Test_serveRawWithContentTypePlain(t *testing.T) {
 	}
 
 	t.Run("404 Not Found for non existent directory", func(t *testing.T) {
-		// httptest server will return a 200 OK, so gitserver.DefaultClient.RepoInfo will not return an error.
+		// httptest server will return a 200 OK, so gitserver.Client.RepoInfo will not return an error.
 		initHTTPTestGitServer(t, http.StatusOK, "{}")
 
 		git.Mocks.Stat = func(commit api.CommitID, name string) (fs.FileInfo, error) {
@@ -260,7 +260,7 @@ func Test_serveRawWithContentTypePlain(t *testing.T) {
 	})
 
 	t.Run("success response for existing directory", func(t *testing.T) {
-		// httptest server will return a 200 OK, so gitserver.DefaultClient.RepoInfo will not return an error.
+		// httptest server will return a 200 OK, so gitserver.Client.RepoInfo will not return an error.
 		initHTTPTestGitServer(t, http.StatusOK, "{}")
 
 		git.Mocks.Stat = func(commit api.CommitID, name string) (fs.FileInfo, error) {
@@ -301,7 +301,7 @@ c.go`
 	})
 
 	t.Run("success response for existing file", func(t *testing.T) {
-		// httptest server will return a 200 OK, so gitserver.DefaultClient.RepoInfo will not return an error.
+		// httptest server will return a 200 OK, so gitserver.Client.RepoInfo will not return an error.
 		initHTTPTestGitServer(t, http.StatusOK, "{}")
 
 		git.Mocks.Stat = func(commit api.CommitID, name string) (fs.FileInfo, error) {
@@ -338,7 +338,7 @@ c.go`
 
 	// Ensure that anything apart from tar/zip/text is still handled with a text/plain content type.
 	t.Run("success response for existing file with format=exe", func(t *testing.T) {
-		// httptest server will return a 200 OK, so gitserver.DefaultClient.RepoInfo will not return an error.
+		// httptest server will return a 200 OK, so gitserver.Client.RepoInfo will not return an error.
 		initHTTPTestGitServer(t, http.StatusOK, "{}")
 
 		git.Mocks.Stat = func(commit api.CommitID, name string) (fs.FileInfo, error) {

--- a/cmd/frontend/internal/app/updatecheck/client.go
+++ b/cmd/frontend/internal/app/updatecheck/client.go
@@ -176,10 +176,10 @@ func getAndMarshalHomepagePanelsJSON(ctx context.Context, db database.DB) (_ jso
 	return json.Marshal(homepagePanels)
 }
 
-func getAndMarshalRepositoriesJSON(ctx context.Context) (_ json.RawMessage, err error) {
+func getAndMarshalRepositoriesJSON(ctx context.Context, db database.DB) (_ json.RawMessage, err error) {
 	defer recordOperation("getAndMarshalRepositoriesJSON")(&err)
 
-	repos, err := usagestats.GetRepositories(ctx)
+	repos, err := usagestats.GetRepositories(ctx, db)
 	if err != nil {
 		return nil, err
 	}
@@ -480,7 +480,7 @@ func updateBody(ctx context.Context, db database.DB) (io.Reader, error) {
 			logFunc("telemetry: updatecheck.getAndMarshalSearchOnboardingJSON failed", "error", err)
 		}
 
-		r.Repositories, err = getAndMarshalRepositoriesJSON(ctx)
+		r.Repositories, err = getAndMarshalRepositoriesJSON(ctx, db)
 		if err != nil {
 			logFunc("telemetry: updatecheck.getAndMarshalRepositoriesJSON failed", "error", err)
 		}
@@ -563,7 +563,7 @@ func updateBody(ctx context.Context, db database.DB) (io.Reader, error) {
 
 		wg.Wait()
 	} else {
-		r.Repositories, err = getAndMarshalRepositoriesJSON(ctx)
+		r.Repositories, err = getAndMarshalRepositoriesJSON(ctx, db)
 		if err != nil {
 			logFunc("telemetry: updatecheck.getAndMarshalRepositoriesJSON failed", "error", err)
 		}

--- a/cmd/frontend/internal/handlerutil/repo.go
+++ b/cmd/frontend/internal/handlerutil/repo.go
@@ -19,7 +19,7 @@ import (
 func GetRepo(ctx context.Context, db database.DB, vars map[string]string) (*types.Repo, error) {
 	origRepo := routevar.ToRepo(vars)
 
-	repo, err := backend.NewRepos(db.Repos()).GetByName(ctx, origRepo)
+	repo, err := backend.NewRepos(db).GetByName(ctx, origRepo)
 	if err != nil {
 		return nil, err
 	}
@@ -34,11 +34,11 @@ func GetRepo(ctx context.Context, db database.DB, vars map[string]string) (*type
 // getRepoRev resolves the repository and commit specified in the route vars.
 func getRepoRev(ctx context.Context, db database.DB, vars map[string]string, repoID api.RepoID) (api.RepoID, api.CommitID, error) {
 	repoRev := routevar.ToRepoRev(vars)
-	repo, err := backend.NewRepos(db.Repos()).Get(ctx, repoID)
+	repo, err := backend.NewRepos(db).Get(ctx, repoID)
 	if err != nil {
 		return repoID, "", err
 	}
-	commitID, err := backend.NewRepos(db.Repos()).ResolveRev(ctx, repo, repoRev.Rev)
+	commitID, err := backend.NewRepos(db).ResolveRev(ctx, repo, repoRev.Rev)
 	if err != nil {
 		return repoID, "", err
 	}

--- a/cmd/frontend/internal/httpapi/httpapi.go
+++ b/cmd/frontend/internal/httpapi/httpapi.go
@@ -133,7 +133,8 @@ func NewInternalHandler(m *mux.Router, db database.DB, schema *graphql.Schema, n
 
 	// zoekt-indexserver endpoints
 	indexer := &searchIndexerServer{
-		ListIndexable: backend.NewRepos(db.Repos()).ListIndexable,
+		db:            db,
+		ListIndexable: backend.NewRepos(db).ListIndexable,
 		RepoStore:     database.Repos(db),
 		SearchContextsRepoRevs: func(ctx context.Context, repoIDs []api.RepoID) (map[api.RepoID][]string, error) {
 			return searchcontexts.RepoRevs(ctx, db, repoIDs)
@@ -155,8 +156,8 @@ func NewInternalHandler(m *mux.Router, db database.DB, schema *graphql.Schema, n
 	m.Get(apirouter.CanSendEmail).Handler(trace.Route(handler(serveCanSendEmail)))
 	m.Get(apirouter.SendEmail).Handler(trace.Route(handler(serveSendEmail)))
 	m.Get(apirouter.GitExec).Handler(trace.Route(handler(serveGitExec(db))))
-	m.Get(apirouter.GitResolveRevision).Handler(trace.Route(handler(serveGitResolveRevision)))
-	m.Get(apirouter.GitTar).Handler(trace.Route(handler(serveGitTar)))
+	m.Get(apirouter.GitResolveRevision).Handler(trace.Route(handler(serveGitResolveRevision(db))))
+	m.Get(apirouter.GitTar).Handler(trace.Route(handler(serveGitTar(db))))
 	gitService := &gitServiceHandler{
 		Gitserver: gitserver.DefaultClient,
 	}

--- a/cmd/frontend/internal/httpapi/internal.go
+++ b/cmd/frontend/internal/httpapi/internal.go
@@ -2,6 +2,7 @@ package httpapi
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -28,7 +29,7 @@ import (
 func serveReposGetByName(db database.DB) func(http.ResponseWriter, *http.Request) error {
 	return func(w http.ResponseWriter, r *http.Request) error {
 		repoName := api.RepoName(mux.Vars(r)["RepoName"])
-		repo, err := backend.NewRepos(db.Repos()).GetByName(r.Context(), repoName)
+		repo, err := backend.NewRepos(db).GetByName(r.Context(), repoName)
 		if err != nil {
 			return err
 		}
@@ -273,47 +274,52 @@ func serveSendEmail(w http.ResponseWriter, r *http.Request) error {
 	return txemail.Send(r.Context(), msg)
 }
 
-func serveGitResolveRevision(w http.ResponseWriter, r *http.Request) error {
-	// used by zoekt-sourcegraph-mirror
-	vars := mux.Vars(r)
-	name := api.RepoName(vars["RepoName"])
-	spec := vars["Spec"]
+func serveGitResolveRevision(db database.DB) func(w http.ResponseWriter, r *http.Request) error {
+	return func(w http.ResponseWriter, r *http.Request) error {
+		// used by zoekt-sourcegraph-mirror
+		vars := mux.Vars(r)
+		name := api.RepoName(vars["RepoName"])
+		spec := vars["Spec"]
 
-	// Do not to trigger a repo-updater lookup since this is a batch job.
-	commitID, err := git.ResolveRevision(r.Context(), name, spec, git.ResolveRevisionOptions{})
-	if err != nil {
-		return err
+		// Do not to trigger a repo-updater lookup since this is a batch job.
+		commitID, err := git.ResolveRevision(r.Context(), db, name, spec, git.ResolveRevisionOptions{})
+		if err != nil {
+			return err
+		}
+
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(commitID))
+		return nil
 	}
-
-	w.WriteHeader(http.StatusOK)
-	_, _ = w.Write([]byte(commitID))
-	return nil
 }
 
-func serveGitTar(w http.ResponseWriter, r *http.Request) error {
-	// used by zoekt-sourcegraph-mirror
-	vars := mux.Vars(r)
-	name := vars["RepoName"]
-	spec := vars["Commit"]
+func serveGitTar(db database.DB) func(w http.ResponseWriter, r *http.Request) error {
+	return func(w http.ResponseWriter, r *http.Request) error {
+		// used by zoekt-sourcegraph-mirror
+		vars := mux.Vars(r)
+		name := vars["RepoName"]
+		spec := vars["Commit"]
 
-	// Ensure commit exists. Do not want to trigger a repo-updater lookup since this is a batch job.
-	repo := api.RepoName(name)
-	commit, err := git.ResolveRevision(r.Context(), repo, spec, git.ResolveRevisionOptions{})
-	if err != nil {
-		return err
+		// Ensure commit exists. Do not want to trigger a repo-updater lookup since this is a batch job.
+		repo := api.RepoName(name)
+		ctx := r.Context()
+		commit, err := git.ResolveRevision(ctx, db, repo, spec, git.ResolveRevisionOptions{})
+		if err != nil {
+			return err
+		}
+
+		opts := gitserver.ArchiveOptions{
+			Treeish: string(commit),
+			Format:  "tar",
+		}
+
+		location := gitserver.DefaultClient.ArchiveURL(ctx, repo, opts)
+
+		w.Header().Set("Location", location.String())
+		w.WriteHeader(http.StatusFound)
+
+		return nil
 	}
-
-	opts := gitserver.ArchiveOptions{
-		Treeish: string(commit),
-		Format:  "tar",
-	}
-
-	location := gitserver.DefaultClient.ArchiveURL(repo, opts)
-
-	w.Header().Set("Location", location.String())
-	w.WriteHeader(http.StatusFound)
-
-	return nil
 }
 
 func serveGitExec(db database.DB) func(http.ResponseWriter, *http.Request) error {
@@ -331,7 +337,8 @@ func serveGitExec(db database.DB) func(http.ResponseWriter, *http.Request) error
 			return nil
 		}
 
-		repo, err := database.Repos(db).Get(r.Context(), api.RepoID(repoID))
+		ctx := r.Context()
+		repo, err := database.Repos(db).Get(ctx, api.RepoID(repoID))
 		if err != nil {
 			return err
 		}
@@ -345,7 +352,7 @@ func serveGitExec(db database.DB) func(http.ResponseWriter, *http.Request) error
 		}
 
 		// Find the correct shard to query
-		addr := gitserver.DefaultClient.AddrForRepo(repo.Name)
+		addr := gitserver.DefaultClient.AddrForRepo(ctx, repo.Name)
 
 		director := func(req *http.Request) {
 			req.URL.Scheme = "http"
@@ -364,7 +371,7 @@ func serveGitExec(db database.DB) func(http.ResponseWriter, *http.Request) error
 // gitserver for the repo.
 type gitServiceHandler struct {
 	Gitserver interface {
-		AddrForRepo(api.RepoName) string
+		AddrForRepo(context.Context, api.RepoName) string
 	}
 }
 
@@ -381,7 +388,7 @@ func (s *gitServiceHandler) redirectToGitServer(w http.ResponseWriter, r *http.R
 
 	u := &url.URL{
 		Scheme:   "http",
-		Host:     s.Gitserver.AddrForRepo(api.RepoName(repo)),
+		Host:     s.Gitserver.AddrForRepo(r.Context(), api.RepoName(repo)),
 		Path:     path.Join("/git", repo, gitPath),
 		RawQuery: r.URL.RawQuery,
 	}

--- a/cmd/frontend/internal/httpapi/internal_test.go
+++ b/cmd/frontend/internal/httpapi/internal_test.go
@@ -1,6 +1,7 @@
 package httpapi
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -48,6 +49,6 @@ func TestGitServiceHandlers(t *testing.T) {
 
 type mockAddrForRepo struct{}
 
-func (mockAddrForRepo) AddrForRepo(name api.RepoName) string {
+func (mockAddrForRepo) AddrForRepo(context context.Context, name api.RepoName) string {
 	return strings.ReplaceAll(string(name), "/", ".") + ".gitserver"
 }

--- a/cmd/frontend/internal/httpapi/search.go
+++ b/cmd/frontend/internal/httpapi/search.go
@@ -46,6 +46,7 @@ func repoRankFromConfig(siteConfig schema.SiteConfiguration, repoName string) fl
 // searchIndexerServer has handlers that zoekt-sourcegraph-indexserver
 // interacts with (search-indexer).
 type searchIndexerServer struct {
+	db database.DB
 	// ListIndexable returns the repositories to index.
 	ListIndexable func(context.Context) ([]types.MinimalRepo, error)
 
@@ -157,7 +158,7 @@ func (h *searchIndexerServer) serveConfiguration(w http.ResponseWriter, r *http.
 		getVersion := func(branch string) (string, error) {
 			metricGetVersion.Inc()
 			// Do not to trigger a repo-updater lookup since this is a batch job.
-			commitID, err := git.ResolveRevision(ctx, repo.Name, branch, git.ResolveRevisionOptions{
+			commitID, err := git.ResolveRevision(ctx, h.db, repo.Name, branch, git.ResolveRevisionOptions{
 				NoEnsureRevision: true,
 			})
 			if err != nil && errcode.HTTP(err) == http.StatusNotFound {

--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -189,7 +189,7 @@ func (h *streamHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 			eventMatch := fromMatch(match, repoMetadata)
 			if args.DecorationLimit == -1 || args.DecorationLimit > i {
-				eventMatch = withDecoration(ctx, eventMatch, match, args.DecorationKind, args.DecorationContextLines)
+				eventMatch = withDecoration(ctx, h.db, eventMatch, match, args.DecorationKind, args.DecorationContextLines)
 			}
 			_ = matchesBuf.Append(eventMatch)
 		}
@@ -391,7 +391,7 @@ func strPtr(s string) *string {
 }
 
 // withDecoration hydrates event match with decorated hunks for a corresponding file match.
-func withDecoration(ctx context.Context, eventMatch streamhttp.EventMatch, internalResult result.Match, kind string, contextLines int) streamhttp.EventMatch {
+func withDecoration(ctx context.Context, db database.DB, eventMatch streamhttp.EventMatch, internalResult result.Match, kind string, contextLines int) streamhttp.EventMatch {
 	// FIXME: Use contextLines to constrain hunks.
 	_ = contextLines
 	if _, ok := internalResult.(*result.FileMatch); !ok {
@@ -404,7 +404,7 @@ func withDecoration(ctx context.Context, eventMatch streamhttp.EventMatch, inter
 	}
 
 	if kind == "html" {
-		event.Hunks = DecorateFileHunksHTML(ctx, internalResult.(*result.FileMatch))
+		event.Hunks = DecorateFileHunksHTML(ctx, db, internalResult.(*result.FileMatch))
 	}
 
 	// TODO(team/search-product): support additional decoration for terminal clients #24617.

--- a/cmd/repo-updater/repoupdater/server_test.go
+++ b/cmd/repo-updater/repoupdater/server_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp/cmpopts"
+
 	"github.com/sourcegraph/sourcegraph/internal/conf/reposource"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/npm/npmpackages"
 
@@ -622,7 +623,7 @@ func TestServer_RepoLookup(t *testing.T) {
 				Sourcer: repos.NewFakeSourcer(nil, tc.src),
 			}
 
-			scheduler := repos.NewUpdateScheduler()
+			scheduler := repos.NewUpdateScheduler(database.NewMockDB())
 
 			s := &Server{
 				Syncer:    syncer,

--- a/cmd/repo-updater/shared/main.go
+++ b/cmd/repo-updater/shared/main.go
@@ -129,7 +129,7 @@ func Main(enterpriseInit EnterpriseInit) {
 		src = repos.NewSourcer(database.NewDB(db), cf, repos.WithDB(db), repos.ObservedSource(log15.Root(), m))
 	}
 
-	updateScheduler := repos.NewUpdateScheduler()
+	updateScheduler := repos.NewUpdateScheduler(db)
 	server := &repoupdater.Server{
 		Store:                 store,
 		Scheduler:             updateScheduler,

--- a/cmd/searcher/main.go
+++ b/cmd/searcher/main.go
@@ -21,11 +21,15 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	connections "github.com/sourcegraph/sourcegraph/internal/database/connections/live"
 	"github.com/sourcegraph/sourcegraph/internal/debugserver"
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
 	"github.com/sourcegraph/sourcegraph/internal/logging"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/profiler"
 	"github.com/sourcegraph/sourcegraph/internal/sentry"
 	"github.com/sourcegraph/sourcegraph/internal/store"
@@ -68,14 +72,24 @@ func main() {
 		cacheSizeBytes = i * 1000 * 1000
 	}
 
+	dsn := conf.GetServiceConnectionValueAndRestartOnChange(func(serviceConnections conftypes.ServiceConnections) string {
+		return serviceConnections.PostgresDSN
+	})
+	sqlDB, err := connections.EnsureNewFrontendDB(dsn, "searcher", &observation.TestContext)
+	if err != nil {
+		log.Fatalf("Failed to connect to frontend database: %s", err)
+	}
+	db := database.NewDB(sqlDB)
+
 	service := &search.Service{
 		Store: &store.Store{
-			FetchTar: func(ctx context.Context, repo api.RepoName, commit api.CommitID) (io.ReadCloser, error) {
-				return git.ArchiveReader(ctx, repo, gitserver.ArchiveOptions{Treeish: string(commit), Format: git.ArchiveFormatTar})
+			FetchTar: func(ctx context.Context, db database.DB, repo api.RepoName, commit api.CommitID) (io.ReadCloser, error) {
+				return git.ArchiveReader(ctx, db, repo, gitserver.ArchiveOptions{Treeish: string(commit), Format: git.ArchiveFormatTar})
 			},
 			FilterTar:         search.NewFilter,
 			Path:              filepath.Join(cacheDir, "searcher-archives"),
 			MaxCacheSizeBytes: cacheSizeBytes,
+			DB:                db,
 		},
 		Log: log15.Root(),
 	}

--- a/cmd/searcher/search/filter.go
+++ b/cmd/searcher/search/filter.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/zoekt/ignore"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/store"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 )
@@ -18,8 +19,8 @@ import (
 const maxFileSize = 2 << 20
 
 // NewFilter is a wrapper around newIgnoreMatcher.
-func NewFilter(ctx context.Context, repo api.RepoName, commit api.CommitID) (store.FilterFunc, error) {
-	ig, err := newIgnoreMatcher(ctx, repo, commit)
+func NewFilter(ctx context.Context, db database.DB, repo api.RepoName, commit api.CommitID) (store.FilterFunc, error) {
+	ig, err := newIgnoreMatcher(ctx, db, repo, commit)
 	if err != nil {
 		return nil, err
 	}
@@ -33,8 +34,8 @@ func NewFilter(ctx context.Context, repo api.RepoName, commit api.CommitID) (sto
 
 // newIgnoreMatcher calls gitserver to retrieve the ignore-file.
 // If the file doesn't exist we return an empty ignore.Matcher.
-func newIgnoreMatcher(ctx context.Context, repo api.RepoName, commit api.CommitID) (*ignore.Matcher, error) {
-	ignoreFile, err := git.ReadFile(ctx, repo, commit, ignore.IgnoreFile, 0, nil)
+func newIgnoreMatcher(ctx context.Context, db database.DB, repo api.RepoName, commit api.CommitID) (*ignore.Matcher, error) {
+	ignoreFile, err := git.ReadFile(ctx, db, repo, commit, ignore.IgnoreFile, 0, nil)
 	if err != nil {
 		if strings.Contains(err.Error(), "file does not exist") {
 			return &ignore.Matcher{}, nil

--- a/cmd/searcher/search/filter_test.go
+++ b/cmd/searcher/search/filter_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/google/zoekt/ignore"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
@@ -18,7 +19,7 @@ func TestNewIgnoreMatcher(t *testing.T) {
 	}
 	defer func() { git.Mocks.ReadFile = nil }()
 
-	ig, err := newIgnoreMatcher(context.Background(), "", "")
+	ig, err := newIgnoreMatcher(context.Background(), database.NewMockDB(), "", "")
 	if err != nil {
 		t.Error(err)
 	}
@@ -33,7 +34,7 @@ func TestMissingIgnoreFile(t *testing.T) {
 	}
 	defer func() { git.Mocks.ReadFile = nil }()
 
-	ig, err := newIgnoreMatcher(context.Background(), "", "")
+	ig, err := newIgnoreMatcher(context.Background(), database.NewMockDB(), "", "")
 	if err != nil {
 		t.Error(err)
 	}

--- a/cmd/searcher/search/search_regex_test.go
+++ b/cmd/searcher/search/search_regex_test.go
@@ -4,6 +4,7 @@ import (
 	"archive/zip"
 	"bytes"
 	"context"
+	"io"
 	"os"
 	"reflect"
 	"sort"
@@ -15,6 +16,8 @@ import (
 	"github.com/grafana/regexp/syntax"
 
 	"github.com/sourcegraph/sourcegraph/cmd/searcher/protocol"
+	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/pathmatch"
 	"github.com/sourcegraph/sourcegraph/internal/store"
 	storetest "github.com/sourcegraph/sourcegraph/internal/store/testutil"
@@ -391,8 +394,13 @@ func TestPathMatches(t *testing.T) {
 
 // githubStore fetches from github and caches across test runs.
 var githubStore = &store.Store{
-	FetchTar: testutil.FetchTarFromGithub,
+	FetchTar: FetchTarFromGithub,
 	Path:     "/tmp/search_test/store",
+}
+
+func FetchTarFromGithub(ctx context.Context, db database.DB, repo api.RepoName, commit api.CommitID) (io.ReadCloser, error) {
+	r, err := testutil.FetchTarFromGithubWithPaths(ctx, repo, commit, []string{})
+	return r, err
 }
 
 func init() {

--- a/cmd/searcher/search/search_test.go
+++ b/cmd/searcher/search/search_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/searcher/protocol"
 	"github.com/sourcegraph/sourcegraph/cmd/searcher/search"
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/search/searcher"
 	"github.com/sourcegraph/sourcegraph/internal/store"
 	"github.com/sourcegraph/sourcegraph/internal/testutil"
@@ -237,7 +238,7 @@ abc.txt
 	if err != nil {
 		t.Fatal(err)
 	}
-	s.FilterTar = func(_ context.Context, _ api.RepoName, _ api.CommitID) (store.FilterFunc, error) {
+	s.FilterTar = func(_ context.Context, _ database.DB, _ api.RepoName, _ api.CommitID) (store.FilterFunc, error) {
 		return func(hdr *tar.Header) bool {
 			return hdr.Name == "ignore.me"
 		}, nil
@@ -511,7 +512,7 @@ func newStore(files map[string]struct {
 		return nil, nil, err
 	}
 	return &store.Store{
-		FetchTar: func(ctx context.Context, repo api.RepoName, commit api.CommitID) (io.ReadCloser, error) {
+		FetchTar: func(ctx context.Context, _ database.DB, repo api.RepoName, commit api.CommitID) (io.ReadCloser, error) {
 			return io.NopCloser(bytes.NewReader(buf.Bytes())), nil
 		},
 		Path: d,

--- a/cmd/symbols/types/types.go
+++ b/cmd/symbols/types/types.go
@@ -3,7 +3,6 @@ package types
 import (
 	"context"
 	"os"
-
 	"runtime"
 	"strconv"
 	"time"

--- a/doc/admin/observability/alert_solutions.md
+++ b/doc/admin/observability/alert_solutions.md
@@ -3949,6 +3949,33 @@ with your code hosts connections or networking issues affecting communication wi
 
 <br />
 
+## searcher: mean_blocked_seconds_per_conn_request
+
+<p class="subtitle">mean blocked seconds per conn request</p>
+
+**Descriptions**
+
+- <span class="badge badge-warning">warning</span> searcher: 0.05s+ mean blocked seconds per conn request for 10m0s
+- <span class="badge badge-critical">critical</span> searcher: 0.1s+ mean blocked seconds per conn request for 15m0s
+
+**Possible solutions**
+
+- Increase SRC_PGSQL_MAX_OPEN together with giving more memory to the database if needed
+- Scale up Postgres memory / cpus [See our scaling guide](https://docs.sourcegraph.com/admin/config/postgres-conf)
+- Learn more about the related dashboard panel in the [dashboards reference](./dashboards.md#searcher-mean-blocked-seconds-per-conn-request).
+- **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
+
+```json
+"observability.silenceAlerts": [
+  "warning_searcher_mean_blocked_seconds_per_conn_request",
+  "critical_searcher_mean_blocked_seconds_per_conn_request"
+]
+```
+
+<sub>*Managed by the [Sourcegraph Devops team](https://handbook.sourcegraph.com/engineering/cloud/devops).*</sub>
+
+<br />
+
 ## searcher: frontend_internal_api_error_responses
 
 <p class="subtitle">frontend-internal API error responses every 5m by route</p>

--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -12106,6 +12106,160 @@ Query: `sum by(instance) (rate(searcher_service_request_total[10m]))`
 
 <br />
 
+### Searcher: Database connections
+
+#### searcher: max_open_conns
+
+<p class="subtitle">Maximum open</p>
+
+This panel has no related alerts.
+
+To see this panel, visit `/-/debug/grafana/d/searcher/searcher?viewPanel=100100` on your Sourcegraph instance.
+
+<sub>*Managed by the [Sourcegraph Devops team](https://handbook.sourcegraph.com/engineering/cloud/devops).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Query: `sum by (app_name, db_name) (src_pgsql_conns_max_open{app_name="searcher"})`
+
+</details>
+
+<br />
+
+#### searcher: open_conns
+
+<p class="subtitle">Established</p>
+
+This panel has no related alerts.
+
+To see this panel, visit `/-/debug/grafana/d/searcher/searcher?viewPanel=100101` on your Sourcegraph instance.
+
+<sub>*Managed by the [Sourcegraph Devops team](https://handbook.sourcegraph.com/engineering/cloud/devops).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Query: `sum by (app_name, db_name) (src_pgsql_conns_open{app_name="searcher"})`
+
+</details>
+
+<br />
+
+#### searcher: in_use
+
+<p class="subtitle">Used</p>
+
+This panel has no related alerts.
+
+To see this panel, visit `/-/debug/grafana/d/searcher/searcher?viewPanel=100110` on your Sourcegraph instance.
+
+<sub>*Managed by the [Sourcegraph Devops team](https://handbook.sourcegraph.com/engineering/cloud/devops).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Query: `sum by (app_name, db_name) (src_pgsql_conns_in_use{app_name="searcher"})`
+
+</details>
+
+<br />
+
+#### searcher: idle
+
+<p class="subtitle">Idle</p>
+
+This panel has no related alerts.
+
+To see this panel, visit `/-/debug/grafana/d/searcher/searcher?viewPanel=100111` on your Sourcegraph instance.
+
+<sub>*Managed by the [Sourcegraph Devops team](https://handbook.sourcegraph.com/engineering/cloud/devops).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Query: `sum by (app_name, db_name) (src_pgsql_conns_idle{app_name="searcher"})`
+
+</details>
+
+<br />
+
+#### searcher: mean_blocked_seconds_per_conn_request
+
+<p class="subtitle">Mean blocked seconds per conn request</p>
+
+Refer to the [alert solutions reference](./alert_solutions.md#searcher-mean-blocked-seconds-per-conn-request) for 2 alerts related to this panel.
+
+To see this panel, visit `/-/debug/grafana/d/searcher/searcher?viewPanel=100120` on your Sourcegraph instance.
+
+<sub>*Managed by the [Sourcegraph Devops team](https://handbook.sourcegraph.com/engineering/cloud/devops).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Query: `sum by (app_name, db_name) (increase(src_pgsql_conns_blocked_seconds{app_name="searcher"}[5m])) / sum by (app_name, db_name) (increase(src_pgsql_conns_waited_for{app_name="searcher"}[5m]))`
+
+</details>
+
+<br />
+
+#### searcher: closed_max_idle
+
+<p class="subtitle">Closed by SetMaxIdleConns</p>
+
+This panel has no related alerts.
+
+To see this panel, visit `/-/debug/grafana/d/searcher/searcher?viewPanel=100130` on your Sourcegraph instance.
+
+<sub>*Managed by the [Sourcegraph Devops team](https://handbook.sourcegraph.com/engineering/cloud/devops).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Query: `sum by (app_name, db_name) (increase(src_pgsql_conns_closed_max_idle{app_name="searcher"}[5m]))`
+
+</details>
+
+<br />
+
+#### searcher: closed_max_lifetime
+
+<p class="subtitle">Closed by SetConnMaxLifetime</p>
+
+This panel has no related alerts.
+
+To see this panel, visit `/-/debug/grafana/d/searcher/searcher?viewPanel=100131` on your Sourcegraph instance.
+
+<sub>*Managed by the [Sourcegraph Devops team](https://handbook.sourcegraph.com/engineering/cloud/devops).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Query: `sum by (app_name, db_name) (increase(src_pgsql_conns_closed_max_lifetime{app_name="searcher"}[5m]))`
+
+</details>
+
+<br />
+
+#### searcher: closed_max_idle_time
+
+<p class="subtitle">Closed by SetConnMaxIdleTime</p>
+
+This panel has no related alerts.
+
+To see this panel, visit `/-/debug/grafana/d/searcher/searcher?viewPanel=100132` on your Sourcegraph instance.
+
+<sub>*Managed by the [Sourcegraph Devops team](https://handbook.sourcegraph.com/engineering/cloud/devops).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Query: `sum by (app_name, db_name) (increase(src_pgsql_conns_closed_max_idle_time{app_name="searcher"}[5m]))`
+
+</details>
+
+<br />
+
 ### Searcher: Internal service requests
 
 #### searcher: frontend_internal_api_error_responses
@@ -12114,7 +12268,7 @@ Query: `sum by(instance) (rate(searcher_service_request_total[10m]))`
 
 Refer to the [alert solutions reference](./alert_solutions.md#searcher-frontend-internal-api-error-responses) for 1 alert related to this panel.
 
-To see this panel, visit `/-/debug/grafana/d/searcher/searcher?viewPanel=100100` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/searcher/searcher?viewPanel=100200` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Search-core team](https://handbook.sourcegraph.com/engineering/search/core).*</sub>
 
@@ -12145,7 +12299,7 @@ value change independent of deployment events (such as an upgrade), it could ind
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/searcher/searcher?viewPanel=100200` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/searcher/searcher?viewPanel=100300` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Search-core team](https://handbook.sourcegraph.com/engineering/search/core).*</sub>
 
@@ -12164,7 +12318,7 @@ Query: `count by(name) ((time() - container_last_seen{name=~"^searcher.*"}) > 60
 
 Refer to the [alert solutions reference](./alert_solutions.md#searcher-container-cpu-usage) for 1 alert related to this panel.
 
-To see this panel, visit `/-/debug/grafana/d/searcher/searcher?viewPanel=100201` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/searcher/searcher?viewPanel=100301` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Search-core team](https://handbook.sourcegraph.com/engineering/search/core).*</sub>
 
@@ -12183,7 +12337,7 @@ Query: `cadvisor_container_cpu_usage_percentage_total{name=~"^searcher.*"}`
 
 Refer to the [alert solutions reference](./alert_solutions.md#searcher-container-memory-usage) for 1 alert related to this panel.
 
-To see this panel, visit `/-/debug/grafana/d/searcher/searcher?viewPanel=100202` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/searcher/searcher?viewPanel=100302` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Search-core team](https://handbook.sourcegraph.com/engineering/search/core).*</sub>
 
@@ -12205,7 +12359,7 @@ When extremely high, this can indicate a resource usage problem, or can cause pr
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/searcher/searcher?viewPanel=100203` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/searcher/searcher?viewPanel=100303` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Search-core team](https://handbook.sourcegraph.com/engineering/search/core).*</sub>
 
@@ -12226,7 +12380,7 @@ Query: `sum by(name) (rate(container_fs_reads_total{name=~"^searcher.*"}[1h]) + 
 
 Refer to the [alert solutions reference](./alert_solutions.md#searcher-provisioning-container-cpu-usage-long-term) for 1 alert related to this panel.
 
-To see this panel, visit `/-/debug/grafana/d/searcher/searcher?viewPanel=100300` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/searcher/searcher?viewPanel=100400` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Search-core team](https://handbook.sourcegraph.com/engineering/search/core).*</sub>
 
@@ -12245,7 +12399,7 @@ Query: `quantile_over_time(0.9, cadvisor_container_cpu_usage_percentage_total{na
 
 Refer to the [alert solutions reference](./alert_solutions.md#searcher-provisioning-container-memory-usage-long-term) for 1 alert related to this panel.
 
-To see this panel, visit `/-/debug/grafana/d/searcher/searcher?viewPanel=100301` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/searcher/searcher?viewPanel=100401` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Search-core team](https://handbook.sourcegraph.com/engineering/search/core).*</sub>
 
@@ -12264,7 +12418,7 @@ Query: `max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^s
 
 Refer to the [alert solutions reference](./alert_solutions.md#searcher-provisioning-container-cpu-usage-short-term) for 1 alert related to this panel.
 
-To see this panel, visit `/-/debug/grafana/d/searcher/searcher?viewPanel=100310` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/searcher/searcher?viewPanel=100410` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Search-core team](https://handbook.sourcegraph.com/engineering/search/core).*</sub>
 
@@ -12283,7 +12437,7 @@ Query: `max_over_time(cadvisor_container_cpu_usage_percentage_total{name=~"^sear
 
 Refer to the [alert solutions reference](./alert_solutions.md#searcher-provisioning-container-memory-usage-short-term) for 1 alert related to this panel.
 
-To see this panel, visit `/-/debug/grafana/d/searcher/searcher?viewPanel=100311` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/searcher/searcher?viewPanel=100411` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Search-core team](https://handbook.sourcegraph.com/engineering/search/core).*</sub>
 
@@ -12306,7 +12460,7 @@ A high value here indicates a possible goroutine leak.
 
 Refer to the [alert solutions reference](./alert_solutions.md#searcher-go-goroutines) for 1 alert related to this panel.
 
-To see this panel, visit `/-/debug/grafana/d/searcher/searcher?viewPanel=100400` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/searcher/searcher?viewPanel=100500` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Search-core team](https://handbook.sourcegraph.com/engineering/search/core).*</sub>
 
@@ -12325,7 +12479,7 @@ Query: `max by(instance) (go_goroutines{job=~".*searcher"})`
 
 Refer to the [alert solutions reference](./alert_solutions.md#searcher-go-gc-duration-seconds) for 1 alert related to this panel.
 
-To see this panel, visit `/-/debug/grafana/d/searcher/searcher?viewPanel=100401` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/searcher/searcher?viewPanel=100501` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Search-core team](https://handbook.sourcegraph.com/engineering/search/core).*</sub>
 
@@ -12346,7 +12500,7 @@ Query: `max by(instance) (go_gc_duration_seconds{job=~".*searcher"})`
 
 Refer to the [alert solutions reference](./alert_solutions.md#searcher-pods-available-percentage) for 1 alert related to this panel.
 
-To see this panel, visit `/-/debug/grafana/d/searcher/searcher?viewPanel=100500` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/searcher/searcher?viewPanel=100600` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Search-core team](https://handbook.sourcegraph.com/engineering/search/core).*</sub>
 

--- a/enterprise/cmd/frontend/internal/authz/init.go
+++ b/enterprise/cmd/frontend/internal/authz/init.go
@@ -47,7 +47,7 @@ func Init(ctx context.Context, db database.DB, _ conftypes.UnifiedWatchable, ent
 	// Report any authz provider problems in external configs.
 	conf.ContributeWarning(func(cfg conftypes.SiteConfigQuerier) (problems conf.Problems) {
 		_, providers, seriousProblems, warnings :=
-			eiauthz.ProvidersFromConfig(ctx, cfg, extsvcStore)
+			eiauthz.ProvidersFromConfig(ctx, cfg, extsvcStore, db)
 		problems = append(problems, conf.NewExternalServiceProblems(seriousProblems...)...)
 
 		// Add connection validation issue
@@ -72,7 +72,7 @@ func Init(ctx context.Context, db database.DB, _ conftypes.UnifiedWatchable, ent
 		}
 
 		// We can ignore problems returned here because they would have been surfaced in other places.
-		_, providers, _, _ := eiauthz.ProvidersFromConfig(ctx, conf.Get(), extsvcStore)
+		_, providers, _, _ := eiauthz.ProvidersFromConfig(ctx, conf.Get(), extsvcStore, db)
 		if len(providers) == 0 {
 			return nil
 		}
@@ -182,7 +182,7 @@ func Init(ctx context.Context, db database.DB, _ conftypes.UnifiedWatchable, ent
 		t := time.NewTicker(5 * time.Second)
 		for range t.C {
 			allowAccessByDefault, authzProviders, _, _ :=
-				eiauthz.ProvidersFromConfig(ctx, conf.Get(), extsvcStore)
+				eiauthz.ProvidersFromConfig(ctx, conf.Get(), extsvcStore, db)
 			authz.SetProviders(allowAccessByDefault, authzProviders)
 		}
 	}()

--- a/enterprise/cmd/frontend/internal/codeintel/httpapi/upload_handler_state.go
+++ b/enterprise/cmd/frontend/internal/codeintel/httpapi/upload_handler_state.go
@@ -103,7 +103,7 @@ func ensureRepoAndCommitExist(ctx context.Context, db database.DB, repoName, com
 	//
 	// 1. Resolve repository
 
-	repo, err := backend.NewRepos(db.Repos()).GetByName(ctx, api.RepoName(repoName))
+	repo, err := backend.NewRepos(db).GetByName(ctx, api.RepoName(repoName))
 	if err != nil {
 		if errcode.IsNotFound(err) {
 			return 0, http.StatusNotFound, errors.Errorf("unknown repository %q", repoName)
@@ -115,7 +115,7 @@ func ensureRepoAndCommitExist(ctx context.Context, db database.DB, repoName, com
 	//
 	// 2. Resolve commit
 
-	if _, err := backend.NewRepos(db.Repos()).ResolveRev(ctx, repo, commit); err != nil {
+	if _, err := backend.NewRepos(db).ResolveRev(ctx, repo, commit); err != nil {
 		var reason string
 		if errors.HasType(err, &gitdomain.RevisionNotFoundError{}) {
 			reason = "commit not found"

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/configuration_policy.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/configuration_policy.go
@@ -49,7 +49,7 @@ func (r *configurationPolicyResolver) Repository(ctx context.Context) (_ *gql.Re
 		log.Int("repoID", *r.configurationPolicy.RepositoryID),
 	)
 
-	repo, err := backend.NewRepos(r.db.Repos()).Get(ctx, api.RepoID(*r.configurationPolicy.RepositoryID))
+	repo, err := backend.NewRepos(r.db).Get(ctx, api.RepoID(*r.configurationPolicy.RepositoryID))
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/locations.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/locations.go
@@ -201,7 +201,7 @@ func (r *CachedLocationResolver) cachedPath(ctx context.Context, id api.RepoID, 
 // repo that has since been deleted. This method must be called only when constructing a resolver to
 // populate the cache.
 func (r *CachedLocationResolver) resolveRepository(ctx context.Context, id api.RepoID) (*gql.RepositoryResolver, error) {
-	repo, err := backend.NewRepos(r.db.Repos()).Get(ctx, id)
+	repo, err := backend.NewRepos(r.db).Get(ctx, id)
 	if err != nil {
 		if errcode.IsNotFound(err) {
 			return nil, nil
@@ -221,7 +221,7 @@ func (r *CachedLocationResolver) resolveCommit(ctx context.Context, repositoryRe
 		return nil, err
 	}
 
-	commitID, err := git.ResolveRevision(ctx, repo.Name, commit, git.ResolveRevisionOptions{NoEnsureRevision: true})
+	commitID, err := git.ResolveRevision(ctx, r.db, repo.Name, commit, git.ResolveRevisionOptions{NoEnsureRevision: true})
 	if err != nil {
 		if errors.HasType(err, &gitdomain.RevisionNotFoundError{}) {
 			return nil, nil

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/resolver.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/resolver.go
@@ -561,7 +561,7 @@ func (r *Resolver) PreviewRepositoryFilter(ctx context.Context, args *gql.Previe
 
 	resolvers := make([]*gql.RepositoryResolver, 0, len(ids))
 	for _, id := range ids {
-		repo, err := backend.NewRepos(r.db.Repos()).Get(ctx, api.RepoID(id))
+		repo, err := backend.NewRepos(r.db).Get(ctx, api.RepoID(id))
 		if err != nil {
 			return nil, err
 		}

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/position.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/position.go
@@ -6,9 +6,9 @@ import (
 	"strings"
 
 	"github.com/sourcegraph/go-diff/diff"
-
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/lsifstore"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 )
@@ -35,6 +35,7 @@ type PositionAdjuster interface {
 }
 
 type positionAdjuster struct {
+	db        database.DB
 	repo      *types.Repo
 	commit    string
 	hunkCache HunkCache
@@ -122,7 +123,7 @@ func (p *positionAdjuster) readHunksCached(ctx context.Context, repo *types.Repo
 // readHunks returns a position-ordered slice of changes (additions or deletions) of
 // the given path between the given source and target commits.
 func (p *positionAdjuster) readHunks(ctx context.Context, repo *types.Repo, sourceCommit, targetCommit, path string) ([]*diff.Hunk, error) {
-	return git.DiffPath(ctx, repo.Name, sourceCommit, targetCommit, path, authz.DefaultSubRepoPermsChecker)
+	return git.DiffPath(ctx, p.db, repo.Name, sourceCommit, targetCommit, path, authz.DefaultSubRepoPermsChecker)
 }
 
 // adjustPosition translates the given position by adjusting the line number based on the

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/query.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/query.go
@@ -6,6 +6,7 @@ import (
 	store "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/dbstore"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/lsifstore"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/lib/codeintel/precise"
 )
 
@@ -71,6 +72,7 @@ type Documentation struct {
 }
 
 type queryResolver struct {
+	db                  database.DB
 	dbStore             DBStore
 	lsifStore           LSIFStore
 	cachedCommitChecker *cachedCommitChecker
@@ -88,6 +90,7 @@ type queryResolver struct {
 // struct return queries for the given repository, commit, and path, and will query only the
 // bundles associated with the given dump objects.
 func NewQueryResolver(
+	db database.DB,
 	dbStore DBStore,
 	lsifStore LSIFStore,
 	cachedCommitChecker *cachedCommitChecker,
@@ -99,11 +102,12 @@ func NewQueryResolver(
 	operations *operations,
 	checker authz.SubRepoPermissionChecker,
 ) QueryResolver {
-	return newQueryResolver(dbStore, lsifStore, cachedCommitChecker, positionAdjuster,
+	return newQueryResolver(db, dbStore, lsifStore, cachedCommitChecker, positionAdjuster,
 		repositoryID, commit, path, uploads, operations, checker)
 }
 
 func newQueryResolver(
+	db database.DB,
 	dbStore DBStore,
 	lsifStore LSIFStore,
 	cachedCommitChecker *cachedCommitChecker,
@@ -125,6 +129,7 @@ func newQueryResolver(
 	}
 
 	return &queryResolver{
+		db:                  db,
 		dbStore:             dbStore,
 		lsifStore:           lsifStore,
 		cachedCommitChecker: cachedCommitChecker,

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/query_definitions_test.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/query_definitions_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/lsifstore"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/lib/codeintel/precise"
 )
@@ -37,6 +38,7 @@ func TestDefinitions(t *testing.T) {
 		{ID: 53, Commit: "deadbeef", Root: "sub4/"},
 	}
 	resolver := newQueryResolver(
+		database.NewMockDB(),
 		mockDBStore,
 		mockLSIFStore,
 		newCachedCommitChecker(mockGitserverClient),
@@ -103,6 +105,7 @@ func TestDefinitionsWithSubRepoPermissions(t *testing.T) {
 	})
 
 	resolver := newQueryResolver(
+		database.NewMockDB(),
 		mockDBStore,
 		mockLSIFStore,
 		newCachedCommitChecker(mockGitserverClient),
@@ -181,6 +184,7 @@ func TestDefinitionsRemote(t *testing.T) {
 		{ID: 53, Commit: "deadbeef", Root: "sub4/"},
 	}
 	resolver := newQueryResolver(
+		database.NewMockDB(),
 		mockDBStore,
 		mockLSIFStore,
 		newCachedCommitChecker(mockGitserverClient),
@@ -303,6 +307,7 @@ func TestDefinitionsRemoteWithSubRepoPermissions(t *testing.T) {
 	})
 
 	resolver := newQueryResolver(
+		database.NewMockDB(),
 		mockDBStore,
 		mockLSIFStore,
 		newCachedCommitChecker(mockGitserverClient),

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/query_diagnostics_test.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/query_diagnostics_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/lsifstore"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/lib/codeintel/precise"
 )
@@ -39,6 +40,7 @@ func TestDiagnostics(t *testing.T) {
 		{ID: 53, Commit: "deadbeef", Root: "sub4/"},
 	}
 	resolver := newQueryResolver(
+		database.NewMockDB(),
 		mockDBStore,
 		mockLSIFStore,
 		newCachedCommitChecker(mockGitserverClient),
@@ -119,6 +121,7 @@ func TestDiagnosticsWithSubRepoPermissions(t *testing.T) {
 	})
 
 	resolver := newQueryResolver(
+		database.NewMockDB(),
 		mockDBStore,
 		mockLSIFStore,
 		newCachedCommitChecker(mockGitserverClient),

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/query_hover_test.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/query_hover_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/dbstore"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/lsifstore"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/lib/codeintel/precise"
 )
@@ -33,6 +34,7 @@ func TestHover(t *testing.T) {
 		{ID: 53, Commit: "deadbeef", Root: "sub4/"},
 	}
 	resolver := newQueryResolver(
+		database.NewMockDB(),
 		mockDBStore,
 		mockLSIFStore,
 		newCachedCommitChecker(mockGitserverClient),
@@ -116,6 +118,7 @@ func TestHoverRemote(t *testing.T) {
 		{ID: 50, Commit: "deadbeef"},
 	}
 	resolver := newQueryResolver(
+		database.NewMockDB(),
 		mockDBStore,
 		mockLSIFStore,
 		newCachedCommitChecker(mockGitserverClient),

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/query_implementations_test.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/query_implementations_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/shared"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/lib/codeintel/bloomfilter"
 	"github.com/sourcegraph/sourcegraph/lib/codeintel/precise"
@@ -43,6 +44,7 @@ func TestImplementations(t *testing.T) {
 		{ID: 53, Commit: "deadbeef", Root: "sub4/"},
 	}
 	resolver := newQueryResolver(
+		database.NewMockDB(),
 		mockDBStore,
 		mockLSIFStore,
 		newCachedCommitChecker(mockGitserverClient),
@@ -113,6 +115,7 @@ func TestImplementationsWithSubRepoPermissions(t *testing.T) {
 	})
 
 	resolver := newQueryResolver(
+		database.NewMockDB(),
 		mockDBStore,
 		mockLSIFStore,
 		newCachedCommitChecker(mockGitserverClient),
@@ -230,6 +233,7 @@ func TestImplementationsRemote(t *testing.T) {
 		{ID: 53, Commit: "deadbeef", Root: "sub4/"},
 	}
 	resolver := newQueryResolver(
+		database.NewMockDB(),
 		mockDBStore,
 		mockLSIFStore,
 		newCachedCommitChecker(mockGitserverClient),
@@ -405,6 +409,7 @@ func TestImplementationsRemoteWithSubRepoPermissions(t *testing.T) {
 	})
 
 	resolver := newQueryResolver(
+		database.NewMockDB(),
 		mockDBStore,
 		mockLSIFStore,
 		newCachedCommitChecker(mockGitserverClient),

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/query_ranges_test.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/query_ranges_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/dbstore"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/lsifstore"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 )
 
@@ -46,6 +47,7 @@ func TestRanges(t *testing.T) {
 		{ID: 53, Commit: "deadbeef", Root: "sub4/"},
 	}
 	resolver := newQueryResolver(
+		database.NewMockDB(),
 		mockDBStore,
 		mockLSIFStore,
 		newCachedCommitChecker(mockGitserverClient),

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/query_references_test.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/query_references_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/shared"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/lib/codeintel/bloomfilter"
 	"github.com/sourcegraph/sourcegraph/lib/codeintel/precise"
@@ -43,6 +44,7 @@ func TestReferences(t *testing.T) {
 		{ID: 53, Commit: "deadbeef", Root: "sub4/"},
 	}
 	resolver := newQueryResolver(
+		database.NewMockDB(),
 		mockDBStore,
 		mockLSIFStore,
 		newCachedCommitChecker(mockGitserverClient),
@@ -113,6 +115,7 @@ func TestReferencesWithSubRepoPermissions(t *testing.T) {
 	})
 
 	resolver := newQueryResolver(
+		database.NewMockDB(),
 		mockDBStore,
 		mockLSIFStore,
 		newCachedCommitChecker(mockGitserverClient),
@@ -234,6 +237,7 @@ func TestReferencesRemote(t *testing.T) {
 		{ID: 53, Commit: "deadbeef", Root: "sub4/"},
 	}
 	resolver := newQueryResolver(
+		database.NewMockDB(),
 		mockDBStore,
 		mockLSIFStore,
 		newCachedCommitChecker(mockGitserverClient),
@@ -420,6 +424,7 @@ func TestReferencesRemoteWithSubRepoPermissions(t *testing.T) {
 	})
 
 	resolver := newQueryResolver(
+		database.NewMockDB(),
 		mockDBStore,
 		mockLSIFStore,
 		newCachedCommitChecker(mockGitserverClient),
@@ -497,6 +502,7 @@ func TestIgnoredIDs(t *testing.T) {
 	mockDBStore := NewMockDBStore()
 
 	resolver := newQueryResolver(
+		database.NewMockDB(),
 		mockDBStore,
 		NewMockLSIFStore(),
 		newCachedCommitChecker(NewMockGitserverClient()),

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/query_stencil_test.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/query_stencil_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/dbstore"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/lsifstore"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 )
 
@@ -40,6 +41,7 @@ func TestStencil(t *testing.T) {
 		{ID: 53, Commit: "deadbeef", Root: "sub4/"},
 	}
 	resolver := newQueryResolver(
+		database.NewMockDB(),
 		mockDBStore,
 		mockLSIFStore,
 		newCachedCommitChecker(mockGitserverClient),

--- a/enterprise/cmd/frontend/internal/codeintel/services.go
+++ b/enterprise/cmd/frontend/internal/codeintel/services.go
@@ -84,7 +84,7 @@ func NewServices(ctx context.Context, config *Config, siteConfig conftypes.Watch
 	externalUploadHandler := newUploadHandler(false)
 
 	// Initialize gitserver client
-	gitserverClient := gitserver.New(dbStore, observationContext)
+	gitserverClient := gitserver.New(db, dbStore, observationContext)
 	repoUpdaterClient := repoupdater.New(observationContext)
 
 	// Initialize the index enqueuer

--- a/enterprise/cmd/frontend/internal/compute/resolvers/resolvers.go
+++ b/enterprise/cmd/frontend/internal/compute/resolvers/resolvers.go
@@ -198,7 +198,7 @@ func toResultResolverList(ctx context.Context, cmd compute.Command, matches []re
 
 	results := make([]gql.ComputeResultResolver, 0, len(matches))
 	for _, m := range matches {
-		computeResult, err := cmd.Run(ctx, m)
+		computeResult, err := cmd.Run(ctx, db, m)
 		if err != nil {
 			return nil, err
 		}

--- a/enterprise/cmd/frontend/internal/compute/streaming/compute.go
+++ b/enterprise/cmd/frontend/internal/compute/streaming/compute.go
@@ -13,9 +13,9 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
 )
 
-func toComputeResultStream(ctx context.Context, cmd compute.Command, matches []result.Match, f func(compute.Result)) error {
+func toComputeResultStream(ctx context.Context, db database.DB, cmd compute.Command, matches []result.Match, f func(compute.Result)) error {
 	for _, m := range matches {
-		result, err := cmd.Run(ctx, m)
+		result, err := cmd.Run(ctx, db, m)
 		if err != nil {
 			return err
 		}
@@ -41,7 +41,7 @@ func NewComputeStream(ctx context.Context, db database.DB, query string) (<-chan
 			callback := func(result compute.Result) {
 				eventsC <- Event{Results: []compute.Result{result}}
 			}
-			_ = toComputeResultStream(ctx, computeQuery.Command, event.Results, callback)
+			_ = toComputeResultStream(ctx, db, computeQuery.Command, event.Results, callback)
 			// TODO(rvantonder): compute err is currently ignored. Process it and send alerts/errors as needed.
 		}
 	})

--- a/enterprise/cmd/precise-code-intel-worker/internal/worker/handler.go
+++ b/enterprise/cmd/precise-code-intel-worker/internal/worker/handler.go
@@ -101,7 +101,7 @@ func (h *handler) getSize(record workerutil.Record) int64 {
 // upload record was requeued and false otherwise.
 func (h *handler) handle(ctx context.Context, upload store.Upload, trace observation.TraceLogger) (requeued bool, err error) {
 	db := database.NewDBWith(h.workerStore)
-	repo, err := backend.NewRepos(db.Repos()).Get(ctx, api.RepoID(upload.RepositoryID))
+	repo, err := backend.NewRepos(db).Get(ctx, api.RepoID(upload.RepositoryID))
 	if err != nil {
 		return false, errors.Wrap(err, "Repos.Get")
 	}
@@ -237,7 +237,7 @@ const requeueDelay = time.Minute
 // valued flag. Otherwise, the repo does not exist or there is an unexpected infrastructure error, which we'll
 // fail on.
 func requeueIfCloningOrCommitUnknown(ctx context.Context, db database.DB, workerStore dbworkerstore.Store, upload store.Upload, repo *types.Repo) (requeued bool, _ error) {
-	_, err := backend.NewRepos(db.Repos()).ResolveRev(ctx, repo, upload.Commit)
+	_, err := backend.NewRepos(db).ResolveRev(ctx, repo, upload.Commit)
 	if err == nil {
 		// commit is resolvable
 		return false, nil

--- a/enterprise/cmd/precise-code-intel-worker/main.go
+++ b/enterprise/cmd/precise-code-intel-worker/main.go
@@ -94,7 +94,7 @@ func main() {
 	dbStore := dbstore.NewWithDB(db, observationContext)
 	workerStore := dbstore.WorkerutilUploadStore(dbStore, makeObservationContext(observationContext, false))
 	lsifStore := lsifstore.NewStore(codeIntelDB, conf.Get(), observationContext)
-	gitserverClient := gitserver.New(dbStore, observationContext)
+	gitserverClient := gitserver.New(database.NewDB(db), dbStore, observationContext)
 
 	uploadStore, err := lsifuploadstore.New(context.Background(), config.LSIFUploadStoreConfig, observationContext)
 	if err != nil {
@@ -152,7 +152,7 @@ func mustInitializeDB() *sql.DB {
 	ctx := context.Background()
 	go func() {
 		for range time.NewTicker(eiauthz.RefreshInterval()).C {
-			allowAccessByDefault, authzProviders, _, _ := eiauthz.ProvidersFromConfig(ctx, conf.Get(), database.ExternalServices(sqlDB))
+			allowAccessByDefault, authzProviders, _, _ := eiauthz.ProvidersFromConfig(ctx, conf.Get(), database.ExternalServices(sqlDB), database.NewDB(sqlDB))
 			authz.SetProviders(allowAccessByDefault, authzProviders)
 		}
 	}()

--- a/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
+++ b/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
@@ -470,7 +470,7 @@ func (s *PermsSyncer) fetchUserPermsViaExternalServices(ctx context.Context, use
 
 	var repoSpecs, includeContainsSpecs, excludeContainsSpecs []api.ExternalRepoSpec
 	for _, svc := range svcs {
-		provider, err := eauthz.ProviderFromExternalService(s.db.ExternalServices(), conf.Get().SiteConfiguration, svc)
+		provider, err := eauthz.ProviderFromExternalService(s.db.ExternalServices(), conf.Get().SiteConfiguration, svc, s.db)
 		if err != nil {
 			return nil, errors.Wrapf(err, "new provider from external service %d", svc.ID)
 		}

--- a/enterprise/cmd/repo-updater/main.go
+++ b/enterprise/cmd/repo-updater/main.go
@@ -77,6 +77,7 @@ func startBackgroundPermsSync(ctx context.Context, syncer *authz.PermsSyncer, db
 					ctx,
 					conf.Get(),
 					ossDB.ExternalServices(db),
+					db,
 				)
 			ossAuthz.SetProviders(allowAccessByDefault, authzProviders)
 		}

--- a/enterprise/cmd/symbols/main.go
+++ b/enterprise/cmd/symbols/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	connections "github.com/sourcegraph/sourcegraph/internal/database/connections/live"
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
@@ -170,12 +171,12 @@ func NewGitserver(repositoryFetcher fetcher.RepositoryFetcher) Gitserver {
 	return Gitserver{repositoryFetcher: repositoryFetcher}
 }
 
-func (g Gitserver) LogReverseEach(repo string, commit string, n int, onLogEntry func(entry git.LogEntry) error) error {
+func (g Gitserver) LogReverseEach(repo string, db database.DB, commit string, n int, onLogEntry func(entry git.LogEntry) error) error {
 	return git.LogReverseEach(repo, commit, n, onLogEntry)
 }
 
-func (g Gitserver) RevListEach(repo string, commit string, onCommit func(commit string) (shouldContinue bool, err error)) error {
-	return git.RevList(repo, commit, onCommit)
+func (g Gitserver) RevListEach(repo string, db database.DB, commit string, onCommit func(commit string) (shouldContinue bool, err error)) error {
+	return git.RevList(repo, db, commit, onCommit)
 }
 
 func (g Gitserver) ArchiveEach(repo string, commit string, paths []string, onFile func(path string, contents []byte) error) error {

--- a/enterprise/cmd/worker/internal/codeintel/clients.go
+++ b/enterprise/cmd/worker/internal/codeintel/clients.go
@@ -8,6 +8,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/worker/memo"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/gitserver"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/repoupdater"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 )
@@ -34,7 +35,7 @@ var initGitserverClient = memo.NewMemoizedConstructor(func() (interface{}, error
 		return nil, err
 	}
 
-	return gitserver.New(dbStore, observationContext), nil
+	return gitserver.New(database.NewDBWith(dbStore), dbStore, observationContext), nil
 })
 
 func InitRepoUpdaterClient() *repoupdater.Client {

--- a/enterprise/cmd/worker/internal/codeintel/janitor/unknown_commits.go
+++ b/enterprise/cmd/worker/internal/codeintel/janitor/unknown_commits.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/dbstore"
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
@@ -110,7 +111,7 @@ func (j *unknownCommitJanitor) handleSourcedCommits(ctx context.Context, tx DBSt
 
 func (j *unknownCommitJanitor) handleCommit(ctx context.Context, tx DBStore, repositoryID int, repositoryName, commit string) error {
 	var shouldDelete bool
-	_, err := git.ResolveRevision(ctx, api.RepoName(repositoryName), commit, git.ResolveRevisionOptions{})
+	_, err := git.ResolveRevision(ctx, database.NewDBWith(tx), api.RepoName(repositoryName), commit, git.ResolveRevisionOptions{})
 	if err == nil {
 		// If we have no error then the commit is resolvable and we shouldn't touch it.
 		shouldDelete = false

--- a/enterprise/cmd/worker/main.go
+++ b/enterprise/cmd/worker/main.go
@@ -67,7 +67,7 @@ func setAuthzProviders() {
 	ctx := context.Background()
 
 	for range time.NewTicker(eiauthz.RefreshInterval()).C {
-		allowAccessByDefault, authzProviders, _, _ := eiauthz.ProvidersFromConfig(ctx, conf.Get(), database.ExternalServices(db))
+		allowAccessByDefault, authzProviders, _, _ := eiauthz.ProvidersFromConfig(ctx, conf.Get(), database.ExternalServices(db), database.NewDB(db))
 		authz.SetProviders(allowAccessByDefault, authzProviders)
 	}
 }

--- a/enterprise/internal/authz/authz.go
+++ b/enterprise/internal/authz/authz.go
@@ -37,6 +37,7 @@ func ProvidersFromConfig(
 	ctx context.Context,
 	cfg conftypes.SiteConfigQuerier,
 	store database.ExternalServiceStore,
+	db database.DB,
 ) (
 	allowAccessByDefault bool,
 	providers []authz.Provider,
@@ -157,7 +158,7 @@ func ProvidersFromConfig(
 	}
 
 	if len(perforceConns) > 0 {
-		pfProviders, pfProblems, pfWarnings := perforce.NewAuthzProviders(perforceConns)
+		pfProviders, pfProblems, pfWarnings := perforce.NewAuthzProviders(perforceConns, db)
 		providers = append(providers, pfProviders...)
 		seriousProblems = append(seriousProblems, pfProblems...)
 		warnings = append(warnings, pfWarnings...)
@@ -197,6 +198,7 @@ func ProviderFromExternalService(
 	externalServicesStore database.ExternalServiceStore,
 	siteConfig schema.SiteConfiguration,
 	svc *types.ExternalService,
+	db database.DB,
 ) (authz.Provider, error) {
 	if MockProviderFromExternalService != nil {
 		return MockProviderFromExternalService(siteConfig, svc)
@@ -259,6 +261,7 @@ func ProviderFromExternalService(
 					PerforceConnection: c,
 				},
 			},
+			db,
 		)
 	default:
 		return nil, errors.Errorf("unsupported connection type %T", cfg)

--- a/enterprise/internal/authz/authz_test.go
+++ b/enterprise/internal/authz/authz_test.go
@@ -499,6 +499,7 @@ func TestAuthzProvidersFromConfig(t *testing.T) {
 				context.Background(),
 				staticConfig(test.cfg.SiteConfiguration),
 				externalServices,
+				database.NewMockDB(),
 			)
 			assert.Equal(t, test.expAuthzAllowAccessByDefault, allowAccessByDefault)
 			if test.expAuthzProviders != nil {

--- a/enterprise/internal/authz/perforce/authz.go
+++ b/enterprise/internal/authz/perforce/authz.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"github.com/sourcegraph/sourcegraph/internal/authz"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/schema"
@@ -18,9 +19,9 @@ import (
 // This constructor does not and should not directly check connectivity to external services - if
 // desired, callers should use `(*Provider).ValidateConnection` directly to get warnings related
 // to connection issues.
-func NewAuthzProviders(conns []*types.PerforceConnection) (ps []authz.Provider, problems []string, warnings []string) {
+func NewAuthzProviders(conns []*types.PerforceConnection, db database.DB) (ps []authz.Provider, problems []string, warnings []string) {
 	for _, c := range conns {
-		p := newAuthzProvider(c.URN, c.Authorization, c.P4Port, c.P4User, c.P4Passwd, c.Depots)
+		p := newAuthzProvider(c.URN, c.Authorization, c.P4Port, c.P4User, c.P4Passwd, c.Depots, db)
 		if p != nil {
 			ps = append(ps, p)
 		}
@@ -34,6 +35,7 @@ func newAuthzProvider(
 	a *schema.PerforceAuthorization,
 	host, user, password string,
 	depots []string,
+	db database.DB,
 ) authz.Provider {
 	// Call this function from ValidateAuthz if this function starts returning an error.
 	if a == nil {
@@ -53,7 +55,7 @@ func newAuthzProvider(
 		}
 	}
 
-	return NewProvider(urn, host, user, password, depotIDs)
+	return NewProvider(urn, host, user, password, depotIDs, db)
 }
 
 // ValidateAuthz validates the authorization fields of the given Perforce

--- a/enterprise/internal/authz/perforce/perforce.go
+++ b/enterprise/internal/authz/perforce/perforce.go
@@ -13,6 +13,7 @@ import (
 	otlog "github.com/opentracing/opentracing-go/log"
 
 	"github.com/sourcegraph/sourcegraph/internal/authz"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/perforce"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
@@ -49,7 +50,7 @@ type p4Execer interface {
 // host, user and password to talk to a Perforce Server that is the source of
 // truth for permissions. It assumes emails of Sourcegraph accounts match 1-1
 // with emails of Perforce Server users. It uses our default gitserver client.
-func NewProvider(urn, host, user, password string, depots []extsvc.RepoID) *Provider {
+func NewProvider(urn, host, user, password string, depots []extsvc.RepoID, db database.DB) *Provider {
 	baseURL, _ := url.Parse(host)
 	return &Provider{
 		urn:                urn,

--- a/enterprise/internal/batches/background.go
+++ b/enterprise/internal/batches/background.go
@@ -46,7 +46,7 @@ func InitBackgroundJobs(
 
 	syncRegistry := syncer.NewSyncRegistry(ctx, bstore, cf, observationContext)
 
-	routines := background.Routines(ctx, bstore, cf, observationContext)
+	routines := background.Routines(ctx, bstore, cf, observationContext, db)
 
 	routines = append(routines, syncRegistry)
 

--- a/enterprise/internal/batches/background/background.go
+++ b/enterprise/internal/batches/background/background.go
@@ -6,13 +6,14 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/scheduler"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/sources"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/store"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 )
 
-func Routines(ctx context.Context, batchesStore *store.Store, cf *httpcli.Factory, observationContext *observation.Context) []goroutine.BackgroundRoutine {
+func Routines(ctx context.Context, batchesStore *store.Store, cf *httpcli.Factory, observationContext *observation.Context, db database.DB) []goroutine.BackgroundRoutine {
 	sourcer := sources.NewSourcer(cf)
 	metrics := newMetrics(observationContext)
 

--- a/enterprise/internal/codemonitors/background/search.go
+++ b/enterprise/internal/codemonitors/background/search.go
@@ -34,7 +34,7 @@ import (
 
 const gqlSettingsQuery = `query CodeMonitorSettings{
 	viewerSettings {
-		final	
+		final
 	}
 }`
 
@@ -119,7 +119,7 @@ func doSearch(ctx context.Context, db database.DB, query string, monitorID int64
 		return nil, err
 	}
 
-	planJob, err := job.FromExpandedPlan(jobArgs, plan)
+	planJob, err := job.FromExpandedPlan(jobArgs, plan, db)
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/internal/compute/command.go
+++ b/enterprise/internal/compute/command.go
@@ -3,12 +3,13 @@ package compute
 import (
 	"context"
 
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
 )
 
 type Command interface {
 	command()
-	Run(context.Context, result.Match) (Result, error)
+	Run(context.Context, database.DB, result.Match) (Result, error)
 	ToSearchPattern() string
 	String() string
 }

--- a/enterprise/internal/compute/match_only_command.go
+++ b/enterprise/internal/compute/match_only_command.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/grafana/regexp"
 
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
 )
 
@@ -78,7 +79,7 @@ func matchOnly(fm *result.FileMatch, r *regexp.Regexp) *MatchContext {
 	return &MatchContext{Matches: matches, Path: fm.Path}
 }
 
-func (c *MatchOnly) Run(_ context.Context, r result.Match) (Result, error) {
+func (c *MatchOnly) Run(_ context.Context, db database.DB, r result.Match) (Result, error) {
 	switch m := r.(type) {
 	case *result.FileMatch:
 		return matchOnly(m, c.ComputePattern.(*Regexp).Value), nil

--- a/enterprise/internal/compute/output_command.go
+++ b/enterprise/internal/compute/output_command.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/comby"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 )
@@ -59,10 +60,10 @@ func output(ctx context.Context, fragment string, matchPattern MatchPattern, rep
 	return &Text{Value: newContent, Kind: "output"}, nil
 }
 
-func resultContent(ctx context.Context, r result.Match) (string, bool, error) {
+func resultContent(ctx context.Context, db database.DB, r result.Match) (string, bool, error) {
 	switch m := r.(type) {
 	case *result.FileMatch:
-		contentBytes, err := git.ReadFile(ctx, m.Repo.Name, m.CommitID, m.Path, 0, authz.DefaultSubRepoPermsChecker)
+		contentBytes, err := git.ReadFile(ctx, db, m.Repo.Name, m.CommitID, m.Path, 0, authz.DefaultSubRepoPermsChecker)
 		if err != nil {
 			return "", false, err
 		}
@@ -80,8 +81,8 @@ func resultContent(ctx context.Context, r result.Match) (string, bool, error) {
 	}
 }
 
-func (c *Output) Run(ctx context.Context, r result.Match) (Result, error) {
-	content, ok, err := resultContent(ctx, r)
+func (c *Output) Run(ctx context.Context, db database.DB, r result.Match) (Result, error) {
+	content, ok, err := resultContent(ctx, db, r)
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/internal/compute/output_command_test.go
+++ b/enterprise/internal/compute/output_command_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/comby"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
@@ -71,7 +72,7 @@ func TestRun(t *testing.T) {
 	test := func(q string, m result.Match) string {
 		defer git.ResetMocks()
 		computeQuery, _ := Parse(q)
-		res, err := computeQuery.Command.Run(context.Background(), m)
+		res, err := computeQuery.Command.Run(context.Background(), database.NewMockDB(), m)
 		if err != nil {
 			return err.Error()
 		}

--- a/enterprise/internal/compute/replace_command.go
+++ b/enterprise/internal/compute/replace_command.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/comby"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
@@ -49,10 +50,10 @@ func replace(ctx context.Context, content []byte, matchPattern MatchPattern, rep
 	return &Text{Value: newContent, Kind: "replace-in-place"}, nil
 }
 
-func (c *Replace) Run(ctx context.Context, r result.Match) (Result, error) {
+func (c *Replace) Run(ctx context.Context, db database.DB, r result.Match) (Result, error) {
 	switch m := r.(type) {
 	case *result.FileMatch:
-		content, err := git.ReadFile(ctx, m.Repo.Name, m.CommitID, m.Path, 0, authz.DefaultSubRepoPermsChecker)
+		content, err := git.ReadFile(ctx, db, m.Repo.Name, m.CommitID, m.Path, 0, authz.DefaultSubRepoPermsChecker)
 		if err != nil {
 			return nil, err
 		}

--- a/enterprise/internal/insights/background/background.go
+++ b/enterprise/internal/insights/background/background.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/background/pings"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/discovery"
 
@@ -55,7 +56,7 @@ func GetBackgroundJobs(ctx context.Context, mainAppDB *sql.DB, insightsDB *sql.D
 	}
 
 	// todo(insights) add setting to disable this indexer
-	routines = append(routines, compression.NewCommitIndexerWorker(ctx, mainAppDB, insightsDB, observationContext))
+	routines = append(routines, compression.NewCommitIndexerWorker(ctx, database.NewDB(mainAppDB), insightsDB, observationContext))
 
 	// Register the background goroutine which discovers historical gaps in data and enqueues
 	// work to fill them - if not disabled.

--- a/enterprise/internal/insights/background/historical_enqueuer_test.go
+++ b/enterprise/internal/insights/background/historical_enqueuer_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/store"
 	itypes "github.com/sourcegraph/sourcegraph/enterprise/internal/insights/types"
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
@@ -116,7 +117,7 @@ func testHistoricalEnqueuer(t *testing.T, p *testParams) *testResults {
 		return nil
 	}
 
-	gitFirstEverCommit := func(ctx context.Context, repoName api.RepoName) (*gitdomain.Commit, error) {
+	gitFirstEverCommit := func(ctx context.Context, db database.DB, repoName api.RepoName) (*gitdomain.Commit, error) {
 		if repoName == "repo/1" {
 			daysAgo := clock().Add(-3 * 24 * time.Hour)
 			return &gitdomain.Commit{Committer: &gitdomain.Signature{Date: daysAgo}}, nil

--- a/enterprise/internal/insights/compression/worker.go
+++ b/enterprise/internal/insights/compression/worker.go
@@ -17,6 +17,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbcache"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
@@ -40,7 +41,7 @@ type CommitIndexer struct {
 	operations        *operations
 }
 
-func NewCommitIndexer(background context.Context, base database.DB, insights database.DB, observationContext *observation.Context) *CommitIndexer {
+func NewCommitIndexer(background context.Context, base database.DB, insights dbutil.DB, observationContext *observation.Context) *CommitIndexer {
 	//TODO(insights): add a setting for historical index length
 	startTime := time.Now().AddDate(-1, 0, 0)
 
@@ -77,7 +78,7 @@ func NewCommitIndexer(background context.Context, base database.DB, insights dat
 	return &indexer
 }
 
-func NewCommitIndexerWorker(ctx context.Context, base database.DB, insights database.DB, observationContext *observation.Context) goroutine.BackgroundRoutine {
+func NewCommitIndexerWorker(ctx context.Context, base database.DB, insights dbutil.DB, observationContext *observation.Context) goroutine.BackgroundRoutine {
 	indexer := NewCommitIndexer(ctx, base, insights, observationContext)
 
 	return indexer.Handler(ctx, observationContext)

--- a/enterprise/internal/insights/compression/worker_test.go
+++ b/enterprise/internal/insights/compression/worker_test.go
@@ -10,6 +10,7 @@ import (
 	"golang.org/x/time/rate"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 )
@@ -193,8 +194,8 @@ func commit(ref string, commitTime string) *gitdomain.Commit {
 	}
 }
 
-func mockCommits(commits map[string][]*gitdomain.Commit) func(ctx context.Context, name api.RepoName, after time.Time, operation *observation.Operation) ([]*gitdomain.Commit, error) {
-	return func(ctx context.Context, name api.RepoName, after time.Time, operation *observation.Operation) ([]*gitdomain.Commit, error) {
+func mockCommits(commits map[string][]*gitdomain.Commit) func(ctx context.Context, db database.DB, name api.RepoName, after time.Time, operation *observation.Operation) ([]*gitdomain.Commit, error) {
+	return func(ctx context.Context, db database.DB, name api.RepoName, after time.Time, operation *observation.Operation) ([]*gitdomain.Commit, error) {
 		return commits[(string(name))], nil
 	}
 }

--- a/enterprise/internal/insights/query/query_executor.go
+++ b/enterprise/internal/insights/query/query_executor.go
@@ -16,6 +16,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
@@ -27,9 +28,9 @@ type CaptureGroupExecutor struct {
 	clock     func() time.Time
 }
 
-func NewCaptureGroupExecutor(postgres, insightsDb database.DB, clock func() time.Time) *CaptureGroupExecutor {
+func NewCaptureGroupExecutor(postgres, insightsDb dbutil.DB, clock func() time.Time) *CaptureGroupExecutor {
 	return &CaptureGroupExecutor{
-		db:        postgres,
+		db:        database.NewDB(postgres),
 		repoStore: database.Repos(postgres),
 		// filter:    compression.NewHistoricalFilter(true, clock().Add(time.Hour*24*365*-1), insightsDb),
 		filter: &compression.NoopFilter{},

--- a/enterprise/internal/insights/query/query_executor.go
+++ b/enterprise/internal/insights/query/query_executor.go
@@ -16,19 +16,20 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 type CaptureGroupExecutor struct {
+	db        database.DB
 	repoStore database.RepoStore
 	filter    compression.DataFrameFilter
 	clock     func() time.Time
 }
 
-func NewCaptureGroupExecutor(postgres, insightsDb dbutil.DB, clock func() time.Time) *CaptureGroupExecutor {
+func NewCaptureGroupExecutor(postgres, insightsDb database.DB, clock func() time.Time) *CaptureGroupExecutor {
 	return &CaptureGroupExecutor{
+		db:        postgres,
 		repoStore: database.Repos(postgres),
 		// filter:    compression.NewHistoricalFilter(true, clock().Add(time.Hour*24*365*-1), insightsDb),
 		filter: &compression.NoopFilter{},
@@ -53,7 +54,7 @@ func (c *CaptureGroupExecutor) Execute(ctx context.Context, query string, reposi
 	pivoted := make(map[string]timeCounts)
 
 	for _, repository := range repositories {
-		firstCommit, err := git.FirstEverCommit(ctx, api.RepoName(repository), authz.DefaultSubRepoPermsChecker)
+		firstCommit, err := git.FirstEverCommit(ctx, c.db, api.RepoName(repository), authz.DefaultSubRepoPermsChecker)
 		if err != nil {
 			return nil, errors.Wrapf(err, "FirstEverCommit")
 		}
@@ -81,7 +82,7 @@ func (c *CaptureGroupExecutor) Execute(ctx context.Context, query string, reposi
 				continue
 			}
 
-			commits, err := git.Commits(ctx, api.RepoName(repository), git.CommitsOptions{N: 1, Before: execution.RecordingTime.Format(time.RFC3339), DateOrder: true}, authz.DefaultSubRepoPermsChecker)
+			commits, err := git.Commits(ctx, c.db, api.RepoName(repository), git.CommitsOptions{N: 1, Before: execution.RecordingTime.Format(time.RFC3339), DateOrder: true}, authz.DefaultSubRepoPermsChecker)
 			if err != nil {
 				return nil, errors.Wrap(err, "git.Commits")
 			} else if len(commits) < 1 {

--- a/enterprise/internal/rockskip/git.go
+++ b/enterprise/internal/rockskip/git.go
@@ -3,7 +3,7 @@ package rockskip
 import "github.com/sourcegraph/sourcegraph/internal/vcs/git"
 
 type Git interface {
-	LogReverseEach(repo string, commit string, n int, onLogEntry func(logEntry git.LogEntry) error) error
-	RevListEach(repo string, commit string, onCommit func(commit string) (shouldContinue bool, err error)) error
+	LogReverseEach(repo string, db database.DB, commit string, n int, onLogEntry func(logEntry git.LogEntry) error) error
+	RevListEach(repo string, db database.DB, commit string, onCommit func(commit string) (shouldContinue bool, err error)) error
 	ArchiveEach(repo string, commit string, paths []string, onFile func(path string, contents []byte) error) error
 }

--- a/enterprise/internal/rockskip/git.go
+++ b/enterprise/internal/rockskip/git.go
@@ -1,6 +1,9 @@
 package rockskip
 
-import "github.com/sourcegraph/sourcegraph/internal/vcs/git"
+import (
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
+)
 
 type Git interface {
 	LogReverseEach(repo string, db database.DB, commit string, n int, onLogEntry func(logEntry git.LogEntry) error) error

--- a/enterprise/internal/rockskip/server_test.go
+++ b/enterprise/internal/rockskip/server_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/symbols/types"
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
@@ -222,7 +223,7 @@ func (g SubprocessGit) Close() error {
 	return g.catFileCmd.Wait()
 }
 
-func (g SubprocessGit) LogReverseEach(repo string, givenCommit string, n int, onLogEntry func(entry git.LogEntry) error) (returnError error) {
+func (g SubprocessGit) LogReverseEach(repo string, db database.DB, givenCommit string, n int, onLogEntry func(entry git.LogEntry) error) (returnError error) {
 	log := exec.Command("git", git.LogReverseArgs(n, givenCommit)...)
 	log.Dir = g.gitDir
 	output, err := log.StdoutPipe()
@@ -244,7 +245,7 @@ func (g SubprocessGit) LogReverseEach(repo string, givenCommit string, n int, on
 	return git.ParseLogReverseEach(output, onLogEntry)
 }
 
-func (g SubprocessGit) RevListEach(repo string, givenCommit string, onCommit func(commit string) (shouldContinue bool, err error)) (returnError error) {
+func (g SubprocessGit) RevListEach(repo string, db database.DB, givenCommit string, onCommit func(commit string) (shouldContinue bool, err error)) (returnError error) {
 	revList := exec.Command("git", git.RevListArgs(givenCommit)...)
 	revList.Dir = g.gitDir
 	output, err := revList.StdoutPipe()

--- a/internal/codeintel/lockfiles/iface.go
+++ b/internal/codeintel/lockfiles/iface.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 )
@@ -16,23 +17,25 @@ type GitService interface {
 }
 
 type gitService struct {
+	db      database.DB
 	checker authz.SubRepoPermissionChecker
 }
 
-func NewDefaultGitService(checker authz.SubRepoPermissionChecker) GitService {
+func NewDefaultGitService(checker authz.SubRepoPermissionChecker, db database.DB) GitService {
 	if checker == nil {
 		checker = authz.DefaultSubRepoPermsChecker
 	}
 
 	return &gitService{
+		db:      db,
 		checker: checker,
 	}
 }
 
 func (s *gitService) LsFiles(ctx context.Context, repo api.RepoName, commits api.CommitID, paths ...string) ([]string, error) {
-	return git.LsFiles(ctx, s.checker, repo, commits, paths...)
+	return git.LsFiles(ctx, s.db, s.checker, repo, commits, paths...)
 }
 
 func (s *gitService) Archive(ctx context.Context, repo api.RepoName, opts gitserver.ArchiveOptions) (io.ReadCloser, error) {
-	return git.ArchiveReader(ctx, repo, opts)
+	return git.ArchiveReader(ctx, s.db, repo, opts)
 }

--- a/internal/gitserver/client.go
+++ b/internal/gitserver/client.go
@@ -28,7 +28,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 
 	"github.com/sourcegraph/go-rendezvous"
-
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/gitolite"
@@ -110,7 +109,7 @@ type ClientImplementor struct {
 //go:generate ../../dev/mockgen.sh github.com/sourcegraph/sourcegraph/internal/gitserver -i Client -o mock_client.go
 type Client interface {
 	// AddrForRepo returns the gitserver address to use for the given repo name.
-	AddrForRepo(api.RepoName) string
+	AddrForRepo(context.Context, api.RepoName) string
 
 	Addrs() []string
 
@@ -119,7 +118,7 @@ type Client interface {
 
 	// ArchiveURL returns a URL from which an archive of the given Git repository can
 	// be downloaded from.
-	ArchiveURL(api.RepoName, ArchiveOptions) *url.URL
+	ArchiveURL(context.Context, api.RepoName, ArchiveOptions) *url.URL
 
 	// Command creates a new Cmd. Command name must be 'git', otherwise it panics.
 	Command(name string, args ...string) *Cmd
@@ -198,7 +197,7 @@ func (c *ClientImplementor) Addrs() []string {
 	return c.addrs()
 }
 
-func (c *ClientImplementor) AddrForRepo(repo api.RepoName) string {
+func (c *ClientImplementor) AddrForRepo(ctx context.Context, repo api.RepoName) string {
 	addrs := c.addrs()
 	if len(addrs) == 0 {
 		panic("unexpected state: no gitserver addresses")
@@ -290,7 +289,7 @@ func (a *archiveReader) Close() error {
 
 // ArchiveURL returns a URL from which an archive of the given Git repository can
 // be downloaded from.
-func (c *ClientImplementor) ArchiveURL(repo api.RepoName, opt ArchiveOptions) *url.URL {
+func (c *ClientImplementor) ArchiveURL(ctx context.Context, repo api.RepoName, opt ArchiveOptions) *url.URL {
 	q := url.Values{
 		"repo":    {string(repo)},
 		"treeish": {opt.Treeish},
@@ -303,7 +302,7 @@ func (c *ClientImplementor) ArchiveURL(repo api.RepoName, opt ArchiveOptions) *u
 
 	return &url.URL{
 		Scheme:   "http",
-		Host:     c.AddrForRepo(repo),
+		Host:     c.AddrForRepo(ctx, repo),
 		Path:     "/archive",
 		RawQuery: q.Encode(),
 	}
@@ -327,7 +326,7 @@ func (c *ClientImplementor) Archive(ctx context.Context, repo api.RepoName, opt 
 		return nil, err
 	}
 
-	u := c.ArchiveURL(repo, opt)
+	u := c.ArchiveURL(ctx, repo, opt)
 	resp, err := c.do(ctx, repo, "POST", u.String(), nil)
 	if err != nil {
 		return nil, err
@@ -441,7 +440,7 @@ func (c *ClientImplementor) Search(ctx context.Context, args *protocol.SearchReq
 		return false, err
 	}
 
-	uri := "http://" + c.AddrForRepo(repoName) + "/search"
+	uri := "http://" + c.AddrForRepo(ctx, repoName) + "/search"
 	resp, err := c.do(ctx, repoName, "POST", uri, buf.Bytes())
 	if err != nil {
 		return false, err
@@ -732,7 +731,7 @@ func (c *ClientImplementor) RequestRepoMigrate(ctx context.Context, repo api.Rep
 	// ignored.
 	req := &protocol.RepoUpdateRequest{
 		Repo:           repo,
-		CloneFromShard: c.AddrForRepo(repo),
+		CloneFromShard: c.AddrForRepo(ctx, repo),
 	}
 
 	// We set "uri" to the HTTP URL of the gitserver instance that should be the new owner of this
@@ -842,7 +841,7 @@ func (c *ClientImplementor) RepoCloneProgress(ctx context.Context, repos ...api.
 	shards := make(map[string]*protocol.RepoCloneProgressRequest, (len(repos)/numPossibleShards)*2) // 2x because it may not be a perfect division
 
 	for _, r := range repos {
-		addr := c.AddrForRepo(r)
+		addr := c.AddrForRepo(ctx, r)
 		shard := shards[addr]
 
 		if shard == nil {
@@ -912,7 +911,7 @@ func (c *ClientImplementor) RepoInfo(ctx context.Context, repos ...api.RepoName)
 	shards := make(map[string]*protocol.RepoInfoRequest, (len(repos)/numPossibleShards)*2) // 2x because it may not be a perfect division
 
 	for _, r := range repos {
-		addr := c.AddrForRepo(r)
+		addr := c.AddrForRepo(ctx, r)
 		shard := shards[addr]
 
 		if shard == nil {
@@ -1038,7 +1037,7 @@ func (c *ClientImplementor) httpPost(ctx context.Context, repo api.RepoName, op 
 		return nil, err
 	}
 
-	uri := "http://" + c.AddrForRepo(repo) + "/" + op
+	uri := "http://" + c.AddrForRepo(ctx, repo) + "/" + op
 	return c.do(ctx, repo, "POST", uri, b)
 }
 

--- a/internal/gitserver/mock_client.go
+++ b/internal/gitserver/mock_client.go
@@ -90,7 +90,7 @@ type MockClient struct {
 func NewMockClient() *MockClient {
 	return &MockClient{
 		AddrForRepoFunc: &ClientAddrForRepoFunc{
-			defaultHook: func(api.RepoName) string {
+			defaultHook: func(context.Context, api.RepoName) string {
 				return ""
 			},
 		},
@@ -105,7 +105,7 @@ func NewMockClient() *MockClient {
 			},
 		},
 		ArchiveURLFunc: &ClientArchiveURLFunc{
-			defaultHook: func(api.RepoName, ArchiveOptions) *url.URL {
+			defaultHook: func(context.Context, api.RepoName, ArchiveOptions) *url.URL {
 				return nil
 			},
 		},
@@ -202,7 +202,7 @@ func NewMockClient() *MockClient {
 func NewStrictMockClient() *MockClient {
 	return &MockClient{
 		AddrForRepoFunc: &ClientAddrForRepoFunc{
-			defaultHook: func(api.RepoName) string {
+			defaultHook: func(context.Context, api.RepoName) string {
 				panic("unexpected invocation of MockClient.AddrForRepo")
 			},
 		},
@@ -217,7 +217,7 @@ func NewStrictMockClient() *MockClient {
 			},
 		},
 		ArchiveURLFunc: &ClientArchiveURLFunc{
-			defaultHook: func(api.RepoName, ArchiveOptions) *url.URL {
+			defaultHook: func(context.Context, api.RepoName, ArchiveOptions) *url.URL {
 				panic("unexpected invocation of MockClient.ArchiveURL")
 			},
 		},
@@ -382,23 +382,23 @@ func NewMockClientFrom(i Client) *MockClient {
 // ClientAddrForRepoFunc describes the behavior when the AddrForRepo method
 // of the parent MockClient instance is invoked.
 type ClientAddrForRepoFunc struct {
-	defaultHook func(api.RepoName) string
-	hooks       []func(api.RepoName) string
+	defaultHook func(context.Context, api.RepoName) string
+	hooks       []func(context.Context, api.RepoName) string
 	history     []ClientAddrForRepoFuncCall
 	mutex       sync.Mutex
 }
 
 // AddrForRepo delegates to the next hook function in the queue and stores
 // the parameter and result values of this invocation.
-func (m *MockClient) AddrForRepo(v0 api.RepoName) string {
-	r0 := m.AddrForRepoFunc.nextHook()(v0)
-	m.AddrForRepoFunc.appendCall(ClientAddrForRepoFuncCall{v0, r0})
+func (m *MockClient) AddrForRepo(v0 context.Context, v1 api.RepoName) string {
+	r0 := m.AddrForRepoFunc.nextHook()(v0, v1)
+	m.AddrForRepoFunc.appendCall(ClientAddrForRepoFuncCall{v0, v1, r0})
 	return r0
 }
 
 // SetDefaultHook sets function that is called when the AddrForRepo method
 // of the parent MockClient instance is invoked and the hook queue is empty.
-func (f *ClientAddrForRepoFunc) SetDefaultHook(hook func(api.RepoName) string) {
+func (f *ClientAddrForRepoFunc) SetDefaultHook(hook func(context.Context, api.RepoName) string) {
 	f.defaultHook = hook
 }
 
@@ -406,7 +406,7 @@ func (f *ClientAddrForRepoFunc) SetDefaultHook(hook func(api.RepoName) string) {
 // AddrForRepo method of the parent MockClient instance invokes the hook at
 // the front of the queue and discards it. After the queue is empty, the
 // default hook function is invoked for any future action.
-func (f *ClientAddrForRepoFunc) PushHook(hook func(api.RepoName) string) {
+func (f *ClientAddrForRepoFunc) PushHook(hook func(context.Context, api.RepoName) string) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -415,19 +415,19 @@ func (f *ClientAddrForRepoFunc) PushHook(hook func(api.RepoName) string) {
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
 func (f *ClientAddrForRepoFunc) SetDefaultReturn(r0 string) {
-	f.SetDefaultHook(func(api.RepoName) string {
+	f.SetDefaultHook(func(context.Context, api.RepoName) string {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
 func (f *ClientAddrForRepoFunc) PushReturn(r0 string) {
-	f.PushHook(func(api.RepoName) string {
+	f.PushHook(func(context.Context, api.RepoName) string {
 		return r0
 	})
 }
 
-func (f *ClientAddrForRepoFunc) nextHook() func(api.RepoName) string {
+func (f *ClientAddrForRepoFunc) nextHook() func(context.Context, api.RepoName) string {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -462,7 +462,10 @@ func (f *ClientAddrForRepoFunc) History() []ClientAddrForRepoFuncCall {
 type ClientAddrForRepoFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.
-	Arg0 api.RepoName
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 api.RepoName
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 string
@@ -471,7 +474,7 @@ type ClientAddrForRepoFuncCall struct {
 // Args returns an interface slice containing the arguments of this
 // invocation.
 func (c ClientAddrForRepoFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0}
+	return []interface{}{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
@@ -691,23 +694,23 @@ func (c ClientArchiveFuncCall) Results() []interface{} {
 // ClientArchiveURLFunc describes the behavior when the ArchiveURL method of
 // the parent MockClient instance is invoked.
 type ClientArchiveURLFunc struct {
-	defaultHook func(api.RepoName, ArchiveOptions) *url.URL
-	hooks       []func(api.RepoName, ArchiveOptions) *url.URL
+	defaultHook func(context.Context, api.RepoName, ArchiveOptions) *url.URL
+	hooks       []func(context.Context, api.RepoName, ArchiveOptions) *url.URL
 	history     []ClientArchiveURLFuncCall
 	mutex       sync.Mutex
 }
 
 // ArchiveURL delegates to the next hook function in the queue and stores
 // the parameter and result values of this invocation.
-func (m *MockClient) ArchiveURL(v0 api.RepoName, v1 ArchiveOptions) *url.URL {
-	r0 := m.ArchiveURLFunc.nextHook()(v0, v1)
-	m.ArchiveURLFunc.appendCall(ClientArchiveURLFuncCall{v0, v1, r0})
+func (m *MockClient) ArchiveURL(v0 context.Context, v1 api.RepoName, v2 ArchiveOptions) *url.URL {
+	r0 := m.ArchiveURLFunc.nextHook()(v0, v1, v2)
+	m.ArchiveURLFunc.appendCall(ClientArchiveURLFuncCall{v0, v1, v2, r0})
 	return r0
 }
 
 // SetDefaultHook sets function that is called when the ArchiveURL method of
 // the parent MockClient instance is invoked and the hook queue is empty.
-func (f *ClientArchiveURLFunc) SetDefaultHook(hook func(api.RepoName, ArchiveOptions) *url.URL) {
+func (f *ClientArchiveURLFunc) SetDefaultHook(hook func(context.Context, api.RepoName, ArchiveOptions) *url.URL) {
 	f.defaultHook = hook
 }
 
@@ -715,7 +718,7 @@ func (f *ClientArchiveURLFunc) SetDefaultHook(hook func(api.RepoName, ArchiveOpt
 // ArchiveURL method of the parent MockClient instance invokes the hook at
 // the front of the queue and discards it. After the queue is empty, the
 // default hook function is invoked for any future action.
-func (f *ClientArchiveURLFunc) PushHook(hook func(api.RepoName, ArchiveOptions) *url.URL) {
+func (f *ClientArchiveURLFunc) PushHook(hook func(context.Context, api.RepoName, ArchiveOptions) *url.URL) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -724,19 +727,19 @@ func (f *ClientArchiveURLFunc) PushHook(hook func(api.RepoName, ArchiveOptions) 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
 func (f *ClientArchiveURLFunc) SetDefaultReturn(r0 *url.URL) {
-	f.SetDefaultHook(func(api.RepoName, ArchiveOptions) *url.URL {
+	f.SetDefaultHook(func(context.Context, api.RepoName, ArchiveOptions) *url.URL {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
 func (f *ClientArchiveURLFunc) PushReturn(r0 *url.URL) {
-	f.PushHook(func(api.RepoName, ArchiveOptions) *url.URL {
+	f.PushHook(func(context.Context, api.RepoName, ArchiveOptions) *url.URL {
 		return r0
 	})
 }
 
-func (f *ClientArchiveURLFunc) nextHook() func(api.RepoName, ArchiveOptions) *url.URL {
+func (f *ClientArchiveURLFunc) nextHook() func(context.Context, api.RepoName, ArchiveOptions) *url.URL {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -771,10 +774,13 @@ func (f *ClientArchiveURLFunc) History() []ClientArchiveURLFuncCall {
 type ClientArchiveURLFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.
-	Arg0 api.RepoName
+	Arg0 context.Context
 	// Arg1 is the value of the 2nd argument passed to this method
 	// invocation.
-	Arg1 ArchiveOptions
+	Arg1 api.RepoName
+	// Arg2 is the value of the 3rd argument passed to this method
+	// invocation.
+	Arg2 ArchiveOptions
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 *url.URL
@@ -783,7 +789,7 @@ type ClientArchiveURLFuncCall struct {
 // Args returns an interface slice containing the arguments of this
 // invocation.
 func (c ClientArchiveURLFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
 }
 
 // Results returns an interface slice containing the results of this

--- a/internal/search/execute/execute.go
+++ b/internal/search/execute/execute.go
@@ -31,7 +31,7 @@ func Execute(
 		return nil, err
 	}
 
-	planJob, err := job.FromExpandedPlan(jobArgs, plan)
+	planJob, err := job.FromExpandedPlan(jobArgs, plan, db)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/search/job/job_test.go
+++ b/internal/search/job/job_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/hexops/autogold"
 
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
 	"github.com/sourcegraph/sourcegraph/internal/search/run"
@@ -23,7 +24,7 @@ func TestToSearchInputs(t *testing.T) {
 			},
 		}
 
-		j, _ := ToSearchJob(args, q)
+		j, _ := ToSearchJob(args, q, database.NewMockDB())
 		return "\n" + PrettySexp(j) + "\n"
 	}
 
@@ -184,7 +185,7 @@ func TestToEvaluateJob(t *testing.T) {
 		}
 
 		b, _ := query.ToBasicQuery(q)
-		j, _ := ToEvaluateJob(args, b)
+		j, _ := ToEvaluateJob(args, b, database.NewMockDB())
 		return "\n" + PrettySexp(j) + "\n"
 	}
 

--- a/internal/search/job/printers_test.go
+++ b/internal/search/job/printers_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 
 	"github.com/hexops/autogold"
+
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
 	"github.com/sourcegraph/sourcegraph/internal/search/run"
@@ -193,7 +195,7 @@ func TestPrettyJSON(t *testing.T) {
 				Protocol:     search.Streaming,
 			},
 		}
-		j, _ := ToSearchJob(args, q)
+		j, _ := ToSearchJob(args, q, database.NewMockDB())
 		return PrettyJSONVerbose(j)
 	}
 

--- a/internal/search/predicate/substitute.go
+++ b/internal/search/predicate/substitute.go
@@ -37,7 +37,7 @@ func Expand(ctx context.Context, db database.DB, jobArgs *job.Args, oldPlan quer
 		q := q
 		g.Go(func() error {
 			predicatePlan, err := Substitute(q, func(plan query.Plan) (result.Matches, error) {
-				predicateJob, err := job.FromExpandedPlan(jobArgs, plan)
+				predicateJob, err := job.FromExpandedPlan(jobArgs, plan, db)
 				if err != nil {
 					return nil, err
 				}

--- a/internal/search/repo_revs.go
+++ b/internal/search/repo_revs.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 )
@@ -72,7 +73,7 @@ type RepositoryRevisions struct {
 
 	// ListRefs is called to list all Git refs for a repository. It is intended to be mocked by
 	// tests. If nil, git.ListRefs is used.
-	ListRefs func(context.Context, api.RepoName) ([]git.Ref, error) `json:"-"`
+	ListRefs func(ctx context.Context, db database.DB, repo api.RepoName) ([]git.Ref, error) `json:"-"`
 }
 
 func (r *RepositoryRevisions) Copy() *RepositoryRevisions {
@@ -194,9 +195,9 @@ func (r *RepositoryRevisions) RevSpecs() []string {
 // Not all callers need to expand ref glob expressions. If a caller is passing the ref globs as
 // command-line args to `git` directly (e.g., to `git log --glob ... --exclude ...`), it does not
 // need to use this function.
-func (r *RepositoryRevisions) ExpandedRevSpecs(ctx context.Context) ([]string, error) {
+func (r *RepositoryRevisions) ExpandedRevSpecs(ctx context.Context, db database.DB) ([]string, error) {
 	r.resolveOnce.Do(func() {
-		revSpecsList, err := expandedRevSpec(ctx, r)
+		revSpecsList, err := expandedRevSpec(ctx, db, r)
 		if err != nil {
 			r.resolveErr = err
 			return
@@ -209,7 +210,7 @@ func (r *RepositoryRevisions) ExpandedRevSpecs(ctx context.Context) ([]string, e
 // expandedRevSpecs evaluates all of r's ref glob expressions and returns the full, current list of
 // refs matched or resolved by them, plus the explicitly listed Git revspecs. See
 // git.CompileRefGlobs for information on how ref include/exclude globs are handled.
-func expandedRevSpec(ctx context.Context, r *RepositoryRevisions) ([]string, error) {
+func expandedRevSpec(ctx context.Context, db database.DB, r *RepositoryRevisions) ([]string, error) {
 	listRefs := r.ListRefs
 	if listRefs == nil {
 		listRefs = git.ListRefs
@@ -230,7 +231,7 @@ func expandedRevSpec(ctx context.Context, r *RepositoryRevisions) ([]string, err
 		}
 	}
 	if len(globs) > 0 {
-		allRefs, err := listRefs(ctx, r.GitserverRepo())
+		allRefs, err := listRefs(ctx, db, r.GitserverRepo())
 		if err != nil {
 			return nil, err
 		}

--- a/internal/search/repos/repos.go
+++ b/internal/search/repos/repos.go
@@ -334,7 +334,7 @@ func (r *Resolver) Resolve(ctx context.Context, op search.RepoOptions) (Resolved
 				}
 
 				trimmedRefSpec := strings.TrimPrefix(rev.RevSpec, "^") // handle negated revisions, such as ^<branch>, ^<tag>, or ^<commit>
-				commitID, err := git.ResolveRevision(ctx, repoRev.Repo.Name, trimmedRefSpec, git.ResolveRevisionOptions{NoEnsureRevision: true})
+				commitID, err := git.ResolveRevision(ctx, r.DB, repoRev.Repo.Name, trimmedRefSpec, git.ResolveRevisionOptions{NoEnsureRevision: true})
 				if err != nil {
 					if errors.Is(err, context.DeadlineExceeded) || errors.HasType(err, gitdomain.BadCommitError{}) {
 						return err
@@ -360,7 +360,7 @@ func (r *Resolver) Resolve(ctx context.Context, op search.RepoOptions) (Resolved
 
 				if op.CommitAfter != "" {
 
-					if hasCommitAfter, err := git.HasCommitAfter(ctx, repoRev.Repo.Name, op.CommitAfter, string(commitID), authz.DefaultSubRepoPermsChecker); err != nil {
+					if hasCommitAfter, err := git.HasCommitAfter(ctx, r.DB, repoRev.Repo.Name, op.CommitAfter, string(commitID), authz.DefaultSubRepoPermsChecker); err != nil {
 						if !errors.HasType(err, &gitdomain.RevisionNotFoundError{}) && !gitdomain.IsRepoNotExist(err) {
 							res.Lock()
 							res.MultiError = errors.Append(res.MultiError, err)
@@ -568,7 +568,7 @@ func (r *Resolver) dependencies(ctx context.Context, op *search.RepoOptions) (_ 
 
 	depsSvc := codeintel.GetDependenciesService(
 		r.DB,
-		lockfiles.GetService(lockfiles.NewDefaultGitService(nil)),
+		lockfiles.GetService(lockfiles.NewDefaultGitService(nil, r.DB)),
 		&packageRepoSyncer{cli: repoupdater.DefaultClient},
 	)
 

--- a/internal/search/run/repository.go
+++ b/internal/search/run/repository.go
@@ -64,7 +64,7 @@ func (s *RepoSearch) Run(ctx context.Context, db database.DB, stream streaming.S
 		}
 
 		stream.Send(streaming.SearchEvent{
-			Results: repoRevsToRepoMatches(ctx, page.RepoRevs),
+			Results: repoRevsToRepoMatches(ctx, db, page.RepoRevs),
 		})
 
 		return nil
@@ -81,10 +81,10 @@ func (*RepoSearch) Name() string {
 	return "RepoSearch"
 }
 
-func repoRevsToRepoMatches(ctx context.Context, repos []*search.RepositoryRevisions) []result.Match {
+func repoRevsToRepoMatches(ctx context.Context, db database.DB, repos []*search.RepositoryRevisions) []result.Match {
 	matches := make([]result.Match, 0, len(repos))
 	for _, r := range repos {
-		revs, err := r.ExpandedRevSpecs(ctx)
+		revs, err := r.ExpandedRevSpecs(ctx, db)
 		if err != nil { // fallback to just return revspecs
 			revs = r.RevSpecs()
 		}

--- a/internal/search/textsearch/textsearch_test.go
+++ b/internal/search/textsearch/textsearch_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/endpoint"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
@@ -267,7 +268,7 @@ func TestSearchFilesInRepos_multipleRevsPerRepo(t *testing.T) {
 	}
 
 	repos := makeRepositoryRevisions("foo@master:mybranch:*refs/heads/")
-	repos[0].ListRefs = func(context.Context, api.RepoName) ([]git.Ref, error) {
+	repos[0].ListRefs = func(context.Context, database.DB, api.RepoName) ([]git.Ref, error) {
 		return []git.Ref{{Name: "refs/heads/branch3"}, {Name: "refs/heads/branch4"}}, nil
 	}
 

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
@@ -30,7 +31,7 @@ func TestPrepareZip(t *testing.T) {
 	var gotRepo api.RepoName
 	var gotCommit api.CommitID
 	var fetchZipCalled int64
-	s.FetchTar = func(ctx context.Context, repo api.RepoName, commit api.CommitID) (io.ReadCloser, error) {
+	s.FetchTar = func(ctx context.Context, db database.DB, repo api.RepoName, commit api.CommitID) (io.ReadCloser, error) {
 		<-returnFetch
 		atomic.AddInt64(&fetchZipCalled, 1)
 		gotRepo = repo
@@ -88,7 +89,7 @@ func TestPrepareZip_fetchTarFail(t *testing.T) {
 	fetchErr := errors.New("test")
 	s, cleanup := tmpStore(t)
 	defer cleanup()
-	s.FetchTar = func(ctx context.Context, repo api.RepoName, commit api.CommitID) (io.ReadCloser, error) {
+	s.FetchTar = func(ctx context.Context, db database.DB, repo api.RepoName, commit api.CommitID) (io.ReadCloser, error) {
 		return nil, fetchErr
 	}
 	_, err := s.PrepareZip(context.Background(), "foo", "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef")
@@ -100,7 +101,7 @@ func TestPrepareZip_fetchTarFail(t *testing.T) {
 func TestPrepareZip_errHeader(t *testing.T) {
 	s, cleanup := tmpStore(t)
 	defer cleanup()
-	s.FetchTar = func(ctx context.Context, repo api.RepoName, commit api.CommitID) (io.ReadCloser, error) {
+	s.FetchTar = func(ctx context.Context, db database.DB, repo api.RepoName, commit api.CommitID) (io.ReadCloser, error) {
 		buf := new(bytes.Buffer)
 		w := tar.NewWriter(buf)
 		w.Flush()

--- a/internal/store/testutil/store.go
+++ b/internal/store/testutil/store.go
@@ -8,6 +8,7 @@ import (
 	"os"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/store"
 )
 
@@ -43,7 +44,7 @@ func NewStore(files map[string]string) (*store.Store, func(), error) {
 		return nil, nil, err
 	}
 	return &store.Store{
-		FetchTar: func(ctx context.Context, repo api.RepoName, commit api.CommitID) (io.ReadCloser, error) {
+		FetchTar: func(ctx context.Context, db database.DB, repo api.RepoName, commit api.CommitID) (io.ReadCloser, error) {
 			return io.NopCloser(bytes.NewReader(buf.Bytes())), nil
 		},
 		Path: d,

--- a/internal/store/zipcache_test.go
+++ b/internal/store/zipcache_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 )
 
 // TestZipCacheDelete ensures that zip cache deletion is correctly hooked up to cache eviction.
@@ -15,7 +16,7 @@ func TestZipCacheDelete(t *testing.T) {
 	s, cleanup := tmpStore(t)
 	defer cleanup()
 
-	s.FetchTar = func(ctx context.Context, repo api.RepoName, commit api.CommitID) (io.ReadCloser, error) {
+	s.FetchTar = func(ctx context.Context, db database.DB, repo api.RepoName, commit api.CommitID) (io.ReadCloser, error) {
 		return emptyTar(t), nil
 	}
 

--- a/internal/testutil/github_archive.go
+++ b/internal/testutil/github_archive.go
@@ -14,7 +14,6 @@ import (
 	"golang.org/x/net/context/ctxhttp"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
-	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
@@ -72,11 +71,6 @@ func FetchTarFromGithubWithPaths(ctx context.Context, repo api.RepoName, commit 
 	}
 
 	return openGzipReader(path)
-}
-
-func FetchTarFromGithub(ctx context.Context, db database.DB, repo api.RepoName, commit api.CommitID) (io.ReadCloser, error) {
-	r, err := FetchTarFromGithubWithPaths(ctx, repo, commit, []string{})
-	return r, err
 }
 
 func openGzipReader(name string) (io.ReadCloser, error) {

--- a/internal/testutil/github_archive.go
+++ b/internal/testutil/github_archive.go
@@ -14,6 +14,7 @@ import (
 	"golang.org/x/net/context/ctxhttp"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
@@ -73,7 +74,7 @@ func FetchTarFromGithubWithPaths(ctx context.Context, repo api.RepoName, commit 
 	return openGzipReader(path)
 }
 
-func FetchTarFromGithub(ctx context.Context, repo api.RepoName, commit api.CommitID) (io.ReadCloser, error) {
+func FetchTarFromGithub(ctx context.Context, db database.DB, repo api.RepoName, commit api.CommitID) (io.ReadCloser, error) {
 	r, err := FetchTarFromGithubWithPaths(ctx, repo, commit, []string{})
 	return r, err
 }

--- a/internal/usagestats/repositories.go
+++ b/internal/usagestats/repositories.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/google/zoekt"
 	"github.com/google/zoekt/query"
+
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/search"
 )
@@ -34,7 +36,7 @@ type Repositories struct {
 	OtherBranchesNewLinesCount uint64
 }
 
-func GetRepositories(ctx context.Context) (*Repositories, error) {
+func GetRepositories(ctx context.Context, db database.DB) (*Repositories, error) {
 	var total Repositories
 
 	stats, err := gitserver.DefaultClient.ReposStats(ctx)

--- a/internal/vcs/git/archive.go
+++ b/internal/vcs/git/archive.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
@@ -22,6 +23,7 @@ const (
 // ArchiveReader streams back the file contents of an archived git repo.
 func ArchiveReader(
 	ctx context.Context,
+	db database.DB,
 	repoName api.RepoName,
 	options gitserver.ArchiveOptions,
 ) (io.ReadCloser, error) {
@@ -30,6 +32,7 @@ func ArchiveReader(
 
 func ArchiveReaderWithSubRepo(
 	ctx context.Context,
+	db database.DB,
 	checker authz.SubRepoPermissionChecker,
 	repo *types.Repo,
 	options gitserver.ArchiveOptions,
@@ -43,5 +46,5 @@ func ArchiveReaderWithSubRepo(
 			return nil, errors.New("archiveReader invoked for a repo with sub-repo permissions")
 		}
 	}
-	return ArchiveReader(ctx, repo.Name, options)
+	return ArchiveReader(ctx, db, repo.Name, options)
 }

--- a/internal/vcs/git/archive_test.go
+++ b/internal/vcs/git/archive_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
@@ -34,7 +35,7 @@ func TestArchiveReaderForRepoWithSubRepoPermissions(t *testing.T) {
 		Treeish: commitID,
 		Paths:   []string{"."},
 	}
-	if _, err := ArchiveReaderWithSubRepo(context.Background(), checker, repo, opts); err == nil {
+	if _, err := ArchiveReaderWithSubRepo(context.Background(), database.NewMockDB(), checker, repo, opts); err == nil {
 		t.Error("Error should not be null because ArchiveReader is invoked for a repo with sub-repo permissions")
 	}
 }
@@ -63,7 +64,7 @@ func TestArchiveReaderForRepoWithoutSubRepoPermissions(t *testing.T) {
 		Treeish: commitID,
 		Paths:   []string{"."},
 	}
-	readCloser, err := ArchiveReaderWithSubRepo(context.Background(), checker, repo, opts)
+	readCloser, err := ArchiveReaderWithSubRepo(context.Background(), database.NewMockDB(), checker, repo, opts)
 	if err != nil {
 		t.Error("Error should not be thrown because ArchiveReader is invoked for a repo without sub-repo permissions")
 	}

--- a/internal/vcs/git/blame.go
+++ b/internal/vcs/git/blame.go
@@ -11,6 +11,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
@@ -38,13 +39,13 @@ type Hunk struct {
 }
 
 // BlameFile returns Git blame information about a file.
-func BlameFile(ctx context.Context, repo api.RepoName, path string, opt *BlameOptions, checker authz.SubRepoPermissionChecker) ([]*Hunk, error) {
+func BlameFile(ctx context.Context, db database.DB, repo api.RepoName, path string, opt *BlameOptions, checker authz.SubRepoPermissionChecker) ([]*Hunk, error) {
 	span, ctx := ot.StartSpanFromContext(ctx, "Git: BlameFile")
 	span.SetTag("repo", repo)
 	span.SetTag("path", path)
 	span.SetTag("opt", opt)
 	defer span.Finish()
-	return blameFileCmd(ctx, gitserverCmdFunc(repo), path, opt, repo, checker)
+	return blameFileCmd(ctx, gitserverCmdFunc(repo, db), path, opt, repo, checker)
 }
 
 func blameFileCmd(ctx context.Context, command cmdFunc, path string, opt *BlameOptions, repo api.RepoName, checker authz.SubRepoPermissionChecker) ([]*Hunk, error) {

--- a/internal/vcs/git/blame_test.go
+++ b/internal/vcs/git/blame_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 )
 
@@ -63,7 +64,7 @@ func TestRepository_BlameFile(t *testing.T) {
 	}
 
 	for label, test := range tests {
-		newestCommitID, err := ResolveRevision(ctx, test.repo, string(test.opt.NewestCommit), ResolveRevisionOptions{})
+		newestCommitID, err := ResolveRevision(ctx, database.NewMockDB(), test.repo, string(test.opt.NewestCommit), ResolveRevisionOptions{})
 		if err != nil {
 			t.Errorf("%s: ResolveRevision(%q) on base: %s", label, test.opt.NewestCommit, err)
 			continue
@@ -101,7 +102,7 @@ func TestRepository_BlameFile(t *testing.T) {
 func runBlameFileTest(ctx context.Context, t *testing.T, repo api.RepoName, path string, opt *BlameOptions,
 	checker authz.SubRepoPermissionChecker, label string, wantHunks []*Hunk) {
 	t.Helper()
-	hunks, err := BlameFile(ctx, repo, path, opt, checker)
+	hunks, err := BlameFile(ctx, database.NewMockDB(), repo, path, opt, checker)
 	if err != nil {
 		t.Errorf("%s: BlameFile(%s, %+v): %s", label, path, opt, err)
 		return

--- a/internal/vcs/git/blob.go
+++ b/internal/vcs/git/blob.go
@@ -10,6 +10,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/util"
@@ -18,7 +19,7 @@ import (
 
 // ReadFile returns the first maxBytes of the named file at commit. If maxBytes <= 0, the entire
 // file is read. (If you just need to check a file's existence, use Stat, not ReadFile.)
-func ReadFile(ctx context.Context, repo api.RepoName, commit api.CommitID, name string, maxBytes int64, checker authz.SubRepoPermissionChecker) ([]byte, error) {
+func ReadFile(ctx context.Context, db database.DB, repo api.RepoName, commit api.CommitID, name string, maxBytes int64, checker authz.SubRepoPermissionChecker) ([]byte, error) {
 	if Mocks.ReadFile != nil {
 		return Mocks.ReadFile(commit, name)
 	}
@@ -38,7 +39,7 @@ func ReadFile(ctx context.Context, repo api.RepoName, commit api.CommitID, name 
 	}
 
 	name = util.Rel(name)
-	b, err := readFileBytes(ctx, repo, commit, name, maxBytes)
+	b, err := readFileBytes(ctx, db, repo, commit, name, maxBytes)
 	if err != nil {
 		return nil, err
 	}
@@ -47,7 +48,7 @@ func ReadFile(ctx context.Context, repo api.RepoName, commit api.CommitID, name 
 
 // NewFileReader returns an io.ReadCloser reading from the named file at commit.
 // The caller should always close the reader after use
-func NewFileReader(ctx context.Context, repo api.RepoName, commit api.CommitID, name string, checker authz.SubRepoPermissionChecker) (io.ReadCloser, error) {
+func NewFileReader(ctx context.Context, db database.DB, repo api.RepoName, commit api.CommitID, name string, checker authz.SubRepoPermissionChecker) (io.ReadCloser, error) {
 	if Mocks.NewFileReader != nil {
 		return Mocks.NewFileReader(commit, name)
 	}
@@ -63,15 +64,15 @@ func NewFileReader(ctx context.Context, repo api.RepoName, commit api.CommitID, 
 	defer span.Finish()
 
 	name = util.Rel(name)
-	br, err := newBlobReader(ctx, repo, commit, name)
+	br, err := newBlobReader(ctx, db, repo, commit, name)
 	if err != nil {
 		return nil, errors.Wrapf(err, "getting blobReader for %q", name)
 	}
 	return br, nil
 }
 
-func readFileBytes(ctx context.Context, repo api.RepoName, commit api.CommitID, name string, maxBytes int64) ([]byte, error) {
-	br, err := newBlobReader(ctx, repo, commit, name)
+func readFileBytes(ctx context.Context, db database.DB, repo api.RepoName, commit api.CommitID, name string, maxBytes int64) ([]byte, error) {
+	br, err := newBlobReader(ctx, db, repo, commit, name)
 	if err != nil {
 		return nil, err
 	}
@@ -91,6 +92,7 @@ func readFileBytes(ctx context.Context, repo api.RepoName, commit api.CommitID, 
 // blobReader, which should be created using newBlobReader, is a struct that allows
 // us to get a ReadCloser to a specific named file at a specific commit
 type blobReader struct {
+	db     database.DB
 	ctx    context.Context
 	repo   api.RepoName
 	commit api.CommitID
@@ -99,7 +101,7 @@ type blobReader struct {
 	rc     io.ReadCloser
 }
 
-func newBlobReader(ctx context.Context, repo api.RepoName, commit api.CommitID, name string) (*blobReader, error) {
+func newBlobReader(ctx context.Context, db database.DB, repo api.RepoName, commit api.CommitID, name string) (*blobReader, error) {
 	if err := ensureAbsoluteCommit(commit); err != nil {
 		return nil, err
 	}
@@ -112,6 +114,7 @@ func newBlobReader(ctx context.Context, repo api.RepoName, commit api.CommitID, 
 	}
 
 	return &blobReader{
+		db:     db,
 		ctx:    ctx,
 		repo:   repo,
 		commit: commit,
@@ -146,7 +149,7 @@ func (br *blobReader) convertError(err error) error {
 	}
 	if strings.Contains(err.Error(), "fatal: bad object ") {
 		// Could be a git submodule.
-		fi, err := Stat(br.ctx, authz.DefaultSubRepoPermsChecker, br.repo, br.commit, br.name)
+		fi, err := Stat(br.ctx, br.db, authz.DefaultSubRepoPermsChecker, br.repo, br.commit, br.name)
 		if err != nil {
 			return err
 		}

--- a/internal/vcs/git/blob_test.go
+++ b/internal/vcs/git/blob_test.go
@@ -9,11 +9,13 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 )
 
 func TestRead(t *testing.T) {
 	t.Parallel()
 
+	db := database.NewMockDB()
 	const wantData = "abcd\n"
 	repo := MakeGitRepository(t,
 		"echo abcd > file1",
@@ -60,7 +62,7 @@ func TestRead(t *testing.T) {
 			UID: 1,
 		})
 		t.Run(name+"-ReadFile", func(t *testing.T) {
-			data, err := ReadFile(ctx, repo, commitID, test.file, test.maxBytes, nil)
+			data, err := ReadFile(ctx, db, repo, commitID, test.file, test.maxBytes, nil)
 			test.checkFn(t, err, data)
 		})
 		t.Run(name+"-ReadFile-with-sub-repo-permissions-no-op", func(t *testing.T) {
@@ -73,7 +75,7 @@ func TestRead(t *testing.T) {
 				}
 				return authz.None, nil
 			})
-			data, err := ReadFile(ctx, repo, commitID, test.file, test.maxBytes, checker)
+			data, err := ReadFile(ctx, db, repo, commitID, test.file, test.maxBytes, checker)
 			test.checkFn(t, err, data)
 		})
 		t.Run(name+"-ReadFile-with-sub-repo-permissions-filters-file", func(t *testing.T) {
@@ -83,7 +85,7 @@ func TestRead(t *testing.T) {
 			checker.PermissionsFunc.SetDefaultHook(func(ctx context.Context, i int32, content authz.RepoContent) (authz.Perms, error) {
 				return authz.None, nil
 			})
-			data, err := ReadFile(ctx, repo, commitID, test.file, test.maxBytes, checker)
+			data, err := ReadFile(ctx, db, repo, commitID, test.file, test.maxBytes, checker)
 			if err != os.ErrNotExist {
 				t.Errorf("unexpected error reading file: %s", err)
 			}
@@ -113,7 +115,7 @@ func TestRead(t *testing.T) {
 			checker.PermissionsFunc.SetDefaultHook(func(ctx context.Context, i int32, content authz.RepoContent) (authz.Perms, error) {
 				return authz.None, nil
 			})
-			rc, err := NewFileReader(ctx, repo, commitID, test.file, checker)
+			rc, err := NewFileReader(ctx, database.NewMockDB(), repo, commitID, test.file, checker)
 			if err != os.ErrNotExist {
 				t.Fatalf("unexpected error: %s", err)
 			}
@@ -124,7 +126,7 @@ func TestRead(t *testing.T) {
 	}
 
 	t.Run("maxBytes", func(t *testing.T) {
-		data, err := ReadFile(ctx, repo, commitID, "file1", 3, nil)
+		data, err := ReadFile(ctx, db, repo, commitID, "file1", 3, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -137,7 +139,7 @@ func TestRead(t *testing.T) {
 func runNewFileReaderTest(ctx context.Context, t *testing.T, repo api.RepoName, commitID api.CommitID, file string,
 	checker authz.SubRepoPermissionChecker, checkFn func(*testing.T, error, []byte)) {
 	t.Helper()
-	rc, err := NewFileReader(ctx, repo, commitID, file, checker)
+	rc, err := NewFileReader(ctx, database.NewMockDB(), repo, commitID, file, checker)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/vcs/git/commits.go
+++ b/internal/vcs/git/commits.go
@@ -301,7 +301,7 @@ func commitLog(ctx context.Context, db database.DB, repo api.RepoName, opt Commi
 	return filtered, err
 }
 
-func getWrappedCommits(ctx context.Context, db database.DB, repo api.RepoName, opt CommitsOptions) ([]*wrappedCommit, error) {
+func getWrappedCommits(ctx context.Context, _ database.DB, repo api.RepoName, opt CommitsOptions) ([]*wrappedCommit, error) {
 	args, err := commitLogArgs([]string{"log", logFormatWithoutRefs}, opt)
 	if err != nil {
 		return nil, err
@@ -464,7 +464,7 @@ func commitLogArgs(initialArgs []string, opt CommitsOptions) (args []string, err
 }
 
 // commitCount returns the number of commits that would be returned by Commits.
-func commitCount(ctx context.Context, db database.DB, repo api.RepoName, opt CommitsOptions) (uint, error) {
+func commitCount(ctx context.Context, _ database.DB, repo api.RepoName, opt CommitsOptions) (uint, error) {
 	span, ctx := ot.StartSpanFromContext(ctx, "Git: CommitCount")
 	span.SetTag("Opt", opt)
 	defer span.Finish()

--- a/internal/vcs/git/default_branch.go
+++ b/internal/vcs/git/default_branch.go
@@ -5,6 +5,7 @@ import (
 	"context"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
@@ -14,11 +15,11 @@ import (
 //
 // If the repository is empty or currently being cloned, empty values and no
 // error are returned.
-func GetDefaultBranch(ctx context.Context, repo api.RepoName) (refName string, commit api.CommitID, err error) {
+func GetDefaultBranch(ctx context.Context, db database.DB, repo api.RepoName) (refName string, commit api.CommitID, err error) {
 	if Mocks.GetDefaultBranch != nil {
 		return Mocks.GetDefaultBranch(repo)
 	}
-	return getDefaultBranch(ctx, repo, false)
+	return getDefaultBranch(ctx, db, repo, false)
 }
 
 // GetDefaultBranchShort returns the short name of the default branch for the
@@ -27,11 +28,11 @@ func GetDefaultBranch(ctx context.Context, repo api.RepoName) (refName string, c
 //
 // If the repository is empty or currently being cloned, empty values and no
 // error are returned.
-func GetDefaultBranchShort(ctx context.Context, repo api.RepoName) (refName string, commit api.CommitID, err error) {
+func GetDefaultBranchShort(ctx context.Context, db database.DB, repo api.RepoName) (refName string, commit api.CommitID, err error) {
 	if Mocks.GetDefaultBranchShort != nil {
 		return Mocks.GetDefaultBranchShort(repo)
 	}
-	return getDefaultBranch(ctx, repo, true)
+	return getDefaultBranch(ctx, db, repo, true)
 }
 
 // GetDefaultBranch returns the name of the default branch and the commit it's
@@ -39,17 +40,17 @@ func GetDefaultBranchShort(ctx context.Context, repo api.RepoName) (refName stri
 //
 // If the repository is empty or currently being cloned, empty values and no
 // error are returned.
-func getDefaultBranch(ctx context.Context, repo api.RepoName, short bool) (refName string, commit api.CommitID, err error) {
+func getDefaultBranch(ctx context.Context, db database.DB, repo api.RepoName, short bool) (refName string, commit api.CommitID, err error) {
 	args := []string{"symbolic-ref", "HEAD"}
 	if short {
 		args = append(args, "--short")
 	}
-	refBytes, _, exitCode, err := execSafe(ctx, repo, args)
+	refBytes, _, exitCode, err := execSafe(ctx, db, repo, args)
 	refName = string(bytes.TrimSpace(refBytes))
 
 	if err == nil && exitCode == 0 {
 		// Check that our repo is not empty
-		commit, err = ResolveRevision(ctx, repo, "HEAD", ResolveRevisionOptions{NoEnsureRevision: true})
+		commit, err = ResolveRevision(ctx, db, repo, "HEAD", ResolveRevisionOptions{NoEnsureRevision: true})
 	}
 
 	// If we fail to get the default branch due to cloning or being empty, we return nothing.

--- a/internal/vcs/git/exec.go
+++ b/internal/vcs/git/exec.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
@@ -21,7 +22,7 @@ import (
 //
 // execSafe should NOT be exported. We want to limit direct git calls to this
 // package.
-func execSafe(ctx context.Context, repo api.RepoName, params []string) (stdout, stderr []byte, exitCode int, err error) {
+func execSafe(ctx context.Context, db database.DB, repo api.RepoName, params []string) (stdout, stderr []byte, exitCode int, err error) {
 	if Mocks.ExecSafe != nil {
 		return Mocks.ExecSafe(params)
 	}
@@ -52,7 +53,7 @@ func execSafe(ctx context.Context, repo api.RepoName, params []string) (stdout, 
 //
 // execReader should NOT be exported. We want to limit direct git calls to this
 // package.
-func execReader(ctx context.Context, repo api.RepoName, args []string) (io.ReadCloser, error) {
+func execReader(ctx context.Context, db database.DB, repo api.RepoName, args []string) (io.ReadCloser, error) {
 	if Mocks.ExecReader != nil {
 		return Mocks.ExecReader(args)
 	}
@@ -78,7 +79,7 @@ func checkSpecArgSafety(spec string) error {
 	return nil
 }
 
-func gitserverCmdFunc(repo api.RepoName) cmdFunc {
+func gitserverCmdFunc(repo api.RepoName, db database.DB) cmdFunc {
 	return func(args []string) cmd {
 		cmd := gitserver.DefaultClient.Command("git", args...)
 		cmd.Repo = repo

--- a/internal/vcs/git/exec.go
+++ b/internal/vcs/git/exec.go
@@ -22,7 +22,7 @@ import (
 //
 // execSafe should NOT be exported. We want to limit direct git calls to this
 // package.
-func execSafe(ctx context.Context, db database.DB, repo api.RepoName, params []string) (stdout, stderr []byte, exitCode int, err error) {
+func execSafe(ctx context.Context, _ database.DB, repo api.RepoName, params []string) (stdout, stderr []byte, exitCode int, err error) {
 	if Mocks.ExecSafe != nil {
 		return Mocks.ExecSafe(params)
 	}
@@ -53,7 +53,7 @@ func execSafe(ctx context.Context, db database.DB, repo api.RepoName, params []s
 //
 // execReader should NOT be exported. We want to limit direct git calls to this
 // package.
-func execReader(ctx context.Context, db database.DB, repo api.RepoName, args []string) (io.ReadCloser, error) {
+func execReader(ctx context.Context, _ database.DB, repo api.RepoName, args []string) (io.ReadCloser, error) {
 	if Mocks.ExecReader != nil {
 		return Mocks.ExecReader(args)
 	}
@@ -79,7 +79,7 @@ func checkSpecArgSafety(spec string) error {
 	return nil
 }
 
-func gitserverCmdFunc(repo api.RepoName, db database.DB) cmdFunc {
+func gitserverCmdFunc(repo api.RepoName, _ database.DB) cmdFunc {
 	return func(args []string) cmd {
 		cmd := gitserver.DefaultClient.Command("git", args...)
 		cmd.Repo = repo

--- a/internal/vcs/git/exec_test.go
+++ b/internal/vcs/git/exec_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"testing"
+
+	"github.com/sourcegraph/sourcegraph/internal/database"
 )
 
 func TestExecSafe(t *testing.T) {
@@ -55,7 +57,7 @@ func TestExecSafe(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(fmt.Sprint(test.args), func(t *testing.T) {
-			stdout, stderr, exitCode, err := execSafe(context.Background(), repo, test.args)
+			stdout, stderr, exitCode, err := execSafe(context.Background(), database.NewMockDB(), repo, test.args)
 			if err == nil && test.wantError {
 				t.Errorf("got error %v, want error %v", err, test.wantError)
 			}

--- a/internal/vcs/git/merge_base.go
+++ b/internal/vcs/git/merge_base.go
@@ -6,13 +6,14 @@ import (
 	"fmt"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 // MergeBase returns the merge base commit for the specified commits.
-func MergeBase(ctx context.Context, repo api.RepoName, a, b api.CommitID) (api.CommitID, error) {
+func MergeBase(ctx context.Context, db database.DB, repo api.RepoName, a, b api.CommitID) (api.CommitID, error) {
 	if Mocks.MergeBase != nil {
 		return Mocks.MergeBase(repo, a, b)
 	}

--- a/internal/vcs/git/merge_base_test.go
+++ b/internal/vcs/git/merge_base_test.go
@@ -5,11 +5,13 @@ import (
 	"testing"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 )
 
 func TestMerger_MergeBase(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
+	db := database.NewMockDB()
 
 	// TODO(sqs): implement for hg
 	// TODO(sqs): make a more complex test case
@@ -42,25 +44,25 @@ func TestMerger_MergeBase(t *testing.T) {
 	}
 
 	for label, test := range tests {
-		a, err := ResolveRevision(ctx, test.repo, test.a, ResolveRevisionOptions{})
+		a, err := ResolveRevision(ctx, db, test.repo, test.a, ResolveRevisionOptions{})
 		if err != nil {
 			t.Errorf("%s: ResolveRevision(%q) on a: %s", label, test.a, err)
 			continue
 		}
 
-		b, err := ResolveRevision(ctx, test.repo, test.b, ResolveRevisionOptions{})
+		b, err := ResolveRevision(ctx, db, test.repo, test.b, ResolveRevisionOptions{})
 		if err != nil {
 			t.Errorf("%s: ResolveRevision(%q) on b: %s", label, test.b, err)
 			continue
 		}
 
-		want, err := ResolveRevision(ctx, test.repo, test.wantMergeBase, ResolveRevisionOptions{})
+		want, err := ResolveRevision(ctx, db, test.repo, test.wantMergeBase, ResolveRevisionOptions{})
 		if err != nil {
 			t.Errorf("%s: ResolveRevision(%q) on wantMergeBase: %s", label, test.wantMergeBase, err)
 			continue
 		}
 
-		mb, err := MergeBase(ctx, test.repo, a, b)
+		mb, err := MergeBase(ctx, db, test.repo, a, b)
 		if err != nil {
 			t.Errorf("%s: MergeBase(%s, %s): %s", label, a, b, err)
 			continue

--- a/internal/vcs/git/refs.go
+++ b/internal/vcs/git/refs.go
@@ -202,7 +202,7 @@ func ListBranches(ctx context.Context, db database.DB, repo api.RepoName, opt Br
 
 // branches runs the `git branch` command followed by the given arguments and
 // returns the list of branches if successful.
-func branches(ctx context.Context, db database.DB, repo api.RepoName, args ...string) ([]string, error) {
+func branches(ctx context.Context, _ database.DB, repo api.RepoName, args ...string) ([]string, error) {
 	cmd := gitserver.DefaultClient.Command("git", append([]string{"branch"}, args...)...)
 	cmd.Repo = repo
 	out, err := cmd.Output(ctx)
@@ -317,7 +317,7 @@ type Ref struct {
 	CommitID api.CommitID
 }
 
-func showRef(ctx context.Context, db database.DB, repo api.RepoName, args ...string) ([]Ref, error) {
+func showRef(ctx context.Context, _ database.DB, repo api.RepoName, args ...string) ([]Ref, error) {
 	cmd := gitserver.DefaultClient.Command("git", "show-ref")
 	cmd.Args = append(cmd.Args, args...)
 	cmd.Repo = repo

--- a/internal/vcs/git/refs_test.go
+++ b/internal/vcs/git/refs_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 )
 
@@ -41,7 +42,7 @@ func testBranches(t *testing.T, gitCommands []string, wantBranches []*Branch, op
 	t.Helper()
 
 	repo := MakeGitRepository(t, gitCommands...)
-	gotBranches, err := ListBranches(context.Background(), repo, options)
+	gotBranches, err := ListBranches(context.Background(), database.NewMockDB(), repo, options)
 	require.Nil(t, err)
 
 	sort.Sort(Branches(wantBranches))
@@ -98,7 +99,7 @@ func TestRepository_Branches_MergedInto(t *testing.T) {
 	repo := MakeGitRepository(t, gitCommands...)
 	wantBranches := gitBranches
 	for branch, mergedInto := range wantBranches {
-		branches, err := ListBranches(context.Background(), repo, BranchesOptions{MergedInto: branch})
+		branches, err := ListBranches(context.Background(), database.NewMockDB(), repo, BranchesOptions{MergedInto: branch})
 		require.Nil(t, err)
 		if diff := cmp.Diff(mergedInto, branches); diff != "" {
 			t.Fatalf("branch mismatch (-want +got):\n%s", diff)
@@ -126,7 +127,7 @@ func TestRepository_Branches_ContainsCommit(t *testing.T) {
 	repo := MakeGitRepository(t, gitCommands...)
 	commitToWantBranches := gitWantBranches
 	for commit, wantBranches := range commitToWantBranches {
-		branches, err := ListBranches(context.Background(), repo, BranchesOptions{ContainsCommit: commit})
+		branches, err := ListBranches(context.Background(), database.NewMockDB(), repo, BranchesOptions{ContainsCommit: commit})
 		require.Nil(t, err)
 
 		sort.Sort(Branches(branches))
@@ -216,7 +217,7 @@ func TestRepository_ListTags(t *testing.T) {
 		{Name: "t2", CommitID: "ea167fe3d76b1e5fd3ed8ca44cbd2fe3897684f8", CreatorDate: MustParseTime(time.RFC3339, "2006-01-02T15:04:05Z")},
 	}
 
-	tags, err := ListTags(context.Background(), repo)
+	tags, err := ListTags(context.Background(), database.NewMockDB(), repo)
 	require.Nil(t, err)
 
 	sort.Sort(Tags(tags))

--- a/internal/vcs/git/revisions.go
+++ b/internal/vcs/git/revisions.go
@@ -9,6 +9,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
@@ -62,7 +63,7 @@ var resolveRevisionCounter = promauto.NewCounterVec(prometheus.CounterOpts{
 // * Commit does not exist: gitdomain.RevisionNotFoundError
 // * Empty repository: gitdomain.RevisionNotFoundError
 // * Other unexpected errors.
-func ResolveRevision(ctx context.Context, repo api.RepoName, spec string, opt ResolveRevisionOptions) (api.CommitID, error) {
+func ResolveRevision(ctx context.Context, db database.DB, repo api.RepoName, spec string, opt ResolveRevisionOptions) (api.CommitID, error) {
 	if Mocks.ResolveRevision != nil {
 		return Mocks.ResolveRevision(spec, opt)
 	}

--- a/internal/vcs/git/revisions_test.go
+++ b/internal/vcs/git/revisions_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
@@ -43,7 +44,7 @@ func TestRepository_ResolveBranch(t *testing.T) {
 	}
 
 	for label, test := range tests {
-		commitID, err := ResolveRevision(context.Background(), test.repo, test.branch, ResolveRevisionOptions{})
+		commitID, err := ResolveRevision(context.Background(), database.NewMockDB(), test.repo, test.branch, ResolveRevisionOptions{})
 		if err != nil {
 			t.Errorf("%s: ResolveRevision: %s", label, err)
 			continue
@@ -74,7 +75,7 @@ func TestRepository_ResolveBranch_error(t *testing.T) {
 	}
 
 	for label, test := range tests {
-		commitID, err := ResolveRevision(context.Background(), test.repo, test.branch, ResolveRevisionOptions{})
+		commitID, err := ResolveRevision(context.Background(), database.NewMockDB(), test.repo, test.branch, ResolveRevisionOptions{})
 		if !test.wantErr(err) {
 			t.Errorf("%s: ResolveRevision: %s", label, err)
 			continue
@@ -106,7 +107,7 @@ func TestRepository_ResolveTag(t *testing.T) {
 	}
 
 	for label, test := range tests {
-		commitID, err := ResolveRevision(context.Background(), test.repo, test.tag, ResolveRevisionOptions{})
+		commitID, err := ResolveRevision(context.Background(), database.NewMockDB(), test.repo, test.tag, ResolveRevisionOptions{})
 		if err != nil {
 			t.Errorf("%s: ResolveRevision: %s", label, err)
 			continue
@@ -137,7 +138,7 @@ func TestRepository_ResolveTag_error(t *testing.T) {
 	}
 
 	for label, test := range tests {
-		commitID, err := ResolveRevision(context.Background(), test.repo, test.tag, ResolveRevisionOptions{})
+		commitID, err := ResolveRevision(context.Background(), database.NewMockDB(), test.repo, test.tag, ResolveRevisionOptions{})
 		if !test.wantErr(err) {
 			t.Errorf("%s: ResolveRevision: %s", label, err)
 			continue

--- a/internal/vcs/git/shortlog.go
+++ b/internal/vcs/git/shortlog.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
@@ -33,7 +34,7 @@ func (p *PersonCount) String() string {
 }
 
 // ShortLog returns the per-author commit statistics of the repo.
-func ShortLog(ctx context.Context, repo api.RepoName, opt ShortLogOptions) ([]*PersonCount, error) {
+func ShortLog(ctx context.Context, db database.DB, repo api.RepoName, opt ShortLogOptions) ([]*PersonCount, error) {
 	span, ctx := ot.StartSpanFromContext(ctx, "Git: ShortLog")
 	span.SetTag("Opt", opt)
 	defer span.Finish()

--- a/internal/vcs/git/tree.go
+++ b/internal/vcs/git/tree.go
@@ -230,7 +230,7 @@ func lsTree(
 	return entries, nil
 }
 
-func lsTreeUncached(ctx context.Context, db database.DB, repo api.RepoName, commit api.CommitID, path string, recurse bool) ([]fs.FileInfo, error) {
+func lsTreeUncached(ctx context.Context, _ database.DB, repo api.RepoName, commit api.CommitID, path string, recurse bool) ([]fs.FileInfo, error) {
 	if err := ensureAbsoluteCommit(commit); err != nil {
 		return nil, err
 	}

--- a/monitoring/definitions/searcher.go
+++ b/monitoring/definitions/searcher.go
@@ -41,6 +41,7 @@ func Searcher() *monitoring.Container {
 				},
 			},
 
+			shared.NewDatabaseConnectionsMonitoringGroup(containerName),
 			shared.NewFrontendInternalAPIErrorResponseMonitoringGroup(containerName, monitoring.ObservableOwnerSearchCore, nil),
 			shared.NewContainerMonitoringGroup(containerName, monitoring.ObservableOwnerSearchCore, nil),
 			shared.NewProvisioningIndicatorsGroup(containerName, monitoring.ObservableOwnerSearchCore, nil),


### PR DESCRIPTION
**Please check me if I accidentally changed any remaining `dbutil.DB` code usage to `database.DB` -- that was not intended.**

This PR propagates DB connection to all necessary places where `gitserver.Client` should be instantiated.

In further PR `gitserver.DefaultClient` calls will be replaced with `gitserver.NewClient` with added `database.DB` connection. Current PR makes all the necessary preparations for that.

Part of https://github.com/sourcegraph/sourcegraph/issues/32315

## Test plan
Check that no tests are broken
<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


