### PR TITLE
Community search contexts: Fix overflow

### DIFF
--- a/client/web/src/search/panels/HomePanels.module.scss
+++ b/client/web/src/search/panels/HomePanels.module.scss
@@ -7,9 +7,14 @@
     height: 15rem;
 }
 
-.tab-panel {
+.tabs {
     display: flex;
     flex-direction: column;
     position: relative;
     height: 100%;
+}
+
+.tab-panels {
+    overflow-y: auto;
+    overflow-x: hidden;
 }

--- a/client/web/src/search/panels/HomePanels.tsx
+++ b/client/web/src/search/panels/HomePanels.tsx
@@ -70,12 +70,12 @@ const CollaboratorsTabPanel: React.FunctionComponent<Props> = (props: Props) => 
 
     return (
         <div className={classNames('col-lg-5', styles.panel)}>
-            <Tabs defaultIndex={persistedTabIndex} onChange={setPersistedTabIndex} className={styles.tabPanel}>
+            <Tabs defaultIndex={persistedTabIndex} onChange={setPersistedTabIndex} className={styles.tabs}>
                 <TabList>
                     <Tab>{props.isSourcegraphDotCom ? 'Community search contexts' : 'Saved searches'}</Tab>
                     <Tab>Invite colleagues</Tab>
                 </TabList>
-                <TabPanels className="h-100">
+                <TabPanels className={classNames('h-100', styles.tabPanels)}>
                     <TabPanel className="h-100">
                         {props.isSourcegraphDotCom ? (
                             <CommunitySearchContextsPanel {...props} insideTabPanel={true} />


### PR DESCRIPTION
Makes the overflow consistent with other `HomePanels`

Before:
![image](https://user-images.githubusercontent.com/9516420/158978863-a2db28b0-d596-46b6-9c22-ab8fe832eee4.png)

After:
![image](https://user-images.githubusercontent.com/9516420/158978955-cd493833-5021-4133-b7b4-38dc852b0a09.png)


## Test plan

1. Ran the application locally, compared before and after
2. Storybook UI tests

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


