### PR TITLE
[cloud] Add tracking to orgs open beta pages

### DIFF
--- a/client/web/src/org/invitations/OrgInvitationPage.tsx
+++ b/client/web/src/org/invitations/OrgInvitationPage.tsx
@@ -107,11 +107,19 @@ export const OrgInvitationPage: React.FunctionComponent<Props> = ({ authenticate
     })
 
     const acceptInvitation = useCallback(async () => {
-        eventLogger.log('OrganizationInvitationAcceptClicked', {
-            organizationId: orgId,
-            invitationId: data?.id,
-            willVerifyEmail,
-        })
+        eventLogger.log(
+            'OrganizationInvitationAcceptClicked',
+            {
+                organizationId: orgId,
+                invitationId: data?.id,
+                willVerifyEmail,
+            },
+            {
+                organizationId: orgId,
+                invitationId: data?.id,
+                willVerifyEmail,
+            }
+        )
         try {
             await respondToInvitation({
                 variables: {
@@ -119,9 +127,17 @@ export const OrgInvitationPage: React.FunctionComponent<Props> = ({ authenticate
                     response: OrganizationInvitationResponseType.ACCEPT,
                 },
             })
-            eventLogger.log('OrganizationInvitationAcceptSucceeded', { organizationId: orgId, invitationId: data?.id })
+            eventLogger.log(
+                'OrganizationInvitationAcceptSucceeded',
+                { organizationId: orgId, invitationId: data?.id },
+                { organizationId: orgId, invitationId: data?.id }
+            )
         } catch {
-            eventLogger.log('OrganizationInvitationAcceptFailed', { organizationId: orgId, invitationId: data?.id })
+            eventLogger.log(
+                'OrganizationInvitationAcceptFailed',
+                { organizationId: orgId, invitationId: data?.id },
+                { organizationId: orgId, invitationId: data?.id }
+            )
             return
         }
 
@@ -131,11 +147,19 @@ export const OrgInvitationPage: React.FunctionComponent<Props> = ({ authenticate
     }, [data?.id, history, orgId, orgName, respondToInvitation, willVerifyEmail])
 
     const declineInvitation = useCallback(async () => {
-        eventLogger.log('OrganizationInvitationDeclineClicked', {
-            organizationId: orgId,
-            invitationId: data?.id,
-            willVerifyEmail,
-        })
+        eventLogger.log(
+            'OrganizationInvitationDeclineClicked',
+            {
+                organizationId: orgId,
+                invitationId: data?.id,
+                willVerifyEmail,
+            },
+            {
+                organizationId: orgId,
+                invitationId: data?.id,
+                willVerifyEmail,
+            }
+        )
         try {
             await respondToInvitation({
                 variables: {
@@ -143,9 +167,17 @@ export const OrgInvitationPage: React.FunctionComponent<Props> = ({ authenticate
                     response: OrganizationInvitationResponseType.REJECT,
                 },
             })
-            eventLogger.log('OrganizationInvitationDeclineSucceeded', { organizationId: orgId, invitationId: data?.id })
+            eventLogger.log(
+                'OrganizationInvitationDeclineSucceeded',
+                { organizationId: orgId, invitationId: data?.id },
+                { organizationId: orgId, invitationId: data?.id }
+            )
         } catch {
-            eventLogger.log('OrganizationInvitationDeclineFailed', { organizationId: orgId, invitationId: data?.id })
+            eventLogger.log(
+                'OrganizationInvitationDeclineFailed',
+                { organizationId: orgId, invitationId: data?.id },
+                { organizationId: orgId, invitationId: data?.id }
+            )
         }
 
         history.push(userURL(authenticatedUser.username))

--- a/client/web/src/org/members/InviteMemberModal.tsx
+++ b/client/web/src/org/members/InviteMemberModal.tsx
@@ -60,7 +60,11 @@ export const InviteMemberModal: React.FunctionComponent<InviteMemberModalProps> 
             return
         }
 
-        eventLogger.log('InviteOrganizationMemberClicked', { organizationId: orgId, isEmail })
+        eventLogger.log(
+            'InviteOrganizationMemberClicked',
+            { organizationId: orgId, isEmail },
+            { organizationId: orgId, isEmail }
+        )
         try {
             await inviteUserToOrganization({
                 variables: {
@@ -69,16 +73,16 @@ export const InviteMemberModal: React.FunctionComponent<InviteMemberModalProps> 
                     email: isEmail ? userNameOrEmail : null,
                 },
             })
-            eventLogger.log('InviteOrganizationMemberSucceeded', { organizationId: orgId })
+            eventLogger.log('InviteOrganizationMemberSucceeded', { organizationId: orgId }, { organizationId: orgId })
         } catch {
-            eventLogger.log('InviteOrganizationMemberFailed', { organizationId: orgId })
+            eventLogger.log('InviteOrganizationMemberFailed', { organizationId: orgId }, { organizationId: orgId })
         }
     }, [userNameOrEmail, orgId, inviteUserToOrganization, isEmail])
 
     const debounceInviteUser = debounce(inviteUser, 500, { leading: true })
 
     const dismissWithLogging = useCallback(() => {
-        eventLogger.log('OrganizationInviteModalDismissed', { organizationId: orgId })
+        eventLogger.log('OrganizationInviteModalDismissed', { organizationId: orgId }, { organizationId: orgId })
         onDismiss()
     }, [onDismiss, orgId])
 
@@ -162,7 +166,7 @@ export const InviteMemberModalHandler: React.FunctionComponent<InviteMemberModal
     const onInviteClick = useCallback(() => {
         setModalOpened(true)
         if (eventLoggerEventName) {
-            eventLogger.log(eventLoggerEventName, { organizationId: orgId })
+            eventLogger.log(eventLoggerEventName, { organizationId: orgId }, { organizationId: orgId })
         }
     }, [setModalOpened, orgId, eventLoggerEventName])
 

--- a/client/web/src/org/members/OrgMembersListPage.tsx
+++ b/client/web/src/org/members/OrgMembersListPage.tsx
@@ -81,13 +81,13 @@ const MemberItem: React.FunctionComponent<MemberItemProps> = ({
     >(ORG_MEMBER_REMOVE_MUTATION)
 
     const onRemoveClick = useCallback(async () => {
-        eventLogger.log('RemoveFromOrganizationClicked', { organizationId: orgId })
+        eventLogger.log('RemoveFromOrganizationClicked', { organizationId: orgId }, { organizationId: orgId })
         if (window.confirm(isSelf ? 'Leave the organization?' : `Remove the user ${member.username}?`)) {
-            eventLogger.log('RemoveFromOrganizationConfirmed', { organizationId: orgId })
+            eventLogger.log('RemoveFromOrganizationConfirmed', { organizationId: orgId }, { organizationId: orgId })
             await removeUserFromOrganization({ variables: { organization: orgId, user: member.id } })
             onMemberRemoved(member.username)
         } else {
-            eventLogger.log('RemoveFromOrganizationDismissed', { organizationId: orgId })
+            eventLogger.log('RemoveFromOrganizationDismissed', { organizationId: orgId }, { organizationId: orgId })
         }
     }, [isSelf, member.username, removeUserFromOrganization, onMemberRemoved, member.id, orgId])
 
@@ -187,7 +187,7 @@ export const OrgMembersListPage: React.FunctionComponent<Props> = ({
     const setPageWithEventLogging = useCallback(
         (index: number) => {
             setPage(index)
-            eventLogger.log('MemberListPaginationClicked', { organizationId: org.id })
+            eventLogger.log('MemberListPaginationClicked', { organizationId: org.id }, { organizationId: orgId })
         },
         [setPage, org.id]
     )

--- a/client/web/src/org/members/OrgMembersListPage.tsx
+++ b/client/web/src/org/members/OrgMembersListPage.tsx
@@ -187,7 +187,7 @@ export const OrgMembersListPage: React.FunctionComponent<Props> = ({
     const setPageWithEventLogging = useCallback(
         (index: number) => {
             setPage(index)
-            eventLogger.log('MemberListPaginationClicked', { organizationId: org.id }, { organizationId: orgId })
+            eventLogger.log('MemberListPaginationClicked', { organizationId: org.id }, { organizationId: org.id })
         },
         [setPage, org.id]
     )

--- a/client/web/src/org/members/OrgPendingInvites.tsx
+++ b/client/web/src/org/members/OrgPendingInvites.tsx
@@ -120,43 +120,43 @@ const InvitationItem: React.FunctionComponent<InvitationItemProps> = ({
 
     const onCopyInviteLink = useCallback(() => {
         copy(`${window.location.origin}${invite.respondURL}`)
-        eventLogger.log('OrganizationInviteCopied', { organizationId: orgId })
+        eventLogger.log('OrganizationInviteCopied', { organizationId: orgId }, { organizationId: orgId })
         alert('invite url copied to clipboard!')
     }, [invite.respondURL, orgId])
 
     const onRevokeInvite = useCallback(async () => {
-        eventLogger.log('OrganizationInviteRevokeClicked', { organizationId: orgId })
+        eventLogger.log('OrganizationInviteRevokeClicked', { organizationId: orgId }, { organizationId: orgId })
 
         const inviteToText = invite.recipient ? invite.recipient.username : (invite.recipientEmail as string)
         if (window.confirm(`Revoke invitation from ${inviteToText}?`)) {
-            eventLogger.log('OrganizationInviteRevokeConfirmed', { organizationId: orgId })
+            eventLogger.log('OrganizationInviteRevokeConfirmed', { organizationId: orgId }, { organizationId: orgId })
             try {
                 await revokeInvite({ variables: { id: invite.id } })
-                eventLogger.log('OrgRevokeInvitation', { id: invite.id })
+                eventLogger.log('OrgRevokeInvitation', { id: invite.id }, { id: invite.id })
                 onInviteResentRevoked(inviteToText, true)
             } catch {
-                eventLogger.log('OrgRevokeInvitationError', { id: invite.id })
+                eventLogger.log('OrgRevokeInvitationError', { id: invite.id }, { id: invite.id })
             }
         } else {
-            eventLogger.log('OrganizationInviteRevokeDismissed', { organizationId: orgId })
+            eventLogger.log('OrganizationInviteRevokeDismissed', { organizationId: orgId }, { organizationId: orgId })
         }
     }, [revokeInvite, onInviteResentRevoked, invite.id, invite.recipientEmail, invite.recipient, orgId])
 
     const onResendInvite = useCallback(async () => {
-        eventLogger.log('OrganizationInviteResendClicked', { organizationId: orgId })
+        eventLogger.log('OrganizationInviteResendClicked', { organizationId: orgId }, { organizationId: orgId })
 
         const inviteToText = invite.recipient ? invite.recipient.username : (invite.recipientEmail as string)
         if (window.confirm(`Resend invitation to ${inviteToText}?`)) {
-            eventLogger.log('OrganizationInviteResendConfirmed', { organizationId: orgId })
+            eventLogger.log('OrganizationInviteResendConfirmed', { organizationId: orgId }, { organizationId: orgId })
             try {
                 await resendInvite({ variables: { id: invite.id } })
-                eventLogger.logViewEvent('OrgResendInvitation', { id: invite.id })
+                eventLogger.log('OrgResendInvitation', { id: invite.id }, { id: invite.id })
                 onInviteResentRevoked(inviteToText, false)
             } catch {
-                eventLogger.logViewEvent('OrgResendInvitationError', { id: invite.id })
+                eventLogger.log('OrgResendInvitationError', { id: invite.id }, { id: invite.id })
             }
         } else {
-            eventLogger.log('OrganizationInviteResendDismissed', { organizationId: orgId })
+            eventLogger.log('OrganizationInviteResendDismissed', { organizationId: orgId }, { organizationId: orgId })
         }
     }, [orgId, invite.recipient, invite.recipientEmail, invite.id, resendInvite, onInviteResentRevoked])
 

--- a/client/web/src/org/members/SearchUserAutocomplete.tsx
+++ b/client/web/src/org/members/SearchUserAutocomplete.tsx
@@ -166,7 +166,11 @@ export const AutocompleteSearchUsers: React.FunctionComponent<AutocompleteSearch
 
     const onSelectUser = useCallback(
         (user: IUserItem) => {
-            eventLogger.logViewEvent('InviteAutocompleteUserSelected', { organizationId: orgId, user: user.username })
+            eventLogger.log(
+                'InviteAutocompleteUserSelected',
+                { organizationId: orgId, user: user.username },
+                { organizationId: orgId }
+            )
             setOpenResults(false)
             setUsernameOrEmail(user.username)
         },

--- a/client/web/src/org/openBeta/GettingStarted.tsx
+++ b/client/web/src/org/openBeta/GettingStarted.tsx
@@ -148,13 +148,26 @@ const Step: React.FunctionComponent<{
     </li>
 )
 
-const InviteLink: React.FunctionComponent<{ orgName: string; membersCount: number }> = ({ membersCount, orgName }) => {
+const InviteLink: React.FunctionComponent<{ orgName: string; orgId: string; membersCount: number }> = ({
+    membersCount,
+    orgId,
+    orgName,
+}) => {
     const preText = membersCount === 1 ? 'It’s just you so far! ' : null
     const linkText = membersCount === 1 ? 'Invite your teammates' : 'Invite the rest of your teammates'
     return (
         <small>
             {preText}
-            <Link to={`/organizations/${orgName}/settings/members/pending-invites?openInviteModal=1&openBetaBanner=1`}>
+            <Link
+                to={`/organizations/${orgName}/settings/members/pending-invites?openInviteModal=1&openBetaBanner=1`}
+                onClick={() =>
+                    eventLogger.log(
+                        'OrganizationGetStartedInviteTeammatesCTAClicked',
+                        { organizationId: orgId },
+                        { organizationId: orgId }
+                    )
+                }
+            >
                 {linkText}
             </Link>
         </small>
@@ -213,8 +226,8 @@ export const OpenBetaGetStartedPage: React.FunctionComponent<Props> = ({
         (queryResult && !showGetStartPage(queryResult, org.name, openBetaEnabled, isSourcegraphDotCom))
 
     useEffect(() => {
-        eventLogger.log('OpenBeta getting started')
-    }, [])
+        eventLogger.logViewEvent('OrganizationGetStarted', { organizationId: org.id })
+    }, [org.id])
 
     useEffect(() => {
         if (queryResult && !loading && !allowSearch) {
@@ -266,12 +279,26 @@ export const OpenBetaGetStartedPage: React.FunctionComponent<Props> = ({
                                             ? undefined
                                             : `/organizations/${org.name}/settings/code-hosts`
                                     }
+                                    onClick={() =>
+                                        eventLogger.log(
+                                            'OrganizationGetStartedCodeHostsClicked',
+                                            { organizationId: org.id },
+                                            { organizationId: org.id }
+                                        )
+                                    }
                                 />
                                 <Step
                                     label="Choose repositories to sync with Sourcegraph"
                                     complete={repoCompleted}
                                     textMuted={repoCompleted}
                                     to={repoCompleted ? undefined : `/organizations/${org.name}/settings/repositories`}
+                                    onClick={() =>
+                                        eventLogger.log(
+                                            'OrganizationGetStartedChooseRepositoriesClicked',
+                                            { organizationId: org.id },
+                                            { organizationId: org.id }
+                                        )
+                                    }
                                 />
                                 <Step
                                     label="Invite your teammates"
@@ -282,11 +309,25 @@ export const OpenBetaGetStartedPage: React.FunctionComponent<Props> = ({
                                             ? undefined
                                             : `/organizations/${org.name}/settings/members/pending-invites?openInviteModal=1&openBetaBanner=1`
                                     }
+                                    onClick={() =>
+                                        eventLogger.log(
+                                            'OrganizationGetStartedInviteTeammatesClicked',
+                                            { organizationId: org.id },
+                                            { organizationId: org.id }
+                                        )
+                                    }
                                 />
                                 <Step
                                     label={`Search across ${org.displayName || org.name}’s code`}
                                     complete={getSearchStepStatus(org.name) === 'complete'}
-                                    onClick={completeSearchStep}
+                                    onClick={() => {
+                                        eventLogger.log(
+                                            'OrganizationGetStartedSearchClicked',
+                                            { organizationId: org.id },
+                                            { organizationId: org.id }
+                                        )
+                                        completeSearchStep()
+                                    }}
                                     to={
                                         allowSearch ? `/search?q=context:%40${org.name}&patternType=literal` : undefined
                                     }
@@ -332,7 +373,11 @@ export const OpenBetaGetStartedPage: React.FunctionComponent<Props> = ({
                                         </div>
                                     )}
                                 </div>
-                                <InviteLink orgName={org.name} membersCount={queryResult.membersSummary.membersCount} />
+                                <InviteLink
+                                    orgName={org.name}
+                                    orgId={org.id}
+                                    membersCount={queryResult.membersSummary.membersCount}
+                                />
                             </div>
                         </div>
                     </div>

--- a/client/web/src/org/openBeta/JoinOpenBetaPage.tsx
+++ b/client/web/src/org/openBeta/JoinOpenBetaPage.tsx
@@ -75,8 +75,12 @@ export const JoinOpenBetaPage: React.FunctionComponent<Props> = ({ authenticated
         otherPlanValid
 
     useEffect(() => {
-        eventLogger.log('JoinOpenBetaLoaded')
-    }, [])
+        eventLogger.log(
+            'CloudOpenBetaEnrollmentStarted',
+            { userId: authenticatedUser.id },
+            { userId: authenticatedUser.id }
+        )
+    }, [authenticatedUser.id])
 
     useEffect(() => {
         setOtherRepo(undefined)
@@ -100,6 +104,7 @@ export const JoinOpenBetaPage: React.FunctionComponent<Props> = ({ authenticated
     }
 
     const onCancelClick = (): void => {
+        eventLogger.log('CloudOpenBetaEnrollmentCancelled')
         history.push(`/users/${authenticatedUser.username}/settings/organizations`)
     }
 
@@ -123,7 +128,7 @@ export const JoinOpenBetaPage: React.FunctionComponent<Props> = ({ authenticated
     const onSubmit = useCallback<React.FormEventHandler<HTMLFormElement>>(
         async event => {
             event.preventDefault()
-            eventLogger.log('JoinOpenBetaAnswers')
+            eventLogger.log('OpenBetaEnrollmentContinueClicked')
             if (!event.currentTarget.checkValidity() || !isValidForm) {
                 return
             }
@@ -140,10 +145,10 @@ export const JoinOpenBetaPage: React.FunctionComponent<Props> = ({ authenticated
                     ? (result.data as { addOrgsOpenBetaStats: string }).addOrgsOpenBetaStats
                     : INVALID_BETA_ID_KEY
                 localStorage.setItem(OPEN_BETA_ID_KEY, openBetaId)
-                eventLogger.log('JoinOpenBetaAnswersOK')
+                eventLogger.log('OpenBetaEnrollmentSucceeded', { openBetaId }, { openBetaId })
                 history.push(`/organizations/joinopenbeta/neworg/${openBetaId}`)
             } catch {
-                eventLogger.log('JoinOpenBetaAnswersFailed')
+                eventLogger.log('OpenBetaEnrollmentFailed')
             }
         },
         [

--- a/client/web/src/user/settings/openBetaOrgs/OrganizationsList.tsx
+++ b/client/web/src/user/settings/openBetaOrgs/OrganizationsList.tsx
@@ -54,7 +54,19 @@ const OrgItem: React.FunctionComponent<OrgItemProps> = ({ org }) => (
                 <span className="text-muted">Admin</span>
             </div>
             <div>
-                <ButtonLink className={styles.orgSettings} variant="secondary" to={org.settingsURL as string} size="sm">
+                <ButtonLink
+                    className={styles.orgSettings}
+                    variant="secondary"
+                    to={org.settingsURL as string}
+                    size="sm"
+                    onClick={() =>
+                        eventLogger.log(
+                            'UserOrganizationSettingsClicked',
+                            { organizationId: org.id },
+                            { organizationId: org.id }
+                        )
+                    }
+                >
                     Settings
                 </ButtonLink>
             </div>
@@ -79,12 +91,21 @@ export const OrganizationsListPage: React.FunctionComponent<OrganizationsListPro
     const orgs = authenticatedUser.organizations.nodes
     const hasOrgs = orgs.length > 0
 
+    useEffect(() => {
+        eventLogger.logViewEvent('YourOrganizations', { userId: authenticatedUser.id })
+    }, [authenticatedUser.id])
+
     return (
         <div className="org-list-page">
             <div className="d-flex flex-0 justify-content-end align-items-center mb-3 flex-wrap">
                 <PageHeader path={[{ text: 'Organizations' }]} headingElement="h2" className="flex-1" />
 
-                <ButtonLink variant="secondary" to="/organizations/joinopenbeta" size="sm">
+                <ButtonLink
+                    variant="secondary"
+                    to="/organizations/joinopenbeta"
+                    size="sm"
+                    onClick={() => eventLogger.log('CreateOrganizationButtonClicked')}
+                >
                     Create organization
                 </ButtonLink>
             </div>
@@ -102,8 +123,14 @@ export const OrganizationsListPage: React.FunctionComponent<OrganizationsListPro
                     <div className="d-flex flex-0 flex-column justify-content-center align-items-center">
                         <h3>Start searching with your team on Sourcegraph</h3>
                         <div>Product copy here that needs to be written still, this is a placeholder.</div>
-                        <ButtonLink variant="primary" to="/organizations/joinopenbeta" size="sm" className="mt-3">
-                            Create your organization
+                        <ButtonLink
+                            variant="primary"
+                            to="/organizations/joinopenbeta"
+                            size="sm"
+                            className="mt-3"
+                            onClick={() => eventLogger.log('CreateFirstOrganizationButtonClicked')}
+                        >
+                            Create your first organization
                         </ButtonLink>
                     </div>
                 </Container>

--- a/client/web/src/user/settings/openBetaOrgs/OrganizationsList.tsx
+++ b/client/web/src/user/settings/openBetaOrgs/OrganizationsList.tsx
@@ -15,7 +15,7 @@ import styles from './organizationList.module.scss'
 export interface OrganizationsListProps extends ThemeProps, FeatureFlagProps {
     authenticatedUser: Pick<
         AuthenticatedUser,
-        'username' | 'avatarURL' | 'settingsURL' | 'organizations' | 'siteAdmin' | 'session' | 'displayName'
+        'id' | 'username' | 'avatarURL' | 'settingsURL' | 'organizations' | 'siteAdmin' | 'session' | 'displayName'
     >
 }
 


### PR DESCRIPTION
Also changed some of the event metadata from org invitations events to be public

## Test plan
Tested locally. This change only contains usage tracking. Currently behind a feature flag.

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


