### PR TITLE
Accept filters when creating new line chart insights

### DIFF
--- a/cmd/frontend/graphqlbackend/insights.go
+++ b/cmd/frontend/graphqlbackend/insights.go
@@ -286,9 +286,10 @@ type CreateLineChartSearchInsightArgs struct {
 }
 
 type CreateLineChartSearchInsightInput struct {
-	DataSeries []LineChartSearchInsightDataSeriesInput
-	Options    LineChartOptionsInput
-	Dashboards *[]graphql.ID
+	DataSeries   []LineChartSearchInsightDataSeriesInput
+	Options      LineChartOptionsInput
+	Dashboards   *[]graphql.ID
+	ViewControls *InsightViewControlsInput
 }
 
 type UpdateLineChartSearchInsightArgs struct {

--- a/cmd/frontend/graphqlbackend/insights.graphql
+++ b/cmd/frontend/graphqlbackend/insights.graphql
@@ -573,6 +573,11 @@ input LineChartSearchInsightInput {
     The dashboard IDs to associate this insight with once created.
     """
     dashboards: [ID!]
+
+    """
+    The default values for filters and aggregates for this line chart.
+    """
+    viewControls: InsightViewControlsInput
 }
 
 """

--- a/enterprise/internal/insights/resolvers/insight_view_resolvers.go
+++ b/enterprise/internal/insights/resolvers/insight_view_resolvers.go
@@ -402,10 +402,16 @@ func (r *Resolver) CreateLineChartSearchInsight(ctx context.Context, args *graph
 	}
 	defer func() { err = tx.Done(err) }()
 
+	filters := types.InsightViewFilters{}
+	if args.Input.ViewControls != nil {
+		filters.IncludeRepoRegex = args.Input.ViewControls.Filters.IncludeRepoRegex
+		filters.ExcludeRepoRegex = args.Input.ViewControls.Filters.ExcludeRepoRegex
+	}
+
 	view, err := tx.CreateView(ctx, types.InsightView{
 		Title:            emptyIfNil(args.Input.Options.Title),
 		UniqueID:         ksuid.New().String(),
-		Filters:          types.InsightViewFilters{},
+		Filters:          filters,
 		PresentationType: types.Line,
 	}, []store.InsightViewGrant{store.UserGrant(int(uid))})
 	if err != nil {


### PR DESCRIPTION
resolves #27836 

Update LineChartSearchInsightInput so that it optionally accepts filters when creating a new line chart insight.
 
## Test plan
Tested manually by doing the following:
1. Use existing UI to create a new line chart insight
2. Use existing UI to create a new line chart insight from an existing insight
3. Manually call mutation providing filter values



