### PR TITLE
Remove global gitserver.DefaultClient

### DIFF
--- a/cmd/frontend/backend/repos.go
+++ b/cmd/frontend/backend/repos.go
@@ -138,7 +138,7 @@ func (s *repos) Add(ctx context.Context, name api.RepoName) (addedName api.RepoN
 	}()
 
 	if !codehost.IsPackageHost() {
-		if err := gitserver.DefaultClient.IsRepoCloneable(ctx, name); err != nil {
+		if err := gitserver.NewClient(s.db).IsRepoCloneable(ctx, name); err != nil {
 			if ctx.Err() != nil {
 				status = "timeout"
 			} else {

--- a/cmd/frontend/graphqlbackend/git_object.go
+++ b/cmd/frontend/graphqlbackend/git_object.go
@@ -78,7 +78,7 @@ type gitObjectResolver struct {
 
 func (o *gitObjectResolver) resolve(ctx context.Context) (GitObjectID, GitObjectType, error) {
 	o.once.Do(func() {
-		obj, err := gitserver.DefaultClient.GetObject(ctx, o.repo.RepoName(), o.revspec)
+		obj, err := gitserver.NewClient(o.repo.db).GetObject(ctx, o.repo.RepoName(), o.revspec)
 		if err != nil {
 			o.err = err
 			return

--- a/cmd/frontend/graphqlbackend/repository.go
+++ b/cmd/frontend/graphqlbackend/repository.go
@@ -491,7 +491,7 @@ func (r *schemaResolver) ResolvePhabricatorDiff(ctx context.Context, args *struc
 		}
 	}
 
-	_, err = gitserver.DefaultClient.CreateCommitFromPatch(ctx, protocol.CreateCommitFromPatchRequest{
+	_, err = gitserver.NewClient(db).CreateCommitFromPatch(ctx, protocol.CreateCommitFromPatchRequest{
 		Repo:       api.RepoName(args.RepoName),
 		BaseCommit: api.CommitID(args.BaseRev),
 		TargetRef:  targetRef,

--- a/cmd/frontend/graphqlbackend/repository_mirror.go
+++ b/cmd/frontend/graphqlbackend/repository_mirror.go
@@ -41,7 +41,7 @@ type repositoryMirrorInfoResolver struct {
 
 func (r *repositoryMirrorInfoResolver) gitserverRepoInfo(ctx context.Context) (*protocol.RepoInfo, error) {
 	r.repoInfoOnce.Do(func() {
-		resp, err := gitserver.DefaultClient.RepoInfo(ctx, r.repository.RepoName())
+		resp, err := gitserver.NewClient(r.db).RepoInfo(ctx, r.repository.RepoName())
 		r.repoInfoResponse, r.repoInfoErr = resp.Results[r.repository.RepoName()], err
 	})
 	return r.repoInfoResponse, r.repoInfoErr
@@ -231,7 +231,7 @@ func (r *schemaResolver) CheckMirrorRepositoryConnection(ctx context.Context, ar
 	}
 
 	var result checkMirrorRepositoryConnectionResult
-	if err := gitserver.DefaultClient.IsRepoCloneable(ctx, repo.Name); err != nil {
+	if err := gitserver.NewClient(r.db).IsRepoCloneable(ctx, repo.Name); err != nil {
 		result.errorMessage = err.Error()
 	}
 	return &result, nil

--- a/cmd/frontend/internal/app/ui/raw.go
+++ b/cmd/frontend/internal/app/ui/raw.go
@@ -92,7 +92,7 @@ func serveRaw(db database.DB) handlerFunc {
 		}
 
 		if requestedPath == "/" && r.Method == "HEAD" {
-			_, err = gitserver.DefaultClient.RepoInfo(r.Context(), common.Repo.Name)
+			_, err = gitserver.NewClient(db).RepoInfo(r.Context(), common.Repo.Name)
 			if err != nil {
 				w.WriteHeader(http.StatusNotFound)
 				return err

--- a/cmd/frontend/internal/httpapi/httpapi.go
+++ b/cmd/frontend/internal/httpapi/httpapi.go
@@ -159,7 +159,7 @@ func NewInternalHandler(m *mux.Router, db database.DB, schema *graphql.Schema, n
 	m.Get(apirouter.GitResolveRevision).Handler(trace.Route(handler(serveGitResolveRevision(db))))
 	m.Get(apirouter.GitTar).Handler(trace.Route(handler(serveGitTar(db))))
 	gitService := &gitServiceHandler{
-		Gitserver: gitserver.DefaultClient,
+		Gitserver: gitserver.NewClient(db),
 	}
 	m.Get(apirouter.GitInfoRefs).Handler(trace.Route(http.HandlerFunc(gitService.serveInfoRefs)))
 	m.Get(apirouter.GitUploadPack).Handler(trace.Route(http.HandlerFunc(gitService.serveGitUploadPack)))

--- a/cmd/frontend/internal/httpapi/internal.go
+++ b/cmd/frontend/internal/httpapi/internal.go
@@ -313,7 +313,7 @@ func serveGitTar(db database.DB) func(w http.ResponseWriter, r *http.Request) er
 			Format:  "tar",
 		}
 
-		location := gitserver.DefaultClient.ArchiveURL(ctx, repo, opts)
+		location := gitserver.NewClient(db).ArchiveURL(ctx, repo, opts)
 
 		w.Header().Set("Location", location.String())
 		w.WriteHeader(http.StatusFound)
@@ -352,7 +352,7 @@ func serveGitExec(db database.DB) func(http.ResponseWriter, *http.Request) error
 		}
 
 		// Find the correct shard to query
-		addr := gitserver.DefaultClient.AddrForRepo(ctx, repo.Name)
+		addr := gitserver.NewClient(db).AddrForRepo(ctx, repo.Name)
 
 		director := func(req *http.Request) {
 			req.URL.Scheme = "http"

--- a/cmd/repo-updater/shared/main.go
+++ b/cmd/repo-updater/shared/main.go
@@ -133,7 +133,7 @@ func Main(enterpriseInit EnterpriseInit) {
 	server := &repoupdater.Server{
 		Store:                 store,
 		Scheduler:             updateScheduler,
-		GitserverClient:       gitserver.DefaultClient,
+		GitserverClient:       gitserver.NewClient(db),
 		SourcegraphDotComMode: envvar.SourcegraphDotComMode(),
 	}
 

--- a/enterprise/cmd/symbols/main.go
+++ b/enterprise/cmd/symbols/main.go
@@ -172,7 +172,7 @@ func NewGitserver(repositoryFetcher fetcher.RepositoryFetcher) Gitserver {
 }
 
 func (g Gitserver) LogReverseEach(repo string, db database.DB, commit string, n int, onLogEntry func(entry git.LogEntry) error) error {
-	return git.LogReverseEach(repo, commit, n, onLogEntry)
+	return git.LogReverseEach(repo, db, commit, n, onLogEntry)
 }
 
 func (g Gitserver) RevListEach(repo string, db database.DB, commit string, onCommit func(commit string) (shouldContinue bool, err error)) error {

--- a/enterprise/internal/authz/perforce/perforce.go
+++ b/enterprise/internal/authz/perforce/perforce.go
@@ -59,7 +59,7 @@ func NewProvider(urn, host, user, password string, depots []extsvc.RepoID, db da
 		host:               host,
 		user:               user,
 		password:           password,
-		p4Execer:           gitserver.DefaultClient,
+		p4Execer:           gitserver.NewClient(db),
 		cachedGroupMembers: make(map[string][]string),
 	}
 }

--- a/enterprise/internal/batches/background/background.go
+++ b/enterprise/internal/batches/background/background.go
@@ -24,7 +24,7 @@ func Routines(ctx context.Context, batchesStore *store.Store, cf *httpcli.Factor
 	batchSpecResolutionWorkerStore := store.NewBatchSpecResolutionWorkerStore(batchesStore.Handle(), observationContext)
 
 	routines := []goroutine.BackgroundRoutine{
-		newReconcilerWorker(ctx, batchesStore, reconcilerWorkerStore, gitserver.DefaultClient, sourcer, metrics),
+		newReconcilerWorker(ctx, batchesStore, reconcilerWorkerStore, gitserver.NewClient(db), sourcer, metrics),
 		newReconcilerWorkerResetter(reconcilerWorkerStore, metrics),
 
 		newSpecExpireJob(ctx, batchesStore),

--- a/enterprise/internal/codeintel/gitserver/client.go
+++ b/enterprise/internal/codeintel/gitserver/client.go
@@ -107,7 +107,7 @@ func (c *Client) RepoInfo(ctx context.Context, repos ...api.RepoName) (_ map[api
 	}})
 	defer endObservation(1, observation.Args{})
 
-	resp, err := gitserver.DefaultClient.RepoInfo(ctx, repos...)
+	resp, err := gitserver.NewClient(c.db).RepoInfo(ctx, repos...)
 	if resp == nil {
 		return nil, err
 	}

--- a/enterprise/internal/insights/compression/worker.go
+++ b/enterprise/internal/insights/compression/worker.go
@@ -17,6 +17,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbcache"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
 	"github.com/sourcegraph/sourcegraph/internal/observation"

--- a/enterprise/internal/insights/compression/worker.go
+++ b/enterprise/internal/insights/compression/worker.go
@@ -17,7 +17,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbcache"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
 	"github.com/sourcegraph/sourcegraph/internal/observation"

--- a/enterprise/internal/insights/query/query_executor.go
+++ b/enterprise/internal/insights/query/query_executor.go
@@ -16,6 +16,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )

--- a/enterprise/internal/insights/query/query_executor.go
+++ b/enterprise/internal/insights/query/query_executor.go
@@ -16,7 +16,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )

--- a/internal/gitserver/client_test.go
+++ b/internal/gitserver/client_test.go
@@ -141,6 +141,7 @@ func TestClient_Archive(t *testing.T) {
 	u, _ := url.Parse(srv.URL)
 	addrs := []string{u.Host}
 	cli := gitserver.NewTestClient(database.NewMockDB(), addrs)
+	cli.HTTPClient = &http.Client{}
 
 	ctx := context.Background()
 	for name, test := range tests {

--- a/internal/gitserver/client_test.go
+++ b/internal/gitserver/client_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/gitserver/server"
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/protocol"
@@ -32,22 +33,23 @@ import (
 func TestClient_ListCloned(t *testing.T) {
 	addrs := []string{"gitserver-0", "gitserver-1"}
 	cli := gitserver.NewTestClient(
-		httpcli.DoerFunc(func(r *http.Request) (*http.Response, error) {
-			switch r.URL.String() {
-			case "http://gitserver-0/list?cloned":
-				return &http.Response{
-					Body: io.NopCloser(bytes.NewBufferString(`["repo0-a", "repo0-b"]`)),
-				}, nil
-			case "http://gitserver-1/list?cloned":
-				return &http.Response{
-					Body: io.NopCloser(bytes.NewBufferString(`["repo1-a", "repo1-b"]`)),
-				}, nil
-			default:
-				return nil, errors.Errorf("unexpected url: %s", r.URL.String())
-			}
-		}),
+		database.NewMockDB(),
 		addrs,
 	)
+	cli.HTTPClient = httpcli.DoerFunc(func(r *http.Request) (*http.Response, error) {
+		switch r.URL.String() {
+		case "http://gitserver-0/list?cloned":
+			return &http.Response{
+				Body: io.NopCloser(bytes.NewBufferString(`["repo0-a", "repo0-b"]`)),
+			}, nil
+		case "http://gitserver-1/list?cloned":
+			return &http.Response{
+				Body: io.NopCloser(bytes.NewBufferString(`["repo1-a", "repo1-b"]`)),
+			}, nil
+		default:
+			return nil, errors.Errorf("unexpected url: %s", r.URL.String())
+		}
+	})
 
 	want := []string{"repo0-a", "repo1-a", "repo1-b"}
 	got, err := cli.ListCloned(context.Background())
@@ -68,22 +70,23 @@ func TestClient_RequestRepoMigrate(t *testing.T) {
 	expected := "http://" + gitserver.RendezvousAddrForRepo(repo, addrs)
 
 	cli := gitserver.NewTestClient(
-		httpcli.DoerFunc(func(r *http.Request) (*http.Response, error) {
-			switch r.URL.String() {
-			// Ensure that the request was received by the "expected" gitserver instance - where
-			// expected is the gitserver instance according to the Rendezvous hashing scheme.
-			// For anything else apart from this we return an error.
-			case expected + "/repo-update":
-				return &http.Response{
-					StatusCode: 200,
-					Body:       io.NopCloser(bytes.NewBufferString("{}")),
-				}, nil
-			default:
-				return nil, errors.Newf("unexpected URL: %q", r.URL.String())
-			}
-		}),
+		database.NewMockDB(),
 		addrs,
 	)
+	cli.HTTPClient = httpcli.DoerFunc(func(r *http.Request) (*http.Response, error) {
+		switch r.URL.String() {
+		// Ensure that the request was received by the "expected" gitserver instance - where
+		// expected is the gitserver instance according to the Rendezvous hashing scheme.
+		// For anything else apart from this we return an error.
+		case expected + "/repo-update":
+			return &http.Response{
+				StatusCode: 200,
+				Body:       io.NopCloser(bytes.NewBufferString("{}")),
+			}, nil
+		default:
+			return nil, errors.Newf("unexpected URL: %q", r.URL.String())
+		}
+	})
 
 	_, err := cli.RequestRepoMigrate(context.Background(), repo)
 	if err != nil {
@@ -137,7 +140,7 @@ func TestClient_Archive(t *testing.T) {
 
 	u, _ := url.Parse(srv.URL)
 	addrs := []string{u.Host}
-	cli := gitserver.NewTestClient(&http.Client{}, addrs)
+	cli := gitserver.NewTestClient(database.NewMockDB(), addrs)
 
 	ctx := context.Background()
 	for name, test := range tests {
@@ -418,7 +421,7 @@ func TestClient_P4Exec(t *testing.T) {
 
 			u, _ := url.Parse(server.URL)
 			addrs := []string{u.Host}
-			cli := gitserver.NewTestClient(&http.Client{}, addrs)
+			cli := gitserver.NewTestClient(database.NewMockDB(), addrs)
 
 			rc, _, err := cli.P4Exec(ctx, test.host, test.user, test.password, test.args...)
 			if diff := cmp.Diff(test.wantErr, fmt.Sprintf("%v", err)); diff != "" {
@@ -490,7 +493,7 @@ func TestClient_ResolveRevisions(t *testing.T) {
 
 	u, _ := url.Parse(srv.URL)
 	addrs := []string{u.Host}
-	cli := gitserver.NewTestClient(&http.Client{}, addrs)
+	cli := gitserver.NewTestClient(database.NewMockDB(), addrs)
 
 	ctx := context.Background()
 	for _, test := range tests {

--- a/internal/gitserver/client_test.go
+++ b/internal/gitserver/client_test.go
@@ -423,6 +423,7 @@ func TestClient_P4Exec(t *testing.T) {
 			u, _ := url.Parse(server.URL)
 			addrs := []string{u.Host}
 			cli := gitserver.NewTestClient(database.NewMockDB(), addrs)
+			cli.HTTPClient = &http.Client{}
 
 			rc, _, err := cli.P4Exec(ctx, test.host, test.user, test.password, test.args...)
 			if diff := cmp.Diff(test.wantErr, fmt.Sprintf("%v", err)); diff != "" {
@@ -495,6 +496,7 @@ func TestClient_ResolveRevisions(t *testing.T) {
 	u, _ := url.Parse(srv.URL)
 	addrs := []string{u.Host}
 	cli := gitserver.NewTestClient(database.NewMockDB(), addrs)
+	cli.HTTPClient = &http.Client{}
 
 	ctx := context.Background()
 	for _, test := range tests {

--- a/internal/repos/gitolite.go
+++ b/internal/repos/gitolite.go
@@ -54,10 +54,13 @@ func NewGitoliteSource(db database.DB, svc *types.ExternalService, cf *httpcli.F
 		return nil, err
 	}
 
+	gitserverClient := gitserver.NewClient(db)
+	gitserverClient.HTTPClient = gitserverDoer
+
 	return &GitoliteSource{
 		svc:     svc,
 		conn:    &c,
-		cli:     gitserver.NewClient(gitserverDoer),
+		cli:     gitserverClient,
 		exclude: exclude,
 	}, nil
 }

--- a/internal/repos/purge.go
+++ b/internal/repos/purge.go
@@ -53,7 +53,7 @@ func purge(ctx context.Context, db database.DB, log log15.Logger) error {
 	// However, if we fetch cloned first the only race is we may miss a
 	// repository that got disabled. The next time purge runs we will remove
 	// it though.
-	cloned, err := gitserver.DefaultClient.ListCloned(ctx)
+	cloned, err := gitserver.NewClient(db).ListCloned(ctx)
 	if err != nil {
 		return err
 	}
@@ -80,7 +80,7 @@ func purge(ctx context.Context, db database.DB, log log15.Logger) error {
 		// Race condition: A repo can be re-enabled between our listing and
 		// now. This should be very rare, so we ignore it since it will get
 		// cloned again.
-		if err = gitserver.DefaultClient.Remove(ctx, repo); err != nil {
+		if err = gitserver.NewClient(db).Remove(ctx, repo); err != nil {
 			// Do not fail at this point, just log so we can remove other
 			// repos.
 			log.Error("failed to remove disabled repository", "repo", repo, "error", err)

--- a/internal/repos/scheduler.go
+++ b/internal/repos/scheduler.go
@@ -254,7 +254,7 @@ func getCustomInterval(c *conf.Unified, repoName string) time.Duration {
 
 // requestRepoUpdate sends a request to gitserver to request an update.
 var requestRepoUpdate = func(ctx context.Context, db database.DB, repo configuredRepo, since time.Duration) (*gitserverprotocol.RepoUpdateResponse, error) {
-	return gitserver.DefaultClient.RequestRepoUpdate(ctx, repo.Name, since)
+	return gitserver.NewClient(db).RequestRepoUpdate(ctx, repo.Name, since)
 }
 
 // configuredLimiter returns a mutable limiter that is

--- a/internal/search/job/job.go
+++ b/internal/search/job/job.go
@@ -233,7 +233,7 @@ func ToSearchJob(jargs *Args, q query.Q, db database.DB) (Job, error) {
 				HasTimeFilter:        b.Exists("after") || b.Exists("before"),
 				Limit:                int(patternInfo.FileMatchLimit),
 				IncludeModifiedFiles: authz.SubRepoEnabled(authz.DefaultSubRepoPermsChecker),
-				Gitserver:            gitserver.DefaultClient,
+				Gitserver:            gitserver.NewClient(db),
 			})
 		}
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -398,7 +398,7 @@ func (s *Store) watchAndEvict() {
 func (s *Store) watchConfig() {
 	for {
 		// Allow roughly 10 fetches per gitserver
-		limit := 10 * len(gitserver.DefaultClient.Addrs())
+		limit := 10 * len(gitserver.NewClient(s.DB).Addrs())
 		if limit == 0 {
 			limit = 15
 		}

--- a/internal/testutil/github_archive.go
+++ b/internal/testutil/github_archive.go
@@ -14,7 +14,6 @@ import (
 	"golang.org/x/net/context/ctxhttp"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
-	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 

--- a/internal/testutil/github_archive.go
+++ b/internal/testutil/github_archive.go
@@ -14,6 +14,7 @@ import (
 	"golang.org/x/net/context/ctxhttp"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 

--- a/internal/usagestats/repositories.go
+++ b/internal/usagestats/repositories.go
@@ -39,7 +39,7 @@ type Repositories struct {
 func GetRepositories(ctx context.Context, db database.DB) (*Repositories, error) {
 	var total Repositories
 
-	stats, err := gitserver.DefaultClient.ReposStats(ctx)
+	stats, err := gitserver.NewClient(db).ReposStats(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/vcs/git/archive.go
+++ b/internal/vcs/git/archive.go
@@ -27,7 +27,7 @@ func ArchiveReader(
 	repoName api.RepoName,
 	options gitserver.ArchiveOptions,
 ) (io.ReadCloser, error) {
-	return gitserver.DefaultClient.Archive(ctx, repoName, options)
+	return gitserver.NewClient(db).Archive(ctx, repoName, options)
 }
 
 func ArchiveReaderWithSubRepo(

--- a/internal/vcs/git/archive_test.go
+++ b/internal/vcs/git/archive_test.go
@@ -2,6 +2,8 @@ package git
 
 import (
 	"context"
+	"io"
+	"strings"
 	"testing"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
@@ -27,6 +29,11 @@ func TestArchiveReaderForRepoWithSubRepoPermissions(t *testing.T) {
 		// sub-repo permissions are enabled only for repo with repoID = 1
 		return id == 1, nil
 	})
+	gitserver.ClientMocks.Archive = func(ctx context.Context, repo api.RepoName, opt gitserver.ArchiveOptions) (io.ReadCloser, error) {
+		stringReader := strings.NewReader("1337")
+		return io.NopCloser(stringReader), nil
+	}
+	defer gitserver.ResetClientMocks()
 
 	repo := &types.Repo{Name: repoName, ID: 1}
 
@@ -56,6 +63,11 @@ func TestArchiveReaderForRepoWithoutSubRepoPermissions(t *testing.T) {
 		// sub-repo permissions are not present for repo with repoID = 1
 		return id != 1, nil
 	})
+	gitserver.ClientMocks.Archive = func(ctx context.Context, repo api.RepoName, opt gitserver.ArchiveOptions) (io.ReadCloser, error) {
+		stringReader := strings.NewReader("1337")
+		return io.NopCloser(stringReader), nil
+	}
+	defer gitserver.ResetClientMocks()
 
 	repo := &types.Repo{Name: repoName, ID: 1}
 

--- a/internal/vcs/git/blob.go
+++ b/internal/vcs/git/blob.go
@@ -106,7 +106,7 @@ func newBlobReader(ctx context.Context, db database.DB, repo api.RepoName, commi
 		return nil, err
 	}
 
-	cmd := gitserver.DefaultClient.Command("git", "show", string(commit)+":"+name)
+	cmd := gitserver.NewClient(db).Command("git", "show", string(commit)+":"+name)
 	cmd.Repo = repo
 	stdout, err := gitserver.StdoutReader(ctx, cmd)
 	if err != nil {

--- a/internal/vcs/git/commits.go
+++ b/internal/vcs/git/commits.go
@@ -301,7 +301,7 @@ func commitLog(ctx context.Context, db database.DB, repo api.RepoName, opt Commi
 	return filtered, err
 }
 
-func getWrappedCommits(ctx context.Context, db database.DB, repo api.RepoName, opt CommitsOptions) ([]*wrappedCommit, error) {
+func getWrappedCommits(ctx context.Context, _ database.DB, repo api.RepoName, opt CommitsOptions) ([]*wrappedCommit, error) {
 	args, err := commitLogArgs([]string{"log", logFormatWithoutRefs}, opt)
 	if err != nil {
 		return nil, err
@@ -464,7 +464,7 @@ func commitLogArgs(initialArgs []string, opt CommitsOptions) (args []string, err
 }
 
 // commitCount returns the number of commits that would be returned by Commits.
-func commitCount(ctx context.Context, db database.DB, repo api.RepoName, opt CommitsOptions) (uint, error) {
+func commitCount(ctx context.Context, _ database.DB, repo api.RepoName, opt CommitsOptions) (uint, error) {
 	span, ctx := ot.StartSpanFromContext(ctx, "Git: CommitCount")
 	span.SetTag("Opt", opt)
 	defer span.Finish()

--- a/internal/vcs/git/commits.go
+++ b/internal/vcs/git/commits.go
@@ -192,7 +192,7 @@ func CommitsUniqueToBranch(ctx context.Context, db database.DB, repo api.RepoNam
 		args = append(args, branchName, "^HEAD")
 	}
 
-	cmd := gitserver.DefaultClient.Command("git", args...)
+	cmd := gitserver.NewClient(db).Command("git", args...)
 	cmd.Repo = repo
 	out, err := cmd.CombinedOutput(ctx)
 	if err != nil {
@@ -307,7 +307,7 @@ func getWrappedCommits(ctx context.Context, db database.DB, repo api.RepoName, o
 		return nil, err
 	}
 
-	cmd := gitserver.DefaultClient.Command("git", args...)
+	cmd := gitserver.NewClient(db).Command("git", args...)
 	cmd.Repo = repo
 	if !opt.NoEnsureRevision {
 		cmd.EnsureRevision = opt.Range
@@ -474,7 +474,7 @@ func commitCount(ctx context.Context, db database.DB, repo api.RepoName, opt Com
 		return 0, err
 	}
 
-	cmd := gitserver.DefaultClient.Command("git", args...)
+	cmd := gitserver.NewClient(db).Command("git", args...)
 	cmd.Repo = repo
 	if opt.Path != "" {
 		// This doesn't include --follow flag because rev-list doesn't support it, so the number may be slightly off.
@@ -496,7 +496,7 @@ func FirstEverCommit(ctx context.Context, db database.DB, repo api.RepoName, che
 	defer span.Finish()
 
 	args := []string{"rev-list", "--reverse", "--date-order", "--max-parents=0", "HEAD"}
-	cmd := gitserver.DefaultClient.Command("git", args...)
+	cmd := gitserver.NewClient(db).Command("git", args...)
 	cmd.Repo = repo
 	out, err := cmd.Output(ctx)
 	if err != nil {
@@ -529,7 +529,7 @@ func CommitExists(ctx context.Context, db database.DB, repo api.RepoName, id api
 // repositories), a false-valued flag is returned along with a nil error and
 // empty revision.
 func Head(ctx context.Context, db database.DB, repo api.RepoName, checker authz.SubRepoPermissionChecker) (_ string, revisionExists bool, err error) {
-	cmd := gitserver.DefaultClient.Command("git", "rev-parse", "HEAD")
+	cmd := gitserver.NewClient(db).Command("git", "rev-parse", "HEAD")
 	cmd.Repo = repo
 
 	out, err := cmd.Output(ctx)
@@ -647,7 +647,7 @@ func BranchesContaining(ctx context.Context, db database.DB, repo api.RepoName, 
 			return nil, err
 		}
 	}
-	cmd := gitserver.DefaultClient.Command("git", "branch", "--contains", string(commit), "--format", "%(refname)")
+	cmd := gitserver.NewClient(db).Command("git", "branch", "--contains", string(commit), "--format", "%(refname)")
 	cmd.Repo = repo
 
 	out, err := cmd.CombinedOutput(ctx)
@@ -693,7 +693,7 @@ func RefDescriptions(ctx context.Context, db database.DB, repo api.RepoName, che
 			args = append(args, "--points-at="+obj)
 		}
 
-		cmd := gitserver.DefaultClient.Command("git", args...)
+		cmd := gitserver.NewClient(db).Command("git", args...)
 		cmd.Repo = repo
 
 		out, err := cmd.CombinedOutput(ctx)
@@ -819,7 +819,7 @@ func CommitDate(ctx context.Context, db database.DB, repo api.RepoName, commit a
 		}
 	}
 
-	cmd := gitserver.DefaultClient.Command("git", "show", "-s", "--format=%H:%cI", string(commit))
+	cmd := gitserver.NewClient(db).Command("git", "show", "-s", "--format=%H:%cI", string(commit))
 	cmd.Repo = repo
 
 	out, err := cmd.CombinedOutput(ctx)
@@ -875,7 +875,7 @@ func CommitGraph(ctx context.Context, db database.DB, repo api.RepoName, opts Co
 		args = append(args, fmt.Sprintf("-%d", opts.Limit))
 	}
 
-	cmd := gitserver.DefaultClient.Command("git", args...)
+	cmd := gitserver.NewClient(db).Command("git", args...)
 	cmd.Repo = repo
 
 	out, err := cmd.CombinedOutput(ctx)

--- a/internal/vcs/git/commits.go
+++ b/internal/vcs/git/commits.go
@@ -301,7 +301,7 @@ func commitLog(ctx context.Context, db database.DB, repo api.RepoName, opt Commi
 	return filtered, err
 }
 
-func getWrappedCommits(ctx context.Context, _ database.DB, repo api.RepoName, opt CommitsOptions) ([]*wrappedCommit, error) {
+func getWrappedCommits(ctx context.Context, db database.DB, repo api.RepoName, opt CommitsOptions) ([]*wrappedCommit, error) {
 	args, err := commitLogArgs([]string{"log", logFormatWithoutRefs}, opt)
 	if err != nil {
 		return nil, err
@@ -464,7 +464,7 @@ func commitLogArgs(initialArgs []string, opt CommitsOptions) (args []string, err
 }
 
 // commitCount returns the number of commits that would be returned by Commits.
-func commitCount(ctx context.Context, _ database.DB, repo api.RepoName, opt CommitsOptions) (uint, error) {
+func commitCount(ctx context.Context, db database.DB, repo api.RepoName, opt CommitsOptions) (uint, error) {
 	span, ctx := ot.StartSpanFromContext(ctx, "Git: CommitCount")
 	span.SetTag("Opt", opt)
 	defer span.Finish()

--- a/internal/vcs/git/diff.go
+++ b/internal/vcs/git/diff.go
@@ -102,7 +102,7 @@ func DiffPath(ctx context.Context, db database.DB, repo api.RepoName, sourceComm
 
 // DiffSymbols performs a diff command which is expected to be parsed by our symbols package
 func DiffSymbols(ctx context.Context, db database.DB, repo api.RepoName, commitA, commitB api.CommitID) ([]byte, error) {
-	command := gitserver.DefaultClient.Command("git", "diff", "-z", "--name-status", "--no-renames", string(commitA), string(commitB))
+	command := gitserver.NewClient(db).Command("git", "diff", "-z", "--name-status", "--no-renames", string(commitA), string(commitB))
 	command.Repo = repo
 	return command.Output(ctx)
 }

--- a/internal/vcs/git/exec.go
+++ b/internal/vcs/git/exec.go
@@ -22,7 +22,7 @@ import (
 //
 // execSafe should NOT be exported. We want to limit direct git calls to this
 // package.
-func execSafe(ctx context.Context, db database.DB, repo api.RepoName, params []string) (stdout, stderr []byte, exitCode int, err error) {
+func execSafe(ctx context.Context, _ database.DB, repo api.RepoName, params []string) (stdout, stderr []byte, exitCode int, err error) {
 	if Mocks.ExecSafe != nil {
 		return Mocks.ExecSafe(params)
 	}
@@ -53,7 +53,7 @@ func execSafe(ctx context.Context, db database.DB, repo api.RepoName, params []s
 //
 // execReader should NOT be exported. We want to limit direct git calls to this
 // package.
-func execReader(ctx context.Context, db database.DB, repo api.RepoName, args []string) (io.ReadCloser, error) {
+func execReader(ctx context.Context, _ database.DB, repo api.RepoName, args []string) (io.ReadCloser, error) {
 	if Mocks.ExecReader != nil {
 		return Mocks.ExecReader(args)
 	}
@@ -79,7 +79,7 @@ func checkSpecArgSafety(spec string) error {
 	return nil
 }
 
-func gitserverCmdFunc(repo api.RepoName, db database.DB) cmdFunc {
+func gitserverCmdFunc(repo api.RepoName, _ database.DB) cmdFunc {
 	return func(args []string) cmd {
 		cmd := gitserver.DefaultClient.Command("git", args...)
 		cmd.Repo = repo

--- a/internal/vcs/git/exec.go
+++ b/internal/vcs/git/exec.go
@@ -38,7 +38,7 @@ func execSafe(ctx context.Context, db database.DB, repo api.RepoName, params []s
 		return nil, nil, 0, errors.Errorf("command failed: %q is not a allowed git command", params)
 	}
 
-	cmd := gitserver.DefaultClient.Command("git", params...)
+	cmd := gitserver.NewClient(db).Command("git", params...)
 	cmd.Repo = repo
 	stdout, stderr, err = cmd.DividedOutput(ctx)
 	exitCode = cmd.ExitStatus
@@ -65,7 +65,7 @@ func execReader(ctx context.Context, db database.DB, repo api.RepoName, args []s
 	if !gitdomain.IsAllowedGitCmd(args) {
 		return nil, errors.Errorf("command failed: %v is not a allowed git command", args)
 	}
-	cmd := gitserver.DefaultClient.Command("git", args...)
+	cmd := gitserver.NewClient(db).Command("git", args...)
 	cmd.Repo = repo
 	return gitserver.StdoutReader(ctx, cmd)
 }
@@ -81,7 +81,7 @@ func checkSpecArgSafety(spec string) error {
 
 func gitserverCmdFunc(repo api.RepoName, db database.DB) cmdFunc {
 	return func(args []string) cmd {
-		cmd := gitserver.DefaultClient.Command("git", args...)
+		cmd := gitserver.NewClient(db).Command("git", args...)
 		cmd.Repo = repo
 		return cmd
 	}

--- a/internal/vcs/git/exec.go
+++ b/internal/vcs/git/exec.go
@@ -22,7 +22,7 @@ import (
 //
 // execSafe should NOT be exported. We want to limit direct git calls to this
 // package.
-func execSafe(ctx context.Context, _ database.DB, repo api.RepoName, params []string) (stdout, stderr []byte, exitCode int, err error) {
+func execSafe(ctx context.Context, db database.DB, repo api.RepoName, params []string) (stdout, stderr []byte, exitCode int, err error) {
 	if Mocks.ExecSafe != nil {
 		return Mocks.ExecSafe(params)
 	}
@@ -53,7 +53,7 @@ func execSafe(ctx context.Context, _ database.DB, repo api.RepoName, params []st
 //
 // execReader should NOT be exported. We want to limit direct git calls to this
 // package.
-func execReader(ctx context.Context, _ database.DB, repo api.RepoName, args []string) (io.ReadCloser, error) {
+func execReader(ctx context.Context, db database.DB, repo api.RepoName, args []string) (io.ReadCloser, error) {
 	if Mocks.ExecReader != nil {
 		return Mocks.ExecReader(args)
 	}
@@ -79,7 +79,7 @@ func checkSpecArgSafety(spec string) error {
 	return nil
 }
 
-func gitserverCmdFunc(repo api.RepoName, _ database.DB) cmdFunc {
+func gitserverCmdFunc(repo api.RepoName, db database.DB) cmdFunc {
 	return func(args []string) cmd {
 		cmd := gitserver.DefaultClient.Command("git", args...)
 		cmd.Repo = repo

--- a/internal/vcs/git/log.go
+++ b/internal/vcs/git/log.go
@@ -7,6 +7,7 @@ import (
 	"io"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
@@ -47,11 +48,11 @@ func LogReverseArgs(n int, givenCommit string) []string {
 	}
 }
 
-func LogReverseEach(repo string, commit string, n int, onLogEntry func(entry LogEntry) error) error {
+func LogReverseEach(repo string, db database.DB, commit string, n int, onLogEntry func(entry LogEntry) error) error {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	command := gitserver.DefaultClient.Command("git", LogReverseArgs(n, commit)...)
+	command := gitserver.NewClient(db).Command("git", LogReverseArgs(n, commit)...)
 	command.Repo = api.RepoName(repo)
 	// We run a single `git log` command and stream the output while the repo is being processed, which
 	// can take much longer than 1 minute (the default timeout).

--- a/internal/vcs/git/main_test.go
+++ b/internal/vcs/git/main_test.go
@@ -79,8 +79,12 @@ func init() {
 		}
 	}()
 
-	testGitserverClient = gitserver.NewTestClient(database.NewMockDB(), []string{l.Addr().String()})
+	serverAddress := l.Addr().String()
+	testGitserverClient = gitserver.NewTestClient(database.NewMockDB(), []string{serverAddress})
 	testGitserverClient.HTTPClient = httpcli.InternalDoer
+	if err := os.Setenv("GO_TEST_SERVER_ADDRESS", serverAddress); err != nil {
+		panic(err)
+	}
 }
 
 func AsJSON(v interface{}) string {

--- a/internal/vcs/git/merge_base.go
+++ b/internal/vcs/git/merge_base.go
@@ -22,7 +22,7 @@ func MergeBase(ctx context.Context, db database.DB, repo api.RepoName, a, b api.
 	span.SetTag("B", b)
 	defer span.Finish()
 
-	cmd := gitserver.DefaultClient.Command("git", "merge-base", "--", string(a), string(b))
+	cmd := gitserver.NewClient(db).Command("git", "merge-base", "--", string(a), string(b))
 	cmd.Repo = repo
 	out, err := cmd.CombinedOutput(ctx)
 	if err != nil {

--- a/internal/vcs/git/object_test.go
+++ b/internal/vcs/git/object_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 )
@@ -33,7 +34,7 @@ func TestGetObject(t *testing.T) {
 
 	for label, test := range tests {
 		t.Run(label, func(t *testing.T) {
-			obj, err := gitserver.DefaultClient.GetObject(context.Background(), test.repo, test.objectName)
+			obj, err := gitserver.NewClient(database.NewMockDB()).GetObject(context.Background(), test.repo, test.objectName)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/vcs/git/refs.go
+++ b/internal/vcs/git/refs.go
@@ -202,7 +202,7 @@ func ListBranches(ctx context.Context, db database.DB, repo api.RepoName, opt Br
 
 // branches runs the `git branch` command followed by the given arguments and
 // returns the list of branches if successful.
-func branches(ctx context.Context, db database.DB, repo api.RepoName, args ...string) ([]string, error) {
+func branches(ctx context.Context, _ database.DB, repo api.RepoName, args ...string) ([]string, error) {
 	cmd := gitserver.DefaultClient.Command("git", append([]string{"branch"}, args...)...)
 	cmd.Repo = repo
 	out, err := cmd.Output(ctx)
@@ -317,7 +317,7 @@ type Ref struct {
 	CommitID api.CommitID
 }
 
-func showRef(ctx context.Context, db database.DB, repo api.RepoName, args ...string) ([]Ref, error) {
+func showRef(ctx context.Context, _ database.DB, repo api.RepoName, args ...string) ([]Ref, error) {
 	cmd := gitserver.DefaultClient.Command("git", "show-ref")
 	cmd.Args = append(cmd.Args, args...)
 	cmd.Repo = repo

--- a/internal/vcs/git/refs.go
+++ b/internal/vcs/git/refs.go
@@ -203,7 +203,7 @@ func ListBranches(ctx context.Context, db database.DB, repo api.RepoName, opt Br
 // branches runs the `git branch` command followed by the given arguments and
 // returns the list of branches if successful.
 func branches(ctx context.Context, db database.DB, repo api.RepoName, args ...string) ([]string, error) {
-	cmd := gitserver.DefaultClient.Command("git", append([]string{"branch"}, args...)...)
+	cmd := gitserver.NewClient(db).Command("git", append([]string{"branch"}, args...)...)
 	cmd.Repo = repo
 	out, err := cmd.Output(ctx)
 	if err != nil {
@@ -231,7 +231,7 @@ func GetBehindAhead(ctx context.Context, db database.DB, repo api.RepoName, left
 		return nil, err
 	}
 
-	cmd := gitserver.DefaultClient.Command("git", "rev-list", "--count", "--left-right", fmt.Sprintf("%s...%s", left, right))
+	cmd := gitserver.NewClient(db).Command("git", "rev-list", "--count", "--left-right", fmt.Sprintf("%s...%s", left, right))
 	cmd.Repo = repo
 	out, err := cmd.Output(ctx)
 	if err != nil {
@@ -257,7 +257,7 @@ func ListTags(ctx context.Context, db database.DB, repo api.RepoName) ([]*Tag, e
 	// Support both lightweight tags and tag objects. For creatordate, use an %(if) to prefer the
 	// taggerdate for tag objects, otherwise use the commit's committerdate (instead of just always
 	// using committerdate).
-	cmd := gitserver.DefaultClient.Command("git", "tag", "--list", "--sort", "-creatordate", "--format", "%(if)%(*objectname)%(then)%(*objectname)%(else)%(objectname)%(end)%00%(refname:short)%00%(if)%(creatordate:unix)%(then)%(creatordate:unix)%(else)%(*creatordate:unix)%(end)")
+	cmd := gitserver.NewClient(db).Command("git", "tag", "--list", "--sort", "-creatordate", "--format", "%(if)%(*objectname)%(then)%(*objectname)%(else)%(objectname)%(end)%00%(refname:short)%00%(if)%(creatordate:unix)%(then)%(creatordate:unix)%(else)%(*creatordate:unix)%(end)")
 	cmd.Repo = repo
 	out, err := cmd.CombinedOutput(ctx)
 	if err != nil {
@@ -318,7 +318,7 @@ type Ref struct {
 }
 
 func showRef(ctx context.Context, db database.DB, repo api.RepoName, args ...string) ([]Ref, error) {
-	cmd := gitserver.DefaultClient.Command("git", "show-ref")
+	cmd := gitserver.NewClient(db).Command("git", "show-ref")
 	cmd.Args = append(cmd.Args, args...)
 	cmd.Repo = repo
 	out, err := cmd.CombinedOutput(ctx)
@@ -363,7 +363,7 @@ func RevList(repo string, db database.DB, commit string, onCommit func(commit st
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	command := gitserver.DefaultClient.Command("git", RevListArgs(commit)...)
+	command := gitserver.NewClient(db).Command("git", RevListArgs(commit)...)
 	command.Repo = api.RepoName(repo)
 	command.DisableTimeout()
 	stdout, err := gitserver.StdoutReader(ctx, command)

--- a/internal/vcs/git/refs.go
+++ b/internal/vcs/git/refs.go
@@ -202,7 +202,7 @@ func ListBranches(ctx context.Context, db database.DB, repo api.RepoName, opt Br
 
 // branches runs the `git branch` command followed by the given arguments and
 // returns the list of branches if successful.
-func branches(ctx context.Context, _ database.DB, repo api.RepoName, args ...string) ([]string, error) {
+func branches(ctx context.Context, db database.DB, repo api.RepoName, args ...string) ([]string, error) {
 	cmd := gitserver.DefaultClient.Command("git", append([]string{"branch"}, args...)...)
 	cmd.Repo = repo
 	out, err := cmd.Output(ctx)
@@ -317,7 +317,7 @@ type Ref struct {
 	CommitID api.CommitID
 }
 
-func showRef(ctx context.Context, _ database.DB, repo api.RepoName, args ...string) ([]Ref, error) {
+func showRef(ctx context.Context, db database.DB, repo api.RepoName, args ...string) ([]Ref, error) {
 	cmd := gitserver.DefaultClient.Command("git", "show-ref")
 	cmd.Args = append(cmd.Args, args...)
 	cmd.Repo = repo

--- a/internal/vcs/git/revisions.go
+++ b/internal/vcs/git/revisions.go
@@ -93,7 +93,7 @@ func ResolveRevision(ctx context.Context, db database.DB, repo api.RepoName, spe
 		spec = spec + "^0"
 	}
 
-	cmd := gitserver.DefaultClient.Command("git", "rev-parse", spec)
+	cmd := gitserver.NewClient(db).Command("git", "rev-parse", spec)
 	cmd.Repo = repo
 	cmd.EnsureRevision = spec
 

--- a/internal/vcs/git/shortlog.go
+++ b/internal/vcs/git/shortlog.go
@@ -55,7 +55,7 @@ func ShortLog(ctx context.Context, db database.DB, repo api.RepoName, opt ShortL
 	if opt.Path != "" {
 		args = append(args, opt.Path)
 	}
-	cmd := gitserver.DefaultClient.Command("git", args...)
+	cmd := gitserver.NewClient(db).Command("git", args...)
 	cmd.Repo = repo
 	out, err := cmd.Output(ctx)
 	if err != nil {

--- a/internal/vcs/git/tree.go
+++ b/internal/vcs/git/tree.go
@@ -230,7 +230,7 @@ func lsTree(
 	return entries, nil
 }
 
-func lsTreeUncached(ctx context.Context, db database.DB, repo api.RepoName, commit api.CommitID, path string, recurse bool) ([]fs.FileInfo, error) {
+func lsTreeUncached(ctx context.Context, _ database.DB, repo api.RepoName, commit api.CommitID, path string, recurse bool) ([]fs.FileInfo, error) {
 	if err := ensureAbsoluteCommit(commit); err != nil {
 		return nil, err
 	}

--- a/internal/vcs/git/tree.go
+++ b/internal/vcs/git/tree.go
@@ -230,7 +230,7 @@ func lsTree(
 	return entries, nil
 }
 
-func lsTreeUncached(ctx context.Context, _ database.DB, repo api.RepoName, commit api.CommitID, path string, recurse bool) ([]fs.FileInfo, error) {
+func lsTreeUncached(ctx context.Context, db database.DB, repo api.RepoName, commit api.CommitID, path string, recurse bool) ([]fs.FileInfo, error) {
 	if err := ensureAbsoluteCommit(commit); err != nil {
 		return nil, err
 	}

--- a/internal/vcs/git/tree.go
+++ b/internal/vcs/git/tree.go
@@ -114,7 +114,7 @@ func LsFiles(ctx context.Context, db database.DB, checker authz.SubRepoPermissio
 		args = append(args, pathspecs...)
 	}
 
-	cmd := gitserver.DefaultClient.Command("git", args...)
+	cmd := gitserver.NewClient(db).Command("git", args...)
 	cmd.Repo = repo
 	out, err := cmd.CombinedOutput(ctx)
 	if err != nil {
@@ -145,7 +145,7 @@ func lStat(ctx context.Context, db database.DB, checker authz.SubRepoPermissionC
 
 	if path == "." {
 		// Special case root, which is not returned by `git ls-tree`.
-		obj, err := gitserver.DefaultClient.GetObject(ctx, repo, string(commit)+"^{tree}")
+		obj, err := gitserver.NewClient(db).GetObject(ctx, repo, string(commit)+"^{tree}")
 		if err != nil {
 			return nil, err
 		}
@@ -255,7 +255,7 @@ func lsTreeUncached(ctx context.Context, db database.DB, repo api.RepoName, comm
 	if path != "" {
 		args = append(args, "--", filepath.ToSlash(path))
 	}
-	cmd := gitserver.DefaultClient.Command("git", args...)
+	cmd := gitserver.NewClient(db).Command("git", args...)
 	cmd.Repo = repo
 	out, err := cmd.CombinedOutput(ctx)
 	if err != nil {
@@ -334,7 +334,7 @@ func lsTreeUncached(ctx context.Context, db database.DB, repo api.RepoName, comm
 			}
 		case "commit":
 			mode = mode | ModeSubmodule
-			cmd := gitserver.DefaultClient.Command("git", "show", fmt.Sprintf("%s:.gitmodules", commit))
+			cmd := gitserver.NewClient(db).Command("git", "show", fmt.Sprintf("%s:.gitmodules", commit))
 			cmd.Repo = repo
 			var submodule Submodule
 			if out, err := cmd.Output(ctx); err == nil {
@@ -374,7 +374,7 @@ func lsTreeUncached(ctx context.Context, db database.DB, repo api.RepoName, comm
 // ListFiles returns a list of root-relative file paths matching the given
 // pattern in a particular commit of a repository.
 func ListFiles(ctx context.Context, db database.DB, repo api.RepoName, commit api.CommitID, pattern *regexp.Regexp, checker authz.SubRepoPermissionChecker) (_ []string, err error) {
-	cmd := gitserver.DefaultClient.Command("git", "ls-tree", "--name-only", "-r", string(commit), "--")
+	cmd := gitserver.NewClient(db).Command("git", "ls-tree", "--name-only", "-r", string(commit), "--")
 	cmd.Repo = repo
 
 	out, err := cmd.CombinedOutput(ctx)
@@ -419,7 +419,7 @@ func ListDirectoryChildren(
 ) (map[string][]string, error) {
 	args := []string{"ls-tree", "--name-only", string(commit), "--"}
 	args = append(args, cleanDirectoriesForLsTree(dirnames)...)
-	cmd := gitserver.DefaultClient.Command("git", args...)
+	cmd := gitserver.NewClient(db).Command("git", args...)
 	cmd.Repo = repo
 
 	out, err := cmd.CombinedOutput(ctx)

--- a/internal/vcs/git/tree_test.go
+++ b/internal/vcs/git/tree_test.go
@@ -45,7 +45,7 @@ func TestRepository_FileSystem_Symlinks(t *testing.T) {
 	dir := InitGitRepository(t, gitCommands...)
 	repo := api.RepoName(filepath.Base(dir))
 
-	if resp, err := gitserver.DefaultClient.RequestRepoUpdate(context.Background(), repo, 0); err != nil {
+	if resp, err := gitserver.NewClient(db).RequestRepoUpdate(context.Background(), repo, 0); err != nil {
 		t.Fatal(err)
 	} else if resp.Error != "" {
 		t.Fatal(resp.Error)
@@ -697,7 +697,7 @@ func TestStat(t *testing.T) {
 	dir := InitGitRepository(t, gitCommands...)
 	repo := api.RepoName(filepath.Base(dir))
 
-	if resp, err := gitserver.DefaultClient.RequestRepoUpdate(context.Background(), repo, 0); err != nil {
+	if resp, err := gitserver.NewClient(db).RequestRepoUpdate(context.Background(), repo, 0); err != nil {
 		t.Fatal(err)
 	} else if resp.Error != "" {
 		t.Fatal(resp.Error)


### PR DESCRIPTION
Global gitserver.DefaultClient is deleted, gitserver.NewClient function should be used instead. 
It will allow creating a client ad-hoc, and injecting it with a database connection.

Due to removal of global client, testing became harder to do, because there is no way I can think about which will give me an opportunity to modify gitserver clients which are now created "on the fly". 

Please pay attention to [this commit](https://github.com/sourcegraph/sourcegraph/pull/32781/commits/241db5ee08c4016f88a1d0665ae0a2d6eb0640cd), which illustrates my way of fixing the problem. `main_test.go` used to directly create a global test client with arbitrary `l.Addr().String()` addresses. Which is not really feasible now, because the client is created ad-hoc and addresses are taken from configuration, which is empty for such tests ([here is why](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/internal/conf/conf.go?L78))

## Test plan
Check that there are no failing tests introduced

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


