### PR TITLE
dev/ci: do not use pre-command directly in go-backcompat test

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -18,54 +18,6 @@ export BUILD_START_TIME
 STEP_START=$(date +'%s')
 export STEP_START
 
-# ASDF setup
+# asdf setup
 # ----------
-
-# TODO remove this when making job the default queue
-# Skip on normal queues because standard agents do not have fresh asdf installs
-if [[ ! "$BUILDKITE_AGENT_META_DATA_QUEUE" =~ .*job.* ]]; then
-  echo "~~~ asdf install"
-  asdf install
-  echo "done installing"
-  # We can't use exit 0 here, it would prevent the variables to be exported (that's a particular buildkite hook peculiarity).
-else
-  # We need awscli to use asdf cache
-  echo "~~~ asdf install from cache"
-  asdf install awscli
-  echo "done installing awscli"
-
-  # set the buildkite cache access keys
-  AWS_CONFIG_DIR_PATH="/buildkite/.aws"
-  mkdir -p "$AWS_CONFIG_DIR_PATH"
-  AWS_CONFIG_FILE="$AWS_CONFIG_DIR_PATH/config"
-  export AWS_CONFIG_FILE
-  AWS_SHARED_CREDENTIALS_FILE="/buildkite/.aws/credentials"
-  export AWS_SHARED_CREDENTIALS_FILE
-  aws configure set aws_access_key_id "$BUILDKITE_HMAC_KEY" --profile buildkite
-  aws configure set aws_secret_access_key "$BUILDKITE_HMAC_SECRET" --profile buildkite
-
-  asdf_checksum=$(sha1sum .tool-versions | awk '{print $1}')
-  cache_file="cache-asdf-$asdf_checksum.tar.gz"
-  cache_key="$BUILDKITE_ORGANIZATION_SLUG/$BUILDKITE_PIPELINE_NAME/$cache_file"
-
-  echo -e "ASDF 🔍 Locating cache: $cache_key"
-  if aws s3api head-object --bucket "sourcegraph_buildkite_cache" --profile buildkite --endpoint-url 'https://storage.googleapis.com' --region "us-central1" --key "$cache_key"; then
-    echo -e "ASDF 🔥 Cache hit: $cache_key"
-    aws s3 cp --profile buildkite --endpoint-url 'https://storage.googleapis.com' --region "us-central1" "s3://sourcegraph_buildkite_cache/$cache_key" "$HOME/"
-    pushd "$HOME"
-    tar xzf "$cache_file"
-    popd
-  else
-    echo -e "ASDF 🚨 Cache miss: $cache_key"
-    echo "~~~ fresh install of all asdf tool versions"
-    asdf install
-    echo "~~~ cache asdf installation"
-    pushd "$HOME"
-    tar cfz "$cache_file" .asdf
-    popd
-    aws s3 cp --profile buildkite --endpoint-url 'https://storage.googleapis.com' --region "us-central1" "$HOME/$cache_file" "s3://sourcegraph_buildkite_cache/$cache_key"
-  fi
-
-  unset AWS_SHARED_CREDENTIALS_FILE
-  unset AWS_CONFIG_FILE
-fi
+./dev/ci/asdf-install.sh

--- a/dev/ci/asdf-install.sh
+++ b/dev/ci/asdf-install.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+# ASDF setup that either does a simple install, or pulls it from cache, geared towards
+# usage in CI.
+# In most cases you should not need to call this script directly.
+
+# TODO remove this when making job the default queue
+# Skip on normal queues because standard agents do not have fresh asdf installs
+if [[ ! "$BUILDKITE_AGENT_META_DATA_QUEUE" =~ .*job.* ]]; then
+  echo "~~~ asdf install"
+  asdf install
+  echo "done installing"
+  # We can't use exit 0 here, it would prevent the variables to be exported (that's a particular buildkite hook peculiarity).
+else
+  # We need awscli to use asdf cache
+  echo "~~~ asdf install from cache"
+  asdf install awscli
+  echo "done installing awscli"
+
+  # set the buildkite cache access keys
+  AWS_CONFIG_DIR_PATH="/buildkite/.aws"
+  mkdir -p "$AWS_CONFIG_DIR_PATH"
+  AWS_CONFIG_FILE="$AWS_CONFIG_DIR_PATH/config"
+  export AWS_CONFIG_FILE
+  AWS_SHARED_CREDENTIALS_FILE="/buildkite/.aws/credentials"
+  export AWS_SHARED_CREDENTIALS_FILE
+  aws configure set aws_access_key_id "$BUILDKITE_HMAC_KEY" --profile buildkite
+  aws configure set aws_secret_access_key "$BUILDKITE_HMAC_SECRET" --profile buildkite
+
+  asdf_checksum=$(sha1sum .tool-versions | awk '{print $1}')
+  cache_file="cache-asdf-$asdf_checksum.tar.gz"
+  cache_key="$BUILDKITE_ORGANIZATION_SLUG/$BUILDKITE_PIPELINE_NAME/$cache_file"
+
+  echo -e "ASDF 🔍 Locating cache: $cache_key"
+  if aws s3api head-object --bucket "sourcegraph_buildkite_cache" --profile buildkite --endpoint-url 'https://storage.googleapis.com' --region "us-central1" --key "$cache_key"; then
+    echo -e "ASDF 🔥 Cache hit: $cache_key"
+    aws s3 cp --profile buildkite --endpoint-url 'https://storage.googleapis.com' --region "us-central1" "s3://sourcegraph_buildkite_cache/$cache_key" "$HOME/"
+    pushd "$HOME" || exit
+    tar xzf "$cache_file"
+    popd || exit
+  else
+    echo -e "ASDF 🚨 Cache miss: $cache_key"
+    echo "~~~ fresh install of all asdf tool versions"
+    asdf install
+    echo "~~~ cache asdf installation"
+    pushd "$HOME" || exit
+    tar cfz "$cache_file" .asdf
+    popd || exit
+    aws s3 cp --profile buildkite --endpoint-url 'https://storage.googleapis.com' --region "us-central1" "$HOME/$cache_file" "s3://sourcegraph_buildkite_cache/$cache_key"
+  fi
+
+  unset AWS_SHARED_CREDENTIALS_FILE
+  unset AWS_CONFIG_FILE
+fi

--- a/dev/ci/go-backcompat/test.sh
+++ b/dev/ci/go-backcompat/test.sh
@@ -91,7 +91,7 @@ echo ""
 PROTECTED_FILES=(
   ./dev/ci/go-test.sh
   ./dev/ci/go-backcompat
-  ./.buildkite/hooks
+  ./dev/ci/asdf-install.sh
 )
 
 # Rewrite the current migrations into a temporary folder that we can force
@@ -132,7 +132,7 @@ fi
 
 # Re-run asdf to ensure we have the correct set of utilities to
 # run the currently checked out version of the Go unit tests.
-./.buildkite/hooks/pre-command
+./dev/ci/asdf-install.sh
 
 if ! ./dev/ci/go-test.sh "$@"; then
   annotation=$(

--- a/enterprise/dev/ci/internal/ci/changed/diff.go
+++ b/enterprise/dev/ci/internal/ci/changed/diff.go
@@ -68,6 +68,9 @@ func ParseDiff(files []string) (diff Diff) {
 		if strings.HasPrefix(p, "migrations/") {
 			diff |= (DatabaseSchema | Go)
 		}
+		if strings.HasPrefix(p, "dev/ci/go-backcompat") {
+			diff |= DatabaseSchema
+		}
 
 		// Affects docs
 		if strings.HasPrefix(p, "doc/") && p != "CHANGELOG.md" {


### PR DESCRIPTION
`.buildkite/pre-command` has a bunch of Buildkite-specific plumbing setup that interferes with the backcompat test script's ability to run locally. This PR extracts the required asdf installation script into a separate file, and calls that instead.

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


Confirmed that I can get to the test running part of the script locally. Also CI should pass.