### PR TITLE
Search backend: add standardized tracing for jobs

### DIFF
--- a/internal/search/job/expression_job.go
+++ b/internal/search/job/expression_job.go
@@ -8,9 +8,9 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/search"
+	"github.com/sourcegraph/sourcegraph/internal/search/job/jobutil"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
 	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
-	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
@@ -29,12 +29,9 @@ type AndJob struct {
 	children []Job
 }
 
-func (a *AndJob) Run(ctx context.Context, db database.DB, stream streaming.Sender) (_ *search.Alert, err error) {
-	tr, ctx := trace.New(ctx, "AndJob", "")
-	defer func() {
-		tr.SetError(err)
-		tr.Finish()
-	}()
+func (a *AndJob) Run(ctx context.Context, db database.DB, stream streaming.Sender) (alert *search.Alert, err error) {
+	tr, ctx := jobutil.StartSpan(ctx, a)
+	defer func() { jobutil.FinishSpan(tr, alert, err) }()
 
 	var (
 		g           errors.Group
@@ -127,12 +124,9 @@ type OrJob struct {
 // - The bias is towards documents that match all of our subqueries, so doesn't bias any individual subquery.
 //   Additionally, a bias towards matching all subqueries is probably desirable, since it's more likely that
 //   a document matching all subqueries is what the user is looking for than a document matching only one.
-func (j *OrJob) Run(ctx context.Context, db database.DB, stream streaming.Sender) (_ *search.Alert, err error) {
-	tr, ctx := trace.New(ctx, "OrJob", "")
-	defer func() {
-		tr.SetError(err)
-		tr.Finish()
-	}()
+func (j *OrJob) Run(ctx context.Context, db database.DB, stream streaming.Sender) (alert *search.Alert, err error) {
+	tr, ctx := jobutil.StartSpan(ctx, j)
+	defer func() { jobutil.FinishSpan(tr, alert, err) }()
 
 	var (
 		maxAlerter search.MaxAlerter

--- a/internal/search/job/job_test.go
+++ b/internal/search/job/job_test.go
@@ -34,21 +34,21 @@ func TestToSearchInputs(t *testing.T) {
     (PARALLEL
       ZoektRepoSubset
       Searcher))
-  Repo
+  RepoSearch
   ComputeExcludedRepos)
 `).Equal(t, test(`foo context:@userA`, search.Streaming, query.ParseLiteral))
 
 	autogold.Want("universal (AKA global) search context", `
 (PARALLEL
   ZoektGlobalSearch
-  Repo
+  RepoSearch
   ComputeExcludedRepos)
 `).Equal(t, test(`foo context:global`, search.Streaming, query.ParseLiteral))
 
 	autogold.Want("universal (AKA global) search", `
 (PARALLEL
   ZoektGlobalSearch
-  Repo
+  RepoSearch
   ComputeExcludedRepos)
 `).Equal(t, test(`foo`, search.Streaming, query.ParseLiteral))
 
@@ -58,7 +58,7 @@ func TestToSearchInputs(t *testing.T) {
     (PARALLEL
       ZoektRepoSubset
       Searcher))
-  Repo
+  RepoSearch
   ComputeExcludedRepos)
 `).Equal(t, test(`foo repo:sourcegraph/sourcegraph`, search.Streaming, query.ParseLiteral))
 
@@ -68,7 +68,7 @@ func TestToSearchInputs(t *testing.T) {
     (PARALLEL
       ZoektRepoSubset
       Searcher))
-  Repo
+  RepoSearch
   ComputeExcludedRepos)
 `).Equal(t, test(`foo repo:contains(bar)`, search.Streaming, query.ParseLiteral))
 
@@ -76,14 +76,14 @@ func TestToSearchInputs(t *testing.T) {
 	autogold.Want("supported Repo job", `
 (PARALLEL
   ZoektGlobalSearch
-  Repo
+  RepoSearch
   ComputeExcludedRepos)
 `).Equal(t, test("ok ok", search.Streaming, query.ParseRegexp))
 
 	autogold.Want("supportedRepo job literal", `
 (PARALLEL
   ZoektGlobalSearch
-  Repo
+  RepoSearch
   ComputeExcludedRepos)
 `).Equal(t, test("ok @thing", search.Streaming, query.ParseLiteral))
 
@@ -102,7 +102,7 @@ func TestToSearchInputs(t *testing.T) {
 	// Job generation for other types of search
 	autogold.Want("symbol", `
 (PARALLEL
-  RepoUniverseSymbol
+  RepoUniverseSymbolSearch
   ComputeExcludedRepos)
 `).Equal(t, test("type:symbol test", search.Streaming, query.ParseRegexp))
 
@@ -136,7 +136,7 @@ func TestToSearchInputs(t *testing.T) {
       ZoektSymbolSearch
       SymbolSearcher))
   Commit
-  Repo
+  RepoSearch
   ComputeExcludedRepos)
 `).Equal(t, test("type:file type:path type:repo type:commit type:symbol repo:test test", search.Streaming, query.ParseRegexp))
 
@@ -159,7 +159,7 @@ func TestToSearchInputs(t *testing.T) {
         (PARALLEL
           ZoektRepoSubset
           Searcher))
-      Repo
+      RepoSearch
       ComputeExcludedRepos))
   (OPTIONAL
     (PARALLEL
@@ -195,7 +195,7 @@ func TestToEvaluateJob(t *testing.T) {
     500
     (PARALLEL
       ZoektGlobalSearch
-      Repo
+      RepoSearch
       ComputeExcludedRepos)))
 `).Equal(t, test("foo", search.Streaming))
 
@@ -206,7 +206,7 @@ func TestToEvaluateJob(t *testing.T) {
     30
     (PARALLEL
       ZoektGlobalSearch
-      Repo
+      RepoSearch
       ComputeExcludedRepos)))
 `).Equal(t, test("foo", search.Batch))
 }

--- a/internal/search/job/jobutil/observe.go
+++ b/internal/search/job/jobutil/observe.go
@@ -1,0 +1,27 @@
+package jobutil
+
+import (
+	"context"
+
+	"github.com/opentracing/opentracing-go/log"
+
+	"github.com/sourcegraph/sourcegraph/internal/search"
+	"github.com/sourcegraph/sourcegraph/internal/trace"
+)
+
+type observableJob interface {
+	Name() string
+}
+
+func StartSpan(ctx context.Context, job observableJob) (*trace.Trace, context.Context) {
+	tr, ctx := trace.New(ctx, job.Name(), "")
+	return tr, ctx
+}
+
+func FinishSpan(tr *trace.Trace, alert *search.Alert, err error) {
+	tr.SetError(err)
+	if alert != nil {
+		tr.TagFields(log.String("alert", alert.Title))
+	}
+	tr.Finish()
+}

--- a/internal/search/job/printers_test.go
+++ b/internal/search/job/printers_test.go
@@ -250,7 +250,7 @@ func TestPrettyJSON(t *testing.T) {
       }
     },
     {
-      "Repo": {
+      "RepoSearch": {
         "Args": {
           "PatternInfo": {
             "Pattern": "bar",

--- a/internal/search/zoekt/symbol_search_job.go
+++ b/internal/search/zoekt/symbol_search_job.go
@@ -10,8 +10,8 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/search/filter"
+	"github.com/sourcegraph/sourcegraph/internal/search/job/jobutil"
 	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
-	"github.com/sourcegraph/sourcegraph/internal/trace"
 )
 
 type ZoektSymbolSearch struct {
@@ -24,12 +24,9 @@ type ZoektSymbolSearch struct {
 }
 
 // Run calls the zoekt backend to search symbols
-func (z *ZoektSymbolSearch) Run(ctx context.Context, _ database.DB, stream streaming.Sender) (_ *search.Alert, err error) {
-	tr, ctx := trace.New(ctx, "ZoektSymbolSearch", "")
-	defer func() {
-		tr.SetError(err)
-		tr.Finish()
-	}()
+func (z *ZoektSymbolSearch) Run(ctx context.Context, _ database.DB, stream streaming.Sender) (alert *search.Alert, err error) {
+	tr, ctx := jobutil.StartSpan(ctx, z)
+	defer func() { jobutil.FinishSpan(tr, alert, err) }()
 
 	if z.Repos == nil {
 		return nil, nil

--- a/internal/tracer/tracer.go
+++ b/internal/tracer/tracer.go
@@ -147,7 +147,6 @@ func initTracer(opts *options, c conftypes.WatchableSiteConfig) {
 
 // TODO Use openTelemetry https://github.com/sourcegraph/sourcegraph/issues/27386
 func newTracer(opts *options, prevTracer tracerType) (opentracing.Tracer, io.Closer, error) {
-	fmt.Printf("%#v\n", opts)
 	if opts.tracerType == None {
 		log15.Info("tracing disabled")
 		if prevTracer == Datadog {
@@ -172,7 +171,6 @@ func newTracer(opts *options, prevTracer tracerType) (opentracing.Tracer, io.Clo
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "jaegercfg.FromEnv failed")
 	}
-	fmt.Printf("%#v\n", cfg)
 	cfg.Tags = append(cfg.Tags, opentracing.Tag{Key: "service.version", Value: version.Version()})
 	if reflect.DeepEqual(cfg.Sampler, &jaegercfg.SamplerConfig{}) {
 		// Default sampler configuration for when it is not specified via

--- a/internal/tracer/tracer.go
+++ b/internal/tracer/tracer.go
@@ -147,6 +147,7 @@ func initTracer(opts *options, c conftypes.WatchableSiteConfig) {
 
 // TODO Use openTelemetry https://github.com/sourcegraph/sourcegraph/issues/27386
 func newTracer(opts *options, prevTracer tracerType) (opentracing.Tracer, io.Closer, error) {
+	fmt.Printf("%#v\n", opts)
 	if opts.tracerType == None {
 		log15.Info("tracing disabled")
 		if prevTracer == Datadog {
@@ -171,6 +172,7 @@ func newTracer(opts *options, prevTracer tracerType) (opentracing.Tracer, io.Clo
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "jaegercfg.FromEnv failed")
 	}
+	fmt.Printf("%#v\n", cfg)
 	cfg.Tags = append(cfg.Tags, opentracing.Tag{Key: "service.version", Value: version.Version()})
 	if reflect.DeepEqual(cfg.Sampler, &jaegercfg.SamplerConfig{}) {
 		// Default sampler configuration for when it is not specified via


### PR DESCRIPTION
This adds some utility functions for tracing search jobs. They live in a new subpackage
of `internal/search/job` because jobs cannot import the `job` package because the `job`
package imports all the jobs for pretty printing (we could use some dep inversion here).

Right now, these functions are very minimal. They basically just set the trace title to 
`job.Name()` and set the error and alert on job completion. However, having one place
to handle all this will allow us to quickly add some richness to our traces with things like
job args, logs for events, total events streamed through the job, etc.

## Test plan

Manually tested locally. See screenshot and note the new `alert` tag. 

<img width="2018" alt="Screen Shot 2022-03-18 at 14 16 32" src="https://user-images.githubusercontent.com/12631702/159077392-b16e39a5-8456-40bc-b396-8537f4e33372.png">




<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


