### PR TITLE
code monitoring: update email template

### DIFF
--- a/enterprise/internal/codemonitors/background/email.go
+++ b/enterprise/internal/codemonitors/background/email.go
@@ -41,56 +41,58 @@ var (
 )
 
 var newSearchResultsEmailTemplates = txemail.MustValidate(txtypes.Templates{
-	Subject: `{{ if .IsTest }}Test: {{ end }}[{{.Priority}} event] {{.Description}}`,
+	Subject: `{{ if .IsTest }}Test: {{ end }}{{.Priority}}Sourcegraph code monitor {{.Description}} detected {{.NumberOfResults}} new {{.ResultPluralized}}`,
 	Text:    textTemplate,
 	HTML:    htmlTemplate,
 })
 
 type TemplateDataNewSearchResults struct {
-	Priority                  string
-	CodeMonitorURL            string
-	SearchURL                 string
-	Description               string
-	NumberOfResultsWithDetail string
-	IsTest                    bool
+	Priority         string
+	CodeMonitorURL   string
+	SearchURL        string
+	Description      string
+	NumberOfResults  int
+	ResultPluralized string
+	IsTest           bool
 }
 
 func NewTemplateDataForNewSearchResults(args actionArgs, email *edb.EmailAction) (d *TemplateDataNewSearchResults, err error) {
 	var (
-		priority                  string
-		numberOfResultsWithDetail string
+		priority         string
+		resultPluralized string
 	)
 
 	searchURL := getSearchURL(args.ExternalURL, args.Query, utmSourceEmail)
 	codeMonitorURL := getCodeMonitorURL(args.ExternalURL, email.Monitor, utmSourceEmail)
 
 	if email.Priority == priorityCritical {
-		priority = "Critical"
+		priority = " [Critical]"
 	} else {
-		priority = "New"
+		priority = ""
 	}
 
 	if len(args.Results) == 1 {
-		numberOfResultsWithDetail = fmt.Sprintf("There was %d new search result for your query", len(args.Results))
+		resultPluralized = "result"
 	} else {
-		numberOfResultsWithDetail = fmt.Sprintf("There were %d new search results for your query", len(args.Results))
+		resultPluralized = "results"
 	}
 
 	return &TemplateDataNewSearchResults{
-		Priority:                  priority,
-		CodeMonitorURL:            codeMonitorURL,
-		SearchURL:                 searchURL,
-		Description:               args.MonitorDescription,
-		NumberOfResultsWithDetail: numberOfResultsWithDetail,
+		Priority:         priority,
+		CodeMonitorURL:   codeMonitorURL,
+		SearchURL:        searchURL,
+		Description:      args.MonitorDescription,
+		NumberOfResults:  len(args.Results),
+		ResultPluralized: resultPluralized,
 	}, nil
 }
 
 func NewTestTemplateDataForNewSearchResults(ctx context.Context, monitorDescription string) *TemplateDataNewSearchResults {
 	return &TemplateDataNewSearchResults{
-		Priority:                  "New",
-		Description:               monitorDescription,
-		NumberOfResultsWithDetail: "There was 1 new search result for your query",
-		IsTest:                    true,
+		Priority:        "New",
+		Description:     monitorDescription,
+		NumberOfResults: 1,
+		IsTest:          true,
 	}
 }
 

--- a/enterprise/internal/codemonitors/background/email.go
+++ b/enterprise/internal/codemonitors/background/email.go
@@ -89,10 +89,11 @@ func NewTemplateDataForNewSearchResults(args actionArgs, email *edb.EmailAction)
 
 func NewTestTemplateDataForNewSearchResults(ctx context.Context, monitorDescription string) *TemplateDataNewSearchResults {
 	return &TemplateDataNewSearchResults{
-		Priority:        "New",
-		Description:     monitorDescription,
-		NumberOfResults: 1,
-		IsTest:          true,
+		Priority:         "",
+		Description:      monitorDescription,
+		NumberOfResults:  1,
+		IsTest:           true,
+		ResultPluralized: "result",
 	}
 }
 

--- a/enterprise/internal/codemonitors/background/email.go
+++ b/enterprise/internal/codemonitors/background/email.go
@@ -66,7 +66,7 @@ func NewTemplateDataForNewSearchResults(args actionArgs, email *edb.EmailAction)
 	codeMonitorURL := getCodeMonitorURL(args.ExternalURL, email.Monitor, utmSourceEmail)
 
 	if email.Priority == priorityCritical {
-		priority = " [Critical]"
+		priority = "[Critical] "
 	} else {
 		priority = ""
 	}

--- a/enterprise/internal/codemonitors/background/email_template.html.tmpl
+++ b/enterprise/internal/codemonitors/background/email_template.html.tmpl
@@ -1,44 +1,38 @@
 <!DOCTYPE html>
 <html>
   <body>
-	{{ if .IsTest }}
-	<p style="color: #523704; padding: 16px; background-color: #FDECCC; font-size: 14px; line-height: 21px; border-radius: 4px; margin-bottom: 50px">
-		<span style="font-weight: 700">This email is a preview.</span>&nbsp;<span style="font-weight: 400">Links are disabled.</span>
-	</p>
-	{{ end }}
+{{ if .IsTest }}
+    <p style="color: #523704; padding: 16px; background-color: #FDECCC; font-size: 14px; line-height: 21px; border-radius: 4px; margin-bottom: 50px">
+      <span style="font-weight: 700">This email is a preview.</span>&nbsp;<span style="font-weight: 400">Links are disabled.</span>
+    </p>
+{{ end }}
+
+    <h1 style="font-size: 18px; line-height: 24px">
+      Your Sourcegraph code monitor, <b>{{.Description}}</b>, detected <b>{{.NumberOfResults}}</b> new {{.ResultPluralized}}.
+    </h1>
 
     <p style="font-size: 16px; line-height: 24px">
-      Code monitoring triggered a new event:
-    </p>
-
-    <p style="font-size: 20px; line-height: 30px; font-weight: 700">
-      {{.Description}}<br />
-      <span style="font-size: 16px; line-height: 24px; font-weight: 400">{{.NumberOfResultsWithDetail}}</span>
-    </p>
-
-	<p style="font-size: 16px; line-height: 24px">
-	  <a href="{{.SearchURL}}" {{ if .IsTest }}style="color: #9C9FA6; font-weight: 400; text-decoration: underline; cursor: default"{{ end }}>
+      <a href="{{.SearchURL}}" {{ if .IsTest }}style="color: #9C9FA6; font-weight: 400; text-decoration: underline; cursor: default"{{ end }}>
         View search on Sourcegraph
-	  </a>
+      </a>
     </p>
 
     <br />
     <br />
     __
     <p style="font-size: 14px; line-height: 24px">
-      You are receiving this notification because you are a recipient on a code
-      monitor.
+      You are receiving this notification because you are a recipient on a code monitor.
     </p>
     <p style="font-size: 14px; line-height: 24px">
-	  <a href="{{.CodeMonitorURL}}" {{ if .IsTest }}style="color: #9C9FA6; font-weight: 400; text-decoration: underline; cursor: default"{{ end }}>
-	    View code monitor
-	  </a>
+      <a href="{{.CodeMonitorURL}}" {{ if .IsTest }}style="color: #9C9FA6; font-weight: 400; text-decoration: underline; cursor: default"{{ end }}>
+        View code monitor
+      </a>
     </p>
     <p style="font-size: 12px; line-height: 24px; margin-bottom: 24px">
       Search results may contain confidential data. To protect your privacy and
       security, Sourcegraph limits what information is contained in this
       notification.
-	</p>
-	<img src="https://about.sourcegraph.com/sourcegraph-logo-small.png" width="106" height="20" alt="Sourcegraph logo" />
+    </p>
+    <img src="https://about.sourcegraph.com/sourcegraph-logo-small.png" width="106" height="20" alt="Sourcegraph logo" />
   </body>
 </html>

--- a/enterprise/internal/codemonitors/background/email_template.html.tmpl
+++ b/enterprise/internal/codemonitors/background/email_template.html.tmpl
@@ -17,8 +17,6 @@
       </a>
     </p>
 
-    <br />
-    <br />
     __
     <p style="font-size: 14px; line-height: 24px">
       You are receiving this notification because you are a recipient on a code monitor.

--- a/enterprise/internal/codemonitors/background/email_template.txt.tmpl
+++ b/enterprise/internal/codemonitors/background/email_template.txt.tmpl
@@ -1,11 +1,8 @@
 {{ if .IsTest }}This email is a preview. Links are disabled.{{ end }}
 
-Code monitoring triggered a new event:
+Your Sourcegraph code monitor, {{.Description}}, detected {{.NumberOfResults}} new {{.ResultPluralized}}.
 
-{{.Description}}
-{{.NumberOfResultsWithDetail}}
-
-View search on Sourcegraph {{.SearchURL}}
+View search on Sourcegraph: {{.SearchURL}}
 
 __
 You are receiving this notification because you are a recipient on a code monitor.

--- a/enterprise/internal/codemonitors/background/email_test.go
+++ b/enterprise/internal/codemonitors/background/email_test.go
@@ -15,12 +15,13 @@ func TestEmail(t *testing.T) {
 
 	t.Run("test message", func(t *testing.T) {
 		templateData := &TemplateDataNewSearchResults{
-			Priority:                  "New",
-			CodeMonitorURL:            "https://sourcegraph.com/your/code/monitor",
-			SearchURL:                 "https://sourcegraph.com/search",
-			Description:               "My test monitor",
-			NumberOfResultsWithDetail: "There was 1 new search result for your query",
-			IsTest:                    true,
+			Priority:         "",
+			CodeMonitorURL:   "https://sourcegraph.com/your/code/monitor",
+			SearchURL:        "https://sourcegraph.com/search",
+			Description:      "My test monitor",
+			NumberOfResults:  1,
+			IsTest:           true,
+			ResultPluralized: "result",
 		}
 
 		t.Run("html", func(t *testing.T) {
@@ -41,17 +42,18 @@ func TestEmail(t *testing.T) {
 			var buf bytes.Buffer
 			err := template.Subj.Execute(&buf, templateData)
 			require.NoError(t, err)
-			require.Equal(t, "Test: [New event] My test monitor", buf.String())
+			require.Equal(t, "Test: Sourcegraph code monitor My test monitor detected 1 new result", buf.String())
 		})
 	})
 
 	t.Run("one result", func(t *testing.T) {
 		templateData := &TemplateDataNewSearchResults{
-			Priority:                  "New",
-			CodeMonitorURL:            "https://sourcegraph.com/your/code/monitor",
-			SearchURL:                 "https://sourcegraph.com/search",
-			Description:               "My test monitor",
-			NumberOfResultsWithDetail: "There was 1 new search result for your query",
+			Priority:         "",
+			CodeMonitorURL:   "https://sourcegraph.com/your/code/monitor",
+			SearchURL:        "https://sourcegraph.com/search",
+			Description:      "My test monitor",
+			NumberOfResults:  1,
+			ResultPluralized: "result",
 		}
 
 		t.Run("html", func(t *testing.T) {
@@ -72,17 +74,18 @@ func TestEmail(t *testing.T) {
 			var buf bytes.Buffer
 			err := template.Subj.Execute(&buf, templateData)
 			require.NoError(t, err)
-			require.Equal(t, "[New event] My test monitor", buf.String())
+			require.Equal(t, "Sourcegraph code monitor My test monitor detected 1 new result", buf.String())
 		})
 	})
 
 	t.Run("multiple results", func(t *testing.T) {
 		templateData := &TemplateDataNewSearchResults{
-			Priority:                  "New",
-			CodeMonitorURL:            "https://sourcegraph.com/your/code/monitor",
-			SearchURL:                 "https://sourcegraph.com/search",
-			Description:               "My test monitor",
-			NumberOfResultsWithDetail: "There was 1 new search result for your query",
+			Priority:         "",
+			CodeMonitorURL:   "https://sourcegraph.com/your/code/monitor",
+			SearchURL:        "https://sourcegraph.com/search",
+			Description:      "My test monitor",
+			NumberOfResults:  2,
+			ResultPluralized: "results",
 		}
 
 		t.Run("html", func(t *testing.T) {
@@ -103,7 +106,7 @@ func TestEmail(t *testing.T) {
 			var buf bytes.Buffer
 			err := template.Subj.Execute(&buf, templateData)
 			require.NoError(t, err)
-			require.Equal(t, "[New event] My test monitor", buf.String())
+			require.Equal(t, "Sourcegraph code monitor My test monitor detected 2 new results", buf.String())
 		})
 	})
 }

--- a/enterprise/internal/codemonitors/background/testdata/TestEmail/multiple_results/html.html
+++ b/enterprise/internal/codemonitors/background/testdata/TestEmail/multiple_results/html.html
@@ -13,8 +13,6 @@
       </a>
     </p>
 
-    <br />
-    <br />
     __
     <p style="font-size: 14px; line-height: 24px">
       You are receiving this notification because you are a recipient on a code monitor.

--- a/enterprise/internal/codemonitors/background/testdata/TestEmail/multiple_results/html.html
+++ b/enterprise/internal/codemonitors/background/testdata/TestEmail/multiple_results/html.html
@@ -1,40 +1,34 @@
 <!DOCTYPE html>
 <html>
   <body>
-	
+
+
+    <h1 style="font-size: 18px; line-height: 24px">
+      Your Sourcegraph code monitor, <b>My test monitor</b>, detected <b>2</b> new results.
+    </h1>
 
     <p style="font-size: 16px; line-height: 24px">
-      Code monitoring triggered a new event:
-    </p>
-
-    <p style="font-size: 20px; line-height: 30px; font-weight: 700">
-      My test monitor<br />
-      <span style="font-size: 16px; line-height: 24px; font-weight: 400">There was 1 new search result for your query</span>
-    </p>
-
-	<p style="font-size: 16px; line-height: 24px">
-	  <a href="https://sourcegraph.com/search" >
+      <a href="https://sourcegraph.com/search" >
         View search on Sourcegraph
-	  </a>
+      </a>
     </p>
 
     <br />
     <br />
     __
     <p style="font-size: 14px; line-height: 24px">
-      You are receiving this notification because you are a recipient on a code
-      monitor.
+      You are receiving this notification because you are a recipient on a code monitor.
     </p>
     <p style="font-size: 14px; line-height: 24px">
-	  <a href="https://sourcegraph.com/your/code/monitor" >
-	    View code monitor
-	  </a>
+      <a href="https://sourcegraph.com/your/code/monitor" >
+        View code monitor
+      </a>
     </p>
     <p style="font-size: 12px; line-height: 24px; margin-bottom: 24px">
       Search results may contain confidential data. To protect your privacy and
       security, Sourcegraph limits what information is contained in this
       notification.
-	</p>
-	<img src="https://about.sourcegraph.com/sourcegraph-logo-small.png" width="106" height="20" alt="Sourcegraph logo" />
+    </p>
+    <img src="https://about.sourcegraph.com/sourcegraph-logo-small.png" width="106" height="20" alt="Sourcegraph logo" />
   </body>
 </html>

--- a/enterprise/internal/codemonitors/background/testdata/TestEmail/multiple_results/text.txt
+++ b/enterprise/internal/codemonitors/background/testdata/TestEmail/multiple_results/text.txt
@@ -1,11 +1,8 @@
 
 
-Code monitoring triggered a new event:
+Your Sourcegraph code monitor, My test monitor, detected 2 new results.
 
-My test monitor
-There was 1 new search result for your query
-
-View search on Sourcegraph https://sourcegraph.com/search
+View search on Sourcegraph: https://sourcegraph.com/search
 
 __
 You are receiving this notification because you are a recipient on a code monitor.

--- a/enterprise/internal/codemonitors/background/testdata/TestEmail/one_result/html.html
+++ b/enterprise/internal/codemonitors/background/testdata/TestEmail/one_result/html.html
@@ -13,8 +13,6 @@
       </a>
     </p>
 
-    <br />
-    <br />
     __
     <p style="font-size: 14px; line-height: 24px">
       You are receiving this notification because you are a recipient on a code monitor.

--- a/enterprise/internal/codemonitors/background/testdata/TestEmail/one_result/html.html
+++ b/enterprise/internal/codemonitors/background/testdata/TestEmail/one_result/html.html
@@ -1,40 +1,34 @@
 <!DOCTYPE html>
 <html>
   <body>
-	
+
+
+    <h1 style="font-size: 18px; line-height: 24px">
+      Your Sourcegraph code monitor, <b>My test monitor</b>, detected <b>1</b> new result.
+    </h1>
 
     <p style="font-size: 16px; line-height: 24px">
-      Code monitoring triggered a new event:
-    </p>
-
-    <p style="font-size: 20px; line-height: 30px; font-weight: 700">
-      My test monitor<br />
-      <span style="font-size: 16px; line-height: 24px; font-weight: 400">There was 1 new search result for your query</span>
-    </p>
-
-	<p style="font-size: 16px; line-height: 24px">
-	  <a href="https://sourcegraph.com/search" >
+      <a href="https://sourcegraph.com/search" >
         View search on Sourcegraph
-	  </a>
+      </a>
     </p>
 
     <br />
     <br />
     __
     <p style="font-size: 14px; line-height: 24px">
-      You are receiving this notification because you are a recipient on a code
-      monitor.
+      You are receiving this notification because you are a recipient on a code monitor.
     </p>
     <p style="font-size: 14px; line-height: 24px">
-	  <a href="https://sourcegraph.com/your/code/monitor" >
-	    View code monitor
-	  </a>
+      <a href="https://sourcegraph.com/your/code/monitor" >
+        View code monitor
+      </a>
     </p>
     <p style="font-size: 12px; line-height: 24px; margin-bottom: 24px">
       Search results may contain confidential data. To protect your privacy and
       security, Sourcegraph limits what information is contained in this
       notification.
-	</p>
-	<img src="https://about.sourcegraph.com/sourcegraph-logo-small.png" width="106" height="20" alt="Sourcegraph logo" />
+    </p>
+    <img src="https://about.sourcegraph.com/sourcegraph-logo-small.png" width="106" height="20" alt="Sourcegraph logo" />
   </body>
 </html>

--- a/enterprise/internal/codemonitors/background/testdata/TestEmail/one_result/text.txt
+++ b/enterprise/internal/codemonitors/background/testdata/TestEmail/one_result/text.txt
@@ -1,11 +1,8 @@
 
 
-Code monitoring triggered a new event:
+Your Sourcegraph code monitor, My test monitor, detected 1 new result.
 
-My test monitor
-There was 1 new search result for your query
-
-View search on Sourcegraph https://sourcegraph.com/search
+View search on Sourcegraph: https://sourcegraph.com/search
 
 __
 You are receiving this notification because you are a recipient on a code monitor.

--- a/enterprise/internal/codemonitors/background/testdata/TestEmail/test_message/html.html
+++ b/enterprise/internal/codemonitors/background/testdata/TestEmail/test_message/html.html
@@ -1,44 +1,38 @@
 <!DOCTYPE html>
 <html>
   <body>
-	
-	<p style="color: #523704; padding: 16px; background-color: #FDECCC; font-size: 14px; line-height: 21px; border-radius: 4px; margin-bottom: 50px">
-		<span style="font-weight: 700">This email is a preview.</span>&nbsp;<span style="font-weight: 400">Links are disabled.</span>
-	</p>
-	
+
+    <p style="color: #523704; padding: 16px; background-color: #FDECCC; font-size: 14px; line-height: 21px; border-radius: 4px; margin-bottom: 50px">
+      <span style="font-weight: 700">This email is a preview.</span>&nbsp;<span style="font-weight: 400">Links are disabled.</span>
+    </p>
+
+
+    <h1 style="font-size: 18px; line-height: 24px">
+      Your Sourcegraph code monitor, <b>My test monitor</b>, detected <b>1</b> new result.
+    </h1>
 
     <p style="font-size: 16px; line-height: 24px">
-      Code monitoring triggered a new event:
-    </p>
-
-    <p style="font-size: 20px; line-height: 30px; font-weight: 700">
-      My test monitor<br />
-      <span style="font-size: 16px; line-height: 24px; font-weight: 400">There was 1 new search result for your query</span>
-    </p>
-
-	<p style="font-size: 16px; line-height: 24px">
-	  <a href="https://sourcegraph.com/search" style="color: #9C9FA6; font-weight: 400; text-decoration: underline; cursor: default">
+      <a href="https://sourcegraph.com/search" style="color: #9C9FA6; font-weight: 400; text-decoration: underline; cursor: default">
         View search on Sourcegraph
-	  </a>
+      </a>
     </p>
 
     <br />
     <br />
     __
     <p style="font-size: 14px; line-height: 24px">
-      You are receiving this notification because you are a recipient on a code
-      monitor.
+      You are receiving this notification because you are a recipient on a code monitor.
     </p>
     <p style="font-size: 14px; line-height: 24px">
-	  <a href="https://sourcegraph.com/your/code/monitor" style="color: #9C9FA6; font-weight: 400; text-decoration: underline; cursor: default">
-	    View code monitor
-	  </a>
+      <a href="https://sourcegraph.com/your/code/monitor" style="color: #9C9FA6; font-weight: 400; text-decoration: underline; cursor: default">
+        View code monitor
+      </a>
     </p>
     <p style="font-size: 12px; line-height: 24px; margin-bottom: 24px">
       Search results may contain confidential data. To protect your privacy and
       security, Sourcegraph limits what information is contained in this
       notification.
-	</p>
-	<img src="https://about.sourcegraph.com/sourcegraph-logo-small.png" width="106" height="20" alt="Sourcegraph logo" />
+    </p>
+    <img src="https://about.sourcegraph.com/sourcegraph-logo-small.png" width="106" height="20" alt="Sourcegraph logo" />
   </body>
 </html>

--- a/enterprise/internal/codemonitors/background/testdata/TestEmail/test_message/html.html
+++ b/enterprise/internal/codemonitors/background/testdata/TestEmail/test_message/html.html
@@ -17,8 +17,6 @@
       </a>
     </p>
 
-    <br />
-    <br />
     __
     <p style="font-size: 14px; line-height: 24px">
       You are receiving this notification because you are a recipient on a code monitor.

--- a/enterprise/internal/codemonitors/background/testdata/TestEmail/test_message/text.txt
+++ b/enterprise/internal/codemonitors/background/testdata/TestEmail/test_message/text.txt
@@ -1,11 +1,8 @@
 This email is a preview. Links are disabled.
 
-Code monitoring triggered a new event:
+Your Sourcegraph code monitor, My test monitor, detected 1 new result.
 
-My test monitor
-There was 1 new search result for your query
-
-View search on Sourcegraph https://sourcegraph.com/search
+View search on Sourcegraph: https://sourcegraph.com/search
 
 __
 You are receiving this notification because you are a recipient on a code monitor.

--- a/enterprise/internal/codemonitors/background/workers_test.go
+++ b/enterprise/internal/codemonitors/background/workers_test.go
@@ -16,19 +16,19 @@ import (
 
 func TestActionRunner(t *testing.T) {
 	tests := []struct {
-		name               string
-		results            []*result.CommitMatch
-		wantNumResultsText string
+		name           string
+		results        []*result.CommitMatch
+		wantNumResults int
 	}{
 		{
-			name:               "5 results",
-			results:            make([]*result.CommitMatch, 5),
-			wantNumResultsText: "There were 5 new search results for your query",
+			name:           "5 results",
+			results:        make([]*result.CommitMatch, 5),
+			wantNumResults: 5,
 		},
 		{
-			name:               "1 result",
-			results:            make([]*result.CommitMatch, 1),
-			wantNumResultsText: "There was 1 new search result for your query",
+			name:           "1 result",
+			results:        make([]*result.CommitMatch, 1),
+			wantNumResults: 1,
 		},
 	}
 
@@ -80,14 +80,21 @@ func TestActionRunner(t *testing.T) {
 			err = a.Handle(ctx, record)
 			require.NoError(t, err)
 
-			want := TemplateDataNewSearchResults{
-				Priority:       "New",
-				SearchURL:      externalURL + "/search?q=test+patternType%3Aliteral&utm_source=code-monitoring-email",
-				Description:    "test description",
-				CodeMonitorURL: externalURL + "/code-monitoring/" + string(relay.MarshalID("CodeMonitor", 1)) + "?utm_source=code-monitoring-email",
+			wantResultsPluralized := "results"
+			if tt.wantNumResults == 1 {
+				wantResultsPluralized = "result"
 			}
 
-			want.NumberOfResultsWithDetail = tt.wantNumResultsText
+			want := TemplateDataNewSearchResults{
+				Priority:         "",
+				SearchURL:        externalURL + "/search?q=test+patternType%3Aliteral&utm_source=code-monitoring-email",
+				Description:      "test description",
+				CodeMonitorURL:   externalURL + "/code-monitoring/" + string(relay.MarshalID("CodeMonitor", 1)) + "?utm_source=code-monitoring-email",
+				NumberOfResults:  tt.wantNumResults,
+				ResultPluralized: wantResultsPluralized,
+			}
+
+			want.NumberOfResults = tt.wantNumResults
 			require.Equal(t, want, got)
 		})
 	}


### PR DESCRIPTION
Part of #31580

Updates code monitoring email templates to match the new format [described in this doc](https://docs.google.com/document/d/1iqpCma3Em6fj4Mkv6PRo-4lszIMMxKTW45PzXqRBDEo/edit).
Conditional results will be added in a subsequent PR.

### Template from test data rendered in a browser
![image](https://user-images.githubusercontent.com/206864/159085754-643a4711-7048-49d1-a12c-3e1edb584d5c.png)

### Test email rendered in Gmail

![image](https://user-images.githubusercontent.com/206864/159087015-4f7806cb-6d78-455a-974c-fe3e4c2355e9.png)

## Test plan

- Updated Go unit tests to check that the new template is rendered
- Manual testing of test email