### PR TITLE
Search backend: add stream tracing

### DIFF
--- a/internal/search/commit/commit.go
+++ b/internal/search/commit/commit.go
@@ -49,8 +49,8 @@ type GitserverClient interface {
 }
 
 func (j *CommitSearch) Run(ctx context.Context, db database.DB, stream streaming.Sender) (alert *search.Alert, err error) {
-	tr, ctx := jobutil.StartSpan(ctx, j)
-	defer func() { jobutil.FinishSpan(tr, alert, err) }()
+	tr, ctx, stream, finish := jobutil.StartSpan(ctx, stream, j)
+	defer func() { finish(alert, err) }()
 	tr.TagFields(trace.LazyFields(j.Tags))
 
 	if err := j.ExpandUsernames(ctx, db); err != nil {

--- a/internal/search/job/alert.go
+++ b/internal/search/job/alert.go
@@ -32,8 +32,8 @@ type alertJob struct {
 }
 
 func (j *alertJob) Run(ctx context.Context, db database.DB, stream streaming.Sender) (alert *search.Alert, err error) {
-	tr, ctx := jobutil.StartSpan(ctx, j)
-	defer func() { jobutil.FinishSpan(tr, alert, err) }()
+	_, ctx, stream, finish := jobutil.StartSpan(ctx, stream, j)
+	defer func() { finish(alert, err) }()
 
 	start := time.Now()
 	countingStream := streaming.NewResultCountingStream(stream)

--- a/internal/search/job/combinators.go
+++ b/internal/search/job/combinators.go
@@ -36,8 +36,8 @@ func (r *PriorityJob) Name() string {
 }
 
 func (r *PriorityJob) Run(ctx context.Context, db database.DB, s streaming.Sender) (alert *search.Alert, err error) {
-	tr, ctx := jobutil.StartSpan(ctx, r)
-	defer func() { jobutil.FinishSpan(tr, alert, err) }()
+	tr, ctx, s, finish := jobutil.StartSpan(ctx, s, r)
+	defer func() { finish(alert, err) }()
 
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
@@ -102,8 +102,8 @@ func (p *ParallelJob) Name() string {
 }
 
 func (p *ParallelJob) Run(ctx context.Context, db database.DB, s streaming.Sender) (alert *search.Alert, err error) {
-	tr, ctx := jobutil.StartSpan(ctx, p)
-	defer func() { jobutil.FinishSpan(tr, alert, err) }()
+	_, ctx, s, finish := jobutil.StartSpan(ctx, s, p)
+	defer func() { finish(alert, err) }()
 
 	var (
 		g          errors.Group
@@ -138,8 +138,8 @@ type TimeoutJob struct {
 }
 
 func (t *TimeoutJob) Run(ctx context.Context, db database.DB, s streaming.Sender) (alert *search.Alert, err error) {
-	tr, ctx := jobutil.StartSpan(ctx, t)
-	defer func() { jobutil.FinishSpan(tr, alert, err) }()
+	_, ctx, s, finish := jobutil.StartSpan(ctx, s, t)
+	defer func() { finish(alert, err) }()
 
 	ctx, cancel := context.WithTimeout(ctx, t.timeout)
 	defer cancel()
@@ -171,8 +171,8 @@ type LimitJob struct {
 }
 
 func (l *LimitJob) Run(ctx context.Context, db database.DB, s streaming.Sender) (alert *search.Alert, err error) {
-	tr, ctx := jobutil.StartSpan(ctx, l)
-	defer func() { jobutil.FinishSpan(tr, alert, err) }()
+	_, ctx, s, finish := jobutil.StartSpan(ctx, s, l)
+	defer func() { finish(alert, err) }()
 
 	ctx, s, cancel := streaming.WithLimit(ctx, s, l.limit)
 	defer cancel()

--- a/internal/search/job/expression_job.go
+++ b/internal/search/job/expression_job.go
@@ -30,8 +30,8 @@ type AndJob struct {
 }
 
 func (a *AndJob) Run(ctx context.Context, db database.DB, stream streaming.Sender) (alert *search.Alert, err error) {
-	tr, ctx := jobutil.StartSpan(ctx, a)
-	defer func() { jobutil.FinishSpan(tr, alert, err) }()
+	_, ctx, stream, finish := jobutil.StartSpan(ctx, stream, a)
+	defer func() { finish(alert, err) }()
 
 	var (
 		g           errors.Group
@@ -125,8 +125,8 @@ type OrJob struct {
 //   Additionally, a bias towards matching all subqueries is probably desirable, since it's more likely that
 //   a document matching all subqueries is what the user is looking for than a document matching only one.
 func (j *OrJob) Run(ctx context.Context, db database.DB, stream streaming.Sender) (alert *search.Alert, err error) {
-	tr, ctx := jobutil.StartSpan(ctx, j)
-	defer func() { jobutil.FinishSpan(tr, alert, err) }()
+	_, ctx, stream, finish := jobutil.StartSpan(ctx, stream, j)
+	defer func() { finish(alert, err) }()
 
 	var (
 		maxAlerter search.MaxAlerter

--- a/internal/search/job/jobutil/observe.go
+++ b/internal/search/job/jobutil/observe.go
@@ -4,24 +4,58 @@ import (
 	"context"
 
 	"github.com/opentracing/opentracing-go/log"
+	"go.uber.org/atomic"
 
 	"github.com/sourcegraph/sourcegraph/internal/search"
+	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
+	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
 )
 
 type observableJob interface {
 	Name() string
 }
 
-func StartSpan(ctx context.Context, job observableJob) (*trace.Trace, context.Context) {
+type finishSpanFunc func(*search.Alert, error)
+
+func StartSpan(ctx context.Context, stream streaming.Sender, job observableJob) (*trace.Trace, context.Context, streaming.Sender, finishSpanFunc) {
 	tr, ctx := trace.New(ctx, job.Name(), "")
-	return tr, ctx
+
+	basicFinish := func(alert *search.Alert, err error) {
+		tr.SetError(err)
+		if alert != nil {
+			tr.TagFields(log.String("alert", alert.Title))
+		}
+		tr.Finish()
+	}
+
+	if ot.ShouldTrace(ctx) {
+		// Only wrap the stream if we are actually tracing since the stream
+		// wrapper is not zero cost.
+		observingStream := newObservingStream(tr, stream)
+		return tr, ctx, observingStream, func(alert *search.Alert, err error) {
+			tr.LogFields(log.Int64("total_results", observingStream.totalEvents.Load()))
+			basicFinish(alert, err)
+		}
+	}
+
+	return tr, ctx, stream, basicFinish
 }
 
-func FinishSpan(tr *trace.Trace, alert *search.Alert, err error) {
-	tr.SetError(err)
-	if alert != nil {
-		tr.TagFields(log.String("alert", alert.Title))
+func newObservingStream(tr *trace.Trace, parent streaming.Sender) *observingStream {
+	return &observingStream{tr: tr, parent: parent}
+}
+
+type observingStream struct {
+	tr          *trace.Trace
+	parent      streaming.Sender
+	totalEvents atomic.Int64
+}
+
+func (o *observingStream) Send(event streaming.SearchEvent) {
+	if l := len(event.Results); l > 0 {
+		o.tr.LogFields(log.Int("results", l))
+		o.totalEvents.Add(int64(l))
 	}
-	tr.Finish()
+	o.parent.Send(event)
 }

--- a/internal/search/job/repo_pager_job.go
+++ b/internal/search/job/repo_pager_job.go
@@ -61,8 +61,8 @@ func setRepos(job Job, indexed *zoekt.IndexedRepoRevs, unindexed []*search.Repos
 }
 
 func (p *repoPagerJob) Run(ctx context.Context, db database.DB, stream streaming.Sender) (alert *search.Alert, err error) {
-	tr, ctx := jobutil.StartSpan(ctx, p)
-	defer func() { jobutil.FinishSpan(tr, alert, err) }()
+	_, ctx, stream, finish := jobutil.StartSpan(ctx, stream, p)
+	defer func() { finish(alert, err) }()
 
 	var maxAlerter search.MaxAlerter
 

--- a/internal/search/job/select.go
+++ b/internal/search/job/select.go
@@ -22,8 +22,8 @@ type selectJob struct {
 }
 
 func (j *selectJob) Run(ctx context.Context, db database.DB, stream streaming.Sender) (alert *search.Alert, err error) {
-	tr, ctx := jobutil.StartSpan(ctx, j)
-	defer func() { jobutil.FinishSpan(tr, alert, err) }()
+	_, ctx, stream, finish := jobutil.StartSpan(ctx, stream, j)
+	defer func() { finish(alert, err) }()
 
 	selectingStream := streaming.WithSelect(stream, j.path)
 	return j.child.Run(ctx, db, selectingStream)

--- a/internal/search/job/sub_repo_perms_job.go
+++ b/internal/search/job/sub_repo_perms_job.go
@@ -27,8 +27,8 @@ type subRepoPermsFilterJob struct {
 }
 
 func (s *subRepoPermsFilterJob) Run(ctx context.Context, db database.DB, stream streaming.Sender) (alert *search.Alert, err error) {
-	tr, ctx := jobutil.StartSpan(ctx, s)
-	defer func() { jobutil.FinishSpan(tr, alert, err) }()
+	_, ctx, stream, finish := jobutil.StartSpan(ctx, stream, s)
+	defer func() { finish(alert, err) }()
 
 	checker := authz.DefaultSubRepoPermsChecker
 

--- a/internal/search/repos/excluded_job.go
+++ b/internal/search/repos/excluded_job.go
@@ -14,8 +14,8 @@ type ComputeExcludedRepos struct {
 }
 
 func (c *ComputeExcludedRepos) Run(ctx context.Context, db database.DB, s streaming.Sender) (alert *search.Alert, err error) {
-	tr, ctx := jobutil.StartSpan(ctx, c)
-	defer func() { jobutil.FinishSpan(tr, alert, err) }()
+	_, ctx, s, finish := jobutil.StartSpan(ctx, s, c)
+	defer func() { finish(alert, err) }()
 
 	repositoryResolver := Resolver{DB: db}
 	excluded, err := repositoryResolver.Excluded(ctx, c.Options)

--- a/internal/search/run/repository.go
+++ b/internal/search/run/repository.go
@@ -25,8 +25,8 @@ type RepoSearch struct {
 }
 
 func (s *RepoSearch) Run(ctx context.Context, db database.DB, stream streaming.Sender) (alert *search.Alert, err error) {
-	tr, ctx := jobutil.StartSpan(ctx, s)
-	defer func() { jobutil.FinishSpan(tr, alert, err) }()
+	tr, ctx, stream, finish := jobutil.StartSpan(ctx, stream, s)
+	defer func() { finish(alert, err) }()
 
 	tr.LogFields(otlog.String("pattern", s.Args.PatternInfo.Pattern))
 

--- a/internal/search/searcher/symbol_search_job.go
+++ b/internal/search/searcher/symbol_search_job.go
@@ -29,8 +29,8 @@ type SymbolSearcher struct {
 
 // Run calls the searcher service to search symbols.
 func (s *SymbolSearcher) Run(ctx context.Context, _ database.DB, stream streaming.Sender) (alert *search.Alert, err error) {
-	tr, ctx := jobutil.StartSpan(ctx, s)
-	defer func() { jobutil.FinishSpan(tr, alert, err) }()
+	tr, ctx, stream, finish := jobutil.StartSpan(ctx, stream, s)
+	defer func() { finish(alert, err) }()
 
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()

--- a/internal/search/structural/structural.go
+++ b/internal/search/structural/structural.go
@@ -163,8 +163,8 @@ type StructuralSearch struct {
 }
 
 func (s *StructuralSearch) Run(ctx context.Context, db database.DB, stream streaming.Sender) (alert *search.Alert, err error) {
-	tr, ctx := jobutil.StartSpan(ctx, s)
-	defer func() { jobutil.FinishSpan(tr, alert, err) }()
+	_, ctx, stream, finish := jobutil.StartSpan(ctx, stream, s)
+	defer func() { finish(alert, err) }()
 
 	repos := &searchrepos.Resolver{DB: db, Opts: s.RepoOpts}
 	return nil, repos.Paginate(ctx, nil, func(page *searchrepos.Resolved) error {

--- a/internal/search/symbol/symbol.go
+++ b/internal/search/symbol/symbol.go
@@ -241,8 +241,8 @@ type RepoUniverseSymbolSearch struct {
 }
 
 func (s *RepoUniverseSymbolSearch) Run(ctx context.Context, db database.DB, stream streaming.Sender) (alert *search.Alert, err error) {
-	tr, ctx := jobutil.StartSpan(ctx, s)
-	defer func() { jobutil.FinishSpan(tr, alert, err) }()
+	tr, ctx, stream, finish := jobutil.StartSpan(ctx, stream, s)
+	defer func() { finish(alert, err) }()
 
 	userPrivateRepos := repos.PrivateReposForActor(ctx, db, s.RepoOptions)
 	s.GlobalZoektQuery.ApplyPrivateFilter(userPrivateRepos)

--- a/internal/search/zoekt/indexed_search.go
+++ b/internal/search/zoekt/indexed_search.go
@@ -592,8 +592,8 @@ type ZoektRepoSubsetSearch struct {
 
 // ZoektSearch is a job that searches repositories using zoekt.
 func (z *ZoektRepoSubsetSearch) Run(ctx context.Context, _ database.DB, stream streaming.Sender) (alert *search.Alert, err error) {
-	tr, ctx := jobutil.StartSpan(ctx, z)
-	defer func() { jobutil.FinishSpan(tr, alert, err) }()
+	_, ctx, stream, finish := jobutil.StartSpan(ctx, stream, z)
+	defer func() { finish(alert, err) }()
 
 	if z.Repos == nil {
 		return nil, nil
@@ -626,8 +626,8 @@ type GlobalSearch struct {
 }
 
 func (t *GlobalSearch) Run(ctx context.Context, db database.DB, stream streaming.Sender) (alert *search.Alert, err error) {
-	tr, ctx := jobutil.StartSpan(ctx, t)
-	defer func() { jobutil.FinishSpan(tr, alert, err) }()
+	_, ctx, stream, finish := jobutil.StartSpan(ctx, stream, t)
+	defer func() { finish(alert, err) }()
 
 	userPrivateRepos := searchrepos.PrivateReposForActor(ctx, db, t.RepoOptions)
 	t.GlobalZoektQuery.ApplyPrivateFilter(userPrivateRepos)

--- a/internal/search/zoekt/symbol_search_job.go
+++ b/internal/search/zoekt/symbol_search_job.go
@@ -25,8 +25,8 @@ type ZoektSymbolSearch struct {
 
 // Run calls the zoekt backend to search symbols
 func (z *ZoektSymbolSearch) Run(ctx context.Context, _ database.DB, stream streaming.Sender) (alert *search.Alert, err error) {
-	tr, ctx := jobutil.StartSpan(ctx, z)
-	defer func() { jobutil.FinishSpan(tr, alert, err) }()
+	tr, ctx, stream, finish := jobutil.StartSpan(ctx, stream, z)
+	defer func() { finish(alert, err) }()
 
 	if z.Repos == nil {
 		return nil, nil


### PR DESCRIPTION
This adds stream tracing to all our jobs. For each event sent down
the stream, we log the number of results in the event. This is useful
for debugging latency and visualizing the frequency of events across the
job tree. Additionally, we log the total number of events streamed by
each job.

It's possible that on sourcegraph.com, this will generate traces that are
unreasonably large. There are a few options from there: including batching
events, only logging first and last event, or just disabling logging events
on the trace. I don't expect issues, so I don't plan to prematurely optimize
here. 

We may also find that this information is not valuable, or too noisy to
be useful. I'm mostly just experimenting, so feel free to riff. 

## Test plan

Manually tested. See screenshot:

<img width="1102" alt="Screen Shot 2022-03-18 at 15 35 15" src="https://user-images.githubusercontent.com/12631702/159086562-3cb4801c-a238-42ba-95ab-bd0e77ed55bc.png">
<img width="878" alt="Screen Shot 2022-03-18 at 15 55 06" src="https://user-images.githubusercontent.com/12631702/159089159-9573a293-202b-41dc-82c1-e5c69db264e6.png">


<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


