### PR TITLE
search: remove unused args values

### DIFF
--- a/internal/search/job/job.go
+++ b/internal/search/job/job.go
@@ -379,14 +379,10 @@ func ToSearchJob(jargs *Args, q query.Q) (Job, error) {
 
 func toTextParameters(jargs *Args, b query.Basic, q query.Q, resultTypes result.Types) search.TextParameters {
 	args := search.TextParameters{
-		Query:   q,
-		Timeout: search.TimeoutDuration(b),
+		Query: q,
 
 		// UseFullDeadline if timeout: set or we are streaming.
 		UseFullDeadline: q.Timeout() != nil || q.Count() != nil || jargs.SearchInputs.Protocol == search.Streaming,
-
-		Zoekt:        jargs.Zoekt,
-		SearcherURLs: jargs.SearcherURLs,
 	}
 
 	args.PatternInfo = search.ToTextPatternInfo(b, resultTypes, jargs.SearchInputs.Protocol)

--- a/internal/search/job/printers_test.go
+++ b/internal/search/job/printers_test.go
@@ -322,7 +322,6 @@ func TestPrettyJSON(t *testing.T) {
           "Features": {
             "ContentBasedLangFilters": false
           },
-          "Timeout": 20000000000,
           "Repos": null,
           "Mode": 0,
           "Query": [

--- a/internal/search/types.go
+++ b/internal/search/types.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/google/zoekt"
 	zoektquery "github.com/google/zoekt/query"
@@ -130,7 +129,6 @@ type TextParameters struct {
 	PatternInfo *TextPatternInfo
 	RepoOptions RepoOptions
 	Features    Features
-	Timeout     time.Duration
 
 	Repos []*RepositoryRevisions
 


### PR DESCRIPTION
Stacked on https://github.com/sourcegraph/sourcegraph/pull/32801.

More culling `args` values.

## Test plan
Semantics-preserving.


