### PR TITLE
search: remove search.TextParameters type

### DIFF
--- a/internal/search/job/job.go
+++ b/internal/search/job/job.go
@@ -343,27 +343,22 @@ func ToSearchJob(jargs *Args, q query.Q) (Job, error) {
 
 			if valid() {
 				if repoOptions, ok := addPatternAsRepoFilter(patternInfo.Pattern, repoOptions); ok {
-					// Note: if we run a repo search,
-					// downstream logic relies on the
-					// following args values to be set for
-					// repoHasFile operation. It is slated
-					// for removal.
-					args := search.TextParameters{}
-					args.Zoekt = jargs.Zoekt
-					args.SearcherURLs = jargs.SearcherURLs
-					args.RepoOptions = repoOptions
-					args.Features = features
-					args.UseFullDeadline = useFullDeadline
-					args.Query = q
-					args.PatternInfo = patternInfo
+					var mode search.GlobalSearchMode
 					if repoUniverseSearch {
-						args.Mode = search.ZoektGlobalSearch
+						mode = search.ZoektGlobalSearch
 					}
 					if skipRepoSubsetSearch {
-						args.Mode = search.SkipUnindexed
+						mode = search.SkipUnindexed
 					}
 					addJob(true, &run.RepoSearch{
-						Args: &args,
+						Zoekt:           jargs.Zoekt,
+						SearcherURLs:    jargs.SearcherURLs,
+						RepoOptions:     repoOptions,
+						Features:        features,
+						UseFullDeadline: useFullDeadline,
+						Query:           q,
+						PatternInfo:     patternInfo,
+						Mode:            mode,
 					})
 				}
 			}

--- a/internal/search/job/printers_test.go
+++ b/internal/search/job/printers_test.go
@@ -251,79 +251,43 @@ func TestPrettyJSON(t *testing.T) {
     },
     {
       "RepoSearch": {
-        "Args": {
-          "PatternInfo": {
-            "Pattern": "bar",
-            "IsNegated": false,
-            "IsRegExp": true,
-            "IsStructuralPat": false,
-            "CombyRule": "",
-            "IsWordMatch": false,
-            "IsCaseSensitive": false,
-            "FileMatchLimit": 500,
-            "Index": "yes",
-            "Select": [],
-            "IncludePatterns": null,
-            "ExcludePattern": "",
-            "FilePatternsReposMustInclude": null,
-            "FilePatternsReposMustExclude": null,
-            "PathPatternsAreCaseSensitive": false,
-            "PatternMatchesContent": true,
-            "PatternMatchesPath": true,
-            "Languages": null
-          },
-          "RepoOptions": {
-            "RepoFilters": [
-              "foo",
-              "bar"
-            ],
-            "MinusRepoFilters": null,
-            "Dependencies": null,
-            "CaseSensitiveRepoFilters": false,
-            "SearchContextSpec": "",
-            "NoForks": true,
-            "OnlyForks": false,
-            "NoArchived": true,
-            "OnlyArchived": false,
-            "CommitAfter": "",
-            "Visibility": "Any",
-            "Limit": 0,
-            "Cursors": null,
-            "Query": [
-              {
-                "Kind": 1,
-                "Operands": [
-                  {
-                    "field": "repo",
-                    "value": "foo",
-                    "negated": false
-                  },
-                  {
-                    "value": "bar",
-                    "negated": false
-                  }
-                ],
-                "Annotation": {
-                  "labels": 0,
-                  "range": {
-                    "start": {
-                      "line": 0,
-                      "column": 0
-                    },
-                    "end": {
-                      "line": 0,
-                      "column": 0
-                    }
-                  }
-                }
-              }
-            ]
-          },
-          "Features": {
-            "ContentBasedLangFilters": false
-          },
-          "Repos": null,
-          "Mode": 0,
+        "PatternInfo": {
+          "Pattern": "bar",
+          "IsNegated": false,
+          "IsRegExp": true,
+          "IsStructuralPat": false,
+          "CombyRule": "",
+          "IsWordMatch": false,
+          "IsCaseSensitive": false,
+          "FileMatchLimit": 500,
+          "Index": "yes",
+          "Select": [],
+          "IncludePatterns": null,
+          "ExcludePattern": "",
+          "FilePatternsReposMustInclude": null,
+          "FilePatternsReposMustExclude": null,
+          "PathPatternsAreCaseSensitive": false,
+          "PatternMatchesContent": true,
+          "PatternMatchesPath": true,
+          "Languages": null
+        },
+        "RepoOptions": {
+          "RepoFilters": [
+            "foo",
+            "bar"
+          ],
+          "MinusRepoFilters": null,
+          "Dependencies": null,
+          "CaseSensitiveRepoFilters": false,
+          "SearchContextSpec": "",
+          "NoForks": true,
+          "OnlyForks": false,
+          "NoArchived": true,
+          "OnlyArchived": false,
+          "CommitAfter": "",
+          "Visibility": "Any",
+          "Limit": 0,
+          "Cursors": null,
           "Query": [
             {
               "Kind": 1,
@@ -352,11 +316,45 @@ func TestPrettyJSON(t *testing.T) {
                 }
               }
             }
-          ],
-          "UseFullDeadline": true,
-          "Zoekt": null,
-          "SearcherURLs": null
-        }
+          ]
+        },
+        "Features": {
+          "ContentBasedLangFilters": false
+        },
+        "Repos": null,
+        "Mode": 0,
+        "Query": [
+          {
+            "Kind": 1,
+            "Operands": [
+              {
+                "field": "repo",
+                "value": "foo",
+                "negated": false
+              },
+              {
+                "value": "bar",
+                "negated": false
+              }
+            ],
+            "Annotation": {
+              "labels": 0,
+              "range": {
+                "start": {
+                  "line": 0,
+                  "column": 0
+                },
+                "end": {
+                  "line": 0,
+                  "column": 0
+                }
+              }
+            }
+          }
+        ],
+        "UseFullDeadline": true,
+        "Zoekt": null,
+        "SearcherURLs": null
       }
     },
     {

--- a/internal/search/run/repository_test.go
+++ b/internal/search/run/repository_test.go
@@ -131,11 +131,11 @@ func TestRepoShouldBeAdded(t *testing.T) {
 // of repostiories specified in the query's `repohasfile` and `-repohasfile` fields if they exist.
 func repoShouldBeAdded(ctx context.Context, zoekt zoekt.Streamer, repo *search.RepositoryRevisions, pattern *search.TextPatternInfo) (bool, error) {
 	repos := []*search.RepositoryRevisions{repo}
-	args := search.TextParameters{
+	s := RepoSearch{
 		PatternInfo: pattern,
 		Zoekt:       zoekt,
 	}
-	rsta, err := reposToAdd(ctx, &args, repos)
+	rsta, err := s.reposToAdd(ctx, repos)
 	if err != nil {
 		return false, err
 	}

--- a/internal/search/textsearch/textsearch_test.go
+++ b/internal/search/textsearch/textsearch_test.go
@@ -88,18 +88,22 @@ func TestRepoSubsetTextSearch(t *testing.T) {
 		t.Fatal(err)
 	}
 	repoRevs := makeRepositoryRevisions("foo/one", "foo/two", "foo/empty", "foo/cloning", "foo/missing", "foo/missing-database", "foo/timedout", "foo/no-rev")
-	args := &search.TextParameters{
-		PatternInfo: &search.TextPatternInfo{
-			FileMatchLimit: limits.DefaultMaxSearchResults,
-			Pattern:        "foo",
-		},
-		Repos:        repoRevs,
-		Query:        q,
-		Zoekt:        zoekt,
-		SearcherURLs: endpoint.Static("test"),
+
+	patternInfo := &search.TextPatternInfo{
+		FileMatchLimit: limits.DefaultMaxSearchResults,
+		Pattern:        "foo",
 	}
 
-	matches, common, err := RunRepoSubsetTextSearch(context.Background(), args)
+	matches, common, err := RunRepoSubsetTextSearch(
+		context.Background(),
+		patternInfo,
+		repoRevs,
+		q,
+		zoekt,
+		endpoint.Static("test"),
+		search.DefaultMode,
+		false,
+	)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -119,18 +123,16 @@ func TestRepoSubsetTextSearch(t *testing.T) {
 
 	// If we specify a rev and it isn't found, we fail the whole search since
 	// that should be checked earlier.
-	args = &search.TextParameters{
-		PatternInfo: &search.TextPatternInfo{
-			FileMatchLimit: limits.DefaultMaxSearchResults,
-			Pattern:        "foo",
-		},
-		Repos:        makeRepositoryRevisions("foo/no-rev@dev"),
-		Query:        q,
-		Zoekt:        zoekt,
-		SearcherURLs: endpoint.Static("test"),
-	}
-
-	_, _, err = RunRepoSubsetTextSearch(context.Background(), args)
+	_, _, err = RunRepoSubsetTextSearch(
+		context.Background(),
+		patternInfo,
+		makeRepositoryRevisions("foo/no-rev@dev"),
+		q,
+		zoekt,
+		endpoint.Static("test"),
+		search.DefaultMode,
+		false,
+	)
 	if !errors.HasType(err, &gitdomain.RevisionNotFoundError{}) {
 		t.Fatalf("searching non-existent rev expected to fail with RevisionNotFoundError got: %v", err)
 	}
@@ -185,18 +187,22 @@ func TestSearchFilesInReposStream(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	args := &search.TextParameters{
-		PatternInfo: &search.TextPatternInfo{
-			FileMatchLimit: limits.DefaultMaxSearchResults,
-			Pattern:        "foo",
-		},
-		Repos:        makeRepositoryRevisions("foo/one", "foo/two", "foo/three"),
-		Query:        q,
-		Zoekt:        zoekt,
-		SearcherURLs: endpoint.Static("test"),
+
+	patternInfo := &search.TextPatternInfo{
+		FileMatchLimit: limits.DefaultMaxSearchResults,
+		Pattern:        "foo",
 	}
 
-	matches, _, err := RunRepoSubsetTextSearch(context.Background(), args)
+	matches, _, err := RunRepoSubsetTextSearch(
+		context.Background(),
+		patternInfo,
+		makeRepositoryRevisions("foo/one", "foo/two", "foo/three"),
+		q,
+		zoekt,
+		endpoint.Static("test"),
+		search.DefaultMode,
+		false,
+	)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -254,21 +260,27 @@ func TestSearchFilesInRepos_multipleRevsPerRepo(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	args := &search.TextParameters{
-		PatternInfo: &search.TextPatternInfo{
-			FileMatchLimit: limits.DefaultMaxSearchResults,
-			Pattern:        "foo",
-		},
-		Repos:        makeRepositoryRevisions("foo@master:mybranch:*refs/heads/"),
-		Query:        q,
-		Zoekt:        zoekt,
-		SearcherURLs: endpoint.Static("test"),
+
+	patternInfo := &search.TextPatternInfo{
+		FileMatchLimit: limits.DefaultMaxSearchResults,
+		Pattern:        "foo",
 	}
-	args.Repos[0].ListRefs = func(context.Context, api.RepoName) ([]git.Ref, error) {
+
+	repos := makeRepositoryRevisions("foo@master:mybranch:*refs/heads/")
+	repos[0].ListRefs = func(context.Context, api.RepoName) ([]git.Ref, error) {
 		return []git.Ref{{Name: "refs/heads/branch3"}, {Name: "refs/heads/branch4"}}, nil
 	}
 
-	matches, _, err := RunRepoSubsetTextSearch(context.Background(), args)
+	matches, _, err := RunRepoSubsetTextSearch(
+		context.Background(),
+		patternInfo,
+		repos,
+		q,
+		zoekt,
+		endpoint.Static("test"),
+		search.DefaultMode,
+		false,
+	)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -393,14 +405,21 @@ func TestFileMatch_Limit(t *testing.T) {
 }
 
 // RunRepoSubsetTextSearch is a convenience function that simulates the RepoSubsetTextSearch job.
-func RunRepoSubsetTextSearch(ctx context.Context, args *search.TextParameters) ([]*result.FileMatch, streaming.Stats, error) {
-	repos := args.Repos
-	q := args.Query
-	notSearcherOnly := args.Mode != search.SearcherOnly
+func RunRepoSubsetTextSearch(
+	ctx context.Context,
+	patternInfo *search.TextPatternInfo,
+	repos []*search.RepositoryRevisions,
+	q query.Q,
+	zoekt *searchbackend.FakeSearcher,
+	searcherURLs *endpoint.Map,
+	mode search.GlobalSearchMode,
+	useFullDeadline bool,
+) ([]*result.FileMatch, streaming.Stats, error) {
+	notSearcherOnly := mode != search.SearcherOnly
 	searcherArgs := &search.SearcherParameters{
-		SearcherURLs:    args.SearcherURLs,
-		PatternInfo:     args.PatternInfo,
-		UseFullDeadline: args.UseFullDeadline,
+		SearcherURLs:    searcherURLs,
+		PatternInfo:     patternInfo,
+		UseFullDeadline: useFullDeadline,
 	}
 
 	agg := streaming.NewAggregatingStream()
@@ -408,7 +427,7 @@ func RunRepoSubsetTextSearch(ctx context.Context, args *search.TextParameters) (
 	indexed, unindexed, err := zoektutil.PartitionRepos(
 		context.Background(),
 		repos,
-		args.Zoekt,
+		zoekt,
 		search.TextRequest,
 		query.Yes,
 		query.ContainsRefGlobs(q),
@@ -422,7 +441,7 @@ func RunRepoSubsetTextSearch(ctx context.Context, args *search.TextParameters) (
 
 	if notSearcherOnly {
 		typ := search.TextRequest
-		zoektQuery, err := search.QueryToZoektQuery(args.PatternInfo, nil, typ)
+		zoektQuery, err := search.QueryToZoektQuery(patternInfo, nil, typ)
 		if err != nil {
 			return nil, streaming.Stats{}, err
 		}
@@ -431,9 +450,9 @@ func RunRepoSubsetTextSearch(ctx context.Context, args *search.TextParameters) (
 			Repos:          indexed,
 			Query:          zoektQuery,
 			Typ:            search.TextRequest,
-			FileMatchLimit: args.PatternInfo.FileMatchLimit,
-			Select:         args.PatternInfo.Select,
-			Zoekt:          args.Zoekt,
+			FileMatchLimit: patternInfo.FileMatchLimit,
+			Select:         patternInfo.Select,
+			Zoekt:          zoekt,
 			Since:          nil,
 		}
 

--- a/internal/search/types.go
+++ b/internal/search/types.go
@@ -122,36 +122,6 @@ type SearcherParameters struct {
 	UseFullDeadline bool
 }
 
-// TextParameters are the parameters passed to a search backend. It contains the Pattern
-// to search for, as well as the hydrated list of repository revisions to
-// search. It defines behavior for text search on repository names, file names, and file content.
-type TextParameters struct {
-	PatternInfo *TextPatternInfo
-	RepoOptions RepoOptions
-	Features    Features
-
-	Repos []*RepositoryRevisions
-
-	Mode GlobalSearchMode
-
-	// Query is the parsed query from the user. You should be using Pattern
-	// instead, but Query is useful for checking extra fields that are set and
-	// ignored by Pattern, such as index:no
-	Query query.Q
-
-	// UseFullDeadline indicates that the search should try do as much work as
-	// it can within context.Deadline. If false the search should try and be
-	// as fast as possible, even if a "slow" deadline is set.
-	//
-	// For example searcher will wait to full its archive cache for a
-	// repository if this field is true. Another example is we set this field
-	// to true if the user requests a specific timeout or maximum result size.
-	UseFullDeadline bool
-
-	Zoekt        zoekt.Streamer
-	SearcherURLs *endpoint.Map
-}
-
 // TextPatternInfo is the struct used by vscode pass on search queries. Keep it in
 // sync with pkg/searcher/protocol.PatternInfo.
 type TextPatternInfo struct {


### PR DESCRIPTION
Stacked on https://github.com/sourcegraph/sourcegraph/pull/32809.

Only the repo search job relies on the `TextParameters` (args) type. So all of those values are just going get absorbed and be the definition of the repo search job now. It's gone.

## Test plan
Semantics-preserving.


