### PR TITLE
If only sampling is set, use opentracer

### DIFF
--- a/internal/tracer/tracer.go
+++ b/internal/tracer/tracer.go
@@ -113,7 +113,6 @@ func initTracer(opts *options, c conftypes.WatchableSiteConfig) {
 			}
 			if t := tracerType(tracingConfig.Type); t.isSetByUser() {
 				setTracer = t
-				println("tracer type:", t)
 			}
 			shouldLog = tracingConfig.Debug
 		}

--- a/internal/tracer/tracer.go
+++ b/internal/tracer/tracer.go
@@ -48,14 +48,16 @@ type options struct {
 type tracerType string
 
 const (
-	None    tracerType = ""
+	None    tracerType = "none"
 	Datadog tracerType = "datadog"
 	Ot      tracerType = "opentracing"
 )
 
-func (t tracerType) isValid() bool {
+// isSetByUser returns true if the tracerType is one supported by the schema
+// should be kept in sync with ObservabilityTracing.Type in schema/site.schema.json
+func (t tracerType) isSetByUser() bool {
 	switch t {
-	case None, Datadog, Ot:
+	case Datadog, Ot:
 		return true
 	}
 	return false
@@ -109,8 +111,9 @@ func initTracer(opts *options, c conftypes.WatchableSiteConfig) {
 				samplingStrategy = ot.TraceSelective
 				setTracer = Ot
 			}
-			if t := tracerType(tracingConfig.Type); t.isValid() {
+			if t := tracerType(tracingConfig.Type); t.isSetByUser() {
 				setTracer = t
+				println("tracer type:", t)
 			}
 			shouldLog = tracingConfig.Debug
 		}


### PR DESCRIPTION
Previously, we were overwriting the value here if it was not set which defaulted to ""
We now correctly mark that as value that isn't set by the user



## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->
Tested locally, ensured that 
```json
  "observability.tracing": {
    "sampling": "selective"
  },
```
in site-config causes tracing to be enabled 

