### PR TITLE
batches: unify HTTP certificate option handling when creating sources

### DIFF
--- a/enterprise/internal/batches/sources/bitbucketserver.go
+++ b/enterprise/internal/batches/sources/bitbucketserver.go
@@ -39,10 +39,7 @@ func newBitbucketServerSource(c *schema.BitbucketServerConnection, cf *httpcli.F
 		cf = httpcli.ExternalClientFactory
 	}
 
-	var opts []httpcli.Opt
-	if c.Certificate != "" {
-		opts = append(opts, httpcli.NewCertPoolOpt(c.Certificate))
-	}
+	opts := httpClientCertificateOptions(nil, c.Certificate)
 
 	cli, err := cf.Doer(opts...)
 	if err != nil {

--- a/enterprise/internal/batches/sources/github.go
+++ b/enterprise/internal/batches/sources/github.go
@@ -47,15 +47,11 @@ func newGithubSource(c *schema.GitHubConnection, cf *httpcli.Factory, au auth.Au
 		cf = httpcli.ExternalClientFactory
 	}
 
-	opts := []httpcli.Opt{
+	opts := httpClientCertificateOptions([]httpcli.Opt{
 		// Use a 30s timeout to avoid running into EOF errors, because GitHub
 		// closes idle connections after 60s
 		httpcli.NewIdleConnTimeoutOpt(30 * time.Second),
-	}
-
-	if c.Certificate != "" {
-		opts = append(opts, httpcli.NewCertPoolOpt(c.Certificate))
-	}
+	}, c.Certificate)
 
 	cli, err := cf.Doer(opts...)
 	if err != nil {

--- a/enterprise/internal/batches/sources/gitlab.go
+++ b/enterprise/internal/batches/sources/gitlab.go
@@ -47,10 +47,7 @@ func newGitLabSource(c *schema.GitLabConnection, cf *httpcli.Factory) (*GitLabSo
 		cf = httpcli.ExternalClientFactory
 	}
 
-	var opts []httpcli.Opt
-	if c.Certificate != "" {
-		opts = append(opts, httpcli.NewCertPoolOpt(c.Certificate))
-	}
+	opts := httpClientCertificateOptions(nil, c.Certificate)
 
 	cli, err := cf.Doer(opts...)
 	if err != nil {

--- a/enterprise/internal/batches/sources/util.go
+++ b/enterprise/internal/batches/sources/util.go
@@ -31,7 +31,7 @@ func newUnsupportedAuthenticatorError(source string, a auth.Authenticator) Unsup
 //
 // It is valid to pass in nil for the default options.
 func httpClientCertificateOptions(defaultOpts []httpcli.Opt, certificate string) []httpcli.Opt {
-	opts := defaultOpts[:]
+	opts := defaultOpts
 	if certificate != "" {
 		opts = append(opts, httpcli.NewCertPoolOpt(certificate))
 	}

--- a/enterprise/internal/batches/sources/util.go
+++ b/enterprise/internal/batches/sources/util.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/auth"
+	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 )
 
 // UnsupportedAuthenticatorError is returned by WithAuthenticator if the
@@ -22,4 +23,17 @@ func newUnsupportedAuthenticatorError(source string, a auth.Authenticator) Unsup
 		have:   fmt.Sprintf("%T", a),
 		source: source,
 	}
+}
+
+// httpClientCertificateOptions creates a httpcli.Opt slice based on the default
+// options provided and a valid certificate pool option if the certificate
+// string isn't empty.
+//
+// It is valid to pass in nil for the default options.
+func httpClientCertificateOptions(defaultOpts []httpcli.Opt, certificate string) []httpcli.Opt {
+	opts := defaultOpts[:]
+	if certificate != "" {
+		opts = append(opts, httpcli.NewCertPoolOpt(certificate))
+	}
+	return opts
 }


### PR DESCRIPTION
Spotted this while working on Bitbucket Cloud, which doesn't actually need this (because, duh, bitbucket.org always has a valid public certificate), but by the time I realised that I was committed.

## Test plan

The tests still pass.