### PR TITLE
Fix GraphQL warning

### DIFF
--- a/client/web/src/codeintel/ReferencesPanelQueries.ts
+++ b/client/web/src/codeintel/ReferencesPanelQueries.ts
@@ -95,8 +95,8 @@ export const USE_PRECISE_CODE_INTEL_FOR_POSITION_QUERY = gql`
         }
     }
 
-    ${codeIntelFragments}
     ${gitBlobLsifDataQueryFragment}
+    ${codeIntelFragments}
 `
 
 export const LOAD_ADDITIONAL_REFERENCES_QUERY = gql`


### PR DESCRIPTION
This fixes a linter/TypeScript warning/error that didn't show up at runtime but that has been bugging me for a while in VS Code.

## Test plan

- Manually test that query still works as intended
- Error disappears in VS Code

