### PR TITLE
Update docker-compose version used in installation references

### DIFF
--- a/doc/admin/install/docker-compose/aws.md
+++ b/doc/admin/install/docker-compose/aws.md
@@ -30,7 +30,7 @@ set -euxo pipefail
 EBS_VOLUME_DEVICE_NAME='/dev/sdb'
 DOCKER_DATA_ROOT='/mnt/docker-data'
 
-DOCKER_COMPOSE_VERSION='1.25.3'
+DOCKER_COMPOSE_VERSION='1.29.2'
 DEPLOY_SOURCEGRAPH_DOCKER_CHECKOUT='/home/ec2-user/deploy-sourcegraph-docker'
 
 # 🚨 Update these variables with the correct values from your fork!

--- a/doc/admin/install/docker-compose/digitalocean.md
+++ b/doc/admin/install/docker-compose/digitalocean.md
@@ -31,7 +31,7 @@ set -euxo pipefail
 PERSISTENT_DISK_DEVICE_NAME='/dev/sda'
 DOCKER_DATA_ROOT='/mnt/docker-data'
 
-DOCKER_COMPOSE_VERSION='1.25.3'
+DOCKER_COMPOSE_VERSION='1.29.2'
 DEPLOY_SOURCEGRAPH_DOCKER_CHECKOUT='/root/deploy-sourcegraph-docker'
 
 # 🚨 Update these variables with the correct values from your fork!

--- a/doc/admin/install/docker-compose/google_cloud.md
+++ b/doc/admin/install/docker-compose/google_cloud.md
@@ -32,7 +32,7 @@ set -euxo pipefail
 PERSISTENT_DISK_DEVICE_NAME='/dev/sdb'
 DOCKER_DATA_ROOT='/mnt/docker-data'
 
-DOCKER_COMPOSE_VERSION='1.25.3'
+DOCKER_COMPOSE_VERSION='1.29.2'
 DEPLOY_SOURCEGRAPH_DOCKER_CHECKOUT='/root/deploy-sourcegraph-docker'
 
 # 🚨 Update these variables with the correct values from your fork!


### PR DESCRIPTION
Update the provider-specific  installation references to use the new required docker compose version. The general docs were updated in https://github.com/sourcegraph/sourcegraph/pull/32631 but we missed these specific references.

Related: https://github.com/sourcegraph/sourcegraph/pull/32825

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

Confirm docs look ok. The new version was tested as part of https://github.com/sourcegraph/deploy-sourcegraph-docker/pull/782