### PR TITLE
ci: Serialize all fields for go-backcompat tests

### DIFF
--- a/dev/ci/go-backcompat/reorganize.go
+++ b/dev/ci/go-backcompat/reorganize.go
@@ -50,9 +50,13 @@ func renderMetadata(definition definition.Definition) ([]byte, error) {
 		Name                    string `yaml:"name"`
 		Parents                 []int  `yaml:"parents"`
 		CreateIndexConcurrently bool   `yaml:"createIndexConcurrently"`
+		Privileged              bool   `yaml:"privileged"`
+		NonIdempotent           bool   `yaml:"nonIdempotent"`
 	}{
 		Name:                    definition.Name,
 		Parents:                 definition.Parents,
 		CreateIndexConcurrently: definition.IsCreateIndexConcurrently,
+		Privileged:              definition.Privileged,
+		NonIdempotent:           definition.NonIdempotent,
 	})
 }


### PR DESCRIPTION
Ensure that we write `privileged` and `nonIdempotent` fields to ensure we don't panic on malformed migration definitions in go-backcompat tests.

## Test plan

Go-backcompat tests should go green on PRs after merging in this change.

