### PR TITLE
dev/ci: scale down stateless rollout to 10%

### DIFF
--- a/enterprise/dev/ci/internal/buildkite/buildkite.go
+++ b/enterprise/dev/ci/internal/buildkite/buildkite.go
@@ -37,7 +37,7 @@ var FeatureFlags = featureFlags{
 		// TODO: remove when we switch over entirely to stateless agents
 		os.Getenv("BUILDKITE_REBUILT_FROM_BUILD_NUMBER") != "" ||
 		// Roll out to 75% of builds
-		rand.NewSource(time.Now().UnixNano()).Int63()%100 < 75,
+		rand.NewSource(time.Now().UnixNano()).Int63()%100 < 10,
 }
 
 type Pipeline struct {


### PR DESCRIPTION
We have been seeing sporadic, severe slowdowns in stateless agent scaling. As we investigate approaches, we're scaling down the rollout in order to continue collecting data/feedback and alternative approaches

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

n/a
