### PR TITLE
gitserver: don't use geometric repacking

### DIFF
--- a/cmd/gitserver/server/sg_maintenance.sh
+++ b/cmd/gitserver/server/sg_maintenance.sh
@@ -47,10 +47,11 @@ git pack-refs --all --prune
 git reflog expire --all
 
 # Usually run by git gc. Here with the additional option --window-memory
-# We previously set the option --geometric=2, however this turned out to be too
-# memory intensive for monorepos on some customer instances. Restricting the
-# memory consumption by setting pack.windowMemory, pack.deltaCacheSize and
-# pack.threads in addition to --geometric=2 seemed to have no effect.
+# and --write-bitmap-index. We previously set the option --geometric=2, however
+# this turned out to be too memory intensive for monorepos on some customer
+# instances. Restricting the memory consumption by setting pack.windowMemory,
+# pack.deltaCacheSize and pack.threads in addition to --geometric=2 seemed to
+# have no effect.
 git repack -d -l -A --write-bitmap-index --window-memory 100m --unpack-unreachable=2.weeks.ago
 
 # Usually run by git gc. Prune all unreachable objects form the object database.

--- a/cmd/gitserver/server/sg_maintenance.sh
+++ b/cmd/gitserver/server/sg_maintenance.sh
@@ -21,7 +21,7 @@
 # We deviate from git gc like follows:
 # - For "git repack" and "git commit-graph write" we choose a different set of
 # flags.
-# - We ommit the commands "git rerere" and "git worktree prune" because they
+# - We omit the commands "git rerere" and "git worktree prune" because they
 # don't apply to our use-case.
 #
 # git-maintenance
@@ -46,12 +46,12 @@ git pack-refs --all --prune
 # --all Process the reflogs of all references
 git reflog expire --all
 
-# With multi-pack-index and geometric packing, repacking should take time
-# proportional to the number of new objects. Inspired by
-# https://github.blog/2021-04-29-scaling-monorepo-maintenance/
-# --write-midx reqiures git>=2.34.1.
-# [NOTE: git-version-min-requirement]
-git -c pack.windowMemory=100m repack --write-midx --write-bitmap-index -d --geometric=2
+# Usually run by git gc. Here with the additional option --window-memory
+# We previously set the option --geometric=2, however this turned out to be too
+# memory intensive for monorepos on some customer instances. Restricting the
+# memory consumption by setting pack.windowMemory, pack.deltaCacheSize and
+# pack.threads in addition to --geometric=2 seemed to have no effect.
+git repack -d -l -A --window-memory 100m --unpack-unreachable=2.weeks.ago
 
 # Usually run by git gc. Prune all unreachable objects form the object database.
 git prune --expire 2.weeks.ago

--- a/cmd/gitserver/server/sg_maintenance.sh
+++ b/cmd/gitserver/server/sg_maintenance.sh
@@ -51,7 +51,7 @@ git reflog expire --all
 # memory intensive for monorepos on some customer instances. Restricting the
 # memory consumption by setting pack.windowMemory, pack.deltaCacheSize and
 # pack.threads in addition to --geometric=2 seemed to have no effect.
-git repack -d -l -A --window-memory 100m --unpack-unreachable=2.weeks.ago
+git repack -d -l -A --write-bitmap-index --window-memory 100m --unpack-unreachable=2.weeks.ago
 
 # Usually run by git gc. Prune all unreachable objects form the object database.
 git prune --expire 2.weeks.ago


### PR DESCRIPTION
Geometric repacking proved to be very memory intensive, leading to OOM
kills of the sg maintenance cleanup job for monorepos on some customer
instances.

For sourcegraph, we can see the OOM kills for our megarepo on dogfood.
The Cloud instance has more resources and doesn't show the same behavior.

With this change we use the same repack command that git gc uses, with
an additional flag "--window-memory" that limits the memory used during
repack.

## Test Plan

- Added SG_PAUSE file on dogfood to pause all cleanup jobs for the
megarepo
  - ran the old command -> OOM kill
  - ran the new command -> success

I tried various other config values, which limit memory during
repacking, to see whether it is possible to keep geometric repacking
enabled. Unfortunately without success. Here are the config values I
tried:

- pack.window 0
- pack.deltacachesize 50m
- pack.threads 1