### PR TITLE
chore: update golangci-lint to version 1.45.0

### DIFF
--- a/dev/golangci-lint.sh
+++ b/dev/golangci-lint.sh
@@ -6,7 +6,7 @@ pushd "$(dirname "${BASH_SOURCE[0]}")/.." >/dev/null
 
 mkdir -p .bin
 
-version="1.43.0"
+version="1.45.0"
 suffix="${version}-$(go env GOOS)-$(go env GOARCH)"
 target="$PWD/.bin/golangci-lint-${suffix}"
 


### PR DESCRIPTION
This updates our linter to version 1.45.0. This is the [first version](https://github.com/golangci/golangci-lint/issues/2649)
that will run with go 1.18. Currently, running lints locally
with go 1.18 installed will cause a panic.

Note that lints will still fail when running with go 1.18,
but this fixes the panic. We cannot fix lints until CI is running
with go 1.18.

## Test plan

The lints pass in CI. 

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


