### PR TITLE
search: generate Zoekt query using method on Basic query

### DIFF
--- a/internal/search/query/types_test.go
+++ b/internal/search/query/types_test.go
@@ -1,0 +1,33 @@
+package query
+
+import (
+	"testing"
+
+	"github.com/hexops/autogold"
+)
+
+func TestToZoektQuery(t *testing.T) {
+	test := func(input string) string {
+		q, err := ParseLiteral(input)
+		if err != nil {
+			return err.Error()
+		}
+		b, err := ToBasicQuery(q)
+		if err != nil {
+			return err.Error()
+		}
+		zoektQuery, err := b.ToZoektQuery(false, true, true)
+		if err != nil {
+			return err.Error()
+		}
+		return zoektQuery.String()
+	}
+
+	autogold.Want("basic string",
+		`file_substr:"a"`).
+		Equal(t, test(`a`))
+
+	autogold.Want("basic and-expression",
+		`(or (and file_substr:"a" file_substr:"b" (not file_substr:"c")) file_substr:"d")`).
+		Equal(t, test(`a and b and not c or d`))
+}

--- a/internal/search/query_converter.go
+++ b/internal/search/query_converter.go
@@ -15,7 +15,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/search/limits"
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
-	"github.com/sourcegraph/sourcegraph/lib/errors"
 
 	zoekt "github.com/google/zoekt/query"
 )
@@ -212,76 +211,19 @@ func parseRe(pattern string, filenameOnly bool, contentOnly bool, queryIsCaseSen
 	}, nil
 }
 
-func toZoektPattern(expression query.Node, isCaseSensitive, patternMatchesContent, patternMatchesPath bool) (zoekt.Q, error) {
-	var fold func(node query.Node) (zoekt.Q, error)
-	fold = func(node query.Node) (zoekt.Q, error) {
-		switch n := node.(type) {
-		case query.Operator:
-			children := make([]zoekt.Q, 0, len(n.Operands))
-			for _, op := range n.Operands {
-				child, err := fold(op)
-				if err != nil {
-					return nil, err
-				}
-				children = append(children, child)
-			}
-			switch n.Kind {
-			case query.Or:
-				return &zoekt.Or{Children: children}, nil
-			case query.And:
-				return &zoekt.And{Children: children}, nil
-			default:
-				// unreachable
-				return nil, errors.Errorf("broken invariant: don't know what to do with node %T in toZoektPattern", node)
-			}
-		case query.Pattern:
-			var q zoekt.Q
-			var err error
-			if n.Annotation.Labels.IsSet(query.Regexp) {
-				fileNameOnly := patternMatchesPath && !patternMatchesContent
-				contentOnly := !patternMatchesPath && patternMatchesContent
-				q, err = parseRe(n.Value, fileNameOnly, contentOnly, isCaseSensitive)
-				if err != nil {
-					return nil, err
-				}
-			} else {
-				q = &zoekt.Substring{
-					Pattern:       n.Value,
-					CaseSensitive: isCaseSensitive,
-
-					FileName: true,
-					Content:  true,
-				}
-			}
-
-			if n.Negated {
-				q = &zoekt.Not{Child: q}
-			}
-			return q, nil
-		}
-		// unreachable
-		return nil, errors.Errorf("broken invariant: don't know what to do with node %T in toZoektPattern", node)
-	}
-
-	q, err := fold(expression)
-	if err != nil {
-		return nil, err
-	}
-
-	return q, nil
-}
-
 func QueryToZoektQuery(p *TextPatternInfo, feat *Features, typ IndexedRequestType) (zoekt.Q, error) {
 	labels := query.Literal
 	if p.IsRegExp {
 		labels = query.Regexp
 	}
-	pattern := query.Pattern{
-		Value:      p.Pattern,
-		Negated:    p.IsNegated,
-		Annotation: query.Annotation{Labels: labels},
+	b := query.Basic{
+		Pattern: query.Pattern{
+			Value:      p.Pattern,
+			Negated:    p.IsNegated,
+			Annotation: query.Annotation{Labels: labels},
+		},
 	}
-	q, err := toZoektPattern(pattern, p.IsCaseSensitive, p.PatternMatchesContent, p.PatternMatchesPath)
+	q, err := b.ToZoektQuery(p.IsCaseSensitive, p.PatternMatchesContent, p.PatternMatchesPath)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/search/query_converter_test.go
+++ b/internal/search/query_converter_test.go
@@ -473,29 +473,3 @@ func TestToTextPatternInfo(t *testing.T) {
 
 	autogold.Want("107", `{"Pattern":"(?://).*?(?:literal).*?(?:slash)","IsNegated":false,"IsRegExp":true,"IsStructuralPat":false,"CombyRule":"","IsWordMatch":false,"IsCaseSensitive":false,"FileMatchLimit":30,"Index":"yes","Select":[],"IncludePatterns":null,"ExcludePattern":"","FilePatternsReposMustInclude":null,"FilePatternsReposMustExclude":null,"PathPatternsAreCaseSensitive":false,"PatternMatchesContent":true,"PatternMatchesPath":true,"Languages":null}`).Equal(t, test(`patterntype:regexp // literal slash`))
 }
-
-func Test_toZoektPattern(t *testing.T) {
-	test := func(input string) string {
-		q, err := query.ParseLiteral(input)
-		if err != nil {
-			return err.Error()
-		}
-		b, err := query.ToBasicQuery(q)
-		if err != nil {
-			return err.Error()
-		}
-		zoektQuery, err := toZoektPattern(b.Pattern, false, true, true)
-		if err != nil {
-			return err.Error()
-		}
-		return zoektQuery.String()
-	}
-
-	autogold.Want("basic string",
-		`file_substr:"a"`).
-		Equal(t, test(`a`))
-
-	autogold.Want("basic and-expression",
-		`(or (and file_substr:"a" file_substr:"b" (not file_substr:"c")) file_substr:"d")`).
-		Equal(t, test(`a and b and not c or d`))
-}


### PR DESCRIPTION
More prep for removing pattern info. First I need to absorb the `query_converter.go` file into jobs. This PR moves the function that generates Zoekt queries to be a method on Basic query. 

`query_converter.go` has always been a holding ground for "messy" query conversion. It entangles a lot of concerns: converting queries to PatternInfo and also PatternInfo to Zoekt queries. We don't want to route through PatternInfo type, we want that type gone. 

## Test plan
Semantics-preserving.


