### PR TITLE
chore: run CI with go 1.18

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,4 @@
-golang 1.17.5
+golang 1.18.0
 nodejs 16.7.0
 yarn 1.22.17
 fd 7.4.0


### PR DESCRIPTION
The first step towards using go 1.18 is building with 1.18 in CI. 
This does not yet update our project's go mod version, so no
new language features from go 1.18 will be available. However,
it does mean things deprecated in go 1.18 will show up as lint
errors.

## Test plan

Build/test with go 1.18

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


