### PR TITLE
Fail dashboard permissions check when dashboard id does not exist

### DIFF
--- a/enterprise/internal/insights/store/dashboard_store.go
+++ b/enterprise/internal/insights/store/dashboard_store.go
@@ -294,7 +294,7 @@ func (s *DBDashboardStore) GetDashboardGrants(ctx context.Context, dashboardId i
 func (s *DBDashboardStore) HasDashboardPermission(ctx context.Context, dashboardIds []int, userIds []int, orgIds []int) (bool, error) {
 	query := sqlf.Sprintf(getDashboardGrantsByPermissionsSql, pq.Array(dashboardIds), visibleDashboardsQuery(userIds, orgIds))
 	count, _, err := basestore.ScanFirstInt(s.Query(ctx, query))
-	return count == 0, err
+	return count == len(dashboardIds), err
 }
 
 func (s *DBDashboardStore) AddDashboardGrants(ctx context.Context, dashboardId int, grants []DashboardGrant) error {
@@ -374,7 +374,7 @@ const getDashboardGrantsByPermissionsSql = `
 SELECT count(*)
 FROM dashboard
 WHERE id = ANY (%s)
-AND id NOT IN (%s);
+AND id IN (%s);
 `
 
 const addDashboardGrantsSql = `

--- a/enterprise/internal/insights/store/dashboard_store_test.go
+++ b/enterprise/internal/insights/store/dashboard_store_test.go
@@ -449,7 +449,20 @@ func TestHasDashboardPermission(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if created == nil {
+
+	second, err := store.CreateDashboard(ctx, CreateDashboardArgs{
+		Dashboard: types.Dashboard{
+			Title: "second test dashboard",
+			Save:  true,
+		},
+		Grants: []DashboardGrant{UserDashboardGrant(2), OrgDashboardGrant(5)},
+		UserID: []int{2}, // this is a weird thing I'd love to get rid of, but for now this will cause the db to return
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if second == nil {
 		t.Fatalf("nil dashboard")
 	}
 
@@ -458,47 +471,54 @@ func TestHasDashboardPermission(t *testing.T) {
 		shouldHavePermission bool
 		userIds              []int
 		orgIds               []int
-		dashboardID          int
+		dashboardIDs         []int
 	}{
 		{
 			name:                 "user 1 has access to dashboard",
 			shouldHavePermission: true,
 			userIds:              []int{1},
 			orgIds:               nil,
-			dashboardID:          created.ID,
+			dashboardIDs:         []int{created.ID},
 		},
 		{
 			name:                 "user 3 does not have access to dashboard",
 			shouldHavePermission: false,
 			userIds:              []int{3},
 			orgIds:               nil,
-			dashboardID:          created.ID,
+			dashboardIDs:         []int{created.ID},
 		},
 		{
 			name:                 "org 5 has access to dashboard",
 			shouldHavePermission: true,
 			userIds:              nil,
 			orgIds:               []int{5},
-			dashboardID:          created.ID,
+			dashboardIDs:         []int{created.ID},
 		},
 		{
 			name:                 "org 7 does not have access to dashboard",
 			shouldHavePermission: false,
 			userIds:              nil,
 			orgIds:               []int{7},
-			dashboardID:          created.ID,
+			dashboardIDs:         []int{created.ID},
 		},
 		{
 			name:                 "no access when dashboard does not exist",
 			shouldHavePermission: false,
 			userIds:              []int{3},
 			orgIds:               []int{5},
-			dashboardID:          -1,
+			dashboardIDs:         []int{-2},
+		},
+		{
+			name:                 "user 1 has access to one of two dashboards",
+			shouldHavePermission: false,
+			userIds:              []int{1},
+			orgIds:               nil,
+			dashboardIDs:         []int{created.ID, second.ID},
 		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got, err := store.HasDashboardPermission(ctx, []int{test.dashboardID}, test.userIds, test.orgIds)
+			got, err := store.HasDashboardPermission(ctx, test.dashboardIDs, test.userIds, test.orgIds)
 			if err != nil {
 				t.Error(err)
 			}

--- a/enterprise/internal/insights/store/dashboard_store_test.go
+++ b/enterprise/internal/insights/store/dashboard_store_test.go
@@ -450,6 +450,10 @@ func TestHasDashboardPermission(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	if created == nil {
+		t.Fatalf("nil dashboard")
+	}
+
 	second, err := store.CreateDashboard(ctx, CreateDashboardArgs{
 		Dashboard: types.Dashboard{
 			Title: "second test dashboard",

--- a/enterprise/internal/insights/store/dashboard_store_test.go
+++ b/enterprise/internal/insights/store/dashboard_store_test.go
@@ -458,35 +458,47 @@ func TestHasDashboardPermission(t *testing.T) {
 		shouldHavePermission bool
 		userIds              []int
 		orgIds               []int
+		dashboardID          int
 	}{
 		{
 			name:                 "user 1 has access to dashboard",
 			shouldHavePermission: true,
 			userIds:              []int{1},
 			orgIds:               nil,
+			dashboardID:          created.ID,
 		},
 		{
 			name:                 "user 3 does not have access to dashboard",
 			shouldHavePermission: false,
 			userIds:              []int{3},
 			orgIds:               nil,
+			dashboardID:          created.ID,
 		},
 		{
 			name:                 "org 5 has access to dashboard",
 			shouldHavePermission: true,
 			userIds:              nil,
 			orgIds:               []int{5},
+			dashboardID:          created.ID,
 		},
 		{
 			name:                 "org 7 does not have access to dashboard",
 			shouldHavePermission: false,
 			userIds:              nil,
 			orgIds:               []int{7},
+			dashboardID:          created.ID,
+		},
+		{
+			name:                 "no access when dashboard does not exist",
+			shouldHavePermission: false,
+			userIds:              []int{3},
+			orgIds:               []int{5},
+			dashboardID:          -1,
 		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got, err := store.HasDashboardPermission(ctx, []int{created.ID}, test.userIds, test.orgIds)
+			got, err := store.HasDashboardPermission(ctx, []int{test.dashboardID}, test.userIds, test.orgIds)
 			if err != nil {
 				t.Error(err)
 			}


### PR DESCRIPTION
resolves #29058 

Update permissions SQL to count the number of requested dashboards that the user has access to and ensure the user has access to all requested dashboards.


## Test plan

Existing unit tests + new additional unit tests pass 

