### PR TITLE
Allow label notify to notify teams

### DIFF
--- a/.github/workflows/label-notify.yml
+++ b/.github/workflows/label-notify.yml
@@ -10,6 +10,7 @@ jobs:
     steps:
         - uses: jenschelkopf/issue-label-notification-action@f7d2363e5efa18b8aeea671ca8093e183ae8f218 # 1.3
           with:
+             token: "${{ secrets.LABELER_GITHUB_TOKEN }}"
              recipients: |
                   team/growth-and-integrations=@muratsu @rrhyne @jjinnii @ryankscott
                   team/cloud=@RafLeszczynski


### PR DESCRIPTION
Adds a token to allow for team mentions per https://github.com/jenschelkopf/issue-label-notification-action/issues/12

needed for @sourcegraph/cloud-devops mentions
## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->
Can't be tested until after merge but will comment on the PR if it worked

