### PR TITLE
notebooks: wrap long data lines in compute block

### DIFF
--- a/client/web/src/notebooks/blocks/compute/component/src/Main.elm
+++ b/client/web/src/notebooks/blocks/compute/component/src/Main.elm
@@ -409,7 +409,17 @@ table data =
             , columns =
                 [ { header = E.el headerAttrs (E.text " ")
                   , width = E.fillPortion 2
-                  , view = \v -> E.el [ E.padding 10 ] (E.el [ E.width E.fill, E.padding 10, Border.rounded 5, Border.width 1 ] (E.text v.name))
+                  , view =
+                        \v ->
+                            E.el [ E.padding 10 ]
+                                (E.el
+                                    [ E.width E.fill
+                                    , E.padding 10
+                                    , Border.rounded 5
+                                    , Border.width 1
+                                    ]
+                                    (E.paragraph [ E.width (E.fill |> E.maximum 600) ] [ E.text v.name ])
+                                )
                   }
                 , { header = E.el (headerAttrs ++ [ F.alignRight ]) (E.text "Count")
                   , width = E.fillPortion 1
@@ -455,7 +465,23 @@ dataView : List DataValue -> E.Element Msg
 dataView data =
     E.row [ E.width E.fill ]
         [ E.el [ E.padding 10, E.alignLeft ]
-            (E.column [] (List.map (\d -> E.text d.name) data))
+            (E.column []
+                (List.map
+                    (\d ->
+                        E.paragraph
+                            [ E.paddingEach
+                                { bottom = 2
+                                , top = 0
+                                , left = 0
+                                , right = 0
+                                }
+                            , E.width (E.fill |> E.maximum 600)
+                            ]
+                            [ E.text d.name ]
+                    )
+                    data
+                )
+            )
         , E.el
             [ E.paddingXY 0 10
             , E.alignRight


### PR DESCRIPTION
Stacked on https://github.com/sourcegraph/sourcegraph/pull/32862.

Just wraps text data to stop the overflow madness

![Screen Shot 2022-03-21 at 4 11 40 PM](https://user-images.githubusercontent.com/888624/159378011-96607721-5759-4e60-b9e5-1b87ebbce920.png)


![Screen Shot 2022-03-21 at 4 11 23 PM](https://user-images.githubusercontent.com/888624/159378017-f7774695-08c2-45c3-aa30-d522e7716ec2.png)

## Test plan
Manual testing for experimental feature


