### PR TITLE
notebooks: compute block warns on incomplete commit/diff query

### DIFF
--- a/client/web/src/notebooks/blocks/compute/component/src/Main.elm
+++ b/client/web/src/notebooks/blocks/compute/component/src/Main.elm
@@ -38,7 +38,7 @@ debounceQueryInputMillis =
 
 placeholderQuery : String
 placeholderQuery =
-    "repo:github\\.com/sourcegraph/sourcegraph$ content:output((.|\\n)* -> $author) type:commit"
+    "repo:github\\.com/sourcegraph/sourcegraph$ content:output((.|\\n)* -> $author) type:commit after:\"1 month ago\" count:all"
 
 
 type alias Flags =
@@ -327,7 +327,18 @@ update msg model =
                 ( { model | resultsMap = exampleResultsMap }, Cmd.none )
 
             else
-                ( { model | resultsMap = Dict.empty, alerts = [] }
+                let
+                    alerts =
+                        if String.contains "type:commit" model.query || String.contains "type:diff" model.query && not (String.contains "count:all" model.query) then
+                            [ { title = "Heads up"
+                              , description = "This data may be incomplete! Add `count:all` to this query? Avoid doing this all the time though... 🤣"
+                              }
+                            ]
+
+                        else
+                            []
+                in
+                ( { model | resultsMap = Dict.empty, alerts = alerts }
                 , Cmd.batch
                     [ emitInput
                         { computeQueries = [ model.query ]


### PR DESCRIPTION
Stacked on https://github.com/sourcegraph/sourcegraph/pull/32864

AFAIK we don't have an alert/signal for "incomplete commit/diff" results from search backend. We do have result limit hit, which is count based, but even if you go beyond the count, we will clamp to 1500 results in the search client.

Since compute uses an internal search client, and we don't have a limit hit, I'm just surfacing an alert in the compute client if we do a `diff` or `commit` search without `count:all`. The [footgun potential of assuming complete data](https://sourcegraph.slack.com/archives/C02FSM7DW/p1647887512354349) is greater than my concern that we'll overload the server with commit/diff searches. The searches tend to finish quickly, and I did confirm we impose the 50 repo limit on Sourcegraph.com. The search won't even execute otherwise, and that includes search that compute kicks off.

<img width="1031" alt="Screen Shot 2022-03-21 at 5 13 50 PM" src="https://user-images.githubusercontent.com/888624/159383388-28c9b38a-01fd-418b-9ae9-e80c57f749b8.png">



## Test plan
Tested manually experimental feature


