### PR TITLE
fix: ActivationDropdown missing on chromatic

### DIFF
--- a/client/web/src/components/ActivationDropdown/ActivationDropdown.story.tsx
+++ b/client/web/src/components/ActivationDropdown/ActivationDropdown.story.tsx
@@ -62,6 +62,9 @@ const decorator: DecoratorFn = story => (
 const config: Meta = {
     title: 'shared/ActivationDropdown',
     decorators: [decorator],
+    parameters: {
+        chromatic: { viewports: [480] },
+    },
 }
 export default config
 export const Loading: Story = () => <ActivationDropdown {...commonProps} activation={baseActivation()} />


### PR DESCRIPTION
## Description

- bugs: ActivationDropdown popup content is missing on chromatic

## Refs

[SG Issue](https://github.com/sourcegraph/sourcegraph/issues/32275)
[Gitstart Ticket](https://app.gitstart.com/clients/sourcegraph/tickets/SG-32275)

## Test plan

- Check UI reviews to make sure chromatic captured ActivationDropdown content

