### PR TITLE
doc: correct the note of code host API rate limiting

### DIFF
--- a/doc/admin/repo/update_frequency.md
+++ b/doc/admin/repo/update_frequency.md
@@ -21,7 +21,7 @@ You may also choose to disable automatic Git updates entirely and instead [confi
 
 Sourcegraph uses a configurable internal rate limiter for API requests made from Sourcegraph to [GitHub](../external_service/github.md#internal-rate-limits), [GitLab](../external_service/gitlab.md#internal-rate-limits), [Bitucket Server](../external_service/bitbucket_server.md#internal-rate-limits) and [Bitbucket Cloud](../external_service/bitbucket_cloud.md#internal-rate-limits).
 
-**NOTE** Internal rate limiting is currently only enforced for syncing changesets in [batch changes](../../batch_changes/index.md)
+**NOTE** Internal rate limiting is currently only enforced for syncing changesets in [batch changes](../../batch_changes/index.md), repository permissions and repository metadata from code hosts.
 
 ## Repo Updater State
 


### PR DESCRIPTION
The current statement is outdated and misaligned with where the links are pointing to, e.g. https://github.com/sourcegraph/sourcegraph/blob/045a533bcbc18ab9f1e3e10b213ed6304c26b64b/doc/admin/external_service/github.md?plain=1#L77

## Test plan

Pure doc update.


