### PR TITLE
gitserver: change the way gitserver client is created

### DIFF
--- a/cmd/frontend/internal/app/ui/raw_test.go
+++ b/cmd/frontend/internal/app/ui/raw_test.go
@@ -53,6 +53,7 @@ func initHTTPTestGitServer(t *testing.T, httpStatusCode int, resp string) {
 
 	gitserver.DefaultClient = gitserver.NewTestClient(
 		httpcli.InternalDoer,
+		database.NewMockDB(),
 		[]string{strings.TrimPrefix(s.URL, "http://")},
 	)
 }

--- a/internal/gitserver/client_test.go
+++ b/internal/gitserver/client_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/gitserver/server"
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/protocol"
@@ -46,6 +47,7 @@ func TestClient_ListCloned(t *testing.T) {
 				return nil, errors.Errorf("unexpected url: %s", r.URL.String())
 			}
 		}),
+		database.NewMockDB(),
 		addrs,
 	)
 
@@ -82,6 +84,7 @@ func TestClient_RequestRepoMigrate(t *testing.T) {
 				return nil, errors.Newf("unexpected URL: %q", r.URL.String())
 			}
 		}),
+		database.NewMockDB(),
 		addrs,
 	)
 
@@ -137,7 +140,7 @@ func TestClient_Archive(t *testing.T) {
 
 	u, _ := url.Parse(srv.URL)
 	addrs := []string{u.Host}
-	cli := gitserver.NewTestClient(&http.Client{}, addrs)
+	cli := gitserver.NewTestClient(&http.Client{}, database.NewMockDB(), addrs)
 
 	ctx := context.Background()
 	for name, test := range tests {
@@ -418,7 +421,7 @@ func TestClient_P4Exec(t *testing.T) {
 
 			u, _ := url.Parse(server.URL)
 			addrs := []string{u.Host}
-			cli := gitserver.NewTestClient(&http.Client{}, addrs)
+			cli := gitserver.NewTestClient(&http.Client{}, database.NewMockDB(), addrs)
 
 			rc, _, err := cli.P4Exec(ctx, test.host, test.user, test.password, test.args...)
 			if diff := cmp.Diff(test.wantErr, fmt.Sprintf("%v", err)); diff != "" {
@@ -490,7 +493,7 @@ func TestClient_ResolveRevisions(t *testing.T) {
 
 	u, _ := url.Parse(srv.URL)
 	addrs := []string{u.Host}
-	cli := gitserver.NewTestClient(&http.Client{}, addrs)
+	cli := gitserver.NewTestClient(&http.Client{}, database.NewMockDB(), addrs)
 
 	ctx := context.Background()
 	for _, test := range tests {

--- a/internal/repos/gitolite.go
+++ b/internal/repos/gitolite.go
@@ -54,10 +54,13 @@ func NewGitoliteSource(db database.DB, svc *types.ExternalService, cf *httpcli.F
 		return nil, err
 	}
 
+	gitserverClient := gitserver.NewClient(db)
+	gitserverClient.HTTPClient = gitserverDoer
+
 	return &GitoliteSource{
 		svc:     svc,
 		conn:    &c,
-		cli:     gitserver.NewClient(gitserverDoer),
+		cli:     gitserverClient,
 		exclude: exclude,
 	}, nil
 }

--- a/internal/vcs/git/main_test.go
+++ b/internal/vcs/git/main_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/gitserver/server"
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
@@ -76,7 +77,7 @@ func init() {
 		}
 	}()
 
-	gitserver.DefaultClient = gitserver.NewTestClient(httpcli.InternalDoer, []string{l.Addr().String()})
+	gitserver.DefaultClient = gitserver.NewTestClient(httpcli.InternalDoer, database.NewMockDB(), []string{l.Addr().String()})
 }
 
 func AsJSON(v interface{}) string {


### PR DESCRIPTION
From now on, gitserver client accepts a DB connection which will be further used for gitserver hashing algorithm change and repos migration.

This PR makes a little change of `gitserver.NewClient` function signature

## Test plan
Check that there are no failing tests

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


