### PR TITLE
Revert "chore: update golangci-lint to version 1.45.0"

### DIFF
--- a/dev/golangci-lint.sh
+++ b/dev/golangci-lint.sh
@@ -6,7 +6,7 @@ pushd "$(dirname "${BASH_SOURCE[0]}")/.." >/dev/null
 
 mkdir -p .bin
 
-version="1.45.0"
+version="1.43.0"
 suffix="${version}-$(go env GOOS)-$(go env GOARCH)"
 target="$PWD/.bin/golangci-lint-${suffix}"
 


### PR DESCRIPTION
Reverts sourcegraph/sourcegraph#32844

There is a change somewhere is golang-ci lint that causes `depguard` to ignore its configuration.