### PR TITLE
web: fix `webpack` export warning

### DIFF
--- a/client/web/src/components/ActivationDropdown/index.ts
+++ b/client/web/src/components/ActivationDropdown/index.ts
@@ -1,1 +1,1 @@
-export { ActivationDropdown, ActivationDropdownProps } from './ActivationDropdown'
+export * from './ActivationDropdown'


### PR DESCRIPTION
## Context

[Webpack is not happy](https://sourcegraph.slack.com/archives/C01C3NCGD40/p1647950266147059) about [explicit type export](https://github.com/webpack/webpack/issues/7378). Exporting everything together or with a separate `export type` expression fixes the issue.

## Test plan

Run `sg start web-standalone` locally. There should be no `webpack` warnings in the console.


