### PR TITLE
gitserver: refactor gitserver.Client and its usage

### DIFF
--- a/cmd/frontend/backend/repos.go
+++ b/cmd/frontend/backend/repos.go
@@ -138,7 +138,7 @@ func (s *repos) Add(ctx context.Context, name api.RepoName) (addedName api.RepoN
 	}()
 
 	if !codehost.IsPackageHost() {
-		if err := gitserver.DefaultClient.IsRepoCloneable(ctx, name); err != nil {
+		if err := gitserver.NewClient(s.db).IsRepoCloneable(ctx, name); err != nil {
 			if ctx.Err() != nil {
 				status = "timeout"
 			} else {

--- a/cmd/frontend/graphqlbackend/git_object.go
+++ b/cmd/frontend/graphqlbackend/git_object.go
@@ -78,7 +78,7 @@ type gitObjectResolver struct {
 
 func (o *gitObjectResolver) resolve(ctx context.Context) (GitObjectID, GitObjectType, error) {
 	o.once.Do(func() {
-		obj, err := gitserver.DefaultClient.GetObject(ctx, o.repo.RepoName(), o.revspec)
+		obj, err := gitserver.NewClient(o.repo.db).GetObject(ctx, o.repo.RepoName(), o.revspec)
 		if err != nil {
 			o.err = err
 			return

--- a/cmd/frontend/graphqlbackend/repository.go
+++ b/cmd/frontend/graphqlbackend/repository.go
@@ -491,7 +491,7 @@ func (r *schemaResolver) ResolvePhabricatorDiff(ctx context.Context, args *struc
 		}
 	}
 
-	_, err = gitserver.DefaultClient.CreateCommitFromPatch(ctx, protocol.CreateCommitFromPatchRequest{
+	_, err = gitserver.NewClient(db).CreateCommitFromPatch(ctx, protocol.CreateCommitFromPatchRequest{
 		Repo:       api.RepoName(args.RepoName),
 		BaseCommit: api.CommitID(args.BaseRev),
 		TargetRef:  targetRef,

--- a/cmd/frontend/graphqlbackend/repository_mirror.go
+++ b/cmd/frontend/graphqlbackend/repository_mirror.go
@@ -41,7 +41,7 @@ type repositoryMirrorInfoResolver struct {
 
 func (r *repositoryMirrorInfoResolver) gitserverRepoInfo(ctx context.Context) (*protocol.RepoInfo, error) {
 	r.repoInfoOnce.Do(func() {
-		resp, err := gitserver.DefaultClient.RepoInfo(ctx, r.repository.RepoName())
+		resp, err := gitserver.NewClient(r.db).RepoInfo(ctx, r.repository.RepoName())
 		r.repoInfoResponse, r.repoInfoErr = resp.Results[r.repository.RepoName()], err
 	})
 	return r.repoInfoResponse, r.repoInfoErr
@@ -231,7 +231,7 @@ func (r *schemaResolver) CheckMirrorRepositoryConnection(ctx context.Context, ar
 	}
 
 	var result checkMirrorRepositoryConnectionResult
-	if err := gitserver.DefaultClient.IsRepoCloneable(ctx, repo.Name); err != nil {
+	if err := gitserver.NewClient(r.db).IsRepoCloneable(ctx, repo.Name); err != nil {
 		result.errorMessage = err.Error()
 	}
 	return &result, nil

--- a/cmd/frontend/internal/app/ui/raw.go
+++ b/cmd/frontend/internal/app/ui/raw.go
@@ -92,7 +92,7 @@ func serveRaw(db database.DB) handlerFunc {
 		}
 
 		if requestedPath == "/" && r.Method == "HEAD" {
-			_, err = gitserver.DefaultClient.RepoInfo(r.Context(), common.Repo.Name)
+			_, err = gitserver.NewClient(db).RepoInfo(r.Context(), common.Repo.Name)
 			if err != nil {
 				w.WriteHeader(http.StatusNotFound)
 				return err

--- a/cmd/frontend/internal/app/ui/raw_test.go
+++ b/cmd/frontend/internal/app/ui/raw_test.go
@@ -1,6 +1,8 @@
 package ui
 
 import (
+	"context"
+	"errors"
 	"io"
 	"io/fs"
 	"mime"
@@ -13,7 +15,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
-	"github.com/sourcegraph/sourcegraph/internal/httpcli"
+	"github.com/sourcegraph/sourcegraph/internal/gitserver/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/util"
@@ -45,17 +47,21 @@ func initHTTPTestGitServer(t *testing.T, httpStatusCode int, resp string) {
 
 	t.Cleanup(func() { s.Close() })
 
-	// Strip the protocol from the URI while patching the gitserver client's
-	// addresses, since the gitserver implementation does not want the protocol in
-	// the address.
-	original := gitserver.DefaultClient
-	t.Cleanup(func() { gitserver.DefaultClient = original })
-
-	gitserver.DefaultClient = gitserver.NewTestClient(
-		httpcli.InternalDoer,
-		database.NewMockDB(),
-		[]string{strings.TrimPrefix(s.URL, "http://")},
-	)
+	gitserver.ClientMocks.RepoInfo = func(ctx context.Context, repos ...api.RepoName) (resp *protocol.RepoInfoResponse, err error) {
+		if httpStatusCode != http.StatusOK {
+			err = errors.New("error")
+		}
+		return nil, err
+	}
+	gitserver.ClientMocks.Archive = func(ctx context.Context, repo api.RepoName, opt gitserver.ArchiveOptions) (reader io.ReadCloser, err error) {
+		if httpStatusCode != http.StatusOK {
+			err = errors.New("error")
+		} else {
+			stringReader := strings.NewReader(resp)
+			reader = io.NopCloser(stringReader)
+		}
+		return reader, err
+	}
 }
 
 func Test_serveRawWithHTTPRequestMethodHEAD(t *testing.T) {
@@ -76,6 +82,7 @@ func Test_serveRawWithHTTPRequestMethodHEAD(t *testing.T) {
 		// httptest server will return a 200 OK, so gitserver.Client.RepoInfo will not return
 		// an error.
 		initHTTPTestGitServer(t, http.StatusOK, "{}")
+		defer gitserver.ResetClientMocks()
 
 		req := httptest.NewRequest("HEAD", "/github.com/sourcegraph/sourcegraph/-/raw", nil)
 		w := httptest.NewRecorder()
@@ -94,6 +101,7 @@ func Test_serveRawWithHTTPRequestMethodHEAD(t *testing.T) {
 		// httptest server will return a 404 Not Found, so gitserver.Client.RepoInfo will
 		// return an error.
 		initHTTPTestGitServer(t, http.StatusNotFound, "{}")
+		defer gitserver.ResetClientMocks()
 
 		req := httptest.NewRequest("HEAD", "/github.com/sourcegraph/sourcegraph/-/raw", nil)
 		w := httptest.NewRecorder()
@@ -128,6 +136,7 @@ func Test_serveRawWithContentArchive(t *testing.T) {
 		// httptest server will return a 200 OK, so gitserver.Client.RepoInfo will not return an error.
 
 		initHTTPTestGitServer(t, http.StatusOK, mockGitServerResponse)
+		defer gitserver.ResetClientMocks()
 
 		req := httptest.NewRequest("GET", "/github.com/sourcegraph/sourcegraph/-/raw?format=zip", nil)
 		w := httptest.NewRecorder()
@@ -167,6 +176,7 @@ func Test_serveRawWithContentArchive(t *testing.T) {
 		// httptest server will return a 200 OK, so gitserver.Client.RepoInfo will not return an error.
 
 		initHTTPTestGitServer(t, http.StatusOK, mockGitServerResponse)
+		defer gitserver.ResetClientMocks()
 
 		req := httptest.NewRequest("GET", "/github.com/sourcegraph/sourcegraph/-/raw?format=tar", nil)
 		w := httptest.NewRecorder()
@@ -239,6 +249,7 @@ func Test_serveRawWithContentTypePlain(t *testing.T) {
 	t.Run("404 Not Found for non existent directory", func(t *testing.T) {
 		// httptest server will return a 200 OK, so gitserver.Client.RepoInfo will not return an error.
 		initHTTPTestGitServer(t, http.StatusOK, "{}")
+		defer gitserver.ResetClientMocks()
 
 		git.Mocks.Stat = func(commit api.CommitID, name string) (fs.FileInfo, error) {
 			return &util.FileInfo{}, os.ErrNotExist
@@ -263,6 +274,7 @@ func Test_serveRawWithContentTypePlain(t *testing.T) {
 	t.Run("success response for existing directory", func(t *testing.T) {
 		// httptest server will return a 200 OK, so gitserver.Client.RepoInfo will not return an error.
 		initHTTPTestGitServer(t, http.StatusOK, "{}")
+		defer gitserver.ResetClientMocks()
 
 		git.Mocks.Stat = func(commit api.CommitID, name string) (fs.FileInfo, error) {
 			return &util.FileInfo{Mode_: os.ModeDir}, nil
@@ -304,6 +316,7 @@ c.go`
 	t.Run("success response for existing file", func(t *testing.T) {
 		// httptest server will return a 200 OK, so gitserver.Client.RepoInfo will not return an error.
 		initHTTPTestGitServer(t, http.StatusOK, "{}")
+		defer gitserver.ResetClientMocks()
 
 		git.Mocks.Stat = func(commit api.CommitID, name string) (fs.FileInfo, error) {
 			return &util.FileInfo{Mode_: 0}, nil
@@ -341,6 +354,7 @@ c.go`
 	t.Run("success response for existing file with format=exe", func(t *testing.T) {
 		// httptest server will return a 200 OK, so gitserver.Client.RepoInfo will not return an error.
 		initHTTPTestGitServer(t, http.StatusOK, "{}")
+		defer gitserver.ResetClientMocks()
 
 		git.Mocks.Stat = func(commit api.CommitID, name string) (fs.FileInfo, error) {
 			return &util.FileInfo{Mode_: 0}, nil

--- a/cmd/frontend/internal/app/ui/raw_test.go
+++ b/cmd/frontend/internal/app/ui/raw_test.go
@@ -45,7 +45,10 @@ func initHTTPTestGitServer(t *testing.T, httpStatusCode int, resp string) {
 		}
 	}))
 
-	t.Cleanup(func() { s.Close() })
+	t.Cleanup(func() {
+		s.Close()
+		gitserver.ResetClientMocks()
+	})
 
 	gitserver.ClientMocks.RepoInfo = func(ctx context.Context, repos ...api.RepoName) (resp *protocol.RepoInfoResponse, err error) {
 		if httpStatusCode != http.StatusOK {
@@ -82,7 +85,6 @@ func Test_serveRawWithHTTPRequestMethodHEAD(t *testing.T) {
 		// httptest server will return a 200 OK, so gitserver.Client.RepoInfo will not return
 		// an error.
 		initHTTPTestGitServer(t, http.StatusOK, "{}")
-		defer gitserver.ResetClientMocks()
 
 		req := httptest.NewRequest("HEAD", "/github.com/sourcegraph/sourcegraph/-/raw", nil)
 		w := httptest.NewRecorder()
@@ -101,7 +103,6 @@ func Test_serveRawWithHTTPRequestMethodHEAD(t *testing.T) {
 		// httptest server will return a 404 Not Found, so gitserver.Client.RepoInfo will
 		// return an error.
 		initHTTPTestGitServer(t, http.StatusNotFound, "{}")
-		defer gitserver.ResetClientMocks()
 
 		req := httptest.NewRequest("HEAD", "/github.com/sourcegraph/sourcegraph/-/raw", nil)
 		w := httptest.NewRecorder()
@@ -136,7 +137,6 @@ func Test_serveRawWithContentArchive(t *testing.T) {
 		// httptest server will return a 200 OK, so gitserver.Client.RepoInfo will not return an error.
 
 		initHTTPTestGitServer(t, http.StatusOK, mockGitServerResponse)
-		defer gitserver.ResetClientMocks()
 
 		req := httptest.NewRequest("GET", "/github.com/sourcegraph/sourcegraph/-/raw?format=zip", nil)
 		w := httptest.NewRecorder()
@@ -176,7 +176,6 @@ func Test_serveRawWithContentArchive(t *testing.T) {
 		// httptest server will return a 200 OK, so gitserver.Client.RepoInfo will not return an error.
 
 		initHTTPTestGitServer(t, http.StatusOK, mockGitServerResponse)
-		defer gitserver.ResetClientMocks()
 
 		req := httptest.NewRequest("GET", "/github.com/sourcegraph/sourcegraph/-/raw?format=tar", nil)
 		w := httptest.NewRecorder()
@@ -249,7 +248,6 @@ func Test_serveRawWithContentTypePlain(t *testing.T) {
 	t.Run("404 Not Found for non existent directory", func(t *testing.T) {
 		// httptest server will return a 200 OK, so gitserver.Client.RepoInfo will not return an error.
 		initHTTPTestGitServer(t, http.StatusOK, "{}")
-		defer gitserver.ResetClientMocks()
 
 		git.Mocks.Stat = func(commit api.CommitID, name string) (fs.FileInfo, error) {
 			return &util.FileInfo{}, os.ErrNotExist
@@ -274,7 +272,6 @@ func Test_serveRawWithContentTypePlain(t *testing.T) {
 	t.Run("success response for existing directory", func(t *testing.T) {
 		// httptest server will return a 200 OK, so gitserver.Client.RepoInfo will not return an error.
 		initHTTPTestGitServer(t, http.StatusOK, "{}")
-		defer gitserver.ResetClientMocks()
 
 		git.Mocks.Stat = func(commit api.CommitID, name string) (fs.FileInfo, error) {
 			return &util.FileInfo{Mode_: os.ModeDir}, nil
@@ -316,7 +313,6 @@ c.go`
 	t.Run("success response for existing file", func(t *testing.T) {
 		// httptest server will return a 200 OK, so gitserver.Client.RepoInfo will not return an error.
 		initHTTPTestGitServer(t, http.StatusOK, "{}")
-		defer gitserver.ResetClientMocks()
 
 		git.Mocks.Stat = func(commit api.CommitID, name string) (fs.FileInfo, error) {
 			return &util.FileInfo{Mode_: 0}, nil
@@ -354,7 +350,6 @@ c.go`
 	t.Run("success response for existing file with format=exe", func(t *testing.T) {
 		// httptest server will return a 200 OK, so gitserver.Client.RepoInfo will not return an error.
 		initHTTPTestGitServer(t, http.StatusOK, "{}")
-		defer gitserver.ResetClientMocks()
 
 		git.Mocks.Stat = func(commit api.CommitID, name string) (fs.FileInfo, error) {
 			return &util.FileInfo{Mode_: 0}, nil

--- a/cmd/frontend/internal/httpapi/httpapi.go
+++ b/cmd/frontend/internal/httpapi/httpapi.go
@@ -159,7 +159,7 @@ func NewInternalHandler(m *mux.Router, db database.DB, schema *graphql.Schema, n
 	m.Get(apirouter.GitResolveRevision).Handler(trace.Route(handler(serveGitResolveRevision(db))))
 	m.Get(apirouter.GitTar).Handler(trace.Route(handler(serveGitTar(db))))
 	gitService := &gitServiceHandler{
-		Gitserver: gitserver.DefaultClient,
+		Gitserver: gitserver.NewClient(db),
 	}
 	m.Get(apirouter.GitInfoRefs).Handler(trace.Route(http.HandlerFunc(gitService.serveInfoRefs)))
 	m.Get(apirouter.GitUploadPack).Handler(trace.Route(http.HandlerFunc(gitService.serveGitUploadPack)))

--- a/cmd/frontend/internal/httpapi/internal.go
+++ b/cmd/frontend/internal/httpapi/internal.go
@@ -313,7 +313,7 @@ func serveGitTar(db database.DB) func(w http.ResponseWriter, r *http.Request) er
 			Format:  "tar",
 		}
 
-		location := gitserver.DefaultClient.ArchiveURL(ctx, repo, opts)
+		location := gitserver.NewClient(db).ArchiveURL(ctx, repo, opts)
 
 		w.Header().Set("Location", location.String())
 		w.WriteHeader(http.StatusFound)
@@ -352,7 +352,7 @@ func serveGitExec(db database.DB) func(http.ResponseWriter, *http.Request) error
 		}
 
 		// Find the correct shard to query
-		addr := gitserver.DefaultClient.AddrForRepo(ctx, repo.Name)
+		addr := gitserver.NewClient(db).AddrForRepo(ctx, repo.Name)
 
 		director := func(req *http.Request) {
 			req.URL.Scheme = "http"

--- a/cmd/repo-updater/shared/main.go
+++ b/cmd/repo-updater/shared/main.go
@@ -133,7 +133,7 @@ func Main(enterpriseInit EnterpriseInit) {
 	server := &repoupdater.Server{
 		Store:                 store,
 		Scheduler:             updateScheduler,
-		GitserverClient:       gitserver.DefaultClient,
+		GitserverClient:       gitserver.NewClient(db),
 		SourcegraphDotComMode: envvar.SourcegraphDotComMode(),
 	}
 

--- a/enterprise/cmd/symbols/main.go
+++ b/enterprise/cmd/symbols/main.go
@@ -172,7 +172,7 @@ func NewGitserver(repositoryFetcher fetcher.RepositoryFetcher) Gitserver {
 }
 
 func (g Gitserver) LogReverseEach(repo string, db database.DB, commit string, n int, onLogEntry func(entry git.LogEntry) error) error {
-	return git.LogReverseEach(repo, commit, n, onLogEntry)
+	return git.LogReverseEach(repo, db, commit, n, onLogEntry)
 }
 
 func (g Gitserver) RevListEach(repo string, db database.DB, commit string, onCommit func(commit string) (shouldContinue bool, err error)) error {

--- a/enterprise/internal/authz/perforce/perforce.go
+++ b/enterprise/internal/authz/perforce/perforce.go
@@ -59,7 +59,7 @@ func NewProvider(urn, host, user, password string, depots []extsvc.RepoID, db da
 		host:               host,
 		user:               user,
 		password:           password,
-		p4Execer:           gitserver.DefaultClient,
+		p4Execer:           gitserver.NewClient(db),
 		cachedGroupMembers: make(map[string][]string),
 	}
 }

--- a/enterprise/internal/batches/background/background.go
+++ b/enterprise/internal/batches/background/background.go
@@ -24,7 +24,7 @@ func Routines(ctx context.Context, batchesStore *store.Store, cf *httpcli.Factor
 	batchSpecResolutionWorkerStore := store.NewBatchSpecResolutionWorkerStore(batchesStore.Handle(), observationContext)
 
 	routines := []goroutine.BackgroundRoutine{
-		newReconcilerWorker(ctx, batchesStore, reconcilerWorkerStore, gitserver.DefaultClient, sourcer, metrics),
+		newReconcilerWorker(ctx, batchesStore, reconcilerWorkerStore, gitserver.NewClient(db), sourcer, metrics),
 		newReconcilerWorkerResetter(reconcilerWorkerStore, metrics),
 
 		newSpecExpireJob(ctx, batchesStore),

--- a/enterprise/internal/codeintel/gitserver/client.go
+++ b/enterprise/internal/codeintel/gitserver/client.go
@@ -107,7 +107,7 @@ func (c *Client) RepoInfo(ctx context.Context, repos ...api.RepoName) (_ map[api
 	}})
 	defer endObservation(1, observation.Args{})
 
-	resp, err := gitserver.DefaultClient.RepoInfo(ctx, repos...)
+	resp, err := gitserver.NewClient(c.db).RepoInfo(ctx, repos...)
 	if resp == nil {
 		return nil, err
 	}

--- a/internal/gitserver/client.go
+++ b/internal/gitserver/client.go
@@ -44,17 +44,20 @@ var (
 	clientFactory  = httpcli.NewInternalClientFactory("gitserver")
 	defaultDoer, _ = clientFactory.Doer()
 	defaultLimiter = parallel.NewRun(500)
-
-	// DefaultClient is the default Client. Unless overwritten it is connected to servers specified by SRC_GIT_SERVERS.
-	// For now this DefaultClient has a nil DB connection because it is not used.
-	// In a following commit DefaultClient will be removed and there will be no such absurd thing as NewClient(nil)
-	// Contact sashaostrikov for questions and clarifications if you see this, and it irritates you
-	DefaultClient Client = NewClient(nil)
 )
 
 var ClientMocks, emptyClientMocks struct {
 	GetObject func(repo api.RepoName, objectName string) (*gitdomain.GitObject, error)
+	RepoInfo  func(ctx context.Context, repos ...api.RepoName) (*protocol.RepoInfoResponse, error)
+	Archive   func(ctx context.Context, repo api.RepoName, opt ArchiveOptions) (_ io.ReadCloser, err error)
 }
+
+// AddrsMock is a mock for Addrs() function. It is separated from ClientMocks
+// because it is not intended to be cleared when other mocks should be.
+// This mock should be initialized during tests initialization so that
+// gitserver client always contain address of a local machine during tests
+// and tests which use gitserver client can pass successfully
+var AddrsMock func() []string
 
 // ResetClientMocks clears the mock functions set on Mocks (so that subsequent
 // tests don't inadvertently use them).
@@ -203,11 +206,14 @@ type Client interface {
 }
 
 func (c *ClientImplementor) Addrs() []string {
+	if AddrsMock != nil {
+		return AddrsMock()
+	}
 	return c.addrs()
 }
 
 func (c *ClientImplementor) AddrForRepo(ctx context.Context, repo api.RepoName) string {
-	addrs := c.addrs()
+	addrs := c.Addrs()
 	if len(addrs) == 0 {
 		panic("unexpected state: no gitserver addresses")
 	}
@@ -215,7 +221,7 @@ func (c *ClientImplementor) AddrForRepo(ctx context.Context, repo api.RepoName) 
 }
 
 func (c *ClientImplementor) RendezvousAddrForRepo(repo api.RepoName) string {
-	addrs := c.addrs()
+	addrs := c.Addrs()
 	if len(addrs) == 0 {
 		panic("unexpected state: no gitserver addresses")
 	}
@@ -226,7 +232,7 @@ func (c *ClientImplementor) RendezvousAddrForRepo(repo api.RepoName) string {
 // addrForKey returns the gitserver address to use for the given string key,
 // which is hashed for sharding purposes.
 func (c *ClientImplementor) addrForKey(key string) string {
-	addrs := c.addrs()
+	addrs := c.Addrs()
 	if len(addrs) == 0 {
 		panic("unexpected state: no gitserver addresses")
 	}
@@ -318,6 +324,9 @@ func (c *ClientImplementor) ArchiveURL(ctx context.Context, repo api.RepoName, o
 }
 
 func (c *ClientImplementor) Archive(ctx context.Context, repo api.RepoName, opt ArchiveOptions) (_ io.ReadCloser, err error) {
+	if ClientMocks.Archive != nil {
+		return ClientMocks.Archive(ctx, repo, opt)
+	}
 	span, ctx := ot.StartSpanFromContext(ctx, "Git: Archive")
 	span.SetTag("Repo", repo)
 	span.SetTag("Treeish", opt.Treeish)
@@ -668,7 +677,7 @@ func (c *ClientImplementor) ListCloned(ctx context.Context) ([]string, error) {
 		err   error
 		repos []string
 	)
-	addrs := c.addrs()
+	addrs := c.Addrs()
 	for _, addr := range addrs {
 		wg.Add(1)
 		go func(addr string) {
@@ -846,7 +855,7 @@ func (c *ClientImplementor) IsRepoCloned(ctx context.Context, repo api.RepoName)
 }
 
 func (c *ClientImplementor) RepoCloneProgress(ctx context.Context, repos ...api.RepoName) (*protocol.RepoCloneProgressResponse, error) {
-	numPossibleShards := len(c.addrs())
+	numPossibleShards := len(c.Addrs())
 	shards := make(map[string]*protocol.RepoCloneProgressRequest, (len(repos)/numPossibleShards)*2) // 2x because it may not be a perfect division
 
 	for _, r := range repos {
@@ -916,7 +925,11 @@ func (c *ClientImplementor) RepoCloneProgress(ctx context.Context, repos ...api.
 }
 
 func (c *ClientImplementor) RepoInfo(ctx context.Context, repos ...api.RepoName) (*protocol.RepoInfoResponse, error) {
-	numPossibleShards := len(c.addrs())
+	if ClientMocks.RepoInfo != nil {
+		return ClientMocks.RepoInfo(ctx, repos...)
+	}
+
+	numPossibleShards := len(c.Addrs())
 	shards := make(map[string]*protocol.RepoInfoRequest, (len(repos)/numPossibleShards)*2) // 2x because it may not be a perfect division
 
 	for _, r := range repos {
@@ -988,7 +1001,7 @@ func (c *ClientImplementor) RepoInfo(ctx context.Context, repos ...api.RepoName)
 func (c *ClientImplementor) ReposStats(ctx context.Context) (map[string]*protocol.ReposStats, error) {
 	stats := map[string]*protocol.ReposStats{}
 	var allErr error
-	for _, addr := range c.addrs() {
+	for _, addr := range c.Addrs() {
 		stat, err := c.doReposStats(ctx, addr)
 		if err != nil {
 			allErr = errors.Append(allErr, err)

--- a/internal/repos/purge.go
+++ b/internal/repos/purge.go
@@ -53,7 +53,7 @@ func purge(ctx context.Context, db database.DB, log log15.Logger) error {
 	// However, if we fetch cloned first the only race is we may miss a
 	// repository that got disabled. The next time purge runs we will remove
 	// it though.
-	cloned, err := gitserver.DefaultClient.ListCloned(ctx)
+	cloned, err := gitserver.NewClient(db).ListCloned(ctx)
 	if err != nil {
 		return err
 	}
@@ -80,7 +80,7 @@ func purge(ctx context.Context, db database.DB, log log15.Logger) error {
 		// Race condition: A repo can be re-enabled between our listing and
 		// now. This should be very rare, so we ignore it since it will get
 		// cloned again.
-		if err = gitserver.DefaultClient.Remove(ctx, repo); err != nil {
+		if err = gitserver.NewClient(db).Remove(ctx, repo); err != nil {
 			// Do not fail at this point, just log so we can remove other
 			// repos.
 			log.Error("failed to remove disabled repository", "repo", repo, "error", err)

--- a/internal/repos/scheduler.go
+++ b/internal/repos/scheduler.go
@@ -254,7 +254,7 @@ func getCustomInterval(c *conf.Unified, repoName string) time.Duration {
 
 // requestRepoUpdate sends a request to gitserver to request an update.
 var requestRepoUpdate = func(ctx context.Context, db database.DB, repo configuredRepo, since time.Duration) (*gitserverprotocol.RepoUpdateResponse, error) {
-	return gitserver.DefaultClient.RequestRepoUpdate(ctx, repo.Name, since)
+	return gitserver.NewClient(db).RequestRepoUpdate(ctx, repo.Name, since)
 }
 
 // configuredLimiter returns a mutable limiter that is

--- a/internal/search/job/job.go
+++ b/internal/search/job/job.go
@@ -233,7 +233,7 @@ func ToSearchJob(jargs *Args, q query.Q, db database.DB) (Job, error) {
 				HasTimeFilter:        b.Exists("after") || b.Exists("before"),
 				Limit:                int(patternInfo.FileMatchLimit),
 				IncludeModifiedFiles: authz.SubRepoEnabled(authz.DefaultSubRepoPermsChecker),
-				Gitserver:            gitserver.DefaultClient,
+				Gitserver:            gitserver.NewClient(db),
 			})
 		}
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -398,7 +398,7 @@ func (s *Store) watchAndEvict() {
 func (s *Store) watchConfig() {
 	for {
 		// Allow roughly 10 fetches per gitserver
-		limit := 10 * len(gitserver.DefaultClient.Addrs())
+		limit := 10 * len(gitserver.NewClient(s.DB).Addrs())
 		if limit == 0 {
 			limit = 15
 		}

--- a/internal/usagestats/repositories.go
+++ b/internal/usagestats/repositories.go
@@ -39,7 +39,7 @@ type Repositories struct {
 func GetRepositories(ctx context.Context, db database.DB) (*Repositories, error) {
 	var total Repositories
 
-	stats, err := gitserver.DefaultClient.ReposStats(ctx)
+	stats, err := gitserver.NewClient(db).ReposStats(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/vcs/git/archive.go
+++ b/internal/vcs/git/archive.go
@@ -27,7 +27,7 @@ func ArchiveReader(
 	repoName api.RepoName,
 	options gitserver.ArchiveOptions,
 ) (io.ReadCloser, error) {
-	return gitserver.DefaultClient.Archive(ctx, repoName, options)
+	return gitserver.NewClient(db).Archive(ctx, repoName, options)
 }
 
 func ArchiveReaderWithSubRepo(

--- a/internal/vcs/git/archive_test.go
+++ b/internal/vcs/git/archive_test.go
@@ -2,6 +2,8 @@ package git
 
 import (
 	"context"
+	"io"
+	"strings"
 	"testing"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
@@ -27,6 +29,11 @@ func TestArchiveReaderForRepoWithSubRepoPermissions(t *testing.T) {
 		// sub-repo permissions are enabled only for repo with repoID = 1
 		return id == 1, nil
 	})
+	gitserver.ClientMocks.Archive = func(ctx context.Context, repo api.RepoName, opt gitserver.ArchiveOptions) (io.ReadCloser, error) {
+		stringReader := strings.NewReader("1337")
+		return io.NopCloser(stringReader), nil
+	}
+	defer gitserver.ResetClientMocks()
 
 	repo := &types.Repo{Name: repoName, ID: 1}
 
@@ -56,6 +63,11 @@ func TestArchiveReaderForRepoWithoutSubRepoPermissions(t *testing.T) {
 		// sub-repo permissions are not present for repo with repoID = 1
 		return id != 1, nil
 	})
+	gitserver.ClientMocks.Archive = func(ctx context.Context, repo api.RepoName, opt gitserver.ArchiveOptions) (io.ReadCloser, error) {
+		stringReader := strings.NewReader("1337")
+		return io.NopCloser(stringReader), nil
+	}
+	defer gitserver.ResetClientMocks()
 
 	repo := &types.Repo{Name: repoName, ID: 1}
 

--- a/internal/vcs/git/blob.go
+++ b/internal/vcs/git/blob.go
@@ -106,7 +106,7 @@ func newBlobReader(ctx context.Context, db database.DB, repo api.RepoName, commi
 		return nil, err
 	}
 
-	cmd := gitserver.DefaultClient.Command("git", "show", string(commit)+":"+name)
+	cmd := gitserver.NewClient(db).Command("git", "show", string(commit)+":"+name)
 	cmd.Repo = repo
 	stdout, err := gitserver.StdoutReader(ctx, cmd)
 	if err != nil {

--- a/internal/vcs/git/commits.go
+++ b/internal/vcs/git/commits.go
@@ -192,7 +192,7 @@ func CommitsUniqueToBranch(ctx context.Context, db database.DB, repo api.RepoNam
 		args = append(args, branchName, "^HEAD")
 	}
 
-	cmd := gitserver.DefaultClient.Command("git", args...)
+	cmd := gitserver.NewClient(db).Command("git", args...)
 	cmd.Repo = repo
 	out, err := cmd.CombinedOutput(ctx)
 	if err != nil {
@@ -301,13 +301,13 @@ func commitLog(ctx context.Context, db database.DB, repo api.RepoName, opt Commi
 	return filtered, err
 }
 
-func getWrappedCommits(ctx context.Context, _ database.DB, repo api.RepoName, opt CommitsOptions) ([]*wrappedCommit, error) {
+func getWrappedCommits(ctx context.Context, db database.DB, repo api.RepoName, opt CommitsOptions) ([]*wrappedCommit, error) {
 	args, err := commitLogArgs([]string{"log", logFormatWithoutRefs}, opt)
 	if err != nil {
 		return nil, err
 	}
 
-	cmd := gitserver.DefaultClient.Command("git", args...)
+	cmd := gitserver.NewClient(db).Command("git", args...)
 	cmd.Repo = repo
 	if !opt.NoEnsureRevision {
 		cmd.EnsureRevision = opt.Range
@@ -464,7 +464,7 @@ func commitLogArgs(initialArgs []string, opt CommitsOptions) (args []string, err
 }
 
 // commitCount returns the number of commits that would be returned by Commits.
-func commitCount(ctx context.Context, _ database.DB, repo api.RepoName, opt CommitsOptions) (uint, error) {
+func commitCount(ctx context.Context, db database.DB, repo api.RepoName, opt CommitsOptions) (uint, error) {
 	span, ctx := ot.StartSpanFromContext(ctx, "Git: CommitCount")
 	span.SetTag("Opt", opt)
 	defer span.Finish()
@@ -474,7 +474,7 @@ func commitCount(ctx context.Context, _ database.DB, repo api.RepoName, opt Comm
 		return 0, err
 	}
 
-	cmd := gitserver.DefaultClient.Command("git", args...)
+	cmd := gitserver.NewClient(db).Command("git", args...)
 	cmd.Repo = repo
 	if opt.Path != "" {
 		// This doesn't include --follow flag because rev-list doesn't support it, so the number may be slightly off.
@@ -496,7 +496,7 @@ func FirstEverCommit(ctx context.Context, db database.DB, repo api.RepoName, che
 	defer span.Finish()
 
 	args := []string{"rev-list", "--reverse", "--date-order", "--max-parents=0", "HEAD"}
-	cmd := gitserver.DefaultClient.Command("git", args...)
+	cmd := gitserver.NewClient(db).Command("git", args...)
 	cmd.Repo = repo
 	out, err := cmd.Output(ctx)
 	if err != nil {
@@ -529,7 +529,7 @@ func CommitExists(ctx context.Context, db database.DB, repo api.RepoName, id api
 // repositories), a false-valued flag is returned along with a nil error and
 // empty revision.
 func Head(ctx context.Context, db database.DB, repo api.RepoName, checker authz.SubRepoPermissionChecker) (_ string, revisionExists bool, err error) {
-	cmd := gitserver.DefaultClient.Command("git", "rev-parse", "HEAD")
+	cmd := gitserver.NewClient(db).Command("git", "rev-parse", "HEAD")
 	cmd.Repo = repo
 
 	out, err := cmd.Output(ctx)
@@ -647,7 +647,7 @@ func BranchesContaining(ctx context.Context, db database.DB, repo api.RepoName, 
 			return nil, err
 		}
 	}
-	cmd := gitserver.DefaultClient.Command("git", "branch", "--contains", string(commit), "--format", "%(refname)")
+	cmd := gitserver.NewClient(db).Command("git", "branch", "--contains", string(commit), "--format", "%(refname)")
 	cmd.Repo = repo
 
 	out, err := cmd.CombinedOutput(ctx)
@@ -693,7 +693,7 @@ func RefDescriptions(ctx context.Context, db database.DB, repo api.RepoName, che
 			args = append(args, "--points-at="+obj)
 		}
 
-		cmd := gitserver.DefaultClient.Command("git", args...)
+		cmd := gitserver.NewClient(db).Command("git", args...)
 		cmd.Repo = repo
 
 		out, err := cmd.CombinedOutput(ctx)
@@ -819,7 +819,7 @@ func CommitDate(ctx context.Context, db database.DB, repo api.RepoName, commit a
 		}
 	}
 
-	cmd := gitserver.DefaultClient.Command("git", "show", "-s", "--format=%H:%cI", string(commit))
+	cmd := gitserver.NewClient(db).Command("git", "show", "-s", "--format=%H:%cI", string(commit))
 	cmd.Repo = repo
 
 	out, err := cmd.CombinedOutput(ctx)
@@ -875,7 +875,7 @@ func CommitGraph(ctx context.Context, db database.DB, repo api.RepoName, opts Co
 		args = append(args, fmt.Sprintf("-%d", opts.Limit))
 	}
 
-	cmd := gitserver.DefaultClient.Command("git", args...)
+	cmd := gitserver.NewClient(db).Command("git", args...)
 	cmd.Repo = repo
 
 	out, err := cmd.CombinedOutput(ctx)

--- a/internal/vcs/git/diff.go
+++ b/internal/vcs/git/diff.go
@@ -102,7 +102,7 @@ func DiffPath(ctx context.Context, db database.DB, repo api.RepoName, sourceComm
 
 // DiffSymbols performs a diff command which is expected to be parsed by our symbols package
 func DiffSymbols(ctx context.Context, db database.DB, repo api.RepoName, commitA, commitB api.CommitID) ([]byte, error) {
-	command := gitserver.DefaultClient.Command("git", "diff", "-z", "--name-status", "--no-renames", string(commitA), string(commitB))
+	command := gitserver.NewClient(db).Command("git", "diff", "-z", "--name-status", "--no-renames", string(commitA), string(commitB))
 	command.Repo = repo
 	return command.Output(ctx)
 }

--- a/internal/vcs/git/log.go
+++ b/internal/vcs/git/log.go
@@ -7,6 +7,7 @@ import (
 	"io"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
@@ -47,11 +48,11 @@ func LogReverseArgs(n int, givenCommit string) []string {
 	}
 }
 
-func LogReverseEach(repo string, commit string, n int, onLogEntry func(entry LogEntry) error) error {
+func LogReverseEach(repo string, db database.DB, commit string, n int, onLogEntry func(entry LogEntry) error) error {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	command := gitserver.DefaultClient.Command("git", LogReverseArgs(n, commit)...)
+	command := gitserver.NewClient(db).Command("git", LogReverseArgs(n, commit)...)
 	command.Repo = api.RepoName(repo)
 	// We run a single `git log` command and stream the output while the repo is being processed, which
 	// can take much longer than 1 minute (the default timeout).

--- a/internal/vcs/git/merge_base.go
+++ b/internal/vcs/git/merge_base.go
@@ -22,7 +22,7 @@ func MergeBase(ctx context.Context, db database.DB, repo api.RepoName, a, b api.
 	span.SetTag("B", b)
 	defer span.Finish()
 
-	cmd := gitserver.DefaultClient.Command("git", "merge-base", "--", string(a), string(b))
+	cmd := gitserver.NewClient(db).Command("git", "merge-base", "--", string(a), string(b))
 	cmd.Repo = repo
 	out, err := cmd.CombinedOutput(ctx)
 	if err != nil {

--- a/internal/vcs/git/object_test.go
+++ b/internal/vcs/git/object_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 )
@@ -33,7 +34,7 @@ func TestGetObject(t *testing.T) {
 
 	for label, test := range tests {
 		t.Run(label, func(t *testing.T) {
-			obj, err := gitserver.DefaultClient.GetObject(context.Background(), test.repo, test.objectName)
+			obj, err := gitserver.NewClient(database.NewMockDB()).GetObject(context.Background(), test.repo, test.objectName)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/vcs/git/revisions.go
+++ b/internal/vcs/git/revisions.go
@@ -93,7 +93,7 @@ func ResolveRevision(ctx context.Context, db database.DB, repo api.RepoName, spe
 		spec = spec + "^0"
 	}
 
-	cmd := gitserver.DefaultClient.Command("git", "rev-parse", spec)
+	cmd := gitserver.NewClient(db).Command("git", "rev-parse", spec)
 	cmd.Repo = repo
 	cmd.EnsureRevision = spec
 

--- a/internal/vcs/git/shortlog.go
+++ b/internal/vcs/git/shortlog.go
@@ -55,7 +55,7 @@ func ShortLog(ctx context.Context, db database.DB, repo api.RepoName, opt ShortL
 	if opt.Path != "" {
 		args = append(args, opt.Path)
 	}
-	cmd := gitserver.DefaultClient.Command("git", args...)
+	cmd := gitserver.NewClient(db).Command("git", args...)
 	cmd.Repo = repo
 	out, err := cmd.Output(ctx)
 	if err != nil {

--- a/internal/vcs/git/tree_test.go
+++ b/internal/vcs/git/tree_test.go
@@ -45,7 +45,7 @@ func TestRepository_FileSystem_Symlinks(t *testing.T) {
 	dir := InitGitRepository(t, gitCommands...)
 	repo := api.RepoName(filepath.Base(dir))
 
-	if resp, err := gitserver.DefaultClient.RequestRepoUpdate(context.Background(), repo, 0); err != nil {
+	if resp, err := gitserver.NewClient(db).RequestRepoUpdate(context.Background(), repo, 0); err != nil {
 		t.Fatal(err)
 	} else if resp.Error != "" {
 		t.Fatal(resp.Error)
@@ -697,7 +697,7 @@ func TestStat(t *testing.T) {
 	dir := InitGitRepository(t, gitCommands...)
 	repo := api.RepoName(filepath.Base(dir))
 
-	if resp, err := gitserver.DefaultClient.RequestRepoUpdate(context.Background(), repo, 0); err != nil {
+	if resp, err := gitserver.NewClient(db).RequestRepoUpdate(context.Background(), repo, 0); err != nil {
 		t.Fatal(err)
 	} else if resp.Error != "" {
 		t.Fatal(resp.Error)


### PR DESCRIPTION
Part of https://github.com/sourcegraph/sourcegraph/issues/32315

Removing global gitserver client in favor of creating them locally in an ad-hoc manner.

## Test plan
CI + additional main-dry-run build

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


