### PR TITLE
Add amd64 argument for m1 macOS users

### DIFF
--- a/doc/admin/install/docker/index.md
+++ b/doc/admin/install/docker/index.md
@@ -36,7 +36,7 @@ For next steps and further configuration options, visit the [site administration
 
 <span class="virtual-br"></span>
 
-> NOTE: On a macOS machine with an Apple M1 chip, you’ll need to add an extra ` --platform linux/amd64 ` argument to your Docker command so that the platform does not interfere with the installation and running of Sourcegraph. 
+> NOTE: On Mac computers with Apple silicon, you’ll need to add an extra `--platform linux/amd64` argument to your Docker command for correctly running and installing Sourcegraph. 
 
 <span class="virtual-br"></span>
 

--- a/doc/admin/install/docker/index.md
+++ b/doc/admin/install/docker/index.md
@@ -36,6 +36,10 @@ For next steps and further configuration options, visit the [site administration
 
 <span class="virtual-br"></span>
 
+> NOTE: On a macOS machine with an Apple M1 chip, you’ll need to add an extra ` --platform linux/amd64 ` argument to your Docker command so that the platform does not interfere with the installation and running of Sourcegraph. 
+
+<span class="virtual-br"></span>
+
 > NOTE: If you run Docker on an OS such as RHEL, Fedora, or CentOS with SELinux enabled, sVirt doesn't allow the Docker process
 > to access `~/.sourcegraph/config` and `~/.sourcegraph/data`. In that case, you will see the following message:
 


### PR DESCRIPTION
Following the same instructions we have on [learn.sourcegraph.com about m1 chips](https://learn.sourcegraph.com/how-to-install-sourcegraph-on-mac-with-docker#on-an-apple-m1-chip-on-macos) this adds a note to inform the user about the need of including a extra argument do the docker command.



## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


