### PR TITLE
Integration tests: Add option to run automated accessibility audits

### DIFF
--- a/client/shared/src/testing/accessibility.ts
+++ b/client/shared/src/testing/accessibility.ts
@@ -33,9 +33,21 @@ interface AccessibilityAuditConfiguration {
     mode?: 'fail' | 'warn'
 }
 
+/**
+ * Use this `CSS` class constant to ignore an element in an accessibility audit.
+ */
+export const ACCESSIBILITY_AUDIT_IGNORE_CLASS = '.a11y-ignore'
+
+/**
+ * Runs an accessibility audit for the current page.
+ *
+ * Will error with a list of violations if any are found.
+ *
+ * See further documentation: https://docs.sourcegraph.com/dev/how-to/testing#accessibility-tests
+ */
 export async function accessibilityAudit(page: Page, config: AccessibilityAuditConfiguration = {}): Promise<void> {
     const { options, mode = 'fail' } = config
-    const axe = new AxePuppeteer(page).exclude('.a11y-ignore')
+    const axe = new AxePuppeteer(page).exclude(ACCESSIBILITY_AUDIT_IGNORE_CLASS)
 
     if (options) {
         axe.options(options)

--- a/client/shared/src/testing/accessibility.ts
+++ b/client/shared/src/testing/accessibility.ts
@@ -1,0 +1,70 @@
+import { AxePuppeteer } from '@axe-core/puppeteer'
+import type { Result, NodeResult, RunOptions } from 'axe-core'
+import { Page } from 'puppeteer'
+
+/**
+ * Takes a list of Axe violation nodes and formats them into a readable string.
+ */
+const formatViolationProblems = (nodes: NodeResult[]): string =>
+    nodes
+        .map(
+            ({ failureSummary = '', html }) => `
+${html}:
+${failureSummary}
+            `
+        )
+        .join('')
+
+/**
+ * Filters any nodes that should be explicitly ignored from our Axe violations.
+ */
+const filterIgnoredNodes = (nodes: NodeResult[]): NodeResult[] =>
+    nodes.filter(({ target }) => !target.includes('a11y-ignore'))
+
+/**
+ * Takes a list of Axe violation and formats them into readable strings.
+ */
+const formatRuleViolations = (violations: Result[]): string[] =>
+    violations
+        .map(violation => ({
+            ...violation,
+            nodes: filterIgnoredNodes(violation.nodes),
+        }))
+        .filter(({ nodes }) => nodes.length > 0)
+        .map(
+            ({ id, help, helpUrl, nodes }) => `
+Rule: "${id}" (${help})
+Further information: ${helpUrl}
+How to manually audit: https://docs.sourcegraph.com/dev/background-information/web/accessibility/how-to-audit#auditing-a-user-journey
+Required changes: ${formatViolationProblems(nodes)}
+`
+        )
+
+interface AccessibilityAuditConfiguration {
+    options?: RunOptions
+    mode?: 'fail' | 'warn'
+}
+
+export async function accessibilityAudit(page: Page, config: AccessibilityAuditConfiguration = {}): Promise<void> {
+    const { options, mode = 'fail' } = config
+    const axe = new AxePuppeteer(page)
+
+    if (options) {
+        axe.options(options)
+    }
+
+    const { violations } = await axe.analyze()
+    const formattedViolations = formatRuleViolations(violations)
+
+    if (formattedViolations.length > 0) {
+        const errorMessage = `Accessibility audit failed, ${
+            formattedViolations.length
+        } rule violations found: \n${formattedViolations.join('\n')}`
+
+        if (mode === 'fail') {
+            throw new Error(errorMessage)
+        }
+
+        console.warn(errorMessage)
+    }
+}

--- a/client/shared/src/testing/accessibility.ts
+++ b/client/shared/src/testing/accessibility.ts
@@ -16,29 +16,17 @@ ${failureSummary}
         .join('')
 
 /**
- * Filters any nodes that should be explicitly ignored from our Axe violations.
- */
-const filterIgnoredNodes = (nodes: NodeResult[]): NodeResult[] =>
-    nodes.filter(({ target }) => !target.includes('a11y-ignore'))
-
-/**
  * Takes a list of Axe violation and formats them into readable strings.
  */
 const formatRuleViolations = (violations: Result[]): string[] =>
-    violations
-        .map(violation => ({
-            ...violation,
-            nodes: filterIgnoredNodes(violation.nodes),
-        }))
-        .filter(({ nodes }) => nodes.length > 0)
-        .map(
-            ({ id, help, helpUrl, nodes }) => `
+    violations.map(
+        ({ id, help, helpUrl, nodes }) => `
 Rule: "${id}" (${help})
 Further information: ${helpUrl}
 How to manually audit: https://docs.sourcegraph.com/dev/background-information/web/accessibility/how-to-audit#auditing-a-user-journey
 Required changes: ${formatViolationProblems(nodes)}
 `
-        )
+    )
 
 interface AccessibilityAuditConfiguration {
     options?: RunOptions
@@ -47,7 +35,7 @@ interface AccessibilityAuditConfiguration {
 
 export async function accessibilityAudit(page: Page, config: AccessibilityAuditConfiguration = {}): Promise<void> {
     const { options, mode = 'fail' } = config
-    const axe = new AxePuppeteer(page)
+    const axe = new AxePuppeteer(page).exclude('.a11y-ignore')
 
     if (options) {
         axe.options(options)

--- a/client/shared/src/testing/accessibility.ts
+++ b/client/shared/src/testing/accessibility.ts
@@ -59,7 +59,7 @@ export async function accessibilityAudit(page: Page, config: AccessibilityAuditC
     if (formattedViolations.length > 0) {
         const errorMessage = `Accessibility audit failed, ${
             formattedViolations.length
-        } rule violations found: \n${formattedViolations.join('\n')}`
+        } rule violations found:\n${formattedViolations.join('\n')}`
 
         if (mode === 'fail') {
             throw new Error(errorMessage)

--- a/client/web/src/integration/code-monitoring.test.ts
+++ b/client/web/src/integration/code-monitoring.test.ts
@@ -2,7 +2,6 @@ import assert from 'assert'
 
 import expect from 'expect'
 
-import { accessibilityAudit } from '@sourcegraph/shared/src/testing/accessibility'
 import { Driver, createDriverForTest } from '@sourcegraph/shared/src/testing/driver'
 import { afterEachSaveScreenshotIfFailed } from '@sourcegraph/shared/src/testing/screenshotReporter'
 
@@ -105,11 +104,10 @@ describe('Code monitoring', () => {
     afterEach(() => testContext?.dispose())
 
     describe('Code monitoring', () => {
-        it.only('is styled correctly', async () => {
+        it('is styled correctly', async () => {
             await driver.page.goto(driver.sourcegraphBaseUrl + '/code-monitoring')
             await driver.page.waitForSelector('[data-testid="code-monitoring-page"]')
             await percySnapshotWithVariants(driver.page, 'Code monitor list')
-            await accessibilityAudit(driver.page)
         })
     })
 

--- a/client/web/src/integration/code-monitoring.test.ts
+++ b/client/web/src/integration/code-monitoring.test.ts
@@ -2,6 +2,7 @@ import assert from 'assert'
 
 import expect from 'expect'
 
+import { accessibilityAudit } from '@sourcegraph/shared/src/testing/accessibility'
 import { Driver, createDriverForTest } from '@sourcegraph/shared/src/testing/driver'
 import { afterEachSaveScreenshotIfFailed } from '@sourcegraph/shared/src/testing/screenshotReporter'
 
@@ -104,10 +105,11 @@ describe('Code monitoring', () => {
     afterEach(() => testContext?.dispose())
 
     describe('Code monitoring', () => {
-        it('is styled correctly', async () => {
+        it.only('is styled correctly', async () => {
             await driver.page.goto(driver.sourcegraphBaseUrl + '/code-monitoring')
             await driver.page.waitForSelector('[data-testid="code-monitoring-page"]')
             await percySnapshotWithVariants(driver.page, 'Code monitor list')
+            await accessibilityAudit(driver.page)
         })
     })
 

--- a/client/web/src/integration/context.ts
+++ b/client/web/src/integration/context.ts
@@ -80,7 +80,7 @@ export const createWebIntegrationTestContext = async ({
         .filter(request => !request.pathname.startsWith('/-/'))
         .intercept((request, response) => {
             response.type('text/html').send(html`
-                <html>
+                <html lang="en">
                     <head>
                         <title>Sourcegraph Test</title>
                     </head>

--- a/doc/dev/how-to/testing.md
+++ b/doc/dev/how-to/testing.md
@@ -399,6 +399,15 @@ test('Repositories list', async function () {
 })
 ```
 
+If, for whatever reason, we have to ignore some elements from an accessibility audit, we can use the `a11y-ignore` CSS class:
+
+```JSX
+  {/* Some explanation as to why we need to ignore this element */}
+  <h3 className="a11y-ignore">Heading</h3>
+```
+
+**Tip:** Don't forget you'll need to rebuild the code if you want to see the tests pass locally after making this change.
+
 ### Lighthouse tests
 
 We run Lighthouse performance tests through [Lighthouse CI](https://github.com/GoogleChrome/lighthouse-ci). These tests are relatively hands-off and run a series of Lighthouse audits against a deployed server. The flow for running these tests is:

--- a/doc/dev/how-to/testing.md
+++ b/doc/dev/how-to/testing.md
@@ -385,7 +385,7 @@ Flakiness in snapshot tests can be caused by the search response time, order of 
 
 This can be solved with [Percy specific CSS](https://docs.percy.io/docs/percy-specific-css) that will be applied only when taking the snapshot and allow you to hide flaky elements with `display: none`. In simple cases, you can simply apply the `percy-hide` (to apply `visibility: hidden`) or `percy-display-none` (to apply `display: none`) CSS classes to the problematic element and it will be hidden from Percy.
 
-#### Accessibility tests
+### Accessibility tests
 
 We use [axe-core](https://github.com/dequelabs/axe-core) to run accessibility audits through our integration tests. It ensures we can quickly assess entire pages and raise any errors before they become problems in production.
 
@@ -402,8 +402,10 @@ test('Repositories list', async function () {
 If, for whatever reason, we have to ignore some elements from an accessibility audit, we can use the `a11y-ignore` CSS class:
 
 ```JSX
+  import { ACCESSIBILITY_AUDIT_IGNORE_CLASS } from '@sourcegraph/shared/src/testing/accessibility'
+
   {/* Some explanation as to why we need to ignore this element */}
-  <h3 className="a11y-ignore">Heading</h3>
+  <h3 className={ACCESSIBILITY_AUDIT_IGNORE_CLASS}>Heading</h3>
 ```
 
 **Tip:** Don't forget you'll need to rebuild the code if you want to see the tests pass locally after making this change.

--- a/doc/dev/how-to/testing.md
+++ b/doc/dev/how-to/testing.md
@@ -385,6 +385,20 @@ Flakiness in snapshot tests can be caused by the search response time, order of 
 
 This can be solved with [Percy specific CSS](https://docs.percy.io/docs/percy-specific-css) that will be applied only when taking the snapshot and allow you to hide flaky elements with `display: none`. In simple cases, you can simply apply the `percy-hide` (to apply `visibility: hidden`) or `percy-display-none` (to apply `display: none`) CSS classes to the problematic element and it will be hidden from Percy.
 
+#### Accessibility tests
+
+We use [axe-core](https://github.com/dequelabs/axe-core) to run accessibility audits through our integration tests. It ensures we can quickly assess entire pages and raise any errors before they become problems in production.
+
+You can run an audit in any test by calling `accessibilityAudit()`:
+
+```TypeScript
+test('Repositories list', async function () {
+    await page.goto(baseURL + '/site-admin/repositories?query=gorilla%2Fmux')
+    await page.waitForSelector('[test-repository-name="/github.com/gorilla/mux"]', { visible: true })
+    await accessibilityAudit(page)
+})
+```
+
 ### Lighthouse tests
 
 We run Lighthouse performance tests through [Lighthouse CI](https://github.com/GoogleChrome/lighthouse-ci). These tests are relatively hands-off and run a series of Lighthouse audits against a deployed server. The flow for running these tests is:

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
   },
   "devDependencies": {
     "@atlassian/aui": "^7.10.1",
+    "@axe-core/puppeteer": "^4.4.2",
     "@babel/core": "^7.14.2",
     "@babel/plugin-proposal-decorators": "^7.14.2",
     "@babel/plugin-transform-typescript": "^7.13.0",
@@ -224,6 +225,7 @@
     "@types/webpack-manifest-plugin": "3.0.5",
     "abort-controller": "^3.0.0",
     "autoprefixer": "^10.2.1",
+    "axe-core": "^4.4.1",
     "babel-jest": "^25.5.1",
     "babel-loader": "^8.2.2",
     "babel-plugin-lodash": "^3.3.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -94,6 +94,13 @@
   dependencies:
     axe-core "^4.2.1"
 
+"@axe-core/puppeteer@^4.4.2":
+  version "4.4.2"
+  resolved "https://registry.npmjs.org/@axe-core/puppeteer/-/puppeteer-4.4.2.tgz#63ada57d407d8bea45bac5b05974e16282f41820"
+  integrity sha512-HsiXUALjQ5fcWZZgGUvYGr/b7qvWbQXeDuW2z+2YYOJsavlPV9z0IGdm4rmX0lmsdJ9usA5vq5LNLiz23ZyXmw==
+  dependencies:
+    axe-core "^4.4.1"
+
 "@babel/code-frame@7.10.4":
   version "7.10.4"
   resolved "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz#168da1a36e90da68ae8d49c0f1b48c7c6249213a"
@@ -7126,6 +7133,11 @@ axe-core@4.2.1, axe-core@^4.0.2, axe-core@^4.2.0, axe-core@^4.2.1:
   version "4.2.1"
   resolved "https://registry.npmjs.org/axe-core/-/axe-core-4.2.1.tgz#2e50bcf10ee5b819014f6e342e41e45096239e34"
   integrity sha512-evY7DN8qSIbsW2H/TWQ1bX3sXN1d4MNb5Vb4n7BzPuCwRHdkZ1H2eNLuSh73EoQqkGKUtju2G2HCcjCfhvZIAA==
+
+axe-core@^4.4.1:
+  version "4.4.1"
+  resolved "https://registry.npmjs.org/axe-core/-/axe-core-4.4.1.tgz#7dbdc25989298f9ad006645cd396782443757413"
+  integrity sha512-gd1kmb21kwNuWr6BQz8fv6GNECPBnUasepcoLbekws23NVBLODdsClRZ+bQ8+9Uomf3Sm3+Vwn0oYG9NvwnJCw==
 
 axios@0.19.0, axios@^0.19.0:
   version "0.19.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -87,14 +87,7 @@
     underscore "1.6.0"
     webcomponents.js "0.7.20"
 
-"@axe-core/puppeteer@^4.2.0":
-  version "4.2.1"
-  resolved "https://registry.npmjs.org/@axe-core/puppeteer/-/puppeteer-4.2.1.tgz#5b7a191e4f4f3d56f975fdf5c2682eed3ad306a7"
-  integrity sha512-2JDELbLCKK2KqBvLOpsROtJU0i+zqyseMCd8S86S1H8loxy30/v7xJQo32WWbAa+x8xABQcejO1U4Kk1VEVssw==
-  dependencies:
-    axe-core "^4.2.1"
-
-"@axe-core/puppeteer@^4.4.2":
+"@axe-core/puppeteer@^4.2.0", "@axe-core/puppeteer@^4.4.2":
   version "4.4.2"
   resolved "https://registry.npmjs.org/@axe-core/puppeteer/-/puppeteer-4.4.2.tgz#63ada57d407d8bea45bac5b05974e16282f41820"
   integrity sha512-HsiXUALjQ5fcWZZgGUvYGr/b7qvWbQXeDuW2z+2YYOJsavlPV9z0IGdm4rmX0lmsdJ9usA5vq5LNLiz23ZyXmw==
@@ -7129,12 +7122,12 @@ aws4@^1.8.0:
   resolved "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
   integrity sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
 
-axe-core@4.2.1, axe-core@^4.0.2, axe-core@^4.2.0, axe-core@^4.2.1:
+axe-core@4.2.1:
   version "4.2.1"
   resolved "https://registry.npmjs.org/axe-core/-/axe-core-4.2.1.tgz#2e50bcf10ee5b819014f6e342e41e45096239e34"
   integrity sha512-evY7DN8qSIbsW2H/TWQ1bX3sXN1d4MNb5Vb4n7BzPuCwRHdkZ1H2eNLuSh73EoQqkGKUtju2G2HCcjCfhvZIAA==
 
-axe-core@^4.4.1:
+axe-core@^4.0.2, axe-core@^4.2.0, axe-core@^4.2.1, axe-core@^4.4.1:
   version "4.4.1"
   resolved "https://registry.npmjs.org/axe-core/-/axe-core-4.4.1.tgz#7dbdc25989298f9ad006645cd396782443757413"
   integrity sha512-gd1kmb21kwNuWr6BQz8fv6GNECPBnUasepcoLbekws23NVBLODdsClRZ+bQ8+9Uomf3Sm3+Vwn0oYG9NvwnJCw==


### PR DESCRIPTION
<img width="987" alt="image" src="https://user-images.githubusercontent.com/9516420/159530169-84b06238-4602-452a-b090-acd2e553b606.png">

## Description

This PR adds the testing util: `accessibilityAudit` for automated accessibility tests.

Some notes:
- It functions quite similar to `percySnapshot`, in that it just takes the current Puppeteer page and handles everything else. We should be able to use this wherever we use `percySnapshot`.
- It is performant, I didn't notice any significant slowness when running this in tests.
- We can ignore elements through the `a11y-ignore` class, similar to `percy-hide` and `chromatic-ignore`

### Usage

Right now we're not using this util anywhere in our tests. We should:

1. Use`accessibilityAudit` wherever where we use `percySnapshot`.
2. Fix any issues reported by the audit, use `a11y-ignore` only if absolutely necessary, or we can't immediately fix the issue.

We can ask GitStart to focus on this work.

### Why not Lighthouse?

We could use our Lighthouse checks for our accessibility audits, but it has some caveats:
- It is a lot slower. We'd have to cut out a lot of the other Lighthouse checks to make it faster, and it'd ultimately end up being a wrapper around the accessibility checks anyway.
- It doesn't test as many issues as axe-core does, as far as I can tell.
- Lighthouse CLI isn't great and has no TypeScript support (boo)

We can consider extending these utils in future to potentially test performance through Lighthouse too.

## Test plan

1. Ran through the integration tests locally and in CI
4. Tested in the `code-monitoring` test

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


