### PR TITLE
Add match highlight style and update csp

### DIFF
--- a/client/vscode/src/webview/initialize.ts
+++ b/client/vscode/src/webview/initialize.ts
@@ -142,9 +142,9 @@ export function initializeSearchSidebarWebview({
         </style>
         <meta http-equiv="Content-Security-Policy" content="default-src 'none'; child-src data: ${
             webviewView.webview.cspSource
-        }; img-src data: https:; script-src blob: https:; style-src 'unsafe-inline' ${
+        }; worker-src blob: data:; img-src data: https:; script-src blob: https:; style-src 'unsafe-inline' ${
         webviewView.webview.cspSource
-    } http: https: data:; connect-src 'self' http: https:; font-src vscode-resource: https:;">
+    } http: https: data:; connect-src 'self' http: https:; font-src vscode-resource: blob: https:;">
         <title>Sourcegraph Search</title>
         <link rel="stylesheet" href="${styleSource.toString()}" />
         <link rel="stylesheet" href="${cssModuleSource.toString()}" />

--- a/client/vscode/src/webview/theming/highlight.scss
+++ b/client/vscode/src/webview/theming/highlight.scss
@@ -11,6 +11,8 @@
         color: var(--vscode-editorLineNumber-foreground);
     }
 
+    .match-highlight,
+    .match-highlight-sticky,
     .selection-highlight,
     .selection-highlight-sticky {
         background-color: var(--vscode-editor-findMatchHighlightBackground);
@@ -337,6 +339,8 @@ body[data-vscode-theme-name^='Light (Visual Studio)'].sourcegraph-extension.them
 
 // High contrast (default VS Code dark HC theme)
 body[data-vscode-theme-name='High Contrast'].sourcegraph-extension.theme-dark {
+    .match-highlight,
+    .match-highlight-sticky,
     .selection-highlight,
     .selection-highlight-sticky {
         background-color: white;


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/32894

Looks like the css class has been updated from `selection-highlight` to `match-highlight` for matched results
![image](https://user-images.githubusercontent.com/68532117/159510846-2624e235-ece1-49f7-befb-e7b54cd1c342.png)

Adding the new classname to the CSS stylesheet has resolved the issue.

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

Not required
