### PR TITLE
Docs: update saved search docs

### DIFF
--- a/doc/code_search/how-to/saved_searches.md
+++ b/doc/code_search/how-to/saved_searches.md
@@ -1,25 +1,24 @@
 # Saved searches
 
-Saved searches lets you save and describe search queries so you can easily monitor the results on an ongoing basis. You can create a saved search for anything, including diffs and commits across all branches of your repositories.
-
-Saved searches can be an early warning system for common problems in your code--and a way to monitor best practices, the progress of refactors, etc. Alerts for saved searches can be sent through email, ensuring you're aware of important code changes.
+Saved searches let you save and describe search queries so you can easily find and use them again later. You can create a saved search for anything, including diffs and commits across all branches of your repositories.
 
 ## Creating saved searches
 
 A saved search consists of a description and a query, both of which you can define and edit.
 
-Saved searches are written as JSON entries in settings, and they can be associated with a user or an org:
+Saved searches can be associated with a user or an org:
 
 - User saved searches are only visible to (and editable by) the user that created them.
 - Org saved searches are visible to (and editable by) all members of the org.
 
-To create a saved search:
+### User saved searches
+
+To create a User saved search:
 
 1. Go to **User menu > Saved searches** in the top navigation bar.
 1. Press the **+ Add new search** button.
 1. In the **Query** field, type in the components of the search query.
 1. In the **Description** field, type in a human-readable description for your saved search.
-1. In the user and org dropdown menu, select where you'd like the search to be saved.
 1. Click **Create**. The saved search is created, and you can see the number of results.
 
 Alternatively, to create a saved search from a search you've already run:
@@ -28,15 +27,20 @@ Alternatively, to create a saved search from a search you've already run:
 1. Press the **Save this search query** button that appears on the right side of the screen above the first result.
 1. Follow the instructions from above to fill in the remaining fields.
 
-To view saved searches, go to **User menu > Saved searches** in the top navigation bar.
+To view User saved searches, go to **User menu > Saved searches** in the top navigation bar.
 
-## Configuring email notifications
+### Org saved searches
 
-Sourcegraph can automatically run your saved searches and notify you when new results are available via email. With this feature you can get notified about issues in your code (such as licensing issues, security changes, potential secrets being committed, etc.)
+To create an Org saved search:
 
-To configure email notifications, click **Edit** on a saved search and check the **Email notifications** checkbox and press **Save**. You will receive a notification telling you it is set up and working almost instantly!
+1. Go to **User menu** and click the desired organization under **Your organizations**
+1. Click the **Saved Searches** tab
+1. Press the **+ Add new search** button.
+1. In the **Query** field, type in the components of the search query.
+1. In the **Description** field, type in a human-readable description for your saved search.
+1. Click **Create**. The saved search is created, and you can see the number of results.
 
-By default, email notifications notify the owner of the configuration (either a single user or the entire org).
+Org saved searches are viewable in the **Saved Searches** tab of the organization's page.
 
 ## Example saved searches
 


### PR DESCRIPTION
The docs for saved searches were quite out of date, and still referred to UI elements that don't exist and saved search notifications, which also don't exist. 

Fixes #32896 

## Test plan

Ran the docsite locally and confirmed everything looked correct.

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


