### PR TITLE
Code monitors: pass hook to addCodeMonitorHook

### DIFF
--- a/enterprise/internal/codemonitors/background/search_test.go
+++ b/enterprise/internal/codemonitors/background/search_test.go
@@ -77,7 +77,7 @@ func TestAddCodeMonitorHook(t *testing.T) {
 
 		for _, j := range erroringJobs {
 			t.Run("", func(t *testing.T) {
-				_, err := addCodeMonitorHook(j, 0)
+				_, err := addCodeMonitorHook(j, nil)
 				require.Error(t, err)
 			})
 		}
@@ -93,7 +93,7 @@ func TestAddCodeMonitorHook(t *testing.T) {
 
 		for _, j := range nonErroringJobs {
 			t.Run("", func(t *testing.T) {
-				_, err := addCodeMonitorHook(j, 0)
+				_, err := addCodeMonitorHook(j, nil)
 				require.NoError(t, err)
 			})
 		}

--- a/internal/search/commit/commit.go
+++ b/internal/search/commit/commit.go
@@ -38,10 +38,11 @@ type CommitSearch struct {
 	Gitserver            GitserverClient `json:"-"`
 
 	// CodeMonitorSearchWrapper, if set, will wrap the commit search with extra logic specific to code monitors.
-	CodeMonitorSearchWrapper func(context.Context, database.DB, GitserverClient, *gitprotocol.SearchRequest, DoSearchFunc) error `json:"-"`
+	CodeMonitorSearchWrapper CodeMonitorHook `json:"-"`
 }
 
 type DoSearchFunc func(*gitprotocol.SearchRequest) error
+type CodeMonitorHook func(context.Context, database.DB, GitserverClient, *gitprotocol.SearchRequest, DoSearchFunc) error
 
 type GitserverClient interface {
 	Search(_ context.Context, _ *protocol.SearchRequest, onMatches func([]protocol.CommitMatch)) (limitHit bool, _ error)


### PR DESCRIPTION
This passes a hook into addCodeMonitorHook so that I can pass a
different hook in for snapshotting repo state. This is how I think I'm
going to fix the issue with new repos skipping their first commits.


## Test plan

Semantics-preserving and covered by unit tests.

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


