### PR TITLE
notebooks: fix compute block alert check

### DIFF
--- a/client/web/src/notebooks/blocks/compute/component/src/Main.elm
+++ b/client/web/src/notebooks/blocks/compute/component/src/Main.elm
@@ -329,7 +329,7 @@ update msg model =
             else
                 let
                     alerts =
-                        if String.contains "type:commit" model.query || String.contains "type:diff" model.query && not (String.contains "count:all" model.query) then
+                        if (String.contains "type:commit" model.query || String.contains "type:diff" model.query) && not (String.contains "count:all" model.query) then
                             [ { title = "Heads up"
                               , description = "This data may be incomplete! Add `count:all` to this query? Avoid doing this all the time though... 🤣"
                               }


### PR DESCRIPTION
Need to parenthesize this expression because operator precedence. I noticed the fix before but forgot to commit it to the PR :facepalm:

## Test plan
Manually tested for experimental feature