### PR TITLE
Add docker resources

### DIFF
--- a/doc/admin/install/docker/index.md
+++ b/doc/admin/install/docker/index.md
@@ -45,6 +45,18 @@ For next steps and further configuration options, visit the [site administration
 
 > `mkdir -p ~/.sourcegraph/config ~/.sourcegraph/data && chown -R -t svirt_sandbox_file_t ~/.sourcegraph/config ~/.sourcegraph/data`
 
+# Docker Resources
+Minimum requirements:
+
+**CPUs:** NUMBER
+
+**Memory:** NUMBER
+
+**Swap:** NUMBER
+
+**Disk image size:** Number
+
+
 ### Cloud installation guides
 
 Cloud specific Sourcegraph installation guides for AWS, Google Cloud and Digital Ocean.


### PR DESCRIPTION
We recently had a prospect reach out with questions about why their local instance of Single Container Docker was crashing and I think it was b/c they had their docker resources set to the default. I tried to use the default resources and was able to recreate their problem.

Thought something along the lines of minimum requirements would prevent running into issues like this in the future!



## Test plan

Opening this PR to bring it to the attention of the docs/ delivery teams. This specific PR will not get merged.


