### PR TITLE
notebooks: Monaco compute block font

### DIFF
--- a/client/web/src/notebooks/blocks/compute/component/src/Main.elm
+++ b/client/web/src/notebooks/blocks/compute/component/src/Main.elm
@@ -697,7 +697,7 @@ view : Model -> Html Msg
 view model =
     E.layout
         [ E.width E.fill
-        , F.family [ F.typeface "Fira Code" ]
+        , F.family [ F.typeface "Fira Code", F.typeface "Monaco" ]
         , F.size 12
         , F.color darkModeFontColor
         , Background.color darkModeBackgroundColor


### PR DESCRIPTION
Compute block was using Fira Code typeface that isn't installed by default on most people's computers 🙈 . This falls back to Monaco.

## Test plan
Tested manually (Chrome and FF)


