### PR TITLE
codeintel: Add envvar to disable bloom filter tests

### DIFF
--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/query_references.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/query_references.go
@@ -3,6 +3,7 @@ package resolvers
 import (
 	"context"
 	"fmt"
+	"os"
 	"sort"
 	"time"
 
@@ -462,6 +463,10 @@ func (r *queryResolver) uploadIDsWithReferences(
 // testFilter returns true if the set underlying the given encoded bloom filter probably includes any of
 // the given monikers.
 func testFilter(filter []byte, orderedMonikers []precise.QualifiedMonikerData) (bool, error) {
+	if os.Getenv("DEBUG_PRECISE_CODE_INTEL_BLOOM_FILTER_BAIL_OUT") != "" {
+		return true, nil
+	}
+
 	includesIdentifier, err := bloomfilter.Decode(filter)
 	if err != nil {
 		return false, errors.Wrap(err, "bloomfilter.Decode")


### PR DESCRIPTION
Add an environment variable to disable bloom filter tests for find reference and implementations queries.

We plan to disable bloom filters in Cloud to see if they, once a requirement for good performance when using SQLite, are a dominating overhead for some types of reference queries. If we see no negative changes in honeycomb for average queries and and we also see a positive improvement for the queries we're targeting, we can set this on-by-default and eventually deprecate the bloom filter code and data columns (which are actually quite sizeable in the database).

This is partial effort towards fixing #32328.

## Test plan

Current CI tests. Should not affect any environment apart from Cloud, which we will enable only under surveillance.