### PR TITLE
Update pure-docker commit reference

### DIFF
--- a/doc/admin/updates/pure_docker.md
+++ b/doc/admin/updates/pure_docker.md
@@ -13,7 +13,7 @@ Each section comprehensively describes the changes needed in Docker images, envi
 This release adds the requirement that the environment variables `SRC_GIT_SERVERS`, `SEARCHER_URL`, `SYMBOLS_URL`, and `INDEXED_SEARCH_SERVERS` are set for the worker process.
 
 To upgrade, please perform the changes in the following diff:
-[https://github.com/sourcegraph/deploy-sourcegraph-docker/commit/d0e97e86472a44f1dc966e0c7dec07f0eae8a6a3](https://github.com/sourcegraph/deploy-sourcegraph-docker/commit/d0e97e86472a44f1dc966e0c7dec07f0eae8a6a3)
+[https://github.com/sourcegraph/deploy-sourcegraph-docker/commit/a66a74ce9a120a9da743eb44c6fea3a55f51842a](https://github.com/sourcegraph/deploy-sourcegraph-docker/commit/a66a74ce9a120a9da743eb44c6fea3a55f51842a)
 
 *How smooth was this upgrade process for you? You can give us your feedback on this upgrade by filling out [this feedback form](https://share.hsforms.com/1aGeG7ALQQEGO6zyfauIiCA1n7ku?update_version=3.37).*
 


### PR DESCRIPTION
The 3.38-customer-replica branch was updated to include a fix for the pgsql image reference, so this documentation needs to point to that new commit.

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->
Confirm docs look ok