### PR TITLE
[cloud] Case insensitive comparison of emails for invitations

### DIFF
--- a/cmd/frontend/graphqlbackend/org_invitations.go
+++ b/cmd/frontend/graphqlbackend/org_invitations.go
@@ -7,6 +7,7 @@ import (
 	"math"
 	"net/url"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/golang-jwt/jwt/v4"
@@ -88,7 +89,7 @@ func checkEmail(ctx context.Context, db database.DB, inviteEmail string) (bool, 
 
 	containsEmail := func(userEmails []*database.UserEmail, email string) *database.UserEmail {
 		for _, userEmail := range userEmails {
-			if email == userEmail.Email {
+			if strings.EqualFold(email, userEmail.Email) {
 				return userEmail
 			}
 		}

--- a/cmd/frontend/graphqlbackend/org_invitations_test.go
+++ b/cmd/frontend/graphqlbackend/org_invitations_test.go
@@ -659,7 +659,7 @@ func TestRespondToOrganizationInvitation(t *testing.T) {
 		invitationID := int64(3)
 		orgID := int32(3)
 		email := "foo@bar.baz"
-		orgInvitations.GetPendingByIDFunc.SetDefaultReturn(&database.OrgInvitation{ID: invitationID, OrgID: orgID, RecipientEmail: email}, nil)
+		orgInvitations.GetPendingByIDFunc.SetDefaultReturn(&database.OrgInvitation{ID: invitationID, OrgID: orgID, RecipientEmail: strings.ToUpper(email)}, nil)
 
 		userEmails := database.NewMockUserEmailsStore()
 		userEmails.ListByUserFunc.SetDefaultReturn([]*database.UserEmail{{Email: email, UserID: 2}}, nil)


### PR DESCRIPTION
Previously, there was a case sensitive string comparison of the
email on the invitation with the emails configured on the user account.
But email is case insensitive in it's nature, meaning that people
are likely to fill their email as John.Doe@foo.bar instead of john.doe@foo.bar

Doing a case insensitive comparison fixes the problem.

Related:
https://sourcegraph.atlassian.net/browse/CLOUD-337



## Test plan

Tested with unit test

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


