### PR TITLE
Add page titles to insights pages

### DIFF
--- a/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/DashboardsContentPage.tsx
+++ b/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/DashboardsContentPage.tsx
@@ -6,6 +6,7 @@ import { Redirect } from 'react-router-dom'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { LoadingSpinner, useObservable } from '@sourcegraph/wildcard'
 
+import { PageTitle } from '../../../../../components/PageTitle'
 import { CodeInsightsBackendContext } from '../../../core/backend/code-insights-backend-context'
 import { ALL_INSIGHTS_DASHBOARD } from '../../../core/constants'
 
@@ -42,5 +43,12 @@ export const DashboardsContentPage: React.FunctionComponent<DashboardsContentPag
         )
     }
 
-    return <DashboardsContent telemetryService={telemetryService} dashboardID={dashboardID} dashboards={dashboards} />
+    const currentDashboard = dashboards.find(dashboard => dashboard.id === dashboardID)
+
+    return (
+        <>
+            <PageTitle title={currentDashboard?.title} />
+            <DashboardsContent telemetryService={telemetryService} dashboardID={dashboardID} dashboards={dashboards} />
+        </>
+    )
 }

--- a/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/DashboardsContentPage.tsx
+++ b/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/DashboardsContentPage.tsx
@@ -47,7 +47,7 @@ export const DashboardsContentPage: React.FunctionComponent<DashboardsContentPag
 
     return (
         <>
-            <PageTitle title={currentDashboard?.title} />
+            <PageTitle title={`Dashboard ${currentDashboard?.title || ''}`} />
             <DashboardsContent telemetryService={telemetryService} dashboardID={dashboardID} dashboards={dashboards} />
         </>
     )

--- a/client/web/src/enterprise/insights/pages/dashboards/edit-dashboard/EditDashobardPage.tsx
+++ b/client/web/src/enterprise/insights/pages/dashboards/edit-dashboard/EditDashobardPage.tsx
@@ -109,7 +109,7 @@ export const EditDashboardPage: React.FunctionComponent<EditDashboardPageProps> 
 
     return (
         <CodeInsightsPage className={classNames('col-8', styles.page)}>
-            <PageTitle title="Configure dashboard" />
+            <PageTitle title={`Configure ${dashboard.title}`} />
 
             <PageHeader path={[{ icon: CodeInsightsIcon }, { text: 'Configure dashboard' }]} />
 

--- a/client/web/src/enterprise/insights/pages/insights/creation/intro/IntroCreationPage.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/intro/IntroCreationPage.tsx
@@ -6,6 +6,7 @@ import { useLocation } from 'react-router-dom'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { PageHeader, Link } from '@sourcegraph/wildcard'
 
+import { PageTitle } from '../../../../../../components/PageTitle'
 import { CodeInsightsIcon } from '../../../../../../insights/Icons'
 import { CodeInsightsPage } from '../../../../components/code-insights-page/CodeInsightsPage'
 
@@ -53,6 +54,7 @@ export const IntroCreationPage: React.FunctionComponent<IntroCreationPageProps> 
 
     return (
         <CodeInsightsPage className={styles.container}>
+            <PageTitle title="Create new code insight" />
             <PageHeader
                 path={[{ icon: CodeInsightsIcon }, { text: 'Create new code insight' }]}
                 description={

--- a/client/web/src/enterprise/insights/pages/insights/edit-insight/EditInsightPage.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/edit-insight/EditInsightPage.tsx
@@ -60,7 +60,7 @@ export const EditInsightPage: React.FunctionComponent<EditInsightPageProps> = pr
 
     return (
         <CodeInsightsPage>
-            <PageTitle title="Edit code insight" />
+            <PageTitle title={`Edit ${insight.title}`} />
 
             <PageHeader
                 className="mb-3"

--- a/client/web/src/enterprise/insights/pages/landing/getting-started/CodeInsightsGettingStartedPage.tsx
+++ b/client/web/src/enterprise/insights/pages/landing/getting-started/CodeInsightsGettingStartedPage.tsx
@@ -2,6 +2,8 @@ import React, { useEffect } from 'react'
 
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 
+import { PageTitle } from '../../../../../components/PageTitle'
+
 import { CodeInsightsExamples } from './components/code-insights-examples/CodeInsightsExamples'
 import { CodeInsightsLearnMore } from './components/code-insights-learn-more/CodeInsightsLearnMore'
 import { CodeInsightsTemplates } from './components/code-insights-templates/CodeInsightsTemplates'
@@ -20,6 +22,7 @@ export const CodeInsightsGettingStartedPage: React.FunctionComponent<CodeInsight
 
     return (
         <main className="pb-5">
+            <PageTitle title="Code Insights" />
             <DynamicCodeInsightExample telemetryService={telemetryService} />
             <CodeInsightsExamples telemetryService={telemetryService} className={styles.section} />
             <CodeInsightsTemplates telemetryService={telemetryService} className={styles.section} />


### PR DESCRIPTION
closes #24367

Add new page titles to insights pages based on dashboard or insight name.  Add a generic title to the Add new insight creation page.

## Test plan
 Manual - Screen shots below:

Page title for dashboard view:
<img width="643" alt="Dashboard Title" src="https://user-images.githubusercontent.com/6098507/159564652-adb9f82b-e58c-4df3-ba1b-2422f5b9dc4f.png">

Page title editing insight:
<img width="386" alt="Edit Insight" src="https://user-images.githubusercontent.com/6098507/159564755-6f8fe2be-a42c-493e-8149-4995c8df9027.png">
 
Page title configuring dashbaord
<img width="739" alt="Configure Dashboard" src="https://user-images.githubusercontent.com/6098507/159564844-33662f31-7738-4e6e-8d29-7e3841079047.png">

