### PR TITLE
Code monitors: move code monitor search code out of background package

### DIFF
--- a/enterprise/internal/codemonitors/background/workers.go
+++ b/enterprise/internal/codemonitors/background/workers.go
@@ -9,6 +9,7 @@ import (
 	"github.com/inconshreveable/log15"
 	"github.com/keegancsmith/sqlf"
 
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/codemonitors"
 	edb "github.com/sourcegraph/sourcegraph/enterprise/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
@@ -172,7 +173,7 @@ func (r *queryRunner) Handle(ctx context.Context, record workerutil.Record) (err
 	ctx = actor.WithActor(ctx, actor.FromUser(m.UserID))
 	ctx = featureflag.WithFlags(ctx, r.db.FeatureFlags())
 
-	settings, err := settings(ctx)
+	settings, err := codemonitors.Settings(ctx)
 	if err != nil {
 		return errors.Wrap(err, "query settings")
 	}
@@ -182,7 +183,7 @@ func (r *queryRunner) Handle(ctx context.Context, record workerutil.Record) (err
 		// Only add an after filter when repo-aware monitors is disabled
 		query = newQueryWithAfterFilter(q)
 	}
-	results, searchErr := doSearch(ctx, r.db, query, m.ID, settings)
+	results, searchErr := codemonitors.Search(ctx, r.db, query, m.ID, settings)
 
 	// Log next_run and latest_result to table cm_queries.
 	newLatestResult := latestResultTime(q.LatestResult, results, searchErr)

--- a/enterprise/internal/codemonitors/search.go
+++ b/enterprise/internal/codemonitors/search.go
@@ -1,4 +1,4 @@
-package background
+package codemonitors
 
 import (
 	"bytes"
@@ -47,8 +47,8 @@ type gqlSettingsResponse struct {
 	Errors []gqlerrors.FormattedError
 }
 
-// settings queries for the computed settings for the current actor
-func settings(ctx context.Context) (_ *schema.Settings, err error) {
+// Settings queries for the computed Settings for the current actor
+func Settings(ctx context.Context) (_ *schema.Settings, err error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "CodeMonitorSearch")
 	defer func() {
 		span.LogFields(log.Error(err))
@@ -105,7 +105,7 @@ func settings(ctx context.Context) (_ *schema.Settings, err error) {
 	return &unmarshaledSettings, nil
 }
 
-func doSearch(ctx context.Context, db database.DB, query string, monitorID int64, settings *schema.Settings) (_ []*result.CommitMatch, err error) {
+func Search(ctx context.Context, db database.DB, query string, monitorID int64, settings *schema.Settings) (_ []*result.CommitMatch, err error) {
 	searchClient := client.NewSearchClient(db, search.Indexed(), search.SearcherURLs())
 	inputs, err := searchClient.Plan(ctx, "V2", nil, query, search.Streaming, settings, envvar.SourcegraphDotComMode())
 	if err != nil {

--- a/enterprise/internal/codemonitors/search_test.go
+++ b/enterprise/internal/codemonitors/search_test.go
@@ -1,4 +1,4 @@
-package background
+package codemonitors
 
 import (
 	"context"


### PR DESCRIPTION
Just a small reorg moving stuff out of the massive `background` package.

## Test plan

Relying on CI.

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


