### PR TITLE
Code monitors: snapshot repo state on code monitor create or update

### DIFF
--- a/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers.go
+++ b/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers.go
@@ -13,6 +13,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codemonitors"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codemonitors/background"
 	edb "github.com/sourcegraph/sourcegraph/enterprise/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/featureflag"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
@@ -145,16 +146,18 @@ func (r *Resolver) CreateCodeMonitor(ctx context.Context, args *graphqlbackend.C
 		return nil, err
 	}
 
-	settings, err := graphqlbackend.DecodedViewerFinalSettings(ctx, tx.db)
-	if err != nil {
-		return nil, err
-	}
+	if featureflag.FromContext(ctx).GetBoolOr("cc-repo-aware-monitors", false) {
+		settings, err := graphqlbackend.DecodedViewerFinalSettings(ctx, tx.db)
+		if err != nil {
+			return nil, err
+		}
 
-	// Snapshot the state of the searched repos when the monitor is created so that
-	// we can distinguish new repos.
-	err = codemonitors.Snapshot(ctx, tx.db, args.Trigger.Query, m.ID, settings)
-	if err != nil {
-		return nil, err
+		// Snapshot the state of the searched repos when the monitor is created so that
+		// we can distinguish new repos.
+		err = codemonitors.Snapshot(ctx, tx.db, args.Trigger.Query, m.ID, settings)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	// Create actions.
@@ -521,24 +524,26 @@ func (r *Resolver) updateCodeMonitor(ctx context.Context, args *graphqlbackend.U
 		return nil, err
 	}
 
-	currentTrigger, err := r.db.CodeMonitors().GetQueryTriggerForMonitor(ctx, monitorID)
-	if err != nil {
-		return nil, err
-	}
-
-	// When the query is changed, take a new snapshot of the commits that currently
-	// exist so we know where to start.
-	if currentTrigger.QueryString != args.Trigger.Update.Query {
-		settings, err := graphqlbackend.DecodedViewerFinalSettings(ctx, r.db)
+	if featureflag.FromContext(ctx).GetBoolOr("cc-repo-aware-monitors", false) {
+		currentTrigger, err := r.db.CodeMonitors().GetQueryTriggerForMonitor(ctx, monitorID)
 		if err != nil {
 			return nil, err
 		}
 
-		// Snapshot the state of the searched repos when the monitor is created so that
-		// we can distinguish new repos.
-		err = codemonitors.Snapshot(ctx, r.db, args.Trigger.Update.Query, monitorID, settings)
-		if err != nil {
-			return nil, err
+		// When the query is changed, take a new snapshot of the commits that currently
+		// exist so we know where to start.
+		if currentTrigger.QueryString != args.Trigger.Update.Query {
+			settings, err := graphqlbackend.DecodedViewerFinalSettings(ctx, r.db)
+			if err != nil {
+				return nil, err
+			}
+
+			// Snapshot the state of the searched repos when the monitor is created so that
+			// we can distinguish new repos.
+			err = codemonitors.Snapshot(ctx, r.db, args.Trigger.Update.Query, monitorID, settings)
+			if err != nil {
+				return nil, err
+			}
 		}
 	}
 

--- a/enterprise/internal/codemonitors/search.go
+++ b/enterprise/internal/codemonitors/search.go
@@ -153,6 +153,39 @@ func Search(ctx context.Context, db database.DB, query string, monitorID int64, 
 	return results, nil
 }
 
+// Snapshot runs a dummy search that just saves the current state of the searched repos in the database.
+// On subsequent runs, this allows us to treat all new repos or sets of args as something new that should
+// be searched from the beginning.
+func Snapshot(ctx context.Context, db database.DB, query string, monitorID int64, settings *schema.Settings) error {
+	searchClient := client.NewSearchClient(db, search.Indexed(), search.SearcherURLs())
+	inputs, err := searchClient.Plan(ctx, "V2", nil, query, search.Streaming, settings, envvar.SourcegraphDotComMode())
+	if err != nil {
+		return err
+	}
+
+	jobArgs := searchClient.JobArgs(inputs)
+	plan, err := predicate.Expand(ctx, db, jobArgs, inputs.Plan)
+	if err != nil {
+		return err
+	}
+
+	planJob, err := job.FromExpandedPlan(jobArgs, plan, db)
+	if err != nil {
+		return err
+	}
+
+	hook := func(ctx context.Context, db database.DB, gs commit.GitserverClient, args *gitprotocol.SearchRequest, doSearch commit.DoSearchFunc) error {
+		return snapshotHook(ctx, db, gs, args, doSearch, monitorID)
+	}
+	planJob, err = addCodeMonitorHook(planJob, hook)
+	if err != nil {
+		return err
+	}
+
+	_, err = planJob.Run(ctx, db, streaming.NewNullStream())
+	return err
+}
+
 func addCodeMonitorHook(in job.Job, hook commit.CodeMonitorHook) (_ job.Job, err error) {
 	return job.MapAtom(in, func(atom job.Job) job.Job {
 		switch typedAtom := atom.(type) {
@@ -192,10 +225,6 @@ func hookWithID(
 	if err != nil {
 		return err
 	}
-	if len(lastSearched) == 0 {
-		// We've never run this monitor before. Do not run, but start here next time.
-		return cm.UpsertLastSearched(ctx, monitorID, argsHash, commitHashes)
-	}
 
 	// Merge requested hashes and excluded hashes
 	newRevs := make([]gitprotocol.RevisionSpecifier, 0, len(commitHashes)+len(lastSearched))
@@ -218,6 +247,26 @@ func hookWithID(
 
 	// If the search was successful, store the resolved hashes
 	// as the new "last searched" hashes
+	return cm.UpsertLastSearched(ctx, monitorID, argsHash, commitHashes)
+}
+
+func snapshotHook(
+	ctx context.Context,
+	db database.DB,
+	gs commit.GitserverClient,
+	args *gitprotocol.SearchRequest,
+	doSearch commit.DoSearchFunc,
+	monitorID int64,
+) error {
+	cm := edb.NewEnterpriseDB(db).CodeMonitors()
+
+	// Resolve the requested revisions into a static set of commit hashes
+	commitHashes, err := gs.ResolveRevisions(ctx, args.Repo, args.Revisions)
+	if err != nil {
+		return err
+	}
+
+	argsHash := hashArgs(args)
 	return cm.UpsertLastSearched(ctx, monitorID, argsHash, commitHashes)
 }
 

--- a/enterprise/internal/codemonitors/search.go
+++ b/enterprise/internal/codemonitors/search.go
@@ -174,8 +174,8 @@ func Snapshot(ctx context.Context, db database.DB, query string, monitorID int64
 		return err
 	}
 
-	hook := func(ctx context.Context, db database.DB, gs commit.GitserverClient, args *gitprotocol.SearchRequest, doSearch commit.DoSearchFunc) error {
-		return snapshotHook(ctx, db, gs, args, doSearch, monitorID)
+	hook := func(ctx context.Context, db database.DB, gs commit.GitserverClient, args *gitprotocol.SearchRequest, _ commit.DoSearchFunc) error {
+		return snapshotHook(ctx, db, gs, args, monitorID)
 	}
 	planJob, err = addCodeMonitorHook(planJob, hook)
 	if err != nil {
@@ -255,7 +255,6 @@ func snapshotHook(
 	db database.DB,
 	gs commit.GitserverClient,
 	args *gitprotocol.SearchRequest,
-	doSearch commit.DoSearchFunc,
 	monitorID int64,
 ) error {
 	cm := edb.NewEnterpriseDB(db).CodeMonitors()


### PR DESCRIPTION
Due to the somewhat hacky way I've added hooks, it's not currently
possible to tell the difference between "this is the first run and we
should start from whatever commits exists" and "this is a new repo and
we should start searching from the beginning." This fixes that issue by
snapshotting the state of things when a code monitor is created or
updated so that we can know, unambiguously, that whenever we don't have
a set of last-searched hashes, we should just start searching from the
beginning.

In the future, when we can optimize a query down to a single commit
search job (no and/or jobs), we should be able to remove this hack 
along with the "job args hash" hack because then we'll be able to
do all the code-monitor-specific mutations ahead of time rather than
resorting to this hook solution.

## Test plan

Manually tested that when I created or updated a monitor, the `cm_last_searched` table was populated appropriately. 

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


