### PR TITLE
Migrate remaining `icon-inline` classNames to wildcard

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -114,6 +114,10 @@ See https://handbook.sourcegraph.com/community/faq#is-all-of-sourcegraph-open-so
             className: 'badge',
             message: 'Use the <Badge /> component from @sourcegraph/wildcard instead.',
           },
+          {
+            className: 'icon-inline',
+            message: 'Use the <Icon /> component from @sourcegraph/wildcard instead.',
+          },
         ],
       },
     ],

--- a/client/search-ui/src/components/SearchResult.tsx
+++ b/client/search-ui/src/components/SearchResult.tsx
@@ -47,7 +47,7 @@ export const SearchResult: React.FunctionComponent<Props> = ({
         const formattedRepositoryStarCount = formatRepositoryStarCount(result.repoStars)
         return (
             <div className={styles.title}>
-                <RepoIcon repoName={repoName} className="icon-inline text-muted flex-shrink-0" />
+                <RepoIcon repoName={repoName} className="text-muted flex-shrink-0" />
                 <span className="test-search-result-label ml-1 flex-shrink-past-contents text-truncate">
                     {result.type === 'commit' && (
                         <>

--- a/client/search-ui/src/results/progress/StreamingProgressSkippedButton.tsx
+++ b/client/search-ui/src/results/progress/StreamingProgressSkippedButton.tsx
@@ -42,7 +42,7 @@ export const StreamingProgressSkippedButton: React.FunctionComponent<
                         aria-expanded={isOpen}
                     >
                         {skippedWithWarningOrError ? <Icon className="mr-2" as={AlertCircleIcon} /> : null}
-                        Some results excluded <ChevronDownIcon data-caret={true} className="icon-inline mr-0" />
+                        Some results excluded <Icon data-caret={true} className="mr-0" as={ChevronDownIcon} />
                     </PopoverTrigger>
                     <PopoverContent
                         position={Position.bottomStart}

--- a/client/web/src/auth/SignInPage.tsx
+++ b/client/web/src/auth/SignInPage.tsx
@@ -89,7 +89,7 @@ export const SignInPage: React.FunctionComponent<SignInPageProps> = props => {
                                 )}
                                 {provider.serviceType === 'gitlab' && (
                                     <>
-                                        <GitlabIcon className="icon-inline" />{' '}
+                                        <Icon as={GitlabIcon} />{' '}
                                     </>
                                 )}
                                 Continue with {provider.displayName}

--- a/client/web/src/enterprise/batches/create/workspaces-preview/WorkspacesPreview.tsx
+++ b/client/web/src/enterprise/batches/create/workspaces-preview/WorkspacesPreview.tsx
@@ -211,7 +211,7 @@ export const WorkspacesPreview: React.FunctionComponent<WorkspacesPreviewProps> 
                 Workspaces preview{' '}
                 {(batchSpecStale || !hasPreviewed) && shouldShowConnection && !isWorkspacesPreviewInProgress && (
                     <Icon
-                        className={classNames('icon-inline text-muted ml-1', styles.warningIcon)}
+                        className={classNames('text-muted ml-1', styles.warningIcon)}
                         data-tooltip="The workspaces previewed below may not be up-to-date."
                         as={WarningIcon}
                     />

--- a/client/web/src/enterprise/batches/detail/changesets/ChangesetLastSynced.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/ChangesetLastSynced.tsx
@@ -102,7 +102,7 @@ const UpdateLoaderIcon: React.FunctionComponent<{
     }
 
     if (viewerCanAdminister) {
-        return <SyncIcon className="icon-inline cursor-pointer" onClick={onEnqueueChangeset} role="button" />
+        return <Icon className="cursor-pointer" onClick={onEnqueueChangeset} role="button" as={SyncIcon} />
     }
 
     return <Icon as={InfoCircleOutlineIcon} />

--- a/client/web/src/enterprise/code-monitoring/components/logs/CollapsibleDetailsWithStatus.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/logs/CollapsibleDetailsWithStatus.tsx
@@ -4,7 +4,7 @@ import classNames from 'classnames'
 import ChevronDownIcon from 'mdi-react/ChevronDownIcon'
 import ChevronRightIcon from 'mdi-react/ChevronRightIcon'
 
-import { Badge, Button } from '@sourcegraph/wildcard'
+import { Badge, Button, Icon } from '@sourcegraph/wildcard'
 
 import { EventStatus } from '../../../../graphql-operations'
 
@@ -49,11 +49,7 @@ export const CollapsibleDetailsWithStatus: React.FunctionComponent<{
     return (
         <div className={styles.wrapper}>
             <Button onClick={toggleExpanded} className={classNames('btn-icon d-block', styles.expandButton)}>
-                {expanded ? (
-                    <ChevronDownIcon className="icon-inline mr-2" />
-                ) : (
-                    <ChevronRightIcon className="icon-inline mr-2" />
-                )}
+                <Icon className="mr-2" as={expanded ? ChevronDownIcon : ChevronRightIcon} />
                 <span>{title}</span>
                 <Badge variant={statusBadge} className="ml-2 text-uppercase">
                     {statusText}

--- a/client/web/src/enterprise/code-monitoring/components/logs/MonitorLogNode.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/logs/MonitorLogNode.tsx
@@ -87,7 +87,7 @@ export const MonitorLogNode: React.FunctionComponent<{
                     rel="noopener noreferrer"
                     onClick={clickCatcher}
                 >
-                    Monitor details <OpenInNewIcon className="icon-inline" />
+                    Monitor details <Icon as={OpenInNewIcon} />
                 </Link>
             </Button>
             <span className="text-nowrap mr-2">

--- a/client/web/src/enterprise/code-monitoring/components/logs/TriggerEvent.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/logs/TriggerEvent.tsx
@@ -8,7 +8,7 @@ import OpenInNewIcon from 'mdi-react/OpenInNewIcon'
 
 import { pluralize } from '@sourcegraph/common'
 import { buildSearchURLQuery } from '@sourcegraph/shared/src/util/url'
-import { Button, Link } from '@sourcegraph/wildcard'
+import { Button, Link, Icon } from '@sourcegraph/wildcard'
 
 import { Timestamp } from '../../../../components/time/Timestamp'
 import {
@@ -59,13 +59,9 @@ export const TriggerEvent: React.FunctionComponent<{
     return (
         <>
             <Button onClick={toggleExpanded} className={classNames('btn-icon d-block', styles.expandButton)}>
-                {expanded ? (
-                    <ChevronDownIcon className="icon-inline mr-2" />
-                ) : (
-                    <ChevronRightIcon className="icon-inline mr-2" />
-                )}
+                <Icon className="mr-2" as={expanded ? ChevronDownIcon : ChevronRightIcon} />
 
-                {hasError ? <AlertCircleIcon className={classNames(styles.errorIcon, 'icon-inline mr-2')} /> : <span />}
+                {hasError ? <Icon className={classNames(styles.errorIcon, 'mr-2')} as={AlertCircleIcon} /> : <span />}
 
                 <span>
                     Run <Timestamp date={triggerEvent.timestamp} noAbout={true} now={now} />
@@ -77,7 +73,7 @@ export const TriggerEvent: React.FunctionComponent<{
                             className="font-weight-normal ml-2"
                         >
                             {triggerEvent.resultCount} new {pluralize('result', triggerEvent.resultCount)}{' '}
-                            <OpenInNewIcon className="icon-inline" />
+                            <Icon as={OpenInNewIcon} />
                         </Link>
                     )}
                 </span>

--- a/client/web/src/enterprise/codeintel/uploads/components/UploadRetentionStatusNode.tsx
+++ b/client/web/src/enterprise/codeintel/uploads/components/UploadRetentionStatusNode.tsx
@@ -4,6 +4,7 @@ import classNames from 'classnames'
 import InformationOutlineIcon from 'mdi-react/InformationOutlineIcon'
 
 import { pluralize } from '@sourcegraph/common'
+import { Icon } from '@sourcegraph/wildcard'
 import { Link } from '@sourcegraph/wildcard/src/components/Link'
 
 import {
@@ -55,16 +56,18 @@ const RetentionPolicyRetentionMatchNode: FunctionComponent<{ match: RetentionPol
                                 .slice(0, 4)
                                 .map(hash => hash.slice(0, 7))
                                 .join(', ')}
-                            <InformationOutlineIcon
-                                className="ml-1 icon-inline"
+                            <Icon
+                                className="ml-1"
                                 data-tooltip="This upload is retained to service code-intel queries for commit(s) with applicable retention policies."
+                                as={InformationOutlineIcon}
                             />
                         </>
                     )}
                     {!match.configurationPolicy && (
-                        <InformationOutlineIcon
-                            className="ml-1 icon-inline"
+                        <Icon
+                            className="ml-1"
                             data-tooltip="Uploads at the tip of the default branch are always retained indefinitely."
+                            as={InformationOutlineIcon}
                         />
                     )}
                 </div>
@@ -90,9 +93,10 @@ const UploadReferenceRetentionMatchNode: FunctionComponent<{ match: UploadRefere
                             </Link>
                         ))
                         .reduce((previous, current) => [previous, ', ', current])}
-                    <InformationOutlineIcon
-                        className="ml-1 icon-inline"
+                    <Icon
+                        className="ml-1"
                         data-tooltip="Uploads that are dependencies of other upload(s) are retained to service cross-repository code-intel queries."
+                        as={InformationOutlineIcon}
                     />
                 </div>
             </div>

--- a/client/web/src/notebooks/blocks/file/NotebookFileBlock.tsx
+++ b/client/web/src/notebooks/blocks/file/NotebookFileBlock.tsx
@@ -240,7 +240,7 @@ const NotebookFileBlockHeader: React.FunctionComponent<FileBlockInput & { fileUR
 }) => (
     <>
         <div className="mr-2">
-            <Icon as={FileDocumentIcon} className="icon-inline" />
+            <Icon as={FileDocumentIcon} />
         </div>
         <div className="d-flex flex-column">
             <div className="mb-1 d-flex align-items-center">

--- a/client/web/src/notebooks/blocks/symbol/NotebookSymbolBlock.tsx
+++ b/client/web/src/notebooks/blocks/symbol/NotebookSymbolBlock.tsx
@@ -118,7 +118,7 @@ export const NotebookSymbolBlock: React.FunctionComponent<NotebookSymbolBlockPro
             {
                 type: 'link',
                 label: 'Open in new tab',
-                icon: <Icon as={OpenInNewIcon} className="icon-inline" />,
+                icon: <Icon as={OpenInNewIcon} />,
                 url: symbolURL,
                 isDisabled: symbolURL.length === 0,
             },
@@ -132,11 +132,7 @@ export const NotebookSymbolBlock: React.FunctionComponent<NotebookSymbolBlockPro
             {
                 type: 'button',
                 label: showInputs ? 'Save' : 'Edit',
-                icon: showInputs ? (
-                    <Icon as={CheckIcon} className="icon-inline" />
-                ) : (
-                    <Icon as={PencilIcon} className="icon-inline" />
-                ),
+                icon: <Icon as={showInputs ? CheckIcon : PencilIcon} />,
                 onClick: () => setShowInputs(!showInputs),
                 keyboardShortcutLabel: showInputs ? `${modifierKeyLabel} + ↵` : '↵',
             },
@@ -250,7 +246,7 @@ const NotebookSymbolBlockHeader: React.FunctionComponent<NotebookSymbolBlockHead
 }) => (
     <>
         <div className="mr-2">
-            <SymbolIcon className="icon-inline" kind={symbolKind} />
+            <SymbolIcon kind={symbolKind} />
         </div>
         <div className="d-flex flex-column">
             <div className="mb-1 d-flex align-items-center">
@@ -263,7 +259,7 @@ const NotebookSymbolBlockHeader: React.FunctionComponent<NotebookSymbolBlockHead
                 {symbolFoundAtLatestRevision === false && (
                     <Icon
                         as={InformationOutlineIcon}
-                        className="icon-inline ml-1"
+                        className="ml-1"
                         data-tooltip={`Symbol not found at the latest revision, showing symbol at revision ${effectiveRevision}.`}
                     />
                 )}

--- a/client/web/src/notebooks/blocks/symbol/NotebookSymbolBlockInput.tsx
+++ b/client/web/src/notebooks/blocks/symbol/NotebookSymbolBlockInput.tsx
@@ -110,7 +110,7 @@ const SymbolSuggestions: React.FunctionComponent<{
                         }
                         data-testid="symbol-suggestion-button"
                     >
-                        <SymbolIcon kind={symbol.kind} className="icon-inline mr-1" />
+                        <SymbolIcon kind={symbol.kind} className="mr-1" />
                         <code>
                             {symbol.name}{' '}
                             {symbol.containerName && <span className="text-muted">{symbol.containerName}</span>}

--- a/client/web/src/notebooks/notebook/NotebookComponent.tsx
+++ b/client/web/src/notebooks/notebook/NotebookComponent.tsx
@@ -494,7 +494,7 @@ export const NotebookComponent: React.FunctionComponent<NotebookComponentProps> 
                         data-testid="copy-notebook-button"
                         disabled={copiedNotebookOrError === LOADING}
                     >
-                        <ContentCopyIcon className="icon-inline mr-1" />
+                        <Icon className="mr-1" as={ContentCopyIcon} />
                         <span>{copiedNotebookOrError === LOADING ? 'Copying...' : 'Copy to My Notebooks'}</span>
                     </Button>
                 )}

--- a/client/web/src/org/members/utils.tsx
+++ b/client/web/src/org/members/utils.tsx
@@ -5,7 +5,7 @@ import { drop } from 'lodash'
 import CloseIcon from 'mdi-react/CloseIcon'
 import { useLocation } from 'react-router'
 
-import { Alert, Button } from '@sourcegraph/wildcard'
+import { Alert, Button, Icon } from '@sourcegraph/wildcard'
 
 import styles from './InviteMemberModal.module.scss'
 
@@ -60,7 +60,7 @@ export const OrgMemberNotification: React.FunctionComponent<MembersNotificationP
     <Alert variant="success" className={classNames(styles.invitedNotification, className)}>
         <div className={styles.message}>{message}</div>
         <Button className="btn-icon" title="Dismiss" onClick={onDismiss}>
-            <CloseIcon className="icon-inline" />
+            <Icon as={CloseIcon} />
         </Button>
     </Alert>
 )

--- a/client/web/src/org/openBeta/GettingStarted.tsx
+++ b/client/web/src/org/openBeta/GettingStarted.tsx
@@ -10,7 +10,7 @@ import { ErrorAlert } from '@sourcegraph/branded/src/components/alerts'
 import { AuthenticatedUser } from '@sourcegraph/shared/src/auth'
 import { MarketingBlock } from '@sourcegraph/web/src/components/MarketingBlock'
 import { PageTitle } from '@sourcegraph/web/src/components/PageTitle'
-import { Link, LoadingSpinner, PageHeader } from '@sourcegraph/wildcard'
+import { Link, LoadingSpinner, PageHeader, Icon } from '@sourcegraph/wildcard'
 
 import { FeatureFlagProps } from '../../featureFlags/featureFlags'
 import {
@@ -125,10 +125,7 @@ const Step: React.FunctionComponent<{
 }> = ({ complete, label, textMuted, to, onClick }) => (
     <li className={styles.entryItem}>
         <div className={styles.iconContainer}>
-            <CheckCircleIcon
-                className={classNames('icon-inline', complete ? 'text-success' : styles.iconMuted)}
-                size="1rem"
-            />
+            <Icon className={classNames(complete ? 'text-success' : styles.iconMuted)} as={CheckCircleIcon} />
         </div>
         <h3
             className={classNames({

--- a/client/web/src/org/settings/DeleteOrgModal.tsx
+++ b/client/web/src/org/settings/DeleteOrgModal.tsx
@@ -5,7 +5,7 @@ import CloseIcon from 'mdi-react/CloseIcon'
 import { useHistory } from 'react-router'
 import { RouteComponentProps } from 'react-router-dom'
 
-import { Button, Input, LoadingSpinner, Modal } from '@sourcegraph/wildcard'
+import { Button, Input, LoadingSpinner, Modal, Icon } from '@sourcegraph/wildcard'
 
 import { eventLogger } from '../../tracking/eventLogger'
 import { OrgAreaPageProps } from '../area/OrgArea'
@@ -67,10 +67,11 @@ export const DeleteOrgModal: React.FunctionComponent<DeleteOrgModalProps> = prop
                 <h3 className="text-danger" id={deleteLabelId}>
                     Delete organization?
                 </h3>
-                <CloseIcon
-                    className="icon-inline position-absolute cursor-pointer"
+                <Icon
+                    className="position-absolute cursor-pointer"
                     style={{ top: '1rem', right: '1rem' }}
                     onClick={toggleDeleteModal}
+                    as={CloseIcon}
                 />
                 <p className="pt-3">
                     <strong>You are going to delete {org.name} from Sourcegraph.</strong>

--- a/client/web/src/search/home/SelfHostInstructions.tsx
+++ b/client/web/src/search/home/SelfHostInstructions.tsx
@@ -73,7 +73,7 @@ export const SelfHostInstructions: React.FunctionComponent<TelemetryProps> = ({ 
                         aria-label="Copy Docker command to clipboard"
                         variant="link"
                     >
-                        <ContentCopyIcon className="icon-inline" />
+                        <Icon as={ContentCopyIcon} />
                     </Button>
                     <code className={styles.codeBlock}>{dockerCommand}</code>
                 </MarketingBlock>

--- a/client/web/src/search/panels/CollaboratorsPanel.tsx
+++ b/client/web/src/search/panels/CollaboratorsPanel.tsx
@@ -9,7 +9,7 @@ import { Observable } from 'rxjs'
 import { ErrorAlert } from '@sourcegraph/branded/src/components/alerts'
 import { ErrorLike, isErrorLike } from '@sourcegraph/common'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
-import { Button, Card, CardBody, Link, LoadingSpinner, useObservable } from '@sourcegraph/wildcard'
+import { Button, Card, CardBody, Link, LoadingSpinner, useObservable, Icon } from '@sourcegraph/wildcard'
 
 import { AuthenticatedUser } from '../../auth'
 import { InvitableCollaborator } from '../../auth/welcome/InviteCollaborators/InviteCollaborators'
@@ -117,12 +117,12 @@ export const CollaboratorsPanel: React.FunctionComponent<Props> = ({
                                 <div className={styles.inviteButton}>
                                     {loadingInvites.has(person.email) ? (
                                         <span className=" ml-auto mr-3">
-                                            <LoadingSpinner inline={true} className="icon-inline mr-1" />
+                                            <LoadingSpinner className="mr-1" />
                                             Inviting...
                                         </span>
                                     ) : successfulInvites.has(person.email) ? (
                                         <span className="text-success ml-auto mr-3">
-                                            <EmailCheckIcon className="icon-inline mr-1" />
+                                            <Icon className="mr-1" as={EmailCheckIcon} />
                                             Invited
                                         </span>
                                     ) : (
@@ -131,7 +131,7 @@ export const CollaboratorsPanel: React.FunctionComponent<Props> = ({
                                                 {person.email}
                                             </div>
                                             <div className={classNames('text-primary', styles.inviteButtonOverlay)}>
-                                                <EmailIcon className="icon-inline mr-1" />
+                                                <Icon className="mr-1" as={EmailIcon} />
                                                 Invite to Sourcegraph
                                             </div>
                                         </>
@@ -212,7 +212,7 @@ const CollaboratorsPanelInfo: React.FunctionComponent<{ isSiteAdmin: boolean }> 
                     <CardBody>
                         <div className={classNames('d-flex', 'align-content-start', 'mb-2')}>
                             <h2 className={classNames(styles.infoBox, 'mb-0')}>
-                                <InformationOutlineIcon className="icon-inline mr-2 text-muted" />
+                                <Icon className="mr-2 text-muted" as={InformationOutlineIcon} />
                                 What is this?
                             </h2>
                             <div className="flex-grow-1" />
@@ -253,7 +253,7 @@ const CollaboratorsPanelInfo: React.FunctionComponent<{ isSiteAdmin: boolean }> 
             <div className={classNames('text-muted', styles.info)}>Collaborators from your repositories</div>
             <div className="flex-grow-1" />
             <div>
-                <InformationOutlineIcon className="icon-inline mr-1 text-muted" />
+                <Icon className="mr-1 text-muted" as={InformationOutlineIcon} />
                 <Button
                     variant="link"
                     className={classNames(styles.info, 'p-0')}

--- a/client/web/src/settings/SettingsFile.tsx
+++ b/client/web/src/settings/SettingsFile.tsx
@@ -190,7 +190,7 @@ export class SettingsFile extends React.PureComponent<Props, State> {
                         ))}
                     </div>
                 </div>
-                <React.Suspense fallback={<LoadingSpinner className="icon-inline mt-2" />}>
+                <React.Suspense fallback={<LoadingSpinner className="mt-2" />}>
                     <MonacoSettingsEditor
                         value={contents}
                         jsonSchema={this.props.jsonSchema}

--- a/client/web/src/site-admin/SiteAdminFeatureFlagConfigurationPage.tsx
+++ b/client/web/src/site-admin/SiteAdminFeatureFlagConfigurationPage.tsx
@@ -12,7 +12,7 @@ import { Toggle } from '@sourcegraph/branded/src/components/Toggle'
 import { asError, ErrorLike, isErrorLike, pluralize } from '@sourcegraph/common'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { PageTitle } from '@sourcegraph/web/src/components/PageTitle'
-import { Button, Container, Link, LoadingSpinner, PageHeader, Select, useObservable } from '@sourcegraph/wildcard'
+import { Button, Container, Link, LoadingSpinner, PageHeader, Select, useObservable, Icon } from '@sourcegraph/wildcard'
 
 import { Collapsible } from '../components/Collapsible'
 
@@ -179,7 +179,7 @@ export const SiteAdminFeatureFlagConfigurationPage: FunctionComponent<SiteAdminF
                         </>
                     ) : (
                         <>
-                            <DeleteIcon className="icon-inline" /> Delete
+                            <Icon as={DeleteIcon} /> Delete
                         </>
                     )}
                 </Button>

--- a/client/wildcard/src/components/Button/story/ButtonVariants.tsx
+++ b/client/wildcard/src/components/Button/story/ButtonVariants.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import { startCase } from 'lodash'
 import 'storybook-addon-designs'
 
+import { Icon } from '../../Icon'
 import { Button, ButtonProps } from '../Button'
 import { BUTTON_VARIANTS } from '../constants'
 
@@ -17,21 +18,21 @@ export const ButtonVariants: React.FunctionComponent<ButtonVariantsProps> = ({
     variants,
     size,
     outline,
-    icon: Icon,
+    icon: ButtonIcon,
 }) => (
     <div className={styles.grid}>
         {variants.map(variant => (
             <React.Fragment key={variant}>
                 <Button variant={variant} size={size} outline={outline} onClick={console.log}>
-                    {Icon && <Icon className="icon-inline mr-1" />}
+                    {ButtonIcon && <Icon as={ButtonIcon} className="mr-1" />}
                     {startCase(variant)}
                 </Button>
                 <Button variant={variant} size={size} outline={outline} onClick={console.log} className="focus">
-                    {Icon && <Icon className="icon-inline mr-1" />}
+                    {ButtonIcon && <Icon as={ButtonIcon} className="mr-1" />}
                     Focus
                 </Button>
                 <Button variant={variant} size={size} outline={outline} onClick={console.log} disabled={true}>
-                    {Icon && <Icon className="icon-inline mr-1" />}
+                    {ButtonIcon && <Icon as={ButtonIcon} className="mr-1" />}
                     Disabled
                 </Button>
             </React.Fragment>

--- a/client/wildcard/src/components/ButtonLink/ButtonLink.story.tsx
+++ b/client/wildcard/src/components/ButtonLink/ButtonLink.story.tsx
@@ -10,6 +10,7 @@ import webStyles from '@sourcegraph/web/src/SourcegraphWebApp.scss'
 import { ButtonLink } from '..'
 import { BUTTON_VARIANTS } from '../Button/constants'
 import { Grid } from '../Grid'
+import { Icon } from '../Icon'
 
 const Config: Meta = {
     title: 'wildcard/ButtonLink',
@@ -76,7 +77,7 @@ export const Overview: Story = () => (
             onClick={console.log}
             className="mb-2"
         >
-            <SearchIcon className="icon-inline mr-1" />
+            <Icon as={SearchIcon} className="mr-1" />
             Search
         </ButtonLink>
         <h2>Smaller</h2>

--- a/client/wildcard/src/components/Collapse/Collapse.story.tsx
+++ b/client/wildcard/src/components/Collapse/Collapse.story.tsx
@@ -10,6 +10,7 @@ import webStyles from '@sourcegraph/web/src/SourcegraphWebApp.scss'
 
 import { Button } from '../Button'
 import { Input } from '../Form'
+import { Icon } from '../Icon'
 
 import { Collapse, CollapseHeader, CollapsePanel } from './Collapse'
 
@@ -39,11 +40,7 @@ export const Simple: Story = () => {
             <Collapse isOpen={isOpened} onOpenChange={handleOpenChange}>
                 <CollapseHeader as={Button} outline={true} focusLocked={true} variant="secondary" className="w-50">
                     Collapsable
-                    {!isOpened ? (
-                        <ChevronLeftIcon className="icon-inline mr-1" />
-                    ) : (
-                        <ChevronDownIcon className="icon-inline mr-1" />
-                    )}
+                    <Icon as={isOpened ? ChevronDownIcon : ChevronLeftIcon} className="mr-1" />
                 </CollapseHeader>
                 <CollapsePanel className="w-50">
                     <Input placeholder="testing this one" />
@@ -62,11 +59,7 @@ export const Simple: Story = () => {
                             className="w-50"
                         >
                             Collapsable
-                            {isOpen ? (
-                                <ChevronDownIcon className="icon-inline mr-1" />
-                            ) : (
-                                <ChevronLeftIcon className="icon-inline mr-1" />
-                            )}
+                            <Icon as={isOpen ? ChevronDownIcon : ChevronLeftIcon} className="mr-1" />
                         </CollapseHeader>
                         <CollapsePanel className="w-50">
                             <Input placeholder="testing this one" />
@@ -87,11 +80,7 @@ export const Simple: Story = () => {
                             className="w-50"
                         >
                             Collapsable
-                            {isOpen ? (
-                                <ChevronDownIcon className="icon-inline mr-1" />
-                            ) : (
-                                <ChevronLeftIcon className="icon-inline mr-1" />
-                            )}
+                            <Icon as={isOpen ? ChevronDownIcon : ChevronLeftIcon} className="mr-1" />
                         </CollapseHeader>
                         <CollapsePanel className="w-50">
                             <Input placeholder="testing this one" />

--- a/client/wildcard/src/components/PageHeader/PageHeader.story.tsx
+++ b/client/wildcard/src/components/PageHeader/PageHeader.story.tsx
@@ -10,6 +10,7 @@ import webStyles from '@sourcegraph/web/src/SourcegraphWebApp.scss'
 
 import { Button } from '../Button'
 import { FeedbackBadge } from '../Feedback'
+import { Icon } from '../Icon'
 import { Link } from '../Link'
 
 import { PageHeader } from './PageHeader'
@@ -31,7 +32,7 @@ export const BasicHeader: Story = () => (
         path={[{ icon: PuzzleOutlineIcon, text: 'Header' }]}
         actions={
             <Button to={`${location.pathname}/close`} className="mr-1" variant="secondary" as={Link}>
-                <SearchIcon className="icon-inline" /> Button with icon
+                <Icon as={SearchIcon} /> Button with icon
             </Button>
         }
     />
@@ -64,7 +65,7 @@ export const ComplexHeader: Story = () => (
                     Secondary
                 </Button>
                 <Button as={Link} to="/page" variant="primary" className="text-nowrap">
-                    <PlusIcon className="icon-inline" /> Create
+                    <Icon as={PlusIcon} /> Create
                 </Button>
             </div>
         }

--- a/client/wildcard/src/components/PageSelector/PageSelector.tsx
+++ b/client/wildcard/src/components/PageSelector/PageSelector.tsx
@@ -10,6 +10,7 @@ import { createAggregateError } from '@sourcegraph/common'
 
 import { useOffsetPagination, useDebounce } from '../../hooks'
 import { Button } from '../Button'
+import { Icon } from '../Icon'
 
 import styles from './PageSelector.module.scss'
 
@@ -88,13 +89,9 @@ export const PageSelector: React.FunctionComponent<PageSelectorProps> = props =>
                         return (
                             <li key={key}>
                                 <PageButton {...omit(page, 'type')}>
-                                    {page.type === 'previous' && (
-                                        <ChevronLeftIcon className="icon-inline" aria-hidden={true} />
-                                    )}
+                                    {page.type === 'previous' && <Icon as={ChevronLeftIcon} aria-hidden={true} />}
                                     <span className={classNames(shouldShrink && 'd-none')}>{page.content}</span>
-                                    {page.type === 'next' && (
-                                        <ChevronRightIcon className="icon-inline" aria-hidden={true} />
-                                    )}
+                                    {page.type === 'next' && <Icon as={ChevronRightIcon} aria-hidden={true} />}
                                 </PageButton>
                             </li>
                         )

--- a/client/wildcard/src/components/Panel/Panel.story.tsx
+++ b/client/wildcard/src/components/Panel/Panel.story.tsx
@@ -12,6 +12,7 @@ import webStyles from '@sourcegraph/web/src/SourcegraphWebApp.scss'
 
 import { Button } from '../Button'
 import { Grid } from '../Grid'
+import { Icon } from '../Icon'
 import { Tabs, Tab, TabList, TabPanel, TabPanels } from '../Tabs'
 
 import { PANEL_POSITIONS } from './constants'
@@ -122,7 +123,7 @@ export const WithChildren: Story = props => {
                             data-placement="left"
                             variant="icon"
                         >
-                            <CloseIcon className="icon-inline" />
+                            <Icon as={CloseIcon} />
                         </Button>
                     </div>
                 </div>


### PR DESCRIPTION
## Description
Applied codemod on codebase to migrate remaining usage of <Icon /> component and ban `icon-inline` usage on codebase.

## Test plan
- Run app locally on attached preview link
- Compare the rendered instance of migrated components on branch, with equivalent version on prod.
- Ensure there are no UI diffs
- Confirm that you are now unable to use className `icon-inline` on codebase.

## Refs
- [SG Issue](https://github.com/sourcegraph/sourcegraph/issues/32879)
- [Gitstart Ticket](https://app.gitstart.com/clients/sourcegraph/tickets/SG-32879)

## Implementation Detail
1. Run Icon codemod tool on the codebase, to migrate the usage of icon-inline classNames to wildcard <Icon/>
2. Add eslint rule to ban usage of icon-inline className on codebase


## Preview App
[Frontend App](https://client-sourcegraph-frontend-pr-293.onrender.com/)
[Storybook](https://client-sourcegraph-storybook-pr-293.onrender.com/)