### PR TITLE
Web: [Charts] Add new pie chart

### DIFF
--- a/client/web/src/charts/components/line-chart/LineChart.story.tsx
+++ b/client/web/src/charts/components/line-chart/LineChart.story.tsx
@@ -1,12 +1,13 @@
 import React from 'react'
 
 import { Meta } from '@storybook/react'
+import { ParentSize } from '@visx/responsive'
 
 import { WebStory } from '../../../components/WebStory'
 
 import { LineChartSeries } from './types'
 
-import { LineChart, LegendList, ParentSize } from '.'
+import { LineChart, LegendList } from '.'
 
 export default {
     title: 'web/charts/line',

--- a/client/web/src/charts/components/line-chart/index.ts
+++ b/client/web/src/charts/components/line-chart/index.ts
@@ -1,3 +1,2 @@
-export { ParentSize } from '@visx/responsive'
 export { LineChart } from './LineChart'
 export { LegendList } from './components/legend-list/LegendList'

--- a/client/web/src/charts/components/pie-chart/PieChart.module.scss
+++ b/client/web/src/charts/components/pie-chart/PieChart.module.scss
@@ -1,0 +1,20 @@
+.svg {
+    overflow: visible;
+}
+
+.link:hover {
+    text-decoration: none;
+}
+
+.arc-path {
+    &--with-link {
+        cursor: pointer;
+    }
+}
+
+.link:focus .arc-path {
+    stroke-width: 3;
+    stroke: var(--primary);
+    z-index: 2;
+    position: relative;
+}

--- a/client/web/src/charts/components/pie-chart/PieChart.story.tsx
+++ b/client/web/src/charts/components/pie-chart/PieChart.story.tsx
@@ -12,10 +12,10 @@ export default {
 } as Meta
 
 interface LanguageUsageDatum {
-    name: string,
-    value: number,
-    fill: string,
-    linkURL: string,
+    name: string
+    value: number
+    fill: string
+    linkURL: string
 }
 
 const LANGUAGE_USAGE_DATA: LanguageUsageDatum[] = [

--- a/client/web/src/charts/components/pie-chart/PieChart.story.tsx
+++ b/client/web/src/charts/components/pie-chart/PieChart.story.tsx
@@ -1,0 +1,63 @@
+import React from 'react'
+
+import { Meta, Story } from '@storybook/react'
+
+import { WebStory } from '../../../components/WebStory'
+
+import { PieChart } from './PieChart'
+
+export default {
+    title: 'web/charts/pie',
+    decorators: [story => <WebStory>{() => story()}</WebStory>],
+} as Meta
+
+interface LanguageUsageDatum {
+    name: string,
+    value: number,
+    fill: string,
+    linkURL: string,
+}
+
+const LANGUAGE_USAGE_DATA: LanguageUsageDatum[] = [
+    {
+        name: 'JavaScript',
+        value: 422,
+        fill: '#f1e05a',
+        linkURL: 'https://en.wikipedia.org/wiki/JavaScript',
+    },
+    {
+        name: 'CSS',
+        value: 273,
+        fill: '#563d7c',
+        linkURL: 'https://en.wikipedia.org/wiki/CSS',
+    },
+    {
+        name: 'HTML',
+        value: 129,
+        fill: '#e34c26',
+        linkURL: 'https://en.wikipedia.org/wiki/HTML',
+    },
+    {
+        name: 'Markdown',
+        value: 35,
+        fill: '#083fa1',
+        linkURL: 'https://en.wikipedia.org/wiki/Markdown',
+    },
+]
+
+const getValue = (datum: LanguageUsageDatum) => datum.value
+const getColor = (datum: LanguageUsageDatum) => datum.fill
+const getLink = (datum: LanguageUsageDatum) => datum.linkURL
+const getName = (datum: LanguageUsageDatum) => datum.name
+
+export const PieChartVitrina: Story = () => (
+    <PieChart<LanguageUsageDatum>
+        width={400}
+        height={400}
+        data={LANGUAGE_USAGE_DATA}
+        getDatumName={getName}
+        getDatumValue={getValue}
+        getDatumColor={getColor}
+        getDatumLink={getLink}
+    />
+)

--- a/client/web/src/charts/components/pie-chart/PieChart.tsx
+++ b/client/web/src/charts/components/pie-chart/PieChart.tsx
@@ -1,0 +1,127 @@
+import React, { ReactElement, useMemo, useState } from 'react'
+
+import { Group } from '@visx/group'
+import Pie, { PieArcDatum } from '@visx/shape/lib/shapes/Pie'
+import classNames from 'classnames'
+import { noop } from 'rxjs'
+
+import { MaybeLink } from '../../../views/components/view/content/chart-view-content/charts/MaybeLink'
+
+import { PieArc } from './components/PieArc'
+import { distributePieArcs } from './distribute-pie-data'
+
+import styles from './PieChart.module.scss'
+
+const DEFAULT_PADDING = { top: 20, right: 20, bottom: 20, left: 20 }
+
+/**
+ * Generate percent value for each part of pie chart.
+ * For example, we have two pies with 30 and 90 values. This means that percentage
+ * for the first one is 30 / (30 + 90) = 0.25%
+ * and for the second one 90 / (30 + 90) = 0.75%
+ */
+const getSubtitle = <Datum extends object>(arc: PieArcDatum<Datum>, total: number): string =>
+    `${((100 * arc.value) / total).toFixed(2)}%`
+
+export interface PieChartProps<Datum extends object> {
+    width: number
+    height: number
+    data: Datum[]
+    padding?: typeof DEFAULT_PADDING
+
+    getDatumValue: (datum: Datum) => number
+    getDatumName: (datum: Datum) => string
+    getDatumColor: (datum: Datum) => string | undefined
+    getDatumLink: (datum: Datum) => string | undefined
+    onDatumLinkClick?: (event: React.MouseEvent) => void
+}
+
+export function PieChart<Datum extends object = {}>(props: PieChartProps<Datum>): ReactElement | null {
+    const {
+        width,
+        height,
+        data,
+        padding = DEFAULT_PADDING,
+        getDatumValue,
+        getDatumName,
+        getDatumColor,
+        getDatumLink,
+        onDatumLinkClick = noop,
+    } = props
+
+    // We have to track which arc is hovered to change order of rendering.
+    // Due to the fact that svg elements don't have css z-index (in svg only order of renderings matters)
+    // we have to render PieArcs in different order to prevent visual label overlapping on small
+    // datasets. When user hovers one pie arc we change arcs order in a way to put this
+    // hovered arc last in arcs array. By that we sort of change z-index (ordering) of svg element
+    // and put hovered label and arc over other arc elements
+    const [hoveredArc, setHoveredArc] = useState<PieArcDatum<Datum> | null>(null)
+    const sortedData = useMemo(() => distributePieArcs(data, getDatumValue), [data, getDatumValue])
+
+    const innerWidth = width - padding.left - padding.right
+    const innerHeight = height - padding.top - padding.bottom
+
+    const radius = Math.min(innerWidth, innerHeight) / 4
+    const centerY = innerHeight / 2
+    const centerX = innerWidth / 2
+
+    // Calculate total value (used in PieArc component to get percent value for particular arc)
+    const total = useMemo(
+        () =>
+            sortedData.reduce(
+                // Here we have to cast datum[dataKey] to number because we ts can't derive value by dataKey
+                (sum, datum) => sum + getDatumValue(datum),
+                0
+            ),
+        [sortedData, getDatumValue]
+    )
+
+    if (width < 10) {
+        return null
+    }
+
+    return (
+        <svg aria-label="Pie chart" width={width} height={height} className={styles.svg}>
+            <Group top={centerY + padding.top} left={centerX + padding.left}>
+                <Pie data={sortedData} pieValue={getDatumValue} outerRadius={radius} cornerRadius={3}>
+                    {pie => {
+                        const arcs = hoveredArc
+                            ? [...pie.arcs.filter(arc => arc.index !== hoveredArc?.index), hoveredArc]
+                            : pie.arcs
+
+                        return (
+                            <Group>
+                                {arcs.map((arc, index) => (
+                                    <MaybeLink
+                                        key={getDatumName(arc.data)}
+                                        to={getDatumLink(arc.data)}
+                                        target="_blank"
+                                        rel="noopener"
+                                        className={styles.link}
+                                        role={getDatumLink(arc.data) ? 'link' : 'graphics-dataunit'}
+                                        aria-label={`Element ${index + 1} of ${arcs.length}. Name: ${getDatumName(
+                                            arc.data
+                                        )}. Value: ${getSubtitle(arc, total)}.`}
+                                        onClick={onDatumLinkClick}
+                                    >
+                                        <PieArc
+                                            arc={arc}
+                                            path={pie.path}
+                                            title={getDatumName(arc.data)}
+                                            subtitle={getSubtitle(arc, total)}
+                                            className={classNames(styles.arcPath, {
+                                                [styles.arcPathWithLink]: !!getDatumLink(arc.data),
+                                            })}
+                                            getColor={getDatumColor}
+                                            onPointerMove={() => setHoveredArc(arc)}
+                                        />
+                                    </MaybeLink>
+                                ))}
+                            </Group>
+                        )
+                    }}
+                </Pie>
+            </Group>
+        </svg>
+    )
+}

--- a/client/web/src/charts/components/pie-chart/components/PieArc.module.scss
+++ b/client/web/src/charts/components/pie-chart/components/PieArc.module.scss
@@ -1,0 +1,43 @@
+// Because @visx/annotation HTMLLabel doesn't have api for
+// passing custom CSS class to the Label component container
+// we have to get this element through CSS Cascade
+.label div {
+    background-color: var(--body-bg);
+    border: 1px solid var(--border-color);
+    padding: 0.25rem 0.5rem;
+    display: flex;
+    flex-direction: column;
+}
+
+.label-title {
+    font-weight: 400;
+    color: var(--body-color);
+    background-color: var(--body-bg);
+    text-decoration: none;
+    max-width: 150px;
+    text-overflow: ellipsis;
+    overflow: hidden;
+    margin-bottom: 0;
+}
+
+.label-sub-title {
+    color: var(--text-muted);
+    text-decoration: none;
+    margin-bottom: 0;
+}
+
+/* Arcs */
+.arc {
+    stroke: var(--body-bg);
+}
+
+.arc-path {
+    stroke-width: 1;
+    stroke: var(--body-bg);
+}
+
+.label-line,
+.label-circle {
+    stroke: var(--body-color);
+    fill: var(--body-color);
+}

--- a/client/web/src/charts/components/pie-chart/components/PieArc.tsx
+++ b/client/web/src/charts/components/pie-chart/components/PieArc.tsx
@@ -1,0 +1,75 @@
+import React, { PointerEventHandler, ReactElement } from 'react'
+
+import { Annotation, HtmlLabel, Connector } from '@visx/annotation'
+import { Group } from '@visx/group'
+import { PieArcDatum } from '@visx/shape/lib/shapes/Pie'
+import classNames from 'classnames'
+import { Arc as ArcType } from 'd3-shape'
+
+import { DEFAULT_FALLBACK_COLOR } from '../../../constants'
+
+import styles from './PieArc.module.scss'
+
+// Pie arc visual settings
+const CONNECTION_LINE_LENGTH = 15
+const CONNECTION_LINE_MARGIN = 2
+
+interface PieArcProps<Datum> {
+    title: string
+    subtitle: string
+    path: ArcType<unknown, PieArcDatum<Datum>>
+    arc: PieArcDatum<Datum>
+    className?: string
+    getColor: (datum: Datum) => string | undefined
+    onPointerMove?: PointerEventHandler
+    onPointerOut?: PointerEventHandler
+}
+
+export function PieArc<Datum>(props: PieArcProps<Datum>): ReactElement {
+    const { title, subtitle, path, arc, getColor, className, onPointerMove, onPointerOut } = props
+
+    const pathValue = path(arc) ?? ''
+
+    // Math to put label and connection line in a middle of arc radius surface
+    // Find the middle of the arc segment. Here we have polar system of coordinate.
+    // In polar system we have angle and radius to describe the point.
+    const middleAngle = Math.PI / 2 - (arc.startAngle + (arc.endAngle - arc.startAngle) / 2)
+    const radius = path.outerRadius()(arc)
+
+    // Pie chart operate polar system of coords but svg operates with a Cartesian coordinate system
+    // normalX and normalY they are just projections on the axes. You can thing about this code like
+    // transformation polar coords to cartesian coords.
+    // https://en.wikipedia.org/wiki/Polar_coordinate_system#/media/File:Polar_to_cartesian.svg
+    const normalX = Math.cos(middleAngle)
+    const normalY = Math.sin(-middleAngle)
+
+    // Calculate coords for start point of label line
+    const surfaceX = normalX * (radius + CONNECTION_LINE_MARGIN)
+    const surfaceY = normalY * (radius + CONNECTION_LINE_MARGIN)
+
+    // Calculate coords for end point of label line
+    const labelX = normalX * CONNECTION_LINE_LENGTH
+    const labelY = normalY * CONNECTION_LINE_LENGTH
+
+    return (
+        <Group aria-hidden={true} className={styles.arc} onPointerMove={onPointerMove} onPointerOut={onPointerOut}>
+            <path
+                data-testid="pie-chart-arc-element"
+                className={classNames(className, styles.arcPath)}
+                d={pathValue}
+                fill={getColor(arc.data) ?? DEFAULT_FALLBACK_COLOR}
+            />
+
+            <Annotation x={surfaceX} y={surfaceY} dx={labelX} dy={labelY}>
+                <Connector className={styles.labelLine} type="line" />
+
+                <HtmlLabel showAnchorLine={false} className={styles.label}>
+                    <h3 className={styles.labelTitle}>{title}</h3>
+                    <small className={styles.labelSubTitle}>{subtitle}</small>
+                </HtmlLabel>
+            </Annotation>
+
+            <circle className={styles.labelCircle} r={2} cx={surfaceX + labelX} cy={surfaceY + labelY} />
+        </Group>
+    )
+}

--- a/client/web/src/charts/components/pie-chart/distribute-pie-data.ts
+++ b/client/web/src/charts/components/pie-chart/distribute-pie-data.ts
@@ -1,0 +1,26 @@
+/**
+ * This algorithm sort origin data array in a way to alternate data for
+ * better visual distribution of labels. When you have small parts of pie chart
+ * together often you have label overlapping to avoid this we can change order
+ * of data to => big arc => small arc => big arc. Just to add some space between labels.
+ */
+export function distributePieArcs<D>(data: readonly D[], getDatumValue: (datum: D) => number): D[] {
+    const sortedData = [...data].sort((first, second) => getDatumValue(first) - getDatumValue(second))
+    const result: D[] = []
+
+    while (sortedData.length) {
+        const firstElement = sortedData.shift()
+
+        if (firstElement) {
+            result.push(firstElement)
+        }
+
+        const lastElement = sortedData.pop()
+
+        if (lastElement) {
+            result.push(lastElement)
+        }
+    }
+
+    return result
+}

--- a/client/web/src/charts/components/pie-chart/index.ts
+++ b/client/web/src/charts/components/pie-chart/index.ts
@@ -1,0 +1,2 @@
+
+export { PieChart } from './PieChart'

--- a/client/web/src/charts/components/pie-chart/index.ts
+++ b/client/web/src/charts/components/pie-chart/index.ts
@@ -1,2 +1,1 @@
-
 export { PieChart } from './PieChart'

--- a/client/web/src/charts/index.ts
+++ b/client/web/src/charts/index.ts
@@ -1,1 +1,4 @@
+export { ParentSize } from '@visx/responsive'
+
 export * from './components/line-chart'
+export * from './components/pie-chart'

--- a/package.json
+++ b/package.json
@@ -354,7 +354,7 @@
     "@sqs/jsonc-parser": "^1.0.3",
     "@types/svgo": "2.6.0",
     "@types/vscode": "^1.63.1",
-    "@visx/annotation": "^1.7.2",
+    "@visx/annotation": "^2.9.0",
     "@visx/axis": "^1.7.0",
     "@visx/glyph": "^1.7.0",
     "@visx/grid": "^1.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4843,7 +4843,7 @@
   dependencies:
     "@types/d3-time" "*"
 
-"@types/d3-scale@^3.2.1":
+"@types/d3-scale@^3.2.1", "@types/d3-scale@^3.3.0":
   version "3.3.2"
   resolved "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-3.3.2.tgz#18c94e90f4f1c6b1ee14a70f14bfca2bd1c61d06"
   integrity sha512-gGqr7x1ost9px3FvIfUMi5XA/F/yAf4UkUDtdQhpH92XCT0Oa7zkkRzY61gPVJq+DxpHn/btouw5ohWkbBsCzQ==
@@ -4867,7 +4867,7 @@
   resolved "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-3.0.0.tgz#913e984362a59792dc8d8b122dd17625991eade2"
   integrity sha512-UpLg1mn/8PLyjr+J/JwdQJM/GzysMvv2CS8y+WYAL5K0+wbvXv/pPSLEfdNaprCZsGcXTxPsFMy8QtkYv9ueew==
 
-"@types/d3-time@*", "@types/d3-time@^2":
+"@types/d3-time@*", "@types/d3-time@^2", "@types/d3-time@^2.0.0":
   version "2.1.1"
   resolved "https://registry.npmjs.org/@types/d3-time/-/d3-time-2.1.1.tgz#743fdc821c81f86537cbfece07093ac39b4bc342"
   integrity sha512-9MVYlmIgmRR31C5b4FVSWtuMmBHh2mOWQYfl7XAYOa8dsnb7iEmUmRSWSFgXFtkjxO65d7hTUHQC+RhR/9IWFg==
@@ -5195,6 +5195,11 @@
   version "4.14.168"
   resolved "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.168.tgz#fe24632e79b7ade3f132891afff86caa5e5ce008"
   integrity sha512-oVfRvqHV/V6D1yifJbVRU3TMp8OT6o6BG+U9MkwuJ3U8/CsDHvalRpsxBqivn71ztOFZBTfJMvETbqHiaNSj7Q==
+
+"@types/lodash@^4.14.172":
+  version "4.14.180"
+  resolved "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.180.tgz#4ab7c9ddfc92ec4a887886483bc14c79fb380670"
+  integrity sha512-XOKXa1KIxtNXgASAnwj7cnttJxS4fksBRywK/9LzRV5YxrF80BXZIGeQSuoESQ/VkUj30Ae0+YcuHc15wJCB2g==
 
 "@types/markdown-to-jsx@^6.11.3":
   version "6.11.3"
@@ -5878,7 +5883,7 @@
   resolved "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz#aa58042711d6e3275dd37dc597e5d31e8c290a44"
   integrity sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==
 
-"@visx/annotation@1.7.2", "@visx/annotation@^1.7.2":
+"@visx/annotation@1.7.2":
   version "1.7.2"
   resolved "https://registry.npmjs.org/@visx/annotation/-/annotation-1.7.2.tgz#8d75469926958495eca3569a84cdfbb11b74ef90"
   integrity sha512-/XsgzSMF5ls2z6okHy71gu2uWZDTFg5yBimG34gK5cO2G0ZP7oBv7p6k4yyaGroAy7gXbiXAQqqMsAJPmKtq+Q==
@@ -5891,6 +5896,21 @@
     "@visx/shape" "1.7.0"
     "@visx/text" "1.7.0"
     classnames "^2.2.5"
+    prop-types "^15.5.10"
+    react-use-measure "^2.0.4"
+
+"@visx/annotation@^2.9.0":
+  version "2.9.0"
+  resolved "https://registry.npmjs.org/@visx/annotation/-/annotation-2.9.0.tgz#99c216a3ef9eab8b2d19f38e34d4ab6c9f1e93b0"
+  integrity sha512-bZiV1I6sDixRP4uPTtKR7fui52GhmkoZzIXGMhQwXtkwrCu/UkMYNvYeRbFYjkMNsjjVD7ULcIteeXcamIOrpw==
+  dependencies:
+    "@types/react" "*"
+    "@visx/drag" "2.6.0"
+    "@visx/group" "2.1.0"
+    "@visx/point" "2.6.0"
+    "@visx/shape" "2.4.0"
+    "@visx/text" "2.3.0"
+    classnames "^2.3.1"
     prop-types "^15.5.10"
     react-use-measure "^2.0.4"
 
@@ -5926,6 +5946,14 @@
     "@types/d3-shape" "^1.3.1"
     d3-shape "^1.0.6"
 
+"@visx/curve@2.1.0":
+  version "2.1.0"
+  resolved "https://registry.npmjs.org/@visx/curve/-/curve-2.1.0.tgz#f614bfe3db66df7db7382db7a75ced1506b94602"
+  integrity sha512-9b6JOnx91gmOQiSPhUOxdsvcnW88fgqfTPKoVgQxidMsD/I3wksixtwo8TR/vtEz2aHzzsEEhlv1qK7Y3yaSDw==
+  dependencies:
+    "@types/d3-shape" "^1.3.1"
+    d3-shape "^1.0.6"
+
 "@visx/drag@1.7.0":
   version "1.7.0"
   resolved "https://registry.npmjs.org/@visx/drag/-/drag-1.7.0.tgz#b57295b852d957ae5f327c25aa2171a78ee4a71a"
@@ -5935,6 +5963,16 @@
     "@visx/event" "1.7.0"
     prop-types "^15.5.10"
 
+"@visx/drag@2.6.0":
+  version "2.6.0"
+  resolved "https://registry.npmjs.org/@visx/drag/-/drag-2.6.0.tgz#382ad9628c8b978d4ee2cf9cfb4392d8b89f315c"
+  integrity sha512-/VTNgpKT1i4+O053C3feI6EIEf7ml+PMr6/YDe+nCuqQeypdRtmxvU6QzhKOJ5xrGT+gxaECE5kLgrx94xZ3aw==
+  dependencies:
+    "@types/react" "*"
+    "@visx/event" "2.6.0"
+    "@visx/point" "2.6.0"
+    prop-types "^15.5.10"
+
 "@visx/event@1.7.0":
   version "1.7.0"
   resolved "https://registry.npmjs.org/@visx/event/-/event-1.7.0.tgz#76a1e726dfb72f33dffb957fd7e0c49488f426fe"
@@ -5942,6 +5980,14 @@
   dependencies:
     "@types/react" "*"
     "@visx/point" "1.7.0"
+
+"@visx/event@2.6.0":
+  version "2.6.0"
+  resolved "https://registry.npmjs.org/@visx/event/-/event-2.6.0.tgz#0718eb1efabd5305cf659a153779c94ba4038996"
+  integrity sha512-WGp91g82s727g3NAnENF1ppC3ZAlvWg+Y+GG0WFg34NmmOZbvPI/PTOqTqZE3x6B8EUn8NJiMxRjxIMbi+IvRw==
+  dependencies:
+    "@types/react" "*"
+    "@visx/point" "2.6.0"
 
 "@visx/glyph@1.7.0", "@visx/glyph@^1.7.0":
   version "1.7.0"
@@ -5981,6 +6027,15 @@
     classnames "^2.2.5"
     prop-types "^15.6.2"
 
+"@visx/group@2.1.0":
+  version "2.1.0"
+  resolved "https://registry.npmjs.org/@visx/group/-/group-2.1.0.tgz#65d4a72feb20dd09443f73cdc12ad5fb339792ef"
+  integrity sha512-bZKa54yVjGYPZZhzYHLz4AVlidSr4ET9B/xmSa7nnictMJWr7e/IuZThB/bMfDQlgdtvhcfTgs+ZluySc5SBUg==
+  dependencies:
+    "@types/react" "*"
+    classnames "^2.3.1"
+    prop-types "^15.6.2"
+
 "@visx/mock-data@^1.7.0":
   version "1.7.0"
   resolved "https://registry.npmjs.org/@visx/mock-data/-/mock-data-1.7.0.tgz#b56e30604ab0e775ada741cb96e6c9c1eaaac56d"
@@ -6002,6 +6057,11 @@
   version "1.7.0"
   resolved "https://registry.npmjs.org/@visx/point/-/point-1.7.0.tgz#1df3c3425eae464f498473bcdda2fcae05c8ecbe"
   integrity sha512-oaoY/HXYHhmpkkeKI4rBPmFtjHWtxSrIhZCVm1ipPoyQp3voJ8L6JD5eUIVmmaUCdUGUGwL1lFLnJiQ2p1Vlwg==
+
+"@visx/point@2.6.0":
+  version "2.6.0"
+  resolved "https://registry.npmjs.org/@visx/point/-/point-2.6.0.tgz#c4316ca409b5b829c5455f07118d8c14a92cc633"
+  integrity sha512-amBi7yMz4S2VSchlPdliznN41TuES64506ySI22DeKQ+mc1s1+BudlpnY90sM1EIw4xnqbKmrghTTGfy6SVqvQ==
 
 "@visx/react-spring@1.7.0":
   version "1.7.0"
@@ -6040,6 +6100,18 @@
     d3-scale "^3.2.3"
     d3-time "^1.1.0"
 
+"@visx/scale@2.2.2":
+  version "2.2.2"
+  resolved "https://registry.npmjs.org/@visx/scale/-/scale-2.2.2.tgz#b8eafabdcf92bb45ab196058fe184772ad80fd25"
+  integrity sha512-3aDySGUTpe6VykDQmF+g2nz5paFu9iSPTcCOEgkcru0/v5tmGzUdvivy8CkYbr87HN73V/Jc53lGm+kJUQcLBw==
+  dependencies:
+    "@types/d3-interpolate" "^1.3.1"
+    "@types/d3-scale" "^3.3.0"
+    "@types/d3-time" "^2.0.0"
+    d3-interpolate "^1.4.0"
+    d3-scale "^3.3.0"
+    d3-time "^2.1.1"
+
 "@visx/shape@1.7.0":
   version "1.7.0"
   resolved "https://registry.npmjs.org/@visx/shape/-/shape-1.7.0.tgz#2a89abf875a6925a6c969de0dc8a6beaa09d00ea"
@@ -6059,6 +6131,24 @@
     lodash "^4.17.15"
     prop-types "^15.5.10"
 
+"@visx/shape@2.4.0":
+  version "2.4.0"
+  resolved "https://registry.npmjs.org/@visx/shape/-/shape-2.4.0.tgz#d25d6a319c416258e12947d74773edb83051ba03"
+  integrity sha512-D6XdGCgWi0/0ZKJ5iK8W5gILCKdrbDwnR/e7o6n/favLU0o+ntiI4a9PZBZ5bYS0aFNG7r+miGMcWV/AQfODuA==
+  dependencies:
+    "@types/d3-path" "^1.0.8"
+    "@types/d3-shape" "^1.3.1"
+    "@types/lodash" "^4.14.172"
+    "@types/react" "*"
+    "@visx/curve" "2.1.0"
+    "@visx/group" "2.1.0"
+    "@visx/scale" "2.2.2"
+    classnames "^2.3.1"
+    d3-path "^1.0.5"
+    d3-shape "^1.2.0"
+    lodash "^4.17.21"
+    prop-types "^15.5.10"
+
 "@visx/text@1.7.0":
   version "1.7.0"
   resolved "https://registry.npmjs.org/@visx/text/-/text-1.7.0.tgz#530dfd85426fa87c3a43ae1d96e3148a14e7c864"
@@ -6069,6 +6159,18 @@
     "@types/react" "*"
     classnames "^2.2.5"
     lodash "^4.17.20"
+    prop-types "^15.7.2"
+    reduce-css-calc "^1.3.0"
+
+"@visx/text@2.3.0":
+  version "2.3.0"
+  resolved "https://registry.npmjs.org/@visx/text/-/text-2.3.0.tgz#34b66a467685cf1db2380a2673e032f2f874919a"
+  integrity sha512-5mEcmzWZqbziz6Azv+H6BWrnUbnpygAw4SNzBqF+YiGik5gR/USaBRAs9aKjnoUg6qFe3NZWFOcGpR3BzDR/bQ==
+  dependencies:
+    "@types/lodash" "^4.14.172"
+    "@types/react" "*"
+    classnames "^2.3.1"
+    lodash "^4.17.21"
     prop-types "^15.7.2"
     reduce-css-calc "^1.3.0"
 
@@ -9856,7 +9958,7 @@ d3-scale@4:
     d3-time "2.1.1 - 3"
     d3-time-format "2 - 4"
 
-d3-scale@^3.2.1, d3-scale@^3.2.3:
+d3-scale@^3.2.1, d3-scale@^3.2.3, d3-scale@^3.3.0:
   version "3.3.0"
   resolved "https://registry.npmjs.org/d3-scale/-/d3-scale-3.3.0.tgz#28c600b29f47e5b9cd2df9749c206727966203f3"
   integrity sha512-1JGp44NQCt5d1g+Yy+GeOnZP7xHo0ii8zsQp6PGzd+C1/dl0KGsp9A7Mxwp+1D1o4unbTTxVdU/ZOIEBoeZPbQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -5191,12 +5191,7 @@
   resolved "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.167.tgz#ce7d78553e3c886d4ea643c37ec7edc20f16765e"
   integrity sha512-w7tQPjARrvdeBkX/Rwg95S592JwxqOjmms3zWQ0XZgSyxSLdzWaYH3vErBhdVS/lRBX7F8aBYcYJYTr5TMGOzw==
 
-"@types/lodash@^4.14.146", "@types/lodash@^4.14.160", "@types/lodash@^4.14.168":
-  version "4.14.168"
-  resolved "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.168.tgz#fe24632e79b7ade3f132891afff86caa5e5ce008"
-  integrity sha512-oVfRvqHV/V6D1yifJbVRU3TMp8OT6o6BG+U9MkwuJ3U8/CsDHvalRpsxBqivn71ztOFZBTfJMvETbqHiaNSj7Q==
-
-"@types/lodash@^4.14.172":
+"@types/lodash@^4.14.146", "@types/lodash@^4.14.160", "@types/lodash@^4.14.168", "@types/lodash@^4.14.172":
   version "4.14.180"
   resolved "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.180.tgz#4ab7c9ddfc92ec4a887886483bc14c79fb380670"
   integrity sha512-XOKXa1KIxtNXgASAnwj7cnttJxS4fksBRywK/9LzRV5YxrF80BXZIGeQSuoESQ/VkUj30Ae0+YcuHc15wJCB2g==


### PR DESCRIPTION
Closes: https://github.com/sourcegraph/sourcegraph/issues/32936

## Background

This PR simply adds a new Pie Chart component to the `charts` package. The foundation of this component has been developed under the Code Insights needs but since this might be useful for other teams as well this PR brings this component to the shared charts package.

<img width="417" alt="Screenshot 2022-03-23 at 12 59 18" src="https://user-images.githubusercontent.com/18492575/159661713-d4fcd19b-a98a-4848-b453-3adbfc7fef3b.png">

## Test plan

- Make sure that the storybook story of pie chart works properly in all modern browsers (safari, chrome, firefox) 



