### PR TITLE
Use fully specified file path for process module provider

### DIFF
--- a/client/build-config/src/webpack/plugins.ts
+++ b/client/build-config/src/webpack/plugins.ts
@@ -15,7 +15,10 @@ export const getTerserPlugin = (): TerserPlugin =>
 
 export const getProvidePlugin = (): webpack.ProvidePlugin =>
     new webpack.ProvidePlugin({
-        process: 'process/browser',
+        // Adding the file extension is necessary to make importing this file
+        // work inside JavaScript modules. The alternative is to set
+        // `fullySpecified: false` (https://webpack.js.org/configuration/module/#resolvefullyspecified).
+        process: 'process/browser.js',
         // Based on the issue: https://github.com/webpack/changelog-v5/issues/10
         Buffer: ['buffer', 'Buffer'],
     })


### PR DESCRIPTION
Using only `process/browser` doesn't work if a JavaScript module
references `process`. At the moment, webpack will throw the following error:

```
[web-standalone-http]       looking for modules in /home/fkling/work/sourcegraph/code/sourcegraph/node_modules
[web-standalone-http]         existing directory /home/fkling/work/sourcegraph/code/sourcegraph/node_modules/process
[web-standalone-http]           using description file: /home/fkling/work/sourcegraph/code/sourcegraph/node_modules/process/package.json (relative path: .)
[web-standalone-http]             using description file: /home/fkling/work/sourcegraph/code/sourcegraph/node_modules/process/package.json (relative path: ./browser)
[web-standalone-http]               Field 'browser' doesn't contain a valid alias configuration
[web-standalone-http]               /home/fkling/work/sourcegraph/code/sourcegraph/node_modules/process/browser doesn't exist
```

Using the full file path fixes this.


## Test plan

No webpack errors when building https://github.com/sourcegraph/sourcegraph/pull/32919 . One of the `@codemirror` dependencies is a module and accesses `process`.

