### PR TITLE
ci: attempt at fixing golangci's depguard

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -20,7 +20,7 @@ linters:
 
 linters-settings:
   depguard:
-    list-type: blacklist
+    list-type: denylist
     include-go-root: true
     packages-with-error-message:
       # Deprecated packages


### PR DESCRIPTION
This is very empirical, and checking from where exactly this is coming from is a rabbithole. It seems that with golangci-lint 1.45, having updated depguard is coming with strange behaviour regarding the list-type. 

After multiple manual attempts on the CI, I noticed that while we get the issues in https://buildkite.com/sourcegraph/sourcegraph/builds/138564#392cb37d-9228-43c6-a051-9a94c11b3657 with `blacklist`, it's not happening with `denylist. I was not able to reproduce it locally, which is very strange. 

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

green builds