### PR TITLE
Restrict y axis ticks to integers for line charts

### DIFF
--- a/client/web/src/charts/components/line-chart/utils/ticks.ts
+++ b/client/web/src/charts/components/line-chart/utils/ticks.ts
@@ -51,12 +51,15 @@ export function getXScaleTicks(input: GetScaleTicksInput): number[] {
  * Number of lines (ticks) is based on chart height value and our expectation
  * around label density on the chart (no more than 1 tick in each 40px, see
  * HEIGHT_PER_TICK const)
+ *
+ * Ticks are constrained to integers.
  */
+
 export function getYScaleTicks(input: GetScaleTicksInput): number[] {
     const { scale, space, pixelsPerTick = 40 } = input
 
     // Generate max density ticks (d3 scale generation)
-    const ticks = getTicks(scale) as number[]
+    const ticks: number[] = getTicks(scale).filter(Number.isInteger) as number[]
 
     if (ticks.length <= 2) {
         return ticks

--- a/client/web/src/views/components/view/content/chart-view-content/charts/line/helpers/get-y-ticks.ts
+++ b/client/web/src/views/components/view/content/chart-view-content/charts/line/helpers/get-y-ticks.ts
@@ -10,10 +10,13 @@ const HEIGHT_PER_TICK = 40
  * Number of lines (ticks) is based on chart height value and our expectation
  * around label density on the chart (no more than 1 tick in each 40px, see
  * HEIGHT_PER_TICK const)
+ *
+ * Ticks are constrained to integers.
  */
+
 export function getYTicks(scale: AnyD3Scale, height: number): number[] {
     // Generate max density ticks (d3 scale generation)
-    const ticks: number[] = getTicks(scale)
+    const ticks: number[] = getTicks(scale).filter(Number.isInteger)
 
     if (ticks.length <= 2) {
         return ticks


### PR DESCRIPTION
resolves #31587

Filter out any non-integer ticks returned by the scale.

## Test plan
Verify Storybook LineCharts for `0 to 1 data` only show the 0 and 1 tick marks.

## App preview:

- [Link](https://sg-web-cw-insight-line-axis.onrender.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

