### PR TITLE
Search backend: pull `logBatch` from `searchResolver`

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -462,9 +462,9 @@ func logPrometheusBatch(status, alertType, requestSource, requestName string, el
 	).Observe(elapsed.Seconds())
 }
 
-func (r *searchResolver) logBatch(ctx context.Context, searchInputs *run.SearchInputs, srr *SearchResultsResolver, err error) {
+func logBatch(ctx context.Context, db database.DB, searchInputs *run.SearchInputs, srr *SearchResultsResolver, err error) {
 	var wg sync.WaitGroup
-	LogSearchLatency(ctx, r.db, &wg, searchInputs, srr.ElapsedMilliseconds())
+	LogSearchLatency(ctx, db, &wg, searchInputs, srr.ElapsedMilliseconds())
 	defer wg.Wait()
 
 	var status, alertType string
@@ -483,7 +483,7 @@ func (r *searchResolver) logBatch(ctx context.Context, searchInputs *run.SearchI
 			n = len(srr.Matches)
 		}
 		ev := searchhoney.SearchEvent(ctx, searchhoney.SearchEventArgs{
-			OriginalQuery: r.SearchInputs.OriginalQuery,
+			OriginalQuery: searchInputs.OriginalQuery,
 			Typ:           requestName,
 			Source:        requestSource,
 			Status:        status,
@@ -507,7 +507,7 @@ func (r *searchResolver) Results(ctx context.Context) (*SearchResultsResolver, e
 	alert, err := execute.Execute(ctx, r.db, agg, r.JobArgs())
 	srr := r.resultsToResolver(agg.Results, alert, agg.Stats)
 	srr.elapsed = time.Since(start)
-	r.logBatch(ctx, r.SearchInputs, srr, err)
+	logBatch(ctx, r.SearchInputs, srr, err)
 	return srr, err
 }
 

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -507,7 +507,7 @@ func (r *searchResolver) Results(ctx context.Context) (*SearchResultsResolver, e
 	alert, err := execute.Execute(ctx, r.db, agg, r.JobArgs())
 	srr := r.resultsToResolver(agg.Results, alert, agg.Stats)
 	srr.elapsed = time.Since(start)
-	logBatch(ctx, r.SearchInputs, srr, err)
+	logBatch(ctx, r.db, r.SearchInputs, srr, err)
 	return srr, err
 }
 

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -462,9 +462,9 @@ func logPrometheusBatch(status, alertType, requestSource, requestName string, el
 	).Observe(elapsed.Seconds())
 }
 
-func (r *searchResolver) logBatch(ctx context.Context, srr *SearchResultsResolver, err error) {
+func (r *searchResolver) logBatch(ctx context.Context, searchInputs *run.SearchInputs, srr *SearchResultsResolver, err error) {
 	var wg sync.WaitGroup
-	LogSearchLatency(ctx, r.db, &wg, r.SearchInputs, srr.ElapsedMilliseconds())
+	LogSearchLatency(ctx, r.db, &wg, searchInputs, srr.ElapsedMilliseconds())
 	defer wg.Wait()
 
 	var status, alertType string
@@ -507,7 +507,7 @@ func (r *searchResolver) Results(ctx context.Context) (*SearchResultsResolver, e
 	alert, err := execute.Execute(ctx, r.db, agg, r.JobArgs())
 	srr := r.resultsToResolver(agg.Results, alert, agg.Stats)
 	srr.elapsed = time.Since(start)
-	r.logBatch(ctx, srr, err)
+	r.logBatch(ctx, r.SearchInputs, srr, err)
 	return srr, err
 }
 


### PR DESCRIPTION
This makes `logBatch` independent of `searchResolver`. The goal is to make dependencies more clear and make it easier to cut `SearchInputs` off `searchResolver`, which will allow us to make `searchResolver` a thin(ner) wrapper over `SearchClient`. 

## Test plan

Semantics preserving. 

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


