### PR TITLE
Add ON UPDATE CASCADE to feature_flag_overrides

### DIFF
--- a/internal/database/feature_flags_test.go
+++ b/internal/database/feature_flags_test.go
@@ -493,6 +493,21 @@ func testUserFlags(t *testing.T) {
 		expected := map[string]bool{"f1": true, "f2": false}
 		require.Equal(t, expected, got)
 	})
+
+	t.Run("delete flag with override", func(t *testing.T) {
+		t.Cleanup(cleanup(t, db))
+		o1 := mkOrg("o1")
+		u1 := mkUser("u", o1.ID)
+		f1 := mkFFBool("f1", true)
+		mkUserOverride(u1.ID, "f1", false)
+
+		err := flagStore.DeleteFeatureFlag(ctx, f1.Name)
+		require.NoError(t, err)
+
+		flags, err := flagStore.GetFeatureFlags(ctx)
+		require.NoError(t, err)
+		require.Len(t, flags, 0)
+	})
 }
 
 func testAnonymousUserFlags(t *testing.T) {

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -947,7 +947,7 @@ Indexes:
 Check constraints:
     "feature_flag_overrides_has_org_or_user_id" CHECK (namespace_org_id IS NOT NULL OR namespace_user_id IS NOT NULL)
 Foreign-key constraints:
-    "feature_flag_overrides_flag_name_fkey" FOREIGN KEY (flag_name) REFERENCES feature_flags(flag_name) ON DELETE CASCADE
+    "feature_flag_overrides_flag_name_fkey" FOREIGN KEY (flag_name) REFERENCES feature_flags(flag_name) ON UPDATE CASCADE ON DELETE CASCADE
     "feature_flag_overrides_namespace_org_id_fkey" FOREIGN KEY (namespace_org_id) REFERENCES orgs(id) ON DELETE CASCADE
     "feature_flag_overrides_namespace_user_id_fkey" FOREIGN KEY (namespace_user_id) REFERENCES users(id) ON DELETE CASCADE
 
@@ -981,7 +981,7 @@ CASE
     ELSE 1
 END)
 Referenced by:
-    TABLE "feature_flag_overrides" CONSTRAINT "feature_flag_overrides_flag_name_fkey" FOREIGN KEY (flag_name) REFERENCES feature_flags(flag_name) ON DELETE CASCADE
+    TABLE "feature_flag_overrides" CONSTRAINT "feature_flag_overrides_flag_name_fkey" FOREIGN KEY (flag_name) REFERENCES feature_flags(flag_name) ON UPDATE CASCADE ON DELETE CASCADE
 
 ```
 

--- a/migrations/frontend/1648051770/down.sql
+++ b/migrations/frontend/1648051770/down.sql
@@ -1,0 +1,11 @@
+-- Undo the changes made in the up migration
+
+ALTER TABLE feature_flag_overrides
+    DROP CONSTRAINT feature_flag_overrides_flag_name_fkey;
+
+ALTER TABLE feature_flag_overrides
+    ADD CONSTRAINT feature_flag_overrides_flag_name_fkey
+    FOREIGN KEY (flag_name)
+    REFERENCES feature_flags(flag_name)
+    ON DELETE CASCADE;
+

--- a/migrations/frontend/1648051770/metadata.yaml
+++ b/migrations/frontend/1648051770/metadata.yaml
@@ -1,0 +1,2 @@
+name: cascade feature flag updates
+parents: [1647849753, 1647860082]

--- a/migrations/frontend/1648051770/up.sql
+++ b/migrations/frontend/1648051770/up.sql
@@ -1,0 +1,22 @@
+-- Perform migration here.
+--
+-- See /migrations/README.md. Highlights:
+--  * Make migrations idempotent (use IF EXISTS)
+--  * Make migrations backwards-compatible (old readers/writers must continue to work)
+--  * If you are using CREATE INDEX CONCURRENTLY, then make sure that only one statement
+--    is defined per file, and that each such statement is NOT wrapped in a transaction.
+--    Each such migration must also declare "createIndexConcurrently: true" in their
+--    associated metadata.yaml file.
+--  * If you are modifying Postgres extensions, you must also declare "privileged: true"
+--    in the associated metadata.yaml file.
+
+ALTER TABLE feature_flag_overrides
+    DROP CONSTRAINT feature_flag_overrides_flag_name_fkey;
+
+ALTER TABLE feature_flag_overrides
+    ADD CONSTRAINT feature_flag_overrides_flag_name_fkey
+    FOREIGN KEY (flag_name)
+    REFERENCES feature_flags(flag_name)
+    ON DELETE CASCADE
+    ON UPDATE CASCADE;
+


### PR DESCRIPTION
We soft-delete feature flags, which updates the feature flag name, which
is also the feature flag's primary key. This was a problem because
feature flag overrides refer to the flag's name as a foreign key, so when we 
update the feature flag name to soft delete, it fails with a foreign key constraint 
violation. This fixes the issue by adding ON UPDATE CASCADE to the foreign key
constraint.


## Test plan

Added a test for deleting a feature flag with an override.

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


