### PR TITLE
worker: Fix MaxDurationInQueue error

### DIFF
--- a/internal/workerutil/dbworker/store/store.go
+++ b/internal/workerutil/dbworker/store/store.go
@@ -452,18 +452,17 @@ oldest_retryable AS (
 		{state} = 'errored' AND
 		%s - {finished_at} > (%s * '1 second'::interval) AND
 		{num_failures} < %s
-)
-SELECT EXTRACT(EPOCH FROM NOW() - (
+),
+oldest_record AS (
 	(
 		SELECT last_queued_at FROM oldest_queued
-		ORDER BY last_queued_at LIMIT 1
-	)
-	UNION
-	(
+		UNION
 		SELECT last_queued_at FROM oldest_retryable
 	)
-	ORDER BY last_queued_at LIMIT 1
-))::integer AS age
+	ORDER BY last_queued_at
+	LIMIT 1
+)
+SELECT EXTRACT(EPOCH FROM NOW() - last_queued_at)::integer AS age FROM oldest_record
 `
 
 // columnsUpdatedByDequeue are the unmapped column names modified by the dequeue method.

--- a/internal/workerutil/dbworker/store/store_test.go
+++ b/internal/workerutil/dbworker/store/store_test.go
@@ -192,6 +192,18 @@ func TestStoreMaxDurationInQueueFailed(t *testing.T) {
 	}
 }
 
+func TestStoreMaxDurationInQueueEmpty(t *testing.T) {
+	db := setupStoreTest(t)
+
+	age, err := testStore(db, defaultTestStoreOptions(nil)).MaxDurationInQueue(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error getting max duration in queue: %s", err)
+	}
+	if age.Round(time.Second) != 0*time.Minute {
+		t.Fatalf("unexpected max age. want=%s have=%s", 0*time.Minute, age)
+	}
+}
+
 func TestStoreDequeueState(t *testing.T) {
 	db := setupStoreTest(t)
 


### PR DESCRIPTION
Old query could respond with a NULL value, which was unexpected by the scanner. Causes noisy (but harmless) error messages in v3.38.0:

```
Failed to determine queued duration” error=“sql: Scan error on column index 0, name \“age\“: converting NULL to int is unsupported
```

## Test plan

New unit tests.