### PR TITLE
gitserver: use migration cursor to decide which hashing algorithm to use during gitserver address determination

### DIFF
--- a/cmd/frontend/internal/httpapi/httpapi.go
+++ b/cmd/frontend/internal/httpapi/httpapi.go
@@ -161,8 +161,8 @@ func NewInternalHandler(m *mux.Router, db database.DB, schema *graphql.Schema, n
 	gitService := &gitServiceHandler{
 		Gitserver: gitserver.NewClient(db),
 	}
-	m.Get(apirouter.GitInfoRefs).Handler(trace.Route(http.HandlerFunc(gitService.serveInfoRefs)))
-	m.Get(apirouter.GitUploadPack).Handler(trace.Route(http.HandlerFunc(gitService.serveGitUploadPack)))
+	m.Get(apirouter.GitInfoRefs).Handler(trace.Route(handler(gitService.serveInfoRefs())))
+	m.Get(apirouter.GitUploadPack).Handler(trace.Route(handler(gitService.serveGitUploadPack())))
 	m.Get(apirouter.Telemetry).Handler(trace.Route(telemetryHandler(db)))
 	m.Get(apirouter.GraphQL).Handler(trace.Route(handler(serveGraphQL(schema, rateLimitWatcher, true))))
 	m.Get(apirouter.Configuration).Handler(trace.Route(handler(serveConfiguration)))

--- a/cmd/frontend/internal/httpapi/internal_test.go
+++ b/cmd/frontend/internal/httpapi/internal_test.go
@@ -20,8 +20,12 @@ func TestGitServiceHandlers(t *testing.T) {
 	gitService := &gitServiceHandler{
 		Gitserver: mockAddrForRepo{},
 	}
-	m.Get(apirouter.GitInfoRefs).Handler(http.HandlerFunc(gitService.serveInfoRefs))
-	m.Get(apirouter.GitUploadPack).Handler(http.HandlerFunc(gitService.serveGitUploadPack))
+	handler := jsonMiddleware(&errorHandler{
+		// Internal endpoints can expose sensitive errors
+		WriteErrBody: true,
+	})
+	m.Get(apirouter.GitInfoRefs).Handler(handler(gitService.serveInfoRefs()))
+	m.Get(apirouter.GitUploadPack).Handler(handler(gitService.serveGitUploadPack()))
 
 	cases := map[string]string{
 		"/git/foo/bar/info/refs?service=git-upload-pack": "http://foo.bar.gitserver/git/foo/bar/info/refs?service=git-upload-pack",
@@ -49,6 +53,6 @@ func TestGitServiceHandlers(t *testing.T) {
 
 type mockAddrForRepo struct{}
 
-func (mockAddrForRepo) AddrForRepo(context context.Context, name api.RepoName) string {
-	return strings.ReplaceAll(string(name), "/", ".") + ".gitserver"
+func (mockAddrForRepo) AddrForRepo(_ context.Context, name api.RepoName) (string, error) {
+	return strings.ReplaceAll(string(name), "/", ".") + ".gitserver", nil
 }

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -582,7 +582,11 @@ func (s *Server) syncRepoState(gitServerAddrs gitserver.GitServerAddresses, batc
 	err := store.IterateRepoGitserverStatus(ctx, options, func(repo types.RepoGitserverStatus) error {
 		repoSyncStateCounter.WithLabelValues("check").Inc()
 		// Ensure we're only dealing with repos we are responsible for
-		if addr := gitserver.AddrForRepo(repo.Name, gitServerAddrs); !s.hostnameMatch(addr) {
+		addr, err := gitserver.AddrForRepo(ctx, s.DB, repo.Name, gitServerAddrs)
+		if err != nil {
+			return err
+		}
+		if !s.hostnameMatch(addr) {
 			repoSyncStateCounter.WithLabelValues("other_shard").Inc()
 			return nil
 		}

--- a/internal/gitserver/client.go
+++ b/internal/gitserver/client.go
@@ -34,6 +34,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/gitolite"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
+	"github.com/sourcegraph/sourcegraph/internal/gitserver/migration"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
@@ -138,7 +139,7 @@ type ClientImplementor struct {
 //go:generate ../../dev/mockgen.sh github.com/sourcegraph/sourcegraph/internal/gitserver -i Client -o mock_client.go
 type Client interface {
 	// AddrForRepo returns the gitserver address to use for the given repo name.
-	AddrForRepo(context.Context, api.RepoName) string
+	AddrForRepo(context.Context, api.RepoName) (string, error)
 
 	Addrs() []string
 
@@ -147,7 +148,7 @@ type Client interface {
 
 	// ArchiveURL returns a URL from which an archive of the given Git repository can
 	// be downloaded from.
-	ArchiveURL(context.Context, api.RepoName, ArchiveOptions) *url.URL
+	ArchiveURL(context.Context, api.RepoName, ArchiveOptions) (*url.URL, error)
 
 	// Command creates a new Cmd. Command name must be 'git', otherwise it panics.
 	Command(name string, args ...string) *Cmd
@@ -229,12 +230,12 @@ func (c *ClientImplementor) Addrs() []string {
 	return c.addrs()
 }
 
-func (c *ClientImplementor) AddrForRepo(ctx context.Context, repo api.RepoName) string {
+func (c *ClientImplementor) AddrForRepo(ctx context.Context, repo api.RepoName) (string, error) {
 	addrs := c.Addrs()
 	if len(addrs) == 0 {
 		panic("unexpected state: no gitserver addresses")
 	}
-	return AddrForRepo(repo, GitServerAddresses{
+	return AddrForRepo(ctx, c.db, repo, GitServerAddresses{
 		Addresses:     addrs,
 		PinnedServers: c.pinned(),
 	})
@@ -245,7 +246,9 @@ func (c *ClientImplementor) RendezvousAddrForRepo(repo api.RepoName) string {
 	if len(addrs) == 0 {
 		panic("unexpected state: no gitserver addresses")
 	}
-
+	if repoPinned, addr := getPinnedRepoAddr(string(repo), c.pinned()); repoPinned {
+		return addr
+	}
 	return RendezvousAddrForRepo(repo, addrs)
 }
 
@@ -259,22 +262,31 @@ func (c *ClientImplementor) addrForKey(key string) string {
 	return addrForKey(key, addrs)
 }
 
-var addForRepoInvoked = promauto.NewCounter(prometheus.CounterOpts{
+var addrForRepoInvoked = promauto.NewCounter(prometheus.CounterOpts{
 	Name: "src_gitserver_addr_for_repo_invoked",
 	Help: "Number of times gitserver.AddrForRepo was invoked",
 })
 
 // AddrForRepo returns the gitserver address to use for the given repo name.
 // It should never be called with a nil addresses pointer.
-func AddrForRepo(repo api.RepoName, addresses GitServerAddresses) string {
-	addForRepoInvoked.Inc()
+func AddrForRepo(ctx context.Context, db database.DB, repo api.RepoName, addresses GitServerAddresses) (string, error) {
+	addrForRepoInvoked.Inc()
 
 	repo = protocol.NormalizeRepo(repo) // in case the caller didn't already normalize it
 	rs := string(repo)
-	if pinned, found := addresses.PinnedServers[rs]; found {
-		return pinned
+	if repoPinned, addr := getPinnedRepoAddr(string(repo), addresses.PinnedServers); repoPinned {
+		return addr, nil
 	}
-	return addrForKey(rs, addresses.Addresses)
+
+	useRendezvous, err := shouldUseRendezvousHashing(ctx, db, rs)
+	if err != nil {
+		return "", err
+	}
+	if useRendezvous {
+		return RendezvousAddrForRepo(repo, addresses.Addresses), nil
+	}
+
+	return addrForKey(rs, addresses.Addresses), nil
 }
 
 type GitServerAddresses struct {
@@ -333,7 +345,7 @@ func (a *archiveReader) Close() error {
 
 // ArchiveURL returns a URL from which an archive of the given Git repository can
 // be downloaded from.
-func (c *ClientImplementor) ArchiveURL(ctx context.Context, repo api.RepoName, opt ArchiveOptions) *url.URL {
+func (c *ClientImplementor) ArchiveURL(ctx context.Context, repo api.RepoName, opt ArchiveOptions) (*url.URL, error) {
 	q := url.Values{
 		"repo":    {string(repo)},
 		"treeish": {opt.Treeish},
@@ -344,12 +356,16 @@ func (c *ClientImplementor) ArchiveURL(ctx context.Context, repo api.RepoName, o
 		q.Add("path", path)
 	}
 
+	addrForRepo, err := c.AddrForRepo(ctx, repo)
+	if err != nil {
+		return nil, err
+	}
 	return &url.URL{
 		Scheme:   "http",
-		Host:     c.AddrForRepo(ctx, repo),
+		Host:     addrForRepo,
 		Path:     "/archive",
 		RawQuery: q.Encode(),
-	}
+	}, nil
 }
 
 func (c *ClientImplementor) Archive(ctx context.Context, repo api.RepoName, opt ArchiveOptions) (_ io.ReadCloser, err error) {
@@ -373,7 +389,11 @@ func (c *ClientImplementor) Archive(ctx context.Context, repo api.RepoName, opt 
 		return nil, err
 	}
 
-	u := c.ArchiveURL(ctx, repo, opt)
+	u, err := c.ArchiveURL(ctx, repo, opt)
+	if err != nil {
+		return nil, err
+	}
+
 	resp, err := c.do(ctx, repo, "POST", u.String(), nil)
 	if err != nil {
 		return nil, err
@@ -487,7 +507,12 @@ func (c *ClientImplementor) Search(ctx context.Context, args *protocol.SearchReq
 		return false, err
 	}
 
-	uri := "http://" + c.AddrForRepo(ctx, repoName) + "/search"
+	addrForRepo, err := c.AddrForRepo(ctx, repoName)
+	if err != nil {
+		return false, err
+	}
+
+	uri := "http://" + addrForRepo + "/search"
 	resp, err := c.do(ctx, repoName, "POST", uri, buf.Bytes())
 	if err != nil {
 		return false, err
@@ -776,9 +801,13 @@ func (c *ClientImplementor) RequestRepoMigrate(ctx context.Context, repo api.Rep
 	// We do not need to set a value for the attribute "Since" because the repo is not expected to
 	// be cloned at the new gitserver instance. And for not cloned repos, this attribute is already
 	// ignored.
+	addrForRepo, err := c.AddrForRepo(ctx, repo)
+	if err != nil {
+		return nil, err
+	}
 	req := &protocol.RepoUpdateRequest{
 		Repo:           repo,
-		CloneFromShard: c.AddrForRepo(ctx, repo),
+		CloneFromShard: addrForRepo,
 	}
 
 	// We set "uri" to the HTTP URL of the gitserver instance that should be the new owner of this
@@ -888,7 +917,10 @@ func (c *ClientImplementor) RepoCloneProgress(ctx context.Context, repos ...api.
 	shards := make(map[string]*protocol.RepoCloneProgressRequest, (len(repos)/numPossibleShards)*2) // 2x because it may not be a perfect division
 
 	for _, r := range repos {
-		addr := c.AddrForRepo(ctx, r)
+		addr, err := c.AddrForRepo(ctx, r)
+		if err != nil {
+			return nil, err
+		}
 		shard := shards[addr]
 
 		if shard == nil {
@@ -962,7 +994,10 @@ func (c *ClientImplementor) RepoInfo(ctx context.Context, repos ...api.RepoName)
 	shards := make(map[string]*protocol.RepoInfoRequest, (len(repos)/numPossibleShards)*2) // 2x because it may not be a perfect division
 
 	for _, r := range repos {
-		addr := c.AddrForRepo(ctx, r)
+		addr, err := c.AddrForRepo(ctx, r)
+		if err != nil {
+			return nil, err
+		}
 		shard := shards[addr]
 
 		if shard == nil {
@@ -1088,7 +1123,11 @@ func (c *ClientImplementor) httpPost(ctx context.Context, repo api.RepoName, op 
 		return nil, err
 	}
 
-	uri := "http://" + c.AddrForRepo(ctx, repo) + "/" + op
+	addrForRepo, err := c.AddrForRepo(ctx, repo)
+	if err != nil {
+		return nil, err
+	}
+	uri := "http://" + addrForRepo + "/" + op
 	return c.do(ctx, repo, "POST", uri, b)
 }
 
@@ -1242,4 +1281,29 @@ func revsToGitArgs(revSpecs []protocol.RevisionSpecifier) []string {
 		args = append(args, "HEAD")
 	}
 	return args
+}
+
+// shouldUseRendezvousHashing returns true if rendezvous hashing is to be used to find
+// an address of gitserver instance for a given repo
+func shouldUseRendezvousHashing(ctx context.Context, db database.DB, repo string) (bool, error) {
+	cursor, err := migration.GetCursor(ctx, db)
+	if err != nil {
+		return false, err
+	}
+	if cursor == "" {
+		return false, nil
+	}
+
+	// Migration is in progress or finished, if the name is less than or equal to cursor -- use rendezvous
+	return repo <= cursor, nil
+}
+
+// getPinnedRepoAddr returns true and gitserver address if given repo is pinned.
+// Otherwise, if repo is not pinned -- false and empty string are returned
+func getPinnedRepoAddr(repo string, pinnedServers map[string]string) (bool, string) {
+	if pinned, found := pinnedServers[repo]; found {
+		return true, pinned
+	} else {
+		return false, ""
+	}
 }

--- a/internal/gitserver/migration/migration.go
+++ b/internal/gitserver/migration/migration.go
@@ -8,11 +8,24 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 )
 
+var MigrationMocks, emptyMigrationMocks struct {
+	GetCursor func(ctx context.Context, db dbutil.DB) (string, error)
+}
+
+// ResetMigrationMocks clears the mock functions set on Mocks (so that subsequent
+// tests don't inadvertently use them).
+func ResetMigrationMocks() {
+	MigrationMocks = emptyMigrationMocks
+}
+
 // GetCursor is a helper function that returns the current state of the migration.
 // The cursor is used to determine which is the last repository that was migrated.
 // Since repositories are migrated in alphabetical order, the cursor can be used by clients
 // to determine which hashing algorithm to use.
 // Before the migration is run, this function returns an empty string.
 func GetCursor(ctx context.Context, db dbutil.DB) (string, error) {
+	if MigrationMocks.GetCursor != nil {
+		return MigrationMocks.GetCursor(ctx, db)
+	}
 	return "", nil
 }


### PR DESCRIPTION
The cursor is a name of last repository which was processed (i.e. migrated to new gitserver instance in most cases) during the process of hashing algorithm change. Any repo with a lexicographically smaller or equal name than cursor is located on a gitserver instance which hostname is resolved using rendezvous hashing.


Closes https://github.com/sourcegraph/sourcegraph/issues/32315


## Test plan

Unit tests added

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


