### PR TITLE
searcher: fix formatting of godoc lists

### DIFF
--- a/cmd/searcher/search/search.go
+++ b/cmd/searcher/search/search.go
@@ -2,13 +2,13 @@
 // a specific commit.
 //
 // Architecture Notes:
-// * Archive is fetched from gitserver
-// * Simple HTTP API exposed
-// * Currently no concept of authorization
-// * On disk cache of fetched archives to reduce load on gitserver
-// * Run search on archive. Rely on OS file buffers
-// * Simple to scale up since stateless
-// * Use ingress with affinity to increase local cache hit ratio
+//  * Archive is fetched from gitserver
+//  * Simple HTTP API exposed
+//  * Currently no concept of authorization
+//  * On disk cache of fetched archives to reduce load on gitserver
+//  * Run search on archive. Rely on OS file buffers
+//  * Simple to scale up since stateless
+//  * Use ingress with affinity to increase local cache hit ratio
 package search
 
 import (

--- a/cmd/searcher/search/store.go
+++ b/cmd/searcher/search/store.go
@@ -45,10 +45,10 @@ const maxFileSize = 2 << 20 // 2MB; match https://sourcegraph.com/search?q=repo:
 //
 // We use an LRU to do cache eviction:
 //
-// * When to evict is based on the total size of *.zip on disk.
-// * What to evict uses the LRU algorithm.
-// * We touch files when opening them, so can do LRU based on file
-//   modification times.
+//  * When to evict is based on the total size of *.zip on disk.
+//  * What to evict uses the LRU algorithm.
+//  * We touch files when opening them, so can do LRU based on file
+//    modification times.
 //
 // Note: The store fetches tarballs but stores zips. We want to be able to
 // filter which files we cache, so we need a format that supports streaming


### PR DESCRIPTION
godoc doesn't have native support for lists. The trick the stdlib uses
is to add 1 level of whitespace before the bullet points.

Test Plan: "go doc -all ./cmd/searcher/search" outputs each bullet point
on its own line.