### PR TITLE
Add in wait for pods to be initiated

### DIFF
--- a/dev/ci/integration/cluster/test.sh
+++ b/dev/ci/integration/cluster/test.sh
@@ -56,6 +56,7 @@ function cluster_setup() {
   kubectl apply -n "$NAMESPACE" --recursive --validate -f generated-cluster
   popd
   echo "--- wait for ready"
+  sleep 15 #add in a small wait for all pods to be rolled out by the replication controller
   kubectl get pods -n "$NAMESPACE"
   time kubectl wait --for=condition=Ready -l app=sourcegraph-frontend pod --timeout=5m -n "$NAMESPACE"
   set -e


### PR DESCRIPTION
Adds in a small delay for pods to be created (not ready) by the kubelet. I saw in local testing that some pods were very slightly behind the rest. Given how quickly this script runs through commands it's possible the pod hasn't been created before we check that it's ready. 

fixes https://github.com/sourcegraph/sourcegraph/issues/32403


## Test plan

Green build on main-dry-run
https://buildkite.com/sourcegraph/sourcegraph/builds/138656#bc3329ff-daf6-4616-a44a-fa670cff5afa/1

