### PR TITLE
sg: don't magically source .bashrc for keegan

### DIFF
--- a/dev/sg/internal/usershell/usershell.go
+++ b/dev/sg/internal/usershell/usershell.go
@@ -106,6 +106,11 @@ func Cmd(ctx context.Context, cmd string) *exec.Cmd {
 		command := fmt.Sprintf("fish || true; %s", cmd)
 		return exec.CommandContext(ctx, ShellPath(ctx), "-c", command)
 	}
+	if os.Getenv("USER") == "keegan" {
+		// Here be dragons. The "-i" below breaks stuff for me. I use direnv
+		// to setup my environment, I don't mutate my .bashrc.
+		return exec.CommandContext(ctx, ShellPath(ctx), "-c", cmd)
+	}
 	if runtime.GOOS == "linux" {
 		// The default Ubuntu bashrc comes with a caveat that prevents the bashrc to be
 		// reloaded unless the shell is interactive. Therefore, we need to request for an


### PR DESCRIPTION
I think we do this because we mutate .bashrc in the sg setup and we try
to validate if stuff is working after mutation. However, I don't use sg
setup and I rely direnv to setup a special environment just for
Sourcegraph.

This regression came from https://github.com/sourcegraph/sourcegraph/pull/31312

This commit exists as a talking point for the proper solution. Although
I don't mind landing it either :)

Test Plan: sg works on my linux machine.