### PR TITLE
Fix rendering of Markdown quote for page

### DIFF
--- a/doc/dev/background-information/testing_web_code.md
+++ b/doc/dev/background-information/testing_web_code.md
@@ -85,6 +85,7 @@ Snapshot diffs should be reviewed in pull request reviews the same way any other
 ### Behavior
 
 The most effective way we can test our React components is through our behavior tests. These tests should all follow the same core guiding principle:
+
 > The more our tests resemble the way our software is used, the more confidence they will give us.
 
 This means that our behavior tests should be designed to simulate a typical user journey **as closely as possible**.


### PR DESCRIPTION
## Test plan

The quote formatting was not rendered correctly on the [Testing web code](https://docs.sourcegraph.com/dev/background-information/testing_web_code) doc page:
<img width="839" alt="image" src="https://user-images.githubusercontent.com/10523985/159787241-d776776c-054f-48b1-8173-9b67e46e6c9b.png">

Adding a leading newline should resolve the issue, as that appears to render correctly on [the code search queries page](https://docs.sourcegraph.com/code_search/reference/queries):
<img width="851" alt="image" src="https://user-images.githubusercontent.com/10523985/159787817-c71a6857-9d79-47be-81eb-1c09c56a9bc6.png">

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


