### PR TITLE
codeintel: Do not query filters when bloom filters are disabled

### DIFF
--- a/enterprise/internal/codeintel/stores/dbstore/xrepo.go
+++ b/enterprise/internal/codeintel/stores/dbstore/xrepo.go
@@ -208,7 +208,6 @@ WHERE
 `
 
 const referenceIDsAndFiltersQuery = referenceIDsAndFiltersCTEDefinitions + `
--- source: enterprise/internal/codeintel/stores/dbstore/xrepo.go:ReferenceIDsAndFilters
 SELECT r.dump_id, r.scheme, r.name, r.version, r.filter
 ` + referenceIDsAndFiltersBaseQuery + `
 ORDER BY dump_id
@@ -216,7 +215,6 @@ LIMIT %s OFFSET %s
 `
 
 const referenceIDsQuery = referenceIDsAndFiltersCTEDefinitions + `
--- source: enterprise/internal/codeintel/stores/dbstore/xrepo.go:ReferenceIDsAndFilters
 SELECT r.dump_id, r.scheme, r.name, r.version, NULL AS filter
 ` + referenceIDsAndFiltersBaseQuery + `
 ORDER BY dump_id

--- a/enterprise/internal/codeintel/stores/dbstore/xrepo.go
+++ b/enterprise/internal/codeintel/stores/dbstore/xrepo.go
@@ -3,6 +3,7 @@ package dbstore
 import (
 	"context"
 	"fmt"
+	"os"
 	"strconv"
 	"strings"
 
@@ -164,8 +165,14 @@ func (s *Store) ReferenceIDsAndFilters(ctx context.Context, repositoryID int, co
 	}
 	trace.Log(log.Int("totalCount", totalCount))
 
+	query := referenceIDsAndFiltersQuery
+	if os.Getenv("DEBUG_PRECISE_CODE_INTEL_BLOOM_FILTER_BAIL_OUT") != "" {
+		// Do not select filter payloads, we won't test them later on
+		query = referenceIDsQuery
+	}
+
 	rows, err := s.Query(ctx, sqlf.Sprintf(
-		referenceIDsAndFiltersQuery,
+		query,
 		visibleUploadsQuery,
 		repositoryID,
 		sqlf.Join(qs, ", "),
@@ -201,7 +208,16 @@ WHERE
 `
 
 const referenceIDsAndFiltersQuery = referenceIDsAndFiltersCTEDefinitions + `
+-- source: enterprise/internal/codeintel/stores/dbstore/xrepo.go:ReferenceIDsAndFilters
 SELECT r.dump_id, r.scheme, r.name, r.version, r.filter
+` + referenceIDsAndFiltersBaseQuery + `
+ORDER BY dump_id
+LIMIT %s OFFSET %s
+`
+
+const referenceIDsQuery = referenceIDsAndFiltersCTEDefinitions + `
+-- source: enterprise/internal/codeintel/stores/dbstore/xrepo.go:ReferenceIDsAndFilters
+SELECT r.dump_id, r.scheme, r.name, r.version, NULL AS filter
 ` + referenceIDsAndFiltersBaseQuery + `
 ORDER BY dump_id
 LIMIT %s OFFSET %s


### PR DESCRIPTION
Continuing from #32908.

This PR stops loading `filter` payloads from the `lsif_references` table when the new envvar `DEBUG_PRECISE_CODE_INTEL_BLOOM_FILTER_BAIL_OUT` is set. We don't need this data, as the presence of the same envvar stops the filter from being tested later on.

We should see smaller query times (currently seen at around 300ms) for these particular queries in subsequent traces if successful.

## Test plan

Current CI tests. Should not affect any environment apart from Cloud, which we will enable only under surveillance.
