### PR TITLE
batches: Don't 500 on unknown webhook events

### DIFF
--- a/cmd/frontend/webhooks/github_webhooks.go
+++ b/cmd/frontend/webhooks/github_webhooks.go
@@ -62,7 +62,7 @@ func (h *GitHubWebhook) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	// parse event
 	eventType := gh.WebHookType(r)
-	e, err := gh.ParseWebHook(gh.WebHookType(r), body)
+	e, err := gh.ParseWebHook(eventType, body)
 	if err != nil {
 		log15.Error("Error parsing github webhook event", "error", err)
 		http.Error(w, err.Error(), http.StatusBadRequest)

--- a/enterprise/cmd/frontend/internal/batches/webhooks/github_test.go
+++ b/enterprise/cmd/frontend/internal/batches/webhooks/github_test.go
@@ -230,8 +230,8 @@ func testGitHubWebhook(db *sql.DB, userID int32) func(*testing.T) {
 					NodeID: &githubRepo.ExternalRepo.ID,
 				},
 				Action: &action,
-			}); err == nil {
-				t.Error("unexpected nil error")
+			}); err != nil {
+				t.Errorf("unexpected non-nil error: %v", err)
 			}
 		})
 	}


### PR DESCRIPTION
Fixes the behavior reported here: https://github.com/sourcegraph/customer/issues/782 and doesn't mark webhooks we don't need as errors in the webhook logs. Also this will stop GitHub from retrying webhook delivery.

## Test plan

Tested locally using postman that this doesn't trigger the log anymore.