### PR TITLE
docs: add helm doc

### DIFF
--- a/doc/admin/install/kubernetes/helm.md
+++ b/doc/admin/install/kubernetes/helm.md
@@ -41,7 +41,13 @@ __TODO__
 
 ### Using external Redis instances
 
-__TODO__
+To use external Redis instances, first review our [general recommendations](https://docs.sourcegraph.com/admin/external_services/redis).
+
+<!-- 
+  If we copy the entire README.md over here the page will be too clutterd.
+  When the docsite V2 is ready, this should potentially have its own page
+-->
+Follow [using your own Redis](https://github.com/sourcegraph/deploy-sourcegraph-helm/tree/main/charts/sourcegraph/examples/external-redis) to configure your override file.
 
 ### Using external Object Storage
 

--- a/doc/admin/install/kubernetes/helm.md
+++ b/doc/admin/install/kubernetes/helm.md
@@ -1,0 +1,151 @@
+# Sourcegraph Helm Chart
+
+## Requirements
+
+* [Helm 3 CLI](https://helm.sh/docs/intro/install/)
+* Kubernetes 1.19 or greater
+
+## Quickstart
+
+To use the Helm chart, add Sourcegraph helm repository:
+ 
+```sh
+helm repo add sourcegraph https://sourcegraph.github.io/deploy-sourcegraph-helm/
+```
+
+Install the Sourcegraph chart using default values:
+
+```sh
+helm install --version 0.7.0 sourcegraph sourcegraph/sourcegraph
+```
+
+## Configuration 
+
+The Sourcegraph chart is highly customizable to support a wide range of environments. Please review the default values from [values.yaml](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/charts/sourcegraph/values.yaml) and all [supported options](https://github.com/sourcegraph/deploy-sourcegraph-helm/tree/main/charts/sourcegraph#configuration-options). Customizations can be applied using an override file. Using an override file allows customizations to persist through upgrades without needing to manage merge conflicts.
+
+To customize configuration settings with an override file, create an empty yaml file (e.g. `override.yaml`) and configure overrides.
+
+> WARNING: __DO NOT__ copy the [default values file](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/charts/sourcegraph/values.yaml) as a boilerplate for your override file. You risk having outdated values during upgrades.
+
+Example overrides can be found in the [examples](https://github.com/sourcegraph/deploy-sourcegraph-helm/tree/main/charts/sourcegraph/examples) folder. Please take a look at our examples before providing your own configuration and consider using them as boilerplates.
+
+Provide the override file to helm:
+
+```sh
+# Installation
+helm install --values ./override.yaml --version 0.7.0 sourcegraph sourcegraph/sourcegraph
+
+# Upgrade
+helm upgrade --values ./override.yaml --version 0.7.0 sourcegraph sourcegraph/sourcegraph
+```
+
+### Using external PostgreSQL databases
+
+__TODO__
+
+### Using external Redis instances
+
+__TODO__
+
+### Using external Object Storage
+
+__TODO__
+
+### Cloud providers guides
+
+#### Configure Sourcegraph on Google Kubernetes Engine (GKE)
+
+You should include these suggested values in your override file, learn more from [override.yaml](https://github.com/sourcegraph/deploy-sourcegraph-helm/tree/main/charts/sourcegraph/examples/gcp/override.yaml).
+
+> Looking to enable TLS with Google-managed certificates? [learn more](https://cloud.google.com/kubernetes-engine/docs/how-to/managed-certs)
+
+In addition to the provided values, you need to deploy the [BackendConfig] CRD to properly expose Sourcegraph publically. The [BackendConfig] CR should be deployed in the same namespace where Sourcegraph chart is installed.
+
+```yaml
+apiVersion: cloud.google.com/v1
+kind: BackendConfig
+metadata:
+  name: sourcegraph-frontend
+spec:
+  healthCheck:
+    checkIntervalSec: 5
+    timeoutSec: 5
+    requestPath: /ready
+    port: 6060 # we use a custom port to perform healthcheck
+```
+
+#### Configure Sourcegraph on Elastic Kubernetes Service (EKS)
+
+You should include these suggested values in your override file, learn more from [override.yaml](https://github.com/sourcegraph/deploy-sourcegraph-helm/tree/main/charts/sourcegraph/examples/aws/override.yaml).
+
+In addition to the provided values, you should consult AWS documentation to learn how to configure the Ingress properly.
+
+- [Applicatoin load balancing on Amazon EKS](https://docs.aws.amazon.com/eks/latest/userguide/alb-ingress.html)
+- [Enable TLS with AWS-managed certificate](https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.2/guide/ingress/annotations/#ssl)
+- [Supported AWS load balancer annotations](https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.2/guide/ingress/annotations)
+
+```yaml
+frontend:
+  ingress:
+    enabled: true
+    annotations:
+      kubernetes.io/ingress.class: alb
+      # additional aws alb ingress controller supported annotations
+      # ...
+    # replace with your actual domain
+    host: sourcegraph.company.com
+```
+
+#### Configure Sourcegraph on Azure Managed Kubernetes Service (AKS)
+
+You should include these suggested values in your override file, learn more from [override.yaml](https://github.com/sourcegraph/deploy-sourcegraph-helm/tree/main/charts/sourcegraph/examples/azure/override.yaml).
+
+In addition to the provided values, you should configure Ingress to use [Azure Application Gateway] to expose Sourcegraph publically.
+
+- [Expose an AKS service over HTTP or HTTPS using Application Gateway](https://docs.microsoft.com/en-us/azure/application-gateway/ingress-controller-expose-service-over-http-https)
+- [Use certificates with LetsEncrypt.org on Application Gateway for AKS clusters](https://docs.microsoft.com/en-us/azure/application-gateway/ingress-controller-letsencrypt-certificate-application-gateway)
+- [Supported Azure Application Gateway Ingress Controller annotations](https://azure.github.io/application-gateway-kubernetes-ingress/annotations/)
+- [What is Application Gateway Ingress Controller?](https://docs.microsoft.com/en-us/azure/application-gateway/ingress-controller-overview)
+
+```yaml
+frontend:
+  ingress:
+    enabled: true
+    annotations:
+      kubernetes.io/ingress.class: azure/application-gateway
+      # additional azure application gateway supported annotations
+      # ...
+    # replace with your actual domain
+    host: sourcegraph.company.com
+```
+
+#### Configure Sourcegraph on other Cloud providers or on-prem
+
+Read <https://kubernetes.io/docs/concepts/storage/storage-classes/> to configure the `storageClass.provisioner` and `storageClass.parameters` fields for your cloud provider or your on-prem environment.
+
+```yaml
+storageClass:
+  create: true
+  provisioner: <REPLACE_ME>
+  volumeBindingMode: WaitForFirstConsumer
+  reclaimPolicy: Retain
+  parameters:
+    key1: value1
+```
+
+### Advanced configuration
+
+The Helm chart is new and still under active development, and we may not cover all of your use cases. 
+
+Please contact [support@sourcegraph.com](mailto:support@sourcegraph.com) or your Customer Engineer directly to discuss your specific need.
+
+For advanced users who are looking for a temporary workaround, we __recommend__ applying [Kustomize](https://kustomize.io) on the rendered manifests from our chart. Please __do not__ maintain your own fork of our chart, this may impact our ability to support you if you run into issues.
+
+You can learn more about how to integrate Kustomize with Helm from our [example](https://github.com/sourcegraph/deploy-sourcegraph-helm/tree/main/charts/sourcegraph/examples/kustomize-chart).
+
+## Upgrading Sourcegraph
+
+__TODO__
+
+[backendconfig]: https://cloud.google.com/kubernetes-engine/docs/how-to/ingress-features#create_backendconfig
+[azure application gateway]: https://docs.microsoft.com/en-us/azure/application-gateway/overview

--- a/doc/admin/install/kubernetes/helm.md
+++ b/doc/admin/install/kubernetes/helm.md
@@ -189,6 +189,8 @@ storageClass:
 
 ### Advanced configuration
 
+#### Integrate Kustomize with Helm chart
+
 The Helm chart is new and still under active development, and we may not cover all of your use cases. 
 
 Please contact [support@sourcegraph.com](mailto:support@sourcegraph.com) or your Customer Engineer directly to discuss your specific need.
@@ -196,6 +198,10 @@ Please contact [support@sourcegraph.com](mailto:support@sourcegraph.com) or your
 For advanced users who are looking for a temporary workaround, we __recommend__ applying [Kustomize](https://kustomize.io) on the rendered manifests from our chart. Please __do not__ maintain your own fork of our chart, this may impact our ability to support you if you run into issues.
 
 You can learn more about how to integrate Kustomize with Helm from our [example](https://github.com/sourcegraph/deploy-sourcegraph-helm/tree/main/charts/sourcegraph/examples/kustomize-chart).
+
+#### Sub-chart
+
+__TODO__
 
 ## Upgrading Sourcegraph
 

--- a/doc/admin/install/kubernetes/helm.md
+++ b/doc/admin/install/kubernetes/helm.md
@@ -151,6 +151,8 @@ frontend:
 
 You need to have a EKS cluster (>=1.19) with the following addons enabled:
 
+> You may consider deploying your own Ingress Controller instead of ALB Ingress Controller, [learn more](https://kubernetes.github.io/ingress-nginx/)
+
 - [x] [AWS Load Balancer Controller]
 - [x] [AWS EBS CSI driver]
 

--- a/doc/admin/install/kubernetes/helm.md
+++ b/doc/admin/install/kubernetes/helm.md
@@ -60,7 +60,7 @@ This section is aimed at providing high-level guidance on deploying Sourcegraph 
 
 #### Prerequisites
 
-You need to have a __public__ VPC-native GKE cluster (>=1.19) with the following addons enabled:
+You need to have a GKE cluster (>=1.19) with the following addons enabled:
 
 - [x] HTTP Load Balancing
 - [x] Compute Engine persistent disk CSI Driver
@@ -68,6 +68,8 @@ You need to have a __public__ VPC-native GKE cluster (>=1.19) with the following
 You account should have sufficient access equivalent to the `cluster-admin` ClusterRole.
 
 #### Steps
+
+> [Container-native load balancing] is only available on VPC-native cluster. For legacy clusters, [learn more](https://cloud.google.com/kubernetes-engine/docs/how-to/load-balance-ingress)
 
 Create an override file with the following value. We configure Ingress to use [Container-native load balancing] to expose Sourcegraph publically and Storage Class to use [Compute Engine persistent disk].
 
@@ -126,7 +128,7 @@ It will take around 10 mintues for the load balancer to be fully ready, you may 
 kubectl describe ingress sourcegraph-frontend
 ```
 
-Upon obtaining the allocated IP address of the load balancer, you should create an A record for the `sourcegraph.company.com` domain. Finally, it is recommended to enable TLS and you can learn more from about how to use [Google-managed certificate](https://cloud.google.com/kubernetes-engine/docs/how-to/managed-certs) in GKE.
+Upon obtaining the allocated IP address of the load balancer, you should create an A record for the `sourcegraph.company.com` domain. Finally, it is recommended to enable TLS and you may consider using [Google-managed certificate](https://cloud.google.com/kubernetes-engine/docs/how-to/managed-certs) in GKE.
 
 Upon creating the Google-managed certificate, you may add the following annotations to Ingress.
 
@@ -324,7 +326,9 @@ kubectl describe ingress sourcegraph-frontend
 
 You should create a DNS record for the `sourcegraph.company.com` domain that resolves to the Ingress public address.
 
-It is recommended to enable TLS and configure certificate properly on your Ingress. You are encouraged to utilize managed certificate solution provided by Cloud providers. Alternatively, you may consider configuring [cert-manager with Let's Encrypt](https://cert-manager.io/docs/configuration/acme/) in your cluster and add the following override to Ingress.
+It is recommended to enable TLS and configure certificate properly on your Ingress. You may utilize managed certificate solution provided by Cloud providers. 
+
+Alternatively, you may consider configuring [cert-manager with Let's Encrypt](https://cert-manager.io/docs/configuration/acme/) in your cluster and add the following override to Ingress.
 
 ```yaml
 frontend:
@@ -341,7 +345,7 @@ frontend:
     host: sourcegraph.company.com
 ```
 
-As a last resort, you may manually configure TLS certificate via [TLS Secrets](https://kubernetes.io/docs/concepts/configuration/secret/#tls-secrets).
+You also have the option to manually configure TLS certificate via [TLS Secrets](https://kubernetes.io/docs/concepts/configuration/secret/#tls-secrets).
 
 `sourcegraph-frontend-tls.Secret.yaml`
 ```yaml

--- a/doc/admin/install/kubernetes/helm.md
+++ b/doc/admin/install/kubernetes/helm.md
@@ -216,6 +216,8 @@ frontend:
 
 You need to have a AKS cluster (>=1.19) with the following addons enabled:
 
+> You may consider using your custom Ingress Controller instead of Application Gateway, [learn more](https://docs.microsoft.com/en-us/azure/aks/ingress-basic)
+
 - [x] [Azure Application Gateway Ingress Controller](https://docs.microsoft.com/en-us/azure/application-gateway/ingress-controller-install-new)
 - [x] [Azure Disk CSI driver](https://docs.microsoft.com/en-us/azure/aks/csi-storage-drivers)
 

--- a/doc/admin/install/kubernetes/helm.md
+++ b/doc/admin/install/kubernetes/helm.md
@@ -62,6 +62,8 @@ This section is aimed at providing high-level guidance on deploying Sourcegraph 
 
 You need to have a GKE cluster (>=1.19) with the following addons enabled:
 
+> Alternatively, you may consider using your custom Ingress Controller and disable `HTTP Load Balancing` add-on, [learn more](https://cloud.google.com/kubernetes-engine/docs/how-to/custom-ingress-controller).
+
 - [x] HTTP Load Balancing
 - [x] Compute Engine persistent disk CSI Driver
 
@@ -70,8 +72,6 @@ You account should have sufficient access equivalent to the `cluster-admin` Clus
 #### Steps
 
 > [Container-native load balancing] is only available on VPC-native cluster. For legacy clusters, [learn more](https://cloud.google.com/kubernetes-engine/docs/how-to/load-balance-ingress).
->
-> Alternatively, you may consider using your custom Ingress Controller, [learn more](https://cloud.google.com/kubernetes-engine/docs/how-to/custom-ingress-controller).
 
 Create an override file with the following value. We configure Ingress to use [Container-native load balancing] to expose Sourcegraph publically and Storage Class to use [Compute Engine persistent disk].
 

--- a/doc/admin/install/kubernetes/helm.md
+++ b/doc/admin/install/kubernetes/helm.md
@@ -23,7 +23,7 @@ helm install --version 0.7.0 sourcegraph sourcegraph/sourcegraph
 
 The Sourcegraph chart is highly customizable to support a wide range of environments. Please review the default values from [values.yaml](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/charts/sourcegraph/values.yaml) and all [supported options](https://github.com/sourcegraph/deploy-sourcegraph-helm/tree/main/charts/sourcegraph#configuration-options). Customizations can be applied using an override file. Using an override file allows customizations to persist through upgrades without needing to manage merge conflicts.
 
-To customize configuration settings with an override file, create an empty yaml file (e.g. `override.yaml`) and configure overrides.
+To customize configuration settings with an override file, create an empty yaml file (e.g. `override.yaml`) to get started.
 
 > WARNING: __DO NOT__ copy the [default values file](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/charts/sourcegraph/values.yaml) as a boilerplate for your override file. You risk having outdated values during upgrades.
 
@@ -49,11 +49,11 @@ __TODO__
 
 ### Cloud providers guides
 
-This section is aimed at providing high-level guidance on configuring Ingress and Storage Class for Sourcegraph deployment on major Cloud providers. In general, you need the following to get started:
+This section is aimed at providing high-level guidance on deploying Sourcegraph via Helm on major Cloud providers. In general, you need the following to get started:
 
 - A working Kubernetes cluster 1.19 and higher
-- The cluster should have Block Storage CSI storage drivers installed
-- The cluster should have Ingress Controller installed. We recommend the use of platform native ingress controller.
+- The ability to provision persistent volumes, e.g. Block Storage [CSI storage driver](https://kubernetes-csi.github.io/docs/drivers.html) is installed.
+- The cluster should have Ingress Controller installed, e.g. platform native ingress controller, [NGINX Ingress Controller].
 - You can have control over your `company.com` domain to create DNS records for Sourcegraph, e.g. `sourcegraph.company.com`
 
 #### Configure Sourcegraph on Google Kubernetes Engine (GKE)
@@ -281,7 +281,7 @@ frontend:
 
 You need to have a Kubernetes cluster (>=1.19) with the following components installed:
 
-- [x] Ingress Controller, e.g. Cloud providers-native solution, [NGINX Ingress Controller](https://github.com/kubernetes/ingress-nginx)
+- [x] Ingress Controller, e.g. Cloud providers-native solution, [NGINX Ingress Controller]
 - [x] Block Storage CSI driver
 
 You account should have sufficient access equivalent to the `cluster-admin` ClusterRole.
@@ -403,3 +403,4 @@ __TODO__
 [Compute Engine persistent disk]: https://cloud.google.com/kubernetes-engine/docs/how-to/persistent-volumes/gce-pd-csi-driver
 [AWS Load Balancer Controller]: https://docs.aws.amazon.com/eks/latest/userguide/aws-load-balancer-controller.html
 [AWS EBS CSI driver]: https://docs.aws.amazon.com/eks/latest/userguide/managing-ebs-csi.html
+[NGINX Ingress Controller]: https://github.com/kubernetes/ingress-nginx

--- a/doc/admin/install/kubernetes/helm.md
+++ b/doc/admin/install/kubernetes/helm.md
@@ -128,6 +128,19 @@ kubectl describe ingress sourcegraph-frontend
 
 Upon obtaining the allocated IP address of the load balancer, you should create an A record for the `sourcegraph.company.com` domain. Finally, it is recommended to enable TLS and you can learn more from about how to use [Google-managed certificate](https://cloud.google.com/kubernetes-engine/docs/how-to/managed-certs) in GKE.
 
+Upon creating the Google-managed certificate, you may add the following annotations to Ingress.
+
+```yaml
+frontend:
+  ingress:
+    annotations:
+      kubernetes.io/ingress.class: null
+      networking.gke.io/managed-certificates: managed-cert # replace with actual Google-managed certificate name
+      # if you reserve a static IP, uncomment below and update ADDRESS_NAME
+      # also, make changes to your DNS record accordingly
+      # kubernetes.io/ingress.global-static-ip-name: ADDRESS_NAME
+```
+
 #### Configure Sourcegraph on Elastic Kubernetes Service (EKS)
 
 #### Prerequisites

--- a/doc/admin/install/kubernetes/helm.md
+++ b/doc/admin/install/kubernetes/helm.md
@@ -32,11 +32,7 @@ Example overrides can be found in the [examples](https://github.com/sourcegraph/
 Provide the override file to helm:
 
 ```sh
-# Installation
-helm install --values ./override.yaml --version 0.7.0 sourcegraph sourcegraph/sourcegraph
-
-# Upgrade
-helm upgrade --values ./override.yaml --version 0.7.0 sourcegraph sourcegraph/sourcegraph
+helm upgrade --install --values ./override.yaml --version 0.7.0 sourcegraph sourcegraph/sourcegraph
 ```
 
 ### Using external PostgreSQL databases
@@ -53,14 +49,60 @@ __TODO__
 
 ### Cloud providers guides
 
+This section is aimed at providing high-level guidance on configuring Ingress and Storage Class for Sourcegraph deployment on major Cloud providers. In general, you need the following to get started:
+
+- A working Kubernetes cluster 1.19 and higher
+- The cluster should have Block Storage CSI storage drivers installed
+- The cluster should have Ingress Controller installed. We recommend the use of platform native ingress controller.
+- You can have control over your `company.com` domain to create DNS records for Sourcegraph, e.g. `sourcegraph.company.com`
+
 #### Configure Sourcegraph on Google Kubernetes Engine (GKE)
 
-You should include these suggested values in your override file, learn more from [override.yaml](https://github.com/sourcegraph/deploy-sourcegraph-helm/tree/main/charts/sourcegraph/examples/gcp/override.yaml).
+#### Prerequisites
 
-> Looking to enable TLS with Google-managed certificates? [learn more](https://cloud.google.com/kubernetes-engine/docs/how-to/managed-certs)
+You need to have a __public__ VPC-native GKE cluster (>=1.19) with the following addons enabled:
 
-In addition to the provided values, you need to deploy the [BackendConfig] CRD to properly expose Sourcegraph publically. The [BackendConfig] CR should be deployed in the same namespace where Sourcegraph chart is installed.
+- [x] HTTP Load Balancing
+- [x] Compute Engine persistent disk CSI Driver
 
+You account should have sufficient access equivalent to the `cluster-admin` ClusterRole.
+
+#### Steps
+
+Create an override file with the following value. We configure Ingress to use [Container-native load balancing] to expose Sourcegraph publically and Storage Class to use [Compute Engine persistent disk].
+
+[override.yaml](https://github.com/sourcegraph/deploy-sourcegraph-helm/tree/main/charts/sourcegraph/examples/gcp/override.yaml)
+```yaml
+frontend:
+  serviceType: ClusterIP
+  ingress:
+    enabled: true
+    annotations:
+      kubernetes.io/ingress.class: null
+    ingressClassName: gce
+    host: sourcegraph.company.com # Replace with your actual domain
+  serviceAnnotations:
+    cloud.google.com/neg: '{"ingress": true}'
+    # reference the `BackendConfig` CR we will be configuring at a later step
+    beta.cloud.google.com/backend-config: '{"default": "sourcegraph-frontend"}'
+
+storageClass:
+  create: true
+  type: pd-ssd # This configures SSDs (recommended).
+  provisioner: pd.csi.storage.gke.io
+  volumeBindingMode: WaitForFirstConsumer
+  reclaimPolicy: Retain
+```
+
+Install the chart
+
+```sh
+helm upgrade --install --values ./override.yaml --version 0.7.0 sourcegraph sourcegraph/sourcegraph
+```
+
+You need to deploy the [BackendConfig] CRD to properly expose Sourcegraph publically. The [BackendConfig] CR should be deployed in the same namespace where Sourcegraph chart is installed.
+
+[sourcegraph-frontend.BackendConfig.yaml](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/michael/improve-gcp-example/charts/sourcegraph/examples/gcp/sourcegraph-frontend.BackendConfig.yaml)
 ```yaml
 apiVersion: cloud.google.com/v1
 kind: BackendConfig
@@ -73,6 +115,18 @@ spec:
     requestPath: /ready
     port: 6060 # we use a custom port to perform healthcheck
 ```
+
+```sh
+kubectl apply -f sourcegraph-frontend.BackendConfig.yaml
+```
+
+It will take around 10 mintues for the load balancer to be fully ready, you may check on the status and obtain the load balancer IP:
+
+```sh
+kubectl describe ingress sourcegraph-frontend
+```
+
+Upon obtaining the allocated IP address of the load balancer, you should create an A record for the `sourcegraph.company.com` domain. Finally, it is recommended to enable TLS and you can learn more from about how to use [Google-managed certificate](https://cloud.google.com/kubernetes-engine/docs/how-to/managed-certs) in GKE.
 
 #### Configure Sourcegraph on Elastic Kubernetes Service (EKS)
 
@@ -149,3 +203,5 @@ __TODO__
 
 [backendconfig]: https://cloud.google.com/kubernetes-engine/docs/how-to/ingress-features#create_backendconfig
 [azure application gateway]: https://docs.microsoft.com/en-us/azure/application-gateway/overview
+[Container-native load balancing]: https://cloud.google.com/kubernetes-engine/docs/how-to/container-native-load-balancing
+[Compute Engine persistent disk]: https://cloud.google.com/kubernetes-engine/docs/how-to/persistent-volumes/gce-pd-csi-driver

--- a/doc/admin/install/kubernetes/helm.md
+++ b/doc/admin/install/kubernetes/helm.md
@@ -69,7 +69,9 @@ You account should have sufficient access equivalent to the `cluster-admin` Clus
 
 #### Steps
 
-> [Container-native load balancing] is only available on VPC-native cluster. For legacy clusters, [learn more](https://cloud.google.com/kubernetes-engine/docs/how-to/load-balance-ingress)
+> [Container-native load balancing] is only available on VPC-native cluster. For legacy clusters, [learn more](https://cloud.google.com/kubernetes-engine/docs/how-to/load-balance-ingress).
+>
+> Alternatively, you may consider using your custom Ingress Controller, [learn more](https://cloud.google.com/kubernetes-engine/docs/how-to/custom-ingress-controller).
 
 Create an override file with the following value. We configure Ingress to use [Container-native load balancing] to expose Sourcegraph publically and Storage Class to use [Compute Engine persistent disk].
 

--- a/doc/admin/install/kubernetes/helm.md
+++ b/doc/admin/install/kubernetes/helm.md
@@ -51,7 +51,52 @@ Follow [using your own Redis](https://github.com/sourcegraph/deploy-sourcegraph-
 
 ### Using external Object Storage
 
-__TODO__
+To use external Object Storage service (S3-compatible services, or GCS), first review our [general recommendations](https://docs.sourcegraph.com/admin/external_services/object_storage). Then you may come back to add the following values to your override file.
+
+Prior to installing the chart, you should store these sensitive environment variables in [Secrets](https://kubernetes.io/docs/concepts/configuration/secret/).
+
+> The example override assumes the use of AWS S3. You may configure the environment variables accordingly for your own use case based on our [general recommendations](https://docs.sourcegraph.com/admin/external_services/object_storage).
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: sourcegraph-s3-credentials
+data:
+  # notes: secrets data has to be base64-encoded
+  PRECISE_CODE_INTEL_UPLOAD_AWS_ACCESS_KEY_ID: ""
+  PRECISE_CODE_INTEL_UPLOAD_AWS_SECRET_ACCESS_KEY: ""
+```
+
+[override.yaml](https://github.com/sourcegraph/deploy-sourcegraph-helm/tree/main/charts/sourcegraph/examples/external-object-storage/override.yaml)
+```yaml
+# we use YAML anchors and alias to keep override file clean
+objectStorageEnv: &objectStorageEnv
+  PRECISE_CODE_INTEL_UPLOAD_BACKEND:
+    value: S3 # external object stoage type, one of "S3" or "GCS"
+  PRECISE_CODE_INTEL_UPLOAD_BUCKET:
+    value: lsif-uploads # external object storage bucket name
+  PRECISE_CODE_INTEL_UPLOAD_AWS_ENDPOINT:
+    value: https://s3.us-east-1.amazonaws.com
+  PRECISE_CODE_INTEL_UPLOAD_AWS_REGION:
+    value: us-east-1
+  PRECISE_CODE_INTEL_UPLOAD_AWS_ACCESS_KEY_ID:
+    secretKeyRef: # Pre-existing secret, not created by this chart
+      name: sourcegraph-s3-credentials
+      key: PRECISE_CODE_INTEL_UPLOAD_AWS_ACCESS_KEY_ID
+  PRECISE_CODE_INTEL_UPLOAD_AWS_SECRET_ACCESS_KEY:
+    secretKeyRef: # Pre-existing secret, not created by this chart
+      name: sourcegraph-s3-credentials
+      key: PRECISE_CODE_INTEL_UPLOAD_AWS_SECRET_ACCESS_KEY
+
+frontend:
+  env:
+    <<: *objectStorageEnv
+
+preciseCodeIntel:
+  env:
+    <<: *objectStorageEnv
+```
 
 ### Cloud providers guides
 

--- a/doc/admin/install/kubernetes/helm.md
+++ b/doc/admin/install/kubernetes/helm.md
@@ -7,7 +7,7 @@
 
 ## Quickstart
 
-To use the Helm chart, add Sourcegraph helm repository:
+To use the Helm chart, add the Sourcegraph helm repository:
  
 ```sh
 helm repo add sourcegraph https://sourcegraph.github.io/deploy-sourcegraph-helm/
@@ -67,13 +67,13 @@ You need to have a GKE cluster (>=1.19) with the following addons enabled:
 - [x] HTTP Load Balancing
 - [x] Compute Engine persistent disk CSI Driver
 
-You account should have sufficient access equivalent to the `cluster-admin` ClusterRole.
+Your account should have sufficient access equivalent to the `cluster-admin` ClusterRole.
 
 #### Steps
 
 > [Container-native load balancing] is only available on VPC-native cluster. For legacy clusters, [learn more](https://cloud.google.com/kubernetes-engine/docs/how-to/load-balance-ingress).
 
-Create an override file with the following value. We configure Ingress to use [Container-native load balancing] to expose Sourcegraph publically and Storage Class to use [Compute Engine persistent disk].
+Create an override file with the following values. We configure Ingress to use [Container-native load balancing] to expose Sourcegraph publicly on a domain of your choosing and Storage Class to use [Compute Engine persistent disk].
 
 [override.yaml](https://github.com/sourcegraph/deploy-sourcegraph-helm/tree/main/charts/sourcegraph/examples/gcp/override.yaml)
 ```yaml
@@ -104,7 +104,7 @@ Install the chart
 helm upgrade --install --values ./override.yaml --version 0.7.0 sourcegraph sourcegraph/sourcegraph
 ```
 
-You need to deploy the [BackendConfig] CRD to properly expose Sourcegraph publically. The [BackendConfig] CR should be deployed in the same namespace where Sourcegraph chart is installed.
+You need to deploy the [BackendConfig] CRD to properly expose Sourcegraph publicly. The [BackendConfig] CR should be deployed in the same namespace where the Sourcegraph chart is installed.
 
 [sourcegraph-frontend.BackendConfig.yaml](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/michael/improve-gcp-example/charts/sourcegraph/examples/gcp/sourcegraph-frontend.BackendConfig.yaml)
 ```yaml
@@ -124,7 +124,7 @@ spec:
 kubectl apply -f sourcegraph-frontend.BackendConfig.yaml
 ```
 
-It will take around 10 mintues for the load balancer to be fully ready, you may check on the status and obtain the load balancer IP:
+It will take around 10 minutes for the load balancer to be fully ready, you may check on the status and obtain the load balancer IP:
 
 ```sh
 kubectl describe ingress sourcegraph-frontend
@@ -156,11 +156,11 @@ You need to have a EKS cluster (>=1.19) with the following addons enabled:
 - [x] [AWS Load Balancer Controller]
 - [x] [AWS EBS CSI driver]
 
-You account should have sufficient access equivalent to the `cluster-admin` ClusterRole.
+Your account should have sufficient access equivalent to the `cluster-admin` ClusterRole.
 
 #### Steps
 
-Create an override file with the following value. We configure Ingress to use [AWS Load Balancer Controller] to expose Sourcegraph publically and Storage Class to use [AWS EBS CSI driver].
+Create an override file with the following values. We configure Ingress to use [AWS Load Balancer Controller] to expose Sourcegraph publicly on a domain of your choosing and Storage Class to use [AWS EBS CSI driver].
 
 [override.yaml](https://github.com/sourcegraph/deploy-sourcegraph-helm/tree/main/charts/sourcegraph/examples/aws/override.yaml)
 ```yaml
@@ -223,11 +223,11 @@ You need to have a AKS cluster (>=1.19) with the following addons enabled:
 - [x] [Azure Application Gateway Ingress Controller](https://docs.microsoft.com/en-us/azure/application-gateway/ingress-controller-install-new)
 - [x] [Azure Disk CSI driver](https://docs.microsoft.com/en-us/azure/aks/csi-storage-drivers)
 
-You account should have sufficient access equivalent to the `cluster-admin` ClusterRole.
+Your account should have sufficient access equivalent to the `cluster-admin` ClusterRole.
 
 #### Steps
 
-Create an override file with the following value. We configure Ingress to use [Application Gateway](https://azure.microsoft.com/en-us/services/application-gateway) to expose Sourcegraph publically and Storage Class to use [Azure Disk CSI driver](https://docs.microsoft.com/en-us/azure/aks/azure-disk-csi).
+Create an override file with the following values. We configure Ingress to use [Application Gateway](https://azure.microsoft.com/en-us/services/application-gateway) to expose Sourcegraph publicly on a domain of your choosing and Storage Class to use [Azure Disk CSI driver](https://docs.microsoft.com/en-us/azure/aks/azure-disk-csi).
 
 [override.yaml](https://github.com/sourcegraph/deploy-sourcegraph-helm/tree/main/charts/sourcegraph/examples/azure/override.yaml)
 ```yaml
@@ -292,7 +292,7 @@ You need to have a Kubernetes cluster (>=1.19) with the following components ins
 - [x] Ingress Controller, e.g. Cloud providers-native solution, [NGINX Ingress Controller]
 - [x] Block Storage CSI driver
 
-You account should have sufficient access equivalent to the `cluster-admin` ClusterRole.
+Your account should have sufficient access equivalent to the `cluster-admin` ClusterRole.
 
 #### Steps
 

--- a/doc/admin/install/kubernetes/helm.md
+++ b/doc/admin/install/kubernetes/helm.md
@@ -160,7 +160,7 @@ preciseCodeIntel:
     <<: *objectStorageEnv
 ```
 
-### Cloud providers guides
+## Cloud providers guides
 
 This section is aimed at providing high-level guidance on deploying Sourcegraph via Helm on major Cloud providers. In general, you need the following to get started:
 
@@ -169,7 +169,7 @@ This section is aimed at providing high-level guidance on deploying Sourcegraph 
 - The cluster should have Ingress Controller installed, e.g. platform native ingress controller, [NGINX Ingress Controller].
 - You can have control over your `company.com` domain to create DNS records for Sourcegraph, e.g. `sourcegraph.company.com`
 
-#### Configure Sourcegraph on Google Kubernetes Engine (GKE)
+### Configure Sourcegraph on Google Kubernetes Engine (GKE)
 
 #### Prerequisites
 
@@ -258,7 +258,7 @@ frontend:
       # kubernetes.io/ingress.global-static-ip-name: ADDRESS_NAME
 ```
 
-#### Configure Sourcegraph on Elastic Kubernetes Service (EKS)
+### Configure Sourcegraph on Elastic Kubernetes Service (EKS)
 
 #### Prerequisites
 
@@ -325,7 +325,7 @@ frontend:
 - [Enable TLS with AWS-managed certificate](https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.2/guide/ingress/annotations/#ssl)
 - [Supported AWS load balancer annotations](https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.2/guide/ingress/annotations)
 
-#### Configure Sourcegraph on Azure Managed Kubernetes Service (AKS)
+### Configure Sourcegraph on Azure Managed Kubernetes Service (AKS)
 
 #### Prerequisites
 
@@ -396,7 +396,7 @@ frontend:
 - [What is Application Gateway Ingress Controller?](https://docs.microsoft.com/en-us/azure/application-gateway/ingress-controller-overview)
 
 
-#### Configure Sourcegraph on other Cloud providers or on-prem
+### Configure Sourcegraph on other Cloud providers or on-prem
 
 #### Prerequisites
 
@@ -500,9 +500,9 @@ frontend:
     host: sourcegraph.company.com
 ```
 
-### Advanced configuration
+## Advanced configuration
 
-#### Integrate Kustomize with Helm chart
+### Integrate Kustomize with Helm chart
 
 The Helm chart is new and still under active development, and we may not cover all of your use cases. 
 
@@ -512,7 +512,7 @@ For advanced users who are looking for a temporary workaround, we __recommend__ 
 
 You can learn more about how to integrate Kustomize with Helm from our [example](https://github.com/sourcegraph/deploy-sourcegraph-helm/tree/main/charts/sourcegraph/examples/kustomize-chart).
 
-#### Sub-chart
+### Sub-chart
 
 __TODO__
 

--- a/doc/admin/install/kubernetes/helm.md
+++ b/doc/admin/install/kubernetes/helm.md
@@ -37,7 +37,69 @@ helm upgrade --install --values ./override.yaml --version 0.7.0 sourcegraph sour
 
 ### Using external PostgreSQL databases
 
-__TODO__
+To use external PostgreSQL databases, first review our [general recommendations](https://docs.sourcegraph.com/admin/external_services/postgres#using-your-own-postgresql-server) and [required postgres permissions](https://docs.sourcegraph.com/admin/external_services/postgres#postgres-permissions-and-database-migrations). Then you may come back to add the following values to your override file.
+
+Prior to installing the chart, you should store these sensitive environment variables in [Secrets](https://kubernetes.io/docs/concepts/configuration/secret/).
+
+`pgsql-credentials.Secret.yaml`
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: sourcegraph-pgsql-credentials
+data:
+  # notes: secrets data has to be base64-encoded
+  PGPASSWORD: ""
+```
+
+`codeintel-db-credentials.Secret.yaml`
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: sourcegraph-codeintel-db-credentials
+data:
+  # notes: secrets data has to be base64-encoded
+  CODEINTEL_PGPASSWORD: ""
+```
+
+[override.yaml](https://github.com/sourcegraph/deploy-sourcegraph-helm/tree/main/charts/sourcegraph/examples/external-databases/override.yaml)
+```yaml
+frontend:
+  env:
+    PGHOST:
+      value: pgsql.database.company.com # external pgsql host
+    PGPORT:
+      value: "5432" # external pgsql port
+    PGDATABASE:
+      value: sg # external pgsql database name
+    PGUSER:
+      value: sg # external pgsql user
+    PGPASSWORD:
+      valueFrom:
+        secretKeyRef: # Pre-existing secret, not created by this chart
+          name: sourcegraph-pgsql-credentials
+          key: PGPASSWORD
+    CODEINTEL_PGHOST:
+      value: codeintel-db.database.company.com # external codeintel-db host
+    CODEINTEL_PGPORT:
+      value: "5432" # external codeintel-db port
+    CODEINTEL_PGDATABASE:
+      value: sg # external codeintel-db database name
+    CODEINTEL_PGUSER:
+      value: sg # external codeintel-db user
+    CODEINTEL_PGPASSWORD:
+      valueFrom:
+        secretKeyRef: # Pre-existing secret, not created by this chart
+          name: sourcegraph-codeintel-db-credentials
+          key: CODEINTEL_PGPASSWORD
+
+pgsql:
+  enabled: false # disable internal pgsql database
+
+codeIntelDB:
+  enabled: false # disable internal codeintel-db database
+```
 
 ### Using external Redis instances
 

--- a/doc/admin/install/kubernetes/index.md
+++ b/doc/admin/install/kubernetes/index.md
@@ -16,8 +16,6 @@ Not sure if Kubernetes is the right choice for you? Learn more about the various
 
 ## Installation
 
-> NOTE: We recently launched beta support for deploying Sourcegraph with Helm chart. [Give it a try](./helm.md)! 🎉
-
 Before you get started, we recommend [learning about how Sourcegraph with Kubernetes works](#about).
 
 Additionally, we recommend reading the [configuration guide](configure.md#getting-started), ensuring you have prepared the items below so that you're ready to start your installation:

--- a/doc/admin/install/kubernetes/index.md
+++ b/doc/admin/install/kubernetes/index.md
@@ -16,6 +16,8 @@ Not sure if Kubernetes is the right choice for you? Learn more about the various
 
 ## Installation
 
+> NOTE: We recently launched beta support for deploying Sourcegraph with Helm chart. [Give it a try](./helm.md)! 🎉
+
 Before you get started, we recommend [learning about how Sourcegraph with Kubernetes works](#about).
 
 Additionally, we recommend reading the [configuration guide](configure.md#getting-started), ensuring you have prepared the items below so that you're ready to start your installation:

--- a/doc/dev/background-information/index.md
+++ b/doc/dev/background-information/index.md
@@ -71,3 +71,4 @@
 
 - [Telemetry](telemetry.md)
 - [Adding, changing and debugging pings](adding_ping_data.md)
+- [Deploy Sourcegraph with Helm chart (BETA)](../../admin/install/kubernetes/helm.md)


### PR DESCRIPTION
"dark launch" helm docs

extracted from https://github.com/sourcegraph/sourcegraph/pull/32463

this PR focuses on enabling prospects to deploy Sourcegraph on one of the major cloud providers. I try to include the right amount of detail (I think) without being too specific that we will have a hard time keeping up with upstream changes.

it pretty much translates the "Configure a storage class" and "Configure network access" sections from https://docs.sourcegraph.com/admin/install/kubernetes/configure and combine them together (group by cloud vendor instead of topics).

In future PR, we should try to add more advanced configuration, e.g. using external databases

## Notes

Some referenced files won't be available until below PR is merged

- [ ] https://github.com/sourcegraph/deploy-sourcegraph-helm/pull/81

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


It docs