### PR TITLE
search: Zoekt query generation does not depend on pattern info

### DIFF
--- a/internal/search/job/job.go
+++ b/internal/search/job/job.go
@@ -101,7 +101,7 @@ func ToSearchJob(jargs *Args, q query.Q, db database.DB) (Job, error) {
 
 			if resultTypes.Has(result.TypeFile | result.TypePath) {
 				typ := search.TextRequest
-				zoektQuery, err := search.QueryToZoektQuery(b, patternInfo, &features, typ)
+				zoektQuery, err := search.QueryToZoektQuery(b, resultTypes, &features, typ)
 				if err != nil {
 					return nil, err
 				}
@@ -131,7 +131,7 @@ func ToSearchJob(jargs *Args, q query.Q, db database.DB) (Job, error) {
 
 			if resultTypes.Has(result.TypeSymbol) {
 				typ := search.SymbolRequest
-				zoektQuery, err := search.QueryToZoektQuery(b, patternInfo, &features, typ)
+				zoektQuery, err := search.QueryToZoektQuery(b, resultTypes, &features, typ)
 				if err != nil {
 					return nil, err
 				}
@@ -160,7 +160,7 @@ func ToSearchJob(jargs *Args, q query.Q, db database.DB) (Job, error) {
 			var textSearchJobs []Job
 			typ := search.TextRequest
 			if !onlyRunSearcher {
-				zoektQuery, err := search.QueryToZoektQuery(b, patternInfo, &features, typ)
+				zoektQuery, err := search.QueryToZoektQuery(b, resultTypes, &features, typ)
 				if err != nil {
 					return nil, err
 				}
@@ -194,7 +194,7 @@ func ToSearchJob(jargs *Args, q query.Q, db database.DB) (Job, error) {
 			typ := search.SymbolRequest
 
 			if !onlyRunSearcher {
-				zoektQuery, err := search.QueryToZoektQuery(b, patternInfo, &features, typ)
+				zoektQuery, err := search.QueryToZoektQuery(b, resultTypes, &features, typ)
 				if err != nil {
 					return nil, err
 				}
@@ -244,7 +244,7 @@ func ToSearchJob(jargs *Args, q query.Q, db database.DB) (Job, error) {
 
 		if jargs.SearchInputs.PatternType == query.SearchTypeStructural && b.PatternString() != "" {
 			typ := search.TextRequest
-			zoektQuery, err := search.QueryToZoektQuery(b, patternInfo, &features, typ)
+			zoektQuery, err := search.QueryToZoektQuery(b, resultTypes, &features, typ)
 			if err != nil {
 				return nil, err
 			}

--- a/internal/search/job/job.go
+++ b/internal/search/job/job.go
@@ -101,7 +101,7 @@ func ToSearchJob(jargs *Args, q query.Q, db database.DB) (Job, error) {
 
 			if resultTypes.Has(result.TypeFile | result.TypePath) {
 				typ := search.TextRequest
-				zoektQuery, err := search.QueryToZoektQuery(patternInfo, &features, typ)
+				zoektQuery, err := search.QueryToZoektQuery(b, patternInfo, &features, typ)
 				if err != nil {
 					return nil, err
 				}
@@ -131,7 +131,7 @@ func ToSearchJob(jargs *Args, q query.Q, db database.DB) (Job, error) {
 
 			if resultTypes.Has(result.TypeSymbol) {
 				typ := search.SymbolRequest
-				zoektQuery, err := search.QueryToZoektQuery(patternInfo, &features, typ)
+				zoektQuery, err := search.QueryToZoektQuery(b, patternInfo, &features, typ)
 				if err != nil {
 					return nil, err
 				}
@@ -160,7 +160,7 @@ func ToSearchJob(jargs *Args, q query.Q, db database.DB) (Job, error) {
 			var textSearchJobs []Job
 			typ := search.TextRequest
 			if !onlyRunSearcher {
-				zoektQuery, err := search.QueryToZoektQuery(patternInfo, &features, typ)
+				zoektQuery, err := search.QueryToZoektQuery(b, patternInfo, &features, typ)
 				if err != nil {
 					return nil, err
 				}
@@ -194,7 +194,7 @@ func ToSearchJob(jargs *Args, q query.Q, db database.DB) (Job, error) {
 			typ := search.SymbolRequest
 
 			if !onlyRunSearcher {
-				zoektQuery, err := search.QueryToZoektQuery(patternInfo, &features, typ)
+				zoektQuery, err := search.QueryToZoektQuery(b, patternInfo, &features, typ)
 				if err != nil {
 					return nil, err
 				}
@@ -244,7 +244,7 @@ func ToSearchJob(jargs *Args, q query.Q, db database.DB) (Job, error) {
 
 		if jargs.SearchInputs.PatternType == query.SearchTypeStructural && b.PatternString() != "" {
 			typ := search.TextRequest
-			zoektQuery, err := search.QueryToZoektQuery(patternInfo, &features, typ)
+			zoektQuery, err := search.QueryToZoektQuery(b, patternInfo, &features, typ)
 			if err != nil {
 				return nil, err
 			}

--- a/internal/search/job/printers_test.go
+++ b/internal/search/job/printers_test.go
@@ -410,5 +410,5 @@ func TestPrettyJSON(t *testing.T) {
       }
     }
   ]
-}`).Equal(t, fmt.Sprintf("\n%s", test("repo:foo bar")))
+}`).Equal(t, fmt.Sprintf("\n%s", test("repo:foo ba.*r")))
 }

--- a/internal/search/job/printers_test.go
+++ b/internal/search/job/printers_test.go
@@ -410,5 +410,5 @@ func TestPrettyJSON(t *testing.T) {
       }
     }
   ]
-}`).Equal(t, fmt.Sprintf("\n%s", test("repo:foo ba.*r")))
+}`).Equal(t, fmt.Sprintf("\n%s", test("repo:foo bar")))
 }

--- a/internal/search/query_converter.go
+++ b/internal/search/query_converter.go
@@ -237,9 +237,10 @@ func toZoektPattern(expression query.Node, isCaseSensitive, patternMatchesConten
 		case query.Pattern:
 			var q zoekt.Q
 			var err error
+			fileNameOnly := patternMatchesPath && !patternMatchesContent
+			contentOnly := !patternMatchesPath && patternMatchesContent
+
 			if n.Annotation.Labels.IsSet(query.Regexp) {
-				fileNameOnly := patternMatchesPath && !patternMatchesContent
-				contentOnly := !patternMatchesPath && patternMatchesContent
 				q, err = parseRe(n.Value, fileNameOnly, contentOnly, isCaseSensitive)
 				if err != nil {
 					return nil, err
@@ -249,8 +250,8 @@ func toZoektPattern(expression query.Node, isCaseSensitive, patternMatchesConten
 					Pattern:       regexp.QuoteMeta(n.Value),
 					CaseSensitive: isCaseSensitive,
 
-					FileName: true,
-					Content:  true,
+					FileName: fileNameOnly,
+					Content:  contentOnly,
 				}
 			}
 
@@ -302,7 +303,9 @@ func QueryToZoektQuery(b query.Basic, resultTypes result.Types, feat *Features, 
 	}
 
 	var and []zoekt.Q
-	and = append(and, q)
+	if q != nil {
+		and = append(and, q)
+	}
 
 	// zoekt also uses regular expressions for file paths
 	// TODO PathPatternsAreCaseSensitive

--- a/internal/search/query_converter.go
+++ b/internal/search/query_converter.go
@@ -240,19 +240,14 @@ func toZoektPattern(expression query.Node, isCaseSensitive, patternMatchesConten
 			fileNameOnly := patternMatchesPath && !patternMatchesContent
 			contentOnly := !patternMatchesPath && patternMatchesContent
 
-			if n.Annotation.Labels.IsSet(query.Regexp) {
-				q, err = parseRe(n.Value, fileNameOnly, contentOnly, isCaseSensitive)
-				if err != nil {
-					return nil, err
-				}
-			} else {
-				q = &zoekt.Substring{
-					Pattern:       regexp.QuoteMeta(n.Value),
-					CaseSensitive: isCaseSensitive,
+			pattern := n.Value
+			if n.Annotation.Labels.IsSet(query.Literal) {
+				pattern = regexp.QuoteMeta(pattern)
+			}
 
-					FileName: fileNameOnly,
-					Content:  contentOnly,
-				}
+			q, err = parseRe(pattern, fileNameOnly, contentOnly, isCaseSensitive)
+			if err != nil {
+				return nil, err
 			}
 
 			if n.Negated {

--- a/internal/search/query_converter_test.go
+++ b/internal/search/query_converter_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hexops/autogold"
 
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
+	"github.com/sourcegraph/sourcegraph/internal/search/result"
 
 	zoekt "github.com/google/zoekt/query"
 )
@@ -197,7 +198,8 @@ func TestQueryToZoektQuery(t *testing.T) {
 			if err != nil {
 				t.Fatalf("failed to parse %q: %v", tt.Query, err)
 			}
-			got, err := QueryToZoektQuery(tt.Pattern, &tt.Features, tt.Type)
+			resultTypes = result.TypeFile | result.TypePath | result.TypeRepo
+			got, err := QueryToZoektQuery("" /*FIXME*/, resultTypes, &tt.Features, tt.Type)
 			if err != nil {
 				t.Fatal("queryToZoektQuery failed:", err)
 			}

--- a/internal/search/query_converter_test.go
+++ b/internal/search/query_converter_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/hexops/autogold"
 
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
-	"github.com/sourcegraph/sourcegraph/internal/search/result"
 
 	zoekt "github.com/google/zoekt/query"
 )
@@ -17,194 +16,111 @@ func TestQueryToZoektQuery(t *testing.T) {
 	cases := []struct {
 		Name     string
 		Type     IndexedRequestType
-		Pattern  *TextPatternInfo
+		Pattern  string
 		Features Features
 		Query    string
 	}{
 		{
-			Name: "substr",
-			Type: TextRequest,
-			Pattern: &TextPatternInfo{
-				IsRegExp:                     true,
-				IsCaseSensitive:              false,
-				Pattern:                      "foo",
-				IncludePatterns:              nil,
-				ExcludePattern:               "",
-				PathPatternsAreCaseSensitive: false,
-			},
-			Query: "foo case:no",
+			Name:    "substr",
+			Type:    TextRequest,
+			Pattern: `foo patterntype:regexp`,
+			Query:   "foo case:no",
 		},
 		{
-			Name: "symbol substr",
-			Type: SymbolRequest,
-			Pattern: &TextPatternInfo{
-				IsRegExp:                     true,
-				IsCaseSensitive:              false,
-				Pattern:                      "foo",
-				IncludePatterns:              nil,
-				ExcludePattern:               "",
-				PathPatternsAreCaseSensitive: false,
-			},
-			Query: "sym:foo case:no",
+			Name:    "symbol substr",
+			Type:    SymbolRequest,
+			Pattern: `foo patterntype:regexp type:symbol`,
+			Query:   "sym:foo case:no",
 		},
 		{
-			Name: "regex",
-			Type: TextRequest,
-			Pattern: &TextPatternInfo{
-				IsRegExp:                     true,
-				IsCaseSensitive:              false,
-				Pattern:                      "(foo).*?(bar)",
-				IncludePatterns:              nil,
-				ExcludePattern:               "",
-				PathPatternsAreCaseSensitive: false,
-			},
-			Query: "(foo).*?(bar) case:no",
+			Name:    "regex",
+			Type:    TextRequest,
+			Pattern: `(foo).*?(bar) patterntype:regexp`,
+			Query:   "(foo).*?(bar) case:no",
 		},
 		{
-			Name: "path",
-			Type: TextRequest,
-			Pattern: &TextPatternInfo{
-				IsRegExp:                     true,
-				IsCaseSensitive:              false,
-				Pattern:                      "foo",
-				IncludePatterns:              []string{`\.go$`, `\.yaml$`},
-				ExcludePattern:               `\bvendor\b`,
-				PathPatternsAreCaseSensitive: false,
-			},
-			Query: `foo case:no f:\.go$ f:\.yaml$ -f:\bvendor\b`,
+			Name:    "path",
+			Type:    TextRequest,
+			Pattern: `foo file:\.go$ file:\.yaml$ -file:\bvendor\b patterntype:regexp`,
+			Query:   `foo case:no f:\.go$ f:\.yaml$ -f:\bvendor\b`,
 		},
 		{
-			Name: "case",
-			Type: TextRequest,
-			Pattern: &TextPatternInfo{
-				IsRegExp:                     true,
-				IsCaseSensitive:              true,
-				Pattern:                      "foo",
-				IncludePatterns:              []string{`\.go$`, `yaml`},
-				ExcludePattern:               "",
-				PathPatternsAreCaseSensitive: true,
-			},
-			Query: `foo case:yes f:\.go$ f:yaml`,
+			Name:    "case",
+			Type:    TextRequest,
+			Pattern: `foo case:yes patterntype:regexp file:\.go$ file:yaml`,
+			Query:   `foo case:yes f:\.go$ f:yaml`,
 		},
 		{
-			Name: "casepath",
-			Type: TextRequest,
-			Pattern: &TextPatternInfo{
-				IsRegExp:                     true,
-				IsCaseSensitive:              true,
-				Pattern:                      "foo",
-				IncludePatterns:              []string{`\.go$`, `\.yaml$`},
-				ExcludePattern:               `\bvendor\b`,
-				PathPatternsAreCaseSensitive: true,
-			},
-			Query: `foo case:yes f:\.go$ f:\.yaml$ -f:\bvendor\b`,
+			Name:    "casepath",
+			Type:    TextRequest,
+			Pattern: `foo case:yes file:\.go$ file:\.yaml$ -file:\bvendor\b patterntype:regexp`,
+			Query:   `foo case:yes f:\.go$ f:\.yaml$ -f:\bvendor\b`,
 		},
 		{
-			Name: "path matches only",
-			Type: TextRequest,
-			Pattern: &TextPatternInfo{
-				IsRegExp:                     true,
-				IsCaseSensitive:              false,
-				Pattern:                      "test",
-				IncludePatterns:              []string{},
-				ExcludePattern:               ``,
-				PathPatternsAreCaseSensitive: true,
-				PatternMatchesContent:        false,
-				PatternMatchesPath:           true,
-			},
-			Query: `f:test`,
+			Name:    "path matches only",
+			Type:    TextRequest,
+			Pattern: `test type:path`,
+			Query:   `f:test`,
 		},
 		{
-			Name: "content matches only",
-			Type: TextRequest,
-			Pattern: &TextPatternInfo{
-				IsRegExp:                     true,
-				IsCaseSensitive:              false,
-				Pattern:                      "test",
-				IncludePatterns:              []string{},
-				ExcludePattern:               ``,
-				PathPatternsAreCaseSensitive: true,
-				PatternMatchesContent:        true,
-				PatternMatchesPath:           false,
-			},
-			Query: `c:test`,
+			Name:    "content matches only",
+			Type:    TextRequest,
+			Pattern: `test type:file patterntype:literal`,
+			Query:   `c:test`,
 		},
 		{
-			Name: "content and path matches 1",
-			Type: TextRequest,
-			Pattern: &TextPatternInfo{
-				IsRegExp:                     true,
-				IsCaseSensitive:              false,
-				Pattern:                      "test",
-				IncludePatterns:              []string{},
-				ExcludePattern:               ``,
-				PathPatternsAreCaseSensitive: true,
-				PatternMatchesContent:        true,
-				PatternMatchesPath:           true,
-			},
-			Query: `test`,
+			Name:    "content and path matches",
+			Type:    TextRequest,
+			Pattern: `test`,
+			Query:   `test`,
 		},
 		{
-			Name: "content and path matches 2",
-			Type: TextRequest,
-			Pattern: &TextPatternInfo{
-				IsRegExp:                     true,
-				IsCaseSensitive:              false,
-				Pattern:                      "test",
-				IncludePatterns:              []string{},
-				ExcludePattern:               ``,
-				PathPatternsAreCaseSensitive: true,
-				PatternMatchesContent:        false,
-				PatternMatchesPath:           false,
-			},
-			Query: `test`,
+			Name:    "repos must include",
+			Type:    TextRequest,
+			Pattern: `foo repohasfile:\.go$ repohasfile:\.yaml$ -repohasfile:\.java$ -repohasfile:\.xml$ patterntype:regexp`,
+			Query:   `foo (type:repo file:\.go$) (type:repo file:\.yaml$) -(type:repo file:\.java$) -(type:repo file:\.xml$)`,
 		},
 		{
-			Name: "repos must include",
-			Type: TextRequest,
-			Pattern: &TextPatternInfo{
-				IsRegExp:                     true,
-				Pattern:                      "foo",
-				FilePatternsReposMustInclude: []string{`\.go$`, `\.yaml$`},
-				FilePatternsReposMustExclude: []string{`\.java$`, `\.xml$`},
-			},
-			Query: `foo (type:repo file:\.go$) (type:repo file:\.yaml$) -(type:repo file:\.java$) -(type:repo file:\.xml$)`,
+			Name:    "Just file",
+			Type:    TextRequest,
+			Pattern: `file:\.go$`,
+			Query:   `file:"\\.go(?m:$)"`,
 		},
 		{
-			Name: "TextPatternInfo.Languages is ignored",
-			Type: TextRequest,
-			Pattern: &TextPatternInfo{
-				IncludePatterns: []string{`\.go$`},
-				Languages:       []string{"go"},
-			},
-			Query: `file:"\\.go(?m:$)"`,
+			Name:    "Languages is ignored",
+			Type:    TextRequest,
+			Pattern: `file:\.go$ lang:go`,
+			Query:   `file:"\\.go(?m:$)" file:"\\.go(?m:$)"`,
 		},
 		{
-			Name: "language gets passed as both file include and lang: predicate",
-			Type: TextRequest,
-			Pattern: &TextPatternInfo{
-				IncludePatterns: []string{`\.go$`},
-				Languages:       []string{"go"},
-			},
+			Name:    "language gets passed as both file include and lang: predicate",
+			Type:    TextRequest,
+			Pattern: `file:\.go$ lang:go`,
 			Features: Features{
 				ContentBasedLangFilters: true,
 			},
-			Query: `file:"\\.go(?m:$)" lang:Go`,
+			Query: `file:"\\.go(?m:$)" file:"\\.go(?m:$)" lang:Go`,
 		},
 	}
 	for _, tt := range cases {
 		t.Run(tt.Name, func(t *testing.T) {
-			q, err := zoekt.Parse(tt.Query)
+			sourceQuery, _ := query.ParseRegexp(tt.Pattern)
+			b, _ := query.ToBasicQuery(sourceQuery)
+
+			types, _ := b.ToParseTree().StringValues(query.FieldType)
+			resultTypes := ComputeResultTypes(types, b.PatternString(), query.SearchTypeRegex)
+			got, err := QueryToZoektQuery(b, resultTypes, &tt.Features, tt.Type)
+			if err != nil {
+				t.Fatal("QueryToZoektQuery failed:", err)
+			}
+
+			zoektQuery, err := zoekt.Parse(tt.Query)
 			if err != nil {
 				t.Fatalf("failed to parse %q: %v", tt.Query, err)
 			}
-			resultTypes = result.TypeFile | result.TypePath | result.TypeRepo
-			got, err := QueryToZoektQuery("" /*FIXME*/, resultTypes, &tt.Features, tt.Type)
-			if err != nil {
-				t.Fatal("queryToZoektQuery failed:", err)
-			}
-			if !queryEqual(got, q) {
-				t.Fatalf("mismatched queries\ngot  %s\nwant %s", got.String(), q.String())
+
+			if !queryEqual(got, zoektQuery) {
+				t.Fatalf("mismatched queries\ngot  %s\nwant %s", got.String(), zoektQuery.String())
 			}
 		})
 	}
@@ -486,7 +402,7 @@ func Test_toZoektPattern(t *testing.T) {
 		if err != nil {
 			return err.Error()
 		}
-		zoektQuery, err := toZoektPattern(b.Pattern, false, true, true)
+		zoektQuery, err := toZoektPattern(b.Pattern, false, false, true)
 		if err != nil {
 			return err.Error()
 		}

--- a/internal/search/run/repo_has_file.go
+++ b/internal/search/run/repo_has_file.go
@@ -80,7 +80,16 @@ func (s *RepoSearch) reposContainingPath(ctx context.Context, repos []*search.Re
 			return nil, err
 		}
 
-		zoektQuery, err := search.QueryToZoektQuery(b, newArgs.PatternInfo, &newArgs.Features, typ)
+		types, _ := q.StringValues(query.FieldType)
+		var resultTypes result.Types
+		if len(types) == 0 {
+			resultTypes = result.TypeFile | result.TypePath | result.TypeRepo
+		} else {
+			for _, t := range types {
+				resultTypes = resultTypes.With(result.TypeFromString[t])
+			}
+		}
+		zoektQuery, err := search.QueryToZoektQuery(b, resultTypes, &newArgs.Features, typ)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/search/run/repo_has_file.go
+++ b/internal/search/run/repo_has_file.go
@@ -74,7 +74,13 @@ func (s *RepoSearch) reposContainingPath(ctx context.Context, repos []*search.Re
 
 	if newArgs.Mode != search.SearcherOnly {
 		typ := search.TextRequest
-		zoektQuery, err := search.QueryToZoektQuery(newArgs.PatternInfo, &newArgs.Features, typ)
+
+		b, err := query.ToBasicQuery(q)
+		if err != nil {
+			return nil, err
+		}
+
+		zoektQuery, err := search.QueryToZoektQuery(b, newArgs.PatternInfo, &newArgs.Features, typ)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/search/textsearch/textsearch_test.go
+++ b/internal/search/textsearch/textsearch_test.go
@@ -441,8 +441,23 @@ func RunRepoSubsetTextSearch(
 	g, ctx := errgroup.WithContext(ctx)
 
 	if notSearcherOnly {
+		b, err := query.ToBasicQuery(q)
+		if err != nil {
+			return nil, streaming.Stats{}, err
+		}
+
+		types, _ := q.StringValues(query.FieldType)
+		var resultTypes result.Types
+		if len(types) == 0 {
+			resultTypes = result.TypeFile | result.TypePath | result.TypeRepo
+		} else {
+			for _, t := range types {
+				resultTypes = resultTypes.With(result.TypeFromString[t])
+			}
+		}
+
 		typ := search.TextRequest
-		zoektQuery, err := search.QueryToZoektQuery(patternInfo, nil, typ)
+		zoektQuery, err := search.QueryToZoektQuery(b, resultTypes, nil, typ)
 		if err != nil {
 			return nil, streaming.Stats{}, err
 		}

--- a/internal/search/zoekt/indexed_search_test.go
+++ b/internal/search/zoekt/indexed_search_test.go
@@ -271,7 +271,8 @@ func TestIndexedSearch(t *testing.T) {
 				Repos:  zoektRepos,
 			}
 
-			zoektQuery, err := search.QueryToZoektQuery(&search.TextPatternInfo{}, &search.Features{}, search.TextRequest)
+			var resultTypes result.Types
+			zoektQuery, err := search.QueryToZoektQuery(query.Basic{}, resultTypes, &search.Features{}, search.TextRequest)
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
Previously we created a Zoekt query from `PatternInfo`, which we created from the input query, and which was nested inside `TextPatternInfo`. With this PR, Zoekt queries are generated directly from Basic Sourcegraph queries. It's a huge victory (on a scale of 1 to 10, this is eleventy). The only caveat is I took a winding road to converge on the solution and preserve existing behavior. I could unwind things and make clean PRs, but instead my plan is to do a walkthrough of the code with Camden directly.

## Test plan
Updated existing tests. Semantics-preserving.
