### PR TITLE
[site-admin] Add feature flag override management to site admin

### DIFF
--- a/client/http-client/src/graphql/links/concurrent-requests-link.ts
+++ b/client/http-client/src/graphql/links/concurrent-requests-link.ts
@@ -1,4 +1,12 @@
-import { ApolloLink, FetchResult, NextLink, Operation, Observable, Observer } from '@apollo/client'
+import {
+    ApolloLink,
+    FetchResult,
+    NextLink,
+    Operation,
+    Observable,
+    Observer,
+    ObservableSubscription,
+} from '@apollo/client'
 
 import { ApolloContext } from '../types'
 
@@ -11,7 +19,7 @@ interface OperationQueueEntry {
     limit: number
     observable: Observable<FetchResult>
     observers: Observer<unknown>[]
-    currentSubscription?: ZenObservable.Subscription
+    currentSubscription?: ObservableSubscription
 }
 
 interface RequestGroupQueues {

--- a/client/web/src/codeintel/usePreciseCodeIntel.ts
+++ b/client/web/src/codeintel/usePreciseCodeIntel.ts
@@ -119,6 +119,7 @@ export const usePreciseCodeIntel = ({ variables }: UsePreciseCodeIntelParameters
     const fetchMoreReferences = (): void => {
         const cursor = referenceData?.references.pageInfo?.endCursor || null
 
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
         fetchAdditionalReferences({
             variables: {
                 ...variables,
@@ -130,6 +131,7 @@ export const usePreciseCodeIntel = ({ variables }: UsePreciseCodeIntelParameters
     const fetchMoreImplementations = (): void => {
         const cursor = referenceData?.implementations.pageInfo?.endCursor || null
 
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
         fetchAdditionalImplementations({
             variables: {
                 ...variables,

--- a/client/web/src/components/Collapsible.tsx
+++ b/client/web/src/components/Collapsible.tsx
@@ -17,7 +17,7 @@ interface Props {
     /**
      * Sub-content always visible in the title bar.
      */
-    detail?: string
+    detail?: string | React.ReactElement
 
     /**
      * Optional children that appear below the title bar that can be expanded/collapsed. If present,

--- a/client/web/src/enterprise/batches/create/useWorkspacesPreview.ts
+++ b/client/web/src/enterprise/batches/create/useWorkspacesPreview.ts
@@ -253,7 +253,9 @@ export const useWorkspacesPreview = (
             // We can stop polling once the workspace resolution completes.
             stop()
             // Fetch the results of the workspace preview resolution.
+            // eslint-disable-next-line @typescript-eslint/no-floating-promises
             fetchWorkspaces()
+            // eslint-disable-next-line @typescript-eslint/no-floating-promises
             fetchImportingChangesets()
             // Call the optional `onComplete` handler.
             onComplete?.()

--- a/client/web/src/org/members/SearchUserAutocomplete.tsx
+++ b/client/web/src/org/members/SearchUserAutocomplete.tsx
@@ -129,6 +129,7 @@ export const AutocompleteSearchUsers: React.FunctionComponent<AutocompleteSearch
     const searchUsers = useCallback(
         (query: string): void => {
             setOpenResults(true)
+            // eslint-disable-next-line @typescript-eslint/no-floating-promises
             getUsers({ variables: { query, organization: orgId } })
         },
         [getUsers, orgId]

--- a/client/web/src/org/openBeta/NewOrganizationPage.tsx
+++ b/client/web/src/org/openBeta/NewOrganizationPage.tsx
@@ -130,6 +130,7 @@ export const NewOrgOpenBetaPage: React.FunctionComponent<Props> = ({
         if (existId && isSuggested.current && orgId && !loadingOrg) {
             setDisplayBox(true)
             const autofixID = `${orgId}-1`
+            // eslint-disable-next-line @typescript-eslint/no-floating-promises
             tryGetOrg({ variables: { name: autofixID } })
             setOrgId(autofixID)
         }
@@ -140,6 +141,7 @@ export const NewOrgOpenBetaPage: React.FunctionComponent<Props> = ({
             const orgId = normalizeOrgId(event.currentTarget.value)
             setOrgId(orgId)
             setDisplayBox(false)
+            // eslint-disable-next-line @typescript-eslint/no-floating-promises
             debounceTryGetOrg.current({ variables: { name: orgId } })
         }
         setDisplayName(event.currentTarget.value)
@@ -150,6 +152,7 @@ export const NewOrgOpenBetaPage: React.FunctionComponent<Props> = ({
         const orgId = normalizeOrgId(event.currentTarget.value)
         setOrgId(orgId)
         setDisplayBox(false)
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
         debounceTryGetOrg.current({ variables: { name: orgId } })
     }
 

--- a/client/web/src/site-admin/SiteAdminFeatureFlagConfigurationPage.module.scss
+++ b/client/web/src/site-admin/SiteAdminFeatureFlagConfigurationPage.module.scss
@@ -7,3 +7,20 @@
         border-left: 1px solid var(--border-color-2);
     }
 }
+
+.feature-flag-override-list {
+    padding: 0px;
+
+    ul {
+        padding: 0px;
+        margin: 0px;
+
+        li {
+            &:first-child {
+                border-top: unset;
+            }
+
+            border-top: 1px solid var(--border-color-2);
+        }
+    }
+}

--- a/client/web/src/site-admin/SiteAdminFeatureFlagConfigurationPage.module.scss
+++ b/client/web/src/site-admin/SiteAdminFeatureFlagConfigurationPage.module.scss
@@ -9,11 +9,11 @@
 }
 
 .feature-flag-override-list {
-    padding: 0px;
+    padding: 0;
 
     ul {
-        padding: 0px;
-        margin: 0px;
+        padding: 0;
+        margin: 0;
 
         li {
             &:first-child {

--- a/client/web/src/site-admin/SiteAdminFeatureFlagConfigurationPage.tsx
+++ b/client/web/src/site-admin/SiteAdminFeatureFlagConfigurationPage.tsx
@@ -364,7 +364,7 @@ const AddFeatureFlagOverride: FunctionComponent<{
                     </Label>
                     <Input
                         className="mt-2"
-                        label="Namespace ID"
+                        label={`${overrideType} ID`}
                         type="number"
                         value={namespaceID}
                         onChange={setInputValue}

--- a/client/web/src/site-admin/SiteAdminFeatureFlagConfigurationPage.tsx
+++ b/client/web/src/site-admin/SiteAdminFeatureFlagConfigurationPage.tsx
@@ -532,8 +532,8 @@ const ManageFeatureFlag: FunctionComponent<{
 
     const updateOverride = useCallback(
         (index: number, value: boolean): void => {
-            if (overrides?.length > index) {
-                const newOverrides = overrides.slice()
+            if ((overrides?.length || -1) > index) {
+                const newOverrides = overrides?.slice() || []
                 newOverrides[index].value = value
                 onOverridesUpdate(newOverrides)
             }
@@ -543,8 +543,8 @@ const ManageFeatureFlag: FunctionComponent<{
 
     const deleteOverride = useCallback(
         (index: number): void => {
-            if (overrides?.length > index) {
-                const newOverrides = overrides.slice()
+            if ((overrides?.length || -1) > index) {
+                const newOverrides = overrides?.slice() || []
                 newOverrides?.splice(index, 1)
                 onOverridesUpdate(newOverrides)
             }

--- a/client/web/src/site-admin/SiteAdminFeatureFlagConfigurationPage.tsx
+++ b/client/web/src/site-admin/SiteAdminFeatureFlagConfigurationPage.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, useEffect, useMemo, useState } from 'react'
+import React, { FunctionComponent, useCallback, useEffect, useMemo, useState } from 'react'
 
 import { gql, useMutation } from '@apollo/client'
 import classNames from 'classnames'
@@ -8,13 +8,27 @@ import { of } from 'rxjs'
 import { catchError, map } from 'rxjs/operators'
 
 import { ErrorAlert } from '@sourcegraph/branded/src/components/alerts'
+import { Form } from '@sourcegraph/branded/src/components/Form'
 import { Toggle } from '@sourcegraph/branded/src/components/Toggle'
 import { asError, ErrorLike, isErrorLike, pluralize } from '@sourcegraph/common'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { PageTitle } from '@sourcegraph/web/src/components/PageTitle'
-import { Button, Container, Link, LoadingSpinner, PageHeader, Select, useObservable, Icon } from '@sourcegraph/wildcard'
+import {
+    Button,
+    Container,
+    Link,
+    LoadingSpinner,
+    PageHeader,
+    Select,
+    useObservable,
+    Icon,
+    Modal,
+    Input,
+    Label,
+} from '@sourcegraph/wildcard'
 
 import { Collapsible } from '../components/Collapsible'
+import { LoaderButton } from '../components/LoaderButton'
 
 import { fetchFeatureFlags as defaultFetchFeatureFlags } from './backend'
 import { getFeatureFlagReferences, parseProductReference } from './SiteAdminFeatureFlagsPage'
@@ -69,6 +83,13 @@ export const SiteAdminFeatureFlagConfigurationPage: FunctionComponent<SiteAdminF
             setOverrides(featureFlagOrError.overrides)
         }
     }, [featureFlagOrError])
+
+    const onOverridesUpdate = useCallback(
+        (overrides: FeatureFlagOverride[]) => {
+            setOverrides(overrides)
+        },
+        [setOverrides]
+    )
 
     // Set up mutations for creation or management of this feature flag.
     const [createFeatureFlag, { loading: createFlagLoading, error: createFlagError }] = useMutation(
@@ -131,6 +152,7 @@ export const SiteAdminFeatureFlagConfigurationPage: FunctionComponent<SiteAdminF
                 type={flagType}
                 value={flagValue}
                 overrides={flagOverrides}
+                onOverridesUpdate={onOverridesUpdate}
                 setFlagValue={setFlagValue}
             />
         )
@@ -230,6 +252,12 @@ interface FeatureFlagOverride {
     value: boolean
 }
 
+interface FeaturefFlagOverrideParsedID {
+    OrgID: number
+    UserID: number
+    FlagName: string
+}
+
 interface FeatureFlagBooleanValue {
     value: boolean
 }
@@ -238,7 +266,233 @@ interface FeatureFlagRolloutValue {
     rolloutBasisPoints: number
 }
 
+interface CreateFeatureFlagOverrideResult {
+    createFeatureFlagOverride: FeatureFlagOverride
+}
+interface CreateFeatureFlagOverrideVariables {
+    namespace: string
+    flagName: string
+    value: boolean
+}
+
 type FeatureFlagValue = FeatureFlagBooleanValue | FeatureFlagRolloutValue
+
+const AddFeatureFlagOverride: FunctionComponent<{
+    name: string
+    value: boolean
+    onOverrideAdded: (override: FeatureFlagOverride) => void
+}> = ({ name, value, onOverrideAdded }) => {
+    const [showAddOverride, setShowAddOverride] = useState<boolean>(false)
+    const [overrideValue, setOverrideValue] = useState<boolean>(!value)
+    const [userID, setUserID] = useState<number | string>('')
+    const [orgID, setOrgID] = useState<number | string>('')
+
+    const getBase64Namespace = useCallback((): string => {
+        if (userID > 0) {
+            return btoa(`User:${userID}`)
+        }
+        return btoa(`Org:${orgID}`)
+    }, [userID, orgID])
+
+    const [addOverride, { loading, error, reset }] = useMutation<
+        CreateFeatureFlagOverrideResult,
+        CreateFeatureFlagOverrideVariables
+    >(CREATE_FEATURE_FLAG_OVERRIDE_MUTATION, {
+        variables: {
+            namespace: getBase64Namespace(),
+            flagName: name,
+            value: overrideValue,
+        },
+        onCompleted: data => {
+            onOverrideAdded(data.createFeatureFlagOverride)
+            closeModal()
+        },
+    })
+
+    const closeModal = useCallback(() => {
+        setShowAddOverride(false)
+        setUserID('')
+        setOrgID('')
+        setOverrideValue(!value)
+        reset()
+    }, [setShowAddOverride, setUserID, setOrgID, setOverrideValue, value, reset])
+
+    const openModal = useCallback(
+        (event: React.MouseEvent<HTMLButtonElement>) => {
+            event.stopPropagation()
+            setShowAddOverride(true)
+        },
+        [setShowAddOverride]
+    )
+
+    const setInputValue = useCallback(
+        (
+            event: React.ChangeEvent<HTMLInputElement>,
+            setValue: React.Dispatch<React.SetStateAction<number | string>>
+        ) => {
+            const stringValue = event.target.value.trim()
+            if (stringValue !== '') {
+                setValue(Number(stringValue))
+            } else {
+                setValue('')
+            }
+        },
+        []
+    )
+
+    return (
+        <div>
+            <Modal isOpen={showAddOverride} onDismiss={closeModal} aria-label="Add Feature Flag Override Modal">
+                <h3>Add feature flag override for {name}</h3>
+                <Form>
+                    <div className="d-flex mt-4">
+                        <Input
+                            label="User ID"
+                            className="mr-2 mb-0"
+                            disabled={orgID > 0}
+                            type="number"
+                            value={userID}
+                            onChange={event => setInputValue(event, setUserID)}
+                        />
+                        <Input
+                            label="Organization ID"
+                            className="mb-0"
+                            disabled={userID > 0}
+                            type="number"
+                            value={orgID}
+                            onChange={event => setInputValue(event, setOrgID)}
+                        />
+                    </div>
+                    <div className="mb-3">
+                        <small>Fill either User ID or Organization ID, not both</small>
+                    </div>
+                    <Label className="w-100">
+                        <div className="mb-2">Value</div>
+                        <Toggle
+                            title="Value"
+                            value={overrideValue}
+                            disabled={false}
+                            onToggle={() => setOverrideValue(!overrideValue)}
+                            aria-describedby="add-feature-flag-override-value-toggle-description"
+                        />
+                        <span className="ml-1 text-capitalize">{Boolean(overrideValue).toString()}</span>
+                    </Label>
+                    {error && <ErrorAlert prefix="Error adding override" error={error} />}
+                    <div className="d-flex justify-content-end">
+                        <Button onClick={closeModal} variant="secondary" className="mr-2">
+                            Cancel
+                        </Button>
+                        <LoaderButton
+                            type="submit"
+                            variant="primary"
+                            disabled={loading || (userID > 0 && orgID > 0) || (!userID && !orgID)}
+                            onClick={() => addOverride()}
+                            label="Add override"
+                            loading={loading}
+                        />
+                    </div>
+                </Form>
+            </Modal>
+            <Button variant="primary" size="sm" className="mt-1 mb-2" onClick={openModal}>
+                Add override
+            </Button>
+        </div>
+    )
+}
+
+const FeatureFlagOverridesHeader: FunctionComponent<{
+    name: string
+    type: FeatureFlagType
+    value: FeatureFlagValue
+    overrides: FeatureFlagOverride[]
+    onOverrideAdded: (flag: FeatureFlagOverride) => void
+}> = ({ name, type, value, overrides, onOverrideAdded }) => {
+    const count = `${overrides.length} override${overrides.length === 1 ? '' : 's'}`
+
+    return (
+        <>
+            {type === 'FeatureFlagBoolean' && (
+                <AddFeatureFlagOverride
+                    name={name}
+                    value={(value as FeatureFlagBooleanValue).value}
+                    onOverrideAdded={onOverrideAdded}
+                />
+            )}
+            <div className="mr-auto">{count}</div>
+        </>
+    )
+}
+
+interface UpdateFeatureFlagOverrideResult {
+    updateFeatureFlagOverride: FeatureFlagOverride
+}
+
+const FeatureFlagOverrideItem: FunctionComponent<{
+    override: FeatureFlagOverride
+    onUpdate: (value: boolean) => void
+    onDelete: () => void
+}> = ({ override, onUpdate, onDelete }) => {
+    const { id, value } = override
+
+    const { OrgID: orgID, UserID: userID } = JSON.parse(
+        atob(id).replace('FeatureFlagOverride:{', '{')
+    ) as FeaturefFlagOverrideParsedID
+    const nsLabel = orgID > 0 ? 'OrgID' : 'UserID'
+    const nsValue = orgID > 0 ? orgID : userID
+
+    const [deleteFeatureFlagOverride, { loading: deleteOverrideLoading, error: deleteOverrideError }] = useMutation(
+        DELETE_FEATURE_FLAG_OVERRIDE_MUTATION,
+        {
+            variables: { id },
+            onCompleted: onDelete,
+        }
+    )
+
+    const [updateFeatureFlagOverride, { loading: updateOverrideLoading, error: updateOverrideError }] = useMutation<
+        UpdateFeatureFlagOverrideResult,
+        FeatureFlagOverride
+    >(UPDATE_FEATURE_FLAG_OVERRIDE_MUTATION, {
+        variables: {
+            id,
+            value: !value,
+        },
+        onCompleted: data => {
+            onUpdate(data.updateFeatureFlagOverride.value)
+        },
+    })
+
+    return (
+        <li className="d-flex align-items-center p-2">
+            {updateOverrideLoading && <LoadingSpinner />}
+            <Toggle
+                title="Value"
+                value={value}
+                disabled={updateOverrideLoading}
+                onToggle={() => updateFeatureFlagOverride()}
+                className="mr-1"
+                aria-describedby="feature-flag-override-toggle-description"
+            />
+            <span className="text-capitalize aaa">{Boolean(value).toString()}</span>
+            {/*
+                TODO: querying for namespace of orgId does not work on Cloud,
+                so just present the ID for now.
+                https://github.com/sourcegraph/sourcegraph/issues/32238
+            */}
+            <strong className="ml-4">{nsLabel}:</strong>
+            <span className="pl-1 mr-auto">{nsValue}</span>
+            <LoaderButton
+                variant="danger"
+                outline={true}
+                className="align-self-end"
+                size="sm"
+                onClick={() => deleteFeatureFlagOverride()}
+                label="Delete Override"
+                loading={deleteOverrideLoading}
+                alwaysShowLabel={true}
+            />
+        </li>
+    )
+}
 
 /**
  * Component with form fields for managing an existing feature flag.
@@ -248,46 +502,83 @@ const ManageFeatureFlag: FunctionComponent<{
     type: FeatureFlagType
     value: FeatureFlagValue
     overrides?: FeatureFlagOverride[]
+    onOverridesUpdate: (overrides: FeatureFlagOverride[]) => void
     setFlagValue: (flag: FeatureFlagValue) => void
-}> = ({ name, type, value, overrides, setFlagValue }) => (
-    <>
-        <h3>Name</h3>
-        <p>{name}</p>
+}> = ({ name, type, value, overrides, onOverridesUpdate, setFlagValue }) => {
+    const addOverride = useCallback(
+        (override: FeatureFlagOverride): void => {
+            const newOverrides = overrides?.slice() || []
+            newOverrides.push(override)
+            onOverridesUpdate(newOverrides)
+        },
+        [overrides, onOverridesUpdate]
+    )
 
-        <h3>Type</h3>
-        <p>{type.slice('FeatureFlag'.length)}</p>
+    const updateOverride = useCallback(
+        (index: number, value: boolean): void => {
+            if (overrides?.length > index) {
+                const newOverrides = overrides.slice()
+                newOverrides[index].value = value
+                onOverridesUpdate(newOverrides)
+            }
+        },
+        [overrides, onOverridesUpdate]
+    )
 
-        <FeatureFlagValueSettings type={type} value={value} setFlagValue={setFlagValue} />
+    const deleteOverride = useCallback(
+        (index: number): void => {
+            if (overrides?.length > index) {
+                const newOverrides = overrides.slice()
+                newOverrides?.splice(index, 1)
+                onOverridesUpdate(newOverrides)
+            }
+        },
+        [overrides, onOverridesUpdate]
+    )
 
-        <Collapsible
-            title={<h3>Overrides</h3>}
-            detail={`${overrides?.length || 0} ${overrides?.length !== 1 ? 'overrides' : 'override'}`}
-            className="p-0 font-weight-normal"
-            buttonClassName="mb-0"
-            titleAtStart={true}
-            defaultExpanded={false}
-        >
-            <div className={classNames('pt-2', styles.nodeGrid)}>
-                {overrides?.map(override => (
-                    <React.Fragment key={override.id}>
-                        <div className="py-1 pr-2">
-                            <code>{JSON.stringify(override.value)}</code>
-                        </div>
+    return (
+        <>
+            <h3>Name</h3>
+            <p>{name}</p>
 
-                        <span className={classNames('py-1 pl-2', styles.nodeGridCode)}>
-                            {/*
-                                TODO: querying for namespace connection seems to
-                                error out often, so just present the ID for now.
-                                https://github.com/sourcegraph/sourcegraph/issues/32238
-                            */}
-                            <code>{override.id}</code>
-                        </span>
-                    </React.Fragment>
-                ))}
-            </div>
-        </Collapsible>
-    </>
-)
+            <h3>Type</h3>
+            <p>{type.slice('FeatureFlag'.length)}</p>
+
+            <FeatureFlagValueSettings type={type} value={value} setFlagValue={setFlagValue} />
+
+            <Collapsible
+                title={<h3>Overrides</h3>}
+                detail={
+                    <FeatureFlagOverridesHeader
+                        overrides={overrides || []}
+                        name={name}
+                        type={type}
+                        value={value}
+                        onOverrideAdded={addOverride}
+                    />
+                }
+                className="p-0 font-weight-normal"
+                buttonClassName="mb-0"
+                titleAtStart={true}
+                defaultExpanded={false}
+                wholeTitleClickable={false}
+            >
+                <Container className={classNames('mb-2 mt-2', styles.featureFlagOverrideList)}>
+                    <ul>
+                        {overrides?.map((override, index) => (
+                            <FeatureFlagOverrideItem
+                                key={override.id}
+                                override={override}
+                                onUpdate={(newValue: boolean) => updateOverride(index, newValue)}
+                                onDelete={() => deleteOverride(index)}
+                            />
+                        ))}
+                    </ul>
+                </Container>
+            </Collapsible>
+        </>
+    )
+}
 
 /**
  * Component with form fields for creating a feature flag.
@@ -501,6 +792,32 @@ const UPDATE_FEATURE_FLAG_MUTATION = gql`
 const DELETE_FEATURE_FLAG_MUTATION = gql`
     mutation delete($name: String!) {
         deleteFeatureFlag(name: $name) {
+            alwaysNil
+        }
+    }
+`
+
+const CREATE_FEATURE_FLAG_OVERRIDE_MUTATION = gql`
+    mutation CreateFeatureFlagOverride($namespace: ID!, $flagName: String!, $value: Boolean!) {
+        createFeatureFlagOverride(namespace: $namespace, flagName: $flagName, value: $value) {
+            id
+            value
+        }
+    }
+`
+
+const UPDATE_FEATURE_FLAG_OVERRIDE_MUTATION = gql`
+    mutation UpdateFeatureFlagOverride($id: ID!, $value: Boolean!) {
+        updateFeatureFlagOverride(id: $id, value: $value) {
+            id
+            value
+        }
+    }
+`
+
+const DELETE_FEATURE_FLAG_OVERRIDE_MUTATION = gql`
+    mutation DeleteFeatureFlagOverride($id: ID!) {
+        deleteFeatureFlagOverride(id: $id) {
             alwaysNil
         }
     }

--- a/client/web/src/site-admin/SiteAdminFeatureFlagConfigurationPage.tsx
+++ b/client/web/src/site-admin/SiteAdminFeatureFlagConfigurationPage.tsx
@@ -488,10 +488,10 @@ const FeatureFlagOverrideItem: FunctionComponent<{
                 className="mr-1"
                 aria-describedby="feature-flag-override-toggle-description"
             />
-            <span className="text-capitalize aaa">{Boolean(value).toString()}</span>
+            <span className="text-capitalize">{Boolean(value).toString()}</span>
             {/*
                 TODO: querying for namespace of orgId does not work on Cloud,
-                so just present the ID for now.
+                so just present the decoded contents of the ID for now.
                 https://github.com/sourcegraph/sourcegraph/issues/32238
             */}
             <strong className="ml-4">{nsLabel}:</strong>

--- a/client/web/src/site-admin/SiteAdminFeatureFlagConfigurationPage.tsx
+++ b/client/web/src/site-admin/SiteAdminFeatureFlagConfigurationPage.tsx
@@ -798,7 +798,7 @@ const DELETE_FEATURE_FLAG_MUTATION = gql`
 `
 
 const CREATE_FEATURE_FLAG_OVERRIDE_MUTATION = gql`
-    mutation CreateFeatureFlagOverride($namespace: ID!, $flagName: String!, $value: Boolean!) {
+    mutation createFeatureFlagOverride($namespace: ID!, $flagName: String!, $value: Boolean!) {
         createFeatureFlagOverride(namespace: $namespace, flagName: $flagName, value: $value) {
             id
             value
@@ -807,7 +807,7 @@ const CREATE_FEATURE_FLAG_OVERRIDE_MUTATION = gql`
 `
 
 const UPDATE_FEATURE_FLAG_OVERRIDE_MUTATION = gql`
-    mutation UpdateFeatureFlagOverride($id: ID!, $value: Boolean!) {
+    mutation updateFeatureFlagOverride($id: ID!, $value: Boolean!) {
         updateFeatureFlagOverride(id: $id, value: $value) {
             id
             value
@@ -816,7 +816,7 @@ const UPDATE_FEATURE_FLAG_OVERRIDE_MUTATION = gql`
 `
 
 const DELETE_FEATURE_FLAG_OVERRIDE_MUTATION = gql`
-    mutation DeleteFeatureFlagOverride($id: ID!) {
+    mutation deleteFeatureFlagOverride($id: ID!) {
         deleteFeatureFlagOverride(id: $id) {
             alwaysNil
         }

--- a/package.json
+++ b/package.json
@@ -336,7 +336,7 @@
     "yarn-deduplicate": "^3.1.0"
   },
   "dependencies": {
-    "@apollo/client": "3.4.7",
+    "@apollo/client": "^3.5.0",
     "@codemirror/autocomplete": "^0.19.14",
     "@codemirror/highlight": "^0.19.7",
     "@codemirror/state": "^0.19.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -40,10 +40,10 @@
     call-me-maybe "^1.0.1"
     js-yaml "^3.13.1"
 
-"@apollo/client@3.4.7":
-  version "3.4.7"
-  resolved "https://registry.npmjs.org/@apollo/client/-/client-3.4.7.tgz#63d7c3539cc45fe44ac9cb093a27641479a8d1ad"
-  integrity sha512-EmqGxXD8hr05cIFWJFwtGXifc+Lo8hTCEuiaQMtKknHszJfqIFXSxqP+H+eJnjfuoxH74aTSsZKtJlnE83Vt6w==
+"@apollo/client@^3.5.0":
+  version "3.5.10"
+  resolved "https://registry.npmjs.org/@apollo/client/-/client-3.5.10.tgz#43463108a6e07ae602cca0afc420805a19339a71"
+  integrity sha512-tL3iSpFe9Oldq7gYikZK1dcYxp1c01nlSwtsMz75382HcI6fvQXyFXUCJTTK3wgO2/ckaBvRGw7VqjFREdVoRw==
   dependencies:
     "@graphql-typed-document-node/core" "^3.0.0"
     "@wry/context" "^0.6.0"
@@ -54,9 +54,9 @@
     optimism "^0.16.1"
     prop-types "^15.7.2"
     symbol-observable "^4.0.0"
-    ts-invariant "^0.9.0"
+    ts-invariant "^0.9.4"
     tslib "^2.3.0"
-    zen-observable-ts "^1.1.0"
+    zen-observable-ts "^1.2.0"
 
 "@ardatan/aggregate-error@0.0.1":
   version "0.0.1"
@@ -5798,11 +5798,6 @@
   integrity sha512-A1b8SU4D10uoPjwb0lnHmmu8wZhR9d+9o2PKBQT2jU5YPTKsxac6M2qGAdY7VcL+dHHhARVUDmeg0rOrcd9EjA==
   dependencies:
     "@types/node" "*"
-
-"@types/zen-observable@0.8.3":
-  version "0.8.3"
-  resolved "https://registry.npmjs.org/@types/zen-observable/-/zen-observable-0.8.3.tgz#781d360c282436494b32fe7d9f7f8e64b3118aa3"
-  integrity sha512-fbF6oTd4sGGy0xjHPKAt+eS2CrxJ3+6gQ3FGcBoIJR2TLAyCkCyI8JqZNy+FeON0AhVgNJoUumVoZQjBFUqHkw==
 
 "@typescript-eslint/eslint-plugin@^4.28.3":
   version "4.28.3"
@@ -23195,10 +23190,10 @@ ts-essentials@^7.0.3:
   resolved "https://registry.npmjs.org/ts-essentials/-/ts-essentials-7.0.3.tgz#686fd155a02133eedcc5362dc8b5056cde3e5a38"
   integrity sha512-8+gr5+lqO3G84KdiTSMRLtuyJ+nTBVRKuCrK4lidMPdVeEp0uqC875uE5NMcaA7YYMN7XsNiFQuMvasF8HT/xQ==
 
-ts-invariant@^0.9.0:
-  version "0.9.3"
-  resolved "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.9.3.tgz#4b41e0a80c2530a56ce4b8fd4e14183aaac0efa8"
-  integrity sha512-HinBlTbFslQI0OHP07JLsSXPibSegec6r9ai5xxq/qHYCsIQbzpymLpDhAUsnXcSrDEcd0L62L8vsOEdzM0qlA==
+ts-invariant@^0.9.4:
+  version "0.9.4"
+  resolved "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.9.4.tgz#42ac6c791aade267dd9dc65276549df5c5d71cac"
+  integrity sha512-63jtX/ZSwnUNi/WhXjnK8kz4cHHpYS60AnmA6ixz17l7E12a5puCWFlNpkne5Rl0J8TBPVHpGjsj4fxs8ObVLQ==
   dependencies:
     tslib "^2.1.0"
 
@@ -25091,12 +25086,11 @@ yocto-queue@^0.1.0:
   resolved "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
 
-zen-observable-ts@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-1.1.0.tgz#2d1aa9d79b87058e9b75698b92791c1838551f83"
-  integrity sha512-1h4zlLSqI2cRLPJUHJFL8bCWHhkpuXkF+dbGkRaWjgDIG26DmzyshUMrdV/rL3UnR+mhaX4fRq8LPouq0MYYIA==
+zen-observable-ts@^1.2.0:
+  version "1.2.3"
+  resolved "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-1.2.3.tgz#c2f5ccebe812faf0cfcde547e6004f65b1a6d769"
+  integrity sha512-hc/TGiPkAWpByykMwDcem3SdUgA4We+0Qb36bItSuJC9xD0XVBZoFHYoadAomDSNf64CG8Ydj0Qb8Od8BUWz5g==
   dependencies:
-    "@types/zen-observable" "0.8.3"
     zen-observable "0.8.15"
 
 zen-observable@0.8.15:


### PR DESCRIPTION
## Screenshots

<img width="926" alt="Screenshot 2022-03-24 at 17 24 17" src="https://user-images.githubusercontent.com/9974711/159963628-60dce240-81f2-43ba-b858-71b3f16093c3.png">
<img width="521" alt="Screenshot 2022-03-24 at 20 17 58" src="https://user-images.githubusercontent.com/9974711/159993756-1ee7cc61-a13c-468b-a333-b6d8755a695c.png">
<img width="522" alt="Screenshot 2022-03-24 at 20 18 05" src="https://user-images.githubusercontent.com/9974711/159993764-0213113a-d69a-4e5f-9554-992fc882f3ae.png">
<img width="523" alt="Screenshot 2022-03-24 at 20 18 21" src="https://user-images.githubusercontent.com/9974711/159993778-1fb74ad2-b5f3-4bdc-b1ce-7d34821f38cf.png">


## Test plan

Tested manually on local instance. These changes only touch site admin functionality for managing feature flag overrides.
As these are UI changes, I don't want to spend too much effort on writing automated tests.

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


