### PR TITLE
db: add gitserver_localclone_jobs_with_repo_name view

### DIFF
--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -2623,6 +2623,52 @@ Foreign-key constraints:
      JOIN external_service_sync_jobs j ON ((e.id = j.external_service_id)));
 ```
 
+# View "public.gitserver_localclone_jobs_with_repo_name"
+```
+      Column       |           Type           | Collation | Nullable | Default 
+-------------------+--------------------------+-----------+----------+---------
+ id                | integer                  |           |          | 
+ state             | text                     |           |          | 
+ failure_message   | text                     |           |          | 
+ started_at        | timestamp with time zone |           |          | 
+ finished_at       | timestamp with time zone |           |          | 
+ process_after     | timestamp with time zone |           |          | 
+ num_resets        | integer                  |           |          | 
+ num_failures      | integer                  |           |          | 
+ last_heartbeat_at | timestamp with time zone |           |          | 
+ execution_logs    | json[]                   |           |          | 
+ worker_hostname   | text                     |           |          | 
+ repo_id           | integer                  |           |          | 
+ source_hostname   | text                     |           |          | 
+ dest_hostname     | text                     |           |          | 
+ delete_source     | boolean                  |           |          | 
+ repo_name         | citext                   |           |          | 
+
+```
+
+## View query:
+
+```sql
+ SELECT glj.id,
+    glj.state,
+    glj.failure_message,
+    glj.started_at,
+    glj.finished_at,
+    glj.process_after,
+    glj.num_resets,
+    glj.num_failures,
+    glj.last_heartbeat_at,
+    glj.execution_logs,
+    glj.worker_hostname,
+    glj.repo_id,
+    glj.source_hostname,
+    glj.dest_hostname,
+    glj.delete_source,
+    r.name AS repo_name
+   FROM (gitserver_localclone_jobs glj
+     JOIN repo r ON ((r.id = glj.repo_id)));
+```
+
 # View "public.lsif_dumps"
 ```
          Column         |           Type           | Collation | Nullable | Default 

--- a/migrations/frontend/1648115472/down.sql
+++ b/migrations/frontend/1648115472/down.sql
@@ -1,0 +1,1 @@
+DROP VIEW IF EXISTS gitserver_localclone_jobs_with_repo_name;

--- a/migrations/frontend/1648115472/metadata.yaml
+++ b/migrations/frontend/1648115472/metadata.yaml
@@ -1,0 +1,2 @@
+name: add_localclone_worker_view
+parents: [1647849753, 1647860082]

--- a/migrations/frontend/1648115472/up.sql
+++ b/migrations/frontend/1648115472/up.sql
@@ -1,4 +1,4 @@
-CREATE VIEW gitserver_localclone_jobs_with_repo_name AS
+CREATE OR REPLACE VIEW gitserver_localclone_jobs_with_repo_name AS
   SELECT glj.*, r.name AS repo_name
   FROM gitserver_localclone_jobs glj
   JOIN repo r ON r.id = glj.repo_id;

--- a/migrations/frontend/1648115472/up.sql
+++ b/migrations/frontend/1648115472/up.sql
@@ -1,0 +1,4 @@
+CREATE VIEW gitserver_localclone_jobs_with_repo_name AS
+  SELECT glj.*, r.name AS repo_name
+  FROM gitserver_localclone_jobs glj
+  JOIN repo r ON r.id = glj.repo_id;


### PR DESCRIPTION
This adds a view for the LocalClone worker to fetch jobs with a repo name instead of just the repo id.

See https://docs.sourcegraph.com/dev/background-information/workers#adding-a-new-worker for more info

## Test plan

sg migration up & undo

Related to #32827