### PR TITLE
web: disable event logging for "web-standalone" and "oss-web-standalone" commandsets

### DIFF
--- a/client/web/src/tracking/eventLogger.ts
+++ b/client/web/src/tracking/eventLogger.ts
@@ -13,6 +13,7 @@ export const COHORT_ID_KEY = 'sourcegraphCohortId'
 export const FIRST_SOURCE_URL_KEY = 'sourcegraphSourceUrl'
 export const LAST_SOURCE_URL_KEY = 'sourcegraphRecentSourceUrl'
 export const DEVICE_ID_KEY = 'sourcegraphDeviceId'
+const isProduction = process.env.NODE_ENV === 'production'
 
 export class EventLogger implements TelemetryService {
     private hasStrippedQueryParameters = false
@@ -56,7 +57,9 @@ export class EventLogger implements TelemetryService {
 
     private logViewEventInternal(eventName: string, eventProperties?: any, logAsActiveUser = true): void {
         const props = pageViewQueryParameters(window.location.href)
-        serverAdmin.trackPageView(eventName, logAsActiveUser, eventProperties)
+        if (isProduction) {
+            serverAdmin.trackPageView(eventName, logAsActiveUser, eventProperties)
+        }
         this.logToConsole(eventName, props)
 
         // Use flag to ensure URL query params are only stripped once
@@ -111,7 +114,9 @@ export class EventLogger implements TelemetryService {
         if (window.context?.userAgentIsBot || !eventLabel) {
             return
         }
-        serverAdmin.trackAction(eventLabel, eventProperties, publicArgument)
+        if (isProduction) {
+            serverAdmin.trackAction(eventLabel, eventProperties, publicArgument)
+        }
         this.logToConsole(eventLabel, eventProperties, publicArgument)
     }
 

--- a/client/web/src/tracking/eventLogger.ts
+++ b/client/web/src/tracking/eventLogger.ts
@@ -13,7 +13,7 @@ export const COHORT_ID_KEY = 'sourcegraphCohortId'
 export const FIRST_SOURCE_URL_KEY = 'sourcegraphSourceUrl'
 export const LAST_SOURCE_URL_KEY = 'sourcegraphRecentSourceUrl'
 export const DEVICE_ID_KEY = 'sourcegraphDeviceId'
-const isProduction = process.env.NODE_ENV === 'production'
+const isTelemetryDisabled = process.env.DISABLE_TELEMETRY
 
 export class EventLogger implements TelemetryService {
     private hasStrippedQueryParameters = false
@@ -57,7 +57,7 @@ export class EventLogger implements TelemetryService {
 
     private logViewEventInternal(eventName: string, eventProperties?: any, logAsActiveUser = true): void {
         const props = pageViewQueryParameters(window.location.href)
-        if (isProduction) {
+        if (!isTelemetryDisabled) {
             serverAdmin.trackPageView(eventName, logAsActiveUser, eventProperties)
         }
         this.logToConsole(eventName, props)
@@ -114,7 +114,7 @@ export class EventLogger implements TelemetryService {
         if (window.context?.userAgentIsBot || !eventLabel) {
             return
         }
-        if (isProduction) {
+        if (!isTelemetryDisabled) {
             serverAdmin.trackAction(eventLabel, eventProperties, publicArgument)
         }
         this.logToConsole(eventLabel, eventProperties, publicArgument)

--- a/client/web/webpack.config.js
+++ b/client/web/webpack.config.js
@@ -159,6 +159,7 @@ const config = {
     new webpack.DefinePlugin({
       'process.env': {
         NODE_ENV: JSON.stringify(mode),
+        DISABLE_TELEMETRY: process.env.DISABLE_TELEMETRY,
         ...(shouldServeIndexHTML && webServerEnvironmentVariables),
       },
     }),

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -930,11 +930,14 @@ commandsets:
       - caddy
     env:
       ENTERPRISE: 1
+      DISABLE_TELEMETRY: true
 
   oss-web-standalone:
     commands:
       - web-standalone-http
       - caddy
+    env:
+      DISABLE_TELEMETRY: true
 
   web-standalone-prod:
     commands:


### PR DESCRIPTION
Seems like event logs are being sent even on local development env. This PR aims to fix it by enabling only on production builds.

## Test plan
- Run `sg start web-standalone` and check in DevTools>Network that event logs are NOT being sent
- Run `sg start web-standalone-prod` and check in DevTools>Network that event logs are being sent
<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


