### PR TITLE
ci: downgrade golangci-lint

### DIFF
--- a/dev/golangci-lint.sh
+++ b/dev/golangci-lint.sh
@@ -6,7 +6,7 @@ pushd "$(dirname "${BASH_SOURCE[0]}")/.." >/dev/null
 
 mkdir -p .bin
 
-version="1.45.1"
+version="1.44.1"
 suffix="${version}-$(go env GOOS)-$(go env GOARCH)"
 target="$PWD/.bin/golangci-lint-${suffix}"
 


### PR DESCRIPTION
Another attempt at fixing the golangci-lint weird depguard issues. 

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

green build. 
