### PR TITLE
notebooks: factor out compute input update

### DIFF
--- a/client/web/src/notebooks/blocks/compute/component/src/Main.elm
+++ b/client/web/src/notebooks/blocks/compute/component/src/Main.elm
@@ -279,6 +279,20 @@ type DataFilterMsg
     | OnExcludeStopWordsCheckbox Bool
 
 
+updateComputeInput : List String -> DataFilter -> Tab -> ComputeInput
+updateComputeInput queries dataFilter selectedTab =
+    { computeQueries = queries
+    , experimentalOptions =
+        Just
+            { dataPoints = Just dataFilter.dataPoints
+            , sortByCount = Just dataFilter.sortByCount
+            , reverse = Just dataFilter.reverse
+            , excludeStopWords = Just dataFilter.excludeStopWords
+            , activeTab = Just { name = stringFromTab selectedTab }
+            }
+    }
+
+
 update : Msg -> Model -> ( Model, Cmd Msg )
 update msg model =
     case msg of
@@ -300,32 +314,12 @@ update msg model =
                     updateDataFilter dataFilterMsg model.dataFilter
             in
             ( { model | dataFilter = newDataFilter }
-            , emitInput
-                { computeQueries = [ model.query ]
-                , experimentalOptions =
-                    Just
-                        { dataPoints = Just newDataFilter.dataPoints
-                        , sortByCount = Just newDataFilter.sortByCount
-                        , reverse = Just newDataFilter.reverse
-                        , excludeStopWords = Just newDataFilter.excludeStopWords
-                        , activeTab = Just { name = stringFromTab model.selectedTab }
-                        }
-                }
+            , emitInput (updateComputeInput [ model.query ] newDataFilter model.selectedTab)
             )
 
         OnTabSelected selectedTab ->
             ( { model | selectedTab = selectedTab }
-            , emitInput
-                { computeQueries = [ model.query ]
-                , experimentalOptions =
-                    Just
-                        { dataPoints = Just model.dataFilter.dataPoints
-                        , sortByCount = Just model.dataFilter.sortByCount
-                        , reverse = Just model.dataFilter.reverse
-                        , excludeStopWords = Just model.dataFilter.excludeStopWords
-                        , activeTab = Just { name = stringFromTab selectedTab }
-                        }
-                }
+            , emitInput (updateComputeInput [ model.query ] model.dataFilter selectedTab)
             )
 
         OnDownloadData ->
@@ -355,17 +349,7 @@ update msg model =
                 in
                 ( { model | resultsMap = Dict.empty, alerts = alerts }
                 , Cmd.batch
-                    [ emitInput
-                        { computeQueries = [ model.query ]
-                        , experimentalOptions =
-                            Just
-                                { dataPoints = Just model.dataFilter.dataPoints
-                                , sortByCount = Just model.dataFilter.sortByCount
-                                , reverse = Just model.dataFilter.reverse
-                                , excludeStopWords = Just model.dataFilter.excludeStopWords
-                                , activeTab = Just { name = stringFromTab model.selectedTab }
-                                }
-                        }
+                    [ emitInput (updateComputeInput [ model.query ] model.dataFilter model.selectedTab)
                     , openStream
                         ( Url.Builder.crossOrigin
                             model.sourcegraphURL
@@ -944,7 +928,7 @@ textInputBackgroundColor theme =
         Dark ->
             E.rgb255 0x1D 0x22 0x2F
 
-        Light ->            
+        Light ->
             E.rgb 0xFF 0xFF 0xFF
 
 


### PR DESCRIPTION
Just factoring out a common update function. Setup for issue where Thorsten was alarmed that the notebook updated without him doing anything.

## Test plan
Semantics-preserving.


