### PR TITLE
notebooks: compute blocks do not persist inputs after making requests

### DIFF
--- a/client/web/src/notebooks/blocks/compute/component/src/Main.elm
+++ b/client/web/src/notebooks/blocks/compute/component/src/Main.elm
@@ -303,7 +303,16 @@ update msg model =
 
         OnDebounce ->
             if model.debounce - 1 == 0 then
-                update RunCompute { model | debounce = model.debounce - 1 }
+                let
+                    ( newModel, runCompute ) =
+                        update RunCompute { model | debounce = model.debounce - 1 }
+                in
+                ( newModel
+                , Cmd.batch
+                    [ emitInput (updateComputeInput [ model.query ] model.dataFilter model.selectedTab)
+                    , runCompute
+                    ]
+                )
 
             else
                 ( { model | debounce = model.debounce - 1 }, Cmd.none )
@@ -349,8 +358,7 @@ update msg model =
                 in
                 ( { model | resultsMap = Dict.empty, alerts = alerts }
                 , Cmd.batch
-                    [ emitInput (updateComputeInput [ model.query ] model.dataFilter model.selectedTab)
-                    , openStream
+                    [ openStream
                         ( Url.Builder.crossOrigin
                             model.sourcegraphURL
                             [ ".api", "compute", "stream" ]


### PR DESCRIPTION
Stacked on https://github.com/sourcegraph/sourcegraph/pull/33048.

Fixes an issue where previously, the notebook state would be persisted to the backend when we fire a server request. This had the effect where, if someone else visited the notebook (Thorsten in this case) the notebook would update and say they edited something, when really they did nothing. Now, the notebook only updates with something edited if one of the inputs change, irrespective of whether we request something from the server.

## Test plan
Tested locally. Experimental.


