### PR TITLE
insights: increase test db max_connections to 20 for parity with old image

### DIFF
--- a/enterprise/internal/insights/dbtesting/insights.go
+++ b/enterprise/internal/insights/dbtesting/insights.go
@@ -73,7 +73,7 @@ func TimescaleDB(t testing.TB) (db *sql.DB, cleanup func()) {
 	}
 	// Some tests that exercise concurrency need lots of connections or they block forever.
 	// e.g. TestIntegration/DBStore/Syncer/MultipleServices
-	db.SetMaxOpenConns(10)
+	db.SetMaxOpenConns(20)
 
 	// Perform DB migrations.
 	cleanup = func() {

--- a/enterprise/internal/insights/resolvers/insight_series_resolver_test.go
+++ b/enterprise/internal/insights/resolvers/insight_series_resolver_test.go
@@ -26,6 +26,7 @@ func TestResolver_InsightSeries(t *testing.T) {
 		now := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC).Truncate(time.Microsecond)
 		clock := func() time.Time { return now }
 		timescale, cleanup := insightsdbtesting.TimescaleDB(t)
+		defer cleanup()
 		postgres := dbtest.NewDB(t)
 		resolver := newWithClock(timescale, postgres, clock)
 

--- a/enterprise/internal/insights/resolvers/insight_series_resolver_test.go
+++ b/enterprise/internal/insights/resolvers/insight_series_resolver_test.go
@@ -26,7 +26,6 @@ func TestResolver_InsightSeries(t *testing.T) {
 		now := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC).Truncate(time.Microsecond)
 		clock := func() time.Time { return now }
 		timescale, cleanup := insightsdbtesting.TimescaleDB(t)
-		defer cleanup()
 		postgres := dbtest.NewDB(t)
 		resolver := newWithClock(timescale, postgres, clock)
 


### PR DESCRIPTION
Related to https://github.com/sourcegraph/sourcegraph/issues/32861#issuecomment-1077918386

After starting up the old Timescale image, it seems the default configuration was 20 max connections. So this sets the same for parity. We also had one test that wasn't appropriately cleaning up resources, so fixing that.

## Test plan

Ran locally and CI to ensure test DB can connect


