### PR TITLE
search: use result.Types to construct Zoekt text vs symbol queries

### DIFF
--- a/internal/search/job/job.go
+++ b/internal/search/job/job.go
@@ -100,8 +100,7 @@ func ToSearchJob(jargs *Args, q query.Q, db database.DB) (Job, error) {
 			includePrivate := repoOptions.Visibility == query.Private || repoOptions.Visibility == query.Any
 
 			if resultTypes.Has(result.TypeFile | result.TypePath) {
-				typ := search.TextRequest
-				zoektQuery, err := search.QueryToZoektQuery(b, resultTypes, &features, typ)
+				zoektQuery, err := search.QueryToZoektQuery(b, resultTypes, &features)
 				if err != nil {
 					return nil, err
 				}
@@ -115,7 +114,7 @@ func ToSearchJob(jargs *Args, q query.Q, db database.DB) (Job, error) {
 					// Ideally, The ZoektParameters type should not expose this field for Universe text
 					// searches at all, and will be removed once jobs are fully migrated.
 					Query:          nil,
-					Typ:            typ,
+					Typ:            search.TextRequest,
 					FileMatchLimit: fileMatchLimit,
 					Select:         selector,
 					Zoekt:          jargs.Zoekt,
@@ -130,8 +129,7 @@ func ToSearchJob(jargs *Args, q query.Q, db database.DB) (Job, error) {
 			}
 
 			if resultTypes.Has(result.TypeSymbol) {
-				typ := search.SymbolRequest
-				zoektQuery, err := search.QueryToZoektQuery(b, resultTypes, &features, typ)
+				zoektQuery, err := search.QueryToZoektQuery(b, resultTypes, &features)
 				if err != nil {
 					return nil, err
 				}
@@ -139,7 +137,7 @@ func ToSearchJob(jargs *Args, q query.Q, db database.DB) (Job, error) {
 
 				zoektArgs := &search.ZoektParameters{
 					Query:          nil,
-					Typ:            typ,
+					Typ:            search.SymbolRequest,
 					FileMatchLimit: fileMatchLimit,
 					Select:         selector,
 					Zoekt:          jargs.Zoekt,
@@ -158,15 +156,14 @@ func ToSearchJob(jargs *Args, q query.Q, db database.DB) (Job, error) {
 
 		if resultTypes.Has(result.TypeFile|result.TypePath) && !skipRepoSubsetSearch {
 			var textSearchJobs []Job
-			typ := search.TextRequest
 			if !onlyRunSearcher {
-				zoektQuery, err := search.QueryToZoektQuery(b, resultTypes, &features, typ)
+				zoektQuery, err := search.QueryToZoektQuery(b, resultTypes, &features)
 				if err != nil {
 					return nil, err
 				}
 				textSearchJobs = append(textSearchJobs, &zoektutil.ZoektRepoSubsetSearch{
 					Query:          zoektQuery,
-					Typ:            typ,
+					Typ:            search.TextRequest,
 					FileMatchLimit: fileMatchLimit,
 					Select:         selector,
 					Zoekt:          jargs.Zoekt,
@@ -191,10 +188,8 @@ func ToSearchJob(jargs *Args, q query.Q, db database.DB) (Job, error) {
 
 		if resultTypes.Has(result.TypeSymbol) && b.PatternString() != "" && !skipRepoSubsetSearch {
 			var symbolSearchJobs []Job
-			typ := search.SymbolRequest
-
 			if !onlyRunSearcher {
-				zoektQuery, err := search.QueryToZoektQuery(b, resultTypes, &features, typ)
+				zoektQuery, err := search.QueryToZoektQuery(b, resultTypes, &features)
 				if err != nil {
 					return nil, err
 				}
@@ -243,14 +238,13 @@ func ToSearchJob(jargs *Args, q query.Q, db database.DB) (Job, error) {
 		}
 
 		if jargs.SearchInputs.PatternType == query.SearchTypeStructural && b.PatternString() != "" {
-			typ := search.TextRequest
-			zoektQuery, err := search.QueryToZoektQuery(b, resultTypes, &features, typ)
+			zoektQuery, err := search.QueryToZoektQuery(b, resultTypes, &features)
 			if err != nil {
 				return nil, err
 			}
 			zoektArgs := &search.ZoektParameters{
 				Query:          zoektQuery,
-				Typ:            typ,
+				Typ:            search.TextRequest,
 				FileMatchLimit: fileMatchLimit,
 				Select:         selector,
 				Zoekt:          jargs.Zoekt,

--- a/internal/search/query_converter.go
+++ b/internal/search/query_converter.go
@@ -267,7 +267,7 @@ func toZoektPattern(expression query.Node, isCaseSensitive, patternMatchesConten
 	return q, nil
 }
 
-func QueryToZoektQuery(b query.Basic, resultTypes result.Types, feat *Features, typ IndexedRequestType) (q zoekt.Q, err error) {
+func QueryToZoektQuery(b query.Basic, resultTypes result.Types, feat *Features) (q zoekt.Q, err error) {
 	isCaseSensitive := b.IsCaseSensitive()
 
 	if b.Pattern != nil {
@@ -290,7 +290,7 @@ func QueryToZoektQuery(b query.Basic, resultTypes result.Types, feat *Features, 
 	filesExclude = append(filesExclude, mapSlice(langExclude, LangToFileRegexp)...)
 	filesReposMustInclude, filesReposMustExclude := b.IncludeExcludeValues(query.FieldRepoHasFile)
 
-	if typ == SymbolRequest {
+	if resultTypes.Has(result.TypeSymbol) {
 		// Tell zoekt q must match on symbols
 		q = &zoekt.Symbol{
 			Expr: q,

--- a/internal/search/query_converter_test.go
+++ b/internal/search/query_converter_test.go
@@ -109,7 +109,7 @@ func TestQueryToZoektQuery(t *testing.T) {
 
 			types, _ := b.ToParseTree().StringValues(query.FieldType)
 			resultTypes := ComputeResultTypes(types, b.PatternString(), query.SearchTypeRegex)
-			got, err := QueryToZoektQuery(b, resultTypes, &tt.Features, tt.Type)
+			got, err := QueryToZoektQuery(b, resultTypes, &tt.Features)
 			if err != nil {
 				t.Fatal("QueryToZoektQuery failed:", err)
 			}

--- a/internal/search/run/repo_has_file.go
+++ b/internal/search/run/repo_has_file.go
@@ -73,8 +73,6 @@ func (s *RepoSearch) reposContainingPath(ctx context.Context, repos []*search.Re
 	g, ctx := errgroup.WithContext(ctx)
 
 	if newArgs.Mode != search.SearcherOnly {
-		typ := search.TextRequest
-
 		b, err := query.ToBasicQuery(q)
 		if err != nil {
 			return nil, err
@@ -89,14 +87,14 @@ func (s *RepoSearch) reposContainingPath(ctx context.Context, repos []*search.Re
 				resultTypes = resultTypes.With(result.TypeFromString[t])
 			}
 		}
-		zoektQuery, err := search.QueryToZoektQuery(b, resultTypes, &newArgs.Features, typ)
+		zoektQuery, err := search.QueryToZoektQuery(b, resultTypes, &newArgs.Features)
 		if err != nil {
 			return nil, err
 		}
 
 		zoektArgs := search.ZoektParameters{
 			Query:          zoektQuery,
-			Typ:            typ,
+			Typ:            search.TextRequest,
 			FileMatchLimit: newArgs.PatternInfo.FileMatchLimit,
 			Select:         newArgs.PatternInfo.Select,
 			Zoekt:          newArgs.Zoekt,

--- a/internal/search/textsearch/textsearch_test.go
+++ b/internal/search/textsearch/textsearch_test.go
@@ -456,8 +456,7 @@ func RunRepoSubsetTextSearch(
 			}
 		}
 
-		typ := search.TextRequest
-		zoektQuery, err := search.QueryToZoektQuery(b, resultTypes, nil, typ)
+		zoektQuery, err := search.QueryToZoektQuery(b, resultTypes, nil)
 		if err != nil {
 			return nil, streaming.Stats{}, err
 		}

--- a/internal/search/zoekt/indexed_search_test.go
+++ b/internal/search/zoekt/indexed_search_test.go
@@ -272,7 +272,7 @@ func TestIndexedSearch(t *testing.T) {
 			}
 
 			var resultTypes result.Types
-			zoektQuery, err := search.QueryToZoektQuery(query.Basic{}, resultTypes, &search.Features{}, search.TextRequest)
+			zoektQuery, err := search.QueryToZoektQuery(query.Basic{}, resultTypes, &search.Features{})
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
2+N or so PRs away from optimized Zoekt queries. For real this time :-) Just a couple more simplifications...

## Test plan
Semantics-preserving.


