### PR TITLE
Update LAM dashboards UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Changed
 
--
+- Code Insights: Added locked insights overlays for frozen insights while in limited access mode. Restricted insight editing save change button for frozen insights. [#33062](https://github.com/sourcegraph/sourcegraph/pull/33062)
 
 ### Fixed
 

--- a/client/branded/src/global-styles/colors.scss
+++ b/client/branded/src/global-styles/colors.scss
@@ -8,6 +8,7 @@
 $blue: #0b70db;
 $indigo: #0864c6;
 $purple: #a305e1;
+$purple-01: #e8d1ff;
 $purple-03: #820dde;
 $pink: #d68cf3;
 $red: $oc-red-9;
@@ -66,6 +67,7 @@ $theme-colors: (
     --blue: #{$blue};
     --indigo: #{$indigo};
     --purple: #{$purple};
+    --purple-01: #{$purple-01};
     --purple-03: #{$purple-03};
     --pink: #{$pink};
     --red: #{$red};

--- a/client/web/src/enterprise/insights/components/insights-view-grid/SmartInsightsViewGrid.story.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/SmartInsightsViewGrid.story.tsx
@@ -39,6 +39,7 @@ const insightsWithManyLines: Insight[] = [
         step: { weeks: 2 },
         filters: { excludeRepoRegexp: '', includeRepoRegexp: '' },
         dashboardReferenceCount: 0,
+        isFrozen: false,
     },
     {
         id: 'searchInsights.insight.Backend_2',
@@ -49,6 +50,7 @@ const insightsWithManyLines: Insight[] = [
         step: { weeks: 2 },
         filters: { excludeRepoRegexp: '', includeRepoRegexp: '' },
         dashboardReferenceCount: 0,
+        isFrozen: false,
     },
     {
         id: 'searchInsights.insight.Backend_3',
@@ -66,6 +68,7 @@ const insightsWithManyLines: Insight[] = [
         step: { weeks: 2 },
         filters: { excludeRepoRegexp: '', includeRepoRegexp: '' },
         dashboardReferenceCount: 0,
+        isFrozen: false,
     },
     {
         id: 'searchInsights.insight.Backend_4',
@@ -76,6 +79,7 @@ const insightsWithManyLines: Insight[] = [
         step: { weeks: 2 },
         filters: { excludeRepoRegexp: '', includeRepoRegexp: '' },
         dashboardReferenceCount: 0,
+        isFrozen: false,
     },
     {
         id: 'searchInsights.insight.Backend_5',
@@ -107,6 +111,7 @@ const insightsWithManyLines: Insight[] = [
         step: { weeks: 2 },
         filters: { excludeRepoRegexp: '', includeRepoRegexp: '' },
         dashboardReferenceCount: 0,
+        isFrozen: false,
     },
     {
         id: 'searchInsights.insight.Backend_6',
@@ -117,6 +122,7 @@ const insightsWithManyLines: Insight[] = [
         step: { weeks: 2 },
         filters: { excludeRepoRegexp: '', includeRepoRegexp: '' },
         dashboardReferenceCount: 0,
+        isFrozen: false,
     },
     {
         id: 'searchInsights.insight.Backend_7',
@@ -127,6 +133,7 @@ const insightsWithManyLines: Insight[] = [
         step: { weeks: 2 },
         filters: { excludeRepoRegexp: '', includeRepoRegexp: '' },
         dashboardReferenceCount: 0,
+        isFrozen: false,
     },
 ]
 

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/BackendInsight.story.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/BackendInsight.story.tsx
@@ -36,6 +36,7 @@ const INSIGHT_CONFIGURATION_MOCK: SearchBackendBasedInsight = {
     step: { weeks: 2 },
     filters: { excludeRepoRegexp: '', includeRepoRegexp: '' },
     dashboardReferenceCount: 0,
+    isFrozen: false,
 }
 
 const mockInsightAPI = ({

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/BackendInsight.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/BackendInsight.tsx
@@ -9,6 +9,7 @@ import { useDebounce, Alert } from '@sourcegraph/wildcard'
 
 import * as View from '../../../../../../views'
 import { LineChartSettingsContext } from '../../../../../../views'
+import { LockedChart } from '../../../../../../views/components/view/content/chart-view-content/charts/locked/LockedChart'
 import { CodeInsightsBackendContext } from '../../../../core/backend/code-insights-backend-context'
 import { InsightInProcessError } from '../../../../core/backend/utils/errors'
 import { BackendInsight, InsightFilters } from '../../../../core/types'
@@ -187,6 +188,8 @@ export const BackendInsightView: React.FunctionComponent<BackendInsightProps> = 
                         </Alert>
                     ) : null}
                 </View.ErrorContent>
+            ) : insight.isFrozen ? (
+                <LockedChart />
             ) : (
                 data && (
                     <LineChartSettingsContext.Provider value={{ zeroYAxisMin }}>

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/built-in-insight/BuiltInInsight.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/built-in-insight/BuiltInInsight.tsx
@@ -90,7 +90,11 @@ export function BuiltInInsight(props: BuiltInInsightProps): React.ReactElement {
             ) : (
                 data.view && (
                     <LineChartSettingsContext.Provider value={{ zeroYAxisMin }}>
-                        <View.Content content={data.view.content} onDatumLinkClick={trackDatumClicks} />
+                        <View.Content
+                            content={data.view.content}
+                            onDatumLinkClick={trackDatumClicks}
+                            locked={insight.isFrozen}
+                        />
                     </LineChartSettingsContext.Provider>
                 )
             )}

--- a/client/web/src/enterprise/insights/core/backend/code-insights-backend-types.ts
+++ b/client/web/src/enterprise/insights/core/backend/code-insights-backend-types.ts
@@ -43,12 +43,18 @@ export interface FindInsightByNameInput {
     name: string
 }
 
-export type MinimalSearchRuntimeBasedInsightData = Omit<SearchRuntimeBasedInsight, 'id' | 'dashboardReferenceCount'>
-export type MinimalSearchBackendBasedInsightData = Omit<SearchBackendBasedInsight, 'id' | 'dashboardReferenceCount'>
+export type MinimalSearchRuntimeBasedInsightData = Omit<
+    SearchRuntimeBasedInsight,
+    'id' | 'dashboardReferenceCount' | 'isFrozen'
+>
+export type MinimalSearchBackendBasedInsightData = Omit<
+    SearchBackendBasedInsight,
+    'id' | 'dashboardReferenceCount' | 'isFrozen'
+>
 export type MinimalSearchBasedInsightData = MinimalSearchRuntimeBasedInsightData | MinimalSearchBackendBasedInsightData
 
-export type MinimalCaptureGroupInsightData = Omit<CaptureGroupInsight, 'id' | 'dashboardReferenceCount'>
-export type MinimalLangStatsInsightData = Omit<LangStatsInsight, 'id' | 'dashboardReferenceCount'>
+export type MinimalCaptureGroupInsightData = Omit<CaptureGroupInsight, 'id' | 'dashboardReferenceCount' | 'isFrozen'>
+export type MinimalLangStatsInsightData = Omit<LangStatsInsight, 'id' | 'dashboardReferenceCount' | 'isFrozen'>
 
 export type CreationInsightInput =
     | MinimalSearchBasedInsightData

--- a/client/web/src/enterprise/insights/core/backend/gql-backend/deserialization/create-insight-view.ts
+++ b/client/web/src/enterprise/insights/core/backend/gql-backend/deserialization/create-insight-view.ts
@@ -2,7 +2,8 @@ import { Duration } from 'date-fns'
 import { uniq } from 'lodash'
 
 import { InsightViewNode, TimeIntervalStepInput, TimeIntervalStepUnit } from '../../../../../../graphql-operations'
-import { BaseInsight, Insight, InsightExecutionType, InsightType } from '../../../types'
+import { Insight, InsightExecutionType, InsightType } from '../../../types'
+import { BaseInsight } from '../../../types/insight/common'
 
 /**
  * Transforms/casts gql api insight model to FE insight model. We still

--- a/client/web/src/enterprise/insights/core/backend/gql-backend/gql/GetInsights.ts
+++ b/client/web/src/enterprise/insights/core/backend/gql-backend/gql/GetInsights.ts
@@ -40,6 +40,7 @@ const INSIGHT_VIEW_SERIES_FRAGMENT = gql`
 export const INSIGHT_VIEW_FRAGMENT = gql`
     fragment InsightViewNode on InsightView {
         id
+        isFrozen
         appliedFilters {
             includeRepoRegex
             excludeRepoRegex

--- a/client/web/src/enterprise/insights/core/types/insight/common.ts
+++ b/client/web/src/enterprise/insights/core/types/insight/common.ts
@@ -29,4 +29,5 @@ export interface BaseInsight {
     executionType: InsightExecutionType
     type: InsightType
     dashboardReferenceCount: number
+    isFrozen: boolean
 }

--- a/client/web/src/enterprise/insights/core/types/insight/common.ts
+++ b/client/web/src/enterprise/insights/core/types/insight/common.ts
@@ -22,3 +22,11 @@ export interface InsightFilters {
     excludeRepoRegexp: string
     repositories?: string[]
 }
+
+export interface BaseInsight {
+    id: string
+    title: string
+    executionType: InsightExecutionType
+    type: InsightType
+    dashboardReferenceCount: number
+}

--- a/client/web/src/enterprise/insights/core/types/insight/types/capture-group-insight.ts
+++ b/client/web/src/enterprise/insights/core/types/insight/types/capture-group-insight.ts
@@ -1,6 +1,6 @@
 import { Duration } from 'date-fns'
 
-import { BaseInsight, InsightExecutionType, InsightFilters, InsightType } from './common'
+import { BaseInsight, InsightExecutionType, InsightFilters, InsightType } from '../common'
 
 export interface CaptureGroupInsight extends BaseInsight {
     /**

--- a/client/web/src/enterprise/insights/core/types/insight/types/capture-group-insight.ts
+++ b/client/web/src/enterprise/insights/core/types/insight/types/capture-group-insight.ts
@@ -1,16 +1,14 @@
 import { Duration } from 'date-fns'
 
-import { InsightExecutionType, InsightFilters, InsightType } from '../common'
+import { BaseInsight, InsightExecutionType, InsightFilters, InsightType } from './common'
 
-export interface CaptureGroupInsight {
-    id: string
+export interface CaptureGroupInsight extends BaseInsight {
     /**
-     * We do not support capture group insight in setting based API or in
-     * runtime mode. Capture group should always have data provided by BE.
+     * We do not support capture group insight in runtime mode.
+     * Capture group should always have data provided by BE.
      */
     executionType: InsightExecutionType.Backend
     type: InsightType.CaptureGroup
-    title: string
 
     /** Capture group regexp query string */
     query: string
@@ -20,6 +18,5 @@ export interface CaptureGroupInsight {
      */
     repositories: string[]
     step: Duration
-    dashboardReferenceCount: number
     filters: InsightFilters
 }

--- a/client/web/src/enterprise/insights/core/types/insight/types/lang-stat-insight.ts
+++ b/client/web/src/enterprise/insights/core/types/insight/types/lang-stat-insight.ts
@@ -1,4 +1,4 @@
-import { BaseInsight, InsightExecutionType, InsightType } from './common'
+import { BaseInsight, InsightExecutionType, InsightType } from '../common'
 
 /**
  * Extended Lang Stats Insight.

--- a/client/web/src/enterprise/insights/core/types/insight/types/lang-stat-insight.ts
+++ b/client/web/src/enterprise/insights/core/types/insight/types/lang-stat-insight.ts
@@ -1,4 +1,4 @@
-import { InsightExecutionType, InsightType } from '../common'
+import { BaseInsight, InsightExecutionType, InsightType } from './common'
 
 /**
  * Extended Lang Stats Insight.
@@ -8,12 +8,9 @@ import { InsightExecutionType, InsightType } from '../common'
  * Note: Lang stats insight works only via Extension API and doesn't have a be version
  * (like search based insight has)
  */
-export interface LangStatsInsight {
-    id: string
+export interface LangStatsInsight extends BaseInsight {
     executionType: InsightExecutionType.Runtime
     type: InsightType.LangStats
-    title: string
     repository: string
     otherThreshold: number
-    dashboardReferenceCount: number
 }

--- a/client/web/src/enterprise/insights/core/types/insight/types/search-insight.ts
+++ b/client/web/src/enterprise/insights/core/types/insight/types/search-insight.ts
@@ -1,6 +1,6 @@
 import { Duration } from 'date-fns'
 
-import { BaseInsight, InsightExecutionType, InsightFilters, InsightType } from './common'
+import { BaseInsight, InsightExecutionType, InsightFilters, InsightType } from '../common'
 
 export type SearchBasedInsight = SearchRuntimeBasedInsight | SearchBackendBasedInsight
 

--- a/client/web/src/enterprise/insights/core/types/insight/types/search-insight.ts
+++ b/client/web/src/enterprise/insights/core/types/insight/types/search-insight.ts
@@ -1,28 +1,22 @@
 import { Duration } from 'date-fns'
 
-import { InsightExecutionType, InsightFilters, InsightType } from '../common'
+import { BaseInsight, InsightExecutionType, InsightFilters, InsightType } from './common'
 
 export type SearchBasedInsight = SearchRuntimeBasedInsight | SearchBackendBasedInsight
 
-export interface SearchRuntimeBasedInsight {
-    id: string
-    title: string
+export interface SearchRuntimeBasedInsight extends BaseInsight {
     repositories: string[]
     series: SearchBasedInsightSeries[]
     step: Duration
-    dashboardReferenceCount: number
 
     executionType: InsightExecutionType.Runtime
     type: InsightType.SearchBased
 }
 
-export interface SearchBackendBasedInsight {
-    id: string
-    title: string
+export interface SearchBackendBasedInsight extends BaseInsight {
     filters: InsightFilters
     series: SearchBasedInsightSeries[]
     step: Duration
-    dashboardReferenceCount: number
 
     executionType: InsightExecutionType.Backend
     type: InsightType.SearchBased

--- a/client/web/src/enterprise/insights/hooks/use-ui-features.ts
+++ b/client/web/src/enterprise/insights/hooks/use-ui-features.ts
@@ -38,7 +38,7 @@ export interface UseUiFeatures {
     insight: {
         getContextActionsPermissions: (insight: Insight) => { showYAxis: boolean }
         getCreationPermissions: () => Observable<{ available: boolean }>
-        getEditPermissions: () => Observable<{ available: boolean }>
+        getEditPermissions: (insight: Insight) => Observable<{ available: boolean }>
     }
 }
 
@@ -95,7 +95,7 @@ export function useUiFeatures(): UseUiFeatures {
                     insightsLimit !== null
                         ? hasInsights(insightsLimit).pipe(map(reachedLimit => ({ available: !reachedLimit })))
                         : of({ available: true }),
-                getEditPermissions: () => of({ available: true }),
+                getEditPermissions: (insight: Insight) => of({ available: licensed || !insight.isFrozen }),
             },
         }),
         [licensed, insightsLimit, hasInsights]

--- a/client/web/src/enterprise/insights/pages/dashboards/creation/components/InsightsDashboardCreationContent.module.scss
+++ b/client/web/src/enterprise/insights/pages/dashboards/creation/components/InsightsDashboardCreationContent.module.scss
@@ -1,0 +1,3 @@
+.limited-banner {
+    margin: 1rem 0 1.5rem 0;
+}

--- a/client/web/src/enterprise/insights/pages/dashboards/creation/components/InsightsDashboardCreationContent.tsx
+++ b/client/web/src/enterprise/insights/pages/dashboards/creation/components/InsightsDashboardCreationContent.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from 'react'
+import React, { ReactNode, useContext } from 'react'
 
 import classNames from 'classnames'
 
@@ -12,8 +12,7 @@ import { FORM_ERROR, FormAPI, SubmissionErrors, useForm } from '../../../../comp
 import { createRequiredValidator } from '../../../../components/form/validators'
 import { LimitedAccessLabel } from '../../../../components/limited-access-label/LimitedAccessLabel'
 import { CodeInsightsBackendContext } from '../../../../core/backend/code-insights-backend-context'
-import { InsightsDashboardOwner } from '../../../../core/types'
-import { isGlobalSubject, isOrganizationSubject, isUserSubject } from '../../../../core/types/subjects'
+import { InsightsDashboardOwner, isGlobalOwner, isOrganizationOwner, isPersonalOwner } from '../../../../core/types'
 
 import styles from './InsightsDashboardCreationContent.module.scss'
 
@@ -42,17 +41,13 @@ export interface InsightsDashboardCreationContentProps {
 export const InsightsDashboardCreationContent: React.FunctionComponent<InsightsDashboardCreationContentProps> = props => {
     const { initialValues, owners, onSubmit, children } = props
 
-    const { findDashboardByName } = useContext(CodeInsightsBackendContext)
-
     const { UIFeatures } = useContext(CodeInsightsBackendContext)
     const { licensed } = UIFeatures
 
-    // We always have user subject in our settings cascade
-    const userSubjectID = subjects.find(isUserSubject)?.id ?? ''
-    const organizationSubjects = subjects.filter(isOrganizationSubject)
-
-    // We always have global subject in our settings cascade
-    const globalSubject = subjects.find(isGlobalSubject)
+    const userOwner = owners.find(isPersonalOwner)
+    const personalOwners = owners.filter(isPersonalOwner)
+    const organizationOwners = owners.filter(isOrganizationOwner)
+    const globalOwners = owners.filter(isGlobalOwner)
 
     const { ref, handleSubmit, formAPI } = useForm<DashboardCreationFields>({
         initialValues: initialValues ?? {

--- a/client/web/src/enterprise/insights/pages/insights/creation/capture-group/components/CaptureGoupCreationForm.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/capture-group/components/CaptureGoupCreationForm.tsx
@@ -13,6 +13,7 @@ import { useFieldAPI } from '../../../../../components/form/hooks/useField'
 import { Form, FORM_ERROR } from '../../../../../components/form/hooks/useForm'
 import { RepositoriesField } from '../../../../../components/form/repositories-field/RepositoriesField'
 import { LimitedAccessLabel } from '../../../../../components/limited-access-label/LimitedAccessLabel'
+import { Insight } from '../../../../../core/types'
 import { useUiFeatures } from '../../../../../hooks/use-ui-features'
 import { CaptureGroupFormFields } from '../types'
 import { searchQueryValidator } from '../utils/search-query-validator'
@@ -34,6 +35,7 @@ interface CaptureGroupCreationFormProps {
     dashboardReferenceCount?: number
     isFormClearActive?: boolean
     className?: string
+    insight?: Insight
 
     onCancel: () => void
     onFormReset: () => void
@@ -54,6 +56,7 @@ export const CaptureGroupCreationForm: React.FunctionComponent<CaptureGroupCreat
         isFormClearActive,
         onFormReset,
         onCancel,
+        insight,
     } = props
 
     const {
@@ -62,14 +65,17 @@ export const CaptureGroupCreationForm: React.FunctionComponent<CaptureGroupCreat
         formAPI: { submitErrors, submitting },
     } = form
 
-    const { licensed, insight } = useUiFeatures()
+    const { licensed, insight: insightFeatures } = useUiFeatures()
     const isEditMode = mode === 'edit'
 
     const creationPermission = useObservable(
-        useMemo(() => (isEditMode ? insight.getEditPermissions() : insight.getCreationPermissions()), [
-            insight,
-            isEditMode,
-        ])
+        useMemo(
+            () =>
+                isEditMode && insight
+                    ? insightFeatures.getEditPermissions(insight)
+                    : insightFeatures.getCreationPermissions(),
+            [insightFeatures, isEditMode, insight]
+        )
     )
 
     return (

--- a/client/web/src/enterprise/insights/pages/insights/creation/capture-group/components/CaptureGroupCreationContent.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/capture-group/components/CaptureGroupCreationContent.tsx
@@ -8,6 +8,7 @@ import { useAsyncInsightTitleValidator } from '../../../../../components/form/ho
 import { useField } from '../../../../../components/form/hooks/useField'
 import { FormChangeEvent, SubmissionErrors, useForm } from '../../../../../components/form/hooks/useForm'
 import { createRequiredValidator } from '../../../../../components/form/validators'
+import { Insight } from '../../../../../core/types'
 import {
     repositoriesExistValidator,
     repositoriesFieldValidator,
@@ -36,6 +37,7 @@ interface CaptureGroupCreationContentProps {
     mode: 'creation' | 'edit'
     initialValues?: Partial<CaptureGroupFormFields>
     className?: string
+    insight?: Insight
 
     onSubmit: (values: CaptureGroupFormFields) => SubmissionErrors | Promise<SubmissionErrors> | void
     onChange?: (event: FormChangeEvent<CaptureGroupFormFields>) => void
@@ -43,7 +45,7 @@ interface CaptureGroupCreationContentProps {
 }
 
 export const CaptureGroupCreationContent: React.FunctionComponent<CaptureGroupCreationContentProps> = props => {
-    const { mode, className, initialValues = {}, onSubmit, onChange = noop, onCancel } = props
+    const { mode, className, initialValues = {}, onSubmit, onChange = noop, onCancel, insight } = props
 
     // Search query validators
     const validateChecks = useCallback((value: string | undefined) => {
@@ -156,11 +158,12 @@ export const CaptureGroupCreationContent: React.FunctionComponent<CaptureGroupCr
                 stepValue={stepValue}
                 query={query}
                 isFormClearActive={hasFilledValue}
-                onCancel={onCancel}
-                onFormReset={handleFormReset}
                 className={styles.contentForm}
                 allReposMode={allReposMode}
                 dashboardReferenceCount={initialValues.dashboardReferenceCount}
+                insight={insight}
+                onCancel={onCancel}
+                onFormReset={handleFormReset}
             />
 
             <CaptureGroupCreationLivePreview

--- a/client/web/src/enterprise/insights/pages/insights/creation/lang-stats/components/lang-stats-insight-creation-content/LangStatsInsightCreationContent.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/lang-stats/components/lang-stats-insight-creation-content/LangStatsInsightCreationContent.tsx
@@ -8,6 +8,7 @@ import { useAsyncInsightTitleValidator } from '../../../../../../components/form
 import { useField } from '../../../../../../components/form/hooks/useField'
 import { FormChangeEvent, SubmissionErrors, useForm } from '../../../../../../components/form/hooks/useForm'
 import { createRequiredValidator } from '../../../../../../components/form/validators'
+import { Insight } from '../../../../../../core/types'
 import { LangStatsCreationFormFields } from '../../types'
 import { LangStatsInsightCreationForm } from '../lang-stats-insight-creation-form/LangStatsInsightCreationForm'
 import { LangStatsInsightLivePreview } from '../live-preview-chart/LangStatsInsightLivePreview'
@@ -32,6 +33,7 @@ export interface LangStatsInsightCreationContentProps {
 
     initialValues?: Partial<LangStatsCreationFormFields>
     className?: string
+    insight?: Insight
 
     onSubmit: (values: LangStatsCreationFormFields) => SubmissionErrors | Promise<SubmissionErrors> | void
     onCancel?: () => void
@@ -41,7 +43,15 @@ export interface LangStatsInsightCreationContentProps {
 }
 
 export const LangStatsInsightCreationContent: React.FunctionComponent<LangStatsInsightCreationContentProps> = props => {
-    const { mode = 'creation', initialValues = {}, className, onSubmit, onCancel = noop, onChange = noop } = props
+    const {
+        mode = 'creation',
+        initialValues = {},
+        className,
+        onSubmit,
+        onCancel = noop,
+        onChange = noop,
+        insight,
+    } = props
 
     const { values, handleSubmit, formAPI, ref } = useForm<LangStatsCreationFormFields>({
         initialValues: {
@@ -107,6 +117,7 @@ export const LangStatsInsightCreationContent: React.FunctionComponent<LangStatsI
                 isFormClearActive={hasFilledValue}
                 dashboardReferenceCount={initialValues.dashboardReferenceCount}
                 className={styles.contentForm}
+                insight={insight}
                 onCancel={onCancel}
                 onFormReset={handleFormReset}
             />

--- a/client/web/src/enterprise/insights/pages/insights/creation/lang-stats/components/lang-stats-insight-creation-form/LangStatsInsightCreationForm.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/lang-stats/components/lang-stats-insight-creation-form/LangStatsInsightCreationForm.tsx
@@ -12,6 +12,7 @@ import { useFieldAPI } from '../../../../../../components/form/hooks/useField'
 import { FORM_ERROR, SubmissionErrors } from '../../../../../../components/form/hooks/useForm'
 import { RepositoryField } from '../../../../../../components/form/repositories-field/RepositoryField'
 import { LimitedAccessLabel } from '../../../../../../components/limited-access-label/LimitedAccessLabel'
+import { Insight } from '../../../../../../core/types'
 import { useUiFeatures } from '../../../../../../hooks/use-ui-features'
 import { LangStatsCreationFormFields } from '../../types'
 
@@ -30,6 +31,7 @@ export interface LangStatsInsightCreationFormProps {
     title: useFieldAPI<LangStatsCreationFormFields['title']>
     repository: useFieldAPI<LangStatsCreationFormFields['repository']>
     threshold: useFieldAPI<LangStatsCreationFormFields['threshold']>
+    insight?: Insight
 
     onCancel: () => void
     onFormReset: () => void
@@ -50,16 +52,20 @@ export const LangStatsInsightCreationForm: React.FunctionComponent<LangStatsInsi
         dashboardReferenceCount,
         onCancel,
         onFormReset,
+        insight,
     } = props
 
     const isEditMode = mode === 'edit'
-    const { licensed, insight } = useUiFeatures()
+    const { licensed, insight: insightFeatures } = useUiFeatures()
 
     const creationPermission = useObservable(
-        useMemo(() => (isEditMode ? insight.getEditPermissions() : insight.getCreationPermissions()), [
-            insight,
-            isEditMode,
-        ])
+        useMemo(
+            () =>
+                isEditMode && insight
+                    ? insightFeatures.getEditPermissions(insight)
+                    : insightFeatures.getCreationPermissions(),
+            [insightFeatures, isEditMode, insight]
+        )
     )
 
     return (

--- a/client/web/src/enterprise/insights/pages/insights/creation/search-insight/components/search-insight-creation-content/SearchInsightCreationContent.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/search-insight/components/search-insight-creation-content/SearchInsightCreationContent.tsx
@@ -5,6 +5,7 @@ import { noop } from 'rxjs'
 
 import { styles } from '../../../../../../components/creation-ui-kit'
 import { FormChangeEvent, SubmissionErrors } from '../../../../../../components/form/hooks/useForm'
+import { Insight } from '../../../../../../core/types'
 import { CreateInsightFormFields } from '../../types'
 import { SearchInsightLivePreview } from '../live-preview-chart/SearchInsightLivePreview'
 import { SearchInsightCreationForm } from '../search-insight-creation-form/SearchInsightCreationForm'
@@ -19,6 +20,7 @@ export interface SearchInsightCreationContentProps {
     initialValue?: Partial<CreateInsightFormFields>
     className?: string
     dataTestId?: string
+    insight?: Insight
 
     onSubmit: (values: CreateInsightFormFields) => SubmissionErrors | Promise<SubmissionErrors> | void
     onCancel?: () => void
@@ -28,7 +30,16 @@ export interface SearchInsightCreationContentProps {
 }
 
 export const SearchInsightCreationContent: React.FunctionComponent<SearchInsightCreationContentProps> = props => {
-    const { mode = 'creation', initialValue, className, dataTestId, onSubmit, onCancel = noop, onChange = noop } = props
+    const {
+        mode = 'creation',
+        initialValue,
+        className,
+        dataTestId,
+        insight,
+        onSubmit,
+        onCancel = noop,
+        onChange = noop,
+    } = props
 
     const {
         form: { values, formAPI, ref, handleSubmit },
@@ -90,6 +101,7 @@ export const SearchInsightCreationContent: React.FunctionComponent<SearchInsight
                 stepValue={stepValue}
                 isFormClearActive={hasFilledValue}
                 dashboardReferenceCount={initialValue?.dashboardReferenceCount}
+                insight={insight}
                 onSeriesLiveChange={listen}
                 onCancel={onCancel}
                 onEditSeriesRequest={editRequest}

--- a/client/web/src/enterprise/insights/pages/insights/creation/search-insight/components/search-insight-creation-form/SearchInsightCreationForm.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/search-insight/components/search-insight-creation-form/SearchInsightCreationForm.tsx
@@ -14,6 +14,7 @@ import { useFieldAPI } from '../../../../../../components/form/hooks/useField'
 import { FORM_ERROR, SubmissionErrors } from '../../../../../../components/form/hooks/useForm'
 import { RepositoriesField } from '../../../../../../components/form/repositories-field/RepositoriesField'
 import { LimitedAccessLabel } from '../../../../../../components/limited-access-label/LimitedAccessLabel'
+import { Insight } from '../../../../../../core/types'
 import { useUiFeatures } from '../../../../../../hooks/use-ui-features'
 import { CreateInsightFormFields, EditableDataSeries } from '../../types'
 import { FormSeries } from '../form-series/FormSeries'
@@ -38,6 +39,7 @@ interface CreationSearchInsightFormProps {
     series: useFieldAPI<CreateInsightFormFields['series']>
     step: useFieldAPI<CreateInsightFormFields['step']>
     stepValue: useFieldAPI<CreateInsightFormFields['stepValue']>
+    insight?: Insight
 
     onCancel: () => void
 
@@ -80,6 +82,7 @@ export const SearchInsightCreationForm: React.FunctionComponent<CreationSearchIn
         className,
         isFormClearActive,
         dashboardReferenceCount,
+        insight,
         onCancel,
         onSeriesLiveChange,
         onEditSeriesRequest,
@@ -90,13 +93,16 @@ export const SearchInsightCreationForm: React.FunctionComponent<CreationSearchIn
     } = props
 
     const isEditMode = mode === 'edit'
-    const { licensed, insight } = useUiFeatures()
+    const { licensed, insight: insightFeatures } = useUiFeatures()
 
     const creationPermission = useObservable(
-        useMemo(() => (isEditMode ? insight.getEditPermissions() : insight.getCreationPermissions()), [
-            insight,
-            isEditMode,
-        ])
+        useMemo(
+            () =>
+                isEditMode && insight
+                    ? insightFeatures.getEditPermissions(insight)
+                    : insightFeatures.getCreationPermissions(),
+            [insightFeatures, isEditMode, insight]
+        )
     )
 
     return (
@@ -200,8 +206,8 @@ export const SearchInsightCreationForm: React.FunctionComponent<CreationSearchIn
 
             <hr className="my-4 w-100" />
 
-            {!licensed && !isEditMode && (
-                <LimitedAccessLabel message="Unlock Code Insights to create unlimited insights" className="my-3" />
+            {!licensed && (
+                <LimitedAccessLabel message="Unlock Code Insights to create unlimited insights" className="mb-3" />
             )}
 
             <div className="d-flex flex-wrap align-items-center">

--- a/client/web/src/enterprise/insights/pages/insights/edit-insight/components/EditCaptureGroupInsight.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/edit-insight/components/EditCaptureGroupInsight.tsx
@@ -43,6 +43,7 @@ export const EditCaptureGroupInsight: React.FunctionComponent<EditCaptureGroupIn
             mode="edit"
             initialValues={insightFormValues}
             className="pb-5"
+            insight={insight}
             onSubmit={handleSubmit}
             onCancel={onCancel}
         />

--- a/client/web/src/enterprise/insights/pages/insights/edit-insight/components/EditLangStatsInsight.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/edit-insight/components/EditLangStatsInsight.tsx
@@ -38,6 +38,7 @@ export const EditLangStatsInsight: React.FunctionComponent<EditLangStatsInsightP
             mode="edit"
             className="pb-5"
             initialValues={insightFormValues}
+            insight={insight}
             onSubmit={handleSubmit}
             onCancel={onCancel}
         />

--- a/client/web/src/enterprise/insights/pages/insights/edit-insight/components/EditSearchInsight.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/edit-insight/components/EditSearchInsight.tsx
@@ -65,6 +65,7 @@ export const EditSearchBasedInsight: React.FunctionComponent<EditSearchBasedInsi
             className="pb-5"
             onSubmit={handleSubmit}
             onCancel={onCancel}
+            insight={insight}
         />
     )
 }

--- a/client/web/src/integration/insights/fixtures/insights-metadata.ts
+++ b/client/web/src/integration/insights/fixtures/insights-metadata.ts
@@ -8,6 +8,7 @@ export const createJITMigrationToGQLInsightMetadataFixture = (options: InsightOp
     __typename: 'InsightView',
     id: '001',
     dashboardReferenceCount: 0,
+    isFrozen: false,
     appliedFilters: {
         __typename: 'InsightViewFilters',
         includeRepoRegex: '',
@@ -71,6 +72,7 @@ export const STORYBOOK_GROWTH_INSIGHT_METADATA_FIXTURE: InsightViewNode = {
     __typename: 'InsightView',
     id: '002',
     dashboardReferenceCount: 0,
+    isFrozen: false,
     appliedFilters: {
         __typename: 'InsightViewFilters',
         includeRepoRegex: '',
@@ -112,6 +114,7 @@ export const SOURCEGRAPH_LANG_STATS_INSIGHT_METADATA_FIXTURE: InsightViewNode = 
     __typename: 'InsightView',
     id: '003',
     dashboardReferenceCount: 0,
+    isFrozen: false,
     appliedFilters: {
         __typename: 'InsightViewFilters',
         includeRepoRegex: '',

--- a/client/web/src/views/components/view/View.module.scss
+++ b/client/web/src/views/components/view/View.module.scss
@@ -17,6 +17,7 @@
 
 .header-content {
     display: flex;
+    min-height: 2rem;
 }
 
 .title {

--- a/client/web/src/views/components/view/content/ViewContent.tsx
+++ b/client/web/src/views/components/view/content/ViewContent.tsx
@@ -28,6 +28,7 @@ export interface ViewContentProps extends React.HTMLAttributes<HTMLElement> {
      * the chart datum (pie arc, line point, bar category)
      */
     onDatumLinkClick?: () => void
+    locked?: boolean
 }
 
 /**
@@ -38,7 +39,7 @@ export interface ViewContentProps extends React.HTMLAttributes<HTMLElement> {
  * without notice.
  */
 export const ViewContent: React.FunctionComponent<ViewContentProps> = props => {
-    const { content, alert, layout, className, onDatumLinkClick, ...attributes } = props
+    const { content, alert, layout, className, onDatumLinkClick, locked = false, ...attributes } = props
 
     return (
         <div {...attributes} className={classNames(styles.viewContent, className)}>
@@ -63,6 +64,7 @@ export const ViewContent: React.FunctionComponent<ViewContentProps> = props => {
                             layout={layout}
                             className="flex-grow-1"
                             onDatumLinkClick={onDatumLinkClick}
+                            locked={locked}
                         />
                     </React.Fragment>
                 ) : null

--- a/client/web/src/views/components/view/content/chart-view-content/ChartViewContent.story.tsx
+++ b/client/web/src/views/components/view/content/chart-view-content/ChartViewContent.story.tsx
@@ -23,6 +23,7 @@ const commonProps = {
     viewID: '1',
     telemetryService: NOOP_TELEMETRY_SERVICE,
     className: styles.chart,
+    locked: false,
 }
 
 const { add } = storiesOf('web/ChartViewContent', module).addDecorator(story => (

--- a/client/web/src/views/components/view/content/chart-view-content/ChartViewContent.tsx
+++ b/client/web/src/views/components/view/content/chart-view-content/ChartViewContent.tsx
@@ -38,13 +38,20 @@ export interface ChartViewContentProps {
      * the chart datum (pie arc, line point, bar category)
      */
     onDatumLinkClick?: () => void
+    locked?: boolean
 }
 
 /**
  * Display chart content with different type of charts (line, bar, pie)
  */
 export const ChartViewContent: FunctionComponent<ChartViewContentProps> = props => {
-    const { content, className = '', layout = ChartViewContentLayout.ByParentSize, onDatumLinkClick = noop } = props
+    const {
+        content,
+        className = '',
+        layout = ChartViewContentLayout.ByParentSize,
+        onDatumLinkClick = noop,
+        locked = false,
+    } = props
 
     // Click link-zone handler for line chart only. Catch click around point and redirect user by
     // link which we've got from the nearest datum point to user cursor position. This allows user
@@ -80,19 +87,32 @@ export const ChartViewContent: FunctionComponent<ChartViewContentProps> = props 
                                 width={width}
                                 height={height}
                                 hasChartParentFixedSize={isResponsive}
+                                locked={locked}
                             />
                         )
                     }
 
                     if (content.chart === 'bar') {
                         return (
-                            <BarChart {...content} width={width} height={height} onDatumLinkClick={onDatumLinkClick} />
+                            <BarChart
+                                {...content}
+                                width={width}
+                                height={height}
+                                onDatumLinkClick={onDatumLinkClick}
+                                locked={locked}
+                            />
                         )
                     }
 
                     if (content.chart === 'pie') {
                         return (
-                            <PieChart {...content} width={width} height={height} onDatumLinkClick={onDatumLinkClick} />
+                            <PieChart
+                                {...content}
+                                width={width}
+                                height={height}
+                                onDatumLinkClick={onDatumLinkClick}
+                                locked={locked}
+                            />
                         )
                     }
 

--- a/client/web/src/views/components/view/content/chart-view-content/charts/bar/BarChart.tsx
+++ b/client/web/src/views/components/view/content/chart-view-content/charts/bar/BarChart.tsx
@@ -11,6 +11,7 @@ import classNames from 'classnames'
 import { range } from 'lodash'
 import { BarChartContent } from 'sourcegraph'
 
+import { LockedChart } from '../locked/LockedChart'
 import { MaybeLink } from '../MaybeLink'
 
 import styles from './BarChart.module.scss'
@@ -36,6 +37,7 @@ interface BarChartProps<Datum extends object> extends Omit<BarChartContent<Datum
     height: number
     /** Callback calls every time when a bar-link on the chart was clicked */
     onDatumLinkClick: (event: React.MouseEvent) => void
+    locked?: boolean
 }
 
 /**
@@ -49,6 +51,7 @@ export function BarChart<Datum extends object>(props: BarChartProps<Datum>): Rea
         series,
         onDatumLinkClick,
         xAxis: { dataKey: xDataKey },
+        locked = false,
     } = props
 
     // Respect only first element of data series
@@ -98,6 +101,10 @@ export function BarChart<Datum extends object>(props: BarChartProps<Datum>): Rea
         tooltipTimeout = window.setTimeout(() => {
             hideTooltip()
         }, 300)
+    }
+
+    if (locked) {
+        return <LockedChart />
     }
 
     return (

--- a/client/web/src/views/components/view/content/chart-view-content/charts/line/LineChart.tsx
+++ b/client/web/src/views/components/view/content/chart-view-content/charts/line/LineChart.tsx
@@ -3,6 +3,8 @@ import React, { ReactElement, useContext } from 'react'
 import { ParentSize } from '@visx/responsive'
 import classNames from 'classnames'
 
+import { LockedChart } from '../locked/LockedChart'
+
 import { getLineStroke, LineChart as LineChartContent, LineChartContentProps } from './components/LineChartContent'
 import { ScrollBox } from './components/scroll-box/ScrollBox'
 import { MINIMAL_HORIZONTAL_LAYOUT_WIDTH, MINIMAL_SERIES_FOR_ASIDE_LEGEND } from './constants'
@@ -16,13 +18,14 @@ export interface LineChartProps<Datum extends object> extends LineChartContentPr
      * By default, LineChart doesn't require
      */
     hasChartParentFixedSize?: boolean
+    locked?: boolean
 }
 
 /**
  * Display responsive line chart with legend below the chart.
  */
 export function LineChart<Datum extends object>(props: LineChartProps<Datum>): ReactElement {
-    const { width, height, hasChartParentFixedSize, ...otherProps } = props
+    const { width, height, hasChartParentFixedSize, locked = false, ...otherProps } = props
     const { layout } = useContext(LineChartSettingsContext)
 
     const hasViewManySeries = otherProps.series.length > MINIMAL_SERIES_FOR_ASIDE_LEGEND
@@ -46,7 +49,9 @@ export function LineChart<Datum extends object>(props: LineChartProps<Datum>): R
                 just to calculate right sizes for chart content = rootContainerSizes - legendSizes
             */}
             <ParentSize className={styles.contentParentSize} data-line-chart-size-root="">
-                {({ width, height }) => <LineChartContent {...otherProps} width={width} height={height} />}
+                {({ width, height }) =>
+                    locked ? <LockedChart /> : <LineChartContent {...otherProps} width={width} height={height} />
+                }
             </ParentSize>
 
             <ScrollBox

--- a/client/web/src/views/components/view/content/chart-view-content/charts/locked/LockedChart.module.scss
+++ b/client/web/src/views/components/view/content/chart-view-content/charts/locked/LockedChart.module.scss
@@ -1,0 +1,30 @@
+.wrapper {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    margin: 0 2rem;
+    border-top: solid 1px var(--border-color);
+    border-bottom: solid 1px var(--border-color);
+    justify-content: center;
+    align-items: center;
+    color: var(--icon-color);
+}
+
+.banner {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    margin-top: 1.25rem;
+}
+
+.banner span {
+    color: var(--purple-03);
+    text-transform: uppercase;
+    padding-right: 0.5rem;
+    margin-right: 0.5rem;
+    border-right: solid 1px var(--purple-01);
+}
+
+.banner small {
+    color: var(--text-muted);
+}

--- a/client/web/src/views/components/view/content/chart-view-content/charts/locked/LockedChart.tsx
+++ b/client/web/src/views/components/view/content/chart-view-content/charts/locked/LockedChart.tsx
@@ -1,3 +1,16 @@
 import React from 'react'
 
-export const LockedChart: React.FunctionComponent = () => <div>It's locked alright</div>
+import classNames from 'classnames'
+import LockIcon from 'mdi-react/LockOutlineIcon'
+
+import styles from './LockedChart.module.scss'
+
+export const LockedChart: React.FunctionComponent<{ className?: string }> = ({ className }) => (
+    <section className={classNames(styles.wrapper, className)}>
+        <LockIcon size={40} />
+        <div className={classNames(styles.banner)}>
+            <span>Limited access</span>
+            <small>Insight locked</small>
+        </div>
+    </section>
+)

--- a/client/web/src/views/components/view/content/chart-view-content/charts/locked/LockedChart.tsx
+++ b/client/web/src/views/components/view/content/chart-view-content/charts/locked/LockedChart.tsx
@@ -1,0 +1,3 @@
+import React from 'react'
+
+export const LockedChart: React.FunctionComponent = () => <div>It's locked alright</div>

--- a/client/web/src/views/components/view/content/chart-view-content/charts/pie/PieChart.module.scss
+++ b/client/web/src/views/components/view/content/chart-view-content/charts/pie/PieChart.module.scss
@@ -6,3 +6,7 @@
     stroke-width: 3;
     stroke: var(--primary);
 }
+
+.locked-chart {
+    margin-bottom: 2rem;
+}

--- a/client/web/src/views/components/view/content/chart-view-content/charts/pie/PieChart.tsx
+++ b/client/web/src/views/components/view/content/chart-view-content/charts/pie/PieChart.tsx
@@ -5,6 +5,7 @@ import Pie, { PieArcDatum } from '@visx/shape/lib/shapes/Pie'
 import { noop } from 'rxjs'
 import { PieChartContent } from 'sourcegraph'
 
+import { LockedChart } from '../locked/LockedChart'
 import { MaybeLink } from '../MaybeLink'
 
 import { PieArc } from './components/PieArc'
@@ -29,10 +30,11 @@ export interface PieChartProps<Datum extends object> extends PieChartContent<Dat
     onDatumLinkClick?: (event: React.MouseEvent) => void
     /** Chart padding in px */
     padding?: typeof DEFAULT_PADDING
+    locked?: boolean
 }
 
 export function PieChart<Datum extends object>(props: PieChartProps<Datum>): ReactElement | null {
-    const { width, height, padding = DEFAULT_PADDING, pies, onDatumLinkClick = noop } = props
+    const { width, height, padding = DEFAULT_PADDING, pies, onDatumLinkClick = noop, locked = false } = props
 
     // We have to track which arc is hovered to change order of rendering.
     // Due the fact svg elements don't have css z-index (in svg only order of renderings matters)
@@ -65,6 +67,10 @@ export function PieChart<Datum extends object>(props: PieChartProps<Datum>): Rea
             ),
         [sortedData, dataKey]
     )
+
+    if (locked) {
+        return <LockedChart />
+    }
 
     // Potential problem, we use title/name of pie arc as key, that's not 100% unique value
     // TODO change this we will have id for each pie

--- a/client/web/src/views/components/view/content/chart-view-content/charts/pie/PieChart.tsx
+++ b/client/web/src/views/components/view/content/chart-view-content/charts/pie/PieChart.tsx
@@ -69,7 +69,7 @@ export function PieChart<Datum extends object>(props: PieChartProps<Datum>): Rea
     )
 
     if (locked) {
-        return <LockedChart />
+        return <LockedChart className={styles.lockedChart} />
     }
 
     // Potential problem, we use title/name of pie arc as key, that's not 100% unique value


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/32164

## Test plan

Should match designs: https://www.figma.com/file/38cMCA2pOScKIqzt3ZNuiz/Limited-access-mode-RFC-Private-567-%2330165-%5BREADY-FOR-DEV%5D?node-id=1117%3A4436

The easiest way to test this is to run the app locally `sg start enterprise-codeinsights`
Add at least 3 insights to a global dashboard with a dev license
Change to starter license
Review designs from right most design to left deleting insights to see the layouts with two, one, and zero insights.