### PR TITLE
db: add queued_at column to gitserver_localclone_jobs

### DIFF
--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -1008,6 +1008,7 @@ Referenced by:
  source_hostname   | text                     |           | not null | 
  dest_hostname     | text                     |           | not null | 
  delete_source     | boolean                  |           | not null | false
+ queued_at         | timestamp with time zone |           |          | now()
 Indexes:
     "gitserver_localclone_jobs_pkey" PRIMARY KEY, btree (id)
 
@@ -2642,6 +2643,7 @@ Foreign-key constraints:
  source_hostname   | text                     |           |          | 
  dest_hostname     | text                     |           |          | 
  delete_source     | boolean                  |           |          | 
+ queued_at         | timestamp with time zone |           |          | 
  repo_name         | citext                   |           |          | 
 
 ```
@@ -2664,6 +2666,7 @@ Foreign-key constraints:
     glj.source_hostname,
     glj.dest_hostname,
     glj.delete_source,
+    glj.queued_at,
     r.name AS repo_name
    FROM (gitserver_localclone_jobs glj
      JOIN repo r ON ((r.id = glj.repo_id)));

--- a/migrations/frontend/1648195639/down.sql
+++ b/migrations/frontend/1648195639/down.sql
@@ -1,0 +1,12 @@
+
+-- drop view
+DROP VIEW IF EXISTS gitserver_localclone_jobs_with_repo_name;
+
+-- drop the column
+ALTER TABLE gitserver_localclone_jobs DROP COLUMN IF EXISTS queued_at;
+
+-- recreate the view without the column
+CREATE OR REPLACE VIEW gitserver_localclone_jobs_with_repo_name AS
+  SELECT glj.*, r.name AS repo_name
+  FROM gitserver_localclone_jobs glj
+  JOIN repo r ON r.id = glj.repo_id;

--- a/migrations/frontend/1648195639/metadata.yaml
+++ b/migrations/frontend/1648195639/metadata.yaml
@@ -1,0 +1,2 @@
+name: add_localclone_worker_queued_at
+parents: [1648051770, 1648115472]

--- a/migrations/frontend/1648195639/up.sql
+++ b/migrations/frontend/1648195639/up.sql
@@ -1,0 +1,10 @@
+ALTER TABLE gitserver_localclone_jobs ADD COLUMN IF NOT EXISTS queued_at timestamptz DEFAULT NOW();
+
+-- drop view and recreate it with the new column
+
+DROP VIEW IF EXISTS gitserver_localclone_jobs_with_repo_name;
+
+CREATE OR REPLACE VIEW gitserver_localclone_jobs_with_repo_name AS
+  SELECT glj.*, r.name AS repo_name
+  FROM gitserver_localclone_jobs glj
+  JOIN repo r ON r.id = glj.repo_id;


### PR DESCRIPTION
This adds a missing column to the `gitserver_localclone_jobs`. I also updated the worker [documentation](https://github.com/sourcegraph/sourcegraph/pull/33066) to avoid making that mistake again.
Adding a column requires rebuilding views.

## Test plan

sg migration up and undo


Related to #32827