### PR TITLE
Code Insights: Disabled Code Insights visual tests

### DIFF
--- a/client/web/src/integration/insights/insights-visual.test.ts
+++ b/client/web/src/integration/insights/insights-visual.test.ts
@@ -19,7 +19,10 @@ import {
 } from './fixtures/runtime-insights'
 import { overrideInsightsGraphQLApi } from './utils/override-insights-graphql-api'
 
-describe('[VISUAL] Code insights page', () => {
+// Disable these tests since SVG elements rendering is super flaky in the Percy sandbox,
+// Enable these visual code insights tests when we finish the investigation around screenshot
+// testing tooling.
+describe.skip('[VISUAL] Code insights page', () => {
     let driver: Driver
     let testContext: WebIntegrationTestContext
 


### PR DESCRIPTION

Due to the flakiness of Code Insights Percy screenshot around the charts, this PR simply skips the visual code insights tests.


## Test plan
- Make sure that Percy doesn't have Code Insights charts screenshot


