### PR TITLE
gitserver: fix hostname in RequestRepoMigrate

### DIFF
--- a/cmd/gitserver/server/server_test.go
+++ b/cmd/gitserver/server/server_test.go
@@ -840,12 +840,13 @@ func TestHandleRepoUpdateFromShard(t *testing.T) {
 		t.Fatal(diff)
 	}
 
-	// if the repo is already cloned, it should not fail
-	// let's run the same request again
+	// let's run the same request again.
+	// If the repo is already cloned, handleRepoUpdate will trigger an update instead of a clone.
+	// Because this test doesn't mock that code path, the method will return an error.
 	resp = runAndCheck(t, httptest.NewRequest("GET", "/repo-update", bytes.NewReader(body)))
 	// we ignore the error, since this should trigger a fetch and fail because the URI is fake
 
-	// the repo should be cloned though
+	// the repo should still be cloned though
 	if !resp.Cloned {
 		t.Fatal("expected cloned to be true")
 	}

--- a/cmd/gitserver/server/server_test.go
+++ b/cmd/gitserver/server/server_test.go
@@ -789,7 +789,6 @@ func TestHandleRepoUpdateFromShard(t *testing.T) {
 	_ = s.Handler()
 
 	// we send a request to the dest server, asking it to clone the repo from the source server
-	rr := httptest.NewRecorder()
 	updateReq := protocol.RepoUpdateRequest{
 		Repo:           repoName,
 		CloneFromShard: srv.URL,
@@ -799,12 +798,27 @@ func TestHandleRepoUpdateFromShard(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// This will perform an initial clone
-	req := httptest.NewRequest("GET", "/repo-update", bytes.NewReader(body))
-	s.handleRepoUpdate(rr, req)
+	runAndCheck := func(t *testing.T, req *http.Request) *protocol.RepoUpdateResponse {
+		t.Helper()
+		rr := httptest.NewRecorder()
+		s.handleRepoUpdate(rr, req)
 
-	if rr.Code != http.StatusOK {
-		t.Fatalf("unexpected status code: %d", rr.Code)
+		if rr.Code != http.StatusOK {
+			t.Fatalf("unexpected status code: %d", rr.Code)
+		}
+
+		var resp protocol.RepoUpdateResponse
+		if err = json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+			t.Fatal(err)
+		}
+
+		return &resp
+	}
+
+	// This will perform an initial clone
+	resp := runAndCheck(t, httptest.NewRequest("GET", "/repo-update", bytes.NewReader(body)))
+	if resp.Error != "" {
+		t.Fatalf("unexpected error: %s", resp.Error)
 	}
 
 	size := dirSize(s.dir(repoName).Path("."))
@@ -824,6 +838,16 @@ func TestHandleRepoUpdateFromShard(t *testing.T) {
 	// We don't expect an error
 	if diff := cmp.Diff(want, fromDB, cmpIgnored); diff != "" {
 		t.Fatal(diff)
+	}
+
+	// if the repo is already cloned, it should not fail
+	// let's run the same request again
+	resp = runAndCheck(t, httptest.NewRequest("GET", "/repo-update", bytes.NewReader(body)))
+	// we ignore the error, since this should trigger a fetch and fail because the URI is fake
+
+	// the repo should be cloned though
+	if !resp.Cloned {
+		t.Fatal("expected cloned to be true")
 	}
 }
 

--- a/internal/gitserver/client.go
+++ b/internal/gitserver/client.go
@@ -818,7 +818,7 @@ func (c *ClientImplementor) RequestRepoMigrate(ctx context.Context, repo api.Rep
 	// ignored.
 	req := &protocol.RepoUpdateRequest{
 		Repo:           repo,
-		CloneFromShard: from,
+		CloneFromShard: "http://" + from,
 	}
 
 	// We set "uri" to the HTTP URL of the gitserver instance that should be the new owner of this

--- a/internal/gitserver/client_test.go
+++ b/internal/gitserver/client_test.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -81,6 +82,14 @@ func TestClient_RequestRepoMigrate(t *testing.T) {
 			// expected is the gitserver instance according to the Rendezvous hashing scheme.
 			// For anything else apart from this we return an error.
 			case expected + "/repo-update":
+				var req protocol.RepoUpdateRequest
+				err := json.NewDecoder(r.Body).Decode(&req)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if req.CloneFromShard != "http://172.16.8.1:8080" {
+					t.Fatalf("expected cloneFromShard to be \"http://172.16.8.1:8080\", got %q", req.CloneFromShard)
+				}
 				return &http.Response{
 					StatusCode: 200,
 					Body:       io.NopCloser(bytes.NewBufferString("{}")),


### PR DESCRIPTION
This adds a missing "http://" prefix to the source hostname in RequestRepoMigrate.

## Test plan

Improved some unit tests

Related to #32827