### PR TITLE
gitserver: simplify logic in getPinnedRepoAddr function

### DIFF
--- a/internal/gitserver/client.go
+++ b/internal/gitserver/client.go
@@ -1327,9 +1327,6 @@ func shouldUseRendezvousHashing(ctx context.Context, db database.DB, repo string
 // getPinnedRepoAddr returns true and gitserver address if given repo is pinned.
 // Otherwise, if repo is not pinned -- false and empty string are returned
 func getPinnedRepoAddr(repo string, pinnedServers map[string]string) (bool, string) {
-	if pinned, found := pinnedServers[repo]; found {
-		return true, pinned
-	} else {
-		return false, ""
-	}
+	pinned, found := pinnedServers[repo]
+	return found, pinned
 }


### PR DESCRIPTION
Just a small non-functional change as per review comment in https://github.com/sourcegraph/sourcegraph/pull/32971

## Test plan
n/a
<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


