### PR TITLE
sg: add a workaround to prevent auto reloading env

### DIFF
--- a/dev/sg/internal/usershell/usershell.go
+++ b/dev/sg/internal/usershell/usershell.go
@@ -102,6 +102,12 @@ func Context(ctx context.Context) (context.Context, error) {
 // changes added by various checks to be run. This negates the new to ask the
 // user to restart sg for many checks.
 func Cmd(ctx context.Context, cmd string) *exec.Cmd {
+	if os.Getenv("SG_DEV_NO_RELOAD_ENV") != "" {
+		// If the user does not want the auto env reloading mechanism, just
+		// perform a standard command.
+		return exec.CommandContext(ctx, ShellPath(ctx), "-c", cmd)
+	}
+
 	if ShellType(ctx) == FishShell {
 		command := fmt.Sprintf("fish || true; %s", cmd)
 		return exec.CommandContext(ctx, ShellPath(ctx), "-c", command)


### PR DESCRIPTION
Bandage fix: add `SG_DEV_NO_RELOAD_ENV` in your env and it will never reload stuff.

Fixes https://github.com/sourcegraph/sourcegraph/pull/32977 

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

- locally tested
- [x] ask @keegancsmith to test it on its machine. 
