### PR TITLE
gitserver: add heuristics to skip maintenance job if possible

### DIFF
--- a/cmd/gitserver/server/cleanup.go
+++ b/cmd/gitserver/server/cleanup.go
@@ -57,9 +57,9 @@ var autoPackLimit, _ = strconv.Atoi(env.Get("SRC_GIT_AUTO_PACK_LIMIT", "50", "th
 
 // Our original Git gc job used 1 as limit, while git's default is 6700. We
 // don't want to be too aggressive to avoid unnecessary IO, hence we choose a
-// value somewhere in the middle. Gitlab's gitaly uses a limit of 1024, which
-// corresponds to an average of 4 loose objects per folder. We can tune this
-// parameter once we gain more experience.
+// value somewhere in the middle. https://gitlab.com/gitlab-org/gitaly uses a
+// limit of 1024, which corresponds to an average of 4 loose objects per folder.
+// We can tune this parameter once we gain more experience.
 var looseObjectsLimit, _ = strconv.Atoi(env.Get("SRC_GIT_LOOSE_OBJECTS_LIMIT", "1024", "the maximum number of loose objects we tolerate before we trigger a repack"))
 
 // sg maintenance and git gc must not be enabled at the same time. However, both
@@ -833,6 +833,8 @@ func needsPruning(dir GitDir) (bool, error) {
 	return tooMany, nil
 }
 
+// We run git-prune only if there are enough loose objects that are older than 2
+// weeks. This approach is adapted from https://gitlab.com/gitlab-org/gitaly.
 func pruneIfNeeded(dir GitDir) error {
 	needed, err := needsPruning(dir)
 	defer func() {

--- a/cmd/gitserver/server/cleanup_test.go
+++ b/cmd/gitserver/server/cleanup_test.go
@@ -3,7 +3,6 @@ package server
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"io"
 	"io/fs"
 	"log"
@@ -850,7 +849,7 @@ func prepareEmptyGitRepo(dir string) error {
 	cmd := exec.Command("/bin/sh", "-euxc", "git init")
 	cmd.Dir = dir
 	if out, err := cmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("execution error: %v, output %s", err, out)
+		return errors.Newf("execution error: %v, output %s", err, out)
 	}
 	return nil
 }

--- a/cmd/gitserver/server/cleanup_test.go
+++ b/cmd/gitserver/server/cleanup_test.go
@@ -917,7 +917,7 @@ func TestTooManyLooseObjects(t *testing.T) {
 					t.Fatal(err)
 				}
 			}
-			tooManyLO, err := tooManyLooseObjects(gitDir, limit)
+			tooManyLO, err := tooManyLooseObjects(gitDir, limit, time.Now())
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -935,7 +935,7 @@ func TestTooManyLooseObjectsMissingSentinelDir(t *testing.T) {
 	}
 	gitDir := GitDir(filepath.Join(dir, ".git"))
 
-	_, err := tooManyLooseObjects(gitDir, 1)
+	_, err := tooManyLooseObjects(gitDir, 1, time.Now())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1115,5 +1115,21 @@ git commit-graph write --reachable --changed-paths
 	}
 	if needed {
 		t.Fatal("this repo doesn't need maintenance")
+	}
+}
+
+func TestNeedsPruning(t *testing.T) {
+	dir := t.TempDir()
+	if err := prepareEmptyGitRepo(dir); err != nil {
+		t.Fatal(err)
+	}
+	gitDir := GitDir(filepath.Join(dir, ".git"))
+
+	needed, err := needsPruning(gitDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if needed {
+		t.Fatal("empty repos don't need pruning")
 	}
 }

--- a/cmd/gitserver/server/sg_maintenance.sh
+++ b/cmd/gitserver/server/sg_maintenance.sh
@@ -54,9 +54,6 @@ git reflog expire --all
 # have no effect.
 git repack -d -l -A --write-bitmap-index --window-memory 100m --unpack-unreachable=2.weeks.ago
 
-# Usually run by git gc. Prune all unreachable objects form the object database.
-git prune --expire 2.weeks.ago
-
 # With the --changed-paths option, compute and write information about the
 # paths changed between a commit and its first parent. This operation can take
 # a while on large repositories. It provides significant performance gains for


### PR DESCRIPTION
Running git-repack on every cleanup is very expensive. This adds
heuristics similar to those used by git and GiLlab's gitaly.  The goal
is to skip the maintenance job most of the time.

There is a caveat for repos with a lot of unreachable loose objects:  If
a repo has enough loose objects, we trigger a repack. If a lot of those
loose objects are unreachable, they will remain loose after the repack.
This means we run repack every time until those unreachable
objects are eventually pruned. We could reduce the chance of this
happening by reducing the time we keep the unreachable objects, which
is currently 2 weeks. 

I will add panels for the new metrics in a separate PR.

## Test plan
- added unit tests
- ran a local instance of sourcegraph and 
  - inspected the Prometheus metrics
  - check timestamp of packfiles to see if a repack occured
