### PR TITLE
[feat] Deprecate eventLogger.logViewEvent for a new method called eventLogger.logPageView

### DIFF
--- a/client/browser/src/shared/tracking/eventLogger.tsx
+++ b/client/browser/src/shared/tracking/eventLogger.tsx
@@ -46,6 +46,9 @@ export class ConditionalTelemetryService implements TelemetryService {
             }
         })
     }
+    /**
+     * @deprecated Use logPageView instead
+     */
     public logViewEvent(eventName: string, eventProperties?: any): void {
         // Wait for this.isEnabled to get a new value
         setTimeout(() => {
@@ -54,6 +57,20 @@ export class ConditionalTelemetryService implements TelemetryService {
             }
         })
     }
+    public logPageView(eventName: string, eventProperties?: any, publicArgument?: any): void {
+        // Wait for this.isEnabled to get a new value
+        setTimeout(() => {
+            if (this.isEnabled) {
+                this.innerTelemetryService.logPageView(eventName, eventProperties, publicArgument)
+            }
+        })
+    }
+    /**
+     * Logs page view events, adding a suffix
+     *
+     * @returns
+     *
+     */
     public unsubscribe(): void {
         // Reset initial state
         this.isEnabled = false
@@ -173,9 +190,20 @@ export class EventLogger implements TelemetryService {
     /**
      * Implements {@link TelemetryService}.
      *
+     * @deprecated Use logPageView instead
+     *
      * @param pageTitle The title of the page being viewed.
      */
     public async logViewEvent(pageTitle: string, eventProperties?: any): Promise<void> {
         await this.logEvent(`View${pageTitle}`, eventProperties)
+    }
+
+    /**
+     * Implements {@link TelemetryService}.
+     *
+     * @param eventName The name of the entity being viewed.
+     */
+    public async logPageView(eventName: string, eventProperties?: any, publicArgument?: any): Promise<void> {
+        await this.logEvent(`${eventName}Viewed`, eventProperties, publicArgument)
     }
 }

--- a/client/shared/src/telemetry/telemetryService.ts
+++ b/client/shared/src/telemetry/telemetryService.ts
@@ -17,10 +17,16 @@ export interface TelemetryService {
      */
     log(eventName: string, eventProperties?: any, publicArgument?: any): void
     /**
+     * @deprecated, use logPageView instead
+     *
      * Log a pageview event (by sending it to the server).
      */
     logViewEvent(eventName: string, eventProperties?: any, publicArgument?: any): void
-
+    /**
+     * Log a pageview event (by sending it to the server).
+     * Adheres to the new event naming policy
+     */
+    logPageView(eventName: string, eventProperties?: any, publicArgument?: any): void
     /**
      * Listen for event logs
      *
@@ -37,6 +43,9 @@ export const NOOP_TELEMETRY_SERVICE: TelemetryService = {
         /* noop */
     },
     logViewEvent: () => {
+        /* noop */
+    },
+    logPageView: () => {
         /* noop */
     },
 }

--- a/client/shared/src/telemetry/telemetryService.ts
+++ b/client/shared/src/telemetry/telemetryService.ts
@@ -17,7 +17,7 @@ export interface TelemetryService {
      */
     log(eventName: string, eventProperties?: any, publicArgument?: any): void
     /**
-     * @deprecated, use logPageView instead
+     * @deprecated use logPageView instead
      *
      * Log a pageview event (by sending it to the server).
      */

--- a/client/vscode/src/webview/platform/telemetryService.ts
+++ b/client/vscode/src/webview/platform/telemetryService.ts
@@ -6,4 +6,5 @@ export const vscodeTelemetryService: TelemetryService = {
 
     log: () => {},
     logViewEvent: () => {},
+    logPageView: () => {},
 }

--- a/client/web/src/enterprise/insights/pages/CodeInsightsRootPage.test.tsx
+++ b/client/web/src/enterprise/insights/pages/CodeInsightsRootPage.test.tsx
@@ -41,6 +41,7 @@ jest.mock('react-router', () => ({
 const mockTelemetryService = {
     log: sinon.spy(),
     logViewEvent: sinon.spy(),
+    logPageView: sinon.spy(),
 }
 
 const fakeApi = new FakeDefaultCodeInsightsBackend()

--- a/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/DashboardsContentPage.test.tsx
+++ b/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/DashboardsContentPage.test.tsx
@@ -38,6 +38,7 @@ jest.mock('./components/dashboards-content/hooks/use-copy-url-handler', () => ({
 const mockTelemetryService = {
     log: sinon.spy(),
     logViewEvent: sinon.spy(),
+    logPageView: sinon.spy(),
 }
 
 const Wrapper: React.FunctionComponent = ({ children }) => {

--- a/client/web/src/org/invitations/OrgInvitationPage.tsx
+++ b/client/web/src/org/invitations/OrgInvitationPage.tsx
@@ -94,7 +94,7 @@ export const OrgInvitationPage: React.FunctionComponent<Props> = ({ authenticate
     const willVerifyEmail = data?.recipientEmail && !data?.isVerifiedEmail
 
     useEffect(() => {
-        eventLogger.logViewEvent('OrganizationInvitation', { organizationId: orgId, invitationId: data?.id })
+        eventLogger.logPageView('OrganizationInvitation', { organizationId: orgId, invitationId: data?.id })
     }, [orgId, data?.id])
 
     const [respondToInvitation, { loading: respondLoading, error: respondError }] = useMutation<

--- a/client/web/src/org/members/OrgMembersListPage.tsx
+++ b/client/web/src/org/members/OrgMembersListPage.tsx
@@ -200,7 +200,7 @@ export const OrgMembersListPage: React.FunctionComponent<Props> = ({
     )
 
     useEffect(() => {
-        eventLogger.logViewEvent('OrganizationMembers', { organizationId: org.id })
+        eventLogger.logPageView('OrganizationMembers', { organizationId: org.id })
     }, [org.id])
 
     const isSelf = (userId: string): boolean => authenticatedUser !== null && userId === authenticatedUser.id

--- a/client/web/src/org/members/OrgPendingInvites.tsx
+++ b/client/web/src/org/members/OrgPendingInvites.tsx
@@ -263,7 +263,7 @@ export const OrgPendingInvitesPage: React.FunctionComponent<Props> = ({
     const query = useQueryStringParameters()
     const openInviteModal = !!query.get('openInviteModal')
     useEffect(() => {
-        eventLogger.logViewEvent('OrganizationPendingInvites', { organizationId: orgId })
+        eventLogger.logPageView('OrganizationPendingInvites', { organizationId: orgId })
     }, [orgId])
 
     const [invite, setInvite] = useState<IModalInviteResult>()

--- a/client/web/src/org/openBeta/GettingStarted.tsx
+++ b/client/web/src/org/openBeta/GettingStarted.tsx
@@ -247,7 +247,7 @@ export const OpenBetaGetStartedPage: React.FunctionComponent<Props> = ({
         (queryResult && !showGetStartPage(queryResult, org.name, openBetaEnabled, isSourcegraphDotCom))
 
     useEffect(() => {
-        eventLogger.logViewEvent('OrganizationGetStarted', { organizationId: org.id })
+        eventLogger.logPageView('OrganizationGetStarted', { organizationId: org.id })
     }, [org.id])
 
     useEffect(() => {

--- a/client/web/src/tracking/eventLogger.ts
+++ b/client/web/src/tracking/eventLogger.ts
@@ -83,7 +83,7 @@ export class EventLogger implements TelemetryService {
     /**
      * Log a pageview, following the new event naming conventions
      *
-     * @eventName should be specific and human-readable in pascal case, e.g. "SearchResults" or "Blob" or "NewOrg"
+     * @param eventName should be specific and human-readable in pascal case, e.g. "SearchResults" or "Blob" or "NewOrg"
      */
     public logPageView(eventName: string, eventProperties?: any, logAsActiveUser = true): void {
         if (window.context?.userAgentIsBot || !eventName) {

--- a/client/web/src/tracking/eventLogger.ts
+++ b/client/web/src/tracking/eventLogger.ts
@@ -67,7 +67,7 @@ export class EventLogger implements TelemetryService {
     }
 
     /**
-     * @deprecated, Use logPageView instead
+     * @deprecated Use logPageView instead
      *
      * Log a pageview.
      * Page titles should be specific and human-readable in pascal case, e.g. "SearchResults" or "Blob" or "NewOrg"

--- a/client/web/src/user/settings/openBetaOrgs/OrganizationsList.tsx
+++ b/client/web/src/user/settings/openBetaOrgs/OrganizationsList.tsx
@@ -88,7 +88,7 @@ export const OrganizationsListPage: React.FunctionComponent<OrganizationsListPro
     const hasOrgs = orgs.length > 0
 
     useEffect(() => {
-        eventLogger.logViewEvent('YourOrganizations', { userId: authenticatedUser.id })
+        eventLogger.logPageView('YourOrganizations', { userId: authenticatedUser.id })
     }, [authenticatedUser.id])
 
     return (


### PR DESCRIPTION
## Description

Previously, `logViewEvent` method was logging events in format `View${PageName}`, however the new convention is to give the verb as a suffix instead of a prefix, e.g. `${PageName}Viewed`. The new `logPageView` function follows the new convention.

## Test plan

These are changes in event tracking, which are almost of impossible to test locally.
The change is mostly about deprecating a method and creating a new one to replace it. 
Only used the new method in part of the code that is behind feature flags. So should be pretty safe.
The only change in new method implementation is a new string format for the event name, 
that follows new conventions.


