### PR TITLE
search: Fix reading default search pattern type from settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Fixed
 
+- Fixed reading search pattern type from settings [#32989](https://github.com/sourcegraph/sourcegraph/issues/32989)
 -
 
 ### Removed

--- a/client/web/src/stores/navbarSearchQueryState.test.ts
+++ b/client/web/src/stores/navbarSearchQueryState.test.ts
@@ -1,0 +1,29 @@
+import { SearchPatternType } from '@sourcegraph/shared/src/graphql-operations'
+
+import { setQueryStateFromSettings, useNavbarQueryState } from './navbarSearchQueryState'
+
+describe('navbar query state', () => {
+    describe('set state from settings', () => {
+        it('sets default search pattern', () => {
+            setQueryStateFromSettings({
+                subjects: [],
+                final: {
+                    'search.defaultPatternType': SearchPatternType.regexp,
+                },
+            })
+
+            expect(useNavbarQueryState.getState()).toHaveProperty('searchPatternType', SearchPatternType.regexp)
+        })
+
+        it('sets default case sensitivity', () => {
+            setQueryStateFromSettings({
+                subjects: [],
+                final: {
+                    'search.defaultCaseSensitive': true,
+                },
+            })
+
+            expect(useNavbarQueryState.getState()).toHaveProperty('searchCaseSensitivity', true)
+        })
+    })
+})

--- a/client/web/src/stores/navbarSearchQueryState.ts
+++ b/client/web/src/stores/navbarSearchQueryState.ts
@@ -89,7 +89,7 @@ export function setQueryStateFromSettings(settings: SettingsCascadeOrError<Setti
     }
 
     const searchPatternType = defaultPatternTypeFromSettings(settings)
-    if (caseSensitive) {
+    if (searchPatternType) {
         newState.searchPatternType = searchPatternType
     }
 


### PR DESCRIPTION
Fixes #32989

## Test plan

- Added unit test
- Change default pattern type to `"regexp"` in your users settings and go to the search page. The regular expression button is selected by default.

