### PR TITLE
ci: run the gql tests on gql backend changes

### DIFF
--- a/cmd/frontend/graphqlbackend/user.go
+++ b/cmd/frontend/graphqlbackend/user.go
@@ -21,6 +21,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
+// foo
 func (r *schemaResolver) User(
 	ctx context.Context,
 	args struct {

--- a/enterprise/dev/ci/internal/ci/changed/diff.go
+++ b/enterprise/dev/ci/internal/ci/changed/diff.go
@@ -60,7 +60,7 @@ func ParseDiff(files []string) (diff Diff) {
 		}
 
 		// Affects GraphQL
-		if strings.HasSuffix(p, ".graphql") {
+		if strings.HasSuffix(p, ".graphql") || strings.HasPrefix(p, "cmd/frontend/graphqlbackend/") {
 			diff |= GraphQL
 		}
 

--- a/enterprise/dev/ci/internal/ci/pipeline.go
+++ b/enterprise/dev/ci/internal/ci/pipeline.go
@@ -92,6 +92,14 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 			ops.Merge(operations.NewNamedSet(operations.PipelineSetupSetName,
 				triggerAsync(buildOptions)))
 		}
+
+		if c.Diff.Has(changed.GraphQL) {
+			ops.Merge(operations.NewNamedSet("Integration tests",
+				buildCandidateDockerImage("server", c.Version, c.candidateImageTag()),
+				backendIntegrationTests(c.candidateImageTag()),
+				codeIntelQA(c.candidateImageTag()),
+			))
+		}
 		ops.Merge(CoreTestOperations(c.Diff, CoreTestOperationsOptions{MinimumUpgradeableVersion: minimumUpgradeableVersion}))
 
 	case runtype.ReleaseNightly:


### PR DESCRIPTION
As @Strum355 pointed out on [Slack](https://sourcegraph.slack.com/archives/C02FLQDD3TQ/p1648217078208809) it's logical to expect the backend integration tests to be run when changing the backend integration tests in a PR. 

TODO: 
- [ ] Drop the test commit to trigger the changes 
- [ ] Regenerate the CI inline docs. 

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

New plan: 

```
~/work/sourcegraph U ci/run-backend-integrations-test-on-graphqlbackend $ sg ci preview
If the current branch were to be pushed, the following pipeline would be run:


  • Detected run type: Pull request
  • Detected diffs: Go, GraphQL
  • Computed build steps:
    • Integration tests
      • :docker: 🚧 Build server
      • ⛓️ Backend integration tests → depends on server:candidate
      • :docker:🧠 Code Intel QA → depends on server:candidate
    • Linters and static analysis
      • 💄 Prettier
      • 📋 Misc linters
      • 💄 :graphql: GraphQL lint
    • Client checks
      • :puppeteer:🔌 Puppeteer tests prep
      • :puppeteer:🔌 Puppeteer tests chunk #1 → depends on puppeteer:prep
      • :puppeteer:🔌 Puppeteer tests chunk #2 → depends on puppeteer:prep
      • :puppeteer:🔌 Puppeteer tests chunk #3 → depends on puppeteer:prep
      • :puppeteer:🔌 Puppeteer tests chunk #4 → depends on puppeteer:prep
      • :puppeteer:🔌 Puppeteer tests chunk #5 → depends on puppeteer:prep
      • :puppeteer:🔌 Puppeteer tests chunk #6 → depends on puppeteer:prep
      • :puppeteer:🔌 Puppeteer tests chunk #7 → depends on puppeteer:prep
      • :puppeteer:🔌 Puppeteer tests chunk #8 → depends on puppeteer:prep
      • :puppeteer:🔌 Puppeteer tests chunk #9 → depends on puppeteer:prep
      • :puppeteer:🔌 Puppeteer tests finalize → depends on puppeteer:chunk:1, puppeteer:chunk:2, puppeteer:chunk:3,
      puppeteer:chunk:4, puppeteer:chunk:5, ... (4 more steps)
      • :chromatic: Upload Storybook to Chromatic
      • :jest: Test (all)
      • :webpack:🌐 Build
      • :webpack:🌐💰 Enterprise build
      • :jest:🌐 Test (client/web)
      • :chrome: Puppeteer tests for chrome extension
      • :jest::chrome: Test (client/browser)
      • :eslint: ESLint
      • :typescript: Build TS
      • :stylelint: Stylelint
    • Go checks
      • :go: Test (all)
      • :go: Test (enterprise/internal/codeintel/stores/dbstore)
      • :go: Test (enterprise/internal/codeintel/stores/lsifstore)
      • :go: Test (enterprise/internal/insights)
      • :go: Test (internal/database)
      • :go: Test (internal/repos)
      • :go: Test (enterprise/internal/batches)
      • :go: Test (cmd/frontend)
      • :go: Test (enterprise/internal/database)
      • :go: Test (enterprise/cmd/frontend/internal/batches/resolvers)
      • :go: Build
    • ⤴️ Upload build trace
```

+ green build 


