### PR TITLE
schemadoc: Disable postgres container

### DIFF
--- a/dev/schemadoc/main.go
+++ b/dev/schemadoc/main.go
@@ -59,12 +59,12 @@ func main() {
 }
 
 func mainErr() error {
-	// Run pg12 locally if it exists
-	if version, _ := exec.Command("psql", "--version").CombinedOutput(); versionRe.Match(version) {
-		return mainLocal()
-	}
+	// // Run pg12 locally if it exists
+	// if version, _ := exec.Command("psql", "--version").CombinedOutput(); versionRe.Match(version) {
+	return mainLocal()
+	// }
 
-	return mainContainer()
+	// return mainContainer()
 }
 
 func mainLocal() error {


### PR DESCRIPTION
After #33006, we no longer need to be careful about format changes between versions of psql. This should speed up generation in local dev when running Postgres > 12 (and possibly in CI).

## Test plan

N/A.