### PR TITLE
Revert "authz/github: Simplify cachedGroup.key"

### DIFF
--- a/enterprise/internal/authz/github/cache.go
+++ b/enterprise/internal/authz/github/cache.go
@@ -35,11 +35,11 @@ type cachedGroup struct {
 }
 
 func (g *cachedGroup) key() string {
+	key := cacheVersion + "/" + g.Org
 	if g.Team != "" {
-		return "/" + g.Team
+		key += "/" + g.Team
 	}
-
-	return cacheVersion + "/" + g.Org
+	return key
 }
 
 type cachedGroups struct {


### PR DESCRIPTION
Reverts sourcegraph/sourcegraph#32991

# Test Plan

Not applicable. Reverting a buggy PR.