### PR TITLE
ci: fix deployment notifier reaching slack block size

### DIFF
--- a/enterprise/dev/deployment-notifier/slack.go
+++ b/enterprise/dev/deployment-notifier/slack.go
@@ -15,7 +15,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
-var slackTemplate = `:truck: *{{.Environment}}* deployment (<{{.BuildURL}}|build>)
+var slackTemplate = `*{{.Environment}}* deployment (<{{.BuildURL}}|build>)
 
 - Applications:
 {{- range .Services }}
@@ -130,7 +130,7 @@ func postSlackUpdate(webhook string, summary string) error {
 	}
 	defer resp.Body.Close()
 	if buf.String() != "ok" {
-		return err
+		return errors.Newf("failed to post on slack: %q", buf.String())
 	}
 	return err
 }

--- a/enterprise/dev/deployment-notifier/slack.go
+++ b/enterprise/dev/deployment-notifier/slack.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
 	"net/http"
 	"strings"
 	"text/template"
@@ -15,7 +14,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
-var slackTemplate = `*{{.Environment}}* deployment (<{{.BuildURL}}|build>)
+var slackTemplate = `:arrow_left: *{{.Environment}}* deployment (<{{.BuildURL}}|build>)
 
 - Applications:
 {{- range .Services }}
@@ -92,22 +91,26 @@ func postSlackUpdate(webhook string, summary string) error {
 		Text *slackText `json:"text,omitempty"`
 	}
 
+	var blocks []slackBlock
+	for _, s := range strings.Split(summary, "\n\n") {
+		blocks = append(blocks, slackBlock{
+			Type: "section",
+			Text: &slackText{
+				Type: "mrkdwn",
+				Text: s,
+			},
+		})
+	}
+
 	// Generate request
 	body, err := json.MarshalIndent(struct {
 		Blocks []slackBlock `json:"blocks"`
 	}{
-		Blocks: []slackBlock{{
-			Type: "section",
-			Text: &slackText{
-				Type: "mrkdwn",
-				Text: summary,
-			},
-		}},
+		Blocks: blocks,
 	}, "", "  ")
 	if err != nil {
 		return errors.Newf("MarshalIndent: %w", err)
 	}
-	log.Println("slackBody: ", string(body))
 
 	req, err := http.NewRequest(http.MethodPost, webhook, bytes.NewBuffer(body))
 	if err != nil {


### PR DESCRIPTION
Slack has a fixed limit of 3000 chars per block, and due to the currently low frequency of preprod updates, it means we're getting a lot of PRs. 

This expedited PR fixes it by breaking the paragraph in separate blocks. 

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

Tested locally: https://sourcegraph.slack.com/archives/C02L31KTHHT/p1648228774060979
