### PR TITLE
search: remove unused global search job values

### DIFF
--- a/internal/search/job/job.go
+++ b/internal/search/job/job.go
@@ -148,10 +148,7 @@ func ToSearchJob(jargs *Args, q query.Q, db database.DB) (Job, error) {
 				addJob(true, &symbol.RepoUniverseSymbolSearch{
 					GlobalZoektQuery: globalZoektQuery,
 					ZoektArgs:        zoektArgs,
-					PatternInfo:      patternInfo,
-					Limit:            maxResults,
-
-					RepoOptions: repoOptions,
+					RepoOptions:      repoOptions,
 				})
 			}
 		}

--- a/internal/search/symbol/symbol.go
+++ b/internal/search/symbol/symbol.go
@@ -234,10 +234,7 @@ func limitOrDefault(first *int32) int {
 type RepoUniverseSymbolSearch struct {
 	GlobalZoektQuery *zoektutil.GlobalZoektQuery
 	ZoektArgs        *search.ZoektParameters
-	PatternInfo      *search.TextPatternInfo
-	Limit            int
-
-	RepoOptions search.RepoOptions
+	RepoOptions      search.RepoOptions
 }
 
 func (s *RepoUniverseSymbolSearch) Run(ctx context.Context, db database.DB, stream streaming.Sender) (alert *search.Alert, err error) {

--- a/internal/search/zoekt/indexed_search.go
+++ b/internal/search/zoekt/indexed_search.go
@@ -620,9 +620,7 @@ func (*ZoektRepoSubsetSearch) Name() string {
 type GlobalSearch struct {
 	GlobalZoektQuery *GlobalZoektQuery
 	ZoektArgs        *search.ZoektParameters
-
-	RepoOptions search.RepoOptions
-	UserID      int32
+	RepoOptions      search.RepoOptions
 }
 
 func (t *GlobalSearch) Run(ctx context.Context, db database.DB, stream streaming.Sender) (alert *search.Alert, err error) {


### PR DESCRIPTION
Removes values not used in some jobs. Just left overs from mechanical factorings it seems.

## Test plan
Semantics-preserving.


