### PR TITLE
search: simplify control flow for creating structural search job

### DIFF
--- a/internal/search/job/job.go
+++ b/internal/search/job/job.go
@@ -57,14 +57,7 @@ func ToSearchJob(jargs *Args, q query.Q, db database.DB) (Job, error) {
 	}
 	types, _ := q.StringValues(query.FieldType)
 	resultTypes := search.ComputeResultTypes(types, b.PatternString(), jargs.SearchInputs.PatternType)
-
 	patternInfo := search.ToTextPatternInfo(b, resultTypes, jargs.SearchInputs.Protocol)
-	if b.PatternString() == "" {
-		// Fallback to basic search for searching repos and files if
-		// the structural search pattern is empty.
-		jargs.SearchInputs.PatternType = query.SearchTypeLiteral
-		patternInfo.IsStructuralPat = false
-	}
 
 	// searcher to use full deadline if timeout: set or we are streaming.
 	useFullDeadline := q.Timeout() != nil || q.Count() != nil || jargs.SearchInputs.Protocol == search.Streaming
@@ -239,7 +232,7 @@ func ToSearchJob(jargs *Args, q query.Q, db database.DB) (Job, error) {
 			})
 		}
 
-		if jargs.SearchInputs.PatternType == query.SearchTypeStructural && b.PatternString() != "" {
+		if resultTypes.Has(result.TypeStructural) {
 			typ := search.TextRequest
 			zoektQuery, err := search.QueryToZoektQuery(b, resultTypes, &features, typ)
 			if err != nil {


### PR DESCRIPTION
Stacked on https://github.com/sourcegraph/sourcegraph/pull/33111.

After some careful auditing, this simplification preserves desired behavior. Great because it removes annoying mutations on values we want to not use.

## Test plan
Semantics-preserving.

