### PR TITLE
dev/ci: fix TODO on stateless rollout back to 10 percent

### DIFF
--- a/enterprise/dev/ci/internal/buildkite/feature_flags.go
+++ b/enterprise/dev/ci/internal/buildkite/feature_flags.go
@@ -22,7 +22,7 @@ var FeatureFlags = featureFlags{
 		// TODO: remove when we switch over entirely to stateless agents
 		os.Getenv("BUILDKITE_REBUILT_FROM_BUILD_NUMBER") != "" ||
 		// Roll out to 10% of builds
-		rand.NewSource(time.Now().UnixNano()).Int63()%100 < 10 || true, // TODO remove
+		rand.NewSource(time.Now().UnixNano()).Int63()%100 < 10,
 }
 
 func (f *featureFlags) ApplyEnv(env map[string]string) {


### PR DESCRIPTION
🤦 This is not quite ready for this kind of prime time. Was looking at metrics and wondering why we were seeing such big spikes

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

n/a
