### PR TITLE
dev/ci: bump stateless agent rollout to 50

### DIFF
--- a/enterprise/dev/ci/internal/buildkite/feature_flags.go
+++ b/enterprise/dev/ci/internal/buildkite/feature_flags.go
@@ -21,8 +21,8 @@ var FeatureFlags = featureFlags{
 		// Always process retries on stateless agents.
 		// TODO: remove when we switch over entirely to stateless agents
 		os.Getenv("BUILDKITE_REBUILT_FROM_BUILD_NUMBER") != "" ||
-		// Roll out to 10% of builds
-		rand.NewSource(time.Now().UnixNano()).Int63()%100 < 10,
+		// Roll out to 50% of builds
+		rand.NewSource(time.Now().UnixNano()).Int63()%100 < 50,
 }
 
 func (f *featureFlags) ApplyEnv(env map[string]string) {


### PR DESCRIPTION
Give us a better view for comparing some recently flakey steps by splitting the new stateless and old stateful builds equally

The rollout was set to 100% accidentally (https://github.com/sourcegraph/sourcegraph/pull/33115), and I've adjusted the behaviour for the dispatcher a bit to keep up better - hopefully it's in a good shape to make this bump. 

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

See https://github.com/sourcegraph/infrastructure/pull/3182 for observability measures. We can easily disable the rollout by adjusting the line edited in this PR.
