### PR TITLE
dev/dn: add ServicesPerPullRequest and ManifestRevision

### DIFF
--- a/enterprise/dev/deployment-notifier/deployment_notifier_test.go
+++ b/enterprise/dev/deployment-notifier/deployment_notifier_test.go
@@ -11,10 +11,11 @@ import (
 
 	"github.com/dnaeon/go-vcr/cassette"
 	"github.com/google/go-github/v41/github"
-	"github.com/sourcegraph/sourcegraph/internal/httptestutil"
-	"github.com/sourcegraph/sourcegraph/lib/errors"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/oauth2"
+
+	"github.com/sourcegraph/sourcegraph/internal/httptestutil"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 var updateRecordings = flag.Bool("update", false, "update integration test")
@@ -50,6 +51,11 @@ func TestDeploymentNotifier(t *testing.T) {
 			"symbols",
 			"worker",
 		}
+		expectedServicesPerPullRequest := map[int][]string{
+			32996: {"frontend", "gitserver", "searcher", "symbols", "worker"},
+			32871: {"frontend", "gitserver", "searcher", "symbols", "worker"},
+			32767: {"gitserver"},
+		}
 
 		newCommit := "e1aea6f8d82283695ae4a3b2b5a7a8f36b1b934b"
 		oldCommit := "54d527f7f7b5770e0dfd1f56398bf8a2f30b935d"
@@ -68,6 +74,7 @@ func TestDeploymentNotifier(t *testing.T) {
 			ghc,
 			NewMockManifestDeployementsDiffer(m),
 			"tests",
+			"",
 		)
 		report, err := dn.Report(ctx)
 		if err != nil {
@@ -80,6 +87,7 @@ func TestDeploymentNotifier(t *testing.T) {
 		}
 		assert.EqualValues(t, expectedPRs, prNumbers)
 		assert.EqualValues(t, expectedServices, report.Services)
+		assert.EqualValues(t, expectedServicesPerPullRequest, report.ServicesPerPullRequest)
 	})
 
 	t.Run("OK no relevant changed files", func(t *testing.T) {
@@ -92,6 +100,7 @@ func TestDeploymentNotifier(t *testing.T) {
 			ghc,
 			NewMockManifestDeployementsDiffer(m),
 			"tests",
+			"",
 		)
 
 		_, err := dn.Report(ctx)
@@ -125,6 +134,7 @@ func TestDeploymentNotifier(t *testing.T) {
 			ghc,
 			NewMockManifestDeployementsDiffer(m),
 			"tests",
+			"",
 		)
 
 		report, err := dn.Report(ctx)
@@ -157,6 +167,7 @@ func TestDeploymentNotifier(t *testing.T) {
 			ghc,
 			NewMockManifestDeployementsDiffer(m),
 			"tests",
+			"",
 		)
 		_, err := dn.Report(ctx)
 		assert.NotNil(t, err)

--- a/enterprise/dev/deployment-notifier/slack.go
+++ b/enterprise/dev/deployment-notifier/slack.go
@@ -19,7 +19,7 @@ var slackTemplate = `:arrow_left: *{{.Environment}}* deployment (<{{.BuildURL}}|
 - Applications:
 {{- range .Services }}
     - ` + "`" + `{{ . }}` + "`" + `
-{{- end }} 
+{{- end }}
 
 - Pull Requests:
 {{- range .PullRequests }}
@@ -39,7 +39,7 @@ type pullRequestPresenter struct {
 	WebURL        string
 }
 
-func slackSummary(ctx context.Context, teammates team.TeammateResolver, report *report) (string, error) {
+func slackSummary(ctx context.Context, teammates team.TeammateResolver, report *DeploymentReport) (string, error) {
 	presenter := &slackSummaryPresenter{
 		Environment: report.Environment,
 		BuildURL:    report.BuildkiteBuildURL,


### PR DESCRIPTION
Adds detailed metadata to `DeploymentReport` require to enable https://github.com/sourcegraph/sourcegraph/pull/33120 , primarily `ServicesPerPullRequest`, which is an accurate representation of exactly which pull requests are associated with each service in the deployment, because each service might be deployed with a different source diff. This is important for notifications, tracing, etc, and the information is currrently discarded by the report's PRs and services summary.

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


Adds a unit test check, and existing tests should pass.