### PR TITLE
dev/dn: create trace for PR to deploy

### DIFF
--- a/enterprise/dev/deployment-notifier/README.md
+++ b/enterprise/dev/deployment-notifier/README.md
@@ -18,6 +18,7 @@ deployment-notifier -environment $MY_ENV -slack.token=$SLACK_TOKEN -slack.webhoo
 - `-dry` (optional) do not post on Slack or GitHub, just print out what would be posted.
 - `-slack.token` Slack Token used to find the matching Slack handle for pull request authors.
 - `-slack.webhook` Slack webhook URL to post the notifications on.
+- `-honeycomb.token` Honeycomb API token that is used to upload deployment traces.
 
 ## How it works
 

--- a/enterprise/dev/deployment-notifier/deployment_notifier.go
+++ b/enterprise/dev/deployment-notifier/deployment_notifier.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"sort"
 	"strconv"
@@ -230,7 +231,7 @@ var commentTemplate = `### Deployment status
 {{- end }}
 `
 
-func renderComment(report *DeploymentReport) (string, error) {
+func renderComment(report *DeploymentReport, traceURL string) (string, error) {
 	tmpl, err := template.New("deployment-status-comment").Parse(commentTemplate)
 	if err != nil {
 		return "", err
@@ -239,6 +240,12 @@ func renderComment(report *DeploymentReport) (string, error) {
 	err = tmpl.Execute(&sb, report)
 	if err != nil {
 		return "", err
+	}
+	if traceURL != "" {
+		_, err = sb.WriteString(fmt.Sprintf("\n[Deployment trace](%s)", traceURL))
+		if err != nil {
+			return "", err
+		}
 	}
 	return sb.String(), nil
 }

--- a/enterprise/dev/deployment-notifier/main.go
+++ b/enterprise/dev/deployment-notifier/main.go
@@ -5,11 +5,14 @@ import (
 	"flag"
 	"fmt"
 	"log"
+	"net/http"
 	"os"
 	"os/exec"
 	"strings"
 
 	"github.com/google/go-github/v41/github"
+	"github.com/honeycombio/libhoney-go"
+	"github.com/honeycombio/libhoney-go/transmission"
 	"github.com/slack-go/slack"
 	"golang.org/x/oauth2"
 
@@ -23,6 +26,7 @@ type Flags struct {
 	Environment          string
 	SlackToken           string
 	SlackAnnounceWebhook string
+	HoneycombToken       string
 	BaseDir              string
 }
 
@@ -32,6 +36,7 @@ func (f *Flags) Parse() {
 	flag.BoolVar(&f.DryRun, "dry", false, "Pretend to post notifications, printing to stdout instead")
 	flag.StringVar(&f.SlackToken, "slack.token", "", "mandatory slack api token")
 	flag.StringVar(&f.SlackAnnounceWebhook, "slack.webhook", "", "Slack Webhook URL to post the results on")
+	flag.StringVar(&f.HoneycombToken, "honeycomb.token", "", "mandatory honeycomb api token")
 	flag.Parse()
 }
 
@@ -41,12 +46,16 @@ func main() {
 	flags := &Flags{}
 	flags.Parse()
 	if flags.Environment == "" {
-		log.Fatalf("-enviroment must be specified: preprod or production.")
+		log.Fatalf("-environment must be specified: preprod or production.")
 	}
 
 	ghc := github.NewClient(oauth2.NewClient(ctx, oauth2.StaticTokenSource(
 		&oauth2.Token{AccessToken: flags.GitHubToken},
 	)))
+	if flags.GitHubToken == "" {
+		log.Println("warning: using unauthenticated github client")
+		ghc = github.NewClient(http.DefaultClient)
+	}
 
 	changedFiles, err := getChangedFiles()
 	if err != nil {
@@ -74,6 +83,31 @@ func main() {
 		}
 		log.Fatal(err)
 	}
+
+	honeyConfig := libhoney.Config{
+		APIKey:  flags.HoneycombToken,
+		Dataset: "deploy-sourcegraph",
+	}
+	if flags.DryRun {
+		honeyConfig.Transmission = &transmission.WriterSender{} // prints events to stdout instead
+	}
+	if err := libhoney.Init(honeyConfig); err != nil {
+		log.Fatal(err)
+	}
+	events, err := GenerateDeploymentTrace(report)
+	if err != nil {
+		log.Fatal(err)
+	}
+	var sendErrs error
+	for _, event := range events {
+		if err := event.Send(); err != nil {
+			sendErrs = errors.Append(sendErrs, err)
+		}
+	}
+	if sendErrs != nil {
+		log.Fatal(err)
+	}
+	libhoney.Close()
 
 	slc := slack.New(flags.SlackToken)
 	teammates := team.NewTeammateResolver(ghc, slc)

--- a/enterprise/dev/deployment-notifier/main.go
+++ b/enterprise/dev/deployment-notifier/main.go
@@ -128,19 +128,19 @@ func main() {
 		for _, pr := range report.PullRequests {
 			fmt.Println("-", pr.GetNumber())
 		}
-		out, err := renderComment(report)
+		out, err := renderComment(report, traceURL)
 		if err != nil {
 			log.Fatalf("can't render GitHub comment %q", err)
 		}
 		fmt.Println(out)
 		fmt.Println("Slack\n---")
-		out, err = slackSummary(ctx, teammates, report)
+		out, err = slackSummary(ctx, teammates, report, traceURL)
 		if err != nil {
 			log.Fatalf("can't render Slack post %q", err)
 		}
 		fmt.Println(out)
 	} else {
-		out, err := slackSummary(ctx, teammates, report)
+		out, err := slackSummary(ctx, teammates, report, traceURL)
 		if err != nil {
 			log.Fatalf("can't render Slack post %q", err)
 		}

--- a/enterprise/dev/deployment-notifier/slack.go
+++ b/enterprise/dev/deployment-notifier/slack.go
@@ -39,7 +39,7 @@ type pullRequestPresenter struct {
 	WebURL        string
 }
 
-func slackSummary(ctx context.Context, teammates team.TeammateResolver, report *DeploymentReport) (string, error) {
+func slackSummary(ctx context.Context, teammates team.TeammateResolver, report *DeploymentReport, traceURL string) (string, error) {
 	presenter := &slackSummaryPresenter{
 		Environment: report.Environment,
 		BuildURL:    report.BuildkiteBuildURL,
@@ -70,6 +70,13 @@ func slackSummary(ctx context.Context, teammates team.TeammateResolver, report *
 	err = tmpl.Execute(&sb, presenter)
 	if err != nil {
 		return "", err
+	}
+
+	if traceURL != "" {
+		_, err = sb.WriteString(fmt.Sprintf("\n<%s|Deployment trace>", traceURL))
+		if err != nil {
+			return "", err
+		}
 	}
 
 	return sb.String(), nil

--- a/enterprise/dev/deployment-notifier/trace.go
+++ b/enterprise/dev/deployment-notifier/trace.go
@@ -2,11 +2,16 @@ package main
 
 import (
 	"fmt"
+	"net/url"
+	"path"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/google/go-github/v41/github"
 	"github.com/honeycombio/libhoney-go"
+
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 const traceVersion = "dev"
@@ -25,6 +30,13 @@ func newSpanID(root string, components ...string) string {
 	return root
 }
 
+type DeploymentTrace struct {
+	Root *libhoney.Event
+	ID   string
+
+	Spans []*libhoney.Event
+}
+
 // GenerateDeploymentTrace generates a set of events that trace PRs from merge to deploy.
 //
 // The generated trace is structured as follows:
@@ -38,7 +50,11 @@ func newSpanID(root string, components ...string) string {
 //         -------- svc/2
 //                    ...
 //
-func GenerateDeploymentTrace(r *DeploymentReport) (events []*libhoney.Event, err error) {
+// Learn more about Honeycomb fields:
+//
+// - https://docs.honeycomb.io/working-with-your-data/home/#configuring-home
+// - https://docs.honeycomb.io/getting-data-in/tracing/send-trace-data/#span-annotations
+func GenerateDeploymentTrace(r *DeploymentReport) (*DeploymentTrace, error) {
 	libhoney.UserAgentAddition = fmt.Sprintf("deployment-notifier/%s", traceVersion)
 
 	rev := r.ManifestRevision
@@ -49,7 +65,7 @@ func GenerateDeploymentTrace(r *DeploymentReport) (events []*libhoney.Event, err
 
 	deployTime, err := time.Parse(time.RFC822Z, r.DeployedAt)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "r.DeployedAt")
 	}
 	oldestPR := time.Now()
 
@@ -58,6 +74,7 @@ func GenerateDeploymentTrace(r *DeploymentReport) (events []*libhoney.Event, err
 		prSet[pr.GetNumber()] = pr
 	}
 
+	var spans []*libhoney.Event
 	for prNumber, prServices := range r.ServicesPerPullRequest {
 		pr := prSet[prNumber]
 		if pr.GetMergedAt().Before(oldestPR) {
@@ -70,50 +87,82 @@ func GenerateDeploymentTrace(r *DeploymentReport) (events []*libhoney.Event, err
 			prServiceEvent := newTraceEvent(deploymentTraceID)
 			prServiceEvent.Timestamp = pr.GetMergedAt()
 			prServiceEvent.Add(map[string]interface{}{
+				// Honeycomb fields
+				"name":            service,
+				"service.name":    "service",
 				"trace.parent_id": prTraceID,
 				"trace.span_id":   newSpanID("svc", strconv.Itoa(pr.GetNumber()), service),
+				"duration_ms":     deployTime.Sub(pr.GetMergedAt()) / time.Millisecond,
+				"user":            pr.GetUser().GetLogin(),
 
-				"service": service,
-
-				"duration_ms": deployTime.Sub(pr.GetMergedAt()) / time.Millisecond,
+				// Extra metadata
+				"service":               service,
+				"pull_request.number":   pr.GetNumber(),
+				"pull_request.revision": pr.GetMergeCommitSHA(),
 			})
-			events = append(events, prServiceEvent)
+			spans = append(spans, prServiceEvent)
 		}
 
 		prEvent := newTraceEvent(deploymentTraceID)
 		prEvent.Timestamp = pr.GetMergedAt()
 		prEvent.Add(map[string]interface{}{
+			// Honeycomb fields
+			"name":            pr.GetNumber(),
+			"service.name":    "pull_request",
 			"trace.parent_id": deploymentTraceID,
 			"trace.span_id":   prTraceID,
+			"user":            pr.GetUser().GetLogin(),
+			// Don't include a duration - PR might have other services not deployed yet
 
+			// Extra metadata
 			"pull_request.number":   pr.GetNumber(),
 			"pull_request.title":    pr.GetTitle(),
 			"pull_request.revision": pr.GetMergeCommitSHA(),
 			"pull_request.url":      pr.GetHTMLURL(),
-
-			// Don't include duration - PR might have other services not deployed yet
-			// TODO does this work?
 		})
-		events = append(events, prEvent)
+		spans = append(spans, prEvent)
 	}
 
-	deployEvent := newTraceEvent(deploymentTraceID)
-	deployEvent.Timestamp = oldestPR
-	deployEvent.Add(map[string]interface{}{
+	root := newTraceEvent(deploymentTraceID)
+	root.Timestamp = oldestPR
+	root.Add(map[string]interface{}{
+		// Honeycomb fields
+		"name":          fmt.Sprintf("%s (%s)", r.Environment, r.DeployedAt),
+		"service.name":  fmt.Sprintf("deploy/%s", r.Environment),
 		"trace.span_id": deploymentTraceID,
-		"name":          r.DeployedAt,
+		"duration_ms":   deployTime.Sub(oldestPR) / time.Millisecond,
 
-		"environment":         r.Environment,
-		"buildkite.build_url": r.BuildkiteBuildURL,
-		"manifest.revision":   r.ManifestRevision,
-
+		// Extra metadata
+		"environment":            r.Environment,
+		"buildkite.build_url":    r.BuildkiteBuildURL,
+		"manifest.revision":      r.ManifestRevision,
 		"deployed.at":            r.DeployedAt,
 		"deployed.pull_requests": len(r.PullRequests),
 		"deployed.services":      len(r.Services),
-
-		"duration_ms": deployTime.Sub(oldestPR) / time.Millisecond,
 	})
-	events = append(events, deployEvent)
 
-	return
+	return &DeploymentTrace{
+		ID:    deploymentTraceID,
+		Root:  root,
+		Spans: spans,
+	}, nil
+}
+
+// https://sourcegraph.com/search?q=context:global+repo:%5Egithub%5C.com/honeycombio/buildevents%24%40main+func+buildURL&patternType=literal
+func buildTraceURL(cfg *libhoney.Config, traceID string, ts int64) (string, error) {
+	teamName, err := libhoney.VerifyAPIKey(*cfg)
+	if err != nil {
+		return "", errors.Newf("unable to verify API key: %w", err)
+	}
+	uiHost := strings.Replace(cfg.APIHost, "api", "ui", 1)
+	u, err := url.Parse(uiHost)
+	if err != nil {
+		return "", errors.Newf("unable to infer UI host: %s", uiHost)
+	}
+	u.Path = path.Join(teamName, "datasets", strings.Replace(cfg.Dataset, " ", "-", -1), "trace")
+	endTime := time.Now().Add(10 * time.Minute).Unix()
+	return fmt.Sprintf(
+		"%s?trace_id=%s&trace_start_ts=%d&trace_end_ts=%d",
+		u.String(), traceID, ts, endTime,
+	), nil
 }

--- a/enterprise/dev/deployment-notifier/trace.go
+++ b/enterprise/dev/deployment-notifier/trace.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/google/go-github/v41/github"
+	"github.com/honeycombio/libhoney-go"
+)
+
+const traceVersion = "dev"
+
+func newTraceEvent(traceID string) *libhoney.Event {
+	event := libhoney.NewEvent()
+	event.AddField("meta.version", traceVersion)
+	event.AddField("trace.trace_id", traceID)
+	return event
+}
+
+func newSpanID(root string, components ...string) string {
+	for _, c := range components {
+		root += fmt.Sprintf("/%s", c)
+	}
+	return root
+}
+
+// GenerateDeploymentTrace generates a set of events that trace PRs from merge to deploy.
+//
+// The generated trace is structured as follows:
+//
+//   deploy/env/rev -----
+//     pr/1 -------------
+//     ------------ svc/1
+//     ------------ svc/2
+//         pr/2 ---------
+//         -------- svc/1
+//         -------- svc/2
+//                    ...
+//
+func GenerateDeploymentTrace(r *DeploymentReport) (events []*libhoney.Event, err error) {
+	libhoney.UserAgentAddition = fmt.Sprintf("deployment-notifier/%s", traceVersion)
+
+	rev := r.ManifestRevision
+	if len(rev) > 12 {
+		rev = rev[:12]
+	}
+	deploymentTraceID := newSpanID("deploy", r.Environment, rev)
+
+	deployTime, err := time.Parse(time.RFC822Z, r.DeployedAt)
+	if err != nil {
+		return nil, err
+	}
+	oldestPR := time.Now()
+
+	prSet := map[int]*github.PullRequest{}
+	for _, pr := range r.PullRequests {
+		prSet[pr.GetNumber()] = pr
+	}
+
+	for prNumber, prServices := range r.ServicesPerPullRequest {
+		pr := prSet[prNumber]
+		if pr.GetMergedAt().Before(oldestPR) {
+			oldestPR = pr.GetMergedAt()
+		}
+
+		prTraceID := newSpanID("pr", strconv.Itoa(pr.GetNumber()))
+
+		for _, service := range prServices {
+			prServiceEvent := newTraceEvent(deploymentTraceID)
+			prServiceEvent.Timestamp = pr.GetMergedAt()
+			prServiceEvent.Add(map[string]interface{}{
+				"trace.parent_id": prTraceID,
+				"trace.span_id":   newSpanID("svc", strconv.Itoa(pr.GetNumber()), service),
+
+				"service": service,
+
+				"duration_ms": deployTime.Sub(pr.GetMergedAt()) / time.Millisecond,
+			})
+			events = append(events, prServiceEvent)
+		}
+
+		prEvent := newTraceEvent(deploymentTraceID)
+		prEvent.Timestamp = pr.GetMergedAt()
+		prEvent.Add(map[string]interface{}{
+			"trace.parent_id": deploymentTraceID,
+			"trace.span_id":   prTraceID,
+
+			"pull_request.number":   pr.GetNumber(),
+			"pull_request.title":    pr.GetTitle(),
+			"pull_request.revision": pr.GetMergeCommitSHA(),
+			"pull_request.url":      pr.GetHTMLURL(),
+
+			// Don't include duration - PR might have other services not deployed yet
+			// TODO does this work?
+		})
+		events = append(events, prEvent)
+	}
+
+	deployEvent := newTraceEvent(deploymentTraceID)
+	deployEvent.Timestamp = oldestPR
+	deployEvent.Add(map[string]interface{}{
+		"trace.span_id": deploymentTraceID,
+		"name":          r.DeployedAt,
+
+		"environment":         r.Environment,
+		"buildkite.build_url": r.BuildkiteBuildURL,
+		"manifest.revision":   r.ManifestRevision,
+
+		"deployed.at":            r.DeployedAt,
+		"deployed.pull_requests": len(r.PullRequests),
+		"deployed.services":      len(r.Services),
+
+		"duration_ms": deployTime.Sub(oldestPR) / time.Millisecond,
+	})
+	events = append(events, deployEvent)
+
+	return
+}

--- a/enterprise/dev/deployment-notifier/trace.go
+++ b/enterprise/dev/deployment-notifier/trace.go
@@ -159,7 +159,7 @@ func buildTraceURL(cfg *libhoney.Config, traceID string, ts int64) (string, erro
 	if err != nil {
 		return "", errors.Newf("unable to infer UI host: %s", uiHost)
 	}
-	u.Path = path.Join(teamName, "datasets", strings.Replace(cfg.Dataset, " ", "-", -1), "trace")
+	u.Path = path.Join(teamName, "datasets", strings.ReplaceAll(cfg.Dataset, " ", "-"), "trace")
 	endTime := time.Now().Add(10 * time.Minute).Unix()
 	return fmt.Sprintf(
 		"%s?trace_id=%s&trace_start_ts=%d&trace_end_ts=%d",

--- a/enterprise/dev/deployment-notifier/trace_test.go
+++ b/enterprise/dev/deployment-notifier/trace_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/google/go-github/v41/github"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -13,7 +14,7 @@ func intPtr(v int) *int {
 }
 
 func TestGenerateDeploymentTrace(t *testing.T) {
-	events, err := GenerateDeploymentTrace(&DeploymentReport{
+	trace, err := GenerateDeploymentTrace(&DeploymentReport{
 		DeployedAt: time.RFC822Z,
 		PullRequests: []*github.PullRequest{
 			{Number: intPtr(32996)},
@@ -27,11 +28,13 @@ func TestGenerateDeploymentTrace(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
+	require.NotNil(t, trace)
 
 	const (
-		expectRootSpan     = 1
 		expectPRSpans      = 3
 		expectServiceSpans = 3 + 3 + 1
 	)
-	require.Equal(t, expectRootSpan+expectPRSpans+expectServiceSpans, len(events))
+	assert.NotEmpty(t, trace.ID)
+	assert.NotNil(t, trace.Root)
+	assert.Equal(t, expectPRSpans+expectServiceSpans, len(trace.Spans))
 }


### PR DESCRIPTION
When notifying for a deployment event, also create a build trace that ties all associated PRs' merge times per-service to the deployment event, to measure how long each service goes from change to a deployed environment.

Closes https://github.com/sourcegraph/sourcegraph/issues/31851

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

```
go install ./enterprise/dev/deployment-notifier
```

Then head over to `deploy-sourcegraph-cloud`:

```
deployment-notifier -environment preprod -honeycomb.token=$HONEYCOMB_TOKEN -github.token=$GITHUB_TOKEN
```

https://github.com/sourcegraph/sourcegraph/pull/33120#issuecomment-1080969897