### PR TITLE
Defined logged fields next to type definition.

### DIFF
--- a/enterprise/internal/codeintel/gitserver/client.go
+++ b/enterprise/internal/codeintel/gitserver/client.go
@@ -119,11 +119,9 @@ func (c *Client) RepoInfo(ctx context.Context, repos ...api.RepoName) (_ map[api
 // to its parents. If a commit is supplied, the returned graph will be rooted at the given
 // commit. If a non-zero limit is supplied, at most that many commits will be returned.
 func (c *Client) CommitGraph(ctx context.Context, repositoryID int, opts git.CommitGraphOptions) (_ *gitdomain.CommitGraph, err error) {
-	ctx, endObservation := c.operations.commitGraph.With(ctx, &err, observation.Args{LogFields: []log.Field{
-		log.Int("repositoryID", repositoryID),
-		log.String("commit", opts.Commit),
-		log.Int("limit", opts.Limit),
-	}})
+	ctx, endObservation := c.operations.commitGraph.With(ctx, &err, observation.Args{
+		LogFields: append([]log.Field{log.Int("repositoryID", repositoryID)}, opts.LogFields()...),
+	})
 	defer endObservation(1, observation.Args{})
 
 	repo, err := c.repositoryIDToRepo(ctx, repositoryID)

--- a/internal/vcs/git/commits.go
+++ b/internal/vcs/git/commits.go
@@ -866,7 +866,7 @@ func stableTimeRepr(t time.Time) string {
 var unixEpoch = stableTimeRepr(time.Unix(0, 0))
 
 func (opts *CommitGraphOptions) LogFields() []log.Field {
-	var since = unixEpoch
+	since := unixEpoch
 	if opts.Since != nil {
 		since = stableTimeRepr(*opts.Since)
 	}

--- a/internal/vcs/git/commits.go
+++ b/internal/vcs/git/commits.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/opentracing/opentracing-go/log"
+
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
@@ -854,6 +856,26 @@ type CommitGraphOptions struct {
 	AllRefs bool
 	Limit   int
 	Since   *time.Time
+} // please update LogFields if you add a field here
+
+func stableTimeRepr(t time.Time) string {
+	s, _ := t.MarshalText()
+	return string(s)
+}
+
+var unixEpoch = stableTimeRepr(time.Unix(0, 0))
+
+func (opts *CommitGraphOptions) LogFields() []log.Field {
+	var since = unixEpoch
+	if opts.Since != nil {
+		since = stableTimeRepr(*opts.Since)
+	}
+	return []log.Field{
+		log.String("commit", opts.Commit),
+		log.Int("limit", opts.Limit),
+		log.Bool("allrefs", opts.AllRefs),
+		log.String("since", since),
+	}
 }
 
 // CommitGraph returns the commit graph for the given repository as a mapping


### PR DESCRIPTION
I have been looking at a bug from a customer where we run into
an issue where limit=0 and commit is unset. However, those are
the only two fields we are logging; we weren't logging the Since
time. This limits the usability of the log. Ideally, we should
log all fields IMO. Moreover, specifying the fields next to the type
definition means that if someone adds a field to the type definition,
they need to make a change in one place only.

I don't understand why most of the places doing instrumentation
don't add similar methods on the type. Are the subset of fields
that need to be logged for a type mostly context specific?

## Test plan

Not sure if this needs a test for the `LogFields` function?