### PR TITLE
sg: autoupdates now use binary releases rather that compiling sg

### DIFF
--- a/dev/sg/main.go
+++ b/dev/sg/main.go
@@ -143,6 +143,7 @@ func checkSgVersion(ctx context.Context) error {
 	}
 
 	stdout.Out.WriteLine(output.Line(output.EmojiInfo, output.StyleSuggestion, "Auto updating sg ..."))
+	*updateDownload = true
 	err = updateCommand.Exec(ctx, nil)
 	if err != nil {
 		return err

--- a/dev/sg/main.go
+++ b/dev/sg/main.go
@@ -143,8 +143,7 @@ func checkSgVersion(ctx context.Context) error {
 	}
 
 	stdout.Out.WriteLine(output.Line(output.EmojiInfo, output.StyleSuggestion, "Auto updating sg ..."))
-	*updateDownload = true
-	err = updateCommand.Exec(ctx, nil)
+	err = updateToPrebuiltSG(ctx)
 	if err != nil {
 		return err
 	}

--- a/dev/sg/sg_update.go
+++ b/dev/sg/sg_update.go
@@ -3,18 +3,26 @@ package main
 import (
 	"context"
 	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
 	"os/exec"
+	"runtime"
+	"strings"
 
 	"github.com/peterbourgon/ff/v3/ffcli"
 
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/run"
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/stdout"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 	"github.com/sourcegraph/sourcegraph/lib/output"
 )
 
 var (
-	updateFlags   = flag.NewFlagSet("sg update", flag.ExitOnError)
-	updateToLocal = updateFlags.Bool("local", false, "Update to local copy of 'dev/sg'")
+	updateFlags    = flag.NewFlagSet("sg update", flag.ExitOnError)
+	updateToLocal  = updateFlags.Bool("local", false, "Update to local copy of 'dev/sg'")
+	updateDownload = updateFlags.Bool("download", false, "Download instead of building")
 )
 
 var updateCommand = &ffcli.Command{
@@ -28,6 +36,9 @@ var updateCommand = &ffcli.Command{
 
 Requires a local copy of the 'sourcegraph/sourcegraph' codebase.`,
 	Exec: func(ctx context.Context, args []string) error {
+		if *updateDownload {
+			return download(ctx)
+		}
 		if *updateToLocal {
 			stdout.Out.WriteLine(output.Line(output.EmojiHourglass, output.StylePending, "Upgrading to local copy of 'dev/sg'..."))
 		} else {
@@ -96,4 +107,63 @@ Requires a local copy of the 'sourcegraph/sourcegraph' codebase.`,
 		writeSuccessLinef("Update succeeded!")
 		return nil
 	},
+}
+
+func download(ctx context.Context) error {
+	req, err := http.NewRequest("GET", "https://github.com/sourcegraph/sg/releases/latest", nil)
+	if err != nil {
+		return err
+	}
+	// We use the RountTripper to make an HTTP request without having to deal
+	// with redirections.
+	resp, err := http.DefaultTransport.RoundTrip(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	location := resp.Header.Get("location")
+	if location == "" {
+		return errors.New("GitHub latest release: empty location")
+	}
+	location = strings.ReplaceAll(location, "/tag/", "/download/")
+	downloadURL := fmt.Sprintf("%s/sg_%s_%s", location, runtime.GOOS, runtime.GOARCH)
+
+	tmpDir, err := os.MkdirTemp("", "sg")
+	if err != nil {
+		return err
+	}
+	defer func() {
+		os.RemoveAll(tmpDir)
+	}()
+
+	resp, err = http.Get(downloadURL)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	tmpSgPath := tmpDir + "/sg"
+	f, err := os.Create(tmpSgPath)
+	if err != nil {
+		return err
+	}
+
+	_, err = io.Copy(f, resp.Body)
+	if err != nil {
+		return err
+	}
+	err = os.Chmod(tmpSgPath, 0755)
+	if err != nil {
+		return err
+	}
+
+	// Reliable way to find where to put sg, even if the user is using
+	// asdf.
+	cmd := exec.CommandContext(ctx, "go", "list", "-f", "{{.Target}}")
+	out, err := cmd.CombinedOutput()
+	sgPath := strings.TrimSpace(string(out))
+	if err != nil {
+		return err
+	}
+	return os.Rename(tmpSgPath, sgPath)
 }


### PR DESCRIPTION
As pointed out by @bobheadxi, depending on your machine, rebuilding `sg` can vary a lot in duration. On my heavy machine, it takes less than 10 seconds, but it can go up to 30s on @bobheadxi's machine. 

This really affects the user experience. 

This PR adds a `-download` flag to `sg update`, which is always enabled when an auto-update is run. 

```
~/work/sourcegraph/dev/sg U devx/sg-downloading-updates $ time sg help
?? Auto updating sg ...
USAGE
  sg [flags] <subcommand>
# (...)
error: flag: help requested
sg help  0.99s user 2.17s system 71% cpu 4.441 total
```

It's now down to 5 seconds, and will only depend on your connection, though that should be much more stable across different machines as we all have decent connections. 

There is a very small time window where a commit affecting sg has been pushed to main but hasn't yet run on the GitHub action. But looking at the releases timestamps, that window is below a few minutes. If the user were to be in that window, in the worst-case scenario, a new update will happen on the next git fetch, which, considering its just 5 seconds, is fine. 

Bonus: because the download mechanism does not stash, it will stop bothering editors which will detect the file having changed on the disk even though the stash part did restore them afterward.

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

- Tested manually in local.
