### PR TITLE
web: fix input `box-shadow`

### DIFF
--- a/client/branded/src/global-styles/forms.scss
+++ b/client/branded/src/global-styles/forms.scss
@@ -358,10 +358,10 @@ textarea.form-control.is-valid {
     border-color: var(--success);
 
     &:focus {
-        @at-root #{selector-append('.theme-light', &)} {
+        @at-root #{selector-append('.theme-light')} & {
             box-shadow: var(--input-focus-box-shadow-valid);
         }
-        @at-root #{selector-append('.theme-dark', &)} {
+        @at-root #{selector-append('.theme-dark')} & {
             box-shadow: var(--input-focus-box-shadow-valid);
         }
     }
@@ -375,10 +375,10 @@ textarea.form-control.is-valid {
     border-color: var(--danger);
 
     &:focus {
-        @at-root #{selector-append('.theme-light', &)} {
+        @at-root #{selector-append('.theme-light')} & {
             box-shadow: var(--input-focus-box-shadow-invalid);
         }
-        @at-root #{selector-append('.theme-dark', &)} {
+        @at-root #{selector-append('.theme-dark')} & {
             box-shadow: var(--input-focus-box-shadow-invalid);
         }
     }


### PR DESCRIPTION
## Context

| Before | After |
| -- | -- |
| <img width="538" alt="Screen Shot 2022-03-28 at 12 16 01" src="https://user-images.githubusercontent.com/3846380/160355726-e2110c72-4db5-4c1c-a732-23bc97b12023.png"> | <img width="537" alt="Screen Shot 2022-03-28 at 12 15 43" src="https://user-images.githubusercontent.com/3846380/160355748-da67a9c3-2873-4949-a6d3-5e4aada23f0e.png"> |


## Test plan

Invalid input `box-shadow` should have the correct color.

