### PR TITLE
ci: skip emtpy commits in deployment-notifier

### DIFF
--- a/enterprise/dev/deployment-notifier/main.go
+++ b/enterprise/dev/deployment-notifier/main.go
@@ -52,6 +52,10 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
+	if len(changedFiles) == 0 {
+		fmt.Println(":warning: No relevant changes, skipping notifications and exiting normally.")
+		return
+	}
 
 	dd := NewManifestDeploymentDiffer(changedFiles)
 	dn := NewDeploymentNotifier(
@@ -105,6 +109,11 @@ func getChangedFiles() ([]string, error) {
 	if output, err := exec.Command("git", diffCommand...).Output(); err != nil {
 		return nil, err
 	} else {
+		strOutput := string(output)
+		strOutput = strings.TrimSpace(strOutput)
+		if strOutput == "" {
+			return nil, nil
+		}
 		return strings.Split(strings.TrimSpace(string(output)), "\n"), nil
 	}
 }

--- a/enterprise/dev/deployment-notifier/manifest_differ.go
+++ b/enterprise/dev/deployment-notifier/manifest_differ.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -45,7 +44,6 @@ func (m *manifestDeploymentDiffer) Services() (map[string]*ServiceVersionDiff, e
 func (m *manifestDeploymentDiffer) parseManifests() error {
 	services := map[string]*ServiceVersionDiff{}
 	for _, path := range m.changedFiles {
-		fmt.Println(path)
 		info, err := os.Stat(path)
 		if err != nil {
 			return err


### PR DESCRIPTION
In some cases, it's possible that the deploy-sourcegraph pipelines will build an empty commit, ex: https://github.com/sourcegraph/deploy-sourcegraph-cloud/commit/3debd2abc227fe0b0800d02ee2ddebd069c0cc82 

This causes the deployment notifier to fail unexpectedly. Being a soft failure, it does not interrupt the build, though it appears as a failure whereas it's not. 

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

Manually reproduced locally with an empty commit and qa'ed against it. 
