### PR TITLE
Stop pinning exact versions for jaeger, fix linter

### DIFF
--- a/dev/sg/internal/docker/lints.go
+++ b/dev/sg/internal/docker/lints.go
@@ -26,7 +26,7 @@ var commandCheckApkAdd = commandCheck{
 	check: func(c instructions.Command) error {
 		if runCmd, okay := c.(*instructions.RunCommand); okay {
 			run := runCmd.String()
-			if strings.Contains(run, "apk add") {
+			if strings.Contains(run, "apk") && strings.Contains(run, "add") {
 				matches := illegalApkAddRegexp.FindAllString(run, -1)
 				if len(matches) == 0 {
 					return nil

--- a/docker-images/jaeger-agent/Dockerfile
+++ b/docker-images/jaeger-agent/Dockerfile
@@ -5,7 +5,7 @@ FROM jaegertracing/jaeger-agent:${JAEGER_VERSION} as base
 
 FROM sourcegraph/alpine-3.12:137550_2022-03-17_32d45d6a2a7f@sha256:d67684c174c577e7d61b4d7ef9d173fb73973f5b941bd65401dad90fc5e74353
 USER root
-RUN apk --no-cache add bash curl apk-tools=2.10.8-r0
+RUN apk --no-cache add bash curl apk-tools>=2.10.8-r0
 
 COPY --from=base /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=base /go/bin/agent-linux /go/bin/agent-linux

--- a/docker-images/jaeger-all-in-one/Dockerfile
+++ b/docker-images/jaeger-all-in-one/Dockerfile
@@ -8,7 +8,7 @@ FROM jaegertracing/all-in-one:${JAEGER_VERSION} as base
 FROM sourcegraph/alpine-3.12:137550_2022-03-17_32d45d6a2a7f@sha256:d67684c174c577e7d61b4d7ef9d173fb73973f5b941bd65401dad90fc5e74353
 USER root
 RUN apk update
-RUN apk --no-cache add bash curl apk-tools=2.10.8-r0 krb5-libs=1.18.4-r0
+RUN apk --no-cache add bash curl apk-tools>=2.10.8-r0 krb5-libs>=1.18.4-r0
 
 COPY --from=base /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=base /go/bin/all-in-one-linux /go/bin/all-in-one-linux


### PR DESCRIPTION
We are no longer supposed to be pinning exact versions in Dockerfiles, since this causes surprise-failures as alpine removes the older versions.

A linter was added for this situation in https://github.com/sourcegraph/sourcegraph/pull/31217 but it wasn't catching the problem because the Dockerfiles used `apk --no-cache add` as the command.

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

Build / tests should pass, no CVE's.
