### PR TITLE
Fix 3.37 build by removing exact pins

### DIFF
--- a/docker-images/jaeger-agent/Dockerfile
+++ b/docker-images/jaeger-agent/Dockerfile
@@ -5,7 +5,7 @@ FROM jaegertracing/jaeger-agent:${JAEGER_VERSION} as base
 
 FROM sourcegraph/alpine-3.12:120059_2021-12-09_b34c7b2@sha256:9a1fde12f56fea02027cf4caeebdddfedb7b73bf8db6c16f7907a6e04a29134c
 USER root
-RUN apk --no-cache add bash curl apk-tools=2.10.8-r0
+RUN apk --no-cache add bash curl apk-tools>=2.10.8-r0
 
 COPY --from=base /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=base /go/bin/agent-linux /go/bin/agent-linux

--- a/docker-images/jaeger-all-in-one/Dockerfile
+++ b/docker-images/jaeger-all-in-one/Dockerfile
@@ -8,7 +8,7 @@ FROM jaegertracing/all-in-one:${JAEGER_VERSION} as base
 FROM sourcegraph/alpine-3.12:120059_2021-12-09_b34c7b2@sha256:9a1fde12f56fea02027cf4caeebdddfedb7b73bf8db6c16f7907a6e04a29134c
 USER root
 RUN apk update
-RUN apk --no-cache add bash curl apk-tools=2.10.8-r0 krb5-libs=1.18.4-r0
+RUN apk --no-cache add bash curl apk-tools>=2.10.8-r0 krb5-libs>=1.18.4-r0
 
 COPY --from=base /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=base /go/bin/all-in-one-linux /go/bin/all-in-one-linux


### PR DESCRIPTION
The 3.37 jaeger-all-in-one build was failing due to missing packages. This PR pulls the change made in https://github.com/sourcegraph/sourcegraph/pull/33140 to stop pinning.

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->
Build should succeed.