### PR TITLE
Stop pinning exact versions for jaeger-all-in-one and jaeger-agent in 3.38 branch

### DIFF
--- a/docker-images/jaeger-agent/Dockerfile
+++ b/docker-images/jaeger-agent/Dockerfile
@@ -5,7 +5,7 @@ FROM jaegertracing/jaeger-agent:${JAEGER_VERSION} as base
 
 FROM sourcegraph/alpine-3.12:137550_2022-03-17_32d45d6a2a7f@sha256:d67684c174c577e7d61b4d7ef9d173fb73973f5b941bd65401dad90fc5e74353
 USER root
-RUN apk --no-cache add bash curl apk-tools=2.10.8-r0
+RUN apk --no-cache add bash curl apk-tools>=2.10.8-r0
 
 COPY --from=base /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=base /go/bin/agent-linux /go/bin/agent-linux

--- a/docker-images/jaeger-all-in-one/Dockerfile
+++ b/docker-images/jaeger-all-in-one/Dockerfile
@@ -8,7 +8,7 @@ FROM jaegertracing/all-in-one:${JAEGER_VERSION} as base
 FROM sourcegraph/alpine-3.12:137550_2022-03-17_32d45d6a2a7f@sha256:d67684c174c577e7d61b4d7ef9d173fb73973f5b941bd65401dad90fc5e74353
 USER root
 RUN apk update
-RUN apk --no-cache add bash curl apk-tools=2.10.8-r0 krb5-libs=1.18.4-r0
+RUN apk --no-cache add bash curl apk-tools>=2.10.8-r0 krb5-libs>=1.18.4-r0
 
 COPY --from=base /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=base /go/bin/all-in-one-linux /go/bin/all-in-one-linux


### PR DESCRIPTION
Same as https://github.com/sourcegraph/sourcegraph/pull/33141 - the 3.38 build hasn't actually failed yet but it's easier to go ahead and make these changes now instead of waiting.

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

Build should succeed.