### PR TITLE
sg: make update downloads independent of workdir

### DIFF
--- a/dev/sg/sg_update.go
+++ b/dev/sg/sg_update.go
@@ -176,10 +176,9 @@ func updateToPrebuiltSG(ctx context.Context) error {
 		return err
 	}
 
-	// Reliable way to find where to put sg, even if the user is using
-	// asdf.
-	cmd := exec.CommandContext(ctx, "go", "list", "-f", "{{.Target}}")
-	out, err := cmd.CombinedOutput()
+	// Reliable way to find where to put sg, even if the user is using asdf.
+	cmd := exec.CommandContext(ctx, "go", "list", "-f", "{{.Target}}", "./dev/sg")
+	out, err := run.InRoot(cmd)
 	sgPath := strings.TrimSpace(string(out))
 	if err != nil {
 		return err


### PR DESCRIPTION
I missed during my tests that `go list -f '{{.Target}}'` depends on the workdir and because I happened to perform all my tests in `dev/sg` I did not see it. 

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

Tested locally. 
