### PR TITLE
hackathon - search/notebook: basic end-to-end notebook result rendering

### DIFF
--- a/client/search-ui/src/components/SearchResult.tsx
+++ b/client/search-ui/src/components/SearchResult.tsx
@@ -17,6 +17,7 @@ import {
     getRepoMatchLabel,
     getRepoMatchUrl,
     getRepositoryUrl,
+    NotebookMatch,
     RepositoryMatch,
 } from '@sourcegraph/shared/src/search/stream'
 import { formatRepositoryStarCount } from '@sourcegraph/shared/src/util/stars'
@@ -28,7 +29,7 @@ import { CommitSearchResultMatch } from './CommitSearchResultMatch'
 import styles from './SearchResult.module.scss'
 
 interface Props extends PlatformContextProps<'requestGraphQL'> {
-    result: CommitMatch | RepositoryMatch
+    result: CommitMatch | RepositoryMatch | NotebookMatch
     repoName: string
     icon: React.ComponentType<{ className?: string }>
     onSelect: () => void
@@ -44,7 +45,7 @@ export const SearchResult: React.FunctionComponent<Props> = ({
     openInNewTab,
 }) => {
     const renderTitle = (): JSX.Element => {
-        const formattedRepositoryStarCount = formatRepositoryStarCount(result.repoStars)
+        const formattedRepositoryStarCount = formatRepositoryStarCount(result.type === 'notebook' ? result.stars : result.repoStars)
         return (
             <div className={styles.title}>
                 <RepoIcon repoName={repoName} className="text-muted flex-shrink-0" />
@@ -60,6 +61,9 @@ export const SearchResult: React.FunctionComponent<Props> = ({
                     )}
                     {result.type === 'repo' && (
                         <Link to={getRepoMatchUrl(result)}>{displayRepoName(getRepoMatchLabel(result))}</Link>
+                    )}
+                    {result.type === 'notebook' && (
+                        <Link to={result.url}>{repoName}</Link>
                     )}
                 </span>
                 <span className={styles.spacer} />
@@ -143,6 +147,33 @@ export const SearchResult: React.FunctionComponent<Props> = ({
                                 </div>
                             </>
                         )}
+                    </div>
+                </div>
+            )
+        }
+        if (result.type === 'notebook') {
+            return (
+                <div data-testid="search-repo-result">
+                    <div className={classNames(styles.searchResultMatch, 'p-2 flex-column')}>
+                        <div className="d-flex align-items-center flex-row">
+                            <div className={styles.matchType}>
+                                <small>Notebook match</small>
+                            </div>
+                            {result.private && (
+                                <>
+                                    <div className={styles.divider} />
+                                    <div>
+                                        <Icon
+                                            className={classNames('flex-shrink-0 text-muted', styles.icon)}
+                                            as={LockIcon}
+                                        />
+                                    </div>
+                                    <div>
+                                        <small>Private</small>
+                                    </div>
+                                </>
+                            )}
+                        </div>
                     </div>
                 </div>
             )

--- a/client/search-ui/src/results/StreamingSearchResultsList.tsx
+++ b/client/search-ui/src/results/StreamingSearchResultsList.tsx
@@ -147,7 +147,7 @@ export const StreamingSearchResultsList: React.FunctionComponent<StreamingSearch
                         <SearchResult
                             icon={NotebookIcon}
                             result={result}
-                            repoName={`${result.namespaceName} / ${result.name}`}
+                            repoName={`${result.namespace} / ${result.title}`}
                             platformContext={platformContext}
                             onSelect={() => logSearchResultClicked(index, 'notebook')}
                         />

--- a/client/search-ui/src/results/StreamingSearchResultsList.tsx
+++ b/client/search-ui/src/results/StreamingSearchResultsList.tsx
@@ -5,6 +5,7 @@ import * as H from 'history'
 import AlphaSBoxIcon from 'mdi-react/AlphaSBoxIcon'
 import FileDocumentIcon from 'mdi-react/FileDocumentIcon'
 import FileIcon from 'mdi-react/FileIcon'
+import NotebookIcon from 'mdi-react/NotebookIcon'
 import SourceCommitIcon from 'mdi-react/SourceCommitIcon'
 import SourceRepositoryIcon from 'mdi-react/SourceRepositoryIcon'
 import { Observable } from 'rxjs'
@@ -139,6 +140,16 @@ export const StreamingSearchResultsList: React.FunctionComponent<StreamingSearch
                             repoName={result.repository}
                             platformContext={platformContext}
                             onSelect={() => logSearchResultClicked(index, 'repo')}
+                        />
+                    )
+                case 'notebook':
+                    return (
+                        <SearchResult
+                            icon={NotebookIcon}
+                            result={result}
+                            repoName={`${result.namespaceName} / ${result.name}`}
+                            platformContext={platformContext}
+                            onSelect={() => logSearchResultClicked(index, 'notebook')}
                         />
                     )
             }

--- a/client/shared/src/search/stream.ts
+++ b/client/shared/src/search/stream.ts
@@ -9,7 +9,7 @@ import { SearchPatternType } from '../graphql-operations'
 import { SymbolKind } from '../schema'
 
 /** All values that are valid for the `type:` filter. `null` represents default code search. */
-export type SearchType = 'file' | 'repo' | 'path' | 'symbol' | 'diff' | 'commit' | null
+export type SearchType = 'file' | 'repo' | 'path' | 'symbol' | 'diff' | 'commit' | 'notebook' | null
 
 export type SearchEvent =
     | { type: 'matches'; data: SearchMatch[] }
@@ -19,7 +19,7 @@ export type SearchEvent =
     | { type: 'error'; data: ErrorLike }
     | { type: 'done'; data: {} }
 
-export type SearchMatch = ContentMatch | RepositoryMatch | CommitMatch | SymbolMatch | PathMatch
+export type SearchMatch = ContentMatch | RepositoryMatch | CommitMatch | SymbolMatch | PathMatch | NotebookMatch
 
 export interface PathMatch {
     type: 'path'
@@ -124,6 +124,17 @@ export interface RepositoryMatch {
     archived?: boolean
     private?: boolean
     branches?: string[]
+}
+
+export interface NotebookMatch {
+    type: 'notebook'
+    id: string
+    name: string
+    namespaceName: string
+    url: string
+
+    stars?: number
+    private: boolean
 }
 
 /**
@@ -528,5 +539,7 @@ export function getMatchUrl(match: SearchMatch): string {
             return getCommitMatchUrl(match)
         case 'repo':
             return getRepoMatchUrl(match)
+        case 'notebook':
+            return match.url
     }
 }

--- a/client/shared/src/search/stream.ts
+++ b/client/shared/src/search/stream.ts
@@ -129,8 +129,8 @@ export interface RepositoryMatch {
 export interface NotebookMatch {
     type: 'notebook'
     id: string
-    name: string
-    namespaceName: string
+    title: string
+    namespace: string
     url: string
 
     stars?: number

--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -586,13 +586,13 @@ func fromCommit(commit *result.CommitMatch, repoCache map[api.RepoID]*types.Sear
 
 func fromNotebook(notebook *result.NotebookMatch) *streamhttp.EventNotebookMatch {
 	return &streamhttp.EventNotebookMatch{
-		Type:          streamhttp.NotebookMatchType,
-		ID:            notebook.Key().ID,
-		Name:          notebook.Name,
-		NamespaceName: notebook.NamespaceName,
-		URL:           notebook.URL().String(),
-		Stars:         notebook.Stars,
-		Private:       notebook.Private,
+		Type:      streamhttp.NotebookMatchType,
+		ID:        notebook.Key().ID,
+		Title:     notebook.Title,
+		Namespace: notebook.Namespace,
+		URL:       notebook.URL().String(),
+		Stars:     notebook.Stars,
+		Private:   notebook.Private,
 	}
 }
 

--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -186,7 +186,7 @@ func (h *streamHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			//
 			// This check doesn't apply if the result is not associated with a repository,
 			// i.e. RepoName is a 0-value.
-			if string(repo.ID) != "" && string(repo.Name) != "" {
+			if repo.ID != 0 && repo.Name != "" {
 				if md, ok := repoMetadata[repo.ID]; !ok || md.Name != repo.Name {
 					continue
 				}

--- a/internal/search/job/job.go
+++ b/internal/search/job/job.go
@@ -370,6 +370,7 @@ func ToSearchJob(jargs *Args, q query.Q, db database.DB) (Job, error) {
 	}
 
 	if resultTypes.Has(result.TypeNotebook) {
+		// TODO
 		log15.Info("Notebook search yay")
 		addJob(true, &notebook.SearchJob{})
 	}

--- a/internal/search/job/job.go
+++ b/internal/search/job/job.go
@@ -372,7 +372,9 @@ func ToSearchJob(jargs *Args, q query.Q, db database.DB) (Job, error) {
 	if resultTypes.Has(result.TypeNotebook) {
 		// TODO
 		log15.Info("Notebook search yay")
-		addJob(true, &notebook.SearchJob{})
+		addJob(true, &notebook.SearchJob{
+			// Query: b.PatternString(),
+		})
 	}
 
 	addJob(true, &searchrepos.ComputeExcludedRepos{

--- a/internal/search/notebook/notebook.go
+++ b/internal/search/notebook/notebook.go
@@ -3,7 +3,6 @@ package notebook
 import (
 	"context"
 
-	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
@@ -15,14 +14,24 @@ type SearchJob struct {
 
 func (s *SearchJob) Run(ctx context.Context, db database.DB, stream streaming.Sender) (alert *search.Alert, err error) {
 	// TODO:
-	//  1. New result.NotebookMatch
+	//  ~1. New result.NotebookMatch~
 	//  2. Search database for input pattern
 	//  3. Return NotebookMatches to frontend.
 	stream.Send(streaming.SearchEvent{
 		Results: result.Matches{
-			&result.RepoMatch{
-				Name: api.RepoName("FOOBAR"),
-				ID:   1,
+			&result.NotebookMatch{
+				Name:          "FOOBAR",
+				NamespaceName: "sourcegraph",
+				ID:            1,
+				Stars:         64,
+				Private:       false,
+			},
+			&result.NotebookMatch{
+				Name:          "BAZ",
+				NamespaceName: "robert",
+				ID:            2,
+				Stars:         0,
+				Private:       true,
 			},
 		},
 	})

--- a/internal/search/notebook/notebook.go
+++ b/internal/search/notebook/notebook.go
@@ -20,18 +20,18 @@ func (s *SearchJob) Run(ctx context.Context, db database.DB, stream streaming.Se
 	stream.Send(streaming.SearchEvent{
 		Results: result.Matches{
 			&result.NotebookMatch{
-				Name:          "FOOBAR",
-				NamespaceName: "sourcegraph",
-				ID:            1,
-				Stars:         64,
-				Private:       false,
+				Title:     "FOOBAR",
+				Namespace: "sourcegraph",
+				ID:        1,
+				Stars:     64,
+				Private:   false,
 			},
 			&result.NotebookMatch{
-				Name:          "BAZ",
-				NamespaceName: "robert",
-				ID:            2,
-				Stars:         0,
-				Private:       true,
+				Title:     "BAZ",
+				Namespace: "robert",
+				ID:        2,
+				Stars:     0,
+				Private:   true,
 			},
 		},
 	})

--- a/internal/search/result/match.go
+++ b/internal/search/result/match.go
@@ -33,6 +33,7 @@ var (
 	_ Match = (*FileMatch)(nil)
 	_ Match = (*RepoMatch)(nil)
 	_ Match = (*CommitMatch)(nil)
+	_ Match = (*NotebookMatch)(nil)
 )
 
 // Match ranks are used for sorting the different match types.
@@ -56,6 +57,10 @@ type Key struct {
 
 	// Rev is the revision associated with the repo if it exists
 	Rev string
+
+	// ID is an arbitrary identifier that can be used to distinguish this result,
+	// e.g. if the result type is not associated with a repository.
+	ID string
 
 	// AuthorDate is the date a commit was authored if this key is for
 	// a commit match.

--- a/internal/search/result/notebook.go
+++ b/internal/search/result/notebook.go
@@ -12,10 +12,10 @@ import (
 type NotebookMatch struct {
 	ID int64
 
-	Name          string
-	NamespaceName string
-	Private       bool
-	Stars         int
+	Title     string
+	Namespace string
+	Private   bool
+	Stars     int
 }
 
 func (n NotebookMatch) RepoName() types.MinimalRepo {

--- a/internal/search/result/notebook.go
+++ b/internal/search/result/notebook.go
@@ -1,0 +1,66 @@
+package result
+
+import (
+	"net/url"
+
+	"github.com/graph-gophers/graphql-go/relay"
+
+	"github.com/sourcegraph/sourcegraph/internal/search/filter"
+	"github.com/sourcegraph/sourcegraph/internal/types"
+)
+
+type NotebookMatch struct {
+	ID int64
+
+	Name          string
+	NamespaceName string
+	Private       bool
+	Stars         int
+}
+
+func (n NotebookMatch) RepoName() types.MinimalRepo {
+	// This result type is not associated with any repository.
+	return types.MinimalRepo{}
+}
+
+func (n NotebookMatch) Limit(limit int) int {
+	// Always represents one result and limit > 0 so we just return limit - 1.
+	return limit - 1
+}
+
+func (n *NotebookMatch) ResultCount() int {
+	return 1
+}
+
+func (n *NotebookMatch) Select(path filter.SelectPath) Match {
+	return nil
+}
+
+func (n *NotebookMatch) URL() *url.URL {
+	return &url.URL{Path: "/notebooks/" + n.marshalNotebookID()}
+}
+
+func (n *NotebookMatch) Key() Key {
+	return Key{
+		ID: n.marshalNotebookID(),
+
+		// TODO: Could represent date created, or maybe date updated, to improve relevance
+		// AuthorDate: n.AuthorDate,
+
+		// Use same rank as repos
+		TypeRank: rankRepoMatch,
+
+		// TODO: Key appears to be used for ranking results, maybe we should extend it to
+		// include star count, or a more generic rank weight. This might be duplicative of
+		// repo.Stars, but that appears only to be used in
+		// (*searchIndexerServer).serveConfiguration so maybe that is okay?
+		// WeightRank: n.Stars,
+	}
+}
+
+func (n *NotebookMatch) searchResultMarker() {}
+
+// from enterprise/cmd/frontend/internal/notebooks/resolvers/resolvers.go
+func (n *NotebookMatch) marshalNotebookID() string {
+	return string(relay.MarshalID("Notebook", 1))
+}

--- a/internal/search/streaming/http/events.go
+++ b/internal/search/streaming/http/events.go
@@ -150,6 +150,19 @@ type EventCommitMatch struct {
 
 func (e *EventCommitMatch) eventMatch() {}
 
+type EventNotebookMatch struct {
+	Type MatchType `json:"type"`
+
+	ID            string `json:"id"`
+	Name          string `json:"name"`
+	NamespaceName string `json:"namespaceName"`
+	URL           string `json:"url"`
+	Private       bool   `json:"private"`
+	Stars         int    `json:"stars,omitempty"`
+}
+
+func (e *EventNotebookMatch) eventMatch() {}
+
 // EventFilter is a suggestion for a search filter. Currently has a 1-1
 // correspondance with the SearchFilter graphql type.
 type EventFilter struct {
@@ -188,6 +201,7 @@ const (
 	SymbolMatchType
 	CommitMatchType
 	PathMatchType
+	NotebookMatchType
 )
 
 func (t MatchType) MarshalJSON() ([]byte, error) {
@@ -202,6 +216,8 @@ func (t MatchType) MarshalJSON() ([]byte, error) {
 		return []byte(`"commit"`), nil
 	case PathMatchType:
 		return []byte(`"path"`), nil
+	case NotebookMatchType:
+		return []byte(`"notebook"`), nil
 	default:
 		return nil, errors.Errorf("unknown MatchType: %d", t)
 	}
@@ -218,6 +234,8 @@ func (t *MatchType) UnmarshalJSON(b []byte) error {
 		*t = CommitMatchType
 	} else if bytes.Equal(b, []byte(`"path"`)) {
 		*t = PathMatchType
+	} else if bytes.Equal(b, []byte(`"notebook"`)) {
+		*t = NotebookMatchType
 	} else {
 		return errors.Errorf("unknown MatchType: %s", b)
 	}

--- a/internal/search/streaming/http/events.go
+++ b/internal/search/streaming/http/events.go
@@ -153,12 +153,12 @@ func (e *EventCommitMatch) eventMatch() {}
 type EventNotebookMatch struct {
 	Type MatchType `json:"type"`
 
-	ID            string `json:"id"`
-	Name          string `json:"name"`
-	NamespaceName string `json:"namespaceName"`
-	URL           string `json:"url"`
-	Private       bool   `json:"private"`
-	Stars         int    `json:"stars,omitempty"`
+	ID        string `json:"id"`
+	Title     string `json:"title"`
+	Namespace string `json:"namespace"`
+	URL       string `json:"url"`
+	Private   bool   `json:"private"`
+	Stars     int    `json:"stars,omitempty"`
 }
 
 func (e *EventNotebookMatch) eventMatch() {}


### PR DESCRIPTION
> This is a hackathon project, and is not being merged into `main`! See https://sourcegraph.com/notebooks/Tm90ZWJvb2s6NTE5

Implements end-to-end "rendering" of some stub Notebook results. For real results, see https://github.com/sourcegraph/sourcegraph/pull/33170

This was quite tedious - to define a new search thing, we have to:

1. create a job
2. create a match type
3. create an event type + adapters
4. copy the above to web app
5. create custom UI (all the search results UI are very tightly coupled to the result type) to handle this result type, adding to the mess

I had to extend `Match.Key` with an identifier that's not a repository, and bypass the repository permissions filter here: [`notebooks-search...notebooks-search-e2e-basic?expand=1`#diff-99275f59b8](https://github.com/sourcegraph/sourcegraph/compare/notebooks-search...notebooks-search-e2e-basic?expand=1#diff-99275f59b8950f078e80979246ac6d0edbdf671b104ee61d817164131e37bd41R183-R192)

<img width="1057" alt="image" src="https://user-images.githubusercontent.com/23356519/160482875-8e440f35-e5d6-4f10-8f92-ddca1ae773ee.png">

Thought: A generic match + event type + UI for generic match types would be really nice IMO. Then the only custom stuff we need to create is a job to extend search with new backends, and everything else would ideally take care of itself. I suspect extending this to include notebook blocks, then batch changes, then etc. will not be very pretty

My first thought is that there seem to be roughly 2 categories:

- "Entity" things (repos, commits, files, etc + notebooks)
- "Content" things that fall under an entity (content, symbols, etc + notebook blocks)