### PR TITLE
migration: Fix error on empty migration targets

### DIFF
--- a/internal/database/migration/cliutil/downto.go
+++ b/internal/database/migration/cliutil/downto.go
@@ -33,11 +33,11 @@ func DownTo(commandName string, factory RunnerFactory, out *output.Output, devel
 			return flag.ErrHelp
 		}
 
-		targets := strings.Split(*targetsFlag, ",")
-		if len(targets) == 0 {
+		if *targetsFlag == "" {
 			out.WriteLine(output.Linef("", output.StyleWarning, "ERROR: supply a migration target via -target"))
 			return flag.ErrHelp
 		}
+		targets := strings.Split(*targetsFlag, ",")
 
 		versions := make([]int, 0, len(targets))
 		for _, target := range targets {

--- a/internal/database/migration/cliutil/upto.go
+++ b/internal/database/migration/cliutil/upto.go
@@ -33,11 +33,11 @@ func UpTo(commandName string, factory RunnerFactory, out *output.Output, develop
 			return flag.ErrHelp
 		}
 
-		targets := strings.Split(*targetsFlag, ",")
-		if len(targets) == 0 {
+		if *targetsFlag == "" {
 			out.WriteLine(output.Linef("", output.StyleWarning, "ERROR: supply a migration target via -target"))
 			return flag.ErrHelp
 		}
+		targets := strings.Split(*targetsFlag, ",")
 
 		versions := make([]int, 0, len(targets))
 		for _, target := range targets {


### PR DESCRIPTION
`strings.Split` never returns a zero-element slice.

## Test plan

Tested by hand via `sg`.