### PR TITLE
migration: Expose Store.Describe

### DIFF
--- a/internal/database/connections/test/store.go
+++ b/internal/database/connections/test/store.go
@@ -3,7 +3,6 @@ package connections
 import (
 	"context"
 	"database/sql"
-	"errors"
 
 	"github.com/keegancsmith/sqlf"
 
@@ -11,6 +10,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database/migration/runner"
 	"github.com/sourcegraph/sourcegraph/internal/database/migration/schemas"
 	"github.com/sourcegraph/sourcegraph/internal/database/migration/storetypes"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 // memoryStore implements runner.Store but writes to migration metadata are
@@ -37,7 +37,7 @@ func (s *memoryStore) Done(err error) error {
 }
 
 func (s *memoryStore) Describe(ctx context.Context) (map[string]schemas.SchemaDescription, error) {
-	return nil, errors.New("unimplemented")
+	return nil, errors.Newf("unimplemented")
 }
 
 func (s *memoryStore) Versions(ctx context.Context) (appliedVersions, pendingVersions, failedVersions []int, _ error) {

--- a/internal/database/connections/test/store.go
+++ b/internal/database/connections/test/store.go
@@ -3,11 +3,13 @@ package connections
 import (
 	"context"
 	"database/sql"
+	"errors"
 
 	"github.com/keegancsmith/sqlf"
 
 	"github.com/sourcegraph/sourcegraph/internal/database/migration/definition"
 	"github.com/sourcegraph/sourcegraph/internal/database/migration/runner"
+	"github.com/sourcegraph/sourcegraph/internal/database/migration/schemas"
 	"github.com/sourcegraph/sourcegraph/internal/database/migration/storetypes"
 )
 
@@ -32,6 +34,10 @@ func (s *memoryStore) Transact(ctx context.Context) (runner.Store, error) {
 
 func (s *memoryStore) Done(err error) error {
 	return err
+}
+
+func (s *memoryStore) Describe(ctx context.Context) (map[string]schemas.SchemaDescription, error) {
+	return nil, errors.New("unimplemented")
 }
 
 func (s *memoryStore) Versions(ctx context.Context) (appliedVersions, pendingVersions, failedVersions []int, _ error) {

--- a/internal/database/migration/cliutil/iface.go
+++ b/internal/database/migration/cliutil/iface.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/database/migration/definition"
 	"github.com/sourcegraph/sourcegraph/internal/database/migration/runner"
+	"github.com/sourcegraph/sourcegraph/internal/database/migration/schemas"
 )
 
 type Runner interface {
@@ -15,6 +16,7 @@ type Runner interface {
 
 type Store interface {
 	WithMigrationLog(ctx context.Context, definition definition.Definition, up bool, f func() error) error
+	Describe(ctx context.Context) (map[string]schemas.SchemaDescription, error)
 }
 
 type RunnerFactory func(ctx context.Context, schemaNames []string) (Runner, error)

--- a/internal/database/migration/runner/iface.go
+++ b/internal/database/migration/runner/iface.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/sourcegraph/sourcegraph/internal/database/migration/definition"
+	"github.com/sourcegraph/sourcegraph/internal/database/migration/schemas"
 	"github.com/sourcegraph/sourcegraph/internal/database/migration/storetypes"
 )
 
@@ -17,4 +18,5 @@ type Store interface {
 	Down(ctx context.Context, migration definition.Definition) error
 	WithMigrationLog(ctx context.Context, definition definition.Definition, up bool, f func() error) error
 	IndexStatus(ctx context.Context, tableName, indexName string) (storetypes.IndexStatus, bool, error)
+	Describe(ctx context.Context) (map[string]schemas.SchemaDescription, error)
 }


### PR DESCRIPTION
Expose `Describe` method in interfaces for later use for drift detection in `sg`.

## Test plan

No changes in executed code.