### PR TITLE
hackathon - search/notebook: basic notebooks query

### DIFF
--- a/internal/search/job/job.go
+++ b/internal/search/job/job.go
@@ -373,7 +373,7 @@ func ToSearchJob(jargs *Args, q query.Q, db database.DB) (Job, error) {
 		// TODO
 		log15.Info("Notebook search yay")
 		addJob(true, &notebook.SearchJob{
-			// Query: b.PatternString(),
+			Query: b.PatternString(),
 		})
 	}
 

--- a/internal/search/notebook/notebook.go
+++ b/internal/search/notebook/notebook.go
@@ -10,32 +10,22 @@ import (
 )
 
 type SearchJob struct {
+	Query string
 }
 
 func (s *SearchJob) Run(ctx context.Context, db database.DB, stream streaming.Sender) (alert *search.Alert, err error) {
-	// TODO:
-	//  ~1. New result.NotebookMatch~
-	//  2. Search database for input pattern
-	//  3. Return NotebookMatches to frontend.
+	store := Search(db)
+	notebooks, err := store.SearchNotebooks(ctx, s.Query)
+	if err != nil {
+		return nil, err
+	}
+	matches := make([]result.Match, len(notebooks))
+	for i, n := range notebooks {
+		matches[i] = n
+	}
 	stream.Send(streaming.SearchEvent{
-		Results: result.Matches{
-			&result.NotebookMatch{
-				Title:     "FOOBAR",
-				Namespace: "sourcegraph",
-				ID:        1,
-				Stars:     64,
-				Private:   false,
-			},
-			&result.NotebookMatch{
-				Title:     "BAZ",
-				Namespace: "robert",
-				ID:        2,
-				Stars:     0,
-				Private:   true,
-			},
-		},
+		Results: matches,
 	})
-
 	return nil, nil
 }
 

--- a/internal/search/notebook/store.go
+++ b/internal/search/notebook/store.go
@@ -1,0 +1,113 @@
+package notebook
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/keegancsmith/sqlf"
+
+	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
+	"github.com/sourcegraph/sourcegraph/internal/search/result"
+)
+
+// We must reimplement notebooks DB queries here because notebooks is an enterprise
+// product. For some parts makes sense to re-implement some of this regardless since we
+// want to specialize queries for search, but for e.g. permissions we might want to make
+// the implementation OSS and use it from Enterprise. For now they are duplicated in
+// store_copied.go
+//
+// TODO what is a good home for this?
+
+type NotebooksSearchStore interface {
+	SearchNotebooks(ctx context.Context, query string) ([]*result.NotebookMatch, error)
+}
+
+type notebooksSearchStore struct {
+	*basestore.Store
+}
+
+func Search(db dbutil.DB) NotebooksSearchStore {
+	store := basestore.NewWithDB(db, sql.TxOptions{})
+	return &notebooksSearchStore{store}
+}
+
+var notebookColumns = []*sqlf.Query{
+	sqlf.Sprintf("notebooks.id"),
+	sqlf.Sprintf("notebooks.title"),
+}
+
+const searchNotebooksFmtStr = `
+SELECT
+	%s, -- notebook columns
+	NOT public as private, -- consistency with other match types
+	users.username as namespace_user,
+	orgs.name as namespace_org,
+	(
+		SELECT COUNT(*)
+		FROM notebook_stars
+		WHERE notebook_id = notebooks.id
+	) as stars
+FROM
+	notebooks
+	LEFT JOIN users on users.id = notebooks.namespace_user_id
+	LEFT JOIN orgs on orgs.id = notebooks.namespace_org_id
+WHERE
+	(%s) -- permission conditions
+	AND (%s) -- query conditions
+ORDER BY
+	stars
+LIMIT
+	25
+`
+
+func scanMatch(scanner dbutil.Scanner) (*result.NotebookMatch, error) {
+	n := &result.NotebookMatch{}
+	var namespaceUser, namespaceOrg *string
+	err := scanner.Scan(
+		&n.ID,
+		&n.Title,
+		&n.Private,
+		&namespaceUser,
+		&namespaceOrg,
+		&n.Stars,
+	)
+	if err != nil {
+		return nil, err
+	}
+	if namespaceUser != nil {
+		n.Namespace = *namespaceUser
+	} else if namespaceOrg != nil {
+		n.Namespace = *namespaceOrg
+	}
+	return n, nil
+}
+
+func scanMatches(rows *sql.Rows) ([]*result.NotebookMatch, error) {
+	var notebooks []*result.NotebookMatch
+	for rows.Next() {
+		n, err := scanMatch(rows)
+		if err != nil {
+			return nil, err
+		}
+		notebooks = append(notebooks, n)
+	}
+	return notebooks, nil
+}
+
+func (s *notebooksSearchStore) SearchNotebooks(ctx context.Context, query string) ([]*result.NotebookMatch, error) {
+	rows, err := s.Query(ctx,
+		sqlf.Sprintf(
+			searchNotebooksFmtStr,
+			sqlf.Join(notebookColumns, ","),
+			notebooksPermissionsCondition(ctx),
+			sqlf.Sprintf("(notebooks.title ILIKE %s OR notebooks.blocks_tsvector @@ to_tsquery('english', %s))",
+				"%"+query+"%", toPostgresTextSearchQuery(query)),
+		),
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	return scanMatches(rows)
+}

--- a/internal/search/notebook/store_copied.go
+++ b/internal/search/notebook/store_copied.go
@@ -1,0 +1,49 @@
+package notebook
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/keegancsmith/sqlf"
+
+	"github.com/sourcegraph/sourcegraph/internal/actor"
+	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
+)
+
+// TODO copied wholesale from enterprise/internal/notebooks/store.go
+
+const notebooksPermissionsConditionFmtStr = `(
+	-- Bypass permission check
+	%s
+	-- Happy path of public notebooks
+	OR notebooks.public
+	-- Private notebooks are available only to its creator
+	OR (notebooks.namespace_user_id IS NOT NULL AND notebooks.namespace_user_id = %d)
+	-- Private org notebooks are available only to its members
+	OR (notebooks.namespace_org_id IS NOT NULL AND EXISTS (SELECT FROM org_members om WHERE om.org_id = notebooks.namespace_org_id AND om.user_id = %d))
+)`
+
+func notebooksPermissionsCondition(ctx context.Context) *sqlf.Query {
+	a := actor.FromContext(ctx)
+	authenticatedUserID := int32(0)
+	bypassPermissionsCheck := a.Internal
+	if !bypassPermissionsCheck && a.IsAuthenticated() {
+		authenticatedUserID = a.UID
+	}
+	return sqlf.Sprintf(notebooksPermissionsConditionFmtStr, bypassPermissionsCheck, authenticatedUserID, authenticatedUserID)
+}
+
+// Special characters used by TSQUERY we need to omit to prevent syntax errors.
+// See: https://www.postgresql.org/docs/12/datatype-textsearch.html#DATATYPE-TSQUERY
+var postgresTextSearchSpecialCharsRegex = lazyregexp.New(`&|!|\||\(|\)|:`)
+
+func toPostgresTextSearchQuery(query string) string {
+	tokens := strings.Fields(postgresTextSearchSpecialCharsRegex.ReplaceAllString(query, " "))
+	prefixTokens := make([]string, len(tokens))
+	for idx, token := range tokens {
+		// :* is used for prefix matching
+		prefixTokens[idx] = fmt.Sprintf("%s:*", token)
+	}
+	return strings.Join(prefixTokens, " & ")
+}

--- a/internal/search/notebook/store_copied.go
+++ b/internal/search/notebook/store_copied.go
@@ -2,13 +2,10 @@ package notebook
 
 import (
 	"context"
-	"fmt"
-	"strings"
 
 	"github.com/keegancsmith/sqlf"
 
 	"github.com/sourcegraph/sourcegraph/internal/actor"
-	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
 )
 
 // TODO copied wholesale from enterprise/internal/notebooks/store.go
@@ -32,18 +29,4 @@ func notebooksPermissionsCondition(ctx context.Context) *sqlf.Query {
 		authenticatedUserID = a.UID
 	}
 	return sqlf.Sprintf(notebooksPermissionsConditionFmtStr, bypassPermissionsCheck, authenticatedUserID, authenticatedUserID)
-}
-
-// Special characters used by TSQUERY we need to omit to prevent syntax errors.
-// See: https://www.postgresql.org/docs/12/datatype-textsearch.html#DATATYPE-TSQUERY
-var postgresTextSearchSpecialCharsRegex = lazyregexp.New(`&|!|\||\(|\)|:`)
-
-func toPostgresTextSearchQuery(query string) string {
-	tokens := strings.Fields(postgresTextSearchSpecialCharsRegex.ReplaceAllString(query, " "))
-	prefixTokens := make([]string, len(tokens))
-	for idx, token := range tokens {
-		// :* is used for prefix matching
-		prefixTokens[idx] = fmt.Sprintf("%s:*", token)
-	}
-	return strings.Join(prefixTokens, " & ")
 }


### PR DESCRIPTION
> This is a hackathon project, and is not being merged into `main`! See https://sourcegraph.com/notebooks/Tm90ZWJvb2s6NTE5

Implements a basic end-to-end query that searches the full "notebook name" (namespace + title) with a simple `ILIKE` query. The query emulates how normal search works by replacing spaces with wildcards so you can be pretty loose with your query.

Sharing code with `enterprise/.../notebooks`: we could possibly refactor this so that it lives in the same store as other notebooks stuff, but register it as the handler for the notebook search job from an init function. That said it makes sense, perhaps, to have the DB queries live here so that we can specialize it for search. It would be nice to share the permissions filter at least, however - not sure where this would live.

Stacked on https://github.com/sourcegraph/sourcegraph/pull/33161

https://user-images.githubusercontent.com/23356519/160510622-883ff248-809d-46dd-b9a9-8107dd41fe4b.mp4