### PR TITLE
Fix "BrowserExtensionInstalled" event logging

### DIFF
--- a/client/browser/CHANGELOG.md
+++ b/client/browser/CHANGELOG.md
@@ -13,6 +13,8 @@ All notable changes to Sourcegraph [Browser Extensions](./README.md) are documen
 
 ## Unreleased
 
+- Fixes telemetry for initial "browser extension installed" event [#pull/33175](https://github.com/sourcegraph/sourcegraph/pull/33175), [#issues/33143](https://github.com/sourcegraph/sourcegraph/issues/33143)
+
 ## Chrome & Firefox v22.3.11.1145, Safari v1.12
 
 - Fix client-side routing support on GitHub repository browse file tree pages: [#pull/32199](https://github.com/sourcegraph/sourcegraph/pull/32199), [#issues/31716](https://github.com/sourcegraph/sourcegraph/issues/31716)

--- a/client/browser/src/browser-extension/scripts/backgroundPage.main.ts
+++ b/client/browser/src/browser-extension/scripts/backgroundPage.main.ts
@@ -122,15 +122,16 @@ async function main(): Promise<void> {
         }
 
         if (IsProductionVersion) {
-            observeSourcegraphURL(IS_EXTENSION)
-                .pipe(take(1))
-                .toPromise()
-                .then(sourcegraphURL =>
-                    new EventLogger(requestGraphQL, sourcegraphURL)
-                        .log('BrowserExtensionInstalled')
-                        .then(() => console.log(`Triggered "BrowserExtensionInstalled" using ${sourcegraphURL}`))
-                )
-                .catch(error => console.error('Error triggering "BrowserExtensionInstalled" event:', error))
+            subscriptions.add(
+                observeSourcegraphURL(IS_EXTENSION)
+                    .pipe(take(1))
+                    .subscribe(sourcegraphURL => {
+                        new EventLogger(requestGraphQL, sourcegraphURL)
+                            .log('BrowserExtensionInstalled')
+                            .then(() => console.log(`Triggered "BrowserExtensionInstalled" using ${sourcegraphURL}`))
+                            .catch(error => console.error('Error triggering "BrowserExtensionInstalled" event:', error))
+                    })
+            )
         }
 
         browser.tabs.create({ url: browser.extension.getURL('after_install.html') }).catch(error => {

--- a/client/browser/src/browser-extension/scripts/backgroundPage.main.ts
+++ b/client/browser/src/browser-extension/scripts/backgroundPage.main.ts
@@ -122,15 +122,15 @@ async function main(): Promise<void> {
         }
 
         if (IsProductionVersion) {
-            subscriptions.add(
-                observeSourcegraphURL(IS_EXTENSION).subscribe(sourcegraphURL => {
-                    const eventLogger = new EventLogger(requestGraphQL, sourcegraphURL)
-                    eventLogger
+            observeSourcegraphURL(IS_EXTENSION)
+                .pipe(take(1))
+                .toPromise()
+                .then(sourcegraphURL =>
+                    new EventLogger(requestGraphQL, sourcegraphURL)
                         .log('BrowserExtensionInstalled')
                         .then(() => console.log(`Triggered "BrowserExtensionInstalled" using ${sourcegraphURL}`))
-                        .catch(error => console.error('Error triggering "BrowserExtensionInstalled" event:', error))
-                })
-            )
+                )
+                .catch(error => console.error('Error triggering "BrowserExtensionInstalled" event:', error))
         }
 
         browser.tabs.create({ url: browser.extension.getURL('after_install.html') }).catch(error => {


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/33143.

Turned out it was logging not only on initial install but every time URL is changed

## Test plan
- `yarn --cwd client/browser dev`
- Install browser extension locally
- Open browser extension background page and see the console log `Triggered "BrowserExtensionInstalled" using https://sourcegraph.com`
- Change URL and check that there no more such console log messages
> NOTE: For debug purposes 6b2208dd7a7882a0a42566ed962a35478727a4a5 code was added to only log to console, because there is no other way to see background page DevTools/Network tab initial (on install) requests 

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


