### PR TITLE
git: Move ShortLog to gitserver client

### DIFF
--- a/cmd/frontend/graphqlbackend/repository_contributors.go
+++ b/cmd/frontend/graphqlbackend/repository_contributors.go
@@ -6,7 +6,8 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
+	"github.com/sourcegraph/sourcegraph/internal/gitserver"
+	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 )
 
 type repositoryContributorsArgs struct {
@@ -36,13 +37,14 @@ type repositoryContributorConnectionResolver struct {
 
 	// cache result because it is used by multiple fields
 	once    sync.Once
-	results []*git.PersonCount
+	results []*gitdomain.PersonCount
 	err     error
 }
 
-func (r *repositoryContributorConnectionResolver) compute(ctx context.Context) ([]*git.PersonCount, error) {
+func (r *repositoryContributorConnectionResolver) compute(ctx context.Context) ([]*gitdomain.PersonCount, error) {
 	r.once.Do(func() {
-		var opt git.ShortLogOptions
+		client := gitserver.NewClient(r.db)
+		var opt gitserver.ShortLogOptions
 		if r.args.RevisionRange != nil {
 			opt.Range = *r.args.RevisionRange
 		}
@@ -52,7 +54,7 @@ func (r *repositoryContributorConnectionResolver) compute(ctx context.Context) (
 		if r.args.After != nil {
 			opt.After = *r.args.After
 		}
-		r.results, r.err = git.ShortLog(ctx, r.db, r.repo.RepoName(), opt)
+		r.results, r.err = client.ShortLog(ctx, r.repo.RepoName(), opt)
 	})
 	return r.results, r.err
 }

--- a/internal/gitserver/commands.go
+++ b/internal/gitserver/commands.go
@@ -1,16 +1,15 @@
-package git
+package gitserver
 
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"net/mail"
 	"strconv"
 	"strings"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
-	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/gitserver"
+	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
+	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
@@ -22,29 +21,7 @@ type ShortLogOptions struct {
 	Path  string // compute stats for commits that touch this path
 }
 
-// A PersonCount is a contributor to a repository.
-type PersonCount struct {
-	Name  string
-	Email string
-	Count int32
-}
-
-func (p *PersonCount) String() string {
-	return fmt.Sprintf("%d %s <%s>", p.Count, p.Name, p.Email)
-}
-
-// ShortLog returns the per-author commit statistics of the repo.
-//
-// TODO: Experiment:
-// Move this up to the gitserver client so that it's called instead
-// like this: gitserver.NewClient(db).ShortLog(ctx, repo, opt)
-//
-// This should allow us to move a lot of code into the gitserver package without changing
-// anything and give us the quickest path to being able to remove the Command type since at
-// that point it will only be used inside the gitserver package and it can be made internal.
-//
-// AFTER that we can start exposing commands on gitserver
-func ShortLog(ctx context.Context, db database.DB, repo api.RepoName, opt ShortLogOptions) ([]*PersonCount, error) {
+func (c *ClientImplementor) ShortLog(ctx context.Context, repo api.RepoName, opt ShortLogOptions) ([]*gitdomain.PersonCount, error) {
 	span, ctx := ot.StartSpanFromContext(ctx, "Git: ShortLog")
 	span.SetTag("Opt", opt)
 	defer span.Finish()
@@ -65,7 +42,7 @@ func ShortLog(ctx context.Context, db database.DB, repo api.RepoName, opt ShortL
 	if opt.Path != "" {
 		args = append(args, opt.Path)
 	}
-	cmd := gitserver.NewClient(db).Command("git", args...)
+	cmd := c.Command("git", args...)
 	cmd.Repo = repo
 	out, err := cmd.Output(ctx)
 	if err != nil {
@@ -74,13 +51,17 @@ func ShortLog(ctx context.Context, db database.DB, repo api.RepoName, opt ShortL
 	return parseShortLog(out)
 }
 
-func parseShortLog(out []byte) ([]*PersonCount, error) {
+// logEntryPattern is the regexp pattern that matches entries in the output of the `git shortlog
+// -sne` command.
+var logEntryPattern = lazyregexp.New(`^\s*([0-9]+)\s+(.*)$`)
+
+func parseShortLog(out []byte) ([]*gitdomain.PersonCount, error) {
 	out = bytes.TrimSpace(out)
 	if len(out) == 0 {
 		return nil, nil
 	}
 	lines := bytes.Split(out, []byte{'\n'})
-	results := make([]*PersonCount, len(lines))
+	results := make([]*gitdomain.PersonCount, len(lines))
 	for i, line := range lines {
 		// example line: "1125\tJane Doe <jane@sourcegraph.com>"
 		match := logEntryPattern.FindSubmatch(line)
@@ -96,7 +77,7 @@ func parseShortLog(out []byte) ([]*PersonCount, error) {
 		if err != nil || addr == nil {
 			addr = &mail.Address{Name: string(match[2])}
 		}
-		results[i] = &PersonCount{
+		results[i] = &gitdomain.PersonCount{
 			Count: int32(count),
 			Name:  addr.Name,
 			Email: addr.Address,
@@ -128,4 +109,13 @@ func lenientParseAddress(address string) (*mail.Address, error) {
 		}, nil
 	}
 	return addr, err
+}
+
+// checkSpecArgSafety returns a non-nil err if spec begins with a "-", which
+// could cause it to be interpreted as a git command line argument.
+func checkSpecArgSafety(spec string) error {
+	if strings.HasPrefix(spec, "-") {
+		return errors.Errorf("invalid git revision spec %q (begins with '-')", spec)
+	}
+	return nil
 }

--- a/internal/gitserver/commands_test.go
+++ b/internal/gitserver/commands_test.go
@@ -1,15 +1,17 @@
-package git
+package gitserver
 
 import (
 	"reflect"
 	"testing"
+
+	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 )
 
 func TestParseShortLog(t *testing.T) {
 	tests := []struct {
 		name    string
 		input   string // in the format of `git shortlog -sne`
-		want    []*PersonCount
+		want    []*gitdomain.PersonCount
 		wantErr error
 	}{
 		{
@@ -18,7 +20,7 @@ func TestParseShortLog(t *testing.T) {
   1125	Jane Doe <jane@sourcegraph.com>
    390	Bot Of Doom <bot@doombot.com>
 `,
-			want: []*PersonCount{
+			want: []*gitdomain.PersonCount{
 				{
 					Name:  "Jane Doe",
 					Email: "jane@sourcegraph.com",
@@ -36,7 +38,7 @@ func TestParseShortLog(t *testing.T) {
 			input: `  1125	jane@sourcegraph.com <jane@sourcegraph.com>
    390	Bot Of Doom <bot@doombot.com>
 `,
-			want: []*PersonCount{
+			want: []*gitdomain.PersonCount{
 				{
 					Name:  "jane@sourcegraph.com",
 					Email: "jane@sourcegraph.com",

--- a/internal/gitserver/gitdomain/common.go
+++ b/internal/gitserver/gitdomain/common.go
@@ -2,6 +2,7 @@ package gitdomain
 
 import (
 	"encoding/hex"
+	"fmt"
 	"strings"
 	"time"
 
@@ -102,4 +103,15 @@ type RefDescription struct {
 	Type            RefType
 	IsDefaultBranch bool
 	CreatedDate     time.Time
+}
+
+// A PersonCount is a contributor to a repository.
+type PersonCount struct {
+	Name  string
+	Email string
+	Count int32
+}
+
+func (p *PersonCount) String() string {
+	return fmt.Sprintf("%d %s <%s>", p.Count, p.Name, p.Email)
 }

--- a/internal/vcs/git/commits.go
+++ b/internal/vcs/git/commits.go
@@ -19,7 +19,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 	"github.com/sourcegraph/sourcegraph/internal/honey"
-	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
@@ -49,10 +48,6 @@ type CommitsOptions struct {
 	// When true return the names of the files changed in the commit
 	NameOnly bool
 }
-
-// logEntryPattern is the regexp pattern that matches entries in the output of the `git shortlog
-// -sne` command.
-var logEntryPattern = lazyregexp.New(`^\s*([0-9]+)\s+(.*)$`)
 
 var recordGetCommitQueries = os.Getenv("RECORD_GET_COMMIT_QUERIES") == "1"
 

--- a/internal/vcs/git/shortlog.go
+++ b/internal/vcs/git/shortlog.go
@@ -34,6 +34,16 @@ func (p *PersonCount) String() string {
 }
 
 // ShortLog returns the per-author commit statistics of the repo.
+//
+// TODO: Experiment:
+// Move this up to the gitserver client so that it's called instead
+// like this: gitserver.NewClient(db).ShortLog(ctx, repo, opt)
+//
+// This should allow us to move a lot of code into the gitserver package without changing
+// anything and give us the quickest path to being able to remove the Command type since at
+// that point it will only be used inside the gitserver package and it can be made internal.
+//
+// AFTER that we can start exposing commands on gitserver
 func ShortLog(ctx context.Context, db database.DB, repo api.RepoName, opt ShortLogOptions) ([]*PersonCount, error) {
 	span, ctx := ot.StartSpanFromContext(ctx, "Git: ShortLog")
 	span.SetTag("Opt", opt)


### PR DESCRIPTION
Move `vcs/git.ShortLog` to `gitserver.Client.ShortLog`.

This is an example PR to get thoughts on this refactoring pattern and is based on this [doc](https://docs.google.com/document/d/1hE8NHeNiEJkTDnRm0EihSM-nvQiqra5Y-fntP1K0rv8/edit#).

If @sourcegraph/repo-management are happy with this approach then the plan is to move all
other methods in `vcs/git` onto the client and I'll create another issue to track that.

# Test plan

Code only moved around, all tests still pas