### PR TITLE
golanci: disable depguard

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,6 +3,8 @@ linters:
   disable-all: true
   enable:
     - bodyclose
+    # Disabled due to flakes: https://github.com/sourcegraph/sourcegraph/issues/33183
+    # - depguard
     - forbidigo
     - gocritic
     - goimports

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,7 +3,6 @@ linters:
   disable-all: true
   enable:
     - bodyclose
-    - depguard
     - forbidigo
     - gocritic
     - goimports


### PR DESCRIPTION
This check has been flakey like no tomorrow on both stateful and stateless agents.
The issue seems to persist across multiple depguard versions. Until we have the
chance to dive deeper into what is happening, disable this step.

Created issue: https://github.com/sourcegraph/sourcegraph/issues/33183

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


n/a