### PR TITLE
Add Notebooks feature flag to doc

### DIFF
--- a/doc/notebooks/index.md
+++ b/doc/notebooks/index.md
@@ -42,6 +42,14 @@ Inspired by Jupyter Notebooks and powered by Markdown and Sourcegraph's code sea
 ## Notebooks are in Beta
 Notebooks are currently in public [Beta](https://sourcegraph.com/notebooks?order=stars-desc) on Sourcegraph Cloud and in Sourcegraph enterprise installs at version 3.36 or later. You can explore all the public notebooks on Sourcegraph.com without an account, or create a [Sourcegraph Cloud](https://about.sourcegraph.com/get-started/cloud) account to start creating your own Notebooks.
 
+To try out notebooks on your enterprise install, enable them in global settings:
+
+```
+"experimentalFeatures": {
+    "showSearchNotebook": true
+}
+```
+
 We're still actively developing Notebooks while in Beta and we'd love your [feedback and bugs](mailto:feedback@sourcegraph.com) so we can make them better.
 
 <div class="cta-group">


### PR DESCRIPTION
Under the "Notebooks are in Beta" section, add the feature flag that should be enabled by Enterprise customers who wish to try Notebooks.

## Test plan

This is a docs change.


