### PR TITLE
lsif utils: Switch from kingpin to flag

### DIFF
--- a/lib/codeintel/tools/lsif-validate/args.go
+++ b/lib/codeintel/tools/lsif-validate/args.go
@@ -1,32 +1,9 @@
 package main
 
 import (
-	"os"
-
-	"github.com/alecthomas/kingpin"
+	"flag"
 )
-
-var app = kingpin.New(
-	"lsif-validate",
-	"lsif-validate is validator for LSIF indexer output.",
-).Version(version)
 
 var (
-	indexFile *os.File
+	indexFilePath = flag.String("index-file", "dump.lsif", "The LSIF index to validate.")
 )
-
-func init() {
-	app.HelpFlag.Short('h')
-	app.VersionFlag.Short('v')
-	app.HelpFlag.Hidden()
-
-	app.Arg("index-file", "The LSIF index to validate.").Default("dump.lsif").FileVar(&indexFile)
-}
-
-func parseArgs(args []string) (err error) {
-	if _, err := app.Parse(args); err != nil {
-		return err
-	}
-
-	return nil
-}

--- a/lib/codeintel/tools/lsif-validate/main.go
+++ b/lib/codeintel/tools/lsif-validate/main.go
@@ -1,11 +1,10 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"os"
 )
-
-const version = "0.1.0"
 
 func main() {
 	if err := mainErr(); err != nil {
@@ -15,7 +14,10 @@ func main() {
 }
 
 func mainErr() error {
-	if err := parseArgs(os.Args[1:]); err != nil {
+	flag.Parse()
+
+	indexFile, err := os.OpenFile(*indexFilePath, os.O_RDONLY, 0)
+	if err != nil {
 		return err
 	}
 	defer indexFile.Close()

--- a/lib/codeintel/tools/lsif-visualize/args.go
+++ b/lib/codeintel/tools/lsif-visualize/args.go
@@ -1,39 +1,14 @@
 package main
 
 import (
-	"os"
-
-	"github.com/alecthomas/kingpin"
+	"flag"
+	"strings"
 )
-
-var app = kingpin.New(
-	"lsif-visualize",
-	"lsif-visualize is visualizer for LSIF indexer output.",
-).Version(version)
 
 var (
-	indexFile     *os.File
-	fromID        int
-	subgraphDepth int
-	exclude       []string
+	indexFilePath = flag.String("index-file", "dump.lsif", "The LSIF index to visualize.")
+	fromID        = flag.Int("from-id", 2, "The edge/vertex ID to visualize a subgraph from. Must be used in combination with '-depth'.")
+	subgraphDepth = flag.Int("depth", -1, "Depth limit of the subgraph to be output")
+	excludeArg    = flag.String("exclude", "", "Comma-separated list of vertices to exclude from the visualization")
+	exclude       = strings.Split(*excludeArg, ",")
 )
-
-func init() {
-	app.HelpFlag.Short('h')
-	app.VersionFlag.Short('v')
-	app.HelpFlag.Hidden()
-
-	app.Flag("from-id", "The edge/vertex ID to visualize a subgraph from. Must be used in combination with '-depth'.").Default("2").IntVar(&fromID)
-	app.Flag("depth", "Depth limit of the subgraph to be output").Default("-1").IntVar(&subgraphDepth)
-	app.Flag("exclude", "Vertices to exclude from the visualization").StringsVar(&exclude)
-
-	app.Arg("index-file", "The LSIF index to visualize.").Default("dump.lsif").FileVar(&indexFile)
-}
-
-func parseArgs(args []string) (err error) {
-	if _, err := app.Parse(args); err != nil {
-		return err
-	}
-
-	return nil
-}

--- a/lib/codeintel/tools/lsif-visualize/main.go
+++ b/lib/codeintel/tools/lsif-visualize/main.go
@@ -1,11 +1,10 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"os"
 )
-
-const version = "0.1.0"
 
 func main() {
 	if err := mainErr(); err != nil {
@@ -15,10 +14,13 @@ func main() {
 }
 
 func mainErr() error {
-	if err := parseArgs(os.Args[1:]); err != nil {
+	flag.Parse()
+
+	indexFile, err := os.OpenFile(*indexFilePath, os.O_RDONLY, 0)
+	if err != nil {
 		return err
 	}
 	defer indexFile.Close()
 
-	return visualize(indexFile, fromID, subgraphDepth, exclude)
+	return visualize(indexFile, *fromID, *subgraphDepth, exclude)
 }


### PR DESCRIPTION
Golang lint has blacklisted kingpin, so this switches to the flag package.

https://buildkite.com/sourcegraph/sourcegraph/builds/139490

<img width="820" alt="CleanShot 2022-03-29 at 16 32 20@2x" src="https://user-images.githubusercontent.com/1387653/160717679-b9d0821e-b03b-4ae4-b8d4-529b08a5bc30.png">

## Test plan

Existing tests.