### PR TITLE
batches: fix loading spinner background in Chromium

### DIFF
--- a/client/web/src/enterprise/batches/create/workspaces-preview/PreviewLoadingSpinner.module.scss
+++ b/client/web/src/enterprise/batches/create/workspaces-preview/PreviewLoadingSpinner.module.scss
@@ -1,0 +1,5 @@
+.object {
+    // This is to prevent a bug in Chromium which applies a white background to an
+    // `<object />` when it is the child of an element with color-scheme: dark; applied.
+    color-scheme: none;
+}

--- a/client/web/src/enterprise/batches/create/workspaces-preview/PreviewLoadingSpinner.tsx
+++ b/client/web/src/enterprise/batches/create/workspaces-preview/PreviewLoadingSpinner.tsx
@@ -1,5 +1,9 @@
 import React, { memo } from 'react'
 
+import classNames from 'classnames'
+
+import styles from './PreviewLoadingSpinner.module.scss'
+
 // The SVG is animated with inline <script> tags, so we can't just render it like a normal
 // React component and instead load it in with an <object> tag:
 // https://www.w3schools.com/tags/tag_object.asp
@@ -9,7 +13,13 @@ export const PreviewLoadingSpinner: React.FunctionComponent<{
     const svgSource = `${window.context?.assetsRoot || ''}/img/unoptimized/batchchanges-preview-loading.svg`
 
     return (
-        <object type="image/svg+xml" data={svgSource} className={className} height="50" width="50">
+        <object
+            type="image/svg+xml"
+            data={svgSource}
+            className={classNames(className, styles.object)}
+            height="50"
+            width="50"
+        >
             <img src={svgSource} alt="Workspaces preview is loading..." />
         </object>
     )


### PR DESCRIPTION
😑

https://stackoverflow.com/questions/70352898/why-does-color-scheme-dark-cause-objects-to-have-white-backgrounds-in-chrom

Before | After
:------:|:-----:
<img width="445" alt="Screen Shot 2022-03-29 at 3 39 59 PM" src="https://user-images.githubusercontent.com/8942601/160718674-cfc0cbcb-8cbb-47e5-a36f-6b25d2dfdb98.png"> | <img width="394" alt="Screen Shot 2022-03-29 at 3 39 46 PM" src="https://user-images.githubusercontent.com/8942601/160718657-108526dd-91e9-41ae-8f94-fe1e32035e1f.png">


## Test plan

Manually verified display of SVG across multiple Chromium- and non-Chromium-based browsers, in both light and dark mode.


