### PR TITLE
hackathon - search/notebook: select and view notebook block results

### DIFF
--- a/client/shared/src/search/stream.ts
+++ b/client/shared/src/search/stream.ts
@@ -19,7 +19,14 @@ export type SearchEvent =
     | { type: 'error'; data: ErrorLike }
     | { type: 'done'; data: {} }
 
-export type SearchMatch = ContentMatch | RepositoryMatch | CommitMatch | SymbolMatch | PathMatch | NotebookMatch
+export type SearchMatch =
+    | ContentMatch
+    | RepositoryMatch
+    | CommitMatch
+    | SymbolMatch
+    | PathMatch
+    | NotebookMatch
+    | NotebookBlockMatch
 
 export interface PathMatch {
     type: 'path'
@@ -135,6 +142,14 @@ export interface NotebookMatch {
 
     stars?: number
     private: boolean
+}
+
+export interface NotebookBlockMatch {
+    type: 'notebook.block'
+    notebook: NotebookMatch
+    // TODO lots of variants of these types, leave as any for now and massage the data
+    // as needed
+    blocks: any[]
 }
 
 /**

--- a/client/web/src/notebooks/notebook/NotebookComponent.tsx
+++ b/client/web/src/notebooks/notebook/NotebookComponent.tsx
@@ -65,6 +65,7 @@ export interface NotebookComponentProps
     >
     exportedFileName: string
     isEmbedded?: boolean
+    noRunButton?: boolean
     onSerializeBlocks: (blocks: Block[]) => void
     onCopyNotebook: (props: Omit<CopyNotebookProps, 'title'>) => Observable<NotebookFields>
 }
@@ -101,6 +102,7 @@ export const NotebookComponent: React.FunctionComponent<NotebookComponentProps> 
         onSerializeBlocks,
         onCopyNotebook,
         isReadOnly = false,
+        noRunButton,
         extensionsController,
         exportedFileName,
         isEmbedded,
@@ -501,7 +503,7 @@ export const NotebookComponent: React.FunctionComponent<NotebookComponentProps> 
         return (
             <div className={styles.searchNotebook} ref={nextNotebookElement}>
                 <div className="pb-1">
-                    <Button
+                    {!noRunButton && <Button
                         className="mr-2"
                         variant="primary"
                         size="sm"
@@ -510,7 +512,7 @@ export const NotebookComponent: React.FunctionComponent<NotebookComponentProps> 
                     >
                         <Icon className="mr-1" as={PlayCircleOutlineIcon} />
                         <span>{runningAllBlocks === LOADING ? 'Running...' : 'Run all blocks'}</span>
-                    </Button>
+                    </Button>}
                     {!isEmbedded && (
                         <Button
                             className="mr-2"

--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -426,6 +426,8 @@ func fromMatch(match result.Match, repoCache map[api.RepoID]*types.SearchedRepo)
 		return fromCommit(v, repoCache)
 	case *result.NotebookMatch:
 		return fromNotebook(v)
+	case *result.NotebookBlocksMatch:
+		return fromNotebookBlocks(v)
 	default:
 		panic(fmt.Sprintf("unknown match type %T", v))
 	}
@@ -593,6 +595,14 @@ func fromNotebook(notebook *result.NotebookMatch) *streamhttp.EventNotebookMatch
 		URL:       notebook.URL().String(),
 		Stars:     notebook.Stars,
 		Private:   notebook.Private,
+	}
+}
+
+func fromNotebookBlocks(blocks *result.NotebookBlocksMatch) *streamhttp.EventNotebookBlockMatch {
+	return &streamhttp.EventNotebookBlockMatch{
+		Type:     streamhttp.NotebookBlockMatchType,
+		Notebook: *fromNotebook(&blocks.Notebook),
+		Blocks:   blocks.Blocks,
 	}
 }
 

--- a/internal/search/filter/select.go
+++ b/internal/search/filter/select.go
@@ -12,6 +12,7 @@ const (
 	File       = "file"
 	Repository = "repo"
 	Symbol     = "symbol"
+	Notebook   = "notebook"
 )
 
 // SelectPath represents a parsed and validated select value
@@ -73,6 +74,16 @@ var validSelectors = object{
 		"event":          nil,
 		"operator":       nil,
 		"type-parameter": nil,
+	},
+	Notebook: object{
+		"block": object{
+			// enterprise/internal/notebooks/types.go
+			"query":   nil,
+			"md":      nil,
+			"file":    nil,
+			"symbol":  nil,
+			"compute": nil,
+		},
 	},
 }
 

--- a/internal/search/job/job.go
+++ b/internal/search/job/job.go
@@ -373,7 +373,7 @@ func ToSearchJob(jargs *Args, q query.Q, db database.DB) (Job, error) {
 		// TODO
 		log15.Info("Notebook search yay")
 		addJob(true, &notebook.SearchJob{
-			Query: b.PatternString(),
+			Query: b,
 		})
 	}
 

--- a/internal/search/notebook/notebook.go
+++ b/internal/search/notebook/notebook.go
@@ -5,17 +5,23 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/search"
+	"github.com/sourcegraph/sourcegraph/internal/search/query"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
 	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
 )
 
 type SearchJob struct {
-	Query string
+	Query query.Basic
 }
 
 func (s *SearchJob) Run(ctx context.Context, db database.DB, stream streaming.Sender) (alert *search.Alert, err error) {
 	store := Search(db)
-	notebooks, err := store.SearchNotebooks(ctx, s.Query)
+	// TODO:
+	// - search over everything by default
+	// - search only "full name" on 'notebook:' filter
+	// - account for search pattern types
+	// - actually filter blocks (we return all right now)
+	notebooks, err := store.SearchNotebooks(ctx, s.Query.PatternString(), true)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/search/notebook/store_copied.go
+++ b/internal/search/notebook/store_copied.go
@@ -2,10 +2,13 @@ package notebook
 
 import (
 	"context"
+	"fmt"
+	"strings"
 
 	"github.com/keegancsmith/sqlf"
 
 	"github.com/sourcegraph/sourcegraph/internal/actor"
+	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
 )
 
 // TODO copied wholesale from enterprise/internal/notebooks/store.go
@@ -29,4 +32,18 @@ func notebooksPermissionsCondition(ctx context.Context) *sqlf.Query {
 		authenticatedUserID = a.UID
 	}
 	return sqlf.Sprintf(notebooksPermissionsConditionFmtStr, bypassPermissionsCheck, authenticatedUserID, authenticatedUserID)
+}
+
+// Special characters used by TSQUERY we need to omit to prevent syntax errors.
+// See: https://www.postgresql.org/docs/12/datatype-textsearch.html#DATATYPE-TSQUERY
+var postgresTextSearchSpecialCharsRegex = lazyregexp.New(`&|!|\||\(|\)|:`)
+
+func toPostgresTextSearchQuery(query string) string {
+	tokens := strings.Fields(postgresTextSearchSpecialCharsRegex.ReplaceAllString(query, " "))
+	prefixTokens := make([]string, len(tokens))
+	for idx, token := range tokens {
+		// :* is used for prefix matching
+		prefixTokens[idx] = fmt.Sprintf("%s:*", token)
+	}
+	return strings.Join(prefixTokens, " & ")
 }

--- a/internal/search/result/notebook_block.go
+++ b/internal/search/result/notebook_block.go
@@ -1,0 +1,73 @@
+package result
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/sourcegraph/sourcegraph/internal/search/filter"
+	"github.com/sourcegraph/sourcegraph/internal/types"
+)
+
+// TODO these types are all in enterprise, a bit much to copy-paste, so we keep it
+// untyped for ease of use for now.
+type NotebookBlock map[string]interface{}
+
+type NotebookBlocksMatch struct {
+	Notebook NotebookMatch
+
+	Blocks []NotebookBlock
+}
+
+func (n NotebookBlocksMatch) RepoName() types.MinimalRepo {
+	// This result type is not associated with any repository.
+	return types.MinimalRepo{}
+}
+
+func (n NotebookBlocksMatch) Limit(limit int) int {
+	return limit - len(n.Blocks)
+}
+
+func (n *NotebookBlocksMatch) ResultCount() int {
+	return len(n.Blocks)
+}
+
+func (n *NotebookBlocksMatch) Select(path filter.SelectPath) Match {
+	if path.Root() != filter.Notebook {
+		return nil
+	}
+	switch len(path) {
+	case 2:
+		if path[1] == "block" {
+			return n
+		}
+	case 3:
+		blockType := path[2]
+		var blocks NotebookBlocks
+		for _, b := range n.Blocks {
+			if b["type"] == blockType {
+				blocks = append(blocks, b)
+			}
+		}
+		return &NotebookBlocksMatch{
+			Notebook: n.Notebook,
+			Blocks:   blocks,
+		}
+	}
+
+	return nil
+}
+
+func (n *NotebookBlocksMatch) URL() *url.URL {
+	// Cannot link directly to blocks yet
+	return &url.URL{Path: "/notebooks/" + n.Notebook.marshalNotebookID()}
+}
+
+func (n *NotebookBlocksMatch) Key() Key {
+	return Key{
+		ID: fmt.Sprintf("%s-blocks", n.Notebook.marshalNotebookID()),
+		// Use same rank as files
+		TypeRank: rankFileMatch,
+	}
+}
+
+func (n *NotebookBlocksMatch) searchResultMarker() {}

--- a/internal/search/streaming/http/events.go
+++ b/internal/search/streaming/http/events.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"time"
 
+	"github.com/sourcegraph/sourcegraph/internal/search/result"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
@@ -163,6 +164,15 @@ type EventNotebookMatch struct {
 
 func (e *EventNotebookMatch) eventMatch() {}
 
+type EventNotebookBlockMatch struct {
+	Type MatchType `json:"type"`
+
+	Notebook EventNotebookMatch     `json:"notebook"`
+	Blocks   []result.NotebookBlock `json:"blocks"`
+}
+
+func (e *EventNotebookBlockMatch) eventMatch() {}
+
 // EventFilter is a suggestion for a search filter. Currently has a 1-1
 // correspondance with the SearchFilter graphql type.
 type EventFilter struct {
@@ -202,6 +212,7 @@ const (
 	CommitMatchType
 	PathMatchType
 	NotebookMatchType
+	NotebookBlockMatchType
 )
 
 func (t MatchType) MarshalJSON() ([]byte, error) {
@@ -218,6 +229,8 @@ func (t MatchType) MarshalJSON() ([]byte, error) {
 		return []byte(`"path"`), nil
 	case NotebookMatchType:
 		return []byte(`"notebook"`), nil
+	case NotebookBlockMatchType:
+		return []byte(`"notebook.block"`), nil
 	default:
 		return nil, errors.Errorf("unknown MatchType: %d", t)
 	}
@@ -236,6 +249,8 @@ func (t *MatchType) UnmarshalJSON(b []byte) error {
 		*t = PathMatchType
 	} else if bytes.Equal(b, []byte(`"notebook"`)) {
 		*t = NotebookMatchType
+	} else if bytes.Equal(b, []byte(`"notebook.block"`)) {
+		*t = NotebookBlockMatchType
 	} else {
 		return errors.Errorf("unknown MatchType: %s", b)
 	}


### PR DESCRIPTION
> This is a hackathon project, and is not being merged into `main`! See https://sourcegraph.com/notebooks/Tm90ZWJvb2s6NTE5, https://github.com/sourcegraph/sourcegraph/pull/33170, and https://github.com/sourcegraph/sourcegraph/pull/33161

This is _entirely_ quite silly, but here we are!

https://user-images.githubusercontent.com/23356519/160736855-cc02b3d9-cc55-4f36-8e0a-5e8bb210fd6e.mp4

Lots of hacks and caveats:

- some more code had to be copy-pasted from enterprise
- not using strong types on notebook blocks, due to OSS/enterprise. Some massaging of data needed since there appears to be **three** (!!!!) different iterations of notebook block types: the DB types, the GraphQL types, and then an internal representation used within the notebook components that are each ever so slightly different.
- I'm not sure how to go about doing "real" querying of blocks without some drastic database restructuring, I've left some notes in https://sourcegraph.com/notebooks/Tm90ZWJvb2s6NTE5
- Search syntax and when to search what probably needs some work 
- I'm not 100% sure the match type implementation is the "right way" to do this but it does seem to work within the search job framework
- The idea originally was to have query blocks open a new window by default but since that requires fiddling with the component and this kind of... just works... 😅 

And of course, the big question:

![image](https://user-images.githubusercontent.com/23356519/160737120-264e41ea-501a-4ef5-b88d-f43e7a4b29ed.png)
