### PR TITLE
search: factor out Zoekt job creation logic to functions

### DIFF
--- a/internal/search/job/job.go
+++ b/internal/search/job/job.go
@@ -75,6 +75,7 @@ func ToSearchJob(jargs *Args, q query.Q, db database.DB) (Job, error) {
 		features:       &features,
 		fileMatchLimit: fileMatchLimit,
 		selector:       selector,
+		zoekt:          jargs.Zoekt,
 	}
 
 	repoUniverseSearch, skipRepoSubsetSearch, onlyRunSearcher := jobMode(b, resultTypes, jargs.SearchInputs.PatternType, jargs.SearchInputs.OnSourcegraphDotCom)


### PR DESCRIPTION
Now that the big `ToSearchJob` function block is "flat" over all kinds of state, we can finally start squashing shared concerns/state and keep separate ones... separate. This PR factors out functions for creating Zoekt jobs such that:

- shared state/compute values are shared by a `jobBuilder` type (see comments)
- different variants on the job are determined by using the appropriate constructor (global vs nonglobal) and parameterized by `symbol` vs `text` type.

This is just the _start_ of factoring things out. The inconsistent naming and appearance of duplication is going to go away as the factoring becomes cleaner.

Context on why I'm doing this now: the state is finally approachable to cleanly separate, and I want to create those optimized Zoekt jobs. To do that, I need clear constructors to create Zoekt jobs in a place outside of this `ToSearchJob` function.

You can go by commit, but honestly, it's very mechanical and starts off with duplication, and then crunches logic into the constructors. Probably most time-efficient to just look at the full PR.

---

Directions after this PR:

- Make Job types consistent (naming, reduce unneeded/unshared/duplicative state). I'm paying less attention to this right now because it's the slowest route to optimized Zoekt queries.
- Factor out constructors for other search jobs in `ToSearchJobs` as methods on `jobBuilder`
- Have `ToSearchJobs` be a method on `jobBuilder` (we won't construct `jobBuilder` in line).



## Test plan
Semantics-preserving.


