### PR TITLE
db: rename gitserver_localclone_jobs to gitserver_relocator_jobs

### DIFF
--- a/internal/database/gitserver_localclone_jobs.go
+++ b/internal/database/gitserver_localclone_jobs.go
@@ -46,7 +46,7 @@ func (s *gitserverLocalCloneStore) Enqueue(ctx context.Context, repoID int, sour
 	err := s.QueryRow(ctx, sqlf.Sprintf(`
 -- source: internal/database/gitserver_localclone_jobs.go:gitserverLocalCloneStore.Enqueue
 INSERT INTO
-	gitserver_localclone_jobs (repo_id, source_hostname, dest_hostname, delete_source)
+	gitserver_relocator_jobs (repo_id, source_hostname, dest_hostname, delete_source)
 VALUES (%s, %s, %s, %s) RETURNING id
 	`, repoID, sourceHostname, destHostname, deleteSource)).Scan(&jobId)
 	if err != nil {

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -989,11 +989,11 @@ Referenced by:
 
 **rollout**: Rollout only defined when flag_type is rollout. Increments of 0.01%
 
-# Table "public.gitserver_replicator_jobs"
+# Table "public.gitserver_relocator_jobs"
 ```
-      Column       |           Type           | Collation | Nullable |                        Default                        
--------------------+--------------------------+-----------+----------+-------------------------------------------------------
- id                | integer                  |           | not null | nextval('gitserver_replicator_jobs_id_seq'::regclass)
+      Column       |           Type           | Collation | Nullable |                       Default                        
+-------------------+--------------------------+-----------+----------+------------------------------------------------------
+ id                | integer                  |           | not null | nextval('gitserver_relocator_jobs_id_seq'::regclass)
  state             | text                     |           |          | 'queued'::text
  queued_at         | timestamp with time zone |           |          | now()
  failure_message   | text                     |           |          | 
@@ -1010,7 +1010,7 @@ Referenced by:
  dest_hostname     | text                     |           | not null | 
  delete_source     | boolean                  |           | not null | false
 Indexes:
-    "gitserver_replicator_jobs_pkey" PRIMARY KEY, btree (id)
+    "gitserver_relocator_jobs_pkey" PRIMARY KEY, btree (id)
 
 ```
 
@@ -2592,7 +2592,7 @@ Foreign-key constraints:
      JOIN external_service_sync_jobs j ON ((e.id = j.external_service_id)));
 ```
 
-# View "public.gitserver_replicator_jobs_with_repo_name"
+# View "public.gitserver_relocator_jobs_with_repo_name"
 
 ## View query:
 
@@ -2614,7 +2614,7 @@ Foreign-key constraints:
     glj.dest_hostname,
     glj.delete_source,
     r.name AS repo_name
-   FROM (gitserver_replicator_jobs glj
+   FROM (gitserver_relocator_jobs glj
      JOIN repo r ON ((r.id = glj.repo_id)));
 ```
 

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -989,12 +989,13 @@ Referenced by:
 
 **rollout**: Rollout only defined when flag_type is rollout. Increments of 0.01%
 
-# Table "public.gitserver_localclone_jobs"
+# Table "public.gitserver_replicator_jobs"
 ```
       Column       |           Type           | Collation | Nullable |                        Default                        
 -------------------+--------------------------+-----------+----------+-------------------------------------------------------
- id                | integer                  |           | not null | nextval('gitserver_localclone_jobs_id_seq'::regclass)
+ id                | integer                  |           | not null | nextval('gitserver_replicator_jobs_id_seq'::regclass)
  state             | text                     |           |          | 'queued'::text
+ queued_at         | timestamp with time zone |           |          | now()
  failure_message   | text                     |           |          | 
  started_at        | timestamp with time zone |           |          | 
  finished_at       | timestamp with time zone |           |          | 
@@ -1008,9 +1009,8 @@ Referenced by:
  source_hostname   | text                     |           | not null | 
  dest_hostname     | text                     |           | not null | 
  delete_source     | boolean                  |           | not null | false
- queued_at         | timestamp with time zone |           |          | now()
 Indexes:
-    "gitserver_localclone_jobs_pkey" PRIMARY KEY, btree (id)
+    "gitserver_replicator_jobs_pkey" PRIMARY KEY, btree (id)
 
 ```
 
@@ -2592,13 +2592,14 @@ Foreign-key constraints:
      JOIN external_service_sync_jobs j ON ((e.id = j.external_service_id)));
 ```
 
-# View "public.gitserver_localclone_jobs_with_repo_name"
+# View "public.gitserver_replicator_jobs_with_repo_name"
 
 ## View query:
 
 ```sql
  SELECT glj.id,
     glj.state,
+    glj.queued_at,
     glj.failure_message,
     glj.started_at,
     glj.finished_at,
@@ -2612,9 +2613,8 @@ Foreign-key constraints:
     glj.source_hostname,
     glj.dest_hostname,
     glj.delete_source,
-    glj.queued_at,
     r.name AS repo_name
-   FROM (gitserver_localclone_jobs glj
+   FROM (gitserver_replicator_jobs glj
      JOIN repo r ON ((r.id = glj.repo_id)));
 ```
 

--- a/migrations/frontend/1648628900/down.sql
+++ b/migrations/frontend/1648628900/down.sql
@@ -1,0 +1,32 @@
+-- drop view
+DROP VIEW IF EXISTS gitserver_replicator_jobs_with_repo_name;
+
+-- drop the table
+DROP TABLE IF EXISTS gitserver_replicator_jobs;
+
+-- create the old table
+CREATE TABLE IF NOT EXISTS gitserver_localclone_jobs (
+    id                  SERIAL PRIMARY KEY,
+    state               text DEFAULT 'queued',
+    queued_at           timestamptz DEFAULT NOW(),
+    failure_message     text,
+    started_at          timestamp with time zone,
+    finished_at         timestamp with time zone,
+    process_after       timestamp with time zone,
+    num_resets          integer not null DEFAULT 0,
+    num_failures        integer not null DEFAULT 0,
+    last_heartbeat_at   timestamp with time zone,
+    execution_logs      json[],
+    worker_hostname     text not null DEFAULT '',
+
+    repo_id             integer not null,
+    source_hostname     text not null,
+    dest_hostname       text not null,
+    delete_source       boolean not null DEFAULT false
+);
+
+-- create the old view
+CREATE OR REPLACE VIEW gitserver_localclone_jobs_with_repo_name AS
+  SELECT glj.*, r.name AS repo_name
+  FROM gitserver_localclone_jobs glj
+  JOIN repo r ON r.id = glj.repo_id;

--- a/migrations/frontend/1648628900/down.sql
+++ b/migrations/frontend/1648628900/down.sql
@@ -1,8 +1,8 @@
 -- drop view
-DROP VIEW IF EXISTS gitserver_replicator_jobs_with_repo_name;
+DROP VIEW IF EXISTS gitserver_relocator_jobs_with_repo_name;
 
 -- drop the table
-DROP TABLE IF EXISTS gitserver_replicator_jobs;
+DROP TABLE IF EXISTS gitserver_relocator_jobs;
 
 -- create the old table
 CREATE TABLE IF NOT EXISTS gitserver_localclone_jobs (

--- a/migrations/frontend/1648628900/metadata.yaml
+++ b/migrations/frontend/1648628900/metadata.yaml
@@ -1,0 +1,2 @@
+name: rename_localclone_worker_table
+parents: [1648195639]

--- a/migrations/frontend/1648628900/up.sql
+++ b/migrations/frontend/1648628900/up.sql
@@ -5,7 +5,7 @@ DROP VIEW IF EXISTS gitserver_localclone_jobs_with_repo_name;
 DROP TABLE IF EXISTS gitserver_localclone_jobs;
 
 -- create the new table
-CREATE TABLE IF NOT EXISTS gitserver_replicator_jobs (
+CREATE TABLE IF NOT EXISTS gitserver_relocator_jobs (
     id                  SERIAL PRIMARY KEY,
     state               text DEFAULT 'queued',
     queued_at           timestamptz DEFAULT NOW(),
@@ -26,7 +26,7 @@ CREATE TABLE IF NOT EXISTS gitserver_replicator_jobs (
 );
 
 -- create the view
-CREATE OR REPLACE VIEW gitserver_replicator_jobs_with_repo_name AS
+CREATE OR REPLACE VIEW gitserver_relocator_jobs_with_repo_name AS
   SELECT glj.*, r.name AS repo_name
-  FROM gitserver_replicator_jobs glj
+  FROM gitserver_relocator_jobs glj
   JOIN repo r ON r.id = glj.repo_id;

--- a/migrations/frontend/1648628900/up.sql
+++ b/migrations/frontend/1648628900/up.sql
@@ -1,0 +1,32 @@
+-- drop view
+DROP VIEW IF EXISTS gitserver_localclone_jobs_with_repo_name;
+
+-- drop the table
+DROP TABLE IF EXISTS gitserver_localclone_jobs;
+
+-- create the new table
+CREATE TABLE IF NOT EXISTS gitserver_replicator_jobs (
+    id                  SERIAL PRIMARY KEY,
+    state               text DEFAULT 'queued',
+    queued_at           timestamptz DEFAULT NOW(),
+    failure_message     text,
+    started_at          timestamp with time zone,
+    finished_at         timestamp with time zone,
+    process_after       timestamp with time zone,
+    num_resets          integer not null DEFAULT 0,
+    num_failures        integer not null DEFAULT 0,
+    last_heartbeat_at   timestamp with time zone,
+    execution_logs      json[],
+    worker_hostname     text not null DEFAULT '',
+
+    repo_id             integer not null,
+    source_hostname     text not null,
+    dest_hostname       text not null,
+    delete_source       boolean not null DEFAULT false
+);
+
+-- create the view
+CREATE OR REPLACE VIEW gitserver_replicator_jobs_with_repo_name AS
+  SELECT glj.*, r.name AS repo_name
+  FROM gitserver_replicator_jobs glj
+  JOIN repo r ON r.id = glj.repo_id;


### PR DESCRIPTION
This renames the `gitserver_localclone_jobs` table and `gitserver_localclone_jobs_with_repo_name` view to `gitserver_relocator_jobs` and `gitserver_relocator_jobs_with_repo_name`.

This is done after the [discussion](https://github.com/sourcegraph/sourcegraph/pull/33072#issuecomment-1082725270) about renaming the GitserverLocalClone worker to GitserverReplicator worker.

The table is not used yet so it's safe to just drop it instead of renaming it:
- so that we can fix the order of columns
- so we don't have to rename constraints too
- start fresh basically

## Test plan

sg migration up and undo


Related to #32827