### PR TITLE
Fix various things in sg install

### DIFF
--- a/dev/sg/install.sh
+++ b/dev/sg/install.sh
@@ -3,6 +3,28 @@
 set -euf -o pipefail
 pushd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null
 
+
+echo "╔═════════════════════════════════════════════════════════════════════════════╗"
+echo "║                                                                             ║"
+echo "║       ______ _________________ _____ _____   ___ _____ ___________ _        ║"
+echo "║       |  _  \  ___| ___ \ ___ \  ___/  __ \ / _ \_   _|  ___|  _  \ |       ║"
+echo "║       | | | | |__ | |_/ / |_/ / |__ | /  \// /_\ \| | | |__ | | | | |       ║"
+echo "║       | | | |  __||  __/|    /|  __|| |    |  _  || | |  __|| | | | |       ║"
+echo "║       | |/ /| |___| |   | |\ \| |___| \__/\| | | || | | |___| |/ /|_|       ║"
+echo "║       |___/ \____/\_|   \_| \_\____/ \____/\_| |_/\_/ \____/|___/ (_)       ║"
+echo "║                                                                             ║"
+echo "╚═════════════════════════════════════════════════════════════════════════════╝"
+echo " "
+echo "                  ./dev/sg/install.sh has been deprecated!"
+echo " "
+echo "             It will be removed soon. Use the following instead:"
+echo " "
+echo " Install sg:  curl --proto '=https' --tlsv1.2 -sSLf https://install.sg.dev | sh"
+echo " "
+echo " Update sg:  sg update"
+echo " "
+sleep 3
+
 # The BUILD_COMMIT is baked into the binary (see `go install` below) and
 # contains the latest commit in the `dev/sg` folder. If the directory is
 # "dirty", though, we mark the build as a dev build.

--- a/dev/sg/main.go
+++ b/dev/sg/main.go
@@ -135,23 +135,22 @@ func checkSgVersion(ctx context.Context) error {
 	}
 
 	if *skipAutoUpdatesFlag {
-		stdout.Out.WriteLine(output.Linef("", output.StyleSearchMatch, "------------------------------------------------------------------------------"))
-		stdout.Out.WriteLine(output.Linef("", output.StyleSearchMatch, "       HEY! New version of sg available. Run 'sg update' to install it.       "))
-		stdout.Out.WriteLine(output.Linef("", output.StyleSearchMatch, "             To see what's new, run 'sg version changelog -next'.             "))
-		stdout.Out.WriteLine(output.Linef("", output.StyleSearchMatch, "------------------------------------------------------------------------------"))
+		stdout.Out.WriteLine(output.Linef("", output.StyleSearchMatch, "╭──────────────────────────────────────────────────────────────────╮  "))
+		stdout.Out.WriteLine(output.Linef("", output.StyleSearchMatch, "│                                                                  │░░"))
+		stdout.Out.WriteLine(output.Linef("", output.StyleSearchMatch, "│ HEY! New version of sg available. Run 'sg update' to install it. │░░"))
+		stdout.Out.WriteLine(output.Linef("", output.StyleSearchMatch, "│       To see what's new, run 'sg version changelog -next'.       │░░"))
+		stdout.Out.WriteLine(output.Linef("", output.StyleSearchMatch, "│                                                                  │░░"))
+		stdout.Out.WriteLine(output.Linef("", output.StyleSearchMatch, "╰──────────────────────────────────────────────────────────────────╯░░"))
+		stdout.Out.WriteLine(output.Linef("", output.StyleSearchMatch, "  ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░"))
 		return nil
 	}
 
 	stdout.Out.WriteLine(output.Line(output.EmojiInfo, output.StyleSuggestion, "Auto updating sg ..."))
-	err = updateToPrebuiltSG(ctx)
+	newPath, err := updateToPrebuiltSG(ctx)
 	if err != nil {
 		return err
 	}
-	sgPath, err := os.Executable()
-	if err != nil {
-		return err
-	}
-	return syscall.Exec(sgPath, os.Args, os.Environ())
+	return syscall.Exec(newPath, os.Args, os.Environ())
 }
 
 func loadSecrets() error {

--- a/dev/sg/main.go
+++ b/dev/sg/main.go
@@ -106,6 +106,8 @@ func setMaxOpenFiles() error {
 	return nil
 }
 
+const sgOneLineCmd = `curl --proto '=https' --tlsv1.2 -sSLf https://install.sg.dev | sh`
+
 func checkSgVersion(ctx context.Context) error {
 	_, err := root.RepositoryRoot()
 	if err != nil {
@@ -124,7 +126,7 @@ func checkSgVersion(ctx context.Context) error {
 	out, err := run.GitCmd("rev-list", fmt.Sprintf("%s..origin/main", rev), "./dev/sg")
 	if err != nil {
 		fmt.Printf("error getting new commits since %s in ./dev/sg: %s\n", rev, err)
-		fmt.Println("try reinstalling sg with `./dev/sg/install.sh`.")
+		fmt.Printf("try reinstalling sg with `%s`.\n", sgOneLineCmd)
 		os.Exit(1)
 	}
 
@@ -178,8 +180,9 @@ func main() {
 		// If we're not running "sg update ...", we want to check the version first
 		err := checkSgVersion(ctx)
 		if err != nil {
-			fmt.Printf("checking sg version failed: %s\n", err)
-			os.Exit(1)
+			writeWarningLinef("Checking sg version and updating failed: %s\n", err)
+			// Do not exit here, so we don't break user flow when they want to
+			// run `sg` but updating fails
 		}
 	}
 

--- a/dev/sg/sg_install.go
+++ b/dev/sg/sg_install.go
@@ -28,6 +28,24 @@ var (
 	}
 )
 
+// Problems:
+//
+// 1. `./dev/sg/install.sh` installs `sg` into `$GOBIN`
+// 2. `bootstraph.sh && sg install` puts it into
+//   a) on macOS: `~/.sg/`
+//   b) on Linux: `~/.local/bin/sg`
+// 3. `sg update` (auto-triggered by `sg start`) puts it in `$GOBIN`
+// 4. `which sg` still points to old `sg`
+// 5. endless loop of auto-updates
+//
+//
+// Other problem:
+//
+// 1. ./dev/sg/install.sh` installs `sg` into `$GOBIN`
+// 2. It should instead just build `sg` and call `sg install`
+// BUT:
+// 3. `sg install` is not idempotent
+
 func installExec(ctx context.Context, args []string) error {
 	homeDir, err := os.UserHomeDir()
 	if err != nil {

--- a/dev/sg/sg_install.go
+++ b/dev/sg/sg_install.go
@@ -28,24 +28,6 @@ var (
 	}
 )
 
-// Problems:
-//
-// 1. `./dev/sg/install.sh` installs `sg` into `$GOBIN`
-// 2. `bootstraph.sh && sg install` puts it into
-//   a) on macOS: `~/.sg/`
-//   b) on Linux: `~/.local/bin/sg`
-// 3. `sg update` (auto-triggered by `sg start`) puts it in `$GOBIN`
-// 4. `which sg` still points to old `sg`
-// 5. endless loop of auto-updates
-//
-//
-// Other problem:
-//
-// 1. ./dev/sg/install.sh` installs `sg` into `$GOBIN`
-// 2. It should instead just build `sg` and call `sg install`
-// BUT:
-// 3. `sg install` is not idempotent
-
 func installExec(ctx context.Context, args []string) error {
 	homeDir, err := os.UserHomeDir()
 	if err != nil {

--- a/dev/sg/sg_logo.go
+++ b/dev/sg/sg_logo.go
@@ -21,7 +21,7 @@ var (
 		Name:       "logo",
 		ShortUsage: "sg logo [classic]",
 		ShortHelp:  "Print the sg logo",
-		LongHelp:   "Prints the sg logo in different colors. When the 'classic' argument is passed it prints the logo that's used in install.sh",
+		LongHelp:   "Prints the sg logo in different colors. When the 'classic' argument is passed it prints the classic logo.",
 		FlagSet:    funkyLogoFlagSet,
 		Exec:       logoExec,
 	}

--- a/dev/sg/sg_update.go
+++ b/dev/sg/sg_update.go
@@ -18,8 +18,8 @@ import (
 var (
 	updateFlags = flag.NewFlagSet("sg update", flag.ExitOnError)
 	// TODO: These are deprecated flags and can be removed May 1st 2022
-	updateToLocal  = updateFlags.Bool("local", false, "Update to local copy of 'dev/sg'")
-	updateDownload = updateFlags.Bool("download", true, "Download a prebuilt binary of 'sg' instead of compiling it locally")
+	_ = updateFlags.Bool("local", false, "Update to local copy of 'dev/sg'")
+	_ = updateFlags.Bool("download", true, "Download a prebuilt binary of 'sg' instead of compiling it locally")
 )
 
 var updateCommand = &ffcli.Command{

--- a/dev/sg/sg_update.go
+++ b/dev/sg/sg_update.go
@@ -22,7 +22,7 @@ import (
 var (
 	updateFlags    = flag.NewFlagSet("sg update", flag.ExitOnError)
 	updateToLocal  = updateFlags.Bool("local", false, "Update to local copy of 'dev/sg'")
-	updateDownload = updateFlags.Bool("download", false, "Download a prebuilt binary of 'sg' instead of compiling it locally")
+	updateDownload = updateFlags.Bool("download", true, "Download a prebuilt binary of 'sg' instead of compiling it locally")
 )
 
 var updateCommand = &ffcli.Command{
@@ -36,81 +36,15 @@ var updateCommand = &ffcli.Command{
 
 Requires a local copy of the 'sourcegraph/sourcegraph' codebase.`,
 	Exec: func(ctx context.Context, args []string) error {
-		if *updateDownload {
-			return updateToPrebuiltSG(ctx)
-		}
 		if *updateToLocal {
 			return updateToLocalSG(ctx)
 		}
-		return updateSG(ctx)
-	},
-}
-
-// updateSG fetches the latest sg changes on the main branch, build them and install the new sg version.
-func updateSG(ctx context.Context) error {
-	// Update from remote
-	if _, err := run.GitCmd("fetch", "origin", "main"); err != nil {
-		return err
-	}
-
-	// Make sure to switch back to previous working state
-	var restoreFuncs []func() error
-	defer func() {
-		stdout.Out.WriteLine(output.Line(output.EmojiHourglass, output.StyleSuggestion, "Restoring workspace..."))
-		var failed bool
-		for i := len(restoreFuncs) - 1; i >= 0; i-- {
-			if restoreErr := restoreFuncs[i](); restoreErr != nil {
-				failed = true
-				writeWarningLinef(restoreErr.Error())
-			}
-		}
-		if !failed {
-			stdout.Out.WriteLine(output.Line(output.EmojiInfo, output.StyleSuggestion, "Workspace restored!"))
-		} else {
-			writeFailureLinef("Failed to restore workspace")
-		}
-	}()
-
-	// Stash workspace if dirty
-	changes, err := run.TrimResult(run.GitCmd("status", "--porcelain"))
-	if err != nil {
-		return err
-	}
-	if len(changes) > 0 {
-		stdout.Out.WriteLine(output.Line(output.EmojiHourglass, output.StyleSuggestion, "Stashing workspace..."))
-		if _, err := run.GitCmd("stash", "--include-untracked"); err != nil {
+		if *updateDownload {
+			_, err := updateToPrebuiltSG(ctx)
 			return err
 		}
-		restoreFuncs = append(restoreFuncs, func() (restoreErr error) {
-			_, restoreErr = run.GitCmd("stash", "pop")
-			return
-		})
-	}
-
-	// Checkout main, which we will install from
-	stdout.Out.WriteLine(output.Line(output.EmojiHourglass, output.StyleSuggestion, "Setting workspace up for update..."))
-	if _, err := run.GitCmd("checkout", "origin/main"); err != nil {
-		return err
-	}
-	restoreFuncs = append(restoreFuncs, func() (restoreErr error) {
-		_, restoreErr = run.GitCmd("switch", "-")
-		return
-	})
-
-	// For info, show what sg revision we are upgrading to
-	commit, err := run.TrimResult(run.GitCmd("rev-parse", "HEAD"))
-	if err != nil {
-		return err
-	}
-	stdout.Out.WriteLine(output.Linef(output.EmojiHourglass, output.StylePending, "Updating to sg@%s...", commit))
-
-	// Run installation script
-	cmd := exec.CommandContext(ctx, "./dev/sg/install.sh")
-	if err := run.InteractiveInRoot(cmd); err != nil {
-		return err
-	}
-	writeSuccessLinef("Update succeeded!")
-	return nil
+		return nil
+	},
 }
 
 // updateToLocalSG builds the currently checkout sg code and install the resulting sg binary.
@@ -127,29 +61,29 @@ func updateToLocalSG(ctx context.Context) error {
 }
 
 // updateToPrebuiltSG downloads the latest release of sg prebuilt binaries and install it.
-func updateToPrebuiltSG(ctx context.Context) error {
+func updateToPrebuiltSG(ctx context.Context) (string, error) {
 	req, err := http.NewRequest("GET", "https://github.com/sourcegraph/sg/releases/latest", nil)
 	if err != nil {
-		return err
+		return "", err
 	}
 	// We use the RountTripper to make an HTTP request without having to deal
 	// with redirections.
 	resp, err := http.DefaultTransport.RoundTrip(req)
 	if err != nil {
-		return err
+		return "", err
 	}
 	defer resp.Body.Close()
 
 	location := resp.Header.Get("location")
 	if location == "" {
-		return errors.New("GitHub latest release: empty location")
+		return "", errors.New("GitHub latest release: empty location")
 	}
 	location = strings.ReplaceAll(location, "/tag/", "/download/")
 	downloadURL := fmt.Sprintf("%s/sg_%s_%s", location, runtime.GOOS, runtime.GOARCH)
 
 	tmpDir, err := os.MkdirTemp("", "sg")
 	if err != nil {
-		return err
+		return "", err
 	}
 	defer func() {
 		os.RemoveAll(tmpDir)
@@ -157,33 +91,29 @@ func updateToPrebuiltSG(ctx context.Context) error {
 
 	resp, err = http.Get(downloadURL)
 	if err != nil {
-		return err
+		return "", err
 	}
 	defer resp.Body.Close()
 
 	tmpSgPath := tmpDir + "/sg"
 	f, err := os.Create(tmpSgPath)
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	_, err = io.Copy(f, resp.Body)
 	if err != nil {
-		return err
+		return "", err
 	}
 	err = os.Chmod(tmpSgPath, 0755)
 	if err != nil {
-		return err
+		return "", err
 	}
 
-	// Reliable way to find where to put sg, even if the user is using
-	// asdf.
-	cmd := exec.CommandContext(ctx, "go", "list", "-f", "{{.Target}}")
-	out, err := cmd.CombinedOutput()
-	sgPath := strings.TrimSpace(string(out))
+	currentExecPath, err := os.Executable()
 	if err != nil {
-		return err
+		return "", err
 	}
 
-	return os.Rename(tmpSgPath, sgPath)
+	return currentExecPath, os.Rename(tmpSgPath, currentExecPath)
 }

--- a/doc/dev/background-information/sg/index.md
+++ b/doc/dev/background-information/sg/index.md
@@ -60,21 +60,19 @@ curl --proto '=https' --tlsv1.2 -sSLf https://install.sg.dev | sh
 
 That will download the latest release of `sg` from [here](https://github.com/sourcegraph/sg/releases), put it in a temporary location and run `sg install` to install it to a permanent location in your `$PATH`.
 
-### Using install script
+### Manually building the binary
 
 > NOTE: **This method requires that Go has already been installed according to the [development quickstart guide](../../setup/quickstart.md).**
 
-Run the following in the root of `sourcegraph/sourcegraph`:
+If you want full control over where the `sg` binary ends up, use this option.
+
+In the root of `sourcegraph/sourcegraph`, run:
 
 ```sh
-./dev/sg/install.sh
+go build -o ~/my/path/sg ./dev/sg
 ```
 
-That builds the `sg` binary and moves it to the standard installation location for Go binaries.
-
-If you don't have a `$GOPATH` set (or don't know what that is), that location is `$HOME/go/bin`. If you do use `$GOPATH` the location is `$GOPATH/bin`.
-
-Make sure that location is in your `$PATH`. (If you use `$GOPATH` then `$GOPATH/bin` needs to be in the `$PATH`)
+Then make sure that `~/my/path` is in your `$PATH`.
 
 > NOTE: **For Linux users:** A command called [sg](https://www.man7.org/linux/man-pages/man1/sg.1.html) is already available at `/usr/bin/sg`. To use the Sourcegraph `sg` CLI, you need to make sure that its location comes first in `PATH`. For example, by prepending `$GOPATH/bin`:
 >
@@ -87,18 +85,6 @@ Make sure that location is in your `$PATH`. (If you use `$GOPATH` then `$GOPATH/
 > Or you may add an alias to your `.bashrc`:
 >
 > `alias sg=$HOME/go/bin/sg`
-
-### Manually building the binary
-
-If you want full control over where the `sg` binary ends up, use this option.
-
-In the root of `sourcegraph/sourcegraph`, run:
-
-```sh
-go build -o ~/my/path/sg ./dev/sg
-```
-
-Then make sure that `~/my/path` is in your `$PATH`.
 
 ## Updates
 


### PR DESCRIPTION
This does a bunch of things.

### Fix sg updates getting confused by `sg` installed in multiple paths

This solves this problem:

1. `./dev/sg/install.sh` installs `sg` into `$GOBIN`
2. `bootstraph.sh && sg install` puts it into
  a) on macOS: `~/.sg/`
  b) on Linux: `~/.local/bin/sg`
3. `sg update` (auto-triggered by `sg start`) puts it in `$GOBIN`
4. `which sg` still points to old `sg`
5. endless loop of auto-updates

It fixes it by changing `sg update` to move the newly-downloaded `sg` to the path of the *currently executed* `sg`.

And we also updated the path used in `sg ...` auto-updating to use the path of the currently-executing `sg`.

### Do not fail if auto-update fails

Since we now rely on prebuilt binaries and downloading them from GitHub we don't want to fail `sg start` etc when GitHub is down. So we don't exit when checking version && auto-updating fails.

### Removes multiple install destination from `sg`

This deprecates `./dev/sg/install.sh` as a way to install `sg` and advertises for downloading the binary.

Why? Because `./dev/sg/install.sh` installs `sg` into `$GOBIN`, which is not the "canonical" install location used by `sg install`. We could've made `./dev/sg/install.sh` use `sg install` instead, but then we'd have to make `sg install` idempotent. Instead we decided to deprecate `install.sh` altogether so we only have 2 **official** ways to install/update `sg`:

1. `curl ... |sh` to install `sg`
2. `sg update` to update to latest prebuilt binary

If you're an `sg` developer, you can still use `go build` in `./dev/sg`.


### Bring the "new `sg` version available" banner into 2022

See diff. New banner is tasty.

## Follow-ups

- Detect new versions on GitHub, not locally
- Add something unique to `sg help` or `sg version` that tells us that this `sg` is Sourcegraph's `sg` and not the `sg` thing on Linux

## Test plan

- Tested this locally by running `sg install`, `sg update`, playing around with `$PATH` etc.


