### PR TITLE
search: Remove unindexed search limiting

### DIFF
--- a/internal/search/job/repo_pager_job.go
+++ b/internal/search/job/repo_pager_job.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	zoektstreamer "github.com/google/zoekt"
+
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/search/job/jobutil"
@@ -75,7 +76,6 @@ func (p *repoPagerJob) Run(ctx context.Context, db database.DB, stream streaming
 			search.TextRequest,
 			p.useIndex,
 			p.containsRefGlobs,
-			zoekt.MissingRepoRevStatus(stream),
 		)
 		if err != nil {
 			return err

--- a/internal/search/run/repo_has_file.go
+++ b/internal/search/run/repo_has_file.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"math"
 
+	"golang.org/x/sync/errgroup"
+
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
@@ -12,7 +14,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
 	zoektutil "github.com/sourcegraph/sourcegraph/internal/search/zoekt"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
-	"golang.org/x/sync/errgroup"
 )
 
 var MockReposContainingPath func() ([]*result.FileMatch, error)
@@ -56,7 +57,6 @@ func (s *RepoSearch) reposContainingPath(ctx context.Context, repos []*search.Re
 		search.TextRequest,
 		newArgs.PatternInfo.Index,
 		query.ContainsRefGlobs(newArgs.Query),
-		func([]*search.RepositoryRevisions) {},
 	)
 	if err != nil {
 		return nil, err

--- a/internal/search/structural/structural.go
+++ b/internal/search/structural/structural.go
@@ -175,7 +175,6 @@ func (s *StructuralSearch) Run(ctx context.Context, db database.DB, stream strea
 			search.TextRequest,
 			s.UseIndex,
 			s.ContainsRefGlobs,
-			zoektutil.MissingRepoRevStatus(stream),
 		)
 		if err != nil {
 			return err

--- a/internal/search/textsearch/textsearch_test.go
+++ b/internal/search/textsearch/textsearch_test.go
@@ -432,7 +432,6 @@ func RunRepoSubsetTextSearch(
 		search.TextRequest,
 		query.Yes,
 		query.ContainsRefGlobs(q),
-		zoektutil.MissingRepoRevStatus(agg),
 	)
 	if err != nil {
 		return nil, streaming.Stats{}, err

--- a/internal/search/zoekt/indexed_search_test.go
+++ b/internal/search/zoekt/indexed_search_test.go
@@ -289,7 +289,6 @@ func TestIndexedSearch(t *testing.T) {
 				search.TextRequest,
 				query.Yes,
 				query.ContainsRefGlobs(q),
-				MissingRepoRevStatus(agg),
 			)
 			if err != nil {
 				t.Fatal(err)


### PR DESCRIPTION
The existing unindexed search limiting to 200 repo revisions was introduced in #11546 before we had paginated repository resolution, which has a page size of 500 and naturally limits the number of concurrent unindexed searches happening per-request.

This is more than double of the previous limit, but nowhere close the originally reported problematic number of 20k.

Fixes #33214



## Test plan

Existing tests.


