### PR TITLE
gitserver: fix git prune command

### DIFF
--- a/cmd/gitserver/server/cleanup_test.go
+++ b/cmd/gitserver/server/cleanup_test.go
@@ -1104,3 +1104,17 @@ git commit-graph write --reachable --changed-paths
 		t.Fatal("this repo doesn't need maintenance")
 	}
 }
+
+func TestPruneIfNeeded(t *testing.T) {
+	gitDir := prepareEmptyGitRepo(t, t.TempDir())
+
+	// create sentinel object folder
+	if err := os.MkdirAll(gitDir.Path("objects", "17"), fs.ModePerm); err != nil {
+		t.Fatal(err)
+	}
+
+	limit := -1 // always run prune
+	if err := pruneIfNeeded(gitDir, limit); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
The prune command had an extra "-c" which caused it to fail. I added a
test that would have caught this.



## Test plan

Fixes a bug. Added a unit test that would have caught the bug.


<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


