### PR TITLE
New reference panel: sort search-based results by proximity

### DIFF
--- a/client/web/src/codeintel/sort.ts
+++ b/client/web/src/codeintel/sort.ts
@@ -1,0 +1,38 @@
+import { sortBy } from 'lodash'
+
+import { Location } from './location'
+
+/**
+ * Sort the locations by their url field's (which is a relative path, e.g.
+ * `/github.com/golang/go/-/blob/src/cmd/trace/trace.go`) similarity to the
+ * current text document URI path. This is done by applying a similarity
+ * coefficient to the segments of each file path. Paths with more segments in
+ * common will have a higher similarity coefficient.
+ *
+ * @param locations A list of locations to sort.
+ * @param currentPath The pathname of the current text document.
+ */
+export function sortByProximity(locations: Location[], currentPath: string): Location[] {
+    return sortBy(
+        locations,
+        ({ url }) => -jaccardIndex(new Set(url.slice(1).split('/')), new Set(currentPath.slice(1).split('/')))
+    )
+}
+
+/**
+ * Calculate the jaccard index, or the Intersection over Union of two sets.
+ *
+ * @param a The first set.
+ * @param b The second set.
+ */
+function jaccardIndex<T>(a: Set<T>, b: Set<T>): number {
+    const aArray = [...a]
+    const bArray = [...b]
+
+    return (
+        // Get the size of the intersection
+        new Set(aArray.filter(value => b.has(value))).size /
+        // Get the size of the union
+        new Set(aArray.concat(bArray)).size
+    )
+}

--- a/client/web/src/codeintel/useCodeIntel.ts
+++ b/client/web/src/codeintel/useCodeIntel.ts
@@ -32,6 +32,7 @@ import {
     USE_PRECISE_CODE_INTEL_FOR_POSITION_QUERY,
 } from './ReferencesPanelQueries'
 import { definitionQuery, referencesQuery } from './searchBased'
+import { sortByProximity } from './sort'
 
 interface CodeIntelData {
     references: {
@@ -111,6 +112,7 @@ export const useCodeIntel = ({
         fetchPolicy: 'no-cache',
         onCompleted: result => {
             const newReferences = searchResultsToLocations(result).map(buildSearchBasedLocation)
+            const sorted = sortByProximity(newReferences, location.pathname)
 
             const previousData = codeIntelData
             if (!previousData) {
@@ -119,7 +121,7 @@ export const useCodeIntel = ({
                     definitions: { endCursor: null, nodes: [] },
                     references: {
                         endCursor: null,
-                        nodes: newReferences,
+                        nodes: sorted,
                     },
                 })
             } else {
@@ -128,7 +130,7 @@ export const useCodeIntel = ({
                     definitions: previousData.definitions,
                     references: {
                         endCursor: null,
-                        nodes: newReferences,
+                        nodes: sorted,
                     },
                 })
             }
@@ -142,8 +144,9 @@ export const useCodeIntel = ({
         fetchPolicy: 'no-cache',
         onCompleted: result => {
             const newDefinitions = searchResultsToLocations(result).map(buildSearchBasedLocation)
+            const sorted = sortByProximity(newDefinitions, location.pathname)
             // Definitions are filtered based on the LanguageSpec
-            const filteredDefinitions = filterDefinitions(newDefinitions)
+            const filteredDefinitions = filterDefinitions(sorted)
 
             const previousData = codeIntelData
             if (!previousData) {


### PR DESCRIPTION
This ports the jaccard-index-based sorting from code-intel-extensions to the new reference panel and adjusts the types for it to work properly.

I also need to double-check whether the old code isn't broken in code-intel-extensions, because it uses the `url.hash` to get to the "file path" and our current URL schema doesn't have that in the hash. But maybe the extension-api uses different schemes. Will check.

## Test plan

- Tested manually _a lot_, with lots of debug printing and manual checking of results before/after sort.


## App preview:
- [Link](https://sg-web-mrn-sort-prox.onrender.com)

