### PR TITLE
Revert "Revert "dev/ci: switch 100% to stateless agents" (#33222)"

### DIFF
--- a/dev/ci/asdf-install.sh
+++ b/dev/ci/asdf-install.sh
@@ -3,10 +3,8 @@
 # ASDF setup that either does a simple install, or pulls it from cache, geared towards
 # usage in CI.
 # In most cases you should not need to call this script directly.
-
-# TODO remove this when making job the default queue
-# Skip on normal queues because standard agents do not have fresh asdf installs
-if [[ ! "$CI_FEATURE_FLAG_STATELESS_BUILD" == "true" ]]; then
+if [[ ! "$BUILDKITE" == "true" ]]; then
+  # Not-in-buildkite simple install.
   echo "~~~ asdf install"
   asdf install
   echo "done installing"

--- a/doc/dev/background-information/ci/index.md
+++ b/doc/dev/background-information/ci/index.md
@@ -298,12 +298,6 @@ The term _secret_ refers to authentication credentials like passwords, API keys,
 - use an environment variable name with one of the following suffixes to ensure it gets redacted in the logs: `*_PASSWORD, *_SECRET, *_TOKEN, *_ACCESS_KEY, *_SECRET_KEY, *_CREDENTIALS`
 - while environment variables can be assigned when declaring steps, they should never be used for secrets, because they won't get redacted, even if they match one of the above patterns.
 
-#### Feature flags
-
-Enabling a feature flag on the CI pipeline is achieved by setting environment variables `CI_FEATURE_FLAGS_*` to `true`.
-
-- `CI_FEATURE_FLAG_STATELESS`: schedule the build on stateless agents instead of normal agents (this forces a `main-dry-run` run type).
-
 ## GitHub Actions
 
 ### `buildchecker`

--- a/enterprise/dev/ci/internal/buildkite/agents.go
+++ b/enterprise/dev/ci/internal/buildkite/agents.go
@@ -3,6 +3,6 @@ package buildkite
 const (
 	AgentQueueStandard  = "standard"
 	AgentQueueBaremetal = "baremetal"
-	AgentQueueStateless = "stateless2"
-	AgentQueueStateful  = "stateful"
+	// TODO eventually replace with 'standard'
+	AgentQueueStateless = "stateless"
 )

--- a/enterprise/dev/ci/internal/buildkite/feature_flags.go
+++ b/enterprise/dev/ci/internal/buildkite/feature_flags.go
@@ -1,26 +1,10 @@
 package buildkite
 
-import (
-	"fmt"
-	"os"
-)
-
 type featureFlags struct {
-	// StatelessBuild triggers a stateless build by overriding the default queue to send the build on the stateless
-	// agents and forces a MainDryRun type build to avoid impacting normal builds.
-	//
-	// It is meant to test the stateless builds without any side effects.
-	StatelessBuild bool
 }
 
 // FeatureFlags are for experimenting with CI pipeline features. Use sparingly!
-var FeatureFlags = featureFlags{
-	StatelessBuild: os.Getenv("CI_FEATURE_FLAG_STATELESS") == "true" ||
-		// Always process retries on stateless agents.
-		// TODO: remove when we switch over entirely to stateless agents
-		os.Getenv("BUILDKITE_REBUILT_FROM_BUILD_NUMBER") != "",
-}
+var FeatureFlags = featureFlags{}
 
 func (f *featureFlags) ApplyEnv(env map[string]string) {
-	env["CI_FEATURE_FLAG_STATELESS_BUILD"] = fmt.Sprintf("%v", f.StatelessBuild)
 }

--- a/enterprise/dev/ci/internal/ci/cache_helpers.go
+++ b/enterprise/dev/ci/internal/ci/cache_helpers.go
@@ -3,10 +3,6 @@ package ci
 import "github.com/sourcegraph/sourcegraph/enterprise/dev/ci/internal/buildkite"
 
 func withYarnCache() buildkite.StepOpt {
-	if !buildkite.FeatureFlags.StatelessBuild {
-		return buildkite.RawCmd(`echo "skipping yarn cache, not a stateless agent"`)
-	}
-
 	return buildkite.Cache(&buildkite.CacheOptions{
 		ID:          "node_modules",
 		Key:         "cache-node_modules-{{ checksum 'yarn.lock' }}",

--- a/enterprise/dev/ci/internal/ci/pipeline.go
+++ b/enterprise/dev/ci/internal/ci/pipeline.go
@@ -317,11 +317,7 @@ func withDefaultTimeout(s *bk.Step) {
 // steps are configured appropriately to run on the queue
 func withAgentQueueDefaults(s *bk.Step) {
 	if len(s.Agents) == 0 || s.Agents["queue"] == "" {
-		if bk.FeatureFlags.StatelessBuild {
-			s.Agents["queue"] = bk.AgentQueueStateless
-		} else {
-			s.Agents["queue"] = bk.AgentQueueStateful
-		}
+		s.Agents["queue"] = bk.AgentQueueStateless
 	}
 
 	if s.Agents["queue"] != bk.AgentQueueBaremetal {


### PR DESCRIPTION
Reverts sourcegraph/sourcegraph#33222

Test plan: back again to a known state. builds are working, caching is a big borked