### PR TITLE
dev/ci: always generate pipeline on standard agents

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -11,6 +11,7 @@ steps:
   - group: "Pipeline setup"
     steps:
       - label: ':hammer_and_wrench: :pipeline: Generate pipeline'
+        agents: { queue: standard }
         # Prioritize generating pipelines so that jobs can get generated and queued up as soon
         # as possible, so as to better assess pipeline load e.g. to scale the Buildkite fleet.
         priority: 10


### PR DESCRIPTION
We don't specify an agent type on pipeline generate, causing jobs to go to places we don't want

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

n/a
