### PR TITLE
search-blitz: add incremental queries to monitor impact of delta indexing strategy on search times

### DIFF
--- a/internal/cmd/search-blitz/queries.txt
+++ b/internal/cmd/search-blitz/queries.txt
@@ -95,3 +95,60 @@ patterntype:regexp \bdeadbeeeeef\b or \bdeadbeeeeeef\b or \bdeadBEEEEEF\b or \bd
 
 # or_literal_simple
 patterntype:literal readUInt16LE or readUInt8
+
+## incremental_ queries consist of standard queries that run against two versions of
+## sourcegraph/sourcegraph that use different indexing strategies:
+##
+## - incremental_delta_  queries run against a fork of sourcegraph/sourcegraph that uses the experimental delta
+##                       indexing strategy: https://github.com/sourcegraph/sourcegraph-incremental-indexing-fork
+##
+## - incremental_normal_ queries run against the main sourcegraph/sourcegraph repository that uses the "normal"
+##                       (non-delta) indexing strategy: https://github.com/sourcegraph/sourcegraph
+
+# incremental_delta_literal_small
+repo:^github\.com/sourcegraph/sourcegraph-incremental-indexing-fork$ patterntype:literal bitbucketserver.Activity
+
+# incremental_normal_literal_small
+repo:^github\.com/sourcegraph/sourcegraph$ patterntype:literal bitbucketserver.Activity
+
+# incremental_delta_literal_large
+repo:^github\.com/sourcegraph/sourcegraph-incremental-indexing-fork$ patterntype:literal time.Duration count:1000
+
+# incremental_normal_literal_large
+repo:^github\.com/sourcegraph/sourcegraph$ patterntype:literal time.Duration count:1000
+
+# incremental_delta_regex_small
+repo:^github\.com/sourcegraph/sourcegraph-incremental-indexing-fork$ patterntype:regexp se[arc]{3}hZoekt
+
+# incremental_normal_regex_small
+repo:^github\.com/sourcegraph/sourcegraph$ patterntype:regexp se[arc]{3}hZoekt
+
+# incremental_delta_rev_regex_small
+repo:^github\.com/sourcegraph/sourcegraph-incremental-indexing-fork$ patterntype:regexp se[arc]{3}hZoekt rev:main
+
+# incremental_normal_rev_regex_small
+repo:^github\.com/sourcegraph/sourcegraph$ patterntype:regexp se[arc]{3}hZoekt rev:main
+
+# incremental_delta_symbol_small
+repo:^github\.com/sourcegraph/sourcegraph-incremental-indexing-fork$ type:symbol redispool
+
+# incremental_normal_symbol_small
+repo:^github\.com/sourcegraph/sourcegraph$ type:symbol redispool
+
+# incremental_delta_rev_symbol_small
+repo:^github\.com/sourcegraph/sourcegraph-incremental-indexing-fork$ type:symbol redispool rev:main
+
+# incremental_normal_rev_symbol_small
+repo:^github\.com/sourcegraph/sourcegraph$ type:symbol redispool rev:main
+
+# incremental_delta_diff_small
+repo:^github\.com/sourcegraph/sourcegraph-incremental-indexing-fork$ type:diff author:camden before:"february 1 2021"
+
+# incremental_normal_diff_small
+repo:^github\.com/sourcegraph/sourcegraph$ type:diff author:camden before:"february 1 2021"
+
+# incremental_delta_commit_small
+repo:^github\.com/sourcegraph/sourcegraph-incremental-indexing-fork$ type:commit author:camden before:"february 1 2021"
+
+# incremental_normal_commit_small
+repo:^github\.com/sourcegraph/sourcegraph$ type:commit author:camden before:"february 1 2021"


### PR DESCRIPTION
This PR adds queries to search blitz to monitor the impact of our new experimental incremental indexing strategy on search times. 

See https://github.com/sourcegraph/sourcegraph/issues/29731 for more context on incremental indexing. 

## Test plan

This change doesn't require testing since it only affects search-blitz - an external monitoring tool.



