### PR TITLE
Add helm subchart documentation

### DIFF
--- a/doc/admin/install/kubernetes/helm.md
+++ b/doc/admin/install/kubernetes/helm.md
@@ -516,7 +516,7 @@ You can learn more about how to integrate Kustomize with Helm from our [example]
 
 ### Helm subcharts
 
-[Helm subcharts](https://helm.sh/docs/chart_template_guide/subcharts_and_globals/) can be used for permanent customizations to the official Sourcegraph helm chart. This is useful for changes such as using a custom database configuration file or adding a new resource unique to your deployment. These are long-lived customizations that shouldn't be contributed back to the Sourcegraph helm chart.
+[Helm subcharts](https://helm.sh/docs/chart_template_guide/subcharts_and_globals/) can be used for permanent customizations to the official Sourcegraph helm chart. This is useful for changes such as adding a new resource unique to your deployment (PodSecurityPolicy, NetworkPolicy, additional services, etc.). These are long-lived customizations that shouldn't be contributed back to the Sourcegraph helm chart.
 
 With a subchart, you create your own helm chart and specify the Sourcegraph chart as a dependency. Any resources you place in the templates folder of your chart will be deployed, as well as the Sourcegraph resources, allowing you to extend the Sourcegraph chart without maintaining a fork.
 

--- a/doc/admin/install/kubernetes/helm.md
+++ b/doc/admin/install/kubernetes/helm.md
@@ -8,7 +8,7 @@
 ## Quickstart
 
 To use the Helm chart, add the Sourcegraph helm repository:
- 
+
 ```sh
 helm repo add sourcegraph https://sourcegraph.github.io/deploy-sourcegraph-helm/
 ```
@@ -19,7 +19,7 @@ Install the Sourcegraph chart using default values:
 helm install --version 0.7.0 sourcegraph sourcegraph/sourcegraph
 ```
 
-## Configuration 
+## Configuration
 
 The Sourcegraph chart is highly customizable to support a wide range of environments. Please review the default values from [values.yaml](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/charts/sourcegraph/values.yaml) and all [supported options](https://github.com/sourcegraph/deploy-sourcegraph-helm/tree/main/charts/sourcegraph#configuration-options). Customizations can be applied using an override file. Using an override file allows customizations to persist through upgrades without needing to manage merge conflicts.
 
@@ -107,7 +107,7 @@ codeIntelDB:
 
 To use external Redis instances, first review our [general recommendations](https://docs.sourcegraph.com/admin/external_services/redis).
 
-<!-- 
+<!--
   If we copy the entire README.md over here the page will be too clutterd.
   When the docsite V2 is ready, this should potentially have its own page
 -->
@@ -447,7 +447,7 @@ kubectl describe ingress sourcegraph-frontend
 
 You should create a DNS record for the `sourcegraph.company.com` domain that resolves to the Ingress public address.
 
-It is recommended to enable TLS and configure certificate properly on your Ingress. You may utilize managed certificate solution provided by Cloud providers. 
+It is recommended to enable TLS and configure certificate properly on your Ingress. You may utilize managed certificate solution provided by Cloud providers.
 
 Alternatively, you may consider configuring [cert-manager with Let's Encrypt](https://cert-manager.io/docs/configuration/acme/) in your cluster and add the following override to Ingress.
 
@@ -506,7 +506,7 @@ frontend:
 
 ### Integrate Kustomize with Helm chart
 
-The Helm chart is new and still under active development, and we may not cover all of your use cases. 
+The Helm chart is new and still under active development, and we may not cover all of your use cases.
 
 Please contact [support@sourcegraph.com](mailto:support@sourcegraph.com) or your Customer Engineer directly to discuss your specific need.
 

--- a/doc/admin/install/kubernetes/helm.md
+++ b/doc/admin/install/kubernetes/helm.md
@@ -514,9 +514,15 @@ For advanced users who are looking for a temporary workaround, we __recommend__ 
 
 You can learn more about how to integrate Kustomize with Helm from our [example](https://github.com/sourcegraph/deploy-sourcegraph-helm/tree/main/charts/sourcegraph/examples/kustomize-chart).
 
-### Sub-chart
+### Helm subcharts
 
-__TODO__
+[Helm subcharts](https://helm.sh/docs/chart_template_guide/subcharts_and_globals/) can be used for permanent customizations to the official Sourcegraph helm chart. This is useful for changes such as using a custom database configuration file or adding a new resource unique to your deployment. These are long-lived customizations that shouldn't be contributed back to the Sourcegraph helm chart.
+
+With a subchart, you create your own helm chart and specify the Sourcegraph chart as a dependency. Any resources you place in the templates folder of your chart will be deployed, as well as the Sourcegraph resources, allowing you to extend the Sourcegraph chart without maintaining a fork.
+
+An example of a subchart is shown in the [examples/subchart](https://github.com/sourcegraph/deploy-sourcegraph-helm/tree/main/charts/sourcegraph/examples) folder.
+
+More details on how to create and configure a subchart can be found in the [helm documentation](https://helm.sh/docs/chart_template_guide/subcharts_and_globals).
 
 ## Upgrading Sourcegraph
 


### PR DESCRIPTION
Adds documentation around using a subchart. It's somewhat light on implementation details since that seems to fall under "how to use helm" - thoughts on whether that's ok?

I'll have a separate PR in the helm repo to rename the current `examples/custom-resources` folder to `examples/subchart`.

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->
Review docs

