### PR TITLE
search: structural search doesn't depend on global Zoekt eval

### DIFF
--- a/internal/search/job/job.go
+++ b/internal/search/job/job.go
@@ -208,10 +208,8 @@ func ToSearchJob(jargs *Args, q query.Q, db database.DB) (Job, error) {
 			}
 
 			addJob(true, &structural.StructuralSearch{
-				ZoektArgs:    zoektArgs,
-				SearcherArgs: searcherArgs,
-
-				NotSearcherOnly:  !onlyRunSearcher,
+				ZoektArgs:        zoektArgs,
+				SearcherArgs:     searcherArgs,
 				UseIndex:         b.Index(),
 				ContainsRefGlobs: query.ContainsRefGlobs(q),
 				RepoOpts:         repoOptions,

--- a/internal/search/structural/structural.go
+++ b/internal/search/structural/structural.go
@@ -152,10 +152,8 @@ func runStructuralSearch(ctx context.Context, args *search.SearcherParameters, r
 }
 
 type StructuralSearch struct {
-	ZoektArgs    *search.ZoektParameters
-	SearcherArgs *search.SearcherParameters
-
-	NotSearcherOnly  bool
+	ZoektArgs        *search.ZoektParameters
+	SearcherArgs     *search.SearcherParameters
 	UseIndex         query.YesNoOnly
 	ContainsRefGlobs bool
 
@@ -181,10 +179,8 @@ func (s *StructuralSearch) Run(ctx context.Context, db database.DB, stream strea
 		}
 
 		repoSet := []repoData{UnindexedList(unindexed)}
-		if s.NotSearcherOnly {
-			if indexed != nil {
-				repoSet = append(repoSet, IndexedMap(indexed.RepoRevs))
-			}
+		if indexed != nil {
+			repoSet = append(repoSet, IndexedMap(indexed.RepoRevs))
 		}
 		return runStructuralSearch(ctx, s.SearcherArgs, repoSet, stream)
 	})


### PR DESCRIPTION
Context: I'm trying to simplify yucky stuff around search job creation. This is setup for a more involved simplification.

This PR: Before separating "search over indexed repositories" for different text search vs structural search, we controlled whether that path would be executed for global searches. Back then, structural search always executed along the "search over indexed repositories" path, so over the course of mechanical factoring, it kept this decision to "search over indexed repositories only when we didn't run global mode". It is, and should be, agnostic to whether global mode runs or not, because it calls Zoekt from searcher with a resolved set of repos. We can and should optimize the global case for it, but historically it never was, and it shouldn't depend on this value now either way. 

## Test plan
Semantics-preserving.
