### PR TITLE
search-blitz: change docker build script to force linux/amd64

### DIFF
--- a/internal/cmd/search-blitz/scripts/build.sh
+++ b/internal/cmd/search-blitz/scripts/build.sh
@@ -5,6 +5,7 @@ pushd "$(dirname "${BASH_SOURCE[0]}")/../../../.." >/dev/null
 
 docker build \
   -f ./internal/cmd/search-blitz/Dockerfile \
+  --platform linux/amd64 \
   --build-arg COMMIT_SHA="$(git rev-parse HEAD)" \
   -t "us.gcr.io/sourcegraph-dev/search-blitz:$1" \
   .


### PR DESCRIPTION
Without this flag, it'll default to whatever you're local architecture is (which can cause havoc elsewhere). 

## Test Plan 

I ran this change locally. 