### PR TITLE
search: simplify conditional logic for running Zoekt search over repo…

### DIFF
--- a/internal/search/job/job.go
+++ b/internal/search/job/job.go
@@ -78,7 +78,7 @@ func ToSearchJob(jargs *Args, q query.Q, db database.DB) (Job, error) {
 		zoekt:          jargs.Zoekt,
 	}
 
-	repoUniverseSearch, skipRepoSubsetSearch, onlyRunSearcher := jobMode(b, resultTypes, jargs.SearchInputs.PatternType, jargs.SearchInputs.OnSourcegraphDotCom)
+	repoUniverseSearch, skipRepoSubsetSearch, runZoektOverRepos := jobMode(b, resultTypes, jargs.SearchInputs.PatternType, jargs.SearchInputs.OnSourcegraphDotCom)
 
 	var requiredJobs, optionalJobs []Job
 	addJob := func(required bool, job Job) {
@@ -116,7 +116,7 @@ func ToSearchJob(jargs *Args, q query.Q, db database.DB) (Job, error) {
 
 		if resultTypes.Has(result.TypeFile|result.TypePath) && !skipRepoSubsetSearch {
 			var textSearchJobs []Job
-			if !onlyRunSearcher {
+			if runZoektOverRepos {
 				job, err := builder.newZoektSearch(search.TextRequest)
 				if err != nil {
 					return nil, err
@@ -143,7 +143,7 @@ func ToSearchJob(jargs *Args, q query.Q, db database.DB) (Job, error) {
 		if resultTypes.Has(result.TypeSymbol) && b.PatternString() != "" && !skipRepoSubsetSearch {
 			var symbolSearchJobs []Job
 
-			if !onlyRunSearcher {
+			if runZoektOverRepos {
 				job, err := builder.newZoektSearch(search.SymbolRequest)
 				if err != nil {
 					return nil, err
@@ -479,7 +479,7 @@ func (b *jobBuilder) newZoektSearch(typ search.IndexedRequestType) (Job, error) 
 	return nil, errors.Errorf("attempt to create unrecognized zoekt search with value %v", typ)
 }
 
-func jobMode(b query.Basic, resultTypes result.Types, st query.SearchType, onSourcegraphDotCom bool) (repoUniverseSearch, skipRepoSubsetSearch, onlyRunSearcher bool) {
+func jobMode(b query.Basic, resultTypes result.Types, st query.SearchType, onSourcegraphDotCom bool) (repoUniverseSearch, skipRepoSubsetSearch, runZoektOverRepos bool) {
 	isGlobalSearch := func() bool {
 		if st == query.SearchTypeStructural {
 			return false
@@ -520,13 +520,20 @@ func jobMode(b query.Basic, resultTypes result.Types, st query.SearchType, onSou
 	// is always 0, meaning that we should not create jobs to run
 	// unindexed searcher.
 	skipRepoSubsetSearch = isEmpty || (repoUniverseSearch && onSourcegraphDotCom)
-	// onlyRunSearcher is a value that controls whether to run unindexed
-	// search if a query triggers repoUniverseSearch. We want to run
-	// searcher on unindexed repos when we run a repoUniverseSearch, but
-	// only on instances where we are NOT on sourcegraph.com.
-	onlyRunSearcher = repoUniverseSearch && !onSourcegraphDotCom
 
-	return repoUniverseSearch, skipRepoSubsetSearch, onlyRunSearcher
+	// runZoektOverRepos controls whether we run Zoekt over a set of
+	// resolved repositories. Because Zoekt can run natively run over all
+	// repositories (AKA global search), we can sometimes skip searching
+	// over resolved repos.
+	//
+	// The decision to run over a set of repos is as follows:
+	// (1) When we don't run global search, run Zoekt over repositories (we have to, otherwise
+	// we'd be skipping indexed search entirely).
+	// (2) If on Sourcegraph.com, resolve repos unconditionally (we run both global search
+	// and search over resolved repos, and return results from either job).
+	runZoektOverRepos = !repoUniverseSearch || onSourcegraphDotCom
+
+	return repoUniverseSearch, skipRepoSubsetSearch, runZoektOverRepos
 }
 
 func toFeatures(flags featureflag.FlagSet) search.Features {


### PR DESCRIPTION
Stacked on https://github.com/sourcegraph/sourcegraph/pull/33243.

This corrects the misnomered `onlyRunSearcher` variable that we use to decide which jobs to create. I negate it and propagate it. I need this change to fix the `jobMode` stuff in general.

## Test plan
Semantics-preserving.

