### PR TITLE
gitserver: remove stale commit-graph.lock

### DIFF
--- a/cmd/gitserver/server/cleanup.go
+++ b/cmd/gitserver/server/cleanup.go
@@ -232,23 +232,21 @@ func (s *Server) cleanupRepos() {
 		return true, nil
 	}
 
-	removeStaleLocks := func(dir GitDir) (done bool, err error) {
-		gitDir := string(dir)
-
+	removeStaleLocks := func(gitDir GitDir) (done bool, err error) {
 		// if removing a lock fails, we still want to try the other locks.
 		var multi error
 
 		// config.lock should be held for a very short amount of time.
-		if err := removeFileOlderThan(filepath.Join(gitDir, "config.lock"), time.Minute); err != nil {
+		if err := removeFileOlderThan(gitDir.Path("config.lock"), time.Minute); err != nil {
 			multi = errors.Append(multi, err)
 		}
 		// packed-refs can be held for quite a while, so we are conservative
 		// with the age.
-		if err := removeFileOlderThan(filepath.Join(gitDir, "packed-refs.lock"), time.Hour); err != nil {
+		if err := removeFileOlderThan(gitDir.Path("packed-refs.lock"), time.Hour); err != nil {
 			multi = errors.Append(multi, err)
 		}
 		// we use the same conservative age for locks inside of refs
-		if err := bestEffortWalk(filepath.Join(gitDir, "refs"), func(path string, fi fs.FileInfo) error {
+		if err := bestEffortWalk(gitDir.Path("refs"), func(path string, fi fs.FileInfo) error {
 			if fi.IsDir() {
 				return nil
 			}
@@ -259,6 +257,14 @@ func (s *Server) cleanupRepos() {
 
 			return removeFileOlderThan(path, time.Hour)
 		}); err != nil {
+			multi = errors.Append(multi, err)
+		}
+		// We have seen that, occasionally, commit-graph.locks prevent a git repack from
+		// succeeding. Benchmarks on our dogfood cluster have shown that a commit-graph
+		// call for a 5GB bare repository takes less than 1 min. The lock is only held
+		// during a short period during this time. A 1-hour grace period is very
+		// conservative.
+		if err := removeFileOlderThan(gitDir.Path("objects", "info", "commit-graph.lock"), time.Hour); err != nil {
 			multi = errors.Append(multi, err)
 		}
 

--- a/cmd/gitserver/server/cleanup_test.go
+++ b/cmd/gitserver/server/cleanup_test.go
@@ -356,6 +356,12 @@ func TestCleanupOldLocks(t *testing.T) {
 		"github.com/foo/freshpacked/.git/HEAD",
 		"github.com/foo/freshpacked/.git/packed-refs.lock",
 
+		"github.com/foo/freshcommitgraphlock/.git/HEAD",
+		"github.com/foo/freshcommitgraphlock/.git/objects/info/commit-graph.lock",
+
+		"github.com/foo/stalecommitgraphlock/.git/HEAD",
+		"github.com/foo/stalecommitgraphlock/.git/objects/info/commit-graph.lock",
+
 		"github.com/foo/staleconfiglock/.git/HEAD",
 		"github.com/foo/staleconfiglock/.git/config.lock",
 
@@ -378,6 +384,7 @@ func TestCleanupOldLocks(t *testing.T) {
 	chtime("github.com/foo/staleconfiglock/.git/config.lock", time.Hour)
 	chtime("github.com/foo/stalepacked/.git/packed-refs.lock", 2*time.Hour)
 	chtime("github.com/foo/refslock/.git/refs/heads/stale.lock", 2*time.Hour)
+	chtime("github.com/foo/stalecommitgraphlock/.git/objects/info/commit-graph.lock", 2*time.Hour)
 
 	s := &Server{ReposDir: root}
 	s.Handler() // Handler as a side-effect sets up Server
@@ -396,6 +403,14 @@ func TestCleanupOldLocks(t *testing.T) {
 		"github.com/foo/freshpacked/.git/HEAD",
 		"github.com/foo/freshpacked/.git/packed-refs.lock",
 		"github.com/foo/freshpacked/.git/info/attributes",
+
+		"github.com/foo/freshcommitgraphlock/.git/HEAD",
+		"github.com/foo/freshcommitgraphlock/.git/objects/info/commit-graph.lock",
+		"github.com/foo/freshcommitgraphlock/.git/info/attributes",
+
+		"github.com/foo/stalecommitgraphlock/.git/HEAD",
+		"github.com/foo/stalecommitgraphlock/.git/info/attributes",
+		"github.com/foo/stalecommitgraphlock/.git/objects/info",
 
 		"github.com/foo/staleconfiglock/.git/HEAD",
 		"github.com/foo/staleconfiglock/.git/info/attributes",


### PR DESCRIPTION
We have seen that, occasionally, commit-graph.locks prevent a git repack
from succeeding. Benchmarks on our dogfood cluster have shown that a
commit-graph call for a 5GB bare repository takes less than 1 min. The
lock is only held during a short period during this time. A 1-hour grace
period is very conservative.

## Test Plan:

(1)
I ran "git commit-graph write" for the megarepo on the dogfood cluster to
get a sense of a meaningful graceperiod.

(2)
I ran a local instance of Sourcegraph and manually created a commit-graph.lock file.

```
cd .sourcegraph/repos/github.com/sourcegraph/sourcegraph/.git/objects/info
touch commit-graph.lock
```

I monitored the cleanup cycles and confirmed that the lock file stays in place.

I updated the lock file's timestamp.
```
touch -t <1 hour prior> commit-graph.lock
```

The lock file was removed.

(3)
added a unit test

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


