### PR TITLE
gitserver: update janitor so it sets repo sizes

### DIFF
--- a/cmd/gitserver/server/cleanup.go
+++ b/cmd/gitserver/server/cleanup.go
@@ -15,6 +15,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -99,6 +100,9 @@ var (
 
 const reposStatsName = "repos-stats.json"
 
+// Used for setRepoSizes function to run only during the first run of janitor
+var setRepoSizesOnce sync.Once
+
 // cleanupRepos walks the repos directory and performs maintenance tasks:
 //
 // 1. Compute the amount of space used by the repo
@@ -111,6 +115,7 @@ const reposStatsName = "repos-stats.json"
 // 8. Remove repos based on disk pressure.
 // 9. Perform sg-maintenance
 // 10. Git prune
+// 11. Only during first run: Set sizes of repos which don't have it in a database.
 func (s *Server) cleanupRepos() {
 	janitorRunning.Set(1)
 	defer janitorRunning.Set(0)
@@ -122,8 +127,11 @@ func (s *Server) cleanupRepos() {
 		UpdatedAt: time.Now(),
 	}
 
+	repoToSize := make(map[api.RepoName]int64)
 	computeStats := func(dir GitDir) (done bool, err error) {
-		stats.GitDirBytes += dirSize(dir.Path("."))
+		size := dirSize(dir.Path("."))
+		stats.GitDirBytes += size
+		repoToSize[s.name(dir)] = size
 		return false, nil
 	}
 
@@ -364,6 +372,15 @@ func (s *Server) cleanupRepos() {
 		log15.Error("cleanup: failed to write periodic stats", "error", err)
 	}
 
+	// Repo sizes are set only once during the first janitor run.
+	// There is no need for a second run because all repo sizes will be set until this moment
+	setRepoSizesOnce.Do(func() {
+		err = s.setRepoSizes(context.Background(), repoToSize)
+		if err != nil {
+			log15.Error("cleanup: setting repo sizes", "error", err)
+		}
+	})
+
 	if s.DiskSizer == nil {
 		s.DiskSizer = &StatDiskSizer{}
 	}
@@ -374,6 +391,37 @@ func (s *Server) cleanupRepos() {
 	if err := s.freeUpSpace(b); err != nil {
 		log15.Error("cleanup: error freeing up space", "error", err)
 	}
+}
+
+// setRepoSizes uses calculated sizes of repos to update database entries of repos with repo_size_bytes = NULL
+func (s *Server) setRepoSizes(ctx context.Context, repoToSize map[api.RepoName]int64) error {
+	db := s.DB
+	gitserverRepos := db.GitserverRepos()
+	// getting all the repos without size
+	reposWithoutSize, err := gitserverRepos.ListReposWithoutSize(ctx)
+	if err != nil {
+		return err
+	}
+	if len(reposWithoutSize) == 0 {
+		log15.Info("cleanup: all repos have their sizes")
+		return nil
+	}
+
+	// preparing a mapping of repoID to its size which should be inserted
+	reposToUpdate := make(map[api.RepoID]int64)
+	for repoName, repoID := range reposWithoutSize {
+		if size, exists := repoToSize[repoName]; exists {
+			reposToUpdate[repoID] = size
+		}
+	}
+
+	// updating repos
+	err = gitserverRepos.UpdateRepoSizes(ctx, s.Hostname, reposToUpdate)
+	if err != nil {
+		return err
+	}
+	log15.Info(fmt.Sprintf("cleanup: %v repos had their sizes updated", len(reposToUpdate)))
+	return nil
 }
 
 // DiskSizer gets information about disk size and free space.

--- a/cmd/gitserver/server/cleanup_test.go
+++ b/cmd/gitserver/server/cleanup_test.go
@@ -61,7 +61,28 @@ func TestCleanup_computeStats(t *testing.T) {
 	// the correct file in the correct place.
 	s := &Server{ReposDir: root}
 	s.Handler() // Handler as a side-effect sets up Server
+	db := dbtest.NewDB(t)
+	s.DB = database.NewDB(db)
+
+	if _, err := db.Exec(`
+insert into repo(id, name) values (1, 'a'), (2, 'b/d'), (3, 'c');
+insert into gitserver_repos(repo_id, shard_id) values (1, 1), (2, 1);
+insert into gitserver_repos(repo_id, shard_id, repo_size_bytes) values (3, 1, 228);
+`); err != nil {
+		t.Fatalf("unexpected error while inserting test data: %s", err)
+	}
+
 	s.cleanupRepos()
+
+	for i := 1; i <= 3; i++ {
+		repo, err := s.DB.GitserverRepos().GetByID(context.Background(), 1)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if repo.RepoSizeBytes == 0 {
+			t.Fatal("repo_size_bytes is not updated")
+		}
+	}
 
 	// we hardcode the name here so the tests break if someone changes the
 	// value of reposStatsName. We don't want it to change without good reason
@@ -1116,5 +1137,62 @@ func TestPruneIfNeeded(t *testing.T) {
 	limit := -1 // always run prune
 	if err := pruneIfNeeded(gitDir, limit); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestCleanup_setRepoSizes(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
+	root, err := os.MkdirTemp("", "gitserver-test-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(root)
+
+	for _, name := range []string{"a", "b", "c"} {
+		p := path.Join(root, name, ".git")
+		if err := os.MkdirAll(p, 0755); err != nil {
+			t.Fatal(err)
+		}
+		cmd := exec.Command("git", "--bare", "init", p)
+		if err := cmd.Run(); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// We run cleanupRepos because we want to test as a side-effect it creates
+	// the correct file in the correct place.
+	s := &Server{ReposDir: root}
+	s.Handler() // Handler as a side-effect sets up Server
+	db := dbtest.NewDB(t)
+	s.DB = database.NewDB(db)
+
+	// inserting info about repos to DB. Repo with ID = 1 already has its size
+	if _, err := db.Exec(`
+insert into repo(id, name) values (1, 'a'), (2, 'b'), (3, 'c');
+insert into gitserver_repos(repo_id, shard_id) values (2, 1), (3, 1);
+insert into gitserver_repos(repo_id, shard_id, repo_size_bytes) values (1, 1, 228);
+`); err != nil {
+		t.Fatalf("unexpected error while inserting test data: %s", err)
+	}
+
+	s.cleanupRepos()
+
+	for i := 1; i <= 3; i++ {
+		repo, err := s.DB.GitserverRepos().GetByID(context.Background(), 1)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if repo.RepoSizeBytes == 0 {
+			t.Fatal("repo_size_bytes is not updated")
+		}
+		if i == 1 && repo.RepoSizeBytes != 228 {
+			t.Fatal("existing repo_size_bytes has been updated")
+		}
+		if repo.ShardID != "1" {
+			t.Fatal("shard_id has been corrupted")
+		}
 	}
 }

--- a/internal/database/gitserver_repos.go
+++ b/internal/database/gitserver_repos.go
@@ -439,7 +439,7 @@ func (s *gitserverRepoStore) ListReposWithoutSize(ctx context.Context) (map[api.
 	for rows.Next() {
 		var name string
 		var ID int32
-		if err := rows.Scan(&dbutil.NullString{S: &name}, &dbutil.NullInt32{N: &ID}); err != nil {
+		if err := rows.Scan(&name, &ID); err != nil {
 			return nil, errors.Wrap(err, "scanning row")
 		}
 		repos[api.RepoName(name)] = api.RepoID(ID)
@@ -458,8 +458,6 @@ WHERE gr.repo_size_bytes IS NULL
 `
 
 // UpdateRepoSizes sets repo sizes according to input map. Key is repoID, value is repo_size_bytes.
-// INSERT clause has shard_id column which is hardcoded to "0" because of not null constraint.
-// In fact shard_id is always "updated" to existing value, that's why "0" is just skipped.
 func (s *gitserverRepoStore) UpdateRepoSizes(ctx context.Context, shardID string, repos map[api.RepoID]int64) error {
 	values := make([]*sqlf.Query, 0, len(repos))
 	for repo, size := range repos {

--- a/internal/database/gitserver_repos.go
+++ b/internal/database/gitserver_repos.go
@@ -492,15 +492,6 @@ func (s *gitserverRepoStore) UpdateRepoSizes(ctx context.Context, shardID string
 	return nil
 }
 
-const updateRepoSizesQueryTemplate = `
--- source: internal/database/gitserver_repos.go:gitserverRepoStore.UpdateRepoSizes
-INSERT INTO gitserver_repos(repo_id, shard_id, repo_size_bytes, updated_at)
-VALUES %s
-ON CONFLICT (repo_id) DO UPDATE
-SET (repo_size_bytes, shard_id, updated_at) =
-    (EXCLUDED.repo_size_bytes, gitserver_repos.shard_id, now())
-`
-
 // sanitizeToUTF8 will remove any null character terminated string. The null character can be
 // represented in one of the following ways in Go:
 //

--- a/internal/database/mocks.go
+++ b/internal/database/mocks.go
@@ -16124,6 +16124,9 @@ type MockGitserverRepoStore struct {
 	// object controlling the behavior of the method
 	// IterateWithNonemptyLastError.
 	IterateWithNonemptyLastErrorFunc *GitserverRepoStoreIterateWithNonemptyLastErrorFunc
+	// ListReposWithoutSizeFunc is an instance of a mock function object
+	// controlling the behavior of the method ListReposWithoutSize.
+	ListReposWithoutSizeFunc *GitserverRepoStoreListReposWithoutSizeFunc
 	// SetCloneStatusFunc is an instance of a mock function object
 	// controlling the behavior of the method SetCloneStatus.
 	SetCloneStatusFunc *GitserverRepoStoreSetCloneStatusFunc
@@ -16140,6 +16143,9 @@ type MockGitserverRepoStore struct {
 	// object controlling the behavior of the method
 	// TotalErroredCloudDefaultRepos.
 	TotalErroredCloudDefaultReposFunc *GitserverRepoStoreTotalErroredCloudDefaultReposFunc
+	// UpdateRepoSizesFunc is an instance of a mock function object
+	// controlling the behavior of the method UpdateRepoSizes.
+	UpdateRepoSizesFunc *GitserverRepoStoreUpdateRepoSizesFunc
 	// UpsertFunc is an instance of a mock function object controlling the
 	// behavior of the method Upsert.
 	UpsertFunc *GitserverRepoStoreUpsertFunc
@@ -16178,6 +16184,11 @@ func NewMockGitserverRepoStore() *MockGitserverRepoStore {
 				return nil
 			},
 		},
+		ListReposWithoutSizeFunc: &GitserverRepoStoreListReposWithoutSizeFunc{
+			defaultHook: func(context.Context) (map[api.RepoName]api.RepoID, error) {
+				return nil, nil
+			},
+		},
 		SetCloneStatusFunc: &GitserverRepoStoreSetCloneStatusFunc{
 			defaultHook: func(context.Context, api.RepoName, types.CloneStatus, string) error {
 				return nil
@@ -16201,6 +16212,11 @@ func NewMockGitserverRepoStore() *MockGitserverRepoStore {
 		TotalErroredCloudDefaultReposFunc: &GitserverRepoStoreTotalErroredCloudDefaultReposFunc{
 			defaultHook: func(context.Context) (int, error) {
 				return 0, nil
+			},
+		},
+		UpdateRepoSizesFunc: &GitserverRepoStoreUpdateRepoSizesFunc{
+			defaultHook: func(context.Context, string, map[api.RepoID]int64) error {
+				return nil
 			},
 		},
 		UpsertFunc: &GitserverRepoStoreUpsertFunc{
@@ -16246,6 +16262,11 @@ func NewStrictMockGitserverRepoStore() *MockGitserverRepoStore {
 				panic("unexpected invocation of MockGitserverRepoStore.IterateWithNonemptyLastError")
 			},
 		},
+		ListReposWithoutSizeFunc: &GitserverRepoStoreListReposWithoutSizeFunc{
+			defaultHook: func(context.Context) (map[api.RepoName]api.RepoID, error) {
+				panic("unexpected invocation of MockGitserverRepoStore.ListReposWithoutSize")
+			},
+		},
 		SetCloneStatusFunc: &GitserverRepoStoreSetCloneStatusFunc{
 			defaultHook: func(context.Context, api.RepoName, types.CloneStatus, string) error {
 				panic("unexpected invocation of MockGitserverRepoStore.SetCloneStatus")
@@ -16269,6 +16290,11 @@ func NewStrictMockGitserverRepoStore() *MockGitserverRepoStore {
 		TotalErroredCloudDefaultReposFunc: &GitserverRepoStoreTotalErroredCloudDefaultReposFunc{
 			defaultHook: func(context.Context) (int, error) {
 				panic("unexpected invocation of MockGitserverRepoStore.TotalErroredCloudDefaultRepos")
+			},
+		},
+		UpdateRepoSizesFunc: &GitserverRepoStoreUpdateRepoSizesFunc{
+			defaultHook: func(context.Context, string, map[api.RepoID]int64) error {
+				panic("unexpected invocation of MockGitserverRepoStore.UpdateRepoSizes")
 			},
 		},
 		UpsertFunc: &GitserverRepoStoreUpsertFunc{
@@ -16304,6 +16330,9 @@ func NewMockGitserverRepoStoreFrom(i GitserverRepoStore) *MockGitserverRepoStore
 		IterateWithNonemptyLastErrorFunc: &GitserverRepoStoreIterateWithNonemptyLastErrorFunc{
 			defaultHook: i.IterateWithNonemptyLastError,
 		},
+		ListReposWithoutSizeFunc: &GitserverRepoStoreListReposWithoutSizeFunc{
+			defaultHook: i.ListReposWithoutSize,
+		},
 		SetCloneStatusFunc: &GitserverRepoStoreSetCloneStatusFunc{
 			defaultHook: i.SetCloneStatus,
 		},
@@ -16318,6 +16347,9 @@ func NewMockGitserverRepoStoreFrom(i GitserverRepoStore) *MockGitserverRepoStore
 		},
 		TotalErroredCloudDefaultReposFunc: &GitserverRepoStoreTotalErroredCloudDefaultReposFunc{
 			defaultHook: i.TotalErroredCloudDefaultRepos,
+		},
+		UpdateRepoSizesFunc: &GitserverRepoStoreUpdateRepoSizesFunc{
+			defaultHook: i.UpdateRepoSizes,
 		},
 		UpsertFunc: &GitserverRepoStoreUpsertFunc{
 			defaultHook: i.Upsert,
@@ -16862,6 +16894,115 @@ func (c GitserverRepoStoreIterateWithNonemptyLastErrorFuncCall) Args() []interfa
 // invocation.
 func (c GitserverRepoStoreIterateWithNonemptyLastErrorFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
+}
+
+// GitserverRepoStoreListReposWithoutSizeFunc describes the behavior when
+// the ListReposWithoutSize method of the parent MockGitserverRepoStore
+// instance is invoked.
+type GitserverRepoStoreListReposWithoutSizeFunc struct {
+	defaultHook func(context.Context) (map[api.RepoName]api.RepoID, error)
+	hooks       []func(context.Context) (map[api.RepoName]api.RepoID, error)
+	history     []GitserverRepoStoreListReposWithoutSizeFuncCall
+	mutex       sync.Mutex
+}
+
+// ListReposWithoutSize delegates to the next hook function in the queue and
+// stores the parameter and result values of this invocation.
+func (m *MockGitserverRepoStore) ListReposWithoutSize(v0 context.Context) (map[api.RepoName]api.RepoID, error) {
+	r0, r1 := m.ListReposWithoutSizeFunc.nextHook()(v0)
+	m.ListReposWithoutSizeFunc.appendCall(GitserverRepoStoreListReposWithoutSizeFuncCall{v0, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the ListReposWithoutSize
+// method of the parent MockGitserverRepoStore instance is invoked and the
+// hook queue is empty.
+func (f *GitserverRepoStoreListReposWithoutSizeFunc) SetDefaultHook(hook func(context.Context) (map[api.RepoName]api.RepoID, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// ListReposWithoutSize method of the parent MockGitserverRepoStore instance
+// invokes the hook at the front of the queue and discards it. After the
+// queue is empty, the default hook function is invoked for any future
+// action.
+func (f *GitserverRepoStoreListReposWithoutSizeFunc) PushHook(hook func(context.Context) (map[api.RepoName]api.RepoID, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *GitserverRepoStoreListReposWithoutSizeFunc) SetDefaultReturn(r0 map[api.RepoName]api.RepoID, r1 error) {
+	f.SetDefaultHook(func(context.Context) (map[api.RepoName]api.RepoID, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *GitserverRepoStoreListReposWithoutSizeFunc) PushReturn(r0 map[api.RepoName]api.RepoID, r1 error) {
+	f.PushHook(func(context.Context) (map[api.RepoName]api.RepoID, error) {
+		return r0, r1
+	})
+}
+
+func (f *GitserverRepoStoreListReposWithoutSizeFunc) nextHook() func(context.Context) (map[api.RepoName]api.RepoID, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *GitserverRepoStoreListReposWithoutSizeFunc) appendCall(r0 GitserverRepoStoreListReposWithoutSizeFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of
+// GitserverRepoStoreListReposWithoutSizeFuncCall objects describing the
+// invocations of this function.
+func (f *GitserverRepoStoreListReposWithoutSizeFunc) History() []GitserverRepoStoreListReposWithoutSizeFuncCall {
+	f.mutex.Lock()
+	history := make([]GitserverRepoStoreListReposWithoutSizeFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// GitserverRepoStoreListReposWithoutSizeFuncCall is an object that
+// describes an invocation of method ListReposWithoutSize on an instance of
+// MockGitserverRepoStore.
+type GitserverRepoStoreListReposWithoutSizeFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 map[api.RepoName]api.RepoID
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c GitserverRepoStoreListReposWithoutSizeFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c GitserverRepoStoreListReposWithoutSizeFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
 }
 
 // GitserverRepoStoreSetCloneStatusFunc describes the behavior when the
@@ -17422,6 +17563,117 @@ func (c GitserverRepoStoreTotalErroredCloudDefaultReposFuncCall) Args() []interf
 // invocation.
 func (c GitserverRepoStoreTotalErroredCloudDefaultReposFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
+}
+
+// GitserverRepoStoreUpdateRepoSizesFunc describes the behavior when the
+// UpdateRepoSizes method of the parent MockGitserverRepoStore instance is
+// invoked.
+type GitserverRepoStoreUpdateRepoSizesFunc struct {
+	defaultHook func(context.Context, string, map[api.RepoID]int64) error
+	hooks       []func(context.Context, string, map[api.RepoID]int64) error
+	history     []GitserverRepoStoreUpdateRepoSizesFuncCall
+	mutex       sync.Mutex
+}
+
+// UpdateRepoSizes delegates to the next hook function in the queue and
+// stores the parameter and result values of this invocation.
+func (m *MockGitserverRepoStore) UpdateRepoSizes(v0 context.Context, v1 string, v2 map[api.RepoID]int64) error {
+	r0 := m.UpdateRepoSizesFunc.nextHook()(v0, v1, v2)
+	m.UpdateRepoSizesFunc.appendCall(GitserverRepoStoreUpdateRepoSizesFuncCall{v0, v1, v2, r0})
+	return r0
+}
+
+// SetDefaultHook sets function that is called when the UpdateRepoSizes
+// method of the parent MockGitserverRepoStore instance is invoked and the
+// hook queue is empty.
+func (f *GitserverRepoStoreUpdateRepoSizesFunc) SetDefaultHook(hook func(context.Context, string, map[api.RepoID]int64) error) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// UpdateRepoSizes method of the parent MockGitserverRepoStore instance
+// invokes the hook at the front of the queue and discards it. After the
+// queue is empty, the default hook function is invoked for any future
+// action.
+func (f *GitserverRepoStoreUpdateRepoSizesFunc) PushHook(hook func(context.Context, string, map[api.RepoID]int64) error) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *GitserverRepoStoreUpdateRepoSizesFunc) SetDefaultReturn(r0 error) {
+	f.SetDefaultHook(func(context.Context, string, map[api.RepoID]int64) error {
+		return r0
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *GitserverRepoStoreUpdateRepoSizesFunc) PushReturn(r0 error) {
+	f.PushHook(func(context.Context, string, map[api.RepoID]int64) error {
+		return r0
+	})
+}
+
+func (f *GitserverRepoStoreUpdateRepoSizesFunc) nextHook() func(context.Context, string, map[api.RepoID]int64) error {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *GitserverRepoStoreUpdateRepoSizesFunc) appendCall(r0 GitserverRepoStoreUpdateRepoSizesFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of GitserverRepoStoreUpdateRepoSizesFuncCall
+// objects describing the invocations of this function.
+func (f *GitserverRepoStoreUpdateRepoSizesFunc) History() []GitserverRepoStoreUpdateRepoSizesFuncCall {
+	f.mutex.Lock()
+	history := make([]GitserverRepoStoreUpdateRepoSizesFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// GitserverRepoStoreUpdateRepoSizesFuncCall is an object that describes an
+// invocation of method UpdateRepoSizes on an instance of
+// MockGitserverRepoStore.
+type GitserverRepoStoreUpdateRepoSizesFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 string
+	// Arg2 is the value of the 3rd argument passed to this method
+	// invocation.
+	Arg2 map[api.RepoID]int64
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c GitserverRepoStoreUpdateRepoSizesFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c GitserverRepoStoreUpdateRepoSizesFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0}
 }
 
 // GitserverRepoStoreUpsertFunc describes the behavior when the Upsert


### PR DESCRIPTION
Gitserver janitor during its first run will now query the DB for repos in gitserver_repos table which have repo_size_bytes = NULL and update them with calculated values. Janitor always calculates a size of a repo (i.e. directory in file system) and now these data are used to fill the gaps in gitserver repo sizes.

Closes https://github.com/sourcegraph/sourcegraph/issues/33000

## Test plan
Unit tests are added

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


