### PR TITLE
ci: fix deployment-notifier pr number parsing

### DIFF
--- a/enterprise/dev/deployment-notifier/deployment_notifier_test.go
+++ b/enterprise/dev/deployment-notifier/deployment_notifier_test.go
@@ -184,6 +184,9 @@ func TestParsePRNumberInMergeCommit(t *testing.T) {
 		{name: "Merge commit with revert", message: `Revert "Support diffing for unrelated commits. (#32015)" (#32737)`, want: 32737},
 		{name: "Normal commit", message: `YOLO I commit on main without PR`, want: 0},
 		{name: "Merge commit", message: `batches: Properly quote name in YAML (#32951)`, want: 32951},
+		{name: "Merge commit with additional desc", message: `Fix repopendingperms tests (#33247)
+
+* Fix repopendingperms tests`, want: 33247},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
An edge case was missing, where the merge commit is a multiline string.
Fixed it by only parsing the first line and added a unit test.

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

Added a unit test to cover the edge case. 
