### PR TITLE
gitserver: Skip remote urls for private cloud default repos

### DIFF
--- a/cmd/gitserver/main.go
+++ b/cmd/gitserver/main.go
@@ -285,6 +285,14 @@ func getRemoteURLFunc(
 			return "", err
 		}
 
+		if svc.CloudDefault && r.Private {
+			// We won't be able to use this remote URL, so we should skip it. This can happen
+			// if a repo moves from being public to private while belonging to both a cloud
+			// default external service and another external service with a token that has
+			// access to the private repo.
+			continue
+		}
+
 		dotcomConfig := conf.SiteConfig().Dotcom
 		if envvar.SourcegraphDotComMode() &&
 			repos.IsGitHubAppCloudEnabled(dotcomConfig) &&


### PR DESCRIPTION
We won't be able to use a remote URL for a private repo linked to a
cloud default external service, so we should skip it. This can happen if
a repo moves from being public to private while belonging to both a
cloud default external service and another external service with a token
that has access to the private repo.

I spotted this while looking into why we still have a bunch of repos that are
consistently failing to update on cloud.

# Test plan

We should see the number of repos in [this gauge](https://sourcegraph.com/-/debug/grafana/explore?orgId=1&left=%5B%22now-1h%22,%22now%22,%22Prometheus%22,%7B%22exemplar%22:true,%22expr%22:%22sum(src_repoupdater_syncer_sync_repos_with_last_error_total)%22,%22requestId%22:%22Q-b9b149e4-0593-4d27-8dd0-176da235f595-0A%22%7D%5D) drop.
