### PR TITLE
Update schema/README with step to update TypeScript schema files

### DIFF
--- a/schema/README.md
+++ b/schema/README.md
@@ -14,6 +14,7 @@ Sourcegraph uses the following JSON Schemas:
 1.  Edit the `*.schema.json` file in this directory.
 1.  Run `go generate` to update the `*_stringdata.json` file.
 1.  Commit the changes to both files.
+1.  Run `sg start` to automatically update TypeScript schema files.
 1.  When the change is ready for release, [update the documentation](https://github.com/sourcegraph/website/blob/master/README.md#documentation-pages).
 
 ## Known issues


### PR DESCRIPTION
As discussed on [Slack](https://sourcegraph.slack.com/archives/C07KZF47K/p1648650441285149), there is a bit of tribal knowledge on how to update TypeScript autogen'd files- restarting `sg` locally is an easy way to do it. This updates the README with the step.

## Test plan

n/a

