### PR TITLE
database: Skip forks and archives indexing

### DIFF
--- a/internal/database/repos.go
+++ b/internal/database/repos.go
@@ -1137,7 +1137,7 @@ FROM repo
 %s
 WHERE
 	(
-		(repo.stars >= %s AND NOT fork AND NOT archived)
+		(repo.stars >= %s AND NOT COALESCE(fork, false) AND NOT archived)
 		OR
 		lower(repo.name) ~ '^(src\.fedoraproject\.org|maven|npm|jdk)'
 		OR

--- a/internal/database/repos.go
+++ b/internal/database/repos.go
@@ -1137,7 +1137,7 @@ FROM repo
 %s
 WHERE
 	(
-		repo.stars >= %s
+		(repo.stars >= %s AND NOT fork AND NOT archived)
 		OR
 		lower(repo.name) ~ '^(src\.fedoraproject\.org|maven|npm|jdk)'
 		OR


### PR DESCRIPTION
While the Starburst external service doesn't produce any forks or archives, this clause would pick up any such repos that have enough stars that were owned by other external services.



## Test plan

Existing tests.


