### PR TITLE
repo-updater: Enable the purge worker on Cloud

### DIFF
--- a/cmd/repo-updater/shared/main.go
+++ b/cmd/repo-updater/shared/main.go
@@ -181,11 +181,8 @@ func Main(enterpriseInit EnterpriseInit) {
 	}
 
 	go repos.RunPhabricatorRepositorySyncWorker(ctx, store)
-
-	if !envvar.SourcegraphDotComMode() {
-		// git-server repos purging thread
-		go repos.RunRepositoryPurgeWorker(ctx, db)
-	}
+	// git-server repos purging thread
+	go repos.RunRepositoryPurgeWorker(ctx, db)
 
 	// Git fetches scheduler
 	go repos.RunScheduler(ctx, updateScheduler)


### PR DESCRIPTION
This has been disabled for a long time and it would appear that it is
safe to re-enable.

*PLEASE DON'T MERGE*