### PR TITLE
ci: document deployment notifications

### DIFF
--- a/doc/dev/background-information/ci/index.md
+++ b/doc/dev/background-information/ci/index.md
@@ -158,6 +158,13 @@ Also see [Buildkite infrastructure](#buildkite-infrastructure).
 
 See [Pipeline development](./development.md) to get started with contributing to our Buildkite pipelines!
 
+### Deployment notifications
+
+When a pull request is deployed, an automated notification will be posted in either [#alerts-cloud-preprod](https://sourcegraph.slack.com/archives/C039JKERFBN) or [#deployments-cloud](https://sourcegraph.slack.com/archives/C03BGBR796H) depending in which environment it happened.
+Notifications include a list of the pull-request that were shipped as well as a list of which services specifically were rolled out.
+
+If you want to be explictly notified (through a Slack ping) when your pull request reaches _preprod_ or _cloud production_, add the label `notify-on-deploy`.
+
 ## GitHub Actions
 
 ### `buildchecker`


### PR DESCRIPTION
This is the first iteration of deployment notifications documentation. 

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

<img width="907" alt="image" src="https://user-images.githubusercontent.com/10151/161053967-2ef4583f-e913-4aad-a663-19ae900c423b.png">

