### PR TITLE
gitserver: track janitor job status

### DIFF
--- a/cmd/gitserver/server/cleanup.go
+++ b/cmd/gitserver/server/cleanup.go
@@ -86,7 +86,7 @@ var (
 	jobTimer = promauto.NewHistogramVec(prometheus.HistogramOpts{
 		Name: "src_gitserver_janitor_job_duration_seconds",
 		Help: "Duration of the individual jobs within the gitserver janitor background job",
-	}, []string{"job_name"})
+	}, []string{"success", "job_name"})
 	maintenanceStatus = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "src_gitserver_maintenance_status",
 		Help: "whether the maintenance run was a success (true/false) and the reason why a cleanup was needed",
@@ -347,7 +347,7 @@ func (s *Server) cleanupRepos() {
 			if err != nil {
 				log15.Error("error running cleanup command", "name", cfn.Name, "repo", gitDir, "error", err)
 			}
-			jobTimer.WithLabelValues(cfn.Name).Observe(time.Since(start).Seconds())
+			jobTimer.WithLabelValues(strconv.FormatBool(err == nil), cfn.Name).Observe(time.Since(start).Seconds())
 			if done {
 				break
 			}


### PR DESCRIPTION
this adds the label "success" to the histogram "jobTimer". The goal is to
monitor the rate of failed janitor jobs with the default count bucket
of the histrogram, "src_gitserver_janitor_job_duration_seconds_count".

I will add panels based on this new data in another PR.

## Test plan
- existing tests
- ran local instance of sourcegraph and explored the metric.

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


