### PR TITLE
search: suppress Zoekt error about nil query node for symbols

### DIFF
--- a/internal/search/query_converter.go
+++ b/internal/search/query_converter.go
@@ -290,7 +290,7 @@ func QueryToZoektQuery(b query.Basic, resultTypes result.Types, feat *Features, 
 	filesExclude = append(filesExclude, mapSlice(langExclude, LangToFileRegexp)...)
 	filesReposMustInclude, filesReposMustExclude := b.IncludeExcludeValues(query.FieldRepoHasFile)
 
-	if typ == SymbolRequest {
+	if typ == SymbolRequest && q != nil {
 		// Tell zoekt q must match on symbols
 		q = &zoekt.Symbol{
 			Expr: q,


### PR DESCRIPTION
This is just a check to suppress a non-friendly user error about a Zoekt query having a nil node:

![Screen Shot 2022-03-31 at 9 58 46 AM](https://user-images.githubusercontent.com/888624/161120796-25aeee29-b78c-4b87-ad49-712b4b257d21.png)

The error came up after restructuring some code around Zoekt query creation.


## Test plan
Semantics-preserving with respect to functionality. Manually checked it doesn't show the error.


