### PR TITLE
search: Refactor Monaco query input suggestions

### DIFF
--- a/client/search-ui/src/input/CodeMirrorQueryInput.tsx
+++ b/client/search-ui/src/input/CodeMirrorQueryInput.tsx
@@ -2,7 +2,6 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import {
     autocompletion,
-    CompletionResult,
     Completion,
     snippet,
     completionKeymap,
@@ -23,8 +22,7 @@ import {
 import { Shortcut } from '@slimsag/react-shortcuts'
 import classNames from 'classnames'
 import { editor as Monaco, MarkerSeverity, languages } from 'monaco-editor'
-import { Observable, of } from 'rxjs'
-import { delay, map, switchMap } from 'rxjs/operators'
+import { Observable } from 'rxjs'
 
 import { renderMarkdown } from '@sourcegraph/common'
 import { QueryChangeSource, SearchPatternType, SearchPatternTypeProps } from '@sourcegraph/search'
@@ -35,7 +33,7 @@ import { decorate, DecoratedToken } from '@sourcegraph/shared/src/search/query/d
 import { getDiagnostics } from '@sourcegraph/shared/src/search/query/diagnostics'
 import { resolveFilter } from '@sourcegraph/shared/src/search/query/filters'
 import { toHover } from '@sourcegraph/shared/src/search/query/hover'
-import { getSuggestionQuery } from '@sourcegraph/shared/src/search/query/providers'
+import { createCancelableFetchSuggestions, getSuggestionQuery } from '@sourcegraph/shared/src/search/query/providers'
 import { scanSearchQuery } from '@sourcegraph/shared/src/search/query/scanner'
 import { Filter, Token } from '@sourcegraph/shared/src/search/query/token'
 import { appendContextFilter } from '@sourcegraph/shared/src/search/query/transformer'
@@ -691,76 +689,63 @@ const queryDiagnostic: Extension[] = [
 const autocomplete = (
     fetchSuggestions: (query: string) => Observable<SearchMatch[]>,
     options: { globbing: boolean; isSourcegraphDotCom: boolean }
-): Extension[] => [
-    // Uses the default keymapping but changes accepting suggestions from Enter
-    // to Tab
-    Prec.highest(
-        keymap.of(
-            completionKeymap.map(keybinding =>
-                keybinding.key === 'Enter' ? { ...keybinding, key: 'Tab' } : keybinding
+): Extension => {
+    const cancelableFetch = createCancelableFetchSuggestions(fetchSuggestions)
+    return [
+        // Uses the default keymapping but changes accepting suggestions from Enter
+        // to Tab
+        Prec.highest(
+            keymap.of(
+                completionKeymap.map(keybinding =>
+                    keybinding.key === 'Enter' ? { ...keybinding, key: 'Tab' } : keybinding
+                )
             )
-        )
-    ),
-    EditorView.updateListener.of(update => {
-        // We want the completion list to be hidden when the editor looses focus
-        if (update.focusChanged && !update.view.hasFocus) {
-            closeCompletion(update.view)
-        }
-        // Show the completion list again if a filter was completed
-        if (update.transactions.some(transaction => transaction.isUserEvent('input.complete'))) {
-            const query = update.state.facet(parsedQuery)
-            const token = query.tokens.find(token => isTokenInRange(update.state.selection.main.anchor - 1, token))
-            if (token) {
-                startCompletion(update.view)
+        ),
+        EditorView.updateListener.of(update => {
+            // We want the completion list to be hidden when the editor looses focus
+            if (update.focusChanged && !update.view.hasFocus) {
+                closeCompletion(update.view)
             }
-        }
-    }),
-    autocompletion({
-        defaultKeymap: false,
-        override: [
-            context => {
-                const query = context.state.facet(parsedQuery)
-                const token = query.tokens.find(token => isTokenInRange(context.pos - 1, token))
-                if (!token) {
-                    return null
+            // Show the completion list again if a filter was completed
+            if (update.transactions.some(transaction => transaction.isUserEvent('input.complete'))) {
+                const query = update.state.facet(parsedQuery)
+                const token = query.tokens.find(token => isTokenInRange(update.state.selection.main.anchor - 1, token))
+                if (token) {
+                    startCompletion(update.view)
                 }
-                return of(getSuggestionQuery(query.tokens, token))
-                    .pipe(
-                        // We use a delay here to implement a custom debounce. In the
-                        // next step we check if the current completion request was
-                        // cancelled in the meantime (`context.aborted`).
-                        // This prevents us from needlessly running multiple suggestion
-                        // queries.
-                        delay(200),
-                        switchMap(query =>
-                            context.aborted
-                                ? Promise.resolve(null)
-                                : getCompletionItems(
-                                      token,
-                                      { column: context.pos + 1 },
-                                      fetchSuggestions(query),
-                                      options.globbing,
-                                      options.isSourcegraphDotCom
-                                  )
-                        ),
-                        map((completionList): CompletionResult | null => {
-                            if (completionList === null || completionList.suggestions.length === 0) {
-                                return null
-                            }
-                            return {
-                                from:
-                                    token.type === 'filter'
-                                        ? token.value?.range.start ?? context.pos
-                                        : token.range.start,
-                                options: toCMCompletions(completionList),
-                            }
-                        })
+            }
+        }),
+        autocompletion({
+            defaultKeymap: false,
+            override: [
+                async context => {
+                    const query = context.state.facet(parsedQuery)
+                    const token = query.tokens.find(token => isTokenInRange(context.pos - 1, token))
+                    if (!token) {
+                        return null
+                    }
+                    const completionList = await getCompletionItems(
+                        token,
+                        { column: context.pos + 1 },
+                        async (token, type) =>
+                            cancelableFetch(getSuggestionQuery(query.tokens, token, type), listener =>
+                                context.addEventListener('abort', listener)
+                            ),
+                        options
                     )
-                    .toPromise()
-            },
-        ],
-    }),
-]
+
+                    if (completionList === null || completionList.suggestions.length === 0) {
+                        return null
+                    }
+                    return {
+                        from: token.type === 'filter' ? token.value?.range.start ?? context.pos : token.range.start,
+                        options: toCMCompletions(completionList),
+                    }
+                },
+            ],
+        }),
+    ]
+}
 
 function toCMCompletions(completionList: languages.CompletionList): Completion[] {
     // Boost suggestions by position because it appears they are already orderd.

--- a/client/search-ui/src/input/CodeMirrorQueryInput.tsx
+++ b/client/search-ui/src/input/CodeMirrorQueryInput.tsx
@@ -37,7 +37,7 @@ import { createCancelableFetchSuggestions, getSuggestionQuery } from '@sourcegra
 import { scanSearchQuery } from '@sourcegraph/shared/src/search/query/scanner'
 import { Filter, Token } from '@sourcegraph/shared/src/search/query/token'
 import { appendContextFilter } from '@sourcegraph/shared/src/search/query/transformer'
-import { SearchMatch } from '@sourcegraph/shared/src/search/stream'
+import { isSearchMatchOfType, SearchMatch } from '@sourcegraph/shared/src/search/stream'
 import { fetchStreamSuggestions } from '@sourcegraph/shared/src/search/suggestions'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
 import { isInputElement } from '@sourcegraph/shared/src/util/dom'
@@ -727,10 +727,10 @@ const autocomplete = (
                     const completionList = await getCompletionItems(
                         token,
                         { column: context.pos + 1 },
-                        async (token, type) =>
+                        (token, type) =>
                             cancelableFetch(getSuggestionQuery(query.tokens, token, type), listener =>
                                 context.addEventListener('abort', listener)
-                            ),
+                            ).then(matches => matches.filter(isSearchMatchOfType(type))),
                         options
                     )
 

--- a/client/shared/src/search/query/completion.test.ts
+++ b/client/shared/src/search/query/completion.test.ts
@@ -15,6 +15,8 @@ const toSuccess = (result: ScanResult<Token[]>): Token[] => (result as ScanSucce
 
 const getToken = (query: string, tokenIndex: number): Token => toSuccess(scanSearchQuery(query))[tokenIndex]
 
+// Using async as a short way to create functions that return promises
+/* eslint-disable @typescript-eslint/require-await */
 describe('getCompletionItems()', () => {
     test('returns only static filter type completions when the token matches a known filter', async () => {
         expect(

--- a/client/shared/src/search/query/completion.test.ts
+++ b/client/shared/src/search/query/completion.test.ts
@@ -1,6 +1,3 @@
-import * as Monaco from 'monaco-editor'
-import { NEVER, of } from 'rxjs'
-
 import { SymbolKind } from '../../graphql-operations'
 import { SearchMatch } from '../stream'
 
@@ -25,23 +22,24 @@ describe('getCompletionItems()', () => {
                 await getCompletionItems(
                     getToken('re', 0),
                     { column: 3 },
-                    of([
-                        {
-                            type: 'repo',
-                            repository: 'github.com/sourcegraph/jsonrpc2',
-                        },
-                        {
-                            type: 'symbol',
-                            repository: 'github.com/sourcegraph/jsonrpc2',
-                            symbols: [
-                                {
-                                    kind: SymbolKind.VARIABLE,
-                                    name: 'RepoRoutes',
-                                },
-                            ],
-                        },
-                    ] as SearchMatch[]),
-                    false
+                    async () =>
+                        [
+                            {
+                                type: 'repo',
+                                repository: 'github.com/sourcegraph/jsonrpc2',
+                            },
+                            {
+                                type: 'symbol',
+                                repository: 'github.com/sourcegraph/jsonrpc2',
+                                symbols: [
+                                    {
+                                        kind: SymbolKind.VARIABLE,
+                                        name: 'RepoRoutes',
+                                    },
+                                ],
+                            },
+                        ] as SearchMatch[],
+                    {}
                 )
             )?.suggestions.map(({ label }) => label)
         ).toStrictEqual([
@@ -85,23 +83,24 @@ describe('getCompletionItems()', () => {
                 await getCompletionItems(
                     getToken('reposi', 0),
                     { column: 7 },
-                    of([
-                        {
-                            type: 'repo',
-                            repository: 'github.com/sourcegraph/jsonrpc2',
-                        },
-                        {
-                            type: 'symbol',
-                            repository: 'github.com/sourcegraph/jsonrpc2',
-                            symbols: [
-                                {
-                                    kind: SymbolKind.VARIABLE,
-                                    name: 'RepoRoutes',
-                                },
-                            ],
-                        },
-                    ] as SearchMatch[]),
-                    false
+                    async () =>
+                        [
+                            {
+                                type: 'repo',
+                                repository: 'github.com/sourcegraph/jsonrpc2',
+                            },
+                            {
+                                type: 'symbol',
+                                repository: 'github.com/sourcegraph/jsonrpc2',
+                                symbols: [
+                                    {
+                                        kind: SymbolKind.VARIABLE,
+                                        name: 'RepoRoutes',
+                                    },
+                                ],
+                            },
+                        ] as SearchMatch[],
+                    {}
                 )
             )?.suggestions.map(({ label }) => label)
         ).toStrictEqual([
@@ -143,7 +142,7 @@ describe('getCompletionItems()', () => {
 
     test('returns suggestions for an empty query', async () => {
         expect(
-            (await getCompletionItems(getToken('', 0), { column: 1 }, NEVER, false))?.suggestions.map(
+            (await getCompletionItems(getToken('', 0), { column: 1 }, async () => [], {}))?.suggestions.map(
                 ({ label }) => label
             )
         ).toStrictEqual([
@@ -187,13 +186,14 @@ describe('getCompletionItems()', () => {
                 await getCompletionItems(
                     getToken('a ', 1),
                     { column: 3 },
-                    of([
-                        {
-                            type: 'repo',
-                            repository: 'github.com/sourcegraph/jsonrpc2',
-                        },
-                    ] as SearchMatch[]),
-                    false
+                    async () =>
+                        [
+                            {
+                                type: 'repo',
+                                repository: 'github.com/sourcegraph/jsonrpc2',
+                            },
+                        ] as SearchMatch[],
+                    {}
                 )
             )?.suggestions.map(({ label }) => label)
         ).toStrictEqual([
@@ -234,7 +234,7 @@ describe('getCompletionItems()', () => {
 
     test('returns static filter type completions for case-insensitive query', async () => {
         expect(
-            (await getCompletionItems(getToken('rE', 0), { column: 3 }, of([]), false))?.suggestions.map(
+            (await getCompletionItems(getToken('rE', 0), { column: 3 }, async () => [], {}))?.suggestions.map(
                 ({ label }) => label
             )
         ).toStrictEqual([
@@ -274,7 +274,7 @@ describe('getCompletionItems()', () => {
 
     test('returns completions for filters with discrete values', async () => {
         expect(
-            (await getCompletionItems(getToken('case:y', 0), { column: 7 }, NEVER, false))?.suggestions.map(
+            (await getCompletionItems(getToken('case:y', 0), { column: 7 }, async () => [], {}))?.suggestions.map(
                 ({ label }) => label
             )
         ).toStrictEqual(['yes', 'no'])
@@ -288,8 +288,8 @@ describe('getCompletionItems()', () => {
                     {
                         column: 6,
                     },
-                    of([]),
-                    false
+                    async () => [],
+                    {}
                 )
             )?.suggestions.map(({ label }) => label)
         ).toStrictEqual(POPULAR_LANGUAGES)
@@ -303,8 +303,8 @@ describe('getCompletionItems()', () => {
                     {
                         column: 8,
                     },
-                    of([]),
-                    false
+                    async () => [],
+                    {}
                 )
             )?.suggestions.map(({ label }) => label)
         ).toStrictEqual(['repo', 'file', 'content', 'symbol', 'commit'])
@@ -316,45 +316,18 @@ describe('getCompletionItems()', () => {
                 await getCompletionItems(
                     getToken('file:c', 0),
                     { column: 7 },
-                    of([
-                        {
-                            type: 'path',
-                            path: 'connect.go',
-                            repository: 'github.com/sourcegraph/jsonrpc2',
-                        },
-                    ] as SearchMatch[]),
-                    false
+                    async () =>
+                        [
+                            {
+                                type: 'path',
+                                path: 'connect.go',
+                                repository: 'github.com/sourcegraph/jsonrpc2',
+                            },
+                        ] as SearchMatch[],
+                    {}
                 )
             )?.suggestions.map(({ label, insertText }) => ({ label, insertText }))
         ).toStrictEqual([{ label: 'connect.go', insertText: '^connect\\.go$ ' }])
-    })
-
-    test('inserts valid filters when selecting a file or repository suggestion', async () => {
-        expect(
-            (
-                await getCompletionItems(
-                    getToken('jsonrpc', 0),
-                    { column: 8 },
-                    of([
-                        {
-                            type: 'path',
-                            path: 'jsonrpc2.go',
-                            repository: 'github.com/sourcegraph/jsonrpc2',
-                        },
-                        {
-                            type: 'repo',
-                            repository: 'github.com/sourcegraph/jsonrpc2.go',
-                        },
-                    ] as SearchMatch[]),
-                    false
-                )
-            )?.suggestions
-                .filter(
-                    ({ kind }) =>
-                        kind === Monaco.languages.CompletionItemKind.File || kind === repositoryCompletionItemKind
-                )
-                .map(({ insertText }) => insertText)
-        ).toStrictEqual(['file:^jsonrpc2\\.go$ ', 'repo:^github\\.com/sourcegraph/jsonrpc2\\.go$ '])
     })
 
     test('inserts valid suggestion when completing repo:deps predicate', async () => {
@@ -363,13 +336,14 @@ describe('getCompletionItems()', () => {
                 await getCompletionItems(
                     getToken('repo:deps(sourcegraph', 0),
                     { column: 21 },
-                    of([
-                        {
-                            type: 'repo',
-                            repository: 'github.com/sourcegraph/jsonrpc2.go',
-                        },
-                    ] as SearchMatch[]),
-                    false
+                    async () =>
+                        [
+                            {
+                                type: 'repo',
+                                repository: 'github.com/sourcegraph/jsonrpc2.go',
+                            },
+                        ] as SearchMatch[],
+                    {}
                 )
             )?.suggestions
                 .filter(({ kind }) => kind === repositoryCompletionItemKind)
@@ -383,38 +357,17 @@ describe('getCompletionItems()', () => {
                 await getCompletionItems(
                     getToken('f:^jsonrpc', 0),
                     { column: 11 },
-                    of([
+                    async () => [
                         {
                             type: 'path',
                             path: 'jsonrpc2.go',
                             repository: 'github.com/sourcegraph/jsonrpc2',
                         },
-                    ] as SearchMatch[]),
-                    false
+                    ],
+                    {}
                 )
             )?.suggestions.map(({ filterText }) => filterText)
         ).toStrictEqual(['^jsonrpc'])
-    })
-
-    test('includes file path in insertText with fuzzy completions', async () => {
-        expect(
-            (
-                await getCompletionItems(
-                    getToken('main.go', 0),
-                    { column: 7 },
-                    of([
-                        {
-                            type: 'path',
-                            path: 'some/path/main.go',
-                            repository: 'github.com/sourcegraph/jsonrpc2',
-                        },
-                    ] as SearchMatch[]),
-                    false
-                )
-            )?.suggestions
-                .filter(({ insertText }) => insertText.includes('some/path'))
-                .map(({ insertText }) => insertText)
-        ).toStrictEqual(['file:^some/path/main\\.go$ '])
     })
 
     test('includes file path in insertText when completing filter value', async () => {
@@ -423,14 +376,14 @@ describe('getCompletionItems()', () => {
                 await getCompletionItems(
                     getToken('f:', 0),
                     { column: 2 },
-                    of([
+                    async () => [
                         {
                             type: 'path',
                             path: 'some/path/main.go',
                             repository: 'github.com/sourcegraph/jsonrpc2',
                         },
-                    ] as SearchMatch[]),
-                    false
+                    ],
+                    {}
                 )
             )?.suggestions.map(({ insertText }) => insertText)
         ).toStrictEqual(['^some/path/main\\.go$ '])
@@ -442,13 +395,13 @@ describe('getCompletionItems()', () => {
                 await getCompletionItems(
                     getToken('repo:', 0),
                     { column: 5 },
-                    of([
+                    async () => [
                         {
                             type: 'repo',
                             repository: 'repo/with a space',
                         },
-                    ] as SearchMatch[]),
-                    false
+                    ],
+                    {}
                 )
             )?.suggestions.map(({ insertText }) => insertText)
         ).toMatchInlineSnapshot(`
@@ -466,9 +419,11 @@ describe('getCompletionItems()', () => {
 
     test('Sourcegraph.com GH repo completions', async () => {
         expect(
-            (await getCompletionItems(getToken('repo:', 0), { column: 5 }, of([]), false, true))?.suggestions.map(
-                ({ insertText }) => insertText
-            )
+            (
+                await getCompletionItems(getToken('repo:', 0), { column: 5 }, async () => [], {
+                    isSourcegraphDotCom: true,
+                })
+            )?.suggestions.map(({ insertText }) => insertText)
         ).toMatchInlineSnapshot(`
             [
               "^github\\\\.com/\${1:ORGANIZATION}/.* ",

--- a/client/shared/src/search/query/completion.test.ts
+++ b/client/shared/src/search/query/completion.test.ts
@@ -184,20 +184,9 @@ describe('getCompletionItems()', () => {
 
     test('returns suggestions on whitespace', async () => {
         expect(
-            (
-                await getCompletionItems(
-                    getToken('a ', 1),
-                    { column: 3 },
-                    async () =>
-                        [
-                            {
-                                type: 'repo',
-                                repository: 'github.com/sourcegraph/jsonrpc2',
-                            },
-                        ] as SearchMatch[],
-                    {}
-                )
-            )?.suggestions.map(({ label }) => label)
+            (await getCompletionItems(getToken('a ', 1), { column: 3 }, async () => [], {}))?.suggestions.map(
+                ({ label }) => label
+            )
         ).toStrictEqual([
             'after',
             'archived',
@@ -230,7 +219,6 @@ describe('getCompletionItems()', () => {
             'timeout',
             'type',
             'visibility',
-            'github.com/sourcegraph/jsonrpc2',
         ])
     })
 

--- a/client/shared/src/search/query/completion.test.ts
+++ b/client/shared/src/search/query/completion.test.ts
@@ -144,7 +144,6 @@ describe('getCompletionItems()', () => {
             'timeout',
             'type',
             'visibility',
-            'github.com/sourcegraph/jsonrpc2',
             'RepoRoutes',
         ])
     })

--- a/client/shared/src/search/query/completion.ts
+++ b/client/shared/src/search/query/completion.ts
@@ -34,12 +34,11 @@ export const COMPLETION_ITEM_SELECTED: Monaco.languages.Command = {
 export const createFilterSuggestions = (
     filter: FilterType[]
 ): { label: string; insertText: string; filterText: string; detail: string }[] =>
-    filter.flatMap(label => {
-        const filterType = label as FilterType
+    filter.flatMap(filterType => {
         const completionItem = {
-            label,
-            insertText: `${label}:`,
-            filterText: label,
+            label: filterType,
+            insertText: `${filterType}:`,
+            filterText: filterType,
             detail: '',
         }
         if (isNegatableFilter(filterType)) {
@@ -50,9 +49,9 @@ export const createFilterSuggestions = (
                 },
                 {
                     ...completionItem,
-                    label: `-${label}`,
-                    insertText: `-${label}:`,
-                    filterText: `-${label}`,
+                    label: `-${filterType}`,
+                    insertText: `-${filterType}:`,
+                    filterText: `-${filterType}`,
                     detail: FILTERS[filterType].description(true),
                 },
             ]

--- a/client/shared/src/search/query/completion.ts
+++ b/client/shared/src/search/query/completion.ts
@@ -307,6 +307,10 @@ async function completeFilterValue(
 
 const startRange: CharacterRange = { start: 1, end: 1 }
 
+export interface FetchSuggestions {
+    <T extends SearchMatch['type']>(token: Token, type: T): Promise<Extract<SearchMatch, { type: T }>[]>
+}
+
 /**
  * Returns the completion items for a search query being typed in the Monaco query input,
  * including both static and dynamically fetched suggestions.
@@ -314,7 +318,7 @@ const startRange: CharacterRange = { start: 1, end: 1 }
 export async function getCompletionItems(
     tokenAtPosition: Token | null,
     { column }: Pick<Monaco.Position, 'column'>,
-    fetchDynamicSuggestions: (token: Token, type: SearchMatch['type']) => Promise<SearchMatch[]>,
+    fetchDynamicSuggestions: FetchSuggestions,
     {
         globbing = false,
         isSourcegraphDotCom = false,

--- a/client/shared/src/search/query/completion.ts
+++ b/client/shared/src/search/query/completion.ts
@@ -307,9 +307,10 @@ async function completeFilterValue(
 
 const startRange: CharacterRange = { start: 1, end: 1 }
 
-export interface FetchSuggestions {
-    <T extends SearchMatch['type']>(token: Token, type: T): Promise<Extract<SearchMatch, { type: T }>[]>
-}
+export type FetchSuggestions = <T extends SearchMatch['type']>(
+    token: Token,
+    type: T
+) => Promise<Extract<SearchMatch, { type: T }>[]>
 
 /**
  * Returns the completion items for a search query being typed in the Monaco query input,

--- a/client/shared/src/search/query/filters.ts
+++ b/client/shared/src/search/query/filters.ts
@@ -303,15 +303,15 @@ export const discreteValueAliases: { [key: string]: string[] } = {
     only: ['o', 'only', 'ONLY', 'Only'],
 }
 
+export type ResolvedFilter =
+    | { type: NegatableFilter; negated: boolean; definition: NegatableFilterDefinition }
+    | { type: Exclude<FilterType, NegatableFilter>; definition: BaseFilterDefinition }
+    | undefined
+
 /**
  * Returns the {@link FilterDefinition} for the given filterType if it exists, or `undefined` otherwise.
  */
-export const resolveFilter = (
-    filterType: string
-):
-    | { type: NegatableFilter; negated: boolean; definition: NegatableFilterDefinition }
-    | { type: Exclude<FilterType, NegatableFilter>; definition: BaseFilterDefinition }
-    | undefined => {
+export const resolveFilter = (filterType: string): ResolvedFilter => {
     filterType = filterType.toLowerCase()
 
     if (isAliasedFilterType(filterType)) {

--- a/client/shared/src/search/query/providers.test.ts
+++ b/client/shared/src/search/query/providers.test.ts
@@ -11,43 +11,45 @@ function getTokens(query: string, tokenIndex: number): [Token[], Token] {
 
 describe('getSuggestionQuery', () => {
     test('should generate suggestion query for repo filter', () => {
-        expect(getSuggestionQuery(...getTokens('repo:a', 0))).toEqual('repo:a type:repo count:50')
+        expect(getSuggestionQuery(...getTokens('repo:a', 0), 'repo')).toEqual('repo:a type:repo count:50')
     })
 
     test('should not add non-relevant filters and patterns to repo suggestion query', () => {
-        expect(getSuggestionQuery(...getTokens('repo:a count:10 pattern', 0))).toEqual('repo:a type:repo count:50')
+        expect(getSuggestionQuery(...getTokens('repo:a count:10 pattern', 0), 'repo')).toEqual(
+            'repo:a type:repo count:50'
+        )
     })
 
     test('should archived, visibility, and fork filters to repo suggestion query', () => {
-        expect(getSuggestionQuery(...getTokens('visibility:private archived:no fork:only repo:a', 6))).toEqual(
+        expect(getSuggestionQuery(...getTokens('visibility:private archived:no fork:only repo:a', 6), 'repo')).toEqual(
             'visibility:private archived:no fork:only repo:a type:repo count:50'
         )
     })
 
     test('should not include relevant filters for repo suggestion query if inside an `or` expression', () => {
-        expect(getSuggestionQuery(...getTokens('(visibility:private repo:a) or repo:b', 3))).toEqual(
+        expect(getSuggestionQuery(...getTokens('(visibility:private repo:a) or repo:b', 3), 'repo')).toEqual(
             'repo:a type:repo count:50'
         )
     })
 
     test('should not generate a file suggestion query if inside an `or` expression', () => {
-        expect(getSuggestionQuery(...getTokens('(file:a) or pattern', 1))).toEqual('')
+        expect(getSuggestionQuery(...getTokens('(file:a) or pattern', 1), 'path')).toEqual('')
     })
 
     test('should generate a file suggestion query with relevant filters', () => {
-        expect(getSuggestionQuery(...getTokens('file:a archived:yes lang:Go', 0))).toEqual(
+        expect(getSuggestionQuery(...getTokens('file:a archived:yes lang:Go', 0), 'path')).toEqual(
             'archived:yes lang:Go file:a type:path count:50'
         )
     })
 
     test('should generate a symbol suggestion query with relevant filters', () => {
-        expect(getSuggestionQuery(...getTokens('pattern fork:only repo:a lang:Go', 0))).toEqual(
+        expect(getSuggestionQuery(...getTokens('pattern fork:only repo:a lang:Go', 0), 'symbol')).toEqual(
             'fork:only repo:a lang:Go pattern type:symbol count:50'
         )
     })
 
     test('should generate a suggestion query for repo:deps without relevant filters ', () => {
-        expect(getSuggestionQuery(...getTokens('repo:deps(sourcegraph) fork:only lang:Go', 0))).toEqual(
+        expect(getSuggestionQuery(...getTokens('repo:deps(sourcegraph) fork:only lang:Go', 0), 'repo')).toEqual(
             'repo:sourcegraph type:repo count:50'
         )
     })

--- a/client/shared/src/search/query/providers.ts
+++ b/client/shared/src/search/query/providers.ts
@@ -115,18 +115,25 @@ export function createCancelableFetchSuggestions(
             })
         })
 
-        return of(query)
-            .pipe(
-                // We use a delay here to implement a custom debounce. In the
-                // next step we check if the current completion request was
-                // cancelled in the meantime.
-                // This prevents us from needlessly running multiple suggestion
-                // queries.
-                delay(200),
-                switchMap(query => (aborted ? Promise.resolve([]) : fetchSuggestions(query))),
-                takeUntil(abort)
-            )
-            .toPromise()
+        return (
+            of(query)
+                .pipe(
+                    // We use a delay here to implement a custom debounce. In the
+                    // next step we check if the current completion request was
+                    // cancelled in the meantime.
+                    // This prevents us from needlessly running multiple suggestion
+                    // queries.
+                    delay(200),
+                    switchMap(query => (aborted ? Promise.resolve([]) : fetchSuggestions(query))),
+                    takeUntil(abort)
+                )
+                // toPromise may return undefined if the observable completes before
+                // a value was emitted . The return type was fixed in newer versions
+                // (and the method was actually deprecated).
+                // See https://rxjs.dev/deprecations/to-promise
+                .toPromise()
+                .then(result => result ?? [])
+        )
     }
 }
 

--- a/client/shared/src/search/stream.ts
+++ b/client/shared/src/search/stream.ts
@@ -530,3 +530,11 @@ export function getMatchUrl(match: SearchMatch): string {
             return getRepoMatchUrl(match)
     }
 }
+
+export type SearchMatchOfType<T extends SearchMatch['type']> = Extract<SearchMatch, { type: T }>
+
+export function isSearchMatchOfType<T extends SearchMatch['type']>(
+    type: T
+): (match: SearchMatch) => match is SearchMatchOfType<T> {
+    return (match): match is SearchMatchOfType<T> => match.type === type
+}

--- a/client/web/src/integration/search.test.ts
+++ b/client/web/src/integration/search.test.ts
@@ -183,7 +183,7 @@ describe('Search', () => {
             await driver.page.waitForSelector('#monaco-query-input')
             await driver.replaceText({
                 selector: '#monaco-query-input',
-                newText: 'go-jwt-middlew',
+                newText: 'repo:go-jwt-middlew',
                 enterTextMethod: 'type',
             })
             await driver.page.waitForSelector('#monaco-query-input .suggest-widget.visible')
@@ -200,7 +200,7 @@ describe('Search', () => {
             // File autocomplete from repo search bar
             await driver.page.waitForSelector('#monaco-query-input')
             await driver.page.focus('#monaco-query-input')
-            await driver.page.keyboard.type('jwtmi')
+            await driver.page.keyboard.type('file:jwtmi')
             await driver.page.waitForSelector('#monaco-query-input .suggest-widget.visible')
             await driver.findElementWithText('jwtmiddleware.go', {
                 selector: '#monaco-query-input .suggest-widget.visible span',


### PR DESCRIPTION
I intended to factor out some of the Monaco specific logic to make the other parts easier to reuse for CodeMirror, but in the end I wasn't able to separate things as much as I would liked.
Still, I hope this change streamlines the implementation, which had evolved quite a bit over the last years.

A PR for the changes for the CodeMirror implementation will follow.

While it looks like this PR contains a lot of changes, most of it is just moving lines around and reorganize things.

---

**Most notable changes**

~Debouncing the completion request was replaced by canceling the search stream instead. This has the effect that results are shown quicker, especially static ones since we don't have to wait anymore. (not sure whether cancelling the stream is a good approach since it will still consume some server resources?; however, through this refactor we could still get faster results for static suggestions and continue to debounce dynamic queries)~ We still debounce but also cancel any running queries. Suggestions that only contain static entries are still faster since we only debounce dynamic suggestions.
Together with this change I refactored how the search request is initiated. Instead of getting an Observable, `getCompletionItems` is now passed a function that returns a promise.

`getSuggestionQuery` was changed to accept the completion type as parameter instead of inferring it from the token. Additionally that type is now being supplied by `completeFilterValue` from the filter's configuration. This makes the relationship between the generated search query and the filter value that is being completed more explicit and easier to follow (IMO).

This PR also fixes the cases where triggering completion in an empty input wouldn't show any suggestions and where triggering completion at a whitespace token would show suggestions for filters and repos (due to empty search query).

---

Videos of before and after behavior (note that the for server side suggestions is unfortunately not comparable because there was much lower network latency when I recorded the new after version 🤷🏻‍♂️ )

Before:

https://user-images.githubusercontent.com/179026/161146499-05936efe-c164-4175-bab7-b00e830afa58.mp4

After (outdated because this version didn't include debouncing dynamic suggestions):

https://user-images.githubusercontent.com/179026/161146538-1cf817d5-5fe5-47c8-98fe-5bde366abddf.mp4




## Test plan

- Unit test
- Opened search page, triggered completion in empty search input and saw filter suggestions
- Typed arbitrary input and verified via the browser dev tools that search streams are cancelled (see video)
## App preview:
- [Link](https://sg-web-fkling-cm-suggestions.onrender.com)

