### PR TITLE
squirrel: Suppress noisy error about unrecognized languages

### DIFF
--- a/cmd/symbols/squirrel/http_handlers.go
+++ b/cmd/symbols/squirrel/http_handlers.go
@@ -16,6 +16,7 @@ import (
 	sitter "github.com/smacker/go-tree-sitter"
 
 	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 // Responds to /localCodeIntel
@@ -58,9 +59,7 @@ func LocalCodeIntelHandler(w http.ResponseWriter, r *http.Request) {
 		_ = json.NewEncoder(w).Encode(nil)
 
 		// Log the error if it's not an unrecognized file extension or unsupported language error.
-		_, isUnrecognizedFileExtension := err.(UnrecognizedFileExtensionError)
-		_, isUnsupportedLanguage := err.(UnsupportedLanguageError)
-		if !isUnrecognizedFileExtension && !isUnsupportedLanguage {
+		if !errors.Is(err, unrecognizedFileExtensionError) && !errors.Is(err, unsupportedLanguageError) {
 			log15.Error("failed to generate local code intel payload", "err", err)
 		}
 

--- a/cmd/symbols/squirrel/http_handlers.go
+++ b/cmd/symbols/squirrel/http_handlers.go
@@ -56,7 +56,14 @@ func LocalCodeIntelHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	if err != nil {
 		_ = json.NewEncoder(w).Encode(nil)
-		log15.Error("failed to generate local code intel payload", "err", err)
+
+		// Log the error if it's not an unrecognized file extension or unsupported language error.
+		_, isUnrecognizedFileExtension := err.(UnrecognizedFileExtensionError)
+		_, isUnsupportedLanguage := err.(UnsupportedLanguageError)
+		if !isUnrecognizedFileExtension && !isUnsupportedLanguage {
+			log15.Error("failed to generate local code intel payload", "err", err)
+		}
+
 		return
 	}
 

--- a/cmd/symbols/squirrel/util.go
+++ b/cmd/symbols/squirrel/util.go
@@ -207,17 +207,8 @@ func WithNodePtr(other Node, newNode *sitter.Node) *Node {
 	}
 }
 
-type UnrecognizedFileExtensionError string
-
-func (e UnrecognizedFileExtensionError) Error() string {
-	return fmt.Sprintf("unrecognized file extension: %s", string(e))
-}
-
-type UnsupportedLanguageError string
-
-func (e UnsupportedLanguageError) Error() string {
-	return fmt.Sprintf("unsupported language: %s", string(e))
-}
+var unrecognizedFileExtensionError = errors.New("unrecognized file extension")
+var unsupportedLanguageError = errors.New("unsupported language")
 
 // Parses a file and returns info about it.
 func (s *SquirrelService) parse(ctx context.Context, repoCommitPath types.RepoCommitPath) (*Node, error) {
@@ -225,12 +216,12 @@ func (s *SquirrelService) parse(ctx context.Context, repoCommitPath types.RepoCo
 
 	langName, ok := extToLang[ext]
 	if !ok {
-		return nil, UnrecognizedFileExtensionError(ext)
+		return nil, unrecognizedFileExtensionError
 	}
 
 	langSpec, ok := langToLangSpec[langName]
 	if !ok {
-		return nil, UnsupportedLanguageError(langName)
+		return nil, unsupportedLanguageError
 	}
 
 	s.parser.SetLanguage(langSpec.language)

--- a/cmd/symbols/squirrel/util.go
+++ b/cmd/symbols/squirrel/util.go
@@ -207,18 +207,30 @@ func WithNodePtr(other Node, newNode *sitter.Node) *Node {
 	}
 }
 
+type UnrecognizedFileExtensionError string
+
+func (e UnrecognizedFileExtensionError) Error() string {
+	return fmt.Sprintf("unrecognized file extension: %s", string(e))
+}
+
+type UnsupportedLanguageError string
+
+func (e UnsupportedLanguageError) Error() string {
+	return fmt.Sprintf("unsupported language: %s", string(e))
+}
+
 // Parses a file and returns info about it.
 func (s *SquirrelService) parse(ctx context.Context, repoCommitPath types.RepoCommitPath) (*Node, error) {
 	ext := strings.TrimPrefix(filepath.Ext(repoCommitPath.Path), ".")
 
 	langName, ok := extToLang[ext]
 	if !ok {
-		return nil, errors.Newf("unrecognized file extension %s", ext)
+		return nil, UnrecognizedFileExtensionError(ext)
 	}
 
 	langSpec, ok := langToLangSpec[langName]
 	if !ok {
-		return nil, errors.Newf("unsupported language %s", langName)
+		return nil, UnsupportedLanguageError(langName)
 	}
 
 	s.parser.SetLanguage(langSpec.language)


### PR DESCRIPTION
This was causing some noisy logs:

```
t=2022-03-31T22:41:34+0000 lvl=eror msg="failed to generate local code intel payload" err="unsupported language python"
t=2022-03-31T22:44:10+0000 lvl=eror msg="failed to generate local code intel payload" err="unsupported language ruby"
t=2022-03-31T22:44:34+0000 lvl=eror msg="failed to generate local code intel payload" err="unsupported language python"
t=2022-03-31T22:44:48+0000 lvl=eror msg="failed to generate local code intel payload" err="unsupported language python"
t=2022-03-31T22:44:59+0000 lvl=eror msg="failed to generate local code intel payload" err="unsupported language python"
t=2022-03-31T22:45:39+0000 lvl=eror msg="failed to generate local code intel payload" err="unsupported language go"
```

## Test plan

Existing tests.

