### PR TITLE
doc: use absolute images for image links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# <a href="https://sourcegraph.com"><picture><source srcset="./ui/assets/img/sourcegraph-head-logo.svg" media="(prefers-color-scheme: dark)"/><img alt="Sourcegraph" src="./ui/assets/img/sourcegraph-logo-light.svg" height="48px" /></picture></a>
+# <a href="https://sourcegraph.com"><picture><source srcset="https://raw.githubusercontent.com/sourcegraph/sourcegraph/main/ui/assets/img/sourcegraph-head-logo.svg" media="(prefers-color-scheme: dark)"/><img alt="Sourcegraph" src="https://raw.githubusercontent.com/sourcegraph/sourcegraph/main/ui/assets/img/sourcegraph-logo-light.svg" height="48px" /></picture></a>
 
 [![build](https://badge.buildkite.com/00bbe6fa9986c78b8e8591cffeb0b0f2e8c4bb610d7e339ff6.svg?branch=main)](https://buildkite.com/sourcegraph/sourcegraph)
 


### PR DESCRIPTION
This allows our README to render correctly in more environments, most notably Sourcegraph itself.

Sourcegraph doesn't have a homegrown mechanism for serving images :disappointed: the `/-/raw` endpoint specifically does not allow images to be served and rendered. Details:
https://sourcegraph.com/github.com/sourcegraph/sourcegraph@main/-/blob/cmd/frontend/internal/app/ui/raw.go?L200%3A3-205%3A80= That means that we won't be able to get the Sourcegraph logo to render without updating the image source in the README to use a full URL rather than a relative URL

Right now, images just fail to load:

<img width="221" alt="image" src="https://user-images.githubusercontent.com/23356519/161170511-dfc9f65e-617c-4b2a-8dff-e328b019bb8a.png">

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

n/a
