### PR TITLE
Add error handling for extension activation event

### DIFF
--- a/client/shared/src/api/extension/activation.ts
+++ b/client/shared/src/api/extension/activation.ts
@@ -166,21 +166,28 @@ export function activateExtensions(
                         return from(
                             Promise.all([
                                 toActivate.map(async ({ id, scriptURL }) => {
-                                    console.log(`Activating Sourcegraph extension: ${id}`)
-
                                     // We only want to log non-default extension events
                                     if (!defaultExtensions[id]) {
                                         // Hash extension IDs that specify host, since that means that it's a private registry extension.
-                                        const telemetryExtensionID = splitExtensionID(id).host ? await hashCode(id) : id
-                                        mainAPI
-                                            .logEvent('ExtensionActivation', {
-                                                extension_id: telemetryExtensionID,
-                                            })
-                                            .catch(() => {
-                                                // noop
-                                            })
+                                        try {
+                                            const telemetryExtensionID = splitExtensionID(id).host
+                                                ? await hashCode(id)
+                                                : id
+                                            mainAPI
+                                                .logEvent('ExtensionActivation', {
+                                                    extension_id: telemetryExtensionID,
+                                                })
+                                                .catch(() => {
+                                                    // noop
+                                                })
+                                        } catch (error) {
+                                            console.error(
+                                                `Fail to log ExtensionActivation event for extension ${id}:`,
+                                                asError(error)
+                                            )
+                                        }
                                     }
-
+                                    console.log(`Activating Sourcegraph extension: ${id}`)
                                     return activate(id, scriptURL, createExtensionAPI).catch(error =>
                                         console.error(`Error activating extension ${id}:`, asError(error))
                                     )


### PR DESCRIPTION
Close: https://github.com/sourcegraph/sourcegraph/issues/33286

Sourcegraph extensions do not run on instances with HTTP connections because the `Crypto.subtle` feature we are using in our hashCode function is only available in [secure contexts](https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts) (HTTPS), which would cause the whole activation process to fail when trying to log the event:
  
![Screen Shot 2022-03-31 at 5 22 01 PM](https://user-images.githubusercontent.com/68532117/161171857-a2ae4553-5458-416a-8252-0dfcbb355101.png)

The PR adds error handling for the event logging step so that failing to log the event would not stop the extension from activating: 

![Screen Shot 2022-03-31 at 5 21 29 PM](https://user-images.githubusercontent.com/68532117/161172091-eb5bb972-766f-4838-9563-c2140f66057e.png)


## Test plan
Added error handling
<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


