### PR TITLE
monitoring: more panels for gitserver janitor jobs

### DIFF
--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -4400,11 +4400,11 @@ Query: `histogram_quantile(0.95, sum(rate(src_gitserver_janitor_job_duration_sec
 
 <br />
 
-#### gitserver: repos_removed
+#### gitserver: janitor_job_failures
 
-<p class="subtitle">Repositories removed due to disk pressure</p>
+<p class="subtitle">Failures over 5m (by job)</p>
 
-Repositories removed due to disk pressure
+the rate of failures over 5m (by job)
 
 This panel has no related alerts.
 
@@ -4415,7 +4415,70 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10022
 <details>
 <summary>Technical details</summary>
 
+Query: `sum by (job_name) (rate(src_gitserver_janitor_job_duration_seconds_count{success="false"}[5m]))`
+
+</details>
+
+<br />
+
+#### gitserver: repos_removed
+
+<p class="subtitle">Repositories removed due to disk pressure</p>
+
+Repositories removed due to disk pressure
+
+This panel has no related alerts.
+
+To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=100230` on your Sourcegraph instance.
+
+<sub>*Managed by the [Sourcegraph Core application team](https://handbook.sourcegraph.com/engineering/core-application).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
 Query: `sum by (instance) (rate(src_gitserver_repos_removed_disk_pressure[5m]))`
+
+</details>
+
+<br />
+
+#### gitserver: sg_maintenance_reason
+
+<p class="subtitle">Successful sg maintenance jobs over 1h (by reason)</p>
+
+the rate of successful sg maintenance jobs and the reason why they were triggered
+
+This panel has no related alerts.
+
+To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=100240` on your Sourcegraph instance.
+
+<sub>*Managed by the [Sourcegraph Core application team](https://handbook.sourcegraph.com/engineering/core-application).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Query: `sum by (reason) (rate(src_gitserver_maintenance_status{success="true"}[1h]))`
+
+</details>
+
+<br />
+
+#### gitserver: git_prune_skipped
+
+<p class="subtitle">Successful git prune jobs over 1h</p>
+
+the rate of successful git prune jobs over 1h and whether they were skipped
+
+This panel has no related alerts.
+
+To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=100250` on your Sourcegraph instance.
+
+<sub>*Managed by the [Sourcegraph Core application team](https://handbook.sourcegraph.com/engineering/core-application).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Query: `sum by (skipped) (rate(src_gitserver_prune_status{success="true"}[1h]))`
 
 </details>
 

--- a/monitoring/definitions/git_server.go
+++ b/monitoring/definitions/git_server.go
@@ -392,6 +392,17 @@ func GitServer() *monitoring.Container {
 					},
 					{
 						{
+							Name:           "janitor_job_failures",
+							Description:    "failures over 5m (by job)",
+							Query:          `sum by (job_name) (rate(src_gitserver_janitor_job_duration_seconds_count{success="false"}[5m]))`,
+							NoAlert:        true,
+							Panel:          monitoring.Panel().LegendFormat("{{job_name}}").Unit(monitoring.Number),
+							Owner:          monitoring.ObservableOwnerCoreApplication,
+							Interpretation: "the rate of failures over 5m (by job)",
+						},
+					},
+					{
+						{
 							Name:           "repos_removed",
 							Description:    "repositories removed due to disk pressure",
 							Query:          "sum by (instance) (rate(src_gitserver_repos_removed_disk_pressure[5m]))",
@@ -399,6 +410,28 @@ func GitServer() *monitoring.Container {
 							Panel:          monitoring.Panel().LegendFormat("{{instance}}").Unit(monitoring.Number),
 							Owner:          monitoring.ObservableOwnerCoreApplication,
 							Interpretation: "Repositories removed due to disk pressure",
+						},
+					},
+					{
+						{
+							Name:           "sg_maintenance_reason",
+							Description:    "successful sg maintenance jobs over 1h (by reason)",
+							Query:          `sum by (reason) (rate(src_gitserver_maintenance_status{success="true"}[1h]))`,
+							NoAlert:        true,
+							Panel:          monitoring.Panel().LegendFormat("{{reason}}").Unit(monitoring.Number),
+							Owner:          monitoring.ObservableOwnerCoreApplication,
+							Interpretation: "the rate of successful sg maintenance jobs and the reason why they were triggered",
+						},
+					},
+					{
+						{
+							Name:           "git_prune_skipped",
+							Description:    "successful git prune jobs over 1h",
+							Query:          `sum by (skipped) (rate(src_gitserver_prune_status{success="true"}[1h]))`,
+							NoAlert:        true,
+							Panel:          monitoring.Panel().LegendFormat("skipped={{skipped}}").Unit(monitoring.Number),
+							Owner:          monitoring.ObservableOwnerCoreApplication,
+							Interpretation: "the rate of successful git prune jobs over 1h and whether they were skipped",
 						},
 					},
 				},


### PR DESCRIPTION
This adds 3 more panels (marked by dashed red rectangles in the screenshot) giving us better insight into the health of the
janitor jobs.

<img width="2495" alt="Screenshot 2022-04-01 at 09 02 08" src="https://user-images.githubusercontent.com/26413131/161214701-6de1e72f-eb38-4997-b0fa-cf67d8e78942.png">

## Test plan
I ran a local instance of Grafana based on the monitoring definitions in this PR and port-forwarded to
the Prometheus instance on dogfood.