### PR TITLE
Revert "bext: add firstSourcegraphUrl to logs (#32719)"

### DIFF
--- a/client/browser/src/browser-extension/manifest.spec.json
+++ b/client/browser/src/browser-extension/manifest.spec.json
@@ -40,7 +40,6 @@
   },
   "dev": {
     "permissions": [
-      "cookies",
       "storage",
       "activeTab",
       "contextMenus",
@@ -53,13 +52,6 @@
     "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAvyGmcOkw4cTnhO0bgl3fQLAdv1jZp8T1ZHYI+4d8FgwwVKLYWE+pAuJ/0LrI69ibed4Nnnw5YleB1xCpI+mzB56xfXWboKp6lljevKqWJ5TpJk/Vam3kSSoZwpmJRXnzmcM3qKpL6viUhTfwGmQO6WVTsN4YCx+KWXv97IyF6yDTgd6hwFsvCZY2n1ADgurrQkE6AcJ3kK4xZ14jaHllXEdFcqwh0+Am5qLcIJ1cNo5iFD35exXsjwdQbmpt8sEk5f95pK5FEEbJFmOTguu2fOZycqIoTgoDrbbhT5k9TUogZaN5Lup0Iwh0Cv60i4C1f7IdPrxHuaYmYCfoUezXnQIDAQAB"
   },
   "prod": {
-    "permissions": [
-      "cookies",
-      "activeTab",
-      "storage",
-      "contextMenus",
-      "https://github.com/*",
-      "https://sourcegraph.com/*"
-    ]
+    "permissions": ["activeTab", "storage", "contextMenus", "https://github.com/*", "https://sourcegraph.com/*"]
   }
 }

--- a/client/browser/src/browser-extension/scripts/backgroundPage.main.ts
+++ b/client/browser/src/browser-extension/scripts/backgroundPage.main.ts
@@ -255,10 +255,6 @@ async function main(): Promise<void> {
         },
 
         fetchCache,
-
-        getCookie(details) {
-            return browser.cookies.get(details)
-        },
     }
 
     // Handle calls from other scripts

--- a/client/browser/src/browser-extension/web-extension-api/runtime.ts
+++ b/client/browser/src/browser-extension/web-extension-api/runtime.ts
@@ -22,5 +22,4 @@ export const background: BackgroundPageApi = {
     notifyRepoSyncError: messageSender('notifyRepoSyncError'),
     checkRepoSyncError: messageSender('checkRepoSyncError'),
     fetchCache: messageSender('fetchCache'),
-    getCookie: messageSender('getCookie'),
 }

--- a/client/browser/src/browser-extension/web-extension-api/types.ts
+++ b/client/browser/src/browser-extension/web-extension-api/types.ts
@@ -98,7 +98,6 @@ export interface BackgroundPageApi {
     notifyRepoSyncError(payload: { sourcegraphURL: string; hasRepoSyncError: boolean }): Promise<void>
     checkRepoSyncError(payload: { tabId: number; sourcegraphURL: string }): Promise<boolean>
     fetchCache: typeof fetchCache
-    getCookie: typeof browser.cookies.get
 }
 
 /**

--- a/client/browser/src/shared/backend/userEvents.tsx
+++ b/client/browser/src/shared/backend/userEvents.tsx
@@ -43,14 +43,7 @@ export const logUserEvent = (
  * Log a raw user action on the associated Sourcegraph instance
  */
 export const logEvent = (
-    event: {
-        name: string
-        userCookieID: string
-        url: string
-        firstSourceURL?: string
-        argument?: string | {}
-        publicArgument?: string | {}
-    },
+    event: { name: string; userCookieID: string; url: string; argument?: string | {}; publicArgument?: string | {} },
     requestGraphQL: PlatformContext['requestGraphQL']
 ): void => {
     requestGraphQL<GQL.IMutation>({

--- a/client/browser/src/shared/tracking/eventLogger.tsx
+++ b/client/browser/src/shared/tracking/eventLogger.tsx
@@ -5,12 +5,11 @@ import * as uuid from 'uuid'
 import { PlatformContext } from '@sourcegraph/shared/src/platform/context'
 import { TelemetryService } from '@sourcegraph/shared/src/telemetry/telemetryService'
 
-import { background } from '../../browser-extension/web-extension-api/runtime'
 import { storage } from '../../browser-extension/web-extension-api/storage'
 import { UserEvent } from '../../graphql-operations'
 import { logUserEvent, logEvent } from '../backend/userEvents'
-import { isBackground, isInPage } from '../context'
-import { getExtensionVersion, getPlatformName, isDefaultSourcegraphUrl } from '../util/context'
+import { isInPage } from '../context'
+import { getExtensionVersion, getPlatformName } from '../util/context'
 
 const uidKey = 'sourcegraphAnonymousUid'
 
@@ -141,22 +140,11 @@ export class EventLogger implements TelemetryService {
         if (userEvent) {
             logUserEvent(userEvent, anonUserId, this.sourcegraphURL, this.requestGraphQL)
         }
-
-        const firstSourceURL = isDefaultSourcegraphUrl(this.sourcegraphURL)
-            ? (
-                  await (isBackground ? browser.cookies.get : background.getCookie)({
-                      url: this.sourcegraphURL,
-                      name: 'sourcegraphSourceUrl',
-                  })
-              )?.value
-            : undefined
-
         logEvent(
             {
                 name: event,
                 userCookieID: anonUserId,
                 url: this.sourcegraphURL,
-                firstSourceURL,
                 argument: { platform: this.platform, version: this.version, ...eventProperties },
                 publicArgument: { platform: this.platform, version: this.version, ...publicArgument },
             },


### PR DESCRIPTION
This reverts commit 07b84091f1d567c58609bf82520da47a91fe110c.
Reverts https://github.com/sourcegraph/sourcegraph/pull/32719

## Test plan
Ensure `firstSourcegraphURL` value is not added to browser extension logs.
## App preview:
- [Link](https://sg-web-taras-yemets-revert-adding-first.onrender.com)

