### PR TITLE
search: optimize pattern expressions to native Zoekt queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 - Fixed reading search pattern type from settings [#32989](https://github.com/sourcegraph/sourcegraph/issues/32989)
 - Display a tooltip and truncate the title of a search result when content overflows [#32904](https://github.com/sourcegraph/sourcegraph/pull/32904)
-- Search patterns containing `and` and `not` expressions are now optimized to evaluate natively on the Zoekt backend for indexed code content and symbol search wherever possible. These kinds of queries are now typically an order of magnitude faster. [#33308](https://github.com/sourcegraph/sourcegraph/pull/33308)
+- Search patterns containing `and` and `not` expressions are now optimized to evaluate natively on the Zoekt backend for indexed code content and symbol search wherever possible. These kinds of queries are now typically an order of magnitude faster. Previous cases where no results were returned for expensive search expressions should now work and return results quickly. [#33308](https://github.com/sourcegraph/sourcegraph/pull/33308)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 - Fixed reading search pattern type from settings [#32989](https://github.com/sourcegraph/sourcegraph/issues/32989)
 - Display a tooltip and truncate the title of a search result when content overflows [#32904](https://github.com/sourcegraph/sourcegraph/pull/32904)
+- Search patterns containing `and` and `not` expressions are now optimized to evaluate natively on the Zoekt backend for indexed code content and symbol search wherever possible. These kinds of queries are now typically an order of magnitude faster. [#33308](https://github.com/sourcegraph/sourcegraph/pull/33308)
 
 ### Removed
 

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -529,13 +529,6 @@ func TestEvaluateAnd(t *testing.T) {
 			wantAlert:    false,
 		},
 		{
-			name:         "zoekt does not return enough matches, not exhausted",
-			query:        "foo and bar index:only count:50",
-			zoektMatches: 0,
-			filesSkipped: 1,
-			wantAlert:    true,
-		},
-		{
 			name:         "zoekt returns enough matches, not exhausted",
 			query:        "foo and bar index:only count:50",
 			zoektMatches: 50,

--- a/internal/search/job/mapper.go
+++ b/internal/search/job/mapper.go
@@ -119,6 +119,8 @@ func (m *Mapper) Map(job Job) Job {
 		return j
 
 	case *repoPagerJob:
+		child := m.Map(j.child)
+		j.child = child
 		if m.MapRepoPagerJob != nil {
 			j = m.MapRepoPagerJob(j)
 		}

--- a/internal/search/query/types.go
+++ b/internal/search/query/types.go
@@ -226,6 +226,16 @@ func (b Basic) PatternString() string {
 	return ""
 }
 
+func (b Basic) IsEmptyPattern() bool {
+	if b.Pattern == nil {
+		return true
+	}
+	if p, ok := b.Pattern.(Pattern); ok {
+		return p.Value == ""
+	}
+	return false
+}
+
 // IncludeExcludeValues partitions multiple values of a field into positive
 // (include) and negated (exclude) values.
 func (b Basic) IncludeExcludeValues(field string) (include, exclude []string) {
@@ -286,6 +296,14 @@ func (q Q) StringValue(field string) (value, negatedValue string) {
 		}
 	})
 	return value, negatedValue
+}
+
+func (q Q) Index() YesNoOnly {
+	v := q.yesNoOnlyValue(FieldIndex)
+	if v == nil {
+		return Yes
+	}
+	return *v
 }
 
 func (q Q) Values(field string) []*Value {

--- a/internal/search/query_converter.go
+++ b/internal/search/query_converter.go
@@ -363,9 +363,9 @@ func QueryToZoektQuery(b query.Basic, resultTypes result.Types, feat *Features, 
 
 // ComputeResultTypes returns result types based three inputs: `type:...` in the query,
 // the `pattern`, and top-level `searchType` (coming from a GQL value).
-func ComputeResultTypes(types []string, pattern string, searchType query.SearchType) result.Types {
+func ComputeResultTypes(types []string, b query.Basic, searchType query.SearchType) result.Types {
 	var rts result.Types
-	if searchType == query.SearchTypeStructural && pattern != "" {
+	if searchType == query.SearchTypeStructural && !b.IsEmptyPattern() {
 		rts = result.TypeStructural
 	} else {
 		if len(types) == 0 {

--- a/internal/search/query_converter_test.go
+++ b/internal/search/query_converter_test.go
@@ -108,7 +108,7 @@ func TestQueryToZoektQuery(t *testing.T) {
 			b, _ := query.ToBasicQuery(sourceQuery)
 
 			types, _ := b.ToParseTree().StringValues(query.FieldType)
-			resultTypes := ComputeResultTypes(types, b.PatternString(), query.SearchTypeRegex)
+			resultTypes := ComputeResultTypes(types, b, query.SearchTypeRegex)
 			got, err := QueryToZoektQuery(b, resultTypes, &tt.Features, tt.Type)
 			if err != nil {
 				t.Fatal("QueryToZoektQuery failed:", err)
@@ -177,11 +177,7 @@ func TestToTextPatternInfo(t *testing.T) {
 		b := plan[0]
 		types, _ := b.ToParseTree().StringValues(query.FieldType)
 		mode := Batch
-		resultTypes := ComputeResultTypes(
-			types,
-			b.PatternString(),
-			query.SearchTypeLiteral,
-		)
+		resultTypes := ComputeResultTypes(types, b, query.SearchTypeLiteral)
 		p := ToTextPatternInfo(b, resultTypes, mode)
 		v, _ := json.Marshal(p)
 		return string(v)


### PR DESCRIPTION
Closes #9824. Hopefully without incident. I'm quite confident in the correctness. I only tested speed a little bit on a local machine. The effect is going to be a much bigger win on larger instances. But you can still see a major difference locally:

Before:

![Screen Shot 2022-04-01 at 3 37 27 AM](https://user-images.githubusercontent.com/888624/161247960-b37d1604-8fdb-4fba-a703-f1224b8732e9.png)


Now:

![Screen Shot 2022-04-01 at 3 35 52 AM](https://user-images.githubusercontent.com/888624/161247948-7c828e8f-88b9-423e-ba63-2ac3000c54ac.png)


The way we optimize is a bit involved. But it is "clean" and predictable, in the sense that it is a small footprint, and generalizes well enough that we can extend the current structure (e.g., for commit queries too, which Camden threatened to do). So yeah, because I don't want to spaghettify our code and actually have a concrete vision of keeping things hygienic and "small" (this ended up being under 100 line addition), this is how it works:

- Create our job tree like we normally would: call `ToSearchJob`

- Do an optimization phase. First:
  - Create a job tree like we normally would: call `ToSearchJob`. But this time, we give it the entire pattern expression by calling it with a `query.Basic` type, but _before_ we do the expression splitting we normally do. The Zoekt jobs created in `ToSearchJob` is _already_ structured to be able to handle this advanced expression type, and not just a simple string. This means that the Zoekt jobs created in this call are the optimized ones, with native Zoekt queries. We get some non-Zoekt jobs back from this tree that are invalid (maybe) because they might still be assuming that they're not dealing with an expression. This does not matter, we care about optimizing Zoekt queries only at this point.
  - To wit, we take this job tree with optimized Zoekt queries and extract them--we just want the atomic jobs, which have optimized Zoekt queries.
  - Now we take our original job tree and _remove_ (trim) all the Zoekt jobs that we've created optimizated versions of. Everything else stays in place. 
  - Now we add our optimized Zoekt jobs to the trimmed version and compose with a `Parallel` job.

Here's a visual example.

## **Default** job tree for: `foo and bar and not baz`

```mermaid
flowchart TB
0([AND])
  0---1
  1([LIMIT])
    1---2
    2[40000]
    1---3
    3([PARALLEL])
      3---4
      4([ZoektGlobalSearch])
      3---5
      5([RepoSearch])
      3---6
      6([ComputeExcludedRepos])
      0---7
  7([LIMIT])
    7---8
    8[40000]
    7---9
    9([PARALLEL])
      9---10
      10([ZoektGlobalSearch])
      9---11
      11([RepoSearch])
      9---12
      12([ComputeExcludedRepos])
      0---13
  13([LIMIT])
    13---14
    14[40000]
    13---15
    15([PARALLEL])
      15---16
      16([ZoektGlobalSearch])
      15---17
      17([RepoSearch])
      15---18
      18([ComputeExcludedRepos])
```

## **Optimized** job tree for: `foo and bar and not baz`

```mermaid
flowchart TB
0([PARALLEL])
  0---1
  1([ZoektGlobalSearch])
  0---2
  2([AND])
    2---3
    3([LIMIT])
      3---4
      4[40000]
      3---5
      5([PARALLEL])
        5---6
        6([NoopJob])
        5---7
        7([RepoSearch])
        5---8
        8([ComputeExcludedRepos])
        2---9
    9([LIMIT])
      9---10
      10[40000]
      9---11
      11([PARALLEL])
        11---12
        12([NoopJob])
        11---13
        13([RepoSearch])
        11---14
        14([ComputeExcludedRepos])
        2---15
    15([LIMIT])
      15---16
      16[40000]
      15---17
      17([PARALLEL])
        17---18
        18([NoopJob])
        17---19
        19([RepoSearch])
        17---20
        20([ComputeExcludedRepos])

```

(don't mind the benign `NoOp` nodes, we will tidy such things later)


---

Optional reading

Why not...?

1. why not create the optimized Zoekt jobs directly from the query? Because there is _so much stuff_ that needs to be computed in order to know _which_ Zoekt jobs to create when (global vs non global, on soucegraph.com, symbol or not, etc.). This is what I tried to keep contained but it is still too difficult to cut through the state. So the solution is: do _exactly_ what we would have done before since we make a second call to `ToSearchJob. We're guaranteed to make the right decisions and not regress on which jobs to create. The static computations are cheap--simplifying the logic and separating the state is what's tricky. I'll continue chugging on this but we are able to have these optimizations now. At some point we may be able to achieve this.

2. why not figure out whether you can add optimized Zoekt queries before doing the default strategy and then just not add the other jobs? Even if we can't create them directly from the query, we can detect whether to add the queries beforehand when creating jobs currently no? Yeah but that would be far less tractable: with our current structure, you would then need to send flags all over the places between functions based on something you did or didn't do before. This is a recipe for disaster. Build an abstraction to manipulate trees and use those abstractions to ensure correctness. Manipulation is cheap and reasoning is sound--mutating state and ad-hoc control flow will destroy us.

---

## Test plan
Added unit tests.

