### PR TITLE
bext: fix "Open on Sourcegraph" button for files with symbols in the filePath

### DIFF
--- a/client/browser/src/browser-extension/scripts/backgroundPage.main.ts
+++ b/client/browser/src/browser-extension/scripts/backgroundPage.main.ts
@@ -69,7 +69,6 @@ const tabRepoSyncErrorCache = (() => {
          * private code on Cloud or not synced repo on other than Cloud Sourcegrpah instance error.
          */
         setTabHasRepoSyncError(tabId: number, hasRepoSyncError: boolean, sourcegraphURL?: string): void {
-            console.log('cache', [...cache.keys()])
             if (sourcegraphURL) {
                 let record = cache.get(tabId)
 

--- a/client/shared/src/util/url.test.ts
+++ b/client/shared/src/util/url.test.ts
@@ -289,6 +289,12 @@ describe('util/url', () => {
                 '/github.com/gorilla/mux/-/blob/mux.go?L1:1#tab=references'
             )
         })
+
+        test('formats url with symbols in filePath', () => {
+            expect(toPrettyBlobURL({ ...context, filePath: '.shellrc/zshrc.d/functions/gdk.sh##class.Work' })).toBe(
+                '/github.com/gorilla/mux/-/blob/.shellrc/zshrc.d/functions/gdk.sh%23%23class.Work'
+            )
+        })
     })
 
     describe('toAbsoluteBlobURL', () => {

--- a/client/shared/src/util/url.ts
+++ b/client/shared/src/util/url.ts
@@ -440,9 +440,10 @@ export function toPrettyBlobURL(
         toPositionOrRangeQueryParameter(target)
     )
     const searchQuery = [...searchParameters].length > 0 ? `?${formatSearchParameters(searchParameters)}` : ''
-    return `/${encodeRepoRevision({ repoName: target.repoName, revision: target.revision })}/-/blob/${
-        target.filePath
-    }${searchQuery}${toViewStateHash(target.viewState)}`
+    return `/${encodeRepoRevision({
+        repoName: target.repoName,
+        revision: target.revision,
+    })}/-/blob/${encodeURIPathComponent(target.filePath)}${searchQuery}${toViewStateHash(target.viewState)}`
 }
 
 /**


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/33310.

## Test plan
- `sg run bext`
- Open https://gitlab.com/pedropombeiro/dotfiles/-/blob/master/.shellrc/zshrc.d/functions/gdk.sh%23%23class.Work#L55-L117
- Check that "Open on Sourcegraph" button on a file toolbar correctly opens file on Sourcegraph
- Check that it works for other files without special symbols in filePath
<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->
## App preview:
- [Link](https://sg-web-erzhtor-fix-open-on-sourcegraph.onrender.com)

