### PR TITLE
Revert "ctags: Do not warn when we can't determine the symbol's column (#33166)

### DIFF
--- a/cmd/symbols/parser/parser.go
+++ b/cmd/symbols/parser/parser.go
@@ -180,13 +180,13 @@ func (p *parser) handleParseRequest(ctx context.Context, symbolOrErrors chan<- S
 		// ⚠️ Careful, ctags lines are 1-indexed!
 		line := e.Line - 1
 		if line < 0 || line >= len(lines) {
-			log15.Warn("ctags returned an invalid line number", "path", parseRequest.Path, "line", e.Line, "len(lines)", len(lines), "symbol", e.Name)
+			log15.Warn("Invalid line number", "entry", e)
 			continue
 		}
 
 		character := strings.Index(lines[line], e.Name)
 		if character == -1 {
-			// Could not find the symbol in the line. ctags doesn't always return the right line.
+			log15.Warn("Could not find symbol on line", "symbol", e.Name, "line", line)
 			character = 0
 		}
 

--- a/enterprise/internal/rockskip/search.go
+++ b/enterprise/internal/rockskip/search.go
@@ -244,13 +244,13 @@ func (s *Service) querySymbols(ctx context.Context, args types.SearchArgs, repoI
 		for _, symbol := range allSymbols {
 			if isMatch(symbol.Name) {
 				if symbol.Line < 0 || symbol.Line >= len(lines) {
-					log15.Warn("ctags returned an invalid line number", "path", path, "line", symbol.Line, "len(lines)", len(lines), "symbol", symbol.Name)
+					log15.Warn("symbol.Line out of range, skipping", "symbol", symbol, "lines", len(lines))
 					continue
 				}
 
 				character := strings.Index(lines[symbol.Line], symbol.Name)
 				if character == -1 {
-					// Could not find the symbol in the line. ctags doesn't always return the right line.
+					log15.Warn("symbol.Name not found in line, setting to 0", "path", path, "symbol", symbol.Name, "line", lines[symbol.Line])
 					character = 0
 				}
 

--- a/internal/search/result/symbol.go
+++ b/internal/search/result/symbol.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/inconshreveable/log15"
 	"github.com/sourcegraph/go-lsp"
 )
 
@@ -36,8 +37,8 @@ func NewSymbolMatch(file *File, lineNumber, character int, name, kind, parent, p
 		character = strings.Index(line, name)
 
 		if character == -1 {
-			// We couldn't find the symbol in the line, so set the column to 0. ctags doesn't always
-			// return the right line.
+			// We couldn't find the symbol in the line, so set the column to 0.
+			log15.Warn("Could not infer symbol column", "file", file.Path, "line", lineNumber, "name", name)
 			character = 0
 		}
 	}


### PR DESCRIPTION
This reverts commit 75ce0b0022aa4bc6ea0519bb4685b90fdc0155f4.

Checking if this fixes the e2e test failures, since buildkite is sad.

## Test plan

Running tests via main-dry-run.