### PR TITLE
skip flaky test

### DIFF
--- a/client/web/src/end-to-end/end-to-end.test.ts
+++ b/client/web/src/end-to-end/end-to-end.test.ts
@@ -651,10 +651,10 @@ describe('e2e test suite', () => {
                         )
                     })
                 })
-
+                // TODO re-enable once flake is identified @frontend-platform team
                 describe('find references', () => {
-                    test('opens widget and fetches local references', async function () {
-                        this.timeout(120000)
+                    test.skip('opens widget and fetches local references', async () => {
+                        // this.timeout(120000)
 
                         await driver.page.goto(
                             sourcegraphBaseUrl +


### PR DESCRIPTION
Removes flaky e2e test that is blocking main


## Test plan

test on main-dry-run https://buildkite.com/sourcegraph/sourcegraph/builds?branch=main-dry-run%2Fdt%2Fflaky_test

## App preview:
- [Link](https://sg-web-dt-flaky-test.onrender.com)

