### PR TITLE
hackathon: load code insights inside notebooks (do not merge)

### DIFF
--- a/client/web/src/enterprise/notebooks/blocks/insights/NotebookInsightsBlock.tsx
+++ b/client/web/src/enterprise/notebooks/blocks/insights/NotebookInsightsBlock.tsx
@@ -1,0 +1,40 @@
+import React, { useMemo } from 'react'
+
+import { useLocation } from 'react-router'
+import { of } from 'rxjs'
+
+import { useObservable } from '@sourcegraph/wildcard'
+
+import { ErrorBoundary } from '../../../../components/ErrorBoundary'
+import { NotebookInsightsBlockProps } from '../../../../notebooks/blocks/insights/NotebooksInightsBlock'
+import { SmartInsight } from '../../../insights/components/insights-view-grid/components/smart-insight/SmartInsight'
+import { CodeInsightsBackendContext } from '../../../insights/core/backend/code-insights-backend-context'
+import { useGetApi } from '../../../insights/hooks/use-get-api'
+
+export const NotebookInsightsBlock: React.FunctionComponent<NotebookInsightsBlockProps> = React.memo(
+    ({ id, telemetryService }) => {
+        const location = useLocation()
+
+        return (
+            <ErrorBoundary location={location} render={error => <div>Error: {error.message}</div>}>
+                <NotebookInsightsBlockInner id={id} telemetryService={telemetryService} />
+            </ErrorBoundary>
+        )
+    }
+)
+
+const NotebookInsightsBlockInner: React.FunctionComponent<NotebookInsightsBlockProps> = ({
+    id,
+    telemetryService,
+}: NotebookInsightsBlockProps) => {
+    const api = useGetApi()
+    const insight = useObservable(useMemo(() => (api ? api.getInsightById(id) : of(null)), [api, id]))
+
+    return insight && api ? (
+        <CodeInsightsBackendContext.Provider value={api}>
+            <SmartInsight insight={insight} telemetryService={telemetryService} style={{ height: '300px' }} />
+        </CodeInsightsBackendContext.Provider>
+    ) : (
+        <div>No insight</div>
+    )
+}

--- a/client/web/src/notebooks/blocks/insights/NotebooksInightsBlock.tsx
+++ b/client/web/src/notebooks/blocks/insights/NotebooksInightsBlock.tsx
@@ -1,0 +1,3 @@
+import React from 'react'
+
+export const NotebookInsightsBlock: React.FunctionComponent<{}> = React.memo(() => <div>Hello world</div>)

--- a/client/web/src/notebooks/blocks/insights/NotebooksInightsBlock.tsx
+++ b/client/web/src/notebooks/blocks/insights/NotebooksInightsBlock.tsx
@@ -1,3 +1,30 @@
-import React from 'react'
+import React, { useMemo } from 'react'
 
-export const NotebookInsightsBlock: React.FunctionComponent<{}> = React.memo(() => <div>Hello world</div>)
+import { of } from 'rxjs'
+
+import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
+import { useObservable } from '@sourcegraph/wildcard'
+
+import { SmartInsight } from '../../../enterprise/insights/components/insights-view-grid/components/smart-insight/SmartInsight'
+import { CodeInsightsBackendContext } from '../../../enterprise/insights/core/backend/code-insights-backend-context'
+import { useGetApi } from '../../../enterprise/insights/hooks/use-get-api'
+
+interface NotebookInsightsBlockProps extends TelemetryProps {
+    id: string
+}
+
+export const NotebookInsightsBlock: React.FunctionComponent<NotebookInsightsBlockProps> = React.memo(
+    ({ id, telemetryService }) => {
+        const api = useGetApi()
+
+        const insight = useObservable(useMemo(() => (api ? api.getInsightById(id) : of(null)), [api, id]))
+
+        return insight && api ? (
+            <CodeInsightsBackendContext.Provider value={api}>
+                <SmartInsight insight={insight} telemetryService={telemetryService} style={{ height: '300px' }} />
+            </CodeInsightsBackendContext.Provider>
+        ) : (
+            <div>No insight</div>
+        )
+    }
+)

--- a/client/web/src/notebooks/blocks/insights/NotebooksInightsBlock.tsx
+++ b/client/web/src/notebooks/blocks/insights/NotebooksInightsBlock.tsx
@@ -1,30 +1,11 @@
-import React, { useMemo } from 'react'
-
-import { of } from 'rxjs'
+import React from 'react'
 
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
-import { useObservable } from '@sourcegraph/wildcard'
 
-import { SmartInsight } from '../../../enterprise/insights/components/insights-view-grid/components/smart-insight/SmartInsight'
-import { CodeInsightsBackendContext } from '../../../enterprise/insights/core/backend/code-insights-backend-context'
-import { useGetApi } from '../../../enterprise/insights/hooks/use-get-api'
-
-interface NotebookInsightsBlockProps extends TelemetryProps {
+export interface NotebookInsightsBlockProps extends TelemetryProps {
     id: string
 }
 
-export const NotebookInsightsBlock: React.FunctionComponent<NotebookInsightsBlockProps> = React.memo(
-    ({ id, telemetryService }) => {
-        const api = useGetApi()
-
-        const insight = useObservable(useMemo(() => (api ? api.getInsightById(id) : of(null)), [api, id]))
-
-        return insight && api ? (
-            <CodeInsightsBackendContext.Provider value={api}>
-                <SmartInsight insight={insight} telemetryService={telemetryService} style={{ height: '300px' }} />
-            </CodeInsightsBackendContext.Provider>
-        ) : (
-            <div>No insight</div>
-        )
-    }
-)
+export const NotebookInsightsBlock: React.FunctionComponent<NotebookInsightsBlockProps> = React.memo(() => (
+    <div>Code Insights not enabled</div>
+))

--- a/client/web/src/notebooks/notebook/NotebookComponent.story.tsx
+++ b/client/web/src/notebooks/notebook/NotebookComponent.story.tsx
@@ -13,6 +13,7 @@ import {
 
 import { BlockInit } from '..'
 import { WebStory } from '../../components/WebStory'
+import { NotebookInsightsBlock } from '../blocks/insights/NotebooksInightsBlock'
 
 import { NotebookComponent } from './NotebookComponent'
 
@@ -56,6 +57,7 @@ add('default', () => (
                 platformContext={NOOP_PLATFORM_CONTEXT}
                 exportedFileName="notebook.snb.md"
                 onCopyNotebook={() => NEVER}
+                NotebookInsightsBlock={NotebookInsightsBlock}
             />
         )}
     </WebStory>
@@ -82,6 +84,7 @@ add('default read-only', () => (
                 platformContext={NOOP_PLATFORM_CONTEXT}
                 exportedFileName="notebook.snb.md"
                 onCopyNotebook={() => NEVER}
+                NotebookInsightsBlock={NotebookInsightsBlock}
             />
         )}
     </WebStory>

--- a/client/web/src/notebooks/notebook/NotebookComponent.tsx
+++ b/client/web/src/notebooks/notebook/NotebookComponent.tsx
@@ -37,7 +37,7 @@ import { PageRoutes } from '../../routes.constants'
 import { SearchStreamingProps } from '../../search'
 import { NotebookComputeBlock } from '../blocks/compute/NotebookComputeBlock'
 import { NotebookFileBlock } from '../blocks/file/NotebookFileBlock'
-import { NotebookInsightsBlock } from '../blocks/insights/NotebooksInightsBlock'
+import { NotebookInsightsBlockProps } from '../blocks/insights/NotebooksInightsBlock'
 import { NotebookMarkdownBlock } from '../blocks/markdown/NotebookMarkdownBlock'
 import { NotebookQueryBlock } from '../blocks/query/NotebookQueryBlock'
 import { NotebookSymbolBlock } from '../blocks/symbol/NotebookSymbolBlock'
@@ -68,6 +68,8 @@ export interface NotebookComponentProps
     isEmbedded?: boolean
     onSerializeBlocks: (blocks: Block[]) => void
     onCopyNotebook: (props: Omit<CopyNotebookProps, 'title'>) => Observable<NotebookFields>
+
+    NotebookInsightsBlock: React.ComponentType<NotebookInsightsBlockProps>
 }
 
 const LOADING = 'LOADING' as const
@@ -115,6 +117,7 @@ export const NotebookComponent: React.FunctionComponent<NotebookComponentProps> 
         globbing,
         searchContextsEnabled,
         settingsCascade,
+        NotebookInsightsBlock,
     }) => {
         const notebook = useMemo(
             () =>
@@ -547,7 +550,7 @@ export const NotebookComponent: React.FunctionComponent<NotebookComponentProps> 
                 <div>
                     <NotebookBlockSeparator isReadOnly={isReadOnly} index={blocks.length} onAddBlock={onAddBlock} />
                     <NotebookInsightsBlock
-                        id="aW5zaWdodF92aWV3OiIyNzI0THE4YVFoSWJxdnBBcHBRTWhQTzNuRm4i"
+                        id="aW5zaWdodF92aWV3OiIyNzJFbWU4TmVVZjRocGlLVVhSUkJlN3NDVUIi"
                         telemetryService={telemetryService}
                     />
                 </div>

--- a/client/web/src/notebooks/notebook/NotebookComponent.tsx
+++ b/client/web/src/notebooks/notebook/NotebookComponent.tsx
@@ -37,6 +37,7 @@ import { PageRoutes } from '../../routes.constants'
 import { SearchStreamingProps } from '../../search'
 import { NotebookComputeBlock } from '../blocks/compute/NotebookComputeBlock'
 import { NotebookFileBlock } from '../blocks/file/NotebookFileBlock'
+import { NotebookInsightsBlock } from '../blocks/insights/NotebooksInightsBlock'
 import { NotebookMarkdownBlock } from '../blocks/markdown/NotebookMarkdownBlock'
 import { NotebookQueryBlock } from '../blocks/query/NotebookQueryBlock'
 import { NotebookSymbolBlock } from '../blocks/symbol/NotebookSymbolBlock'
@@ -543,6 +544,10 @@ export const NotebookComponent: React.FunctionComponent<NotebookComponentProps> 
                         {renderBlock(block)}
                     </div>
                 ))}
+                <div>
+                    <NotebookBlockSeparator isReadOnly={isReadOnly} index={blocks.length} onAddBlock={onAddBlock} />
+                    <NotebookInsightsBlock />
+                </div>
                 {!isReadOnly && (
                     <NotebookCommandPaletteInput
                         ref={commandPaletteInputReference}

--- a/client/web/src/notebooks/notebook/NotebookComponent.tsx
+++ b/client/web/src/notebooks/notebook/NotebookComponent.tsx
@@ -546,7 +546,10 @@ export const NotebookComponent: React.FunctionComponent<NotebookComponentProps> 
                 ))}
                 <div>
                     <NotebookBlockSeparator isReadOnly={isReadOnly} index={blocks.length} onAddBlock={onAddBlock} />
-                    <NotebookInsightsBlock />
+                    <NotebookInsightsBlock
+                        id="aW5zaWdodF92aWV3OiIyNzI0THE4YVFoSWJxdnBBcHBRTWhQTzNuRm4i"
+                        telemetryService={telemetryService}
+                    />
                 </div>
                 {!isReadOnly && (
                     <NotebookCommandPaletteInput

--- a/client/web/src/notebooks/notebook/NotebookComponent.tsx
+++ b/client/web/src/notebooks/notebook/NotebookComponent.tsx
@@ -550,7 +550,7 @@ export const NotebookComponent: React.FunctionComponent<NotebookComponentProps> 
                 <div>
                     <NotebookBlockSeparator isReadOnly={isReadOnly} index={blocks.length} onAddBlock={onAddBlock} />
                     <NotebookInsightsBlock
-                        id="aW5zaWdodF92aWV3OiIyNzJFbWU4TmVVZjRocGlLVVhSUkJlN3NDVUIi"
+                        id="aW5zaWdodF92aWV3OiIyNzRFOVJvM3hsWjdPWjBaT3NCZUZQNTdRNVAi"
                         telemetryService={telemetryService}
                     />
                 </div>

--- a/client/web/src/notebooks/notebookPage/EmbeddedNotebookPage.tsx
+++ b/client/web/src/notebooks/notebookPage/EmbeddedNotebookPage.tsx
@@ -14,6 +14,7 @@ import { createPlatformContext } from '../../platform/context'
 import { fetchHighlightedFileLineRanges } from '../../repo/backend'
 import { eventLogger } from '../../tracking/eventLogger'
 import { fetchNotebook } from '../backend'
+import { NotebookInsightsBlock } from '../blocks/insights/NotebooksInightsBlock'
 import { convertNotebookTitleToFileName } from '../serialize'
 
 import { NotebookContent, NotebookContentProps } from './NotebookContent'
@@ -80,6 +81,7 @@ export const EmbeddedNotebookPage: React.FunctionComponent<EmbeddedNotebookPageP
                     // Copying is not supported in embedded notebooks
                     onCopyNotebook={() => NEVER}
                     isEmbedded={true}
+                    NotebookInsightsBlock={NotebookInsightsBlock}
                 />
             )}
         </div>

--- a/client/web/src/notebooks/notebookPage/NotebookContent.tsx
+++ b/client/web/src/notebooks/notebookPage/NotebookContent.tsx
@@ -13,6 +13,7 @@ import { ThemeProps } from '@sourcegraph/shared/src/theme'
 import { Block, BlockInit } from '..'
 import { NotebookFields } from '../../graphql-operations'
 import { SearchStreamingProps } from '../../search'
+import { NotebookInsightsBlockProps } from '../blocks/insights/NotebooksInightsBlock'
 import { CopyNotebookProps } from '../notebook'
 import { NotebookComponent } from '../notebook/NotebookComponent'
 
@@ -30,6 +31,8 @@ export interface NotebookContentProps
     isEmbedded?: boolean
     onUpdateBlocks: (blocks: Block[]) => void
     onCopyNotebook: (props: Omit<CopyNotebookProps, 'title'>) => Observable<NotebookFields>
+
+    NotebookInsightsBlock: React.ComponentType<NotebookInsightsBlockProps>
 }
 
 export const NotebookContent: React.FunctionComponent<NotebookContentProps> = React.memo(
@@ -51,6 +54,7 @@ export const NotebookContent: React.FunctionComponent<NotebookContentProps> = Re
         settingsCascade,
         platformContext,
         extensionsController,
+        NotebookInsightsBlock,
     }) => {
         const initializerBlocks: BlockInit[] = useMemo(
             () =>
@@ -102,6 +106,7 @@ export const NotebookContent: React.FunctionComponent<NotebookContentProps> = Re
                 onSerializeBlocks={viewerCanManage ? onUpdateBlocks : noop}
                 exportedFileName={exportedFileName}
                 onCopyNotebook={onCopyNotebook}
+                NotebookInsightsBlock={NotebookInsightsBlock}
             />
         )
     }

--- a/client/web/src/notebooks/notebookPage/NotebookPage.tsx
+++ b/client/web/src/notebooks/notebookPage/NotebookPage.tsx
@@ -36,6 +36,7 @@ import {
     createNotebookStar as _createNotebookStar,
     deleteNotebookStar as _deleteNotebookStar,
 } from '../backend'
+import { NotebookInsightsBlockProps } from '../blocks/insights/NotebooksInightsBlock'
 import { copyNotebook as _copyNotebook, CopyNotebookProps } from '../notebook'
 import { blockToGQLInput, convertNotebookTitleToFileName, GQLBlockToGQLInput } from '../serialize'
 
@@ -61,6 +62,8 @@ interface NotebookPageProps
     createNotebookStar?: typeof _createNotebookStar
     deleteNotebookStar?: typeof _deleteNotebookStar
     copyNotebook?: typeof _copyNotebook
+
+    NotebookInsightsBlock: React.ComponentType<NotebookInsightsBlockProps>
 }
 
 const LOADING = 'loading' as const
@@ -90,6 +93,7 @@ export const NotebookPage: React.FunctionComponent<NotebookPageProps> = ({
     platformContext,
     extensionsController,
     match,
+    NotebookInsightsBlock,
 }) => {
     useEffect(() => telemetryService.logViewEvent('SearchNotebookPage'), [telemetryService])
 
@@ -290,6 +294,7 @@ export const NotebookPage: React.FunctionComponent<NotebookPageProps> = ({
                             settingsCascade={settingsCascade}
                             platformContext={platformContext}
                             extensionsController={extensionsController}
+                            NotebookInsightsBlock={NotebookInsightsBlock}
                         />
                         <div className={styles.spacer} />
                     </>

--- a/client/web/src/repo/blob/BlobPage.tsx
+++ b/client/web/src/repo/blob/BlobPage.tsx
@@ -26,6 +26,7 @@ import { BreadcrumbSetters } from '../../components/Breadcrumbs'
 import { HeroPage } from '../../components/HeroPage'
 import { PageTitle } from '../../components/PageTitle'
 import { render as renderLsifHtml } from '../../lsif/html'
+import { NotebookInsightsBlock } from '../../notebooks/blocks/insights/NotebooksInightsBlock'
 import { copyNotebook, CopyNotebookProps } from '../../notebooks/notebook'
 import { SearchStreamingProps } from '../../search'
 import { useSearchStack, useExperimentalFeatures } from '../../stores'
@@ -343,6 +344,7 @@ export const BlobPage: React.FunctionComponent<Props> = props => {
                     onCopyNotebook={onCopyNotebook}
                     showSearchContext={showSearchContext}
                     exportedFileName={basename(blobInfoOrError.filePath)}
+                    NotebookInsightsBlock={NotebookInsightsBlock}
                 />
             )}
             {!isSearchNotebook && blobInfoOrError.richHTML && renderMode === 'rendered' && (

--- a/client/web/src/routes.tsx
+++ b/client/web/src/routes.tsx
@@ -10,6 +10,7 @@ import { CodeIntelligenceProps } from './codeintel'
 import { communitySearchContextsRoutes } from './communitySearchContexts/routes'
 import { BreadcrumbsProps, BreadcrumbSetters } from './components/Breadcrumbs'
 import type { LayoutProps } from './Layout'
+import { NotebookInsightsBlock } from './notebooks/blocks/insights/NotebooksInightsBlock'
 import { CreateNotebookPage } from './notebooks/createPage/CreateNotebookPage'
 import { NotebooksListPage } from './notebooks/listPage/NotebooksListPage'
 import { InstallGitHubAppSuccessPage } from './org/settings/codeHosts/InstallGitHubAppSuccessPage'
@@ -114,7 +115,7 @@ export const routes: readonly LayoutRouteProps<any>[] = [
             const { showSearchNotebook, showSearchContext } = useExperimentalFeatures.getState()
 
             return showSearchNotebook ? (
-                <NotebookPage {...props} showSearchContext={showSearchContext ?? false} />
+                <NotebookPage {...props} showSearchContext={showSearchContext ?? false} NotebookInsightsBlock={NotebookInsightsBlock} />
             ) : (
                 <Redirect to={PageRoutes.Search} />
             )


### PR DESCRIPTION
This hackathon project loads a code insights block instead notebooks. Right now, the block is hardcoded to a specific insight and to the bottom of every notebook. This is a proof-of-concept to get code insights to load inside of notebooks, which is non-trivial due to code insights being enterprise code and notebooks being OSS code. The enterprise router overrides the notebooks path to inject the full enterprise code insights block.