### PR TITLE
insights: add check for issue to be a code insights issue before adding to the project

### DIFF
--- a/.github/workflows/update-project-items.ps1
+++ b/.github/workflows/update-project-items.ps1
@@ -95,6 +95,11 @@ switch ($github.event_name) {
                 Send-SlackMessage -Uri $SlackWebhookUri
 
         } else {
+            if ($github.event.issue.labels.labels -notcontains $TeamLabel) {
+                Write-Information "Closed / re-opened issue labeled with non-team label ($($github.event.label.name)), exiting."
+                return
+            }
+
             # If issue was closed or reopened, update Status column
             $status = if ($github.event.action -eq 'closed') { 'Done' } else { 'In Progress' }
 

--- a/.github/workflows/update-project-items.ps1
+++ b/.github/workflows/update-project-items.ps1
@@ -95,7 +95,7 @@ switch ($github.event_name) {
                 Send-SlackMessage -Uri $SlackWebhookUri
 
         } else {
-            if ($github.event.issue.labels.labels -notcontains $TeamLabel) {
+            if ($github.event.issue.labels -notcontains $TeamLabel) {
                 Write-Information "Closed / re-opened issue labeled with non-team label ($($github.event.label.name)), exiting."
                 return
             }

--- a/.github/workflows/update-project-items.ps1
+++ b/.github/workflows/update-project-items.ps1
@@ -95,8 +95,8 @@ switch ($github.event_name) {
                 Send-SlackMessage -Uri $SlackWebhookUri
 
         } else {
-            if ($github.event.issue.labels -notcontains $TeamLabel) {
-                Write-Information "Closed / re-opened issue labeled with non-team label ($($github.event.label.name)), exiting."
+            if ($github.event.issue.labels | Where-Object { $_.name -eq  $TeamLabel }) {
+                Write-Information "Closed / re-opened issue labeled without team label $TeamLabel, exiting."
                 return
             }
 


### PR DESCRIPTION
We are accidentally adding any issue that is marked done or re-opened to our project. This adds a check that the issue contains the team label. 

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


