### PR TITLE
dev/ci: try to de-emphasize log upload

### DIFF
--- a/.buildkite/hooks/pre-exit
+++ b/.buildkite/hooks/pre-exit
@@ -7,24 +7,25 @@
 set -e # Not -u because $SOFT_FAIL_EXIT_CODES may not be bound
 
 if [[ "$BUILDKITE_PIPELINE_NAME" != "sourcegraph" ]]; then
-    exit 0
+  exit 0
 fi
 
 if [ "$BUILDKITE_BRANCH" == "main" ]; then
-    if [ "$BUILDKITE_COMMAND_EXIT_STATUS" -eq 0 ]; then
-        # If the job exit code is either 0 or a soft failt exit code defined by that step, do nothing.
-        exit 0
+  if [ "$BUILDKITE_COMMAND_EXIT_STATUS" -eq 0 ]; then
+    # If the job exit code is either 0 or a soft failt exit code defined by that step, do nothing.
+    exit 0
+  fi
+
+  # Turn the string of exit codes "1 2 3 4" into an array of strings
+  IFS=' ' read -ra codes <<<"$SOFT_FAIL_EXIT_CODES"
+  for code in "${codes[@]}"; do
+    if [ "$code" == "$BUILDKITE_COMMAND_EXIT_STATUS" ]; then
+      # If the Buildkite exit code is a soft fail, do nothing either.
+      exit 0
     fi
+  done
 
-    # Turn the string of exit codes "1 2 3 4" into an array of strings
-    IFS=' ' read -ra codes <<<"$SOFT_FAIL_EXIT_CODES"
-    for code in "${codes[@]}"; do
-        if [ "$code" == "$BUILDKITE_COMMAND_EXIT_STATUS" ]; then
-            # If the Buildkite exit code is a soft fail, do nothing either.
-            exit 0
-        fi
-    done
-
-    # Non-zero exit code and not a soft fail: upload the logs.
-    ./enterprise/dev/ci/scripts/upload-build-logs.sh
+  # Non-zero exit code and not a soft fail: upload the logs.
+  echo "--- Uploading build logs: this only runs if your build has already failed, check the logs above, NOT below!"
+  ./enterprise/dev/ci/scripts/upload-build-logs.sh
 fi

--- a/enterprise/dev/ci/scripts/upload-build-logs.sh
+++ b/enterprise/dev/ci/scripts/upload-build-logs.sh
@@ -24,7 +24,7 @@ set -euo pipefail
 
 cd "$(dirname "${BASH_SOURCE[0]}")"/../../../..
 
-echo "--- :go: Building sg"
+echo "~~~ :go: Building sg"
 (
   set -x
   pushd dev/sg
@@ -32,7 +32,7 @@ echo "--- :go: Building sg"
   popd
 )
 
-echo "--- :file_cabinet: Uploading logs"
+echo "~~~ :file_cabinet: Uploading logs"
 
 # Because we are running this script in the buildkite post-exit hook, the state of the job is still "running".
 # Passing --state="" just overrides the default. It's not set to any specific state because this script caller


### PR DESCRIPTION
This is often a source of confusion - the log upload might look like the cause of a build failure, but it only ever runs if the build has already fails. This tries to de-emphasize its log output to point towards the real issue.

(Log upload sometimes fails for some reason for another, often log lines that are too long. It's mostly a convenience tool for maintaining observability, and some logs failing to upload is not critical)


## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

n/a
