### PR TITLE
Main dry run/dt/stateless qa

### DIFF
--- a/client/shared/src/testing/config.ts
+++ b/client/shared/src/testing/config.ts
@@ -93,7 +93,7 @@ const configFields: ConfigFields = {
             'Cilent secret of the GitHub app to use to authenticate to Sourcegraph. Follow these instructions to obtain: https://developer.github.com/apps/building-oauth-apps/creating-an-oauth-app/',
     },
     gitHubDotComToken: {
-        envVar: 'BUILDKITE_GITHUBDOTCOM_TOKEN',
+        envVar: 'GH_TOKEN',
         description:
             'A Github personal token with access to private repos used for e2e tests.',
     },

--- a/client/shared/src/testing/config.ts
+++ b/client/shared/src/testing/config.ts
@@ -94,8 +94,7 @@ const configFields: ConfigFields = {
     },
     gitHubDotComToken: {
         envVar: 'GH_TOKEN',
-        description:
-            'A Github personal token with access to private repos used for e2e tests.',
+        description: 'A Github personal token with access to private repos used for e2e tests.',
     },
     gitHubToken: {
         envVar: 'GITHUB_TOKEN',

--- a/client/shared/src/testing/config.ts
+++ b/client/shared/src/testing/config.ts
@@ -30,6 +30,7 @@ export interface Config {
     headless: boolean
     keepBrowser: boolean
     bitbucketCloudUserBobAppPassword: string
+    gitHubDotComToken: string
 }
 
 interface Field<T = string> {
@@ -90,6 +91,11 @@ const configFields: ConfigFields = {
         envVar: 'GITHUB_CLIENT_SECRET',
         description:
             'Cilent secret of the GitHub app to use to authenticate to Sourcegraph. Follow these instructions to obtain: https://developer.github.com/apps/building-oauth-apps/creating-an-oauth-app/',
+    },
+    gitHubDotComToken: {
+        envVar: 'BUILDKITE_GITHUBDOTCOM_TOKEN',
+        description:
+            'A Github personal token with access to private repos used for e2e tests.',
     },
     gitHubToken: {
         envVar: 'GITHUB_TOKEN',

--- a/client/web/src/end-to-end/end-to-end.test.ts
+++ b/client/web/src/end-to-end/end-to-end.test.ts
@@ -10,7 +10,7 @@ import { createDriverForTest, Driver, percySnapshot } from '@sourcegraph/shared/
 import { afterEachSaveScreenshotIfFailed } from '@sourcegraph/shared/src/testing/screenshotReporter'
 import { retry } from '@sourcegraph/shared/src/testing/utils'
 
-const { gitHubToken, sourcegraphBaseUrl } = getConfig('gitHubToken', 'sourcegraphBaseUrl')
+const { gitHubDotComToken, sourcegraphBaseUrl } = getConfig('gitHubDotComToken', 'sourcegraphBaseUrl')
 
 describe('e2e test suite', () => {
     let driver: Driver
@@ -51,7 +51,7 @@ describe('e2e test suite', () => {
             displayName: 'test-test-github',
             config: JSON.stringify({
                 url: 'https://github.com',
-                token: gitHubToken,
+                token: gitHubDotComToken,
                 repos: clonedRepoSlugs.concat(alwaysCloningRepoSlugs),
             }),
             ensureRepos: clonedRepoSlugs.map(slug => `github.com/${slug}`),

--- a/enterprise/dev/ci/internal/ci/operations.go
+++ b/enterprise/dev/ci/internal/ci/operations.go
@@ -523,7 +523,6 @@ func codeIntelQA(candidateTag string) operations.Operation {
 func serverE2E(candidateTag string) operations.Operation {
 	return func(p *bk.Pipeline) {
 		p.AddStep(":chromium: Sourcegraph E2E",
-			bk.Agent("queue", bk.AgentQueueBaremetal),
 			// Run tests against the candidate server image
 			bk.DependsOn(candidateImageStepKey("server")),
 			bk.Env("CANDIDATE_VERSION", candidateTag),

--- a/enterprise/dev/ci/internal/ci/operations.go
+++ b/enterprise/dev/ci/internal/ci/operations.go
@@ -541,7 +541,6 @@ func serverE2E(candidateTag string) operations.Operation {
 func serverQA(candidateTag string) operations.Operation {
 	return func(p *bk.Pipeline) {
 		p.AddStep(":docker::chromium: Sourcegraph QA",
-			bk.Agent("queue", bk.AgentQueueBaremetal),
 			// Run tests against the candidate server image
 			bk.DependsOn(candidateImageStepKey("server")),
 			bk.Env("CANDIDATE_VERSION", candidateTag),
@@ -561,7 +560,6 @@ func serverQA(candidateTag string) operations.Operation {
 func testUpgrade(candidateTag, minimumUpgradeableVersion string) operations.Operation {
 	return func(p *bk.Pipeline) {
 		p.AddStep(":docker::arrow_double_up: Sourcegraph Upgrade",
-			bk.Agent("queue", bk.AgentQueueBaremetal),
 			// Run tests against the candidate server image
 			bk.DependsOn(candidateImageStepKey("server")),
 			bk.Env("CANDIDATE_VERSION", candidateTag),


### PR DESCRIPTION
Moves e2e/qa onto stateless agents. 

The GH token addition/change is required because we have two github tokens, one of which access private repos in the sourcegraph org, in the case of the e2e test it is [this repo](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/client/web/src/end-to-end/end-to-end.test.ts?L44&subtree=true)

This token existed on the e2e/baremetal setup as GITHUB_TOKEN, hence its addition here.

NOTE: don't merge until puppetize tests are fixed on main

## Test plan

main-dry-run on this PR


