### PR TITLE
Cleary the removal of view repo button from browser extension in doc

### DIFF
--- a/doc/integration/browser_extension.md
+++ b/doc/integration/browser_extension.md
@@ -117,7 +117,9 @@ Follow these instructions:
 
 The most common problem is:
 
-### No code intelligence or buttons ("View repository", "View file", etc.) are displayed on the code host
+### No code intelligence or buttons ("View file", "View diff") are displayed on the code host
+
+Note there used to be a "View repository" button on the repository page, but has been removed. This is not a malfunction. Continue if there is no button being displayed on the file/diff specific page.
 
 ![Browser extension not working on code host](https://sourcegraphstatic.com/BrowserExtensionNotWorkingCodeHost.gif)
 


### PR DESCRIPTION
Doc edit only.

The "View repository on Sourcegraph" button has been removed at [commit 56c6c7](https://github.com/sourcegraph/sourcegraph/commit/56c6c7bdca2578ca2f51685332db0195d39f73f5#r70371251), but the [button-missing troubleshooting section](https://docs.sourcegraph.com/integration/browser_extension#troubleshooting) of the doc does not mention this, and includes "View repository" button as a example.

This can be a bit confusing, especially for those who used to use the "View repository" button, they may think this is a malfunction and follow the rest part of the troubleshooting section.

See #30134 & #33337.

This PR clarify this removal at the beginning of the section.