### PR TITLE
Reference panel: fix scrollbars after introducing new row

### DIFF
--- a/client/web/src/codeintel/ReferencesPanel.module.scss
+++ b/client/web/src/codeintel/ReferencesPanel.module.scss
@@ -35,7 +35,12 @@
 }
 
 .references {
+    $references-token-height: 2rem;
     $references-filter-height: 2rem;
+
+    &--token {
+        height: $references-token-height;
+    }
 
     &--filter {
         height: $references-filter-height;
@@ -44,7 +49,7 @@
     &--list {
         display: flex;
         // Ensure list spans entire height of panel, and that the scrollable area does not include the filter height
-        height: calc(100% - #{$references-filter-height});
+        height: calc(100% - #{$references-filter-height + $references-token-height});
     }
 
     // Left side of the panel: hover & list of references/definition/...
@@ -63,6 +68,6 @@
     // Code needs to be smaller than 100% so it scrolls correctly
     &--side-blob-code {
         // Subtract the space taken up by the filename
-        height: calc(100% - #{$references-filter-height});
+        height: calc(100% - #{$references-filter-height + $references-token-height});
     }
 }

--- a/client/web/src/codeintel/ReferencesPanel.tsx
+++ b/client/web/src/codeintel/ReferencesPanel.tsx
@@ -204,7 +204,7 @@ const FilterableReferencesList: React.FunctionComponent<ReferencesPanelPropsWith
 
     return (
         <>
-            <CardHeader>
+            <CardHeader className={styles.referencesToken}>
                 <code>{tokenResult.searchToken}</code>{' '}
                 <span className="text-muted ml-2">
                     <code>


### PR DESCRIPTION
When I added the "token" to the panel, I forgot to adjust the heights
here.

### Before
![before](https://user-images.githubusercontent.com/1185253/161513526-73f81337-39dc-484b-8122-ca9a21df040f.png)

### After

![after](https://user-images.githubusercontent.com/1185253/161513533-d711cd81-3b7c-4217-a9bb-832a2ca79680.png)



## Test plan

Looked at it locally to confirm it's now correct


## App preview:
- [Link](https://sg-web-mrn-fix-scrollbar.onrender.com)

