### PR TITLE
Validate email format / length for sign-up

### DIFF
--- a/cmd/frontend/internal/auth/userpasswd/handlers.go
+++ b/cmd/frontend/internal/auth/userpasswd/handlers.go
@@ -218,6 +218,7 @@ func handleSignUp(db database.DB, w http.ResponseWriter, r *http.Request, failIf
 }
 
 func checkEmailFormat(email string) error {
+	// Max email length is 320 chars https://datatracker.ietf.org/doc/html/rfc3696#section-3
 	if len(email) > 320 {
 		return fmt.Errorf("maximum email length is 320, got %d", len(email))
 	}

--- a/cmd/frontend/internal/auth/userpasswd/handlers.go
+++ b/cmd/frontend/internal/auth/userpasswd/handlers.go
@@ -28,6 +28,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/featureflag"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/internal/usagestats"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 type credentials struct {
@@ -220,7 +221,7 @@ func handleSignUp(db database.DB, w http.ResponseWriter, r *http.Request, failIf
 func checkEmailFormat(email string) error {
 	// Max email length is 320 chars https://datatracker.ietf.org/doc/html/rfc3696#section-3
 	if len(email) > 320 {
-		return fmt.Errorf("maximum email length is 320, got %d", len(email))
+		return errors.Newf("maximum email length is 320, got %d", len(email))
 	}
 	if _, err := mail.ParseAddress(email); err != nil {
 		return err

--- a/cmd/frontend/internal/auth/userpasswd/handlers_test.go
+++ b/cmd/frontend/internal/auth/userpasswd/handlers_test.go
@@ -2,6 +2,7 @@ package userpasswd
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -66,6 +67,30 @@ func TestCheckEmailAbuse(t *testing.T) {
 				t.Fatalf("abused: want %v but got %v", test.expAbused, abused)
 			} else if test.expReason != reason {
 				t.Fatalf("reason: want %q but got %q", test.expReason, reason)
+			}
+		})
+	}
+}
+
+func TestCheckEmailFormat(t *testing.T) {
+	for name, test := range map[string]struct {
+		email string
+		err   error
+		code  int
+	}{
+		"valid":   {email: "foo@bar.pl", err: nil},
+		"invalid": {email: "foo@", err: fmt.Errorf("mail: no angle-addr")},
+		"toolong": {email: "a012345678901234567890123456789012345678901234567890123456789@0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789.comeeeeqwqwwe", err: fmt.Errorf("maximum email length is 320, got 326")}} {
+		t.Run(name, func(t *testing.T) {
+			err := checkEmailFormat(test.email)
+			if test.err == nil {
+				if err != nil {
+					t.Fatalf("err: want nil but got %v", err)
+				}
+			} else {
+				if test.err.Error() != err.Error() {
+					t.Fatalf("err: want %v but got %v", test.err, err)
+				}
 			}
 		})
 	}

--- a/cmd/frontend/internal/auth/userpasswd/handlers_test.go
+++ b/cmd/frontend/internal/auth/userpasswd/handlers_test.go
@@ -2,11 +2,11 @@ package userpasswd
 
 import (
 	"context"
-	"fmt"
 	"testing"
 	"time"
 
 	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 func TestCheckEmailAbuse(t *testing.T) {
@@ -79,8 +79,8 @@ func TestCheckEmailFormat(t *testing.T) {
 		code  int
 	}{
 		"valid":   {email: "foo@bar.pl", err: nil},
-		"invalid": {email: "foo@", err: fmt.Errorf("mail: no angle-addr")},
-		"toolong": {email: "a012345678901234567890123456789012345678901234567890123456789@0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789.comeeeeqwqwwe", err: fmt.Errorf("maximum email length is 320, got 326")}} {
+		"invalid": {email: "foo@", err: errors.Newf("mail: no angle-addr")},
+		"toolong": {email: "a012345678901234567890123456789012345678901234567890123456789@0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789.comeeeeqwqwwe", err: errors.Newf("maximum email length is 320, got 326")}} {
 		t.Run(name, func(t *testing.T) {
 			err := checkEmailFormat(test.email)
 			if test.err == nil {


### PR DESCRIPTION
Add validation for email during sign-up - see https://github.com/sourcegraph/security-issues/issues/200 and [CLOUD-345](https://sourcegraph.atlassian.net/browse/CLOUD-345)
## Test plan

- Unit tests
- Tested locally


