### PR TITLE
symbols: bump ctags to 5.9.20220403.0

### DIFF
--- a/cmd/symbols/ctags-install-alpine.sh
+++ b/cmd/symbols/ctags-install-alpine.sh
@@ -3,8 +3,9 @@
 # This script installs ctags within an alpine container.
 
 # Commit hash of github.com/universal-ctags/ctags.
-# Last bumped 2022-02-10
-CTAGS_VERSION=37a4b3601288bcdc02a387197ff8d9b971f7ab34
+# Last bumped 2022-04-04.
+# When bumping please remember to also update Zoekt: https://github.com/sourcegraph/zoekt/blob/d3a8fbd8385f0201dd54ab24114ebd588dfcf0d8/install-ctags-alpine.sh
+CTAGS_VERSION=f95bb3497f53748c2b6afc7f298cff218103ab90
 
 cleanup() {
   apk --no-cache --purge del ctags-build-deps || true

--- a/shell.nix
+++ b/shell.nix
@@ -13,12 +13,12 @@ let
   # Pin a specific version of universal-ctags to the same version as in cmd/symbols/ctags-install-alpine.sh.
   ctags-overlay = (self: super: {
     universal-ctags = super.universal-ctags.overrideAttrs (old: {
-      version = "5.9.20220206.0";
+      version = "5.9.20220403.0";
       src = super.fetchFromGitHub {
         owner = "universal-ctags";
         repo = "ctags";
-        rev = "40603a68c1f3b14dc1db4671111096733f6d2485";
-        sha256 = "sha256-oqrLO6/+TP5ccimkgZJ66agaUcNQMOalwVsY8GWS2rg=";
+        rev = "f95bb3497f53748c2b6afc7f298cff218103ab90";
+        sha256 = "sha256-pd89KERQj6K11Nue3YFNO+NLOJGqcMnHkeqtWvMFk38=";
       };
       # disable checks, else we get `make[1]: *** No rule to make target 'optlib/cmake.c'.  Stop.`
       doCheck = false;


### PR DESCRIPTION
The older commit was not a tagged commit. So just updating to be the
latest tagged release.

Test Plan: CI