### PR TITLE
search: Only highlight current filter when input has focus

### DIFF
--- a/client/search-ui/src/input/CodeMirrorQueryInput.tsx
+++ b/client/search-ui/src/input/CodeMirrorQueryInput.tsx
@@ -12,7 +12,14 @@ import {
 import { RangeSetBuilder } from '@codemirror/rangeset'
 import { EditorSelection, EditorState, Extension, Facet, StateEffect, StateField, Prec } from '@codemirror/state'
 import { hoverTooltip, TooltipView } from '@codemirror/tooltip'
-import { EditorView, ViewUpdate, keymap, Decoration, placeholder as placeholderExtension } from '@codemirror/view'
+import {
+    EditorView,
+    ViewUpdate,
+    keymap,
+    Decoration,
+    placeholder as placeholderExtension,
+    ViewPlugin,
+} from '@codemirror/view'
 import { Shortcut } from '@slimsag/react-shortcuts'
 import classNames from 'classnames'
 import { editor as Monaco, MarkerSeverity, languages } from 'monaco-editor'
@@ -475,23 +482,29 @@ const tokenHighlight = EditorView.decorations.compute([decoratedTokens], state =
 
 // Determines whether the cursor is over a filter and if yes, decorates that
 // filter.
-const highlightFocusedFilter = EditorView.decorations.compute(
-    ['selection', EditorView.editable, parsedQuery],
-    state => {
-        // No need to highlight anything if the input is "disabled"
-        if (!state.facet(EditorView.editable)) {
-            return Decoration.none
-        }
-
-        const query = state.facet(parsedQuery)
-        const position = state.selection.main.head
-        const focusedFilter = query.tokens.find(
-            (token): token is Filter =>
-                token.type === 'filter' && token.range.start <= position && token.range.end >= position
-        )
-        return focusedFilter
-            ? Decoration.set(focusedFilterDeco.range(focusedFilter.range.start, focusedFilter.range.end))
-            : Decoration.none
+const highlightFocusedFilter = ViewPlugin.define(
+    () => ({
+        decorations: Decoration.none,
+        update(update) {
+            if (update.focusChanged && !update.view.hasFocus) {
+                this.decorations = Decoration.none
+            } else if (update.docChanged || update.selectionSet || update.focusChanged) {
+                const query = update.state.facet(parsedQuery)
+                const position = update.state.selection.main.head
+                const focusedFilter = query.tokens.find(
+                    (token): token is Filter =>
+                        // Inclusive end so that the filter is highlighed when
+                        // the cursor is positioned directly after the value
+                        token.type === 'filter' && token.range.start <= position && token.range.end >= position
+                )
+                this.decorations = focusedFilter
+                    ? Decoration.set(focusedFilterDeco.range(focusedFilter.range.start, focusedFilter.range.end))
+                    : Decoration.none
+            }
+        },
+    }),
+    {
+        decorations: plugin => plugin.decorations,
     }
 )
 


### PR DESCRIPTION
I think it's a better experience if the token is not highlighted if the input doesn't have input.


https://user-images.githubusercontent.com/179026/161580355-e2a5e31f-ec7b-41c4-a948-b4567b28e5fc.mp4


## Test plan

Manual test: Enter multiple filters into the search input. Moving the cursor (via keyboard or mouse) should update the filter highlight. Removing focus should remove the highlight. Refocusing the element should highlight the filter again (if any).
## App preview:
- [Link](https://sg-web-fkling-cm-filter-highlight.onrender.com)

