### PR TITLE
web(repo/tree): fix link to batch changes docs

### DIFF
--- a/client/web/src/repo/tree/HomeTab.tsx
+++ b/client/web/src/repo/tree/HomeTab.tsx
@@ -332,7 +332,7 @@ export const HomeTab: React.FunctionComponent<Props> = ({
                                     <div className="text-right">
                                         <Link
                                             className="btn btn-sm btn-link mr-0 pr-0"
-                                            to="https://docs.sourcegraph.com/batch_changes"
+                                            to="/help/batch_changes"
                                         >
                                             Learn more
                                         </Link>

--- a/client/web/src/repo/tree/HomeTab.tsx
+++ b/client/web/src/repo/tree/HomeTab.tsx
@@ -330,10 +330,7 @@ export const HomeTab: React.FunctionComponent<Props> = ({
                                         <div className="col">Not available</div>
                                     </div>
                                     <div className="text-right">
-                                        <Link
-                                            className="btn btn-sm btn-link mr-0 pr-0"
-                                            to="/help/batch_changes"
-                                        >
+                                        <Link className="btn btn-sm btn-link mr-0 pr-0" to="/help/batch_changes">
                                             Learn more
                                         </Link>
                                     </div>


### PR DESCRIPTION
This triggered an alert here: https://sourcegraph.slack.com/archives/C01DXLN3D0T/p1649088496280419

> Literal unversioned docs links (bad), detected 1 new matches.
>
> [View results](https://k8s.sgdev.org/search?q=repo%3A%5E%28github%5C.com%2Fsourcegraph%2Fsourcegraph%29%24+type%3Adiff+to%3D%22https%3A%2F%2Fdocs.sourcegraph.com+file%3Aclient+select%3Acommit.diff.added++patternType%3Aliteral+after%3A%222022-04-04T10%3A16%3A48Z%22&utm_source=code-monitor-slack-webhook)

We should be using `/help` since that links to versioned docs

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

n/a
## App preview:
- [Link](https://sg-web-web-fix-doc-link.onrender.com)

