### PR TITLE
Remove Rob from G&I notifications

### DIFF
--- a/.github/workflows/label-notify.yml
+++ b/.github/workflows/label-notify.yml
@@ -12,7 +12,7 @@ jobs:
           with:
              token: "${{ secrets.LABELER_GITHUB_TOKEN }}"
              recipients: |
-                  team/growth-and-integrations=@muratsu @rrhyne @jjinnii @ryankscott
+                  team/growth-and-integrations=@muratsu @jjinnii @ryankscott
                   team/cloud=@RafLeszczynski
                   team/search-product=@benvenker @lguychard
                   team/search-core=@jjeffwarner


### PR DESCRIPTION
This change removes Rob from G&I automated notifications



## Test plan

No need for a test plan as this is a very trivial change 


