### PR TITLE
search: Refactor CodeMirror query input suggestions

### DIFF
--- a/client/search-ui/src/input/CodeMirrorQueryInput.tsx
+++ b/client/search-ui/src/input/CodeMirrorQueryInput.tsx
@@ -1,13 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
-import {
-    autocompletion,
-    Completion,
-    snippet,
-    completionKeymap,
-    closeCompletion,
-    startCompletion,
-} from '@codemirror/autocomplete'
+import { startCompletion } from '@codemirror/autocomplete'
 import { RangeSetBuilder } from '@codemirror/rangeset'
 import { EditorSelection, EditorState, Extension, Facet, StateEffect, StateField, Prec } from '@codemirror/state'
 import { hoverTooltip, TooltipView } from '@codemirror/tooltip'
@@ -21,27 +14,25 @@ import {
 } from '@codemirror/view'
 import { Shortcut } from '@slimsag/react-shortcuts'
 import classNames from 'classnames'
-import { editor as Monaco, MarkerSeverity, languages } from 'monaco-editor'
-import { Observable } from 'rxjs'
+import { editor as Monaco, MarkerSeverity } from 'monaco-editor'
 
 import { renderMarkdown } from '@sourcegraph/common'
-import { QueryChangeSource, SearchPatternType, SearchPatternTypeProps } from '@sourcegraph/search'
+import { QueryChangeSource, SearchPatternTypeProps } from '@sourcegraph/search'
 import { useCodeMirror } from '@sourcegraph/shared/src/components/CodeMirrorEditor'
 import { KEYBOARD_SHORTCUT_FOCUS_SEARCHBAR } from '@sourcegraph/shared/src/keyboardShortcuts/keyboardShortcuts'
-import { getCompletionItems } from '@sourcegraph/shared/src/search/query/completion'
-import { decorate, DecoratedToken } from '@sourcegraph/shared/src/search/query/decoratedToken'
+import { DecoratedToken } from '@sourcegraph/shared/src/search/query/decoratedToken'
 import { getDiagnostics } from '@sourcegraph/shared/src/search/query/diagnostics'
 import { resolveFilter } from '@sourcegraph/shared/src/search/query/filters'
 import { toHover } from '@sourcegraph/shared/src/search/query/hover'
-import { createCancelableFetchSuggestions, getSuggestionQuery } from '@sourcegraph/shared/src/search/query/providers'
-import { scanSearchQuery } from '@sourcegraph/shared/src/search/query/scanner'
-import { Filter, Token } from '@sourcegraph/shared/src/search/query/token'
+import { createCancelableFetchSuggestions } from '@sourcegraph/shared/src/search/query/providers'
+import { Filter } from '@sourcegraph/shared/src/search/query/token'
 import { appendContextFilter } from '@sourcegraph/shared/src/search/query/transformer'
-import { isSearchMatchOfType, SearchMatch } from '@sourcegraph/shared/src/search/stream'
 import { fetchStreamSuggestions } from '@sourcegraph/shared/src/search/suggestions'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
 import { isInputElement } from '@sourcegraph/shared/src/util/dom'
 
+import { searchQueryAutocompletion, createDefaultSuggestionSources } from './extensions/completion'
+import { decoratedTokens, parsedQuery, parseInputAsQuery, setQueryParseOptions } from './extensions/parsedQuery'
 import { MonacoQueryInputProps } from './MonacoQueryInput'
 
 import styles from './CodeMirrorQueryInput.module.scss'
@@ -98,10 +89,15 @@ export const CodeMirrorMonacoFacade: React.FunctionComponent<MonacoQueryInputPro
 
     const autocompletion = useMemo(
         () =>
-            autocomplete(query => fetchStreamSuggestions(appendContextFilter(query, selectedSearchContextSpec)), {
-                globbing,
-                isSourcegraphDotCom,
-            }),
+            searchQueryAutocompletion(
+                createDefaultSuggestionSources({
+                    fetchSuggestions: createCancelableFetchSuggestions(query =>
+                        fetchStreamSuggestions(appendContextFilter(query, selectedSearchContextSpec))
+                    ),
+                    globbing,
+                    isSourcegraphDotCom,
+                })
+            ),
         [selectedSearchContextSpec, globbing, isSourcegraphDotCom]
     )
 
@@ -268,9 +264,7 @@ const CodeMirrorQueryInput: React.FunctionComponent<CodeMirrorQueryInputProps> =
             useMemo(
                 () => [
                     EditorView.darkTheme.of(isLightTheme === false),
-                    queryParsingOptions,
-                    computeParsedQuery,
-                    computeDecoratedTokens,
+                    parseInputAsQuery(),
                     tokenHighlight,
                     queryDiagnostic,
                     tokenInfo(),
@@ -292,7 +286,7 @@ const CodeMirrorQueryInput: React.FunctionComponent<CodeMirrorQueryInputProps> =
 
         // Update pattern type and/or interpretComments when changed
         useEffect(() => {
-            editor?.dispatch({ effects: [setQueryOptions.of({ patternType, interpretComments })] })
+            editor?.dispatch({ effects: [setQueryParseOptions.of({ patternType, interpretComments })] })
         }, [editor, patternType, interpretComments])
 
         return <div ref={setContainer} className={classNames(styles.root, className)} id="monaco-query-input" />
@@ -409,58 +403,6 @@ const decoratedToDecoration = (token: DecoratedToken): Decoration => {
     }
     return tokenDecorators[cssClass] ?? emptyDecorator
 }
-
-// Editor state to keep information about how to parse the query. Can be updated
-// with the `setQueryOptions` effect.
-const queryParsingOptions = StateField.define<{ patternType: SearchPatternType; interpretComments?: boolean }>({
-    create() {
-        return {
-            patternType: SearchPatternType.literal,
-        }
-    },
-    update(value, transaction) {
-        for (const effect of transaction.effects) {
-            if (effect.is(setQueryOptions)) {
-                return { ...value, ...effect.value }
-            }
-        }
-        return value
-    },
-})
-const setQueryOptions = StateEffect.define<{ patternType: SearchPatternType; interpretComments?: boolean }>()
-
-interface ParsedQuery {
-    patternType: SearchPatternType
-    tokens: Token[]
-}
-// Facet which parses the query using our existing parser. It depends on the
-// current input (obviously) and the selected pattern type. It gets recomputed
-// whenever one of those values changes.
-// The parsed query is used for syntax highlighting and hover information.
-const parsedQuery = Facet.define<ParsedQuery, ParsedQuery>({
-    combine(input) {
-        // There will always only be one extension which parses this query
-        return input[0] ?? { patternType: SearchPatternType.literal, tokens: [] }
-    },
-})
-const computeParsedQuery = parsedQuery.compute(['doc', queryParsingOptions], state => {
-    const { patternType, interpretComments } = state.field(queryParsingOptions)
-    // Looks like Text overwrites toString somehow
-    // eslint-disable-next-line @typescript-eslint/no-base-to-string
-    const result = scanSearchQuery(state.doc.toString(), interpretComments, patternType)
-    return {
-        patternType,
-        tokens: result.type === 'success' ? result.term : [],
-    }
-})
-const decoratedTokens = Facet.define<DecoratedToken[], DecoratedToken[]>({
-    combine(input) {
-        return input[0] ?? []
-    },
-})
-const computeDecoratedTokens = decoratedTokens.compute([parsedQuery], state =>
-    state.facet(parsedQuery).tokens.flatMap(decorate)
-)
 
 // This provides syntax highlighting. This is a custom solution so that we an
 // use our existing query parser (instead of using codemirrors language
@@ -684,87 +626,6 @@ const queryDiagnostic: Extension[] = [
         { hoverTime: 100 }
     ),
 ]
-
-// Hook up autocompletion
-const autocomplete = (
-    fetchSuggestions: (query: string) => Observable<SearchMatch[]>,
-    options: { globbing: boolean; isSourcegraphDotCom: boolean }
-): Extension => {
-    const cancelableFetch = createCancelableFetchSuggestions(fetchSuggestions)
-    return [
-        // Uses the default keymapping but changes accepting suggestions from Enter
-        // to Tab
-        Prec.highest(
-            keymap.of(
-                completionKeymap.map(keybinding =>
-                    keybinding.key === 'Enter' ? { ...keybinding, key: 'Tab' } : keybinding
-                )
-            )
-        ),
-        EditorView.updateListener.of(update => {
-            // We want the completion list to be hidden when the editor looses focus
-            if (update.focusChanged && !update.view.hasFocus) {
-                closeCompletion(update.view)
-            }
-            // Show the completion list again if a filter was completed
-            if (update.transactions.some(transaction => transaction.isUserEvent('input.complete'))) {
-                const query = update.state.facet(parsedQuery)
-                const token = query.tokens.find(token => isTokenInRange(update.state.selection.main.anchor - 1, token))
-                if (token) {
-                    startCompletion(update.view)
-                }
-            }
-        }),
-        autocompletion({
-            defaultKeymap: false,
-            override: [
-                async context => {
-                    const query = context.state.facet(parsedQuery)
-                    const token = query.tokens.find(token => isTokenInRange(context.pos - 1, token))
-                    if (!token) {
-                        return null
-                    }
-                    const completionList = await getCompletionItems(
-                        token,
-                        { column: context.pos + 1 },
-                        (token, type) =>
-                            cancelableFetch(getSuggestionQuery(query.tokens, token, type), listener =>
-                                context.addEventListener('abort', listener)
-                            ).then(matches => matches.filter(isSearchMatchOfType(type))),
-                        options
-                    )
-
-                    if (completionList === null || completionList.suggestions.length === 0) {
-                        return null
-                    }
-                    return {
-                        from: token.type === 'filter' ? token.value?.range.start ?? context.pos : token.range.start,
-                        options: toCMCompletions(completionList),
-                    }
-                },
-            ],
-        }),
-    ]
-}
-
-function toCMCompletions(completionList: languages.CompletionList): Completion[] {
-    // Boost suggestions by position because it appears they are already orderd.
-    let boost = 99
-    return completionList.suggestions.map(
-        (item): Completion => ({
-            type: languages.CompletionItemKind[item.kind].toLowerCase(),
-            label: typeof item.label === 'string' ? item.label : item.label.name,
-            apply:
-                ((item.insertTextRules ?? 0) & languages.CompletionItemInsertTextRule.InsertAsSnippet) ===
-                languages.CompletionItemInsertTextRule.InsertAsSnippet
-                    ? snippet(item.insertText)
-                    : item.insertText,
-            detail: item.detail,
-            info: item.documentation?.toString(),
-            boost: boost--,
-        })
-    )
-}
 
 // Looks like there might be a bug with how the end range for a field is
 // computed? Need to add 1 to make this work properly.

--- a/client/search-ui/src/input/extensions/README.md
+++ b/client/search-ui/src/input/extensions/README.md
@@ -1,0 +1,2 @@
+This folder contains various extensions used for the CodeMirror based search
+query input.

--- a/client/search-ui/src/input/extensions/completion.test.ts
+++ b/client/search-ui/src/input/extensions/completion.test.ts
@@ -1,0 +1,316 @@
+import { Completion } from '@codemirror/autocomplete'
+
+import { SymbolKind } from '@sourcegraph/shared/src/graphql-operations'
+import { POPULAR_LANGUAGES } from '@sourcegraph/shared/src/search/query/languageFilter'
+import { ScanResult, scanSearchQuery, ScanSuccess } from '@sourcegraph/shared/src/search/query/scanner'
+import { Token } from '@sourcegraph/shared/src/search/query/token'
+import { SearchMatch } from '@sourcegraph/shared/src/search/stream'
+
+import { createDefaultSuggestionSources } from './completion'
+
+expect.addSnapshotSerializer({
+    serialize: value => JSON.stringify(value, null, 2),
+    test: () => true,
+})
+
+/**
+ * Helper function for invoking all sources.
+ */
+async function getCompletionItems(
+    token: Token,
+    position: number,
+    fetchSuggestions: () => Promise<SearchMatch[]>,
+    options?: { globbing?: boolean; isSourcegraphDotCom?: boolean }
+) {
+    const sources = createDefaultSuggestionSources({
+        globbing: false,
+        isSourcegraphDotCom: false,
+        fetchSuggestions,
+        ...options,
+    })
+
+    const results = await Promise.all(sources.map(source => source({ position, onAbort: () => {} }, [token], token)))
+    const allOptions: Completion[] = []
+    for (const result of results) {
+        if (result) {
+            allOptions.push(...result.options)
+        }
+    }
+    return allOptions
+}
+
+const toSuccess = (result: ScanResult<Token[]>): Token[] => (result as ScanSuccess<Token[]>).term
+
+const getToken = (query: string, tokenIndex: number): Token => toSuccess(scanSearchQuery(query))[tokenIndex]
+
+// Using async as a short way to create functions that return promises
+/* eslint-disable @typescript-eslint/require-await */
+describe('codmirror completions', () => {
+    test('returns static and dynamic filter type completions when the token matches a known filter', async () => {
+        expect(
+            (
+                await getCompletionItems(getToken('re', 0), 2, async () => [
+                    {
+                        type: 'symbol',
+                        repository: 'github.com/sourcegraph/jsonrpc2',
+                        path: 'src/RepoRoutes.js',
+                        symbols: [
+                            {
+                                kind: SymbolKind.VARIABLE,
+                                name: 'RepoRoutes',
+                                url: '',
+                                containerName: '',
+                            },
+                        ],
+                    },
+                ])
+            )?.map(({ label }) => label)
+        ).toStrictEqual([
+            'after',
+            'archived',
+            'author',
+            '-author',
+            'before',
+            'case',
+            'committer',
+            '-committer',
+            'content',
+            '-content',
+            'context',
+            'count',
+            'file',
+            '-file',
+            'fork',
+            'lang',
+            '-lang',
+            'message',
+            '-message',
+            'patterntype',
+            'repo',
+            '-repo',
+            'repogroup',
+            'repohascommitafter',
+            'repohasfile',
+            '-repohasfile',
+            'rev',
+            'select',
+            'timeout',
+            'type',
+            'visibility',
+            'RepoRoutes',
+        ])
+    })
+
+    test('returns suggestions for an empty query', async () => {
+        expect(
+            (await getCompletionItems(getToken('', 0), 0, async () => []))?.map(({ label }) => label)
+        ).toStrictEqual([
+            'after',
+            'archived',
+            'author',
+            '-author',
+            'before',
+            'case',
+            'committer',
+            '-committer',
+            'content',
+            '-content',
+            'context',
+            'count',
+            'file',
+            '-file',
+            'fork',
+            'lang',
+            '-lang',
+            'message',
+            '-message',
+            'patterntype',
+            'repo',
+            '-repo',
+            'repogroup',
+            'repohascommitafter',
+            'repohasfile',
+            '-repohasfile',
+            'rev',
+            'select',
+            'timeout',
+            'type',
+            'visibility',
+        ])
+    })
+
+    test('returns suggestions on whitespace', async () => {
+        expect(
+            (await getCompletionItems(getToken('a ', 1), 2, async () => []))?.map(({ label }) => label)
+        ).toStrictEqual([
+            'after',
+            'archived',
+            'author',
+            '-author',
+            'before',
+            'case',
+            'committer',
+            '-committer',
+            'content',
+            '-content',
+            'context',
+            'count',
+            'file',
+            '-file',
+            'fork',
+            'lang',
+            '-lang',
+            'message',
+            '-message',
+            'patterntype',
+            'repo',
+            '-repo',
+            'repogroup',
+            'repohascommitafter',
+            'repohasfile',
+            '-repohasfile',
+            'rev',
+            'select',
+            'timeout',
+            'type',
+            'visibility',
+        ])
+    })
+
+    test('returns static filter type completions for case-insensitive query', async () => {
+        expect(
+            (await getCompletionItems(getToken('rE', 0), 2, async () => []))?.map(({ label }) => label)
+        ).toStrictEqual([
+            'after',
+            'archived',
+            'author',
+            '-author',
+            'before',
+            'case',
+            'committer',
+            '-committer',
+            'content',
+            '-content',
+            'context',
+            'count',
+            'file',
+            '-file',
+            'fork',
+            'lang',
+            '-lang',
+            'message',
+            '-message',
+            'patterntype',
+            'repo',
+            '-repo',
+            'repogroup',
+            'repohascommitafter',
+            'repohasfile',
+            '-repohasfile',
+            'rev',
+            'select',
+            'timeout',
+            'type',
+            'visibility',
+        ])
+    })
+
+    test('returns completions for filters with discrete values', async () => {
+        expect(
+            (await getCompletionItems(getToken('case:y', 0), 6, async () => []))?.map(({ label }) => label)
+        ).toStrictEqual(['yes', 'no'])
+    })
+
+    test('returns completions for filters with static suggestions', async () => {
+        expect(
+            (await getCompletionItems(getToken('lang:', 0), 5, async () => []))?.map(({ label }) => label)
+        ).toStrictEqual(POPULAR_LANGUAGES)
+    })
+
+    test('returns completions in order of discrete value definition, not alphabetically', async () => {
+        expect(
+            (await getCompletionItems(getToken('select:', 0), 7, async () => []))?.map(({ label }) => label)
+        ).toStrictEqual(['repo', 'file', 'content', 'symbol', 'commit'])
+    })
+
+    test('returns dynamically fetched completions', async () => {
+        expect(
+            (
+                await getCompletionItems(
+                    getToken('file:c', 0),
+                    6,
+                    async () =>
+                        [
+                            {
+                                type: 'path',
+                                path: 'connect.go',
+                                repository: 'github.com/sourcegraph/jsonrpc2',
+                            },
+                        ] as SearchMatch[],
+                    {}
+                )
+            )?.map(({ label, apply }) => ({ label, apply }))
+        ).toStrictEqual([{ label: 'connect.go', apply: '^connect\\.go$ ' }])
+    })
+
+    test('inserts valid suggestion when completing repo:deps predicate', async () => {
+        expect(
+            (
+                await getCompletionItems(
+                    getToken('repo:deps(sourcegraph', 0),
+                    20,
+                    async () =>
+                        [
+                            {
+                                type: 'repo',
+                                repository: 'github.com/sourcegraph/jsonrpc2.go',
+                            },
+                        ] as SearchMatch[]
+                )
+            )?.map(({ apply }) => apply)
+        ).toStrictEqual(['deps(^github\\.com/sourcegraph/jsonrpc2\\.go$) '])
+    })
+
+    test('includes file path in insertText when completing filter value', async () => {
+        expect(
+            (
+                await getCompletionItems(
+                    getToken('f:', 0),
+                    2,
+                    async () =>
+                        [
+                            {
+                                type: 'path',
+                                path: 'some/path/main.go',
+                                repository: 'github.com/sourcegraph/jsonrpc2',
+                            },
+                        ] as SearchMatch[]
+                )
+            )?.map(({ apply }) => apply)
+        ).toStrictEqual(['^some/path/main\\.go$ '])
+    })
+
+    test('escapes spaces in repo value', async () => {
+        expect(
+            (
+                await getCompletionItems(
+                    getToken('repo:', 0),
+                    5,
+                    async () =>
+                        [
+                            {
+                                type: 'repo',
+                                repository: 'repo/with a space',
+                            },
+                        ] as SearchMatch[]
+                )
+            )
+                ?.map(({ apply }) => apply)
+                .filter(apply => typeof apply === 'string')
+        ).toMatchInlineSnapshot(`
+            [
+              "^repo/with\\\\ a\\\\ space$ "
+            ]
+        `)
+    })
+})

--- a/client/search-ui/src/input/extensions/completion.ts
+++ b/client/search-ui/src/input/extensions/completion.ts
@@ -1,0 +1,340 @@
+import { basename } from 'path'
+
+import {
+    autocompletion,
+    closeCompletion,
+    startCompletion,
+    completionKeymap,
+    CompletionResult,
+    Completion,
+    snippet,
+    CompletionSource,
+} from '@codemirror/autocomplete'
+import { Extension, Prec } from '@codemirror/state'
+import { keymap, EditorView } from '@codemirror/view'
+import { startCase } from 'lodash'
+
+import { isDefined } from '@sourcegraph/common'
+import { SymbolKind } from '@sourcegraph/search'
+import {
+    createFilterSuggestions,
+    PREDICATE_REGEX,
+    regexInsertText,
+    repositoryInsertText,
+} from '@sourcegraph/shared/src/search/query/completion'
+import { DecoratedToken } from '@sourcegraph/shared/src/search/query/decoratedToken'
+import { FILTERS, FilterType, resolveFilter } from '@sourcegraph/shared/src/search/query/filters'
+import { getSuggestionQuery } from '@sourcegraph/shared/src/search/query/providers'
+import { Filter, Token } from '@sourcegraph/shared/src/search/query/token'
+import { SearchMatch } from '@sourcegraph/shared/src/search/stream'
+
+import { parsedQuery } from './parsedQuery'
+
+enum Type {
+    class = 'class',
+    constant = 'constant',
+    enum = 'enum',
+    function = 'function',
+    interface = 'interface',
+    keyword = 'keyword',
+    method = 'method',
+    namespace = 'namespace',
+    property = 'property',
+    text = 'text',
+    type = 'type',
+    variable = 'variable',
+    repo = 'repo',
+    queryFilter = 'queryfilter',
+}
+
+const typeMap: Record<SymbolKind, Type | undefined> = {
+    MODULE: Type.namespace,
+    NAMESPACE: Type.namespace,
+    PACKAGE: Type.namespace,
+    CLASS: Type.class,
+    METHOD: Type.method,
+    PROPERTY: Type.property,
+    FIELD: Type.property,
+    CONSTRUCTOR: Type.class,
+    ENUM: Type.enum,
+    INTERFACE: Type.interface,
+    FUNCTION: Type.function,
+    VARIABLE: Type.variable,
+    CONSTANT: Type.constant,
+    ENUMMEMBER: Type.enum,
+    STRING: undefined,
+    NUMBER: undefined,
+    BOOLEAN: undefined,
+    ARRAY: undefined,
+    OBJECT: undefined,
+    KEY: undefined,
+    NULL: undefined,
+    STRUCT: undefined,
+    EVENT: undefined,
+    OPERATOR: undefined,
+    TYPEPARAMETER: undefined,
+    UNKNOWN: undefined,
+    FILE: undefined,
+}
+
+interface SuggestionContext {
+    position: number
+    onAbort: (listener: () => void) => void
+}
+
+/**
+ * A suggestion source is given a completion context, the current tokens in the
+ * query and the token at the current cursor position. It returns the
+ * corresponding completion results.
+ * The return type is generic so that it can be used to create different
+ * suggestion structures.
+ */
+type SuggestionSource<R, C extends SuggestionContext> = (
+    context: C,
+    tokens: Token[],
+    tokenAtPosition?: Token
+) => R | null | Promise<R | null>
+
+/**
+ * searchQueryAutocompletion registers extensions for automcompletion, using the
+ * provided suggestion sources.
+ */
+export function searchQueryAutocompletion(
+    sources: SuggestionSource<CompletionResult | null, SuggestionContext>[]
+): Extension {
+    const override: CompletionSource[] = sources.map(source => context => {
+        const position = context.pos
+        const query = context.state.facet(parsedQuery)
+        const token = query.tokens.find(token => isTokenInRange(token, position))
+        return source(
+            { position, onAbort: listener => context.addEventListener('abort', listener) },
+            query.tokens,
+            token
+        )
+    })
+
+    return [
+        // Uses the default keymapping but changes accepting suggestions from Enter
+        // to Tab
+        Prec.highest(
+            keymap.of(
+                completionKeymap.map(keybinding =>
+                    keybinding.key === 'Enter' ? { ...keybinding, key: 'Tab' } : keybinding
+                )
+            )
+        ),
+        EditorView.theme({
+            '.completion-type-queryfilter > .cm-completionLabel': {
+                fontWeight: 'bold',
+            },
+        }),
+        EditorView.updateListener.of(update => {
+            // Hide completion list when the editor looses focus
+            if (update.focusChanged && !update.view.hasFocus) {
+                closeCompletion(update.view)
+            }
+            // If a filter was completed, show the completion list again for
+            // filter values.
+            if (update.transactions.some(transaction => transaction.isUserEvent('input.complete'))) {
+                const query = update.state.facet(parsedQuery)
+                const token = query.tokens.find(token => isTokenInRange(token, update.state.selection.main.anchor - 1))
+                if (token) {
+                    startCompletion(update.view)
+                }
+            }
+        }),
+        autocompletion({
+            // We define our own keymap above
+            defaultKeymap: false,
+            override,
+            optionClass: completionItem => 'completion-type-' + (completionItem.type ?? ''),
+        }),
+    ]
+}
+
+/**
+ * Creates default suggestion sources to complete available filters, dynamic
+ * suggestions for the current pattern and static and dynamic suggestions for
+ * the current filter value.
+ */
+export function createDefaultSuggestionSources(options: {
+    fetchSuggestions: (query: string, onAbort: (listener: () => void) => void) => Promise<SearchMatch[]>
+    isSourcegraphDotCom: boolean
+    globbing: boolean
+}): SuggestionSource<CompletionResult | null, SuggestionContext>[] {
+    return [
+        // Static suggestions shown if the the current position is
+        // outside a filter value
+        createDefaultSource((context, _tokens, token) => ({
+            from: token ? token.range.start : context.position,
+            options: FILTER_SUGGESTIONS,
+        })),
+
+        // Show symbol suggestions outside of filters
+        createDefaultSource(async (context, tokens, token) => {
+            if (!token || token.type !== 'pattern') {
+                return null
+            }
+
+            const results = await options.fetchSuggestions(getSuggestionQuery(tokens, token, 'symbol'), context.onAbort)
+            if (results.length === 0) {
+                return null
+            }
+
+            return {
+                from: token.range.start,
+                options: results
+                    .flatMap(result => {
+                        if (result.type === 'symbol') {
+                            const path = result.path
+                            return result.symbols.map(symbol => ({
+                                label: symbol.name,
+                                type: typeMap[symbol.kind],
+                                apply: symbol.name + ' ',
+                                detail: `${startCase(symbol.kind.toLowerCase())} | ${basename(path)}`,
+                                info: result.repository,
+                            }))
+                        }
+                        return null
+                    })
+                    .filter(isDefined),
+            }
+        }),
+
+        // Show static filter value suggestions
+        createFilterSource((_context, _tokens, token, resolvedFilter) => {
+            if (!resolvedFilter?.definition.discreteValues) {
+                return null
+            }
+
+            const { value } = token
+            const insidePredicate = value ? PREDICATE_REGEX.test(value.value) : false
+
+            if (insidePredicate) {
+                return null
+            }
+
+            return {
+                from: value?.range.start ?? token.range.end,
+                options: resolvedFilter.definition
+                    .discreteValues(value, options.isSourcegraphDotCom)
+                    .map(({ label, insertText, asSnippet }) => {
+                        const apply = (insertText || label) + ' '
+                        return {
+                            label,
+                            apply: asSnippet ? snippet(apply) : apply,
+                        }
+                    }),
+            }
+        }),
+
+        // Show dynamic filter value suggestions
+        createFilterSource(async (context, tokens, token, resolvedFilter) => {
+            // On Sourcegraph.com, prompt only static suggestions (above) if there is no value to use for generating dynamic suggestions yet.
+            if (
+                options.isSourcegraphDotCom &&
+                (!token.value || (token.value.type === 'literal' && token.value.value === ''))
+            ) {
+                return null
+            }
+
+            if (!resolvedFilter?.definition.suggestions) {
+                return null
+            }
+
+            const results = await options.fetchSuggestions(
+                getSuggestionQuery(tokens, token, resolvedFilter.definition.suggestions),
+                context.onAbort
+            )
+            if (results.length === 0) {
+                return null
+            }
+
+            return {
+                from: token.value?.range.start ?? token.range.end,
+                filter: false,
+                options: results
+                    .map(match => {
+                        switch (match.type) {
+                            case 'path':
+                                return {
+                                    label: match.path,
+                                    apply: regexInsertText(match.path, options) + ' ',
+                                    info: match.repository,
+                                }
+                            case 'repo':
+                                return {
+                                    label: match.repository,
+                                    type: Type.repo,
+                                    apply:
+                                        repositoryInsertText(match, { ...options, filterValue: token.value?.value }) +
+                                        ' ',
+                                }
+                        }
+                        return null
+                    })
+                    .filter(isDefined),
+            }
+        }),
+    ]
+}
+
+/**
+ * Creates a suggestion source that triggers on no token or pattern or whitespace
+ * tokens.
+ */
+function createDefaultSource<R, C extends SuggestionContext>(source: SuggestionSource<R, C>): SuggestionSource<R, C> {
+    return (context, tokens, token) => {
+        if (token && token.type !== 'pattern' && token.type !== 'whitespace') {
+            return null
+        }
+        return source(context, tokens, token)
+    }
+}
+
+type FilterSuggestionSource<R, C extends SuggestionContext> = (
+    context: C,
+    tokens: Token[],
+    filter: Filter,
+    resolvedFilter: ReturnType<typeof resolveFilter>
+) => ReturnType<SuggestionSource<R, C>>
+
+/**
+ * Creates a suggestion source that triggers when a filter value is completed.
+ */
+function createFilterSource<R, C extends SuggestionContext>(
+    source: FilterSuggestionSource<R, C>
+): SuggestionSource<R, C> {
+    return (context, tokens, token) => {
+        // Not completing filter value
+        if (!token || token.type !== 'filter' || (token.value && token.value.range.start > context.position)) {
+            return null
+        }
+
+        const resolvedFilter = resolveFilter(token.field.value)
+        if (!resolvedFilter) {
+            return null
+        }
+
+        return source(context, tokens, token, resolvedFilter)
+    }
+}
+
+const FILTER_SUGGESTIONS: Completion[] = createFilterSuggestions(Object.keys(FILTERS) as FilterType[]).map(
+    ({ label, insertText, detail }) => ({
+        label,
+        type: Type.queryFilter,
+        apply: insertText,
+        detail,
+        boost: insertText.startsWith('-') ? 1 : 2, // demote negated filters
+    })
+)
+
+// Looks like there might be a bug with how the end range for a field is
+// computed? Need to add 1 to make this work properly.
+function isTokenInRange(
+    token: { type: DecoratedToken['type']; range: { start: number; end: number } },
+    position: number
+): boolean {
+    return token.range.start <= position && token.range.end + (token.type === 'field' ? 2 : 0) >= position
+}

--- a/client/search-ui/src/input/extensions/parsedQuery.ts
+++ b/client/search-ui/src/input/extensions/parsedQuery.ts
@@ -1,0 +1,82 @@
+import { Extension, Facet, StateEffect, StateField } from '@codemirror/state'
+
+import { SearchPatternType } from '@sourcegraph/search'
+import { decorate, DecoratedToken } from '@sourcegraph/shared/src/search/query/decoratedToken'
+import { scanSearchQuery } from '@sourcegraph/shared/src/search/query/scanner'
+import { Token } from '@sourcegraph/shared/src/search/query/token'
+
+export interface ParsedQuery {
+    patternType: SearchPatternType
+    tokens: Token[]
+}
+
+/**
+ * Use this effect to update parse options.
+ */
+export const setQueryParseOptions = StateEffect.define<{
+    patternType: SearchPatternType
+    interpretComments?: boolean
+}>()
+
+/**
+ * Facet representing the parsed query. Other extensions can use this to access
+ * the parsed query.
+ */
+export const parsedQuery = Facet.define<ParsedQuery, ParsedQuery>({
+    combine(input) {
+        // There will always only be one extension which parses this query
+        return input[0] ?? { patternType: SearchPatternType.literal, tokens: [] }
+    },
+})
+
+/**
+ * Facet representing decorated tokens (which includes e.g. regular
+ * expressions).
+ */
+export const decoratedTokens = Facet.define<DecoratedToken[], DecoratedToken[]>({
+    combine(input) {
+        return input[0] ?? []
+    },
+})
+
+/**
+ * Creates an extension that parses the input as search query and stores the
+ * result in the {@link parsedQuery} facet.
+ */
+export function parseInputAsQuery(): Extension {
+    // Editor state to keep information about how to parse the query. Can be updated
+    // with the `setQueryParseOptions` effect.
+    return StateField.define<{ patternType: SearchPatternType; interpretComments?: boolean }>({
+        create() {
+            return {
+                patternType: SearchPatternType.literal,
+            }
+        },
+        update(value, transaction) {
+            for (const effect of transaction.effects) {
+                if (effect.is(setQueryParseOptions)) {
+                    return { ...value, ...effect.value }
+                }
+            }
+            return value
+        },
+        provide(parseOptions) {
+            // Parse the query using our existing parser. It depends on the
+            // current input (obviously) and the current parse options. It gets
+            // recomputed whenever one of those values changes.
+            return [
+                parsedQuery.compute(['doc', parseOptions], state => {
+                    const { patternType, interpretComments } = state.field(parseOptions)
+                    // Looks like Text overwrites toString somehow
+                    // eslint-disable-next-line @typescript-eslint/no-base-to-string
+                    const result = scanSearchQuery(state.doc.toString(), interpretComments, patternType)
+                    return {
+                        patternType,
+                        tokens: result.type === 'success' ? result.term : [],
+                    }
+                }),
+                decoratedTokens.compute([parsedQuery], state => state.facet(parsedQuery).tokens.flatMap(decorate)),
+            ]
+        },
+    })
+}


### PR DESCRIPTION
Depends on #33295 

This PR refactors the suggestions CodeMirror integration. Because CodeMirror makes it easy to use multiple autocompletion sources, suggestions are now implemented as four sources for default suggestions, dynamic symbol suggestions, static filter value suggestions and dynamic filter suggestions. Most importantly, autocompletion for regex filter values (e.g. `repo:^git`) now work, by instructing CodeMirror to not filter the values (`filter: false`) (fixes #33005).

`searchQueryAutocompletion` now accepts an arrow of suggestion sources, making it easier in the future to extend the autocompletion behavior (e.g. to provide better support for completion inside predicates).

As an experiment I'm also rending filter suggestion slightly differently (bold) to make them easier to distinguish from symbol suggestions (this will likely change with more design input and better support for icons).


https://user-images.githubusercontent.com/179026/161617202-383703d0-248f-40fa-9602-233a5852e8d3.mp4



## Test plan

New unit test: I ported the relevant existing autocompletion tests to the new implementation.

## App preview:
- [Link](https://sg-web-fkling-cm-suggestions-2.onrender.com)

