### PR TITLE
insights: Add codeinsights-db to monitoring

### DIFF
--- a/doc/admin/observability/alert_solutions.md
+++ b/doc/admin/observability/alert_solutions.md
@@ -1767,8 +1767,8 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 **Possible solutions**
 
-- **Kubernetes:** Consider increasing CPU limits in the `Deployment.yaml` for the (pgsql|codeintel-db) service.
-- **Docker Compose:** Consider increasing `cpus:` of the (pgsql|codeintel-db) container in `docker-compose.yml`.
+- **Kubernetes:** Consider increasing CPU limits in the `Deployment.yaml` for the (pgsql|codeintel-db|codeinsights-db) service.
+- **Docker Compose:** Consider increasing `cpus:` of the (pgsql|codeintel-db|codeinsights-db) container in `docker-compose.yml`.
 - Learn more about the related dashboard panel in the [dashboards reference](./dashboards.md#postgres-provisioning-container-cpu-usage-long-term).
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
@@ -1792,8 +1792,8 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 **Possible solutions**
 
-- **Kubernetes:** Consider increasing memory limits in the `Deployment.yaml` for the (pgsql|codeintel-db) service.
-- **Docker Compose:** Consider increasing `memory:` of the (pgsql|codeintel-db) container in `docker-compose.yml`.
+- **Kubernetes:** Consider increasing memory limits in the `Deployment.yaml` for the (pgsql|codeintel-db|codeinsights-db) service.
+- **Docker Compose:** Consider increasing `memory:` of the (pgsql|codeintel-db|codeinsights-db) container in `docker-compose.yml`.
 - Learn more about the related dashboard panel in the [dashboards reference](./dashboards.md#postgres-provisioning-container-memory-usage-long-term).
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
@@ -1818,7 +1818,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 **Possible solutions**
 
 - **Kubernetes:** Consider increasing CPU limits in the the relevant `Deployment.yaml`.
-- **Docker Compose:** Consider increasing `cpus:` of the (pgsql|codeintel-db) container in `docker-compose.yml`.
+- **Docker Compose:** Consider increasing `cpus:` of the (pgsql|codeintel-db|codeinsights-db) container in `docker-compose.yml`.
 - Learn more about the related dashboard panel in the [dashboards reference](./dashboards.md#postgres-provisioning-container-cpu-usage-short-term).
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
@@ -1843,7 +1843,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 **Possible solutions**
 
 - **Kubernetes:** Consider increasing memory limit in relevant `Deployment.yaml`.
-- **Docker Compose:** Consider increasing `memory:` of (pgsql|codeintel-db) container in `docker-compose.yml`.
+- **Docker Compose:** Consider increasing `memory:` of (pgsql|codeintel-db|codeinsights-db) container in `docker-compose.yml`.
 - Learn more about the related dashboard panel in the [dashboards reference](./dashboards.md#postgres-provisioning-container-memory-usage-short-term).
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 

--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -5758,7 +5758,7 @@ To see this panel, visit `/-/debug/grafana/d/postgres/postgres?viewPanel=100300`
 <details>
 <summary>Technical details</summary>
 
-Query: `quantile_over_time(0.9, cadvisor_container_cpu_usage_percentage_total{name=~"^(pgsql|codeintel-db).*"}[1d])`
+Query: `quantile_over_time(0.9, cadvisor_container_cpu_usage_percentage_total{name=~"^(pgsql|codeintel-db|codeinsights-db).*"}[1d])`
 
 </details>
 
@@ -5777,7 +5777,7 @@ To see this panel, visit `/-/debug/grafana/d/postgres/postgres?viewPanel=100301`
 <details>
 <summary>Technical details</summary>
 
-Query: `max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^(pgsql|codeintel-db).*"}[1d])`
+Query: `max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^(pgsql|codeintel-db|codeinsights-db).*"}[1d])`
 
 </details>
 
@@ -5796,7 +5796,7 @@ To see this panel, visit `/-/debug/grafana/d/postgres/postgres?viewPanel=100310`
 <details>
 <summary>Technical details</summary>
 
-Query: `max_over_time(cadvisor_container_cpu_usage_percentage_total{name=~"^(pgsql|codeintel-db).*"}[5m])`
+Query: `max_over_time(cadvisor_container_cpu_usage_percentage_total{name=~"^(pgsql|codeintel-db|codeinsights-db).*"}[5m])`
 
 </details>
 
@@ -5815,7 +5815,7 @@ To see this panel, visit `/-/debug/grafana/d/postgres/postgres?viewPanel=100311`
 <details>
 <summary>Technical details</summary>
 
-Query: `max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^(pgsql|codeintel-db).*"}[5m])`
+Query: `max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^(pgsql|codeintel-db|codeinsights-db).*"}[5m])`
 
 </details>
 
@@ -5836,7 +5836,7 @@ To see this panel, visit `/-/debug/grafana/d/postgres/postgres?viewPanel=100400`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by(app) (up{app=~".*(pgsql|codeintel-db)"}) / count by (app) (up{app=~".*(pgsql|codeintel-db)"}) * 100`
+Query: `sum by(app) (up{app=~".*(pgsql|codeintel-db|codeinsights-db)"}) / count by (app) (up{app=~".*(pgsql|codeintel-db|codeinsights-db)"}) * 100`
 
 </details>
 

--- a/docker-images/postgres_exporter/build.sh
+++ b/docker-images/postgres_exporter/build.sh
@@ -12,10 +12,11 @@ trap cleanup EXIT
 mkdir -p "${OUTPUT}"
 OUTPUT_FILE="${OUTPUT}/queries.yaml"
 CODEINTEL_OUTPUT_FILE="${OUTPUT}/code_intel_queries.yaml"
+CODEINSIGHTS_OUTPUT_FILE="${OUTPUT}/code_insights_queries.yaml"
 
 for source in ./config/*.yaml; do
   {
-    if [[ "$source" == *"codeintel"* ]]; then
+    if [[ "$source" == *"codeintel"* || "$source" == *"codeinsights"* ]]; then
       echo "# skipping $source"
       continue
     fi
@@ -27,7 +28,7 @@ done
 
 for source in ./config/*.yaml; do
   {
-    if [[ "$source" == *"standard"* ]]; then
+    if [[ "$source" == *"frontend"* || "$source" == *"codeinsights"* ]]; then
       echo "# skipping $source"
       continue
     fi
@@ -37,8 +38,21 @@ for source in ./config/*.yaml; do
   } >>"${CODEINTEL_OUTPUT_FILE}"
 done
 
+for source in ./config/*.yaml; do
+  {
+    if [[ "$source" == *"frontend"* || "$source" == *"codeintel"* ]]; then
+      echo "# skipping $source"
+      continue
+    fi
+    echo "# source: ${source}"
+    cat "$source"
+    echo ""
+  } >>"${CODEINSIGHTS_OUTPUT_FILE}"
+done
+
 echo "${OUTPUT_FILE}"
 echo "${CODEINTEL_OUTPUT_FILE}"
+echo "${CODEINSIGHTS_OUTPUT_FILE}"
 
 docker build -f ./Dockerfile -t "${IMAGE:-sourcegraph/postgres_exporter}" "${OUTPUT}" \
   --progress=plain \

--- a/docker-images/postgres_exporter/config/06_codeinsights_migration.yaml
+++ b/docker-images/postgres_exporter/config/06_codeinsights_migration.yaml
@@ -1,0 +1,27 @@
+# In this file:
+#
+# | name                   | type    | description                                |
+# | ---------------------- | ------- | ------------------------------------------ |
+# | pg_sg_migration_status | GAUGE   | Whether the migration applied successfully |
+# |                        |         | This only applies to the codeinsights-db.    |
+
+pg_sg_codeinsights_migration:
+  query: |
+    WITH ranked_migration_logs AS (
+      SELECT
+        migration_logs.*,
+        ROW_NUMBER() OVER (PARTITION BY version ORDER BY finished_at DESC) AS row_number
+      FROM migration_logs
+      WHERE schema = 'codeinsights_schema_migrations'
+    )
+    SELECT EXISTS (
+      SELECT 1
+      FROM ranked_migration_logs
+      WHERE row_number = 1
+      AND NOT success
+    )::int;
+  master: true
+  metrics:
+    - status:
+        usage: 'GAUGE'
+        description: Whether the migration applied successfully

--- a/monitoring/definitions/postgres.go
+++ b/monitoring/definitions/postgres.go
@@ -13,7 +13,7 @@ func Postgres() *monitoring.Container {
 		// codeintel-db container is called codeintel-db Because of this, we track
 		// all database cAdvisor metrics in a single panel using this container
 		// name regex to ensure we have observability on all platforms.
-		containerName = "(pgsql|codeintel-db)"
+		containerName = "(pgsql|codeintel-db|codeinsights-db)"
 	)
 	return &monitoring.Container{
 		Name:                     "postgres",


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/32860

## Description

I believe this is all we need here, to include the codeinsights-db in the rest of the db monitoring and alerts.

## Test plan

I'm actually not sure how to test this, other than on `k8s`. Locally all I'm seeing is `postgres_exporter`, but on `k8s` I see the buckets for `pgsql` and `codeintel-db`. https://k8s.sgdev.org/-/debug/grafana/d/postgres/postgres

So my plan is to check it out on `k8s` once it's merged to verify that it worked. Any other ideas here? 

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


