### PR TITLE
prom-wrapper: fix conf usage

### DIFF
--- a/docker-images/prometheus/cmd/prom-wrapper/siteconfig.go
+++ b/docker-images/prometheus/cmd/prom-wrapper/siteconfig.go
@@ -161,6 +161,9 @@ func (c *SiteConfigSubscriber) Subscribe(ctx context.Context) {
 		c.log.Debug("no relevant configuration to init")
 	}
 
+	// Initialize conf package
+	conf.Init()
+
 	// Watch for future changes
 	conf.Watch(func() {
 		c.mux.RLock()

--- a/docker-images/prometheus/cmd/prom-wrapper/siteconfig.go
+++ b/docker-images/prometheus/cmd/prom-wrapper/siteconfig.go
@@ -152,6 +152,9 @@ func (c *SiteConfigSubscriber) Handler() http.Handler {
 }
 
 func (c *SiteConfigSubscriber) Subscribe(ctx context.Context) {
+	// Initialize conf package
+	conf.Init()
+
 	// Load initial alerts configuration
 	siteConfig := newSubscribedSiteConfig(conf.Get().SiteConfiguration)
 	diffs := siteConfig.Diff(c.config)
@@ -160,9 +163,6 @@ func (c *SiteConfigSubscriber) Subscribe(ctx context.Context) {
 	} else {
 		c.log.Debug("no relevant configuration to init")
 	}
-
-	// Initialize conf package
-	conf.Init()
 
 	// Watch for future changes
 	conf.Watch(func() {

--- a/docker-images/prometheus/cmd/prom-wrapper/siteconfig.go
+++ b/docker-images/prometheus/cmd/prom-wrapper/siteconfig.go
@@ -156,6 +156,7 @@ func (c *SiteConfigSubscriber) Subscribe(ctx context.Context) {
 	conf.Init()
 
 	// Load initial alerts configuration
+	c.log.Debug("making initial site config load")
 	siteConfig := newSubscribedSiteConfig(conf.Get().SiteConfiguration)
 	diffs := siteConfig.Diff(c.config)
 	if len(diffs) > 0 {


### PR DESCRIPTION
due to changes related to https://github.com/sourcegraph/sourcegraph/issues/29222, it looks like `prom-wrapper` is no longer using `conf` correctly and requires a call to `conf.Init` somewhere. This is causing all alerting to break for all sourcegraph instances as of 3.38 (see https://github.com/sourcegraph/sourcegraph/issues/33394)

closes https://github.com/sourcegraph/sourcegraph/issues/33394


## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


apply in demo.sourcegraph.com