### PR TITLE
add caveat to check https://lsif.dev/

### DIFF
--- a/doc/code_intelligence/references/troubleshooting.md
+++ b/doc/code_intelligence/references/troubleshooting.md
@@ -16,7 +16,7 @@ A customer issue should **possibly** be routed to code intelligence if any of th
 
 ## Gathering evidence
 
-Before bringing a code intelligence issue to the engineering team, the site-admin or customer engineer should gather the following details. Not all of these details will be necessary for all classes of errors.
+Before bringing a code intelligence issue to the engineering team, the site-admin, customer engineer or support engineer should first double check the current status is `ready` for the specific LSIF Indexer in question at https://lsif.dev/. Next, gather the following details keeping in mind that not all of these details will be necessary for all classes of errors.
 
 #### Sourcegraph instance details
 

--- a/doc/code_intelligence/references/troubleshooting.md
+++ b/doc/code_intelligence/references/troubleshooting.md
@@ -4,7 +4,8 @@ This guide gives specific instructions for troubleshooting code intelligence in 
 
 ## When are issues related to code-intelligence?
 
-If the [LSIF indexer](/indexers) is one that we build and maintain.
+
+Issues are related to Sourcegraph code intelligence when the [LSIF indexer](./indexers.md) is one that we build and maintain.
 
 A customer issue should **definitely** be routed to code intelligence if any of the following are true.
 
@@ -18,11 +19,11 @@ A customer issue should **possibly** be routed to code intelligence if any of th
 
 A customer issue should **not** be routed to code intelligence if any of the following are true.
 
-- If the indexer is listed in [LSIF.dev](https://lsif.dev/) and _it is not_ one that we maintain. In that case, share the status of the relevant indexer with the customer, along with who created and maintains it.
+- The indexer is listed in [LSIF.dev](https://lsif.dev/) and _it is not_ one that we maintain. Instead, flag the indexers status and maintainer of the relevant indexer with the customer, and suggest they reach out directly
 
 ## Gathering evidence
 
-Before bringing a code intelligence issue to the engineering team, the site-admin, customer engineer or support engineer should first double check the current status is `ready` for the specific LSIF Indexer in question at [LSIF.dev](https://lsif.dev/). Next, gather the following details keeping in mind that not all of these details will be necessary for all classes of errors.
+Before bringing a code intelligence issue to the engineering team, the site-admin or customer engineer should gather the following details. Not all of these details will be necessary for all classes of errors.
 
 #### Sourcegraph instance details
 

--- a/doc/code_intelligence/references/troubleshooting.md
+++ b/doc/code_intelligence/references/troubleshooting.md
@@ -4,6 +4,8 @@ This guide gives specific instructions for troubleshooting code intelligence in 
 
 ## When are issues related to code-intelligence?
 
+If the [LSIF indexer](/indexers) is one that we build and maintain.
+
 A customer issue should **definitely** be routed to code intelligence if any of the following are true.
 
 - Precise code intelligence queries are slow
@@ -13,6 +15,10 @@ A customer issue should **possibly** be routed to code intelligence if any of th
 
 - Search-based code intelligence queries are slow
 - Search-based code intelligence queries yield unexpected results
+
+A customer issue should **not** be routed to code intelligence if any of the following are true.
+
+- If the indexer is listed in [LSIF.dev](https://lsif.dev/) and _it is not_ one that we maintain. In that case, share the status of the relevant indexer with the customer, along with who created and maintains it.
 
 ## Gathering evidence
 

--- a/doc/code_intelligence/references/troubleshooting.md
+++ b/doc/code_intelligence/references/troubleshooting.md
@@ -16,7 +16,7 @@ A customer issue should **possibly** be routed to code intelligence if any of th
 
 ## Gathering evidence
 
-Before bringing a code intelligence issue to the engineering team, the site-admin, customer engineer or support engineer should first double check the current status is `ready` for the specific LSIF Indexer in question at https://lsif.dev/. Next, gather the following details keeping in mind that not all of these details will be necessary for all classes of errors.
+Before bringing a code intelligence issue to the engineering team, the site-admin, customer engineer or support engineer should first double check the current status is `ready` for the specific LSIF Indexer in question at [LSIF.dev](https://lsif.dev/). Next, gather the following details keeping in mind that not all of these details will be necessary for all classes of errors.
 
 #### Sourcegraph instance details
 


### PR DESCRIPTION
## Test plan
Ensured link went to correct place, and was recently made aware that https://lsif.dev/ is the place to check for LSIF status.
This doc update was prompted by Zendesk ticket [#7154](https://sourcegraph.zendesk.com/agent/tickets/7154) in which I had the fun of re-remembering that page existed. I wish I had remembered this before filing an unnecessary bug report for lsif-py 🙃 The hope is that in the future when others reference this LSIF troubleshooting doc, they will avoid a similar fate.
<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


