### PR TITLE
searcher: add Store.FetchTarPaths

### DIFF
--- a/cmd/searcher/main.go
+++ b/cmd/searcher/main.go
@@ -92,6 +92,17 @@ func main() {
 					Format:  "tar",
 				})
 			},
+			FetchTarPaths: func(ctx context.Context, repo api.RepoName, commit api.CommitID, paths []string) (io.ReadCloser, error) {
+				pathspecs := make([]gitserver.Pathspec, len(paths))
+				for i, p := range paths {
+					pathspecs[i] = gitserver.PathspecLiteral(p)
+				}
+				return git.Archive(ctx, repo, gitserver.ArchiveOptions{
+					Treeish:   string(commit),
+					Format:    "tar",
+					Pathspecs: pathspecs,
+				})
+			},
 			FilterTar:         search.NewFilter,
 			Path:              filepath.Join(cacheDir, "searcher-archives"),
 			MaxCacheSizeBytes: cacheSizeBytes,

--- a/cmd/searcher/search/store.go
+++ b/cmd/searcher/search/store.go
@@ -60,6 +60,13 @@ type Store struct {
 	// determine if the error is a bad request (eg invalid repo).
 	FetchTar func(ctx context.Context, repo api.RepoName, commit api.CommitID) (io.ReadCloser, error)
 
+	// FetchTarPaths is the future version of FetchTar, but for now exists as
+	// its own function to minimize changes.
+	//
+	// If paths is non-empty, the archive will only contain files from paths.
+	// If a path is missing the first Read call will fail with an error.
+	FetchTarPaths func(ctx context.Context, repo api.RepoName, commit api.CommitID, paths []string) (io.ReadCloser, error)
+
 	// FilterTar returns a FilterFunc that filters out files we don't want to write to disk
 	FilterTar func(ctx context.Context, db database.DB, repo api.RepoName, commit api.CommitID) (FilterFunc, error)
 


### PR DESCRIPTION
This will be used by the prototype Stefan and I are hacking on for
faster unindexed searches. I had this code lieing around and thought I'd
send it out as its own commit to make our future hacks smaller.

Test Plan: n/a it is unused.