### PR TITLE
web: remove `percy` from e2e tests

### DIFF
--- a/client/web/src/end-to-end/end-to-end.test.ts
+++ b/client/web/src/end-to-end/end-to-end.test.ts
@@ -6,7 +6,7 @@ import MockDate from 'mockdate'
 import { ExternalServiceKind } from '@sourcegraph/shared/src/schema'
 import { getConfig } from '@sourcegraph/shared/src/testing/config'
 import { afterEachRecordCoverage } from '@sourcegraph/shared/src/testing/coverage'
-import { createDriverForTest, Driver, percySnapshot } from '@sourcegraph/shared/src/testing/driver'
+import { createDriverForTest, Driver } from '@sourcegraph/shared/src/testing/driver'
 import { afterEachSaveScreenshotIfFailed } from '@sourcegraph/shared/src/testing/screenshotReporter'
 import { retry } from '@sourcegraph/shared/src/testing/utils'
 
@@ -87,14 +87,12 @@ describe('e2e test suite', () => {
         test('Repositories list', async () => {
             await driver.page.goto(sourcegraphBaseUrl + '/site-admin/repositories?query=gorilla%2Fmux')
             await driver.page.waitForSelector('a[href="/github.com/gorilla/mux"]', { visible: true })
-            await percySnapshot(driver.page, 'Repositories list')
         })
 
         test('Site admin overview', async () => {
             await driver.page.goto(sourcegraphBaseUrl + '/site-admin')
             await driver.page.waitForSelector('.test-site-admin-overview-menu', { visible: true })
             await driver.page.waitForSelector('.test-product-certificate', { visible: true })
-            await percySnapshot(driver.page, 'Site admin overview')
         })
     })
 
@@ -593,7 +591,6 @@ describe('e2e test suite', () => {
                     await hoverOver(24, 6)
 
                     await getHoverContents() // verify there is a hover
-                    await percySnapshot(driver.page, 'Code intel hover tooltip')
                 })
 
                 describe('jump to definition', () => {

--- a/dev/ci/integration/e2e/test.sh
+++ b/dev/ci/integration/e2e/test.sh
@@ -6,7 +6,7 @@ set -ex
 URL="${1:-"http://localhost:7080"}"
 
 echo "--- yarn run test-e2e"
-env SOURCEGRAPH_BASE_URL="$URL" PERCY_ON=true ./node_modules/.bin/percy exec -- yarn run cover-e2e
+env SOURCEGRAPH_BASE_URL="$URL" yarn run cover-e2e
 
 echo "--- coverage"
 yarn nyc report -r json


### PR DESCRIPTION
## Context 

As noticed in [this comment](https://github.com/sourcegraph/sourcegraph/pull/31555#pullrequestreview-931570766) we [recently](https://github.com/sourcegraph/sourcegraph/pull/33329) started successfully snapshotting in E2E tests. It [caused](https://percy.io/Sourcegraph/Sourcegraph/builds/17066092/changed/958733386?browser=chrome&browser_ids=20&subcategories=unreviewed%2Cchanges_requested&viewLayout=side-by-side&viewMode=new&width=1920&widths=1920) all snapshots to disappear from the Percy diff on the `main` branch. Let's use Percy snapshots only in integration tests to avoid such situations, and confusion about multiple Percy builds. That's the only diff that we used before [this PR](https://github.com/sourcegraph/sourcegraph/pull/33329), so it doesn't change anything from the confidence perspective.

## Test plan

Check that `percySnapshot` is not called in `web` E2E tests.


## App preview:
- [Link](https://sg-web-vb-remove-percy-from-e2e-tests.onrender.com)

