### PR TITLE
repo-updater: Expose current rate limit settings per external service

### DIFF
--- a/cmd/repo-updater/shared/main.go
+++ b/cmd/repo-updater/shared/main.go
@@ -59,9 +59,10 @@ var stateHTMLTemplate string
 type EnterpriseInit func(db database.DB, store *repos.Store, keyring keyring.Ring, cf *httpcli.Factory, server *repoupdater.Server) []debugserver.Dumper
 
 type LazyDebugserverEndpoint struct {
-	repoUpdaterStateEndpoint   http.HandlerFunc
-	listAuthzProvidersEndpoint http.HandlerFunc
-	gitserverReposStatus       http.HandlerFunc
+	repoUpdaterStateEndpoint     http.HandlerFunc
+	listAuthzProvidersEndpoint   http.HandlerFunc
+	gitserverReposStatusEndpoint http.HandlerFunc
+	rateLimiterStateEndpoint     http.HandlerFunc
 }
 
 func Main(enterpriseInit EnterpriseInit) {
@@ -215,7 +216,8 @@ func Main(enterpriseInit EnterpriseInit) {
 
 	debugserverEndpoints.repoUpdaterStateEndpoint = repoUpdaterStatsHandler(db, updateScheduler, debugDumpers)
 	debugserverEndpoints.listAuthzProvidersEndpoint = listAuthzProvidersHandler()
-	debugserverEndpoints.gitserverReposStatus = gitserverReposStatusHandler(db)
+	debugserverEndpoints.gitserverReposStatusEndpoint = gitserverReposStatusHandler(db)
+	debugserverEndpoints.rateLimiterStateEndpoint = rateLimiterStateHandler
 
 	// We mark the service as ready now AFTER assigning the additional endpoints in
 	// the debugserver constructed at the top of this function. This ensures we don't
@@ -267,7 +269,15 @@ func createDebugServerRoutine(ready chan struct{}, debugserverEndpoints *LazyDeb
 			Path: "/gitserver-repo-status",
 			Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				<-ready
-				debugserverEndpoints.gitserverReposStatus(w, r)
+				debugserverEndpoints.gitserverReposStatusEndpoint(w, r)
+			}),
+		},
+		debugserver.Endpoint{
+			Name: "Rate Limiter State",
+			Path: "/rate-limiter-state",
+			Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				<-ready
+				debugserverEndpoints.rateLimiterStateEndpoint(w, r)
 			}),
 		},
 	)
@@ -295,6 +305,17 @@ func gitserverReposStatusHandler(db database.DB) http.HandlerFunc {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write(resp)
 	}
+}
+
+func rateLimiterStateHandler(w http.ResponseWriter, r *http.Request) {
+	info := ratelimit.DefaultRegistry.LimitInfo()
+	resp, err := json.MarshalIndent(info, "", "  ")
+	if err != nil {
+		http.Error(w, fmt.Sprintf("failed to marshal rate limiter state: %q", err.Error()), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_, _ = w.Write(resp)
 }
 
 func listAuthzProvidersHandler() http.HandlerFunc {

--- a/internal/ratelimit/rate_limit.go
+++ b/internal/ratelimit/rate_limit.go
@@ -59,3 +59,27 @@ func (r *Registry) Count() int {
 	defer r.mu.Unlock()
 	return len(r.rateLimiters)
 }
+
+type LimitInfo struct {
+	// Maximum allowed burst of requests
+	Burst int
+	// Maximum allowed requests per second
+	Limit float64
+}
+
+// LimitInfo reports how all of the existing rate limiters are configured, keyed
+// by URN.
+func (r *Registry) LimitInfo() map[string]LimitInfo {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	m := make(map[string]LimitInfo, len(r.rateLimiters))
+	for urn, rl := range r.rateLimiters {
+		info := LimitInfo{
+			Burst: rl.Burst(),
+			Limit: float64(rl.Limit()),
+		}
+		m[urn] = info
+	}
+	return m
+}


### PR DESCRIPTION
It can be accessed via our existing instrumentation area:

`Site Admin -> Instrumentation -> Repo Updater -> Rate Limiter State`

It only shows the current Burst and Limit value as JSON

For example:

```json
{
  "extsvc:github:1": {
    "Burst": 1,
    "Limit": 1.3888888888888888
  },
  "extsvc:github:2": {
    "Burst": 1,
    "Limit": 1.3888888888888888
  }
}
```

# Test Plan

Tested locally