### PR TITLE
New reference panel: handle `codeIntel.mixPreciseAndSearchBasedReferences`

### DIFF
--- a/client/web/src/codeintel/ReferencesPanel.tsx
+++ b/client/web/src/codeintel/ReferencesPanel.tsx
@@ -683,60 +683,43 @@ const CollapsibleRepoLocationGroup: React.FunctionComponent<{
     setActiveLocation: (reference: Location | undefined) => void
     getLineContent: (location: Location) => string
     filter: string | undefined
-}> = ({ repoLocationGroup, setActiveLocation, getLineContent, activeLocation, filter }) => {
-    const quality = useMemo(
-        () => locationGroupQuality(repoLocationGroup.referenceGroups.flatMap(reference => reference.locations)),
-        [repoLocationGroup]
-    )
+}> = ({ repoLocationGroup, setActiveLocation, getLineContent, activeLocation, filter }) => (
+    <Collapse openByDefault={true}>
+        {({ isOpen }) => (
+            <>
+                <CollapseHeader
+                    as={Button}
+                    aria-expanded={isOpen}
+                    type="button"
+                    className="bg-transparent py-1 border-bottom border-top-0 border-left-0 border-right-0 d-flex justify-content-start w-100"
+                >
+                    <span className="p-0 mb-0">
+                        {isOpen ? (
+                            <Icon aria-label="Close" as={ChevronDownIcon} />
+                        ) : (
+                            <Icon aria-label="Expand" as={ChevronRightIcon} />
+                        )}
 
-    return (
-        <Collapse openByDefault={true}>
-            {({ isOpen }) => (
-                <>
-                    <CollapseHeader
-                        as={Button}
-                        aria-expanded={isOpen}
-                        type="button"
-                        className="bg-transparent py-1 border-bottom border-top-0 border-left-0 border-right-0 d-flex justify-content-start w-100"
-                    >
-                        <span className="p-0 mb-0">
-                            {isOpen ? (
-                                <Icon aria-label="Close" as={ChevronDownIcon} />
-                            ) : (
-                                <Icon aria-label="Expand" as={ChevronRightIcon} />
-                            )}
+                        <Link to={`/${repoLocationGroup.repoName}`}>{displayRepoName(repoLocationGroup.repoName)}</Link>
+                    </span>
+                </CollapseHeader>
 
-                            <Link to={`/${repoLocationGroup.repoName}`}>
-                                {displayRepoName(repoLocationGroup.repoName)}
-                            </Link>
-
-                            <Badge pill={true} small={true} variant="secondary" className="ml-2">
-                                {quality === 'MIXED'
-                                    ? 'PRECISE AND SEARCH-BASED'
-                                    : quality === 'SEARCH-BASED'
-                                    ? 'SEARCH-BASED'
-                                    : 'PRECISE'}
-                            </Badge>
-                        </span>
-                    </CollapseHeader>
-
-                    <CollapsePanel id={repoLocationGroup.repoName}>
-                        {repoLocationGroup.referenceGroups.map(group => (
-                            <ReferenceGroup
-                                key={group.path + group.repoName}
-                                group={group}
-                                activeLocation={activeLocation}
-                                setActiveLocation={setActiveLocation}
-                                getLineContent={getLineContent}
-                                filter={filter}
-                            />
-                        ))}
-                    </CollapsePanel>
-                </>
-            )}
-        </Collapse>
-    )
-}
+                <CollapsePanel id={repoLocationGroup.repoName}>
+                    {repoLocationGroup.referenceGroups.map(group => (
+                        <ReferenceGroup
+                            key={group.path + group.repoName}
+                            group={group}
+                            activeLocation={activeLocation}
+                            setActiveLocation={setActiveLocation}
+                            getLineContent={getLineContent}
+                            filter={filter}
+                        />
+                    ))}
+                </CollapsePanel>
+            </>
+        )}
+    </Collapse>
+)
 
 const ReferenceGroup: React.FunctionComponent<{
     group: LocationGroup
@@ -777,6 +760,9 @@ const ReferenceGroup: React.FunctionComponent<{
                                     group.path
                                 )}{' '}
                                 ({group.locations.length} references)
+                                <Badge pill={true} small={true} variant="secondary" className="ml-2">
+                                    {locationGroupQuality(group)}
+                                </Badge>
                             </span>
                         </CollapseHeader>
 

--- a/client/web/src/codeintel/ReferencesPanel.tsx
+++ b/client/web/src/codeintel/ReferencesPanel.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useMemo, useState } from 'react'
 
 import classNames from 'classnames'
 import * as H from 'history'
-import { capitalize, find } from 'lodash'
+import { capitalize } from 'lodash'
 import ChevronDownIcon from 'mdi-react/ChevronDownIcon'
 import ChevronRightIcon from 'mdi-react/ChevronRightIcon'
 import CloseIcon from 'mdi-react/CloseIcon'
@@ -54,7 +54,7 @@ import { parseBrowserRepoURL } from '../util/url'
 
 import { findLanguageSpec } from './language-specs/languages'
 import { LanguageSpec } from './language-specs/languagespec'
-import { Location, RepoLocationGroup, LocationGroup } from './location'
+import { Location, RepoLocationGroup, LocationGroup, locationGroupQuality } from './location'
 import { FETCH_HIGHLIGHTED_BLOB } from './ReferencesPanelQueries'
 import { newSettingsGetter } from './settings'
 import { findSearchToken } from './token'
@@ -684,12 +684,8 @@ const CollapsibleRepoLocationGroup: React.FunctionComponent<{
     getLineContent: (location: Location) => string
     filter: string | undefined
 }> = ({ repoLocationGroup, setActiveLocation, getLineContent, activeLocation, filter }) => {
-    const allSearchBased = useMemo(
-        () =>
-            find(
-                repoLocationGroup.referenceGroups.flatMap(reference => reference.locations),
-                location => !location.precise
-            ) !== undefined,
+    const quality = useMemo(
+        () => locationGroupQuality(repoLocationGroup.referenceGroups.flatMap(reference => reference.locations)),
         [repoLocationGroup]
     )
 
@@ -715,7 +711,11 @@ const CollapsibleRepoLocationGroup: React.FunctionComponent<{
                             </Link>
 
                             <Badge pill={true} small={true} variant="secondary" className="ml-2">
-                                {allSearchBased ? 'SEARCH-BASED' : 'PRECISE'}
+                                {quality === 'MIXED'
+                                    ? 'PRECISE AND SEARCH-BASED'
+                                    : quality === 'SEARCH-BASED'
+                                    ? 'SEARCH-BASED'
+                                    : 'PRECISE'}
                             </Badge>
                         </span>
                     </CollapseHeader>

--- a/client/web/src/codeintel/location.ts
+++ b/client/web/src/codeintel/location.ts
@@ -44,3 +44,26 @@ const buildLocation = (node: LocationFields, precise: boolean): Location => {
     location.lines = location.content.split(/\r?\n/)
     return location
 }
+
+export type LocationGroupQuality = 'PRECISE' | 'SEARCH-BASED' | 'MIXED'
+
+export const locationGroupQuality = (locations: Location[]): LocationGroupQuality => {
+    let hasPrecise = false
+    let hasSearchBased = false
+
+    for (const location of locations) {
+        if (location.precise) {
+            hasPrecise = true
+        } else {
+            hasSearchBased = true
+        }
+    }
+
+    if (hasPrecise && hasSearchBased) {
+        return 'MIXED'
+    }
+    if (hasPrecise) {
+        return 'PRECISE'
+    }
+    return 'SEARCH-BASED'
+}

--- a/client/web/src/codeintel/location.ts
+++ b/client/web/src/codeintel/location.ts
@@ -24,6 +24,18 @@ export interface LocationGroup {
     locations: Location[]
 }
 
+export type LocationGroupQuality = 'PRECISE' | 'SEARCH-BASED'
+
+export const locationGroupQuality = (group: LocationGroup): LocationGroupQuality => {
+    if (group.locations.length === 0) {
+        throw new Error(`No locations in ${group.path}`)
+    }
+
+    // Since we don't mix precise & search-based in a single file, we know that in a
+    // single group all locations are either search-based or precise.
+    return group.locations[0].precise ? 'PRECISE' : 'SEARCH-BASED'
+}
+
 export const buildPreciseLocation = (node: LocationFields): Location => buildLocation(node, true)
 export const buildSearchBasedLocation = (node: LocationFields): Location => buildLocation(node, false)
 
@@ -43,27 +55,4 @@ const buildLocation = (node: LocationFields, precise: boolean): Location => {
     location.url = node.url
     location.lines = location.content.split(/\r?\n/)
     return location
-}
-
-export type LocationGroupQuality = 'PRECISE' | 'SEARCH-BASED' | 'MIXED'
-
-export const locationGroupQuality = (locations: Location[]): LocationGroupQuality => {
-    let hasPrecise = false
-    let hasSearchBased = false
-
-    for (const location of locations) {
-        if (location.precise) {
-            hasPrecise = true
-        } else {
-            hasSearchBased = true
-        }
-    }
-
-    if (hasPrecise && hasSearchBased) {
-        return 'MIXED'
-    }
-    if (hasPrecise) {
-        return 'PRECISE'
-    }
-    return 'SEARCH-BASED'
 }

--- a/client/web/src/codeintel/useCodeIntel.ts
+++ b/client/web/src/codeintel/useCodeIntel.ts
@@ -75,10 +75,6 @@ interface UseCodeIntelParameters {
     getSetting: SettingsGetter
 }
 
-const dropDefinitions = (definitions: Location[]): void => {
-    console.info(`dropping ${definitions.length} search-based definitions`)
-}
-
 export const useCodeIntel = ({
     variables,
     searchToken,
@@ -158,6 +154,7 @@ export const useCodeIntel = ({
         loading: searchBasedLoading,
         error: searchBasedError,
         fetch: fetchSearchBasedCodeIntel,
+        fetchReferences: fetchSearchBasedReferences,
     } = useSearchBasedCodeIntel({
         repo: variables.repository,
         commit: variables.commit,
@@ -187,8 +184,7 @@ export const useCodeIntel = ({
                     setCodeIntelData(lsifData)
 
                     if (shouldMixPreciseAndSearchBasedReferences()) {
-                        // TODO: We don't need to request definitions here
-                        fetchSearchBasedCodeIntel(deduplicateAndAddReferences, dropDefinitions)
+                        fetchSearchBasedReferences(deduplicateAndAddReferences)
                     }
                 } else {
                     console.info('No LSIF data. Falling back to search-based code intelligence.')


### PR DESCRIPTION
This fixes one of the last big chunks of https://github.com/sourcegraph/sourcegraph/issues/30970 by replicating the behaviour in `code-intel-extensions` where [we mix precise and search-based results](https://github.com/sourcegraph/code-intel-extensions/blob/1b19eb6e6ef2435d9f0f7c7639e1749787799e4b/template/src/providers.ts#L309-L341) depending on the user setting.

It works (see video below), but I ran into two issues that I think can be fixed as follow-ups:

- https://github.com/sourcegraph/sourcegraph/issues/33412 - this is a bug that we should fix
- https://github.com/sourcegraph/sourcegraph/issues/33417 - this might be nice to have


Video:


https://user-images.githubusercontent.com/1185253/161749404-facc90c1-226a-4b39-97b9-3a7cad3a9424.mp4



## Test plan

Tested this locally (see video). With different pagination sizes and in repos with and without precise code intel.


## App preview:
- [Link](https://sg-web-mrn-mix-search-precise.onrender.com)

