### PR TITLE
gitserver: eventually re-clone after failed sg maintenance

### DIFF
--- a/cmd/gitserver/server/cleanup.go
+++ b/cmd/gitserver/server/cleanup.go
@@ -71,6 +71,7 @@ var looseObjectsLimit, _ = strconv.Atoi(env.Get("SRC_GIT_LOOSE_OBJECTS_LIMIT", "
 // Subsequent sg maintenance runs are skipped unless the log file is old. Based
 // on how https://github.com/git/git handles the gc.log file.
 var sgmLogExpire, _ = strconv.Atoi(env.Get("SRC_GIT_LOG_FILE_EXPIRY", "24", "the number of hours after which sg maintenance runs even if a log file is present"))
+var sgmLogExpire = env.MustGetDuration("SRC_GIT_LOG_FILE_EXPIRY", 24*time.Hour, "the number of hours after which sg maintenance runs even if a log file is present")
 
 // sg maintenance and git gc must not be enabled at the same time. However, both
 // might be disabled at the same time, hence we need both SRC_ENABLE_GC_AUTO and
@@ -886,7 +887,7 @@ func sgMaintenance(dir GitDir, cmd *exec.Cmd) (err error) {
 	// to report an error, because the error has already been logged in a previous
 	// run.
 	if fi, err := os.Stat(dir.Path(sgmLog)); err == nil {
-		if fi.ModTime().After(time.Now().Add(-time.Hour * time.Duration(sgmLogExpire))) {
+		if fi.ModTime().After(time.Now().Add(-sgmLogExpire)) {
 			return nil
 		}
 	}

--- a/cmd/gitserver/server/cleanup.go
+++ b/cmd/gitserver/server/cleanup.go
@@ -906,7 +906,7 @@ func sgMaintenance(dir GitDir) (err error) {
 	b, err := cmd.CombinedOutput()
 	if err != nil {
 		if err := os.WriteFile(dir.Path(sgmLog), b, 0666); err != nil {
-			log15.Debug(fmt.Sprintf("cloud not write %s", sgmLog), "err", err)
+			log15.Debug("sg maintenance failed to write log file", "file", dir.Path(sgmLog), "err", err)
 		}
 		log15.Debug("sg maintenance", "dir", dir, "out", string(b))
 		return errors.Wrapf(wrapCmdError(cmd, err), "failed to run sg maintenance")

--- a/cmd/gitserver/server/cleanup.go
+++ b/cmd/gitserver/server/cleanup.go
@@ -41,8 +41,9 @@ const (
 	// repoTTLGC is how often we should re-clone a repository once it is
 	// reporting git gc issues.
 	repoTTLGC = time.Hour * 24 * 2
-	// repoTTLSGM is how often we should re-clone a repository once it is
-	// reporting issues with sg maintenance.
+	// repoTTLSGM is how often we should re-clone a repository once it is reporting
+	// issues with sg maintenance. repoTTLSGM should be greater than sgmLogExpire,
+	// otherwise we will always re-clone before the log expires.
 	repoTTLSGM = time.Hour * 24 * 2
 	// gitConfigMaybeCorrupt is a key we add to git config to signal that a repo may be
 	// corrupt on disk.
@@ -69,8 +70,9 @@ var looseObjectsLimit, _ = strconv.Atoi(env.Get("SRC_GIT_LOOSE_OBJECTS_LIMIT", "
 
 // A failed sg maintenance run will place a log file in the git directory.
 // Subsequent sg maintenance runs are skipped unless the log file is old. Based
-// on how https://github.com/git/git handles the gc.log file.
-var sgmLogExpire, _ = strconv.Atoi(env.Get("SRC_GIT_LOG_FILE_EXPIRY", "24", "the number of hours after which sg maintenance runs even if a log file is present"))
+// on how https://github.com/git/git handles the gc.log file. sgmLogExpire should
+// be less than repoTLLSGM, otherwise we will always re-clone before the log
+// expires.
 var sgmLogExpire = env.MustGetDuration("SRC_GIT_LOG_FILE_EXPIRY", 24*time.Hour, "the number of hours after which sg maintenance runs even if a log file is present")
 
 // sg maintenance and git gc must not be enabled at the same time. However, both

--- a/cmd/gitserver/server/cleanup_test.go
+++ b/cmd/gitserver/server/cleanup_test.go
@@ -1263,7 +1263,7 @@ func TestSGMLogFile(t *testing.T) {
 	}
 
 	// backdate sgmLog file => sgMaintenance ignores log file
-	old := time.Now().Add(-2 * time.Hour * time.Duration(sgmLogExpire))
+	old := time.Now().Add(-2 * sgmLogExpire)
 	if err := os.Chtimes(dir.Path(sgmLog), old, old); err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/gitserver/server/cleanup_test.go
+++ b/cmd/gitserver/server/cleanup_test.go
@@ -416,34 +416,42 @@ func TestCleanupOldLocks(t *testing.T) {
 
 		"github.com/foo/empty/.git/HEAD",
 		"github.com/foo/empty/.git/info/attributes",
+		"github.com/foo/empty/.git/sgm.log",
 
 		"github.com/foo/freshconfiglock/.git/HEAD",
 		"github.com/foo/freshconfiglock/.git/config.lock",
 		"github.com/foo/freshconfiglock/.git/info/attributes",
+		"github.com/foo/freshconfiglock/.git/sgm.log",
 
 		"github.com/foo/freshpacked/.git/HEAD",
 		"github.com/foo/freshpacked/.git/packed-refs.lock",
 		"github.com/foo/freshpacked/.git/info/attributes",
+		"github.com/foo/freshpacked/.git/sgm.log",
 
 		"github.com/foo/freshcommitgraphlock/.git/HEAD",
 		"github.com/foo/freshcommitgraphlock/.git/objects/info/commit-graph.lock",
 		"github.com/foo/freshcommitgraphlock/.git/info/attributes",
+		"github.com/foo/freshcommitgraphlock/.git/sgm.log",
 
 		"github.com/foo/stalecommitgraphlock/.git/HEAD",
 		"github.com/foo/stalecommitgraphlock/.git/info/attributes",
 		"github.com/foo/stalecommitgraphlock/.git/objects/info",
+		"github.com/foo/stalecommitgraphlock/.git/sgm.log",
 
 		"github.com/foo/staleconfiglock/.git/HEAD",
 		"github.com/foo/staleconfiglock/.git/info/attributes",
+		"github.com/foo/staleconfiglock/.git/sgm.log",
 
 		"github.com/foo/stalepacked/.git/HEAD",
 		"github.com/foo/stalepacked/.git/info/attributes",
+		"github.com/foo/stalepacked/.git/sgm.log",
 
 		"github.com/foo/refslock/.git/HEAD",
 		"github.com/foo/refslock/.git/refs/heads/fresh",
 		"github.com/foo/refslock/.git/refs/heads/fresh.lock",
 		"github.com/foo/refslock/.git/refs/heads/stale",
 		"github.com/foo/refslock/.git/info/attributes",
+		"github.com/foo/refslock/.git/sgm.log",
 	)
 }
 


### PR DESCRIPTION
It is possible that sg maintenance fails on a corrupt repo. If this is
the case, we keep running sg maintenance periodically until the repo is
eventually fixed (either manually or due to a re-clone). However the
time until re-clone can be very long and we should re-clone earlier if we 
know the repo is corrupt.

On dogfood we currently see such a case. sg maintenance fails for 1 repo
with the error `(...) refs/pull/138704/merge does not point to a valid
object`

Git's gc deals with this by placing a gc.log file in the git dir. This
PR follows the same logic.

A failed sg maintenance run will place a log file in the git directory.
Subsequent sg maintenance runs are skipped unless the log file is old.
A successful run removes the log file.

If `maybeReclone` encounters the log file, it will re-clone the repo.



## Test plan
added a unit test

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


