### PR TITLE
graphql: Add `GitCommit.Path` resolver

### DIFF
--- a/cmd/frontend/graphqlbackend/git_tree_entry.go
+++ b/cmd/frontend/graphqlbackend/git_tree_entry.go
@@ -65,8 +65,8 @@ func NewGitTreeEntryResolver(db database.DB, commit *GitCommitResolver, stat fs.
 func (r *GitTreeEntryResolver) Path() string { return r.stat.Name() }
 func (r *GitTreeEntryResolver) Name() string { return path.Base(r.stat.Name()) }
 
-func (r *GitTreeEntryResolver) ToGitTree() (*GitTreeEntryResolver, bool) { return r, true }
-func (r *GitTreeEntryResolver) ToGitBlob() (*GitTreeEntryResolver, bool) { return r, true }
+func (r *GitTreeEntryResolver) ToGitTree() (*GitTreeEntryResolver, bool) { return r, r.IsDirectory() }
+func (r *GitTreeEntryResolver) ToGitBlob() (*GitTreeEntryResolver, bool) { return r, !r.IsDirectory() }
 
 func (r *GitTreeEntryResolver) ToVirtualFile() (*virtualFileResolver, bool) { return nil, false }
 

--- a/cmd/frontend/graphqlbackend/graphqlbackend_test.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend_test.go
@@ -81,7 +81,6 @@ func TestResolverTo(t *testing.T) {
 	// codecov coverage reports are noisy.
 	resolvers := []interface{}{
 		&FileMatchResolver{db: db},
-		&GitTreeEntryResolver{db: db},
 		&NamespaceResolver{},
 		&NodeResolver{},
 		&RepositoryResolver{db: db},
@@ -92,12 +91,40 @@ func TestResolverTo(t *testing.T) {
 	}
 	for _, r := range resolvers {
 		typ := reflect.TypeOf(r)
-		for i := 0; i < typ.NumMethod(); i++ {
-			if name := typ.Method(i).Name; strings.HasPrefix(name, "To") {
-				reflect.ValueOf(r).MethodByName(name).Call(nil)
+		t.Run(typ.Name(), func(t *testing.T) {
+			for i := 0; i < typ.NumMethod(); i++ {
+				if name := typ.Method(i).Name; strings.HasPrefix(name, "To") {
+					reflect.ValueOf(r).MethodByName(name).Call(nil)
+				}
 			}
-		}
+		})
 	}
+
+	t.Run("GitTreeEntryResolver", func(t *testing.T) {
+		blobStat, err := os.Stat("graphqlbackend_test.go")
+		if err != nil {
+			t.Fatalf("unexpected error opening file: %s", err)
+		}
+		blobEntry := &GitTreeEntryResolver{db: db, stat: blobStat}
+		if _, isBlob := blobEntry.ToGitBlob(); !isBlob {
+			t.Errorf("expected blobEntry to be blob")
+		}
+		if _, isTree := blobEntry.ToGitTree(); isTree {
+			t.Errorf("expected blobEntry to be blob, but is tree")
+		}
+
+		treeStat, err := os.Stat(".")
+		if err != nil {
+			t.Fatalf("unexpected error opening directory: %s", err)
+		}
+		treeEntry := &GitTreeEntryResolver{db: db, stat: treeStat}
+		if _, isBlob := treeEntry.ToGitBlob(); isBlob {
+			t.Errorf("expected treeEntry to be blob, but is blob")
+		}
+		if _, isTree := treeEntry.ToGitTree(); !isTree {
+			t.Errorf("expected treeEntry to be blob")
+		}
+	})
 }
 
 func TestMain(m *testing.M) {

--- a/cmd/frontend/graphqlbackend/graphqlbackend_test.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend_test.go
@@ -119,10 +119,10 @@ func TestResolverTo(t *testing.T) {
 		}
 		treeEntry := &GitTreeEntryResolver{db: db, stat: treeStat}
 		if _, isBlob := treeEntry.ToGitBlob(); isBlob {
-			t.Errorf("expected treeEntry to be blob, but is blob")
+			t.Errorf("expected treeEntry to be tree, but is blob")
 		}
 		if _, isTree := treeEntry.ToGitTree(); !isTree {
-			t.Errorf("expected treeEntry to be blob")
+			t.Errorf("expected treeEntry to be tree")
 		}
 	})
 }

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -3768,6 +3768,15 @@ type GitCommit implements Node {
     """
     externalURLs: [ExternalLink!]!
     """
+    The Git tree or blob in this commit at the given path.
+    """
+    path(
+        """
+        The path of the tree or blob.
+        """
+        path: String = ""
+    ): GitTreeOrGitBlob
+    """
     The Git tree in this commit at the given path.
     """
     tree(
@@ -3847,6 +3856,8 @@ type GitCommit implements Node {
         includePatterns: [String!]
     ): SymbolConnection!
 }
+
+union GitTreeOrGitBlob = GitTree | GitBlob
 
 """
 A set of Git behind/ahead counts for one commit relative to another.

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -3775,7 +3775,7 @@ type GitCommit implements Node {
         The path of the tree or blob.
         """
         path: String = ""
-    ): GitTreeOrGitBlob
+    ): GitTreeOrBlob
     """
     The Git tree in this commit at the given path.
     """
@@ -3857,7 +3857,10 @@ type GitCommit implements Node {
     ): SymbolConnection!
 }
 
-union GitTreeOrGitBlob = GitTree | GitBlob
+"""
+Either a git tree or blob.
+"""
+union GitTreeOrBlob = GitTree | GitBlob
 
 """
 A set of Git behind/ahead counts for one commit relative to another.


### PR DESCRIPTION
This PR adds a new `path` resolver as as sibling to `tree` and `blob` on git commit. Currently, if we have a path in a repo but do not know whether it is a blob or a tree, we cannot query the API to determine which it is: both resolvers have a non-intersecting set of conditions that return an error to the user.

In order not to encourage users to trust requests containing partial errors, we should allow a resolver to gather a git tree or blob resolver by path name only, and introspect the type.

See the following API requests/responses for what I've come up with so far.

Open questions/feedback requests include:

- Is there another way to query this data I'm not aware of?
- ~`__typename` is always `GitTree` in the new resolver. Is this odd or worth documenting?~

### Blobs (current behavior)

Success:

```graphql
{
  repository(name: "github.com/sourcegraph/sourcegraph") {
    commit(rev: "HEAD") {
      blob(path: "enterprise/cmd/server/main.go") {
        path
        isDirectory
      }
    }
  }
}
```

```json
{
  "data": {
    "repository": {
      "commit": {
        "blob": {
          "path": "enterprise/cmd/server/main.go",
          "isDirectory": false
        }
      }
    }
  }
}
```

Blob on a directory returns an error:

```graphql
{
  repository(name: "github.com/sourcegraph/sourcegraph") {
    commit(rev: "HEAD") {
      blob(path: "enterprise") {
        path
        isDirectory
      }
    }
  }
}
```

```json
{
  "errors": [
    {
      "message": "not a blob: \"enterprise\"",
      "path": [
        "repository",
        "commit",
        "blob"
      ]
    }
  ],
  "data": {
    "repository": {
      "commit": {
        "blob": null
      }
    }
  }
}
```

### Trees (current behavior)

Success:

```graphql
{
  repository(name: "github.com/sourcegraph/sourcegraph") {
    commit(rev: "HEAD") {
      tree(path: "enterprise") {
        path
        isDirectory
      }
    }
  }
}
```

```json
{
  "data": {
    "repository": {
      "commit": {
        "tree": {
          "path": "enterprise",
          "isDirectory": true
        }
      }
    }
  }
}
```

Tree on a blob returns an error:

```graphql
{
  repository(name: "github.com/sourcegraph/sourcegraph") {
    commit(rev: "HEAD") {
      tree(path: "enterprise/cmd/server/main.go") {
        path
        isDirectory
      }
    }
  }
}
```

```json
{
  "errors": [
    {
      "message": "not a directory: \"enterprise/cmd/server/main.go\"",
      "path": [
        "repository",
        "commit",
        "tree"
      ]
    }
  ],
  "data": {
    "repository": {
      "commit": {
        "tree": null
      }
    }
  }
}
```

### Paths (new behavior)

Success (blob):

```graphql
{
  repository(name: "github.com/sourcegraph/sourcegraph") {
    commit(rev: "HEAD") {
      path(path: "enterprise/cmd/server/main.go") {
        ... on GitTree {
          __typename
          path
          isDirectory
        }
        ... on GitBlob {
          __typename
          path
          isDirectory
        }
      }
    }
  }
}
```

```json
{
  "data": {
    "repository": {
      "commit": {
        "path": {
          "__typename": "GitTree",
          "path": "enterprise/cmd/server/main.go",
          "isDirectory": false
        }
      }
    }
  }
}
```

Success (tree):

```graphql
{
  repository(name: "github.com/sourcegraph/sourcegraph") {
    commit(rev: "HEAD") {
      path(path: "enterprise") {
        ... on GitTree {
          __typename
          path
          isDirectory
        }
        ... on GitBlob {
          __typename
          path
          isDirectory
        }
      }
    }
  }
}
```

```json
{
  "data": {
    "repository": {
      "commit": {
        "path": {
          "__typename": "GitTree",
          "path": "enterprise",
          "isDirectory": true
        }
      }
    }
  }
}
```

## Test plan

Tested local API via console by hand. See PR description.