### PR TITLE
Fix global keyboard shorcuts interference with CodeMirror search query input

### DIFF
--- a/client/search-ui/src/input/CodeMirrorQueryInput.tsx
+++ b/client/search-ui/src/input/CodeMirrorQueryInput.tsx
@@ -35,11 +35,11 @@ import { appendContextFilter } from '@sourcegraph/shared/src/search/query/transf
 import { SearchMatch } from '@sourcegraph/shared/src/search/stream'
 import { fetchStreamSuggestions } from '@sourcegraph/shared/src/search/suggestions'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
+import { isInputElement } from '@sourcegraph/shared/src/util/dom'
 
 import { MonacoQueryInputProps } from './MonacoQueryInput'
 
 import styles from './CodeMirrorQueryInput.module.scss'
-import { isInputElement } from '@sourcegraph/shared/src/util/dom'
 
 const replacePattern = /[\n\r↵]/g
 

--- a/client/search-ui/src/input/CodeMirrorQueryInput.tsx
+++ b/client/search-ui/src/input/CodeMirrorQueryInput.tsx
@@ -39,6 +39,7 @@ import { ThemeProps } from '@sourcegraph/shared/src/theme'
 import { MonacoQueryInputProps } from './MonacoQueryInput'
 
 import styles from './CodeMirrorQueryInput.module.scss'
+import { isInputElement } from '@sourcegraph/shared/src/util/dom'
 
 const replacePattern = /[\n\r↵]/g
 
@@ -213,11 +214,7 @@ export const CodeMirrorMonacoFacade: React.FunctionComponent<MonacoQueryInputPro
     // It looks like <Shortcut ... /> needs a stable onMatch callback, hence we
     // are storing the editor in a ref so that `globalFocus` is stable.
     const globalFocus = useCallback(() => {
-        if (
-            editorReference.current &&
-            !!document.activeElement &&
-            !['INPUT', 'TEXTAREA'].includes(document.activeElement.nodeName)
-        ) {
+        if (editorReference.current && !!document.activeElement && !isInputElement(document.activeElement)) {
             editorReference.current.focus()
         }
     }, [editorReference])

--- a/client/shared/src/components/CodeMirrorEditor.ts
+++ b/client/shared/src/components/CodeMirrorEditor.ts
@@ -55,9 +55,3 @@ export function useCodeMirror(
 
     return view
 }
-
-export function elementIsInput(element: HTMLElement): boolean {
-    return (
-        element.nodeName === 'INPUT' || element.nodeName === 'TEXTAREA' || !!element.closest('[contenteditable=true]')
-    )
-}

--- a/client/shared/src/components/MonacoEditor.tsx
+++ b/client/shared/src/components/MonacoEditor.tsx
@@ -8,6 +8,7 @@ import { map, distinctUntilChanged } from 'rxjs/operators'
 
 import { KeyboardShortcut } from '../keyboardShortcuts'
 import { ThemeProps } from '../theme'
+import { isInputElement } from '../util/dom'
 
 const SOURCEGRAPH_LIGHT = 'sourcegraph-light'
 const SOURCEGRAPH_DARK = 'sourcegraph-dark'
@@ -300,11 +301,7 @@ export class MonacoEditor extends React.PureComponent<Props, State> {
     }
 
     private focusInput = (): void => {
-        if (
-            this.editor &&
-            !!document.activeElement &&
-            !['INPUT', 'TEXTAREA'].includes(document.activeElement.nodeName)
-        ) {
+        if (this.editor && !!document.activeElement && !isInputElement(document.activeElement)) {
             this.editor.focus()
         }
     }

--- a/client/shared/src/util/dom.test.ts
+++ b/client/shared/src/util/dom.test.ts
@@ -1,0 +1,35 @@
+import { isInputElement } from './dom'
+
+describe('isInputElement', () => {
+    test('detect <input> elements as input', () => {
+        const element = document.createElement('input')
+        expect(isInputElement(element)).toBe(true)
+    })
+
+    test('detect <textarea> elements as input', () => {
+        const element = document.createElement('textarea')
+        expect(isInputElement(element)).toBe(true)
+    })
+
+    test('detect contenteditable elements as input', () => {
+        const element = document.createElement('div')
+        element.contentEditable = ''
+        expect(isInputElement(element)).toBe(true)
+
+        element.contentEditable = 'true'
+        expect(isInputElement(element)).toBe(true)
+
+        element.contentEditable = 'invalid value'
+        expect(isInputElement(element)).toBe(false)
+    })
+
+    test('detect content editable elements inherited', () => {
+        const parent = document.createElement('div')
+        parent.contentEditable = ''
+
+        const element = document.createElement('span')
+        parent.appendChild(element)
+
+        expect(isInputElement(element)).toBe(true)
+    })
+})

--- a/client/shared/src/util/dom.test.ts
+++ b/client/shared/src/util/dom.test.ts
@@ -28,7 +28,7 @@ describe('isInputElement', () => {
         parent.contentEditable = ''
 
         const element = document.createElement('span')
-        parent.appendChild(element)
+        parent.append(element)
 
         expect(isInputElement(element)).toBe(true)
     })

--- a/client/shared/src/util/dom.ts
+++ b/client/shared/src/util/dom.ts
@@ -1,0 +1,32 @@
+/**
+ * Checks whether the element can receive (keyboard) input. That's the case for
+ * <input>, <textarea> and content editable elements.
+ */
+export function isInputElement(element: Element): boolean {
+    switch (element.nodeName) {
+        case 'INPUT':
+        case 'TEXTAREA':
+            return true
+        default:
+            return elementIsContentEditable(element as HTMLElement)
+    }
+}
+
+/**
+ * Empty string and 'true' indicate that the element is editable. 'false'
+ * indicates that the element is not editable. A missing value or an invalid
+ * value implies inheritence from the parent.
+ *
+ * See https://html.spec.whatwg.org/multipage/interaction.html#attr-contenteditable
+ */
+function elementIsContentEditable(element: HTMLElement): boolean {
+    switch (element.contentEditable) {
+        case '':
+        case 'true':
+            return true
+        case 'false':
+            return false
+        default:
+            return element.parentElement ? elementIsContentEditable(element.parentElement) : false
+    }
+}

--- a/client/web/src/notebooks/notebook/useNotebookEventHandlers.ts
+++ b/client/web/src/notebooks/notebook/useNotebookEventHandlers.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo } from 'react'
 
 import { isMacPlatform as isMacPlatformFn } from '@sourcegraph/common'
-import { elementIsInput } from '@sourcegraph/shared/src/components/CodeMirrorEditor'
+import { isInputElement } from '@sourcegraph/shared/src/util/dom'
 
 import { BlockDirection, BlockProps } from '..'
 
@@ -75,7 +75,7 @@ export function useNotebookEventHandlers({
         const handleKeyDown = (event: KeyboardEvent): void => {
             const target = event.target as HTMLElement
 
-            if (elementIsInput(target)) {
+            if (isInputElement(target)) {
                 return
             }
 

--- a/client/web/src/repo/actions/GoToPermalinkAction.tsx
+++ b/client/web/src/repo/actions/GoToPermalinkAction.tsx
@@ -6,6 +6,7 @@ import { fromEvent, Subscription } from 'rxjs'
 import { filter } from 'rxjs/operators'
 
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
+import { isInputElement } from '@sourcegraph/shared/src/util/dom'
 import { Icon } from '@sourcegraph/wildcard'
 
 import { replaceRevisionInURL } from '../../util/url'
@@ -43,9 +44,7 @@ export class GoToPermalinkAction extends React.PureComponent<
                     filter(
                         event =>
                             // 'y' shortcut (if no input element is focused)
-                            event.key === 'y' &&
-                            !!document.activeElement &&
-                            !['INPUT', 'TEXTAREA'].includes(document.activeElement.nodeName)
+                            event.key === 'y' && !!document.activeElement && !isInputElement(document.activeElement)
                     )
                 )
                 .subscribe(event => {


### PR DESCRIPTION
Fixes #33208

The logic we use [in a couple of places](https://sourcegraph.com/search?q=context:%40sourcegraph/all+%28%27INPUT%27+OR+%27TEXTAREA%27%29+r:%5Egithub%5C.com/sourcegraph/sourcegraph%24+rev:c41e51dfaed1d26a941c9053401fb39ea99e9915+&patternType=literal&case=yes) to determine whether events originate in an input element doesn't work for CodeMirror because it uses a `contenteditable` element (unlike, apparently, Monaco).
Note that not all those places interfere with the CodeMirror query input but I thought it would make sense to use the same function everywhere.

Not sure whether that's the best place to put this logic.

## Test plan

New unit test

Enabled CodeMirror query input (`"editor": "codemirror6"` in user settings) and verified that typing `y` in the input on a blob page doesn't trigger the global keyboard shortcut anymore.
## App preview:
- [Link](https://sg-web-fkling-33208-global-keyboard.onrender.com)

