### PR TITLE
codeintel: Add useCodeIntelStatus hook

### DIFF
--- a/client/web/src/enterprise/codeintel/RepositoryMenu.tsx
+++ b/client/web/src/enterprise/codeintel/RepositoryMenu.tsx
@@ -23,7 +23,7 @@ export const RepositoryMenuContent: React.FunctionComponent<RepositoryMenuConten
     return loading ? (
         <LoadingSpinner />
     ) : error ? (
-        { error }
+        <span>{error}</span>
     ) : data ? (
         <>
             <div className="px-2 py-1">

--- a/client/web/src/enterprise/codeintel/RepositoryMenu.tsx
+++ b/client/web/src/enterprise/codeintel/RepositoryMenu.tsx
@@ -1,15 +1,30 @@
 import React from 'react'
 
 import { isErrorLike } from '@sourcegraph/common'
+import { LoadingSpinner } from '@sourcegraph/wildcard'
 
 import { RepositoryMenuContentProps } from '../../codeintel/RepositoryMenu'
 
+import { useCodeIntelStatus } from './useCodeIntelStatus'
+
 export const RepositoryMenuContent: React.FunctionComponent<RepositoryMenuContentProps> = props => {
+    const { data, loading, error } = useCodeIntelStatus({
+        variables: {
+            repository: props.repoName,
+            commit: props.revision,
+            path: props.filePath,
+        },
+    })
+
     const forNerds =
         !isErrorLike(props.settingsCascade.final) &&
         props.settingsCascade.final?.experimentalFeatures?.codeIntelRepositoryBadge?.forNerds
 
-    return (
+    return loading ? (
+        <LoadingSpinner />
+    ) : error ? (
+        { error }
+    ) : data ? (
         <>
             <div className="px-2 py-1">
                 <h2>Unimplemented</h2>
@@ -19,5 +34,7 @@ export const RepositoryMenuContent: React.FunctionComponent<RepositoryMenuConten
 
             {forNerds && <div className="px-2 py-1">NERD DATA</div>}
         </>
+    ) : (
+        <></>
     )
 }

--- a/client/web/src/enterprise/codeintel/useCodeIntelStatus.ts
+++ b/client/web/src/enterprise/codeintel/useCodeIntelStatus.ts
@@ -1,0 +1,169 @@
+import { ApolloError } from '@apollo/client'
+
+import { gql, useQuery } from '@sourcegraph/http-client'
+
+import {
+    CodeIntelStatusResult,
+    CodeIntelStatusVariables,
+    PreciseSupportFields,
+    SearchBasedCodeIntelSupportFields,
+} from '../../graphql-operations'
+
+import { lsifIndexFieldsFragment } from './indexes/hooks/types'
+import { lsifUploadFieldsFragment } from './uploads/hooks/types'
+
+const codeIntelIndexerFieldsFragment = gql`
+    fragment CodeIntelIndexerFields on CodeIntelIndexer {
+        name
+        url
+    }
+`
+
+const codeIntelSupportFieldsFragment = gql`
+    fragment CodeIntelSupportFields on CodeIntelSupport {
+        preciseSupport {
+            ...PreciseSupportFields
+        }
+        searchBasedSupport {
+            ...SearchBasedCodeIntelSupportFields
+        }
+    }
+`
+
+const gitTreeCodeIntelInfoFieldsFragment = gql`
+    fragment GitTreeCodeIntelInfoFields on GitTreeCodeIntelInfo {
+        preciseSupport {
+            support {
+                ...PreciseSupportFields
+            }
+            confidence
+        }
+        searchBasedSupport {
+            support {
+                ...SearchBasedCodeIntelSupportFields
+            }
+        }
+    }
+`
+
+const preciseSupportFieldsFragment = gql`
+    fragment PreciseSupportFields on PreciseCodeIntelSupport {
+        supportLevel
+        indexers {
+            ...CodeIntelIndexerFields
+        }
+    }
+`
+
+const searchBasedCodeIntelSupportFieldsFragment = gql`
+    fragment SearchBasedCodeIntelSupportFields on SearchBasedCodeIntelSupport {
+        language
+        supportLevel
+    }
+`
+
+const codeIntelStatusQuery = gql`
+    query CodeIntelStatus($repository: String!, $commit: String!, $path: String!) {
+        repository(name: $repository) {
+            codeIntelSummary {
+                lastIndexScan
+                lastUploadRetentionScan
+                recentUploads {
+                    root
+                    indexer {
+                        ...CodeIntelIndexerFields
+                    }
+                    uploads {
+                        ...LsifUploadFields
+                    }
+                }
+                recentIndexes {
+                    root
+                    indexer {
+                        ...CodeIntelIndexerFields
+                    }
+                    indexes {
+                        ...LsifIndexFields
+                    }
+                }
+            }
+            commit(rev: $commit) {
+                path(path: $path) {
+                    ... on GitBlob {
+                        codeIntelSupport {
+                            ...CodeIntelSupportFields
+                        }
+                    }
+                    ... on GitTree {
+                        codeIntelInfo {
+                            ...GitTreeCodeIntelInfoFields
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    ${lsifUploadFieldsFragment}
+    ${lsifIndexFieldsFragment}
+    ${codeIntelIndexerFieldsFragment}
+    ${codeIntelSupportFieldsFragment}
+    ${gitTreeCodeIntelInfoFieldsFragment}
+    ${preciseSupportFieldsFragment}
+    ${searchBasedCodeIntelSupportFieldsFragment}
+`
+
+interface UseCodeIntelStatusParameters {
+    variables: CodeIntelStatusVariables
+}
+
+interface UseCodeIntelStatusResult {
+    data?: {
+        preciseSupport?: PreciseSupportFields[]
+        searchBasedSupport?: SearchBasedCodeIntelSupportFields[]
+    }
+    error?: ApolloError
+    loading: boolean
+}
+
+export const useCodeIntelStatus = ({ variables }: UseCodeIntelStatusParameters): UseCodeIntelStatusResult => {
+    const { data: rawData, error, loading } = useQuery<CodeIntelStatusResult, CodeIntelStatusVariables>(
+        codeIntelStatusQuery,
+        {
+            variables,
+            notifyOnNetworkStatusChange: false,
+            fetchPolicy: 'no-cache',
+        }
+    )
+
+    const path = rawData?.repository?.commit?.path
+    switch (path?.__typename) {
+        case 'GitBlob': {
+            return {
+                data: {
+                    searchBasedSupport: [path.codeIntelSupport.searchBasedSupport],
+                    preciseSupport: [path.codeIntelSupport.preciseSupport],
+                },
+                error,
+                loading,
+            }
+        }
+
+        case 'GitTree': {
+            const info = path.codeIntelInfo
+            return {
+                data: info
+                    ? {
+                          searchBasedSupport: info.searchBasedSupport?.map(wrapper => wrapper.support) || [],
+                          preciseSupport: info.preciseSupport?.map(wrapper => wrapper.support) || [],
+                      }
+                    : undefined,
+                error,
+                loading,
+            }
+        }
+
+        default:
+            return { data: undefined, error, loading }
+    }
+}


### PR DESCRIPTION
Create `useCodeIntelStatus` hook and call it from feature-flagged code intel status badge. This doesn't change any behaviors yet (as we don't display anything but a loading spinner + error hook), but it presents the data to the component for display.

We should start being able to fill out both _nerd_ data as well as what's requested in the [figma document](https://www.figma.com/file/p5rVseXjNvXRkvXCdttbWt/Semantic-badge?node-id=541%3A227).

## Test plan

N/A.
## App preview:
- [Link](https://sg-web-ef-31180-2.onrender.com)

