### PR TITLE
codeintel: Fix naked scheme for index resolver URL

### DIFF
--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/indexers.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/indexers.go
@@ -12,6 +12,10 @@ func (r *codeIntelIndexerResolver) Name() string {
 }
 
 func (r *codeIntelIndexerResolver) URL() string {
+	if r.urn == "" {
+		return ""
+	}
+
 	return "https://" + r.urn
 }
 


### PR DESCRIPTION
Return `""`, not `"https://"` when no URI is supplied.

## Test plan

N/A.