### PR TITLE
Set insights data mount locally to match PG_DATA folder

### DIFF
--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -525,7 +525,7 @@ commands:
         -e POSTGRES_DATABASE=postgres \
         -e POSTGRES_USER=postgres \
         -p 0.0.0.0:$PORT:5432 \
-        -v $DISK:/var/lib/postgresql/data \
+        -v $DISK:/data/pgdata-12 \
         $IMAGE >$LOG_FILE 2>&1
     install: |
       mkdir -p $LOGS


### PR DESCRIPTION
When doing this I had to remove my existing `$HOME/.sourcegraph-dev/data/codeinsights-db` because startup would fail due to a timescale file not being present.

## Test plan
tbd
<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


