### PR TITLE
Update quickstart.md

### DIFF
--- a/doc/batch_changes/quickstart.md
+++ b/doc/batch_changes/quickstart.md
@@ -57,7 +57,7 @@ on:
 
 # In each repository, run this command. Each repository's resulting diff is captured.
 steps:
-  - run: echo Hello World | tee -a $(find -name README.md)
+  - run: echo Hello World | tee -a $(find README.md)
     container: alpine:3
 
 # Describe the changeset (e.g., GitHub pull request) you want for each repository.


### PR DESCRIPTION
`tee` might not take a `-name` field any longer:

```
kelvinlee@Kelvins-MacBook-Pro Project-Euler-Solutions % echo hello | tee -a $(find -name ./README.txt)
find: illegal option -- n
usage: find [-H | -L | -P] [-EXdsx] [-f path] path ... [expression]
       find [-H | -L | -P] [-EXdsx] -f path [path ...] [expression]
hello
```

`man tee` outputs:

```
(END)
TEE(1)                    BSD General Commands Manual                   TEE(1)

NAME
     tee -- pipe fitting

SYNOPSIS
     tee [-ai] [file ...]

DESCRIPTION
     The tee utility copies standard input to standard output, making a copy
     in zero or more files.  The output is unbuffered.

     The following options are available:

     -a      Append the output to the files rather than overwriting them.

     -i      Ignore the SIGINT signal.

     The following operands are available:

     file  A pathname of an output file.

     The tee utility takes the default action for all signals, except in the
     event of the -i option.

     The tee utility exits 0 on success, and >0 if an error occurs.

STANDARDS
     The tee function is expected to be POSIX IEEE Std 1003.2 (``POSIX.2'')
     compatible.

BSD                              June 6, 1993                              BSD
```

## Test plan
Trying out the Batch Changes doc locally. Including the `-name` flag fails. Excluding it allows me to create an expected changset.

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


