### PR TITLE
batches: fix file name command error on batch preview

### DIFF
--- a/client/web/src/enterprise/batches/create/OldCreateBatchChangeContent.tsx
+++ b/client/web/src/enterprise/batches/create/OldCreateBatchChangeContent.tsx
@@ -98,7 +98,7 @@ export const OldBatchChangePageContent: React.FunctionComponent<{}> = () => {
                     to preview the commits and changesets that your batch change will make:
                 </p>
                 <CodeSnippet
-                    code={`src batch preview -f ${getFileName(selectedSample.file)}`}
+                    code={`src batch preview -f ${getFileName(selectedSample.name)}`}
                     language="bash"
                     className="mb-3"
                 />

--- a/client/web/src/enterprise/batches/create/OldCreateBatchChangeContent.tsx
+++ b/client/web/src/enterprise/batches/create/OldCreateBatchChangeContent.tsx
@@ -4,6 +4,7 @@ import { CodeSnippet } from '@sourcegraph/branded/src/components/CodeSnippet'
 import { Container, Button, Link } from '@sourcegraph/wildcard'
 
 import { SidebarGroup, SidebarGroupHeader } from '../../../components/Sidebar'
+import { getFileName } from '../BatchSpec'
 
 import combySample from './library/comby.batch.yaml'
 import goImportsSample from './library/go-imports.batch.yaml'
@@ -96,7 +97,11 @@ export const OldBatchChangePageContent: React.FunctionComponent<{}> = () => {
                     </Link>{' '}
                     to preview the commits and changesets that your batch change will make:
                 </p>
-                <CodeSnippet code={`src batch preview -f ${selectedSample.name}`} language="bash" className="mb-3" />
+                <CodeSnippet
+                    code={`src batch preview -f ${getFileName(selectedSample.file)}`}
+                    language="bash"
+                    className="mb-3"
+                />
                 <p className="mb-0">
                     Follow the URL printed in your terminal to see the preview and (when you're ready) create the batch
                     change.


### PR DESCRIPTION
Closes #33082

Using `getFileName` helper to properly generate a file name on old create batch page to remove the error that currently displays due to incorrect format (missing yaml extension)


## Test plan
disabled experimental features in order to see the old batch change create page 

<img width="1138" alt="Screen Shot 2022-04-05 at 6 53 47 PM" src="https://user-images.githubusercontent.com/67931373/161864005-1c60b957-0d61-4cf8-8f03-268f1ef7e860.png">

## App preview:
- [Link](https://sg-web-aa-fix-batch-preview-cmd.onrender.com)

