### PR TITLE
gitserver: add logs to janitor and make the test less primitive in terms of repo names

### DIFF
--- a/cmd/gitserver/server/cleanup.go
+++ b/cmd/gitserver/server/cleanup.go
@@ -401,6 +401,12 @@ func (s *Server) cleanupRepos() {
 
 // setRepoSizes uses calculated sizes of repos to update database entries of repos with repo_size_bytes = NULL
 func (s *Server) setRepoSizes(ctx context.Context, repoToSize map[api.RepoName]int64) error {
+	if len(repoToSize) == 0 {
+		log15.Info("cleanup: file system walk didn't yield any directory sizes")
+		return nil
+	}
+	log15.Info(fmt.Sprintf("cleanup: %v directory sizes calculated during file system walk", len(repoToSize)))
+
 	db := s.DB
 	gitserverRepos := db.GitserverRepos()
 	// getting all the repos without size
@@ -409,7 +415,7 @@ func (s *Server) setRepoSizes(ctx context.Context, repoToSize map[api.RepoName]i
 		return err
 	}
 	if len(reposWithoutSize) == 0 {
-		log15.Info("cleanup: all repos have their sizes")
+		log15.Info("cleanup: all repos in a DB have their sizes")
 		return nil
 	}
 

--- a/cmd/gitserver/server/cleanup_test.go
+++ b/cmd/gitserver/server/cleanup_test.go
@@ -1166,7 +1166,11 @@ func TestCleanup_setRepoSizes(t *testing.T) {
 	}
 	defer os.RemoveAll(root)
 
-	for _, name := range []string{"a", "b", "c"} {
+	for _, name := range []string{
+		"ghe.sgdev.org/sourcegraph/gorilla-websocket",
+		"ghe.sgdev.org/sourcegraph/gorilla-mux",
+		"ghe.sgdev.org/sourcegraph/gorilla-sessions",
+	} {
 		p := path.Join(root, name, ".git")
 		if err := os.MkdirAll(p, 0755); err != nil {
 			t.Fatal(err)
@@ -1186,7 +1190,10 @@ func TestCleanup_setRepoSizes(t *testing.T) {
 
 	// inserting info about repos to DB. Repo with ID = 1 already has its size
 	if _, err := db.Exec(`
-insert into repo(id, name) values (1, 'a'), (2, 'b'), (3, 'c');
+insert into repo(id, name)
+values (1, 'ghe.sgdev.org/sourcegraph/gorilla-websocket'),
+       (2, 'ghe.sgdev.org/sourcegraph/gorilla-mux'),
+       (3, 'ghe.sgdev.org/sourcegraph/gorilla-sessions');
 insert into gitserver_repos(repo_id, shard_id) values (2, 1), (3, 1);
 insert into gitserver_repos(repo_id, shard_id, repo_size_bytes) values (1, 1, 228);
 `); err != nil {


### PR DESCRIPTION
Just adding logs to see why repo sizes are not updated on .com

## Test plan
CI passed
<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


