### PR TITLE
repo-updater: Increase time allowed to sync repo in background

### DIFF
--- a/cmd/repo-updater/repoupdater/server.go
+++ b/cmd/repo-updater/repoupdater/server.go
@@ -286,9 +286,9 @@ func externalServiceValidate(ctx context.Context, req protocol.ExternalServiceSy
 var mockRepoLookup func(protocol.RepoLookupArgs) (*protocol.RepoLookupResult, error)
 
 func (s *Server) repoLookup(ctx context.Context, args protocol.RepoLookupArgs) (result *protocol.RepoLookupResult, err error) {
-	// Sourcegraph.com: this is on the user path, do not block for ever if codehost is being
-	// bad. Ideally block before cloudflare 504s the request (1min).
-	// Other: we only speak to our database, so response should be in a few ms.
+	// Sourcegraph.com: this is on the user path, do not block forever if codehost is
+	// being bad. Ideally block before cloudflare 504s the request (1min). Other: we
+	// only speak to our database, so response should be in a few ms.
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 

--- a/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
+++ b/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
@@ -1225,7 +1225,7 @@ func (s *PermsSyncer) observe(ctx context.Context, family, title string) (contex
 
 		if !success {
 			tr.SetError(*err)
-			metricsSyncErrors.WithLabelValues(typLabel).Add(1)
+			metricsSyncErrors.WithLabelValues(typLabel).Inc()
 		}
 	}
 }

--- a/enterprise/internal/batches/syncer/syncer.go
+++ b/enterprise/internal/batches/syncer/syncer.go
@@ -366,7 +366,7 @@ func (s *changesetSyncer) Run(ctx context.Context) {
 			err := s.syncFunc(ctx, next.changesetID)
 			labelValues := []string{s.codeHostURL, strconv.FormatBool(err == nil)}
 			s.metrics.syncDuration.WithLabelValues(labelValues...).Observe(s.syncStore.Clock()().Sub(start).Seconds())
-			s.metrics.syncs.WithLabelValues(labelValues...).Add(1)
+			s.metrics.syncs.WithLabelValues(labelValues...).Inc()
 
 			if err != nil {
 				log15.Error("Syncing changeset", "err", err)

--- a/internal/metrics/operation.go
+++ b/internal/metrics/operation.go
@@ -28,7 +28,7 @@ func (m *REDMetrics) Observe(secs, count float64, err *error, lvals ...string) {
 	}
 
 	if err != nil && *err != nil {
-		m.Errors.WithLabelValues(lvals...).Add(1)
+		m.Errors.WithLabelValues(lvals...).Inc()
 	} else {
 		m.Duration.WithLabelValues(lvals...).Observe(secs)
 		m.Count.WithLabelValues(lvals...).Add(count)

--- a/internal/repos/sync_errored.go
+++ b/internal/repos/sync_errored.go
@@ -54,7 +54,7 @@ func (s *Syncer) SyncReposWithLastErrors(ctx context.Context, rateLimiter *rate.
 		if err != nil {
 			log15.Error("error syncing repo", "repo", repo.Name, "err", err)
 		}
-		erroredRepoGauge.Add(1)
+		erroredRepoGauge.Inc()
 		return nil
 	})
 	return err

--- a/internal/repos/syncer.go
+++ b/internal/repos/syncer.go
@@ -289,7 +289,7 @@ func (s *Syncer) SyncRepo(ctx context.Context, name api.RepoName, background boo
 
 	if background && repo != nil {
 		go func() {
-			ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+			ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
 			defer cancel()
 
 			// We don't care about the return value here, but we still want to ensure that
@@ -841,7 +841,7 @@ func (s *Syncer) observeSync(
 
 		if !success {
 			tr.SetError(err)
-			syncErrors.WithLabelValues(family, owner).Add(1)
+			syncErrors.WithLabelValues(family, owner).Inc()
 		}
 
 		tr.Finish()


### PR DESCRIPTION
This only affects sourcegraph.com

We're seeing an increase in failed background syncs and looking into the
logs we can see that most of them are due to our internal rate limiter
being exceeded.

Since we usually wait on the limiter, the reason it is failing is that
the amount of time we'd need to wait would exceed the time on the
context we're using in the background sync, which was set to one minute.
In this case, it bails out immediately with an error since the context
would expire before the rate limiter would allow the request.

I've increase the context on our background context to three minutes
which should decrease these failures. One potential downside is we're
going to have more running goroutines but they're pretty cheap and so it
should be ok.

I also updated a few places in our code where I noticed we were
increasing metrics using Add(1) instead of Inc()
