### PR TITLE
Move git.DiffPath to gitserver.Client

### DIFF
--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/resolver.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/resolver.go
@@ -14,6 +14,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	executor "github.com/sourcegraph/sourcegraph/internal/services/executors/transport/graphql"
 	"github.com/sourcegraph/sourcegraph/internal/symbols"
@@ -212,7 +213,7 @@ func (r *resolver) QueryResolver(ctx context.Context, args *gql.GitBlobLSIFDataA
 		r.dbStore,
 		r.lsifStore,
 		cachedCommitChecker,
-		NewPositionAdjuster(args.Repo, string(args.Commit), r.hunkCache),
+		NewPositionAdjuster(gitserver.NewClient(r.db), args.Repo, string(args.Commit), r.hunkCache),
 		int(args.Repo.ID),
 		string(args.Commit),
 		args.Path,

--- a/internal/gitserver/client.go
+++ b/internal/gitserver/client.go
@@ -26,10 +26,12 @@ import (
 	otlog "github.com/opentracing/opentracing-go/log"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/sourcegraph/go-diff/diff"
 
 	"github.com/sourcegraph/go-rendezvous"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/gitolite"
@@ -224,6 +226,10 @@ type Client interface {
 	// it goes by calling onMatches with each set of results it receives in
 	// response.
 	Search(_ context.Context, _ *protocol.SearchRequest, onMatches func([]protocol.CommitMatch)) (limitHit bool, _ error)
+
+	// DiffPath returns a position-ordered slice of changes (additions or deletions)
+	// of the given path between the given source and target commits.
+	DiffPath(ctx context.Context, repo api.RepoName, sourceCommit, targetCommit, path string, checker authz.SubRepoPermissionChecker) ([]*diff.Hunk, error)
 }
 
 func (c *ClientImplementor) Addrs() []string {

--- a/internal/gitserver/commands_test.go
+++ b/internal/gitserver/commands_test.go
@@ -3,10 +3,13 @@ package gitserver
 import (
 	"context"
 	"io"
+	"os"
 	"reflect"
 	"strings"
 	"testing"
 
+	"github.com/sourcegraph/sourcegraph/internal/actor"
+	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
@@ -228,6 +231,65 @@ index 9bd8209..d2acfa9 100644
 		}
 		if count != testDiffFiles {
 			t.Errorf("unexpected diff count: have %d; want %d", count, testDiffFiles)
+		}
+	})
+}
+
+func TestDiffPath(t *testing.T) {
+	testDiff := `
+diff --git a/foo.md b/foo.md
+index 51a59ef1c..493090958 100644
+--- a/foo.md
++++ b/foo.md
+@@ -1 +1 @@
+-this is my file content
++this is my file contnent
+`
+	db := database.NewMockDB()
+	client := NewClient(db)
+	t.Run("basic", func(t *testing.T) {
+		Mocks.ExecReader = func(args []string) (io.ReadCloser, error) {
+			return io.NopCloser(strings.NewReader(testDiff)), nil
+		}
+		ctx := context.Background()
+		checker := authz.NewMockSubRepoPermissionChecker()
+		ctx = actor.WithActor(ctx, &actor.Actor{
+			UID: 1,
+		})
+		hunks, err := client.DiffPath(ctx, "", "sourceCommit", "", "file", checker)
+		if err != nil {
+			t.Errorf("unexpected error: %s", err)
+		}
+		if len(hunks) != 1 {
+			t.Errorf("unexpected hunks returned: %d", len(hunks))
+		}
+	})
+	t.Run("with sub-repo permissions enabled", func(t *testing.T) {
+		Mocks.ExecReader = func(args []string) (io.ReadCloser, error) {
+			return io.NopCloser(strings.NewReader(testDiff)), nil
+		}
+		ctx := context.Background()
+		checker := authz.NewMockSubRepoPermissionChecker()
+		ctx = actor.WithActor(ctx, &actor.Actor{
+			UID: 1,
+		})
+		fileName := "foo"
+		checker.EnabledFunc.SetDefaultHook(func() bool {
+			return true
+		})
+		// User doesn't have access to this file
+		checker.PermissionsFunc.SetDefaultHook(func(ctx context.Context, i int32, content authz.RepoContent) (authz.Perms, error) {
+			if content.Path == fileName {
+				return authz.None, nil
+			}
+			return authz.Read, nil
+		})
+		hunks, err := client.DiffPath(ctx, "", "sourceCommit", "", fileName, checker)
+		if !reflect.DeepEqual(err, os.ErrNotExist) {
+			t.Errorf("unexpected error: %s", err)
+		}
+		if hunks != nil {
+			t.Errorf("expected DiffPath to return no results, got %v", hunks)
 		}
 	})
 }

--- a/internal/vcs/git/diff.go
+++ b/internal/vcs/git/diff.go
@@ -1,49 +1,15 @@
 package git
 
 import (
-	"bytes"
 	"context"
 	"io"
-	"os"
 
 	"github.com/sourcegraph/go-diff/diff"
 
-	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/api"
-	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 )
-
-// DiffPath returns a position-ordered slice of changes (additions or deletions)
-// of the given path between the given source and target commits.
-func DiffPath(ctx context.Context, db database.DB, repo api.RepoName, sourceCommit, targetCommit, path string, checker authz.SubRepoPermissionChecker) ([]*diff.Hunk, error) {
-	a := actor.FromContext(ctx)
-	if hasAccess, err := authz.FilterActorPath(ctx, checker, a, repo, path); err != nil {
-		return nil, err
-	} else if !hasAccess {
-		return nil, os.ErrNotExist
-	}
-	reader, err := execReader(ctx, db, repo, []string{"diff", sourceCommit, targetCommit, "--", path})
-	if err != nil {
-		return nil, err
-	}
-	defer reader.Close()
-
-	output, err := io.ReadAll(reader)
-	if err != nil {
-		return nil, err
-	}
-	if len(output) == 0 {
-		return nil, nil
-	}
-
-	d, err := diff.NewFileDiffReader(bytes.NewReader(output)).Read()
-	if err != nil {
-		return nil, err
-	}
-	return d.Hunks, nil
-}
 
 // DiffSymbols performs a diff command which is expected to be parsed by our symbols package
 func DiffSymbols(ctx context.Context, db database.DB, repo api.RepoName, commitA, commitB api.CommitID) ([]byte, error) {

--- a/internal/vcs/git/diff_test.go
+++ b/internal/vcs/git/diff_test.go
@@ -1,76 +1,10 @@
 package git
 
 import (
-	"context"
-	"io"
-	"os"
-	"reflect"
-	"strings"
 	"testing"
 
-	"github.com/sourcegraph/sourcegraph/internal/actor"
-	"github.com/sourcegraph/sourcegraph/internal/authz"
-	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
-
-func TestDiffPath(t *testing.T) {
-	testDiff := `
-diff --git a/foo.md b/foo.md
-index 51a59ef1c..493090958 100644
---- a/foo.md
-+++ b/foo.md
-@@ -1 +1 @@
--this is my file content
-+this is my file contnent
-`
-	db := database.NewMockDB()
-	t.Run("basic", func(t *testing.T) {
-		Mocks.ExecReader = func(args []string) (io.ReadCloser, error) {
-			return io.NopCloser(strings.NewReader(testDiff)), nil
-		}
-		ctx := context.Background()
-		checker := authz.NewMockSubRepoPermissionChecker()
-		ctx = actor.WithActor(ctx, &actor.Actor{
-			UID: 1,
-		})
-		hunks, err := DiffPath(ctx, db, "", "sourceCommit", "", "file", checker)
-		if err != nil {
-			t.Errorf("unexpected error: %s", err)
-		}
-		if len(hunks) != 1 {
-			t.Errorf("unexpected hunks returned: %d", len(hunks))
-		}
-	})
-	t.Run("with sub-repo permissions enabled", func(t *testing.T) {
-		Mocks.ExecReader = func(args []string) (io.ReadCloser, error) {
-			return io.NopCloser(strings.NewReader(testDiff)), nil
-		}
-		ctx := context.Background()
-		checker := authz.NewMockSubRepoPermissionChecker()
-		ctx = actor.WithActor(ctx, &actor.Actor{
-			UID: 1,
-		})
-		fileName := "foo"
-		checker.EnabledFunc.SetDefaultHook(func() bool {
-			return true
-		})
-		// User doesn't have access to this file
-		checker.PermissionsFunc.SetDefaultHook(func(ctx context.Context, i int32, content authz.RepoContent) (authz.Perms, error) {
-			if content.Path == fileName {
-				return authz.None, nil
-			}
-			return authz.Read, nil
-		})
-		hunks, err := DiffPath(ctx, db, "", "sourceCommit", "", fileName, checker)
-		if !reflect.DeepEqual(err, os.ErrNotExist) {
-			t.Errorf("unexpected error: %s", err)
-		}
-		if hunks != nil {
-			t.Errorf("expected DiffPath to return no results, got %v", hunks)
-		}
-	})
-}
 
 func TestDiffFileIterator(t *testing.T) {
 	t.Run("Close", func(t *testing.T) {


### PR DESCRIPTION
### Description

This change is a part of a larger effort to reorganize code in gitserver. The Repository Management Team is moving git commands from `internal/vcs/git` to `internal/gitserver`.

See this issue for more details https://github.com/sourcegraph/sourcegraph/issues/33280

Closes https://github.com/sourcegraph/sourcegraph/issues/33439

## Test plan

Code only moved around, all tests still pass.
