### PR TITLE
search-blitz: extra queries for dogfood

### DIFF
--- a/internal/cmd/search-blitz/config.go
+++ b/internal/cmd/search-blitz/config.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"embed"
 	_ "embed"
 	"strings"
 	"time"
@@ -9,8 +10,8 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
-//go:embed queries.txt
-var queriesRaw []byte
+//go:embed queries*.txt
+var queriesFS embed.FS
 
 type Config struct {
 	Groups []*QueryGroupConfig
@@ -42,7 +43,25 @@ const (
 	Stream
 )
 
-func loadQueries() (_ *Config, err error) {
+func loadQueries(env string) (_ *Config, err error) {
+	if env == "" {
+		env = "cloud"
+	}
+
+	queriesRaw, err := queriesFS.ReadFile("queries.txt")
+	if err != nil {
+		return nil, err
+	}
+
+	if env != "cloud" {
+		extra, err := queriesFS.ReadFile("queries_" + env + ".txt")
+		if err != nil {
+			return nil, err
+		}
+		queriesRaw = append(queriesRaw, '\n')
+		queriesRaw = append(queriesRaw, extra...)
+	}
+
 	var queries []*QueryConfig
 	var current QueryConfig
 	add := func() {

--- a/internal/cmd/search-blitz/config_test.go
+++ b/internal/cmd/search-blitz/config_test.go
@@ -3,30 +3,34 @@ package main
 import "testing"
 
 func TestLoadQueries(t *testing.T) {
-	c, err := loadQueries()
-	if err != nil {
-		t.Fatal(err)
-	}
+	for _, env := range []string{"", "cloud", "dogfood"} {
+		t.Run(env, func(t *testing.T) {
+			c, err := loadQueries(env)
+			if err != nil {
+				t.Fatal(err)
+			}
 
-	if len(c.Groups) < 1 {
-		t.Fatal("expected atleast 1 group")
-	}
+			if len(c.Groups) < 1 {
+				t.Fatal("expected atleast 1 group")
+			}
 
-	if len(c.Groups[0].Queries) < 2 {
-		t.Fatal("expected atleast 2 queries")
-	}
+			if len(c.Groups[0].Queries) < 2 {
+				t.Fatal("expected atleast 2 queries")
+			}
 
-	names := map[string]bool{}
-	for _, q := range c.Groups[0].Queries {
-		if names[q.Name] {
-			t.Fatalf("name %q is not unique", q.Name)
-		}
-		names[q.Name] = true
-	}
+			names := map[string]bool{}
+			for _, q := range c.Groups[0].Queries {
+				if names[q.Name] {
+					t.Fatalf("name %q is not unique", q.Name)
+				}
+				names[q.Name] = true
+			}
 
-	if testing.Verbose() {
-		for _, q := range c.Groups[0].Queries {
-			t.Logf("% -25s %s", q.Name, q.Query)
-		}
+			if testing.Verbose() {
+				for _, q := range c.Groups[0].Queries {
+					t.Logf("% -25s %s", q.Name, q.Query)
+				}
+			}
+		})
 	}
 }

--- a/internal/cmd/search-blitz/main.go
+++ b/internal/cmd/search-blitz/main.go
@@ -24,7 +24,7 @@ const (
 	envLogDir = "LOG_DIR"
 )
 
-func run(ctx context.Context, wg *sync.WaitGroup) {
+func run(ctx context.Context, wg *sync.WaitGroup, env string) {
 	defer wg.Done()
 
 	bc, err := newClient()
@@ -37,7 +37,7 @@ func run(ctx context.Context, wg *sync.WaitGroup) {
 		panic(err)
 	}
 
-	config, err := loadQueries()
+	config, err := loadQueries(env)
 	if err != nil {
 		panic(err)
 	}
@@ -188,9 +188,11 @@ func main() {
 	ctx, cleanup := SignalSensitiveContext()
 	defer cleanup()
 
+	env := os.Getenv("SEARCH_BLITZ_ENV")
+
 	wg := sync.WaitGroup{}
 	wg.Add(1)
-	go run(ctx, &wg)
+	go run(ctx, &wg, env)
 
 	wg.Add(1)
 	srv := startServer(&wg)

--- a/internal/cmd/search-blitz/queries_dogfood.txt
+++ b/internal/cmd/search-blitz/queries_dogfood.txt
@@ -1,0 +1,29 @@
+## queries just for dogfood (k8s.sgdev.org)
+
+## These are our monorepo queries, but targetting the gigarepo instead which
+## is much larger scale and only exists on dogfood. We keep the regular
+## monorepo queries so we can compare performance between cloud and dogfood.
+
+# giga_regex_small
+repo:^gigarepo$ patterntype:regexp se[arc]{3}hZoekt
+
+# giga_rev_regex_small
+repo:^gigarepo$ patterntype:regexp se[arc]{3}hZoekt rev:main
+
+# giga_structural_small
+repo:^gigarepo$ patterntype:structural strings.ToUpper(...)
+
+# giga_rev_structural_small
+repo:^gigarepo$ patterntype:structural strings.ToUpper(...) rev:main
+
+# giga_symbol_small
+repo:^gigarepo$ type:symbol IndexFormatVersion
+
+# giga_rev_symbol_small
+repo:^gigarepo$ type:symbol IndexFormatVersion rev:main
+
+# giga_diff_small
+repo:^gigarepo$ type:diff   author:camden before:"february 1 2021"
+
+# giga_commit_small
+repo:^gigarepo$ type:commit author:camden before:"february 1 2021"


### PR DESCRIPTION
We want to run search blitz on dogfood. However, we need extra queries to target gigarepo which is only available on dogfood. This commit adds logic to take the existing queries and add extra queries based on the environment variable SEARCH_BLITZ_ENV.

Test Plan: CI and manual testing on dogfood.

This is an alternative implementation to https://github.com/sourcegraph/sourcegraph/pull/33436
