### PR TITLE
Wildcard: update multi select styles for better accessibility

### DIFF
--- a/client/branded/src/global-styles/forms.scss
+++ b/client/branded/src/global-styles/forms.scss
@@ -15,6 +15,7 @@
     --input-placeholder-color: var(--gray-07);
     --input-focus-border-color: var(--border-active-color);
     --input-focus-box-shadow: var(--focus-box-shadow);
+    --input-light-hover: var(--gray-02);
     --input-focus-box-shadow-valid: 0 0 0 2px var(--success-2);
     --input-focus-box-shadow-invalid: 0 0 0 2px var(--danger-2);
 
@@ -30,6 +31,7 @@
     --input-placeholder-color: var(--gray-05);
     --input-focus-border-color: var(--border-active-color);
     --input-focus-box-shadow: var(--focus-box-shadow);
+    --input-light-hover: var(--gray-09);
     --input-focus-box-shadow-valid: 0 0 0 2px var(--success-3);
     --input-focus-box-shadow-invalid: 0 0 0 2px var(--danger-3);
 

--- a/client/wildcard/src/components/Form/MultiSelect/styles.ts
+++ b/client/wildcard/src/components/Form/MultiSelect/styles.ts
@@ -4,6 +4,10 @@ export const STYLES: StylesConfig = {
     clearIndicator: provided => ({
         ...provided,
         padding: '0 0.125rem',
+        borderRadius: 'var(--border-radius)',
+        '&:hover': {
+            background: 'var(--input-light-hover)'
+        },
     }),
     control: (provided, state) => ({
         ...provided,
@@ -24,6 +28,7 @@ export const STYLES: StylesConfig = {
                 ? 'var(--input-focus-box-shadow-invalid)'
                 : 'var(--input-focus-box-shadow)'
             : undefined,
+        cursor: 'pointer',
         '&:hover': {
             borderColor: undefined,
         },
@@ -31,6 +36,10 @@ export const STYLES: StylesConfig = {
     dropdownIndicator: provided => ({
         ...provided,
         padding: '0 0.125rem',
+        borderRadius: 'var(--border-radius)',
+        '&:hover': {
+            background: 'var(--input-light-hover)'
+        }
     }),
     indicatorSeparator: (provided, state) => ({
         ...provided,
@@ -45,21 +54,23 @@ export const STYLES: StylesConfig = {
     menu: provided => ({
         ...provided,
         background: 'var(--dropdown-bg)',
-        padding: '0.25rem 0',
+        padding: 0,
         margin: '0.125rem 0 0',
         dropShadow: 'var(--dropdown-shadow)',
+        // This is to prevent item edges from sticking out of the rounded dropdown container
+        overflow: 'hidden'
     }),
     menuList: provided => ({
         ...provided,
         padding: 0,
     }),
-    multiValueRemove: (provided, state) => ({
+    multiValueRemove: provided => ({
         ...provided,
         backgroundColor: 'transparent',
-        boxShadow: state.isFocused ? 'var(--input-focus-box-shadow)' : undefined,
+        borderRadius: 'var(--border-radius)',
         ':hover': {
             ...provided[':hover'],
-            backgroundColor: 'transparent',
+            backgroundColor: 'var(--input-light-hover)',
             color: undefined,
         },
     }),


### PR DESCRIPTION
## Problem
As described in https://github.com/sourcegraph/sourcegraph/issues/32560, there's a bunch of small accessibility/usability issues with the `Multiselect` component implementation.

## Solution
- Add cursor: pointer for the entire thing
- Add hover colors for buttons inside the select
- Remove paddings in the dropdown
- Remove box-shadow from the multi select remove button


https://user-images.githubusercontent.com/2196347/161971999-9f3085a4-38c7-4c2c-aabf-6e3328819440.mov

### What hasn't been fixed
1. Three different background colors. I agree that having a check mark near selected items would probably make more sense - however, there's no way of doing so in `react-select` that we use
2. I haven't made the "x" button on selected items work because IMO the implementation will be too complicated for to the outcome - we now have ability to press backspace anyways

## Test plan

1. Open storybook: `yarn storybook:wildcard` and find `Multiselect` component
3. Check that the cursor is `pointer` for the entire component
4. Check that buttons inside have hover styles
5. Don't forget about the dark theme
6. Navigating with keyboard left and right keys still focuses the remove button but doesn't highlight it - as I haven't found a way of making it work. Also, there's a backspace that users can press to remove individual values from keyboard
7. Check that there's no space above the first and below the last items in the dropdown