### PR TITLE
Fix "quick start" file page overflow when file tree is longer than height

### DIFF
--- a/client/web/src/repo/RepoRevisionSidebar.tsx
+++ b/client/web/src/repo/RepoRevisionSidebar.tsx
@@ -89,17 +89,17 @@ export const RepoRevisionSidebar: React.FunctionComponent<Props> = props => {
     }
 
     return (
-        <Panel defaultSize={256} position="left" className="h-100" storageKey={SIZE_STORAGE_KEY}>
+        <Panel defaultSize={256} position="left" storageKey={SIZE_STORAGE_KEY}>
             <div className="d-flex flex-column h-100 w-100">
                 <GettingStartedTour
-                    className="mr-3 flex-shrink-0"
+                    className="mr-3"
                     telemetryService={props.telemetryService}
                     isAuthenticated={!!props.authenticatedUser}
                     featureFlags={props.featureFlags}
                     isSourcegraphDotCom={props.isSourcegraphDotCom}
                 />
                 <Tabs
-                    className="w-100 test-repo-revision-sidebar pr-3 flex-shrink-0 h-25 flex-grow-1"
+                    className="w-100 test-repo-revision-sidebar pr-3 h-25 flex-grow-1"
                     defaultIndex={persistedTabIndex}
                     onChange={setPersistedTabIndex}
                     lazy={true}

--- a/client/web/src/repo/RepoRevisionSidebar.tsx
+++ b/client/web/src/repo/RepoRevisionSidebar.tsx
@@ -89,17 +89,18 @@ export const RepoRevisionSidebar: React.FunctionComponent<Props> = props => {
     }
 
     return (
-        <Panel defaultSize={256} position="left" storageKey={SIZE_STORAGE_KEY}>
+        <Panel defaultSize={256} position="left" className="h-100" storageKey={SIZE_STORAGE_KEY}>
             <div className="d-flex flex-column h-100 w-100">
                 <GettingStartedTour
-                    className="mb-1 mr-3"
+                    className="mr-3 flex-shrink-0"
                     telemetryService={props.telemetryService}
                     isAuthenticated={!!props.authenticatedUser}
                     featureFlags={props.featureFlags}
                     isSourcegraphDotCom={props.isSourcegraphDotCom}
                 />
                 <Tabs
-                    className="w-100 h-100 test-repo-revision-sidebar pr-3"
+                    className="w-100 test-repo-revision-sidebar pr-3 flex-shrink-0 flex-grow-1"
+                    style={{ height: 10 }}
                     defaultIndex={persistedTabIndex}
                     onChange={setPersistedTabIndex}
                     lazy={true}

--- a/client/web/src/repo/RepoRevisionSidebar.tsx
+++ b/client/web/src/repo/RepoRevisionSidebar.tsx
@@ -99,8 +99,7 @@ export const RepoRevisionSidebar: React.FunctionComponent<Props> = props => {
                     isSourcegraphDotCom={props.isSourcegraphDotCom}
                 />
                 <Tabs
-                    className="w-100 test-repo-revision-sidebar pr-3 flex-shrink-0 flex-grow-1"
-                    style={{ height: 10 }}
+                    className="w-100 test-repo-revision-sidebar pr-3 flex-shrink-0 h-25 flex-grow-1"
                     defaultIndex={persistedTabIndex}
                     onChange={setPersistedTabIndex}
                     lazy={true}


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/33273

## Description 
This PR:
- Fix quick start tour causing overflow on the file page

## Test plan
- Run sourcegraph web locally: `SOURCEGRAPH_API_URL=https://sourcegraph.com SOURCEGRAPHDOTCOM_MODE=true sg -skip-auto-update=true start web-standalone`
- Open https://sourcegraph.test:3443/github.com/sourcegraph/sourcegraph/-/blob/enterprise/cmd/frontend/internal/batches/resolvers/urls.go?feature-flag-key=quick-start-tour-for-authenticated-users&feature-flag-value=true in a regular small desktop screen
- Check that page is rendered correctly, tour is shown and File tree section auto-scrolls to the selected file
- Close the tour and refresh. Check that page is rendered correctly, file tree section auto-scrolls to the selected file
<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


<!-- ## App preview:
 - [Link](https://sg-web-erzhtor-fix-quick-start-on-file.onrender.com) -->

