### PR TITLE
New reference panel: filter out defs on isExternalPrivateSymbol

### DIFF
--- a/client/web/src/codeintel/location.ts
+++ b/client/web/src/codeintel/location.ts
@@ -2,6 +2,8 @@ import { Range } from '@sourcegraph/extension-api-types'
 
 import { LocationFields } from '../graphql-operations'
 
+import { Result } from './searchBased'
+
 export interface Location {
     repo: string
     file: string
@@ -36,23 +38,30 @@ export const locationGroupQuality = (group: LocationGroup): LocationGroupQuality
     return group.locations[0].precise ? 'PRECISE' : 'SEARCH-BASED'
 }
 
-export const buildPreciseLocation = (node: LocationFields): Location => buildLocation(node, true)
-export const buildSearchBasedLocation = (node: LocationFields): Location => buildLocation(node, false)
+export const buildSearchBasedLocation = (node: Result): Location => ({
+    repo: node.repo,
+    file: node.file,
+    commitID: node.rev,
+    content: node.content,
+    url: node.url,
+    lines: node.content.split(/\r?\n/),
+    precise: false,
+    range: node.range,
+})
 
-const buildLocation = (node: LocationFields, precise: boolean): Location => {
+export const buildPreciseLocation = (node: LocationFields): Location => {
     const location: Location = {
         content: node.resource.content,
         commitID: node.resource.commit.oid,
         repo: node.resource.repository.name,
         file: node.resource.path,
-        url: '',
+        url: node.url,
         lines: [],
-        precise,
+        precise: true,
     }
     if (node.range !== null) {
         location.range = node.range
     }
-    location.url = node.url
     location.lines = location.content.split(/\r?\n/)
     return location
 }


### PR DESCRIPTION
Part of #30970. This replicates another bit from `code-intel-extensions`: the filtering by `isExternalPrivateSymbol`.

I started trying to port the existing filter but then realised it'll be easier if I copy the `Result` and `SearchResult` types from `code-intel-extensions` too. That's why the diff is so long. It's 95% copy&pasted code. 

And it also fixes two TODOs from before.

## Test plan

- Tested this manually to check that it doesn't break anything. But not sure how to replicate the exact behaviour that this filters out.


## App preview:
- [Link](https://sg-web-mrn-is-external-symbol.onrender.com)

