### PR TITLE
Don't show fork indicator when not forking

### DIFF
--- a/client/web/src/enterprise/batches/Branch.story.tsx
+++ b/client/web/src/enterprise/batches/Branch.story.tsx
@@ -15,7 +15,9 @@ add('Forked', () => (
 ))
 
 add('Will be forked into the user', () => (
-    <WebStory>{() => <BranchMerge baseRef="main" forkTarget={{ pushUser: true }} headRef="branch" />}</WebStory>
+    <WebStory>
+        {() => <BranchMerge baseRef="main" forkTarget={{ pushUser: true, namespace: 'org' }} headRef="branch" />}
+    </WebStory>
 ))
 
 add('Unforked', () => <WebStory>{() => <BranchMerge baseRef="main" headRef="branch" />}</WebStory>)

--- a/client/web/src/enterprise/batches/Branch.tsx
+++ b/client/web/src/enterprise/batches/Branch.tsx
@@ -8,7 +8,7 @@ import { Badge, Icon, BadgeProps } from '@sourcegraph/wildcard'
 
 export interface ForkTarget {
     pushUser: boolean
-    namespace?: string | null
+    namespace: string | null
 }
 
 export interface BranchProps extends Pick<BadgeProps, 'variant'> {
@@ -24,7 +24,7 @@ export const Branch: React.FunctionComponent<BranchProps> = ({ className, delete
         className={classNames('text-monospace', className)}
         as={deleted ? 'del' : undefined}
     >
-        {!forkTarget ? (
+        {!forkTarget || forkTarget.namespace === null ? (
             name
         ) : (
             <>


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/32558

## Test plan

Tested manually and verified storybook looks correct.
## App preview:
- [Link](https://sg-web-es-no-fork-no-icon.onrender.com)

