### PR TITLE
New reference panel: fix grouping of files by repo

### DIFF
--- a/client/web/src/codeintel/ReferencesPanel.tsx
+++ b/client/web/src/codeintel/ReferencesPanel.tsx
@@ -54,7 +54,7 @@ import { parseBrowserRepoURL } from '../util/url'
 
 import { findLanguageSpec } from './language-specs/languages'
 import { LanguageSpec } from './language-specs/languagespec'
-import { Location, RepoLocationGroup, LocationGroup, locationGroupQuality } from './location'
+import { Location, RepoLocationGroup, LocationGroup, locationGroupQuality, buildRepoLocationGroups } from './location'
 import { FETCH_HIGHLIGHTED_BLOB } from './ReferencesPanelQueries'
 import { newSettingsGetter } from './settings'
 import { findSearchToken } from './token'
@@ -630,36 +630,7 @@ const LocationsList: React.FunctionComponent<LocationsListProps> = ({
     setActiveLocation,
     filter,
 }) => {
-    const repoLocationGroups = useMemo((): RepoLocationGroup[] => {
-        const byFile: Record<string, Location[]> = {}
-        for (const location of locations) {
-            if (byFile[location.file] === undefined) {
-                byFile[location.file] = []
-            }
-            byFile[location.file].push(location)
-        }
-
-        const locationsGroups: LocationGroup[] = []
-        Object.keys(byFile).map(path => {
-            const references = byFile[path]
-            const repoName = references[0].repo
-            locationsGroups.push({ path, locations: references, repoName })
-        })
-
-        const byRepo: Record<string, LocationGroup[]> = {}
-        for (const group of locationsGroups) {
-            if (byRepo[group.repoName] === undefined) {
-                byRepo[group.repoName] = []
-            }
-            byRepo[group.repoName].push(group)
-        }
-        const repoLocationGroups: RepoLocationGroup[] = []
-        Object.keys(byRepo).map(repoName => {
-            const referenceGroups = byRepo[repoName]
-            repoLocationGroups.push({ repoName, referenceGroups })
-        })
-        return repoLocationGroups
-    }, [locations])
+    const repoLocationGroups = useMemo(() => buildRepoLocationGroups(locations), [locations])
 
     return (
         <>

--- a/client/web/src/codeintel/location.ts
+++ b/client/web/src/codeintel/location.ts
@@ -56,3 +56,28 @@ const buildLocation = (node: LocationFields, precise: boolean): Location => {
     location.lines = location.content.split(/\r?\n/)
     return location
 }
+
+export const buildRepoLocationGroups = (locations: Location[]): RepoLocationGroup[] => {
+    const byRepoAndFile: Record<string, Record<string, Location[]>> = {}
+    for (const location of locations) {
+        if (byRepoAndFile[location.repo] === undefined) {
+            byRepoAndFile[location.repo] = {}
+        }
+        if (byRepoAndFile[location.repo][location.file] === undefined) {
+            byRepoAndFile[location.repo][location.file] = []
+        }
+        byRepoAndFile[location.repo][location.file].push(location)
+    }
+
+    return Object.keys(byRepoAndFile).map(repoName => {
+        const byFile = byRepoAndFile[repoName]
+
+        const referenceGroups: LocationGroup[] = Object.keys(byFile).map(path => ({
+            path,
+            locations: byFile[path],
+            repoName,
+        }))
+
+        return { repoName, referenceGroups }
+    })
+}


### PR DESCRIPTION
When in a fork, results from fork and main repo would be grouped under
one repository. This fixes it by first grouping the files by repo.



## Test plan

- Tested this locally inside a forked repository and comparing before and after


## App preview:
- [Link](https://sg-web-mrn-fix-grouping-forks.onrender.com)

