### PR TITLE
search: Fix user settings overwriting search parameters from URL

### DIFF
--- a/client/search-ui/src/results/sidebar/SearchSidebar.story.tsx
+++ b/client/search-ui/src/results/sidebar/SearchSidebar.story.tsx
@@ -8,6 +8,7 @@ import create from 'zustand'
 import { BrandedStory } from '@sourcegraph/branded/src/components/BrandedStory'
 import {
     BuildSearchQueryURLParameters,
+    InitialParametersSource,
     SearchPatternType,
     SearchQueryState,
     SearchQueryStateStoreProvider,
@@ -29,6 +30,7 @@ const { add } = storiesOf('search-ui/results/sidebar/SearchSidebar', module).add
 })
 
 const mockUseQueryState = create<SearchQueryState>((set, get) => ({
+    parametersSource: InitialParametersSource.DEFAULT,
     queryState: { query: '' },
     searchCaseSensitivity: false,
     searchPatternType: SearchPatternType.literal,

--- a/client/search/src/searchQueryState.tsx
+++ b/client/search/src/searchQueryState.tsx
@@ -9,7 +9,7 @@ import { filterExists } from '@sourcegraph/shared/src/search/query/validate'
 
 import { QueryState, SubmitSearchParameters, toggleSubquery } from '.'
 
-export type SearchQueryStateStore = UseBoundStore<SearchQueryState, StoreApi<SearchQueryState>>
+export type SearchQueryStateStore<T extends SearchQueryState = SearchQueryState> = UseBoundStore<T, StoreApi<T>>
 
 export const SearchQueryStateStoreContext = createContext<SearchQueryStateStore | null>(null)
 
@@ -37,8 +37,28 @@ export const useSearchQueryStateStoreContext = (): SearchQueryStateStore => {
     return context
 }
 
+/**
+ * Describes where settings have been loaded from when the app loads. Higher
+ * values have higher precedence, i.e. if settings have been loaded from the
+ * URL, user settings should not overwrite them.
+ */
+export enum InitialParametersSource {
+    DEFAULT,
+    USER_SETTINGS,
+    URL,
+}
+
 // Implemented in /web as navbar query state, /vscode as webview query state.
 export interface SearchQueryState {
+    /**
+     * This is used to determine whether a source is allowed to overwrite
+     * parameters that have been loaded from another source. For example, user
+     * settings (e.g. default pattern type) are not allowed to overwrite the
+     * parameters if they have been loaded from a URL (because parameters loaded
+     * from a URL are more specific).
+     */
+    parametersSource: InitialParametersSource
+
     // DATA
     /**
      * The current seach query and auxiliary information needed by the

--- a/client/web/src/stores/navbarSearchQueryState.test.ts
+++ b/client/web/src/stores/navbarSearchQueryState.test.ts
@@ -1,6 +1,6 @@
 import { SearchPatternType } from '@sourcegraph/shared/src/graphql-operations'
 
-import { setQueryStateFromSettings, useNavbarQueryState } from './navbarSearchQueryState'
+import { setQueryStateFromSettings, setQueryStateFromURL, useNavbarQueryState } from './navbarSearchQueryState'
 
 describe('navbar query state', () => {
     describe('set state from settings', () => {
@@ -24,6 +24,72 @@ describe('navbar query state', () => {
             })
 
             expect(useNavbarQueryState.getState()).toHaveProperty('searchCaseSensitivity', true)
+        })
+    })
+
+    describe('set state from URL', () => {
+        it('sets the search pattern from URL parementer', () => {
+            setQueryStateFromURL('q=context:global+&patternType=regexp')
+
+            expect(useNavbarQueryState.getState()).toHaveProperty('searchPatternType', SearchPatternType.regexp)
+        })
+
+        it('sets the search pattern from filter', () => {
+            setQueryStateFromURL('q=context:global+&patternType=regexp')
+
+            expect(useNavbarQueryState.getState()).toHaveProperty('searchPatternType', SearchPatternType.regexp)
+        })
+
+        it('sets case sensitivity from filter', () => {
+            setQueryStateFromURL('q=context:global+case:yes')
+
+            expect(useNavbarQueryState.getState()).toHaveProperty('searchCaseSensitivity', true)
+        })
+
+        it('sets case sensitivity from URL paramster', () => {
+            setQueryStateFromURL('q=context:global+&case=yes')
+
+            expect(useNavbarQueryState.getState()).toHaveProperty('searchCaseSensitivity', true)
+        })
+    })
+
+    describe('state initialization precedence', () => {
+        // Note that the other tests already verify that user settings and URL
+        // settings can override defaults
+
+        it('prefers settings from URL over user settings', () => {
+            setQueryStateFromSettings({
+                subjects: [],
+                final: {
+                    'search.defaultPatternType': SearchPatternType.structural,
+                },
+            })
+            setQueryStateFromURL('q=context:global+&patternType=regexp')
+
+            expect(useNavbarQueryState.getState()).toHaveProperty('searchPatternType', SearchPatternType.regexp)
+        })
+        it('prefers user settings over settings from empty URL', () => {
+            setQueryStateFromURL('')
+            setQueryStateFromSettings({
+                subjects: [],
+                final: {
+                    'search.defaultPatternType': SearchPatternType.structural,
+                },
+            })
+
+            expect(useNavbarQueryState.getState()).toHaveProperty('searchPatternType', SearchPatternType.structural)
+        })
+
+        it('does not prefer user settings over settings from URL', () => {
+            setQueryStateFromURL('q=context:global+&patternType=regexp')
+            setQueryStateFromSettings({
+                subjects: [],
+                final: {
+                    'search.defaultPatternType': SearchPatternType.structural,
+                },
+            })
+
+            expect(useNavbarQueryState.getState()).toHaveProperty('searchPatternType', SearchPatternType.regexp)
         })
     })
 })


### PR DESCRIPTION
Fixes: #33435 

The logic to load search parameters from user settings only accounted
for search parameters passed as actual URL parameters, not as part of
the search query.

This PR changes the approach and moves the responsibility of correctly
applying the settings from the user settings loading code to the query
state store.

I'm also removing the default values from the settings helper methods since I'm not a fan of sprinkling the default values across the code base and it aligns better with my expectations for these functions (no settings, not value). But I'm OK adding it back if we want those functions to always return a valid value.


## Test plan

New unit tests.

- Navigated to https://sourcegraph.test:3443/search and verified that `regexp` is selected as configured in my user settings.
- Navigated to https://sourcegraph.test:3443/search?q=context:global+test+patternType:structural and verified that structural search is selected (i.e. overwriting my user settings).
## App preview:
- [Link](https://sg-web-fkling-33435-patterntype-from-url.onrender.com)

