### PR TITLE
Make initiator on workspace resolution non nullable

### DIFF
--- a/internal/database/schema.json
+++ b/internal/database/schema.json
@@ -1592,7 +1592,7 @@
           "Name": "initiator_id",
           "Index": 16,
           "TypeName": "integer",
-          "IsNullable": true,
+          "IsNullable": false,
           "Default": "",
           "CharacterMaximumLength": 0,
           "IsIdentity": false,

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -119,7 +119,7 @@ Foreign-key constraints:
  created_at        | timestamp with time zone |           | not null | now()
  updated_at        | timestamp with time zone |           | not null | now()
  queued_at         | timestamp with time zone |           |          | now()
- initiator_id      | integer                  |           |          | 
+ initiator_id      | integer                  |           | not null | 
 Indexes:
     "batch_spec_resolution_jobs_pkey" PRIMARY KEY, btree (id)
     "batch_spec_resolution_jobs_batch_spec_id_unique" UNIQUE CONSTRAINT, btree (batch_spec_id)

--- a/migrations/frontend/1649253538/down.sql
+++ b/migrations/frontend/1649253538/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE batch_spec_resolution_jobs ALTER COLUMN initiator_id DROP NOT NULL;

--- a/migrations/frontend/1649253538/metadata.yaml
+++ b/migrations/frontend/1649253538/metadata.yaml
@@ -1,2 +1,2 @@
 name: batch_spec_resolution_user_id_non_null
-parents: [1649159359]
+parents: [1653479179]

--- a/migrations/frontend/1649253538/metadata.yaml
+++ b/migrations/frontend/1649253538/metadata.yaml
@@ -1,0 +1,2 @@
+name: batch_spec_resolution_user_id_non_null
+parents: [1649159359]

--- a/migrations/frontend/1649253538/up.sql
+++ b/migrations/frontend/1649253538/up.sql
@@ -1,1 +1,3 @@
+UPDATE batch_spec_resolution_jobs SET initiator_id = (SELECT bs.user_id FROM batch_specs bs WHERE bs.id = batch_spec_id);
+
 ALTER TABLE batch_spec_resolution_jobs ALTER COLUMN initiator_id SET NOT NULL;

--- a/migrations/frontend/1649253538/up.sql
+++ b/migrations/frontend/1649253538/up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE batch_spec_resolution_jobs ALTER COLUMN initiator_id SET NOT NULL;

--- a/migrations/frontend/squashed.sql
+++ b/migrations/frontend/squashed.sql
@@ -580,7 +580,7 @@ CREATE TABLE batch_spec_resolution_jobs (
     created_at timestamp with time zone DEFAULT now() NOT NULL,
     updated_at timestamp with time zone DEFAULT now() NOT NULL,
     queued_at timestamp with time zone DEFAULT now(),
-    initiator_id integer
+    initiator_id integer NOT NULL
 );
 
 CREATE SEQUENCE batch_spec_resolution_jobs_id_seq


### PR DESCRIPTION
This has been split out of the workspace permissions PR to please the backcompat check. It cannot be merged before 3.40 is out.

## Test plan

DB schema changes are covered by our test suite.
## App preview:
- [Link](https://sg-web-es-workspace-repo-perms-no.onrender.com)

