### PR TITLE
web: wait for query highlighting to avoid Percy flakes

### DIFF
--- a/client/web/src/integration/search-contexts.test.ts
+++ b/client/web/src/integration/search-contexts.test.ts
@@ -274,7 +274,9 @@ describe('Search contexts', () => {
             }),
         })
 
-        await driver.page.goto(driver.sourcegraphBaseUrl + '/contexts/new')
+        await driver.page.goto(driver.sourcegraphBaseUrl + '/contexts/new', {
+            waitUntil: 'networkidle0',
+        })
 
         await driver.replaceText({
             selector: '[data-testid="search-context-name-input"]',

--- a/client/web/src/integration/search-contexts.test.ts
+++ b/client/web/src/integration/search-contexts.test.ts
@@ -298,10 +298,14 @@ describe('Search contexts', () => {
         // Select query option
         await driver.page.click('#search-context-type-dynamic')
 
-        // Enter query
-        await driver.page.waitForSelector('[data-testid="search-context-dynamic-query"] .monaco-editor')
+        // Wait for search query input
+        const searchQueryInputSelector = '[data-testid="search-context-dynamic-query"] .monaco-editor .view-lines'
+        await driver.page.waitForSelector(searchQueryInputSelector)
+        await driver.page.click(searchQueryInputSelector)
+
+        // Enter search query
         await driver.replaceText({
-            selector: '[data-testid="search-context-dynamic-query"] .monaco-editor',
+            selector: searchQueryInputSelector,
             newText: 'repo:abc',
             selectMethod: 'keyboard',
             enterTextMethod: 'paste',


### PR DESCRIPTION
## Context

[The Percy snapshot is flaky](https://sourcegraph.slack.com/archives/C07KZF47K/p1649251442579279) due to search query syntax highlighting.

## Test plan

Percy shouldn't have issues after multiple runs.
UPD: ran tests multiple times without flakes.

## App preview:
- [Link](https://sg-web-vb-fix-flaky-percy-test.onrender.com)

