### PR TITLE
ratelimit: Handle marshalling of infinite limiters

### DIFF
--- a/internal/ratelimit/rate_limit.go
+++ b/internal/ratelimit/rate_limit.go
@@ -1,6 +1,7 @@
 package ratelimit
 
 import (
+	"math"
 	"sync"
 
 	"golang.org/x/time/rate"
@@ -63,21 +64,30 @@ func (r *Registry) Count() int {
 type LimitInfo struct {
 	// Maximum allowed burst of requests
 	Burst int
-	// Maximum allowed requests per second
+	// Maximum allowed requests per second. If the limit is infinite, Limit will be
+	// zero and Infinite will be true
 	Limit float64
+	// Infinite is true if Limit is infinite. This is required since infinity cannot
+	// be marshalled in JSON.
+	Infinite bool
 }
 
-// LimitInfo reports how all of the existing rate limiters are configured, keyed
-// by URN.
+// LimitInfo reports how all the existing rate limiters are configured, keyed by
+// URN.
 func (r *Registry) LimitInfo() map[string]LimitInfo {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
 	m := make(map[string]LimitInfo, len(r.rateLimiters))
 	for urn, rl := range r.rateLimiters {
+		limit := rl.Limit()
 		info := LimitInfo{
 			Burst: rl.Burst(),
-			Limit: float64(rl.Limit()),
+			Limit: float64(limit),
+		}
+		if math.IsInf(info.Limit, 0) || limit == rate.Inf {
+			info.Limit = 0
+			info.Infinite = true
 		}
 		m[urn] = info
 	}

--- a/internal/ratelimit/rate_limit_test.go
+++ b/internal/ratelimit/rate_limit_test.go
@@ -23,3 +23,22 @@ func TestRegistry(t *testing.T) {
 
 	assert.Equal(t, 2, r.Count())
 }
+
+func TestLimitInfo(t *testing.T) {
+	r := NewRegistry()
+	r.GetOrSet("extsvc:github:1", rate.NewLimiter(rate.Inf, 1))
+	r.GetOrSet("extsvc:github:2", rate.NewLimiter(10, 1))
+
+	info := r.LimitInfo()
+
+	assert.Equal(t, info["extsvc:github:1"], LimitInfo{
+		Limit:    0,
+		Burst:    1,
+		Infinite: true,
+	})
+	assert.Equal(t, info["extsvc:github:2"], LimitInfo{
+		Limit:    10,
+		Burst:    1,
+		Infinite: false,
+	})
+}


### PR DESCRIPTION
This avoid an issue where we get this error when viewing rate limit information:

```
failed to marshal rate limiter state: "json: unsupported value: +Inf"
```

# Test plan

Added a unit test