### PR TITLE
codeintel: Update nullability of code intel support in graphql

### DIFF
--- a/client/web/src/enterprise/codeintel/useCodeIntelStatus.ts
+++ b/client/web/src/enterprise/codeintel/useCodeIntelStatus.ts
@@ -31,8 +31,8 @@ export interface UseCodeIntelStatusPayload {
     activeUploads: LsifUploadFields[]
     recentUploads: LSIFUploadsWithRepositoryNamespaceFields[]
     recentIndexes: LSIFIndexesWithRepositoryNamespaceFields[]
-    preciseSupport: (PreciseSupportFields & { confidence?: InferedPreciseSupportLevel })[]
-    searchBasedSupport: SearchBasedCodeIntelSupportFields[]
+    preciseSupport?: (PreciseSupportFields & { confidence?: InferedPreciseSupportLevel })[]
+    searchBasedSupport?: SearchBasedCodeIntelSupportFields[]
 }
 
 export const useCodeIntelStatus = ({ variables }: UseCodeIntelStatusParameters): UseCodeIntelStatusResult => {
@@ -67,8 +67,8 @@ export const useCodeIntelStatus = ({ variables }: UseCodeIntelStatusParameters):
             return {
                 data: {
                     ...common,
-                    searchBasedSupport: [support.searchBasedSupport],
-                    preciseSupport: [support.preciseSupport],
+                    searchBasedSupport: support.searchBasedSupport ? [support.searchBasedSupport] : undefined,
+                    preciseSupport: support.preciseSupport ? [support.preciseSupport] : undefined,
                 },
                 error,
                 loading,

--- a/cmd/frontend/graphqlbackend/codeintel.go
+++ b/cmd/frontend/graphqlbackend/codeintel.go
@@ -422,5 +422,5 @@ type CodeIntelIndexerResolver interface {
 
 type SearchBasedSupportResolver interface {
 	SupportLevel() string
-	Language() *string
+	Language() string
 }

--- a/cmd/frontend/graphqlbackend/codeintel.graphql
+++ b/cmd/frontend/graphqlbackend/codeintel.graphql
@@ -1658,7 +1658,7 @@ type SearchBasedCodeIntelSupport {
     The infered language the underlying tool infered when building an index for
     search-based code-intel.
     """
-    language: String
+    language: String!
 }
 
 """

--- a/cmd/frontend/graphqlbackend/codeintel.graphql
+++ b/cmd/frontend/graphqlbackend/codeintel.graphql
@@ -1587,12 +1587,12 @@ type CodeIntelSupport {
     """
     Search-based code-intel support overview.
     """
-    searchBasedSupport: SearchBasedCodeIntelSupport!
+    searchBasedSupport: SearchBasedCodeIntelSupport
 
     """
     Precise code-intel support overview.
     """
-    preciseSupport: PreciseCodeIntelSupport!
+    preciseSupport: PreciseCodeIntelSupport
 }
 
 """

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/codeintel_blob_info_resolver.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/codeintel_blob_info_resolver.go
@@ -46,10 +46,10 @@ func (r *codeIntelSupportResolver) SearchBasedSupport(ctx context.Context) (_ gq
 	}
 
 	if ctagsSupported {
-		return NewSearchBasedCodeIntelResolver(&language), nil
+		return NewSearchBasedCodeIntelResolver(language), nil
 	}
 
-	return NewSearchBasedCodeIntelResolver(nil), nil
+	return NewSearchBasedCodeIntelResolver(""), nil
 }
 
 func (r *codeIntelSupportResolver) PreciseSupport(ctx context.Context) (gql.PreciseSupportResolver, error) {

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/codeintel_blob_info_resolver.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/codeintel_blob_info_resolver.go
@@ -45,11 +45,11 @@ func (r *codeIntelSupportResolver) SearchBasedSupport(ctx context.Context) (_ gq
 		return nil, err
 	}
 
-	if ctagsSupported {
-		return NewSearchBasedCodeIntelResolver(language), nil
+	if !ctagsSupported {
+		return nil, nil
 	}
 
-	return NewSearchBasedCodeIntelResolver(""), nil
+	return NewSearchBasedCodeIntelResolver(language), nil
 }
 
 func (r *codeIntelSupportResolver) PreciseSupport(ctx context.Context) (gql.PreciseSupportResolver, error) {

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/codeintel_tree_info_resolver.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/codeintel_tree_info_resolver.go
@@ -140,5 +140,5 @@ func (r *codeIntelTreeSearchBasedCoverageResolver) CoveredPaths() []string {
 }
 
 func (r *codeIntelTreeSearchBasedCoverageResolver) Support() gql.SearchBasedSupportResolver {
-	return NewSearchBasedCodeIntelResolver(&r.language)
+	return NewSearchBasedCodeIntelResolver(r.language)
 }

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/support.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/support.go
@@ -23,21 +23,21 @@ const (
 )
 
 type searchBasedSupportResolver struct {
-	language *string
+	language string
 }
 
-func NewSearchBasedCodeIntelResolver(language *string) gql.SearchBasedSupportResolver {
+func NewSearchBasedCodeIntelResolver(language string) gql.SearchBasedSupportResolver {
 	return &searchBasedSupportResolver{language}
 }
 
 func (r *searchBasedSupportResolver) SupportLevel() string {
-	if r.language != nil && *r.language != "" {
+	if r.language != "" {
 		return string(basic)
 	}
 	return string(unsupported)
 }
 
-func (r *searchBasedSupportResolver) Language() *string {
+func (r *searchBasedSupportResolver) Language() string {
 	return r.language
 }
 


### PR DESCRIPTION
This PR makes precise/search fields nullable if there is no support of that type, and makes the nullable fields there by necessity (language name) now non-nullable.

## Test plan

Started frontend locally to confirm it doesn't blow up due to bad reflection scan of resolvers.
## App preview:
- [Link](https://sg-web-ef-non-pointer.onrender.com)

