### PR TITLE
Search: close PartitionRepos trace

### DIFF
--- a/internal/search/zoekt/indexed_search.go
+++ b/internal/search/zoekt/indexed_search.go
@@ -197,6 +197,11 @@ func PartitionRepos(
 	}
 
 	tr, ctx := trace.New(ctx, "PartitionRepos", string(typ))
+	defer func() {
+		tr.SetError(err)
+		tr.Finish()
+	}()
+
 	// Only include indexes with symbol information if a symbol request.
 	var filter func(repo *zoekt.MinimalRepoListEntry) bool
 	if typ == search.SymbolRequest {


### PR DESCRIPTION
We were creating a span, but never calling `Finish()`, so the span
never completes and is not visible when debugging.

Found while investigating https://github.com/sourcegraph/sourcegraph/issues/33538

## Test plan

I ran it locally and saw that the trace shows up in Jaeger. 

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


