### PR TITLE
gitserver: add GetByNames function to gitserver store

### DIFF
--- a/internal/database/gitserver_repos.go
+++ b/internal/database/gitserver_repos.go
@@ -23,6 +23,7 @@ type GitserverRepoStore interface {
 	IterateRepoGitserverStatus(ctx context.Context, options IterateRepoGitserverStatusOptions, repoFn func(repo types.RepoGitserverStatus) error) error
 	GetByID(ctx context.Context, id api.RepoID) (*types.GitserverRepo, error)
 	GetByName(ctx context.Context, name api.RepoName) (*types.GitserverRepo, error)
+	GetByNames(ctx context.Context, names ...api.RepoName) ([]*types.GitserverRepo, error)
 	SetCloneStatus(ctx context.Context, name api.RepoName, status types.CloneStatus, shardID string) error
 	SetLastError(ctx context.Context, name api.RepoName, error, shardID string) error
 	SetLastFetched(ctx context.Context, name api.RepoName, data GitserverFetchData) error
@@ -319,13 +320,62 @@ WHERE r.name = %s
 	return scanSingleGitserverRepo(s.QueryRow(ctx, sqlf.Sprintf(q, name)))
 }
 
-func scanSingleGitserverRepo(row *sql.Row) (*types.GitserverRepo, error) {
-	if row.Err() != nil {
-		return nil, errors.Wrap(row.Err(), "getting GitserverRepo")
+func (s *gitserverRepoStore) GetByNames(ctx context.Context, names ...api.RepoName) ([]*types.GitserverRepo, error) {
+	if len(names) > batch.MaxNumPostgresParameters {
+		return nil, errors.Newf("getting GitserverRepos by names: too much names provided: %v", len(names))
+	}
+
+	q := `
+-- source: internal/database/gitserver_repos.go:gitserverRepoStore.GetByName
+SELECT
+       g.repo_id,
+       g.clone_status,
+       g.shard_id,
+       g.last_error,
+       g.last_fetched,
+       g.last_changed,
+	   g.repo_size_bytes,
+       g.updated_at
+FROM gitserver_repos g
+JOIN repo r on r.id = g.repo_id
+WHERE r.name IN (%s)
+`
+	nameQueries := []*sqlf.Query{}
+	for _, v := range names {
+		nameQueries = append(nameQueries, sqlf.Sprintf("%s", v))
+	}
+
+	rows, err := s.Query(ctx, sqlf.Sprintf(q, sqlf.Join(nameQueries, ",")))
+	if err != nil {
+		return nil, err
+	}
+
+	repos := []*types.GitserverRepo{}
+
+	for rows.Next() {
+		repo, err := scanSingleGitserverRepo(rows)
+		if err != nil {
+			return nil, err
+		}
+		repos = append(repos, repo)
+	}
+
+	return repos, nil
+}
+
+// ScannerWithError captures Scan and Err methods of sql.Rows and sql.Row.
+type ScannerWithError interface {
+	Scan(dst ...interface{}) error
+	Err() error
+}
+
+func scanSingleGitserverRepo(scanner ScannerWithError) (*types.GitserverRepo, error) {
+	if scanner.Err() != nil {
+		return nil, errors.Wrap(scanner.Err(), "getting GitserverRepo")
 	}
 	var gr types.GitserverRepo
 	var cloneStatus string
-	err := row.Scan(
+	err := scanner.Scan(
 		&gr.RepoID,
 		&cloneStatus,
 		&gr.ShardID,

--- a/internal/database/gitserver_repos.go
+++ b/internal/database/gitserver_repos.go
@@ -350,7 +350,7 @@ WHERE r.name IN (%s)
 		return nil, err
 	}
 
-	repos := []*types.GitserverRepo{}
+	repos := make([]*types.GitserverRepo, 0, len(names))
 
 	for rows.Next() {
 		repo, err := scanSingleGitserverRepo(rows)

--- a/internal/database/gitserver_repos.go
+++ b/internal/database/gitserver_repos.go
@@ -322,7 +322,7 @@ WHERE r.name = %s
 
 func (s *gitserverRepoStore) GetByNames(ctx context.Context, names ...api.RepoName) ([]*types.GitserverRepo, error) {
 	if len(names) > batch.MaxNumPostgresParameters {
-		return nil, errors.Newf("getting GitserverRepos by names: too much names provided: %v", len(names))
+		return nil, errors.Newf("getting GitserverRepos by names: too many names provided: %v", len(names))
 	}
 
 	q := `

--- a/internal/database/mocks.go
+++ b/internal/database/mocks.go
@@ -16113,6 +16113,9 @@ type MockGitserverRepoStore struct {
 	// GetByNameFunc is an instance of a mock function object controlling
 	// the behavior of the method GetByName.
 	GetByNameFunc *GitserverRepoStoreGetByNameFunc
+	// GetByNamesFunc is an instance of a mock function object controlling
+	// the behavior of the method GetByNames.
+	GetByNamesFunc *GitserverRepoStoreGetByNamesFunc
 	// HandleFunc is an instance of a mock function object controlling the
 	// behavior of the method Handle.
 	HandleFunc *GitserverRepoStoreHandleFunc
@@ -16166,6 +16169,11 @@ func NewMockGitserverRepoStore() *MockGitserverRepoStore {
 		},
 		GetByNameFunc: &GitserverRepoStoreGetByNameFunc{
 			defaultHook: func(context.Context, api.RepoName) (*types.GitserverRepo, error) {
+				return nil, nil
+			},
+		},
+		GetByNamesFunc: &GitserverRepoStoreGetByNamesFunc{
+			defaultHook: func(context.Context, ...api.RepoName) ([]*types.GitserverRepo, error) {
 				return nil, nil
 			},
 		},
@@ -16247,6 +16255,11 @@ func NewStrictMockGitserverRepoStore() *MockGitserverRepoStore {
 				panic("unexpected invocation of MockGitserverRepoStore.GetByName")
 			},
 		},
+		GetByNamesFunc: &GitserverRepoStoreGetByNamesFunc{
+			defaultHook: func(context.Context, ...api.RepoName) ([]*types.GitserverRepo, error) {
+				panic("unexpected invocation of MockGitserverRepoStore.GetByNames")
+			},
+		},
 		HandleFunc: &GitserverRepoStoreHandleFunc{
 			defaultHook: func() *basestore.TransactableHandle {
 				panic("unexpected invocation of MockGitserverRepoStore.Handle")
@@ -16320,6 +16333,9 @@ func NewMockGitserverRepoStoreFrom(i GitserverRepoStore) *MockGitserverRepoStore
 		},
 		GetByNameFunc: &GitserverRepoStoreGetByNameFunc{
 			defaultHook: i.GetByName,
+		},
+		GetByNamesFunc: &GitserverRepoStoreGetByNamesFunc{
+			defaultHook: i.GetByNames,
 		},
 		HandleFunc: &GitserverRepoStoreHandleFunc{
 			defaultHook: i.Handle,
@@ -16573,6 +16589,122 @@ func (c GitserverRepoStoreGetByNameFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c GitserverRepoStoreGetByNameFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
+}
+
+// GitserverRepoStoreGetByNamesFunc describes the behavior when the
+// GetByNames method of the parent MockGitserverRepoStore instance is
+// invoked.
+type GitserverRepoStoreGetByNamesFunc struct {
+	defaultHook func(context.Context, ...api.RepoName) ([]*types.GitserverRepo, error)
+	hooks       []func(context.Context, ...api.RepoName) ([]*types.GitserverRepo, error)
+	history     []GitserverRepoStoreGetByNamesFuncCall
+	mutex       sync.Mutex
+}
+
+// GetByNames delegates to the next hook function in the queue and stores
+// the parameter and result values of this invocation.
+func (m *MockGitserverRepoStore) GetByNames(v0 context.Context, v1 ...api.RepoName) ([]*types.GitserverRepo, error) {
+	r0, r1 := m.GetByNamesFunc.nextHook()(v0, v1...)
+	m.GetByNamesFunc.appendCall(GitserverRepoStoreGetByNamesFuncCall{v0, v1, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the GetByNames method of
+// the parent MockGitserverRepoStore instance is invoked and the hook queue
+// is empty.
+func (f *GitserverRepoStoreGetByNamesFunc) SetDefaultHook(hook func(context.Context, ...api.RepoName) ([]*types.GitserverRepo, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// GetByNames method of the parent MockGitserverRepoStore instance invokes
+// the hook at the front of the queue and discards it. After the queue is
+// empty, the default hook function is invoked for any future action.
+func (f *GitserverRepoStoreGetByNamesFunc) PushHook(hook func(context.Context, ...api.RepoName) ([]*types.GitserverRepo, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *GitserverRepoStoreGetByNamesFunc) SetDefaultReturn(r0 []*types.GitserverRepo, r1 error) {
+	f.SetDefaultHook(func(context.Context, ...api.RepoName) ([]*types.GitserverRepo, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *GitserverRepoStoreGetByNamesFunc) PushReturn(r0 []*types.GitserverRepo, r1 error) {
+	f.PushHook(func(context.Context, ...api.RepoName) ([]*types.GitserverRepo, error) {
+		return r0, r1
+	})
+}
+
+func (f *GitserverRepoStoreGetByNamesFunc) nextHook() func(context.Context, ...api.RepoName) ([]*types.GitserverRepo, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *GitserverRepoStoreGetByNamesFunc) appendCall(r0 GitserverRepoStoreGetByNamesFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of GitserverRepoStoreGetByNamesFuncCall
+// objects describing the invocations of this function.
+func (f *GitserverRepoStoreGetByNamesFunc) History() []GitserverRepoStoreGetByNamesFuncCall {
+	f.mutex.Lock()
+	history := make([]GitserverRepoStoreGetByNamesFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// GitserverRepoStoreGetByNamesFuncCall is an object that describes an
+// invocation of method GetByNames on an instance of MockGitserverRepoStore.
+type GitserverRepoStoreGetByNamesFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is a slice containing the values of the variadic arguments
+	// passed to this method invocation.
+	Arg1 []api.RepoName
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 []*types.GitserverRepo
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation. The variadic slice argument is flattened in this array such
+// that one positional argument and three variadic arguments would result in
+// a slice of four, not two.
+func (c GitserverRepoStoreGetByNamesFuncCall) Args() []interface{} {
+	trailing := []interface{}{}
+	for _, val := range c.Arg1 {
+		trailing = append(trailing, val)
+	}
+
+	return append([]interface{}{c.Arg0}, trailing...)
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c GitserverRepoStoreGetByNamesFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 


### PR DESCRIPTION
This function fetches repos by a slice of names provided.

Includes some tests refactoring, mostly removing duplicated code using a function creating both repo and gitserverRepo.

## Test plan
unit test added
<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


