### PR TITLE
insights docs: emphasize backfiller gives you years of history even if you start using it today

### DIFF
--- a/doc/code_insights/index.md
+++ b/doc/code_insights/index.md
@@ -40,7 +40,7 @@ body.theme-dark .markdown-body ul li:before {
 
 <p class="lead">Code Insights reveals high-level information about your codebase, based on both how your code changes over time and its current state.</p>
 
-Code Insights is based on our universal code search, making it precise and configurable. Track anything that can be expressed with a Sourcegraph search query: migrations, package use, version adoption, code smells, codebase size and much more, across 1,000s of repositories.
+Code Insights is based on our universal code search, making it precise and configurable. Track anything that can be expressed with a Sourcegraph search query: migrations, package use, version adoption, code smells, codebase size and much more, across 1,000s of repositories. Code Insights will backfill years of historical data from your version control, so you can immediately reveal current trends and baselines. 
 
 <div class="cta-group">
 <a class="btn btn-primary" href="quickstart">★ Quickstart</a>


### PR DESCRIPTION
Gotten a few questions about this and want to make it extra-clear, because in the words of customers, this is "Magic!"

Periodically on calls or in slack, [CEs get asked this](https://sourcegraph.slack.com/archives/C014ZCKMCAV/p1649236569648819?thread_ts=1649152923.922799&cid=C014ZCKMCAV) and I want to ensure this information is widely known. 

## Test plan

This is a docs change that I previewed. 

