### PR TITLE
fix: Remove expanded commits from non-root directory page

### DIFF
--- a/client/web/src/repo/tree/HomeTab.tsx
+++ b/client/web/src/repo/tree/HomeTab.tsx
@@ -200,12 +200,7 @@ export const HomeTab: React.FunctionComponent<Props> = ({
                 GitCommitFields,
                 Pick<
                     GitCommitNodeProps,
-                    | 'className'
-                    | 'compact'
-                    | 'messageSubjectClassName'
-                    | 'expandCommitMessageBody'
-                    | 'hideExpandCommitMessageBody'
-                    | 'sidebar'
+                    'className' | 'compact' | 'messageSubjectClassName' | 'hideExpandCommitMessageBody' | 'sidebar'
                 >
             >
                 location={props.location}
@@ -220,7 +215,6 @@ export const HomeTab: React.FunctionComponent<Props> = ({
                     className: classNames('list-group-item', styles.gitCommitNode),
                     messageSubjectClassName: isSidebar ? 'd-none' : styles.gitCommitNodeMessageSubject,
                     compact: isSidebar,
-                    expandCommitMessageBody: !isSidebar,
                     hideExpandCommitMessageBody: isSidebar,
                     sidebar: isSidebar,
                 }}


### PR DESCRIPTION
Closes: https://github.com/sourcegraph/sourcegraph/issues/33555

The new repo page is gigantic because it is set to display commit messages when available:
![image](https://user-images.githubusercontent.com/68532117/162047101-f6fd2867-9361-4089-9050-705918f04bbe.png)

This PR fixes the aforementioned issue by removing the option to show commit message in line:
![image](https://user-images.githubusercontent.com/68532117/162046785-5e2d9af2-920a-449c-9c5a-3b3987863e05.png)


## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->
No test plan available for the experimental feature

## App preview:
- [Link](https://sg-web-bee-fix-newrepo-dir.onrender.com)

