### PR TITLE
wildcard: Add outline-secondary to badge variants

### DIFF
--- a/client/wildcard/src/components/Badge/constants.ts
+++ b/client/wildcard/src/components/Badge/constants.ts
@@ -1,2 +1,11 @@
-export const BADGE_VARIANTS = ['primary', 'secondary', 'success', 'danger', 'warning', 'info', 'merged'] as const
+export const BADGE_VARIANTS = [
+    'primary',
+    'secondary',
+    'success',
+    'danger',
+    'warning',
+    'info',
+    'merged',
+    'outline-secondary',
+] as const
 export const PRODUCT_STATUSES = ['beta', 'prototype', 'experimental', 'wip', 'new'] as const

--- a/client/wildcard/src/components/Badge/constants.ts
+++ b/client/wildcard/src/components/Badge/constants.ts
@@ -6,6 +6,6 @@ export const BADGE_VARIANTS = [
     'warning',
     'info',
     'merged',
-    'outline-secondary',
+    'outlineSecondary',
 ] as const
 export const PRODUCT_STATUSES = ['beta', 'prototype', 'experimental', 'wip', 'new'] as const


### PR DESCRIPTION
Seems like this was missing.

## Test plan

Failing build should catch any related errors here. Confirmed usage works as intended in non-committed branch.
## App preview:
- [Link](https://sg-web-ef-wildcard-babyyyyyyy.onrender.com)

