### PR TITLE
buildkite: use standard queue

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -11,7 +11,7 @@ steps:
   - group: "Pipeline setup"
     steps:
       - label: ':hammer_and_wrench: :pipeline: Generate pipeline'
-        agents: { queue: stateless }
+        agents: { queue: standard }
         # Prioritize generating pipelines so that jobs can get generated and queued up as soon
         # as possible, so as to better assess pipeline load e.g. to scale the Buildkite fleet.
         priority: 10


### PR DESCRIPTION
Part of https://github.com/sourcegraph/sourcegraph/issues/33238

[_Created by Sourcegraph batch change `robert/buildkite-standard-queue-rollback`._](https://k8s.sgdev.org/users/robert/batch-changes/buildkite-standard-queue-rollback)

Test plan: CI!