### PR TITLE
codeintel: Add rich indexer to lsif upload/indexer types

### DIFF
--- a/cmd/frontend/graphqlbackend/codeintel.go
+++ b/cmd/frontend/graphqlbackend/codeintel.go
@@ -77,6 +77,7 @@ type LSIFUploadResolver interface {
 	StartedAt() *DateTime
 	FinishedAt() *DateTime
 	InputIndexer() string
+	Indexer() CodeIntelIndexerResolver
 	PlaceInQueue() *int32
 	AssociatedIndex(ctx context.Context) (LSIFIndexResolver, error)
 	ProjectRoot(ctx context.Context) (*GitTreeEntryResolver, error)
@@ -106,6 +107,7 @@ type LSIFIndexResolver interface {
 	InputCommit() string
 	InputRoot() string
 	InputIndexer() string
+	Indexer() CodeIntelIndexerResolver
 	QueuedAt() DateTime
 	State() string
 	Failure() *string

--- a/cmd/frontend/graphqlbackend/codeintel.graphql
+++ b/cmd/frontend/graphqlbackend/codeintel.graphql
@@ -1212,6 +1212,11 @@ type LSIFUpload implements Node {
     inputIndexer: String!
 
     """
+    The indexer used to produce this index.
+    """
+    indexer: CodeIntelIndexer
+
+    """
     The upload's current state.
     """
     state: LSIFUploadState!
@@ -1356,6 +1361,11 @@ type LSIFIndex implements Node {
     The name of the target indexer Docker image (e.g., sourcegraph/lsif-go@sha256:...).
     """
     inputIndexer: String!
+
+    """
+    The indexer used to produce the index artifact.
+    """
+    indexer: CodeIntelIndexer
 
     """
     The index's current state.

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/index.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/index.go
@@ -91,3 +91,12 @@ func (r *IndexResolver) ProjectRoot(ctx context.Context) (_ *gql.GitTreeEntryRes
 
 	return r.locationResolver.Path(ctx, api.RepoID(r.index.RepositoryID), r.index.Commit, r.index.Root)
 }
+
+func (r *IndexResolver) Indexer() gql.CodeIntelIndexerResolver {
+	// drop the tag if it exists
+	if idx, ok := imageToIndexer[strings.Split(r.index.Indexer, ":")[0]]; ok {
+		return idx
+	}
+
+	return &codeIntelIndexerResolver{name: r.index.Indexer}
+}

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/summary.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/summary.go
@@ -1,6 +1,8 @@
 package graphql
 
 import (
+	"strings"
+
 	gql "github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/codeintel/resolvers"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/policies"
@@ -128,7 +130,8 @@ func (r *LSIFIndexesWithRepositoryNamespaceResolver) Root() string {
 }
 
 func (r *LSIFIndexesWithRepositoryNamespaceResolver) Indexer() gql.CodeIntelIndexerResolver {
-	if idx, ok := imageToIndexer[r.indexesSummary.Indexer]; ok {
+	// drop the tag if it exists
+	if idx, ok := imageToIndexer[strings.Split(r.indexesSummary.Indexer, ":")[0]]; ok {
 		return idx
 	}
 

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/upload.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/upload.go
@@ -116,3 +116,13 @@ func (r *UploadResolver) RetentionPolicyOverview(ctx context.Context, args *gql.
 
 	return NewCodeIntelligenceRetentionPolicyMatcherConnectionResolver(r.db, r.resolver, matches, totalCount, r.traceErrs), nil
 }
+
+func (r *UploadResolver) Indexer() gql.CodeIntelIndexerResolver {
+	for _, indexer := range allIndexers {
+		if indexer.Name() == r.upload.Indexer {
+			return indexer
+		}
+	}
+
+	return &codeIntelIndexerResolver{name: r.upload.Indexer}
+}


### PR DESCRIPTION
This adds an `indexer` field as a sibling to `inputIndexert` on both lsif uploads and indexes. We will try to match these values against a known indexer so that we can give additional information in the frontend about the tool.

Immediately, we'll be able to expose a link to the indexer hompage, which is already a huge plus.

## Test plan

Tested locally by hand.