### PR TITLE
bext: fix show repo on Sourcegraph button rendering logic on GitHub

### DIFF
--- a/client/browser/src/shared/code-hosts/shared/ViewOnSourcegraphButton.tsx
+++ b/client/browser/src/shared/code-hosts/shared/ViewOnSourcegraphButton.tsx
@@ -25,7 +25,7 @@ interface ViewOnSourcegraphButtonProps
         Pick<ConfigureSourcegraphButtonProps, 'codeHostType' | 'onConfigureSourcegraphClick'> {
     context: CodeHostContext
     sourcegraphURL: string
-    userSettingsURL: string
+    userSettingsURL?: string
     minimalUI: boolean
     repoExistsOrError?: boolean | ErrorLike
     showSignInButton?: boolean
@@ -106,7 +106,7 @@ export const ViewOnSourcegraphButton: React.FunctionComponent<ViewOnSourcegraphB
 
     // If the repository does not exist, communicate that to explain why e.g. code intelligence does not work
     if (!repoExistsOrError) {
-        if (isDefaultSourcegraphUrl(sourcegraphURL) && privateRepository) {
+        if (isDefaultSourcegraphUrl(sourcegraphURL) && privateRepository && userSettingsURL) {
             return <ConfigureSourcegraphButton {...commonProps} codeHostType={codeHostType} href={userSettingsURL} />
         }
 

--- a/client/browser/src/shared/code-hosts/shared/codeHost.tsx
+++ b/client/browser/src/shared/code-hosts/shared/codeHost.tsx
@@ -1030,7 +1030,7 @@ export async function handleCodeHost({
                         distinctUntilChanged()
                     ),
                     from(getContext()),
-                    observeUserSettingsURL(requestGraphQL),
+                    observeUserSettingsURL(requestGraphQL).pipe(startWith(undefined)),
                 ]).subscribe(([repoExistsOrError, mount, showSignInButton, context, userSettingsURL]) => {
                     render(
                         <ViewOnSourcegraphButton
@@ -1039,11 +1039,10 @@ export async function handleCodeHost({
                             context={context}
                             minimalUI={minimalUI}
                             sourcegraphURL={sourcegraphURL}
-                            userSettingsURL={buildManageRepositoriesURL(
-                                sourcegraphURL,
-                                userSettingsURL,
-                                context.rawRepoName
-                            )}
+                            userSettingsURL={
+                                userSettingsURL &&
+                                buildManageRepositoriesURL(sourcegraphURL, userSettingsURL, context.rawRepoName)
+                            }
                             repoExistsOrError={repoExistsOrError}
                             showSignInButton={showSignInButton}
                             // The bound function is constant


### PR DESCRIPTION
Fixes 'Show on Sourcegraph' icon button rendering logic on GitHub (regression introduced by https://github.com/sourcegraph/sourcegraph/pull/31922).
Previously icon button was not rendered if the current user `settingsURL` value was not defined. 
If the user is not logged in their Sourcegraph instance `curentUser` value returned by the API expectedly is `null`, and the 'Show on Sourcegraph' icon button should still be rendered.

## Test plan
- `sg run bext`
- ensure you're not logged in into browser extension active current Sourcegraph instance
- open public repo page on GitHub and check whether the Sourcegraph icon button is rendered
- ensure use cases from https://github.com/sourcegraph/sourcegraph/pull/31922 test plan are passing 


<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->
## App preview:
- [Link](https://sg-web-taras-yemets-fix-show-repo-on-sg.onrender.com)

