### PR TITLE
gitserver: fix cleanup tests

### DIFF
--- a/cmd/gitserver/server/cleanup.go
+++ b/cmd/gitserver/server/cleanup.go
@@ -15,7 +15,6 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"sync"
 	"syscall"
 	"time"
 
@@ -112,9 +111,6 @@ var (
 )
 
 const reposStatsName = "repos-stats.json"
-
-// Used for setRepoSizes function to run only during the first run of janitor
-var setRepoSizesOnce sync.Once
 
 // cleanupRepos walks the repos directory and performs maintenance tasks:
 //
@@ -398,7 +394,7 @@ func (s *Server) cleanupRepos() {
 
 	// Repo sizes are set only once during the first janitor run.
 	// There is no need for a second run because all repo sizes will be set until this moment
-	setRepoSizesOnce.Do(func() {
+	s.setRepoSizesOnce.Do(func() {
 		err = s.setRepoSizes(context.Background(), repoToSize)
 		if err != nil {
 			log15.Error("cleanup: setting repo sizes", "error", err)

--- a/cmd/gitserver/server/cleanup_test.go
+++ b/cmd/gitserver/server/cleanup_test.go
@@ -31,6 +31,13 @@ const (
 	testRepoC = "testrepo-C"
 )
 
+func (s *Server) testHandlerWithDB(t *testing.T) {
+	t.Helper()
+	s.Handler() // Handler as a side-effect sets up Server
+	db := dbtest.NewDB(t)
+	s.DB = database.NewDB(db)
+}
+
 func TestCleanup_computeStats(t *testing.T) {
 	root, err := os.MkdirTemp("", "gitserver-test-")
 	if err != nil {
@@ -60,11 +67,9 @@ func TestCleanup_computeStats(t *testing.T) {
 	// We run cleanupRepos because we want to test as a side-effect it creates
 	// the correct file in the correct place.
 	s := &Server{ReposDir: root}
-	s.Handler() // Handler as a side-effect sets up Server
-	db := dbtest.NewDB(t)
-	s.DB = database.NewDB(db)
+	s.testHandlerWithDB(t)
 
-	if _, err := db.Exec(`
+	if _, err := s.DB.ExecContext(context.Background(), `
 insert into repo(id, name) values (1, 'a'), (2, 'b/d'), (3, 'c');
 insert into gitserver_repos(repo_id, shard_id) values (1, 1), (2, 1);
 insert into gitserver_repos(repo_id, shard_id, repo_size_bytes) values (3, 1, 228);
@@ -128,7 +133,7 @@ func TestCleanupInactive(t *testing.T) {
 	}
 
 	s := &Server{ReposDir: root}
-	s.Handler() // Handler as a side-effect sets up Server
+	s.testHandlerWithDB(t)
 	s.cleanupRepos()
 
 	if _, err := os.Stat(repoA); os.IsNotExist(err) {
@@ -190,7 +195,7 @@ func TestGitGCAuto(t *testing.T) {
 
 	// Handler must be invoked for Server side-effects.
 	s := &Server{ReposDir: root}
-	s.Handler()
+	s.testHandlerWithDB(t)
 	s.cleanupRepos()
 
 	// Verify that there are no more GC-able objects in the repository.
@@ -313,7 +318,7 @@ func TestCleanupExpired(t *testing.T) {
 			return &GitRepoSyncer{}, nil
 		},
 	}
-	s.Handler() // Handler as a side-effect sets up Server
+	s.testHandlerWithDB(t)
 	s.cleanupRepos()
 
 	// repos that shouldn't be re-cloned
@@ -408,7 +413,7 @@ func TestCleanupOldLocks(t *testing.T) {
 	chtime("github.com/foo/stalecommitgraphlock/.git/objects/info/commit-graph.lock", 2*time.Hour)
 
 	s := &Server{ReposDir: root}
-	s.Handler() // Handler as a side-effect sets up Server
+	s.testHandlerWithDB(t)
 	s.cleanupRepos()
 
 	assertPaths(t, root,

--- a/cmd/gitserver/server/cleanup_test.go
+++ b/cmd/gitserver/server/cleanup_test.go
@@ -31,7 +31,7 @@ const (
 	testRepoC = "testrepo-C"
 )
 
-func (s *Server) testHandlerWithDB(t *testing.T) {
+func (s *Server) testSetup(t *testing.T) {
 	t.Helper()
 	s.Handler() // Handler as a side-effect sets up Server
 	db := dbtest.NewDB(t)
@@ -67,7 +67,7 @@ func TestCleanup_computeStats(t *testing.T) {
 	// We run cleanupRepos because we want to test as a side-effect it creates
 	// the correct file in the correct place.
 	s := &Server{ReposDir: root}
-	s.testHandlerWithDB(t)
+	s.testSetup(t)
 
 	if _, err := s.DB.ExecContext(context.Background(), `
 insert into repo(id, name) values (1, 'a'), (2, 'b/d'), (3, 'c');
@@ -133,7 +133,7 @@ func TestCleanupInactive(t *testing.T) {
 	}
 
 	s := &Server{ReposDir: root}
-	s.testHandlerWithDB(t)
+	s.testSetup(t)
 	s.cleanupRepos()
 
 	if _, err := os.Stat(repoA); os.IsNotExist(err) {
@@ -195,7 +195,7 @@ func TestGitGCAuto(t *testing.T) {
 
 	// Handler must be invoked for Server side-effects.
 	s := &Server{ReposDir: root}
-	s.testHandlerWithDB(t)
+	s.testSetup(t)
 	s.cleanupRepos()
 
 	// Verify that there are no more GC-able objects in the repository.
@@ -318,7 +318,7 @@ func TestCleanupExpired(t *testing.T) {
 			return &GitRepoSyncer{}, nil
 		},
 	}
-	s.testHandlerWithDB(t)
+	s.testSetup(t)
 	s.cleanupRepos()
 
 	// repos that shouldn't be re-cloned
@@ -413,7 +413,7 @@ func TestCleanupOldLocks(t *testing.T) {
 	chtime("github.com/foo/stalecommitgraphlock/.git/objects/info/commit-graph.lock", 2*time.Hour)
 
 	s := &Server{ReposDir: root}
-	s.testHandlerWithDB(t)
+	s.testSetup(t)
 	s.cleanupRepos()
 
 	assertPaths(t, root,

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -243,6 +243,9 @@ type Server struct {
 
 	repoUpdateLocksMu sync.Mutex // protects the map below and also updates to locks.once
 	repoUpdateLocks   map[api.RepoName]*locks
+
+	// Used for setRepoSizes function to run only during the first run of janitor
+	setRepoSizesOnce sync.Once
 }
 
 type locks struct {


### PR DESCRIPTION
Some of the tests in cleanup_test.go fail if run separately or with `go test -short ./...` because we don't set up the DB before calling `cleanupRepos()`.

This was masked by a global `sync.Once` protecting `setRepoSizes`: the first test that ran set up the DB and triggered the `sync.Once`, the other tests didn't call the DB anymore because `setRepoSizes` was skipped.

## Test plan
- I ran the test suite locally with `git test -short ./...`
- I ran the tests in cleanup_test.go individually

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


