### PR TITLE
repos: Tag sync errors with a reason

### DIFF
--- a/internal/repos/metrics.go
+++ b/internal/repos/metrics.go
@@ -17,6 +17,7 @@ const (
 	tagID      = "id"
 	tagSuccess = "success"
 	tagState   = "state"
+	tagReason  = "reason"
 )
 
 var (
@@ -38,7 +39,7 @@ var (
 	syncErrors = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "src_repoupdater_syncer_sync_errors_total",
 		Help: "Total number of sync errors",
-	}, []string{tagFamily, tagOwner})
+	}, []string{tagFamily, tagOwner, tagReason})
 
 	syncDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
 		Name: "src_repoupdater_syncer_sync_duration_seconds",

--- a/internal/repos/syncer.go
+++ b/internal/repos/syncer.go
@@ -138,13 +138,11 @@ func (s *Syncer) TriggerExternalServiceSync(ctx context.Context, id int64) error
 	return s.Store.EnqueueSingleSyncJob(ctx, id)
 }
 
-type externalServiceOwnerType string
-
 const (
-	ownerUndefined externalServiceOwnerType = ""
-	ownerSite      externalServiceOwnerType = "site"
-	ownerUser      externalServiceOwnerType = "user"
-	ownerOrg       externalServiceOwnerType = "org"
+	ownerUndefined = ""
+	ownerSite      = "site"
+	ownerUser      = "user"
+	ownerOrg       = "org"
 )
 
 type ErrUnauthorized struct{}
@@ -820,13 +818,13 @@ func (s *Syncer) observeSync(
 	return ctx, func(svc *types.ExternalService, err error) {
 		var owner string
 		if svc == nil {
-			owner = string(ownerUndefined)
+			owner = ownerUndefined
 		} else if svc.NamespaceUserID > 0 {
-			owner = string(ownerUser)
+			owner = ownerUser
 		} else if svc.NamespaceOrgID > 0 {
-			owner = string(ownerOrg)
+			owner = ownerOrg
 		} else {
-			owner = string(ownerSite)
+			owner = ownerSite
 		}
 
 		syncStarted.WithLabelValues(family, owner).Inc()

--- a/internal/repos/syncer.go
+++ b/internal/repos/syncer.go
@@ -839,9 +839,26 @@ func (s *Syncer) observeSync(
 
 		if !success {
 			tr.SetError(err)
-			syncErrors.WithLabelValues(family, owner).Inc()
+			syncErrors.WithLabelValues(family, owner, syncErrorReason(err)).Inc()
 		}
 
 		tr.Finish()
+	}
+}
+
+func syncErrorReason(err error) string {
+	switch {
+	case err == nil:
+		return ""
+	case errcode.IsNotFound(err):
+		return "not_found"
+	case errcode.IsUnauthorized(err):
+		return "unauthorized"
+	case errcode.IsForbidden(err):
+		return "forbidden"
+	case errcode.IsTemporary(err):
+		return "temporary"
+	default:
+		return "unknown"
 	}
 }


### PR DESCRIPTION
We now tag sync errors with a reason when recording metrics.

This should help us narrow down spikes in sync errors we've been seeing
recently.
