### PR TITLE
search: Add information about dependencies predicate to search reference

### DIFF
--- a/client/search-ui/src/results/sidebar/SearchReference.tsx
+++ b/client/search-ui/src/results/sidebar/SearchReference.tsx
@@ -210,6 +210,14 @@ To use this filter, the search query must contain \`type:diff\` or \`type:commit
         showSuggestions: false,
     },
     {
+        ...createQueryExampleFromString('dependencies({regex-pattern})'),
+        field: FilterType.repo,
+        description:
+            'Search inside repositories that are dependencies of repositories matched by the provided regex pattern. This parameter is experimental.',
+        examples: ['repo:deps(^github\\.com/sourcegraph/sourcegraph$@3.36:3.35)'],
+        showSuggestions: false,
+    },
+    {
         ...createQueryExampleFromString('{revision}'),
         field: FilterType.rev,
         commonRank: 20,


### PR DESCRIPTION
Requested in [slack](https://sourcegraph.slack.com/archives/C032G1CLM7X/p1649315955096159).

I copied and adjusted the text and example from the documentation on docs.sourcegraph.com

<img width="212" alt="2022-04-07_15-49" src="https://user-images.githubusercontent.com/179026/162217729-fced9045-5abc-40df-af9d-171299eebf8c.png">
<img width="330" alt="2022-04-07_15-48_1" src="https://user-images.githubusercontent.com/179026/162217736-ad87c478-a355-4470-847c-a4688c84c57f.png">


## Test plan

Open search result page, browser search reference and verify that `repo:dependencies(...)` is in the list.


## App preview:
- [Link](https://sg-web-fkling-search-reference.onrender.com)

