### PR TITLE
bext: fix command palette mount container selector

### DIFF
--- a/client/browser/src/shared/code-hosts/github/extensions.tsx
+++ b/client/browser/src/shared/code-hosts/github/extensions.tsx
@@ -4,7 +4,9 @@ import { MountGetter } from '../shared/codeHost'
 export const getCommandPaletteMount: MountGetter = (container: HTMLElement): HTMLElement | null => {
     const className = 'command-palette-button'
     // This selector matches both GitHub Enterprise and github.com
-    const existing = container.querySelector<HTMLElement>(`.Header .${className}`)
+    const existing =
+        container.querySelector<HTMLElement>(`.Header .${className}`) ||
+        container.querySelector<HTMLElement>(`.Header-old .${className}`) // selector for not logged in user on github.com
     if (existing) {
         return existing
     }


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/33607

Fixes multiple command palette buttons issue on GitHub when the user is not logged in.

## Test plan
Tested manually on GitHub as a guest and as a logged-in user.
<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


## App preview:
- [Link](https://sg-web-taras-yemets-fix-bext-command.onrender.com)

