### PR TITLE
ratelimit: Increase default burst to 10

### DIFF
--- a/internal/extsvc/bitbucketcloud/client.go
+++ b/internal/extsvc/bitbucketcloud/client.go
@@ -40,7 +40,7 @@ var requestCounter = metrics.NewRequestMeter("bitbucket_cloud", "Total number of
 // See `pkg/extsvc/bitbucketserver/client.go` for the calculations behind these limits`
 const (
 	rateLimitRequestsPerSecond = 2 // 120/min or 7200/hr
-	RateLimitMaxBurstRequests  = 500
+	rateLimitMaxBurstRequests  = 500
 )
 
 // Client access a Bitbucket Cloud via the REST API 2.0.
@@ -86,7 +86,7 @@ func NewClient(config *schema.BitbucketCloudConnection, httpClient httpcli.Doer)
 	// Normally our registry will return a default infinite limiter when nothing has been
 	// synced from config. However, we always want to ensure there is at least some form of rate
 	// limiting for Bitbucket.
-	defaultLimiter := rate.NewLimiter(rateLimitRequestsPerSecond, RateLimitMaxBurstRequests)
+	defaultLimiter := rate.NewLimiter(rateLimitRequestsPerSecond, rateLimitMaxBurstRequests)
 	l := ratelimit.DefaultRegistry.GetOrSet(apiURL.String(), defaultLimiter)
 
 	return &Client{

--- a/internal/ratelimit/rate_limit.go
+++ b/internal/ratelimit/rate_limit.go
@@ -11,6 +11,8 @@ import (
 // limit mappings for each instance of our services.
 var DefaultRegistry = NewRegistry()
 
+const defaultBurst = 10
+
 // NewRegistry creates and returns an empty rate limit registry.
 func NewRegistry() *Registry {
 	return &Registry{
@@ -46,7 +48,7 @@ func (r *Registry) GetOrSet(urn string, fallback *rate.Limiter) *rate.Limiter {
 	l := r.rateLimiters[urn]
 	if l == nil {
 		if fallback == nil {
-			fallback = rate.NewLimiter(rate.Inf, 1)
+			fallback = rate.NewLimiter(rate.Inf, defaultBurst)
 		}
 		r.rateLimiters[urn] = fallback
 		return fallback

--- a/internal/ratelimit/rate_limit_test.go
+++ b/internal/ratelimit/rate_limit_test.go
@@ -11,7 +11,7 @@ func TestRegistry(t *testing.T) {
 	r := NewRegistry()
 
 	got := r.Get("404")
-	want := rate.NewLimiter(rate.Inf, 1)
+	want := rate.NewLimiter(rate.Inf, defaultBurst)
 	assert.Equal(t, want, got)
 
 	rl := rate.NewLimiter(10, 10)


### PR DESCRIPTION
We have a few places in the code where we request a burst larger than 1
so this gives us some headroom. It doesn't appear to be an issue yet so
this is just a safety measure.
