### PR TITLE
Code Insights: Refactor search based live preview card

### DIFF
--- a/client/web/src/charts/components/line-chart/LineChart.tsx
+++ b/client/web/src/charts/components/line-chart/LineChart.tsx
@@ -61,7 +61,7 @@ export function LineChart<D>(props: LineChartContentProps<D>): ReactElement | nu
                 height: outerHeight,
                 margin: {
                     top: 10,
-                    right: 0,
+                    right: 20,
                     left: yAxisReference.current?.getBoundingClientRect().width,
                     bottom: xAxisReference.current?.getBoundingClientRect().height,
                 },
@@ -85,11 +85,11 @@ export function LineChart<D>(props: LineChartContentProps<D>): ReactElement | nu
         () =>
             scaleTime({
                 domain: [minX, maxX],
-                range: [margin.left, outerWidth],
+                range: [margin.left, outerWidth - margin.right],
                 nice: true,
                 clamp: true,
             }),
-        [minX, maxX, margin.left, outerWidth]
+        [minX, maxX, margin.left, margin.right, outerWidth]
     )
 
     const yScale = useMemo(
@@ -149,7 +149,7 @@ export function LineChart<D>(props: LineChartContentProps<D>): ReactElement | nu
             <AxisLeft
                 ref={yAxisReference}
                 scale={yScale}
-                width={outerWidth}
+                width={width}
                 height={height}
                 top={margin.top}
                 left={margin.left}

--- a/client/web/src/charts/components/line-chart/LineChart.tsx
+++ b/client/web/src/charts/components/line-chart/LineChart.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useMemo, useRef, useState } from 'react'
+import React, { ReactElement, useMemo, useRef, useState, SVGProps } from 'react'
 
 import { curveLinear } from '@visx/curve'
 import { Group } from '@visx/group'
@@ -26,7 +26,7 @@ import { SeriesDatum } from './utils/data-series-processing/types'
 
 import styles from './LineChart.module.scss'
 
-export interface LineChartContentProps<Datum> extends SeriesLikeChart<Datum> {
+export interface LineChartContentProps<Datum> extends SeriesLikeChart<Datum>, SVGProps<SVGSVGElement> {
     width: number
     height: number
     zeroYAxisMin?: boolean
@@ -46,6 +46,8 @@ export function LineChart<D>(props: LineChartContentProps<D>): ReactElement | nu
         zeroYAxisMin = false,
         getXValue,
         onDatumClick = noop,
+        className,
+        ...attributes
     } = props
 
     const [activePoint, setActivePoint] = useState<Point<D> & { element?: Element }>()
@@ -59,12 +61,12 @@ export function LineChart<D>(props: LineChartContentProps<D>): ReactElement | nu
                 height: outerHeight,
                 margin: {
                     top: 10,
-                    right: 10,
-                    left: yAxisReference.current?.getBoundingClientRect().width ?? 30,
-                    bottom: xAxisReference.current?.getBoundingClientRect().height ?? 30,
+                    right: 0,
+                    left: yAxisReference.current?.getBoundingClientRect().width,
+                    bottom: xAxisReference.current?.getBoundingClientRect().height,
                 },
             }),
-        [outerWidth, outerHeight, yAxisReference]
+        [outerWidth, outerHeight]
     )
 
     const dataSeries = useMemo(() => getSeriesData({ data, series, stacked, getXValue }), [
@@ -83,11 +85,11 @@ export function LineChart<D>(props: LineChartContentProps<D>): ReactElement | nu
         () =>
             scaleTime({
                 domain: [minX, maxX],
-                range: [margin.left, width],
+                range: [margin.left, outerWidth],
                 nice: true,
                 clamp: true,
             }),
-        [minX, maxX, margin.left, width]
+        [minX, maxX, margin.left, outerWidth]
     )
 
     const yScale = useMemo(
@@ -140,13 +142,14 @@ export function LineChart<D>(props: LineChartContentProps<D>): ReactElement | nu
         <svg
             width={outerWidth}
             height={outerHeight}
-            className={classNames(styles.root, { [styles.rootWithHoveredLinkPoint]: activePoint?.linkUrl })}
+            className={classNames(styles.root, className, { [styles.rootWithHoveredLinkPoint]: activePoint?.linkUrl })}
+            {...attributes}
             {...handlers}
         >
             <AxisLeft
                 ref={yAxisReference}
                 scale={yScale}
-                width={width}
+                width={outerWidth}
                 height={height}
                 top={margin.top}
                 left={margin.left}

--- a/client/web/src/charts/components/line-chart/components/axis/Axis.module.scss
+++ b/client/web/src/charts/components/line-chart/components/axis/Axis.module.scss
@@ -10,7 +10,7 @@
 }
 
 .axis-line {
-    stroke: var(--border-color);
+    stroke: var(--border-color-2);
     stroke-width: 1;
 
     &--vertical {
@@ -23,7 +23,7 @@
 .axis-tick {
     // small tick line
     line {
-        stroke: var(--border-color);
+        stroke: var(--border-color-2);
         stroke-width: 1;
     }
 

--- a/client/web/src/charts/components/line-chart/components/axis/Axis.tsx
+++ b/client/web/src/charts/components/line-chart/components/axis/Axis.tsx
@@ -29,7 +29,7 @@ export const AxisLeft = memo(
                 <GridRows
                     top={top}
                     left={left}
-                    width={width - left}
+                    width={width}
                     height={height}
                     scale={scale}
                     tickValues={getYScaleTicks({ scale, space: height })}

--- a/client/web/src/charts/components/line-chart/utils/generate-points-field.ts
+++ b/client/web/src/charts/components/line-chart/utils/generate-points-field.ts
@@ -31,7 +31,7 @@ export function generatePointsField<Datum>(input: PointsFieldInput<Datum>): Poin
                 x: xScale(data.x),
                 time: data.x,
                 color: series.color ?? 'green',
-                linkUrl: getLinkURL(data.datum),
+                linkUrl: getLinkURL(data.datum, index),
                 datum: data.datum,
             }
         })

--- a/client/web/src/charts/components/pie-chart/PieChart.story.tsx
+++ b/client/web/src/charts/components/pie-chart/PieChart.story.tsx
@@ -6,7 +6,7 @@ import { WebStory } from '../../../components/WebStory'
 
 import { PieChart } from './PieChart'
 
-export const StoryConfig: Meta = {
+const StoryConfig: Meta = {
     title: 'web/charts/pie',
     decorators: [story => <WebStory>{() => story()}</WebStory>],
 }

--- a/client/web/src/charts/types.ts
+++ b/client/web/src/charts/types.ts
@@ -30,15 +30,15 @@ export interface Series<Datum> {
     dataKey: keyof Datum
 
     /**
-     * Link for data series point. It may be used to make datum points with links
-     * instead of plain visual svg elements.
-     */
-    getLinkURL?: (datum: Datum) => string | undefined
-
-    /**
      * The name of the line shown in the legend and tooltip
      */
     name: string
+
+    /**
+     * Link for data series point. It may be used to make datum points with links
+     * instead of plain visual svg elements.
+     */
+    getLinkURL?: (datum: Datum, index: number) => string | undefined
 
     /**
      * The CSS color of the series. If color wasn't provided the default (gray) color

--- a/client/web/src/enterprise/insights/components/views/chart/categorical/CategoricalChart.story.tsx
+++ b/client/web/src/enterprise/insights/components/views/chart/categorical/CategoricalChart.story.tsx
@@ -7,7 +7,7 @@ import { CategoricalBasedChartTypes } from '../../types'
 
 import { CategoricalChart } from './CategoricalChart'
 
-export const StoryConfig: Meta = {
+const StoryConfig: Meta = {
     title: 'web/insights/views/CategoricalChart',
     decorators: [story => <WebStory>{() => story()}</WebStory>],
 }

--- a/client/web/src/enterprise/insights/components/views/chart/series/SeriesChart.story.tsx
+++ b/client/web/src/enterprise/insights/components/views/chart/series/SeriesChart.story.tsx
@@ -8,7 +8,7 @@ import { SeriesBasedChartTypes } from '../../types'
 
 import { SeriesChart } from './SeriesChart'
 
-export const StoryConfig: Meta = {
+const StoryConfig: Meta = {
     title: 'web/insights/views/SeriesChart',
     decorators: [story => <WebStory>{() => story()}</WebStory>],
 }

--- a/client/web/src/enterprise/insights/components/views/chart/series/SeriesChart.tsx
+++ b/client/web/src/enterprise/insights/components/views/chart/series/SeriesChart.tsx
@@ -1,9 +1,9 @@
-import React from 'react'
+import React, { SVGProps } from 'react'
 
 import { LineChart, SeriesLikeChart } from '../../../../../../charts'
 import { SeriesBasedChartTypes } from '../../types'
 
-export interface SeriesChartProps<D> extends SeriesLikeChart<D> {
+export interface SeriesChartProps<D> extends SeriesLikeChart<D>, Omit<SVGProps<SVGSVGElement>, 'type'> {
     type: SeriesBasedChartTypes
     width: number
     height: number

--- a/client/web/src/enterprise/insights/core/backend/code-insights-backend-context.ts
+++ b/client/web/src/enterprise/insights/core/backend/code-insights-backend-context.ts
@@ -1,10 +1,10 @@
 import React from 'react'
 
 import { throwError } from 'rxjs'
-import { LineChartContent } from 'sourcegraph'
+import { LineChartContent as LegacyChartContent } from 'sourcegraph'
 
 import { CodeInsightsBackend } from './code-insights-backend'
-import { PieChartContent, RepositorySuggestionData } from './code-insights-backend-types'
+import { LineChartContent, PieChartContent, RepositorySuggestionData } from './code-insights-backend-types'
 
 const errorMockMethod = (methodName: string) => () => throwError(new Error(`Implement ${methodName} method first`))
 
@@ -39,12 +39,12 @@ export class FakeDefaultCodeInsightsBackend implements CodeInsightsBackend {
     public assignInsightsToDashboard = errorMockMethod('assignInsightsToDashboard')
 
     // Live preview fetchers
-    public getSearchInsightContent = (): Promise<LineChartContent<any, string>> =>
+    public getSearchInsightContent = (): Promise<LineChartContent<unknown>> =>
         errorMockMethod('getSearchInsightContent')().toPromise()
-    public getLangStatsInsightContent = (): Promise<PieChartContent<any>> =>
+    public getLangStatsInsightContent = (): Promise<PieChartContent<unknown>> =>
         errorMockMethod('getLangStatsInsightContent')().toPromise()
 
-    public getCaptureInsightContent = (): Promise<LineChartContent<any, string>> =>
+    public getCaptureInsightContent = (): Promise<LegacyChartContent<any, string>> =>
         errorMockMethod('getCaptureInsightContent')().toPromise()
 
     // Repositories API

--- a/client/web/src/enterprise/insights/core/backend/code-insights-backend-types.ts
+++ b/client/web/src/enterprise/insights/core/backend/code-insights-backend-types.ts
@@ -1,6 +1,7 @@
 import { Duration } from 'date-fns'
-import { LineChartContent } from 'sourcegraph'
+import { LineChartContent as LegacyLineChartContent } from 'sourcegraph'
 
+import { Series } from '../../../../charts'
 import {
     RuntimeInsight,
     InsightDashboard,
@@ -18,6 +19,12 @@ export interface PieChartContent<Datum> {
     getDatumName: (datum: Datum) => string
     getDatumColor: (datum: Datum) => string | undefined
     getDatumLink?: (datum: Datum) => string | undefined
+}
+
+export interface LineChartContent<Datum> {
+    data: Datum[]
+    series: Series<Datum>[]
+    getXValue: (datum: Datum) => Date
 }
 
 export interface DashboardCreateInput {
@@ -112,7 +119,7 @@ export interface BackendInsightData {
     view: {
         title: string
         subtitle?: string
-        content: LineChartContent<any, string>[]
+        content: LegacyLineChartContent<any, string>[]
         isFetchingHistoricalData: boolean
     }
 }

--- a/client/web/src/enterprise/insights/core/backend/code-insights-backend.ts
+++ b/client/web/src/enterprise/insights/core/backend/code-insights-backend.ts
@@ -1,5 +1,5 @@
 import { Observable } from 'rxjs'
-import { LineChartContent } from 'sourcegraph'
+import { LineChartContent as LegacyLineChartContent } from 'sourcegraph'
 
 import { ViewProviderResult } from '@sourcegraph/shared/src/api/extension/extensionHostApi'
 
@@ -24,6 +24,7 @@ import {
     RemoveInsightFromDashboardInput,
     RepositorySuggestionData,
     PieChartContent,
+    LineChartContent,
 } from './code-insights-backend-types'
 
 export interface UiFeaturesConfig {
@@ -105,14 +106,14 @@ export interface CodeInsightsBackend {
     /**
      * Returns content for the search based insight live preview chart.
      */
-    getSearchInsightContent: (input: GetSearchInsightContentInput) => Promise<LineChartContent<any, string>>
+    getSearchInsightContent: (input: GetSearchInsightContentInput) => Promise<LineChartContent<unknown>>
 
     /**
      * Returns content for the code stats insight live preview chart.
      */
     getLangStatsInsightContent: (input: GetLangStatsInsightContentInput) => Promise<PieChartContent<unknown>>
 
-    getCaptureInsightContent: (input: CaptureInsightSettings) => Promise<LineChartContent<any, string>>
+    getCaptureInsightContent: (input: CaptureInsightSettings) => Promise<LegacyLineChartContent<any, string>>
 
     /**
      * Returns a list of suggestions for the repositories' field in the insight creation UI.

--- a/client/web/src/enterprise/insights/pages/insights/creation/lang-stats/components/live-preview-chart/LangStatsInsightLivePreview.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/lang-stats/components/live-preview-chart/LangStatsInsightLivePreview.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 
-import classNames from 'classnames'
 import RefreshIcon from 'mdi-react/RefreshIcon'
 
 import { ErrorAlert } from '@sourcegraph/branded/src/components/alerts'
@@ -48,7 +47,7 @@ export const LangStatsInsightLivePreview: React.FunctionComponent<LangStatsInsig
     const { loading, dataOrError, update } = useLangStatsPreviewContent({ disabled, previewSetting })
 
     return (
-        <aside className={classNames(className)}>
+        <aside className={className}>
             <Button variant="icon" disabled={disabled} onClick={update}>
                 Live preview <RefreshIcon size="1rem" />
             </Button>

--- a/client/web/src/enterprise/insights/pages/insights/creation/lang-stats/components/live-preview-chart/LangStatsInsightLivePreview.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/lang-stats/components/live-preview-chart/LangStatsInsightLivePreview.tsx
@@ -33,7 +33,7 @@ export interface LangStatsInsightLivePreviewProps {
 }
 
 /**
- * Displays live preview chart for creation UI with latest insights settings
+ * Displays live preview chart for creation UI with the latest insights settings
  * from creation UI form.
  */
 export const LangStatsInsightLivePreview: React.FunctionComponent<LangStatsInsightLivePreviewProps> = props => {
@@ -42,9 +42,10 @@ export const LangStatsInsightLivePreview: React.FunctionComponent<LangStatsInsig
     const previewSetting = useDeepMemo({
         repository: repository.trim(),
         otherThreshold: threshold / 100,
+        disabled,
     })
 
-    const { loading, dataOrError, update } = useLangStatsPreviewContent({ disabled, previewSetting })
+    const { loading, dataOrError, update } = useLangStatsPreviewContent(previewSetting)
 
     return (
         <aside className={className}>

--- a/client/web/src/enterprise/insights/pages/insights/creation/lang-stats/components/live-preview-chart/hooks/use-lang-stats-preview-content.ts
+++ b/client/web/src/enterprise/insights/pages/insights/creation/lang-stats/components/live-preview-chart/hooks/use-lang-stats-preview-content.ts
@@ -10,10 +10,8 @@ export interface UseLangStatsPreviewContentProps {
     /** Prop to turn off fetching and reset data for live preview chart. */
     disabled: boolean
     /** Settings which needed to fetch data for live preview. */
-    previewSetting: {
-        repository: string
-        otherThreshold: number
-    }
+    repository: string
+    otherThreshold: number
 }
 
 export interface UseLangStatsPreviewContentAPI {
@@ -25,9 +23,7 @@ export interface UseLangStatsPreviewContentAPI {
 /**
  * Unified logic for fetching data for live preview chart of lang stats insight.
  */
-export function useLangStatsPreviewContent(props: UseLangStatsPreviewContentProps): UseLangStatsPreviewContentAPI {
-    const { disabled, previewSetting } = props
-
+export function useLangStatsPreviewContent(input: UseLangStatsPreviewContentProps): UseLangStatsPreviewContentAPI {
     const { getLangStatsInsightContent } = useContext(CodeInsightsBackendContext)
 
     const [loading, setLoading] = useState<boolean>(false)
@@ -36,14 +32,14 @@ export function useLangStatsPreviewContent(props: UseLangStatsPreviewContentProp
     // Synthetic deps to trigger dry run for fetching live preview data
     const [lastPreviewVersion, setLastPreviewVersion] = useState(0)
 
-    const liveDebouncedSettings = useDebounce(previewSetting, 500)
+    const liveDebouncedSettings = useDebounce(input, 500)
 
     useEffect(() => {
         let hasRequestCanceled = false
         setLoading(true)
         setDataOrError(undefined)
 
-        if (disabled) {
+        if (liveDebouncedSettings.disabled) {
             setLoading(false)
 
             return
@@ -57,7 +53,7 @@ export function useLangStatsPreviewContent(props: UseLangStatsPreviewContentProp
         return () => {
             hasRequestCanceled = true
         }
-    }, [disabled, lastPreviewVersion, getLangStatsInsightContent, liveDebouncedSettings])
+    }, [lastPreviewVersion, getLangStatsInsightContent, liveDebouncedSettings])
 
     return {
         loading,

--- a/client/web/src/enterprise/insights/pages/insights/creation/search-insight/components/live-preview-chart/SearchInsightLivePreview.module.scss
+++ b/client/web/src/enterprise/insights/pages/insights/creation/search-insight/components/live-preview-chart/SearchInsightLivePreview.module.scss
@@ -1,0 +1,32 @@
+.insight-card {
+    min-height: 20rem;
+}
+
+.chart-block {
+    flex: 1;
+    position: relative;
+}
+
+.chart-with-mock {
+    filter: blur(4px);
+    pointer-events: none;
+    opacity: 0.4;
+
+    // In order to turn off any interactions with chart like
+    // tooltip or chart shutter for user cursor we have to
+    // override pointer events. Since visx charts add pointer events
+    // by html attribute we have to use important statement.
+    :global(.visx-group) {
+        pointer-events: none !important;
+    }
+}
+
+.disable-banner {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    padding: 1rem 2rem;
+    text-align: center;
+}

--- a/client/web/src/enterprise/insights/pages/insights/creation/search-insight/components/live-preview-chart/SearchInsightLivePreview.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/search-insight/components/live-preview-chart/SearchInsightLivePreview.tsx
@@ -1,74 +1,55 @@
-import React, { ReactNode, useContext, useEffect, useState } from 'react'
+import React from 'react'
 
-import type { LineChartContent, ChartContent } from 'sourcegraph'
+import RefreshIcon from 'mdi-react/RefreshIcon'
 
-import { asError } from '@sourcegraph/common'
-import { useDebounce } from '@sourcegraph/wildcard'
+import { ErrorAlert } from '@sourcegraph/branded/src/components/alerts'
+import { isErrorLike } from '@sourcegraph/common'
+import { Button, useDeepMemo } from '@sourcegraph/wildcard'
 
-import { LivePreviewContainer, getSanitizedRepositories } from '../../../../../../components/creation-ui-kit'
-import { CodeInsightsBackendContext } from '../../../../../../core/backend/code-insights-backend-context'
+import { getLineColor, LegendItem, LegendList, ParentSize } from '../../../../../../../../charts'
+import { getSanitizedRepositories } from '../../../../../../components/creation-ui-kit'
+import {
+    InsightCard,
+    InsightCardBanner,
+    InsightCardLoading,
+    SeriesBasedChartTypes,
+    SeriesChart,
+} from '../../../../../../components/views'
 import { SearchBasedInsightSeries } from '../../../../../../core/types'
-import { useDistinctValue } from '../../../../../../hooks/use-distinct-value'
 import { EditableDataSeries, InsightStep } from '../../types'
 import { getSanitizedLine } from '../../utils/insight-sanitizer'
 
+import { useSearchBasedLivePreviewContent } from './hooks/use-search-based-live-preview-content'
 import { DEFAULT_MOCK_CHART_CONTENT } from './live-preview-mock-data'
 
-export interface SearchInsightLivePreviewProps {
-    /** Custom className for the root element of live preview. */
-    className?: string
-    /** List of repositories for insights. */
-    repositories: string
-    /** All Series for live chart. */
-    series: EditableDataSeries[]
-    /** Step value for chart. */
-    stepValue: string
+import styles from './SearchInsightLivePreview.module.scss'
 
+export interface SearchInsightLivePreviewProps {
     /**
      * Disable prop to disable live preview.
      * Used in a consumer of this component when some required fields
      * for live preview are invalid.
      */
-    disabled?: boolean
-
-    /** Step mode for step value prop. */
+    disabled: boolean
+    repositories: string
+    series: EditableDataSeries[]
+    stepValue: string
     step: InsightStep
-
     isAllReposMode: boolean
 
-    withLivePreviewControls?: boolean
-    title?: string
-    children?: (data: ChartContent) => ReactNode
+    className?: string
 }
 
 /**
- * Displays live preview chart for creation UI with latest insights settings
+ * Displays live preview chart for creation UI with the latest insights settings
  * from creation UI form.
  */
 export const SearchInsightLivePreview: React.FunctionComponent<SearchInsightLivePreviewProps> = props => {
-    const {
-        series,
-        repositories,
-        step,
-        stepValue,
-        disabled = false,
-        isAllReposMode,
-        title,
-        withLivePreviewControls = true,
-        className,
-        children,
-    } = props
-
-    const { getSearchInsightContent } = useContext(CodeInsightsBackendContext)
-
-    const [loading, setLoading] = useState<boolean>(false)
-    const [dataOrError, setDataOrError] = useState<LineChartContent<any, string> | Error | undefined>()
-    // Synthetic deps to trigger dry run for fetching live preview data
-    const [lastPreviewVersion, setLastPreviewVersion] = useState(0)
+    const { series, repositories, step, stepValue, disabled = false, isAllReposMode, className } = props
 
     // Compare live insight settings with deep check to avoid unnecessary
     // search insight content fetching
-    const liveSettings = useDistinctValue({
+    const previewSetting = useDeepMemo({
         series: series
             .filter(series => series.valid)
             // Cut off all unnecessary for live preview fields in order to
@@ -80,60 +61,58 @@ export const SearchInsightLivePreview: React.FunctionComponent<SearchInsightLive
         disabled,
     })
 
-    const liveDebouncedSettings = useDebounce(liveSettings, 500)
-
-    useEffect(() => {
-        let hasRequestCanceled = false
-        setLoading(true)
-        setDataOrError(undefined)
-
-        if (liveDebouncedSettings.disabled) {
-            setLoading(false)
-
-            return
-        }
-
-        getSearchInsightContent({
-            insight: liveDebouncedSettings,
-        })
-            .then(data => !hasRequestCanceled && setDataOrError(data))
-            .catch(error => !hasRequestCanceled && setDataOrError(asError(error)))
-            .finally(() => !hasRequestCanceled && setLoading(false))
-
-        return () => {
-            hasRequestCanceled = true
-        }
-    }, [lastPreviewVersion, getSearchInsightContent, liveDebouncedSettings])
+    const { loading, dataOrError, update } = useSearchBasedLivePreviewContent(previewSetting)
 
     return (
-        <LivePreviewContainer
-            dataOrError={dataOrError}
-            loading={loading}
-            title={title}
-            disabled={disabled}
-            livePreviewControls={withLivePreviewControls}
-            defaultMock={DEFAULT_MOCK_CHART_CONTENT}
-            mockMessage={
-                isAllReposMode ? (
-                    <span> Live previews are currently not available for insights running over all repositories. </span>
+        <aside className={className}>
+            <Button variant="icon" disabled={disabled} onClick={update}>
+                Live preview <RefreshIcon size="1rem" />
+            </Button>
+
+            <InsightCard className={styles.insightCard}>
+                {loading ? (
+                    <InsightCardLoading>Loading code insight</InsightCardLoading>
+                ) : isErrorLike(dataOrError) ? (
+                    <ErrorAlert error={dataOrError} />
                 ) : (
-                    <span>
-                        {' '}
-                        The chart preview will be shown here once you have filled out the repositories and series
-                        fields.
-                    </span>
-                )
-            }
-            description={
-                isAllReposMode
-                    ? 'Previews are only displayed only if you individually list up to 50 repositories.'
-                    : null
-            }
-            className={className}
-            chartContentClassName={title ? '' : 'pt-4'}
-            onUpdateClick={() => setLastPreviewVersion(version => version + 1)}
-        >
-            {children}
-        </LivePreviewContainer>
+                    <ParentSize className={styles.chartBlock}>
+                        {parent =>
+                            dataOrError ? (
+                                <SeriesChart
+                                    type={SeriesBasedChartTypes.Line}
+                                    width={parent.width}
+                                    height={parent.height}
+                                    {...dataOrError}
+                                />
+                            ) : (
+                                <>
+                                    <SeriesChart
+                                        type={SeriesBasedChartTypes.Line}
+                                        width={parent.width}
+                                        height={parent.height}
+                                        className={styles.chartWithMock}
+                                        {...DEFAULT_MOCK_CHART_CONTENT}
+                                    />
+                                    <InsightCardBanner className={styles.disableBanner}>
+                                        {isAllReposMode
+                                            ? 'Live previews are currently not available for insights running over all repositories.'
+                                            : 'The chart preview will be shown here once you have filled out the repositories and series fields.'}
+                                    </InsightCardBanner>
+                                </>
+                            )
+                        }
+                    </ParentSize>
+                )}
+
+                {dataOrError && !isErrorLike(dataOrError) && (
+                    <LegendList className="mt-3">
+                        {dataOrError.series.map(series => (
+                            <LegendItem key={series.dataKey} color={getLineColor(series)} name={series.name} />
+                        ))}
+                    </LegendList>
+                )}
+            </InsightCard>
+            {isAllReposMode && <p>Previews are only displayed if you individually list up to 50 repositories.</p>}
+        </aside>
     )
 }

--- a/client/web/src/enterprise/insights/pages/insights/creation/search-insight/components/live-preview-chart/SearchInsightLivePreview.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/search-insight/components/live-preview-chart/SearchInsightLivePreview.tsx
@@ -82,6 +82,7 @@ export const SearchInsightLivePreview: React.FunctionComponent<SearchInsightLive
                                     type={SeriesBasedChartTypes.Line}
                                     width={parent.width}
                                     height={parent.height}
+                                    data-testid="code-search-insight-live-preview"
                                     {...dataOrError}
                                 />
                             ) : (

--- a/client/web/src/enterprise/insights/pages/insights/creation/search-insight/components/live-preview-chart/hooks/use-search-based-live-preview-content.ts
+++ b/client/web/src/enterprise/insights/pages/insights/creation/search-insight/components/live-preview-chart/hooks/use-search-based-live-preview-content.ts
@@ -1,0 +1,64 @@
+import { useContext, useEffect, useState } from 'react'
+
+import { Duration } from 'date-fns'
+
+import { asError } from '@sourcegraph/common'
+import { useDebounce } from '@sourcegraph/wildcard'
+
+import { CodeInsightsBackendContext } from '../../../../../../../core/backend/code-insights-backend-context'
+import { LineChartContent } from '../../../../../../../core/backend/code-insights-backend-types'
+import { SearchBasedInsightSeries } from '../../../../../../../core/types'
+
+export interface Input {
+    /** Prop to turn off fetching and reset data for live preview chart. */
+    disabled: boolean
+    series: SearchBasedInsightSeries[]
+    step: Duration
+    repositories: string[]
+}
+
+export interface Output {
+    loading: boolean
+    dataOrError: LineChartContent<unknown> | Error | undefined
+    update: () => void
+}
+
+export function useSearchBasedLivePreviewContent(input: Input): Output {
+    const { getSearchInsightContent } = useContext(CodeInsightsBackendContext)
+
+    // Synthetic deps to trigger dry run for fetching live preview data
+    const [lastPreviewVersion, setLastPreviewVersion] = useState(0)
+    const [loading, setLoading] = useState<boolean>(false)
+    const [dataOrError, setDataOrError] = useState<LineChartContent<unknown> | Error | undefined>()
+
+    const debouncedInput = useDebounce(input, 500)
+
+    useEffect(() => {
+        let hasRequestCanceled = false
+        setLoading(true)
+        setDataOrError(undefined)
+
+        if (debouncedInput.disabled) {
+            setLoading(false)
+
+            return
+        }
+
+        getSearchInsightContent({
+            insight: debouncedInput,
+        })
+            .then(data => !hasRequestCanceled && setDataOrError(data))
+            .catch(error => !hasRequestCanceled && setDataOrError(asError(error)))
+            .finally(() => !hasRequestCanceled && setLoading(false))
+
+        return () => {
+            hasRequestCanceled = true
+        }
+    }, [lastPreviewVersion, getSearchInsightContent, debouncedInput])
+
+    return {
+        loading,
+        dataOrError,
+        update: () => setLastPreviewVersion(count => count + 1),
+    }
+}

--- a/client/web/src/enterprise/insights/pages/insights/creation/search-insight/components/live-preview-chart/index.ts
+++ b/client/web/src/enterprise/insights/pages/insights/creation/search-insight/components/live-preview-chart/index.ts
@@ -1,0 +1,3 @@
+export { SearchInsightLivePreview } from './SearchInsightLivePreview'
+export { DEFAULT_MOCK_CHART_CONTENT } from './live-preview-mock-data'
+export { useSearchBasedLivePreviewContent } from './hooks/use-search-based-live-preview-content'

--- a/client/web/src/enterprise/insights/pages/insights/creation/search-insight/components/live-preview-chart/live-preview-mock-data.ts
+++ b/client/web/src/enterprise/insights/pages/insights/creation/search-insight/components/live-preview-chart/live-preview-mock-data.ts
@@ -1,8 +1,14 @@
 import { random } from 'lodash'
-import type { LineChartContent } from 'sourcegraph'
 
-export const DEFAULT_MOCK_CHART_CONTENT: LineChartContent<any, string> = {
-    chart: 'line' as const,
+import { LineChartContent } from '../../../../../../core/backend/code-insights-backend-types'
+
+interface LivePreviewDatum {
+    x: number
+    a: number
+    b: number
+}
+
+export const DEFAULT_MOCK_CHART_CONTENT: LineChartContent<LivePreviewDatum> = {
     data: [
         { x: 1588965700286 - 6 * 24 * 60 * 60 * 1000, a: 20, b: 200 },
         { x: 1588965700286 - 5 * 24 * 60 * 60 * 1000, a: 40, b: 177 },
@@ -16,19 +22,15 @@ export const DEFAULT_MOCK_CHART_CONTENT: LineChartContent<any, string> = {
         {
             dataKey: 'a',
             name: 'Old gql imports',
-            stroke: 'var(--oc-indigo-7)',
+            color: 'var(--oc-indigo-7)',
         },
         {
             dataKey: 'b',
             name: 'New gql operation imports',
-            stroke: 'var(--oc-orange-7)',
+            color: 'var(--oc-orange-7)',
         },
     ],
-    xAxis: {
-        dataKey: 'x',
-        scale: 'time' as const,
-        type: 'number',
-    },
+    getXValue: datum => new Date(datum.x),
 }
 
 export const getRandomDataForMock = (): unknown[] =>

--- a/client/web/src/enterprise/insights/pages/insights/creation/search-insight/components/search-insight-creation-content/SearchInsightCreationContent.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/search-insight/components/search-insight-creation-content/SearchInsightCreationContent.tsx
@@ -70,12 +70,12 @@ export const SearchInsightCreationContent: React.FunctionComponent<SearchInsight
     }
 
     // If some fields that needed to run live preview  are invalid
-    // we should disabled live chart preview
+    // we should disable live chart preview
     const allFieldsForPreviewAreValid =
         repositories.meta.validState === 'VALID' &&
         (series.meta.validState === 'VALID' || editSeries.some(series => series.valid)) &&
         stepValue.meta.validState === 'VALID' &&
-        // For all repos mode we are not able to show the live preview chart
+        // For the "all repositories" mode we are not able to show the live preview chart
         !allReposMode.input.value
 
     const hasFilledValue =

--- a/client/web/src/enterprise/insights/pages/insights/creation/search-insight/index.ts
+++ b/client/web/src/enterprise/insights/pages/insights/creation/search-insight/index.ts
@@ -1,7 +1,9 @@
-export { SearchInsightCreationPage } from './SearchInsightCreationPage'
-export { encodeSearchInsightUrl } from './utils/search-insight-url-parsers/search-insight-url-parsers'
-export { CreateInsightFormFields, EditableDataSeries, InsightStep } from './types'
-
 export { DATA_SERIES_COLORS, DEFAULT_DATA_SERIES_COLOR } from './constants'
 
+export { SearchInsightCreationPage } from './SearchInsightCreationPage'
+export { encodeSearchInsightUrl } from './utils/search-insight-url-parsers/search-insight-url-parsers'
+export { getQueryPatternTypeFilter } from './components/form-series-input/get-pattern-type-filter'
+export { useSearchBasedLivePreviewContent, DEFAULT_MOCK_CHART_CONTENT } from './components/live-preview-chart'
+
 export type { SearchInsightURLValues } from './utils/search-insight-url-parsers/search-insight-url-parsers'
+export type { CreateInsightFormFields, EditableDataSeries, InsightStep } from './types'

--- a/client/web/src/enterprise/insights/pages/landing/getting-started/components/dynamic-code-insight-example/DynamicCodeInsightExample.tsx
+++ b/client/web/src/enterprise/insights/pages/landing/getting-started/components/dynamic-code-insight-example/DynamicCodeInsightExample.tsx
@@ -7,21 +7,19 @@ import { noop } from 'rxjs'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Button, Card, Link, useObservable, useDebounce, Icon, Input } from '@sourcegraph/wildcard'
 
-import * as View from '../../../../../../../views'
 import { getDefaultInputProps } from '../../../../../components/form/getDefaultInputProps'
 import { useField } from '../../../../../components/form/hooks/useField'
 import { useForm } from '../../../../../components/form/hooks/useForm'
 import { InsightQueryInput } from '../../../../../components/form/query-input/InsightQueryInput'
 import { RepositoriesField } from '../../../../../components/form/repositories-field/RepositoriesField'
 import { CodeInsightsBackendContext } from '../../../../../core/backend/code-insights-backend-context'
-import { useCodeInsightViewPings, CodeInsightTrackType } from '../../../../../pings'
-import { DATA_SERIES_COLORS, EditableDataSeries } from '../../../../insights/creation/search-insight'
-import { getQueryPatternTypeFilter } from '../../../../insights/creation/search-insight/components/form-series-input/get-pattern-type-filter'
-import { SearchInsightLivePreview } from '../../../../insights/creation/search-insight/components/live-preview-chart/SearchInsightLivePreview'
+import { getQueryPatternTypeFilter } from '../../../../insights/creation/search-insight'
 import {
     repositoriesExistValidator,
     repositoriesFieldValidator,
 } from '../../../../insights/creation/search-insight/components/search-insight-creation-content/validators'
+
+import { DynamicInsightPreview } from './DynamicInsightPreivew/DynamicInsightPreview'
 
 import styles from './DynamicCodeInsightExample.module.scss'
 
@@ -34,17 +32,6 @@ const INITIAL_INSIGHT_VALUES: CodeInsightExampleFormValues = {
     repositories: 'github.com/sourcegraph/sourcegraph',
     query: 'TODO archived:no fork:no',
 }
-
-const createExampleDataSeries = (query: string): EditableDataSeries[] => [
-    {
-        query,
-        valid: true,
-        edit: false,
-        id: '1',
-        name: 'TODOs',
-        stroke: DATA_SERIES_COLORS.ORANGE,
-    },
-]
 
 interface DynamicCodeInsightExampleProps extends TelemetryProps, React.HTMLAttributes<HTMLDivElement> {}
 
@@ -90,11 +77,6 @@ export const DynamicCodeInsightExample: React.FunctionComponent<DynamicCodeInsig
         }
     }, [setRepositoryValue, derivedRepositoryURL])
 
-    const { trackMouseEnter, trackMouseLeave, trackDatumClicks } = useCodeInsightViewPings({
-        telemetryService,
-        insightType: CodeInsightTrackType.InProductLandingPageInsight,
-    })
-
     useEffect(() => {
         if (debouncedQuery !== INITIAL_INSIGHT_VALUES.query) {
             telemetryService.log('InsightsGetStartedPageQueryModification')
@@ -117,27 +99,13 @@ export const DynamicCodeInsightExample: React.FunctionComponent<DynamicCodeInsig
         <Card {...otherProps} className={classNames(styles.wrapper, otherProps.className)}>
             {/* eslint-disable-next-line react/forbid-elements */}
             <form ref={form.ref} noValidate={true} onSubmit={form.handleSubmit} className={styles.chartSection}>
-                <SearchInsightLivePreview
-                    title="In-line TODO statements"
-                    withLivePreviewControls={false}
-                    repositories={repositories.input.value}
-                    series={createExampleDataSeries(query.input.value)}
-                    stepValue="2"
-                    step="months"
+                <DynamicInsightPreview
+                    telemetryService={telemetryService}
                     disabled={!hasValidLivePreview}
-                    isAllReposMode={false}
+                    repositories={repositories.input.value}
+                    query={query.input.value}
                     className={styles.chart}
-                >
-                    {data => (
-                        <View.Content
-                            onMouseEnter={trackMouseEnter}
-                            onMouseLeave={trackMouseLeave}
-                            onDatumLinkClick={trackDatumClicks}
-                            content={[data]}
-                            layout={View.ChartViewContentLayout.ByContentSize}
-                        />
-                    )}
-                </SearchInsightLivePreview>
+                />
 
                 <Input
                     label="Data series search query"

--- a/client/web/src/enterprise/insights/pages/landing/getting-started/components/dynamic-code-insight-example/DynamicInsightPreivew/DynamicInsightPreview.module.scss
+++ b/client/web/src/enterprise/insights/pages/landing/getting-started/components/dynamic-code-insight-example/DynamicInsightPreivew/DynamicInsightPreview.module.scss
@@ -1,0 +1,32 @@
+.insight-card {
+    min-height: 20rem;
+}
+
+.chart-block {
+    flex: 1;
+    position: relative;
+}
+
+.chart-with-mock {
+    filter: blur(4px);
+    pointer-events: none;
+    opacity: 0.4;
+
+    // In order to turn off any interactions with chart like
+    // tooltip or chart shutter for user cursor we have to
+    // override pointer events. Since visx charts add pointer events
+    // by html attribute we have to use important statement.
+    :global(.visx-group) {
+        pointer-events: none !important;
+    }
+}
+
+.disable-banner {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    padding: 1rem 2rem;
+    text-align: center;
+}

--- a/client/web/src/enterprise/insights/pages/landing/getting-started/components/dynamic-code-insight-example/DynamicInsightPreivew/DynamicInsightPreview.tsx
+++ b/client/web/src/enterprise/insights/pages/landing/getting-started/components/dynamic-code-insight-example/DynamicInsightPreivew/DynamicInsightPreview.tsx
@@ -1,0 +1,112 @@
+import React from 'react'
+
+import classNames from 'classnames'
+
+import { ErrorAlert } from '@sourcegraph/branded/src/components/alerts'
+import { isErrorLike } from '@sourcegraph/common'
+import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
+import { useDeepMemo } from '@sourcegraph/wildcard'
+
+import { LegendItem, LegendList, ParentSize } from '../../../../../../../../charts'
+import { getSanitizedRepositories } from '../../../../../../components/creation-ui-kit'
+import {
+    InsightCard,
+    InsightCardHeader,
+    InsightCardBanner,
+    InsightCardLoading,
+    SeriesBasedChartTypes,
+    SeriesChart,
+} from '../../../../../../components/views'
+import { CodeInsightTrackType, useCodeInsightViewPings } from '../../../../../../pings'
+import {
+    DATA_SERIES_COLORS,
+    DEFAULT_MOCK_CHART_CONTENT,
+    EditableDataSeries,
+    useSearchBasedLivePreviewContent,
+} from '../../../../../insights/creation/search-insight'
+
+import styles from './DynamicInsightPreview.module.scss'
+
+const createExampleDataSeries = (query: string): EditableDataSeries[] => [
+    {
+        query,
+        valid: true,
+        edit: false,
+        id: '1',
+        name: 'TODOs',
+        stroke: DATA_SERIES_COLORS.ORANGE,
+    },
+]
+
+interface DynamicInsightPreviewProps extends TelemetryProps {
+    disabled: boolean
+    repositories: string
+    query: string
+    className?: string
+}
+
+export const DynamicInsightPreview: React.FunctionComponent<DynamicInsightPreviewProps> = props => {
+    const { disabled, repositories, query, className, telemetryService } = props
+
+    // Compare live insight settings with deep check to avoid unnecessary
+    // search insight content fetching
+    const previewSetting = useDeepMemo({
+        series: createExampleDataSeries(query),
+        repositories: getSanitizedRepositories(repositories),
+        step: { months: 2 },
+        disabled,
+    })
+
+    const { loading, dataOrError } = useSearchBasedLivePreviewContent(previewSetting)
+
+    const { trackMouseEnter, trackMouseLeave, trackDatumClicks } = useCodeInsightViewPings({
+        telemetryService,
+        insightType: CodeInsightTrackType.InProductLandingPageInsight,
+    })
+
+    return (
+        <InsightCard className={classNames(className, styles.insightCard)}>
+            <InsightCardHeader title="In-line TODO statements" />
+            {loading ? (
+                <InsightCardLoading>Loading code insight</InsightCardLoading>
+            ) : isErrorLike(dataOrError) ? (
+                <ErrorAlert error={dataOrError} />
+            ) : (
+                <ParentSize className={styles.chartBlock}>
+                    {parent =>
+                        dataOrError ? (
+                            <SeriesChart
+                                type={SeriesBasedChartTypes.Line}
+                                width={parent.width}
+                                height={parent.height}
+                                {...dataOrError}
+                            />
+                        ) : (
+                            <>
+                                <SeriesChart
+                                    type={SeriesBasedChartTypes.Line}
+                                    width={parent.width}
+                                    height={parent.height}
+                                    className={styles.chartWithMock}
+                                    onMouseEnter={trackMouseEnter}
+                                    onMouseLeave={trackMouseLeave}
+                                    onDatumClick={trackDatumClicks}
+                                    {...DEFAULT_MOCK_CHART_CONTENT}
+                                />
+                                <InsightCardBanner className={styles.disableBanner}>
+                                    The chart preview will be shown here once you have filled out the repositories and
+                                    series fields.
+                                </InsightCardBanner>
+                            </>
+                        )
+                    }
+                </ParentSize>
+            )}
+            {dataOrError && !isErrorLike(dataOrError) && (
+                <LegendList className="mt-3">
+                    <LegendItem color={DATA_SERIES_COLORS.ORANGE} name="TODOs" />
+                </LegendList>
+            )}
+        </InsightCard>
+    )
+}

--- a/client/web/src/integration/insights/create-insights.test.ts
+++ b/client/web/src/integration/insights/create-insights.test.ts
@@ -214,7 +214,7 @@ describe('Code insight create insight page', () => {
         })
 
         // With two filled data series our mock for live preview should work - render line chart with two lines
-        await driver.page.waitForSelector('[data-testid="line-chart__content"] svg circle')
+        await driver.page.waitForSelector('[data-testid="code-search-insight-live-preview"] circle')
 
         const addToUserConfigRequest = await testContext.waitForGraphQLRequest(async () => {
             await driver.page.click('[data-testid="insight-save-button"]')

--- a/client/web/src/integration/insights/edit-search-insights.test.ts
+++ b/client/web/src/integration/insights/edit-search-insights.test.ts
@@ -126,7 +126,7 @@ describe('Code insight edit insight page', () => {
         await driver.page.goto(driver.sourcegraphBaseUrl + '/insights/edit/001')
 
         // Waiting for all important part of creation form will be rendered.
-        await driver.page.waitForSelector('[data-testid="line-chart__content"] svg circle')
+        await driver.page.waitForSelector('[name="repositories"]')
 
         // Edit all insight form fields ↓
 

--- a/client/web/src/integration/insights/insights-visual.test.ts
+++ b/client/web/src/integration/insights/insights-visual.test.ts
@@ -47,7 +47,7 @@ describe.skip('[VISUAL] Code insights page', () => {
     afterEachSaveScreenshotIfFailed(() => driver.page)
 
     async function takeChartSnapshot(name: string): Promise<void> {
-        await driver.page.waitForSelector('[data-testid="line-chart__content"] svg circle')
+        await driver.page.waitForSelector('svg circle')
         await delay(500)
         await percySnapshotWithVariants(driver.page, name)
     }


### PR DESCRIPTION
Based on https://github.com/sourcegraph/sourcegraph/pull/33553

1. [Implementation of low level card components and lang stats live preview refactoring](https://github.com/sourcegraph/sourcegraph/pull/33553)
2. This PR

Closes part of https://github.com/sourcegraph/sourcegraph/issues/32944

## Background 

This PR simplifies the live preview card for the search-based insight creation UI and edit UI, also since the in-product landing page uses this component as well in this PR we adjust the dynamic insight card as well. 

The main idea is simple. Prior to this PR, we tried to reuse card components for different cases, creation UI, and dynamic insight on the landing page, Since they are similar but not exactly the same we have a lot of UI props and logic to render/hide some elements within the card.

In this PR we re-implement dynamic insight and live preview cards separately with our low-level-based card components. But we are still reusing data fetch logic and data models as well. 

So the rule I found: if UI is becoming more and more complex it's ok to duplicate implementation in different consumers as long as all consumers rely on low-level abstraction. 

## Test plan
- Make sure that chart live preview logic works properly on the search based creation UI and edit UI
- Make sure that the dynamic insight card works properly on the landing page


## App preview:
- [Link](https://sg-web-vk-refactor-search-based-live.onrender.com)

