### PR TITLE
repo-updater: move vcs/git/tree/ReadTree to gitserver/commands/ReadTree

### DIFF
--- a/cmd/frontend/backend/inventory.go
+++ b/cmd/frontend/backend/inventory.go
@@ -14,6 +14,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/env"
+	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/inventory"
 	"github.com/sourcegraph/sourcegraph/internal/rcache"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
@@ -44,7 +45,7 @@ func InventoryContext(repo api.RepoName, db database.DB, commitID api.CommitID, 
 		ReadTree: func(ctx context.Context, path string) ([]fs.FileInfo, error) {
 			// TODO: As a perf optimization, we could read multiple levels of the Git tree at once
 			// to avoid sequential tree traversal calls.
-			return git.ReadDir(ctx, db, authz.DefaultSubRepoPermsChecker, repo, commitID, path, false)
+			return gitserver.ReadDir(ctx, db, authz.DefaultSubRepoPermsChecker, repo, commitID, path, false)
 		},
 		NewFileReader: func(ctx context.Context, path string) (io.ReadCloser, error) {
 			return git.NewFileReader(ctx, db, repo, commitID, path, authz.DefaultSubRepoPermsChecker)

--- a/cmd/frontend/backend/inventory.go
+++ b/cmd/frontend/backend/inventory.go
@@ -45,7 +45,7 @@ func InventoryContext(repo api.RepoName, db database.DB, commitID api.CommitID, 
 		ReadTree: func(ctx context.Context, path string) ([]fs.FileInfo, error) {
 			// TODO: As a perf optimization, we could read multiple levels of the Git tree at once
 			// to avoid sequential tree traversal calls.
-			return gitserver.ReadDir(ctx, db, authz.DefaultSubRepoPermsChecker, repo, commitID, path, false)
+			return gitserver.NewClient(db).ReadDir(ctx, db, authz.DefaultSubRepoPermsChecker, repo, commitID, path, false)
 		},
 		NewFileReader: func(ctx context.Context, path string) (io.ReadCloser, error) {
 			return git.NewFileReader(ctx, db, repo, commitID, path, authz.DefaultSubRepoPermsChecker)

--- a/cmd/frontend/backend/repos_test.go
+++ b/cmd/frontend/backend/repos_test.go
@@ -157,7 +157,7 @@ func TestReposGetInventory(t *testing.T) {
 		}
 		return &util.FileInfo{Name_: path, Mode_: os.ModeDir, Sys_: gitObjectInfo(wantRootOID)}, nil
 	}
-	git.Mocks.ReadDir = func(commit api.CommitID, name string, recurse bool) ([]fs.FileInfo, error) {
+	gitserver.Mocks.ReadDir = func(commit api.CommitID, name string, recurse bool) ([]fs.FileInfo, error) {
 		if commit != wantCommitID {
 			t.Errorf("got commit %q, want %q", commit, wantCommitID)
 		}
@@ -188,7 +188,10 @@ func TestReposGetInventory(t *testing.T) {
 		}
 		return io.NopCloser(bytes.NewReader(data)), nil
 	}
-	defer git.ResetMocks()
+	defer func() {
+		git.ResetMocks()
+		gitserver.Mocks.ReadDir = nil
+	}()
 
 	tests := []struct {
 		useEnhancedLanguageDetection bool

--- a/cmd/frontend/graphqlbackend/git_tree.go
+++ b/cmd/frontend/graphqlbackend/git_tree.go
@@ -43,7 +43,7 @@ func (r *GitTreeEntryResolver) entries(ctx context.Context, args *gitTreeEntryCo
 	span, ctx := ot.StartSpanFromContext(ctx, "tree.entries")
 	defer span.Finish()
 
-	entries, err := gitserver.ReadDir(
+	entries, err := gitserver.NewClient(r.db).ReadDir(
 		ctx,
 		r.db,
 		authz.DefaultSubRepoPermsChecker,

--- a/cmd/frontend/graphqlbackend/git_tree.go
+++ b/cmd/frontend/graphqlbackend/git_tree.go
@@ -10,8 +10,8 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
+	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
-	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 )
 
 func (r *GitTreeEntryResolver) IsRoot() bool {
@@ -43,7 +43,7 @@ func (r *GitTreeEntryResolver) entries(ctx context.Context, args *gitTreeEntryCo
 	span, ctx := ot.StartSpanFromContext(ctx, "tree.entries")
 	defer span.Finish()
 
-	entries, err := git.ReadDir(
+	entries, err := gitserver.ReadDir(
 		ctx,
 		r.db,
 		authz.DefaultSubRepoPermsChecker,

--- a/cmd/frontend/graphqlbackend/git_tree_entry.go
+++ b/cmd/frontend/graphqlbackend/git_tree_entry.go
@@ -225,7 +225,7 @@ func (r *GitTreeEntryResolver) IsSingleChild(ctx context.Context, args *gitTreeE
 	if r.isSingleChild != nil {
 		return *r.isSingleChild, nil
 	}
-	entries, err := gitserver.ReadDir(
+	entries, err := gitserver.NewClient(r.db).ReadDir(
 		ctx,
 		r.db,
 		authz.DefaultSubRepoPermsChecker,

--- a/cmd/frontend/graphqlbackend/git_tree_entry.go
+++ b/cmd/frontend/graphqlbackend/git_tree_entry.go
@@ -22,6 +22,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/symbols"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
@@ -224,7 +225,7 @@ func (r *GitTreeEntryResolver) IsSingleChild(ctx context.Context, args *gitTreeE
 	if r.isSingleChild != nil {
 		return *r.isSingleChild, nil
 	}
-	entries, err := git.ReadDir(
+	entries, err := gitserver.ReadDir(
 		ctx,
 		r.db,
 		authz.DefaultSubRepoPermsChecker,

--- a/cmd/frontend/graphqlbackend/git_tree_test.go
+++ b/cmd/frontend/graphqlbackend/git_tree_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
@@ -103,7 +104,7 @@ func testGitTree(t *testing.T, db *database.MockDB, tests []*Test) {
 		assert.Equal(t, "foo bar", path)
 		return &util.FileInfo{Name_: path, Mode_: os.ModeDir}, nil
 	}
-	git.Mocks.ReadDir = func(commit api.CommitID, name string, recurse bool) ([]fs.FileInfo, error) {
+	gitserver.Mocks.ReadDir = func(commit api.CommitID, name string, recurse bool) ([]fs.FileInfo, error) {
 		assert.Equal(t, api.CommitID(exampleCommitSHA1), commit)
 		assert.Equal(t, "foo bar", name)
 		assert.False(t, recurse)

--- a/cmd/frontend/graphqlbackend/search_results_stats_languages_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_stats_languages_test.go
@@ -112,7 +112,7 @@ func TestSearchResultsStatsLanguages(t *testing.T) {
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			git.Mocks.ReadDir = func(commit api.CommitID, name string, recurse bool) ([]fs.FileInfo, error) {
+			gitserver.Mocks.ReadDir = func(commit api.CommitID, name string, recurse bool) ([]fs.FileInfo, error) {
 				return test.getFiles, nil
 			}
 

--- a/cmd/frontend/internal/app/ui/raw.go
+++ b/cmd/frontend/internal/app/ui/raw.go
@@ -91,8 +91,9 @@ func serveRaw(db database.DB) handlerFunc {
 			requestedPath = "/" + requestedPath
 		}
 
+		client := gitserver.NewClient(db)
 		if requestedPath == "/" && r.Method == "HEAD" {
-			_, err = gitserver.NewClient(db).RepoInfo(r.Context(), common.Repo.Name)
+			_, err = client.RepoInfo(r.Context(), common.Repo.Name)
 			if err != nil {
 				w.WriteHeader(http.StatusNotFound)
 				return err
@@ -246,7 +247,7 @@ func serveRaw(db database.DB) handlerFunc {
 
 			if fi.IsDir() {
 				requestType = "dir"
-				infos, err := gitserver.ReadDir(r.Context(), db, authz.DefaultSubRepoPermsChecker, common.Repo.Name, common.CommitID, requestedPath, false)
+				infos, err := client.ReadDir(r.Context(), db, authz.DefaultSubRepoPermsChecker, common.Repo.Name, common.CommitID, requestedPath, false)
 				if err != nil {
 					return err
 				}

--- a/cmd/frontend/internal/app/ui/raw.go
+++ b/cmd/frontend/internal/app/ui/raw.go
@@ -246,7 +246,7 @@ func serveRaw(db database.DB) handlerFunc {
 
 			if fi.IsDir() {
 				requestType = "dir"
-				infos, err := git.ReadDir(r.Context(), db, authz.DefaultSubRepoPermsChecker, common.Repo.Name, common.CommitID, requestedPath, false)
+				infos, err := gitserver.ReadDir(r.Context(), db, authz.DefaultSubRepoPermsChecker, common.Repo.Name, common.CommitID, requestedPath, false)
 				if err != nil {
 					return err
 				}

--- a/cmd/frontend/internal/app/ui/raw_test.go
+++ b/cmd/frontend/internal/app/ui/raw_test.go
@@ -277,7 +277,7 @@ func Test_serveRawWithContentTypePlain(t *testing.T) {
 			return &util.FileInfo{Mode_: os.ModeDir}, nil
 		}
 
-		git.Mocks.ReadDir = func(commit api.CommitID, name string, recurse bool) ([]fs.FileInfo, error) {
+		gitserver.Mocks.ReadDir = func(commit api.CommitID, name string, recurse bool) ([]fs.FileInfo, error) {
 			return []fs.FileInfo{
 				&util.FileInfo{Name_: "test/a", Mode_: os.ModeDir},
 				&util.FileInfo{Name_: "test/b", Mode_: os.ModeDir},

--- a/internal/gitserver/client.go
+++ b/internal/gitserver/client.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"io/fs"
 	"net/http"
 	"net/url"
 	"os"
@@ -250,6 +251,9 @@ type Client interface {
 	// DiffPath returns a position-ordered slice of changes (additions or deletions)
 	// of the given path between the given source and target commits.
 	DiffPath(ctx context.Context, repo api.RepoName, sourceCommit, targetCommit, path string, checker authz.SubRepoPermissionChecker) ([]*diff.Hunk, error)
+
+	// ReadDir reads the contents of the named directory at commit.
+	ReadDir(ctx context.Context, db database.DB, checker authz.SubRepoPermissionChecker, repo api.RepoName, commit api.CommitID, path string, recurse bool) ([]fs.FileInfo, error)
 }
 
 func (c *ClientImplementor) Addrs() []string {

--- a/internal/gitserver/commands.go
+++ b/internal/gitserver/commands.go
@@ -330,7 +330,7 @@ func (c *ClientImplementor) DiffSymbols(ctx context.Context, repo api.RepoName, 
 }
 
 // ReadDir reads the contents of the named directory at commit.
-func ReadDir(
+func (c *ClientImplementor) ReadDir(
 	ctx context.Context,
 	db database.DB,
 	checker authz.SubRepoPermissionChecker,

--- a/internal/gitserver/commands.go
+++ b/internal/gitserver/commands.go
@@ -3,16 +3,27 @@ package gitserver
 import (
 	"bytes"
 	"context"
+	"encoding/hex"
 	"fmt"
 	"io"
+	"io/fs"
 	"net/mail"
 	"os"
+	stdlibpath "path"
+	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
+	"gopkg.in/src-d/go-git.v4/plumbing/format/config"
+
+	"github.com/golang/groupcache/lru"
 	"github.com/opentracing/opentracing-go/log"
+
 	"github.com/sourcegraph/go-diff/diff"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/vcs/util"
 
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/api"
@@ -316,4 +327,305 @@ func (c *ClientImplementor) DiffSymbols(ctx context.Context, repo api.RepoName, 
 	command := c.Command("git", "diff", "-z", "--name-status", "--no-renames", string(commitA), string(commitB))
 	command.Repo = repo
 	return command.Output(ctx)
+}
+
+// ReadDir reads the contents of the named directory at commit.
+func ReadDir(
+	ctx context.Context,
+	db database.DB,
+	checker authz.SubRepoPermissionChecker,
+	repo api.RepoName,
+	commit api.CommitID,
+	path string,
+	recurse bool,
+) ([]fs.FileInfo, error) {
+	if Mocks.ReadDir != nil {
+		return Mocks.ReadDir(commit, path, recurse)
+	}
+
+	span, ctx := ot.StartSpanFromContext(ctx, "Git: ReadDir")
+	span.SetTag("Commit", commit)
+	span.SetTag("Path", path)
+	span.SetTag("Recurse", recurse)
+	defer span.Finish()
+
+	if err := checkSpecArgSafety(string(commit)); err != nil {
+		return nil, err
+	}
+
+	if path != "" {
+		// Trailing slash is necessary to ls-tree under the dir (not just
+		// to list the dir's tree entry in its parent dir).
+		path = filepath.Clean(util.Rel(path)) + "/"
+	}
+	files, err := lsTree(ctx, db, repo, commit, path, recurse)
+
+	if err != nil || !authz.SubRepoEnabled(checker) {
+		return files, err
+	}
+
+	a := actor.FromContext(ctx)
+	filtered, filteringErr := authz.FilterActorFileInfos(ctx, checker, a, repo, files)
+	if filteringErr != nil {
+		return nil, errors.Wrap(err, "filtering paths")
+	} else {
+		return filtered, nil
+	}
+}
+
+// lsTreeRootCache caches the result of running `git ls-tree ...` on a repository's root path
+// (because non-root paths are likely to have a lower cache hit rate). It is intended to improve the
+// perceived performance of large monorepos, where the tree for a given repo+commit (usually the
+// repo's latest commit on default branch) will be requested frequently and would take multiple
+// seconds to compute if uncached.
+var (
+	lsTreeRootCacheMu sync.Mutex
+	lsTreeRootCache   = lru.New(5)
+)
+
+// lsTree returns ls of tree at path.
+func lsTree(
+	ctx context.Context,
+	db database.DB,
+	repo api.RepoName,
+	commit api.CommitID,
+	path string,
+	recurse bool,
+) (files []fs.FileInfo, err error) {
+	if path != "" || !recurse {
+		// Only cache the root recursive ls-tree.
+		return lsTreeUncached(ctx, db, repo, commit, path, recurse)
+	}
+
+	key := string(repo) + ":" + string(commit) + ":" + path
+	lsTreeRootCacheMu.Lock()
+	v, ok := lsTreeRootCache.Get(key)
+	lsTreeRootCacheMu.Unlock()
+	var entries []fs.FileInfo
+	if ok {
+		// Cache hit.
+		entries = v.([]fs.FileInfo)
+	} else {
+		// Cache miss.
+		var err error
+		start := time.Now()
+		entries, err = lsTreeUncached(ctx, db, repo, commit, path, recurse)
+		if err != nil {
+			return nil, err
+		}
+
+		// It's only worthwhile to cache if the operation took a while and returned a lot of
+		// data. This is a heuristic.
+		if time.Since(start) > 500*time.Millisecond && len(entries) > 5000 {
+			lsTreeRootCacheMu.Lock()
+			lsTreeRootCache.Add(key, entries)
+			lsTreeRootCacheMu.Unlock()
+		}
+	}
+	return entries, nil
+}
+
+type objectInfo gitdomain.OID
+
+func (oid objectInfo) OID() gitdomain.OID { return gitdomain.OID(oid) }
+
+// LStat returns a FileInfo describing the named file at commit. If the file is a symbolic link, the
+// returned FileInfo describes the symbolic link.  lStat makes no attempt to follow the link.
+// TODO(sashaostrikov): make private when git.Stat is moved here as well
+func LStat(ctx context.Context, db database.DB, checker authz.SubRepoPermissionChecker, repo api.RepoName, commit api.CommitID, path string) (fs.FileInfo, error) {
+	span, ctx := ot.StartSpanFromContext(ctx, "Git: lStat")
+	span.SetTag("Commit", commit)
+	span.SetTag("Path", path)
+	defer span.Finish()
+
+	if err := checkSpecArgSafety(string(commit)); err != nil {
+		return nil, err
+	}
+
+	path = filepath.Clean(util.Rel(path))
+
+	if path == "." {
+		// Special case root, which is not returned by `git ls-tree`.
+		obj, err := NewClient(db).GetObject(ctx, repo, string(commit)+"^{tree}")
+		if err != nil {
+			return nil, err
+		}
+		return &util.FileInfo{Mode_: os.ModeDir, Sys_: objectInfo(obj.ID)}, nil
+	}
+
+	fis, err := lsTree(ctx, db, repo, commit, path, false)
+	if err != nil {
+		return nil, err
+	}
+	if len(fis) == 0 {
+		return nil, &os.PathError{Op: "ls-tree", Path: path, Err: os.ErrNotExist}
+	}
+
+	if !authz.SubRepoEnabled(checker) {
+		return fis[0], nil
+	}
+	// Applying sub-repo permissions
+	a := actor.FromContext(ctx)
+	include, filteringErr := authz.FilterActorFileInfo(ctx, checker, a, repo, fis[0])
+	if include && filteringErr == nil {
+		return fis[0], nil
+	} else {
+		if filteringErr != nil {
+			err = errors.Wrap(err, "filtering paths")
+		} else {
+			err = &os.PathError{Op: "ls-tree", Path: path, Err: os.ErrNotExist}
+		}
+		return nil, err
+	}
+}
+
+func lsTreeUncached(ctx context.Context, db database.DB, repo api.RepoName, commit api.CommitID, path string, recurse bool) ([]fs.FileInfo, error) {
+	if err := gitdomain.EnsureAbsoluteCommit(commit); err != nil {
+		return nil, err
+	}
+
+	// Don't call filepath.Clean(path) because ReadDir needs to pass
+	// path with a trailing slash.
+
+	if err := checkSpecArgSafety(path); err != nil {
+		return nil, err
+	}
+
+	args := []string{
+		"ls-tree",
+		"--long", // show size
+		"--full-name",
+		"-z",
+		string(commit),
+	}
+	if recurse {
+		args = append(args, "-r", "-t")
+	}
+	if path != "" {
+		args = append(args, "--", filepath.ToSlash(path))
+	}
+	cmd := NewClient(db).Command("git", args...)
+	cmd.Repo = repo
+	out, err := cmd.CombinedOutput(ctx)
+	if err != nil {
+		if bytes.Contains(out, []byte("exists on disk, but not in")) {
+			return nil, &os.PathError{Op: "ls-tree", Path: filepath.ToSlash(path), Err: os.ErrNotExist}
+		}
+		return nil, errors.WithMessage(err, fmt.Sprintf("git command %v failed (output: %q)", cmd.Args, out))
+	}
+
+	if len(out) == 0 {
+		// If we are listing the empty root tree, we will have no output.
+		if stdlibpath.Clean(path) == "." {
+			return []fs.FileInfo{}, nil
+		}
+		return nil, &os.PathError{Op: "git ls-tree", Path: path, Err: os.ErrNotExist}
+	}
+
+	trimPath := strings.TrimPrefix(path, "./")
+	lines := strings.Split(string(out), "\x00")
+	fis := make([]fs.FileInfo, len(lines)-1)
+	for i, line := range lines {
+		if i == len(lines)-1 {
+			// last entry is empty
+			continue
+		}
+
+		tabPos := strings.IndexByte(line, '\t')
+		if tabPos == -1 {
+			return nil, errors.Errorf("invalid `git ls-tree` output: %q", out)
+		}
+		info := strings.SplitN(line[:tabPos], " ", 4)
+		name := line[tabPos+1:]
+		if len(name) < len(trimPath) {
+			// This is in a submodule; return the original path to avoid a slice out of bounds panic
+			// when setting the FileInfo._Name below.
+			name = trimPath
+		}
+
+		if len(info) != 4 {
+			return nil, errors.Errorf("invalid `git ls-tree` output: %q", out)
+		}
+		typ := info[1]
+		sha := info[2]
+		if !gitdomain.IsAbsoluteRevision(sha) {
+			return nil, errors.Errorf("invalid `git ls-tree` SHA output: %q", sha)
+		}
+		oid, err := decodeOID(sha)
+		if err != nil {
+			return nil, err
+		}
+
+		sizeStr := strings.TrimSpace(info[3])
+		var size int64
+		if sizeStr != "-" {
+			// Size of "-" indicates a dir or submodule.
+			size, err = strconv.ParseInt(sizeStr, 10, 64)
+			if err != nil || size < 0 {
+				return nil, errors.Errorf("invalid `git ls-tree` size output: %q (error: %s)", sizeStr, err)
+			}
+		}
+
+		var sys interface{}
+		modeVal, err := strconv.ParseInt(info[0], 8, 32)
+		if err != nil {
+			return nil, err
+		}
+		mode := os.FileMode(modeVal)
+		switch typ {
+		case "blob":
+			const gitModeSymlink = 020000
+			if mode&gitModeSymlink != 0 {
+				mode = os.ModeSymlink
+			} else {
+				// Regular file.
+				mode = mode | 0644
+			}
+		case "commit":
+			mode = mode | gitdomain.ModeSubmodule
+			cmd := NewClient(db).Command("git", "show", fmt.Sprintf("%s:.gitmodules", commit))
+			cmd.Repo = repo
+			var submodule gitdomain.Submodule
+			if out, err := cmd.Output(ctx); err == nil {
+
+				var cfg config.Config
+				err := config.NewDecoder(bytes.NewBuffer(out)).Decode(&cfg)
+				if err != nil {
+					return nil, errors.Errorf("error parsing .gitmodules: %s", err)
+				}
+
+				submodule.Path = cfg.Section("submodule").Subsection(name).Option("path")
+				submodule.URL = cfg.Section("submodule").Subsection(name).Option("url")
+			}
+			submodule.CommitID = api.CommitID(oid.String())
+			sys = submodule
+		case "tree":
+			mode = mode | os.ModeDir
+		}
+
+		if sys == nil {
+			// Some callers might find it useful to know the object's OID.
+			sys = objectInfo(oid)
+		}
+
+		fis[i] = &util.FileInfo{
+			Name_: name, // full path relative to root (not just basename)
+			Mode_: mode,
+			Size_: size,
+			Sys_:  sys,
+		}
+	}
+	util.SortFileInfosByName(fis)
+
+	return fis, nil
+}
+
+func decodeOID(sha string) (gitdomain.OID, error) {
+	oidBytes, err := hex.DecodeString(sha)
+	if err != nil {
+		return gitdomain.OID{}, err
+	}
+	var oid gitdomain.OID
+	copy(oid[:], oidBytes)
+	return oid, nil
 }

--- a/internal/gitserver/gitdomain/common.go
+++ b/internal/gitserver/gitdomain/common.go
@@ -3,10 +3,12 @@ package gitdomain
 import (
 	"encoding/hex"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 // OID is a Git OID (40-char hex-encoded).
@@ -24,6 +26,33 @@ const (
 	ObjectTypeTree   ObjectType = "tree"
 	ObjectTypeBlob   ObjectType = "blob"
 )
+
+// ModeSubmodule is an os.FileMode mask indicating that the file is a Git submodule.
+//
+// To avoid being reported as a regular file mode by (os.FileMode).IsRegular, it sets other bits
+// (os.ModeDevice) beyond the Git "160000" commit mode bits. The choice of os.ModeDevice is
+// arbitrary.
+const ModeSubmodule = 0160000 | os.ModeDevice
+
+// Submodule holds information about a Git submodule and is
+// returned in the FileInfo's Sys field by Stat/ReadDir calls.
+type Submodule struct {
+	// URL is the submodule repository clone URL.
+	URL string
+
+	// Path is the path of the submodule relative to the repository root.
+	Path string
+
+	// CommitID is the pinned commit ID of the submodule (in the
+	// submodule repository's commit ID space).
+	CommitID api.CommitID
+}
+
+// ObjectInfo holds information about a Git object and is returned in (fs.FileInfo).Sys for blobs
+// and trees from Stat/ReadDir calls.
+type ObjectInfo interface {
+	OID() OID
+}
 
 // GitObject represents a GitObject
 type GitObject struct {
@@ -47,6 +76,16 @@ func IsAbsoluteRevision(s string) bool {
 		}
 	}
 	return true
+}
+
+func EnsureAbsoluteCommit(commitID api.CommitID) error {
+	// We don't want to even be running commands on non-absolute
+	// commit IDs if we can avoid it, because we can't cache the
+	// expensive part of those computations.
+	if !IsAbsoluteRevision(string(commitID)) {
+		return errors.Errorf("non-absolute commit ID: %q", commitID)
+	}
+	return nil
 }
 
 // Commit represents a git commit

--- a/internal/gitserver/mocks.go
+++ b/internal/gitserver/mocks.go
@@ -1,6 +1,11 @@
 package gitserver
 
-import "io"
+import (
+	"io"
+	"io/fs"
+
+	"github.com/sourcegraph/sourcegraph/internal/api"
+)
 
 // Mocks is used to mock behavior in tests. Tests must call ResetMocks() when finished to ensure its
 // mocks are not (inadvertently) used by subsequent tests.
@@ -13,6 +18,7 @@ import "io"
 // package instead.
 var Mocks, emptyMocks struct {
 	ExecReader func(args []string) (reader io.ReadCloser, err error)
+	ReadDir    func(commit api.CommitID, name string, recurse bool) ([]fs.FileInfo, error)
 }
 
 // ResetMocks clears the mock functions set on Mocks (so that subsequent tests don't inadvertently

--- a/internal/vcs/git/blob.go
+++ b/internal/vcs/git/blob.go
@@ -12,6 +12,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
+	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/util"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
@@ -102,7 +103,7 @@ type blobReader struct {
 }
 
 func newBlobReader(ctx context.Context, db database.DB, repo api.RepoName, commit api.CommitID, name string) (*blobReader, error) {
-	if err := ensureAbsoluteCommit(commit); err != nil {
+	if err := gitdomain.EnsureAbsoluteCommit(commit); err != nil {
 		return nil, err
 	}
 

--- a/internal/vcs/git/file_info.go
+++ b/internal/vcs/git/file_info.go
@@ -33,7 +33,3 @@ type Submodule struct {
 type ObjectInfo interface {
 	OID() gitdomain.OID
 }
-
-type objectInfo gitdomain.OID
-
-func (oid objectInfo) OID() gitdomain.OID { return gitdomain.OID(oid) }

--- a/internal/vcs/git/mocks.go
+++ b/internal/vcs/git/mocks.go
@@ -18,7 +18,6 @@ var Mocks, emptyMocks struct {
 	ExecReader            func(args []string) (reader io.ReadCloser, err error)
 	NewFileReader         func(commit api.CommitID, name string) (io.ReadCloser, error)
 	ReadFile              func(commit api.CommitID, name string) ([]byte, error)
-	ReadDir               func(commit api.CommitID, name string, recurse bool) ([]fs.FileInfo, error)
 	LsFiles               func(repo api.RepoName, commit api.CommitID) ([]string, error)
 	ResolveRevision       func(spec string, opt ResolveRevisionOptions) (api.CommitID, error)
 	Stat                  func(commit api.CommitID, name string) (fs.FileInfo, error)

--- a/internal/vcs/git/revisions.go
+++ b/internal/vcs/git/revisions.go
@@ -34,16 +34,6 @@ func IsAbsoluteRevision(s string) bool {
 	return true
 }
 
-func ensureAbsoluteCommit(commitID api.CommitID) error {
-	// We don't want to even be running commands on non-absolute
-	// commit IDs if we can avoid it, because we can't cache the
-	// expensive part of those computations.
-	if !IsAbsoluteRevision(string(commitID)) {
-		return errors.Errorf("non-absolute commit ID: %q", commitID)
-	}
-	return nil
-}
-
 // ResolveRevisionOptions configure how we resolve revisions.
 // The zero value should contain appropriate default values.
 type ResolveRevisionOptions struct {

--- a/internal/vcs/git/tree.go
+++ b/internal/vcs/git/tree.go
@@ -1,30 +1,19 @@
 package git
 
 import (
-	"bytes"
 	"context"
-	"encoding/hex"
 	"fmt"
 	"io/fs"
-	"os"
-	stdlibpath "path"
-	"path/filepath"
 	"sort"
-	"strconv"
 	"strings"
-	"sync"
-	"time"
 
-	"github.com/golang/groupcache/lru"
 	"github.com/grafana/regexp"
-	"gopkg.in/src-d/go-git.v4/plumbing/format/config"
 
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
-	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/util"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
@@ -47,56 +36,12 @@ func Stat(ctx context.Context, db database.DB, checker authz.SubRepoPermissionCh
 
 	path = util.Rel(path)
 
-	fi, err := lStat(ctx, db, checker, repo, commit, path)
+	fi, err := gitserver.LStat(ctx, db, checker, repo, commit, path)
 	if err != nil {
 		return nil, err
 	}
 
 	return fi, nil
-}
-
-// ReadDir reads the contents of the named directory at commit.
-func ReadDir(
-	ctx context.Context,
-	db database.DB,
-	checker authz.SubRepoPermissionChecker,
-	repo api.RepoName,
-	commit api.CommitID,
-	path string,
-	recurse bool,
-) ([]fs.FileInfo, error) {
-	if Mocks.ReadDir != nil {
-		return Mocks.ReadDir(commit, path, recurse)
-	}
-
-	span, ctx := ot.StartSpanFromContext(ctx, "Git: ReadDir")
-	span.SetTag("Commit", commit)
-	span.SetTag("Path", path)
-	span.SetTag("Recurse", recurse)
-	defer span.Finish()
-
-	if err := checkSpecArgSafety(string(commit)); err != nil {
-		return nil, err
-	}
-
-	if path != "" {
-		// Trailing slash is necessary to ls-tree under the dir (not just
-		// to list the dir's tree entry in its parent dir).
-		path = filepath.Clean(util.Rel(path)) + "/"
-	}
-	files, err := lsTree(ctx, db, repo, commit, path, recurse)
-
-	if err != nil || !authz.SubRepoEnabled(checker) {
-		return files, err
-	}
-
-	a := actor.FromContext(ctx)
-	filtered, filteringErr := authz.FilterActorFileInfos(ctx, checker, a, repo, files)
-	if filteringErr != nil {
-		return nil, errors.Wrap(err, "filtering paths")
-	} else {
-		return filtered, nil
-	}
 }
 
 // LsFiles returns the output of `git ls-files`
@@ -131,248 +76,6 @@ func LsFiles(ctx context.Context, db database.DB, checker authz.SubRepoPermissio
 		files = files[:len(files)-1]
 	}
 	return filterPaths(ctx, repo, checker, files)
-}
-
-// lStat returns a FileInfo describing the named file at commit. If the file is a symbolic link, the
-// returned FileInfo describes the symbolic link.  lStat makes no attempt to follow the link.
-func lStat(ctx context.Context, db database.DB, checker authz.SubRepoPermissionChecker, repo api.RepoName, commit api.CommitID, path string) (fs.FileInfo, error) {
-	span, ctx := ot.StartSpanFromContext(ctx, "Git: lStat")
-	span.SetTag("Commit", commit)
-	span.SetTag("Path", path)
-	defer span.Finish()
-
-	if err := checkSpecArgSafety(string(commit)); err != nil {
-		return nil, err
-	}
-
-	path = filepath.Clean(util.Rel(path))
-
-	if path == "." {
-		// Special case root, which is not returned by `git ls-tree`.
-		obj, err := gitserver.NewClient(db).GetObject(ctx, repo, string(commit)+"^{tree}")
-		if err != nil {
-			return nil, err
-		}
-		return &util.FileInfo{Mode_: os.ModeDir, Sys_: objectInfo(obj.ID)}, nil
-	}
-
-	fis, err := lsTree(ctx, db, repo, commit, path, false)
-	if err != nil {
-		return nil, err
-	}
-	if len(fis) == 0 {
-		return nil, &os.PathError{Op: "ls-tree", Path: path, Err: os.ErrNotExist}
-	}
-
-	if !authz.SubRepoEnabled(checker) {
-		return fis[0], nil
-	}
-	// Applying sub-repo permissions
-	a := actor.FromContext(ctx)
-	include, filteringErr := authz.FilterActorFileInfo(ctx, checker, a, repo, fis[0])
-	if include && filteringErr == nil {
-		return fis[0], nil
-	} else {
-		if filteringErr != nil {
-			err = errors.Wrap(err, "filtering paths")
-		} else {
-			err = &os.PathError{Op: "ls-tree", Path: path, Err: os.ErrNotExist}
-		}
-		return nil, err
-	}
-}
-
-// lsTreeRootCache caches the result of running `git ls-tree ...` on a repository's root path
-// (because non-root paths are likely to have a lower cache hit rate). It is intended to improve the
-// perceived performance of large monorepos, where the tree for a given repo+commit (usually the
-// repo's latest commit on default branch) will be requested frequently and would take multiple
-// seconds to compute if uncached.
-var (
-	lsTreeRootCacheMu sync.Mutex
-	lsTreeRootCache   = lru.New(5)
-)
-
-// lsTree returns ls of tree at path.
-func lsTree(
-	ctx context.Context,
-	db database.DB,
-	repo api.RepoName,
-	commit api.CommitID,
-	path string,
-	recurse bool,
-) (files []fs.FileInfo, err error) {
-	if path != "" || !recurse {
-		// Only cache the root recursive ls-tree.
-		return lsTreeUncached(ctx, db, repo, commit, path, recurse)
-	}
-
-	key := string(repo) + ":" + string(commit) + ":" + path
-	lsTreeRootCacheMu.Lock()
-	v, ok := lsTreeRootCache.Get(key)
-	lsTreeRootCacheMu.Unlock()
-	var entries []fs.FileInfo
-	if ok {
-		// Cache hit.
-		entries = v.([]fs.FileInfo)
-	} else {
-		// Cache miss.
-		var err error
-		start := time.Now()
-		entries, err = lsTreeUncached(ctx, db, repo, commit, path, recurse)
-		if err != nil {
-			return nil, err
-		}
-
-		// It's only worthwhile to cache if the operation took a while and returned a lot of
-		// data. This is a heuristic.
-		if time.Since(start) > 500*time.Millisecond && len(entries) > 5000 {
-			lsTreeRootCacheMu.Lock()
-			lsTreeRootCache.Add(key, entries)
-			lsTreeRootCacheMu.Unlock()
-		}
-	}
-	return entries, nil
-}
-
-func lsTreeUncached(ctx context.Context, db database.DB, repo api.RepoName, commit api.CommitID, path string, recurse bool) ([]fs.FileInfo, error) {
-	if err := ensureAbsoluteCommit(commit); err != nil {
-		return nil, err
-	}
-
-	// Don't call filepath.Clean(path) because ReadDir needs to pass
-	// path with a trailing slash.
-
-	if err := checkSpecArgSafety(path); err != nil {
-		return nil, err
-	}
-
-	args := []string{
-		"ls-tree",
-		"--long", // show size
-		"--full-name",
-		"-z",
-		string(commit),
-	}
-	if recurse {
-		args = append(args, "-r", "-t")
-	}
-	if path != "" {
-		args = append(args, "--", filepath.ToSlash(path))
-	}
-	cmd := gitserver.NewClient(db).Command("git", args...)
-	cmd.Repo = repo
-	out, err := cmd.CombinedOutput(ctx)
-	if err != nil {
-		if bytes.Contains(out, []byte("exists on disk, but not in")) {
-			return nil, &os.PathError{Op: "ls-tree", Path: filepath.ToSlash(path), Err: os.ErrNotExist}
-		}
-		return nil, errors.WithMessage(err, fmt.Sprintf("git command %v failed (output: %q)", cmd.Args, out))
-	}
-
-	if len(out) == 0 {
-		// If we are listing the empty root tree, we will have no output.
-		if stdlibpath.Clean(path) == "." {
-			return []fs.FileInfo{}, nil
-		}
-		return nil, &os.PathError{Op: "git ls-tree", Path: path, Err: os.ErrNotExist}
-	}
-
-	trimPath := strings.TrimPrefix(path, "./")
-	lines := strings.Split(string(out), "\x00")
-	fis := make([]fs.FileInfo, len(lines)-1)
-	for i, line := range lines {
-		if i == len(lines)-1 {
-			// last entry is empty
-			continue
-		}
-
-		tabPos := strings.IndexByte(line, '\t')
-		if tabPos == -1 {
-			return nil, errors.Errorf("invalid `git ls-tree` output: %q", out)
-		}
-		info := strings.SplitN(line[:tabPos], " ", 4)
-		name := line[tabPos+1:]
-		if len(name) < len(trimPath) {
-			// This is in a submodule; return the original path to avoid a slice out of bounds panic
-			// when setting the FileInfo._Name below.
-			name = trimPath
-		}
-
-		if len(info) != 4 {
-			return nil, errors.Errorf("invalid `git ls-tree` output: %q", out)
-		}
-		typ := info[1]
-		sha := info[2]
-		if !IsAbsoluteRevision(sha) {
-			return nil, errors.Errorf("invalid `git ls-tree` SHA output: %q", sha)
-		}
-		oid, err := decodeOID(sha)
-		if err != nil {
-			return nil, err
-		}
-
-		sizeStr := strings.TrimSpace(info[3])
-		var size int64
-		if sizeStr != "-" {
-			// Size of "-" indicates a dir or submodule.
-			size, err = strconv.ParseInt(sizeStr, 10, 64)
-			if err != nil || size < 0 {
-				return nil, errors.Errorf("invalid `git ls-tree` size output: %q (error: %s)", sizeStr, err)
-			}
-		}
-
-		var sys interface{}
-		modeVal, err := strconv.ParseInt(info[0], 8, 32)
-		if err != nil {
-			return nil, err
-		}
-		mode := os.FileMode(modeVal)
-		switch typ {
-		case "blob":
-			const gitModeSymlink = 020000
-			if mode&gitModeSymlink != 0 {
-				mode = os.ModeSymlink
-			} else {
-				// Regular file.
-				mode = mode | 0644
-			}
-		case "commit":
-			mode = mode | ModeSubmodule
-			cmd := gitserver.NewClient(db).Command("git", "show", fmt.Sprintf("%s:.gitmodules", commit))
-			cmd.Repo = repo
-			var submodule Submodule
-			if out, err := cmd.Output(ctx); err == nil {
-
-				var cfg config.Config
-				err := config.NewDecoder(bytes.NewBuffer(out)).Decode(&cfg)
-				if err != nil {
-					return nil, errors.Errorf("error parsing .gitmodules: %s", err)
-				}
-
-				submodule.Path = cfg.Section("submodule").Subsection(name).Option("path")
-				submodule.URL = cfg.Section("submodule").Subsection(name).Option("url")
-			}
-			submodule.CommitID = api.CommitID(oid.String())
-			sys = submodule
-		case "tree":
-			mode = mode | os.ModeDir
-		}
-
-		if sys == nil {
-			// Some callers might find it useful to know the object's OID.
-			sys = objectInfo(oid)
-		}
-
-		fis[i] = &util.FileInfo{
-			Name_: name, // full path relative to root (not just basename)
-			Mode_: mode,
-			Size_: size,
-			Sys_:  sys,
-		}
-	}
-	util.SortFileInfosByName(fis)
-
-	return fis, nil
 }
 
 // ListFiles returns a list of root-relative file paths matching the given
@@ -504,13 +207,3 @@ func parseDirectoryChildren(dirnames, paths []string) map[string][]string {
 // tree /dev/null`, which is used as the base when computing the `git diff` of
 // the root commit.
 const DevNullSHA = "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
-
-func decodeOID(sha string) (gitdomain.OID, error) {
-	oidBytes, err := hex.DecodeString(sha)
-	if err != nil {
-		return gitdomain.OID{}, err
-	}
-	var oid gitdomain.OID
-	copy(oid[:], oidBytes)
-	return oid, nil
-}


### PR DESCRIPTION
@ryanslade I think that `commands.go` will get very big, can we probably have the same file structure as it was in `git` package?

## Test plan
Check that tests are green
<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


