### PR TITLE
RFC 619: (M1) Generate policies service skeleton

### DIFF
--- a/cmd/worker/internal/codeintel/policies_repomatcher_job.go
+++ b/cmd/worker/internal/codeintel/policies_repomatcher_job.go
@@ -1,0 +1,28 @@
+package codeintel
+
+import (
+	"context"
+
+	"github.com/sourcegraph/sourcegraph/cmd/worker/job"
+	"github.com/sourcegraph/sourcegraph/internal/codeintel/policies/background/repomatcher"
+	"github.com/sourcegraph/sourcegraph/internal/env"
+	"github.com/sourcegraph/sourcegraph/internal/goroutine"
+)
+
+type policiesRepositoryMatcherJob struct{}
+
+func NewPoliciesRepositoryMatcherJob() job.Job {
+	return &policiesRepositoryMatcherJob{}
+}
+
+func (j *policiesRepositoryMatcherJob) Config() []env.Config {
+	return []env.Config{
+		repomatcher.ConfigInst,
+	}
+}
+
+func (j *policiesRepositoryMatcherJob) Routines(ctx context.Context) ([]goroutine.BackgroundRoutine, error) {
+	return []goroutine.BackgroundRoutine{
+		repomatcher.NewMatcher(),
+	}, nil
+}

--- a/cmd/worker/shared/main.go
+++ b/cmd/worker/shared/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/inconshreveable/log15"
 	"github.com/prometheus/client_golang/prometheus"
 
+	"github.com/sourcegraph/sourcegraph/cmd/worker/internal/codeintel"
 	"github.com/sourcegraph/sourcegraph/cmd/worker/internal/migrations"
 	"github.com/sourcegraph/sourcegraph/cmd/worker/internal/migrations/migrators"
 	"github.com/sourcegraph/sourcegraph/cmd/worker/internal/webhooks"
@@ -39,8 +40,9 @@ func Start(additionalJobs map[string]job.Job, registerEnterpriseMigrations func(
 	registerMigrations := composeRegisterMigrations(migrators.RegisterOSSMigrations, registerEnterpriseMigrations)
 
 	builtins := map[string]job.Job{
-		"webhook-log-janitor":    webhooks.NewJanitor(),
-		"out-of-band-migrations": migrations.NewMigrator(registerMigrations),
+		"webhook-log-janitor":                   webhooks.NewJanitor(),
+		"out-of-band-migrations":                migrations.NewMigrator(registerMigrations),
+		"codeintel-policies-repository-matcher": codeintel.NewPoliciesRepositoryMatcherJob(),
 	}
 
 	jobs := map[string]job.Job{}

--- a/doc/admin/workers.md
+++ b/doc/admin/workers.md
@@ -10,6 +10,10 @@ The following jobs are defined by the `worker` service.
 
 This job runs [out of band migrations](migration.md#mout-of-band-migrations), which perform large data migrations in the background over time instead of synchronously during Sourcegraph instance updates.
 
+#### `codeintel-policies-repository-matcher`
+
+This job periodically updates an index of policy repository patterns to matching repository names.
+
 #### `codeintel-commitgraph`
 
 This job periodically updates the set of precise code intelligence indexes that are visible from each relevant commit for a repository. The commit graph for a repository is marked as stale (to be recalculated) after repository updates and precise code intelligence uploads and updated asynchronously by this job.

--- a/internal/codeintel/policies/background/repomatcher/config.go
+++ b/internal/codeintel/policies/background/repomatcher/config.go
@@ -1,0 +1,19 @@
+package repomatcher
+
+import (
+	"time"
+
+	"github.com/sourcegraph/sourcegraph/internal/env"
+)
+
+type config struct {
+	env.BaseConfig
+
+	Interval time.Duration
+}
+
+var ConfigInst = &config{}
+
+func (c *config) Load() {
+	c.Interval = c.GetInterval("CODEINTEL_POLICIES_REPO_MATCHER_INTERVAL", "1s", "How frequently to run the policies repository matcher routine.")
+}

--- a/internal/codeintel/policies/background/repomatcher/init.go
+++ b/internal/codeintel/policies/background/repomatcher/init.go
@@ -1,0 +1,11 @@
+package repomatcher
+
+import (
+	"context"
+
+	"github.com/sourcegraph/sourcegraph/internal/goroutine"
+)
+
+func NewMatcher() goroutine.BackgroundRoutine {
+	return goroutine.NewPeriodicGoroutine(context.Background(), ConfigInst.Interval, &matcher{})
+}

--- a/internal/codeintel/policies/background/repomatcher/matcher.go
+++ b/internal/codeintel/policies/background/repomatcher/matcher.go
@@ -1,0 +1,20 @@
+package repomatcher
+
+import (
+	"context"
+
+	"github.com/sourcegraph/sourcegraph/internal/goroutine"
+)
+
+type matcher struct{}
+
+var _ goroutine.Handler = &matcher{}
+var _ goroutine.ErrorHandler = &matcher{}
+
+func (r *matcher) Handle(ctx context.Context) error {
+	// To be implemented in https://github.com/sourcegraph/sourcegraph/issues/33376
+	return nil
+}
+
+func (r *matcher) HandleError(err error) {
+}

--- a/internal/codeintel/policies/gen.go
+++ b/internal/codeintel/policies/gen.go
@@ -1,0 +1,3 @@
+package policies
+
+//go:generate ../../../dev/mockgen.sh github.com/sourcegraph/sourcegraph/internal/codeintel/policies -i Store -o mock_iface_test.go

--- a/internal/codeintel/policies/iface.go
+++ b/internal/codeintel/policies/iface.go
@@ -1,0 +1,11 @@
+package policies
+
+import (
+	"context"
+
+	"github.com/sourcegraph/sourcegraph/internal/codeintel/policies/internal/store"
+)
+
+type Store interface {
+	List(ctx context.Context, opts store.ListOpts) ([]Policy, error)
+}

--- a/internal/codeintel/policies/init.go
+++ b/internal/codeintel/policies/init.go
@@ -1,0 +1,46 @@
+package policies
+
+import (
+	"sync"
+
+	"github.com/inconshreveable/log15"
+	"github.com/opentracing/opentracing-go"
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/sourcegraph/sourcegraph/internal/codeintel/policies/internal/store"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
+	"github.com/sourcegraph/sourcegraph/internal/trace"
+)
+
+var (
+	svc     *Service
+	svcOnce sync.Once
+)
+
+// GetService creates or returns an already-initialized policies service. If the service is
+// new, it will use the given database handle.
+func GetService(db database.DB) *Service {
+	svcOnce.Do(func() {
+		observationContext := &observation.Context{
+			Logger:     log15.Root(),
+			Tracer:     &trace.Tracer{Tracer: opentracing.GlobalTracer()},
+			Registerer: prometheus.DefaultRegisterer,
+		}
+
+		svc = newService(
+			store.GetStore(db),
+			observationContext,
+		)
+	})
+
+	return svc
+}
+
+// TestService creates a fresh policies service with the given database handle.
+func TestService(db database.DB) *Service {
+	return newService(
+		store.GetStore(db),
+		&observation.TestContext,
+	)
+}

--- a/internal/codeintel/policies/internal/store/init.go
+++ b/internal/codeintel/policies/internal/store/init.go
@@ -1,0 +1,36 @@
+package store
+
+import (
+	"sync"
+
+	"github.com/inconshreveable/log15"
+	"github.com/opentracing/opentracing-go"
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
+	"github.com/sourcegraph/sourcegraph/internal/trace"
+)
+
+var (
+	store     *Store
+	storeOnce sync.Once
+)
+
+func GetStore(db database.DB) *Store {
+	storeOnce.Do(func() {
+		observationContext := &observation.Context{
+			Logger:     log15.Root(),
+			Tracer:     &trace.Tracer{Tracer: opentracing.GlobalTracer()},
+			Registerer: prometheus.DefaultRegisterer,
+		}
+
+		store = newStore(db, observationContext)
+	})
+
+	return store
+}
+
+func TestStore(db database.DB) *Store {
+	return newStore(db, &observation.TestContext)
+}

--- a/internal/codeintel/policies/internal/store/observability.go
+++ b/internal/codeintel/policies/internal/store/observability.go
@@ -1,0 +1,33 @@
+package store
+
+import (
+	"fmt"
+
+	"github.com/sourcegraph/sourcegraph/internal/metrics"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
+)
+
+type operations struct {
+	list *observation.Operation
+}
+
+func newOperations(observationContext *observation.Context) *operations {
+	metrics := metrics.NewREDMetrics(
+		observationContext.Registerer,
+		"codeintel_policies_store",
+		metrics.WithLabels("op"),
+		metrics.WithCountHelp("Total number of method invocations."),
+	)
+
+	op := func(name string) *observation.Operation {
+		return observationContext.Operation(observation.Op{
+			Name:              fmt.Sprintf("codeintel.policies.store.%s", name),
+			MetricLabelValues: []string{name},
+			Metrics:           metrics,
+		})
+	}
+
+	return &operations{
+		list: op("List"),
+	}
+}

--- a/internal/codeintel/policies/internal/store/scan.go
+++ b/internal/codeintel/policies/internal/store/scan.go
@@ -1,0 +1,29 @@
+package store
+
+import (
+	"database/sql"
+
+	"github.com/sourcegraph/sourcegraph/internal/codeintel/policies/shared"
+	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
+)
+
+func scanPolicies(rows *sql.Rows, queryErr error) (policies []shared.Policy, err error) {
+	if queryErr != nil {
+		return nil, queryErr
+	}
+	defer func() { err = basestore.CloseRows(rows, err) }()
+
+	for rows.Next() {
+		var policy shared.Policy
+
+		if err = rows.Scan(
+			&policy.ID,
+		); err != nil {
+			return nil, err
+		}
+
+		policies = append(policies, policy)
+	}
+
+	return policies, nil
+}

--- a/internal/codeintel/policies/internal/store/store.go
+++ b/internal/codeintel/policies/internal/store/store.go
@@ -1,0 +1,70 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/keegancsmith/sqlf"
+	"github.com/opentracing/opentracing-go/log"
+
+	"github.com/sourcegraph/sourcegraph/internal/codeintel/policies/shared"
+	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+type Store struct {
+	*basestore.Store
+	operations *operations
+}
+
+func newStore(db dbutil.DB, observationContext *observation.Context) *Store {
+	return &Store{
+		Store:      basestore.NewWithDB(db, sql.TxOptions{}),
+		operations: newOperations(observationContext),
+	}
+}
+
+func (s *Store) With(other basestore.ShareableStore) *Store {
+	return &Store{
+		Store:      s.Store.With(other),
+		operations: s.operations,
+	}
+}
+
+func (s *Store) Transact(ctx context.Context) (*Store, error) {
+	txBase, err := s.Store.Transact(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Store{
+		Store:      txBase,
+		operations: s.operations,
+	}, nil
+}
+
+type ListOpts struct {
+	Limit int
+}
+
+func (s *Store) List(ctx context.Context, opts ListOpts) (policies []shared.Policy, err error) {
+	ctx, endObservation := s.operations.list.With(ctx, &err, observation.Args{})
+	defer func() {
+		endObservation(1, observation.Args{LogFields: []log.Field{
+			log.Int("numPolicies", len(policies)),
+		}})
+	}()
+
+	// This is only a stub and will be replaced or significantly modified
+	// in https://github.com/sourcegraph/sourcegraph/issues/33376
+	_, _ = scanPolicies(s.Query(ctx, sqlf.Sprintf(listQuery, opts.Limit)))
+	return nil, errors.Newf("unimplemented: policies.store.List")
+}
+
+const listQuery = `
+-- source: internal/codeintel/policies/store/internal/store.go:List
+SELECT id FROM TODO
+LIMIT %s
+`

--- a/internal/codeintel/policies/observability.go
+++ b/internal/codeintel/policies/observability.go
@@ -1,0 +1,45 @@
+package policies
+
+import (
+	"fmt"
+
+	"github.com/sourcegraph/sourcegraph/internal/metrics"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
+)
+
+type operations struct {
+	commitsMatchingIndexingPolicies  *observation.Operation
+	commitsMatchingRetentionPolicies *observation.Operation
+	create                           *observation.Operation
+	delete                           *observation.Operation
+	get                              *observation.Operation
+	list                             *observation.Operation
+	update                           *observation.Operation
+}
+
+func newOperations(observationContext *observation.Context) *operations {
+	metrics := metrics.NewREDMetrics(
+		observationContext.Registerer,
+		"codeintel_policies",
+		metrics.WithLabels("op"),
+		metrics.WithCountHelp("Total number of method invocations."),
+	)
+
+	op := func(name string) *observation.Operation {
+		return observationContext.Operation(observation.Op{
+			Name:              fmt.Sprintf("codeintel.policies.%s", name),
+			MetricLabelValues: []string{name},
+			Metrics:           metrics,
+		})
+	}
+
+	return &operations{
+		commitsMatchingIndexingPolicies:  op("CommitsMatchingIndexingPolicies"),
+		commitsMatchingRetentionPolicies: op("CommitsMatchingRetentionPolicies"),
+		create:                           op("Create"),
+		delete:                           op("Delete"),
+		get:                              op("Get"),
+		list:                             op("List"),
+		update:                           op("Update"),
+	}
+}

--- a/internal/codeintel/policies/service.go
+++ b/internal/codeintel/policies/service.go
@@ -1,0 +1,84 @@
+package policies
+
+import (
+	"context"
+	"time"
+
+	"github.com/sourcegraph/sourcegraph/internal/codeintel/policies/internal/store"
+	"github.com/sourcegraph/sourcegraph/internal/codeintel/policies/shared"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+type Service struct {
+	policiesStore Store
+	operations    *operations
+}
+
+func newService(policiesStore Store, observationContext *observation.Context) *Service {
+	return &Service{
+		policiesStore: policiesStore,
+		operations:    newOperations(observationContext),
+	}
+}
+
+type Policy = shared.Policy
+
+type ListOpts struct {
+	Limit int
+}
+
+func (s *Service) List(ctx context.Context, opts ListOpts) (policies []Policy, err error) {
+	ctx, endObservation := s.operations.list.With(ctx, &err, observation.Args{})
+	defer endObservation(1, observation.Args{})
+
+	return s.policiesStore.List(ctx, store.ListOpts(opts))
+}
+
+func (s *Service) Get(ctx context.Context, id int) (policy Policy, ok bool, err error) {
+	ctx, endObservation := s.operations.get.With(ctx, &err, observation.Args{})
+	defer endObservation(1, observation.Args{})
+
+	// To be implemented in https://github.com/sourcegraph/sourcegraph/issues/33376
+	return Policy{}, false, errors.Newf("unimplemented: policies.Get")
+}
+
+func (s *Service) Create(ctx context.Context, policy Policy) (hydratedPolicy Policy, err error) {
+	ctx, endObservation := s.operations.create.With(ctx, &err, observation.Args{})
+	defer endObservation(1, observation.Args{})
+
+	// To be implemented in https://github.com/sourcegraph/sourcegraph/issues/33376
+	return Policy{}, errors.Newf("unimplemented: policies.Create")
+}
+
+func (s *Service) Update(ctx context.Context, policy Policy) (hydratedPolicy Policy, err error) {
+	ctx, endObservation := s.operations.update.With(ctx, &err, observation.Args{})
+	defer endObservation(1, observation.Args{})
+
+	// To be implemented in https://github.com/sourcegraph/sourcegraph/issues/33376
+	return Policy{}, errors.Newf("unimplemented: policies.Update")
+}
+
+func (s *Service) Delete(ctx context.Context, id int) (err error) {
+	ctx, endObservation := s.operations.delete.With(ctx, &err, observation.Args{})
+	defer endObservation(1, observation.Args{})
+
+	// To be implemented in https://github.com/sourcegraph/sourcegraph/issues/33376
+	return errors.Newf("unimplemented: policies.Delete")
+}
+
+func (s *Service) CommitsMatchingRetentionPolicies(ctx context.Context, repoID int, policies []Policy, instant time.Time, commitSubset ...string) (commitsToPolicies map[string][]Policy, err error) {
+	ctx, endObservation := s.operations.commitsMatchingRetentionPolicies.With(ctx, &err, observation.Args{})
+	defer endObservation(1, observation.Args{})
+
+	// To be implemented in https://github.com/sourcegraph/sourcegraph/issues/33376
+	return nil, errors.Newf("unimplemented: policies.CommitsMatchingRetentionPolicies")
+}
+
+func (s *Service) CommitsMatchingIndexingPolicies(ctx context.Context, repoID int, policies []Policy, instant time.Time) (commitsToPolicies map[string][]Policy, err error) {
+	ctx, endObservation := s.operations.commitsMatchingIndexingPolicies.With(ctx, &err, observation.Args{})
+	defer endObservation(1, observation.Args{})
+
+	// To be implemented in https://github.com/sourcegraph/sourcegraph/issues/33376
+	return nil, errors.Newf("unimplemented: policies.CommitsMatchingIndexingPolicies")
+}

--- a/internal/codeintel/policies/shared/types.go
+++ b/internal/codeintel/policies/shared/types.go
@@ -1,0 +1,5 @@
+package shared
+
+type Policy struct {
+	ID int
+}


### PR DESCRIPTION
Generate an empty policies service skeleton as defined by [RFC 619: Code Intelligence Data Platform](https://docs.google.com/document/d/1AjZ_d0nJVHbV75IH3jZRkrGXhsv_AXp2kS4nrw2SAQ8).

Partially covers https://github.com/sourcegraph/sourcegraph/issues/33372.
Originally drafted in https://github.com/sourcegraph/sourcegraph/pull/32473.

## Test plan

N/A - all code is new and no-op'd.