### PR TITLE
RFC 619: (M1) Generate symbols service skeleton

### DIFF
--- a/internal/codeintel/symbols/gen.go
+++ b/internal/codeintel/symbols/gen.go
@@ -1,0 +1,3 @@
+package symbols
+
+//go:generate ../../../dev/mockgen.sh github.com/sourcegraph/sourcegraph/internal/codeintel/symbols -i Store -o mock_iface_test.go

--- a/internal/codeintel/symbols/iface.go
+++ b/internal/codeintel/symbols/iface.go
@@ -1,0 +1,11 @@
+package symbols
+
+import (
+	"context"
+
+	"github.com/sourcegraph/sourcegraph/internal/codeintel/symbols/internal/store"
+)
+
+type Store interface {
+	List(ctx context.Context, opts store.ListOpts) ([]Symbol, error)
+}

--- a/internal/codeintel/symbols/init.go
+++ b/internal/codeintel/symbols/init.go
@@ -1,0 +1,46 @@
+package symbols
+
+import (
+	"sync"
+
+	"github.com/inconshreveable/log15"
+	"github.com/opentracing/opentracing-go"
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/sourcegraph/sourcegraph/internal/codeintel/symbols/internal/store"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
+	"github.com/sourcegraph/sourcegraph/internal/trace"
+)
+
+var (
+	svc     *Service
+	svcOnce sync.Once
+)
+
+// GetService creates or returns an already-initialized symbols service. If the service is
+// new, it will use the given database handle.
+func GetService(db database.DB) *Service {
+	svcOnce.Do(func() {
+		observationContext := &observation.Context{
+			Logger:     log15.Root(),
+			Tracer:     &trace.Tracer{Tracer: opentracing.GlobalTracer()},
+			Registerer: prometheus.DefaultRegisterer,
+		}
+
+		svc = newService(
+			store.GetStore(db),
+			observationContext,
+		)
+	})
+
+	return svc
+}
+
+// TestService creates a fresh symbols service with the given database handle.
+func TestService(db database.DB) *Service {
+	return newService(
+		store.GetStore(db),
+		&observation.TestContext,
+	)
+}

--- a/internal/codeintel/symbols/internal/store/init.go
+++ b/internal/codeintel/symbols/internal/store/init.go
@@ -1,0 +1,36 @@
+package store
+
+import (
+	"sync"
+
+	"github.com/inconshreveable/log15"
+	"github.com/opentracing/opentracing-go"
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
+	"github.com/sourcegraph/sourcegraph/internal/trace"
+)
+
+var (
+	store     *Store
+	storeOnce sync.Once
+)
+
+func GetStore(db database.DB) *Store {
+	storeOnce.Do(func() {
+		observationContext := &observation.Context{
+			Logger:     log15.Root(),
+			Tracer:     &trace.Tracer{Tracer: opentracing.GlobalTracer()},
+			Registerer: prometheus.DefaultRegisterer,
+		}
+
+		store = newStore(db, observationContext)
+	})
+
+	return store
+}
+
+func TestStore(db database.DB) *Store {
+	return newStore(db, &observation.TestContext)
+}

--- a/internal/codeintel/symbols/internal/store/observability.go
+++ b/internal/codeintel/symbols/internal/store/observability.go
@@ -1,0 +1,33 @@
+package store
+
+import (
+	"fmt"
+
+	"github.com/sourcegraph/sourcegraph/internal/metrics"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
+)
+
+type operations struct {
+	list *observation.Operation
+}
+
+func newOperations(observationContext *observation.Context) *operations {
+	metrics := metrics.NewREDMetrics(
+		observationContext.Registerer,
+		"codeintel_symbols_store",
+		metrics.WithLabels("op"),
+		metrics.WithCountHelp("Total number of method invocations."),
+	)
+
+	op := func(name string) *observation.Operation {
+		return observationContext.Operation(observation.Op{
+			Name:              fmt.Sprintf("codeintel.symbols.store.%s", name),
+			MetricLabelValues: []string{name},
+			Metrics:           metrics,
+		})
+	}
+
+	return &operations{
+		list: op("List"),
+	}
+}

--- a/internal/codeintel/symbols/internal/store/scan.go
+++ b/internal/codeintel/symbols/internal/store/scan.go
@@ -1,0 +1,29 @@
+package store
+
+import (
+	"database/sql"
+
+	"github.com/sourcegraph/sourcegraph/internal/codeintel/symbols/shared"
+	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
+)
+
+func scanSymbols(rows *sql.Rows, queryErr error) (symbols []shared.Symbol, err error) {
+	if queryErr != nil {
+		return nil, queryErr
+	}
+	defer func() { err = basestore.CloseRows(rows, err) }()
+
+	for rows.Next() {
+		var symbol shared.Symbol
+
+		if err = rows.Scan(
+			&symbol.Name,
+		); err != nil {
+			return nil, err
+		}
+
+		symbols = append(symbols, symbol)
+	}
+
+	return symbols, nil
+}

--- a/internal/codeintel/symbols/internal/store/store.go
+++ b/internal/codeintel/symbols/internal/store/store.go
@@ -1,0 +1,70 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/keegancsmith/sqlf"
+	"github.com/opentracing/opentracing-go/log"
+
+	"github.com/sourcegraph/sourcegraph/internal/codeintel/symbols/shared"
+	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+type Store struct {
+	*basestore.Store
+	operations *operations
+}
+
+func newStore(db dbutil.DB, observationContext *observation.Context) *Store {
+	return &Store{
+		Store:      basestore.NewWithDB(db, sql.TxOptions{}),
+		operations: newOperations(observationContext),
+	}
+}
+
+func (s *Store) With(other basestore.ShareableStore) *Store {
+	return &Store{
+		Store:      s.Store.With(other),
+		operations: s.operations,
+	}
+}
+
+func (s *Store) Transact(ctx context.Context) (*Store, error) {
+	txBase, err := s.Store.Transact(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Store{
+		Store:      txBase,
+		operations: s.operations,
+	}, nil
+}
+
+type ListOpts struct {
+	Limit int
+}
+
+func (s *Store) List(ctx context.Context, opts ListOpts) (symbols []shared.Symbol, err error) {
+	ctx, endObservation := s.operations.list.With(ctx, &err, observation.Args{})
+	defer func() {
+		endObservation(1, observation.Args{LogFields: []log.Field{
+			log.Int("numSymbols", len(symbols)),
+		}})
+	}()
+
+	// This is only a stub and will be replaced or significantly modified
+	// in https://github.com/sourcegraph/sourcegraph/issues/33374
+	_, _ = scanSymbols(s.Query(ctx, sqlf.Sprintf(listQuery, opts.Limit)))
+	return nil, errors.Newf("unimplemented: symbols.store.List")
+}
+
+const listQuery = `
+-- source: internal/codeintel/symbols/store/store.go:List
+SELECT name FROM TODO
+LIMIT %d
+`

--- a/internal/codeintel/symbols/observability.go
+++ b/internal/codeintel/symbols/observability.go
@@ -1,0 +1,33 @@
+package symbols
+
+import (
+	"fmt"
+
+	"github.com/sourcegraph/sourcegraph/internal/metrics"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
+)
+
+type operations struct {
+	symbol *observation.Operation
+}
+
+func newOperations(observationContext *observation.Context) *operations {
+	metrics := metrics.NewREDMetrics(
+		observationContext.Registerer,
+		"codeintel_symbols",
+		metrics.WithLabels("op"),
+		metrics.WithCountHelp("Total number of method invocations."),
+	)
+
+	op := func(name string) *observation.Operation {
+		return observationContext.Operation(observation.Op{
+			Name:              fmt.Sprintf("codeintel.symbols.%s", name),
+			MetricLabelValues: []string{name},
+			Metrics:           metrics,
+		})
+	}
+
+	return &operations{
+		symbol: op("Symbol"),
+	}
+}

--- a/internal/codeintel/symbols/service.go
+++ b/internal/codeintel/symbols/service.go
@@ -1,0 +1,36 @@
+package symbols
+
+import (
+	"context"
+
+	"github.com/sourcegraph/sourcegraph/internal/codeintel/symbols/internal/store"
+	"github.com/sourcegraph/sourcegraph/internal/codeintel/symbols/shared"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+type Service struct {
+	symbolsStore Store
+	operations   *operations
+}
+
+func newService(symbolsStore Store, observationContext *observation.Context) *Service {
+	return &Service{
+		symbolsStore: symbolsStore,
+		operations:   newOperations(observationContext),
+	}
+}
+
+type Symbol = shared.Symbol
+
+type SymbolOpts struct {
+}
+
+func (s *Service) Symbol(ctx context.Context, opts SymbolOpts) (symbols []Symbol, err error) {
+	ctx, endObservation := s.operations.symbol.With(ctx, &err, observation.Args{})
+	defer endObservation(1, observation.Args{})
+
+	// To be implemented in https://github.com/sourcegraph/sourcegraph/issues/33374
+	_, _ = s.symbolsStore.List(ctx, store.ListOpts{})
+	return nil, errors.Newf("unimplemented: symbols.Symbol")
+}

--- a/internal/codeintel/symbols/shared/types.go
+++ b/internal/codeintel/symbols/shared/types.go
@@ -1,0 +1,5 @@
+package shared
+
+type Symbol struct {
+	Name string
+}


### PR DESCRIPTION
Generate an empty symbols service skeleton as defined by [RFC 619: Code Intelligence Data Platform](https://docs.google.com/document/d/1AjZ_d0nJVHbV75IH3jZRkrGXhsv_AXp2kS4nrw2SAQ8).

Partially covers https://github.com/sourcegraph/sourcegraph/issues/33372.
Originally drafted in https://github.com/sourcegraph/sourcegraph/pull/32473.

## Test plan

N/A - all code is new and no-op'd.