### PR TITLE
RFC 619: (M1) Generate dependencies service skeleton (transport)

### DIFF
--- a/internal/codeintel/dependencies/transport/graphql/init.go
+++ b/internal/codeintel/dependencies/transport/graphql/init.go
@@ -1,0 +1,32 @@
+package graphql
+
+import (
+	"sync"
+
+	"github.com/inconshreveable/log15"
+	"github.com/opentracing/opentracing-go"
+	"github.com/prometheus/client_golang/prometheus"
+
+	dependencies "github.com/sourcegraph/sourcegraph/internal/codeintel/dependencies"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
+	"github.com/sourcegraph/sourcegraph/internal/trace"
+)
+
+var (
+	resolver     *Resolver
+	resolverOnce sync.Once
+)
+
+func GetResolver(svc *dependencies.Service) *Resolver {
+	resolverOnce.Do(func() {
+		observationContext := &observation.Context{
+			Logger:     log15.Root(),
+			Tracer:     &trace.Tracer{Tracer: opentracing.GlobalTracer()},
+			Registerer: prometheus.DefaultRegisterer,
+		}
+
+		resolver = newResolver(svc, observationContext)
+	})
+
+	return resolver
+}

--- a/internal/codeintel/dependencies/transport/graphql/observability.go
+++ b/internal/codeintel/dependencies/transport/graphql/observability.go
@@ -1,0 +1,33 @@
+package graphql
+
+import (
+	"fmt"
+
+	"github.com/sourcegraph/sourcegraph/internal/metrics"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
+)
+
+type operations struct {
+	dependencies *observation.Operation
+}
+
+func newOperations(observationContext *observation.Context) *operations {
+	metrics := metrics.NewREDMetrics(
+		observationContext.Registerer,
+		"codeintel_dependencies_transport_graphql",
+		metrics.WithLabels("op"),
+		metrics.WithCountHelp("Total number of method invocations."),
+	)
+
+	op := func(name string) *observation.Operation {
+		return observationContext.Operation(observation.Op{
+			Name:              fmt.Sprintf("codeintel.dependencies.transport.graphql.%s", name),
+			MetricLabelValues: []string{name},
+			Metrics:           metrics,
+		})
+	}
+
+	return &operations{
+		dependencies: op("Dependencies"),
+	}
+}

--- a/internal/codeintel/dependencies/transport/graphql/resolver.go
+++ b/internal/codeintel/dependencies/transport/graphql/resolver.go
@@ -1,0 +1,29 @@
+package graphql
+
+import (
+	"context"
+
+	"github.com/sourcegraph/sourcegraph/internal/codeintel/dependencies"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
+)
+
+type Resolver struct {
+	svc        *dependencies.Service
+	operations *operations
+}
+
+func newResolver(svc *dependencies.Service, observationContext *observation.Context) *Resolver {
+	return &Resolver{
+		svc:        svc,
+		operations: newOperations(observationContext),
+	}
+}
+
+func (r *Resolver) Dependencies(ctx context.Context) (err error) {
+	ctx, endObservation := r.operations.dependencies.With(ctx, &err, observation.Args{})
+	defer endObservation(1, observation.Args{})
+
+	// TODO
+	_, err = r.svc.Dependencies(ctx, nil)
+	return err
+}


### PR DESCRIPTION
Modify the existing dependencies service to include (initially empty) missing components defined in [RFC 619: Code Intelligence Data Platform](https://docs.google.com/document/d/1AjZ_d0nJVHbV75IH3jZRkrGXhsv_AXp2kS4nrw2SAQ8).

Partially covers https://github.com/sourcegraph/sourcegraph/issues/33372.
Originally drafted in https://github.com/sourcegraph/sourcegraph/pull/32473.

## Test plan

N/A - all code is new and no-op'd.