### PR TITLE
Add executedQuery and resultClassName props to search list

### DIFF
--- a/client/search-ui/src/components/SearchResult.tsx
+++ b/client/search-ui/src/components/SearchResult.tsx
@@ -34,6 +34,7 @@ interface Props extends PlatformContextProps<'requestGraphQL'> {
     icon: React.ComponentType<{ className?: string }>
     onSelect: () => void
     openInNewTab?: boolean
+    containerClassName?: string
 }
 
 export const SearchResult: React.FunctionComponent<Props> = ({
@@ -43,6 +44,7 @@ export const SearchResult: React.FunctionComponent<Props> = ({
     platformContext,
     onSelect,
     openInNewTab,
+    containerClassName,
 }) => {
     /**
      * Use the custom hook useIsTruncated to check if overflow: ellipsis is activated for the element
@@ -186,6 +188,7 @@ export const SearchResult: React.FunctionComponent<Props> = ({
             resultType={result.type}
             onResultClicked={onSelect}
             expandedChildren={renderBody()}
+            className={containerClassName}
         />
     )
 }

--- a/client/search-ui/src/results/StreamingSearchResultsList.tsx
+++ b/client/search-ui/src/results/StreamingSearchResultsList.tsx
@@ -67,6 +67,10 @@ export interface StreamingSearchResultsListProps
      * For example, `location.search` on web.
      */
     executedQuery: string
+    /**
+     * Classname to be applied to the container of a search result.
+     */
+    resultClassName?: string
 }
 
 export const StreamingSearchResultsList: React.FunctionComponent<StreamingSearchResultsListProps> = ({
@@ -88,6 +92,7 @@ export const StreamingSearchResultsList: React.FunctionComponent<StreamingSearch
     hoverifier,
     openMatchesInNewTab,
     executedQuery,
+    resultClassName,
 }) => {
     const resultsNumber = results?.results.length || 0
     const { itemsToShow, handleBottomHit } = useItemsToShow(executedQuery, resultsNumber)
@@ -124,6 +129,7 @@ export const StreamingSearchResultsList: React.FunctionComponent<StreamingSearch
                             extensionsController={extensionsController}
                             hoverifier={hoverifier}
                             openInNewTab={openMatchesInNewTab}
+                            containerClassName={resultClassName}
                         />
                     )
                 case 'commit':
@@ -135,6 +141,7 @@ export const StreamingSearchResultsList: React.FunctionComponent<StreamingSearch
                             platformContext={platformContext}
                             onSelect={() => logSearchResultClicked(index, 'commit')}
                             openInNewTab={openMatchesInNewTab}
+                            containerClassName={resultClassName}
                         />
                     )
                 case 'repo':
@@ -145,6 +152,7 @@ export const StreamingSearchResultsList: React.FunctionComponent<StreamingSearch
                             repoName={result.repository}
                             platformContext={platformContext}
                             onSelect={() => logSearchResultClicked(index, 'repo')}
+                            containerClassName={resultClassName}
                         />
                     )
             }
@@ -160,6 +168,7 @@ export const StreamingSearchResultsList: React.FunctionComponent<StreamingSearch
             extensionsController,
             hoverifier,
             openMatchesInNewTab,
+            resultClassName,
         ]
     )
 

--- a/client/search-ui/src/results/StreamingSearchResultsList.tsx
+++ b/client/search-ui/src/results/StreamingSearchResultsList.tsx
@@ -62,6 +62,11 @@ export interface StreamingSearchResultsListProps
 
     extensionsController?: Pick<ExtensionsController, 'extHostAPI'>
     hoverifier?: Hoverifier<HoverContext, HoverMerged, ActionItemAction>
+    /**
+     * Latest run query. Resets scroll visibility state when changed.
+     * For example, `location.search` on web.
+     */
+    executedQuery: string
 }
 
 export const StreamingSearchResultsList: React.FunctionComponent<StreamingSearchResultsListProps> = ({
@@ -82,9 +87,10 @@ export const StreamingSearchResultsList: React.FunctionComponent<StreamingSearch
     extensionsController,
     hoverifier,
     openMatchesInNewTab,
+    executedQuery,
 }) => {
     const resultsNumber = results?.results.length || 0
-    const { itemsToShow, handleBottomHit } = useItemsToShow(location.search, resultsNumber)
+    const { itemsToShow, handleBottomHit } = useItemsToShow(executedQuery, resultsNumber)
 
     const logSearchResultClicked = useCallback(
         (index: number, type: string) => {

--- a/client/web/src/notebooks/blocks/query/NotebookQueryBlock.tsx
+++ b/client/web/src/notebooks/blocks/query/NotebookQueryBlock.tsx
@@ -174,6 +174,7 @@ export const NotebookQueryBlock: React.FunctionComponent<NotebookQueryBlockProps
                             extensionsController={props.extensionsController}
                             hoverifier={hoverifier}
                             openMatchesInNewTab={true}
+                            executedQuery={location.search}
                         />
                     </div>
                 )}

--- a/client/web/src/notebooks/blocks/query/NotebookQueryBlock.tsx
+++ b/client/web/src/notebooks/blocks/query/NotebookQueryBlock.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useMemo } from 'react'
+import React, { useState, useCallback, useMemo, useEffect } from 'react'
 
 import classNames from 'classnames'
 import { noop } from 'lodash'
@@ -75,11 +75,19 @@ export const NotebookQueryBlock: React.FunctionComponent<NotebookQueryBlockProps
         const [editor, setEditor] = useState<Monaco.editor.IStandaloneCodeEditor>()
         const searchResults = useObservable(output ?? of(undefined))
         const location = useLocation()
+        const [executedQuery, setExecutedQuery] = useState<string>(input.query)
 
         const onInputChange = useCallback(
             (query: string) => onBlockInputChange(id, { type: 'query', input: { query } }),
             [id, onBlockInputChange]
         )
+
+        useEffect(() => {
+            setExecutedQuery(input.query)
+            // We intentionally want to track the input query state at the time
+            // of search submission, not on input change.
+            // eslint-disable-next-line react-hooks/exhaustive-deps
+        }, [output])
 
         useMonacoBlockInput({
             editor,
@@ -174,7 +182,7 @@ export const NotebookQueryBlock: React.FunctionComponent<NotebookQueryBlockProps
                             extensionsController={props.extensionsController}
                             hoverifier={hoverifier}
                             openMatchesInNewTab={true}
-                            executedQuery={location.search}
+                            executedQuery={executedQuery}
                         />
                     </div>
                 )}

--- a/client/web/src/notebooks/notebook/NotebookComponent.tsx
+++ b/client/web/src/notebooks/notebook/NotebookComponent.tsx
@@ -53,7 +53,7 @@ export interface NotebookComponentProps
     extends SearchStreamingProps,
         ThemeProps,
         TelemetryProps,
-        Omit<StreamingSearchResultsListProps, 'location' | 'allExpanded'> {
+        Omit<StreamingSearchResultsListProps, 'location' | 'allExpanded' | 'executedQuery'> {
     globbing: boolean
     isReadOnly?: boolean
     blocks: BlockInit[]

--- a/client/web/src/notebooks/notebookPage/NotebookContent.tsx
+++ b/client/web/src/notebooks/notebookPage/NotebookContent.tsx
@@ -20,7 +20,10 @@ export interface NotebookContentProps
     extends SearchStreamingProps,
         ThemeProps,
         TelemetryProps,
-        Omit<StreamingSearchResultsListProps, 'allExpanded' | 'extensionsController' | 'platformContext'>,
+        Omit<
+            StreamingSearchResultsListProps,
+            'allExpanded' | 'extensionsController' | 'platformContext' | 'executedQuery'
+        >,
         PlatformContextProps<'sourcegraphURL' | 'requestGraphQL' | 'urlToFile' | 'settings' | 'forceUpdateTooltip'>,
         ExtensionsControllerProps<'extHostAPI' | 'executeCommand'> {
     globbing: boolean

--- a/client/web/src/notebooks/notebookPage/NotebookPage.tsx
+++ b/client/web/src/notebooks/notebookPage/NotebookPage.tsx
@@ -50,7 +50,10 @@ interface NotebookPageProps
         SearchStreamingProps,
         ThemeProps,
         TelemetryProps,
-        Omit<StreamingSearchResultsListProps, 'allExpanded' | 'extensionsController' | 'platformContext'>,
+        Omit<
+            StreamingSearchResultsListProps,
+            'allExpanded' | 'extensionsController' | 'platformContext' | 'executedQuery'
+        >,
         PlatformContextProps<'sourcegraphURL' | 'requestGraphQL' | 'urlToFile' | 'settings' | 'forceUpdateTooltip'>,
         ExtensionsControllerProps<'extHostAPI' | 'executeCommand'> {
     authenticatedUser: AuthenticatedUser | null

--- a/client/web/src/search/SearchConsolePage.tsx
+++ b/client/web/src/search/SearchConsolePage.tsx
@@ -28,7 +28,7 @@ import styles from './SearchConsolePage.module.scss'
 
 interface SearchConsolePageProps
     extends SearchStreamingProps,
-        Omit<StreamingSearchResultsListProps, 'allExpanded' | 'extensionsController'>,
+        Omit<StreamingSearchResultsListProps, 'allExpanded' | 'extensionsController' | 'executedQuery'>,
         ExtensionsControllerProps<'executeCommand' | 'extHostAPI'> {
     globbing: boolean
     isMacPlatform: boolean
@@ -174,6 +174,7 @@ export const SearchConsolePage: React.FunctionComponent<SearchConsolePageProps> 
                                 showSearchContext={showSearchContext}
                                 assetsRoot={window.context?.assetsRoot || ''}
                                 renderSearchUserNeedsCodeHost={user => <SearchUserNeedsCodeHost user={user} />}
+                                executedQuery={props.location.search}
                             />
                         ))}
                 </div>

--- a/client/web/src/search/results/StreamingSearchResults.tsx
+++ b/client/web/src/search/results/StreamingSearchResults.tsx
@@ -453,6 +453,7 @@ export const StreamingSearchResults: React.FunctionComponent<StreamingSearchResu
                     renderSearchUserNeedsCodeHost={user => (
                         <SearchUserNeedsCodeHost user={user} orgSearchContext={props.selectedSearchContextSpec} />
                     )}
+                    executedQuery={location.search}
                 />
             </div>
         </div>


### PR DESCRIPTION
Add props to `StreamingSearchResultsList` for the VS Code extension (likely the last VS Code extension search-ui PR for initial release 🎊).
- `executedQuery`: Simply the latest run query. Used to be `location.search` by default. Used to reset virtual list height/items to show on new search.
- `resultClassName`: Allows consumer to style search result container 

## Test plan

**On Sourcegraph web:**

`resultClassName` (search result rendering):
1. Run a search
2. Observe that search result rendering has not changed 

| After | sourcegraph.com |
| --- | --- |
| ![search-result-after](https://user-images.githubusercontent.com/37420160/162452121-78b5d50b-3577-4723-8229-e04f19441b12.png) | ![search-result-dotcom](https://user-images.githubusercontent.com/37420160/162452149-589e141d-bee3-42a7-8ffc-8573973b839c.png) |

`executedQuery`: (scroll visibility state reset):
1. Run a search
2. Scroll to the bottom of the search results list and see the next set of search results are now shown
3. Run a new search
4. Observe that the scroll height of the search results list has decreased (only the initial count of search results are shown)

## App preview:
- [Link](https://sg-web-tjk-search-list-query-prop.onrender.com)

