### PR TITLE
pr-auditor: support test plans in poorly formatted markdown

### DIFF
--- a/dev/pr-auditor/check.go
+++ b/dev/pr-auditor/check.go
@@ -23,7 +23,7 @@ func (r checkResult) HasTestPlan() bool {
 }
 
 var (
-	testPlanDividerRegexp       = regexp.MustCompile("(?m)(^#+ Test [pP]lan)|(^Test [pP]lan:)")
+	testPlanDividerRegexp       = regexp.MustCompile("(?m)(#+ Test [pP]lan)|(Test [pP]lan:)")
 	noReviewNeededDividerRegexp = regexp.MustCompile("(?m)([nN]o [rR]eview [rR]equired:)")
 	markdownCommentRegexp       = regexp.MustCompile("<!--((.|\n)*?)-->(\n)*")
 )

--- a/dev/pr-auditor/check_test.go
+++ b/dev/pr-auditor/check_test.go
@@ -70,6 +70,14 @@ And a little complicated; there's also the following reasons:
 				TestPlan: "I have a plan! No review required: this is a bot PR",
 			},
 		},
+		{
+			name:     "bad markdown still passes",
+			bodyFile: "testdata/pull_request_body/bad-markdown.md",
+			want: checkResult{
+				Reviewed: true,
+				TestPlan: "This is still a plan! No review required: just trust me",
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/dev/pr-auditor/testdata/pull_request_body/bad-markdown.md
+++ b/dev/pr-auditor/testdata/pull_request_body/bad-markdown.md
@@ -1,0 +1,3 @@
+Some poorly formatted markdown test plan
+    ## Test plan
+  This is still a plan! No review required: just trust me


### PR DESCRIPTION
Previously the regexp required the test plan anchor to be at the start of a line, which fails on PRs with poorly formatted markdown. This changes the regexp to allow the test plan anchor to show up anywhere

Fun example: https://github.com/sourcegraph/sec-pr-audit-trail/issues/170, the PR https://github.com/sourcegraph/deploy-sourcegraph-cloud/pull/16102 has a test plan but it starts after some leading whitespace

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

unit test