### PR TITLE
web(repo/tree): friendlier no-readme placeholder

### DIFF
--- a/client/web/src/repo/tree/HomeTab.tsx
+++ b/client/web/src/repo/tree/HomeTab.tsx
@@ -228,21 +228,21 @@ export const HomeTab: React.FunctionComponent<Props> = ({
         </div>
     )
 
-    const ReadmeFile: React.FunctionComponent = () => (
+    const READMEFile: React.FunctionComponent = () => (
         <div>
             {richHTML && richHTML !== 'loading' && (
                 <RenderedFile className="pt-0 pl-3" dangerousInnerHTML={richHTML} location={props.location} />
             )}
             {!richHTML && richHTML !== 'loading' && (
-                <div className="text-center">
-                    <img src="https://i.ibb.co/tztztYB/eric.png" alt="loser" className="mb-3 w-50" />
-                    <h2>No README available, loser.</h2>
+                <div className="text-center mt-5">
+                    <img src="https://i.ibb.co/tztztYB/eric.png" alt="winner" className="mb-3 w-25" />
+                    <h2>No README available :)</h2>
                 </div>
             )}
             {blobInfoOrError && richHTML && aborted && (
                 <div>
                     <Alert variant="info">
-                        Syntax-highlighting this file took too long. &nbsp;
+                        Rendering this file took too long. &nbsp;
                         <Button onClick={onExtendTimeoutClick} variant="primary" size="sm">
                             Try again
                         </Button>
@@ -258,15 +258,7 @@ export const HomeTab: React.FunctionComponent<Props> = ({
             <div className="container mw-100">
                 <RecentCommits isSidebar={false} />
                 <h2 className="mt-5">README.md</h2>
-                {richHTML && richHTML !== 'loading' && (
-                    <RenderedFile dangerousInnerHTML={richHTML} location={props.location} />
-                )}
-                {!richHTML && richHTML !== 'loading' && (
-                    <div className="text-center">
-                        <img src="https://i.ibb.co/tztztYB/eric.png" alt="loser" className="mb-3 w-50" />
-                        <h2>No README available, loser.</h2>
-                    </div>
-                )}
+                <READMEFile />
             </div>
         )
     }
@@ -276,7 +268,7 @@ export const HomeTab: React.FunctionComponent<Props> = ({
             <div className="row">
                 {/* RENDER README */}
                 <div className="col-sm m-0 pl-0 pt-0">
-                    <ReadmeFile />
+                    <READMEFile />
                 </div>
                 {/* SIDE MENU*/}
                 <div className="col-sm col-lg-4 m-0">


### PR DESCRIPTION
Slightly friendlier placeholder for the no-readme component :) and removes some code duplication



## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

<img width="1368" alt="image" src="https://user-images.githubusercontent.com/23356519/162324367-a865f6e7-6dfd-4d3a-accd-cafcf72109fc.png">

<img width="1521" alt="image" src="https://user-images.githubusercontent.com/23356519/162324740-b3ee3766-b680-4038-8242-9e8bac8fd897.png">

## App preview:
- [Link](https://sg-web-new-repo-page-friendly-readme.onrender.com)

