### PR TITLE
docs: add PR previews documentation

### DIFF
--- a/dev/ci/render-pr-preview.sh
+++ b/dev/ci/render-pr-preview.sh
@@ -183,7 +183,11 @@ if [[ -n "${github_api_key}" && -n "${pr_number}" ]]; then
   if [[ "${pr_description}" != *"## App preview"* ]]; then
     echo "Updating PR #${pr_number} in ${owner_and_repo} description"
 
-    pr_description=$(echo -e "${pr_description}\n## App preview:\n- [Link](${pr_preview_url})\n" | jq -Rs .)
+    pr_description=$(printf '%s\n\n' "${pr_description}" \
+      "## App preview:" \
+      "- [Link](${pr_preview_url})" \
+      "Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more." |
+      jq -Rs .)
 
     curl -sSf -o /dev/null --request PATCH \
       --url "${github_pr_api_url}" \

--- a/doc/dev/how-to/client_pr_previews.md
+++ b/doc/dev/how-to/client_pr_previews.md
@@ -1,0 +1,26 @@
+# Exploring client changes with PR previews
+
+We have app previews for each PR with **only client changes**. It means that everyone can easily explore UI updates and play with new client features by clicking a link in the PR description instead of pulling a branch and running the application locally!
+
+## Under the hood
+
+A link to a deployed preview is automatically added to the bottom of the PR description. [Under the hood](https://sourcegraph.com/search?q=context:global+repo:sourcegraph/sourcegraph%24+Get+service+id+of+preview+app+on+render.com&patternType=literal), it uses a production build of the web application running on the standalone web server:
+
+```sh
+dev/ci/yarn-build.sh client/web
+yarn workspace @sourcegraph/web serve:prod
+```
+
+The standalone web server is deployed as [a web service](https://render.com/docs/web-services) to [render.com](https://render.com/) via [a Buildkite step](https://sourcegraph.com/search?q=context:global+repo:sourcegraph/sourcegraph%24+prPreview%28%29&patternType=literal).
+
+## How to login
+
+[The dogfood instance](https://k8s.sgdev.org/) API is used as the backend, so use your k8s username and password credentials to log in to the preview version of the application. Use the dogfood instance to sign up if you do not have one.
+
+Other resources:
+
+- [Testing in Dogfood](./testing_in_dogfood.md)
+
+## Why does it work for client-only pull requests?
+
+We do not create client PR previews [if Go or GraphQL is changed](https://sourcegraph.com/search?q=context:global+repo:sourcegraph/sourcegraph%24+%21c.Diff.Has%28changed.Go%29&patternType=literal) in a PR to avoid confusing preview behavior because only Client code is used to deploy application preview. Otherwise, the PR preview would sometimes show incomplete features with the updated client code, which is not yet supported by the backend.

--- a/doc/dev/how-to/index.md
+++ b/doc/dev/how-to/index.md
@@ -33,6 +33,7 @@
 - [Configure a test instance of Phabricator and Gitolite](configure_phabricator_gitolite.md)
 - [Test a Phabricator and Gitolite instance](test_phabricator.md)
 - [How to test changes in dogfood](testing_in_dogfood.md)
+- [How to use client app PR previews](client_pr_previews.md)
 
 ## Profiling
 


### PR DESCRIPTION
## Context

Adding client PR previews documentation.

## Test plan

- Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
- Test PR [here](https://github.com/sourcegraph/sourcegraph/pull/33643).