### PR TITLE
ratelimit: NPM package syncer should sync rate limit from config

### DIFF
--- a/cmd/gitserver/server/vcs_syncer_npm_packages.go
+++ b/cmd/gitserver/server/vcs_syncer_npm_packages.go
@@ -43,8 +43,8 @@ type NpmPackagesSyncer struct {
 	client npm.Client
 }
 
-// Create a new NpmPackagesSyncer. If customClient is nil, the client
-// for the syncer is configured based on the connection parameter.
+// NewNpmPackagesSyncer create a new NpmPackageSyncer. If customClient is nil,
+// the client for the syncer is configured based on the connection parameter.
 func NewNpmPackagesSyncer(
 	connection schema.NpmPackagesConnection,
 	dbStore repos.DependenciesStore,
@@ -52,7 +52,7 @@ func NewNpmPackagesSyncer(
 ) *NpmPackagesSyncer {
 	var client = customClient
 	if client == nil {
-		client = npm.NewHTTPClient(connection.Registry, connection.RateLimit, connection.Credentials)
+		client = npm.NewHTTPClient(connection.Registry, connection.Credentials)
 	}
 	return &NpmPackagesSyncer{connection, dbStore, client}
 }
@@ -70,8 +70,8 @@ func (s *NpmPackagesSyncer) IsCloneable(ctx context.Context, remoteURL *vcs.URL)
 	return nil
 }
 
-// Similar to CloneCommand for JVMPackagesSyncer; it handles cloning itself
-// instead of returning a command that does the cloning.
+// CloneCommand is similar ro CloneCommand for JVMPackagesSyncer; it handles
+// cloning itself instead of returning a command that does the cloning.
 func (s *NpmPackagesSyncer) CloneCommand(ctx context.Context, remoteURL *vcs.URL, bareGitDirectory string) (*exec.Cmd, error) {
 	err := os.MkdirAll(bareGitDirectory, 0755)
 	if err != nil {

--- a/cmd/gitserver/server/vcs_syncer_npm_packages.go
+++ b/cmd/gitserver/server/vcs_syncer_npm_packages.go
@@ -70,7 +70,7 @@ func (s *NpmPackagesSyncer) IsCloneable(ctx context.Context, remoteURL *vcs.URL)
 	return nil
 }
 
-// CloneCommand is similar ro CloneCommand for JVMPackagesSyncer; it handles
+// CloneCommand is similar to CloneCommand for JVMPackagesSyncer; it handles
 // cloning itself instead of returning a command that does the cloning.
 func (s *NpmPackagesSyncer) CloneCommand(ctx context.Context, remoteURL *vcs.URL, bareGitDirectory string) (*exec.Cmd, error) {
 	err := os.MkdirAll(bareGitDirectory, 0755)

--- a/internal/extsvc/npm/npm.go
+++ b/internal/extsvc/npm/npm.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"math"
 	"net/http"
 	"time"
 
@@ -26,7 +25,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
-	"github.com/sourcegraph/sourcegraph/schema"
 )
 
 type Client interface {
@@ -94,15 +92,8 @@ type HTTPClient struct {
 	credentials string
 }
 
-func NewHTTPClient(registryURL string, rateLimit *schema.NpmRateLimit, credentials string) *HTTPClient {
-	var requestsPerHour float64
-	if rateLimit == nil || !rateLimit.Enabled {
-		requestsPerHour = math.Inf(1)
-	} else {
-		requestsPerHour = rateLimit.RequestsPerHour
-	}
-	defaultLimiter := rate.NewLimiter(rate.Limit(requestsPerHour/3600.0), 100)
-	cachedLimiter := ratelimit.DefaultRegistry.GetOrSet(registryURL, defaultLimiter)
+func NewHTTPClient(registryURL string, credentials string) *HTTPClient {
+	cachedLimiter := ratelimit.DefaultRegistry.Get(registryURL)
 	return &HTTPClient{
 		registryURL,
 		httpcli.ExternalDoer,

--- a/internal/extsvc/npm/npm_test.go
+++ b/internal/extsvc/npm/npm_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/conf/reposource"
 	"github.com/sourcegraph/sourcegraph/internal/httptestutil"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
-	"github.com/sourcegraph/sourcegraph/schema"
 )
 
 func TestMain(m *testing.M) {
@@ -35,8 +34,7 @@ var updateRecordings = flag.Bool("update", false, "make npm API calls, record an
 func newTestHTTPClient(t *testing.T) (client *HTTPClient, stop func()) {
 	t.Helper()
 	recorderFactory, stop := httptestutil.NewRecorderFactory(t, *updateRecordings, t.Name())
-	rateLimit := schema.NpmRateLimit{true, 1000}
-	client = NewHTTPClient("https://registry.npmjs.org", &rateLimit, "")
+	client = NewHTTPClient("https://registry.npmjs.org", "")
 	doer, err := recorderFactory.Doer()
 	require.Nil(t, err)
 	client.doer = doer
@@ -78,8 +76,7 @@ func TestCredentials(t *testing.T) {
 	defer server.Close()
 
 	ctx := context.Background()
-	rateLimit := schema.NpmRateLimit{true, 1000}
-	client := NewHTTPClient(server.URL, &rateLimit, credentials)
+	client := NewHTTPClient(server.URL, credentials)
 
 	presentDep, err := reposource.ParseNpmDependency("left-pad@1.3.0")
 	require.NoError(t, err)

--- a/internal/extsvc/types.go
+++ b/internal/extsvc/types.go
@@ -461,7 +461,8 @@ func GetLimitFromConfig(kind string, config interface{}) (rlc RateLimitConfig, e
 		}
 		rlc.BaseURL = c.Url
 	case *schema.NpmPackagesConnection:
-		rlc.Limit = defaultRateLimit
+		// 3000 per hour is the same default we use in our schema
+		rlc.Limit = rate.Limit(3000.0 / 3600.0)
 		if c != nil && c.RateLimit != nil {
 			rlc.Limit = limitOrInf(c.RateLimit.Enabled, c.RateLimit.RequestsPerHour)
 			rlc.IsDefault = false

--- a/internal/extsvc/types.go
+++ b/internal/extsvc/types.go
@@ -460,6 +460,13 @@ func GetLimitFromConfig(kind string, config interface{}) (rlc RateLimitConfig, e
 			rlc.IsDefault = false
 		}
 		rlc.BaseURL = c.Url
+	case *schema.NpmPackagesConnection:
+		rlc.Limit = defaultRateLimit
+		if c != nil && c.RateLimit != nil {
+			rlc.Limit = limitOrInf(c.RateLimit.Enabled, c.RateLimit.RequestsPerHour)
+			rlc.IsDefault = false
+		}
+		rlc.BaseURL = c.Registry
 	default:
 		return rlc, ErrRateLimitUnsupported{codehostKind: kind}
 	}

--- a/internal/extsvc/types_test.go
+++ b/internal/extsvc/types_test.go
@@ -164,7 +164,7 @@ func TestExtractRateLimitConfig(t *testing.T) {
 			want: RateLimitConfig{
 				BaseURL:     "https://registry.npmjs.org/",
 				DisplayName: "NPM 1",
-				Limit:       2.0,
+				Limit:       3000.0 / 3600.0,
 				IsDefault:   true,
 			},
 		},

--- a/internal/extsvc/types_test.go
+++ b/internal/extsvc/types_test.go
@@ -121,7 +121,7 @@ func TestExtractRateLimitConfig(t *testing.T) {
 			},
 		},
 		{
-			name:        "GitHub default",
+			name:        "GitHub non-default",
 			config:      `{"url": "https://example.com/", "rateLimit": {"enabled": true, "requestsPerHour": 3600}}`,
 			kind:        KindGitHub,
 			displayName: "GitHub 1",
@@ -133,7 +133,7 @@ func TestExtractRateLimitConfig(t *testing.T) {
 			},
 		},
 		{
-			name:        "Bitbucket Server default",
+			name:        "Bitbucket Server non-default",
 			config:      `{"url": "https://example.com/", "rateLimit": {"enabled": true, "requestsPerHour": 3600}}`,
 			kind:        KindBitbucketServer,
 			displayName: "BitbucketServer 1",
@@ -145,13 +145,37 @@ func TestExtractRateLimitConfig(t *testing.T) {
 			},
 		},
 		{
-			name:        "Bitbucket Cloud default",
+			name:        "Bitbucket Cloud non-default",
 			config:      `{"url": "https://example.com/", "rateLimit": {"enabled": true, "requestsPerHour": 3600}}`,
 			kind:        KindBitbucketCloud,
 			displayName: "BitbucketCloud 1",
 			want: RateLimitConfig{
 				BaseURL:     "https://example.com/",
 				DisplayName: "BitbucketCloud 1",
+				Limit:       1.0,
+				IsDefault:   false,
+			},
+		},
+		{
+			name:        "NPM default",
+			config:      `{"registry": "https://registry.npmjs.org"}`,
+			kind:        KindNpmPackages,
+			displayName: "NPM 1",
+			want: RateLimitConfig{
+				BaseURL:     "https://registry.npmjs.org/",
+				DisplayName: "NPM 1",
+				Limit:       2.0,
+				IsDefault:   true,
+			},
+		},
+		{
+			name:        "NPM non-default",
+			config:      `{"registry": "https://registry.npmjs.org", "rateLimit": {"enabled": true, "requestsPerHour": 3600}}`,
+			kind:        KindNpmPackages,
+			displayName: "NPM 1",
+			want: RateLimitConfig{
+				BaseURL:     "https://registry.npmjs.org/",
+				DisplayName: "NPM 1",
 				Limit:       1.0,
 				IsDefault:   false,
 			},

--- a/internal/repos/npm_packages.go
+++ b/internal/repos/npm_packages.go
@@ -38,8 +38,8 @@ func NewNpmPackagesSource(svc *types.ExternalService) (*NpmPackagesSource, error
 	return &NpmPackagesSource{
 		svc:        svc,
 		connection: c,
-		/*dbStore initialized in SetDB */
-		client: npm.NewHTTPClient(c.Registry, c.RateLimit, c.Credentials),
+		/* dbStore initialized in SetDB */
+		client: npm.NewHTTPClient(c.Registry, c.Credentials),
 	}, nil
 }
 


### PR DESCRIPTION
It now follows the the pattern used by other rate limiters where their
rate limit is synced on startup and then updated if the config changes.

We also switch to a stricter, non-infinite rate limiter if none is
specified.

# Test plan

Will confirm after deployment that we no longer see an infinite rate limit.