### PR TITLE
search-blitz: update-deploy.sh updates dogfood

### DIFF
--- a/internal/cmd/search-blitz/scripts/build.sh
+++ b/internal/cmd/search-blitz/scripts/build.sh
@@ -1,7 +1,15 @@
 #!/usr/bin/env bash
 
-set -ex
+set -e
 pushd "$(dirname "${BASH_SOURCE[0]}")/../../../.." >/dev/null
+
+if [ -z "$1" ]; then
+  echo "USAGE $0 VERSION"
+  echo "To see current versions visit https://console.cloud.google.com/gcr/images/sourcegraph-dev/us/search-blitz?project=sourcegraph-dev"
+  exit 1
+fi
+
+set -x
 
 docker build \
   -f ./internal/cmd/search-blitz/Dockerfile \

--- a/internal/cmd/search-blitz/scripts/update-deploy-sourcegraph-dot-com.sh
+++ b/internal/cmd/search-blitz/scripts/update-deploy-sourcegraph-dot-com.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-pushd "$(dirname "${BASH_SOURCE[0]}")/../../../.." >/dev/null
-
-sed -i "" "s/search-blitz:.\{1,2\}\..\{1,2\}\..\{1,2\}/search-blitz:$1/" ../deploy-sourcegraph-cloud/configure/search-blitz/search-blitz.StatefulSet.yaml
-
-popd >/dev/null

--- a/internal/cmd/search-blitz/scripts/update-deploy.sh
+++ b/internal/cmd/search-blitz/scripts/update-deploy.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/../../../.."
+
+export PATH="$PWD/../deploy-sourcegraph-cloud:$PATH"
+
+image="us.gcr.io/sourcegraph-dev/search-blitz:$1"
+
+set -x
+
+cd ../deploy-sourcegraph-cloud
+update-images.py "$image"
+
+cd ../deploy-sourcegraph-dogfood-k8s
+update-images.py "$image"


### PR DESCRIPTION
We now want to update dogfood as well. We also change the script to use
the update-images.py helper.

Additionally I added a helpful error message if build has no arguments.
In particular how to check the current version.

Test Plan: ran both scripts to build 0.1.16
