### PR TITLE
ratelimit: Replace RateLimitConfig with rate.Limit

### DIFF
--- a/internal/extsvc/types.go
+++ b/internal/extsvc/types.go
@@ -373,85 +373,81 @@ func ExtractToken(config string, kind string) (string, error) {
 	}
 }
 
-// ExtractRateLimitConfig extracts the rate limit config from the given args. If rate limiting is not
+// ExtractRateLimit extracts the rate limit from the given args. If rate limiting is not
 // supported the error returned will be an ErrRateLimitUnsupported.
-func ExtractRateLimitConfig(config, kind string) (RateLimitConfig, error) {
+func ExtractRateLimit(config, kind string) (rate.Limit, error) {
 	parsed, err := ParseConfig(kind, config)
 	if err != nil {
-		return RateLimitConfig{}, errors.Wrap(err, "loading service configuration")
+		return rate.Inf, errors.Wrap(err, "loading service configuration")
 	}
 
 	rlc, err := GetLimitFromConfig(kind, parsed)
 	if err != nil {
-		return RateLimitConfig{}, err
+		return rate.Inf, err
 	}
 
 	return rlc, nil
 }
 
-// RateLimitConfig represents the internal rate limit configured for an external service
-type RateLimitConfig struct {
-	Limit rate.Limit
-}
-
 // GetLimitFromConfig gets RateLimitConfig from an already parsed config schema.
-func GetLimitFromConfig(kind string, config interface{}) (rlc RateLimitConfig, err error) {
+func GetLimitFromConfig(kind string, config interface{}) (rate.Limit, error) {
 	// Rate limit config can be in a few states:
 	// 1. Not defined: We fall back to default specified in code.
 	// 2. Defined and enabled: We use their defined limit.
 	// 3. Defined and disabled: We use an infinite limiter.
 
+	var limit rate.Limit
 	switch c := config.(type) {
 	case *schema.GitLabConnection:
 		// 10/s is the default enforced by GitLab on their end
-		rlc.Limit = rate.Limit(10)
+		limit = rate.Limit(10)
 		if c != nil && c.RateLimit != nil {
-			rlc.Limit = limitOrInf(c.RateLimit.Enabled, c.RateLimit.RequestsPerHour)
+			limit = limitOrInf(c.RateLimit.Enabled, c.RateLimit.RequestsPerHour)
 		}
 	case *schema.GitHubConnection:
 		// 5000 per hour is the default enforced by GitHub on their end
-		rlc.Limit = rate.Limit(5000.0 / 3600.0)
+		limit = rate.Limit(5000.0 / 3600.0)
 		if c != nil && c.RateLimit != nil {
-			rlc.Limit = limitOrInf(c.RateLimit.Enabled, c.RateLimit.RequestsPerHour)
+			limit = limitOrInf(c.RateLimit.Enabled, c.RateLimit.RequestsPerHour)
 		}
 	case *schema.BitbucketServerConnection:
 		// 8/s is the default limit we enforce
-		rlc.Limit = rate.Limit(8)
+		limit = rate.Limit(8)
 		if c != nil && c.RateLimit != nil {
-			rlc.Limit = limitOrInf(c.RateLimit.Enabled, c.RateLimit.RequestsPerHour)
+			limit = limitOrInf(c.RateLimit.Enabled, c.RateLimit.RequestsPerHour)
 		}
 	case *schema.BitbucketCloudConnection:
-		rlc.Limit = defaultRateLimit
+		limit = defaultRateLimit
 		if c != nil && c.RateLimit != nil {
-			rlc.Limit = limitOrInf(c.RateLimit.Enabled, c.RateLimit.RequestsPerHour)
+			limit = limitOrInf(c.RateLimit.Enabled, c.RateLimit.RequestsPerHour)
 		}
 	case *schema.PerforceConnection:
-		rlc.Limit = rate.Limit(5000.0 / 3600.0)
+		limit = rate.Limit(5000.0 / 3600.0)
 		if c != nil && c.RateLimit != nil {
-			rlc.Limit = limitOrInf(c.RateLimit.Enabled, c.RateLimit.RequestsPerHour)
+			limit = limitOrInf(c.RateLimit.Enabled, c.RateLimit.RequestsPerHour)
 		}
 	case *schema.JVMPackagesConnection:
-		rlc.Limit = defaultRateLimit
+		limit = defaultRateLimit
 		if c != nil && c.Maven.RateLimit != nil {
-			rlc.Limit = limitOrInf(c.Maven.RateLimit.Enabled, c.Maven.RateLimit.RequestsPerHour)
+			limit = limitOrInf(c.Maven.RateLimit.Enabled, c.Maven.RateLimit.RequestsPerHour)
 		}
 	case *schema.PagureConnection:
 		// 8/s is the default limit we enforce
-		rlc.Limit = rate.Limit(8)
+		limit = rate.Limit(8)
 		if c != nil && c.RateLimit != nil {
-			rlc.Limit = limitOrInf(c.RateLimit.Enabled, c.RateLimit.RequestsPerHour)
+			limit = limitOrInf(c.RateLimit.Enabled, c.RateLimit.RequestsPerHour)
 		}
 	case *schema.NpmPackagesConnection:
 		// 3000 per hour is the same default we use in our schema
-		rlc.Limit = rate.Limit(3000.0 / 3600.0)
+		limit = rate.Limit(3000.0 / 3600.0)
 		if c != nil && c.RateLimit != nil {
-			rlc.Limit = limitOrInf(c.RateLimit.Enabled, c.RateLimit.RequestsPerHour)
+			limit = limitOrInf(c.RateLimit.Enabled, c.RateLimit.RequestsPerHour)
 		}
 	default:
-		return rlc, ErrRateLimitUnsupported{codehostKind: kind}
+		return limit, ErrRateLimitUnsupported{codehostKind: kind}
 	}
 
-	return rlc, nil
+	return limit, nil
 }
 
 func limitOrInf(enabled bool, perHour float64) rate.Limit {

--- a/internal/extsvc/types.go
+++ b/internal/extsvc/types.go
@@ -391,8 +391,7 @@ func ExtractRateLimitConfig(config, kind string) (RateLimitConfig, error) {
 
 // RateLimitConfig represents the internal rate limit configured for an external service
 type RateLimitConfig struct {
-	BaseURL string
-	Limit   rate.Limit
+	Limit rate.Limit
 }
 
 // GetLimitFromConfig gets RateLimitConfig from an already parsed config schema.
@@ -409,63 +408,48 @@ func GetLimitFromConfig(kind string, config interface{}) (rlc RateLimitConfig, e
 		if c != nil && c.RateLimit != nil {
 			rlc.Limit = limitOrInf(c.RateLimit.Enabled, c.RateLimit.RequestsPerHour)
 		}
-		rlc.BaseURL = c.Url
 	case *schema.GitHubConnection:
 		// 5000 per hour is the default enforced by GitHub on their end
 		rlc.Limit = rate.Limit(5000.0 / 3600.0)
 		if c != nil && c.RateLimit != nil {
 			rlc.Limit = limitOrInf(c.RateLimit.Enabled, c.RateLimit.RequestsPerHour)
 		}
-		rlc.BaseURL = c.Url
 	case *schema.BitbucketServerConnection:
 		// 8/s is the default limit we enforce
 		rlc.Limit = rate.Limit(8)
 		if c != nil && c.RateLimit != nil {
 			rlc.Limit = limitOrInf(c.RateLimit.Enabled, c.RateLimit.RequestsPerHour)
 		}
-		rlc.BaseURL = c.Url
 	case *schema.BitbucketCloudConnection:
 		rlc.Limit = defaultRateLimit
 		if c != nil && c.RateLimit != nil {
 			rlc.Limit = limitOrInf(c.RateLimit.Enabled, c.RateLimit.RequestsPerHour)
 		}
-		rlc.BaseURL = c.Url
 	case *schema.PerforceConnection:
 		rlc.Limit = rate.Limit(5000.0 / 3600.0)
 		if c != nil && c.RateLimit != nil {
 			rlc.Limit = limitOrInf(c.RateLimit.Enabled, c.RateLimit.RequestsPerHour)
 		}
-		rlc.BaseURL = c.P4Port
 	case *schema.JVMPackagesConnection:
 		rlc.Limit = defaultRateLimit
 		if c != nil && c.Maven.RateLimit != nil {
 			rlc.Limit = limitOrInf(c.Maven.RateLimit.Enabled, c.Maven.RateLimit.RequestsPerHour)
 		}
-		rlc.BaseURL = "maven"
 	case *schema.PagureConnection:
 		// 8/s is the default limit we enforce
 		rlc.Limit = rate.Limit(8)
 		if c != nil && c.RateLimit != nil {
 			rlc.Limit = limitOrInf(c.RateLimit.Enabled, c.RateLimit.RequestsPerHour)
 		}
-		rlc.BaseURL = c.Url
 	case *schema.NpmPackagesConnection:
 		// 3000 per hour is the same default we use in our schema
 		rlc.Limit = rate.Limit(3000.0 / 3600.0)
 		if c != nil && c.RateLimit != nil {
 			rlc.Limit = limitOrInf(c.RateLimit.Enabled, c.RateLimit.RequestsPerHour)
 		}
-		rlc.BaseURL = c.Registry
 	default:
 		return rlc, ErrRateLimitUnsupported{codehostKind: kind}
 	}
-
-	u, err := url.Parse(rlc.BaseURL)
-	if err != nil {
-		return rlc, errors.Wrap(err, "parsing external service URL")
-	}
-
-	rlc.BaseURL = NormalizeBaseURL(u).String()
 
 	return rlc, nil
 }

--- a/internal/extsvc/types_test.go
+++ b/internal/extsvc/types_test.go
@@ -64,8 +64,7 @@ func TestExtractRateLimitConfig(t *testing.T) {
 			config: `{"url": "https://example.com/"}`,
 			kind:   KindGitLab,
 			want: RateLimitConfig{
-				BaseURL: "https://example.com/",
-				Limit:   10.0,
+				Limit: 10.0,
 			},
 		},
 		{
@@ -73,8 +72,7 @@ func TestExtractRateLimitConfig(t *testing.T) {
 			config: `{"url": "https://example.com/"}`,
 			kind:   KindGitHub,
 			want: RateLimitConfig{
-				BaseURL: "https://example.com/",
-				Limit:   1.3888888888888888,
+				Limit: 1.3888888888888888,
 			},
 		},
 		{
@@ -82,8 +80,7 @@ func TestExtractRateLimitConfig(t *testing.T) {
 			config: `{"url": "https://example.com/"}`,
 			kind:   KindBitbucketServer,
 			want: RateLimitConfig{
-				BaseURL: "https://example.com/",
-				Limit:   8.0,
+				Limit: 8.0,
 			},
 		},
 		{
@@ -91,8 +88,7 @@ func TestExtractRateLimitConfig(t *testing.T) {
 			config: `{"url": "https://example.com/"}`,
 			kind:   KindBitbucketCloud,
 			want: RateLimitConfig{
-				BaseURL: "https://example.com/",
-				Limit:   2.0,
+				Limit: 2.0,
 			},
 		},
 		{
@@ -100,8 +96,7 @@ func TestExtractRateLimitConfig(t *testing.T) {
 			config: `{"url": "https://example.com/", "rateLimit": {"enabled": true, "requestsPerHour": 3600}}`,
 			kind:   KindGitLab,
 			want: RateLimitConfig{
-				BaseURL: "https://example.com/",
-				Limit:   1.0,
+				Limit: 1.0,
 			},
 		},
 		{
@@ -109,8 +104,7 @@ func TestExtractRateLimitConfig(t *testing.T) {
 			config: `{"url": "https://example.com/", "rateLimit": {"enabled": true, "requestsPerHour": 3600}}`,
 			kind:   KindGitHub,
 			want: RateLimitConfig{
-				BaseURL: "https://example.com/",
-				Limit:   1.0,
+				Limit: 1.0,
 			},
 		},
 		{
@@ -118,8 +112,7 @@ func TestExtractRateLimitConfig(t *testing.T) {
 			config: `{"url": "https://example.com/", "rateLimit": {"enabled": true, "requestsPerHour": 3600}}`,
 			kind:   KindBitbucketServer,
 			want: RateLimitConfig{
-				BaseURL: "https://example.com/",
-				Limit:   1.0,
+				Limit: 1.0,
 			},
 		},
 		{
@@ -127,8 +120,7 @@ func TestExtractRateLimitConfig(t *testing.T) {
 			config: `{"url": "https://example.com/", "rateLimit": {"enabled": true, "requestsPerHour": 3600}}`,
 			kind:   KindBitbucketCloud,
 			want: RateLimitConfig{
-				BaseURL: "https://example.com/",
-				Limit:   1.0,
+				Limit: 1.0,
 			},
 		},
 		{
@@ -136,8 +128,7 @@ func TestExtractRateLimitConfig(t *testing.T) {
 			config: `{"registry": "https://registry.npmjs.org"}`,
 			kind:   KindNpmPackages,
 			want: RateLimitConfig{
-				BaseURL: "https://registry.npmjs.org/",
-				Limit:   3000.0 / 3600.0,
+				Limit: 3000.0 / 3600.0,
 			},
 		},
 		{
@@ -145,8 +136,7 @@ func TestExtractRateLimitConfig(t *testing.T) {
 			config: `{"registry": "https://registry.npmjs.org", "rateLimit": {"enabled": true, "requestsPerHour": 3600}}`,
 			kind:   KindNpmPackages,
 			want: RateLimitConfig{
-				BaseURL: "https://registry.npmjs.org/",
-				Limit:   1.0,
+				Limit: 1.0,
 			},
 		},
 		{
@@ -154,8 +144,7 @@ func TestExtractRateLimitConfig(t *testing.T) {
 			config: `{"url": "https://example.com", "rateLimit": {"enabled": true, "requestsPerHour": 3600}}`,
 			kind:   KindBitbucketCloud,
 			want: RateLimitConfig{
-				BaseURL: "https://example.com/",
-				Limit:   1.0,
+				Limit: 1.0,
 			},
 		},
 	} {

--- a/internal/extsvc/types_test.go
+++ b/internal/extsvc/types_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"golang.org/x/time/rate"
 )
 
 func TestExtractToken(t *testing.T) {
@@ -57,99 +58,77 @@ func TestExtractRateLimitConfig(t *testing.T) {
 		name   string
 		config string
 		kind   string
-		want   RateLimitConfig
+		want   rate.Limit
 	}{
 		{
 			name:   "GitLab default",
 			config: `{"url": "https://example.com/"}`,
 			kind:   KindGitLab,
-			want: RateLimitConfig{
-				Limit: 10.0,
-			},
+			want:   10.0,
 		},
 		{
 			name:   "GitHub default",
 			config: `{"url": "https://example.com/"}`,
 			kind:   KindGitHub,
-			want: RateLimitConfig{
-				Limit: 1.3888888888888888,
-			},
+			want:   1.3888888888888888,
 		},
 		{
 			name:   "Bitbucket Server default",
 			config: `{"url": "https://example.com/"}`,
 			kind:   KindBitbucketServer,
-			want: RateLimitConfig{
-				Limit: 8.0,
-			},
+			want:   8.0,
 		},
 		{
 			name:   "Bitbucket Cloud default",
 			config: `{"url": "https://example.com/"}`,
 			kind:   KindBitbucketCloud,
-			want: RateLimitConfig{
-				Limit: 2.0,
-			},
+			want:   2.0,
 		},
 		{
 			name:   "GitLab non-default",
 			config: `{"url": "https://example.com/", "rateLimit": {"enabled": true, "requestsPerHour": 3600}}`,
 			kind:   KindGitLab,
-			want: RateLimitConfig{
-				Limit: 1.0,
-			},
+			want:   1.0,
 		},
 		{
 			name:   "GitHub non-default",
 			config: `{"url": "https://example.com/", "rateLimit": {"enabled": true, "requestsPerHour": 3600}}`,
 			kind:   KindGitHub,
-			want: RateLimitConfig{
-				Limit: 1.0,
-			},
+			want:   1.0,
 		},
 		{
 			name:   "Bitbucket Server non-default",
 			config: `{"url": "https://example.com/", "rateLimit": {"enabled": true, "requestsPerHour": 3600}}`,
 			kind:   KindBitbucketServer,
-			want: RateLimitConfig{
-				Limit: 1.0,
-			},
+			want:   1.0,
 		},
 		{
 			name:   "Bitbucket Cloud non-default",
 			config: `{"url": "https://example.com/", "rateLimit": {"enabled": true, "requestsPerHour": 3600}}`,
 			kind:   KindBitbucketCloud,
-			want: RateLimitConfig{
-				Limit: 1.0,
-			},
+			want:   1.0,
 		},
 		{
 			name:   "NPM default",
 			config: `{"registry": "https://registry.npmjs.org"}`,
 			kind:   KindNpmPackages,
-			want: RateLimitConfig{
-				Limit: 3000.0 / 3600.0,
-			},
+			want:   3000.0 / 3600.0,
 		},
 		{
 			name:   "NPM non-default",
 			config: `{"registry": "https://registry.npmjs.org", "rateLimit": {"enabled": true, "requestsPerHour": 3600}}`,
 			kind:   KindNpmPackages,
-			want: RateLimitConfig{
-				Limit: 1.0,
-			},
+			want:   1.0,
 		},
 		{
 			name:   "No trailing slash",
 			config: `{"url": "https://example.com", "rateLimit": {"enabled": true, "requestsPerHour": 3600}}`,
 			kind:   KindBitbucketCloud,
-			want: RateLimitConfig{
-				Limit: 1.0,
-			},
+			want:   1.0,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			rlc, err := ExtractRateLimitConfig(tc.config, tc.kind)
+			rlc, err := ExtractRateLimit(tc.config, tc.kind)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/extsvc/types_test.go
+++ b/internal/extsvc/types_test.go
@@ -54,147 +54,113 @@ func TestExtractToken(t *testing.T) {
 
 func TestExtractRateLimitConfig(t *testing.T) {
 	for _, tc := range []struct {
-		name        string
-		config      string
-		kind        string
-		displayName string
-		want        RateLimitConfig
+		name   string
+		config string
+		kind   string
+		want   RateLimitConfig
 	}{
 		{
-			name:        "GitLab default",
-			config:      `{"url": "https://example.com/"}`,
-			kind:        KindGitLab,
-			displayName: "GitLab 1",
+			name:   "GitLab default",
+			config: `{"url": "https://example.com/"}`,
+			kind:   KindGitLab,
 			want: RateLimitConfig{
-				BaseURL:     "https://example.com/",
-				DisplayName: "GitLab 1",
-				Limit:       10.0,
-				IsDefault:   true,
+				BaseURL: "https://example.com/",
+				Limit:   10.0,
 			},
 		},
 		{
-			name:        "GitHub default",
-			config:      `{"url": "https://example.com/"}`,
-			kind:        KindGitHub,
-			displayName: "GitHub 1",
+			name:   "GitHub default",
+			config: `{"url": "https://example.com/"}`,
+			kind:   KindGitHub,
 			want: RateLimitConfig{
-				BaseURL:     "https://example.com/",
-				DisplayName: "GitHub 1",
-				Limit:       1.3888888888888888,
-				IsDefault:   true,
+				BaseURL: "https://example.com/",
+				Limit:   1.3888888888888888,
 			},
 		},
 		{
-			name:        "Bitbucket Server default",
-			config:      `{"url": "https://example.com/"}`,
-			kind:        KindBitbucketServer,
-			displayName: "BitbucketServer 1",
+			name:   "Bitbucket Server default",
+			config: `{"url": "https://example.com/"}`,
+			kind:   KindBitbucketServer,
 			want: RateLimitConfig{
-				BaseURL:     "https://example.com/",
-				DisplayName: "BitbucketServer 1",
-				Limit:       8.0,
-				IsDefault:   true,
+				BaseURL: "https://example.com/",
+				Limit:   8.0,
 			},
 		},
 		{
-			name:        "Bitbucket Cloud default",
-			config:      `{"url": "https://example.com/"}`,
-			kind:        KindBitbucketCloud,
-			displayName: "BitbucketCloud 1",
+			name:   "Bitbucket Cloud default",
+			config: `{"url": "https://example.com/"}`,
+			kind:   KindBitbucketCloud,
 			want: RateLimitConfig{
-				BaseURL:     "https://example.com/",
-				DisplayName: "BitbucketCloud 1",
-				Limit:       2.0,
-				IsDefault:   true,
+				BaseURL: "https://example.com/",
+				Limit:   2.0,
 			},
 		},
 		{
-			name:        "GitLab non-default",
-			config:      `{"url": "https://example.com/", "rateLimit": {"enabled": true, "requestsPerHour": 3600}}`,
-			kind:        KindGitLab,
-			displayName: "GitLab 1",
+			name:   "GitLab non-default",
+			config: `{"url": "https://example.com/", "rateLimit": {"enabled": true, "requestsPerHour": 3600}}`,
+			kind:   KindGitLab,
 			want: RateLimitConfig{
-				BaseURL:     "https://example.com/",
-				DisplayName: "GitLab 1",
-				Limit:       1.0,
-				IsDefault:   false,
+				BaseURL: "https://example.com/",
+				Limit:   1.0,
 			},
 		},
 		{
-			name:        "GitHub non-default",
-			config:      `{"url": "https://example.com/", "rateLimit": {"enabled": true, "requestsPerHour": 3600}}`,
-			kind:        KindGitHub,
-			displayName: "GitHub 1",
+			name:   "GitHub non-default",
+			config: `{"url": "https://example.com/", "rateLimit": {"enabled": true, "requestsPerHour": 3600}}`,
+			kind:   KindGitHub,
 			want: RateLimitConfig{
-				BaseURL:     "https://example.com/",
-				DisplayName: "GitHub 1",
-				Limit:       1.0,
-				IsDefault:   false,
+				BaseURL: "https://example.com/",
+				Limit:   1.0,
 			},
 		},
 		{
-			name:        "Bitbucket Server non-default",
-			config:      `{"url": "https://example.com/", "rateLimit": {"enabled": true, "requestsPerHour": 3600}}`,
-			kind:        KindBitbucketServer,
-			displayName: "BitbucketServer 1",
+			name:   "Bitbucket Server non-default",
+			config: `{"url": "https://example.com/", "rateLimit": {"enabled": true, "requestsPerHour": 3600}}`,
+			kind:   KindBitbucketServer,
 			want: RateLimitConfig{
-				BaseURL:     "https://example.com/",
-				DisplayName: "BitbucketServer 1",
-				Limit:       1.0,
-				IsDefault:   false,
+				BaseURL: "https://example.com/",
+				Limit:   1.0,
 			},
 		},
 		{
-			name:        "Bitbucket Cloud non-default",
-			config:      `{"url": "https://example.com/", "rateLimit": {"enabled": true, "requestsPerHour": 3600}}`,
-			kind:        KindBitbucketCloud,
-			displayName: "BitbucketCloud 1",
+			name:   "Bitbucket Cloud non-default",
+			config: `{"url": "https://example.com/", "rateLimit": {"enabled": true, "requestsPerHour": 3600}}`,
+			kind:   KindBitbucketCloud,
 			want: RateLimitConfig{
-				BaseURL:     "https://example.com/",
-				DisplayName: "BitbucketCloud 1",
-				Limit:       1.0,
-				IsDefault:   false,
+				BaseURL: "https://example.com/",
+				Limit:   1.0,
 			},
 		},
 		{
-			name:        "NPM default",
-			config:      `{"registry": "https://registry.npmjs.org"}`,
-			kind:        KindNpmPackages,
-			displayName: "NPM 1",
+			name:   "NPM default",
+			config: `{"registry": "https://registry.npmjs.org"}`,
+			kind:   KindNpmPackages,
 			want: RateLimitConfig{
-				BaseURL:     "https://registry.npmjs.org/",
-				DisplayName: "NPM 1",
-				Limit:       3000.0 / 3600.0,
-				IsDefault:   true,
+				BaseURL: "https://registry.npmjs.org/",
+				Limit:   3000.0 / 3600.0,
 			},
 		},
 		{
-			name:        "NPM non-default",
-			config:      `{"registry": "https://registry.npmjs.org", "rateLimit": {"enabled": true, "requestsPerHour": 3600}}`,
-			kind:        KindNpmPackages,
-			displayName: "NPM 1",
+			name:   "NPM non-default",
+			config: `{"registry": "https://registry.npmjs.org", "rateLimit": {"enabled": true, "requestsPerHour": 3600}}`,
+			kind:   KindNpmPackages,
 			want: RateLimitConfig{
-				BaseURL:     "https://registry.npmjs.org/",
-				DisplayName: "NPM 1",
-				Limit:       1.0,
-				IsDefault:   false,
+				BaseURL: "https://registry.npmjs.org/",
+				Limit:   1.0,
 			},
 		},
 		{
-			name:        "No trailing slash",
-			config:      `{"url": "https://example.com", "rateLimit": {"enabled": true, "requestsPerHour": 3600}}`,
-			kind:        KindBitbucketCloud,
-			displayName: "No Trailing Slash",
+			name:   "No trailing slash",
+			config: `{"url": "https://example.com", "rateLimit": {"enabled": true, "requestsPerHour": 3600}}`,
+			kind:   KindBitbucketCloud,
 			want: RateLimitConfig{
-				BaseURL:     "https://example.com/",
-				DisplayName: "No Trailing Slash",
-				Limit:       1.0,
-				IsDefault:   false,
+				BaseURL: "https://example.com/",
+				Limit:   1.0,
 			},
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			rlc, err := ExtractRateLimitConfig(tc.config, tc.kind, tc.displayName)
+			rlc, err := ExtractRateLimitConfig(tc.config, tc.kind)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/repos/types.go
+++ b/internal/repos/types.go
@@ -58,7 +58,7 @@ func (r *RateLimitSyncer) SyncRateLimiters(ctx context.Context, ids ...int64) er
 		cursor.Offset += len(services)
 
 		for _, svc := range services {
-			rlc, err := extsvc.ExtractRateLimitConfig(svc.Config, svc.Kind)
+			limit, err := extsvc.ExtractRateLimit(svc.Config, svc.Kind)
 			if err != nil {
 				if errors.HasType(err, extsvc.ErrRateLimitUnsupported{}) {
 					continue
@@ -67,7 +67,7 @@ func (r *RateLimitSyncer) SyncRateLimiters(ctx context.Context, ids ...int64) er
 			}
 
 			l := r.registry.Get(svc.URN())
-			l.SetLimit(rlc.Limit)
+			l.SetLimit(limit)
 		}
 
 		if len(services) < int(r.limit) {

--- a/internal/repos/types.go
+++ b/internal/repos/types.go
@@ -58,7 +58,7 @@ func (r *RateLimitSyncer) SyncRateLimiters(ctx context.Context, ids ...int64) er
 		cursor.Offset += len(services)
 
 		for _, svc := range services {
-			rlc, err := extsvc.ExtractRateLimitConfig(svc.Config, svc.Kind, svc.DisplayName)
+			rlc, err := extsvc.ExtractRateLimitConfig(svc.Config, svc.Kind)
 			if err != nil {
 				if errors.HasType(err, extsvc.ErrRateLimitUnsupported{}) {
 					continue


### PR DESCRIPTION
We no longer need to return a `RateLimitConfig` type with extra metadata. All we need is the actual
rate limit. This data was needed in the past for some error messages we passed back when saving a 
config with rate limiting but that was removed a while back.

## Test plan

Only removal of code that was no longer used. All tests still pass.