### PR TITLE
Quick start tour updates. part 1

### DIFF
--- a/client/web/src/repo/actions/InstallIntegrationsAlert.tsx
+++ b/client/web/src/repo/actions/InstallIntegrationsAlert.tsx
@@ -5,6 +5,7 @@ import { useLocalStorage } from '@sourcegraph/wildcard'
 
 import { usePersistentCadence } from '../../hooks'
 import { useIsActiveIdeIntegrationUser } from '../../IdeExtensionTracker'
+import { useTourQueryParameters } from '../../tour/components/Tour/TourAgent'
 import { useIsBrowserExtensionActiveUser } from '../../tracking/BrowserExtensionTracker'
 import { HOVER_COUNT_KEY, HOVER_THRESHOLD } from '../RepoContainer'
 
@@ -53,8 +54,14 @@ export const InstallIntegrationsAlert: React.FunctionComponent<InstallIntegratio
         false
     )
 
+    const tourQueryParameters = useTourQueryParameters()
+
     const ctaToDisplay = useMemo<CtaToDisplay | undefined>(
         (): CtaToDisplay | undefined => {
+            if (tourQueryParameters?.isTour) {
+                return
+            }
+
             if (
                 isBrowserExtensionActiveUser === false &&
                 displayBrowserExtensionCTABasedOnCadence &&
@@ -72,7 +79,7 @@ export const InstallIntegrationsAlert: React.FunctionComponent<InstallIntegratio
                 return 'ide'
             }
 
-            return undefined
+            return
         },
         /**
          * Intentionally use useMemo() here without a dependency on hoverCount to only show the alert on the next reload,
@@ -86,6 +93,7 @@ export const InstallIntegrationsAlert: React.FunctionComponent<InstallIntegratio
             hasDismissedIDEExtensionAlert,
             isBrowserExtensionActiveUser,
             isUsingIdeIntegration,
+            tourQueryParameters,
         ]
     )
 

--- a/client/web/src/search/home/LoggedOutHomepage.module.scss
+++ b/client/web/src/search/home/LoggedOutHomepage.module.scss
@@ -217,13 +217,14 @@
     width: 18rem;
 
     @media (--md-breakpoint-down) {
-        max-width: 50%;
+        max-width: 40%;
         flex: 1;
     }
 
     @media (--sm-breakpoint-down) {
         max-width: 100%;
         width: 100%;
+        flex: initial;
     }
 }
 

--- a/client/web/src/search/home/LoggedOutHomepage.tsx
+++ b/client/web/src/search/home/LoggedOutHomepage.tsx
@@ -69,8 +69,8 @@ export const LoggedOutHomepage: React.FunctionComponent<LoggedOutHomepageProps> 
         <div className={styles.loggedOutHomepage}>
             <div className={styles.content}>
                 <GettingStartedTour
-                    height={7.5}
-                    className={styles.gettingStartedTour}
+                    height={8}
+                    className={classNames(styles.gettingStartedTour, 'h-100')}
                     telemetryService={props.telemetryService}
                     featureFlags={props.featureFlags}
                     isSourcegraphDotCom={true}

--- a/client/web/src/search/results/StreamingSearchResults.tsx
+++ b/client/web/src/search/results/StreamingSearchResults.tsx
@@ -41,6 +41,7 @@ import {
     useSearchStack,
     buildSearchURLQueryFromQueryState,
 } from '../../stores'
+import { useTourQueryParameters } from '../../tour/components/Tour/TourAgent'
 import { GettingStartedTour } from '../../tour/GettingStartedTour'
 import { useIsBrowserExtensionActiveUser } from '../../tracking/BrowserExtensionTracker'
 import { SearchUserNeedsCodeHost } from '../../user/settings/codeHosts/OrgUserNeedsCodeHost'
@@ -116,8 +117,13 @@ function useCtaAlert(
         IDE_CTA_CADENCE_SHIFT
     )
 
+    const tourQueryParameters = useTourQueryParameters()
+
     const ctaToDisplay = useMemo<CtaToDisplay | undefined>((): CtaToDisplay | undefined => {
         if (!areResultsFound) {
+            return
+        }
+        if (tourQueryParameters?.isTour) {
             return
         }
 
@@ -145,14 +151,15 @@ function useCtaAlert(
         return
     }, [
         areResultsFound,
+        tourQueryParameters?.isTour,
         hasDismissedSignupAlert,
         isAuthenticated,
         displaySignupAndBrowserExtensionCTAsBasedOnCadence,
         hasDismissedBrowserExtensionAlert,
         isBrowserExtensionActiveUser,
         isUsingIdeIntegration,
-        hasDismissedIDEExtensionAlert,
         displayIDEExtensionCTABasedOnCadence,
+        hasDismissedIDEExtensionAlert,
     ])
 
     const onCtaAlertDismissed = useCallback((): void => {

--- a/client/web/src/tour/components/ItemPicker.module.scss
+++ b/client/web/src/tour/components/ItemPicker.module.scss
@@ -6,7 +6,7 @@
     &:hover {
         background-color: var(--oc-blue-1);
 
-        :global(.theme-dark) > & {
+        :global(.theme-dark) & {
             background-color: var(--oc-blue-7);
         }
     }

--- a/client/web/src/tour/components/Tour/TourAgent.tsx
+++ b/client/web/src/tour/components/Tour/TourAgent.tsx
@@ -18,6 +18,20 @@ interface TourAgentProps extends TelemetryProps {
     onStepComplete: (step: TourTaskStepType) => void
 }
 
+export function useTourQueryParameters(): ReturnType<typeof parseURIMarkers> | undefined {
+    const location = useLocation()
+    const [data, setData] = useState<ReturnType<typeof parseURIMarkers> | undefined>()
+    useEffect(() => {
+        const { isTour, stepId } = parseURIMarkers(location.search)
+        if (!isTour || !stepId) {
+            return
+        }
+        setData({ isTour, stepId })
+    }, [location])
+
+    return data
+}
+
 /**
  * Component to track TourTaskStepType.completeAfterEvents and show info box for steps.
  */
@@ -37,19 +51,14 @@ export const TourAgent: React.FunctionComponent<TourAgentProps> = React.memo(
         // Agent 2: Track info panel
         const [info, setInfo] = useState<TourTaskStepType['info'] | undefined>()
 
-        const location = useLocation()
+        const tourQueryParameters = useTourQueryParameters()
 
         useEffect(() => {
-            const { isTour, stepId } = parseURIMarkers(location.search)
-            if (!isTour || !stepId) {
-                return
-            }
-
-            const info = tasks.flatMap(task => task.steps).find(step => stepId === step.id)?.info
+            const info = tasks.flatMap(task => task.steps).find(step => tourQueryParameters?.stepId === step.id)?.info
             if (info) {
                 setInfo(info)
             }
-        }, [tasks, location])
+        }, [tasks, tourQueryParameters?.stepId])
 
         if (!info) {
             return null

--- a/client/web/src/tour/components/Tour/TourContent.tsx
+++ b/client/web/src/tour/components/Tour/TourContent.tsx
@@ -31,6 +31,19 @@ const Header: React.FunctionComponent<{ onClose: () => void }> = ({ children, on
     </div>
 )
 
+const Footer: React.FunctionComponent<{ completedCount: number; totalCount: number }> = ({
+    completedCount,
+    totalCount,
+}) => (
+    <p className="text-right mt-2 mb-0">
+        <Icon
+            as={CheckCircleIcon}
+            className={classNames('mr-1', completedCount === 0 ? 'text-muted' : 'text-success')}
+        />
+        {completedCount} of {totalCount} completed
+    </p>
+)
+
 const CompletedItem: React.FunctionComponent = ({ children }) => (
     <div className="d-flex align-items-start">
         <Icon as={CheckCircleIcon} size="sm" className={classNames('text-success mr-1', styles.completedCheckIcon)} />
@@ -61,11 +74,7 @@ export const TourContent: React.FunctionComponent<TourContentProps> = ({
             {variant === 'horizontal' && <Header onClose={onClose}>Don't show again</Header>}
             <MarketingBlock
                 wrapperClassName={classNames('w-100 d-flex', variant !== 'horizontal' && styles.marketingBlockWrapper)}
-                contentClassName={classNames(
-                    styles.marketingBlockContent,
-                    'w-100 d-flex flex-column',
-                    variant === 'horizontal' ? 'pt-3 pb-1' : 'py-3'
-                )}
+                contentClassName={classNames(styles.marketingBlockContent, 'w-100 d-flex flex-column pt-3 pb-1')}
             >
                 {variant !== 'horizontal' && <Header onClose={onClose} />}
                 <div
@@ -97,11 +106,9 @@ export const TourContent: React.FunctionComponent<TourContentProps> = ({
                         </div>
                     )}
                 </div>
+                {variant !== 'horizontal' && <Footer completedCount={completedCount} totalCount={totalCount} />}
             </MarketingBlock>
-            <p className="text-right mt-2 mb-0">
-                <Icon as={CheckCircleIcon} className="text-success" />
-                {completedCount} of {totalCount} completed
-            </p>
+            {variant === 'horizontal' && <Footer completedCount={completedCount} totalCount={totalCount} />}
         </div>
     )
 }

--- a/client/web/src/tour/data/index.tsx
+++ b/client/web/src/tour/data/index.tsx
@@ -305,7 +305,7 @@ export const authenticatedTasks: TourTaskType[] = [
         ],
     },
     {
-        title: 'Quickly understand a new codebase',
+        title: 'Understand a new codebase',
         icon: <CursorPointerIcon size="2.3rem" />,
         steps: [
             {


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/33339.

## Description 
This PR:
- Updates the checkbox icon color to when at 0 completed and make the distance between the icon and text 4px
- Moves completion status inside quick start when displayed vertically
- Fixes dark theme styles for the language selector
- Disables SignUp/IDE/BEXT install CTA on results/file pages when showing tour info panel
- Removes "Quickly" from "Understand a new codebase" from authenticated tour version

## Test plan
- `SOURCEGRAPH_API_URL=https://sourcegraph.com SOURCEGRAPHDOTCOM_MODE=true sg -skip-auto-update=true start web-standalone`
- Open https://sourcegraph.test:3443/search as non-signed in user
- Check tour for the above changes/fixes from "Decription" section ☝️ 


## Screenshots
| BEFORE | AFTER |
| --: | :-- |
| ![image](https://user-images.githubusercontent.com/6717049/162428715-2242851c-dfb3-401a-9a2f-bcb2c3b97f1d.png) | ![image](https://user-images.githubusercontent.com/6717049/162429301-81248cc4-ec28-4c8b-bd0c-6ab7b728b8eb.png) |
| ![image](https://user-images.githubusercontent.com/6717049/162429472-766adc73-0d54-458a-96ba-57b8c4ebd20d.png) | ![image](https://user-images.githubusercontent.com/6717049/162429507-1ba4cf02-0741-4778-a8a0-a30cb376d8ba.png) |
| ![image](https://user-images.githubusercontent.com/6717049/162430219-6e1c45c4-91ab-4d54-8da3-c9ca7cc349d4.png) | ![image](https://user-images.githubusercontent.com/6717049/162430284-9a823b16-a3ff-4c28-95ef-a0350f9488a6.png) |


<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->



## App preview:

- [Link](https://sg-web-erzhtor-quick-start-tour-updates.onrender.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

