### PR TITLE
Refactoring to accept multiple org identifiers in one call to DB

### DIFF
--- a/cmd/frontend/graphqlbackend/affiliated_repositories_connection.go
+++ b/cmd/frontend/graphqlbackend/affiliated_repositories_connection.go
@@ -46,7 +46,7 @@ func (a *affiliatedRepositoriesConnection) getNodesAndErrors(ctx context.Context
 		if a.codeHost == 0 {
 			svcs, err = a.db.ExternalServices().List(ctx, database.ExternalServicesListOptions{
 				NamespaceUserID: a.userID,
-				NamespaceOrgID:  a.orgID,
+				NamespaceOrgIDs: []int32{a.orgID},
 			})
 			if err != nil {
 				a.err = err

--- a/cmd/frontend/graphqlbackend/external_services.go
+++ b/cmd/frontend/graphqlbackend/external_services.go
@@ -300,7 +300,10 @@ func (r *schemaResolver) ExternalServices(ctx context.Context, args *ExternalSer
 			return nil, err
 		}
 	}
-
+	var orgIDs []int32
+	if namespaceOrgID > 0 {
+		orgIDs = append(orgIDs, namespaceOrgID)
+	}
 	opt := database.ExternalServicesListOptions{
 		// 🚨 SECURITY: When both `namespaceUserID` and `namespaceOrgID` are not
 		// specified we need to explicitly specify `NoNamespace`, otherwise site
@@ -308,7 +311,7 @@ func (r *schemaResolver) ExternalServices(ctx context.Context, args *ExternalSer
 		// accessible when trying to access them individually.
 		NoNamespace:     namespaceUserID == 0 && namespaceOrgID == 0,
 		NamespaceUserID: namespaceUserID,
-		NamespaceOrgID:  namespaceOrgID,
+		NamespaceOrgIDs: orgIDs,
 		AfterID:         afterID,
 	}
 	args.ConnectionArgs.Set(&opt.LimitOffset)

--- a/cmd/frontend/graphqlbackend/org.go
+++ b/cmd/frontend/graphqlbackend/org.go
@@ -247,7 +247,7 @@ func (o *OrgResolver) ViewerNeedsCodeHostUpdate(ctx context.Context) (bool, erro
 	if _, err := o.db.OrgMembers().GetByOrgIDAndUserID(ctx, o.org.ID, actor.UID); err != nil {
 		return false, nil
 	}
-	orgServices, err := o.db.ExternalServices().List(ctx, database.ExternalServicesListOptions{Kinds: []string{extsvc.KindGitHub}, NamespaceOrgID: o.OrgID()})
+	orgServices, err := o.db.ExternalServices().List(ctx, database.ExternalServicesListOptions{Kinds: []string{extsvc.KindGitHub}, NamespaceOrgIDs: []int32{o.OrgID()}})
 	if err != nil {
 		return false, err
 	}

--- a/cmd/frontend/graphqlbackend/org_test.go
+++ b/cmd/frontend/graphqlbackend/org_test.go
@@ -627,7 +627,7 @@ func TestOrganization_viewerNeedsCodeHostUpdate(t *testing.T) {
 				if opts.NamespaceUserID == 1 {
 					return test.UserServices, nil
 				}
-				if opts.NamespaceOrgID == 1 {
+				if len(opts.NamespaceOrgIDs) == 1 && opts.NamespaceOrgIDs[0] == 1 {
 					return test.OrgServices, nil
 				}
 				return nil, nil

--- a/cmd/frontend/graphqlbackend/user.go
+++ b/cmd/frontend/graphqlbackend/user.go
@@ -581,14 +581,11 @@ func viewerNeedsCodeHostUpgrade(ctx context.Context, db database.DB, userID int3
 	if len(queryFor) == 0 {
 		return false
 	}
-	orgServices := []*types.ExternalService{}
-	for _, orgID := range queryFor {
-		s, err := db.ExternalServices().List(ctx, database.ExternalServicesListOptions{Kinds: []string{extsvc.KindGitHub}, NamespaceOrgID: orgID})
-		if err != nil {
-			return false
-		}
-		orgServices = append(orgServices, s...)
+	orgServices, err := db.ExternalServices().List(ctx, database.ExternalServicesListOptions{Kinds: []string{extsvc.KindGitHub}, NamespaceOrgIDs: queryFor})
+	if err != nil {
+		return false
 	}
+
 	if len(orgServices) == 0 {
 		return false
 	}

--- a/enterprise/cmd/frontend/internal/app/app.go
+++ b/enterprise/cmd/frontend/internal/app/app.go
@@ -221,8 +221,8 @@ func newGitHubAppCloudSetupHandler(db database.DB, apiURL *url.URL, client githu
 		externalServices := db.ExternalServices()
 		svcs, err := externalServices.List(r.Context(),
 			database.ExternalServicesListOptions{
-				NamespaceOrgID: org.ID,
-				Kinds:          []string{extsvc.KindGitHub},
+				NamespaceOrgIDs: []int32{org.ID},
+				Kinds:           []string{extsvc.KindGitHub},
 			},
 		)
 		if err != nil {


### PR DESCRIPTION
Refactoring to accept multiple Org identifiers in one call to DB (to avoid SELECT N+1).
## Test plan

- tested E2E locally
- all unit tests pass
- new unit tests added
## App preview:
- [Link](https://sg-web-cloud-317-refactor.onrender.com)

