### PR TITLE
repo-updater: Sync rate limiter before service

### DIFF
--- a/cmd/repo-updater/repoupdater/server.go
+++ b/cmd/repo-updater/repoupdater/server.go
@@ -231,15 +231,15 @@ func (s *Server) handleExternalServiceSync(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	if err := s.Syncer.TriggerExternalServiceSync(ctx, req.ExternalService.ID); err != nil {
-		log15.Warn("Enqueueing external service sync job", "error", err, "id", req.ExternalService.ID)
-	}
-
 	if s.RateLimitSyncer != nil {
 		err = s.RateLimitSyncer.SyncRateLimiters(ctx, req.ExternalService.ID)
 		if err != nil {
 			log15.Warn("Handling rate limiter sync", "err", err, "id", req.ExternalService.ID)
 		}
+	}
+
+	if err := s.Syncer.TriggerExternalServiceSync(ctx, req.ExternalService.ID); err != nil {
+		log15.Warn("Enqueueing external service sync job", "error", err, "id", req.ExternalService.ID)
 	}
 
 	log15.Info("server.external-service-sync", "synced", req.ExternalService.Kind)

--- a/cmd/repo-updater/shared/main.go
+++ b/cmd/repo-updater/shared/main.go
@@ -136,12 +136,11 @@ func Main(enterpriseInit EnterpriseInit) {
 		Scheduler:             updateScheduler,
 		GitserverClient:       gitserver.NewClient(db),
 		SourcegraphDotComMode: envvar.SourcegraphDotComMode(),
+		RateLimitSyncer:       repos.NewRateLimitSyncer(ratelimit.DefaultRegistry, store.ExternalServiceStore),
 	}
 
-	rateLimitSyncer := repos.NewRateLimitSyncer(ratelimit.DefaultRegistry, store.ExternalServiceStore)
-	server.RateLimitSyncer = rateLimitSyncer
 	// Attempt to perform an initial sync with all external services
-	if err := rateLimitSyncer.SyncRateLimiters(ctx); err != nil {
+	if err := server.RateLimitSyncer.SyncRateLimiters(ctx); err != nil {
 		// This is not a fatal error since the syncer has been added to the server above
 		// and will still be run whenever an external service is added or updated
 		log15.Error("Performing initial rate limit sync", "err", err)


### PR DESCRIPTION
When a new service is added then syncing the service first means we
won't have a rate limiter in place yet. When we first attempt to make an
API call we'll lazily add a default infinite limiter.

In theory the rate limit sync should replace it shortly afterwards but
we're seeing cases of infinite limiters in production and this is one
area that could be the culprit.

We have a 15 second timeout when performing the initial sync so what may be
happening in production is that the initial sync takes longer than 15 seconds in
some cases so the sync fails and we don't get to the point in the code where we
sync the rate limiter.

## Test plan

Tested locally