### PR TITLE
Add metric for KMS.Encrypt payload size

### DIFF
--- a/internal/encryption/cloudkms/cloud_kms.go
+++ b/internal/encryption/cloudkms/cloud_kms.go
@@ -9,10 +9,11 @@ import (
 	"strings"
 
 	kms "cloud.google.com/go/kms/apiv1"
-	"github.com/sourcegraph/sourcegraph/lib/errors"
 	"google.golang.org/api/option"
 	kmspb "google.golang.org/genproto/googleapis/cloud/kms/v1"
 	"google.golang.org/protobuf/types/known/wrapperspb"
+
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 
 	"github.com/sourcegraph/sourcegraph/internal/encryption"
 	"github.com/sourcegraph/sourcegraph/schema"
@@ -98,6 +99,7 @@ func (k *Key) Decrypt(ctx context.Context, cipherText []byte) (_ *encryption.Sec
 func (k *Key) Encrypt(ctx context.Context, plaintext []byte) (_ []byte, err error) {
 	defer func() {
 		cryptographicTotal.WithLabelValues("encrypt", strconv.FormatBool(err == nil)).Inc()
+		encryptPayloadSize.WithLabelValues(strconv.FormatBool(err == nil)).Observe(float64(len(plaintext)) / 1024)
 	}()
 
 	// encrypt plaintext

--- a/internal/encryption/cloudkms/metrics.go
+++ b/internal/encryption/cloudkms/metrics.go
@@ -13,4 +13,11 @@ var (
 		},
 		[]string{"operation", "success"},
 	)
+	encryptPayloadSize = promauto.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "src_cloudkms_encrypt_payload_kilobytes",
+			Help:    "Size of payload to be encrypted by Cloud KMS (in kilobytes)",
+			Buckets: []float64{1, 2, 5, 10, 50, 100, 200},
+		}, []string{"success"},
+	)
 )


### PR DESCRIPTION
Add a metric to track size of payload we encrypt using CloudKMS.
Only tracks size during encryption (not to produce too much data). 
Some context in [CLOUD-336](https://sourcegraph.atlassian.net/browse/CLOUD-336)
## Test plan

- adds a metric only
- tested locally with a different encryption provider


