### PR TITLE
npm: Use external service urn for rate limiter

### DIFF
--- a/cmd/gitserver/main.go
+++ b/cmd/gitserver/main.go
@@ -378,28 +378,29 @@ func getVCSSyncer(ctx context.Context, externalServiceStore database.ExternalSer
 		return nil, errors.Wrap(err, "get repository")
 	}
 
-	extractOptions := func(connection interface{}) error {
+	extractOptions := func(connection interface{}) (string, error) {
 		for _, info := range r.Sources {
 			extSvc, err := externalServiceStore.GetByID(ctx, info.ExternalServiceID())
 			if err != nil {
-				return errors.Wrap(err, "get external service")
+				return "", errors.Wrap(err, "get external service")
 			}
+			urn := extSvc.URN()
 			normalized, err := jsonc.Parse(extSvc.Config)
 			if err != nil {
-				return errors.Wrap(err, "normalize JSON")
+				return "", errors.Wrap(err, "normalize JSON")
 			}
 			if err = jsoniter.Unmarshal(normalized, connection); err != nil {
-				return errors.Wrap(err, "unmarshal JSON")
+				return "", errors.Wrap(err, "unmarshal JSON")
 			}
-			return nil
+			return urn, nil
 		}
-		return errors.Errorf("unexpected empty Sources map in %v", r)
+		return "", errors.Errorf("unexpected empty Sources map in %v", r)
 	}
 
 	switch r.ExternalRepo.ServiceType {
 	case extsvc.TypePerforce:
 		var c schema.PerforceConnection
-		if err := extractOptions(&c); err != nil {
+		if _, err := extractOptions(&c); err != nil {
 			return nil, err
 		}
 		return &server.PerforceDepotSyncer{
@@ -409,19 +410,20 @@ func getVCSSyncer(ctx context.Context, externalServiceStore database.ExternalSer
 		}, nil
 	case extsvc.TypeJVMPackages:
 		var c schema.JVMPackagesConnection
-		if err := extractOptions(&c); err != nil {
+		if _, err := extractOptions(&c); err != nil {
 			return nil, err
 		}
 		return &server.JVMPackagesSyncer{Config: &c, DepsStore: codeintelDB}, nil
 	case extsvc.TypeNpmPackages:
 		var c schema.NpmPackagesConnection
-		if err := extractOptions(&c); err != nil {
+		urn, err := extractOptions(&c)
+		if err != nil {
 			return nil, err
 		}
-		return server.NewNpmPackagesSyncer(c, codeintelDB, nil), nil
+		return server.NewNpmPackagesSyncer(c, codeintelDB, nil, urn), nil
 	case extsvc.TypeGoModules:
 		var c schema.GoModulesConnection
-		if err := extractOptions(&c); err != nil {
+		if _, err := extractOptions(&c); err != nil {
 			return nil, err
 		}
 		cli := gomodproxy.NewClient(&c, httpcli.ExternalDoer)

--- a/cmd/gitserver/main.go
+++ b/cmd/gitserver/main.go
@@ -384,7 +384,6 @@ func getVCSSyncer(ctx context.Context, externalServiceStore database.ExternalSer
 			if err != nil {
 				return "", errors.Wrap(err, "get external service")
 			}
-			urn := extSvc.URN()
 			normalized, err := jsonc.Parse(extSvc.Config)
 			if err != nil {
 				return "", errors.Wrap(err, "normalize JSON")
@@ -392,7 +391,7 @@ func getVCSSyncer(ctx context.Context, externalServiceStore database.ExternalSer
 			if err = jsoniter.Unmarshal(normalized, connection); err != nil {
 				return "", errors.Wrap(err, "unmarshal JSON")
 			}
-			return urn, nil
+			return extSvc.URN(), nil
 		}
 		return "", errors.Errorf("unexpected empty Sources map in %v", r)
 	}

--- a/cmd/gitserver/server/vcs_syncer_npm_packages.go
+++ b/cmd/gitserver/server/vcs_syncer_npm_packages.go
@@ -49,10 +49,11 @@ func NewNpmPackagesSyncer(
 	connection schema.NpmPackagesConnection,
 	dbStore repos.DependenciesStore,
 	customClient npm.Client,
+	urn string,
 ) *NpmPackagesSyncer {
 	var client = customClient
 	if client == nil {
-		client = npm.NewHTTPClient(connection.Registry, connection.Credentials)
+		client = npm.NewHTTPClient(urn, connection.Registry, connection.Credentials)
 	}
 	return &NpmPackagesSyncer{connection, dbStore, client}
 }

--- a/cmd/gitserver/server/vcs_syncer_npm_packages_test.go
+++ b/cmd/gitserver/server/vcs_syncer_npm_packages_test.go
@@ -56,6 +56,7 @@ func TestNoMaliciousFilesNpm(t *testing.T) {
 		schema.NpmPackagesConnection{Dependencies: []string{}},
 		NewMockDependenciesStore(),
 		nil,
+		"urn",
 	)
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // cancel now  to prevent any network IO
@@ -119,6 +120,7 @@ func TestNpmCloneCommand(t *testing.T) {
 		schema.NpmPackagesConnection{Dependencies: []string{}},
 		NewMockDependenciesStore(),
 		&client,
+		"urn",
 	)
 	bareGitDirectory := path.Join(dir, "git")
 	s.runCloneCommand(t, bareGitDirectory, []string{exampleNpmVersionedPackage})

--- a/internal/extsvc/npm/npm.go
+++ b/internal/extsvc/npm/npm.go
@@ -92,8 +92,8 @@ type HTTPClient struct {
 	credentials string
 }
 
-func NewHTTPClient(registryURL string, credentials string) *HTTPClient {
-	cachedLimiter := ratelimit.DefaultRegistry.Get(registryURL)
+func NewHTTPClient(urn string, registryURL string, credentials string) *HTTPClient {
+	cachedLimiter := ratelimit.DefaultRegistry.Get(urn)
 	return &HTTPClient{
 		registryURL,
 		httpcli.ExternalDoer,

--- a/internal/extsvc/npm/npm_test.go
+++ b/internal/extsvc/npm/npm_test.go
@@ -34,7 +34,7 @@ var updateRecordings = flag.Bool("update", false, "make npm API calls, record an
 func newTestHTTPClient(t *testing.T) (client *HTTPClient, stop func()) {
 	t.Helper()
 	recorderFactory, stop := httptestutil.NewRecorderFactory(t, *updateRecordings, t.Name())
-	client = NewHTTPClient("https://registry.npmjs.org", "")
+	client = NewHTTPClient("urn", "https://registry.npmjs.org", "")
 	doer, err := recorderFactory.Doer()
 	require.Nil(t, err)
 	client.doer = doer
@@ -76,7 +76,7 @@ func TestCredentials(t *testing.T) {
 	defer server.Close()
 
 	ctx := context.Background()
-	client := NewHTTPClient(server.URL, credentials)
+	client := NewHTTPClient("urn", server.URL, credentials)
 
 	presentDep, err := reposource.ParseNpmDependency("left-pad@1.3.0")
 	require.NoError(t, err)

--- a/internal/repos/npm_packages.go
+++ b/internal/repos/npm_packages.go
@@ -39,7 +39,7 @@ func NewNpmPackagesSource(svc *types.ExternalService) (*NpmPackagesSource, error
 		svc:        svc,
 		connection: c,
 		/* dbStore initialized in SetDB */
-		client: npm.NewHTTPClient(c.Registry, c.Credentials),
+		client: npm.NewHTTPClient(svc.URN(), c.Registry, c.Credentials),
 	}, nil
 }
 


### PR DESCRIPTION
This is consistent with all the other rate limiters.

## Test plan

All tests continue to pass.
Once deployed will confirm that the npm service no longer has an infinite rate limiter.