### PR TITLE
Insights:  Optional batching of commit indexer

### DIFF
--- a/enterprise/internal/insights/background/background.go
+++ b/enterprise/internal/insights/background/background.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"os"
 	"strconv"
+	"time"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/background/pings"
 	"github.com/sourcegraph/sourcegraph/internal/database"
@@ -56,7 +57,7 @@ func GetBackgroundJobs(ctx context.Context, mainAppDB *sql.DB, insightsDB *sql.D
 	}
 
 	// todo(insights) add setting to disable this indexer
-	routines = append(routines, compression.NewCommitIndexerWorker(ctx, database.NewDB(mainAppDB), insightsDB, observationContext))
+	routines = append(routines, compression.NewCommitIndexerWorker(ctx, database.NewDB(mainAppDB), insightsDB, time.Now, observationContext))
 
 	// Register the background goroutine which discovers historical gaps in data and enqueues
 	// work to fill them - if not disabled.

--- a/enterprise/internal/insights/compression/commits.go
+++ b/enterprise/internal/insights/compression/commits.go
@@ -23,8 +23,8 @@ type CommitStore interface {
 	Save(ctx context.Context, id api.RepoID, commit *gitdomain.Commit, debugInfo string) error
 	Get(ctx context.Context, id api.RepoID, start time.Time, end time.Time) ([]CommitStamp, error)
 	GetMetadata(ctx context.Context, id api.RepoID) (CommitIndexMetadata, error)
-	UpsertMetadataStamp(ctx context.Context, id api.RepoID) (CommitIndexMetadata, error)
-	InsertCommits(ctx context.Context, id api.RepoID, commits []*gitdomain.Commit, debugInfo string) error
+	UpsertMetadataStamp(ctx context.Context, id api.RepoID, indexedThrough time.Time) (CommitIndexMetadata, error)
+	InsertCommits(ctx context.Context, id api.RepoID, commits []*gitdomain.Commit, commitsUntil time.Time, debugInfo string) error
 }
 
 func NewCommitStore(db dbutil.DB) *DBCommitStore {
@@ -52,7 +52,7 @@ func (c *DBCommitStore) Save(ctx context.Context, id api.RepoID, commit *gitdoma
 	return nil
 }
 
-func (c *DBCommitStore) InsertCommits(ctx context.Context, id api.RepoID, commits []*gitdomain.Commit, debugInfo string) (err error) {
+func (c *DBCommitStore) InsertCommits(ctx context.Context, id api.RepoID, commits []*gitdomain.Commit, commitsUntil time.Time, debugInfo string) (err error) {
 	tx, err := c.Transact(ctx)
 	if err != nil {
 		return err
@@ -66,7 +66,7 @@ func (c *DBCommitStore) InsertCommits(ctx context.Context, id api.RepoID, commit
 		}
 	}
 
-	if _, err = tx.UpsertMetadataStamp(ctx, id); err != nil {
+	if _, err = tx.UpsertMetadataStamp(ctx, id, commitsUntil); err != nil {
 		return err
 	}
 
@@ -108,8 +108,8 @@ func (c *DBCommitStore) GetMetadata(ctx context.Context, id api.RepoID) (CommitI
 }
 
 // UpsertMetadataStamp inserts (or updates, if the row already exists) the index metadata timestamp for a given repository
-func (c *DBCommitStore) UpsertMetadataStamp(ctx context.Context, id api.RepoID) (CommitIndexMetadata, error) {
-	row := c.QueryRow(ctx, sqlf.Sprintf(upsertCommitIndexMetadataStampStr, id))
+func (c *DBCommitStore) UpsertMetadataStamp(ctx context.Context, id api.RepoID, indexedThrough time.Time) (CommitIndexMetadata, error) {
+	row := c.QueryRow(ctx, sqlf.Sprintf(upsertCommitIndexMetadataStampStr, id, indexedThrough))
 
 	var metadata CommitIndexMetadata
 	if err := row.Scan(&metadata.RepoId, &metadata.Enabled, &metadata.LastIndexedAt); err != nil {
@@ -154,6 +154,6 @@ const upsertCommitIndexMetadataStampStr = `
 INSERT INTO commit_index_metadata(repo_id)
 VALUES (%v)
 ON CONFLICT (repo_id) DO UPDATE
-SET last_indexed_at = CURRENT_TIMESTAMP
+SET last_indexed_at = %v
 RETURNING repo_id, enabled, last_indexed_at;
 `

--- a/enterprise/internal/insights/compression/commits.go
+++ b/enterprise/internal/insights/compression/commits.go
@@ -24,7 +24,7 @@ type CommitStore interface {
 	Get(ctx context.Context, id api.RepoID, start time.Time, end time.Time) ([]CommitStamp, error)
 	GetMetadata(ctx context.Context, id api.RepoID) (CommitIndexMetadata, error)
 	UpsertMetadataStamp(ctx context.Context, id api.RepoID, indexedThrough time.Time) (CommitIndexMetadata, error)
-	InsertCommits(ctx context.Context, id api.RepoID, commits []*gitdomain.Commit, commitsUntil time.Time, debugInfo string) error
+	InsertCommits(ctx context.Context, id api.RepoID, commits []*gitdomain.Commit, indexedThrough time.Time, debugInfo string) error
 }
 
 func NewCommitStore(db dbutil.DB) *DBCommitStore {
@@ -52,7 +52,7 @@ func (c *DBCommitStore) Save(ctx context.Context, id api.RepoID, commit *gitdoma
 	return nil
 }
 
-func (c *DBCommitStore) InsertCommits(ctx context.Context, id api.RepoID, commits []*gitdomain.Commit, commitsUntil time.Time, debugInfo string) (err error) {
+func (c *DBCommitStore) InsertCommits(ctx context.Context, id api.RepoID, commits []*gitdomain.Commit, indexedThrough time.Time, debugInfo string) (err error) {
 	tx, err := c.Transact(ctx)
 	if err != nil {
 		return err
@@ -66,7 +66,7 @@ func (c *DBCommitStore) InsertCommits(ctx context.Context, id api.RepoID, commit
 		}
 	}
 
-	if _, err = tx.UpsertMetadataStamp(ctx, id, commitsUntil); err != nil {
+	if _, err = tx.UpsertMetadataStamp(ctx, id, indexedThrough); err != nil {
 		return err
 	}
 

--- a/enterprise/internal/insights/compression/worker.go
+++ b/enterprise/internal/insights/compression/worker.go
@@ -109,6 +109,9 @@ func (i *CommitIndexer) indexAll(ctx context.Context) error {
 	return nil
 }
 
+// maxPagesPerRepo Limits the number of pages of commits indexRepository can process per run
+const maxPagesPerRepo = 25
+
 // indexRepository attempts to index the commits given a repository name one page at a time.
 // This method will absorb any errors that occur during execution and skip any remaining pages.
 // If this repository already has some commits indexed, only commits made more recently than the previous index will be added.
@@ -118,7 +121,7 @@ func (i *CommitIndexer) indexRepository(name string, id api.RepoID) error {
 	// It is important that the page size stays consistent during processing for each page
 	// so that it can correctly determine the time the repository has been indexed though
 	pageSize := conf.Get().InsightsCommitIndexerPageSize
-	for additionalPages && pagesProccssed < 25 {
+	for additionalPages && pagesProccssed < maxPagesPerRepo {
 		var err error
 		additionalPages, err = i.indexNextPage(name, id, pageSize)
 		pagesProccssed++

--- a/enterprise/internal/insights/compression/worker.go
+++ b/enterprise/internal/insights/compression/worker.go
@@ -76,10 +76,10 @@ func NewCommitIndexer(background context.Context, base database.DB, insights dbu
 		getCommits:        getCommits,
 		operations:        operations,
 	}
-	conf.Watch(func() {
-		log15.Debug("Insights commit indexer page size updated")
-		indexer.commitsBatchSize = conf.Get().InsightsCommitIndexerPageSize
-	})
+	// conf.Watch(func() {
+	// 	log15.Debug("Insights commit indexer page size updated")
+	indexer.commitsBatchSize = conf.Get().InsightsCommitIndexerBatchSize
+	// })
 	return &indexer
 }
 

--- a/enterprise/internal/insights/compression/worker.go
+++ b/enterprise/internal/insights/compression/worker.go
@@ -187,7 +187,7 @@ func (i *CommitIndexer) indexNextWindow(name string, id api.RepoID, windowDurati
 		}
 	}
 
-	log15.Debug("indexing commits", "repo_id", repoId, "count", len(commits), "logSearchSize", windowDuration, "indexedThrough", indexedThrough)
+	log15.Debug("indexing commits", "repo_id", repoId, "count", len(commits), "indexedThrough", indexedThrough)
 	err = i.commitStore.InsertCommits(ctx, repoId, commits, indexedThrough, fmt.Sprintf("|repoName:%s|repoId:%d", repoName, repoId))
 	if err != nil {
 		return false, errors.Wrapf(err, "unable to update commit index repo_id: %v", repoId)

--- a/enterprise/internal/insights/compression/worker.go
+++ b/enterprise/internal/insights/compression/worker.go
@@ -135,7 +135,7 @@ func (i *CommitIndexer) indexRepository(name string, id api.RepoID) error {
 }
 
 func (i *CommitIndexer) indexNextWindow(name string, id api.RepoID, windowDuration int) (moreWindows bool, err error) {
-	ctx, cancel := context.WithTimeout(i.background, time.Minute*45)
+	ctx, cancel := context.WithTimeout(i.background, time.Second*45)
 	defer cancel()
 
 	err = i.limiter.Wait(ctx)

--- a/enterprise/internal/insights/compression/worker_test.go
+++ b/enterprise/internal/insights/compression/worker_test.go
@@ -3,6 +3,7 @@ package compression
 import (
 	"context"
 	"database/sql"
+	"math"
 	"testing"
 	"time"
 
@@ -10,23 +11,29 @@ import (
 	"golang.org/x/time/rate"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
+	"github.com/sourcegraph/sourcegraph/schema"
 )
+
+var ops *operations = newOperations(&observation.TestContext)
 
 func TestCommitIndexer_indexAll(t *testing.T) {
 	ctx := context.Background()
 	commitStore := NewMockCommitStore()
 
 	maxHistorical := time.Date(2019, 1, 1, 0, 0, 0, 0, time.UTC)
+	clock := func() time.Time { return time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC) }
 
 	indexer := CommitIndexer{
 		limiter:           rate.NewLimiter(10, 1),
 		commitStore:       commitStore,
 		maxHistoricalTime: maxHistorical,
 		background:        context.Background(),
-		operations:        newOperations(&observation.TestContext),
+		operations:        ops,
+		clock:             clock,
 	}
 
 	// Testing a scenario with 3 repos
@@ -70,6 +77,13 @@ func TestCommitIndexer_indexAll(t *testing.T) {
 	}, nil)
 
 	t.Run("multi_repository", func(t *testing.T) {
+		pageSize := 0
+		conf.Mock(&conf.Unified{
+			SiteConfiguration: schema.SiteConfiguration{
+				InsightsCommitIndexerPageSize: pageSize,
+			},
+		})
+		defer conf.Mock(nil)
 		err := indexer.indexAll(ctx)
 		if err != nil {
 			t.Fatal(err)
@@ -171,6 +185,132 @@ func Test_getMetadata_NoInsertRequired(t *testing.T) {
 	})
 }
 
+func TestCommitIndexer_paging(t *testing.T) {
+	ctx := context.Background()
+	commitStore := NewMockCommitStore()
+
+	maxHistorical := time.Date(2019, 1, 1, 0, 0, 0, 0, time.UTC)
+	clock := func() time.Time { return time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC) }
+
+	indexer := CommitIndexer{
+		limiter:           rate.NewLimiter(10, 1),
+		commitStore:       commitStore,
+		maxHistoricalTime: maxHistorical,
+		background:        context.Background(),
+		operations:        ops,
+		clock:             clock,
+	}
+
+	// Testing a scenario with 3 repos
+	// "repo-one" has less than 1 page of commits it should update index and metadata
+	// "really-big-repo" has 2 pages of commits, it should update index and metadata
+	// "no-commits" has no commits but is enabled, and will not update the index but will update the metadata
+	commits := map[string][]*gitdomain.Commit{
+		"repo-one": {
+			commit("ref1", "2020-05-01T00:00:00+00:00"),
+			commit("ref2", "2020-05-10T00:00:00+00:00"),
+		},
+		"really-big-repo": {
+			commit("bigref1", "1999-04-01T00:00:00+00:00"),
+			commit("bigref2", "1999-04-03T00:00:00+00:00"),
+			commit("bigref3", "1999-04-06T00:00:00+00:00"),
+			commit("bigref4", "1999-04-09T00:00:00+00:00"),
+		},
+		"no-commits": {},
+	}
+	indexer.getCommits = mockCommits(commits)
+	indexer.allReposIterator = mockIterator([]string{"repo-one", "really-big-repo", "no-commits"})
+
+	commitStore.GetMetadataFunc.PushReturn(CommitIndexMetadata{
+		RepoId:        1,
+		Enabled:       true,
+		LastIndexedAt: time.Now(),
+	}, nil)
+
+	commitStore.GetMetadataFunc.PushReturn(CommitIndexMetadata{
+		RepoId:        2,
+		Enabled:       true,
+		LastIndexedAt: time.Now(),
+	}, nil)
+
+	commitStore.GetMetadataFunc.PushReturn(CommitIndexMetadata{
+		RepoId:        2,
+		Enabled:       true,
+		LastIndexedAt: time.Now(),
+	}, nil)
+
+	commitStore.GetMetadataFunc.PushReturn(CommitIndexMetadata{
+		RepoId:        3,
+		Enabled:       true,
+		LastIndexedAt: time.Now(),
+	}, nil)
+
+	t.Run("multi_repository_paging", func(t *testing.T) {
+		pageSize := 3
+		conf.Mock(&conf.Unified{
+			SiteConfiguration: schema.SiteConfiguration{
+				InsightsCommitIndexerPageSize: pageSize,
+			},
+		})
+		defer conf.Mock(nil)
+		err := indexer.indexAll(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Three enabled repos get metadata, repo 2 had 2 pages of commits so it makes 2 metadata calls
+		if got, want := len(commitStore.GetMetadataFunc.history), 4; got != want {
+			t.Errorf("got GetMetadata invocations: %v want %v", got, want)
+		}
+
+		// Repo 1 and 2 have commits, repo 1 has 1 page and repo 2 has 2 pages so 3 total calls
+		if got, want := len(commitStore.InsertCommitsFunc.history), 3; got != want {
+			t.Errorf("got InsertCommits invocations: %v want %v", got, want)
+		} else {
+			repo1Page1 := commitStore.InsertCommitsFunc.history[0]
+			repo2Page1 := commitStore.InsertCommitsFunc.history[1]
+			repo2Page2 := commitStore.InsertCommitsFunc.history[2]
+			// All commits from repo-one because it was less than a page size
+			checkCommits(t, commits["repo-one"], repo1Page1.Arg2)
+			// One page of commits for really-big-repo because it was > one page
+			checkCommits(t, commits["really-big-repo"][:pageSize+1], repo2Page1.Arg2)
+			// The rest of the commits for really-big-repo
+			checkCommits(t, commits["really-big-repo"][pageSize:], repo2Page2.Arg2)
+
+			// "Current time" for repo-one because commit history did not fill a full page
+			checkIndexedThough(t, clock().UTC(), repo1Page1.Arg3)
+			// Time of last indexed commit because really big repo's first call was a full page
+			checkIndexedThough(t, commits["really-big-repo"][pageSize-1].Committer.Date, repo2Page1.Arg3)
+			// "Current time" for page two of really-big-repo because remaining commit history did not fill a full page
+			checkIndexedThough(t, clock().UTC(), repo2Page2.Arg3)
+		}
+
+		// One repository had no commits, so only the timestamp would get updated
+		if got, want := len(commitStore.UpsertMetadataStampFunc.history), 1; got != want {
+			t.Errorf("got UpsertMetadataStamp invocations: %v want %v", got, want)
+		} else {
+			call := commitStore.UpsertMetadataStampFunc.history[0]
+			if call.Arg1 != 2 {
+				t.Errorf("unexpected repository for UpsertMetadataStamp repo_id: %v", call.Arg1)
+			}
+		}
+	})
+}
+
+func checkCommits(t *testing.T, want []*gitdomain.Commit, got []*gitdomain.Commit) {
+	for i, commit := range got {
+		if diff := cmp.Diff(want[i], commit); diff != "" {
+			t.Errorf("unexpected commit\n%s", diff)
+		}
+	}
+}
+
+func checkIndexedThough(t *testing.T, want time.Time, got time.Time) {
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("unexpected indexed through date\n%s", diff)
+	}
+}
+
 // mockIterator generates iterator methods given a list of repo names for test scenarios
 func mockIterator(repos []string) func(ctx context.Context, each func(repoName string, id api.RepoID) error) error {
 	return func(ctx context.Context, each func(repoName string, id api.RepoID) error) error {
@@ -194,8 +334,16 @@ func commit(ref string, commitTime string) *gitdomain.Commit {
 	}
 }
 
-func mockCommits(commits map[string][]*gitdomain.Commit) func(ctx context.Context, db database.DB, name api.RepoName, after time.Time, batchSize int, operation *observation.Operation) ([]*gitdomain.Commit, error) {
-	return func(ctx context.Context, db database.DB, name api.RepoName, after time.Time, batchSize int, operation *observation.Operation) ([]*gitdomain.Commit, error) {
-		return commits[(string(name))], nil
+func mockCommits(commits map[string][]*gitdomain.Commit) func(ctx context.Context, db database.DB, name api.RepoName, after time.Time, pageSize int, operation *observation.Operation) ([]*gitdomain.Commit, error) {
+	repoPages := map[string]int{}
+	return func(ctx context.Context, db database.DB, name api.RepoName, after time.Time, pageSize int, operation *observation.Operation) ([]*gitdomain.Commit, error) {
+		if pageSize == 0 {
+			pageSize = len(commits[(string(name))])
+		}
+		curentPage := repoPages[string(name)]
+		repoPages[string(name)] = repoPages[string(name)] + 1
+		startItem := curentPage * pageSize
+		endItem := int(math.Min(float64(startItem+pageSize), float64(len(commits[(string(name))]))))
+		return commits[(string(name))][startItem:endItem], nil
 	}
 }

--- a/enterprise/internal/insights/compression/worker_test.go
+++ b/enterprise/internal/insights/compression/worker_test.go
@@ -76,10 +76,10 @@ func TestCommitIndexer_indexAll(t *testing.T) {
 	}, nil)
 
 	t.Run("multi_repository", func(t *testing.T) {
-		pageSize := 0
+		windowDuration := 0
 		conf.Mock(&conf.Unified{
 			SiteConfiguration: schema.SiteConfiguration{
-				InsightsCommitIndexerPageSize: pageSize,
+				InsightsCommitIndexerWindowDuration: windowDuration,
 			},
 		})
 		defer conf.Mock(nil)
@@ -185,7 +185,7 @@ func Test_getMetadata_NoInsertRequired(t *testing.T) {
 	})
 }
 
-func TestCommitIndexer_paging(t *testing.T) {
+func TestCommitIndexer_windowing(t *testing.T) {
 	ctx := context.Background()
 	commitStore := NewMockCommitStore()
 
@@ -280,7 +280,7 @@ func TestCommitIndexer_paging(t *testing.T) {
 
 		conf.Mock(&conf.Unified{
 			SiteConfiguration: schema.SiteConfiguration{
-				InsightsCommitIndexerPageSize: 30,
+				InsightsCommitIndexerWindowDuration: 30,
 			},
 		})
 		defer conf.Mock(nil)

--- a/enterprise/internal/insights/compression/worker_test.go
+++ b/enterprise/internal/insights/compression/worker_test.go
@@ -194,8 +194,8 @@ func commit(ref string, commitTime string) *gitdomain.Commit {
 	}
 }
 
-func mockCommits(commits map[string][]*gitdomain.Commit) func(ctx context.Context, db database.DB, name api.RepoName, after time.Time, operation *observation.Operation) ([]*gitdomain.Commit, error) {
-	return func(ctx context.Context, db database.DB, name api.RepoName, after time.Time, operation *observation.Operation) ([]*gitdomain.Commit, error) {
+func mockCommits(commits map[string][]*gitdomain.Commit) func(ctx context.Context, db database.DB, name api.RepoName, after time.Time, batchSize int, operation *observation.Operation) ([]*gitdomain.Commit, error) {
+	return func(ctx context.Context, db database.DB, name api.RepoName, after time.Time, batchSize int, operation *observation.Operation) ([]*gitdomain.Commit, error) {
 		return commits[(string(name))], nil
 	}
 }

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1787,10 +1787,10 @@ type SiteConfiguration struct {
 	HtmlHeadBottom string `json:"htmlHeadBottom,omitempty"`
 	// HtmlHeadTop description: HTML to inject at the top of the `<head>` element on each page, for analytics scripts
 	HtmlHeadTop string `json:"htmlHeadTop,omitempty"`
-	// InsightsCommitIndexerBatchSize description: The number of commits in each batch the insights commit indexer will pull during each request (0 is no limit).
-	InsightsCommitIndexerBatchSize int `json:"insights.commit.indexer.batchSize,omitempty"`
 	// InsightsCommitIndexerInterval description: The interval (in minutes) at which the insights commit indexer will check for new commits.
 	InsightsCommitIndexerInterval int `json:"insights.commit.indexer.interval,omitempty"`
+	// InsightsCommitIndexerPageSize description: The number of commits in each page the insights commit indexer will pull during each request (0 is no limit).
+	InsightsCommitIndexerPageSize int `json:"insights.commit.indexer.pageSize,omitempty"`
 	// InsightsHistoricalFrameLength description: (debug) duration of historical insights timeframes, one point per repository will be recorded in each timeframe.
 	InsightsHistoricalFrameLength string `json:"insights.historical.frameLength,omitempty"`
 	// InsightsHistoricalFrames description: (debug) number of historical insights timeframes to populate

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1789,8 +1789,8 @@ type SiteConfiguration struct {
 	HtmlHeadTop string `json:"htmlHeadTop,omitempty"`
 	// InsightsCommitIndexerInterval description: The interval (in minutes) at which the insights commit indexer will check for new commits.
 	InsightsCommitIndexerInterval int `json:"insights.commit.indexer.interval,omitempty"`
-	// InsightsCommitIndexerPageSize description: The number of commits in each page the insights commit indexer will pull during each request (0 is no limit).
-	InsightsCommitIndexerPageSize int `json:"insights.commit.indexer.pageSize,omitempty"`
+	// InsightsCommitIndexerWindowDuration description: The number of days of commits the insights commit indexer will pull during each request (0 is no limit).
+	InsightsCommitIndexerWindowDuration int `json:"insights.commit.indexer.windowDuration,omitempty"`
 	// InsightsHistoricalFrameLength description: (debug) duration of historical insights timeframes, one point per repository will be recorded in each timeframe.
 	InsightsHistoricalFrameLength string `json:"insights.historical.frameLength,omitempty"`
 	// InsightsHistoricalFrames description: (debug) number of historical insights timeframes to populate

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1787,10 +1787,10 @@ type SiteConfiguration struct {
 	HtmlHeadBottom string `json:"htmlHeadBottom,omitempty"`
 	// HtmlHeadTop description: HTML to inject at the top of the `<head>` element on each page, for analytics scripts
 	HtmlHeadTop string `json:"htmlHeadTop,omitempty"`
+	// InsightsCommitIndexerBatchSize description: The number of commits in each batch the insights commit indexer will pull during each request (0 is no limit).
+	InsightsCommitIndexerBatchSize int `json:"insights.commit.indexer.batchSize,omitempty"`
 	// InsightsCommitIndexerInterval description: The interval (in minutes) at which the insights commit indexer will check for new commits.
 	InsightsCommitIndexerInterval int `json:"insights.commit.indexer.interval,omitempty"`
-	// InsightsCommitIndexerPageSize description: The number of commits each in each page the insights commit indexer pull each request (0 is no limit).
-	InsightsCommitIndexerPageSize int `json:"insights.commit.indexer.pageSize,omitempty"`
 	// InsightsHistoricalFrameLength description: (debug) duration of historical insights timeframes, one point per repository will be recorded in each timeframe.
 	InsightsHistoricalFrameLength string `json:"insights.historical.frameLength,omitempty"`
 	// InsightsHistoricalFrames description: (debug) number of historical insights timeframes to populate

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1789,6 +1789,8 @@ type SiteConfiguration struct {
 	HtmlHeadTop string `json:"htmlHeadTop,omitempty"`
 	// InsightsCommitIndexerInterval description: The interval (in minutes) at which the insights commit indexer will check for new commits.
 	InsightsCommitIndexerInterval int `json:"insights.commit.indexer.interval,omitempty"`
+	// InsightsCommitIndexerPageSize description: The number of commits each in each page the insights commit indexer pull each request (0 is no limit).
+	InsightsCommitIndexerPageSize int `json:"insights.commit.indexer.pageSize,omitempty"`
 	// InsightsHistoricalFrameLength description: (debug) duration of historical insights timeframes, one point per repository will be recorded in each timeframe.
 	InsightsHistoricalFrameLength string `json:"insights.historical.frameLength,omitempty"`
 	// InsightsHistoricalFrames description: (debug) number of historical insights timeframes to populate

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -1162,6 +1162,13 @@
       "default": 60,
       "examples": [120]
     },
+    "insights.commit.indexer.batchSize": {
+      "description": "The number of commits in each batch the insights commit indexer will pull during each request (0 is no limit).",
+      "type": "integer",
+      "group": "CodeInsights",
+      "default": 0,
+      "examples": [5000]
+    },
     "htmlHeadTop": {
       "description": "HTML to inject at the top of the `<head>` element on each page, for analytics scripts",
       "type": "string",

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -1162,8 +1162,8 @@
       "default": 60,
       "examples": [120]
     },
-    "insights.commit.indexer.batchSize": {
-      "description": "The number of commits in each batch the insights commit indexer will pull during each request (0 is no limit).",
+    "insights.commit.indexer.pageSize": {
+      "description": "The number of commits in each page the insights commit indexer will pull during each request (0 is no limit).",
       "type": "integer",
       "group": "CodeInsights",
       "default": 0,

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -1162,12 +1162,12 @@
       "default": 60,
       "examples": [120]
     },
-    "insights.commit.indexer.pageSize": {
-      "description": "The number of commits in each page the insights commit indexer will pull during each request (0 is no limit).",
+    "insights.commit.indexer.windowDuration": {
+      "description": "The number of days of commits the insights commit indexer will pull during each request (0 is no limit).",
       "type": "integer",
       "group": "CodeInsights",
       "default": 0,
-      "examples": [5000]
+      "examples": [30]
     },
     "htmlHeadTop": {
       "description": "HTML to inject at the top of the `<head>` element on each page, for analytics scripts",


### PR DESCRIPTION
To ensure that the insights commit indexer can complete it's indexing task when attempting to index a repository with a large number of commits add a setting `insights.commit.indexer.windowDuration`.  This setting allows the insights commit indexer to limit git log requests to a window of time instead of getting all commits after a specified date.  

The default setting value does not specify a duration so behavior is the same as current state where all commits after the last indexed date are fetched.

resolves #22035

## Test plan
All tests pass 

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


