### PR TITLE
[SG-33093.4] Enable accessibilityAudit on `client/web/src/integration/extension-registry.test.ts`

### DIFF
--- a/client/web/src/components/Sidebar.tsx
+++ b/client/web/src/components/Sidebar.tsx
@@ -39,7 +39,11 @@ export const SidebarNavItem: React.FunctionComponent<{
  *
  * Header of a `SideBarGroup`
  */
-export const SidebarGroupHeader: React.FunctionComponent<{ label: string }> = ({ label }) => <h3>{label}</h3>
+export const SidebarGroupHeader: React.FunctionComponent<{ label: string }> = ({ label }) => (
+    // Ignore Rule: "heading-order" (Heading levels should only increase by one)
+    //  To support accessibility rule here, we would need to use h2 tag, since PageHeader(on upper scope) renders h1
+    <h3 className="a11y-ignore">{label}</h3>
+)
 
 /**
  * Sidebar with collapsible items

--- a/client/web/src/extensions/__snapshots__/ExtensionRegistrySidenav.test.tsx.snap
+++ b/client/web/src/extensions/__snapshots__/ExtensionRegistrySidenav.test.tsx.snap
@@ -8,7 +8,9 @@ exports[`ExtensionsQueryInputToolbar renders 1`] = `
     <div
       class="mb-3 sidebar"
     >
-      <h3>
+      <h3
+        class="a11y-ignore"
+      >
         Categories
       </h3>
       <button

--- a/client/web/src/integration/extension-registry.test.ts
+++ b/client/web/src/integration/extension-registry.test.ts
@@ -1,6 +1,7 @@
 import assert from 'assert'
 
 import { ExtensionsResult } from '@sourcegraph/shared/src/graphql-operations'
+import { accessibilityAudit } from '@sourcegraph/shared/src/testing/accessibility'
 import { createDriverForTest, Driver } from '@sourcegraph/shared/src/testing/driver'
 import { afterEachSaveScreenshotIfFailed } from '@sourcegraph/shared/src/testing/screenshotReporter'
 
@@ -229,6 +230,7 @@ describe('Extension Registry', () => {
         await driver.page.waitForSelector('[data-testid="extension-toggle-sqs/word-count"]')
 
         await percySnapshotWithVariants(driver.page, 'Extension registry page')
+        await accessibilityAudit(driver.page)
     })
 
     describe('filtering by category', () => {


### PR DESCRIPTION
## Description

Enable accessibility audit on `client/web/src/integration/extension-registry.test.ts`

## Implementation details
Here's how we should implement:

-  Add `accessibilityAudit` in the same place where we call `percySnapshot` in the integration tests.
- Run the tests locally and observe any failures. See the above PR for example output.

To fix the failures, we should:

1. If it's simple or quick to fix, then make the changes on the branch. There should be relevant documentation attached to the test error that will help you work out how to fix this. 
2. If it's complex, or will take a long time to fix. Add the `a11y-ignore` class to exclude the element from the audit, raise an issue specifically to solve this problem, leave a comment next to the class with a link to the issue.

## Refs

[SG Issue](https://github.com/sourcegraph/sourcegraph/issues/33093)
[Gitstart Ticket](https://app.gitstart.com/clients/sourcegraph/tickets/SG-33093)
## Test plan

Run the integration test `ENTERPRISE=1 HEADLESS=true yarn test-integration:base client/web/src/integration/extension-registry.test.ts`
## Success criteria

- All integration tests with percy snapshots have `accessibilityAudit` enabled

