### PR TITLE
Backend: remove unused variable

### DIFF
--- a/internal/database/users.go
+++ b/internal/database/users.go
@@ -282,9 +282,6 @@ func (u *userStore) CreateInTransaction(ctx context.Context, info NewUser) (newU
 		avatarURL = &info.AvatarURL
 	}
 
-	dbEmailCode := sql.NullString{String: info.EmailVerificationCode}
-	dbEmailCode.Valid = info.EmailVerificationCode != ""
-
 	// Creating the initial site admin user is equivalent to initializing the
 	// site. ensureInitialized runs in the transaction, so we are guaranteed that the user account
 	// creation and site initialization operations occur atomically (to guarantee to the legitimate


### PR DESCRIPTION
This variable is unused and causing my editor to complain. It's been this way at least since the initial open source commit, so I think it's safe to just delete. To check my assumption here, we currently have 36 rows in the production DB with empty, but non-null verification codes, but they were all created in December of 2017. 

## Test plan

Just deleting dead code. Checked prod DB to make sure this isn't a larger issue than it appears. 

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


