### PR TITLE
RFC 625: lsif_uploads audit log table and trigger

### DIFF
--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -1557,6 +1557,8 @@ Referenced by:
     TABLE "lsif_dependency_indexing_jobs" CONSTRAINT "lsif_dependency_indexing_jobs_upload_id_fkey1" FOREIGN KEY (upload_id) REFERENCES lsif_uploads(id) ON DELETE CASCADE
     TABLE "lsif_packages" CONSTRAINT "lsif_packages_dump_id_fkey" FOREIGN KEY (dump_id) REFERENCES lsif_uploads(id) ON DELETE CASCADE
     TABLE "lsif_references" CONSTRAINT "lsif_references_dump_id_fkey" FOREIGN KEY (dump_id) REFERENCES lsif_uploads(id) ON DELETE CASCADE
+Triggers:
+    trigger_lsif_uploads_update AFTER UPDATE OF state, num_resets, num_failures, worker_hostname, expired, committed_at ON lsif_uploads FOR EACH ROW EXECUTE FUNCTION func_lsif_uploads_update()
 
 ```
 
@@ -1585,6 +1587,27 @@ Stores metadata about an LSIF index uploaded by a user.
 **upload_size**: The size of the index file (in bytes).
 
 **uploaded_parts**: The index of parts that have been successfully uploaded.
+
+# Table "public.lsif_uploads_audit_logs"
+```
+       Column        |           Type           | Collation | Nullable | Default 
+---------------------+--------------------------+-----------+----------+---------
+ instant             | timestamp with time zone |           |          | now()
+ upload_id           | integer                  |           | not null | 
+ commit              | text                     |           | not null | 
+ root                | text                     |           | not null | 
+ repository_id       | integer                  |           | not null | 
+ uploaded_at         | timestamp with time zone |           | not null | 
+ indexer             | text                     |           | not null | 
+ indexer_version     | text                     |           |          | 
+ upload_size         | integer                  |           | not null | 
+ associated_index_id | integer                  |           | not null | 
+ committed_at        | timestamp with time zone |           |          | 
+ transition_columns  | USER-DEFINED[]           |           |          | 
+Indexes:
+    "lsif_uploads_audit_logs_timestamp" brin (instant)
+
+```
 
 # Table "public.lsif_uploads_visible_at_tip"
 ```

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -1600,12 +1600,13 @@ Stores metadata about an LSIF index uploaded by a user.
  uploaded_at         | timestamp with time zone |           | not null | 
  indexer             | text                     |           | not null | 
  indexer_version     | text                     |           |          | 
- upload_size         | integer                  |           | not null | 
- associated_index_id | integer                  |           | not null | 
+ upload_size         | integer                  |           |          | 
+ associated_index_id | integer                  |           |          | 
  committed_at        | timestamp with time zone |           |          | 
  transition_columns  | USER-DEFINED[]           |           |          | 
 Indexes:
     "lsif_uploads_audit_logs_timestamp" brin (instant)
+    "lsif_uploads_audit_logs_upload_id" btree (upload_id)
 
 ```
 

--- a/migrations/frontend/1649441222/down.sql
+++ b/migrations/frontend/1649441222/down.sql
@@ -1,0 +1,5 @@
+DROP TRIGGER IF EXISTS trigger_lsif_uploads_update ON lsif_uploads;
+
+DROP FUNCTION IF EXISTS func_lsif_uploads_update;
+
+DROP TABLE IF EXISTS lsif_uploads_audit_logs;

--- a/migrations/frontend/1649441222/down.sql
+++ b/migrations/frontend/1649441222/down.sql
@@ -1,10 +1,16 @@
 DROP TRIGGER IF EXISTS trigger_lsif_uploads_update ON lsif_uploads;
 DROP TRIGGER IF EXISTS trigger_lsif_uploads_delete ON lsif_uploads;
+DROP TRIGGER IF EXISTS trigger_lsif_uploads_insert ON lsif_uploads;
 
 DROP FUNCTION IF EXISTS func_lsif_uploads_update;
 DROP FUNCTION IF EXISTS func_lsif_uploads_delete;
+DROP FUNCTION IF EXISTS func_lsif_uploads_insert;
+DROP FUNCTION IF EXISTS func_lsif_uploads_transition_columns_diff;
+DROP FUNCTION IF EXISTS func_row_to_lsif_uploads_transition_columns;
 
 DROP TABLE IF EXISTS lsif_uploads_audit_logs;
 
 DROP INDEX IF EXISTS lsif_uploads_audit_logs_upload_id;
 DROP INDEX IF EXISTS lsif_uploads_audit_logs_timestamp;
+
+DROP TYPE IF EXISTS lsif_uploads_transition_columns;

--- a/migrations/frontend/1649441222/down.sql
+++ b/migrations/frontend/1649441222/down.sql
@@ -1,6 +1,8 @@
 DROP TRIGGER IF EXISTS trigger_lsif_uploads_update ON lsif_uploads;
+DROP TRIGGER IF EXISTS trigger_lsif_uploads_delete ON lsif_uploads;
 
 DROP FUNCTION IF EXISTS func_lsif_uploads_update;
+DROP FUNCTION IF EXISTS func_lsif_uploads_delete;
 
 DROP TABLE IF EXISTS lsif_uploads_audit_logs;
 

--- a/migrations/frontend/1649441222/down.sql
+++ b/migrations/frontend/1649441222/down.sql
@@ -3,3 +3,6 @@ DROP TRIGGER IF EXISTS trigger_lsif_uploads_update ON lsif_uploads;
 DROP FUNCTION IF EXISTS func_lsif_uploads_update;
 
 DROP TABLE IF EXISTS lsif_uploads_audit_logs;
+
+DROP INDEX IF EXISTS lsif_uploads_audit_logs_upload_id;
+DROP INDEX IF EXISTS lsif_uploads_audit_logs_timestamp;

--- a/migrations/frontend/1649441222/metadata.yaml
+++ b/migrations/frontend/1649441222/metadata.yaml
@@ -1,0 +1,2 @@
+name: lsif_uploads_audit_logging
+parents: [1649269601]

--- a/migrations/frontend/1649441222/up.sql
+++ b/migrations/frontend/1649441222/up.sql
@@ -59,8 +59,10 @@ CREATE OR REPLACE FUNCTION func_lsif_uploads_update() RETURNS TRIGGER AS $$
     END;
 $$ LANGUAGE plpgsql;
 
+-- CREATE OR REPLACE only supported in Postgres 14+
+DROP TRIGGER IF EXISTS trigger_lsif_uploads_update on lsif_uploads;
 
-CREATE OR REPLACE TRIGGER trigger_lsif_uploads_update
+CREATE TRIGGER trigger_lsif_uploads_update
 AFTER UPDATE OF state, num_resets, num_failures, worker_hostname, expired, committed_at
 ON lsif_uploads
 FOR EACH ROW

--- a/migrations/frontend/1649441222/up.sql
+++ b/migrations/frontend/1649441222/up.sql
@@ -7,8 +7,8 @@ CREATE TABLE IF NOT EXISTS lsif_uploads_audit_logs (
     uploaded_at         timestamptz not null,
     indexer             text not null,
     indexer_version     text,
-    upload_size         integer not null,
-    associated_index_id integer not null,
+    upload_size         integer,
+    associated_index_id integer,
     committed_at        timestamptz,
     transition_columns  hstore[]
 );

--- a/migrations/frontend/1649441222/up.sql
+++ b/migrations/frontend/1649441222/up.sql
@@ -1,0 +1,67 @@
+CREATE TABLE IF NOT EXISTS lsif_uploads_audit_logs (
+    instant             timestamptz DEFAULT NOW(),
+    upload_id           integer not null,
+    commit              text not null,
+    root                text not null,
+    repository_id       integer not null,
+    uploaded_at         timestamptz not null,
+    indexer             text not null,
+    indexer_version     text,
+    upload_size         integer not null,
+    associated_index_id integer not null,
+    committed_at        timestamptz,
+    transition_columns  hstore[]
+);
+
+CREATE INDEX lsif_uploads_audit_logs_timestamp ON lsif_uploads_audit_logs USING brin (instant);
+
+CREATE OR REPLACE FUNCTION func_lsif_uploads_update() RETURNS TRIGGER AS $$
+    BEGIN
+        INSERT INTO lsif_uploads_audit_logs
+        (upload_id, commit, root, repository_id, uploaded_at,
+        indexer, indexer_version, upload_size, associated_index_id,
+        committed_at, transition_columns)
+        VALUES (
+            NEW.id, NEW.commit, NEW.root, NEW.repository_id, NEW.uploaded_at,
+            NEW.indexer, NEW.indexer_version, NEW.upload_size, NEW.associated_index_id,
+            NEW.committed_at,
+            -- array || NULL should be a noop, but that doesn't seem to be happening
+            -- hence array_remove here
+            array_remove(
+                ARRAY[]::hstore[] ||
+                CASE WHEN OLD.state IS DISTINCT FROM NEW.state THEN
+                    hstore(ARRAY['column', 'state', 'old', OLD.state, 'new', NEW.state])
+                    ELSE NULL
+                END ||
+                CASE WHEN OLD.expired IS DISTINCT FROM NEW.expired THEN
+                    hstore(ARRAY['column', 'expired', 'old', OLD.expired::text, 'new', NEW.expired::text])
+                    ELSE NULL
+                END ||
+                CASE WHEN OLD.num_resets IS DISTINCT FROM NEW.num_resets THEN
+                    hstore(ARRAY['column', 'num_resets', 'old', OLD.num_resets::text, 'new', NEW.num_resets::text])
+                    ELSE NULL
+                END ||
+                CASE WHEN OLD.num_failures IS DISTINCT FROM NEW.num_failures THEN
+                    hstore(ARRAY['column', 'num_failures', 'old', OLD.num_failures::text, 'new', NEW.num_failures::text])
+                    ELSE NULL
+                END ||
+                CASE WHEN OLD.worker_hostname IS DISTINCT FROM NEW.worker_hostname THEN
+                    hstore(ARRAY['column', 'worker_hostname', 'old', OLD.worker_hostname, 'new', NEW.worker_hostname])
+                    ELSE NULL
+                END ||
+                CASE WHEN OLD.committed_at IS DISTINCT FROM NEW.committed_at THEN
+                    hstore(ARRAY['column', 'committed_at', 'old', OLD.committed_at::text, 'new', NEW.committed_at::text])
+                    ELSE NULL
+                END,
+            NULL)
+        );
+        RETURN NULL;
+    END;
+$$ LANGUAGE plpgsql;
+
+
+CREATE OR REPLACE TRIGGER trigger_lsif_uploads_update
+AFTER UPDATE OF state, num_resets, num_failures, worker_hostname, expired, committed_at
+ON lsif_uploads
+FOR EACH ROW
+EXECUTE FUNCTION func_lsif_uploads_update();

--- a/migrations/frontend/1649441222/up.sql
+++ b/migrations/frontend/1649441222/up.sql
@@ -13,7 +13,8 @@ CREATE TABLE IF NOT EXISTS lsif_uploads_audit_logs (
     transition_columns  hstore[]
 );
 
-CREATE INDEX lsif_uploads_audit_logs_timestamp ON lsif_uploads_audit_logs USING brin (instant);
+CREATE INDEX IF NOT EXISTS lsif_uploads_audit_logs_upload_id ON lsif_uploads_audit_logs USING btree (upload_id);
+CREATE INDEX IF NOT EXISTS lsif_uploads_audit_logs_timestamp ON lsif_uploads_audit_logs USING brin (instant);
 
 CREATE OR REPLACE FUNCTION func_lsif_uploads_update() RETURNS TRIGGER AS $$
     BEGIN

--- a/migrations/frontend/1649441222/up.sql
+++ b/migrations/frontend/1649441222/up.sql
@@ -18,10 +18,21 @@ CREATE TABLE IF NOT EXISTS lsif_uploads_audit_logs (
 
 COMMENT ON COLUMN lsif_uploads_audit_logs.log_timestamp IS 'Timestamp for this log entry.';
 COMMENT ON COLUMN lsif_uploads_audit_logs.record_deleted_at IS 'Set once the upload this entry is associated with is deleted. Once NOW() - record_deleted_at is above a certain threshold, this log entry will be deleted.';
-COMMENT ON COLUMN lsif_uploads_audit_logs.transition_columns IS 'Array of changes that occurred to the upload for this entry, in the form of {"column"=>"<column name>", "old"=>"<previous value>", "new"=>"<new value>"}';
+COMMENT ON COLUMN lsif_uploads_audit_logs.transition_columns IS 'Array of changes that occurred to the upload for this entry, in the form of {"column"=>"<column name>", "old"=>"<previous value>", "new"=>"<new value>"}.';
 
 CREATE INDEX IF NOT EXISTS lsif_uploads_audit_logs_upload_id ON lsif_uploads_audit_logs USING btree (upload_id);
 CREATE INDEX IF NOT EXISTS lsif_uploads_audit_logs_timestamp ON lsif_uploads_audit_logs USING brin (log_timestamp);
+
+CREATE TYPE lsif_uploads_transition_columns AS (
+    state           text,
+    expired         boolean,
+    num_resets      integer,
+    num_failures    integer,
+    worker_hostname text,
+    committed_at    timestamptz
+);
+
+COMMENT ON TYPE lsif_uploads_transition_columns IS 'A type containing the columns that make-up the set of tracked transition columns. Primarily used to create a nulled record due to `OLD` being unset in INSERT queries, and creating a nulled record with a subquery is not allowed.';
 
 CREATE OR REPLACE FUNCTION func_lsif_uploads_update() RETURNS TRIGGER AS $$
     BEGIN
@@ -32,39 +43,13 @@ CREATE OR REPLACE FUNCTION func_lsif_uploads_update() RETURNS TRIGGER AS $$
         VALUES (
             NEW.id, NEW.commit, NEW.root, NEW.repository_id, NEW.uploaded_at,
             NEW.indexer, NEW.indexer_version, NEW.upload_size, NEW.associated_index_id,
-            NEW.committed_at,
-            -- array || NULL should be a noop, but that doesn't seem to be happening
-            -- hence array_remove here
-            array_remove(
-                ARRAY[]::hstore[] ||
-                CASE WHEN OLD.state IS DISTINCT FROM NEW.state THEN
-                    hstore(ARRAY['column', 'state', 'old', OLD.state, 'new', NEW.state])
-                    ELSE NULL
-                END ||
-                CASE WHEN OLD.expired IS DISTINCT FROM NEW.expired THEN
-                    hstore(ARRAY['column', 'expired', 'old', OLD.expired::text, 'new', NEW.expired::text])
-                    ELSE NULL
-                END ||
-                CASE WHEN OLD.num_resets IS DISTINCT FROM NEW.num_resets THEN
-                    hstore(ARRAY['column', 'num_resets', 'old', OLD.num_resets::text, 'new', NEW.num_resets::text])
-                    ELSE NULL
-                END ||
-                CASE WHEN OLD.num_failures IS DISTINCT FROM NEW.num_failures THEN
-                    hstore(ARRAY['column', 'num_failures', 'old', OLD.num_failures::text, 'new', NEW.num_failures::text])
-                    ELSE NULL
-                END ||
-                CASE WHEN OLD.worker_hostname IS DISTINCT FROM NEW.worker_hostname THEN
-                    hstore(ARRAY['column', 'worker_hostname', 'old', OLD.worker_hostname, 'new', NEW.worker_hostname])
-                    ELSE NULL
-                END ||
-                CASE WHEN OLD.committed_at IS DISTINCT FROM NEW.committed_at THEN
-                    hstore(ARRAY['column', 'committed_at', 'old', OLD.committed_at::text, 'new', NEW.committed_at::text])
-                    ELSE NULL
-                END,
-            NULL)
+            NEW.committed_at, func_lsif_uploads_transition_columns_diff(
+                func_row_to_lsif_uploads_transition_columns(OLD),
+                func_row_to_lsif_uploads_transition_columns(NEW)
+            )
         );
 
-        RETURN NULL;
+        RETURN NEW;
     END;
 $$ LANGUAGE plpgsql;
 
@@ -80,12 +65,79 @@ CREATE OR REPLACE FUNCTION func_lsif_uploads_delete() RETURNS TRIGGER AS $$
     END;
 $$ LANGUAGE plpgsql;
 
+CREATE OR REPLACE FUNCTION func_lsif_uploads_insert() RETURNS TRIGGER AS $$
+    BEGIN
+        INSERT INTO lsif_uploads_audit_logs
+        (upload_id, commit, root, repository_id, uploaded_at,
+        indexer, indexer_version, upload_size, associated_index_id,
+        committed_at, transition_columns)
+        VALUES (
+            NEW.id, NEW.commit, NEW.root, NEW.repository_id, NEW.uploaded_at,
+            NEW.indexer, NEW.indexer_version, NEW.upload_size, NEW.associated_index_id,
+            NEW.committed_at, func_lsif_uploads_transition_columns_diff(
+                (NULL, NULL, NULL, NULL, NULL, NULL),
+                func_row_to_lsif_uploads_transition_columns(NEW)
+            )
+        );
+        RETURN NULL;
+    END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION func_row_to_lsif_uploads_transition_columns(
+    rec record
+) RETURNS lsif_uploads_transition_columns AS $$
+    BEGIN
+        RETURN (rec.state, rec.expired, rec.num_resets, rec.num_failures, rec.worker_hostname, rec.committed_at);
+    END;
+$$ LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION func_lsif_uploads_insert IS 'Transforms a record from the lsif_uploads table into an `lsif_uploads_transition_columns` type variable.';
+
+CREATE OR REPLACE FUNCTION func_lsif_uploads_transition_columns_diff(
+    old lsif_uploads_transition_columns, new lsif_uploads_transition_columns
+) RETURNS hstore[] AS $$
+    BEGIN
+        -- array || NULL should be a noop, but that doesn't seem to be happening
+        -- hence array_remove here
+        RETURN array_remove(
+            ARRAY[]::hstore[] ||
+            CASE WHEN old.state IS DISTINCT FROM new.state THEN
+                hstore(ARRAY['column', 'state', 'old', old.state, 'new', new.state])
+                ELSE NULL
+            END ||
+            CASE WHEN old.expired IS DISTINCT FROM new.expired THEN
+                hstore(ARRAY['column', 'expired', 'old', old.expired::text, 'new', new.expired::text])
+                ELSE NULL
+            END ||
+            CASE WHEN old.num_resets IS DISTINCT FROM new.num_resets THEN
+                hstore(ARRAY['column', 'num_resets', 'old', old.num_resets::text, 'new', new.num_resets::text])
+                ELSE NULL
+            END ||
+            CASE WHEN old.num_failures IS DISTINCT FROM new.num_failures THEN
+                hstore(ARRAY['column', 'num_failures', 'old', old.num_failures::text, 'new', new.num_failures::text])
+                ELSE NULL
+            END ||
+            CASE WHEN old.worker_hostname IS DISTINCT FROM new.worker_hostname THEN
+                hstore(ARRAY['column', 'worker_hostname', 'old', old.worker_hostname, 'new', new.worker_hostname])
+                ELSE NULL
+            END ||
+            CASE WHEN old.committed_at IS DISTINCT FROM new.committed_at THEN
+                hstore(ARRAY['column', 'committed_at', 'old', old.committed_at::text, 'new', new.committed_at::text])
+                ELSE NULL
+            END,
+        NULL);
+    END;
+$$ LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION func_lsif_uploads_transition_columns_diff IS 'Diffs two `lsif_uploads_transition_columns` values into an array of hstores, where each hstore is in the format {"column"=>"<column name>", "old"=>"<previous value>", "new"=>"<new value>"}.';
+
 -- CREATE OR REPLACE only supported in Postgres 14+
-DROP TRIGGER IF EXISTS trigger_lsif_uploads_update on lsif_uploads;
-DROP TRIGGER IF EXISTS trigger_lsif_uploads_delete on lsif_uploads;
+DROP TRIGGER IF EXISTS trigger_lsif_uploads_update ON lsif_uploads;
+DROP TRIGGER IF EXISTS trigger_lsif_uploads_delete ON lsif_uploads;
+DROP TRIGGER IF EXISTS trigger_lsif_uploads_insert ON lsif_uploads;
 
 CREATE TRIGGER trigger_lsif_uploads_update
-AFTER UPDATE OF state, num_resets, num_failures, worker_hostname, expired, committed_at
+BEFORE UPDATE OF state, num_resets, num_failures, worker_hostname, expired, committed_at
 ON lsif_uploads
 FOR EACH ROW
 EXECUTE FUNCTION func_lsif_uploads_update();
@@ -96,3 +148,9 @@ ON lsif_uploads
 REFERENCING OLD TABLE AS OLD
 FOR EACH STATEMENT
 EXECUTE FUNCTION func_lsif_uploads_delete();
+
+CREATE TRIGGER trigger_lsif_uploads_insert
+AFTER INSERT
+ON lsif_uploads
+FOR EACH ROW
+EXECUTE FUNCTION func_lsif_uploads_insert();

--- a/migrations/frontend/1649441222/up.sql
+++ b/migrations/frontend/1649441222/up.sql
@@ -1,6 +1,8 @@
 CREATE TABLE IF NOT EXISTS lsif_uploads_audit_logs (
+    -- log entry columns
     log_timestamp       timestamptz DEFAULT NOW(),
     log_expiry          timestamptz,
+    -- associated object columns
     upload_id           integer not null,
     commit              text not null,
     root                text not null,
@@ -13,6 +15,10 @@ CREATE TABLE IF NOT EXISTS lsif_uploads_audit_logs (
     committed_at        timestamptz,
     transition_columns  hstore[]
 );
+
+COMMENT ON COLUMN lsif_uploads_audit_logs.log_timestamp IS 'Timestamp for this log entry.';
+COMMENT ON COLUMN lsif_uploads_audit_logs.log_expiry IS 'Set once the upload this entry is associated with is deleted. Once NOW() + log_expiry is above a certain threshold, this log entry will be deleted.';
+COMMENT ON COLUMN lsif_uploads_audit_logs.transition_columns IS 'Array of changes that occurred to the upload for this entry, in the form of {"column"=>"<column name>", "old"=>"<previous value>", "new"=>"<new value>"}';
 
 CREATE INDEX IF NOT EXISTS lsif_uploads_audit_logs_upload_id ON lsif_uploads_audit_logs USING btree (upload_id);
 CREATE INDEX IF NOT EXISTS lsif_uploads_audit_logs_timestamp ON lsif_uploads_audit_logs USING brin (log_timestamp);

--- a/migrations/frontend/1649441222/up.sql
+++ b/migrations/frontend/1649441222/up.sql
@@ -23,6 +23,12 @@ COMMENT ON COLUMN lsif_uploads_audit_logs.transition_columns IS 'Array of change
 CREATE INDEX IF NOT EXISTS lsif_uploads_audit_logs_upload_id ON lsif_uploads_audit_logs USING btree (upload_id);
 CREATE INDEX IF NOT EXISTS lsif_uploads_audit_logs_timestamp ON lsif_uploads_audit_logs USING brin (log_timestamp);
 
+-- CREATE TYPE IF NOT EXISTS is not a thing, so we must drop it here,
+-- but also all the functions that reference the type...
+DROP FUNCTION IF EXISTS func_row_to_lsif_uploads_transition_columns;
+DROP FUNCTION IF EXISTS func_lsif_uploads_transition_columns_diff;
+DROP TYPE IF EXISTS lsif_uploads_transition_columns;
+
 CREATE TYPE lsif_uploads_transition_columns AS (
     state           text,
     expired         boolean,


### PR DESCRIPTION
Closes #33599

Example data with an existing LSIF upload and a newer (shadowing) upload being processed. Historic logs for the older upload are gone due to testing migrations, would usually be a whole trail.

![image](https://user-images.githubusercontent.com/18282288/162494394-8af2deab-3016-4fce-8b10-ca77e95e04de.png)


## Test plan

Manually tested locally

