### PR TITLE
batches: fix publication of all changesets on the preview page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Search patterns containing `and` and `not` expressions are now optimized to evaluate natively on the Zoekt backend for indexed code content and symbol search wherever possible. These kinds of queries are now typically an order of magnitude faster. Previous cases where no results were returned for expensive search expressions should now work and return results quickly. [#33308](https://github.com/sourcegraph/sourcegraph/pull/33308)
 - Fail to log extension activation event will no longer block extension from activating [#33300][https://github.com/sourcegraph/sourcegraph/pull/33300]
 - Fixed out-ouf-memory events for gitserver's janitor job "sg maintenance". [#33353](https://github.com/sourcegraph/sourcegraph/issues/33353)
+- Setting the publication state for changesets when previewing a batch spec now works correctly if all changesets are selected and there is more than one page of changesets. [#33619](https://github.com/sourcegraph/sourcegraph/issues/33619)
 
 ### Removed
 

--- a/client/web/src/enterprise/batches/preview/list/PreviewSelectRow.tsx
+++ b/client/web/src/enterprise/batches/preview/list/PreviewSelectRow.tsx
@@ -81,8 +81,17 @@ export const PreviewSelectRow: React.FunctionComponent<PreviewSelectRowProps> = 
                 const dropdownAction: Action = {
                     ...action,
                     onTrigger: onDone => {
+                        const specIDs = selected === 'all' ? allChangesetSpecIDs : [...selected]
+                        if (!specIDs) {
+                            // allChangesetSpecIDs hasn't populated yet: it
+                            // shouldn't be possible to set selected to 'all' if
+                            // that's the case, but to be safe, we'll just bail
+                            // early if that somehow happens.
+                            return
+                        }
+
                         updatePublicationStates(
-                            [...selected].map(changeSpecID => ({
+                            specIDs.map(changeSpecID => ({
                                 changesetSpec: changeSpecID,
                                 publicationState: getPublicationStateFromAction(action),
                             }))
@@ -94,7 +103,7 @@ export const PreviewSelectRow: React.FunctionComponent<PreviewSelectRowProps> = 
 
                 return dropdownAction
             }),
-        [deselectAll, selected, updatePublicationStates]
+        [allChangesetSpecIDs, deselectAll, selected, updatePublicationStates]
     )
 
     return (


### PR DESCRIPTION
Fixes #33619.

## Test plan

Tested by creating a batch spec with more than 15 changesets, setting a publication state on the preview page, and then verifying that all changeset specs have the right publication states and actions.

## App preview:

- [Link](https://sg-web-aharvey-fix-select-all-preview.onrender.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

