### PR TITLE
fix: VSCE code monitor button and update save search form style

### DIFF
--- a/client/vscode/CHANGELOG.md
+++ b/client/vscode/CHANGELOG.md
@@ -14,6 +14,8 @@ The Sourcegraph extension uses major.EVEN_NUMBER.patch (eg. 2.0.1) for release v
 ### Fixes
 
 - Improve developer scripts [issue/32741](https://github.com/sourcegraph/sourcegraph/issues/32741)
+- Code Monitor button redirect issue for non signed-in users [issues/33631](https://github.com/sourcegraph/sourcegraph/issues/33631)
+- Error regarding missing PatternType when creating save search [issues/31093](https://github.com/sourcegraph/sourcegraph/issues/31093)
 
 ## 2.2.0
 

--- a/client/vscode/src/webview/search-panel/SearchResultsView.tsx
+++ b/client/vscode/src/webview/search-panel/SearchResultsView.tsx
@@ -377,7 +377,7 @@ export const SearchResultsView: React.FunctionComponent<SearchResultsViewProps> 
                             authenticatedUser={authenticatedUser}
                             submitLabel="Add saved search"
                             title="Add saved search"
-                            fullQuery={fullQuery}
+                            fullQuery={`${fullQuery} patternType:${context.submittedSearchQueryState.searchPatternType}`}
                             onComplete={() => setShowSavedSearchForm(false)}
                             platformContext={platformContext}
                             instanceURL={instanceURL}

--- a/client/vscode/src/webview/search-panel/components/ButtonDropdownCta.tsx
+++ b/client/vscode/src/webview/search-panel/components/ButtonDropdownCta.tsx
@@ -1,15 +1,18 @@
 import React, { useCallback, useEffect, useState } from 'react'
+
+import { VSCodeButton } from '@vscode/webview-ui-toolkit/react'
 import classNames from 'classnames'
 import { ButtonDropdown, DropdownMenu, DropdownToggle } from 'reactstrap'
 
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
-import { Link, Button } from '@sourcegraph/wildcard'
+
+import { WebviewPageProps } from '../../platform/context'
 
 import styles from './ButtonDropdownCta.module.scss'
 
 // Debt: this is a fork of the web <ButtonDropdownCta>.
 
-export interface ButtonDropdownCtaProps extends TelemetryProps {
+export interface ButtonDropdownCtaProps extends TelemetryProps, Pick<WebviewPageProps, 'extensionCoreAPI'> {
     button: JSX.Element
     icon: JSX.Element
     title: string
@@ -19,7 +22,7 @@ export interface ButtonDropdownCtaProps extends TelemetryProps {
     returnTo: string
     onToggle?: () => void
     className?: string
-    instanceURL: string
+    instanceURL?: string
 }
 
 export const ButtonDropdownCta: React.FunctionComponent<ButtonDropdownCtaProps> = ({
@@ -33,7 +36,7 @@ export const ButtonDropdownCta: React.FunctionComponent<ButtonDropdownCtaProps> 
     returnTo,
     onToggle,
     className,
-    instanceURL,
+    extensionCoreAPI,
 }) => {
     const [isDropdownOpen, setIsDropdownOpen] = useState(false)
 
@@ -41,10 +44,6 @@ export const ButtonDropdownCta: React.FunctionComponent<ButtonDropdownCtaProps> 
         setIsDropdownOpen(isOpen => !isOpen)
         onToggle?.()
     }, [onToggle])
-
-    const onClick = (): void => {
-        telemetryService.log(`VSCE${source}SignUpModalClick`)
-    }
 
     // Whenever dropdown opens, log view event
     useEffect(() => {
@@ -60,6 +59,13 @@ export const ButtonDropdownCta: React.FunctionComponent<ButtonDropdownCtaProps> 
     const signUpURL = `https://sourcegraph.com/sign-up?src=${source}&returnTo=${encodeURIComponent(
         returnTo
     )}&utm_medium=VSCODE&utm_source=sidebar&utm_campaign=vsce-sign-up&utm_content=sign-up`
+
+    const onClick = (): void => {
+        telemetryService.log(`VSCE${source}SignUpModalClick`)
+        extensionCoreAPI.openLink(signUpURL).catch(() => {
+            console.error('Error opening sign up link')
+        })
+    }
 
     return (
         <ButtonDropdown className="menu-nav-item" direction="down" isOpen={isDropdownOpen} toggle={toggleDropdownOpen}>
@@ -86,9 +92,9 @@ export const ButtonDropdownCta: React.FunctionComponent<ButtonDropdownCtaProps> 
                         <div className={classNames('text-muted', styles.copyText)}>{copyText}</div>
                     </div>
                 </div>
-                <Button to={signUpURL} onClick={onClick} variant="primary" as={Link}>
+                <VSCodeButton type="button" onClick={onClick} autofocus={true}>
                     Sign up for Sourcegraph
-                </Button>
+                </VSCodeButton>
             </DropdownMenu>
         </ButtonDropdown>
     )

--- a/client/vscode/src/webview/search-panel/components/SavedSearchForm.module.scss
+++ b/client/vscode/src/webview/search-panel/components/SavedSearchForm.module.scss
@@ -1,13 +1,14 @@
+.container {
+    background-color: var(--vscode-editorWidget-background) !important;
+    padding: 0.5rem;
+}
+
 .checkbox {
     margin-right: 0.25rem;
 }
 
 .label {
     font-weight: bold;
-}
-
-.submit-button {
-    margin-bottom: 1rem;
 }
 
 // Hide icon in alert

--- a/client/vscode/src/webview/search-panel/components/SearchResultsInfoBar.tsx
+++ b/client/vscode/src/webview/search-panel/components/SearchResultsInfoBar.tsx
@@ -7,6 +7,7 @@ import LinkIcon from 'mdi-react/LinkIcon'
 
 import { SearchPatternType } from '@sourcegraph/shared/src/schema'
 import { FilterKind, findFilter } from '@sourcegraph/shared/src/search/query/query'
+import { Icon } from '@sourcegraph/wildcard'
 
 import { WebviewPageProps } from '../../platform/context'
 
@@ -68,7 +69,7 @@ const QuotesInterpretedLiterallyNotice: React.FunctionComponent<SearchResultsInf
             data-tooltip="Your search query is interpreted literally, including the quotes. Use the .* toggle to switch between literal and regular expression search."
         >
             <span>
-                <FormatQuoteOpenIcon className="icon-inline" />
+                <Icon className="mr-1" as={FormatQuoteOpenIcon} />
                 Searching literally <strong>(including quotes)</strong>
             </span>
         </small>
@@ -129,21 +130,20 @@ export const SearchResultsInfoBar: React.FunctionComponent<SearchResultsInfoBarP
         searchParameters.set('q', fullQuery)
         searchParameters.set('trigger-query', `${fullQuery} patternType:${patternType}`)
         return (
-            <li
-                className={classNames('mr-2', styles.navItem)}
-                data-tooltip={
-                    !canCreateMonitorFromQuery
-                        ? 'Code monitors only support type:diff or type:commit searches.'
-                        : undefined
-                }
-            >
+            <li className={classNames('mr-2', styles.navItem)}>
                 <ExperimentalActionButton
+                    extensionCoreAPI={extensionCoreAPI}
                     showExperimentalVersion={showActionButtonExperimentalVersion}
                     onNonExperimentalLinkClick={onCreateCodeMonitorButtonClick}
                     className="test-save-search-link"
+                    data-tooltip={
+                        !canCreateMonitorFromQuery
+                            ? 'Code monitors only support type:diff or type:commit searches.'
+                            : undefined
+                    }
                     button={
                         <>
-                            <CodeMonitoringLogo className="icon-inline mr-1" />
+                            <Icon className="mr-1" as={CodeMonitoringLogo} />
                             Monitor
                         </>
                     }
@@ -156,30 +156,31 @@ export const SearchResultsInfoBar: React.FunctionComponent<SearchResultsInfoBarP
                     telemetryService={platformContext.telemetryService}
                     isNonExperimentalLinkDisabled={!canCreateMonitorFromQuery}
                     instanceURL={instanceURL}
-                    onToggle={onCreateCodeMonitorButtonClick}
                 />
             </li>
         )
     }, [
-        canCreateMonitorFromQuery,
         fullQuery,
-        instanceURL,
-        onCreateCodeMonitorButtonClick,
-        platformContext.telemetryService,
-        showActionButtonExperimentalVersion,
         patternType,
+        extensionCoreAPI,
+        showActionButtonExperimentalVersion,
+        onCreateCodeMonitorButtonClick,
+        canCreateMonitorFromQuery,
+        platformContext.telemetryService,
+        instanceURL,
     ])
 
     const saveSearchButton = useMemo(
         () => (
             <li className={classNames('mr-2', styles.navItem)}>
                 <ExperimentalActionButton
+                    extensionCoreAPI={extensionCoreAPI}
                     showExperimentalVersion={showActionButtonExperimentalVersion}
                     onNonExperimentalLinkClick={onSaveSearchButtonClick}
                     className="test-save-search-link"
                     button={
                         <>
-                            <BookmarkOutlineIcon className="icon-inline mr-1" />
+                            <Icon className="mr-1" as={BookmarkOutlineIcon} />
                             Save search
                         </>
                     }
@@ -192,35 +193,47 @@ export const SearchResultsInfoBar: React.FunctionComponent<SearchResultsInfoBarP
                     telemetryService={platformContext.telemetryService}
                     isNonExperimentalLinkDisabled={showActionButtonExperimentalVersion}
                     instanceURL={instanceURL}
-                    onToggle={onSaveSearchButtonClick}
+                    onToggle={() => setShowSavedSearchForm(!showSavedSearchForm)}
                 />
             </li>
         ),
-        [showActionButtonExperimentalVersion, onSaveSearchButtonClick, platformContext.telemetryService, instanceURL]
+        [
+            extensionCoreAPI,
+            showActionButtonExperimentalVersion,
+            onSaveSearchButtonClick,
+            platformContext.telemetryService,
+            instanceURL,
+            setShowSavedSearchForm,
+            showSavedSearchForm,
+        ]
+    )
+
+    const ShareLinkButton = useMemo(
+        () => (
+            <li className={classNames('mr-2', styles.navItem)} data-tooltip="Share results link">
+                <button
+                    type="button"
+                    className="btn btn-sm btn-outline-secondary text-decoration-none"
+                    onClick={onShareResultsClick}
+                >
+                    <Icon className="mr-1" as={LinkIcon} />
+                    Share
+                </button>
+            </li>
+        ),
+        [onShareResultsClick]
     )
 
     return (
         <div className={classNames('flex-grow-1 my-2', styles.searchResultsInfoBar)} data-testid="results-info-bar">
             <div className={styles.row}>
                 {stats}
-
                 <QuotesInterpretedLiterallyNotice {...props} />
-
                 <div className={styles.expander} />
-
                 <ul className="nav align-items-center">
                     {createCodeMonitorButton}
                     {saveSearchButton}
-                    <li className={classNames('mr-2', styles.navItem)} data-tooltip="Share results link">
-                        <button
-                            type="button"
-                            className="btn btn-sm btn-outline-secondary text-decoration-none"
-                            onClick={onShareResultsClick}
-                        >
-                            <LinkIcon className="icon-inline mr-1" />
-                            Share
-                        </button>
-                    </li>
+                    {ShareLinkButton}
                 </ul>
             </div>
         </div>


### PR DESCRIPTION
This PR fixes the code monitor button redirect issue as mentioned in https://github.com/sourcegraph/sourcegraph/issues/33631

Currently Clicking on the Code Monitor Button as a non-signed-in user would open the sign up modal as well as the browser window to create code monitor. The expected behavior is to open the browser window if the user is signed in, and open the modal only if the user is not signed in.

In addition to the fix for the aforementioned issue, this PR also:
- update button element for the pop up modal (now using the button element from the vscode webview kit) as we were using the wrong button color previously.
Before:
![image](https://user-images.githubusercontent.com/68532117/162544867-bd8fe851-970f-447e-911a-851eb0a58b48.png)
After:
![image](https://user-images.githubusercontent.com/68532117/162544809-0e0bf66b-a4f5-4c2c-8433-a3c68218166b.png)

- fix the save search create form issue discussed in https://github.com/sourcegraph/sourcegraph/issues/31093 where pattern type is not imported when trying to create a new save search, resulting in error.
Before:
![image](https://user-images.githubusercontent.com/68532117/162545141-9102eb7b-3b62-48b0-aeaf-5b2a834a34b9.png)
After:
![image](https://user-images.githubusercontent.com/68532117/162545365-dd59bdf8-a8ca-4287-b777-44ef8686fa5f.png)


- update the save search create form style to match the CTA banner. Also included a dismiss button
Before
![image](https://user-images.githubusercontent.com/68532117/162545013-c8baa947-f2fc-4599-9229-6963e843e097.png)
After:
![image](https://user-images.githubusercontent.com/68532117/162544987-313e6505-be2c-4269-a2a3-dcda89b4d6d9.png)

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

N/A for styling
