### PR TITLE
Accessibility: Expand accessibility issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/accessibility_issue.yaml
+++ b/.github/ISSUE_TEMPLATE/accessibility_issue.yaml
@@ -5,33 +5,55 @@ labels:
 - 'accessibility'
 - 'wcag/2.1'
 - 'wcag/2.1/fixing'
-- 'estimate/3d'
 body:
   - type: markdown
     attributes:
       value: |
         Thanks for your contribution to the accessibility of Sourcegraph!
-
-        Please note that this issue has been automatically given an estimate of **3 days**.
-        You can modify this estimate by changing the label from *estimate/3d* to *estimate/Xd* where X is the correct number of days.
+  - type: dropdown
+    id: audit-type
+    attributes:
+      label: Audit type
+      description: What type of audit does this issue relate to?
+      options:
+        - Keyboard navigation
+        - Screen reader navigation
+        - Mobile device navigation
+        - ARC Toolkit
+        - General/Other
+    validations:
+      required: true
+  - type: input
+    id: user-journey-issue
+    attributes:
+      label: User journey audit issue
+      description: If this issue is related to a specific GH issue for auditing an individual user journey, please provide a link to the issue here.
   - type: textarea
     id: problem-description
     attributes:
       label: Problem description
-      description: Please describe the issue is as much detail as possible
+      description: Please describe the issue and the steps required to replicate it.
     validations:
       required: true
   - type: textarea
     id: solution-description
     attributes:
       label: Expected behavior
-      description: Please describe the expected behavior
+      description: Please describe the expected or accessibility-compliant behavior.
     validations:
       required: true
   - type: textarea
     id: additional-details
     attributes:
       label: Additional details
-      description: Notes and/or screenshot describing the problem, details how to replicate, etc
+      description: Provide any notes, screenshots, and/or additional context here.
     validations:
       required: false
+  - type: checkboxes
+    id: labels
+    attributes:
+      label: Assigning labels
+      options:
+      - label: Please give this issue an estimate by applying a label like `estimate/Xd`, where X is the estimated number of days it will take to complete.
+      - label: If this issue is specific to a specific Sourcegraph product, e.g. Code Intel, Batch Changes, etc., please assign the appropriate team label to this issue.
+      - label: If this issue will require input from designers in order to complete, please assign the label `needs-design`.


### PR DESCRIPTION
As part of estimating the effort that auditing and fixing accessibility issues will require for our team in Q2, I pretended to walk through all of the steps required to audit one of the Batch Changes user journeys. I found, when pretending to submit a GitHub issue for an accessibility bug, that I wanted to have a couple other pieces of information included here. I've modified the GitHub issue template slightly to reflect these fields, as well as more explicitly encourage setting the appropriate labels on the issue.

## Test plan

This just modifies an issue template.


