### PR TITLE
Fix CentOS installation troubleshooting docs

### DIFF
--- a/doc/admin/deploy/docker-single-container/index.md
+++ b/doc/admin/deploy/docker-single-container/index.md
@@ -198,7 +198,7 @@ If you run Docker on an OS such as RHEL, Fedora, or CentOS with SELinux enabled,
 
 To fix this, run:
 
-`mkdir -p ~/.sourcegraph/config ~/.sourcegraph/data && chown -R -t svirt_sandbox_file_t ~/.sourcegraph/config ~/.sourcegraph/data`
+`mkdir -p ~/.sourcegraph/config ~/.sourcegraph/data && chcon -R -t svirt_sandbox_file_t ~/.sourcegraph/config ~/.sourcegraph/data`
 
 ## Reference
 


### PR DESCRIPTION
The SELinux permissions fix in the single-container instructions seem to
be mis-transcribed. To change SELinux permissions you need to use
`chcon` not `chown`.

No functional changes.

## Test plan
Manually verified on CentOS Stream 9
<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


