### PR TITLE
Enable notebooks by default

### DIFF
--- a/client/web/src/nav/GlobalNavbar.tsx
+++ b/client/web/src/nav/GlobalNavbar.tsx
@@ -26,15 +26,7 @@ import { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
 import { buildGetStartedURL } from '@sourcegraph/shared/src/util/url'
-import {
-    ProductStatusBadge,
-    useObservable,
-    Button,
-    Link,
-    FeedbackPrompt,
-    ButtonLink,
-    PopoverTrigger,
-} from '@sourcegraph/wildcard'
+import { useObservable, Button, Link, FeedbackPrompt, ButtonLink, PopoverTrigger } from '@sourcegraph/wildcard'
 
 import { AuthenticatedUser } from '../auth'
 import { BatchChangesProps } from '../batches'
@@ -209,11 +201,7 @@ export const GlobalNavbar: React.FunctionComponent<Props> = ({
                 !!showSearchContext && { path: EnterprisePageRoutes.Contexts, content: 'Contexts' },
             !!showSearchNotebook && {
                 path: PageRoutes.Notebooks,
-                content: (
-                    <>
-                        Notebooks <ProductStatusBadge className="ml-1" status="beta" />
-                    </>
-                ),
+                content: 'Notebooks',
             },
         ]
         return items.filter<NavDropdownItem>((item): item is NavDropdownItem => !!item)

--- a/client/web/src/notebooks/notebookPage/NotebookPage.tsx
+++ b/client/web/src/notebooks/notebookPage/NotebookPage.tsx
@@ -13,14 +13,7 @@ import { ExtensionsControllerProps } from '@sourcegraph/shared/src/extensions/co
 import { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
-import {
-    FeedbackBadge,
-    LoadingSpinner,
-    PageHeader,
-    useEventObservable,
-    useObservable,
-    Alert,
-} from '@sourcegraph/wildcard'
+import { LoadingSpinner, PageHeader, useEventObservable, useObservable, Alert } from '@sourcegraph/wildcard'
 
 import { Block } from '..'
 import { AuthenticatedUser } from '../../auth'
@@ -204,10 +197,7 @@ export const NotebookPage: React.FunctionComponent<NotebookPageProps> = ({
                     {isNotebookLoaded(notebookOrError) && (
                         <>
                             <PageHeader
-                                className="mt-3"
-                                annotation={
-                                    <FeedbackBadge status="beta" feedback={{ mailto: 'support@sourcegraph.com' }} />
-                                }
+                                className="mt-2"
                                 path={[
                                     { icon: MagnifyIcon, to: '/search' },
                                     { to: '/notebooks', text: 'Notebooks' },

--- a/client/web/src/stores/experimentalFeatures.ts
+++ b/client/web/src/stores/experimentalFeatures.ts
@@ -15,7 +15,7 @@ const defaultSettings: SettingsExperimentalFeatures = {
     showOnboardingTour: true,
     showSearchContext: true,
     showSearchContextManagement: true,
-    showSearchNotebook: false,
+    showSearchNotebook: true,
     showComputeComponent: false,
     codeMonitoringWebHooks: false,
     showCodeMonitoringLogs: true,

--- a/schema/settings.schema.json
+++ b/schema/settings.schema.json
@@ -154,7 +154,7 @@
         "showSearchNotebook": {
           "description": "Enables the search notebook at search/notebook",
           "type": "boolean",
-          "default": false,
+          "default": true,
           "!go": {
             "pointer": true
           }


### PR DESCRIPTION
This PR enables notebooks by default and removes the `Beta` tags from the notebook page and the nav dropdown item.

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

* Checked the notebooks pages and the nav header to see if the beta tag is removed
* No other functionality has been changed


