### PR TITLE
gomodproxy: Look up the rate limiter based on extsvc urn

### DIFF
--- a/cmd/gitserver/main.go
+++ b/cmd/gitserver/main.go
@@ -422,10 +422,11 @@ func getVCSSyncer(ctx context.Context, externalServiceStore database.ExternalSer
 		return server.NewNpmPackagesSyncer(c, codeintelDB, nil, urn), nil
 	case extsvc.TypeGoModules:
 		var c schema.GoModulesConnection
-		if _, err := extractOptions(&c); err != nil {
+		urn, err := extractOptions(&c)
+		if err != nil {
 			return nil, err
 		}
-		cli := gomodproxy.NewClient(&c, httpcli.ExternalDoer)
+		cli := gomodproxy.NewClient(urn, &c, httpcli.ExternalDoer)
 		return server.NewGoModulesSyncer(&c, codeintelDB, cli), nil
 	}
 	return &server.GitRepoSyncer{}, nil

--- a/cmd/gitserver/main.go
+++ b/cmd/gitserver/main.go
@@ -426,7 +426,7 @@ func getVCSSyncer(ctx context.Context, externalServiceStore database.ExternalSer
 		if err != nil {
 			return nil, err
 		}
-		cli := gomodproxy.NewClient(urn, &c, httpcli.ExternalDoer)
+		cli := gomodproxy.NewClient(urn, c.Urls, httpcli.ExternalDoer)
 		return server.NewGoModulesSyncer(&c, codeintelDB, cli), nil
 	}
 	return &server.GitRepoSyncer{}, nil

--- a/internal/extsvc/gomodproxy/client.go
+++ b/internal/extsvc/gomodproxy/client.go
@@ -18,7 +18,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/internal/ratelimit"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
-	"github.com/sourcegraph/sourcegraph/schema"
 )
 
 // A Client to Go module proxies.
@@ -28,11 +27,11 @@ type Client struct {
 	limiter *rate.Limiter
 }
 
-// NewClient returns a new Client for the given configuration. urn represents the
+// NewClient returns a new Client for the given urls. urn represents the
 // unique urn of the external service this client's config is from.
-func NewClient(urn string, config *schema.GoModulesConnection, cli httpcli.Doer) *Client {
+func NewClient(urn string, urls []string, cli httpcli.Doer) *Client {
 	return &Client{
-		urls:    config.Urls,
+		urls:    urls,
 		cli:     cli,
 		limiter: ratelimit.DefaultRegistry.Get(urn),
 	}

--- a/internal/extsvc/gomodproxy/client.go
+++ b/internal/extsvc/gomodproxy/client.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"math"
 	"net/http"
 	"net/url"
 	"path"
@@ -29,19 +28,13 @@ type Client struct {
 	limiter *rate.Limiter
 }
 
-// NewClient returns a new Client for the given configuration.
-func NewClient(config *schema.GoModulesConnection, cli httpcli.Doer) *Client {
-	var requestsPerHour float64
-	if config.RateLimit == nil || !config.RateLimit.Enabled {
-		requestsPerHour = math.Inf(1)
-	} else {
-		requestsPerHour = config.RateLimit.RequestsPerHour
-	}
-
+// NewClient returns a new Client for the given configuration. urn represents the
+// unique urn of the external service this client's config is from.
+func NewClient(urn string, config *schema.GoModulesConnection, cli httpcli.Doer) *Client {
 	return &Client{
 		urls:    config.Urls,
 		cli:     cli,
-		limiter: rate.NewLimiter(rate.Limit(requestsPerHour/3600.0), 100),
+		limiter: ratelimit.DefaultRegistry.Get(urn),
 	}
 }
 
@@ -103,10 +96,8 @@ func (c *Client) get(ctx context.Context, mod string, paths ...string) (respBody
 	)
 
 	for _, baseURL := range c.urls {
-		limiter := ratelimit.DefaultRegistry.GetOrSet(baseURL, c.limiter)
-
 		startWait := time.Now()
-		if err = limiter.Wait(ctx); err != nil {
+		if err = c.limiter.Wait(ctx); err != nil {
 			return nil, err
 		}
 

--- a/internal/extsvc/gomodproxy/client_test.go
+++ b/internal/extsvc/gomodproxy/client_test.go
@@ -139,7 +139,7 @@ func newTestClient(t testing.TB, name string, update bool) *Client {
 		Urls: []string{"https://proxy.golang.org"},
 	}
 
-	return NewClient(c, hc)
+	return NewClient("urn", c, hc)
 }
 
 var normalizer = lazyregexp.New("[^A-Za-z0-9-]+")

--- a/internal/extsvc/gomodproxy/client_test.go
+++ b/internal/extsvc/gomodproxy/client_test.go
@@ -139,7 +139,7 @@ func newTestClient(t testing.TB, name string, update bool) *Client {
 		Urls: []string{"https://proxy.golang.org"},
 	}
 
-	return NewClient("urn", c, hc)
+	return NewClient("urn", c.Urls, hc)
 }
 
 var normalizer = lazyregexp.New("[^A-Za-z0-9-]+")

--- a/internal/extsvc/npm/npm.go
+++ b/internal/extsvc/npm/npm.go
@@ -93,12 +93,11 @@ type HTTPClient struct {
 }
 
 func NewHTTPClient(urn string, registryURL string, credentials string) *HTTPClient {
-	cachedLimiter := ratelimit.DefaultRegistry.Get(urn)
 	return &HTTPClient{
-		registryURL,
-		httpcli.ExternalDoer,
-		cachedLimiter,
-		credentials,
+		registryURL: registryURL,
+		doer:        httpcli.ExternalDoer,
+		limiter:     ratelimit.DefaultRegistry.Get(urn),
+		credentials: credentials,
 	}
 }
 

--- a/internal/extsvc/types.go
+++ b/internal/extsvc/types.go
@@ -443,6 +443,12 @@ func GetLimitFromConfig(kind string, config interface{}) (rate.Limit, error) {
 		if c != nil && c.RateLimit != nil {
 			limit = limitOrInf(c.RateLimit.Enabled, c.RateLimit.RequestsPerHour)
 		}
+	case *schema.GoModulesConnection:
+		// 3000 per hour is the same default we use in our schema
+		limit = rate.Limit(3000.0 / 3600.0)
+		if c != nil && c.RateLimit != nil {
+			limit = limitOrInf(c.RateLimit.Enabled, c.RateLimit.RequestsPerHour)
+		}
 	default:
 		return limit, ErrRateLimitUnsupported{codehostKind: kind}
 	}

--- a/internal/extsvc/types_test.go
+++ b/internal/extsvc/types_test.go
@@ -121,6 +121,18 @@ func TestExtractRateLimitConfig(t *testing.T) {
 			want:   1.0,
 		},
 		{
+			name:   "Go mod default",
+			config: `{"urls": ["https://example.com"]}`,
+			kind:   KindGoModules,
+			want:   3000.0 / 3600.0,
+		},
+		{
+			name:   "Go mod non-default",
+			config: `{"urls": ["https://example.com"], "rateLimit": {"enabled": true, "requestsPerHour": 3600}}`,
+			kind:   KindNpmPackages,
+			want:   1.0,
+		},
+		{
 			name:   "No trailing slash",
 			config: `{"url": "https://example.com", "rateLimit": {"enabled": true, "requestsPerHour": 3600}}`,
 			kind:   KindBitbucketCloud,

--- a/internal/repos/go_modules.go
+++ b/internal/repos/go_modules.go
@@ -46,8 +46,8 @@ func NewGoModulesSource(svc *types.ExternalService, cf *httpcli.Factory) (*GoMod
 	return &GoModulesSource{
 		svc:    svc,
 		config: &c,
-		/*dbStore initialized in SetDB */
-		client: gomodproxy.NewClient(&c, cli),
+		/* dbStore initialized in SetDB */
+		client: gomodproxy.NewClient(svc.URN(), &c, cli),
 	}, nil
 }
 

--- a/internal/repos/go_modules.go
+++ b/internal/repos/go_modules.go
@@ -47,7 +47,7 @@ func NewGoModulesSource(svc *types.ExternalService, cf *httpcli.Factory) (*GoMod
 		svc:    svc,
 		config: &c,
 		/* dbStore initialized in SetDB */
-		client: gomodproxy.NewClient(svc.URN(), &c, cli),
+		client: gomodproxy.NewClient(svc.URN(), c.Urls, cli),
 	}, nil
 }
 


### PR DESCRIPTION
This is consistent with our other external services and should fix an
issue where the connection always has an infinite limiter in production.

# Test plan

Tested locally and will also confirm that rate limit isn't infinite in production after deployment.