### PR TITLE
Double user added repos limit

### DIFF
--- a/doc/admin/observability/alert_solutions.md
+++ b/doc/admin/observability/alert_solutions.md
@@ -3076,7 +3076,7 @@ with your code hosts connections or networking issues affecting communication wi
 
 **Descriptions**
 
-- <span class="badge badge-critical">critical</span> repo-updater: 360000+ total number of user added repos for 5m0s
+- <span class="badge badge-critical">critical</span> repo-updater: 720000+ total number of user added repos for 5m0s
 
 **Possible solutions**
 

--- a/internal/gitserver/mock_client.go
+++ b/internal/gitserver/mock_client.go
@@ -5,7 +5,7 @@ package gitserver
 import (
 	"context"
 	"io"
-	fs "io/fs"
+	"io/fs"
 	"net/http"
 	"net/url"
 	"sync"

--- a/monitoring/definitions/repo_updater.go
+++ b/monitoring/definitions/repo_updater.go
@@ -134,7 +134,7 @@ func RepoUpdater() *monitoring.Container {
 							Description: "total number of user added repos",
 							Query:       `max(src_repoupdater_user_repos_total)`,
 							// 90% of our enforced limit
-							Critical:          monitoring.Alert().GreaterOrEqual(400000 * 0.9).For(5 * time.Minute),
+							Critical:          monitoring.Alert().GreaterOrEqual(800000 * 0.9).For(5 * time.Minute),
 							Panel:             monitoring.Panel().Unit(monitoring.Number),
 							Owner:             monitoring.ObservableOwnerCoreApplication,
 							PossibleSolutions: "Check for unusual spikes in user added repos. Each user is only allowed to add 2000 and we have a site wide limit of 400k.",


### PR DESCRIPTION
Increase the user added repos limit from 400000 to 800000 - growth looks organic enough.
<img width="1843" alt="Screenshot 2022-04-11 at 15 19 35" src="https://user-images.githubusercontent.com/1022220/162748085-9c1acd85-d9b6-486c-a499-935fe007c513.png">
Context [slack](https://sourcegraph.slack.com/archives/C0J618TTM/p1649680343430269)
Site-config change https://github.com/sourcegraph/deploy-sourcegraph-cloud/pull/16130

## Test plan

- Monitoring change

