### PR TITLE
ci: clarify instrumentation failure impact

### DIFF
--- a/.buildkite/hooks/post-command
+++ b/.buildkite/hooks/post-command
@@ -20,7 +20,12 @@
     done
 
     # None of the exit codes were 0 or soft fails, report the failure then.
-    buildevents build "$BUILDKITE_BUILD_ID" "$BUILD_START_TIME" failure
+    # buildevents wfpwfp # build "$BUILDKITE_BUILD_ID" "$BUILD_START_TIME" failure
+    if ! buildevents build "$BUILDKITE_BUILD_ID" "$BUILD_START_TIME" failure; then
+      echo -e "\033[33m┌────────────────────────────────────────────────────────────────────┐\033[0m"
+      echo -e "\033[33m│ The failure in this hook does not impact the outcome of this build │\033[0m"
+      echo -e "\033[33m└────────────────────────────────────────────────────────────────────┘\033[0m"
+    fi
 
     # Return the original exit code
     exit "$exit_code"

--- a/dev/ci/yarn-run.sh
+++ b/dev/ci/yarn-run.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+exit 66
+
 echo "--- yarn"
 # mutex is necessary since CI runs various yarn installs in parallel
 yarn --mutex network --frozen-lockfile --network-timeout 60000

--- a/enterprise/dev/ci/scripts/upload-build-logs.sh
+++ b/enterprise/dev/ci/scripts/upload-build-logs.sh
@@ -37,4 +37,11 @@ echo "~~~ :file_cabinet: Uploading logs"
 # Because we are running this script in the buildkite post-exit hook, the state of the job is still "running".
 # Passing --state="" just overrides the default. It's not set to any specific state because this script caller
 # is responsible of making sure the job has failed.
-./enterprise/dev/ci/scripts/sentry-capture.sh ./sg ci logs --out="$BUILD_LOGS_LOKI_URL" --state="" --overwrite-state="failed" --build="$BUILDKITE_BUILD_NUMBER" --job="$BUILDKITE_JOB_ID"
+./enterprise/dev/ci/scripts/sentry-capture.sh ./sg ci logs --out="" --state="" --overwrite-state="failed" --build="$BUILDKITE_BUILD_NUMBER" --job="$BUILDKITE_JOB_ID"
+local_exit_code=$?
+if [[ $local_exit_code -ne 0 ]]; then
+  echo -e "\033[33m┌────────────────────────────────────────────────────────────────────┐\033[0m"
+  echo -e "\033[33m│ The failure in this hook does not impact the outcome of this build │\033[0m"
+  echo -e "\033[33m└────────────────────────────────────────────────────────────────────┘\033[0m"
+fi
+exit $local_exit_code


### PR DESCRIPTION
Twice today, someone got confused and incorrectly assumed the failure in logs uploading was the cause of a failed build. 

The problem is that leads teammates to think the CI is at fault, while it actually isn't, which will either be surfaced by a subsequent failure or reaching us on the support. 

This PR adds a visible warning explaining that the log uploading and trace uploading are not the source of build failures.

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

See QA run: https://buildkite.com/sourcegraph/sourcegraph/builds/141537#fd1313e3-29e1-4d61-a9b5-6eac8e495ae5/174-176