### PR TITLE
Search: make ComputeExcludedRepos aware of dependency search

### DIFF
--- a/internal/search/repos/repos.go
+++ b/internal/search/repos/repos.go
@@ -441,16 +441,11 @@ func (r *Resolver) Excluded(ctx context.Context, op search.RepoOptions) (ex Excl
 		return ExcludedRepos{}, err
 	}
 
-	var depNames []string
 	if len(op.Dependencies) > 0 {
-		depNames, _, err = r.dependencies(ctx, &op)
-		if err != nil {
-			return ExcludedRepos{}, err
-		}
-
-		if len(depNames) == 0 {
-			return ExcludedRepos{}, ErrNoResolvedRepos
-		}
+		// Dependency search only operates on package repos. Since package repos
+		// cannot be archives or forks, there will never be any excluded repos for
+		// dependency search, so we can avoid doing extra work here.
+		return ExcludedRepos{}, nil
 	}
 
 	searchContext, err := searchcontexts.ResolveSearchContextSpec(ctx, r.DB, op.SearchContextSpec)
@@ -460,7 +455,6 @@ func (r *Resolver) Excluded(ctx context.Context, op search.RepoOptions) (ex Excl
 
 	options := database.ReposListOptions{
 		IncludePatterns: includePatterns,
-		Names:           depNames,
 		ExcludePattern:  search.UnionRegExps(excludePatterns),
 		// List N+1 repos so we can see if there are repos omitted due to our repo limit.
 		LimitOffset:            &database.LimitOffset{Limit: limit + 1},


### PR DESCRIPTION
When dependency search was added, the ComputeExcludedRepos job was not
updated to reflect the new repo search type, so the statistics returned
by ComputeExcludedRepos were incorrect. This makes the exclusion
computation step behave the same as the resolution step by adding
dependency resolution to the job.

I _think_ it's probably safe to just disable excluded repo computation for 
dependency search since I don't think package repos will ever be marked as
forks or archived. However, right now, dependency search still excludes forks
and archived repos by default, so I implemented the fix such that it follows
exactly what dependency search does (whether or not it matters). 

## Test plan

Manually tested that dependency search does not show skipped repo stats.

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


