### PR TITLE
rcache: handle redis not instantly expiring

### DIFF
--- a/internal/rcache/rcache_test.go
+++ b/internal/rcache/rcache_test.go
@@ -194,8 +194,12 @@ func TestCache_Increase(t *testing.T) {
 	assert.Equal(t, []byte("1"), got)
 
 	time.Sleep(time.Second)
-	_, ok = c.Get("a")
-	assert.False(t, ok)
+
+	// now wait upto another 5s. We do this because timing is hard.
+	assert.Eventually(t, func() bool {
+		_, ok = c.Get("a")
+		return !ok
+	}, 5*time.Second, 50*time.Millisecond, "rcache.increase did not respect expiration")
 }
 
 func bytes(s ...string) [][]byte {


### PR DESCRIPTION
This test has been flakey on CI. It feels like we shouldn't be so strict
on the timing, especially since they are different processes running. I
added a 5s buffer.

Test Plan: "go test -count=5". Additionally I increased the TTL to 10s
and the test did fail.