### PR TITLE
dev/sg: check status code of sg download before using it as binary

### DIFF
--- a/dev/sg/sg_update.go
+++ b/dev/sg/sg_update.go
@@ -73,6 +73,10 @@ func updateToPrebuiltSG(ctx context.Context) (string, error) {
 	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode != http.StatusOK {
+		return "", errors.Newf("downloading sg: status %d", resp.StatusCode)
+	}
+
 	tmpSgPath := tmpDir + "/sg"
 	f, err := os.Create(tmpSgPath)
 	if err != nil {


### PR DESCRIPTION
Prevents trying to run an HTML file as sg. See https://sourcegraph.slack.com/archives/C01N83PS4TU/p1649689285098699

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

n/a
