### PR TITLE
pagure: Rely on rate limiter syncing

### DIFF
--- a/internal/extsvc/pagure/testing.go
+++ b/internal/extsvc/pagure/testing.go
@@ -42,7 +42,7 @@ func NewTestClient(t testing.TB, name string, update bool) (*Client, func()) {
 		Url:   instanceURL,
 	}
 
-	cli, err := NewClient(c, hc)
+	cli, err := NewClient("urn", c, hc)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/repos/pagure.go
+++ b/internal/repos/pagure.go
@@ -42,7 +42,7 @@ func NewPagureSource(svc *types.ExternalService, cf *httpcli.Factory) (*PagureSo
 		return nil, err
 	}
 
-	cli, err := pagure.NewClient(&c, httpCli)
+	cli, err := pagure.NewClient(svc.URN(), &c, httpCli)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
We don't need to set up a custom fallback rate limiter as we can rely on
our existing rate limit syncing.

This is the same approach that is used for all our other code host
connections.
