### PR TITLE
Enable accessibilityAudit on `client/web/src/integration/org.test.ts`

### DIFF
--- a/client/shared/src/testing/accessibility.ts
+++ b/client/shared/src/testing/accessibility.ts
@@ -47,7 +47,10 @@ export const ACCESSIBILITY_AUDIT_IGNORE_CLASS = '.a11y-ignore'
  */
 export async function accessibilityAudit(page: Page, config: AccessibilityAuditConfiguration = {}): Promise<void> {
     const { options, mode = 'fail' } = config
-    const axe = new AxePuppeteer(page).exclude(ACCESSIBILITY_AUDIT_IGNORE_CLASS)
+    const axe = new AxePuppeteer(page)
+        .exclude(ACCESSIBILITY_AUDIT_IGNORE_CLASS)
+        // https://github.com/microsoft/monaco-editor/issues/2448
+        .exclude('.monaco-status')
 
     if (options) {
         axe.options(options)

--- a/client/web/src/components/Sidebar.tsx
+++ b/client/web/src/components/Sidebar.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 
 import classNames from 'classnames'
+import kebabCase from 'lodash/kebabCase'
 import MenuDownIcon from 'mdi-react/MenuDownIcon'
 import MenuUpIcon from 'mdi-react/MenuUpIcon'
 import { useRouteMatch } from 'react-router-dom'
@@ -55,7 +56,7 @@ export const SidebarCollapseItems: React.FunctionComponent<{
             <>
                 <CollapseHeader
                     aria-expanded={isOpen}
-                    aria-controls={label}
+                    aria-controls={kebabCase(label)}
                     type="button"
                     className="bg-2 border-0 d-flex justify-content-between list-group-item-action py-2 w-100"
                 >
@@ -64,7 +65,7 @@ export const SidebarCollapseItems: React.FunctionComponent<{
                     </span>
                     <Icon className={styles.chevron} as={isOpen ? MenuUpIcon : MenuDownIcon} />
                 </CollapseHeader>
-                <CollapsePanel id={label} className="border-top">
+                <CollapsePanel id={kebabCase(label)} className="border-top">
                     {children}
                 </CollapsePanel>
             </>

--- a/client/web/src/integration/org.test.ts
+++ b/client/web/src/integration/org.test.ts
@@ -2,6 +2,7 @@ import assert from 'assert'
 
 import { subtypeOf } from '@sourcegraph/common'
 import { SharedGraphQlOperations } from '@sourcegraph/shared/src/graphql-operations'
+import { accessibilityAudit } from '@sourcegraph/shared/src/testing/accessibility'
 import { Driver, createDriverForTest } from '@sourcegraph/shared/src/testing/driver'
 import { emptyResponse } from '@sourcegraph/shared/src/testing/integration/graphQlResults'
 import { afterEachSaveScreenshotIfFailed } from '@sourcegraph/shared/src/testing/screenshotReporter'
@@ -88,6 +89,7 @@ describe('Organizations', () => {
             await driver.page.waitForSelector('.test-create-org-button')
 
             await percySnapshotWithVariants(driver.page, 'Site admin org page')
+            await accessibilityAudit(driver.page)
 
             await driver.page.click('.test-create-org-button')
 
@@ -173,6 +175,7 @@ describe('Organizations', () => {
                 })
 
                 await percySnapshotWithVariants(driver.page, 'Organization settings page')
+                await accessibilityAudit(driver.page)
             })
         })
         describe('Members tab', () => {
@@ -229,6 +232,7 @@ describe('Organizations', () => {
                 )
 
                 await percySnapshotWithVariants(driver.page, 'Organization members list')
+                await accessibilityAudit(driver.page)
 
                 // Override for the fetch post-removal
                 testContext.overrideGraphQL({

--- a/client/web/src/org/OrgAvatar.module.scss
+++ b/client/web/src/org/OrgAvatar.module.scss
@@ -1,7 +1,7 @@
 .org-avatar {
     border-radius: 100%;
     background: #a2b0cd;
-    color: #39496a;
+    color: #304368; /* Fix accessibility Rule: "color-contrast" (Elements must have sufficient color contrast) GitHub issue: https://github.com/sourcegraph/sourcegraph/issues/33343 */
     text-align: center;
     display: inline-flex;
     align-items: center;

--- a/client/web/src/site-admin/SiteAdminAlert.tsx
+++ b/client/web/src/site-admin/SiteAdminAlert.tsx
@@ -21,7 +21,12 @@ export const SiteAdminAlert: React.FunctionComponent<SiteAdminAlertProps> = ({
     variant = 'warning',
 }) => (
     <Alert className={classNames(styles.siteAdminAlert, className)} variant={variant}>
-        <h5>
+        {/**
+         * ally-ignore
+         * Rule: "heading-order" (Heading levels should only increase by one)
+         * Since `PageHeader` (which is on upper scope), renders `h1`, We could consider using `h2` tag instead, to meet accessibility criteria
+         */}
+        <h5 className="a11y-ignore">
             <Icon as={LockIcon} /> Site admin
         </h5>
         <div>{children}</div>

--- a/client/web/src/site-admin/SiteAdminAlert.tsx
+++ b/client/web/src/site-admin/SiteAdminAlert.tsx
@@ -3,7 +3,7 @@ import * as React from 'react'
 import classNames from 'classnames'
 import LockIcon from 'mdi-react/LockIcon'
 
-import { Alert, AlertProps, Icon } from '@sourcegraph/wildcard'
+import { Alert, AlertProps, Icon, H5, H2 } from '@sourcegraph/wildcard'
 
 import styles from './SiteAdminAlert.module.scss'
 
@@ -21,14 +21,9 @@ export const SiteAdminAlert: React.FunctionComponent<SiteAdminAlertProps> = ({
     variant = 'warning',
 }) => (
     <Alert className={classNames(styles.siteAdminAlert, className)} variant={variant}>
-        {/**
-         * ally-ignore
-         * Rule: "heading-order" (Heading levels should only increase by one)
-         * Since `PageHeader` (which is on upper scope), renders `h1`, We could consider using `h2` tag instead, to meet accessibility criteria
-         */}
-        <h5 className="a11y-ignore">
+        <H5 as={H2}>
             <Icon as={LockIcon} /> Site admin
-        </h5>
+        </H5>
         <div>{children}</div>
     </Alert>
 )


### PR DESCRIPTION
## Description

Enable accessibility audit on `client/web/src/integration/org.test.ts`

## Refs

[SG Issue](https://github.com/sourcegraph/sourcegraph/issues/33093)
[Gitstart Ticket](https://app.gitstart.com/clients/sourcegraph/tickets/SG-33093)
## Test plan

Run the integration test `ENTERPRISE=1 HEADLESS=true yarn test-integration:base client/web/src/integration/org.test.ts
`
## Success criteria

- All integration tests with Percy snapshots have `accessibility audit` enabled


## App preview:

- [Link](https://sg-web-contractors-sg-33093-6.onrender.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

