### PR TITLE
Code monitors: simplify last searched

### DIFF
--- a/dev/ci/go-backcompat/flakefiles/v3.38.0.json
+++ b/dev/ci/go-backcompat/flakefiles/v3.38.0.json
@@ -1,0 +1,4 @@
+[
+    { "path": "enterprise/internal/database", "prefix": "CodeMonitorStoreLastSearched", "reason": "Feature is experimental and not enabled for any customers" },
+    { "path": "enterprise/internal/codemonitors", "prefix": "CodeMonitorHook", "reason": "Feature is experimental and not enabled for any customers" }
+]

--- a/dev/ci/go-backcompat/flakefiles/v3.38.0.json
+++ b/dev/ci/go-backcompat/flakefiles/v3.38.0.json
@@ -1,4 +1,12 @@
 [
-    { "path": "enterprise/internal/database", "prefix": "CodeMonitorStoreLastSearched", "reason": "Feature is experimental and not enabled for any customers" },
-    { "path": "enterprise/internal/codemonitors", "prefix": "CodeMonitorHook", "reason": "Feature is experimental and not enabled for any customers" }
+    {
+        "path": "enterprise/internal/database",
+        "prefix": "CodeMonitorStoreLastSearched",
+        "reason": "Feature is experimental and not enabled for any customers"
+    },
+    {
+        "path": "enterprise/internal/codemonitors",
+        "prefix": "CodeMonitorHook",
+        "reason": "Feature is experimental and not enabled for any customers"
+    }
 ]

--- a/dev/ci/go-backcompat/flakefiles/v3.38.0.json
+++ b/dev/ci/go-backcompat/flakefiles/v3.38.0.json
@@ -1,12 +1,12 @@
 [
-    {
-        "path": "enterprise/internal/database",
-        "prefix": "TestCodeMonitorStoreLastSearched",
-        "reason": "Feature is experimental and not enabled for any customers"
-    },
-    {
-        "path": "enterprise/internal/codemonitors",
-        "prefix": "TestCodeMonitorHook",
-        "reason": "Feature is experimental and not enabled for any customers"
-    }
+  {
+    "path": "enterprise/internal/database",
+    "prefix": "TestCodeMonitorStoreLastSearched",
+    "reason": "Feature is experimental and not enabled for any customers"
+  },
+  {
+    "path": "enterprise/internal/codemonitors",
+    "prefix": "TestCodeMonitorHook",
+    "reason": "Feature is experimental and not enabled for any customers"
+  }
 ]

--- a/dev/ci/go-backcompat/flakefiles/v3.38.0.json
+++ b/dev/ci/go-backcompat/flakefiles/v3.38.0.json
@@ -1,12 +1,12 @@
 [
     {
         "path": "enterprise/internal/database",
-        "prefix": "CodeMonitorStoreLastSearched",
+        "prefix": "TestCodeMonitorStoreLastSearched",
         "reason": "Feature is experimental and not enabled for any customers"
     },
     {
         "path": "enterprise/internal/codemonitors",
-        "prefix": "CodeMonitorHook",
+        "prefix": "TestCodeMonitorHook",
         "reason": "Feature is experimental and not enabled for any customers"
     }
 ]

--- a/enterprise/internal/database/code_monitor_last_searched_test.go
+++ b/enterprise/internal/database/code_monitor_last_searched_test.go
@@ -22,21 +22,21 @@ func TestCodeMonitorStoreLastSearched(t *testing.T) {
 
 		// Insert
 		insertLastSearched := []string{"commit1", "commit2"}
-		err := cm.UpsertLastSearched(ctx, fixtures.Monitor.ID, 3851, insertLastSearched)
+		err := cm.UpsertLastSearched(ctx, fixtures.Monitor.ID, fixtures.Repo.ID, insertLastSearched)
 		require.NoError(t, err)
 
 		// Get
-		lastSearched, err := cm.GetLastSearched(ctx, fixtures.Monitor.ID, 3851)
+		lastSearched, err := cm.GetLastSearched(ctx, fixtures.Monitor.ID, fixtures.Repo.ID)
 		require.NoError(t, err)
 		require.Equal(t, insertLastSearched, lastSearched)
 
 		// Update
 		updateLastSearched := []string{"commit3", "commit4"}
-		err = cm.UpsertLastSearched(ctx, fixtures.Monitor.ID, 3851, updateLastSearched)
+		err = cm.UpsertLastSearched(ctx, fixtures.Monitor.ID, fixtures.Repo.ID, updateLastSearched)
 		require.NoError(t, err)
 
 		// Get
-		lastSearched, err = cm.GetLastSearched(ctx, fixtures.Monitor.ID, 3851)
+		lastSearched, err = cm.GetLastSearched(ctx, fixtures.Monitor.ID, fixtures.Repo.ID)
 		require.NoError(t, err)
 		require.Equal(t, updateLastSearched, lastSearched)
 	})
@@ -63,20 +63,20 @@ func TestCodeMonitorStoreLastSearched(t *testing.T) {
 		cm := db.CodeMonitors()
 
 		// Insert with nil last searched
-		err := cm.UpsertLastSearched(ctx, fixtures.Monitor.ID, 3851, nil)
+		err := cm.UpsertLastSearched(ctx, fixtures.Monitor.ID, fixtures.Repo.ID, nil)
 		require.NoError(t, err)
 
 		// Get nil last searched
-		lastSearched, err := cm.GetLastSearched(ctx, fixtures.Monitor.ID, 3851)
+		lastSearched, err := cm.GetLastSearched(ctx, fixtures.Monitor.ID, fixtures.Repo.ID)
 		require.NoError(t, err)
 		require.Empty(t, lastSearched)
 
 		// Insert with empty last searched
-		err = cm.UpsertLastSearched(ctx, fixtures.Monitor.ID, 3852, []string{})
+		err = cm.UpsertLastSearched(ctx, fixtures.Monitor.ID, fixtures.Repo.ID, []string{})
 		require.NoError(t, err)
 
 		// Get nil last searched
-		lastSearched, err = cm.GetLastSearched(ctx, fixtures.Monitor.ID, 3852)
+		lastSearched, err = cm.GetLastSearched(ctx, fixtures.Monitor.ID, fixtures.Repo.ID)
 		require.NoError(t, err)
 		require.Empty(t, lastSearched)
 	})

--- a/enterprise/internal/database/code_monitor_test.go
+++ b/enterprise/internal/database/code_monitor_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/internal/api"
 )
 
 type testFixtures struct {
@@ -71,16 +72,21 @@ type codeMonitorTestFixtures struct {
 	User    *types.User
 	Monitor *Monitor
 	Query   *QueryTrigger
+	Repo    *types.Repo
 }
 
 func populateCodeMonitorFixtures(t *testing.T, db EnterpriseDB) codeMonitorTestFixtures {
 	ctx := context.Background()
 	u, err := db.Users().Create(ctx, database.NewUser{Email: "test", Username: "test", EmailVerificationCode: "test"})
 	require.NoError(t, err)
+	err = db.Repos().Create(ctx, &types.Repo{Name: "test"})
+	require.NoError(t, err)
+	r, err := db.Repos().GetByName(ctx, api.RepoName("test"))
+	require.NoError(t, err)
 	ctx = actor.WithActor(ctx, actor.FromUser(u.ID))
 	m, err := db.CodeMonitors().CreateMonitor(ctx, MonitorArgs{NamespaceUserID: &u.ID, Enabled: true})
 	require.NoError(t, err)
 	q, err := db.CodeMonitors().CreateQueryTrigger(ctx, m.ID, "type:commit repo:.")
 	require.NoError(t, err)
-	return codeMonitorTestFixtures{User: u, Monitor: m, Query: q}
+	return codeMonitorTestFixtures{User: u, Monitor: m, Query: q, Repo: r}
 }

--- a/enterprise/internal/database/code_monitor_test.go
+++ b/enterprise/internal/database/code_monitor_test.go
@@ -7,9 +7,9 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/sourcegraph/sourcegraph/internal/actor"
+	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/types"
-	"github.com/sourcegraph/sourcegraph/internal/api"
 )
 
 type testFixtures struct {

--- a/enterprise/internal/database/code_monitors.go
+++ b/enterprise/internal/database/code_monitors.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/sourcegraph/sourcegraph/internal/actor"
+	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
@@ -81,8 +82,8 @@ type CodeMonitorStore interface {
 	GetActionJob(ctx context.Context, jobID int32) (*ActionJob, error)
 	EnqueueActionJobsForMonitor(ctx context.Context, monitorID int64, triggerJob int32) ([]*ActionJob, error)
 
-	UpsertLastSearched(ctx context.Context, monitorID int64, argsHash int64, lastSearched []string) error
-	GetLastSearched(ctx context.Context, monitorID int64, argsHash int64) ([]string, error)
+	UpsertLastSearched(ctx context.Context, monitorID int64, repoID api.RepoID, lastSearched []string) error
+	GetLastSearched(ctx context.Context, monitorID int64, repoID api.RepoID) ([]string, error)
 }
 
 // codeMonitorStore exposes methods to read and write codemonitors domain models

--- a/enterprise/internal/database/mocks.go
+++ b/enterprise/internal/database/mocks.go
@@ -331,7 +331,7 @@ func NewMockCodeMonitorStore() *MockCodeMonitorStore {
 			},
 		},
 		GetLastSearchedFunc: &CodeMonitorStoreGetLastSearchedFunc{
-			defaultHook: func(context.Context, int64, int64) ([]string, error) {
+			defaultHook: func(context.Context, int64, api.RepoID) ([]string, error) {
 				return nil, nil
 			},
 		},
@@ -456,7 +456,7 @@ func NewMockCodeMonitorStore() *MockCodeMonitorStore {
 			},
 		},
 		UpsertLastSearchedFunc: &CodeMonitorStoreUpsertLastSearchedFunc{
-			defaultHook: func(context.Context, int64, int64, []string) error {
+			defaultHook: func(context.Context, int64, api.RepoID, []string) error {
 				return nil
 			},
 		},
@@ -603,7 +603,7 @@ func NewStrictMockCodeMonitorStore() *MockCodeMonitorStore {
 			},
 		},
 		GetLastSearchedFunc: &CodeMonitorStoreGetLastSearchedFunc{
-			defaultHook: func(context.Context, int64, int64) ([]string, error) {
+			defaultHook: func(context.Context, int64, api.RepoID) ([]string, error) {
 				panic("unexpected invocation of MockCodeMonitorStore.GetLastSearched")
 			},
 		},
@@ -728,7 +728,7 @@ func NewStrictMockCodeMonitorStore() *MockCodeMonitorStore {
 			},
 		},
 		UpsertLastSearchedFunc: &CodeMonitorStoreUpsertLastSearchedFunc{
-			defaultHook: func(context.Context, int64, int64, []string) error {
+			defaultHook: func(context.Context, int64, api.RepoID, []string) error {
 				panic("unexpected invocation of MockCodeMonitorStore.UpsertLastSearched")
 			},
 		},
@@ -3909,15 +3909,15 @@ func (c CodeMonitorStoreGetEmailActionFuncCall) Results() []interface{} {
 // GetLastSearched method of the parent MockCodeMonitorStore instance is
 // invoked.
 type CodeMonitorStoreGetLastSearchedFunc struct {
-	defaultHook func(context.Context, int64, int64) ([]string, error)
-	hooks       []func(context.Context, int64, int64) ([]string, error)
+	defaultHook func(context.Context, int64, api.RepoID) ([]string, error)
+	hooks       []func(context.Context, int64, api.RepoID) ([]string, error)
 	history     []CodeMonitorStoreGetLastSearchedFuncCall
 	mutex       sync.Mutex
 }
 
 // GetLastSearched delegates to the next hook function in the queue and
 // stores the parameter and result values of this invocation.
-func (m *MockCodeMonitorStore) GetLastSearched(v0 context.Context, v1 int64, v2 int64) ([]string, error) {
+func (m *MockCodeMonitorStore) GetLastSearched(v0 context.Context, v1 int64, v2 api.RepoID) ([]string, error) {
 	r0, r1 := m.GetLastSearchedFunc.nextHook()(v0, v1, v2)
 	m.GetLastSearchedFunc.appendCall(CodeMonitorStoreGetLastSearchedFuncCall{v0, v1, v2, r0, r1})
 	return r0, r1
@@ -3926,7 +3926,7 @@ func (m *MockCodeMonitorStore) GetLastSearched(v0 context.Context, v1 int64, v2 
 // SetDefaultHook sets function that is called when the GetLastSearched
 // method of the parent MockCodeMonitorStore instance is invoked and the
 // hook queue is empty.
-func (f *CodeMonitorStoreGetLastSearchedFunc) SetDefaultHook(hook func(context.Context, int64, int64) ([]string, error)) {
+func (f *CodeMonitorStoreGetLastSearchedFunc) SetDefaultHook(hook func(context.Context, int64, api.RepoID) ([]string, error)) {
 	f.defaultHook = hook
 }
 
@@ -3935,7 +3935,7 @@ func (f *CodeMonitorStoreGetLastSearchedFunc) SetDefaultHook(hook func(context.C
 // invokes the hook at the front of the queue and discards it. After the
 // queue is empty, the default hook function is invoked for any future
 // action.
-func (f *CodeMonitorStoreGetLastSearchedFunc) PushHook(hook func(context.Context, int64, int64) ([]string, error)) {
+func (f *CodeMonitorStoreGetLastSearchedFunc) PushHook(hook func(context.Context, int64, api.RepoID) ([]string, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -3944,19 +3944,19 @@ func (f *CodeMonitorStoreGetLastSearchedFunc) PushHook(hook func(context.Context
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
 func (f *CodeMonitorStoreGetLastSearchedFunc) SetDefaultReturn(r0 []string, r1 error) {
-	f.SetDefaultHook(func(context.Context, int64, int64) ([]string, error) {
+	f.SetDefaultHook(func(context.Context, int64, api.RepoID) ([]string, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
 func (f *CodeMonitorStoreGetLastSearchedFunc) PushReturn(r0 []string, r1 error) {
-	f.PushHook(func(context.Context, int64, int64) ([]string, error) {
+	f.PushHook(func(context.Context, int64, api.RepoID) ([]string, error) {
 		return r0, r1
 	})
 }
 
-func (f *CodeMonitorStoreGetLastSearchedFunc) nextHook() func(context.Context, int64, int64) ([]string, error) {
+func (f *CodeMonitorStoreGetLastSearchedFunc) nextHook() func(context.Context, int64, api.RepoID) ([]string, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -3998,7 +3998,7 @@ type CodeMonitorStoreGetLastSearchedFuncCall struct {
 	Arg1 int64
 	// Arg2 is the value of the 3rd argument passed to this method
 	// invocation.
-	Arg2 int64
+	Arg2 api.RepoID
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 []string
@@ -6689,15 +6689,15 @@ func (c CodeMonitorStoreUpdateWebhookActionFuncCall) Results() []interface{} {
 // UpsertLastSearched method of the parent MockCodeMonitorStore instance is
 // invoked.
 type CodeMonitorStoreUpsertLastSearchedFunc struct {
-	defaultHook func(context.Context, int64, int64, []string) error
-	hooks       []func(context.Context, int64, int64, []string) error
+	defaultHook func(context.Context, int64, api.RepoID, []string) error
+	hooks       []func(context.Context, int64, api.RepoID, []string) error
 	history     []CodeMonitorStoreUpsertLastSearchedFuncCall
 	mutex       sync.Mutex
 }
 
 // UpsertLastSearched delegates to the next hook function in the queue and
 // stores the parameter and result values of this invocation.
-func (m *MockCodeMonitorStore) UpsertLastSearched(v0 context.Context, v1 int64, v2 int64, v3 []string) error {
+func (m *MockCodeMonitorStore) UpsertLastSearched(v0 context.Context, v1 int64, v2 api.RepoID, v3 []string) error {
 	r0 := m.UpsertLastSearchedFunc.nextHook()(v0, v1, v2, v3)
 	m.UpsertLastSearchedFunc.appendCall(CodeMonitorStoreUpsertLastSearchedFuncCall{v0, v1, v2, v3, r0})
 	return r0
@@ -6706,7 +6706,7 @@ func (m *MockCodeMonitorStore) UpsertLastSearched(v0 context.Context, v1 int64, 
 // SetDefaultHook sets function that is called when the UpsertLastSearched
 // method of the parent MockCodeMonitorStore instance is invoked and the
 // hook queue is empty.
-func (f *CodeMonitorStoreUpsertLastSearchedFunc) SetDefaultHook(hook func(context.Context, int64, int64, []string) error) {
+func (f *CodeMonitorStoreUpsertLastSearchedFunc) SetDefaultHook(hook func(context.Context, int64, api.RepoID, []string) error) {
 	f.defaultHook = hook
 }
 
@@ -6715,7 +6715,7 @@ func (f *CodeMonitorStoreUpsertLastSearchedFunc) SetDefaultHook(hook func(contex
 // invokes the hook at the front of the queue and discards it. After the
 // queue is empty, the default hook function is invoked for any future
 // action.
-func (f *CodeMonitorStoreUpsertLastSearchedFunc) PushHook(hook func(context.Context, int64, int64, []string) error) {
+func (f *CodeMonitorStoreUpsertLastSearchedFunc) PushHook(hook func(context.Context, int64, api.RepoID, []string) error) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -6724,19 +6724,19 @@ func (f *CodeMonitorStoreUpsertLastSearchedFunc) PushHook(hook func(context.Cont
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
 func (f *CodeMonitorStoreUpsertLastSearchedFunc) SetDefaultReturn(r0 error) {
-	f.SetDefaultHook(func(context.Context, int64, int64, []string) error {
+	f.SetDefaultHook(func(context.Context, int64, api.RepoID, []string) error {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
 func (f *CodeMonitorStoreUpsertLastSearchedFunc) PushReturn(r0 error) {
-	f.PushHook(func(context.Context, int64, int64, []string) error {
+	f.PushHook(func(context.Context, int64, api.RepoID, []string) error {
 		return r0
 	})
 }
 
-func (f *CodeMonitorStoreUpsertLastSearchedFunc) nextHook() func(context.Context, int64, int64, []string) error {
+func (f *CodeMonitorStoreUpsertLastSearchedFunc) nextHook() func(context.Context, int64, api.RepoID, []string) error {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -6778,7 +6778,7 @@ type CodeMonitorStoreUpsertLastSearchedFuncCall struct {
 	Arg1 int64
 	// Arg2 is the value of the 3rd argument passed to this method
 	// invocation.
-	Arg2 int64
+	Arg2 api.RepoID
 	// Arg3 is the value of the 4th argument passed to this method
 	// invocation.
 	Arg3 []string

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -463,21 +463,20 @@ Referenced by:
 
 # Table "public.cm_last_searched"
 ```
-   Column    |  Type  | Collation | Nullable | Default 
--------------+--------+-----------+----------+---------
- monitor_id  | bigint |           | not null | 
- args_hash   | bigint |           | not null | 
- commit_oids | text[] |           | not null | 
+   Column    |  Type   | Collation | Nullable | Default 
+-------------+---------+-----------+----------+---------
+ monitor_id  | bigint  |           | not null | 
+ commit_oids | text[]  |           | not null | 
+ repo_id     | integer |           | not null | 
 Indexes:
-    "cm_last_searched_pkey" PRIMARY KEY, btree (monitor_id, args_hash)
+    "cm_last_searched_pkey" PRIMARY KEY, btree (monitor_id, repo_id)
 Foreign-key constraints:
     "cm_last_searched_monitor_id_fkey" FOREIGN KEY (monitor_id) REFERENCES cm_monitors(id) ON DELETE CASCADE
+    "cm_last_searched_repo_id_fkey" FOREIGN KEY (repo_id) REFERENCES repo(id) ON DELETE CASCADE
 
 ```
 
 The last searched commit hashes for the given code monitor and unique set of search arguments
-
-**args_hash**: A unique hash of the gitserver search arguments to identify this search job
 
 **commit_oids**: The set of commit OIDs that was previously successfully searched and should be excluded on the next run
 
@@ -2063,6 +2062,7 @@ Referenced by:
     TABLE "batch_spec_workspaces" CONSTRAINT "batch_spec_workspaces_repo_id_fkey" FOREIGN KEY (repo_id) REFERENCES repo(id) DEFERRABLE
     TABLE "changeset_specs" CONSTRAINT "changeset_specs_repo_id_fkey" FOREIGN KEY (repo_id) REFERENCES repo(id) DEFERRABLE
     TABLE "changesets" CONSTRAINT "changesets_repo_id_fkey" FOREIGN KEY (repo_id) REFERENCES repo(id) ON DELETE CASCADE DEFERRABLE
+    TABLE "cm_last_searched" CONSTRAINT "cm_last_searched_repo_id_fkey" FOREIGN KEY (repo_id) REFERENCES repo(id) ON DELETE CASCADE
     TABLE "discussion_threads_target_repo" CONSTRAINT "discussion_threads_target_repo_repo_id_fkey" FOREIGN KEY (repo_id) REFERENCES repo(id) ON DELETE CASCADE
     TABLE "external_service_repos" CONSTRAINT "external_service_repos_repo_id_fkey" FOREIGN KEY (repo_id) REFERENCES repo(id) ON DELETE CASCADE DEFERRABLE
     TABLE "gitserver_repos" CONSTRAINT "gitserver_repos_repo_id_fkey" FOREIGN KEY (repo_id) REFERENCES repo(id) ON DELETE CASCADE

--- a/internal/search/commit/commit.go
+++ b/internal/search/commit/commit.go
@@ -41,7 +41,7 @@ type CommitSearch struct {
 }
 
 type DoSearchFunc func(*gitprotocol.SearchRequest) error
-type CodeMonitorHook func(context.Context, database.DB, GitserverClient, *gitprotocol.SearchRequest, DoSearchFunc) error
+type CodeMonitorHook func(context.Context, database.DB, GitserverClient, *gitprotocol.SearchRequest, api.RepoID, DoSearchFunc) error
 
 type GitserverClient interface {
 	Search(_ context.Context, _ *protocol.SearchRequest, onMatches func([]protocol.CommitMatch)) (limitHit bool, _ error)
@@ -119,7 +119,7 @@ func (j *CommitSearch) Run(ctx context.Context, clients job.RuntimeClients, stre
 
 		bounded.Go(func() error {
 			if j.CodeMonitorSearchWrapper != nil {
-				return j.CodeMonitorSearchWrapper(ctx, clients.DB, clients.Gitserver, args, doSearch)
+				return j.CodeMonitorSearchWrapper(ctx, clients.DB, clients.Gitserver, args, repoRev.Repo.ID, doSearch)
 			}
 			return doSearch(args)
 		})

--- a/migrations/frontend/1649432863/down.sql
+++ b/migrations/frontend/1649432863/down.sql
@@ -1,7 +1,7 @@
 -- Undo the changes made in the up migration
 
 ALTER TABLE cm_last_searched
-    DROP CONSTRAINT cm_last_searched_pkey,
-    DROP COLUMN repo_id,
+    DROP CONSTRAINT IF EXISTS cm_last_searched_pkey,
+    DROP COLUMN IF EXISTS repo_id,
     ADD COLUMN IF NOT EXISTS args_hash bigint NOT NULL,
     ADD PRIMARY KEY (monitor_id, args_hash);

--- a/migrations/frontend/1649432863/down.sql
+++ b/migrations/frontend/1649432863/down.sql
@@ -1,0 +1,7 @@
+-- Undo the changes made in the up migration
+
+ALTER TABLE cm_last_searched
+    DROP CONSTRAINT cm_last_searched_pkey,
+    DROP COLUMN repo_id,
+    ADD COLUMN IF NOT EXISTS args_hash bigint NOT NULL,
+    ADD PRIMARY KEY (monitor_id, args_hash);

--- a/migrations/frontend/1649432863/metadata.yaml
+++ b/migrations/frontend/1649432863/metadata.yaml
@@ -1,0 +1,2 @@
+name: no hash for code monitor last searched
+parents: [1648524019, 1648628900]

--- a/migrations/frontend/1649432863/up.sql
+++ b/migrations/frontend/1649432863/up.sql
@@ -1,0 +1,18 @@
+-- Perform migration here.
+--
+-- See /migrations/README.md. Highlights:
+--  * Make migrations idempotent (use IF EXISTS)
+--  * Make migrations backwards-compatible (old readers/writers must continue to work)
+--  * If you are using CREATE INDEX CONCURRENTLY, then make sure that only one statement
+--    is defined per file, and that each such statement is NOT wrapped in a transaction.
+--    Each such migration must also declare "createIndexConcurrently: true" in their
+--    associated metadata.yaml file.
+--  * If you are modifying Postgres extensions, you must also declare "privileged: true"
+--    in the associated metadata.yaml file.
+
+DELETE FROM cm_last_searched;
+ALTER TABLE cm_last_searched
+    DROP CONSTRAINT IF EXISTS cm_last_searched_pkey,
+    DROP COLUMN IF EXISTS args_hash,
+    ADD COLUMN IF NOT EXISTS repo_id INTEGER NOT NULL REFERENCES repo(id) ON DELETE CASCADE,
+    ADD PRIMARY KEY (monitor_id, repo_id);


### PR DESCRIPTION
This PR removes the concept of an "args hash" from repo-aware code monitors. Previously, we would use the args hash (a hash of all the arguments to the code monitor) to identify subqueries in complex code monitor queries so that we could independently run each job and still update the last searched commits appropriately.

For example, in the search `type:commit ((repo:a b) or (repo:c d))`, we would have two subqueries: `repo:a b` and `repo:c d`. These would each be hashed to identify them, and we would track the commits searched by each independently since they will search over different sets of commits (each searches its own set of repos). 

However, it turns out this is extremely fragile because if we ever change how the arguments are hashed, or if we ever add an argument, all the hashes change and we can no longer associate a subquery with its last searched commits.

As a fix, this PR restricts the types of queries that can be run by code monitors to queries that generate a single commit search job. This way, we only need to know which commits were last searched by the code monitor. 

Currently, any time we have an `and` or an `or` in a query, we will generate multiple commit search jobs. This means this PR makes `and/or` queries invalid when repo-aware monitors are enabled. However, with the recent optimizations Rijnard has been working on, we should be able to generate a single commit search job that works for any `and/or` patterns. That will happen in followup PRs.

Note that all the changes here are hidden behind the `cc-repo-aware-monitors` flag.

## Test plan

Added test for error condition, manually tested that monitors still work as expected.

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


