### PR TITLE
ci: fix left-over from QA'ing changes

### DIFF
--- a/enterprise/dev/ci/scripts/upload-build-logs.sh
+++ b/enterprise/dev/ci/scripts/upload-build-logs.sh
@@ -37,7 +37,7 @@ echo "~~~ :file_cabinet: Uploading logs"
 # Because we are running this script in the buildkite post-exit hook, the state of the job is still "running".
 # Passing --state="" just overrides the default. It's not set to any specific state because this script caller
 # is responsible of making sure the job has failed.
-./enterprise/dev/ci/scripts/sentry-capture.sh ./sg ci logs --out="" --state="" --overwrite-state="failed" --build="$BUILDKITE_BUILD_NUMBER" --job="$BUILDKITE_JOB_ID"
+./enterprise/dev/ci/scripts/sentry-capture.sh ./sg ci logs --out="$BUILD_LOGS_LOKI_URL" --state="" --overwrite-state="failed" --build="$BUILDKITE_BUILD_NUMBER" --job="$BUILDKITE_JOB_ID"
 local_exit_code=$?
 if [[ $local_exit_code -ne 0 ]]; then
   echo -e "\033[33m┌────────────────────────────────────────────────────────────────────┐\033[0m"


### PR DESCRIPTION
I squashed my QA commit rather than dropping it, which left this small change I used to QA in a previous PR. 

This fixes it. 

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

n/a, this is kind of a revert. 
