### PR TITLE
codeintel: Make cross-index navigation batch size configurable

### DIFF
--- a/enterprise/cmd/frontend/internal/codeintel/config.go
+++ b/enterprise/cmd/frontend/internal/codeintel/config.go
@@ -10,9 +10,10 @@ import (
 type Config struct {
 	env.BaseConfig
 
-	LSIFUploadStoreConfig   *lsifuploadstore.Config
-	AutoIndexEnqueuerConfig *enqueuer.Config
-	HunkCacheSize           int
+	LSIFUploadStoreConfig          *lsifuploadstore.Config
+	AutoIndexEnqueuerConfig        *enqueuer.Config
+	HunkCacheSize                  int
+	MaximumIndexesPerMonikerSearch int
 }
 
 func (c *Config) Load() {
@@ -24,6 +25,7 @@ func (c *Config) Load() {
 	c.LSIFUploadStoreConfig.Load()
 
 	c.HunkCacheSize = c.GetInt("PRECISE_CODE_INTEL_HUNK_CACHE_SIZE", "1000", "The capacity of the git diff hunk cache.")
+	c.MaximumIndexesPerMonikerSearch = c.GetInt("PRECISE_CODE_INTEL_MAXIMUM_INDEXES_PER_MONIKER_SEARCH", "50", "The maximum number of indexes to search at once when doing cross-index code navigation.")
 }
 
 func (c *Config) Validate() error {

--- a/enterprise/cmd/frontend/internal/codeintel/init.go
+++ b/enterprise/cmd/frontend/internal/codeintel/init.go
@@ -59,6 +59,7 @@ func newResolver(db database.DB, config *Config, observationContext *observation
 		services.indexEnqueuer,
 		hunkCache,
 		symbols.DefaultClient,
+		config.MaximumIndexesPerMonikerSearch,
 		observationContext,
 		db,
 	)

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/query_definitions_test.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/query_definitions_test.go
@@ -50,6 +50,7 @@ func TestDefinitions(t *testing.T) {
 		uploads,
 		newOperations(&observation.TestContext),
 		authz.NewMockSubRepoPermissionChecker(),
+		50,
 	)
 	adjustedLocations, err := resolver.Definitions(context.Background(), 10, 20)
 	if err != nil {
@@ -117,6 +118,7 @@ func TestDefinitionsWithSubRepoPermissions(t *testing.T) {
 		uploads,
 		newOperations(&observation.TestContext),
 		checker,
+		50,
 	)
 
 	ctx := context.Background()
@@ -200,6 +202,7 @@ func TestDefinitionsRemote(t *testing.T) {
 		uploads,
 		newOperations(&observation.TestContext),
 		authz.NewMockSubRepoPermissionChecker(),
+		50,
 	)
 	adjustedLocations, err := resolver.Definitions(context.Background(), 10, 20)
 	if err != nil {
@@ -327,6 +330,7 @@ func TestDefinitionsRemoteWithSubRepoPermissions(t *testing.T) {
 		uploads,
 		newOperations(&observation.TestContext),
 		checker,
+		50,
 	)
 
 	ctx := context.Background()

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/query_diagnostics_test.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/query_diagnostics_test.go
@@ -51,6 +51,7 @@ func TestDiagnostics(t *testing.T) {
 		uploads,
 		newOperations(&observation.TestContext),
 		authz.NewMockSubRepoPermissionChecker(),
+		50,
 	)
 	adjustedDiagnostics, totalCount, err := resolver.Diagnostics(context.Background(), 5)
 	if err != nil {
@@ -132,6 +133,7 @@ func TestDiagnosticsWithSubRepoPermissions(t *testing.T) {
 		uploads,
 		newOperations(&observation.TestContext),
 		checker,
+		50,
 	)
 
 	ctx := context.Background()

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/query_hover_test.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/query_hover_test.go
@@ -46,6 +46,7 @@ func TestHover(t *testing.T) {
 		uploads,
 		newOperations(&observation.TestContext),
 		authz.NewMockSubRepoPermissionChecker(),
+		50,
 	)
 	text, rn, exists, err := resolver.Hover(context.Background(), 10, 20)
 	if err != nil {
@@ -137,6 +138,7 @@ func TestHoverRemote(t *testing.T) {
 		uploads,
 		newOperations(&observation.TestContext),
 		authz.NewMockSubRepoPermissionChecker(),
+		50,
 	)
 	text, rn, exists, err := resolver.Hover(context.Background(), 10, 20)
 	if err != nil {

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/query_implementations_test.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/query_implementations_test.go
@@ -56,6 +56,7 @@ func TestImplementations(t *testing.T) {
 		uploads,
 		newOperations(&observation.TestContext),
 		authz.NewMockSubRepoPermissionChecker(),
+		50,
 	)
 	adjustedLocations, _, err := resolver.Implementations(context.Background(), 10, 20, 50, "")
 	if err != nil {
@@ -127,6 +128,7 @@ func TestImplementationsWithSubRepoPermissions(t *testing.T) {
 		uploads,
 		newOperations(&observation.TestContext),
 		checker,
+		50,
 	)
 
 	ctx := context.Background()
@@ -245,6 +247,7 @@ func TestImplementationsRemote(t *testing.T) {
 		uploads,
 		newOperations(&observation.TestContext),
 		authz.NewMockSubRepoPermissionChecker(),
+		50,
 	)
 	adjustedLocations, _, err := resolver.Implementations(context.Background(), 10, 20, 50, "")
 	if err != nil {
@@ -421,6 +424,7 @@ func TestImplementationsRemoteWithSubRepoPermissions(t *testing.T) {
 		uploads,
 		newOperations(&observation.TestContext),
 		checker,
+		50,
 	)
 
 	ctx := context.Background()

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/query_ranges_test.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/query_ranges_test.go
@@ -58,6 +58,7 @@ func TestRanges(t *testing.T) {
 		uploads,
 		newOperations(&observation.TestContext),
 		authz.NewMockSubRepoPermissionChecker(),
+		50,
 	)
 	adjustedRanges, err := resolver.Ranges(context.Background(), 10, 20)
 	if err != nil {

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/query_references.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/query_references.go
@@ -255,10 +255,6 @@ func (r *queryResolver) pageLocalLocations(
 	return allLocations, cursor.UploadOffset < len(adjustedUploads), nil
 }
 
-// maximumIndexesPerMonikerSearch configures the maximum number of reference upload identifiers
-// that can be passed to a single moniker search query.
-const maximumIndexesPerMonikerSearch = 50
-
 // pageRemoteLocations returns a slice of the (remote) result set denoted by the given cursor fulfilled by
 // performing a moniker search over a group of indexes. The given cursor will be adjusted to reflect the
 // offsets required to resolve the next page of results. If there are no more pages left in the result set,
@@ -288,7 +284,7 @@ func (r *queryResolver) pageRemoteLocations(
 			ctx,
 			orderedMonikers,
 			ignoreIDs,
-			maximumIndexesPerMonikerSearch,
+			r.maximumIndexesPerMonikerSearch,
 			cursor.UploadOffset,
 			trace,
 		)

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/query_references_test.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/query_references_test.go
@@ -56,6 +56,7 @@ func TestReferences(t *testing.T) {
 		uploads,
 		newOperations(&observation.TestContext),
 		authz.NewMockSubRepoPermissionChecker(),
+		50,
 	)
 	adjustedLocations, _, err := resolver.References(context.Background(), 10, 20, 50, "")
 	if err != nil {
@@ -127,6 +128,7 @@ func TestReferencesWithSubRepoPermissions(t *testing.T) {
 		uploads,
 		newOperations(&observation.TestContext),
 		checker,
+		50,
 	)
 
 	ctx := context.Background()
@@ -249,6 +251,7 @@ func TestReferencesRemote(t *testing.T) {
 		uploads,
 		newOperations(&observation.TestContext),
 		authz.NewMockSubRepoPermissionChecker(),
+		50,
 	)
 	adjustedLocations, _, err := resolver.References(context.Background(), 10, 20, 50, "")
 	if err != nil {
@@ -436,6 +439,7 @@ func TestReferencesRemoteWithSubRepoPermissions(t *testing.T) {
 		uploads,
 		newOperations(&observation.TestContext),
 		checker,
+		50,
 	)
 
 	ctx := context.Background()
@@ -514,6 +518,7 @@ func TestIgnoredIDs(t *testing.T) {
 		[]dbstore.Dump{},
 		newOperations(&observation.TestContext),
 		authz.NewMockSubRepoPermissionChecker(),
+		50,
 	)
 
 	refDumpID := 50

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/query_stencil_test.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/query_stencil_test.go
@@ -52,6 +52,7 @@ func TestStencil(t *testing.T) {
 		uploads,
 		newOperations(&observation.TestContext),
 		authz.NewMockSubRepoPermissionChecker(),
+		50,
 	)
 	ranges, err := resolver.Stencil(context.Background())
 	if err != nil {

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/resolver_test.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/resolver_test.go
@@ -15,7 +15,7 @@ func TestQueryResolver(t *testing.T) {
 	mockLSIFStore := NewMockLSIFStore()
 	mockGitserverClient := NewMockGitserverClient()
 
-	resolver := NewResolver(mockDBStore, mockLSIFStore, mockGitserverClient, nil, nil, nil, nil, &observation.TestContext, nil)
+	resolver := NewResolver(mockDBStore, mockLSIFStore, mockGitserverClient, nil, nil, nil, nil, 50, &observation.TestContext, nil)
 	queryResolver, err := resolver.QueryResolver(context.Background(), &gql.GitBlobLSIFDataArgs{
 		Repo:      &types.Repo{ID: 50},
 		Commit:    api.CommitID("deadbeef"),

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/upload_retention_test.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/upload_retention_test.go
@@ -18,7 +18,7 @@ func TestRetentionPolicyOverview(t *testing.T) {
 	mockLSIFStore := NewMockLSIFStore()
 	mockGitserverClient := NewMockGitserverClient()
 
-	resolver := NewResolver(mockDBStore, mockLSIFStore, mockGitserverClient, nil, nil, nil, nil, &observation.TestContext, nil)
+	resolver := NewResolver(mockDBStore, mockLSIFStore, mockGitserverClient, nil, nil, nil, nil, 50, &observation.TestContext, nil)
 
 	mockClock := glock.NewMockClock()
 
@@ -217,7 +217,7 @@ func TestRetentionPolicyOverview_ByVisibility(t *testing.T) {
 	mockLSIFStore := NewMockLSIFStore()
 	mockGitserverClient := NewMockGitserverClient()
 
-	resolver := NewResolver(mockDBStore, mockLSIFStore, mockGitserverClient, nil, nil, nil, nil, &observation.TestContext, nil)
+	resolver := NewResolver(mockDBStore, mockLSIFStore, mockGitserverClient, nil, nil, nil, nil, 50, &observation.TestContext, nil)
 
 	mockClock := glock.NewMockClock()
 


### PR DESCRIPTION
Replace hard-coded constant with envvar with equivalent default.

## Test plan

Existing integration tests.
