### PR TITLE
do not display "Sourcegraph cannot send emails!" alerts to non-admins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Fixed
 
+- Fixed an issue where a `Warning: Sourcegraph cannot send emails!` banner would appear for all users instead of just site admins (introduced in v3.38).
 - Fixed reading search pattern type from settings [#32989](https://github.com/sourcegraph/sourcegraph/issues/32989)
 - Display a tooltip and truncate the title of a search result when content overflows [#32904](https://github.com/sourcegraph/sourcegraph/pull/32904)
 - Search patterns containing `and` and `not` expressions are now optimized to evaluate natively on the Zoekt backend for indexed code content and symbol search wherever possible. These kinds of queries are now typically an order of magnitude faster. Previous cases where no results were returned for expensive search expressions should now work and return results quickly. [#33308](https://github.com/sourcegraph/sourcegraph/pull/33308)

--- a/cmd/frontend/graphqlbackend/site_alerts.go
+++ b/cmd/frontend/graphqlbackend/site_alerts.go
@@ -214,6 +214,9 @@ func isMinorUpdateAvailable(currentVersion, updateVersion string) bool {
 }
 
 func emailSendingNotConfiguredAlert(args AlertFuncArgs) []*Alert {
+	if !args.IsSiteAdmin {
+		return nil
+	}
 	if conf.Get().EmailSmtp == nil || conf.Get().EmailSmtp.Host == "" {
 		return []*Alert{{
 			TypeValue:                 AlertTypeWarning,


### PR DESCRIPTION
In v3.38 we introduced a banner at the top of the page that would inform site admins if email sending is not configured:

> Warning: Sourcegraph cannot send emails! Configure `email.smtp` so that features such as Code Monitors, password resets, and invitations work.

This was only intended to be shown to site admins, but unfortunately was shown to all users which [caused issue for some customers](https://sourcegraph.slack.com/archives/C022SPMNR0W/p1648233834859799?thread_ts=1648226738.063809&cid=C022SPMNR0W)

The issue could be worked around by adding this to their site configuration:

```
"htmlHeadTop": "<script>localStorage.setItem('DismissibleAlert/alert.email-sending/dismissed', 'true')</script>",
```

This PR (and v3.39) will fix the issue for good.

Signed-off-by: Stephen Gutekanst <stephen@sourcegraph.com>


## Test plan

Manually tested, plus super obvious / simple change.
