### PR TITLE
WIP: fix sub repo filtering for sub-dir of repo

### DIFF
--- a/cmd/frontend/graphqlbackend/git_commit.go
+++ b/cmd/frontend/graphqlbackend/git_commit.go
@@ -219,7 +219,9 @@ func (r *GitCommitResolver) Tree(ctx context.Context, args *struct {
 	}
 
 	// Note: args.Recursive is deprecated
-	treeEntry.isRecursive = args.Recursive
+	if treeEntry != nil {
+		treeEntry.isRecursive = args.Recursive
+	}
 	return treeEntry, nil
 }
 

--- a/internal/authz/sub_repo_perms.go
+++ b/internal/authz/sub_repo_perms.go
@@ -433,10 +433,14 @@ func FilterActorFileInfos(ctx context.Context, checker SubRepoPermissionChecker,
 }
 
 func FilterActorFileInfo(ctx context.Context, checker SubRepoPermissionChecker, a *actor.Actor, repo api.RepoName, fi fs.FileInfo) (bool, error) {
-	perms, err := ActorPermissions(ctx, checker, a, RepoContent{
+	rc := RepoContent{
 		Repo: repo,
 		Path: fi.Name(),
-	})
+	}
+	if fi.IsDir() {
+		rc.Path += "/"
+	}
+	perms, err := ActorPermissions(ctx, checker, a, rc)
 	if err != nil {
 		return false, errors.Wrap(err, "checking sub-repo permissions")
 	}


### PR DESCRIPTION
See https://docs.google.com/document/d/1nw-P1ZOgR5qYOe725vm9xNnRRWYRucdeSXeblsG8seQ/edit for more context. Essentially, the `ReadDir` function makes a `git ls-tree` call, which returns a list of files/directories, where the directories do _not_ have trailing slashes. However, when permissions to view a directory in perforce is revoked, the trailing slash _is_ present. The rule from perforce looks something like `read group <group name> * -//app/…` which translates to a path_excludes in psql that looks like `{app/**}`, and the path that's passed in in this case is `"app"`.

This leads to these two paths not matching and thus filtering working incorrectly. I've remedied that by adding the trailing slash to the directories before checking permissions. We could loop through and add this trailing slash this right after the `git ls-tree` command rather than inside the authz package if people prefer (I just wanted to avoid looping through all the paths more than necessary).

Question: Could we potentially see something like `read group <group name> * -//app…` ? What would that mean? It looks like in practice we _aren't_ seeing this pattern. 

## Test plan
Tested locally already, validated that the directory the user shouldn't have access to is now no longer visible. Will also need to validate that this works for the customer test case.

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


