### PR TITLE
Search backend: pass runtime dependencies at runtime

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -439,15 +439,6 @@ func LogSearchLatency(ctx context.Context, db database.DB, wg *sync.WaitGroup, s
 	}
 }
 
-// JobArgs converts the parts of search resolver state to values needed to create search jobs.
-func (r *searchResolver) JobArgs() *jobutil.Args {
-	return &jobutil.Args{
-		SearchInputs: r.SearchInputs,
-		Zoekt:        r.zoekt,
-		SearcherURLs: r.searcherURLs,
-	}
-}
-
 func (r *searchResolver) JobClients() job.RuntimeClients {
 	return job.RuntimeClients{
 		DB:           r.db,

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -602,11 +602,10 @@ func (r *searchResolver) Stats(ctx context.Context) (stats *searchResultsStats, 
 	attempts := 0
 	var v *SearchResultsResolver
 
-	args := r.JobArgs()
 	for {
 		// Query search results.
 		var err error
-		j, err := jobutil.ToSearchJob(args.SearchInputs, r.SearchInputs.Query, r.db)
+		j, err := jobutil.ToSearchJob(r.SearchInputs, r.SearchInputs.Query, r.db)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -606,7 +606,7 @@ func (r *searchResolver) Stats(ctx context.Context) (stats *searchResultsStats, 
 	for {
 		// Query search results.
 		var err error
-		j, err := jobutil.ToSearchJob(args, r.SearchInputs.Query, r.db)
+		j, err := jobutil.ToSearchJob(args.SearchInputs, r.SearchInputs.Query, r.db)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -515,7 +515,7 @@ func logBatch(ctx context.Context, db database.DB, searchInputs *run.SearchInput
 func (r *searchResolver) Results(ctx context.Context) (*SearchResultsResolver, error) {
 	start := time.Now()
 	agg := streaming.NewAggregatingStream()
-	alert, err := execute.Execute(ctx, r.db, agg, r.JobArgs())
+	alert, err := execute.Execute(ctx, agg, r.SearchInputs, r.JobClients())
 	srr := r.resultsToResolver(agg.Results, alert, agg.Stats)
 	srr.elapsed = time.Since(start)
 	logBatch(ctx, r.db, r.SearchInputs, srr, err)

--- a/cmd/frontend/graphqlbackend/search_results_stats_languages.go
+++ b/cmd/frontend/graphqlbackend/search_results_stats_languages.go
@@ -41,7 +41,7 @@ func (srs *searchResultsStats) Languages(ctx context.Context) ([]*languageStatis
 func (srs *searchResultsStats) getResults(ctx context.Context) (result.Matches, error) {
 	args := srs.sr.JobArgs()
 	srs.once.Do(func() {
-		j, err := jobutil.ToSearchJob(args, srs.sr.SearchInputs.Query, srs.sr.db)
+		j, err := jobutil.ToSearchJob(args.SearchInputs, srs.sr.SearchInputs.Query, srs.sr.db)
 		if err != nil {
 			srs.err = err
 			return

--- a/cmd/frontend/graphqlbackend/search_results_stats_languages.go
+++ b/cmd/frontend/graphqlbackend/search_results_stats_languages.go
@@ -47,7 +47,7 @@ func (srs *searchResultsStats) getResults(ctx context.Context) (result.Matches, 
 			return
 		}
 		agg := streaming.NewAggregatingStream()
-		_, err = j.Run(ctx, srs.sr.db, agg)
+		_, err = j.Run(ctx, srs.sr.JobClients(), agg)
 		if err != nil {
 			srs.err = err
 			return

--- a/cmd/frontend/graphqlbackend/search_results_stats_languages.go
+++ b/cmd/frontend/graphqlbackend/search_results_stats_languages.go
@@ -39,9 +39,8 @@ func (srs *searchResultsStats) Languages(ctx context.Context) ([]*languageStatis
 }
 
 func (srs *searchResultsStats) getResults(ctx context.Context) (result.Matches, error) {
-	args := srs.sr.JobArgs()
 	srs.once.Do(func() {
-		j, err := jobutil.ToSearchJob(args.SearchInputs, srs.sr.SearchInputs.Query, srs.sr.db)
+		j, err := jobutil.ToSearchJob(srs.sr.SearchInputs, srs.sr.SearchInputs.Query, srs.sr.db)
 		if err != nil {
 			srs.err = err
 			return

--- a/enterprise/internal/codemonitors/search.go
+++ b/enterprise/internal/codemonitors/search.go
@@ -18,7 +18,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/api/internalapi"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/featureflag"
-	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	gitprotocol "github.com/sourcegraph/sourcegraph/internal/gitserver/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/internal/search"
@@ -115,13 +114,7 @@ func Search(ctx context.Context, db database.DB, query string, monitorID int64, 
 	}
 
 	// Inline job creation so we can mutate the commit job before running it
-	jobArgs := searchClient.JobArgs(inputs)
-	clients := job.RuntimeClients{
-		DB:           db,
-		Zoekt:        jobArgs.Zoekt,
-		SearcherURLs: jobArgs.SearcherURLs,
-		Gitserver:    gitserver.NewClient(db),
-	}
+	clients := searchClient.JobClients()
 	plan, err := predicate.Expand(ctx, clients, inputs, inputs.Plan)
 	if err != nil {
 		return nil, err
@@ -171,13 +164,7 @@ func Snapshot(ctx context.Context, db database.DB, query string, monitorID int64
 		return err
 	}
 
-	jobArgs := searchClient.JobArgs(inputs)
-	clients := job.RuntimeClients{
-		DB:           db,
-		Zoekt:        jobArgs.Zoekt,
-		SearcherURLs: jobArgs.SearcherURLs,
-		Gitserver:    gitserver.NewClient(db),
-	}
+	clients := searchClient.JobClients()
 	plan, err := predicate.Expand(ctx, clients, inputs, inputs.Plan)
 	if err != nil {
 		return err

--- a/enterprise/internal/codemonitors/search.go
+++ b/enterprise/internal/codemonitors/search.go
@@ -121,7 +121,7 @@ func Search(ctx context.Context, db database.DB, query string, monitorID int64, 
 		return nil, err
 	}
 
-	planJob, err := jobutil.FromExpandedPlan(jobArgs, plan, db)
+	planJob, err := jobutil.FromExpandedPlan(inputs, plan, db)
 	if err != nil {
 		return nil, err
 	}
@@ -177,7 +177,7 @@ func Snapshot(ctx context.Context, db database.DB, query string, monitorID int64
 		return err
 	}
 
-	planJob, err := jobutil.FromExpandedPlan(jobArgs, plan, db)
+	planJob, err := jobutil.FromExpandedPlan(inputs, plan, db)
 	if err != nil {
 		return err
 	}

--- a/internal/search/execute/execute.go
+++ b/internal/search/execute/execute.go
@@ -27,8 +27,15 @@ func Execute(
 		tr.Finish()
 	}()
 
+	clients := job.RuntimeClients{
+		DB:           db,
+		Zoekt:        jobArgs.Zoekt,
+		SearcherURLs: jobArgs.SearcherURLs,
+		Gitserver:    gitserver.NewClient(db),
+	}
+
 	plan := jobArgs.SearchInputs.Plan
-	plan, err = predicate.Expand(ctx, db, jobArgs, plan)
+	plan, err = predicate.Expand(ctx, clients, jobArgs.SearchInputs, plan)
 	if err != nil {
 		return nil, err
 	}
@@ -38,11 +45,5 @@ func Execute(
 		return nil, err
 	}
 
-	clients := job.RuntimeClients{
-		DB:           db,
-		Zoekt:        jobArgs.Zoekt,
-		SearcherURLs: jobArgs.SearcherURLs,
-		Gitserver:    gitserver.NewClient(db),
-	}
 	return planJob.Run(ctx, clients, stream)
 }

--- a/internal/search/execute/execute.go
+++ b/internal/search/execute/execute.go
@@ -33,7 +33,7 @@ func Execute(
 		return nil, err
 	}
 
-	planJob, err := jobutil.FromExpandedPlan(jobArgs, plan, db)
+	planJob, err := jobutil.FromExpandedPlan(jobArgs.SearchInputs, plan, db)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/search/execute/execute.go
+++ b/internal/search/execute/execute.go
@@ -4,7 +4,9 @@ import (
 	"context"
 
 	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/search"
+	"github.com/sourcegraph/sourcegraph/internal/search/job"
 	"github.com/sourcegraph/sourcegraph/internal/search/job/jobutil"
 	"github.com/sourcegraph/sourcegraph/internal/search/predicate"
 	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
@@ -36,5 +38,11 @@ func Execute(
 		return nil, err
 	}
 
-	return planJob.Run(ctx, db, stream)
+	clients := job.RuntimeClients{
+		DB:           db,
+		Zoekt:        jobArgs.Zoekt,
+		SearcherURLs: jobArgs.SearcherURLs,
+		Gitserver:    gitserver.NewClient(db),
+	}
+	return planJob.Run(ctx, clients, stream)
 }

--- a/internal/search/job/job.go
+++ b/internal/search/job/job.go
@@ -6,7 +6,11 @@ package job
 import (
 	"context"
 
+	"github.com/google/zoekt"
+
 	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/endpoint"
+	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
 )
@@ -17,6 +21,13 @@ import (
 // timeout). Calling Run on a job object runs a search.
 //go:generate ../../../dev/mockgen.sh github.com/sourcegraph/sourcegraph/internal/search/job -i Job -d mockjob
 type Job interface {
-	Run(context.Context, database.DB, streaming.Sender) (*search.Alert, error)
+	Run(context.Context, RuntimeClients, streaming.Sender) (*search.Alert, error)
 	Name() string
+}
+
+type RuntimeClients struct {
+	DB           database.DB
+	Zoekt        zoekt.Streamer
+	SearcherURLs *endpoint.Map
+	Gitserver    gitserver.Client
 }

--- a/internal/search/job/jobutil/expression_job_test.go
+++ b/internal/search/job/jobutil/expression_job_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/search/job"
 	"github.com/sourcegraph/sourcegraph/internal/search/job/mockjob"
@@ -56,7 +55,7 @@ func (ss senders) Jobs() []job.Job {
 func newMockSender() sender {
 	mj := mockjob.NewMockJob()
 	send := make(chan streaming.SearchEvent)
-	mj.RunFunc.SetDefaultHook(func(_ context.Context, _ database.DB, s streaming.Sender) (*search.Alert, error) {
+	mj.RunFunc.SetDefaultHook(func(_ context.Context, _ job.RuntimeClients, s streaming.Sender) (*search.Alert, error) {
 		for event := range send {
 			s.Send(event)
 		}
@@ -111,7 +110,7 @@ func TestAndJob(t *testing.T) {
 
 				finished := make(chan struct{})
 				go func() {
-					_, err := j.Run(context.Background(), nil, stream)
+					_, err := j.Run(context.Background(), job.RuntimeClients{}, stream)
 					require.NoError(t, err)
 					close(finished)
 				}()
@@ -137,7 +136,7 @@ func TestAndJob(t *testing.T) {
 
 				finished := make(chan struct{})
 				go func() {
-					_, err := j.Run(context.Background(), nil, stream)
+					_, err := j.Run(context.Background(), job.RuntimeClients{}, stream)
 					require.NoError(t, err)
 					close(finished)
 				}()
@@ -174,7 +173,7 @@ func TestOrJob(t *testing.T) {
 
 				finished := make(chan struct{})
 				go func() {
-					_, err := j.Run(context.Background(), nil, stream)
+					_, err := j.Run(context.Background(), job.RuntimeClients{}, stream)
 					require.NoError(t, err)
 					close(finished)
 				}()
@@ -203,7 +202,7 @@ func TestOrJob(t *testing.T) {
 
 				finished := make(chan struct{})
 				go func() {
-					_, err := j.Run(context.Background(), nil, stream)
+					_, err := j.Run(context.Background(), job.RuntimeClients{}, stream)
 					require.NoError(t, err)
 					close(finished)
 				}()
@@ -226,7 +225,7 @@ func TestOrJob(t *testing.T) {
 		stream := streaming.NewAggregatingStream()
 		finished := make(chan struct{})
 		go func() {
-			_, err := j.Run(context.Background(), nil, stream)
+			_, err := j.Run(context.Background(), job.RuntimeClients{}, stream)
 			require.Error(t, err)
 			close(finished)
 		}()

--- a/internal/search/job/jobutil/job.go
+++ b/internal/search/job/jobutil/job.go
@@ -301,7 +301,6 @@ func ToSearchJob(jargs *Args, q query.Q, db database.DB) (job.Job, error) {
 						mode = search.SkipUnindexed
 					}
 					addJob(true, &run.RepoSearch{
-						SearcherURLs:    jargs.SearcherURLs,
 						RepoOptions:     repoOptions,
 						Features:        features,
 						UseFullDeadline: useFullDeadline,

--- a/internal/search/job/jobutil/job.go
+++ b/internal/search/job/jobutil/job.go
@@ -4,7 +4,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/google/zoekt"
 	"github.com/grafana/regexp"
 	"github.com/inconshreveable/log15"
 	"github.com/prometheus/client_golang/prometheus"
@@ -12,7 +11,6 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/endpoint"
 	"github.com/sourcegraph/sourcegraph/internal/featureflag"
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/search/commit"
@@ -31,12 +29,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
-
-type Args struct {
-	SearchInputs *run.SearchInputs
-	Zoekt        zoekt.Streamer
-	SearcherURLs *endpoint.Map
-}
 
 // ToSearchJob converts a query parse tree to the _internal_ representation
 // needed to run a search routine. To understand why this conversion matters, think

--- a/internal/search/job/jobutil/job.go
+++ b/internal/search/job/jobutil/job.go
@@ -482,7 +482,6 @@ func (b *jobBuilder) newZoektSearch(typ search.IndexedRequestType) (job.Job, err
 			Typ:            typ,
 			FileMatchLimit: b.fileMatchLimit,
 			Select:         b.selector,
-			Zoekt:          b.zoekt,
 		}, nil
 	}
 	return nil, errors.Errorf("attempt to create unrecognized zoekt search with value %v", typ)

--- a/internal/search/job/jobutil/job.go
+++ b/internal/search/job/jobutil/job.go
@@ -468,7 +468,6 @@ func (b *jobBuilder) newZoektSearch(typ search.IndexedRequestType) (job.Job, err
 			Query:          zoektQuery,
 			FileMatchLimit: b.fileMatchLimit,
 			Select:         b.selector,
-			Zoekt:          b.zoekt,
 		}, nil
 	case search.TextRequest:
 		return &zoektutil.ZoektRepoSubsetSearch{

--- a/internal/search/job/jobutil/job.go
+++ b/internal/search/job/jobutil/job.go
@@ -627,7 +627,7 @@ func ToEvaluateJob(args *Args, q query.Basic, db database.DB) (job.Job, error) {
 		if _, ok := q.Pattern.(query.Pattern); !ok {
 			// This pattern is not an atomic Pattern, but an
 			// expression. Optimize the expression for backends.
-			job, err = optimizeJobs(job, args, q.ToParseTree(), db)
+			job, err = optimizeJobs(job, args.SearchInputs, q.ToParseTree(), db)
 		}
 	}
 	if err != nil {
@@ -647,8 +647,8 @@ func ToEvaluateJob(args *Args, q query.Basic, db database.DB) (job.Job, error) {
 // converts them directly to native queries for a backed. Currently that backend
 // is Zoekt. It removes unoptimized Zoekt jobs from the baseJob and repalces it
 // with the optimized ones.
-func optimizeJobs(baseJob job.Job, jargs *Args, q query.Q, db database.DB) (job.Job, error) {
-	candidateOptimizedJobs, err := ToSearchJob(jargs.SearchInputs, q, db)
+func optimizeJobs(baseJob job.Job, inputs *run.SearchInputs, q query.Q, db database.DB) (job.Job, error) {
+	candidateOptimizedJobs, err := ToSearchJob(inputs, q, db)
 	if err != nil {
 		return nil, err
 	}
@@ -729,7 +729,7 @@ func optimizeJobs(baseJob job.Job, jargs *Args, q query.Q, db database.DB) (job.
 			*zoektutil.ZoektSymbolSearch:
 			optimizedJobs[i] = &repoPagerJob{
 				child:            job,
-				repoOptions:      toRepoOptions(q, jargs.SearchInputs.UserSettings),
+				repoOptions:      toRepoOptions(q, inputs.UserSettings),
 				useIndex:         q.Index(),
 				containsRefGlobs: query.ContainsRefGlobs(q),
 			}

--- a/internal/search/job/jobutil/job.go
+++ b/internal/search/job/jobutil/job.go
@@ -14,7 +14,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/endpoint"
 	"github.com/sourcegraph/sourcegraph/internal/featureflag"
-	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/search/commit"
 	"github.com/sourcegraph/sourcegraph/internal/search/filter"
@@ -191,7 +190,6 @@ func ToSearchJob(jargs *Args, q query.Q, db database.DB) (job.Job, error) {
 				HasTimeFilter:        b.Exists("after") || b.Exists("before"),
 				Limit:                int(fileMatchLimit),
 				IncludeModifiedFiles: authz.SubRepoEnabled(authz.DefaultSubRepoPermsChecker),
-				Gitserver:            gitserver.NewClient(db),
 			})
 		}
 

--- a/internal/search/job/jobutil/job.go
+++ b/internal/search/job/jobutil/job.go
@@ -75,7 +75,6 @@ func ToSearchJob(jargs *Args, q query.Q, db database.DB) (job.Job, error) {
 		features:       &features,
 		fileMatchLimit: fileMatchLimit,
 		selector:       selector,
-		zoekt:          jargs.Zoekt,
 	}
 
 	repoUniverseSearch, skipRepoSubsetSearch, runZoektOverRepos := jobMode(b, resultTypes, jargs.SearchInputs.PatternType, jargs.SearchInputs.OnSourcegraphDotCom)
@@ -408,9 +407,6 @@ type jobBuilder struct {
 	features       *search.Features
 	fileMatchLimit int32
 	selector       filter.SelectPath
-
-	// Just a handle to a Zoekt client, which we always want around.
-	zoekt zoekt.Streamer
 }
 
 func (b *jobBuilder) newZoektGlobalSearch(typ search.IndexedRequestType) (job.Job, error) {

--- a/internal/search/job/jobutil/job.go
+++ b/internal/search/job/jobutil/job.go
@@ -301,7 +301,6 @@ func ToSearchJob(jargs *Args, q query.Q, db database.DB) (job.Job, error) {
 						mode = search.SkipUnindexed
 					}
 					addJob(true, &run.RepoSearch{
-						Zoekt:           jargs.Zoekt,
 						SearcherURLs:    jargs.SearcherURLs,
 						RepoOptions:     repoOptions,
 						Features:        features,

--- a/internal/search/job/jobutil/job.go
+++ b/internal/search/job/jobutil/job.go
@@ -122,7 +122,6 @@ func ToSearchJob(jargs *Args, q query.Q, db database.DB) (job.Job, error) {
 				textSearchJobs = append(textSearchJobs, &searcher.Searcher{
 					PatternInfo:     patternInfo,
 					Indexed:         false,
-					SearcherURLs:    jargs.SearcherURLs,
 					UseFullDeadline: useFullDeadline,
 				})
 

--- a/internal/search/job/jobutil/job.go
+++ b/internal/search/job/jobutil/job.go
@@ -209,7 +209,6 @@ func ToSearchJob(jargs *Args, q query.Q, db database.DB) (job.Job, error) {
 			}
 
 			searcherArgs := &search.SearcherParameters{
-				SearcherURLs:    jargs.SearcherURLs,
 				PatternInfo:     patternInfo,
 				UseFullDeadline: useFullDeadline,
 			}

--- a/internal/search/job/jobutil/job.go
+++ b/internal/search/job/jobutil/job.go
@@ -128,7 +128,6 @@ func ToSearchJob(jargs *Args, q query.Q, db database.DB) (job.Job, error) {
 					repoOptions:      repoOptions,
 					useIndex:         b.Index(),
 					containsRefGlobs: query.ContainsRefGlobs(q),
-					zoekt:            jargs.Zoekt,
 				})
 			}
 		}
@@ -167,7 +166,6 @@ func ToSearchJob(jargs *Args, q query.Q, db database.DB) (job.Job, error) {
 					repoOptions:      repoOptions,
 					useIndex:         q.Index(),
 					containsRefGlobs: query.ContainsRefGlobs(q),
-					zoekt:            jargs.Zoekt,
 				})
 			}
 		}
@@ -736,7 +734,6 @@ func optimizeJobs(baseJob job.Job, jargs *Args, q query.Q, db database.DB) (job.
 				repoOptions:      toRepoOptions(q, jargs.SearchInputs.UserSettings),
 				useIndex:         q.Index(),
 				containsRefGlobs: query.ContainsRefGlobs(q),
-				zoekt:            jargs.Zoekt,
 			}
 		}
 	}

--- a/internal/search/job/jobutil/job.go
+++ b/internal/search/job/jobutil/job.go
@@ -207,7 +207,6 @@ func ToSearchJob(jargs *Args, q query.Q, db database.DB) (job.Job, error) {
 				Typ:            typ,
 				FileMatchLimit: fileMatchLimit,
 				Select:         selector,
-				Zoekt:          jargs.Zoekt,
 			}
 
 			searcherArgs := &search.SearcherParameters{
@@ -442,7 +441,6 @@ func (b *jobBuilder) newZoektGlobalSearch(typ search.IndexedRequestType) (job.Jo
 		Typ:            typ,
 		FileMatchLimit: b.fileMatchLimit,
 		Select:         b.selector,
-		Zoekt:          b.zoekt,
 	}
 
 	switch typ {

--- a/internal/search/job/jobutil/job_test.go
+++ b/internal/search/job/jobutil/job_test.go
@@ -15,16 +15,14 @@ import (
 func TestToSearchInputs(t *testing.T) {
 	test := func(input string, protocol search.Protocol, parser func(string) (query.Q, error)) string {
 		q, _ := parser(input)
-		args := &Args{
-			SearchInputs: &run.SearchInputs{
-				UserSettings:        &schema.Settings{},
-				PatternType:         query.SearchTypeLiteral,
-				Protocol:            protocol,
-				OnSourcegraphDotCom: true,
-			},
+		inputs := &run.SearchInputs{
+			UserSettings:        &schema.Settings{},
+			PatternType:         query.SearchTypeLiteral,
+			Protocol:            protocol,
+			OnSourcegraphDotCom: true,
 		}
 
-		j, _ := ToSearchJob(args, q, database.NewMockDB())
+		j, _ := ToSearchJob(inputs, q, database.NewMockDB())
 		return "\n" + PrettySexp(j) + "\n"
 	}
 

--- a/internal/search/job/jobutil/job_test.go
+++ b/internal/search/job/jobutil/job_test.go
@@ -224,7 +224,7 @@ func Test_optimizeJobs(t *testing.T) {
 
 		b, _ := query.ToBasicQuery(q)
 		baseJob, _ := toPatternExpressionJob(args, b, database.NewMockDB())
-		optimizedJob, _ := optimizeJobs(baseJob, args, b.ToParseTree(), database.NewMockDB())
+		optimizedJob, _ := optimizeJobs(baseJob, args.SearchInputs, b.ToParseTree(), database.NewMockDB())
 		return "\nBASE:\n\n" + PrettySexp(baseJob) + "\n\nOPTIMIZED:\n\n" + PrettySexp(optimizedJob) + "\n"
 	}
 

--- a/internal/search/job/jobutil/job_test.go
+++ b/internal/search/job/jobutil/job_test.go
@@ -173,17 +173,15 @@ func TestToSearchInputs(t *testing.T) {
 func TestToEvaluateJob(t *testing.T) {
 	test := func(input string, protocol search.Protocol) string {
 		q, _ := query.ParseLiteral(input)
-		args := &Args{
-			SearchInputs: &run.SearchInputs{
-				UserSettings:        &schema.Settings{},
-				PatternType:         query.SearchTypeLiteral,
-				Protocol:            protocol,
-				OnSourcegraphDotCom: true,
-			},
+		inputs := &run.SearchInputs{
+			UserSettings:        &schema.Settings{},
+			PatternType:         query.SearchTypeLiteral,
+			Protocol:            protocol,
+			OnSourcegraphDotCom: true,
 		}
 
 		b, _ := query.ToBasicQuery(q)
-		j, _ := ToEvaluateJob(args, b, database.NewMockDB())
+		j, _ := ToEvaluateJob(inputs, b, database.NewMockDB())
 		return "\n" + PrettySexp(j) + "\n"
 	}
 
@@ -213,18 +211,16 @@ func TestToEvaluateJob(t *testing.T) {
 func Test_optimizeJobs(t *testing.T) {
 	test := func(input string) string {
 		q, _ := query.ParseLiteral(input)
-		args := &Args{
-			SearchInputs: &run.SearchInputs{
-				UserSettings:        &schema.Settings{},
-				PatternType:         query.SearchTypeLiteral,
-				Protocol:            search.Streaming,
-				OnSourcegraphDotCom: true,
-			},
+		inputs := &run.SearchInputs{
+			UserSettings:        &schema.Settings{},
+			PatternType:         query.SearchTypeLiteral,
+			Protocol:            search.Streaming,
+			OnSourcegraphDotCom: true,
 		}
 
 		b, _ := query.ToBasicQuery(q)
-		baseJob, _ := toPatternExpressionJob(args, b, database.NewMockDB())
-		optimizedJob, _ := optimizeJobs(baseJob, args.SearchInputs, b.ToParseTree(), database.NewMockDB())
+		baseJob, _ := toPatternExpressionJob(inputs, b, database.NewMockDB())
+		optimizedJob, _ := optimizeJobs(baseJob, inputs, b.ToParseTree(), database.NewMockDB())
 		return "\nBASE:\n\n" + PrettySexp(baseJob) + "\n\nOPTIMIZED:\n\n" + PrettySexp(optimizedJob) + "\n"
 	}
 

--- a/internal/search/job/jobutil/printers_test.go
+++ b/internal/search/job/jobutil/printers_test.go
@@ -189,13 +189,11 @@ func TestPrettyJSON(t *testing.T) {
 							NewNoopJob()))))))))
 	test := func(input string) string {
 		q, _ := query.ParseLiteral(input)
-		args := &Args{
-			SearchInputs: &run.SearchInputs{
-				UserSettings: &schema.Settings{},
-				Protocol:     search.Streaming,
-			},
+		inputs := &run.SearchInputs{
+			UserSettings: &schema.Settings{},
+			Protocol:     search.Streaming,
 		}
-		j, _ := ToSearchJob(args, q, database.NewMockDB())
+		j, _ := ToSearchJob(inputs, q, database.NewMockDB())
 		return PrettyJSONVerbose(j)
 	}
 

--- a/internal/search/job/jobutil/printers_test.go
+++ b/internal/search/job/jobutil/printers_test.go
@@ -214,8 +214,7 @@ func TestPrettyJSON(t *testing.T) {
               },
               "Typ": "text",
               "FileMatchLimit": 500,
-              "Select": [],
-              "Zoekt": null
+              "Select": []
             }
           },
           {
@@ -242,7 +241,6 @@ func TestPrettyJSON(t *testing.T) {
               },
               "Repos": null,
               "Indexed": false,
-              "SearcherURLs": null,
               "UseFullDeadline": true
             }
           }
@@ -352,9 +350,7 @@ func TestPrettyJSON(t *testing.T) {
             }
           }
         ],
-        "UseFullDeadline": true,
-        "Zoekt": null,
-        "SearcherURLs": null
+        "UseFullDeadline": true
       }
     },
     {

--- a/internal/search/job/jobutil/repo_pager_job.go
+++ b/internal/search/job/jobutil/repo_pager_job.go
@@ -3,8 +3,6 @@ package jobutil
 import (
 	"context"
 
-	zoektstreamer "github.com/google/zoekt"
-
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/search/job"
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
@@ -19,8 +17,6 @@ type repoPagerJob struct {
 	useIndex         query.YesNoOnly // whether to include indexed repos
 	containsRefGlobs bool            // whether to include repositories with refs
 	child            job.Job         // child job tree that need populating a repos field to run
-
-	zoekt zoektstreamer.Streamer
 }
 
 // setRepos populates the repos field for all jobs that need repos. Jobs are
@@ -71,7 +67,7 @@ func (p *repoPagerJob) Run(ctx context.Context, clients job.RuntimeClients, stre
 		indexed, unindexed, err := zoekt.PartitionRepos(
 			ctx,
 			page.RepoRevs,
-			p.zoekt,
+			clients.Zoekt,
 			search.TextRequest,
 			p.useIndex,
 			p.containsRefGlobs,

--- a/internal/search/job/jobutil/repo_pager_job_test.go
+++ b/internal/search/job/jobutil/repo_pager_job_test.go
@@ -49,8 +49,7 @@ func Test_setRepos(t *testing.T) {
         "Query": null,
         "Typ": "",
         "FileMatchLimit": 0,
-        "Select": null,
-        "Zoekt": null
+        "Select": null
       }
     },
     {
@@ -67,7 +66,6 @@ func Test_setRepos(t *testing.T) {
           }
         ],
         "Indexed": false,
-        "SearcherURLs": null,
         "UseFullDeadline": false
       }
     }

--- a/internal/search/job/jobutil/select.go
+++ b/internal/search/job/jobutil/select.go
@@ -3,7 +3,6 @@ package jobutil
 import (
 	"context"
 
-	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/search/filter"
 	"github.com/sourcegraph/sourcegraph/internal/search/job"
@@ -21,12 +20,12 @@ type selectJob struct {
 	child job.Job
 }
 
-func (j *selectJob) Run(ctx context.Context, db database.DB, stream streaming.Sender) (alert *search.Alert, err error) {
+func (j *selectJob) Run(ctx context.Context, clients job.RuntimeClients, stream streaming.Sender) (alert *search.Alert, err error) {
 	_, ctx, stream, finish := job.StartSpan(ctx, stream, j)
 	defer func() { finish(alert, err) }()
 
 	selectingStream := streaming.WithSelect(stream, j.path)
-	return j.child.Run(ctx, db, selectingStream)
+	return j.child.Run(ctx, clients, selectingStream)
 }
 
 func (j *selectJob) Name() string {

--- a/internal/search/job/jobutil/sub_repo_perms_job.go
+++ b/internal/search/job/jobutil/sub_repo_perms_job.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
-	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/search/job"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
@@ -26,7 +25,7 @@ type subRepoPermsFilterJob struct {
 	child job.Job
 }
 
-func (s *subRepoPermsFilterJob) Run(ctx context.Context, db database.DB, stream streaming.Sender) (alert *search.Alert, err error) {
+func (s *subRepoPermsFilterJob) Run(ctx context.Context, clients job.RuntimeClients, stream streaming.Sender) (alert *search.Alert, err error) {
 	_, ctx, stream, finish := job.StartSpan(ctx, stream, s)
 	defer func() { finish(alert, err) }()
 
@@ -48,7 +47,7 @@ func (s *subRepoPermsFilterJob) Run(ctx context.Context, db database.DB, stream 
 		stream.Send(event)
 	})
 
-	alert, err = s.child.Run(ctx, db, filteredStream)
+	alert, err = s.child.Run(ctx, clients, filteredStream)
 	if err != nil {
 		errs = errors.Append(errs, err)
 	}

--- a/internal/search/job/mockjob/job_mock.go
+++ b/internal/search/job/mockjob/job_mock.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"sync"
 
-	database "github.com/sourcegraph/sourcegraph/internal/database"
 	search "github.com/sourcegraph/sourcegraph/internal/search"
 	job "github.com/sourcegraph/sourcegraph/internal/search/job"
 	streaming "github.com/sourcegraph/sourcegraph/internal/search/streaming"
@@ -34,7 +33,7 @@ func NewMockJob() *MockJob {
 			},
 		},
 		RunFunc: &JobRunFunc{
-			defaultHook: func(context.Context, database.DB, streaming.Sender) (*search.Alert, error) {
+			defaultHook: func(context.Context, job.RuntimeClients, streaming.Sender) (*search.Alert, error) {
 				return nil, nil
 			},
 		},
@@ -51,7 +50,7 @@ func NewStrictMockJob() *MockJob {
 			},
 		},
 		RunFunc: &JobRunFunc{
-			defaultHook: func(context.Context, database.DB, streaming.Sender) (*search.Alert, error) {
+			defaultHook: func(context.Context, job.RuntimeClients, streaming.Sender) (*search.Alert, error) {
 				panic("unexpected invocation of MockJob.Run")
 			},
 		},
@@ -172,15 +171,15 @@ func (c JobNameFuncCall) Results() []interface{} {
 // JobRunFunc describes the behavior when the Run method of the parent
 // MockJob instance is invoked.
 type JobRunFunc struct {
-	defaultHook func(context.Context, database.DB, streaming.Sender) (*search.Alert, error)
-	hooks       []func(context.Context, database.DB, streaming.Sender) (*search.Alert, error)
+	defaultHook func(context.Context, job.RuntimeClients, streaming.Sender) (*search.Alert, error)
+	hooks       []func(context.Context, job.RuntimeClients, streaming.Sender) (*search.Alert, error)
 	history     []JobRunFuncCall
 	mutex       sync.Mutex
 }
 
 // Run delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockJob) Run(v0 context.Context, v1 database.DB, v2 streaming.Sender) (*search.Alert, error) {
+func (m *MockJob) Run(v0 context.Context, v1 job.RuntimeClients, v2 streaming.Sender) (*search.Alert, error) {
 	r0, r1 := m.RunFunc.nextHook()(v0, v1, v2)
 	m.RunFunc.appendCall(JobRunFuncCall{v0, v1, v2, r0, r1})
 	return r0, r1
@@ -188,7 +187,7 @@ func (m *MockJob) Run(v0 context.Context, v1 database.DB, v2 streaming.Sender) (
 
 // SetDefaultHook sets function that is called when the Run method of the
 // parent MockJob instance is invoked and the hook queue is empty.
-func (f *JobRunFunc) SetDefaultHook(hook func(context.Context, database.DB, streaming.Sender) (*search.Alert, error)) {
+func (f *JobRunFunc) SetDefaultHook(hook func(context.Context, job.RuntimeClients, streaming.Sender) (*search.Alert, error)) {
 	f.defaultHook = hook
 }
 
@@ -196,7 +195,7 @@ func (f *JobRunFunc) SetDefaultHook(hook func(context.Context, database.DB, stre
 // Run method of the parent MockJob instance invokes the hook at the front
 // of the queue and discards it. After the queue is empty, the default hook
 // function is invoked for any future action.
-func (f *JobRunFunc) PushHook(hook func(context.Context, database.DB, streaming.Sender) (*search.Alert, error)) {
+func (f *JobRunFunc) PushHook(hook func(context.Context, job.RuntimeClients, streaming.Sender) (*search.Alert, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -205,19 +204,19 @@ func (f *JobRunFunc) PushHook(hook func(context.Context, database.DB, streaming.
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
 func (f *JobRunFunc) SetDefaultReturn(r0 *search.Alert, r1 error) {
-	f.SetDefaultHook(func(context.Context, database.DB, streaming.Sender) (*search.Alert, error) {
+	f.SetDefaultHook(func(context.Context, job.RuntimeClients, streaming.Sender) (*search.Alert, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
 func (f *JobRunFunc) PushReturn(r0 *search.Alert, r1 error) {
-	f.PushHook(func(context.Context, database.DB, streaming.Sender) (*search.Alert, error) {
+	f.PushHook(func(context.Context, job.RuntimeClients, streaming.Sender) (*search.Alert, error) {
 		return r0, r1
 	})
 }
 
-func (f *JobRunFunc) nextHook() func(context.Context, database.DB, streaming.Sender) (*search.Alert, error) {
+func (f *JobRunFunc) nextHook() func(context.Context, job.RuntimeClients, streaming.Sender) (*search.Alert, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -255,7 +254,7 @@ type JobRunFuncCall struct {
 	Arg0 context.Context
 	// Arg1 is the value of the 2nd argument passed to this method
 	// invocation.
-	Arg1 database.DB
+	Arg1 job.RuntimeClients
 	// Arg2 is the value of the 3rd argument passed to this method
 	// invocation.
 	Arg2 streaming.Sender

--- a/internal/search/predicate/substitute.go
+++ b/internal/search/predicate/substitute.go
@@ -46,7 +46,7 @@ func Expand(ctx context.Context, db database.DB, jobArgs *jobutil.Args, oldPlan 
 		q := q
 		g.Go(func() error {
 			predicatePlan, err := Substitute(q, func(plan query.Plan) (result.Matches, error) {
-				predicateJob, err := jobutil.FromExpandedPlan(jobArgs, plan, db)
+				predicateJob, err := jobutil.FromExpandedPlan(jobArgs.SearchInputs, plan, db)
 				if err != nil {
 					return nil, err
 				}

--- a/internal/search/repos/excluded_job.go
+++ b/internal/search/repos/excluded_job.go
@@ -3,7 +3,6 @@ package repos
 import (
 	"context"
 
-	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/search/job"
 	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
@@ -13,11 +12,11 @@ type ComputeExcludedRepos struct {
 	Options search.RepoOptions
 }
 
-func (c *ComputeExcludedRepos) Run(ctx context.Context, db database.DB, s streaming.Sender) (alert *search.Alert, err error) {
+func (c *ComputeExcludedRepos) Run(ctx context.Context, clients job.RuntimeClients, s streaming.Sender) (alert *search.Alert, err error) {
 	_, ctx, s, finish := job.StartSpan(ctx, s, c)
 	defer func() { finish(alert, err) }()
 
-	repositoryResolver := Resolver{DB: db}
+	repositoryResolver := Resolver{DB: clients.DB}
 	excluded, err := repositoryResolver.Excluded(ctx, c.Options)
 	if err != nil {
 		return nil, err

--- a/internal/search/run/repo_has_file.go
+++ b/internal/search/run/repo_has_file.go
@@ -46,7 +46,6 @@ func (s *RepoSearch) reposContainingPath(ctx context.Context, clients job.Runtim
 		RepoOptions:     s.RepoOptions,
 		Features:        s.Features,
 		Mode:            s.Mode,
-		SearcherURLs:    s.SearcherURLs,
 		UseFullDeadline: true,
 	}
 

--- a/internal/search/run/repo_has_file.go
+++ b/internal/search/run/repo_has_file.go
@@ -64,7 +64,6 @@ func (s *RepoSearch) reposContainingPath(ctx context.Context, clients job.Runtim
 	}
 
 	searcherArgs := &search.SearcherParameters{
-		SearcherURLs:    newArgs.SearcherURLs,
 		PatternInfo:     newArgs.PatternInfo,
 		UseFullDeadline: newArgs.UseFullDeadline,
 	}

--- a/internal/search/run/repo_has_file.go
+++ b/internal/search/run/repo_has_file.go
@@ -124,7 +124,6 @@ func (s *RepoSearch) reposContainingPath(ctx context.Context, clients job.Runtim
 			PatternInfo:     searcherArgs.PatternInfo,
 			Repos:           unindexed,
 			Indexed:         false,
-			SearcherURLs:    searcherArgs.SearcherURLs,
 			UseFullDeadline: searcherArgs.UseFullDeadline,
 		}
 

--- a/internal/search/run/repo_has_file.go
+++ b/internal/search/run/repo_has_file.go
@@ -46,7 +46,6 @@ func (s *RepoSearch) reposContainingPath(ctx context.Context, clients job.Runtim
 		RepoOptions:     s.RepoOptions,
 		Features:        s.Features,
 		Mode:            s.Mode,
-		Zoekt:           s.Zoekt,
 		SearcherURLs:    s.SearcherURLs,
 		UseFullDeadline: true,
 	}
@@ -54,7 +53,7 @@ func (s *RepoSearch) reposContainingPath(ctx context.Context, clients job.Runtim
 	indexed, unindexed, err := zoektutil.PartitionRepos(
 		ctx,
 		newArgs.Repos,
-		newArgs.Zoekt,
+		clients.Zoekt,
 		search.TextRequest,
 		newArgs.PatternInfo.Index,
 		query.ContainsRefGlobs(newArgs.Query),

--- a/internal/search/run/repo_has_file.go
+++ b/internal/search/run/repo_has_file.go
@@ -100,7 +100,6 @@ func (s *RepoSearch) reposContainingPath(ctx context.Context, clients job.Runtim
 			Typ:            typ,
 			FileMatchLimit: newArgs.PatternInfo.FileMatchLimit,
 			Select:         newArgs.PatternInfo.Select,
-			Zoekt:          newArgs.Zoekt,
 		}
 
 		zoektJob := &zoektutil.ZoektRepoSubsetSearch{

--- a/internal/search/run/repo_has_file.go
+++ b/internal/search/run/repo_has_file.go
@@ -109,7 +109,6 @@ func (s *RepoSearch) reposContainingPath(ctx context.Context, clients job.Runtim
 			Typ:            search.TextRequest,
 			FileMatchLimit: zoektArgs.FileMatchLimit,
 			Select:         zoektArgs.Select,
-			Zoekt:          zoektArgs.Zoekt,
 			Since:          nil,
 		}
 

--- a/internal/search/run/repository.go
+++ b/internal/search/run/repository.go
@@ -3,7 +3,6 @@ package run
 import (
 	"context"
 
-	"github.com/google/zoekt"
 	otlog "github.com/opentracing/opentracing-go/log"
 
 	"github.com/sourcegraph/sourcegraph/internal/database"
@@ -40,7 +39,6 @@ type RepoSearch struct {
 	// to true if the user requests a specific timeout or maximum result size.
 	UseFullDeadline bool
 
-	Zoekt        zoekt.Streamer
 	SearcherURLs *endpoint.Map
 }
 

--- a/internal/search/run/repository.go
+++ b/internal/search/run/repository.go
@@ -6,7 +6,6 @@ import (
 	otlog "github.com/opentracing/opentracing-go/log"
 
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/endpoint"
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/search/job"
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
@@ -38,8 +37,6 @@ type RepoSearch struct {
 	// repository if this field is true. Another example is we set this field
 	// to true if the user requests a specific timeout or maximum result size.
 	UseFullDeadline bool
-
-	SearcherURLs *endpoint.Map
 }
 
 func (s *RepoSearch) Run(ctx context.Context, clients job.RuntimeClients, stream streaming.Sender) (alert *search.Alert, err error) {

--- a/internal/search/run/repository_test.go
+++ b/internal/search/run/repository_test.go
@@ -133,7 +133,6 @@ func repoShouldBeAdded(ctx context.Context, clients job.RuntimeClients, repo *se
 	repos := []*search.RepositoryRevisions{repo}
 	s := RepoSearch{
 		PatternInfo: pattern,
-		Zoekt:       clients.Zoekt,
 	}
 	rsta, err := s.reposToAdd(ctx, clients, repos)
 	if err != nil {

--- a/internal/search/run/repository_test.go
+++ b/internal/search/run/repository_test.go
@@ -5,9 +5,9 @@ import (
 	"os"
 	"testing"
 
-	"github.com/google/zoekt"
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	searchbackend "github.com/sourcegraph/sourcegraph/internal/search/backend"
+	"github.com/sourcegraph/sourcegraph/internal/search/job"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
@@ -41,7 +41,7 @@ func TestRepoShouldBeAdded(t *testing.T) {
 			PatternMatchesContent:        true,
 			PatternMatchesPath:           true,
 		}
-		shouldBeAdded, err := repoShouldBeAdded(context.Background(), zoekt, repo, pat)
+		shouldBeAdded, err := repoShouldBeAdded(context.Background(), job.RuntimeClients{Zoekt: zoekt}, repo, pat)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -64,7 +64,7 @@ func TestRepoShouldBeAdded(t *testing.T) {
 			PatternMatchesContent:        true,
 			PatternMatchesPath:           true,
 		}
-		shouldBeAdded, err := repoShouldBeAdded(context.Background(), zoekt, repo, pat)
+		shouldBeAdded, err := repoShouldBeAdded(context.Background(), job.RuntimeClients{Zoekt: zoekt}, repo, pat)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -94,7 +94,7 @@ func TestRepoShouldBeAdded(t *testing.T) {
 			PatternMatchesContent:        true,
 			PatternMatchesPath:           true,
 		}
-		shouldBeAdded, err := repoShouldBeAdded(context.Background(), zoekt, repo, pat)
+		shouldBeAdded, err := repoShouldBeAdded(context.Background(), job.RuntimeClients{Zoekt: zoekt}, repo, pat)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -117,7 +117,7 @@ func TestRepoShouldBeAdded(t *testing.T) {
 			PatternMatchesContent:        true,
 			PatternMatchesPath:           true,
 		}
-		shouldBeAdded, err := repoShouldBeAdded(context.Background(), zoekt, repo, pat)
+		shouldBeAdded, err := repoShouldBeAdded(context.Background(), job.RuntimeClients{Zoekt: zoekt}, repo, pat)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -129,13 +129,13 @@ func TestRepoShouldBeAdded(t *testing.T) {
 
 // repoShouldBeAdded determines whether a repository should be included in the result set based on whether the repository fits in the subset
 // of repostiories specified in the query's `repohasfile` and `-repohasfile` fields if they exist.
-func repoShouldBeAdded(ctx context.Context, zoekt zoekt.Streamer, repo *search.RepositoryRevisions, pattern *search.TextPatternInfo) (bool, error) {
+func repoShouldBeAdded(ctx context.Context, clients job.RuntimeClients, repo *search.RepositoryRevisions, pattern *search.TextPatternInfo) (bool, error) {
 	repos := []*search.RepositoryRevisions{repo}
 	s := RepoSearch{
 		PatternInfo: pattern,
-		Zoekt:       zoekt,
+		Zoekt:       clients.Zoekt,
 	}
-	rsta, err := s.reposToAdd(ctx, repos)
+	rsta, err := s.reposToAdd(ctx, clients, repos)
 	if err != nil {
 		return false, err
 	}

--- a/internal/search/searcher/search.go
+++ b/internal/search/searcher/search.go
@@ -34,8 +34,7 @@ type Searcher struct {
 	// Indexed represents whether the set of repositories are indexed (used
 	// to communicate whether searcher should call Zoekt search on these
 	// repos).
-	Indexed      bool
-	SearcherURLs *endpoint.Map
+	Indexed bool
 
 	// UseFullDeadline indicates that the search should try do as much work as
 	// it can within context.Deadline. If false the search should try and be
@@ -83,7 +82,7 @@ func (s *Searcher) Run(ctx context.Context, clients job.RuntimeClients, stream s
 	// The number of searcher endpoints can change over time. Inform our
 	// limiter of the new limit, which is a multiple of the number of
 	// searchers.
-	eps, err := s.SearcherURLs.Endpoints()
+	eps, err := clients.SearcherURLs.Endpoints()
 	if err != nil {
 		return nil, err
 	}
@@ -113,7 +112,7 @@ func (s *Searcher) Run(ctx context.Context, clients job.RuntimeClients, stream s
 					ctx, done := limitCtx, limitDone
 					defer done()
 
-					repoLimitHit, err := searchFilesInRepo(ctx, clients.DB, s.SearcherURLs, repoRev.Repo, repoRev.GitserverRepo(), repoRev.RevSpecs()[0], s.Indexed, s.PatternInfo, fetchTimeout, stream)
+					repoLimitHit, err := searchFilesInRepo(ctx, clients.DB, clients.SearcherURLs, repoRev.Repo, repoRev.GitserverRepo(), repoRev.RevSpecs()[0], s.Indexed, s.PatternInfo, fetchTimeout, stream)
 					if err != nil {
 						tr.LogFields(otlog.String("repo", string(repoRev.Repo.Name)), otlog.Error(err), otlog.Bool("timeout", errcode.IsTimeout(err)), otlog.Bool("temporary", errcode.IsTemporary(err)))
 						log15.Warn("searchFilesInRepo failed", "error", err, "repo", repoRev.Repo.Name)

--- a/internal/search/searcher/symbol_search_job.go
+++ b/internal/search/searcher/symbol_search_job.go
@@ -29,7 +29,7 @@ type SymbolSearcher struct {
 }
 
 // Run calls the searcher service to search symbols.
-func (s *SymbolSearcher) Run(ctx context.Context, db database.DB, stream streaming.Sender) (alert *search.Alert, err error) {
+func (s *SymbolSearcher) Run(ctx context.Context, clients job.RuntimeClients, stream streaming.Sender) (alert *search.Alert, err error) {
 	tr, ctx, stream, finish := job.StartSpan(ctx, stream, s)
 	defer func() { finish(alert, err) }()
 
@@ -50,7 +50,7 @@ func (s *SymbolSearcher) Run(ctx context.Context, db database.DB, stream streami
 		goroutine.Go(func() {
 			defer run.Release()
 
-			matches, err := searchInRepo(ctx, db, repoRevs, s.PatternInfo, s.Limit)
+			matches, err := searchInRepo(ctx, clients.DB, repoRevs, s.PatternInfo, s.Limit)
 			status, limitHit, err := search.HandleRepoSearchResult(repoRevs, len(matches) > s.Limit, false, err)
 			stream.Send(streaming.SearchEvent{
 				Results: matches,

--- a/internal/search/structural/structural.go
+++ b/internal/search/structural/structural.go
@@ -7,7 +7,6 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
-	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/search/job"
 	"github.com/sourcegraph/sourcegraph/internal/search/limits"
@@ -53,6 +52,7 @@ func (UnindexedList) IsIndexed() bool {
 // searchRepos represent the arguments to a search called over repositories.
 type searchRepos struct {
 	args    *search.SearcherParameters
+	clients job.RuntimeClients
 	repoSet repoData
 	stream  streaming.Sender
 }
@@ -68,7 +68,7 @@ func (s *searchRepos) getJob(ctx context.Context) func() error {
 			UseFullDeadline: s.args.UseFullDeadline,
 		}
 
-		_, err := searcherJob.Run(ctx, nil, s.stream)
+		_, err := searcherJob.Run(ctx, s.clients, s.stream)
 		return err
 	}
 }
@@ -82,7 +82,7 @@ func runJobs(ctx context.Context, jobs []*searchRepos) error {
 }
 
 // streamStructuralSearch runs structural search jobs and streams the results.
-func streamStructuralSearch(ctx context.Context, args *search.SearcherParameters, repos []repoData, stream streaming.Sender) (err error) {
+func streamStructuralSearch(ctx context.Context, clients job.RuntimeClients, args *search.SearcherParameters, repos []repoData, stream streaming.Sender) (err error) {
 	jobs := []*searchRepos{}
 	for _, repoSet := range repos {
 		searcherArgs := &search.SearcherParameters{
@@ -91,39 +91,39 @@ func streamStructuralSearch(ctx context.Context, args *search.SearcherParameters
 			UseFullDeadline: args.UseFullDeadline,
 		}
 
-		jobs = append(jobs, &searchRepos{args: searcherArgs, stream: stream, repoSet: repoSet})
+		jobs = append(jobs, &searchRepos{clients: clients, args: searcherArgs, stream: stream, repoSet: repoSet})
 	}
 	return runJobs(ctx, jobs)
 }
 
 // retryStructuralSearch runs a structural search with a higher limit file match
 // limit so that Zoekt resolves more potential file matches.
-func retryStructuralSearch(ctx context.Context, args *search.SearcherParameters, repos []repoData, stream streaming.Sender) error {
+func retryStructuralSearch(ctx context.Context, clients job.RuntimeClients, args *search.SearcherParameters, repos []repoData, stream streaming.Sender) error {
 	patternCopy := *(args.PatternInfo)
 	patternCopy.FileMatchLimit = 1000
 	argsCopy := *args
 	argsCopy.PatternInfo = &patternCopy
 	args = &argsCopy
-	return streamStructuralSearch(ctx, args, repos, stream)
+	return streamStructuralSearch(ctx, clients, args, repos, stream)
 }
 
-func runStructuralSearch(ctx context.Context, args *search.SearcherParameters, repos []repoData, stream streaming.Sender) error {
+func runStructuralSearch(ctx context.Context, clients job.RuntimeClients, args *search.SearcherParameters, repos []repoData, stream streaming.Sender) error {
 	if args.PatternInfo.FileMatchLimit != limits.DefaultMaxSearchResults {
 		// streamStructuralSearch performs a streaming search when the user sets a value
 		// for `count`. The first return parameter indicates whether the request was
 		// serviced with streaming.
-		return streamStructuralSearch(ctx, args, repos, stream)
+		return streamStructuralSearch(ctx, clients, args, repos, stream)
 	}
 
 	// For structural search with default limits we retry if we get no results.
 	agg := streaming.NewAggregatingStream()
-	err := streamStructuralSearch(ctx, args, repos, agg)
+	err := streamStructuralSearch(ctx, clients, args, repos, agg)
 
 	event := agg.SearchEvent
 	if len(event.Results) == 0 && err == nil {
 		// retry structural search with a higher limit.
 		agg := streaming.NewAggregatingStream()
-		err := retryStructuralSearch(ctx, args, repos, agg)
+		err := retryStructuralSearch(ctx, clients, args, repos, agg)
 		if err != nil {
 			return err
 		}
@@ -160,11 +160,11 @@ type StructuralSearch struct {
 	RepoOpts search.RepoOptions
 }
 
-func (s *StructuralSearch) Run(ctx context.Context, db database.DB, stream streaming.Sender) (alert *search.Alert, err error) {
+func (s *StructuralSearch) Run(ctx context.Context, clients job.RuntimeClients, stream streaming.Sender) (alert *search.Alert, err error) {
 	_, ctx, stream, finish := job.StartSpan(ctx, stream, s)
 	defer func() { finish(alert, err) }()
 
-	repos := &searchrepos.Resolver{DB: db, Opts: s.RepoOpts}
+	repos := &searchrepos.Resolver{DB: clients.DB, Opts: s.RepoOpts}
 	return nil, repos.Paginate(ctx, nil, func(page *searchrepos.Resolved) error {
 		indexed, unindexed, err := zoektutil.PartitionRepos(
 			ctx,
@@ -182,7 +182,7 @@ func (s *StructuralSearch) Run(ctx context.Context, db database.DB, stream strea
 		if indexed != nil {
 			repoSet = append(repoSet, IndexedMap(indexed.RepoRevs))
 		}
-		return runStructuralSearch(ctx, s.SearcherArgs, repoSet, stream)
+		return runStructuralSearch(ctx, clients, s.SearcherArgs, repoSet, stream)
 	})
 }
 

--- a/internal/search/structural/structural.go
+++ b/internal/search/structural/structural.go
@@ -85,7 +85,6 @@ func streamStructuralSearch(ctx context.Context, clients job.RuntimeClients, arg
 	jobs := []*searchRepos{}
 	for _, repoSet := range repos {
 		searcherArgs := &search.SearcherParameters{
-			SearcherURLs:    args.SearcherURLs,
 			PatternInfo:     args.PatternInfo,
 			UseFullDeadline: args.UseFullDeadline,
 		}

--- a/internal/search/structural/structural.go
+++ b/internal/search/structural/structural.go
@@ -169,7 +169,7 @@ func (s *StructuralSearch) Run(ctx context.Context, clients job.RuntimeClients, 
 		indexed, unindexed, err := zoektutil.PartitionRepos(
 			ctx,
 			page.RepoRevs,
-			s.ZoektArgs.Zoekt,
+			clients.Zoekt,
 			search.TextRequest,
 			s.UseIndex,
 			s.ContainsRefGlobs,

--- a/internal/search/structural/structural.go
+++ b/internal/search/structural/structural.go
@@ -64,7 +64,6 @@ func (s *searchRepos) getJob(ctx context.Context) func() error {
 			PatternInfo:     s.args.PatternInfo,
 			Repos:           s.repoSet.AsList(),
 			Indexed:         s.repoSet.IsIndexed(),
-			SearcherURLs:    s.args.SearcherURLs,
 			UseFullDeadline: s.args.UseFullDeadline,
 		}
 

--- a/internal/search/symbol/symbol.go
+++ b/internal/search/symbol/symbol.go
@@ -245,7 +245,7 @@ func (s *RepoUniverseSymbolSearch) Run(ctx context.Context, clients job.RuntimeC
 	s.ZoektArgs.Query = s.GlobalZoektQuery.Generate()
 
 	// always search for symbols in indexed repositories when searching the repo universe.
-	err = zoektutil.DoZoektSearchGlobal(ctx, s.ZoektArgs, stream)
+	err = zoektutil.DoZoektSearchGlobal(ctx, clients.Zoekt, s.ZoektArgs, stream)
 	if err != nil {
 		tr.LogFields(otlog.Error(err))
 		// Only record error if we haven't timed out.

--- a/internal/search/symbol/symbol.go
+++ b/internal/search/symbol/symbol.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/internal/api"
-	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/search/job"
 	"github.com/sourcegraph/sourcegraph/internal/search/repos"
@@ -237,11 +236,11 @@ type RepoUniverseSymbolSearch struct {
 	RepoOptions      search.RepoOptions
 }
 
-func (s *RepoUniverseSymbolSearch) Run(ctx context.Context, db database.DB, stream streaming.Sender) (alert *search.Alert, err error) {
+func (s *RepoUniverseSymbolSearch) Run(ctx context.Context, clients job.RuntimeClients, stream streaming.Sender) (alert *search.Alert, err error) {
 	tr, ctx, stream, finish := job.StartSpan(ctx, stream, s)
 	defer func() { finish(alert, err) }()
 
-	userPrivateRepos := repos.PrivateReposForActor(ctx, db, s.RepoOptions)
+	userPrivateRepos := repos.PrivateReposForActor(ctx, clients.DB, s.RepoOptions)
 	s.GlobalZoektQuery.ApplyPrivateFilter(userPrivateRepos)
 	s.ZoektArgs.Query = s.GlobalZoektQuery.Generate()
 

--- a/internal/search/textsearch/textsearch_test.go
+++ b/internal/search/textsearch/textsearch_test.go
@@ -486,7 +486,7 @@ func RunRepoSubsetTextSearch(
 			UseFullDeadline: searcherArgs.UseFullDeadline,
 		}
 
-		_, err := searcherJob.Run(ctx, job.RuntimeClients{Zoekt: zoekt}, agg)
+		_, err := searcherJob.Run(ctx, job.RuntimeClients{SearcherURLs: searcherURLs, Zoekt: zoekt}, agg)
 		return err
 	})
 

--- a/internal/search/textsearch/textsearch_test.go
+++ b/internal/search/textsearch/textsearch_test.go
@@ -484,7 +484,6 @@ func RunRepoSubsetTextSearch(
 			PatternInfo:     searcherArgs.PatternInfo,
 			Repos:           unindexed,
 			Indexed:         false,
-			SearcherURLs:    searcherArgs.SearcherURLs,
 			UseFullDeadline: searcherArgs.UseFullDeadline,
 		}
 

--- a/internal/search/textsearch/textsearch_test.go
+++ b/internal/search/textsearch/textsearch_test.go
@@ -468,7 +468,6 @@ func RunRepoSubsetTextSearch(
 			Typ:            search.TextRequest,
 			FileMatchLimit: patternInfo.FileMatchLimit,
 			Select:         patternInfo.Select,
-			Zoekt:          zoekt,
 			Since:          nil,
 		}
 

--- a/internal/search/textsearch/textsearch_test.go
+++ b/internal/search/textsearch/textsearch_test.go
@@ -419,7 +419,6 @@ func RunRepoSubsetTextSearch(
 ) ([]*result.FileMatch, streaming.Stats, error) {
 	notSearcherOnly := mode != search.SearcherOnly
 	searcherArgs := &search.SearcherParameters{
-		SearcherURLs:    searcherURLs,
 		PatternInfo:     patternInfo,
 		UseFullDeadline: useFullDeadline,
 	}

--- a/internal/search/textsearch/textsearch_test.go
+++ b/internal/search/textsearch/textsearch_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	searchbackend "github.com/sourcegraph/sourcegraph/internal/search/backend"
+	"github.com/sourcegraph/sourcegraph/internal/search/job"
 	"github.com/sourcegraph/sourcegraph/internal/search/limits"
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
@@ -473,7 +474,7 @@ func RunRepoSubsetTextSearch(
 
 		// Run literal and regexp searches on indexed repositories.
 		g.Go(func() error {
-			_, err := zoektJob.Run(ctx, nil, agg)
+			_, err := zoektJob.Run(ctx, job.RuntimeClients{Zoekt: zoekt}, agg)
 			return err
 		})
 	}
@@ -488,7 +489,7 @@ func RunRepoSubsetTextSearch(
 			UseFullDeadline: searcherArgs.UseFullDeadline,
 		}
 
-		_, err := searcherJob.Run(ctx, nil, agg)
+		_, err := searcherJob.Run(ctx, job.RuntimeClients{Zoekt: zoekt}, agg)
 		return err
 	})
 

--- a/internal/search/types.go
+++ b/internal/search/types.go
@@ -5,7 +5,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/google/zoekt"
 	zoektquery "github.com/google/zoekt/query"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/endpoint"
@@ -101,8 +100,6 @@ type ZoektParameters struct {
 	Typ            IndexedRequestType
 	FileMatchLimit int32
 	Select         filter.SelectPath
-
-	Zoekt zoekt.Streamer
 }
 
 // SearcherParameters the inputs for a search fulfilled by the Searcher service

--- a/internal/search/types.go
+++ b/internal/search/types.go
@@ -7,7 +7,6 @@ import (
 
 	zoektquery "github.com/google/zoekt/query"
 	"github.com/sourcegraph/sourcegraph/internal/api"
-	"github.com/sourcegraph/sourcegraph/internal/endpoint"
 	"github.com/sourcegraph/sourcegraph/internal/search/filter"
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
 	"github.com/sourcegraph/sourcegraph/internal/types"
@@ -106,8 +105,7 @@ type ZoektParameters struct {
 // (cmd/searcher). Searcher fulfills (1) unindexed literal and regexp searches
 // and (2) structural search requests.
 type SearcherParameters struct {
-	SearcherURLs *endpoint.Map
-	PatternInfo  *TextPatternInfo
+	PatternInfo *TextPatternInfo
 
 	// UseFullDeadline indicates that the search should try do as much work as
 	// it can within context.Deadline. If false the search should try and be

--- a/internal/search/zoekt/indexed_search.go
+++ b/internal/search/zoekt/indexed_search.go
@@ -537,7 +537,6 @@ type ZoektRepoSubsetSearch struct {
 	Typ            search.IndexedRequestType
 	FileMatchLimit int32
 	Select         filter.SelectPath
-	Zoekt          zoekt.Streamer
 	Since          func(time.Time) time.Duration `json:"-"` // since if non-nil will be used instead of time.Since. For tests
 }
 
@@ -561,7 +560,7 @@ func (z *ZoektRepoSubsetSearch) Run(ctx context.Context, clients job.RuntimeClie
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	return nil, zoektSearch(ctx, z.Repos, z.Query, z.Typ, z.Zoekt, z.FileMatchLimit, z.Select, since, stream)
+	return nil, zoektSearch(ctx, z.Repos, z.Query, z.Typ, clients.Zoekt, z.FileMatchLimit, z.Select, since, stream)
 }
 
 func (*ZoektRepoSubsetSearch) Name() string {

--- a/internal/search/zoekt/indexed_search_test.go
+++ b/internal/search/zoekt/indexed_search_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	searchbackend "github.com/sourcegraph/sourcegraph/internal/search/backend"
 	"github.com/sourcegraph/sourcegraph/internal/search/filter"
+	"github.com/sourcegraph/sourcegraph/internal/search/job"
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
 	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
@@ -308,7 +309,7 @@ func TestIndexedSearch(t *testing.T) {
 				Since:          tt.args.since,
 			}
 
-			_, err = zoektJob.Run(tt.args.ctx, nil, agg)
+			_, err = zoektJob.Run(tt.args.ctx, job.RuntimeClients{Zoekt: zoekt}, agg)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("zoektSearchHEAD() error = %v, wantErr = %v", err, tt.wantErr)
 				return

--- a/internal/search/zoekt/indexed_search_test.go
+++ b/internal/search/zoekt/indexed_search_test.go
@@ -305,7 +305,6 @@ func TestIndexedSearch(t *testing.T) {
 				Typ:            search.TextRequest,
 				FileMatchLimit: tt.args.fileMatchLimit,
 				Select:         tt.args.selectPath,
-				Zoekt:          zoekt,
 				Since:          tt.args.since,
 			}
 

--- a/internal/search/zoekt/symbol_search_job.go
+++ b/internal/search/zoekt/symbol_search_job.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"time"
 
-	"github.com/google/zoekt"
 	zoektquery "github.com/google/zoekt/query"
 	otlog "github.com/opentracing/opentracing-go/log"
+
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/search/filter"
 	"github.com/sourcegraph/sourcegraph/internal/search/job"
@@ -18,7 +18,6 @@ type ZoektSymbolSearch struct {
 	Query          zoektquery.Q
 	FileMatchLimit int32
 	Select         filter.SelectPath
-	Zoekt          zoekt.Streamer
 	Since          func(time.Time) time.Duration `json:"-"` // since if non-nil will be used instead of time.Since. For tests
 }
 
@@ -42,7 +41,7 @@ func (z *ZoektSymbolSearch) Run(ctx context.Context, clients job.RuntimeClients,
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	err = zoektSearch(ctx, z.Repos, z.Query, search.SymbolRequest, z.Zoekt, z.FileMatchLimit, z.Select, since, stream)
+	err = zoektSearch(ctx, z.Repos, z.Query, search.SymbolRequest, clients.Zoekt, z.FileMatchLimit, z.Select, since, stream)
 	if err != nil {
 		tr.LogFields(otlog.Error(err))
 		// Only record error if we haven't timed out.

--- a/internal/search/zoekt/symbol_search_job.go
+++ b/internal/search/zoekt/symbol_search_job.go
@@ -7,7 +7,6 @@ import (
 	"github.com/google/zoekt"
 	zoektquery "github.com/google/zoekt/query"
 	otlog "github.com/opentracing/opentracing-go/log"
-	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/search/filter"
 	"github.com/sourcegraph/sourcegraph/internal/search/job"
@@ -24,7 +23,7 @@ type ZoektSymbolSearch struct {
 }
 
 // Run calls the zoekt backend to search symbols
-func (z *ZoektSymbolSearch) Run(ctx context.Context, _ database.DB, stream streaming.Sender) (alert *search.Alert, err error) {
+func (z *ZoektSymbolSearch) Run(ctx context.Context, clients job.RuntimeClients, stream streaming.Sender) (alert *search.Alert, err error) {
 	tr, ctx, stream, finish := job.StartSpan(ctx, stream, z)
 	defer func() { finish(alert, err) }()
 


### PR DESCRIPTION
This brings us most of the way to a static query execution plan. In particular, it modifies search jobs to accept a `job.RuntimeDependencies` struct for their `Run` methods and removes all runtime clients from the search job structs.

This is valuable because it reduces the dependency requirements of the `Plan` step of query execution, greatly simplifying the set of values that need to be passed through the tree. The eventual goal is a clean separation between the `Plan` step and the `Run` step.

Each commit is pretty independent, but I would not recommend reviewing commit-by-commit since there are many. The commits were mostly me making jumps between islands of passing typechecks. 

Stacked on #33741

## Test plan

Should be fully semantics preserving, but I'm relying pretty heavily on backend integration tests here. I did do some light manual testing.

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


