### PR TITLE
Search backend: remove DB handle from planning code

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -596,7 +596,7 @@ func (r *searchResolver) Stats(ctx context.Context) (stats *searchResultsStats, 
 	for {
 		// Query search results.
 		var err error
-		j, err := jobutil.ToSearchJob(r.SearchInputs, r.SearchInputs.Query, r.db)
+		j, err := jobutil.ToSearchJob(r.SearchInputs, r.SearchInputs.Query)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/frontend/graphqlbackend/search_results_stats_languages.go
+++ b/cmd/frontend/graphqlbackend/search_results_stats_languages.go
@@ -40,7 +40,7 @@ func (srs *searchResultsStats) Languages(ctx context.Context) ([]*languageStatis
 
 func (srs *searchResultsStats) getResults(ctx context.Context) (result.Matches, error) {
 	srs.once.Do(func() {
-		j, err := jobutil.ToSearchJob(srs.sr.SearchInputs, srs.sr.SearchInputs.Query, srs.sr.db)
+		j, err := jobutil.ToSearchJob(srs.sr.SearchInputs, srs.sr.SearchInputs.Query)
 		if err != nil {
 			srs.err = err
 			return

--- a/enterprise/internal/codemonitors/search.go
+++ b/enterprise/internal/codemonitors/search.go
@@ -120,7 +120,7 @@ func Search(ctx context.Context, db database.DB, query string, monitorID int64, 
 		return nil, err
 	}
 
-	planJob, err := jobutil.FromExpandedPlan(inputs, plan, db)
+	planJob, err := jobutil.FromExpandedPlan(inputs, plan)
 	if err != nil {
 		return nil, err
 	}
@@ -170,7 +170,7 @@ func Snapshot(ctx context.Context, db database.DB, query string, monitorID int64
 		return err
 	}
 
-	planJob, err := jobutil.FromExpandedPlan(inputs, plan, db)
+	planJob, err := jobutil.FromExpandedPlan(inputs, plan)
 	if err != nil {
 		return err
 	}

--- a/internal/search/execute/execute.go
+++ b/internal/search/execute/execute.go
@@ -32,7 +32,7 @@ func Execute(
 		return nil, err
 	}
 
-	planJob, err := jobutil.FromExpandedPlan(inputs, plan, clients.DB)
+	planJob, err := jobutil.FromExpandedPlan(inputs, plan)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/search/job/jobutil/job.go
+++ b/internal/search/job/jobutil/job.go
@@ -40,7 +40,7 @@ import (
 // query on all indexed repositories) then we need to convert our tree to
 // Zoekt's internal inputs and representation. These concerns are all handled by
 // toSearchJob.
-func ToSearchJob(searchInputs *run.SearchInputs, q query.Q, db database.DB) (job.Job, error) {
+func ToSearchJob(searchInputs *run.SearchInputs, q query.Q) (job.Job, error) {
 	maxResults := q.MaxResults(searchInputs.DefaultLimit())
 
 	b, err := query.ToBasicQuery(q)
@@ -589,10 +589,10 @@ func toPatternExpressionJob(inputs *run.SearchInputs, q query.Basic, db database
 		case query.Or:
 			return toOrJob(inputs, q, db)
 		case query.Concat:
-			return ToSearchJob(inputs, q.ToParseTree(), db)
+			return ToSearchJob(inputs, q.ToParseTree())
 		}
 	case query.Pattern:
-		return ToSearchJob(inputs, q.ToParseTree(), db)
+		return ToSearchJob(inputs, q.ToParseTree())
 	case query.Parameter:
 		// evaluatePatternExpression does not process Parameter nodes.
 		return NewNoopJob(), nil
@@ -610,7 +610,7 @@ func ToEvaluateJob(inputs *run.SearchInputs, q query.Basic, db database.DB) (job
 		err error
 	)
 	if q.Pattern == nil {
-		job, err = ToSearchJob(inputs, query.ToNodes(q.Parameters), db)
+		job, err = ToSearchJob(inputs, query.ToNodes(q.Parameters))
 	} else {
 		job, err = toPatternExpressionJob(inputs, q, db)
 		if err != nil {
@@ -640,7 +640,7 @@ func ToEvaluateJob(inputs *run.SearchInputs, q query.Basic, db database.DB) (job
 // is Zoekt. It removes unoptimized Zoekt jobs from the baseJob and repalces it
 // with the optimized ones.
 func optimizeJobs(baseJob job.Job, inputs *run.SearchInputs, q query.Q, db database.DB) (job.Job, error) {
-	candidateOptimizedJobs, err := ToSearchJob(inputs, q, db)
+	candidateOptimizedJobs, err := ToSearchJob(inputs, q)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/search/job/jobutil/job.go
+++ b/internal/search/job/jobutil/job.go
@@ -10,7 +10,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 
 	"github.com/sourcegraph/sourcegraph/internal/authz"
-	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/featureflag"
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/search/commit"
@@ -534,7 +533,7 @@ func toFeatures(flags featureflag.FlagSet) search.Features {
 }
 
 // toAndJob creates a new job from a basic query whose pattern is an And operator at the root.
-func toAndJob(inputs *run.SearchInputs, q query.Basic, db database.DB) (job.Job, error) {
+func toAndJob(inputs *run.SearchInputs, q query.Basic) (job.Job, error) {
 	// Invariant: this function is only reachable from callers that
 	// guarantee a root node with one or more queryOperands.
 	queryOperands := q.Pattern.(query.Operator).Operands
@@ -549,7 +548,7 @@ func toAndJob(inputs *run.SearchInputs, q query.Basic, db database.DB) (job.Job,
 
 	operands := make([]job.Job, 0, len(queryOperands))
 	for _, queryOperand := range queryOperands {
-		operand, err := toPatternExpressionJob(inputs, q.MapPattern(queryOperand), db)
+		operand, err := toPatternExpressionJob(inputs, q.MapPattern(queryOperand))
 		if err != nil {
 			return nil, err
 		}
@@ -560,14 +559,14 @@ func toAndJob(inputs *run.SearchInputs, q query.Basic, db database.DB) (job.Job,
 }
 
 // toOrJob creates a new job from a basic query whose pattern is an Or operator at the top level
-func toOrJob(inputs *run.SearchInputs, q query.Basic, db database.DB) (job.Job, error) {
+func toOrJob(inputs *run.SearchInputs, q query.Basic) (job.Job, error) {
 	// Invariant: this function is only reachable from callers that
 	// guarantee a root node with one or more queryOperands.
 	queryOperands := q.Pattern.(query.Operator).Operands
 
 	operands := make([]job.Job, 0, len(queryOperands))
 	for _, term := range queryOperands {
-		operand, err := toPatternExpressionJob(inputs, q.MapPattern(term), db)
+		operand, err := toPatternExpressionJob(inputs, q.MapPattern(term))
 		if err != nil {
 			return nil, err
 		}
@@ -576,7 +575,7 @@ func toOrJob(inputs *run.SearchInputs, q query.Basic, db database.DB) (job.Job, 
 	return NewOrJob(operands...), nil
 }
 
-func toPatternExpressionJob(inputs *run.SearchInputs, q query.Basic, db database.DB) (job.Job, error) {
+func toPatternExpressionJob(inputs *run.SearchInputs, q query.Basic) (job.Job, error) {
 	switch term := q.Pattern.(type) {
 	case query.Operator:
 		if len(term.Operands) == 0 {
@@ -585,9 +584,9 @@ func toPatternExpressionJob(inputs *run.SearchInputs, q query.Basic, db database
 
 		switch term.Kind {
 		case query.And:
-			return toAndJob(inputs, q, db)
+			return toAndJob(inputs, q)
 		case query.Or:
-			return toOrJob(inputs, q, db)
+			return toOrJob(inputs, q)
 		case query.Concat:
 			return ToSearchJob(inputs, q.ToParseTree())
 		}
@@ -601,7 +600,7 @@ func toPatternExpressionJob(inputs *run.SearchInputs, q query.Basic, db database
 	return nil, errors.Errorf("unrecognized type %T in evaluatePatternExpression", q.Pattern)
 }
 
-func ToEvaluateJob(inputs *run.SearchInputs, q query.Basic, db database.DB) (job.Job, error) {
+func ToEvaluateJob(inputs *run.SearchInputs, q query.Basic) (job.Job, error) {
 	maxResults := q.ToParseTree().MaxResults(inputs.DefaultLimit())
 	timeout := search.TimeoutDuration(q)
 
@@ -612,14 +611,14 @@ func ToEvaluateJob(inputs *run.SearchInputs, q query.Basic, db database.DB) (job
 	if q.Pattern == nil {
 		job, err = ToSearchJob(inputs, query.ToNodes(q.Parameters))
 	} else {
-		job, err = toPatternExpressionJob(inputs, q, db)
+		job, err = toPatternExpressionJob(inputs, q)
 		if err != nil {
 			return nil, err
 		}
 		if _, ok := q.Pattern.(query.Pattern); !ok {
 			// This pattern is not an atomic Pattern, but an
 			// expression. Optimize the expression for backends.
-			job, err = optimizeJobs(job, inputs, q.ToParseTree(), db)
+			job, err = optimizeJobs(job, inputs, q.ToParseTree())
 		}
 	}
 	if err != nil {
@@ -639,7 +638,7 @@ func ToEvaluateJob(inputs *run.SearchInputs, q query.Basic, db database.DB) (job
 // converts them directly to native queries for a backed. Currently that backend
 // is Zoekt. It removes unoptimized Zoekt jobs from the baseJob and repalces it
 // with the optimized ones.
-func optimizeJobs(baseJob job.Job, inputs *run.SearchInputs, q query.Q, db database.DB) (job.Job, error) {
+func optimizeJobs(baseJob job.Job, inputs *run.SearchInputs, q query.Q) (job.Job, error) {
 	candidateOptimizedJobs, err := ToSearchJob(inputs, q)
 	if err != nil {
 		return nil, err
@@ -741,10 +740,10 @@ func optimizeJobs(baseJob job.Job, inputs *run.SearchInputs, q query.Q, db datab
 
 // FromExpandedPlan takes a query plan that has had all predicates expanded,
 // and converts it to a job.
-func FromExpandedPlan(inputs *run.SearchInputs, plan query.Plan, db database.DB) (job.Job, error) {
+func FromExpandedPlan(inputs *run.SearchInputs, plan query.Plan) (job.Job, error) {
 	children := make([]job.Job, 0, len(plan))
 	for _, q := range plan {
-		child, err := ToEvaluateJob(inputs, q, db)
+		child, err := ToEvaluateJob(inputs, q)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/search/job/jobutil/job_test.go
+++ b/internal/search/job/jobutil/job_test.go
@@ -22,7 +22,7 @@ func TestToSearchInputs(t *testing.T) {
 			OnSourcegraphDotCom: true,
 		}
 
-		j, _ := ToSearchJob(inputs, q, database.NewMockDB())
+		j, _ := ToSearchJob(inputs, q)
 		return "\n" + PrettySexp(j) + "\n"
 	}
 

--- a/internal/search/job/jobutil/job_test.go
+++ b/internal/search/job/jobutil/job_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/hexops/autogold"
 
-	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
 	"github.com/sourcegraph/sourcegraph/internal/search/run"
@@ -181,7 +180,7 @@ func TestToEvaluateJob(t *testing.T) {
 		}
 
 		b, _ := query.ToBasicQuery(q)
-		j, _ := ToEvaluateJob(inputs, b, database.NewMockDB())
+		j, _ := ToEvaluateJob(inputs, b)
 		return "\n" + PrettySexp(j) + "\n"
 	}
 
@@ -219,8 +218,8 @@ func Test_optimizeJobs(t *testing.T) {
 		}
 
 		b, _ := query.ToBasicQuery(q)
-		baseJob, _ := toPatternExpressionJob(inputs, b, database.NewMockDB())
-		optimizedJob, _ := optimizeJobs(baseJob, inputs, b.ToParseTree(), database.NewMockDB())
+		baseJob, _ := toPatternExpressionJob(inputs, b)
+		optimizedJob, _ := optimizeJobs(baseJob, inputs, b.ToParseTree())
 		return "\nBASE:\n\n" + PrettySexp(baseJob) + "\n\nOPTIMIZED:\n\n" + PrettySexp(optimizedJob) + "\n"
 	}
 

--- a/internal/search/job/jobutil/printers_test.go
+++ b/internal/search/job/jobutil/printers_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/hexops/autogold"
 
-	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
 	"github.com/sourcegraph/sourcegraph/internal/search/run"
@@ -193,7 +192,7 @@ func TestPrettyJSON(t *testing.T) {
 			UserSettings: &schema.Settings{},
 			Protocol:     search.Streaming,
 		}
-		j, _ := ToSearchJob(inputs, q, database.NewMockDB())
+		j, _ := ToSearchJob(inputs, q)
 		return PrettyJSONVerbose(j)
 	}
 

--- a/internal/search/predicate/substitute.go
+++ b/internal/search/predicate/substitute.go
@@ -38,7 +38,7 @@ func Expand(ctx context.Context, clients job.RuntimeClients, inputs *run.SearchI
 		q := q
 		g.Go(func() error {
 			predicatePlan, err := Substitute(q, func(plan query.Plan) (result.Matches, error) {
-				predicateJob, err := jobutil.FromExpandedPlan(inputs, plan, clients.DB)
+				predicateJob, err := jobutil.FromExpandedPlan(inputs, plan)
 				if err != nil {
 					return nil, err
 				}


### PR DESCRIPTION
This removes the unused DB handle from a bunch of code in the search `Plan` step.

Stacked on #33760

## Test plan

Semantics-preserving. Just removing dead args.

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


