### PR TITLE
Rockskip: reduce round trips to DB

### DIFF
--- a/enterprise/internal/rockskip/index.go
+++ b/enterprise/internal/rockskip/index.go
@@ -221,17 +221,9 @@ func (s *Service) Index(ctx context.Context, db database.DB, repo, givenCommit s
 				id := 0
 				ok := false
 				if id, ok = symbolCache.get(path, symbol); !ok {
+					tasklog.Start("GetSymbol")
 					found := false
-					for _, hop := range hops {
-						tasklog.Start("GetSymbol")
-						id, found, err = GetSymbol(ctx, tx, repoId, path, symbol, hop)
-						if err != nil {
-							return err
-						}
-						if found {
-							break
-						}
-					}
+					id, found, err = GetSymbol(ctx, tx, repoId, path, symbol, hops)
 					if !found {
 						// We did not find the symbol that (supposedly) has been deleted, so ignore the
 						// deletion. This will probably lead to extra symbols in search results.

--- a/enterprise/internal/rockskip/server.go
+++ b/enterprise/internal/rockskip/server.go
@@ -71,6 +71,11 @@ func NewService(
 
 	go service.startCleanupLoop()
 
+	err := CreateGetSymbolFn(context.Background(), db)
+	if err != nil {
+		return nil, err
+	}
+
 	for i := 0; i < maxConcurrentlyIndexing; i++ {
 		go service.startIndexingLoop(database.NewDB(service.db), service.indexRequestQueues[i])
 	}

--- a/migrations/codeintel/1000000035/down.sql
+++ b/migrations/codeintel/1000000035/down.sql
@@ -1,0 +1,1 @@
+DROP FUNCTION IF EXISTS rockskip_get_symbol;

--- a/migrations/codeintel/1000000035/metadata.yaml
+++ b/migrations/codeintel/1000000035/metadata.yaml
@@ -1,0 +1,2 @@
+name: 'rockskip_get_symbol'
+parent: 1000000034

--- a/migrations/codeintel/1000000035/up.sql
+++ b/migrations/codeintel/1000000035/up.sql
@@ -1,0 +1,36 @@
+CREATE OR REPLACE FUNCTION rockskip_get_symbol(repo_arg INTEGER, path_arg TEXT, name_arg TEXT, hops INTEGER[]) RETURNS INTEGER AS $$
+DECLARE
+    hop INTEGER;
+    found_id INTEGER;
+BEGIN
+    FOREACH hop IN ARRAY hops LOOP
+        SELECT id
+            INTO found_id
+            FROM rockskip_symbols
+            WHERE
+                repo_id    =  repo_arg AND
+                path       =  path_arg AND
+                name       =  name_arg AND
+                ARRAY[hop] && added;
+
+        IF FOUND THEN
+            RETURN found_id;
+        END IF;
+
+        IF
+            EXISTS (
+                SELECT id
+                FROM rockskip_symbols
+                WHERE
+                    repo_id    =  repo_arg AND
+                    path       =  path_arg AND
+                    name       =  name_arg AND
+                    ARRAY[hop] && deleted
+            )
+            THEN
+            RETURN -1;
+        END IF;
+    END LOOP;
+
+    RETURN -1;
+END; $$ IMMUTABLE language plpgsql;


### PR DESCRIPTION
- Replaces the tight loop of `GetSymbol()` with a single pl/pgsql function call
- Batches insertions of symbols

Resolves https://github.com/sourcegraph/sourcegraph/issues/33751

## Test plan

Automated tests