### PR TITLE
frontend: Replace use of errors.Cause with errors.Is.

### DIFF
--- a/cmd/frontend/internal/highlight/highlight.go
+++ b/cmd/frontend/internal/highlight/highlight.go
@@ -288,6 +288,19 @@ func (h *HighlightedCode) LinesForRanges(ranges []LineRange) ([][]string, error)
 	return lineRanges, nil
 }
 
+func identifyError(err error) string {
+	if errors.Is(err, gosyntect.ErrRequestTooLarge) {
+		return "request_too_large"
+	} else if errors.Is(err, gosyntect.ErrPanic) {
+		return "panic"
+	} else if errors.Is(err, gosyntect.ErrHSSWorkerTimeout) {
+		return "hss_worker_timeout"
+	} else if strings.Contains(err.Error(), "broken pipe") {
+		return "broken pipe"
+	}
+	return ""
+}
+
 // Code highlights the given file content with the given filepath (must contain
 // at least the file name + extension) and returns the properly escaped HTML
 // table representing the highlighted code.
@@ -424,21 +437,8 @@ func Code(ctx context.Context, p Params) (response *HighlightedCode, aborted boo
 			"snippet", fmt.Sprintf("%q…", firstCharacters(code, 80)),
 			"error", err,
 		)
-		var problem string
-		switch errors.Cause(err) {
-		case gosyntect.ErrRequestTooLarge:
-			problem = "request_too_large"
-		case gosyntect.ErrPanic:
-			problem = "panic"
-		case gosyntect.ErrHSSWorkerTimeout:
-			problem = "hss_worker_timeout"
-		}
 
-		if problem == "" && strings.Contains(err.Error(), "broken pipe") {
-			problem = "broken pipe"
-		}
-
-		if problem != "" {
+		if problem := identifyError(err); problem != "" {
 			// A problem that can sometimes be expected has occurred. We will
 			// identify such problems through metrics/logs and resolve them on
 			// a case-by-case basis, but they are frequent enough that we want

--- a/cmd/frontend/internal/highlight/highlight_test.go
+++ b/cmd/frontend/internal/highlight/highlight_test.go
@@ -7,10 +7,21 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
 
+	"github.com/sourcegraph/sourcegraph/internal/gosyntect"
 	"github.com/sourcegraph/sourcegraph/lib/codeintel/lsiftyped"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
+
+func TestIdentifyError(t *testing.T) {
+	errs := []error{gosyntect.ErrPanic, gosyntect.ErrHSSWorkerTimeout, gosyntect.ErrRequestTooLarge}
+	for _, err := range errs {
+		wrappedErr := errors.Wrap(err, "some other information")
+		require.NotEqual(t, "", identifyError(wrappedErr))
+	}
+}
 
 func TestDeserialize(t *testing.T) {
 	original := new(lsiftyped.Document)

--- a/cmd/frontend/internal/highlight/highlight_test.go
+++ b/cmd/frontend/internal/highlight/highlight_test.go
@@ -19,7 +19,9 @@ func TestIdentifyError(t *testing.T) {
 	errs := []error{gosyntect.ErrPanic, gosyntect.ErrHSSWorkerTimeout, gosyntect.ErrRequestTooLarge}
 	for _, err := range errs {
 		wrappedErr := errors.Wrap(err, "some other information")
-		require.NotEqual(t, "", identifyError(wrappedErr))
+		known, problem := identifyError(wrappedErr)
+		require.True(t, known)
+		require.NotEqual(t, "", problem)
 	}
 }
 


### PR DESCRIPTION
`errors.UnwrapAll` (called internally by `errors.Cause`) can return a more 'bare'
error than the original error created by `errors.New`. This means that
`errors.Cause` would have 0 stack frames; comparing that to a result from
`errors.New` (with 1 stack frame) would fail.
Thanks to this counter-intuitive behavior, switching over the result
of `errors.Cause` is (ahem) error-prone; it MUST NOT be compared directly
with the result of `errors.New`. `errors.Is` does not suffer from this problem.

Fixes issue #33697; we had code paths for making sure that we showed
the un-highlighted file on HSS timeouts, but that code path was not
triggered because we weren't checking the error's identity properly.

I think it is better to be paranoid here given that a regression in this functionality
adversely affects customers in a meaningful way. That is why I've added a test
here for seemingly trivial functionality. The test should hopefully prevent someone
from carelessly "cleaning up" the if-else chain to use `errors.Cause` + `switch`.

([Slack discussion](https://sourcegraph.slack.com/archives/CHXHX7XAS/p1649709835518209))

## Test plan

Added automated test.
