### PR TITLE
docs: mention contributing to enterprise code, update code of conduct link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,12 @@
 
 In short, we are open to nearly all contributions! We love feedback in all forms, issues, comments, PRs, etc!
 
+## Contributing to `enterprise/` code
+
+Anyone is free to contribute changes to any file in this repository, including `enterprise/` code. Once you open a pull request, the CLA bot will require you sign our contributor CLA before we can accept the change.
+
+## Contributing large changes, new features, etc.
+
 Unless you feel confident your change will be accepted (trivial bug fixes, code cleanup, etc) you should first create an issue or a [Sourcegraph RFC](https://handbook.sourcegraph.com/communication/rfcs#external-contributors) (preferred for bigger changes) to discuss your change with us. This lets us all discuss the design and proposed implementation of your change, which helps ensure your time is well spent and that your contribution will be accepted.
 
 > Exception: If you contribute functionality that already exists as a [paid Sourcegraph feature](https://about.sourcegraph.com/pricing/), we are unlikely to accept it. Consult us beforehand for a definitive answer. (We'll add more details about the process here, and they'll be similar to [GitLab's stewardship principles](https://about.gitlab.com/stewardship/#contributing-an-existing-ee-feature-to-ce).)
@@ -11,7 +17,7 @@ Unless you feel confident your change will be accepted (trivial bug fixes, code 
 ## Code of Conduct
 
 All interactions with the Sourcegraph open source project are governed by the
-[Sourcegraph Code of Conduct](https://handbook.sourcegraph.com/community/code_of_conduct).
+[Sourcegraph Community Code of Conduct](https://handbook.sourcegraph.com/company-info-and-process/community/code_of_conduct/).
 
 ## How to contribute
 


### PR DESCRIPTION
This is a copy of the changes in #33766 and https://github.com/sourcegraph/sourcegraph/commit/9139f5d7e1ca2f086500a6fa206dfa40129c653d which were accidentally merged into `master` instead of `main`. In @slimsag's words:

> - Made clear that contributing to enterprise/ code is 100% fine as long as you've signed the CLA.
> - Fixed URL to Code of Conduct.
> - Make it more clear that the big-scary-wording section about talking to us first is regarding contributing large changes (this is more contributor friendly.)

## Test plan
n/a, docs changes only
