### PR TITLE
doc: add redis k8s guidance

### DIFF
--- a/doc/admin/how-to/redis_configmap.md
+++ b/doc/admin/how-to/redis_configmap.md
@@ -1,0 +1,205 @@
+
+# How to Set a password for Redis using a ConfigMap
+
+
+```
+Note: This is considered a workaround for a customer issue.
+```
+
+
+This procedure allows a Kuberenetes user to set a password for the Redis services included in the Sourcegraph deployment. 
+
+In this approach, we store the redis.conf file for each service in a ConfigMap. The ConfigMap is then mounted as a volume into the corresponding Redis pod.
+
+The Redis Docker image does not expose a dedicated environment variable to set a password. Due to this limitation, we must supply the configuration by supplying a custom /etc/redis/redis.conf file into the pod.
+
+Reference Materials
+
+
+
+* [Docs: Configure custom Redis](https://docs.sourcegraph.com/admin/install/kubernetes/configure#configure-custom-redis)
+* [Docs: Using your own Redis server](https://docs.sourcegraph.com/admin/external_services/redis)
+
+
+## Conventions
+
+
+
+* **‘... truncated for brevity …’** indicates that a portion of the code listing has been removed to improve readability. This means that the code listing will not work by itself. The code listing is intended for you to identify the areas of your existing code that need to be modified. \
+
+* Items in **BOLD** indicate an addition to an existing code file. It should be considered safe to copy and paste the text in **BOLD **directly into your existing code.
+
+
+## Caveats
+
+
+
+* **Note: **This procedure uses a ConfigMap, which stores values in plaintext. In order to improve security, we recommend using Kubernetes Secrets. \
+
+* **Note:** These instructions are generic and should be incorporated into your deployment tool (helm or Kustomize) as needed.
+* **Note:** This example uses the password “demopasswordchangeme123”. Please change this to another value that meets your organization’s security requirements.
+
+
+## Procedure
+
+
+
+1. Locate the original redis-cache configuration file: [https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/docker-images/redis-cache/redis.conf](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/docker-images/redis-cache/redis.conf) Use this as the “Default redis.conf file” content in the ConfigMap
+2. Create the redis-cache-conf ConfigMap:
+
+```
+ apiVersion: v1
+data:
+  redis.conf: |
+    #############################
+    ## Default redis.conf file           ##
+    #############################
+    # allow access from all instances
+    protected-mode no
+    # limit memory usage, discard unused keys when hitting limit
+    maxmemory 6gb
+    maxmemory-policy allkeys-lru
+    # snapshots on disk every minute
+    dir /redis-data/
+    appendonly no
+    save 60 1
+
+    ###################
+    ## Customization ##
+    ###################
+    requirepass demopasswordchangeme123
+
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/component: redis-cache
+    deploy: sourcegraph
+  name: redis-cache-conf
+```
+
+
+3. Modify the apps_v1_deployment_redis-cache.yaml manifest. Add the corresponding volumeMounts: and volumes:
+
+```
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis-cache
+spec:
+… truncated for brevity … 
+  template:
+    metadata:
+      labels:
+        app: redis-cache
+        deploy: sourcegraph
+    spec:
+      containers:
+… truncated for brevity …
+        volumeMounts:
+        - mountPath: /redis-data
+          name: redis-data
+          subPathExpr: $(POD_NAME)
+        - mountPath: /etc/redis/
+          name: redis-cache-conf
+… truncated for brevity …
+      volumes:
+      - configMap:
+          name: redis-cache-conf
+        name: redis-cache-conf
+
+```
+
+
+4. Locate the original redis-store configuration file. [https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/docker-images/redis-cache/redis.conf](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/docker-images/redis-cache/redis.conf) Use this as the “Default redis.conf file” content in the ConfigMap. \
+
+5. Create the redis-store-conf ConfigMap:
+
+```
+ apiVersion: v1
+data:
+  redis.conf: |
+    #############################
+    ## Default redis.conf file           ##
+    #############################
+    # allow access from all instances
+    protected-mode no
+    # limit memory usage, return error when hitting limit
+    maxmemory 6gb
+    maxmemory-policy noeviction
+    # live commit log to disk, additionally snapshot every 5 minutes
+    dir /redis-data/
+    appendonly yes
+    aof-use-rdb-preamble yes
+    save 300 1
+
+    ###################
+    ## Customization ##
+    ###################
+    requirepass demopasswordchangeme123
+
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/component: redis-store
+    deploy: sourcegraph
+  name: redis-store-conf
+```
+
+
+6. Modify the apps_v1_deployment_redis-store.yaml manifest. Add the corresponding volumeMounts: and volumes: \
+
+
+```
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis-store
+… truncated for brevity … 
+  template:
+    metadata:
+      labels:
+        app: redis-store
+        deploy: sourcegraph
+    spec:
+      containers:
+… truncated for brevity … 
+        volumeMounts:
+        - mountPath: /redis-data
+          name: redis-data
+          subPathExpr: $(POD_NAME)
+        - mountPath: /etc/redis/
+          name: redis-cache-conf
+… truncated for brevity …
+      volumes:
+      - configMap:
+          name: redis-store-conf
+        name: redis-store-conf
+```
+
+
+7. Modify the manifests for all services listed in[ Configure custom Redis](https://docs.sourcegraph.com/admin/install/kubernetes/configure#configure-custom-redis). The listing below is an example of the two environment variables that must be added to the services listed in the documentation. \
+
+
+    ```
+apiVersion: apps/v1
+kind: Deployment
+… truncated for brevity …
+    spec:
+      containers:
+… truncated for brevity …
+        env:
+        - name: REDIS_CACHE_ENDPOINT
+          value: redis://:demopasswordchangeme123@redis-cache:6379
+        - name: REDIS_STORE_ENDPOINT
+          value: redis://:demopasswordchangeme123@redis-store:6379
+```
+
+
+
+**Note:  **Be sure to add both environment variables to all services listed in [Configure custom Redis](https://docs.sourcegraph.com/admin/install/kubernetes/configure#configure-custom-redis).
+
+
+
+8. After making the necessary changes to the manifests, apply the changes. Kubernetes should recreate all pods that were modified.
+9. Verify the sourcegraph-frontend pods are running and do not contain log messages that indicate that sourcegraph-frontend is unable to the redis services.
+10. All services should be running and passing health checks. If there are any services that are in a CrashLoop or not running, ensure that the necessary environment variables are correct, captured in the Kubernetes manifests, and applied to your installation.


### PR DESCRIPTION

## Test plan
doc site builds as part of CI
<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


