### PR TITLE
Quick start tour design updates. part 2

### DIFF
--- a/client/web/src/tour/components/ItemPicker.tsx
+++ b/client/web/src/tour/components/ItemPicker.tsx
@@ -8,22 +8,26 @@ import { Button } from '@sourcegraph/wildcard'
 import styles from './ItemPicker.module.scss'
 
 interface ItemPickerProps<TItem> {
+    title: string
     items: TItem[]
     onClose: () => void
     onSelect: (language: TItem) => void
+    className?: string
 }
 
 /**
  * ItemPicker component. Displays a closable block with list of items passed.
  */
 export const ItemPicker = <TItem extends string>({
+    title,
     items,
     onClose,
     onSelect,
+    className,
 }: ItemPickerProps<TItem>): React.ReactElement => (
-    <div>
+    <div className={className}>
         <div className="d-flex justify-content-between">
-            <p className="mt-2">Please select a language:</p>
+            <p className="mt-0 mb-1">{title}</p>
             <CloseIcon onClick={onClose} size="1rem" />
         </div>
         <div className="d-flex flex-wrap">

--- a/client/web/src/tour/components/Tour/Tour.module.scss
+++ b/client/web/src/tour/components/Tour/Tour.module.scss
@@ -24,15 +24,7 @@
 
 .task-list {
     &::-webkit-scrollbar {
-        /* stylelint-disable-next-line declaration-property-unit-allowed-list */
-        width: 4px;
-        /* stylelint-disable-next-line declaration-property-unit-allowed-list */
-        height: 4px;
-    }
-
-    &::-webkit-scrollbar-thumb {
-        border-radius: 3px;
-        box-shadow: inset 0 0 6px var(--text-muted);
+        display: none;
     }
 
     &.is-horizontal {
@@ -41,14 +33,6 @@
         scroll-snap-type: x mandatory;
         scroll-behavior: smooth;
         padding-bottom: 0.5rem;
-
-        &::-webkit-scrollbar-thumb {
-            visibility: hidden;
-        }
-
-        &:hover::-webkit-scrollbar-thumb {
-            visibility: visible;
-        }
 
         > * {
             flex: 1 0 19rem;
@@ -65,7 +49,6 @@
     &:not(.is-horizontal) {
         overflow-y: auto;
         flex-grow: 1;
-        padding-right: 0.25rem;
 
         > :not(:last-child)::after {
             content: ' ';
@@ -77,15 +60,7 @@
 
     // Firefox custom scrollbar
     @-moz-document url-prefix('') {
-        scrollbar-width: thin;
-        scrollbar-color: var(--text-muted);
-        &.is-horizontal {
-            padding-bottom: 1rem;
-        }
-
-        &:not(.is-horizontal) {
-            padding-right: 0.5rem;
-        }
+        scrollbar-width: none;
     }
 }
 

--- a/client/web/src/tour/components/Tour/Tour.module.scss
+++ b/client/web/src/tour/components/Tour/Tour.module.scss
@@ -126,7 +126,11 @@
         color: var(--link-color);
         font-weight: bold;
         display: inline-block;
-        padding: 0 0.25rem 0 0.5rem;
+        padding: 0 0.25rem 0 0;
+
+        .is-small & {
+            padding-left: 0.5rem;
+        }
     }
 
     .step-list-item {

--- a/client/web/src/tour/components/Tour/Tour.module.scss
+++ b/client/web/src/tour/components/Tour/Tour.module.scss
@@ -1,3 +1,4 @@
+@import 'wildcard/src/global-styles/breakpoints';
 :global(.theme-light) {
     --getting-started-tour-oc-blue-bg: var(--oc-blue-1);
     --getting-started-tour-oc-blue-border: var(--oc-blue-2);
@@ -88,6 +89,18 @@
     }
 }
 
+.completed-items {
+    flex-grow: 2 !important;
+
+    &-inner {
+        display: flex;
+        gap: 7.5rem;
+
+        @media (--md-breakpoint-down) {
+            gap: 2rem;
+        }
+    }
+}
 .completed-check-icon {
     margin-top: 0.125rem;
 }

--- a/client/web/src/tour/components/Tour/TourContent.tsx
+++ b/client/web/src/tour/components/Tour/TourContent.tsx
@@ -45,10 +45,10 @@ const Footer: React.FunctionComponent<{ completedCount: number; totalCount: numb
 )
 
 const CompletedItem: React.FunctionComponent = ({ children }) => (
-    <div className="d-flex align-items-start">
+    <li className="d-flex align-items-start">
         <Icon as={CheckCircleIcon} size="sm" className={classNames('text-success mr-1', styles.completedCheckIcon)} />
         <span className="flex-1">{children}</span>
-    </div>
+    </li>
 )
 
 export const TourContent: React.FunctionComponent<TourContentProps> = ({
@@ -58,7 +58,7 @@ export const TourContent: React.FunctionComponent<TourContentProps> = ({
     className,
     height = 18,
 }) => {
-    const { completedCount, totalCount, completedTaskChunks, completedTasks, ongoingTasks } = useMemo(() => {
+    const { completedCount, totalCount, completedTasks, completedTaskChunks, ongoingTasks } = useMemo(() => {
         const completedTasks = tasks.filter(task => task.completed === 100)
         return {
             completedTasks,
@@ -68,15 +68,16 @@ export const TourContent: React.FunctionComponent<TourContentProps> = ({
             completedCount: completedTasks.length,
         }
     }, [tasks])
+    const isHorizontal = variant === 'horizontal'
 
     return (
         <div className={className} data-testid="tour-content">
-            {variant === 'horizontal' && <Header onClose={onClose}>Don't show again</Header>}
+            {isHorizontal && <Header onClose={onClose}>Don't show again</Header>}
             <MarketingBlock
-                wrapperClassName={classNames('w-100 d-flex', variant !== 'horizontal' && styles.marketingBlockWrapper)}
+                wrapperClassName={classNames('w-100 d-flex', !isHorizontal && styles.marketingBlockWrapper)}
                 contentClassName={classNames(styles.marketingBlockContent, 'w-100 d-flex flex-column pt-3 pb-1')}
             >
-                {variant !== 'horizontal' && <Header onClose={onClose} />}
+                {!isHorizontal && <Header onClose={onClose} />}
                 <div
                     className={classNames(
                         styles.taskList,
@@ -85,20 +86,26 @@ export const TourContent: React.FunctionComponent<TourContentProps> = ({
                     // eslint-disable-next-line react/forbid-dom-props
                     style={{ maxHeight: `${height}rem` }}
                 >
-                    {variant === 'horizontal' &&
-                        completedTaskChunks.length > 0 &&
-                        completedTaskChunks.map((completedTaskChunk, index) => (
-                            <div key={index}>
-                                {variant === 'horizontal' && index === 0 && <p className={styles.title}>Completed</p>}
-                                {completedTaskChunk.map(completedTask => (
-                                    <CompletedItem key={completedTask.title}>{completedTask.title}</CompletedItem>
+                    {isHorizontal && completedTaskChunks.length > 0 && (
+                        <div className={classNames('pl-2 flex-grow-1', styles.completedItems)}>
+                            <p className={styles.title}>Completed</p>
+                            <div className={styles.completedItemsInner}>
+                                {completedTaskChunks.map((completedTaskChunk, index) => (
+                                    <ul key={index} className="p-0 m-0 list-unstyled text-nowrap">
+                                        {completedTaskChunk.map(completedTask => (
+                                            <CompletedItem key={completedTask.title}>
+                                                {completedTask.title}
+                                            </CompletedItem>
+                                        ))}
+                                    </ul>
                                 ))}
                             </div>
-                        ))}
+                        </div>
+                    )}
                     {ongoingTasks.map(task => (
-                        <TourTask key={task.title} {...task} variant={variant !== 'horizontal' ? 'small' : undefined} />
+                        <TourTask key={task.title} {...task} variant={!isHorizontal ? 'small' : undefined} />
                     ))}
-                    {variant !== 'horizontal' && completedTasks.length > 0 && (
+                    {!isHorizontal && completedTasks.length > 0 && (
                         <div>
                             {completedTasks.map(completedTask => (
                                 <CompletedItem key={completedTask.title}>{completedTask.title}</CompletedItem>
@@ -106,9 +113,9 @@ export const TourContent: React.FunctionComponent<TourContentProps> = ({
                         </div>
                     )}
                 </div>
-                {variant !== 'horizontal' && <Footer completedCount={completedCount} totalCount={totalCount} />}
+                {!isHorizontal && <Footer completedCount={completedCount} totalCount={totalCount} />}
             </MarketingBlock>
-            {variant === 'horizontal' && <Footer completedCount={completedCount} totalCount={totalCount} />}
+            {isHorizontal && <Footer completedCount={completedCount} totalCount={totalCount} />}
         </div>
     )
 }

--- a/client/web/src/tour/components/Tour/TourTask.tsx
+++ b/client/web/src/tour/components/Tour/TourTask.tsx
@@ -94,7 +94,7 @@ export const TourTask: React.FunctionComponent<TourTaskProps> = ({ title, steps,
                     className={classNames(
                         styles.stepList,
                         'm-0',
-                        variant !== 'small' && 'flex-grow-1 d-flex flex-column justify-content-center',
+                        variant !== 'small' && 'flex-grow-1 d-flex flex-column',
                         isMultiStep && styles.isMultiStep
                     )}
                 >

--- a/client/web/src/tour/components/Tour/TourTask.tsx
+++ b/client/web/src/tour/components/Tour/TourTask.tsx
@@ -73,7 +73,13 @@ export const TourTask: React.FunctionComponent<TourTaskProps> = ({ title, steps,
 
     if (showLanguagePicker) {
         return (
-            <ItemPicker items={Object.values(TourLanguage)} onClose={onLanguageClose} onSelect={handleLanguageSelect} />
+            <ItemPicker
+                title="Please select a language:"
+                className={classNames(variant !== 'small' && 'pl-2')}
+                items={Object.values(TourLanguage)}
+                onClose={onLanguageClose}
+                onSelect={handleLanguageSelect}
+            />
         )
     }
 

--- a/client/web/src/tour/data/index.tsx
+++ b/client/web/src/tour/data/index.tsx
@@ -260,7 +260,7 @@ export const authenticatedTasks: TourTaskType[] = [
             },
             {
                 id: 'DiffSearch',
-                label: 'Find problem code in diffs',
+                label: 'Find problematic code in diffs',
                 action: {
                     type: 'link',
                     value: {

--- a/client/web/src/tour/data/index.tsx
+++ b/client/web/src/tour/data/index.tsx
@@ -260,7 +260,7 @@ export const authenticatedTasks: TourTaskType[] = [
             },
             {
                 id: 'DiffSearch',
-                label: 'Learn how to find and fix vulnerabilities faster',
+                label: 'Find problem code in diffs',
                 action: {
                     type: 'link',
                     value: {


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/33650.

## Test plan
- `SOURCEGRAPH_API_URL=https://sourcegraph.com SOURCEGRAPHDOTCOM_MODE=true sg -skip-auto-update=true start web-standalone`
- Open https://sourcegraph.test:3443/search?feature-flag-key=quick-start-tour-for-authenticated-users&feature-flag-value=true and sign in
- Check quick-start tour design changes described in the ticket

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

## Screenshots
| BEFORE | AFTER |
| --: | :-- |
| ![image](https://user-images.githubusercontent.com/6717049/162977184-6caed9a8-d729-4071-8603-e310f0f07d77.png) | ![image](https://user-images.githubusercontent.com/6717049/162977253-6ac65f47-e895-4cd5-b8e0-93b127eda6f4.png) |
| ![image](https://user-images.githubusercontent.com/6717049/162977971-3acc76b0-58ea-422c-975a-9b5909a5208b.png) | ![image](https://user-images.githubusercontent.com/6717049/162977673-600218f0-c76f-4e53-a26d-9a063f7f69ca.png) |
| ![image](https://user-images.githubusercontent.com/6717049/162977386-753d49ab-3848-4e83-9eb5-898d5f1caba1.png) | ![image](https://user-images.githubusercontent.com/6717049/162977429-5c3ff15f-a10a-4fd4-ba71-7ce98fd38111.png) |





## App preview:

- [Link](https://sg-web-erzhtor-quick-start-tour-updates.onrender.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

