### PR TITLE
gitserver: add user agent to metrics for number of AddrForRepo hits

### DIFF
--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -594,7 +594,7 @@ func (s *Server) syncRepoState(gitServerAddrs gitserver.GitServerAddresses, batc
 	err := store.IterateRepoGitserverStatus(ctx, options, func(repo types.RepoGitserverStatus) error {
 		repoSyncStateCounter.WithLabelValues("check").Inc()
 		// Ensure we're only dealing with repos we are responsible for
-		addr, err := gitserver.AddrForRepo(ctx, s.DB, repo.Name, gitServerAddrs)
+		addr, err := gitserver.AddrForRepo(ctx, filepath.Base(os.Args[0]), s.DB, repo.Name, gitServerAddrs)
 		if err != nil {
 			return err
 		}

--- a/internal/gitserver/client_test.go
+++ b/internal/gitserver/client_test.go
@@ -375,7 +375,7 @@ func TestAddrForRepo(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := gitserver.AddrForRepo(context.Background(), database.NewMockDB(), tc.repo, gitserver.GitServerAddresses{
+			got, err := gitserver.AddrForRepo(context.Background(), "gitserver", database.NewMockDB(), tc.repo, gitserver.GitServerAddresses{
 				Addresses:     addrs,
 				PinnedServers: pinned,
 			})


### PR DESCRIPTION
This metric is needed to estimate how many requests are coming from which services.
Estimates will be used to design AddrForRepo calls batching (because every call will result in DB query and our services should not overwhelm the DB with a huge number of RPS)

## Test plan
Tested locally, metrics are saved and can be queried
<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


