### PR TITLE
gitserver: Command to GitCommand

### DIFF
--- a/cmd/symbols/squirrel/service.go
+++ b/cmd/symbols/squirrel/service.go
@@ -40,7 +40,7 @@ func (squirrel *SquirrelService) Close() {
 
 // How to read a file from gitserver.
 func readFileFromGitserver(ctx context.Context, repoCommitPath types.RepoCommitPath) ([]byte, error) {
-	cmd := gitserver.NewClient(nil).Command(api.RepoName(repoCommitPath.Repo), "git", "cat-file", "blob", repoCommitPath.Commit+":"+repoCommitPath.Path)
+	cmd := gitserver.NewClient(nil).GitCommand(api.RepoName(repoCommitPath.Repo), "cat-file", "blob", repoCommitPath.Commit+":"+repoCommitPath.Path)
 	stdout, stderr, err := cmd.DividedOutput(ctx)
 	if err != nil {
 		return nil, errors.Newf("failed to get file contents: %s\n\nstdout:\n\n%s\n\nstderr:\n\n%s", err, stdout, stderr)

--- a/internal/gitserver/client.go
+++ b/internal/gitserver/client.go
@@ -172,8 +172,8 @@ type Client interface {
 	// to abort processing further results.
 	BatchLog(ctx context.Context, opts BatchLogOptions, callback BatchLogCallback) error
 
-	// Command creates a new Cmd. Command name must be 'git', otherwise it panics.
-	Command(repo api.RepoName, name string, args ...string) *Cmd
+	// GitCommand creates a new Cmd.
+	GitCommand(repo api.RepoName, args ...string) *Cmd
 
 	// CreateCommitFromPatch will attempt to create a commit from a patch
 	// If possible, the error returned will be of type protocol.CreateCommitFromPatchError
@@ -939,10 +939,7 @@ func (c *cmdReader) Close() error {
 	return c.rc.Close()
 }
 
-func (c *ClientImplementor) Command(repo api.RepoName, name string, arg ...string) *Cmd {
-	if name != "git" {
-		panic("gitserver: command name must be 'git'")
-	}
+func (c *ClientImplementor) GitCommand(repo api.RepoName, arg ...string) *Cmd {
 	return &Cmd{
 		repo:   repo,
 		execFn: c.httpPost,
@@ -1502,7 +1499,7 @@ var ambiguousArgPattern = lazyregexp.New(`ambiguous argument '([^']+)'`)
 func (c *ClientImplementor) ResolveRevisions(ctx context.Context, repo api.RepoName, revs []protocol.RevisionSpecifier) ([]string, error) {
 	args := append([]string{"rev-parse"}, revsToGitArgs(revs)...)
 
-	cmd := c.Command(repo, "git", args...)
+	cmd := c.GitCommand(repo, args...)
 	stdout, stderr, err := cmd.DividedOutput(ctx)
 	if err != nil {
 		if gitdomain.IsRepoNotExist(err) {

--- a/internal/gitserver/client.go
+++ b/internal/gitserver/client.go
@@ -653,7 +653,7 @@ func (c *ClientImplementor) BatchLog(ctx context.Context, opts BatchLogOptions, 
 	ctx, endObservation := c.operations.batchLog.With(ctx, &err, observation.Args{LogFields: opts.LogFields()})
 	defer endObservation(1, observation.Args{})
 
-	// Make a request to a singlee gitserver shard and feed the results to the user-supplied
+	// Make a request to a single gitserver shard and feed the results to the user-supplied
 	// callback. This function is invoked multiple times (and concurrently) in the loops below
 	// this function definition.
 	performLogRequestToShard := func(ctx context.Context, addr string, repoCommits []api.RepoCommit) (err error) {

--- a/internal/vcs/git/blob.go
+++ b/internal/vcs/git/blob.go
@@ -107,7 +107,7 @@ func newBlobReader(ctx context.Context, db database.DB, repo api.RepoName, commi
 		return nil, err
 	}
 
-	cmd := gitserver.NewClient(db).Command(repo, "git", "show", string(commit)+":"+name)
+	cmd := gitserver.NewClient(db).GitCommand(repo, "show", string(commit)+":"+name)
 	stdout, err := gitserver.StdoutReader(ctx, cmd)
 	if err != nil {
 		return nil, err

--- a/internal/vcs/git/commits.go
+++ b/internal/vcs/git/commits.go
@@ -189,7 +189,7 @@ func CommitsUniqueToBranch(ctx context.Context, db database.DB, repo api.RepoNam
 		args = append(args, branchName, "^HEAD")
 	}
 
-	cmd := gitserver.NewClient(db).Command(repo, "git", args...)
+	cmd := gitserver.NewClient(db).GitCommand(repo, args...)
 	out, err := cmd.CombinedOutput(ctx)
 	if err != nil {
 		return nil, err
@@ -303,7 +303,7 @@ func getWrappedCommits(ctx context.Context, db database.DB, repo api.RepoName, o
 		return nil, err
 	}
 
-	cmd := gitserver.NewClient(db).Command(repo, "git", args...)
+	cmd := gitserver.NewClient(db).GitCommand(repo, args...)
 	if !opt.NoEnsureRevision {
 		cmd.SetEnsureRevision(opt.Range)
 	}
@@ -477,7 +477,7 @@ func commitCount(ctx context.Context, db database.DB, repo api.RepoName, opt Com
 		// This doesn't include --follow flag because rev-list doesn't support it, so the number may be slightly off.
 		args = append(args, "--", opt.Path)
 	}
-	cmd := gitserver.NewClient(db).Command(repo, "git", args...)
+	cmd := gitserver.NewClient(db).GitCommand(repo, args...)
 	out, err := cmd.Output(ctx)
 	if err != nil {
 		return 0, errors.WithMessage(err, fmt.Sprintf("git command %v failed (output: %q)", cmd.Args(), out))
@@ -494,7 +494,7 @@ func FirstEverCommit(ctx context.Context, db database.DB, repo api.RepoName, che
 	defer span.Finish()
 
 	args := []string{"rev-list", "--reverse", "--date-order", "--max-parents=0", "HEAD"}
-	cmd := gitserver.NewClient(db).Command(repo, "git", args...)
+	cmd := gitserver.NewClient(db).GitCommand(repo, args...)
 	out, err := cmd.Output(ctx)
 	if err != nil {
 		return nil, errors.WithMessage(err, fmt.Sprintf("git command %v failed (output: %q)", args, out))
@@ -636,7 +636,7 @@ func getCommits(ctx context.Context, db database.DB, repoCommits []api.RepoCommi
 // repositories), a false-valued flag is returned along with a nil error and
 // empty revision.
 func Head(ctx context.Context, db database.DB, repo api.RepoName, checker authz.SubRepoPermissionChecker) (_ string, revisionExists bool, err error) {
-	cmd := gitserver.NewClient(db).Command(repo, "git", "rev-parse", "HEAD")
+	cmd := gitserver.NewClient(db).GitCommand(repo, "rev-parse", "HEAD")
 
 	out, err := cmd.Output(ctx)
 	if err != nil {
@@ -753,7 +753,7 @@ func BranchesContaining(ctx context.Context, db database.DB, repo api.RepoName, 
 			return nil, err
 		}
 	}
-	cmd := gitserver.NewClient(db).Command(repo, "git", "branch", "--contains", string(commit), "--format", "%(refname)")
+	cmd := gitserver.NewClient(db).GitCommand(repo, "branch", "--contains", string(commit), "--format", "%(refname)")
 
 	out, err := cmd.CombinedOutput(ctx)
 	if err != nil {
@@ -798,7 +798,7 @@ func RefDescriptions(ctx context.Context, db database.DB, repo api.RepoName, che
 			args = append(args, "--points-at="+obj)
 		}
 
-		cmd := gitserver.NewClient(db).Command(repo, "git", args...)
+		cmd := gitserver.NewClient(db).GitCommand(repo, args...)
 
 		out, err := cmd.CombinedOutput(ctx)
 		if err != nil {
@@ -932,7 +932,7 @@ func CommitDate(ctx context.Context, db database.DB, repo api.RepoName, commit a
 		}
 	}
 
-	cmd := gitserver.NewClient(db).Command(repo, "git", "show", "-s", "--format=%H:%cI", string(commit))
+	cmd := gitserver.NewClient(db).GitCommand(repo, "show", "-s", "--format=%H:%cI", string(commit))
 
 	out, err := cmd.CombinedOutput(ctx)
 	if err != nil {

--- a/internal/vcs/git/exec.go
+++ b/internal/vcs/git/exec.go
@@ -37,7 +37,7 @@ func execSafe(ctx context.Context, db database.DB, repo api.RepoName, params []s
 		return nil, nil, 0, errors.Errorf("command failed: %q is not a allowed git command", params)
 	}
 
-	cmd := gitserver.NewClient(db).Command(repo, "git", params...)
+	cmd := gitserver.NewClient(db).GitCommand(repo, params...)
 	stdout, stderr, err = cmd.DividedOutput(ctx)
 	exitCode = cmd.ExitStatus()
 	if exitCode != 0 && err != nil {
@@ -57,7 +57,7 @@ func checkSpecArgSafety(spec string) error {
 
 func gitserverCmdFunc(repo api.RepoName, db database.DB) cmdFunc {
 	return func(args []string) cmd {
-		return gitserver.NewClient(db).Command(repo, "git", args...)
+		return gitserver.NewClient(db).GitCommand(repo, args...)
 	}
 }
 

--- a/internal/vcs/git/merge_base.go
+++ b/internal/vcs/git/merge_base.go
@@ -22,7 +22,7 @@ func MergeBase(ctx context.Context, db database.DB, repo api.RepoName, a, b api.
 	span.SetTag("B", b)
 	defer span.Finish()
 
-	cmd := gitserver.NewClient(db).Command(repo, "git", "merge-base", "--", string(a), string(b))
+	cmd := gitserver.NewClient(db).GitCommand(repo, "merge-base", "--", string(a), string(b))
 	out, err := cmd.CombinedOutput(ctx)
 	if err != nil {
 		return "", errors.WithMessage(err, fmt.Sprintf("git command %v failed (output: %q)", cmd.Args(), out))

--- a/internal/vcs/git/refs.go
+++ b/internal/vcs/git/refs.go
@@ -176,7 +176,7 @@ func ListBranches(ctx context.Context, db database.DB, repo api.RepoName, opt Br
 // branches runs the `git branch` command followed by the given arguments and
 // returns the list of branches if successful.
 func branches(ctx context.Context, db database.DB, repo api.RepoName, args ...string) ([]string, error) {
-	cmd := gitserver.NewClient(db).Command(repo, "git", append([]string{"branch"}, args...)...)
+	cmd := gitserver.NewClient(db).GitCommand(repo, append([]string{"branch"}, args...)...)
 	out, err := cmd.Output(ctx)
 	if err != nil {
 		return nil, errors.Errorf("exec %v in %s failed: %v (output follows)\n\n%s", cmd.Args(), cmd.Repo(), err, out)
@@ -203,7 +203,7 @@ func GetBehindAhead(ctx context.Context, db database.DB, repo api.RepoName, left
 		return nil, err
 	}
 
-	cmd := gitserver.NewClient(db).Command(repo, "git", "rev-list", "--count", "--left-right", fmt.Sprintf("%s...%s", left, right))
+	cmd := gitserver.NewClient(db).GitCommand(repo, "rev-list", "--count", "--left-right", fmt.Sprintf("%s...%s", left, right))
 	out, err := cmd.Output(ctx)
 	if err != nil {
 		return nil, err
@@ -228,7 +228,7 @@ func ListTags(ctx context.Context, db database.DB, repo api.RepoName) ([]*Tag, e
 	// Support both lightweight tags and tag objects. For creatordate, use an %(if) to prefer the
 	// taggerdate for tag objects, otherwise use the commit's committerdate (instead of just always
 	// using committerdate).
-	cmd := gitserver.NewClient(db).Command(repo, "git", "tag", "--list", "--sort", "-creatordate", "--format", "%(if)%(*objectname)%(then)%(*objectname)%(else)%(objectname)%(end)%00%(refname:short)%00%(if)%(creatordate:unix)%(then)%(creatordate:unix)%(else)%(*creatordate:unix)%(end)")
+	cmd := gitserver.NewClient(db).GitCommand(repo, "tag", "--list", "--sort", "-creatordate", "--format", "%(if)%(*objectname)%(then)%(*objectname)%(else)%(objectname)%(end)%00%(refname:short)%00%(if)%(creatordate:unix)%(then)%(creatordate:unix)%(else)%(*creatordate:unix)%(end)")
 	out, err := cmd.CombinedOutput(ctx)
 	if err != nil {
 		if gitdomain.IsRepoNotExist(err) {
@@ -289,7 +289,7 @@ type Ref struct {
 
 func showRef(ctx context.Context, db database.DB, repo api.RepoName, args ...string) ([]Ref, error) {
 	cmdArgs := append([]string{"show-ref"}, args...)
-	cmd := gitserver.NewClient(db).Command(repo, "git", cmdArgs...)
+	cmd := gitserver.NewClient(db).GitCommand(repo, cmdArgs...)
 	out, err := cmd.CombinedOutput(ctx)
 	if err != nil {
 		if gitdomain.IsRepoNotExist(err) {
@@ -332,7 +332,7 @@ func RevList(repo string, db database.DB, commit string, onCommit func(commit st
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	command := gitserver.NewClient(db).Command(api.RepoName(repo), "git", RevListArgs(commit)...)
+	command := gitserver.NewClient(db).GitCommand(api.RepoName(repo), RevListArgs(commit)...)
 	command.DisableTimeout()
 	stdout, err := gitserver.StdoutReader(ctx, command)
 	if err != nil {

--- a/internal/vcs/git/revisions.go
+++ b/internal/vcs/git/revisions.go
@@ -83,7 +83,7 @@ func ResolveRevision(ctx context.Context, db database.DB, repo api.RepoName, spe
 		spec = spec + "^0"
 	}
 
-	cmd := gitserver.NewClient(db).Command(repo, "git", "rev-parse", spec)
+	cmd := gitserver.NewClient(db).GitCommand(repo, "rev-parse", spec)
 	cmd.SetEnsureRevision(spec)
 
 	// We don't ever need to ensure that HEAD is in git-server.

--- a/internal/vcs/git/tree.go
+++ b/internal/vcs/git/tree.go
@@ -63,7 +63,7 @@ func LsFiles(ctx context.Context, db database.DB, checker authz.SubRepoPermissio
 		}
 	}
 
-	cmd := gitserver.NewClient(db).Command(repo, "git", args...)
+	cmd := gitserver.NewClient(db).GitCommand(repo, args...)
 	out, err := cmd.CombinedOutput(ctx)
 	if err != nil {
 		return nil, errors.WithMessage(err, fmt.Sprintf("git command %v failed (output: %q)", cmd.Args(), out))
@@ -80,7 +80,7 @@ func LsFiles(ctx context.Context, db database.DB, checker authz.SubRepoPermissio
 // ListFiles returns a list of root-relative file paths matching the given
 // pattern in a particular commit of a repository.
 func ListFiles(ctx context.Context, db database.DB, repo api.RepoName, commit api.CommitID, pattern *regexp.Regexp, checker authz.SubRepoPermissionChecker) (_ []string, err error) {
-	cmd := gitserver.NewClient(db).Command(repo, "git", "ls-tree", "--name-only", "-r", string(commit), "--")
+	cmd := gitserver.NewClient(db).GitCommand(repo, "ls-tree", "--name-only", "-r", string(commit), "--")
 
 	out, err := cmd.CombinedOutput(ctx)
 	if err != nil {
@@ -124,7 +124,7 @@ func ListDirectoryChildren(
 ) (map[string][]string, error) {
 	args := []string{"ls-tree", "--name-only", string(commit), "--"}
 	args = append(args, cleanDirectoriesForLsTree(dirnames)...)
-	cmd := gitserver.NewClient(db).Command(repo, "git", args...)
+	cmd := gitserver.NewClient(db).GitCommand(repo, args...)
 
 	out, err := cmd.CombinedOutput(ctx)
 	if err != nil {


### PR DESCRIPTION
`Command` had to take `git` as its first argument or it would panic so
renamed to `GitCommand` and don't even allow passing in the command name.

Stacked on top of https://github.com/sourcegraph/sourcegraph/pull/33782