### PR TITLE
lib/errors: switch to std Unwrap, Is, As

### DIFF
--- a/lib/errors/cockroach.go
+++ b/lib/errors/cockroach.go
@@ -7,22 +7,21 @@ import (
 )
 
 var (
-	New               = errors.New
-	Newf              = errors.Newf
-	Wrap              = errors.Wrap
-	Wrapf             = errors.Wrapf
-	Errorf            = errors.Errorf
-	Is                = errors.Is
-	As                = errors.As
+	New    = errors.New
+	Newf   = errors.Newf
+	Wrap   = errors.Wrap
+	Wrapf  = errors.Wrapf
+	Errorf = errors.Errorf
+
 	HasType           = errors.HasType
 	WithMessage       = errors.WithMessage
-	Cause             = errors.Cause
-	Unwrap            = errors.Unwrap
-	UnwrapAll         = errors.UnwrapAll
 	WithStack         = errors.WithStack
 	BuildSentryReport = errors.BuildSentryReport
 	Safe              = errors.Safe
-	IsAny             = errors.IsAny
+
+	// TODO this implementation is complex, but uses the potentially problematic
+	// cockroachdb/errors.UnwrapOnce
+	IsAny = errors.IsAny
 )
 
 // Extend multiError to work with cockroachdb errors. Implement here to keep imports in

--- a/lib/errors/errors.go
+++ b/lib/errors/errors.go
@@ -106,3 +106,21 @@ func (e *multiError) As(target interface{}) bool {
 	}
 	return false
 }
+
+// UnwrapAll accesses the root cause object of the error by calling this library's choice
+// of `Unwrap` repeatedly.
+//
+// If the error has no cause (leaf error), it is returned directly.
+func UnwrapAll(err error) error {
+	for {
+		if cause := Unwrap(err); cause != nil {
+			err = cause
+			continue
+		}
+		break
+	}
+	return err
+}
+
+// Cause is an alias for UnwrapAll.
+var Cause = UnwrapAll

--- a/lib/errors/std.go
+++ b/lib/errors/std.go
@@ -1,0 +1,9 @@
+package errors
+
+import "errors"
+
+var (
+	Unwrap = errors.Unwrap
+	Is     = errors.Is
+	As     = errors.As
+)


### PR DESCRIPTION
Unify error assertions on standard library implementations, instead of cockroachdb implementations - the `UnwrapOnce` in that library supports `Cause` for back-compat, but `Cause` can have many meanings it seems

Discussion: https://sourcegraph.slack.com/archives/CHXHX7XAS/p1649709835518209

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

TODO
