### PR TITLE
fix disabled create insight button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Fixed
 
+- Fixed create insight button being erroneously disabled.
 - Fixed an issue where a `Warning: Sourcegraph cannot send emails!` banner would appear for all users instead of just site admins (introduced in v3.38).
 - Fixed reading search pattern type from settings [#32989](https://github.com/sourcegraph/sourcegraph/issues/32989)
 - Display a tooltip and truncate the title of a search result when content overflows [#32904](https://github.com/sourcegraph/sourcegraph/pull/32904)

--- a/client/web/src/enterprise/insights/core/backend/gql-backend/code-insights-gql-backend.ts
+++ b/client/web/src/enterprise/insights/core/backend/gql-backend/code-insights-gql-backend.ts
@@ -112,10 +112,11 @@ export class CodeInsightsGqlBackend implements CodeInsightsBackend {
         fromObservableQuery(
             this.apolloClient.watchQuery<HasAvailableCodeInsightResult>({
                 query: gql`
-                    query HasAvailableCodeInsight($count: Int!) {
-                        insightViews(first: $count) {
+                    query HasAvailableCodeInsight {
+                        insightViews {
                             nodes {
                                 id
+                                isFrozen
                             }
                         }
                     }
@@ -123,7 +124,7 @@ export class CodeInsightsGqlBackend implements CodeInsightsBackend {
                 variables: { count: insightsCount },
                 nextFetchPolicy: 'cache-only',
             })
-        ).pipe(map(({ data }) => data.insightViews.nodes.length === insightsCount))
+        ).pipe(map(({ data }) => data.insightViews.nodes.filter(node => !node.isFrozen).length === insightsCount))
 
     // TODO: This method is used only for insight title validation but since we don't have
     // limitations about title field in gql api remove this method and async validation for

--- a/client/web/src/integration/insights/utils/override-insights-graphql-api.ts
+++ b/client/web/src/integration/insights/utils/override-insights-graphql-api.ts
@@ -70,7 +70,7 @@ export function overrideInsightsGraphQLApi(props: OverrideGraphQLExtensionsProps
         HasAvailableCodeInsight: () => ({
             insightViews: {
                 __typename: 'InsightViewConnection',
-                nodes: [{ id: '001' }],
+                nodes: [{ id: '001', isFrozen: false }],
             },
         }),
         IsCodeInsightsLicensed: () => ({ __typename: 'Query', enterpriseLicenseHasFeature: true }),


### PR DESCRIPTION
The create insight button on the create insight screen was erroneously counting all insights instead of just nonfrozen insights. This caused the create insight button to be disabled if there was more than 2 insights total.

This PR filters the insight count to only include non-frozen insights.

## Test plan

- Set up local instance with starter license.
- Go to insights
- Create insights until you have two unlocked insights
- Should not be able to create any more

## App preview:

- [Link](https://sg-web-jdb-fix-disabled-create-insight.onrender.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

