### PR TITLE
codeintel: Update lsif-typescript flag.

### DIFF
--- a/lib/codeintel/autoindex/inference/typescript.go
+++ b/lib/codeintel/autoindex/inference/typescript.go
@@ -75,7 +75,7 @@ func inferSingleTypeScriptIndexJob(
 
 	indexerArgs := []string{"lsif-typescript-autoindex", "index"}
 	if shouldInferConfig {
-		indexerArgs = append(indexerArgs, "--inferTSConfig")
+		indexerArgs = append(indexerArgs, "--infer-tsconfig")
 	}
 
 	return &config.IndexJob{

--- a/lib/codeintel/autoindex/inference/typescript_test.go
+++ b/lib/codeintel/autoindex/inference/typescript_test.go
@@ -34,7 +34,7 @@ func TestInferTypeScriptIndexJobsMissingTsConfig(t *testing.T) {
 				Steps:       []config.DockerStep{{Image: "sourcegraph/lsif-typescript:autoindex", Commands: []string{testCase.command}}},
 				Root:        "",
 				Indexer:     lsifTypescriptImage,
-				IndexerArgs: []string{"lsif-typescript-autoindex", "index", "--inferTSConfig"},
+				IndexerArgs: []string{"lsif-typescript-autoindex", "index", "--infer-tsconfig"},
 				Outfile:     "",
 			},
 		}


### PR DESCRIPTION
lsif-node used --inferTSConfig but lsif-typescript started
using a different spelling for consistency with other flags.

Since we we've been using the wrong flag, auto-indexing
for plain JavaScript projects has been broken for a while now.

## Test plan

Updated test; checked the [lsif-typescript code](https://sourcegraph.com/github.com/sourcegraph/lsif-typescript/-/blob/src/main.ts?L45:10).