### PR TITLE
SSBC: Integrate "Create" form into 4-step layout as step 1: Configuration

### DIFF
--- a/client/web/src/enterprise/batches/create/CreateOrEditBatchChangePage.module.scss
+++ b/client/web/src/enterprise/batches/create/CreateOrEditBatchChangePage.module.scss
@@ -1,3 +1,5 @@
+@import 'wildcard/src/global-styles/breakpoints';
+
 .editor-layout-container {
     // Default of min-height: auto when this element is display: flex allows children to
     // set its height. We want to keep this fixed and have children overflow: auto
@@ -51,4 +53,14 @@
     justify-content: flex-end;
     align-items: center;
     gap: 0.625rem;
+}
+
+.batch-config-form {
+    margin: 1.5rem auto;
+    padding-bottom: 3rem;
+    width: 50%;
+
+    @media (--sm-breakpoint-down) {
+        width: 100%;
+    }
 }

--- a/client/web/src/enterprise/batches/create/CreateOrEditBatchChangePage.module.scss
+++ b/client/web/src/enterprise/batches/create/CreateOrEditBatchChangePage.module.scss
@@ -56,7 +56,7 @@
 }
 
 .batch-config-form {
-    margin: 1.5rem auto;
+    margin: 2rem auto;
     padding-bottom: 3rem;
     width: 50%;
 

--- a/client/web/src/enterprise/batches/create/CreateOrEditBatchChangePage.module.scss
+++ b/client/web/src/enterprise/batches/create/CreateOrEditBatchChangePage.module.scss
@@ -44,3 +44,11 @@
     padding: 0;
     font-weight: normal;
 }
+
+.cta-group {
+    display: flex;
+    flex-direction: row;
+    justify-content: flex-end;
+    align-items: center;
+    gap: 0.625rem;
+}

--- a/client/web/src/enterprise/batches/create/CreateOrEditBatchChangePage.tsx
+++ b/client/web/src/enterprise/batches/create/CreateOrEditBatchChangePage.tsx
@@ -5,6 +5,7 @@ import classNames from 'classnames'
 import { compact, noop } from 'lodash'
 import AlertCircleIcon from 'mdi-react/AlertCircleIcon'
 import InfoCircleOutlineIcon from 'mdi-react/InfoCircleOutlineIcon'
+import LockIcon from 'mdi-react/LockIcon'
 import { useHistory } from 'react-router'
 
 import { ErrorAlert } from '@sourcegraph/branded/src/components/alerts'
@@ -27,12 +28,12 @@ import {
     FeedbackBadge,
     Icon,
     Panel,
-    Checkbox,
     Tabs,
     Tab,
     TabList,
     TabPanel,
     TabPanels,
+    RadioButton,
 } from '@sourcegraph/wildcard'
 
 import { BatchChangesIcon } from '../../../batches/icons'
@@ -266,17 +267,33 @@ const BatchConfigurationPage: React.FunctionComponent<BatchConfigurationPageProp
                     placeholder="My batch change name"
                     disabled={isReadOnly}
                 />
-                <h3 className="text-muted mt-3">
+                <hr className="my-3" />
+                <h3 className="text-muted">
                     Visibility <Icon data-tooltip="Coming soon" as={InfoCircleOutlineIcon} />
                 </h3>
                 <div className="form-group mb-1">
-                    <Checkbox
+                    <RadioButton
                         name="visibility"
                         value="public"
+                        className="mr-2"
                         checked={true}
+                        disabled={true}
                         label="Public"
                         aria-label="Public"
+                    />
+                </div>
+                <div className="form-group mb-0">
+                    <RadioButton
+                        name="visibility"
+                        value="private"
+                        className="mr-2 mb-0"
                         disabled={true}
+                        label={
+                            <>
+                                Private <Icon className="text-warning" aria-hidden={true} as={LockIcon} />
+                            </>
+                        }
+                        aria-label="Private"
                     />
                 </div>
             </Container>

--- a/client/web/src/enterprise/batches/create/CreateOrEditBatchChangePage.tsx
+++ b/client/web/src/enterprise/batches/create/CreateOrEditBatchChangePage.tsx
@@ -273,6 +273,13 @@ const BatchConfigurationPage: React.FunctionComponent<BatchConfigurationPageProp
                     placeholder="My batch change name"
                     disabled={isReadOnly}
                 />
+                <small className="text-muted">
+                    Give it a short, descriptive name to reference the batch change on Sourcegraph. Do not include
+                    confidential information.{' '}
+                    <span className={classNames(isNameValid === false && 'text-danger')}>
+                        Only regular characters, _ and - are allowed.
+                    </span>
+                </small>
                 <hr className="my-3" />
                 <h3 className="text-muted">
                     Visibility <Icon data-tooltip="Coming soon" as={InfoCircleOutlineIcon} />

--- a/client/web/src/enterprise/batches/create/CreateOrEditBatchChangePage.tsx
+++ b/client/web/src/enterprise/batches/create/CreateOrEditBatchChangePage.tsx
@@ -213,7 +213,7 @@ const BatchConfigurationPage: React.FunctionComponent<BatchConfigurationPageProp
     namespaceID,
     settingsCascade,
     isReadOnly,
-    batchChangeName
+    batchChangeName,
 }) => {
     const [createEmptyBatchChange, { loading, error }] = useMutation<
         CreateEmptyBatchChangeResult,

--- a/client/web/src/enterprise/batches/create/CreateOrEditBatchChangePage.tsx
+++ b/client/web/src/enterprise/batches/create/CreateOrEditBatchChangePage.tsx
@@ -5,7 +5,6 @@ import classNames from 'classnames'
 import { compact, noop } from 'lodash'
 import AlertCircleIcon from 'mdi-react/AlertCircleIcon'
 import InfoCircleOutlineIcon from 'mdi-react/InfoCircleOutlineIcon'
-import LockIcon from 'mdi-react/LockIcon'
 import { useHistory } from 'react-router'
 
 import { ErrorAlert } from '@sourcegraph/branded/src/components/alerts'
@@ -26,9 +25,14 @@ import {
     Input,
     LoadingSpinner,
     FeedbackBadge,
-    RadioButton,
     Icon,
     Panel,
+    Checkbox,
+    Tabs,
+    Tab,
+    TabList,
+    TabPanel,
+    TabPanels,
 } from '@sourcegraph/wildcard'
 
 import { BatchChangesIcon } from '../../../batches/icons'
@@ -72,6 +76,8 @@ export interface CreateOrEditBatchChangePageProps extends ThemeProps, SettingsCa
     initialNamespaceID?: Scalars['ID']
     /** The batch change name, if it already exists. */
     batchChangeName?: BatchChangeFields['name']
+    /** Display the configuration page in read-only mode */
+    isReadOnly?: boolean
 }
 
 /**
@@ -109,7 +115,7 @@ export const CreateOrEditBatchChangePage: React.FunctionComponent<CreateOrEditBa
     )
 
     if (!batchChangeName) {
-        return <CreatePage namespaceID={initialNamespaceID} {...props} />
+        return <CreatePage isReadOnly={false} namespaceID={initialNamespaceID} {...props} />
     }
 
     if (loading && !data) {
@@ -124,6 +130,18 @@ export const CreateOrEditBatchChangePage: React.FunctionComponent<CreateOrEditBa
         return <HeroPage icon={AlertCircleIcon} title="Batch change not found" />
     }
 
+    const isConfigurationReadOnly = data?.batchChange && props.isReadOnly
+    if (isConfigurationReadOnly) {
+        return (
+            <CreatePage
+                isReadOnly={props.isReadOnly}
+                batchChangeName={data?.batchChange.name}
+                namespaceID={data?.batchChange.namespace.id}
+                {...props}
+            />
+        )
+    }
+
     return <EditPage batchChange={data.batchChange} refetchBatchChange={refetchBatchChange} {...props} />
 }
 
@@ -133,9 +151,71 @@ interface CreatePageProps extends SettingsCascadeProps<Settings> {
      * default to the user's own namespace.
      */
     namespaceID?: Scalars['ID']
+    /** Display configuration in read-only mode */
+    isReadOnly?: boolean
+    /** Name of batch change when in read-only mode */
+    batchChangeName?: string
 }
 
-const CreatePage: React.FunctionComponent<CreatePageProps> = ({ namespaceID, settingsCascade }) => {
+const CreatePage: React.FunctionComponent<CreatePageProps> = props => {
+    const isNewBatchChange = props.batchChangeName === undefined && !props.isReadOnly
+
+    return (
+        <div className="m-4">
+            <PageTitle title="Create new batch change" />
+            <PageHeader
+                path={[{ icon: BatchChangesIcon, to: '.' }, { text: 'Create batch change' }]}
+                className="flex-1 pb-2"
+                description="Run custom code over hundreds of repositories and manage the resulting changesets."
+                annotation={<FeedbackBadge status="experimental" feedback={{ mailto: 'support@sourcegraph.com' }} />}
+            />
+            <Tabs>
+                <TabList>
+                    <Tab>1. Configuration</Tab>
+                    <Tab disabled={isNewBatchChange}>2. Batch Specification</Tab>
+                    <Tab disabled={isNewBatchChange}>3. Execution</Tab>
+                    <Tab disabled={isNewBatchChange}>4. Preview</Tab>
+                </TabList>
+                <TabPanels>
+                    <TabPanel>
+                        <BatchConfigurationPage {...props} />
+                    </TabPanel>
+
+                    <TabPanel>
+                        <div>Batch Specification</div>
+                    </TabPanel>
+
+                    <TabPanel>
+                        <div>Execution</div>
+                    </TabPanel>
+
+                    <TabPanel>
+                        <div>Preview</div>
+                    </TabPanel>
+                </TabPanels>
+            </Tabs>
+        </div>
+    )
+}
+
+interface BatchConfigurationPageProps extends SettingsCascadeProps<Settings> {
+    /**
+     * The namespace the batch change should be created in. If none is provided, it will
+     * default to the user's own namespace.
+     */
+    namespaceID?: Scalars['ID']
+    /** Display configuration in read-only mode */
+    isReadOnly?: boolean
+    /** Batch change when in read-only mode */
+    batchChangeName?: string
+}
+
+const BatchConfigurationPage: React.FunctionComponent<BatchConfigurationPageProps> = ({
+    namespaceID,
+    settingsCascade,
+    isReadOnly,
+    batchChangeName
+}) => {
     const [createEmptyBatchChange, { loading, error }] = useMutation<
         CreateEmptyBatchChangeResult,
         CreateEmptyBatchChangeVariables
@@ -148,7 +228,7 @@ const CreatePage: React.FunctionComponent<CreatePageProps> = ({ namespaceID, set
         defaultSelectedNamespace
     )
 
-    const [nameInput, setNameInput] = useState('')
+    const [nameInput, setNameInput] = useState(batchChangeName || '')
     const [isNameValid, setIsNameValid] = useState<boolean>()
 
     const onNameChange = useCallback<React.ChangeEventHandler<HTMLInputElement>>(event => {
@@ -168,87 +248,56 @@ const CreatePage: React.FunctionComponent<CreatePageProps> = ({ namespaceID, set
     }
 
     return (
-        <div className="container">
-            <div className="container col-8 my-4">
-                <PageTitle title="Create new batch change" />
-                <PageHeader
-                    path={[{ icon: BatchChangesIcon, to: '.' }, { text: 'Create batch change' }]}
-                    className="flex-1 pb-2"
-                    description="Run custom code over hundreds of repositories and manage the resulting changesets."
-                    annotation={
-                        <FeedbackBadge status="experimental" feedback={{ mailto: 'support@sourcegraph.com' }} />
-                    }
+        <Form className="container my-4 pb-5 w-50" onSubmit={handleCreate}>
+            <Container className="mb-4">
+                {error && <ErrorAlert error={error} />}
+                <NamespaceSelector
+                    namespaces={namespaces}
+                    selectedNamespace={selectedNamespace.id}
+                    onSelect={setSelectedNamespace}
+                    disabled={isReadOnly}
                 />
-                <Form className="my-4 pb-5" onSubmit={handleCreate}>
-                    <Container className="mb-4">
-                        {error && <ErrorAlert error={error} />}
-                        <NamespaceSelector
-                            namespaces={namespaces}
-                            selectedNamespace={selectedNamespace.id}
-                            onSelect={setSelectedNamespace}
-                        />
-                        <Input
-                            label="Batch change name"
-                            value={nameInput}
-                            onChange={onNameChange}
-                            pattern={String(NAME_PATTERN)}
-                            required={true}
-                            status={isNameValid === undefined ? undefined : isNameValid ? 'valid' : 'error'}
-                        />
-                        <small className="text-muted">
-                            Give it a short, descriptive name to reference the batch change on Sourcegraph. Do not
-                            include confidential information.{' '}
-                            <span className={classNames(isNameValid === false && 'text-danger')}>
-                                Only regular characters, _ and - are allowed.
-                            </span>
-                        </small>
-                        <hr className="my-3" />
-                        <h3 className="text-muted">
-                            Visibility <Icon data-tooltip="Coming soon" as={InfoCircleOutlineIcon} />
-                        </h3>
-                        <div className="form-group mb-1">
-                            <RadioButton
-                                name="visibility"
-                                value="public"
-                                className="mr-2"
-                                checked={true}
-                                disabled={true}
-                                label="Public"
-                                aria-label="Public"
-                            />
-                        </div>
-                        <div className="form-group mb-0">
-                            <RadioButton
-                                name="visibility"
-                                value="private"
-                                className="mr-2 mb-0"
-                                disabled={true}
-                                label={
-                                    <>
-                                        Private <Icon className="text-warning" aria-hidden={true} as={LockIcon} />
-                                    </>
-                                }
-                                aria-label="Private"
-                            />
-                        </div>
-                    </Container>
-                    <div>
-                        <Button
-                            variant="primary"
-                            type="submit"
-                            onClick={handleCreate}
-                            disabled={loading || nameInput === '' || !isNameValid}
-                            className="mr-2"
-                        >
-                            Create batch change
-                        </Button>
-                        <Button variant="secondary" type="button" outline={true} onClick={handleCancel}>
-                            Cancel
-                        </Button>
-                    </div>
-                </Form>
-            </div>
-        </div>
+                <Input
+                    label="Batch change name"
+                    value={nameInput}
+                    onChange={onNameChange}
+                    pattern={String(NAME_PATTERN)}
+                    required={true}
+                    status={isNameValid === undefined ? undefined : isNameValid ? 'valid' : 'error'}
+                    placeholder="My batch change name"
+                    disabled={isReadOnly}
+                />
+                <h3 className="text-muted mt-3">
+                    Visibility <Icon data-tooltip="Coming soon" as={InfoCircleOutlineIcon} />
+                </h3>
+                <div className="form-group mb-1">
+                    <Checkbox
+                        name="visibility"
+                        value="public"
+                        checked={true}
+                        label="Public"
+                        aria-label="Public"
+                        disabled={true}
+                    />
+                </div>
+            </Container>
+
+            {isReadOnly ? null : (
+                <div className={styles.ctaGroup}>
+                    <Button variant="secondary" type="button" outline={true} onClick={handleCancel}>
+                        Cancel
+                    </Button>
+                    <Button
+                        variant="primary"
+                        type="submit"
+                        onClick={handleCreate}
+                        disabled={loading || nameInput === '' || !isNameValid}
+                    >
+                        Create
+                    </Button>
+                </div>
+            )}
+        </Form>
     )
 }
 

--- a/client/web/src/enterprise/batches/create/CreateOrEditBatchChangePage.tsx
+++ b/client/web/src/enterprise/batches/create/CreateOrEditBatchChangePage.tsx
@@ -248,7 +248,7 @@ const BatchConfigurationPage: React.FunctionComponent<BatchConfigurationPageProp
     }
 
     return (
-        <Form className="container my-4 pb-5 w-50" onSubmit={handleCreate}>
+        <Form className={styles.batchConfigForm} onSubmit={handleCreate}>
             <Container className="mb-4">
                 {error && <ErrorAlert error={error} />}
                 <NamespaceSelector

--- a/client/web/src/enterprise/batches/create/CreateOrEditBatchChangePage.tsx
+++ b/client/web/src/enterprise/batches/create/CreateOrEditBatchChangePage.tsx
@@ -173,7 +173,7 @@ const CreatePage: React.FunctionComponent<CreatePageProps> = props => {
                 <TabList>
                     <Tab className="text-content py-2 px-3">1. Configuration</Tab>
                     <Tab className="text-content py-2 px-3" disabled={isNewBatchChange}>
-                        2. Batch Specification
+                        2. Batch spec
                     </Tab>
                     <Tab className="text-content py-2 px-3" disabled={isNewBatchChange}>
                         3. Execution

--- a/client/web/src/enterprise/batches/create/CreateOrEditBatchChangePage.tsx
+++ b/client/web/src/enterprise/batches/create/CreateOrEditBatchChangePage.tsx
@@ -161,7 +161,7 @@ const CreatePage: React.FunctionComponent<CreatePageProps> = props => {
     const isNewBatchChange = props.batchChangeName === undefined && !props.isReadOnly
 
     return (
-        <div className="w-100 m-4">
+        <div className="w-100 p-4">
             <PageTitle title="Create new batch change" />
             <PageHeader
                 path={[{ icon: BatchChangesIcon, to: '.' }, { text: 'Create batch change' }]}
@@ -171,10 +171,10 @@ const CreatePage: React.FunctionComponent<CreatePageProps> = props => {
             />
             <Tabs>
                 <TabList>
-                    <Tab>1. Configuration</Tab>
-                    <Tab disabled={isNewBatchChange}>2. Batch Specification</Tab>
-                    <Tab disabled={isNewBatchChange}>3. Execution</Tab>
-                    <Tab disabled={isNewBatchChange}>4. Preview</Tab>
+                    <Tab className="text-content py-2 px-3">1. Configuration</Tab>
+                    <Tab className="text-content" disabled={isNewBatchChange}>2. Batch Specification</Tab>
+                    <Tab className="text-content" disabled={isNewBatchChange}>3. Execution</Tab>
+                    <Tab className="text-content" disabled={isNewBatchChange}>4. Preview</Tab>
                 </TabList>
                 <TabPanels>
                     <TabPanel>

--- a/client/web/src/enterprise/batches/create/CreateOrEditBatchChangePage.tsx
+++ b/client/web/src/enterprise/batches/create/CreateOrEditBatchChangePage.tsx
@@ -304,7 +304,7 @@ const BatchConfigurationPage: React.FunctionComponent<BatchConfigurationPageProp
                 </div>
             </Container>
 
-            {isReadOnly ? null : (
+            {!isReadOnly && (
                 <div className={styles.ctaGroup}>
                     <Button variant="secondary" type="button" outline={true} onClick={handleCancel}>
                         Cancel

--- a/client/web/src/enterprise/batches/create/CreateOrEditBatchChangePage.tsx
+++ b/client/web/src/enterprise/batches/create/CreateOrEditBatchChangePage.tsx
@@ -161,7 +161,7 @@ const CreatePage: React.FunctionComponent<CreatePageProps> = props => {
     const isNewBatchChange = props.batchChangeName === undefined && !props.isReadOnly
 
     return (
-        <div className="m-4">
+        <div className="w-100 m-4">
             <PageTitle title="Create new batch change" />
             <PageHeader
                 path={[{ icon: BatchChangesIcon, to: '.' }, { text: 'Create batch change' }]}

--- a/client/web/src/enterprise/batches/create/CreateOrEditBatchChangePage.tsx
+++ b/client/web/src/enterprise/batches/create/CreateOrEditBatchChangePage.tsx
@@ -188,7 +188,7 @@ const CreatePage: React.FunctionComponent<CreatePageProps> = props => {
                     </TabPanel>
 
                     <TabPanel>
-                        <div>Batch Specification</div>
+                        <div>Batch spec</div>
                     </TabPanel>
 
                     <TabPanel>

--- a/client/web/src/enterprise/batches/create/CreateOrEditBatchChangePage.tsx
+++ b/client/web/src/enterprise/batches/create/CreateOrEditBatchChangePage.tsx
@@ -172,9 +172,15 @@ const CreatePage: React.FunctionComponent<CreatePageProps> = props => {
             <Tabs>
                 <TabList>
                     <Tab className="text-content py-2 px-3">1. Configuration</Tab>
-                    <Tab className="text-content" disabled={isNewBatchChange}>2. Batch Specification</Tab>
-                    <Tab className="text-content" disabled={isNewBatchChange}>3. Execution</Tab>
-                    <Tab className="text-content" disabled={isNewBatchChange}>4. Preview</Tab>
+                    <Tab className="text-content py-2 px-3" disabled={isNewBatchChange}>
+                        2. Batch Specification
+                    </Tab>
+                    <Tab className="text-content py-2 px-3" disabled={isNewBatchChange}>
+                        3. Execution
+                    </Tab>
+                    <Tab className="text-content py-2 px-3" disabled={isNewBatchChange}>
+                        4. Preview
+                    </Tab>
                 </TabList>
                 <TabPanels>
                     <TabPanel>

--- a/client/web/src/enterprise/batches/create/CreateOrEditBatchChangePage.tsx
+++ b/client/web/src/enterprise/batches/create/CreateOrEditBatchChangePage.tsx
@@ -130,8 +130,7 @@ export const CreateOrEditBatchChangePage: React.FunctionComponent<CreateOrEditBa
         return <HeroPage icon={AlertCircleIcon} title="Batch change not found" />
     }
 
-    const isConfigurationReadOnly = data?.batchChange && props.isReadOnly
-    if (isConfigurationReadOnly) {
+    if (props.isReadOnly) {
         return (
             <CreatePage
                 isReadOnly={props.isReadOnly}

--- a/client/web/src/enterprise/batches/execution/BatchSpecExecutionDetailsPage.tsx
+++ b/client/web/src/enterprise/batches/execution/BatchSpecExecutionDetailsPage.tsx
@@ -158,6 +158,7 @@ export const BatchSpecExecutionDetailsPage: React.FunctionComponent<BatchSpecExe
     )
 }
 
+// TODO: Deprecate this component once Tabs 2-4 on the Create form is active
 const TabBar: React.FunctionComponent<{ url: string; batchSpec: BatchSpecExecutionFields }> = ({ url, batchSpec }) => (
     <div className="mb-3">
         <ul className="nav nav-tabs d-inline-flex d-sm-flex flex-nowrap text-nowrap">

--- a/client/web/src/enterprise/batches/execution/BatchSpecExecutionDetailsPage.tsx
+++ b/client/web/src/enterprise/batches/execution/BatchSpecExecutionDetailsPage.tsx
@@ -158,7 +158,6 @@ export const BatchSpecExecutionDetailsPage: React.FunctionComponent<BatchSpecExe
     )
 }
 
-// TODO: Deprecate this component once Tabs 2-4 on the Create form is active
 const TabBar: React.FunctionComponent<{ url: string; batchSpec: BatchSpecExecutionFields }> = ({ url, batchSpec }) => (
     <div className="mb-3">
         <ul className="nav nav-tabs d-inline-flex d-sm-flex flex-nowrap text-nowrap">

--- a/client/web/src/enterprise/organizations/routes.tsx
+++ b/client/web/src/enterprise/organizations/routes.tsx
@@ -54,6 +54,20 @@ export const enterpriseOrganizationAreaRoutes: readonly OrgAreaRoute[] = [
         fullPage: true,
     },
     {
+        path: '/batch-changes/:batchChangeName/executions/:batchSpecID/configuration',
+        render: ({ match, ...props }: OrgAreaPageProps & RouteComponentProps<{ batchChangeName: string }>) => (
+            <CreateOrEditBatchChangePage
+                {...props}
+                initialNamespaceID={props.org.id}
+                batchChangeName={match.params.batchChangeName}
+                isReadOnly={true}
+            />
+        ),
+        condition: ({ batchChangesEnabled, batchChangesExecutionEnabled }) =>
+            batchChangesEnabled && batchChangesExecutionEnabled,
+        fullPage: true,
+    },
+    {
         path: '/batch-changes/:batchChangeName/executions/:batchSpecID',
         render: (props: OrgAreaPageProps & RouteComponentProps<{ batchSpecID: string }>) => (
             <ExecutionArea {...props} namespaceID={props.org.id} />

--- a/client/web/src/enterprise/user/routes.tsx
+++ b/client/web/src/enterprise/user/routes.tsx
@@ -68,6 +68,20 @@ export const enterpriseUserAreaRoutes: readonly UserAreaRoute[] = [
         fullPage: true,
     },
     {
+        path: '/batch-changes/:batchChangeName/executions/:batchSpecID/configuration',
+        render: ({ match, ...props }: UserAreaRouteContext & RouteComponentProps<{ batchChangeName: string }>) => (
+            <CreateOrEditBatchChangePage
+                {...props}
+                initialNamespaceID={props.user.id}
+                batchChangeName={match.params.batchChangeName}
+                isReadOnly={true}
+            />
+        ),
+        condition: ({ batchChangesEnabled, batchChangesExecutionEnabled }) =>
+            batchChangesEnabled && batchChangesExecutionEnabled,
+        fullPage: true,
+    },
+    {
         path: '/batch-changes/:batchChangeName/executions/:batchSpecID',
         render: (props: UserAreaRouteContext & RouteComponentProps<{ batchSpecID: string }>) => (
             <ExecutionArea {...props} namespaceID={props.user.id} />


### PR DESCRIPTION
## Screenshot

<img width="1511" alt="Screenshot 2022-04-12 at 22 49 48" src="https://user-images.githubusercontent.com/25608335/163060218-09dd82cd-f005-474f-9a26-44e740aeb803.png">

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

* Navigate to the `/batch-changes/create` - the new tab navigation for the configuration step should be displayed.
* Navigating to `/users/<namespace_user_id>/batch-changes/<batch_change_name>/configuration` which is an alias for the read-only configuration for batch changes should display a similar page with disabled input fields.

Closes #32337 

## App preview:

- [Link](https://sg-web-bo-ssbc-integrate-4-step-create.onrender.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

