### PR TITLE
luasandbox: Add utilities

### DIFF
--- a/internal/luasandbox/observability.go
+++ b/internal/luasandbox/observability.go
@@ -8,10 +8,11 @@ import (
 )
 
 type operations struct {
-	createSandbox *observation.Operation
-	runScript     *observation.Operation
 	call          *observation.Operation
 	callGenerator *observation.Operation
+	createSandbox *observation.Operation
+	runGoCallback *observation.Operation
+	runScript     *observation.Operation
 }
 
 func newOperations(observationContext *observation.Context) *operations {
@@ -31,9 +32,10 @@ func newOperations(observationContext *observation.Context) *operations {
 	}
 
 	return &operations{
-		createSandbox: op("CreateSandbox"),
-		runScript:     op("RunScript"),
 		call:          op("Call"),
 		callGenerator: op("CallGenerator"),
+		createSandbox: op("CreateSandbox"),
+		runGoCallback: op("RunGoCallback"),
+		runScript:     op("RunScript"),
 	}
 }

--- a/internal/luasandbox/sandbox.go
+++ b/internal/luasandbox/sandbox.go
@@ -32,15 +32,15 @@ func (s *Sandbox) RunScript(ctx context.Context, opts RunOptions, script string)
 	ctx, endObservation := s.operations.runScript.With(ctx, &err, observation.Args{})
 	defer endObservation(1, observation.Args{})
 
-	f := func() error {
-		if err := s.state.DoString(script); err != nil {
+	f := func(ctx context.Context, state *lua.LState) error {
+		if err := state.DoString(script); err != nil {
 			return err
 		}
 
-		retValue = s.state.Get(lua.MultRet)
+		retValue = state.Get(lua.MultRet)
 		return nil
 	}
-	err = s.run(ctx, opts, f)
+	err = s.RunGoCallback(ctx, opts, f)
 	return
 }
 
@@ -49,20 +49,20 @@ func (s *Sandbox) Call(ctx context.Context, opts RunOptions, luaFunction *lua.LF
 	ctx, endObservation := s.operations.call.With(ctx, &err, observation.Args{})
 	defer endObservation(1, observation.Args{})
 
-	f := func() error {
-		s.state.Push(luaFunction)
+	f := func(ctx context.Context, state *lua.LState) error {
+		state.Push(luaFunction)
 		for _, arg := range args {
-			s.state.Push(luar.New(s.state, arg))
+			state.Push(luar.New(s.state, arg))
 		}
 
-		if err := s.state.PCall(len(args), lua.MultRet, nil); err != nil {
+		if err := state.PCall(len(args), lua.MultRet, nil); err != nil {
 			return err
 		}
 
-		retValue = s.state.Get(lua.MultRet)
+		retValue = state.Get(lua.MultRet)
 		return nil
 	}
-	err = s.run(ctx, opts, f)
+	err = s.RunGoCallback(ctx, opts, f)
 	return
 }
 
@@ -74,17 +74,17 @@ func (s *Sandbox) CallGenerator(ctx context.Context, opts RunOptions, luaFunctio
 	ctx, endObservation := s.operations.callGenerator.With(ctx, &err, observation.Args{})
 	defer endObservation(1, observation.Args{})
 
-	f := func() error {
+	f := func(ctx context.Context, state *lua.LState) error {
 		luaArgs := make([]lua.LValue, 0, len(args))
 		for _, arg := range args {
 			luaArgs = append(luaArgs, luar.New(s.state, arg))
 		}
 
-		co, _ := s.state.NewThread()
+		co, _ := state.NewThread()
 
 	loop:
 		for {
-			state, err, yieldedValues := s.state.Resume(co, luaFunction, luaArgs...)
+			state, err, yieldedValues := state.Resume(co, luaFunction, luaArgs...)
 			switch state {
 			case lua.ResumeError:
 				return err
@@ -101,7 +101,7 @@ func (s *Sandbox) CallGenerator(ctx context.Context, opts RunOptions, luaFunctio
 
 		return nil
 	}
-	err = s.run(ctx, opts, f)
+	err = s.RunGoCallback(ctx, opts, f)
 	return
 }
 
@@ -111,7 +111,9 @@ type RunOptions struct {
 
 const DefaultTimeout = time.Millisecond * 200
 
-func (s *Sandbox) run(ctx context.Context, opts RunOptions, f func() error) (err error) {
+// RunGoCallback invokes the given Go callback with exclusive access
+// to the state of the sandbox.
+func (s *Sandbox) RunGoCallback(ctx context.Context, opts RunOptions, f func(ctx context.Context, state *lua.LState) error) (err error) {
 	s.m.Lock()
 	defer s.m.Unlock()
 
@@ -124,5 +126,5 @@ func (s *Sandbox) run(ctx context.Context, opts RunOptions, f func() error) (err
 	s.state.SetContext(ctx)
 	defer s.state.RemoveContext()
 
-	return f()
+	return f(ctx, s.state)
 }

--- a/internal/luasandbox/sandbox.go
+++ b/internal/luasandbox/sandbox.go
@@ -111,9 +111,12 @@ type RunOptions struct {
 
 const DefaultTimeout = time.Millisecond * 200
 
-// RunGoCallback invokes the given Go callback with exclusive access
-// to the state of the sandbox.
+// RunGoCallback invokes the given Go callback with exclusive access to the state of the
+// sandbox.
 func (s *Sandbox) RunGoCallback(ctx context.Context, opts RunOptions, f func(ctx context.Context, state *lua.LState) error) (err error) {
+	ctx, endObservation := s.operations.runGoCallback.With(ctx, &err, observation.Args{})
+	defer endObservation(1, observation.Args{})
+
 	s.m.Lock()
 	defer s.m.Unlock()
 

--- a/internal/luasandbox/util.go
+++ b/internal/luasandbox/util.go
@@ -1,0 +1,29 @@
+package luasandbox
+
+import lua "github.com/yuin/gopher-lua"
+
+// CreateModule wraps a map of functions into a lua.LGFunction suitable for
+// use in CreateOptions.Modules.
+func CreateModule(api map[string]lua.LGFunction) lua.LGFunction {
+	return WrapLuaFunction(func(state *lua.LState) error {
+		t := state.NewTable()
+		state.SetFuncs(t, api)
+		state.Push(t)
+		return nil
+	})
+}
+
+// WrapLuaFunction invokes the given callback and returns 2 (raising an error) if the
+// returned error is non-nil, and returns 1 (success) otherwise. This wrapper function
+// makes no assumptions about how the called function modifies the Lua virtual machine
+// state.
+func WrapLuaFunction(f func(state *lua.LState) error) func(state *lua.LState) int {
+	return func(state *lua.LState) int {
+		if err := f(state); err != nil {
+			state.RaiseError(err.Error())
+			return 2
+		}
+
+		return 1
+	}
+}


### PR DESCRIPTION
Small refactor with some added utilities to help create modules. UX will come in bursts here as I flesh out what we actually need from this code. This PR also exposes the bare `run` method for use by module definitions (coming soon).

## Test plan

Existing/modified unit tests.