### PR TITLE
fix line chart hover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Fixed
 
--
+- Code Insights: Fixed line chart data series hover effect. Now the active line will be rendered on top of the others.
 
 ### Removed
 

--- a/client/web/src/charts/components/line-chart/LineChart.tsx
+++ b/client/web/src/charts/components/line-chart/LineChart.tsx
@@ -32,6 +32,9 @@ export interface LineChartContentProps<Datum> extends SeriesLikeChart<Datum>, SV
     zeroYAxisMin?: boolean
 }
 
+const sortByDataKey = (dataKey: string | number | symbol, activeDataKey: string): number =>
+    dataKey === activeDataKey ? 1 : -1
+
 /**
  * Visual component that renders svg line chart with pre-defined sizes, tooltip,
  * voronoi area distribution.
@@ -160,33 +163,37 @@ export function LineChart<D>(props: LineChartContentProps<D>): ReactElement | nu
             <Group top={margin.top}>
                 {stacked && <StackedArea dataSeries={dataSeries} xScale={xScale} yScale={yScale} />}
 
-                {dataSeries.map(line => (
-                    <LinePath
-                        key={line.dataKey as string}
-                        data={line.data as SeriesDatum<D>[]}
-                        curve={curveLinear}
-                        defined={isDatumWithValidNumber}
-                        x={data => xScale(data.x)}
-                        y={data => yScale(getDatumValue(data))}
-                        stroke={line.color}
-                        strokeWidth={2}
-                        strokeLinecap="round"
-                    />
-                ))}
+                {[...dataSeries]
+                    .sort(series => sortByDataKey(series.dataKey, activePoint?.seriesKey || ''))
+                    .map(line => (
+                        <LinePath
+                            key={line.dataKey as string}
+                            data={line.data as SeriesDatum<D>[]}
+                            curve={curveLinear}
+                            defined={isDatumWithValidNumber}
+                            x={data => xScale(data.x)}
+                            y={data => yScale(getDatumValue(data))}
+                            stroke={line.color}
+                            strokeWidth={2}
+                            strokeLinecap="round"
+                        />
+                    ))}
 
-                {points.map(point => (
-                    <PointGlyph
-                        key={point.id}
-                        left={point.x}
-                        top={point.y}
-                        active={activePoint?.id === point.id}
-                        color={point.color}
-                        linkURL={point.linkUrl}
-                        onClick={onDatumClick}
-                        onFocus={event => setActivePoint({ ...point, element: event.target })}
-                        onBlur={() => setActivePoint(undefined)}
-                    />
-                ))}
+                {[...points]
+                    .sort(point => sortByDataKey(point.seriesKey, activePoint?.seriesKey || ''))
+                    .map(point => (
+                        <PointGlyph
+                            key={point.id}
+                            left={point.x}
+                            top={point.y}
+                            active={activePoint?.id === point.id}
+                            color={point.color}
+                            linkURL={point.linkUrl}
+                            onClick={onDatumClick}
+                            onFocus={event => setActivePoint({ ...point, element: event.target })}
+                            onBlur={() => setActivePoint(undefined)}
+                        />
+                    ))}
             </Group>
 
             {activePoint && (

--- a/client/web/src/views/components/view/content/chart-view-content/charts/line/components/LineChartContent.tsx
+++ b/client/web/src/views/components/view/content/chart-view-content/charts/line/components/LineChartContent.tsx
@@ -28,7 +28,7 @@ import { getYAxisWidth } from '../helpers/get-y-axis-width'
 import { getYTicks } from '../helpers/get-y-ticks'
 import { usePointerEventEmitters } from '../helpers/use-event-emitters'
 import { useScalesConfiguration, useXScale, useYScale } from '../helpers/use-scales'
-import { LineChartSeriesWithData, onDatumZoneClick, Point } from '../types'
+import { onDatumZoneClick, Point } from '../types'
 
 import { ActiveDatum, GlyphContent } from './GlyphContent'
 import { NonActiveBackground } from './NonActiveBackground'
@@ -240,9 +240,6 @@ export function LineChartContent<Datum extends object>(props: LineChartContentPr
         : null
     const rootClasses = classNames({ [styles.contentWithCursor]: !!hoveredDatumLink })
 
-    const hoveredLineLast = (line: LineChartSeriesWithData<Datum>): number =>
-        line.dataKey === hoveredDatum?.line?.dataKey ? 1 : -1
-
     return (
         <div className={classNames(rootClasses, 'percy-inactive-element')} data-testid="line-chart__content">
             {/*
@@ -332,7 +329,7 @@ export function LineChartContent<Datum extends object>(props: LineChartContentPr
                                 fill="transparent"
                             />
 
-                            {seriesWithData.sort(hoveredLineLast).map((line, index) => (
+                            {seriesWithData.map((line, index) => (
                                 <Group
                                     key={line.dataKey as string}
                                     // eslint-disable-next-line jsx-a11y/aria-role

--- a/client/web/src/views/components/view/content/chart-view-content/charts/line/components/LineChartContent.tsx
+++ b/client/web/src/views/components/view/content/chart-view-content/charts/line/components/LineChartContent.tsx
@@ -28,7 +28,7 @@ import { getYAxisWidth } from '../helpers/get-y-axis-width'
 import { getYTicks } from '../helpers/get-y-ticks'
 import { usePointerEventEmitters } from '../helpers/use-event-emitters'
 import { useScalesConfiguration, useXScale, useYScale } from '../helpers/use-scales'
-import { onDatumZoneClick, Point } from '../types'
+import { LineChartSeriesWithData, onDatumZoneClick, Point } from '../types'
 
 import { ActiveDatum, GlyphContent } from './GlyphContent'
 import { NonActiveBackground } from './NonActiveBackground'
@@ -240,6 +240,9 @@ export function LineChartContent<Datum extends object>(props: LineChartContentPr
         : null
     const rootClasses = classNames({ [styles.contentWithCursor]: !!hoveredDatumLink })
 
+    const hoveredLineLast = (line: LineChartSeriesWithData<Datum>): number =>
+        line.dataKey === hoveredDatum?.line?.dataKey ? 1 : -1
+
     return (
         <div className={classNames(rootClasses, 'percy-inactive-element')} data-testid="line-chart__content">
             {/*
@@ -329,7 +332,7 @@ export function LineChartContent<Datum extends object>(props: LineChartContentPr
                                 fill="transparent"
                             />
 
-                            {seriesWithData.map((line, index) => (
+                            {seriesWithData.sort(hoveredLineLast).map((line, index) => (
                                 <Group
                                     key={line.dataKey as string}
                                     // eslint-disable-next-line jsx-a11y/aria-role


### PR DESCRIPTION
re-sorts series data to put hovered line last so that
the line renders on top.

Closes https://github.com/sourcegraph/sourcegraph/issues/31658

### Note ❗ 

This PR will not actually take effect until https://github.com/sourcegraph/sourcegraph/pull/33799 is merged since it only updates the new line chart component

## Test plan

Open Smart Insights View Grid Example in storybook.
When hovering over a chart with many lines, the hovered
line should always render on top.

## App preview:

- [Link](https://sg-web-jdb-fix-line-chart-hover.onrender.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

