### PR TITLE
ci: do not asdf install for pipeline upload

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -23,4 +23,8 @@ mkdir -p ./annotations/
 
 # asdf setup
 # ----------
-./dev/ci/asdf-install.sh
+if [[ ! "$BUILDKITE_STEP_KEY" == "pipeline-upload" ]]; then
+  ./dev/ci/asdf-install.sh
+else
+  echo "skipping asdf install for pipeline upload setp"
+fi


### PR DESCRIPTION
pipeline upload does not need all our asdf tools, and it does not need to take an entire minute 😆 

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

ci passes

before: ~45s, after: ~15s

<img width="1173" alt="image" src="https://user-images.githubusercontent.com/23356519/163072622-a1054b9c-9464-4316-a579-11d0c24ba1df.png">
