### PR TITLE
dev/dn: include environment, deploy in all events

### DIFF
--- a/enterprise/dev/deployment-notifier/trace_test.go
+++ b/enterprise/dev/deployment-notifier/trace_test.go
@@ -15,7 +15,8 @@ func intPtr(v int) *int {
 
 func TestGenerateDeploymentTrace(t *testing.T) {
 	trace, err := GenerateDeploymentTrace(&DeploymentReport{
-		DeployedAt: time.RFC822Z,
+		Environment: "preprepod",
+		DeployedAt:  time.RFC822Z,
 		PullRequests: []*github.PullRequest{
 			{Number: intPtr(32996)},
 			{Number: intPtr(32871)},
@@ -37,4 +38,9 @@ func TestGenerateDeploymentTrace(t *testing.T) {
 	assert.NotEmpty(t, trace.ID)
 	assert.NotNil(t, trace.Root)
 	assert.Equal(t, expectPRSpans+expectServiceSpans, len(trace.Spans))
+
+	// Assert fields every event should have
+	for _, ev := range append(trace.Spans, trace.Root) {
+		assert.Equal(t, ev.Fields()["environment"], "preprepod")
+	}
 }


### PR DESCRIPTION
While building a dashboard for https://github.com/sourcegraph/sourcegraph/issues/32153#issuecomment-1094820837 I realized I cant build a chart for per-service deployments because I don't have the `environment` in child spans of the root deploy trace. This change standardizes on a set of metadata to better help identify all spans.

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

unit tests

