### PR TITLE
Enable accessibilityAudit on `batches.test.ts`

### DIFF
--- a/client/web/src/components/diff/DiffStat.tsx
+++ b/client/web/src/components/diff/DiffStat.tsx
@@ -50,9 +50,16 @@ export const DiffStat: React.FunctionComponent<DiffStatProps> = React.memo(funct
         <div className={classNames(styles.diffStat, className)} data-tooltip={labels.join(', ')}>
             {expandedCounts ? (
                 <>
-                    <strong className="text-success mr-1">+{numberWithCommas(added)}</strong>
-                    {changed > 0 && <strong className="text-warning mr-1">&bull;{numberWithCommas(changed)}</strong>}
-                    <strong className="text-danger">&minus;{numberWithCommas(deleted)}</strong>
+                    {/*
+                        a11y-ignore
+                        Rule: "color-contrast" (Elements must have sufficient color contrast)
+                        GitHub issue: https://github.com/sourcegraph/sourcegraph/issues/33343
+                    */}
+                    <strong className="a11y-ignore text-success mr-1">+{numberWithCommas(added)}</strong>
+                    {changed > 0 && (
+                        <strong className="a11y-ignore text-warning mr-1">&bull;{numberWithCommas(changed)}</strong>
+                    )}
+                    <strong className="a11y-ignore text-danger">&minus;{numberWithCommas(deleted)}</strong>
                 </>
             ) : (
                 <small>{numberWithCommas(total + changed)}</small>

--- a/client/web/src/components/diff/__snapshots__/DiffStat.test.tsx.snap
+++ b/client/web/src/components/diff/__snapshots__/DiffStat.test.tsx.snap
@@ -7,17 +7,17 @@ exports[`DiffStat expandedCounts 1`] = `
     data-tooltip="1 addition, 2 changes, 3 deletions"
   >
     <strong
-      class="text-success mr-1"
+      class="a11y-ignore text-success mr-1"
     >
       +1
     </strong>
     <strong
-      class="text-warning mr-1"
+      class="a11y-ignore text-warning mr-1"
     >
       •2
     </strong>
     <strong
-      class="text-danger"
+      class="a11y-ignore text-danger"
     >
       −3
     </strong>
@@ -72,17 +72,17 @@ exports[`DiffStatStack 1`] = `
       data-tooltip="1 addition, 2 changes, 3 deletions"
     >
       <strong
-        class="text-success mr-1"
+        class="a11y-ignore text-success mr-1"
       >
         +1
       </strong>
       <strong
-        class="text-warning mr-1"
+        class="a11y-ignore text-warning mr-1"
       >
         •2
       </strong>
       <strong
-        class="text-danger"
+        class="a11y-ignore text-danger"
       >
         −3
       </strong>

--- a/client/web/src/enterprise/batches/ChangesetFilter.tsx
+++ b/client/web/src/enterprise/batches/ChangesetFilter.tsx
@@ -30,7 +30,7 @@ export const ChangesetFilter = <T extends string>({
     return (
         <>
             <Select
-                aria-label=""
+                aria-label={label}
                 id=""
                 selectClassName={classNames('form-control changeset-filter__dropdown', className)}
                 className="mb-0"

--- a/client/web/src/enterprise/batches/detail/BatchChangeDetailsPage.tsx
+++ b/client/web/src/enterprise/batches/detail/BatchChangeDetailsPage.tsx
@@ -112,6 +112,7 @@ export const BatchChangeDetailsPage: React.FunctionComponent<BatchChangeDetailsP
                     {
                         icon: BatchChangesIcon,
                         to: '/batch-changes',
+                        ariaLabel: 'Batch changes',
                     },
                     { to: `${batchChange.namespace.url}/batch-changes`, text: batchChange.namespace.namespaceName },
                     { text: batchChange.name },

--- a/client/web/src/enterprise/batches/detail/BatchChangeStatsCard.tsx
+++ b/client/web/src/enterprise/batches/detail/BatchChangeStatsCard.tsx
@@ -49,11 +49,19 @@ export const BatchChangeStatsCard: React.FunctionComponent<BatchChangeStatsCardP
         <div className={classNames(className)}>
             <div className="d-flex flex-wrap align-items-center flex-grow-1">
                 <h2 className="m-0">
-                    <BatchChangeStateBadge isClosed={!!closedAt} className={styles.batchChangeStatsCardStateBadge} />
+                    {/*
+                        a11y-ignore
+                        Rule: "color-contrast" (Elements must have sufficient color contrast)
+                        GitHub issue: https://github.com/sourcegraph/sourcegraph/issues/33343
+                    */}
+                    <BatchChangeStateBadge
+                        isClosed={!!closedAt}
+                        className={classNames('a11y-ignore', styles.batchChangeStatsCardStateBadge)}
+                    />
                 </h2>
                 <div className={classNames(styles.batchChangeStatsCardDivider, 'mx-3')} />
                 <div className="d-flex align-items-center">
-                    <h1 className="d-inline mb-0">
+                    <h1 className="d-inline mb-0" aria-label="Batch Change Status">
                         <Icon
                             className={classNames('mr-2', isCompleted ? 'text-success' : 'text-muted')}
                             as={BatchChangeStatusIcon}

--- a/client/web/src/enterprise/batches/detail/changesets/BatchChangeChangesets.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/BatchChangeChangesets.tsx
@@ -277,7 +277,7 @@ const BatchChangeChangesetsImpl: React.FunctionComponent<Props> = ({
             <div className="list-group position-relative" ref={nextContainerElement}>
                 <ConnectionContainer>
                     {error && <ConnectionError errors={[error.message]} />}
-                    <ConnectionList className={styles.batchChangeChangesetsGrid}>
+                    <ConnectionList as="div" className={styles.batchChangeChangesetsGrid}>
                         {connection?.nodes?.length ? (
                             <BatchChangeChangesetsHeader
                                 allSelected={showSelectRow && areAllVisibleSelected()}

--- a/client/web/src/enterprise/batches/detail/changesets/BatchChangeChangesetsHeader.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/BatchChangeChangesetsHeader.tsx
@@ -1,5 +1,7 @@
 import React from 'react'
 
+import { H3, H5 } from '@sourcegraph/wildcard'
+
 import { InputTooltip } from '../../../../components/InputTooltip'
 
 export interface BatchChangeChangesetsHeaderProps {
@@ -30,10 +32,20 @@ export const BatchChangeChangesetsHeader: React.FunctionComponent<BatchChangeCha
                 }
             />
         )}
-        <h5 className="p-2 d-none d-md-block text-uppercase text-center text-nowrap">Status</h5>
-        <h5 className="p-2 d-none d-md-block text-uppercase text-nowrap">Changeset information</h5>
-        <h5 className="p-2 d-none d-md-block text-uppercase text-center text-nowrap">Check state</h5>
-        <h5 className="p-2 d-none d-md-block text-uppercase text-center text-nowrap">Review state</h5>
-        <h5 className="p-2 d-none d-md-block text-uppercase text-center text-nowrap">Changes</h5>
+        <H5 as={H3} className="p-2 d-none d-md-block text-uppercase text-center text-nowrap">
+            Status
+        </H5>
+        <H5 as={H3} className="p-2 d-none d-md-block text-uppercase text-nowrap">
+            Changeset information
+        </H5>
+        <H5 as={H3} className="p-2 d-none d-md-block text-uppercase text-center text-nowrap">
+            Check state
+        </H5>
+        <H5 as={H3} className="p-2 d-none d-md-block text-uppercase text-center text-nowrap">
+            Review state
+        </H5>
+        <H5 as={H3} className="p-2 d-none d-md-block text-uppercase text-center text-nowrap">
+            Changes
+        </H5>
     </>
 )

--- a/client/web/src/enterprise/batches/detail/changesets/ExternalChangesetNode.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/ExternalChangesetNode.tsx
@@ -81,6 +81,10 @@ export const ExternalChangesetNode: React.FunctionComponent<ExternalChangesetNod
         selectable?.onSelect(node.id)
     }, [selectable, node.id])
 
+    const tooltipLabel = viewerCanAdminister
+        ? 'Click to select changeset for bulk operation'
+        : 'You do not have permission to perform this operation'
+
     return (
         <>
             <Button
@@ -103,11 +107,8 @@ export const ExternalChangesetNode: React.FunctionComponent<ExternalChangesetNod
                         checked={selected}
                         onChange={toggleSelected}
                         disabled={!viewerCanAdminister}
-                        tooltip={
-                            viewerCanAdminister
-                                ? 'Click to select changeset for bulk operation'
-                                : 'You do not have permission to perform this operation'
-                        }
+                        tooltip={tooltipLabel}
+                        aria-label={tooltipLabel}
                     />
                 </div>
             ) : (

--- a/client/web/src/enterprise/batches/list/BatchChangeListPage.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangeListPage.tsx
@@ -7,7 +7,7 @@ import { dataOrThrowErrors, useQuery } from '@sourcegraph/http-client'
 import { Settings } from '@sourcegraph/shared/src/schema/settings.schema'
 import { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
-import { PageHeader, CardBody, Card, Link, Container } from '@sourcegraph/wildcard'
+import { PageHeader, CardBody, Card, Link, Container, H3, H2, H4 } from '@sourcegraph/wildcard'
 
 import { AuthenticatedUser } from '../../../auth'
 import { isBatchChangesExecutionEnabled } from '../../../batches'
@@ -153,9 +153,13 @@ export const BatchChangeListPage: React.FunctionComponent<BatchChangeListPagePro
                     <ConnectionContainer>
                         <div className={styles.filtersRow}>
                             {(licenseAndUsageInfo?.allBatchChanges.totalCount || 0) > 0 && (
-                                <h3 className="align-self-end flex-1">{lastTotalCount} batch changes</h3>
+                                <H3 as={H2} className="align-self-end flex-1">
+                                    {lastTotalCount} batch changes
+                                </H3>
                             )}
-                            <h4 className="mb-0 mr-2">Status</h4>
+                            <H4 as={H3} className="mb-0 mr-2">
+                                Status
+                            </H4>
                             <BatchChangeListFilters
                                 className="m-0"
                                 isExecutionEnabled={isExecutionEnabled}
@@ -165,6 +169,7 @@ export const BatchChangeListPage: React.FunctionComponent<BatchChangeListPagePro
                         </div>
                         {error && <ConnectionError errors={[error.message]} />}
                         <ConnectionList
+                            as="div"
                             className={classNames(styles.grid, isExecutionEnabled ? styles.wide : styles.narrow)}
                         >
                             {connection?.nodes?.map(node => (

--- a/client/web/src/enterprise/batches/list/BatchChangeNode.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangeNode.tsx
@@ -38,7 +38,15 @@ const StateBadge: React.FunctionComponent<{ state: BatchChangeState }> = ({ stat
     switch (state) {
         case BatchChangeState.OPEN:
             return (
-                <Badge variant="success" className={classNames(styles.batchChangeNodeBadge, 'text-uppercase')}>
+                /*
+                        a11y-ignore
+                        Rule: "color-contrast" (Elements must have sufficient color contrast)
+                        GitHub issue: https://github.com/sourcegraph/sourcegraph/issues/33343
+                    */
+                <Badge
+                    variant="success"
+                    className={classNames('a11y-ignore', styles.batchChangeNodeBadge, 'text-uppercase')}
+                >
                     Open
                 </Badge>
             )

--- a/client/web/src/enterprise/batches/preview/BatchChangePreviewPage.tsx
+++ b/client/web/src/enterprise/batches/preview/BatchChangePreviewPage.tsx
@@ -67,6 +67,7 @@ export const BatchChangePreviewPage: React.FunctionComponent<BatchChangePreviewP
                             {
                                 icon: BatchChangesIcon,
                                 to: '/batch-changes',
+                                ariaLabel: 'Batch changes',
                             },
                             { to: `${spec.namespace.url}/batch-changes`, text: spec.namespace.namespaceName },
                             { text: spec.description.name },

--- a/client/web/src/enterprise/batches/preview/list/PreviewListHeader.tsx
+++ b/client/web/src/enterprise/batches/preview/list/PreviewListHeader.tsx
@@ -1,5 +1,7 @@
 import React from 'react'
 
+import { H5, H3 } from '@sourcegraph/wildcard'
+
 import { InputTooltip } from '../../../../components/InputTooltip'
 
 export interface PreviewListHeaderProps {
@@ -25,13 +27,23 @@ export const PreviewListHeader: React.FunctionComponent<PreviewListHeaderProps> 
                 <span className="pl-2 d-block d-sm-none">Select all</span>
             </div>
         )}
-        <h5 className="p-2 d-none d-sm-block text-uppercase text-center">Current state</h5>
-        <h5 className="d-none d-sm-block text-uppercase text-center">
+        <H5 as={H3} className="p-2 d-none d-sm-block text-uppercase text-center">
+            Current state
+        </H5>
+        <H5 as={H3} className="d-none d-sm-block text-uppercase text-center">
             +<br />-
-        </h5>
-        <h5 className="p-2 d-none d-sm-block text-uppercase text-nowrap">Actions</h5>
-        <h5 className="p-2 d-none d-sm-block text-uppercase text-nowrap">Changeset information</h5>
-        <h5 className="p-2 d-none d-sm-block text-uppercase text-center text-nowrap">Commit changes</h5>
-        <h5 className="p-2 d-none d-sm-block text-uppercase text-center text-nowrap">Change state</h5>
+        </H5>
+        <H5 as={H3} className="p-2 d-none d-sm-block text-uppercase text-nowrap">
+            Actions
+        </H5>
+        <H5 as={H3} className="p-2 d-none d-sm-block text-uppercase text-nowrap">
+            Changeset information
+        </H5>
+        <H5 as={H3} className="p-2 d-none d-sm-block text-uppercase text-center text-nowrap">
+            Commit changes
+        </H5>
+        <H5 as={H3} className="p-2 d-none d-sm-block text-uppercase text-center text-nowrap">
+            Change state
+        </H5>
     </>
 )

--- a/client/web/src/enterprise/batches/preview/list/VisibleChangesetApplyPreviewNode.tsx
+++ b/client/web/src/enterprise/batches/preview/list/VisibleChangesetApplyPreviewNode.tsx
@@ -227,6 +227,7 @@ const SelectBox: React.FunctionComponent<{
             checked={selectable.isSelected(isPublishableResult.changesetSpecID)}
             onChange={toggleSelected}
             tooltip="Click to select changeset for bulk-modifying the publication state"
+            aria-label="Click to select changeset for bulk-modifying the publication state"
         />
     ) : (
         <InputTooltip
@@ -235,6 +236,7 @@ const SelectBox: React.FunctionComponent<{
             checked={false}
             disabled={true}
             tooltip={isPublishableResult.reason}
+            aria-label={isPublishableResult.reason}
         />
     )
 

--- a/client/web/src/enterprise/batches/settings/CodeHostConnectionNode.tsx
+++ b/client/web/src/enterprise/batches/settings/CodeHostConnectionNode.tsx
@@ -110,8 +110,13 @@ export const CodeHostConnectionNode: React.FunctionComponent<CodeHostConnectionN
                             </>
                         )}
                         {!isEnabled && (
+                            /*
+                                a11y-ignore
+                                Rule: "color-contrast" (Elements must have sufficient color contrast)
+                                GitHub issue: https://github.com/sourcegraph/sourcegraph/issues/33343
+                            */
                             <Button
-                                className="text-nowrap test-code-host-connection-node-btn-add"
+                                className="a11y-ignore text-nowrap test-code-host-connection-node-btn-add"
                                 onClick={onClickAdd}
                                 variant="success"
                             >

--- a/client/web/src/integration/batches.test.ts
+++ b/client/web/src/integration/batches.test.ts
@@ -328,7 +328,8 @@ function mockCommonGraphQLResponses(
                 closedAt: null,
                 createdAt: subDays(now, 5).toISOString(),
                 updatedAt: subDays(now, 5).toISOString(),
-                description: '### Very cool batch change',
+                // To fix accessibility rule: "heading-order"
+                description: '## Very cool batch change',
                 creator: {
                     url: '/users/alice',
                     username: 'alice',
@@ -500,6 +501,7 @@ describe('Batches', () => {
             )
 
             await percySnapshotWithVariants(driver.page, 'Batch Changes List')
+            await accessibilityAudit(driver.page)
         })
 
         it('lists user batch changes', async () => {
@@ -544,6 +546,7 @@ describe('Batches', () => {
         it('is styled correctly', async () => {
             await driver.page.goto(driver.sourcegraphBaseUrl + '/batch-changes/create')
             await percySnapshotWithVariants(driver.page, 'Create batch change')
+            await accessibilityAudit(driver.page)
         })
     })
 
@@ -565,6 +568,7 @@ describe('Batches', () => {
                 // View overview page.
                 await driver.page.waitForSelector('.test-batch-change-details-page')
                 await percySnapshotWithVariants(driver.page, 'Batch change details page')
+                await accessibilityAudit(driver.page)
 
                 // Expand one changeset.
                 await driver.page.click('.test-batches-expand-changeset')
@@ -814,6 +818,7 @@ describe('Batches', () => {
                 // View overview page.
                 await driver.page.waitForSelector('.test-batch-change-apply-page')
                 await percySnapshotWithVariants(driver.page, 'Batch change preview page')
+                await accessibilityAudit(driver.page)
 
                 // Expand one changeset.
                 await driver.page.click('.test-batches-expand-preview')
@@ -939,6 +944,7 @@ describe('Batches', () => {
             // View settings page.
             await driver.page.waitForSelector('.test-batches-settings-page')
             await percySnapshotWithVariants(driver.page, 'User batch changes settings page')
+            await accessibilityAudit(driver.page)
             // Wait for list to load.
             await driver.page.waitForSelector('.test-code-host-connection-node')
             // Check no credential is configured.


### PR DESCRIPTION
## Description

- Enabling accessibility audit on `batches` page in its integration test

## Refs

[SG Issue](https://github.com/sourcegraph/sourcegraph/issues/33093)
[Gitstart Ticket](https://app.gitstart.com/clients/sourcegraph/tickets/SG-33093)

## Test plan

Run the integration test `yarn test-integration:base client/web/src/integration/batches.test.ts`

## Success criteria

- All integration tests with percy snapshots have `accessibilityAudit` enabled


## App preview:

- [Link](https://sg-web-contractors-sg-33093-1-2.onrender.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

