### PR TITLE
ignore go workspace files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -170,3 +170,6 @@ annotations/
 
 # Buildkite analytics files
 test-reports/
+
+# go workspace files shouldn't be committed
+go.work


### PR DESCRIPTION
This is a new feature in go1.18 to simplify working on multiple modules. For example I can easily test sourcegraph with local changes to zoekt by running the command:

``` shell
go work init . ../../google/zoekt/
```

These files shouldn't be committed, as they are files that are specific to someones task.

Test Plan: my go.work file doesn't show up in git status

