### PR TITLE
[Repo Header] fix view on github inside dropdown

### DIFF
--- a/client/web/src/repo/RepoHeader.tsx
+++ b/client/web/src/repo/RepoHeader.tsx
@@ -251,7 +251,12 @@ export const RepoHeader: React.FunctionComponent<Props> = ({ onLifecyclePropsCha
                                 </RepoHeaderActionDropdownToggle>
                                 <MenuList position={Position.bottomEnd}>
                                     {rightActions.map((a, index) => (
-                                        <MenuItem className="p-0" key={a.id || index} onSelect={noop}>
+                                        <MenuItem
+                                            className="p-0"
+                                            key={a.id || index}
+                                            onSelect={noop}
+                                            onMouseUp={event => event.preventDefault()}
+                                        >
                                             {a.element}
                                         </MenuItem>
                                     ))}


### PR DESCRIPTION
This PR resolved the issue https://github.com/sourcegraph/sourcegraph/issues/33730

The links inside the dropdown in the repo header for small screen devices are not working.

Resolved the issue by calling `preventDefault` in the wrapping `MenuItem` div.

## Before
https://www.loom.com/share/ac84558af315428e8058f08ddd2f4acb

## Test plan
- Go to any file in the cloud using Safari with a viewport width < 990px
- Open the right-side options menu beside the file path
- Click "View on GitHub". The link should open in a new tab.


## App preview:

- [Link](https://sg-web-naman-fix-repo-header-dropdown.onrender.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

