### PR TITLE
web: Start upgrade to React Router v6

### DIFF
--- a/client/web/src/SourcegraphWebApp.tsx
+++ b/client/web/src/SourcegraphWebApp.tsx
@@ -7,6 +7,7 @@ import { ShortcutProvider } from '@slimsag/react-shortcuts'
 import { createBrowserHistory } from 'history'
 import ServerIcon from 'mdi-react/ServerIcon'
 import { Route, Router } from 'react-router'
+import { CompatRouter } from 'react-router-dom-v5-compat'
 import { ScrollManager } from 'react-scroll-manager'
 import { combineLatest, from, Subscription, fromEvent, of, Subject } from 'rxjs'
 import { catchError, distinctUntilChanged, map, startWith, switchMap } from 'rxjs/operators'
@@ -406,78 +407,84 @@ export class SourcegraphWebApp extends React.Component<SourcegraphWebAppProps, S
                                     <SearchQueryStateStoreProvider useSearchQueryState={useNavbarQueryState}>
                                         <ScrollManager history={history}>
                                             <Router history={history} key={0}>
-                                                <OverrideFeatureFlagsAgent />
-                                                <Route
-                                                    path="/"
-                                                    render={routeComponentProps => (
-                                                        <CodeHostScopeProvider authenticatedUser={authenticatedUser}>
-                                                            <LayoutWithActivation
-                                                                {...props}
-                                                                {...routeComponentProps}
+                                                <CompatRouter>
+                                                    <OverrideFeatureFlagsAgent />
+                                                    <Route
+                                                        path="/"
+                                                        render={routeComponentProps => (
+                                                            <CodeHostScopeProvider
                                                                 authenticatedUser={authenticatedUser}
-                                                                viewerSubject={this.state.viewerSubject}
-                                                                settingsCascade={this.state.settingsCascade}
-                                                                batchChangesEnabled={this.props.batchChangesEnabled}
-                                                                batchChangesExecutionEnabled={isBatchChangesExecutionEnabled(
-                                                                    this.state.settingsCascade
-                                                                )}
-                                                                batchChangesWebhookLogsEnabled={
-                                                                    window.context.batchChangesWebhookLogsEnabled
-                                                                }
-                                                                // Search query
-                                                                fetchHighlightedFileLineRanges={
-                                                                    fetchHighlightedFileLineRanges
-                                                                }
-                                                                // Extensions
-                                                                platformContext={this.platformContext}
-                                                                extensionsController={this.extensionsController}
-                                                                telemetryService={eventLogger}
-                                                                isSourcegraphDotCom={
-                                                                    window.context.sourcegraphDotComMode
-                                                                }
-                                                                searchContextsEnabled={this.props.searchContextsEnabled}
-                                                                hasUserAddedRepositories={this.hasUserAddedRepositories()}
-                                                                hasUserAddedExternalServices={
-                                                                    this.state.hasUserAddedExternalServices
-                                                                }
-                                                                selectedSearchContextSpec={this.getSelectedSearchContextSpec()}
-                                                                setSelectedSearchContextSpec={
-                                                                    this.setSelectedSearchContextSpec
-                                                                }
-                                                                getUserSearchContextNamespaces={
-                                                                    getUserSearchContextNamespaces
-                                                                }
-                                                                fetchAutoDefinedSearchContexts={
-                                                                    fetchAutoDefinedSearchContexts
-                                                                }
-                                                                fetchSearchContexts={fetchSearchContexts}
-                                                                fetchSearchContextBySpec={fetchSearchContextBySpec}
-                                                                fetchSearchContext={fetchSearchContext}
-                                                                createSearchContext={createSearchContext}
-                                                                updateSearchContext={updateSearchContext}
-                                                                deleteSearchContext={deleteSearchContext}
-                                                                isSearchContextSpecAvailable={
-                                                                    isSearchContextSpecAvailable
-                                                                }
-                                                                defaultSearchContextSpec={
-                                                                    this.state.defaultSearchContextSpec
-                                                                }
-                                                                globbing={this.state.globbing}
-                                                                streamSearch={aggregateStreamingSearch}
-                                                                onUserExternalServicesOrRepositoriesUpdate={
-                                                                    this.onUserExternalServicesOrRepositoriesUpdate
-                                                                }
-                                                                onSyncedPublicRepositoriesUpdate={
-                                                                    this.onSyncedPublicRepositoriesUpdate
-                                                                }
-                                                                featureFlags={this.state.featureFlags}
-                                                            />
-                                                        </CodeHostScopeProvider>
-                                                    )}
-                                                />
-                                                <SearchStack onCreateNotebook={this.onCreateNotebook} />
-                                                <IdeExtensionTracker />
-                                                <BrowserExtensionTracker />
+                                                            >
+                                                                <LayoutWithActivation
+                                                                    {...props}
+                                                                    {...routeComponentProps}
+                                                                    authenticatedUser={authenticatedUser}
+                                                                    viewerSubject={this.state.viewerSubject}
+                                                                    settingsCascade={this.state.settingsCascade}
+                                                                    batchChangesEnabled={this.props.batchChangesEnabled}
+                                                                    batchChangesExecutionEnabled={isBatchChangesExecutionEnabled(
+                                                                        this.state.settingsCascade
+                                                                    )}
+                                                                    batchChangesWebhookLogsEnabled={
+                                                                        window.context.batchChangesWebhookLogsEnabled
+                                                                    }
+                                                                    // Search query
+                                                                    fetchHighlightedFileLineRanges={
+                                                                        fetchHighlightedFileLineRanges
+                                                                    }
+                                                                    // Extensions
+                                                                    platformContext={this.platformContext}
+                                                                    extensionsController={this.extensionsController}
+                                                                    telemetryService={eventLogger}
+                                                                    isSourcegraphDotCom={
+                                                                        window.context.sourcegraphDotComMode
+                                                                    }
+                                                                    searchContextsEnabled={
+                                                                        this.props.searchContextsEnabled
+                                                                    }
+                                                                    hasUserAddedRepositories={this.hasUserAddedRepositories()}
+                                                                    hasUserAddedExternalServices={
+                                                                        this.state.hasUserAddedExternalServices
+                                                                    }
+                                                                    selectedSearchContextSpec={this.getSelectedSearchContextSpec()}
+                                                                    setSelectedSearchContextSpec={
+                                                                        this.setSelectedSearchContextSpec
+                                                                    }
+                                                                    getUserSearchContextNamespaces={
+                                                                        getUserSearchContextNamespaces
+                                                                    }
+                                                                    fetchAutoDefinedSearchContexts={
+                                                                        fetchAutoDefinedSearchContexts
+                                                                    }
+                                                                    fetchSearchContexts={fetchSearchContexts}
+                                                                    fetchSearchContextBySpec={fetchSearchContextBySpec}
+                                                                    fetchSearchContext={fetchSearchContext}
+                                                                    createSearchContext={createSearchContext}
+                                                                    updateSearchContext={updateSearchContext}
+                                                                    deleteSearchContext={deleteSearchContext}
+                                                                    isSearchContextSpecAvailable={
+                                                                        isSearchContextSpecAvailable
+                                                                    }
+                                                                    defaultSearchContextSpec={
+                                                                        this.state.defaultSearchContextSpec
+                                                                    }
+                                                                    globbing={this.state.globbing}
+                                                                    streamSearch={aggregateStreamingSearch}
+                                                                    onUserExternalServicesOrRepositoriesUpdate={
+                                                                        this.onUserExternalServicesOrRepositoriesUpdate
+                                                                    }
+                                                                    onSyncedPublicRepositoriesUpdate={
+                                                                        this.onSyncedPublicRepositoriesUpdate
+                                                                    }
+                                                                    featureFlags={this.state.featureFlags}
+                                                                />
+                                                            </CodeHostScopeProvider>
+                                                        )}
+                                                    />
+                                                    <SearchStack onCreateNotebook={this.onCreateNotebook} />
+                                                    <IdeExtensionTracker />
+                                                    <BrowserExtensionTracker />
+                                                </CompatRouter>
                                             </Router>
                                         </ScrollManager>
                                         <Tooltip key={1} />

--- a/client/web/src/enterprise/embed/EmbeddedWebApp.tsx
+++ b/client/web/src/enterprise/embed/EmbeddedWebApp.tsx
@@ -1,6 +1,7 @@
 import React, { Suspense, useEffect } from 'react'
 
 import { BrowserRouter, Route, RouteComponentProps, Switch } from 'react-router-dom'
+import { CompatRouter } from 'react-router-dom-v5-compat'
 
 import { lazyComponent } from '@sourcegraph/shared/src/util/lazyComponent'
 import { Alert, LoadingSpinner, setLinkComponent, WildcardTheme, WildcardThemeContext } from '@sourcegraph/wildcard'
@@ -55,42 +56,44 @@ export const EmbeddedWebApp: React.FunctionComponent = () => {
     // IMPORTANT: Please consult with the security team if you are unsure whether your changes could introduce security exploits.
     return (
         <BrowserRouter>
-            <WildcardThemeContext.Provider value={WILDCARD_THEME}>
-                <div className={styles.body}>
-                    <Suspense
-                        fallback={
-                            <div className="d-flex justify-content-center p-3">
-                                <LoadingSpinner />
-                            </div>
-                        }
-                    >
-                        <Switch>
-                            <Route
-                                path="/embed/notebooks/:notebookId"
-                                render={(props: RouteComponentProps<{ notebookId: string }>) => (
-                                    <EmbeddedNotebookPage
-                                        notebookId={props.match.params.notebookId}
-                                        searchContextsEnabled={true}
-                                        showSearchContext={true}
-                                        isSourcegraphDotCom={window.context.sourcegraphDotComMode}
-                                        authenticatedUser={null}
-                                        isLightTheme={isLightTheme}
-                                        settingsCascade={EMPTY_SETTINGS_CASCADE}
-                                    />
-                                )}
-                            />
-                            <Route
-                                path="*"
-                                render={() => (
-                                    <Alert variant="danger">
-                                        Invalid embedding route, please check the embedding URL.
-                                    </Alert>
-                                )}
-                            />
-                        </Switch>
-                    </Suspense>
-                </div>
-            </WildcardThemeContext.Provider>
+            <CompatRouter>
+                <WildcardThemeContext.Provider value={WILDCARD_THEME}>
+                    <div className={styles.body}>
+                        <Suspense
+                            fallback={
+                                <div className="d-flex justify-content-center p-3">
+                                    <LoadingSpinner />
+                                </div>
+                            }
+                        >
+                            <Switch>
+                                <Route
+                                    path="/embed/notebooks/:notebookId"
+                                    render={(props: RouteComponentProps<{ notebookId: string }>) => (
+                                        <EmbeddedNotebookPage
+                                            notebookId={props.match.params.notebookId}
+                                            searchContextsEnabled={true}
+                                            showSearchContext={true}
+                                            isSourcegraphDotCom={window.context.sourcegraphDotComMode}
+                                            authenticatedUser={null}
+                                            isLightTheme={isLightTheme}
+                                            settingsCascade={EMPTY_SETTINGS_CASCADE}
+                                        />
+                                    )}
+                                />
+                                <Route
+                                    path="*"
+                                    render={() => (
+                                        <Alert variant="danger">
+                                            Invalid embedding route, please check the embedding URL.
+                                        </Alert>
+                                    )}
+                                />
+                            </Switch>
+                        </Suspense>
+                    </div>
+                </WildcardThemeContext.Provider>
+            </CompatRouter>
         </BrowserRouter>
     )
 }

--- a/package.json
+++ b/package.json
@@ -421,6 +421,7 @@
     "react-grid-layout": "1.3.0",
     "react-router": "^5.2.0",
     "react-router-dom": "^5.2.0",
+    "react-router-dom-v5-compat": "^6.3.0",
     "react-scroll-manager": "^1.0.3",
     "react-select": "^5.2.2",
     "react-spring": "^9.4.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14166,7 +14166,7 @@ highlightjs-graphql@^1.0.2:
   resolved "https://registry.npmjs.org/highlightjs-graphql/-/highlightjs-graphql-1.0.2.tgz#841e26831e7da9f0a3d66f93e6ff98a0d1ad6f43"
   integrity sha512-jShTftpKQDwMXc+7OHOpHXRYSweT08EO2YOIcLbwU00e9yuwJMYXGLF1eiDO0aUPeQU4/5EjAh5HtPt3ly7rvg==
 
-history@4.5.1, history@^4.9.0:
+history@4.5.1, history@^4.9.0, history@^5.2.0, history@^5.3.0:
   version "4.5.1"
   resolved "https://registry.npmjs.org/history/-/history-4.5.1.tgz#44935a51021e3b8e67ebac267a35675732aba569"
   integrity sha1-RJNaUQIeO45n66wmejVnVzKrpWk=
@@ -20574,6 +20574,14 @@ react-resize-detector@^2.3.0:
     prop-types "^15.6.0"
     resize-observer-polyfill "^1.5.0"
 
+react-router-dom-v5-compat@^6.3.0:
+  version "6.3.0"
+  resolved "https://registry.npmjs.org/react-router-dom-v5-compat/-/react-router-dom-v5-compat-6.3.0.tgz#a6b1bf18a42e3c1b902711931c4b496920740815"
+  integrity sha512-lfnfDEAdfXf92VQQ692+aMFj9JKb73GZ7EbiQJeJT4sK+KUGvua3FGN2H8n2H5zSMaY1cvrihGiaI373cvv7OQ==
+  dependencies:
+    history "^5.3.0"
+    react-router "6.3.0"
+
 react-router-dom@^5.2.0:
   version "5.2.0"
   resolved "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.2.0.tgz#9e65a4d0c45e13289e66c7b17c7e175d0ea15662"
@@ -20602,6 +20610,13 @@ react-router@5.2.0, react-router@^5.2.0:
     react-is "^16.6.0"
     tiny-invariant "^1.0.2"
     tiny-warning "^1.0.0"
+
+react-router@6.3.0:
+  version "6.3.0"
+  resolved "https://registry.npmjs.org/react-router/-/react-router-6.3.0.tgz#3970cc64b4cb4eae0c1ea5203a80334fdd175557"
+  integrity sha512-7Wh1DzVQ+tlFjkeo+ujvjSqSJmkt1+8JO+T5xklPlgrh70y7ogx75ODRW0ThWhY7S+6yEDks8TYrtQe/aoboBQ==
+  dependencies:
+    history "^5.2.0"
 
 react-scroll-manager@^1.0.3:
   version "1.0.3"


### PR DESCRIPTION
## Description

React Router V6 is out, and they have just published a [migration plan](https://github.com/remix-run/react-router/discussions/8753).

This PR is following the "Setting up" stage of the migration plan, which will allow us to start using the V6 router and incrementally upgrade the rest of our app.

Migration will be tackled in this issue: https://github.com/sourcegraph/sourcegraph/issues/33834

## Test plan
- Run the app locally
- Integration tests



## App preview:

- [Link](https://sg-web-tr-react-router-upgrade.onrender.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

