### PR TITLE
github: Log more detail when we exceed our internal rate limiter

### DIFF
--- a/internal/extsvc/github/v3.go
+++ b/internal/extsvc/github/v3.go
@@ -215,6 +215,7 @@ func (c *V3Client) request(ctx context.Context, req *http.Request, result interf
 			return nil, ctx.Err()
 		}
 
+		log15.Warn("internal rate limiter error", "error", err, "urn", c.urn)
 		return nil, errInternalRateLimitExceeded
 	}
 


### PR DESCRIPTION
We're seeing a number of production logs indicating that we're exceeding
our internal rate limiter. Logging more information to aid debugging.
