### PR TITLE
go modules proxy: raise self-enforced API rate limit

### DIFF
--- a/schema/go-modules.schema.json
+++ b/schema/go-modules.schema.json
@@ -31,13 +31,13 @@
         "requestsPerHour": {
           "description": "Requests per hour permitted. This is an average, calculated per second. Internally, the burst limit is set to 100, which implies that for a requests per hour limit as low as 1, users will continue to be able to send a maximum of 100 requests immediately, provided that the complexity cost of each request is 1.",
           "type": "number",
-          "default": 3000,
+          "default": 6000,
           "minimum": 0
         }
       },
       "default": {
         "enabled": true,
-        "requestsPerHour": 3000
+        "requestsPerHour": 6000
       }
     },
     "dependencies": {


### PR DESCRIPTION
We are hitting the self-enforced rate limit. The logs suggest that
doubling should fix it.

For comparison:
JVM-packages: 5000 req/h
NPM-packages: 3000 req/h

## Test plan
CI

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


