### PR TITLE
migration: Fix flaky TestIndexStatus

### DIFF
--- a/dev/ci/go-backcompat/flakefiles/v3.38.0.json
+++ b/dev/ci/go-backcompat/flakefiles/v3.38.0.json
@@ -17,6 +17,6 @@
   {
     "path": "internal/database/migration/store",
     "prefix": "TestIndexStatus",
-    "reason": "Flaky condition reported in https://github.com/sourcegraph/sourcegraph/issues/33837, fixed in TODO."
+    "reason": "Flaky condition reported in https://github.com/sourcegraph/sourcegraph/issues/33837, fixed in https://github.com/sourcegraph/sourcegraph/pull/33843."
   }
 ]

--- a/dev/ci/go-backcompat/flakefiles/v3.38.0.json
+++ b/dev/ci/go-backcompat/flakefiles/v3.38.0.json
@@ -13,5 +13,10 @@
     "path": "internal/database",
     "prefix": "TestUsers_CheckAndDecrementInviteQuota",
     "reason": "Test is written in a bad way (depends on default value definition, but does not affect backwards compatibility) in https://github.com/sourcegraph/sourcegraph/pull/33786."
+  },
+  {
+    "path": "internal/database/migration/store",
+    "prefix": "TestIndexStatus",
+    "reason": "Flaky condition reported in https://github.com/sourcegraph/sourcegraph/issues/33837, fixed in TODO."
   }
 ]

--- a/internal/database/migration/store/store_test.go
+++ b/internal/database/migration/store/store_test.go
@@ -495,11 +495,6 @@ func TestIndexStatus(t *testing.T) {
 		return err
 	})
 
-	// Wait until we can see Session C's lock before querying index status
-	if err := whileEmpty(ctx, db, "SELECT 1 FROM pg_locks WHERE locktype = 'relation' AND mode = 'ShareUpdateExclusiveLock'"); err != nil {
-		t.Fatalf("unexpected error: %s", err)
-	}
-
 	// "waiting for old snapshots" will be the phase that is blocked by the concurrent
 	// sessions holding advisory locks. We may happen to hit one of the earlier phases
 	// if we're quick enough, so we'll keep polling progress until we hit the target.
@@ -516,12 +511,22 @@ func TestIndexStatus(t *testing.T) {
 		return value == prefix || strings.HasPrefix(value, prefix+":")
 	}
 
+	start := time.Now()
+	const missingIndexThreshold = time.Millisecond * 500
+
 retryLoop:
 	for {
 		if status, ok, err := store.IndexStatus(ctx, "tbl", "idx"); err != nil {
 			t.Fatalf("unexpected error: %s", err)
 		} else if !ok {
-			t.Fatalf("expected index status")
+			// Give a small amount of time for Session C to begin creating the index. Signaling
+			// when Postgres has started to create teh index is as detailed as checking the status,
+			// so weo resort to polling here for a short time.
+			if time.Since(start) < missingIndexThreshold {
+				continue
+			}
+
+			t.Fatalf("expected index status after %s", missingIndexThreshold)
 		} else if status.Phase == nil {
 			t.Fatalf("unexpected phase. want=%q have=nil", blockingPhase)
 		} else if *status.Phase == blockingPhase {

--- a/internal/database/migration/store/store_test.go
+++ b/internal/database/migration/store/store_test.go
@@ -520,8 +520,8 @@ retryLoop:
 			t.Fatalf("unexpected error: %s", err)
 		} else if !ok {
 			// Give a small amount of time for Session C to begin creating the index. Signaling
-			// when Postgres has started to create teh index is as detailed as checking the status,
-			// so weo resort to polling here for a short time.
+			// when Postgres has started to create the index is as difficult and expensive as
+			// querying the index the status, so we just poll here for a short time.
 			if time.Since(start) < missingIndexThreshold {
 				continue
 			}

--- a/internal/database/migration/store/store_test.go
+++ b/internal/database/migration/store/store_test.go
@@ -512,7 +512,7 @@ func TestIndexStatus(t *testing.T) {
 	}
 
 	start := time.Now()
-	const missingIndexThreshold = time.Millisecond * 500
+	const missingIndexThreshold = time.Second
 
 retryLoop:
 	for {
@@ -522,7 +522,8 @@ retryLoop:
 			// Give a small amount of time for Session C to begin creating the index. Signaling
 			// when Postgres has started to create the index is as difficult and expensive as
 			// querying the index the status, so we just poll here for a short time.
-			if time.Since(start) < missingIndexThreshold {
+			if remaining := time.Since(start) - missingIndexThreshold; remaining > 0 {
+				time.Sleep(time.Millisecond)
 				continue
 			}
 


### PR DESCRIPTION
Fixes #33837. This PR disables a the flaky test in affected db-backcompat tests, and fixes the test's flakiness by polling an index status for up to one second instead of checking for an exclusive lock in postgres system tables. Apparently there is a race between a postgres backend acquiring that lock and checking for index creation status details.

## Test plan

N/A.
