### PR TITLE
SG: add protoc dependencies to sg setup

### DIFF
--- a/dev/sg/sg_setup_mac.go
+++ b/dev/sg/sg_setup_mac.go
@@ -186,6 +186,24 @@ asdf plugin-add rust https://github.com/asdf-community/asdf-rust.git
 asdf install rust
 `,
 			},
+			{
+				name:                 "protoc",
+				check:                check.InPath("protoc"),
+				instructionsComment:  `Souregraph requires protoc to be installed.`,
+				instructionsCommands: `brew install protoc`,
+			},
+			{
+				name:                 "protoc-gen-go",
+				check:                check.InPath("protoc-gen-go"),
+				instructionsComment:  `Souregraph requires protoc-gen-go to be installed.`,
+				instructionsCommands: `go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.28`,
+			},
+			{
+				name:                 "protoc-gen-go-grpc",
+				check:                check.InPath("protoc-gen-go-grpc"),
+				instructionsComment:  `Souregraph requires protoc-gen-go-grpc to be installed.`,
+				instructionsCommands: `go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.2`,
+			},
 		},
 	},
 	{

--- a/dev/sg/sg_setup_ubuntu.go
+++ b/dev/sg/sg_setup_ubuntu.go
@@ -199,6 +199,24 @@ asdf plugin-add rust https://github.com/asdf-community/asdf-rust.git
 asdf install rust
 `,
 			},
+			{
+				name:                 "protoc",
+				check:                check.InPath("protoc"),
+				instructionsComment:  `Souregraph requires protoc to be installed.`,
+				instructionsCommands: `apt install -y protobuf-compiler`,
+			},
+			{
+				name:                 "protoc-gen-go",
+				check:                check.InPath("protoc-gen-go"),
+				instructionsComment:  `Souregraph requires protoc-gen-go to be installed.`,
+				instructionsCommands: `go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.28`,
+			},
+			{
+				name:                 "protoc-gen-go-grpc",
+				check:                check.InPath("protoc-gen-go-grpc"),
+				instructionsComment:  `Souregraph requires protoc-gen-go-grpc to be installed.`,
+				instructionsCommands: `go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.2`,
+			},
 		},
 	},
 	{


### PR DESCRIPTION
This adds protoc, protoc-gen-go, and protoc-gen-go-grpc to the list of
sg setup dependencies. They are not used yet, but will be required once
we have generated gRPC files.

Dependencies are as documented [here](https://grpc.io/docs/languages/go/quickstart/).
I've tested that these are the minimum set of dependencies needed to generate gRPC
services from `.proto` files.

## Test plan

Manually tested that the checks and auto-fix work on my MacOS machine.

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


