### PR TITLE
ci: remove codeinsights db vestigial from go-test script

### DIFF
--- a/dev/ci/go-test.sh
+++ b/dev/ci/go-test.sh
@@ -83,10 +83,17 @@ asdf reshim golang
 echo "--- comby install"
 ./dev/comby-install-or-upgrade.sh
 
-# For code insights test
-./dev/codeinsights-db.sh &
-export CODEINSIGHTS_PGDATASOURCE=postgres://postgres:password@127.0.0.1:5435/postgres
-export DB_STARTUP_TIMEOUT=360s # codeinsights-db needs more time to start in some instances.
+# Temporary fix to keep the backcompat test operational until the next release.
+# This is needed because the go-test.sh is protected and the backcompat tests are 
+# not checking out the old version when the tests with the old code against the latest
+# commit database schema.
+# TODO @jhchabran remove this when we release the next version.
+if [ "v3.38.0" == "$(git describe --tags)" ];then
+  # For code insights test
+  ./dev/codeinsights-db.sh &
+  export CODEINSIGHTS_PGDATASOURCE=postgres://postgres:password@127.0.0.1:5435/postgres
+  export DB_STARTUP_TIMEOUT=360s # codeinsights-db needs more time to start in some instances.
+fi
 
 # Disable GraphQL logs which are wildly noisy
 export NO_GRAPHQL_LOG=true


### PR DESCRIPTION
The codeinsights DB has been recently rolled back into the main DB, and we don't need to fire it up anymore. 

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

main-dry-run build with the back compat test green. 

