### PR TITLE
dev/ci: only asdf install go in pipeline gen

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -23,11 +23,13 @@ mkdir -p ./annotations/
 
 # asdf setup
 # ----------
+echo "~~~ Preparing asdf dependencies"
+
 if [[ "$BUILDKITE_STEP_KEY" == "pipeline-gen" ]]; then
-  echo "running go install only"
+  echo "pipeline-gen step: running go install only"
   asdf install golang
 elif [[ "$BUILDKITE_STEP_KEY" == "pipeline-upload" ]]; then
-  echo "skipping asdf install for pipeline upload step"
+  echo "pipeline-upload step: skipping asdf install"
 else
   echo "running normal install"
   ./dev/ci/asdf-install.sh

--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -23,8 +23,12 @@ mkdir -p ./annotations/
 
 # asdf setup
 # ----------
-if [[ ! "$BUILDKITE_STEP_KEY" == "pipeline-upload" ]]; then
-  ./dev/ci/asdf-install.sh
+if [[ "$BUILDKITE_STEP_KEY" == "pipeline-gen" ]]; then
+  echo "running go install only"
+  asdf install golang
+elif [[ "$BUILDKITE_STEP_KEY" == "pipeline-upload" ]]; then
+  echo "skipping asdf install for pipeline upload step"
 else
-  echo "skipping asdf install for pipeline upload setp"
+  echo "running normal install"
+  ./dev/ci/asdf-install.sh
 fi

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -11,6 +11,7 @@ steps:
   - group: "Pipeline setup"
     steps:
       - label: ':hammer_and_wrench: :pipeline: Generate pipeline'
+        key: 'pipeline-gen'
         agents: { queue: standard }
         # Prioritize generating pipelines so that jobs can get generated and queued up as soon
         # as possible, so as to better assess pipeline load e.g. to scale the Buildkite fleet.

--- a/dev/ci/asdf-install.sh
+++ b/dev/ci/asdf-install.sh
@@ -5,13 +5,13 @@
 # In most cases you should not need to call this script directly.
 if [[ ! "$BUILDKITE" == "true" ]]; then
   # Not-in-buildkite simple install.
-  echo "~~~ asdf install"
+  echo "asdf install"
   asdf install
   echo "done installing"
   # We can't use exit 0 here, it would prevent the variables to be exported (that's a particular buildkite hook peculiarity).
 else
   # We need awscli to use asdf cache
-  echo "~~~ asdf install from cache"
+  echo "asdf install from cache"
   asdf install awscli
   echo "done installing awscli"
 

--- a/dev/ci/go-backcompat/test.sh
+++ b/dev/ci/go-backcompat/test.sh
@@ -132,8 +132,10 @@ fi
 
 # Re-run asdf to ensure we have the correct set of utilities to
 # run the currently checked out version of the Go unit tests.
+echo "--- asdf install checked out tools"
 ./dev/ci/asdf-install.sh
 
+echo "--- run tests"
 if ! ./dev/ci/go-test.sh "$@"; then
   annotation=$(
     cat <<EOF


### PR DESCRIPTION
Cuts the pipeline generation step from ~60s to ~25s - doing a fresh `asdf install golang` seems significantly faster than using the asdf tools cache.

Opened a related idea: https://github.com/sourcegraph/sourcegraph/issues/33854

Together with https://github.com/sourcegraph/sourcegraph/pull/33821 , this significantly reduces the time it takes for builds to get to the "actually running" state (~120s -> ~50s)

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

https://buildkite.com/sourcegraph/sourcegraph/builds/142131
