### PR TITLE
dev/ci: recurse over nested pipelines to generate step keys

### DIFF
--- a/enterprise/dev/ci/internal/ci/pipeline.go
+++ b/enterprise/dev/ci/internal/ci/pipeline.go
@@ -273,7 +273,7 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 	ops.Apply(pipeline)
 
 	// Validate generated pipeline have unique keys
-	if err := pipeline.EnsureUniqueKeys(); err != nil {
+	if err := pipeline.EnsureUniqueKeys(make(map[string]int)); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/33227

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

pipeline generates and runs

```
go run ./enterprise/dev/ci/gen-pipeline.go -yaml | grep key
  key: Lintersandstaticanalysis
    key: lipstickPrettier
        key: cache-node_modules-{{ checksum 'yarn.lock' }}
        restore_keys:
    key: clipboardMisclinters
        key: cache-node_modules-{{ checksum 'yarn.lock' }}
        restore_keys:
  key: Gochecks
    key: goTestall
    key: goTestenterpriseinternalcodeintelstoresdbstore
    key: goTestenterpriseinternalcodeintelstoreslsifstore
    key: goTestenterpriseinternalinsights
    key: goTestinternaldatabase
    key: goTestinternalrepos
    key: goTestenterpriseinternalbatches
    key: goTestcmdfrontend
    key: goTestenterpriseinternaldatabase
    key: goTestenterprisecmdfrontendinternalbatchesresolvers
    key: goBuild
  key: arrowheadingupUploadbuildtrace
```