### PR TITLE
dev/sg: improve update clarity, fix changelog

### DIFF
--- a/dev/sg/main.go
+++ b/dev/sg/main.go
@@ -108,7 +108,7 @@ var sg = &cli.App{
 			// If we're not running "sg update ...", we want to check the version first
 			err := checkSgVersionAndUpdate(cmd.Context, cmd.Bool("skip-auto-update"))
 			if err != nil {
-				writeWarningLinef("Checking sg version and updating failed: %s", err)
+				writeWarningLinef("update check: %s", err)
 				// Do not exit here, so we don't break user flow when they want to
 				// run `sg` but updating fails
 			}

--- a/dev/sg/main.go
+++ b/dev/sg/main.go
@@ -46,7 +46,6 @@ var (
 	// Note that these values are only available after the main sg CLI app has been run.
 	configFlag          string
 	overwriteConfigFlag string
-	skipAutoUpdatesFlag bool
 
 	// Global verbose mode
 	verbose bool
@@ -88,11 +87,10 @@ var sg = &cli.App{
 			Destination: &overwriteConfigFlag,
 		},
 		&cli.BoolFlag{
-			Name:        "skip-auto-update",
-			Usage:       "prevent sg from automatically updating itself",
-			EnvVars:     []string{"SG_SKIP_AUTO_UPDATE"},
-			Value:       BuildCommit == "dev", // Default to skip in dev, otherwise don't
-			Destination: &skipAutoUpdatesFlag,
+			Name:    "skip-auto-update",
+			Usage:   "prevent sg from automatically updating itself",
+			EnvVars: []string{"SG_SKIP_AUTO_UPDATE"},
+			Value:   BuildCommit == "dev", // Default to skip in dev, otherwise don't
 		},
 	},
 	Before: func(cmd *cli.Context) error {
@@ -108,7 +106,7 @@ var sg = &cli.App{
 
 		if cmd.Args().First() != "update" {
 			// If we're not running "sg update ...", we want to check the version first
-			err := checkSgVersion(cmd.Context)
+			err := checkSgVersionAndUpdate(cmd.Context, cmd.Bool("skip-auto-update"))
 			if err != nil {
 				writeWarningLinef("Checking sg version and updating failed: %s", err)
 				// Do not exit here, so we don't break user flow when they want to

--- a/dev/sg/sg_update.go
+++ b/dev/sg/sg_update.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/urfave/cli/v2"
 
+	"github.com/sourcegraph/sourcegraph/dev/sg/internal/stdout"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
@@ -24,8 +25,12 @@ var updateCommand = &cli.Command{
 Requires a local copy of the 'sourcegraph/sourcegraph' codebase.`,
 	Category: CategoryUtil,
 	Action: func(cmd *cli.Context) error {
-		_, err := updateToPrebuiltSG(cmd.Context)
-		return err
+		if _, err := updateToPrebuiltSG(cmd.Context); err != nil {
+			return err
+		}
+		writeSuccessLinef("sg has been updated!")
+		stdout.Out.Write("To see what's new, run 'sg version changelog'.")
+		return nil
 	},
 }
 


### PR DESCRIPTION
1. Improve messages when updating sg (both auto update and manual update)
2. Remove global auto update variable (this is only used in one place)
3. Fix changelog command (broken because I forgot to set a default value on the new flag)

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->
manually tested `sg version c`, `sg update`

