### PR TITLE
docker:prometheus change ownership of prometheus config files

### DIFF
--- a/docker-images/prometheus/Dockerfile
+++ b/docker-images/prometheus/Dockerfile
@@ -75,6 +75,8 @@ COPY config/*_rules.yml /sg_config_prometheus/
 COPY config/prometheus.yml /sg_config_prometheus/
 COPY config/alertmanager.yml /sg_config_prometheus/
 
+RUN chown -R sourcegraph:sourcegraph /sg_config_prometheus
+
 ENTRYPOINT ["/bin/prom-wrapper"]
 # Note that upstream's 'VOLUME' directive was deliberately removed. Including it makes it impossible
 # to chmod the directory to our 'sourcegraph' user.


### PR DESCRIPTION

## Test plan
Testing on local development K8S cluster with helm and kustomize deployments

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


