### PR TITLE
codeintel: Make lack of indexers actionable to users

### DIFF
--- a/client/web/src/enterprise/codeintel/RepositoryMenu.module.scss
+++ b/client/web/src/enterprise/codeintel/RepositoryMenu.module.scss
@@ -1,3 +1,9 @@
 .badge-multiple {
     min-width: 7rem;
 }
+
+.language-request{
+font-weight: normal;}
+
+
+

--- a/client/web/src/enterprise/codeintel/RepositoryMenu.module.scss
+++ b/client/web/src/enterprise/codeintel/RepositoryMenu.module.scss
@@ -2,8 +2,6 @@
     min-width: 7rem;
 }
 
-.language-request{
-font-weight: normal;}
-
-
-
+.language-request {
+    font-weight: normal;
+}

--- a/client/web/src/enterprise/codeintel/RepositoryMenu.story.tsx
+++ b/client/web/src/enterprise/codeintel/RepositoryMenu.story.tsx
@@ -9,6 +9,7 @@ import {
     LsifUploadFields,
     LSIFUploadState,
     PreciseSupportLevel,
+    SearchBasedSupportLevel,
 } from '../../graphql-operations'
 
 import { RepositoryMenuContent } from './RepositoryMenu'
@@ -204,12 +205,12 @@ const multiplePreciseSupport = [
     },
 ]
 
-// const searchBasedSupport = [
-//     {
-//         language: 'Perl',
-//         supportLevel: SearchBasedSupportLevel.BASIC,
-//     },
-// ]
+const searchBasedSupport = [
+    {
+        language: 'Perl',
+        supportLevel: SearchBasedSupportLevel.BASIC,
+    },
+]
 
 const emptyPayload: UseCodeIntelStatusPayload = {
     activeUploads: [],
@@ -239,7 +240,11 @@ const withPayload = (payload: Partial<UseCodeIntelStatusPayload>): typeof defaul
     useCodeIntelStatus: () => ({ data: { ...emptyPayload, ...payload }, loading: false }),
 })
 
-add('Unavailable', () => <RepositoryMenu {...defaultProps} content={RepositoryMenuContent} />)
+add('Unsupported', () => <RepositoryMenu {...defaultProps} content={RepositoryMenuContent} />)
+
+add('Unavailable', () => (
+    <RepositoryMenu {...defaultProps} content={RepositoryMenuContent} {...withPayload({ searchBasedSupport })} />
+))
 
 add('Multiple projects', () => (
     <RepositoryMenu

--- a/client/web/src/enterprise/codeintel/RepositoryMenu.story.tsx
+++ b/client/web/src/enterprise/codeintel/RepositoryMenu.story.tsx
@@ -229,6 +229,11 @@ const defaultProps = {
     filePath: 'foo/bar/baz.bonk',
     settingsCascade: { subjects: null, final: null },
     useCodeIntelStatus: () => ({ data: emptyPayload, loading: false }),
+    useRequestedLanguageSupportQuery: () => ({ data: { languages: ['ocaml'] }, loading: false, error: undefined }),
+    useRequestLanguageSupportQuery: ({ onCompleted }: { onCompleted?: () => void }) => [
+        () => Promise.resolve({ data: {} }).then(onCompleted),
+        {},
+    ],
     now,
 }
 const { add } = storiesOf('web/codeintel/enterprise/RepositoryMenu', module).addDecorator(story => (
@@ -242,21 +247,14 @@ const withPayload = (payload: Partial<UseCodeIntelStatusPayload>): typeof defaul
 
 add('Unsupported', () => <RepositoryMenu {...defaultProps} content={RepositoryMenuContent} />)
 
-add('Unavailable', () => (
-    <RepositoryMenu {...defaultProps} content={RepositoryMenuContent} {...withPayload({ searchBasedSupport })} />
-))
+add('Unavailable', () => <RepositoryMenu content={RepositoryMenuContent} {...withPayload({ searchBasedSupport })} />)
 
 add('Multiple projects', () => (
-    <RepositoryMenu
-        {...defaultProps}
-        content={RepositoryMenuContent}
-        {...withPayload({ preciseSupport: multiplePreciseSupport })}
-    />
+    <RepositoryMenu content={RepositoryMenuContent} {...withPayload({ preciseSupport: multiplePreciseSupport })} />
 ))
 
 add('Multiple projects, one enabled', () => (
     <RepositoryMenu
-        {...defaultProps}
         content={RepositoryMenuContent}
         {...withPayload({ recentUploads: [completedUpload], preciseSupport })}
     />
@@ -264,7 +262,6 @@ add('Multiple projects, one enabled', () => (
 
 add('Processing error', () => (
     <RepositoryMenu
-        {...defaultProps}
         content={RepositoryMenuContent}
         {...withPayload({ recentUploads: [completedUpload, failingUpload] })}
     />
@@ -272,7 +269,6 @@ add('Processing error', () => (
 
 add('Indexing error', () => (
     <RepositoryMenu
-        {...defaultProps}
         content={RepositoryMenuContent}
         {...withPayload({ recentUploads: [completedUpload], recentIndexes: [failingIndex] })}
     />
@@ -280,7 +276,6 @@ add('Indexing error', () => (
 
 add('Multiple errors', () => (
     <RepositoryMenu
-        {...defaultProps}
         content={RepositoryMenuContent}
         {...withPayload({ recentUploads: [completedUpload, failingUpload], recentIndexes: [failingIndex] })}
     />

--- a/client/web/src/enterprise/codeintel/RepositoryMenu.tsx
+++ b/client/web/src/enterprise/codeintel/RepositoryMenu.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react'
 
+import classNames from 'classnames'
 import AlertIcon from 'mdi-react/AlertIcon'
 import CheckIcon from 'mdi-react/CheckIcon'
 import InfoCircleOutlineIcon from 'mdi-react/InfoCircleOutlineIcon'
@@ -124,13 +125,16 @@ const UserFacingRepositoryMenuContent: React.FunctionComponent<{
     const indexerNames = [...new Set(allIndexers.map(indexer => indexer.name).concat(fakeIndexerNames))].sort()
 
     // Expand badges to be as large as the maximum badge when we are displaying
-    // badges of different types. This condition checks that there's at least one
-    // ENABLED and one CONFIGURABLE badge each in the following rendered component.
+    // badges of different types. This condition checks that there's at least
+    // two distinct states being displayed in the following rendered component.
     const className =
         new Set(
-            indexerNames.map(
-                name =>
-                    uploadsByIndexerName.get(name)?.length || 0 > 0 || indexesByIndexerName.get(name)?.length || 0 > 0
+            indexerNames.map(name =>
+                (uploadsByIndexerName.get(name)?.length || 0) + (indexesByIndexerName.get(name)?.length || 0) > 0
+                    ? 'enabled'
+                    : allIndexers.find(candidate => candidate.name === name) !== undefined
+                    ? 'configurable'
+                    : 'unavailable'
             )
         ).size > 1
             ? styles.badgeMultiple
@@ -192,7 +196,9 @@ const IndexerSummary: React.FunctionComponent<{
                             Configurable
                         </Badge>
                     ) : (
-                        <Badge variant="outlineSecondary">Unavailable</Badge>
+                        <Badge variant="outlineSecondary" className={className}>
+                            Unavailable
+                        </Badge>
                     )}
                 </div>
 
@@ -439,10 +445,18 @@ const RequestLink: React.FunctionComponent<{ indexerName: string }> = ({ indexer
             ) : data ? (
                 data.languages.includes(language) || requested ? (
                     <span className="text-muted">
-                        Received your request <InfoCircleOutlineIcon size={16} />
+                        Received your request{' '}
+                        <InfoCircleOutlineIcon
+                            size={16}
+                            data-tooltip="Requests are documented and contribute to our precise support roadmap"
+                        />
                     </span>
                 ) : (
-                    <Button variant="link" className="m-0 p-0" onClick={requestSupport}>
+                    <Button
+                        variant="link"
+                        className={classNames('m-0 p-0', styles.languageRequest)}
+                        onClick={requestSupport}
+                    >
                         I want precise support!
                     </Button>
                 )

--- a/client/web/src/enterprise/codeintel/queries.ts
+++ b/client/web/src/enterprise/codeintel/queries.ts
@@ -106,3 +106,17 @@ export const codeIntelStatusQuery = gql`
     ${lsifUploadFieldsFragment}
     ${lsifIndexFieldsFragment}
 `
+
+export const requestedLanguageSupportQuery = gql`
+    query RequestedLanguageSupport {
+        requestedLanguageSupport
+    }
+`
+
+export const requestLanguageSupportQuery = gql`
+    mutation RequestLanguageSupport($language: String!) {
+        requestLanguageSupport(language: $language) {
+            alwaysNil
+        }
+    }
+`

--- a/client/web/src/enterprise/codeintel/useCodeIntelStatus.ts
+++ b/client/web/src/enterprise/codeintel/useCodeIntelStatus.ts
@@ -1,6 +1,6 @@
 import { ApolloError } from '@apollo/client'
 
-import { useQuery } from '@sourcegraph/http-client'
+import { useMutation, useQuery } from '@sourcegraph/http-client'
 
 import {
     CodeIntelStatusResult,
@@ -10,10 +10,14 @@ import {
     LsifUploadFields,
     LSIFUploadsWithRepositoryNamespaceFields,
     PreciseSupportFields,
+    RequestedLanguageSupportResult,
+    RequestedLanguageSupportVariables,
+    RequestLanguageSupportResult,
+    RequestLanguageSupportVariables,
     SearchBasedCodeIntelSupportFields,
 } from '../../graphql-operations'
 
-import { codeIntelStatusQuery } from './queries'
+import { codeIntelStatusQuery, requestedLanguageSupportQuery, requestLanguageSupportQuery } from './queries'
 
 export interface UseCodeIntelStatusParameters {
     variables: CodeIntelStatusVariables
@@ -97,3 +101,51 @@ export const useCodeIntelStatus = ({ variables }: UseCodeIntelStatusParameters):
             return { data: undefined, error, loading }
     }
 }
+
+export interface UseRequestedLanguageSupportParameters {
+    variables: RequestedLanguageSupportVariables
+}
+
+export interface UseRequestedLanguageSupportResult {
+    data?: {
+        languages: string[]
+    }
+    error?: ApolloError
+    loading: boolean
+}
+
+export const useRequestedLanguageSupportQuery = ({
+    variables,
+}: UseRequestedLanguageSupportParameters): UseRequestedLanguageSupportResult => {
+    const { data: rawData, error, loading } = useQuery<
+        RequestedLanguageSupportResult,
+        RequestedLanguageSupportVariables
+    >(requestedLanguageSupportQuery, {
+        variables,
+        notifyOnNetworkStatusChange: false,
+        fetchPolicy: 'no-cache',
+    })
+
+    return { data: rawData && { languages: rawData.requestedLanguageSupport }, error, loading }
+}
+
+export interface UseRequestLanguageSupportParameters {
+    variables: RequestLanguageSupportVariables
+    onCompleted?: () => void
+}
+
+export interface UseRequestLanguageSupportResult {
+    error?: ApolloError
+    loading: boolean
+}
+
+export const useRequestLanguageSupportQuery = ({
+    variables,
+    onCompleted,
+}: UseRequestLanguageSupportParameters): [() => Promise<{}>, UseRequestLanguageSupportResult] =>
+    useMutation<RequestLanguageSupportResult, RequestLanguageSupportVariables>(requestLanguageSupportQuery, {
+        variables,
+        onCompleted,
+        notifyOnNetworkStatusChange: false,
+        fetchPolicy: 'no-cache',
+    })

--- a/cmd/frontend/graphqlbackend/codeintel.go
+++ b/cmd/frontend/graphqlbackend/codeintel.go
@@ -41,6 +41,9 @@ type CodeIntelResolver interface {
 	NodeResolvers() map[string]NodeByIDFunc
 	DocumentationSearch(ctx context.Context, args *DocumentationSearchArgs) (DocumentationSearchResultsResolver, error)
 
+	RequestLanguageSupport(ctx context.Context, args *RequestLanguageSupportArgs) (*EmptyResponse, error)
+	RequestedLanguageSupport(ctx context.Context) ([]string, error)
+
 	ExecutorResolver() executor.Resolver
 }
 
@@ -425,4 +428,8 @@ type CodeIntelIndexerResolver interface {
 type SearchBasedSupportResolver interface {
 	SupportLevel() string
 	Language() string
+}
+
+type RequestLanguageSupportArgs struct {
+	Language string
 }

--- a/cmd/frontend/graphqlbackend/codeintel.graphql
+++ b/cmd/frontend/graphqlbackend/codeintel.graphql
@@ -75,6 +75,11 @@ extend type Mutation {
     Deletes an LSIF index.
     """
     deleteLSIFIndex(id: ID!): EmptyResponse
+
+    """
+    Request support for a particular language.
+    """
+    requestLanguageSupport(language: String!): EmptyResponse
 }
 
 extend type Query {
@@ -241,6 +246,11 @@ extend type Query {
         """
         repos: [String!]
     ): DocumentationSearchResults!
+
+    """
+    Return the languages that this user has requested support for.
+    """
+    requestedLanguageSupport: [String!]!
 }
 
 """

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/observability.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/observability.go
@@ -7,29 +7,31 @@ import (
 )
 
 type operations struct {
-	lsifUploadByID            *observation.Operation
-	lsifUploads               *observation.Operation
-	lsifUploadsByRepo         *observation.Operation
+	commitGraph               *observation.Operation
+	configurationPolicies     *observation.Operation
+	configurationPolicyByID   *observation.Operation
+	createConfigurationPolicy *observation.Operation
+	deleteConfigurationPolicy *observation.Operation
+	deleteLsifIndexes         *observation.Operation
 	deleteLsifUpload          *observation.Operation
+	gitBlobCodeIntelInfo      *observation.Operation
+	gitBlobLsifData           *observation.Operation
+	gitTreeCodeIntelInfo      *observation.Operation
+	indexConfiguration        *observation.Operation
 	lsifIndexByID             *observation.Operation
 	lsifIndexes               *observation.Operation
 	lsifIndexesByRepo         *observation.Operation
-	deleteLsifIndexes         *observation.Operation
-	commitGraph               *observation.Operation
-	queueAutoIndexJobsForRepo *observation.Operation
-	gitBlobLsifData           *observation.Operation
-	gitBlobCodeIntelInfo      *observation.Operation
-	gitTreeCodeIntelInfo      *observation.Operation
-	configurationPolicyByID   *observation.Operation
-	configurationPolicies     *observation.Operation
-	createConfigurationPolicy *observation.Operation
-	updateConfigurationPolicy *observation.Operation
-	deleteConfigurationPolicy *observation.Operation
-	indexConfiguration        *observation.Operation
-	updateIndexConfiguration  *observation.Operation
-	previewRepoFilter         *observation.Operation
+	lsifUploadByID            *observation.Operation
+	lsifUploads               *observation.Operation
+	lsifUploadsByRepo         *observation.Operation
 	previewGitObjectFilter    *observation.Operation
+	previewRepoFilter         *observation.Operation
+	queueAutoIndexJobsForRepo *observation.Operation
 	repositorySummary         *observation.Operation
+	requestedLanguageSupport  *observation.Operation
+	requestLanguageSupport    *observation.Operation
+	updateConfigurationPolicy *observation.Operation
+	updateIndexConfiguration  *observation.Operation
 }
 
 func newOperations(observationContext *observation.Context) *operations {
@@ -46,28 +48,30 @@ func newOperations(observationContext *observation.Context) *operations {
 	}
 
 	return &operations{
-		lsifUploadByID:            op("LSIFUploadByID"),
-		lsifUploads:               op("LSIFUploads"),
-		lsifUploadsByRepo:         op("LSIFUploadsByRepo"),
+		commitGraph:               op("CommitGraph"),
+		configurationPolicies:     op("ConfigurationPolicies"),
+		configurationPolicyByID:   op("ConfigurationPolicyByID"),
+		createConfigurationPolicy: op("CreateConfigurationPolicy"),
+		deleteConfigurationPolicy: op("DeleteConfigurationPolicy"),
+		deleteLsifIndexes:         op("DeleteLSIFIndexes"),
 		deleteLsifUpload:          op("DeleteLSIFUpload"),
+		gitBlobCodeIntelInfo:      op("GitBlobCodeIntelInfo"),
+		gitBlobLsifData:           op("GitBlobLSIFData"),
+		gitTreeCodeIntelInfo:      op("GitTreeCodeIntelInfo"),
+		indexConfiguration:        op("IndexConfiguration"),
 		lsifIndexByID:             op("LSIFIndexByID"),
 		lsifIndexes:               op("LSIFIndexes"),
 		lsifIndexesByRepo:         op("LSIFIndexesByRepo"),
-		deleteLsifIndexes:         op("DeleteLSIFIndexes"),
-		commitGraph:               op("CommitGraph"),
-		queueAutoIndexJobsForRepo: op("QueueAutoIndexJobsForRepo"),
-		gitBlobLsifData:           op("GitBlobLSIFData"),
-		gitBlobCodeIntelInfo:      op("GitBlobCodeIntelInfo"),
-		gitTreeCodeIntelInfo:      op("GitTreeCodeIntelInfo"),
-		configurationPolicyByID:   op("ConfigurationPolicyByID"),
-		configurationPolicies:     op("ConfigurationPolicies"),
-		createConfigurationPolicy: op("CreateConfigurationPolicy"),
-		updateConfigurationPolicy: op("UpdateConfigurationPolicy"),
-		deleteConfigurationPolicy: op("DeleteConfigurationPolicy"),
-		indexConfiguration:        op("IndexConfiguration"),
-		updateIndexConfiguration:  op("UpdateIndexConfiguration"),
-		previewRepoFilter:         op("PreviewRepoFilter"),
+		lsifUploadByID:            op("LSIFUploadByID"),
+		lsifUploads:               op("LSIFUploads"),
+		lsifUploadsByRepo:         op("LSIFUploadsByRepo"),
 		previewGitObjectFilter:    op("PreviewGitObjectFilter"),
+		previewRepoFilter:         op("PreviewRepoFilter"),
+		queueAutoIndexJobsForRepo: op("QueueAutoIndexJobsForRepo"),
 		repositorySummary:         op("RepositorySummary"),
+		requestedLanguageSupport:  op("RequestedLanguageSupport"),
+		requestLanguageSupport:    op("RequestLanguageSupport"),
+		updateConfigurationPolicy: op("UpdateConfigurationPolicy"),
+		updateIndexConfiguration:  op("UpdateIndexConfiguration"),
 	}
 }

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/support.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/support.go
@@ -1,10 +1,14 @@
 package graphql
 
 import (
+	"context"
 	"path"
 	"strings"
 
 	gql "github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
+	"github.com/sourcegraph/sourcegraph/internal/actor"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 type searchBasedCodeIntelSupportType string
@@ -76,4 +80,32 @@ func (r *preciseCodeIntelSupportResolver) Indexers() *[]gql.CodeIntelIndexerReso
 		return nil
 	}
 	return &r.indexers
+}
+
+func (r *Resolver) RequestLanguageSupport(ctx context.Context, args *gql.RequestLanguageSupportArgs) (_ *gql.EmptyResponse, err error) {
+	ctx, endObservation := r.observationContext.requestLanguageSupport.With(ctx, &err, observation.Args{})
+	defer endObservation(1, observation.Args{})
+
+	userID := int(actor.FromContext(ctx).UID)
+	if userID == 0 {
+		return nil, errors.Newf("language support requests only logged for authenticated users")
+	}
+
+	if err := r.resolver.RequestLanguageSupport(ctx, userID, args.Language); err != nil {
+		return nil, err
+	}
+
+	return &gql.EmptyResponse{}, nil
+}
+
+func (r *Resolver) RequestedLanguageSupport(ctx context.Context) (_ []string, err error) {
+	ctx, endObservation := r.observationContext.requestedLanguageSupport.With(ctx, &err, observation.Args{})
+	defer endObservation(1, observation.Args{})
+
+	userID := int(actor.FromContext(ctx).UID)
+	if userID == 0 {
+		return nil, errors.Newf("language support requests only logged for authenticated users")
+	}
+
+	return r.resolver.RequestedLanguageSupport(ctx, userID)
 }

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/iface.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/iface.go
@@ -60,6 +60,8 @@ type DBStore interface {
 	RecentIndexesSummary(ctx context.Context, repositoryID int) ([]dbstore.IndexesWithRepositoryNamespace, error)
 	LastUploadRetentionScanForRepository(ctx context.Context, repositoryID int) (*time.Time, error)
 	LastIndexScanForRepository(ctx context.Context, repositoryID int) (*time.Time, error)
+	RequestLanguageSupport(ctx context.Context, userID int, language string) error
+	LanguagesRequestedBy(ctx context.Context, userID int) ([]string, error)
 }
 
 type LSIFStore interface {

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/mock_iface_test.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/mock_iface_test.go
@@ -94,6 +94,9 @@ type MockDBStore struct {
 	// HasRepositoryFunc is an instance of a mock function object
 	// controlling the behavior of the method HasRepository.
 	HasRepositoryFunc *DBStoreHasRepositoryFunc
+	// LanguagesRequestedByFunc is an instance of a mock function object
+	// controlling the behavior of the method LanguagesRequestedBy.
+	LanguagesRequestedByFunc *DBStoreLanguagesRequestedByFunc
 	// LastIndexScanForRepositoryFunc is an instance of a mock function
 	// object controlling the behavior of the method
 	// LastIndexScanForRepository.
@@ -123,6 +126,9 @@ type MockDBStore struct {
 	// RepoNamesFunc is an instance of a mock function object controlling
 	// the behavior of the method RepoNames.
 	RepoNamesFunc *DBStoreRepoNamesFunc
+	// RequestLanguageSupportFunc is an instance of a mock function object
+	// controlling the behavior of the method RequestLanguageSupport.
+	RequestLanguageSupportFunc *DBStoreRequestLanguageSupportFunc
 	// UpdateConfigurationPolicyFunc is an instance of a mock function
 	// object controlling the behavior of the method
 	// UpdateConfigurationPolicy.
@@ -242,6 +248,11 @@ func NewMockDBStore() *MockDBStore {
 				return false, nil
 			},
 		},
+		LanguagesRequestedByFunc: &DBStoreLanguagesRequestedByFunc{
+			defaultHook: func(context.Context, int) ([]string, error) {
+				return nil, nil
+			},
+		},
 		LastIndexScanForRepositoryFunc: &DBStoreLastIndexScanForRepositoryFunc{
 			defaultHook: func(context.Context, int) (*time.Time, error) {
 				return nil, nil
@@ -285,6 +296,11 @@ func NewMockDBStore() *MockDBStore {
 		RepoNamesFunc: &DBStoreRepoNamesFunc{
 			defaultHook: func(context.Context, ...int) (map[int]string, error) {
 				return nil, nil
+			},
+		},
+		RequestLanguageSupportFunc: &DBStoreRequestLanguageSupportFunc{
+			defaultHook: func(context.Context, int, string) error {
+				return nil
 			},
 		},
 		UpdateConfigurationPolicyFunc: &DBStoreUpdateConfigurationPolicyFunc{
@@ -409,6 +425,11 @@ func NewStrictMockDBStore() *MockDBStore {
 				panic("unexpected invocation of MockDBStore.HasRepository")
 			},
 		},
+		LanguagesRequestedByFunc: &DBStoreLanguagesRequestedByFunc{
+			defaultHook: func(context.Context, int) ([]string, error) {
+				panic("unexpected invocation of MockDBStore.LanguagesRequestedBy")
+			},
+		},
 		LastIndexScanForRepositoryFunc: &DBStoreLastIndexScanForRepositoryFunc{
 			defaultHook: func(context.Context, int) (*time.Time, error) {
 				panic("unexpected invocation of MockDBStore.LastIndexScanForRepository")
@@ -452,6 +473,11 @@ func NewStrictMockDBStore() *MockDBStore {
 		RepoNamesFunc: &DBStoreRepoNamesFunc{
 			defaultHook: func(context.Context, ...int) (map[int]string, error) {
 				panic("unexpected invocation of MockDBStore.RepoNames")
+			},
+		},
+		RequestLanguageSupportFunc: &DBStoreRequestLanguageSupportFunc{
+			defaultHook: func(context.Context, int, string) error {
+				panic("unexpected invocation of MockDBStore.RequestLanguageSupport")
 			},
 		},
 		UpdateConfigurationPolicyFunc: &DBStoreUpdateConfigurationPolicyFunc{
@@ -534,6 +560,9 @@ func NewMockDBStoreFrom(i DBStore) *MockDBStore {
 		HasRepositoryFunc: &DBStoreHasRepositoryFunc{
 			defaultHook: i.HasRepository,
 		},
+		LanguagesRequestedByFunc: &DBStoreLanguagesRequestedByFunc{
+			defaultHook: i.LanguagesRequestedBy,
+		},
 		LastIndexScanForRepositoryFunc: &DBStoreLastIndexScanForRepositoryFunc{
 			defaultHook: i.LastIndexScanForRepository,
 		},
@@ -560,6 +589,9 @@ func NewMockDBStoreFrom(i DBStore) *MockDBStore {
 		},
 		RepoNamesFunc: &DBStoreRepoNamesFunc{
 			defaultHook: i.RepoNames,
+		},
+		RequestLanguageSupportFunc: &DBStoreRequestLanguageSupportFunc{
+			defaultHook: i.RequestLanguageSupport,
 		},
 		UpdateConfigurationPolicyFunc: &DBStoreUpdateConfigurationPolicyFunc{
 			defaultHook: i.UpdateConfigurationPolicy,
@@ -2933,6 +2965,115 @@ func (c DBStoreHasRepositoryFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 
+// DBStoreLanguagesRequestedByFunc describes the behavior when the
+// LanguagesRequestedBy method of the parent MockDBStore instance is
+// invoked.
+type DBStoreLanguagesRequestedByFunc struct {
+	defaultHook func(context.Context, int) ([]string, error)
+	hooks       []func(context.Context, int) ([]string, error)
+	history     []DBStoreLanguagesRequestedByFuncCall
+	mutex       sync.Mutex
+}
+
+// LanguagesRequestedBy delegates to the next hook function in the queue and
+// stores the parameter and result values of this invocation.
+func (m *MockDBStore) LanguagesRequestedBy(v0 context.Context, v1 int) ([]string, error) {
+	r0, r1 := m.LanguagesRequestedByFunc.nextHook()(v0, v1)
+	m.LanguagesRequestedByFunc.appendCall(DBStoreLanguagesRequestedByFuncCall{v0, v1, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the LanguagesRequestedBy
+// method of the parent MockDBStore instance is invoked and the hook queue
+// is empty.
+func (f *DBStoreLanguagesRequestedByFunc) SetDefaultHook(hook func(context.Context, int) ([]string, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// LanguagesRequestedBy method of the parent MockDBStore instance invokes
+// the hook at the front of the queue and discards it. After the queue is
+// empty, the default hook function is invoked for any future action.
+func (f *DBStoreLanguagesRequestedByFunc) PushHook(hook func(context.Context, int) ([]string, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *DBStoreLanguagesRequestedByFunc) SetDefaultReturn(r0 []string, r1 error) {
+	f.SetDefaultHook(func(context.Context, int) ([]string, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *DBStoreLanguagesRequestedByFunc) PushReturn(r0 []string, r1 error) {
+	f.PushHook(func(context.Context, int) ([]string, error) {
+		return r0, r1
+	})
+}
+
+func (f *DBStoreLanguagesRequestedByFunc) nextHook() func(context.Context, int) ([]string, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *DBStoreLanguagesRequestedByFunc) appendCall(r0 DBStoreLanguagesRequestedByFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of DBStoreLanguagesRequestedByFuncCall objects
+// describing the invocations of this function.
+func (f *DBStoreLanguagesRequestedByFunc) History() []DBStoreLanguagesRequestedByFuncCall {
+	f.mutex.Lock()
+	history := make([]DBStoreLanguagesRequestedByFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// DBStoreLanguagesRequestedByFuncCall is an object that describes an
+// invocation of method LanguagesRequestedBy on an instance of MockDBStore.
+type DBStoreLanguagesRequestedByFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 int
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 []string
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c DBStoreLanguagesRequestedByFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c DBStoreLanguagesRequestedByFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
+}
+
 // DBStoreLastIndexScanForRepositoryFunc describes the behavior when the
 // LastIndexScanForRepository method of the parent MockDBStore instance is
 // invoked.
@@ -3943,6 +4084,116 @@ func (c DBStoreRepoNamesFuncCall) Args() []interface{} {
 // invocation.
 func (c DBStoreRepoNamesFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
+}
+
+// DBStoreRequestLanguageSupportFunc describes the behavior when the
+// RequestLanguageSupport method of the parent MockDBStore instance is
+// invoked.
+type DBStoreRequestLanguageSupportFunc struct {
+	defaultHook func(context.Context, int, string) error
+	hooks       []func(context.Context, int, string) error
+	history     []DBStoreRequestLanguageSupportFuncCall
+	mutex       sync.Mutex
+}
+
+// RequestLanguageSupport delegates to the next hook function in the queue
+// and stores the parameter and result values of this invocation.
+func (m *MockDBStore) RequestLanguageSupport(v0 context.Context, v1 int, v2 string) error {
+	r0 := m.RequestLanguageSupportFunc.nextHook()(v0, v1, v2)
+	m.RequestLanguageSupportFunc.appendCall(DBStoreRequestLanguageSupportFuncCall{v0, v1, v2, r0})
+	return r0
+}
+
+// SetDefaultHook sets function that is called when the
+// RequestLanguageSupport method of the parent MockDBStore instance is
+// invoked and the hook queue is empty.
+func (f *DBStoreRequestLanguageSupportFunc) SetDefaultHook(hook func(context.Context, int, string) error) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// RequestLanguageSupport method of the parent MockDBStore instance invokes
+// the hook at the front of the queue and discards it. After the queue is
+// empty, the default hook function is invoked for any future action.
+func (f *DBStoreRequestLanguageSupportFunc) PushHook(hook func(context.Context, int, string) error) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *DBStoreRequestLanguageSupportFunc) SetDefaultReturn(r0 error) {
+	f.SetDefaultHook(func(context.Context, int, string) error {
+		return r0
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *DBStoreRequestLanguageSupportFunc) PushReturn(r0 error) {
+	f.PushHook(func(context.Context, int, string) error {
+		return r0
+	})
+}
+
+func (f *DBStoreRequestLanguageSupportFunc) nextHook() func(context.Context, int, string) error {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *DBStoreRequestLanguageSupportFunc) appendCall(r0 DBStoreRequestLanguageSupportFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of DBStoreRequestLanguageSupportFuncCall
+// objects describing the invocations of this function.
+func (f *DBStoreRequestLanguageSupportFunc) History() []DBStoreRequestLanguageSupportFuncCall {
+	f.mutex.Lock()
+	history := make([]DBStoreRequestLanguageSupportFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// DBStoreRequestLanguageSupportFuncCall is an object that describes an
+// invocation of method RequestLanguageSupport on an instance of
+// MockDBStore.
+type DBStoreRequestLanguageSupportFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 int
+	// Arg2 is the value of the 3rd argument passed to this method
+	// invocation.
+	Arg2 string
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c DBStoreRequestLanguageSupportFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c DBStoreRequestLanguageSupportFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0}
 }
 
 // DBStoreUpdateConfigurationPolicyFunc describes the behavior when the

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/mocks/mock_resolver.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/mocks/mock_resolver.go
@@ -93,6 +93,12 @@ type MockResolver struct {
 	// RepositorySummaryFunc is an instance of a mock function object
 	// controlling the behavior of the method RepositorySummary.
 	RepositorySummaryFunc *ResolverRepositorySummaryFunc
+	// RequestLanguageSupportFunc is an instance of a mock function object
+	// controlling the behavior of the method RequestLanguageSupport.
+	RequestLanguageSupportFunc *ResolverRequestLanguageSupportFunc
+	// RequestedLanguageSupportFunc is an instance of a mock function object
+	// controlling the behavior of the method RequestedLanguageSupport.
+	RequestedLanguageSupportFunc *ResolverRequestedLanguageSupportFunc
 	// RetentionPolicyOverviewFunc is an instance of a mock function object
 	// controlling the behavior of the method RetentionPolicyOverview.
 	RetentionPolicyOverviewFunc *ResolverRetentionPolicyOverviewFunc
@@ -224,6 +230,16 @@ func NewMockResolver() *MockResolver {
 		RepositorySummaryFunc: &ResolverRepositorySummaryFunc{
 			defaultHook: func(context.Context, int) (resolvers.RepositorySummary, error) {
 				return resolvers.RepositorySummary{}, nil
+			},
+		},
+		RequestLanguageSupportFunc: &ResolverRequestLanguageSupportFunc{
+			defaultHook: func(context.Context, int, string) error {
+				return nil
+			},
+		},
+		RequestedLanguageSupportFunc: &ResolverRequestedLanguageSupportFunc{
+			defaultHook: func(context.Context, int) ([]string, error) {
+				return nil, nil
 			},
 		},
 		RetentionPolicyOverviewFunc: &ResolverRetentionPolicyOverviewFunc{
@@ -368,6 +384,16 @@ func NewStrictMockResolver() *MockResolver {
 				panic("unexpected invocation of MockResolver.RepositorySummary")
 			},
 		},
+		RequestLanguageSupportFunc: &ResolverRequestLanguageSupportFunc{
+			defaultHook: func(context.Context, int, string) error {
+				panic("unexpected invocation of MockResolver.RequestLanguageSupport")
+			},
+		},
+		RequestedLanguageSupportFunc: &ResolverRequestedLanguageSupportFunc{
+			defaultHook: func(context.Context, int) ([]string, error) {
+				panic("unexpected invocation of MockResolver.RequestedLanguageSupport")
+			},
+		},
 		RetentionPolicyOverviewFunc: &ResolverRetentionPolicyOverviewFunc{
 			defaultHook: func(context.Context, dbstore.Upload, bool, int, int64, string, time.Time) ([]resolvers.RetentionPolicyMatchCandidate, int, error) {
 				panic("unexpected invocation of MockResolver.RetentionPolicyOverview")
@@ -465,6 +491,12 @@ func NewMockResolverFrom(i resolvers.Resolver) *MockResolver {
 		},
 		RepositorySummaryFunc: &ResolverRepositorySummaryFunc{
 			defaultHook: i.RepositorySummary,
+		},
+		RequestLanguageSupportFunc: &ResolverRequestLanguageSupportFunc{
+			defaultHook: i.RequestLanguageSupport,
+		},
+		RequestedLanguageSupportFunc: &ResolverRequestedLanguageSupportFunc{
+			defaultHook: i.RequestedLanguageSupport,
 		},
 		RetentionPolicyOverviewFunc: &ResolverRetentionPolicyOverviewFunc{
 			defaultHook: i.RetentionPolicyOverview,
@@ -2930,6 +2962,227 @@ func (c ResolverRepositorySummaryFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c ResolverRepositorySummaryFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
+}
+
+// ResolverRequestLanguageSupportFunc describes the behavior when the
+// RequestLanguageSupport method of the parent MockResolver instance is
+// invoked.
+type ResolverRequestLanguageSupportFunc struct {
+	defaultHook func(context.Context, int, string) error
+	hooks       []func(context.Context, int, string) error
+	history     []ResolverRequestLanguageSupportFuncCall
+	mutex       sync.Mutex
+}
+
+// RequestLanguageSupport delegates to the next hook function in the queue
+// and stores the parameter and result values of this invocation.
+func (m *MockResolver) RequestLanguageSupport(v0 context.Context, v1 int, v2 string) error {
+	r0 := m.RequestLanguageSupportFunc.nextHook()(v0, v1, v2)
+	m.RequestLanguageSupportFunc.appendCall(ResolverRequestLanguageSupportFuncCall{v0, v1, v2, r0})
+	return r0
+}
+
+// SetDefaultHook sets function that is called when the
+// RequestLanguageSupport method of the parent MockResolver instance is
+// invoked and the hook queue is empty.
+func (f *ResolverRequestLanguageSupportFunc) SetDefaultHook(hook func(context.Context, int, string) error) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// RequestLanguageSupport method of the parent MockResolver instance invokes
+// the hook at the front of the queue and discards it. After the queue is
+// empty, the default hook function is invoked for any future action.
+func (f *ResolverRequestLanguageSupportFunc) PushHook(hook func(context.Context, int, string) error) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *ResolverRequestLanguageSupportFunc) SetDefaultReturn(r0 error) {
+	f.SetDefaultHook(func(context.Context, int, string) error {
+		return r0
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *ResolverRequestLanguageSupportFunc) PushReturn(r0 error) {
+	f.PushHook(func(context.Context, int, string) error {
+		return r0
+	})
+}
+
+func (f *ResolverRequestLanguageSupportFunc) nextHook() func(context.Context, int, string) error {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *ResolverRequestLanguageSupportFunc) appendCall(r0 ResolverRequestLanguageSupportFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of ResolverRequestLanguageSupportFuncCall
+// objects describing the invocations of this function.
+func (f *ResolverRequestLanguageSupportFunc) History() []ResolverRequestLanguageSupportFuncCall {
+	f.mutex.Lock()
+	history := make([]ResolverRequestLanguageSupportFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// ResolverRequestLanguageSupportFuncCall is an object that describes an
+// invocation of method RequestLanguageSupport on an instance of
+// MockResolver.
+type ResolverRequestLanguageSupportFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 int
+	// Arg2 is the value of the 3rd argument passed to this method
+	// invocation.
+	Arg2 string
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c ResolverRequestLanguageSupportFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c ResolverRequestLanguageSupportFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0}
+}
+
+// ResolverRequestedLanguageSupportFunc describes the behavior when the
+// RequestedLanguageSupport method of the parent MockResolver instance is
+// invoked.
+type ResolverRequestedLanguageSupportFunc struct {
+	defaultHook func(context.Context, int) ([]string, error)
+	hooks       []func(context.Context, int) ([]string, error)
+	history     []ResolverRequestedLanguageSupportFuncCall
+	mutex       sync.Mutex
+}
+
+// RequestedLanguageSupport delegates to the next hook function in the queue
+// and stores the parameter and result values of this invocation.
+func (m *MockResolver) RequestedLanguageSupport(v0 context.Context, v1 int) ([]string, error) {
+	r0, r1 := m.RequestedLanguageSupportFunc.nextHook()(v0, v1)
+	m.RequestedLanguageSupportFunc.appendCall(ResolverRequestedLanguageSupportFuncCall{v0, v1, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the
+// RequestedLanguageSupport method of the parent MockResolver instance is
+// invoked and the hook queue is empty.
+func (f *ResolverRequestedLanguageSupportFunc) SetDefaultHook(hook func(context.Context, int) ([]string, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// RequestedLanguageSupport method of the parent MockResolver instance
+// invokes the hook at the front of the queue and discards it. After the
+// queue is empty, the default hook function is invoked for any future
+// action.
+func (f *ResolverRequestedLanguageSupportFunc) PushHook(hook func(context.Context, int) ([]string, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *ResolverRequestedLanguageSupportFunc) SetDefaultReturn(r0 []string, r1 error) {
+	f.SetDefaultHook(func(context.Context, int) ([]string, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *ResolverRequestedLanguageSupportFunc) PushReturn(r0 []string, r1 error) {
+	f.PushHook(func(context.Context, int) ([]string, error) {
+		return r0, r1
+	})
+}
+
+func (f *ResolverRequestedLanguageSupportFunc) nextHook() func(context.Context, int) ([]string, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *ResolverRequestedLanguageSupportFunc) appendCall(r0 ResolverRequestedLanguageSupportFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of ResolverRequestedLanguageSupportFuncCall
+// objects describing the invocations of this function.
+func (f *ResolverRequestedLanguageSupportFunc) History() []ResolverRequestedLanguageSupportFuncCall {
+	f.mutex.Lock()
+	history := make([]ResolverRequestedLanguageSupportFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// ResolverRequestedLanguageSupportFuncCall is an object that describes an
+// invocation of method RequestedLanguageSupport on an instance of
+// MockResolver.
+type ResolverRequestedLanguageSupportFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 int
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 []string
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c ResolverRequestedLanguageSupportFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c ResolverRequestedLanguageSupportFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/resolver.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/resolver.go
@@ -61,6 +61,9 @@ type Resolver interface {
 	QueryResolver(ctx context.Context, args *gql.GitBlobLSIFDataArgs) (QueryResolver, error)
 	RepositorySummary(ctx context.Context, repositoryID int) (RepositorySummary, error)
 
+	RequestLanguageSupport(ctx context.Context, userID int, language string) error
+	RequestedLanguageSupport(ctx context.Context, userID int) ([]string, error)
+
 	ExecutorResolver() executor.Resolver
 }
 

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/support.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/support.go
@@ -1,0 +1,13 @@
+package resolvers
+
+import (
+	"context"
+)
+
+func (r *resolver) RequestLanguageSupport(ctx context.Context, userID int, language string) error {
+	return r.dbStore.RequestLanguageSupport(ctx, userID, language)
+}
+
+func (r *resolver) RequestedLanguageSupport(ctx context.Context, userID int) ([]string, error) {
+	return r.dbStore.LanguagesRequestedBy(ctx, userID)
+}

--- a/enterprise/internal/codeintel/stores/dbstore/observability.go
+++ b/enterprise/internal/codeintel/stores/dbstore/observability.go
@@ -49,6 +49,7 @@ type operations struct {
 	insertIndex                                 *observation.Operation
 	insertUpload                                *observation.Operation
 	isQueued                                    *observation.Operation
+	languagesRequestedBy                        *observation.Operation
 	lastIndexScanForRepository                  *observation.Operation
 	lastUploadRetentionScanForRepository        *observation.Operation
 	markComplete                                *observation.Operation
@@ -67,6 +68,7 @@ type operations struct {
 	refreshCommitResolvability                  *observation.Operation
 	repoIDsByGlobPatterns                       *observation.Operation
 	repoName                                    *observation.Operation
+	requestLanguageSupport                      *observation.Operation
 	requeue                                     *observation.Operation
 	requeueIndex                                *observation.Operation
 	selectPoliciesForRepositoryMembershipUpdate *observation.Operation
@@ -153,6 +155,7 @@ func newOperations(observationContext *observation.Context, metrics *metrics.RED
 		insertIndex:                          op("InsertIndex"),
 		insertUpload:                         op("InsertUpload"),
 		isQueued:                             op("IsQueued"),
+		languagesRequestedBy:                 op("LanguagesRequestedBy"),
 		lastIndexScanForRepository:           op("LastIndexScanForRepository"),
 		lastUploadRetentionScanForRepository: op("LastUploadRetentionScanForRepository"),
 		markComplete:                         op("MarkComplete"),
@@ -171,6 +174,7 @@ func newOperations(observationContext *observation.Context, metrics *metrics.RED
 		refreshCommitResolvability:           op("RefreshCommitResolvability"),
 		repoIDsByGlobPatterns:                op("repoIDsByGlobPatterns"),
 		repoName:                             op("RepoName"),
+		requestLanguageSupport:               op("RequestLanguageSupport"),
 		requeue:                              op("Requeue"),
 		requeueIndex:                         op("RequeueIndex"),
 

--- a/enterprise/internal/codeintel/stores/dbstore/support.go
+++ b/enterprise/internal/codeintel/stores/dbstore/support.go
@@ -1,0 +1,39 @@
+package dbstore
+
+import (
+	"context"
+
+	"github.com/keegancsmith/sqlf"
+
+	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
+)
+
+func (s *Store) RequestLanguageSupport(ctx context.Context, userID int, language string) (err error) {
+	ctx, endObservation := s.operations.requestLanguageSupport.With(ctx, &err, observation.Args{})
+	defer endObservation(1, observation.Args{})
+
+	return s.Exec(ctx, sqlf.Sprintf(requestLanguageSupportQuery, userID, language))
+}
+
+const requestLanguageSupportQuery = `
+-- source: enterprise/internal/codeintel/stores/dbstore/support.go:RequestLanguageSupport
+INSERT INTO codeintel_langugage_support_requests (user_id, language_id)
+VALUES (%s, %s)
+ON CONFLICT DO NOTHING
+`
+
+func (s *Store) LanguagesRequestedBy(ctx context.Context, userID int) (_ []string, err error) {
+	ctx, endObservation := s.operations.languagesRequestedBy.With(ctx, &err, observation.Args{})
+	defer endObservation(1, observation.Args{})
+
+	return basestore.ScanStrings(s.Query(ctx, sqlf.Sprintf(languagesRequestedByQuery, userID)))
+}
+
+const languagesRequestedByQuery = `
+-- source: enterprise/internal/codeintel/stores/dbstore/support.go:LanguagesRequestedBy
+SELECT language_id
+FROM codeintel_langugage_support_requests
+WHERE user_id = %s
+ORDER BY language_id
+`

--- a/enterprise/internal/codeintel/stores/dbstore/support_test.go
+++ b/enterprise/internal/codeintel/stores/dbstore/support_test.go
@@ -1,0 +1,52 @@
+package dbstore
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
+)
+
+func TestRequestLanguageSupport(t *testing.T) {
+	ctx := context.Background()
+	store := testStore(database.NewDB(dbtest.NewDB(t)))
+
+	requests := []struct {
+		userID    int
+		languages []string
+	}{
+		{1, []string{"go", "go", "perl"}},
+		{2, []string{"perl", "ocaml"}},
+		{3, []string{"ocaml", "ocaml", "ocaml", "ocaml", "ocaml"}}, // we get it
+	}
+	for _, r := range requests {
+		for _, language := range r.languages {
+			if err := store.RequestLanguageSupport(ctx, r.userID, language); err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+		}
+	}
+
+	languages := map[int][]string{}
+	for _, r := range requests {
+		userLanguages, err := store.LanguagesRequestedBy(ctx, r.userID)
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+
+		languages[r.userID] = userLanguages
+	}
+
+	expected := map[int][]string{
+		1: {"go", "perl"},
+		2: {"ocaml", "perl"},
+		3: {"ocaml"},
+	}
+
+	if diff := cmp.Diff(expected, languages); diff != "" {
+		t.Errorf("unexpected languages requested (-want +got):\n%s", diff)
+	}
+}

--- a/internal/database/mocks.go
+++ b/internal/database/mocks.go
@@ -6788,6 +6788,9 @@ type MockEventLogStore struct {
 	// object controlling the behavior of the method
 	// MaxTimestampByUserIDAndSource.
 	MaxTimestampByUserIDAndSourceFunc *EventLogStoreMaxTimestampByUserIDAndSourceFunc
+	// RequestsByLanguageFunc is an instance of a mock function object
+	// controlling the behavior of the method RequestsByLanguage.
+	RequestsByLanguageFunc *EventLogStoreRequestsByLanguageFunc
 	// SiteUsageFunc is an instance of a mock function object controlling
 	// the behavior of the method SiteUsage.
 	SiteUsageFunc *EventLogStoreSiteUsageFunc
@@ -6948,6 +6951,11 @@ func NewMockEventLogStore() *MockEventLogStore {
 		},
 		MaxTimestampByUserIDAndSourceFunc: &EventLogStoreMaxTimestampByUserIDAndSourceFunc{
 			defaultHook: func(context.Context, int32, string) (*time.Time, error) {
+				return nil, nil
+			},
+		},
+		RequestsByLanguageFunc: &EventLogStoreRequestsByLanguageFunc{
+			defaultHook: func(context.Context) (map[string]int, error) {
 				return nil, nil
 			},
 		},
@@ -7123,6 +7131,11 @@ func NewStrictMockEventLogStore() *MockEventLogStore {
 				panic("unexpected invocation of MockEventLogStore.MaxTimestampByUserIDAndSource")
 			},
 		},
+		RequestsByLanguageFunc: &EventLogStoreRequestsByLanguageFunc{
+			defaultHook: func(context.Context) (map[string]int, error) {
+				panic("unexpected invocation of MockEventLogStore.RequestsByLanguage")
+			},
+		},
 		SiteUsageFunc: &EventLogStoreSiteUsageFunc{
 			defaultHook: func(context.Context) (types.SiteUsageSummary, error) {
 				panic("unexpected invocation of MockEventLogStore.SiteUsage")
@@ -7237,6 +7250,9 @@ func NewMockEventLogStoreFrom(i EventLogStore) *MockEventLogStore {
 		},
 		MaxTimestampByUserIDAndSourceFunc: &EventLogStoreMaxTimestampByUserIDAndSourceFunc{
 			defaultHook: i.MaxTimestampByUserIDAndSource,
+		},
+		RequestsByLanguageFunc: &EventLogStoreRequestsByLanguageFunc{
+			defaultHook: i.RequestsByLanguage,
 		},
 		SiteUsageFunc: &EventLogStoreSiteUsageFunc{
 			defaultHook: i.SiteUsage,
@@ -10462,6 +10478,114 @@ func (c EventLogStoreMaxTimestampByUserIDAndSourceFuncCall) Args() []interface{}
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c EventLogStoreMaxTimestampByUserIDAndSourceFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
+}
+
+// EventLogStoreRequestsByLanguageFunc describes the behavior when the
+// RequestsByLanguage method of the parent MockEventLogStore instance is
+// invoked.
+type EventLogStoreRequestsByLanguageFunc struct {
+	defaultHook func(context.Context) (map[string]int, error)
+	hooks       []func(context.Context) (map[string]int, error)
+	history     []EventLogStoreRequestsByLanguageFuncCall
+	mutex       sync.Mutex
+}
+
+// RequestsByLanguage delegates to the next hook function in the queue and
+// stores the parameter and result values of this invocation.
+func (m *MockEventLogStore) RequestsByLanguage(v0 context.Context) (map[string]int, error) {
+	r0, r1 := m.RequestsByLanguageFunc.nextHook()(v0)
+	m.RequestsByLanguageFunc.appendCall(EventLogStoreRequestsByLanguageFuncCall{v0, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the RequestsByLanguage
+// method of the parent MockEventLogStore instance is invoked and the hook
+// queue is empty.
+func (f *EventLogStoreRequestsByLanguageFunc) SetDefaultHook(hook func(context.Context) (map[string]int, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// RequestsByLanguage method of the parent MockEventLogStore instance
+// invokes the hook at the front of the queue and discards it. After the
+// queue is empty, the default hook function is invoked for any future
+// action.
+func (f *EventLogStoreRequestsByLanguageFunc) PushHook(hook func(context.Context) (map[string]int, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *EventLogStoreRequestsByLanguageFunc) SetDefaultReturn(r0 map[string]int, r1 error) {
+	f.SetDefaultHook(func(context.Context) (map[string]int, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *EventLogStoreRequestsByLanguageFunc) PushReturn(r0 map[string]int, r1 error) {
+	f.PushHook(func(context.Context) (map[string]int, error) {
+		return r0, r1
+	})
+}
+
+func (f *EventLogStoreRequestsByLanguageFunc) nextHook() func(context.Context) (map[string]int, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *EventLogStoreRequestsByLanguageFunc) appendCall(r0 EventLogStoreRequestsByLanguageFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of EventLogStoreRequestsByLanguageFuncCall
+// objects describing the invocations of this function.
+func (f *EventLogStoreRequestsByLanguageFunc) History() []EventLogStoreRequestsByLanguageFuncCall {
+	f.mutex.Lock()
+	history := make([]EventLogStoreRequestsByLanguageFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// EventLogStoreRequestsByLanguageFuncCall is an object that describes an
+// invocation of method RequestsByLanguage on an instance of
+// MockEventLogStore.
+type EventLogStoreRequestsByLanguageFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 map[string]int
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c EventLogStoreRequestsByLanguageFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c EventLogStoreRequestsByLanguageFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 

--- a/internal/database/mocks.go
+++ b/internal/database/mocks.go
@@ -6788,9 +6788,6 @@ type MockEventLogStore struct {
 	// object controlling the behavior of the method
 	// MaxTimestampByUserIDAndSource.
 	MaxTimestampByUserIDAndSourceFunc *EventLogStoreMaxTimestampByUserIDAndSourceFunc
-	// RequestsByLanguageFunc is an instance of a mock function object
-	// controlling the behavior of the method RequestsByLanguage.
-	RequestsByLanguageFunc *EventLogStoreRequestsByLanguageFunc
 	// SiteUsageFunc is an instance of a mock function object controlling
 	// the behavior of the method SiteUsage.
 	SiteUsageFunc *EventLogStoreSiteUsageFunc
@@ -6951,11 +6948,6 @@ func NewMockEventLogStore() *MockEventLogStore {
 		},
 		MaxTimestampByUserIDAndSourceFunc: &EventLogStoreMaxTimestampByUserIDAndSourceFunc{
 			defaultHook: func(context.Context, int32, string) (*time.Time, error) {
-				return nil, nil
-			},
-		},
-		RequestsByLanguageFunc: &EventLogStoreRequestsByLanguageFunc{
-			defaultHook: func(context.Context) (map[string]int, error) {
 				return nil, nil
 			},
 		},
@@ -7131,11 +7123,6 @@ func NewStrictMockEventLogStore() *MockEventLogStore {
 				panic("unexpected invocation of MockEventLogStore.MaxTimestampByUserIDAndSource")
 			},
 		},
-		RequestsByLanguageFunc: &EventLogStoreRequestsByLanguageFunc{
-			defaultHook: func(context.Context) (map[string]int, error) {
-				panic("unexpected invocation of MockEventLogStore.RequestsByLanguage")
-			},
-		},
 		SiteUsageFunc: &EventLogStoreSiteUsageFunc{
 			defaultHook: func(context.Context) (types.SiteUsageSummary, error) {
 				panic("unexpected invocation of MockEventLogStore.SiteUsage")
@@ -7250,9 +7237,6 @@ func NewMockEventLogStoreFrom(i EventLogStore) *MockEventLogStore {
 		},
 		MaxTimestampByUserIDAndSourceFunc: &EventLogStoreMaxTimestampByUserIDAndSourceFunc{
 			defaultHook: i.MaxTimestampByUserIDAndSource,
-		},
-		RequestsByLanguageFunc: &EventLogStoreRequestsByLanguageFunc{
-			defaultHook: i.RequestsByLanguage,
 		},
 		SiteUsageFunc: &EventLogStoreSiteUsageFunc{
 			defaultHook: i.SiteUsage,
@@ -10478,114 +10462,6 @@ func (c EventLogStoreMaxTimestampByUserIDAndSourceFuncCall) Args() []interface{}
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c EventLogStoreMaxTimestampByUserIDAndSourceFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
-}
-
-// EventLogStoreRequestsByLanguageFunc describes the behavior when the
-// RequestsByLanguage method of the parent MockEventLogStore instance is
-// invoked.
-type EventLogStoreRequestsByLanguageFunc struct {
-	defaultHook func(context.Context) (map[string]int, error)
-	hooks       []func(context.Context) (map[string]int, error)
-	history     []EventLogStoreRequestsByLanguageFuncCall
-	mutex       sync.Mutex
-}
-
-// RequestsByLanguage delegates to the next hook function in the queue and
-// stores the parameter and result values of this invocation.
-func (m *MockEventLogStore) RequestsByLanguage(v0 context.Context) (map[string]int, error) {
-	r0, r1 := m.RequestsByLanguageFunc.nextHook()(v0)
-	m.RequestsByLanguageFunc.appendCall(EventLogStoreRequestsByLanguageFuncCall{v0, r0, r1})
-	return r0, r1
-}
-
-// SetDefaultHook sets function that is called when the RequestsByLanguage
-// method of the parent MockEventLogStore instance is invoked and the hook
-// queue is empty.
-func (f *EventLogStoreRequestsByLanguageFunc) SetDefaultHook(hook func(context.Context) (map[string]int, error)) {
-	f.defaultHook = hook
-}
-
-// PushHook adds a function to the end of hook queue. Each invocation of the
-// RequestsByLanguage method of the parent MockEventLogStore instance
-// invokes the hook at the front of the queue and discards it. After the
-// queue is empty, the default hook function is invoked for any future
-// action.
-func (f *EventLogStoreRequestsByLanguageFunc) PushHook(hook func(context.Context) (map[string]int, error)) {
-	f.mutex.Lock()
-	f.hooks = append(f.hooks, hook)
-	f.mutex.Unlock()
-}
-
-// SetDefaultReturn calls SetDefaultHook with a function that returns the
-// given values.
-func (f *EventLogStoreRequestsByLanguageFunc) SetDefaultReturn(r0 map[string]int, r1 error) {
-	f.SetDefaultHook(func(context.Context) (map[string]int, error) {
-		return r0, r1
-	})
-}
-
-// PushReturn calls PushHook with a function that returns the given values.
-func (f *EventLogStoreRequestsByLanguageFunc) PushReturn(r0 map[string]int, r1 error) {
-	f.PushHook(func(context.Context) (map[string]int, error) {
-		return r0, r1
-	})
-}
-
-func (f *EventLogStoreRequestsByLanguageFunc) nextHook() func(context.Context) (map[string]int, error) {
-	f.mutex.Lock()
-	defer f.mutex.Unlock()
-
-	if len(f.hooks) == 0 {
-		return f.defaultHook
-	}
-
-	hook := f.hooks[0]
-	f.hooks = f.hooks[1:]
-	return hook
-}
-
-func (f *EventLogStoreRequestsByLanguageFunc) appendCall(r0 EventLogStoreRequestsByLanguageFuncCall) {
-	f.mutex.Lock()
-	f.history = append(f.history, r0)
-	f.mutex.Unlock()
-}
-
-// History returns a sequence of EventLogStoreRequestsByLanguageFuncCall
-// objects describing the invocations of this function.
-func (f *EventLogStoreRequestsByLanguageFunc) History() []EventLogStoreRequestsByLanguageFuncCall {
-	f.mutex.Lock()
-	history := make([]EventLogStoreRequestsByLanguageFuncCall, len(f.history))
-	copy(history, f.history)
-	f.mutex.Unlock()
-
-	return history
-}
-
-// EventLogStoreRequestsByLanguageFuncCall is an object that describes an
-// invocation of method RequestsByLanguage on an instance of
-// MockEventLogStore.
-type EventLogStoreRequestsByLanguageFuncCall struct {
-	// Arg0 is the value of the 1st argument passed to this method
-	// invocation.
-	Arg0 context.Context
-	// Result0 is the value of the 1st result returned from this method
-	// invocation.
-	Result0 map[string]int
-	// Result1 is the value of the 2nd result returned from this method
-	// invocation.
-	Result1 error
-}
-
-// Args returns an interface slice containing the arguments of this
-// invocation.
-func (c EventLogStoreRequestsByLanguageFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0}
-}
-
-// Results returns an interface slice containing the results of this
-// invocation.
-func (c EventLogStoreRequestsByLanguageFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -649,6 +649,18 @@ Webhook actions configured on code monitors
 
 **url**: The webhook URL we send the code monitor event to
 
+# Table "public.codeintel_langugage_support_requests"
+```
+   Column    |  Type   | Collation | Nullable |                             Default                              
+-------------+---------+-----------+----------+------------------------------------------------------------------
+ id          | integer |           | not null | nextval('codeintel_langugage_support_requests_id_seq'::regclass)
+ user_id     | integer |           | not null | 
+ language_id | text    |           | not null | 
+Indexes:
+    "codeintel_langugage_support_requests_user_id_language" UNIQUE, btree (user_id, language_id)
+
+```
+
 # Table "public.critical_and_site_config"
 ```
    Column   |           Type           | Collation | Nullable |                       Default                        

--- a/migrations/frontend/1650637472/down.sql
+++ b/migrations/frontend/1650637472/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS codeintel_langugage_support_requests;

--- a/migrations/frontend/1650637472/metadata.yaml
+++ b/migrations/frontend/1650637472/metadata.yaml
@@ -1,0 +1,2 @@
+name: Add codeintel_langugage_support_requests table
+parents: [1649159359, 1649441222, 1649759318, 1649432863]

--- a/migrations/frontend/1650637472/up.sql
+++ b/migrations/frontend/1650637472/up.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS codeintel_langugage_support_requests (
+    id SERIAL,
+    user_id integer NOT NULL,
+    language_id text NOT NULL
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS codeintel_langugage_support_requests_user_id_language ON codeintel_langugage_support_requests(user_id, language_id);


### PR DESCRIPTION
This effort is attached to #33795. This PR differentiates the _unavailable_ cases into _unsupported_ (wth are we looking at here?), and _search-based available, but no precise indexer is_. The latter case is actionable.

The user is now presented with a button that will record their request for support of a particular language. If this user has already requested that particular language, then a canned 'your request has been noted' message. This data is stored in a new Postgres table with a unique user_id/language_id pairing. Counts of requests by language id are sent via pings regular with on-prem update checks.

~Blocked by https://github.com/sourcegraph/analytics/pull/412.~ Telemetry concerns pulled out into https://github.com/sourcegraph/sourcegraph/pull/34469. Merging this should not harm pings.

## Test plan

Additional unit tests. 

## App preview:

- [Link](https://sg-web-ef-33795.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-yrxjwlvojx.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

