### PR TITLE
insights: update note on flag docs page

### DIFF
--- a/doc/dev/background-information/architecture/index.md
+++ b/doc/dev/background-information/architecture/index.md
@@ -115,8 +115,6 @@ Code insights surface higher-level, aggregated information to leaders in enginee
 For example, code insights can track the number of matches of a search query over time, the number of code intelligence diagnostic warnings in a code base, usage of different programming languages, or even data from external services, like test coverage from Codecov.
 Sample use cases for this are for tracking migrations, usage of libraries across an organization, tech debt, code base health, and much more.
 
-Code insights are currently feature-flagged - set `"experimentalFeatures": { "codeInsights": true }` in your user settings to enable them.
-
 Code Insights are persisted in a separate databased called `codeinsights-db`. The web application interacts with the backend through a [GraphQL API](../../../code_insights/references/code_insights_graphql_api.md).
 
 Code Insights makes use of data from the `frontend` database for repository metadata, as well as repository permissions to filter time series data.
@@ -126,6 +124,7 @@ For code insights being run just-in-time in the client, the performance of code 
 These insights are relatively fast as long as the scope doesn't include many repositories (or large monorepos), but performance degrades when trying to include a lot of repositories. Insights
 that are processed in the background are rate limited and will perform approximately 28,000 queries per hour when fully saturated on default settings.
 
+There is also a feature flag left over from the original development of the early stage product that we retained in case a customer who doesn't purchase it ever has a justified need to disable insights. You can set `"experimentalFeatures": { "codeInsights": false }` in your settings to disable insights. 
 
 If you want to learn more about code insights:
 


### PR DESCRIPTION
Update the stale flag docs note. [Came up in this slack thread](https://sourcegraph.slack.com/archives/C014ZCKMCAV/p1649876213258019?thread_ts=1649749906.495739&cid=C014ZCKMCAV)

## Test plan

This is a docs update that has been viewed. 

