### PR TITLE
dev/sg: detect completion mode and omit setup

### DIFF
--- a/dev/sg/sg_install.go
+++ b/dev/sg/sg_install.go
@@ -47,7 +47,7 @@ Can also be used to install a custom build of 'sg' globally, for example:
 func installAction(cmd *cli.Context) error {
 	ctx := cmd.Context
 
-	probeCmdOut, err := exec.CommandContext(ctx, "sg", "-help").CombinedOutput()
+	probeCmdOut, err := exec.CommandContext(ctx, "sg", "help").CombinedOutput()
 	if err == nil && outputLooksLikeSG(string(probeCmdOut)) {
 		path, err := exec.LookPath("sg")
 		if err != nil {

--- a/dev/sg/sg_run.go
+++ b/dev/sg/sg_run.go
@@ -16,10 +16,9 @@ import (
 )
 
 func init() {
-	postInitHooks = append(postInitHooks, func(cmd *cli.Context) error {
+	postInitHooks = append(postInitHooks, func(cmd *cli.Context) {
 		// Create 'sg run' help text after flag (and config) initialization
 		runCommand.Description = constructRunCmdLongHelp()
-		return nil
 	})
 }
 

--- a/dev/sg/sg_start.go
+++ b/dev/sg/sg_start.go
@@ -19,10 +19,9 @@ import (
 )
 
 func init() {
-	postInitHooks = append(postInitHooks, func(cmd *cli.Context) error {
+	postInitHooks = append(postInitHooks, func(cmd *cli.Context) {
 		// Create 'sg start' help text after flag (and config) initialization
 		startCommand.Description = constructStartCmdLongHelp()
-		return nil
 	})
 }
 

--- a/dev/sg/sg_tests.go
+++ b/dev/sg/sg_tests.go
@@ -16,10 +16,9 @@ import (
 )
 
 func init() {
-	postInitHooks = append(postInitHooks, func(cmd *cli.Context) error {
+	postInitHooks = append(postInitHooks, func(cmd *cli.Context) {
 		// Create 'sg test' help text after flag (and config) initialization
 		testCommand.Description = constructTestCmdLongHelp()
-		return nil
 	})
 }
 


### PR DESCRIPTION
Partially reverts https://github.com/sourcegraph/sourcegraph/pull/33868 , closes https://github.com/sourcegraph/sourcegraph/issues/33873

Fixes the `rev-list` call in the update check, and just discard  "bad revision" messages

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

```
$ git rev-list asdfasdf..main -- ./dev/sg
fatal: bad revision 'asdfasdf..main'
```

and a bunch of manual testing