### PR TITLE
set getBackendInsights to network-only

### DIFF
--- a/client/web/src/enterprise/insights/core/backend/gql-backend/methods/get-backend-insight-data/get-backend-insight-data.ts
+++ b/client/web/src/enterprise/insights/core/backend/gql-backend/methods/get-backend-insight-data/get-backend-insight-data.ts
@@ -25,6 +25,7 @@ export const getBackendInsightData = (
         client.watchQuery<GetInsightViewResult>({
             query: GET_INSIGHT_VIEW_GQL,
             variables: { id: insight.id, filters },
+            fetchPolicy: 'network-only',
         })
     ).pipe(
         // Note: this insight is guaranteed to exist since this function

--- a/client/web/src/enterprise/insights/core/backend/gql-backend/methods/get-backend-insight-data/get-backend-insight-data.ts
+++ b/client/web/src/enterprise/insights/core/backend/gql-backend/methods/get-backend-insight-data/get-backend-insight-data.ts
@@ -25,6 +25,8 @@ export const getBackendInsightData = (
         client.watchQuery<GetInsightViewResult>({
             query: GET_INSIGHT_VIEW_GQL,
             variables: { id: insight.id, filters },
+            // This query is set to network-only becasue the caching is not working correctly
+            // https://github.com/sourcegraph/sourcegraph/issues/33813
             fetchPolicy: 'network-only',
         })
     ).pipe(


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/33813

Note: This is a temporary hot fix. Caching is basically broken here. We should come back to this issue in the future to fix the caching.

## Test plan

Go to any filterable insight. ex: Using regex
Open the filter panel
Filter for any repo that doesn't exist. i.e. "hash"
Click the reset button
Graph should reset back to previous values

## App preview:

- [Link](https://sg-web-jdb-fix-get-insights-caching.onrender.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

