### PR TITLE
dev/sg: remove globalConf, extract Config into sgconf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -173,3 +173,6 @@ test-reports/
 
 # go workspace files shouldn't be committed
 go.work
+
+# binary
+/sg

--- a/dev/sg/checks.go
+++ b/dev/sg/checks.go
@@ -14,6 +14,7 @@ import (
 	"github.com/jackc/pgx/v4"
 
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/check"
+	"github.com/sourcegraph/sourcegraph/dev/sg/internal/sgconf"
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/stdout"
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/usershell"
 	"github.com/sourcegraph/sourcegraph/dev/sg/root"
@@ -229,8 +230,8 @@ func checkSourcegraphDatabase(ctx context.Context) error {
 	// This check runs only in the `sourcegraph/sourcegraph` repository, so
 	// we try to parse the globalConf and use its `Env` to configure the
 	// Postgres connection.
-	ok, _ := parseConf(configFlag, overwriteConfigFlag)
-	if !ok {
+	config, _ := sgconf.Get(configFile, configOverwriteFile)
+	if config == nil {
 		return errors.New("failed to read sg.config.yaml. This step of `sg setup` needs to be run in the `sourcegraph` repository")
 	}
 
@@ -242,7 +243,7 @@ func checkSourcegraphDatabase(ctx context.Context) error {
 			return val
 		}
 		// Otherwise check in globalConf.Env
-		return globalConf.Env[key]
+		return config.Env[key]
 	}
 
 	dsn := postgresdsn.New("", "", getEnv)

--- a/dev/sg/internal/sgconf/config.go
+++ b/dev/sg/internal/sgconf/config.go
@@ -1,4 +1,4 @@
-package main
+package sgconf
 
 import (
 	"io"
@@ -10,7 +10,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
-func ParseConfigFile(name string) (*Config, error) {
+func parseConfigFile(name string) (*Config, error) {
 	file, err := os.Open(name)
 	if err != nil {
 		return nil, errors.Wrapf(err, "cannot open file %q", name)
@@ -22,10 +22,10 @@ func ParseConfigFile(name string) (*Config, error) {
 		return nil, errors.Wrap(err, "reading configuration file")
 	}
 
-	return ParseConfig(data)
+	return parseConfig(data)
 }
 
-func ParseConfig(data []byte) (*Config, error) {
+func parseConfig(data []byte) (*Config, error) {
 	var conf Config
 	if err := yaml.Unmarshal(data, &conf); err != nil {
 		return nil, err

--- a/dev/sg/internal/sgconf/config_test.go
+++ b/dev/sg/internal/sgconf/config_test.go
@@ -1,4 +1,4 @@
-package main
+package sgconf
 
 import (
 	"testing"
@@ -40,7 +40,7 @@ commandsets:
       - gitserver
 `
 
-	have, err := ParseConfig([]byte(input))
+	have, err := parseConfig([]byte(input))
 	if err != nil {
 		t.Errorf("unexpected error: %s", err)
 	}
@@ -92,7 +92,7 @@ commands:
       - enterprise/internal
       - enterprise/cmd/frontend
 `
-	config, err := ParseConfig([]byte(a))
+	config, err := parseConfig([]byte(a))
 	if err != nil {
 		t.Errorf("unexpected error: %s", err)
 	}
@@ -104,7 +104,7 @@ commands:
       EXTSVC_CONFIG_FILE: ''
 `
 
-	overwrite, err := ParseConfig([]byte(b))
+	overwrite, err := parseConfig([]byte(b))
 	if err != nil {
 		t.Errorf("unexpected error: %s", err)
 	}

--- a/dev/sg/internal/sgconf/global.go
+++ b/dev/sg/internal/sgconf/global.go
@@ -1,0 +1,82 @@
+package sgconf
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+
+	"github.com/sourcegraph/sourcegraph/dev/sg/root"
+	"github.com/sourcegraph/sourcegraph/lib/output"
+)
+
+const (
+	DefaultFile          = "sg.config.yaml"
+	DefaultOverwriteFile = "sg.config.overwrite.yaml"
+)
+
+var (
+	globalConfOnce sync.Once
+	globalConf     *Config
+	globalConfErr  output.FancyLine
+)
+
+// Get retrieves the global config files. If Config is nil, a line will be provided that
+// can be printed for an explanation as to what went wrong.
+//
+// It must not be called before flag initalization, i.e. when confFile or overwriteFile is
+// not set.
+func Get(confFile, overwriteFile string) (*Config, output.FancyLine) {
+	// If unset, Get was called in an illegal context, since sg.Before validates that the
+	// flags are non-empty.
+	if confFile == "" || overwriteFile == "" {
+		panic("sgconf.Get called before flag initialization")
+	}
+
+	globalConfOnce.Do(func() {
+		globalConf, globalConfErr = parseConf(confFile, overwriteFile)
+	})
+	return globalConf, globalConfErr
+}
+
+func parseConf(confFile, overwriteFile string) (*Config, output.FancyLine) {
+	// Try to determine root of repository, so we can look for config there
+	repoRoot, err := root.RepositoryRoot()
+	if err != nil {
+		return nil, output.Linef("", output.StyleWarning, "Failed to determine repository root location: %s", err)
+	}
+
+	// If the configFlag/overwriteConfigFlag flags have their default value, we
+	// take the value as relative to the root of the repository.
+	if confFile == DefaultFile {
+		confFile = filepath.Join(repoRoot, confFile)
+	}
+	if overwriteFile == DefaultOverwriteFile {
+		overwriteFile = filepath.Join(repoRoot, overwriteFile)
+	}
+
+	conf, err := parseConfigFile(confFile)
+	if err != nil {
+		return nil, output.Linef("", output.StyleWarning, "Failed to parse %s%s%s%s as configuration file:%s\n%s", output.StyleBold, confFile, output.StyleReset, output.StyleWarning, output.StyleReset, err)
+	}
+
+	if ok, _ := fileExists(overwriteFile); ok {
+		overwriteConf, err := parseConfigFile(overwriteFile)
+		if err != nil {
+			return nil, output.Linef("", output.StyleWarning, "Failed to parse %s%s%s%s as overwrites configuration file:%s\n%s", output.StyleBold, overwriteFile, output.StyleReset, output.StyleWarning, output.StyleReset, err)
+		}
+		conf.Merge(overwriteConf)
+	}
+
+	return conf, output.FancyLine{}
+}
+
+func fileExists(path string) (bool, error) {
+	_, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}

--- a/dev/sg/main.go
+++ b/dev/sg/main.go
@@ -10,9 +10,10 @@ import (
 	"github.com/urfave/cli/v2"
 
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/secrets"
+	"github.com/sourcegraph/sourcegraph/dev/sg/internal/sgconf"
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/stdout"
 	"github.com/sourcegraph/sourcegraph/dev/sg/root"
-	"github.com/sourcegraph/sourcegraph/lib/output"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 func main() {
@@ -27,24 +28,21 @@ func main() {
 }
 
 const (
-	defaultConfigFile          = "sg.config.yaml"
-	defaultConfigOverwriteFile = "sg.config.overwrite.yaml"
-	defaultSecretsFile         = "sg.secrets.json"
+	defaultSecretsFile = "sg.secrets.json"
 )
 
 var (
 	BuildCommit = "dev"
 
-	// globalConf is the global config. If a command needs to access it, it *must* call
-	// `parseConf` before.
-	globalConf *Config
-
 	// secretsStore is instantiated when sg gets run.
 	secretsStore *secrets.Store
 
-	// Note that these values are only available after the main sg CLI app has been run.
-	configFlag          string
-	overwriteConfigFlag string
+	// configFile is the path to use with sgconf.Get - it must not be used before flag
+	// initialization.
+	configFile string
+	// configOverwriteFile is the path to use with sgconf.Get - it must not be used before
+	// flag initialization.
+	configOverwriteFile string
 
 	// Global verbose mode
 	verbose bool
@@ -81,19 +79,21 @@ var sg = &cli.App{
 		},
 		&cli.StringFlag{
 			Name:        "config",
+			Aliases:     []string{"c"},
 			Usage:       "load sg configuration from `file`",
 			EnvVars:     []string{"SG_CONFIG"},
 			TakesFile:   true,
-			Value:       defaultConfigFile,
-			Destination: &configFlag,
+			Value:       sgconf.DefaultFile,
+			Destination: &configFile,
 		},
 		&cli.StringFlag{
 			Name:        "overwrite",
+			Aliases:     []string{"o"},
 			Usage:       "load sg configuration from `file` that is gitignored and can be used to, for example, add credentials",
 			EnvVars:     []string{"SG_OVERWRITE"},
 			TakesFile:   true,
-			Value:       defaultConfigOverwriteFile,
-			Destination: &overwriteConfigFlag,
+			Value:       sgconf.DefaultOverwriteFile,
+			Destination: &configOverwriteFile,
 		},
 		&cli.BoolFlag{
 			Name:    "skip-auto-update",
@@ -103,14 +103,22 @@ var sg = &cli.App{
 		},
 	},
 	Before: func(cmd *cli.Context) error {
-		if verbose {
-			stdout.Out.SetVerbose()
-		}
-
 		if batchCompletionMode {
 			// All other setup pertains to running commands - to keep completions fast,
 			// we skip all other setup.
 			return nil
+		}
+
+		if verbose {
+			stdout.Out.SetVerbose()
+		}
+
+		// Validate configuration flags, which is required for sgconf.Get to work everywhere else.
+		if configFile == "" {
+			return errors.Newf("--config must not be empty")
+		}
+		if configOverwriteFile == "" {
+			return errors.Newf("--overwrite must not be empty")
 		}
 
 		// Set up access to secrets
@@ -187,43 +195,4 @@ func loadSecrets() error {
 	fp := filepath.Join(homePath, defaultSecretsFile)
 	secretsStore, err = secrets.LoadFile(fp)
 	return err
-}
-
-// parseConf parses the config file and the optional overwrite file.
-// Iear the conf has already been parsed it's a noop.
-func parseConf(confFile, overwriteFile string) (bool, output.FancyLine) {
-	if globalConf != nil {
-		return true, output.FancyLine{}
-	}
-
-	// Try to determine root of repository, so we can look for config there
-	repoRoot, err := root.RepositoryRoot()
-	if err != nil {
-		return false, output.Linef("", output.StyleWarning, "Failed to determine repository root location: %s", err)
-	}
-
-	// If the configFlag/overwriteConfigFlag flags have their default value, we
-	// take the value as relative to the root of the repository.
-	if confFile == defaultConfigFile {
-		confFile = filepath.Join(repoRoot, confFile)
-	}
-
-	if overwriteFile == defaultConfigOverwriteFile {
-		overwriteFile = filepath.Join(repoRoot, overwriteFile)
-	}
-
-	globalConf, err = ParseConfigFile(confFile)
-	if err != nil {
-		return false, output.Linef("", output.StyleWarning, "Failed to parse %s%s%s%s as configuration file:%s\n%s", output.StyleBold, confFile, output.StyleReset, output.StyleWarning, output.StyleReset, err)
-	}
-
-	if ok, _ := fileExists(overwriteFile); ok {
-		overwriteConf, err := ParseConfigFile(overwriteFile)
-		if err != nil {
-			return false, output.Linef("", output.StyleWarning, "Failed to parse %s%s%s%s as overwrites configuration file:%s\n%s", output.StyleBold, overwriteFile, output.StyleReset, output.StyleWarning, output.StyleReset, err)
-		}
-		globalConf.Merge(overwriteConf)
-	}
-
-	return true, output.FancyLine{}
 }

--- a/dev/sg/main_test.go
+++ b/dev/sg/main_test.go
@@ -9,17 +9,30 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
+// testSG creates a copy of the sg app for testing.
+func testSG() *cli.App {
+	tsg := *sg
+	return &tsg
+}
+
 func TestAppRun(t *testing.T) {
-	// Check app starts up correctly
+	sg := testSG()
+
+	// Capture output
 	var out, err bytes.Buffer
 	sg.Writer = &out
 	sg.ErrWriter = &err
+	// Check app starts up correctly
 	assert.NoError(t, sg.Run([]string{"help"}))
 	assert.Contains(t, out.String(), "The Sourcegraph developer tool!")
+	// We do not want errors anywhere
+	assert.NotContains(t, out.String(), "error")
 	assert.Empty(t, err.String())
 }
 
 func TestCommandFormatting(t *testing.T) {
+	sg := testSG()
+
 	sg.Setup()
 	for _, cmd := range sg.Commands {
 		testCommandFormatting(t, cmd)

--- a/dev/sg/main_test.go
+++ b/dev/sg/main_test.go
@@ -27,6 +27,7 @@ func TestAppRun(t *testing.T) {
 	assert.Contains(t, out.String(), "The Sourcegraph developer tool!")
 	// We do not want errors anywhere
 	assert.NotContains(t, out.String(), "error")
+	assert.NotContains(t, out.String(), "panic")
 	assert.Empty(t, err.String())
 }
 

--- a/dev/sg/os.go
+++ b/dev/sg/os.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"os"
 	"syscall"
 
 	"github.com/sourcegraph/sourcegraph/lib/errors"
@@ -28,15 +27,4 @@ func setMaxOpenFiles() error {
 	}
 
 	return nil
-}
-
-func fileExists(path string) (bool, error) {
-	_, err := os.Stat(path)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return false, nil
-		}
-		return false, err
-	}
-	return true, nil
 }

--- a/dev/sg/printing.go
+++ b/dev/sg/printing.go
@@ -19,8 +19,12 @@ func writeFailureLinef(fmtStr string, args ...interface{}) {
 	stdout.Out.WriteLine(output.Linef(output.EmojiFailure, output.StyleWarning, fmtStr, args...))
 }
 
+func newWarningLinef(fmtStr string, args ...interface{}) output.FancyLine {
+	return output.Linef(output.EmojiWarningSign, output.StyleYellow, fmtStr, args...)
+}
+
 func writeWarningLinef(fmtStr string, args ...interface{}) {
-	stdout.Out.WriteLine(output.Linef(output.EmojiWarningSign, output.StyleYellow, fmtStr, args...))
+	stdout.Out.WriteLine(newWarningLinef(fmtStr, args...))
 }
 
 func writeSkippedLinef(fmtStr string, args ...interface{}) {

--- a/dev/sg/sg_live.go
+++ b/dev/sg/sg_live.go
@@ -31,7 +31,7 @@ func constructLiveCmdLongHelp() string {
 	fmt.Fprintf(&out, "Prints the Sourcegraph version deployed to the given environment.")
 	fmt.Fprintf(&out, "\n")
 	fmt.Fprintf(&out, "\n")
-	fmt.Fprintf(&out, "AVAILABLE PRESET ENVIRONMENTS\n")
+	fmt.Fprintf(&out, "AVAILABLE PRESET ENVIRONMENTS:\n")
 
 	for _, name := range environmentNames() {
 		fmt.Fprintf(&out, "  %s\n", name)

--- a/dev/sg/sg_migration.go
+++ b/dev/sg/sg_migration.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/db"
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/migration"
+	"github.com/sourcegraph/sourcegraph/dev/sg/internal/sgconf"
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/stdout"
 	"github.com/sourcegraph/sourcegraph/dev/sg/root"
 	connections "github.com/sourcegraph/sourcegraph/internal/database/connections/live"
@@ -101,9 +102,9 @@ func makeRunner(ctx context.Context, schemaNames []string) (cliutil.Runner, erro
 	// Try to read the `sg` configuration so we can read ENV vars from the
 	// configuration and use process env as fallback.
 	var getEnv func(string) string
-	ok, _ := parseConf(configFlag, overwriteConfigFlag)
-	if ok {
-		getEnv = globalConf.GetEnv
+	config, _ := sgconf.Get(configFile, configOverwriteFile)
+	if config != nil {
+		getEnv = config.GetEnv
 	} else {
 		getEnv = os.Getenv
 	}

--- a/dev/sg/sg_start_test.go
+++ b/dev/sg/sg_start_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/run"
+	"github.com/sourcegraph/sourcegraph/dev/sg/internal/sgconf"
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/stdout"
 	"github.com/sourcegraph/sourcegraph/lib/output"
 	"github.com/sourcegraph/sourcegraph/lib/output/outputtest"
@@ -20,16 +21,16 @@ func TestStartCommandSet(t *testing.T) {
 
 	buf := useOutputBuffer(t)
 
-	commandSet := &Commandset{Name: "test-set", Commands: []string{"test-cmd-1"}}
+	commandSet := &sgconf.Commandset{Name: "test-set", Commands: []string{"test-cmd-1"}}
 	command := run.Command{
 		Name:    "test-cmd-1",
 		Install: "echo 'booting up horsegraph'",
 		Cmd:     "echo 'horsegraph booted up. mount your horse.' && echo 'quitting. not horsing around anymore.'",
 	}
 
-	testConf := &Config{
+	testConf := &sgconf.Config{
 		Commands:    map[string]run.Command{"test-cmd-1": command},
-		Commandsets: map[string]*Commandset{"test-set": commandSet},
+		Commandsets: map[string]*sgconf.Commandset{"test-set": commandSet},
 	}
 
 	if err := startCommandSet(ctx, commandSet, testConf, false); err != nil {
@@ -60,16 +61,16 @@ func TestStartCommandSet_InstallError(t *testing.T) {
 
 			buf := useOutputBuffer(t)
 
-			commandSet := &Commandset{Name: "test-set", Commands: []string{"test-cmd-1"}}
+			commandSet := &sgconf.Commandset{Name: "test-set", Commands: []string{"test-cmd-1"}}
 			command := run.Command{
 				Name:    "test-cmd-1",
 				Install: "echo 'booting up horsegraph' && exit 1",
 				Cmd:     "echo 'never appears'",
 			}
 
-			testConf := &Config{
+			testConf := &sgconf.Config{
 				Commands:    map[string]run.Command{"test-cmd-1": command},
-				Commandsets: map[string]*Commandset{"test-set": commandSet},
+				Commandsets: map[string]*sgconf.Commandset{"test-set": commandSet},
 			}
 
 			err := startCommandSet(ctx, commandSet, testConf, withPostInstallCallback)


### PR DESCRIPTION
Instead of hoping `globalConf` is initialized somewhere, callers now explicitly use `sgconf.Get` to retrieve the global instance of sg config and any relevant warning.

The new `sgconf.Get` can only be called after the app is initialized - e.g. within an Action or in a Before, After, or postInitHook hook, otherwise it panics. This will get caught by `TestAppRun` if it ever happens (the test caught one instance of it occurring)

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

```
go build -o ./sg ./dev/sg
./sg ...
```
