### PR TITLE
Make sure to restore the LAM dashboard if needed

### DIFF
--- a/enterprise/internal/insights/resolvers/dashboard_resolvers.go
+++ b/enterprise/internal/insights/resolvers/dashboard_resolvers.go
@@ -378,7 +378,7 @@ func (r *Resolver) DeleteInsightsDashboard(ctx context.Context, args *graphqlbac
 		return nil, err
 	}
 
-	err = r.dashboardStore.DeleteDashboard(ctx, dashboardID.Arg)
+	err = r.dashboardStore.DeleteDashboard(ctx, int(dashboardID.Arg))
 	if err != nil {
 		return emptyResponse, err
 	}

--- a/enterprise/internal/insights/store/dashboard_store.go
+++ b/enterprise/internal/insights/store/dashboard_store.go
@@ -378,7 +378,7 @@ func (s *DBDashboardStore) EnsureLimitedAccessModeDashboard(ctx context.Context)
 	// This dashboard may have been previously deleted.
 	tx.RestoreDashboard(ctx, id)
 	if err != nil {
-		return 0, err
+		return 0, errors.Wrap(err, "RestoreDashboard")
 	}
 	return id, nil
 }

--- a/enterprise/internal/insights/store/dashboard_store.go
+++ b/enterprise/internal/insights/store/dashboard_store.go
@@ -97,10 +97,18 @@ func (s *DBDashboardStore) GetDashboards(ctx context.Context, args DashboardQuer
 	return scanDashboard(s.Query(ctx, q))
 }
 
-func (s *DBDashboardStore) DeleteDashboard(ctx context.Context, id int64) error {
+func (s *DBDashboardStore) DeleteDashboard(ctx context.Context, id int) error {
 	err := s.Exec(ctx, sqlf.Sprintf(deleteDashboardSql, id))
 	if err != nil {
 		return errors.Wrapf(err, "failed to delete dashboard with id: %s", id)
+	}
+	return nil
+}
+
+func (s *DBDashboardStore) RestoreDashboard(ctx context.Context, id int) error {
+	err := s.Exec(ctx, sqlf.Sprintf(restoreDashboardSql, id))
+	if err != nil {
+		return errors.Wrapf(err, "failed to restore dashboard with id: %s", id)
 	}
 	return nil
 }
@@ -172,6 +180,11 @@ ORDER BY db.id
 const deleteDashboardSql = `
 -- source: enterprise/internal/insights/store/dashboard_store.go:DeleteDashboard
 update dashboard set deleted_at = NOW() where id = %s;
+`
+
+const restoreDashboardSql = `
+-- source: enterprise/internal/insights/store/dashboard_store.go:DeleteDashboard
+update dashboard set deleted_at = NULL where id = %s;
 `
 
 type CreateDashboardArgs struct {
@@ -362,6 +375,11 @@ func (s *DBDashboardStore) EnsureLimitedAccessModeDashboard(ctx context.Context)
 			return 0, err
 		}
 	}
+	// This dashboard may have been previously deleted.
+	tx.RestoreDashboard(ctx, id)
+	if err != nil {
+		return 0, err
+	}
 	return id, nil
 }
 
@@ -431,7 +449,8 @@ type DashboardStore interface {
 	GetDashboards(ctx context.Context, args DashboardQueryArgs) ([]*types.Dashboard, error)
 	CreateDashboard(ctx context.Context, args CreateDashboardArgs) (_ *types.Dashboard, err error)
 	UpdateDashboard(ctx context.Context, args UpdateDashboardArgs) (_ *types.Dashboard, err error)
-	DeleteDashboard(ctx context.Context, id int64) error
+	DeleteDashboard(ctx context.Context, id int) error
+	RestoreDashboard(ctx context.Context, id int) error
 	HasDashboardPermission(ctx context.Context, dashboardId []int, userIds []int, orgIds []int) (bool, error)
 }
 


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/33808

## Description

We weren't handling the case where a customer enters Limited Access Mode (LAM), then upgrades, deletes their LAM dashboard, then goes back into trial mode for whatever reason. (Possibly an edge case, but an easy fix!)

So this makes sure that the LAM dashboard gets restored if it had previously been deleted.

## Test plan

1. Mark the LAM dashboard as deleted and make sure all of the insights are not currently frozen.
2. Start sourcegraph without a `code-insights` license.
3. Verify that the LAM dashboard has been restored.

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


