### PR TITLE
web: fix `stylelint` issues

### DIFF
--- a/client/vscode/.stylelintrc.json
+++ b/client/vscode/.stylelintrc.json
@@ -2,7 +2,12 @@
   "extends": ["../../.stylelintrc.json"],
   "overrides": [
     {
-      "files": ["./src/webview/index.scss"],
+      "files": [
+         "./src/webview/index.scss",
+         "./src/webview/forkedBranded.scss",
+         "./src/webview/theming/highlight.scss",
+         "./src/webview/theming/monaco.scss"
+      ],
       "rules": {
         "filenames/match-regex": null
       }

--- a/client/vscode/.stylelintrc.json
+++ b/client/vscode/.stylelintrc.json
@@ -3,10 +3,10 @@
   "overrides": [
     {
       "files": [
-         "./src/webview/index.scss",
-         "./src/webview/forkedBranded.scss",
-         "./src/webview/theming/highlight.scss",
-         "./src/webview/theming/monaco.scss"
+        "./src/webview/index.scss",
+        "./src/webview/forkedBranded.scss",
+        "./src/webview/theming/highlight.scss",
+        "./src/webview/theming/monaco.scss"
       ],
       "rules": {
         "filenames/match-regex": null

--- a/client/vscode/src/webview/forkedBranded.scss
+++ b/client/vscode/src/webview/forkedBranded.scss
@@ -6,7 +6,6 @@ $border-radius: var(--border-radius);
 $border-radius-sm: var(--border-radius);
 $border-radius-lg: var(--border-radius);
 $popover-border-radius: var(--popover-border-radius);
-
 $font-size-base: 0.875rem;
 $line-height-base: (20/14);
 

--- a/client/vscode/src/webview/index.scss
+++ b/client/vscode/src/webview/index.scss
@@ -12,14 +12,12 @@
         --code-bg: var(--vscode-editor-background);
         --color-bg-1: var(--vscode-editor-background);
         --color-bg-2: var(--vscode-editorWidget-background);
-
         --border-color: var(--vscode-editor-lineHighlightBorder);
         --border-color-2: var(--vscode-editor-lineHighlightBorder);
 
         // VS Code themes cannot change border radius, so we can safely hardcode it.
         --border-radius: 0;
         --popover-border-radius: 0;
-
         --dropdown-bg: var(--vscode-dropdown-background);
         --dropdown-border-color: var(--vscode-dropdown-border);
         --dropdown-header-color: var(--vscode-panelTitle-activeForeground);
@@ -29,6 +27,7 @@
             --primary: var(--vscode-textLink-foreground); // hover background
             --color-bg-3: var(--color-bg-3); // active background
 
+            /* stylelint-disable-next-line scss/selector-no-redundant-nesting-selector */
             & input {
                 background-color: var(--vscode-input-background) !important;
             }
@@ -83,6 +82,7 @@ body {
     font-family: var(--vscode-font-family);
     font-weight: var(--vscode-font-weight);
     font-size: var(--vscode-editor-font-size);
+
     --body-color: var(--vscode-dropdown-foreground);
 
     &.search-sidebar {

--- a/client/vscode/src/webview/search-panel/components/ButtonDropdownCta.module.scss
+++ b/client/vscode/src/webview/search-panel/components/ButtonDropdownCta.module.scss
@@ -18,7 +18,7 @@
 }
 
 .icon {
-    // stylelint-disable-next-line declaration-property-unit-whitelist
+    /* stylelint-disable-next-line declaration-property-unit-allowed-list */
     padding: 15px;
     color: var(--merged-3);
 

--- a/client/vscode/src/webview/search-panel/components/HomeFooter.module.scss
+++ b/client/vscode/src/webview/search-panel/components/HomeFooter.module.scss
@@ -56,7 +56,6 @@
 }
 
 .search-example-icon {
-    color: var(--primary);
     padding: 0.5rem 0.75rem;
     display: flex;
     align-items: center;
@@ -126,6 +125,7 @@
     text-transform: uppercase;
 }
 
+/* stylelint-disable-next-line selector-class-pattern */
 .thumbnailWrapper {
     padding: 0;
 

--- a/client/vscode/src/webview/search-panel/index.module.scss
+++ b/client/vscode/src/webview/search-panel/index.module.scss
@@ -42,7 +42,6 @@
 
 .logo-text {
     margin-top: 0.5rem;
-    align-items: center;
     font-style: italic;
     font-weight: normal;
     align-items: center;

--- a/client/vscode/src/webview/sidebars/search/SearchSidebarView.module.scss
+++ b/client/vscode/src/webview/sidebars/search/SearchSidebarView.module.scss
@@ -1,6 +1,7 @@
 .sidebar-container {
     padding: 0.125rem 0 0 0 !important;
 
+    /* stylelint-disable-next-line scss/selector-no-redundant-nesting-selector */
     & [data-reach-tabs] {
         // Override our default background color.
         background: none;

--- a/client/vscode/src/webview/theming/highlight.scss
+++ b/client/vscode/src/webview/theming/highlight.scss
@@ -1,3 +1,5 @@
+// stylelint-disable
+
 // Default token colors from "Dark (Visual Studio)" and "Light (Visual Studio)".
 // It's conservative, meaning it doesn't highlght more specific token types that
 // may correspond to different CSS variables across themes.

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "lint:js:all": "DOCSITE_LIST=\"$(./dev/docsite.sh -config doc/docsite.json ls)\" dev/foreach-ts-project.sh yarn -s run lint:js --quiet",
     "_lint:css": "stylelint",
     "lint:css:changed": "yarn _lint:css $(git diff --diff-filter=d --name-only main | grep -E '.s?css$' | xargs)",
-    "lint:css:all": "yarn _lint:css 'client/*/src/**/*.scss'",
+    "lint:css:all": "yarn _lint:css 'client/*/src/**/*.scss' --quiet",
     "lint:graphql": "graphql-schema-linter",
     "build-ts": "tsc -b tsconfig.all.json",
     "build-web": "yarn workspace @sourcegraph/web run build",


### PR DESCRIPTION
## Context

Fixing [the failed build on `main`](https://sourcegraph.slack.com/archives/C02FLQDD3TQ/p1649923230838839).

`stylelint` was disabled for the `vscode` package before [this PR](https://github.com/sourcegraph/sourcegraph/pull/33701). @tjkandala recently merged [the PR](https://github.com/sourcegraph/sourcegraph/issues/30084) with changes that `stylelint` didn't catch. This PR fixes those issues.

## Test plan

`yarn lint:css:all` should not give errors.



## App preview:

- [Link](https://sg-web-vb-fix-stylelint-issues.onrender.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

