### PR TITLE
github: Don't capture pointer in collector

### DIFF
--- a/internal/repos/github.go
+++ b/internal/repos/github.go
@@ -259,15 +259,17 @@ func newGithubSource(
 			"graphql": v4Client.RateLimitMonitor(),
 			"search":  searchClient.RateLimitMonitor(),
 		} {
-			// Need to copy the resource or func will use the last one seen while iterating
+			// Copy the resource or funcs below will use the last one seen while iterating
 			// the map
 			resource := resource
+			// Copy displayName so that the funcs below don't capture the svc pointer
+			displayName := svc.DisplayName
 			monitor.SetCollector(&ratelimit.MetricsCollector{
 				Remaining: func(n float64) {
-					githubRemainingGauge.WithLabelValues(resource, svc.DisplayName).Set(n)
+					githubRemainingGauge.WithLabelValues(resource, displayName).Set(n)
 				},
 				WaitDuration: func(n time.Duration) {
-					githubRatelimitWaitCounter.WithLabelValues(resource, svc.DisplayName).Add(n.Seconds())
+					githubRatelimitWaitCounter.WithLabelValues(resource, displayName).Add(n.Seconds())
 				},
 			})
 		}


### PR DESCRIPTION
We're seeing metrics being collected with names of non site owned
external services, this should not be the case as we only set up
collectors for site owned external services. The only way the wrong name
could be coming through is if the pointer to the service that is
captured by the collector closure is changed at some point. It's not
clear where this could happen, but by passing the name through as a
value we avoid this possibility.

The affected dashboard is [here](https://sourcegraph.com/-/debug/grafana/explore?orgId=1&left=%5B%22now-6h%22,%22now%22,%22Prometheus%22,%7B%22expr%22:%22max%20by%20(name)%20(src_github_rate_limit_remaining_v2%7Bresource%3D%5C%22rest%5C%22%7D)%22,%22datasource%22:%22Prometheus%22,%22exemplar%22:true,%22requestId%22:%22Q-e2754d2d-919d-4746-93ac-bcec2be61000-0A%22%7D%5D)

# Test plan

Deploy and check dashboard again