### PR TITLE
New ref panel: filter results client-side when using search-based

### DIFF
--- a/client/web/src/codeintel/useCodeIntel.ts
+++ b/client/web/src/codeintel/useCodeIntel.ts
@@ -159,6 +159,7 @@ export const useCodeIntel = ({
         repo: variables.repository,
         commit: variables.commit,
         path: variables.path,
+        filter: variables.filter ?? undefined,
         searchToken,
         fileContent,
         spec,


### PR DESCRIPTION
This fixes #33412 by filtering the search-based results client side to
get back to feature parity.

## Test plan

- Tested manually



## App preview:

- [Link](https://sg-web-mrn-filter-search-based.onrender.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

