### PR TITLE
Fix lsif-typescript in GitHub action

### DIFF
--- a/.github/workflows/lsif-typescript.yml
+++ b/.github/workflows/lsif-typescript.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install lsif-typescript
         run: yarn global add @sourcegraph/lsif-typescript
       - name: Run lsif-typescript
-        run: lsif-typescript index --yarnWorkspaces
+        run: lsif-typescript index --yarn-workspaces
       - uses: actions/setup-go@v2
         with: { go-version: '1.17' }
       - name: Convert LSIF Typed into LSIF Graph


### PR DESCRIPTION
Seems like the arg has been changed a few weeks ago (see
1abc1be3196fd0c4b3af160063d339ab719ce468), but only published yesterday: https://github.com/sourcegraph/lsif-typescript/commit/dff7f7dd5d286d30d45081a4a704e97ef0c72cc0

This changes the arg to the new version.

## Test plan

- N/A


