### PR TITLE
syntax-highlighter: fix clippy warnings

### DIFF
--- a/docker-images/syntax-highlighter/crates/sg-macros/src/lib.rs
+++ b/docker-images/syntax-highlighter/crates/sg-macros/src/lib.rs
@@ -48,8 +48,8 @@ pub fn include_project_file_optional(input: TokenStream) -> TokenStream {
     let literals = parse_macro_input!(input as IncludeOptional).literals;
 
     // project files are always relative to the Cargo.toml of the compiling project.
-    let base = std::env::var("CARGO_MANIFEST_DIR").unwrap().to_owned() + "/";
-    let filepath: PathBuf = literals.iter().fold(base, |acc, lit| acc + &lit).into();
+    let base = std::env::var("CARGO_MANIFEST_DIR").unwrap() + "/";
+    let filepath: PathBuf = literals.iter().fold(base, |acc, lit| acc + lit).into();
 
     if filepath.exists() {
         let filepath = filepath

--- a/docker-images/syntax-highlighter/crates/sg-syntax/src/sg_treesitter.rs
+++ b/docker-images/syntax-highlighter/crates/sg-syntax/src/sg_treesitter.rs
@@ -127,12 +127,10 @@ pub fn lsif_highlight(q: SourcegraphQuery) -> Result<JsonValue, JsonValue> {
 }
 
 pub fn index_language(filetype: &str, code: &str) -> Result<Document, Error> {
-    let lang_config = match CONFIGURATIONS.get(filetype) {
-        Some(lang_config) => lang_config,
-        None => return Err(Error::InvalidLanguage),
-    };
-
-    index_language_with_config(code, &lang_config)
+    match CONFIGURATIONS.get(filetype) {
+        Some(lang_config) => index_language_with_config(code, lang_config),
+        None => Err(Error::InvalidLanguage),
+    }
 }
 
 pub fn make_highlight_config(name: &str, highlights: &str) -> Option<HighlightConfiguration> {
@@ -456,7 +454,7 @@ SELECT * FROM my_table
     #[test]
     fn test_all_files() -> Result<(), std::io::Error> {
         let dir = read_dir("./src/snapshots/files/")?;
-        for entry in dir.into_iter() {
+        for entry in dir {
             let entry = entry?;
             let filepath = entry.path();
             let mut file = File::open(&filepath)?;

--- a/docker-images/syntax-highlighter/src/bin/lsif-syntax-repl.rs
+++ b/docker-images/syntax-highlighter/src/bin/lsif-syntax-repl.rs
@@ -52,10 +52,10 @@ fn main() {
         _ => return,
     };
 
-    eprintln!("");
+    eprintln!();
     eprintln!("Usage Instructions:");
     eprintln!("- <Up> / <Down> to cycle through history");
-    eprintln!("");
+    eprintln!();
 
     while let Ok(line) = rl.readline("Query >> ") {
         if line.is_empty() {


### PR DESCRIPTION
These clippy warnings showed up while reading through the code.

The `match` I changed on my own. Happy to change it back if it's too
dense.


## Test plan

- Existing tests
