### PR TITLE
Add notebooks to main navbar

### DIFF
--- a/client/web/src/nav/GlobalNavbar.tsx
+++ b/client/web/src/nav/GlobalNavbar.tsx
@@ -3,6 +3,7 @@ import React, { useEffect, useMemo } from 'react'
 import classNames from 'classnames'
 import * as H from 'history'
 import BarChartIcon from 'mdi-react/BarChartIcon'
+import BookOutlineIcon from 'mdi-react/BookOutlineIcon'
 import MagnifyIcon from 'mdi-react/MagnifyIcon'
 import PuzzleOutlineIcon from 'mdi-react/PuzzleOutlineIcon'
 import { of } from 'rxjs'
@@ -199,13 +200,9 @@ export const GlobalNavbar: React.FunctionComponent<Props> = ({
         const items: (NavDropdownItem | false)[] = [
             searchContextsEnabled &&
                 !!showSearchContext && { path: EnterprisePageRoutes.Contexts, content: 'Contexts' },
-            !!showSearchNotebook && {
-                path: PageRoutes.Notebooks,
-                content: 'Notebooks',
-            },
         ]
         return items.filter<NavDropdownItem>((item): item is NavDropdownItem => !!item)
-    }, [searchContextsEnabled, showSearchNotebook, showSearchContext])
+    }, [searchContextsEnabled, showSearchContext])
 
     return (
         <>
@@ -225,6 +222,11 @@ export const GlobalNavbar: React.FunctionComponent<Props> = ({
                         mobileHomeItem={{ content: 'Search home' }}
                         items={searchNavBarItems}
                     />
+                    {showSearchNotebook && (
+                        <NavItem icon={BookOutlineIcon}>
+                            <NavLink to={PageRoutes.Notebooks}>Notebooks</NavLink>
+                        </NavItem>
+                    )}
                     {enableCodeMonitoring && (
                         <NavItem icon={CodeMonitoringLogo}>
                             <NavLink to="/code-monitoring">Monitoring</NavLink>

--- a/client/web/src/notebooks/listPage/NotebooksListPage.tsx
+++ b/client/web/src/notebooks/listPage/NotebooksListPage.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react'
 
 import classNames from 'classnames'
 import * as H from 'history'
-import MagnifyIcon from 'mdi-react/MagnifyIcon'
+import BookOutlineIcon from 'mdi-react/BookOutlineIcon'
 import PlusIcon from 'mdi-react/PlusIcon'
 import { Redirect, useHistory, useLocation } from 'react-router'
 import { Observable } from 'rxjs'
@@ -231,7 +231,7 @@ export const NotebooksListPage: React.FunctionComponent<NotebooksListPageProps> 
         <div className="w-100">
             <Page>
                 <PageHeader
-                    path={[{ icon: MagnifyIcon, to: '/search', ariaLabel: 'Code search' }, { text: 'Notebooks' }]}
+                    path={[{ icon: BookOutlineIcon, text: 'Notebooks' }]}
                     actions={
                         authenticatedUser && (
                             <>

--- a/client/web/src/notebooks/notebookPage/NotebookPage.tsx
+++ b/client/web/src/notebooks/notebookPage/NotebookPage.tsx
@@ -1,8 +1,8 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import classNames from 'classnames'
+import BookOutlineIcon from 'mdi-react/BookOutlineIcon'
 import CheckCircleIcon from 'mdi-react/CheckCircleIcon'
-import MagnifyIcon from 'mdi-react/MagnifyIcon'
 import { RouteComponentProps } from 'react-router'
 import { Observable } from 'rxjs'
 import { catchError, delay, startWith, switchMap } from 'rxjs/operators'
@@ -198,8 +198,7 @@ export const NotebookPage: React.FunctionComponent<NotebookPageProps> = ({
                             <PageHeader
                                 className="mt-2"
                                 path={[
-                                    { icon: MagnifyIcon, to: '/search', ariaLabel: 'Code search' },
-                                    { to: '/notebooks', text: 'Notebooks' },
+                                    { to: '/notebooks', icon: BookOutlineIcon, ariaLabel: 'Notebooks' },
                                     {
                                         text: (
                                             <NotebookTitle


### PR DESCRIPTION
Adding notebooks in the main nav bar and refactoring the header on list and notebook pages.

Screenshots:

<img width="904" alt="Screenshot 2022-04-14 at 15 50 05" src="https://user-images.githubusercontent.com/6417322/163404890-290e09d8-c3b5-4b70-8680-f26a927eb339.png">
<img width="1195" alt="Screenshot 2022-04-14 at 15 44 34" src="https://user-images.githubusercontent.com/6417322/163404914-5b5cedc8-0aa1-46bd-a490-e0dd60e56332.png">
<img width="1279" alt="Screenshot 2022-04-14 at 15 44 38" src="https://user-images.githubusercontent.com/6417322/163404929-d7db7bce-ccfd-413b-bc43-28797783dde0.png">

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

* Manually testing that the Notebooks nav item shows up, and testing on mobile screen sizes

## App preview:

- [Link](https://sg-web-rn-notebooks-nav-items-refactor.onrender.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

