### PR TITLE
gitserver: Increase client parallelism for BatchLog

### DIFF
--- a/internal/gitserver/client.go
+++ b/internal/gitserver/client.go
@@ -784,15 +784,19 @@ func (c *ClientImplementor) BatchLog(ctx context.Context, opts BatchLogOptions, 
 		})
 	}
 
-	// Perform each batch request concurrently, but only allow four requests to be
-	// in-flight at a time. This operation returns partial results in the case of a
-	// malformed or missing repository or a bad commit reference, but does not
-	// attempt to return partial results when an entire shard is down. Any of these
-	// operations failing will cause an error to be returned from the entire BatchLog
-	// function.
+	// Perform each batch request concurrently up to a maximum limit of 16 requests
+	// in-flight at one time.
+	//
+	// This limit will be useless in practice most of the  time as we should only be
+	// making one request per shard and instances should _generally_ have fewer than
+	// 16 gitserver shards. This condition is really to catch unexpected bad behavior.
+	//
+	// This operation returns partial results in the case of a malformed or missing
+	// repository or a bad commit reference, but does not attempt to return partial
+	// results when an entire shard is down. Any of these operations failing will
+	// cause an error to be returned from the entire BatchLog function.
 
-	limit := int64(4)
-	sem := semaphore.NewWeighted(limit)
+	sem := semaphore.NewWeighted(int64(16))
 	g, ctx := errgroup.WithContext(ctx)
 
 	for addr, repoCommits := range batches {


### PR DESCRIPTION
Increase concurrent requests for each gitserver client `BatchLog` operation from 4 to 32. This should be safe as each request should be hitting a different gitserver address, so we're currently leaving performance on the table.

Should improve issue described in #32328.

## Test plan

Existing integration tests.