### PR TITLE
dev/sg: remove global secrets store

### DIFF
--- a/dev/sg/internal/bk/bk.go
+++ b/dev/sg/internal/bk/bk.go
@@ -29,9 +29,12 @@ func retrieveToken(ctx context.Context, out *output.Output) (string, error) {
 		return tok, nil
 	}
 
-	sec := secrets.FromContext(ctx)
+	sec, err := secrets.FromContext(ctx)
+	if err != nil {
+		return "", err
+	}
 	bkSecrets := buildkiteSecrets{}
-	err := sec.Get("buildkite", &bkSecrets)
+	err = sec.Get("buildkite", &bkSecrets)
 	if errors.Is(err, secrets.ErrSecretNotFound) {
 		str, err := getTokenFromUser(out)
 		if err != nil {

--- a/dev/sg/internal/rfc/rfc.go
+++ b/dev/sg/internal/rfc/rfc.go
@@ -24,7 +24,10 @@ const (
 
 // Retrieve a token, saves the token, then returns the generated client.
 func getClient(ctx context.Context, config *oauth2.Config, out *output.Output) (*http.Client, error) {
-	sec := secrets.FromContext(ctx)
+	sec, err := secrets.FromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
 	tok := &oauth2.Token{}
 	if err := sec.Get("rfc", tok); err != nil {
 		// ...if it doesn't exist, open browser and ask user to give us

--- a/dev/sg/internal/secrets/store.go
+++ b/dev/sg/internal/secrets/store.go
@@ -9,6 +9,10 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
+const (
+	DefaultFile = "sg.secrets.json"
+)
+
 var (
 	ErrSecretNotFound = errors.New("secret not found")
 )

--- a/dev/sg/internal/secrets/store.go
+++ b/dev/sg/internal/secrets/store.go
@@ -25,12 +25,13 @@ type Store struct {
 
 type storeKey struct{}
 
-// FromContext fetches a store from context.
-func FromContext(ctx context.Context) *Store {
+// FromContext fetches a store from context. In sg, a store is set in the command context
+// when sg starts - if the load fails, an error is printed and a store is not set.
+func FromContext(ctx context.Context) (*Store, error) {
 	if store, ok := ctx.Value(storeKey{}).(*Store); ok {
-		return store
+		return store, nil
 	}
-	return nil
+	return nil, errors.New("secrets store not available")
 }
 
 // WithContext stores a Store in the context.
@@ -38,15 +39,15 @@ func WithContext(ctx context.Context, store *Store) context.Context {
 	return context.WithValue(ctx, storeKey{}, store)
 }
 
-// New returns an empty store that if saved, will be written at filepath.
-func New(filepath string) *Store {
+// newStore returns an empty store that if saved, will be written at filepath.
+func newStore(filepath string) *Store {
 	return &Store{filepath: filepath, m: map[string]json.RawMessage{}}
 }
 
-// LoadFile deserialize from a file into a Store, returning an error if
+// LoadFromFile deserialize from a file into a Store, returning an error if
 // deserialization fails.
-func LoadFile(filepath string) (*Store, error) {
-	s := New(filepath)
+func LoadFromFile(filepath string) (*Store, error) {
+	s := newStore(filepath)
 	f, err := os.Open(filepath)
 	if err != nil {
 		if os.IsNotExist(err) {

--- a/dev/sg/internal/secrets/store_test.go
+++ b/dev/sg/internal/secrets/store_test.go
@@ -15,7 +15,7 @@ type mySecrets struct {
 func TestSecrets(t *testing.T) {
 	t.Run("Put and Get", func(t *testing.T) {
 		data := mySecrets{ID: "foo", Secret: "bar"}
-		store := New("")
+		store := newStore("")
 		err := store.Put("foo", data)
 		if err != nil {
 			t.Fatalf("want no error, got %v", err)
@@ -45,7 +45,7 @@ func TestSecrets(t *testing.T) {
 		})
 
 		// Assign a secret and save it
-		s, err := LoadFile(filepath)
+		s, err := LoadFromFile(filepath)
 		if err != nil {
 			t.Fatalf("%v", err)
 		}
@@ -57,7 +57,7 @@ func TestSecrets(t *testing.T) {
 		}
 
 		// Fetch it back and compare
-		got, err := LoadFile(filepath)
+		got, err := LoadFromFile(filepath)
 		if err != nil {
 			t.Fatalf("%v", err)
 		}

--- a/dev/sg/internal/slack/slack.go
+++ b/dev/sg/internal/slack/slack.go
@@ -28,9 +28,12 @@ func NewClient(ctx context.Context) (*slack.Client, error) {
 
 // retrieveToken obtains a token either from the cached configuration or by asking the user for it.
 func retrieveToken(ctx context.Context) (string, error) {
-	sec := secrets.FromContext(ctx)
+	sec, err := secrets.FromContext(ctx)
+	if err != nil {
+		return "", err
+	}
 	tok := slackToken{}
-	err := sec.Get("slack", &tok)
+	err = sec.Get("slack", &tok)
 	if errors.Is(err, secrets.ErrSecretNotFound) {
 		str, err := getTokenFromUser()
 		if err != nil {

--- a/dev/sg/main.go
+++ b/dev/sg/main.go
@@ -188,5 +188,5 @@ func loadSecrets() (*secrets.Store, error) {
 		return nil, err
 	}
 	fp := filepath.Join(homePath, secrets.DefaultFile)
-	return secrets.LoadFile(fp)
+	return secrets.LoadFromFile(fp)
 }

--- a/dev/sg/main.go
+++ b/dev/sg/main.go
@@ -27,15 +27,8 @@ func main() {
 	}
 }
 
-const (
-	defaultSecretsFile = "sg.secrets.json"
-)
-
 var (
 	BuildCommit = "dev"
-
-	// secretsStore is instantiated when sg gets run.
-	secretsStore *secrets.Store
 
 	// configFile is the path to use with sgconf.Get - it must not be used before flag
 	// initialization.
@@ -122,10 +115,12 @@ var sg = &cli.App{
 		}
 
 		// Set up access to secrets
-		if err := loadSecrets(); err != nil {
+		secretsStore, err := loadSecrets()
+		if err != nil {
 			writeWarningLinef("failed to open secrets: %s", err)
+		} else {
+			cmd.Context = secrets.WithContext(cmd.Context, secretsStore)
 		}
-		cmd.Context = secrets.WithContext(cmd.Context, secretsStore)
 
 		// We always try to set this, since we often want to watch files, start commands, etc...
 		if err := setMaxOpenFiles(); err != nil {
@@ -187,12 +182,11 @@ var sg = &cli.App{
 	HideHelpCommand: true,
 }
 
-func loadSecrets() error {
+func loadSecrets() (*secrets.Store, error) {
 	homePath, err := root.GetSGHomePath()
 	if err != nil {
-		return err
+		return nil, err
 	}
-	fp := filepath.Join(homePath, defaultSecretsFile)
-	secretsStore, err = secrets.LoadFile(fp)
-	return err
+	fp := filepath.Join(homePath, secrets.DefaultFile)
+	return secrets.LoadFile(fp)
 }

--- a/dev/sg/sg_secret.go
+++ b/dev/sg/sg_secret.go
@@ -52,7 +52,10 @@ func resetSecretExec(ctx context.Context, args []string) error {
 		return errors.New("no key provided to reset")
 	}
 
-	secretsStore := secrets.FromContext(ctx)
+	secretsStore, err := secrets.FromContext(ctx)
+	if err != nil {
+		return err
+	}
 	for _, arg := range args {
 		if err := secretsStore.Remove(arg); err != nil {
 			return err
@@ -66,7 +69,10 @@ func resetSecretExec(ctx context.Context, args []string) error {
 }
 
 func listSecretExec(ctx context.Context, args []string) error {
-	secretsStore := secrets.FromContext(ctx)
+	secretsStore, err := secrets.FromContext(ctx)
+	if err != nil {
+		return err
+	}
 	stdout.Out.WriteLine(output.Linef("", output.StyleBold, "Secrets:"))
 	keys := secretsStore.Keys()
 	if secretListViewFlag {

--- a/dev/sg/sg_secret.go
+++ b/dev/sg/sg_secret.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/urfave/cli/v2"
 
+	"github.com/sourcegraph/sourcegraph/dev/sg/internal/secrets"
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/stdout"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 	"github.com/sourcegraph/sourcegraph/lib/output"
@@ -51,10 +52,7 @@ func resetSecretExec(ctx context.Context, args []string) error {
 		return errors.New("no key provided to reset")
 	}
 
-	if err := loadSecrets(); err != nil {
-		return err
-	}
-
+	secretsStore := secrets.FromContext(ctx)
 	for _, arg := range args {
 		if err := secretsStore.Remove(arg); err != nil {
 			return err
@@ -68,9 +66,7 @@ func resetSecretExec(ctx context.Context, args []string) error {
 }
 
 func listSecretExec(ctx context.Context, args []string) error {
-	if err := loadSecrets(); err != nil {
-		return err
-	}
+	secretsStore := secrets.FromContext(ctx)
 	stdout.Out.WriteLine(output.Linef("", output.StyleBold, "Secrets:"))
 	keys := secretsStore.Keys()
 	if secretListViewFlag {


### PR DESCRIPTION
Continuing removals of globals that may-or-may-not-be-there

Stacked on https://github.com/sourcegraph/sourcegraph/pull/33882

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

Build and check `./sg secrets list`