### PR TITLE
Search backend: remove ResultCount from SearchResultResolver interface

### DIFF
--- a/cmd/frontend/graphqlbackend/commit_search_result.go
+++ b/cmd/frontend/graphqlbackend/commit_search_result.go
@@ -94,7 +94,3 @@ func (r *CommitSearchResultResolver) ToFileMatch() (*FileMatchResolver, bool)   
 func (r *CommitSearchResultResolver) ToCommitSearchResult() (*CommitSearchResultResolver, bool) {
 	return r, true
 }
-
-func (r *CommitSearchResultResolver) ResultCount() int32 {
-	return 1
-}

--- a/cmd/frontend/graphqlbackend/file_match.go
+++ b/cmd/frontend/graphqlbackend/file_match.go
@@ -73,10 +73,6 @@ func (fm *FileMatchResolver) ToCommitSearchResult() (*CommitSearchResultResolver
 	return nil, false
 }
 
-func (fm *FileMatchResolver) ResultCount() int32 {
-	return int32(fm.FileMatch.ResultCount())
-}
-
 type lineMatchResolver struct {
 	*result.LineMatch
 }

--- a/cmd/frontend/graphqlbackend/repository.go
+++ b/cmd/frontend/graphqlbackend/repository.go
@@ -295,10 +295,6 @@ func (r *RepositoryResolver) ToCommitSearchResult() (*CommitSearchResultResolver
 	return nil, false
 }
 
-func (r *RepositoryResolver) ResultCount() int32 {
-	return 1
-}
-
 func (r *RepositoryResolver) Type(ctx context.Context) (*types.Repo, error) {
 	return r.repo(ctx)
 }

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -677,6 +677,4 @@ type SearchResultResolver interface {
 	ToRepository() (*RepositoryResolver, bool)
 	ToFileMatch() (*FileMatchResolver, bool)
 	ToCommitSearchResult() (*CommitSearchResultResolver, bool)
-
-	ResultCount() int32
 }


### PR DESCRIPTION
This removes ResultCount from the interface of SearchResultResolver. It
was previously used widely when resolvers were used as our primary
types, but now it's not used at all. It is not required by the GraphQL
schema, so there is no reason to keep it on the resolver type.

## Test plan

Removing dead code. Any issues should be caught statically.

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


