### PR TITLE
schema: escape html characters

### DIFF
--- a/internal/database/migration/schemas/formatter_psql.go
+++ b/internal/database/migration/schemas/formatter_psql.go
@@ -2,6 +2,7 @@ package schemas
 
 import (
 	"fmt"
+	"html"
 	"math"
 	"sort"
 	"strconv"
@@ -53,7 +54,6 @@ func (f psqlFormatter) formatTable(schemaDescription SchemaDescription, table Ta
 	}
 
 	formatColumns := func(headers []string, rows [][]string) []string {
-
 		sizes := make([]int, len(headers))
 		headerValues := make([]string, len(headers))
 		sepValues := make([]string, len(headers))
@@ -212,13 +212,13 @@ func (f psqlFormatter) formatTable(schemaDescription SchemaDescription, table Ta
 	docs = append(docs, "\n```\n")
 
 	if table.Comment != "" {
-		docs = append(docs, table.Comment+"\n")
+		docs = append(docs, html.EscapeString(table.Comment)+"\n")
 	}
 
 	sortColumnsByName(table.Columns)
 	for _, column := range table.Columns {
 		if column.Comment != "" {
-			docs = append(docs, fmt.Sprintf("**%s**: %s\n", column.Name, column.Comment))
+			docs = append(docs, fmt.Sprintf("**%s**: %s\n", column.Name, html.EscapeString(column.Comment)))
 		}
 	}
 

--- a/internal/database/schema.codeinsights.md
+++ b/internal/database/schema.codeinsights.md
@@ -216,7 +216,7 @@ Views for insight data series. An insight view is an abstraction on top of an in
 
 **id**: Primary key ID for this view
 
-**other_threshold**: Percent threshold for grouping series under "other"
+**other_threshold**: Percent threshold for grouping series under &#34;other&#34;
 
 **presentation_type**: The basic presentation type for the insight view. (e.g Line, Pie, etc.)
 
@@ -297,7 +297,7 @@ Records arbitrary metadata about events. Stored in a separate table as it is oft
 
 **id**: The metadata ID.
 
-**metadata**: Metadata about some event, this can be any arbitrary JSON emtadata which will be returned when querying events, and can be filtered on and grouped using jsonb operators ?, ?&, ?|, and @>. This should be small data only.
+**metadata**: Metadata about some event, this can be any arbitrary JSON emtadata which will be returned when querying events, and can be filtered on and grouped using jsonb operators ?, ?&amp;, ?|, and @&gt;. This should be small data only.
 
 # Table "public.migration_logs"
 ```

--- a/internal/database/schema.codeintel.md
+++ b/internal/database/schema.codeintel.md
@@ -259,7 +259,7 @@ A tsvector search index over API documentation (private repos only)
 
 **lang_name_id**: The programming language (or indexer name) that produced the result. Foreign key into lsif_data_docs_search_lang_names_private.
 
-**path_id**: The fully qualified documentation page path ID, e.g. including "#section". See GraphQL codeintel.schema:documentationPage for what this is.
+**path_id**: The fully qualified documentation page path ID, e.g. including &#34;#section&#34;. See GraphQL codeintel.schema:documentationPage for what this is.
 
 **repo_id**: The repo ID, from the main app DB repo table. Used to search over a select set of repos by ID.
 
@@ -329,7 +329,7 @@ A tsvector search index over API documentation (public repos only)
 
 **lang_name_id**: The programming language (or indexer name) that produced the result. Foreign key into lsif_data_docs_search_lang_names_public.
 
-**path_id**: The fully qualified documentation page path ID, e.g. including "#section". See GraphQL codeintel.schema:documentationPage for what this is.
+**path_id**: The fully qualified documentation page path ID, e.g. including &#34;#section&#34;. See GraphQL codeintel.schema:documentationPage for what this is.
 
 **repo_id**: The repo ID, from the main app DB repo table. Used to search over a select set of repos by ID.
 

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -1075,7 +1075,7 @@ Referenced by:
 
 ```
 
-See [enterprise/internal/insights/background/queryrunner/worker.go:Job](https://sourcegraph.com/search?q=repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+file:enterprise/internal/insights/background/queryrunner/worker.go+type+Job&patternType=literal)
+See [enterprise/internal/insights/background/queryrunner/worker.go:Job](https://sourcegraph.com/search?q=repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+file:enterprise/internal/insights/background/queryrunner/worker.go+type+Job&amp;patternType=literal)
 
 **cost**: Integer representing a cost approximation of executing this search query.
 
@@ -1271,7 +1271,7 @@ Indexes:
 
 ```
 
-Stores whether or not the nearest upload data for a repository is out of date (when update_token > dirty_token).
+Stores whether or not the nearest upload data for a repository is out of date (when update_token &gt; dirty_token).
 
 **dirty_token**: Set to the value of update_token visible to the transaction that updates the commit graph. Updates of dirty_token during this time will cause a second update.
 
@@ -1347,7 +1347,7 @@ Stores metadata about a code intel index job.
 
 **indexer**: The docker image used to run the index command (e.g. sourcegraph/lsif-go).
 
-**indexer_args**: The command run inside the indexer image to produce the index file (e.g. ['lsif-node', '-p', '.'])
+**indexer_args**: The command run inside the indexer image to produce the index file (e.g. [&#39;lsif-node&#39;, &#39;-p&#39;, &#39;.&#39;])
 
 **local_steps**: A list of commands to run inside the indexer image prior to running the indexer command.
 
@@ -1404,7 +1404,7 @@ Associates commits with the complete set of uploads visible from that commit. Ev
 
 **commit_bytea**: A 40-char revhash. Note that this commit may not be resolvable in the future.
 
-**uploads**: Encodes an {upload_id => distance} map that includes an entry for every upload visible from the commit. There is always at least one entry with a distance of zero.
+**uploads**: Encodes an {upload_id =&gt; distance} map that includes an entry for every upload visible from the commit. There is always at least one entry with a distance of zero.
 
 # Table "public.lsif_nearest_uploads_links"
 ```


### PR DESCRIPTION
Text surrounded by `< ... >` would disappear after being converted as theyd be taken as a HTML tag. This PR escapes comments to avoid this happening

## Test plan

Just docs changes
