### PR TITLE
gitserver: support suffix .git for go modules 

### DIFF
--- a/internal/gitserver/protocol/util.go
+++ b/internal/gitserver/protocol/util.go
@@ -10,30 +10,35 @@ import (
 
 func NormalizeRepo(input api.RepoName) api.RepoName {
 	repo := string(input)
+
+	host := ""
+	firstSlash := strings.IndexByte(repo, '/')
+	if firstSlash != -1 {
+		host = strings.ToLower(repo[:firstSlash]) // host is always case-insensitive
+	}
+
 	repo = strings.TrimSuffix(repo, ".git")
 
 	// Clean with a "/" so we get out an absolute path
 	repo = path.Clean("/" + repo)
 	repo = strings.TrimPrefix(repo, "/")
 
-	// Check if we need to do lowercasing. If we don't we can avoid the
+	// Check if we need to do lower-casing. If we don't we can avoid the
 	// allocations we do later in the function.
 	if !hasUpperASCII(repo) {
 		return api.RepoName(repo)
 	}
 
-	slash := strings.IndexByte(repo, '/')
-	if slash == -1 {
+	if host == "" {
 		return api.RepoName(repo)
 	}
-	host := strings.ToLower(repo[:slash]) // host is always case insensitive
-	path := repo[slash:]
 
+	repoPath := repo[firstSlash:]
 	if host == "github.com" {
-		return api.RepoName(host + strings.ToLower(path)) // GitHub is fully case insensitive
+		return api.RepoName(host + strings.ToLower(repoPath)) // GitHub is fully case insensitive
 	}
 
-	return api.RepoName(host + path) // other git hosts can be case sensitive on path
+	return api.RepoName(host + repoPath) // other git hosts can be case sensitive on path
 }
 
 // hasUpperASCII returns true if s contains any upper-case letters in ASCII,

--- a/internal/gitserver/protocol/util_test.go
+++ b/internal/gitserver/protocol/util_test.go
@@ -16,7 +16,7 @@ func TestNormalizeRepo(t *testing.T) {
 		"myServer.Com/FooBar.git":  "myserver.com/FooBar",
 		"myServer.Com/FooBar/.git": "myserver.com/FooBar",
 
-		// support repos with suffix .git for go/ host
+		// support repos with suffix .git for Go
 		"go/git.foo.org/bar.git": "go/git.foo.org/bar.git",
 
 		// trying to escape gitserver root

--- a/internal/gitserver/protocol/util_test.go
+++ b/internal/gitserver/protocol/util_test.go
@@ -16,6 +16,9 @@ func TestNormalizeRepo(t *testing.T) {
 		"myServer.Com/FooBar.git":  "myserver.com/FooBar",
 		"myServer.Com/FooBar/.git": "myserver.com/FooBar",
 
+		// support repos with suffix .git for go/ host
+		"go/git.foo.org/bar.git": "go/git.foo.org/bar.git",
+
 		// trying to escape gitserver root
 		"/etc/passwd":                       "etc/passwd",
 		"../../../etc/passwd":               "etc/passwd",

--- a/internal/gitserver/protocol/util_test.go
+++ b/internal/gitserver/protocol/util_test.go
@@ -9,6 +9,9 @@ import (
 func TestNormalizeRepo(t *testing.T) {
 	cases := map[api.RepoName]api.RepoName{
 		"FooBar.git":               "FooBar",
+		"foobar":                   "foobar",
+		"FooBar":                   "FooBar",
+		"foo/bar":                  "foo/bar",
 		"gitHub.Com/FooBar.git":    "github.com/foobar",
 		"myServer.Com/FooBar.git":  "myserver.com/FooBar",
 		"myServer.Com/FooBar/.git": "myserver.com/FooBar",


### PR DESCRIPTION
With this change we don't remove the suffix ".git" if the code host is a go module proxy.

Go supports module names with suffix ".git", see for example git.apache.org/thrift.git ([sourcegraph](https://sourcegraph.com/search?q=context:global+file:go.mod+thrift.git+not+replace&patternType=literal), [pkg.go.dev](https://pkg.go.dev/git.apache.org/thrift.git)). So far, we removed the suffix for all code hosts during normalization, which meant we weren't able to clone thrift.git.

## Test plan
- Unit tests
- I ran a local instance of Sourcegraph and confirmed that thrift.git, as a dependency, is now clonable and searchable.

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


