### PR TITLE
dev/sg: levenshtein suggestions when subcommand not found

### DIFF
--- a/dev/sg/main.go
+++ b/dev/sg/main.go
@@ -175,6 +175,8 @@ var sg = &cli.App{
 		funkyLogoCommand,
 	},
 
+	CommandNotFound: suggestCommands,
+
 	EnableBashCompletion:   true,
 	UseShortOptionHandling: true,
 

--- a/dev/sg/main_test.go
+++ b/dev/sg/main_test.go
@@ -44,8 +44,10 @@ func TestCommandFormatting(t *testing.T) {
 
 func testCommandFormatting(t *testing.T, cmd *cli.Command) {
 	t.Run(cmd.Name, func(t *testing.T) {
+		assert.NotEmpty(t, cmd.Name, "Name should be set")
 		assert.NotEmpty(t, cmd.Usage, "Usage should be set")
 		assert.False(t, strings.HasSuffix(cmd.Usage, "."), "Usage should not end with period")
+		assert.NotNil(t, cmd.Action, "Action must be provided (for parent commands, 'suggestSubcommandsAction'")
 
 		for _, subCmd := range cmd.Subcommands {
 			testCommandFormatting(t, subCmd)

--- a/dev/sg/sg_audit.go
+++ b/dev/sg/sg_audit.go
@@ -27,7 +27,7 @@ var auditCommand = &cli.Command{
 	ArgsUsage: "[target]",
 	Hidden:    true,
 	Category:  CategoryCompany,
-	Action:    cli.ShowSubcommandHelp,
+	Action:    suggestSubcommandsAction,
 	Subcommands: []*cli.Command{{
 		Name:  "pr",
 		Usage: "Display audit trail for pull requests",

--- a/dev/sg/sg_ci.go
+++ b/dev/sg/sg_ci.go
@@ -74,7 +74,7 @@ var ciCommand = &cli.Command{
 
 Note that Sourcegraph's CI pipelines are under our enterprise license: https://github.com/sourcegraph/sourcegraph/blob/main/LICENSE.enterprise`,
 	Category: CategoryDev,
-	Action:   cli.ShowSubcommandHelp,
+	Action:   suggestSubcommandsAction,
 	Subcommands: []*cli.Command{{
 		Name:    "preview",
 		Aliases: []string{"plan"},

--- a/dev/sg/sg_db.go
+++ b/dev/sg/sg_db.go
@@ -30,7 +30,7 @@ var (
 	dbCommand = &cli.Command{
 		Name:     "db",
 		Usage:    "Interact with local Sourcegraph databases for development",
-		Action:   cli.ShowSubcommandHelp,
+		Action:   suggestSubcommandsAction,
 		Category: CategoryDev,
 		Subcommands: []*cli.Command{
 			{

--- a/dev/sg/sg_migration.go
+++ b/dev/sg/sg_migration.go
@@ -82,7 +82,7 @@ var (
 		Name:     "migration",
 		Usage:    "Modifies and runs database migrations",
 		Category: CategoryDev,
-		Action:   cli.ShowSubcommandHelp,
+		Action:   suggestSubcommandsAction,
 		Subcommands: []*cli.Command{
 			addCommand,
 			revertCommand,

--- a/dev/sg/sg_ops.go
+++ b/dev/sg/sg_ops.go
@@ -22,7 +22,7 @@ var (
 		Usage:       "Commands used by operations teams to perform common tasks",
 		Description: constructOpsCmdLongHelp(),
 		Category:    CategoryCompany,
-		Action:      cli.ShowSubcommandHelp,
+		Action:      suggestSubcommandsAction,
 		Subcommands: []*cli.Command{opsUpdateImagesCommand},
 	}
 

--- a/dev/sg/sg_secret.go
+++ b/dev/sg/sg_secret.go
@@ -21,7 +21,7 @@ var (
 		ArgsUsage: "<...subcommand>",
 		Usage:     "Manipulate secrets stored in memory and in file",
 		Category:  CategoryEnv,
-		Action:    cli.ShowSubcommandHelp,
+		Action:    suggestSubcommandsAction,
 		Subcommands: []*cli.Command{
 			{
 				Name:      "reset",

--- a/dev/sg/sg_teammate.go
+++ b/dev/sg/sg_teammate.go
@@ -32,7 +32,7 @@ var (
 		Usage:       "Get information about Sourcegraph teammates",
 		Description: `Get information about Sourcegraph teammates, such as their current time and handbook page!`,
 		Category:    CategoryCompany,
-		Action:      cli.ShowSubcommandHelp,
+		Action:      suggestSubcommandsAction,
 		Subcommands: []*cli.Command{{
 			Name:      "time",
 			ArgsUsage: "<nickname>",

--- a/dev/sg/suggest.go
+++ b/dev/sg/suggest.go
@@ -63,7 +63,7 @@ type commandSuggestion struct {
 
 type commandSuggestions []commandSuggestion
 
-// makeSuggestions returns the n most similar command names  to arg, from most similar to
+// makeSuggestions returns the n most similar command names to arg, from most similar to
 // least, where the levenshtein score is above the threshold.
 func makeSuggestions(cmds []*cli.Command, arg string, threshold float64, n int) commandSuggestions {
 	suggestions := commandSuggestions{}

--- a/dev/sg/suggest.go
+++ b/dev/sg/suggest.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"math"
+	"sort"
+	"strings"
+
+	"github.com/agnivade/levenshtein"
+	"github.com/urfave/cli/v2"
+
+	"github.com/sourcegraph/sourcegraph/dev/sg/internal/stdout"
+)
+
+// reconstructArgs reconstructs the argument string from the command context lineage.
+func reconstructArgs(cmd *cli.Context) string {
+	lineage := cmd.Lineage()
+	root := lineage[len(lineage)-1]
+	args := append([]string{cmd.App.Name}, root.Args().Slice()...)
+	return strings.Join(args, " ")
+}
+
+// suggestSubcommandsAction is a cli.Action that calculates and suggests subcommands
+// similar to the first argument.
+func suggestSubcommandsAction(cmd *cli.Context) error {
+	s := cmd.Args().First()
+	if s == "" {
+		// Use default if no args are provided
+		return cli.ShowSubcommandHelp(cmd)
+	}
+	suggestCommands(cmd, s)
+	return cli.Exit("", 1)
+}
+
+// suggestCommands is a cli.CommandNotFoundFunc that calculates and suggests subcommands
+// similar arg.
+func suggestCommands(cmd *cli.Context, arg string) {
+	var cmds []*cli.Command
+	if cmd.Command == nil || cmd.Command.Name == "" {
+		cmds = cmd.App.Commands
+	} else {
+		cmds = cmd.Command.Subcommands
+	}
+
+	args := reconstructArgs(cmd)
+	writeOrangeLinef("command '%s %s' not found", args, arg)
+
+	suggestions := makeSuggestions(cmds, arg, 3, 0.7)
+	if len(suggestions) == 0 {
+		stdout.Out.Writef("try running '%s -h' for help", args)
+		return
+	}
+
+	stdout.Out.Write("did you mean:")
+	for _, s := range suggestions {
+		writeFingerPointingLinef("  %s %s", args, s.name)
+	}
+	stdout.Out.Write("learn more about each command with the '-h' flag")
+}
+
+type commandSuggestion struct {
+	name  string
+	score int
+}
+
+type commandSuggestions []commandSuggestion
+
+// makeSuggestions returns the n most similar command names to arg where the levenshtein
+// score is roughly less than name * thresholdRatio.
+func makeSuggestions(cmds []*cli.Command, arg string, n int, thresholdRatio float64) commandSuggestions {
+	suggestions := commandSuggestions{}
+	for _, c := range cmds {
+		if c.Hidden || c.Name == "help" {
+			continue
+		}
+
+		closestName := commandSuggestion{score: 99999}
+		for _, n := range c.Names() {
+			score := levenshtein.ComputeDistance(n, arg)
+			if closestName.score > score {
+				closestName.name = n
+				closestName.score = score
+			}
+		}
+
+		// Scale score threshold to length of name, i.e. to avoid dropping alias
+		// suggestions and avoid making really bad suggestions on long commands
+		threshold := int(math.Round(float64(len(closestName.name)) * thresholdRatio))
+		if closestName.score <= threshold {
+			suggestions = append(suggestions, closestName)
+		}
+	}
+
+	sort.Sort(suggestions)
+	if len(suggestions) < n {
+		return suggestions
+	}
+	return suggestions[:n]
+}
+
+func (cs commandSuggestions) Len() int {
+	return len(cs)
+}
+
+func (cs commandSuggestions) Less(i, j int) bool {
+	return cs[i].score < cs[j].score
+}
+
+func (cs commandSuggestions) Swap(i, j int) {
+	cs[i], cs[j] = cs[j], cs[i]
+}

--- a/dev/sg/suggest_test.go
+++ b/dev/sg/suggest_test.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/urfave/cli/v2"
+)
+
+func TestMakeSuggestions(t *testing.T) {
+	cmds := []*cli.Command{
+		{Name: "elloo"},
+		{Name: "helo"},
+		{Name: "totally unrelated"},
+		{Name: "hello"},
+		{Name: "hlloo"},
+	}
+	t.Run("restrict suggestions", func(t *testing.T) {
+		suggestions := makeSuggestions(cmds, "hello", 2, 0.7)
+		assert.Len(t, suggestions, 2)
+		assert.Equal(t, "hello", suggestions[0].name)
+		assert.Equal(t, "helo", suggestions[1].name)
+	})
+	t.Run("all suggestions", func(t *testing.T) {
+		suggestions := makeSuggestions(cmds, "hello", 999, 0.7)
+		assert.Len(t, suggestions, len(cmds)-1)
+		assert.Equal(t, "hello", suggestions[0].name)
+		assert.Equal(t, "helo", suggestions[1].name)
+	})
+}

--- a/dev/sg/suggest_test.go
+++ b/dev/sg/suggest_test.go
@@ -16,13 +16,13 @@ func TestMakeSuggestions(t *testing.T) {
 		{Name: "hlloo"},
 	}
 	t.Run("restrict suggestions", func(t *testing.T) {
-		suggestions := makeSuggestions(cmds, "hello", 2, 0.7)
+		suggestions := makeSuggestions(cmds, "hello", 0.3, 2)
 		assert.Len(t, suggestions, 2)
 		assert.Equal(t, "hello", suggestions[0].name)
 		assert.Equal(t, "helo", suggestions[1].name)
 	})
 	t.Run("all suggestions", func(t *testing.T) {
-		suggestions := makeSuggestions(cmds, "hello", 999, 0.7)
+		suggestions := makeSuggestions(cmds, "hello", 0.3, 999)
 		assert.Len(t, suggestions, len(cmds)-1)
 		assert.Equal(t, "hello", suggestions[0].name)
 		assert.Equal(t, "helo", suggestions[1].name)

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/NYTimes/gziphandler v1.1.1
 	github.com/PuerkitoBio/rehttp v1.1.0
 	github.com/RoaringBitmap/roaring v0.9.4
-	github.com/agnivade/levenshtein v1.1.1
+	github.com/agext/levenshtein v1.2.3
 	github.com/aws/aws-sdk-go-v2 v1.13.0
 	github.com/aws/aws-sdk-go-v2/config v1.13.1
 	github.com/aws/aws-sdk-go-v2/credentials v1.8.0
@@ -192,7 +192,6 @@ require (
 	github.com/DataDog/sketches-go v1.4.1 // indirect
 	github.com/Masterminds/goutils v1.1.1 // indirect
 	github.com/Masterminds/sprig v2.22.0+incompatible // indirect
-	github.com/agext/levenshtein v1.2.3 // indirect
 	github.com/alecthomas/chroma v0.10.0 // indirect
 	github.com/cockroachdb/errors v1.8.9 // indirect
 	github.com/containerd/typeurl v1.0.2 // indirect

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/NYTimes/gziphandler v1.1.1
 	github.com/PuerkitoBio/rehttp v1.1.0
 	github.com/RoaringBitmap/roaring v0.9.4
+	github.com/agnivade/levenshtein v1.1.1
 	github.com/aws/aws-sdk-go-v2 v1.13.0
 	github.com/aws/aws-sdk-go-v2/config v1.13.1
 	github.com/aws/aws-sdk-go-v2/credentials v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -247,8 +247,6 @@ github.com/acomagu/bufpipe v1.0.3/go.mod h1:mxdxdup/WdsKVreO5GpW4+M/1CE2sMG4jeGJ
 github.com/agext/levenshtein v1.2.3 h1:YB2fHEn0UJagG8T1rrWknE3ZQzWM06O8AMAatNn7lmo=
 github.com/agext/levenshtein v1.2.3/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/agnivade/levenshtein v1.0.1/go.mod h1:CURSv5d9Uaml+FovSIICkLbAUZ9S4RqaHDIsdSBg7lM=
-github.com/agnivade/levenshtein v1.1.1 h1:QY8M92nrzkmr798gCo3kmMyqXFzdQVpxLlGPRBij0P8=
-github.com/agnivade/levenshtein v1.1.1/go.mod h1:veldBMzWxcCG2ZvUTKD2kJNRdCk5hVbJomOvKkmgYbo=
 github.com/ajg/form v1.5.1/go.mod h1:uL1WgH+h2mgNtvBq0339dVnzXdBETtL2LeUXaIv25UY=
 github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af/go.mod h1:K08gAheRH3/J6wwsYMMT4xOr94bZjxIelGM0+d/wbFw=
 github.com/alcortesm/tgz v0.0.0-20161220082320-9c5fe88206d7/go.mod h1:6zEj6s6u/ghQa61ZWa/C2Aw3RkjiTBOix7dkqa1VLIs=
@@ -282,8 +280,6 @@ github.com/apex/log v1.3.0/go.mod h1:jd8Vpsr46WAe3EZSQ/IUMs2qQD/GOycT5rPWCO1yGcs
 github.com/apex/logs v0.0.4/go.mod h1:XzxuLZ5myVHDy9SAmYpamKKRNApGj54PfYLcFrXqDwo=
 github.com/aphistic/golf v0.0.0-20180712155816-02c07f170c5a/go.mod h1:3NqKYiepwy8kCu4PNA+aP7WUV72eXWJeP9/r3/K9aLE=
 github.com/aphistic/sweet v0.2.0/go.mod h1:fWDlIh/isSE9n6EPsRmC0det+whmX6dJid3stzu0Xys=
-github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0 h1:jfIu9sQUG6Ig+0+Ap1h4unLjW6YQJpKZVmUzxsD4E/Q=
-github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0/go.mod h1:t2tdKJDJF9BV14lnkjHmOQgcvEKgtqs5a1N3LNdJhGE=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
@@ -653,8 +649,6 @@ github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2 h1:tdlZCpZ/P9DhczC
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
-github.com/dgryski/trifles v0.0.0-20200323201526-dd97f9abfb48 h1:fRzb/w+pyskVMQ+UbP35JkH8yB7MYb4q/qhBarqZE6g=
-github.com/dgryski/trifles v0.0.0-20200323201526-dd97f9abfb48/go.mod h1:if7Fbed8SFyPtHLHbg49SI7NAdJiC5WIA09pe59rfAA=
 github.com/dimchansky/utfbom v1.1.0/go.mod h1:rO41eb7gLfo8SF1jd9F8HplJm1Fewwi4mQvIirEdv+8=
 github.com/dimchansky/utfbom v1.1.1/go.mod h1:SxdoEBH5qIqFocHMyGOXVAybYJdr71b1Q/j0mACtrfE=
 github.com/dineshappavoo/basex v0.0.0-20170425072625-481a6f6dc663 h1:fctNkSsavbXpt8geFWZb8n+noCqS8MrOXRJ/YfdZ2dQ=

--- a/go.sum
+++ b/go.sum
@@ -247,6 +247,8 @@ github.com/acomagu/bufpipe v1.0.3/go.mod h1:mxdxdup/WdsKVreO5GpW4+M/1CE2sMG4jeGJ
 github.com/agext/levenshtein v1.2.3 h1:YB2fHEn0UJagG8T1rrWknE3ZQzWM06O8AMAatNn7lmo=
 github.com/agext/levenshtein v1.2.3/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/agnivade/levenshtein v1.0.1/go.mod h1:CURSv5d9Uaml+FovSIICkLbAUZ9S4RqaHDIsdSBg7lM=
+github.com/agnivade/levenshtein v1.1.1 h1:QY8M92nrzkmr798gCo3kmMyqXFzdQVpxLlGPRBij0P8=
+github.com/agnivade/levenshtein v1.1.1/go.mod h1:veldBMzWxcCG2ZvUTKD2kJNRdCk5hVbJomOvKkmgYbo=
 github.com/ajg/form v1.5.1/go.mod h1:uL1WgH+h2mgNtvBq0339dVnzXdBETtL2LeUXaIv25UY=
 github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af/go.mod h1:K08gAheRH3/J6wwsYMMT4xOr94bZjxIelGM0+d/wbFw=
 github.com/alcortesm/tgz v0.0.0-20161220082320-9c5fe88206d7/go.mod h1:6zEj6s6u/ghQa61ZWa/C2Aw3RkjiTBOix7dkqa1VLIs=
@@ -280,6 +282,8 @@ github.com/apex/log v1.3.0/go.mod h1:jd8Vpsr46WAe3EZSQ/IUMs2qQD/GOycT5rPWCO1yGcs
 github.com/apex/logs v0.0.4/go.mod h1:XzxuLZ5myVHDy9SAmYpamKKRNApGj54PfYLcFrXqDwo=
 github.com/aphistic/golf v0.0.0-20180712155816-02c07f170c5a/go.mod h1:3NqKYiepwy8kCu4PNA+aP7WUV72eXWJeP9/r3/K9aLE=
 github.com/aphistic/sweet v0.2.0/go.mod h1:fWDlIh/isSE9n6EPsRmC0det+whmX6dJid3stzu0Xys=
+github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0 h1:jfIu9sQUG6Ig+0+Ap1h4unLjW6YQJpKZVmUzxsD4E/Q=
+github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0/go.mod h1:t2tdKJDJF9BV14lnkjHmOQgcvEKgtqs5a1N3LNdJhGE=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
@@ -649,6 +653,8 @@ github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2 h1:tdlZCpZ/P9DhczC
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
+github.com/dgryski/trifles v0.0.0-20200323201526-dd97f9abfb48 h1:fRzb/w+pyskVMQ+UbP35JkH8yB7MYb4q/qhBarqZE6g=
+github.com/dgryski/trifles v0.0.0-20200323201526-dd97f9abfb48/go.mod h1:if7Fbed8SFyPtHLHbg49SI7NAdJiC5WIA09pe59rfAA=
 github.com/dimchansky/utfbom v1.1.0/go.mod h1:rO41eb7gLfo8SF1jd9F8HplJm1Fewwi4mQvIirEdv+8=
 github.com/dimchansky/utfbom v1.1.1/go.mod h1:SxdoEBH5qIqFocHMyGOXVAybYJdr71b1Q/j0mACtrfE=
 github.com/dineshappavoo/basex v0.0.0-20170425072625-481a6f6dc663 h1:fctNkSsavbXpt8geFWZb8n+noCqS8MrOXRJ/YfdZ2dQ=


### PR DESCRIPTION
Adds a subcommand suggester to the following hooks:

- `(App).CommandNotFound`
- `(Command).Action`, where the action used to be "show subcommand help"

Currently, we suggest up to the 3 most similar command names to arg where the levenshtein match score is > 0.3, as described here: https://github.com/agext/levenshtein#overview , emphasis mine as to why this seemed like a good fit:

> The Match function provides a similarity metric, with the same range and meaning as Similarity, **but with a bonus for string pairs that share a common prefix and have a similarity above a "bonus threshold"**. It uses the same method as proposed by Winkler for the Jaro distance, and the reasoning behind it is that these string pairs are very likely spelling variations or errors, and they are more closely linked than the edit distance alone would suggest.

Closes https://github.com/sourcegraph/sourcegraph/issues/33886

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

Simple unit tests, and manual tests:

<img width="447" alt="image" src="https://user-images.githubusercontent.com/23356519/163476445-62bde286-2dd2-4032-ac90-fdd9e931a8ab.png">

