### PR TITLE
Add params into marketingQueryParameters

### DIFF
--- a/internal/usagestats/event_handlers.go
+++ b/internal/usagestats/event_handlers.go
@@ -271,6 +271,5 @@ func redactSensitiveInfoFromCloudURL(rawURL string) (string, error) {
 
 	parsedURL.RawQuery = urlQueryParams.Encode()
 
-	
 	return parsedURL.String(), nil
 }

--- a/internal/usagestats/event_handlers.go
+++ b/internal/usagestats/event_handlers.go
@@ -254,9 +254,9 @@ func redactSensitiveInfoFromCloudURL(rawURL string) (string, error) {
 		"utm_term":     {},
 		"utm_content":  {},
 		"utm_cid":      {},
-		"obility_id":   {}, 
+		"obility_id":   {},
 		"campaign_id":  {},
-		"ad_id":        {}, 
+		"ad_id":        {},
 		"offer":        {},
 	}
 	urlQueryParams, err := url.ParseQuery(parsedURL.RawQuery)

--- a/internal/usagestats/event_handlers.go
+++ b/internal/usagestats/event_handlers.go
@@ -254,6 +254,10 @@ func redactSensitiveInfoFromCloudURL(rawURL string) (string, error) {
 		"utm_term":     {},
 		"utm_content":  {},
 		"utm_cid":      {},
+		"obility_id":   {}, 
+		"campaign_id":  {},
+		"ad_id":        {}, 
+		"offer":        {},
 	}
 	urlQueryParams, err := url.ParseQuery(parsedURL.RawQuery)
 	if err != nil {

--- a/internal/usagestats/event_handlers.go
+++ b/internal/usagestats/event_handlers.go
@@ -271,5 +271,6 @@ func redactSensitiveInfoFromCloudURL(rawURL string) (string, error) {
 
 	parsedURL.RawQuery = urlQueryParams.Encode()
 
+	
 	return parsedURL.String(), nil
 }


### PR DESCRIPTION
There are 4 marketing parameters that should not be redacted from the URL that were added to the list



## Test plan
Reviewed final list of marketing allowed parameters with marketing ops and got sign off. As this is just fields to add in a list of parameters that already exists, there is no other testing needed.
<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


