### PR TITLE
docs: customze pg config for compose

### DIFF
--- a/doc/admin/config/postgres-conf.md
+++ b/doc/admin/config/postgres-conf.md
@@ -2,6 +2,8 @@
 
 Sourcegraph Kubernetes cluster site admins can override the default PostgreSQL configuration by supplying their own `postgresql.conf` file contents. These are specified in [`pgsql.ConfigMap.yaml`](https://github.com/sourcegraph/deploy-sourcegraph/blob/master/base/pgsql/pgsql.ConfigMap.yaml).
 
+For [Docker Compose](../install/docker-compose/index.md) deployment, site admins can also override the default PostgreSQL configuration by modifying the external configuration files at [pgsql/conf/postgresql.conf], [codeintel-db/conf/postgresql.conf], and [codeinsights-db/conf/postgresql.conf]. These files are mounted to the Postgres server during runtime (NOTE: This is only available in versions 3.39 and later).
+
 There is no officially supported way of customizing the PostgreSQL configuration in the single Docker image.
 
 ## Suggested configuration
@@ -108,3 +110,7 @@ This can be done by mounting a memory backed `EmptyDir`.
 ```
 
 See this [stackexchange](https://dba.stackexchange.com/questions/275378/dev-shm-size-recommendation-for-postgres-database-in-docker) post for tips on tuning this value
+
+[pgsql/conf/postgresql.conf]: https://github.com/sourcegraph/deploy-sourcegraph-docker/blob/master/pgsql/conf/postgresql.conf
+[codeintel-db/conf/postgresql.conf]: https://github.com/sourcegraph/deploy-sourcegraph-docker/blob/master/codeintel-db/conf/postgresql.conf
+[codeinsights-db/conf/postgresql.conf]: https://github.com/sourcegraph/deploy-sourcegraph-docker/blob/master/codeinsights-db/conf/postgresql.conf


### PR DESCRIPTION
add docs to mention we can now customize pg-conf for docker-compose, 

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

Visit http://localhost:5080/admin/config/postgres-conf

```
SG_SKIP_AUTO_UPDATE=true sg run docsite   
```