### PR TITLE
codeintel: Schedule Go dependencies sync jobs

### DIFF
--- a/enterprise/cmd/worker/internal/codeintel/indexing/dependency_sync_scheduler.go
+++ b/enterprise/cmd/worker/internal/codeintel/indexing/dependency_sync_scheduler.go
@@ -23,6 +23,7 @@ import (
 var schemeToExternalService = map[string]string{
 	dependenciesStore.JVMPackagesScheme: extsvc.KindJVMPackages,
 	dependenciesStore.NpmPackagesScheme: extsvc.KindNpmPackages,
+	dependenciesStore.GoModulesScheme:   extsvc.KindGoModules,
 }
 
 // NewDependencySyncScheduler returns a new worker instance that processes


### PR DESCRIPTION
This commit makes it so we schedule Go dependency sync jobs from LSIF uploads. Is this change enough? Guidance appreciated.

## Test plan

N/A