### PR TITLE
Notepad: persist the entry annotation when hiding the annotation input

### DIFF
--- a/client/web/src/search/SearchStack.tsx
+++ b/client/web/src/search/SearchStack.tsx
@@ -549,6 +549,17 @@ const SearchStackEntryComponent: React.FunctionComponent<SearchStackEntryCompone
 
     const deletionLabel = selected ? 'Remove all selected notes' : 'Remove note'
 
+    const toggleAnnotationInput = useCallback(
+        (show: boolean) => {
+            setShowAnnotationInput(show)
+            if (!show) {
+                // Persist the entry annotation when hiding the annotation input.
+                setEntryAnnotation(entry, annotation)
+            }
+        },
+        [entry, annotation, setShowAnnotationInput]
+    )
+
     return (
         <div className={classNames(styles.entry, { [styles.selected]: selected })}>
             <div className="d-flex">
@@ -566,7 +577,7 @@ const SearchStackEntryComponent: React.FunctionComponent<SearchStackEntryCompone
                         className="text-muted"
                         onClick={event => {
                             event.stopPropagation()
-                            setShowAnnotationInput(show => !show)
+                            toggleAnnotationInput(!showAnnotationInput)
                         }}
                     >
                         <Icon as={TextBoxIcon} />
@@ -601,7 +612,7 @@ const SearchStackEntryComponent: React.FunctionComponent<SearchStackEntryCompone
                                 break
                             case 'Enter':
                                 if (isMetaKey(event, isMacPlatform())) {
-                                    setShowAnnotationInput(false)
+                                    toggleAnnotationInput(false)
                                 }
                                 break
                         }

--- a/client/web/src/stores/searchStack.ts
+++ b/client/web/src/stores/searchStack.ts
@@ -7,8 +7,7 @@ import { IHighlightLineRange } from '@sourcegraph/shared/src/schema'
 import { FilterType } from '@sourcegraph/shared/src/search/query/filters'
 import { FilterKind, findFilter } from '@sourcegraph/shared/src/search/query/query'
 import { omitFilter } from '@sourcegraph/shared/src/search/query/transformer'
-
-import { useExperimentalFeatures } from './experimentalFeatures'
+import { useTemporarySetting } from '@sourcegraph/shared/src/settings/temporary/useTemporarySetting'
 
 export type SearchStackEntryID = number
 export interface SearchEntry {
@@ -84,7 +83,7 @@ export const useSearchStackState = create<SearchStackStore>(() => {
  * the component gets unmounted.
  */
 export function useSearchStack(newEntry: SearchStackEntryInput | null): void {
-    const enableSearchStack = useExperimentalFeatures(features => features.enableSearchStack)
+    const [enableSearchStack] = useTemporarySetting('search.notepad.enabled')
     useEffect(() => {
         if (enableSearchStack && newEntry) {
             let entry: SearchStackEntryInput = newEntry


### PR DESCRIPTION
Fixes #33922

The notepad annotations were persisted only on textarea blur event, which doesn't work when the textarea is unmounted. Now we persist the entry annotation when hiding the input.

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

* Enable the notepad
* Run a search
* Open the notepad and add the search as a new entry
* Add an annotation, and without leaving the input field (without blurring) hide the input using CMD+Enter
* Create a notebook from the notepad
* The annotation should be persisted in the notebook

## App preview:

- [Link](https://sg-web-rn-fix-notepad-annotation.onrender.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

