### PR TITLE
oauth: Ensure we sync newly created external services

### DIFF
--- a/cmd/frontend/graphqlbackend/external_services.go
+++ b/cmd/frontend/graphqlbackend/external_services.go
@@ -18,11 +18,9 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
-	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/env"
-	"github.com/sourcegraph/sourcegraph/internal/repoupdater/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
@@ -112,7 +110,7 @@ func (r *schemaResolver) AddExternalService(ctx context.Context, args *addExtern
 	}
 
 	res := &externalServiceResolver{db: r.db, externalService: externalService}
-	if err = syncExternalService(ctx, externalService, syncExternalServiceTimeout, r.repoupdaterClient); err != nil {
+	if err = backend.SyncExternalService(ctx, externalService, syncExternalServiceTimeout, r.repoupdaterClient); err != nil {
 		res.warning = fmt.Sprintf("External service created, but we encountered a problem while validating the external service: %s", err)
 	}
 
@@ -178,55 +176,13 @@ func (r *schemaResolver) UpdateExternalService(ctx context.Context, args *update
 	res := &externalServiceResolver{db: r.db, externalService: es}
 
 	if oldConfig != es.Config {
-		err = syncExternalService(ctx, es, syncExternalServiceTimeout, r.repoupdaterClient)
+		err = backend.SyncExternalService(ctx, es, syncExternalServiceTimeout, r.repoupdaterClient)
 		if err != nil {
 			res.warning = fmt.Sprintf("External service updated, but we encountered a problem while validating the external service: %s", err)
 		}
 	}
 
 	return res, nil
-}
-
-// repoupdaterClient is an interface with only the methods required in syncExternalService. As a
-// result instead of using the entire repoupdater client implementation, we use a thinner API which
-// only needs the SyncExternalService method to be defined on the object.
-type repoupdaterClient interface {
-	SyncExternalService(ctx context.Context, svc api.ExternalService) (*protocol.ExternalServiceSyncResult, error)
-}
-
-// syncExternalService will eagerly trigger a repo-updater sync. It accepts a
-// timeout as an argument which is recommended to be 5 seconds unless the caller
-// has special requirements for it to be larger or smaller.
-func syncExternalService(ctx context.Context, svc *types.ExternalService, timeout time.Duration, client repoupdaterClient) error {
-	// Set a timeout to validate external service sync. It usually fails in
-	// under 5s if there is a problem.
-	ctx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
-
-	_, err := client.SyncExternalService(ctx, api.ExternalService{
-		ID:              svc.ID,
-		Kind:            svc.Kind,
-		DisplayName:     svc.DisplayName,
-		Config:          svc.Config,
-		CreatedAt:       svc.CreatedAt,
-		UpdatedAt:       svc.UpdatedAt,
-		DeletedAt:       svc.DeletedAt,
-		LastSyncAt:      svc.LastSyncAt,
-		NextSyncAt:      svc.NextSyncAt,
-		NamespaceUserID: svc.NamespaceUserID,
-		NamespaceOrgID:  svc.NamespaceOrgID,
-	})
-
-	// If context error is anything but a deadline exceeded error, we do not want to propagate
-	// it. But we definitely want to log the error as a warning.
-	if ctx.Err() != nil && ctx.Err() != context.DeadlineExceeded {
-		log15.Warn("syncExternalService: context error discarded", "err", ctx.Err())
-		return nil
-	}
-
-	// err is either nil or contains an actual error from the API call. And we return it
-	// nonetheless.
-	return errors.Wrapf(err, "error in syncExternalService for service %q with ID %d", svc.Kind, svc.ID)
 }
 
 type deleteExternalServiceArgs struct {
@@ -267,7 +223,7 @@ func (r *schemaResolver) DeleteExternalService(ctx context.Context, args *delete
 	// The user doesn't care if triggering syncing failed when deleting a
 	// service, so kick off in the background.
 	go func() {
-		if err := syncExternalService(context.Background(), es, syncExternalServiceTimeout, r.repoupdaterClient); err != nil {
+		if err := backend.SyncExternalService(context.Background(), es, syncExternalServiceTimeout, r.repoupdaterClient); err != nil {
 			log15.Warn("Performing final sync after external service deletion", "err", err)
 		}
 	}()

--- a/cmd/frontend/graphqlbackend/external_services_test.go
+++ b/cmd/frontend/graphqlbackend/external_services_test.go
@@ -1325,7 +1325,7 @@ func TestSyncExternalService_ContextTimeout(t *testing.T) {
 	ctx := context.Background()
 	svc := &types.ExternalService{}
 
-	err := syncExternalService(ctx, svc, 0*time.Millisecond, repoupdater.NewClient(s.URL))
+	err := backend.SyncExternalService(ctx, svc, 0*time.Millisecond, repoupdater.NewClient(s.URL))
 
 	if err == nil {
 		t.Error("Expected error but got nil")

--- a/cmd/frontend/graphqlbackend/set_external_service_repos.go
+++ b/cmd/frontend/graphqlbackend/set_external_service_repos.go
@@ -82,7 +82,7 @@ func (r *schemaResolver) SetExternalServiceRepos(ctx context.Context, args struc
 		return nil, err
 	}
 
-	if err = syncExternalService(ctx, es, 5*time.Second, r.repoupdaterClient); err != nil {
+	if err = backend.SyncExternalService(ctx, es, 5*time.Second, r.repoupdaterClient); err != nil {
 		return nil, err
 	}
 

--- a/enterprise/cmd/frontend/internal/auth/githuboauth/session_test.go
+++ b/enterprise/cmd/frontend/internal/auth/githuboauth/session_test.go
@@ -318,7 +318,7 @@ func createCodeHostConnectionHelper(t *testing.T, serviceExists bool) {
 	db := database.NewMockDB()
 	s := &sessionIssuerHelper{db: db}
 	t.Run("Unauthenticated request", func(t *testing.T) {
-		_, err := s.CreateCodeHostConnection(ctx, nil, "")
+		_, _, err := s.CreateCodeHostConnection(ctx, nil, "")
 		assert.Error(t, err)
 	})
 
@@ -375,7 +375,7 @@ func createCodeHostConnectionHelper(t *testing.T, serviceExists bool) {
 	})
 	db.ExternalServicesFunc.SetDefaultReturn(externalServices)
 
-	_, err := s.CreateCodeHostConnection(ctx, tok, mockGitHubCom.ConfigID().ID)
+	fromCreation, _, err := s.CreateCodeHostConnection(ctx, tok, mockGitHubCom.ConfigID().ID)
 	require.NoError(t, err)
 
 	want := &types.ExternalService{
@@ -393,6 +393,7 @@ func createCodeHostConnectionHelper(t *testing.T, serviceExists bool) {
 		UpdatedAt:       now,
 	}
 	assert.Equal(t, want, got)
+	assert.Equal(t, want, fromCreation)
 }
 
 func u(username, email string, emailIsVerified bool) database.NewUser {

--- a/enterprise/cmd/frontend/internal/auth/gitlaboauth/session_test.go
+++ b/enterprise/cmd/frontend/internal/auth/gitlaboauth/session_test.go
@@ -34,7 +34,7 @@ func createCodeHostConnectionHelper(t *testing.T, serviceExists bool) {
 	db := database.NewMockDB()
 	s := &sessionIssuerHelper{db: db}
 	t.Run("Unauthenticated request", func(t *testing.T) {
-		_, err := s.CreateCodeHostConnection(ctx, nil, "")
+		_, _, err := s.CreateCodeHostConnection(ctx, nil, "")
 		assert.Error(t, err)
 	})
 
@@ -95,7 +95,7 @@ func createCodeHostConnectionHelper(t *testing.T, serviceExists bool) {
 	})
 	db.ExternalServicesFunc.SetDefaultReturn(externalServices)
 
-	_, err := s.CreateCodeHostConnection(ctx, tok, mockGitLabCom.ConfigID().ID)
+	fromCreation, _, err := s.CreateCodeHostConnection(ctx, tok, mockGitLabCom.ConfigID().ID)
 	require.NoError(t, err)
 
 	want := &types.ExternalService{
@@ -114,4 +114,5 @@ func createCodeHostConnectionHelper(t *testing.T, serviceExists bool) {
 		UpdatedAt:       now,
 	}
 	assert.Equal(t, want, got)
+	assert.Equal(t, want, fromCreation)
 }


### PR DESCRIPTION
We ensure that we call out to repo-updater to sync newly added external services that are
created during our OAuth flow.

The `syncExternalService` helper was moved from `graphqlbackend` to the `backend` package
so that it could be called from our OAuth handler too.

# Test plan

Tests pass and tested the flow on a local instance