### PR TITLE
Remove "quick start tour for authenticated users" / "create team" step

### DIFF
--- a/client/web/src/tour/data/index.tsx
+++ b/client/web/src/tour/data/index.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 
-import AccountGroupIcon from 'mdi-react/AccountGroupIcon'
 import CheckCircleIcon from 'mdi-react/CheckCircleIcon'
 import CursorPointerIcon from 'mdi-react/CursorPointerIcon'
 import MagnifyIcon from 'mdi-react/MagnifyIcon'
@@ -351,21 +350,6 @@ export const authenticatedTasks: TourTaskType[] = [
                     type: 'new-tab-link',
                     value:
                         'https://docs.sourcegraph.com/integration/editor?utm_medium=direct-traffic&utm_source=in-product&utm_content=getting-started',
-                },
-            },
-        ],
-    },
-    {
-        title: 'Create a team',
-        icon: <AccountGroupIcon size="2.3rem" />,
-        steps: [
-            {
-                id: 'CreateTeam',
-                label: 'Sourcegraph helps teams from 2 to any size collaborate.',
-                action: {
-                    type: 'new-tab-link',
-                    value:
-                        'https://share.hsforms.com/14OQ3RoPpQTOXvZlUpgx6-A1n7ku?utm_medium=direct-traffic&utm_source=in-product&utm_content=getting-started',
                 },
             },
         ],


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/33901.

## Test plan
- `SOURCEGRAPH_API_URL=https://sourcegraph.com SOURCEGRAPHDOTCOM_MODE=true sg -skip-auto-update=true start web-standalone`
- Open https://sourcegraph.test:3443/search?feature-flag-key=quick-start-tour-for-authenticated-users&feature-flag-value=true and sign in
- Check that the "Create team" step is not in the quick start tour
- Check that the rest for tour works as previously
<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


## Screenshots
| BEFORE | AFTER |
| --: | :-- |
| <img width="1579" alt="image" src="https://user-images.githubusercontent.com/6717049/163561273-f01ee926-43f0-4fe4-945d-f6f231a4f5bd.png"> | <img width="1579" alt="Screen Shot 2022-04-15 at 16 34 41" src="https://user-images.githubusercontent.com/6717049/163561158-e1954c29-75b4-44bf-bfab-2cc442433287.png"> |
| <img width="277" alt="image" src="https://user-images.githubusercontent.com/6717049/163561334-b92e55cb-b5b4-4648-b014-c2d31ac3cfb2.png"> | <img width="277" alt="image" src="https://user-images.githubusercontent.com/6717049/163561373-a086e6e7-7e1b-4c56-af80-a67c2a536153.png"> |

## App preview:

- [Link](https://sg-web-erzhtor-remove-quick-start-tour.onrender.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

