### PR TITLE
New reference panel: keep collapse state for lists across rerender/remounts

### DIFF
--- a/client/web/src/codeintel/ReferencesPanel.tsx
+++ b/client/web/src/codeintel/ReferencesPanel.tsx
@@ -54,7 +54,7 @@ import { parseBrowserRepoURL } from '../util/url'
 
 import { findLanguageSpec } from './language-specs/languages'
 import { LanguageSpec } from './language-specs/languagespec'
-import { Location, LocationGroup, locationGroupQuality, buildRepoLocationGroups } from './location'
+import { Location, LocationGroup, locationGroupQuality, buildRepoLocationGroups, RepoLocationGroup } from './location'
 import { FETCH_HIGHLIGHTED_BLOB } from './ReferencesPanelQueries'
 import { newSettingsGetter } from './settings'
 import { findSearchToken } from './token'
@@ -285,6 +285,8 @@ export const ReferencesList: React.FunctionComponent<
     // activeLocation is the location that is selected/clicked in the list of
     // definitions/references/implementations.
     const [activeLocation, setActiveLocation] = useState<Location>()
+    const isActiveLocation = (location: Location): boolean =>
+        activeLocation !== undefined && activeLocation.url === location.url
     // We create an in-memory history here so we don't modify the browser
     // location. This panel is detached from the URL state.
     const blobMemoryHistory = useMemo(() => H.createMemoryHistory(), [])
@@ -348,6 +350,17 @@ export const ReferencesList: React.FunctionComponent<
         props.externalHistory.push(url)
     }
 
+    // Manual management of the open/closed state of collapsible lists so they
+    // stay open/closed across re-renders and re-mounts.
+    const [collapsed, setCollapsed] = useState<Record<string, boolean>>({})
+    const handleOpenChange = (id: string, isOpen: boolean): void =>
+        setCollapsed(previous => ({ ...previous, [id]: isOpen }))
+    const isOpen = (id: string): boolean | undefined => collapsed[id]
+    // But when the input changes, we reset the collapse state
+    useEffect(() => {
+        setCollapsed({})
+    }, [props.token])
+
     if (loading && !data) {
         return <LoadingCodeIntel />
     }
@@ -378,10 +391,12 @@ export const ReferencesList: React.FunctionComponent<
                         locations={definitions}
                         hasMore={false}
                         loadingMore={false}
-                        setActiveLocation={onReferenceClick}
                         filter={props.filter}
-                        activeLocation={activeLocation}
                         navigateToUrl={navigateToUrl}
+                        isActiveLocation={isActiveLocation}
+                        setActiveLocation={onReferenceClick}
+                        handleOpenChange={handleOpenChange}
+                        isOpen={isOpen}
                     />
                     <CollapsibleLocationList
                         {...props}
@@ -390,10 +405,12 @@ export const ReferencesList: React.FunctionComponent<
                         hasMore={referencesHasNextPage}
                         fetchMore={fetchMoreReferences}
                         loadingMore={fetchMoreReferencesLoading}
-                        setActiveLocation={onReferenceClick}
                         filter={props.filter}
-                        activeLocation={activeLocation}
                         navigateToUrl={navigateToUrl}
+                        setActiveLocation={onReferenceClick}
+                        isActiveLocation={isActiveLocation}
+                        handleOpenChange={handleOpenChange}
+                        isOpen={isOpen}
                     />
                     {implementations.length > 0 && (
                         <CollapsibleLocationList
@@ -405,8 +422,10 @@ export const ReferencesList: React.FunctionComponent<
                             loadingMore={fetchMoreImplementationsLoading}
                             setActiveLocation={onReferenceClick}
                             filter={props.filter}
-                            activeLocation={activeLocation}
+                            isActiveLocation={isActiveLocation}
                             navigateToUrl={navigateToUrl}
+                            handleOpenChange={handleOpenChange}
+                            isOpen={isOpen}
                         />
                     )}
                 </div>
@@ -450,11 +469,19 @@ export const ReferencesList: React.FunctionComponent<
     )
 }
 
-interface CollapsibleLocationListProps {
+interface CollapseProps {
+    isOpen: (id: string) => boolean | undefined
+    handleOpenChange: (id: string, isOpen: boolean) => void
+}
+
+interface ActiveLocationProps {
+    isActiveLocation: (location: Location) => boolean
+    setActiveLocation: (reference: Location | undefined) => void
+}
+
+interface CollapsibleLocationListProps extends ActiveLocationProps, CollapseProps {
     name: string
     locations: Location[]
-    setActiveLocation: (location: Location | undefined) => void
-    activeLocation: Location | undefined
     filter: string | undefined
     hasMore: boolean
     fetchMore?: () => void
@@ -463,70 +490,73 @@ interface CollapsibleLocationListProps {
 }
 
 const CollapsibleLocationList: React.FunctionComponent<CollapsibleLocationListProps> = props => (
-    <Collapse openByDefault={true}>
-        {({ isOpen }) => (
-            <>
-                <CardHeader className="p-0">
-                    <CollapseHeader
-                        as={Button}
-                        aria-expanded={isOpen}
-                        type="button"
-                        className="bg-transparent py-1 px-0 border-bottom border-top-0 border-left-0 border-right-0 d-flex justify-content-start w-100"
-                    >
-                        <h4 className="px-1 py-0 mb-0">
-                            {' '}
-                            {isOpen ? (
-                                <Icon aria-label="Close" as={ChevronDownIcon} />
-                            ) : (
-                                <Icon aria-label="Expand" as={ChevronRightIcon} />
-                            )}{' '}
-                            {capitalize(props.name)}
-                            <Badge pill={true} variant="secondary" className="ml-2">
-                                {props.locations.length}
-                                {props.hasMore && '+'}
-                            </Badge>
-                        </h4>
-                    </CollapseHeader>
-                </CardHeader>
-
-                <CollapsePanel id="references">
-                    {props.locations.length > 0 ? (
-                        <LocationsList
-                            locations={props.locations}
-                            activeLocation={props.activeLocation}
-                            setActiveLocation={props.setActiveLocation}
-                            filter={props.filter}
-                            navigateToUrl={props.navigateToUrl}
-                        />
-                    ) : (
-                        <p className="text-muted pl-2">
-                            {props.filter ? (
-                                <i>
-                                    No {props.name} matching <strong>{props.filter}</strong> found
-                                </i>
-                            ) : (
-                                <i>No {props.name} found</i>
-                            )}
-                        </p>
-                    )}
-
-                    {props.hasMore &&
-                        props.fetchMore !== undefined &&
-                        (props.loadingMore ? (
-                            <div className="text-center mb-1">
-                                <em>Loading more {props.name}...</em>
-                                <LoadingSpinner inline={true} />
-                            </div>
+    <Collapse
+        isOpen={props.isOpen(props.name) ?? true}
+        onOpenChange={isOpen => props.handleOpenChange(props.name, isOpen)}
+    >
+        <>
+            <CardHeader className="p-0">
+                <CollapseHeader
+                    as={Button}
+                    aria-expanded={props.isOpen(props.name)}
+                    type="button"
+                    className="bg-transparent py-1 px-0 border-bottom border-top-0 border-left-0 border-right-0 d-flex justify-content-start w-100"
+                >
+                    <h4 className="px-1 py-0 mb-0">
+                        {' '}
+                        {props.isOpen(props.name) ? (
+                            <Icon aria-label="Close" as={ChevronDownIcon} />
                         ) : (
-                            <div className="text-center mb-1">
-                                <Button variant="secondary" onClick={props.fetchMore}>
-                                    Load more {props.name}
-                                </Button>
-                            </div>
-                        ))}
-                </CollapsePanel>
-            </>
-        )}
+                            <Icon aria-label="Expand" as={ChevronRightIcon} />
+                        )}{' '}
+                        {capitalize(props.name)}
+                        <Badge pill={true} variant="secondary" className="ml-2">
+                            {props.locations.length}
+                            {props.hasMore && '+'}
+                        </Badge>
+                    </h4>
+                </CollapseHeader>
+            </CardHeader>
+
+            <CollapsePanel id="references">
+                {props.locations.length > 0 ? (
+                    <LocationsList
+                        locations={props.locations}
+                        isActiveLocation={props.isActiveLocation}
+                        setActiveLocation={props.setActiveLocation}
+                        filter={props.filter}
+                        navigateToUrl={props.navigateToUrl}
+                        handleOpenChange={(id, isOpen) => props.handleOpenChange(props.name + id, isOpen)}
+                        isOpen={id => props.isOpen(props.name + id)}
+                    />
+                ) : (
+                    <p className="text-muted pl-2">
+                        {props.filter ? (
+                            <i>
+                                No {props.name} matching <strong>{props.filter}</strong> found
+                            </i>
+                        ) : (
+                            <i>No {props.name} found</i>
+                        )}
+                    </p>
+                )}
+
+                {props.hasMore &&
+                    props.fetchMore !== undefined &&
+                    (props.loadingMore ? (
+                        <div className="text-center mb-1">
+                            <em>Loading more {props.name}...</em>
+                            <LoadingSpinner inline={true} />
+                        </div>
+                    ) : (
+                        <div className="text-center mb-1">
+                            <Button variant="secondary" onClick={props.fetchMore}>
+                                Load more {props.name}
+                            </Button>
+                        </div>
+                    ))}
+            </CollapsePanel>
+        </>
     </Collapse>
 )
 
@@ -618,166 +648,196 @@ const SideBlob: React.FunctionComponent<
     )
 }
 
-const getLineContent = (location: Location): string => {
-    const range = location.range
-    if (range !== undefined) {
-        return location.lines[range.start?.line].trim()
-    }
-    return ''
-}
-
-interface LocationsListProps {
+interface LocationsListProps extends ActiveLocationProps, CollapseProps {
     locations: Location[]
-    activeLocation?: Location
-    setActiveLocation: (reference: Location | undefined) => void
     filter: string | undefined
     navigateToUrl: (url: string) => void
 }
 
 const LocationsList: React.FunctionComponent<LocationsListProps> = ({
     locations,
-    activeLocation,
+    isActiveLocation,
     setActiveLocation,
     filter,
     navigateToUrl,
+    handleOpenChange,
+    isOpen,
 }) => {
     const repoLocationGroups = useMemo(() => buildRepoLocationGroups(locations), [locations])
+    const openByDefault = repoLocationGroups.length === 1
 
     return (
         <>
-            {repoLocationGroups.map(repoLocationGroup => {
-                const repoUrl = `/${repoLocationGroup.repoName}`
-                return (
-                    <Collapse key={repoLocationGroup.repoName} openByDefault={true}>
-                        {({ isOpen }) => (
-                            <>
-                                <CollapseHeader
-                                    as={Button}
-                                    aria-expanded={isOpen}
-                                    type="button"
-                                    className="bg-transparent py-1 border-bottom border-top-0 border-left-0 border-right-0 d-flex justify-content-start w-100"
-                                >
-                                    <span className="p-0 mb-0">
-                                        {isOpen ? (
-                                            <Icon aria-label="Close" as={ChevronDownIcon} />
-                                        ) : (
-                                            <Icon aria-label="Expand" as={ChevronRightIcon} />
-                                        )}
-
-                                        <Link
-                                            to={repoUrl}
-                                            onClick={event => {
-                                                event.preventDefault()
-                                                navigateToUrl(repoUrl)
-                                            }}
-                                        >
-                                            {displayRepoName(repoLocationGroup.repoName)}
-                                        </Link>
-                                    </span>
-                                </CollapseHeader>
-
-                                <CollapsePanel id={repoLocationGroup.repoName}>
-                                    {repoLocationGroup.referenceGroups.map(group => (
-                                        <ReferenceGroup
-                                            key={group.path + group.repoName}
-                                            group={group}
-                                            activeLocation={activeLocation}
-                                            setActiveLocation={setActiveLocation}
-                                            getLineContent={getLineContent}
-                                            filter={filter}
-                                        />
-                                    ))}
-                                </CollapsePanel>
-                            </>
-                        )}
-                    </Collapse>
-                )
-            })}
+            {repoLocationGroups.map(group => (
+                <CollapsibleRepoLocationGroup
+                    key={group.repoName}
+                    repoLocationGroup={group}
+                    openByDefault={openByDefault}
+                    isActiveLocation={isActiveLocation}
+                    setActiveLocation={setActiveLocation}
+                    filter={filter}
+                    navigateToUrl={navigateToUrl}
+                    handleOpenChange={handleOpenChange}
+                    isOpen={isOpen}
+                />
+            ))}
         </>
     )
 }
 
-const ReferenceGroup: React.FunctionComponent<{
-    group: LocationGroup
-    activeLocation?: Location
-    setActiveLocation: (reference: Location | undefined) => void
-    getLineContent: (reference: Location) => string
-    filter: string | undefined
-}> = ({ group, setActiveLocation: setActiveLocation, getLineContent, activeLocation, filter }) => {
+const CollapsibleRepoLocationGroup: React.FunctionComponent<
+    ActiveLocationProps &
+        CollapseProps & {
+            filter: string | undefined
+            navigateToUrl: (url: string) => void
+            repoLocationGroup: RepoLocationGroup
+            openByDefault: boolean
+        }
+> = ({
+    repoLocationGroup,
+    isActiveLocation,
+    setActiveLocation,
+    navigateToUrl,
+    filter,
+    openByDefault,
+    isOpen,
+    handleOpenChange,
+}) => {
+    const repoUrl = `/${repoLocationGroup.repoName}`
+    const open = isOpen(repoLocationGroup.repoName) ?? openByDefault
+
+    return (
+        <Collapse isOpen={open} onOpenChange={isOpen => handleOpenChange(repoLocationGroup.repoName, isOpen)}>
+            <>
+                <CollapseHeader
+                    as={Button}
+                    aria-expanded={open}
+                    type="button"
+                    className="bg-transparent py-1 border-bottom border-top-0 border-left-0 border-right-0 d-flex justify-content-start w-100"
+                >
+                    <span className="p-0 mb-0">
+                        {open ? (
+                            <Icon aria-label="Close" as={ChevronDownIcon} />
+                        ) : (
+                            <Icon aria-label="Expand" as={ChevronRightIcon} />
+                        )}
+
+                        <Link
+                            to={repoUrl}
+                            onClick={event => {
+                                event.preventDefault()
+                                navigateToUrl(repoUrl)
+                            }}
+                        >
+                            {displayRepoName(repoLocationGroup.repoName)}
+                        </Link>
+                    </span>
+                </CollapseHeader>
+
+                <CollapsePanel id={repoLocationGroup.repoName}>
+                    {repoLocationGroup.referenceGroups.map(group => (
+                        <CollapsibleLocationGroup
+                            key={group.path + group.repoName}
+                            group={group}
+                            isActiveLocation={isActiveLocation}
+                            setActiveLocation={setActiveLocation}
+                            filter={filter}
+                            handleOpenChange={(id, isOpen) => handleOpenChange(repoLocationGroup.repoName + id, isOpen)}
+                            isOpen={id => isOpen(repoLocationGroup.repoName + id)}
+                        />
+                    ))}
+                </CollapsePanel>
+            </>
+        </Collapse>
+    )
+}
+
+const CollapsibleLocationGroup: React.FunctionComponent<
+    ActiveLocationProps &
+        CollapseProps & {
+            group: LocationGroup
+            filter: string | undefined
+        }
+> = ({ group, setActiveLocation, isActiveLocation, filter, isOpen, handleOpenChange }) => {
     let highlighted = [group.path]
     if (filter !== undefined) {
         highlighted = group.path.split(filter)
     }
 
+    const open = isOpen(group.path) ?? true
+
     return (
         <div className="ml-4">
-            <Collapse openByDefault={true}>
-                {({ isOpen }) => (
-                    <>
-                        <CollapseHeader
-                            as={Button}
-                            aria-expanded={isOpen}
-                            type="button"
-                            className="bg-transparent py-1 border-bottom border-top-0 border-left-0 border-right-0 d-flex justify-content-start w-100"
-                        >
-                            <span className={styles.referenceFilename}>
-                                {isOpen ? (
-                                    <Icon aria-label="Close" as={ChevronDownIcon} />
-                                ) : (
-                                    <Icon aria-label="Expand" as={ChevronRightIcon} />
-                                )}
-                                {highlighted.length === 2 ? (
-                                    <span>
-                                        {highlighted[0]}
-                                        <mark>{filter}</mark>
-                                        {highlighted[1]}
-                                    </span>
-                                ) : (
-                                    group.path
-                                )}{' '}
-                                ({group.locations.length} references)
-                                <Badge pill={true} small={true} variant="secondary" className="ml-2">
-                                    {locationGroupQuality(group)}
-                                </Badge>
-                            </span>
-                        </CollapseHeader>
+            <Collapse isOpen={open} onOpenChange={isOpen => handleOpenChange(group.path, isOpen)}>
+                <>
+                    <CollapseHeader
+                        as={Button}
+                        aria-expanded={open}
+                        type="button"
+                        className="bg-transparent py-1 border-bottom border-top-0 border-left-0 border-right-0 d-flex justify-content-start w-100"
+                    >
+                        <span className={styles.referenceFilename}>
+                            {open ? (
+                                <Icon aria-label="Close" as={ChevronDownIcon} />
+                            ) : (
+                                <Icon aria-label="Expand" as={ChevronRightIcon} />
+                            )}
+                            {highlighted.length === 2 ? (
+                                <span>
+                                    {highlighted[0]}
+                                    <mark>{filter}</mark>
+                                    {highlighted[1]}
+                                </span>
+                            ) : (
+                                group.path
+                            )}{' '}
+                            ({group.locations.length} references)
+                            <Badge pill={true} small={true} variant="secondary" className="ml-2">
+                                {locationGroupQuality(group)}
+                            </Badge>
+                        </span>
+                    </CollapseHeader>
 
-                        <CollapsePanel id={group.repoName + group.path} className="ml-2">
-                            <ul className="list-unstyled pl-3 py-1 mb-0">
-                                {group.locations.map(reference => {
-                                    const className =
-                                        activeLocation && activeLocation.url === reference.url
-                                            ? styles.referenceActive
-                                            : ''
+                    <CollapsePanel id={group.repoName + group.path} className="ml-2">
+                        <ul className="list-unstyled pl-3 py-1 mb-0">
+                            {group.locations.map(reference => {
+                                const className = isActiveLocation(reference) ? styles.referenceActive : ''
 
-                                    return (
-                                        <li key={reference.url} className={classNames('border-0 rounded-0', className)}>
-                                            <div>
-                                                <Link
-                                                    onClick={event => {
-                                                        event.preventDefault()
-                                                        setActiveLocation(reference)
-                                                    }}
-                                                    to={reference.url}
-                                                    className={styles.referenceLink}
-                                                >
-                                                    <span className={styles.referenceLinkLineNumber}>
-                                                        {(reference.range?.start?.line ?? 0) + 1}
-                                                        {': '}
-                                                    </span>
-                                                    <code>{getLineContent(reference)}</code>
-                                                </Link>
-                                            </div>
-                                        </li>
-                                    )
-                                })}
-                            </ul>
-                        </CollapsePanel>
-                    </>
-                )}
+                                return (
+                                    <li key={reference.url} className={classNames('border-0 rounded-0', className)}>
+                                        <div>
+                                            <Link
+                                                onClick={event => {
+                                                    event.preventDefault()
+                                                    setActiveLocation(reference)
+                                                }}
+                                                to={reference.url}
+                                                className={styles.referenceLink}
+                                            >
+                                                <span className={styles.referenceLinkLineNumber}>
+                                                    {(reference.range?.start?.line ?? 0) + 1}
+                                                    {': '}
+                                                </span>
+                                                <code>{getLineContent(reference)}</code>
+                                            </Link>
+                                        </div>
+                                    </li>
+                                )
+                            })}
+                        </ul>
+                    </CollapsePanel>
+                </>
             </Collapse>
         </div>
     )
+}
+
+const getLineContent = (location: Location): string => {
+    const range = location.range
+    if (range !== undefined) {
+        return location.lines[range.start?.line].trim()
+    }
+    return ''
 }
 
 const LoadingCodeIntel: React.FunctionComponent<{}> = () => (


### PR DESCRIPTION
This fixes #33418 by doing manual management of the collapse state in the top component. That allows us to keep the state across re-renders and re-mounts, which is what happens when a location is clicked on.

**Note for reviewers**: the diff is quite busy. Review without whitespace changes. It's essentially just 10 lines. The managing of the state in the top-most component and changing `<Collapse />` invocations to use that state.

But I also decided to get rid of the `activeLocation` being passed down, because I ran into this while debugging the re-renders/re-mounts. And I also changed the props so they're easier to separate.

## Test plan

Manual local testing.


## App preview:

- [Link](https://sg-web-mrn-keep-collapsed.onrender.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

