### PR TITLE
Change order of "Install an IDE extension" to be 2nd

### DIFF
--- a/client/web/src/tour/data/index.tsx
+++ b/client/web/src/tour/data/index.tsx
@@ -248,6 +248,22 @@ export const authenticatedTasks: TourTaskType[] = [
             },
         ],
     },
+
+    {
+        title: 'Install an IDE extension',
+        icon: <PuzzleOutlineIcon size="2.3rem" />,
+        steps: [
+            {
+                id: 'InstallIDEExtension',
+                label: 'Integrate Sourcegraph with your favorite IDE',
+                action: {
+                    type: 'new-tab-link',
+                    value:
+                        'https://docs.sourcegraph.com/integration/editor?utm_medium=direct-traffic&utm_source=in-product&utm_content=getting-started',
+                },
+            },
+        ],
+    },
     {
         title: 'Find and fix vulnerabilities',
         icon: <ShieldSearchIcon size="2.3rem" />,
@@ -336,21 +352,6 @@ export const authenticatedTasks: TourTaskType[] = [
                     </>
                 ),
                 completeAfterEvents: ['findReferences'],
-            },
-        ],
-    },
-    {
-        title: 'Install an IDE extension',
-        icon: <PuzzleOutlineIcon size="2.3rem" />,
-        steps: [
-            {
-                id: 'InstallIDEExtension',
-                label: 'Integrate Sourcegraph with your favorite IDE',
-                action: {
-                    type: 'new-tab-link',
-                    value:
-                        'https://docs.sourcegraph.com/integration/editor?utm_medium=direct-traffic&utm_source=in-product&utm_content=getting-started',
-                },
             },
         ],
     },


### PR DESCRIPTION
As requested by @a-bergevin in [Amplitude Notebook comments](https://analytics.amplitude.com/sourcegraph/notebook/shc5nsr/comments)
## Test plan
- `SOURCEGRAPH_API_URL=https://sourcegraph.com SOURCEGRAPHDOTCOM_MODE=true sg -skip-auto-update=true start web-standalone`
- Open https://sourcegraph.test:3443/search?feature-flag-key=quick-start-tour-for-authenticated-users&feature-flag-value=true and sign in
- Check that "Install an IDE extension" step is 2nd in the tasks list
<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


## Screenshots
| BEFORE | AFTER |
| --: | :-- |
| <img width="1592" alt="image" src="https://user-images.githubusercontent.com/6717049/163567042-8b923d57-541f-408a-8f9b-cbd12f06fb66.png"> | <img width="1592" alt="image" src="https://user-images.githubusercontent.com/6717049/163567059-4520ffbe-4b8f-42c1-8c28-91cca4ebe0aa.png"> |
| <img width="279" alt="image" src="https://user-images.githubusercontent.com/6717049/163567099-7f83055c-8f73-4253-906e-82accb435ac9.png"> | <img width="279" alt="image" src="https://user-images.githubusercontent.com/6717049/163567115-c22aca5f-6138-4601-9127-24f396e0736b.png"> |


## App preview:

- [Link](https://sg-web-erzhtor-remove-quick-start-tour.onrender.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

