### PR TITLE
Search: run repo subset symbol search on empty pattern

### DIFF
--- a/internal/search/job/jobutil/job_test.go
+++ b/internal/search/job/jobutil/job_test.go
@@ -104,6 +104,13 @@ func TestToSearchInputs(t *testing.T) {
   ComputeExcludedRepos)
 `).Equal(t, test("type:symbol test", search.Streaming, query.ParseRegexp))
 
+	autogold.Want("symbol", `
+(PARALLEL
+  REPOPAGER
+    ZoektSymbolSearch)
+  ComputeExcludedRepos)
+`).Equal(t, test("type:symbol repo:github.com/sourcegraph/sourcegraph", search.Streaming, query.ParseRegexp))
+
 	autogold.Want("commit", `
 (PARALLEL
   Commit


### PR DESCRIPTION
Currently, searches like `type:symbol repo:^github\.com/sourcegraph/sourcegraph$ count:all` do not return any results.

It seems that "skipRepoSubsetSearch" specifically means "skipUnindexedRepoSubsetSearch", but we were using it to determine whether to skip _indexed_ symbol subset search. This modifies the logic to still run zoekt subset search on symbols even when `skipRepoSubsetSearch` is true.

## Test plan



<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


