### PR TITLE
bext: only create driver once for github tests

### DIFF
--- a/client/browser/src/integration/github.test.ts
+++ b/client/browser/src/integration/github.test.ts
@@ -14,6 +14,17 @@ import { closeInstallPageTab, percySnapshot } from './shared'
 
 describe('GitHub', () => {
     let driver: Driver
+    before(async () => {
+        driver = await createDriverForTest({ loadExtension: true })
+        await closeInstallPageTab(driver.browser)
+        if (driver.sourcegraphBaseUrl !== 'https://sourcegraph.com') {
+            await driver.setExtensionSourcegraphUrl()
+        }
+    })
+    after(async () => {
+        await driver?.close()
+    })
+
     let testContext: BrowserIntegrationTestContext
 
     const mockUrls = (urls: string[]) => {
@@ -25,12 +36,6 @@ describe('GitHub', () => {
     }
 
     beforeEach(async function () {
-        driver = await createDriverForTest({ loadExtension: true })
-        await closeInstallPageTab(driver.browser)
-        if (driver.sourcegraphBaseUrl !== 'https://sourcegraph.com') {
-            await driver.setExtensionSourcegraphUrl()
-        }
-
         testContext = await createBrowserIntegrationTestContext({
             driver,
             currentTest: this.currentTest!,
@@ -112,7 +117,7 @@ describe('GitHub', () => {
     afterEachSaveScreenshotIfFailed(() => driver.page)
     afterEach(async () => {
         await testContext?.dispose()
-        await driver?.close()
+        // await driver?.close()
     })
 
     it('adds "View on Sourcegraph" buttons to files', async () => {

--- a/client/browser/src/integration/github.test.ts
+++ b/client/browser/src/integration/github.test.ts
@@ -117,7 +117,6 @@ describe('GitHub', () => {
     afterEachSaveScreenshotIfFailed(() => driver.page)
     afterEach(async () => {
         await testContext?.dispose()
-        // await driver?.close()
     })
 
     it('adds "View on Sourcegraph" buttons to files', async () => {


### PR DESCRIPTION
Not sure that this has any impact, but it didn't seem right that we created and disposed the driver for each test (don't know why I did this for GitHub but not GitLab originally).

## Test plan

- Observe that the browser extension Puppeteer tests still pass after this change

## App preview:

- [Link](https://sg-web-tjk-gh-itest-driver.onrender.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

