### PR TITLE
Configure Datadog analytics rate

### DIFF
--- a/cmd/frontend/internal/app/ui/router.go
+++ b/cmd/frontend/internal/app/ui/router.go
@@ -2,8 +2,6 @@ package ui
 
 import (
 	"fmt"
-	"github.com/sourcegraph/sourcegraph/internal/tracer"
-	muxtrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/gorilla/mux"
 	"log"
 	"net/http"
 	"net/url"
@@ -29,7 +27,9 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/randstring"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
+	"github.com/sourcegraph/sourcegraph/internal/tracer"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
+	muxtrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/gorilla/mux"
 )
 
 const (

--- a/cmd/frontend/internal/app/ui/router.go
+++ b/cmd/frontend/internal/app/ui/router.go
@@ -2,6 +2,8 @@ package ui
 
 import (
 	"fmt"
+	"github.com/sourcegraph/sourcegraph/internal/tracer"
+	muxtrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/gorilla/mux"
 	"log"
 	"net/http"
 	"net/url"
@@ -16,8 +18,6 @@ import (
 	"github.com/inconshreveable/log15"
 	"github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/ext"
-	muxtrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/gorilla/mux"
-
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/globals"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
@@ -128,7 +128,7 @@ func InitRouter(db database.DB, codeIntelResolver graphqlbackend.CodeIntelResolv
 var mockServeRepo func(w http.ResponseWriter, r *http.Request)
 
 func newRouter() *muxtrace.Router {
-	r := muxtrace.NewRouter()
+	r := muxtrace.NewRouter(muxtrace.WithAnalyticsRate(tracer.MUX_ANALYTICS_TRACE_RATE))
 	r.StrictSlash(true)
 
 	// Top-level routes.

--- a/internal/tracer/tracer.go
+++ b/internal/tracer/tracer.go
@@ -3,6 +3,7 @@ package tracer
 import (
 	"fmt"
 	"io"
+	"os"
 	"reflect"
 	"sync"
 
@@ -39,7 +40,7 @@ type options struct {
 	TracerType
 	externalURL string
 	debug       bool
-	// these values are not configurable at runtime
+	// these values are not configurable by site config
 	serviceName string
 	version     string
 	env         string
@@ -69,6 +70,9 @@ func Init(c conftypes.WatchableSiteConfig) {
 	opts.serviceName = env.MyName
 	if version.IsDev(version.Version()) {
 		opts.env = "dev"
+	}
+	if d := os.Getenv("DD_ENV"); d != "" {
+		opts.env = d
 	}
 	opts.version = version.Version()
 
@@ -173,7 +177,7 @@ func newTracer(opts *options, prevTracer TracerType) (opentracing.Tracer, io.Clo
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "jaegercfg.FromEnv failed")
 	}
-	cfg.Tags = append(cfg.Tags, opentracing.Tag{Key: "service.version", Value: version.Version()})
+	cfg.Tags = append(cfg.Tags, opentracing.Tag{Key: "service.version", Value: opts.version}, opentracing.Tag{Key: "service.env", Value: opts.env})
 	if reflect.DeepEqual(cfg.Sampler, &jaegercfg.SamplerConfig{}) {
 		// Default sampler configuration for when it is not specified via
 		// JAEGER_SAMPLER_* env vars. In most cases, this is sufficient

--- a/internal/tracer/tracer.go
+++ b/internal/tracer/tracer.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"reflect"
+	"strconv"
 	"sync"
 
 	"github.com/inconshreveable/log15"
@@ -33,7 +34,18 @@ func init() {
 	if _, err := maxprocs.Set(); err != nil {
 		log15.Error("automaxprocs failed", "error", err)
 	}
+	if r := os.Getenv("MUX_ANALYTICS_TRACE_RATE"); r != "" {
+		rate, err := strconv.ParseFloat(r, 64)
+		if err != nil {
+			log15.Error("Failed to parse MUX_ANALYTICS_TRACE_RATE", "error", err)
+			return
+		}
+		MUX_ANALYTICS_TRACE_RATE = rate
+	}
+
 }
+
+var MUX_ANALYTICS_TRACE_RATE = 0.1
 
 // options control the behavior of a TracerType
 type options struct {


### PR DESCRIPTION
- Correct get env for Datadog tracing
- Make mux trace rate configurable

Part of https://github.com/sourcegraph/sourcegraph/issues/29651

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->
Tested locally with Datadog agent

