### PR TITLE
repo-updater: Include owners when syncing external service

### DIFF
--- a/cmd/repo-updater/repoupdater/server.go
+++ b/cmd/repo-updater/repoupdater/server.go
@@ -195,10 +195,12 @@ func (s *Server) handleExternalServiceSync(w http.ResponseWriter, r *http.Reques
 		sourcer = repos.NewSourcer(database.NewDB(s.Handle().DB()), httpcli.ExternalClientFactory, repos.WithDB(s.Handle().DB()))
 	}
 	src, err := sourcer(&types.ExternalService{
-		ID:          req.ExternalService.ID,
-		Kind:        req.ExternalService.Kind,
-		DisplayName: req.ExternalService.DisplayName,
-		Config:      req.ExternalService.Config,
+		ID:              req.ExternalService.ID,
+		Kind:            req.ExternalService.Kind,
+		DisplayName:     req.ExternalService.DisplayName,
+		Config:          req.ExternalService.Config,
+		NamespaceUserID: req.ExternalService.NamespaceUserID,
+		NamespaceOrgID:  req.ExternalService.NamespaceOrgID,
 	})
 	if err != nil {
 		log15.Error("server.external-service-sync", "kind", req.ExternalService.Kind, "error", err)


### PR DESCRIPTION
We were sending the owners in the sync request but not including them
when creating the external services struct. This meant that it would
appear as a site owned external service.

At the very least, this is causing us to log metrics against the wrong
external service and it may be causing bugs in other areas of the code
base.

Thanks @unknwon for spotting this.

# Test plan

Confirm that our metrics bug is fixed after deployment