### PR TITLE
[CLOUD-222] auth: add config options for account lockout

### DIFF
--- a/cmd/frontend/internal/app/app.go
+++ b/cmd/frontend/internal/app/app.go
@@ -13,6 +13,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/auth/userpasswd"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/session"
 	registry "github.com/sourcegraph/sourcegraph/cmd/frontend/registry/api"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 )
@@ -50,7 +51,12 @@ func NewHandler(db database.DB, githubAppCloudSetupHandler http.Handler) http.Ha
 
 	r.Get(router.UI).Handler(ui.Router())
 
-	lockoutStore := userpasswd.NewLockoutStore(5, 30*time.Minute, time.Hour)
+	lockoutOptions := conf.AuthLockout()
+	lockoutStore := userpasswd.NewLockoutStore(
+		lockoutOptions.FailedAttemptThreshold,
+		time.Duration(lockoutOptions.LockoutPeriod)*time.Second,
+		time.Duration(lockoutOptions.ConsecutivePeriod)*time.Second,
+	)
 	r.Get(router.SignUp).Handler(trace.Route(userpasswd.HandleSignUp(db)))
 	r.Get(router.SiteInit).Handler(trace.Route(userpasswd.HandleSiteInit(db)))
 	r.Get(router.SignIn).Handler(trace.Route(http.HandlerFunc(userpasswd.HandleSignIn(db, lockoutStore))))

--- a/cmd/frontend/internal/auth/userpasswd/lockout.go
+++ b/cmd/frontend/internal/auth/userpasswd/lockout.go
@@ -27,11 +27,13 @@ type LockoutStore interface {
 	IncreaseFailedAttempt(userID int32)
 	// Reset clears the failed login attempt count and releases the lockout.
 	Reset(userID int32)
-	// Creates the unlock account url with the signet unlock token
-	GenerateUnlockAccountUrl(userID int32) (string, string, error)
-	// Verifies the provided unlock token is valid
+	// GenerateUnlockAccountURL creates the URL to unlock account with a signet
+	// unlock token.
+	GenerateUnlockAccountURL(userID int32) (string, string, error)
+	// VerifyUnlockAccountTokenAndReset verifies the provided unlock token is valid.
 	VerifyUnlockAccountTokenAndReset(urlToken string) (bool, error)
-	// Sends an email to the locked account email providing a temporary unlock link
+	// SendUnlockAccountEmail sends an email to the locked account email providing a
+	// temporary unlock link.
 	SendUnlockAccountEmail(ctx context.Context, userID int32, userEmail string) error
 }
 
@@ -75,9 +77,8 @@ type unlockAccountClaims struct {
 	jwt.RegisteredClaims
 }
 
-func (s *lockoutStore) GenerateUnlockAccountUrl(userID int32) (string, string, error) {
+func (s *lockoutStore) GenerateUnlockAccountURL(userID int32) (string, string, error) {
 	signingKey := conf.SiteConfig().AuthUnlockAccountLinkSigningKey
-
 	if signingKey == "" {
 		return "", "", errors.Newf("signing key not provided, cannot validate JWT on unlock account URL. Please add AuthUnlockAccountLinkSigningKey to site configuration.")
 	}
@@ -117,7 +118,7 @@ func (s *lockoutStore) GenerateUnlockAccountUrl(userID int32) (string, string, e
 }
 
 func (s *lockoutStore) SendUnlockAccountEmail(ctx context.Context, userID int32, recipientEmail string) error {
-	unlockUrl, _, err := s.GenerateUnlockAccountUrl(userID)
+	unlockUrl, _, err := s.GenerateUnlockAccountURL(userID)
 
 	if err != nil {
 		return err

--- a/cmd/frontend/internal/auth/userpasswd/lockout_test.go
+++ b/cmd/frontend/internal/auth/userpasswd/lockout_test.go
@@ -98,7 +98,7 @@ func TestLockoutStore(t *testing.T) {
 
 		s := NewLockoutStore(2, time.Minute, time.Second)
 
-		path, _, err := s.GenerateUnlockAccountUrl(1)
+		path, _, err := s.GenerateUnlockAccountURL(1)
 
 		assert.EqualError(t, err, "signing key not provided, cannot validate JWT on unlock account URL. Please add AuthUnlockAccountLinkSigningKey to site configuration.")
 		assert.Empty(t, path)
@@ -113,7 +113,7 @@ func TestLockoutStore(t *testing.T) {
 		mockSiteConfigSigningKey()
 		defer mockDefaultSiteConfig()
 
-		path, _, err := s.GenerateUnlockAccountUrl(1)
+		path, _, err := s.GenerateUnlockAccountURL(1)
 
 		assert.Empty(t, err)
 
@@ -130,7 +130,7 @@ func TestLockoutStore(t *testing.T) {
 		signingKey := mockSiteConfigSigningKey()
 		defer mockDefaultSiteConfig()
 
-		_, token, err := s.GenerateUnlockAccountUrl(1)
+		_, token, err := s.GenerateUnlockAccountURL(1)
 
 		assert.Empty(t, err)
 
@@ -168,7 +168,7 @@ func TestLockoutStore(t *testing.T) {
 		mockSiteConfigSigningKey()
 		defer mockDefaultSiteConfig()
 
-		_, token, err := s.GenerateUnlockAccountUrl(1)
+		_, token, err := s.GenerateUnlockAccountURL(1)
 
 		assert.Empty(t, err)
 
@@ -190,7 +190,7 @@ func TestLockoutStore(t *testing.T) {
 		mockSiteConfigSigningKey()
 		defer mockDefaultSiteConfig()
 
-		_, token, err := s.GenerateUnlockAccountUrl(1)
+		_, token, err := s.GenerateUnlockAccountURL(1)
 
 		assert.Empty(t, err)
 

--- a/cmd/frontend/internal/auth/userpasswd/mocks.go
+++ b/cmd/frontend/internal/auth/userpasswd/mocks.go
@@ -12,9 +12,9 @@ import (
 // github.com/sourcegraph/sourcegraph/cmd/frontend/internal/auth/userpasswd)
 // used for unit testing.
 type MockLockoutStore struct {
-	// GenerateUnlockAccountUrlFunc is an instance of a mock function object
-	// controlling the behavior of the method GenerateUnlockAccountUrl.
-	GenerateUnlockAccountUrlFunc *LockoutStoreGenerateUnlockAccountUrlFunc
+	// GenerateUnlockAccountURLFunc is an instance of a mock function object
+	// controlling the behavior of the method GenerateUnlockAccountURL.
+	GenerateUnlockAccountURLFunc *LockoutStoreGenerateUnlockAccountURLFunc
 	// IncreaseFailedAttemptFunc is an instance of a mock function object
 	// controlling the behavior of the method IncreaseFailedAttempt.
 	IncreaseFailedAttemptFunc *LockoutStoreIncreaseFailedAttemptFunc
@@ -37,7 +37,7 @@ type MockLockoutStore struct {
 // methods return zero values for all results, unless overwritten.
 func NewMockLockoutStore() *MockLockoutStore {
 	return &MockLockoutStore{
-		GenerateUnlockAccountUrlFunc: &LockoutStoreGenerateUnlockAccountUrlFunc{
+		GenerateUnlockAccountURLFunc: &LockoutStoreGenerateUnlockAccountURLFunc{
 			defaultHook: func(int32) (string, string, error) {
 				return "", "", nil
 			},
@@ -74,9 +74,9 @@ func NewMockLockoutStore() *MockLockoutStore {
 // interface. All methods panic on invocation, unless overwritten.
 func NewStrictMockLockoutStore() *MockLockoutStore {
 	return &MockLockoutStore{
-		GenerateUnlockAccountUrlFunc: &LockoutStoreGenerateUnlockAccountUrlFunc{
+		GenerateUnlockAccountURLFunc: &LockoutStoreGenerateUnlockAccountURLFunc{
 			defaultHook: func(int32) (string, string, error) {
-				panic("unexpected invocation of MockLockoutStore.GenerateUnlockAccountUrl")
+				panic("unexpected invocation of MockLockoutStore.GenerateUnlockAccountURL")
 			},
 		},
 		IncreaseFailedAttemptFunc: &LockoutStoreIncreaseFailedAttemptFunc{
@@ -112,8 +112,8 @@ func NewStrictMockLockoutStore() *MockLockoutStore {
 // overwritten.
 func NewMockLockoutStoreFrom(i LockoutStore) *MockLockoutStore {
 	return &MockLockoutStore{
-		GenerateUnlockAccountUrlFunc: &LockoutStoreGenerateUnlockAccountUrlFunc{
-			defaultHook: i.GenerateUnlockAccountUrl,
+		GenerateUnlockAccountURLFunc: &LockoutStoreGenerateUnlockAccountURLFunc{
+			defaultHook: i.GenerateUnlockAccountURL,
 		},
 		IncreaseFailedAttemptFunc: &LockoutStoreIncreaseFailedAttemptFunc{
 			defaultHook: i.IncreaseFailedAttempt,
@@ -133,37 +133,37 @@ func NewMockLockoutStoreFrom(i LockoutStore) *MockLockoutStore {
 	}
 }
 
-// LockoutStoreGenerateUnlockAccountUrlFunc describes the behavior when the
-// GenerateUnlockAccountUrl method of the parent MockLockoutStore instance
+// LockoutStoreGenerateUnlockAccountURLFunc describes the behavior when the
+// GenerateUnlockAccountURL method of the parent MockLockoutStore instance
 // is invoked.
-type LockoutStoreGenerateUnlockAccountUrlFunc struct {
+type LockoutStoreGenerateUnlockAccountURLFunc struct {
 	defaultHook func(int32) (string, string, error)
 	hooks       []func(int32) (string, string, error)
-	history     []LockoutStoreGenerateUnlockAccountUrlFuncCall
+	history     []LockoutStoreGenerateUnlockAccountURLFuncCall
 	mutex       sync.Mutex
 }
 
-// GenerateUnlockAccountUrl delegates to the next hook function in the queue
+// GenerateUnlockAccountURL delegates to the next hook function in the queue
 // and stores the parameter and result values of this invocation.
-func (m *MockLockoutStore) GenerateUnlockAccountUrl(v0 int32) (string, string, error) {
-	r0, r1, r2 := m.GenerateUnlockAccountUrlFunc.nextHook()(v0)
-	m.GenerateUnlockAccountUrlFunc.appendCall(LockoutStoreGenerateUnlockAccountUrlFuncCall{v0, r0, r1, r2})
+func (m *MockLockoutStore) GenerateUnlockAccountURL(v0 int32) (string, string, error) {
+	r0, r1, r2 := m.GenerateUnlockAccountURLFunc.nextHook()(v0)
+	m.GenerateUnlockAccountURLFunc.appendCall(LockoutStoreGenerateUnlockAccountURLFuncCall{v0, r0, r1, r2})
 	return r0, r1, r2
 }
 
 // SetDefaultHook sets function that is called when the
-// GenerateUnlockAccountUrl method of the parent MockLockoutStore instance
+// GenerateUnlockAccountURL method of the parent MockLockoutStore instance
 // is invoked and the hook queue is empty.
-func (f *LockoutStoreGenerateUnlockAccountUrlFunc) SetDefaultHook(hook func(int32) (string, string, error)) {
+func (f *LockoutStoreGenerateUnlockAccountURLFunc) SetDefaultHook(hook func(int32) (string, string, error)) {
 	f.defaultHook = hook
 }
 
 // PushHook adds a function to the end of hook queue. Each invocation of the
-// GenerateUnlockAccountUrl method of the parent MockLockoutStore instance
+// GenerateUnlockAccountURL method of the parent MockLockoutStore instance
 // invokes the hook at the front of the queue and discards it. After the
 // queue is empty, the default hook function is invoked for any future
 // action.
-func (f *LockoutStoreGenerateUnlockAccountUrlFunc) PushHook(hook func(int32) (string, string, error)) {
+func (f *LockoutStoreGenerateUnlockAccountURLFunc) PushHook(hook func(int32) (string, string, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -171,20 +171,20 @@ func (f *LockoutStoreGenerateUnlockAccountUrlFunc) PushHook(hook func(int32) (st
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *LockoutStoreGenerateUnlockAccountUrlFunc) SetDefaultReturn(r0 string, r1 string, r2 error) {
+func (f *LockoutStoreGenerateUnlockAccountURLFunc) SetDefaultReturn(r0 string, r1 string, r2 error) {
 	f.SetDefaultHook(func(int32) (string, string, error) {
 		return r0, r1, r2
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *LockoutStoreGenerateUnlockAccountUrlFunc) PushReturn(r0 string, r1 string, r2 error) {
+func (f *LockoutStoreGenerateUnlockAccountURLFunc) PushReturn(r0 string, r1 string, r2 error) {
 	f.PushHook(func(int32) (string, string, error) {
 		return r0, r1, r2
 	})
 }
 
-func (f *LockoutStoreGenerateUnlockAccountUrlFunc) nextHook() func(int32) (string, string, error) {
+func (f *LockoutStoreGenerateUnlockAccountURLFunc) nextHook() func(int32) (string, string, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -197,28 +197,28 @@ func (f *LockoutStoreGenerateUnlockAccountUrlFunc) nextHook() func(int32) (strin
 	return hook
 }
 
-func (f *LockoutStoreGenerateUnlockAccountUrlFunc) appendCall(r0 LockoutStoreGenerateUnlockAccountUrlFuncCall) {
+func (f *LockoutStoreGenerateUnlockAccountURLFunc) appendCall(r0 LockoutStoreGenerateUnlockAccountURLFuncCall) {
 	f.mutex.Lock()
 	f.history = append(f.history, r0)
 	f.mutex.Unlock()
 }
 
 // History returns a sequence of
-// LockoutStoreGenerateUnlockAccountUrlFuncCall objects describing the
+// LockoutStoreGenerateUnlockAccountURLFuncCall objects describing the
 // invocations of this function.
-func (f *LockoutStoreGenerateUnlockAccountUrlFunc) History() []LockoutStoreGenerateUnlockAccountUrlFuncCall {
+func (f *LockoutStoreGenerateUnlockAccountURLFunc) History() []LockoutStoreGenerateUnlockAccountURLFuncCall {
 	f.mutex.Lock()
-	history := make([]LockoutStoreGenerateUnlockAccountUrlFuncCall, len(f.history))
+	history := make([]LockoutStoreGenerateUnlockAccountURLFuncCall, len(f.history))
 	copy(history, f.history)
 	f.mutex.Unlock()
 
 	return history
 }
 
-// LockoutStoreGenerateUnlockAccountUrlFuncCall is an object that describes
-// an invocation of method GenerateUnlockAccountUrl on an instance of
+// LockoutStoreGenerateUnlockAccountURLFuncCall is an object that describes
+// an invocation of method GenerateUnlockAccountURL on an instance of
 // MockLockoutStore.
-type LockoutStoreGenerateUnlockAccountUrlFuncCall struct {
+type LockoutStoreGenerateUnlockAccountURLFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.
 	Arg0 int32
@@ -235,13 +235,13 @@ type LockoutStoreGenerateUnlockAccountUrlFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c LockoutStoreGenerateUnlockAccountUrlFuncCall) Args() []interface{} {
+func (c LockoutStoreGenerateUnlockAccountURLFuncCall) Args() []interface{} {
 	return []interface{}{c.Arg0}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c LockoutStoreGenerateUnlockAccountUrlFuncCall) Results() []interface{} {
+func (c LockoutStoreGenerateUnlockAccountURLFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1, c.Result2}
 }
 

--- a/internal/conf/computed.go
+++ b/internal/conf/computed.go
@@ -299,6 +299,30 @@ func AuthPasswordResetLinkExpiry() int {
 	return val
 }
 
+// AuthLockout populates and returns the *schema.AuthLockout with default values
+// for fields that are not initialized.
+func AuthLockout() *schema.AuthLockout {
+	val := Get().AuthLockout
+	if val == nil {
+		return &schema.AuthLockout{
+			ConsecutivePeriod:      3600,
+			FailedAttemptThreshold: 5,
+			LockoutPeriod:          1800,
+		}
+	}
+
+	if val.ConsecutivePeriod <= 0 {
+		val.ConsecutivePeriod = 3600
+	}
+	if val.FailedAttemptThreshold <= 0 {
+		val.FailedAttemptThreshold = 5
+	}
+	if val.LockoutPeriod <= 0 {
+		val.LockoutPeriod = 1800
+	}
+	return val
+}
+
 type ExternalServiceMode int
 
 const (

--- a/internal/conf/computed_test.go
+++ b/internal/conf/computed_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/sourcegraph/sourcegraph/internal/conf/confdefaults"
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 
@@ -208,6 +210,58 @@ func TestGitMaxConcurrentClones(t *testing.T) {
 			if got, want := GitMaxConcurrentClones(), test.want; got != want {
 				t.Fatalf("GitMaxConcurrentClones() = %v, want %v", got, want)
 			}
+		})
+	}
+}
+
+func TestAuthLockout(t *testing.T) {
+	defer Mock(nil)
+
+	tests := []struct {
+		name string
+		mock *schema.AuthLockout
+		want *schema.AuthLockout
+	}{
+		{
+			name: "missing entire config",
+			mock: nil,
+			want: &schema.AuthLockout{
+				ConsecutivePeriod:      3600,
+				FailedAttemptThreshold: 5,
+				LockoutPeriod:          1800,
+			},
+		},
+		{
+			name: "missing all fields",
+			mock: &schema.AuthLockout{},
+			want: &schema.AuthLockout{
+				ConsecutivePeriod:      3600,
+				FailedAttemptThreshold: 5,
+				LockoutPeriod:          1800,
+			},
+		},
+		{
+			name: "missing some fields",
+			mock: &schema.AuthLockout{
+				ConsecutivePeriod: 7200,
+			},
+			want: &schema.AuthLockout{
+				ConsecutivePeriod:      7200,
+				FailedAttemptThreshold: 5,
+				LockoutPeriod:          1800,
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			Mock(&Unified{
+				SiteConfiguration: schema.SiteConfiguration{
+					AuthLockout: test.mock,
+				},
+			})
+
+			got := AuthLockout()
+			assert.Equal(t, test.want, got)
 		})
 	}
 }

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -72,6 +72,16 @@ type AuthAccessTokens struct {
 	Allow string `json:"allow,omitempty"`
 }
 
+// AuthLockout description: The config options for account lockout
+type AuthLockout struct {
+	// ConsecutivePeriod description: The number of seconds to be considered as a consecutive period
+	ConsecutivePeriod int `json:"consecutivePeriod,omitempty"`
+	// FailedAttemptThreshold description: The threshold of failed sign-in attempts in a consecutive period
+	FailedAttemptThreshold int `json:"failedAttemptThreshold,omitempty"`
+	// LockoutPeriod description: The number of seconds for the lockout period
+	LockoutPeriod int `json:"lockoutPeriod,omitempty"`
+}
+
 // AuthProviderCommon description: Common properties for authentication providers.
 type AuthProviderCommon struct {
 	// DisplayName description: The name to use when displaying this authentication provider in the UI. Defaults to an auto-generated name with the type of authentication provider and other relevant identifiers (such as a hostname).
@@ -1691,6 +1701,8 @@ type SiteConfiguration struct {
 	AuthAccessTokens *AuthAccessTokens `json:"auth.accessTokens,omitempty"`
 	// AuthEnableUsernameChanges description: Enables users to change their username after account creation. Warning: setting this to be true has security implications if you have enabled (or will at any point in the future enable) repository permissions with an option that relies on username equivalency between Sourcegraph and an external service or authentication provider. Do NOT set this to true if you are using non-built-in authentication OR rely on username equivalency for repository permissions.
 	AuthEnableUsernameChanges bool `json:"auth.enableUsernameChanges,omitempty"`
+	// AuthLockout description: The config options for account lockout
+	AuthLockout *AuthLockout `json:"auth.lockout,omitempty"`
 	// AuthMinPasswordLength description: The minimum number of Unicode code points that a password must contain.
 	AuthMinPasswordLength int `json:"auth.minPasswordLength,omitempty"`
 	// AuthPasswordResetLinkExpiry description: The duration (in seconds) that a password reset link is considered valid.

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -1322,6 +1322,28 @@
       "default": 14400,
       "group": "Authentication"
     },
+    "auth.lockout": {
+      "description": "The config options for account lockout",
+      "type": "object",
+      "properties": {
+        "failedAttemptThreshold": {
+          "description": "The threshold of failed sign-in attempts in a consecutive period",
+          "type": "integer",
+          "default": 5
+        },
+        "lockoutPeriod": {
+          "description": "The number of seconds for the lockout period",
+          "type": "integer",
+          "default": 1800
+        },
+        "consecutivePeriod": {
+          "description": "The number of seconds to be considered as a consecutive period",
+          "type": "integer",
+          "default": 3600
+        }
+      },
+      "group": "Authentication"
+    },
     "auth.unlockAccountLinkSigningKey": {
       "description": "Base64 encoded HMAC Signing key to sign a JWT token, which is attached to each invitation URL.",
       "type": "string",


### PR DESCRIPTION
This PR adds config options for account lockout measures, namely failed attempts threshold, lockout period and consecutive period.

This also fixes a potential server panic due to unexpected usages of `log15` package. cc @pietrorosa77 

CHANGELOG entry and docs will be updated in a subsequent PR for both CLOUD-222 and CLOUD-277.

## Test plan

Unit tests and,

1. Boot up local instance (doesn't have to be in dotcom mode)
2. Try wrong password for an existing user for 5 times
3. On the sixth time, the account lockout error is shown
4. Try again after 30 minutes (or change the config to 10 seconds) or delete the Redis key `v2:account_lockout:<user ID>`, the account is unlocked

<img width="429" alt="CleanShot 2022-04-08 at 16 22 57@2x" src="https://user-images.githubusercontent.com/2946214/162395810-7ec20d83-70ea-467e-9cbd-34172a21b1cc.png">


