### PR TITLE
Add ActionItemsBar to storybook

### DIFF
--- a/client/web/src/extensions/components/ActionItemsBar.story.tsx
+++ b/client/web/src/extensions/components/ActionItemsBar.story.tsx
@@ -9,6 +9,8 @@ import { FlatExtensionHostAPI } from '@sourcegraph/shared/src/api/contract'
 import { pretendProxySubscribable, pretendRemote } from '@sourcegraph/shared/src/api/util'
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { extensionsController, NOOP_PLATFORM_CONTEXT } from '@sourcegraph/shared/src/testing/searchTestHelpers'
+// eslint-disable-next-line no-restricted-imports
+import { Tooltip } from '@sourcegraph/wildcard'
 
 import { AppRouterContainer } from '../../components/AppRouterContainer'
 
@@ -61,6 +63,7 @@ const decorator: DecoratorFn = story => (
     <>
         <style>{webStyles}</style>
         <AppRouterContainer>
+            <Tooltip />
             <div className="container mt-3">{story()}</div>
         </AppRouterContainer>
     </>

--- a/client/web/src/extensions/components/ActionItemsBar.story.tsx
+++ b/client/web/src/extensions/components/ActionItemsBar.story.tsx
@@ -30,12 +30,12 @@ const mockContributions: Evaluated<Contributions> = {
             iconURL: mockIconURL,
             label: 'Some label',
             pressed: index < 2,
+            description: 'Some description',
         },
         command: 'open',
         active: true,
         category: 'Some category',
         title: 'Some title',
-        description: 'Some description',
     })),
     menus: {
         [ContributableMenu.EditorTitle]: mockActionItems.map(id => ({
@@ -88,7 +88,7 @@ export const Default: React.FunctionComponent = () => {
             location={LOCATION}
             useActionItemsBar={useActionItemsBar}
             extensionsController={mockExtensionsController}
-            platformContext={NOOP_PLATFORM_CONTEXT}
+            platformContext={NOOP_PLATFORM_CONTEXT as any}
             telemetryService={NOOP_TELEMETRY_SERVICE}
         />
     )

--- a/client/web/src/extensions/components/ActionItemsBar.story.tsx
+++ b/client/web/src/extensions/components/ActionItemsBar.story.tsx
@@ -1,0 +1,42 @@
+import React from 'react'
+import { NEVER } from 'rxjs'
+import { storiesOf } from '@storybook/react'
+
+
+import { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
+import { extensionsController } from '@sourcegraph/shared/src/testing/searchTestHelpers'
+import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
+
+import { ActionItemsBar, useWebActionItems } from './ActionItemsBar'
+import webStyles from '../../SourcegraphWebApp.scss'
+import { AppRouterContainer } from '../../components/AppRouterContainer'
+
+const LOCATION: H.Location = { hash: '', pathname: '/', search: '', state: undefined }
+
+const PLATFORM_CONTEXT: PlatformContextProps = {
+    forceUpdateTooltip: () => undefined,
+    settings: NEVER,
+}
+
+const { add } = storiesOf('web/extensions/ActionItemsBar', module).addDecorator(story => (
+    <>
+        <style>{webStyles}</style>
+        <AppRouterContainer>
+            <div className="container mt-3">{story()}</div>
+        </AppRouterContainer>
+    </>
+))
+
+add('default', () => {
+    const { useActionItemsBar } = useWebActionItems()
+
+    return (
+        <ActionItemsBar
+            location={LOCATION}
+            useActionItemsBar={useActionItemsBar}
+            extensionsController={extensionsController}
+            platformContext={PLATFORM_CONTEXT}
+            telemetryService={NOOP_TELEMETRY_SERVICE}
+        />
+    )
+})

--- a/client/web/src/extensions/components/ActionItemsBar.story.tsx
+++ b/client/web/src/extensions/components/ActionItemsBar.story.tsx
@@ -1,42 +1,95 @@
 import React from 'react'
-import { NEVER } from 'rxjs'
-import { storiesOf } from '@storybook/react'
 
+import { DecoratorFn, Meta } from '@storybook/react'
+import * as H from 'history'
+import { EMPTY, noop, of } from 'rxjs'
 
-import { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
-import { extensionsController } from '@sourcegraph/shared/src/testing/searchTestHelpers'
+import { ContributableMenu, Contributions, Evaluated } from '@sourcegraph/client-api'
+import { FlatExtensionHostAPI } from '@sourcegraph/shared/src/api/contract'
+import { pretendProxySubscribable, pretendRemote } from '@sourcegraph/shared/src/api/util'
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
+import { extensionsController, NOOP_PLATFORM_CONTEXT } from '@sourcegraph/shared/src/testing/searchTestHelpers'
+
+import { AppRouterContainer } from '../../components/AppRouterContainer'
 
 import { ActionItemsBar, useWebActionItems } from './ActionItemsBar'
+
 import webStyles from '../../SourcegraphWebApp.scss'
-import { AppRouterContainer } from '../../components/AppRouterContainer'
 
 const LOCATION: H.Location = { hash: '', pathname: '/', search: '', state: undefined }
 
-const PLATFORM_CONTEXT: PlatformContextProps = {
-    forceUpdateTooltip: () => undefined,
-    settings: NEVER,
+const mockIconURL =
+    'data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPCEtLSBHZW5lcmF0b3I6IEFkb2JlIElsbHVzdHJhdG9yIDE2LjAuMCwgU1ZHIEV4cG9ydCBQbHVnLUluIC4gU1ZHIFZlcnNpb246IDYuMDAgQnVpbGQgMCkgIC0tPgo8IURPQ1RZUEUgc3ZnIFBVQkxJQyAiLS8vVzNDLy9EVEQgU1ZHIDEuMS8vRU4iICJodHRwOi8vd3d3LnczLm9yZy9HcmFwaGljcy9TVkcvMS4xL0RURC9zdmcxMS5kdGQiPgo8c3ZnIHZlcnNpb249IjEuMSIgaWQ9IkxheWVyXzEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4IgoJIHdpZHRoPSI5N3B4IiBoZWlnaHQ9Ijk3cHgiIHZpZXdCb3g9IjAgMCA5NyA5NyIgZW5hYmxlLWJhY2tncm91bmQ9Im5ldyAwIDAgOTcgOTciIHhtbDpzcGFjZT0icHJlc2VydmUiPgo8Zz4KCTxwYXRoIGZpbGw9IiNGMDUxMzMiIGQ9Ik05Mi43MSw0NC40MDhMNTIuNTkxLDQuMjkxYy0yLjMxLTIuMzExLTYuMDU3LTIuMzExLTguMzY5LDBsLTguMzMsOC4zMzJMNDYuNDU5LDIzLjE5CgkJYzIuNDU2LTAuODMsNS4yNzItMC4yNzMsNy4yMjksMS42ODVjMS45NjksMS45NywyLjUyMSw0LjgxLDEuNjcsNy4yNzVsMTAuMTg2LDEwLjE4NWMyLjQ2NS0wLjg1LDUuMzA3LTAuMyw3LjI3NSwxLjY3MQoJCWMyLjc1LDIuNzUsMi43NSw3LjIwNiwwLDkuOTU4Yy0yLjc1MiwyLjc1MS03LjIwOCwyLjc1MS05Ljk2MSwwYy0yLjA2OC0yLjA3LTIuNTgtNS4xMS0xLjUzMS03LjY1OGwtOS41LTkuNDk5djI0Ljk5NwoJCWMwLjY3LDAuMzMyLDEuMzAzLDAuNzc0LDEuODYxLDEuMzMyYzIuNzUsMi43NSwyLjc1LDcuMjA2LDAsOS45NTljLTIuNzUsMi43NDktNy4yMDksMi43NDktOS45NTcsMGMtMi43NS0yLjc1NC0yLjc1LTcuMjEsMC05Ljk1OQoJCWMwLjY4LTAuNjc5LDEuNDY3LTEuMTkzLDIuMzA3LTEuNTM3VjM2LjM2OWMtMC44NC0wLjM0NC0xLjYyNS0wLjg1My0yLjMwNy0xLjUzN2MtMi4wODMtMi4wODItMi41ODQtNS4xNC0xLjUxNi03LjY5OAoJCUwzMS43OTgsMTYuNzE1TDQuMjg4LDQ0LjIyMmMtMi4zMTEsMi4zMTMtMi4zMTEsNi4wNiwwLDguMzcxbDQwLjEyMSw0MC4xMThjMi4zMSwyLjMxMSw2LjA1NiwyLjMxMSw4LjM2OSwwTDkyLjcxLDUyLjc3OQoJCUM5NS4wMjEsNTAuNDY4LDk1LjAyMSw0Ni43MTksOTIuNzEsNDQuNDA4eiIvPgo8L2c+Cjwvc3ZnPgo='
+
+// eslint-disable-next-line id-length
+const mockActionItems = [...(new Array(10) as (number | undefined)[])].map((_, index) => `${index}`)
+const mockContributions: Evaluated<Contributions> = {
+    actions: mockActionItems.map((id, index) => ({
+        id,
+        actionItem: {
+            iconURL: mockIconURL,
+            label: 'Some label',
+            pressed: index < 2,
+        },
+        command: 'open',
+        active: true,
+        category: 'Some category',
+        title: 'Some title',
+        description: 'Some description',
+    })),
+    menus: {
+        [ContributableMenu.EditorTitle]: mockActionItems.map(id => ({
+            action: id,
+            alt: id,
+            when: true,
+        })),
+    },
 }
 
-const { add } = storiesOf('web/extensions/ActionItemsBar', module).addDecorator(story => (
+const mockExtensionsController = {
+    ...extensionsController,
+    extHostAPI: Promise.resolve(
+        pretendRemote<FlatExtensionHostAPI>({
+            getContributions: () => pretendProxySubscribable(of(mockContributions)),
+            registerContributions: () => pretendProxySubscribable(EMPTY).subscribe(noop as any),
+            haveInitialExtensionsLoaded: () => pretendProxySubscribable(of(true)),
+        })
+    ),
+}
+
+const decorator: DecoratorFn = story => (
     <>
         <style>{webStyles}</style>
         <AppRouterContainer>
             <div className="container mt-3">{story()}</div>
         </AppRouterContainer>
     </>
-))
+)
 
-add('default', () => {
+const config: Meta = {
+    title: 'web/extensions/ActionItemsBar',
+    decorators: [decorator],
+    component: ActionItemsBar,
+    parameters: {
+        chromatic: {
+            enableDarkMode: true,
+            disableSnapshot: false,
+        },
+    },
+}
+
+export default config
+
+export const Default: React.FunctionComponent = () => {
     const { useActionItemsBar } = useWebActionItems()
 
     return (
         <ActionItemsBar
             location={LOCATION}
             useActionItemsBar={useActionItemsBar}
-            extensionsController={extensionsController}
-            platformContext={PLATFORM_CONTEXT}
+            extensionsController={mockExtensionsController}
+            platformContext={NOOP_PLATFORM_CONTEXT}
             telemetryService={NOOP_TELEMETRY_SERVICE}
         />
     )
-})
+}

--- a/client/web/src/extensions/components/ActionItemsBar.tsx
+++ b/client/web/src/extensions/components/ActionItemsBar.tsx
@@ -19,7 +19,7 @@ import { ActionItem } from '@sourcegraph/shared/src/actions/ActionItem'
 import { ActionsContainer } from '@sourcegraph/shared/src/actions/ActionsContainer'
 import { haveInitialExtensionsLoaded } from '@sourcegraph/shared/src/api/features'
 import { ExtensionsControllerProps } from '@sourcegraph/shared/src/extensions/controller'
-import { PlatformContext } from '@sourcegraph/shared/src/platform/context'
+import { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Button, LoadingSpinner, useObservable, Link, ButtonLink, Icon } from '@sourcegraph/wildcard'
 
@@ -173,13 +173,9 @@ export function useWebActionItems(): Pick<ActionItemsBarProps, 'useActionItemsBa
     }
 }
 
-export interface ActionItemsBarProps extends ExtensionsControllerProps, TelemetryProps {
+export interface ActionItemsBarProps extends ExtensionsControllerProps, TelemetryProps, PlatformContextProps {
     useActionItemsBar: () => { isOpen: boolean | undefined; barReference: React.RefCallback<HTMLElement> }
     location: H.Location
-    platformContext: Pick<
-        PlatformContext,
-        'sourcegraphURL' | 'requestGraphQL' | 'urlToFile' | 'settings' | 'forceUpdateTooltip'
-    >
 }
 
 const actionItemClassName = classNames(

--- a/client/web/src/extensions/components/ActionItemsBar.tsx
+++ b/client/web/src/extensions/components/ActionItemsBar.tsx
@@ -19,7 +19,7 @@ import { ActionItem } from '@sourcegraph/shared/src/actions/ActionItem'
 import { ActionsContainer } from '@sourcegraph/shared/src/actions/ActionsContainer'
 import { haveInitialExtensionsLoaded } from '@sourcegraph/shared/src/api/features'
 import { ExtensionsControllerProps } from '@sourcegraph/shared/src/extensions/controller'
-import { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
+import { PlatformContext } from '@sourcegraph/shared/src/platform/context'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Button, LoadingSpinner, useObservable, Link, ButtonLink, Icon } from '@sourcegraph/wildcard'
 
@@ -173,19 +173,13 @@ export function useWebActionItems(): Pick<ActionItemsBarProps, 'useActionItemsBa
     }
 }
 
-export interface ActionItemsBarProps extends ExtensionsControllerProps, PlatformContextProps, TelemetryProps {
+export interface ActionItemsBarProps extends ExtensionsControllerProps, TelemetryProps {
     useActionItemsBar: () => { isOpen: boolean | undefined; barReference: React.RefCallback<HTMLElement> }
     location: H.Location
-}
-
-export interface ActionItemsToggleProps extends ExtensionsControllerProps<'extHostAPI'> {
-    useActionItemsToggle: () => {
-        isOpen: boolean | undefined
-        toggle: () => void
-        toggleReference: React.RefCallback<HTMLElement>
-        barInPage: boolean
-    }
-    className?: string
+    platformContext: Pick<
+        PlatformContext,
+        'sourcegraphURL' | 'requestGraphQL' | 'urlToFile' | 'settings' | 'forceUpdateTooltip'
+    >
 }
 
 const actionItemClassName = classNames(
@@ -194,9 +188,9 @@ const actionItemClassName = classNames(
 )
 
 /**
- *
+ * TODO: description
  */
-export const ActionItemsBar = React.memo<ActionItemsBarProps>(props => {
+export const ActionItemsBar = React.memo<ActionItemsBarProps>(function ActionItemsBar(props) {
     const { isOpen, barReference } = props.useActionItemsBar()
 
     const {
@@ -307,6 +301,16 @@ export const ActionItemsBar = React.memo<ActionItemsBarProps>(props => {
         </div>
     )
 })
+
+export interface ActionItemsToggleProps extends ExtensionsControllerProps<'extHostAPI'> {
+    useActionItemsToggle: () => {
+        isOpen: boolean | undefined
+        toggle: () => void
+        toggleReference: React.RefCallback<HTMLElement>
+        barInPage: boolean
+    }
+    className?: string
+}
 
 export const ActionItemsToggle: React.FunctionComponent<ActionItemsToggleProps> = ({
     useActionItemsToggle,

--- a/client/wildcard/src/components/Button/Button.tsx
+++ b/client/wildcard/src/components/Button/Button.tsx
@@ -107,3 +107,5 @@ export const Button = React.forwardRef(
         return buttonComponent
     }
 ) as ForwardReferenceComponent<'button', ButtonProps>
+
+Button.displayName = 'Button'

--- a/client/wildcard/src/components/ButtonLink/ButtonLink.tsx
+++ b/client/wildcard/src/components/ButtonLink/ButtonLink.tsx
@@ -123,3 +123,5 @@ export const ButtonLink = React.forwardRef((props, reference) => {
         </Button>
     )
 }) as ForwardReferenceComponent<typeof AnchorLink, ButtonLinkProps>
+
+ButtonLink.displayName = 'ButtonLink'


### PR DESCRIPTION
Add ActionItemsBar story  to storyboard. 
closes: #19318

## Test plan
- run `yarn storybook:web`
- visit http://localhost:9001/?path=/story/web-extensions-actionitemsbar--default


## App preview:
<img width="176" alt="CleanShot 2022-04-19 at 07 20 31@2x" src="https://user-images.githubusercontent.com/22571395/163904230-d5f67299-37d3-48b2-b50f-1d40589cded1.png">
