### PR TITLE
ci: retry vscode smoke test

### DIFF
--- a/enterprise/dev/ci/internal/ci/operations.go
+++ b/enterprise/dev/ci/internal/ci/operations.go
@@ -279,6 +279,7 @@ func addVSCExt(pipeline *bk.Pipeline) {
 	pipeline.AddStep(
 		":vscode: Puppeteer tests for VS Code extension",
 		withYarnCache(),
+		bk.AutomaticRetry(1), // Temporary, to be removed after implementing integration tests.
 		bk.Cmd("yarn --frozen-lockfile --network-timeout 60000"),
 		bk.Cmd("yarn generate"),
 		bk.Cmd("yarn --cwd client/vscode -s build"),


### PR DESCRIPTION
Context: https://sourcegraph.slack.com/archives/C01LZKLRF0C/p1650013900276399

Our VS Code extension smoke test appears to be flaky, often due to the search panel webview not rendering in time. I believe this is because we're making real requests to sourcegraph.com (for settings, for example) and we show a loading spinner until we receive all responses.

We have an integration test harness (#33921) with mock API responses soon to be merged that will replace the smoke test. If my theory is correct, we won't observe flakes anymore and we can remove the automatic retries.

## Test plan

n/a


