### PR TITLE
Code monitors: add documentation for webhooks

### DIFF
--- a/doc/code_monitoring/how-tos/index.md
+++ b/doc/code_monitoring/how-tos/index.md
@@ -2,3 +2,4 @@
 
 * [Starting points](starting_points.md)
 * <span class="badge badge-experimental">Experimental</span> [Setting up Slack notifications](slack.md)
+* <span class="badge badge-experimental">Experimental</span> [Setting up Webhook notifications](webhook.md)

--- a/doc/code_monitoring/how-tos/webhook.md
+++ b/doc/code_monitoring/how-tos/webhook.md
@@ -1,0 +1,72 @@
+# Setting up Webhook notifications
+
+<aside class="experimental">
+<p>
+<span class="badge badge-experimental">Experimental</span> This feature is experimental and might change or be removed in the future. We've released it as an experimental feature to provide a preview of functionality we're working on.
+</p>
+
+<p><b>We're very much looking for input and feedback on this feature.</b> You can either <a href="https://about.sourcegraph.com/contact">contact us directly</a>, <a href="https://github.com/sourcegraph/sourcegraph">file an issue</a>, or <a href="https://twitter.com/sourcegraph">tweet at us</a>.</p>
+</aside>
+
+Webhook notifications provide a way to execute custom responses to a code monitor notification.
+They are implemented as a POST request to a URL of your choice. The body of the request is defined
+by Sourcegraph, and contains all the information available about the cause of the notification.
+
+## Prerequisites
+
+- You must have the experimental feature flag `experimentalFeatures.codeMonitoringWebHooks` set to `true` in your Sourcegraph settings
+- You must have a service running that can accept the POST request triggered by the webhook notification
+
+## Creating a webhook receiver
+
+A webhook reciever is a service that can accept an HTTP POST request with the contents of the webhook notification.
+The receiver must be reachable from the Sourcegraph cluster using the URL that is configured below.
+
+The HTTP POST request sent to the receiver will have a JSON-encoded body with the following fields:
+
+- `monitorDescription`: The description of the monitor as configured in the UI
+- `monitorURL`: A link to the monitor configuration page
+- `query`: The query that generated `results`
+- `results`: The list of results that triggered this notification. Contains the following sub-fields
+  - `repository`: The name of the repository the commit belongs to
+  - `commit`: The commit hash for the matched commit.
+  - `diff`: The matching diff in unified diff format. Only set if the result is a diff match.
+  - `matchedDiffRanges`: The character ranges of `diff` that matched `query`. Only set if the result is a diff match.
+  - `message`: The matching commit message. Only set if the result is a commit match.
+  - `matchedMessageRanges`: The character ranges of `message` that matched `query`. Only set if the result is a commit match.
+
+Example payload:
+```json
+{
+  "monitorDescription": "My test monitor",
+  "monitorURL": "https://sourcegraph.com/code-monitoring/Q29kZU1vbml0b3I6NDI=?utm_source=",
+  "query": "repo:camdentest -file:id_rsa.pub BEGIN",
+  "results": [
+    {
+      "repository": "github.com/test/test",
+      "commit": "7815187511872asbasdfgasd",
+      "diff": "file1.go file2.go\n@ -97,5 +97,5 @ func Test() {\n leading context\n+matched added\n-matched removed\n trailing context\n",
+      "matchedDiffRanges": [
+        [ 66, 73 ],
+        [ 91, 98 ]
+      ]
+    },
+    {
+      "repository": "github.com/test/test",
+      "commit": "7815187511872asbasdfgasd",
+      "message": "summary line\n\nsample\ncommit\nmessage\n",
+      "matchedMessageRanges": [
+        [ 15, 19 ]
+      ]
+    }
+  ]
+}
+```
+
+## Configuring a code monitor to send Webhook notifications
+
+1. In Sourcegraph, click on the "Code Monitoring" nav item at the top of the page.
+1. Create a new code monitor or edit an existing monitor by clicking on the "Edit" button next to it.
+1. Go through the standard configuration steps for a code monitor and select action "Call a webhook".
+1. Paste your webhook URL into the "Webhook URL" field.
+1. Click on the "Continue" button, and then the "Save" button.


### PR DESCRIPTION
Fixes #32221 

## Test plan

Viewed the docs locally to check formatting.

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


