### PR TITLE
zoekt: add grafana dashboards for job queueing delays

### DIFF
--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -14594,6 +14594,108 @@ Query: `index_queue_len{instance=~`${instance:regex}`}`
 
 <br />
 
+#### zoekt: indexed_queueing_delay_heatmap
+
+<p class="subtitle">Job queuing delay heatmap</p>
+
+The queueing delay represents the amount of time an indexing job spent in the queue before it was processed.
+
+Large queueing delays can be an indicator of:
+	- resource saturation
+	- each Zoekt replica has too many jobs for it to be able to process all of them promptly. In this scenario, consider adding additional Zoekt replicas to distribute the work better .
+
+This panel has no related alerts.
+
+To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100410` on your Sourcegraph instance.
+
+<sub>*Managed by the [Sourcegraph Search-core team](https://handbook.sourcegraph.com/engineering/search/core).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Query: `sum by (le) (increase(index_queue_age_seconds_bucket[$__rate_interval]))`
+
+</details>
+
+<br />
+
+#### zoekt: indexed_queueing_delay_p99_9
+
+<p class="subtitle">99.9th percentile job queuing delay over 5m</p>
+
+The queueing delay represents the amount of time an indexing job spent in the queue before it was processed.
+
+Large queueing delays can be an indicator of:
+	- resource saturation
+	- each Zoekt replica has too many jobs for it to be able to process all of them promptly. In this scenario, consider adding additional Zoekt replicas to distribute the work better.
+
+The 99.9 percentile dashboard is useful for capturing the long tail of queueing delays (on the order of 24+ hours, etc.).
+
+This panel has no related alerts.
+
+To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100420` on your Sourcegraph instance.
+
+<sub>*Managed by the [Sourcegraph Search-core team](https://handbook.sourcegraph.com/engineering/search/core).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Query: `histogram_quantile(0.999, sum by (le, name)(rate(index_queue_age_seconds_bucket[5m])))`
+
+</details>
+
+<br />
+
+#### zoekt: indexed_queueing_delay_p90
+
+<p class="subtitle">90th percentile job queueing delay over 5m</p>
+
+The queueing delay represents the amount of time an indexing job spent in the queue before it was processed.
+
+Large queueing delays can be an indicator of:
+	- resource saturation
+	- each Zoekt replica has too many jobs for it to be able to process all of them promptly. In this scenario, consider adding additional Zoekt replicas to distribute the work better.
+
+This panel has no related alerts.
+
+To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100421` on your Sourcegraph instance.
+
+<sub>*Managed by the [Sourcegraph Search-core team](https://handbook.sourcegraph.com/engineering/search/core).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Query: `histogram_quantile(0.90, sum by (le, name)(rate(index_queue_age_seconds_bucket[5m])))`
+
+</details>
+
+<br />
+
+#### zoekt: indexed_queueing_delay_p75
+
+<p class="subtitle">75th percentile job queueing delay over 5m</p>
+
+The queueing delay represents the amount of time an indexing job spent in the queue before it was processed.
+
+Large queueing delays can be an indicator of:
+	- resource saturation
+	- each Zoekt replica has too many jobs for it to be able to process all of them promptly. In this scenario, consider adding additional Zoekt replicas to distribute the work better.
+
+This panel has no related alerts.
+
+To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100422` on your Sourcegraph instance.
+
+<sub>*Managed by the [Sourcegraph Search-core team](https://handbook.sourcegraph.com/engineering/search/core).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Query: `histogram_quantile(0.75, sum by (le, name)(rate(index_queue_age_seconds_bucket[5m])))`
+
+</details>
+
+<br />
+
 ### Zoekt: Compound shards (experimental)
 
 #### zoekt: compound_shards_aggregate

--- a/monitoring/definitions/zoekt.go
+++ b/monitoring/definitions/zoekt.go
@@ -322,6 +322,74 @@ func Zoekt() *monitoring.Container {
 							Interpretation: "A queue that is constantly growing could be a leading indicator of a bottleneck or under-provisioning",
 						},
 					},
+					{
+						{
+							Name:        "indexed_queueing_delay_heatmap",
+							Description: "job queuing delay heatmap",
+							Query:       "sum by (le) (increase(index_queue_age_seconds_bucket[$__rate_interval]))",
+							NoAlert:     true,
+							Panel: monitoring.PanelHeatmap().With(func(o monitoring.Observable, p *sdk.Panel) {
+								p.HeatmapPanel.YAxis.Format = string(monitoring.Seconds)
+							}),
+							Owner: monitoring.ObservableOwnerSearchCore,
+							Interpretation: `
+							The queueing delay represents the amount of time an indexing job spent in the queue before it was processed.
+
+							Large queueing delays can be an indicator of:
+								- resource saturation
+								- each Zoekt replica has too many jobs for it to be able to process all of them promptly. In this scenario, consider adding additional Zoekt replicas to distribute the work better .
+						`,
+						},
+					},
+					{
+						{
+							Name:        "indexed_queueing_delay_p99_9",
+							Description: "99.9th percentile job queuing delay over 5m",
+							Query:       "histogram_quantile(0.999, sum by (le, name)(rate(index_queue_age_seconds_bucket[5m])))",
+							NoAlert:     true,
+							Panel:       monitoring.Panel().LegendFormat("{{name}}").Unit(monitoring.Seconds),
+							Owner:       monitoring.ObservableOwnerSearchCore,
+							Interpretation: `
+							The queueing delay represents the amount of time an indexing job spent in the queue before it was processed.
+
+							Large queueing delays can be an indicator of:
+								- resource saturation
+								- each Zoekt replica has too many jobs for it to be able to process all of them promptly. In this scenario, consider adding additional Zoekt replicas to distribute the work better.
+
+							The 99.9 percentile dashboard is useful for capturing the long tail of queueing delays (on the order of 24+ hours, etc.).
+						`,
+						},
+						{
+							Name:        "indexed_queueing_delay_p90",
+							Description: "90th percentile job queueing delay over 5m",
+							Query:       "histogram_quantile(0.90, sum by (le, name)(rate(index_queue_age_seconds_bucket[5m])))",
+							NoAlert:     true,
+							Panel:       monitoring.Panel().LegendFormat("{{name}}").Unit(monitoring.Seconds),
+							Owner:       monitoring.ObservableOwnerSearchCore,
+							Interpretation: `
+							The queueing delay represents the amount of time an indexing job spent in the queue before it was processed.
+
+							Large queueing delays can be an indicator of:
+								- resource saturation
+								- each Zoekt replica has too many jobs for it to be able to process all of them promptly. In this scenario, consider adding additional Zoekt replicas to distribute the work better.
+						`,
+						},
+						{
+							Name:        "indexed_queueing_delay_p75",
+							Description: "75th percentile job queueing delay over 5m",
+							Query:       "histogram_quantile(0.75, sum by (le, name)(rate(index_queue_age_seconds_bucket[5m])))",
+							NoAlert:     true,
+							Panel:       monitoring.Panel().LegendFormat("{{name}}").Unit(monitoring.Seconds),
+							Owner:       monitoring.ObservableOwnerSearchCore,
+							Interpretation: `
+							The queueing delay represents the amount of time an indexing job spent in the queue before it was processed.
+
+							Large queueing delays can be an indicator of:
+								- resource saturation
+								- each Zoekt replica has too many jobs for it to be able to process all of them promptly. In this scenario, consider adding additional Zoekt replicas to distribute the work better.
+						`,
+						},
+					},
 				},
 			},
 			{


### PR DESCRIPTION
Follow up to https://github.com/sourcegraph/zoekt/pull/331

![Screen Shot 2022-04-18 at 11 26 27 AM](https://user-images.githubusercontent.com/9022011/163856735-9a0f17e0-9c16-4937-b5ce-09863ea9d057.png)

![Screen Shot 2022-04-18 at 11 28 03 AM](https://user-images.githubusercontent.com/9022011/163856747-17c22ba3-0fad-410a-aaa6-778cf073d5aa.png)

This PR adds new Grafana dashboards that surface `zoket-indexserver`'s job queuing delay. The hope is that we can use these to help us debug strange indexing delays that we can see on sourcegraph.com. 

## Test plan

The existing unit tests, and manually testing against k8s.sgdev.org 

