### PR TITLE
Update label notifications

### DIFF
--- a/.github/workflows/label-notify.yml
+++ b/.github/workflows/label-notify.yml
@@ -12,7 +12,8 @@ jobs:
           with:
              token: "${{ secrets.LABELER_GITHUB_TOKEN }}"
              recipients: |
-                  team/growth-and-integrations=@muratsu @jjinnii @ryankscott
+                  team/integrations=@muratsu @jjinnii @ryankscott
+                  team/growth=@muratsu @a-bergevin
                   team/cloud=@RafLeszczynski
                   team/search-product=@benvenker @lguychard
                   team/search-core=@jjeffwarner


### PR DESCRIPTION
Split growth & integrations teams into two separate teams and notify the team triads accordingly



## Test plan

no test plan needed


