### PR TITLE
compute: support repo matches

### DIFF
--- a/enterprise/internal/compute/output_command.go
+++ b/enterprise/internal/compute/output_command.go
@@ -62,6 +62,8 @@ func output(ctx context.Context, fragment string, matchPattern MatchPattern, rep
 
 func resultContent(ctx context.Context, db database.DB, r result.Match) (string, bool, error) {
 	switch m := r.(type) {
+	case *result.RepoMatch:
+		return string(m.Name), true, nil
 	case *result.FileMatch:
 		contentBytes, err := git.ReadFile(ctx, db, m.Repo.Name, m.CommitID, m.Path, 0, authz.DefaultSubRepoPermsChecker)
 		if err != nil {

--- a/enterprise/internal/compute/output_command_test.go
+++ b/enterprise/internal/compute/output_command_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
+	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 )
 
@@ -54,7 +55,10 @@ func fileMatch(content string) result.Match {
 		return []byte(content), nil
 	}
 	return &result.FileMatch{
-		File: result.File{Path: "my/awesome/path.ml"},
+		File: result.File{
+			Repo: types.MinimalRepo{Name: "my/awesome/repo"},
+			Path: "my/awesome/path.ml",
+		},
 	}
 }
 
@@ -83,6 +87,11 @@ func TestRun(t *testing.T) {
 		"template substitution regexp",
 		"(1)\n(2)\n(3)\n").
 		Equal(t, test(`content:output((\d) -> ($1))`, fileMatch("a 1 b 2 c 3")))
+
+	autogold.Want(
+		"handles repo match via select on file match",
+		"my/awesome/repo\n").
+		Equal(t, test(`lang:ocaml content:output(.* -> $repo) select:repo`, fileMatch("a 1 b 2 c 3")))
 
 	autogold.Want(
 		"template substitution regexp with commit author",

--- a/enterprise/internal/compute/template.go
+++ b/enterprise/internal/compute/template.go
@@ -244,6 +244,11 @@ func substituteMetaVariables(pattern string, env *MetaEnvironment) (string, erro
 // metavariables can be referenced and substituted for in an output template.
 func NewMetaEnvironment(r result.Match, content string) *MetaEnvironment {
 	switch m := r.(type) {
+	case *result.RepoMatch:
+		return &MetaEnvironment{
+			Repo:    string(m.Name),
+			Content: string(m.Name),
+		}
 	case *result.FileMatch:
 		lang, _ := enry.GetLanguageByExtension(m.Path)
 		return &MetaEnvironment{


### PR DESCRIPTION
Previously compute queries only processed `FileMatch` and `Commit`/`Diff` results. This adds `Repo` results. So now it's possible to do, e.g., `lang:rust select:repo content:output(.* -> $repo)` which will find all rust files (because `lang:rust`) and then convert/dedupe to repository results (because `select:repo`) and finally `output(...)` now understands repository results and can output a plain string like "Unique Rust Repo!", or metavariables `$repo` and `$content` (both of which will just refer to the repo name of a repo result).

## Test plan
Added unit test

