### PR TITLE
Add display name eslint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -116,6 +116,12 @@ See https://handbook.sourcegraph.com/community/faq#is-all-of-sourcegraph-open-so
         ],
       },
     ],
+    'react/display-name': [
+      'warning',
+      {
+        ignoreTranspilerName: false,
+      },
+    ],
     '@sourcegraph/wildcard/forbid-class-name': [
       'error',
       {


### PR DESCRIPTION
Add eslint rule for react component display name. Warning only.

closes #34005

## Test plan
- run cd client/web && yarn -s run lint:js

## App preview:

- [Link](https://sg-web-naman-display-rule-name.onrender.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

