### PR TITLE
ci: Report deployment metrics to OkayHQ

### DIFF
--- a/dev/okay/okay.go
+++ b/dev/okay/okay.go
@@ -126,6 +126,7 @@ func (c *Client) post(event *customEvent) error {
 	if c.token == "" {
 		// If the token is empty, just log the events
 		c.logger.Debug("pretending to send event", log.String("event", string(b)))
+		return nil
 	}
 
 	buf := bytes.NewReader(b)

--- a/dev/okay/okay_test.go
+++ b/dev/okay/okay_test.go
@@ -1,0 +1,256 @@
+package okay_test
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/sourcegraph/sourcegraph/dev/okay"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPush(t *testing.T) {
+	t.Run("serialization", func(t *testing.T) {
+		wantJSON := `{
+  "event": "custom",
+  "metrics": {
+    "elapsed": {
+      "type": "durationMs",
+      "value": 112728000
+    }
+  },
+  "identity": {
+    "type": "sourceControlLogin",
+    "user": "bobheadxi"
+  },
+  "timestamp": "2022-04-21T12:37:00Z",
+  "uniqueKey": [
+    "unique_key"
+  ],
+  "properties": {
+    "unique_key":"preprod,34159,frontend,github-proxy,precise-code-intel,searcher,symbols,syntect-server,worker",
+    "okay.url": "https://github.com/sourcegraph/sourcegraph/pull/34159",
+    "environment": "preprod",
+    "pull_request.url": "https://github.com/sourcegraph/sourcegraph/pull/34159",
+    "pull_request.title": "httptestutil: delete all VCR headers that look risky",
+    "pull_request.number": "34159",
+    "pull_request.revision": "abef4220236c7114d84933574fadba43beaf54f5"
+  },
+  "customEventName": "qa.deployment",
+  "labels": [
+      "frontend",
+      "github-proxy",
+      "precise-code-intel",
+      "searcher",
+      "symbols",
+      "syntect-server",
+      "worker"
+   ]
+}`
+
+		svr, cli := newTestServer(t, eventHandler(func(body []byte) int {
+			assert.JSONEq(t, wantJSON, string(body))
+			return 200
+		}))
+		defer svr.Close()
+
+		err := cli.Push(&okay.Event{
+			Name:      "qa.deployment",
+			Timestamp: time.Date(2022, 04, 21, 12, 37, 0, 0, time.UTC),
+			Metrics: map[string]okay.Metric{
+				"elapsed": {
+					Type:  "durationMs",
+					Value: 112728000,
+				},
+			},
+			GitHubLogin: "bobheadxi",
+			OkayURL:     "https://github.com/sourcegraph/sourcegraph/pull/34159",
+			UniqueKey:   []string{"unique_key"},
+			Properties: map[string]string{
+				"unique_key":            "preprod,34159,frontend,github-proxy,precise-code-intel,searcher,symbols,syntect-server,worker",
+				"environment":           "preprod",
+				"pull_request.url":      "https://github.com/sourcegraph/sourcegraph/pull/34159",
+				"pull_request.title":    "httptestutil: delete all VCR headers that look risky",
+				"pull_request.number":   "34159",
+				"pull_request.revision": "abef4220236c7114d84933574fadba43beaf54f5",
+			},
+			Labels: []string{
+				"frontend",
+				"github-proxy",
+				"precise-code-intel",
+				"searcher",
+				"symbols",
+				"syntect-server",
+				"worker",
+			},
+		})
+		assert.NoError(t, err)
+		assert.NoError(t, cli.Flush())
+	})
+
+	t.Run("validation", func(t *testing.T) {
+		svr, cli := newTestServer(t)
+		defer svr.Close()
+
+		t.Run("NOK blank name", func(t *testing.T) {
+			event := dummyEvent()
+			event.Name = ""
+			err := cli.Push(event)
+			assert.Error(t, err)
+
+			// No error because we never reached the server.
+			assert.NoError(t, cli.Flush())
+		})
+
+		t.Run("NOK zero value timestamp", func(t *testing.T) {
+			event := dummyEvent()
+			event.Timestamp = time.Time{}
+			err := cli.Push(event)
+			assert.Error(t, err)
+
+			// No error because we never reached the server.
+			assert.NoError(t, cli.Flush())
+		})
+
+		t.Run("NOK no metrics", func(t *testing.T) {
+			event := dummyEvent()
+			event.Metrics = nil
+			err := cli.Push(event)
+			assert.Error(t, err)
+
+			// No error because we never reached the server.
+			assert.NoError(t, cli.Flush())
+		})
+
+		t.Run("NOK absent uniqueKey", func(t *testing.T) {
+			event := dummyEvent()
+			event.UniqueKey = []string{"not-existing"}
+			err := cli.Push(event)
+			assert.Error(t, err)
+
+			// No error because we never reached the server.
+			assert.NoError(t, cli.Flush())
+		})
+
+	})
+}
+
+func TestFlush(t *testing.T) {
+	t.Run("OK", func(t *testing.T) {
+		svr, cli := newTestServer(t,
+			eventHandlerMap(func(rawEvent map[string]interface{}) int {
+				assert.Equal(t, "one", rawEvent["customEventName"])
+				return 200
+			}),
+			eventHandlerMap(func(rawEvent map[string]interface{}) int {
+				assert.Equal(t, "two", rawEvent["customEventName"])
+				return 200
+			}),
+			eventHandlerMap(func(rawEvent map[string]interface{}) int {
+				assert.Equal(t, "three", rawEvent["customEventName"])
+				return 200
+			}),
+		)
+		defer svr.Close()
+
+		for _, name := range []string{"one", "two", "three"} {
+			event := dummyEvent()
+			event.Name = name
+			err := cli.Push(event)
+			assert.NoError(t, err)
+		}
+		assert.NoError(t, cli.Flush())
+	})
+
+	t.Run("NOK http errors", func(t *testing.T) {
+		svr, cli := newTestServer(t,
+			eventHandlerMap(func(rawEvent map[string]interface{}) int {
+				assert.Equal(t, "one", rawEvent["customEventName"])
+				return 200
+			}),
+			eventHandlerMap(func(rawEvent map[string]interface{}) int {
+				assert.Equal(t, "two", rawEvent["customEventName"])
+				return 500
+			}),
+			eventHandlerMap(func(rawEvent map[string]interface{}) int {
+				assert.Equal(t, "three", rawEvent["customEventName"])
+				return 500
+			}),
+			eventHandlerMap(func(rawEvent map[string]interface{}) int {
+				assert.Equal(t, "four", rawEvent["customEventName"])
+				return 200
+			}),
+		)
+		defer svr.Close()
+
+		for _, name := range []string{"one", "two", "three", "four"} {
+			event := dummyEvent()
+			event.Name = name
+			err := cli.Push(event)
+			assert.NoError(t, err)
+		}
+		err := cli.Flush()
+		assert.NotNil(t, err)
+
+		assert.Contains(t, err.Error(), "three")
+		assert.Contains(t, err.Error(), "two")
+	})
+}
+
+func newTestServer(t *testing.T, handlers ...eventHandler) (*httptest.Server, *okay.Client) {
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer r.Body.Close()
+		if len(handlers) == 0 {
+			t.Fatalf("unexpected request")
+		}
+		b, err := io.ReadAll(r.Body)
+		assert.NoError(t, err)
+
+		var h eventHandler
+		h, handlers = handlers[0], handlers[1:]
+
+		status := h(b)
+		w.WriteHeader(status)
+	}))
+
+	cli := okay.NewClient(svr.Client(), "foobar")
+	cli.SetEndpoint(svr.URL)
+
+	return svr, cli
+}
+
+func timestamp() time.Time {
+	t, _ := time.Parse(time.RFC822, time.RFC822)
+	return t
+}
+
+type eventHandler func([]byte) int
+
+func eventHandlerMap(h func(map[string]interface{}) int) eventHandler {
+	return func(body []byte) int {
+		var rawEvent map[string]interface{}
+		_ = json.Unmarshal(body, &rawEvent)
+		return h(rawEvent)
+	}
+}
+
+func dummyEvent() *okay.Event {
+	return &okay.Event{
+		Name:      "dummy",
+		Timestamp: timestamp(),
+		Metrics: map[string]okay.Metric{
+			"fooMetric": {
+				Type:  "count",
+				Value: 1,
+			},
+		},
+		UniqueKey: []string{"foo"},
+		Properties: map[string]string{
+			"foo": "bar",
+			"bar": "baz",
+		},
+	}
+}

--- a/dev/okay/okay_test.go
+++ b/dev/okay/okay_test.go
@@ -9,8 +9,14 @@ import (
 	"time"
 
 	"github.com/sourcegraph/sourcegraph/dev/okay"
+	"github.com/sourcegraph/sourcegraph/lib/log/logtest"
 	"github.com/stretchr/testify/assert"
 )
+
+func TestMain(m *testing.M) {
+	logtest.Init(m)
+	m.Run()
+}
 
 func TestPush(t *testing.T) {
 	t.Run("serialization", func(t *testing.T) {

--- a/dev/okay/okay_test.go
+++ b/dev/okay/okay_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 	"time"
 
@@ -16,6 +17,7 @@ import (
 func TestMain(m *testing.M) {
 	logtest.Init(m)
 	m.Run()
+	os.Exit(0)
 }
 
 func TestPush(t *testing.T) {

--- a/enterprise/dev/deployment-notifier/main.go
+++ b/enterprise/dev/deployment-notifier/main.go
@@ -198,6 +198,7 @@ func (o *OkayMetricsClient) post(event *okayEvent) error {
 		return err
 	}
 	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", o.token))
+	req.Header.Add("Content-Type", "application/json")
 	resp, err := o.cli.Do(req)
 	if err != nil {
 		return err
@@ -263,7 +264,7 @@ func reportDeploymentMetrics(report *DeploymentReport, token string, dryRun bool
 
 	for _, pr := range report.PullRequests {
 		durationInMin := deployTime.Sub(pr.GetMergedAt()) / time.Minute
-		okayCli.Push("qa.deployment", deployTime, map[string]interface{}{
+		err := okayCli.Push("qa.deployment", deployTime, map[string]interface{}{
 			// context
 			"environment":           report.Environment,
 			"author":                pr.GetUser().GetLogin(),
@@ -275,6 +276,9 @@ func reportDeploymentMetrics(report *DeploymentReport, token string, dryRun bool
 			// duration
 			"duration.minutes": durationInMin,
 		})
+		if err != nil {
+			return err
+		}
 	}
 	return okayCli.Flush()
 }

--- a/enterprise/dev/deployment-notifier/okayhq_metrics.go
+++ b/enterprise/dev/deployment-notifier/okayhq_metrics.go
@@ -1,0 +1,171 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+var okayhqAPIEndpoint = "https://app.okayhq.com/api/events/v1"
+
+// OkayMetric represents a particular metric attached to an event.
+type OkayMetric struct {
+	// Type is either "count", "durationMs" or "number".
+	Type string `json:"type"`
+	// Value is the actual value reported for this metric in a given event.
+	Value float64 `json:"value"`
+}
+
+// okayEvent represents a custom event sent to the OkayHQ API.
+type okayEvent struct {
+	// Event is the event type, should be always set to "custom".
+	Event string `json:"event"`
+	// Name is the custom event name, used to select those events amonst others to build dashboards.
+	Name string `json:"customEventName"`
+	// Timestamp is the time at which this event occured.
+	Timestamp time.Time `json:"timestamp"`
+	// Identity ties this specific event to a particular user, enabling to filter events on various group predicates
+	// such as teams, organizations, etc ...
+	Identity okayEventIdentity `json:"identity"`
+	// UniqueKey lists the property keys that are used to uniquely identify this event (optional).
+	//
+	// Sending another event with the same UniqueKey results in overwritting the previous event,
+	// enabling to replay events with historical data or to correct incorrect events that were previously sent.
+	UniqueKey []string `json:"uniqueKey,omitempty"`
+	// Metrics are a map of okayMetric whose keys are the metric name.
+	Metrics map[string]OkayMetric `json:"metrics"`
+	// Properties are a map of additonal metadata (optional).
+	Properties map[string]interface{} `json:"properties,omitempty"`
+}
+
+type okayEventIdentity struct {
+	// Type represents from where this identity is registered, should always be "sourceControlLogin".
+	Type string `json:"type"`
+	// User is the unique identifier to reference this identity amongst its Type.
+	User string `json:"user"`
+}
+
+type OkayEvent struct {
+	// Name is the custom event name, used to select those events amonst others to build dashboards.
+	Name string
+	// Timestamp is the time at which this event occured.
+	Timestamp time.Time
+	// GitHub login this event is attached to
+	GitHubLogin string
+	// UniqueKey lists the property keys that are used to uniquely identify this event (optional).
+	//
+	// Sending another event with the same UniqueKey results in overwritting the previous event,
+	// enabling to replay events with historical data or to correct incorrect events that were previously sent.
+	UniqueKey []string
+	// Properties are a map of additonal metadata (optional).
+	Properties map[string]interface{}
+	// Metrics are a map of okayMetric whose keys are the metric name.
+	Metrics map[string]OkayMetric
+}
+
+// OkayMetricsClient collects and submit metrics to the OkayHQ custom events API.
+//
+// See https://app.okayhq.com/help/_api/events
+//
+// TODO: If we were to extract this into a package:
+//       - Flush should take a context.Context
+//       - Flush should check if the context is cancelled in between making requests.
+//       - Add some tests.
+type OkayMetricsClient struct {
+	token  string
+	cli    *http.Client
+	events []*okayEvent
+	mu     sync.Mutex
+}
+
+// NewOkayMetricsClient returns a new OkayMetricsClient, using the provided http.Client.
+func NewOkayMetricsClient(client *http.Client, token string) *OkayMetricsClient {
+	return &OkayMetricsClient{
+		cli:   client,
+		token: token,
+	}
+}
+
+// post submits an individual event to the API.
+func (o *OkayMetricsClient) post(event *okayEvent) error {
+	fmt.Println(okayhqAPIEndpoint)
+	b, err := json.Marshal(event)
+	if err != nil {
+		return err
+	}
+	buf := bytes.NewReader(b)
+	req, err := http.NewRequest(http.MethodPost, okayhqAPIEndpoint, buf)
+	if err != nil {
+		return err
+	}
+	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", o.token))
+	req.Header.Add("Content-Type", "application/json")
+	resp, err := o.cli.Do(req)
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 400 {
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			body = []byte("can't read response body")
+		}
+		defer resp.Body.Close()
+		return errors.Newf("failed to submit custom metric to OkayHQ: %q", string(body))
+	}
+	fmt.Println(resp.StatusCode)
+	return nil
+}
+
+// Push stores a new custom event to be submitted to OkayHQ once Flush is called.
+func (o *OkayMetricsClient) Push(name string, event *OkayEvent) error {
+	if name == "" {
+		return errors.New("Okay event name can't be blank")
+	}
+	if event.Timestamp.IsZero() {
+		return errors.New("Okay event timestamp name can't be zero")
+	}
+	if len(event.Metrics) == 0 {
+		return errors.New("Okay event must have metrics")
+	}
+
+	o.mu.Lock()
+	defer o.mu.Unlock()
+
+	o.events = append(o.events, &okayEvent{
+		Event:     "custom",
+		Name:      name,
+		Timestamp: event.Timestamp,
+		UniqueKey: event.UniqueKey,
+		Identity: okayEventIdentity{
+			Type: "sourceControlLogin",
+			User: event.GitHubLogin,
+		},
+		Metrics:    event.Metrics,
+		Properties: event.Properties,
+	})
+
+	return nil
+}
+
+// Flush empties the list of events accumulated by the client.
+func (o *OkayMetricsClient) Flush() error {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+
+	var errs error
+	for _, event := range o.events {
+		err := o.post(event)
+		if err != nil {
+			errs = errors.Append(err)
+		}
+	}
+	// Reset the internal events buffer
+	o.events = nil
+	return errs
+}


### PR DESCRIPTION
Submit metrics to OkayHQ to track deployment timings along with other team metrics. I'll be creating a dashboard to visualize those. We should get the events to appear in the UI by tomorrow. 

This uses the new API that they released today!

I'll submit historical data as well, so we can have more things to show. 

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

- Manual test in local and checked with the OkayHQ fellow that they got our events. 
