### PR TITLE
Code Insights: Fix repositories field visual border

### DIFF
--- a/client/web/src/enterprise/insights/components/form/repositories-field/RepositoriesField.module.scss
+++ b/client/web/src/enterprise/insights/components/form/repositories-field/RepositoriesField.module.scss
@@ -1,10 +1,10 @@
 .combobox {
     width: 100%;
 
-    &-popover {
-        border: solid 1px var(--border-color);
-        box-shadow: var(--box-shadow);
-        background-color: var(--input-bg);
+    // Reset default @reach ui combobox styles
+    &-reach-popover {
+        border: none;
+        box-shadow: none;
 
         /**
             By default reach-ui/combobox sets `font-size` to 85% for the content
@@ -13,4 +13,10 @@
          */
         font-size: inherit;
     }
+}
+
+.popover {
+    border: solid 1px var(--border-color);
+    box-shadow: var(--box-shadow);
+    background-color: var(--input-bg);
 }

--- a/client/web/src/enterprise/insights/components/form/repositories-field/RepositoriesField.tsx
+++ b/client/web/src/enterprise/insights/components/form/repositories-field/RepositoriesField.tsx
@@ -126,8 +126,8 @@ const RepositoriesField = forwardRef((props: RepositoryFieldProps, reference: Re
             />
 
             {panel && (
-                <ComboboxPopover className={styles.comboboxPopover}>
-                    <SuggestionsPanel value={searchValue} suggestions={suggestions} />
+                <ComboboxPopover hidden={false} className={styles.comboboxReachPopover}>
+                    <SuggestionsPanel value={searchValue} suggestions={suggestions} className={styles.popover} />
                 </ComboboxPopover>
             )}
         </Combobox>

--- a/client/web/src/enterprise/insights/components/form/repositories-field/RepositoryField.tsx
+++ b/client/web/src/enterprise/insights/components/form/repositories-field/RepositoryField.tsx
@@ -41,8 +41,8 @@ export const RepositoryField = forwardRef((props: RepositoryFieldProps, referenc
                 onChange={handleInputChange}
             />
 
-            <ComboboxPopover className={styles.comboboxPopover}>
-                <SuggestionsPanel value={searchValue} suggestions={suggestions} />
+            <ComboboxPopover className={styles.comboboxReachPopover}>
+                <SuggestionsPanel value={searchValue} suggestions={suggestions} className={styles.popover} />
             </ComboboxPopover>
         </Combobox>
     )

--- a/client/web/src/enterprise/insights/components/form/repositories-field/components/suggestion-panel/SuggestionPanel.tsx
+++ b/client/web/src/enterprise/insights/components/form/repositories-field/components/suggestion-panel/SuggestionPanel.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 
 import { ComboboxList, ComboboxOption, ComboboxOptionText } from '@reach/combobox'
+import classNames from 'classnames'
 import SourceRepositoryIcon from 'mdi-react/SourceRepositoryIcon'
 
 import { ErrorAlert } from '@sourcegraph/branded/src/components/alerts'
@@ -12,6 +13,7 @@ import styles from './SuggestionPanel.module.scss'
 interface SuggestionsPanelProps {
     value: string | null
     suggestions?: Error | RepositorySuggestion[]
+    className?: string
 }
 
 interface RepositorySuggestion {
@@ -23,11 +25,11 @@ interface RepositorySuggestion {
  * Renders suggestion panel for repositories combobox component.
  */
 export const SuggestionsPanel: React.FunctionComponent<SuggestionsPanelProps> = props => {
-    const { value, suggestions } = props
+    const { value, suggestions, className } = props
 
     if (suggestions === undefined) {
         return (
-            <div className={styles.loadingPanel}>
+            <div className={classNames(styles.loadingPanel, classNames)}>
                 <LoadingSpinner inline={false} />
             </div>
         )
@@ -37,11 +39,15 @@ export const SuggestionsPanel: React.FunctionComponent<SuggestionsPanelProps> = 
         return <ErrorAlert className="m-1" error={suggestions} data-testid="repository-suggestions-error" />
     }
 
+    if (suggestions.length === 0) {
+        return null
+    }
+
     const searchValue = value ?? ''
     const isValueEmpty = searchValue.trim() === ''
 
     return (
-        <ComboboxList className={styles.suggestionsList}>
+        <ComboboxList className={classNames(styles.suggestionsList, className)}>
             {suggestions.map(suggestion => (
                 <ComboboxOption className={styles.suggestionsListItem} key={suggestion.id} value={suggestion.name}>
                     <SourceRepositoryIcon className="mr-1" size="1rem" />


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/34044

| Before  | After |
| ------------- | ------------- |
| <img width="941" alt="Screenshot 2022-04-19 at 14 17 54" src="https://user-images.githubusercontent.com/18492575/163983052-bf7beab2-a0c0-45fe-aa8e-e85aa689598d.png">  | <img width="957" alt="Screenshot 2022-04-19 at 14 17 35" src="https://user-images.githubusercontent.com/18492575/163983040-c5b368bb-0c29-4c5a-858e-a9005e0c4581.png">  |


## Test plan
- Make sure that you can't see an empty Combobox element border if you don't have any suggestions yet


<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->



## App preview:

- [Link](https://sg-web-vk-fix-repo-suggestion-combobox.onrender.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

