### PR TITLE
search: Remove NPM specific alerts and warnings

### DIFF
--- a/client/shared/src/search/query/predicates.ts
+++ b/client/shared/src/search/query/predicates.ts
@@ -171,12 +171,12 @@ export const predicateCompletion = (field: string): Completion[] => {
                 asSnippet: true,
             },
             {
-                label: 'deps(...) Includes npm dependencies only (beta)',
+                label: 'deps(...)',
                 insertText: 'deps(${1})',
                 asSnippet: true,
             },
             {
-                label: 'dependencies(...) Includes npm dependencies only (beta)',
+                label: 'dependencies(...)',
                 insertText: 'dependencies(${1})',
                 asSnippet: true,
             },

--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -1455,7 +1455,7 @@ func testDependenciesSearch(client, streamClient searchClient) func(*testing.T) 
 				require.Zero(t, results.MatchCount)
 				require.Equal(t, results.Alert, &gqltestutil.SearchAlert{
 					Title:       "No dependency repositories found",
-					Description: "Dependency repos are cloned on-demand when first searched. Try again in a few seconds if you know the given repositories have dependencies.\n\nOnly npm dependencies from `package-lock.json` and `yarn.lock` files are currently supported.",
+					Description: "Dependency repos are cloned on-demand when first searched. Try again in a few seconds if you know the given repositories have dependencies.\n\nRead more about dependencies search [here](https://docs.sourcegraph.com/code_search/how-to/dependencies_search).",
 				})
 			})
 		}


### PR DESCRIPTION
This commit removes NPM specific warnings from dependencies
search snippets and modifies the respective search alerts to work for Go
dependency repos too.



## Test plan

Manual testing.

