### PR TITLE
gitserver: implement GetReposByNames batching

### DIFF
--- a/internal/database/gitserver_repos.go
+++ b/internal/database/gitserver_repos.go
@@ -350,20 +350,20 @@ func (s *gitserverRepoStore) getByNames(ctx context.Context, maxNumPostgresParam
 	for i := 0; i <= len(names); i++ {
 		if remainingNames == 0 || batchSize == maxNumPostgresParameters {
 			// executing the DB query
-			if res, err := s.sendBatchQuery(ctx, batchSize, nameQueries); err == nil {
-				repos = append(repos, res...)
-			} else {
+			res, err := s.sendBatchQuery(ctx, batchSize, nameQueries)
+			if err != nil {
 				return nil, err
 			}
+			repos = append(repos, res...)
 
 			if remainingNames == 0 {
 				// last batch: break out of the loop
 				break
-			} else {
-				// intermediate batch: reset variables required for a new batch
-				batchSize = 0
-				nameQueries = nil
 			}
+
+			// intermediate batch: reset variables required for a new batch
+			batchSize = 0
+			nameQueries = nil
 		}
 		nameQueries = append(nameQueries, sqlf.Sprintf("%s", names[i]))
 		batchSize++

--- a/internal/database/gitserver_repos.go
+++ b/internal/database/gitserver_repos.go
@@ -320,12 +320,7 @@ WHERE r.name = %s
 	return scanSingleGitserverRepo(s.QueryRow(ctx, sqlf.Sprintf(q, name)))
 }
 
-func (s *gitserverRepoStore) GetByNames(ctx context.Context, names ...api.RepoName) ([]*types.GitserverRepo, error) {
-	if len(names) > batch.MaxNumPostgresParameters {
-		return nil, errors.Newf("getting GitserverRepos by names: too many names provided: %v", len(names))
-	}
-
-	q := `
+const getByNamesQueryTemplate = `
 -- source: internal/database/gitserver_repos.go:gitserverRepoStore.GetByName
 SELECT
        g.repo_id,
@@ -340,17 +335,61 @@ FROM gitserver_repos g
 JOIN repo r on r.id = g.repo_id
 WHERE r.name IN (%s)
 `
-	nameQueries := []*sqlf.Query{}
-	for _, v := range names {
-		nameQueries = append(nameQueries, sqlf.Sprintf("%s", v))
+
+var MaxNumPostgresParametersMock func() int
+
+func ResetMaxNumPostgresParametersMock() {
+	MaxNumPostgresParametersMock = nil
+}
+
+func (s *gitserverRepoStore) GetByNames(ctx context.Context, names ...api.RepoName) ([]*types.GitserverRepo, error) {
+	var maxNumPostgresParameters int
+	if MaxNumPostgresParametersMock != nil {
+		maxNumPostgresParameters = MaxNumPostgresParametersMock()
+	} else {
+		maxNumPostgresParameters = batch.MaxNumPostgresParameters
 	}
 
-	rows, err := s.Query(ctx, sqlf.Sprintf(q, sqlf.Join(nameQueries, ",")))
+	remainingNames := len(names)
+	nameQueries := make([]*sqlf.Query, 0)
+	batchSize := 0
+	repos := make([]*types.GitserverRepo, 0, remainingNames)
+
+	// iterating len(names) + 1 times because last iteration is needed for the last batch
+	for i := 0; i <= len(names); i++ {
+		if remainingNames == 0 {
+			// last batch: execute query and break out of the loop
+			if res, err := s.sendBatchQuery(ctx, maxNumPostgresParameters, nameQueries); err == nil {
+				repos = append(repos, res...)
+			} else {
+				return nil, err
+			}
+			break
+		}
+		if batchSize == maxNumPostgresParameters {
+			// batch is full: execute query and clear any variables for a new batch
+			if res, err := s.sendBatchQuery(ctx, maxNumPostgresParameters, nameQueries); err == nil {
+				repos = append(repos, res...)
+			} else {
+				return nil, err
+			}
+			batchSize = 0
+			nameQueries = nil
+		}
+		nameQueries = append(nameQueries, sqlf.Sprintf("%s", names[i]))
+		batchSize++
+		remainingNames--
+	}
+
+	return repos, nil
+}
+
+func (s *gitserverRepoStore) sendBatchQuery(ctx context.Context, maxNumPostgresParameters int, nameQueries []*sqlf.Query) ([]*types.GitserverRepo, error) {
+	repos := make([]*types.GitserverRepo, 0, maxNumPostgresParameters)
+	rows, err := s.Query(ctx, sqlf.Sprintf(getByNamesQueryTemplate, sqlf.Join(nameQueries, ",")))
 	if err != nil {
 		return nil, err
 	}
-
-	repos := make([]*types.GitserverRepo, 0, len(names))
 
 	for rows.Next() {
 		repo, err := scanSingleGitserverRepo(rows)
@@ -359,8 +398,7 @@ WHERE r.name IN (%s)
 		}
 		repos = append(repos, repo)
 	}
-
-	return repos, nil
+	return repos, err
 }
 
 // ScannerWithError captures Scan and Err methods of sql.Rows and sql.Row.

--- a/internal/database/gitserver_repos_test.go
+++ b/internal/database/gitserver_repos_test.go
@@ -347,6 +347,7 @@ func TestGitserverReposGetByNames(t *testing.T) {
 	}
 
 	repoIdx := 0
+	gitserverRepoStore := &gitserverRepoStore{Store: basestore.NewWithDB(db, sql.TxOptions{})}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			// Creating tc.reposNumber repos
@@ -365,14 +366,8 @@ func TestGitserverReposGetByNames(t *testing.T) {
 				idToExpectedRepo[gitserverRepo.RepoID] = gitserverRepo
 			}
 
-			// Mock maxNumPostgresParameters to test how well does batching work
-			MaxNumPostgresParametersMock = func() int {
-				return tc.batchSize
-			}
-			defer ResetMaxNumPostgresParametersMock()
-
 			// GetByNames should now work
-			fromDB, err := GitserverRepos(db).GetByNames(ctx, repoNames...)
+			fromDB, err := gitserverRepoStore.getByNames(ctx, tc.batchSize, repoNames...)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/database/gitserver_repos_test.go
+++ b/internal/database/gitserver_repos_test.go
@@ -318,37 +318,71 @@ func TestGitserverReposGetByNames(t *testing.T) {
 	db := dbtest.NewDB(t)
 	ctx := context.Background()
 
-	// Creating 2 repos
-	repo1, gitserverRepo1 := createTestRepo(ctx, t, db, &createTestRepoPayload{
-		Name:         "github.com/sourcegraph/repo1",
-		URI:          "github.com/sourcegraph/repo1",
-		ExternalRepo: api.ExternalRepoSpec{},
-		ShardID:      "test1",
-	})
-
-	repo2, gitserverRepo2 := createTestRepo(ctx, t, db, &createTestRepoPayload{
-		Name:         "github.com/sourcegraph/repo2",
-		URI:          "github.com/sourcegraph/repo2",
-		ExternalRepo: api.ExternalRepoSpec{},
-		ShardID:      "test2",
-	})
-
-	idToExpectedRepo := map[api.RepoID]*types.GitserverRepo{
-		gitserverRepo1.RepoID: gitserverRepo1,
-		gitserverRepo2.RepoID: gitserverRepo2,
+	type testCase struct {
+		name        string
+		reposNumber int
+		batchSize   int
+	}
+	testCases := []testCase{
+		{
+			name:        "GetReposByNames: repos=10, batch=3",
+			reposNumber: 10,
+			batchSize:   3,
+		},
+		{
+			name:        "GetReposByNames: repos=5, batch=30",
+			reposNumber: 5,
+			batchSize:   30,
+		},
+		{
+			name:        "GetReposByNames: repos=10, batch=5",
+			reposNumber: 10,
+			batchSize:   5,
+		},
+		{
+			name:        "GetReposByNames: repos=1, batch=3",
+			reposNumber: 1,
+			batchSize:   3,
+		},
 	}
 
-	// GetByNames should now work
-	fromDB, err := GitserverRepos(db).GetByNames(ctx, repo1.Name, repo2.Name)
-	if err != nil {
-		t.Fatal(err)
-	}
+	repoIdx := 0
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Creating tc.reposNumber repos
+			repoNames := make([]api.RepoName, 0)
+			idToExpectedRepo := make(map[api.RepoID]*types.GitserverRepo, 0)
+			for i := 0; i < tc.reposNumber; i++ {
+				repoName := fmt.Sprintf("github.com/sourcegraph/repo%d", repoIdx)
+				repoIdx++
+				repo, gitserverRepo := createTestRepo(ctx, t, db, &createTestRepoPayload{
+					Name:         api.RepoName(repoName),
+					URI:          repoName,
+					ExternalRepo: api.ExternalRepoSpec{},
+					ShardID:      shardID,
+				})
+				repoNames = append(repoNames, repo.Name)
+				idToExpectedRepo[gitserverRepo.RepoID] = gitserverRepo
+			}
 
-	if diff := cmp.Diff(idToExpectedRepo[fromDB[0].RepoID], fromDB[0], cmpopts.IgnoreFields(types.GitserverRepo{}, "UpdatedAt")); diff != "" {
-		t.Fatal(diff)
-	}
-	if diff := cmp.Diff(idToExpectedRepo[fromDB[1].RepoID], fromDB[1], cmpopts.IgnoreFields(types.GitserverRepo{}, "UpdatedAt")); diff != "" {
-		t.Fatal(diff)
+			// Mock maxNumPostgresParameters to test how well does batching work
+			MaxNumPostgresParametersMock = func() int {
+				return tc.batchSize
+			}
+			defer ResetMaxNumPostgresParametersMock()
+
+			// GetByNames should now work
+			fromDB, err := GitserverRepos(db).GetByNames(ctx, repoNames...)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			for i := 0; i < tc.reposNumber; i++ {
+				if diff := cmp.Diff(idToExpectedRepo[fromDB[i].RepoID], fromDB[i], cmpopts.IgnoreFields(types.GitserverRepo{}, "UpdatedAt")); diff != "" {
+					t.Fatal(diff)
+				}
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
This adds batching to already implemented [GetReposByNames function](https://github.com/sourcegraph/sourcegraph/pull/33560).

This code can probably be used as a base for a more generic batch select implementation (like [batch inserter](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/internal/database/batch/batch.go))


## Test plan
New tests added
<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


