### PR TITLE
gitserver: document Addrs

### DIFF
--- a/internal/gitserver/client.go
+++ b/internal/gitserver/client.go
@@ -159,6 +159,8 @@ type Client interface {
 	// AddrForRepo returns the gitserver address to use for the given repo name.
 	AddrForRepo(context.Context, api.RepoName) (string, error)
 
+	// Addrs returns the addresses for gitservers. It is safe for concurrent
+	// use. It may return different results at different times.
 	Addrs() []string
 
 	// Archive produces an archive from a Git repository.


### PR DESCRIPTION
This was missing the documentation that was originally present when
Addrs was a function field on the gitserver client struct.

Note: I checked the other methods which are not documented, and the
signature for those is so obvious that I don't think documentation
helps.

Test Plan: n/a internal documentation change.