### PR TITLE
monitoring: relax alerting thresholds for sentinel queries

### DIFF
--- a/doc/admin/observability/alert_solutions.md
+++ b/doc/admin/observability/alert_solutions.md
@@ -927,27 +927,27 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 <br />
 
-## frontend: mean_successful_sentinel_duration_over_1h30m
+## frontend: mean_successful_sentinel_duration_over_2h
 
-<p class="subtitle">mean successful sentinel search duration over 1h30m</p>
+<p class="subtitle">mean successful sentinel search duration over 2h</p>
 
 **Descriptions**
 
-- <span class="badge badge-warning">warning</span> frontend: 5s+ mean successful sentinel search duration over 1h30m for 15m0s
-- <span class="badge badge-critical">critical</span> frontend: 8s+ mean successful sentinel search duration over 1h30m for 30m0s
+- <span class="badge badge-warning">warning</span> frontend: 5s+ mean successful sentinel search duration over 2h for 15m0s
+- <span class="badge badge-critical">critical</span> frontend: 8s+ mean successful sentinel search duration over 2h for 30m0s
 
 **Possible solutions**
 
 - Look at the breakdown by query to determine if a specific query type is being affected
 - Check for high CPU usage on zoekt-webserver
 - Check Honeycomb for unusual activity
-- More help interpreting this metric is available in the [dashboards reference](./dashboards.md#frontend-mean-successful-sentinel-duration-over-1h30m).
+- More help interpreting this metric is available in the [dashboards reference](./dashboards.md#frontend-mean-successful-sentinel-duration-over-2h).
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
 ```json
 "observability.silenceAlerts": [
-  "warning_frontend_mean_successful_sentinel_duration_over_1h30m",
-  "critical_frontend_mean_successful_sentinel_duration_over_1h30m"
+  "warning_frontend_mean_successful_sentinel_duration_over_2h",
+  "critical_frontend_mean_successful_sentinel_duration_over_2h"
 ]
 ```
 
@@ -955,27 +955,27 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 <br />
 
-## frontend: mean_sentinel_stream_latency_over_1h30m
+## frontend: mean_sentinel_stream_latency_over_2h
 
-<p class="subtitle">mean successful sentinel stream latency over 1h30m</p>
+<p class="subtitle">mean successful sentinel stream latency over 2h</p>
 
 **Descriptions**
 
-- <span class="badge badge-warning">warning</span> frontend: 2s+ mean successful sentinel stream latency over 1h30m for 15m0s
-- <span class="badge badge-critical">critical</span> frontend: 3s+ mean successful sentinel stream latency over 1h30m for 30m0s
+- <span class="badge badge-warning">warning</span> frontend: 2s+ mean successful sentinel stream latency over 2h for 15m0s
+- <span class="badge badge-critical">critical</span> frontend: 3s+ mean successful sentinel stream latency over 2h for 30m0s
 
 **Possible solutions**
 
 - Look at the breakdown by query to determine if a specific query type is being affected
 - Check for high CPU usage on zoekt-webserver
 - Check Honeycomb for unusual activity
-- More help interpreting this metric is available in the [dashboards reference](./dashboards.md#frontend-mean-sentinel-stream-latency-over-1h30m).
+- More help interpreting this metric is available in the [dashboards reference](./dashboards.md#frontend-mean-sentinel-stream-latency-over-2h).
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
 ```json
 "observability.silenceAlerts": [
-  "warning_frontend_mean_sentinel_stream_latency_over_1h30m",
-  "critical_frontend_mean_sentinel_stream_latency_over_1h30m"
+  "warning_frontend_mean_sentinel_stream_latency_over_2h",
+  "critical_frontend_mean_sentinel_stream_latency_over_2h"
 ]
 ```
 
@@ -983,27 +983,27 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 <br />
 
-## frontend: 90th_percentile_successful_sentinel_duration_over_1h30m
+## frontend: 90th_percentile_successful_sentinel_duration_over_2h
 
-<p class="subtitle">90th percentile successful sentinel search duration over 1h30m</p>
+<p class="subtitle">90th percentile successful sentinel search duration over 2h</p>
 
 **Descriptions**
 
-- <span class="badge badge-warning">warning</span> frontend: 5s+ 90th percentile successful sentinel search duration over 1h30m for 15m0s
-- <span class="badge badge-critical">critical</span> frontend: 10s+ 90th percentile successful sentinel search duration over 1h30m for 30m0s
+- <span class="badge badge-warning">warning</span> frontend: 5s+ 90th percentile successful sentinel search duration over 2h for 15m0s
+- <span class="badge badge-critical">critical</span> frontend: 10s+ 90th percentile successful sentinel search duration over 2h for 3h30m0s
 
 **Possible solutions**
 
 - Look at the breakdown by query to determine if a specific query type is being affected
 - Check for high CPU usage on zoekt-webserver
 - Check Honeycomb for unusual activity
-- More help interpreting this metric is available in the [dashboards reference](./dashboards.md#frontend-90th-percentile-successful-sentinel-duration-over-1h30m).
+- More help interpreting this metric is available in the [dashboards reference](./dashboards.md#frontend-90th-percentile-successful-sentinel-duration-over-2h).
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
 ```json
 "observability.silenceAlerts": [
-  "warning_frontend_90th_percentile_successful_sentinel_duration_over_1h30m",
-  "critical_frontend_90th_percentile_successful_sentinel_duration_over_1h30m"
+  "warning_frontend_90th_percentile_successful_sentinel_duration_over_2h",
+  "critical_frontend_90th_percentile_successful_sentinel_duration_over_2h"
 ]
 ```
 
@@ -1011,27 +1011,27 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 <br />
 
-## frontend: 90th_percentile_sentinel_stream_latency_over_1h30m
+## frontend: 90th_percentile_sentinel_stream_latency_over_2h
 
-<p class="subtitle">90th percentile successful sentinel stream latency over 1h30m</p>
+<p class="subtitle">90th percentile successful sentinel stream latency over 2h</p>
 
 **Descriptions**
 
-- <span class="badge badge-warning">warning</span> frontend: 4s+ 90th percentile successful sentinel stream latency over 1h30m for 15m0s
-- <span class="badge badge-critical">critical</span> frontend: 6s+ 90th percentile successful sentinel stream latency over 1h30m for 30m0s
+- <span class="badge badge-warning">warning</span> frontend: 4s+ 90th percentile successful sentinel stream latency over 2h for 15m0s
+- <span class="badge badge-critical">critical</span> frontend: 6s+ 90th percentile successful sentinel stream latency over 2h for 3h30m0s
 
 **Possible solutions**
 
 - Look at the breakdown by query to determine if a specific query type is being affected
 - Check for high CPU usage on zoekt-webserver
 - Check Honeycomb for unusual activity
-- More help interpreting this metric is available in the [dashboards reference](./dashboards.md#frontend-90th-percentile-sentinel-stream-latency-over-1h30m).
+- More help interpreting this metric is available in the [dashboards reference](./dashboards.md#frontend-90th-percentile-sentinel-stream-latency-over-2h).
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
 ```json
 "observability.silenceAlerts": [
-  "warning_frontend_90th_percentile_sentinel_stream_latency_over_1h30m",
-  "critical_frontend_90th_percentile_sentinel_stream_latency_over_1h30m"
+  "warning_frontend_90th_percentile_sentinel_stream_latency_over_2h",
+  "critical_frontend_90th_percentile_sentinel_stream_latency_over_2h"
 ]
 ```
 

--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -3664,13 +3664,13 @@ Query: `round(sum(increase(src_search_ranking_result_clicked_sum{type="commit"}[
 
 ### Frontend: Sentinel queries (only on sourcegraph.com)
 
-#### frontend: mean_successful_sentinel_duration_over_1h30m
+#### frontend: mean_successful_sentinel_duration_over_2h
 
-<p class="subtitle">Mean successful sentinel search duration over 1h30m</p>
+<p class="subtitle">Mean successful sentinel search duration over 2h</p>
 
 Mean search duration for all successful sentinel queries
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-mean-successful-sentinel-duration-over-1h30m) for 2 alerts related to this panel.
+Refer to the [alert solutions reference](./alert_solutions.md#frontend-mean-successful-sentinel-duration-over-2h) for 2 alerts related to this panel.
 
 To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102800` on your Sourcegraph instance.
 
@@ -3679,19 +3679,19 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102800`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(rate(src_search_response_latency_seconds_sum{source=~`searchblitz.*`, status=`success`}[1h30m])) / sum(rate(src_search_response_latency_seconds_count{source=~`searchblitz.*`, status=`success`}[1h30m]))`
+Query: `sum(rate(src_search_response_latency_seconds_sum{source=~`searchblitz.*`, status=`success`}[2h])) / sum(rate(src_search_response_latency_seconds_count{source=~`searchblitz.*`, status=`success`}[2h]))`
 
 </details>
 
 <br />
 
-#### frontend: mean_sentinel_stream_latency_over_1h30m
+#### frontend: mean_sentinel_stream_latency_over_2h
 
-<p class="subtitle">Mean successful sentinel stream latency over 1h30m</p>
+<p class="subtitle">Mean successful sentinel stream latency over 2h</p>
 
 Mean time to first result for all successful streaming sentinel queries
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-mean-sentinel-stream-latency-over-1h30m) for 2 alerts related to this panel.
+Refer to the [alert solutions reference](./alert_solutions.md#frontend-mean-sentinel-stream-latency-over-2h) for 2 alerts related to this panel.
 
 To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102801` on your Sourcegraph instance.
 
@@ -3700,19 +3700,19 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102801`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(rate(src_search_streaming_latency_seconds_sum{source=~"searchblitz.*"}[1h30m])) / sum(rate(src_search_streaming_latency_seconds_count{source=~"searchblitz.*"}[1h30m]))`
+Query: `sum(rate(src_search_streaming_latency_seconds_sum{source=~"searchblitz.*"}[2h])) / sum(rate(src_search_streaming_latency_seconds_count{source=~"searchblitz.*"}[2h]))`
 
 </details>
 
 <br />
 
-#### frontend: 90th_percentile_successful_sentinel_duration_over_1h30m
+#### frontend: 90th_percentile_successful_sentinel_duration_over_2h
 
-<p class="subtitle">90th percentile successful sentinel search duration over 1h30m</p>
+<p class="subtitle">90th percentile successful sentinel search duration over 2h</p>
 
 90th percentile search duration for all successful sentinel queries
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-90th-percentile-successful-sentinel-duration-over-1h30m) for 2 alerts related to this panel.
+Refer to the [alert solutions reference](./alert_solutions.md#frontend-90th-percentile-successful-sentinel-duration-over-2h) for 2 alerts related to this panel.
 
 To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102810` on your Sourcegraph instance.
 
@@ -3721,19 +3721,19 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102810`
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.90, sum by (le)(label_replace(rate(src_search_response_latency_seconds_bucket{source=~"searchblitz.*", status="success"}[1h30m]), "source", "$1", "source", "searchblitz_(.*)")))`
+Query: `histogram_quantile(0.90, sum by (le)(label_replace(rate(src_search_response_latency_seconds_bucket{source=~"searchblitz.*", status="success"}[2h]), "source", "$1", "source", "searchblitz_(.*)")))`
 
 </details>
 
 <br />
 
-#### frontend: 90th_percentile_sentinel_stream_latency_over_1h30m
+#### frontend: 90th_percentile_sentinel_stream_latency_over_2h
 
-<p class="subtitle">90th percentile successful sentinel stream latency over 1h30m</p>
+<p class="subtitle">90th percentile successful sentinel stream latency over 2h</p>
 
 90th percentile time to first result for all successful streaming sentinel queries
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-90th-percentile-sentinel-stream-latency-over-1h30m) for 2 alerts related to this panel.
+Refer to the [alert solutions reference](./alert_solutions.md#frontend-90th-percentile-sentinel-stream-latency-over-2h) for 2 alerts related to this panel.
 
 To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102811` on your Sourcegraph instance.
 
@@ -3742,7 +3742,7 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102811`
 <details>
 <summary>Technical details</summary>
 
-Query: `histogram_quantile(0.90, sum by (le)(label_replace(rate(src_search_streaming_latency_seconds_bucket{source=~"searchblitz.*"}[1h30m]), "source", "$1", "source", "searchblitz_(.*)")))`
+Query: `histogram_quantile(0.90, sum by (le)(label_replace(rate(src_search_streaming_latency_seconds_bucket{source=~"searchblitz.*"}[2h]), "source", "$1", "source", "searchblitz_(.*)")))`
 
 </details>
 

--- a/monitoring/definitions/frontend.go
+++ b/monitoring/definitions/frontend.go
@@ -679,11 +679,11 @@ func Frontend() *monitoring.Container {
 				Rows: []monitoring.Row{
 					{
 						{
-							Name:        "mean_successful_sentinel_duration_over_1h30m",
-							Description: "mean successful sentinel search duration over 1h30m",
+							Name:        "mean_successful_sentinel_duration_over_2h",
+							Description: "mean successful sentinel search duration over 2h",
 							// WARNING: if you change this, ensure that it will not trigger alerts on a customer instance
 							// since these panels relate to metrics that don't exist on a customer instance.
-							Query:          "sum(rate(src_search_response_latency_seconds_sum{source=~`searchblitz.*`, status=`success`}[1h30m])) / sum(rate(src_search_response_latency_seconds_count{source=~`searchblitz.*`, status=`success`}[1h30m]))",
+							Query:          "sum(rate(src_search_response_latency_seconds_sum{source=~`searchblitz.*`, status=`success`}[2h])) / sum(rate(src_search_response_latency_seconds_count{source=~`searchblitz.*`, status=`success`}[2h]))",
 							Warning:        monitoring.Alert().GreaterOrEqual(5).For(15 * time.Minute),
 							Critical:       monitoring.Alert().GreaterOrEqual(8).For(30 * time.Minute),
 							Panel:          monitoring.Panel().LegendFormat("duration").Unit(monitoring.Seconds).With(monitoring.PanelOptions.NoLegend()),
@@ -696,11 +696,11 @@ func Frontend() *monitoring.Container {
 							`,
 						},
 						{
-							Name:        "mean_sentinel_stream_latency_over_1h30m",
-							Description: "mean successful sentinel stream latency over 1h30m",
+							Name:        "mean_sentinel_stream_latency_over_2h",
+							Description: "mean successful sentinel stream latency over 2h",
 							// WARNING: if you change this, ensure that it will not trigger alerts on a customer instance
 							// since these panels relate to metrics that don't exist on a customer instance.
-							Query:    `sum(rate(src_search_streaming_latency_seconds_sum{source=~"searchblitz.*"}[1h30m])) / sum(rate(src_search_streaming_latency_seconds_count{source=~"searchblitz.*"}[1h30m]))`,
+							Query:    `sum(rate(src_search_streaming_latency_seconds_sum{source=~"searchblitz.*"}[2h])) / sum(rate(src_search_streaming_latency_seconds_count{source=~"searchblitz.*"}[2h]))`,
 							Warning:  monitoring.Alert().GreaterOrEqual(2).For(15 * time.Minute),
 							Critical: monitoring.Alert().GreaterOrEqual(3).For(30 * time.Minute),
 							Panel: monitoring.Panel().LegendFormat("latency").Unit(monitoring.Seconds).With(
@@ -718,13 +718,13 @@ func Frontend() *monitoring.Container {
 					},
 					{
 						{
-							Name:        "90th_percentile_successful_sentinel_duration_over_1h30m",
-							Description: "90th percentile successful sentinel search duration over 1h30m",
+							Name:        "90th_percentile_successful_sentinel_duration_over_2h",
+							Description: "90th percentile successful sentinel search duration over 2h",
 							// WARNING: if you change this, ensure that it will not trigger alerts on a customer instance
 							// since these panels relate to metrics that don't exist on a customer instance.
-							Query:          `histogram_quantile(0.90, sum by (le)(label_replace(rate(src_search_response_latency_seconds_bucket{source=~"searchblitz.*", status="success"}[1h30m]), "source", "$1", "source", "searchblitz_(.*)")))`,
+							Query:          `histogram_quantile(0.90, sum by (le)(label_replace(rate(src_search_response_latency_seconds_bucket{source=~"searchblitz.*", status="success"}[2h]), "source", "$1", "source", "searchblitz_(.*)")))`,
 							Warning:        monitoring.Alert().GreaterOrEqual(5).For(15 * time.Minute),
-							Critical:       monitoring.Alert().GreaterOrEqual(10).For(30 * time.Minute),
+							Critical:       monitoring.Alert().GreaterOrEqual(10).For(210 * time.Minute),
 							Panel:          monitoring.Panel().LegendFormat("duration").Unit(monitoring.Seconds).With(monitoring.PanelOptions.NoLegend()),
 							Owner:          monitoring.ObservableOwnerSearch,
 							Interpretation: `90th percentile search duration for all successful sentinel queries`,
@@ -735,13 +735,13 @@ func Frontend() *monitoring.Container {
 							`,
 						},
 						{
-							Name:        "90th_percentile_sentinel_stream_latency_over_1h30m",
-							Description: "90th percentile successful sentinel stream latency over 1h30m",
+							Name:        "90th_percentile_sentinel_stream_latency_over_2h",
+							Description: "90th percentile successful sentinel stream latency over 2h",
 							// WARNING: if you change this, ensure that it will not trigger alerts on a customer instance
 							// since these panels relate to metrics that don't exist on a customer instance.
-							Query:    `histogram_quantile(0.90, sum by (le)(label_replace(rate(src_search_streaming_latency_seconds_bucket{source=~"searchblitz.*"}[1h30m]), "source", "$1", "source", "searchblitz_(.*)")))`,
+							Query:    `histogram_quantile(0.90, sum by (le)(label_replace(rate(src_search_streaming_latency_seconds_bucket{source=~"searchblitz.*"}[2h]), "source", "$1", "source", "searchblitz_(.*)")))`,
 							Warning:  monitoring.Alert().GreaterOrEqual(4).For(15 * time.Minute),
-							Critical: monitoring.Alert().GreaterOrEqual(6).For(30 * time.Minute),
+							Critical: monitoring.Alert().GreaterOrEqual(6).For(210 * time.Minute),
 							Panel: monitoring.Panel().LegendFormat("latency").Unit(monitoring.Seconds).With(
 								monitoring.PanelOptions.NoLegend(),
 								monitoring.PanelOptions.ColorOverride("latency", "#8AB8FF"),


### PR DESCRIPTION
We get [sentinel query alerts](https://sourcegraph.slack.com/archives/C0J618TTM/p1650047760337339) whenever Zoekt is deployed on sourcegraph.com. 

These alerts are just noise - artifacts caused by _how_ Zoekt is deployed:
- a [statefulset](https://github.com/sourcegraph/deploy-sourcegraph-cloud/blob/682cc0cb00f196805a7d959766b6afd11566be15/base/indexed-search/indexed-search.StatefulSet.yaml#L14) with ~50 replicas will take quite a long time to update
- when a Zoekt pod first starts, it needs to load the shards on its disk into memory before it can respond to search queries

There is no action that a user can take to resolve this - all these alerts do is cause stress. Therefore, this PR relaxes the sentinel query alerts so they don't trigger opsgenie in the common case of a Zoekt rollout:
- the _critical_ alerting threshold duration increases from 30 minutes to 3 1/2 hours (this window was determined by looking at the [width of latency spikes from past alerts](https://sourcegraph.com/-/debug/grafana/d/frontend/frontend?viewPanel=102811&orgId=1&from=1650038870149&to=1650056364363) + adding some slack)
- the width of the sampling duration increases from 1 1/2 hours to 2 hours

Take a look at this dashboard snapshot over the past 7 days. Note the highlighted spikes - those correspond to a Zoekt rollout that tripped the _critical_ alerting threshold (which, in-turn, triggered an opsgenie call).
<img width="1646" alt="Screen Shot 2022-04-19 at 8 41 36 AM" src="https://user-images.githubusercontent.com/9022011/164045831-034388e8-01b6-43f7-8972-7172983dea45.png">

Now take a look at the same dashboard after we apply the changes from this PR (relaxing the alerting thresholds and widening the sampling duration):

<img width="1647" alt="Screen Shot 2022-04-19 at 8 46 55 AM" src="https://user-images.githubusercontent.com/9022011/164046057-16173bfb-c478-4749-9086-fc1f81dfb432.png">

- Notice that the highlighted spike no longer trips the _critical_ alert threshold (which would trigger an ops genie call), only the _warning_ threshold
- The original spike (that corresponds to the [back-to-back Zoekt rollouts in this incident](https://sourcegraph.slack.com/archives/C03B87ND5KQ)) would still trigger a critical alert (which is still okay, since it's an unusual situation)

## Test plan

This PR just changes a Grafana dashboard, and doesn't need further testing.

