### PR TITLE
extsvc: Add back default rate limits for npm and Go

### DIFF
--- a/doc/integration/go.md
+++ b/doc/integration/go.md
@@ -25,7 +25,8 @@ Each entry in the `"urls"` array can contain basic auth if needed (e.g. `https:/
 
 ## Rate limiting
 
-By default, requests to configured Go module proxies won't be rate-limited. To configure rate limiting, add the following to your code host configuration:
+By default, requests to the Go module proxies will be rate-limited
+based on a default internal limit. ([source](https://github.com/sourcegraph/sourcegraph/blob/main/schema/go-modules.schema.json))
 
 ```json
 "rateLimit": {
@@ -34,6 +35,15 @@ By default, requests to configured Go module proxies won't be rate-limited. To c
 }
 ```
 where the `requestsPerHour` field is set based on your requirements.
+
+**Not recommended**: Rate-limiting can be turned off entirely as well.
+This increases the risk of overloading the proxy.
+
+```json
+"rateLimit": {
+  "enabled": false
+}
+```
 
 ## Repository permissions
 

--- a/doc/integration/npm.md
+++ b/doc/integration/npm.md
@@ -25,15 +25,24 @@ Use the `"credentials"` section of the JSON configuration to provide an access t
 
 ## Rate limiting
 
-By default, requests to the npm dependency code host won't be rate limited. To configure rate-limiting, add the following to your code host configuration:
+By default, requests to the npm registry will be rate-limited based on a default [internal limit](https://github.com/sourcegraph/sourcegraph/blob/main/schema/npm-packages.schema.json) which complies with the [documented acceptable use policy](https://docs.npmjs.com/policies/open-source-terms#acceptable-use) of registry.npmjs.org (i.e. max 5 million requests per month).
 
 ```json
 "rateLimit": {
   "enabled": true,
-  "requestsPerHour": 600.0
+  "requestsPerHour": 3000.0
 }
 ```
 where the `requestsPerHour` field is set based on your requirements.
+
+**Not recommended**: Rate-limiting can be turned off entirely as well.
+This increases the risk of overloading the code host.
+
+```json
+"rateLimit": {
+  "enabled": false
+}
+```
 
 ## Repository permissions
 

--- a/internal/extsvc/types.go
+++ b/internal/extsvc/types.go
@@ -436,20 +436,15 @@ func GetLimitFromConfig(kind string, config interface{}) (rate.Limit, error) {
 			limit = limitOrInf(c.RateLimit.Enabled, c.RateLimit.RequestsPerHour)
 		}
 	case *schema.NpmPackagesConnection:
-		// Unlike the GitHub or GitLab APIs, the public npm registry (i.e. https://registry.npmjs.org)
-		// doesn't document an enforced req/s rate limit AND we do a lot more individual
-		// requests in comparison since they don't offer enough batch APIs. For private registries,
-		// site-admins can manually configure their desired rate limits if needed.
-		limit = rate.Inf
+		limit = rate.Limit(3000 / 3600.0) // Same as the default in npm-packages.schema.json
 		if c != nil && c.RateLimit != nil {
 			limit = limitOrInf(c.RateLimit.Enabled, c.RateLimit.RequestsPerHour)
 		}
 	case *schema.GoModulesConnection:
 		// Unlike the GitHub or GitLab APIs, the public npm registry (i.e. https://proxy.golang.org)
 		// doesn't document an enforced req/s rate limit AND we do a lot more individual
-		// requests in comparison since they don't offer enough batch APIs. For private proxies,
-		// site-admins can manually configure their desired rate limits if needed.
-		limit = rate.Inf
+		// requests in comparison since they don't offer enough batch APIs.
+		limit = rate.Limit(57600.0 / 3600.0) // Same as default in go-modules.schema.json
 		if c != nil && c.RateLimit != nil {
 			limit = limitOrInf(c.RateLimit.Enabled, c.RateLimit.RequestsPerHour)
 		}

--- a/internal/extsvc/types_test.go
+++ b/internal/extsvc/types_test.go
@@ -112,7 +112,7 @@ func TestExtractRateLimitConfig(t *testing.T) {
 			name:   "NPM default",
 			config: `{"registry": "https://registry.npmjs.org"}`,
 			kind:   KindNpmPackages,
-			want:   rate.Inf,
+			want:   3000.0 / 3600.0,
 		},
 		{
 			name:   "NPM non-default",
@@ -124,7 +124,7 @@ func TestExtractRateLimitConfig(t *testing.T) {
 			name:   "Go mod default",
 			config: `{"urls": ["https://example.com"]}`,
 			kind:   KindGoModules,
-			want:   rate.Inf,
+			want:   57600.0 / 3600.0,
 		},
 		{
 			name:   "Go mod non-default",

--- a/schema/npm-packages.schema.json
+++ b/schema/npm-packages.schema.json
@@ -34,13 +34,13 @@
         "requestsPerHour": {
           "description": "Requests per hour permitted. This is an average, calculated per second. Internally, the burst limit is set to 100, which implies that for a requests per hour limit as low as 1, users will continue to be able to send a maximum of 100 requests immediately, provided that the complexity cost of each request is 1.",
           "type": "number",
-          "default": 57600,
+          "default": 3000,
           "minimum": 0
         }
       },
       "default": {
         "enabled": true,
-        "requestsPerHour": 57600
+        "requestsPerHour": 3000
       }
     },
     "dependencies": {


### PR DESCRIPTION
We [learned](https://github.com/sourcegraph/sourcegraph/pull/34042#issuecomment-1102824364) that there is an acceptable use policy of the registry.npmjs.org, and we want to default on the safe side with Go as well, despite not having a documented limit.



## Test plan

Unit tests.


