### PR TITLE
Search backend: detach computeExcluded

### DIFF
--- a/internal/search/repos/excluded_job.go
+++ b/internal/search/repos/excluded_job.go
@@ -16,7 +16,7 @@ func (c *ComputeExcludedRepos) Run(ctx context.Context, clients job.RuntimeClien
 	_, ctx, s, finish := job.StartSpan(ctx, s, c)
 	defer func() { finish(alert, err) }()
 
-	excluded, err := computeExcluded(ctx, clients.DB, c.Options)
+	excluded, err := computeExcludedRepos(ctx, clients.DB, c.Options)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/search/repos/excluded_job.go
+++ b/internal/search/repos/excluded_job.go
@@ -16,8 +16,7 @@ func (c *ComputeExcludedRepos) Run(ctx context.Context, clients job.RuntimeClien
 	_, ctx, s, finish := job.StartSpan(ctx, s, c)
 	defer func() { finish(alert, err) }()
 
-	repositoryResolver := Resolver{DB: clients.DB}
-	excluded, err := repositoryResolver.Excluded(ctx, c.Options)
+	excluded, err := computeExcluded(ctx, clients.DB, c.Options)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/search/repos/repos.go
+++ b/internal/search/repos/repos.go
@@ -407,9 +407,9 @@ func (r *Resolver) Resolve(ctx context.Context, op search.RepoOptions) (Resolved
 	return res.Resolved, err
 }
 
-// Excluded computes the ExcludedRepos that the given RepoOptions would not match. This is
+// computeExcluded computes the ExcludedRepos that the given RepoOptions would not match. This is
 // used to show in the search UI what repos are excluded precisely.
-func (r *Resolver) Excluded(ctx context.Context, op search.RepoOptions) (ex ExcludedRepos, err error) {
+func computeExcluded(ctx context.Context, db database.DB, op search.RepoOptions) (ex ExcludedRepos, err error) {
 	tr, ctx := trace.New(ctx, "searchrepos.Excluded", op.String())
 	defer func() {
 		tr.LazyPrintf("excluded repos: %+v", ex)
@@ -444,7 +444,7 @@ func (r *Resolver) Excluded(ctx context.Context, op search.RepoOptions) (ex Excl
 		return ExcludedRepos{}, nil
 	}
 
-	searchContext, err := searchcontexts.ResolveSearchContextSpec(ctx, r.DB, op.SearchContextSpec)
+	searchContext, err := searchcontexts.ResolveSearchContextSpec(ctx, db, op.SearchContextSpec)
 	if err != nil {
 		return ExcludedRepos{}, err
 	}
@@ -480,7 +480,7 @@ func (r *Resolver) Excluded(ctx context.Context, op search.RepoOptions) (ex Excl
 			selectForks := options
 			selectForks.OnlyForks = true
 			selectForks.NoForks = false
-			numExcludedForks, err := r.DB.Repos().Count(ctx, selectForks)
+			numExcludedForks, err := db.Repos().Count(ctx, selectForks)
 			if err != nil {
 				return err
 			}
@@ -500,7 +500,7 @@ func (r *Resolver) Excluded(ctx context.Context, op search.RepoOptions) (ex Excl
 			selectArchived := options
 			selectArchived.OnlyArchived = true
 			selectArchived.NoArchived = false
-			numExcludedArchived, err := r.DB.Repos().Count(ctx, selectArchived)
+			numExcludedArchived, err := db.Repos().Count(ctx, selectArchived)
 			if err != nil {
 				return err
 			}

--- a/internal/search/repos/repos.go
+++ b/internal/search/repos/repos.go
@@ -407,9 +407,9 @@ func (r *Resolver) Resolve(ctx context.Context, op search.RepoOptions) (Resolved
 	return res.Resolved, err
 }
 
-// computeExcluded computes the ExcludedRepos that the given RepoOptions would not match. This is
+// computeExcludedRepos computes the ExcludedRepos that the given RepoOptions would not match. This is
 // used to show in the search UI what repos are excluded precisely.
-func computeExcluded(ctx context.Context, db database.DB, op search.RepoOptions) (ex ExcludedRepos, err error) {
+func computeExcludedRepos(ctx context.Context, db database.DB, op search.RepoOptions) (ex ExcludedRepos, err error) {
 	tr, ctx := trace.New(ctx, "searchrepos.Excluded", op.String())
 	defer func() {
 		tr.LazyPrintf("excluded repos: %+v", ex)


### PR DESCRIPTION
This detaches the `Excluded` method from `repos.Resolver` and makes it a
standalone, private function. Computing excluded repos requires a
slightly different set of information than actually resolving repos.
Specifically, whether `fork` and `archived` were explicitly set. This
makes it possible to only pass that information to the function that
needs it.

This doesn't actually partition the types here, but the overarching goal is to 
minimize passing informaiton into scopes where it isn't used.

Stacked on #34138

## Test plan

Minimal and semantics-preserving

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


