### PR TITLE
Search backend: remove unused fields from RepoSearch

### DIFF
--- a/internal/search/job/jobutil/job.go
+++ b/internal/search/job/jobutil/job.go
@@ -292,12 +292,10 @@ func ToSearchJob(searchInputs *run.SearchInputs, q query.Q) (job.Job, error) {
 						mode = search.SkipUnindexed
 					}
 					addJob(true, &run.RepoSearch{
-						RepoOptions:     repoOptions,
-						Features:        features,
-						UseFullDeadline: useFullDeadline,
-						Query:           q,
-						PatternInfo:     patternInfo,
-						Mode:            mode,
+						RepoOptions: repoOptions,
+						Features:    features,
+						PatternInfo: patternInfo,
+						Mode:        mode,
 					})
 				}
 			}

--- a/internal/search/job/jobutil/printers_test.go
+++ b/internal/search/job/jobutil/printers_test.go
@@ -291,38 +291,7 @@ func TestPrettyJSON(t *testing.T) {
         "Features": {
           "ContentBasedLangFilters": false
         },
-        "Repos": null,
-        "Mode": 0,
-        "Query": [
-          {
-            "Kind": 1,
-            "Operands": [
-              {
-                "field": "repo",
-                "value": "foo",
-                "negated": false
-              },
-              {
-                "value": "bar",
-                "negated": false
-              }
-            ],
-            "Annotation": {
-              "labels": 0,
-              "range": {
-                "start": {
-                  "line": 0,
-                  "column": 0
-                },
-                "end": {
-                  "line": 0,
-                  "column": 0
-                }
-              }
-            }
-          }
-        ],
-        "UseFullDeadline": true
+        "Mode": 0
       }
     },
     {

--- a/internal/search/run/repository.go
+++ b/internal/search/run/repository.go
@@ -8,7 +8,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/search/job"
-	"github.com/sourcegraph/sourcegraph/internal/search/query"
 	searchrepos "github.com/sourcegraph/sourcegraph/internal/search/repos"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
 	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
@@ -20,23 +19,7 @@ type RepoSearch struct {
 	RepoOptions search.RepoOptions
 	Features    search.Features
 
-	Repos []*search.RepositoryRevisions
-
 	Mode search.GlobalSearchMode
-
-	// Query is the parsed query from the user. You should be using Pattern
-	// instead, but Query is useful for checking extra fields that are set and
-	// ignored by Pattern, such as index:no
-	Query query.Q
-
-	// UseFullDeadline indicates that the search should try do as much work as
-	// it can within context.Deadline. If false the search should try and be
-	// as fast as possible, even if a "slow" deadline is set.
-	//
-	// For example searcher will wait to full its archive cache for a
-	// repository if this field is true. Another example is we set this field
-	// to true if the user requests a specific timeout or maximum result size.
-	UseFullDeadline bool
 }
 
 func (s *RepoSearch) Run(ctx context.Context, clients job.RuntimeClients, stream streaming.Sender) (alert *search.Alert, err error) {


### PR DESCRIPTION
There were a few unused fields on the RepoSearch job. Removing these
will allow me to continue simplifying.

Stacked on #34140

## Test plan

Semantics-preserving and minimal. Checked that the changed tests are correct.

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


