### PR TITLE
Search backend: inline relevant PatternInfo fields into RepoSearch job

### DIFF
--- a/internal/search/job/jobutil/job.go
+++ b/internal/search/job/jobutil/job.go
@@ -292,10 +292,11 @@ func ToSearchJob(searchInputs *run.SearchInputs, q query.Q) (job.Job, error) {
 						mode = search.SkipUnindexed
 					}
 					addJob(true, &run.RepoSearch{
-						RepoOptions: repoOptions,
-						Features:    features,
-						PatternInfo: patternInfo,
-						Mode:        mode,
+						RepoOptions:                  repoOptions,
+						Features:                     features,
+						FilePatternsReposMustInclude: patternInfo.FilePatternsReposMustInclude,
+						FilePatternsReposMustExclude: patternInfo.FilePatternsReposMustExclude,
+						Mode:                         mode,
 					})
 				}
 			}

--- a/internal/search/job/jobutil/printers_test.go
+++ b/internal/search/job/jobutil/printers_test.go
@@ -248,26 +248,6 @@ func TestPrettyJSON(t *testing.T) {
     },
     {
       "RepoSearch": {
-        "PatternInfo": {
-          "Pattern": "bar",
-          "IsNegated": false,
-          "IsRegExp": true,
-          "IsStructuralPat": false,
-          "CombyRule": "",
-          "IsWordMatch": false,
-          "IsCaseSensitive": false,
-          "FileMatchLimit": 500,
-          "Index": "yes",
-          "Select": [],
-          "IncludePatterns": null,
-          "ExcludePattern": "",
-          "FilePatternsReposMustInclude": null,
-          "FilePatternsReposMustExclude": null,
-          "PathPatternsAreCaseSensitive": false,
-          "PatternMatchesContent": true,
-          "PatternMatchesPath": true,
-          "Languages": null
-        },
         "RepoOptions": {
           "RepoFilters": [
             "foo",
@@ -288,6 +268,8 @@ func TestPrettyJSON(t *testing.T) {
           "NoArchived": true,
           "OnlyArchived": false
         },
+        "FilePatternsReposMustInclude": null,
+        "FilePatternsReposMustExclude": null,
         "Features": {
           "ContentBasedLangFilters": false
         },

--- a/internal/search/run/repo_has_file.go
+++ b/internal/search/run/repo_has_file.go
@@ -138,8 +138,8 @@ func (s *RepoSearch) reposToAdd(ctx context.Context, clients job.RuntimeClients,
 	// matchCounts will contain the count of repohasfile patterns that matched.
 	// For negations, we will explicitly set this to -1 if it matches.
 	matchCounts := make(map[api.RepoID]int)
-	if len(s.PatternInfo.FilePatternsReposMustInclude) > 0 {
-		for _, pattern := range s.PatternInfo.FilePatternsReposMustInclude {
+	if len(s.FilePatternsReposMustInclude) > 0 {
+		for _, pattern := range s.FilePatternsReposMustInclude {
 			matches, err := s.reposContainingPath(ctx, clients, repos, pattern)
 			if err != nil {
 				return nil, err
@@ -162,8 +162,8 @@ func (s *RepoSearch) reposToAdd(ctx context.Context, clients job.RuntimeClients,
 		}
 	}
 
-	if len(s.PatternInfo.FilePatternsReposMustExclude) > 0 {
-		for _, pattern := range s.PatternInfo.FilePatternsReposMustExclude {
+	if len(s.FilePatternsReposMustExclude) > 0 {
+		for _, pattern := range s.FilePatternsReposMustExclude {
 			matches, err := s.reposContainingPath(ctx, clients, repos, pattern)
 			if err != nil {
 				return nil, err
@@ -176,7 +176,7 @@ func (s *RepoSearch) reposToAdd(ctx context.Context, clients job.RuntimeClients,
 
 	var rsta []*search.RepositoryRevisions
 	for _, r := range repos {
-		if count, ok := matchCounts[r.Repo.ID]; ok && count == len(s.PatternInfo.FilePatternsReposMustInclude) {
+		if count, ok := matchCounts[r.Repo.ID]; ok && count == len(s.FilePatternsReposMustInclude) {
 			rsta = append(rsta, r)
 		}
 	}

--- a/internal/search/run/repository.go
+++ b/internal/search/run/repository.go
@@ -15,9 +15,10 @@ import (
 )
 
 type RepoSearch struct {
-	PatternInfo *search.TextPatternInfo
-	RepoOptions search.RepoOptions
-	Features    search.Features
+	RepoOptions                  search.RepoOptions
+	FilePatternsReposMustInclude []string
+	FilePatternsReposMustExclude []string
+	Features                     search.Features
 
 	Mode search.GlobalSearchMode
 }
@@ -26,14 +27,12 @@ func (s *RepoSearch) Run(ctx context.Context, clients job.RuntimeClients, stream
 	tr, ctx, stream, finish := job.StartSpan(ctx, stream, s)
 	defer func() { finish(alert, err) }()
 
-	tr.LogFields(otlog.String("pattern", s.PatternInfo.Pattern))
-
 	repos := &searchrepos.Resolver{DB: clients.DB, Opts: s.RepoOptions}
 	err = repos.Paginate(ctx, nil, func(page *searchrepos.Resolved) error {
 		tr.LogFields(otlog.Int("resolved.len", len(page.RepoRevs)))
 
 		// Filter the repos if there is a repohasfile: or -repohasfile field.
-		if len(s.PatternInfo.FilePatternsReposMustExclude) > 0 || len(s.PatternInfo.FilePatternsReposMustInclude) > 0 {
+		if len(s.FilePatternsReposMustExclude) > 0 || len(s.FilePatternsReposMustInclude) > 0 {
 			// Fallback to batch for reposToAdd
 			page.RepoRevs, err = s.reposToAdd(ctx, clients, page.RepoRevs)
 			if err != nil {
@@ -48,11 +47,11 @@ func (s *RepoSearch) Run(ctx context.Context, clients job.RuntimeClients, stream
 		return nil
 	})
 
-	if s.PatternInfo.Pattern != "" {
-		err = errors.Ignore(err, errors.IsPred(searchrepos.ErrNoResolvedRepos))
-	}
-
+	// Do not error with no results for repo search. For text search, this is an
+	// actionable error, but for repo search, it is not.
+	err = errors.Ignore(err, errors.IsPred(searchrepos.ErrNoResolvedRepos))
 	return nil, err
+
 }
 
 func (*RepoSearch) Name() string {

--- a/internal/search/run/repository_test.go
+++ b/internal/search/run/repository_test.go
@@ -32,16 +32,7 @@ func TestRepoShouldBeAdded(t *testing.T) {
 				},
 			}}, nil
 		}
-		pat := &search.TextPatternInfo{
-			Pattern:                      "",
-			FilePatternsReposMustInclude: []string{"foo"},
-			IsRegExp:                     true,
-			FileMatchLimit:               1,
-			PathPatternsAreCaseSensitive: false,
-			PatternMatchesContent:        true,
-			PatternMatchesPath:           true,
-		}
-		shouldBeAdded, err := repoShouldBeAdded(context.Background(), job.RuntimeClients{Zoekt: zoekt}, repo, pat)
+		shouldBeAdded, err := repoShouldBeAdded(context.Background(), job.RuntimeClients{Zoekt: zoekt}, repo, []string{"foo"}, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -55,16 +46,7 @@ func TestRepoShouldBeAdded(t *testing.T) {
 		MockReposContainingPath = func() ([]*result.FileMatch, error) {
 			return nil, nil
 		}
-		pat := &search.TextPatternInfo{
-			Pattern:                      "",
-			FilePatternsReposMustInclude: []string{"foo"},
-			IsRegExp:                     true,
-			FileMatchLimit:               1,
-			PathPatternsAreCaseSensitive: false,
-			PatternMatchesContent:        true,
-			PatternMatchesPath:           true,
-		}
-		shouldBeAdded, err := repoShouldBeAdded(context.Background(), job.RuntimeClients{Zoekt: zoekt}, repo, pat)
+		shouldBeAdded, err := repoShouldBeAdded(context.Background(), job.RuntimeClients{Zoekt: zoekt}, repo, []string{"foo"}, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -85,16 +67,7 @@ func TestRepoShouldBeAdded(t *testing.T) {
 				},
 			}}, nil
 		}
-		pat := &search.TextPatternInfo{
-			Pattern:                      "",
-			FilePatternsReposMustExclude: []string{"foo"},
-			IsRegExp:                     true,
-			FileMatchLimit:               1,
-			PathPatternsAreCaseSensitive: false,
-			PatternMatchesContent:        true,
-			PatternMatchesPath:           true,
-		}
-		shouldBeAdded, err := repoShouldBeAdded(context.Background(), job.RuntimeClients{Zoekt: zoekt}, repo, pat)
+		shouldBeAdded, err := repoShouldBeAdded(context.Background(), job.RuntimeClients{Zoekt: zoekt}, repo, nil, []string{"foo"})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -108,16 +81,7 @@ func TestRepoShouldBeAdded(t *testing.T) {
 		MockReposContainingPath = func() ([]*result.FileMatch, error) {
 			return nil, nil
 		}
-		pat := &search.TextPatternInfo{
-			Pattern:                      "",
-			FilePatternsReposMustExclude: []string{"foo"},
-			IsRegExp:                     true,
-			FileMatchLimit:               1,
-			PathPatternsAreCaseSensitive: false,
-			PatternMatchesContent:        true,
-			PatternMatchesPath:           true,
-		}
-		shouldBeAdded, err := repoShouldBeAdded(context.Background(), job.RuntimeClients{Zoekt: zoekt}, repo, pat)
+		shouldBeAdded, err := repoShouldBeAdded(context.Background(), job.RuntimeClients{Zoekt: zoekt}, repo, nil, []string{"foo"})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -129,10 +93,11 @@ func TestRepoShouldBeAdded(t *testing.T) {
 
 // repoShouldBeAdded determines whether a repository should be included in the result set based on whether the repository fits in the subset
 // of repostiories specified in the query's `repohasfile` and `-repohasfile` fields if they exist.
-func repoShouldBeAdded(ctx context.Context, clients job.RuntimeClients, repo *search.RepositoryRevisions, pattern *search.TextPatternInfo) (bool, error) {
+func repoShouldBeAdded(ctx context.Context, clients job.RuntimeClients, repo *search.RepositoryRevisions, filePatternsInclude, filePatternsExclude []string) (bool, error) {
 	repos := []*search.RepositoryRevisions{repo}
 	s := RepoSearch{
-		PatternInfo: pattern,
+		FilePatternsReposMustInclude: filePatternsInclude,
+		FilePatternsReposMustExclude: filePatternsExclude,
 	}
 	rsta, err := s.reposToAdd(ctx, clients, repos)
 	if err != nil {


### PR DESCRIPTION
The RepoSearch job currently requires a full PatternInfo object just so
RepoSearch can handle the `repohasfile` filters. However, the only thing
it really needs form PatternInfo is the values of
`FilePatternsReposMust{In,Ex}clude`, so we can pass those in directly.

The next step here is moving `repohasfile` handling into `RepoOptions`
since it is logically a part of filtering the set of repos to be
searched. This will also allow us to more easily optimize the
`repo:contains.file()` predicate.

Stacked on #34141 

## Test plan

Almost completely semantics-preserving. Manually tested the changed error condition. 

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


