### PR TITLE
codeintel: Add janitor tasks for audit log records

### DIFF
--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -8251,7 +8251,7 @@ Query: `sum(increase(src_codeintel_background_documentation_search_records_remov
 
 <br />
 
-#### worker: src_codeintel_background_audit_log_records_expired_total
+#### worker: codeintel_background_audit_log_records_expired_total
 
 <p class="subtitle">Lsif upload audit log records deleted every 5m</p>
 
@@ -8266,7 +8266,7 @@ To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=100520` on 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_src_codeintel_background_audit_log_records_expired_total{job=~"^worker.*"}[5m]))`
+Query: `sum(increase(src_codeintel_background_audit_log_records_expired_total{job=~"^worker.*"}[5m]))`
 
 </details>
 

--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -8251,6 +8251,27 @@ Query: `sum(increase(src_codeintel_background_documentation_search_records_remov
 
 <br />
 
+#### worker: src_codeintel_background_audit_log_records_expired_total
+
+<p class="subtitle">Lsif upload audit log records deleted every 5m</p>
+
+Number of LSIF upload audit log records deleted due to expiration every 5m
+
+This panel has no related alerts.
+
+To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=100520` on your Sourcegraph instance.
+
+<sub>*Managed by the [Sourcegraph Code-intel team](https://handbook.sourcegraph.com/engineering/code-intelligence).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Query: `sum(increase(src_src_codeintel_background_audit_log_records_expired_total{job=~"^worker.*"}[5m]))`
+
+</details>
+
+<br />
+
 #### worker: codeintel_background_errors_total
 
 <p class="subtitle">Janitor operation errors every 5m</p>
@@ -8259,7 +8280,7 @@ Number of code intelligence janitor errors every 5m
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=100520` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/worker/worker?viewPanel=100521` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Code-intel team](https://handbook.sourcegraph.com/engineering/code-intelligence).*</sub>
 

--- a/enterprise/cmd/worker/internal/codeintel/janitor/auditlog_janitor.go
+++ b/enterprise/cmd/worker/internal/codeintel/janitor/auditlog_janitor.go
@@ -1,0 +1,44 @@
+package janitor
+
+import (
+	"context"
+	"time"
+
+	"github.com/inconshreveable/log15"
+
+	"github.com/sourcegraph/sourcegraph/internal/goroutine"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+type auditLogJanitor struct {
+	dbStore DBStore
+	maxAge  time.Duration
+	metrics *metrics
+}
+
+var _ goroutine.Handler = &auditLogJanitor{}
+var _ goroutine.ErrorHandler = &auditLogJanitor{}
+
+// NewAuditLogJanitor returns a background routine that periodically deletes old audit log records.
+func NewAuditLogJanitor(dbStore DBStore, maxAge time.Duration, interval time.Duration, metrics *metrics) goroutine.BackgroundRoutine {
+	return goroutine.NewPeriodicGoroutine(context.Background(), interval, &auditLogJanitor{
+		dbStore: dbStore,
+		maxAge:  maxAge,
+		metrics: metrics,
+	})
+}
+
+func (j *auditLogJanitor) Handle(ctx context.Context) (err error) {
+	count, err := j.dbStore.DeleteOldAuditLogs(ctx, j.maxAge, time.Now())
+	if err != nil {
+		return errors.Wrap(err, "dbstore.DeleteOldAuditLogs")
+	}
+
+	j.metrics.numAuditLogRecordsExpired.Add(float64(count))
+	return nil
+}
+
+func (j *auditLogJanitor) HandleError(err error) {
+	j.metrics.numErrors.Inc()
+	log15.Error("Failed to delete codeintel audit log records", "error", err)
+}

--- a/enterprise/cmd/worker/internal/codeintel/janitor/iface.go
+++ b/enterprise/cmd/worker/internal/codeintel/janitor/iface.go
@@ -33,6 +33,7 @@ type DBStore interface {
 	DeleteSourcedCommits(ctx context.Context, repositoryID int, commit string, maximumCommitLag time.Duration, now time.Time) (int, int, int, error)
 	SelectPoliciesForRepositoryMembershipUpdate(ctx context.Context, batchSize int) (configurationPolicies []dbstore.ConfigurationPolicy, err error)
 	UpdateReposMatchingPatterns(ctx context.Context, patterns []string, policyID int, repositoryMatchLimit *int) (err error)
+	DeleteOldAuditLogs(ctx context.Context, maxAge time.Duration, now time.Time) (int, error)
 }
 
 type DBStoreShim struct {

--- a/enterprise/cmd/worker/internal/codeintel/janitor/observability.go
+++ b/enterprise/cmd/worker/internal/codeintel/janitor/observability.go
@@ -17,6 +17,7 @@ type metrics struct {
 	numUploadsPurged                prometheus.Counter
 	numDocumentSearchRecordsRemoved prometheus.Counter
 	numPoliciesUpdated              prometheus.Counter
+	numAuditLogRecordsExpired       prometheus.Counter
 	numErrors                       prometheus.Counter
 
 	// Resetter metrics
@@ -80,6 +81,10 @@ func newMetrics(observationContext *observation.Context) *metrics {
 		"src_codeintel_background_policies_updated_total",
 		"The number of configuration policies whose repository membership list was updated.",
 	)
+	numAuditLogRecordsExpired := counter(
+		"src_codeintel_background_audit_log_records_expired_total",
+		"The number of audit log records removed due to age.",
+	)
 	numErrors := counter(
 		"src_codeintel_background_errors_total",
 		"The number of errors that occur during a codeintel expiration job.",
@@ -134,6 +139,7 @@ func newMetrics(observationContext *observation.Context) *metrics {
 		numUploadsPurged:                numUploadsPurged,
 		numDocumentSearchRecordsRemoved: numDocumentSearchRecordsRemoved,
 		numPoliciesUpdated:              numPoliciesUpdated,
+		numAuditLogRecordsExpired:       numAuditLogRecordsExpired,
 		numErrors:                       numErrors,
 		numUploadResets:                 numUploadResets,
 		numUploadResetFailures:          numUploadResetFailures,

--- a/enterprise/cmd/worker/internal/codeintel/janitor_config.go
+++ b/enterprise/cmd/worker/internal/codeintel/janitor_config.go
@@ -27,6 +27,7 @@ type janitorConfig struct {
 	ConfigurationPolicyMembershipBatchSize              int
 	DocumentationSearchCurrentMinimumTimeSinceLastCheck time.Duration
 	DocumentationSearchCurrentBatchSize                 int
+	AuditLogMaxAge                                      time.Duration
 
 	MetricsConfig *executorqueue.Config
 }
@@ -54,6 +55,7 @@ func (c *janitorConfig) Load() {
 	c.ConfigurationPolicyMembershipBatchSize = c.GetInt("PRECISE_CODE_INTEL_CONFIGURATION_POLICY_MEMBERSHIP_BATCH_SIZE", "100", "The maximum number of policy configurations to update repository membership for at a time.")
 	c.DocumentationSearchCurrentMinimumTimeSinceLastCheck = c.GetInterval("PRECISE_CODE_INTEL_DOCUMENTATION_SEARCH_CURRENT_MINIMUM_TIME_SINCE_LAST_CHECK", "24h", "The minimum time the documentation search current janitor will re-check records for a unique search key.")
 	c.DocumentationSearchCurrentBatchSize = c.GetInt("PRECISE_CODE_INTEL_DOCUMENTATION_SEARCH_CURRENT_BATCH_SIZE", "100", "The maximum number of unique search keys to clean up at a time.")
+	c.AuditLogMaxAge = c.GetInterval("PRECISE_CODE_INTEL_AUDIT_LOG_MAX_AGE", "720h", "The maximum time a code intel audit log record can remain on the database.")
 }
 
 func (c *janitorConfig) Validate() error {

--- a/enterprise/cmd/worker/internal/codeintel/janitor_job.go
+++ b/enterprise/cmd/worker/internal/codeintel/janitor_job.go
@@ -78,6 +78,7 @@ func (j *janitorJob) Routines(ctx context.Context) ([]goroutine.BackgroundRoutin
 		janitor.NewUploadExpirer(dbStoreShim, policyMatcher, janitorConfigInst.RepositoryProcessDelay, janitorConfigInst.RepositoryBatchSize, janitorConfigInst.UploadProcessDelay, janitorConfigInst.UploadBatchSize, janitorConfigInst.PolicyBatchSize, janitorConfigInst.CommitBatchSize, janitorConfigInst.BranchesCacheMaxKeys, janitorConfigInst.CleanupTaskInterval, metrics),
 		janitor.NewExpiredUploadDeleter(dbStoreShim, janitorConfigInst.CleanupTaskInterval, metrics),
 		janitor.NewHardDeleter(dbStoreShim, lsifStoreShim, janitorConfigInst.CleanupTaskInterval, metrics),
+		janitor.NewAuditLogJanitor(dbStoreShim, janitorConfigInst.AuditLogMaxAge, janitorConfigInst.CleanupTaskInterval, metrics),
 
 		// Current indexes
 		janitor.NewDocumentationSearchCurrentJanitor(lsifStoreShim, janitorConfigInst.DocumentationSearchCurrentMinimumTimeSinceLastCheck, janitorConfigInst.DocumentationSearchCurrentBatchSize, janitorConfigInst.CleanupTaskInterval, metrics),

--- a/enterprise/internal/codeintel/stores/dbstore/janitor_test.go
+++ b/enterprise/internal/codeintel/stores/dbstore/janitor_test.go
@@ -204,3 +204,14 @@ func TestDeleteSourcedCommits(t *testing.T) {
 		t.Errorf("unexpected index states (-want +got):\n%s", diff)
 	}
 }
+
+func TestDeleteOldAuditLogs(t *testing.T) {
+	sqlDB := dbtest.NewDB(t)
+	db := database.NewDB(sqlDB)
+	store := testStore(db)
+
+	// Sanity check for syntax only
+	if _, err := store.DeleteOldAuditLogs(context.Background(), time.Second, time.Now()); err != nil {
+		t.Fatalf("unexpected error deleting old audit logs: %s", err)
+	}
+}

--- a/enterprise/internal/codeintel/stores/dbstore/observability.go
+++ b/enterprise/internal/codeintel/stores/dbstore/observability.go
@@ -17,6 +17,7 @@ type operations struct {
 	deleteConfigurationPolicyByID               *observation.Operation
 	deleteIndexByID                             *observation.Operation
 	deleteIndexesWithoutRepository              *observation.Operation
+	deleteOldAuditLogs                          *observation.Operation
 	deleteOverlappingDumps                      *observation.Operation
 	deleteSourcedCommits                        *observation.Operation
 	deleteUploadByID                            *observation.Operation
@@ -120,6 +121,7 @@ func newOperations(observationContext *observation.Context, metrics *metrics.RED
 		deleteConfigurationPolicyByID:        op("DeleteConfigurationPolicyByID"),
 		deleteIndexByID:                      op("DeleteIndexByID"),
 		deleteIndexesWithoutRepository:       op("DeleteIndexesWithoutRepository"),
+		deleteOldAuditLogs:                   op("DeleteOldAuditLogs"),
 		deleteOverlappingDumps:               op("DeleteOverlappingDumps"),
 		deleteSourcedCommits:                 op("DeleteSourcedCommits"),
 		deleteUploadByID:                     op("DeleteUploadByID"),

--- a/monitoring/definitions/shared/codeintel.go
+++ b/monitoring/definitions/shared/codeintel.go
@@ -862,6 +862,13 @@ func (codeIntelligence) NewJanitorGroup(containerName string) monitoring.Group {
 				`).Observable(),
 			},
 			{
+				Standard.Count("records deleted")(ObservableConstructorOptions{
+					MetricNameRoot:        "codeintel_background_audit_log_records_expired",
+					MetricDescriptionRoot: "lsif upload audit log",
+				})(containerName, monitoring.ObservableOwnerCodeIntel).WithNoAlerts(`
+					Number of LSIF upload audit log records deleted due to expiration every 5m
+				`).Observable(),
+
 				Observation.Errors(ObservableConstructorOptions{
 					MetricNameRoot:        "codeintel_background",
 					MetricDescriptionRoot: "janitor",


### PR DESCRIPTION
This PR adds a quick way to prune old data from the new `lsif_uploads_audit_log` table, which can hold a lot (unknown number) of rows with frequent activity.

## Test plan

Validated records and dashboards work as expected in local environment.