### PR TITLE
insights: adds ability to run just it time insight on backend

### DIFF
--- a/enterprise/internal/insights/query/streaming_query_executor.go
+++ b/enterprise/internal/insights/query/streaming_query_executor.go
@@ -1,0 +1,113 @@
+package query
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/grafana/regexp"
+	"github.com/inconshreveable/log15"
+
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/compression"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/query/streaming"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/timeseries"
+	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/authz"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
+	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+type StreamingQueryExecutor struct {
+	justInTimeExecutor
+}
+
+func NewStreamingExecutor(postgres, insightsDb dbutil.DB, clock func() time.Time) *StreamingQueryExecutor {
+	return &StreamingQueryExecutor{
+		justInTimeExecutor: justInTimeExecutor{
+			db:        database.NewDB(postgres),
+			repoStore: database.Repos(postgres),
+			filter:    &compression.NoopFilter{},
+			clock:     clock,
+		},
+	}
+}
+
+func (c *StreamingQueryExecutor) Execute(ctx context.Context, query string, seriesLabel string, seriesID string, repositories []string, interval timeseries.TimeInterval) ([]GeneratedTimeSeries, error) {
+	repoIds := make(map[string]api.RepoID)
+	for _, repository := range repositories {
+		repo, err := c.repoStore.GetByName(ctx, api.RepoName(repository))
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to fetch repository information for repository name: %s", repository)
+		}
+		repoIds[repository] = repo.ID
+	}
+	log15.Debug("Generated repoIds", "repoids", repoIds)
+
+	frames := BuildFrames(7, interval, c.clock())
+	points := timeCounts{}
+	timeseries := []TimeDataPoint{}
+
+	for _, repository := range repositories {
+		firstCommit, err := git.FirstEverCommit(ctx, c.db, api.RepoName(repository), authz.DefaultSubRepoPermsChecker)
+		if err != nil {
+			return nil, errors.Wrapf(err, "FirstEverCommit")
+		}
+		// uncompressed plan for now, because there is some complication between the way compressed plans are generated and needing to resolve revhashes
+		plan := c.filter.FilterFrames(ctx, frames, repoIds[repository])
+
+		// we need to perform the pivot from time -> {label, count} to label -> {time, count}
+		for _, execution := range plan.Executions {
+			if execution.RecordingTime.Before(firstCommit.Committer.Date) {
+				// this logic is faulty, but works for now. If the plan was compressed (these executions had children) we would have to
+				// iterate over the children to ensure they are also all before the first commit date. Otherwise, we would have to promote
+				// that child to the new execution, and all of the remaining children (after the promoted one) become children of the new execution.
+				// since we are using uncompressed plans (to avoid this problem and others) right now, each execution is standalone
+				continue
+			}
+
+			commits, err := git.Commits(ctx, c.db, api.RepoName(repository), git.CommitsOptions{N: 1, Before: execution.RecordingTime.Format(time.RFC3339), DateOrder: true}, authz.DefaultSubRepoPermsChecker)
+			if err != nil {
+				return nil, errors.Wrap(err, "git.Commits")
+			} else if len(commits) < 1 {
+				// there is no commit so skip this execution. Once again faulty logic for the same reasons as above.
+				continue
+			}
+
+			modifiedQuery := withCountUnlimited(query)
+			modifiedQuery = fmt.Sprintf("%s repo:^%s$@%s", modifiedQuery, regexp.QuoteMeta(repository), commits[0].ID)
+
+			decoder, countPtr, _, streamErrs := streaming.TabulationDecoder()
+			err = streaming.Search(ctx, modifiedQuery, decoder)
+			if err != nil {
+				return nil, errors.Wrap(err, "streaming.Search")
+			}
+
+			if len(streamErrs) > 0 {
+				log15.Error("streaming errors", "errors", streamErrs)
+			}
+
+			points[execution.RecordingTime] += *countPtr
+		}
+	}
+
+	for pointTime, pointCount := range points {
+		timeseries = append(timeseries, TimeDataPoint{
+			Time:  pointTime,
+			Count: pointCount,
+		})
+	}
+
+	sort.Slice(timeseries, func(i, j int) bool {
+		return timeseries[i].Time.Before(timeseries[j].Time)
+	})
+	generated := []GeneratedTimeSeries{{
+		Label:    seriesLabel,
+		SeriesId: seriesID,
+		Points:   timeseries,
+	}}
+	return generated, nil
+
+}

--- a/enterprise/internal/insights/resolvers/insight_series_resolver.go
+++ b/enterprise/internal/insights/resolvers/insight_series_resolver.go
@@ -445,3 +445,29 @@ func expandCaptureGroupSeriesJustInTime(ctx context.Context, definition types.In
 
 	return resolvers, nil
 }
+
+func streamingSeriesJustInTime(ctx context.Context, definition types.InsightViewSeries, r baseInsightResolver, filters types.InsightViewFilters) ([]graphqlbackend.InsightSeriesResolver, error) {
+	executor := query.NewStreamingExecutor(r.postgresDB, r.insightsDB, time.Now)
+	interval := timeseries.TimeInterval{
+		Unit:  types.IntervalUnit(definition.SampleIntervalUnit),
+		Value: definition.SampleIntervalValue,
+	}
+
+	scLoader := &scLoader{primary: r.postgresDB}
+	matchedRepos, err := filterRepositories(ctx, filters, definition.Repositories, scLoader)
+	if err != nil {
+		return nil, err
+	}
+	log15.Debug("capture group series", "seriesId", definition.SeriesID, "filteredRepos", matchedRepos)
+	generatedSeries, err := executor.Execute(ctx, definition.Query, definition.Label, definition.SeriesID, matchedRepos, interval)
+	if err != nil {
+		return nil, errors.Wrap(err, "CaptureGroupExecutor.Execute")
+	}
+
+	var resolvers []graphqlbackend.InsightSeriesResolver
+	for i := range generatedSeries {
+		resolvers = append(resolvers, &dynamicInsightSeriesResolver{generated: &generatedSeries[i]})
+	}
+
+	return resolvers, nil
+}

--- a/enterprise/internal/insights/resolvers/insight_view_resolvers.go
+++ b/enterprise/internal/insights/resolvers/insight_view_resolvers.go
@@ -106,9 +106,17 @@ func (i *insightViewResolver) registerDataSeriesGenerators() {
 		recordedSeries,
 	)
 
+	jitStreamingGenerator := newSeriesResolverGenerator(
+		func(series types.InsightViewSeries) bool {
+			return series.JustInTime && !series.GeneratedFromCaptureGroups
+		},
+		streamingSeriesJustInTime,
+	)
+
 	// build the chain of generators
 	jitCaptureGroupGenerator.SetNext(recordedCaptureGroupGenerator)
 	recordedCaptureGroupGenerator.SetNext(recordedGenerator)
+	recordedGenerator.SetNext(jitStreamingGenerator)
 
 	// set the local variable to the first generator in the chain
 	i.dataSeriesGenerator = jitCaptureGroupGenerator


### PR DESCRIPTION
wip - example of how I would add this functionality using the reorganization of code I have in https://github.com/sourcegraph/sourcegraph/pull/34148

Didn't do live preview yet and there is still a lot of duplicate or very similar code that over time I'd like to limit if possible.

## Test plan
tbd
<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


