### PR TITLE
search: remove Fields() method on query

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -409,7 +409,7 @@ func LogSearchLatency(ctx context.Context, db database.DB, wg *sync.WaitGroup, s
 			types = append(types, "regexp")
 		} else if q.IsStructural() {
 			types = append(types, "structural")
-		} else if len(si.Query.Fields()["file"]) > 0 {
+		} else if si.Query.Exists(query.FieldFile) {
 			// No search pattern specified and file: is specified.
 			types = append(types, "file")
 		} else {

--- a/internal/search/query/types.go
+++ b/internal/search/query/types.go
@@ -306,6 +306,14 @@ func (q Q) Index() YesNoOnly {
 	return *v
 }
 
+func (q Q) Exists(field string) bool {
+	found := false
+	VisitField(q, field, func(_ string, _ bool, _ Annotation) {
+		found = true
+	})
+	return found
+}
+
 func (q Q) Values(field string) []*Value {
 	var values []*Value
 	if field == "" {
@@ -318,17 +326,6 @@ func (q Q) Values(field string) []*Value {
 		})
 	}
 	return values
-}
-
-func (q Q) Fields() map[string][]*Value {
-	fields := make(map[string][]*Value)
-	VisitPattern(q, func(_ string, _ bool, _ Annotation) {
-		fields[""] = q.Values("")
-	})
-	VisitParameter(q, func(field, _ string, _ bool, _ Annotation) {
-		fields[field] = q.Values(field)
-	})
-	return fields
 }
 
 func (q Q) BoolValue(field string) bool {


### PR DESCRIPTION
Just doing some query cleanups. Don't want us to use `Fields()`, it assumes a flat query.


## Test plan
Semantics-preserving.

