### PR TITLE
Search backend: remove passed-in RepoOptions from Paginate signature

### DIFF
--- a/internal/search/commit/commit.go
+++ b/internal/search/commit/commit.go
@@ -68,8 +68,8 @@ func (j *CommitSearch) Run(ctx context.Context, clients job.RuntimeClients, stre
 	}
 
 	var repoRevs []*search.RepositoryRevisions
-	repos := searchrepos.Resolver{DB: clients.DB, Opts: j.RepoOpts}
-	err = repos.Paginate(ctx, &opts, func(page *searchrepos.Resolved) error {
+	repos := searchrepos.Resolver{DB: clients.DB, Opts: opts}
+	err = repos.Paginate(ctx, nil, func(page *searchrepos.Resolved) error {
 		if repoRevs = page.RepoRevs; page.Next != nil {
 			return newReposLimitError(opts.Limit, j.HasTimeFilter, resultType)
 		}

--- a/internal/search/commit/commit.go
+++ b/internal/search/commit/commit.go
@@ -69,7 +69,7 @@ func (j *CommitSearch) Run(ctx context.Context, clients job.RuntimeClients, stre
 
 	var repoRevs []*search.RepositoryRevisions
 	repos := searchrepos.Resolver{DB: clients.DB, Opts: opts}
-	err = repos.Paginate(ctx, nil, func(page *searchrepos.Resolved) error {
+	err = repos.Paginate(ctx, func(page *searchrepos.Resolved) error {
 		if repoRevs = page.RepoRevs; page.Next != nil {
 			return newReposLimitError(opts.Limit, j.HasTimeFilter, resultType)
 		}

--- a/internal/search/job/jobutil/repo_pager_job.go
+++ b/internal/search/job/jobutil/repo_pager_job.go
@@ -82,7 +82,7 @@ func (p *repoPagerJob) Run(ctx context.Context, clients job.RuntimeClients, stre
 		return err
 	}
 
-	return maxAlerter.Alert, repoResolver.Paginate(ctx, nil, pager)
+	return maxAlerter.Alert, repoResolver.Paginate(ctx, pager)
 }
 
 func (p *repoPagerJob) Name() string {

--- a/internal/search/repos/repos.go
+++ b/internal/search/repos/repos.go
@@ -70,7 +70,6 @@ func (r *Resolver) Paginate(ctx context.Context, handle func(*Resolved) error) (
 		tr.Finish()
 	}()
 
-
 	opts := r.Opts
 	if opts.Limit == 0 {
 		opts.Limit = 500

--- a/internal/search/repos/repos.go
+++ b/internal/search/repos/repos.go
@@ -63,20 +63,15 @@ type Resolver struct {
 	Opts search.RepoOptions
 }
 
-func (r *Resolver) Paginate(ctx context.Context, op *search.RepoOptions, handle func(*Resolved) error) (err error) {
+func (r *Resolver) Paginate(ctx context.Context, handle func(*Resolved) error) (err error) {
 	tr, ctx := trace.New(ctx, "searchrepos.Paginate", "")
 	defer func() {
 		tr.SetError(err)
 		tr.Finish()
 	}()
 
-	var opts search.RepoOptions
-	if op != nil {
-		opts = *op
-	} else {
-		opts = r.Opts
-	}
 
+	opts := r.Opts
 	if opts.Limit == 0 {
 		opts.Limit = 500
 	}

--- a/internal/search/repos/repos_test.go
+++ b/internal/search/repos/repos_test.go
@@ -371,7 +371,7 @@ func TestResolverPaginate(t *testing.T) {
 			r := Resolver{Opts: tc.opts, DB: db}
 
 			var pages []Resolved
-			err := r.Paginate(ctx, nil, func(page *Resolved) error {
+			err := r.Paginate(ctx, func(page *Resolved) error {
 				pages = append(pages, *page)
 				return nil
 			})

--- a/internal/search/run/repository.go
+++ b/internal/search/run/repository.go
@@ -28,7 +28,7 @@ func (s *RepoSearch) Run(ctx context.Context, clients job.RuntimeClients, stream
 	defer func() { finish(alert, err) }()
 
 	repos := &searchrepos.Resolver{DB: clients.DB, Opts: s.RepoOptions}
-	err = repos.Paginate(ctx, nil, func(page *searchrepos.Resolved) error {
+	err = repos.Paginate(ctx, func(page *searchrepos.Resolved) error {
 		tr.LogFields(otlog.Int("resolved.len", len(page.RepoRevs)))
 
 		// Filter the repos if there is a repohasfile: or -repohasfile field.

--- a/internal/search/structural/structural.go
+++ b/internal/search/structural/structural.go
@@ -163,7 +163,7 @@ func (s *StructuralSearch) Run(ctx context.Context, clients job.RuntimeClients, 
 	defer func() { finish(alert, err) }()
 
 	repos := &searchrepos.Resolver{DB: clients.DB, Opts: s.RepoOpts}
-	return nil, repos.Paginate(ctx, nil, func(page *searchrepos.Resolved) error {
+	return nil, repos.Paginate(ctx, func(page *searchrepos.Resolved) error {
 		indexed, unindexed, err := zoektutil.PartitionRepos(
 			ctx,
 			page.RepoRevs,


### PR DESCRIPTION
We've got some duplication in the API for repo search since options can
either be passed in through Paginate or passed in as a field of the
resolver. This removes the less-used first option. This is not an
opinion on which way is better, but rather just a "make it work one way"
thing.

## Test plan

Should not change behavior. Depending on existing tests.

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


