### PR TITLE
Search backend: clean up `Count` on `query.Basic`

### DIFF
--- a/internal/search/job/jobutil/job.go
+++ b/internal/search/job/jobutil/job.go
@@ -1,7 +1,6 @@
 package jobutil
 
 import (
-	"strconv"
 	"strings"
 
 	"github.com/grafana/regexp"
@@ -758,9 +757,8 @@ var metricFeatureFlagUnavailable = promauto.NewCounter(prometheus.CounterOpts{
 })
 
 func computeFileMatchLimit(q query.Basic, p search.Protocol) int {
-	if count := q.GetCount(); count != "" {
-		v, _ := strconv.Atoi(count) // Invariant: count is validated.
-		return v
+	if count := q.Count(); count != nil {
+		return *count
 	}
 
 	if q.IsStructural() {

--- a/internal/search/query/types.go
+++ b/internal/search/query/types.go
@@ -97,15 +97,6 @@ func (b Basic) MapParameters(parameters []Parameter) Basic {
 	return Basic{Parameters: parameters, Pattern: b.Pattern}
 }
 
-// AddCount adds a count parameter to a basic query. Behavior of AddCount on a
-// query that already has a count parameter is undefined.
-func (b Basic) AddCount(count int) Basic {
-	return b.MapParameters(append(b.Parameters, Parameter{
-		Field: "count",
-		Value: strconv.FormatInt(int64(count), 10),
-	}))
-}
-
 // GetCount returns the string value of the "count:" field. Returns empty string if none.
 func (b Basic) GetCount() string {
 	var countStr string

--- a/internal/search/query/types.go
+++ b/internal/search/query/types.go
@@ -97,13 +97,16 @@ func (b Basic) MapParameters(parameters []Parameter) Basic {
 	return Basic{Parameters: parameters, Pattern: b.Pattern}
 }
 
-// GetCount returns the string value of the "count:" field. Returns empty string if none.
-func (b Basic) GetCount() string {
-	var countStr string
-	VisitField(ToNodes(b.Parameters), "count", func(value string, _ bool, _ Annotation) {
-		countStr = value
+// Count returns the string value of the "count:" field. Returns empty string if none.
+func (b Basic) Count() (count *int) {
+	VisitField(ToNodes(b.Parameters), FieldCount, func(value string, _ bool, _ Annotation) {
+		c, err := strconv.Atoi(value)
+		if err != nil {
+			panic(fmt.Sprintf("Value %q for count cannot be parsed as an int", value))
+		}
+		count = &c
 	})
-	return countStr
+	return count
 }
 
 // GetTimeout returns the time.Duration value from the `timeout:` field.

--- a/internal/search/query_converter.go
+++ b/internal/search/query_converter.go
@@ -2,7 +2,6 @@ package search
 
 import (
 	"regexp/syntax" //nolint:depguard // zoekt requires this pkg
-	"strconv"
 	"strings"
 	"time"
 
@@ -78,9 +77,8 @@ func mapSlice(values []string, f func(string) string) []string {
 }
 
 func count(q query.Basic, p Protocol) int {
-	if count := q.GetCount(); count != "" {
-		v, _ := strconv.Atoi(count) // Invariant: count is validated.
-		return v
+	if count := q.Count(); count != nil {
+		return *count
 	}
 
 	if q.IsStructural() {
@@ -164,7 +162,7 @@ func TimeoutDuration(b query.Basic) time.Duration {
 	timeout := b.GetTimeout()
 	if timeout != nil {
 		d = *timeout
-	} else if b.GetCount() != "" {
+	} else if b.Count() != nil {
 		// If `count:` is set but `timeout:` is not explicitly set, use the max timeout
 		d = maxTimeout
 	}


### PR DESCRIPTION
This does three things:
- Removes the unused `AddCount`
- Renames `basic.GetCount` to `basic.Count`
- Makes `basic.Count` return a well-typed integer so the string doesn't need to be parsed by every caller

Stacked on #34156

## Test plan

Should not change any behavior. Depending on tests. 

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


