### PR TITLE
httptestutil: delete all VCR headers that look risky

### DIFF
--- a/internal/httptestutil/recorder.go
+++ b/internal/httptestutil/recorder.go
@@ -32,6 +32,20 @@ func NewRecorder(file string, record bool, filters ...cassette.Filter) (*recorde
 		// This is used for GitLab.
 		delete(i.Request.Headers, "Private-Token")
 		delete(i.Response.Headers, "Set-Cookie")
+		// Delete anything that looks risky
+		riskyHeaderKeys := []string{
+			"auth", "cookie", "token",
+		}
+		for _, headers := range []http.Header{i.Request.Headers, i.Response.Headers} {
+			for k := range headers {
+				for _, riskyKey := range riskyHeaderKeys {
+					if strings.Contains(strings.ToLower(k), riskyKey) {
+						delete(headers, k)
+						break
+					}
+				}
+			}
+		}
 		return nil
 	})
 

--- a/internal/httptestutil/recorder.go
+++ b/internal/httptestutil/recorder.go
@@ -28,11 +28,7 @@ func NewRecorder(file string, record bool, filters ...cassette.Filter) (*recorde
 	}
 
 	filters = append(filters, func(i *cassette.Interaction) error {
-		delete(i.Request.Headers, "Authorization")
-		// This is used for GitLab.
-		delete(i.Request.Headers, "Private-Token")
-		delete(i.Response.Headers, "Set-Cookie")
-		// Delete anything that looks risky
+		// Delete anything that looks risky on both requests and responses
 		riskyHeaderKeys := []string{
 			"auth", "cookie", "token",
 		}


### PR DESCRIPTION
We had a key leak via VCR from an unexpected header - this change makes the header pruning much more aggressive in the recorder by deleting anything that looks scary.

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

n/a
