### PR TITLE
Search backend: narrow query type to query.Basic

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -595,8 +595,11 @@ func (r *searchResolver) Stats(ctx context.Context) (stats *searchResultsStats, 
 
 	for {
 		// Query search results.
-		var err error
-		j, err := jobutil.ToSearchJob(r.SearchInputs, r.SearchInputs.Query)
+		b, err := query.ToBasicQuery(r.SearchInputs.Query)
+		if err != nil {
+			return nil, err
+		}
+		j, err := jobutil.ToSearchJob(r.SearchInputs, b)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/search/job/jobutil/job_test.go
+++ b/internal/search/job/jobutil/job_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/hexops/autogold"
+	"github.com/stretchr/testify/require"
 
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
@@ -14,6 +15,8 @@ import (
 func TestToSearchInputs(t *testing.T) {
 	test := func(input string, protocol search.Protocol, parser func(string) (query.Q, error)) string {
 		q, _ := parser(input)
+		b, err := query.ToBasicQuery(q)
+		require.NoError(t, err)
 		inputs := &run.SearchInputs{
 			UserSettings:        &schema.Settings{},
 			PatternType:         query.SearchTypeLiteral,
@@ -21,7 +24,7 @@ func TestToSearchInputs(t *testing.T) {
 			OnSourcegraphDotCom: true,
 		}
 
-		j, _ := ToSearchJob(inputs, q)
+		j, _ := ToSearchJob(inputs, b)
 		return "\n" + PrettySexp(j) + "\n"
 	}
 
@@ -219,7 +222,7 @@ func Test_optimizeJobs(t *testing.T) {
 
 		b, _ := query.ToBasicQuery(q)
 		baseJob, _ := toPatternExpressionJob(inputs, b)
-		optimizedJob, _ := optimizeJobs(baseJob, inputs, b.ToParseTree())
+		optimizedJob, _ := optimizeJobs(baseJob, inputs, b)
 		return "\nBASE:\n\n" + PrettySexp(baseJob) + "\n\nOPTIMIZED:\n\n" + PrettySexp(optimizedJob) + "\n"
 	}
 

--- a/internal/search/job/jobutil/printers_test.go
+++ b/internal/search/job/jobutil/printers_test.go
@@ -188,11 +188,12 @@ func TestPrettyJSON(t *testing.T) {
 							NewNoopJob()))))))))
 	test := func(input string) string {
 		q, _ := query.ParseLiteral(input)
+		b, _ := query.ToBasicQuery(q)
 		inputs := &run.SearchInputs{
 			UserSettings: &schema.Settings{},
 			Protocol:     search.Streaming,
 		}
-		j, _ := ToSearchJob(inputs, q)
+		j, _ := ToSearchJob(inputs, b)
 		return PrettyJSONVerbose(j)
 	}
 


### PR DESCRIPTION
This narrows the type on `ToSearchJob` from `query.Q` to `query.Basic`.
This was already an implicit requirement because we checked that the
`query.Q` was a basic query inside `ToSearchJob`.

The goal here is, when we know that a query is a basic query, to have that
represented in the type so that we don't have to keep converting between
the different types. @rvantonder I think this was your eventual intent with
`query.Basic`, but feel free to redirect if you had another direction in mind.

I could probably scope this down a bit, but this is one where I could just
keep splitting it smaller, so this felt like a good place to stop. 

Stacked on #34157

## Test plan

The surface area of this change is pretty large, but all the code in question is very well tested. I'm depending on those tests to ensure correctness here. 

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


