### PR TITLE
internal/extsvc/github: Check status code only for conditional request

### DIFF
--- a/internal/extsvc/github/common.go
+++ b/internal/extsvc/github/common.go
@@ -1562,13 +1562,11 @@ func doRequest(ctx context.Context, apiURL *url.URL, auth auth.Authenticator, ra
 		return newHttpResponseState(resp.StatusCode, resp.Header), &err
 	}
 
-	// If this is a conditional request (If-None-Match or If-Modified-Since header in the request)
-	// and the response is a 304 (resource not modified), the body is empty. Return early. It is now
-	// the caller's responsibility to read from a cache.
+	// If the resource is not modified, the body is empty. Return early. This is expected for
+	// resources that support conditional requests.
 	//
 	// See: https://docs.github.com/en/rest/overview/resources-in-the-rest-api#conditional-requests
-	if (req.Header.Get(headerIfNoneMatch) != "" || req.Header.Get(headerIfModifiedSince) != "") &&
-		resp.StatusCode == 304 {
+	if resp.StatusCode == 304 {
 		return newHttpResponseState(resp.StatusCode, resp.Header), nil
 	}
 


### PR DESCRIPTION
We no longer set the headerIfNoneMatch for conditional requests since
we let the httpcache take care of etags and adding the appropriate
header[1]. As a result we should not check for this either since the
check fails for conditional requests and ends up in an EOF error with
the body being empty.

[1]: https://sourcegraph.com/github.com/gregjones/httpcache@901d90724c7919163f472a9812253fb26761123d/-/blob/httpcache.go?L170-173&subtree=true

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

This commit is extracted from https://github.com/sourcegraph/sourcegraph/pull/34004 , where there are a lot of testing efforts going on. I'm pretty confident the behaviour is correct, namely with https://github.com/sourcegraph/sourcegraph/pull/34004#discussion_r853523786 https://github.com/sourcegraph/sourcegraph/commit/b3a0e430cc0526a975038c827769e9bd48a0971b#diff-ee6bd73704b29750eb3d94d6068033609be3cb2d5052506f176aa5adb5ab09d9L82
