### PR TITLE
insights: add docs for using query-based contexts to filter insights

### DIFF
--- a/doc/code_insights/explanations/code_insights_filters.md
+++ b/doc/code_insights/explanations/code_insights_filters.md
@@ -8,7 +8,7 @@ Filters take effect immediately, without needing to re-process the data series o
 
 ## Filter options
 
-### `repo:` filters
+### `repo:` Repo filters
 
 You can include or exclude repositories from your insight using regular expressions, the same way you can with the `repo:` filter in [Sourcegraph searches](../../code_search/reference/queries.md#keywords-all-searches).
 
@@ -17,6 +17,18 @@ For inclusion, only repositories that have a repository name matching the regula
 For exclusion, only repositories that have a repository name **not** matching the regular expression will be counted.
 
 If you combine both filters, the inclusion pattern will be applied first, then the exclusion pattern.
+
+### `context:` Query-based search context filters 
+
+You can use a [query-based search context](../../code_search/how-to/search_contexts.md#beta-query-based-search-contexts) to filter your insights to only results matching repositories that match the `repo:` filter of the query-based context. 
+
+You can use this to filter multiple insights to a group of repositories that need only be maintained in one location. When you update a context that's being used as a filter, the next time you load the page, the filtered insight will reflect the updated context. 
+
+At this time, all other filter keywords are not yet supported – only the `repo:` keyword of a context is recognized. When creating your context, you can define any group of repos using the syntax `repo:(^github\.com/sourcegraph/sourcegraph$|^github\.com/sourcegraph/about$...)`. 
+
+### Setting more than one filter 
+
+Filters are intersected. This means if you use the search context `context:` filter that narrows your insight down from all repositories to some repo A, repo B, and repo C, and then you use the `repo:` filter that's set only to repo A, your insight will show only results from repo A. Similarly, if you were to use the same `context:` and then also use the `-repo:` exclusion filter set to repo C, your insight would show results from repo A and repo B. 
 
 ### Other filtering options
 

--- a/doc/code_insights/explanations/code_insights_filters.md
+++ b/doc/code_insights/explanations/code_insights_filters.md
@@ -20,11 +20,11 @@ If you combine both filters, the inclusion pattern will be applied first, then t
 
 ### `context:` Query-based search context filters 
 
-You can use a [query-based search context](../../code_search/how-to/search_contexts.md#beta-query-based-search-contexts) to filter your insights to only results matching repositories that match the `repo:` filter of the query-based context. 
+You can use a [query-based search context](../../code_search/how-to/search_contexts.md#beta-query-based-search-contexts) to filter your insights to only results matching repositories that match the `repo:` or `-repo:` filter of the query-based context. 
 
 You can use this to filter multiple insights to a group of repositories that need only be maintained in one location. When you update a context that's being used as a filter, the next time you load the page, the filtered insight will reflect the updated context. 
 
-At this time, all other filter keywords are not yet supported – only the `repo:` keyword of a context is recognized. When creating your context, you can define any group of repos using the syntax `repo:(^github\.com/sourcegraph/sourcegraph$|^github\.com/sourcegraph/about$...)`. 
+At this time, all other filter keywords are not yet supported – only the `repo:` and `-repo:` keywords of a context are recognized. When creating your context, you can define any group of repos using the syntax `repo:(^github\.com/sourcegraph/sourcegraph$|^github\.com/sourcegraph/about$...)`. 
 
 ### Setting more than one filter 
 

--- a/doc/code_insights/how-tos/filtering_an_insight.md
+++ b/doc/code_insights/how-tos/filtering_an_insight.md
@@ -10,9 +10,9 @@ While viewing the insight you want to filter, click the filter icon in the upper
 
 ### 2. Filter to include or exclude repositories using a regular expression
 
-The filter popover gives you two inputs that allow you to to filter the repositories contributing to the insight, either via inclusion or exlcusion. 
+The filter popover gives you two inputs that allow you to to filter the repositories contributing to the insight, either via inclusion with `repo:` or exclusion with `-repo:`. 
 
-Enter a regular expression for repository names that you'd like to include or exclude. Inclusion filters limit your insight to show data from only given repository matches. Exclusion filters filter out results from the repository matches. ([More details on how repo filters are applied](../explanations/code_insights_filters.md#repo-filters).)
+Enter a regular expression for repository names that you'd like to include or exclude. Inclusion filters limit your insight to show data from only given repository matches. Exclusion filters filter out results from the repository matches. ([More details on how repo filters are applied](../explanations/code_insights_filters.md#repo-repo-filters).)
 
 The regular expression to filter for a repository works the same as the [`repo:` filter in the search box](../../code_search/reference/queries.md#keywords-all-searches).
 
@@ -26,23 +26,33 @@ Examples:
 | `service` | Filter all repositories that contain the word `service` in their name |
 | `\.js$` | Filter all repositories that end in `.js` |
 
-### 3. Close the filter panel 
+### 3. Or, filter to include a reusable group of repositories using a query-based search context
+
+In the `context:` field of the filter panel, you can use a [query-based search context](../../code_search/how-to/search_contexts.md#beta-query-based-search-contexts) to filter your insights to only results matching repositories that match the query-based context's `repo:` keyword. 
+
+First, if you haven't already created a search context, create a [query-based search context](../../code_search/how-to/search_contexts.md#beta-query-based-search-contexts). You can define any group of repos using the syntax `repo:(^github\.com/sourcegraph/sourcegraph$|^github\.com/sourcegraph/about$...)`. 
+
+Then, in the context field, reference the search context's name, usually `@owner/name-of-context`. 
+
+([More details on using search contexts as filters, and currently supported search keywords](../explanations/code_insights_filters.md#context-query-based-search-context-filters).)
+
+### 4. Close the filter panel 
 
 You can safely click outside the panel to close it and your filters will remain (until a page reload).
 
 A dot next to the filter icon indicates that an insight currently has filters applied.
 
-### 4. Edit or reset filters
+### 5. Edit or reset filters
 
 Click the filter button again to edit or reset filters. 
 
-### 5. Save your filters as defaults on this insight (optional)
+### 6. Save your filters as defaults on this insight (optional)
 
 By default, the filter will only be visible to you locally and will reset after a page reload.
 
 To persist the filter so that anyone who views the insight will have the filters applied by default, click "Save/update default filters".
 
-### 6. Save as new view (optional)
+### 7. Save as new view (optional)
 
 If you don't want to modify the insight for all future viewers, but still want to preserve your filtered view, you can select "save as new view." 
 


### PR DESCRIPTION
Add docs for the v0 of supporting contexts as filters on your code insights. 

## Test plan

This is a docs update I have viewed/checked locally. 


