### PR TITLE
dev/release: specify clone with depth 1 instead of 10

### DIFF
--- a/dev/release/src/github.ts
+++ b/dev/release/src/github.ts
@@ -522,7 +522,7 @@ async function cloneRepo(
 }> {
     const tmpdir = await mkdtemp(path.join(os.tmpdir(), `sg-release-${owner}-${repo}-`))
     console.log(`Created temp directory ${tmpdir}`)
-    const fetchFlags = '--depth 10'
+    const fetchFlags = '--depth 1'
 
     // Determine whether or not to create the base branch, or use the existing one
     let revisionExists = true


### PR DESCRIPTION
10 seems like a weird magic number copy pasted from somewhere. The
operations we do on the repo don't seem like they need more than the
latest commit.

Test Plan: dry run for tags and commented out main branch check. Then ran `yarn release release:create-candidate 3`