### PR TITLE
gitserver: extract Command interface to use different implementations for prod and unit tests

### DIFF
--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -2153,11 +2153,11 @@ var testGitRepoExists func(ctx context.Context, remoteURL *vcs.URL) error
 var (
 	execRunning = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "src_gitserver_exec_running",
-		Help: "number of gitserver.Command running concurrently.",
+		Help: "number of gitserver.GitCommand running concurrently.",
 	}, []string{"cmd", "repo"})
 	execDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
 		Name:    "src_gitserver_exec_duration_seconds",
-		Help:    "gitserver.Command latencies in seconds.",
+		Help:    "gitserver.GitCommand latencies in seconds.",
 		Buckets: trace.UserLatencyBuckets,
 	}, []string{"cmd", "repo", "status"})
 

--- a/internal/gitserver/client.go
+++ b/internal/gitserver/client.go
@@ -175,8 +175,8 @@ type Client interface {
 	// to abort processing further results.
 	BatchLog(ctx context.Context, opts BatchLogOptions, callback BatchLogCallback) error
 
-	// GitCommand creates a new Command.
-	GitCommand(repo api.RepoName, args ...string) Command
+	// GitCommand creates a new GitCommand.
+	GitCommand(repo api.RepoName, args ...string) GitCommand
 
 	// CreateCommitFromPatch will attempt to create a commit from a patch
 	// If possible, the error returned will be of type protocol.CreateCommitFromPatchError
@@ -837,8 +837,8 @@ func repoNamesFromRepoCommits(repoCommits []api.RepoCommit) []string {
 	return repoNames
 }
 
-// Command is an interface describing a command to be executed remotely.
-type Command interface {
+// GitCommand is an interface describing a git command to be executed remotely.
+type GitCommand interface {
 	// DividedOutput runs the command and returns its standard output and standard error.
 	DividedOutput(ctx context.Context) ([]byte, []byte, error)
 
@@ -980,7 +980,7 @@ func (c *cmdReader) Close() error {
 	return c.rc.Close()
 }
 
-func (c *ClientImplementor) GitCommand(repo api.RepoName, arg ...string) Command {
+func (c *ClientImplementor) GitCommand(repo api.RepoName, arg ...string) GitCommand {
 	return &Cmd{
 		repo:   repo,
 		execFn: c.httpPost,

--- a/internal/gitserver/client.go
+++ b/internal/gitserver/client.go
@@ -837,17 +837,41 @@ func repoNamesFromRepoCommits(repoCommits []api.RepoCommit) []string {
 	return repoNames
 }
 
+// Command is an interface describing a command to be executed remotely.
 type Command interface {
+	// DividedOutput runs the command and returns its standard output and standard error.
 	DividedOutput(ctx context.Context) ([]byte, []byte, error)
+
+	// Output runs the command and returns its standard output.
 	Output(ctx context.Context) ([]byte, error)
+
+	// CombinedOutput runs the command and returns its combined standard output and standard error.
 	CombinedOutput(ctx context.Context) ([]byte, error)
+
+	// DisableTimeout turns command timeout off
 	DisableTimeout()
+
+	// Repo returns repo against which the command is run
 	Repo() api.RepoName
+
+	// Args returns arguments of the command
 	Args() []string
+
+	// ExitStatus returns exit status of the command
 	ExitStatus() int
+
+	// SetEnsureRevision sets the revision which should be ensured when the command is ran
 	SetEnsureRevision(r string)
+
+	// EnsureRevision returns ensureRevision parameter of the command
 	EnsureRevision() string
+
+	// String returns string representation of the command (in fact prints args parameter of the command)
 	String() string
+
+	// StdoutReader returns an io.ReadCloser of stdout of c. If the command has a
+	// non-zero return value, Read returns a non io.EOF error. Do not pass in a
+	// started command.
 	StdoutReader(ctx context.Context) (io.ReadCloser, error)
 }
 

--- a/internal/gitserver/client.go
+++ b/internal/gitserver/client.go
@@ -175,8 +175,8 @@ type Client interface {
 	// to abort processing further results.
 	BatchLog(ctx context.Context, opts BatchLogOptions, callback BatchLogCallback) error
 
-	// GitCommand creates a new Cmd.
-	GitCommand(repo api.RepoName, args ...string) *Cmd
+	// GitCommand creates a new Command.
+	GitCommand(repo api.RepoName, args ...string) Command
 
 	// CreateCommitFromPatch will attempt to create a commit from a patch
 	// If possible, the error returned will be of type protocol.CreateCommitFromPatchError

--- a/internal/gitserver/commands.go
+++ b/internal/gitserver/commands.go
@@ -158,7 +158,7 @@ func (c *ClientImplementor) execReader(ctx context.Context, repo api.RepoName, a
 		return nil, errors.Errorf("command failed: %v is not a allowed git command", args)
 	}
 	cmd := c.GitCommand(repo, args...)
-	return StdoutReader(ctx, cmd)
+	return cmd.StdoutReader(ctx)
 }
 
 // logEntryPattern is the regexp pattern that matches entries in the output of the `git shortlog
@@ -507,7 +507,7 @@ func lsTreeUncached(ctx context.Context, db database.DB, repo api.RepoName, comm
 		if bytes.Contains(out, []byte("exists on disk, but not in")) {
 			return nil, &os.PathError{Op: "ls-tree", Path: filepath.ToSlash(path), Err: os.ErrNotExist}
 		}
-		return nil, errors.WithMessage(err, fmt.Sprintf("git command %v failed (output: %q)", cmd.args, out))
+		return nil, errors.WithMessage(err, fmt.Sprintf("git command %v failed (output: %q)", cmd.Args(), out))
 	}
 
 	if len(out) == 0 {
@@ -634,7 +634,7 @@ func (c *ClientImplementor) LogReverseEach(repo string, commit string, n int, on
 	// We run a single `git log` command and stream the output while the repo is being processed, which
 	// can take much longer than 1 minute (the default timeout).
 	command.DisableTimeout()
-	stdout, err := StdoutReader(ctx, command)
+	stdout, err := command.StdoutReader(ctx)
 	if err != nil {
 		return err
 	}

--- a/internal/gitserver/mock_client.go
+++ b/internal/gitserver/mock_client.go
@@ -146,7 +146,7 @@ func NewMockClient() *MockClient {
 			},
 		},
 		GitCommandFunc: &ClientGitCommandFunc{
-			defaultHook: func(api.RepoName, ...string) *Cmd {
+			defaultHook: func(api.RepoName, ...string) Command {
 				return nil
 			},
 		},
@@ -278,7 +278,7 @@ func NewStrictMockClient() *MockClient {
 			},
 		},
 		GitCommandFunc: &ClientGitCommandFunc{
-			defaultHook: func(api.RepoName, ...string) *Cmd {
+			defaultHook: func(api.RepoName, ...string) Command {
 				panic("unexpected invocation of MockClient.GitCommand")
 			},
 		},
@@ -1320,15 +1320,15 @@ func (c ClientGetObjectFuncCall) Results() []interface{} {
 // ClientGitCommandFunc describes the behavior when the GitCommand method of
 // the parent MockClient instance is invoked.
 type ClientGitCommandFunc struct {
-	defaultHook func(api.RepoName, ...string) *Cmd
-	hooks       []func(api.RepoName, ...string) *Cmd
+	defaultHook func(api.RepoName, ...string) Command
+	hooks       []func(api.RepoName, ...string) Command
 	history     []ClientGitCommandFuncCall
 	mutex       sync.Mutex
 }
 
 // GitCommand delegates to the next hook function in the queue and stores
 // the parameter and result values of this invocation.
-func (m *MockClient) GitCommand(v0 api.RepoName, v1 ...string) *Cmd {
+func (m *MockClient) GitCommand(v0 api.RepoName, v1 ...string) Command {
 	r0 := m.GitCommandFunc.nextHook()(v0, v1...)
 	m.GitCommandFunc.appendCall(ClientGitCommandFuncCall{v0, v1, r0})
 	return r0
@@ -1336,7 +1336,7 @@ func (m *MockClient) GitCommand(v0 api.RepoName, v1 ...string) *Cmd {
 
 // SetDefaultHook sets function that is called when the GitCommand method of
 // the parent MockClient instance is invoked and the hook queue is empty.
-func (f *ClientGitCommandFunc) SetDefaultHook(hook func(api.RepoName, ...string) *Cmd) {
+func (f *ClientGitCommandFunc) SetDefaultHook(hook func(api.RepoName, ...string) Command) {
 	f.defaultHook = hook
 }
 
@@ -1344,7 +1344,7 @@ func (f *ClientGitCommandFunc) SetDefaultHook(hook func(api.RepoName, ...string)
 // GitCommand method of the parent MockClient instance invokes the hook at
 // the front of the queue and discards it. After the queue is empty, the
 // default hook function is invoked for any future action.
-func (f *ClientGitCommandFunc) PushHook(hook func(api.RepoName, ...string) *Cmd) {
+func (f *ClientGitCommandFunc) PushHook(hook func(api.RepoName, ...string) Command) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -1352,20 +1352,20 @@ func (f *ClientGitCommandFunc) PushHook(hook func(api.RepoName, ...string) *Cmd)
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *ClientGitCommandFunc) SetDefaultReturn(r0 *Cmd) {
-	f.SetDefaultHook(func(api.RepoName, ...string) *Cmd {
+func (f *ClientGitCommandFunc) SetDefaultReturn(r0 Command) {
+	f.SetDefaultHook(func(api.RepoName, ...string) Command {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *ClientGitCommandFunc) PushReturn(r0 *Cmd) {
-	f.PushHook(func(api.RepoName, ...string) *Cmd {
+func (f *ClientGitCommandFunc) PushReturn(r0 Command) {
+	f.PushHook(func(api.RepoName, ...string) Command {
 		return r0
 	})
 }
 
-func (f *ClientGitCommandFunc) nextHook() func(api.RepoName, ...string) *Cmd {
+func (f *ClientGitCommandFunc) nextHook() func(api.RepoName, ...string) Command {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -1406,7 +1406,7 @@ type ClientGitCommandFuncCall struct {
 	Arg1 []string
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 *Cmd
+	Result0 Command
 }
 
 // Args returns an interface slice containing the arguments of this

--- a/internal/gitserver/mock_client.go
+++ b/internal/gitserver/mock_client.go
@@ -146,7 +146,7 @@ func NewMockClient() *MockClient {
 			},
 		},
 		GitCommandFunc: &ClientGitCommandFunc{
-			defaultHook: func(api.RepoName, ...string) Command {
+			defaultHook: func(api.RepoName, ...string) GitCommand {
 				return nil
 			},
 		},
@@ -278,7 +278,7 @@ func NewStrictMockClient() *MockClient {
 			},
 		},
 		GitCommandFunc: &ClientGitCommandFunc{
-			defaultHook: func(api.RepoName, ...string) Command {
+			defaultHook: func(api.RepoName, ...string) GitCommand {
 				panic("unexpected invocation of MockClient.GitCommand")
 			},
 		},
@@ -1320,15 +1320,15 @@ func (c ClientGetObjectFuncCall) Results() []interface{} {
 // ClientGitCommandFunc describes the behavior when the GitCommand method of
 // the parent MockClient instance is invoked.
 type ClientGitCommandFunc struct {
-	defaultHook func(api.RepoName, ...string) Command
-	hooks       []func(api.RepoName, ...string) Command
+	defaultHook func(api.RepoName, ...string) GitCommand
+	hooks       []func(api.RepoName, ...string) GitCommand
 	history     []ClientGitCommandFuncCall
 	mutex       sync.Mutex
 }
 
 // GitCommand delegates to the next hook function in the queue and stores
 // the parameter and result values of this invocation.
-func (m *MockClient) GitCommand(v0 api.RepoName, v1 ...string) Command {
+func (m *MockClient) GitCommand(v0 api.RepoName, v1 ...string) GitCommand {
 	r0 := m.GitCommandFunc.nextHook()(v0, v1...)
 	m.GitCommandFunc.appendCall(ClientGitCommandFuncCall{v0, v1, r0})
 	return r0
@@ -1336,7 +1336,7 @@ func (m *MockClient) GitCommand(v0 api.RepoName, v1 ...string) Command {
 
 // SetDefaultHook sets function that is called when the GitCommand method of
 // the parent MockClient instance is invoked and the hook queue is empty.
-func (f *ClientGitCommandFunc) SetDefaultHook(hook func(api.RepoName, ...string) Command) {
+func (f *ClientGitCommandFunc) SetDefaultHook(hook func(api.RepoName, ...string) GitCommand) {
 	f.defaultHook = hook
 }
 
@@ -1344,7 +1344,7 @@ func (f *ClientGitCommandFunc) SetDefaultHook(hook func(api.RepoName, ...string)
 // GitCommand method of the parent MockClient instance invokes the hook at
 // the front of the queue and discards it. After the queue is empty, the
 // default hook function is invoked for any future action.
-func (f *ClientGitCommandFunc) PushHook(hook func(api.RepoName, ...string) Command) {
+func (f *ClientGitCommandFunc) PushHook(hook func(api.RepoName, ...string) GitCommand) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -1352,20 +1352,20 @@ func (f *ClientGitCommandFunc) PushHook(hook func(api.RepoName, ...string) Comma
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *ClientGitCommandFunc) SetDefaultReturn(r0 Command) {
-	f.SetDefaultHook(func(api.RepoName, ...string) Command {
+func (f *ClientGitCommandFunc) SetDefaultReturn(r0 GitCommand) {
+	f.SetDefaultHook(func(api.RepoName, ...string) GitCommand {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *ClientGitCommandFunc) PushReturn(r0 Command) {
-	f.PushHook(func(api.RepoName, ...string) Command {
+func (f *ClientGitCommandFunc) PushReturn(r0 GitCommand) {
+	f.PushHook(func(api.RepoName, ...string) GitCommand {
 		return r0
 	})
 }
 
-func (f *ClientGitCommandFunc) nextHook() func(api.RepoName, ...string) Command {
+func (f *ClientGitCommandFunc) nextHook() func(api.RepoName, ...string) GitCommand {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -1406,7 +1406,7 @@ type ClientGitCommandFuncCall struct {
 	Arg1 []string
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 Command
+	Result0 GitCommand
 }
 
 // Args returns an interface slice containing the arguments of this

--- a/internal/vcs/git/blob.go
+++ b/internal/vcs/git/blob.go
@@ -98,7 +98,7 @@ type blobReader struct {
 	repo   api.RepoName
 	commit api.CommitID
 	name   string
-	cmd    gitserver.Command
+	cmd    gitserver.GitCommand
 	rc     io.ReadCloser
 }
 

--- a/internal/vcs/git/blob.go
+++ b/internal/vcs/git/blob.go
@@ -98,7 +98,7 @@ type blobReader struct {
 	repo   api.RepoName
 	commit api.CommitID
 	name   string
-	cmd    *gitserver.Cmd
+	cmd    gitserver.Command
 	rc     io.ReadCloser
 }
 
@@ -108,7 +108,7 @@ func newBlobReader(ctx context.Context, db database.DB, repo api.RepoName, commi
 	}
 
 	cmd := gitserver.NewClient(db).GitCommand(repo, "show", string(commit)+":"+name)
-	stdout, err := gitserver.StdoutReader(ctx, cmd)
+	stdout, err := cmd.StdoutReader(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/vcs/git/commits.go
+++ b/internal/vcs/git/commits.go
@@ -378,7 +378,7 @@ func joinCommits(previous, next []*gitdomain.Commit, desiredTotal uint) []*gitdo
 // runCommitLog sends the git command to gitserver. It interprets missing
 // revision responses and converts them into RevisionNotFoundError.
 // It is declared as a variable so that we can swap it out in tests
-var runCommitLog = func(ctx context.Context, cmd gitserver.Command, opt CommitsOptions) ([]*wrappedCommit, error) {
+var runCommitLog = func(ctx context.Context, cmd gitserver.GitCommand, opt CommitsOptions) ([]*wrappedCommit, error) {
 	data, stderr, err := cmd.DividedOutput(ctx)
 	if err != nil {
 		data = bytes.TrimSpace(data)

--- a/internal/vcs/git/commits.go
+++ b/internal/vcs/git/commits.go
@@ -378,7 +378,7 @@ func joinCommits(previous, next []*gitdomain.Commit, desiredTotal uint) []*gitdo
 // runCommitLog sends the git command to gitserver. It interprets missing
 // revision responses and converts them into RevisionNotFoundError.
 // It is declared as a variable so that we can swap it out in tests
-var runCommitLog = func(ctx context.Context, cmd *gitserver.Cmd, opt CommitsOptions) ([]*wrappedCommit, error) {
+var runCommitLog = func(ctx context.Context, cmd gitserver.Command, opt CommitsOptions) ([]*wrappedCommit, error) {
 	data, stderr, err := cmd.DividedOutput(ctx)
 	if err != nil {
 		data = bytes.TrimSpace(data)

--- a/internal/vcs/git/commits_test.go
+++ b/internal/vcs/git/commits_test.go
@@ -59,7 +59,7 @@ func TestRepository_GetCommit(t *testing.T) {
 				t.Cleanup(func() {
 					runCommitLog = oldRunCommitLog
 				})
-				runCommitLog = func(ctx context.Context, cmd *gitserver.Cmd, opt CommitsOptions) ([]*wrappedCommit, error) {
+				runCommitLog = func(ctx context.Context, cmd gitserver.Command, opt CommitsOptions) ([]*wrappedCommit, error) {
 					// Track the value of NoEnsureRevision we pass to gitserver
 					noEnsureRevision = opt.NoEnsureRevision
 					return oldRunCommitLog(ctx, cmd, opt)

--- a/internal/vcs/git/commits_test.go
+++ b/internal/vcs/git/commits_test.go
@@ -59,7 +59,7 @@ func TestRepository_GetCommit(t *testing.T) {
 				t.Cleanup(func() {
 					runCommitLog = oldRunCommitLog
 				})
-				runCommitLog = func(ctx context.Context, cmd gitserver.Command, opt CommitsOptions) ([]*wrappedCommit, error) {
+				runCommitLog = func(ctx context.Context, cmd gitserver.GitCommand, opt CommitsOptions) ([]*wrappedCommit, error) {
 					// Track the value of NoEnsureRevision we pass to gitserver
 					noEnsureRevision = opt.NoEnsureRevision
 					return oldRunCommitLog(ctx, cmd, opt)

--- a/internal/vcs/git/refs.go
+++ b/internal/vcs/git/refs.go
@@ -334,7 +334,7 @@ func RevList(repo string, db database.DB, commit string, onCommit func(commit st
 
 	command := gitserver.NewClient(db).GitCommand(api.RepoName(repo), RevListArgs(commit)...)
 	command.DisableTimeout()
-	stdout, err := gitserver.StdoutReader(ctx, command)
+	stdout, err := command.StdoutReader(ctx)
 	if err != nil {
 		return err
 	}

--- a/internal/vcs/git/revisions.go
+++ b/internal/vcs/git/revisions.go
@@ -98,7 +98,7 @@ func ResolveRevision(ctx context.Context, db database.DB, repo api.RepoName, spe
 
 // runRevParse sends the git rev-parse command to gitserver. It interprets
 // missing revision responses and converts them into RevisionNotFoundError.
-func runRevParse(ctx context.Context, cmd *gitserver.Cmd, spec string) (api.CommitID, error) {
+func runRevParse(ctx context.Context, cmd gitserver.Command, spec string) (api.CommitID, error) {
 	stdout, stderr, err := cmd.DividedOutput(ctx)
 	if err != nil {
 		if gitdomain.IsRepoNotExist(err) {

--- a/internal/vcs/git/revisions.go
+++ b/internal/vcs/git/revisions.go
@@ -98,7 +98,7 @@ func ResolveRevision(ctx context.Context, db database.DB, repo api.RepoName, spe
 
 // runRevParse sends the git rev-parse command to gitserver. It interprets
 // missing revision responses and converts them into RevisionNotFoundError.
-func runRevParse(ctx context.Context, cmd gitserver.Command, spec string) (api.CommitID, error) {
+func runRevParse(ctx context.Context, cmd gitserver.GitCommand, spec string) (api.CommitID, error) {
 	stdout, stderr, err := cmd.DividedOutput(ctx)
 	if err != nil {
 		if gitdomain.IsRepoNotExist(err) {


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/34167

## Test plan
Check that existing test are green
<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


