### PR TITLE
docs: correct link to download monorepo stats

### DIFF
--- a/doc/admin/monorepo.md
+++ b/doc/admin/monorepo.md
@@ -32,7 +32,7 @@ You can help the Sourcegraph developers understand the scale of your monorepo by
 Example output on the Sourcegraph repository:
 
 ``` shellsession
-$ wget https://github.com/sourcegraph/sourcegraph/blob/main/dev/git-stats
+$ wget https://github.com/sourcegraph/sourcegraph/raw/main/dev/git-stats
 $ chmod +x git-stats
 $ ./git-stats
 725M	. gitdir


### PR DESCRIPTION
We incorrectly pointed to the HMTL page rather than the actual file contents.

Test Plan: copy pasted line into terminal to see if it worked