### PR TITLE
insights: Add integration tests for dashboards

### DIFF
--- a/dev/gqltest/code_insights_test.go
+++ b/dev/gqltest/code_insights_test.go
@@ -177,7 +177,10 @@ func TestDeleteDashboard(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		client.UpdateDashboard(dashboard.Id, gqltestutil.DashboardInputArgs{})
+		_, err = client.UpdateDashboard(dashboard.Id, gqltestutil.DashboardInputArgs{})
+		if err == nil || !strings.Contains(err.Error(), "got nil for non-null") {
+			t.Fatal(err)
+		}
 		err = client.DeleteDashboard(dashboard.Id)
 		if !strings.Contains(err.Error(), "dashboard not found") {
 			t.Fatal("Should have thrown an error")
@@ -203,7 +206,10 @@ func getTitles(t *testing.T, args gqltestutil.GetDashboardArgs) []string {
 		// Sometimes the LAM dashboard will be present since the service is running. We do not want to count it in the test,
 		// so we hide the LAM dashboard and query the dashboards again.
 		if dashboard.Title == "Limited Access Mode Dashboard" {
-			client.UpdateDashboard(dashboard.Id, gqltestutil.DashboardInputArgs{Title: "Limited Access Mode Dashboard"})
+			_, err = client.UpdateDashboard(dashboard.Id, gqltestutil.DashboardInputArgs{Title: "Limited Access Mode Dashboard"})
+			if err == nil || !strings.Contains(err.Error(), "got nil for non-null") {
+				t.Fatal(err)
+			}
 			retry = true
 		}
 		resultTitles = append(resultTitles, dashboard.Title)

--- a/dev/gqltest/code_insights_test.go
+++ b/dev/gqltest/code_insights_test.go
@@ -1,20 +1,216 @@
 package main
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
+	"github.com/sourcegraph/sourcegraph/internal/gqltestutil"
 )
 
-func TestGetInsights(t *testing.T) {
-	t.Run("can get insights", func(t *testing.T) {
-		result, err := client.GetInsights()
+func TestCreateDashboard(t *testing.T) {
+	t.Run("can create an insights dashboard", func(t *testing.T) {
+		title := "Dashboard Title 1"
+		result, err := client.CreateDashboard(gqltestutil.DashboardInputArgs{
+			Title:       title,
+			GlobalGrant: true,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		want := gqltestutil.DashboardResponse{
+			Title: title,
+			Grants: gqltestutil.GrantsResponse{
+				Users:         []string{},
+				Organizations: []string{},
+				Global:        true,
+			},
+		}
+		err = client.DeleteDashboard(result.Id)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		if diff := cmp.Diff([]string{}, result); diff != "" {
+		// Ignore the newly created id
+		result.Id = ""
+		if diff := cmp.Diff(want, result); diff != "" {
 			t.Fatalf("Mismatch (-want +got):\n%s", diff)
 		}
 	})
+	t.Run("errors on a grant that the user does not have permission to give", func(t *testing.T) {
+		title := "Dashboard Title 1"
+		_, err := client.CreateDashboard(gqltestutil.DashboardInputArgs{
+			Title:     title,
+			UserGrant: string(graphqlbackend.MarshalUserID(9999)),
+		})
+		if !strings.Contains(err.Error(), "user does not have permission") {
+			t.Fatal("Should have thrown an error")
+		}
+	})
+	t.Run("errors on zero grants", func(t *testing.T) {
+		title := "Dashboard Title 1"
+		_, err := client.CreateDashboard(gqltestutil.DashboardInputArgs{
+			Title: title,
+		})
+		if !strings.Contains(err.Error(), "dashboard must be created with at least one grant") {
+			t.Fatal("Should have thrown an error")
+		}
+	})
+}
+
+func TestGetDashboards(t *testing.T) {
+	titles := []string{"Title 1", "Title 2", "Title 3", "Title 4", "Title 5"}
+	ids := []string{}
+	for _, title := range titles {
+		response, err := client.CreateDashboard(gqltestutil.DashboardInputArgs{Title: title, GlobalGrant: true})
+		if err != nil {
+			t.Fatal(err)
+		}
+		ids = append(ids, response.Id)
+	}
+
+	defer func() {
+		for _, id := range ids {
+			err := client.DeleteDashboard(id)
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+	}()
+
+	t.Run("can get all dashboards", func(t *testing.T) {
+		resultTitles := getTitles(t, gqltestutil.GetDashboardArgs{})
+		if diff := cmp.Diff(titles, resultTitles); diff != "" {
+			t.Fatalf("Mismatch (-want +got):\n%s", diff)
+		}
+	})
+	t.Run("can get the first 2 dashboards", func(t *testing.T) {
+		first := 2
+		args := gqltestutil.GetDashboardArgs{First: &first}
+		resultTitles := getTitles(t, args)
+		if diff := cmp.Diff(titles[0:2], resultTitles); diff != "" {
+			t.Fatalf("Mismatch (-want +got):\n%s", diff)
+		}
+	})
+	t.Run("can get a dashboard by id", func(t *testing.T) {
+		args := gqltestutil.GetDashboardArgs{Id: &ids[3]}
+		resultTitles := getTitles(t, args)
+		if diff := cmp.Diff([]string{titles[3]}, resultTitles); diff != "" {
+			t.Fatalf("Mismatch (-want +got):\n%s", diff)
+		}
+	})
+	t.Run("can get all dashboards after a cursor", func(t *testing.T) {
+		args := gqltestutil.GetDashboardArgs{After: &ids[1]}
+		resultTitles := getTitles(t, args)
+		if diff := cmp.Diff(titles[2:5], resultTitles); diff != "" {
+			t.Fatalf("Mismatch (-want +got):\n%s", diff)
+		}
+	})
+	t.Run("can get a single dashboard after a cursor", func(t *testing.T) {
+		first := 1
+		args := gqltestutil.GetDashboardArgs{First: &first, After: &ids[2]}
+		resultTitles := getTitles(t, args)
+		if diff := cmp.Diff([]string{titles[3]}, resultTitles); diff != "" {
+			t.Fatalf("Mismatch (-want +got):\n%s", diff)
+		}
+	})
+}
+
+func TestUpdateDashboard(t *testing.T) {
+	dashboard, err := client.CreateDashboard(gqltestutil.DashboardInputArgs{Title: "Title", GlobalGrant: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer func() {
+		err := client.DeleteDashboard(dashboard.Id)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	t.Run("can update a dashboard", func(t *testing.T) {
+		updatedTitle := "Updated title"
+		userGrant := client.AuthenticatedUserID()
+		updatedDashboard, err := client.UpdateDashboard(dashboard.Id, gqltestutil.DashboardInputArgs{Title: updatedTitle, UserGrant: userGrant})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		wantDashboard := gqltestutil.DashboardResponse{
+			Id:    dashboard.Id,
+			Title: updatedTitle,
+			Grants: gqltestutil.GrantsResponse{
+				Users:         []string{userGrant},
+				Organizations: []string{},
+				Global:        false,
+			},
+		}
+		if diff := cmp.Diff(wantDashboard, updatedDashboard); diff != "" {
+			t.Fatalf("Mismatch (-want +got):\n%s", diff)
+		}
+	})
+}
+
+func TestDeleteDashboard(t *testing.T) {
+	t.Run("can delete an insights dashboard", func(t *testing.T) {
+		dashboard, err := client.CreateDashboard(gqltestutil.DashboardInputArgs{Title: "Should be deleted", GlobalGrant: true})
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = client.DeleteDashboard(dashboard.Id)
+		if err != nil {
+			t.Fatal(err)
+		}
+		responseDashboard, err := client.GetDashboards(gqltestutil.GetDashboardArgs{Id: &dashboard.Id})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if diff := cmp.Diff(0, len(responseDashboard)); diff != "" {
+			t.Fatalf("Mismatch (-want +got):\n%s", diff)
+		}
+	})
+	t.Run("cannot delete an insights dashboard without permission", func(t *testing.T) {
+		dashboard, err := client.CreateDashboard(gqltestutil.DashboardInputArgs{Title: "Should be deleted", GlobalGrant: true})
+		if err != nil {
+			t.Fatal(err)
+		}
+		client.UpdateDashboard(dashboard.Id, gqltestutil.DashboardInputArgs{})
+		err = client.DeleteDashboard(dashboard.Id)
+		if !strings.Contains(err.Error(), "dashboard not found") {
+			t.Fatal("Should have thrown an error")
+		}
+	})
+	t.Run("returns an error when a dashboard does not exist", func(t *testing.T) {
+		err := client.DeleteDashboard("ZGFzaGJvYXJkOnsiSWRUeXBlIjoiY3VzdG9tIiwiQXJnIjo5OTk5OX0=")
+		if !strings.Contains(err.Error(), "dashboard not found") {
+			t.Fatal("Should have thrown an error")
+		}
+	})
+}
+
+func getTitles(t *testing.T, args gqltestutil.GetDashboardArgs) []string {
+	dashboards, err := client.GetDashboards(args)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	retry := false
+	resultTitles := []string{}
+	for _, dashboard := range dashboards {
+		// Sometimes the LAM dashboard will be present since the service is running. We do not want to count it in the test,
+		// so we hide the LAM dashboard and query the dashboards again.
+		if dashboard.Title == "Limited Access Mode Dashboard" {
+			client.UpdateDashboard(dashboard.Id, gqltestutil.DashboardInputArgs{Title: "Limited Access Mode Dashboard"})
+			retry = true
+		}
+		resultTitles = append(resultTitles, dashboard.Title)
+	}
+
+	if retry {
+		return getTitles(t, args)
+	}
+	return resultTitles
 }

--- a/internal/gqltestutil/code_insights.go
+++ b/internal/gqltestutil/code_insights.go
@@ -33,3 +33,178 @@ func (c *Client) GetInsights() ([]string, error) {
 
 	return ids, nil
 }
+
+type GetDashboardArgs struct {
+	First *int
+	After *string
+	Id    *string
+}
+
+type DashboardInputArgs struct {
+	Title       string
+	UserGrant   string
+	OrgGrant    string
+	GlobalGrant bool
+}
+
+type DashboardResponse struct {
+	Id     string         `json:"id"`
+	Title  string         `json:"title"`
+	Grants GrantsResponse `json:"grants"`
+}
+
+type GrantsResponse struct {
+	Users         []string `json:"users"`
+	Organizations []string `json:"organizations"`
+	Global        bool     `json:"global"`
+}
+
+func (c *Client) CreateDashboard(args DashboardInputArgs) (DashboardResponse, error) {
+	const query = `
+		mutation CreateInsightsDashboard($input: CreateInsightsDashboardInput!) {
+			createInsightsDashboard(input: $input) {
+				dashboard {
+					id, title, grants { users, organizations, global }
+				}
+			}
+		}
+	`
+
+	variables := map[string]interface{}{
+		"input": map[string]interface{}{
+			"title":  args.Title,
+			"grants": buildGrants(args.UserGrant, args.OrgGrant, args.GlobalGrant),
+		},
+	}
+
+	var resp struct {
+		Data struct {
+			CreateInsightsDashboard struct {
+				Dashboard DashboardResponse `json:"dashboard"`
+			} `json:"createInsightsDashboard"`
+		} `json:"data"`
+	}
+	err := c.GraphQL("", query, variables, &resp)
+	if err != nil {
+		return DashboardResponse{}, errors.Wrap(err, "request GraphQL")
+	}
+
+	return resp.Data.CreateInsightsDashboard.Dashboard, nil
+}
+
+func (c *Client) GetDashboards(args GetDashboardArgs) ([]DashboardResponse, error) {
+	const query = `
+		query CreateInsightsDashboard($first: Int, $after: String, $id: ID) {
+			insightsDashboards(first: $first, after: $after, id: $id) {
+				nodes {
+					id, title
+				}
+			}
+		}
+	`
+
+	variables := map[string]interface{}{}
+	if args.First != nil {
+		variables["first"] = args.First
+	}
+	if args.After != nil {
+		variables["after"] = args.After
+	}
+	if args.Id != nil {
+		variables["id"] = args.Id
+	}
+
+	var resp struct {
+		Data struct {
+			InsightsDashboards struct {
+				Nodes []DashboardResponse
+			} `json:"insightsDashboards"`
+		} `json:"data"`
+	}
+
+	err := c.GraphQL("", query, variables, &resp)
+	if err != nil {
+		return []DashboardResponse{}, errors.Wrap(err, "request GraphQL")
+	}
+
+	return resp.Data.InsightsDashboards.Nodes, nil
+}
+
+func (c *Client) UpdateDashboard(id string, args DashboardInputArgs) (DashboardResponse, error) {
+	const query = `
+		mutation UpdateInsightsDashboard($id: ID!, $input: UpdateInsightsDashboardInput!) {
+			updateInsightsDashboard(id: $id, input: $input) {
+				dashboard {
+					id, title, grants { users, organizations, global }
+				}
+			}
+		}
+	`
+
+	variables := map[string]interface{}{
+		"id": id,
+		"input": map[string]interface{}{
+			"title":  args.Title,
+			"grants": buildGrants(args.UserGrant, args.OrgGrant, args.GlobalGrant),
+		},
+	}
+
+	var resp struct {
+		Data struct {
+			UpdateInsightsDashboard struct {
+				Dashboard DashboardResponse `json:"dashboard"`
+			} `json:"updateInsightsDashboard"`
+		} `json:"data"`
+	}
+
+	err := c.GraphQL("", query, variables, &resp)
+	if err != nil {
+		return DashboardResponse{}, errors.Wrap(err, "request GraphQL")
+	}
+
+	return resp.Data.UpdateInsightsDashboard.Dashboard, nil
+}
+
+func (c *Client) DeleteDashboard(id string) error {
+	const query = `
+		mutation DeleteInsightsDashboard($id: ID!) {
+			deleteInsightsDashboard(id: $id) {
+				alwaysNil
+			}
+		}
+	`
+	variables := map[string]interface{}{
+		"id": id,
+	}
+	var resp struct {
+		Data struct {
+			DeleteInsightsDashboard struct {
+				AlwaysNil string `json:"alwaysNil"`
+			} `json:"deleteInsightsDashboard"`
+		} `json:"data"`
+	}
+	err := c.GraphQL("", query, variables, &resp)
+	if err != nil {
+		return errors.Wrap(err, "request GraphQL")
+	}
+
+	return nil
+}
+
+func buildGrants(userGrant string, orgGrant string, globalGrant bool) map[string]interface{} {
+	userGrants := []string{}
+	orgGrants := []string{}
+
+	if userGrant != "" {
+		userGrants = []string{userGrant}
+	}
+	if orgGrant != "" {
+		orgGrants = []string{orgGrant}
+	}
+
+	return map[string]interface{}{
+		"users":         userGrants,
+		"organizations": orgGrants,
+		"global":        globalGrant,
+	}
+}


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/33611

## Description
This adds CRUD tests for our dashboard endpoints. The main tricky thing I ran into is that the LAM dashboard gets automatically created here, and I solved that by hiding it (updating it to have no grants,) whenever it shows up in the results. 

## Test plan
I created a branch for this with the `backend-integration` prefix to make sure it passes: https://buildkite.com/sourcegraph/sourcegraph/builds/143298#812fd9db-6ebf-44f1-afc7-e30ebf1155be/193-385


