### PR TITLE
Revert "codeintellify: Fix hover reposition jank"

### DIFF
--- a/client/browser/src/shared/code-hosts/gitlab/codeHost.ts
+++ b/client/browser/src/shared/code-hosts/gitlab/codeHost.ts
@@ -7,7 +7,7 @@ import { NotificationType } from '@sourcegraph/shared/src/api/extension/extensio
 import { toAbsoluteBlobURL } from '@sourcegraph/shared/src/util/url'
 
 import { background } from '../../../browser-extension/web-extension-api/runtime'
-import { CodeHost, OverlayPosition } from '../shared/codeHost'
+import { CodeHost } from '../shared/codeHost'
 import { CodeView } from '../shared/codeViews'
 import { createNotificationClassNameGetter } from '../shared/getNotificationClassName'
 import { getSelectionsFromHash, observeSelectionsFromHash } from '../shared/util/selections'
@@ -24,26 +24,21 @@ export function checkIsGitlab(): boolean {
     return !!document.head.querySelector('meta[content="GitLab"]')
 }
 
-const adjustOverlayPosition: CodeHost['adjustOverlayPosition'] = args => {
-    const topOrBottom = 'top' in args ? 'top' : 'bottom'
-    let topOrBottomValue = 'top' in args ? args.top : args.bottom
-
+const adjustOverlayPosition: CodeHost['adjustOverlayPosition'] = ({ top, left }) => {
     const header = document.querySelector('header')
     if (header) {
-        topOrBottomValue += header.getBoundingClientRect().height
+        top += header.getBoundingClientRect().height
     }
     // When running GitLab from source, we also need to take into account
     // the debug header shown at the top of the page.
     const debugHeader = document.querySelector('#js-peek.development')
     if (debugHeader) {
-        topOrBottomValue += debugHeader.getBoundingClientRect().height
+        top += debugHeader.getBoundingClientRect().height
     }
-
-    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
     return {
-        [topOrBottom]: topOrBottomValue,
-        left: args.left,
-    } as OverlayPosition
+        top,
+        left,
+    }
 }
 
 export const getToolbarMount = (codeView: HTMLElement, pageKind?: GitLabPageKind): HTMLElement => {

--- a/client/browser/src/shared/code-hosts/shared/codeHost.tsx
+++ b/client/browser/src/shared/code-hosts/shared/codeHost.tsx
@@ -136,7 +136,10 @@ import styles from './codeHost.module.scss'
 
 registerHighlightContributions()
 
-export type OverlayPosition = { left: number } & ({ top: number } | { bottom: number })
+export interface OverlayPosition {
+    top: number
+    left: number
+}
 
 export type ObserveMutations = (
     target: Node,

--- a/client/codeintellify/src/hoverifier.ts
+++ b/client/codeintellify/src/hoverifier.ts
@@ -272,7 +272,7 @@ interface InternalHoverifierState<C extends object, D, A> {
     hoverOrError?: typeof LOADING | (HoverAttachment & D) | null | ErrorLike
 
     /** The desired position of the hover overlay */
-    hoverOverlayPosition?: { left: number } & ({ top: number } | { bottom: number })
+    hoverOverlayPosition?: { left: number; top: number }
 
     /** The currently hovered token */
     hoveredToken?: HoveredToken & C

--- a/client/codeintellify/src/overlayPosition.test.ts
+++ b/client/codeintellify/src/overlayPosition.test.ts
@@ -31,7 +31,7 @@ describe('overlay_position', () => {
                             target: rectangle(128, 220, 60, 16),
                             hoverOverlayElement: rectangle(28, 38, 350, 150),
                         }),
-                        { left: 100, bottom: 400 }
+                        { left: 100, top: 50 }
                     )
                 })
 
@@ -62,7 +62,7 @@ describe('overlay_position', () => {
                             target: rectangle(128, 220, 60, 16),
                             hoverOverlayElement: rectangle(28, -362, 350, 150),
                         }),
-                        { left: 100, bottom: 2400 }
+                        { left: 100, top: 450 }
                     )
                 })
 
@@ -96,7 +96,7 @@ describe('overlay_position', () => {
                             target: rectangle(128, 220, 60, 16),
                             hoverOverlayElement: rectangle(28, 38, 350, 150),
                         }),
-                        { left: 100, bottom: 400 }
+                        { left: 100, top: 50 }
                     )
                 })
 
@@ -127,7 +127,7 @@ describe('overlay_position', () => {
                             target: rectangle(128, 220, 60, 16),
                             hoverOverlayElement: rectangle(-172, -362, 350, 150),
                         }),
-                        { left: 300, bottom: 0 }
+                        { left: 300, top: 450 }
                     )
                 })
 

--- a/client/codeintellify/src/overlayPosition.ts
+++ b/client/codeintellify/src/overlayPosition.ts
@@ -12,7 +12,12 @@ export interface CalculateOverlayPositionOptions {
     hoverOverlayElement: HasGetBoundingClientRect
 }
 
-export type CSSOffsets = { left: number } & ({ top: number } | { bottom: number })
+export interface CSSOffsets {
+    /** Offset from the left in pixel */
+    left: number
+    /** Offset from the top in pixel */
+    top: number
+}
 
 /**
  * Calculates the desired position of the hover overlay depending on the container,
@@ -30,21 +35,19 @@ export const calculateOverlayPosition = ({
     // If the relativeElement is scrolled horizontally, we need to account for the offset (if not scrollLeft will be 0)
     const relativeHoverOverlayLeft = targetBounds.left + relativeElement.scrollLeft - relativeElementBounds.left
 
+    let relativeHoverOverlayTop: number
     // Check if the top of the hover overlay would be outside of the relative element or the viewport
     if (targetBounds.top - hoverOverlayBounds.height < Math.max(relativeElementBounds.top, 0)) {
         // Position it below the target
         // If the relativeElement is scrolled, we need to account for the offset (if not scrollTop will be 0)
-        return {
-            left: relativeHoverOverlayLeft,
-            top: targetBounds.bottom - relativeElementBounds.top + relativeElement.scrollTop,
-        }
+        relativeHoverOverlayTop = targetBounds.bottom - relativeElementBounds.top + relativeElement.scrollTop
+    } else {
+        // Else position it above the target
+        // Caculate the offset from the top of the relativeElement content to the top of the target
+        // If the relativeElement is scrolled, we need to account for the offset (if not scrollTop will be 0)
+        const relativeTargetTop = targetBounds.top - relativeElementBounds.top + relativeElement.scrollTop
+        relativeHoverOverlayTop = relativeTargetTop - hoverOverlayBounds.height
     }
 
-    // Else position it above the target
-    // If the relativeElement is scrolled, we need to account for the offset (if not scrollTop will be 0)
-    return {
-        left: relativeHoverOverlayLeft,
-        bottom:
-            relativeElementBounds.height - (targetBounds.top - relativeElementBounds.top + relativeElement.scrollTop),
-    }
+    return { left: relativeHoverOverlayLeft, top: relativeHoverOverlayTop }
 }

--- a/client/codeintellify/src/types.ts
+++ b/client/codeintellify/src/types.ts
@@ -14,7 +14,7 @@ export interface HoverOverlayProps<C extends object, D, A> {
     hoverOrError?: typeof LOADING | (HoverAttachment & D) | null | ErrorLike
 
     /** The position of the tooltip (assigned to `style`) */
-    overlayPosition?: { left: number } & ({ top: number } | { bottom: number })
+    overlayPosition?: { left: number; top: number }
 
     /**
      * The hovered token (position and word).

--- a/client/shared/src/hover/HoverOverlay.tsx
+++ b/client/shared/src/hover/HoverOverlay.tsx
@@ -62,24 +62,18 @@ export interface HoverOverlayProps
     useBrandedLogo?: boolean
 }
 
-const getOverlayStyle = (overlayPosition: HoverOverlayProps['overlayPosition']): CSSProperties => {
-    if (!overlayPosition) {
-        return {
-            opacity: 0,
-            visibility: 'hidden',
-        }
-    }
-
-    const topOrBottom = 'top' in overlayPosition ? 'top' : 'bottom'
-    const topOrBottomValue = 'top' in overlayPosition ? overlayPosition.top : overlayPosition.bottom
-
-    return {
-        opacity: 1,
-        visibility: 'visible',
-        left: `${overlayPosition.left}px`,
-        [topOrBottom]: `${topOrBottomValue}px`,
-    }
-}
+const getOverlayStyle = (overlayPosition: HoverOverlayProps['overlayPosition']): CSSProperties =>
+    overlayPosition
+        ? {
+              opacity: 1,
+              visibility: 'visible',
+              left: `${overlayPosition.left}px`,
+              top: `${overlayPosition.top}px`,
+          }
+        : {
+              opacity: 0,
+              visibility: 'hidden',
+          }
 
 export const HoverOverlay: React.FunctionComponent<HoverOverlayProps> = props => {
     const {


### PR DESCRIPTION
Reverts sourcegraph/sourcegraph#34028

This was causing positioning problems:

- Fixes https://github.com/sourcegraph/sourcegraph/issues/34184

## App preview:

- [Link](https://sg-web-revert-34028-fix-hover-reposition.onrender.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

