### PR TITLE
httptestutil: also strip values including "bearer"

### DIFF
--- a/internal/httptestutil/recorder.go
+++ b/internal/httptestutil/recorder.go
@@ -30,7 +30,7 @@ func NewRecorder(file string, record bool, filters ...cassette.Filter) (*recorde
 	filters = append(filters, func(i *cassette.Interaction) error {
 		// Delete anything that looks risky on both requests and responses
 		riskyHeaderKeys := []string{
-			"auth", "cookie", "token",
+			"auth", "bearer", "cookie", "token",
 		}
 		for _, headers := range []http.Header{i.Request.Headers, i.Response.Headers} {
 			for k := range headers {

--- a/internal/httptestutil/recorder.go
+++ b/internal/httptestutil/recorder.go
@@ -27,23 +27,8 @@ func NewRecorder(file string, record bool, filters ...cassette.Filter) (*recorde
 		return nil, err
 	}
 
-	filters = append(filters, func(i *cassette.Interaction) error {
-		// Delete anything that looks risky on both requests and responses
-		riskyHeaderKeys := []string{
-			"auth", "bearer", "cookie", "token",
-		}
-		for _, headers := range []http.Header{i.Request.Headers, i.Response.Headers} {
-			for k := range headers {
-				for _, riskyKey := range riskyHeaderKeys {
-					if strings.Contains(strings.ToLower(k), riskyKey) {
-						delete(headers, k)
-						break
-					}
-				}
-			}
-		}
-		return nil
-	})
+	// Remove headers that might include secrets.
+	filters = append(filters, riskyHeaderFilter)
 
 	for _, f := range filters {
 		rec.AddFilter(f)
@@ -120,4 +105,45 @@ func NewRecorderFactory(t testing.TB, update bool, name string) (*httpcli.Factor
 			t.Errorf("failed to update test data: %s", err)
 		}
 	}
+}
+
+// riskyHeaderFilter deletes anything that looks risky in request and response
+// headers.
+func riskyHeaderFilter(i *cassette.Interaction) error {
+	riskyHeaderKeys := []string{
+		"auth", "cookie", "token",
+	}
+	riskyHeaderValues := []string{
+		"bearer", "ghp_", "glpat-",
+	}
+
+	isRiskyKey := func(key string) bool {
+		lowerKey := strings.ToLower(key)
+		for _, riskyKey := range riskyHeaderKeys {
+			if strings.Contains(lowerKey, riskyKey) {
+				return true
+			}
+		}
+		return false
+	}
+	hasRiskyValue := func(values []string) bool {
+		for _, value := range values {
+			lowerValue := strings.ToLower(value)
+			for _, riskyValue := range riskyHeaderValues {
+				if strings.Contains(lowerValue, riskyValue) {
+					return true
+				}
+			}
+		}
+		return false
+	}
+
+	for _, headers := range []http.Header{i.Request.Headers, i.Response.Headers} {
+		for k, values := range headers {
+			if isRiskyKey(k) || hasRiskyValue(values) {
+				delete(headers, k)
+			}
+		}
+	}
+	return nil
 }

--- a/internal/httptestutil/recorder_test.go
+++ b/internal/httptestutil/recorder_test.go
@@ -1,0 +1,48 @@
+package httptestutil
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/dnaeon/go-vcr/cassette"
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestRiskyHeaderFilter(t *testing.T) {
+	input := http.Header{
+		"Authorization":   []string{"all values", "should be", "removed"},
+		"Bearer":          []string{"this should be kept as the risky value is only in the name"},
+		"GHP_XXXX":        []string{"this should be kept"},
+		"GLPAT-XXXX":      []string{"this should also be kept"},
+		"GitHub-PAT":      []string{"this should be removed: ghp_XXXX"},
+		"GitLab-PAT":      []string{"this should be removed", "glpat-XXXX"},
+		"Innocent-Header": []string{"this should be removed as it includes", "the word bearer"},
+		"Set-Cookie":      []string{"this is verboten"},
+		"Token":           []string{"a token should be removed"},
+		"X-Powered-By":    []string{"PHP"},
+		"X-Token":         []string{"something that smells like a token should also be removed"},
+	}
+
+	// Build the expected output.
+	want := http.Header{}
+	for _, k := range []string{"Bearer", "GHP_XXXX", "GLPAT-XXXX", "X-Powered-By"} {
+		want[k] = input[k]
+	}
+
+	i := cassette.Interaction{
+		Request:  cassette.Request{Headers: input},
+		Response: cassette.Response{Headers: input},
+	}
+
+	err := riskyHeaderFilter(&i)
+	if err != nil {
+		t.Errorf("unexpected non-nil error: %v", err)
+	}
+
+	if diff := cmp.Diff(i.Request.Headers, want); diff != "" {
+		t.Errorf("unexpected request headers (-have +want):\n%s", diff)
+	}
+	if diff := cmp.Diff(i.Response.Headers, want); diff != "" {
+		t.Errorf("unexpected response headers (-have +want):\n%s", diff)
+	}
+}


### PR DESCRIPTION
While #34159 will _probably_ strip any headers likely to include bearer tokens, I think it's worth explicitly handling that in case we're recording an oddball API.

## Test plan

Added a unit test for the header filter, and regenerated Bitbucket Cloud cassettes to ensure that generation worked as expected.