### PR TITLE
Fix file tree loading indicator styles

### DIFF
--- a/client/web/src/tree/TreeRoot.tsx
+++ b/client/web/src/tree/TreeRoot.tsx
@@ -210,8 +210,8 @@ export class TreeRoot extends React.Component<TreeRootProps, TreeRootState> {
                             <tr>
                                 <TreeLayerCell>
                                     {treeOrError === LOADING ? (
-                                        <div>
-                                            <LoadingSpinner className="tree-page__entries-loader" />
+                                        <div className="d-flex">
+                                            <LoadingSpinner className="tree-page__entries-loader mr-2" />
                                             Loading tree
                                         </div>
                                     ) : (


### PR DESCRIPTION
closes #2544

## Screenshots
| BEFORE             | AFTER             |
:-------------------------:|:-------------------------:
<img width="264" alt="image" src="https://user-images.githubusercontent.com/22571395/164285181-179f0162-8517-4523-a1e9-3379e2b390d0.png">| <img width="256" alt="image" src="https://user-images.githubusercontent.com/22571395/164285157-a7661cc7-9a41-4ff6-8d7a-1218920b49e2.png">


## Test plan

- visit repo page
- check for loading text In the left sidebar file tree section.

## App preview:

- [Link](https://sg-web-naman-fix-file-tree-loading.onrender.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

