### PR TITLE
fix: vsce - incorrect instance version error

### DIFF
--- a/client/vscode/CHANGELOG.md
+++ b/client/vscode/CHANGELOG.md
@@ -8,6 +8,8 @@ The Sourcegraph extension uses major.EVEN_NUMBER.patch (eg. 2.0.1) for release v
 
 ### Fixes
 
+- Remove incorrect unsupported instance error messages on first load [issues/34207](https://github.com/sourcegraph/sourcegraph/issues/34207)
+
 ## 2.2.1
 
 ### Changes

--- a/client/vscode/src/backend/instanceVersion.ts
+++ b/client/vscode/src/backend/instanceVersion.ts
@@ -1,6 +1,7 @@
 import { gql } from '@sourcegraph/http-client'
 import { EventSource } from '@sourcegraph/shared/src/graphql-operations'
 
+import { displayWarning } from '../settings/displayWarnings'
 import { INSTANCE_VERSION_NUMBER_KEY, LocalStorageService } from '../settings/LocalStorageService'
 
 import { requestGraphQLFromVSCode } from './requestGraphQl'
@@ -20,11 +21,17 @@ export function initializeInstantVersionNumber(localStorageService: LocalStorage
                     siteVersionResult.data.site.productVersion.length > 8
                         ? '999999'
                         : siteVersionResult.data.site.productVersion.split('.').join('')
+                if (flattenVersion < '3320') {
+                    displayWarning(
+                        'Your Sourcegraph instance version is not fully compatible with the Sourcegraph extension. Please ask your site admin to upgrade to version 3.32.0 or above. Read more about version support in our [troubleshooting docs](https://docs.sourcegraph.com/admin/how-to/troubleshoot-sg-extension#unsupported-features-by-sourcegraph-version).'
+                    ).catch(() => {})
+                }
                 await localStorageService.setValue(INSTANCE_VERSION_NUMBER_KEY, flattenVersion)
             }
         })
         .catch(error => {
             console.error('Failed to get instance version from host:', error)
+            displayWarning('Cannot determine instance version number').catch(() => {})
         })
     const versionNumber = localStorageService.getValue(INSTANCE_VERSION_NUMBER_KEY)
     // instances below 3.38.0 does not support EventSource.IDEEXTENSION and should fallback to BACKEND source
@@ -32,7 +39,7 @@ export function initializeInstantVersionNumber(localStorageService: LocalStorage
 }
 
 const siteVersionQuery = gql`
-    query {
+    query SiteProductVersion {
         site {
             productVersion
         }

--- a/client/vscode/src/extension.ts
+++ b/client/vscode/src/extension.ts
@@ -21,7 +21,6 @@ import { Event } from './graphql-operations'
 import { initializeCodeSharingCommands } from './link-commands/initialize'
 import polyfillEventSource from './polyfills/eventSource'
 import { accessTokenSetting, updateAccessTokenSetting } from './settings/accessTokenSetting'
-import { displayInstanceVersionWarnings } from './settings/displayWarnings'
 import { endpointRequestHeadersSetting, endpointSetting, updateEndpointSetting } from './settings/endpointSetting'
 import { invalidateContextOnSettingsChange } from './settings/invalidation'
 import { LocalStorageService, SELECTED_SEARCH_CONTEXT_SPEC_KEY } from './settings/LocalStorageService'
@@ -144,6 +143,5 @@ export function activate(context: vscode.ExtensionContext): void {
         instanceURL: initialInstanceURL,
     })
     initializeCodeSharingCommands(context, eventSourceType, localStorageService)
-    displayInstanceVersionWarnings(localStorageService)
     watchUninstall(eventSourceType, localStorageService)
 }

--- a/client/vscode/src/settings/displayWarnings.ts
+++ b/client/vscode/src/settings/displayWarnings.ts
@@ -1,20 +1,5 @@
 import vscode from 'vscode'
 
-import { INSTANCE_VERSION_NUMBER_KEY, LocalStorageService } from './LocalStorageService'
-
 export async function displayWarning(warning: string): Promise<void> {
     await vscode.window.showErrorMessage(warning)
-}
-
-export function displayInstanceVersionWarnings(localStorageService: LocalStorageService): void {
-    const versionNumber = localStorageService.getValue(INSTANCE_VERSION_NUMBER_KEY)
-    if (!versionNumber) {
-        displayWarning('Cannot determine instance version number').catch(() => {})
-    }
-    if (versionNumber < '3320') {
-        displayWarning(
-            'Your Sourcegraph instance version is not fully compatible with the Sourcegraph extension. Please ask your site admin to upgrade to version 3.32.0 or above. Read more about version support in our [troubleshooting docs](https://docs.sourcegraph.com/admin/how-to/troubleshoot-sg-extension#unsupported-features-by-sourcegraph-version).'
-        ).catch(() => {})
-    }
-    return
 }


### PR DESCRIPTION
Closes: https://github.com/sourcegraph/sourcegraph/issues/34207

Currently, errors messages regarding unsupported instance versions would pop up when you first installed the extension even if you are connected to a supported instance / cloud instance:
![Screen Shot 2022-04-20 at 10 29 27 AM](https://user-images.githubusercontent.com/68532117/164288760-f5681d88-1af6-4096-9f1a-340104263557.png)

This is due to the [displayInstanceVersionWarnings](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@v3.39.0-rc.2/-/blob/client/vscode/src/extension.ts?L147) function before called before we call the [function](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@v3.39.0-rc.2/-/blob/client/vscode/src/extension.ts?L67#tab=references) that invoke the graphQL call to retrieve the instance version number.

To resolve this, we can merge the warning display function to when we make the graphQL call, so that we can ensure the version number is ready before we can proceed to display warnings accordingly.

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->
Tested manually


## App preview:

- [Link](https://sg-web-bee-vsce-fix-version-error.onrender.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

