### PR TITLE
monitoring: zoekt - add per instance queueing delay dashboards

### DIFF
--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -14661,9 +14661,11 @@ Query: `sum by (le) (increase(index_queue_age_seconds_bucket[$__rate_interval]))
 
 <br />
 
-#### zoekt: indexed_queueing_delay_p99_9
+#### zoekt: indexed_queueing_delay_p99_9_aggregate
 
-<p class="subtitle">99.9th percentile job queuing delay over 5m</p>
+<p class="subtitle">99.9th percentile job queuing delay over 5m (aggregate)</p>
+
+This dashboard shows the p99.9 job queueing delay aggregated across all Zoekt instances.
 
 The queueing delay represents the amount of time an indexing job spent in the queue before it was processed.
 
@@ -14688,9 +14690,11 @@ Query: `histogram_quantile(0.999, sum by (le, name)(rate(index_queue_age_seconds
 
 <br />
 
-#### zoekt: indexed_queueing_delay_p90
+#### zoekt: indexed_queueing_delay_p90_aggregate
 
-<p class="subtitle">90th percentile job queueing delay over 5m</p>
+<p class="subtitle">90th percentile job queueing delay over 5m (aggregate)</p>
+
+This dashboard shows the p90 job queueing delay aggregated across all Zoekt instances.
 
 The queueing delay represents the amount of time an indexing job spent in the queue before it was processed.
 
@@ -14713,9 +14717,11 @@ Query: `histogram_quantile(0.90, sum by (le, name)(rate(index_queue_age_seconds_
 
 <br />
 
-#### zoekt: indexed_queueing_delay_p75
+#### zoekt: indexed_queueing_delay_p75_aggregate
 
-<p class="subtitle">75th percentile job queueing delay over 5m</p>
+<p class="subtitle">75th percentile job queueing delay over 5m (aggregate)</p>
+
+This dashboard shows the p75 job queueing delay aggregated across all Zoekt instances.
 
 The queueing delay represents the amount of time an indexing job spent in the queue before it was processed.
 
@@ -14733,6 +14739,89 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100422` on yo
 <summary>Technical details</summary>
 
 Query: `histogram_quantile(0.75, sum by (le, name)(rate(index_queue_age_seconds_bucket[5m])))`
+
+</details>
+
+<br />
+
+#### zoekt: indexed_queueing_delay_p99_9_per_instance
+
+<p class="subtitle">99.9th percentile job queuing delay over 5m (per instance)</p>
+
+This dashboard shows the p99.9 job queueing delay, broken out per Zoekt instance.
+
+The queueing delay represents the amount of time an indexing job spent in the queue before it was processed.
+
+Large queueing delays can be an indicator of:
+	- resource saturation
+	- each Zoekt replica has too many jobs for it to be able to process all of them promptly. In this scenario, consider adding additional Zoekt replicas to distribute the work better.
+
+The 99.9 percentile dashboard is useful for capturing the long tail of queueing delays (on the order of 24+ hours, etc.).
+
+This panel has no related alerts.
+
+To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100430` on your Sourcegraph instance.
+
+<sub>*Managed by the [Sourcegraph Search-core team](https://handbook.sourcegraph.com/engineering/search/core).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Query: `histogram_quantile(0.999, sum by (le, instance)(rate(index_queue_age_seconds_bucket{instance=~`${instance:regex}`}[5m])))`
+
+</details>
+
+<br />
+
+#### zoekt: indexed_queueing_delay_p90_per_instance
+
+<p class="subtitle">90th percentile job queueing delay over 5m (per instance)</p>
+
+This dashboard shows the p90 job queueing delay, broken out per Zoekt instance.
+
+The queueing delay represents the amount of time an indexing job spent in the queue before it was processed.
+
+Large queueing delays can be an indicator of:
+	- resource saturation
+	- each Zoekt replica has too many jobs for it to be able to process all of them promptly. In this scenario, consider adding additional Zoekt replicas to distribute the work better.
+
+This panel has no related alerts.
+
+To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100431` on your Sourcegraph instance.
+
+<sub>*Managed by the [Sourcegraph Search-core team](https://handbook.sourcegraph.com/engineering/search/core).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Query: `histogram_quantile(0.90, sum by (le, instance)(rate(index_queue_age_seconds_bucket{instance=~`${instance:regex}`}[5m])))`
+
+</details>
+
+<br />
+
+#### zoekt: indexed_queueing_delay_p75_per_instance
+
+<p class="subtitle">75th percentile job queueing delay over 5m (per instance)</p>
+
+This dashboard shows the p75 job queueing delay, broken out per Zoekt instance.
+
+The queueing delay represents the amount of time an indexing job spent in the queue before it was processed.
+
+Large queueing delays can be an indicator of:
+	- resource saturation
+	- each Zoekt replica has too many jobs for it to be able to process all of them promptly. In this scenario, consider adding additional Zoekt replicas to distribute the work better.
+
+This panel has no related alerts.
+
+To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100432` on your Sourcegraph instance.
+
+<sub>*Managed by the [Sourcegraph Search-core team](https://handbook.sourcegraph.com/engineering/search/core).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Query: `histogram_quantile(0.75, sum by (le, instance)(rate(index_queue_age_seconds_bucket{instance=~`${instance:regex}`}[5m])))`
 
 </details>
 

--- a/monitoring/definitions/zoekt.go
+++ b/monitoring/definitions/zoekt.go
@@ -343,13 +343,15 @@ func Zoekt() *monitoring.Container {
 					},
 					{
 						{
-							Name:        "indexed_queueing_delay_p99_9",
-							Description: "99.9th percentile job queuing delay over 5m",
+							Name:        "indexed_queueing_delay_p99_9_aggregate",
+							Description: "99.9th percentile job queuing delay over 5m (aggregate)",
 							Query:       "histogram_quantile(0.999, sum by (le, name)(rate(index_queue_age_seconds_bucket[5m])))",
 							NoAlert:     true,
 							Panel:       monitoring.Panel().LegendFormat("{{name}}").Unit(monitoring.Seconds),
 							Owner:       monitoring.ObservableOwnerSearchCore,
 							Interpretation: `
+							This dashboard shows the p99.9 job queueing delay aggregated across all Zoekt instances.
+
 							The queueing delay represents the amount of time an indexing job spent in the queue before it was processed.
 
 							Large queueing delays can be an indicator of:
@@ -360,13 +362,15 @@ func Zoekt() *monitoring.Container {
 						`,
 						},
 						{
-							Name:        "indexed_queueing_delay_p90",
-							Description: "90th percentile job queueing delay over 5m",
+							Name:        "indexed_queueing_delay_p90_aggregate",
+							Description: "90th percentile job queueing delay over 5m (aggregate)",
 							Query:       "histogram_quantile(0.90, sum by (le, name)(rate(index_queue_age_seconds_bucket[5m])))",
 							NoAlert:     true,
 							Panel:       monitoring.Panel().LegendFormat("{{name}}").Unit(monitoring.Seconds),
 							Owner:       monitoring.ObservableOwnerSearchCore,
 							Interpretation: `
+							This dashboard shows the p90 job queueing delay aggregated across all Zoekt instances.
+
 							The queueing delay represents the amount of time an indexing job spent in the queue before it was processed.
 
 							Large queueing delays can be an indicator of:
@@ -375,13 +379,70 @@ func Zoekt() *monitoring.Container {
 						`,
 						},
 						{
-							Name:        "indexed_queueing_delay_p75",
-							Description: "75th percentile job queueing delay over 5m",
+							Name:        "indexed_queueing_delay_p75_aggregate",
+							Description: "75th percentile job queueing delay over 5m (aggregate)",
 							Query:       "histogram_quantile(0.75, sum by (le, name)(rate(index_queue_age_seconds_bucket[5m])))",
 							NoAlert:     true,
 							Panel:       monitoring.Panel().LegendFormat("{{name}}").Unit(monitoring.Seconds),
 							Owner:       monitoring.ObservableOwnerSearchCore,
 							Interpretation: `
+							This dashboard shows the p75 job queueing delay aggregated across all Zoekt instances.
+
+							The queueing delay represents the amount of time an indexing job spent in the queue before it was processed.
+
+							Large queueing delays can be an indicator of:
+								- resource saturation
+								- each Zoekt replica has too many jobs for it to be able to process all of them promptly. In this scenario, consider adding additional Zoekt replicas to distribute the work better.
+						`,
+						},
+					},
+					{
+						{
+							Name:        "indexed_queueing_delay_p99_9_per_instance",
+							Description: "99.9th percentile job queuing delay over 5m (per instance)",
+							Query:       "histogram_quantile(0.999, sum by (le, instance)(rate(index_queue_age_seconds_bucket{instance=~`${instance:regex}`}[5m])))",
+							NoAlert:     true,
+							Panel:       monitoring.Panel().LegendFormat("{{instance}}").Unit(monitoring.Seconds),
+							Owner:       monitoring.ObservableOwnerSearchCore,
+							Interpretation: `
+							This dashboard shows the p99.9 job queueing delay, broken out per Zoekt instance.
+
+							The queueing delay represents the amount of time an indexing job spent in the queue before it was processed.
+
+							Large queueing delays can be an indicator of:
+								- resource saturation
+								- each Zoekt replica has too many jobs for it to be able to process all of them promptly. In this scenario, consider adding additional Zoekt replicas to distribute the work better.
+
+							The 99.9 percentile dashboard is useful for capturing the long tail of queueing delays (on the order of 24+ hours, etc.).
+						`,
+						},
+						{
+							Name:        "indexed_queueing_delay_p90_per_instance",
+							Description: "90th percentile job queueing delay over 5m (per instance)",
+							Query:       "histogram_quantile(0.90, sum by (le, instance)(rate(index_queue_age_seconds_bucket{instance=~`${instance:regex}`}[5m])))",
+							NoAlert:     true,
+							Panel:       monitoring.Panel().LegendFormat("{{instance}}").Unit(monitoring.Seconds),
+							Owner:       monitoring.ObservableOwnerSearchCore,
+							Interpretation: `
+							This dashboard shows the p90 job queueing delay, broken out per Zoekt instance.
+
+							The queueing delay represents the amount of time an indexing job spent in the queue before it was processed.
+
+							Large queueing delays can be an indicator of:
+								- resource saturation
+								- each Zoekt replica has too many jobs for it to be able to process all of them promptly. In this scenario, consider adding additional Zoekt replicas to distribute the work better.
+						`,
+						},
+						{
+							Name:        "indexed_queueing_delay_p75_per_instance",
+							Description: "75th percentile job queueing delay over 5m (per instance)",
+							Query:       "histogram_quantile(0.75, sum by (le, instance)(rate(index_queue_age_seconds_bucket{instance=~`${instance:regex}`}[5m])))",
+							NoAlert:     true,
+							Panel:       monitoring.Panel().LegendFormat("{{instance}}").Unit(monitoring.Seconds),
+							Owner:       monitoring.ObservableOwnerSearchCore,
+							Interpretation: `
+							This dashboard shows the p75 job queueing delay, broken out per Zoekt instance.
+
 							The queueing delay represents the amount of time an indexing job spent in the queue before it was processed.
 
 							Large queueing delays can be an indicator of:


### PR DESCRIPTION
<img width="1642" alt="Screen Shot 2022-04-20 at 10 48 11 AM" src="https://user-images.githubusercontent.com/9022011/164292541-c2210b40-8992-42d3-a63e-6adc4149a504.png">

Follow up to https://sourcegraph.slack.com/archives/C023ELQLV7F/p1650471549635389?thread_ts=1649941550.692219&cid=C023ELQLV7F

## Test plan

Ran locally against sourcegraph.com's Prometheus instance. 