### PR TITLE
dev/release: stage updates Install component in about

### DIFF
--- a/dev/release/src/release.ts
+++ b/dev/release/src/release.ts
@@ -445,7 +445,7 @@ CI checks in this repository should pass, and a manual review should confirm if 
                         commitMessage: defaultPRMessage,
                         title: defaultPRMessage,
                         edits: [
-                            `${sed} -i -E 's/sourcegraph\\/server:${versionRegex}/sourcegraph\\/server:${release.version}/g' 'website/src/components/GetStarted.tsx'`,
+                            `${sed} -i -E 's/sourcegraph\\/server:${versionRegex}/sourcegraph\\/server:${release.version}/g' 'website/src/components/Install/index.tsx'`,
                             `${sed} -i -E 's/sourcegraph\\/server:${versionRegex}/sourcegraph\\/server:${release.version}/g' 'website/src/pages/get-started.tsx'`,
                         ],
                         ...prBodyAndDraftState(


### PR DESCRIPTION
The about repository had a change which moved the version string from `website/src/components/GetStarted.tsx` to `website/src/components/Install/index.tsx` in https://github.com/sourcegraph/about/pull/5149. Without this update the stage command fails (and is currently failing while I am doing this release).

Test Plan: running stage command with this commit and it works.