### PR TITLE
dev/release: update version in all tsx files in about repo

### DIFF
--- a/dev/release/src/release.ts
+++ b/dev/release/src/release.ts
@@ -445,8 +445,8 @@ CI checks in this repository should pass, and a manual review should confirm if 
                         commitMessage: defaultPRMessage,
                         title: defaultPRMessage,
                         edits: [
-                            `${sed} -i -E 's/sourcegraph\\/server:${versionRegex}/sourcegraph\\/server:${release.version}/g' 'website/src/components/GetStarted.tsx'`,
-                            `${sed} -i -E 's/sourcegraph\\/server:${versionRegex}/sourcegraph\\/server:${release.version}/g' 'website/src/pages/get-started.tsx'`,
+                            // Update sourcegraph/server:VERSION in all tsx files
+                            `find . -type f -name '*.tsx' -exec ${sed} -i -E 's/sourcegraph\\/server:${versionRegex}/sourcegraph\\/server:${release.version}/g' {} +`,
                         ],
                         ...prBodyAndDraftState(
                             [],


### PR DESCRIPTION
My last commit failed because I forgot to remove get-started.tsx. Lets
just make this run on all tsx files rather than what seems to be a
fragile allow list.

Test Plan: I will actually test this before landing as described in the
previous commit. I landed due to the main check.

