### PR TITLE
notebooks: fix cursor jumping and color in markdown blocks

### DIFF
--- a/client/web/src/notebooks/blocks/markdown/NotebookMarkdownBlock.module.scss
+++ b/client/web/src/notebooks/blocks/markdown/NotebookMarkdownBlock.module.scss
@@ -13,6 +13,7 @@
 
         :global(.cm-content) {
             font-family: var(--code-font-family);
+            caret-color: var(--body-color);
         }
 
         :global(.cm-scroller) {

--- a/client/web/src/notebooks/blocks/markdown/NotebookMarkdownBlock.tsx
+++ b/client/web/src/notebooks/blocks/markdown/NotebookMarkdownBlock.tsx
@@ -80,11 +80,13 @@ const staticExtensions: Extension[] = [
 ]
 
 function focusInput(editor: EditorView): void {
-    editor.focus()
-    editor.dispatch({
-        selection: { anchor: editor.state.doc.length },
-        scrollIntoView: true,
-    })
+    if (!editor.hasFocus) {
+        editor.focus()
+        editor.dispatch({
+            selection: { anchor: editor.state.doc.length },
+            scrollIntoView: true,
+        })
+    }
 }
 
 interface NotebookMarkdownBlockProps extends BlockProps<MarkdownBlock>, ThemeProps {


### PR DESCRIPTION
- Fixes #34216 (cursor jumping)
- Fixes cursor color in dark mode (cursor now matches body text color)


## Test plan

Manual testing to make sure Enter key behavior is correct and the cursor is the right color in both light and dark mode


## App preview:

- [Link](https://sg-web-jp-nbmdcursor.onrender.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

