### PR TITLE
VSCE: add integration test cases for searching

### DIFF
--- a/client/vscode/src/webview/search-panel/RepoView.tsx
+++ b/client/vscode/src/webview/search-panel/RepoView.tsx
@@ -12,7 +12,7 @@ import { QueryState } from '@sourcegraph/search'
 import { fetchTreeEntries } from '@sourcegraph/shared/src/backend/repo'
 import { displayRepoName } from '@sourcegraph/shared/src/components/RepoFileLink'
 import { RepositoryMatch } from '@sourcegraph/shared/src/search/stream'
-import { PageHeader, useObservable } from '@sourcegraph/wildcard'
+import { Icon, PageHeader, useObservable } from '@sourcegraph/wildcard'
 
 import { WebviewPageProps } from '../platform/context'
 
@@ -84,9 +84,9 @@ export const RepoView: React.FunctionComponent<RepoViewProps> = ({
             <button
                 type="button"
                 onClick={onBackToSearchResults}
-                className="btn btn-sm btn-link btn-outline-secondary text-decoration-none border-0"
+                className="test-back-to-search-view-btn btn btn-sm btn-link btn-outline-secondary text-decoration-none border-0"
             >
-                <ArrowLeftIcon className="icon-inline mr-1" />
+                <Icon className="mr-1" as={ArrowLeftIcon} />
                 Back to search view
             </button>
             {directoryStack.length > 0 && (
@@ -95,7 +95,7 @@ export const RepoView: React.FunctionComponent<RepoViewProps> = ({
                     onClick={onPreviousDirectory}
                     className="btn btn-sm btn-link btn-outline-secondary text-decoration-none border-0"
                 >
-                    <ArrowLeftIcon className="icon-inline mr-1" />
+                    <Icon className="mr-1" as={ArrowLeftIcon} />
                     Back to previous directory
                 </button>
             )}
@@ -133,10 +133,10 @@ export const RepoView: React.FunctionComponent<RepoViewProps> = ({
                                 >
                                     <span>
                                         {entry.isDirectory && (
-                                            <FolderOutlineIcon className="icon-inline mr-1 text-muted" />
+                                            <Icon className="mr-1 text-muted" as={FolderOutlineIcon} />
                                         )}
                                         {!entry.isDirectory && (
-                                            <FileDocumentOutlineIcon className="icon-inline mr-1 text-muted" />
+                                            <Icon className="mr-1 text-muted" as={FileDocumentOutlineIcon} />
                                         )}
                                         {entry.name}
                                         {entry.isDirectory && '/'}

--- a/client/vscode/tests/graphql.ts
+++ b/client/vscode/tests/graphql.ts
@@ -74,18 +74,18 @@ export const commonVSCodeGraphQlResults: Partial<
     }),
     RepositoryMetadata: () => ({
         __typename: 'Query',
-        repositoryRedirect: null
+        repositoryRedirect: null,
     }),
     TreeEntries: () => ({
         __typename: 'Query',
-        repository: null
+        repository: null,
     }),
     FileNames: () => ({
         __typename: 'Query',
-        repository: null
+        repository: null,
     }),
     BlobContent: () => ({
         __typename: 'Query',
-        repository: null
-    })
+        repository: null,
+    }),
 }

--- a/client/vscode/tests/graphql.ts
+++ b/client/vscode/tests/graphql.ts
@@ -72,4 +72,20 @@ export const commonVSCodeGraphQlResults: Partial<
             productVersion: '3.38.2',
         },
     }),
+    RepositoryMetadata: () => ({
+        __typename: 'Query',
+        repositoryRedirect: null
+    }),
+    TreeEntries: () => ({
+        __typename: 'Query',
+        repository: null
+    }),
+    FileNames: () => ({
+        __typename: 'Query',
+        repository: null
+    }),
+    BlobContent: () => ({
+        __typename: 'Query',
+        repository: null
+    })
 }

--- a/client/vscode/tests/vsce.test.ts
+++ b/client/vscode/tests/vsce.test.ts
@@ -1,3 +1,5 @@
+import assert from 'assert'
+
 import { downloadAndUnzipVSCode } from '@vscode/test-electron'
 
 import { mixedSearchStreamEvents, highlightFileResult } from '@sourcegraph/search'
@@ -68,30 +70,92 @@ describe('VS Code extension', () => {
                     ],
                 },
             }),
+            BlobContent: () => ({
+                repository: {
+                    commit: {
+                        blob: {
+                            content: '\rtesting\n',
+                            binary: false,
+                            byteSize: 2,
+                        },
+                    },
+                },
+            }),
+            FileNames: () => ({
+                repository: {
+                    commit: {
+                        fileNames: ['overridable/bool_or_string_test.go'],
+                    },
+                },
+            }),
         })
 
         testContext.overrideSearchStreamEvents([...mixedSearchStreamEvents])
 
-        const { searchPanelFrame } = await getVSCodeWebviewFrames(vsCodeDriver.page)
+        const { searchPanelFrame, sidebarFrame } = await getVSCodeWebviewFrames(vsCodeDriver.page)
 
         // Focus search box
         await searchPanelFrame.waitForSelector('.monaco-editor .view-lines')
         await searchPanelFrame.click('.monaco-editor .view-lines')
 
-        await vsCodeDriver.page.keyboard.type('test', { delay: 50 })
+        await vsCodeDriver.page.keyboard.type('test', {
+            delay: 50,
+        })
         // Submit search
         await searchPanelFrame.waitForSelector('.test-search-button', { visible: true })
-        await searchPanelFrame.click('.test-search-button')
+        await searchPanelFrame.click('.test-search-button', { delay: 50 })
 
         try {
             await searchPanelFrame.waitForSelector('.test-search-result', { visible: true })
         } catch {
             throw new Error('Timeout waiting for search results to render')
         }
+
+        // Submit new search from sidebar filter
+        try {
+            await sidebarFrame.waitForSelector('.search-sidebar .search-filter-keyword', { visible: true })
+            await sidebarFrame.click('.search-sidebar .search-filter-keyword', { delay: 100 })
+            await searchPanelFrame.waitForSelector('.test-search-result', { visible: true })
+        } catch {
+            throw new Error('Timeout waiting for filtered search results to render')
+        }
+
+        // Open Repo page from search results
+        await searchPanelFrame.waitForSelector('.test-search-result button', { visible: true })
+        await searchPanelFrame.click('.test-search-result button', { delay: 100 })
+
+        // Redirect back to search results from Repo Page
+        try {
+            await searchPanelFrame.waitForSelector('.test-back-to-search-view-btn', { visible: true })
+            await searchPanelFrame.click('.test-back-to-search-view-btn', { delay: 100 })
+        } catch {
+            throw new Error('Timeout waiting for back to search results button from repo display page to render')
+        }
+
+        // Open remote file from search results
+        try {
+            await searchPanelFrame.waitForSelector('.test-search-result strong', { visible: true })
+            await searchPanelFrame.click('.test-search-result strong', { delay: 100 })
+        } catch {
+            throw new Error('Timeout waiting for search results to render after nevigating back from repo display page')
+        }
+
+        try {
+            await searchPanelFrame.waitForSelector('.file.monaco-breadcrumb-item .monaco-icon-name-container', {
+                visible: true,
+            })
+            const fileNameText = await searchPanelFrame.evaluate(
+                () => document.querySelector('.file.monaco-breadcrumb-item .monaco-icon-name-container')?.textContent
+            )
+            console.log(fileNameText)
+            assert(fileNameText === 'bool_or_string_test.go', 'expected remote file to open')
+        } catch {
+            throw new Error('Timeout waiting for search results to render after nevigating back from repo display page')
+        }
     })
 
     // Potential future test cases:
     // - Clicking search result opens remote files
     // - Sourcegraph extensions work on remote files
-    // - Clicking sidebar filter updates query (and executes for some?)
+    // DONE - Clicking sidebar filter updates query (and executes for some?)
 })


### PR DESCRIPTION
Test cases created for searching in VSCE:
![test](https://user-images.githubusercontent.com/68532117/164331400-e9c2bf2d-9d98-481c-a7a1-5af92c515737.gif)

The current process:
1. We will start each case by clicking on the Sourcegraph Logo from the activity bar on the side.
2. Then we will perform a simple search `test`
3. Once the test results are loaded, we will click on the first filter (`lang: go`) in the sidebar to execute a new search `test` => `test lang:go`
4. Click on the first result from the new search results should lead us to the Repo Page
5. Click on the `Back to search view` from the Repo Page should take us back to the search results
6. Click on the file path in the second search result should open the remote file
7. Check for the page title to see if the remote file is opened accordingly
8. After each test is completed, we will close the remote file panel and the search panel with `afterEach(async () => {})`

![image](https://user-images.githubusercontent.com/68532117/164332776-13a07c8a-f3ea-4538-b2b3-58702c70b8af.png)


## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

See above
