### PR TITLE
compute: enrich MatchContext with simple repo information

### DIFF
--- a/enterprise/internal/compute/match_context_result.go
+++ b/enterprise/internal/compute/match_context_result.go
@@ -34,10 +34,10 @@ type Match struct {
 }
 
 type MatchContext struct {
-	Matches    []Match `json:"matches"`
-	Path       string  `json:"path"`
-	RepoID     int32   `json:"repositoryID"`
-	Repository string  `json:"repository"`
+	Matches      []Match `json:"matches"`
+	Path         string  `json:"path"`
+	RepositoryID int32   `json:"repositoryID"`
+	Repository   string  `json:"repository"`
 }
 
 func newLocation(line, column, offset int) Location {

--- a/enterprise/internal/compute/match_context_result.go
+++ b/enterprise/internal/compute/match_context_result.go
@@ -34,8 +34,10 @@ type Match struct {
 }
 
 type MatchContext struct {
-	Matches []Match `json:"matches"`
-	Path    string  `json:"path"`
+	Matches    []Match `json:"matches"`
+	Path       string  `json:"path"`
+	RepoID     int32   `json:"repositoryID"`
+	Repository string  `json:"repository"`
 }
 
 func newLocation(line, column, offset int) Location {

--- a/enterprise/internal/compute/match_only_command.go
+++ b/enterprise/internal/compute/match_only_command.go
@@ -76,7 +76,7 @@ func matchOnly(fm *result.FileMatch, r *regexp.Regexp) *MatchContext {
 			matches = append(matches, fromRegexpMatches(submatches, r.SubexpNames(), l.Preview, int(l.LineNumber)))
 		}
 	}
-	return &MatchContext{Matches: matches, Path: fm.Path}
+	return &MatchContext{Matches: matches, Path: fm.Path, RepoID: int32(fm.Repo.ID), Repository: string(fm.Repo.Name)}
 }
 
 func (c *MatchOnly) Run(_ context.Context, db database.DB, r result.Match) (Result, error) {

--- a/enterprise/internal/compute/match_only_command.go
+++ b/enterprise/internal/compute/match_only_command.go
@@ -76,7 +76,7 @@ func matchOnly(fm *result.FileMatch, r *regexp.Regexp) *MatchContext {
 			matches = append(matches, fromRegexpMatches(submatches, r.SubexpNames(), l.Preview, int(l.LineNumber)))
 		}
 	}
-	return &MatchContext{Matches: matches, Path: fm.Path, RepoID: int32(fm.Repo.ID), Repository: string(fm.Repo.Name)}
+	return &MatchContext{Matches: matches, Path: fm.Path, RepositoryID: int32(fm.Repo.ID), Repository: string(fm.Repo.Name)}
 }
 
 func (c *MatchOnly) Run(_ context.Context, db database.DB, r result.Match) (Result, error) {

--- a/enterprise/internal/compute/match_only_command_test.go
+++ b/enterprise/internal/compute/match_only_command_test.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/sourcegraph/sourcegraph/internal/types"
+
 	"github.com/grafana/regexp"
 	"github.com/hexops/autogold"
 
@@ -28,7 +30,10 @@ func environment(r *MatchContext) interface{} {
 
 func Test_matchOnly(t *testing.T) {
 	data := &result.FileMatch{
-		File: result.File{Path: "bedge"},
+		File: result.File{Path: "bedge", Repo: types.MinimalRepo{
+			ID:   5,
+			Name: "codehost.com/myorg/myrepo",
+		}},
 		LineMatches: []*result.LineMatch{
 			{
 				Preview:    "abcdefgh",
@@ -46,7 +51,9 @@ func Test_matchOnly(t *testing.T) {
 
 	autogold.Want("compute regexp submatch empty environment", `{
   "matches": [],
-  "path": "bedge"
+  "path": "bedge",
+  "repositoryID": 5,
+  "repository": "codehost.com/myorg/myrepo"
 }`).Equal(t, test("nothing", match))
 
 	autogold.Want("compute named regexp submatch", `{
@@ -136,7 +143,9 @@ func Test_matchOnly(t *testing.T) {
       }
     }
   ],
-  "path": "bedge"
+  "path": "bedge",
+  "repositoryID": 5,
+  "repository": "codehost.com/myorg/myrepo"
 }`).Equal(t, test("a(b(c))(de)f(g)h", match))
 
 	autogold.Want("compute regexp submatch includes all matches on line", `{
@@ -206,7 +215,9 @@ func Test_matchOnly(t *testing.T) {
       }
     }
   ],
-  "path": "bedge"
+  "path": "bedge",
+  "repositoryID": 5,
+  "repository": "codehost.com/myorg/myrepo"
 }`).Equal(t, test("([ag])", match))
 
 }


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/34228

Enrich the compute stream API MatchContext result with simple repository information (repository ID and repository name)

## Test plan
Here's an example event from the stream running locally
```
event: results
data: [{"matches":[{"value":"Historical","range":{"start":{"offset":-1,"line":6,"column":7},"end":{"offset":-1,"line":6,"column":17}},"environment":{"1":{"value":"Historical","range":{"start":{"offset":-1,"line":6,"column":7},"end":{"offset":-1,"line":6,"column":17}}}}}],"path":"enterprise/internal/insights/store/testdata/TestFindMatchingSeries/find_a_matching_series_when_one_exists.golden","repositoryID":11,"repository":"github.com/sourcegraph/sourcegraph"},{"matches":[{"value":"Historical","range":{"start":{"offset":-1,"line":6,"column":7},"end":{"offset":-1,"line":6,"column":17}},"environment":{"1":{"value":"Historical","range":{"start":{"offset":-1,"line":6,"column":7},"end":{"offset":-1,"line":6,"column":17}}}}}],"path":"enterprise/internal/insights/background/queryrunner/testdata/TestGetSeries/series_definition_does_exist.golden","repositoryID":11,"repository":"github.com/sourcegraph/sourcegraph"},{"matches":[{"value":"Historical","range":{"start":{"offset":-1,"line":6,"column":7},"end":{"offset":-1,"line":6,"column":17}},"environment":{"1":{"value":"Historical","range":{"start":{"offset":-1,"line":6,"column":7},"end":{"offset":-1,"line":6,"column":17}}}}}],"path":"enterprise/internal/insights/store/testdata/TestFindMatchingSeries/match_capture_group_series.golden","repositoryID":11,"repository":"github.com/sourcegraph/sourcegraph"},{"matches":[{"value":"Historical","range":{"start":{"offset":-1,"line":5,"column":7},"end":{"offset":-1,"line":5,"column":17}},"environment":{"1":{"value":"Historical","range":{"start":{"offset":-1,"line":5,"column":7},"end":{"offset":-1,"line":5,"column":17}}}}}],"path":"enterprise/internal/insights/store/testdata/TestCreateSeries/test_create_and_get_capture_groups_series.golden","repositoryID":11,"repository":"github.com/sourcegraph/sourcegraph"},{"matches":[{"value":"Historical","range":{"start":{"offset":-1,"line":8,"column":7},"end":{"offset":-1,"line":8,"column":17}},"environment":{"1":{"value":"Historical","range":{"start":{"offset":-1,"line":8,"column":7},"end":{"offset":-1,"line":8,"column":17}}}}}],"path":"enterprise/internal/insights/store/testdata/TestCreateGetView_WithGrants/no_users_or_orgs_provided_should_only_return_global.golden","repositoryID":11,"repository":"github.com/sourcegraph/sourcegraph"},{"matches":[{"value":"Historical","range":{"start":{"offset":-1,"line":8,"column":7},"end":{"offset":-1,"line":8,"column":17}},"environment":{"1":{"value":"Historical","range":{"start":{"offset":-1,"line":8,"column":7},"end":{"offset":-1,"line":8,"column":17}}}}}],"path":"enterprise/internal/insights/store/testdata/TestCreateGetView_WithGrants/org_5_can_see_the_view.golden","repositoryID":11,"repository":"github.com/sourcegraph/sourcegraph"},{"matches":[{"value":"Historical","range":{"start":{"offset":-1,"line":8,"column":7},"end":{"offset":-1,"line":8,"column":17}},"environment":{"1":{"value":"Historical","range":{"start":{"offset":-1,"line":8,"column":7},"end":{"offset":-1,"line":8,"column":17}}}}}],"path":"enterprise/internal/insights/store/testdata/TestCreateGetView_WithGrants/user_1_can_see_this_view.golden","repositoryID":11,"repository":"github.com/sourcegraph/sourcegraph"}]
```

