### PR TITLE
Fix spinner appearance when non-validation errors occur

### DIFF
--- a/client/web/src/enterprise/batches/create/CreateOrEditBatchChangePage.tsx
+++ b/client/web/src/enterprise/batches/create/CreateOrEditBatchChangePage.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useMemo, useState } from 'react'
 
 import { ApolloQueryResult } from '@apollo/client'
 import classNames from 'classnames'
-import { compact, noop } from 'lodash'
+import { noop } from 'lodash'
 import AlertCircleIcon from 'mdi-react/AlertCircleIcon'
 import InfoCircleOutlineIcon from 'mdi-react/InfoCircleOutlineIcon'
 import LockIcon from 'mdi-react/LockIcon'
@@ -499,10 +499,10 @@ const EditPage: React.FunctionComponent<EditPageProps> = ({ batchChange, refetch
                     />
                     <EditorFeedbackPanel
                         errors={{
-                          codeUpdate: codeErrors.update,
-                          codeValidation: codeErrors.validation,
-                          preview: previewError,
-                          execute: executeError
+                            codeUpdate: codeErrors.update,
+                            codeValidation: codeErrors.validation,
+                            preview: previewError,
+                            execute: executeError,
                         }}
                     />
 

--- a/client/web/src/enterprise/batches/create/CreateOrEditBatchChangePage.tsx
+++ b/client/web/src/enterprise/batches/create/CreateOrEditBatchChangePage.tsx
@@ -479,6 +479,8 @@ const EditPage: React.FunctionComponent<EditPageProps> = ({ batchChange, refetch
         </>
     )
 
+    const isValidationError = Boolean(codeErrors.validation)
+
     return (
         <BatchChangePage
             namespace={batchChange.namespace}
@@ -498,6 +500,7 @@ const EditPage: React.FunctionComponent<EditPageProps> = ({ batchChange, refetch
                         onChange={clearErrorsAndHandleCodeChange}
                     />
                     <EditorFeedbackPanel
+                        isValidationError={isValidationError}
                         errors={compact([codeErrors.update, codeErrors.validation, previewError, executeError])}
                     />
 

--- a/client/web/src/enterprise/batches/create/CreateOrEditBatchChangePage.tsx
+++ b/client/web/src/enterprise/batches/create/CreateOrEditBatchChangePage.tsx
@@ -498,8 +498,12 @@ const EditPage: React.FunctionComponent<EditPageProps> = ({ batchChange, refetch
                         onChange={clearErrorsAndHandleCodeChange}
                     />
                     <EditorFeedbackPanel
-                        isValidationError={codeErrors.validation}
-                        errors={compact([codeErrors.update, codeErrors.validation, previewError, executeError])}
+                        errors={{
+                          codeUpdate: codeErrors.update,
+                          codeValidation: codeErrors.validation,
+                          preview: previewError,
+                          execute: executeError
+                        }}
                     />
 
                     {isDownloadSpecModalOpen && !downloadSpecModalDismissed ? (

--- a/client/web/src/enterprise/batches/create/CreateOrEditBatchChangePage.tsx
+++ b/client/web/src/enterprise/batches/create/CreateOrEditBatchChangePage.tsx
@@ -479,8 +479,6 @@ const EditPage: React.FunctionComponent<EditPageProps> = ({ batchChange, refetch
         </>
     )
 
-    const isValidationError = Boolean(codeErrors.validation)
-
     return (
         <BatchChangePage
             namespace={batchChange.namespace}
@@ -500,7 +498,7 @@ const EditPage: React.FunctionComponent<EditPageProps> = ({ batchChange, refetch
                         onChange={clearErrorsAndHandleCodeChange}
                     />
                     <EditorFeedbackPanel
-                        isValidationError={isValidationError}
+                        isValidationError={codeErrors.validation}
                         errors={compact([codeErrors.update, codeErrors.validation, previewError, executeError])}
                     />
 

--- a/client/web/src/enterprise/batches/create/editor/EditorFeedbackPanel.tsx
+++ b/client/web/src/enterprise/batches/create/editor/EditorFeedbackPanel.tsx
@@ -8,7 +8,12 @@ import { Icon } from '@sourcegraph/wildcard'
 
 import styles from './EditorFeedbackPanel.module.scss'
 
-export const EditorFeedbackPanel: React.FunctionComponent<{ errors: (string | Error)[] }> = ({ errors }) => {
+interface EditorFeedbackPanelProps {
+    errors: (string | Error)[]
+    isValidationError: boolean
+}
+
+export const EditorFeedbackPanel: React.FunctionComponent<EditorFeedbackPanelProps> = ({ errors, isValidationError }) => {
     if (errors.length === 0) {
         return null
     }
@@ -16,7 +21,7 @@ export const EditorFeedbackPanel: React.FunctionComponent<{ errors: (string | Er
     return (
         <div className={classNames(styles.panel, 'rounded border bg-1 p-2 w-100 mt-2')}>
             <h4 className="text-danger text-uppercase">
-                <Icon className="text-danger" as={AlertCircleIcon} /> Validation Errors
+                <Icon className="text-danger" as={AlertCircleIcon} /> {isValidationError ? 'Validation Errors' : 'Errors found'}
             </h4>
             {errors.map(error => (
                 <ErrorMessage className="text-monospace" error={error} key={String(error)} />

--- a/client/web/src/enterprise/batches/create/editor/EditorFeedbackPanel.tsx
+++ b/client/web/src/enterprise/batches/create/editor/EditorFeedbackPanel.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 
 import classNames from 'classnames'
+import { compact } from 'lodash'
 import AlertCircleIcon from 'mdi-react/AlertCircleIcon'
 
 import { ErrorMessage } from '@sourcegraph/branded/src/components/alerts'
@@ -9,25 +10,28 @@ import { Icon } from '@sourcegraph/wildcard'
 import styles from './EditorFeedbackPanel.module.scss'
 
 interface EditorFeedbackPanelProps {
-    errors: (string | Error)[]
-    isValidationError: boolean
+    errors: {
+        codeUpdate: string | Error | undefined
+        codeValidation: string | Error | undefined
+        preview: string | Error | undefined
+        execute: string | Error | undefined
+    }
 }
 
-export const EditorFeedbackPanel: React.FunctionComponent<EditorFeedbackPanelProps> = ({
-    errors,
-    isValidationError,
-}) => {
-    if (errors.length === 0) {
+export const EditorFeedbackPanel: React.FunctionComponent<EditorFeedbackPanelProps> = ({ errors }) => {
+    const compactedErrors = compact(Object.values(errors))
+    if (compactedErrors.length === 0) {
         return null
     }
+
+    const errorHeading = errors.codeValidation ? 'Validation Errors' : 'Errors found'
 
     return (
         <div className={classNames(styles.panel, 'rounded border bg-1 p-2 w-100 mt-2')}>
             <h4 className="text-danger text-uppercase">
-                <Icon className="text-danger" as={AlertCircleIcon} />{' '}
-                {isValidationError ? 'Validation Errors' : 'Errors found'}
+                <Icon className="text-danger" as={AlertCircleIcon} /> {errorHeading}
             </h4>
-            {errors.map(error => (
+            {compactedErrors.map(error => (
                 <ErrorMessage className="text-monospace" error={error} key={String(error)} />
             ))}
         </div>

--- a/client/web/src/enterprise/batches/create/editor/EditorFeedbackPanel.tsx
+++ b/client/web/src/enterprise/batches/create/editor/EditorFeedbackPanel.tsx
@@ -13,7 +13,10 @@ interface EditorFeedbackPanelProps {
     isValidationError: boolean
 }
 
-export const EditorFeedbackPanel: React.FunctionComponent<EditorFeedbackPanelProps> = ({ errors, isValidationError }) => {
+export const EditorFeedbackPanel: React.FunctionComponent<EditorFeedbackPanelProps> = ({
+    errors,
+    isValidationError,
+}) => {
     if (errors.length === 0) {
         return null
     }
@@ -21,7 +24,8 @@ export const EditorFeedbackPanel: React.FunctionComponent<EditorFeedbackPanelPro
     return (
         <div className={classNames(styles.panel, 'rounded border bg-1 p-2 w-100 mt-2')}>
             <h4 className="text-danger text-uppercase">
-                <Icon className="text-danger" as={AlertCircleIcon} /> {isValidationError ? 'Validation Errors' : 'Errors found'}
+                <Icon className="text-danger" as={AlertCircleIcon} />{' '}
+                {isValidationError ? 'Validation Errors' : 'Errors found'}
             </h4>
             {errors.map(error => (
                 <ErrorMessage className="text-monospace" error={error} key={String(error)} />

--- a/client/web/src/enterprise/batches/create/useWorkspacesPreview.ts
+++ b/client/web/src/enterprise/batches/create/useWorkspacesPreview.ts
@@ -182,8 +182,10 @@ export const useWorkspacesPreview = (
                         .catch((error: Error) => setError(error.message))
                     startPolling(POLLING_INTERVAL)
                 })
-                .catch((error: Error) => setError(error.message))
-                .finally(() => setIsInProgress(false))
+                .catch((error: Error) => {
+                    setError(error.message)
+                    setIsInProgress(false)
+                })
         },
         [
             batchSpecID,

--- a/client/web/src/enterprise/batches/create/useWorkspacesPreview.ts
+++ b/client/web/src/enterprise/batches/create/useWorkspacesPreview.ts
@@ -183,6 +183,7 @@ export const useWorkspacesPreview = (
                     startPolling(POLLING_INTERVAL)
                 })
                 .catch((error: Error) => setError(error.message))
+                .finally(() => setIsInProgress(false))
         },
         [
             batchSpecID,


### PR DESCRIPTION

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

1. Trigger a batch spec preview execution error
2. The spinner should disappear once preview execution is complete

## App preview:

- [Link](https://sg-web-bo-spinner-on-batch-spec.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-phjsyevqlw.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
