### PR TITLE
RFC 619: (M1) Generate autoindexing service graphql transport skeleton

### DIFF
--- a/internal/codeintel/autoindexing/transport/graphql/init.go
+++ b/internal/codeintel/autoindexing/transport/graphql/init.go
@@ -1,0 +1,32 @@
+package graphql
+
+import (
+	"sync"
+
+	"github.com/inconshreveable/log15"
+	"github.com/opentracing/opentracing-go"
+	"github.com/prometheus/client_golang/prometheus"
+
+	autoindexing "github.com/sourcegraph/sourcegraph/internal/codeintel/autoindexing"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
+	"github.com/sourcegraph/sourcegraph/internal/trace"
+)
+
+var (
+	resolver     *Resolver
+	resolverOnce sync.Once
+)
+
+func GetResolver(svc *autoindexing.Service) *Resolver {
+	resolverOnce.Do(func() {
+		observationContext := &observation.Context{
+			Logger:     log15.Root(),
+			Tracer:     &trace.Tracer{Tracer: opentracing.GlobalTracer()},
+			Registerer: prometheus.DefaultRegisterer,
+		}
+
+		resolver = newResolver(svc, observationContext)
+	})
+
+	return resolver
+}

--- a/internal/codeintel/autoindexing/transport/graphql/observability.go
+++ b/internal/codeintel/autoindexing/transport/graphql/observability.go
@@ -1,0 +1,33 @@
+package graphql
+
+import (
+	"fmt"
+
+	"github.com/sourcegraph/sourcegraph/internal/metrics"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
+)
+
+type operations struct {
+	todo *observation.Operation
+}
+
+func newOperations(observationContext *observation.Context) *operations {
+	metrics := metrics.NewREDMetrics(
+		observationContext.Registerer,
+		"codeintel_autoindexing_transport_graphql",
+		metrics.WithLabels("op"),
+		metrics.WithCountHelp("Total number of method invocations."),
+	)
+
+	op := func(name string) *observation.Operation {
+		return observationContext.Operation(observation.Op{
+			Name:              fmt.Sprintf("codeintel.autoindexing.transport.graphql.%s", name),
+			MetricLabelValues: []string{name},
+			Metrics:           metrics,
+		})
+	}
+
+	return &operations{
+		todo: op("Todo"),
+	}
+}

--- a/internal/codeintel/autoindexing/transport/graphql/resolver.go
+++ b/internal/codeintel/autoindexing/transport/graphql/resolver.go
@@ -1,0 +1,28 @@
+package graphql
+
+import (
+	"context"
+
+	autoindexing "github.com/sourcegraph/sourcegraph/internal/codeintel/autoindexing"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
+)
+
+type Resolver struct {
+	svc        *autoindexing.Service
+	operations *operations
+}
+
+func newResolver(svc *autoindexing.Service, observationContext *observation.Context) *Resolver {
+	return &Resolver{
+		svc:        svc,
+		operations: newOperations(observationContext),
+	}
+}
+
+func (r *Resolver) Todo(ctx context.Context) (err error) {
+	ctx, endObservation := r.operations.todo.With(ctx, &err, observation.Args{})
+	defer endObservation(1, observation.Args{})
+
+	// TODO
+	return r.svc.Delete(ctx, 20)
+}


### PR DESCRIPTION
Generate an empty (as possible) autoindexing service graphql resolver as defined by [RFC 619: Code Intelligence Data Platform](https://docs.google.com/document/d/1AjZ_d0nJVHbV75IH3jZRkrGXhsv_AXp2kS4nrw2SAQ8).

Partially covers https://github.com/sourcegraph/sourcegraph/issues/33372.
Originally drafted in https://github.com/sourcegraph/sourcegraph/pull/32473.
Stacked on/blocked by https://github.com/sourcegraph/sourcegraph/pull/33614.

## Test plan

N/A - all code is new and no-op'd.