### PR TITLE
RFC 619: (M1) Generate documents service graphql transport skeleton

### DIFF
--- a/internal/codeintel/documents/transport/graphql/init.go
+++ b/internal/codeintel/documents/transport/graphql/init.go
@@ -1,0 +1,32 @@
+package graphql
+
+import (
+	"sync"
+
+	"github.com/opentracing/opentracing-go"
+	"github.com/prometheus/client_golang/prometheus"
+
+	documents "github.com/sourcegraph/sourcegraph/internal/codeintel/documents"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
+	"github.com/sourcegraph/sourcegraph/internal/trace"
+	"github.com/sourcegraph/sourcegraph/lib/log"
+)
+
+var (
+	resolver     *Resolver
+	resolverOnce sync.Once
+)
+
+func GetResolver(svc *documents.Service) *Resolver {
+	resolverOnce.Do(func() {
+		observationContext := &observation.Context{
+			Logger:     log.Scoped("documents.transport.graphql", "codeintel documents graphql transport"),
+			Tracer:     &trace.Tracer{Tracer: opentracing.GlobalTracer()},
+			Registerer: prometheus.DefaultRegisterer,
+		}
+
+		resolver = newResolver(svc, observationContext)
+	})
+
+	return resolver
+}

--- a/internal/codeintel/documents/transport/graphql/observability.go
+++ b/internal/codeintel/documents/transport/graphql/observability.go
@@ -1,0 +1,33 @@
+package graphql
+
+import (
+	"fmt"
+
+	"github.com/sourcegraph/sourcegraph/internal/metrics"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
+)
+
+type operations struct {
+	document *observation.Operation
+}
+
+func newOperations(observationContext *observation.Context) *operations {
+	metrics := metrics.NewREDMetrics(
+		observationContext.Registerer,
+		"codeintel_documents_transport_graphql",
+		metrics.WithLabels("op"),
+		metrics.WithCountHelp("Total number of method invocations."),
+	)
+
+	op := func(name string) *observation.Operation {
+		return observationContext.Operation(observation.Op{
+			Name:              fmt.Sprintf("codeintel.documents.transport.graphql.%s", name),
+			MetricLabelValues: []string{name},
+			Metrics:           metrics,
+		})
+	}
+
+	return &operations{
+		document: op("Document"),
+	}
+}

--- a/internal/codeintel/documents/transport/graphql/resolver.go
+++ b/internal/codeintel/documents/transport/graphql/resolver.go
@@ -1,0 +1,30 @@
+package graphql
+
+import (
+	"context"
+
+	documents "github.com/sourcegraph/sourcegraph/internal/codeintel/documents"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+type Resolver struct {
+	svc        *documents.Service
+	operations *operations
+}
+
+func newResolver(svc *documents.Service, observationContext *observation.Context) *Resolver {
+	return &Resolver{
+		svc:        svc,
+		operations: newOperations(observationContext),
+	}
+}
+
+func (r *Resolver) Document(ctx context.Context, args struct{}) (_ interface{}, err error) {
+	ctx, _, endObservation := r.operations.document.With(ctx, &err, observation.Args{})
+	defer endObservation(1, observation.Args{})
+
+	// To be implemented in https://github.com/sourcegraph/sourcegraph/issues/33373
+	_, _ = ctx, args
+	return nil, errors.New("unimplemented: Document")
+}


### PR DESCRIPTION
Generate an empty (as possible) documents service graphql resolver as defined by [RFC 619: Code Intelligence Data Platform](https://docs.google.com/document/d/1AjZ_d0nJVHbV75IH3jZRkrGXhsv_AXp2kS4nrw2SAQ8).

Partially covers https://github.com/sourcegraph/sourcegraph/issues/33372.
Originally drafted in https://github.com/sourcegraph/sourcegraph/pull/32473.
Stacked on/blocked by https://github.com/sourcegraph/sourcegraph/pull/33612.

## Test plan

N/A - all code is new and no-op'd.