### PR TITLE
batches: execution screen polish

### DIFF
--- a/client/web/src/enterprise/batches/create/CreateOrEditBatchChangePage.module.scss
+++ b/client/web/src/enterprise/batches/create/CreateOrEditBatchChangePage.module.scss
@@ -40,6 +40,7 @@
     margin-bottom: 0.5rem;
     border-bottom: 1px solid var(--border-color);
     overflow: hidden;
+    flex-shrink: 0;
 }
 
 .download-link {

--- a/client/web/src/enterprise/batches/create/CreateOrEditBatchChangePage.module.scss
+++ b/client/web/src/enterprise/batches/create/CreateOrEditBatchChangePage.module.scss
@@ -27,7 +27,6 @@
     margin-left: 1rem;
     background: none;
     border: none;
-    width: 100%;
 }
 
 // Should mostly match WorkspacesPreview header and LibraryPane header

--- a/client/web/src/enterprise/batches/create/CreateOrEditBatchChangePage.tsx
+++ b/client/web/src/enterprise/batches/create/CreateOrEditBatchChangePage.tsx
@@ -512,28 +512,31 @@ const EditPage: React.FunctionComponent<EditPageProps> = ({ batchChange, refetch
                     ) : null}
                 </div>
                 <Panel
+                    className="d-flex"
                     defaultSize={500}
                     minSize={405}
                     maxSize={1400}
                     position="right"
                     storageKey={WORKSPACES_PREVIEW_SIZE}
                 >
-                    <div className={styles.workspacesPreviewContainer}>
-                        <WorkspacesPreview
-                            previewDisabled={previewDisabled}
-                            preview={() => previewBatchSpec(debouncedCode)}
-                            batchSpecStale={
-                                isBatchSpecStale || isWorkspacesPreviewInProgress || resolutionState === 'CANCELED'
-                            }
-                            hasPreviewed={hasPreviewed}
-                            excludeRepo={excludeRepo}
-                            cancel={cancel}
-                            isWorkspacesPreviewInProgress={isWorkspacesPreviewInProgress}
-                            resolutionState={resolutionState}
-                            workspacesConnection={workspacesConnection}
-                            importingChangesetsConnection={importingChangesetsConnection}
-                            setFilters={setFilters}
-                        />
+                    <div className="overflow-auto">
+                        <div className={styles.workspacesPreviewContainer}>
+                            <WorkspacesPreview
+                                previewDisabled={previewDisabled}
+                                preview={() => previewBatchSpec(debouncedCode)}
+                                batchSpecStale={
+                                    isBatchSpecStale || isWorkspacesPreviewInProgress || resolutionState === 'CANCELED'
+                                }
+                                hasPreviewed={hasPreviewed}
+                                excludeRepo={excludeRepo}
+                                cancel={cancel}
+                                isWorkspacesPreviewInProgress={isWorkspacesPreviewInProgress}
+                                resolutionState={resolutionState}
+                                workspacesConnection={workspacesConnection}
+                                importingChangesetsConnection={importingChangesetsConnection}
+                                setFilters={setFilters}
+                            />
+                        </div>
                     </div>
                 </Panel>
             </div>

--- a/client/web/src/enterprise/batches/create/library/LibraryPane.module.scss
+++ b/client/web/src/enterprise/batches/create/library/LibraryPane.module.scss
@@ -38,6 +38,7 @@
     margin-bottom: 0.5rem;
     border-bottom: 1px solid var(--border-color);
     overflow: hidden;
+    flex-shrink: 0;
 }
 
 .last-item {

--- a/client/web/src/enterprise/batches/create/library/LibraryPane.module.scss
+++ b/client/web/src/enterprise/batches/create/library/LibraryPane.module.scss
@@ -1,7 +1,7 @@
 .list-container {
     margin: 0;
     padding: 0;
-    // Match this to the value in JS
+    // Match this to the `CONTENT_WIDTH` value in JS
     width: 14rem;
 }
 
@@ -42,4 +42,6 @@
 
 .last-item {
     margin-top: 1rem;
+    // Match this to the `CONTENT_WIDTH` value in JS
+    width: 14rem;
 }

--- a/client/web/src/enterprise/batches/create/workspaces-preview/WorkspacesPreviewFilterRow.tsx
+++ b/client/web/src/enterprise/batches/create/workspaces-preview/WorkspacesPreviewFilterRow.tsx
@@ -50,8 +50,8 @@ export const WorkspacePreviewFilterRow: React.FunctionComponent<WorkspacePreview
     )
 
     return (
-        <div className="w-100 row mr-1">
-            <div className="m-0 col">
+        <div className="w-100 row">
+            <div className="m-0 p-0 col">
                 <Form className="d-flex mb-2" onSubmit={onSubmit}>
                     <Input
                         disabled={disabled}

--- a/client/web/src/enterprise/batches/execution/BatchSpecExecutionDetailsPage.module.scss
+++ b/client/web/src/enterprise/batches/execution/BatchSpecExecutionDetailsPage.module.scss
@@ -9,3 +9,15 @@
     // instead.
     min-height: 0;
 }
+
+.workspaces-stat {
+    color: var(--text-muted);
+    margin: 0 0.5rem;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+
+    svg {
+        height: 1.25rem;
+    }
+}

--- a/client/web/src/enterprise/batches/execution/BatchSpecExecutionDetailsPage.tsx
+++ b/client/web/src/enterprise/batches/execution/BatchSpecExecutionDetailsPage.tsx
@@ -455,13 +455,19 @@ const SelectedWorkspace: React.FunctionComponent<SelectedWorkspaceProps> = ({
     isLightTheme,
 }) => (
     <Card className="w-100 overflow-auto flex-grow-1">
-        <CardBody>
-            {workspace ? (
-                <WorkspaceDetails id={workspace} isLightTheme={isLightTheme} deselectWorkspace={deselectWorkspace} />
-            ) : (
-                <h3 className="text-center my-3">Select a workspace to view details.</h3>
-            )}
-        </CardBody>
+        <div className="w-100">
+            <CardBody>
+                {workspace ? (
+                    <WorkspaceDetails
+                        id={workspace}
+                        isLightTheme={isLightTheme}
+                        deselectWorkspace={deselectWorkspace}
+                    />
+                ) : (
+                    <h3 className="text-center my-3">Select a workspace to view details.</h3>
+                )}
+            </CardBody>
+        </div>
     </Card>
 )
 

--- a/client/web/src/enterprise/batches/execution/BatchSpecExecutionDetailsPage.tsx
+++ b/client/web/src/enterprise/batches/execution/BatchSpecExecutionDetailsPage.tsx
@@ -2,12 +2,17 @@ import React, { useCallback, useState } from 'react'
 
 import classNames from 'classnames'
 import AlertCircleIcon from 'mdi-react/AlertCircleIcon'
+import CheckBoldIcon from 'mdi-react/CheckBoldIcon'
+import CircleOffOutlineIcon from 'mdi-react/CircleOffOutlineIcon'
 import MapSearchIcon from 'mdi-react/MapSearchIcon'
+import ProgressClockIcon from 'mdi-react/ProgressClockIcon'
+import TimelineClockOutlineIcon from 'mdi-react/TimelineClockOutlineIcon'
+import TimerSandIcon from 'mdi-react/TimerSandIcon'
 import { Redirect, Route, RouteComponentProps, Switch, useHistory, useLocation } from 'react-router'
 import { NavLink as RouterLink } from 'react-router-dom'
 
 import { ErrorAlert } from '@sourcegraph/branded/src/components/alerts'
-import { asError, isErrorLike } from '@sourcegraph/common'
+import { asError, isErrorLike, pluralize } from '@sourcegraph/common'
 import { useQuery } from '@sourcegraph/http-client'
 import { LinkOrSpan } from '@sourcegraph/shared/src/components/LinkOrSpan'
 import { BatchSpecState } from '@sourcegraph/shared/src/graphql-operations'
@@ -230,34 +235,41 @@ const BatchSpecActions: React.FunctionComponent<BatchSpecActionsProps> = ({ batc
         }
     }, [batchSpec.id])
 
+    const workspacesStats = batchSpec.workspaceResolution?.workspaces.stats
+
     return (
         <div className="d-flex">
             <span className="align-self-center mr-2">
                 <BatchSpecStateBadge state={batchSpec.state} />
             </span>
             {batchSpec.startedAt && (
-                <div className="mx-2 text-center text-muted">
-                    <h3>
-                        <Duration start={batchSpec.startedAt} end={batchSpec.finishedAt ?? undefined} />
-                    </h3>
-                    Total time
+                <div className={styles.workspacesStat}>
+                    <ProgressClockIcon />
+                    <Duration start={batchSpec.startedAt} end={batchSpec.finishedAt ?? undefined} />
                 </div>
             )}
-            {batchSpec.workspaceResolution?.workspaces.stats && (
+            {workspacesStats && (
                 <>
-                    <WorkspaceStat
-                        stat={batchSpec.workspaceResolution.workspaces.stats.errored}
-                        label="Errors"
-                        iconClassName="text-danger"
-                    />
-                    <WorkspaceStat
-                        stat={batchSpec.workspaceResolution.workspaces.stats.completed}
-                        label="Complete"
-                        iconClassName="text-success"
-                    />
-                    <WorkspaceStat stat={batchSpec.workspaceResolution.workspaces.stats.processing} label="Working" />
-                    <WorkspaceStat stat={batchSpec.workspaceResolution.workspaces.stats.queued} label="Queued" />
-                    <WorkspaceStat stat={batchSpec.workspaceResolution.workspaces.stats.ignored} label="Ignored" />
+                    <div className={styles.workspacesStat}>
+                        <AlertCircleIcon className="text-danger" />
+                        {workspacesStats.errored} {pluralize('error', workspacesStats.errored)}
+                    </div>
+                    <div className={styles.workspacesStat}>
+                        <CheckBoldIcon className="text-success" />
+                        {workspacesStats.completed} complete
+                    </div>
+                    <div className={styles.workspacesStat}>
+                        <TimerSandIcon />
+                        {workspacesStats.processing} working
+                    </div>
+                    <div className={styles.workspacesStat}>
+                        <TimelineClockOutlineIcon />
+                        {workspacesStats.queued} queued{' '}
+                    </div>
+                    <div className={styles.workspacesStat}>
+                        <CircleOffOutlineIcon />
+                        {workspacesStats.ignored} ignored{' '}
+                    </div>
                 </>
             )}
             <span>
@@ -323,17 +335,6 @@ const BatchSpecActions: React.FunctionComponent<BatchSpecActionsProps> = ({ batc
         </div>
     )
 }
-
-const WorkspaceStat: React.FunctionComponent<{ stat: number; label: string; iconClassName?: string }> = ({
-    stat,
-    label,
-    iconClassName,
-}) => (
-    <div className="mx-2 text-center text-muted">
-        <h3 className={iconClassName}>{stat}</h3>
-        {label}
-    </div>
-)
 
 interface EditPageProps extends ThemeProps {
     name: string

--- a/client/web/src/enterprise/batches/execution/BatchSpecExecutionDetailsPage.tsx
+++ b/client/web/src/enterprise/batches/execution/BatchSpecExecutionDetailsPage.tsx
@@ -251,23 +251,23 @@ const BatchSpecActions: React.FunctionComponent<BatchSpecActionsProps> = ({ batc
             {workspacesStats && (
                 <>
                     <div className={styles.workspacesStat}>
-                        <AlertCircleIcon className="text-danger" />
+                        <Icon as={AlertCircleIcon} className="text-danger" />
                         {workspacesStats.errored} {pluralize('error', workspacesStats.errored)}
                     </div>
                     <div className={styles.workspacesStat}>
-                        <CheckBoldIcon className="text-success" />
+                        <Icon as={CheckBoldIcon} className="text-success" />
                         {workspacesStats.completed} complete
                     </div>
                     <div className={styles.workspacesStat}>
-                        <TimerSandIcon />
+                        <Icon as={TimerSandIcon} />
                         {workspacesStats.processing} working
                     </div>
                     <div className={styles.workspacesStat}>
-                        <TimelineClockOutlineIcon />
+                        <Icon as={TimelineClockOutlineIcon} />
                         {workspacesStats.queued} queued{' '}
                     </div>
                     <div className={styles.workspacesStat}>
-                        <CircleOffOutlineIcon />
+                        <Icon as={CircleOffOutlineIcon} />
                         {workspacesStats.ignored} ignored{' '}
                     </div>
                 </>
@@ -329,6 +329,7 @@ const BatchSpecActions: React.FunctionComponent<BatchSpecActionsProps> = ({ batc
                             </Button>
                         )}
                 </ButtonGroup>
+                {/* TODO: Move me out to main page */}
                 {isErrorLike(isCanceling) && <ErrorAlert error={isCanceling} />}
                 {isErrorLike(isRetrying) && <ErrorAlert error={isRetrying} />}
             </span>

--- a/client/web/src/enterprise/batches/execution/BatchSpecExecutionDetailsPage.tsx
+++ b/client/web/src/enterprise/batches/execution/BatchSpecExecutionDetailsPage.tsx
@@ -264,11 +264,11 @@ const BatchSpecActions: React.FunctionComponent<BatchSpecActionsProps> = ({ batc
                     </div>
                     <div className={styles.workspacesStat}>
                         <Icon as={TimelineClockOutlineIcon} />
-                        {workspacesStats.queued} queued{' '}
+                        {workspacesStats.queued} queued
                     </div>
                     <div className={styles.workspacesStat}>
                         <Icon as={CircleOffOutlineIcon} />
-                        {workspacesStats.ignored} ignored{' '}
+                        {workspacesStats.ignored} ignored
                     </div>
                 </>
             )}
@@ -455,6 +455,7 @@ const SelectedWorkspace: React.FunctionComponent<SelectedWorkspaceProps> = ({
     isLightTheme,
 }) => (
     <Card className="w-100 overflow-auto flex-grow-1">
+        {/* This is necessary to prevent the margin collapse on `Card` */}
         <div className="w-100">
             <CardBody>
                 {workspace ? (

--- a/client/web/src/enterprise/batches/execution/BatchSpecExecutionDetailsPage.tsx
+++ b/client/web/src/enterprise/batches/execution/BatchSpecExecutionDetailsPage.tsx
@@ -279,7 +279,7 @@ const BatchSpecActions: React.FunctionComponent<BatchSpecActionsProps> = ({ batc
                             onClick={cancelExecution}
                             disabled={isCanceling === true}
                             outline={true}
-                            variant="secondary"
+                            variant="danger"
                         >
                             {isCanceling !== true && <>Cancel</>}
                             {isCanceling === true && (

--- a/client/web/src/enterprise/batches/execution/TimelineModal.tsx
+++ b/client/web/src/enterprise/batches/execution/TimelineModal.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo } from 'react'
 
+import VisuallyHidden from '@reach/visually-hidden'
 import AlertCircleIcon from 'mdi-react/AlertCircleIcon'
 import CheckIcon from 'mdi-react/CheckIcon'
 import CloseIcon from 'mdi-react/CloseIcon'
@@ -25,7 +26,8 @@ export const TimelineModal: React.FunctionComponent<TimelineModalProps> = ({ nod
     <Modal className={styles.modalBody} onDismiss={onCancel} aria-label="Execution timeline">
         <div className="d-flex justify-content-between">
             <h3 className="mb-0">Execution timeline</h3>
-            <Button className="p-0 m-0" onClick={onCancel} variant="link" size="sm">
+            <Button className="p-0 ml-2" onClick={onCancel} variant="icon">
+                <VisuallyHidden>Close</VisuallyHidden>
                 <Icon as={CloseIcon} />
             </Button>
         </div>

--- a/client/web/src/enterprise/batches/execution/WorkspaceDetails.module.scss
+++ b/client/web/src/enterprise/batches/execution/WorkspaceDetails.module.scss
@@ -1,8 +1,17 @@
 .workspace-detail {
-    color: var(--text-muted);
     padding: 0 0.375rem;
+    margin: 0;
+    line-height: 1.5rem;
 
-    &:not(:last-of-type) {
+    &:not(button) {
+        color: var(--text-muted);
+    }
+
+    &:first-child {
+        padding-left: 0;
+    }
+
+    &:not(:last-child) {
         border-right: 1px solid var(--border-color);
     }
 }

--- a/client/web/src/enterprise/batches/execution/WorkspaceDetails.module.scss
+++ b/client/web/src/enterprise/batches/execution/WorkspaceDetails.module.scss
@@ -1,16 +1,64 @@
+.workspace-detail {
+    color: var(--text-muted);
+    padding: 0 0.375rem;
+
+    &:not(:last-of-type) {
+        border-right: 1px solid var(--border-color);
+    }
+}
+
 .result-card,
 .step-card {
     background-color: var(--body-bg);
 }
 
-.detail-item {
+.collapsible {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+}
+
+.step-header {
+    display: flex;
+    align-items: center;
+    flex: 1;
+    min-width: 0;
+}
+
+.step-number,
+.result {
     display: inline-block;
-    &:not(:last-child) {
-        &::after {
-            padding: 0 0.375rem;
-            height: 1rem;
-            content: '';
-            border-right: 1px solid var(--border-color-2);
-        }
+    font-weight: normal;
+    white-space: nowrap;
+    margin: 0;
+}
+
+.step-number {
+    margin: 0 0.5rem;
+}
+
+.step-command {
+    min-width: 0;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    font-size: 0.75rem;
+    line-height: 0.75rem;
+}
+
+.step-time {
+    font-size: 0.75rem;
+    line-height: 0.75rem;
+}
+
+.step-diff-stat {
+    border-right: 1px solid var(--border-color);
+    padding: 0 0.5rem;
+    margin: 0 0.5rem;
+
+    strong {
+        line-height: 1rem;
     }
 }

--- a/client/web/src/enterprise/batches/execution/WorkspaceDetails.module.scss
+++ b/client/web/src/enterprise/batches/execution/WorkspaceDetails.module.scss
@@ -1,3 +1,11 @@
+.workspace-name {
+    margin: 0;
+    display: flex;
+    align-items: center;
+    line-height: 1.5rem;
+    gap: 0.25rem;
+}
+
 .workspace-detail {
     padding: 0 0.375rem;
     margin: 0;

--- a/client/web/src/enterprise/batches/execution/WorkspaceDetails.tsx
+++ b/client/web/src/enterprise/batches/execution/WorkspaceDetails.tsx
@@ -489,7 +489,7 @@ const WorkspaceStep: React.FunctionComponent<WorkspaceStepProps> = ({
                                 <Tab key="output-variables">Output variables</Tab>
                                 <Tab key="diff">Diff</Tab>
                                 <Tab key="files-env">Files / Env</Tab>
-                                <Tab key="command-container">Commands / container</Tab>
+                                <Tab key="command-container">Commands / Container</Tab>
                             </TabList>
                             <TabPanels>
                                 <TabPanel className="pt-2" key="logs">

--- a/client/web/src/enterprise/batches/execution/WorkspaceDetails.tsx
+++ b/client/web/src/enterprise/batches/execution/WorkspaceDetails.tsx
@@ -124,7 +124,7 @@ const WorkspaceHeader: React.FunctionComponent<WorkspaceHeaderProps> = ({
                     ? workspace.repository.name
                     : 'Workspace in hidden repository'}
                 {workspace.__typename === 'VisibleBatchSpecWorkspace' && (
-                    <Link to={workspace.repository.url} className="ml-2" target="_blank" rel="noopener noreferrer">
+                    <Link to={workspace.repository.url} target="_blank" rel="noopener noreferrer">
                         <Icon as={ExternalLinkIcon} />
                     </Link>
                 )}
@@ -359,7 +359,6 @@ const ChangesetSpecNode: React.FunctionComponent<{ node: BatchSpecWorkspaceChang
 
     return (
         <Collapsible
-            className="py-2"
             title={
                 <div className="d-flex justify-content-between">
                     <div>
@@ -465,7 +464,6 @@ const WorkspaceStep: React.FunctionComponent<WorkspaceStepProps> = ({
 
     return (
         <Collapsible
-            className="py-2"
             titleClassName={styles.collapsible}
             title={
                 <>

--- a/client/web/src/enterprise/batches/execution/WorkspaceDetails.tsx
+++ b/client/web/src/enterprise/batches/execution/WorkspaceDetails.tsx
@@ -492,66 +492,56 @@ const WorkspaceStep: React.FunctionComponent<WorkspaceStepProps> = ({
                                 <Tab key="command-container">Commands / container</Tab>
                             </TabList>
                             <TabPanels>
-                                <TabPanel key="logs">
-                                    <div className="p-2">
-                                        {!step.startedAt && <p className="text-muted mb-0">Step not started yet</p>}
-                                        {step.startedAt && outputLines && <LogOutput text={outputLines.join('\n')} />}
-                                    </div>
+                                <TabPanel className="pt-2" key="logs">
+                                    {!step.startedAt && <p className="text-muted mb-0">Step not started yet</p>}
+                                    {step.startedAt && outputLines && <LogOutput text={outputLines.join('\n')} />}
                                 </TabPanel>
-                                <TabPanel key="output-variables">
-                                    <div className="p-2">
-                                        {!step.startedAt && <p className="text-muted mb-0">Step not started yet</p>}
-                                        {step.outputVariables?.length === 0 && (
-                                            <p className="text-muted mb-0">No output variables specified</p>
-                                        )}
-                                        <ul className="mb-0">
-                                            {step.outputVariables?.map(variable => (
-                                                <li key={variable.name}>
-                                                    {variable.name}: {variable.value}
-                                                </li>
-                                            ))}
-                                        </ul>
-                                    </div>
+                                <TabPanel className="pt-2" key="output-variables">
+                                    {!step.startedAt && <p className="text-muted mb-0">Step not started yet</p>}
+                                    {step.outputVariables?.length === 0 && (
+                                        <p className="text-muted mb-0">No output variables specified</p>
+                                    )}
+                                    <ul className="mb-0">
+                                        {step.outputVariables?.map(variable => (
+                                            <li key={variable.name}>
+                                                {variable.name}: {variable.value}
+                                            </li>
+                                        ))}
+                                    </ul>
                                 </TabPanel>
-                                <TabPanel key="diff">
-                                    <div className="p-2">
-                                        {!step.startedAt && <p className="text-muted mb-0">Step not started yet</p>}
-                                        {step.startedAt && (
-                                            <WorkspaceStepFileDiffConnection
-                                                isLightTheme={isLightTheme}
-                                                step={step.number}
-                                                workspaceID={workspaceID}
-                                            />
-                                        )}
-                                    </div>
+                                <TabPanel className="pt-2" key="diff">
+                                    {!step.startedAt && <p className="text-muted mb-0">Step not started yet</p>}
+                                    {step.startedAt && (
+                                        <WorkspaceStepFileDiffConnection
+                                            isLightTheme={isLightTheme}
+                                            step={step.number}
+                                            workspaceID={workspaceID}
+                                        />
+                                    )}
                                 </TabPanel>
-                                <TabPanel key="files-env">
-                                    <div className="p-2">
-                                        {step.environment.length === 0 && (
-                                            <p className="text-muted mb-0">No environment variables specified</p>
-                                        )}
-                                        <ul className="mb-0">
-                                            {step.environment.map(variable => (
-                                                <li key={variable.name}>
-                                                    {variable.name}: {variable.value}
-                                                </li>
-                                            ))}
-                                        </ul>
-                                    </div>
+                                <TabPanel className="pt-2" key="files-env">
+                                    {step.environment.length === 0 && (
+                                        <p className="text-muted mb-0">No environment variables specified</p>
+                                    )}
+                                    <ul className="mb-0">
+                                        {step.environment.map(variable => (
+                                            <li key={variable.name}>
+                                                {variable.name}: {variable.value}
+                                            </li>
+                                        ))}
+                                    </ul>
                                 </TabPanel>
-                                <TabPanel key="command-container">
-                                    <div className="p-2 pb-0">
-                                        {step.ifCondition !== null && (
-                                            <>
-                                                <h4>If condition</h4>
-                                                <LogOutput text={step.ifCondition} className="mb-2" />
-                                            </>
-                                        )}
-                                        <h4>Command</h4>
-                                        <LogOutput text={step.run} className="mb-2" />
-                                        <h4>Container</h4>
-                                        <p className="text-monospace mb-0">{step.container}</p>
-                                    </div>
+                                <TabPanel className="pt-2" key="command-container">
+                                    {step.ifCondition !== null && (
+                                        <>
+                                            <h4>If condition</h4>
+                                            <LogOutput text={step.ifCondition} className="mb-2" />
+                                        </>
+                                    )}
+                                    <h4>Command</h4>
+                                    <LogOutput text={step.run} className="mb-2" />
+                                    <h4>Container</h4>
+                                    <p className="text-monospace mb-0">{step.container}</p>
                                 </TabPanel>
                             </TabPanels>
                         </Tabs>

--- a/client/web/src/enterprise/batches/execution/WorkspaceDetails.tsx
+++ b/client/web/src/enterprise/batches/execution/WorkspaceDetails.tsx
@@ -4,7 +4,7 @@ import VisuallyHidden from '@reach/visually-hidden'
 import classNames from 'classnames'
 import { cloneDeep } from 'lodash'
 import AlertCircleIcon from 'mdi-react/AlertCircleIcon'
-import CheckCircleIcon from 'mdi-react/CheckCircleIcon'
+import CheckBoldIcon from 'mdi-react/CheckBoldIcon'
 import CloseIcon from 'mdi-react/CloseIcon'
 import ContentSaveIcon from 'mdi-react/ContentSaveIcon'
 import ExternalLinkIcon from 'mdi-react/ExternalLinkIcon'
@@ -116,54 +116,55 @@ const WorkspaceHeader: React.FunctionComponent<WorkspaceHeaderProps> = ({
     toggleShowTimeline,
 }) => (
     <>
-        <div className="d-flex justify-content-between">
-            <h3>
+        <div className="d-flex align-items-center justify-content-between mb-2">
+            <h3 className="m-0">
                 <WorkspaceStateIcon cachedResultFound={workspace.cachedResultFound} state={workspace.state} />{' '}
                 {workspace.__typename === 'VisibleBatchSpecWorkspace'
                     ? workspace.repository.name
                     : 'Workspace in hidden repository'}
                 {workspace.__typename === 'VisibleBatchSpecWorkspace' && (
-                    <Link to={workspace.repository.url}>
+                    <Link to={workspace.repository.url} className="ml-2">
                         <Icon as={ExternalLinkIcon} />
                     </Link>
                 )}
             </h3>
-            <Button className="p-0 ml-2" onClick={deselectWorkspace} variant="link" size="sm">
+            <Button className="p-0 ml-2" onClick={deselectWorkspace} variant="icon">
+                <VisuallyHidden>Deselect Workspace</VisuallyHidden>
                 <Icon as={CloseIcon} />
             </Button>
         </div>
-        <div className="text-muted">
+        <div className="d-flex align-items-center">
             {typeof workspace.placeInQueue === 'number' && (
-                <div className={styles.detailItem}>
-                    <Icon as={SyncIcon} />{' '}
+                <Badge variant="secondary" className="text-uppercase">
+                    <Icon as={TimerSandIcon} />{' '}
                     <strong>
                         <NumberInQueue number={workspace.placeInQueue} />
                     </strong>{' '}
                     in queue
-                </div>
+                </Badge>
             )}
             {workspace.__typename === 'VisibleBatchSpecWorkspace' && workspace.path && (
-                <div className={styles.detailItem}>{workspace.path}</div>
+                <span className={styles.workspaceDetail}>{workspace.path}</span>
             )}
             {workspace.__typename === 'VisibleBatchSpecWorkspace' && (
-                <div className={styles.detailItem}>
-                    <Icon as={SourceBranchIcon} /> base: <strong>{workspace.branch.displayName}</strong>
-                </div>
+                <span className={styles.workspaceDetail}>
+                    <Icon as={SourceBranchIcon} /> {workspace.branch.displayName}
+                </span>
             )}
             {workspace.startedAt && (
-                <div className={styles.detailItem}>
+                <span className={styles.workspaceDetail}>
                     Total time:{' '}
                     <strong>
                         <Duration start={workspace.startedAt} end={workspace.finishedAt ?? undefined} />
                     </strong>
-                </div>
+                </span>
             )}
             {toggleShowTimeline && !workspace.cachedResultFound && workspace.state !== BatchSpecWorkspaceState.SKIPPED && (
-                <div className={styles.detailItem}>
-                    <Button className="text-muted m-0 p-0" onClick={toggleShowTimeline} variant="link">
+                <span className={styles.workspaceDetail}>
+                    <Button className="m-0 p-0" onClick={toggleShowTimeline} variant="link">
                         Timeline
                     </Button>
-                </div>
+                </span>
             )}
         </div>
         <hr />
@@ -255,7 +256,7 @@ const VisibleWorkspaceDetails: React.FunctionComponent<VisibleWorkspaceDetailsPr
                     )}
                     {workspace.changesetSpecs.map((changesetSpec, index) => (
                         <React.Fragment key={changesetSpec.id}>
-                            <ChangesetSpecNode node={changesetSpec} index={index} isLightTheme={isLightTheme} />
+                            <ChangesetSpecNode node={changesetSpec} isLightTheme={isLightTheme} />
                             {index !== workspace.changesetSpecs!.length - 1 && <hr className="m-0" />}
                         </React.Fragment>
                     ))}
@@ -335,9 +336,10 @@ const NumberInQueue: React.FunctionComponent<{ number: number }> = ({ number }) 
     )
 }
 
-const ChangesetSpecNode: React.FunctionComponent<
-    { node: BatchSpecWorkspaceChangesetSpecFields; index: number } & ThemeProps
-> = ({ node, index, isLightTheme }) => {
+const ChangesetSpecNode: React.FunctionComponent<{ node: BatchSpecWorkspaceChangesetSpecFields } & ThemeProps> = ({
+    node,
+    isLightTheme,
+}) => {
     const history = useHistory()
 
     // TODO: This should not happen. When the workspace is visibile, the changeset spec should be visible as well.
@@ -362,9 +364,8 @@ const ChangesetSpecNode: React.FunctionComponent<
             title={
                 <div className="d-flex justify-content-between">
                     <div>
-                        {' '}
                         <h4 className="mb-0 d-inline-block mr-2">
-                            <strong>RESULT {index + 1}</strong>{' '}
+                            <h3 className={styles.result}>Result</h3>
                             {node.description.published !== null && (
                                 <Badge className="text-uppercase">
                                     {publishBadgeLabel(node.description.published)}
@@ -372,14 +373,14 @@ const ChangesetSpecNode: React.FunctionComponent<
                             )}{' '}
                         </h4>
                         <span className="text-muted">
-                            <Icon as={SourceBranchIcon} />
-                            changeset branch: <strong>{node.description.headRef}</strong>
+                            <Icon as={SourceBranchIcon} /> {node.description.headRef}
                         </span>
                     </div>
                     <DiffStat {...node.description.diffStat} expandedCounts={true} />
                 </div>
             }
             titleClassName="flex-grow-1"
+            // TODO: fix me
             defaultExpanded={1 === 1}
         >
             <Card className={classNames('mt-2', styles.resultCard)}>
@@ -393,7 +394,7 @@ const ChangesetSpecNode: React.FunctionComponent<
                     <Collapsible
                         title={<h3 className="mb-0">Changes</h3>}
                         titleClassName="flex-grow-1"
-                        defaultExpanded={false}
+                        defaultExpanded={true}
                     >
                         <ChangesetSpecFileDiffConnection
                             history={history}
@@ -466,18 +467,21 @@ const WorkspaceStep: React.FunctionComponent<WorkspaceStepProps> = ({
     return (
         <Collapsible
             className="py-2"
-            titleClassName="w-100"
+            titleClassName={styles.collapsible}
             title={
-                <div className="d-flex justify-content-between">
-                    <div className={classNames('flex-grow-1', step.skipped && 'text-muted')}>
-                        <StepStateIcon step={step} /> <strong>Step {step.number}</strong>{' '}
-                        <span className="text-monospace text-ellipsis text-muted">{step.run}</span>
+                <>
+                    <div className={classNames(styles.stepHeader, step.skipped && 'text-muted')}>
+                        <StepStateIcon step={step} />
+                        <h3 className={styles.stepNumber}>Step {step.number}</h3>
+                        <span className={classNames('text-monospace text-muted', styles.stepCommand)}>{step.run}</span>
                     </div>
-                    <div>{step.diffStat && <DiffStat {...step.diffStat} expandedCounts={true} />}</div>
-                    <span className="text-monospace text-muted ml-2">
+                    {step.diffStat && (
+                        <DiffStat className={styles.stepDiffStat} {...step.diffStat} expandedCounts={true} />
+                    )}
+                    <span className={classNames('text-monospace text-muted', styles.stepTime)}>
                         <StepTimer step={step} />
                     </span>
-                </div>
+                </>
             }
         >
             <Card className={classNames('mt-2', styles.stepCard)}>

--- a/client/web/src/enterprise/batches/execution/WorkspaceDetails.tsx
+++ b/client/web/src/enterprise/batches/execution/WorkspaceDetails.tsx
@@ -135,13 +135,13 @@ const WorkspaceHeader: React.FunctionComponent<WorkspaceHeaderProps> = ({
         </div>
         <div className="d-flex align-items-center">
             {typeof workspace.placeInQueue === 'number' && (
-                <Badge variant="secondary" className="text-uppercase">
-                    <Icon as={TimerSandIcon} />{' '}
-                    <strong>
+                <>
+                    <Icon as={TimerSandIcon} />
+                    <strong className="ml-1 mr-1">
                         <NumberInQueue number={workspace.placeInQueue} />
-                    </strong>{' '}
+                    </strong>
                     in queue
-                </Badge>
+                </>
             )}
             {workspace.__typename === 'VisibleBatchSpecWorkspace' && workspace.path && (
                 <span className={styles.workspaceDetail}>{workspace.path}</span>

--- a/client/web/src/enterprise/batches/execution/WorkspaceDetails.tsx
+++ b/client/web/src/enterprise/batches/execution/WorkspaceDetails.tsx
@@ -13,6 +13,7 @@ import LinkVariantRemoveIcon from 'mdi-react/LinkVariantRemoveIcon'
 import MapSearchIcon from 'mdi-react/MapSearchIcon'
 import SourceBranchIcon from 'mdi-react/SourceBranchIcon'
 import SyncIcon from 'mdi-react/SyncIcon'
+import TimelineClockOutlineIcon from 'mdi-react/TimelineClockOutlineIcon'
 import TimerSandIcon from 'mdi-react/TimerSandIcon'
 import { useHistory } from 'react-router'
 
@@ -117,7 +118,7 @@ const WorkspaceHeader: React.FunctionComponent<WorkspaceHeaderProps> = ({
 }) => (
     <>
         <div className="d-flex align-items-center justify-content-between mb-2">
-            <h3 className="m-0">
+            <h3 className={styles.workspaceName}>
                 <WorkspaceStateIcon cachedResultFound={workspace.cachedResultFound} state={workspace.state} />{' '}
                 {workspace.__typename === 'VisibleBatchSpecWorkspace'
                     ? workspace.repository.name
@@ -135,13 +136,13 @@ const WorkspaceHeader: React.FunctionComponent<WorkspaceHeaderProps> = ({
         </div>
         <div className="d-flex align-items-center">
             {typeof workspace.placeInQueue === 'number' && (
-                <>
-                    <Icon as={TimerSandIcon} />
+                <span className={classNames(styles.workspaceDetail, 'd-flex align-items-center')}>
+                    <Icon as={TimelineClockOutlineIcon} />
                     <strong className="ml-1 mr-1">
                         <NumberInQueue number={workspace.placeInQueue} />
                     </strong>
                     in queue
-                </>
+                </span>
             )}
             {workspace.__typename === 'VisibleBatchSpecWorkspace' && workspace.path && (
                 <span className={styles.workspaceDetail}>{workspace.path}</span>
@@ -160,11 +161,9 @@ const WorkspaceHeader: React.FunctionComponent<WorkspaceHeaderProps> = ({
                 </span>
             )}
             {toggleShowTimeline && !workspace.cachedResultFound && workspace.state !== BatchSpecWorkspaceState.SKIPPED && (
-                <span className={styles.workspaceDetail}>
-                    <Button className="m-0 p-0" onClick={toggleShowTimeline} variant="link">
-                        Timeline
-                    </Button>
-                </span>
+                <Button className={styles.workspaceDetail} onClick={toggleShowTimeline} variant="link">
+                    Timeline
+                </Button>
             )}
         </div>
         <hr />

--- a/client/web/src/enterprise/batches/execution/WorkspaceDetails.tsx
+++ b/client/web/src/enterprise/batches/execution/WorkspaceDetails.tsx
@@ -378,8 +378,8 @@ const ChangesetSpecNode: React.FunctionComponent<{ node: BatchSpecWorkspaceChang
                 </div>
             }
             titleClassName="flex-grow-1"
-            // TODO: fix me
-            defaultExpanded={1 === 1}
+            // TODO: Under what conditions should this be auto-expanded?
+            defaultExpanded={true}
         >
             <Card className={classNames('mt-2', styles.resultCard)}>
                 <CardBody>

--- a/client/web/src/enterprise/batches/execution/WorkspaceDetails.tsx
+++ b/client/web/src/enterprise/batches/execution/WorkspaceDetails.tsx
@@ -123,7 +123,7 @@ const WorkspaceHeader: React.FunctionComponent<WorkspaceHeaderProps> = ({
                     ? workspace.repository.name
                     : 'Workspace in hidden repository'}
                 {workspace.__typename === 'VisibleBatchSpecWorkspace' && (
-                    <Link to={workspace.repository.url} className="ml-2">
+                    <Link to={workspace.repository.url} className="ml-2" target="_blank" rel="noopener noreferrer">
                         <Icon as={ExternalLinkIcon} />
                     </Link>
                 )}

--- a/client/web/src/enterprise/batches/execution/WorkspaceDetails.tsx
+++ b/client/web/src/enterprise/batches/execution/WorkspaceDetails.tsx
@@ -587,18 +587,18 @@ const StepStateIcon: React.FunctionComponent<StepStateIconProps> = ({ step }) =>
         return <Icon className="text-muted" data-tooltip="The step has been skipped" as={LinkVariantRemoveIcon} />
     }
     if (!step.startedAt) {
-        return <Icon className="text-muted" data-tooltip="Waiting to be processed" as={TimerSandIcon} />
+        return <Icon className="text-muted" data-tooltip="This step is waiting to be processed" as={TimerSandIcon} />
     }
     if (!step.finishedAt) {
-        return <Icon className="text-muted" data-tooltip="Currently running" as={LoadingSpinner} />
+        return <Icon className="text-muted" data-tooltip="This step is currently running" as={LoadingSpinner} />
     }
     if (step.exitCode === 0) {
-        return <Icon className="text-success" data-tooltip="Ran successfully" as={CheckCircleIcon} />
+        return <Icon className="text-success" data-tooltip="This step ran successfully" as={CheckBoldIcon} />
     }
     return (
         <Icon
             className="text-danger"
-            data-tooltip={`Step failed with exit code ${String(step.exitCode)}`}
+            data-tooltip={`This step failed with exit code ${String(step.exitCode)}`}
             as={AlertCircleIcon}
         />
     )

--- a/client/web/src/enterprise/batches/execution/WorkspaceStateIcon.tsx
+++ b/client/web/src/enterprise/batches/execution/WorkspaceStateIcon.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 import AlertCircleIcon from 'mdi-react/AlertCircleIcon'
 import CancelIcon from 'mdi-react/CancelIcon'
-import CheckCircleIcon from 'mdi-react/CheckCircleIcon'
+import CheckBoldIcon from 'mdi-react/CheckBoldIcon'
 import ContentSaveIcon from 'mdi-react/ContentSaveIcon'
 import LinkVariantRemoveIcon from 'mdi-react/LinkVariantRemoveIcon'
 import TimerSandIcon from 'mdi-react/TimerSandIcon'
@@ -76,7 +76,7 @@ export const WorkspaceStateIcon: React.FunctionComponent<WorkspaceStateIconProps
                 <Icon
                     className="text-success"
                     data-tooltip="Execution for this workspace succeeded."
-                    as={CheckCircleIcon}
+                    as={CheckBoldIcon}
                 />
             )
     }

--- a/client/web/src/enterprise/batches/execution/workspaces/WorkspacesFilterRow.tsx
+++ b/client/web/src/enterprise/batches/execution/workspaces/WorkspacesFilterRow.tsx
@@ -63,7 +63,7 @@ export const WorkspaceFilterRow: React.FunctionComponent<WorkspaceFilterRowProps
         <div className="d-flex align-items-center mb-2">
             <Form className="d-flex flex-grow-1 mr-2" onSubmit={onSubmit}>
                 <Input
-                    className="m-0"
+                    className="m-0 flex-1"
                     type="search"
                     ref={searchElement}
                     defaultValue={search}

--- a/client/web/src/enterprise/batches/execution/workspaces/WorkspacesList.tsx
+++ b/client/web/src/enterprise/batches/execution/workspaces/WorkspacesList.tsx
@@ -38,7 +38,7 @@ export const WorkspacesList: React.FunctionComponent<WorkspacesListProps> = ({
     return (
         <ConnectionContainer>
             {error && <ConnectionError errors={[error.message]} />}
-            <ConnectionList as="ul">
+            <ConnectionList as="ul" className="mb-0">
                 {connection?.nodes?.map(node => (
                     <WorkspacesListItem
                         key={node.id}

--- a/client/web/src/enterprise/batches/list/BatchChangeStatePill.module.scss
+++ b/client/web/src/enterprise/batches/list/BatchChangeStatePill.module.scss
@@ -1,7 +1,6 @@
 .pill-group {
     display: flex;
     border-radius: calc(var(--badge-border-radius) * 1.5);
-    border-width: 2px;
     border-style: solid;
     overflow: hidden;
 


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/32345.

Fixes up most of the QA issues identified in [this Figma page](https://www.figma.com/file/cTKjwbvWqU6xAykZmCTTqy/SSBC?node-id=2689%3A68654), and then some! I left off a couple items that either:
- are already included in the requirements for other upcoming GH issues
- are made significantly easier by https://github.com/sourcegraph/sourcegraph/issues/33395 or https://github.com/sourcegraph/sourcegraph/issues/32343, or would need to be redone again after them
- (notably, that includes the super janky Cancel button 😜)

I definitely recommend reviewing this with the "hide whitespace changes" mode enabled. 

## Test plan

Running batch changes server-side is still an experimental feature and will not impact existing src-cli batch changes users. Most of these components changed have storybook coverage, and most of the changes made are visuals or semantics only.


## App preview:

- [Link](https://sg-web-kr-execution-ui-polish.onrender.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

