### PR TITLE
Collapse: Use correct useState import

### DIFF
--- a/client/wildcard/src/components/Collapse/Collapse.story.tsx
+++ b/client/wildcard/src/components/Collapse/Collapse.story.tsx
@@ -1,6 +1,5 @@
-import React, { useCallback } from 'react'
+import React, { useCallback, useState } from 'react'
 
-import { useState } from '@storybook/addons'
 import { DecoratorFn, Meta, Story } from '@storybook/react'
 import ChevronDownIcon from 'mdi-react/ChevronDownIcon'
 import ChevronLeftIcon from 'mdi-react/ChevronLeftIcon'


### PR DESCRIPTION
## Description

Updates import to correct use `useState` from React, not Storybook

## Test plan

Tested in local storybook


## App preview:

- [Link](https://sg-web-tr-fix-storybook-issue.onrender.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

