### PR TITLE
ci: remove Percy retry

### DIFF
--- a/enterprise/dev/ci/internal/ci/operations.go
+++ b/enterprise/dev/ci/internal/ci/operations.go
@@ -330,7 +330,6 @@ func clientIntegrationTests(pipeline *bk.Pipeline) {
 			// https://docs.percy.io/docs/parallel-test-suites#how-it-works
 			bk.Env("PERCY_PARALLEL_TOTAL", strconv.Itoa(parallelTestCount)),
 			bk.Cmd(fmt.Sprintf(`dev/ci/yarn-web-integration.sh "%s"`, chunkTestFiles)),
-			bk.AutomaticRetry(1), // Temporary
 			bk.ArtifactPaths("./puppeteer/*.png"))
 	}
 }


### PR DESCRIPTION
## Context

Restarting individual Percy's steps yields errors because it leads to [duplicate snapshot issues](https://buildkite.com/sourcegraph/sourcegraph/builds/143276#8235e4b8-4436-4b88-b51f-a14fbfd1fb49) and is incompatible with the [PERCY_PARALLEL_TOTAL](https://docs.percy.io/docs/parallel-test-suites#how-it-works) that we use to finalize Percy's build. The whole Percy pipeline should be restarted.

We should solve the underlying issue that [caused](https://buildkite.com/sourcegraph/sourcegraph/builds/143276#b845e2d8-0cb9-4110-9893-d3a0afa1937b) retries: `Error: Timeout getting coverage from https://sourcegraph.test:3443/users/test/settings/profile`. Will look into it in a separate PR.

## Test plan

n/a


