### PR TITLE
[SG-33093.11] Enable accessibilityAudit on `insights-visual.test.ts`

### DIFF
--- a/client/web/src/charts/components/line-chart/components/PointGlyph.tsx
+++ b/client/web/src/charts/components/line-chart/components/PointGlyph.tsx
@@ -27,6 +27,7 @@ export const PointGlyph: React.FunctionComponent<PointGlyphProps> = props => {
             onFocus={onFocus}
             onBlur={onBlur}
             role={linkURL ? 'link' : 'graphics-dataunit'}
+            aria-label={linkURL ? 'Click to view data point detail' : 'Data point'}
         >
             <GlyphDot
                 tabIndex={linkURL ? -1 : 0}

--- a/client/web/src/enterprise/insights/components/views/card/InsightCard.tsx
+++ b/client/web/src/enterprise/insights/components/views/card/InsightCard.tsx
@@ -3,7 +3,7 @@ import React, { forwardRef, HTMLAttributes, ReactNode } from 'react'
 import classNames from 'classnames'
 import { useLocation } from 'react-router-dom'
 
-import { Card, ForwardReferenceComponent, LoadingSpinner } from '@sourcegraph/wildcard'
+import { Card, ForwardReferenceComponent, H2, H4, LoadingSpinner } from '@sourcegraph/wildcard'
 
 import { getLineColor, LegendItem, LegendList, Series } from '../../../../../charts'
 import { ErrorBoundary } from '../../../../../components/ErrorBoundary'
@@ -39,9 +39,9 @@ const InsightCardHeader = forwardRef((props, reference) => {
     return (
         <Component {...attributes} ref={reference} className={classNames(styles.header, className)}>
             <div className={styles.headerContent}>
-                <h4 title={title} className={styles.title}>
+                <H4 as={H2} title={title} className={styles.title}>
                     {title}
-                </h4>
+                </H4>
 
                 {children && (
                     // eslint-disable-next-line jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions

--- a/client/web/src/enterprise/insights/pages/CodeInsightsRootPage.tsx
+++ b/client/web/src/enterprise/insights/pages/CodeInsightsRootPage.tsx
@@ -99,10 +99,6 @@ export const CodeInsightsRootPage: React.FunctionComponent<CodeInsightsRootPageP
 
                     <Tab index={CodeInsightsRootPageTab.GettingStarted}>Getting started</Tab>
                 </TabList>
-                {/* 
-                    To fix Rule: "aria-valid-attr-value" (ARIA attributes must conform to valid values)
-                    Invalid ARIA attribute value: aria-controls="tabs--1--panel--0"
-                 */}
                 <TabPanels className="mt-3">
                     <TabPanel>
                         <DashboardsContentPage telemetryService={telemetryService} dashboardID={params?.dashboardId} />

--- a/client/web/src/enterprise/insights/pages/CodeInsightsRootPage.tsx
+++ b/client/web/src/enterprise/insights/pages/CodeInsightsRootPage.tsx
@@ -7,7 +7,7 @@ import { useLocation } from 'react-router-dom'
 import { useTemporarySetting } from '@sourcegraph/shared/src/settings/temporary/useTemporarySetting'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { lazyComponent } from '@sourcegraph/shared/src/util/lazyComponent'
-import { Button, Link, PageHeader, Tabs, TabList, Tab, Icon } from '@sourcegraph/wildcard'
+import { Button, Link, PageHeader, Tabs, TabList, Tab, Icon, TabPanels, TabPanel } from '@sourcegraph/wildcard'
 
 import { CodeInsightsIcon } from '../../../insights/Icons'
 import { CodeInsightsPage } from '../components/code-insights-page/CodeInsightsPage'
@@ -93,21 +93,25 @@ export const CodeInsightsRootPage: React.FunctionComponent<CodeInsightsRootPageP
                 className="align-items-start mb-3"
             />
 
-            <Tabs index={activeView} size="medium" className="mb-3" onChange={handleTabNavigationChange}>
+            <Tabs index={activeView} size="medium" className="mb-3" onChange={handleTabNavigationChange} lazy={true}>
                 <TabList>
                     <Tab index={CodeInsightsRootPageTab.CodeInsights}>Code Insights</Tab>
 
                     <Tab index={CodeInsightsRootPageTab.GettingStarted}>Getting started</Tab>
                 </TabList>
+                {/* 
+                    To fix Rule: "aria-valid-attr-value" (ARIA attributes must conform to valid values)
+                    Invalid ARIA attribute value: aria-controls="tabs--1--panel--0"
+                 */}
+                <TabPanels className="mt-3">
+                    <TabPanel>
+                        <DashboardsContentPage telemetryService={telemetryService} dashboardID={params?.dashboardId} />
+                    </TabPanel>
+                    <TabPanel>
+                        <LazyCodeInsightsGettingStartedPage telemetryService={telemetryService} />
+                    </TabPanel>
+                </TabPanels>
             </Tabs>
-
-            {activeView === CodeInsightsRootPageTab.CodeInsights && (
-                <DashboardsContentPage telemetryService={telemetryService} dashboardID={params?.dashboardId} />
-            )}
-
-            {activeView === CodeInsightsRootPageTab.GettingStarted && (
-                <LazyCodeInsightsGettingStartedPage telemetryService={telemetryService} />
-            )}
         </CodeInsightsPage>
     )
 }

--- a/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/dashboards-content/DashboardsContent.tsx
+++ b/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/dashboards-content/DashboardsContent.tsx
@@ -93,9 +93,6 @@ export const DashboardsContent: React.FunctionComponent<DashboardsContentProps> 
     const addRemovePermissions = dashboardPermission.getAddRemoveInsightsPermission(currentDashboard)
 
     return (
-        // To fix Rule: "landmark-main-is-top-level", "landmark-no-duplicate-main", "landmark-unique"
-        // We use div here instead of main element
-        // Since the main element is set in AppRouterContainer component
         <div className="pb-4">
             <DashboardHeader className="d-flex flex-wrap align-items-center mb-3">
                 <span className={styles.dashboardSelectLabel}>Dashboard:</span>

--- a/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/dashboards-content/DashboardsContent.tsx
+++ b/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/dashboards-content/DashboardsContent.tsx
@@ -93,7 +93,10 @@ export const DashboardsContent: React.FunctionComponent<DashboardsContentProps> 
     const addRemovePermissions = dashboardPermission.getAddRemoveInsightsPermission(currentDashboard)
 
     return (
-        <main className="pb-4">
+        // To fix Rule: "landmark-main-is-top-level", "landmark-no-duplicate-main", "landmark-unique"
+        // We use div here instead of main element
+        // Since the main element is set in AppRouterContainer component
+        <div className="pb-4">
             <DashboardHeader className="d-flex flex-wrap align-items-center mb-3">
                 <span className={styles.dashboardSelectLabel}>Dashboard:</span>
 
@@ -153,6 +156,6 @@ export const DashboardsContent: React.FunctionComponent<DashboardsContentProps> 
             {isDeleteDashboardActive && isDashboardConfigurable(currentDashboard) && (
                 <DeleteDashboardModal dashboard={currentDashboard} onClose={() => setDeleteDashboardActive(false)} />
             )}
-        </main>
+        </div>
     )
 }

--- a/client/web/src/integration/insights/insights-visual.test.ts
+++ b/client/web/src/integration/insights/insights-visual.test.ts
@@ -1,5 +1,6 @@
 import delay from 'delay'
 
+import { accessibilityAudit } from '@sourcegraph/shared/src/testing/accessibility'
 import { createDriverForTest, Driver } from '@sourcegraph/shared/src/testing/driver'
 import { afterEachSaveScreenshotIfFailed } from '@sourcegraph/shared/src/testing/screenshotReporter'
 
@@ -50,6 +51,7 @@ describe.skip('[VISUAL] Code insights page', () => {
         await driver.page.waitForSelector('svg circle')
         await delay(500)
         await percySnapshotWithVariants(driver.page, name)
+        await accessibilityAudit(driver.page)
     }
 
     it('is styled correctly with back-end insights', async () => {
@@ -118,6 +120,7 @@ describe.skip('[VISUAL] Code insights page', () => {
 
         await delay(500)
         await percySnapshotWithVariants(driver.page, 'Code insights page with search-based errored insight')
+        await accessibilityAudit(driver.page)
     })
 
     it('is styled correctly with all types of insight', async () => {
@@ -203,6 +206,7 @@ describe.skip('[VISUAL] Code insights page', () => {
             await driver.page.waitForSelector('input[name="name"]')
 
             await percySnapshotWithVariants(driver.page, 'Code insights add new dashboard page')
+            await accessibilityAudit(driver.page)
         })
     })
 })


### PR DESCRIPTION
## Description
Enabled accessibility audit on
-  `insights-visual.test.ts` 

## Refs

[SG Issue](https://github.com/sourcegraph/sourcegraph/issues/33093)
[Gitstart Ticket](https://app.gitstart.com/clients/sourcegraph/tickets/SG-33093)

## Test plan

Run the integration test 
`yarn test-integration:base client/web/src/integration/insights/insights-visual.test.ts`

## Success criteria

- All integration tests with percy snapshots have `accessibilityAudit` enabled


## App preview:

- [Web](https://sg-web-contractors-sg-33093-11.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-luvxgzmdxy.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
