### PR TITLE
sg: run "chmod +x" if executable has been updated

### DIFF
--- a/dev/sg/sg_update.go
+++ b/dev/sg/sg_update.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"os/exec"
 	"runtime"
 	"strings"
 
@@ -82,10 +83,14 @@ func updateToPrebuiltSG(ctx context.Context) (string, error) {
 	content := &bytes.Buffer{}
 	content.ReadFrom(resp.Body)
 
-	_, err = fileutil.UpdateFileIfDifferent(currentExecPath, content.Bytes())
+	ok, err := fileutil.UpdateFileIfDifferent(currentExecPath, content.Bytes())
 	if err != nil {
 		return "", err
 	}
+	if !ok {
+		return currentExecPath, nil
+	}
 
-	return currentExecPath, nil
+	err = exec.Command("chmod", "+x", currentExecPath).Run()
+	return currentExecPath, err
 }


### PR DESCRIPTION
This might fix the "permission denied" after update bug as reported [here](https://sourcegraph.slack.com/archives/C01N83PS4TU/p1650535208272439) and [here](https://sourcegraph.slack.com/archives/C01N83PS4TU/p1650542731365989).



## Test plan

- Run this without the changes in this PR to confirm that the behaviour can be replicated:
```
$ go install -ldflags "-X main.BuildCommit=6f8e52dd98" -mod=mod .            # 6f8e... is just an old commit
$ sg start
ℹ️ Auto updating sg ...
✅ sg has been updated!
To see what's new, run 'sg version changelog'.
⚠️ update check: permission denied
```
- Run it with changes in this PR and see that "update check: permission denied" disappears

