### PR TITLE
New reference panel: first stab at polishing according to Figma

### DIFF
--- a/client/web/src/codeintel/ReferencesPanel.module.scss
+++ b/client/web/src/codeintel/ReferencesPanel.module.scss
@@ -1,17 +1,54 @@
-.reference {
-    code {
-        overflow: hidden;
-        color: var(--body-color);
+$filter-input-height: 1.5rem;
+.filter {
+    height: $filter-input-height;
+    padding-left: 1rem;
+
+    input {
+        height: $filter-input-height;
+        padding-left: 0.5rem;
+        border: none;
     }
 
-    &--active {
-        background-color: var(--secondary-2);
-        color: var(--primary);
-        font-weight: bold;
+    &--icon {
+    margin-top: 0.3rem;
+    color: var(--icon-muted);
+    }
+}
+
+.repo-location-group {
+    padding-top: 0.2rem;
+    padding-bottom: 0.2rem;
+    padding-left: 2.3rem;
+    width: 100%;
+    text-align: left;
+
+    font-weight: 400;
+
+    &--icon {
+      // margin-top: 0.05rem;
+    }
+
+    &--repo-name {
+        padding-left: 0.6rem;
+    }
+}
+
+.location-group {
+    padding-left: 3.75rem;
+    padding-top: 0;
+    padding-bottom: 0;
+    width: 100%;
+    text-align: left;
+
+    transition: none !important;
+
+    &--icon {
+      // margin-top: 0.1rem;
     }
 
     &--filename {
-        color: var(--body-color);
+        padding-left: 0.6rem;
+        font-weight: 400;
 
         mark {
             padding-left: 0;
@@ -19,37 +56,81 @@
             font-weight: bold;
         }
     }
+}
+
+.location {
+    button {
+        padding-left: 3.75rem;
+        padding-top: 0;
+        padding-bottom: 0;
+        width: 100%;
+        text-align: left;
+
+        transition: none !important;
+    }
+
+    button:hover {
+        background-color: var(--color-bg-2);
+    }
+
+    code {
+        overflow: hidden;
+        color: var(--body-color);
+    }
+
+    &--active {
+        background-color: var(--color-bg-2);
+    }
 
     &--link {
         color: inherit;
 
         &--line-number {
             font-family: monospace;
-            color: var(--primary);
+            font-weight: 400;
+            color: var(--link-color);
         }
     }
 }
 
-.dismiss-button {
-    color: var(--icon-color);
+$card-header-height: 1.5rem;
+.card-header {
+    padding-top: 0.1rem;
+    padding-bottom: 0.1rem;
+    padding-left: 1rem;
+
+    border: none;
+
+    height: $card-header-height;
+
+    background-color: var(--body-bg);
+
+    &--big {
+        padding-top: 0.3rem;
+        padding-bottom: 0.3rem;
+        padding-left: 1rem;
+
+        border: none;
+
+        height: 1.8rem;
+
+        background-color: var(--body-bg);
+
+        h4 {
+            padding-left: 0.6rem;
+        }
+    }
+
+    &--small-text {
+        font-weight: 400;
+    }
 }
 
 .references {
-    $references-token-height: 2rem;
-    $references-filter-height: 2rem;
-
-    &--token {
-        height: $references-token-height;
-    }
-
-    &--filter {
-        height: $references-filter-height;
-    }
-
     &--list {
         display: flex;
         // Ensure list spans entire height of panel, and that the scrollable area does not include the filter height
-        height: calc(100% - #{$references-filter-height + $references-token-height});
+        height: calc(100% - #{$filter-input-height + $card-header-height});
     }
 
     // Left side of the panel: hover & list of references/definition/...
@@ -65,9 +146,14 @@
         overflow: auto;
     }
 
+    &--side-blob-collapse-button {
+        height: 0.5rem;
+        margin-right: 0.5rem;
+    }
+
     // Code needs to be smaller than 100% so it scrolls correctly
     &--side-blob-code {
         // Subtract the space taken up by the filename
-        height: calc(100% - #{$references-filter-height});
+        height: calc(100% - #{$filter-input-height});
     }
 }

--- a/client/web/src/codeintel/ReferencesPanel.module.scss
+++ b/client/web/src/codeintel/ReferencesPanel.module.scss
@@ -143,8 +143,8 @@ $card-header-height: 1.5rem;
     }
 
     &--side-blob-filename {
-      height: 1rem;
-      vertical-align: middle;
+        height: 1rem;
+        vertical-align: middle;
     }
 
     &--side-blob-collapse-button {

--- a/client/web/src/codeintel/ReferencesPanel.module.scss
+++ b/client/web/src/codeintel/ReferencesPanel.module.scss
@@ -2,16 +2,20 @@ $filter-input-height: 1.5rem;
 .filter {
     height: $filter-input-height;
     padding-left: 1rem;
+    padding-top: 0.25rem;
+    padding-bottom: 0.25rem;
 
     input {
-        height: $filter-input-height;
+        height: 1rem;
+        font-size: 0.75rem;
         padding-left: 0.5rem;
+        padding-top: 0;
+        padding-bottom: 0;
         border: none;
     }
 
     &--icon {
-    margin-top: 0.3rem;
-    color: var(--icon-muted);
+        color: var(--icon-muted);
     }
 }
 
@@ -24,10 +28,6 @@ $filter-input-height: 1.5rem;
 
     font-weight: 400;
 
-    &--icon {
-      // margin-top: 0.05rem;
-    }
-
     &--repo-name {
         padding-left: 0.6rem;
     }
@@ -35,16 +35,12 @@ $filter-input-height: 1.5rem;
 
 .location-group {
     padding-left: 3.75rem;
-    padding-top: 0;
-    padding-bottom: 0;
+    padding-top: 0.2rem;
+    padding-bottom: 0.2rem;
     width: 100%;
     text-align: left;
 
     transition: none !important;
-
-    &--icon {
-      // margin-top: 0.1rem;
-    }
 
     &--filename {
         padding-left: 0.6rem;
@@ -60,7 +56,7 @@ $filter-input-height: 1.5rem;
 
 .location {
     button {
-        padding-left: 3.75rem;
+        padding-left: 3.9rem;
         padding-top: 0;
         padding-bottom: 0;
         width: 100%;
@@ -146,8 +142,12 @@ $card-header-height: 1.5rem;
         overflow: auto;
     }
 
+    &--side-blob-filename {
+      height: 1rem;
+      vertical-align: middle;
+    }
+
     &--side-blob-collapse-button {
-        height: 0.5rem;
         margin-right: 0.5rem;
     }
 

--- a/client/web/src/codeintel/ReferencesPanel.tsx
+++ b/client/web/src/codeintel/ReferencesPanel.tsx
@@ -5,8 +5,8 @@ import * as H from 'history'
 import { capitalize } from 'lodash'
 import ChevronDownIcon from 'mdi-react/ChevronDownIcon'
 import ChevronRightIcon from 'mdi-react/ChevronRightIcon'
-import CloseIcon from 'mdi-react/CloseIcon'
-import OpenInAppIcon from 'mdi-react/OpenInAppIcon'
+import ArrowCollapseRightIcon from 'mdi-react/ArrowCollapseRightIcon'
+import FilterOutlineIcon from 'mdi-react/FilterOutlineIcon'
 import { MemoryRouter, useHistory, useLocation } from 'react-router'
 
 import { HoveredToken } from '@sourcegraph/codeintellify'
@@ -15,6 +15,7 @@ import {
     ErrorLike,
     formatSearchParameters,
     lprToRange,
+    pluralize,
     toPositionOrRangeQueryParameter,
     toViewStateHash,
 } from '@sourcegraph/common'
@@ -45,6 +46,7 @@ import {
     Collapse,
     CollapseHeader,
     CollapsePanel,
+    Code,
 } from '@sourcegraph/wildcard'
 
 import { ReferencesPanelHighlightedBlobResult, ReferencesPanelHighlightedBlobVariables } from '../graphql-operations'
@@ -194,21 +196,21 @@ const FilterableReferencesList: React.FunctionComponent<ReferencesPanelPropsWith
 
     return (
         <>
-            <CardHeader className={styles.referencesToken}>
-                <code>{tokenResult.searchToken}</code>{' '}
-                <span className="text-muted ml-2">
-                    <code>
-                        {props.token.repoName}:{props.token.filePath}
-                    </code>
-                </span>
+            <CardHeader className={styles.cardHeader}>
+                <Code size="base" weight="bold">
+                    {tokenResult.searchToken}
+                </Code>
             </CardHeader>
-            <Input
-                className={classNames('py-0 my-0', styles.referencesFilter)}
-                type="text"
-                placeholder="Filter by filename..."
-                value={filter === undefined ? '' : filter}
-                onChange={event => setFilter(event.target.value)}
-            />
+            <div className={classNames('d-flex justify-content-start', styles.filter)}>
+                <Icon as={FilterOutlineIcon} className={classNames('text-muted', styles.filterIcon)} />
+                <Input
+                    className={classNames('py-0 my-0 w-100')}
+                    type="text"
+                    placeholder="Type to filter by filename"
+                    value={filter === undefined ? '' : filter}
+                    onChange={event => setFilter(event.target.value)}
+                />
+            </div>
             <ReferencesList
                 {...props}
                 token={props.token}
@@ -431,29 +433,25 @@ export const ReferencesList: React.FunctionComponent<
                 </div>
                 {activeLocation !== undefined && (
                     <div className={classNames('px-0 border-left', styles.referencesSideBlob)}>
-                        <CardHeader className={classNames('pl-1 pr-3 py-1 d-flex justify-content-between')}>
-                            <h4 className="mb-0">
-                                {activeLocation.file}{' '}
-                                <Link
-                                    to={activeLocation.url}
-                                    onClick={event => {
-                                        event.preventDefault()
-                                        navigateToUrl(activeLocation.url)
-                                    }}
-                                >
-                                    <Icon as={OpenInAppIcon} />
-                                </Link>
-                            </h4>
-
+                        <CardHeader className={classNames('d-flex', styles.cardHeader)}>
                             <Button
                                 onClick={() => setActiveLocation(undefined)}
-                                className={classNames('btn-icon p-0', styles.dismissButton)}
+                                className={classNames('btn-icon p-0', styles.referencesSideBlobCollapseButton)}
                                 title="Close panel"
                                 data-tooltip="Close panel"
                                 data-placement="left"
                             >
-                                <Icon as={CloseIcon} />
+                                <Icon as={ArrowCollapseRightIcon} />
                             </Button>
+                            <Link
+                                to={activeLocation.url}
+                                onClick={event => {
+                                    event.preventDefault()
+                                    navigateToUrl(activeLocation.url)
+                                }}
+                            >
+                                {activeLocation.file}{' '}
+                            </Link>
                         </CardHeader>
                         <SideBlob
                             {...props}
@@ -489,76 +487,73 @@ interface CollapsibleLocationListProps extends ActiveLocationProps, CollapseProp
     navigateToUrl: (url: string) => void
 }
 
-const CollapsibleLocationList: React.FunctionComponent<CollapsibleLocationListProps> = props => (
-    <Collapse
-        isOpen={props.isOpen(props.name) ?? true}
-        onOpenChange={isOpen => props.handleOpenChange(props.name, isOpen)}
-    >
-        <>
-            <CardHeader className="p-0">
-                <CollapseHeader
-                    as={Button}
-                    aria-expanded={props.isOpen(props.name)}
-                    type="button"
-                    className="bg-transparent py-1 px-0 border-bottom border-top-0 border-left-0 border-right-0 d-flex justify-content-start w-100"
-                >
-                    <h4 className="px-1 py-0 mb-0">
-                        {' '}
-                        {props.isOpen(props.name) ? (
+const CollapsibleLocationList: React.FunctionComponent<CollapsibleLocationListProps> = props => {
+    const isOpen = props.isOpen(props.name) ?? true
+
+    return (
+        <Collapse isOpen={isOpen} onOpenChange={isOpen => props.handleOpenChange(props.name, isOpen)}>
+            <>
+                <CardHeader className={styles.cardHeaderBig}>
+                    <CollapseHeader
+                        as={Button}
+                        aria-expanded={props.isOpen(props.name)}
+                        type="button"
+                        className="d-flex p-0 justify-content-start w-100"
+                    >
+                        {isOpen ? (
                             <Icon aria-label="Close" as={ChevronDownIcon} />
                         ) : (
                             <Icon aria-label="Expand" as={ChevronRightIcon} />
                         )}{' '}
-                        {capitalize(props.name)}
-                        <Badge pill={true} variant="secondary" className="ml-2">
-                            {props.locations.length}
-                            {props.hasMore && '+'}
-                        </Badge>
-                    </h4>
-                </CollapseHeader>
-            </CardHeader>
+                        <h4 className="mb-0">{capitalize(props.name)}</h4>
+                        <span className={classNames('ml-2 text-muted small', styles.cardHeaderSmallText)}>
+                            ({props.locations.length} displayed{props.hasMore ? ', more available)' : ')'}
+                        </span>
+                    </CollapseHeader>
+                </CardHeader>
 
-            <CollapsePanel id="references">
-                {props.locations.length > 0 ? (
-                    <LocationsList
-                        locations={props.locations}
-                        isActiveLocation={props.isActiveLocation}
-                        setActiveLocation={props.setActiveLocation}
-                        filter={props.filter}
-                        navigateToUrl={props.navigateToUrl}
-                        handleOpenChange={(id, isOpen) => props.handleOpenChange(props.name + id, isOpen)}
-                        isOpen={id => props.isOpen(props.name + id)}
-                    />
-                ) : (
-                    <p className="text-muted pl-2">
-                        {props.filter ? (
-                            <i>
-                                No {props.name} matching <strong>{props.filter}</strong> found
-                            </i>
-                        ) : (
-                            <i>No {props.name} found</i>
-                        )}
-                    </p>
-                )}
-
-                {props.hasMore &&
-                    props.fetchMore !== undefined &&
-                    (props.loadingMore ? (
-                        <div className="text-center mb-1">
-                            <em>Loading more {props.name}...</em>
-                            <LoadingSpinner inline={true} />
-                        </div>
+                <CollapsePanel id={props.name}>
+                    {props.locations.length > 0 ? (
+                        <LocationsList
+                            locations={props.locations}
+                            isActiveLocation={props.isActiveLocation}
+                            setActiveLocation={props.setActiveLocation}
+                            filter={props.filter}
+                            navigateToUrl={props.navigateToUrl}
+                            handleOpenChange={(id, isOpen) => props.handleOpenChange(props.name + id, isOpen)}
+                            isOpen={id => props.isOpen(props.name + id)}
+                        />
                     ) : (
-                        <div className="text-center mb-1">
-                            <Button variant="secondary" onClick={props.fetchMore}>
-                                Load more {props.name}
-                            </Button>
-                        </div>
-                    ))}
-            </CollapsePanel>
-        </>
-    </Collapse>
-)
+                        <p className="text-muted pl-2">
+                            {props.filter ? (
+                                <i>
+                                    No {props.name} matching <strong>{props.filter}</strong> found
+                                </i>
+                            ) : (
+                                <i>No {props.name} found</i>
+                            )}
+                        </p>
+                    )}
+
+                    {props.hasMore &&
+                        props.fetchMore !== undefined &&
+                        (props.loadingMore ? (
+                            <div className="text-center mb-1">
+                                <em>Loading more {props.name}...</em>
+                                <LoadingSpinner inline={true} />
+                            </div>
+                        ) : (
+                            <div className="text-center mb-1">
+                                <Button variant="secondary" onClick={props.fetchMore}>
+                                    Load more {props.name}
+                                </Button>
+                            </div>
+                        ))}
+                </CollapsePanel>
+            </>
+        </Collapse>
+    )
+}
 
 const SideBlob: React.FunctionComponent<
     ReferencesPanelProps & {
@@ -713,25 +708,25 @@ const CollapsibleRepoLocationGroup: React.FunctionComponent<
                     as={Button}
                     aria-expanded={open}
                     type="button"
-                    className="bg-transparent py-1 border-bottom border-top-0 border-left-0 border-right-0 d-flex justify-content-start w-100"
+                    className={classNames('d-flex justify-content-start w-100', styles.repoLocationGroup)}
                 >
-                    <span className="p-0 mb-0">
-                        {open ? (
-                            <Icon aria-label="Close" as={ChevronDownIcon} />
-                        ) : (
-                            <Icon aria-label="Expand" as={ChevronRightIcon} />
-                        )}
-
+                    {open ? (
+                        <Icon aria-label="Close" as={ChevronDownIcon} />
+                    ) : (
+                        <Icon aria-label="Expand" as={ChevronRightIcon} />
+                    )}
+                    <small>
                         <Link
                             to={repoUrl}
                             onClick={event => {
                                 event.preventDefault()
                                 navigateToUrl(repoUrl)
                             }}
+                            className={classNames('text-small', styles.repoLocationGroupRepoName)}
                         >
                             {displayRepoName(repoLocationGroup.repoName)}
                         </Link>
-                    </span>
+                    </small>
                 </CollapseHeader>
 
                 <CollapsePanel id={repoLocationGroup.repoName}>
@@ -767,68 +762,73 @@ const CollapsibleLocationGroup: React.FunctionComponent<
     const open = isOpen(group.path) ?? true
 
     return (
-        <div className="ml-4">
-            <Collapse isOpen={open} onOpenChange={isOpen => handleOpenChange(group.path, isOpen)}>
-                <>
-                    <CollapseHeader
-                        as={Button}
-                        aria-expanded={open}
-                        type="button"
-                        className="bg-transparent py-1 border-bottom border-top-0 border-left-0 border-right-0 d-flex justify-content-start w-100"
-                    >
-                        <span className={styles.referenceFilename}>
-                            {open ? (
-                                <Icon aria-label="Close" as={ChevronDownIcon} />
-                            ) : (
-                                <Icon aria-label="Expand" as={ChevronRightIcon} />
-                            )}
-                            {highlighted.length === 2 ? (
-                                <span>
-                                    {highlighted[0]}
-                                    <mark>{filter}</mark>
-                                    {highlighted[1]}
-                                </span>
-                            ) : (
-                                group.path
-                            )}{' '}
-                            ({group.locations.length} references)
-                            <Badge pill={true} small={true} variant="secondary" className="ml-2">
-                                {locationGroupQuality(group)}
-                            </Badge>
+        <Collapse isOpen={open} onOpenChange={isOpen => handleOpenChange(group.path, isOpen)}>
+            <>
+                <CollapseHeader
+                    as={Button}
+                    aria-expanded={open}
+                    type="button"
+                    className={classNames(
+                        'bg-transparent py-1 border-top-0 border-left-0 border-right-0 d-flex justify-content-start w-100',
+                        styles.locationGroup
+                    )}
+                >
+                    {open ? (
+                        <Icon aria-label="Close" as={ChevronDownIcon} />
+                    ) : (
+                        <Icon aria-label="Expand" as={ChevronRightIcon} />
+                    )}
+                    <small className={styles.locationGroupFilename}>
+                        {highlighted.length === 2 ? (
+                            <span>
+                                {highlighted[0]}
+                                <mark>{filter}</mark>
+                                {highlighted[1]}
+                            </span>
+                        ) : (
+                            group.path
+                        )}{' '}
+                        <span className={classNames('ml-2 text-muted small', styles.cardHeaderSmallText)}>
+                            ({group.locations.length} {pluralize('reference', group.locations.length, 'references')})
                         </span>
-                    </CollapseHeader>
+                        <Badge small={true} variant="secondary" className="ml-4">
+                            {locationGroupQuality(group)}
+                        </Badge>
+                    </small>
+                </CollapseHeader>
 
-                    <CollapsePanel id={group.repoName + group.path} className="ml-2">
-                        <ul className="list-unstyled pl-3 py-1 mb-0">
-                            {group.locations.map(reference => {
-                                const className = isActiveLocation(reference) ? styles.referenceActive : ''
+                <CollapsePanel id={group.repoName + group.path} className="ml-0">
+                    <ul className="list-unstyled mb-0">
+                        {group.locations.map(reference => {
+                            const className = isActiveLocation(reference) ? styles.locationActive : ''
 
-                                return (
-                                    <li key={reference.url} className={classNames('border-0 rounded-0', className)}>
-                                        <div>
-                                            <Link
-                                                onClick={event => {
-                                                    event.preventDefault()
-                                                    setActiveLocation(reference)
-                                                }}
-                                                to={reference.url}
-                                                className={styles.referenceLink}
-                                            >
-                                                <span className={styles.referenceLinkLineNumber}>
-                                                    {(reference.range?.start?.line ?? 0) + 1}
-                                                    {': '}
-                                                </span>
-                                                <code>{getLineContent(reference)}</code>
-                                            </Link>
-                                        </div>
-                                    </li>
-                                )
-                            })}
-                        </ul>
-                    </CollapsePanel>
-                </>
-            </Collapse>
-        </div>
+                            return (
+                                <li
+                                    key={reference.url}
+                                    className={classNames('border-0 rounded-0 mb-0', styles.location, className)}
+                                >
+                                    <Link
+                                        as={Button}
+                                        onClick={event => {
+                                            event.preventDefault()
+                                            setActiveLocation(reference)
+                                        }}
+                                        to={reference.url}
+                                        className={styles.locationLink}
+                                    >
+                                        <span className={styles.locationLinkLineNumber}>
+                                            {(reference.range?.start?.line ?? 0) + 1}
+                                            {': '}
+                                        </span>
+                                        <code>{getLineContent(reference)}</code>
+                                    </Link>
+                                </li>
+                            )
+                        })}
+                    </ul>
+                </CollapsePanel>
+            </>
+        </Collapse>
     )
 }
 

--- a/client/web/src/codeintel/ReferencesPanel.tsx
+++ b/client/web/src/codeintel/ReferencesPanel.tsx
@@ -3,9 +3,9 @@ import React, { useEffect, useMemo, useState } from 'react'
 import classNames from 'classnames'
 import * as H from 'history'
 import { capitalize } from 'lodash'
+import ArrowCollapseRightIcon from 'mdi-react/ArrowCollapseRightIcon'
 import ChevronDownIcon from 'mdi-react/ChevronDownIcon'
 import ChevronRightIcon from 'mdi-react/ChevronRightIcon'
-import ArrowCollapseRightIcon from 'mdi-react/ArrowCollapseRightIcon'
 import FilterOutlineIcon from 'mdi-react/FilterOutlineIcon'
 import { MemoryRouter, useHistory, useLocation } from 'react-router'
 
@@ -202,9 +202,11 @@ const FilterableReferencesList: React.FunctionComponent<ReferencesPanelPropsWith
                 </Code>
             </CardHeader>
             <div className={classNames('d-flex justify-content-start', styles.filter)}>
-                <Icon as={FilterOutlineIcon} className={classNames('text-muted', styles.filterIcon)} />
+                <small>
+                    <Icon as={FilterOutlineIcon} size="sm" className={styles.filterIcon} />
+                </small>
                 <Input
-                    className={classNames('py-0 my-0 w-100')}
+                    className={classNames('py-0 my-0 w-100 text-small')}
                     type="text"
                     placeholder="Type to filter by filename"
                     value={filter === undefined ? '' : filter}
@@ -434,24 +436,28 @@ export const ReferencesList: React.FunctionComponent<
                 {activeLocation !== undefined && (
                     <div className={classNames('px-0 border-left', styles.referencesSideBlob)}>
                         <CardHeader className={classNames('d-flex', styles.cardHeader)}>
-                            <Button
-                                onClick={() => setActiveLocation(undefined)}
-                                className={classNames('btn-icon p-0', styles.referencesSideBlobCollapseButton)}
-                                title="Close panel"
-                                data-tooltip="Close panel"
-                                data-placement="left"
-                            >
-                                <Icon as={ArrowCollapseRightIcon} />
-                            </Button>
-                            <Link
-                                to={activeLocation.url}
-                                onClick={event => {
-                                    event.preventDefault()
-                                    navigateToUrl(activeLocation.url)
-                                }}
-                            >
-                                {activeLocation.file}{' '}
-                            </Link>
+                            <small>
+                                <Button
+                                    onClick={() => setActiveLocation(undefined)}
+                                    className={classNames('btn-icon p-0', styles.referencesSideBlobCollapseButton)}
+                                    title="Close panel"
+                                    data-tooltip="Close panel"
+                                    data-placement="left"
+                                    size="sm"
+                                >
+                                    <Icon size="sm" as={ArrowCollapseRightIcon} className="border-0" />
+                                </Button>
+                                <Link
+                                    to={activeLocation.url}
+                                    onClick={event => {
+                                        event.preventDefault()
+                                        navigateToUrl(activeLocation.url)
+                                    }}
+                                    className={styles.referencesSideBlobFilename}
+                                >
+                                    {activeLocation.file}{' '}
+                                </Link>
+                            </small>
                         </CardHeader>
                         <SideBlob
                             {...props}
@@ -769,7 +775,7 @@ const CollapsibleLocationGroup: React.FunctionComponent<
                     aria-expanded={open}
                     type="button"
                     className={classNames(
-                        'bg-transparent py-1 border-top-0 border-left-0 border-right-0 d-flex justify-content-start w-100',
+                        'bg-transparent border-top-0 border-left-0 border-right-0 d-flex justify-content-start w-100',
                         styles.locationGroup
                     )}
                 >

--- a/client/web/src/codeintel/searchBased.ts
+++ b/client/web/src/codeintel/searchBased.ts
@@ -2,11 +2,7 @@ import { extname } from 'path'
 
 import escapeRegExp from 'lodash/escapeRegExp'
 
-import {
-    appendLineRangeQueryParameter,
-    appendSubtreeQueryParameter,
-    toPositionOrRangeQueryParameter,
-} from '@sourcegraph/common'
+import { appendLineRangeQueryParameter, toPositionOrRangeQueryParameter } from '@sourcegraph/common'
 import { Range } from '@sourcegraph/extension-api-types'
 
 import { LanguageSpec } from './language-specs/languagespec'
@@ -404,7 +400,7 @@ function lineMatchesToResults(
 ): Result[] {
     return offsetAndLengths.map(([offset, length]) => {
         const url = appendLineRangeQueryParameter(
-            appendSubtreeQueryParameter(fileUrl),
+            fileUrl,
             toPositionOrRangeQueryParameter({
                 position: { line: lineNumber + 1, character: offset + 1 },
             })


### PR DESCRIPTION
This is the first pass to port [this Figma](https://www.figma.com/file/DZMyEJT3g2HT6HmJGNNOnW/%22Better%22-code-intel-panel?node-id=1220%3A3878) to the reference panel.

This is all the typography/margin/padding/sizing changes.

Reordering of the components so that filter/token are "inside" the left pane I will do in follow-up.

This also includes a *tiny* fix for a regression when creating URLs for search-based results.

### Before

<img width="1611" alt="screenshot_2022-04-21_14 13 41@2x" src="https://user-images.githubusercontent.com/1185253/164455698-bd0ba836-27e0-4bcb-b2d0-12d9543e8f8e.png">

### Figma

<img width="1471" alt="screenshot_2022-04-21_14 14 29@2x" src="https://user-images.githubusercontent.com/1185253/164455820-d641e935-0973-4c63-8caf-c519eb64d508.png">

### After

<img width="1599" alt="screenshot_2022-04-21_14 14 10@2x" src="https://user-images.githubusercontent.com/1185253/164455797-1bd489db-4ada-4f68-bf8d-736ff11622cc.png">



## Test plan

- Manually tested this locally and compared to Figma



## App preview:

- [Web](https://sg-web-mrn-ref-panel-figma-polish.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-yoluicarsb.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
