### PR TITLE
MI upgrades are handled by devops team now

### DIFF
--- a/dev/release/src/github.ts
+++ b/dev/release/src/github.ts
@@ -37,7 +37,7 @@ export enum IssueLabel {
     RELEASE = 'release',
     PATCH = 'patch',
     MANAGED = 'managed-instances',
-    DELIVERY_TEAM = 'team/delivery',
+    DEVOPS_TEAM = 'team/devops',
 }
 
 enum IssueTitleSuffix {
@@ -116,7 +116,7 @@ const getTemplates = () => {
         repo: 'handbook',
         path: 'content/departments/product-engineering/engineering/process/releases/upgrade_managed_issue_template.md',
         titleSuffix: IssueTitleSuffix.MANAGED_TRACKING,
-        labels: [IssueLabel.RELEASE_TRACKING, IssueLabel.MANAGED, IssueLabel.DELIVERY_TEAM],
+        labels: [IssueLabel.RELEASE_TRACKING, IssueLabel.MANAGED, IssueLabel.DEVOPS_TEAM],
     }
     return { releaseIssue, patchReleaseIssue, upgradeManagedInstanceIssue }
 }


### PR DESCRIPTION
Update release tooling to tag the devops team for MI upgrade tracking issues.

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->
Updated tag on new tracking issues