### PR TITLE
notebooks: Refactor column layout

### DIFF
--- a/client/web/src/notebooks/notebook/NotebookOutline.module.scss
+++ b/client/web/src/notebooks/notebook/NotebookOutline.module.scss
@@ -1,12 +1,14 @@
 .outline {
-    position: absolute;
+    flex: 1;
     padding: 0.5rem 1rem 1rem 0.5rem;
     width: 100%;
     max-width: 20rem;
-    height: 100%;
     background-color: var(--subtle-bg-2);
     border-right: 1px solid var(--border-color);
     transition: max-width 0.3s ease;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
 }
 
 .outline-closed {
@@ -23,6 +25,7 @@
     overflow: hidden;
     white-space: nowrap;
     text-overflow: ellipsis;
+    flex-shrink: 0;
 }
 
 .toggle-outline-button {
@@ -31,9 +34,9 @@
 }
 
 .scrollable-container {
-    position: relative;
-    height: 95%;
     overflow: hidden;
+    margin: 0;
+    flex: 1;
 
     &:hover {
         overflow: auto;
@@ -43,7 +46,6 @@
 .heading {
     overflow: hidden;
     white-space: nowrap;
-    text-overflow: ellipsis;
     color: var(--text-muted);
     font-size: 0.75rem;
 }
@@ -71,12 +73,23 @@
 }
 
 .heading-link {
+    display: block;
     position: relative;
     color: inherit;
 
     &:hover {
         color: inherit;
     }
+}
+
+// Together display: block, width: and max-width: have the effect of properly
+// positioning the tooltip text to right (or top) of the _visible_ text.
+.heading-link__text {
+    display: block;
+    width: fit-content;
+    max-width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 .highlight {

--- a/client/web/src/notebooks/notebook/NotebookOutline.tsx
+++ b/client/web/src/notebooks/notebook/NotebookOutline.tsx
@@ -178,15 +178,13 @@ export const NotebookOutline: React.FunctionComponent<NotebookOutlineProps> = Re
                             )}
                             aria-current={highlightedHeading === heading.id}
                         >
-                            <Link
-                                className={classNames(styles.headingLink)}
-                                to={`#${heading.id}`}
-                                data-tooltip={heading.text}
-                            >
+                            <Link className={classNames(styles.headingLink)} to={`#${heading.id}`}>
                                 {highlightedHeading === heading.id && (
                                     <span className={styles.highlightDot}>&middot;</span>
                                 )}
-                                <span>{heading.text}</span>
+                                <span data-tooltip={heading.text} className={classNames(styles.headingLinkText)}>
+                                    {heading.text}
+                                </span>
                             </Link>
                         </li>
                     ))}

--- a/client/web/src/notebooks/notebookPage/NotebookPage.module.scss
+++ b/client/web/src/notebooks/notebookPage/NotebookPage.module.scss
@@ -2,7 +2,8 @@
 
 .search-notebook-page {
     background: var(--color-bg-1);
-    overflow: auto;
+    overflow: hidden;
+    display: flex;
 }
 
 .spacer {
@@ -17,39 +18,26 @@
     height: 1rem !important;
 }
 
-.columns {
-    display: flex;
-}
-
 .side-column {
-    flex: 2;
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    margin-right: 1rem;
 
     @media (--lg-breakpoint-down) {
         display: none;
     }
 }
 
-.right-column {
-    // Reduce the size of the right column if screen size is max calc($viewport-xl + 20rem) = 1520px,
-    // to give more space to the outline and the notebook.
-    @media (max-width: 1520px) {
-        flex: 1;
-    }
-}
-
-.left-column {
-    position: sticky;
-    top: 0;
-    // Subtract the height of the navbar
-    height: calc(100vh - 2.5rem);
-    margin-right: 1rem;
-}
-
 .center-column {
     flex: 3;
+    overflow: hidden auto;
     min-width: #{$viewport-lg};
-    max-width: #{$viewport-xl};
-    padding: 0 1rem;
+
+    .content {
+        max-width: #{$viewport-xl};
+        padding: 0 1rem;
+    }
 
     @media (--lg-breakpoint-down) {
         min-width: 0;

--- a/client/web/src/notebooks/notebookPage/NotebookPage.tsx
+++ b/client/web/src/notebooks/notebookPage/NotebookPage.tsx
@@ -85,7 +85,7 @@ export const NotebookPage: React.FunctionComponent<NotebookPageProps> = ({
     extensionsController,
     match,
 }) => {
-    useEffect(() => telemetryService.logViewEvent('SearchNotebookPage'), [telemetryService])
+    useEffect(() => telemetryService.logPageView('SearchNotebookPage'), [telemetryService])
 
     const notebookId = match.params.id
     const [notebookTitle, setNotebookTitle] = useState('')
@@ -175,9 +175,9 @@ export const NotebookPage: React.FunctionComponent<NotebookPageProps> = ({
     return (
         <div className={classNames('w-100', styles.searchNotebookPage)}>
             <PageTitle title={notebookTitle || 'Notebook'} />
-            <div className={styles.columns}>
-                <div className={classNames(styles.sideColumn, styles.leftColumn)} ref={outlineContainerElement} />
-                <div className={styles.centerColumn}>
+            <div className={styles.sideColumn} ref={outlineContainerElement} />
+            <div className={styles.centerColumn}>
+                <div className={styles.content}>
                     {isErrorLike(notebookOrError) && (
                         <Alert variant="danger">
                             Error while loading the notebook: <strong>{notebookOrError.message}</strong>
@@ -293,7 +293,6 @@ export const NotebookPage: React.FunctionComponent<NotebookPageProps> = ({
                         </>
                     )}
                 </div>
-                <div className={classNames(styles.sideColumn, styles.rightColumn)} />
             </div>
         </div>
     )

--- a/client/web/src/notebooks/notebookPage/NotebookPageHeaderActions.tsx
+++ b/client/web/src/notebooks/notebookPage/NotebookPageHeaderActions.tsx
@@ -244,7 +244,7 @@ const NotebookStarsButton: React.FunctionComponent<NotebookStarsButtonProps> = (
 
     return (
         <Button
-            className="d-flex align-items-center"
+            className="d-flex align-items-center pl-0"
             outline={true}
             disabled={disabled}
             onClick={() => onStarToggle(viewerHasStarred)}


### PR DESCRIPTION
While working on the notepad CTA (which will be a separate PR), I noticed some minor issues with current layout of the notebook page. In particular:

- Gap/outline overflow appearing with small window height (at least in Firefox)
- Seemingly erratic scroll behavior when scrolling the outline (at least in Firefox)
- Incorrect position of tooltip text for very long headings
- Header and action alignment on small screens.

Instead of using flex box with three columns and making one column sticky (which I assume was done to (1) center the content within the window and (2) have the scrollbar for the main content appear on the right edge of the window), the new approach uses two columns which allows it to make them scrollable independently.

I tried to preserve the current look and feel as much as possible. In particular:

- Fixed outline heading and scrollable headings list
- Scrollbar for main content is positioned at the right edge of the window

## Screenshots/Videos

**Outline gap/overflow**: See lower right side. This is fixed with the new approach. This might not be something a user will run into during normal operation, but to me it's an indication that something doesn't work quite right.

<img width="582" alt="nb-outline-gap-overflow" src="https://user-images.githubusercontent.com/179026/164455903-2da66eb1-533a-44fa-be28-f56f5046937c.png">

---

**Tooltip position** (top: new, bottom: old): 

https://user-images.githubusercontent.com/179026/164456288-d7f65e02-3a5a-4e7f-a937-7231a4f8677c.mp4

---

**Erratic scroll behavior**: Since we have two nested scroll containers (left sidebar and parent element of the three columns), it looks like reaching the end/beginning of the sidebar sometimes(?) causes the parent element to scroll. But since we sync main content position with outline position that in turn causes the sidebar to scroll too.
This doesn't happen with the new approach because the scroll containers are not nested.

https://user-images.githubusercontent.com/179026/164456327-dca4f2f4-d0c1-4fd9-94f1-6f733a3697b3.mp4

---

Comparing old (bottom) and new (top) pages at **different screen sizes**: Since the new layout only uses two column, the main content isn't perfectly centered within the whole window anymore, but I hope that's OK (and less important compared to the fixes).
So the main difference is the width of the main content (we reach `max-width` "sooner") and the gaps between the outline and the main content and the right edge and the main content.

This one also shows the alignment change of the star button by removing the left padding:
<img width="386" alt="nb-outline-1" src="https://user-images.githubusercontent.com/179026/164456920-64b88115-9f15-48a4-9c0e-315b93989d82.png">

---
No difference when the outline is hidden:
<img width="771" alt="nb-outline-2" src="https://user-images.githubusercontent.com/179026/164456917-5153ca32-e33c-4bf1-9711-2c08be68ef05.png">

---
Without an (empty) right column, the outline takes up more space, but that actually looks better to me (entirely subjective of course). There is no empty space on the right hand side:

<img width="957" alt="nb-outline-3" src="https://user-images.githubusercontent.com/179026/164456914-e7623d27-974b-45da-98c8-61d2b2cba270.png">

---
Similar here though the way things are currently structured, space will first be added between the outline and the main content instead of the main content and the right hand side, which seems a bit odd to me. I think this could be changed (if desired).

<img width="1153" alt="nb-outline-4" src="https://user-images.githubusercontent.com/179026/164456910-3e78d421-e681-48ba-a74c-79fd82f4b90e.png">

---

The remaining screenshots just show how gaps/spaces and content size differ between old and new at various sizes.

<img width="1346" alt="nb-outline-5" src="https://user-images.githubusercontent.com/179026/164456909-7e4d13bd-fbae-4189-b067-d026a5337919.png">

---

<img width="1536" alt="nb-outline-6" src="https://user-images.githubusercontent.com/179026/164456906-14c4de9a-9733-4620-970a-643e06af262c.png">

---

<img width="1727" alt="nb-outline-7" src="https://user-images.githubusercontent.com/179026/164456903-1fdcda7d-25f6-4e2b-92c1-9821a6300a7c.png">

---

<img width="1920" alt="nb-outline-8" src="https://user-images.githubusercontent.com/179026/164456900-30ca7146-a5f6-4136-b34a-cc6ac9d0b56b.png">


## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


