### PR TITLE
[web][CLOUD-265] Fix focus order for `Forgot password?` link

### DIFF
--- a/client/web/src/auth/UsernamePasswordSignInForm.tsx
+++ b/client/web/src/auth/UsernamePasswordSignInForm.tsx
@@ -114,15 +114,10 @@ export const UsernamePasswordSignInForm: React.FunctionComponent<Props> = ({
                         autoComplete="username"
                     />
                 </div>
-                <div className="form-group d-flex flex-column align-content-start">
-                    <div className="d-flex justify-content-between">
-                        <label htmlFor="password">Password</label>
-                        {context.resetPasswordEnabled && (
-                            <small className="form-text text-muted">
-                                <Link to="/password-reset">Forgot password?</Link>
-                            </small>
-                        )}
-                    </div>
+                <div className="form-group d-flex flex-column align-content-start position-relative">
+                    <label htmlFor="password" className="align-self-start">
+                        Password
+                    </label>
                     <PasswordInput
                         onChange={onPasswordFieldChange}
                         value={password}
@@ -131,6 +126,11 @@ export const UsernamePasswordSignInForm: React.FunctionComponent<Props> = ({
                         autoComplete="current-password"
                         placeholder=" "
                     />
+                    {context.resetPasswordEnabled && (
+                        <small className="form-text text-muted align-self-end position-absolute">
+                            <Link to="/password-reset">Forgot password?</Link>
+                        </small>
+                    )}
                 </div>
                 <div
                     className={classNames('form-group', {

--- a/client/web/src/auth/__snapshots__/SignInPage.test.tsx.snap
+++ b/client/web/src/auth/__snapshots__/SignInPage.test.tsx.snap
@@ -73,27 +73,14 @@ exports[`SignInPage renders sign in page (cloud) 1`] = `
               />
             </div>
             <div
-              class="form-group d-flex flex-column align-content-start"
+              class="form-group d-flex flex-column align-content-start position-relative"
             >
-              <div
-                class="d-flex justify-content-between"
+              <label
+                class="align-self-start"
+                for="password"
               >
-                <label
-                  for="password"
-                >
-                  Password
-                </label>
-                <small
-                  class="form-text text-muted"
-                >
-                  <a
-                    class="anchorLink"
-                    href="/password-reset"
-                  >
-                    Forgot password?
-                  </a>
-                </small>
-              </div>
+                Password
+              </label>
               <input
                 autocomplete="current-password"
                 class="form-control"
@@ -104,6 +91,16 @@ exports[`SignInPage renders sign in page (cloud) 1`] = `
                 type="password"
                 value=""
               />
+              <small
+                class="form-text text-muted align-self-end position-absolute"
+              >
+                <a
+                  class="anchorLink"
+                  href="/password-reset"
+                >
+                  Forgot password?
+                </a>
+              </small>
             </div>
             <div
               class="form-group"
@@ -234,27 +231,14 @@ exports[`SignInPage renders sign in page (server) 1`] = `
               />
             </div>
             <div
-              class="form-group d-flex flex-column align-content-start"
+              class="form-group d-flex flex-column align-content-start position-relative"
             >
-              <div
-                class="d-flex justify-content-between"
+              <label
+                class="align-self-start"
+                for="password"
               >
-                <label
-                  for="password"
-                >
-                  Password
-                </label>
-                <small
-                  class="form-text text-muted"
-                >
-                  <a
-                    class="anchorLink"
-                    href="/password-reset"
-                  >
-                    Forgot password?
-                  </a>
-                </small>
-              </div>
+                Password
+              </label>
               <input
                 autocomplete="current-password"
                 class="form-control"
@@ -265,6 +249,16 @@ exports[`SignInPage renders sign in page (server) 1`] = `
                 type="password"
                 value=""
               />
+              <small
+                class="form-text text-muted align-self-end position-absolute"
+              >
+                <a
+                  class="anchorLink"
+                  href="/password-reset"
+                >
+                  Forgot password?
+                </a>
+              </small>
             </div>
             <div
               class="form-group"


### PR DESCRIPTION
# Description

Previously, the link was second in tab focused items on the page.
This was inconvenient, because after typing in username, hitting
tab would focus on the Forgot password link instead of the
password input.

Now the order of the focus was reversed so that password input
is focused before the Forgot password link. Which allows
to fill the login form by hitting TAB only once.

# Video

https://user-images.githubusercontent.com/9974711/164483837-2e6932b5-0974-4d41-96cf-1874b1df7e3c.mp4



# Related items
https://sourcegraph.atlassian.net/browse/CLOUD-265



## Test plan

There is no change in functionality, just ordering of elements. Tested locally, as seen in the video.



## App preview:

- [Web](https://sg-web-cloud-265.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-mutomkmseo.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
