### PR TITLE
[SG-33302] Upgrade all client packages to use the latest version of the JSX transform 

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -140,6 +140,9 @@ See https://handbook.sourcegraph.com/community/faq#is-all-of-sourcegraph-open-so
           'Consider using useTemporarySetting instead of useLocalStorage so settings are synced when users log in elsewhere. More info at https://docs.sourcegraph.com/dev/background-information/web/temporary_settings',
       },
     ],
+    // https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html#eslint
+    'react/jsx-uses-react': 'off',
+    'react/react-in-jsx-scope': 'off',
   },
   overrides: [
     {

--- a/babel.config.js
+++ b/babel.config.js
@@ -48,7 +48,12 @@ module.exports = api => {
         },
       ],
       '@babel/preset-typescript',
-      '@babel/preset-react',
+      [
+        '@babel/preset-react',
+        {
+          runtime: 'automatic',
+        },
+      ],
     ],
     plugins: [['@babel/plugin-transform-typescript', { isTSX: true }], 'babel-plugin-lodash'],
     // Required for d3-array v1.2 (dependency of recharts). See https://github.com/babel/babel/issues/11038

--- a/client/branded/src/components/LoaderInput.story.tsx
+++ b/client/branded/src/components/LoaderInput.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { boolean } from '@storybook/addon-knobs'
 import { DecoratorFn, Meta, Story } from '@storybook/react'
 

--- a/client/branded/src/components/LoaderInput.test.tsx
+++ b/client/branded/src/components/LoaderInput.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { render } from '@testing-library/react'
 
 import { LoaderInput } from './LoaderInput'

--- a/client/branded/src/components/Toggle.story.tsx
+++ b/client/branded/src/components/Toggle.story.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import { useState } from 'react'
 
 import { action } from '@storybook/addon-actions'
 import { DecoratorFn, Meta, Story } from '@storybook/react'

--- a/client/branded/src/components/Toggle.test.tsx
+++ b/client/branded/src/components/Toggle.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import sinon from 'sinon'

--- a/client/branded/src/components/ToggleBig.story.tsx
+++ b/client/branded/src/components/ToggleBig.story.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import { useState } from 'react'
 
 import { action } from '@storybook/addon-actions'
 import { DecoratorFn, Meta, Story } from '@storybook/react'

--- a/client/branded/src/components/ToggleBig.test.tsx
+++ b/client/branded/src/components/ToggleBig.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import sinon from 'sinon'

--- a/client/branded/src/components/alerts.test.tsx
+++ b/client/branded/src/components/alerts.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { render } from '@testing-library/react'
 
 import { ErrorAlert } from './alerts'

--- a/client/branded/src/components/panel/TabbedPanelContent.story.tsx
+++ b/client/branded/src/components/panel/TabbedPanelContent.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { DecoratorFn, Meta, Story } from '@storybook/react'
 import { noop } from 'lodash'
 import { EMPTY, of } from 'rxjs'

--- a/client/branded/src/components/panel/TabbedPanelContent.test.tsx
+++ b/client/branded/src/components/panel/TabbedPanelContent.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { cleanup, fireEvent } from '@testing-library/react'
 
 import { renderWithBrandedContext } from '@sourcegraph/shared/src/testing'

--- a/client/branded/src/components/panel/views/HierarchicalLocationsView.story.tsx
+++ b/client/branded/src/components/panel/views/HierarchicalLocationsView.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { DecoratorFn, Meta, Story } from '@storybook/react'
 import * as H from 'history'
 import { of } from 'rxjs'

--- a/client/branded/src/components/panel/views/HierarchicalLocationsView.test.tsx
+++ b/client/branded/src/components/panel/views/HierarchicalLocationsView.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { render } from '@testing-library/react'
 import * as H from 'history'
 import { noop } from 'lodash'

--- a/client/branded/src/global-styles/GlobalStylesStory/GlobalStyles.story.tsx
+++ b/client/branded/src/global-styles/GlobalStylesStory/GlobalStyles.story.tsx
@@ -2,7 +2,7 @@
 // documentation of all the Bootstrap classes we have available in our app, please see refer to the Bootstrap
 // documentation for that. Its primary purpose is to show what Bootstrap's componenents look like with our styling
 // customizations.
-import React, { useState } from 'react'
+import { useState } from 'react'
 
 import { action } from '@storybook/addon-actions'
 import { number } from '@storybook/addon-knobs'

--- a/client/branded/tsconfig.json
+++ b/client/branded/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "jsx": "react",
+    "jsx": "react-jsx",
     "module": "esnext",
     "sourceRoot": "src",
     "baseUrl": ".",

--- a/client/browser/src/browser-extension/ThemeWrapper.tsx
+++ b/client/browser/src/browser-extension/ThemeWrapper.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
 

--- a/client/browser/src/browser-extension/after-install-page/AfterInstallPageContent.story.tsx
+++ b/client/browser/src/browser-extension/after-install-page/AfterInstallPageContent.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { Meta, Story } from '@storybook/react'
 
 import { BrandedStory } from '@sourcegraph/branded/src/components/BrandedStory'

--- a/client/browser/src/shared/code-hosts/github/codeHost.tsx
+++ b/client/browser/src/shared/code-hosts/github/codeHost.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import classNames from 'classnames'
 import { trimStart } from 'lodash'
 import { render } from 'react-dom'

--- a/client/browser/src/shared/code-hosts/shared/ViewOnSourcegraphButton.test.tsx
+++ b/client/browser/src/shared/code-hosts/shared/ViewOnSourcegraphButton.test.tsx
@@ -1,5 +1,3 @@
-import * as React from 'react'
-
 import { render } from '@testing-library/react'
 import { noop } from 'lodash'
 

--- a/client/browser/src/shared/code-hosts/shared/extensions.tsx
+++ b/client/browser/src/shared/code-hosts/shared/extensions.tsx
@@ -1,5 +1,3 @@
-import * as React from 'react'
-
 import classNames from 'classnames'
 import * as H from 'history'
 import { isEqual } from 'lodash'

--- a/client/browser/tsconfig.json
+++ b/client/browser/tsconfig.json
@@ -15,7 +15,7 @@
     "paths": {
       "*": ["src/types/*", "../shared/src/types/*", "../common/src/types/*", "*"],
     },
-    "jsx": "react",
+    "jsx": "react-jsx",
     "resolveJsonModule": true,
     "rootDir": ".",
     "outDir": "out",

--- a/client/client-api/tsconfig.json
+++ b/client/client-api/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.json",
   "references": [{ "path": "../common" }],
   "compilerOptions": {
-    "jsx": "react",
+    "jsx": "react-jsx",
     "module": "commonjs",
     "sourceRoot": "src",
     "rootDir": ".",

--- a/client/search-ui/src/components/SyntaxHighlightedSearchQuery.story.tsx
+++ b/client/search-ui/src/components/SyntaxHighlightedSearchQuery.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { storiesOf } from '@storybook/react'
 
 import { BrandedStory } from '@sourcegraph/branded/src/components/BrandedStory'

--- a/client/search-ui/src/components/SyntaxHighlightedSearchQuery.test.tsx
+++ b/client/search-ui/src/components/SyntaxHighlightedSearchQuery.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { render } from '@testing-library/react'
 
 import { SyntaxHighlightedSearchQuery } from './SyntaxHighlightedSearchQuery'

--- a/client/search-ui/src/input/LazyMonacoQueryInput.test.tsx
+++ b/client/search-ui/src/input/LazyMonacoQueryInput.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { render } from '@testing-library/react'
 import { noop } from 'lodash'
 

--- a/client/search-ui/src/input/MonacoQueryInput.story.tsx
+++ b/client/search-ui/src/input/MonacoQueryInput.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { storiesOf } from '@storybook/react'
 
 import { BrandedStory } from '@sourcegraph/branded/src/components/BrandedStory'

--- a/client/search-ui/src/input/SearchBox.story.tsx
+++ b/client/search-ui/src/input/SearchBox.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { storiesOf } from '@storybook/react'
 
 import { BrandedStory } from '@sourcegraph/branded/src/components/BrandedStory'

--- a/client/search-ui/src/input/SearchContextCtaPrompt.story.tsx
+++ b/client/search-ui/src/input/SearchContextCtaPrompt.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { storiesOf } from '@storybook/react'
 
 import { BrandedStory } from '@sourcegraph/branded/src/components/BrandedStory'

--- a/client/search-ui/src/input/SearchContextDropdown.test.tsx
+++ b/client/search-ui/src/input/SearchContextDropdown.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { act } from 'react-dom/test-utils'

--- a/client/search-ui/src/input/SearchContextMenu.story.tsx
+++ b/client/search-ui/src/input/SearchContextMenu.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { storiesOf } from '@storybook/react'
 import { Observable, of } from 'rxjs'
 

--- a/client/search-ui/src/input/SearchContextMenu.test.tsx
+++ b/client/search-ui/src/input/SearchContextMenu.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { act } from 'react-dom/test-utils'

--- a/client/search-ui/src/input/SearchContextMenuItem.story.tsx
+++ b/client/search-ui/src/input/SearchContextMenuItem.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { storiesOf } from '@storybook/react'
 import { noop } from 'lodash'
 

--- a/client/search-ui/src/input/toggles/Toggles.test.tsx
+++ b/client/search-ui/src/input/toggles/Toggles.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { screen } from '@testing-library/react'
 
 import { SearchPatternType } from '@sourcegraph/shared/src/schema'

--- a/client/search-ui/src/results/progress/StreamingProgress.story.tsx
+++ b/client/search-ui/src/results/progress/StreamingProgress.story.tsx
@@ -1,5 +1,3 @@
-import * as React from 'react'
-
 import { storiesOf } from '@storybook/react'
 import sinon from 'sinon'
 

--- a/client/search-ui/src/results/progress/StreamingProgressCount.test.tsx
+++ b/client/search-ui/src/results/progress/StreamingProgressCount.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { render } from '@testing-library/react'
 
 import { Progress } from '@sourcegraph/shared/src/search/stream'

--- a/client/search-ui/src/results/progress/StreamingProgressSkippedButton.test.tsx
+++ b/client/search-ui/src/results/progress/StreamingProgressSkippedButton.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import sinon from 'sinon'

--- a/client/search-ui/src/results/progress/StreamingProgressSkippedPopover.story.tsx
+++ b/client/search-ui/src/results/progress/StreamingProgressSkippedPopover.story.tsx
@@ -1,5 +1,3 @@
-import * as React from 'react'
-
 import { storiesOf } from '@storybook/react'
 
 import { BrandedStory } from '@sourcegraph/branded/src/components/BrandedStory'

--- a/client/search-ui/src/results/progress/StreamingProgressSkippedPopover.test.tsx
+++ b/client/search-ui/src/results/progress/StreamingProgressSkippedPopover.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import sinon from 'sinon'

--- a/client/search-ui/src/results/sidebar/FilterLink.test.tsx
+++ b/client/search-ui/src/results/sidebar/FilterLink.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import sinon from 'sinon'

--- a/client/search-ui/src/results/sidebar/QuickLink.test.tsx
+++ b/client/search-ui/src/results/sidebar/QuickLink.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { QuickLink } from '@sourcegraph/shared/src/schema/settings.schema'
 import { renderWithBrandedContext } from '@sourcegraph/shared/src/testing'
 

--- a/client/search-ui/src/results/sidebar/SearchSidebar.story.tsx
+++ b/client/search-ui/src/results/sidebar/SearchSidebar.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { storiesOf } from '@storybook/react'
 // We need to import `create` to make a mock store just for this story.
 // eslint-disable-next-line no-restricted-imports

--- a/client/search-ui/src/results/sidebar/SearchSidebarSection.test.tsx
+++ b/client/search-ui/src/results/sidebar/SearchSidebarSection.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import sinon from 'sinon'

--- a/client/search-ui/tsconfig.json
+++ b/client/search-ui/tsconfig.json
@@ -6,7 +6,7 @@
     "rootDir": ".",
     "outDir": "./out",
     "baseUrl": "./src",
-    "jsx": "react",
+    "jsx": "react-jsx",
   },
   "include": ["./src/**/*", "./*.ts"],
   "exclude": ["../../node_modules", "./node_modules", "./out"],

--- a/client/search/tsconfig.json
+++ b/client/search/tsconfig.json
@@ -6,7 +6,7 @@
     "rootDir": ".",
     "outDir": "./out",
     "baseUrl": "./src",
-    "jsx": "react",
+    "jsx": "react-jsx",
   },
   "include": ["./src/**/*", "./*.ts"],
   "exclude": ["../../node_modules", "./node_modules", "./out"],

--- a/client/shared/src/actions/ActionItem.story.tsx
+++ b/client/shared/src/actions/ActionItem.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { action } from '@storybook/addon-actions'
 import { DecoratorFn, Meta, Story } from '@storybook/react'
 import * as H from 'history'

--- a/client/shared/src/actions/ActionItem.test.tsx
+++ b/client/shared/src/actions/ActionItem.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import * as H from 'history'

--- a/client/shared/src/actions/ActionsNavItems.test.tsx
+++ b/client/shared/src/actions/ActionsNavItems.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { render, act, RenderResult } from '@testing-library/react'
 import * as H from 'history'
 import { of, NEVER } from 'rxjs'

--- a/client/shared/src/components/CtaAlert.story.tsx
+++ b/client/shared/src/components/CtaAlert.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { DecoratorFn, Meta, Story } from '@storybook/react'
 
 // eslint-disable-next-line no-restricted-imports

--- a/client/shared/src/components/FileMatch.test.tsx
+++ b/client/shared/src/components/FileMatch.test.tsx
@@ -1,5 +1,3 @@
-import * as React from 'react'
-
 import { cleanup, getAllByTestId, getByTestId } from '@testing-library/react'
 import { createBrowserHistory } from 'history'
 import FileIcon from 'mdi-react/FileIcon'

--- a/client/shared/src/components/FileMatchChildren.test.tsx
+++ b/client/shared/src/components/FileMatchChildren.test.tsx
@@ -1,5 +1,3 @@
-import * as React from 'react'
-
 import { cleanup } from '@testing-library/react'
 import * as H from 'history'
 import _VisibilitySensor from 'react-visibility-sensor'

--- a/client/shared/src/components/HighlightedMatches.test.tsx
+++ b/client/shared/src/components/HighlightedMatches.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { render } from '@testing-library/react'
 
 import { fuzzyMatches, HighlightedMatches, Span } from './HighlightedMatches'

--- a/client/shared/src/components/LinkOrSpan.test.tsx
+++ b/client/shared/src/components/LinkOrSpan.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { render } from '@testing-library/react'
 
 import { LinkOrSpan } from './LinkOrSpan'

--- a/client/shared/src/components/Markdown.test.tsx
+++ b/client/shared/src/components/Markdown.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { render } from '@testing-library/react'
 
 import { Markdown } from './Markdown'

--- a/client/shared/src/components/Path.test.tsx
+++ b/client/shared/src/components/Path.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { render } from '@testing-library/react'
 
 import { Path } from './Path'

--- a/client/shared/src/components/RepoFileLink.test.tsx
+++ b/client/shared/src/components/RepoFileLink.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { renderWithBrandedContext } from '../testing'
 
 import { RepoFileLink } from './RepoFileLink'

--- a/client/shared/src/components/RepoLink.test.tsx
+++ b/client/shared/src/components/RepoLink.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { render } from '@testing-library/react'
 
 import { RepoLink } from './RepoLink'

--- a/client/shared/src/components/ResultContainer.test.tsx
+++ b/client/shared/src/components/ResultContainer.test.tsx
@@ -1,5 +1,3 @@
-import * as React from 'react'
-
 import { cleanup, fireEvent, getByTestId, getByText } from '@testing-library/react'
 import * as H from 'history'
 import FileIcon from 'mdi-react/FileIcon'

--- a/client/shared/src/components/activation/ActivationChecklist.test.tsx
+++ b/client/shared/src/components/activation/ActivationChecklist.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { renderWithBrandedContext } from '../../testing'
 
 import { ActivationChecklist } from './ActivationChecklist'

--- a/client/shared/src/components/utils/linkClickHandler.test.tsx
+++ b/client/shared/src/components/utils/linkClickHandler.test.tsx
@@ -1,7 +1,5 @@
 import assert from 'assert'
 
-import React from 'react'
-
 import { createMemoryHistory } from 'history'
 import ReactDOM from 'react-dom'
 import * as sinon from 'sinon'

--- a/client/shared/src/hover/HoverOverlay.story.tsx
+++ b/client/shared/src/hover/HoverOverlay.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import bitbucketStyles from '@atlassian/aui/dist/aui/css/aui.css'
 import { DecoratorFn, Meta, Story } from '@storybook/react'
 import classNames from 'classnames'

--- a/client/shared/src/hover/HoverOverlay.test.tsx
+++ b/client/shared/src/hover/HoverOverlay.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { render } from '@testing-library/react'
 import * as H from 'history'
 import { NEVER } from 'rxjs'

--- a/client/shared/src/keyboardShortcuts/KeyboardShortcutsHelp.test.tsx
+++ b/client/shared/src/keyboardShortcuts/KeyboardShortcutsHelp.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { ShortcutProvider } from '@slimsag/react-shortcuts'
 import { fireEvent, waitFor, screen } from '@testing-library/react'
 

--- a/client/shared/src/notifications/NotificationItem.story.tsx
+++ b/client/shared/src/notifications/NotificationItem.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { action } from '@storybook/addon-actions'
 import { number, select, text } from '@storybook/addon-knobs'
 import { DecoratorFn, Meta, Story } from '@storybook/react'

--- a/client/shared/src/settings/temporary/useTemporarySetting.test.tsx
+++ b/client/shared/src/settings/temporary/useTemporarySetting.test.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react'
+import { useEffect } from 'react'
 
 import { gql } from '@apollo/client'
 import { createMockClient } from '@apollo/client/testing'

--- a/client/shared/src/testing/render-with-branded-context.tsx
+++ b/client/shared/src/testing/render-with-branded-context.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from 'react'
+import { ReactNode } from 'react'
 
 import { RenderResult, render } from '@testing-library/react'
 import { MemoryHistory, createMemoryHistory } from 'history'

--- a/client/shared/tsconfig.json
+++ b/client/shared/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "jsx": "react",
+    "jsx": "react-jsx",
     "module": "esnext",
     "sourceRoot": "src",
     "baseUrl": ".",

--- a/client/storybook/tsconfig.json
+++ b/client/storybook/tsconfig.json
@@ -6,7 +6,7 @@
     "rootDir": ".",
     "outDir": "./out",
     "baseUrl": "./src",
-    "jsx": "react",
+    "jsx": "react-jsx",
   },
   "references": [{ "path": "../shared" }, { "path": "../build-config" }, { "path": "../http-client" }],
   "include": ["./src/**/*", "./*.ts"],

--- a/client/vscode/tsconfig.json
+++ b/client/vscode/tsconfig.json
@@ -13,7 +13,7 @@
     "esModuleInterop": true,
     "resolveJsonModule": true,
     "strict": true,
-    "jsx": "react",
+    "jsx": "react-jsx",
   },
   "references": [
     { "path": "../shared" },

--- a/client/web/src/IdeExtensionTracker.test.tsx
+++ b/client/web/src/IdeExtensionTracker.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { cleanup, render } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 

--- a/client/web/src/Layout.test.tsx
+++ b/client/web/src/Layout.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { render } from '@testing-library/react'
 import { createBrowserHistory } from 'history'
 import { BrowserRouter } from 'react-router-dom'

--- a/client/web/src/auth/CloudSignUpPage.story.tsx
+++ b/client/web/src/auth/CloudSignUpPage.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { storiesOf } from '@storybook/react'
 import sinon from 'sinon'
 

--- a/client/web/src/auth/OrDivider.story.tsx
+++ b/client/web/src/auth/OrDivider.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { storiesOf } from '@storybook/react'
 
 import { Card } from '@sourcegraph/wildcard'

--- a/client/web/src/auth/SignInPage.test.tsx
+++ b/client/web/src/auth/SignInPage.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { createMemoryHistory, createLocation } from 'history'
 import { MemoryRouter } from 'react-router'
 

--- a/client/web/src/auth/SignUpPage.test.tsx
+++ b/client/web/src/auth/SignUpPage.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { createMemoryHistory, createLocation } from 'history'
 import { MemoryRouter } from 'react-router'
 

--- a/client/web/src/auth/Steps/Steps.story.tsx
+++ b/client/web/src/auth/Steps/Steps.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { Meta, Story } from '@storybook/react'
 
 import { BrandedStory } from '@sourcegraph/branded/src/components/BrandedStory'

--- a/client/web/src/auth/Steps/Steps.test.tsx
+++ b/client/web/src/auth/Steps/Steps.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { render, RenderResult, cleanup } from '@testing-library/react'
 import sinon from 'sinon'
 

--- a/client/web/src/auth/TosConsentModal.story.tsx
+++ b/client/web/src/auth/TosConsentModal.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { storiesOf } from '@storybook/react'
 
 import { WebStory } from '../components/WebStory'

--- a/client/web/src/auth/TosConsentModal.test.tsx
+++ b/client/web/src/auth/TosConsentModal.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { MockedProvider } from '@apollo/client/testing'
 import { fireEvent, render } from '@testing-library/react'
 import * as sinon from 'sinon'

--- a/client/web/src/batches/RepoBatchChangesButton.story.tsx
+++ b/client/web/src/batches/RepoBatchChangesButton.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { number } from '@storybook/addon-knobs'
 import { storiesOf } from '@storybook/react'
 import { of } from 'rxjs'

--- a/client/web/src/batches/RepoBatchChangesButton.tsx
+++ b/client/web/src/batches/RepoBatchChangesButton.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useMemo } from 'react'
+import { FC, useMemo } from 'react'
 
 import { encodeURIPathComponent } from '@sourcegraph/common'
 import { Badge, useObservable, Button, Link, Icon } from '@sourcegraph/wildcard'

--- a/client/web/src/charts/components/line-chart/LineChart.story.tsx
+++ b/client/web/src/charts/components/line-chart/LineChart.story.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import { useState } from 'react'
 
 import { Meta, Story } from '@storybook/react'
 import { ParentSize } from '@visx/responsive'

--- a/client/web/src/charts/components/line-chart/LineChart.tsx
+++ b/client/web/src/charts/components/line-chart/LineChart.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useMemo, useState, SVGProps } from 'react'
+import { ReactElement, useMemo, useState, SVGProps } from 'react'
 
 import { curveLinear } from '@visx/curve'
 import { Group } from '@visx/group'

--- a/client/web/src/charts/components/line-chart/components/axis/Axis.tsx
+++ b/client/web/src/charts/components/line-chart/components/axis/Axis.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, memo } from 'react'
+import { forwardRef, memo } from 'react'
 
 import { AxisLeft as VisxAxisLeft, AxisBottom as VisxAsixBottom } from '@visx/axis'
 import { AxisScale } from '@visx/axis/lib/types'

--- a/client/web/src/charts/components/line-chart/components/tooltip/TooltipContent.story.tsx
+++ b/client/web/src/charts/components/line-chart/components/tooltip/TooltipContent.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { Meta, Story } from '@storybook/react'
 
 import { WebStory } from '../../../../../components/WebStory'

--- a/client/web/src/charts/components/line-chart/components/tooltip/TooltipContent.tsx
+++ b/client/web/src/charts/components/line-chart/components/tooltip/TooltipContent.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useMemo } from 'react'
+import { ReactElement, useMemo } from 'react'
 
 import { isDefined } from '@sourcegraph/common'
 

--- a/client/web/src/charts/components/pie-chart/PieChart.story.tsx
+++ b/client/web/src/charts/components/pie-chart/PieChart.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { Meta, Story } from '@storybook/react'
 
 import { WebStory } from '../../../components/WebStory'

--- a/client/web/src/charts/components/pie-chart/PieChart.tsx
+++ b/client/web/src/charts/components/pie-chart/PieChart.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, SVGProps, useMemo, useState } from 'react'
+import { ReactElement, SVGProps, useMemo, useState } from 'react'
 
 import { Group } from '@visx/group'
 import Pie, { PieArcDatum } from '@visx/shape/lib/shapes/Pie'

--- a/client/web/src/charts/components/pie-chart/components/PieArc.tsx
+++ b/client/web/src/charts/components/pie-chart/components/PieArc.tsx
@@ -1,4 +1,4 @@
-import React, { PointerEventHandler, ReactElement } from 'react'
+import { PointerEventHandler, ReactElement } from 'react'
 
 import { Annotation, HtmlLabel, Connector } from '@visx/annotation'
 import { Group } from '@visx/group'

--- a/client/web/src/codeintel/RepositoryMenu.story.tsx
+++ b/client/web/src/codeintel/RepositoryMenu.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { storiesOf } from '@storybook/react'
 
 import { WebStory } from '../components/WebStory'

--- a/client/web/src/communitySearchContexts/CommunitySearchContextPage.story.tsx
+++ b/client/web/src/communitySearchContexts/CommunitySearchContextPage.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { action } from '@storybook/addon-actions'
 import { storiesOf } from '@storybook/react'
 import { subDays } from 'date-fns'

--- a/client/web/src/communitySearchContexts/routes.tsx
+++ b/client/web/src/communitySearchContexts/routes.tsx
@@ -1,5 +1,3 @@
-import * as React from 'react'
-
 import { lazyComponent } from '@sourcegraph/shared/src/util/lazyComponent'
 
 import { LayoutRouteProps } from '../routes'

--- a/client/web/src/components/ActivationDropdown/ActivationDropdown.story.tsx
+++ b/client/web/src/components/ActivationDropdown/ActivationDropdown.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { action } from '@storybook/addon-actions'
 import { boolean } from '@storybook/addon-knobs'
 import { DecoratorFn, Meta, Story } from '@storybook/react'

--- a/client/web/src/components/ActivationDropdown/ActivationDropdown.test.tsx
+++ b/client/web/src/components/ActivationDropdown/ActivationDropdown.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { render } from '@testing-library/react'
 import * as H from 'history'
 import sinon from 'sinon'

--- a/client/web/src/components/Breadcrumbs.story.tsx
+++ b/client/web/src/components/Breadcrumbs.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { storiesOf } from '@storybook/react'
 
 import { Link } from '@sourcegraph/wildcard'

--- a/client/web/src/components/DismissibleAlert/DismissibleAlert.story.tsx
+++ b/client/web/src/components/DismissibleAlert/DismissibleAlert.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { storiesOf } from '@storybook/react'
 
 import { Link } from '@sourcegraph/wildcard'

--- a/client/web/src/components/FilteredConnection/FilteredConnection.test.tsx
+++ b/client/web/src/components/FilteredConnection/FilteredConnection.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { createLocation } from 'history'
 import sinon from 'sinon'

--- a/client/web/src/components/FilteredConnection/hooks/useConnection.test.tsx
+++ b/client/web/src/components/FilteredConnection/hooks/useConnection.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { MockedResponse } from '@apollo/client/testing'
 import { fireEvent } from '@testing-library/react'
 

--- a/client/web/src/components/FilteredConnection/ui/ConnectionSummary.tsx
+++ b/client/web/src/components/FilteredConnection/ui/ConnectionSummary.tsx
@@ -1,5 +1,3 @@
-import * as React from 'react'
-
 import classNames from 'classnames'
 
 import { pluralize } from '@sourcegraph/common'

--- a/client/web/src/components/LoaderButton.story.tsx
+++ b/client/web/src/components/LoaderButton.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { storiesOf } from '@storybook/react'
 
 import { LoaderButton } from './LoaderButton'

--- a/client/web/src/components/LoaderButton.test.tsx
+++ b/client/web/src/components/LoaderButton.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { renderWithBrandedContext } from '@sourcegraph/shared/src/testing'
 
 import { LoaderButton } from './LoaderButton'

--- a/client/web/src/components/MarketingBlock/MarketingBlock.story.tsx
+++ b/client/web/src/components/MarketingBlock/MarketingBlock.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { DecoratorFn, Meta } from '@storybook/react'
 import ArrowRightIcon from 'mdi-react/ArrowRightIcon'
 

--- a/client/web/src/components/SelfHostedCtaLink/SelfHostedCtaLink.story.tsx
+++ b/client/web/src/components/SelfHostedCtaLink/SelfHostedCtaLink.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { DecoratorFn, Meta } from '@storybook/react'
 
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'

--- a/client/web/src/components/Timeline.story.tsx
+++ b/client/web/src/components/Timeline.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { storiesOf } from '@storybook/react'
 import { parseISO } from 'date-fns'
 import AlertCircleIcon from 'mdi-react/AlertCircleIcon'

--- a/client/web/src/components/Timeline.tsx
+++ b/client/web/src/components/Timeline.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, ReactNode } from 'react'
+import { FunctionComponent, ReactNode } from 'react'
 
 import classNames from 'classnames'
 import { formatDistance } from 'date-fns/esm'

--- a/client/web/src/components/WebHoverOverlay/WebHoverOverlay.story.tsx
+++ b/client/web/src/components/WebHoverOverlay/WebHoverOverlay.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { action } from '@storybook/addon-actions'
 import { storiesOf } from '@storybook/react'
 

--- a/client/web/src/components/branding/BrandLogo.test.tsx
+++ b/client/web/src/components/branding/BrandLogo.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { render } from '@testing-library/react'
 
 import { BrandLogo } from './BrandLogo'

--- a/client/web/src/components/diff/DiffHunk.test.tsx
+++ b/client/web/src/components/diff/DiffHunk.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { render } from '@testing-library/react'
 import { createMemoryHistory } from 'history'
 import { Router } from 'react-router-dom'

--- a/client/web/src/components/diff/DiffSplitHunk.test.tsx
+++ b/client/web/src/components/diff/DiffSplitHunk.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { cleanup, fireEvent, render, RenderResult } from '@testing-library/react'
 import { createMemoryHistory } from 'history'
 import { Router } from 'react-router'

--- a/client/web/src/components/diff/DiffStat.story.tsx
+++ b/client/web/src/components/diff/DiffStat.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { number } from '@storybook/addon-knobs'
 import { storiesOf } from '@storybook/react'
 

--- a/client/web/src/components/diff/DiffStat.test.tsx
+++ b/client/web/src/components/diff/DiffStat.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { render } from '@testing-library/react'
 
 import { DiffStat, DiffStatSquares, DiffStatStack } from './DiffStat'

--- a/client/web/src/components/diff/FileDiffHunks.story.tsx
+++ b/client/web/src/components/diff/FileDiffHunks.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { boolean } from '@storybook/addon-knobs'
 import { storiesOf } from '@storybook/react'
 

--- a/client/web/src/components/diff/FileDiffNode.story.tsx
+++ b/client/web/src/components/diff/FileDiffNode.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { boolean } from '@storybook/addon-knobs'
 import { storiesOf } from '@storybook/react'
 

--- a/client/web/src/components/externalServices/AddExternalServicesPage.story.tsx
+++ b/client/web/src/components/externalServices/AddExternalServicesPage.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { storiesOf } from '@storybook/react'
 
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'

--- a/client/web/src/components/externalServices/ExternalServiceForm.test.tsx
+++ b/client/web/src/components/externalServices/ExternalServiceForm.test.tsx
@@ -2,8 +2,6 @@ jest.mock('../../settings/DynamicallyImportedMonacoSettingsEditor', () => ({
     DynamicallyImportedMonacoSettingsEditor: () => 'DynamicallyImportedMonacoSettingsEditor',
 }))
 
-import React from 'react'
-
 import * as H from 'history'
 import { noop } from 'rxjs'
 

--- a/client/web/src/components/externalServices/ExternalServicePage.story.tsx
+++ b/client/web/src/components/externalServices/ExternalServicePage.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { storiesOf } from '@storybook/react'
 import { of } from 'rxjs'
 

--- a/client/web/src/components/externalServices/ExternalServiceWebhook.story.tsx
+++ b/client/web/src/components/externalServices/ExternalServiceWebhook.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { storiesOf } from '@storybook/react'
 
 import { ExternalServiceKind } from '../../graphql-operations'

--- a/client/web/src/components/externalServices/ExternalServicesPage.story.tsx
+++ b/client/web/src/components/externalServices/ExternalServicesPage.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { storiesOf } from '@storybook/react'
 import { of } from 'rxjs'
 

--- a/client/web/src/components/fuzzyFinder/FuzzyModal.story.tsx
+++ b/client/web/src/components/fuzzyFinder/FuzzyModal.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { storiesOf } from '@storybook/react'
 
 import { CaseInsensitiveFuzzySearch } from '../../fuzzyFinder/CaseInsensitiveFuzzySearch'

--- a/client/web/src/components/time/Timestamp.test.tsx
+++ b/client/web/src/components/time/Timestamp.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { render } from '@testing-library/react'
 
 import { Timestamp } from './Timestamp'

--- a/client/web/src/enterprise/batches/BatchSpecNode.story.tsx
+++ b/client/web/src/enterprise/batches/BatchSpecNode.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { storiesOf } from '@storybook/react'
 import classNames from 'classnames'
 import { addDays } from 'date-fns'

--- a/client/web/src/enterprise/batches/BatchSpecsPage.story.tsx
+++ b/client/web/src/enterprise/batches/BatchSpecsPage.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { storiesOf } from '@storybook/react'
 import { addDays } from 'date-fns'
 import { of } from 'rxjs'

--- a/client/web/src/enterprise/batches/Branch.story.tsx
+++ b/client/web/src/enterprise/batches/Branch.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { storiesOf } from '@storybook/react'
 
 import { WebStory } from '../../components/WebStory'

--- a/client/web/src/enterprise/batches/Description.story.tsx
+++ b/client/web/src/enterprise/batches/Description.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { storiesOf } from '@storybook/react'
 
 import { WebStory } from '../../components/WebStory'

--- a/client/web/src/enterprise/batches/DropdownButton.story.tsx
+++ b/client/web/src/enterprise/batches/DropdownButton.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { boolean, select } from '@storybook/addon-knobs'
 import { storiesOf } from '@storybook/react'
 

--- a/client/web/src/enterprise/batches/close/BatchChangeCloseAlert.story.tsx
+++ b/client/web/src/enterprise/batches/close/BatchChangeCloseAlert.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { boolean, number } from '@storybook/addon-knobs'
 import { useState } from '@storybook/addons'
 import { storiesOf } from '@storybook/react'

--- a/client/web/src/enterprise/batches/close/BatchChangeClosePage.story.tsx
+++ b/client/web/src/enterprise/batches/close/BatchChangeClosePage.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { boolean } from '@storybook/addon-knobs'
 import { useMemo, useCallback } from '@storybook/addons'
 import { storiesOf } from '@storybook/react'

--- a/client/web/src/enterprise/batches/create/CreateBatchChangePage.story.tsx
+++ b/client/web/src/enterprise/batches/create/CreateBatchChangePage.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { storiesOf } from '@storybook/react'
 
 import {

--- a/client/web/src/enterprise/batches/create/DownloadSpecModal.story.tsx
+++ b/client/web/src/enterprise/batches/create/DownloadSpecModal.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { storiesOf } from '@storybook/react'
 
 import { WebStory } from '../../../components/WebStory'

--- a/client/web/src/enterprise/batches/create/workspaces-preview/WorkspacesPreview.story.tsx
+++ b/client/web/src/enterprise/batches/create/workspaces-preview/WorkspacesPreview.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { boolean, select } from '@storybook/addon-knobs'
 import { storiesOf } from '@storybook/react'
 import { noop } from 'lodash'

--- a/client/web/src/enterprise/batches/create/workspaces-preview/WorkspacesPreviewListItem.story.tsx
+++ b/client/web/src/enterprise/batches/create/workspaces-preview/WorkspacesPreviewListItem.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { storiesOf } from '@storybook/react'
 import { noop } from 'lodash'
 

--- a/client/web/src/enterprise/batches/detail/ActiveExecutionNotice.story.tsx
+++ b/client/web/src/enterprise/batches/detail/ActiveExecutionNotice.story.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react'
+import { useMemo } from 'react'
 
 import { number } from '@storybook/addon-knobs'
 import { storiesOf } from '@storybook/react'

--- a/client/web/src/enterprise/batches/detail/BatchChangeBurndownChart.story.tsx
+++ b/client/web/src/enterprise/batches/detail/BatchChangeBurndownChart.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { useMemo } from '@storybook/addons'
 import { storiesOf } from '@storybook/react'
 import { addSeconds, isBefore } from 'date-fns'

--- a/client/web/src/enterprise/batches/detail/BatchChangeDetailsPage.story.tsx
+++ b/client/web/src/enterprise/batches/detail/BatchChangeDetailsPage.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { boolean } from '@storybook/addon-knobs'
 import { useMemo } from '@storybook/addons'
 import { storiesOf } from '@storybook/react'

--- a/client/web/src/enterprise/batches/detail/BatchChangeInfoByline.story.tsx
+++ b/client/web/src/enterprise/batches/detail/BatchChangeInfoByline.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { storiesOf } from '@storybook/react'
 import { subDays } from 'date-fns'
 

--- a/client/web/src/enterprise/batches/detail/BatchChangeStatsCard.story.tsx
+++ b/client/web/src/enterprise/batches/detail/BatchChangeStatsCard.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { storiesOf } from '@storybook/react'
 
 import { WebStory } from '../../../components/WebStory'

--- a/client/web/src/enterprise/batches/detail/BulkOperationsAlerts.story.tsx
+++ b/client/web/src/enterprise/batches/detail/BulkOperationsAlerts.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { useMemo } from '@storybook/addons'
 import { storiesOf } from '@storybook/react'
 

--- a/client/web/src/enterprise/batches/detail/ClosedNotice.story.tsx
+++ b/client/web/src/enterprise/batches/detail/ClosedNotice.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { storiesOf } from '@storybook/react'
 
 import { WebStory } from '../../../components/WebStory'

--- a/client/web/src/enterprise/batches/detail/SupersedingBatchSpecAlert.story.tsx
+++ b/client/web/src/enterprise/batches/detail/SupersedingBatchSpecAlert.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { storiesOf } from '@storybook/react'
 import { subDays } from 'date-fns'
 

--- a/client/web/src/enterprise/batches/detail/UnpublishedNotice.story.tsx
+++ b/client/web/src/enterprise/batches/detail/UnpublishedNotice.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { storiesOf } from '@storybook/react'
 
 import { WebStory } from '../../../components/WebStory'

--- a/client/web/src/enterprise/batches/detail/WebhookAlert.story.tsx
+++ b/client/web/src/enterprise/batches/detail/WebhookAlert.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { storiesOf } from '@storybook/react'
 
 import { ExternalServiceKind } from '@sourcegraph/shared/src/graphql-operations'

--- a/client/web/src/enterprise/batches/detail/changesets/BatchChangeChangesets.story.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/BatchChangeChangesets.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { boolean, select } from '@storybook/addon-knobs'
 import { storiesOf } from '@storybook/react'
 import { noop } from 'lodash'

--- a/client/web/src/enterprise/batches/detail/changesets/ChangesetCheckStatusCell.story.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/ChangesetCheckStatusCell.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { storiesOf } from '@storybook/react'
 import { capitalize } from 'lodash'
 

--- a/client/web/src/enterprise/batches/detail/changesets/ChangesetLabel.story.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/ChangesetLabel.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { storiesOf } from '@storybook/react'
 
 import { WebStory } from '../../../../components/WebStory'

--- a/client/web/src/enterprise/batches/detail/changesets/ChangesetReviewStatusCell.story.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/ChangesetReviewStatusCell.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { storiesOf } from '@storybook/react'
 import { capitalize } from 'lodash'
 

--- a/client/web/src/enterprise/batches/detail/changesets/ChangesetSelectRow.story.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/ChangesetSelectRow.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { number } from '@storybook/addon-knobs'
 import { storiesOf } from '@storybook/react'
 import { of } from 'rxjs'

--- a/client/web/src/enterprise/batches/detail/changesets/ChangesetSelectRow.story.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/ChangesetSelectRow.story.tsx
@@ -2,7 +2,8 @@ import { number } from '@storybook/addon-knobs'
 import { storiesOf } from '@storybook/react'
 import { of } from 'rxjs'
 
-import { BulkOperationType } from '../../../../../../shared/src/graphql-operations'
+import { BulkOperationType } from '@sourcegraph/shared/src/graphql-operations'
+
 import { WebStory } from '../../../../components/WebStory'
 import { MultiSelectContextProvider } from '../../MultiSelectContext'
 import {

--- a/client/web/src/enterprise/batches/detail/changesets/ChangesetStatusCell.story.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/ChangesetStatusCell.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { storiesOf } from '@storybook/react'
 import { capitalize } from 'lodash'
 

--- a/client/web/src/enterprise/batches/detail/changesets/CloseChangesetsModal.story.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/CloseChangesetsModal.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { action } from '@storybook/addon-actions'
 import { storiesOf } from '@storybook/react'
 import { noop } from 'lodash'

--- a/client/web/src/enterprise/batches/detail/changesets/CreateCommentModal.story.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/CreateCommentModal.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { action } from '@storybook/addon-actions'
 import { storiesOf } from '@storybook/react'
 import { noop } from 'lodash'

--- a/client/web/src/enterprise/batches/detail/changesets/DetachChangesetsModal.story.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/DetachChangesetsModal.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { action } from '@storybook/addon-actions'
 import { storiesOf } from '@storybook/react'
 import { noop } from 'lodash'

--- a/client/web/src/enterprise/batches/detail/changesets/ExternalChangesetNode.story.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/ExternalChangesetNode.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { boolean } from '@storybook/addon-knobs'
 import { storiesOf } from '@storybook/react'
 import classNames from 'classnames'

--- a/client/web/src/enterprise/batches/detail/changesets/HiddenExternalChangesetNode.story.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/HiddenExternalChangesetNode.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { storiesOf } from '@storybook/react'
 import classNames from 'classnames'
 import { addHours } from 'date-fns'

--- a/client/web/src/enterprise/batches/detail/changesets/MergeChangesetsModal.story.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/MergeChangesetsModal.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { action } from '@storybook/addon-actions'
 import { storiesOf } from '@storybook/react'
 import { noop } from 'lodash'

--- a/client/web/src/enterprise/batches/detail/changesets/PublishChangesetsModal.story.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/PublishChangesetsModal.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { action } from '@storybook/addon-actions'
 import { storiesOf } from '@storybook/react'
 import { noop } from 'lodash'

--- a/client/web/src/enterprise/batches/detail/changesets/ReenqueueChangesetsModal.story.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/ReenqueueChangesetsModal.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { action } from '@storybook/addon-actions'
 import { storiesOf } from '@storybook/react'
 import { noop } from 'lodash'

--- a/client/web/src/enterprise/batches/execution/WorkspaceDetails.story.tsx
+++ b/client/web/src/enterprise/batches/execution/WorkspaceDetails.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { storiesOf } from '@storybook/react'
 import { subMinutes } from 'date-fns/esm'
 import { noop } from 'lodash'

--- a/client/web/src/enterprise/batches/execution/workspaces/WorkspacesListItem.story.tsx
+++ b/client/web/src/enterprise/batches/execution/workspaces/WorkspacesListItem.story.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import { useState } from 'react'
 
 import { storiesOf } from '@storybook/react'
 

--- a/client/web/src/enterprise/batches/global/DotcomGettingStartedPage.story.tsx
+++ b/client/web/src/enterprise/batches/global/DotcomGettingStartedPage.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { storiesOf } from '@storybook/react'
 
 import { WebStory } from '../../../components/WebStory'

--- a/client/web/src/enterprise/batches/list/BatchChangeListPage.story.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangeListPage.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { boolean } from '@storybook/addon-knobs'
 import { storiesOf } from '@storybook/react'
 import { WildcardMockLink, MATCH_ANY_PARAMETERS } from 'wildcard-mock-link'

--- a/client/web/src/enterprise/batches/list/BatchChangeNode.story.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangeNode.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { boolean } from '@storybook/addon-knobs'
 import { storiesOf } from '@storybook/react'
 import isChromatic from 'chromatic/isChromatic'

--- a/client/web/src/enterprise/batches/list/BatchChangesChangelogAlert.story.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangesChangelogAlert.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { storiesOf } from '@storybook/react'
 
 import { WebStory } from '../../../components/WebStory'

--- a/client/web/src/enterprise/batches/list/BatchChangesListIntro.story.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangesListIntro.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { radios } from '@storybook/addon-knobs'
 import { storiesOf } from '@storybook/react'
 

--- a/client/web/src/enterprise/batches/preview/BatchChangePreviewPage.story.tsx
+++ b/client/web/src/enterprise/batches/preview/BatchChangePreviewPage.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { boolean } from '@storybook/addon-knobs'
 import { useMemo } from '@storybook/addons'
 import { storiesOf } from '@storybook/react'

--- a/client/web/src/enterprise/batches/preview/BatchSpecInfoByline.story.tsx
+++ b/client/web/src/enterprise/batches/preview/BatchSpecInfoByline.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { storiesOf } from '@storybook/react'
 import { subDays } from 'date-fns'
 

--- a/client/web/src/enterprise/batches/preview/CreateUpdateBatchChangeAlert.story.tsx
+++ b/client/web/src/enterprise/batches/preview/CreateUpdateBatchChangeAlert.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { boolean } from '@storybook/addon-knobs'
 import { storiesOf } from '@storybook/react'
 

--- a/client/web/src/enterprise/batches/preview/list/ChangesetApplyPreviewNode.story.tsx
+++ b/client/web/src/enterprise/batches/preview/list/ChangesetApplyPreviewNode.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { storiesOf } from '@storybook/react'
 import classNames from 'classnames'
 import { of } from 'rxjs'

--- a/client/web/src/enterprise/batches/preview/list/HiddenChangesetApplyPreviewNode.story.tsx
+++ b/client/web/src/enterprise/batches/preview/list/HiddenChangesetApplyPreviewNode.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { storiesOf } from '@storybook/react'
 import classNames from 'classnames'
 

--- a/client/web/src/enterprise/batches/preview/list/PreviewList.story.tsx
+++ b/client/web/src/enterprise/batches/preview/list/PreviewList.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { boolean } from '@storybook/addon-knobs'
 import { storiesOf } from '@storybook/react'
 import { of, Observable } from 'rxjs'

--- a/client/web/src/enterprise/batches/preview/list/VisibleChangesetApplyPreviewNode.story.tsx
+++ b/client/web/src/enterprise/batches/preview/list/VisibleChangesetApplyPreviewNode.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { storiesOf } from '@storybook/react'
 import classNames from 'classnames'
 import { of } from 'rxjs'

--- a/client/web/src/enterprise/batches/repo/BatchChangeRepoPage.story.tsx
+++ b/client/web/src/enterprise/batches/repo/BatchChangeRepoPage.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { storiesOf } from '@storybook/react'
 import { of } from 'rxjs'
 

--- a/client/web/src/enterprise/batches/settings/AddCredentialModal.story.tsx
+++ b/client/web/src/enterprise/batches/settings/AddCredentialModal.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { select } from '@storybook/addon-knobs'
 import { storiesOf } from '@storybook/react'
 import { noop } from 'lodash'

--- a/client/web/src/enterprise/batches/settings/BatchChangesSettingsArea.story.tsx
+++ b/client/web/src/enterprise/batches/settings/BatchChangesSettingsArea.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { storiesOf } from '@storybook/react'
 
 import { getDocumentNode } from '@sourcegraph/http-client'

--- a/client/web/src/enterprise/batches/settings/BatchChangesSiteConfigSettingsArea.story.tsx
+++ b/client/web/src/enterprise/batches/settings/BatchChangesSiteConfigSettingsArea.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { MockedResponse } from '@apollo/client/testing'
 import { storiesOf } from '@storybook/react'
 

--- a/client/web/src/enterprise/batches/settings/RemoveCredentialModal.story.tsx
+++ b/client/web/src/enterprise/batches/settings/RemoveCredentialModal.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { storiesOf } from '@storybook/react'
 import { noop } from 'lodash'
 

--- a/client/web/src/enterprise/batches/settings/ViewCredentialModal.story.tsx
+++ b/client/web/src/enterprise/batches/settings/ViewCredentialModal.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { storiesOf } from '@storybook/react'
 import { noop } from 'lodash'
 

--- a/client/web/src/enterprise/batches/workspaces-list/Descriptor.tsx
+++ b/client/web/src/enterprise/batches/workspaces-list/Descriptor.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from 'react'
+import { ReactElement } from 'react'
 
 import SourceBranchIcon from 'mdi-react/SourceBranchIcon'
 

--- a/client/web/src/enterprise/code-monitoring/CodeMonitoringLogs.story.tsx
+++ b/client/web/src/enterprise/code-monitoring/CodeMonitoringLogs.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { MockedResponse } from '@apollo/client/testing'
 import { storiesOf } from '@storybook/react'
 import { parseISO } from 'date-fns'

--- a/client/web/src/enterprise/code-monitoring/CodeMonitoringPage.story.tsx
+++ b/client/web/src/enterprise/code-monitoring/CodeMonitoringPage.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { storiesOf } from '@storybook/react'
 import { NEVER, of } from 'rxjs'
 import sinon from 'sinon'

--- a/client/web/src/enterprise/code-monitoring/CodeMonitoringPage.test.tsx
+++ b/client/web/src/enterprise/code-monitoring/CodeMonitoringPage.test.tsx
@@ -1,5 +1,3 @@
-import * as React from 'react'
-
 import { render, fireEvent } from '@testing-library/react'
 import { MemoryRouter } from 'react-router'
 import { of } from 'rxjs'

--- a/client/web/src/enterprise/code-monitoring/CreateCodeMonitorPage.story.tsx
+++ b/client/web/src/enterprise/code-monitoring/CreateCodeMonitorPage.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { storiesOf } from '@storybook/react'
 import sinon from 'sinon'
 

--- a/client/web/src/enterprise/code-monitoring/CreateCodeMonitorPage.test.tsx
+++ b/client/web/src/enterprise/code-monitoring/CreateCodeMonitorPage.test.tsx
@@ -1,5 +1,3 @@
-import * as React from 'react'
-
 import { getByRole, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import * as H from 'history'

--- a/client/web/src/enterprise/code-monitoring/ManageCodeMonitorPage.story.tsx
+++ b/client/web/src/enterprise/code-monitoring/ManageCodeMonitorPage.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { storiesOf } from '@storybook/react'
 import { NEVER, of } from 'rxjs'
 import sinon from 'sinon'

--- a/client/web/src/enterprise/code-monitoring/ManageCodeMonitorPage.test.tsx
+++ b/client/web/src/enterprise/code-monitoring/ManageCodeMonitorPage.test.tsx
@@ -1,5 +1,3 @@
-import * as React from 'react'
-
 import { screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import * as H from 'history'

--- a/client/web/src/enterprise/code-monitoring/components/CodeMonitorForm.test.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/CodeMonitorForm.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { fireEvent, getByRole, screen } from '@testing-library/react'
 import { createMemoryHistory, createLocation } from 'history'
 import { NEVER } from 'rxjs'

--- a/client/web/src/enterprise/code-monitoring/components/DeleteMonitorModal.story.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/DeleteMonitorModal.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { storiesOf } from '@storybook/react'
 import { NEVER } from 'rxjs'
 import sinon from 'sinon'

--- a/client/web/src/enterprise/code-monitoring/components/FormActionArea.test.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/FormActionArea.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import sinon from 'sinon'

--- a/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.story.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { storiesOf } from '@storybook/react'
 import sinon from 'sinon'
 

--- a/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.test.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { act } from 'react-dom/test-utils'

--- a/client/web/src/enterprise/code-monitoring/components/actions/ActionEditor.test.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/actions/ActionEditor.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { render } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import sinon from 'sinon'

--- a/client/web/src/enterprise/code-monitoring/components/actions/EmailAction.story.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/actions/EmailAction.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { storiesOf } from '@storybook/react'
 import sinon from 'sinon'
 

--- a/client/web/src/enterprise/code-monitoring/components/actions/EmailAction.test.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/actions/EmailAction.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { MockedResponse } from '@apollo/client/testing'
 import { render } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'

--- a/client/web/src/enterprise/code-monitoring/components/actions/SlackWebhookAction.story.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/actions/SlackWebhookAction.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { storiesOf } from '@storybook/react'
 import sinon from 'sinon'
 

--- a/client/web/src/enterprise/code-monitoring/components/actions/SlackWebhookAction.test.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/actions/SlackWebhookAction.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { MockedResponse } from '@apollo/client/testing'
 import { render } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'

--- a/client/web/src/enterprise/code-monitoring/components/actions/WebhookAction.story.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/actions/WebhookAction.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { storiesOf } from '@storybook/react'
 import sinon from 'sinon'
 

--- a/client/web/src/enterprise/code-monitoring/components/actions/WebhookAction.test.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/actions/WebhookAction.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { MockedResponse } from '@apollo/client/testing'
 import { render } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'

--- a/client/web/src/enterprise/codeintel/RepositoryMenu.story.tsx
+++ b/client/web/src/enterprise/codeintel/RepositoryMenu.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { storiesOf } from '@storybook/react'
 
 import { RepositoryMenu } from '../../codeintel/RepositoryMenu'

--- a/client/web/src/enterprise/codeintel/configuration/components/BranchTargetSettings.tsx
+++ b/client/web/src/enterprise/codeintel/configuration/components/BranchTargetSettings.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent } from 'react'
+import { FunctionComponent } from 'react'
 
 import { GitObjectType } from '@sourcegraph/shared/src/graphql-operations'
 

--- a/client/web/src/enterprise/codeintel/configuration/components/ConfigurationEditor.tsx
+++ b/client/web/src/enterprise/codeintel/configuration/components/ConfigurationEditor.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, useCallback, useMemo, useState } from 'react'
+import { FunctionComponent, useCallback, useMemo, useState } from 'react'
 
 import * as H from 'history'
 import { editor } from 'monaco-editor'

--- a/client/web/src/enterprise/codeintel/configuration/components/DurationSelect.tsx
+++ b/client/web/src/enterprise/codeintel/configuration/components/DurationSelect.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, useState } from 'react'
+import { FunctionComponent, useState } from 'react'
 
 import classNames from 'classnames'
 

--- a/client/web/src/enterprise/codeintel/configuration/components/GitObjectPreview.tsx
+++ b/client/web/src/enterprise/codeintel/configuration/components/GitObjectPreview.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent } from 'react'
+import { FunctionComponent } from 'react'
 
 import { ApolloError } from '@apollo/client'
 import classNames from 'classnames'

--- a/client/web/src/enterprise/codeintel/configuration/components/GitObjectTargetDescription.tsx
+++ b/client/web/src/enterprise/codeintel/configuration/components/GitObjectTargetDescription.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent } from 'react'
+import { FunctionComponent } from 'react'
 
 import { GitObjectType } from '@sourcegraph/shared/src/schema'
 

--- a/client/web/src/enterprise/codeintel/configuration/components/GitTypeSelector.tsx
+++ b/client/web/src/enterprise/codeintel/configuration/components/GitTypeSelector.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent } from 'react'
+import { FunctionComponent } from 'react'
 
 import { Select } from '@sourcegraph/wildcard'
 

--- a/client/web/src/enterprise/codeintel/configuration/components/IndexingPolicyDescription.tsx
+++ b/client/web/src/enterprise/codeintel/configuration/components/IndexingPolicyDescription.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent } from 'react'
+import { FunctionComponent } from 'react'
 
 import { CodeIntelligenceConfigurationPolicyFields } from '../../../../graphql-operations'
 import { formatDurationValue } from '../shared'

--- a/client/web/src/enterprise/codeintel/configuration/components/ObjectsMatchingGitPattern.tsx
+++ b/client/web/src/enterprise/codeintel/configuration/components/ObjectsMatchingGitPattern.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, useEffect, useMemo, useState } from 'react'
+import { FunctionComponent, useEffect, useMemo, useState } from 'react'
 
 import { debounce } from 'lodash'
 

--- a/client/web/src/enterprise/codeintel/configuration/components/PolicyListActions.tsx
+++ b/client/web/src/enterprise/codeintel/configuration/components/PolicyListActions.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent } from 'react'
+import { FunctionComponent } from 'react'
 
 import * as H from 'history'
 

--- a/client/web/src/enterprise/codeintel/configuration/components/ReposMatchingPattern.tsx
+++ b/client/web/src/enterprise/codeintel/configuration/components/ReposMatchingPattern.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, useEffect, useMemo, useState } from 'react'
+import { FunctionComponent, useEffect, useMemo, useState } from 'react'
 
 import classNames from 'classnames'
 import { debounce } from 'lodash'

--- a/client/web/src/enterprise/codeintel/configuration/components/ReposMatchingPatternList.tsx
+++ b/client/web/src/enterprise/codeintel/configuration/components/ReposMatchingPatternList.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent } from 'react'
+import { FunctionComponent } from 'react'
 
 import classNames from 'classnames'
 

--- a/client/web/src/enterprise/codeintel/configuration/components/RepositoryPreview.tsx
+++ b/client/web/src/enterprise/codeintel/configuration/components/RepositoryPreview.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent } from 'react'
+import { FunctionComponent } from 'react'
 
 import classNames from 'classnames'
 

--- a/client/web/src/enterprise/codeintel/configuration/components/RetentionPolicyDescription.tsx
+++ b/client/web/src/enterprise/codeintel/configuration/components/RetentionPolicyDescription.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent } from 'react'
+import { FunctionComponent } from 'react'
 
 import { CodeIntelligenceConfigurationPolicyFields } from '../../../../graphql-operations'
 import { formatDurationValue } from '../shared'

--- a/client/web/src/enterprise/codeintel/configuration/pages/CodeIntelConfigurationPage.story.tsx
+++ b/client/web/src/enterprise/codeintel/configuration/pages/CodeIntelConfigurationPage.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { MockedResponse } from '@apollo/client/testing'
 import { boolean, withKnobs } from '@storybook/addon-knobs'
 import { Meta, Story } from '@storybook/react'

--- a/client/web/src/enterprise/codeintel/configuration/pages/CodeIntelConfigurationPolicyPage.story.tsx
+++ b/client/web/src/enterprise/codeintel/configuration/pages/CodeIntelConfigurationPolicyPage.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { boolean, withKnobs } from '@storybook/addon-knobs'
 import { Meta, Story } from '@storybook/react'
 

--- a/client/web/src/enterprise/codeintel/configuration/pages/CodeIntelConfigurationPolicyPage.tsx
+++ b/client/web/src/enterprise/codeintel/configuration/pages/CodeIntelConfigurationPolicyPage.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, useCallback, useEffect, useState } from 'react'
+import { FunctionComponent, useCallback, useEffect, useState } from 'react'
 
 import { ApolloError } from '@apollo/client'
 import * as H from 'history'

--- a/client/web/src/enterprise/codeintel/configuration/pages/CodeIntelRepositoryIndexConfigurationPage.story.tsx
+++ b/client/web/src/enterprise/codeintel/configuration/pages/CodeIntelRepositoryIndexConfigurationPage.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { withKnobs } from '@storybook/addon-knobs'
 import { Meta, Story } from '@storybook/react'
 

--- a/client/web/src/enterprise/codeintel/configuration/pages/CodeIntelRepositoryIndexConfigurationPage.tsx
+++ b/client/web/src/enterprise/codeintel/configuration/pages/CodeIntelRepositoryIndexConfigurationPage.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, useEffect } from 'react'
+import { FunctionComponent, useEffect } from 'react'
 
 import * as H from 'history'
 

--- a/client/web/src/enterprise/codeintel/indexes/components/CodeIntelAssociatedUpload.tsx
+++ b/client/web/src/enterprise/codeintel/indexes/components/CodeIntelAssociatedUpload.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent } from 'react'
+import { FunctionComponent } from 'react'
 
 import classNames from 'classnames'
 import ChevronRightIcon from 'mdi-react/ChevronRightIcon'

--- a/client/web/src/enterprise/codeintel/indexes/components/CodeIntelDeleteIndex.tsx
+++ b/client/web/src/enterprise/codeintel/indexes/components/CodeIntelDeleteIndex.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent } from 'react'
+import { FunctionComponent } from 'react'
 
 import DeleteIcon from 'mdi-react/DeleteIcon'
 

--- a/client/web/src/enterprise/codeintel/indexes/components/CodeIntelIndexMeta.tsx
+++ b/client/web/src/enterprise/codeintel/indexes/components/CodeIntelIndexMeta.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent } from 'react'
+import { FunctionComponent } from 'react'
 
 import { CardSubtitle, CardText, CardTitle, CardBody, Card } from '@sourcegraph/wildcard'
 

--- a/client/web/src/enterprise/codeintel/indexes/components/CodeIntelIndexNode.tsx
+++ b/client/web/src/enterprise/codeintel/indexes/components/CodeIntelIndexNode.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent } from 'react'
+import { FunctionComponent } from 'react'
 
 import classNames from 'classnames'
 import ChevronRightIcon from 'mdi-react/ChevronRightIcon'

--- a/client/web/src/enterprise/codeintel/indexes/components/CodeIntelIndexTimeline.tsx
+++ b/client/web/src/enterprise/codeintel/indexes/components/CodeIntelIndexTimeline.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, useMemo } from 'react'
+import { FunctionComponent, useMemo } from 'react'
 
 import AlertCircleIcon from 'mdi-react/AlertCircleIcon'
 import CheckIcon from 'mdi-react/CheckIcon'

--- a/client/web/src/enterprise/codeintel/indexes/components/EnqueueForm.tsx
+++ b/client/web/src/enterprise/codeintel/indexes/components/EnqueueForm.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, useCallback, useState } from 'react'
+import { FunctionComponent, useCallback, useState } from 'react'
 
 import { Subject } from 'rxjs'
 

--- a/client/web/src/enterprise/codeintel/indexes/pages/CodeIntelIndexPage.story.tsx
+++ b/client/web/src/enterprise/codeintel/indexes/pages/CodeIntelIndexPage.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { Meta, Story } from '@storybook/react'
 import { of } from 'rxjs'
 

--- a/client/web/src/enterprise/codeintel/indexes/pages/CodeIntelIndexPage.tsx
+++ b/client/web/src/enterprise/codeintel/indexes/pages/CodeIntelIndexPage.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, useCallback, useEffect, useMemo, useState } from 'react'
+import { FunctionComponent, useCallback, useEffect, useMemo, useState } from 'react'
 
 import { useApolloClient } from '@apollo/client'
 import { Redirect, RouteComponentProps } from 'react-router'

--- a/client/web/src/enterprise/codeintel/indexes/pages/CodeIntelIndexesPage.story.tsx
+++ b/client/web/src/enterprise/codeintel/indexes/pages/CodeIntelIndexesPage.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { Meta, Story } from '@storybook/react'
 import { of } from 'rxjs'
 

--- a/client/web/src/enterprise/codeintel/indexes/pages/CodeIntelIndexesPage.tsx
+++ b/client/web/src/enterprise/codeintel/indexes/pages/CodeIntelIndexesPage.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, useCallback, useEffect, useMemo } from 'react'
+import { FunctionComponent, useCallback, useEffect, useMemo } from 'react'
 
 import { useApolloClient } from '@apollo/client'
 import classNames from 'classnames'

--- a/client/web/src/enterprise/codeintel/shared/components/CodeIntelIndexer.tsx
+++ b/client/web/src/enterprise/codeintel/shared/components/CodeIntelIndexer.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent } from 'react'
+import { FunctionComponent } from 'react'
 
 import { Link } from '@sourcegraph/wildcard'
 

--- a/client/web/src/enterprise/codeintel/shared/components/CodeIntelStateBanner.tsx
+++ b/client/web/src/enterprise/codeintel/shared/components/CodeIntelStateBanner.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent } from 'react'
+import { FunctionComponent } from 'react'
 
 import { Alert, AlertProps } from '@sourcegraph/wildcard'
 

--- a/client/web/src/enterprise/codeintel/shared/components/CodeIntelStateDescription.tsx
+++ b/client/web/src/enterprise/codeintel/shared/components/CodeIntelStateDescription.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent } from 'react'
+import { FunctionComponent } from 'react'
 
 import { upperFirst } from 'lodash'
 

--- a/client/web/src/enterprise/codeintel/shared/components/CodeIntelStateIcon.tsx
+++ b/client/web/src/enterprise/codeintel/shared/components/CodeIntelStateIcon.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent } from 'react'
+import { FunctionComponent } from 'react'
 
 import classNames from 'classnames'
 import AlertCircleIcon from 'mdi-react/AlertCircleIcon'

--- a/client/web/src/enterprise/codeintel/shared/components/CodeIntelStateLabel.tsx
+++ b/client/web/src/enterprise/codeintel/shared/components/CodeIntelStateLabel.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent } from 'react'
+import { FunctionComponent } from 'react'
 
 import classNames from 'classnames'
 

--- a/client/web/src/enterprise/codeintel/shared/components/CodeIntelUploadOrIndexCommit.tsx
+++ b/client/web/src/enterprise/codeintel/shared/components/CodeIntelUploadOrIndexCommit.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent } from 'react'
+import { FunctionComponent } from 'react'
 
 import { Link } from '@sourcegraph/wildcard'
 

--- a/client/web/src/enterprise/codeintel/shared/components/CodeIntelUploadOrIndexIndexer.tsx
+++ b/client/web/src/enterprise/codeintel/shared/components/CodeIntelUploadOrIndexIndexer.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent } from 'react'
+import { FunctionComponent } from 'react'
 
 import { LsifIndexFields } from '../../../../graphql-operations'
 

--- a/client/web/src/enterprise/codeintel/shared/components/CodeIntelUploadOrIndexLastActivity.tsx
+++ b/client/web/src/enterprise/codeintel/shared/components/CodeIntelUploadOrIndexLastActivity.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent } from 'react'
+import { FunctionComponent } from 'react'
 
 import { Timestamp } from '../../../../components/time/Timestamp'
 import { LsifIndexFields, LsifUploadFields } from '../../../../graphql-operations'

--- a/client/web/src/enterprise/codeintel/shared/components/CodeIntelUploadOrIndexRoot.tsx
+++ b/client/web/src/enterprise/codeintel/shared/components/CodeIntelUploadOrIndexRoot.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent } from 'react'
+import { FunctionComponent } from 'react'
 
 import { Link } from '@sourcegraph/wildcard'
 

--- a/client/web/src/enterprise/codeintel/shared/components/CodeIntelUploadOrIndexerRepository.tsx
+++ b/client/web/src/enterprise/codeintel/shared/components/CodeIntelUploadOrIndexerRepository.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent } from 'react'
+import { FunctionComponent } from 'react'
 
 import { Link } from '@sourcegraph/wildcard'
 

--- a/client/web/src/enterprise/codeintel/uploads/components/CodeIntelAssociatedIndex.tsx
+++ b/client/web/src/enterprise/codeintel/uploads/components/CodeIntelAssociatedIndex.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent } from 'react'
+import { FunctionComponent } from 'react'
 
 import classNames from 'classnames'
 import ChevronRightIcon from 'mdi-react/ChevronRightIcon'

--- a/client/web/src/enterprise/codeintel/uploads/components/CodeIntelDeleteUpload.tsx
+++ b/client/web/src/enterprise/codeintel/uploads/components/CodeIntelDeleteUpload.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent } from 'react'
+import { FunctionComponent } from 'react'
 
 import DeleteIcon from 'mdi-react/DeleteIcon'
 

--- a/client/web/src/enterprise/codeintel/uploads/components/CodeIntelUploadMeta.tsx
+++ b/client/web/src/enterprise/codeintel/uploads/components/CodeIntelUploadMeta.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent } from 'react'
+import { FunctionComponent } from 'react'
 
 import { CardSubtitle, CardText, CardTitle, CardBody, Card } from '@sourcegraph/wildcard'
 

--- a/client/web/src/enterprise/codeintel/uploads/components/CodeIntelUploadNode.tsx
+++ b/client/web/src/enterprise/codeintel/uploads/components/CodeIntelUploadNode.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent } from 'react'
+import { FunctionComponent } from 'react'
 
 import classNames from 'classnames'
 import ChevronRightIcon from 'mdi-react/ChevronRightIcon'

--- a/client/web/src/enterprise/codeintel/uploads/components/CodeIntelUploadTimeline.tsx
+++ b/client/web/src/enterprise/codeintel/uploads/components/CodeIntelUploadTimeline.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, useMemo } from 'react'
+import { FunctionComponent, useMemo } from 'react'
 
 import AlertCircleIcon from 'mdi-react/AlertCircleIcon'
 import CheckIcon from 'mdi-react/CheckIcon'

--- a/client/web/src/enterprise/codeintel/uploads/components/CommitGraphMetadata.tsx
+++ b/client/web/src/enterprise/codeintel/uploads/components/CommitGraphMetadata.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent } from 'react'
+import { FunctionComponent } from 'react'
 
 import { Alert } from '@sourcegraph/wildcard'
 

--- a/client/web/src/enterprise/codeintel/uploads/components/DependencyOrDependentNode.tsx
+++ b/client/web/src/enterprise/codeintel/uploads/components/DependencyOrDependentNode.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent } from 'react'
+import { FunctionComponent } from 'react'
 
 import classNames from 'classnames'
 import ChevronRightIcon from 'mdi-react/ChevronRightIcon'

--- a/client/web/src/enterprise/codeintel/uploads/components/UploadRetentionStatusNode.tsx
+++ b/client/web/src/enterprise/codeintel/uploads/components/UploadRetentionStatusNode.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent } from 'react'
+import { FunctionComponent } from 'react'
 
 import classNames from 'classnames'
 import InformationOutlineIcon from 'mdi-react/InformationOutlineIcon'

--- a/client/web/src/enterprise/codeintel/uploads/pages/CodeIntelUploadPage.story.tsx
+++ b/client/web/src/enterprise/codeintel/uploads/pages/CodeIntelUploadPage.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { Meta, Story } from '@storybook/react'
 import { of } from 'rxjs'
 

--- a/client/web/src/enterprise/codeintel/uploads/pages/CodeIntelUploadPage.tsx
+++ b/client/web/src/enterprise/codeintel/uploads/pages/CodeIntelUploadPage.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, useCallback, useEffect, useMemo, useState } from 'react'
+import { FunctionComponent, useCallback, useEffect, useMemo, useState } from 'react'
 
 import { useApolloClient } from '@apollo/client'
 import classNames from 'classnames'

--- a/client/web/src/enterprise/codeintel/uploads/pages/CodeIntelUploadsPage.story.tsx
+++ b/client/web/src/enterprise/codeintel/uploads/pages/CodeIntelUploadsPage.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { boolean } from '@storybook/addon-knobs'
 import { Meta, Story } from '@storybook/react'
 import { of } from 'rxjs'

--- a/client/web/src/enterprise/codeintel/uploads/pages/CodeIntelUploadsPage.tsx
+++ b/client/web/src/enterprise/codeintel/uploads/pages/CodeIntelUploadsPage.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, useCallback, useEffect, useMemo, useState } from 'react'
+import { FunctionComponent, useCallback, useEffect, useMemo, useState } from 'react'
 
 import { useApolloClient } from '@apollo/client'
 import classNames from 'classnames'

--- a/client/web/src/enterprise/dotcom/productPlans/ProductPlanFormControl.test.tsx
+++ b/client/web/src/enterprise/dotcom/productPlans/ProductPlanFormControl.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { render, act } from '@testing-library/react'
 import { of } from 'rxjs'
 

--- a/client/web/src/enterprise/dotcom/productPlans/ProductPlanPrice.test.tsx
+++ b/client/web/src/enterprise/dotcom/productPlans/ProductPlanPrice.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { render } from '@testing-library/react'
 
 import { ProductPlanPrice } from './ProductPlanPrice'

--- a/client/web/src/enterprise/dotcom/productPlans/ProductPlanTiered.test.tsx
+++ b/client/web/src/enterprise/dotcom/productPlans/ProductPlanTiered.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { render } from '@testing-library/react'
 
 import { ProductPlanTiered } from './ProductPlanTiered'

--- a/client/web/src/enterprise/dotcom/productPlans/ProductSubscriptionUserCountFormControl.test.tsx
+++ b/client/web/src/enterprise/dotcom/productPlans/ProductSubscriptionUserCountFormControl.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { render } from '@testing-library/react'
 
 import { ProductSubscriptionUserCountFormControl } from './ProductSubscriptionUserCountFormControl'

--- a/client/web/src/enterprise/embed/main.tsx
+++ b/client/web/src/enterprise/embed/main.tsx
@@ -1,7 +1,5 @@
 import '@sourcegraph/shared/src/polyfills'
 
-import React from 'react'
-
 import { render } from 'react-dom'
 
 import { EmbeddedWebApp } from './EmbeddedWebApp'

--- a/client/web/src/enterprise/insights/components/creation-ui-kit/code-insight-time-step-picker/CodeInsightTimeStepPicker.tsx
+++ b/client/web/src/enterprise/insights/components/creation-ui-kit/code-insight-time-step-picker/CodeInsightTimeStepPicker.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEvent, FocusEventHandler, forwardRef } from 'react'
+import { ChangeEvent, FocusEventHandler, forwardRef } from 'react'
 
 import classNames from 'classnames'
 

--- a/client/web/src/enterprise/insights/components/creation-ui-kit/code-insight-time-step-picker/get-interval-descrtiption-text/get-interval-description-text.tsx
+++ b/client/web/src/enterprise/insights/components/creation-ui-kit/code-insight-time-step-picker/get-interval-descrtiption-text/get-interval-description-text.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from 'react'
+import { ReactNode } from 'react'
 
 import { InsightStep } from '../../../../pages/insights/creation/search-insight/types'
 

--- a/client/web/src/enterprise/insights/components/form/monaco-field/MonacoField.story.tsx
+++ b/client/web/src/enterprise/insights/components/form/monaco-field/MonacoField.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { Meta } from '@storybook/react'
 import RegexIcon from 'mdi-react/RegexIcon'
 

--- a/client/web/src/enterprise/insights/components/form/monaco-field/MonacoField.tsx
+++ b/client/web/src/enterprise/insights/components/form/monaco-field/MonacoField.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, forwardRef, InputHTMLAttributes, useContext, useImperativeHandle, useMemo } from 'react'
+import { createContext, forwardRef, InputHTMLAttributes, useContext, useImperativeHandle, useMemo } from 'react'
 
 import classNames from 'classnames'
 import { noop } from 'lodash'

--- a/client/web/src/enterprise/insights/components/form/query-input/InsightQueryInput.tsx
+++ b/client/web/src/enterprise/insights/components/form/query-input/InsightQueryInput.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react'
+import { forwardRef } from 'react'
 
 import classNames from 'classnames'
 

--- a/client/web/src/enterprise/insights/components/form/repositories-field/RepositoriesField.tsx
+++ b/client/web/src/enterprise/insights/components/form/repositories-field/RepositoriesField.tsx
@@ -1,13 +1,4 @@
-import React, {
-    ChangeEvent,
-    FocusEvent,
-    forwardRef,
-    MouseEvent,
-    Ref,
-    useImperativeHandle,
-    useRef,
-    useState,
-} from 'react'
+import { ChangeEvent, FocusEvent, forwardRef, MouseEvent, Ref, useImperativeHandle, useRef, useState } from 'react'
 
 import { Combobox, ComboboxInput, ComboboxPopover } from '@reach/combobox'
 

--- a/client/web/src/enterprise/insights/components/form/repositories-field/RepositoryField.tsx
+++ b/client/web/src/enterprise/insights/components/form/repositories-field/RepositoryField.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEvent, forwardRef, Ref, useImperativeHandle, useRef } from 'react'
+import { ChangeEvent, forwardRef, Ref, useImperativeHandle, useRef } from 'react'
 
 import { Combobox, ComboboxInput, ComboboxPopover } from '@reach/combobox'
 

--- a/client/web/src/enterprise/insights/components/insights-view-grid/SmartInsightsViewGrid.story.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/SmartInsightsViewGrid.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { Meta } from '@storybook/react'
 import { Observable, of } from 'rxjs'
 

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/DrillDownFiltersPanel.story.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/DrillDownFiltersPanel.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { Meta, Story } from '@storybook/react'
 import delay from 'delay'
 import { of } from 'rxjs'

--- a/client/web/src/enterprise/insights/components/views/card/InsightCard.story.tsx
+++ b/client/web/src/enterprise/insights/components/views/card/InsightCard.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { Meta, Story } from '@storybook/react'
 import { noop } from 'lodash'
 import DotsVerticalIcon from 'mdi-react/DotsVerticalIcon'

--- a/client/web/src/enterprise/insights/components/views/chart/categorical/CategoricalChart.story.tsx
+++ b/client/web/src/enterprise/insights/components/views/chart/categorical/CategoricalChart.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { Meta, Story } from '@storybook/react'
 
 import { WebStory } from '../../../../../../components/WebStory'

--- a/client/web/src/enterprise/insights/components/views/chart/series/SeriesChart.story.tsx
+++ b/client/web/src/enterprise/insights/components/views/chart/series/SeriesChart.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { Meta, Story } from '@storybook/react'
 
 import { Series } from '../../../../../../charts'

--- a/client/web/src/enterprise/insights/pages/dashboards/creation/InsightsDashboardCreationPage.story.tsx
+++ b/client/web/src/enterprise/insights/pages/dashboards/creation/InsightsDashboardCreationPage.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { Meta, Story } from '@storybook/react'
 import { of } from 'rxjs'
 

--- a/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/add-insight-modal/AddInsightModal.story.tsx
+++ b/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/add-insight-modal/AddInsightModal.story.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import { useState } from 'react'
 
 import { storiesOf } from '@storybook/react'
 import { of } from 'rxjs'

--- a/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/dashboard-select/DashboardSelect.story.tsx
+++ b/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/dashboard-select/DashboardSelect.story.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import { useState } from 'react'
 
 import { storiesOf } from '@storybook/react'
 

--- a/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/dashboards-content/components/empty-insight-dashboard/EmptyInsightDashboard.story.tsx
+++ b/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/dashboards-content/components/empty-insight-dashboard/EmptyInsightDashboard.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { storiesOf } from '@storybook/react'
 import { noop } from 'lodash'
 

--- a/client/web/src/enterprise/insights/pages/insights/creation/capture-group/CaptureGroupCreationPage.story.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/capture-group/CaptureGroupCreationPage.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { Meta, Story } from '@storybook/react'
 import { noop } from 'lodash'
 

--- a/client/web/src/enterprise/insights/pages/insights/creation/capture-group/components/query-input/CaptureGroupQueryInput.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/capture-group/components/query-input/CaptureGroupQueryInput.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react'
+import { forwardRef } from 'react'
 
 import RegexIcon from 'mdi-react/RegexIcon'
 

--- a/client/web/src/enterprise/insights/pages/insights/creation/intro/IntroCreationPage.story.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/intro/IntroCreationPage.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { Meta, Story } from '@storybook/react'
 
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'

--- a/client/web/src/enterprise/insights/pages/insights/creation/intro/cards/InsightCards.story.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/intro/cards/InsightCards.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { Meta, Story } from '@storybook/react'
 
 import { WebStory } from '../../../../../../../components/WebStory'

--- a/client/web/src/enterprise/insights/pages/insights/creation/lang-stats/LangStatsInsightCreationPage.story.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/lang-stats/LangStatsInsightCreationPage.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { Meta, Story } from '@storybook/react'
 import delay from 'delay'
 import { noop } from 'lodash'

--- a/client/web/src/enterprise/insights/pages/insights/creation/search-insight/SearchInsightCreationPage.story.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/search-insight/SearchInsightCreationPage.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { Meta, Story } from '@storybook/react'
 import delay from 'delay'
 import { noop, random } from 'lodash'

--- a/client/web/src/enterprise/insights/pages/insights/creation/search-insight/components/form-series/components/series-card/SeriesCard.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/search-insight/components/form-series/components/series-card/SeriesCard.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from 'react'
+import { ReactElement } from 'react'
 
 import classNames from 'classnames'
 

--- a/client/web/src/enterprise/insights/pages/landing/dot-com-get-started/CodeInsightsDotComGetStarted.story.tsx
+++ b/client/web/src/enterprise/insights/pages/landing/dot-com-get-started/CodeInsightsDotComGetStarted.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { Meta } from '@storybook/react'
 
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'

--- a/client/web/src/enterprise/insights/pages/landing/dot-com-get-started/components/code-insights-examples-picker/code-insights-examples-slider/CodeInsightsExamplesSlider.story.tsx
+++ b/client/web/src/enterprise/insights/pages/landing/dot-com-get-started/components/code-insights-examples-picker/code-insights-examples-slider/CodeInsightsExamplesSlider.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { Meta } from '@storybook/react'
 
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'

--- a/client/web/src/enterprise/insights/pages/landing/getting-started/components/code-insights-examples/CodeInsightsExamples.story.tsx
+++ b/client/web/src/enterprise/insights/pages/landing/getting-started/components/code-insights-examples/CodeInsightsExamples.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { Meta } from '@storybook/react'
 
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'

--- a/client/web/src/enterprise/insights/pages/landing/getting-started/components/code-insights-query-block/CodeInsightsQueryBlock.tsx
+++ b/client/web/src/enterprise/insights/pages/landing/getting-started/components/code-insights-query-block/CodeInsightsQueryBlock.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react'
+import { forwardRef } from 'react'
 
 import classNames from 'classnames'
 

--- a/client/web/src/enterprise/main.tsx
+++ b/client/web/src/enterprise/main.tsx
@@ -7,8 +7,6 @@ import '@sourcegraph/shared/src/polyfills'
 
 import '../sentry/init'
 
-import React from 'react'
-
 import { render } from 'react-dom'
 
 import { EnterpriseWebApp } from './EnterpriseWebApp'

--- a/client/web/src/enterprise/organizations/EarlyAccessOrgsCodeForm.tsx
+++ b/client/web/src/enterprise/organizations/EarlyAccessOrgsCodeForm.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, useCallback, useState } from 'react'
+import { FunctionComponent, useCallback, useState } from 'react'
 
 import { Form } from '@sourcegraph/branded/src/components/Form'
 import { gql, useLazyQuery, useMutation } from '@sourcegraph/http-client'

--- a/client/web/src/enterprise/organizations/routes.tsx
+++ b/client/web/src/enterprise/organizations/routes.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { RouteComponentProps } from 'react-router'
 
 import { lazyComponent } from '@sourcegraph/shared/src/util/lazyComponent'

--- a/client/web/src/enterprise/repo/routes.tsx
+++ b/client/web/src/enterprise/repo/routes.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { lazyComponent } from '@sourcegraph/shared/src/util/lazyComponent'
 
 import { RepoContainerRoute } from '../../repo/RepoContainer'

--- a/client/web/src/enterprise/repo/settings/routes.tsx
+++ b/client/web/src/enterprise/repo/settings/routes.tsx
@@ -1,5 +1,3 @@
-import * as React from 'react'
-
 import { Redirect, RouteComponentProps } from 'react-router'
 
 import { lazyComponent } from '@sourcegraph/shared/src/util/lazyComponent'

--- a/client/web/src/enterprise/routes.tsx
+++ b/client/web/src/enterprise/routes.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { Redirect } from 'react-router'
 
 import { isErrorLike } from '@sourcegraph/common'

--- a/client/web/src/enterprise/search/stats/SearchStatsLanguages.test.tsx
+++ b/client/web/src/enterprise/search/stats/SearchStatsLanguages.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { render } from '@testing-library/react'
 import { MemoryRouter } from 'react-router'
 

--- a/client/web/src/enterprise/search/stats/SearchStatsPage.test.tsx
+++ b/client/web/src/enterprise/search/stats/SearchStatsPage.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { render, act } from '@testing-library/react'
 import * as H from 'history'
 import { MemoryRouter } from 'react-router'

--- a/client/web/src/enterprise/searchContexts/DeleteSearchContextModal.story.tsx
+++ b/client/web/src/enterprise/searchContexts/DeleteSearchContextModal.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { storiesOf } from '@storybook/react'
 import { NEVER } from 'rxjs'
 import sinon from 'sinon'

--- a/client/web/src/enterprise/searchContexts/SearchContextForm.story.tsx
+++ b/client/web/src/enterprise/searchContexts/SearchContextForm.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { storiesOf } from '@storybook/react'
 import { subDays } from 'date-fns'
 import { NEVER, Observable, of } from 'rxjs'

--- a/client/web/src/enterprise/searchContexts/SearchContextPage.story.tsx
+++ b/client/web/src/enterprise/searchContexts/SearchContextPage.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { storiesOf } from '@storybook/react'
 import { subDays } from 'date-fns'
 import { NEVER, Observable, of, throwError } from 'rxjs'

--- a/client/web/src/enterprise/searchContexts/SearchContextsListTab.story.tsx
+++ b/client/web/src/enterprise/searchContexts/SearchContextsListTab.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { storiesOf } from '@storybook/react'
 import { subDays } from 'date-fns'
 import { Observable, of } from 'rxjs'

--- a/client/web/src/enterprise/site-admin/SiteAdminLsifUploadPage.tsx
+++ b/client/web/src/enterprise/site-admin/SiteAdminLsifUploadPage.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, useEffect, useMemo } from 'react'
+import { FunctionComponent, useEffect, useMemo } from 'react'
 
 import { RouteComponentProps, Redirect } from 'react-router'
 import { catchError } from 'rxjs/operators'

--- a/client/web/src/enterprise/site-admin/dotcom/customers/SiteAdminCustomerBillingLink.test.tsx
+++ b/client/web/src/enterprise/site-admin/dotcom/customers/SiteAdminCustomerBillingLink.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { renderWithBrandedContext } from '@sourcegraph/shared/src/testing'
 
 import { SiteAdminCustomerBillingLink } from './SiteAdminCustomerBillingLink'

--- a/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminGenerateProductLicenseForSubscriptionForm.test.tsx
+++ b/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminGenerateProductLicenseForSubscriptionForm.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { renderWithBrandedContext } from '@sourcegraph/shared/src/testing'
 
 import { SiteAdminGenerateProductLicenseForSubscriptionForm } from './SiteAdminGenerateProductLicenseForSubscriptionForm'

--- a/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminProductLicenseNode.test.tsx
+++ b/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminProductLicenseNode.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import * as GQL from '@sourcegraph/shared/src/schema'
 import { renderWithBrandedContext } from '@sourcegraph/shared/src/testing'
 

--- a/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminProductSubscriptionBillingLink.test.tsx
+++ b/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminProductSubscriptionBillingLink.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { renderWithBrandedContext } from '@sourcegraph/shared/src/testing'
 
 import { SiteAdminProductSubscriptionBillingLink } from './SiteAdminProductSubscriptionBillingLink'

--- a/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminProductSubscriptionPage.test.tsx
+++ b/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminProductSubscriptionPage.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { act } from '@testing-library/react'
 import * as H from 'history'
 import { of } from 'rxjs'

--- a/client/web/src/enterprise/user/productSubscriptions/NewProductSubscriptionPaymentSection.test.tsx
+++ b/client/web/src/enterprise/user/productSubscriptions/NewProductSubscriptionPaymentSection.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { render, act } from '@testing-library/react'
 import { of } from 'rxjs'
 

--- a/client/web/src/enterprise/user/productSubscriptions/UserProductSubscriptionStatus.test.tsx
+++ b/client/web/src/enterprise/user/productSubscriptions/UserProductSubscriptionStatus.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 

--- a/client/web/src/enterprise/user/productSubscriptions/UserSubscriptionsEditProductSubscriptionPage.test.tsx
+++ b/client/web/src/enterprise/user/productSubscriptions/UserSubscriptionsEditProductSubscriptionPage.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { act } from '@testing-library/react'
 import * as H from 'history'
 import { of } from 'rxjs'

--- a/client/web/src/enterprise/user/productSubscriptions/UserSubscriptionsProductSubscriptionPage.test.tsx
+++ b/client/web/src/enterprise/user/productSubscriptions/UserSubscriptionsProductSubscriptionPage.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { act } from '@testing-library/react'
 import { createMemoryHistory } from 'history'
 import { of } from 'rxjs'

--- a/client/web/src/enterprise/user/routes.tsx
+++ b/client/web/src/enterprise/user/routes.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { Redirect, RouteComponentProps } from 'react-router'
 
 import { lazyComponent } from '@sourcegraph/shared/src/util/lazyComponent'

--- a/client/web/src/extensions/ExtensionBanner.story.tsx
+++ b/client/web/src/extensions/ExtensionBanner.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { storiesOf } from '@storybook/react'
 
 import { WebStory } from '../components/WebStory'

--- a/client/web/src/extensions/ExtensionCard.test.tsx
+++ b/client/web/src/extensions/ExtensionCard.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { render } from '@testing-library/react'
 import { MemoryRouter } from 'react-router'
 

--- a/client/web/src/extensions/ExtensionPermissionModal.test.tsx
+++ b/client/web/src/extensions/ExtensionPermissionModal.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { render } from '@testing-library/react'
 
 import { ExtensionPermissionModal } from './ExtensionPermissionModal'

--- a/client/web/src/extensions/ExtensionRegistrySidenav.test.tsx
+++ b/client/web/src/extensions/ExtensionRegistrySidenav.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { renderWithBrandedContext } from '@sourcegraph/shared/src/testing'
 
 import { ExtensionRegistrySidenav } from './ExtensionRegistrySidenav'

--- a/client/web/src/extensions/ExtensionToggle.test.tsx
+++ b/client/web/src/extensions/ExtensionToggle.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { render } from '@testing-library/react'
 
 import { ConfiguredRegistryExtension } from '@sourcegraph/shared/src/extensions/extension'

--- a/client/web/src/extensions/components/StatusBar.story.tsx
+++ b/client/web/src/extensions/components/StatusBar.story.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react'
+import { useCallback } from 'react'
 
 import { storiesOf } from '@storybook/react'
 import * as H from 'history'

--- a/client/web/src/extensions/components/StatusBar.test.tsx
+++ b/client/web/src/extensions/components/StatusBar.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { render } from '@testing-library/react'
 import * as H from 'history'
 import { BehaviorSubject } from 'rxjs'

--- a/client/web/src/extensions/extension/RegistryExtensionOverviewPage.test.tsx
+++ b/client/web/src/extensions/extension/RegistryExtensionOverviewPage.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { createMemoryHistory } from 'history'
 
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'

--- a/client/web/src/extensions/routes.tsx
+++ b/client/web/src/extensions/routes.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { lazyComponent } from '@sourcegraph/shared/src/util/lazyComponent'
 
 import { ExtensionsAreaRoute } from './ExtensionsArea'

--- a/client/web/src/global/GlobalAlert.story.tsx
+++ b/client/web/src/global/GlobalAlert.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { Meta, Story } from '@storybook/react'
 
 import { BrandedStory } from '@sourcegraph/branded/src/components/BrandedStory'

--- a/client/web/src/global/Notices.test.tsx
+++ b/client/web/src/global/Notices.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { renderWithBrandedContext } from '@sourcegraph/shared/src/testing'
 
 import { Notices } from './Notices'

--- a/client/web/src/main.tsx
+++ b/client/web/src/main.tsx
@@ -7,8 +7,6 @@ import '@sourcegraph/shared/src/polyfills'
 
 import './sentry/init'
 
-import React from 'react'
-
 import { render } from 'react-dom'
 
 import { OpenSourceWebApp } from './OpenSourceWebApp'

--- a/client/web/src/marketing/SurveyPage.story.tsx
+++ b/client/web/src/marketing/SurveyPage.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { DecoratorFn, Meta, Story } from '@storybook/react'
 
 import { MockedStoryProvider } from '@sourcegraph/storybook'

--- a/client/web/src/marketing/SurveyPage.test.tsx
+++ b/client/web/src/marketing/SurveyPage.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { MockedProviderProps } from '@apollo/client/testing'
 import { cleanup, fireEvent, within, waitFor } from '@testing-library/react'
 import { createMemoryHistory } from 'history'

--- a/client/web/src/marketing/SurveyToast.test.tsx
+++ b/client/web/src/marketing/SurveyToast.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { gql } from '@apollo/client'
 import { createMockClient } from '@apollo/client/testing'
 import { cleanup, within, fireEvent } from '@testing-library/react'

--- a/client/web/src/nav/MenuNavItem.test.tsx
+++ b/client/web/src/nav/MenuNavItem.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { render } from '@testing-library/react'
 
 import { MenuNavItem } from './MenuNavItem'

--- a/client/web/src/nav/StatusMessagesNavItem.test.tsx
+++ b/client/web/src/nav/StatusMessagesNavItem.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { createMemoryHistory } from 'history'
 import { of, Observable } from 'rxjs'
 

--- a/client/web/src/nav/UserNavItem.test.tsx
+++ b/client/web/src/nav/UserNavItem.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import * as H from 'history'

--- a/client/web/src/notebooks/blocks/compute/NotebookComputeBlock.story.tsx
+++ b/client/web/src/notebooks/blocks/compute/NotebookComputeBlock.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { storiesOf } from '@storybook/react'
 import { noop } from 'lodash'
 

--- a/client/web/src/notebooks/blocks/file/NotebookFileBlock.story.tsx
+++ b/client/web/src/notebooks/blocks/file/NotebookFileBlock.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { storiesOf } from '@storybook/react'
 import { noop } from 'lodash'
 import { of } from 'rxjs'

--- a/client/web/src/notebooks/blocks/file/NotebookFileBlockInputs.story.tsx
+++ b/client/web/src/notebooks/blocks/file/NotebookFileBlockInputs.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { storiesOf } from '@storybook/react'
 import { noop } from 'lodash'
 

--- a/client/web/src/notebooks/blocks/menu/useCommonBlockMenuActions.tsx
+++ b/client/web/src/notebooks/blocks/menu/useCommonBlockMenuActions.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react'
+import { useMemo } from 'react'
 
 import ArrowDownIcon from 'mdi-react/ArrowDownIcon'
 import ArrowUpIcon from 'mdi-react/ArrowUpIcon'

--- a/client/web/src/notebooks/blocks/query/NotebookQueryBlock.story.tsx
+++ b/client/web/src/notebooks/blocks/query/NotebookQueryBlock.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { storiesOf } from '@storybook/react'
 import { noop } from 'lodash'
 import { of } from 'rxjs'

--- a/client/web/src/notebooks/blocks/suggestions/SearchTypeSuggestionsInput.tsx
+++ b/client/web/src/notebooks/blocks/suggestions/SearchTypeSuggestionsInput.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useCallback, useMemo } from 'react'
+import { ReactElement, useCallback, useMemo } from 'react'
 
 import classNames from 'classnames'
 import { noop } from 'lodash'

--- a/client/web/src/notebooks/listPage/NotebooksListPage.story.tsx
+++ b/client/web/src/notebooks/listPage/NotebooksListPage.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { storiesOf } from '@storybook/react'
 import { subDays } from 'date-fns'
 import { Observable, of } from 'rxjs'

--- a/client/web/src/notebooks/notebook/NotebookComponent.story.tsx
+++ b/client/web/src/notebooks/notebook/NotebookComponent.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { storiesOf } from '@storybook/react'
 import { NEVER, of } from 'rxjs'
 

--- a/client/web/src/notebooks/notebook/useCommandPaletteOptions.tsx
+++ b/client/web/src/notebooks/notebook/useCommandPaletteOptions.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useMemo } from 'react'
+import { ReactElement, useMemo } from 'react'
 
 import CodeTagsIcon from 'mdi-react/CodeTagsIcon'
 import FunctionIcon from 'mdi-react/FunctionIcon'

--- a/client/web/src/org/area/routes.tsx
+++ b/client/web/src/org/area/routes.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { Redirect } from 'react-router'
 
 import { lazyComponent } from '@sourcegraph/shared/src/util/lazyComponent'

--- a/client/web/src/person/PersonLink.test.tsx
+++ b/client/web/src/person/PersonLink.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { render } from '@testing-library/react'
 import { MemoryRouter } from 'react-router'
 

--- a/client/web/src/repo/RepoRevisionSidebarSymbols.test.tsx
+++ b/client/web/src/repo/RepoRevisionSidebarSymbols.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { MockedResponse } from '@apollo/client/testing'
 import { cleanup, fireEvent } from '@testing-library/react'
 import { escapeRegExp } from 'lodash'

--- a/client/web/src/repo/RepositoriesPopover/RepositoriesPopover.story.tsx
+++ b/client/web/src/repo/RepositoriesPopover/RepositoriesPopover.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { Meta } from '@storybook/react'
 
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'

--- a/client/web/src/repo/RepositoriesPopover/RepositoriesPopover.test.tsx
+++ b/client/web/src/repo/RepositoriesPopover/RepositoriesPopover.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { cleanup, fireEvent, act } from '@testing-library/react'
 
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'

--- a/client/web/src/repo/RevisionsPopover/RevisionsPopover.story.tsx
+++ b/client/web/src/repo/RevisionsPopover/RevisionsPopover.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { Meta } from '@storybook/react'
 
 import { WebStory } from '../../components/WebStory'

--- a/client/web/src/repo/RevisionsPopover/RevisionsPopover.test.tsx
+++ b/client/web/src/repo/RevisionsPopover/RevisionsPopover.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { cleanup, within, fireEvent, act } from '@testing-library/react'
 
 import { renderWithBrandedContext, RenderWithBrandedContextResult } from '@sourcegraph/shared/src/testing'

--- a/client/web/src/repo/actions/BrowserExtensionAlert.story.tsx
+++ b/client/web/src/repo/actions/BrowserExtensionAlert.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { action } from '@storybook/addon-actions'
 import { DecoratorFn, Meta, Story } from '@storybook/react'
 

--- a/client/web/src/repo/actions/GoToCodeHostAction.story.tsx
+++ b/client/web/src/repo/actions/GoToCodeHostAction.story.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import { useEffect, useState } from 'react'
 
 import { action } from '@storybook/addon-actions'
 import { storiesOf } from '@storybook/react'

--- a/client/web/src/repo/actions/IdeExtensionAlert.story.tsx
+++ b/client/web/src/repo/actions/IdeExtensionAlert.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { action } from '@storybook/addon-actions'
 import { DecoratorFn, Meta, Story } from '@storybook/react'
 

--- a/client/web/src/repo/blob/LineDecorator.test.tsx
+++ b/client/web/src/repo/blob/LineDecorator.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { render, within, waitFor } from '@testing-library/react'
 import { ReplaySubject } from 'rxjs'
 import { TextDocumentDecoration, ThemableDecorationStyle } from 'sourcegraph'

--- a/client/web/src/repo/blob/actions/ToggleRenderedFileMode.test.tsx
+++ b/client/web/src/repo/blob/actions/ToggleRenderedFileMode.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { renderWithBrandedContext } from '@sourcegraph/shared/src/testing'
 
 import { ToggleRenderedFileMode } from './ToggleRenderedFileMode'

--- a/client/web/src/repo/blob/panel/BlobPanel.tsx
+++ b/client/web/src/repo/blob/panel/BlobPanel.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useRef } from 'react'
+import { useCallback, useEffect, useMemo, useRef } from 'react'
 
 import * as H from 'history'
 import { from, Observable, ReplaySubject, Subscription } from 'rxjs'

--- a/client/web/src/repo/commits/GitCommitNode.story.tsx
+++ b/client/web/src/repo/commits/GitCommitNode.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { boolean } from '@storybook/addon-knobs'
 import { storiesOf } from '@storybook/react'
 import { subDays } from 'date-fns'

--- a/client/web/src/repo/commits/GitCommitNodeByline.test.tsx
+++ b/client/web/src/repo/commits/GitCommitNodeByline.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { render } from '@testing-library/react'
 
 import { SignatureFields } from '../../graphql-operations'

--- a/client/web/src/repo/releases/RepositoryReleasesTagsPage.test.tsx
+++ b/client/web/src/repo/releases/RepositoryReleasesTagsPage.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { render } from '@testing-library/react'
 import * as H from 'history'
 import { of } from 'rxjs'

--- a/client/web/src/repo/tree/TreeEntriesSection.test.tsx
+++ b/client/web/src/repo/tree/TreeEntriesSection.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { renderWithBrandedContext } from '@sourcegraph/shared/src/testing'
 
 import { TreeEntriesSection } from './TreeEntriesSection'

--- a/client/web/src/savedSearches/SavedSearchForm.story.tsx
+++ b/client/web/src/savedSearches/SavedSearchForm.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { storiesOf } from '@storybook/react'
 
 import { WebStory } from '../components/WebStory'

--- a/client/web/src/search/Notepad.test.tsx
+++ b/client/web/src/search/Notepad.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { act, cleanup, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { noop } from 'lodash'

--- a/client/web/src/search/home/SearchPage.story.tsx
+++ b/client/web/src/search/home/SearchPage.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { storiesOf } from '@storybook/react'
 import { parseISO } from 'date-fns'
 import { createMemoryHistory } from 'history'

--- a/client/web/src/search/home/SearchPage.test.tsx
+++ b/client/web/src/search/home/SearchPage.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { cleanup } from '@testing-library/react'
 import { createMemoryHistory } from 'history'
 

--- a/client/web/src/search/input/SearchOnboardingTour.tsx
+++ b/client/web/src/search/input/SearchOnboardingTour.tsx
@@ -1,7 +1,7 @@
 /**
  * This file contains utility functions for the search onboarding tour.
  */
-import React, { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 
 import classNames from 'classnames'
 import * as H from 'history'

--- a/client/web/src/search/panels/CollaboratorsPanel.story.tsx
+++ b/client/web/src/search/panels/CollaboratorsPanel.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { storiesOf } from '@storybook/react'
 
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'

--- a/client/web/src/search/panels/CommunitySearchContextPanel.story.tsx
+++ b/client/web/src/search/panels/CommunitySearchContextPanel.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { storiesOf } from '@storybook/react'
 
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'

--- a/client/web/src/search/panels/CommunitySearchContextPanel.test.tsx
+++ b/client/web/src/search/panels/CommunitySearchContextPanel.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { renderWithBrandedContext } from '@sourcegraph/shared/src/testing'
 

--- a/client/web/src/search/panels/PanelContainer.test.tsx
+++ b/client/web/src/search/panels/PanelContainer.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { render } from '@testing-library/react'
 
 import { PanelContainer } from './PanelContainer'

--- a/client/web/src/search/panels/RecentFilesPanel.story.tsx
+++ b/client/web/src/search/panels/RecentFilesPanel.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { storiesOf } from '@storybook/react'
 import { noop } from 'lodash'
 

--- a/client/web/src/search/panels/RecentFilesPanel.test.tsx
+++ b/client/web/src/search/panels/RecentFilesPanel.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { screen } from '@testing-library/react'
 import { noop } from 'rxjs'
 

--- a/client/web/src/search/panels/RecentSearchesPanel.story.tsx
+++ b/client/web/src/search/panels/RecentSearchesPanel.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { storiesOf } from '@storybook/react'
 import { parseISO } from 'date-fns'
 import { noop } from 'lodash'

--- a/client/web/src/search/panels/RecentSearchesPanel.test.tsx
+++ b/client/web/src/search/panels/RecentSearchesPanel.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { noop } from 'rxjs'

--- a/client/web/src/search/panels/RepositoriesPanel.story.tsx
+++ b/client/web/src/search/panels/RepositoriesPanel.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { storiesOf } from '@storybook/react'
 import { noop } from 'lodash'
 

--- a/client/web/src/search/panels/RepositoriesPanel.test.tsx
+++ b/client/web/src/search/panels/RepositoriesPanel.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { noop } from 'rxjs'

--- a/client/web/src/search/panels/SavedSearchesPanel.story.tsx
+++ b/client/web/src/search/panels/SavedSearchesPanel.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { storiesOf } from '@storybook/react'
 
 import { SearchPatternType } from '@sourcegraph/shared/src/schema'

--- a/client/web/src/search/panels/SavedSearchesPanel.test.tsx
+++ b/client/web/src/search/panels/SavedSearchesPanel.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { cleanup, fireEvent } from '@testing-library/react'
 
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'

--- a/client/web/src/search/results/SearchResultsInfoBar.test.tsx
+++ b/client/web/src/search/results/SearchResultsInfoBar.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { createMemoryHistory, createLocation } from 'history'
 import { noop } from 'lodash'
 import { NEVER } from 'rxjs'

--- a/client/web/src/search/results/StreamingSearchResults.story.tsx
+++ b/client/web/src/search/results/StreamingSearchResults.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { storiesOf } from '@storybook/react'
 import { createBrowserHistory } from 'history'
 import { EMPTY, NEVER, of } from 'rxjs'

--- a/client/web/src/search/results/sidebar/Revisions.story.tsx
+++ b/client/web/src/search/results/sidebar/Revisions.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { MockedProviderProps } from '@apollo/client/testing'
 import { Meta } from '@storybook/react'
 

--- a/client/web/src/search/results/sidebar/Revisions.test.tsx
+++ b/client/web/src/search/results/sidebar/Revisions.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { cleanup, within, fireEvent } from '@testing-library/react'
 
 import { RevisionsProps } from '@sourcegraph/search-ui'

--- a/client/web/src/site-admin/SiteAdminMigrationsPage.story.tsx
+++ b/client/web/src/site-admin/SiteAdminMigrationsPage.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { storiesOf } from '@storybook/react'
 import * as H from 'history'
 import { Observable, of } from 'rxjs'

--- a/client/web/src/site-admin/SiteAdminSidebar.story.tsx
+++ b/client/web/src/site-admin/SiteAdminSidebar.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { storiesOf } from '@storybook/react'
 
 import { WebStory } from '../components/WebStory'

--- a/client/web/src/site-admin/init/SiteInitPage.test.tsx
+++ b/client/web/src/site-admin/init/SiteInitPage.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { createMemoryHistory } from 'history'
 
 import { renderWithBrandedContext } from '@sourcegraph/shared/src/testing'

--- a/client/web/src/site-admin/overview/SiteAdminOverviewPage.test.tsx
+++ b/client/web/src/site-admin/overview/SiteAdminOverviewPage.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { waitFor } from '@testing-library/react'
 import * as H from 'history'
 import { of } from 'rxjs'

--- a/client/web/src/site-admin/routes.tsx
+++ b/client/web/src/site-admin/routes.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { Redirect, RouteComponentProps } from 'react-router'
 
 import { lazyComponent } from '@sourcegraph/shared/src/util/lazyComponent'

--- a/client/web/src/site-admin/webhooks/MessagePanel.story.tsx
+++ b/client/web/src/site-admin/webhooks/MessagePanel.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { number } from '@storybook/addon-knobs'
 import { storiesOf } from '@storybook/react'
 

--- a/client/web/src/site-admin/webhooks/PerformanceGauge.story.tsx
+++ b/client/web/src/site-admin/webhooks/PerformanceGauge.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { storiesOf } from '@storybook/react'
 
 import { WebStory } from '../../components/WebStory'

--- a/client/web/src/site-admin/webhooks/StatusCode.story.tsx
+++ b/client/web/src/site-admin/webhooks/StatusCode.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { number } from '@storybook/addon-knobs'
 import { storiesOf } from '@storybook/react'
 

--- a/client/web/src/site-admin/webhooks/WebhookLogNode.story.tsx
+++ b/client/web/src/site-admin/webhooks/WebhookLogNode.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { storiesOf } from '@storybook/react'
 import classNames from 'classnames'
 

--- a/client/web/src/site-admin/webhooks/WebhookLogPage.story.tsx
+++ b/client/web/src/site-admin/webhooks/WebhookLogPage.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { storiesOf } from '@storybook/react'
 import { addMinutes, formatRFC3339 } from 'date-fns'
 import { of } from 'rxjs'

--- a/client/web/src/site/CodeHostScopeAlerts/CodeHostScopeAlerts.tsx
+++ b/client/web/src/site/CodeHostScopeAlerts/CodeHostScopeAlerts.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent } from 'react'
+import { FunctionComponent } from 'react'
 
 import { Link } from '@sourcegraph/wildcard'
 

--- a/client/web/src/site/LicenseExpirationAlert.test.tsx
+++ b/client/web/src/site/LicenseExpirationAlert.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { subMonths, addDays } from 'date-fns'
 
 import { renderWithBrandedContext } from '@sourcegraph/shared/src/testing'

--- a/client/web/src/tour/GettingStartedTour.tsx
+++ b/client/web/src/tour/GettingStartedTour.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { FeatureFlagProps } from '../featureFlags/featureFlags'
 
 import { Tour, TourProps } from './components/Tour/Tour'

--- a/client/web/src/tour/components/Tour/Tour.test.tsx
+++ b/client/web/src/tour/components/Tour/Tour.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { render, cleanup, RenderResult, fireEvent, act } from '@testing-library/react'
 import { renderHook, RenderHookResult } from '@testing-library/react-hooks'
 import { MemoryRouter } from 'react-router'

--- a/client/web/src/tour/data/index.tsx
+++ b/client/web/src/tour/data/index.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import CheckCircleIcon from 'mdi-react/CheckCircleIcon'
 import CursorPointerIcon from 'mdi-react/CursorPointerIcon'
 import MagnifyIcon from 'mdi-react/MagnifyIcon'

--- a/client/web/src/tree/FileDecorator.test.tsx
+++ b/client/web/src/tree/FileDecorator.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { render } from '@testing-library/react'
 
 import { FileDecorator } from './FileDecorator'

--- a/client/web/src/user/UserAvatar.test.tsx
+++ b/client/web/src/user/UserAvatar.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { render } from '@testing-library/react'
 
 import { UserAvatar } from './UserAvatar'

--- a/client/web/src/user/area/routes.tsx
+++ b/client/web/src/user/area/routes.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { Redirect } from 'react-router'
 
 import { lazyComponent } from '@sourcegraph/shared/src/util/lazyComponent'

--- a/client/web/src/user/settings/RedirectToUserPage.tsx
+++ b/client/web/src/user/settings/RedirectToUserPage.tsx
@@ -1,5 +1,3 @@
-import * as React from 'react'
-
 import * as H from 'history'
 import { Redirect } from 'react-router'
 

--- a/client/web/src/user/settings/RedirectToUserSettings.tsx
+++ b/client/web/src/user/settings/RedirectToUserSettings.tsx
@@ -1,5 +1,3 @@
-import * as React from 'react'
-
 import * as H from 'history'
 import { Redirect } from 'react-router'
 

--- a/client/web/src/user/settings/aboutOrganization/AboutOrganizationPage.story.tsx
+++ b/client/web/src/user/settings/aboutOrganization/AboutOrganizationPage.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { DecoratorFn, Meta } from '@storybook/react'
 
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'

--- a/client/web/src/user/settings/emails/UserEmail.tsx
+++ b/client/web/src/user/settings/emails/UserEmail.tsx
@@ -1,4 +1,4 @@
-import React, { useState, FunctionComponent } from 'react'
+import { useState, FunctionComponent } from 'react'
 
 import { asError, ErrorLike } from '@sourcegraph/common'
 import { dataOrThrowErrors, gql } from '@sourcegraph/http-client'

--- a/client/web/src/user/settings/emails/UserSettingsEmailsPage.tsx
+++ b/client/web/src/user/settings/emails/UserSettingsEmailsPage.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, useEffect, useState, useCallback } from 'react'
+import { FunctionComponent, useEffect, useState, useCallback } from 'react'
 
 import classNames from 'classnames'
 

--- a/client/web/src/user/settings/profile/UserSettingsProfilePage.test.tsx
+++ b/client/web/src/user/settings/profile/UserSettingsProfilePage.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { MockedResponse } from '@apollo/client/testing'
 import { fireEvent, render, RenderResult, act } from '@testing-library/react'
 import { MemoryRouter } from 'react-router'

--- a/client/web/src/user/settings/research/ProductResearch.test.tsx
+++ b/client/web/src/user/settings/research/ProductResearch.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { render, RenderResult } from '@testing-library/react'
 
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'

--- a/client/web/src/user/settings/routes.tsx
+++ b/client/web/src/user/settings/routes.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { RouteComponentProps } from 'react-router'
 
 import { lazyComponent } from '@sourcegraph/shared/src/util/lazyComponent'

--- a/client/web/src/util/getReactElements.test.tsx
+++ b/client/web/src/util/getReactElements.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { getReactElements } from './getReactElements'
 
 describe('util/getReactElements', () => {

--- a/client/web/src/views/components/view-grid/ViewGrid.story.tsx
+++ b/client/web/src/views/components/view-grid/ViewGrid.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { Meta, Story } from '@storybook/react'
 import { noop } from 'lodash'
 import DotsVerticalIcon from 'mdi-react/DotsVerticalIcon'

--- a/client/web/src/views/components/view/View.story.tsx
+++ b/client/web/src/views/components/view/View.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { Meta, Story } from '@storybook/react'
 import { noop } from 'lodash'
 import DotsVerticalIcon from 'mdi-react/DotsVerticalIcon'

--- a/client/web/src/views/components/view/content/chart-view-content/ChartViewContent.story.tsx
+++ b/client/web/src/views/components/view/content/chart-view-content/ChartViewContent.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { storiesOf } from '@storybook/react'
 import isChromatic from 'chromatic/isChromatic'
 import { createMemoryHistory } from 'history'

--- a/client/web/src/views/components/view/content/chart-view-content/ChartViewContent.tsx
+++ b/client/web/src/views/components/view/content/chart-view-content/ChartViewContent.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, useCallback } from 'react'
+import { FunctionComponent, useCallback } from 'react'
 
 import { ParentSize } from '@visx/responsive'
 import classNames from 'classnames'

--- a/client/web/src/views/components/view/content/chart-view-content/charts/line/components/GlyphContent.tsx
+++ b/client/web/src/views/components/view/content/chart-view-content/charts/line/components/GlyphContent.tsx
@@ -1,4 +1,4 @@
-import React, { MouseEventHandler, PointerEventHandler, ReactElement } from 'react'
+import { MouseEventHandler, PointerEventHandler, ReactElement } from 'react'
 
 import { GlyphDot as Glyph } from '@visx/glyph'
 import { EventHandlerParams, GlyphProps } from '@visx/xychart/lib/types'

--- a/client/web/src/views/components/view/content/chart-view-content/charts/line/components/NonActiveBackground.tsx
+++ b/client/web/src/views/components/view/content/chart-view-content/charts/line/components/NonActiveBackground.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useContext, useMemo } from 'react'
+import { ReactElement, useContext, useMemo } from 'react'
 
 import { PatternLines } from '@visx/pattern'
 import { DataContext } from '@visx/xychart'

--- a/client/web/src/views/components/view/content/chart-view-content/charts/line/components/scroll-box/ScrollBox.story.tsx
+++ b/client/web/src/views/components/view/content/chart-view-content/charts/line/components/scroll-box/ScrollBox.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { Meta } from '@storybook/react'
 
 import { WebStory } from '../../../../../../../../../components/WebStory'

--- a/client/web/src/views/components/view/content/chart-view-content/charts/line/components/tooltip-content/TooltipContent.tsx
+++ b/client/web/src/views/components/view/content/chart-view-content/charts/line/components/tooltip-content/TooltipContent.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useMemo } from 'react'
+import { ReactElement, useMemo } from 'react'
 
 import { RenderTooltipParams } from '@visx/xychart/lib/components/Tooltip'
 

--- a/client/web/src/views/components/view/content/chart-view-content/charts/pie/components/PieArc.tsx
+++ b/client/web/src/views/components/view/content/chart-view-content/charts/pie/components/PieArc.tsx
@@ -1,4 +1,4 @@
-import React, { PointerEventHandler, ReactElement } from 'react'
+import { PointerEventHandler, ReactElement } from 'react'
 
 import { Annotation, Connector } from '@visx/annotation'
 import { Group } from '@visx/group'

--- a/client/web/tsconfig.json
+++ b/client/web/tsconfig.json
@@ -6,7 +6,7 @@
     "paths": {
       "*": ["src/types/*", "../shared/src/types/*", "../common/src/types/*", "*"],
     },
-    "jsx": "react",
+    "jsx": "react-jsx",
     "rootDir": ".",
     "outDir": "out",
   },

--- a/client/wildcard/src/components/Alert/Alert.test.tsx
+++ b/client/wildcard/src/components/Alert/Alert.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { render } from '@testing-library/react'
 
 import { Alert } from './Alert'

--- a/client/wildcard/src/components/Badge/Badge.story.tsx
+++ b/client/wildcard/src/components/Badge/Badge.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { Meta } from '@storybook/react'
 
 import { BrandedStory } from '@sourcegraph/branded/src/components/BrandedStory'

--- a/client/wildcard/src/components/Badge/ProductStatusBadge.story.tsx
+++ b/client/wildcard/src/components/Badge/ProductStatusBadge.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { Meta } from '@storybook/react'
 
 import { BrandedStory } from '@sourcegraph/branded/src/components/BrandedStory'

--- a/client/wildcard/src/components/Button/Button.test.tsx
+++ b/client/wildcard/src/components/Button/Button.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { renderWithBrandedContext } from '@sourcegraph/shared/src/testing'
 
 import { Button } from './Button'

--- a/client/wildcard/src/components/Button/story/Button.story.tsx
+++ b/client/wildcard/src/components/Button/story/Button.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { boolean, select } from '@storybook/addon-knobs'
 import { Meta, Story } from '@storybook/react'
 import SearchIcon from 'mdi-react/SearchIcon'

--- a/client/wildcard/src/components/ButtonLink/ButtonLink.story.tsx
+++ b/client/wildcard/src/components/ButtonLink/ButtonLink.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { Meta, Story } from '@storybook/react'
 import { startCase } from 'lodash'
 import SearchIcon from 'mdi-react/SearchIcon'

--- a/client/wildcard/src/components/ButtonLink/ButtonLink.test.tsx
+++ b/client/wildcard/src/components/ButtonLink/ButtonLink.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import sinon from 'sinon'

--- a/client/wildcard/src/components/Card/Card.story.tsx
+++ b/client/wildcard/src/components/Card/Card.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { Meta, Story } from '@storybook/react'
 
 import { BrandedStory } from '@sourcegraph/branded/src/components/BrandedStory'

--- a/client/wildcard/src/components/Card/Card.test.tsx
+++ b/client/wildcard/src/components/Card/Card.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { render, screen } from '@testing-library/react'
 
 import { Card, CardBody, CardHeader, CardSubtitle, CardText, CardTitle } from '.'

--- a/client/wildcard/src/components/Collapse/Collapse.story.tsx
+++ b/client/wildcard/src/components/Collapse/Collapse.story.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react'
+import { useCallback, useState } from 'react'
 
 import { DecoratorFn, Meta, Story } from '@storybook/react'
 import ChevronDownIcon from 'mdi-react/ChevronDownIcon'

--- a/client/wildcard/src/components/Collapse/Collapse.test.tsx
+++ b/client/wildcard/src/components/Collapse/Collapse.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import sinon from 'sinon'

--- a/client/wildcard/src/components/Container/Container.story.tsx
+++ b/client/wildcard/src/components/Container/Container.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { DecoratorFn, Meta, Story } from '@storybook/react'
 
 import { BrandedStory } from '@sourcegraph/branded/src/components/BrandedStory'

--- a/client/wildcard/src/components/Feedback/FeedbackBadge/FeedbackBadge.story.tsx
+++ b/client/wildcard/src/components/Feedback/FeedbackBadge/FeedbackBadge.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { Meta, Story } from '@storybook/react'
 
 import { BrandedStory } from '@sourcegraph/branded/src/components/BrandedStory'

--- a/client/wildcard/src/components/Feedback/FeedbackBadge/FeedbackBadge.test.tsx
+++ b/client/wildcard/src/components/Feedback/FeedbackBadge/FeedbackBadge.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { render } from '@testing-library/react'
 
 import { FEEDBACK_BADGES_STATUS } from './constant'

--- a/client/wildcard/src/components/Feedback/FeedbackPrompt/FeedbackPrompt.story.tsx
+++ b/client/wildcard/src/components/Feedback/FeedbackPrompt/FeedbackPrompt.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { Meta, Story } from '@storybook/react'
 
 import { BrandedStory } from '@sourcegraph/branded/src/components/BrandedStory'

--- a/client/wildcard/src/components/Feedback/FeedbackPrompt/FeedbackPrompt.test.tsx
+++ b/client/wildcard/src/components/Feedback/FeedbackPrompt/FeedbackPrompt.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import sinon from 'sinon'

--- a/client/wildcard/src/components/Feedback/FeedbackText/FeedbackText.story.tsx
+++ b/client/wildcard/src/components/Feedback/FeedbackText/FeedbackText.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { Meta, Story } from '@storybook/react'
 
 import { BrandedStory } from '@sourcegraph/branded/src/components/BrandedStory'

--- a/client/wildcard/src/components/Feedback/FeedbackText/FeedbackText.test.tsx
+++ b/client/wildcard/src/components/Feedback/FeedbackText/FeedbackText.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { render } from '@testing-library/react'
 
 import { FeedbackText } from './FeedbackText'

--- a/client/wildcard/src/components/Form/FlexTextArea/FlexTextArea.tsx
+++ b/client/wildcard/src/components/Form/FlexTextArea/FlexTextArea.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, InputHTMLAttributes, Ref, useEffect, useImperativeHandle, useRef, useState } from 'react'
+import { forwardRef, InputHTMLAttributes, Ref, useEffect, useImperativeHandle, useRef, useState } from 'react'
 
 import classNames from 'classnames'
 

--- a/client/wildcard/src/components/Form/Input/Input.test.tsx
+++ b/client/wildcard/src/components/Form/Input/Input.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { render } from '@testing-library/react'
 
 import { Input } from './Input'

--- a/client/wildcard/src/components/Form/Input/Input.tsx
+++ b/client/wildcard/src/components/Form/Input/Input.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, forwardRef, InputHTMLAttributes, ReactNode } from 'react'
+import { useRef, forwardRef, InputHTMLAttributes, ReactNode } from 'react'
 
 import classNames from 'classnames'
 import { useMergeRefs } from 'use-callback-ref'

--- a/client/wildcard/src/components/Form/MultiSelect/ClearIndicator.tsx
+++ b/client/wildcard/src/components/Form/MultiSelect/ClearIndicator.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from 'react'
+import { ReactElement } from 'react'
 
 import CloseIcon from 'mdi-react/CloseIcon'
 import { components, ClearIndicatorProps } from 'react-select'

--- a/client/wildcard/src/components/Form/MultiSelect/DropdownIndicator.tsx
+++ b/client/wildcard/src/components/Form/MultiSelect/DropdownIndicator.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from 'react'
+import { ReactElement } from 'react'
 
 import ChevronDownIcon from 'mdi-react/ChevronDownIcon'
 import { components, DropdownIndicatorProps } from 'react-select'

--- a/client/wildcard/src/components/Form/MultiSelect/MultiSelect.story.tsx
+++ b/client/wildcard/src/components/Form/MultiSelect/MultiSelect.story.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import { useState } from 'react'
 
 import { Meta, Story } from '@storybook/react'
 

--- a/client/wildcard/src/components/Form/MultiSelect/MultiSelect.tsx
+++ b/client/wildcard/src/components/Form/MultiSelect/MultiSelect.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from 'react'
+import { ReactElement } from 'react'
 
 import classNames from 'classnames'
 import Select, { Props as SelectProps, StylesConfig, GroupBase } from 'react-select'

--- a/client/wildcard/src/components/Form/MultiSelect/MultiValueContainer.tsx
+++ b/client/wildcard/src/components/Form/MultiSelect/MultiValueContainer.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from 'react'
+import { ReactElement } from 'react'
 
 import { MultiValueGenericProps } from 'react-select'
 

--- a/client/wildcard/src/components/Form/MultiSelect/MultiValueLabel.tsx
+++ b/client/wildcard/src/components/Form/MultiSelect/MultiValueLabel.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from 'react'
+import { ReactElement } from 'react'
 
 import { MultiValueGenericProps } from 'react-select'
 

--- a/client/wildcard/src/components/Form/MultiSelect/MultiValueRemove.tsx
+++ b/client/wildcard/src/components/Form/MultiSelect/MultiValueRemove.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from 'react'
+import { ReactElement } from 'react'
 
 import CloseIcon from 'mdi-react/CloseIcon'
 import { components, MultiValueRemoveProps } from 'react-select'

--- a/client/wildcard/src/components/Form/Select/Select.test.tsx
+++ b/client/wildcard/src/components/Form/Select/Select.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { render } from '@testing-library/react'
 
 import { Select, SelectProps } from './Select'

--- a/client/wildcard/src/components/Form/TextArea/TextArea.test.tsx
+++ b/client/wildcard/src/components/Form/TextArea/TextArea.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { render } from '@testing-library/react'
 
 import { TextArea } from './TextArea'

--- a/client/wildcard/src/components/Form/TextArea/TextArea.tsx
+++ b/client/wildcard/src/components/Form/TextArea/TextArea.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, ForwardRefExoticComponent, ReactNode, RefAttributes, TextareaHTMLAttributes } from 'react'
+import { forwardRef, ForwardRefExoticComponent, ReactNode, RefAttributes, TextareaHTMLAttributes } from 'react'
 
 import classNames from 'classnames'
 

--- a/client/wildcard/src/components/Form/internal/BaseControlInput.test.tsx
+++ b/client/wildcard/src/components/Form/internal/BaseControlInput.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { render } from '@testing-library/react'
 
 import { BaseControlInput, BASE_CONTROL_TYPES } from './BaseControlInput'

--- a/client/wildcard/src/components/Form/internal/FormFieldLabel.tsx
+++ b/client/wildcard/src/components/Form/internal/FormFieldLabel.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react'
+import { forwardRef } from 'react'
 
 import { ForwardReferenceComponent } from '../../../types'
 import { Label } from '../../Typography/Label'

--- a/client/wildcard/src/components/Grid/Grid.story.tsx
+++ b/client/wildcard/src/components/Grid/Grid.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { Meta, Story } from '@storybook/react'
 
 import { Grid, GridProps } from './Grid'

--- a/client/wildcard/src/components/Icon/Icon.story.tsx
+++ b/client/wildcard/src/components/Icon/Icon.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { Story, Meta } from '@storybook/react'
 
 import { BrandedStory } from '@sourcegraph/branded/src/components/BrandedStory'

--- a/client/wildcard/src/components/Icon/Icon.test.tsx
+++ b/client/wildcard/src/components/Icon/Icon.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { render } from '@testing-library/react'
 
 import { SourcegraphIcon } from '../SourcegraphIcon'

--- a/client/wildcard/src/components/Link/AnchorLink/AnchorLink.test.tsx
+++ b/client/wildcard/src/components/Link/AnchorLink/AnchorLink.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { render } from '@testing-library/react'
 
 import { AnchorLink } from './AnchorLink'

--- a/client/wildcard/src/components/Link/Link/Link.story.tsx
+++ b/client/wildcard/src/components/Link/Link/Link.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { DecoratorFn, Meta, Story } from '@storybook/react'
 
 import { BrandedStory } from '@sourcegraph/branded/src/components/BrandedStory'

--- a/client/wildcard/src/components/Link/RouterLink/RouterLink.test.tsx
+++ b/client/wildcard/src/components/Link/RouterLink/RouterLink.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { render } from '@testing-library/react'
 
 import { renderWithBrandedContext } from '@sourcegraph/shared/src/testing'

--- a/client/wildcard/src/components/LoadingSpinner/LoadingSpinner.story.tsx
+++ b/client/wildcard/src/components/LoadingSpinner/LoadingSpinner.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { boolean } from '@storybook/addon-knobs'
 import { Meta, Story } from '@storybook/react'
 

--- a/client/wildcard/src/components/Menu/Menu.story.tsx
+++ b/client/wildcard/src/components/Menu/Menu.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { Meta, Story } from '@storybook/react'
 import { noop } from 'lodash'
 

--- a/client/wildcard/src/components/Menu/Menu.tsx
+++ b/client/wildcard/src/components/Menu/Menu.tsx
@@ -1,4 +1,4 @@
-import React, { ComponentType, forwardRef, useMemo } from 'react'
+import { ComponentType, forwardRef, useMemo } from 'react'
 
 import { Menu as ReachMenu, MenuProps as ReachMenuProps } from '@reach/menu-button'
 import { isFunction, noop, uniqueId } from 'lodash'

--- a/client/wildcard/src/components/Modal/Modal.story.tsx
+++ b/client/wildcard/src/components/Modal/Modal.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { Meta, Story } from '@storybook/react'
 
 import { BrandedStory } from '@sourcegraph/branded/src/components/BrandedStory'

--- a/client/wildcard/src/components/NavMenu/NavMenu.story.tsx
+++ b/client/wildcard/src/components/NavMenu/NavMenu.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { Meta, Story } from '@storybook/react'
 import { noop } from 'lodash'
 import AntennaIcon from 'mdi-react/AntennaIcon'

--- a/client/wildcard/src/components/NavMenu/NavMenu.test.tsx
+++ b/client/wildcard/src/components/NavMenu/NavMenu.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import sinon from 'sinon'

--- a/client/wildcard/src/components/PageHeader/PageHeader.story.tsx
+++ b/client/wildcard/src/components/PageHeader/PageHeader.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { DecoratorFn, Meta, Story } from '@storybook/react'
 import PlusIcon from 'mdi-react/PlusIcon'
 import PuzzleOutlineIcon from 'mdi-react/PuzzleOutlineIcon'

--- a/client/wildcard/src/components/PageHeader/PageHeader.test.tsx
+++ b/client/wildcard/src/components/PageHeader/PageHeader.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { RenderResult } from '@testing-library/react'
 import PuzzleOutlineIcon from 'mdi-react/PuzzleOutlineIcon'
 

--- a/client/wildcard/src/components/PageSelector/PageSelector.story.tsx
+++ b/client/wildcard/src/components/PageSelector/PageSelector.story.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import { useState } from 'react'
 
 import { number } from '@storybook/addon-knobs'
 import { DecoratorFn, Meta, Story } from '@storybook/react'

--- a/client/wildcard/src/components/PageSelector/PageSelector.test.tsx
+++ b/client/wildcard/src/components/PageSelector/PageSelector.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { render, RenderResult, cleanup, fireEvent } from '@testing-library/react'
 import sinon from 'sinon'
 

--- a/client/wildcard/src/components/Panel/Panel.test.tsx
+++ b/client/wildcard/src/components/Panel/Panel.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { render } from '@testing-library/react'
 
 import { Panel } from './Panel'

--- a/client/wildcard/src/components/Tabs/Tabs.story.tsx
+++ b/client/wildcard/src/components/Tabs/Tabs.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { Meta, Story } from '@storybook/react'
 
 import brandedStyles from '@sourcegraph/branded/src/global-styles/index.scss'

--- a/client/wildcard/src/components/Tabs/Tabs.test.tsx
+++ b/client/wildcard/src/components/Tabs/Tabs.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { render, RenderResult, cleanup, fireEvent } from '@testing-library/react'
 
 import { Tab, TabList, TabPanel, TabPanels, Tabs, TabsProps } from './Tabs'

--- a/client/wildcard/src/components/Tooltip/Tooltip.test.tsx
+++ b/client/wildcard/src/components/Tooltip/Tooltip.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { render, RenderResult, cleanup, fireEvent, waitFor, screen } from '@testing-library/react'
 
 import { Tooltip } from './Tooltip'

--- a/client/wildcard/src/components/Typography/Code/Code.test.tsx
+++ b/client/wildcard/src/components/Typography/Code/Code.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { render } from '@testing-library/react'
 
 import { Code } from './Code'

--- a/client/wildcard/src/components/Typography/Heading/H1.test.tsx
+++ b/client/wildcard/src/components/Typography/Heading/H1.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { render } from '@testing-library/react'
 
 import { H1 } from './H1'

--- a/client/wildcard/src/components/Typography/Heading/H2.test.tsx
+++ b/client/wildcard/src/components/Typography/Heading/H2.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { render } from '@testing-library/react'
 
 import { H2 } from './H2'

--- a/client/wildcard/src/components/Typography/Heading/H3.test.tsx
+++ b/client/wildcard/src/components/Typography/Heading/H3.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { render } from '@testing-library/react'
 
 import { H3 } from './H3'

--- a/client/wildcard/src/components/Typography/Heading/H4.test.tsx
+++ b/client/wildcard/src/components/Typography/Heading/H4.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { render } from '@testing-library/react'
 
 import { H4 } from './H4'

--- a/client/wildcard/src/components/Typography/Heading/H5.test.tsx
+++ b/client/wildcard/src/components/Typography/Heading/H5.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { render } from '@testing-library/react'
 
 import { H5 } from './H5'

--- a/client/wildcard/src/components/Typography/Heading/H6.test.tsx
+++ b/client/wildcard/src/components/Typography/Heading/H6.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { render } from '@testing-library/react'
 
 import { H6 } from './H6'

--- a/client/wildcard/src/components/Typography/Label/Label.test.tsx
+++ b/client/wildcard/src/components/Typography/Label/Label.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { render } from '@testing-library/react'
 
 import { Label } from './Label'

--- a/client/wildcard/src/components/Typography/Text/Text.test.tsx
+++ b/client/wildcard/src/components/Typography/Text/Text.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { render } from '@testing-library/react'
 
 import { Text } from './Text'

--- a/client/wildcard/src/components/Typography/Typography.story.tsx
+++ b/client/wildcard/src/components/Typography/Typography.story.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { select } from '@storybook/addon-knobs'
 import { DecoratorFn, Meta, Story } from '@storybook/react'
 

--- a/client/wildcard/tsconfig.json
+++ b/client/wildcard/tsconfig.json
@@ -6,7 +6,7 @@
     "rootDir": ".",
     "outDir": "./out",
     "baseUrl": "./src",
-    "jsx": "react",
+    "jsx": "react-jsx",
   },
   "references": [
     { "path": "../shared" },


### PR DESCRIPTION
## Description

- Upgrade to the latest version of the JSX transform in all packages with following steps:
  - Update `babel.config.js` to use new `@babel/preset-react` runtime
  - Update all `tsconfig.json` to use `"jsx": "react-jsx"`
  - Execute: `npx react-codemod update-react-imports ./client --parser=tsx`
  - Fix lint/format errors

- Note: React codemod adds `import * as React from 'react'` in files which are using React APIs via `React.*` form, it requires some extra works to convert `React.react_api` to `import { react_api } from 'react'` (already did that for `client/branded` package). it would be great if we have our own codemod to do that transform

## Test plan

Make sure all checks are passed in CI

## Refs

- [SourceGraph Issue](https://github.com/sourcegraph/sourcegraph/issues/33302)
- [GitStart ticket](https://app.gitstart.com/clients/sourcegraph/tickets/SG-33302)

## App preview:

- [Web](https://sg-web-contractors-sg-33302-6.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-bqdqkmcsdm.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
