### PR TITLE
docs update: add BB Cloud Bext support

### DIFF
--- a/doc/integration/bitbucket_cloud.md
+++ b/doc/integration/bitbucket_cloud.md
@@ -6,7 +6,7 @@ Feature | Supported?
 ------- | ----------
 [Repository syncing](../admin/external_service/bitbucket_cloud.md) | ✅
 Repository permissions | Coming soon
-Browser extension | Coming soon
+Browser extension | ✅
 Native extension | ❌ Not supported on Bitbucket.org
 
 ## Repository syncing


### PR DESCRIPTION
pull/25084 adds support for Bitbucket Cloud code host to browser extension as discussed in [slack](https://sourcegraph.slack.com/archives/C01T0BL4EFN/p1650525712737019)



## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

docs update - not required
