### PR TITLE
Search: ensure zoekt client is always non-nil

### DIFF
--- a/cmd/frontend/graphqlbackend/repositories.go
+++ b/cmd/frontend/graphqlbackend/repositories.go
@@ -12,6 +12,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/types"
@@ -130,7 +131,7 @@ func (r *repositoryConnectionResolver) compute(ctx context.Context) ([]*types.Re
 		}
 
 		var indexed *zoekt.RepoList
-		searchIndexEnabled := search.Indexed() != nil
+		searchIndexEnabled := conf.SearchIndexEnabled()
 		isIndexed := func(id api.RepoID) bool {
 			if !searchIndexEnabled {
 				return true // do not need index

--- a/cmd/frontend/graphqlbackend/repository_text_search_index.go
+++ b/cmd/frontend/graphqlbackend/repository_text_search_index.go
@@ -8,12 +8,13 @@ import (
 	"github.com/google/zoekt"
 	zoektquery "github.com/google/zoekt/query"
 
+	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 )
 
 func (r *RepositoryResolver) TextSearchIndex() *repositoryTextSearchIndexResolver {
-	if search.Indexed() == nil {
+	if !conf.SearchIndexEnabled() {
 		return nil
 	}
 

--- a/internal/search/env.go
+++ b/internal/search/env.go
@@ -70,9 +70,11 @@ func IndexedEndpoints() *endpoint.Map {
 	return indexedEndpoints
 }
 
+var ErrIndexDisabled = errors.New("indexed search has been disabled")
+
 func Indexed() zoekt.Streamer {
 	if !conf.SearchIndexEnabled() {
-		return nil
+		return &backend.FakeSearcher{SearchError: ErrIndexDisabled, ListError: ErrIndexDisabled}
 	}
 
 	indexedSearchOnce.Do(func() {

--- a/internal/search/symbol/symbol.go
+++ b/internal/search/symbol/symbol.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/search/job"
 	"github.com/sourcegraph/sourcegraph/internal/search/repos"
@@ -30,10 +31,10 @@ const DefaultSymbolLimit = 100
 // repository at a specific commit. If it has it returns the branch name (for
 // use when querying zoekt). Otherwise an empty string is returned.
 func indexedSymbolsBranch(ctx context.Context, repo *types.MinimalRepo, commit string) string {
-	z := search.Indexed()
-	if z == nil {
+	if !conf.SearchIndexEnabled() {
 		return ""
 	}
+	z := search.Indexed()
 
 	ctx, cancel := context.WithTimeout(ctx, time.Second)
 	defer cancel()

--- a/internal/search/zoekt/indexed_search.go
+++ b/internal/search/zoekt/indexed_search.go
@@ -178,13 +178,6 @@ func PartitionRepos(
 	useIndex query.YesNoOnly,
 	containsRefGlobs bool,
 ) (indexed *IndexedRepoRevs, unindexed []*search.RepositoryRevisions, err error) {
-	if zoektStreamer == nil {
-		if useIndex == query.Only {
-			return nil, nil, errors.Errorf("invalid index:%q (indexed search is not enabled)", useIndex)
-		}
-		return nil, repos, nil
-
-	}
 	// Fallback to Unindexed if the query contains valid ref-globs.
 	if containsRefGlobs {
 		return nil, repos, nil
@@ -244,10 +237,6 @@ func PartitionRepos(
 }
 
 func DoZoektSearchGlobal(ctx context.Context, client zoekt.Streamer, args *search.ZoektParameters, c streaming.Sender) error {
-	if client == nil {
-		return nil
-	}
-
 	k := ResultCountFactor(0, args.FileMatchLimit, true)
 	searchOpts := SearchOpts(ctx, k, args.FileMatchLimit, args.Select)
 

--- a/internal/usagestats/repositories.go
+++ b/internal/usagestats/repositories.go
@@ -6,6 +6,7 @@ import (
 	"github.com/google/zoekt"
 	"github.com/google/zoekt/query"
 
+	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/search"
@@ -49,7 +50,7 @@ func GetRepositories(ctx context.Context, db database.DB) (*Repositories, error)
 		total.GitDirBytes += uint64(stat.GitDirBytes)
 	}
 
-	if search.Indexed() == nil {
+	if !conf.SearchIndexEnabled() {
 		return &total, nil
 	}
 


### PR DESCRIPTION
Currently, we check whether indexed search is enabled by checking whether the Zoekt client is `nil`. This is dangerous because then we're passing around a possibly-nil `zoekt.Streamer`, which will panic when its methods are called. This has bit us in the past.

This modifies `search.Indexed()` to always return a valid client, even if the index is disabled. The returned client will error when used, but will not panic.

In order to change behavior based on whether the index is enabled, `conf.SearchIndexEnabled()` should be used. Everywhere that was previously checking nilness of `search.Indexed()` has been updated to use `conf.SearchIndexEnabled()`.

~~Stacked on  #34292~~

## Test plan

Manually tested that disabling the index does not cause panics for the modified code paths.

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


