### PR TITLE
dev: fix golangci-lint, re-enable depguard, disable nolintlint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,8 +3,7 @@ linters:
   disable-all: true
   enable:
     - bodyclose
-    # Disabled due to flakes: https://github.com/sourcegraph/sourcegraph/issues/33183
-    # - depguard
+    - depguard
     - forbidigo
     - gocritic
     - goimports

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,7 +10,8 @@ linters:
     - gosimple
     - govet
     - ineffassign
-    - nolintlint
+    # this is flakey: https://github.com/sourcegraph/sourcegraph/issues/34304
+    # - nolintlint
     - staticcheck
     - typecheck
     - unconvert

--- a/dev/check/go-lint.sh
+++ b/dev/check/go-lint.sh
@@ -31,27 +31,28 @@ run() {
     # We want to return after running all tests, we don't want to fail fast, so
     # we store the EXIT_CODE (in a tmp file as this is running in a sub-shell).
     echo "$EXIT_CODE" >"$TMPFILE"
-    echo -e "$OUT" > "$base/annotations/go-lint"
+    mkdir -p "$base/annotations"
+    echo -e "$OUT" >"$base/annotations/go-lint"
     echo "^^^ +++"
   fi
 }
-
 
 # Used to ignore directories (for example, when using submodules)
 #   (It appears to be unused, but it's actually used doing -v below)
 #
 # shellcheck disable=SC2034
 declare -A IGNORED_DIRS=(
-    ["./docker-images/syntax-highlighter"]=1
+  ["./docker-images/syntax-highlighter"]=1
+  ["./internal/codeintel/dependencies/internal/lockfiles/testdata/parse"]=1
 )
 
 # If no args are given, traverse through each project with a `go.mod`
 if [ $# -eq 0 ]; then
-  find . -name go.mod -type file -exec dirname '{}' \; | while read -r d; do
+  find . -name go.mod -exec dirname '{}' \; | while read -r d; do
 
     # Skip any ignored directories.
-    if [ -v "IGNORED_DIRS[$d]" ] ; then
-        continue
+    if [ -v "IGNORED_DIRS[$d]" ]; then
+      continue
     fi
 
     pushd "$d" >/dev/null

--- a/dev/golangci-lint.sh
+++ b/dev/golangci-lint.sh
@@ -6,7 +6,7 @@ pushd "$(dirname "${BASH_SOURCE[0]}")/.." >/dev/null
 
 mkdir -p .bin
 
-version="1.44.1"
+version="1.45.2"
 suffix="${version}-$(go env GOOS)-$(go env GOARCH)"
 target="$PWD/.bin/golangci-lint-${suffix}"
 

--- a/enterprise/dev/ci/internal/ci/operations.go
+++ b/enterprise/dev/ci/internal/ci/operations.go
@@ -143,7 +143,6 @@ func addDocs(pipeline *bk.Pipeline) {
 func addCheck(pipeline *bk.Pipeline) {
 	pipeline.AddStep(":clipboard: Misc linters",
 		withYarnCache(),
-		bk.Parallelism(10),
 		bk.AnnotatedCmd("./dev/check/all.sh", bk.AnnotatedCmdOpts{
 			Annotations: &bk.AnnotationOpts{IncludeNames: true},
 		}))

--- a/enterprise/dev/ci/internal/ci/operations.go
+++ b/enterprise/dev/ci/internal/ci/operations.go
@@ -143,6 +143,7 @@ func addDocs(pipeline *bk.Pipeline) {
 func addCheck(pipeline *bk.Pipeline) {
 	pipeline.AddStep(":clipboard: Misc linters",
 		withYarnCache(),
+		bk.Parallelism(10),
 		bk.AnnotatedCmd("./dev/check/all.sh", bk.AnnotatedCmdOpts{
 			Annotations: &bk.AnnotationOpts{IncludeNames: true},
 		}))

--- a/enterprise/internal/insights/resolvers/insight_view_resolvers.go
+++ b/enterprise/internal/insights/resolvers/insight_view_resolvers.go
@@ -463,8 +463,7 @@ func (r *Resolver) UpdateLineChartSearchInsight(ctx context.Context, args *graph
 		return nil, errors.New("No insight view found with this id")
 	}
 
-	var filters types.InsightViewFilters
-	filters = filtersFromInput(&args.Input.ViewControls.Filters)
+	filters := filtersFromInput(&args.Input.ViewControls.Filters)
 
 	view, err := tx.UpdateView(ctx, types.InsightView{
 		UniqueID:         insightViewId,

--- a/internal/codeintel/dependencies/live/init.go
+++ b/internal/codeintel/dependencies/live/init.go
@@ -26,11 +26,7 @@ func GetService(db database.DB, syncer dependencies.Syncer) *dependencies.Servic
 
 // TestService creates a fresh dependencies service with the given database handle and syncer
 // instance. If the given syncer is nil, then ErrorSyncer will be used instead.
-func TestService(db database.DB, syncer dependencies.Syncer) *dependencies.Service {
-	if syncer == nil {
-		syncer = ErrorSyncer
-	}
-
+func TestService(db database.DB, _ dependencies.Syncer) *dependencies.Service {
 	return dependencies.TestService(db, NewGitService(db), &errorSyncer{})
 }
 

--- a/internal/codeintel/dependencies/live/init.go
+++ b/internal/codeintel/dependencies/live/init.go
@@ -26,8 +26,8 @@ func GetService(db database.DB, syncer dependencies.Syncer) *dependencies.Servic
 
 // TestService creates a fresh dependencies service with the given database handle and syncer
 // instance. If the given syncer is nil, then ErrorSyncer will be used instead.
-func TestService(db database.DB, _ dependencies.Syncer) *dependencies.Service {
-	return dependencies.TestService(db, NewGitService(db), &errorSyncer{})
+func TestService(db database.DB, syncer dependencies.Syncer) *dependencies.Service {
+	return dependencies.TestService(db, NewGitService(db), syncer)
 }
 
 // ErrorSyncer should be used from gitserver and repoupdater code/tests.

--- a/internal/extsvc/bitbucketcloud/main_test.go
+++ b/internal/extsvc/bitbucketcloud/main_test.go
@@ -4,8 +4,9 @@ import (
 	"flag"
 	"os"
 	"path/filepath"
-	"regexp"
 	"testing"
+
+	"github.com/grafana/regexp"
 
 	bbtest "github.com/sourcegraph/sourcegraph/internal/extsvc/bitbucketcloud/testing"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"

--- a/internal/extsvc/gerrit/client.go
+++ b/internal/extsvc/gerrit/client.go
@@ -120,6 +120,7 @@ func (c *Client) ListProjects(ctx context.Context, opts ListProjectsArgs) (proje
 	return &respCodeProjects, nextPage, nil
 }
 
+// nolint:unparam
 func (c *Client) do(ctx context.Context, req *http.Request, result interface{}) (*http.Response, error) {
 	req.URL = c.URL.ResolveReference(req.URL)
 

--- a/internal/gitserver/client.go
+++ b/internal/gitserver/client.go
@@ -35,6 +35,7 @@ import (
 
 	"github.com/sourcegraph/go-diff/diff"
 	"github.com/sourcegraph/go-rendezvous"
+
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
@@ -1004,7 +1005,7 @@ func (l *LocalGitCommand) DividedOutput(ctx context.Context) ([]byte, []byte, er
 		// Do not strip out existing env when setting.
 		cmd.Env = os.Environ()
 	}
-	cmd.Env = append(cmd.Env, "GIT_DIR="+string(path))
+	cmd.Env = append(cmd.Env, "GIT_DIR="+path)
 
 	err := cmd.Run()
 	exitStatus := -10810

--- a/internal/gitserver/protocol/util.go
+++ b/internal/gitserver/protocol/util.go
@@ -3,7 +3,6 @@ package protocol
 import (
 	"path"
 	"strings"
-	"unicode/utf8"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
 )
@@ -44,16 +43,4 @@ func NormalizeRepo(input api.RepoName) api.RepoName {
 	}
 
 	return api.RepoName(host + repoPath)
-}
-
-// hasUpperASCII returns true if s contains any upper-case letters in ASCII,
-// or if it contains any non-ascii characters.
-func hasUpperASCII(s string) bool {
-	for i := 0; i < len(s); i++ {
-		c := s[i]
-		if c >= utf8.RuneSelf || (c >= 'A' && c <= 'Z') {
-			return true
-		}
-	}
-	return false
 }

--- a/internal/luasandbox/util/util.go
+++ b/internal/luasandbox/util/util.go
@@ -197,13 +197,13 @@ func assertLuaString(value lua.LValue) (string, error) {
 
 // assertLuaNumber returns the given value as a number or an error if the value is
 // of a different type.
-func assertLuaNumber(value lua.LValue) (float64, error) {
-	if value.Type() != lua.LTNumber {
-		return 0, NewTypeError("number", value)
-	}
+// func assertLuaNumber(value lua.LValue) (float64, error) {
+// 	if value.Type() != lua.LTNumber {
+// 		return 0, NewTypeError("number", value)
+// 	}
 
-	return float64(lua.LVAsNumber(value)), nil
-}
+// 	return float64(lua.LVAsNumber(value)), nil
+// }
 
 // assertLuaFunction returns the given value as a function or an error if the value is
 // of a different type.

--- a/internal/luasandbox/util/util.go
+++ b/internal/luasandbox/util/util.go
@@ -195,16 +195,6 @@ func assertLuaString(value lua.LValue) (string, error) {
 	return lua.LVAsString(value), nil
 }
 
-// assertLuaNumber returns the given value as a number or an error if the value is
-// of a different type.
-// func assertLuaNumber(value lua.LValue) (float64, error) {
-// 	if value.Type() != lua.LTNumber {
-// 		return 0, NewTypeError("number", value)
-// 	}
-
-// 	return float64(lua.LVAsNumber(value)), nil
-// }
-
 // assertLuaFunction returns the given value as a function or an error if the value is
 // of a different type.
 func assertLuaFunction(value lua.LValue) (*lua.LFunction, error) {

--- a/internal/search/query/types.go
+++ b/internal/search/query/types.go
@@ -441,11 +441,3 @@ func (q Q) MaxResults(defaultLimit int) int {
 
 	return limits.DefaultMaxSearchResults
 }
-
-func parseRegexpOrPanic(field, value string) *regexp.Regexp {
-	r, err := regexp.Compile(value)
-	if err != nil {
-		panic(fmt.Sprintf("Value %s for field %s invalid regex: %s", field, value, err.Error()))
-	}
-	return r
-}

--- a/internal/security/security.go
+++ b/internal/security/security.go
@@ -3,13 +3,13 @@
 package security
 
 import (
-	"errors"
 	"fmt"
 	"unicode"
 	"unicode/utf8"
 
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 // maxPasswordRunes is the maximum number of UTF-8 runes that a password can contain.


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/33183

It also looks like `golangci-lint` has been broken since https://github.com/sourcegraph/sourcegraph/commit/9a4db1085bbf1b86c411975ac87ca3cbc93b2f06 , see https://sourcegraph.slack.com/archives/C01N83PS4TU/p1650565761169409

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


6642350e1974355a2da15ee980b7a371014818ad
