### PR TITLE
migrator: fix default entrypoint behaviour

### DIFF
--- a/cmd/migrator/main.go
+++ b/cmd/migrator/main.go
@@ -28,8 +28,8 @@ var out = output.NewOutput(os.Stdout, output.OutputOpts{
 })
 
 func main() {
-	args := os.Args[1:]
-	if len(args) == 0 {
+	args := os.Args[:]
+	if len(args) == 1 {
 		args = append(args, "up")
 	}
 
@@ -54,7 +54,7 @@ func mainErr(ctx context.Context, args []string) error {
 		},
 	}
 
-	return command.RunContext(ctx, os.Args)
+	return command.RunContext(ctx, args)
 }
 
 func newRunnerFactory() func(ctx context.Context, schemaNames []string) (cliutil.Runner, error) {


### PR DESCRIPTION
I broke this in https://github.com/sourcegraph/sourcegraph/pull/33758 by not correctly using the modified `args []string` provided 😞  See: https://github.com/sourcegraph/customer/issues/845

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->
Before:

```
➜  sourcegraph git:(main) go run ./cmd/migrator
NAME:
   migrator - Validates and runs schema migrations

USAGE:
   migrator command [command options] [arguments...]

COMMANDS:
   up        Apply all migrations
   upto      Ensure a given migration has been applied - may apply dependency migrations
   downto    Revert any applied migrations that are children of the given targets - this effectively "resets" the schmea to the target version
   validate  Validate the current schema
   add-log   Add an entry to the migration log
   help, h   Shows a list of commands or help for one command

OPTIONS:
   --help, -h  show help (default: false)
```

After:

```
➜  sourcegraph git:(fix-migrator-default-cmd) go run ./cmd/migrator                                      
error: databases frontend and codeintel must be distinct, but both target postgres://127.0.0.1:5432
exit status 1
```