### PR TITLE
insights: make insight "start" times consistent between generation methods 

### DIFF
--- a/enterprise/internal/insights/background/historical_enqueuer.go
+++ b/enterprise/internal/insights/background/historical_enqueuer.go
@@ -389,10 +389,14 @@ func (h *historicalEnqueuer) buildForRepo(ctx context.Context, uniqueSeries map[
 		// For every series that we want to potentially gather historical data for, try.
 		for _, seriesID := range sortedSeriesIDs {
 			series := uniqueSeries[seriesID]
+			truncateDuration := time.Hour * 24
+			if series.SampleIntervalUnit == string(itypes.Hour) {
+				truncateDuration = time.Hour
+			}
 			frames := query.BuildFrames(12, timeseries.TimeInterval{
 				Unit:  itypes.IntervalUnit(series.SampleIntervalUnit),
 				Value: series.SampleIntervalValue,
-			}, series.CreatedAt.Truncate(time.Hour*24))
+			}, series.CreatedAt.Truncate(truncateDuration))
 
 			log15.Debug("insights: starting frames", "repo_id", id, "series_id", series.SeriesID, "frames", frames)
 			plan := h.frameFilter.FilterFrames(ctx, frames, id)

--- a/enterprise/internal/insights/query/capture_group_executor.go
+++ b/enterprise/internal/insights/query/capture_group_executor.go
@@ -46,7 +46,7 @@ func (c *CaptureGroupExecutor) Execute(ctx context.Context, query string, reposi
 	}
 	log15.Debug("Generated repoIds", "repoids", repoIds)
 
-	frames := BuildFrames(7, interval, c.clock())
+	frames := BuildFrames(7, interval, c.clock().Truncate(time.Hour*24))
 	pivoted := make(map[string]timeCounts)
 
 	for _, repository := range repositories {

--- a/enterprise/internal/insights/query/capture_group_executor.go
+++ b/enterprise/internal/insights/query/capture_group_executor.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/compression"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/timeseries"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/types"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/database"
@@ -46,7 +47,12 @@ func (c *CaptureGroupExecutor) Execute(ctx context.Context, query string, reposi
 	}
 	log15.Debug("Generated repoIds", "repoids", repoIds)
 
-	frames := BuildFrames(7, interval, c.clock().Truncate(time.Hour*24))
+	truncateDuration := time.Hour * 24
+	if interval.Unit == types.Hour {
+		truncateDuration = time.Hour
+	}
+
+	frames := BuildFrames(7, interval, c.clock().Truncate(truncateDuration))
 	pivoted := make(map[string]timeCounts)
 
 	for _, repository := range repositories {

--- a/enterprise/internal/insights/query/streaming_query_executor.go
+++ b/enterprise/internal/insights/query/streaming_query_executor.go
@@ -12,6 +12,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/compression"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/query/streaming"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/timeseries"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/types"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/database"
@@ -46,7 +47,12 @@ func (c *StreamingQueryExecutor) Execute(ctx context.Context, query string, seri
 	}
 	log15.Debug("Generated repoIds", "repoids", repoIds)
 
-	frames := BuildFrames(7, interval, c.clock().Truncate(time.Hour*24))
+	truncateDuration := time.Hour * 24
+	if interval.Unit == types.Hour {
+		truncateDuration = time.Hour
+	}
+
+	frames := BuildFrames(7, interval, c.clock().Truncate(truncateDuration))
 	points := timeCounts{}
 	timeseries := []TimeDataPoint{}
 


### PR DESCRIPTION
Updates the time truncation for the most recent data point for just in time insights and the backfill process as follows:

- If the insight is calculated `Hourly`, start calculating from the start of the current hour
- If the insight is `Not Hourly`, start calculating from the start of the day (UTC) 

resolves #34301
## Test plan

<details>
  <summary>Just In Time Insights</summary>

Response for `not hourly` - datetime on each point is start of day, most recent is start of current day `"2022-04-25T00:00:00Z"`

```graphql
{
  "data": {
    "insightViews": {
      "nodes": [
        {
          "id": "aW5zaWdodF92aWV3OiIyODRpVkFqQ29LNFFpN1luYXdtdllEbUlpQ0Yi",
          "dataSeriesDefinitions": [
            {
              "generatedFromCaptureGroups": false,
              "timeScope": {
                "unit": "DAY",
                "value": 1
              }
            }
          ],
          "dataSeries": [
            {
              "seriesId": "284iVCCaPPd11kY5iIZQP0B4Xya",
              "label": "TODOs",
              "points": [
                {
                  "dateTime": "2022-04-19T00:00:00Z",
                  "value": 849,
                  "__typename": "InsightDataPoint"
                },
                {
                  "dateTime": "2022-04-20T00:00:00Z",
                  "value": 845,
                  "__typename": "InsightDataPoint"
                },
                {
                  "dateTime": "2022-04-21T00:00:00Z",
                  "value": 842,
                  "__typename": "InsightDataPoint"
                },
                {
                  "dateTime": "2022-04-22T00:00:00Z",
                  "value": 849,
                  "__typename": "InsightDataPoint"
                },
                {
                  "dateTime": "2022-04-23T00:00:00Z",
                  "value": 857,
                  "__typename": "InsightDataPoint"
                },
                {
                  "dateTime": "2022-04-24T00:00:00Z",
                  "value": 857,
                  "__typename": "InsightDataPoint"
                },
                {
                  "dateTime": "2022-04-25T00:00:00Z",
                  "value": 857,
                  "__typename": "InsightDataPoint"
                }
              ],
              "__typename": "InsightsSeries"
            }
          ],
          "__typename": "InsightView"
        }
      ],
      "__typename": "InsightViewConnection"
    }
  }
}
```

Response for `hourly` - datetime on each point is start of hour, most recent is start of current hour `"2022-04-25T13:00:00Z"`
```graphql
{
  "data": {
    "insightViews": {
      "nodes": [
        {
          "id": "aW5zaWdodF92aWV3OiIyODRpVkFqQ29LNFFpN1luYXdtdllEbUlpQ0Yi",
          "dataSeriesDefinitions": [
            {
              "generatedFromCaptureGroups": false,
              "timeScope": {
                "unit": "HOUR",
                "value": 1
              }
            }
          ],
          "dataSeries": [
            {
              "seriesId": "284iVCCaPPd11kY5iIZQP0B4Xya",
              "label": "TODOs",
              "points": [
                {
                  "dateTime": "2022-04-25T07:00:00Z",
                  "value": 857,
                  "__typename": "InsightDataPoint"
                },
                {
                  "dateTime": "2022-04-25T08:00:00Z",
                  "value": 857,
                  "__typename": "InsightDataPoint"
                },
                {
                  "dateTime": "2022-04-25T09:00:00Z",
                  "value": 857,
                  "__typename": "InsightDataPoint"
                },
                {
                  "dateTime": "2022-04-25T10:00:00Z",
                  "value": 857,
                  "__typename": "InsightDataPoint"
                },
                {
                  "dateTime": "2022-04-25T11:00:00Z",
                  "value": 857,
                  "__typename": "InsightDataPoint"
                },
                {
                  "dateTime": "2022-04-25T12:00:00Z",
                  "value": 857,
                  "__typename": "InsightDataPoint"
                },
                {
                  "dateTime": "2022-04-25T13:00:00Z",
                  "value": 857,
                  "__typename": "InsightDataPoint"
                }
              ],
              "__typename": "InsightsSeries"
            }
          ],
          "__typename": "InsightView"
        }
      ],
      "__typename": "InsightViewConnection"
    }
  }
}
```
</details>

<details>
  <summary>Just In Time Capture Group</summary>

Response for `Hourly` - most recent is start of current hour `"2022-04-25T13:00:00Z"`

```graphql
{
  "data": {
    "insightViews": {
      "nodes": [
        {
          "id": "aW5zaWdodF92aWV3OiIyODdSWlZScVlxWFp5QjhSZGRmaWNveHNxSUUi",
          "dataSeriesDefinitions": [
            {
              "generatedFromCaptureGroups": true,
              "timeScope": {
                "unit": "HOUR",
                "value": 2
              }
            }
          ],
          "dataSeries": [
            {
              "seriesId": "dynamic-series-1",
              "label": "ISC",
              "points": [
                {
                  "dateTime": "2022-04-25T01:00:00Z",
                  "value": 1,
                  "__typename": "InsightDataPoint"
                },
                {
                  "dateTime": "2022-04-25T03:00:00Z",
                  "value": 1,
                  "__typename": "InsightDataPoint"
                },
                {
                  "dateTime": "2022-04-25T05:00:00Z",
                  "value": 1,
                  "__typename": "InsightDataPoint"
                },
                {
                  "dateTime": "2022-04-25T07:00:00Z",
                  "value": 1,
                  "__typename": "InsightDataPoint"
                },
                {
                  "dateTime": "2022-04-25T09:00:00Z",
                  "value": 1,
                  "__typename": "InsightDataPoint"
                },
                {
                  "dateTime": "2022-04-25T11:00:00Z",
                  "value": 1,
                  "__typename": "InsightDataPoint"
                },
                {
                  "dateTime": "2022-04-25T13:00:00Z",
                  "value": 1,
                  "__typename": "InsightDataPoint"
                }
              ],
              "__typename": "InsightsSeries"
            },
            {
              "seriesId": "dynamic-series-2",
              "label": "Apache-2.0",
              "points": [
                {
                  "dateTime": "2022-04-25T01:00:00Z",
                  "value": 22,
                  "__typename": "InsightDataPoint"
                },
                {
                  "dateTime": "2022-04-25T03:00:00Z",
                  "value": 22,
                  "__typename": "InsightDataPoint"
                },
                {
                  "dateTime": "2022-04-25T05:00:00Z",
                  "value": 22,
                  "__typename": "InsightDataPoint"
                },
                {
                  "dateTime": "2022-04-25T07:00:00Z",
                  "value": 22,
                  "__typename": "InsightDataPoint"
                },
                {
                  "dateTime": "2022-04-25T09:00:00Z",
                  "value": 22,
                  "__typename": "InsightDataPoint"
                },
                {
                  "dateTime": "2022-04-25T11:00:00Z",
                  "value": 22,
                  "__typename": "InsightDataPoint"
                },
                {
                  "dateTime": "2022-04-25T13:00:00Z",
                  "value": 22,
                  "__typename": "InsightDataPoint"
                }
              ],
              "__typename": "InsightsSeries"
            }
          ],
          "__typename": "InsightView"
        }
      ],
      "__typename": "InsightViewConnection"
    }
  }
}
```

Response for `Not Hourly` - most recent is start of current day `"2022-04-25T00:00:00Z"`

```graphql
{
  "data": {
    "insightViews": {
      "nodes": [
        {
          "id": "aW5zaWdodF92aWV3OiIyODdSWlZScVlxWFp5QjhSZGRmaWNveHNxSUUi",
          "dataSeriesDefinitions": [
            {
              "generatedFromCaptureGroups": true,
              "timeScope": {
                "unit": "MONTH",
                "value": 1
              }
            }
          ],
          "dataSeries": [
            {
              "seriesId": "dynamic-series-1",
              "label": "Apache-2.0",
              "points": [
                {
                  "dateTime": "2021-10-25T00:00:00Z",
                  "value": 11,
                  "__typename": "InsightDataPoint"
                },
                {
                  "dateTime": "2021-11-25T00:00:00Z",
                  "value": 12,
                  "__typename": "InsightDataPoint"
                },
                {
                  "dateTime": "2021-12-25T00:00:00Z",
                  "value": 13,
                  "__typename": "InsightDataPoint"
                },
                {
                  "dateTime": "2022-01-25T00:00:00Z",
                  "value": 20,
                  "__typename": "InsightDataPoint"
                },
                {
                  "dateTime": "2022-02-25T00:00:00Z",
                  "value": 21,
                  "__typename": "InsightDataPoint"
                },
                {
                  "dateTime": "2022-03-25T00:00:00Z",
                  "value": 22,
                  "__typename": "InsightDataPoint"
                },
                {
                  "dateTime": "2022-04-25T00:00:00Z",
                  "value": 22,
                  "__typename": "InsightDataPoint"
                }
              ],
              "__typename": "InsightsSeries"
            },
            {
              "seriesId": "dynamic-series-2",
              "label": "ISC",
              "points": [
                {
                  "dateTime": "2021-10-25T00:00:00Z",
                  "value": 0,
                  "__typename": "InsightDataPoint"
                },
                {
                  "dateTime": "2021-11-25T00:00:00Z",
                  "value": 0,
                  "__typename": "InsightDataPoint"
                },
                {
                  "dateTime": "2021-12-25T00:00:00Z",
                  "value": 0,
                  "__typename": "InsightDataPoint"
                },
                {
                  "dateTime": "2022-01-25T00:00:00Z",
                  "value": 0,
                  "__typename": "InsightDataPoint"
                },
                {
                  "dateTime": "2022-02-25T00:00:00Z",
                  "value": 1,
                  "__typename": "InsightDataPoint"
                },
                {
                  "dateTime": "2022-03-25T00:00:00Z",
                  "value": 1,
                  "__typename": "InsightDataPoint"
                },
                {
                  "dateTime": "2022-04-25T00:00:00Z",
                  "value": 1,
                  "__typename": "InsightDataPoint"
                }
              ],
              "__typename": "InsightsSeries"
            }
          ],
          "__typename": "InsightView"
        }
      ],
      "__typename": "InsightViewConnection"
    }
  }
}
```
</details>

<details>
  <summary>Backfilled Insights</summary>

Response for `not hourly` - datetime on each point is start of day, most recent is start of current day `"2022-04-25T00:00:00Z"`

```graphql
{
  "data": {
    "insightViews": {
      "nodes": [
        {
          "id": "aW5zaWdodF92aWV3OiIyOElHM1hTNjdoczJ5Zkt6Mml2cjNsR1ltZjQi",
          "dataSeriesDefinitions": [
            {
              "generatedFromCaptureGroups": false,
              "timeScope": {
                "unit": "WEEK",
                "value": 1
              }
            }
          ],
          "dataSeries": [
            {
              "seriesId": "28IG3XU13xokDPt1ibJkPoSqfuj",
              "label": "FIXME",
              "points": [
                {
                  "dateTime": "2022-04-25T00:00:00Z",
                  "value": 8019,
                  "__typename": "InsightDataPoint"
                },
                {
                  "dateTime": "2022-04-18T00:00:00Z",
                  "value": 8019,
                  "__typename": "InsightDataPoint"
                },
                {
                  "dateTime": "2022-04-11T00:00:00Z",
                  "value": 8019,
                  "__typename": "InsightDataPoint"
                },
                {
                  "dateTime": "2022-04-04T00:00:00Z",
                  "value": 8019,
                  "__typename": "InsightDataPoint"
                },
                {
                  "dateTime": "2022-03-28T00:00:00Z",
                  "value": 8019,
                  "__typename": "InsightDataPoint"
                },
                {
                  "dateTime": "2022-03-21T00:00:00Z",
                  "value": 8019,
                  "__typename": "InsightDataPoint"
                },
                {
                  "dateTime": "2022-03-14T00:00:00Z",
                  "value": 8018,
                  "__typename": "InsightDataPoint"
                },
                {
                  "dateTime": "2022-03-07T00:00:00Z",
                  "value": 8018,
                  "__typename": "InsightDataPoint"
                },
                {
                  "dateTime": "2022-02-28T00:00:00Z",
                  "value": 8017,
                  "__typename": "InsightDataPoint"
                },
                {
                  "dateTime": "2022-02-21T00:00:00Z",
                  "value": 8017,
                  "__typename": "InsightDataPoint"
                },
                {
                  "dateTime": "2022-02-14T00:00:00Z",
                  "value": 8017,
                  "__typename": "InsightDataPoint"
                },
                {
                  "dateTime": "2022-02-07T00:00:00Z",
                  "value": 8017,
                  "__typename": "InsightDataPoint"
                }
              ],
              "__typename": "InsightsSeries"
            }
          ],
          "__typename": "InsightView"
        }
      ],
      "__typename": "InsightViewConnection"
    }
  }
}
```

Response for `hourly` - datetime on each point is start of hour, most recent is start of current hour `"2022-04-25T14:00:00Z"`

```graphql
{
  "data": {
    "insightViews": {
      "nodes": [
        {
          "id": "aW5zaWdodF92aWV3OiIyOElEd211ZTNlaHNZQ3Y0ZzNncjVtTXlWUFMi",
          "dataSeriesDefinitions": [
            {
              "generatedFromCaptureGroups": true,
              "timeScope": {
                "unit": "HOUR",
                "value": 1
              }
            }
          ],
          "dataSeries": [            
            {
              "seriesId": "28IDwnmv7hATUWdg3I57YkBLZmu-3.12",
              "label": "3.12",
              "points": [
                {
                  "dateTime": "2022-04-25T03:00:00Z",
                  "value": 6,
                  "__typename": "InsightDataPoint"
                },
                {
                  "dateTime": "2022-04-25T04:00:00Z",
                  "value": 6,
                  "__typename": "InsightDataPoint"
                },
                {
                  "dateTime": "2022-04-25T05:00:00Z",
                  "value": 6,
                  "__typename": "InsightDataPoint"
                },
                {
                  "dateTime": "2022-04-25T06:00:00Z",
                  "value": 6,
                  "__typename": "InsightDataPoint"
                },
                {
                  "dateTime": "2022-04-25T07:00:00Z",
                  "value": 6,
                  "__typename": "InsightDataPoint"
                },
                {
                  "dateTime": "2022-04-25T08:00:00Z",
                  "value": 6,
                  "__typename": "InsightDataPoint"
                },
                {
                  "dateTime": "2022-04-25T09:00:00Z",
                  "value": 6,
                  "__typename": "InsightDataPoint"
                },
                {
                  "dateTime": "2022-04-25T10:00:00Z",
                  "value": 6,
                  "__typename": "InsightDataPoint"
                },
                {
                  "dateTime": "2022-04-25T11:00:00Z",
                  "value": 6,
                  "__typename": "InsightDataPoint"
                },
                {
                  "dateTime": "2022-04-25T12:00:00Z",
                  "value": 6,
                  "__typename": "InsightDataPoint"
                },
                {
                  "dateTime": "2022-04-25T13:00:00Z",
                  "value": 6,
                  "__typename": "InsightDataPoint"
                },
                {
                  "dateTime": "2022-04-25T14:00:00Z",
                  "value": 6,
                  "__typename": "InsightDataPoint"
                }
              ],
              "__typename": "InsightsSeries"
            },            
            {
              "seriesId": "28IDwnmv7hATUWdg3I57YkBLZmu-3.15",
              "label": "3.15",
              "points": [
                {
                  "dateTime": "2022-04-25T03:00:00Z",
                  "value": 3,
                  "__typename": "InsightDataPoint"
                },
                {
                  "dateTime": "2022-04-25T04:00:00Z",
                  "value": 3,
                  "__typename": "InsightDataPoint"
                },
                {
                  "dateTime": "2022-04-25T05:00:00Z",
                  "value": 3,
                  "__typename": "InsightDataPoint"
                },
                {
                  "dateTime": "2022-04-25T06:00:00Z",
                  "value": 3,
                  "__typename": "InsightDataPoint"
                },
                {
                  "dateTime": "2022-04-25T07:00:00Z",
                  "value": 3,
                  "__typename": "InsightDataPoint"
                },
                {
                  "dateTime": "2022-04-25T08:00:00Z",
                  "value": 3,
                  "__typename": "InsightDataPoint"
                },
                {
                  "dateTime": "2022-04-25T09:00:00Z",
                  "value": 3,
                  "__typename": "InsightDataPoint"
                },
                {
                  "dateTime": "2022-04-25T10:00:00Z",
                  "value": 3,
                  "__typename": "InsightDataPoint"
                },
                {
                  "dateTime": "2022-04-25T11:00:00Z",
                  "value": 3,
                  "__typename": "InsightDataPoint"
                },
                {
                  "dateTime": "2022-04-25T12:00:00Z",
                  "value": 3,
                  "__typename": "InsightDataPoint"
                },
                {
                  "dateTime": "2022-04-25T13:00:00Z",
                  "value": 3,
                  "__typename": "InsightDataPoint"
                },
                {
                  "dateTime": "2022-04-25T14:00:00Z",
                  "value": 3,
                  "__typename": "InsightDataPoint"
                }
              ],
              "__typename": "InsightsSeries"
            },
            {
              "seriesId": "28IDwnmv7hATUWdg3I57YkBLZmu-3.15.0",
              "label": "3.15.0",
              "points": [
                {
                  "dateTime": "2022-04-25T03:00:00Z",
                  "value": 1,
                  "__typename": "InsightDataPoint"
                },
                {
                  "dateTime": "2022-04-25T04:00:00Z",
                  "value": 1,
                  "__typename": "InsightDataPoint"
                },
                {
                  "dateTime": "2022-04-25T05:00:00Z",
                  "value": 1,
                  "__typename": "InsightDataPoint"
                },
                {
                  "dateTime": "2022-04-25T06:00:00Z",
                  "value": 1,
                  "__typename": "InsightDataPoint"
                },
                {
                  "dateTime": "2022-04-25T07:00:00Z",
                  "value": 1,
                  "__typename": "InsightDataPoint"
                },
                {
                  "dateTime": "2022-04-25T08:00:00Z",
                  "value": 1,
                  "__typename": "InsightDataPoint"
                },
                {
                  "dateTime": "2022-04-25T09:00:00Z",
                  "value": 1,
                  "__typename": "InsightDataPoint"
                },
                {
                  "dateTime": "2022-04-25T10:00:00Z",
                  "value": 1,
                  "__typename": "InsightDataPoint"
                },
                {
                  "dateTime": "2022-04-25T11:00:00Z",
                  "value": 1,
                  "__typename": "InsightDataPoint"
                },
                {
                  "dateTime": "2022-04-25T12:00:00Z",
                  "value": 1,
                  "__typename": "InsightDataPoint"
                },
                {
                  "dateTime": "2022-04-25T13:00:00Z",
                  "value": 1,
                  "__typename": "InsightDataPoint"
                },
                {
                  "dateTime": "2022-04-25T14:00:00Z",
                  "value": 1,
                  "__typename": "InsightDataPoint"
                }
              ],
              "__typename": "InsightsSeries"
            }
          ],
          "__typename": "InsightView"
        }
      ],
      "__typename": "InsightViewConnection"
    }
  }
}
```

</details>
<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


