### PR TITLE
monitoring: add pg connection usage

### DIFF
--- a/doc/admin/observability/alert_solutions.md
+++ b/doc/admin/observability/alert_solutions.md
@@ -1637,6 +1637,32 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 <br />
 
+## postgres: usage_connections_percentage
+
+<p class="subtitle">connection in use</p>
+
+**Descriptions**
+
+- <span class="badge badge-warning">warning</span> postgres: 80%+ connection in use for 5m0s
+- <span class="badge badge-critical">critical</span> postgres: 100%+ connection in use for 5m0s
+
+**Possible solutions**
+
+- Consider increasing [max_connections](https://www.postgresql.org/docs/current/runtime-config-connection.html#GUC-MAX-CONNECTIONS) of the database instance, [learn more](https://docs.sourcegraph.com/admin/config/postgres-conf)
+- Learn more about the related dashboard panel in the [dashboards reference](./dashboards.md#postgres-usage-connections-percentage).
+- **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
+
+```json
+"observability.silenceAlerts": [
+  "warning_postgres_usage_connections_percentage",
+  "critical_postgres_usage_connections_percentage"
+]
+```
+
+<sub>*Managed by the [Sourcegraph Devops team](https://handbook.sourcegraph.com/engineering/cloud/devops).*</sub>
+
+<br />
+
 ## postgres: transaction_durations
 
 <p class="subtitle">maximum transaction durations</p>

--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -5881,13 +5881,32 @@ Query: `sum by (job) (pg_stat_activity_count{datname!~"template.*|postgres|cloud
 
 <br />
 
+#### postgres: usage_connections_percentage
+
+<p class="subtitle">Connection in use</p>
+
+Refer to the [alert solutions reference](./alert_solutions.md#postgres-usage-connections-percentage) for 2 alerts related to this panel.
+
+To see this panel, visit `/-/debug/grafana/d/postgres/postgres?viewPanel=100001` on your Sourcegraph instance.
+
+<sub>*Managed by the [Sourcegraph Devops team](https://handbook.sourcegraph.com/engineering/cloud/devops).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Query: `sum(pg_stat_activity_count) by (job) / (sum(pg_settings_max_connections) by (job) - sum(pg_settings_superuser_reserved_connections) by (job))`
+
+</details>
+
+<br />
+
 #### postgres: transaction_durations
 
 <p class="subtitle">Maximum transaction durations</p>
 
 Refer to the [alert solutions reference](./alert_solutions.md#postgres-transaction-durations) for 2 alerts related to this panel.
 
-To see this panel, visit `/-/debug/grafana/d/postgres/postgres?viewPanel=100001` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/postgres/postgres?viewPanel=100002` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Devops team](https://handbook.sourcegraph.com/engineering/cloud/devops).*</sub>
 

--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -5894,7 +5894,7 @@ To see this panel, visit `/-/debug/grafana/d/postgres/postgres?viewPanel=100001`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(pg_stat_activity_count) by (job) / (sum(pg_settings_max_connections) by (job) - sum(pg_settings_superuser_reserved_connections) by (job))`
+Query: `sum(pg_stat_activity_count) by (job) / (sum(pg_settings_max_connections) by (job) - sum(pg_settings_superuser_reserved_connections) by (job)) * 100`
 
 </details>
 

--- a/monitoring/definitions/postgres.go
+++ b/monitoring/definitions/postgres.go
@@ -39,7 +39,7 @@ func Postgres() *monitoring.Container {
 						Description:   "connection in use",
 						Owner:         monitoring.ObservableOwnerDevOps,
 						DataMustExist: false,
-						Query:         `sum(pg_stat_activity_count) by (job) / (sum(pg_settings_max_connections) by (job) - sum(pg_settings_superuser_reserved_connections) by (job))`,
+						Query:         `sum(pg_stat_activity_count) by (job) / (sum(pg_settings_max_connections) by (job) - sum(pg_settings_superuser_reserved_connections) by (job)) * 100`,
 						Panel:         monitoring.Panel().LegendFormat("{{job}}").Unit(monitoring.Percentage).Max(100).Min(0),
 						Warning:       monitoring.Alert().GreaterOrEqual(80).For(5 * time.Minute),
 						Critical:      monitoring.Alert().GreaterOrEqual(100).For(5 * time.Minute),

--- a/monitoring/definitions/postgres.go
+++ b/monitoring/definitions/postgres.go
@@ -35,6 +35,19 @@ func Postgres() *monitoring.Container {
 						PossibleSolutions: "none",
 					},
 					monitoring.Observable{
+						Name:          "usage_connections_percentage",
+						Description:   "connection in use",
+						Owner:         monitoring.ObservableOwnerDevOps,
+						DataMustExist: false,
+						Query:         `sum(pg_stat_activity_count) by (job) / (sum(pg_settings_max_connections) by (job) - sum(pg_settings_superuser_reserved_connections) by (job))`,
+						Panel:         monitoring.Panel().LegendFormat("{{job}}").Unit(monitoring.Percentage).Max(100).Min(0),
+						Warning:       monitoring.Alert().GreaterOrEqual(80).For(5 * time.Minute),
+						Critical:      monitoring.Alert().GreaterOrEqual(100).For(5 * time.Minute),
+						PossibleSolutions: `
+							- Consider increasing [max_connections](https://www.postgresql.org/docs/current/runtime-config-connection.html#GUC-MAX-CONNECTIONS) of the database instance, [learn more](https://docs.sourcegraph.com/admin/config/postgres-conf)
+						`,
+					},
+					monitoring.Observable{
 						Name:              "transaction_durations",
 						Description:       "maximum transaction durations",
 						Owner:             monitoring.ObservableOwnerDevOps,


### PR DESCRIPTION
We have no alerting when all connections are used. This PR added a new panel to show percentage of in use connection and added two alerts

- warning: 0.8 (high usage)
- critical: 1.0 (no new connection can be created)

related: https://sourcegraph.slack.com/archives/C02KX975BDG/p1650554603472829 (I scale up the number of worker replica and used up all connections, and other services are struggling to make new connection with postgres)

ideally we will use stuff like pgbouncer in production, but I figure some on-prem customers still use the bundle database and this would be useful

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

```sh
sg run redis-postgres
```

Open a new tab

```sh
sg start monitoring   
```

Go to http://localhost:3370/-/debug/grafana/d/postgres/postgres?orgId=1

you should see

![CleanShot 2022-04-21 at 14 35 42](https://user-images.githubusercontent.com/8373004/164556361-48749336-7b5a-4453-90b1-36a99d886a78.png)
