### PR TITLE
fix: unverified primary emails break Emails and Users page 

### DIFF
--- a/client/web/src/user/settings/emails/UserSettingsEmailsPage.tsx
+++ b/client/web/src/user/settings/emails/UserSettingsEmailsPage.tsx
@@ -73,10 +73,6 @@ export const UserSettingsEmailsPage: FunctionComponent<Props> = ({ user }) => {
         return <LoadingSpinner />
     }
 
-    if (isErrorLike(statusOrError)) {
-        return <ErrorAlert className="mt-2" error={statusOrError} />
-    }
-
     return (
         <div className={styles.userSettingsEmailsPage}>
             <PageTitle title="Emails" />
@@ -89,6 +85,7 @@ export const UserSettingsEmailsPage: FunctionComponent<Props> = ({ user }) => {
                 </Alert>
             )}
 
+            {isErrorLike(statusOrError) && <ErrorAlert className="mt-2" error={statusOrError} />}
             {isErrorLike(emailActionError) && <ErrorAlert className="mt-2" error={emailActionError} />}
 
             <Container>

--- a/cmd/frontend/graphqlbackend/user_emails.go
+++ b/cmd/frontend/graphqlbackend/user_emails.go
@@ -50,13 +50,7 @@ type userEmailResolver struct {
 
 func (r *userEmailResolver) Email() string { return r.userEmail.Email }
 
-func (r *userEmailResolver) IsPrimary(ctx context.Context) (bool, error) {
-	email, _, err := database.UserEmails(r.db).GetPrimaryEmail(ctx, r.user.user.ID)
-	if err != nil {
-		return false, err
-	}
-	return email == r.userEmail.Email, nil
-}
+func (r *userEmailResolver) IsPrimary() bool { return r.userEmail.Primary }
 
 func (r *userEmailResolver) Verified() bool { return r.userEmail.VerifiedAt != nil }
 func (r *userEmailResolver) VerificationPending() bool {


### PR DESCRIPTION
To close https://github.com/sourcegraph/sourcegraph/issues/29120

Issue: unverified primary emails break Emails and Users page 

## Steps to reproduce

1. Log in as a Site Admin > Create a new user without an email
![image](https://user-images.githubusercontent.com/68532117/164555527-ae046804-9eff-4099-b837-a0bedbab5f72.png)
2 Then go to the Users page, look for the newly created user
![image](https://user-images.githubusercontent.com/68532117/164555594-c1f1e23c-b5c8-42d7-8e4a-ac88689bf7c3.png)
3.  Click on the username > Emails > add a new email address
![image](https://user-images.githubusercontent.com/68532117/164555742-fe71d070-98ee-4f84-9155-131fefa9aa1a.png)
4. The Emails page will be stuck in loading
![image](https://user-images.githubusercontent.com/68532117/164556011-c253c06f-318d-4e3f-a574-517560df21fd.png)
5. Refreshing the page would display an error message but nothing can be done in the UI
![image](https://user-images.githubusercontent.com/68532117/164556130-1d60f4d1-76a2-4730-8d19-bdbdbc765846.png)
6. It would also break the Users page for Site Admin, again, nothing can be done in the UI to reverse this
![image](https://user-images.githubusercontent.com/68532117/164556261-c874a6d5-f0e2-4e98-9f7b-5de779d74c75.png)

## Root cause - Frontend
- The User Settings Emails Page will [ONLY display error message when an error is presented](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@v3.39.0/-/blob/client/web/src/user/settings/emails/UserSettingsEmailsPage.tsx?L76-78). 
  - This prevents users / site admins to make any changes through the UI when an error occurs
  - In this case, users and site admins are not able to verify or remove the emails that breaks the page
- Solution suggested in this PR: 
  - Display both the error message AND the Emails settings component that allows users and site admin to be aware of the error messages and provide them with the ability to fix them
  - Users can see the Emails page UI  that allows them to remove unverified email / Resend verification email / add new emails etc
![image](https://user-images.githubusercontent.com/68532117/164558941-4523b272-28cc-42c6-9836-7087449f0ca9.png)

## Root cause - Backend:
- Cause: The [IsPrimary function](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@v3.39.0/-/blob/cmd/frontend/graphqlbackend/user_emails.go?L53-59) returns an error saying `User email not found` if primary email is not verified, when it should just return false
- Solution suggested in this PR: 
  - Update this function to return true or false only
![image](https://user-images.githubusercontent.com/68532117/164559210-cfccbfdc-d54a-406c-b98b-c21cd9cbd4df.png)

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->
manually tested?

