### PR TITLE
Clean up PaginatedResultSet in preparation for tests

### DIFF
--- a/internal/extsvc/bitbucketcloud/paginated.go
+++ b/internal/extsvc/bitbucketcloud/paginated.go
@@ -9,7 +9,6 @@ import (
 )
 
 type PaginatedResultSet struct {
-	client    *Client
 	mu        sync.Mutex
 	initial   *url.URL
 	pageToken *PageToken
@@ -17,9 +16,11 @@ type PaginatedResultSet struct {
 	fetch     func(context.Context, *http.Request) (*PageToken, []interface{}, error)
 }
 
-func newResultSet(c *Client, initial *url.URL, fetch func(context.Context, *http.Request) (*PageToken, []interface{}, error)) *PaginatedResultSet {
+// NewPaginatedResultSet instantiates a new result set. This is intended for
+// internal use only, and is exported only to simplify testing in other
+// packages.
+func NewPaginatedResultSet(initial *url.URL, fetch func(context.Context, *http.Request) (*PageToken, []interface{}, error)) *PaginatedResultSet {
 	return &PaginatedResultSet{
-		client:  c,
 		initial: initial,
 		fetch:   fetch,
 	}
@@ -67,7 +68,7 @@ func (rs *PaginatedResultSet) WithPageLength(pageLen int) *PaginatedResultSet {
 	values.Set("pagelen", strconv.Itoa(pageLen))
 	initial.RawQuery = values.Encode()
 
-	return newResultSet(rs.client, &initial, rs.fetch)
+	return NewPaginatedResultSet(&initial, rs.fetch)
 }
 
 func (rs *PaginatedResultSet) reqPage(ctx context.Context) error {

--- a/internal/extsvc/bitbucketcloud/pull_requests.go
+++ b/internal/extsvc/bitbucketcloud/pull_requests.go
@@ -88,7 +88,7 @@ func (c *Client) GetPullRequestStatuses(repo *Repo, id int64) (*PaginatedResultS
 		return nil, errors.Wrap(err, "parsing URL")
 	}
 
-	return newResultSet(c, u, func(ctx context.Context, req *http.Request) (*PageToken, []interface{}, error) {
+	return NewPaginatedResultSet(u, func(ctx context.Context, req *http.Request) (*PageToken, []interface{}, error) {
 		var page struct {
 			*PageToken
 			Values []*PullRequestStatus `json:"values"`


### PR DESCRIPTION
I need the constructor exported for #33946, and noticed the unused field while I was in there.

## Test plan

Test coverage here is good, so the unit tests passing is sufficient.