### PR TITLE
dev: go-lint only looks for go.mod files

### DIFF
--- a/dev/check/go-lint.sh
+++ b/dev/check/go-lint.sh
@@ -48,7 +48,7 @@ declare -A IGNORED_DIRS=(
 
 # If no args are given, traverse through each project with a `go.mod`
 if [ $# -eq 0 ]; then
-  find . -name go.mod -exec dirname '{}' \; | while read -r d; do
+  find . -name go.mod -type f -exec dirname '{}' \; | while read -r d; do
 
     # Skip any ignored directories.
     if [ -v "IGNORED_DIRS[$d]" ]; then


### PR DESCRIPTION
We had "-type file" which broke since this doesn't work on linux. This
was removed, but now we get a test directory called go.mod matching
which is incorrect. This adds back the find condition, but correctly
works on both mac and linux.

```shellsession
$ diff <(find . -name go.mod -type f) <(find . -name go.mod)
1a2
> ./internal/codeintel/dependencies/internal/lockfiles/testdata/parse/go.mod
```

Test Plan: ran the find incantation on both linux and mac. Both agreed
and found all go.mod files.

Context: https://github.com/sourcegraph/sourcegraph/pull/34298/files#r855806408