### PR TITLE
all: make profiler.Init best effort

### DIFF
--- a/cmd/frontend/internal/cli/serve_cmd.go
+++ b/cmd/frontend/internal/cli/serve_cmd.go
@@ -118,10 +118,6 @@ func Main(enterpriseSetupHook func(db database.DB, c conftypes.UnifiedWatchable)
 	log.SetFlags(0)
 	log.SetPrefix("")
 
-	if err := profiler.Init(); err != nil {
-		log.Fatalf("failed to initialize profiling: %v", err)
-	}
-
 	ready := make(chan struct{})
 	go debugserver.NewServerRoutine(ready).Start()
 
@@ -175,6 +171,7 @@ func Main(enterpriseSetupHook func(db database.DB, c conftypes.UnifiedWatchable)
 	tracer.Init(conf.DefaultClient())
 	sentry.Init(conf.DefaultClient())
 	trace.Init()
+	profiler.Init()
 
 	// Run enterprise setup hook
 	enterprise := enterpriseSetupHook(db, conf.DefaultClient())

--- a/cmd/gitserver/main.go
+++ b/cmd/gitserver/main.go
@@ -73,15 +73,12 @@ func main() {
 	env.Lock()
 	env.HandleHelpFlag()
 
-	if err := profiler.Init(); err != nil {
-		log.Fatalf("failed to start profiler: %v", err)
-	}
-
 	conf.Init()
 	logging.Init()
 	tracer.Init(conf.DefaultClient())
 	sentry.Init(conf.DefaultClient())
 	trace.Init()
+	profiler.Init()
 
 	if reposDir == "" {
 		log.Fatal("git-server: SRC_REPOS_DIR is required")

--- a/cmd/repo-updater/shared/main.go
+++ b/cmd/repo-updater/shared/main.go
@@ -73,15 +73,12 @@ func Main(enterpriseInit EnterpriseInit) {
 	env.Lock()
 	env.HandleHelpFlag()
 
-	if err := profiler.Init(); err != nil {
-		log.Fatalf("failed to start profiler: %v", err)
-	}
-
 	conf.Init()
 	logging.Init()
 	tracer.Init(conf.DefaultClient())
 	sentry.Init(conf.DefaultClient())
 	trace.Init()
+	profiler.Init()
 
 	// Signals health of startup
 	ready := make(chan struct{})

--- a/cmd/searcher/main.go
+++ b/cmd/searcher/main.go
@@ -64,10 +64,7 @@ func main() {
 	tracer.Init(conf.DefaultClient())
 	sentry.Init(conf.DefaultClient())
 	trace.Init()
-
-	if err := profiler.Init(); err != nil {
-		log.Fatalf("failed to start Google Cloud profiler: %s", err)
-	}
+	profiler.Init()
 
 	// Ready immediately
 	ready := make(chan struct{})

--- a/cmd/symbols/shared/main.go
+++ b/cmd/symbols/shared/main.go
@@ -37,11 +37,6 @@ type SetupFunc func(observationContext *observation.Context, gitserverClient git
 func Main(setup SetupFunc) {
 	routines := []goroutine.BackgroundRoutine{}
 
-	// Set up Google Cloud Profiler when running in Cloud
-	if err := profiler.Init(); err != nil {
-		log.Fatalf("Failed to start profiler: %v", err)
-	}
-
 	// Initialize tracing/metrics
 	observationContext := &observation.Context{
 		Logger:     log15.Root(),
@@ -71,6 +66,7 @@ func Main(setup SetupFunc) {
 	tracer.Init(conf.DefaultClient())
 	sentry.Init(conf.DefaultClient())
 	trace.Init()
+	profiler.Init()
 
 	// Start debug server
 	ready := make(chan struct{})

--- a/cmd/worker/shared/main.go
+++ b/cmd/worker/shared/main.go
@@ -62,11 +62,6 @@ func Start(additionalJobs map[string]job.Job, registerEnterpriseMigrations func(
 	// Setup environment variables
 	loadConfigs(jobs)
 
-	// Set up Google Cloud Profiler when running in Cloud
-	if err := profiler.Init(); err != nil {
-		log.Fatalf("Failed to start profiler: %v", err)
-	}
-
 	env.Lock()
 	env.HandleHelpFlag()
 	conf.Init()
@@ -74,6 +69,8 @@ func Start(additionalJobs map[string]job.Job, registerEnterpriseMigrations func(
 	tracer.Init(conf.DefaultClient())
 	sentry.Init(conf.DefaultClient())
 	trace.Init()
+	profiler.Init()
+
 	if err := keyring.Init(context.Background()); err != nil {
 		log.Fatalf("Failed to intialise keyring: %v", err)
 	}

--- a/enterprise/cmd/precise-code-intel-worker/main.go
+++ b/enterprise/cmd/precise-code-intel-worker/main.go
@@ -54,10 +54,7 @@ func main() {
 	tracer.Init(conf.DefaultClient())
 	sentry.Init(conf.DefaultClient())
 	trace.Init()
-
-	if err := profiler.Init(); err != nil {
-		log.Fatalf("Failed to start profiler: %v", err)
-	}
+	profiler.Init()
 
 	if err := config.Validate(); err != nil {
 		log.Fatalf("Failed to load config: %s", err)

--- a/internal/profiler/profiler.go
+++ b/internal/profiler/profiler.go
@@ -6,6 +6,7 @@ import (
 	"cloud.google.com/go/profiler"
 	ddprofiler "gopkg.in/DataDog/dd-trace-go.v1/profiler"
 
+	"github.com/inconshreveable/log15"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/internal/conf/deploy"
 	"github.com/sourcegraph/sourcegraph/internal/env"
@@ -14,33 +15,42 @@ import (
 
 // Init starts the Google Cloud Profiler when in sourcegraph.com mode in
 // production.  https://cloud.google.com/profiler/docs/profiling-go
-func Init() error {
+func Init() {
 	if !envvar.SourcegraphDotComMode() {
-		return nil
+		return
 	}
 
 	// SourcegraphDotComMode can be true in dev, so check we are in a k8s
 	// cluster.
 	if !deploy.IsDeployTypeKubernetes(deploy.Type()) {
-		return nil
+		return
 	}
+
 	// https://docs.datadoghq.com/tracing/profiler/enabling/go/
 	if os.Getenv("DD_ENV") != "" {
 		profileTypes := []ddprofiler.ProfileType{ddprofiler.CPUProfile, ddprofiler.HeapProfile}
 		if os.Getenv("DD_PROFILE_ALL") != "" {
 			profileTypes = append(profileTypes, ddprofiler.MutexProfile, ddprofiler.BlockProfile)
 		}
-		return ddprofiler.Start(
+		err := ddprofiler.Start(
 			ddprofiler.WithService(env.MyName),
 			ddprofiler.WithVersion(version.Version()),
 			ddprofiler.WithProfileTypes(profileTypes...,
 			),
 		)
+		if err != nil {
+			log15.Error("profiler.Init datadog", "error", err)
+		}
+		return
 	}
-	return profiler.Start(profiler.Config{
+
+	err := profiler.Start(profiler.Config{
 		Service:        env.MyName,
 		ServiceVersion: version.Version(),
 		MutexProfiling: true,
 		AllocForceGC:   true,
 	})
+	if err != nil {
+		log15.Error("profiler.Init google cloud profiler", "error", err)
+	}
 }


### PR DESCRIPTION
This matches the pattern used by all our other instrumentation tools
initializing. This also helps reduce verbosity in each of our main
implementations.

I also made where we call profiler.Init more uniform. Now we always call
it with the rest of the instrumentation setup.

Note: I used log15 here since I didn't want to introduce a dependency
which assumed lib/log.Init had been called. Tackling logging in these
sort of packages should be handled in another commit.

Test Plan: CI