### PR TITLE
searcher: use lib/log instead of log15 in Service

### DIFF
--- a/cmd/searcher/main.go
+++ b/cmd/searcher/main.go
@@ -35,6 +35,8 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
 	"github.com/sourcegraph/sourcegraph/internal/tracer"
+	"github.com/sourcegraph/sourcegraph/internal/version"
+	sglog "github.com/sourcegraph/sourcegraph/lib/log"
 )
 
 var (
@@ -61,6 +63,10 @@ func main() {
 	log.SetFlags(0)
 	conf.Init()
 	logging.Init()
+	sglog.Init(sglog.Resource{
+		Name:    env.MyName,
+		Version: version.Version(),
+	})
 	tracer.Init(conf.DefaultClient())
 	sentry.Init(conf.DefaultClient())
 	trace.Init()
@@ -105,7 +111,7 @@ func main() {
 			MaxCacheSizeBytes: cacheSizeBytes,
 			DB:                db,
 		},
-		Log: log15.Root(),
+		Log: sglog.Scoped("service", "the searcher service"),
 	}
 	service.Store.Start()
 

--- a/lib/log/fields.go
+++ b/lib/log/fields.go
@@ -26,6 +26,9 @@ var (
 	// is represented is encoder-dependent, so marshaling is necessarily lazy.
 	Float64 = zap.Float64
 
+	// Bool constructs a field that carries a bool.
+	Bool = zap.Bool
+
 	// Duration constructs a field with the given key and value. The encoder controls how
 	// the duration is serialized.
 	Duration = zap.Duration


### PR DESCRIPTION
This updates our one use of log15 in searcher. We still use log15 in the
service in other places, so this is just an initial introduction of
lib/log.

Test Plan: go test