### PR TITLE
Reorder components to move token/filter inside left pane

### DIFF
--- a/client/web/src/codeintel/ReferencesPanel.module.scss
+++ b/client/web/src/codeintel/ReferencesPanel.module.scss
@@ -125,8 +125,8 @@ $card-header-height: 1.5rem;
 .references {
     &--list {
         display: flex;
-        // Ensure list spans entire height of panel, and that the scrollable area does not include the filter height
-        height: calc(100% - #{$filter-input-height + $card-header-height});
+        // Ensure list spans entire height of panel
+        height: 100%;
     }
 
     // Left side of the panel: hover & list of references/definition/...

--- a/client/web/src/codeintel/ReferencesPanel.module.scss
+++ b/client/web/src/codeintel/ReferencesPanel.module.scss
@@ -5,6 +5,8 @@ $filter-input-height: 1.5rem;
     padding-top: 0.25rem;
     padding-bottom: 0.25rem;
 
+    border-bottom: 1px solid var(--body-bg);
+
     input {
         height: 1rem;
         font-size: 0.75rem;

--- a/client/web/src/codeintel/ReferencesPanel.module.scss
+++ b/client/web/src/codeintel/ReferencesPanel.module.scss
@@ -65,6 +65,9 @@ $filter-input-height: 1.5rem;
         text-align: left;
 
         transition: none !important;
+
+        // Avoid line number and filename getting put on different lines
+        white-space: nowrap;
     }
 
     button:hover {

--- a/client/web/src/codeintel/ReferencesPanel.module.scss
+++ b/client/web/src/codeintel/ReferencesPanel.module.scss
@@ -147,14 +147,10 @@ $card-header-height: 1.5rem;
     overflow: auto;
 }
 
-.references {
-    // Left side of the panel: only list
-    &--side-references-list {
-        // height: calc(100% - #{$filter-input-height} - #{$card-header-height});
-        // overflow-y: auto;
-        // overflow-x: hidden;
-    }
-
+// Lists of locations (definitions, references, implementations) on the left
+.location-lists {
+    height: calc(100% - #{$filter-input-height} - #{$card-header-height});
+    overflow: auto;
 }
 
 .side-blob {
@@ -168,6 +164,8 @@ $card-header-height: 1.5rem;
     }
 
     &--code {
-        height: 100%;
+        // The code view needs to be scrollable.
+        // Its height needs to be "100% - <size-of-header-that-has-filename>"
+        height: calc(100% - #{$card-header-height});
     }
 }

--- a/client/web/src/codeintel/ReferencesPanel.module.scss
+++ b/client/web/src/codeintel/ReferencesPanel.module.scss
@@ -124,38 +124,47 @@ $card-header-height: 1.5rem;
     }
 }
 
+// Complete panel
+.panel {
+    display: flex;
+    // Ensure panel spans entire height of enclosing panel
+    height: 100%;
+}
+
+// Left side of the panel, including token name, filter, list of locations
+.left-sub-panel {
+    flex: 1;
+    overflow: auto;
+    height: 100%;
+}
+
+// Right side of the panel
+.right-sub-panel {
+    flex: 1;
+    overflow: auto;
+}
+
 .references {
-    &--list {
-        display: flex;
-        // Ensure list spans entire height of panel
-        height: 100%;
+    // Left side of the panel: only list
+    &--side-references-list {
+        // height: calc(100% - #{$filter-input-height} - #{$card-header-height});
+        // overflow-y: auto;
+        // overflow-x: hidden;
     }
 
-    // Left side of the panel: hover & list of references/definition/...
-    &--side-references {
-        flex: 1;
-        overflow: auto;
-        height: 100%;
-    }
+}
 
-    // Right side of the panel
-    &--side-blob {
-        flex: 1;
-        overflow: auto;
-    }
-
-    &--side-blob-filename {
+.side-blob {
+    &--filename {
         height: 1rem;
         vertical-align: middle;
     }
 
-    &--side-blob-collapse-button {
+    &--collapse-button {
         margin-right: 0.5rem;
     }
 
-    // Code needs to be smaller than 100% so it scrolls correctly
-    &--side-blob-code {
-        // Subtract the space taken up by the filename
-        height: calc(100% - #{$filter-input-height});
+    &--code {
+        height: 100%;
     }
 }

--- a/client/web/src/codeintel/ReferencesPanel.tsx
+++ b/client/web/src/codeintel/ReferencesPanel.tsx
@@ -359,8 +359,8 @@ export const ReferencesList: React.FunctionComponent<
     }
 
     return (
-        <div className={classNames('align-items-stretch', styles.referencesList)}>
-            <div className={classNames('px-0', styles.referencesSideReferences)}>
+        <div className={classNames('align-items-stretch', styles.panel)}>
+            <div className={classNames('px-0', styles.leftSubPanel)}>
                 <CardHeader className={classNames('d-flex align-items-center', styles.cardHeader)}>
                     <Code size="base" weight="bold">
                         {props.searchToken}
@@ -429,12 +429,12 @@ export const ReferencesList: React.FunctionComponent<
                 )}
             </div>
             {activeLocation !== undefined && (
-                <div className={classNames('px-0 border-left', styles.referencesSideBlob)}>
+                <div className={classNames('px-0 border-left', styles.rightSubPanel)}>
                     <CardHeader className={classNames('d-flex', styles.cardHeader)}>
                         <small>
                             <Button
                                 onClick={() => setActiveLocation(undefined)}
-                                className={classNames('btn-icon p-0', styles.referencesSideBlobCollapseButton)}
+                                className={classNames('btn-icon p-0', styles.sideBlobCollapseButton)}
                                 title="Close panel"
                                 data-tooltip="Close panel"
                                 data-placement="left"
@@ -448,7 +448,7 @@ export const ReferencesList: React.FunctionComponent<
                                     event.preventDefault()
                                     navigateToUrl(activeLocation.url)
                                 }}
-                                className={styles.referencesSideBlobFilename}
+                                className={styles.sideBlobFilename}
                             >
                                 {activeLocation.file}{' '}
                             </Link>
@@ -629,7 +629,7 @@ const SideBlob: React.FunctionComponent<
             location={props.location}
             disableStatusBar={true}
             wrapCode={true}
-            className={styles.referencesSideBlobCode}
+            className={styles.sideBlobCode}
             blobInfo={{
                 html,
                 content: props.activeLocation.content,

--- a/client/web/src/codeintel/ReferencesPanel.tsx
+++ b/client/web/src/codeintel/ReferencesPanel.tsx
@@ -148,7 +148,7 @@ export const RevisionResolvingReferencesList: React.FunctionComponent<
     }
 
     return (
-        <FilterableReferencesList
+        <SearchTokenFindingReferencesList
             {...props}
             token={token}
             isFork={data.isFork}
@@ -165,14 +165,7 @@ interface ReferencesPanelPropsWithToken extends ReferencesPanelProps {
     fileContent: string
 }
 
-const FilterableReferencesList: React.FunctionComponent<ReferencesPanelPropsWithToken> = props => {
-    const [filter, setFilter] = useState<string>()
-    const debouncedFilter = useDebounce(filter, 150)
-
-    useEffect(() => {
-        setFilter(undefined)
-    }, [props.token])
-
+const SearchTokenFindingReferencesList: React.FunctionComponent<ReferencesPanelPropsWithToken> = props => {
     const languageId = getModeFromPath(props.token.filePath)
     const spec = findLanguageSpec(languageId)
     const tokenResult = findSearchToken({
@@ -195,35 +188,15 @@ const FilterableReferencesList: React.FunctionComponent<ReferencesPanelPropsWith
     }
 
     return (
-        <>
-            <CardHeader className={styles.cardHeader}>
-                <Code size="base" weight="bold">
-                    {tokenResult.searchToken}
-                </Code>
-            </CardHeader>
-            <div className={classNames('d-flex justify-content-start', styles.filter)}>
-                <small>
-                    <Icon as={FilterOutlineIcon} size="sm" className={styles.filterIcon} />
-                </small>
-                <Input
-                    className={classNames('py-0 my-0 w-100 text-small')}
-                    type="text"
-                    placeholder="Type to filter by filename"
-                    value={filter === undefined ? '' : filter}
-                    onChange={event => setFilter(event.target.value)}
-                />
-            </div>
-            <ReferencesList
-                {...props}
-                token={props.token}
-                filter={debouncedFilter}
-                searchToken={tokenResult?.searchToken}
-                spec={spec}
-                fileContent={props.fileContent}
-                isFork={props.isFork}
-                isArchived={props.isArchived}
-            />
-        </>
+        <ReferencesList
+            {...props}
+            token={props.token}
+            searchToken={tokenResult?.searchToken}
+            spec={spec}
+            fileContent={props.fileContent}
+            isFork={props.isFork}
+            isArchived={props.isArchived}
+        />
     )
 }
 
@@ -231,12 +204,18 @@ const SHOW_SPINNER_DELAY_MS = 100
 
 export const ReferencesList: React.FunctionComponent<
     ReferencesPanelPropsWithToken & {
-        filter?: string
         searchToken: string
         spec: LanguageSpec
         fileContent: string
     }
 > = props => {
+    const [filter, setFilter] = useState<string>()
+    const debouncedFilter = useDebounce(filter, 150)
+
+    useEffect(() => {
+        setFilter(undefined)
+    }, [props.token])
+
     const getSetting = newSettingsGetter(props.settingsCascade)
 
     const {
@@ -258,7 +237,7 @@ export const ReferencesList: React.FunctionComponent<
             // get from hoverifier is 1-indexed.
             line: props.token.line - 1,
             character: props.token.character - 1,
-            filter: props.filter || null,
+            filter: debouncedFilter || null,
             firstReferences: 100,
             afterReferences: null,
             firstImplementations: 100,
@@ -380,96 +359,111 @@ export const ReferencesList: React.FunctionComponent<
     }
 
     return (
-        <>
-            <div className={classNames('align-items-stretch', styles.referencesList)}>
-                <div className={classNames('px-0', styles.referencesSideReferences)}>
+        <div className={classNames('align-items-stretch', styles.referencesList)}>
+            <div className={classNames('px-0', styles.referencesSideReferences)}>
+                <CardHeader className={styles.cardHeader}>
+                    <Code size="base" weight="bold">
+                        {props.searchToken}
+                    </Code>
                     {canShowSpinner && (
-                        <div className="text-muted">
-                            <LoadingSpinner inline={true} />
-                            <i>Loading...</i>
-                        </div>
+                        <small className="ml-2 text-muted">
+                            <Icon as={LoadingSpinner} size="sm" inline={true} />
+                            Loading...
+                        </small>
                     )}
-                    <CollapsibleLocationList
-                        {...props}
-                        name="definitions"
-                        locations={definitions}
-                        hasMore={false}
-                        loadingMore={false}
-                        filter={props.filter}
-                        navigateToUrl={navigateToUrl}
-                        isActiveLocation={isActiveLocation}
-                        setActiveLocation={onReferenceClick}
-                        handleOpenChange={handleOpenChange}
-                        isOpen={isOpen}
+                </CardHeader>
+                <div className={classNames('d-flex justify-content-start', styles.filter)}>
+                    <small>
+                        <Icon as={FilterOutlineIcon} size="sm" className={styles.filterIcon} />
+                    </small>
+                    <Input
+                        className={classNames('py-0 my-0 w-100 text-small')}
+                        type="text"
+                        placeholder="Type to filter by filename"
+                        value={filter === undefined ? '' : filter}
+                        onChange={event => setFilter(event.target.value)}
                     />
-                    <CollapsibleLocationList
-                        {...props}
-                        name="references"
-                        locations={references}
-                        hasMore={referencesHasNextPage}
-                        fetchMore={fetchMoreReferences}
-                        loadingMore={fetchMoreReferencesLoading}
-                        filter={props.filter}
-                        navigateToUrl={navigateToUrl}
-                        setActiveLocation={onReferenceClick}
-                        isActiveLocation={isActiveLocation}
-                        handleOpenChange={handleOpenChange}
-                        isOpen={isOpen}
-                    />
-                    {implementations.length > 0 && (
-                        <CollapsibleLocationList
-                            {...props}
-                            name="implementations"
-                            locations={implementations}
-                            hasMore={implementationsHasNextPage}
-                            fetchMore={fetchMoreImplementations}
-                            loadingMore={fetchMoreImplementationsLoading}
-                            setActiveLocation={onReferenceClick}
-                            filter={props.filter}
-                            isActiveLocation={isActiveLocation}
-                            navigateToUrl={navigateToUrl}
-                            handleOpenChange={handleOpenChange}
-                            isOpen={isOpen}
-                        />
-                    )}
                 </div>
-                {activeLocation !== undefined && (
-                    <div className={classNames('px-0 border-left', styles.referencesSideBlob)}>
-                        <CardHeader className={classNames('d-flex', styles.cardHeader)}>
-                            <small>
-                                <Button
-                                    onClick={() => setActiveLocation(undefined)}
-                                    className={classNames('btn-icon p-0', styles.referencesSideBlobCollapseButton)}
-                                    title="Close panel"
-                                    data-tooltip="Close panel"
-                                    data-placement="left"
-                                    size="sm"
-                                >
-                                    <Icon size="sm" as={ArrowCollapseRightIcon} className="border-0" />
-                                </Button>
-                                <Link
-                                    to={activeLocation.url}
-                                    onClick={event => {
-                                        event.preventDefault()
-                                        navigateToUrl(activeLocation.url)
-                                    }}
-                                    className={styles.referencesSideBlobFilename}
-                                >
-                                    {activeLocation.file}{' '}
-                                </Link>
-                            </small>
-                        </CardHeader>
-                        <SideBlob
-                            {...props}
-                            blobNav={onBlobNav}
-                            history={blobMemoryHistory}
-                            location={blobMemoryHistory.location}
-                            activeLocation={activeLocation}
-                        />
-                    </div>
+                <CollapsibleLocationList
+                    {...props}
+                    name="definitions"
+                    locations={definitions}
+                    hasMore={false}
+                    loadingMore={false}
+                    filter={debouncedFilter}
+                    navigateToUrl={navigateToUrl}
+                    isActiveLocation={isActiveLocation}
+                    setActiveLocation={onReferenceClick}
+                    handleOpenChange={handleOpenChange}
+                    isOpen={isOpen}
+                />
+                <CollapsibleLocationList
+                    {...props}
+                    name="references"
+                    locations={references}
+                    hasMore={referencesHasNextPage}
+                    fetchMore={fetchMoreReferences}
+                    loadingMore={fetchMoreReferencesLoading}
+                    filter={debouncedFilter}
+                    navigateToUrl={navigateToUrl}
+                    setActiveLocation={onReferenceClick}
+                    isActiveLocation={isActiveLocation}
+                    handleOpenChange={handleOpenChange}
+                    isOpen={isOpen}
+                />
+                {implementations.length > 0 && (
+                    <CollapsibleLocationList
+                        {...props}
+                        name="implementations"
+                        locations={implementations}
+                        hasMore={implementationsHasNextPage}
+                        fetchMore={fetchMoreImplementations}
+                        loadingMore={fetchMoreImplementationsLoading}
+                        setActiveLocation={onReferenceClick}
+                        filter={debouncedFilter}
+                        isActiveLocation={isActiveLocation}
+                        navigateToUrl={navigateToUrl}
+                        handleOpenChange={handleOpenChange}
+                        isOpen={isOpen}
+                    />
                 )}
             </div>
-        </>
+            {activeLocation !== undefined && (
+                <div className={classNames('px-0 border-left', styles.referencesSideBlob)}>
+                    <CardHeader className={classNames('d-flex', styles.cardHeader)}>
+                        <small>
+                            <Button
+                                onClick={() => setActiveLocation(undefined)}
+                                className={classNames('btn-icon p-0', styles.referencesSideBlobCollapseButton)}
+                                title="Close panel"
+                                data-tooltip="Close panel"
+                                data-placement="left"
+                                size="sm"
+                            >
+                                <Icon size="sm" as={ArrowCollapseRightIcon} className="border-0" />
+                            </Button>
+                            <Link
+                                to={activeLocation.url}
+                                onClick={event => {
+                                    event.preventDefault()
+                                    navigateToUrl(activeLocation.url)
+                                }}
+                                className={styles.referencesSideBlobFilename}
+                            >
+                                {activeLocation.file}{' '}
+                            </Link>
+                        </small>
+                    </CardHeader>
+                    <SideBlob
+                        {...props}
+                        blobNav={onBlobNav}
+                        history={blobMemoryHistory}
+                        location={blobMemoryHistory.location}
+                        activeLocation={activeLocation}
+                    />
+                </div>
+            )}
+        </div>
     )
 }
 

--- a/client/web/src/codeintel/ReferencesPanel.tsx
+++ b/client/web/src/codeintel/ReferencesPanel.tsx
@@ -361,14 +361,14 @@ export const ReferencesList: React.FunctionComponent<
     return (
         <div className={classNames('align-items-stretch', styles.referencesList)}>
             <div className={classNames('px-0', styles.referencesSideReferences)}>
-                <CardHeader className={styles.cardHeader}>
+                <CardHeader className={classNames('d-flex align-items-center', styles.cardHeader)}>
                     <Code size="base" weight="bold">
                         {props.searchToken}
                     </Code>
                     {canShowSpinner && (
-                        <small className="ml-2 text-muted">
-                            <Icon as={LoadingSpinner} size="sm" inline={true} />
-                            Loading...
+                        <small className="ml-3 text-muted d-flex align-items-center">
+                            <Icon as={LoadingSpinner} size="sm" inline={true} className="mr-1" />
+                            <i>Loading...</i>
                         </small>
                     )}
                 </CardHeader>

--- a/client/web/src/codeintel/ReferencesPanel.tsx
+++ b/client/web/src/codeintel/ReferencesPanel.tsx
@@ -384,49 +384,51 @@ export const ReferencesList: React.FunctionComponent<
                         onChange={event => setFilter(event.target.value)}
                     />
                 </div>
-                <CollapsibleLocationList
-                    {...props}
-                    name="definitions"
-                    locations={definitions}
-                    hasMore={false}
-                    loadingMore={false}
-                    filter={debouncedFilter}
-                    navigateToUrl={navigateToUrl}
-                    isActiveLocation={isActiveLocation}
-                    setActiveLocation={onReferenceClick}
-                    handleOpenChange={handleOpenChange}
-                    isOpen={isOpen}
-                />
-                <CollapsibleLocationList
-                    {...props}
-                    name="references"
-                    locations={references}
-                    hasMore={referencesHasNextPage}
-                    fetchMore={fetchMoreReferences}
-                    loadingMore={fetchMoreReferencesLoading}
-                    filter={debouncedFilter}
-                    navigateToUrl={navigateToUrl}
-                    setActiveLocation={onReferenceClick}
-                    isActiveLocation={isActiveLocation}
-                    handleOpenChange={handleOpenChange}
-                    isOpen={isOpen}
-                />
-                {implementations.length > 0 && (
+                <div className={styles.locationLists}>
                     <CollapsibleLocationList
                         {...props}
-                        name="implementations"
-                        locations={implementations}
-                        hasMore={implementationsHasNextPage}
-                        fetchMore={fetchMoreImplementations}
-                        loadingMore={fetchMoreImplementationsLoading}
-                        setActiveLocation={onReferenceClick}
+                        name="definitions"
+                        locations={definitions}
+                        hasMore={false}
+                        loadingMore={false}
                         filter={debouncedFilter}
-                        isActiveLocation={isActiveLocation}
                         navigateToUrl={navigateToUrl}
+                        isActiveLocation={isActiveLocation}
+                        setActiveLocation={onReferenceClick}
                         handleOpenChange={handleOpenChange}
                         isOpen={isOpen}
                     />
-                )}
+                    <CollapsibleLocationList
+                        {...props}
+                        name="references"
+                        locations={references}
+                        hasMore={referencesHasNextPage}
+                        fetchMore={fetchMoreReferences}
+                        loadingMore={fetchMoreReferencesLoading}
+                        filter={debouncedFilter}
+                        navigateToUrl={navigateToUrl}
+                        setActiveLocation={onReferenceClick}
+                        isActiveLocation={isActiveLocation}
+                        handleOpenChange={handleOpenChange}
+                        isOpen={isOpen}
+                    />
+                    {implementations.length > 0 && (
+                        <CollapsibleLocationList
+                            {...props}
+                            name="implementations"
+                            locations={implementations}
+                            hasMore={implementationsHasNextPage}
+                            fetchMore={fetchMoreImplementations}
+                            loadingMore={fetchMoreImplementationsLoading}
+                            setActiveLocation={onReferenceClick}
+                            filter={debouncedFilter}
+                            isActiveLocation={isActiveLocation}
+                            navigateToUrl={navigateToUrl}
+                            handleOpenChange={handleOpenChange}
+                            isOpen={isOpen}
+                        />
+                    )}
+                </div>
             </div>
             {activeLocation !== undefined && (
                 <div className={classNames('px-0 border-left', styles.rightSubPanel)}>


### PR DESCRIPTION
This is another step towards https://github.com/sourcegraph/sourcegraph/issues/34201.

This PR

- reorders the components so that the token and the filter row are inside the left pane
- it also fixes the appearance of the loading spinner, so it now has a stable position next to token
- fixes some word-wrapping inside the results

## Screenshot of before/after

![screenshot_2022-04-22_13 56 31@2x](https://user-images.githubusercontent.com/1185253/164710080-ab559060-6f6e-43c3-b38b-4cf6d87caab6.png)


## Video

This also shows the loading spinner and the filter and that they're sticky

https://user-images.githubusercontent.com/1185253/164710123-a55ec7d3-d4e2-400b-adba-2d745897637e.mp4




## Test plan

- Tested this locally (see video)



## App preview:

- [Web](https://sg-web-mrn-second-polish-round.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-quenmdypkv.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

