### PR TITLE
Integration tests: Suppress Chromium install log (and other Percy noise that isn't errors)

### DIFF
--- a/client/browser/scripts/test-integration.js
+++ b/client/browser/scripts/test-integration.js
@@ -5,7 +5,7 @@ const { decompressRecordings, deleteRecordings } = require('./utils')
 // eslint-disable-next-line no-void
 void (async () => {
   await decompressRecordings()
-  shelljs.exec('POLLYJS_MODE=replay yarn percy exec -- yarn run-integration', async code => {
+  shelljs.exec('POLLYJS_MODE=replay yarn percy exec --quiet -- yarn run-integration', async code => {
     await deleteRecordings()
     process.exit(code)
   })

--- a/client/shared/src/testing/driver.ts
+++ b/client/shared/src/testing/driver.ts
@@ -183,6 +183,7 @@ export class Driver {
                                             .includes('Warning: componentWillReceiveProps has been renamed') &&
                                         !message.text().includes('Download the Apollo DevTools') &&
                                         !message.text().includes('debug') &&
+                                        !message.text().includes('Downloading Chromium') &&
                                         // These requests are expected to fail, we use them to check if the browser extension is installed.
                                         message.location().url !== 'chrome-extension://invalid/'
                                 ),

--- a/client/shared/src/testing/driver.ts
+++ b/client/shared/src/testing/driver.ts
@@ -183,7 +183,6 @@ export class Driver {
                                             .includes('Warning: componentWillReceiveProps has been renamed') &&
                                         !message.text().includes('Download the Apollo DevTools') &&
                                         !message.text().includes('debug') &&
-                                        !message.text().includes('Downloading Chromium') &&
                                         // These requests are expected to fail, we use them to check if the browser extension is installed.
                                         message.location().url !== 'chrome-extension://invalid/'
                                 ),

--- a/dev/ci/yarn-web-integration.sh
+++ b/dev/ci/yarn-web-integration.sh
@@ -11,7 +11,7 @@ echo "--- Yarn install in root"
 yarn --mutex network --frozen-lockfile --network-timeout 60000 --silent
 
 echo "--- Run integration test suite"
-yarn percy exec yarn _cover-integration "$@"
+yarn percy exec --quiet yarn _cover-integration "$@"
 
 echo "--- Process NYC report"
 yarn nyc report -r json


### PR DESCRIPTION
## Description

We often get errors when trying to sending failing test logs to Buildkite.

Example failure: https://buildkite.com/sourcegraph/sourcegraph/builds/142872#ded1844b-649a-4b71-a944-fd42391f8f6c/2126-2130

<img width="1087" alt="image" src="https://user-images.githubusercontent.com/9516420/164423873-28f81982-8004-4266-9437-40b67f8adbe2.png">

This PR:
- Adds `--quiet` to our `percy exec` commands.
  - This will suppress any noisy logs (particularly the Chromium install logs)
  - Will only log errors, which I think is OK as that's what we primarily care about checking in our CI logs
  - Note: Does not suppress logs from our actual integration tests + Puppeteer (we definitely want those)

Follow up on https://github.com/sourcegraph/sourcegraph/pull/34262

## Test plan
- Checked in CI. No Chromium logs, and we can easily now view the entire logs (Buildkite doesn't hide them)



## App preview:

- [Web](https://sg-web-tr-suppress-chromium.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-apiomvinod.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
