### PR TITLE
fix: use correct spelling of schema

### DIFF
--- a/doc/admin/how-to/manual_database_migrations.md
+++ b/doc/admin/how-to/manual_database_migrations.md
@@ -28,7 +28,7 @@ The `upto` command ensures a given migration has been applied, and may apply dep
 
 Usage: **`downto -db=<schema> -target=<target>,<target>,...`**
 
-The `downto` command revert any applied migrations that are children of the given targets - this effectively "resets" the schmea to the target version. The `-db` flag signifies the target schema to modify. The `-target` flag signifies a set of targets whose proper ancestors should be reverted. Comma-separated values are accepted.
+The `downto` command revert any applied migrations that are children of the given targets - this effectively "resets" the schema to the target version. The `-db` flag signifies the target schema to modify. The `-target` flag signifies a set of targets whose proper ancestors should be reverted. Comma-separated values are accepted.
 
 ### validate
 

--- a/internal/database/migration/cliutil/downto.go
+++ b/internal/database/migration/cliutil/downto.go
@@ -83,7 +83,7 @@ func DownTo(commandName string, factory RunnerFactory, out *output.Output, devel
 	return &cli.Command{
 		Name:        "downto",
 		UsageText:   fmt.Sprintf("%s downto -db=<schema> -target=<target>,<target>,...", commandName),
-		Usage:       `Revert any applied migrations that are children of the given targets - this effectively "resets" the schmea to the target version`,
+		Usage:       `Revert any applied migrations that are children of the given targets - this effectively "resets" the schema to the target version`,
 		Description: ConstructLongHelp(),
 		Flags:       flags,
 		Action:      action,

--- a/internal/repos/bitbucketcloud_test.go
+++ b/internal/repos/bitbucketcloud_test.go
@@ -120,18 +120,18 @@ func TestBitbucketCloudSource_makeRepo(t *testing.T) {
 
 	tests := []struct {
 		name   string
-		schmea *schema.BitbucketCloudConnection
+		schema *schema.BitbucketCloudConnection
 	}{
 		{
 			name: "simple",
-			schmea: &schema.BitbucketCloudConnection{
+			schema: &schema.BitbucketCloudConnection{
 				Url:         "https://bitbucket.org",
 				Username:    "alice",
 				AppPassword: "secret",
 			},
 		}, {
 			name: "ssh",
-			schmea: &schema.BitbucketCloudConnection{
+			schema: &schema.BitbucketCloudConnection{
 				Url:         "https://bitbucket.org",
 				Username:    "alice",
 				AppPassword: "secret",
@@ -139,7 +139,7 @@ func TestBitbucketCloudSource_makeRepo(t *testing.T) {
 			},
 		}, {
 			name: "path-pattern",
-			schmea: &schema.BitbucketCloudConnection{
+			schema: &schema.BitbucketCloudConnection{
 				Url:                   "https://bitbucket.org",
 				Username:              "alice",
 				AppPassword:           "secret",
@@ -150,7 +150,7 @@ func TestBitbucketCloudSource_makeRepo(t *testing.T) {
 	for _, test := range tests {
 		test.name = "BitbucketCloudSource_makeRepo_" + test.name
 		t.Run(test.name, func(t *testing.T) {
-			s, err := newBitbucketCloudSource(&svc, test.schmea, nil)
+			s, err := newBitbucketCloudSource(&svc, test.schema, nil)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/repos/gitlab_test.go
+++ b/internal/repos/gitlab_test.go
@@ -179,22 +179,22 @@ func TestGitLabSource_makeRepo(t *testing.T) {
 
 	tests := []struct {
 		name   string
-		schmea *schema.GitLabConnection
+		schema *schema.GitLabConnection
 	}{
 		{
 			name: "simple",
-			schmea: &schema.GitLabConnection{
+			schema: &schema.GitLabConnection{
 				Url: "https://gitlab.com",
 			},
 		}, {
 			name: "ssh",
-			schmea: &schema.GitLabConnection{
+			schema: &schema.GitLabConnection{
 				Url:        "https://gitlab.com",
 				GitURLType: "ssh",
 			},
 		}, {
 			name: "path-pattern",
-			schmea: &schema.GitLabConnection{
+			schema: &schema.GitLabConnection{
 				Url:                   "https://gitlab.com",
 				RepositoryPathPattern: "gl/{pathWithNamespace}",
 			},
@@ -206,7 +206,7 @@ func TestGitLabSource_makeRepo(t *testing.T) {
 			lg := log15.New()
 			lg.SetHandler(log15.DiscardHandler())
 
-			s, err := newGitLabSource(&svc, test.schmea, nil)
+			s, err := newGitLabSource(&svc, test.schema, nil)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/repos/perforce_test.go
+++ b/internal/repos/perforce_test.go
@@ -96,18 +96,18 @@ func TestPerforceSource_makeRepo(t *testing.T) {
 
 	tests := []struct {
 		name   string
-		schmea *schema.PerforceConnection
+		schema *schema.PerforceConnection
 	}{
 		{
 			name: "simple",
-			schmea: &schema.PerforceConnection{
+			schema: &schema.PerforceConnection{
 				P4Port:   "ssl:111.222.333.444:1666",
 				P4User:   "admin",
 				P4Passwd: "pa$$word",
 			},
 		}, {
 			name: "path-pattern",
-			schmea: &schema.PerforceConnection{
+			schema: &schema.PerforceConnection{
 				P4Port:                "ssl:111.222.333.444:1666",
 				P4User:                "admin",
 				P4Passwd:              "pa$$word",
@@ -118,7 +118,7 @@ func TestPerforceSource_makeRepo(t *testing.T) {
 	for _, test := range tests {
 		test.name = "PerforceSource_makeRepo_" + test.name
 		t.Run(test.name, func(t *testing.T) {
-			s, err := newPerforceSource(&svc, test.schmea)
+			s, err := newPerforceSource(&svc, test.schema)
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
Discovered this while reviewing the `migrator` CLI

## Test plan
Verify that the tests modified pass in CI.
<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


