### PR TITLE
repos: Fix GoModuleSource syncing

### DIFF
--- a/internal/repos/go_modules.go
+++ b/internal/repos/go_modules.go
@@ -172,7 +172,7 @@ func (s *GoModulesSource) makeRepo(dep *reposource.GoDependency) *types.Repo {
 				CloneURL: string(repoName),
 			},
 		},
-		Metadata: struct{}{},
+		Metadata: &struct{}{},
 	}
 }
 


### PR DESCRIPTION
This commit makes it so we return Unmodified Go repos when they didn't
change. So far, the Update method was always returning modified since
the Metadata field differed from what was scanned from the database
(pointer vs non pointer).

## Test plan

Manually tested.

