### PR TITLE
ci: disable depguard again

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,7 +3,8 @@ linters:
   disable-all: true
   enable:
     - bodyclose
-    - depguard
+    # Disabled due to flakes: https://github.com/sourcegraph/sourcegraph/issues/33183
+    # - depguard
     - forbidigo
     - gocritic
     - goimports


### PR DESCRIPTION
Depguard has failed again here https://buildkite.com/sourcegraph/sourcegraph/builds/143948 with the same symptoms as we have seen in the past. 

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

We should see no issue on the misc-lint step. 
