### PR TITLE
Update helm chart repository location

### DIFF
--- a/doc/admin/install/kubernetes/helm.md
+++ b/doc/admin/install/kubernetes/helm.md
@@ -35,7 +35,7 @@
 To use the Helm chart, add the Sourcegraph helm repository (on the machine used to interact with your cluster):
 
 ```sh
-helm repo add sourcegraph https://sourcegraph.github.io/deploy-sourcegraph-helm/
+helm repo add sourcegraph https://helm.sourcegraph.com/release
 ```
 
 Install the Sourcegraph chart using default values:
@@ -349,7 +349,7 @@ This section is aimed at providing high-level guidance on deploying Sourcegraph 
 1. Have the [Helm CLI](https://helm.sh/docs/intro/install/) installed and run the following command to link to the Sourcegraph helm repository (on the machine used to interact with your cluster):
 
 ```sh
-helm repo add sourcegraph https://sourcegraph.github.io/deploy-sourcegraph-helm/
+helm repo add sourcegraph https://helm.sourcegraph.com/release
 ```
 
 #### Steps {#gke-steps}
@@ -483,7 +483,7 @@ Now the deployment is complete, more information on configuring the Sourcegraph 
 1. Have the [Helm CLI](https://helm.sh/docs/intro/install/) installed and run the following command to link to the Sourcegraph helm repository (on the machine used to interact with your cluster):
 
 ```sh
-helm repo add sourcegraph https://sourcegraph.github.io/deploy-sourcegraph-helm/
+helm repo add sourcegraph https://helm.sourcegraph.com/release
 ```
 
 #### Steps {#eks-steps}
@@ -565,7 +565,7 @@ Now the deployment is complete, more information on configuring the Sourcegraph 
 1. Have the [Helm CLI](https://helm.sh/docs/intro/install/) installed and run the following command to link to the Sourcegraph helm repository (on the machine used to interact with your cluster):
 
 ```sh
-helm repo add sourcegraph https://sourcegraph.github.io/deploy-sourcegraph-helm/
+helm repo add sourcegraph https://helm.sourcegraph.com/release
 ```
 
 #### Steps {#aks-steps}
@@ -651,7 +651,7 @@ Now the deployment is complete, more information on configuring the Sourcegraph 
 1. Have the [Helm CLI](https://helm.sh/docs/intro/install/) installed and run the following command to link to the Sourcegraph helm repository (on the machine used to interact with your cluster):
 
 ```sh
-helm repo add sourcegraph https://sourcegraph.github.io/deploy-sourcegraph-helm/
+helm repo add sourcegraph https://helm.sourcegraph.com/release
 ```
 
 #### Steps {#others-steps}


### PR DESCRIPTION
Helm charts are now published to helm.sourcegraph.com/release, instead of the github pages location.

Closes https://github.com/sourcegraph/sourcegraph/issues/33679.

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->
Doc update only, commands work