### PR TITLE
gitserver experiment: add shortcut for getting gitserver address during SyncRepoState

### DIFF
--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -6,7 +6,9 @@ import (
 	"bytes"
 	"container/list"
 	"context"
+	"crypto/md5"
 	"crypto/sha256"
+	"encoding/binary"
 	"encoding/gob"
 	"encoding/hex"
 	"encoding/json"
@@ -600,10 +602,7 @@ func (s *Server) syncRepoState(gitServerAddrs gitserver.GitServerAddresses, batc
 	err := store.IterateRepoGitserverStatus(ctx, options, func(repo types.RepoGitserverStatus) error {
 		repoSyncStateCounter.WithLabelValues("check").Inc()
 		// Ensure we're only dealing with repos we are responsible for
-		addr, err := gitserver.AddrForRepo(ctx, filepath.Base(os.Args[0]), s.DB, repo.Name, gitServerAddrs)
-		if err != nil {
-			return err
-		}
+		addr := addrForKey(repo.Name, gitServerAddrs.Addresses)
 		if !s.hostnameMatch(addr) {
 			repoSyncStateCounter.WithLabelValues("other_shard").Inc()
 			return nil
@@ -648,6 +647,17 @@ func (s *Server) syncRepoState(gitServerAddrs gitserver.GitServerAddresses, batc
 	writeBatch()
 
 	return err
+}
+
+// addrForKey is used only during gitserver client experiment and will be removed as soon as the experiment ends.
+// In fact this commit will be just reverted.
+// If it still bothers you -- contact sashaostrikov
+func addrForKey(repo api.RepoName, addrs []string) string {
+	repo = protocol.NormalizeRepo(repo) // in case the caller didn't already normalize it
+	rs := string(repo)
+	sum := md5.Sum([]byte(rs))
+	serverIndex := binary.BigEndian.Uint64(sum[:]) % uint64(len(addrs))
+	return addrs[serverIndex]
 }
 
 // Stop cancels the running background jobs and returns when done.


### PR DESCRIPTION
gitserver.AddrForRepo call was substituted with this private function call to avoid possible querying of the DB during the experiment. SyncRepoState fetches addresses for all gitserver_repos table rows and this will cause extra unnecessary load on DB and spoil metrics data.


This commit will be reverted as soon as the experiment ends.

## Test plan
Test that existing server tests pass
<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


