### PR TITLE
ci: add automatic retries when agent is lost

### DIFF
--- a/enterprise/dev/ci/internal/buildkite/buildkite.go
+++ b/enterprise/dev/ci/internal/buildkite/buildkite.go
@@ -135,12 +135,13 @@ type Step struct {
 }
 
 type RetryOptions struct {
-	Automatic *AutomaticRetryOptions `json:"automatic,omitempty"`
-	Manual    *ManualRetryOptions    `json:"manual,omitempty"`
+	Automatic []AutomaticRetryOptions `json:"automatic,omitempty"`
+	Manual    *ManualRetryOptions     `json:"manual,omitempty"`
 }
 
 type AutomaticRetryOptions struct {
-	Limit int `json:"limit,omitempty"`
+	Limit      int         `json:"limit,omitempty"`
+	ExitStatus interface{} `json:"exit_status,omitempty"`
 }
 
 type ManualRetryOptions struct {
@@ -447,11 +448,36 @@ func SoftFail(exitCodes ...int) StepOpt {
 // Docs: https://buildkite.com/docs/pipelines/command-step#automatic-retry-attributes
 func AutomaticRetry(limit int) StepOpt {
 	return func(step *Step) {
-		step.Retry = &RetryOptions{
-			Automatic: &AutomaticRetryOptions{
-				Limit: limit,
-			},
+		if step.Retry == nil {
+			step.Retry = &RetryOptions{}
 		}
+		if step.Retry.Automatic == nil {
+			step.Retry.Automatic = []AutomaticRetryOptions{}
+		}
+		step.Retry.Automatic = append(step.Retry.Automatic, AutomaticRetryOptions{
+			Limit:      limit,
+			ExitStatus: "*",
+		})
+	}
+}
+
+// AutomaticRetryStatus enables automatic retry for the step with the number of times this job can be retried
+// when the given exitStatus is encountered.
+//
+// The maximum value this can be set to is 10.
+// Docs: https://buildkite.com/docs/pipelines/command-step#automatic-retry-attributes
+func AutomaticRetryStatus(limit int, exitStatus int) StepOpt {
+	return func(step *Step) {
+		if step.Retry == nil {
+			step.Retry = &RetryOptions{}
+		}
+		if step.Retry.Automatic == nil {
+			step.Retry.Automatic = []AutomaticRetryOptions{}
+		}
+		step.Retry.Automatic = append(step.Retry.Automatic, AutomaticRetryOptions{
+			Limit:      limit,
+			ExitStatus: strconv.Itoa(exitStatus),
+		})
 	}
 }
 

--- a/enterprise/dev/ci/internal/ci/pipeline.go
+++ b/enterprise/dev/ci/internal/ci/pipeline.go
@@ -363,4 +363,9 @@ func withAgentLostRetries(s *bk.Step) {
 		Limit:      1,
 		ExitStatus: -1,
 	})
+	// Testing purposes
+	s.Retry.Automatic = append(s.Retry.Automatic, bk.AutomaticRetryOptions{
+		Limit:      1,
+		ExitStatus: 255,
+	})
 }

--- a/enterprise/dev/ci/internal/ci/pipeline.go
+++ b/enterprise/dev/ci/internal/ci/pipeline.go
@@ -265,6 +265,7 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 		AfterEveryStepOpts: []bk.StepOpt{
 			withDefaultTimeout,
 			withAgentQueueDefaults,
+			withAgentLostRetries,
 		},
 	}
 	// Toggle profiling of each step
@@ -343,4 +344,23 @@ func withProfiling(s *bk.Step) {
 		prefixed = append(prefixed, fmt.Sprintf("env time -v %s", cmd))
 	}
 	s.Command = prefixed
+}
+
+// withAgentLostRetries insert automatic retries when the job has failed because it lost its agent.
+//
+// If the step has been marked as not retryable, the retry will be skipped.
+func withAgentLostRetries(s *bk.Step) {
+	if s.Retry != nil && s.Retry.Manual != nil && !s.Retry.Manual.Allowed {
+		return
+	}
+	if s.Retry == nil {
+		s.Retry = &bk.RetryOptions{}
+	}
+	if s.Retry.Automatic == nil {
+		s.Retry.Automatic = []bk.AutomaticRetryOptions{}
+	}
+	s.Retry.Automatic = append(s.Retry.Automatic, bk.AutomaticRetryOptions{
+		Limit:      1,
+		ExitStatus: -1,
+	})
 }

--- a/enterprise/dev/ci/internal/ci/pipeline.go
+++ b/enterprise/dev/ci/internal/ci/pipeline.go
@@ -363,9 +363,4 @@ func withAgentLostRetries(s *bk.Step) {
 		Limit:      1,
 		ExitStatus: -1,
 	})
-	// Testing purposes
-	s.Retry.Automatic = append(s.Retry.Automatic, bk.AutomaticRetryOptions{
-		Limit:      1,
-		ExitStatus: 255,
-	})
 }


### PR DESCRIPTION
This tweaks the pipeline to automatically insert a retry when an agent is lost, which we can detect by seeing that the exit status is set to `-1`. 

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

Main dry run, no changes in behaviour unless agent dies. 
Killed an agent on purpose and should see the job being restarted. 

<img width="1113" alt="image" src="https://user-images.githubusercontent.com/10151/164762140-8ef984f6-2069-4a12-a714-0d0c0046e988.png">

If manual retry is disabled, we don't restart it either: 

```
    command:
    - ./tr dev/ci/yarn-web-integration.sh "client/web/src/integration/batches.test.ts
      client/web/src/integration/blob-viewer.test.ts"
    depends_on:
    - puppeteer:prep
    # ...
    key: puppeteerelectricplugPuppeteertestschunk1
    label: ':puppeteer::electric_plug: Puppeteer tests chunk #1'
    # ...
    retry:
      manual:
        allowed: false
        reason: The Percy build is not finalized if one of the concurrent agents fails.
          To retry correctly, restart the entire pipeline.
    timeout_in_minutes: "60"
```
