### PR TITLE
search: delete flaky notebook copy test

### DIFF
--- a/client/web/src/integration/notebook.test.ts
+++ b/client/web/src/integration/notebook.test.ts
@@ -559,34 +559,6 @@ https://sourcegraph.test:3443/github.com/sourcegraph/sourcegraph@branch/-/blob/c
         expect(driver.page.url()).toContain('/notebooks/importedId')
     })
 
-    it('Should copy the notebook', async () => {
-        testContext.overrideGraphQL({
-            ...commonSearchGraphQLResults,
-            CreateNotebook: ({ notebook }) => ({
-                createNotebook: notebookFixture(
-                    'copiedId',
-                    notebook.title,
-                    notebook.blocks.map(GQLBlockInputToResponse)
-                ),
-            }),
-        })
-
-        await driver.page.goto(driver.sourcegraphBaseUrl + '/notebooks/n1')
-        await driver.page.waitForSelector('[data-testid="copy-notebook-button"]', { visible: true })
-
-        await Promise.all([
-            // We should be redirected to the copied notebook page, wait for the navigation.
-            driver.page.waitForNavigation({ waitUntil: 'networkidle0' }),
-            driver.page.click('[data-testid="copy-notebook-button"]'),
-        ])
-
-        // Wait for blocks to load.
-        await driver.page.waitForSelector('[data-block-id]', { visible: true })
-
-        // Verify the redirected URL contains the copied notebook id.
-        expect(driver.page.url()).toContain('/notebooks/copiedId')
-    })
-
     it('Should add symbol block and edit it', async () => {
         testContext.overrideSearchStreamEvents(mockSymbolStreamEvents)
 


### PR DESCRIPTION
Flaky test reported, unsure how to fix. See



https://buildkite.com/sourcegraph/sourcegraph/builds/143907#c389c4d0-52ba-401d-b9f6-5c96c847622f/6-71

and

https://sourcegraph.slack.com/archives/C02FLQDD3TQ/p1650616896973669

> Search Notebook
  | ✓ Should render a notebook (12403ms)
  | ✓ Should move, duplicate, and delete blocks (7219ms)
  | ✓ Should add markdown and query blocks, edit, and run them (13509ms)
  | ✓ Should add file block and edit it (8219ms)
  | ✓ Should add file block and auto-fill the inputs when pasting a file URL (7133ms)
  | ✓ Should update the notebook title (6746ms)
  | ✓ Should open the share dialog, switch the share option, and close the dialog (13590ms)
  | ✓ Should export a notebook as Markdown file and import it back (13337ms)
  | ✓ Should copy the notebook (13042ms)
  | 1) "after each" hook for "Should copy the notebook"
  |  
  |  
  | 9 passing (2m)
  | 5 pending
  | 1 failing
  |  
  | 1) Search Notebook
  | "after each" hook for "Should copy the notebook":
  | Error: Timeout getting coverage from https://sourcegraph.test:3443/notebooks/copiedId
  | at /root/buildkite/build/sourcegraph/client/shared/src/testing/coverage.ts:49:17
  | at async Promise.all (index 3)
  | at async recordCoverage (client/shared/src/testing/coverage.ts:37:5)
  | at async /root/buildkite/build/sourcegraph/node_modules/p-timeout/index.js:50:13
 

<br class="Apple-interchange-newline">




## Test plan
Disables flaky test



## App preview:

- [Web](https://sg-web-rvt-copy-notebook.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-rpdkqxqbpv.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
