### PR TITLE
batches: fix regression in workspaces preview

### DIFF
--- a/client/web/src/enterprise/batches/create/CreateOrEditBatchChangePage.module.scss
+++ b/client/web/src/enterprise/batches/create/CreateOrEditBatchChangePage.module.scss
@@ -22,11 +22,13 @@
 
 .workspaces-preview-container {
     display: flex;
+    flex: 1;
     flex-direction: column;
     align-items: center;
     margin-left: 1rem;
     background: none;
     border: none;
+    width: 100%;
 }
 
 // Should mostly match WorkspacesPreview header and LibraryPane header

--- a/client/web/src/enterprise/batches/create/CreateOrEditBatchChangePage.tsx
+++ b/client/web/src/enterprise/batches/create/CreateOrEditBatchChangePage.tsx
@@ -524,24 +524,22 @@ const EditPage: React.FunctionComponent<EditPageProps> = ({ batchChange, refetch
                     position="right"
                     storageKey={WORKSPACES_PREVIEW_SIZE}
                 >
-                    <div className="overflow-auto">
-                        <div className={styles.workspacesPreviewContainer}>
-                            <WorkspacesPreview
-                                previewDisabled={previewDisabled}
-                                preview={() => previewBatchSpec(debouncedCode)}
-                                batchSpecStale={
-                                    isBatchSpecStale || isWorkspacesPreviewInProgress || resolutionState === 'CANCELED'
-                                }
-                                hasPreviewed={hasPreviewed}
-                                excludeRepo={excludeRepo}
-                                cancel={cancel}
-                                isWorkspacesPreviewInProgress={isWorkspacesPreviewInProgress}
-                                resolutionState={resolutionState}
-                                workspacesConnection={workspacesConnection}
-                                importingChangesetsConnection={importingChangesetsConnection}
-                                setFilters={setFilters}
-                            />
-                        </div>
+                    <div className={styles.workspacesPreviewContainer}>
+                        <WorkspacesPreview
+                            previewDisabled={previewDisabled}
+                            preview={() => previewBatchSpec(debouncedCode)}
+                            batchSpecStale={
+                                isBatchSpecStale || isWorkspacesPreviewInProgress || resolutionState === 'CANCELED'
+                            }
+                            hasPreviewed={hasPreviewed}
+                            excludeRepo={excludeRepo}
+                            cancel={cancel}
+                            isWorkspacesPreviewInProgress={isWorkspacesPreviewInProgress}
+                            resolutionState={resolutionState}
+                            workspacesConnection={workspacesConnection}
+                            importingChangesetsConnection={importingChangesetsConnection}
+                            setFilters={setFilters}
+                        />
                     </div>
                 </Panel>
             </div>

--- a/client/web/src/enterprise/batches/create/workspaces-preview/WorkspacesPreview.module.scss
+++ b/client/web/src/enterprise/batches/create/workspaces-preview/WorkspacesPreview.module.scss
@@ -12,6 +12,7 @@
     // stylelint-disable-next-line declaration-property-unit-allowed-list
     width: 50px;
     margin-top: 2rem;
+    position: relative;
     * {
         position: absolute;
     }


### PR DESCRIPTION
There was a regression with the overflow scroll behavior of the workspaces preview when `<Resizable />` was migrated to `<Panel />`, which I fixed in https://github.com/sourcegraph/sourcegraph/pull/34252. However I didn't fix it quite right. 🤦‍♀️

Before | After
|:------:|:------:|
<video src="https://user-images.githubusercontent.com/8942601/165000302-2924e5c0-272f-4f32-957c-f7be1aa3da2a.mov" /> | <video src="https://user-images.githubusercontent.com/8942601/165000490-f7aea70b-dadf-4887-a26a-ba30bf8d01de.mov" />


This restores the original intended behavior, where just the list of workspaces is scrollable. It also fixes a separate regression with the width of the list shifting abruptly after a new resolution preview response comes back.


Before | After
|:------:|:------:|
<video src="https://user-images.githubusercontent.com/8942601/165000460-edf90143-0d8d-45b6-9aec-3e70b7e95e45.mov" /> | <video src="https://user-images.githubusercontent.com/8942601/165000493-97148478-1632-4bf7-b3cc-603c4099229c.mov" />


## Test plan

Manually verified changes with a sufficiently long list of workspaces in the preview to create the scroll. This page will get storybook coverage in an upcoming PR.



## App preview:

- [Web](https://sg-web-kr-flex-on-flex-on-flex.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-brwqpiqsad.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
