### PR TITLE
batches: migrate execution page requests to Apollo

### DIFF
--- a/client/web/src/enterprise/batches/execution/BatchSpecExecutionDetailsPage.tsx
+++ b/client/web/src/enterprise/batches/execution/BatchSpecExecutionDetailsPage.tsx
@@ -213,11 +213,11 @@ interface BatchSpecActionsProps {
 const BatchSpecActions: React.FunctionComponent<BatchSpecActionsProps> = ({ batchSpec, executionURL }) => {
     const location = useLocation()
 
-    const [cancelBatchSpecExecution, { loading: cancelLoading, error: cancelError }] = useCancelBatchSpecExecution(
+    const [cancelBatchSpecExecution, { loading: isCancelLoading, error: cancelError }] = useCancelBatchSpecExecution(
         batchSpec.id
     )
 
-    const [retryBatchSpecExecution, { loading: retryLoading, error: retryError }] = useRetryBatchSpecExecution(
+    const [retryBatchSpecExecution, { loading: isRetryLoading, error: retryError }] = useRetryBatchSpecExecution(
         batchSpec.id
     )
 
@@ -263,11 +263,11 @@ const BatchSpecActions: React.FunctionComponent<BatchSpecActionsProps> = ({ batc
                     {(batchSpec.state === BatchSpecState.QUEUED || batchSpec.state === BatchSpecState.PROCESSING) && (
                         <Button
                             onClick={() => cancelBatchSpecExecution()}
-                            disabled={cancelLoading}
+                            disabled={isCancelLoading}
                             outline={true}
                             variant="danger"
                         >
-                            {cancelLoading ? <LoadingSpinner /> : 'Cancel'}
+                            {isCancelLoading ? <LoadingSpinner /> : 'Cancel'}
                         </Button>
                     )}
                     {!location.pathname.endsWith('preview') &&
@@ -282,12 +282,12 @@ const BatchSpecActions: React.FunctionComponent<BatchSpecActionsProps> = ({ batc
                         // including completed jobs.
                         <Button
                             onClick={() => retryBatchSpecExecution()}
-                            disabled={retryLoading}
-                            data-tooltip={retryLoading ? undefined : 'Retry all failed workspaces'}
+                            disabled={isRetryLoading}
+                            data-tooltip={isRetryLoading ? undefined : 'Retry all failed workspaces'}
                             outline={true}
                             variant="secondary"
                         >
-                            {retryLoading ? <LoadingSpinner /> : 'Retry'}
+                            {isRetryLoading ? <LoadingSpinner /> : 'Retry'}
                         </Button>
                     )}
                     {!location.pathname.endsWith('preview') &&

--- a/client/web/src/enterprise/batches/execution/BatchSpecExecutionDetailsPage.tsx
+++ b/client/web/src/enterprise/batches/execution/BatchSpecExecutionDetailsPage.tsx
@@ -267,7 +267,7 @@ const BatchSpecActions: React.FunctionComponent<BatchSpecActionsProps> = ({ batc
                             outline={true}
                             variant="danger"
                         >
-                            {isCancelLoading ? <LoadingSpinner /> : 'Cancel'}
+                            {isCancelLoading && <LoadingSpinner />}Cancel
                         </Button>
                     )}
                     {!location.pathname.endsWith('preview') &&
@@ -287,7 +287,7 @@ const BatchSpecActions: React.FunctionComponent<BatchSpecActionsProps> = ({ batc
                             outline={true}
                             variant="secondary"
                         >
-                            {isRetryLoading ? <LoadingSpinner /> : 'Retry'}
+                            {isRetryLoading && <LoadingSpinner />}Retry
                         </Button>
                     )}
                     {!location.pathname.endsWith('preview') &&

--- a/client/web/src/enterprise/batches/execution/WorkspaceDetails.mock.ts
+++ b/client/web/src/enterprise/batches/execution/WorkspaceDetails.mock.ts
@@ -1,0 +1,188 @@
+import { subDays, subHours, subMinutes } from 'date-fns'
+
+import {
+    BatchSpecWorkspaceState,
+    BatchSpecWorkspaceStepFields,
+    ChangesetSpecType,
+    HiddenBatchSpecWorkspaceFields,
+    VisibleBatchSpecWorkspaceFields,
+} from '../../../graphql-operations'
+
+const now = new Date()
+
+export const mockStep = (number: number): BatchSpecWorkspaceStepFields => ({
+    cachedResultFound: false,
+    container: 'ubuntu:18.04',
+    diffStat: null,
+    environment: [],
+    exitCode: null,
+    finishedAt: null,
+    ifCondition: null,
+    number,
+    outputLines: [],
+    outputVariables: null,
+    run: `echo Hello World Step ${number} | tee -a $(find -name README.md)`,
+    skipped: false,
+    startedAt: null,
+    __typename: 'BatchSpecWorkspaceStep',
+})
+
+export const mockWorkspace = (
+    numberOfSteps = 1,
+    workspace?: Partial<VisibleBatchSpecWorkspaceFields>
+): VisibleBatchSpecWorkspaceFields => ({
+    __typename: 'VisibleBatchSpecWorkspace',
+    id: 'test-1234',
+    state: BatchSpecWorkspaceState.COMPLETED,
+    searchResultPaths: ['/some/path'],
+    queuedAt: subHours(now, 1).toISOString(),
+    startedAt: subHours(now, 1).toISOString(),
+    finishedAt: now.toISOString(),
+    failureMessage: null,
+    placeInQueue: null,
+    path: '/some/path',
+    onlyFetchWorkspace: false,
+    ignored: false,
+    unsupported: false,
+    cachedResultFound: false,
+    steps: new Array(numberOfSteps).fill(0).map((_item, index) => mockStep(index + 1)),
+    changesetSpecs: [
+        {
+            description: {
+                baseRef: 'main',
+                baseRepository: {
+                    __typename: 'Repository',
+                    name: 'github.com/sourcegraph-testing/batch-changes-test-repo',
+                    url: '/github.com/sourcegraph-testing/batch-changes-test-repo',
+                },
+                body: 'My first batch change!',
+                diffStat: { __typename: 'DiffStat', added: 100, changed: 50, deleted: 90 },
+                headRef: 'hello-world',
+                published: null,
+                title: 'Hello World',
+                __typename: 'GitBranchChangesetDescription',
+            },
+            id: 'test-1234',
+            type: ChangesetSpecType.BRANCH,
+            __typename: 'VisibleChangesetSpec',
+        },
+    ],
+    diffStat: { __typename: 'DiffStat', added: 100, changed: 50, deleted: 90, ...workspace?.diffStat },
+    stages: {
+        __typename: 'BatchSpecWorkspaceStages',
+        setup: [
+            {
+                command: [],
+                durationMilliseconds: 0,
+                exitCode: 0,
+                key: 'setup.fs',
+                out: '',
+                startTime: subMinutes(now, 10).toISOString(),
+                __typename: 'ExecutionLogEntry',
+            },
+        ],
+        srcExec: {
+            command: ['src', 'batch', 'exec', '-f', 'input.json'],
+            durationMilliseconds: null,
+            exitCode: null,
+            key: 'step.src.0',
+            out:
+                'stdout: {"operation":"PREPARING_DOCKER_IMAGES","timestamp":"2022-04-21T06:26:59.055Z","status":"STARTED","metadata":{}}\nstdout: {"operation":"PREPARING_DOCKER_IMAGES","timestamp":"2022-04-21T06:26:59.055Z","status":"PROGRESS","metadata":{"total":1}}\nstdout: {"operation":"PREPARING_DOCKER_IMAGES","timestamp":"2022-04-21T06:26:59.188Z","status":"PROGRESS","metadata":{"done":1,"total":1}}\nstdout: {"operation":"PREPARING_DOCKER_IMAGES","timestamp":"2022-04-21T06:26:59.188Z","status":"SUCCESS","metadata":{}}\nstdout: {"operation":"DETERMINING_WORKSPACE_TYPE","timestamp":"2022-04-21T06:26:59.188Z","status":"STARTED","metadata":{}}\n',
+            startTime: subMinutes(now, 10).toISOString(),
+            __typename: 'ExecutionLogEntry',
+        },
+        teardown: [],
+        ...workspace?.stages,
+    },
+    executor: {
+        active: true,
+        architecture: 'arm64',
+        dockerVersion: '20.10.12',
+        executorVersion: '0.0.0+dev',
+        firstSeenAt: subDays(now, 10).toISOString(),
+        gitVersion: '2.35.1',
+        hostname: 'some-super-long-hostname.at-some-address.id-123450123123902304723749827498724',
+        id: 'test-1234',
+        igniteVersion: '',
+        lastSeenAt: subMinutes(now, 2).toISOString(),
+        os: 'darwin',
+        queueName: 'batches',
+        srcCliVersion: '3.38.0',
+        __typename: 'Executor',
+        ...workspace?.executor,
+    },
+    ...workspace,
+    repository: {
+        __typename: 'Repository',
+        name: 'github.com/sourcegraph-testing/batch-changes-test-repo',
+        url: '/github.com/sourcegraph-testing/batch-changes-test-repo',
+        ...workspace?.repository,
+    },
+    branch: {
+        __typename: 'GitRef',
+        displayName: 'main',
+        ...workspace?.branch,
+    },
+})
+
+export const QUEUED_WORKSPACE = mockWorkspace(1, {
+    state: BatchSpecWorkspaceState.QUEUED,
+    placeInQueue: 2,
+    startedAt: null,
+    finishedAt: null,
+    diffStat: null,
+    changesetSpecs: [],
+})
+
+export const PROCESSING_WORKSPACE = mockWorkspace(1, {
+    state: BatchSpecWorkspaceState.PROCESSING,
+    finishedAt: null,
+    diffStat: null,
+    changesetSpecs: [],
+})
+
+export const SKIPPED_WORKSPACE = mockWorkspace(1, {
+    state: BatchSpecWorkspaceState.SKIPPED,
+    queuedAt: null,
+    startedAt: null,
+    finishedAt: null,
+    stages: null,
+    executor: null,
+    diffStat: null,
+    changesetSpecs: null,
+    ignored: true,
+})
+
+export const UNSUPPORTED_WORKSPACE = mockWorkspace(1, {
+    state: BatchSpecWorkspaceState.SKIPPED,
+    queuedAt: null,
+    startedAt: null,
+    finishedAt: null,
+    stages: null,
+    executor: null,
+    diffStat: null,
+    changesetSpecs: null,
+    unsupported: true,
+})
+
+export const LOTS_OF_STEPS_WORKSPACE = mockWorkspace(20)
+
+export const HIDDEN_WORKSPACE: HiddenBatchSpecWorkspaceFields = {
+    __typename: 'HiddenBatchSpecWorkspace',
+    id: 'id123',
+    queuedAt: subMinutes(new Date(), 10).toISOString(),
+    startedAt: subMinutes(new Date(), 8).toISOString(),
+    finishedAt: subMinutes(new Date(), 2).toISOString(),
+    state: BatchSpecWorkspaceState.COMPLETED,
+    diffStat: {
+        __typename: 'DiffStat',
+        added: 10,
+        changed: 2,
+        deleted: 5,
+    },
+    placeInQueue: null,
+    onlyFetchWorkspace: false,
+    ignored: false,
+    unsupported: false,
+    cachedResultFound: false,
+}

--- a/client/web/src/enterprise/batches/execution/WorkspaceDetails.mock.ts
+++ b/client/web/src/enterprise/batches/execution/WorkspaceDetails.mock.ts
@@ -10,21 +10,25 @@ import {
 
 const now = new Date()
 
-export const mockStep = (number: number): BatchSpecWorkspaceStepFields => ({
+export const mockStep = (
+    number: number,
+    step?: Partial<BatchSpecWorkspaceStepFields>
+): BatchSpecWorkspaceStepFields => ({
+    __typename: 'BatchSpecWorkspaceStep',
     cachedResultFound: false,
     container: 'ubuntu:18.04',
-    diffStat: null,
+    diffStat: { __typename: 'DiffStat', added: 10, changed: 5, deleted: 5 },
     environment: [],
-    exitCode: null,
-    finishedAt: null,
+    exitCode: 0,
+    finishedAt: subMinutes(now, 1).toISOString(),
     ifCondition: null,
     number,
-    outputLines: [],
-    outputVariables: null,
+    outputLines: ['stdout: Hello World', 'stdout: '],
+    outputVariables: [],
     run: `echo Hello World Step ${number} | tee -a $(find -name README.md)`,
     skipped: false,
-    startedAt: null,
-    __typename: 'BatchSpecWorkspaceStep',
+    startedAt: subMinutes(now, 2).toISOString(),
+    ...step,
 })
 
 export const mockWorkspace = (
@@ -186,3 +190,23 @@ export const HIDDEN_WORKSPACE: HiddenBatchSpecWorkspaceFields = {
     unsupported: false,
     cachedResultFound: false,
 }
+
+export const FAILED_WORKSPACE = mockWorkspace(1, {
+    state: BatchSpecWorkspaceState.FAILED,
+    failureMessage: 'failed to perform src-cli step: command failed',
+    steps: [mockStep(1), mockStep(2, { exitCode: 1, diffStat: null })],
+})
+
+export const CANCELING_WORKSPACE = mockWorkspace(1, {
+    state: BatchSpecWorkspaceState.CANCELING,
+    finishedAt: null,
+    diffStat: null,
+    changesetSpecs: [],
+})
+
+export const CANCELED_WORKSPACE = mockWorkspace(1, {
+    state: BatchSpecWorkspaceState.CANCELED,
+    finishedAt: null,
+    diffStat: null,
+    changesetSpecs: [],
+})

--- a/client/web/src/enterprise/batches/execution/WorkspaceDetails.story.tsx
+++ b/client/web/src/enterprise/batches/execution/WorkspaceDetails.story.tsx
@@ -1,66 +1,37 @@
 import React from 'react'
 
 import { storiesOf } from '@storybook/react'
-import { subMinutes } from 'date-fns/esm'
 import { noop } from 'lodash'
 import { MATCH_ANY_PARAMETERS, WildcardMockLink } from 'wildcard-mock-link'
 
+import { BrandedStory } from '@sourcegraph/branded/src/components/BrandedStory'
 import { getDocumentNode } from '@sourcegraph/http-client'
 import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
+import { CardBody, Card } from '@sourcegraph/wildcard'
 
-import { WebStory } from '../../../components/WebStory'
-import {
-    BatchSpecWorkspaceByIDResult,
-    BatchSpecWorkspaceState,
-    HiddenBatchSpecWorkspaceFields,
-    VisibleBatchSpecWorkspaceFields,
-} from '../../../graphql-operations'
+import { BatchSpecWorkspaceByIDResult } from '../../../graphql-operations'
 
 import { BATCH_SPEC_WORKSPACE_BY_ID } from './backend'
 import { WorkspaceDetails } from './WorkspaceDetails'
+import {
+    HIDDEN_WORKSPACE,
+    QUEUED_WORKSPACE,
+    mockWorkspace,
+    PROCESSING_WORKSPACE,
+    SKIPPED_WORKSPACE,
+    UNSUPPORTED_WORKSPACE,
+    LOTS_OF_STEPS_WORKSPACE,
+} from './WorkspaceDetails.mock'
 
 const { add } = storiesOf('web/batches/execution/WorkspaceDetails', module).addDecorator(story => (
-    <div className="p-3 container">{story()}</div>
+    <div className="d-flex w-100" style={{ height: '95vh' }}>
+        <Card className="w-100 overflow-auto flex-grow-1" style={{ backgroundColor: 'var(--color-bg-1)' }}>
+            <div className="w-100">
+                <CardBody>{story()}</CardBody>
+            </div>
+        </Card>
+    </div>
 ))
-
-const HIDDEN_WORKSPACE: HiddenBatchSpecWorkspaceFields = {
-    __typename: 'HiddenBatchSpecWorkspace',
-    id: 'id123',
-    queuedAt: subMinutes(new Date(), 10).toISOString(),
-    startedAt: subMinutes(new Date(), 8).toISOString(),
-    finishedAt: subMinutes(new Date(), 2).toISOString(),
-    state: BatchSpecWorkspaceState.COMPLETED,
-    diffStat: {
-        __typename: 'DiffStat',
-        added: 10,
-        changed: 2,
-        deleted: 5,
-    },
-    placeInQueue: null,
-    onlyFetchWorkspace: false,
-    ignored: false,
-    unsupported: false,
-    cachedResultFound: false,
-}
-
-const VISIBLE_WORKSPACE: VisibleBatchSpecWorkspaceFields = {
-    ...HIDDEN_WORKSPACE,
-    __typename: 'VisibleBatchSpecWorkspace',
-    steps: [],
-    path: '',
-    branch: {
-        displayName: 'asdf',
-    },
-    executor: null,
-    stages: null,
-    searchResultPaths: ['asdf'],
-    failureMessage: null,
-    changesetSpecs: [],
-    repository: {
-        name: 'github.com/sourcegraph/automation-testing',
-        url: '/github.com/sourcegraph/automation-testing',
-    },
-}
 
 function addStory(name: string, node: BatchSpecWorkspaceByIDResult['node']) {
     add(name, () => {
@@ -70,27 +41,28 @@ function addStory(name: string, node: BatchSpecWorkspaceByIDResult['node']) {
                     query: getDocumentNode(BATCH_SPEC_WORKSPACE_BY_ID),
                     variables: MATCH_ANY_PARAMETERS,
                 },
-                result: {
-                    data: {
-                        node,
-                    },
-                },
+                result: { data: { node } },
                 nMatches: Number.POSITIVE_INFINITY,
             },
         ])
 
         return (
-            <WebStory>
+            <BrandedStory>
                 {props => (
                     <MockedTestProvider link={mocks}>
                         <WorkspaceDetails {...props} deselectWorkspace={noop} id="random" />
                     </MockedTestProvider>
                 )}
-            </WebStory>
+            </BrandedStory>
         )
     })
 }
 
 addStory('Hidden workspace', HIDDEN_WORKSPACE)
-addStory('Visible workspace', VISIBLE_WORKSPACE)
-addStory('Not found', null)
+addStory('Workspace not found', null)
+addStory('Visible workspace: complete', mockWorkspace())
+addStory('Visible workspace: complete with lots of steps', LOTS_OF_STEPS_WORKSPACE)
+addStory('Visible workspace: queued', QUEUED_WORKSPACE)
+addStory('Visible workspace: processing', PROCESSING_WORKSPACE)
+addStory('Visible workspace: skipped', SKIPPED_WORKSPACE)
+addStory('Visible workspace: unsupported', UNSUPPORTED_WORKSPACE)

--- a/client/web/src/enterprise/batches/execution/WorkspaceDetails.story.tsx
+++ b/client/web/src/enterprise/batches/execution/WorkspaceDetails.story.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 
 import { storiesOf } from '@storybook/react'
 import { noop } from 'lodash'
+import { of } from 'rxjs'
 import { MATCH_ANY_PARAMETERS, WildcardMockLink } from 'wildcard-mock-link'
 
 import { BrandedStory } from '@sourcegraph/branded/src/components/BrandedStory'
@@ -10,8 +11,12 @@ import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
 import { CardBody, Card } from '@sourcegraph/wildcard'
 
 import { BatchSpecWorkspaceByIDResult } from '../../../graphql-operations'
+import { queryChangesetSpecFileDiffs as _queryChangesetSpecFileDiffs } from '../preview/list/backend'
 
-import { BATCH_SPEC_WORKSPACE_BY_ID } from './backend'
+import {
+    BATCH_SPEC_WORKSPACE_BY_ID,
+    queryBatchSpecWorkspaceStepFileDiffs as _queryBatchSpecWorkspaceStepFileDiffs,
+} from './backend'
 import { WorkspaceDetails } from './WorkspaceDetails'
 import {
     HIDDEN_WORKSPACE,
@@ -21,7 +26,21 @@ import {
     SKIPPED_WORKSPACE,
     UNSUPPORTED_WORKSPACE,
     LOTS_OF_STEPS_WORKSPACE,
+    FAILED_WORKSPACE,
+    CANCELING_WORKSPACE,
+    CANCELED_WORKSPACE,
 } from './WorkspaceDetails.mock'
+
+const queryChangesetSpecFileDiffs = () =>
+    of({ totalCount: 0, pageInfo: { endCursor: null, hasNextPage: false }, nodes: [] })
+
+const queryBatchSpecWorkspaceStepFileDiffs = () =>
+    of({ totalCount: 0, pageInfo: { endCursor: null, hasNextPage: false }, nodes: [] })
+
+const MOCK_FILE_DIFF_QUERIES = {
+    queryBatchSpecWorkspaceStepFileDiffs,
+    queryChangesetSpecFileDiffs,
+}
 
 const { add } = storiesOf('web/batches/execution/WorkspaceDetails', module).addDecorator(story => (
     <div className="d-flex w-100" style={{ height: '95vh' }}>
@@ -33,7 +52,14 @@ const { add } = storiesOf('web/batches/execution/WorkspaceDetails', module).addD
     </div>
 ))
 
-function addStory(name: string, node: BatchSpecWorkspaceByIDResult['node']) {
+function addStory(
+    name: string,
+    node: BatchSpecWorkspaceByIDResult['node'],
+    queries: {
+        queryBatchSpecWorkspaceStepFileDiffs?: typeof _queryBatchSpecWorkspaceStepFileDiffs
+        queryChangesetSpecFileDiffs?: typeof _queryChangesetSpecFileDiffs
+    } = {}
+) {
     add(name, () => {
         const mocks = new WildcardMockLink([
             {
@@ -50,7 +76,7 @@ function addStory(name: string, node: BatchSpecWorkspaceByIDResult['node']) {
             <BrandedStory>
                 {props => (
                     <MockedTestProvider link={mocks}>
-                        <WorkspaceDetails {...props} deselectWorkspace={noop} id="random" />
+                        <WorkspaceDetails {...props} {...queries} deselectWorkspace={noop} id="random" />
                     </MockedTestProvider>
                 )}
             </BrandedStory>
@@ -60,9 +86,12 @@ function addStory(name: string, node: BatchSpecWorkspaceByIDResult['node']) {
 
 addStory('Hidden workspace', HIDDEN_WORKSPACE)
 addStory('Workspace not found', null)
-addStory('Visible workspace: complete', mockWorkspace())
-addStory('Visible workspace: complete with lots of steps', LOTS_OF_STEPS_WORKSPACE)
+addStory('Visible workspace: complete', mockWorkspace(), MOCK_FILE_DIFF_QUERIES)
+addStory('Visible workspace: complete with lots of steps', LOTS_OF_STEPS_WORKSPACE, MOCK_FILE_DIFF_QUERIES)
 addStory('Visible workspace: queued', QUEUED_WORKSPACE)
 addStory('Visible workspace: processing', PROCESSING_WORKSPACE)
 addStory('Visible workspace: skipped', SKIPPED_WORKSPACE)
 addStory('Visible workspace: unsupported', UNSUPPORTED_WORKSPACE)
+addStory('Visible workspace: failed', FAILED_WORKSPACE, MOCK_FILE_DIFF_QUERIES)
+addStory('Visible workspace: canceling', CANCELING_WORKSPACE)
+addStory('Visible workspace: canceled', CANCELED_WORKSPACE)

--- a/client/web/src/enterprise/batches/execution/WorkspaceDetails.tsx
+++ b/client/web/src/enterprise/batches/execution/WorkspaceDetails.tsx
@@ -76,8 +76,6 @@ export const WorkspaceDetails: React.FunctionComponent<WorkspaceDetailsProps> = 
     // Fetch and poll latest workspace information.
     const { loading, error, data } = useBatchSpecWorkspace(id)
 
-    console.log({ data })
-
     // If we're loading and haven't received any data yet
     if (loading && !data) {
         return <LoadingSpinner />

--- a/client/web/src/enterprise/batches/execution/WorkspaceDetails.tsx
+++ b/client/web/src/enterprise/batches/execution/WorkspaceDetails.tsx
@@ -18,7 +18,6 @@ import TimerSandIcon from 'mdi-react/TimerSandIcon'
 import { useHistory } from 'react-router'
 
 import { ErrorAlert } from '@sourcegraph/branded/src/components/alerts'
-import { asError, ErrorLike, isErrorLike } from '@sourcegraph/common'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
 import {
     Badge,
@@ -51,10 +50,14 @@ import {
     Scalars,
     VisibleBatchSpecWorkspaceFields,
 } from '../../../graphql-operations'
-import { queryChangesetSpecFileDiffs } from '../preview/list/backend'
+import { queryChangesetSpecFileDiffs as _queryChangesetSpecFileDiffs } from '../preview/list/backend'
 import { ChangesetSpecFileDiffConnection } from '../preview/list/ChangesetSpecFileDiffConnection'
 
-import { queryBatchSpecWorkspaceStepFileDiffs, retryWorkspaceExecution, useBatchSpecWorkspace } from './backend'
+import {
+    useBatchSpecWorkspace,
+    useRetryWorkspaceExecution,
+    queryBatchSpecWorkspaceStepFileDiffs as _queryBatchSpecWorkspaceStepFileDiffs,
+} from './backend'
 import { TimelineModal } from './TimelineModal'
 import { WorkspaceStateIcon } from './WorkspaceStateIcon'
 
@@ -64,6 +67,9 @@ export interface WorkspaceDetailsProps extends ThemeProps {
     id: Scalars['ID']
     /** Handler to deselect the current workspace, i.e. close the details panel. */
     deselectWorkspace?: () => void
+    /** For testing purposes only */
+    queryBatchSpecWorkspaceStepFileDiffs?: typeof _queryBatchSpecWorkspaceStepFileDiffs
+    queryChangesetSpecFileDiffs?: typeof _queryChangesetSpecFileDiffs
 }
 
 export const WorkspaceDetails: React.FunctionComponent<WorkspaceDetailsProps> = ({ id, ...props }) => {
@@ -184,17 +190,12 @@ const VisibleWorkspaceDetails: React.FunctionComponent<VisibleWorkspaceDetailsPr
     isLightTheme,
     workspace,
     deselectWorkspace,
+    queryBatchSpecWorkspaceStepFileDiffs,
+    queryChangesetSpecFileDiffs,
 }) => {
-    const [retrying, setRetrying] = useState<boolean | ErrorLike>(false)
-    const onRetry = useCallback(async () => {
-        setRetrying(true)
-        try {
-            await retryWorkspaceExecution(workspace.id)
-            setRetrying(false)
-        } catch (error) {
-            setRetrying(asError(error))
-        }
-    }, [workspace.id])
+    const [retryWorkspaceExecution, { loading: retryLoading, error: retryError }] = useRetryWorkspaceExecution(
+        workspace.id
+    )
 
     const [showTimeline, setShowTimeline] = useState<boolean>(false)
     const toggleShowTimeline = useCallback(() => {
@@ -226,15 +227,15 @@ const VisibleWorkspaceDetails: React.FunctionComponent<VisibleWorkspaceDetailsPr
                         <ErrorAlert error={workspace.failureMessage} className="flex-grow-1 mb-0" />
                         <Button
                             className="ml-2"
-                            onClick={onRetry}
-                            disabled={retrying === true}
+                            onClick={() => retryWorkspaceExecution()}
+                            disabled={retryLoading}
                             outline={true}
                             variant="danger"
                         >
                             <Icon as={SyncIcon} /> Retry
                         </Button>
                     </div>
-                    {isErrorLike(retrying) && <ErrorAlert error={retrying} />}
+                    {retryError && <ErrorAlert error={retryError} />}
                 </>
             )}
 
@@ -245,7 +246,11 @@ const VisibleWorkspaceDetails: React.FunctionComponent<VisibleWorkspaceDetailsPr
                     )}
                     {workspace.changesetSpecs.map((changesetSpec, index) => (
                         <React.Fragment key={changesetSpec.id}>
-                            <ChangesetSpecNode node={changesetSpec} isLightTheme={isLightTheme} />
+                            <ChangesetSpecNode
+                                node={changesetSpec}
+                                isLightTheme={isLightTheme}
+                                queryChangesetSpecFileDiffs={queryChangesetSpecFileDiffs}
+                            />
                             {index !== workspace.changesetSpecs!.length - 1 && <hr className="m-0" />}
                         </React.Fragment>
                     ))}
@@ -259,6 +264,7 @@ const VisibleWorkspaceDetails: React.FunctionComponent<VisibleWorkspaceDetailsPr
                         cachedResultFound={workspace.cachedResultFound}
                         workspaceID={workspace.id}
                         isLightTheme={isLightTheme}
+                        queryBatchSpecWorkspaceStepFileDiffs={queryBatchSpecWorkspaceStepFileDiffs}
                     />
                     {index !== workspace.steps.length - 1 && <hr className="my-2" />}
                 </React.Fragment>
@@ -332,9 +338,15 @@ const NumberInQueue: React.FunctionComponent<{ number: number }> = ({ number }) 
     )
 }
 
-const ChangesetSpecNode: React.FunctionComponent<{ node: BatchSpecWorkspaceChangesetSpecFields } & ThemeProps> = ({
+interface ChangesetSpecNodeProps extends ThemeProps {
+    node: BatchSpecWorkspaceChangesetSpecFields
+    queryChangesetSpecFileDiffs?: typeof _queryChangesetSpecFileDiffs
+}
+
+const ChangesetSpecNode: React.FunctionComponent<ChangesetSpecNodeProps> = ({
     node,
     isLightTheme,
+    queryChangesetSpecFileDiffs = _queryChangesetSpecFileDiffs,
 }) => {
     const history = useHistory()
 
@@ -430,6 +442,8 @@ interface WorkspaceStepProps extends ThemeProps {
     cachedResultFound: boolean
     step: BatchSpecWorkspaceStepFields
     workspaceID: Scalars['ID']
+    /** For testing purposes only */
+    queryBatchSpecWorkspaceStepFileDiffs?: typeof _queryBatchSpecWorkspaceStepFileDiffs
 }
 
 const WorkspaceStep: React.FunctionComponent<WorkspaceStepProps> = ({
@@ -437,6 +451,7 @@ const WorkspaceStep: React.FunctionComponent<WorkspaceStepProps> = ({
     isLightTheme,
     workspaceID,
     cachedResultFound,
+    queryBatchSpecWorkspaceStepFileDiffs,
 }) => {
     const outputLines = useMemo(() => {
         const outputLines = cloneDeep(step.outputLines)
@@ -514,6 +529,7 @@ const WorkspaceStep: React.FunctionComponent<WorkspaceStepProps> = ({
                                             isLightTheme={isLightTheme}
                                             step={step.number}
                                             workspaceID={workspaceID}
+                                            queryBatchSpecWorkspaceStepFileDiffs={queryBatchSpecWorkspaceStepFileDiffs}
                                         />
                                     )}
                                 </TabPanel>
@@ -599,12 +615,18 @@ const StepTimer: React.FunctionComponent<{ step: BatchSpecWorkspaceStepFields }>
     return <Duration start={step.startedAt} end={step.finishedAt ?? undefined} />
 }
 
-const WorkspaceStepFileDiffConnection: React.FunctionComponent<
-    {
-        workspaceID: Scalars['ID']
-        step: number
-    } & ThemeProps
-> = ({ workspaceID, step, isLightTheme }) => {
+interface WorkspaceStepFileDiffConnectionProps extends ThemeProps {
+    workspaceID: Scalars['ID']
+    step: number
+    queryBatchSpecWorkspaceStepFileDiffs?: typeof _queryBatchSpecWorkspaceStepFileDiffs
+}
+
+const WorkspaceStepFileDiffConnection: React.FunctionComponent<WorkspaceStepFileDiffConnectionProps> = ({
+    workspaceID,
+    step,
+    isLightTheme,
+    queryBatchSpecWorkspaceStepFileDiffs = _queryBatchSpecWorkspaceStepFileDiffs,
+}) => {
     const queryFileDiffs = useCallback(
         (args: FilteredConnectionQueryArguments) =>
             queryBatchSpecWorkspaceStepFileDiffs({
@@ -613,7 +635,7 @@ const WorkspaceStepFileDiffConnection: React.FunctionComponent<
                 node: workspaceID,
                 step,
             }),
-        [workspaceID, step]
+        [workspaceID, step, queryBatchSpecWorkspaceStepFileDiffs]
     )
     const history = useHistory()
     return (

--- a/client/web/src/enterprise/batches/execution/backend.ts
+++ b/client/web/src/enterprise/batches/execution/backend.ts
@@ -483,22 +483,17 @@ export const useRetryWorkspaceExecution = (
 ): MutationTuple<RetryWorkspaceExecutionResult, RetryWorkspaceExecutionVariables> =>
     useMutation(RETRY_WORKSPACE_EXECUTION, { variables: { id: workspaceID } })
 
-export async function retryBatchSpecExecution(id: Scalars['ID']): Promise<BatchSpecExecutionFields> {
-    return requestGraphQL<RetryBatchSpecExecutionResult, RetryBatchSpecExecutionVariables>(
-        gql`
-            mutation RetryBatchSpecExecution($id: ID!) {
-                retryBatchSpecExecution(batchSpec: $id) {
-                    ...BatchSpecExecutionFields
-                }
-            }
+const RETRY_BATCH_SPEC_EXECUTION = gql`
+    mutation RetryBatchSpecExecution($id: ID!) {
+        retryBatchSpecExecution(batchSpec: $id) {
+            ...BatchSpecExecutionFields
+        }
+    }
 
-            ${batchSpecExecutionFieldsFragment}
-        `,
-        { id }
-    )
-        .pipe(
-            map(dataOrThrowErrors),
-            map(({ retryBatchSpecExecution }) => retryBatchSpecExecution)
-        )
-        .toPromise()
-}
+    ${batchSpecExecutionFieldsFragment}
+`
+
+export const useRetryBatchSpecExecution = (
+    batchSpecID: Scalars['ID']
+): MutationTuple<RetryBatchSpecExecutionResult, RetryBatchSpecExecutionVariables> =>
+    useMutation(RETRY_BATCH_SPEC_EXECUTION, { variables: { id: batchSpecID } })

--- a/client/web/src/enterprise/batches/execution/backend.ts
+++ b/client/web/src/enterprise/batches/execution/backend.ts
@@ -9,7 +9,6 @@ import { fileDiffFields } from '../../../backend/diff'
 import { requestGraphQL } from '../../../backend/graphql'
 import { useConnection, UseConnectionResult } from '../../../components/FilteredConnection/hooks/useConnection'
 import {
-    BatchSpecExecutionFields,
     BatchSpecWorkspaceByIDResult,
     BatchSpecWorkspaceByIDVariables,
     BatchSpecWorkspacesResult,
@@ -273,21 +272,20 @@ export const useBatchSpecWorkspace = (id: Scalars['ID']): BatchSpecWorkspaceHook
     return result
 }
 
-export async function cancelBatchSpecExecution(id: Scalars['ID']): Promise<BatchSpecExecutionFields> {
-    const result = await requestGraphQL<CancelBatchSpecExecutionResult, CancelBatchSpecExecutionVariables>(
-        gql`
-            mutation CancelBatchSpecExecution($id: ID!) {
-                cancelBatchSpecExecution(batchSpec: $id) {
-                    ...BatchSpecExecutionFields
-                }
-            }
+const CANCEL_BATCH_SPEC_EXECUTION = gql`
+    mutation CancelBatchSpecExecution($id: ID!) {
+        cancelBatchSpecExecution(batchSpec: $id) {
+            ...BatchSpecExecutionFields
+        }
+    }
 
-            ${batchSpecExecutionFieldsFragment}
-        `,
-        { id }
-    ).toPromise()
-    return dataOrThrowErrors(result).cancelBatchSpecExecution
-}
+    ${batchSpecExecutionFieldsFragment}
+`
+
+export const useCancelBatchSpecExecution = (
+    batchSpecID: Scalars['ID']
+): MutationTuple<CancelBatchSpecExecutionResult, CancelBatchSpecExecutionVariables> =>
+    useMutation(CANCEL_BATCH_SPEC_EXECUTION, { variables: { id: batchSpecID } })
 
 const batchSpecWorkspaceStepFileDiffsFields = gql`
     fragment BatchSpecWorkspaceStepFileDiffsFields on VisibleBatchSpecWorkspace {


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/32343.

Migrates queries and mutations called on the execution screen, with the exception of file diff connection queries, to Apollo Client and `useQuery` hook.

Don't be alarmed by the diff stat -- ~300 lines of that is in mock data and the storybook story. This PR is net negative lines of code without them. 🙂

## Test plan

Introduced additional storybook coverage for `WorkspaceDetails` in different states. Tested requests and polling manually.


## App preview:

- [Web](https://sg-web-kr-execution-requests-apollo.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-xgoxnwryxu.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

