### PR TITLE
docs: add instructions about account lockout

### DIFF
--- a/cmd/frontend/internal/auth/userpasswd/lockout.go
+++ b/cmd/frontend/internal/auth/userpasswd/lockout.go
@@ -80,7 +80,7 @@ type unlockAccountClaims struct {
 func (s *lockoutStore) GenerateUnlockAccountURL(userID int32) (string, string, error) {
 	signingKey := conf.SiteConfig().AuthUnlockAccountLinkSigningKey
 	if signingKey == "" {
-		return "", "", errors.Newf("signing key not provided, cannot validate JWT on unlock account URL. Please add AuthUnlockAccountLinkSigningKey to site configuration.")
+		return "", "", errors.Newf(`signing key not provided, cannot validate JWT on unlock account URL. Please add "auth.unlockAccountLinkSigningKey" to site configuration.`)
 	}
 
 	defaultExpiryMinutes := 30

--- a/cmd/frontend/internal/auth/userpasswd/lockout_test.go
+++ b/cmd/frontend/internal/auth/userpasswd/lockout_test.go
@@ -100,7 +100,7 @@ func TestLockoutStore(t *testing.T) {
 
 		path, _, err := s.GenerateUnlockAccountURL(1)
 
-		assert.EqualError(t, err, "signing key not provided, cannot validate JWT on unlock account URL. Please add AuthUnlockAccountLinkSigningKey to site configuration.")
+		assert.EqualError(t, err, `signing key not provided, cannot validate JWT on unlock account URL. Please add "auth.unlockAccountLinkSigningKey" to site configuration.`)
 		assert.Empty(t, path)
 
 	})

--- a/doc/admin/auth/index.md
+++ b/doc/admin/auth/index.md
@@ -68,7 +68,7 @@ Site configuration example:
 
 <span class="badge badge-note">Sourcegraph 3.39+</span>
 
-Account will be lockout for 30 minutes after 5 consecutive failed sign-in attempts within one hour for builtin authentication provider. The threshold and duration of periods can be customized via `"auth.lockout"` in the site configuration:
+Account will be locked out for 30 minutes after 5 consecutive failed sign-in attempts within one hour for the builtin authentication provider. The threshold and duration of lockout and consecutive periods can be customized via `"auth.lockout"` in the site configuration:
 
 ```json
 {

--- a/doc/admin/auth/index.md
+++ b/doc/admin/auth/index.md
@@ -90,12 +90,20 @@ To enabled self-serve account unlock through emails, add the following lines to 
 {
   // Validity expressed in minutes of the unlock account token
   "auth.unlockAccountLinkExpiry": 30,
-  // Base64 encoded HMAC Signing key to sign a JWT token, which is attached to each invitation URL
+  // Base64-encoded HMAC signing key to sign the JWT token for account unlock URLs
   "auth.unlockAccountLinkSigningKey": "your-signing-key",
 }
 ```
 
-To generate the signing key, TODO
+The `ssh-keygen` command can be used to generate and encode the signing key, for example:
+
+```bash
+$ ssh-keygen -t ed25519 -a 128 -f auth.unlockAccountLinkSigningKey
+$ base64 auth.unlockAccountLinkSigningKey | tr -d '\n'
+LS0tLS1CRUdJTiBPUEVOU1NIIFBSSVZBVEUgS0VZLS0tLS0KYjNCbGJu...
+```
+
+Copy the result of the `base64` command as the value of the `"auth.unlockAccountLinkSigningKey"`.
 
 ## GitHub
 

--- a/doc/admin/auth/index.md
+++ b/doc/admin/auth/index.md
@@ -64,6 +64,39 @@ Site configuration example:
 }
 ```
 
+### Account lockout
+
+<span class="badge badge-note">Sourcegraph 3.39+</span>
+
+Account will be lockout for 30 minutes after 5 consecutive failed sign-in attempts within one hour for builtin authentication provider. The threshold and duration of periods can be customized via `"auth.lockout"` in the site configuration:
+
+```json
+{
+  // ...
+  "auth.lockout": {
+    // The number of seconds to be considered as a consecutive period
+    "consecutivePeriod": 3600,
+    // The threshold of failed sign-in attempts in a consecutive period
+    "failedAttemptThreshold": 5,
+    // The number of seconds for the lockout period
+    "lockoutPeriod": 1800
+  }
+}
+```
+
+To enabled self-serve account unlock through emails, add the following lines to your site configuration:
+
+```json
+{
+  // Validity expressed in minutes of the unlock account token
+  "auth.unlockAccountLinkExpiry": 30,
+  // Base64 encoded HMAC Signing key to sign a JWT token, which is attached to each invitation URL
+  "auth.unlockAccountLinkSigningKey": "your-signing-key",
+}
+```
+
+To generate the signing key, TODO
+
 ## GitHub
 
 [Create a GitHub OAuth

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1763,7 +1763,7 @@ type SiteConfiguration struct {
 	AuthSessionExpiry string `json:"auth.sessionExpiry,omitempty"`
 	// AuthUnlockAccountLinkExpiry description: Validity expressed in minutes of the unlock account token
 	AuthUnlockAccountLinkExpiry int `json:"auth.unlockAccountLinkExpiry,omitempty"`
-	// AuthUnlockAccountLinkSigningKey description: Base64 encoded HMAC Signing key to sign a JWT token, which is attached to each invitation URL.
+	// AuthUnlockAccountLinkSigningKey description: Base64-encoded HMAC signing key to sign the JWT token for account unlock URLs
 	AuthUnlockAccountLinkSigningKey string `json:"auth.unlockAccountLinkSigningKey,omitempty"`
 	// AuthUserOrgMap description: Ensure that matching users are members of the specified orgs (auto-joining users to the orgs if they are not already a member). Provide a JSON object of the form `{"*": ["org1", "org2"]}`, where org1 and org2 are orgs that all users are automatically joined to. Currently the only supported key is `"*"`.
 	AuthUserOrgMap map[string][]string `json:"auth.userOrgMap,omitempty"`

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -1409,7 +1409,7 @@
       "group": "Authentication"
     },
     "auth.unlockAccountLinkSigningKey": {
-      "description": "Base64 encoded HMAC Signing key to sign a JWT token, which is attached to each invitation URL.",
+      "description": "Base64-encoded HMAC signing key to sign the JWT token for account unlock URLs",
       "type": "string",
       "group": "Authentication"
     },


### PR DESCRIPTION
Add relevant section in admin docs for account lockout.

## Test plan

Docs update.

---

Part of CLOUD-222, followup of https://github.com/sourcegraph/sourcegraph/pull/33810 and https://github.com/sourcegraph/sourcegraph/pull/33999.