### PR TITLE
auth: add metrics for account lockout

### DIFF
--- a/cmd/frontend/internal/auth/userpasswd/lockout.go
+++ b/cmd/frontend/internal/auth/userpasswd/lockout.go
@@ -61,6 +61,8 @@ func (s *lockoutStore) IsLockedOut(userID int32) (reason string, locked bool) {
 }
 
 func (s *lockoutStore) IncreaseFailedAttempt(userID int32) {
+	metricsAccountFailedSignInAttempts.Inc()
+
 	key := strconv.Itoa(int(userID))
 	s.failedAttempts.Increase(key)
 
@@ -68,6 +70,7 @@ func (s *lockoutStore) IncreaseFailedAttempt(userID int32) {
 	v, _ := s.failedAttempts.Get(key)
 	count, _ := strconv.Atoi(string(v))
 	if count >= s.failedThreshold {
+		metricsAccountLockouts.Inc()
 		s.lockouts.Set(key, []byte("too many failed attempts"))
 	}
 }

--- a/cmd/frontend/internal/auth/userpasswd/metrics.go
+++ b/cmd/frontend/internal/auth/userpasswd/metrics.go
@@ -1,0 +1,17 @@
+package userpasswd
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	metricsAccountFailedSignInAttempts = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "src_frontend_account_failed_sign_in_attempts_total",
+		Help: "Total number of failed sign-in attempts",
+	})
+	metricsAccountLockouts = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "src_frontend_account_lockouts_total",
+		Help: "Total number of account lockout",
+	})
+)

--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -2791,7 +2791,7 @@ Query: ` sum by (code)(irate(src_http_request_duration_seconds_count{route="sign
 
 #### frontend: account_failed_sign_in_attempts
 
-<p class="subtitle">Rate of failed sign_in attempts</p>
+<p class="subtitle">Rate of failed sign-in attempts</p>
 
 Failed sign-in attempts per minute
 
@@ -2805,6 +2805,27 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=101930`
 <summary>Technical details</summary>
 
 Query: `sum(rate(src_frontend_account_failed_sign_in_attempts_total[1m]))`
+
+</details>
+
+<br />
+
+#### frontend: account_lockouts
+
+<p class="subtitle">Rate of account lockouts</p>
+
+Account lockouts per minute
+
+This panel has no related alerts.
+
+To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=101931` on your Sourcegraph instance.
+
+<sub>*Managed by the [Sourcegraph Cloud Software-as-a-Service team](https://handbook.sourcegraph.com/engineering/cloud/saas).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Query: `sum(rate(src_frontend_account_lockouts_total[1m]))`
 
 </details>
 

--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -2789,6 +2789,27 @@ Query: ` sum by (code)(irate(src_http_request_duration_seconds_count{route="sign
 
 <br />
 
+#### frontend: account_failed_sign_in_attempts
+
+<p class="subtitle">Rate of failed sign_in attempts</p>
+
+Failed sign-in attempts per minute
+
+This panel has no related alerts.
+
+To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=101930` on your Sourcegraph instance.
+
+<sub>*Managed by the [Sourcegraph Cloud Software-as-a-Service team](https://handbook.sourcegraph.com/engineering/cloud/saas).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Query: `sum(rate(src_frontend_account_failed_sign_in_attempts_total[1m]))`
+
+</details>
+
+<br />
+
 ### Frontend: Organisation GraphQL API requests
 
 #### frontend: org_members_rate

--- a/monitoring/definitions/frontend.go
+++ b/monitoring/definitions/frontend.go
@@ -564,6 +564,26 @@ func Frontend() *monitoring.Container {
 							Interpretation: `Percentage of sign-out requests grouped by http code`,
 						},
 					},
+					{
+						{
+							Name:           "account_failed_sign_in_attempts",
+							Description:    "rate of failed sign-in attempts",
+							Query:          `sum(rate(src_frontend_account_failed_sign_in_attempts_total[1m]))`,
+							NoAlert:        true,
+							Panel:          monitoring.Panel().Unit(monitoring.Number),
+							Owner:          monitoring.ObservableOwnerCloudSaaS,
+							Interpretation: `Failed sign-in attempts per minute`,
+						},
+						{
+							Name:           "account_lockouts",
+							Description:    "rate of account lockouts",
+							Query:          `sum(rate(src_frontend_account_lockouts_total[1m]))`,
+							NoAlert:        true,
+							Panel:          monitoring.Panel().Unit(monitoring.Number),
+							Owner:          monitoring.ObservableOwnerCloudSaaS,
+							Interpretation: `Account lockouts per minute`,
+						},
+					},
 				}},
 			{
 				Title:  "Organisation GraphQL API requests",


### PR DESCRIPTION
New metrics are added for:

- Failed sign-in attempts
- Account lockouts

Below is how they look like in Grafana:

<img width="1218" alt="CleanShot 2022-04-25 at 15 55 55@2x" src="https://user-images.githubusercontent.com/2946214/165045092-ea7ab9be-4242-4513-a953-99c48c9d761a.png">


## Test plan

Manual e2e tests

---

Part of CLOUD-222