### PR TITLE
Increase max-age of static assets to 1 year

### DIFF
--- a/cmd/frontend/internal/app/assetsutil/handler.go
+++ b/cmd/frontend/internal/app/assetsutil/handler.go
@@ -55,7 +55,7 @@ func Mount(mux *http.ServeMux) {
 			if isPhabricatorAsset(r.URL.Path) {
 				w.Header().Set("Cache-Control", "max-age=300, public")
 			} else {
-				w.Header().Set("Cache-Control", "immutable, max-age=172800, public")
+				w.Header().Set("Cache-Control", "immutable, max-age=31536000, public")
 			}
 		}
 


### PR DESCRIPTION
## Test plan

All linked assets should be checked to see if they cachebust in case they were not caught with it set to 2 days. All assets I checked could safely be set to 1 year.