### PR TITLE
JetBrains: Add initial web view modal setup

### DIFF
--- a/client/jetbrains/src/main/java/com/sourcegraph/action/OpenFile.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/action/OpenFile.java
@@ -6,7 +6,7 @@ import java.awt.*;
 import java.io.IOException;
 import java.net.URI;
 
-public class Open extends FileAction {
+public class OpenFile extends FileAction {
 
     @Override
     void handleFileUri(String uri) {

--- a/client/jetbrains/src/main/java/com/sourcegraph/action/OpenSearchAction.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/action/OpenSearchAction.java
@@ -1,0 +1,23 @@
+package com.sourcegraph.action;
+
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.application.AppUIExecutor;
+import com.intellij.openapi.project.DumbAware;
+import com.intellij.openapi.project.ProjectManager;
+import com.sourcegraph.ui.SourcegraphWindow;
+import org.jetbrains.annotations.NotNull;
+
+public class OpenSearchAction extends AnAction implements DumbAware {
+    private SourcegraphWindow window;
+
+    @Override
+    public void actionPerformed(@NotNull AnActionEvent e) {
+        AppUIExecutor.onUiThread().execute(() -> {
+            if (this.window == null) {
+                this.window = new SourcegraphWindow(e.getProject());
+            }
+            this.window.createPopup().showCenteredInCurrentWindow(ProjectManager.getInstance().getOpenProjects()[0]);
+        });
+    }
+}

--- a/client/jetbrains/src/main/java/com/sourcegraph/action/SearchSelection.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/action/SearchSelection.java
@@ -2,7 +2,7 @@ package com.sourcegraph.action;
 
 import com.intellij.openapi.actionSystem.AnActionEvent;
 
-public class Search extends SearchActionBase {
+public class SearchSelection extends SearchActionBase {
     @Override
     public void actionPerformed(AnActionEvent e) {
         super.actionPerformedMode(e, "search");

--- a/client/jetbrains/src/main/java/com/sourcegraph/project/SourcegraphConfig.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/project/SourcegraphConfig.java
@@ -47,6 +47,6 @@ class SourcegraphConfig implements PersistentStateComponent<SourcegraphConfig> {
 
     @Nullable
     public static SourcegraphConfig getInstance(Project project) {
-        return ServiceManager.getService(project, SourcegraphConfig.class);
+        return project.getService(SourcegraphConfig.class);
     }
 }

--- a/client/jetbrains/src/main/java/com/sourcegraph/scheme/SchemeHandler.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/scheme/SchemeHandler.java
@@ -1,0 +1,99 @@
+package com.sourcegraph.scheme;
+
+import org.cef.callback.CefCallback;
+import org.cef.handler.CefResourceHandlerAdapter;
+import org.cef.misc.IntRef;
+import org.cef.misc.StringRef;
+import org.cef.network.CefRequest;
+import org.cef.network.CefResponse;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+public class SchemeHandler extends CefResourceHandlerAdapter {
+    private byte[] data;
+    private String mimeType;
+    private int responseHeader = 400;
+    private int offset = 0;
+
+    public synchronized boolean processRequest(CefRequest request, CefCallback callback) {
+        boolean handled = false;
+        String url = request.getURL();
+        String path = url.replace("http://sourcegraph", "");
+
+        if (url.endsWith(".html")) {
+            handled = loadContent(path);
+            this.mimeType = "text/html";
+            if (!handled) {
+                String html = "<html><head><title>Error 404</title></head>" +
+                    "<body>" +
+                    "<h1>Error 404</h1>" +
+                    "File " + path + "  does not exist." +
+                    "</body></html>";
+                this.data = html.getBytes();
+                this.responseHeader = 404;
+                handled = true;
+            }
+        }
+
+        if (path.endsWith(".js") || path.endsWith(".css")) {
+            handled = loadContent(path);
+            this.mimeType = url.endsWith(".js") ? "text/javascript" : "text/css";
+            if (!handled) {
+                this.data = "".getBytes();
+                this.responseHeader = 404;
+                handled = true;
+            }
+        }
+
+        if (handled) {
+            this.responseHeader = 200;
+            callback.Continue();
+            return true;
+        }
+
+        return false;
+    }
+
+    public void getResponseHeaders(
+        CefResponse response, IntRef responseLength, StringRef redirectUrl) {
+        response.setMimeType(this.mimeType);
+        response.setStatus(this.responseHeader);
+        responseLength.set(this.data.length);
+    }
+
+    public synchronized boolean readResponse(
+        byte[] dataOut, int bytesToRead, IntRef bytesRead, CefCallback callback) {
+        boolean hasData = false;
+
+        if (this.offset < this.data.length) {
+            int transferSize = Math.min(bytesToRead, (this.data.length - this.offset));
+            System.arraycopy(this.data, this.offset, dataOut, 0, transferSize);
+            this.offset += transferSize;
+            bytesRead.set(transferSize);
+            hasData = true;
+        } else {
+            this.offset = 0;
+            bytesRead.set(0);
+        }
+
+        return hasData;
+    }
+
+    private boolean loadContent(String resName) {
+        InputStream inStream = getClass().getResourceAsStream(resName);
+        System.out.println(resName);
+        if (inStream != null) {
+            try {
+                ByteArrayOutputStream outFile = new ByteArrayOutputStream();
+                int readByte = -1;
+                while ((readByte = inStream.read()) >= 0) outFile.write(readByte);
+                this.data = outFile.toByteArray();
+                return true;
+            } catch (IOException e) {
+            }
+        }
+        return false;
+    }
+}

--- a/client/jetbrains/src/main/java/com/sourcegraph/scheme/SchemeHandlerFactory.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/scheme/SchemeHandlerFactory.java
@@ -1,0 +1,15 @@
+package com.sourcegraph.scheme;
+
+import org.cef.browser.CefBrowser;
+import org.cef.browser.CefFrame;
+import org.cef.callback.CefSchemeHandlerFactory;
+import org.cef.handler.CefResourceHandler;
+import org.cef.network.CefRequest;
+
+public class SchemeHandlerFactory implements CefSchemeHandlerFactory {
+    @Override
+    public CefResourceHandler create(CefBrowser browser, CefFrame frame, String schemeName, CefRequest request) {
+        return new SchemeHandler();
+    }
+}
+

--- a/client/jetbrains/src/main/java/com/sourcegraph/service/JCEFService.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/service/JCEFService.java
@@ -1,0 +1,17 @@
+package com.sourcegraph.service;
+
+import com.intellij.openapi.project.Project;
+import com.sourcegraph.ui.JCEFWindow;
+
+public class JCEFService {
+    private Project project;
+    private JCEFWindow window;
+    public JCEFService(Project project) {
+        this.project = project;
+        this.window = new JCEFWindow(project);
+    }
+
+    public JCEFWindow getWindow() {
+        return this.window;
+    }
+}

--- a/client/jetbrains/src/main/java/com/sourcegraph/ui/JCEFWindow.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/ui/JCEFWindow.java
@@ -1,0 +1,59 @@
+package com.sourcegraph.ui;
+
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.Disposer;
+import com.intellij.ui.jcef.JBCefApp;
+import com.intellij.ui.jcef.JBCefBrowser;
+import com.intellij.ui.jcef.JBCefBrowserBase;
+import com.intellij.util.ui.UIUtil;
+import com.sourcegraph.scheme.SchemeHandlerFactory;
+import org.cef.CefApp;
+import org.cef.browser.CefBrowser;
+
+import javax.swing.*;
+import java.awt.*;
+
+public class JCEFWindow {
+    private JPanel panel;
+    private Project project;
+    private JBCefBrowserBase browser;
+    private CefBrowser cefBrowser;
+
+    public JCEFWindow(Project project) {
+        this.project = project;
+        panel = new JPanel(new BorderLayout());
+
+        if (!JBCefApp.isSupported()) {
+            JLabel warningLabel = new JLabel("Unfortunately, the browser is not available on your system. Try running the IDE with the default OpenJDK.");
+            panel.add(warningLabel);
+            return;
+        }
+
+        this.browser = new JBCefBrowser("http://sourcegraph/html/index.html") ;
+        this.cefBrowser= browser.getCefBrowser();
+
+        CefApp
+            .getInstance()
+            .registerSchemeHandlerFactory(
+    "http",
+    "sourcegraph",
+                new SchemeHandlerFactory()
+            );
+
+        panel.add(this.browser.getComponent(),BorderLayout.CENTER);
+
+
+        String backgroundColor = "#" + Integer.toHexString(UIUtil.getPanelBackground().getRGB()).substring(2);
+        this.browser.setPageBackgroundColor(backgroundColor);
+
+        Disposer.register(project, this.browser);
+    }
+
+    public JPanel getContent() {
+        return panel;
+    }
+
+    public void focus() {
+        this.cefBrowser.setFocus(true);
+    }
+}

--- a/client/jetbrains/src/main/java/com/sourcegraph/ui/SourcegraphWindow.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/ui/SourcegraphWindow.java
@@ -1,0 +1,98 @@
+package com.sourcegraph.ui;
+
+import com.intellij.codeInsight.highlighting.HighlightManager;
+import com.intellij.openapi.Disposable;
+import com.intellij.openapi.editor.*;
+import com.intellij.openapi.editor.colors.EditorColors;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.ui.Splitter;
+import com.intellij.openapi.ui.popup.JBPopup;
+import com.intellij.openapi.ui.popup.JBPopupFactory;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.testFramework.LightVirtualFile;
+import com.intellij.ui.*;
+import com.intellij.ui.components.JBPanel;
+import com.intellij.ui.components.JBPanelWithEmptyText;
+import com.intellij.util.ui.JBUI;
+import com.sourcegraph.service.JCEFService;
+
+import javax.swing.*;
+import java.awt.*;
+
+public class SourcegraphWindow implements Disposable {
+    private final Project project;
+    private final JPanel panel;
+    private JCEFWindow jcefWindow;
+    private final EditorFactory editorFactory;
+    private JBPanel editorPanel;
+
+    public SourcegraphWindow(Project project) {
+        this.project = project;
+
+        panel = new JPanel(new BorderLayout());
+        panel.setPreferredSize(JBUI.size(1200, 800));
+        panel.setBorder(PopupBorder.Factory.create(true, true));
+        panel.setFocusCycleRoot(true);
+
+        editorFactory = EditorFactory.getInstance();
+        editorPanel = new JBPanelWithEmptyText(new BorderLayout());
+
+        JCEFService service = project.getService(JCEFService.class);
+        this.jcefWindow = service.getWindow();
+
+        JPanel topPanel = new JPanel(new BorderLayout());
+        topPanel.add(this.jcefWindow.getContent());
+
+
+        String contentTs = "let message: string = 'Hello, TypeScript!';\n" +
+            "\n" +
+            "let heading = document.createElement('h1');\n" +
+            "heading.textContent = message;\n" +
+            "\n" +
+            "document.body.appendChild(heading);";
+        VirtualFile virtualFile = new LightVirtualFile("helloWorld.ts", contentTs);
+        Document document = editorFactory.createDocument(contentTs);
+
+        Editor editor = editorFactory.createEditor(document, project, virtualFile, true, EditorKind.MAIN_EDITOR);
+        EditorSettings settings = editor.getSettings();
+        settings.setLineMarkerAreaShown(true);
+        settings.setFoldingOutlineShown(false);
+        settings.setAdditionalColumnsCount(0);
+        settings.setAdditionalLinesCount(0);
+        settings.setAnimatedScrolling(false);
+        settings.setAutoCodeFoldingEnabled(false);
+        editorPanel.add(editor.getComponent(), BorderLayout.CENTER);
+        editorPanel.invalidate();
+        editorPanel.validate();
+        HighlightManager highlightManager = HighlightManager.getInstance(project);
+        highlightManager.addOccurrenceHighlight(editor, 23, 41, EditorColors.SEARCH_RESULT_ATTRIBUTES, 0, null);
+
+        Splitter splitter = new OnePixelSplitter(true, 0.5f, 0.1f, 0.9f);
+        splitter.setFirstComponent(topPanel);
+        splitter.setSecondComponent(editorPanel);
+
+        panel.add(splitter, BorderLayout.CENTER);
+    }
+
+    public JBPopup createPopup() {
+        JBPopup popup =  JBPopupFactory.getInstance().createComponentPopupBuilder(panel, panel)
+            .setTitle("Sourcegraph")
+            .setCancelOnClickOutside(false)
+            .setResizable(true)
+            .setModalContext(false)
+            .setRequestFocus(true)
+            .setFocusable(true)
+            .setMovable(true)
+            .setBelongsToGlobalPopupStack(true)
+            .setCancelOnOtherWindowOpen(true)
+            .setCancelKeyEnabled(true)
+            .setNormalWindowLevel(true)
+            .createPopup();
+        this.jcefWindow.focus();
+        return popup;
+    }
+
+    @Override
+    public void dispose() {
+    }
+}

--- a/client/jetbrains/src/main/resources/META-INF/plugin.xml
+++ b/client/jetbrains/src/main/resources/META-INF/plugin.xml
@@ -10,34 +10,38 @@
   <extensions defaultExtensionNs="com.intellij">
     <projectService serviceImplementation="com.sourcegraph.project.SourcegraphConfig"/>
     <notificationGroup id="Sourcegraph" displayType="BALLOON"/>
+    <projectService id="sourcegraph.JCEFService" serviceImplementation="com.sourcegraph.service.JCEFService"/>
   </extensions>
 
   <actions>
-    <action id="sourcegraph.open" class="com.sourcegraph.action.Open" text="Open File" description="Open selection in Sourcegraph">
+    <action id="sourcegraph.openFile" class="com.sourcegraph.action.OpenFile" text="Open File" description="Open selection in Sourcegraph">
       <keyboard-shortcut first-keystroke="alt shift a" keymap="$default"/>
     </action>
-    <action id="sourcegraph.search" class="com.sourcegraph.action.Search" text="Search Selection" description="Search selection on Sourcegraph">
+    <action id="sourcegraph.searchSelection" class="com.sourcegraph.action.SearchSelection" text="Search selection" description="Search selection on Sourcegraph">
       <keyboard-shortcut first-keystroke="alt s" keymap="$default"/>
     </action>
-    <action id="sourcegraph.searchRepository" class="com.sourcegraph.action.SearchRepository" text="Search in Repository" description="Search selection in repository on Sourcegraph">
+    <action id="sourcegraph.searchRepository" class="com.sourcegraph.action.SearchRepository" text="Search selection in repository" description="Search selection in repository on Sourcegraph">
       <keyboard-shortcut first-keystroke="alt r" keymap="$default"/>
     </action>
     <action id="sourcegraph.copy" class="com.sourcegraph.action.Copy" text="Copy Link to File" description="Copy link to Sourcegraph">
       <keyboard-shortcut first-keystroke="alt c" keymap="$default"/>
     </action>
     <group id="SourcegraphEditor" icon="/icons/icon.png" popup="true" text="Sourcegraph">
-      <reference ref="sourcegraph.search"/>
+      <reference ref="sourcegraph.openSearch"/>
+      <reference ref="sourcegraph.searchSelection"/>
       <reference ref="sourcegraph.searchRepository"/>
-      <reference ref="sourcegraph.open"/>
+      <reference ref="sourcegraph.openFile"/>
       <reference ref="sourcegraph.copy"/>
       <add-to-group anchor="last" group-id="EditorPopupMenu"/>
     </group>
-    <action id="com.sourcegraph.action.OpenRevisionAction" icon="/icons/icon.png" class="com.sourcegraph.action.OpenRevisionAction" text="Open In Sourcegraph" description="Open revision diff in Sourcegraph">
+    <action id="com.sourcegraph.action.OpenRevisionAction" icon="/icons/icon.png" class="com.sourcegraph.action.OpenRevisionAction" text="Open in Sourcegraph" description="Open revision diff in Sourcegraph">
       <add-to-group group-id="VcsHistoryActionsGroup" anchor="last"/>
       <add-to-group group-id="Vcs.Log.ContextMenu" anchor="last"/>
       <add-to-group group-id="VcsHistoryActionsGroup.Toolbar" anchor="last"/>
       <add-to-group group-id="VcsSelectionHistoryDialog.Popup" anchor="last"/>
     </action>
+    <action id="sourcegraph.openSearch" class="com.sourcegraph.action.OpenSearchAction" text="Search in Sourcegraph">
+      <keyboard-shortcut first-keystroke="alt a" keymap="$default"/>
+    </action>
   </actions>
-
 </idea-plugin>

--- a/client/jetbrains/src/main/resources/META-INF/plugin.xml
+++ b/client/jetbrains/src/main/resources/META-INF/plugin.xml
@@ -27,7 +27,6 @@
       <keyboard-shortcut first-keystroke="alt c" keymap="$default"/>
     </action>
     <group id="SourcegraphEditor" icon="/icons/icon.png" popup="true" text="Sourcegraph">
-      <reference ref="sourcegraph.openSearch"/>
       <reference ref="sourcegraph.searchSelection"/>
       <reference ref="sourcegraph.searchRepository"/>
       <reference ref="sourcegraph.openFile"/>

--- a/client/jetbrains/src/main/resources/META-INF/plugin.xml
+++ b/client/jetbrains/src/main/resources/META-INF/plugin.xml
@@ -14,7 +14,7 @@
 
   <actions>
     <action id="sourcegraph.open" class="com.sourcegraph.action.Open" text="Open File" description="Open selection in Sourcegraph">
-      <keyboard-shortcut first-keystroke="alt A" keymap="$default"/>
+      <keyboard-shortcut first-keystroke="alt shift a" keymap="$default"/>
     </action>
     <action id="sourcegraph.search" class="com.sourcegraph.action.Search" text="Search Selection" description="Search selection on Sourcegraph">
       <keyboard-shortcut first-keystroke="alt s" keymap="$default"/>

--- a/client/jetbrains/src/main/resources/html/index.html
+++ b/client/jetbrains/src/main/resources/html/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>$Title$</title>
+</head>
+<body>
+$END$
+</body>
+</html>

--- a/client/jetbrains/src/main/resources/html/index.html
+++ b/client/jetbrains/src/main/resources/html/index.html
@@ -1,10 +1,9 @@
-<!DOCTYPE html>
-<html lang="en">
+<html>
 <head>
-  <meta charset="UTF-8">
-  <title>$Title$</title>
+    <title>Sourcegraph</title>
+    <meta charset="utf-8"/>
 </head>
 <body>
-$END$
+    Hello world!
 </body>
 </html>


### PR DESCRIPTION
Part of #34366

This is the first PR to merge back our prototype changes from `ps/jetbrains-demo` into `main`. In this PR we:

- Change the keybind for the current open file action
  - Not sure if this is good or bad but I've gotten used to `alt + a` for opening the modal. I figured that if we have users that are used to `alt + a` for the old behavior they now get a free reminder of our new features when they update :P I've changed the existing keybind to `alt + shift + a`.
- Create the base setup to load a modal view with a split screen of web view + editor.
- Create a service to hold the reference to the web view so that we can reuse it when the modal is closed?
- Add the basic scheme handler to load files from the resources folder. For now this supports `.html`, `.css`, and `.js`.

cc @madppiper (I can't tag you for review directly 😢 )

## Known issues

- There's a quick white flash when the web view is loaded the first time.
- You can open more than one popover by pressing `alt + a` multiple times (this should probably not do anything when the modal is still shown).

## Test plan

Verified manually on macOS AArch64:

https://user-images.githubusercontent.com/458591/165087407-e602b18c-9f9f-451c-b61d-45647c115836.mov


<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


