### PR TITLE
web: Remove `<Button />` transition

### DIFF
--- a/client/wildcard/src/components/Button/Button.module.scss
+++ b/client/wildcard/src/components/Button/Button.module.scss
@@ -28,8 +28,6 @@
     line-height: 1.4285714286;
     border-radius: var(--border-radius);
     padding: 0.375rem 0.75rem;
-    transition: color 0.15s ease-in-out, background-color 0.15s ease-in-out, border-color 0.15s ease-in-out,
-        box-shadow 0.15s ease-in-out;
 
     &:disabled {
         cursor: not-allowed;


### PR DESCRIPTION
## Description

Core hover/focus/active transitions were removed in #28901

It seems the Button component still has a transition state. This PR removes that.

## Test plan

Tested in Storybook

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->



## App preview:

- [Web](https://sg-web-tr-remove-button-transition.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-eanvnddhfp.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
