### PR TITLE
JetBrains: Add basic TS pipeline

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -32,3 +32,6 @@ browser/code-intel-extensions/
 .buildkite-cache/
 lib/codeintel/reprolang/
 cmd/symbols/squirrel/language-file-extensions.json
+client/jetbrains/build
+client/jetbrains/.idea
+client/jetbrains/.gradle

--- a/client/jetbrains/.eslintignore
+++ b/client/jetbrains/.eslintignore
@@ -1,0 +1,2 @@
+src/main/resources/dist/
+package.json

--- a/client/jetbrains/.eslintrc.js
+++ b/client/jetbrains/.eslintrc.js
@@ -1,0 +1,12 @@
+// @ts-check
+
+const baseConfig = require('../../.eslintrc.js')
+
+module.exports = {
+  extends: '../../.eslintrc.js',
+  parserOptions: {
+    ...baseConfig.parserOptions,
+    project: [__dirname + '/tsconfig.json'],
+  },
+  overrides: baseConfig.overrides,
+}

--- a/client/jetbrains/.gitignore
+++ b/client/jetbrains/.gitignore
@@ -7,7 +7,7 @@
 # User local IDEA configuration files
 .idea/
 
-#IntelliJ project
+# IntelliJ project
 *.iml
 
 # Build output & caches for IntelliJ plugin development
@@ -32,3 +32,6 @@ com_crashlytics_export_strings.xml
 crashlytics.properties
 crashlytics-build.properties
 fabric.properties
+
+# JavaScript resources
+src/main/resources/dist/*

--- a/client/jetbrains/.stylelintrc.json
+++ b/client/jetbrains/.stylelintrc.json
@@ -2,9 +2,7 @@
   "extends": ["../../.stylelintrc.json"],
   "overrides": [
     {
-      "files": [
-        "./webview/index.scss"
-      ],
+      "files": ["./webview/index.scss"],
       "rules": {
         "filenames/match-regex": null
       }

--- a/client/jetbrains/.stylelintrc.json
+++ b/client/jetbrains/.stylelintrc.json
@@ -1,0 +1,13 @@
+{
+  "extends": ["../../.stylelintrc.json"],
+  "overrides": [
+    {
+      "files": [
+        "./webview/index.scss"
+      ],
+      "rules": {
+        "filenames/match-regex": null
+      }
+    }
+  ]
+}

--- a/client/jetbrains/globals.d.ts
+++ b/client/jetbrains/globals.d.ts
@@ -1,0 +1,13 @@
+declare module '*.scss' {
+    const cssModule: string
+    export default cssModule
+}
+declare module '*.css' {
+    const cssModule: string
+    export default cssModule
+}
+
+/**
+ * Set by shared/dev/jest-environment.js
+ */
+declare var jsdom: import('jsdom').JSDOM

--- a/client/jetbrains/gulpfile.js
+++ b/client/jetbrains/gulpfile.js
@@ -1,0 +1,92 @@
+const path = require('path')
+
+require('ts-node').register({
+  transpileOnly: true,
+  // Use config with "module": "commonjs" because not all modules involved in tasks are esnext modules.
+  project: path.resolve(__dirname, './tsconfig.json'),
+})
+
+const log = require('fancy-log')
+const gulp = require('gulp')
+const createWebpackCompiler = require('webpack')
+
+const {
+  graphQlSchema,
+  graphQlOperations,
+  schema,
+  watchGraphQlSchema,
+  watchGraphQlOperations,
+  watchSchema,
+  cssModulesTypings,
+  watchCSSModulesTypings,
+} = require('../shared/gulpfile')
+
+const createWebpackConfig = require('./webpack.config')
+
+const WEBPACK_STATS_OPTIONS = {
+  all: false,
+  timings: true,
+  errors: true,
+  warnings: true,
+  colors: true,
+}
+
+/**
+ * @param {import('webpack').Stats} stats
+ */
+const logWebpackStats = stats => {
+  log(stats.toString(WEBPACK_STATS_OPTIONS))
+}
+
+async function webpack() {
+  const webpackConfig = await createWebpackConfig()
+  console.log(webpackConfig[0].entry)
+  const compiler = createWebpackCompiler(webpackConfig)
+  /** @type {import('webpack').Stats} */
+  const stats = await new Promise((resolve, reject) => {
+    compiler.run((error, stats) => (error ? reject(error) : resolve(stats)))
+  })
+  logWebpackStats(stats)
+  if (stats.hasErrors()) {
+    throw Object.assign(new Error('Failed to compile'), { showStack: false })
+  }
+}
+
+async function watchWebpack() {
+  const webpackConfig = await createWebpackConfig()
+  const compiler = createWebpackCompiler(webpackConfig)
+  compiler.hooks.watchRun.tap('Notify', () => log('Webpack compiling...'))
+  await new Promise(() => {
+    compiler.watch({ aggregateTimeout: 300 }, (error, stats) => {
+      logWebpackStats(stats)
+      if (error || stats.hasErrors()) {
+        log.error('Webpack compilation error')
+      } else {
+        log('Webpack compilation done')
+      }
+    })
+  })
+}
+
+// Ensure the typings that TypeScript depends on are build to avoid first-time-run errors
+const generate = gulp.parallel(schema, graphQlSchema, graphQlOperations, cssModulesTypings)
+
+// Watches code generation only, rebuilds on file changes
+const watchGenerators = gulp.parallel(watchSchema, watchGraphQlSchema, watchGraphQlOperations, watchCSSModulesTypings)
+
+/**
+ * Builds everything.
+ */
+const build = gulp.series(generate, webpack)
+
+/**
+ * Watches everything, rebuilds on file changes and writes the bundle to disk.
+ * Useful to running integration tests.
+ */
+const watch = gulp.series(
+  // Ensure the typings that TypeScript depends on are build to avoid first-time-run errors
+  generate,
+  gulp.parallel(watchGenerators, watchWebpack)
+)
+
+module.exports = { build, watch, webpack, watchWebpack }

--- a/client/jetbrains/package.json
+++ b/client/jetbrains/package.json
@@ -1,0 +1,21 @@
+{
+  "private": true,
+  "name": "@sourcegraph/jetbrains",
+  "displayName": "Sourcegraph",
+  "version": "1.2.4",
+  "description": "Sourcegraph for JetBrains",
+  "publisher": "sourcegraph",
+  "sideEffects": false,
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/sourcegraph/sourcegraph.git",
+    "directory": "client/jetbrains"
+  },
+  "scripts": {
+    "eslint": "eslint --cache '**/*.[jt]s?(x)'",
+    "task:gulp": "cross-env NODE_OPTIONS=\"--max_old_space_size=8192\" gulp",
+    "build": "yarn task:gulp webpack",
+    "watch": "yarn task:gulp watchWebpack"
+  }
+}

--- a/client/jetbrains/src/main/java/com/sourcegraph/scheme/SchemeHandler.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/scheme/SchemeHandler.java
@@ -83,7 +83,6 @@ public class SchemeHandler extends CefResourceHandlerAdapter {
 
     private boolean loadContent(String resName) {
         InputStream inStream = getClass().getResourceAsStream(resName);
-        System.out.println(resName);
         if (inStream != null) {
             try {
                 ByteArrayOutputStream outFile = new ByteArrayOutputStream();

--- a/client/jetbrains/src/main/resources/html/index.html
+++ b/client/jetbrains/src/main/resources/html/index.html
@@ -1,9 +1,11 @@
 <html>
 <head>
     <title>Sourcegraph</title>
+    <link rel="stylesheet" href="/dist/style.css"/>
     <meta charset="utf-8"/>
 </head>
 <body>
-    Hello world!
+    <div id="main"></div>
+    <script src="/dist/search.js"></script>
 </body>
 </html>

--- a/client/jetbrains/tsconfig.json
+++ b/client/jetbrains/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es2020",
+    "lib": ["esnext", "DOM", "DOM.Iterable"],
+    "sourceMap": true,
+    "sourceRoot": "src",
+    "baseUrl": "./src",
+    "paths": {
+      "*": ["types/*", "../../shared/src/types/*", "../../common/src/types/*", "*"],
+    },
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "strict": true,
+    "jsx": "react",
+  },
+  "references": [
+    { "path": "../shared" },
+    { "path": "../common" },
+    { "path": "../branded" },
+    { "path": "../search" },
+    { "path": "../search-ui" },
+  ],
+  "include": ["./package.json", "**/*", ".*", "**/*.d.ts"],
+  "exclude": ["node_modules", "../../node_modules", ".vscode-test", "out", "dist", "src", "gradle"],
+}

--- a/client/jetbrains/webpack.config.js
+++ b/client/jetbrains/webpack.config.js
@@ -1,0 +1,107 @@
+// @ts-check
+
+'use strict'
+const path = require('path')
+
+const MiniCssExtractPlugin = require('mini-css-extract-plugin')
+const webpack = require('webpack')
+
+const {
+  getMonacoWebpackPlugin,
+  getCSSModulesLoader,
+  getBasicCSSLoader,
+  getMonacoCSSRule,
+  getCSSLoaders,
+} = require('@sourcegraph/build-config')
+
+const mode = process.env.NODE_ENV === 'production' ? 'production' : 'development'
+
+const rootPath = path.resolve(__dirname, '../../')
+const jetbrainsWorkspacePath = path.resolve(rootPath, 'client', 'jetbrains')
+const webviewSourcePath = path.resolve(jetbrainsWorkspacePath, 'webview')
+
+// Build artifacts are put directly into the JetBrains resources folder
+const distPath = path.resolve(jetbrainsWorkspacePath, 'src', 'main', 'resources', 'dist')
+
+const extensionHostWorker = /main\.worker\.ts$/
+
+const MONACO_EDITOR_PATH = path.resolve(rootPath, 'node_modules', 'monaco-editor')
+
+/** @type {import('webpack').Configuration}*/
+
+const webviewConfig = {
+  context: __dirname, // needed when running `gulp` from the root dir
+  mode,
+  name: 'webviews',
+  target: 'web',
+  entry: {
+    search: path.resolve(webviewSourcePath, 'search', 'index.tsx'),
+    style: path.join(webviewSourcePath, 'index.scss'),
+  },
+  devtool: 'source-map',
+  output: {
+    path: distPath,
+    filename: '[name].js',
+  },
+  plugins: [new MiniCssExtractPlugin(), getMonacoWebpackPlugin()],
+  resolve: {
+    // support reading TypeScript and JavaScript files, 📖 -> https://github.com/TypeStrong/ts-loader
+    extensions: ['.ts', '.tsx', '.js', '.jsx'],
+    alias: {
+      path: require.resolve('path-browserify'),
+    },
+    fallback: {
+      path: require.resolve('path-browserify'),
+      process: require.resolve('process/browser'),
+    },
+  },
+  module: {
+    rules: [
+      {
+        test: /\.tsx?$/,
+        exclude: [/node_modules/, extensionHostWorker],
+        use: [
+          {
+            loader: 'ts-loader',
+          },
+        ],
+      },
+      {
+        test: extensionHostWorker,
+        use: [
+          {
+            loader: 'worker-loader',
+            options: { inline: 'no-fallback' },
+          },
+          'ts-loader',
+        ],
+      },
+      {
+        test: /\.(sass|scss)$/,
+        // CSS Modules loaders are only applied when the file is explicitly named as CSS module stylesheet using the extension `.module.scss`.
+        include: /\.module\.(sass|scss)$/,
+        use: getCSSLoaders(MiniCssExtractPlugin.loader, getCSSModulesLoader({})),
+      },
+      {
+        test: /\.(sass|scss)$/,
+        exclude: /\.module\.(sass|scss)$/,
+        use: getCSSLoaders(MiniCssExtractPlugin.loader, getBasicCSSLoader()),
+      },
+      getMonacoCSSRule(),
+      // Don't use shared getMonacoTFFRule(); we want to retain its name
+      // to reference path in the extension when we load the font ourselves.
+      {
+        test: /\.ttf$/,
+        include: [MONACO_EDITOR_PATH],
+        type: 'asset/resource',
+        generator: {
+          filename: '[name][ext]',
+        },
+      },
+    ],
+  },
+}
+
+module.exports = function () {
+  return Promise.resolve([webviewConfig])
+}

--- a/client/jetbrains/webview/index.scss
+++ b/client/jetbrains/webview/index.scss
@@ -1,0 +1,1 @@
+@import '../../branded/src/global-styles/index.scss';

--- a/client/jetbrains/webview/search/index.tsx
+++ b/client/jetbrains/webview/search/index.tsx
@@ -1,0 +1,7 @@
+import React from 'react'
+
+import { render } from 'react-dom'
+
+const node = document.querySelector('#main') as HTMLDivElement
+
+render(<p>Hello from React!</p>, node)


### PR DESCRIPTION
Part of #34366
Part of #34186

This PR sets up a rudimentary TypeScript build process that creates artifacts that are picked up inside our web view.

The setup code is mostly taken from our VSCode extension and I'll update it to use esbuild once https://github.com/sourcegraph/sourcegraph/pull/34010 is merged.

## Test plan

Manually verified that the code is loaded:

![Screenshot 2022-04-25 at 16 14 43](https://user-images.githubusercontent.com/458591/165107274-d63a7501-6858-4447-8102-4f5abe51096d.png)

The build runs:

```
α jetbrains (ps/jetbrains-ts-pipeline) yarn build
yarn run v1.22.17
$ yarn task:gulp webpack
$ cross-env NODE_OPTIONS="--max_old_space_size=8192" gulp webpack
[16:14:25] Using gulpfile ~/dev/sourcegraph/client/jetbrains/gulpfile.js
[16:14:25] Starting 'webpack'...
{
  search: '/Users/philipp/dev/sourcegraph/client/jetbrains/webview/search/index.tsx',
  style: '/Users/philipp/dev/sourcegraph/client/jetbrains/webview/index.scss'
}
[16:14:30] webviews:
  webviews compiled in 4511 ms
[16:14:30] Finished 'webpack' after 4.68 s
✨  Done in 6.44s.

```

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->



## App preview:

- [Web](https://sg-web-ps-jetbrains-ts-pipeline.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-axqlpvqigt.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
