### PR TITLE
Accessibility GitHub issue template: Remove team names from template to avoid team notify

### DIFF
--- a/.github/ISSUE_TEMPLATE/accessibility_issue.yaml
+++ b/.github/ISSUE_TEMPLATE/accessibility_issue.yaml
@@ -55,5 +55,5 @@ body:
       label: Assigning labels
       options:
       - label: Please give this issue an estimate by applying a label like `estimate/Xd`, where X is the estimated number of days it will take to complete.
-      - label: If this issue is specific to a specific Sourcegraph product, e.g. Code Intel, Batch Changes, etc., please assign the appropriate team label to this issue.
+      - label: If this issue is specific to a specific Sourcegraph product, please assign the appropriate team label to this issue.
       - label: If this issue will require input from designers in order to complete, please assign the label `needs-design`.


### PR DESCRIPTION
Removes references to code intel and batch changes to avoid every accessibility issue notifying their teams like [this](https://github.com/sourcegraph/sourcegraph/issues/34409#issuecomment-1108373224).

## Test plan

N/A

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


