### PR TITLE
nix: postgres listen on localhost

### DIFF
--- a/dev/nix/start-postgres.sh
+++ b/dev/nix/start-postgres.sh
@@ -21,7 +21,7 @@ if [ ! -d "$PGDATA" ]; then
   initdb "$PGDATA" --nosync -E UNICODE --auth=trust >/dev/null
   cat <<-EOF >>"$PGDATA"/postgresql.conf
 	    unix_socket_directories = '$PGHOST'
-	    listen_addresses = ''
+	    listen_addresses = 'localhost'
 	    shared_buffers = 12MB
 	    fsync = off
 	    synchronous_commit = off


### PR DESCRIPTION
Jetbrains DataGrip doesn't support postgres via sockets, so this just enables postgres to also listen on the default 5432 port

## Test plan

N/A
