### PR TITLE
lib/log: add log.Object for nested fields, fix logtest.Captured

### DIFF
--- a/lib/log/fields.go
+++ b/lib/log/fields.go
@@ -1,9 +1,10 @@
 package log
 
 import (
-	"github.com/sourcegraph/sourcegraph/lib/log/internal/encoders"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
+
+	"github.com/sourcegraph/sourcegraph/lib/log/internal/encoders"
 )
 
 // A Field is a marshaling operation used to add a key-value pair to a logger's context.

--- a/lib/log/fields.go
+++ b/lib/log/fields.go
@@ -1,6 +1,7 @@
 package log
 
 import (
+	"github.com/sourcegraph/sourcegraph/lib/log/internal/encoders"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
@@ -54,3 +55,11 @@ var (
 	// third-party libraries.
 	Namespace = zap.Namespace
 )
+
+type fieldsObject struct{ Fields []Field }
+
+// Object constructs a field that places all the given fields within the given key's
+// namespace.
+func Object(key string, fields ...Field) Field {
+	return zap.Object(key, encoders.FieldsObjectEncoder(fields))
+}

--- a/lib/log/fields.go
+++ b/lib/log/fields.go
@@ -57,8 +57,6 @@ var (
 	Namespace = zap.Namespace
 )
 
-type fieldsObject struct{ Fields []Field }
-
 // Object constructs a field that places all the given fields within the given key's
 // namespace.
 func Object(key string, fields ...Field) Field {

--- a/lib/log/internal/encoders/encoders.go
+++ b/lib/log/internal/encoders/encoders.go
@@ -49,3 +49,14 @@ func (t *TraceContextEncoder) MarshalLogObject(enc zapcore.ObjectEncoder) error 
 	}
 	return nil
 }
+
+type FieldsObjectEncoder []zapcore.Field
+
+var _ zapcore.ObjectMarshaler = &FieldsObjectEncoder{}
+
+func (fields FieldsObjectEncoder) MarshalLogObject(enc zapcore.ObjectEncoder) error {
+	for _, f := range fields {
+		f.AddTo(enc)
+	}
+	return nil
+}

--- a/lib/log/logger.go
+++ b/lib/log/logger.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 
 	"github.com/sourcegraph/sourcegraph/lib/log/internal/encoders"
 	"github.com/sourcegraph/sourcegraph/lib/log/internal/globallogger"
@@ -81,9 +82,8 @@ type zapAdapter struct {
 	// Attributes namespace.
 	attributes []Field
 
-	// options preserves options from initLogger, for a similar purpose to attributes
-	// and scope.
-	options []zap.Option
+	// additionalCore tracks an additional Core to write to - only to be used by logtest.
+	additionalCore zapcore.Core
 }
 
 var _ Logger = &zapAdapter{}
@@ -99,10 +99,10 @@ func (z *zapAdapter) Scoped(scope string, description string) Logger {
 		newScope = strings.Join([]string{z.scope, scope}, ".")
 	}
 	scopedLogger := &zapAdapter{
-		Logger:     z.Logger.Named(scope), // name -> scope in OT
-		scope:      newScope,
-		attributes: z.attributes,
-		options:    z.options,
+		Logger:         z.Logger.Named(scope), // name -> scope in OT
+		scope:          newScope,
+		attributes:     z.attributes,
+		additionalCore: z.additionalCore,
 	}
 	if len(description) > 0 {
 		if _, alreadyLogged := createdScopes.LoadOrStore(newScope, struct{}{}); !alreadyLogged {
@@ -116,36 +116,53 @@ func (z *zapAdapter) Scoped(scope string, description string) Logger {
 
 func (z *zapAdapter) With(fields ...Field) Logger {
 	return &zapAdapter{
-		Logger:     z.Logger.With(fields...),
-		scope:      z.scope,
-		attributes: append(z.attributes, fields...),
-		options:    z.options,
+		Logger:         z.Logger.With(fields...),
+		scope:          z.scope,
+		attributes:     append(z.attributes, fields...),
+		additionalCore: z.additionalCore,
 	}
 }
 
 func (z *zapAdapter) WithTrace(trace TraceContext) Logger {
-	newLogger := globallogger.Get(development).
-		Named(z.scope).
-		With(zap.Inline(&encoders.TraceContextEncoder{TraceContext: trace})).
-		With(z.attributes...)
-	if len(z.options) > 0 {
-		newLogger = newLogger.WithOptions(z.options...)
+	newLogger := globallogger.Get(development)
+	if z.additionalCore != nil {
+		newLogger = newLogger.WithOptions(zap.WrapCore(func(c zapcore.Core) zapcore.Core {
+			return zapcore.NewTee(c, z.additionalCore)
+		}))
 	}
+
+	newLogger = newLogger.
+		Named(z.scope).
+		// insert trace before attributes
+		With(zap.Inline(&encoders.TraceContextEncoder{TraceContext: trace})).
+		// add attributes
+		With(z.attributes...)
+
 	return &zapAdapter{
-		Logger:     newLogger,
-		scope:      z.scope,
-		attributes: z.attributes,
-		options:    z.options,
+		Logger:         newLogger,
+		scope:          z.scope,
+		attributes:     z.attributes,
+		additionalCore: z.additionalCore,
 	}
 }
 
-// WithOptions is an internal API used to allow packages like logtest to hook into the
-// underlying zap logger.
-func (z *zapAdapter) WithOptions(options ...zap.Option) Logger {
+// WithAdditionalCore is an internal API used to allow packages like logtest to hook into
+// underlying zap logger's core.
+//
+// It must implement logtest.configurableAdapter
+func (z *zapAdapter) WithAdditionalCore(core zapcore.Core) Logger {
+	newLogger := globallogger.Get(development).
+		WithOptions(zap.WrapCore(func(c zapcore.Core) zapcore.Core {
+			return zapcore.NewTee(core, c)
+		})).
+		// add fields back
+		Named(z.scope).
+		With(z.attributes...)
+
 	return &zapAdapter{
-		Logger:     z.Logger.WithOptions(options...),
-		scope:      z.scope,
-		attributes: z.attributes,
-		options:    append(z.options, options...),
+		Logger:         newLogger,
+		scope:          z.scope,
+		attributes:     z.attributes,
+		additionalCore: core,
 	}
 }

--- a/lib/log/logger_test.go
+++ b/lib/log/logger_test.go
@@ -12,18 +12,44 @@ func TestInitLogger(t *testing.T) {
 	logger, exportLogs := logtest.Captured(t)
 	assert.NotNil(t, logger)
 
-	logger.Debug("a debug message") // 1
+	logger.Debug("a debug message") // 0
 
 	logger = logger.With(log.String("some", "field"))
-	logger.Info("hello world", log.String("hello", "world")) // 2
+
+	logger.Info("hello world", log.String("hello", "world")) // 1
 
 	logger = logger.WithTrace(log.TraceContext{TraceID: "asdf"})
-	logger.Info("goodbye", log.String("world", "hello")) // 3
-	logger.Warn("another message")                       // 4
+	logger.Info("goodbye", log.String("world", "hello")) // 2
+	logger.Warn("another message")                       // 3
+
+	logger.Error("object of fields", // 4
+		log.Object("object",
+			log.String("field1", "value"),
+			log.String("field2", "value"),
+		))
 
 	logs := exportLogs()
-	assert.Len(t, logs, 4)
+	assert.Len(t, logs, 5)
 	for _, l := range logs {
 		assert.Equal(t, l.Scope, "TestInitLogger") // scope is always applied
 	}
+
+	assert.Equal(t, map[string]interface{}{
+		"some":  "field",
+		"hello": "world",
+	}, logs[1].Fields["Attributes"])
+
+	assert.Equal(t, "asdf", logs[2].Fields["TraceId"])
+	assert.Equal(t, map[string]interface{}{
+		"some":  "field",
+		"world": "hello",
+	}, logs[2].Fields["Attributes"])
+
+	assert.Equal(t, map[string]interface{}{
+		"some": "field",
+		"object": map[string]interface{}{
+			"field1": "value",
+			"field2": "value",
+		},
+	}, logs[4].Fields["Attributes"])
 }


### PR DESCRIPTION
Adds a more ergonomic API for creating objects using log fields, for example:

```go
	logger.Error("object of fields",
		log.Object("object",
			log.String("field1", "value"),
			log.String("field2", "value"),
		))
```

Also fixes `logtest.Captured` which was re-applying the `Attributes` namespace. Instead of allowing arbitrary options, just specializes the internal hook behaviour to only allow a single additional core (namely the observer core)

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

Unit tests