### PR TITLE
codeintel: Add language request telemetry

### DIFF
--- a/cmd/frontend/internal/app/updatecheck/client.go
+++ b/cmd/frontend/internal/app/updatecheck/client.go
@@ -297,7 +297,6 @@ func getAndMarshalIDEExtensionsUsageJSON(ctx context.Context, db database.DB) (_
 }
 
 func getAndMarshalCodeHostVersionsJSON(_ context.Context, _ database.DB) (_ json.RawMessage, err error) {
-
 	defer recordOperation("getAndMarshalCodeHostVersionsJSON")(&err)
 
 	versions, err := versions.GetVersions()

--- a/cmd/frontend/internal/app/updatecheck/handler_test.go
+++ b/cmd/frontend/internal/app/updatecheck/handler_test.go
@@ -433,6 +433,23 @@ func TestSerializeCodeIntelUsage(t *testing.T) {
 			},
 		},
 		SettingsPageViewCount: int32Ptr(1489),
+		LanguageRequests: []types.LanguageRequest{
+			{
+				LanguageID:  "frob",
+				NumRequests: 123,
+			},
+			{
+				LanguageID:  "borf",
+				NumRequests: 321,
+			},
+		},
+		InvestigationEvents: []types.CodeIntelInvestigationEvent{
+			{
+				Type:  types.CodeIntelUploadErrorInvestigationType,
+				WAUs:  25,
+				Total: 42,
+			},
+		},
 	})
 	if err != nil {
 		t.Fatalf("unexpected error %s", err)
@@ -564,7 +581,24 @@ func TestSerializeCodeIntelUsage(t *testing.T) {
 					"num_repositories_with_fresh_index_records": 45
 				}
 			],
-			"settings_page_view_count": 1489
+			"settings_page_view_count": 1489,
+			"language_requests": [
+				{
+					"language_id": "frob",
+					"num_requests": 123
+				},
+				{
+					"language_id": "borf",
+					"num_requests": 321
+				}
+			],
+			"investigation_events": [
+				{
+					"type": "CodeIntelligenceUploadErrorInvestigated",
+					"waus": 25,
+					"total": 42
+				}
+			]
 		},
 		"code_monitoring_usage": null,
 		"code_host_integration_usage": null,
@@ -730,7 +764,9 @@ func TestSerializeOldCodeIntelUsage(t *testing.T) {
 			"num_repositories_with_fresh_index_records": null,
 			"num_repositories_with_index_configuration_records": null,
 			"counts_by_language": null,
-			"settings_page_view_count": null
+			"settings_page_view_count": null,
+			"language_requests": null,
+			"investigation_events": null
 		},
 		"code_monitoring_usage": null,
 		"code_host_integration_usage": null,

--- a/internal/database/mocks.go
+++ b/internal/database/mocks.go
@@ -6688,6 +6688,10 @@ type MockEventLogStore struct {
 	// object controlling the behavior of the method
 	// AggregatedCodeIntelEvents.
 	AggregatedCodeIntelEventsFunc *EventLogStoreAggregatedCodeIntelEventsFunc
+	// AggregatedCodeIntelInvestigationEventsFunc is an instance of a mock
+	// function object controlling the behavior of the method
+	// AggregatedCodeIntelInvestigationEvents.
+	AggregatedCodeIntelInvestigationEventsFunc *EventLogStoreAggregatedCodeIntelInvestigationEventsFunc
 	// AggregatedSearchEventsFunc is an instance of a mock function object
 	// controlling the behavior of the method AggregatedSearchEvents.
 	AggregatedSearchEventsFunc *EventLogStoreAggregatedSearchEventsFunc
@@ -6788,6 +6792,9 @@ type MockEventLogStore struct {
 	// object controlling the behavior of the method
 	// MaxTimestampByUserIDAndSource.
 	MaxTimestampByUserIDAndSourceFunc *EventLogStoreMaxTimestampByUserIDAndSourceFunc
+	// RequestsByLanguageFunc is an instance of a mock function object
+	// controlling the behavior of the method RequestsByLanguage.
+	RequestsByLanguageFunc *EventLogStoreRequestsByLanguageFunc
 	// SiteUsageFunc is an instance of a mock function object controlling
 	// the behavior of the method SiteUsage.
 	SiteUsageFunc *EventLogStoreSiteUsageFunc
@@ -6808,6 +6815,11 @@ func NewMockEventLogStore() *MockEventLogStore {
 	return &MockEventLogStore{
 		AggregatedCodeIntelEventsFunc: &EventLogStoreAggregatedCodeIntelEventsFunc{
 			defaultHook: func(context.Context) ([]types.CodeIntelAggregatedEvent, error) {
+				return nil, nil
+			},
+		},
+		AggregatedCodeIntelInvestigationEventsFunc: &EventLogStoreAggregatedCodeIntelInvestigationEventsFunc{
+			defaultHook: func(context.Context) ([]types.CodeIntelAggregatedInvestigationEvent, error) {
 				return nil, nil
 			},
 		},
@@ -6951,6 +6963,11 @@ func NewMockEventLogStore() *MockEventLogStore {
 				return nil, nil
 			},
 		},
+		RequestsByLanguageFunc: &EventLogStoreRequestsByLanguageFunc{
+			defaultHook: func(context.Context) (map[string]int, error) {
+				return nil, nil
+			},
+		},
 		SiteUsageFunc: &EventLogStoreSiteUsageFunc{
 			defaultHook: func(context.Context) (types.SiteUsageSummary, error) {
 				return types.SiteUsageSummary{}, nil
@@ -6981,6 +6998,11 @@ func NewStrictMockEventLogStore() *MockEventLogStore {
 		AggregatedCodeIntelEventsFunc: &EventLogStoreAggregatedCodeIntelEventsFunc{
 			defaultHook: func(context.Context) ([]types.CodeIntelAggregatedEvent, error) {
 				panic("unexpected invocation of MockEventLogStore.AggregatedCodeIntelEvents")
+			},
+		},
+		AggregatedCodeIntelInvestigationEventsFunc: &EventLogStoreAggregatedCodeIntelInvestigationEventsFunc{
+			defaultHook: func(context.Context) ([]types.CodeIntelAggregatedInvestigationEvent, error) {
+				panic("unexpected invocation of MockEventLogStore.AggregatedCodeIntelInvestigationEvents")
 			},
 		},
 		AggregatedSearchEventsFunc: &EventLogStoreAggregatedSearchEventsFunc{
@@ -7123,6 +7145,11 @@ func NewStrictMockEventLogStore() *MockEventLogStore {
 				panic("unexpected invocation of MockEventLogStore.MaxTimestampByUserIDAndSource")
 			},
 		},
+		RequestsByLanguageFunc: &EventLogStoreRequestsByLanguageFunc{
+			defaultHook: func(context.Context) (map[string]int, error) {
+				panic("unexpected invocation of MockEventLogStore.RequestsByLanguage")
+			},
+		},
 		SiteUsageFunc: &EventLogStoreSiteUsageFunc{
 			defaultHook: func(context.Context) (types.SiteUsageSummary, error) {
 				panic("unexpected invocation of MockEventLogStore.SiteUsage")
@@ -7153,6 +7180,9 @@ func NewMockEventLogStoreFrom(i EventLogStore) *MockEventLogStore {
 	return &MockEventLogStore{
 		AggregatedCodeIntelEventsFunc: &EventLogStoreAggregatedCodeIntelEventsFunc{
 			defaultHook: i.AggregatedCodeIntelEvents,
+		},
+		AggregatedCodeIntelInvestigationEventsFunc: &EventLogStoreAggregatedCodeIntelInvestigationEventsFunc{
+			defaultHook: i.AggregatedCodeIntelInvestigationEvents,
 		},
 		AggregatedSearchEventsFunc: &EventLogStoreAggregatedSearchEventsFunc{
 			defaultHook: i.AggregatedSearchEvents,
@@ -7237,6 +7267,9 @@ func NewMockEventLogStoreFrom(i EventLogStore) *MockEventLogStore {
 		},
 		MaxTimestampByUserIDAndSourceFunc: &EventLogStoreMaxTimestampByUserIDAndSourceFunc{
 			defaultHook: i.MaxTimestampByUserIDAndSource,
+		},
+		RequestsByLanguageFunc: &EventLogStoreRequestsByLanguageFunc{
+			defaultHook: i.RequestsByLanguage,
 		},
 		SiteUsageFunc: &EventLogStoreSiteUsageFunc{
 			defaultHook: i.SiteUsage,
@@ -7359,6 +7392,117 @@ func (c EventLogStoreAggregatedCodeIntelEventsFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c EventLogStoreAggregatedCodeIntelEventsFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
+}
+
+// EventLogStoreAggregatedCodeIntelInvestigationEventsFunc describes the
+// behavior when the AggregatedCodeIntelInvestigationEvents method of the
+// parent MockEventLogStore instance is invoked.
+type EventLogStoreAggregatedCodeIntelInvestigationEventsFunc struct {
+	defaultHook func(context.Context) ([]types.CodeIntelAggregatedInvestigationEvent, error)
+	hooks       []func(context.Context) ([]types.CodeIntelAggregatedInvestigationEvent, error)
+	history     []EventLogStoreAggregatedCodeIntelInvestigationEventsFuncCall
+	mutex       sync.Mutex
+}
+
+// AggregatedCodeIntelInvestigationEvents delegates to the next hook
+// function in the queue and stores the parameter and result values of this
+// invocation.
+func (m *MockEventLogStore) AggregatedCodeIntelInvestigationEvents(v0 context.Context) ([]types.CodeIntelAggregatedInvestigationEvent, error) {
+	r0, r1 := m.AggregatedCodeIntelInvestigationEventsFunc.nextHook()(v0)
+	m.AggregatedCodeIntelInvestigationEventsFunc.appendCall(EventLogStoreAggregatedCodeIntelInvestigationEventsFuncCall{v0, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the
+// AggregatedCodeIntelInvestigationEvents method of the parent
+// MockEventLogStore instance is invoked and the hook queue is empty.
+func (f *EventLogStoreAggregatedCodeIntelInvestigationEventsFunc) SetDefaultHook(hook func(context.Context) ([]types.CodeIntelAggregatedInvestigationEvent, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// AggregatedCodeIntelInvestigationEvents method of the parent
+// MockEventLogStore instance invokes the hook at the front of the queue and
+// discards it. After the queue is empty, the default hook function is
+// invoked for any future action.
+func (f *EventLogStoreAggregatedCodeIntelInvestigationEventsFunc) PushHook(hook func(context.Context) ([]types.CodeIntelAggregatedInvestigationEvent, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *EventLogStoreAggregatedCodeIntelInvestigationEventsFunc) SetDefaultReturn(r0 []types.CodeIntelAggregatedInvestigationEvent, r1 error) {
+	f.SetDefaultHook(func(context.Context) ([]types.CodeIntelAggregatedInvestigationEvent, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *EventLogStoreAggregatedCodeIntelInvestigationEventsFunc) PushReturn(r0 []types.CodeIntelAggregatedInvestigationEvent, r1 error) {
+	f.PushHook(func(context.Context) ([]types.CodeIntelAggregatedInvestigationEvent, error) {
+		return r0, r1
+	})
+}
+
+func (f *EventLogStoreAggregatedCodeIntelInvestigationEventsFunc) nextHook() func(context.Context) ([]types.CodeIntelAggregatedInvestigationEvent, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *EventLogStoreAggregatedCodeIntelInvestigationEventsFunc) appendCall(r0 EventLogStoreAggregatedCodeIntelInvestigationEventsFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of
+// EventLogStoreAggregatedCodeIntelInvestigationEventsFuncCall objects
+// describing the invocations of this function.
+func (f *EventLogStoreAggregatedCodeIntelInvestigationEventsFunc) History() []EventLogStoreAggregatedCodeIntelInvestigationEventsFuncCall {
+	f.mutex.Lock()
+	history := make([]EventLogStoreAggregatedCodeIntelInvestigationEventsFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// EventLogStoreAggregatedCodeIntelInvestigationEventsFuncCall is an object
+// that describes an invocation of method
+// AggregatedCodeIntelInvestigationEvents on an instance of
+// MockEventLogStore.
+type EventLogStoreAggregatedCodeIntelInvestigationEventsFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 []types.CodeIntelAggregatedInvestigationEvent
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c EventLogStoreAggregatedCodeIntelInvestigationEventsFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c EventLogStoreAggregatedCodeIntelInvestigationEventsFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 
@@ -10462,6 +10606,114 @@ func (c EventLogStoreMaxTimestampByUserIDAndSourceFuncCall) Args() []interface{}
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c EventLogStoreMaxTimestampByUserIDAndSourceFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
+}
+
+// EventLogStoreRequestsByLanguageFunc describes the behavior when the
+// RequestsByLanguage method of the parent MockEventLogStore instance is
+// invoked.
+type EventLogStoreRequestsByLanguageFunc struct {
+	defaultHook func(context.Context) (map[string]int, error)
+	hooks       []func(context.Context) (map[string]int, error)
+	history     []EventLogStoreRequestsByLanguageFuncCall
+	mutex       sync.Mutex
+}
+
+// RequestsByLanguage delegates to the next hook function in the queue and
+// stores the parameter and result values of this invocation.
+func (m *MockEventLogStore) RequestsByLanguage(v0 context.Context) (map[string]int, error) {
+	r0, r1 := m.RequestsByLanguageFunc.nextHook()(v0)
+	m.RequestsByLanguageFunc.appendCall(EventLogStoreRequestsByLanguageFuncCall{v0, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the RequestsByLanguage
+// method of the parent MockEventLogStore instance is invoked and the hook
+// queue is empty.
+func (f *EventLogStoreRequestsByLanguageFunc) SetDefaultHook(hook func(context.Context) (map[string]int, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// RequestsByLanguage method of the parent MockEventLogStore instance
+// invokes the hook at the front of the queue and discards it. After the
+// queue is empty, the default hook function is invoked for any future
+// action.
+func (f *EventLogStoreRequestsByLanguageFunc) PushHook(hook func(context.Context) (map[string]int, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *EventLogStoreRequestsByLanguageFunc) SetDefaultReturn(r0 map[string]int, r1 error) {
+	f.SetDefaultHook(func(context.Context) (map[string]int, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *EventLogStoreRequestsByLanguageFunc) PushReturn(r0 map[string]int, r1 error) {
+	f.PushHook(func(context.Context) (map[string]int, error) {
+		return r0, r1
+	})
+}
+
+func (f *EventLogStoreRequestsByLanguageFunc) nextHook() func(context.Context) (map[string]int, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *EventLogStoreRequestsByLanguageFunc) appendCall(r0 EventLogStoreRequestsByLanguageFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of EventLogStoreRequestsByLanguageFuncCall
+// objects describing the invocations of this function.
+func (f *EventLogStoreRequestsByLanguageFunc) History() []EventLogStoreRequestsByLanguageFuncCall {
+	f.mutex.Lock()
+	history := make([]EventLogStoreRequestsByLanguageFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// EventLogStoreRequestsByLanguageFuncCall is an object that describes an
+// invocation of method RequestsByLanguage on an instance of
+// MockEventLogStore.
+type EventLogStoreRequestsByLanguageFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 map[string]int
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c EventLogStoreRequestsByLanguageFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c EventLogStoreRequestsByLanguageFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 

--- a/internal/types/codeintel.go
+++ b/internal/types/codeintel.go
@@ -17,6 +17,16 @@ type CodeIntelAggregatedEvent struct {
 	UniquesWeek int32
 }
 
+// CodeIntelAggregatedEvent represents the total events and unique users within
+// the current week for a single investigation event (user-CTAs on code intel badges).
+// data source (e.g. precise, search).
+type CodeIntelAggregatedInvestigationEvent struct {
+	Name        string
+	Week        time.Time
+	TotalWeek   int32
+	UniquesWeek int32
+}
+
 // NewCodeIntelUsageStatistics is the type used within the updatecheck handler.
 // This is sent from private instances to the cloud frontends, where it is further
 // massaged and inserted into a BigQuery.
@@ -38,6 +48,8 @@ type NewCodeIntelUsageStatistics struct {
 	NumRepositoriesWithAutoIndexConfigurationRecords *int32
 	CountsByLanguage                                 map[string]CodeIntelRepositoryCountsByLanguage
 	SettingsPageViewCount                            *int32
+	LanguageRequests                                 []LanguageRequest
+	InvestigationEvents                              []CodeIntelInvestigationEvent
 }
 
 type CodeIntelRepositoryCountsByLanguage struct {
@@ -71,6 +83,26 @@ const (
 	UnknownSource CodeIntelSource = iota
 	PreciseSource
 	SearchSource
+)
+
+type LanguageRequest struct {
+	LanguageID  string
+	NumRequests int32
+}
+
+type CodeIntelInvestigationEvent struct {
+	Type  CodeIntelInvestigationType
+	WAUs  int32
+	Total int32
+}
+
+type CodeIntelInvestigationType int
+
+const (
+	CodeIntelUnknownInvestigationType CodeIntelInvestigationType = iota
+	CodeIntelIndexerSetupInvestigationType
+	CodeIntelUploadErrorInvestigationType
+	CodeIntelIndexErrorInvestigationType
 )
 
 // OldCodeIntelUsageStatistics is an old version the code intelligence

--- a/internal/usagestats/aggregated_codeintel.go
+++ b/internal/usagestats/aggregated_codeintel.go
@@ -3,6 +3,7 @@ package usagestats
 import (
 	"context"
 	"strings"
+	"time"
 
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/types"
@@ -15,10 +16,17 @@ func GetAggregatedCodeIntelStats(ctx context.Context, db database.DB) (*types.Ne
 	codeIntelEvents, err := eventLogs.AggregatedCodeIntelEvents(ctx)
 	if err != nil {
 		return nil, err
-	} else if len(codeIntelEvents) == 0 {
+	}
+	codeIntelInvestigationEvents, err := eventLogs.AggregatedCodeIntelInvestigationEvents(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if len(codeIntelEvents) == 0 && len(codeIntelInvestigationEvents) == 0 {
 		return nil, nil
 	}
-	stats := groupAggregatedCodeIntelStats(codeIntelEvents)
+
+	// NOTE: this requires at least one of these to be non-empty (to get an initial date)
+	stats := groupAggregatedCodeIntelStats(codeIntelEvents, codeIntelInvestigationEvents)
 
 	pairs := []struct {
 		fetch  func(ctx context.Context) (int, error)
@@ -75,6 +83,20 @@ func GetAggregatedCodeIntelStats(ctx context.Context, db database.DB) (*types.Ne
 		}
 	}
 
+	requestCountsByLanguage, err := eventLogs.RequestsByLanguage(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	languageRequests := make([]types.LanguageRequest, 0, len(countsByLanguage))
+	for languageID, value := range requestCountsByLanguage {
+		languageRequests = append(languageRequests, types.LanguageRequest{
+			LanguageID:  languageID,
+			NumRequests: int32(value),
+		})
+	}
+	stats.LanguageRequests = languageRequests
+
 	return stats, nil
 }
 
@@ -104,7 +126,16 @@ var sourceMap = map[string]types.CodeIntelSource{
 	"codeintel.searchReferences.xrepo":  types.SearchSource,
 }
 
-func groupAggregatedCodeIntelStats(rawEvents []types.CodeIntelAggregatedEvent) *types.NewCodeIntelUsageStatistics {
+var investigationTypeMap = map[string]types.CodeIntelInvestigationType{
+	"CodeIntelligenceIndexerSetupInvestigated": types.CodeIntelIndexerSetupInvestigationType,
+	"CodeIntelligenceUploadErrorInvestigated":  types.CodeIntelUploadErrorInvestigationType,
+	"CodeIntelligenceIndexErrorInvestigated":   types.CodeIntelIndexErrorInvestigationType,
+}
+
+func groupAggregatedCodeIntelStats(
+	rawEvents []types.CodeIntelAggregatedEvent,
+	rawInvestigationEvents []types.CodeIntelAggregatedInvestigationEvent,
+) *types.NewCodeIntelUsageStatistics {
 	var eventSummaries []types.CodeIntelEventSummary
 	for _, event := range rawEvents {
 		languageID := ""
@@ -122,8 +153,25 @@ func groupAggregatedCodeIntelStats(rawEvents []types.CodeIntelAggregatedEvent) *
 		})
 	}
 
+	var investigationEvents []types.CodeIntelInvestigationEvent
+	for _, event := range rawInvestigationEvents {
+		investigationEvents = append(investigationEvents, types.CodeIntelInvestigationEvent{
+			Type:  investigationTypeMap[event.Name],
+			WAUs:  event.UniquesWeek,
+			Total: event.TotalWeek,
+		})
+	}
+
+	var startOfWeek time.Time
+	if len(rawEvents) > 0 {
+		startOfWeek = rawEvents[0].Week
+	} else if len(rawInvestigationEvents) > 0 {
+		startOfWeek = rawInvestigationEvents[0].Week
+	}
+
 	return &types.NewCodeIntelUsageStatistics{
-		StartOfWeek:    rawEvents[0].Week,
-		EventSummaries: eventSummaries,
+		StartOfWeek:         startOfWeek,
+		EventSummaries:      eventSummaries,
+		InvestigationEvents: investigationEvents,
 	}
 }

--- a/internal/usagestats/aggregated_codeintel_test.go
+++ b/internal/usagestats/aggregated_codeintel_test.go
@@ -19,7 +19,7 @@ func TestGroupAggregatedCodeIntelStats(t *testing.T) {
 		{Name: "codeintel.searchDefinitions", Week: t1, TotalWeek: 20, UniquesWeek: 2, LanguageID: &lang1},
 		{Name: "codeintel.lsifDefinitions", Week: t1, TotalWeek: 30, UniquesWeek: 3},
 		{Name: "codeintel.searchReferences.xrepo", Week: t1, TotalWeek: 40, UniquesWeek: 4, LanguageID: &lang2},
-	})
+	}, nil)
 
 	expectedCodeIntelStats := &types.NewCodeIntelUsageStatistics{
 		StartOfWeek: t1,


### PR DESCRIPTION
Closes #33795. This PR adds additional telemetry from #33869 and #34621. Blocked by https://github.com/sourcegraph/analytics/pull/412.

**Sample payload from client -> Cloud**:

```json
"newCodeIntelUsage": {
  "StartOfWeek": "2022-04-24T00:00:00Z",
  "WAUs": 0,
  "PreciseWAUs": 0,
  "SearchBasedWAUs": 0,
  "CrossRepositoryWAUs": 0,
  "PreciseCrossRepositoryWAUs": 0,
  "SearchBasedCrossRepositoryWAUs": 0,
  "EventSummaries": null,
  "NumRepositories": 3664,
  "NumRepositoriesWithUploadRecords": 6,
  "NumRepositoriesWithoutUploadRecords": null,
  "NumRepositoriesWithFreshUploadRecords": 5,
  "NumRepositoriesWithIndexRecords": 1,
  "NumRepositoriesWithFreshIndexRecords": 1,
  "NumRepositoriesWithAutoIndexConfigurationRecords": 2,
  "CountsByLanguage": {
    "lsif-go": {
      "NumRepositoriesWithUploadRecords": 6,
      "NumRepositoriesWithFreshUploadRecords": 5,
      "NumRepositoriesWithIndexRecords": 1,
      "NumRepositoriesWithFreshIndexRecords": 1
    }
  },
  "SettingsPageViewCount": 0,
  "LanguageRequests": [
    {
      "LanguageID": "lua",
      "NumRequests": 1
    },
    {
      "LanguageID": "javascript",
      "NumRequests": 1
    }
  ],
  "InvestigationEvents": [
    {
      "Type": 3,
      "WAUs": 1,
      "Total": 1
    },
    {
      "Type": 1,
      "WAUs": 1,
      "Total": 2
    }
  ]
}
```

**Sample payload from Cloud -> Google Pub/Sub**:

```json
"new_code_intel_usage": {
  "start_time": "2022-04-24T00:00:00Z",
  "waus": 0,
  "precise_waus": 0,
  "search_waus": 0,
  "xrepo_waus": 0,
  "precise_xrepo_waus": 0,
  "search_xrepo_waus": 0,
  "event_summaries": null,
  "num_repositories": 3664,
  "num_repositories_with_upload_records": 6,
  "num_repositories_without_upload_records": 3658,
  "num_repositories_with_fresh_upload_records": 5,
  "num_repositories_with_index_records": 1,
  "num_repositories_with_fresh_index_records": 1,
  "num_repositories_with_index_configuration_records": 2,
  "counts_by_language": [
    {
      "language_id": "lsif-go",
      "num_repositories_with_upload_records": 6,
      "num_repositories_with_fresh_upload_records": 5,
      "num_repositories_with_index_records": 1,
      "num_repositories_with_fresh_index_records": 1
    }
  ],
  "settings_page_view_count": 0,
  "language_requests": [
    {
      "language_id": "lua",
      "num_requests": 1
    },
    {
      "language_id": "javascript",
      "num_requests": 1
    }
  ],
  "investigation_events": [
    {
      "type": "CodeIntelligenceIndexErrorInvestigated",
      "waus": 1,
      "total": 1
    },
    {
      "type": "CodeIntelligenceIndexerSetupInvestigated",
      "waus": 1,
      "total": 2
    }
  ]
}
```

**Note**: The fields `language_requests` and `investigation_events` are new.

## Test plan

Validated data out of updatecheck client and handler have the expected format (see above).