### PR TITLE
remove baremetal agents

### DIFF
--- a/enterprise/dev/ci/internal/buildkite/agents.go
+++ b/enterprise/dev/ci/internal/buildkite/agents.go
@@ -1,8 +1,7 @@
 package buildkite
 
 const (
-	AgentQueueStandard  = "standard"
-	AgentQueueBaremetal = "baremetal"
+	AgentQueueStandard = "standard"
 	// TODO eventually replace with 'standard'
 	AgentQueueStateless = "stateless"
 )

--- a/enterprise/dev/ci/internal/ci/pipeline.go
+++ b/enterprise/dev/ci/internal/ci/pipeline.go
@@ -328,12 +328,6 @@ func withAgentQueueDefaults(s *bk.Step) {
 	if len(s.Agents) == 0 || s.Agents["queue"] == "" {
 		s.Agents["queue"] = bk.AgentQueueStateless
 	}
-
-	if s.Agents["queue"] != bk.AgentQueueBaremetal {
-		// Use athens proxy for go modules downloads, falling back to direct
-		// https://github.com/sourcegraph/infrastructure/blob/main/buildkite/kubernetes/athens-proxy/athens-athens-proxy.Deployment.yaml
-		s.Env["GOPROXY"] = "http://athens-athens-proxy,direct"
-	}
 }
 
 // withProfiling wraps "time -v" around each command for CPU/RAM utilization information


### PR DESCRIPTION
We no longer use a baremetal queue for any of our agents after the introduction of stateless agents and the subsequent cutover of all e2e/qa tests.


### Test Plan

N/A these agents are no longer deployed see https://github.com/sourcegraph/infrastructure/commit/bbf79b77c56808f3c8490f18c425e4a0b987cad2