### PR TITLE
lib/log: add initialization to more services

### DIFF
--- a/cmd/frontend/internal/cli/serve_cmd.go
+++ b/cmd/frontend/internal/cli/serve_cmd.go
@@ -41,6 +41,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/encryption/keyring"
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
+	"github.com/sourcegraph/sourcegraph/internal/hostname"
 	"github.com/sourcegraph/sourcegraph/internal/httpserver"
 	"github.com/sourcegraph/sourcegraph/internal/logging"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
@@ -53,6 +54,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/tracer"
 	"github.com/sourcegraph/sourcegraph/internal/version"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
+	sglog "github.com/sourcegraph/sourcegraph/lib/log"
 )
 
 var (
@@ -117,6 +119,13 @@ func Main(enterpriseSetupHook func(db database.DB, c conftypes.UnifiedWatchable)
 
 	log.SetFlags(0)
 	log.SetPrefix("")
+
+	syncLogs := sglog.Init(sglog.Resource{
+		Name:       env.MyName,
+		Version:    version.Version(),
+		InstanceID: hostname.Get(),
+	})
+	defer syncLogs()
 
 	ready := make(chan struct{})
 	go debugserver.NewServerRoutine(ready).Start()

--- a/cmd/gitserver/main.go
+++ b/cmd/gitserver/main.go
@@ -55,7 +55,9 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
 	"github.com/sourcegraph/sourcegraph/internal/tracer"
 	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/internal/version"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
+	sglog "github.com/sourcegraph/sourcegraph/lib/log"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
@@ -80,6 +82,12 @@ func main() {
 
 	conf.Init()
 	logging.Init()
+	syncLogs := sglog.Init(sglog.Resource{
+		Name:       env.MyName,
+		Version:    version.Version(),
+		InstanceID: hostname.Get(),
+	})
+	defer syncLogs()
 	tracer.Init(conf.DefaultClient())
 	sentry.Init(conf.DefaultClient())
 	trace.Init()

--- a/cmd/migrator/main.go
+++ b/cmd/migrator/main.go
@@ -15,8 +15,12 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database/migration/cliutil"
 	"github.com/sourcegraph/sourcegraph/internal/database/migration/store"
 	"github.com/sourcegraph/sourcegraph/internal/database/postgresdsn"
+	"github.com/sourcegraph/sourcegraph/internal/env"
+	"github.com/sourcegraph/sourcegraph/internal/hostname"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
+	"github.com/sourcegraph/sourcegraph/internal/version"
+	sglog "github.com/sourcegraph/sourcegraph/lib/log"
 	"github.com/sourcegraph/sourcegraph/lib/output"
 )
 
@@ -40,6 +44,13 @@ func main() {
 }
 
 func mainErr(ctx context.Context, args []string) error {
+	syncLogs := sglog.Init(sglog.Resource{
+		Name:       env.MyName,
+		Version:    version.Version(),
+		InstanceID: hostname.Get(),
+	})
+	defer syncLogs()
+
 	runnerFactory := newRunnerFactory()
 	command := &cli.App{
 		Name:   appName,

--- a/cmd/repo-updater/shared/main.go
+++ b/cmd/repo-updater/shared/main.go
@@ -37,6 +37,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
+	"github.com/sourcegraph/sourcegraph/internal/hostname"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/internal/httpserver"
 	"github.com/sourcegraph/sourcegraph/internal/logging"
@@ -48,6 +49,8 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
 	"github.com/sourcegraph/sourcegraph/internal/tracer"
+	"github.com/sourcegraph/sourcegraph/internal/version"
+	sglog "github.com/sourcegraph/sourcegraph/lib/log"
 )
 
 const port = "3182"
@@ -75,6 +78,12 @@ func Main(enterpriseInit EnterpriseInit) {
 
 	conf.Init()
 	logging.Init()
+	syncLogs := sglog.Init(sglog.Resource{
+		Name:       env.MyName,
+		Version:    version.Version(),
+		InstanceID: hostname.Get(),
+	})
+	defer syncLogs()
 	tracer.Init(conf.DefaultClient())
 	sentry.Init(conf.DefaultClient())
 	trace.Init()

--- a/cmd/searcher/main.go
+++ b/cmd/searcher/main.go
@@ -15,8 +15,6 @@ import (
 	"syscall"
 	"time"
 
-	"golang.org/x/sync/errgroup"
-
 	"github.com/sourcegraph/sourcegraph/cmd/searcher/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/api"
@@ -37,7 +35,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
 	"github.com/sourcegraph/sourcegraph/internal/tracer"
 	"github.com/sourcegraph/sourcegraph/internal/version"
-	"github.com/sourcegraph/sourcegraph/lib/errors"
 	"github.com/sourcegraph/sourcegraph/lib/log"
 )
 
@@ -48,44 +45,36 @@ var (
 
 const port = "3181"
 
-func frontendDB() (database.DB, error) {
+func ensureFrontendDB(logger log.Logger) database.DB {
 	dsn := conf.GetServiceConnectionValueAndRestartOnChange(func(serviceConnections conftypes.ServiceConnections) string {
 		return serviceConnections.PostgresDSN
 	})
 	sqlDB, err := connections.EnsureNewFrontendDB(dsn, "searcher", &observation.TestContext)
 	if err != nil {
-		return nil, err
+		logger.Fatal("Failed to connect to frontend database", log.Error(err))
 	}
 	return database.NewDB(sqlDB), nil
 }
 
-func shutdownOnSignal(ctx context.Context, server *http.Server) error {
-	// Listen for shutdown signals. When we receive one attempt to clean up,
-	// but do an insta-shutdown if we receive more than one signal.
-	c := make(chan os.Signal, 2)
-	signal.Notify(c, syscall.SIGINT, syscall.SIGHUP, syscall.SIGTERM)
+func main() {
+	env.Lock()
+	env.HandleHelpFlag()
+	stdlog.SetFlags(0)
+	conf.Init()
+	logging.Init()
+	syncLogs := log.Init(log.Resource{
+		Name:       env.MyName,
+		Version:    version.Version(),
+		InstanceID: hostname.Get(),
+	})
+	defer syncLogs()
+	tracer.Init(conf.DefaultClient())
+	sentry.Init(conf.DefaultClient())
+	trace.Init()
+	profiler.Init()
 
-	// Once we receive one of the signals from above, continues with the shutdown
-	// process.
-	select {
-	case <-c:
-	case <-ctx.Done(): // still call shutdown below
-	}
+	logger := log.Scoped("service", "the searcher service")
 
-	go func() {
-		// If a second signal is received, exit immediately.
-		<-c
-		os.Exit(1)
-	}()
-
-	// Wait for at most for the configured shutdown timeout.
-	ctx, cancel := context.WithTimeout(ctx, goroutine.GracefulShutdownTimeout)
-	defer cancel()
-	// Stop accepting requests.
-	return server.Shutdown(ctx)
-}
-
-func run(logger log.Logger) error {
 	// Ready immediately
 	ready := make(chan struct{})
 	close(ready)
@@ -93,15 +82,14 @@ func run(logger log.Logger) error {
 
 	var cacheSizeBytes int64
 	if i, err := strconv.ParseInt(cacheSizeMB, 10, 64); err != nil {
-		return errors.Wrapf(err, "invalid int %q for SEARCHER_CACHE_SIZE_MB", cacheSizeMB)
+		logger.Fatal("invalid int for SEARCHER_CACHE_SIZE_MB",
+			log.String("SEARCHER_CACHE_SIZE_MB", cacheSizeMB),
+			log.Error(err))
 	} else {
 		cacheSizeBytes = i * 1000 * 1000
 	}
 
-	db, err := frontendDB()
-	if err != nil {
-		return errors.Wrap(err, "failed to connect to frontend database")
-	}
+	db := ensureFrontendDB(logger)
 	git := gitserver.NewClient(db)
 
 	service := &search.Service{
@@ -164,14 +152,13 @@ func run(logger log.Logger) error {
 		}),
 	}
 
-	// Listen
-	g.Go(func() error {
-		logger.Info("listening", log.String("addr", server.Addr))
+	go func() {
+		logger.Info("searcher: listening", log.String("addr", server.Addr))
 		if err := server.ListenAndServe(); err != http.ErrServerClosed {
-			return err
+			logger.Fatal(err.Error())
 		}
 		return nil
-	})
+	}()
 
 	// Shutdown
 	g.Go(func() error {
@@ -181,27 +168,11 @@ func run(logger log.Logger) error {
 	return g.Wait()
 }
 
-func main() {
-	env.Lock()
-	env.HandleHelpFlag()
-	stdlog.SetFlags(0)
-	conf.Init()
-	logging.Init()
-	syncLogs := log.Init(log.Resource{
-		Name:       env.MyName,
-		Version:    version.Version(),
-		InstanceID: hostname.Get(),
-	})
-	defer syncLogs()
-	tracer.Init(conf.DefaultClient())
-	sentry.Init(conf.DefaultClient())
-	trace.Init()
-	profiler.Init()
-
-	logger := log.Scoped("service", "the searcher service")
-
-	err := run(logger)
-	if err != nil {
-		logger.Fatal("searcher failed", log.Error(err))
+	// Wait for at most for the configured shutdown timeout.
+	ctx, cancel := context.WithTimeout(context.Background(), goroutine.GracefulShutdownTimeout)
+	defer cancel()
+	// Stop accepting requests.
+	if err := server.Shutdown(ctx); err != nil {
+		logger.Error("shutting down http server", log.Error(err))
 	}
 }

--- a/cmd/server/shared/shared.go
+++ b/cmd/server/shared/shared.go
@@ -19,6 +19,10 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/server/internal/goreman"
 	"github.com/sourcegraph/sourcegraph/internal/database/postgresdsn"
+	"github.com/sourcegraph/sourcegraph/internal/env"
+	"github.com/sourcegraph/sourcegraph/internal/hostname"
+	"github.com/sourcegraph/sourcegraph/internal/version"
+	sglog "github.com/sourcegraph/sourcegraph/lib/log"
 )
 
 // FrontendInternalHost is the value of SRC_FRONTEND_INTERNAL.
@@ -71,6 +75,12 @@ var verbose = os.Getenv("SRC_LOG_LEVEL") == "dbug" || os.Getenv("SRC_LOG_LEVEL")
 func Main() {
 	flag.Parse()
 	log.SetFlags(0)
+	syncLogs := sglog.Init(sglog.Resource{
+		Name:       env.MyName,
+		Version:    version.Version(),
+		InstanceID: hostname.Get(),
+	})
+	defer syncLogs()
 
 	// Ensure CONFIG_DIR and DATA_DIR
 

--- a/cmd/symbols/shared/main.go
+++ b/cmd/symbols/shared/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
 	"github.com/sourcegraph/sourcegraph/internal/honey"
+	"github.com/sourcegraph/sourcegraph/internal/hostname"
 	"github.com/sourcegraph/sourcegraph/internal/httpserver"
 	"github.com/sourcegraph/sourcegraph/internal/logging"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
@@ -28,6 +29,8 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
 	"github.com/sourcegraph/sourcegraph/internal/tracer"
+	"github.com/sourcegraph/sourcegraph/internal/version"
+	sglog "github.com/sourcegraph/sourcegraph/lib/log"
 )
 
 const addr = ":3184"
@@ -39,6 +42,12 @@ func Main(setup SetupFunc) {
 	env.HandleHelpFlag()
 	conf.Init()
 	logging.Init()
+	syncLogs := sglog.Init(sglog.Resource{
+		Name:       env.MyName,
+		Version:    version.Version(),
+		InstanceID: hostname.Get(),
+	})
+	defer syncLogs()
 	tracer.Init(conf.DefaultClient())
 	sentry.Init(conf.DefaultClient())
 	trace.Init()

--- a/enterprise/cmd/executor/main.go
+++ b/enterprise/cmd/executor/main.go
@@ -17,10 +17,13 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/debugserver"
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
+	"github.com/sourcegraph/sourcegraph/internal/hostname"
 	"github.com/sourcegraph/sourcegraph/internal/logging"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
+	"github.com/sourcegraph/sourcegraph/internal/version"
 	"github.com/sourcegraph/sourcegraph/internal/workerutil"
+	sglog "github.com/sourcegraph/sourcegraph/lib/log"
 )
 
 func main() {
@@ -31,6 +34,12 @@ func main() {
 	env.HandleHelpFlag()
 
 	logging.Init()
+	syncLogs := sglog.Init(sglog.Resource{
+		Name:       env.MyName,
+		Version:    version.Version(),
+		InstanceID: hostname.Get(),
+	})
+	defer syncLogs()
 	trace.Init()
 
 	if err := config.Validate(); err != nil {

--- a/enterprise/cmd/precise-code-intel-worker/main.go
+++ b/enterprise/cmd/precise-code-intel-worker/main.go
@@ -28,6 +28,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
 	"github.com/sourcegraph/sourcegraph/internal/honey"
+	"github.com/sourcegraph/sourcegraph/internal/hostname"
 	"github.com/sourcegraph/sourcegraph/internal/httpserver"
 	"github.com/sourcegraph/sourcegraph/internal/logging"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
@@ -36,9 +37,11 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/internal/tracer"
 	"github.com/sourcegraph/sourcegraph/internal/uploadstore"
+	"github.com/sourcegraph/sourcegraph/internal/version"
 	"github.com/sourcegraph/sourcegraph/internal/workerutil"
 	"github.com/sourcegraph/sourcegraph/internal/workerutil/dbworker"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
+	sglog "github.com/sourcegraph/sourcegraph/lib/log"
 )
 
 const addr = ":3188"
@@ -51,6 +54,12 @@ func main() {
 	env.HandleHelpFlag()
 	conf.Init()
 	logging.Init()
+	syncLogs := sglog.Init(sglog.Resource{
+		Name:       env.MyName,
+		Version:    version.Version(),
+		InstanceID: hostname.Get(),
+	})
+	defer syncLogs()
 	tracer.Init(conf.DefaultClient())
 	sentry.Init(conf.DefaultClient())
 	trace.Init()


### PR DESCRIPTION
Paves the way for https://github.com/sourcegraph/sourcegraph/pull/34456 , which will add usage of `lib/log` to almost all services.

Worker initialization is added here, so is not included in this PR: https://github.com/sourcegraph/sourcegraph/pull/34320

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

tests pass, `sg start` works
