### PR TITLE
Searchblitz: add query for a simple, literal `and`

### DIFF
--- a/internal/cmd/search-blitz/queries.txt
+++ b/internal/cmd/search-blitz/queries.txt
@@ -61,6 +61,9 @@ patterntype:literal lang:go -file:vendor/ count:1000 cfssl select:repo
 # and_regex
 patterntype:regexp \beven\b and \bintelligence\b and \bdream\b and \bsimplest\b
 
+# and_literal_simple
+patterntype:literal readUInt16LE and readUInt8
+
 # or_regex
 patterntype:regexp \bdeadbeeeeef\b or \bdeadbeeeeeef\b or \bdeadBEEEEEF\b or \bdeadbeeeeef\b or \bdeadbeeeeeef\b or \bdeadBEEEEEF\b or \bdoResults\b
 


### PR DESCRIPTION
Our searchblitz query exercising `and` queries right now is a fairly
complex query with 4 terms and somewhat expensive regexes (`\b`). To reflect
the simplest use of `and` to better measure the base overhead of an `and`
query, this adds the `and_literal_simple` query. This uses the same
query string as `or_literal_simple` (replacing `or` with `and`) so they 
can be directly compared.

## Test plan

Just updating searchblitz config.

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


