### PR TITLE
sg: Fix missing propagation for debug log level.

### DIFF
--- a/dev/sg/sg_start.go
+++ b/dev/sg/sg_start.go
@@ -224,6 +224,7 @@ func startCommandSet(ctx context.Context, set *sgconf.Commandset, conf *sgconf.C
 // logLevelOverrides builds a map of commands -> log level that should be overridden in the environment.
 func logLevelOverrides() map[string]string {
 	levelServices := make(map[string][]string)
+	levelServices["debug"] = parseCsvs(debugStartServices.Value())
 	levelServices["info"] = parseCsvs(infoStartServices.Value())
 	levelServices["warn"] = parseCsvs(warnStartServices.Value())
 	levelServices["error"] = parseCsvs(errorStartServices.Value())


### PR DESCRIPTION
This was introduced in a [recent refactoring](https://github.com/sourcegraph/sourcegraph/pull/33758/files#diff-c1406cefa62b89a2f7ed9d1ec7805de8a5b02219206ed03441bee1da74550e85R215-R219).

Originally flagged in Slack. ([thread](https://sourcegraph.slack.com/archives/C07KZF47K/p1650621992000139))

## Test plan

Checked manually.