### PR TITLE
batches: a11y fixes for code host credentials user journey

### DIFF
--- a/client/web/src/components/FilteredConnection/ui/ConnectionList.tsx
+++ b/client/web/src/components/FilteredConnection/ui/ConnectionList.tsx
@@ -12,6 +12,7 @@ interface ConnectionListProps {
     className?: string
 
     compact?: boolean
+    ['aria-label']?: string
 }
 
 /**
@@ -23,10 +24,12 @@ export const ConnectionList: React.FunctionComponent<ConnectionListProps> = ({
     className,
     children,
     compact,
+    'aria-label': ariaLabel,
 }) => (
     <ListComponent
         className={classNames(styles.normal, compact && styles.compact, className)}
         data-testid="filtered-connection-nodes"
+        aria-label={ariaLabel}
     >
         {children}
     </ListComponent>

--- a/client/web/src/components/FilteredConnection/ui/ConnectionList.tsx
+++ b/client/web/src/components/FilteredConnection/ui/ConnectionList.tsx
@@ -1,10 +1,10 @@
-import React from 'react'
+import React, { AriaAttributes } from 'react'
 
 import classNames from 'classnames'
 
 import styles from './ConnectionList.module.scss'
 
-interface ConnectionListProps {
+interface ConnectionListProps extends AriaAttributes {
     /** list HTML element type. Default is <ul>. */
     as?: 'ul' | 'table' | 'div'
 
@@ -12,7 +12,6 @@ interface ConnectionListProps {
     className?: string
 
     compact?: boolean
-    ['aria-label']?: string
 }
 
 /**
@@ -24,12 +23,12 @@ export const ConnectionList: React.FunctionComponent<ConnectionListProps> = ({
     className,
     children,
     compact,
-    'aria-label': ariaLabel,
+    ...props
 }) => (
     <ListComponent
         className={classNames(styles.normal, compact && styles.compact, className)}
         data-testid="filtered-connection-nodes"
-        aria-label={ariaLabel}
+        {...props}
     >
         {children}
     </ListComponent>

--- a/client/web/src/enterprise/batches/settings/AddCredentialModal.tsx
+++ b/client/web/src/enterprise/batches/settings/AddCredentialModal.tsx
@@ -29,40 +29,28 @@ export interface AddCredentialModalProps {
 
 const HELP_TEXT_LINK_URL = 'https://docs.sourcegraph.com/batch_changes/quickstart#configure-code-host-credentials'
 
-const helpTexts: Record<ExternalServiceKind, JSX.Element> = {
+const scopeRequirements: Record<ExternalServiceKind, JSX.Element> = {
     [ExternalServiceKind.GITHUB]: (
-        <>
-            <Link to={HELP_TEXT_LINK_URL} rel="noreferrer noopener" target="_blank">
-                Create a new access token
-            </Link>{' '}
+        <span>
             with the <code>repo</code>, <code>read:org</code>, <code>user:email</code>, <code>read:discussion</code>,
             and <code>workflow</code> scopes.
-        </>
+        </span>
     ),
     [ExternalServiceKind.GITLAB]: (
-        <>
-            <Link to={HELP_TEXT_LINK_URL} rel="noreferrer noopener" target="_blank">
-                Create a new access token
-            </Link>{' '}
+        <span>
             with <code>api</code>, <code>read_repository</code>, and <code>write_repository</code> scopes.
-        </>
+        </span>
     ),
     [ExternalServiceKind.BITBUCKETSERVER]: (
-        <>
-            <Link to={HELP_TEXT_LINK_URL} rel="noreferrer noopener" target="_blank">
-                Create a new access token
-            </Link>{' '}
+        <span>
             with <code>write</code> permissions on the project and repository level.
-        </>
+        </span>
     ),
     [ExternalServiceKind.BITBUCKETCLOUD]: (
-        <>
-            <Link to={HELP_TEXT_LINK_URL} rel="noreferrer noopener" target="_blank">
-                Create a new access token
-            </Link>{' '}
+        <span>
             with <code>account:read</code>, <code>repo:write</code>, <code>pr:write</code>, and{' '}
             <code>pipeline:read</code> permissions.
-        </>
+        </span>
     ),
 
     // These are just for type completeness and serve as placeholders for a bright future.
@@ -214,7 +202,17 @@ export const AddCredentialModal: React.FunctionComponent<AddCredentialModalProps
                                     value={credential}
                                     onChange={onChangeCredential}
                                 />
-                                <p className="form-text">{helpTexts[externalServiceKind]}</p>
+                                <p className="form-text">
+                                    <Link
+                                        to={HELP_TEXT_LINK_URL}
+                                        rel="noreferrer noopener"
+                                        target="_blank"
+                                        aria-label="Follow our docs to learn how to create a new access token on this code host"
+                                    >
+                                        Create a new access token
+                                    </Link>{' '}
+                                    {scopeRequirements[externalServiceKind]}
+                                </p>
                             </div>
                             <div className="d-flex justify-content-end">
                                 <Button

--- a/client/web/src/enterprise/batches/settings/CodeHostConnectionNode.tsx
+++ b/client/web/src/enterprise/batches/settings/CodeHostConnectionNode.tsx
@@ -85,6 +85,7 @@ export const CodeHostConnectionNode: React.FunctionComponent<CodeHostConnectionN
                                 data-tooltip="This code host has credentials connected."
                                 aria-label="This code host has credentials connected."
                                 as={CheckCircleOutlineIcon}
+                                role="img"
                             />
                         )}
                         {!isEnabled && (
@@ -93,6 +94,7 @@ export const CodeHostConnectionNode: React.FunctionComponent<CodeHostConnectionN
                                 data-tooltip="This code host does not have credentials configured."
                                 aria-label="This code host does not have credentials configured."
                                 as={CheckboxBlankCircleOutlineIcon}
+                                role="img"
                             />
                         )}
                         <Icon className="mx-2" role="img" aria-hidden={true} as={ExternalServiceIcon} />{' '}

--- a/client/web/src/enterprise/batches/settings/CodeHostConnectionNode.tsx
+++ b/client/web/src/enterprise/batches/settings/CodeHostConnectionNode.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react'
+import React, { useCallback, useRef, useState } from 'react'
 
 import classNames from 'classnames'
 import CheckboxBlankCircleOutlineIcon from 'mdi-react/CheckboxBlankCircleOutlineIcon'
@@ -31,6 +31,8 @@ export const CodeHostConnectionNode: React.FunctionComponent<CodeHostConnectionN
     const ExternalServiceIcon = defaultExternalServices[node.externalServiceKind].icon
     const codeHostDisplayName = defaultExternalServices[node.externalServiceKind].defaultDisplayName
 
+    const buttonReference = useRef<HTMLButtonElement | null>(null)
+
     const [openModal, setOpenModal] = useState<OpenModal | undefined>()
     const onClickAdd = useCallback(() => {
         setOpenModal('add')
@@ -48,8 +50,9 @@ export const CodeHostConnectionNode: React.FunctionComponent<CodeHostConnectionN
     }, [])
     const afterAction = useCallback(() => {
         setOpenModal(undefined)
+        buttonReference.current?.focus()
         refetchAll()
-    }, [refetchAll])
+    }, [refetchAll, buttonReference])
 
     const isEnabled = node.credential !== null && (userID === null || !node.credential.isSiteCredential)
 
@@ -107,13 +110,14 @@ export const CodeHostConnectionNode: React.FunctionComponent<CodeHostConnectionN
                         )}
                     </h3>
                     <div className="mb-0 d-flex justify-content-end flex-grow-1">
-                        {isEnabled && (
+                        {isEnabled ? (
                             <>
                                 <Button
                                     className="text-danger text-nowrap test-code-host-connection-node-btn-remove"
                                     onClick={onClickRemove}
                                     variant="link"
                                     aria-label={`Remove credentials for ${codeHostDisplayName}`}
+                                    ref={buttonReference}
                                 >
                                     Remove
                                 </Button>
@@ -123,8 +127,7 @@ export const CodeHostConnectionNode: React.FunctionComponent<CodeHostConnectionN
                                     </Button>
                                 )}
                             </>
-                        )}
-                        {!isEnabled && (
+                        ) : (
                             /*
                                 a11y-ignore
                                 Rule: "color-contrast" (Elements must have sufficient color contrast)
@@ -135,6 +138,7 @@ export const CodeHostConnectionNode: React.FunctionComponent<CodeHostConnectionN
                                 onClick={onClickAdd}
                                 aria-label={`Add credentials for ${codeHostDisplayName}`}
                                 variant="success"
+                                ref={buttonReference}
                             >
                                 Add credentials
                             </Button>

--- a/client/web/src/enterprise/batches/settings/CodeHostConnectionNode.tsx
+++ b/client/web/src/enterprise/batches/settings/CodeHostConnectionNode.tsx
@@ -53,6 +53,14 @@ export const CodeHostConnectionNode: React.FunctionComponent<CodeHostConnectionN
 
     const isEnabled = node.credential !== null && (userID === null || !node.credential.isSiteCredential)
 
+    const headingAriaLabel = `Sourcegraph ${
+        isEnabled ? 'has credentials configured' : 'does not have credentials configured'
+    } for ${codeHostDisplayName} (${node.externalServiceURL}).${
+        !isEnabled && node.credential?.isSiteCredential
+            ? ' Changesets on this code host will be created with a global token until a personal access token is added.'
+            : ''
+    }`
+
     return (
         <>
             <li
@@ -67,12 +75,7 @@ export const CodeHostConnectionNode: React.FunctionComponent<CodeHostConnectionN
                         'd-flex justify-content-between align-items-center flex-wrap mb-0'
                     )}
                 >
-                    <h3
-                        className="text-nowrap mb-0"
-                        aria-label={`Sourcegraph ${
-                            isEnabled ? 'has credentials configured' : 'does not have credentials configured'
-                        } for ${codeHostDisplayName} (${node.externalServiceURL})`}
-                    >
+                    <h3 className="text-nowrap mb-0" aria-label={headingAriaLabel}>
                         {isEnabled && (
                             <Icon
                                 className="text-success test-code-host-connection-node-enabled"
@@ -95,6 +98,8 @@ export const CodeHostConnectionNode: React.FunctionComponent<CodeHostConnectionN
                             <Badge
                                 variant="secondary"
                                 tooltip="Changesets on this code host will
+                            be created with a global token until a personal access token is added."
+                                aria-label="Changesets on this code host will
                             be created with a global token until a personal access token is added."
                             >
                                 Global token

--- a/client/web/src/enterprise/batches/settings/CodeHostConnectionNode.tsx
+++ b/client/web/src/enterprise/batches/settings/CodeHostConnectionNode.tsx
@@ -29,6 +29,7 @@ export const CodeHostConnectionNode: React.FunctionComponent<CodeHostConnectionN
     userID,
 }) => {
     const ExternalServiceIcon = defaultExternalServices[node.externalServiceKind].icon
+    const codeHostDisplayName = defaultExternalServices[node.externalServiceKind].defaultDisplayName
 
     const [openModal, setOpenModal] = useState<OpenModal | undefined>()
     const onClickAdd = useCallback(() => {
@@ -66,22 +67,30 @@ export const CodeHostConnectionNode: React.FunctionComponent<CodeHostConnectionN
                         'd-flex justify-content-between align-items-center flex-wrap mb-0'
                     )}
                 >
-                    <h3 className="text-nowrap mb-0">
+                    <h3
+                        className="text-nowrap mb-0"
+                        aria-label={`Sourcegraph ${
+                            isEnabled ? 'has credentials configured' : 'does not have credentials configured'
+                        } for ${codeHostDisplayName} (${node.externalServiceURL})`}
+                    >
                         {isEnabled && (
                             <Icon
                                 className="text-success test-code-host-connection-node-enabled"
-                                data-tooltip="Connected"
+                                data-tooltip="This code host has credentials connected."
+                                aria-label="This code host has credentials connected."
                                 as={CheckCircleOutlineIcon}
                             />
                         )}
                         {!isEnabled && (
                             <Icon
                                 className="text-danger test-code-host-connection-node-disabled"
-                                data-tooltip="No token set"
+                                data-tooltip="This code host does not have credentials configured."
+                                aria-label="This code host does not have credentials configured."
                                 as={CheckboxBlankCircleOutlineIcon}
                             />
                         )}
-                        <Icon className="mx-2" as={ExternalServiceIcon} /> {node.externalServiceURL}{' '}
+                        <Icon className="mx-2" role="img" aria-hidden={true} as={ExternalServiceIcon} />{' '}
+                        {node.externalServiceURL}{' '}
                         {!isEnabled && node.credential?.isSiteCredential && (
                             <Badge
                                 variant="secondary"
@@ -99,6 +108,7 @@ export const CodeHostConnectionNode: React.FunctionComponent<CodeHostConnectionN
                                     className="text-danger text-nowrap test-code-host-connection-node-btn-remove"
                                     onClick={onClickRemove}
                                     variant="link"
+                                    aria-label={`Remove credentials for ${codeHostDisplayName}`}
                                 >
                                     Remove
                                 </Button>
@@ -118,6 +128,7 @@ export const CodeHostConnectionNode: React.FunctionComponent<CodeHostConnectionN
                             <Button
                                 className="a11y-ignore text-nowrap test-code-host-connection-node-btn-add"
                                 onClick={onClickAdd}
+                                aria-label={`Add credentials for ${codeHostDisplayName}`}
                                 variant="success"
                             >
                                 Add credentials

--- a/client/web/src/enterprise/batches/settings/CodeHostConnections.tsx
+++ b/client/web/src/enterprise/batches/settings/CodeHostConnections.tsx
@@ -51,7 +51,7 @@ const CodeHostConnections: React.FunctionComponent<CodeHostConnectionsProps> = (
             <ConnectionContainer className="mb-3">
                 {error && <ConnectionError errors={[error.message]} />}
                 {loading && !connection && <ConnectionLoading />}
-                <ConnectionList as="ul" className="list-group">
+                <ConnectionList as="ul" className="list-group" aria-label="Code hosts">
                     {connection?.nodes?.map(node => (
                         <CodeHostConnectionNode
                             key={node.externalServiceURL}

--- a/client/web/src/enterprise/batches/settings/RemoveCredentialModal.tsx
+++ b/client/web/src/enterprise/batches/settings/RemoveCredentialModal.tsx
@@ -38,7 +38,7 @@ export const RemoveCredentialModal: React.FunctionComponent<RemoveCredentialModa
                     externalServiceURL={codeHost.externalServiceURL}
                 />
 
-                <h3 className="text-danger mb-4">Removing credentials is irreversible</h3>
+                <strong className="d-block text-danger my-3">Removing credentials is irreversible.</strong>
 
                 {error && <ErrorAlert error={error} />}
 

--- a/client/wildcard/src/components/Icon/Icon.tsx
+++ b/client/wildcard/src/components/Icon/Icon.tsx
@@ -18,13 +18,17 @@ export interface IconProps extends Omit<MdiReactIconProps, 'children'> {
 }
 
 export const Icon = React.forwardRef((props, reference) => {
-    const { children, inline = true, className, size, as: Component = 'svg', role = 'img', ...attributes } = props
+    // TODO: role should have a default value of "img", but most of our Icons don't
+    // provide an aria-label, title, or other form of alternative text, and so setting it
+    // causes accessibility audits to fail in our integration test suite. Once we've added
+    // text to all of our icons, we should restore this as the default value.
+    // const { children, inline = true, className, size, as: Component = 'svg', role = 'img', ...attributes } = props
+    const { children, inline = true, className, size, as: Component = 'svg', ...attributes } = props
 
     return (
         <Component
             className={classNames(styles.iconInline, size === 'md' && styles.iconInlineMd, className)}
             ref={reference}
-            role={role}
             {...attributes}
         >
             {children}

--- a/client/wildcard/src/components/Icon/Icon.tsx
+++ b/client/wildcard/src/components/Icon/Icon.tsx
@@ -18,12 +18,13 @@ export interface IconProps extends Omit<MdiReactIconProps, 'children'> {
 }
 
 export const Icon = React.forwardRef((props, reference) => {
-    const { children, inline = true, className, size, as: Component = 'svg', ...attributes } = props
+    const { children, inline = true, className, size, as: Component = 'svg', role = 'img', ...attributes } = props
 
     return (
         <Component
             className={classNames(styles.iconInline, size === 'md' && styles.iconInlineMd, className)}
             ref={reference}
+            role={role}
             {...attributes}
         >
             {children}


### PR DESCRIPTION
A collection of quick fixes to a11y issues identified while auditing https://github.com/sourcegraph/sourcegraph/issues/34073:
- Adding `role="img"` as the default role for `Icon`s
  - This role should _really_ be the default for _any_ `Icon`, and I've set up a TODO comment to do just that, because the missing role error appears on virtually every instance of an `Icon`:

    ![image](https://user-images.githubusercontent.com/8942601/165216712-3488e001-d3e0-4b00-ba1c-6991afce0413.png)

    This is because until very recently, the HTML spec did not specify a default role for `<svg />`. Using the role `"img"` conveys that the SVG is purely visual and represents a collection of elements that, put together, create a single image. The only cases where we would _not_ want to use this as the role are cases where an SVG actually includes text or interactive elements, which our `Icon`s really should never.

    However, I cannot currently set it as the default, because we run an automated accessibility auditor as part of our integration test suite, and the audits fail if they discover an element with `role="img"` and no `aria-label`, `title`, or other form of alt text. Which, unfortunately, happens to be the case for the vast majority of `Icon`s in our codebase. So in the meantime, I've added a comment about eventually setting this as the default, but for now we'll need to manually provide `role="img"` in each instance where we invoke an `Icon`.
- Adding `aria-label` to icons
- Adding `aria-hidden={true}` to code host connection icon
- Adding `aria-label` to the list of code host connections
- Adding an `aria-label` for the group of elements within `h3` that collectively convey the code host status to a user
- Making it clearer that a docs link is not a form submit link
- Restoring focus to the "Remove" button, after the modal closes and the "Add credentials" button goes away (and likewise to the "Add credentials" button, after the modal closes and the "Remove" button goes away)
- Converting emphasized line in remove credentials modal from `h3` to `strong`

## Test plan

Re-tested with different accessibility audit tools and went through the full flow again for each.

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->



## App preview:

- [Web](https://sg-web-kr-configure-credentials-a11y.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-kszwbrvpel.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
