### PR TITLE
Example repo opens in newtab

### DIFF
--- a/client/web/src/enterprise/batches/batch-spec/edit/library/LibraryPane.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/edit/library/LibraryPane.tsx
@@ -2,6 +2,7 @@ import React, { useState, useCallback } from 'react'
 
 import ChevronDoubleLeftIcon from 'mdi-react/ChevronDoubleLeftIcon'
 import ChevronDoubleRightIcon from 'mdi-react/ChevronDoubleRightIcon'
+import OpenInNewIcon from 'mdi-react/OpenInNewIcon'
 import { animated, useSpring } from 'react-spring'
 
 import { Button, useLocalStorage, Icon, Link, Text } from '@sourcegraph/wildcard'
@@ -142,7 +143,13 @@ export const LibraryPane: React.FunctionComponent<React.PropsWithChildren<Librar
                         ))}
                     </ul>
                     <Text className={styles.lastItem}>
-                        <Link to="https://github.com/sourcegraph/batch-change-examples">View more examples</Link>
+                        <Link
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            to="https://github.com/sourcegraph/batch-change-examples"
+                        >
+                            View more examples <Icon aria-hidden={true} as={OpenInNewIcon} />
+                        </Link>
                     </Text>
                 </animated.div>
             </animated.div>


### PR DESCRIPTION
Example repo opens in newtab, instead of erasing the editor content 🥶 

#### Test plan

Not sure there can be a test here? 

## App preview:

- [Web](https://sg-web-mm-view-examples-newtab.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-ngzsjnjode.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
