### PR TITLE
Code Insights: Add GQL backend insight demo mocks showcase story

### DIFF
--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/BackendInsight.story.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/BackendInsight.story.tsx
@@ -11,12 +11,14 @@ import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
 import { H2 } from '@sourcegraph/wildcard'
 
 import { WebStory } from '../../../../../../components/WebStory'
-import { GetInsightViewResult } from '../../../../../../graphql-operations'
+import { GetInsightViewResult, SeriesSortDirection, SeriesSortMode } from '../../../../../../graphql-operations'
 import { CodeInsightsBackendStoryMock } from '../../../../CodeInsightsBackendStoryMock'
-import { BackendInsightData, SearchBasedInsight, SeriesChartContent } from '../../../../core'
+import { BackendInsightData, CodeInsightsBackendContext, CodeInsightsGqlBackend, SearchBasedInsight, SeriesChartContent } from '../../../../core'
+import { GET_INSIGHT_VIEW_GQL } from '../../../../core/backend/gql-backend/gql/GetInsightView'
 import { InsightInProcessError } from '../../../../core/backend/utils/errors'
 import {
     BackendInsight as BackendInsightType,
+    CaptureGroupInsight,
     InsightExecutionType,
     InsightType,
     isCaptureGroupInsight,
@@ -148,7 +150,7 @@ const TestBackendInsight: React.FunctionComponent<React.PropsWithChildren<unknow
     />
 )
 
-const COMPONENT_MIGRATION_INSIGHT_CONFIGURATION: SearchBackendBasedInsight = {
+const COMPONENT_MIGRATION_INSIGHT_CONFIGURATION: SearchBasedInsight = {
     type: InsightType.SearchBased,
     executionType: InsightExecutionType.Backend,
     id: 'backend-mock',
@@ -162,9 +164,11 @@ const COMPONENT_MIGRATION_INSIGHT_CONFIGURATION: SearchBackendBasedInsight = {
     filters: { excludeRepoRegexp: '', includeRepoRegexp: '', context: '' },
     dashboardReferenceCount: 0,
     isFrozen: false,
+    repositories: [],
+    dashboards: []
 }
 
-const DATA_FETCHING_INSIGHT_CONFIGURATION: SearchBackendBasedInsight = {
+const DATA_FETCHING_INSIGHT_CONFIGURATION: SearchBasedInsight = {
     type: InsightType.SearchBased,
     executionType: InsightExecutionType.Backend,
     id: 'backend-mock',
@@ -178,6 +182,8 @@ const DATA_FETCHING_INSIGHT_CONFIGURATION: SearchBackendBasedInsight = {
     filters: { excludeRepoRegexp: '', includeRepoRegexp: '', context: '' },
     dashboardReferenceCount: 0,
     isFrozen: false,
+    repositories: [],
+    dashboards: []
 }
 
 const TERRAFORM_INSIGHT_CONFIGURATION: CaptureGroupInsight = {
@@ -191,6 +197,7 @@ const TERRAFORM_INSIGHT_CONFIGURATION: CaptureGroupInsight = {
     filters: { excludeRepoRegexp: '', includeRepoRegexp: '', context: '' },
     dashboardReferenceCount: 0,
     isFrozen: false,
+    dashboards: []
 }
 
 const BACKEND_INSIGHT_COMPONENT_MIGRATION_MOCK: MockedResponse<GetInsightViewResult> = {
@@ -207,6 +214,24 @@ const BACKEND_INSIGHT_COMPONENT_MIGRATION_MOCK: MockedResponse<GetInsightViewRes
                 nodes: [
                     {
                         id: 'aW5zaWdodF92aWV3OiIyNU9aNFFpTERPMGRQVUZSQWNtYnBvZ1hhWnMi',
+                        defaultSeriesDisplayOptions: {
+                            __typename: 'SeriesDisplayOptions',
+                            limit: 20,
+                            sortOptions: {
+                                __typename: 'SeriesSortOptions',
+                                mode: SeriesSortMode.LEXICOGRAPHICAL,
+                                direction: SeriesSortDirection.ASC
+                            }
+                        },
+                        appliedSeriesDisplayOptions: {
+                            __typename: 'SeriesDisplayOptions',
+                            limit: 20,
+                            sortOptions: {
+                                __typename: 'SeriesSortOptions',
+                                mode: SeriesSortMode.LEXICOGRAPHICAL,
+                                direction: SeriesSortDirection.ASC
+                            }
+                        },
                         dataSeries: [
                             {
                                 seriesId: '001',
@@ -469,6 +494,24 @@ const BACKEND_INSIGHT_DATA_FETCHING_MOCK: MockedResponse<GetInsightViewResult> =
                 nodes: [
                     {
                         id: 'aW5zaWdodF92aWV3OiIyNU9ZY1VQdThxeXpvcnR1WmJXZE9qdVh2Y2Yi',
+                        defaultSeriesDisplayOptions: {
+                            __typename: 'SeriesDisplayOptions',
+                            limit: 20,
+                            sortOptions: {
+                                __typename: 'SeriesSortOptions',
+                                mode: SeriesSortMode.LEXICOGRAPHICAL,
+                                direction: SeriesSortDirection.ASC
+                            }
+                        },
+                        appliedSeriesDisplayOptions: {
+                            __typename: 'SeriesDisplayOptions',
+                            limit: 20,
+                            sortOptions: {
+                                __typename: 'SeriesSortOptions',
+                                mode: SeriesSortMode.LEXICOGRAPHICAL,
+                                direction: SeriesSortDirection.ASC
+                            }
+                        },
                         dataSeries: [
                             {
                                 seriesId: '001',
@@ -731,6 +774,24 @@ const BACKEND_INSIGHT_TERRAFORM_AWS_VERSIONS_MOCK: MockedResponse<GetInsightView
                 nodes: [
                     {
                         id: 'aW5zaWdodF92aWV3OiIyNU9lSm8xcTZub05nUkh3aG9MWEdCdUdtN3Yi',
+                        defaultSeriesDisplayOptions: {
+                            __typename: 'SeriesDisplayOptions',
+                            limit: 20,
+                            sortOptions: {
+                                __typename: 'SeriesSortOptions',
+                                mode: SeriesSortMode.LEXICOGRAPHICAL,
+                                direction: SeriesSortDirection.ASC
+                            }
+                        },
+                        appliedSeriesDisplayOptions: {
+                            __typename: 'SeriesDisplayOptions',
+                            limit: 20,
+                            sortOptions: {
+                                __typename: 'SeriesSortOptions',
+                                mode: SeriesSortMode.LEXICOGRAPHICAL,
+                                direction: SeriesSortDirection.ASC
+                            }
+                        },
                         dataSeries: [
                             {
                                 seriesId: '25OeJqBD4dOacJDmOA1cXY97Iyb',

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/BackendInsight.story.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/BackendInsight.story.tsx
@@ -13,7 +13,13 @@ import { H2 } from '@sourcegraph/wildcard'
 import { WebStory } from '../../../../../../components/WebStory'
 import { GetInsightViewResult, SeriesSortDirection, SeriesSortMode } from '../../../../../../graphql-operations'
 import { CodeInsightsBackendStoryMock } from '../../../../CodeInsightsBackendStoryMock'
-import { BackendInsightData, CodeInsightsBackendContext, CodeInsightsGqlBackend, SearchBasedInsight, SeriesChartContent } from '../../../../core'
+import {
+    BackendInsightData,
+    CodeInsightsBackendContext,
+    CodeInsightsGqlBackend,
+    SearchBasedInsight,
+    SeriesChartContent,
+} from '../../../../core'
 import { GET_INSIGHT_VIEW_GQL } from '../../../../core/backend/gql-backend/gql/GetInsightView'
 import { InsightInProcessError } from '../../../../core/backend/utils/errors'
 import {
@@ -165,7 +171,7 @@ const COMPONENT_MIGRATION_INSIGHT_CONFIGURATION: SearchBasedInsight = {
     dashboardReferenceCount: 0,
     isFrozen: false,
     repositories: [],
-    dashboards: []
+    dashboards: [],
 }
 
 const DATA_FETCHING_INSIGHT_CONFIGURATION: SearchBasedInsight = {
@@ -183,7 +189,7 @@ const DATA_FETCHING_INSIGHT_CONFIGURATION: SearchBasedInsight = {
     dashboardReferenceCount: 0,
     isFrozen: false,
     repositories: [],
-    dashboards: []
+    dashboards: [],
 }
 
 const TERRAFORM_INSIGHT_CONFIGURATION: CaptureGroupInsight = {
@@ -197,7 +203,7 @@ const TERRAFORM_INSIGHT_CONFIGURATION: CaptureGroupInsight = {
     filters: { excludeRepoRegexp: '', includeRepoRegexp: '', context: '' },
     dashboardReferenceCount: 0,
     isFrozen: false,
-    dashboards: []
+    dashboards: [],
 }
 
 const BACKEND_INSIGHT_COMPONENT_MIGRATION_MOCK: MockedResponse<GetInsightViewResult> = {
@@ -220,8 +226,8 @@ const BACKEND_INSIGHT_COMPONENT_MIGRATION_MOCK: MockedResponse<GetInsightViewRes
                             sortOptions: {
                                 __typename: 'SeriesSortOptions',
                                 mode: SeriesSortMode.LEXICOGRAPHICAL,
-                                direction: SeriesSortDirection.ASC
-                            }
+                                direction: SeriesSortDirection.ASC,
+                            },
                         },
                         appliedSeriesDisplayOptions: {
                             __typename: 'SeriesDisplayOptions',
@@ -229,8 +235,8 @@ const BACKEND_INSIGHT_COMPONENT_MIGRATION_MOCK: MockedResponse<GetInsightViewRes
                             sortOptions: {
                                 __typename: 'SeriesSortOptions',
                                 mode: SeriesSortMode.LEXICOGRAPHICAL,
-                                direction: SeriesSortDirection.ASC
-                            }
+                                direction: SeriesSortDirection.ASC,
+                            },
                         },
                         dataSeries: [
                             {
@@ -500,8 +506,8 @@ const BACKEND_INSIGHT_DATA_FETCHING_MOCK: MockedResponse<GetInsightViewResult> =
                             sortOptions: {
                                 __typename: 'SeriesSortOptions',
                                 mode: SeriesSortMode.LEXICOGRAPHICAL,
-                                direction: SeriesSortDirection.ASC
-                            }
+                                direction: SeriesSortDirection.ASC,
+                            },
                         },
                         appliedSeriesDisplayOptions: {
                             __typename: 'SeriesDisplayOptions',
@@ -509,8 +515,8 @@ const BACKEND_INSIGHT_DATA_FETCHING_MOCK: MockedResponse<GetInsightViewResult> =
                             sortOptions: {
                                 __typename: 'SeriesSortOptions',
                                 mode: SeriesSortMode.LEXICOGRAPHICAL,
-                                direction: SeriesSortDirection.ASC
-                            }
+                                direction: SeriesSortDirection.ASC,
+                            },
                         },
                         dataSeries: [
                             {
@@ -780,8 +786,8 @@ const BACKEND_INSIGHT_TERRAFORM_AWS_VERSIONS_MOCK: MockedResponse<GetInsightView
                             sortOptions: {
                                 __typename: 'SeriesSortOptions',
                                 mode: SeriesSortMode.LEXICOGRAPHICAL,
-                                direction: SeriesSortDirection.ASC
-                            }
+                                direction: SeriesSortDirection.ASC,
+                            },
                         },
                         appliedSeriesDisplayOptions: {
                             __typename: 'SeriesDisplayOptions',
@@ -789,8 +795,8 @@ const BACKEND_INSIGHT_TERRAFORM_AWS_VERSIONS_MOCK: MockedResponse<GetInsightView
                             sortOptions: {
                                 __typename: 'SeriesSortOptions',
                                 mode: SeriesSortMode.LEXICOGRAPHICAL,
-                                direction: SeriesSortDirection.ASC
-                            }
+                                direction: SeriesSortDirection.ASC,
+                            },
                         },
                         dataSeries: [
                             {

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/BackendInsight.story.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/BackendInsight.story.tsx
@@ -27,6 +27,11 @@ import { BackendInsightView } from './BackendInsight'
 const defaultStory: Meta = {
     title: 'web/insights/BackendInsight',
     decorators: [story => <WebStory>{() => story()}</WebStory>],
+    parameters: {
+        chromatic: {
+            disableSnapshot: false,
+        },
+    },
 }
 
 export default defaultStory

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/BackendInsight.story.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/BackendInsight.story.tsx
@@ -154,7 +154,7 @@ const COMPONENT_MIGRATION_INSIGHT_CONFIGURATION: SearchBackendBasedInsight = {
         { id: '003', name: 'shared', query: '', stroke: 'red' },
     ],
     step: { weeks: 2 },
-    filters: { excludeRepoRegexp: '', includeRepoRegexp: '', contexts: [] },
+    filters: { excludeRepoRegexp: '', includeRepoRegexp: '', context: '' },
     dashboardReferenceCount: 0,
     isFrozen: false,
 }
@@ -170,7 +170,7 @@ const DATA_FETCHING_INSIGHT_CONFIGURATION: SearchBackendBasedInsight = {
         { id: '003', name: 'useMutation | useQuery | useConnection hooks', query: '', stroke: 'red' },
     ],
     step: { weeks: 2 },
-    filters: { excludeRepoRegexp: '', includeRepoRegexp: '', contexts: [] },
+    filters: { excludeRepoRegexp: '', includeRepoRegexp: '', context: '' },
     dashboardReferenceCount: 0,
     isFrozen: false,
 }
@@ -183,7 +183,7 @@ const TERRAFORM_INSIGHT_CONFIGURATION: CaptureGroupInsight = {
     step: { weeks: 2 },
     repositories: [],
     query: '',
-    filters: { excludeRepoRegexp: '', includeRepoRegexp: '', contexts: [] },
+    filters: { excludeRepoRegexp: '', includeRepoRegexp: '', context: '' },
     dashboardReferenceCount: 0,
     isFrozen: false,
 }
@@ -193,7 +193,7 @@ const BACKEND_INSIGHT_COMPONENT_MIGRATION_MOCK: MockedResponse<GetInsightViewRes
         query: GET_INSIGHT_VIEW_GQL,
         variables: {
             id: 'backend-mock',
-            filters: { includeRepoRegex: '', excludeRepoRegex: '', searchContexts: [] },
+            filters: { includeRepoRegex: '', excludeRepoRegex: '', searchContexts: [''] },
         },
     },
     result: {
@@ -455,7 +455,7 @@ const BACKEND_INSIGHT_DATA_FETCHING_MOCK: MockedResponse<GetInsightViewResult> =
         query: GET_INSIGHT_VIEW_GQL,
         variables: {
             id: 'backend-mock',
-            filters: { includeRepoRegex: '', excludeRepoRegex: '', searchContexts: [] },
+            filters: { includeRepoRegex: '', excludeRepoRegex: '', searchContexts: [''] },
         },
     },
     result: {
@@ -717,7 +717,7 @@ const BACKEND_INSIGHT_TERRAFORM_AWS_VERSIONS_MOCK: MockedResponse<GetInsightView
         query: GET_INSIGHT_VIEW_GQL,
         variables: {
             id: 'backend-mock',
-            filters: { includeRepoRegex: '', excludeRepoRegex: '', searchContexts: [] },
+            filters: { includeRepoRegex: '', excludeRepoRegex: '', searchContexts: [''] },
         },
     },
     result: {

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/BackendInsight.story.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/BackendInsight.story.tsx
@@ -6,8 +6,8 @@ import { Meta, Story } from '@storybook/react'
 import { Observable, of, throwError } from 'rxjs'
 import { delay } from 'rxjs/operators'
 
-import { MockedTestProvider } from '@sourcegraph/shared/out/src/testing/apollo'
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
+import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
 import { H2 } from '@sourcegraph/wildcard'
 
 import { WebStory } from '../../../../../../components/WebStory'

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/BackendInsight.story.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/BackendInsight.story.tsx
@@ -1,13 +1,17 @@
 import React from 'react'
 
+import { useApolloClient } from '@apollo/client'
+import { MockedResponse } from '@apollo/client/testing'
 import { Meta, Story } from '@storybook/react'
 import { Observable, of, throwError } from 'rxjs'
 import { delay } from 'rxjs/operators'
 
+import { MockedTestProvider } from '@sourcegraph/shared/out/src/testing/apollo'
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { H2 } from '@sourcegraph/wildcard'
 
 import { WebStory } from '../../../../../../components/WebStory'
+import { GetInsightViewResult } from '../../../../../../graphql-operations'
 import { CodeInsightsBackendStoryMock } from '../../../../CodeInsightsBackendStoryMock'
 import { BackendInsightData, SearchBasedInsight, SeriesChartContent } from '../../../../core'
 import { InsightInProcessError } from '../../../../core/backend/utils/errors'
@@ -139,7 +143,968 @@ const TestBackendInsight: React.FunctionComponent<React.PropsWithChildren<unknow
     />
 )
 
-export const BackendInsight: Story = () => (
+const COMPONENT_MIGRATION_INSIGHT_CONFIGURATION: SearchBackendBasedInsight = {
+    type: InsightType.SearchBased,
+    executionType: InsightExecutionType.Backend,
+    id: 'backend-mock',
+    title: 'Backend Insight Mock',
+    series: [
+        { id: '001', name: 'wildcard', query: '', stroke: 'blue' },
+        { id: '002', name: 'branded', query: '', stroke: 'orange' },
+        { id: '003', name: 'shared', query: '', stroke: 'red' },
+    ],
+    step: { weeks: 2 },
+    filters: { excludeRepoRegexp: '', includeRepoRegexp: '', contexts: [] },
+    dashboardReferenceCount: 0,
+    isFrozen: false,
+}
+
+const DATA_FETCHING_INSIGHT_CONFIGURATION: SearchBackendBasedInsight = {
+    type: InsightType.SearchBased,
+    executionType: InsightExecutionType.Backend,
+    id: 'backend-mock',
+    title: 'Backend Insight Mock',
+    series: [
+        { id: '001', name: 'requestGraphql', query: '', stroke: 'blue' },
+        { id: '002', name: 'queryGraphQL | mutateGraphQL', query: '', stroke: 'orange' },
+        { id: '003', name: 'useMutation | useQuery | useConnection hooks', query: '', stroke: 'red' },
+    ],
+    step: { weeks: 2 },
+    filters: { excludeRepoRegexp: '', includeRepoRegexp: '', contexts: [] },
+    dashboardReferenceCount: 0,
+    isFrozen: false,
+}
+
+const TERRAFORM_INSIGHT_CONFIGURATION: CaptureGroupInsight = {
+    type: InsightType.CaptureGroup,
+    executionType: InsightExecutionType.Backend,
+    id: 'backend-mock',
+    title: 'Backend Insight Mock',
+    step: { weeks: 2 },
+    repositories: [],
+    query: '',
+    filters: { excludeRepoRegexp: '', includeRepoRegexp: '', contexts: [] },
+    dashboardReferenceCount: 0,
+    isFrozen: false,
+}
+
+const BACKEND_INSIGHT_COMPONENT_MIGRATION_MOCK: MockedResponse<GetInsightViewResult> = {
+    request: {
+        query: GET_INSIGHT_VIEW_GQL,
+        variables: {
+            id: 'backend-mock',
+            filters: { includeRepoRegex: '', excludeRepoRegex: '', searchContexts: [] },
+        },
+    },
+    result: {
+        data: {
+            insightViews: {
+                nodes: [
+                    {
+                        id: 'aW5zaWdodF92aWV3OiIyNU9aNFFpTERPMGRQVUZSQWNtYnBvZ1hhWnMi',
+                        dataSeries: [
+                            {
+                                seriesId: '001',
+                                label: 'Wildcard components',
+                                points: [
+                                    {
+                                        dateTime: '2022-04-26T00:03:19Z',
+                                        value: 1311,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                    {
+                                        dateTime: '2022-04-21T01:13:43Z',
+                                        value: 586,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                    {
+                                        dateTime: '2022-03-21T01:13:25Z',
+                                        value: 586,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                    {
+                                        dateTime: '2022-02-21T00:00:00Z',
+                                        value: 1212,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                    {
+                                        dateTime: '2022-01-21T00:00:00Z',
+                                        value: 1164,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                    {
+                                        dateTime: '2021-12-21T00:00:00Z',
+                                        value: 490,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                    {
+                                        dateTime: '2021-11-21T00:00:00Z',
+                                        value: 393,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                    {
+                                        dateTime: '2021-10-21T00:00:00Z',
+                                        value: 357,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                    {
+                                        dateTime: '2021-09-21T00:00:00Z',
+                                        value: 348,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                    {
+                                        dateTime: '2021-08-21T00:00:00Z',
+                                        value: 276,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                    {
+                                        dateTime: '2021-07-21T00:00:00Z',
+                                        value: 213,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                    {
+                                        dateTime: '2021-06-21T00:00:00Z',
+                                        value: 192,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                    {
+                                        dateTime: '2021-05-21T00:00:00Z',
+                                        value: 81,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                ],
+                                status: {
+                                    backfillQueuedAt: '2022-02-21T01:33:48Z',
+                                    completedJobs: 10,
+                                    pendingJobs: 0,
+                                    failedJobs: 0,
+                                    __typename: 'InsightSeriesStatus',
+                                },
+                                __typename: 'InsightsSeries',
+                            },
+                            {
+                                seriesId: '002',
+                                label: 'Branded components',
+                                points: [
+                                    {
+                                        dateTime: '2022-04-26T00:03:24Z',
+                                        value: 538,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                    {
+                                        dateTime: '2022-04-21T01:13:44Z',
+                                        value: 283,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                    {
+                                        dateTime: '2022-03-21T01:13:25Z',
+                                        value: 283,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                    {
+                                        dateTime: '2022-02-21T00:00:00Z',
+                                        value: 516,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                    {
+                                        dateTime: '2022-01-21T00:00:00Z',
+                                        value: 513,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                    {
+                                        dateTime: '2021-12-21T00:00:00Z',
+                                        value: 275,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                    {
+                                        dateTime: '2021-11-21T00:00:00Z',
+                                        value: 267,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                    {
+                                        dateTime: '2021-10-21T00:00:00Z',
+                                        value: 261,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                    {
+                                        dateTime: '2021-09-21T00:00:00Z',
+                                        value: 252,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                    {
+                                        dateTime: '2021-08-21T00:00:00Z',
+                                        value: 243,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                    {
+                                        dateTime: '2021-07-21T00:00:00Z',
+                                        value: 216,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                    {
+                                        dateTime: '2021-06-21T00:00:00Z',
+                                        value: 213,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                    {
+                                        dateTime: '2021-05-21T00:00:00Z',
+                                        value: 213,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                ],
+                                status: {
+                                    backfillQueuedAt: '2022-02-21T01:33:48Z',
+                                    completedJobs: 10,
+                                    pendingJobs: 0,
+                                    failedJobs: 0,
+                                    __typename: 'InsightSeriesStatus',
+                                },
+                                __typename: 'InsightsSeries',
+                            },
+                            {
+                                seriesId: '003',
+                                label: 'Shared components',
+                                points: [
+                                    {
+                                        dateTime: '2022-04-26T00:03:37Z',
+                                        value: 468,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                    {
+                                        dateTime: '2022-04-21T01:13:44Z',
+                                        value: 328,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                    {
+                                        dateTime: '2022-03-21T01:13:25Z',
+                                        value: 328,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                    {
+                                        dateTime: '2022-02-21T00:00:00Z',
+                                        value: 475,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                    {
+                                        dateTime: '2022-01-21T00:00:00Z',
+                                        value: 477,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                    {
+                                        dateTime: '2021-12-21T00:00:00Z',
+                                        value: 671,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                    {
+                                        dateTime: '2021-11-21T00:00:00Z',
+                                        value: 660,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                    {
+                                        dateTime: '2021-10-21T00:00:00Z',
+                                        value: 648,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                    {
+                                        dateTime: '2021-09-21T00:00:00Z',
+                                        value: 642,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                    {
+                                        dateTime: '2021-08-21T00:00:00Z',
+                                        value: 621,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                    {
+                                        dateTime: '2021-07-21T00:00:00Z',
+                                        value: 606,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                    {
+                                        dateTime: '2021-06-21T00:00:00Z',
+                                        value: 573,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                    {
+                                        dateTime: '2021-05-21T00:00:00Z',
+                                        value: 564,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                ],
+                                status: {
+                                    backfillQueuedAt: '2022-02-21T01:33:48Z',
+                                    completedJobs: 10,
+                                    pendingJobs: 0,
+                                    failedJobs: 0,
+                                    __typename: 'InsightSeriesStatus',
+                                },
+                                __typename: 'InsightsSeries',
+                            },
+                        ],
+                        __typename: 'InsightView',
+                    },
+                ],
+                __typename: 'InsightViewConnection',
+            },
+        },
+    },
+}
+
+const BACKEND_INSIGHT_DATA_FETCHING_MOCK: MockedResponse<GetInsightViewResult> = {
+    request: {
+        query: GET_INSIGHT_VIEW_GQL,
+        variables: {
+            id: 'backend-mock',
+            filters: { includeRepoRegex: '', excludeRepoRegex: '', searchContexts: [] },
+        },
+    },
+    result: {
+        data: {
+            insightViews: {
+                nodes: [
+                    {
+                        id: 'aW5zaWdodF92aWV3OiIyNU9ZY1VQdThxeXpvcnR1WmJXZE9qdVh2Y2Yi',
+                        dataSeries: [
+                            {
+                                seriesId: '001',
+                                label: 'requestGraphQL',
+                                points: [
+                                    {
+                                        dateTime: '2022-04-26T00:02:30Z',
+                                        value: 235,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                    {
+                                        dateTime: '2022-04-21T00:13:43Z',
+                                        value: 239,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                    {
+                                        dateTime: '2022-03-21T00:13:20Z',
+                                        value: 228,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                    {
+                                        dateTime: '2022-02-20T00:00:00Z',
+                                        value: 232,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                    {
+                                        dateTime: '2022-01-20T00:00:00Z',
+                                        value: 226,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                    {
+                                        dateTime: '2021-12-20T00:00:00Z',
+                                        value: 217,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                    {
+                                        dateTime: '2021-11-20T00:00:00Z',
+                                        value: 214,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                    {
+                                        dateTime: '2021-10-20T00:00:00Z',
+                                        value: 212,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                    {
+                                        dateTime: '2021-09-20T00:00:00Z',
+                                        value: 227,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                    {
+                                        dateTime: '2021-08-20T00:00:00Z',
+                                        value: 218,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                    {
+                                        dateTime: '2021-07-20T00:00:00Z',
+                                        value: 211,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                    {
+                                        dateTime: '2021-06-20T00:00:00Z',
+                                        value: 213,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                    {
+                                        dateTime: '2021-05-20T00:00:00Z',
+                                        value: 200,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                ],
+                                status: {
+                                    backfillQueuedAt: '2022-02-21T00:31:57Z',
+                                    completedJobs: 9,
+                                    pendingJobs: 0,
+                                    failedJobs: 0,
+                                    __typename: 'InsightSeriesStatus',
+                                },
+                                __typename: 'InsightsSeries',
+                            },
+                            {
+                                seriesId: '002',
+                                label: 'queryGraphQL | mutateGraphQL',
+                                points: [
+                                    {
+                                        dateTime: '2022-04-26T00:02:31Z',
+                                        value: 71,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                    {
+                                        dateTime: '2022-04-21T00:13:42Z',
+                                        value: 71,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                    {
+                                        dateTime: '2022-03-21T00:13:20Z',
+                                        value: 73,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                    {
+                                        dateTime: '2022-02-20T00:00:00Z',
+                                        value: 73,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                    {
+                                        dateTime: '2022-01-20T00:00:00Z',
+                                        value: 74,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                    {
+                                        dateTime: '2021-12-20T00:00:00Z',
+                                        value: 73,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                    {
+                                        dateTime: '2021-11-20T00:00:00Z',
+                                        value: 73,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                    {
+                                        dateTime: '2021-10-20T00:00:00Z',
+                                        value: 75,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                    {
+                                        dateTime: '2021-09-20T00:00:00Z',
+                                        value: 76,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                    {
+                                        dateTime: '2021-08-20T00:00:00Z',
+                                        value: 79,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                    {
+                                        dateTime: '2021-07-20T00:00:00Z',
+                                        value: 80,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                    {
+                                        dateTime: '2021-06-20T00:00:00Z',
+                                        value: 80,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                    {
+                                        dateTime: '2021-05-20T00:00:00Z',
+                                        value: 82,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                ],
+                                status: {
+                                    backfillQueuedAt: '2022-02-21T00:31:57Z',
+                                    completedJobs: 9,
+                                    pendingJobs: 0,
+                                    failedJobs: 0,
+                                    __typename: 'InsightSeriesStatus',
+                                },
+                                __typename: 'InsightsSeries',
+                            },
+                            {
+                                seriesId: '003',
+                                label: 'useMutation | useQuery | useConnection hooks',
+                                points: [
+                                    {
+                                        dateTime: '2022-04-26T00:02:53Z',
+                                        value: 227,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                    {
+                                        dateTime: '2022-04-21T00:13:48Z',
+                                        value: 219,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                    {
+                                        dateTime: '2022-03-21T00:13:21Z',
+                                        value: 200,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                    {
+                                        dateTime: '2022-02-20T00:00:00Z',
+                                        value: 156,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                    {
+                                        dateTime: '2022-01-20T00:00:00Z',
+                                        value: 109,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                    {
+                                        dateTime: '2021-12-20T00:00:00Z',
+                                        value: 102,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                    {
+                                        dateTime: '2021-11-20T00:00:00Z',
+                                        value: 85,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                    {
+                                        dateTime: '2021-10-20T00:00:00Z',
+                                        value: 62,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                    {
+                                        dateTime: '2021-09-20T00:00:00Z',
+                                        value: 49,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                    {
+                                        dateTime: '2021-08-20T00:00:00Z',
+                                        value: 24,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                    {
+                                        dateTime: '2021-07-20T00:00:00Z',
+                                        value: 11,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                    {
+                                        dateTime: '2021-06-20T00:00:00Z',
+                                        value: 5,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                    {
+                                        dateTime: '2021-05-20T00:00:00Z',
+                                        value: 5,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                ],
+                                status: {
+                                    backfillQueuedAt: '2022-02-21T00:31:57Z',
+                                    completedJobs: 10,
+                                    pendingJobs: 0,
+                                    failedJobs: 0,
+                                    __typename: 'InsightSeriesStatus',
+                                },
+                                __typename: 'InsightsSeries',
+                            },
+                        ],
+                        __typename: 'InsightView',
+                    },
+                ],
+                __typename: 'InsightViewConnection',
+            },
+        },
+    },
+}
+
+const BACKEND_INSIGHT_TERRAFORM_AWS_VERSIONS_MOCK: MockedResponse<GetInsightViewResult> = {
+    request: {
+        query: GET_INSIGHT_VIEW_GQL,
+        variables: {
+            id: 'backend-mock',
+            filters: { includeRepoRegex: '', excludeRepoRegex: '', searchContexts: [] },
+        },
+    },
+    result: {
+        data: {
+            insightViews: {
+                nodes: [
+                    {
+                        id: 'aW5zaWdodF92aWV3OiIyNU9lSm8xcTZub05nUkh3aG9MWEdCdUdtN3Yi',
+                        dataSeries: [
+                            {
+                                seriesId: '25OeJqBD4dOacJDmOA1cXY97Iyb',
+                                label: 'v 1.x',
+                                points: [
+                                    {
+                                        dateTime: '2022-04-26T00:03:02Z',
+                                        value: 2,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                    {
+                                        dateTime: '2022-04-21T01:13:41Z',
+                                        value: 2,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                    {
+                                        dateTime: '2022-03-21T01:13:19Z',
+                                        value: 2,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                    {
+                                        dateTime: '2022-02-21T00:00:00Z',
+                                        value: 2,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                    {
+                                        dateTime: '2022-01-21T00:00:00Z',
+                                        value: 2,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                    {
+                                        dateTime: '2021-12-21T00:00:00Z',
+                                        value: 2,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                    {
+                                        dateTime: '2021-11-21T00:00:00Z',
+                                        value: 2,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                    {
+                                        dateTime: '2021-10-21T00:00:00Z',
+                                        value: 2,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                    {
+                                        dateTime: '2021-09-21T00:00:00Z',
+                                        value: 2,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                    {
+                                        dateTime: '2021-08-21T00:00:00Z',
+                                        value: 2,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                    {
+                                        dateTime: '2021-07-21T00:00:00Z',
+                                        value: 2,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                    {
+                                        dateTime: '2021-06-21T00:00:00Z',
+                                        value: 2,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                    {
+                                        dateTime: '2021-05-21T00:00:00Z',
+                                        value: 2,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                ],
+                                status: {
+                                    backfillQueuedAt: '2022-02-21T01:33:48Z',
+                                    completedJobs: 10,
+                                    pendingJobs: 0,
+                                    failedJobs: 544,
+                                    __typename: 'InsightSeriesStatus',
+                                },
+                                __typename: 'InsightsSeries',
+                            },
+                            {
+                                seriesId: '25OeJrXQQNK0fjqOqybnEMsHnyR',
+                                label: 'v 2.x',
+                                points: [
+                                    {
+                                        dateTime: '2022-04-26T00:03:05Z',
+                                        value: 12,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                    {
+                                        dateTime: '2022-04-21T01:13:41Z',
+                                        value: 12,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                    {
+                                        dateTime: '2022-03-21T01:13:20Z',
+                                        value: 12,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                    {
+                                        dateTime: '2022-02-21T00:00:00Z',
+                                        value: 12,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                    {
+                                        dateTime: '2022-01-21T00:00:00Z',
+                                        value: 12,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                    {
+                                        dateTime: '2021-12-21T00:00:00Z',
+                                        value: 12,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                    {
+                                        dateTime: '2021-11-21T00:00:00Z',
+                                        value: 12,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                    {
+                                        dateTime: '2021-10-21T00:00:00Z',
+                                        value: 2,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                    {
+                                        dateTime: '2021-09-21T00:00:00Z',
+                                        value: 2,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                    {
+                                        dateTime: '2021-08-21T00:00:00Z',
+                                        value: 2,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                    {
+                                        dateTime: '2021-07-21T00:00:00Z',
+                                        value: 2,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                    {
+                                        dateTime: '2021-06-21T00:00:00Z',
+                                        value: 2,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                    {
+                                        dateTime: '2021-05-21T00:00:00Z',
+                                        value: 0,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                ],
+                                status: {
+                                    backfillQueuedAt: '2022-02-21T01:33:48Z',
+                                    completedJobs: 10,
+                                    pendingJobs: 0,
+                                    failedJobs: 544,
+                                    __typename: 'InsightSeriesStatus',
+                                },
+                                __typename: 'InsightsSeries',
+                            },
+                            {
+                                seriesId: '25OeJlaDvpkh02abDBsPisvDSdi',
+                                label: 'v 3.x',
+                                points: [
+                                    {
+                                        dateTime: '2022-04-26T00:02:49Z',
+                                        value: 4,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                    {
+                                        dateTime: '2022-04-21T01:13:41Z',
+                                        value: 4,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                    {
+                                        dateTime: '2022-03-21T01:13:20Z',
+                                        value: 4,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                    {
+                                        dateTime: '2022-02-21T00:00:00Z',
+                                        value: 4,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                    {
+                                        dateTime: '2022-01-21T00:00:00Z',
+                                        value: 4,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                    {
+                                        dateTime: '2021-12-21T00:00:00Z',
+                                        value: 4,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                    {
+                                        dateTime: '2021-11-21T00:00:00Z',
+                                        value: 4,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                    {
+                                        dateTime: '2021-10-21T00:00:00Z',
+                                        value: 4,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                    {
+                                        dateTime: '2021-09-21T00:00:00Z',
+                                        value: 4,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                    {
+                                        dateTime: '2021-08-21T00:00:00Z',
+                                        value: 4,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                    {
+                                        dateTime: '2021-07-21T00:00:00Z',
+                                        value: 4,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                    {
+                                        dateTime: '2021-06-21T00:00:00Z',
+                                        value: 4,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                    {
+                                        dateTime: '2021-05-21T00:00:00Z',
+                                        value: 4,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                ],
+                                status: {
+                                    backfillQueuedAt: '2022-02-21T01:33:48Z',
+                                    completedJobs: 10,
+                                    pendingJobs: 0,
+                                    failedJobs: 544,
+                                    __typename: 'InsightSeriesStatus',
+                                },
+                                __typename: 'InsightsSeries',
+                            },
+                            {
+                                seriesId: '25OeJmiafuCZe66UR7yQFV3663S',
+                                label: 'v 4.x',
+                                points: [
+                                    {
+                                        dateTime: '2022-04-26T00:02:59Z',
+                                        value: 2,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                    {
+                                        dateTime: '2022-04-21T01:13:43Z',
+                                        value: 2,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                    {
+                                        dateTime: '2022-03-21T01:13:20Z',
+                                        value: 2,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                    {
+                                        dateTime: '2022-02-21T00:00:00Z',
+                                        value: 2,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                    {
+                                        dateTime: '2022-01-21T00:00:00Z',
+                                        value: 2,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                    {
+                                        dateTime: '2021-12-21T00:00:00Z',
+                                        value: 2,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                    {
+                                        dateTime: '2021-11-21T00:00:00Z',
+                                        value: 2,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                    {
+                                        dateTime: '2021-10-21T00:00:00Z',
+                                        value: 2,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                    {
+                                        dateTime: '2021-09-21T00:00:00Z',
+                                        value: 0,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                    {
+                                        dateTime: '2021-08-21T00:00:00Z',
+                                        value: 0,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                    {
+                                        dateTime: '2021-07-21T00:00:00Z',
+                                        value: 0,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                    {
+                                        dateTime: '2021-06-21T00:00:00Z',
+                                        value: 0,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                    {
+                                        dateTime: '2021-05-21T00:00:00Z',
+                                        value: 0,
+                                        __typename: 'InsightDataPoint',
+                                    },
+                                ],
+                                status: {
+                                    backfillQueuedAt: '2022-02-21T01:33:48Z',
+                                    completedJobs: 10,
+                                    pendingJobs: 0,
+                                    failedJobs: 544,
+                                    __typename: 'InsightSeriesStatus',
+                                },
+                                __typename: 'InsightsSeries',
+                            },
+                        ],
+                        __typename: 'InsightView',
+                    },
+                ],
+                __typename: 'InsightViewConnection',
+            },
+        },
+    },
+}
+
+export const BackendInsightDemoCasesShowcase: Story = () => (
+    <div>
+        <GQLBackendProvider mocks={[BACKEND_INSIGHT_COMPONENT_MIGRATION_MOCK]}>
+            <BackendInsightView
+                style={{ width: 400, height: 400 }}
+                insight={COMPONENT_MIGRATION_INSIGHT_CONFIGURATION}
+                telemetryService={NOOP_TELEMETRY_SERVICE}
+                innerRef={() => {}}
+            />
+        </GQLBackendProvider>
+
+        <GQLBackendProvider mocks={[BACKEND_INSIGHT_DATA_FETCHING_MOCK]}>
+            <BackendInsightView
+                style={{ width: 400, height: 400 }}
+                insight={DATA_FETCHING_INSIGHT_CONFIGURATION}
+                telemetryService={NOOP_TELEMETRY_SERVICE}
+                innerRef={() => {}}
+            />
+        </GQLBackendProvider>
+
+        <GQLBackendProvider mocks={[BACKEND_INSIGHT_TERRAFORM_AWS_VERSIONS_MOCK]}>
+            <BackendInsightView
+                style={{ width: 400, height: 400 }}
+                insight={TERRAFORM_INSIGHT_CONFIGURATION}
+                telemetryService={NOOP_TELEMETRY_SERVICE}
+                innerRef={() => {}}
+            />
+        </GQLBackendProvider>
+    </div>
+)
+
+const GQLCodeInsightProvider: React.FunctionComponent = props => {
+    const client = useApolloClient()
+
+    return (
+        <CodeInsightsBackendContext.Provider value={new CodeInsightsGqlBackend(client)}>
+            {props.children}
+        </CodeInsightsBackendContext.Provider>
+    )
+}
+
+interface GQLBackendProviderProps {
+    mocks: readonly MockedResponse[]
+}
+
+const GQLBackendProvider: React.FunctionComponent<GQLBackendProviderProps> = props => (
+    <MockedTestProvider mocks={props.mocks}>
+        <GQLCodeInsightProvider>{props.children}</GQLCodeInsightProvider>
+    </MockedTestProvider>
+)
+
+export const BackendInsightVitrine: Story = () => (
     <section>
         <article>
             <H2>Card</H2>


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/34772
Follow up for https://github.com/sourcegraph/sourcegraph/issues/34485

In order to increase our confidence that we have a proper logic for data handling around charts and data visualization, we should test our components with really low level mocks that should represent the real use cases that we may have on the backend in the production. 

This PR adds some new mocks for screenshot testing backend insight line chart that were taken from demo.sourcegraph.com insights. 

## Test plan
- Make sure that you can see the `backend-insight-demo-cases-showcase` story with three cases that were taken from demo.sourcegraph.com




## App preview:

- [Web](https://sg-web-vk-add-real-demo-showcase-backend.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-duwltywwke.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

