### PR TITLE
sg: finer grained .bin/ detection for FW

### DIFF
--- a/dev/sg/internal/run/run.go
+++ b/dev/sg/internal/run/run.go
@@ -129,29 +129,30 @@ func addToMacosFirewall(cmds []Command) func() error {
 				continue
 			}
 
-			binary := args[0]
-			if strings.HasPrefix(binary, ".bin/") || strings.HasPrefix(binary, "./.bin/") {
-				addException := script.Exec(shell.Join([]string{"sudo", firewallCmdPath, "--add", filepath.Join(root, binary)}))
-				msg, err := addException.String()
-				if err != nil {
-					stdout.Out.WriteLine(output.Linef(output.EmojiFailure, output.StyleBold, "%s: %s", binary, err.Error()))
-					continue
-				}
+			for _, binary := range args {
+				if strings.HasPrefix(binary, ".bin/") || strings.HasPrefix(binary, "./.bin/") {
+					addException := script.Exec(shell.Join([]string{"sudo", firewallCmdPath, "--add", filepath.Join(root, binary)}))
+					msg, err := addException.String()
+					if err != nil {
+						stdout.Out.WriteLine(output.Linef(output.EmojiFailure, output.StyleBold, "%s: %s", binary, err.Error()))
+						continue
+					}
 
-				// socketfilterfw helpfully always returns status 0, so we need to check
-				// the output to determine whether things worked or not. In all cases we
-				// don't error out becasue we want other commands to go through the firewall
-				// updates regardless.
-				switch {
-				case strings.Contains(msg, "does not exist"):
-					stdout.Out.WriteLine(output.Linef(output.EmojiFailure, output.StyleWarning, "%s: %s", binary, strings.TrimSpace(msg)))
+					// socketfilterfw helpfully always returns status 0, so we need to check
+					// the output to determine whether things worked or not. In all cases we
+					// don't error out becasue we want other commands to go through the firewall
+					// updates regardless.
+					switch {
+					case strings.Contains(msg, "does not exist"):
+						stdout.Out.WriteLine(output.Linef(output.EmojiFailure, output.StyleWarning, "%s: %s", binary, strings.TrimSpace(msg)))
 
-				case strings.Contains(msg, "added to firewall"):
-					stdout.Out.WriteLine(output.Linef(output.EmojiFailure, output.StyleSuccess, "%s: added to firewall", binary))
-					needsFirewallRestart = true
+					case strings.Contains(msg, "added to firewall"):
+						stdout.Out.WriteLine(output.Linef(output.EmojiSuccess, output.StyleSuccess, "%s: added to firewall", binary))
+						needsFirewallRestart = true
 
-				default:
-					stdout.Out.WriteLine(output.Linef("", output.StyleSuggestion, "%s: %s", binary, strings.TrimSpace(msg)))
+					default:
+						stdout.Out.WriteLine(output.Linef("", output.StyleSuggestion, "%s: %s", binary, strings.TrimSpace(msg)))
+					}
 				}
 			}
 		}


### PR DESCRIPTION
The previous PR https://github.com/sourcegraph/sourcegraph/pull/34475 nailed the root cause but it did not catch some edge cases where the command is behind a pipe. 

I zoomed with @BolajiOlajide and saw that Zoekt was the culprit that wasn't added as an exception. 

I suspect that the reason for with neither @bobheadxi or me have noticed it is because no connection attempt is being made to some services during the startup due to our local state. 

This PR now iterates through all commands, including the ones in a pipe. The result is that my firewall exceptions are now covering the missing binaries. 

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

Tested locally, asserted the presence of Zoekt in the exceptions in the firewall control panel. 
