### PR TITLE
insights: enable daily snapshots for capture group insights

### DIFF
--- a/enterprise/internal/insights/background/queryrunner/work_handler.go
+++ b/enterprise/internal/insights/background/queryrunner/work_handler.go
@@ -237,7 +237,7 @@ func (r *workHandler) searchHandler(ctx context.Context, job *Job, series *types
 	}
 	defer func() { err = tx.Done(err) }()
 
-	if job.PersistMode == string(store.SnapshotMode) {
+	if store.PersistMode(job.PersistMode) == store.SnapshotMode {
 		// The purpose of the snapshot is for low fidelity but recently updated data points.
 		// We store one snapshot of an insight at any time, so we prune the table whenever adding a new series.
 		if err := tx.DeleteSnapshots(ctx, series); err != nil {
@@ -271,14 +271,25 @@ func (r *workHandler) computeHandler(ctx context.Context, job *Job, series *type
 	if series.JustInTime {
 		return errors.Newf("just in time series are not eligible for background processing, series_id: %s", series.ID)
 	}
-	if store.PersistMode(job.PersistMode) != store.RecordMode {
-		return nil
+
+	tx, err := r.insightsStore.Transact(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() { err = tx.Done(err) }()
+
+	if store.PersistMode(job.PersistMode) == store.SnapshotMode {
+		// The purpose of the snapshot is for low fidelity but recently updated data points.
+		// We store one snapshot of an insight at any time, so we prune the table whenever adding a new series.
+		if err := tx.DeleteSnapshots(ctx, series); err != nil {
+			return err
+		}
 	}
 	recordings, err := r.generateComputeRecordings(ctx, job, recordTime)
 	if err != nil {
 		return err
 	}
-	if recordErr := r.insightsStore.RecordSeriesPoints(ctx, recordings); recordErr != nil {
+	if recordErr := tx.RecordSeriesPoints(ctx, recordings); recordErr != nil {
 		err = errors.Append(err, errors.Wrap(recordErr, "RecordSeriesPointsCapture"))
 	}
 	return err
@@ -301,7 +312,7 @@ func (r *workHandler) searchStreamHandler(ctx context.Context, job *Job, series 
 	}
 	defer func() { err = tx.Done(err) }()
 
-	if job.PersistMode == string(store.SnapshotMode) {
+	if store.PersistMode(job.PersistMode) == store.SnapshotMode {
 		// The purpose of the snapshot is for low fidelity but recently updated data points.
 		// We store one snapshot of an insight at any time, so we prune the table whenever adding a new series.
 		if err := tx.DeleteSnapshots(ctx, series); err != nil {

--- a/enterprise/internal/insights/background/queryrunner/work_handler.go
+++ b/enterprise/internal/insights/background/queryrunner/work_handler.go
@@ -285,6 +285,7 @@ func (r *workHandler) computeHandler(ctx context.Context, job *Job, series *type
 			return err
 		}
 	}
+
 	recordings, err := r.generateComputeRecordings(ctx, job, recordTime)
 	if err != nil {
 		return err


### PR DESCRIPTION
closes #33881

* No longer ignore snapshots in the compute path
* Prune snapshots as well

## Test plan
1. Make a new capture group insight, for example `file:go\.mod$ go\s*(\d\.\d+) patterntype:regexp`
2. Trigger a new snapshot by setting `next_snapshot_after` to `NOW()` in the `insight_series` table and restarting the worker.
3. Observe the snapshot is recorded.
4. Repeat step 2 and observe the snapshots table is pruned correctly.

The following screenshot shows a capture group insight compared to a standard one. The last data point comes from a snapshot. The last two data points are close together due to their timestamp (2022-04-25 and 2022-04-26). We can see this applies in both cases.
<img width="1146" alt="Screenshot 2022-04-26 at 12 09 05" src="https://user-images.githubusercontent.com/29406849/165298151-a20821a2-87da-497c-bcfb-624d285c6627.png">

This query fetches snapshots for capture group insights:
```
SELECT
	*
FROM
	series_points_snapshots sps
	JOIN insight_series ise ON ise.series_id = sps.series_id
WHERE
	ise.generation_method = 'search-compute';
```

