### PR TITLE
JetBrains: Wire up a basic version of the search box component

### DIFF
--- a/client/jetbrains/.stylelintrc.json
+++ b/client/jetbrains/.stylelintrc.json
@@ -2,7 +2,7 @@
   "extends": ["../../.stylelintrc.json"],
   "overrides": [
     {
-      "files": ["./webview/index.scss"],
+      "files": ["./webview/src/index.scss"],
       "rules": {
         "filenames/match-regex": null
       }

--- a/client/jetbrains/src/main/resources/html/index.html
+++ b/client/jetbrains/src/main/resources/html/index.html
@@ -1,11 +1,12 @@
 <html>
 <head>
-    <title>Sourcegraph</title>
-    <link rel="stylesheet" href="/dist/style.css"/>
-    <meta charset="utf-8"/>
+  <title>Sourcegraph</title>
+  <link rel="stylesheet" href="/dist/style.css"/>
+  <link rel="stylesheet" href="/dist/search.css"/>
+  <meta charset="utf-8"/>
 </head>
 <body>
-    <div id="main"></div>
-    <script src="/dist/search.js"></script>
+  <div id="main"></div>
+  <script src="/dist/search.js"></script>
 </body>
 </html>

--- a/client/jetbrains/tsconfig.json
+++ b/client/jetbrains/tsconfig.json
@@ -13,7 +13,7 @@
     "esModuleInterop": true,
     "resolveJsonModule": true,
     "strict": true,
-    "jsx": "react",
+    "jsx": "react-jsx",
   },
   "references": [
     { "path": "../shared" },

--- a/client/jetbrains/webpack.config.js
+++ b/client/jetbrains/webpack.config.js
@@ -18,7 +18,7 @@ const mode = process.env.NODE_ENV === 'production' ? 'production' : 'development
 
 const rootPath = path.resolve(__dirname, '../../')
 const jetbrainsWorkspacePath = path.resolve(rootPath, 'client', 'jetbrains')
-const webviewSourcePath = path.resolve(jetbrainsWorkspacePath, 'webview')
+const webviewSourcePath = path.resolve(jetbrainsWorkspacePath, 'webview', 'src')
 
 // Build artifacts are put directly into the JetBrains resources folder
 const distPath = path.resolve(jetbrainsWorkspacePath, 'src', 'main', 'resources', 'dist')

--- a/client/jetbrains/webview/index.scss
+++ b/client/jetbrains/webview/index.scss
@@ -1,1 +1,0 @@
-@import '../../branded/src/global-styles/index.scss';

--- a/client/jetbrains/webview/search/index.tsx
+++ b/client/jetbrains/webview/search/index.tsx
@@ -1,7 +1,0 @@
-import React from 'react'
-
-import { render } from 'react-dom'
-
-const node = document.querySelector('#main') as HTMLDivElement
-
-render(<p>Hello from React!</p>, node)

--- a/client/jetbrains/webview/src/index.scss
+++ b/client/jetbrains/webview/src/index.scss
@@ -1,0 +1,1 @@
+@import '../../../branded/src/global-styles/index.scss';

--- a/client/jetbrains/webview/src/search/App.module.scss
+++ b/client/jetbrains/webview/src/search/App.module.scss
@@ -1,0 +1,12 @@
+@import 'wildcard/src/global-styles/breakpoints';
+
+.search-box-container {
+    flex: 1 1 auto;
+    flex-grow: 0;
+    margin-top: 2rem;
+    margin-bottom: 4.5rem;
+    width: 100%;
+    max-width: var(--max-homepage-container-width);
+
+    position: relative;
+}

--- a/client/jetbrains/webview/src/search/App.tsx
+++ b/client/jetbrains/webview/src/search/App.tsx
@@ -1,0 +1,107 @@
+import React, { useCallback, useState } from 'react'
+
+import { EMPTY, NEVER, of } from 'rxjs'
+
+import { SearchPatternType, QueryState } from '@sourcegraph/search'
+import { SearchBox } from '@sourcegraph/search-ui'
+import { aggregateStreamingSearch, LATEST_VERSION, SearchMatch } from '@sourcegraph/shared/src/search/stream'
+import { EMPTY_SETTINGS_CASCADE } from '@sourcegraph/shared/src/settings/settings'
+import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
+import { WildcardThemeContext } from '@sourcegraph/wildcard'
+
+import styles from './App.module.scss'
+
+export const App: React.FunctionComponent = () => {
+    // Toggling case sensitivity or pattern type does NOT trigger a new search on home view.
+    const [caseSensitive, setCaseSensitivity] = useState(false)
+    const [patternType, setPatternType] = useState(SearchPatternType.literal)
+    const [results, setResults] = useState<SearchMatch[]>([])
+
+    const [userQueryState, setUserQueryState] = useState<QueryState>({
+        query: '',
+    })
+
+    const onSubmit = useCallback(() => {
+        aggregateStreamingSearch(of(userQueryState.query), {
+            version: LATEST_VERSION,
+            patternType,
+            caseSensitive,
+            trace: undefined,
+            sourcegraphURL: 'https://sourcegraph.com/.api',
+            decorationContextLines: 0,
+            // eslint-disable-next-line rxjs/no-ignored-subscription
+        }).subscribe(searchResults => {
+            setResults(searchResults.results)
+        })
+
+        console.log('onSubmit')
+    }, [caseSensitive, patternType, userQueryState])
+
+    const setSelectedSearchContextSpec = useCallback(() => console.log('setSelectedSearchContextSpec'), [])
+
+    return (
+        <WildcardThemeContext.Provider value={{ isBranded: true }}>
+            <div className={styles.searchBoxContainer}>
+                {/* eslint-disable-next-line react/forbid-elements */}
+                <form
+                    className="d-flex my-2"
+                    onSubmit={event => {
+                        event.preventDefault()
+                        onSubmit()
+                    }}
+                >
+                    <SearchBox
+                        caseSensitive={caseSensitive}
+                        setCaseSensitivity={setCaseSensitivity}
+                        patternType={patternType}
+                        setPatternType={setPatternType}
+                        isSourcegraphDotCom={true}
+                        hasUserAddedExternalServices={false}
+                        hasUserAddedRepositories={true}
+                        structuralSearchDisabled={false}
+                        queryState={userQueryState}
+                        onChange={setUserQueryState}
+                        onSubmit={onSubmit}
+                        authenticatedUser={null}
+                        searchContextsEnabled={true}
+                        showSearchContext={true}
+                        showSearchContextManagement={false}
+                        defaultSearchContextSpec="global"
+                        setSelectedSearchContextSpec={setSelectedSearchContextSpec}
+                        selectedSearchContextSpec={undefined}
+                        fetchSearchContexts={() => {
+                            throw new Error('fetchSearchContexts')
+                        }}
+                        fetchAutoDefinedSearchContexts={() => NEVER}
+                        getUserSearchContextNamespaces={() => []}
+                        fetchStreamSuggestions={() => NEVER}
+                        settingsCascade={EMPTY_SETTINGS_CASCADE}
+                        globbing={false}
+                        isLightTheme={false}
+                        telemetryService={NOOP_TELEMETRY_SERVICE}
+                        platformContext={{
+                            requestGraphQL: () => EMPTY,
+                        }}
+                        className=""
+                        containerClassName=""
+                        autoFocus={true}
+                        editorComponent="monaco"
+                    />
+                </form>
+            </div>
+            <div>
+                <ul>
+                    {results.map((match: SearchMatch) =>
+                        match.type === 'content'
+                            ? match.lineMatches.map(line => (
+                                  <li key={`${match.path}-${line.lineNumber}-${JSON.stringify(line.offsetAndLengths)}`}>
+                                      {line.line} <small>{match.path}</small>
+                                  </li>
+                              ))
+                            : null
+                    )}
+                </ul>
+            </div>
+        </WildcardThemeContext.Provider>
+    )
+}

--- a/client/jetbrains/webview/src/search/index.tsx
+++ b/client/jetbrains/webview/src/search/index.tsx
@@ -1,0 +1,6 @@
+import { render } from 'react-dom'
+
+import { App } from './App'
+
+const node = document.querySelector('#main') as HTMLDivElement
+render(<App />, node)

--- a/client/shared/dev/generateCssModulesTypes.js
+++ b/client/shared/dev/generateCssModulesTypes.js
@@ -4,8 +4,9 @@ const { spawn } = require('child_process')
 const path = require('path')
 
 const REPO_ROOT = path.join(__dirname, '../../..')
-const CSS_MODULES_GLOB = path.resolve(__dirname, '../../**/src/**/*.module.scss')
-const TSM_COMMAND = `yarn --silent --ignore-engines --ignore-scripts tsm --logLevel error "${CSS_MODULES_GLOB}" --includePaths node_modules client`
+const CSS_MODULES_GLOB = path.resolve(__dirname, '../../*/src/**/*.module.scss')
+const JETBRAINS_CSS_MODULES_GLOB = path.resolve(__dirname, '../../jetbrains/webview/**/*.module.scss')
+const TSM_COMMAND = `yarn --silent --ignore-engines --ignore-scripts tsm --logLevel error "{${CSS_MODULES_GLOB},${JETBRAINS_CSS_MODULES_GLOB}}" --includePaths node_modules client`
 const [BIN, ...ARGS] = TSM_COMMAND.split(' ')
 
 /**

--- a/client/shared/dev/generateCssModulesTypes.js
+++ b/client/shared/dev/generateCssModulesTypes.js
@@ -4,7 +4,7 @@ const { spawn } = require('child_process')
 const path = require('path')
 
 const REPO_ROOT = path.join(__dirname, '../../..')
-const CSS_MODULES_GLOB = path.resolve(__dirname, '../../*/src/**/*.module.scss')
+const CSS_MODULES_GLOB = path.resolve(__dirname, '../../**/src/**/*.module.scss')
 const TSM_COMMAND = `yarn --silent --ignore-engines --ignore-scripts tsm --logLevel error "${CSS_MODULES_GLOB}" --includePaths node_modules client`
 const [BIN, ...ARGS] = TSM_COMMAND.split(' ')
 


### PR DESCRIPTION
Part of #34366

With a working web view and TypeScript setup, we're now able to import the web React components and render them inside JetBrains!

## Test plan

Manually verified the changes:

![Screenshot 2022-04-26 at 15 40 52](https://user-images.githubusercontent.com/458591/165313554-9eb41d1e-83d6-4eee-a8ff-4df5f27bb510.png)


<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->



## App preview:

- [Web](https://sg-web-ps-jetbrains-searchbox.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-xirbnhaknp.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
