### PR TITLE
Start using Architecture Decision Records (ADRs) in Sourcegraph.

### DIFF
--- a/adr/0001-record-architecture-decisions.md
+++ b/adr/0001-record-architecture-decisions.md
@@ -1,0 +1,25 @@
+# 1. Record architecture decisions
+
+Date: 2022-04-26
+
+## Context
+
+We have identified a need to capture architecturally significant decisions that will help us understand how our codebase evolved over time.
+
+- Usage of Architecture Decision Records (ADRs) has been proposed at the [Backend Crew Meeting](https://docs.google.com/document/d/1Y51d863Nuqr9BzbTbwwSF9jes0ro71vB724oc2p8qsQ/edit#heading=h.cwkac4n1yeqr).
+- The conversations have been initiated from the Slack thread (where we discussed whether we want to unify our RPC mechanism on gRPC on Protocol Buffers). As a side effect of that conversation, we realized there wasn't a good tool to capture architecturally significant decisions.
+
+## Decision
+
+- We will use Architecture Decision Records (ADRs) to log architecturally significant decisions.
+- ADRs are not meant to replace our current RFC process but to complement it by capturing decisions made in RFCs.
+- As a rule of thumb, we recommend creating ADRs only for those decisions that have a notable architectural impact on our codebase.
+
+## Consequences
+
+- Improve understanding of our codebase in time.
+- Improve onboarding.
+- Many potential positive cultural impacts are well-captured in the following posts:
+  - [Why write ADRs?](https://github.blog/2020-08-13-why-write-adrs/)
+  - [Documenting Architecture Decisions](https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions)
+  - [https://adr.github.io](https://adr.github.io)


### PR DESCRIPTION
## Description

Start using Architecture Decision Records (ADRs).

## Context

Explained in the ADR file.

## Format 

Loosely inspired by [the one from Michael Nygard](https://github.com/npryce/adr-tools/blob/master/doc/adr/0001-record-architecture-decisions.md). I've slightly modified it and dropped the **Status** section, as it felt like that conflicted with RFCs (RFCs help us to come up with decisions, ADRs will help us log them).

There are [other, more sophisticated templates](https://github.com/joelparkerhenderson/architecture-decision-record#adr-example-templates) that we could migrate to if we felt like the current one doesn't do a good job.

## Structure

This is an [example structure](https://github.com/npryce/adr-tools/tree/master/doc/adr) I propose to follow.

```
adr
├── 0001-record-architecture-decisions.md
├── 0002-foo-bar.md
└── 0003-some-decision.md

```

### Tooling

Flat files (markdown), nothing fancy.

There are existing supporting tools, such as [adr-tools](https://github.com/npryce/adr-tools), but my recommendation is to hand-write a few and create `sg adr` later on (once we're happy with how things are going).

## Test plan

None, this is just documentation.


