### PR TITLE
JetBrains: Open popup only once

### DIFF
--- a/client/jetbrains/src/main/java/com/sourcegraph/action/OpenSearchAction.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/action/OpenSearchAction.java
@@ -17,7 +17,7 @@ public class OpenSearchAction extends AnAction implements DumbAware {
             if (this.window == null) {
                 this.window = new SourcegraphWindow(e.getProject());
             }
-            this.window.createPopup().showCenteredInCurrentWindow(ProjectManager.getInstance().getOpenProjects()[0]);
+            this.window.showPopup();
         });
     }
 }

--- a/client/jetbrains/src/main/java/com/sourcegraph/ui/SourcegraphWindow.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/ui/SourcegraphWindow.java
@@ -25,6 +25,7 @@ public class SourcegraphWindow implements Disposable {
     private JCEFWindow jcefWindow;
     private final EditorFactory editorFactory;
     private JBPanel editorPanel;
+    private JBPopup popup;
 
     public SourcegraphWindow(Project project) {
         this.project = project;
@@ -74,25 +75,35 @@ public class SourcegraphWindow implements Disposable {
         panel.add(splitter, BorderLayout.CENTER);
     }
 
-    public JBPopup createPopup() {
-        JBPopup popup =  JBPopupFactory.getInstance().createComponentPopupBuilder(panel, panel)
-            .setTitle("Sourcegraph")
-            .setCancelOnClickOutside(false)
-            .setResizable(true)
-            .setModalContext(false)
-            .setRequestFocus(true)
-            .setFocusable(true)
-            .setMovable(true)
-            .setBelongsToGlobalPopupStack(true)
-            .setCancelOnOtherWindowOpen(true)
-            .setCancelKeyEnabled(true)
-            .setNormalWindowLevel(true)
-            .createPopup();
+    synchronized public JBPopup showPopup() {
+        if (this.popup == null || this.popup.isDisposed()) {
+            this.popup = JBPopupFactory.getInstance().createComponentPopupBuilder(panel, panel)
+                .setTitle("Sourcegraph")
+                .setCancelOnClickOutside(false)
+                .setResizable(true)
+                .setModalContext(false)
+                .setRequestFocus(true)
+                .setFocusable(true)
+                .setMovable(true)
+                .setBelongsToGlobalPopupStack(true)
+                .setCancelOnOtherWindowOpen(true)
+                .setCancelKeyEnabled(true)
+                .setNormalWindowLevel(true)
+                .createPopup();
+            this.popup.showCenteredInCurrentWindow(this.project);
+        }
+
+        // If the popup is already shown, hitting alt + a gain should behave the same as the native find in files
+        // feature and focus the search field.
         this.jcefWindow.focus();
+
         return popup;
     }
 
     @Override
     public void dispose() {
+        if (this.popup != null) {
+            this.popup.dispose();
+        }
     }
 }


### PR DESCRIPTION
This PR fixes an issue that is happening when the shortcut to show the search popup (`alt a`) is hit repeatedly.

To be aligned with the behavior of the native find in files search, hitting `alt a` while already in the search popup should focus the text field again. This does not work yet as we have not implemented the client side focus event for that but this will happen in `JCEFWindow#focus()`. (cc thanks @madppiper for the input!)

## Test plan

Tested this manually, here's a quick walk-through: https://www.loom.com/share/1fe3c67db2234aa18a2240bbcac92839

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->



## App preview:

- [Web](https://sg-web-ps-jetbrains-open-popup-once.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-duipymodzn.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
