### PR TITLE
sg: make firewall flag default depends on OS

### DIFF
--- a/dev/sg/internal/run/run.go
+++ b/dev/sg/internal/run/run.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"sync"
 	"time"
@@ -80,7 +79,7 @@ func Commands(ctx context.Context, globalEnv map[string]string, addToMacOSFirewa
 	}
 
 	postInstall := func() error { return nil }
-	if addToMacOSFirewall || runtime.GOOS == "darwin" {
+	if addToMacOSFirewall {
 		postInstall = addToMacosFirewall(cmds)
 	}
 	err = waitForInstallation(cmdNames, installed, failures, okayToStart, postInstall)

--- a/dev/sg/macos.go
+++ b/dev/sg/macos.go
@@ -1,13 +1,17 @@
 package main
 
-import "github.com/urfave/cli/v2"
+import (
+	"runtime"
+
+	"github.com/urfave/cli/v2"
+)
 
 var (
 	addToMacOSFirewall     bool
 	addToMacOSFirewallFlag = &cli.BoolFlag{
 		Name:        "add-to-macos-firewall",
 		Usage:       "OSX only; Add required exceptions to the firewall",
-		Value:       true,
+		Value:       runtime.GOOS == "darwin",
 		Destination: &addToMacOSFirewall,
 	}
 )


### PR DESCRIPTION
Fix a bug where the firewall flag is still defaulting to `true` on Linux systems. 

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

Tested locally. 

