### PR TITLE
batches: migrate instances of button with loading state to `LoaderButton`

### DIFF
--- a/client/web/src/enterprise/batches/close/BatchChangeCloseAlert.tsx
+++ b/client/web/src/enterprise/batches/close/BatchChangeCloseAlert.tsx
@@ -4,8 +4,9 @@ import * as H from 'history'
 
 import { ErrorAlert } from '@sourcegraph/branded/src/components/alerts'
 import { isErrorLike, asError, pluralize } from '@sourcegraph/common'
-import { Button, AlertLink, LoadingSpinner, CardBody, Card, Alert } from '@sourcegraph/wildcard'
+import { Button, AlertLink, CardBody, Card, Alert } from '@sourcegraph/wildcard'
 
+import { LoaderButton } from '../../../components/LoaderButton'
 import { Scalars } from '../../../graphql-operations'
 
 import { closeBatchChange as _closeBatchChange } from './backend'
@@ -103,14 +104,15 @@ export const BatchChangeCloseAlert: React.FunctionComponent<BatchChangeCloseAler
                         >
                             Cancel
                         </Button>
-                        <Button
+                        <LoaderButton
                             className="test-batches-confirm-close-btn"
                             onClick={onClose}
                             disabled={isClosing === true || !viewerCanAdminister}
                             variant="danger"
-                        >
-                            {isClosing === true && <LoadingSpinner />} Close batch change
-                        </Button>
+                            loading={isClosing === true}
+                            label="Close batch change"
+                            alwaysShowLabel={true}
+                        />
                     </div>
                 </CardBody>
             </Card>

--- a/client/web/src/enterprise/batches/detail/changesets/CloseChangesetsModal.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/CloseChangesetsModal.tsx
@@ -2,8 +2,9 @@ import React, { useCallback, useState } from 'react'
 
 import { ErrorAlert } from '@sourcegraph/branded/src/components/alerts'
 import { asError, isErrorLike } from '@sourcegraph/common'
-import { Button, LoadingSpinner, Modal } from '@sourcegraph/wildcard'
+import { Button, Modal } from '@sourcegraph/wildcard'
 
+import { LoaderButton } from '../../../../components/LoaderButton'
 import { Scalars } from '../../../../graphql-operations'
 import { closeChangesets as _closeChangesets } from '../backend'
 
@@ -51,10 +52,14 @@ export const CloseChangesetsModal: React.FunctionComponent<CloseChangesetsModalP
                 >
                     Cancel
                 </Button>
-                <Button onClick={onSubmit} disabled={isLoading === true} variant="primary">
-                    {isLoading === true && <LoadingSpinner />}
-                    Close
-                </Button>
+                <LoaderButton
+                    onClick={onSubmit}
+                    disabled={isLoading === true}
+                    variant="primary"
+                    loading={isLoading === true}
+                    alwaysShowLabel={true}
+                    label="Close"
+                />
             </div>
         </Modal>
     )

--- a/client/web/src/enterprise/batches/detail/changesets/CreateCommentModal.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/CreateCommentModal.tsx
@@ -3,8 +3,9 @@ import React, { useCallback, useState } from 'react'
 import { ErrorAlert } from '@sourcegraph/branded/src/components/alerts'
 import { Form } from '@sourcegraph/branded/src/components/Form'
 import { asError, isErrorLike } from '@sourcegraph/common'
-import { Button, LoadingSpinner, TextArea, Modal } from '@sourcegraph/wildcard'
+import { Button, TextArea, Modal } from '@sourcegraph/wildcard'
 
+import { LoaderButton } from '../../../../components/LoaderButton'
 import { Scalars } from '../../../../graphql-operations'
 import { createChangesetComments as _createChangesetComments } from '../backend'
 
@@ -75,10 +76,14 @@ export const CreateCommentModal: React.FunctionComponent<CreateCommentModalProps
                     >
                         Cancel
                     </Button>
-                    <Button type="submit" disabled={isLoading === true || commentBody.length === 0} variant="primary">
-                        {isLoading === true && <LoadingSpinner />}
-                        Post comments
-                    </Button>
+                    <LoaderButton
+                        type="submit"
+                        disabled={isLoading === true || commentBody.length === 0}
+                        variant="primary"
+                        loading={isLoading === true}
+                        alwaysShowLabel={true}
+                        label="Post comments"
+                    />
                 </div>
             </Form>
         </Modal>

--- a/client/web/src/enterprise/batches/detail/changesets/DetachChangesetsModal.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/DetachChangesetsModal.tsx
@@ -3,8 +3,9 @@ import React, { useCallback, useState } from 'react'
 import { ErrorAlert } from '@sourcegraph/branded/src/components/alerts'
 import { asError, isErrorLike } from '@sourcegraph/common'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
-import { Button, LoadingSpinner, Modal } from '@sourcegraph/wildcard'
+import { Button, Modal } from '@sourcegraph/wildcard'
 
+import { LoaderButton } from '../../../../components/LoaderButton'
 import { Scalars } from '../../../../graphql-operations'
 import { detachChangesets as _detachChangesets } from '../backend'
 
@@ -56,10 +57,14 @@ export const DetachChangesetsModal: React.FunctionComponent<DetachChangesetsModa
                 >
                     Cancel
                 </Button>
-                <Button onClick={onSubmit} disabled={isLoading === true} variant="primary">
-                    {isLoading === true && <LoadingSpinner />}
-                    Detach
-                </Button>
+                <LoaderButton
+                    onClick={onSubmit}
+                    disabled={isLoading === true}
+                    variant="primary"
+                    loading={isLoading === true}
+                    alwaysShowLabel={true}
+                    label="Detach"
+                />
             </div>
         </Modal>
     )

--- a/client/web/src/enterprise/batches/detail/changesets/MergeChangesetsModal.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/MergeChangesetsModal.tsx
@@ -3,8 +3,9 @@ import React, { useCallback, useState } from 'react'
 import { ErrorAlert } from '@sourcegraph/branded/src/components/alerts'
 import { Form } from '@sourcegraph/branded/src/components/Form'
 import { asError, isErrorLike } from '@sourcegraph/common'
-import { Button, LoadingSpinner, Modal } from '@sourcegraph/wildcard'
+import { Button, Modal } from '@sourcegraph/wildcard'
 
+import { LoaderButton } from '../../../../components/LoaderButton'
 import { Scalars } from '../../../../graphql-operations'
 import { mergeChangesets as _mergeChangesets } from '../backend'
 
@@ -74,10 +75,14 @@ export const MergeChangesetsModal: React.FunctionComponent<MergeChangesetsModalP
                 >
                     Cancel
                 </Button>
-                <Button onClick={onSubmit} disabled={isLoading === true} variant="primary">
-                    {isLoading === true && <LoadingSpinner />}
-                    Merge
-                </Button>
+                <LoaderButton
+                    onClick={onSubmit}
+                    disabled={isLoading === true}
+                    variant="primary"
+                    loading={isLoading === true}
+                    alwaysShowLabel={true}
+                    label="Merge"
+                />
             </div>
         </Modal>
     )

--- a/client/web/src/enterprise/batches/detail/changesets/PublishChangesetsModal.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/PublishChangesetsModal.tsx
@@ -3,8 +3,9 @@ import React, { useCallback, useState } from 'react'
 import { ErrorAlert } from '@sourcegraph/branded/src/components/alerts'
 import { Form } from '@sourcegraph/branded/src/components/Form'
 import { asError, isErrorLike } from '@sourcegraph/common'
-import { Button, LoadingSpinner, Modal } from '@sourcegraph/wildcard'
+import { Button, Modal } from '@sourcegraph/wildcard'
 
+import { LoaderButton } from '../../../../components/LoaderButton'
 import { Scalars } from '../../../../graphql-operations'
 import { publishChangesets as _publishChangesets } from '../backend'
 
@@ -74,10 +75,14 @@ export const PublishChangesetsModal: React.FunctionComponent<PublishChangesetsMo
                 >
                     Cancel
                 </Button>
-                <Button onClick={onSubmit} disabled={isLoading === true} variant="primary">
-                    {isLoading === true && <LoadingSpinner />}
-                    Publish
-                </Button>
+                <LoaderButton
+                    onClick={onSubmit}
+                    disabled={isLoading === true}
+                    variant="primary"
+                    loading={isLoading === true}
+                    alwaysShowLabel={true}
+                    label="Publish"
+                />
             </div>
         </Modal>
     )

--- a/client/web/src/enterprise/batches/detail/changesets/ReenqueueChangesetsModal.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/ReenqueueChangesetsModal.tsx
@@ -2,8 +2,9 @@ import React, { useCallback, useState } from 'react'
 
 import { ErrorAlert } from '@sourcegraph/branded/src/components/alerts'
 import { asError, isErrorLike } from '@sourcegraph/common'
-import { Button, LoadingSpinner, Modal } from '@sourcegraph/wildcard'
+import { Button, Modal } from '@sourcegraph/wildcard'
 
+import { LoaderButton } from '../../../../components/LoaderButton'
 import { Scalars } from '../../../../graphql-operations'
 import { reenqueueChangesets as _reenqueueChangesets } from '../backend'
 
@@ -51,10 +52,14 @@ export const ReenqueueChangesetsModal: React.FunctionComponent<ReenqueueChangese
                 >
                     Cancel
                 </Button>
-                <Button onClick={onSubmit} disabled={isLoading === true} variant="primary">
-                    {isLoading === true && <LoadingSpinner />}
-                    Re-enqueue
-                </Button>
+                <LoaderButton
+                    onClick={onSubmit}
+                    disabled={isLoading === true}
+                    variant="primary"
+                    loading={isLoading === true}
+                    alwaysShowLabel={true}
+                    label="Re-enqueue"
+                />
             </div>
         </Modal>
     )

--- a/client/web/src/enterprise/batches/execution/BatchSpecExecutionDetailsPage.tsx
+++ b/client/web/src/enterprise/batches/execution/BatchSpecExecutionDetailsPage.tsx
@@ -34,6 +34,7 @@ import {
 import { AuthenticatedUser } from '../../../auth'
 import { BatchChangesIcon } from '../../../batches/icons'
 import { HeroPage } from '../../../components/HeroPage'
+import { LoaderButton } from '../../../components/LoaderButton'
 import { PageTitle } from '../../../components/PageTitle'
 import { Duration } from '../../../components/time/Duration'
 import { Timestamp } from '../../../components/time/Timestamp'
@@ -261,14 +262,15 @@ const BatchSpecActions: React.FunctionComponent<BatchSpecActionsProps> = ({ batc
             <span>
                 <ButtonGroup direction="vertical" className="ml-2">
                     {(batchSpec.state === BatchSpecState.QUEUED || batchSpec.state === BatchSpecState.PROCESSING) && (
-                        <Button
+                        <LoaderButton
                             onClick={() => cancelBatchSpecExecution()}
                             disabled={isCancelLoading}
                             outline={true}
                             variant="danger"
-                        >
-                            {isCancelLoading && <LoadingSpinner />}Cancel
-                        </Button>
+                            loading={isCancelLoading}
+                            alwaysShowLabel={true}
+                            label="Cancel"
+                        />
                     )}
                     {!location.pathname.endsWith('preview') &&
                         batchSpec.applyURL &&
@@ -280,15 +282,16 @@ const BatchSpecActions: React.FunctionComponent<BatchSpecActionsProps> = ({ batc
                     {batchSpec.viewerCanRetry && batchSpec.state !== BatchSpecState.COMPLETED && (
                         // TODO: Add a second button to allow retrying an entire batch spec,
                         // including completed jobs.
-                        <Button
+                        <LoaderButton
                             onClick={() => retryBatchSpecExecution()}
                             disabled={isRetryLoading}
                             data-tooltip={isRetryLoading ? undefined : 'Retry all failed workspaces'}
                             outline={true}
                             variant="secondary"
-                        >
-                            {isRetryLoading && <LoadingSpinner />}Retry
-                        </Button>
+                            loading={isRetryLoading}
+                            alwaysShowLabel={true}
+                            label="Retry"
+                        />
                     )}
                     {!location.pathname.endsWith('preview') &&
                         batchSpec.applyURL &&

--- a/client/web/src/enterprise/batches/settings/AddCredentialModal.tsx
+++ b/client/web/src/enterprise/batches/settings/AddCredentialModal.tsx
@@ -4,8 +4,9 @@ import classNames from 'classnames'
 
 import { ErrorAlert } from '@sourcegraph/branded/src/components/alerts'
 import { Form } from '@sourcegraph/branded/src/components/Form'
-import { Button, LoadingSpinner, Modal, Link } from '@sourcegraph/wildcard'
+import { Button, Modal, Link } from '@sourcegraph/wildcard'
 
+import { LoaderButton } from '../../../components/LoaderButton'
 import { ExternalServiceKind, Scalars } from '../../../graphql-operations'
 
 import { useCreateBatchChangesCredential } from './backend'
@@ -226,15 +227,15 @@ export const AddCredentialModal: React.FunctionComponent<AddCredentialModalProps
                                 >
                                     Cancel
                                 </Button>
-                                <Button
+                                <LoaderButton
                                     type="submit"
                                     disabled={loading || credential.length === 0}
                                     className="test-add-credential-modal-submit"
                                     variant="primary"
-                                >
-                                    {loading && <LoadingSpinner />}
-                                    {requiresSSH ? 'Next' : 'Add credential'}
-                                </Button>
+                                    loading={loading}
+                                    alwaysShowLabel={true}
+                                    label={requiresSSH ? 'Next' : 'Add credential'}
+                                />
                             </div>
                         </Form>
                     </>

--- a/client/web/src/enterprise/batches/settings/RemoveCredentialModal.tsx
+++ b/client/web/src/enterprise/batches/settings/RemoveCredentialModal.tsx
@@ -1,8 +1,9 @@
 import React, { useCallback } from 'react'
 
 import { ErrorAlert } from '@sourcegraph/branded/src/components/alerts'
-import { Button, LoadingSpinner, Modal } from '@sourcegraph/wildcard'
+import { Button, Modal } from '@sourcegraph/wildcard'
 
+import { LoaderButton } from '../../../components/LoaderButton'
 import { BatchChangesCodeHostFields, BatchChangesCredentialFields } from '../../../graphql-operations'
 
 import { useDeleteBatchChangesCredential } from './backend'
@@ -61,15 +62,15 @@ export const RemoveCredentialModal: React.FunctionComponent<RemoveCredentialModa
                     <Button disabled={loading} className="mr-2" onClick={onCancel} outline={true} variant="secondary">
                         Cancel
                     </Button>
-                    <Button
+                    <LoaderButton
                         disabled={loading}
                         className="test-remove-credential-modal-submit"
                         onClick={onDelete}
                         variant="danger"
-                    >
-                        {loading && <LoadingSpinner />}
-                        Remove credentials
-                    </Button>
+                        loading={loading}
+                        alwaysShowLabel={true}
+                        label="Remove credentials"
+                    />
                 </div>
             </div>
         </Modal>


### PR DESCRIPTION
I noticed that when we were using a `Button` that has a `LoadingSpinner` appear when the action is occurring, we inconsistently included space between the spinner and the label text. There was also nothing dictating the spinner *had* to appear to the left of the label text. Fortunately, _there's an ~app~ component for that._

This just migrates our uses of buttons with spinners to the dedicated component, `LoaderButton.`

## Test plan

The underlying component is still a `Button` that has all of its props passed, so the only thing that should be changing is how the loading spinner is rendered. I have manually reviewed several cases of the button to verify this.

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->



## App preview:

- [Web](https://sg-web-kr-loader-button.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-lgbhcietjl.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
