### PR TITLE
Update Dockerized jaeger version

### DIFF
--- a/cmd/server/jaeger.sh
+++ b/cmd/server/jaeger.sh
@@ -4,7 +4,7 @@ set -euf -o pipefail
 
 [ -n "$OUTPUT" ]
 
-version=1.24.0
+version=1.30.0
 suffix="${version}-$(go env GOOS)-$(go env GOARCH)"
 target="${OUTPUT}/usr/local/bin/jaeger"
 url="https://github.com/jaegertracing/jaeger/releases/download/v${version}/jaeger-${suffix}.tar.gz"


### PR DESCRIPTION
Drive-by change, please double check as I'm not entirely knowledgeable about the consequences 🙏 

While I was on https://github.com/sourcegraph/sourcegraph/pull/34524 and did some quick search to see if there was another place this naming scheme was used, I stumbled on this file which we use to build Dockerized Jaeger. It was lagging quite a lot behind the one we use in `sg.config.yaml` so I bumped it. 


## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

green build should be fine AFAIK, as we're using this locally and it works.
