### PR TITLE
compute: add stream client for match context compute type

### DIFF
--- a/enterprise/internal/compute/client/match_context_client.go
+++ b/enterprise/internal/compute/client/match_context_client.go
@@ -24,9 +24,7 @@ func NewMatchContextRequest(baseURL string, query string) (*stdhttp.Request, err
 }
 
 type ComputeMatchContextStreamDecoder struct {
-	OnResult  func(ctx *compute.MatchContext)
-	OnAlert   func(*http.EventAlert)
-	OnError   func(*http.EventError)
+	OnResult  func(ctx []compute.MatchContext)
 	OnUnknown func(event, data []byte)
 }
 
@@ -41,11 +39,11 @@ func (rr ComputeMatchContextStreamDecoder) ReadAll(r io.Reader) error {
 			if rr.OnResult == nil {
 				continue
 			}
-			var d compute.MatchContext
+			var d []compute.MatchContext
 			if err := json.Unmarshal(data, &d); err != nil {
 				return errors.Errorf("failed to decode compute match context payload: %w", err)
 			}
-			rr.OnResult(&d)
+			rr.OnResult(d)
 		} else if bytes.Equal(event, []byte("done")) {
 			// Always the last event
 			break

--- a/enterprise/internal/compute/client/match_context_client.go
+++ b/enterprise/internal/compute/client/match_context_client.go
@@ -34,7 +34,6 @@ func (rr ComputeMatchContextStreamDecoder) ReadAll(r io.Reader) error {
 	dec := http.NewDecoder(r)
 
 	for dec.Scan() {
-
 		event := dec.Event()
 		data := dec.Data()
 
@@ -47,24 +46,6 @@ func (rr ComputeMatchContextStreamDecoder) ReadAll(r io.Reader) error {
 				return errors.Errorf("failed to decode compute match context payload: %w", err)
 			}
 			rr.OnResult(&d)
-		} else if bytes.Equal(event, []byte("alert")) {
-			if rr.OnAlert == nil {
-				continue
-			}
-			var d http.EventAlert
-			if err := json.Unmarshal(data, &d); err != nil {
-				return errors.Errorf("failed to decode alert payload: %w", err)
-			}
-			rr.OnAlert(&d)
-		} else if bytes.Equal(event, []byte("error")) {
-			if rr.OnError == nil {
-				continue
-			}
-			var d http.EventError
-			if err := json.Unmarshal(data, &d); err != nil {
-				return errors.Errorf("failed to decode error payload: %w", err)
-			}
-			rr.OnError(&d)
 		} else if bytes.Equal(event, []byte("done")) {
 			// Always the last event
 			break

--- a/enterprise/internal/compute/client/match_context_client.go
+++ b/enterprise/internal/compute/client/match_context_client.go
@@ -1,0 +1,79 @@
+package client
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	stdhttp "net/http"
+	"net/url"
+
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/compute"
+	"github.com/sourcegraph/sourcegraph/internal/search/streaming/http"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+// NewMatchContextRequest returns an http.Request against the streaming API for query.
+func NewMatchContextRequest(baseURL string, query string) (*stdhttp.Request, error) {
+	u := baseURL + "/compute/stream?q=" + url.QueryEscape(query)
+	req, err := stdhttp.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "text/event-stream")
+	return req, nil
+}
+
+type ComputeMatchContextStreamDecoder struct {
+	OnResult  func(ctx *compute.MatchContext)
+	OnAlert   func(*http.EventAlert)
+	OnError   func(*http.EventError)
+	OnUnknown func(event, data []byte)
+}
+
+func (rr ComputeMatchContextStreamDecoder) ReadAll(r io.Reader) error {
+	dec := http.NewDecoder(r)
+
+	for dec.Scan() {
+
+		event := dec.Event()
+		data := dec.Data()
+
+		if bytes.Equal(event, []byte("results")) {
+			if rr.OnResult == nil {
+				continue
+			}
+			var d compute.MatchContext
+			if err := json.Unmarshal(data, &d); err != nil {
+				return errors.Errorf("failed to decode compute match context payload: %w", err)
+			}
+			rr.OnResult(&d)
+		} else if bytes.Equal(event, []byte("alert")) {
+			if rr.OnAlert == nil {
+				continue
+			}
+			var d http.EventAlert
+			if err := json.Unmarshal(data, &d); err != nil {
+				return errors.Errorf("failed to decode alert payload: %w", err)
+			}
+			rr.OnAlert(&d)
+		} else if bytes.Equal(event, []byte("error")) {
+			if rr.OnError == nil {
+				continue
+			}
+			var d http.EventError
+			if err := json.Unmarshal(data, &d); err != nil {
+				return errors.Errorf("failed to decode error payload: %w", err)
+			}
+			rr.OnError(&d)
+		} else if bytes.Equal(event, []byte("done")) {
+			// Always the last event
+			break
+		} else {
+			if rr.OnUnknown == nil {
+				continue
+			}
+			rr.OnUnknown(event, data)
+		}
+	}
+	return dec.Err()
+}

--- a/enterprise/internal/compute/client/match_context_client.go
+++ b/enterprise/internal/compute/client/match_context_client.go
@@ -24,7 +24,7 @@ func NewMatchContextRequest(baseURL string, query string) (*stdhttp.Request, err
 }
 
 type ComputeMatchContextStreamDecoder struct {
-	OnResult  func(ctx []compute.MatchContext)
+	OnResult  func(results []compute.MatchContext)
 	OnUnknown func(event, data []byte)
 }
 

--- a/enterprise/internal/compute/client/match_context_client_test.go
+++ b/enterprise/internal/compute/client/match_context_client_test.go
@@ -19,8 +19,8 @@ data: {}`
 	resultCount := 0
 	unknownCount := 0
 	decoder := ComputeMatchContextStreamDecoder{
-		OnResult: func(matches []compute.MatchContext) {
-			resultCount += len(matches)
+		OnResult: func(results []compute.MatchContext) {
+			resultCount += len(results)
 		},
 		OnUnknown: func(event, data []byte) {
 			unknownCount++

--- a/enterprise/internal/compute/client/match_context_client_test.go
+++ b/enterprise/internal/compute/client/match_context_client_test.go
@@ -1,0 +1,36 @@
+package client
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/hexops/autogold"
+
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/compute"
+)
+
+func TestComputeMatchContextStreamDecoder_ReadAll(t *testing.T) {
+	raw := `event: results
+data: [{"matches":[{"value":"go 1.17","range":{"start":{"offset":-1,"line":2,"column":0},"end":{"offset":-1,"line":2,"column":7}},"environment":{"1":{"value":"1.17","range":{"start":{"offset":-1,"line":2,"column":3},"end":{"offset":-1,"line":2,"column":7}}}}}],"path":"go.mod","repositoryID":11,"repository":"github.com/sourcegraph/sourcegraph"}]
+
+event: done
+data: {}`
+
+	resultCount := 0
+	unknownCount := 0
+	decoder := ComputeMatchContextStreamDecoder{
+		OnResult: func(matches []compute.MatchContext) {
+			resultCount += len(matches)
+		},
+		OnUnknown: func(event, data []byte) {
+			unknownCount++
+		},
+	}
+
+	err := decoder.ReadAll(strings.NewReader(raw))
+	if err != nil {
+		t.Fatal(err)
+	}
+	autogold.Want("resultCount", int(1)).Equal(t, resultCount)
+	autogold.Want("unknownCount", int(0)).Equal(t, unknownCount)
+}


### PR DESCRIPTION
Adds a client similar to the main search stream client for the compute stream endpoint, but scoped to the MatchContext type. Longer term there is probably a better design for this considering the different "modes" of this API, but for now this solves our needs and doesn't seem too burdensome to change.

## Test plan

This is really just a partial PR as part of a larger change, but I did include a test to decode a real stream result.


