### PR TITLE
return insight series data in ascending order

### DIFF
--- a/enterprise/internal/insights/store/store.go
+++ b/enterprise/internal/insights/store/store.go
@@ -205,7 +205,7 @@ SELECT sub.series_id, sub.interval_time, SUM(sub.value) as value, sub.metadata, 
 	ORDER BY sp.series_id, interval_time, sp.repo_name_id
 ) sub
 GROUP BY sub.series_id, sub.interval_time, sub.metadata, sub.capture
-ORDER BY sub.series_id, sub.interval_time DESC
+ORDER BY sub.series_id, sub.interval_time ASC
 `
 
 // Note that the series_points table may contain duplicate points, or points recorded at irregular

--- a/enterprise/internal/insights/store/store_test.go
+++ b/enterprise/internal/insights/store/store_test.go
@@ -287,13 +287,8 @@ func TestRecordSeriesPoints(t *testing.T) {
 	want := []SeriesPoint{
 		{
 			SeriesID: "one",
-			Time:     current,
-			Value:    1.1,
-		},
-		{
-			SeriesID: "one",
-			Time:     current.Add(-time.Hour * 24 * 14),
-			Value:    2.2,
+			Time:     current.Add(-time.Hour * 24 * 42),
+			Value:    3.3,
 		},
 		{
 			SeriesID: "one",
@@ -302,8 +297,13 @@ func TestRecordSeriesPoints(t *testing.T) {
 		},
 		{
 			SeriesID: "one",
-			Time:     current.Add(-time.Hour * 24 * 42),
-			Value:    3.3,
+			Time:     current.Add(-time.Hour * 24 * 14),
+			Value:    2.2,
+		},
+		{
+			SeriesID: "one",
+			Time:     current,
+			Value:    1.1,
 		},
 	}
 


### PR DESCRIPTION
Change insight series points to be returned in ascending order 

resolves #34523 

## Test plan

verified that chart click though links to a search where the `after` clause time is before the `before` clause time

```  type:diff after:2022-01-16T19:00:00-05:00 before:2022-01-30T19:00:00-05:00 docs.sourcegraph.com file:client/web/src/enterprise```

Manual verified api request - when not using a capture group
```graphql
query GetInsightView {
  insightViews(id: INSIGHT_ID) {
    nodes {
      id
      dataSeriesDefinitions {
        ...definition
      }
      dataSeries {
        points {
          dateTime
          value         
        }
        __typename
      }
      __typename
    }
    __typename
  }
}

fragment definition on SearchInsightDataSeriesDefinition {
  generatedFromCaptureGroups
}
```
response - verified that points are in ascending order
```graphql
{
  "data": {
    "insightViews": {
      "nodes": [
        {
          "id": INSIGHT_ID,
          "dataSeriesDefinitions": [
            {
              "generatedFromCaptureGroups": false
            },
            {
              "generatedFromCaptureGroups": false
            }
          ],
          "dataSeries": [
            {
              "points": [
                {
                  "dateTime": "2021-11-22T00:00:00Z",
                  "value": 60
                },
                {
                  "dateTime": "2021-12-06T00:00:00Z",
                  "value": 60
                },
                {
                  "dateTime": "2021-12-20T00:00:00Z",
                  "value": 62
                },
                {
                  "dateTime": "2022-01-03T00:00:00Z",
                  "value": 62
                },
                {
                  "dateTime": "2022-01-17T00:00:00Z",
                  "value": 62
                },
                {
                  "dateTime": "2022-01-31T00:00:00Z",
                  "value": 62
                },
                {
                  "dateTime": "2022-02-14T00:00:00Z",
                  "value": 15
                },
                {
                  "dateTime": "2022-02-28T00:00:00Z",
                  "value": 16
                },
                {
                  "dateTime": "2022-03-14T00:00:00Z",
                  "value": 16
                },
                {
                  "dateTime": "2022-03-28T00:00:00Z",
                  "value": 16
                },
                {
                  "dateTime": "2022-04-11T00:00:00Z",
                  "value": 18
                },
                {
                  "dateTime": "2022-04-25T00:00:00Z",
                  "value": 18
                },
                {
                  "dateTime": "2022-04-26T00:51:21Z",
                  "value": 18
                }
              ],
              "__typename": "InsightsSeries"
            },
            {
              "points": [
                {
                  "dateTime": "2021-11-22T00:00:00Z",
                  "value": 4
                },
                {
                  "dateTime": "2021-12-06T00:00:00Z",
                  "value": 4
                },
                {
                  "dateTime": "2021-12-20T00:00:00Z",
                  "value": 4
                },
                {
                  "dateTime": "2022-01-03T00:00:00Z",
                  "value": 4
                },
                {
                  "dateTime": "2022-01-17T00:00:00Z",
                  "value": 4
                },
                {
                  "dateTime": "2022-01-31T00:00:00Z",
                  "value": 4
                },
                {
                  "dateTime": "2022-02-14T00:00:00Z",
                  "value": 2
                },
                {
                  "dateTime": "2022-02-28T00:00:00Z",
                  "value": 2
                },
                {
                  "dateTime": "2022-03-14T00:00:00Z",
                  "value": 2
                },
                {
                  "dateTime": "2022-03-28T00:00:00Z",
                  "value": 2
                },
                {
                  "dateTime": "2022-04-11T00:00:00Z",
                  "value": 2
                },
                {
                  "dateTime": "2022-04-25T00:00:00Z",
                  "value": 2
                },
                {
                  "dateTime": "2022-04-26T00:51:21Z",
                  "value": 2
                }
              ],
              "__typename": "InsightsSeries"
            }
          ],
          "__typename": "InsightView"
        }
      ],
      "__typename": "InsightViewConnection"
    }
  }
}
```


manually verified api response with a capture group
```graphql
query GetInsightView {
  insightViews(id: INSIGHT_ID) {
    nodes {
      id
      dataSeriesDefinitions {
        ...definition
      }
      dataSeries {
       
        points {
          dateTime
          value         
        }
        __typename
      }
      __typename
    }
    __typename
  }
}

fragment definition on SearchInsightDataSeriesDefinition {
  generatedFromCaptureGroups
}
```

response - verified that data points are in ascending order
```graphql
{
  "data": {
    "insightViews": {
      "nodes": [
        {
          "id": INSIGHT_ID,
          "dataSeriesDefinitions": [
            {
              "generatedFromCaptureGroups": true
            }
          ],
          "dataSeries": [
            {
              "points": [
                {
                  "dateTime": "2022-02-08T00:00:00Z",
                  "value": 2
                },
                {
                  "dateTime": "2022-02-15T00:00:00Z",
                  "value": 2
                },
                {
                  "dateTime": "2022-02-22T00:00:00Z",
                  "value": 2
                },
                {
                  "dateTime": "2022-03-01T00:00:00Z",
                  "value": 2
                },
                {
                  "dateTime": "2022-03-08T00:00:00Z",
                  "value": 2
                },
                {
                  "dateTime": "2022-03-15T00:00:00Z",
                  "value": 2
                },
                {
                  "dateTime": "2022-03-22T00:00:00Z",
                  "value": 2
                },
                {
                  "dateTime": "2022-03-29T00:00:00Z",
                  "value": 2
                },
                {
                  "dateTime": "2022-04-05T00:00:00Z",
                  "value": 2
                },
                {
                  "dateTime": "2022-04-12T00:00:00Z",
                  "value": 2
                },
                {
                  "dateTime": "2022-04-19T00:00:00Z",
                  "value": 2
                },
                {
                  "dateTime": "2022-04-26T00:00:00Z",
                  "value": 2
                }
              ],
              "__typename": "InsightsSeries"
            },
            {
              "points": [
                {
                  "dateTime": "2022-02-08T00:00:00Z",
                  "value": 1
                },
                {
                  "dateTime": "2022-02-15T00:00:00Z",
                  "value": 1
                },
                {
                  "dateTime": "2022-02-22T00:00:00Z",
                  "value": 1
                },
                {
                  "dateTime": "2022-03-01T00:00:00Z",
                  "value": 1
                },
                {
                  "dateTime": "2022-03-08T00:00:00Z",
                  "value": 1
                },
                {
                  "dateTime": "2022-03-15T00:00:00Z",
                  "value": 1
                },
                {
                  "dateTime": "2022-03-22T00:00:00Z",
                  "value": 1
                },
                {
                  "dateTime": "2022-03-29T00:00:00Z",
                  "value": 1
                },
                {
                  "dateTime": "2022-04-05T00:00:00Z",
                  "value": 1
                },
                {
                  "dateTime": "2022-04-12T00:00:00Z",
                  "value": 1
                },
                {
                  "dateTime": "2022-04-19T00:00:00Z",
                  "value": 1
                },
                {
                  "dateTime": "2022-04-26T00:00:00Z",
                  "value": 1
                }
              ],
              "__typename": "InsightsSeries"
            },
            {
              "points": [
                {
                  "dateTime": "2022-02-08T00:00:00Z",
                  "value": 52
                },
                {
                  "dateTime": "2022-02-15T00:00:00Z",
                  "value": 52
                },
                {
                  "dateTime": "2022-02-22T00:00:00Z",
                  "value": 52
                },
                {
                  "dateTime": "2022-03-01T00:00:00Z",
                  "value": 52
                },
                {
                  "dateTime": "2022-03-08T00:00:00Z",
                  "value": 52
                },
                {
                  "dateTime": "2022-03-15T00:00:00Z",
                  "value": 52
                },
                {
                  "dateTime": "2022-03-22T00:00:00Z",
                  "value": 53
                },
                {
                  "dateTime": "2022-03-29T00:00:00Z",
                  "value": 53
                },
                {
                  "dateTime": "2022-04-05T00:00:00Z",
                  "value": 53
                },
                {
                  "dateTime": "2022-04-12T00:00:00Z",
                  "value": 53
                },
                {
                  "dateTime": "2022-04-19T00:00:00Z",
                  "value": 53
                },
                {
                  "dateTime": "2022-04-26T00:00:00Z",
                  "value": 55
                }
              ],
              "__typename": "InsightsSeries"
            },
            {
              "points": [
                {
                  "dateTime": "2022-02-08T00:00:00Z",
                  "value": 10
                },
                {
                  "dateTime": "2022-02-15T00:00:00Z",
                  "value": 10
                },
                {
                  "dateTime": "2022-02-22T00:00:00Z",
                  "value": 10
                },
                {
                  "dateTime": "2022-03-01T00:00:00Z",
                  "value": 10
                },
                {
                  "dateTime": "2022-03-08T00:00:00Z",
                  "value": 10
                },
                {
                  "dateTime": "2022-03-15T00:00:00Z",
                  "value": 10
                },
                {
                  "dateTime": "2022-03-22T00:00:00Z",
                  "value": 10
                },
                {
                  "dateTime": "2022-03-29T00:00:00Z",
                  "value": 10
                },
                {
                  "dateTime": "2022-04-05T00:00:00Z",
                  "value": 10
                },
                {
                  "dateTime": "2022-04-12T00:00:00Z",
                  "value": 10
                },
                {
                  "dateTime": "2022-04-19T00:00:00Z",
                  "value": 10
                },
                {
                  "dateTime": "2022-04-26T00:00:00Z",
                  "value": 10
                }
              ],
              "__typename": "InsightsSeries"
            },
            {
              "points": [
                {
                  "dateTime": "2022-02-08T00:00:00Z",
                  "value": 1
                },
                {
                  "dateTime": "2022-02-15T00:00:00Z",
                  "value": 1
                },
                {
                  "dateTime": "2022-02-22T00:00:00Z",
                  "value": 2
                },
                {
                  "dateTime": "2022-03-01T00:00:00Z",
                  "value": 2
                },
                {
                  "dateTime": "2022-03-08T00:00:00Z",
                  "value": 2
                },
                {
                  "dateTime": "2022-03-15T00:00:00Z",
                  "value": 2
                },
                {
                  "dateTime": "2022-03-22T00:00:00Z",
                  "value": 2
                },
                {
                  "dateTime": "2022-03-29T00:00:00Z",
                  "value": 2
                },
                {
                  "dateTime": "2022-04-05T00:00:00Z",
                  "value": 2
                },
                {
                  "dateTime": "2022-04-12T00:00:00Z",
                  "value": 2
                },
                {
                  "dateTime": "2022-04-19T00:00:00Z",
                  "value": 2
                },
                {
                  "dateTime": "2022-04-26T00:00:00Z",
                  "value": 2
                }
              ],
              "__typename": "InsightsSeries"
            },
            {
              "points": [
                {
                  "dateTime": "2022-02-08T00:00:00Z",
                  "value": 114
                },
                {
                  "dateTime": "2022-02-15T00:00:00Z",
                  "value": 114
                },
                {
                  "dateTime": "2022-02-22T00:00:00Z",
                  "value": 114
                },
                {
                  "dateTime": "2022-03-01T00:00:00Z",
                  "value": 114
                },
                {
                  "dateTime": "2022-03-08T00:00:00Z",
                  "value": 114
                },
                {
                  "dateTime": "2022-03-15T00:00:00Z",
                  "value": 115
                },
                {
                  "dateTime": "2022-03-22T00:00:00Z",
                  "value": 115
                },
                {
                  "dateTime": "2022-03-29T00:00:00Z",
                  "value": 115
                },
                {
                  "dateTime": "2022-04-05T00:00:00Z",
                  "value": 115
                },
                {
                  "dateTime": "2022-04-12T00:00:00Z",
                  "value": 115
                },
                {
                  "dateTime": "2022-04-19T00:00:00Z",
                  "value": 115
                },
                {
                  "dateTime": "2022-04-26T00:00:00Z",
                  "value": 115
                }
              ],
              "__typename": "InsightsSeries"
            }
          ],
          "__typename": "InsightView"
        }
      ],
      "__typename": "InsightViewConnection"
    }
  }
}
```

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


