### PR TITLE
VSCE: Automate release

### DIFF
--- a/client/vscode/package.json
+++ b/client/vscode/package.json
@@ -227,6 +227,7 @@
     "watch:node": "NODE_ENV=development TARGET_TYPE=node yarn task:gulp watchWebpack",
     "watch:web": "NODE_ENV=development TARGET_TYPE=webworker yarn task:gulp watchWebpack",
     "watch:test": "NODE_ENV=development TARGET_TYPE=webworker IS_TEST=true yarn task:gulp watchWebpack",
-    "test-integration": "TS_NODE_PROJECT=tests/tsconfig.json mocha --parallel=$CI --retries=2 ./tests/**/*.test.ts"
+    "test-integration": "TS_NODE_PROJECT=tests/tsconfig.json mocha --parallel=$CI --retries=2 ./tests/**/*.test.ts",
+    "release": "ts-node ./scripts/release.ts"
   }
 }

--- a/client/vscode/scripts/release.ts
+++ b/client/vscode/scripts/release.ts
@@ -1,0 +1,21 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+import childProcess from 'child_process'
+import fs from 'fs'
+
+// Update package name from "@sourcegraph/vscode" to sourcegraph for publishing
+const originalPackageJson = fs.readFileSync('package.json').toString()
+
+try {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const packageJson: any = JSON.parse(originalPackageJson)
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    packageJson.name = 'sourcegraph'
+    fs.writeFileSync('package.json', JSON.stringify(packageJson))
+
+    childProcess.execSync('yarn vsce publish patch --pat $VSCODE_MARKETPLACE_TOKEN --yarn --allow-star-activation', {
+        stdio: 'inherit',
+    })
+} finally {
+    // Update package name back to "@sourcegraph/vscode"
+    fs.writeFileSync('package.json', originalPackageJson)
+}

--- a/dev/ci/runtype/runtype.go
+++ b/dev/ci/runtype/runtype.go
@@ -26,6 +26,7 @@ const (
 	TaggedRelease     // semver-tagged release
 	ReleaseBranch     // release branch build
 	BextReleaseBranch // browser extension release build
+	VsceReleaseBranch // vs code extension release build
 
 	// Main branches
 
@@ -92,12 +93,19 @@ func (t RunType) Matcher() *RunTypeMatcher {
 				"BEXT_NIGHTLY": "true",
 			},
 		}
+
 	case VsceNightly:
 		return &RunTypeMatcher{
 			EnvIncludes: map[string]string{
 				"VSCE_NIGHTLY": "true",
 			},
 		}
+	case VsceReleaseBranch:
+		return &RunTypeMatcher{
+			Branch:      "bext/release",
+			BranchExact: true,
+		}
+
 	case TaggedRelease:
 		return &RunTypeMatcher{
 			TagPrefix: "v",
@@ -168,6 +176,8 @@ func (t RunType) String() string {
 		return "Release branch"
 	case BextReleaseBranch:
 		return "Browser extension release build"
+	case VsceReleaseBranch:
+		return "VS Code extension release build"
 
 	case MainBranch:
 		return "Main branch"

--- a/dev/ci/runtype/runtype.go
+++ b/dev/ci/runtype/runtype.go
@@ -102,7 +102,7 @@ func (t RunType) Matcher() *RunTypeMatcher {
 		}
 	case VsceReleaseBranch:
 		return &RunTypeMatcher{
-			Branch:      "bext/release",
+			Branch:      "vsce/release",
 			BranchExact: true,
 		}
 

--- a/dev/ci/runtype/runtype_test.go
+++ b/dev/ci/runtype/runtype_test.go
@@ -61,6 +61,12 @@ func TestComputeRunType(t *testing.T) {
 		},
 		want: VsceNightly,
 	}, {
+		name: "vsce release",
+		args: args{
+			branch: "vsce/release",
+		},
+		want: VsceReleaseBranch,
+	}, {
 		name: "release nightly",
 		args: args{
 			branch: "main",

--- a/doc/dev/background-information/ci/reference.md
+++ b/doc/dev/background-information/ci/reference.md
@@ -153,6 +153,18 @@ Base pipeline (more steps might be included based on branch changes):
 - npm Release
 - Upload build trace
 
+### VS Code extension release build
+
+The run type for branches matching `vsce/release` (exact match).
+
+Base pipeline (more steps might be included based on branch changes):
+
+- ESLint (all)
+- Stylelint (all)
+- Puppeteer tests for vscode extension
+- Extension release
+- Upload build trace
+
 ### Main branch
 
 The run type for branches matching `main` (exact match).

--- a/enterprise/dev/ci/internal/ci/operations.go
+++ b/enterprise/dev/ci/internal/ci/operations.go
@@ -243,6 +243,7 @@ func addVSCExtIntegrationTests(pipeline *bk.Pipeline) {
 	pipeline.AddStep(
 		":vscode: Puppeteer tests for VS Code extension",
 		withYarnCache(),
+		bk.Cmd("yarn --frozen-lockfile --network-timeout 60000"),
 		bk.Cmd("yarn generate"),
 		bk.Cmd("yarn --cwd client/vscode -s build:test"),
 		bk.Cmd("yarn --cwd client/vscode -s test-integration --verbose"),
@@ -514,6 +515,20 @@ func addBrowserExtensionReleaseSteps(pipeline *bk.Pipeline) {
 		bk.Cmd("yarn --frozen-lockfile --network-timeout 60000"),
 		bk.Cmd("yarn workspace @sourcegraph/browser -s run build"),
 		bk.Cmd("yarn workspace @sourcegraph/browser release:npm"))
+}
+
+// Release the browser extension.
+func addVSCodeExtensionReleaseSteps(pipeline *bk.Pipeline) {
+	addVSCExtIntegrationTests(pipeline)
+
+	pipeline.AddWait()
+
+	// Release to the VS Code Marketplace
+	pipeline.AddStep(":vscode: Extension release",
+		withYarnCache(),
+		bk.Cmd("yarn --frozen-lockfile --network-timeout 60000"),
+		bk.Cmd("yarn generate"),
+		bk.Cmd("yarn --cwd client/vscode -s run release"))
 }
 
 // Adds a Buildkite pipeline "Wait".

--- a/enterprise/dev/ci/internal/ci/pipeline.go
+++ b/enterprise/dev/ci/internal/ci/pipeline.go
@@ -130,6 +130,15 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 			wait,
 			addBrowserExtensionReleaseSteps)
 
+	case runtype.VsceReleaseBranch:
+		// If this is a vs code extension release branch, run the vscode-extension tests and release
+		ops = operations.NewSet(
+			addClientLintersForAllFiles,
+			addBrowserExtensionUnitTests,
+			addVSCExtIntegrationTests,
+			wait,
+			addVSCodeExtensionReleaseSteps)
+
 	case runtype.BextNightly:
 		// If this is a browser extension nightly build, run the browser-extension tests and
 		// e2e tests.


### PR DESCRIPTION
Close https://github.com/sourcegraph/sourcegraph/issues/26437

Combining this with the changes made in the PR for adding the nightly build for VSCE https://github.com/sourcegraph/sourcegraph/pull/34522 to close https://github.com/sourcegraph/sourcegraph/issues/34205. 

This PR automates the release process for the VS Cod, where making commits to the `vsce/release` branch would trigger the release command to build and publish the extension directly to the VS Code Marketplace. 

After the PRs is merged to main, we will need to configure the jobs in buildkite and add the Personal Access Token for VS Code Marketplace into the pipeline.


## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

TBC
