### PR TITLE
Remove cloud waitlist sign-up CTA from settings

### DIFF
--- a/client/web/src/user/settings/aboutOrganization/AboutOrganizationPage.tsx
+++ b/client/web/src/user/settings/aboutOrganization/AboutOrganizationPage.tsx
@@ -25,21 +25,6 @@ export const AboutOrganizationPage: React.FunctionComponent<AboutOrganizationPag
                 description="Support for organizations is not currently available on Sourcegraph Cloud."
                 className="mb-3"
             />
-            <Container className="mb-4">
-                <h3>Private beta access for small teams now available</h3>
-                <p>
-                    Get instant access to code navigation and intelligence across your team’s private code and 2M open
-                    source repositories. Sourcegraph Cloud for teams brings enterprise advantages to small teams.
-                </p>
-                <ButtonLink
-                    to="https://share.hsforms.com/14OQ3RoPpQTOXvZlUpgx6-A1n7ku?utm_medium=direct-traffic&utm_source=in-product&utm_term=in-product-settings&utm_content=cloud-product-beta-teams"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    variant="primary"
-                >
-                    Sign up for private beta access <Icon as={OpenInNewIcon} />
-                </ButtonLink>
-            </Container>
             <SelfHostedCta
                 contentClassName={styles.selfHostedCtaContent}
                 page="organizations"

--- a/client/web/src/user/settings/aboutOrganization/AboutOrganizationPage.tsx
+++ b/client/web/src/user/settings/aboutOrganization/AboutOrganizationPage.tsx
@@ -1,9 +1,7 @@
 import React, { useEffect } from 'react'
 
-import OpenInNewIcon from 'mdi-react/OpenInNewIcon'
-
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
-import { Container, PageHeader, ButtonLink, Icon } from '@sourcegraph/wildcard'
+import { PageHeader } from '@sourcegraph/wildcard'
 
 import { PageTitle } from '../../../components/PageTitle'
 import { SelfHostedCta } from '../../../components/SelfHostedCta'


### PR DESCRIPTION

## Test plan
This change removes a waitlist sign-up call to action in the settings page. I have tested locally and as this does not meaningfully add/remove functionality, this does not require additional testing. 


## App preview:

- [Web](https://sg-web-rpp-remove-waitlist-settings.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-braebndnaa.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
