### PR TITLE
search: factor out zoekt query logic in query_converter.go

### DIFF
--- a/internal/search/job/jobutil/job.go
+++ b/internal/search/job/jobutil/job.go
@@ -177,7 +177,7 @@ func ToSearchJob(searchInputs *run.SearchInputs, b query.Basic) (job.Job, error)
 
 		if resultTypes.Has(result.TypeStructural) {
 			typ := search.TextRequest
-			zoektQuery, err := search.QueryToZoektQuery(b, resultTypes, &features, typ)
+			zoektQuery, err := zoektutil.QueryToZoektQuery(b, resultTypes, &features, typ)
 			if err != nil {
 				return nil, err
 			}
@@ -488,7 +488,7 @@ type jobBuilder struct {
 }
 
 func (b *jobBuilder) newZoektGlobalSearch(typ search.IndexedRequestType) (job.Job, error) {
-	zoektQuery, err := search.QueryToZoektQuery(b.query, b.resultTypes, b.features, typ)
+	zoektQuery, err := zoektutil.QueryToZoektQuery(b.query, b.resultTypes, b.features, typ)
 	if err != nil {
 		return nil, err
 	}
@@ -531,7 +531,7 @@ func (b *jobBuilder) newZoektGlobalSearch(typ search.IndexedRequestType) (job.Jo
 }
 
 func (b *jobBuilder) newZoektSearch(typ search.IndexedRequestType) (job.Job, error) {
-	zoektQuery, err := search.QueryToZoektQuery(b.query, b.resultTypes, b.features, typ)
+	zoektQuery, err := zoektutil.QueryToZoektQuery(b.query, b.resultTypes, b.features, typ)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/search/query_converter.go
+++ b/internal/search/query_converter.go
@@ -1,7 +1,6 @@
 package search
 
 import (
-	"regexp/syntax" //nolint:depguard // zoekt requires this pkg
 	"strings"
 	"time"
 
@@ -12,10 +11,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/search/limits"
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
-	"github.com/sourcegraph/sourcegraph/internal/search/result"
-	"github.com/sourcegraph/sourcegraph/lib/errors"
-
-	zoekt "github.com/google/zoekt/query"
 )
 
 // UnionRegExps separates values with a | operator to create a string
@@ -67,14 +62,6 @@ func LangToFileRegexp(lang string) string {
 	return UnionRegExps(patterns)
 }
 
-func mapSlice(values []string, f func(string) string) []string {
-	result := make([]string, len(values))
-	for i, v := range values {
-		result[i] = f(v)
-	}
-	return result
-}
-
 type Protocol int
 
 const (
@@ -96,191 +83,4 @@ func TimeoutDuration(b query.Basic) time.Duration {
 		d = maxTimeout
 	}
 	return d
-}
-
-func fileRe(pattern string, queryIsCaseSensitive bool) (zoekt.Q, error) {
-	return parseRe(pattern, true, false, queryIsCaseSensitive)
-}
-
-func noOpAnyChar(re *syntax.Regexp) {
-	if re.Op == syntax.OpAnyChar {
-		re.Op = syntax.OpAnyCharNotNL
-	}
-	for _, s := range re.Sub {
-		noOpAnyChar(s)
-	}
-}
-
-func parseRe(pattern string, filenameOnly bool, contentOnly bool, queryIsCaseSensitive bool) (zoekt.Q, error) {
-	// these are the flags used by zoekt, which differ to searcher.
-	re, err := syntax.Parse(pattern, syntax.ClassNL|syntax.PerlX|syntax.UnicodeGroups)
-	if err != nil {
-		return nil, err
-	}
-	noOpAnyChar(re)
-	// zoekt decides to use its literal optimization at the query parser
-	// level, so we check if our regex can just be a literal.
-	if re.Op == syntax.OpLiteral {
-		return &zoekt.Substring{
-			Pattern:       string(re.Rune),
-			CaseSensitive: queryIsCaseSensitive,
-			Content:       contentOnly,
-			FileName:      filenameOnly,
-		}, nil
-	}
-	return &zoekt.Regexp{
-		Regexp:        re,
-		CaseSensitive: queryIsCaseSensitive,
-		Content:       contentOnly,
-		FileName:      filenameOnly,
-	}, nil
-}
-
-func toZoektPattern(expression query.Node, isCaseSensitive, patternMatchesContent, patternMatchesPath bool) (zoekt.Q, error) {
-	var fold func(node query.Node) (zoekt.Q, error)
-	fold = func(node query.Node) (zoekt.Q, error) {
-		switch n := node.(type) {
-		case query.Operator:
-			children := make([]zoekt.Q, 0, len(n.Operands))
-			for _, op := range n.Operands {
-				child, err := fold(op)
-				if err != nil {
-					return nil, err
-				}
-				children = append(children, child)
-			}
-			switch n.Kind {
-			case query.Or:
-				return &zoekt.Or{Children: children}, nil
-			case query.And:
-				return &zoekt.And{Children: children}, nil
-			default:
-				// unreachable
-				return nil, errors.Errorf("broken invariant: don't know what to do with node %T in toZoektPattern", node)
-			}
-		case query.Pattern:
-			var q zoekt.Q
-			var err error
-			fileNameOnly := patternMatchesPath && !patternMatchesContent
-			contentOnly := !patternMatchesPath && patternMatchesContent
-
-			pattern := n.Value
-			if n.Annotation.Labels.IsSet(query.Literal) {
-				pattern = regexp.QuoteMeta(pattern)
-			}
-
-			q, err = parseRe(pattern, fileNameOnly, contentOnly, isCaseSensitive)
-			if err != nil {
-				return nil, err
-			}
-
-			if n.Negated {
-				q = &zoekt.Not{Child: q}
-			}
-			return q, nil
-		}
-		// unreachable
-		return nil, errors.Errorf("broken invariant: don't know what to do with node %T in toZoektPattern", node)
-	}
-
-	q, err := fold(expression)
-	if err != nil {
-		return nil, err
-	}
-
-	return q, nil
-}
-
-func QueryToZoektQuery(b query.Basic, resultTypes result.Types, feat *Features, typ IndexedRequestType) (q zoekt.Q, err error) {
-	isCaseSensitive := b.IsCaseSensitive()
-
-	if b.Pattern != nil {
-		q, err = toZoektPattern(
-			b.Pattern,
-			isCaseSensitive,
-			resultTypes.Has(result.TypeFile),
-			resultTypes.Has(result.TypePath),
-		)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	// Handle file: and -file: filters.
-	filesInclude, filesExclude := b.IncludeExcludeValues(query.FieldFile)
-	// Handle lang: and -lang: filters.
-	langInclude, langExclude := b.IncludeExcludeValues(query.FieldLang)
-	filesInclude = append(filesInclude, mapSlice(langInclude, LangToFileRegexp)...)
-	filesExclude = append(filesExclude, mapSlice(langExclude, LangToFileRegexp)...)
-	filesReposMustInclude, filesReposMustExclude := b.IncludeExcludeValues(query.FieldRepoHasFile)
-
-	if typ == SymbolRequest && q != nil {
-		// Tell zoekt q must match on symbols
-		q = &zoekt.Symbol{
-			Expr: q,
-		}
-	}
-
-	var and []zoekt.Q
-	if q != nil {
-		and = append(and, q)
-	}
-
-	// zoekt also uses regular expressions for file paths
-	// TODO PathPatternsAreCaseSensitive
-	// TODO whitespace in file path patterns?
-	for _, i := range filesInclude {
-		q, err := fileRe(i, isCaseSensitive)
-		if err != nil {
-			return nil, err
-		}
-		and = append(and, q)
-	}
-	if len(filesExclude) > 0 {
-		q, err := fileRe(UnionRegExps(filesExclude), isCaseSensitive)
-		if err != nil {
-			return nil, err
-		}
-		and = append(and, &zoekt.Not{Child: q})
-	}
-
-	// For conditionals that happen on a repo we can use type:repo queries. eg
-	// (type:repo file:foo) (type:repo file:bar) will match all repos which
-	// contain a filename matching "foo" and a filename matchinb "bar".
-	//
-	// Note: (type:repo file:foo file:bar) will only find repos with a
-	// filename containing both "foo" and "bar".
-	for _, i := range filesReposMustInclude {
-		q, err := fileRe(i, isCaseSensitive)
-		if err != nil {
-			return nil, err
-		}
-		and = append(and, &zoekt.Type{Type: zoekt.TypeRepo, Child: q})
-	}
-	for _, i := range filesReposMustExclude {
-		q, err := fileRe(i, isCaseSensitive)
-		if err != nil {
-			return nil, err
-		}
-		and = append(and, &zoekt.Not{Child: &zoekt.Type{Type: zoekt.TypeRepo, Child: q}})
-	}
-
-	// Languages are already partially expressed with IncludePatterns, but Zoekt creates
-	// more precise language metadata based on file contents analyzed by go-enry, so it's
-	// useful to pass lang: queries down.
-	//
-	// Currently, negated lang queries create filename-based ExcludePatterns that cannot be
-	// corrected by the more precise language metadata. If this is a problem, indexed search
-	// queries should have a special query converter that produces *only* Language predicates
-	// instead of filepatterns.
-	if len(langInclude) > 0 && feat.ContentBasedLangFilters {
-		or := &zoekt.Or{}
-		for _, lang := range langInclude {
-			lang, _ = enry.GetLanguageByAlias(lang) // Invariant: lang is valid.
-			or.Children = append(or.Children, &zoekt.Language{Language: lang})
-		}
-		and = append(and, or)
-	}
-
-	return zoekt.Simplify(zoekt.NewAnd(and...)), nil
 }

--- a/internal/search/run/repo_has_file.go
+++ b/internal/search/run/repo_has_file.go
@@ -78,7 +78,7 @@ func (s *RepoSearch) reposContainingPath(ctx context.Context, clients job.Runtim
 				resultTypes = resultTypes.With(result.TypeFromString[t])
 			}
 		}
-		zoektQuery, err := search.QueryToZoektQuery(b, resultTypes, &s.Features, typ)
+		zoektQuery, err := zoektutil.QueryToZoektQuery(b, resultTypes, &s.Features, typ)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/search/textsearch/textsearch_test.go
+++ b/internal/search/textsearch/textsearch_test.go
@@ -456,7 +456,7 @@ func RunRepoSubsetTextSearch(
 		}
 
 		typ := search.TextRequest
-		zoektQuery, err := search.QueryToZoektQuery(b, resultTypes, nil, typ)
+		zoektQuery, err := zoektutil.QueryToZoektQuery(b, resultTypes, nil, typ)
 		if err != nil {
 			return nil, streaming.Stats{}, err
 		}

--- a/internal/search/zoekt/indexed_search_test.go
+++ b/internal/search/zoekt/indexed_search_test.go
@@ -273,7 +273,7 @@ func TestIndexedSearch(t *testing.T) {
 			}
 
 			var resultTypes result.Types
-			zoektQuery, err := search.QueryToZoektQuery(query.Basic{}, resultTypes, &search.Features{}, search.TextRequest)
+			zoektQuery, err := QueryToZoektQuery(query.Basic{}, resultTypes, &search.Features{}, search.TextRequest)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/search/zoekt/query.go
+++ b/internal/search/zoekt/query.go
@@ -1,0 +1,170 @@
+package zoekt
+
+import (
+	"github.com/go-enry/go-enry/v2"
+	"github.com/grafana/regexp"
+
+	"github.com/sourcegraph/sourcegraph/internal/search"
+	"github.com/sourcegraph/sourcegraph/internal/search/query"
+	"github.com/sourcegraph/sourcegraph/internal/search/result"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+
+	zoekt "github.com/google/zoekt/query"
+)
+
+func QueryToZoektQuery(b query.Basic, resultTypes result.Types, feat *search.Features, typ search.IndexedRequestType) (q zoekt.Q, err error) {
+	isCaseSensitive := b.IsCaseSensitive()
+
+	if b.Pattern != nil {
+		q, err = toZoektPattern(
+			b.Pattern,
+			isCaseSensitive,
+			resultTypes.Has(result.TypeFile),
+			resultTypes.Has(result.TypePath),
+		)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// Handle file: and -file: filters.
+	filesInclude, filesExclude := b.IncludeExcludeValues(query.FieldFile)
+	// Handle lang: and -lang: filters.
+	langInclude, langExclude := b.IncludeExcludeValues(query.FieldLang)
+	filesInclude = append(filesInclude, mapSlice(langInclude, search.LangToFileRegexp)...)
+	filesExclude = append(filesExclude, mapSlice(langExclude, search.LangToFileRegexp)...)
+	filesReposMustInclude, filesReposMustExclude := b.IncludeExcludeValues(query.FieldRepoHasFile)
+
+	if typ == search.SymbolRequest && q != nil {
+		// Tell zoekt q must match on symbols
+		q = &zoekt.Symbol{
+			Expr: q,
+		}
+	}
+
+	var and []zoekt.Q
+	if q != nil {
+		and = append(and, q)
+	}
+
+	// zoekt also uses regular expressions for file paths
+	// TODO PathPatternsAreCaseSensitive
+	// TODO whitespace in file path patterns?
+	for _, i := range filesInclude {
+		q, err := FileRe(i, isCaseSensitive)
+		if err != nil {
+			return nil, err
+		}
+		and = append(and, q)
+	}
+	if len(filesExclude) > 0 {
+		q, err := FileRe(search.UnionRegExps(filesExclude), isCaseSensitive)
+		if err != nil {
+			return nil, err
+		}
+		and = append(and, &zoekt.Not{Child: q})
+	}
+
+	// For conditionals that happen on a repo we can use type:repo queries. eg
+	// (type:repo file:foo) (type:repo file:bar) will match all repos which
+	// contain a filename matching "foo" and a filename matchinb "bar".
+	//
+	// Note: (type:repo file:foo file:bar) will only find repos with a
+	// filename containing both "foo" and "bar".
+	for _, i := range filesReposMustInclude {
+		q, err := FileRe(i, isCaseSensitive)
+		if err != nil {
+			return nil, err
+		}
+		and = append(and, &zoekt.Type{Type: zoekt.TypeRepo, Child: q})
+	}
+	for _, i := range filesReposMustExclude {
+		q, err := FileRe(i, isCaseSensitive)
+		if err != nil {
+			return nil, err
+		}
+		and = append(and, &zoekt.Not{Child: &zoekt.Type{Type: zoekt.TypeRepo, Child: q}})
+	}
+
+	// Languages are already partially expressed with IncludePatterns, but Zoekt creates
+	// more precise language metadata based on file contents analyzed by go-enry, so it's
+	// useful to pass lang: queries down.
+	//
+	// Currently, negated lang queries create filename-based ExcludePatterns that cannot be
+	// corrected by the more precise language metadata. If this is a problem, indexed search
+	// queries should have a special query converter that produces *only* Language predicates
+	// instead of filepatterns.
+	if len(langInclude) > 0 && feat.ContentBasedLangFilters {
+		or := &zoekt.Or{}
+		for _, lang := range langInclude {
+			lang, _ = enry.GetLanguageByAlias(lang) // Invariant: lang is valid.
+			or.Children = append(or.Children, &zoekt.Language{Language: lang})
+		}
+		and = append(and, or)
+	}
+
+	return zoekt.Simplify(zoekt.NewAnd(and...)), nil
+}
+
+func toZoektPattern(expression query.Node, isCaseSensitive, patternMatchesContent, patternMatchesPath bool) (zoekt.Q, error) {
+	var fold func(node query.Node) (zoekt.Q, error)
+	fold = func(node query.Node) (zoekt.Q, error) {
+		switch n := node.(type) {
+		case query.Operator:
+			children := make([]zoekt.Q, 0, len(n.Operands))
+			for _, op := range n.Operands {
+				child, err := fold(op)
+				if err != nil {
+					return nil, err
+				}
+				children = append(children, child)
+			}
+			switch n.Kind {
+			case query.Or:
+				return &zoekt.Or{Children: children}, nil
+			case query.And:
+				return &zoekt.And{Children: children}, nil
+			default:
+				// unreachable
+				return nil, errors.Errorf("broken invariant: don't know what to do with node %T in toZoektPattern", node)
+			}
+		case query.Pattern:
+			var q zoekt.Q
+			var err error
+			fileNameOnly := patternMatchesPath && !patternMatchesContent
+			contentOnly := !patternMatchesPath && patternMatchesContent
+
+			pattern := n.Value
+			if n.Annotation.Labels.IsSet(query.Literal) {
+				pattern = regexp.QuoteMeta(pattern)
+			}
+
+			q, err = parseRe(pattern, fileNameOnly, contentOnly, isCaseSensitive)
+			if err != nil {
+				return nil, err
+			}
+
+			if n.Negated {
+				q = &zoekt.Not{Child: q}
+			}
+			return q, nil
+		}
+		// unreachable
+		return nil, errors.Errorf("broken invariant: don't know what to do with node %T in toZoektPattern", node)
+	}
+
+	q, err := fold(expression)
+	if err != nil {
+		return nil, err
+	}
+
+	return q, nil
+}
+
+func mapSlice(values []string, f func(string) string) []string {
+	result := make([]string, len(values))
+	for i, v := range values {
+		result[i] = f(v)
+	}
+	return result
+}


### PR DESCRIPTION
Stacked on https://github.com/sourcegraph/sourcegraph/pull/34549.

Moves the Zoekt query conversion into Zoekt package. This will probably make Zoekt friends @keegancsmith et al. happy, no need to go hunting down for this logic in `internal/search`.

Now there are just a few dangling helper functions and types in `query_converter.go` to clean up/factor.

## Test plan
Semantics-preserving.

