### PR TITLE
[SG-34403-3] Improve Percy + accessibilityAudit test coverage on `Notebooks Explore Page`

### DIFF
--- a/client/web/src/components/FilteredConnection/FilterControl.tsx
+++ b/client/web/src/components/FilteredConnection/FilterControl.tsx
@@ -91,7 +91,7 @@ export const FilterControl: React.FunctionComponent<FilterControlProps> = ({
                             <div className="d-inline-flex flex-row mr-3 align-items-baseline">
                                 <p className="text-xl-center text-nowrap mr-2">{filter.label}:</p>
                                 <Select
-                                    aria-label=""
+                                    aria-label="Sort notebooks"
                                     id=""
                                     name={filter.id}
                                     onChange={event => onChange(filter, event.currentTarget.value)}

--- a/client/web/src/integration/notebook.test.ts
+++ b/client/web/src/integration/notebook.test.ts
@@ -767,4 +767,10 @@ https://sourcegraph.test:3443/github.com/sourcegraph/sourcegraph@branch/-/blob/c
         // The "Title 2" heading in the outline should be highlighted
         expect(await getHighlightedOutlineHeading()).toEqual('title-2-id-1')
     })
+    it('Notebook explore page should be accessible', async () => {
+        await driver.page.goto(driver.sourcegraphBaseUrl + '/notebooks?tab=explore')
+        await driver.page.waitForSelector('[data-testid="filtered-connection-nodes"]', { visible: true })
+        await percySnapshotWithVariants(driver.page, 'Explore notebooks')
+        await accessibilityAudit(driver.page)
+    })
 })

--- a/client/web/src/notebooks/listPage/NotebookNode.tsx
+++ b/client/web/src/notebooks/listPage/NotebookNode.tsx
@@ -37,7 +37,7 @@ function getNotebookDescription(blocks: NotebookBlock[]): string {
 export const NotebookNode: React.FunctionComponent<NotebookNodeProps> = ({ node }: NotebookNodeProps) => {
     const description = useMemo(() => getNotebookDescription(node.blocks), [node.blocks])
     return (
-        <div className={classNames('py-3', styles.notebookNode)}>
+        <li className={classNames('py-3', styles.notebookNode)}>
             <div className="d-flex align-items-center">
                 <Link to={PageRoutes.Notebook.replace(':id', node.id)} className={styles.notebookLink}>
                     <strong>{node.title}</strong>
@@ -74,6 +74,6 @@ export const NotebookNode: React.FunctionComponent<NotebookNodeProps> = ({ node 
                     Created <Timestamp date={node.createdAt} noAbout={true} />
                 </span>
             </div>
-        </div>
+        </li>
     )
 }


### PR DESCRIPTION
## Description
We currently have visual regression + accessibility audit tests on a series of user journeys within Sourcegraph. A lot of core functionality is still not covered, it reduces our confidence in shipping changes as UI/accessibility bugs can be introduced without our awareness.

## Implementation
For this [Notebook Page](https://sourcegraph.com/notebooks?tab=explore)
1. Add percySnapshotWithVariants to store a visual snapshot for the test.
2. Add accessibilityAudit to run our accessibility tests, and fix any identified problems.

## Refs
[Sourcegraph Issue](https://github.com/sourcegraph/sourcegraph/issues/34403)
[Gitstart Ticket](https://app.gitstart.com/clients/sourcegraph/tickets/SG-34403)

## Test plan
Run `ENTERPRISE=1 yarn build-web`
Run `ENTERPRISE=1 HEADLESS=true yarn _test-integration client/web/src/integration/notebook.test.ts`
Test should pass successfully