### PR TITLE
internal: ensure errors.Append has an error

### DIFF
--- a/lib/errors/errors.go
+++ b/lib/errors/errors.go
@@ -61,8 +61,11 @@ func CombineErrors(err1, err2 error) MultiError {
 
 // Append returns a MultiError created from all given errors, skipping errs that are nil.
 // If no non-nil errors are provided, nil is returned.
-func Append(err error, errs ...error) MultiError {
+func Append(err error, firstErr error, errs ...error) MultiError {
 	multi := CombineErrors(err, nil)
+	if firstErr != nil {
+		multi = CombineErrors(multi, firstErr)
+	}
 	for _, e := range errs {
 		if e != nil {
 			multi = CombineErrors(multi, e)


### PR DESCRIPTION
While I was writing some code appending errors, I accidentally wrote: 

```go
var errs error 
for _, elem := range things {
  err := doSomething(elem)
  errs = errors.Append(err) 
}
```

Can you spot the mistake? It should have been 

```go
  errs = errors.Append(errs, err) 
```

It's very similar to using `append` correctly, but somehow, because the package name is `errors` my brain did not register the mistake, as it looked like I was calling `Append` on a struct named `errors`. 

It's obvious that I'm the one at fault here, but keeping in mind the fact that often don't look at errors as much as we look at the slice we're appending to, it's much easier to miss this one, such a mistake could go unnoticed for a long time. At least, I would have in the present case if I did have written a unit test to ensure I was accumulating the errors. 

An easy fix is to declare it as: 

```go
func Append(err error, firstErr error, errs ...error) MultiError
```

The only issue is that it prevents things like `errors.Append(errs, others...)`. 

➡️ 💡 Maybe that should be a linter actually! 

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

The whole codebase builds and tests are green. 

