### PR TITLE
Fix incorrect use of errors.Append masking errors

### DIFF
--- a/enterprise/internal/insights/migration/migration.go
+++ b/enterprise/internal/insights/migration/migration.go
@@ -126,7 +126,7 @@ func (m *migrator) performBatchMigration(ctx context.Context, jobType store.Sett
 	for _, job := range jobs {
 		err := m.performMigrationForRow(ctx, jobStoreTx, *job)
 		if err != nil {
-			errs = errors.Append(err)
+			errs = errors.Append(errs, err)
 		}
 	}
 

--- a/internal/search/job/jobutil/sub_repo_perms_job.go
+++ b/internal/search/job/jobutil/sub_repo_perms_job.go
@@ -41,7 +41,7 @@ func (s *subRepoPermsFilterJob) Run(ctx context.Context, clients job.RuntimeClie
 		event.Results, err = applySubRepoFiltering(ctx, checker, event.Results)
 		if err != nil {
 			mu.Lock()
-			errs = errors.Append(err)
+			errs = errors.Append(errs, err)
 			mu.Unlock()
 		}
 		stream.Send(event)


### PR DESCRIPTION
Follow-up to https://github.com/sourcegraph/sourcegraph/pull/34563 

---

It's possible to pass only a single argument to errors.Append which has
the effect of not appending the errors and only returning the last one.

It's really easy to miss because the API makes it look like you're
calling an Append method on a receiver, which would imply it has a
side-effect. But it's not a receiver it's a package, so it just silently
discards errors.

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

Minor change, green build. 


