### PR TITLE
Accessibility template: Add additional GitStart checkbox

### DIFF
--- a/.github/ISSUE_TEMPLATE/accessibility_issue.yaml
+++ b/.github/ISSUE_TEMPLATE/accessibility_issue.yaml
@@ -57,3 +57,4 @@ body:
       - label: Please give this issue an estimate by applying a label like `estimate/Xd`, where X is the estimated number of days it will take to complete.
       - label: If this issue is specific to a specific Sourcegraph product, please assign the appropriate team label to this issue.
       - label: If this issue will require input from designers in order to complete, please assign the label `needs-design`.
+      - label: If you are confident that this issue should be worked on by GitStart, please assign the label `gitstart` and add the assignee 'gitstart-sourcegraph'

--- a/.github/ISSUE_TEMPLATE/accessibility_issue.yaml
+++ b/.github/ISSUE_TEMPLATE/accessibility_issue.yaml
@@ -57,4 +57,4 @@ body:
       - label: Please give this issue an estimate by applying a label like `estimate/Xd`, where X is the estimated number of days it will take to complete.
       - label: If this issue is specific to a specific Sourcegraph product, please assign the appropriate team label to this issue.
       - label: If this issue will require input from designers in order to complete, please assign the label `needs-design`.
-      - label: If you are confident that this issue should be worked on by GitStart, please assign the label `gitstart` and add the assignee 'gitstart-sourcegraph'
+      - label: If you are confident that this issue should be worked on by GitStart, please assign the label `gitstart` and add the assignee 'gitstart-sourcegraph'. The Frontend Platform team will still triage any unassigned issues.

--- a/.github/ISSUE_TEMPLATE/accessibility_issue.yaml
+++ b/.github/ISSUE_TEMPLATE/accessibility_issue.yaml
@@ -57,4 +57,4 @@ body:
       - label: Please give this issue an estimate by applying a label like `estimate/Xd`, where X is the estimated number of days it will take to complete.
       - label: If this issue is specific to a specific Sourcegraph product, please assign the appropriate team label to this issue.
       - label: If this issue will require input from designers in order to complete, please assign the label `needs-design`.
-      - label: If you are confident that this issue should be worked on by GitStart, please assign the label `gitstart` and add the assignee 'gitstart-sourcegraph'. The Frontend Platform team will still triage any unassigned issues.
+      - label: If you are confident that this issue should be worked on by GitStart, please assign the label `gitstart` and add the assignee `gitstart-sourcegraph`. The Frontend Platform team will still triage any unassigned issues.


### PR DESCRIPTION
Adds an additional checkbox to clarify that unassigned issues with be triaged by our team, and that GitStart are available to immediately pick up issues if it's obvious that they should.

## Test plan

N/A. Minor docs change.
<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


