### PR TITLE
Update helm chart references, release tooling command

### DIFF
--- a/dev/release/src/release.ts
+++ b/dev/release/src/release.ts
@@ -393,7 +393,7 @@ CI checks in this repository should pass, and a manual review should confirm if 
                             `find . -type f -name '*.md' ! -name 'CHANGELOG.md' -exec ${sed} -i -E 's/sourcegraph\\/server:${versionRegex}/sourcegraph\\/server:${release.version}/g' {} +`,
                             // Update Sourcegraph versions in installation guides
                             `find ./doc/admin/install/ -type f -name '*.md' -exec ${sed} -i -E 's/SOURCEGRAPH_VERSION="v${versionRegex}"/SOURCEGRAPH_VERSION="v${release.version}"/g' {} +`,
-                            `find ./doc/admin/install/ -type f -name '*.md' -exec ${sed} -i -E 's/--version "${versionRegex}"/--version "${release.version}"/g' {} +`,
+                            `find ./doc/admin/install/ -type f -name '*.md' -exec ${sed} -i -E 's/--version ${versionRegex}/--version ${release.version}/g' {} +`,
                             // Update fork variables in installation guides
                             `find ./doc/admin/install/ -type f -name '*.md' -exec ${sed} -i -E "s/DEPLOY_SOURCEGRAPH_DOCKER_FORK_REVISION='v${versionRegex}'/DEPLOY_SOURCEGRAPH_DOCKER_FORK_REVISION='v${release.version}'/g" {} +`,
                             // Update sourcegraph.com frontpage

--- a/doc/admin/install/kubernetes/helm.md
+++ b/doc/admin/install/kubernetes/helm.md
@@ -46,7 +46,7 @@ helm repo add sourcegraph https://helm.sourcegraph.com/release
 Install the Sourcegraph chart using default values:
 
 ```sh
-helm install --version 3.39.0 sourcegraph sourcegraph/sourcegraph
+helm install --version 3.39.1 sourcegraph sourcegraph/sourcegraph
 ```
 
 Sourcegraph should now be available via the address set. Browsing to the url should now provide access to the Sourcegraph UI to create the initial administrator account.
@@ -73,7 +73,7 @@ Example overrides can be found in the [examples](https://github.com/sourcegraph/
 
 Providing the override file to Helm is done with the inclusion of the values flag and the name of the file:
 ```sh
-helm upgrade --install --values ./override.yaml --version 3.39.0 sourcegraph sourcegraph/sourcegraph
+helm upgrade --install --values ./override.yaml --version 3.39.1 sourcegraph sourcegraph/sourcegraph
 ```
 When making configuration changes, it's recommended to review the changes that will be applied - see [Reviewing Changes](#reviewing-changes).
 
@@ -408,7 +408,7 @@ The override file includes a [BackendConfig] CRD. This is necessary to instruct 
 **2** – Install the chart
 
 ```sh
-helm upgrade --install --values ./override.yaml --version 3.39.0 sourcegraph sourcegraph/sourcegraph
+helm upgrade --install --values ./override.yaml --version 3.39.1 sourcegraph sourcegraph/sourcegraph
 ```
 
 It will take around 10 minutes for the load balancer to be fully ready, you may check on the status and obtain the load balancer IP using the following command:
@@ -521,7 +521,7 @@ storageClass:
 **2** – Install the chart
 
 ```sh
-helm upgrade --install --values ./override.yaml --version 3.39.0 sourcegraph sourcegraph/sourcegraph
+helm upgrade --install --values ./override.yaml --version 3.39.1 sourcegraph sourcegraph/sourcegraph
 ```
 
 It will take some time for the load balancer to be fully ready, use the following to check on the status and obtain the load balancer address (once available):
@@ -606,7 +606,7 @@ storageClass:
 **2** – Install the chart
 
 ```sh
-helm upgrade --install --values ./override.yaml --version 3.39.0 sourcegraph sourcegraph/sourcegraph
+helm upgrade --install --values ./override.yaml --version 3.39.1 sourcegraph sourcegraph/sourcegraph
 ```
 
 It will take some time for the load balancer to be fully ready, you can check on the status and obtain the load balancer address (when ready) using:
@@ -692,7 +692,7 @@ storageClass:
 **2** – Install the chart
 
 ```sh
-helm upgrade --install --values ./override.yaml --version 3.39.0 sourcegraph sourcegraph/sourcegraph
+helm upgrade --install --values ./override.yaml --version 3.39.1 sourcegraph sourcegraph/sourcegraph
 ```
 
 It may take some time before your ingress is up and ready to proceed. Depending on how your Ingress Controller works, you may be able to check on its status and obtain the public address of your Ingress using:
@@ -790,7 +790,7 @@ A new version of Sourcegraph is released every month (with patch releases in bet
 1.  Install the new version:
 
    ```bash
-      helm upgrade --install -f override.yaml --version 3.39.0 sourcegraph sourcegraph/sourcegraph
+      helm upgrade --install -f override.yaml --version 3.39.1 sourcegraph sourcegraph/sourcegraph
    ```
 
 1.  Verify the installation has started:


### PR DESCRIPTION
Update the docs to reference the new helm chart version, and fix the release tooling command that was supposed to do this automatically.

Same as https://github.com/sourcegraph/sourcegraph/pull/34441 but correct this time?

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->
Doc looks good, and I really ran the release tooling to verify the change this time (instead of just copy-pasting the find / sed).