### PR TITLE
doc: add info about user/repo pending permissions

### DIFF
--- a/doc/admin/repo/permissions.md
+++ b/doc/admin/repo/permissions.md
@@ -401,7 +401,7 @@ mutation {
 
 ### Pending permissions
 
-Pending permissions are created and stored when the repo permissions fetched from the code host contain users which are not yet users of Sourcegraph. This information is stored for the purpose of immediate repo access for such users after joining Sourcegraph. During the process of user creation `user_pending_permissions` is queried and if there are any permissions for the user being created, then these permissions are added to `user_permissions` table and this user is ready to go in no time. Without pending permissions, user would have waited for user permissions sync to happen.
+Pending permissions are created and stored when the repo permissions fetched from the code host contain users which are not yet users of Sourcegraph. This information is stored for the purpose of immediate repo access for such users after joining Sourcegraph. During the process of user creation `user_pending_permissions` is queried and if there are any permissions for the user being created, then these permissions are added to `user_permissions` table and this user is ready to go in no time. Without pending permissions, user would have waited for user a permissions sync to happen.
 
 As soon as new user is created (to be more precise -- during the creation process itself), pending permissions are used to populate "ordinary" permissions (`repo_permissions` and `user_permissions` tables), after that `user_permissions_table` is cleared (however, `repo_pending_permissions` [is not](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@v3.39.1/-/blob/enterprise/internal/database/perms_store.go?L979-981)).
 

--- a/doc/admin/repo/permissions.md
+++ b/doc/admin/repo/permissions.md
@@ -409,7 +409,7 @@ As soon as a new user is created on Sourcegraph, pending permissions (`repo_pend
 
 #### External code host user to Sourcegraph user mapping
 
-The `user_pending_permissions` table has a `bind_id` column which is an ID of the user of the external code host, for example a username for Bitbucket Server, a GraphID for GitHub or a user ID for GitLab.
+The [`user_pending_permissions` table](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/internal/database/schema.md#table-public-user-pending-permissions) has a `bind_id` column which is an ID of the user of the external code host, for example a username for Bitbucket Server, a GraphID for GitHub or a user ID for GitLab.
 
 User pending permission is a composite entity comprising:
 - `service_type` (e.g. `github.com`, `gitlab`, `bitbucketServer`)
@@ -418,13 +418,13 @@ User pending permission is a composite entity comprising:
 - `object_type` (type of what is enumerated in `object_ids_ints` column; for now it is `repos`)
 - `bind_id`
  
-all of which are included in a unique constraint. This entity is addressed in `user_ids_ints` column of `repo_pending_permissions` table by `id`.
+all of which are included in a unique constraint. This entity is addressed in `user_ids_ints` column of [`repo_pending_permissions` table](#repo-pending-permissions) by `id`.
 
 Overall, one entry of `user_pending_permissions` table means that _"There is a user with `bind_id` ID of this exact (`service_id`) external code host of this (`service_type`) type with such permissions for this (`object_ids_ints`) set of repos"_
 
 #### Repo pending permissions
 
-`repo_pending_permissions` table maps `user_pending_permissions` entities to repo ID along with the permission type (currently only `read` is supported). Each row of the table maps a repo ID to an array of `user_pending_permissions` entries. It is designed as an inverted `user_pending_permissions` for more performant CRUD operations (see the DB migration description in [this commit](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/compare/0705aa790d31fcd51713f4432496cc6bbb49cce8...bc30ae1186cf7a491ef21a5c00cb2f565288dfbb#diff-660eca66a5fad95783448fa468b2ce2fR50)).
+[`repo_pending_permissions` table](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/internal/database/schema.md#table-public-repo-pending-permissions) maps `user_pending_permissions` entities to repo ID along with the permission type (currently only `read` is supported). Each row of the table maps a repo ID to an array of `user_pending_permissions` entries. It is designed as an inverted `user_pending_permissions` for more performant CRUD operations (see the DB migration description in [this commit](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/compare/0705aa790d31fcd51713f4432496cc6bbb49cce8...bc30ae1186cf7a491ef21a5c00cb2f565288dfbb#diff-660eca66a5fad95783448fa468b2ce2fR50)).
 
 ## Explicit permissions API
 

--- a/doc/admin/repo/permissions.md
+++ b/doc/admin/repo/permissions.md
@@ -422,7 +422,7 @@ Overall, one entry of `user_pending_permissions` table means that _"There is a u
 
 #### Repo pending permissions
 
-`repo_pending_permissions` table maps `user_pending_permissions` entities to repo ID alongside with permission type (read/write). One row of the table maps one repo ID to an array of `user_pending_permissions` entries. Basically it is designed as an inverted `user_pending_permissions` for more performant CRUD operations (as per DB migration description in [this commit](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/compare/0705aa790d31fcd51713f4432496cc6bbb49cce8...bc30ae1186cf7a491ef21a5c00cb2f565288dfbb#diff-660eca66a5fad95783448fa468b2ce2fR50)).
+`repo_pending_permissions` table maps `user_pending_permissions` entities to repo ID alongside with permission type (only `read` currently). One row of the table maps one repo ID to an array of `user_pending_permissions` entries. Basically it is designed as an inverted `user_pending_permissions` for more performant CRUD operations (as per DB migration description in [this commit](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/compare/0705aa790d31fcd51713f4432496cc6bbb49cce8...bc30ae1186cf7a491ef21a5c00cb2f565288dfbb#diff-660eca66a5fad95783448fa468b2ce2fR50)).
 
 ## Explicit permissions API
 

--- a/doc/admin/repo/permissions.md
+++ b/doc/admin/repo/permissions.md
@@ -414,11 +414,11 @@ The [`user_pending_permissions` table](https://sourcegraph.com/github.com/source
 User pending permission is a composite entity comprising:
 - `service_type` (e.g. `github`, `gitlab`, `bitbucketServer`)
 - `service_id` (ID of the code host, e.g. `https://github.com/`, `https://gitlab.com/`)
-- `permission` (bitmask for a set of permissions)
+- `permission` (access level, e.g. "read")
 - `object_type` (type of what is enumerated in `object_ids_ints` column; for now it is `repos`)
 - `bind_id`
  
-All of which are included as a unique constraint. This entity is addressed in `user_ids_ints` column of [`repo_pending_permissions` table](#repo-pending-permissions) by `id`.
+All of which are included as a unique constraint. This entity is addressed in `user_ids_ints` column of [`repo_pending_permissions` table](#repo-pending-permissions) by `id`. Please see [this godoc](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@8e128dd3434b9e548176f8f1148ead3981458db9/-/blob/internal/authz/perms.go?L190-218=) for more information.
 
 Overall, one entry of `user_pending_permissions` table means that _"There is a user with `bind_id` ID of this exact (`service_id`) external code host of this (`service_type`) type with such permissions for this (`object_ids_ints`) set of repos"_.
 

--- a/doc/admin/repo/permissions.md
+++ b/doc/admin/repo/permissions.md
@@ -409,7 +409,7 @@ As soon as new user is created (to be more precise -- during the creation proces
 
 `user_pending_permissions` table has a `bind_id` column which is an ID of the user of external code host: a username for Bitbucket Server, a GraphID for GitHub or a user ID for GitLab. 
 
-User pending permission is a composite entity containing of:
+User pending permission is a composite entity comprising of:
 - `service_type` (e.g. `github.com`, `gitlab`, `bitbucketServer`);
 - `service_id` (ID of the code host, e.g. `https://github.com/`, `https://gitlab.com/`);
 - `permission` (bitmask for a set of permissions);


### PR DESCRIPTION
While I still remember anything about it, I am adding this doc

## Test plan
Not a functional change
<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


