### PR TITLE
JetBrains: Get rid of IntelliJ warnings

### DIFF
--- a/client/jetbrains/src/main/java/com/sourcegraph/action/OpenSearchAction.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/action/OpenSearchAction.java
@@ -4,18 +4,19 @@ import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.application.AppUIExecutor;
 import com.intellij.openapi.project.DumbAware;
-import com.intellij.openapi.project.ProjectManager;
 import com.sourcegraph.ui.SourcegraphWindow;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.Objects;
 
 public class OpenSearchAction extends AnAction implements DumbAware {
     private SourcegraphWindow window;
 
     @Override
-    public void actionPerformed(@NotNull AnActionEvent e) {
-        AppUIExecutor.onUiThread().execute(() -> {
+    public void actionPerformed(@NotNull AnActionEvent event) {
+        AppUIExecutor.onUiThread().execute(() -> { // TODO: .execute() is not part of the public API, use something else instead
             if (this.window == null) {
-                this.window = new SourcegraphWindow(e.getProject());
+                this.window = new SourcegraphWindow(Objects.requireNonNull(event.getProject()));
             }
             this.window.showPopup();
         });

--- a/client/jetbrains/src/main/java/com/sourcegraph/action/SearchRepository.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/action/SearchRepository.java
@@ -1,11 +1,12 @@
 package com.sourcegraph.action;
 
 import com.intellij.openapi.actionSystem.AnActionEvent;
+import org.jetbrains.annotations.NotNull;
 
 
 public class SearchRepository extends SearchActionBase {
     @Override
-    public void actionPerformed(AnActionEvent e) {
-        super.actionPerformedMode(e, "search.repository");
+    public void actionPerformed(@NotNull AnActionEvent event) {
+        super.actionPerformedMode(event, "search.repository");
     }
 }

--- a/client/jetbrains/src/main/java/com/sourcegraph/action/SearchSelection.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/action/SearchSelection.java
@@ -1,10 +1,11 @@
 package com.sourcegraph.action;
 
 import com.intellij.openapi.actionSystem.AnActionEvent;
+import org.jetbrains.annotations.NotNull;
 
 public class SearchSelection extends SearchActionBase {
     @Override
-    public void actionPerformed(AnActionEvent e) {
-        super.actionPerformedMode(e, "search");
+    public void actionPerformed(@NotNull AnActionEvent event) {
+        super.actionPerformedMode(event, "search");
     }
 }

--- a/client/jetbrains/src/main/java/com/sourcegraph/project/CommitViewUriBuilder.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/project/CommitViewUriBuilder.java
@@ -1,42 +1,40 @@
 package com.sourcegraph.project;
 
 import com.google.common.base.Strings;
-import com.sourcegraph.project.RepoInfo;
 import com.sourcegraph.util.SourcegraphUtil;
 
-import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 
 public class CommitViewUriBuilder {
 
-  public URI build(String sourcegraphBase, String revisionNumber, RepoInfo repoInfo, String productName, String productVersion) {
-    if (Strings.isNullOrEmpty(sourcegraphBase)) {
-      throw new RuntimeException("Missing sourcegraph URI for commit uri.");
-    } else if (Strings.isNullOrEmpty(revisionNumber)) {
-      throw new RuntimeException("Missing revision number for commit uri.");
-    } else if (repoInfo == null || Strings.isNullOrEmpty(repoInfo.remoteURL)) {
-      throw new RuntimeException("Missing remote URL for commit uri.");
+    public URI build(String sourcegraphBase, String revisionNumber, RepoInfo repoInfo, String productName, String productVersion) {
+        if (Strings.isNullOrEmpty(sourcegraphBase)) {
+            throw new RuntimeException("Missing sourcegraph URI for commit uri.");
+        } else if (Strings.isNullOrEmpty(revisionNumber)) {
+            throw new RuntimeException("Missing revision number for commit uri.");
+        } else if (repoInfo == null || Strings.isNullOrEmpty(repoInfo.remoteURL)) {
+            throw new RuntimeException("Missing remote URL for commit uri.");
+        }
+
+        // this is pretty hacky but to try to build the repo string we will just try to naively parse the git remote uri. Worst case scenario this 404s
+        String remoteURL = repoInfo.remoteURL;
+        if (remoteURL.startsWith("git")) {
+            remoteURL = repoInfo.remoteURL.replace(".git", "").replaceFirst(":", "/").replace("git@", "https://");
+        }
+        URI remote = URI.create(remoteURL);
+        String path = remote.getPath();
+
+        String url = sourcegraphBase +
+            String.format("/%s%s", remote.getHost(), path) +
+            String.format("/-/commit/%s", revisionNumber) +
+            String.format("?editor=%s", URLEncoder.encode("JetBrains", StandardCharsets.UTF_8)) +
+            String.format("&version=%s", URLEncoder.encode(SourcegraphUtil.VERSION, StandardCharsets.UTF_8)) +
+            String.format("&utm_product_name=%s", URLEncoder.encode(productName, StandardCharsets.UTF_8)) +
+            String.format("&utm_product_version=%s", URLEncoder.encode(productVersion, StandardCharsets.UTF_8));
+
+        return URI.create(url);
     }
-
-    // this is pretty hacky but to try to build the repo string we will just try to naively parse the git remote uri. Worst case scenario this 404s
-    String remoteURL = repoInfo.remoteURL;
-    if(remoteURL.startsWith("git")){
-      remoteURL = repoInfo.remoteURL.replace(".git", "").replaceFirst(":", "/").replace("git@", "https://");
-    }
-    URI remote = URI.create(remoteURL);
-    String path = remote.getPath();
-
-      String url = sourcegraphBase +
-              String.format("/%s%s", remote.getHost(), path) +
-              String.format("/-/commit/%s", revisionNumber) +
-              String.format("?editor=%s", URLEncoder.encode("JetBrains", StandardCharsets.UTF_8)) +
-              String.format("&version=%s", URLEncoder.encode(SourcegraphUtil.VERSION, StandardCharsets.UTF_8)) +
-              String.format("&utm_product_name=%s", URLEncoder.encode(productName, StandardCharsets.UTF_8)) +
-              String.format("&utm_product_version=%s", URLEncoder.encode(productVersion, StandardCharsets.UTF_8));
-
-    return URI.create(url);
-  }
 
 }

--- a/client/jetbrains/src/main/java/com/sourcegraph/project/RepoInfo.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/project/RepoInfo.java
@@ -1,9 +1,9 @@
 package com.sourcegraph.project;
 
 public class RepoInfo {
-    public String fileRel;
-    public String remoteURL;
-    public String branch;
+    public final String fileRel;
+    public final String remoteURL;
+    public final String branch;
 
     public RepoInfo(String sFileRel, String sRemoteURL, String sBranch) {
         fileRel = sFileRel;

--- a/client/jetbrains/src/main/java/com/sourcegraph/scheme/SchemeHandler.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/scheme/SchemeHandler.java
@@ -82,16 +82,18 @@ public class SchemeHandler extends CefResourceHandlerAdapter {
     }
 
     private boolean loadContent(String resName) {
-        InputStream inStream = getClass().getResourceAsStream(resName);
-        if (inStream != null) {
-            try {
+        try (
+            InputStream inStream = getClass().getResourceAsStream(resName)
+        ) {
+            if (inStream != null) {
                 ByteArrayOutputStream outFile = new ByteArrayOutputStream();
-                int readByte = -1;
+                int readByte;
                 while ((readByte = inStream.read()) >= 0) outFile.write(readByte);
                 this.data = outFile.toByteArray();
                 return true;
-            } catch (IOException e) {
             }
+        } catch (IOException e) {
+            return false;
         }
         return false;
     }

--- a/client/jetbrains/src/main/java/com/sourcegraph/service/JCEFService.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/service/JCEFService.java
@@ -4,10 +4,9 @@ import com.intellij.openapi.project.Project;
 import com.sourcegraph.ui.JCEFWindow;
 
 public class JCEFService {
-    private Project project;
-    private JCEFWindow window;
+    private final JCEFWindow window;
+
     public JCEFService(Project project) {
-        this.project = project;
         this.window = new JCEFWindow(project);
     }
 

--- a/client/jetbrains/src/main/java/com/sourcegraph/ui/JCEFWindow.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/ui/JCEFWindow.java
@@ -12,15 +12,13 @@ import org.cef.browser.CefBrowser;
 
 import javax.swing.*;
 import java.awt.*;
+import java.util.Objects;
 
 public class JCEFWindow {
-    private JPanel panel;
-    private Project project;
-    private JBCefBrowserBase browser;
+    private final JPanel panel;
     private CefBrowser cefBrowser;
 
     public JCEFWindow(Project project) {
-        this.project = project;
         panel = new JPanel(new BorderLayout());
 
         if (!JBCefApp.isSupported()) {
@@ -29,24 +27,18 @@ public class JCEFWindow {
             return;
         }
 
-        this.browser = new JBCefBrowser("http://sourcegraph/html/index.html") ;
-        this.cefBrowser= browser.getCefBrowser();
+        JBCefBrowserBase browser = new JBCefBrowser("http://sourcegraph/html/index.html");
+        this.cefBrowser = browser.getCefBrowser();
 
-        CefApp
-            .getInstance()
-            .registerSchemeHandlerFactory(
-    "http",
-    "sourcegraph",
-                new SchemeHandlerFactory()
-            );
+        CefApp.getInstance().registerSchemeHandlerFactory("http", "sourcegraph", new SchemeHandlerFactory());
 
-        panel.add(this.browser.getComponent(),BorderLayout.CENTER);
+        panel.add(Objects.requireNonNull(browser.getComponent()), BorderLayout.CENTER);
 
 
         String backgroundColor = "#" + Integer.toHexString(UIUtil.getPanelBackground().getRGB()).substring(2);
-        this.browser.setPageBackgroundColor(backgroundColor);
+        browser.setPageBackgroundColor(backgroundColor);
 
-        Disposer.register(project, this.browser);
+        Disposer.register(project, browser);
     }
 
     public JPanel getContent() {

--- a/client/jetbrains/src/main/java/com/sourcegraph/ui/SourcegraphWindow.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/ui/SourcegraphWindow.java
@@ -85,7 +85,7 @@ public class SourcegraphWindow implements Disposable {
         this.jcefWindow.focus();
     }
 
-    public JBPopup createPopup() {
+    private JBPopup createPopup() {
         return JBPopupFactory.getInstance().createComponentPopupBuilder(panel, panel)
             .setTitle("Sourcegraph")
             .setCancelOnClickOutside(false)

--- a/client/jetbrains/src/main/java/com/sourcegraph/ui/SourcegraphWindow.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/ui/SourcegraphWindow.java
@@ -10,7 +10,8 @@ import com.intellij.openapi.ui.popup.JBPopup;
 import com.intellij.openapi.ui.popup.JBPopupFactory;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.testFramework.LightVirtualFile;
-import com.intellij.ui.*;
+import com.intellij.ui.OnePixelSplitter;
+import com.intellij.ui.PopupBorder;
 import com.intellij.ui.components.JBPanel;
 import com.intellij.ui.components.JBPanelWithEmptyText;
 import com.intellij.util.ui.JBUI;
@@ -22,9 +23,7 @@ import java.awt.*;
 public class SourcegraphWindow implements Disposable {
     private final Project project;
     private final JPanel panel;
-    private JCEFWindow jcefWindow;
-    private final EditorFactory editorFactory;
-    private JBPanel editorPanel;
+    private final JCEFWindow jcefWindow;
     private JBPopup popup;
 
     public SourcegraphWindow(Project project) {
@@ -35,8 +34,8 @@ public class SourcegraphWindow implements Disposable {
         panel.setBorder(PopupBorder.Factory.create(true, true));
         panel.setFocusCycleRoot(true);
 
-        editorFactory = EditorFactory.getInstance();
-        editorPanel = new JBPanelWithEmptyText(new BorderLayout());
+        EditorFactory editorFactory = EditorFactory.getInstance();
+        JBPanel<JBPanelWithEmptyText> editorPanel = new JBPanelWithEmptyText(new BorderLayout());
 
         JCEFService service = project.getService(JCEFService.class);
         this.jcefWindow = service.getWindow();
@@ -75,9 +74,9 @@ public class SourcegraphWindow implements Disposable {
         panel.add(splitter, BorderLayout.CENTER);
     }
 
-    synchronized public JBPopup showPopup() {
+    synchronized public void showPopup() {
         if (this.popup == null || this.popup.isDisposed()) {
-            this.popup = JBPopupFactory.getInstance().createComponentPopupBuilder(panel, panel)
+            this.popup = JBPopupFactory.getInstance().createComponentPopupBuilder(panel, panel) // TODO: Try moving this to the constructor to prevent flickering
                 .setTitle("Sourcegraph")
                 .setCancelOnClickOutside(false)
                 .setResizable(true)
@@ -96,8 +95,6 @@ public class SourcegraphWindow implements Disposable {
         // If the popup is already shown, hitting alt + a gain should behave the same as the native find in files
         // feature and focus the search field.
         this.jcefWindow.focus();
-
-        return popup;
     }
 
     @Override

--- a/client/jetbrains/src/main/java/com/sourcegraph/ui/SourcegraphWindow.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/ui/SourcegraphWindow.java
@@ -76,25 +76,29 @@ public class SourcegraphWindow implements Disposable {
 
     synchronized public void showPopup() {
         if (this.popup == null || this.popup.isDisposed()) {
-            this.popup = JBPopupFactory.getInstance().createComponentPopupBuilder(panel, panel) // TODO: Try moving this to the constructor to prevent flickering
-                .setTitle("Sourcegraph")
-                .setCancelOnClickOutside(false)
-                .setResizable(true)
-                .setModalContext(false)
-                .setRequestFocus(true)
-                .setFocusable(true)
-                .setMovable(true)
-                .setBelongsToGlobalPopupStack(true)
-                .setCancelOnOtherWindowOpen(true)
-                .setCancelKeyEnabled(true)
-                .setNormalWindowLevel(true)
-                .createPopup();
+            this.popup = createPopup();
             this.popup.showCenteredInCurrentWindow(this.project);
         }
 
         // If the popup is already shown, hitting alt + a gain should behave the same as the native find in files
         // feature and focus the search field.
         this.jcefWindow.focus();
+    }
+
+    public JBPopup createPopup() {
+        return JBPopupFactory.getInstance().createComponentPopupBuilder(panel, panel)
+            .setTitle("Sourcegraph")
+            .setCancelOnClickOutside(false)
+            .setResizable(true)
+            .setModalContext(false)
+            .setRequestFocus(true)
+            .setFocusable(true)
+            .setMovable(true)
+            .setBelongsToGlobalPopupStack(true)
+            .setCancelOnOtherWindowOpen(true)
+            .setCancelKeyEnabled(true)
+            .setNormalWindowLevel(true)
+            .createPopup();
     }
 
     @Override

--- a/client/jetbrains/src/main/resources/META-INF/plugin.xml
+++ b/client/jetbrains/src/main/resources/META-INF/plugin.xml
@@ -14,25 +14,29 @@
   </extensions>
 
   <actions>
-    <action id="sourcegraph.openFile" class="com.sourcegraph.action.OpenFile" text="Open File" description="Open selection in Sourcegraph">
-      <keyboard-shortcut first-keystroke="alt shift a" keymap="$default"/>
-    </action>
-    <action id="sourcegraph.searchSelection" class="com.sourcegraph.action.SearchSelection" text="Search selection" description="Search selection on Sourcegraph">
-      <keyboard-shortcut first-keystroke="alt s" keymap="$default"/>
-    </action>
-    <action id="sourcegraph.searchRepository" class="com.sourcegraph.action.SearchRepository" text="Search selection in repository" description="Search selection in repository on Sourcegraph">
-      <keyboard-shortcut first-keystroke="alt r" keymap="$default"/>
-    </action>
-    <action id="sourcegraph.copy" class="com.sourcegraph.action.Copy" text="Copy Link to File" description="Copy link to Sourcegraph">
-      <keyboard-shortcut first-keystroke="alt c" keymap="$default"/>
-    </action>
-    <group id="SourcegraphEditor" icon="/icons/icon.png" popup="true" text="Sourcegraph">
-      <reference ref="sourcegraph.searchSelection"/>
-      <reference ref="sourcegraph.searchRepository"/>
-      <reference ref="sourcegraph.openFile"/>
-      <reference ref="sourcegraph.copy"/>
-      <add-to-group anchor="last" group-id="EditorPopupMenu"/>
-    </group>
+      <action id="sourcegraph.openFile" class="com.sourcegraph.action.OpenFile" text="Open File"
+              description="Open selection in Sourcegraph">
+          <keyboard-shortcut first-keystroke="alt shift a" keymap="$default"/>
+      </action>
+      <action id="sourcegraph.searchSelection" class="com.sourcegraph.action.SearchSelection" text="Search Selection"
+              description="Search selection on Sourcegraph">
+          <keyboard-shortcut first-keystroke="alt s" keymap="$default"/>
+      </action>
+      <action id="sourcegraph.searchRepository" class="com.sourcegraph.action.SearchRepository"
+              text="Search Selection in Repository" description="Search selection in repository on Sourcegraph">
+          <keyboard-shortcut first-keystroke="alt r" keymap="$default"/>
+      </action>
+      <action id="sourcegraph.copy" class="com.sourcegraph.action.Copy" text="Copy Link to File"
+              description="Copy link to Sourcegraph">
+          <keyboard-shortcut first-keystroke="alt c" keymap="$default"/>
+      </action>
+      <group id="SourcegraphEditor" icon="/icons/icon.png" popup="true" text="Sourcegraph">
+          <reference ref="sourcegraph.searchSelection"/>
+          <reference ref="sourcegraph.searchRepository"/>
+          <reference ref="sourcegraph.openFile"/>
+          <reference ref="sourcegraph.copy"/>
+          <add-to-group anchor="last" group-id="EditorPopupMenu"/>
+      </group>
     <action id="com.sourcegraph.action.OpenRevisionAction" icon="/icons/icon.png" class="com.sourcegraph.action.OpenRevisionAction" text="Open in Sourcegraph" description="Open revision diff in Sourcegraph">
       <add-to-group group-id="VcsHistoryActionsGroup" anchor="last"/>
       <add-to-group group-id="Vcs.Log.ContextMenu" anchor="last"/>

--- a/client/jetbrains/src/main/resources/META-INF/pluginIcon.svg
+++ b/client/jetbrains/src/main/resources/META-INF/pluginIcon.svg
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 25.2.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" x="0px" y="0px"
+	 viewBox="0 0 53.4 55.5" style="enable-background:new 0 0 53.4 55.5;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#FFFFFF;}
+	.st1{fill:#FF5543;}
+	.st2{fill:#A112FF;}
+	.st3{fill:#00CBEC;}
+</style>
+	<g>
+	<g>
+		<path class="st1" d="M31.5,53.5c-2.8,0.5-5.5-1.3-6-4.1L17.8,7.9c-0.5-2.8,1.3-5.5,4.1-6s5.5,1.3,6,4.1l7.6,41.5
+			C36.1,50.3,34.2,53,31.5,53.5z"/>
+	</g>
+		<g>
+		<path class="st2" d="M11.6,46.5c-1.7,0.3-3.6-0.3-4.8-1.7c-1.8-2.2-1.6-5.4,0.6-7.2l32.1-27.3c2.2-1.8,5.4-1.6,7.2,0.6
+			c1.8,2.2,1.6,5.4-0.6,7.2L14,45.3C13.3,45.9,12.4,46.3,11.6,46.5z"/>
+	</g>
+		<g>
+		<g>
+			<path class="st3" d="M47.5,39.8c-0.9,0.2-1.8,0.1-2.6-0.2L5.1,25.5c-2.7-1-4.1-3.9-3.1-6.6s3.9-4.1,6.6-3.1L48.3,30
+				c2.7,1,4.1,3.9,3.1,6.6C50.8,38.3,49.2,39.5,47.5,39.8z"/>
+		</g>
+	</g>
+</g>
+</svg>

--- a/client/jetbrains/src/main/resources/html/index.html
+++ b/client/jetbrains/src/main/resources/html/index.html
@@ -1,12 +1,12 @@
-<html>
+<html lang="en">
 <head>
   <title>Sourcegraph</title>
-  <link rel="stylesheet" href="/dist/style.css"/>
-  <link rel="stylesheet" href="/dist/search.css"/>
-  <meta charset="utf-8"/>
+  <link href="/dist/style.css" rel="stylesheet" />
+  <link href="/dist/search.css" rel="stylesheet" />
+  <meta charset="utf-8" />
 </head>
 <body>
-  <div id="main"></div>
-  <script src="/dist/search.js"></script>
+<div id="main"></div>
+<script src="/dist/search.js"></script>
 </body>
 </html>

--- a/client/jetbrains/src/test/java/CommitViewUriBuilderTest.java
+++ b/client/jetbrains/src/test/java/CommitViewUriBuilderTest.java
@@ -1,14 +1,14 @@
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-
-import java.net.URI;
-
 import com.sourcegraph.project.CommitViewUriBuilder;
 import com.sourcegraph.project.RepoInfo;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EmptySource;
 import org.junit.jupiter.params.provider.NullSource;
+
+import java.net.URI;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class CommitViewUriBuilderTest {
 


### PR DESCRIPTION
The warnings bothered me because I like it when everything that's yellow or red is something that we should actually get rid of. There is still the `AppUIExecutor.onUiThread().execute()` call ([here](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@dv/jetbrains-fix-warnings/-/blob/client/jetbrains/src/main/java/com/sourcegraph/action/OpenSearchAction.java?L17%3A9-17%3A43=&utm_product_name=IntelliJ+IDEA&utm_product_version=IntelliJ+IDEA)) that I haven't been able to fix, but all other non-generated files are warning-free now in the `jetbrains` folder.

## Test plan

Run the code and make sure it runs as intended.
I went through the main functionality and it seems to work: https://www.loom.com/share/efcfaae8b1844c87ab29e86c114ad4e2

## App preview:

- [Web](https://sg-web-dv-jetbrains-fix-warnings.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-winmczqurd.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
