### PR TITLE
Accessibility: Set <Icon /> as "image" and prep for migration

### DIFF
--- a/client/wildcard/src/components/Icon/Icon.story.tsx
+++ b/client/wildcard/src/components/Icon/Icon.story.tsx
@@ -34,9 +34,9 @@ export default config
 export const Simple: Story = () => (
     <>
         <h3>Small Icon</h3>
-        <Icon as={SourcegraphIcon} size="sm" />
+        <Icon as={SourcegraphIcon} size="sm" title="Sourcegraph logo" />
 
         <h3>Medium Icon</h3>
-        <Icon as={SourcegraphIcon} size="md" />
+        <Icon as={SourcegraphIcon} size="md" title="Sourcegraph logo" />
     </>
 )

--- a/client/wildcard/src/components/Icon/Icon.tsx
+++ b/client/wildcard/src/components/Icon/Icon.tsx
@@ -26,7 +26,7 @@ interface HiddenIconProps extends BaseIconProps {
 }
 
 // We're currently migrating our icons to provide a descriptive label or use aria-hidden to be excluded from screen readers.
-// Migration issue: plzdontforgettoadd
+// Migration issue: https://github.com/sourcegraph/sourcegraph/issues/34582
 // TODO: We should enforce that these props are provided once that migration is complete.
 export type IconProps = HiddenIconProps | ScreenReaderIconProps
 

--- a/client/wildcard/src/components/Icon/Icon.tsx
+++ b/client/wildcard/src/components/Icon/Icon.tsx
@@ -18,7 +18,7 @@ interface BaseIconProps extends Omit<MdiReactIconProps, 'children'> {
 }
 
 interface ScreenReaderIconProps extends BaseIconProps {
-    'aria-label'?: string
+    title?: string
 }
 
 interface HiddenIconProps extends BaseIconProps {

--- a/client/wildcard/src/components/Icon/Icon.tsx
+++ b/client/wildcard/src/components/Icon/Icon.tsx
@@ -9,7 +9,7 @@ import { ICON_SIZES } from './constants'
 
 import styles from './Icon.module.scss'
 
-export interface IconProps extends Omit<MdiReactIconProps, 'children'> {
+interface BaseIconProps extends Omit<MdiReactIconProps, 'children'> {
     className?: string
     /**
      * The variant style of the icon. defaults to 'sm'
@@ -17,18 +17,27 @@ export interface IconProps extends Omit<MdiReactIconProps, 'children'> {
     size?: typeof ICON_SIZES[number]
 }
 
+interface ScreenReaderIconProps extends BaseIconProps {
+    'aria-label'?: string
+}
+
+interface HiddenIconProps extends BaseIconProps {
+    'aria-hidden'?: true | 'true'
+}
+
+// We're currently migrating our icons to provide a descriptive label or use aria-hidden to be excluded from screen readers.
+// Migration issue: plzdontforgettoadd
+// TODO: We should enforce that these props are provided once that migration is complete.
+export type IconProps = HiddenIconProps | ScreenReaderIconProps
+
 export const Icon = React.forwardRef((props, reference) => {
-    // TODO: role should have a default value of "img", but most of our Icons don't
-    // provide an aria-label, title, or other form of alternative text, and so setting it
-    // causes accessibility audits to fail in our integration test suite. Once we've added
-    // text to all of our icons, we should restore this as the default value.
-    // const { children, inline = true, className, size, as: Component = 'svg', role = 'img', ...attributes } = props
-    const { children, inline = true, className, size, as: Component = 'svg', ...attributes } = props
+    const { children, inline = true, className, size, as: Component = 'svg', role = 'img', ...attributes } = props
 
     return (
         <Component
             className={classNames(styles.iconInline, size === 'md' && styles.iconInlineMd, className)}
             ref={reference}
+            role={role}
             {...attributes}
         >
             {children}


### PR DESCRIPTION
# Reference PR See https://github.com/sourcegraph/sourcegraph/issues/34582 for implementation detail



## App preview:

- [Web](https://sg-web-tr-icon-accessibility.onrender.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

