### PR TITLE
gitserver: Sync soft deleted repos clone status

### DIFF
--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -610,7 +610,7 @@ func (s *Server) syncRepoState(gitServerAddrs gitserver.GitServerAddresses, batc
 		// We may have a deleted repo, we need to extract the original name both to
 		// ensure that the shard check is correct and also so that we can find the
 		// directory.
-		repo.Name = api.UndeleteRepoName(repo.Name)
+		repo.Name = api.UndeletedRepoName(repo.Name)
 
 		// Ensure we're only dealing with repos we are responsible for
 		addr := addrForKey(repo.Name, gitServerAddrs.Addresses)

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -440,7 +440,8 @@ func (s *Server) SyncRepoState(interval time.Duration, batchSize, perSecond int)
 	}
 }
 
-// StartClonePipeline clones repos asynchronosuly. It creates a producer-consumer pipeline.
+// StartClonePipeline clones repos asynchronously. It creates a producer-consumer
+// pipeline.
 func (s *Server) StartClonePipeline(ctx context.Context) {
 	jobs := make(chan *cloneJob)
 

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -427,8 +427,10 @@ func (s *Server) SyncRepoState(interval time.Duration, batchSize, perSecond int)
 		previousAddrs = currentAddrs
 
 		gitServerAddrs := gitserver.GitServerAddresses{
-			Addresses:     addrs,
-			PinnedServers: cfg.ExperimentalFeatures.GitServerPinnedRepos,
+			Addresses: addrs,
+		}
+		if cfg.ExperimentalFeatures != nil {
+			gitServerAddrs.PinnedServers = cfg.ExperimentalFeatures.GitServerPinnedRepos
 		}
 		if err := s.syncRepoState(gitServerAddrs, batchSize, perSecond, fullSync); err != nil {
 			log15.Error("Syncing repo state", "error ", err)

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -598,7 +598,7 @@ func (s *Server) syncRepoState(gitServerAddrs gitserver.GitServerAddresses, batc
 	}
 
 	options := database.IterateRepoGitserverStatusOptions{
-		// We also want to include deleted repos as they ay still be cloned on disk
+		// We also want to include deleted repos as they may still be cloned on disk
 		IncludeDeleted: true,
 	}
 	if !fullSync {

--- a/cmd/gitserver/server/server_test.go
+++ b/cmd/gitserver/server/server_test.go
@@ -1236,6 +1236,32 @@ func TestSyncRepoState(t *testing.T) {
 	if gr.CloneStatus != types.CloneStatusCloned {
 		t.Fatalf("Want %v, got %v", types.CloneStatusCloned, gr.CloneStatus)
 	}
+
+	t.Run("sync deleted repo", func(t *testing.T) {
+		// Fake setting an incorrect status
+		if err := database.GitserverRepos(db).SetCloneStatus(ctx, dbRepo.Name, types.CloneStatusUnknown, hostname); err != nil {
+			t.Fatal(err)
+		}
+
+		// We should continue to sync deleted repos
+		if err := database.Repos(db).Delete(ctx, dbRepo.ID); err != nil {
+			t.Fatal(err)
+		}
+
+		err = s.syncRepoState(gitserver.GitServerAddresses{Addresses: []string{hostname}}, 10, 10, true)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		gr, err := database.GitserverRepos(db).GetByID(ctx, dbRepo.ID)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if gr.CloneStatus != types.CloneStatusCloned {
+			t.Fatalf("Want %v, got %v", types.CloneStatusCloned, gr.CloneStatus)
+		}
+	})
 }
 
 type BatchLogTest struct {

--- a/dev/sg/internal/run/run.go
+++ b/dev/sg/internal/run/run.go
@@ -129,29 +129,30 @@ func addToMacosFirewall(cmds []Command) func() error {
 				continue
 			}
 
-			binary := args[0]
-			if strings.HasPrefix(binary, ".bin/") || strings.HasPrefix(binary, "./.bin/") {
-				addException := script.Exec(shell.Join([]string{"sudo", firewallCmdPath, "--add", filepath.Join(root, binary)}))
-				msg, err := addException.String()
-				if err != nil {
-					stdout.Out.WriteLine(output.Linef(output.EmojiFailure, output.StyleBold, "%s: %s", binary, err.Error()))
-					continue
-				}
+			for _, binary := range args {
+				if strings.HasPrefix(binary, ".bin/") || strings.HasPrefix(binary, "./.bin/") {
+					addException := script.Exec(shell.Join([]string{"sudo", firewallCmdPath, "--add", filepath.Join(root, binary)}))
+					msg, err := addException.String()
+					if err != nil {
+						stdout.Out.WriteLine(output.Linef(output.EmojiFailure, output.StyleBold, "%s: %s", binary, err.Error()))
+						continue
+					}
 
-				// socketfilterfw helpfully always returns status 0, so we need to check
-				// the output to determine whether things worked or not. In all cases we
-				// don't error out becasue we want other commands to go through the firewall
-				// updates regardless.
-				switch {
-				case strings.Contains(msg, "does not exist"):
-					stdout.Out.WriteLine(output.Linef(output.EmojiFailure, output.StyleWarning, "%s: %s", binary, strings.TrimSpace(msg)))
+					// socketfilterfw helpfully always returns status 0, so we need to check
+					// the output to determine whether things worked or not. In all cases we
+					// don't error out becasue we want other commands to go through the firewall
+					// updates regardless.
+					switch {
+					case strings.Contains(msg, "does not exist"):
+						stdout.Out.WriteLine(output.Linef(output.EmojiFailure, output.StyleWarning, "%s: %s", binary, strings.TrimSpace(msg)))
 
-				case strings.Contains(msg, "added to firewall"):
-					stdout.Out.WriteLine(output.Linef(output.EmojiFailure, output.StyleSuccess, "%s: added to firewall", binary))
-					needsFirewallRestart = true
+					case strings.Contains(msg, "added to firewall"):
+						stdout.Out.WriteLine(output.Linef(output.EmojiSuccess, output.StyleSuccess, "%s: added to firewall", binary))
+						needsFirewallRestart = true
 
-				default:
-					stdout.Out.WriteLine(output.Linef("", output.StyleSuggestion, "%s: %s", binary, strings.TrimSpace(msg)))
+					default:
+						stdout.Out.WriteLine(output.Linef("", output.StyleSuggestion, "%s: %s", binary, strings.TrimSpace(msg)))
+					}
 				}
 			}
 		}

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -31,7 +31,8 @@ func (r RepoName) Equal(o RepoName) bool {
 var deletedRegex = lazyregexp.New("DELETED-[0-9]+\\.[0-9]+-")
 
 // UndeleteRepoName will "undeleted" a repo name. When we soft-delete a repo we
-// change its name in the database, this function extract the original repo name.
+// change its name in the database, this function extracts the original repo
+// name.
 func UndeleteRepoName(name RepoName) RepoName {
 	return RepoName(deletedRegex.ReplaceAllString(string(name), ""))
 }

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -9,6 +9,8 @@ import (
 	"time"
 
 	"github.com/opentracing/opentracing-go/log"
+
+	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
 )
 
 // RepoID is the unique identifier for a repository.
@@ -24,6 +26,14 @@ type RepoHashedName string
 
 func (r RepoName) Equal(o RepoName) bool {
 	return strings.EqualFold(string(r), string(o))
+}
+
+var deletedRegex = lazyregexp.New("DELETED-[0-9]+\\.[0-9]+-")
+
+// UndeleteRepoName will "undeleted" a repo name. When we soft-delete a repo we
+// change its name in the database, this function extract the original repo name.
+func UndeleteRepoName(name RepoName) RepoName {
+	return RepoName(deletedRegex.ReplaceAllString(string(name), ""))
 }
 
 // CommitID is the 40-character SHA-1 hash for a Git commit.

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -30,10 +30,10 @@ func (r RepoName) Equal(o RepoName) bool {
 
 var deletedRegex = lazyregexp.New("DELETED-[0-9]+\\.[0-9]+-")
 
-// UndeleteRepoName will "undeleted" a repo name. When we soft-delete a repo we
+// UndeletedRepoName will "undeleted" a repo name. When we soft-delete a repo we
 // change its name in the database, this function extracts the original repo
 // name.
-func UndeleteRepoName(name RepoName) RepoName {
+func UndeletedRepoName(name RepoName) RepoName {
 	return RepoName(deletedRegex.ReplaceAllString(string(name), ""))
 }
 

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -1,0 +1,41 @@
+package api
+
+import (
+	"testing"
+)
+
+func TestUndeleteRepoName(t *testing.T) {
+	tests := []struct {
+		name string
+		have RepoName
+		want RepoName
+	}{
+		{
+			name: "Blank",
+			have: RepoName("github.com/owner/repo"),
+			want: RepoName("github.com/owner/repo"),
+		},
+		{
+			name: "Non deleted",
+			have: RepoName("github.com/owner/repo"),
+			want: RepoName("github.com/owner/repo"),
+		},
+		{
+			name: "Deleted 1",
+			have: RepoName("DELETED-1650360042.603863-github.com/owner/repo"),
+			want: RepoName("github.com/owner/repo"),
+		},
+		{
+			name: "Deleted 2",
+			have: RepoName("DELETED-1650977466.716686-github.com/owner/repo"),
+			want: RepoName("github.com/owner/repo"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := UndeleteRepoName(tt.have); got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 )
 
-func TestUndeleteRepoName(t *testing.T) {
+func TestUndeletedRepoName(t *testing.T) {
 	tests := []struct {
 		name string
 		have RepoName
@@ -33,7 +33,7 @@ func TestUndeleteRepoName(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := UndeleteRepoName(tt.have); got != tt.want {
+			if got := UndeletedRepoName(tt.have); got != tt.want {
 				t.Errorf("got %q, want %q", got, tt.want)
 			}
 		})

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -12,11 +12,11 @@ func TestUndeletedRepoName(t *testing.T) {
 	}{
 		{
 			name: "Blank",
-			have: RepoName("github.com/owner/repo"),
-			want: RepoName("github.com/owner/repo"),
+			have: RepoName(""),
+			want: RepoName(""),
 		},
 		{
-			name: "Non deleted",
+			name: "Non deleted, should not change",
 			have: RepoName("github.com/owner/repo"),
 			want: RepoName("github.com/owner/repo"),
 		},

--- a/internal/database/gitserver_repos.go
+++ b/internal/database/gitserver_repos.go
@@ -181,14 +181,19 @@ func (s *gitserverRepoStore) IterateRepoGitserverStatus(ctx context.Context, opt
 		return errors.New("nil repoFn")
 	}
 
-	var q string
-	if options.OnlyWithoutShard {
-		q = iterateRepoGitserverStatusWithoutShardQuery
-	} else {
-		q = iterateRepoGitserverQuery
+	deletedClause := sqlf.Sprintf("repo.deleted_at is null")
+	if options.IncludeDeleted {
+		deletedClause = sqlf.Sprintf("TRUE")
 	}
 
-	rows, err := s.Query(ctx, sqlf.Sprintf(q))
+	var q *sqlf.Query
+	if options.OnlyWithoutShard {
+		q = sqlf.Sprintf(iterateRepoGitserverStatusWithoutShardQuery, deletedClause, deletedClause)
+	} else {
+		q = sqlf.Sprintf(iterateRepoGitserverQuery, deletedClause)
+	}
+
+	rows, err := s.Query(ctx, q)
 	if err != nil {
 		return errors.Wrap(err, "fetching gitserver status")
 	}
@@ -249,7 +254,7 @@ SELECT
 	gr.updated_at
 FROM repo
 LEFT JOIN gitserver_repos gr ON gr.repo_id = repo.id
-WHERE repo.deleted_at IS NULL
+WHERE %s
 `
 
 const iterateRepoGitserverStatusWithoutShardQuery = `
@@ -266,7 +271,7 @@ const iterateRepoGitserverStatusWithoutShardQuery = `
 		NULL AS repo_size_bytes,
 		NULL AS updated_at
 	FROM repo
-	WHERE repo.deleted_at IS NULL AND NOT EXISTS (SELECT 1 FROM gitserver_repos gr WHERE gr.repo_id = repo.id)
+	WHERE %s AND NOT EXISTS (SELECT 1 FROM gitserver_repos gr WHERE gr.repo_id = repo.id)
 ) UNION ALL (
 	SELECT
 		repo.id,
@@ -280,7 +285,7 @@ const iterateRepoGitserverStatusWithoutShardQuery = `
 		gr.updated_at
 	FROM repo
 	JOIN gitserver_repos gr ON gr.repo_id = repo.id
-	WHERE repo.deleted_at IS NULL AND gr.shard_id = ''
+	WHERE %s AND gr.shard_id = ''
 )
 `
 

--- a/internal/database/gitserver_repos.go
+++ b/internal/database/gitserver_repos.go
@@ -167,6 +167,9 @@ WHERE gr.last_error != '' AND repo.deleted_at is NULL AND es.cloud_default IS Tr
 type IterateRepoGitserverStatusOptions struct {
 	// If set, will only iterate over repos that have not been assigned to a shard
 	OnlyWithoutShard bool
+	// If true, also include deleted repos. Note that their repo name will start with
+	// 'DELETED-'
+	IncludeDeleted bool
 }
 
 // IterateRepoGitserverStatus iterates over the status of all repos by joining


### PR DESCRIPTION
We now sync the clone status of repos even after they've been soft deleted in our database. 

This ensures that we accurately list whether or not a deleted repo is still cloned on disk.

## Test plan

Added unit tests. Will also monitor [this metric](https://sourcegraph.com/-/debug/grafana/explore?orgId=1&left=%5B%22now-1h%22,%22now%22,%22Prometheus%22,%7B%22exemplar%22:true,%22expr%22:%22max(src_repoupdater_purgeable_repos)%22,%22requestId%22:%22Q-e397beff-8412-498c-a3ef-d9b56a13a5af-0A%22%7D%5D) when we roll out, we expect to see it drop.