### PR TITLE
Make experimental badges orange

### DIFF
--- a/client/wildcard/src/components/Badge/ProductStatusBadge.tsx
+++ b/client/wildcard/src/components/Badge/ProductStatusBadge.tsx
@@ -15,7 +15,7 @@ export type ProductStatusType = typeof PRODUCT_STATUSES[number]
 const STATUS_VARIANT_MAPPING: Record<ProductStatusType, typeof BADGE_VARIANTS[number]> = {
     prototype: 'warning',
     wip: 'warning',
-    experimental: 'info',
+    experimental: 'warning',
     beta: 'info',
     new: 'info',
 }


### PR DESCRIPTION
As per @AlicjaSuska request here: https://github.com/sourcegraph/sourcegraph/pull/33289#issuecomment-1111144559, updating the style for the experimental badge to the warning color.



## Test plan

This is just a color change. If design approves it, the effect should be justified enough. It does appear as orange in storybooks now.


## App preview:

- [Web](https://sg-web-es-orange-experiment.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-hnzuohiivr.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
