### PR TITLE
JetBrains: Add standalone server

### DIFF
--- a/client/jetbrains/package.json
+++ b/client/jetbrains/package.json
@@ -16,6 +16,7 @@
     "eslint": "eslint --cache '**/*.[jt]s?(x)'",
     "task:gulp": "cross-env NODE_OPTIONS=\"--max_old_space_size=8192\" gulp",
     "build": "yarn task:gulp webpack",
-    "watch": "yarn task:gulp watchWebpack"
+    "watch": "yarn task:gulp watchWebpack",
+    "standalone": "ts-node standalone/src/server.ts"
   }
 }

--- a/client/jetbrains/standalone/src/index.html
+++ b/client/jetbrains/standalone/src/index.html
@@ -1,0 +1,63 @@
+<html>
+<head>
+  <title>Sourcegraph for JetBrains</title>
+  <style type="text/css">
+    html, body {
+      margin: 0;
+      background-color: #3c3f41;
+      color: #bbbbbb;
+      font-size: 13px;
+      font-family: 'DejaVu Sans', sans-serif;
+    }
+
+    #modal {
+      display: flex;
+      flex-direction: column;
+      margin: auto;
+      align-items: center;
+      margin: 20px 0;
+    }
+
+    #webview {
+      width: 960px;
+      max-width: 100%;
+      border: 1px solid #616161;
+      height: 400px;
+      margin: 0;
+      border-top: 0;
+    }
+
+    #title {
+      text-align: center;
+      background-color: #4a4e52;
+      border: 1px solid #616161;
+      width: 960px;
+      padding: 2px 0;
+    }
+
+    #code-details {
+      width: calc(960px - 10px);
+      max-width: 100%;
+      border: 1px solid #616161;
+      border-top: 0;
+      background-color: #2b2b2b;
+      height: 320px;
+      margin: 0;
+      padding: 5px;
+    }
+  </style>
+</head>
+<body>
+  <div id="modal">
+    <div id="title">Sourcegraph for JetBrains</div>
+    <iframe id="webview" src="/html/index.html" width="100%" height="100%"></iframe>
+    <pre id="code-details">let message: string = 'Hello, TypeScript!';
+
+let heading = document.createElement('h1');
+heading.textContent = message;
+
+document.body.appendChild(heading);</pre>
+  </div>
+</body>
+</html>
+

--- a/client/jetbrains/standalone/src/server.ts
+++ b/client/jetbrains/standalone/src/server.ts
@@ -1,0 +1,17 @@
+/* eslint-disable @typescript-eslint/no-unsafe-call */
+import path from 'path'
+
+import express from 'express'
+
+const app = express()
+const port = 3000
+
+const javaResourcesPath = path.join(__dirname, '..', '..', 'src', 'main', 'resources')
+
+app.use(express.static(__dirname))
+app.use('/html', express.static(path.join(javaResourcesPath, 'html')))
+app.use('/dist', express.static(path.join(javaResourcesPath, 'dist')))
+
+app.listen(port, () => {
+    console.log(`Standalone JetBrains extension started on port ${port}`)
+})


### PR DESCRIPTION
This PR adds the standalone server component that we built as a prototype for the JetBrains extension work. It's a simple html version of the Sourcegraph for JetBrains window and allows us to test the JavaScript artifacts without having to start JetBrains.

This is especially useful as it allows faster development since we don't have to rebuild & restart the JetBrains instance every time to make a change. I expect this to get more complex though as we start and introduce more bridge API methods but for now this is useful for developing the next React parts in isolation.
 
## Test plan

```
yarn standalone
open localhost:3000
```

![Screenshot 2022-04-27 at 17 36 01](https://user-images.githubusercontent.com/458591/165557056-b087c9d6-dfb9-40a1-8832-483d8b715ac3.png)


<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->



## App preview:

- [Web](https://sg-web-ps-jetbrains-standalone-mode.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-lhnlnabmxk.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
