### PR TITLE
Structural search: remove always-false useFullDeadline in zoektSearch

### DIFF
--- a/cmd/searcher/internal/search/search_structural.go
+++ b/cmd/searcher/internal/search/search_structural.go
@@ -300,8 +300,7 @@ func structuralSearchWithZoekt(ctx context.Context, p *protocol.Request, sender 
 		p.Branch = "HEAD"
 	}
 	branchRepos := []zoektquery.BranchRepos{{Branch: p.Branch, Repos: roaring.BitmapOf(uint32(p.RepoID))}}
-	useFullDeadline := false
-	zoektMatches, _, _, err := zoektSearch(ctx, patternInfo, branchRepos, time.Since, p.IndexerEndpoints, useFullDeadline, nil)
+	zoektMatches, _, _, err := zoektSearch(ctx, patternInfo, branchRepos, time.Since, p.IndexerEndpoints, nil)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This removes the useFullDeadline parameter from zoektSearch, which was
always false. There is a TODO that was removed as part of this to handle
this better, but I think the real solution is just to stream results
into from zoekt and into comby, so I think it's fine to simplify and
leave it as it's been working for the last while.

As recommended by @stefanhengl [here](https://github.com/sourcegraph/sourcegraph/issues/31028)

## Test plan

Just removing an unused parameter.

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


