### PR TITLE
Replace os.MkdirTemp in tests with t.TempDir()

### DIFF
--- a/cmd/gitserver/server/cleanup_test.go
+++ b/cmd/gitserver/server/cleanup_test.go
@@ -39,11 +39,7 @@ func (s *Server) testSetup(t *testing.T) {
 }
 
 func TestCleanup_computeStats(t *testing.T) {
-	root, err := os.MkdirTemp("", "gitserver-test-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(root)
+	root := t.TempDir()
 
 	for _, name := range []string{"a", "b/d", "c"} {
 		p := path.Join(root, name, ".git")
@@ -116,11 +112,7 @@ insert into gitserver_repos(repo_id, shard_id, repo_size_bytes) values (3, 1, 22
 }
 
 func TestCleanupInactive(t *testing.T) {
-	root, err := os.MkdirTemp("", "gitserver-test-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(root)
+	root := t.TempDir()
 
 	repoA := path.Join(root, testRepoA, ".git")
 	cmd := exec.Command("git", "--bare", "init", repoA)
@@ -205,11 +197,7 @@ func TestGitGCAuto(t *testing.T) {
 }
 
 func TestCleanupExpired(t *testing.T) {
-	root, err := os.MkdirTemp("", "gitserver-test-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(root)
+	root := t.TempDir()
 
 	repoNew := path.Join(root, "repo-new", ".git")
 	repoOld := path.Join(root, "repo-old", ".git")
@@ -839,10 +827,8 @@ func TestFreeUpSpace(t *testing.T) {
 	})
 	t.Run("oldest repo gets removed to free up space", func(t *testing.T) {
 		// Set up.
-		rd, err := os.MkdirTemp("", "freeUpSpace")
-		if err != nil {
-			t.Fatal(err)
-		}
+		rd := t.TempDir()
+
 		r1 := filepath.Join(rd, "repo1")
 		r2 := filepath.Join(rd, "repo2")
 		if err := makeFakeRepo(r1, 1000); err != nil {
@@ -1213,12 +1199,7 @@ func TestCleanup_setRepoSizes(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-
-	root, err := os.MkdirTemp("", "gitserver-test-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(root)
+	root := t.TempDir()
 
 	for _, name := range []string{
 		"ghe.sgdev.org/sourcegraph/gorilla-websocket",

--- a/cmd/gitserver/server/server_test.go
+++ b/cmd/gitserver/server/server_test.go
@@ -296,11 +296,7 @@ func TestServer_handleP4Exec(t *testing.T) {
 }
 
 func BenchmarkQuickRevParseHeadQuickSymbolicRefHead_packed_refs(b *testing.B) {
-	tmp, err := os.MkdirTemp("", "gitserver_test")
-	if err != nil {
-		b.Fatal(err)
-	}
-	defer os.RemoveAll(tmp)
+	tmp := b.TempDir()
 
 	dir := filepath.Join(tmp, ".git")
 	gitDir := GitDir(dir)
@@ -312,7 +308,7 @@ func BenchmarkQuickRevParseHeadQuickSymbolicRefHead_packed_refs(b *testing.B) {
 	// This simulates the most amount of work quickRevParseHead has to do, and
 	// is also the most common in prod. That is where the final rev is in
 	// packed-refs.
-	err = os.WriteFile(filepath.Join(dir, "HEAD"), []byte(fmt.Sprintf("ref: %s\n", masterRef)), 0600)
+	err := os.WriteFile(filepath.Join(dir, "HEAD"), []byte(fmt.Sprintf("ref: %s\n", masterRef)), 0600)
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -374,11 +370,7 @@ func BenchmarkQuickRevParseHeadQuickSymbolicRefHead_packed_refs(b *testing.B) {
 }
 
 func BenchmarkQuickRevParseHeadQuickSymbolicRefHead_unpacked_refs(b *testing.B) {
-	tmp, err := os.MkdirTemp("", "gitserver_test")
-	if err != nil {
-		b.Fatal(err)
-	}
-	defer os.RemoveAll(tmp)
+	tmp := b.TempDir()
 
 	dir := filepath.Join(tmp, ".git")
 	gitDir := GitDir(dir)

--- a/cmd/gitserver/server/vcs_syncer_jvm_packages_test.go
+++ b/cmd/gitserver/server/vcs_syncer_jvm_packages_test.go
@@ -169,9 +169,7 @@ func createMaliciousJar(t *testing.T, name string) {
 }
 
 func TestJVMCloneCommand(t *testing.T) {
-	dir, err := os.MkdirTemp("", "")
-	assert.Nil(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	createPlaceholderSourcesJar(t, dir, exampleFileContents, exampleJar)
 	createPlaceholderByteCodeJar(t,

--- a/cmd/gitserver/server/vcs_syncer_npm_packages_test.go
+++ b/cmd/gitserver/server/vcs_syncer_npm_packages_test.go
@@ -43,16 +43,14 @@ const (
 )
 
 func TestNoMaliciousFilesNpm(t *testing.T) {
-	dir, err := os.MkdirTemp("", "")
-	assert.Nil(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	extractPath := path.Join(dir, "extracted")
 	assert.Nil(t, os.Mkdir(extractPath, os.ModePerm))
 
 	tgz := bytes.NewReader(createMaliciousTgz(t))
 
-	err = decompressTgz(tgz, extractPath)
+	err := decompressTgz(tgz, extractPath)
 	assert.Nil(t, err) // Malicious files are skipped
 
 	dirEntries, err := os.ReadDir(extractPath)
@@ -78,12 +76,7 @@ func createMaliciousTgz(t *testing.T) []byte {
 }
 
 func TestNpmCloneCommand(t *testing.T) {
-	dir, err := os.MkdirTemp("", "")
-	require.NoError(t, err)
-
-	t.Cleanup(func() {
-		require.NoError(t, os.RemoveAll(dir))
-	})
+	dir := t.TempDir()
 
 	tgz1 := createTgz(t, []fileInfo{{exampleJSFilepath, []byte(exampleJSFileContents)}})
 	tgz2 := createTgz(t, []fileInfo{{exampleTSFilepath, []byte(exampleTSFileContents)}})
@@ -260,9 +253,7 @@ func TestDecompressTgz(t *testing.T) {
 
 	for i, testData := range table {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			dir, err := os.MkdirTemp("", "")
-			require.NoError(t, err)
-			t.Cleanup(func() { require.NoError(t, os.RemoveAll(dir)) })
+			dir := t.TempDir()
 
 			var fileInfos []fileInfo
 			for _, path := range testData.paths {
@@ -320,9 +311,7 @@ func testDecompressTgzNoOOBImpl(t *testing.T, entries []tar.Header) {
 
 	reader := bytes.NewReader(buffer.Bytes())
 
-	outDir, err := os.MkdirTemp("", "decompress-oobfix-")
-	require.Nil(t, err)
-	defer os.RemoveAll(outDir)
+	outDir := t.TempDir()
 
 	require.NotPanics(t, func() {
 		decompressTgz(reader, outDir)

--- a/cmd/searcher/internal/search/search_structural_test.go
+++ b/cmd/searcher/internal/search/search_structural_test.go
@@ -57,11 +57,7 @@ func foo(go string) {}
 	if err != nil {
 		t.Fatal(err)
 	}
-	zf, cleanup, err := tempZipFileOnDisk(zipData)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer cleanup()
+	zf := tempZipFileOnDisk(t, zipData)
 
 	t.Run("group", func(t *testing.T) {
 		for _, tt := range cases {
@@ -123,11 +119,7 @@ func foo(go.txt) {}
 	if err != nil {
 		t.Fatal(err)
 	}
-	zf, cleanup, err := tempZipFileOnDisk(zipData)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer cleanup()
+	zf := tempZipFileOnDisk(t, zipData)
 
 	test := func(language, filename string) string {
 		var languages []string
@@ -215,11 +207,7 @@ func foo(real string) {}
 	if err != nil {
 		t.Fatal(err)
 	}
-	zPath, cleanup, err := tempZipFileOnDisk(zipData)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer cleanup()
+	zPath := tempZipFileOnDisk(t, zipData)
 
 	zFile, _ := mockZipFile(zipData)
 	if err != nil {
@@ -327,11 +315,7 @@ func TestIncludePatterns(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	zf, cleanup, err := tempZipFileOnDisk(zipData)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer cleanup()
+	zf := tempZipFileOnDisk(t, zipData)
 
 	p := &protocol.PatternInfo{
 		Pattern:         "",
@@ -369,11 +353,7 @@ func TestRule(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	zf, cleanup, err := tempZipFileOnDisk(zipData)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer cleanup()
+	zf := tempZipFileOnDisk(t, zipData)
 
 	p := &protocol.PatternInfo{
 		Pattern:         "func :[[fn]](:[args])",
@@ -439,9 +419,7 @@ func bar() {
 	zipData, err := createZip(input)
 	require.NoError(t, err)
 
-	zf, cleanup, err := tempZipFileOnDisk(zipData)
-	require.NoError(t, err)
-	defer cleanup()
+	zf := tempZipFileOnDisk(t, zipData)
 
 	count := func(matches []protocol.FileMatch) int {
 		c := 0
@@ -589,11 +567,7 @@ func bar() {
 	if err != nil {
 		t.Fatal(err)
 	}
-	zf, cleanup, err := tempZipFileOnDisk(zipData)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer cleanup()
+	zf := tempZipFileOnDisk(t, zipData)
 
 	t.Run("Strutural search match count", func(t *testing.T) {
 		ctx, cancel, sender := newLimitedStreamCollector(context.Background(), 1000000000)

--- a/cmd/searcher/internal/search/store_test.go
+++ b/cmd/searcher/internal/search/store_test.go
@@ -20,8 +20,7 @@ import (
 )
 
 func TestPrepareZip(t *testing.T) {
-	s, cleanup := tmpStore(t)
-	defer cleanup()
+	s := tmpStore(t)
 
 	wantRepo := api.RepoName("foo")
 	wantCommit := api.CommitID("deadbeefdeadbeefdeadbeefdeadbeefdeadbeef")
@@ -86,8 +85,7 @@ func TestPrepareZip(t *testing.T) {
 
 func TestPrepareZip_fetchTarFail(t *testing.T) {
 	fetchErr := errors.New("test")
-	s, cleanup := tmpStore(t)
-	defer cleanup()
+	s := tmpStore(t)
 	s.FetchTar = func(ctx context.Context, repo api.RepoName, commit api.CommitID) (io.ReadCloser, error) {
 		return nil, fetchErr
 	}
@@ -99,8 +97,7 @@ func TestPrepareZip_fetchTarFail(t *testing.T) {
 
 func TestPrepareZip_fetchTarReaderErr(t *testing.T) {
 	fetchErr := errors.New("test")
-	s, cleanup := tmpStore(t)
-	defer cleanup()
+	s := tmpStore(t)
 	s.FetchTar = func(ctx context.Context, repo api.RepoName, commit api.CommitID) (io.ReadCloser, error) {
 		r, w := io.Pipe()
 		w.CloseWithError(fetchErr)
@@ -113,8 +110,7 @@ func TestPrepareZip_fetchTarReaderErr(t *testing.T) {
 }
 
 func TestPrepareZip_errHeader(t *testing.T) {
-	s, cleanup := tmpStore(t)
-	defer cleanup()
+	s := tmpStore(t)
 	s.FetchTar = func(ctx context.Context, repo api.RepoName, commit api.CommitID) (io.ReadCloser, error) {
 		buf := new(bytes.Buffer)
 		w := tar.NewWriter(buf)
@@ -262,14 +258,11 @@ func tarArchive(dir string) (*tar.Reader, error) {
 	return tar.NewReader(&b), nil
 }
 
-func tmpStore(t *testing.T) (*Store, func()) {
-	d, err := os.MkdirTemp("", "store_test")
-	if err != nil {
-		t.Fatal(err)
-	}
+func tmpStore(t *testing.T) *Store {
+	d := t.TempDir()
 	return &Store{
 		Path: d,
-	}, func() { os.RemoveAll(d) }
+	}
 }
 
 func emptyTar(t *testing.T) io.ReadCloser {

--- a/cmd/searcher/internal/search/zip_test.go
+++ b/cmd/searcher/internal/search/zip_test.go
@@ -46,6 +46,7 @@ func mockZipFile(data []byte) (*zipFile, error) {
 }
 
 func tempZipFileOnDisk(data []byte) (string, func(), error) {
+	// TODO(ryanslade)
 	z, err := mockZipFile(data)
 	if err != nil {
 		return "", nil, err

--- a/cmd/searcher/internal/search/zip_test.go
+++ b/cmd/searcher/internal/search/zip_test.go
@@ -4,6 +4,7 @@ import (
 	"archive/zip"
 	"bytes"
 	"os"
+	"testing"
 )
 
 func createZip(files map[string]string) ([]byte, error) {
@@ -45,23 +46,20 @@ func mockZipFile(data []byte) (*zipFile, error) {
 	return zf, nil
 }
 
-func tempZipFileOnDisk(data []byte) (string, func(), error) {
-	// TODO(ryanslade)
+func tempZipFileOnDisk(t *testing.T, data []byte) string {
+	t.Helper()
 	z, err := mockZipFile(data)
 	if err != nil {
-		return "", nil, err
+		t.Fatal(err)
 	}
-	d, err := os.MkdirTemp("", "temp_zip_dir")
-	if err != nil {
-		return "", nil, err
-	}
+	d := t.TempDir()
 	f, err := os.CreateTemp(d, "temp_zip")
 	if err != nil {
-		return "", nil, err
+		t.Fatal(err)
 	}
 	_, err = f.Write(z.Data)
 	if err != nil {
-		return "", nil, err
+		t.Fatal(err)
 	}
-	return f.Name(), func() { os.RemoveAll(d) }, nil
+	return f.Name()
 }

--- a/cmd/searcher/internal/search/zipcache_test.go
+++ b/cmd/searcher/internal/search/zipcache_test.go
@@ -12,8 +12,7 @@ import (
 // TestZipCacheDelete ensures that zip cache deletion is correctly hooked up to cache eviction.
 func TestZipCacheDelete(t *testing.T) {
 	// Set up a store.
-	s, cleanup := tmpStore(t)
-	defer cleanup()
+	s := tmpStore(t)
 
 	s.FetchTar = func(ctx context.Context, repo api.RepoName, commit api.CommitID) (io.ReadCloser, error) {
 		return emptyTar(t), nil

--- a/cmd/server/shared/nginx_test.go
+++ b/cmd/server/shared/nginx_test.go
@@ -18,11 +18,7 @@ func TestNginx(t *testing.T) {
 		return b
 	}
 
-	dir, err := os.MkdirTemp("", "nginx_test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	path, err := nginxWriteFiles(dir)
 	if err != nil {

--- a/cmd/server/shared/redis_test.go
+++ b/cmd/server/shared/redis_test.go
@@ -17,12 +17,7 @@ func TestRedisFixAOF(t *testing.T) {
 	if _, err := exec.LookPath("redis-check-aof"); err != nil {
 		t.Skip("redis-check-aof not on path: ", err)
 	}
-
-	dataDir, err := os.MkdirTemp("", t.Name())
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dataDir)
+	dataDir := t.TempDir()
 
 	var b bytes.Buffer
 	redisCmd(&b, "PUT", "foo", "bar")

--- a/cmd/symbols/internal/api/handler_test.go
+++ b/cmd/symbols/internal/api/handler_test.go
@@ -3,7 +3,6 @@ package api
 import (
 	"context"
 	"net/http/httptest"
-	"os"
 	"reflect"
 	"testing"
 	"time"
@@ -31,11 +30,7 @@ func init() {
 }
 
 func TestHandler(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() { os.RemoveAll(tmpDir) }()
+	tmpDir := t.TempDir()
 
 	cache := diskcache.NewStore(tmpDir, "symbols", diskcache.WithBackgroundTimeout(20*time.Minute))
 

--- a/dev/src-expose/serve_test.go
+++ b/dev/src-expose/serve_test.go
@@ -143,11 +143,7 @@ func testReposHandler(t *testing.T, h http.Handler, repos []Repo) {
 }
 
 func gitInitRepos(t *testing.T, names ...string) string {
-	root, err := os.MkdirTemp("", "")
-	if err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() { os.RemoveAll(root) })
+	root := t.TempDir()
 	root = filepath.Join(root, "repos-root")
 
 	for _, name := range names {
@@ -165,11 +161,7 @@ func gitInitRepos(t *testing.T, names ...string) string {
 }
 
 func TestIgnoreGitSubmodules(t *testing.T) {
-	root, err := os.MkdirTemp("", "")
-	if err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() { os.RemoveAll(root) })
+	root := t.TempDir()
 
 	if err := os.MkdirAll(filepath.Join(root, "dir"), os.ModePerm); err != nil {
 		t.Fatal(err)

--- a/enterprise/cmd/frontend/internal/auth/openidconnect/middleware_test.go
+++ b/enterprise/cmd/frontend/internal/auth/openidconnect/middleware_test.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"os"
 	"strings"
 	"testing"
 	"time"
@@ -118,14 +117,7 @@ func newOIDCIDServer(t *testing.T, code string, oidcProvider *schema.OpenIDConne
 func TestMiddleware(t *testing.T) {
 	cleanup := session.ResetMockSessionStore(t)
 	defer cleanup()
-
 	defer licensing.TestingSkipFeatureChecks()()
-
-	tempdir, err := os.MkdirTemp("", "sourcegraph-oidc-test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tempdir)
 
 	mockGetProviderValue = &provider{
 		config: schema.OpenIDConnectAuthProvider{
@@ -305,12 +297,6 @@ func TestMiddleware_NoOpenRedirect(t *testing.T) {
 	defer cleanup()
 
 	defer licensing.TestingSkipFeatureChecks()()
-
-	tempdir, err := os.MkdirTemp("", "sourcegraph-oidc-test-no-open-redirect")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tempdir)
 
 	mockGetProviderValue = &provider{
 		config: schema.OpenIDConnectAuthProvider{

--- a/internal/diskcache/cache_test.go
+++ b/internal/diskcache/cache_test.go
@@ -11,11 +11,7 @@ import (
 )
 
 func TestOpen(t *testing.T) {
-	dir, err := os.MkdirTemp("", "diskcache_test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	store := &store{
 		dir:       dir,
@@ -65,11 +61,7 @@ func TestOpen(t *testing.T) {
 }
 
 func TestMultiKeyEviction(t *testing.T) {
-	dir, err := os.MkdirTemp("", "diskcache_test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	store := &store{
 		dir:       dir,

--- a/internal/fileutil/fileutil_test.go
+++ b/internal/fileutil/fileutil_test.go
@@ -7,11 +7,7 @@ import (
 )
 
 func TestUpdateFileIfDifferent(t *testing.T) {
-	dir, err := os.MkdirTemp("", t.Name())
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	target := filepath.Join(dir, "sg_refhash")
 

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"os"
 	"sort"
 	"strings"
 	"testing"
@@ -87,14 +86,7 @@ func TestMustRegisterDiskMonitor(t *testing.T) {
 
 	want := []string{}
 	for i := 0; i <= 2; i++ {
-		path, err := os.MkdirTemp("", "")
-		if err != nil {
-			t.Fatal(err)
-		}
-		t.Cleanup(func() {
-			path := path
-			_ = os.RemoveAll(path)
-		})
+		path := t.TempDir()
 		// Register twice to ensure we don't panic and we don't collect twice.
 		MustRegisterDiskMonitor(path)
 		MustRegisterDiskMonitor(path)

--- a/internal/repos/npm_packages_test.go
+++ b/internal/repos/npm_packages_test.go
@@ -2,7 +2,6 @@ package repos
 
 import (
 	"context"
-	"os"
 	"sort"
 	"testing"
 
@@ -121,10 +120,6 @@ var testDependencyRepos = func() []dependencies.Repo {
 func TestListRepos(t *testing.T) {
 	ctx := context.Background()
 	depsSvc := testDependenciesService(ctx, t, testDependencyRepos)
-
-	dir, err := os.MkdirTemp("", "")
-	require.Nil(t, err)
-	defer os.RemoveAll(dir)
 
 	svc := types.ExternalService{
 		Kind:   extsvc.KindNpmPackages,


### PR DESCRIPTION
That way we don't need to worry about cleaning up the temp directory ourselves.

## Test plan

Only test code changed