### PR TITLE
trace/httptrace: use lib/log

### DIFF
--- a/internal/trace/httptrace.go
+++ b/internal/trace/httptrace.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/felixge/httpsnoop"
 	"github.com/gorilla/mux"
-	"github.com/inconshreveable/log15"
 	"github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/ext"
 	"github.com/prometheus/client_golang/prometheus"
@@ -23,6 +22,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/repotrackutil"
 	"github.com/sourcegraph/sourcegraph/internal/sentry"
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
+	"github.com/sourcegraph/sourcegraph/lib/log"
 )
 
 type key int
@@ -136,14 +136,18 @@ var (
 // 🚨 SECURITY: This handler is served to all clients, even on private servers to clients who have
 // not authenticated. It must not reveal any sensitive information.
 func HTTPMiddleware(next http.Handler, siteConfig conftypes.SiteConfigQuerier) http.Handler {
+	rootLogger := log.Scoped("http", "http tracing middleware")
+
 	return sentry.Recoverer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
+		logger := rootLogger // do not mutate root logger
 
+		// extract propagated span
 		wireContext, err := ot.GetTracer(ctx).Extract(
 			opentracing.HTTPHeaders,
 			opentracing.HTTPHeadersCarrier(r.Header))
 		if err != nil && err != opentracing.ErrSpanContextNotFound {
-			log15.Error("extracting parent span failed", "error", err)
+			logger.Warn("extracting parent span failed", log.Error(err))
 		}
 
 		// start new span
@@ -153,19 +157,25 @@ func HTTPMiddleware(next http.Handler, siteConfig conftypes.SiteConfigQuerier) h
 		span.SetTag("http.referer", r.Header.Get("referer"))
 		defer span.Finish()
 
-		traceID := IDFromSpan(span)
-		var traceType string
-		if ob := siteConfig.SiteConfig().ObservabilityTracing; ob == nil {
-			traceType = ""
-		} else {
-			traceType = ob.Type
+		// get trace ID
+		trace := ContextFromSpan(span)
+		var traceURL string
+		if trace != nil && trace.TraceID != "" {
+			var traceType string
+			if ob := siteConfig.SiteConfig().ObservabilityTracing; ob == nil {
+				traceType = ""
+			} else {
+				traceType = ob.Type
+			}
+
+			traceURL = URL(trace.TraceID, siteConfig.SiteConfig().ExternalURL, traceType)
+			rw.Header().Set("X-Trace", traceURL)
+			logger = logger.WithTrace(*trace)
 		}
 
-		traceURL := URL(traceID, siteConfig.SiteConfig().ExternalURL, traceType)
-
-		rw.Header().Set("X-Trace", traceURL)
 		ctx = opentracing.ContextWithSpan(ctx, span)
 
+		// route name is only known after the request has been handled
 		routeName := "unknown"
 		ctx = context.WithValue(ctx, routeNameKey, &routeName)
 
@@ -181,8 +191,10 @@ func HTTPMiddleware(next http.Handler, siteConfig conftypes.SiteConfigQuerier) h
 		}
 		ctx = WithRequestOrigin(ctx, origin)
 
+		// handle request
 		m := httpsnoop.CaptureMetrics(next, rw, r.WithContext(ctx))
 
+		// get root name, which is set after request is handled
 		if routeName == "graphql" {
 			// We use the query to denote the type of a GraphQL request, e.g. /.api/graphql?Repositories
 			if r.URL.RawQuery != "" {
@@ -191,10 +203,10 @@ func HTTPMiddleware(next http.Handler, siteConfig conftypes.SiteConfigQuerier) h
 				routeName = "graphql: unknown"
 			}
 		}
-
-		// route name is only known after the request has been handled
+		logger = logger.With(log.String("route_name", routeName))
 		span.SetOperationName("Serve: " + routeName)
 		span.SetTag("Route", routeName)
+
 		ext.HTTPStatusCode.Set(span, uint16(m.Code))
 
 		labels := prometheus.Labels{
@@ -221,28 +233,24 @@ func HTTPMiddleware(next http.Handler, siteConfig conftypes.SiteConfigQuerier) h
 		}
 
 		if m.Duration >= minDuration || m.Code >= minCode {
-			kvs := make([]interface{}, 0, 20)
-			kvs = append(kvs,
-				"method", r.Method,
-				"url", truncate(r.URL.String(), 100),
-				"code", m.Code,
-				"duration", m.Duration,
+			fields := make([]log.Field, 0, 20)
+			fields = append(fields,
+				log.String("method", r.Method),
+				log.String("url", truncate(r.URL.String(), 100)),
+				log.Int("code", m.Code),
+				log.Duration("duration", m.Duration),
 			)
 
-			if traceID != "" {
-				kvs = append(kvs, "traceID", traceID)
-			}
-
 			if v := r.Header.Get("X-Forwarded-For"); v != "" {
-				kvs = append(kvs, "x_forwarded_for", v)
+				fields = append(fields, log.String("x_forwarded_for", v))
 			}
 
 			if userID != 0 {
-				kvs = append(kvs, "user", userID)
+				fields = append(fields, log.Int("user", int(userID)))
 			}
 
 			if gqlErr {
-				kvs = append(kvs, "graphql_error", gqlErr)
+				fields = append(fields, log.Bool("graphql_error", gqlErr))
 			}
 			var parts []string
 			if m.Duration >= minDuration {
@@ -251,7 +259,7 @@ func HTTPMiddleware(next http.Handler, siteConfig conftypes.SiteConfigQuerier) h
 			if m.Code >= minCode {
 				parts = append(parts, "unexpected status code")
 			}
-			log15.Warn(strings.Join(parts, ", "), kvs...)
+			logger.Warn(strings.Join(parts, ", "), fields...)
 		}
 
 		// Notify sentry if the status code indicates our system had an error (e.g. 5xx).


### PR DESCRIPTION
Use `lib/log.Logger` in `httptrace.HTTPMiddleware`

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


main dry run: https://buildkite.com/sourcegraph/sourcegraph/builds/144657