### PR TITLE
Search backend: optimize and/or queries for commit jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 - Code Insights: Fixed line chart data series hover effect. Now the active line will be rendered on top of the others.
 - Unverified primary emails no longer breaks the Emails-page for users and Users-page for Site Admin. [#34312](https://github.com/sourcegraph/sourcegraph/pull/34312)
+- Searches containing `or` expressions are now optimized to evaluate natively on the backends that support it ([#34382](https://github.com/sourcegraph/sourcegraph/pull/34382)), and both commit and diff search have been updated to run optimized `and`, `or`, and `not` queries. [#34595](https://github.com/sourcegraph/sourcegraph/pull/34595)
 
 ### Removed
 

--- a/internal/search/job/jobutil/job.go
+++ b/internal/search/job/jobutil/job.go
@@ -732,7 +732,8 @@ func optimizeJobs(baseJob job.Job, inputs *run.SearchInputs, q query.Basic) (job
 				*zoekt.GlobalSearch,
 				*symbol.RepoUniverseSymbolSearch,
 				*zoekt.ZoektRepoSubsetSearch,
-				*zoekt.ZoektSymbolSearch:
+				*zoekt.ZoektSymbolSearch,
+				*commit.CommitSearch:
 				optimizedJobs = append(optimizedJobs, currentJob)
 				return currentJob
 			default:
@@ -780,6 +781,12 @@ func optimizeJobs(baseJob job.Job, inputs *run.SearchInputs, q query.Basic) (job
 
 			case *symbol.RepoUniverseSymbolSearch:
 				if exists("RepoUniverseSymbolSearch") {
+					return &noopJob{}
+				}
+				return currentJob
+
+			case *commit.CommitSearch:
+				if exists("Commit") || exists("Diff") {
 					return &noopJob{}
 				}
 				return currentJob

--- a/internal/search/job/jobutil/job_test.go
+++ b/internal/search/job/jobutil/job_test.go
@@ -424,6 +424,155 @@ OPTIMIZED:
               ComputeExcludedRepos)))))))
 `).Equal(t, test("repo:derp foo and bar not baz type:symbol"))
 
+	autogold.Want("commit with and", `
+BASE:
+
+(ALERT
+  (TIMEOUT
+    20s
+    (LIMIT
+      500
+      (AND
+        (LIMIT
+          40000
+          (PARALLEL
+            Commit
+            ComputeExcludedRepos))
+        (LIMIT
+          40000
+          (PARALLEL
+            Commit
+            ComputeExcludedRepos))))))
+
+OPTIMIZED:
+
+(ALERT
+  (TIMEOUT
+    20s
+    (LIMIT
+      500
+      (PARALLEL
+        Commit
+        (AND
+          (LIMIT
+            40000
+            (PARALLEL
+              NoopJob
+              ComputeExcludedRepos))
+          (LIMIT
+            40000
+            (PARALLEL
+              NoopJob
+              ComputeExcludedRepos)))))))
+`).Equal(t, test("type:commit a and b"))
+	autogold.Want("commit with or", `
+BASE:
+
+(ALERT
+  (TIMEOUT
+    20s
+    (LIMIT
+      500
+      (OR
+        (PARALLEL
+          Commit
+          ComputeExcludedRepos)
+        (PARALLEL
+          Commit
+          ComputeExcludedRepos)))))
+
+OPTIMIZED:
+
+(ALERT
+  (TIMEOUT
+    20s
+    (LIMIT
+      500
+      (PARALLEL
+        Commit
+        (OR
+          (PARALLEL
+            NoopJob
+            ComputeExcludedRepos)
+          (PARALLEL
+            NoopJob
+            ComputeExcludedRepos))))))
+`).Equal(t, test("type:commit a or b"))
+	autogold.Want("diff with and", `
+BASE:
+
+(ALERT
+  (TIMEOUT
+    20s
+    (LIMIT
+      500
+      (AND
+        (LIMIT
+          40000
+          (PARALLEL
+            Diff
+            ComputeExcludedRepos))
+        (LIMIT
+          40000
+          (PARALLEL
+            Diff
+            ComputeExcludedRepos))))))
+
+OPTIMIZED:
+
+(ALERT
+  (TIMEOUT
+    20s
+    (LIMIT
+      500
+      (PARALLEL
+        Diff
+        (AND
+          (LIMIT
+            40000
+            (PARALLEL
+              NoopJob
+              ComputeExcludedRepos))
+          (LIMIT
+            40000
+            (PARALLEL
+              NoopJob
+              ComputeExcludedRepos)))))))
+`).Equal(t, test("type:diff a and b"))
+
+	autogold.Want("diff with or", `
+BASE:
+
+(ALERT
+  (TIMEOUT
+    20s
+    (LIMIT
+      500
+      (OR
+        (PARALLEL
+          Diff
+          ComputeExcludedRepos)
+        (PARALLEL
+          Diff
+          ComputeExcludedRepos)))))
+
+OPTIMIZED:
+
+(ALERT
+  (TIMEOUT
+    20s
+    (LIMIT
+      500
+      (PARALLEL
+        Diff
+        (OR
+          (PARALLEL
+            NoopJob
+            ComputeExcludedRepos)
+          (PARALLEL
+            NoopJob
+            ComputeExcludedRepos))))))
+`).Equal(t, test("type:diff a or b"))
 }
 
 func TestToTextPatternInfo(t *testing.T) {


### PR DESCRIPTION
This adds the Commit search job to this supported jobs that natively
handle and/or queries. Commit search job construction already handles
tree-like queries, so all I had to do was add it to the list of jobs
that can be optimized.

For context, searches with `type:commit` or `type:diff` are executed
by `gitserver`, and `gitserver` can handle queries with a tree-shaped
pattern expression like `a or b`. However, we're currently not sending 
`gitserver` that tree, and instead we're splitting it up into an `a` query
and a `b` query, then merging the results in `frontend`. This is much 
slower than just letting `gitserver` handle `and`/`or` queries. We recently
added this optimization for `zoekt`, so this just extends it to also apply
to commit and diff searches.

## Test plan

Manually tested and checked the traces that we generate optimized commit search queries. Also added some autogold tests and checked that they look right.

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


