### PR TITLE
fix:src-prometheus add default url

### DIFF
--- a/cmd/server/shared/shared.go
+++ b/cmd/server/shared/shared.go
@@ -47,6 +47,7 @@ var DefaultEnv = map[string]string{
 
 	"GRAFANA_SERVER_URL": "http://127.0.0.1:3370",
 	"JAEGER_SERVER_URL":  "http://127.0.0.1:16686",
+	"PROMETHEUS_URL":     "http://127.0.0.1:9090",
 
 	// Limit our cache size to 100GB, same as prod. We should probably update
 	// searcher/symbols to ensure this value isn't larger than the volume for

--- a/internal/src-prometheus/prometheus.go
+++ b/internal/src-prometheus/prometheus.go
@@ -23,7 +23,7 @@ import (
 var ErrPrometheusUnavailable = errors.New("prometheus API is unavailable")
 
 // PrometheusURL is the configured Prometheus instance.
-var PrometheusURL = env.Get("PROMETHEUS_URL", "", "prometheus server URL")
+var PrometheusURL = env.Get("PROMETHEUS_URL", "http://localhost:9090", "prometheus server URL")
 
 // Client provides the interface for interacting with Sourcegraph Prometheus, including
 // prom-wrapper. See https://docs.sourcegraph.com/dev/background-information/observability/prometheus

--- a/internal/src-prometheus/prometheus.go
+++ b/internal/src-prometheus/prometheus.go
@@ -23,7 +23,7 @@ import (
 var ErrPrometheusUnavailable = errors.New("prometheus API is unavailable")
 
 // PrometheusURL is the configured Prometheus instance.
-var PrometheusURL = env.Get("PROMETHEUS_URL", "http://localhost:9090", "prometheus server URL")
+var PrometheusURL = env.Get("PROMETHEUS_URL", "", "prometheus server URL")
 
 // Client provides the interface for interacting with Sourcegraph Prometheus, including
 // prom-wrapper. See https://docs.sourcegraph.com/dev/background-information/observability/prometheus


### PR DESCRIPTION
See https://github.com/sourcegraph/customer/issues/875 for context. 

Customer gets a banner saying that Prometheus is unavailable when alerts are configured on the single docker container server. In other deployments, we explicitly set this, so nobody notices. We also don't have a ton of customer configuring alerts on our single container image as it's really designed for evaluation purposes - a short stop in the Sourcegraph journey.


## Test plan
Will run candidate images locally to verify that nothing is broken in the deployment. Also CI should smoke test.

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


