### PR TITLE
ci: fix failed hook leading to unset exit code

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -8,7 +8,7 @@ set -eu
 echo "~~~ Setting up Honeycomb tracing for the build"
 
 # Record start time if we need to exit
-BUILD_START_TIME=$(curl --retry 5 -H "Authorization: Bearer $BUILDKITE_API_TOKEN" "https://api.buildkite.com/v2/organizations/$BUILDKITE_ORGANIZATION_SLUG/pipelines/$BUILDKITE_PIPELINE_SLUG/builds/$BUILDKITE_BUILD_NUMBER/" | jq -r .started_at)
+BUILD_START_TIME=$(curl --retry 10 --retry-delay 2 -H "Authorization: Bearer $BUILDKITE_API_TOKEN" "https://api.buildkite.com/v2/organizations/$BUILDKITE_ORGANIZATION_SLUG/pipelines/$BUILDKITE_PIPELINE_SLUG/builds/$BUILDKITE_BUILD_NUMBER/" | jq -r .started_at)
 
 # Convert to UTC & Epoch
 BUILD_START_TIME=$(TZ=UTC date -d "$BUILD_START_TIME" +'%s')

--- a/.buildkite/hooks/pre-exit
+++ b/.buildkite/hooks/pre-exit
@@ -11,7 +11,9 @@ if [[ "$BUILDKITE_PIPELINE_NAME" != "sourcegraph" ]]; then
 fi
 
 if [ "$BUILDKITE_BRANCH" == "main" ]; then
-  if [ "$BUILDKITE_COMMAND_EXIT_STATUS" -eq 0 ]; then
+  # It's possible for the exit status to be unset, in the case of an earlier hook failed, so we need to
+  # account for that. 
+  if [ -n "$BUILDKITE_COMMAND_EXIT_STATUS" ] && [ "$BUILDKITE_COMMAND_EXIT_STATUS" -eq 0 ]; then
     # If the job exit code is either 0 or a soft failt exit code defined by that step, do nothing.
     exit 0
   fi

--- a/.buildkite/hooks/pre-exit
+++ b/.buildkite/hooks/pre-exit
@@ -13,7 +13,7 @@ fi
 if [ "$BUILDKITE_BRANCH" == "main" ]; then
   # It's possible for the exit status to be unset, in the case of an earlier hook failed, so we need to
   # account for that. 
-  if [ -n "$BUILDKITE_COMMAND_EXIT_STATUS" ] && [ "$BUILDKITE_COMMAND_EXIT_STATUS" -eq 0 ]; then
+  if [ -n "$BUILDKITE_COMMAND_EXIT_STATUS" ] && [ "$BUILDKITE_COMMAND_EXIT_STATUS" -eq "0" ]; then
     # If the job exit code is either 0 or a soft failt exit code defined by that step, do nothing.
     exit 0
   fi


### PR DESCRIPTION
We've been seeing transient failures with Honeycomb and the previous retry threshold was apparently not enough. 

I also fixed a bug where it's possible for the exit status to be unset when a hook failed, leading to a weird error. 

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

CI will tell with the holy green build. 

