### PR TITLE
Add verify email notification alert AB test

### DIFF
--- a/client/search-ui/src/input/SearchContextCtaPrompt.story.tsx
+++ b/client/search-ui/src/input/SearchContextCtaPrompt.story.tsx
@@ -35,6 +35,7 @@ const authUser: AuthenticatedUser = {
     databaseID: 0,
     tosAccepted: true,
     searchable: true,
+    emails: [],
 }
 
 add(

--- a/client/shared/src/auth.ts
+++ b/client/shared/src/auth.ts
@@ -32,6 +32,10 @@ export const currentAuthStateQuery = gql`
             tags
             tosAccepted
             searchable
+            emails {
+                email
+                verified
+            }
         }
     }
 `

--- a/client/web/src/communitySearchContexts/CommunitySearchContextPage.story.tsx
+++ b/client/web/src/communitySearchContexts/CommunitySearchContextPage.story.tsx
@@ -70,6 +70,7 @@ const authUser: AuthenticatedUser = {
     databaseID: 0,
     tosAccepted: true,
     searchable: true,
+    emails: [],
 }
 
 const repositories: ISearchContextRepositoryRevisions[] = [

--- a/client/web/src/enterprise/code-monitoring/testing/util.ts
+++ b/client/web/src/enterprise/code-monitoring/testing/util.ts
@@ -26,6 +26,7 @@ export const mockUser: AuthenticatedUser = {
     session: { __typename: 'Session', canSignOut: true },
     tosAccepted: true,
     searchable: true,
+    emails: [],
 }
 
 export const mockCodeMonitorFields: CodeMonitorFields = {

--- a/client/web/src/enterprise/codeintel/configuration/pages/CodeIntelConfigurationPage.story.tsx
+++ b/client/web/src/enterprise/codeintel/configuration/pages/CodeIntelConfigurationPage.story.tsx
@@ -294,6 +294,7 @@ Policies.args = {
         },
         tosAccepted: true,
         searchable: true,
+        emails: [],
     },
 }
 

--- a/client/web/src/enterprise/searchContexts/SearchContextForm.story.tsx
+++ b/client/web/src/enterprise/searchContexts/SearchContextForm.story.tsx
@@ -76,6 +76,7 @@ const authUser: AuthenticatedUser = {
     databaseID: 0,
     tosAccepted: true,
     searchable: true,
+    emails: [],
 }
 
 const deleteSearchContext = sinon.fake(() => NEVER)

--- a/client/web/src/featureFlags/featureFlags.ts
+++ b/client/web/src/featureFlags/featureFlags.ts
@@ -9,6 +9,7 @@ export type FeatureFlagName =
     | 'quick-start-tour-for-authenticated-users'
     | 'new-repo-page'
     | 'ab-visitor-tour-with-notebooks'
+    | 'ab-email-verification-alert'
 
 interface OrgFlagOverride {
     orgID: string

--- a/client/web/src/global/GlobalAlerts.tsx
+++ b/client/web/src/global/GlobalAlerts.tsx
@@ -123,7 +123,12 @@ export class GlobalAlerts extends React.PureComponent<Props, State> {
                         .
                     </DismissibleAlert>
                 )}
-                <Notices alertClassName={styles.alert} location="top" settingsCascade={this.props.settingsCascade} />
+                <Notices
+                    alertClassName={styles.alert}
+                    location="top"
+                    settingsCascade={this.props.settingsCascade}
+                    authenticatedUser={this.props.authenticatedUser}
+                />
             </div>
         )
     }

--- a/client/web/src/global/GlobalAlerts.tsx
+++ b/client/web/src/global/GlobalAlerts.tsx
@@ -22,7 +22,7 @@ import { LicenseExpirationAlert } from '../site/LicenseExpirationAlert'
 import { NeedsRepositoryConfigurationAlert } from '../site/NeedsRepositoryConfigurationAlert'
 
 import { GlobalAlert } from './GlobalAlert'
-import { Notices } from './Notices'
+import { Notices, VerifyEmailNotices } from './Notices'
 
 import styles from './GlobalAlerts.module.scss'
 
@@ -123,12 +123,13 @@ export class GlobalAlerts extends React.PureComponent<Props, State> {
                         .
                     </DismissibleAlert>
                 )}
-                <Notices
-                    alertClassName={styles.alert}
-                    location="top"
-                    settingsCascade={this.props.settingsCascade}
-                    authenticatedUser={this.props.authenticatedUser}
-                />
+                <Notices alertClassName={styles.alert} location="top" settingsCascade={this.props.settingsCascade} />
+                {this.props.authenticatedUser && (
+                    <VerifyEmailNotices
+                        alertClassName={styles.alert}
+                        authenticatedUser={this.props.authenticatedUser}
+                    />
+                )}
             </div>
         )
     }

--- a/client/web/src/global/Notices.tsx
+++ b/client/web/src/global/Notices.tsx
@@ -69,16 +69,23 @@ export const Notices: React.FunctionComponent<React.PropsWithChildren<Props>> = 
     location,
     authenticatedUser,
 }) => {
-    const notices = useMemo(() => {
-        const verifyEmailNotices = (experimentEnabled && authenticatedUser ? authenticatedUser.emails : [])
+    const notices: Notice[] = useMemo(() => {
+        const userEmails: AuthenticatedUser['emails'] =
+            experimentEnabled && authenticatedUser ? authenticatedUser.emails : []
+
+        const verifyEmailNotices: Notice[] = userEmails
             .filter(({ verified }) => !verified)
             .map(
                 ({ email }): Notice => ({
-                    message: `Your email ${email as string} is not verified. <a href="#">Send verification email.</a>`,
+                    message: `Please, verify your email <strong>${(email as string)
+                        .split('@')
+                        .join('\\@')}</strong>. <a href="${
+                        authenticatedUser?.settingsURL as string
+                    }/emails">Send verification email.</a>`,
                     location: 'top',
                     dismissible: false,
                 })
-            )
+            ) as Notice[]
 
         if (
             !isSettingsValid<Settings>(settingsCascade) ||
@@ -97,8 +104,8 @@ export const Notices: React.FunctionComponent<React.PropsWithChildren<Props>> = 
 
     return (
         <div className={classNames(styles.notices, className)}>
-            {notices.map((notice, index) => (
-                <NoticeAlert key={index} testId="notice-alert" className={alertClassName} notice={notice} />
+            {notices.map(notice => (
+                <NoticeAlert key={notice.message} testId="notice-alert" className={alertClassName} notice={notice} />
             ))}
         </div>
     )

--- a/client/web/src/global/Notices.tsx
+++ b/client/web/src/global/Notices.tsx
@@ -76,11 +76,9 @@ export const Notices: React.FunctionComponent<React.PropsWithChildren<Props>> = 
             .filter(({ verified }) => !verified)
             .map(
                 ({ email }): Notice => ({
-                    message: `Please, verify your email <strong>${(email as string)
-                        .split('@')
-                        .join('\\@')}</strong>. Go to <a href="${
+                    message: `Please, <a href="${
                         authenticatedUser?.settingsURL as string
-                    }/emails">emails settings</a> to resend verification email.`,
+                    }/emails">verify your email</a> <strong>${(email as string).split('@').join('\\@')}</strong>.`,
                     location: 'top',
                     dismissible: false,
                 })

--- a/client/web/src/global/Notices.tsx
+++ b/client/web/src/global/Notices.tsx
@@ -78,9 +78,9 @@ export const Notices: React.FunctionComponent<React.PropsWithChildren<Props>> = 
                 ({ email }): Notice => ({
                     message: `Please, verify your email <strong>${(email as string)
                         .split('@')
-                        .join('\\@')}</strong>. <a href="${
+                        .join('\\@')}</strong>. Go to <a href="${
                         authenticatedUser?.settingsURL as string
-                    }/emails">Send verification email.</a>`,
+                    }/emails">emails settings</a> to resend verification email.`,
                     location: 'top',
                     dismissible: false,
                 })

--- a/client/web/src/integration/extension-registry.test.ts
+++ b/client/web/src/integration/extension-registry.test.ts
@@ -189,6 +189,7 @@ describe('Extension Registry', () => {
                     session: { canSignOut: true },
                     viewerCanAdminister: true,
                     searchable: true,
+                    emails: [],
                 },
             }),
             RegistryExtensions: () => ({

--- a/client/web/src/integration/graphQlResults.ts
+++ b/client/web/src/integration/graphQlResults.ts
@@ -37,6 +37,7 @@ export const commonWebGraphQlResults: Partial<
             session: { canSignOut: true },
             viewerCanAdminister: true,
             searchable: true,
+            emails: [],
         },
     }),
     ViewerSettings: () => ({

--- a/client/web/src/integration/insights/utils/override-insights-graphql-api.ts
+++ b/client/web/src/integration/insights/utils/override-insights-graphql-api.ts
@@ -122,6 +122,7 @@ export function overrideInsightsGraphQLApi(props: OverrideGraphQLExtensionsProps
                 session: { canSignOut: true },
                 viewerCanAdminister: true,
                 searchable: true,
+                emails: [],
             },
         }),
         ...overrides,

--- a/client/web/src/search/panels/utils.ts
+++ b/client/web/src/search/panels/utils.ts
@@ -27,6 +27,7 @@ export const authUser: AuthenticatedUser & { namespaceName: string } = {
     tosAccepted: true,
     searchable: true,
     namespaceName: 'alice',
+    emails: [],
 }
 
 export const org: IOrg = {

--- a/client/wildcard/src/components/Alert/Alert.tsx
+++ b/client/wildcard/src/components/Alert/Alert.tsx
@@ -51,3 +51,5 @@ export const Alert = React.forwardRef(
         )
     }
 ) as ForwardReferenceComponent<'div', AlertProps>
+
+Alert.displayName = 'Alert'

--- a/client/wildcard/src/components/Alert/Alert.tsx
+++ b/client/wildcard/src/components/Alert/Alert.tsx
@@ -26,29 +26,28 @@ const userShouldBeImmediatelyNotified = (variant?: AlertVariant): boolean =>
  * If this is not desired behavior, you should pass `aria-live="off"` to this component.
  * Further details: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/alert_role
  */
-export const Alert = React.forwardRef(function Alert(
-    { children, as: Component = 'div', variant, className, role = 'alert', ...attributes },
-    reference
-) {
-    const { isBranded } = useWildcardTheme()
-    const brandedClassName = isBranded && classNames(styles.alert, variant && getAlertStyle({ variant }))
+export const Alert = React.forwardRef(
+    ({ children, as: Component = 'div', variant, className, role = 'alert', ...attributes }, reference) => {
+        const { isBranded } = useWildcardTheme()
+        const brandedClassName = isBranded && classNames(styles.alert, variant && getAlertStyle({ variant }))
 
-    /**
-     * Set the assertiveness setting on the alert.
-     * Assertive: The alert will interrupt any current screen reader announcements.
-     * Polite: The alert will be read out by the screen reader when the user is idle.
-     */
-    const alertAssertiveness = userShouldBeImmediatelyNotified(variant) ? 'assertive' : 'polite'
+        /**
+         * Set the assertiveness setting on the alert.
+         * Assertive: The alert will interrupt any current screen reader announcements.
+         * Polite: The alert will be read out by the screen reader when the user is idle.
+         */
+        const alertAssertiveness = userShouldBeImmediatelyNotified(variant) ? 'assertive' : 'polite'
 
-    return (
-        <Component
-            ref={reference}
-            className={classNames(brandedClassName, className)}
-            role={role}
-            aria-live={alertAssertiveness}
-            {...attributes}
-        >
-            {children}
-        </Component>
-    )
-}) as ForwardReferenceComponent<'div', AlertProps>
+        return (
+            <Component
+                ref={reference}
+                className={classNames(brandedClassName, className)}
+                role={role}
+                aria-live={alertAssertiveness}
+                {...attributes}
+            >
+                {children}
+            </Component>
+        )
+    }
+) as ForwardReferenceComponent<'div', AlertProps>

--- a/client/wildcard/src/components/Alert/Alert.tsx
+++ b/client/wildcard/src/components/Alert/Alert.tsx
@@ -26,30 +26,29 @@ const userShouldBeImmediatelyNotified = (variant?: AlertVariant): boolean =>
  * If this is not desired behavior, you should pass `aria-live="off"` to this component.
  * Further details: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/alert_role
  */
-export const Alert = React.forwardRef(
-    ({ children, as: Component = 'div', variant, className, role = 'alert', ...attributes }, reference) => {
-        const { isBranded } = useWildcardTheme()
-        const brandedClassName = isBranded && classNames(styles.alert, variant && getAlertStyle({ variant }))
+export const Alert = React.forwardRef(function Alert(
+    { children, as: Component = 'div', variant, className, role = 'alert', ...attributes },
+    reference
+) {
+    const { isBranded } = useWildcardTheme()
+    const brandedClassName = isBranded && classNames(styles.alert, variant && getAlertStyle({ variant }))
 
-        /**
-         * Set the assertiveness setting on the alert.
-         * Assertive: The alert will interrupt any current screen reader announcements.
-         * Polite: The alert will be read out by the screen reader when the user is idle.
-         */
-        const alertAssertiveness = userShouldBeImmediatelyNotified(variant) ? 'assertive' : 'polite'
+    /**
+     * Set the assertiveness setting on the alert.
+     * Assertive: The alert will interrupt any current screen reader announcements.
+     * Polite: The alert will be read out by the screen reader when the user is idle.
+     */
+    const alertAssertiveness = userShouldBeImmediatelyNotified(variant) ? 'assertive' : 'polite'
 
-        return (
-            <Component
-                ref={reference}
-                className={classNames(brandedClassName, className)}
-                role={role}
-                aria-live={alertAssertiveness}
-                {...attributes}
-            >
-                {children}
-            </Component>
-        )
-    }
-) as ForwardReferenceComponent<'div', AlertProps>
-
-Alert.displayName = 'Alert'
+    return (
+        <Component
+            ref={reference}
+            className={classNames(brandedClassName, className)}
+            role={role}
+            aria-live={alertAssertiveness}
+            {...attributes}
+        >
+            {children}
+        </Component>
+    )
+}) as ForwardReferenceComponent<'div', AlertProps>


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/34603

## Description
This PR:
- Adds email verification global alert experiment
   - All non-verified emails for the current user will show up on the global alert place (on top), which stays there on all web pages

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

## Screenshots
| Description | Screenshot |
| --: | :-- |
| single non-verified email | <img width="1728" alt="image" src="https://user-images.githubusercontent.com/6717049/172609569-a9057691-c735-40d4-85b1-d2cb075936b7.png"> |
| multiple non-verified emails | <img width="1728" alt="image" src="https://user-images.githubusercontent.com/6717049/172609755-90df03d1-0149-45c5-9755-276ba2f44b0c.png"> |

## Event logs
- `ab-email-verification-alert=true|false` event/user property
- `ViewUserSettingsEmails` event. Sent whenever user visits email settings page
- `UserEmailAddressVerificationResent` event. Sent whenever user clicks "resend verification email" on email settings page
## Test plan

## App preview:

- [Web](https://sg-web-erzhtor-add-verify-email.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-jlefmgjlfa.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

