### PR TITLE
codeintel: fix oldest stale commitgraph calculation

### DIFF
--- a/enterprise/internal/codeintel/stores/dbstore/commits.go
+++ b/enterprise/internal/codeintel/stores/dbstore/commits.go
@@ -101,12 +101,12 @@ const markRepositoryAsDirtyQuery = `
 -- source: enterprise/internal/codeintel/stores/dbstore/commits.go:MarkRepositoryAsDirty
 INSERT INTO lsif_dirty_repositories (repository_id, dirty_token, update_token)
 VALUES (%s, 1, 0)
-ON CONFLICT (repository_id)
-DO UPDATE SET dirty_token = lsif_dirty_repositories.dirty_token + 1,
-set_dirty_at = CASE WHEN lsif_dirty_repositories.update_token = lsif_dirty_repositories.dirty_token
-	THEN NOW()
-	ELSE lsif_dirty_repositories.set_dirty_at
-END
+ON CONFLICT (repository_id) DO UPDATE SET
+    dirty_token = lsif_dirty_repositories.dirty_token + 1,
+    set_dirty_at = CASE
+        WHEN lsif_dirty_repositories.update_token = lsif_dirty_repositories.dirty_token THEN NOW()
+        ELSE lsif_dirty_repositories.set_dirty_at
+    END
 `
 
 func scanIntPairs(rows *sql.Rows, queryErr error) (_ map[int]int, err error) {

--- a/enterprise/internal/codeintel/stores/dbstore/commits.go
+++ b/enterprise/internal/codeintel/stores/dbstore/commits.go
@@ -101,7 +101,12 @@ const markRepositoryAsDirtyQuery = `
 -- source: enterprise/internal/codeintel/stores/dbstore/commits.go:MarkRepositoryAsDirty
 INSERT INTO lsif_dirty_repositories (repository_id, dirty_token, update_token)
 VALUES (%s, 1, 0)
-ON CONFLICT (repository_id) DO UPDATE SET dirty_token = lsif_dirty_repositories.dirty_token + 1
+ON CONFLICT (repository_id)
+DO UPDATE SET dirty_token = lsif_dirty_repositories.dirty_token + 1,
+set_dirty_at = CASE WHEN lsif_dirty_repositories.update_token = lsif_dirty_repositories.dirty_token
+	THEN NOW()
+	ELSE lsif_dirty_repositories.set_dirty_at
+END
 `
 
 func scanIntPairs(rows *sql.Rows, queryErr error) (_ map[int]int, err error) {
@@ -168,7 +173,7 @@ func (s *Store) MaxStaleAge(ctx context.Context) (_ time.Duration, err error) {
 
 const maxStaleAgeQuery = `
 -- source: enterprise/internal/codeintel/stores/dbstore/commits.go:MaxStaleAge
-SELECT EXTRACT(EPOCH FROM NOW() - ldr.updated_at)::integer AS age
+SELECT EXTRACT(EPOCH FROM NOW() - ldr.set_dirty_at)::integer AS age
   FROM lsif_dirty_repositories ldr
     INNER JOIN repo ON repo.id = ldr.repository_id
   WHERE ldr.dirty_token > ldr.update_token

--- a/enterprise/internal/codeintel/stores/dbstore/commits_test.go
+++ b/enterprise/internal/codeintel/stores/dbstore/commits_test.go
@@ -128,7 +128,7 @@ func TestMaxStaleAge(t *testing.T) {
 			repository_id,
 			update_token,
 			dirty_token,
-			updated_at
+			set_dirty_at
 		)
 		VALUES
 			(50, 10, 10, NOW() - '45 minutes'::interval), -- not dirty

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -1280,6 +1280,7 @@ Tracks jobs that scan imports of indexes to schedule auto-index jobs.
  dirty_token   | integer                  |           | not null | 
  update_token  | integer                  |           | not null | 
  updated_at    | timestamp with time zone |           |          | 
+ set_dirty_at  | timestamp with time zone |           | not null | now()
 Indexes:
     "lsif_dirty_repositories_pkey" PRIMARY KEY, btree (repository_id)
 

--- a/migrations/frontend/1651077257/down.sql
+++ b/migrations/frontend/1651077257/down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE
+    IF EXISTS lsif_dirty_repositories DROP COLUMN IF EXISTS set_dirty_at;

--- a/migrations/frontend/1651077257/metadata.yaml
+++ b/migrations/frontend/1651077257/metadata.yaml
@@ -1,0 +1,2 @@
+name: lsif_dirty_repo_timestamp
+parents: [1650637472]

--- a/migrations/frontend/1651077257/up.sql
+++ b/migrations/frontend/1651077257/up.sql
@@ -1,0 +1,4 @@
+ALTER TABLE
+    lsif_dirty_repositories
+ADD
+    COLUMN IF NOT EXISTS set_dirty_at timestamptz NOT NULL DEFAULT NOW();


### PR DESCRIPTION
Previously, the calculation for the oldest stale commit graph used `lsif_dirty_repositories.updated_at`, which is the last time the commit graph was updated as opposed to when the commit graph became dirty, the former could be a very long time ago when a new upload increments the dirty token, hence the spikes in the graph.

## Test plan

manually by EYE :eye:


