### PR TITLE
Search backend: remove Dnf and friends

### DIFF
--- a/internal/search/predicate/substitute.go
+++ b/internal/search/predicate/substitute.go
@@ -158,11 +158,7 @@ func Substitute(q query.Basic, evaluate func(query.Plan) (result.Matches, error)
 	if topErr != nil || !success {
 		return nil, topErr
 	}
-	plan, err := query.ToPlan(query.Dnf(newQ))
-	if err != nil {
-		return nil, err
-	}
-	return plan, nil
+	return query.BuildPlan(newQ), nil
 }
 
 // searchResultsToRepoNodes converts a set of search results into repository nodes

--- a/internal/search/query/predicate.go
+++ b/internal/search/query/predicate.go
@@ -188,7 +188,7 @@ func (f *RepoContainsPredicate) Plan(parent Basic) (Plan, error) {
 	}
 
 	nodes = append(nodes, nonPredicateRepos(parent)...)
-	return ToPlan(Dnf(nodes))
+	return BuildPlan(nodes), nil
 }
 
 /* repo:contains.content(pattern) */
@@ -265,7 +265,7 @@ func (f *RepoContainsCommitAfterPredicate) Plan(parent Basic) (Plan, error) {
 	})
 
 	nodes = append(nodes, nonPredicateRepos(parent)...)
-	return ToPlan(Dnf(nodes))
+	return BuildPlan(nodes), nil
 }
 
 // RepoDependenciesPredicate represents the `repo:dependencies(regex@rev)` predicate,
@@ -330,7 +330,7 @@ func (f *FileContainsContentPredicate) Plan(parent Basic) (Plan, error) {
 	})
 
 	nodes = append(nodes, nonPredicateRepos(parent)...)
-	return ToPlan(Dnf(nodes))
+	return BuildPlan(nodes), nil
 }
 
 // nonPredicateRepos returns the repo nodes in a query that aren't predicates,

--- a/internal/search/query/query.go
+++ b/internal/search/query/query.go
@@ -154,18 +154,6 @@ func MapPlan(plan Plan, pass BasicPass) Plan {
 	return Plan(updated)
 }
 
-func ToPlan(disjuncts [][]Node) (Plan, error) {
-	plan := make([]Basic, 0, len(disjuncts))
-	for _, disjunct := range disjuncts {
-		basic, err := ToBasicQuery(disjunct)
-		if err != nil {
-			return nil, err
-		}
-		plan = append(plan, basic)
-	}
-	return plan, nil
-}
-
 // Pipeline processes zero or more steps to produce a query. The first step must
 // be Init, otherwise this function is a no-op.
 func Pipeline(steps ...step) (Plan, error) {

--- a/internal/search/query/query_test.go
+++ b/internal/search/query/query_test.go
@@ -2,25 +2,10 @@ package query
 
 import (
 	"encoding/json"
-	"strings"
 	"testing"
 
 	"github.com/hexops/autogold"
 )
-
-func planToString(disjuncts [][]Node) string {
-	var plan Plan
-	for _, disjunct := range disjuncts {
-		parameters, pattern, _ := PartitionSearchPattern(disjunct)
-		plan = append(plan, Basic{Parameters: parameters, Pattern: pattern})
-	}
-
-	var result []string
-	for _, basic := range plan {
-		result = append(result, toString(basic.ToParseTree()))
-	}
-	return strings.Join(result, " ")
-}
 
 func TestPipelineStructural(t *testing.T) {
 	test := func(input string) string {

--- a/internal/search/query/query_test.go
+++ b/internal/search/query/query_test.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/hexops/autogold"
 )
 
@@ -23,30 +22,10 @@ func planToString(disjuncts [][]Node) string {
 	return strings.Join(result, " ")
 }
 
-func TestPipeline_equivalence(t *testing.T) {
-	// The Pipeline must produce a value that is equivalent under DNF to parsing the query and processing it with DNF.
-	test := func(input string) string {
-		pipelinePlan, _ := Pipeline(InitLiteral(input))
-		nodes, _ := Run(InitLiteral(input))
-		disjuncts := Dnf(nodes)
-		plan, _ := ToPlan(disjuncts)
-		manualPlan := MapPlan(plan, ConcatRevFilters)
-		if diff := cmp.Diff(
-			planToString(Dnf(pipelinePlan.ToParseTree())),
-			planToString(Dnf(manualPlan.ToParseTree())),
-		); diff != "" {
-			return diff
-		}
-		return "equivalent"
-	}
-
-	autogold.Want("equivalent or-expression", "equivalent").Equal(t, test("(repo:bob or repo:jim) ((rev:olga or rev:ham) demo123232)"))
-}
-
 func TestPipelineStructural(t *testing.T) {
 	test := func(input string) string {
 		pipelinePlan, _ := Pipeline(InitStructural(input))
-		return planToString(Dnf(pipelinePlan.ToParseTree()))
+		return pipelinePlan.ToParseTree().String()
 	}
 
 	autogold.Want("contains(...) spans newlines", `"repo:contains.file(\nfoo\n)"`).Equal(t, test("repo:contains.file(\nfoo\n)"))

--- a/internal/search/query/transformer.go
+++ b/internal/search/query/transformer.go
@@ -373,50 +373,6 @@ func partition(nodes []Node, fn func(node Node) bool) (left, right []Node) {
 	return left, right
 }
 
-// product appends the list of n elements in right to each of the m rows in
-// left. If left is empty, it is initialized with right.
-func product(left [][]Node, right []Node) [][]Node {
-	result := [][]Node{}
-	if len(left) == 0 {
-		return append(result, right)
-	}
-
-	for _, row := range left {
-		newRow := make([]Node, len(row))
-		copy(newRow, row)
-		result = append(result, append(newRow, right...))
-	}
-	return result
-}
-
-// distribute applies the distributed property to nodes. See the dnf function
-// for context. Its first argument takes the current set of prefixes to prepend
-// to each term in an or-expression.
-func distribute(prefixes [][]Node, nodes []Node) [][]Node {
-	for _, node := range nodes {
-		switch v := node.(type) {
-		case Operator:
-			switch v.Kind {
-			case Or:
-				result := [][]Node{}
-				for _, o := range v.Operands {
-					var newPrefixes [][]Node
-					newPrefixes = distribute(newPrefixes, []Node{o})
-					for _, newPrefix := range newPrefixes {
-						result = append(result, product(prefixes, newPrefix)...)
-					}
-				}
-				prefixes = result
-			case And, Concat:
-				prefixes = distribute(prefixes, v.Operands)
-			}
-		case Parameter, Pattern:
-			prefixes = product(prefixes, []Node{v})
-		}
-	}
-	return prefixes
-}
-
 // distribute applies the distributed property to the parameters of basic
 // queries. See the BuildPlan function for context. Its first argument takes
 // the current set of prefixes to prepend to each term in an or-expression.
@@ -485,23 +441,6 @@ func basicConjunction(left, right Basic) Basic {
 		Parameters: append(append([]Parameter{}, left.Parameters...), right.Parameters...),
 		Pattern:    pattern,
 	}
-}
-
-// Dnf returns the Disjunctive Normal Form of a query (a flat sequence of
-// or-expressions) by applying the distributive property on (possibly nested)
-// or-expressions. For example, the query:
-//
-// (repo:a (file:b OR file:c))
-// in DNF becomes:
-// (repo:a file:b) OR (repo:a file:c)
-//
-// Using the DNF expression makes it easy to support general nested queries that
-// imply scope, like the one above: We simply evaluate all disjuncts and union
-// the results. Note that various optimizations are possible
-// during evaluation, but those are separate query pre- or postprocessing steps
-// separate from this general transformation.
-func Dnf(query []Node) [][]Node {
-	return distribute([][]Node{}, query)
 }
 
 // BuildPlan converts a raw query tree into a set of disjunct basic queries

--- a/internal/search/query/transformer_test.go
+++ b/internal/search/query/transformer_test.go
@@ -449,60 +449,6 @@ func TestPipeline(t *testing.T) {
 	}
 }
 
-func TestExpandOr(t *testing.T) {
-	cases := []struct {
-		input string
-		want  string
-	}{
-		{
-			input: `a or b`,
-			want:  `("a") OR ("b")`,
-		},
-		{
-			input: `a and b AND c OR d`,
-			want:  `("a" "b" "c") OR ("d")`,
-		},
-		{
-			input: "(repo:a (file:b or file:c))",
-			want:  `("repo:a" "file:b") OR ("repo:a" "file:c")`,
-		},
-		{
-			input: "(repo:a (file:b or file:c) (file:d or file:e))",
-			want:  `("repo:a" "file:b" "file:d") OR ("repo:a" "file:c" "file:d") OR ("repo:a" "file:b" "file:e") OR ("repo:a" "file:c" "file:e")`,
-		},
-		{
-			input: "(repo:a (file:b or file:c) (a b) (x z))",
-			want:  `("repo:a" "file:b" "(a b)" "(x z)") OR ("repo:a" "file:c" "(a b)" "(x z)")`,
-		},
-		{
-			input: `a and b AND c or d and (e OR f) g h i or j`,
-			want:  `("a" "b" "c") OR ("d" "e" "g" "h" "i") OR ("d" "f" "g" "h" "i") OR ("j")`,
-		},
-		{
-			input: "(repo:a (file:b (file:c or file:d) (file:e or file:f)))",
-			want:  `("repo:a" "file:b" "file:c" "file:e") OR ("repo:a" "file:b" "file:d" "file:e") OR ("repo:a" "file:b" "file:c" "file:f") OR ("repo:a" "file:b" "file:d" "file:f")`,
-		},
-		{
-			input: "(repo:a (file:b (file:c or file:d) file:q (file:e or file:f)))",
-			want:  `("repo:a" "file:b" "file:c" "file:q" "file:e") OR ("repo:a" "file:b" "file:d" "file:q" "file:e") OR ("repo:a" "file:b" "file:c" "file:q" "file:f") OR ("repo:a" "file:b" "file:d" "file:q" "file:f")`,
-		},
-	}
-	for _, c := range cases {
-		t.Run("Map query", func(t *testing.T) {
-			query, _ := Parse(c.input, SearchTypeRegex)
-			queries := Dnf(query)
-			var queriesStr []string
-			for _, q := range queries {
-				queriesStr = append(queriesStr, toString(q))
-			}
-			got := "(" + strings.Join(queriesStr, ") OR (") + ")"
-			if diff := cmp.Diff(c.want, got); diff != "" {
-				t.Fatal(diff)
-			}
-		})
-	}
-}
-
 func TestMap(t *testing.T) {
 	cases := []struct {
 		input string
@@ -940,8 +886,7 @@ func TestConcatRevFilters(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.input, func(t *testing.T) {
-			query, _ := Parse(c.input, SearchTypeRegex)
-			plan, _ := ToPlan(Dnf(query))
+			plan, _ := Pipeline(InitRegexp(c.input))
 
 			var queriesStr []string
 			for _, basic := range plan {
@@ -976,8 +921,7 @@ func TestConcatRevFiltersTopLevelAnd(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.input, func(t *testing.T) {
-			query, _ := Parse(c.input, SearchTypeRegex)
-			plan, _ := ToPlan(Dnf(query))
+			plan, _ := Pipeline(InitRegexp(c.input))
 			p := MapPlan(plan, ConcatRevFilters)
 			if diff := cmp.Diff(c.want, toString(p.ToParseTree())); diff != "" {
 				t.Error(diff)


### PR DESCRIPTION
We replaced the functionality of Dnf with BuildPlan, which maintains
tree structure of pattern nodes. I hadn't yet removed the
now-unnecessary Dnf code because I wanted it to be easy to revert, but
it's been out there for a bit with no issues. This replaces uses of Dnf
with BuildPlan, and removes it and associated code. I think there is
more code to simplify here, but I'll leave that for a followup PR.

Followup from https://github.com/sourcegraph/sourcegraph/pull/34382#discussion_r857828205

Some background: We previously ran DNF over all queries, which converted
queries like `repo:a (b or c)` into or-separated terms like `(repo:a b) or (repo:a c)`.
This is useful for sending queries to backends that do not support and/or operators
because we can send them simpler queries and join the results in `frontend`.
However, both zoekt and gitserver commit/diff search do support those operators 
natively. In order to send zoekt and gitserver optimized queries, we needed to stop
splitting up those pattern nodes ahead of time so that we can generate native zoekt and 
commit search queries that have these and/or patterns in them. 

## Test plan

Relying on tests. This shouldn't change any behavior visible to a user, but may change some conversions of queries to plans. Running backend integration tests on the branch. 

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


