### PR TITLE
codeintel: Mirror repository badge on old repository page

### DIFF
--- a/client/web/src/repo/RepoContainer.tsx
+++ b/client/web/src/repo/RepoContainer.tsx
@@ -376,7 +376,7 @@ export const RepoContainer: React.FunctionComponent<RepoContainerProps> = props 
         props.settingsCascade.final?.experimentalFeatures?.codeIntelRepositoryBadge?.enabled === true
 
     // Remove leading repository name and possible leading revision, then compare the remaining routes to
-    // see if we should display the code intelligence badge for this route. We wnat this to be visible on
+    // see if we should display the code intelligence badge for this route. We want this to be visible on
     // the repo root page, as well as directory and code views, but not administrative/non-code views.
     const matchRevisionAndRest = props.match.params.repoRevAndRest.slice(repoName.length)
     const matchOnlyRest =

--- a/client/web/src/repo/RepoContainer.tsx
+++ b/client/web/src/repo/RepoContainer.tsx
@@ -375,6 +375,17 @@ export const RepoContainer: React.FunctionComponent<RepoContainerProps> = props 
         !isErrorLike(props.settingsCascade.final) &&
         props.settingsCascade.final?.experimentalFeatures?.codeIntelRepositoryBadge?.enabled === true
 
+    // Remove leading repository name and possible leading revision, then compare the remaining routes to
+    // see if we should display the code intelligence badge for this route. We wnat this to be visible on
+    // the repo root page, as well as directory and code views, but not administrative/non-code views.
+    const matchRevisionAndRest = props.match.params.repoRevAndRest.slice(repoName.length)
+    const matchOnlyRest =
+        revision && matchRevisionAndRest.startsWith(`@${revision || ''}`)
+            ? matchRevisionAndRest.slice(revision.length + 1)
+            : matchRevisionAndRest
+    const isCodeIntelRepositoryBadgeVisibleOnRoute =
+        matchOnlyRest === '' || matchOnlyRest.startsWith('/-/tree') || matchOnlyRest.startsWith('/-/blob')
+
     const repoMatchURL = '/' + encodeURIPathComponent(repoName)
 
     const context: RepoContainerContext = {
@@ -431,7 +442,7 @@ export const RepoContainer: React.FunctionComponent<RepoContainerProps> = props 
                 )}
             </RepoHeaderContributionPortal>
 
-            {isCodeIntelRepositoryBadgeEnabled && (
+            {isCodeIntelRepositoryBadgeEnabled && isCodeIntelRepositoryBadgeVisibleOnRoute && (
                 <RepoHeaderContributionPortal
                     position="right"
                     priority={110}


### PR DESCRIPTION
This PR **really** covers the first checkbox on #34490 (#34555 is a liar). This PR hides the code intel badge on any repo/rev route that does **not** match a root, tree, or blob view.

## Test plan

Tested by locally to check that visibility state was correct.

## App preview:

- [Web](https://sg-web-ef-badge-repo-page-old.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-pnjmldubiq.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
