### PR TITLE
codeintel: Add additional telemetry to badge

### DIFF
--- a/client/web/src/enterprise/codeintel/badge/components/IndexerSummary.module.scss
+++ b/client/web/src/enterprise/codeintel/badge/components/IndexerSummary.module.scss
@@ -1,0 +1,4 @@
+.telemetric-redirect {
+    display: inline !important;
+    font-weight: normal;
+}

--- a/client/web/src/enterprise/codeintel/badge/components/IndexerSummary.tsx
+++ b/client/web/src/enterprise/codeintel/badge/components/IndexerSummary.tsx
@@ -1,10 +1,11 @@
 import React from 'react'
 
+import classNames from 'classnames'
 import AlertIcon from 'mdi-react/AlertIcon'
 import CheckIcon from 'mdi-react/CheckIcon'
 
 import { isDefined } from '@sourcegraph/common'
-import { Badge, Link } from '@sourcegraph/wildcard'
+import { Badge } from '@sourcegraph/wildcard'
 
 import { Timestamp } from '../../../../components/time/Timestamp'
 import {
@@ -14,12 +15,15 @@ import {
     LSIFUploadState,
     LSIFIndexState,
 } from '../../../../graphql-operations'
+import { TelemetricRedirect } from '../../../../tracking/TelemetricRedirect'
 import {
     useRequestedLanguageSupportQuery as defaultUseRequestedLanguageSupportQuery,
     useRequestLanguageSupportQuery as defaultUseRequestLanguageSupportQuery,
 } from '../hooks/useCodeIntelStatus'
 
 import { RequestLink } from './RequestLink'
+
+import styles from './IndexerSummary.module.scss'
 
 export interface IndexerSummaryProps {
     repoName: string
@@ -30,23 +34,25 @@ export interface IndexerSummaryProps {
         indexer?: CodeIntelIndexerFields
     }
     className?: string
+    now?: () => Date
     useRequestedLanguageSupportQuery: typeof defaultUseRequestedLanguageSupportQuery
     useRequestLanguageSupportQuery: typeof defaultUseRequestLanguageSupportQuery
-    now?: () => Date
 }
 
 export const IndexerSummary: React.FunctionComponent<IndexerSummaryProps> = ({
     repoName,
     summary,
     className,
+    now,
     useRequestedLanguageSupportQuery,
     useRequestLanguageSupportQuery,
-    now,
 }) => {
     const failedUploads = summary.uploads.filter(upload => upload.state === LSIFUploadState.ERRORED)
     const failedIndexes = summary.indexes.filter(index => index.state === LSIFIndexState.ERRORED)
     const finishedAtTimes = summary.uploads.map(upload => upload.finishedAt || undefined).filter(isDefined)
     const lastUpdated = finishedAtTimes.length === 0 ? undefined : finishedAtTimes.sort().reverse()[0]
+
+    const telemetricRedirectClassName = classNames('m-0 p-0', styles.telemetricRedirect)
 
     return (
         <div className="px-2 py-1">
@@ -78,7 +84,12 @@ export const IndexerSummary: React.FunctionComponent<IndexerSummaryProps> = ({
 
                     {summary.uploads.length + summary.indexes.length === 0 ? (
                         summary.indexer?.url ? (
-                            <Link to={summary.indexer?.url}>Set up for this repository</Link>
+                            <TelemetricRedirect
+                                to={summary.indexer.url}
+                                label="Set up for this repository"
+                                eventName="CodeIntelligenceIndexerSetupInvestigated"
+                                className={telemetricRedirectClassName}
+                            />
                         ) : (
                             <RequestLink
                                 indexerName={summary.name}
@@ -96,18 +107,24 @@ export const IndexerSummary: React.FunctionComponent<IndexerSummaryProps> = ({
                             {failedUploads.length > 0 && (
                                 <p className="mb-1 text-muted">
                                     <AlertIcon size={16} className="text-danger" />{' '}
-                                    <Link to={`/${repoName}/-/code-intelligence/uploads?filters=errored`}>
-                                        Latest upload processing
-                                    </Link>{' '}
+                                    <TelemetricRedirect
+                                        to={`/${repoName}/-/code-intelligence/uploads?filters=errored`}
+                                        label="Latest upload processing"
+                                        eventName="CodeIntelligenceUploadErrorInvestigated"
+                                        className={telemetricRedirectClassName}
+                                    />{' '}
                                     failed
                                 </p>
                             )}
                             {failedIndexes.length > 0 && (
                                 <p className="mb-1 text-muted">
                                     <AlertIcon size={16} className="text-danger" />{' '}
-                                    <Link to={`/${repoName}/-/code-intelligence/indexes?filters=errored`}>
-                                        Latest indexing
-                                    </Link>{' '}
+                                    <TelemetricRedirect
+                                        to={`/${repoName}/-/code-intelligence/indexes?filters=errored`}
+                                        label="Latest indexing"
+                                        eventName="CodeIntelligenceIndexErrorInvestigated"
+                                        className={telemetricRedirectClassName}
+                                    />{' '}
                                     failed
                                 </p>
                             )}

--- a/client/web/src/enterprise/codeintel/badge/components/IndexerSummary.tsx
+++ b/client/web/src/enterprise/codeintel/badge/components/IndexerSummary.tsx
@@ -87,6 +87,7 @@ export const IndexerSummary: React.FunctionComponent<IndexerSummaryProps> = ({
                             <TelemetricRedirect
                                 to={summary.indexer.url}
                                 label="Set up for this repository"
+                                alwaysShowLabel={true}
                                 eventName="CodeIntelligenceIndexerSetupInvestigated"
                                 className={telemetricRedirectClassName}
                             />
@@ -110,6 +111,7 @@ export const IndexerSummary: React.FunctionComponent<IndexerSummaryProps> = ({
                                     <TelemetricRedirect
                                         to={`/${repoName}/-/code-intelligence/uploads?filters=errored`}
                                         label="Latest upload processing"
+                                        alwaysShowLabel={true}
                                         eventName="CodeIntelligenceUploadErrorInvestigated"
                                         className={telemetricRedirectClassName}
                                     />{' '}
@@ -122,6 +124,7 @@ export const IndexerSummary: React.FunctionComponent<IndexerSummaryProps> = ({
                                     <TelemetricRedirect
                                         to={`/${repoName}/-/code-intelligence/indexes?filters=errored`}
                                         label="Latest indexing"
+                                        alwaysShowLabel={true}
                                         eventName="CodeIntelligenceIndexErrorInvestigated"
                                         className={telemetricRedirectClassName}
                                     />{' '}

--- a/client/web/src/tracking/TelemetricRedirect.tsx
+++ b/client/web/src/tracking/TelemetricRedirect.tsx
@@ -8,6 +8,7 @@ import { logEventSynchronously } from '../user/settings/backend'
 export interface TelemetricRedirectProps {
     to: string
     label: string
+    alwaysShowLabel: boolean
     eventName: string
     className?: string
 }
@@ -17,6 +18,7 @@ const MAXIMUM_TELEMETRY_DELAY = 5000
 export const TelemetricRedirect: React.FunctionComponent<TelemetricRedirectProps> = ({
     to,
     label,
+    alwaysShowLabel,
     eventName,
     className,
 }) => {
@@ -50,6 +52,13 @@ export const TelemetricRedirect: React.FunctionComponent<TelemetricRedirectProps
     return redirect ? (
         <Redirect to={to} />
     ) : (
-        <LoaderButton variant="link" label={label} className={className} onClick={onClick} loading={loading} />
+        <LoaderButton
+            variant="link"
+            label={label}
+            alwaysShowLabel={alwaysShowLabel}
+            className={className}
+            onClick={onClick}
+            loading={loading}
+        />
     )
 }


### PR DESCRIPTION
This PR replaces the user-CTA links int he coded intel badge from `Link` to `TelemetricRedirect` introduced in #34644. This should populate the event_logs table so we can add additional ping data. This effort is towards the last two checkboxes on #34490 (still need to send and receive telemetry data).

## Test plan

Checked event_logs table by hand with local telemetry enabled.

## App preview:

- [Web](https://sg-web-ef-badge-telemetry.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-fcledoiosz.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

