### PR TITLE
[SG-34403-1] Improve Percy + accessibilityAudit test coverage on User Profile Settings, User Email Settings, User Password Settings Page

### DIFF
--- a/client/web/src/integration/profile.test.ts
+++ b/client/web/src/integration/profile.test.ts
@@ -1,13 +1,33 @@
 import assert from 'assert'
 
+import { accessibilityAudit } from '@sourcegraph/shared/src/testing/accessibility'
 import { createDriverForTest, Driver } from '@sourcegraph/shared/src/testing/driver'
+import { testUserID } from '@sourcegraph/shared/src/testing/integration/graphQlResults'
 import { afterEachSaveScreenshotIfFailed } from '@sourcegraph/shared/src/testing/screenshotReporter'
 
 import { UserSettingsAreaUserFields } from '../graphql-operations'
 
 import { createWebIntegrationTestContext, WebIntegrationTestContext } from './context'
 import { commonWebGraphQlResults } from './graphQlResults'
+import { percySnapshotWithVariants } from './utils'
 
+const USER: UserSettingsAreaUserFields = {
+    __typename: 'User',
+    id: 'VXNlcjoxODkyNw==',
+    username: 'test',
+    displayName: 'Test',
+    url: '/users/test',
+    settingsURL: '/users/test/settings',
+    avatarURL: '',
+    viewerCanAdminister: true,
+    viewerCanChangeUsername: true,
+    siteAdmin: true,
+    builtinAuth: true,
+    createdAt: '2020-04-10T21:11:42Z',
+    emails: [{ email: 'test@example.com', verified: true }],
+    organizations: { nodes: [] },
+    tags: [],
+}
 describe('User profile page', () => {
     let driver: Driver
     before(async () => {
@@ -26,23 +46,6 @@ describe('User profile page', () => {
     afterEach(() => testContext?.dispose())
 
     it('updates display name', async () => {
-        const USER: UserSettingsAreaUserFields = {
-            __typename: 'User',
-            id: 'VXNlcjoxODkyNw==',
-            username: 'test',
-            displayName: 'Test',
-            url: '/users/test',
-            settingsURL: '/users/test/settings',
-            avatarURL: '',
-            viewerCanAdminister: true,
-            viewerCanChangeUsername: true,
-            siteAdmin: true,
-            builtinAuth: true,
-            createdAt: '2020-04-10T21:11:42Z',
-            emails: [{ email: 'test@example.com', verified: true }],
-            organizations: { nodes: [] },
-            tags: [],
-        }
         testContext.overrideGraphQL({
             ...commonWebGraphQlResults,
             UserAreaUserProfile: () => ({
@@ -54,6 +57,8 @@ describe('User profile page', () => {
             UpdateUser: () => ({ updateUser: { ...USER, displayName: 'Test2' } }),
         })
         await driver.page.goto(driver.sourcegraphBaseUrl + '/users/test/settings/profile')
+        await percySnapshotWithVariants(driver.page, 'User Profile Settings Page')
+        await accessibilityAudit(driver.page)
         await driver.page.waitForSelector('[data-testid="user-profile-form-fields"]')
         await driver.replaceText({
             selector: '.test-UserProfileFormFields__displayName',
@@ -66,5 +71,97 @@ describe('User profile page', () => {
         }, 'UpdateUser')
 
         assert.strictEqual(requestVariables.displayName, 'Test2')
+    })
+})
+
+describe('User Different Settings Page', () => {
+    let driver: Driver
+    before(async () => {
+        driver = await createDriverForTest()
+    })
+    after(() => driver?.close())
+    let testContext: WebIntegrationTestContext
+    beforeEach(async function () {
+        testContext = await createWebIntegrationTestContext({
+            driver,
+            currentTest: this.currentTest!,
+            directory: __dirname,
+        })
+    })
+    afterEachSaveScreenshotIfFailed(() => driver.page)
+    afterEach(() => testContext?.dispose())
+
+    it('display user email setting page', async () => {
+        testContext.overrideGraphQL({
+            ...commonWebGraphQlResults,
+            UserAreaUserProfile: () => ({
+                user: USER,
+            }),
+            UserSettingsAreaUserProfile: () => ({
+                node: USER,
+            }),
+            UserEmails: () => ({
+                node: {
+                    __typename: 'User',
+                    emails: [
+                        {
+                            email: 'test@example.com',
+                            isPrimary: true,
+                            verified: true,
+                            verificationPending: false,
+                            viewerCanManuallyVerify: false,
+                        },
+                    ],
+                },
+            }),
+        })
+        await driver.page.goto(driver.sourcegraphBaseUrl + '/users/test/settings/emails')
+        await driver.page.waitForSelector('[data-testid="user-settings-emails-page"]')
+        await percySnapshotWithVariants(driver.page, 'User Email Settings Page')
+        await accessibilityAudit(driver.page)
+    })
+
+    it('display user password setting page', async () => {
+        testContext.overrideGraphQL({
+            ...commonWebGraphQlResults,
+            UserAreaUserProfile: () => ({
+                user: {
+                    __typename: 'User',
+                    id: testUserID,
+                    username: 'test',
+                    displayName: null,
+                    url: '/users/test',
+                    settingsURL: '/users/test/settings',
+                    avatarURL: null,
+                    viewerCanAdminister: true,
+                    builtinAuth: true,
+                    tags: [],
+                },
+            }),
+            UserSettingsAreaUserProfile: () => ({
+                node: {
+                    __typename: 'User',
+                    id: testUserID,
+                    username: 'test',
+                    displayName: null,
+                    url: '/users/test',
+                    settingsURL: '/users/test/settings',
+                    avatarURL: null,
+                    viewerCanAdminister: true,
+                    viewerCanChangeUsername: true,
+                    siteAdmin: true,
+                    builtinAuth: true,
+                    createdAt: '2020-03-02T11:52:15Z',
+                    emails: [{ email: 'test@sourcegraph.test', verified: true }],
+                    organizations: { nodes: [] },
+                    permissionsInfo: null,
+                    tags: [],
+                },
+            }),
+        })
+        await driver.page.goto(driver.sourcegraphBaseUrl + '/user/settings/password')
+        await driver.page.waitForSelector('.user-settings-password-page')
+        await percySnapshotWithVariants(driver.page, 'User Password Settings Page')
+        await accessibilityAudit(driver.page)
     })
 })

--- a/client/web/src/user/settings/emails/UserEmail.tsx
+++ b/client/web/src/user/settings/emails/UserEmail.tsx
@@ -136,8 +136,13 @@ export const UserEmail: FunctionComponent<Props> = ({
             <div className="d-flex align-items-center justify-content-between">
                 <div className="d-flex align-items-center">
                     <span className="mr-2">{email}</span>
+                    {/*
+                        a11y-ignore
+                        Rule: "color-contrast" (Elements must have sufficient color contrast)
+                        GitHub issue: https://github.com/sourcegraph/sourcegraph/issues/33343
+                    */}
                     {verified && (
-                        <Badge variant="success" className="mr-1">
+                        <Badge variant="success" className="mr-1 a11y-ignore">
                             Verified
                         </Badge>
                     )}

--- a/client/web/src/user/settings/emails/UserSettingsEmailsPage.tsx
+++ b/client/web/src/user/settings/emails/UserSettingsEmailsPage.tsx
@@ -74,7 +74,7 @@ export const UserSettingsEmailsPage: FunctionComponent<Props> = ({ user }) => {
     }
 
     return (
-        <div className={styles.userSettingsEmailsPage}>
+        <div className={styles.userSettingsEmailsPage} data-testid="user-settings-emails-page">
             <PageTitle title="Emails" />
             <PageHeader headingElement="h2" path={[{ text: 'Emails' }]} className="mb-3" />
 


### PR DESCRIPTION
## Description
We currently have visual regression + accessibility audit tests on a series of user journeys within Sourcegraph. A lot of core functionality is still not covered, it reduces our confidence in shipping changes as UI/accessibility bugs can be introduced without our awareness.

## Implementation
For [Profile Page](https://k8s.sgdev.org/user/settings/profile) , [Email Page](https://k8s.sgdev.org/user/settings/emails) , [Password Page](https://k8s.sgdev.org/user/settings/password)
1. Add percySnapshotWithVariants to store a visual snapshot for the test.
2. Add accessibilityAudit to run our accessibility tests, and fix any identified problems.

## Refs
[Sourcegraph Issue](https://github.com/sourcegraph/sourcegraph/issues/34403)
[Gitstart Ticket](https://app.gitstart.com/clients/sourcegraph/tickets/SG-34403)

## Test plan
Run `ENTERPRISE=1 yarn build-web`
Run `ENTERPRISE=1 HEADLESS=true yarn _test-integration client/web/src/integration/profile.test.ts`
Test should pass successfully
<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->



## App preview:

- [Web](https://sg-web-contractors-sg-34403-1.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-dagzhploxi.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
