### PR TITLE
New reference panel: bump font sizes, add dividers

### DIFF
--- a/client/web/src/codeintel/ReferencesPanel.module.scss
+++ b/client/web/src/codeintel/ReferencesPanel.module.scss
@@ -21,8 +21,11 @@ $filter-input-height: 1.5rem;
     }
 }
 
+$group-header-font-size: 0.875rem;
+$group-divider-height: 0.25rem;
+
 .repo-location-group {
-    margin-bottom: 0.33rem;
+    margin-bottom: $group-divider-height;
 
     &:last-child {
         margin-bottom: 0;
@@ -39,13 +42,13 @@ $filter-input-height: 1.5rem;
 
         &--repo-name {
             padding-left: 0.6rem;
-            font-size: 0.875rem;
+            font-size: $group-header-font-size;
         }
     }
 }
 
 .location-group {
-    margin-bottom: 0.33rem;
+    margin-bottom: $group-divider-height;
 
     &:last-child {
         margin-bottom: 0;
@@ -63,7 +66,7 @@ $filter-input-height: 1.5rem;
         &--filename {
             padding-left: 0.6rem;
             font-weight: 400;
-            font-size: 0.875rem;
+            font-size: $group-header-font-size;
 
             mark {
                 padding-left: 0;

--- a/client/web/src/codeintel/ReferencesPanel.module.scss
+++ b/client/web/src/codeintel/ReferencesPanel.module.scss
@@ -39,6 +39,7 @@ $filter-input-height: 1.5rem;
 
         &--repo-name {
             padding-left: 0.6rem;
+            font-size: 0.875rem;
         }
     }
 }
@@ -62,6 +63,7 @@ $filter-input-height: 1.5rem;
         &--filename {
             padding-left: 0.6rem;
             font-weight: 400;
+            font-size: 0.875rem;
 
             mark {
                 padding-left: 0;

--- a/client/web/src/codeintel/ReferencesPanel.module.scss
+++ b/client/web/src/codeintel/ReferencesPanel.module.scss
@@ -22,36 +22,52 @@ $filter-input-height: 1.5rem;
 }
 
 .repo-location-group {
-    padding-top: 0.2rem;
-    padding-bottom: 0.2rem;
-    padding-left: 2.3rem;
-    width: 100%;
-    text-align: left;
+    margin-bottom: 0.33rem;
 
-    font-weight: 400;
+    &:last-child {
+        margin-bottom: 0;
+    }
 
-    &--repo-name {
-        padding-left: 0.6rem;
+    &--header {
+        padding-top: 0.2rem;
+        padding-bottom: 0.2rem;
+        padding-left: 2.3rem;
+        width: 100%;
+        text-align: left;
+
+        font-weight: 400;
+
+        &--repo-name {
+            padding-left: 0.6rem;
+        }
     }
 }
 
 .location-group {
-    padding-left: 3.75rem;
-    padding-top: 0.2rem;
-    padding-bottom: 0.2rem;
-    width: 100%;
-    text-align: left;
+    margin-bottom: 0.33rem;
 
-    transition: none !important;
+    &:last-child {
+        margin-bottom: 0;
+    }
 
-    &--filename {
-        padding-left: 0.6rem;
-        font-weight: 400;
+    &--header {
+        padding-left: 3.75rem;
+        padding-top: 0.2rem;
+        padding-bottom: 0.2rem;
+        width: 100%;
+        text-align: left;
 
-        mark {
-            padding-left: 0;
-            padding-right: 0;
-            font-weight: bold;
+        transition: none !important;
+
+        &--filename {
+            padding-left: 0.6rem;
+            font-weight: 400;
+
+            mark {
+                padding-left: 0;
+                padding-right: 0;
+                font-weight: bold;
+            }
         }
     }
 }

--- a/client/web/src/codeintel/ReferencesPanel.tsx
+++ b/client/web/src/codeintel/ReferencesPanel.tsx
@@ -705,12 +705,12 @@ const CollapsibleRepoLocationGroup: React.FunctionComponent<
 
     return (
         <Collapse isOpen={open} onOpenChange={isOpen => handleOpenChange(repoLocationGroup.repoName, isOpen)}>
-            <>
+            <div className={styles.repoLocationGroup}>
                 <CollapseHeader
                     as={Button}
                     aria-expanded={open}
                     type="button"
-                    className={classNames('d-flex justify-content-start w-100', styles.repoLocationGroup)}
+                    className={classNames('d-flex justify-content-start w-100', styles.repoLocationGroupHeader)}
                 >
                     {open ? (
                         <Icon aria-label="Close" as={ChevronDownIcon} />
@@ -744,7 +744,7 @@ const CollapsibleRepoLocationGroup: React.FunctionComponent<
                         />
                     ))}
                 </CollapsePanel>
-            </>
+            </div>
         </Collapse>
     )
 }
@@ -765,14 +765,14 @@ const CollapsibleLocationGroup: React.FunctionComponent<
 
     return (
         <Collapse isOpen={open} onOpenChange={isOpen => handleOpenChange(group.path, isOpen)}>
-            <>
+            <div className={styles.locationGroup}>
                 <CollapseHeader
                     as={Button}
                     aria-expanded={open}
                     type="button"
                     className={classNames(
                         'bg-transparent border-top-0 border-left-0 border-right-0 d-flex justify-content-start w-100',
-                        styles.locationGroup
+                        styles.locationGroupHeader
                     )}
                 >
                     {open ? (
@@ -829,7 +829,7 @@ const CollapsibleLocationGroup: React.FunctionComponent<
                         })}
                     </ul>
                 </CollapsePanel>
-            </>
+            </div>
         </Collapse>
     )
 }

--- a/client/web/src/codeintel/ReferencesPanel.tsx
+++ b/client/web/src/codeintel/ReferencesPanel.tsx
@@ -724,7 +724,7 @@ const CollapsibleRepoLocationGroup: React.FunctionComponent<
                                 event.preventDefault()
                                 navigateToUrl(repoUrl)
                             }}
-                            className={classNames('text-small', styles.repoLocationGroupRepoName)}
+                            className={classNames('text-small', styles.repoLocationGroupHeaderRepoName)}
                         >
                             {displayRepoName(repoLocationGroup.repoName)}
                         </Link>
@@ -780,7 +780,7 @@ const CollapsibleLocationGroup: React.FunctionComponent<
                     ) : (
                         <Icon aria-label="Expand" as={ChevronRightIcon} />
                     )}
-                    <small className={styles.locationGroupFilename}>
+                    <small className={styles.locationGroupHeaderFilename}>
                         {highlighted.length === 2 ? (
                             <span>
                                 {highlighted[0]}


### PR DESCRIPTION
This implements @jjinnii's suggestions in https://github.com/sourcegraph/sourcegraph/issues/34201#issuecomment-1110283086 by

- changing font size of repository name and file name
- adding dividers between file results and repository groups

Left: before, right: after

<img width="1157" alt="screenshot_2022-04-28_10 07 07@2x" src="https://user-images.githubusercontent.com/1185253/165707144-e0863d7c-3d8d-406b-a35a-7809b1485a47.png">

## Test plan

- Existing tests

## App preview:

- [Web](https://sg-web-mrn-more-ref-panel-polish.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-hegjnxmugz.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
