### PR TITLE
Code Insights: Fix request cancellation for the live preview logic

### DIFF
--- a/client/web/src/enterprise/insights/components/creation-ui-kit/live-preview/use-live-preview.ts
+++ b/client/web/src/enterprise/insights/components/creation-ui-kit/live-preview/use-live-preview.ts
@@ -48,7 +48,7 @@ export function useLivePreview<D>(input: Input<D>): Output<D> {
         }
 
         return () => {
-            hasRequestCanceled = false
+            hasRequestCanceled = true
         }
     }, [debouncedInput, lastPreviewVersion])
 


### PR DESCRIPTION

The thing that we missed in the past during chart migration, prior to this PR we didn't have a proper network request cancellation hence it might be possible to fall in race condition there.

## Test plan

- Make sure that you can see the live preview and all live previews (search, capture group, lang stats) work properly around data fetching (even if you're filling the form really fast)



## App preview:

- [Web](https://sg-web-vk-fix-live-preview-insight-fetch.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-xtriyfdecj.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
