### PR TITLE
repos: Fix external service config overwrite during long syncs

### DIFF
--- a/internal/repos/integration_test.go
+++ b/internal/repos/integration_test.go
@@ -36,6 +36,7 @@ func TestIntegration(t *testing.T) {
 		{"ListExternalServicePrivateRepoIDsByUserID", testStoreListExternalServicePrivateRepoIDsByUserID},
 		{"Syncer/SyncWorker", testSyncWorkerPlumbing},
 		{"Syncer/Sync", testSyncerSync},
+		{"Syncer/SyncDoesNotOverwriteUpdatedConfig", testSyncDoesNotOverwriteUpdatedConfig},
 		{"Syncer/SyncRepo", testSyncRepo},
 		{"Syncer/Run", testSyncRun},
 		{"Syncer/MultipleServices", testSyncerMultipleServices},

--- a/internal/repos/syncer.go
+++ b/internal/repos/syncer.go
@@ -616,6 +616,23 @@ func (s *Syncer) SyncExternalService(
 	interval := calcSyncInterval(now, svc.LastSyncAt, minSyncInterval, modified, errs)
 
 	s.log().Debug("Synced external service", "id", externalServiceID, "backoff duration", interval)
+
+	// Re-load the service from the DB and update the sync timestamps. We do this
+	// because a sync can take a long time and we'd potentially over-write changes to
+	// other fields like the config that happened during the sync by re-using the same `svc`
+	// loaded at the beginning of the sync.
+	tx, err := s.Store.ExternalServiceStore.Transact(ctx)
+	if err != nil {
+		return errors.Append(errs, errors.Wrap(err, "failed to start tx"))
+	}
+
+	defer func() { errs = errors.Append(errs, tx.Done(err)) }()
+
+	svc, err = tx.GetByID(ctx, svc.ID)
+	if err != nil {
+		return errors.Append(errs, errors.Wrap(err, "failed to load extsvc"))
+	}
+
 	svc.NextSyncAt = now.Add(interval)
 	svc.LastSyncAt = now
 

--- a/internal/repos/syncer.go
+++ b/internal/repos/syncer.go
@@ -636,7 +636,7 @@ func (s *Syncer) SyncExternalService(
 	svc.NextSyncAt = now.Add(interval)
 	svc.LastSyncAt = now
 
-	err = s.Store.ExternalServiceStore.Upsert(ctx, svc)
+	err = tx.Upsert(ctx, svc)
 	if err != nil {
 		errs = errors.Append(errs, errors.Wrap(err, "upserting external service"))
 	}

--- a/internal/repos/syncer_test.go
+++ b/internal/repos/syncer_test.go
@@ -2217,7 +2217,6 @@ func testSyncDoesNotOverwriteUpdatedConfig(store *repos.Store) func(*testing.T) 
 
 		now := time.Now()
 
-		// create fake source (one user and one org)
 		svc := &types.ExternalService{
 			Kind:        extsvc.KindGitHub,
 			DisplayName: "Github - SyncDoesNotOverwriteUpdatedConfig",

--- a/internal/repos/syncer_test.go
+++ b/internal/repos/syncer_test.go
@@ -2209,3 +2209,64 @@ func setupSyncErroredTest(ctx context.Context, s *repos.Store, t *testing.T,
 	}
 	return syncer, dbRepos
 }
+
+func testSyncDoesNotOverwriteUpdatedConfig(store *repos.Store) func(*testing.T) {
+	return func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		now := time.Now()
+
+		// create fake source (one user and one org)
+		svc := &types.ExternalService{
+			Kind:        extsvc.KindGitHub,
+			DisplayName: "Github - SyncDoesNotOverwriteUpdatedConfig",
+			Config:      `{"url": "https://github.com"}`,
+			CreatedAt:   now,
+			UpdatedAt:   now,
+		}
+
+		// setup service
+		if err := store.ExternalServiceStore.Upsert(ctx, svc); err != nil {
+			t.Fatal(err)
+		}
+
+		const updatedConfig = `{"url": "https://ghe.sgdev.org"}`
+
+		syncer := &repos.Syncer{
+			Sourcer: func(service *types.ExternalService) (repos.Source, error) {
+				// Update the config while the sync is running, emulating what a user
+				// could do via the UI.
+				svc.Config = updatedConfig
+				err := store.ExternalServiceStore.Upsert(ctx, svc)
+				if err != nil {
+					t.Fatal(err)
+				}
+				return repos.NewFakeSource(svc, nil), nil
+			},
+			Store: store,
+			Now:   time.Now,
+		}
+
+		if err := syncer.SyncExternalService(ctx, svc.ID, 10*time.Second); err != nil {
+			t.Fatal("Error occurred. Should not happen because neither site nor user/org limit is exceeded.")
+		}
+
+		syncedSvc, err := store.ExternalServiceStore.GetByID(ctx, svc.ID)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if diff := cmp.Diff(updatedConfig, syncedSvc.Config); diff != "" {
+			t.Fatalf("config mismatch: (+want, -have): %s", diff)
+		}
+
+		if !syncedSvc.NextSyncAt.After(svc.NextSyncAt) {
+			t.Fatalf("NextSyncAt %s not after previous %s", syncedSvc.NextSyncAt, svc.NextSyncAt)
+		}
+
+		if !syncedSvc.NextSyncAt.After(svc.NextSyncAt) {
+			t.Fatalf("LastSyncAt %s not after previous %s", syncedSvc.LastSyncAt, svc.LastSyncAt)
+		}
+	}
+}


### PR DESCRIPTION
This commit makes it so we don't overwrite the config field (or any
other fields for that matter) at the end of an external service sync
with stale data that has since been updated (while a long sync was
running).



## Test plan

Integration test.

