### PR TITLE
Fix infinite spinner when no feature flags are configured

### DIFF
--- a/client/web/src/site-admin/SiteAdminFeatureFlagsPage.tsx
+++ b/client/web/src/site-admin/SiteAdminFeatureFlagsPage.tsx
@@ -151,7 +151,7 @@ export const SiteAdminFeatureFlagsPage: React.FunctionComponent<SiteAdminFeature
                                   )
                               )
                           )
-                        : of(flags)
+                        : of([])
                 ),
                 // Observable<T[]> => T[]
                 mergeMap(flags => flags),

--- a/client/web/src/site-admin/SiteAdminFeatureFlagsPage.tsx
+++ b/client/web/src/site-admin/SiteAdminFeatureFlagsPage.tsx
@@ -138,18 +138,20 @@ export const SiteAdminFeatureFlagsPage: React.FunctionComponent<SiteAdminFeature
                 // T => Observable<T[]>
                 map(flags =>
                     // Observable<T>[] => Observable<T[]>
-                    forkJoin(
-                        flags.map(flag =>
-                            getFeatureFlagReferences(flag.name, productGitVersion).pipe(
-                                map(
-                                    (references): FeatureFlagAndReferences => ({
-                                        ...flag,
-                                        references,
-                                    })
-                                )
-                            )
-                        )
-                    )
+                    flags.length > 0
+                        ? forkJoin(
+                              flags.map(flag =>
+                                  getFeatureFlagReferences(flag.name, productGitVersion).pipe(
+                                      map(
+                                          (references): FeatureFlagAndReferences => ({
+                                              ...flag,
+                                              references,
+                                          })
+                                      )
+                                  )
+                              )
+                          )
+                        : of(flags)
                 ),
                 // Observable<T[]> => T[]
                 mergeMap(flags => flags),


### PR DESCRIPTION
Before this change the feature flags admin page would show a spinner indefinitely if there were no feature flags configured.

@eseliger tracked this down `forkJoin` apparently blocking when receiving `flags` that are empty.

So now we check for the length and then either do the old `forkJoin` or emit `flags` directly.

## Test plan

- Tested locally by comparing before and after with empty and not-empty feature flags page.



## App preview:

- [Web](https://sg-web-mrn-es-fix-feature-flag-empty.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-jsptdzsexk.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
