### PR TITLE
codeintel/indexing: Normalize names of JVM dependency repos

### DIFF
--- a/enterprise/cmd/worker/internal/codeintel/indexing/dependency_sync_scheduler.go
+++ b/enterprise/cmd/worker/internal/codeintel/indexing/dependency_sync_scheduler.go
@@ -3,11 +3,13 @@ package indexing
 import (
 	"context"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/inconshreveable/log15"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/dbstore"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/shared"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/dependencies"
 	"github.com/sourcegraph/sourcegraph/internal/database"
@@ -89,13 +91,9 @@ func (h *dependencySyncSchedulerHandler) Handle(ctx context.Context, record work
 			break
 		}
 
-		pkg := precise.Package{
-			Scheme:  packageReference.Package.Scheme,
-			Name:    packageReference.Package.Name,
-			Version: packageReference.Package.Version,
-		}
+		pkg := newPackage(packageReference.Package)
 
-		extsvcKind, ok := schemeToExternalService[packageReference.Scheme]
+		extsvcKind, ok := schemeToExternalService[pkg.Scheme]
 		// add entry for empty string/kind here so dependencies such as lsif-go ones still get
 		// an associated dependency indexing job
 		kinds[extsvcKind] = struct{}{}
@@ -166,6 +164,27 @@ func (h *dependencySyncSchedulerHandler) Handle(ctx context.Context, record work
 	}
 
 	return errors.Append(nil, errs...)
+}
+
+// newPackage constructs a precise.Package from the given shared.Package,
+// applying any normalization or necessary transformations that lsif uploads
+// require for internal consistency.
+func newPackage(pkg shared.Package) precise.Package {
+	p := precise.Package{
+		Scheme:  pkg.Scheme,
+		Name:    pkg.Name,
+		Version: pkg.Version,
+	}
+
+	switch pkg.Scheme {
+	case dependencies.JVMPackagesScheme:
+		if strings.HasPrefix(p.Name, "maven/") {
+			p.Name = p.Name[len("maven/"):]
+		}
+		p.Name = strings.ReplaceAll(p.Name, "/", ":")
+	}
+
+	return p
 }
 
 func (h *dependencySyncSchedulerHandler) insertDependencyRepo(ctx context.Context, pkg precise.Package) (new bool, err error) {

--- a/enterprise/cmd/worker/internal/codeintel/indexing/dependency_sync_scheduler_test.go
+++ b/enterprise/cmd/worker/internal/codeintel/indexing/dependency_sync_scheduler_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/dependencies"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
+	"github.com/sourcegraph/sourcegraph/lib/codeintel/precise"
 )
 
 func TestDependencySyncSchedulerJVM(t *testing.T) {
@@ -105,5 +106,75 @@ func TestDependencySyncSchedulerGomod(t *testing.T) {
 
 	if len(mockDBStore.InsertCloneableDependencyRepoFunc.History()) != 0 {
 		t.Errorf("unexpected number of calls to InsertCloneableDependencyRepo. want=%d have=%d", 0, len(mockDBStore.InsertCloneableDependencyRepoFunc.History()))
+	}
+}
+
+func TestNewPackage(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		in   shared.Package
+		out  precise.Package
+	}{
+		{
+			name: "jvm name normalization",
+			in: shared.Package{
+				Scheme:  dependencies.JVMPackagesScheme,
+				Name:    "maven/junit/junit",
+				Version: "4.2",
+			},
+			out: precise.Package{
+				Scheme:  dependencies.JVMPackagesScheme,
+				Name:    "junit:junit",
+				Version: "4.2",
+			},
+		},
+		{
+			name: "jvm name normalization no-op",
+			in: shared.Package{
+				Scheme:  dependencies.JVMPackagesScheme,
+				Name:    "junit:junit",
+				Version: "4.2",
+			},
+			out: precise.Package{
+				Scheme:  dependencies.JVMPackagesScheme,
+				Name:    "junit:junit",
+				Version: "4.2",
+			},
+		},
+		{
+			name: "npm no-op",
+			in: shared.Package{
+				Scheme:  dependencies.NpmPackagesScheme,
+				Name:    "@graphql-mesh/graphql",
+				Version: "0.24.0",
+			},
+			out: precise.Package{
+				Scheme:  dependencies.NpmPackagesScheme,
+				Name:    "@graphql-mesh/graphql",
+				Version: "0.24.0",
+			},
+		},
+		{
+			name: "go no-op",
+			in: shared.Package{
+				Scheme:  dependencies.GoModulesScheme,
+				Name:    "github.com/tsenart/vegeta/v12",
+				Version: "12.7.0",
+			},
+			out: precise.Package{
+				Scheme:  dependencies.GoModulesScheme,
+				Name:    "github.com/tsenart/vegeta/v12",
+				Version: "12.7.0",
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			have := newPackage(tc.in)
+			want := tc.out
+
+			if diff := cmp.Diff(want, have); diff != "" {
+				t.Fatalf("mismatch (-want, +have): %s", diff)
+			}
+		})
 	}
 }

--- a/migrations/frontend/1651159431/down.sql
+++ b/migrations/frontend/1651159431/down.sql
@@ -1,0 +1,1 @@
+-- Undo the changes made in the up migration

--- a/migrations/frontend/1651159431/metadata.yaml
+++ b/migrations/frontend/1651159431/metadata.yaml
@@ -1,0 +1,2 @@
+name: fix-maven-dependency-repos-name
+parents: [1651077257]

--- a/migrations/frontend/1651159431/up.sql
+++ b/migrations/frontend/1651159431/up.sql
@@ -1,0 +1,8 @@
+UPDATE lsif_dependency_repos
+SET name = replace(regexp_replace(name, '^maven/', ''), '/', ':')
+WHERE scheme = 'semanticdb'
+AND name LIKE 'maven/%';
+
+DELETE FROM lsif_dependency_repos
+WHERE scheme = 'semanticdb'
+AND (name LIKE '%:%:%' OR name LIKE 'jdk:%' OR name LIKE 'jdk/%');


### PR DESCRIPTION
This commit introduces a normalization step in `dependencySyncSchedulerHandler` for making packages data (scheme, name, version) from LSIF uploads be consistent with internal structure / format.

This is needed most immediatelly for JVM dependency repos to work again after https://github.com/sourcegraph/sourcegraph/pull/34289, which assumed all name columns in the lsif_dependency_repos table matched the `reposource.PackageDependency.PackageSyntax` method.

We also add a SQL migration to migrate existing rows to the new format. lsif-java will be updated in the future.

## Test plan

Unit and manual tests.