### PR TITLE
gitserver: Best effort latest branch deletion in vcsDependenciesSyncer

### DIFF
--- a/cmd/gitserver/server/vcs_dependencies_syncer.go
+++ b/cmd/gitserver/server/vcs_dependencies_syncer.go
@@ -180,9 +180,8 @@ func (s *vcsDependenciesSyncer) Fetch(ctx context.Context, remoteURL *vcs.URL, d
 
 	if len(cloneable) == 0 {
 		cmd := exec.CommandContext(ctx, "git", "branch", "--force", "-D", "latest")
-		if _, err := runCommandInDirectory(ctx, cmd, string(dir), s.placeholder); err != nil {
-			return err
-		}
+		// Best-effort branch deletion since we don't know if this branch has been created yet.
+		_, _ = runCommandInDirectory(ctx, cmd, string(dir), s.placeholder)
 	}
 
 	return nil

--- a/cmd/gitserver/server/vcs_dependencies_syncer_test.go
+++ b/cmd/gitserver/server/vcs_dependencies_syncer_test.go
@@ -40,14 +40,14 @@ func TestVcsDependenciesSyncer_Fetch(t *testing.T) {
 		svc:         depsService,
 	}
 
-	depsService.Add("foo@0.0.1")
-	depsSource.Add("foo@0.0.1")
-
 	remoteURL := &vcs.URL{URL: url.URL{Path: "fake/foo"}}
 
 	dir := GitDir(t.TempDir())
 	_, err := s.CloneCommand(ctx, remoteURL, string(dir))
 	require.NoError(t, err)
+
+	depsService.Add("foo@0.0.1")
+	depsSource.Add("foo@0.0.1")
 
 	t.Run("one version from service", func(t *testing.T) {
 		err := s.Fetch(ctx, remoteURL, dir)
@@ -136,11 +136,7 @@ type fakeDepsService struct {
 }
 
 func (s *fakeDepsService) ListDependencyRepos(ctx context.Context, opts dependencies.ListDependencyReposOpts) ([]dependencies.Repo, error) {
-	dep, ok := s.deps[opts.Name]
-	if !ok {
-		return nil, notFoundError{errors.Errorf("%s not found", opts.Name)}
-	}
-	return dep, nil
+	return s.deps[opts.Name], nil
 }
 
 func (s *fakeDepsService) Add(deps ...string) {


### PR DESCRIPTION
This commit makes us not hard fail a Fetch from `vcsDependenciesSyncer`
when trying to delete the latest branch, which happens when there are no
valid versions for the given dependency.



## Test plan

Integration test.


