### PR TITLE
symbols: fix fetchRepositoryArchive log field

### DIFF
--- a/cmd/symbols/fetcher/repository_fetcher.go
+++ b/cmd/symbols/fetcher/repository_fetcher.go
@@ -4,7 +4,6 @@ import (
 	"archive/tar"
 	"context"
 	"io"
-	"strings"
 
 	"github.com/opentracing/opentracing-go/log"
 
@@ -63,7 +62,6 @@ func (f *repositoryFetcher) fetchRepositoryArchive(ctx context.Context, args typ
 		log.String("repo", string(args.Repo)),
 		log.String("commitID", string(args.CommitID)),
 		log.Int("paths", len(paths)),
-		log.String("paths", strings.Join(paths, ":")),
 	}})
 	defer endObservation(1, observation.Args{})
 


### PR DESCRIPTION
Removes the concatenated paths being logged in fetchRepositoryArchive, which is both a duplicate key and huge (breaking log parsing in Datadog)

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

n/a