### PR TITLE
Add Sourcegraph to VS Code recommended extensions

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,6 +2,7 @@
   // See http://go.microsoft.com/fwlink/?LinkId=827846
   // for the documentation about the extensions.json format
   "recommendations": [
+    "sourcegraph.sourcegraph",
     "EditorConfig.editorconfig",
     "esbenp.prettier-vscode",
     "graphql.vscode-graphql",


### PR DESCRIPTION
To help encourage more use of our own products, we can add the Sourcegraph VS Code extension to the list of recommended extensions!

## Test plan

<img width="304" alt="image" src="https://user-images.githubusercontent.com/10523985/165836961-e6167ba8-e8e1-4bc8-804c-8ed074db82f4.png">


