### PR TITLE
codeintel: state-change reason for lsif uploads audit logs

### DIFF
--- a/enterprise/internal/codeintel/stores/dbstore/commits.go
+++ b/enterprise/internal/codeintel/stores/dbstore/commits.go
@@ -418,6 +418,8 @@ func (s *Store) calculateVisibleUploadsInternal(
 	// All completed uploads are now visible. Mark any uploads queued for deletion as deleted as
 	// they are no longer reachable from the commit graph and cannot be used to fulfill any API
 	// requests.
+	unset, _ := tx.Store.SetLocal(ctx, "codeintel.lsif_uploads_audit.reason", "upload not reachable within the commit graph")
+	defer unset(ctx)
 	if err := tx.Store.Exec(ctx, sqlf.Sprintf(calculateVisibleUploadsDeleteUploadsQueuedForDeletionQuery, repositoryID)); err != nil {
 		return err
 	}

--- a/enterprise/internal/codeintel/stores/dbstore/dumps.go
+++ b/enterprise/internal/codeintel/stores/dbstore/dumps.go
@@ -380,6 +380,8 @@ func (s *Store) DeleteOverlappingDumps(ctx context.Context, repositoryID int, co
 	}})
 	defer endObservation(1, observation.Args{})
 
+	unset, _ := s.Store.SetLocal(ctx, "codeintel.lsif_uploads_audit.reason", "upload overlapping with a newer upload")
+	defer unset(ctx)
 	count, _, err := basestore.ScanFirstInt(s.Store.Query(ctx, sqlf.Sprintf(deleteOverlappingDumpsQuery, repositoryID, commit, root, indexer)))
 	if err != nil {
 		return err

--- a/enterprise/internal/codeintel/stores/dbstore/dumps_test.go
+++ b/enterprise/internal/codeintel/stores/dbstore/dumps_test.go
@@ -425,16 +425,28 @@ func TestFindClosestDumpsIndexerName(t *testing.T) {
 			{UploadID: 5, Distance: 0},
 		},
 		makeCommit(2): {
-			{UploadID: 1, Distance: 1}, {UploadID: 2, Distance: 0},
-			{UploadID: 5, Distance: 1}, {UploadID: 6, Distance: 0},
+			{UploadID: 1, Distance: 1},
+			{UploadID: 2, Distance: 0},
+			{UploadID: 5, Distance: 1},
+			{UploadID: 6, Distance: 0},
 		},
 		makeCommit(3): {
-			{UploadID: 1, Distance: 2}, {UploadID: 2, Distance: 1}, {UploadID: 3, Distance: 0},
-			{UploadID: 5, Distance: 2}, {UploadID: 6, Distance: 1}, {UploadID: 7, Distance: 0},
+			{UploadID: 1, Distance: 2},
+			{UploadID: 2, Distance: 1},
+			{UploadID: 3, Distance: 0},
+			{UploadID: 5, Distance: 2},
+			{UploadID: 6, Distance: 1},
+			{UploadID: 7, Distance: 0},
 		},
 		makeCommit(4): {
-			{UploadID: 1, Distance: 3}, {UploadID: 2, Distance: 2}, {UploadID: 3, Distance: 1}, {UploadID: 4, Distance: 0},
-			{UploadID: 5, Distance: 3}, {UploadID: 6, Distance: 2}, {UploadID: 7, Distance: 1}, {UploadID: 8, Distance: 0},
+			{UploadID: 1, Distance: 3},
+			{UploadID: 2, Distance: 2},
+			{UploadID: 3, Distance: 1},
+			{UploadID: 4, Distance: 0},
+			{UploadID: 5, Distance: 3},
+			{UploadID: 6, Distance: 2},
+			{UploadID: 7, Distance: 1},
+			{UploadID: 8, Distance: 0},
 		},
 	}
 	if diff := cmp.Diff(expectedVisibleUploads, normalizeVisibleUploads(visibleUploads)); diff != "" {
@@ -662,7 +674,6 @@ func testAllOf(t *testing.T, dumps []Dump, expectedIDs []int) {
 			return
 		}
 	}
-
 }
 
 func testPresence(needle int, haystack []int) bool {

--- a/enterprise/internal/codeintel/stores/dbstore/janitor.go
+++ b/enterprise/internal/codeintel/stores/dbstore/janitor.go
@@ -216,6 +216,8 @@ func (s *Store) DeleteSourcedCommits(ctx context.Context, repositoryID int, comm
 	now = now.UTC()
 	interval := int(maximumCommitLag / time.Second)
 
+	unset, _ := s.Store.SetLocal(ctx, "codeintel.lsif_uploads_audit.reason", "upload associated with unknown commit")
+	defer unset(ctx)
 	uploadsUpdated, uploadsDeleted, indexesDeleted, err = scanTripleOfCounts(s.Query(ctx, sqlf.Sprintf(
 		deleteSourcedCommitsQuery,
 		repositoryID, commit, // candidate_uploads

--- a/enterprise/internal/codeintel/stores/dbstore/uploads.go
+++ b/enterprise/internal/codeintel/stores/dbstore/uploads.go
@@ -255,6 +255,8 @@ func (s *Store) DeleteUploadsStuckUploading(ctx context.Context, uploadedBefore 
 	}})
 	defer endObservation(1, observation.Args{})
 
+	unset, _ := s.Store.SetLocal(ctx, "codeintel.lsif_uploads_audit.reason", "stuck in uploading state")
+	defer unset(ctx)
 	count, _, err := basestore.ScanFirstInt(s.Store.Query(ctx, sqlf.Sprintf(deleteUploadsStuckUploadingQuery, uploadedBefore)))
 	if err != nil {
 		return 0, err
@@ -765,6 +767,8 @@ func (s *Store) DeleteUploadsWithoutRepository(ctx context.Context, now time.Tim
 	ctx, trace, endObservation := s.operations.deleteUploadsWithoutRepository.WithAndLogger(ctx, &err, observation.Args{})
 	defer endObservation(1, observation.Args{})
 
+	unset, _ := s.Store.SetLocal(ctx, "codeintel.lsif_uploads_audit.reason", "upload associated with repository not known to this instance")
+	defer unset(ctx)
 	repositories, err := scanCounts(s.Store.Query(ctx, sqlf.Sprintf(deleteUploadsWithoutRepositoryQuery, now.UTC(), DeletedRepositoryGracePeriod/time.Second)))
 	if err != nil {
 		return nil, err
@@ -1299,6 +1303,8 @@ func (s *Store) SoftDeleteExpiredUploads(ctx context.Context) (count int, err er
 		return 0, nil
 	}
 
+	unset, _ := s.Store.SetLocal(ctx, "codeintel.lsif_uploads_audit.reason", "soft-deleting expired uploads")
+	defer unset(ctx)
 	repositories, err := scanCounts(tx.Store.Query(ctx, sqlf.Sprintf(softDeleteExpiredUploadsQuery)))
 	if err != nil {
 		return 0, err

--- a/internal/database/basestore/errors.go
+++ b/internal/database/basestore/errors.go
@@ -5,3 +5,7 @@ import "github.com/sourcegraph/sourcegraph/lib/errors"
 // ErrNotTransactable occurs when Transact is called on a Store instance whose underlying
 // database handle does not support beginning a transaction.
 var ErrNotTransactable = errors.New("store: not transactable")
+
+// ErrNotInTransaction occurs when an operation can only be run in a transaction
+// but the invariant wasn't in place.
+var ErrNotInTransaction = errors.New("store: not in a transaction")

--- a/internal/database/basestore/store.go
+++ b/internal/database/basestore/store.go
@@ -113,11 +113,11 @@ func (s *Store) ExecResult(ctx context.Context, query *sqlf.Query) (sql.Result, 
 
 // SetLocal performs the `SET LOCAL` query and returns a function to clear (aka to empty string) the setting.
 // Calling this method only makes sense within a transaction, as the setting is unset after the transaction
-// is either rolled back or committed.
+// is either rolled back or committed. This does not perform argument parameterization.
 func (s *Store) SetLocal(ctx context.Context, key, value string) (func(context.Context) error, error) {
 	return func(ctx context.Context) error {
-		return s.Exec(ctx, sqlf.Sprintf(`SET LOCAL %s TO ''`, key))
-	}, s.Exec(ctx, sqlf.Sprintf(`SET LOCAL %s TO %s`, key, value))
+		return s.Exec(ctx, sqlf.Sprintf(fmt.Sprintf(`SET LOCAL "%s" TO ''`, key)))
+	}, s.Exec(ctx, sqlf.Sprintf(fmt.Sprintf(`SET LOCAL "%s" TO "%s"`, key, value)))
 }
 
 // InTransaction returns true if the underlying database handle is in a transaction.

--- a/internal/database/basestore/store.go
+++ b/internal/database/basestore/store.go
@@ -116,7 +116,7 @@ func (s *Store) ExecResult(ctx context.Context, query *sqlf.Query) (sql.Result, 
 // is either rolled back or committed. This does not perform argument parameterization.
 func (s *Store) SetLocal(ctx context.Context, key, value string) (func(context.Context) error, error) {
 	if !s.InTransaction() {
-		return nil, ErrNotInTransaction
+		return func(ctx context.Context) error { return nil }, ErrNotInTransaction
 	}
 
 	return func(ctx context.Context) error {

--- a/internal/database/basestore/store.go
+++ b/internal/database/basestore/store.go
@@ -111,6 +111,15 @@ func (s *Store) ExecResult(ctx context.Context, query *sqlf.Query) (sql.Result, 
 	return res, s.wrapError(query, err)
 }
 
+// SetLocal performs the `SET LOCAL` query and returns a function to clear (aka to empty string) the setting.
+// Calling this method only makes sense within a transaction, as the setting is unset after the transaction
+// is either rolled back or committed.
+func (s *Store) SetLocal(ctx context.Context, key, value string) (func(context.Context) error, error) {
+	return func(ctx context.Context) error {
+		return s.Exec(ctx, sqlf.Sprintf(`SET LOCAL %s TO ''`, key))
+	}, s.Exec(ctx, sqlf.Sprintf(`SET LOCAL %s TO %s`, key, value))
+}
+
 // InTransaction returns true if the underlying database handle is in a transaction.
 func (s *Store) InTransaction() bool {
 	return s.handle.InTransaction()

--- a/internal/database/basestore/store.go
+++ b/internal/database/basestore/store.go
@@ -115,6 +115,10 @@ func (s *Store) ExecResult(ctx context.Context, query *sqlf.Query) (sql.Result, 
 // Calling this method only makes sense within a transaction, as the setting is unset after the transaction
 // is either rolled back or committed. This does not perform argument parameterization.
 func (s *Store) SetLocal(ctx context.Context, key, value string) (func(context.Context) error, error) {
+	if !s.InTransaction() {
+		return nil, ErrNotInTransaction
+	}
+
 	return func(ctx context.Context) error {
 		return s.Exec(ctx, sqlf.Sprintf(fmt.Sprintf(`SET LOCAL "%s" TO ''`, key)))
 	}, s.Exec(ctx, sqlf.Sprintf(fmt.Sprintf(`SET LOCAL "%s" TO "%s"`, key, value)))

--- a/internal/database/basestore/store_test.go
+++ b/internal/database/basestore/store_test.go
@@ -101,11 +101,13 @@ func TestSetLocal(t *testing.T) {
 	}
 
 	store, _ = store.Transact(context.Background())
+	defer store.Done(err)
 	func() {
 		unset, err := store.SetLocal(context.Background(), "sourcegraph.banana", "phone")
 		if err != nil {
 			t.Fatalf("unexpected error: %s", err)
 		}
+		defer unset(context.Background())
 
 		str, _, err := ScanFirstString(store.Query(context.Background(), sqlf.Sprintf("SELECT current_setting('sourcegraph.banana')")))
 		if err != nil {
@@ -115,11 +117,9 @@ func TestSetLocal(t *testing.T) {
 		if str != "phone" {
 			t.Fatalf("unexpected value. want=%q got=%q", "phone", str)
 		}
-
-		defer unset(context.Background())
 	}()
 
-	str, _, err := ScanFirstString(store.Query(context.Background(), sqlf.Sprintf("SELECT current_setting('sourcegraph.banana')")))
+	str, _, err := ScanFirstString(store.Query(context.Background(), sqlf.Sprintf("SELECT current_setting('sourcegraph.banana', true)")))
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}

--- a/internal/database/basestore/store_test.go
+++ b/internal/database/basestore/store_test.go
@@ -87,6 +87,48 @@ func TestSavepoints(t *testing.T) {
 	}
 }
 
+func TestSetLocal(t *testing.T) {
+	db := dbtest.NewDB(t)
+	setupStoreTest(t, db)
+	store := testStore(db)
+
+	_, err := store.SetLocal(context.Background(), "sourcegraph.banana", "phone")
+	if err == nil {
+		t.Fatalf("unexpected nil error")
+	}
+	if !errors.Is(err, ErrNotInTransaction) {
+		t.Fatalf("unexpected error. want=%q have=%q", ErrNotInTransaction, err)
+	}
+
+	store, _ = store.Transact(context.Background())
+	func() {
+		unset, err := store.SetLocal(context.Background(), "sourcegraph.banana", "phone")
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+
+		str, _, err := ScanFirstString(store.Query(context.Background(), sqlf.Sprintf("SELECT current_setting('sourcegraph.banana')")))
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+
+		if str != "phone" {
+			t.Fatalf("unexpected value. want=%q got=%q", "phone", str)
+		}
+
+		defer unset(context.Background())
+	}()
+
+	str, _, err := ScanFirstString(store.Query(context.Background(), sqlf.Sprintf("SELECT current_setting('sourcegraph.banana')")))
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	if str != "" {
+		t.Fatalf("unexpected value. want=%q got=%q", "", str)
+	}
+}
+
 func recurSavepoints(t *testing.T, store *Store, index, rollbackAt int) {
 	if index == 0 {
 		return

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -1606,8 +1606,8 @@ Stores metadata about an LSIF index uploaded by a user.
 
 # Table "public.lsif_uploads_audit_logs"
 ```
-       Column        |           Type           | Collation | Nullable | Default 
----------------------+--------------------------+-----------+----------+---------
+       Column        |           Type           | Collation | Nullable | Default  
+---------------------+--------------------------+-----------+----------+----------
  log_timestamp       | timestamp with time zone |           |          | now()
  record_deleted_at   | timestamp with time zone |           |          | 
  upload_id           | integer                  |           | not null | 
@@ -1619,8 +1619,8 @@ Stores metadata about an LSIF index uploaded by a user.
  indexer_version     | text                     |           |          | 
  upload_size         | integer                  |           |          | 
  associated_index_id | integer                  |           |          | 
- committed_at        | timestamp with time zone |           |          | 
  transition_columns  | USER-DEFINED[]           |           |          | 
+ reason              | text                     |           |          | ''::text
 Indexes:
     "lsif_uploads_audit_logs_timestamp" brin (log_timestamp)
     "lsif_uploads_audit_logs_upload_id" btree (upload_id)
@@ -1628,6 +1628,8 @@ Indexes:
 ```
 
 **log_timestamp**: Timestamp for this log entry.
+
+**reason**: The reason/source for this entry.
 
 **record_deleted_at**: Set once the upload this entry is associated with is deleted. Once NOW() - record_deleted_at is above a certain threshold, this log entry will be deleted.
 

--- a/migrations/frontend/1651061363/down.sql
+++ b/migrations/frontend/1651061363/down.sql
@@ -1,0 +1,59 @@
+ALTER TABLE
+    IF EXISTS lsif_uploads_audit_logs
+    DROP COLUMN IF EXISTS reason,
+    ADD COLUMN IF NOT EXISTS committed_at timestamptz;
+
+-- Revert functions to previous version
+
+CREATE OR REPLACE FUNCTION func_lsif_uploads_update() RETURNS TRIGGER AS $$
+    BEGIN
+        INSERT INTO lsif_uploads_audit_logs
+        (upload_id, commit, root, repository_id, uploaded_at,
+        indexer, indexer_version, upload_size, associated_index_id,
+        committed_at, transition_columns)
+        VALUES (
+            NEW.id, NEW.commit, NEW.root, NEW.repository_id, NEW.uploaded_at,
+            NEW.indexer, NEW.indexer_version, NEW.upload_size, NEW.associated_index_id,
+            NEW.committed_at, func_lsif_uploads_transition_columns_diff(
+                func_row_to_lsif_uploads_transition_columns(OLD),
+                func_row_to_lsif_uploads_transition_columns(NEW)
+            )
+        );
+
+        RETURN NEW;
+    END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION func_lsif_uploads_insert() RETURNS TRIGGER AS $$
+    BEGIN
+        INSERT INTO lsif_uploads_audit_logs
+        (upload_id, commit, root, repository_id, uploaded_at,
+        indexer, indexer_version, upload_size, associated_index_id,
+        committed_at, transition_columns)
+        VALUES (
+            NEW.id, NEW.commit, NEW.root, NEW.repository_id, NEW.uploaded_at,
+            NEW.indexer, NEW.indexer_version, NEW.upload_size, NEW.associated_index_id,
+            NEW.committed_at, func_lsif_uploads_transition_columns_diff(
+                (NULL, NULL, NULL, NULL, NULL, NULL),
+                func_row_to_lsif_uploads_transition_columns(NEW)
+            )
+        );
+        RETURN NULL;
+    END;
+$$ LANGUAGE plpgsql;
+
+-- CREATE OR REPLACE only supported in Postgres 14+
+DROP TRIGGER IF EXISTS trigger_lsif_uploads_update ON lsif_uploads;
+DROP TRIGGER IF EXISTS trigger_lsif_uploads_insert ON lsif_uploads;
+
+CREATE TRIGGER trigger_lsif_uploads_update
+BEFORE UPDATE OF state, num_resets, num_failures, worker_hostname, expired, committed_at
+ON lsif_uploads
+FOR EACH ROW
+EXECUTE FUNCTION func_lsif_uploads_update();
+
+CREATE TRIGGER trigger_lsif_uploads_insert
+AFTER INSERT
+ON lsif_uploads
+FOR EACH ROW
+EXECUTE FUNCTION func_lsif_uploads_insert();

--- a/migrations/frontend/1651061363/metadata.yaml
+++ b/migrations/frontend/1651061363/metadata.yaml
@@ -1,0 +1,2 @@
+name: lsif_uploads_audit_logging_reason
+parents: [1650637472]

--- a/migrations/frontend/1651061363/up.sql
+++ b/migrations/frontend/1651061363/up.sql
@@ -1,0 +1,66 @@
+ALTER TABLE lsif_uploads_audit_logs
+ADD COLUMN IF NOT EXISTS reason text DEFAULT '',
+DROP COLUMN IF EXISTS committed_at;
+
+COMMENT ON COLUMN lsif_uploads_audit_logs.reason IS 'The reason/source for this entry.';
+
+CREATE OR REPLACE FUNCTION func_lsif_uploads_update() RETURNS TRIGGER AS $$
+    DECLARE
+        diff hstore[];
+    BEGIN
+        diff = func_lsif_uploads_transition_columns_diff(
+            func_row_to_lsif_uploads_transition_columns(OLD),
+            func_row_to_lsif_uploads_transition_columns(NEW)
+        );
+
+        IF (array_length(diff, 1) > 0) THEN
+            INSERT INTO lsif_uploads_audit_logs
+            (reason, upload_id, commit, root, repository_id, uploaded_at,
+            indexer, indexer_version, upload_size, associated_index_id,
+            transition_columns)
+            VALUES (
+                COALESCE(current_setting('codeintel.lsif_uploads_audit.reason', true), ''),
+                NEW.id, NEW.commit, NEW.root, NEW.repository_id, NEW.uploaded_at,
+                NEW.indexer, NEW.indexer_version, NEW.upload_size, NEW.associated_index_id,
+                diff
+            );
+        END IF;
+
+        RETURN NEW;
+    END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION func_lsif_uploads_insert() RETURNS TRIGGER AS $$
+    BEGIN
+        INSERT INTO lsif_uploads_audit_logs
+        (upload_id, commit, root, repository_id, uploaded_at,
+        indexer, indexer_version, upload_size, associated_index_id,
+        transition_columns)
+        VALUES (
+            NEW.id, NEW.commit, NEW.root, NEW.repository_id, NEW.uploaded_at,
+            NEW.indexer, NEW.indexer_version, NEW.upload_size, NEW.associated_index_id,
+            func_lsif_uploads_transition_columns_diff(
+                (NULL, NULL, NULL, NULL, NULL, NULL),
+                func_row_to_lsif_uploads_transition_columns(NEW)
+            )
+        );
+        RETURN NULL;
+    END;
+$$ LANGUAGE plpgsql;
+
+
+-- CREATE OR REPLACE only supported in Postgres 14+
+DROP TRIGGER IF EXISTS trigger_lsif_uploads_update ON lsif_uploads;
+DROP TRIGGER IF EXISTS trigger_lsif_uploads_insert ON lsif_uploads;
+
+CREATE TRIGGER trigger_lsif_uploads_update
+BEFORE UPDATE OF state, num_resets, num_failures, worker_hostname, expired, committed_at
+ON lsif_uploads
+FOR EACH ROW
+EXECUTE FUNCTION func_lsif_uploads_update();
+
+CREATE TRIGGER trigger_lsif_uploads_insert
+AFTER INSERT
+ON lsif_uploads
+FOR EACH ROW
+EXECUTE FUNCTION func_lsif_uploads_insert();


### PR DESCRIPTION
```
> select record_deleted_at, upload_id as id, transition_columns, reason from lsif_uploads_audit_logs order by log_timestamp desc;
       record_deleted_at       | id |                                                                                                                                                   transition_columns                                                                                                                                                    |       reason       
-------------------------------+----+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+--------------------
 2022-04-28 17:44:55.360428+00 | 26 | {"\"new\"=>\"deleted\", \"old\"=>\"deleting\", \"column\"=>\"state\""}                                                                                                                                                                                                                                                  | non-visible upload
 NULL                          | 27 | {"\"new\"=>\"completed\", \"old\"=>\"processing\", \"column\"=>\"state\""}                                                                                                                                                                                                                                              | 
 2022-04-28 17:44:55.360428+00 | 26 | {"\"new\"=>\"deleting\", \"old\"=>\"completed\", \"column\"=>\"state\""}                                                                                                                                                                                                                                                | overlapping upload
 NULL                          | 27 | {"\"new\"=>\"2022-01-10 17:07:41+00\", \"old\"=>NULL, \"column\"=>\"committed_at\""}                                                                                                                                                                                                                                    | 
 NULL                          | 27 | {"\"new\"=>\"processing\", \"old\"=>\"queued\", \"column\"=>\"state\"","\"new\"=>\"archlinux\", \"old\"=>\"\", \"column\"=>\"worker_hostname\""}                                                                                                                                                                        | 
 NULL                          | 27 | {"\"new\"=>\"uploading\", \"old\"=>NULL, \"column\"=>\"state\"","\"new\"=>\"false\", \"old\"=>NULL, \"column\"=>\"expired\"","\"new\"=>\"0\", \"old\"=>NULL, \"column\"=>\"num_resets\"","\"new\"=>\"0\", \"old\"=>NULL, \"column\"=>\"num_failures\"","\"new\"=>\"\", \"old\"=>NULL, \"column\"=>\"worker_hostname\""} | 
 NULL                          | 27 | {"\"new\"=>\"queued\", \"old\"=>\"uploading\", \"column\"=>\"state\""}                                                                                                                                                                                                                                                  | 
 2022-04-28 17:44:55.360428+00 | 26 | {"\"new\"=>\"completed\", \"old\"=>\"processing\", \"column\"=>\"state\""}                                                                                                                                                                                                                                              | 
 2022-04-28 17:44:55.360428+00 | 26 | {"\"new\"=>\"2022-01-10 17:07:41+00\", \"old\"=>NULL, \"column\"=>\"committed_at\""}                                                                                                                                                                                                                                    | 
 2022-04-28 17:44:55.360428+00 | 26 | {"\"new\"=>\"processing\", \"old\"=>\"queued\", \"column\"=>\"state\"","\"new\"=>\"archlinux\", \"old\"=>\"\", \"column\"=>\"worker_hostname\""}                                                                                                                                                                        | 
 2022-04-28 17:44:55.360428+00 | 26 | {"\"new\"=>\"queued\", \"old\"=>\"uploading\", \"column\"=>\"state\""}                                                                                                                                                                                                                                                  | 
 2022-04-28 17:44:55.360428+00 | 26 | {"\"new\"=>\"uploading\", \"old\"=>NULL, \"column\"=>\"state\"","\"new\"=>\"false\", \"old\"=>NULL, \"column\"=>\"expired\"","\"new\"=>\"0\", \"old\"=>NULL, \"column\"=>\"num_resets\"","\"new\"=>\"0\", \"old\"=>NULL, \"column\"=>\"num_failures\"","\"new\"=>\"\", \"old\"=>NULL, \"column\"=>\"worker_hostname\""} | 
```

## Test plan

yes, I did :slightly_smiling_face: 


