### PR TITLE
search: move protocol type def to search/types.go

### DIFF
--- a/internal/search/query_converter.go
+++ b/internal/search/query_converter.go
@@ -56,10 +56,3 @@ func LangToFileRegexp(lang string) string {
 	}
 	return UnionRegExps(patterns)
 }
-
-type Protocol int
-
-const (
-	Streaming Protocol = iota
-	Batch
-)

--- a/internal/search/types.go
+++ b/internal/search/types.go
@@ -12,6 +12,13 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
+type Protocol int
+
+const (
+	Streaming Protocol = iota
+	Batch
+)
+
 type SymbolsParameters struct {
 	// Repo is the name of the repository to search in.
 	Repo api.RepoName `json:"repo"`


### PR DESCRIPTION
Trimming down `query_conveter.go`. Thought about this belonging in `search/client` but it's cyclical and probably this works to just keep in `search/types`.

## Test plan
Semantics-preserving

