### PR TITLE
search: rename query_converter.go to query/helpers.go

### DIFF
--- a/internal/search/commit/commit.go
+++ b/internal/search/commit/commit.go
@@ -313,7 +313,7 @@ func queryParameterToPredicate(parameter query.Parameter, caseSensitive, diff bo
 	case query.FieldFile:
 		newPred = &gitprotocol.DiffModifiesFile{Expr: parameter.Value, IgnoreCase: !caseSensitive}
 	case query.FieldLang:
-		newPred = &gitprotocol.DiffModifiesFile{Expr: search.LangToFileRegexp(parameter.Value), IgnoreCase: true}
+		newPred = &gitprotocol.DiffModifiesFile{Expr: query.LangToFileRegexp(parameter.Value), IgnoreCase: true}
 	}
 
 	if parameter.Negated && newPred != nil {

--- a/internal/search/job/jobutil/job.go
+++ b/internal/search/job/jobutil/job.go
@@ -351,8 +351,8 @@ func toTextPatternInfo(q query.Basic, resultTypes result.Types, p search.Protoco
 	filesInclude, filesExclude := q.IncludeExcludeValues(query.FieldFile)
 	// Handle lang: and -lang: filters.
 	langInclude, langExclude := q.IncludeExcludeValues(query.FieldLang)
-	filesInclude = append(filesInclude, mapSlice(langInclude, search.LangToFileRegexp)...)
-	filesExclude = append(filesExclude, mapSlice(langExclude, search.LangToFileRegexp)...)
+	filesInclude = append(filesInclude, mapSlice(langInclude, query.LangToFileRegexp)...)
+	filesExclude = append(filesExclude, mapSlice(langExclude, query.LangToFileRegexp)...)
 	filesReposMustInclude, filesReposMustExclude := q.IncludeExcludeValues(query.FieldRepoHasFile)
 	selector, _ := filter.SelectPathFromString(q.FindValue(query.FieldSelect)) // Invariant: select is validated
 	count := count(q, p)
@@ -384,7 +384,7 @@ func toTextPatternInfo(q query.Basic, resultTypes result.Types, p search.Protoco
 
 		// Values dependent on parameters.
 		IncludePatterns:              filesInclude,
-		ExcludePattern:               search.UnionRegExps(filesExclude),
+		ExcludePattern:               query.UnionRegExps(filesExclude),
 		FilePatternsReposMustInclude: filesReposMustInclude,
 		FilePatternsReposMustExclude: filesReposMustExclude,
 		PatternMatchesPath:           resultTypes.Has(result.TypePath),

--- a/internal/search/query/helpers.go
+++ b/internal/search/query/helpers.go
@@ -1,4 +1,4 @@
-package search
+package query
 
 import (
 	"strings"

--- a/internal/search/repos/repos.go
+++ b/internal/search/repos/repos.go
@@ -145,7 +145,7 @@ func (r *Resolver) Resolve(ctx context.Context, op search.RepoOptions) (Resolved
 	options := database.ReposListOptions{
 		IncludePatterns:       includePatterns,
 		Names:                 depNames,
-		ExcludePattern:        search.UnionRegExps(excludePatterns),
+		ExcludePattern:        query.UnionRegExps(excludePatterns),
 		CaseSensitivePatterns: op.CaseSensitiveRepoFilters,
 		Cursors:               op.Cursors,
 		// List N+1 repos so we can see if there are repos omitted due to our repo limit.
@@ -427,7 +427,7 @@ func computeExcludedRepos(ctx context.Context, db database.DB, op search.RepoOpt
 
 	options := database.ReposListOptions{
 		IncludePatterns: includePatterns,
-		ExcludePattern:  search.UnionRegExps(excludePatterns),
+		ExcludePattern:  query.UnionRegExps(excludePatterns),
 		// List N+1 repos so we can see if there are repos omitted due to our repo limit.
 		LimitOffset:            &database.LimitOffset{Limit: limit + 1},
 		NoForks:                op.NoForks,
@@ -761,7 +761,7 @@ func PrivateReposForActor(ctx context.Context, db database.DB, repoOptions searc
 		NoForks:        repoOptions.NoForks,
 		OnlyArchived:   repoOptions.OnlyArchived,
 		NoArchived:     repoOptions.NoArchived,
-		ExcludePattern: search.UnionRegExps(repoOptions.MinusRepoFilters),
+		ExcludePattern: query.UnionRegExps(repoOptions.MinusRepoFilters),
 	})
 
 	if err != nil {

--- a/internal/search/searchcontexts/search_contexts.go
+++ b/internal/search/searchcontexts/search_contexts.go
@@ -506,7 +506,7 @@ func ParseRepoOpts(contextQuery string) ([]RepoOpts, error) {
 		rq := RepoOpts{
 			ReposListOptions: database.ReposListOptions{
 				CaseSensitivePatterns: q.IsCaseSensitive(),
-				ExcludePattern:        search.UnionRegExps(minusRepoFilters),
+				ExcludePattern:        query.UnionRegExps(minusRepoFilters),
 				OnlyForks:             fork == query.Only,
 				NoForks:               fork == query.No,
 				OnlyArchived:          archived == query.Only,

--- a/internal/search/zoekt/query.go
+++ b/internal/search/zoekt/query.go
@@ -31,8 +31,8 @@ func QueryToZoektQuery(b query.Basic, resultTypes result.Types, feat *search.Fea
 	filesInclude, filesExclude := b.IncludeExcludeValues(query.FieldFile)
 	// Handle lang: and -lang: filters.
 	langInclude, langExclude := b.IncludeExcludeValues(query.FieldLang)
-	filesInclude = append(filesInclude, mapSlice(langInclude, search.LangToFileRegexp)...)
-	filesExclude = append(filesExclude, mapSlice(langExclude, search.LangToFileRegexp)...)
+	filesInclude = append(filesInclude, mapSlice(langInclude, query.LangToFileRegexp)...)
+	filesExclude = append(filesExclude, mapSlice(langExclude, query.LangToFileRegexp)...)
 	filesReposMustInclude, filesReposMustExclude := b.IncludeExcludeValues(query.FieldRepoHasFile)
 
 	if typ == search.SymbolRequest && q != nil {
@@ -58,7 +58,7 @@ func QueryToZoektQuery(b query.Basic, resultTypes result.Types, feat *search.Fea
 		and = append(and, q)
 	}
 	if len(filesExclude) > 0 {
-		q, err := FileRe(search.UnionRegExps(filesExclude), isCaseSensitive)
+		q, err := FileRe(query.UnionRegExps(filesExclude), isCaseSensitive)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Stacked on https://github.com/sourcegraph/sourcegraph/pull/34671.

This leaves two functions `UnionRegExps` and `LangToFileRegexp` in `query_converter.go` which are basically query helpers used all over the code base, e.g.,

So I don't know that there's a nicer place for them to live than `query/helpers.go` (maybe `query/converters.go`?) If you have a better suggestion lmk.



## Test plan
Semantics-preserving.


