### PR TITLE
Fix incorrect color in doc table.

### DIFF
--- a/doc/code_intelligence/references/indexers.md
+++ b/doc/code_intelligence/references/indexers.md
@@ -112,7 +112,7 @@ This table is maintained as an authoritative resource for users, Sales, and Cust
         <td class="indexer-implemented-y">✓</td> <!-- Go to definition -->
         <td class="indexer-implemented-y">✓</td> <!-- Find references -->
         <td class="indexer-implemented-y">✓</td> <!-- Cross-file -->
-        <td class="indexer-implemented-y">✗</td> <!-- Cross-repository -->
+        <td class="indexer-implemented-n">✗</td> <!-- Cross-repository -->
         <td class="indexer-implemented-n">✗</td> <!-- Find implementations -->
         <td><a href="https://rust-analyzer.github.io/">See notes</a></td> <!-- Build tooling -->
       </tr>


### PR DESCRIPTION
It is currently marked with an ✗ but shows up as green.

## Test plan

n/a.