### PR TITLE
compute: interpret "select:" intuitively

### DIFF
--- a/enterprise/internal/compute/output_command.go
+++ b/enterprise/internal/compute/output_command.go
@@ -18,6 +18,7 @@ type Output struct {
 	SearchPattern MatchPattern
 	OutputPattern string
 	Separator     string
+	Selector      string
 }
 
 func (c *Output) ToSearchPattern() string {
@@ -96,5 +97,12 @@ func (c *Output) Run(ctx context.Context, db database.DB, r result.Match) (Resul
 	if err != nil {
 		return nil, err
 	}
+
+	if c.Selector != "" {
+		// Don't run the search pattern over the search result content
+		// when there's an explicit `select:` value.
+		return &Text{Value: outputPattern, Kind: "output"}, nil
+	}
+
 	return output(ctx, content, c.SearchPattern, outputPattern, c.Separator)
 }

--- a/enterprise/internal/compute/output_command_test.go
+++ b/enterprise/internal/compute/output_command_test.go
@@ -90,8 +90,8 @@ func TestRun(t *testing.T) {
 
 	autogold.Want(
 		"handles repo match via select on file match",
-		"my/awesome/repo\n").
-		Equal(t, test(`lang:ocaml content:output(.* -> $repo) select:repo`, fileMatch("a 1 b 2 c 3")))
+		"my/awesome/repo").
+		Equal(t, test(`lang:ocaml content:output((\d) -> $repo) select:repo`, fileMatch("a 1 b 2 c 3")))
 
 	autogold.Want(
 		"template substitution regexp with commit author",

--- a/enterprise/internal/compute/query.go
+++ b/enterprise/internal/compute/query.go
@@ -194,8 +194,13 @@ func parseOutput(q *query.Basic) (Command, bool, error) {
 		return nil, false, nil
 	}
 
+	var selector string
+	query.VisitField(q.ToParseTree(), query.FieldSelect, func(value string, _ bool, _ query.Annotation) {
+		selector = value
+	})
+
 	// The default separator is newline and cannot be changed currently.
-	return &Output{SearchPattern: matchPattern, OutputPattern: right, Separator: "\n"}, true, nil
+	return &Output{SearchPattern: matchPattern, OutputPattern: right, Separator: "\n", Selector: selector}, true, nil
 }
 
 func parseMatchOnly(q *query.Basic) (Command, bool, error) {


### PR DESCRIPTION
Compute needs to "understand" the intent of `select` better. See test example for what this fixes.

## Test plan
Updated test.


