### PR TITLE
compute: don't hydrate file contents for "type:path"

### DIFF
--- a/enterprise/internal/compute/output_command_test.go
+++ b/enterprise/internal/compute/output_command_test.go
@@ -94,6 +94,11 @@ func TestRun(t *testing.T) {
 		Equal(t, test(`lang:ocaml content:output((\d) -> $repo) select:repo`, fileMatch("a 1 b 2 c 3")))
 
 	autogold.Want(
+		"honor type:path efficiently (don't hydrate file content when type:path is set)",
+		"my/awesome/path.ml content is my/awesome/path.ml with extension: ml\n").
+		Equal(t, test(`content:output(awesome/.+\.(\w+) -> $path content is $content with extension: $1) type:path`, fileMatch("a 1 b 2 c 3")))
+
+	autogold.Want(
 		"template substitution regexp with commit author",
 		"bob: (1)\nbob: (2)\nbob: (3)\n").
 		Equal(t, test(`content:output((\d) -> $author: ($1))`, commitMatch("a 1 b 2 c 3")))

--- a/enterprise/internal/compute/query.go
+++ b/enterprise/internal/compute/query.go
@@ -194,13 +194,24 @@ func parseOutput(q *query.Basic) (Command, bool, error) {
 		return nil, false, nil
 	}
 
+	var typeValue string
+	query.VisitField(q.ToParseTree(), query.FieldType, func(value string, _ bool, _ query.Annotation) {
+		typeValue = value
+	})
+
 	var selector string
 	query.VisitField(q.ToParseTree(), query.FieldSelect, func(value string, _ bool, _ query.Annotation) {
 		selector = value
 	})
 
 	// The default separator is newline and cannot be changed currently.
-	return &Output{SearchPattern: matchPattern, OutputPattern: right, Separator: "\n", Selector: selector}, true, nil
+	return &Output{
+		SearchPattern: matchPattern,
+		OutputPattern: right,
+		Separator:     "\n",
+		TypeValue:     typeValue,
+		Selector:      selector,
+	}, true, nil
 }
 
 func parseMatchOnly(q *query.Basic) (Command, bool, error) {


### PR DESCRIPTION
Stacked on https://github.com/sourcegraph/sourcegraph/pull/34677

I want compute queries to efficiently return just a file path result (previously, you couldn't avoid fetching file contents because we always fetched file contents for a given `FileMatch`). This PR allows to avoid hydrating content when `type:path` is set. Our lack of a dedicated type really leaks into things here and makes my compute code ugly 😢 🤮 . But I dislike the inefficiency more than how this uglifies things. Having this will let us compute language statistics quickly.

The state tracking could be entirely avoided by having a dedicated `PathMatch`.

## Test plan
Added tests.


