### PR TITLE
Search backend: use non-capturing groups for union regexp

### DIFF
--- a/internal/gitserver/protocol/search_reduce.go
+++ b/internal/gitserver/protocol/search_reduce.go
@@ -162,6 +162,10 @@ func mergeOrRegexp(n Node) Node {
 		return n
 	}
 
+	union := func(left, right string) string {
+		return "(?:" + left + ")|(?:" + right + ")"
+	}
+
 	unmergeable := operator.Operands[:0]
 	mergeable := map[interface{}]Node{}
 	for _, operand := range operator.Operands {
@@ -170,7 +174,7 @@ func mergeOrRegexp(n Node) Node {
 			key := AuthorMatches{IgnoreCase: v.IgnoreCase}
 			if prev, ok := mergeable[key]; ok {
 				mergeable[key] = &AuthorMatches{
-					Expr:       "(" + prev.(*AuthorMatches).Expr + ")|(" + v.Expr + ")",
+					Expr:       union(prev.(*AuthorMatches).Expr, v.Expr),
 					IgnoreCase: v.IgnoreCase,
 				}
 			} else {
@@ -180,7 +184,7 @@ func mergeOrRegexp(n Node) Node {
 			key := CommitterMatches{IgnoreCase: v.IgnoreCase}
 			if prev, ok := mergeable[key]; ok {
 				mergeable[key] = &CommitterMatches{
-					Expr:       "(" + prev.(*CommitterMatches).Expr + ")|(" + v.Expr + ")",
+					Expr:       union(prev.(*CommitterMatches).Expr, v.Expr),
 					IgnoreCase: v.IgnoreCase,
 				}
 			} else {
@@ -190,7 +194,7 @@ func mergeOrRegexp(n Node) Node {
 			key := MessageMatches{IgnoreCase: v.IgnoreCase}
 			if prev, ok := mergeable[key]; ok {
 				mergeable[key] = &MessageMatches{
-					Expr:       "(" + prev.(*MessageMatches).Expr + ")|(" + v.Expr + ")",
+					Expr:       union(prev.(*MessageMatches).Expr, v.Expr),
 					IgnoreCase: v.IgnoreCase,
 				}
 			} else {
@@ -200,7 +204,7 @@ func mergeOrRegexp(n Node) Node {
 			key := DiffMatches{IgnoreCase: v.IgnoreCase}
 			if prev, ok := mergeable[key]; ok {
 				mergeable[key] = &DiffMatches{
-					Expr:       "(" + prev.(*DiffMatches).Expr + ")|(" + v.Expr + ")",
+					Expr:       union(prev.(*DiffMatches).Expr, v.Expr),
 					IgnoreCase: v.IgnoreCase,
 				}
 			} else {
@@ -210,7 +214,7 @@ func mergeOrRegexp(n Node) Node {
 			key := DiffModifiesFile{IgnoreCase: v.IgnoreCase}
 			if prev, ok := mergeable[key]; ok {
 				mergeable[key] = &DiffModifiesFile{
-					Expr:       "(" + prev.(*DiffModifiesFile).Expr + ")|(" + v.Expr + ")",
+					Expr:       union(prev.(*DiffModifiesFile).Expr, v.Expr),
 					IgnoreCase: v.IgnoreCase,
 				}
 			} else {

--- a/internal/gitserver/protocol/search_test.go
+++ b/internal/gitserver/protocol/search_test.go
@@ -258,27 +258,27 @@ func TestReducers(t *testing.T) {
 			{
 				name:   "authorMatches in or is merged",
 				input:  newOperator(Or, &AuthorMatches{Expr: "a"}, &AuthorMatches{Expr: "b"}),
-				output: newOperator(Or, &AuthorMatches{Expr: "(a)|(b)"}),
+				output: newOperator(Or, &AuthorMatches{Expr: "(?:a)|(?:b)"}),
 			},
 			{
 				name:   "committerMatches in or is merged",
 				input:  newOperator(Or, &CommitterMatches{Expr: "a"}, &CommitterMatches{Expr: "b"}),
-				output: newOperator(Or, &CommitterMatches{Expr: "(a)|(b)"}),
+				output: newOperator(Or, &CommitterMatches{Expr: "(?:a)|(?:b)"}),
 			},
 			{
 				name:   "diffMatches in or is merged",
 				input:  newOperator(Or, &DiffMatches{Expr: "a"}, &DiffMatches{Expr: "b"}),
-				output: newOperator(Or, &DiffMatches{Expr: "(a)|(b)"}),
+				output: newOperator(Or, &DiffMatches{Expr: "(?:a)|(?:b)"}),
 			},
 			{
 				name:   "diffModifiesFile in or is merged",
 				input:  newOperator(Or, &DiffModifiesFile{Expr: "a"}, &DiffModifiesFile{Expr: "b"}),
-				output: newOperator(Or, &DiffModifiesFile{Expr: "(a)|(b)"}),
+				output: newOperator(Or, &DiffModifiesFile{Expr: "(?:a)|(?:b)"}),
 			},
 			{
 				name:   "messageMatches in or is merged",
 				input:  newOperator(Or, &MessageMatches{Expr: "a"}, &MessageMatches{Expr: "b"}),
-				output: newOperator(Or, &MessageMatches{Expr: "(a)|(b)"}),
+				output: newOperator(Or, &MessageMatches{Expr: "(?:a)|(?:b)"}),
 			},
 			{
 				name:   "unmergeable are not merged",

--- a/internal/search/commit/commit.go
+++ b/internal/search/commit/commit.go
@@ -168,7 +168,7 @@ func (j *CommitSearch) ExpandUsernames(ctx context.Context, db database.DB) (err
 			return n
 		}
 
-		*expr = "(" + strings.Join(expanded, ")|(") + ")"
+		*expr = "(?:" + strings.Join(expanded, ")|(?:") + ")"
 		return n
 	})
 	return err

--- a/internal/search/query/helpers.go
+++ b/internal/search/query/helpers.go
@@ -24,7 +24,7 @@ func UnionRegExps(values []string) string {
 		// pretty printed.
 		return values[0]
 	}
-	return "(" + strings.Join(values, ")|(") + ")"
+	return "(?:" + strings.Join(values, ")|(?:") + ")"
 }
 
 // filenamesFromLanguage is a map of language name to full filenames

--- a/internal/search/query/transformer.go
+++ b/internal/search/query/transformer.go
@@ -476,7 +476,7 @@ func substituteOrForRegexp(nodes []Node) []Node {
 				for _, node := range patterns {
 					values = append(values, node.(Pattern).Value)
 				}
-				valueString := "(" + strings.Join(values, ")|(") + ")"
+				valueString := "(?:" + strings.Join(values, ")|(?:") + ")"
 				newNode = append(newNode, Pattern{Value: valueString})
 				if len(rest) > 0 {
 					rest = substituteOrForRegexp(rest)

--- a/internal/search/query/transformer_test.go
+++ b/internal/search/query/transformer_test.go
@@ -209,31 +209,31 @@ func TestSubstituteOrForRegexp(t *testing.T) {
 	}{
 		{
 			input: "foo or bar",
-			want:  `"(foo)|(bar)"`,
+			want:  `"(?:foo)|(?:bar)"`,
 		},
 		{
 			input: "(foo or (bar or baz))",
-			want:  `"(foo)|(bar)|(baz)"`,
+			want:  `"(?:foo)|(?:bar)|(?:baz)"`,
 		},
 		{
 			input: "repo:foobar foo or (bar or baz)",
-			want:  `(or "(bar)|(baz)" (and "repo:foobar" "foo"))`,
+			want:  `(or "(?:bar)|(?:baz)" (and "repo:foobar" "foo"))`,
 		},
 		{
 			input: "(foo or (bar or baz)) and foobar",
-			want:  `(and "(foo)|(bar)|(baz)" "foobar")`,
+			want:  `(and "(?:foo)|(?:bar)|(?:baz)" "foobar")`,
 		},
 		{
 			input: "(foo or (bar and baz))",
-			want:  `(or "(foo)" (and "bar" "baz"))`,
+			want:  `(or "(?:foo)" (and "bar" "baz"))`,
 		},
 		{
 			input: "foo or (bar and baz) or foobar",
-			want:  `(or "(foo)|(foobar)" (and "bar" "baz"))`,
+			want:  `(or "(?:foo)|(?:foobar)" (and "bar" "baz"))`,
 		},
 		{
 			input: "repo:foo a or b",
-			want:  `(and "repo:foo" "(a)|(b)")`,
+			want:  `(and "repo:foo" "(?:a)|(?:b)")`,
 		},
 	}
 	for _, c := range cases {


### PR DESCRIPTION
Unioning regex patterns with capturing groups causes a severe
performance hit compared to non-capturing groups, so this modifies
UnionRegexp and the commit search optimizer to union with non-capturing
groups instead.

This dramatically reduces the cost of unioned OR queries. For one diff query,
it brought the total search time down from `9s` to `1.2s`. 

[Slack thread](https://sourcegraph.slack.com/archives/C020S8AT3LN/p1651194738322429) with more discovery/context

## Test plan

Running backend-dry-run and tested the commit `or` queries manually to ensure they were behaving correctly (and performantly).

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


