### PR TITLE
codenotify: do not notify if it spams over 15 people

### DIFF
--- a/.github/workflows/codenotify.yml
+++ b/.github/workflows/codenotify.yml
@@ -12,13 +12,15 @@ jobs:
       - uses: actions/checkout@v2
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-      - uses: sourcegraph/codenotify@v0.5.1
+      - uses: sourcegraph/codenotify@v0.6.0
         with:
           filename: 'CODENOTIFY'
+          subscriber-threshold: '15'
         env:
           GITHUB_TOKEN: ${{ secrets.CODENOTIFY_GITHUB_TOKEN }}
-      - uses: sourcegraph/codenotify@v0.5.1
+      - uses: sourcegraph/codenotify@v0.6.0
         with:
           filename: 'OWNERS'
+          subscriber-threshold: '15'
         env:
           GITHUB_TOKEN: ${{ secrets.CODENOTIFY_GITHUB_TOKEN }}


### PR DESCRIPTION
Use the new `subscriber-threshold` add in https://github.com/sourcegraph/codenotify/pull/18. 15 is a number I think is reaching low-enough signal for people that are notified, happy to discuss and adjust!

## Test plan

n/a

