### PR TITLE
reposource: Fix Maven dependency parsing

### DIFF
--- a/cmd/gitserver/server/vcs_syncer_jvm_packages.go
+++ b/cmd/gitserver/server/vcs_syncer_jvm_packages.go
@@ -62,11 +62,7 @@ func (jvmPackagesSyncer) ParseDependency(dep string) (reposource.PackageDependen
 }
 
 func (jvmPackagesSyncer) ParseDependencyFromRepoName(repoName string) (reposource.PackageDependency, error) {
-	mod, err := reposource.ParseMavenModule(repoName)
-	if err != nil {
-		return nil, err
-	}
-	return &reposource.MavenDependency{MavenModule: mod}, nil
+	return reposource.ParseMavenDependencyFromRepoName(repoName)
 }
 
 func (s *jvmPackagesSyncer) Get(ctx context.Context, name, version string) (reposource.PackageDependency, error) {

--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -1388,7 +1388,27 @@ func testDependenciesSearch(client, streamClient searchClient) func(*testing.T) 
 			t.Fatal(err)
 		}
 
-		err = client.WaitForReposToBeCloned("npm/urql", "go/github.com/oklog/ulid/v2")
+		_, err = client.AddExternalService(gqltestutil.AddExternalServiceInput{
+			Kind:        extsvc.KindJVMPackages,
+			DisplayName: "gqltest-jvm-search",
+			Config: mustMarshalJSONString(&schema.JVMPackagesConnection{
+				Maven: &schema.Maven{
+					Dependencies: []string{
+						"com.google.guava:guava:19",
+						"com.google.guava:guava:21",
+					},
+				},
+			}),
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = client.WaitForReposToBeCloned(
+			"npm/urql",
+			"go/github.com/oklog/ulid/v2",
+			"maven/com.google.guava/guava",
+		)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/conf/reposource/jvm_packages.go
+++ b/internal/conf/reposource/jvm_packages.go
@@ -106,35 +106,35 @@ func (d *MavenDependency) LsifJavaDependencies() []string {
 // ParseMavenDependency parses a dependency string in the Coursier format (colon seperated group ID, artifact ID and version)
 // into a MavenDependency.
 func ParseMavenDependency(dependency string) (*MavenDependency, error) {
-	parts := strings.Split(dependency, ":")
-	if len(parts) < 3 {
-		return nil, errors.Newf("dependency %q must contain at least two colon ':' characters", dependency)
-	}
-	version := parts[2]
+	dep := &MavenDependency{MavenModule: &MavenModule{}}
 
-	return &MavenDependency{
-		MavenModule: &MavenModule{
-			GroupID:    parts[0],
-			ArtifactID: parts[1],
-		},
-		Version: version,
-	}, nil
+	switch ps := strings.Split(dependency, ":"); len(ps) {
+	case 3:
+		dep.Version = ps[2]
+		fallthrough
+	case 2:
+		dep.MavenModule.GroupID = ps[0]
+		dep.MavenModule.ArtifactID = ps[1]
+	default:
+		return nil, errors.Newf("dependency %q must contain at least one colon ':' character", dependency)
+	}
+
+	return dep, nil
 }
 
-// ParseMavenModule returns a parsed JVM module from the provided URL path, without a leading `/`
-func ParseMavenModule(urlPath string) (*MavenModule, error) {
-	if urlPath == "jdk" {
-		return jdkModule(), nil
-	}
-	parts := strings.SplitN(strings.TrimPrefix(urlPath, "maven/"), "/", 2)
-	if len(parts) != 2 {
-		return nil, errors.Newf("failed to parse a maven module from the path %s", urlPath)
+// ParseMavenDependencyFromRepoName is a convenience function to parse a repo name in a
+// 'maven/<name>' format into a MavenDependency.
+func ParseMavenDependencyFromRepoName(name string) (*MavenDependency, error) {
+	if name == "jdk" {
+		return &MavenDependency{MavenModule: jdkModule()}, nil
 	}
 
-	return &MavenModule{
-		GroupID:    parts[0],
-		ArtifactID: parts[1],
-	}, nil
+	dep := strings.ReplaceAll(strings.TrimPrefix(name, "maven/"), "/", ":")
+	if len(dep) == len(name) {
+		return nil, errors.New("invalid maven dependency repo name, missing maven/ prefix")
+	}
+
+	return ParseMavenDependency(dep)
 }
 
 // jdkModule returns the module for the Java standard library (JDK). This module

--- a/internal/conf/reposource/jvm_packages.go
+++ b/internal/conf/reposource/jvm_packages.go
@@ -103,8 +103,8 @@ func (d *MavenDependency) LsifJavaDependencies() []string {
 	return []string{d.PackageManagerSyntax()}
 }
 
-// ParseMavenDependency parses a dependency string in the Coursier format (colon seperated group ID, artifact ID and version)
-// into a MavenDependency.
+// ParseMavenDependency parses a dependency string in the Coursier format
+// (colon seperated group ID, artifact ID and an optional version) into a MavenDependency.
 func ParseMavenDependency(dependency string) (*MavenDependency, error) {
 	dep := &MavenDependency{MavenModule: &MavenModule{}}
 

--- a/internal/conf/reposource/jvm_packages_test.go
+++ b/internal/conf/reposource/jvm_packages_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestDecomposeMavenPath(t *testing.T) {
-	obtained, _ := ParseMavenModule("maven/org.hamcrest/hamcrest-core")
+	obtained, _ := ParseMavenDependencyFromRepoName("maven/org.hamcrest/hamcrest-core")
 	assert.Equal(t, obtained.GroupID, "org.hamcrest")
 	assert.Equal(t, obtained.ArtifactID, "hamcrest-core")
 	assert.Equal(t, api.RepoName("maven/org.hamcrest/hamcrest-core"), obtained.RepoName())

--- a/internal/repos/jvm_packages.go
+++ b/internal/repos/jvm_packages.go
@@ -99,10 +99,10 @@ func (s *JVMPackagesSource) listDependentRepos(ctx context.Context, results chan
 
 		lastID = dbDeps[len(dbDeps)-1].ID
 
-		for _, d := range dbDeps {
-			mavenDependency, err := reposource.ParseMavenDependency(d.Name + ":" + d.Version)
+		for _, dep := range dbDeps {
+			mavenDependency, err := reposource.ParseMavenDependency(dep.Name + ":" + dep.Version)
 			if err != nil {
-				log15.Warn("error parsing maven module", "error", err, "module", d.Name)
+				log15.Warn("error parsing maven module", "error", err, "module", dep.Name)
 				continue
 			}
 

--- a/internal/repos/jvm_packages.go
+++ b/internal/repos/jvm_packages.go
@@ -99,13 +99,12 @@ func (s *JVMPackagesSource) listDependentRepos(ctx context.Context, results chan
 
 		lastID = dbDeps[len(dbDeps)-1].ID
 
-		for _, dep := range dbDeps {
-			parsedModule, err := reposource.ParseMavenModule(dep.Name)
+		for _, d := range dbDeps {
+			mavenDependency, err := reposource.ParseMavenDependency(d.Name + ":" + d.Version)
 			if err != nil {
-				log15.Warn("error parsing maven module", "error", err, "module", dep.Name)
+				log15.Warn("error parsing maven module", "error", err, "module", d.Name)
 				continue
 			}
-			mavenDependency := &reposource.MavenDependency{MavenModule: parsedModule, Version: dep.Version}
 
 			// We dont return anything that isnt resolvable here, to reduce logspam from gitserver. This codepath
 			// should be hit much less frequently than gitservers attempts to get packages, so there should be less


### PR DESCRIPTION
This commit fixes Maven dependency parsing. Yesterday's fix was
incomplete, in that it kept using a reposource.ParseMavenModule that
needed to be changed to parse dependencies from the DB with the
canonical `:` separator.

We add a backend integration test that exercises this code path to
prevent future regressions.



## Test plan

Backend integration test.


