### PR TITLE
authz/github: Support authorization.internalRepos in provider

### DIFF
--- a/enterprise/internal/authz/github/authz.go
+++ b/enterprise/internal/authz/github/authz.go
@@ -153,7 +153,7 @@ func newAuthzProvider(
 		GitHubURL:      baseURL,
 		BaseToken:      c.Token,
 		GroupsCacheTTL: ttl,
-		InternalRepos:  c.Authorization.InternalRepos,
+		InternalRepos:  c.Authorization.Internal,
 	}), nil
 }
 

--- a/enterprise/internal/authz/github/authz_test.go
+++ b/enterprise/internal/authz/github/authz_test.go
@@ -172,7 +172,7 @@ func TestNewAuthzProviders(t *testing.T) {
 			assert.Empty(t, warnings)
 		})
 
-		t.Run("groups cache and internalRepos set to true", func(t *testing.T) {
+		t.Run("groups cache and internal set to true", func(t *testing.T) {
 			github.MockGetAuthenticatedOAuthScopes = func(context.Context) ([]string, error) {
 				return []string{"read:org"}, nil
 			}
@@ -186,7 +186,7 @@ func TestNewAuthzProviders(t *testing.T) {
 								Url: schema.DefaultGitHubURL,
 								Authorization: &schema.GitHubAuthorization{
 									GroupsCacheTTL: 72,
-									InternalRepos:  true,
+									Internal:       true,
 								},
 							},
 						},
@@ -225,7 +225,7 @@ func TestNewAuthzProviders(t *testing.T) {
 							GitHubConnection: &schema.GitHubConnection{
 								Url: schema.DefaultGitHubURL,
 								Authorization: &schema.GitHubAuthorization{
-									InternalRepos: true,
+									Internal: true,
 								},
 							},
 						},

--- a/enterprise/internal/authz/github/github.go
+++ b/enterprise/internal/authz/github/github.go
@@ -25,7 +25,8 @@ type Provider struct {
 	client   func() (client, error)
 	codeHost *extsvc.CodeHost
 	// groupsCache may be nil if group caching is disabled (negative TTL)
-	groupsCache *cachedGroups
+	groupsCache   *cachedGroups
+	internalRepos bool
 
 	// enableGithubInternalRepoVisibility is a feature flag to optionally enable a fix for
 	// internal repos on GithHub Enterprise. At the moment we do not handle internal repos
@@ -43,6 +44,7 @@ type ProviderOptions struct {
 
 	BaseToken      string
 	GroupsCacheTTL time.Duration
+	InternalRepos  bool
 }
 
 func NewProvider(urn string, opts ProviderOptions) *Provider {
@@ -63,9 +65,10 @@ func NewProvider(urn string, opts ProviderOptions) *Provider {
 	}
 
 	return &Provider{
-		urn:         urn,
-		codeHost:    codeHost,
-		groupsCache: cg,
+		urn:           urn,
+		codeHost:      codeHost,
+		groupsCache:   cg,
+		internalRepos: opts.InternalRepos,
 		client: func() (client, error) {
 			return &ClientAdapter{V3Client: opts.GitHubClient}, nil
 		},

--- a/schema/github.schema.json
+++ b/schema/github.schema.json
@@ -168,6 +168,11 @@
           "description": "Experimental: If set, configures hours cached permissions from teams and organizations should be kept for. Setting a negative value disables syncing from teams and organizations, and falls back to the default behaviour of syncing all permisisons directly from user-repository affiliations instead. [Learn more](https://docs.sourcegraph.com/admin/repo/permissions#teams-and-organizations-permissions-caching).",
           "type": "number",
           "default": 72
+        },
+        "internalRepos": {
+          "description": "Experimental: If set, configures the cached permissions to use a pseudo-org internally to support visibility of internal repositories for all users that belong to an organization. Ignored if GroupsCacheTTL is a positive number.",
+          "type": "boolean",
+          "default": "false"
         }
       }
     },

--- a/schema/github.schema.json
+++ b/schema/github.schema.json
@@ -169,7 +169,7 @@
           "type": "number",
           "default": 72
         },
-        "internalRepos": {
+        "internal": {
           "description": "Experimental: If true, treats all repositories in this code host connection as visible to any user that is a member of any organization in the GitHub Enterprise instance. Ignored if GroupsCacheTTL is enabled. Not supported on GitHub.com.",
           "type": "boolean",
           "default": "false"

--- a/schema/github.schema.json
+++ b/schema/github.schema.json
@@ -170,7 +170,7 @@
           "default": 72
         },
         "internalRepos": {
-          "description": "Experimental: If set, configures the cached permissions to use a pseudo-org internally to support visibility of internal repositories for all users that belong to an organization. Ignored if GroupsCacheTTL is a positive number.",
+          "description": "Experimental: If true, treats all repositories in this code host connection as visible to any user that is a member of any organization in the GitHub Enterprise instance. Ignored if GroupsCacheTTL is enabled. Not supported on GitHub.com.",
           "type": "boolean",
           "default": "false"
         }

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -743,6 +743,8 @@ type GitHubAuthProvider struct {
 type GitHubAuthorization struct {
 	// GroupsCacheTTL description: Experimental: If set, configures hours cached permissions from teams and organizations should be kept for. Setting a negative value disables syncing from teams and organizations, and falls back to the default behaviour of syncing all permisisons directly from user-repository affiliations instead. [Learn more](https://docs.sourcegraph.com/admin/repo/permissions#teams-and-organizations-permissions-caching).
 	GroupsCacheTTL float64 `json:"groupsCacheTTL,omitempty"`
+	// InternalRepos description: Experimental: If set, configures the cached permissions to use a pseudo-org internally to support visibility of internal repositories for all users that belong to an organization. Ignored if GroupsCacheTTL is a positive number.
+	InternalRepos bool `json:"internalRepos,omitempty"`
 }
 
 // GitHubConnection description: Configuration for a connection to GitHub or GitHub Enterprise.

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -743,8 +743,8 @@ type GitHubAuthProvider struct {
 type GitHubAuthorization struct {
 	// GroupsCacheTTL description: Experimental: If set, configures hours cached permissions from teams and organizations should be kept for. Setting a negative value disables syncing from teams and organizations, and falls back to the default behaviour of syncing all permisisons directly from user-repository affiliations instead. [Learn more](https://docs.sourcegraph.com/admin/repo/permissions#teams-and-organizations-permissions-caching).
 	GroupsCacheTTL float64 `json:"groupsCacheTTL,omitempty"`
-	// InternalRepos description: Experimental: If set, configures the cached permissions to use a pseudo-org internally to support visibility of internal repositories for all users that belong to an organization. Ignored if GroupsCacheTTL is a positive number.
-	InternalRepos bool `json:"internalRepos,omitempty"`
+	// Internal description: Experimental: If true, treats all repositories in this code host connection as visible to any user that is a member of any organization in the GitHub Enterprise instance. Ignored if GroupsCacheTTL is enabled. Not supported on GitHub.com.
+	Internal bool `json:"internal,omitempty"`
 }
 
 // GitHubConnection description: Configuration for a connection to GitHub or GitHub Enterprise.


### PR DESCRIPTION
First step on #34684. 

This PR adds a new configurable attribute for the GitHub Authorization provider: `internalRepos`. Setting it from the UI is possible but has no affect as this is not being consumed anywhere at the moment. As a result it should be safe to merge this PR.

**Adding authorization.internalRepos to the config**

![authorization-internal-repos](https://user-images.githubusercontent.com/2682729/165947648-74a7f301-19e9-4cda-ae95-5366f5d1d6bf.gif)

**UI Warning with setting both authorization.groupsCacheTTL and authorization.internalRepos in the config**

![authorization-groups-cache-and-internal-repos](https://user-images.githubusercontent.com/2682729/165947662-1fcc33db-7791-4d9e-9117-ad59e706f44b.gif)


## Test plan

Added tests.

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


