### PR TITLE
observation: disable trace logs in dev

### DIFF
--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -10,6 +10,7 @@ env:
   SRC_REPOS_DIR: $HOME/.sourcegraph/repos
   SRC_LOG_LEVEL: info
   SRC_LOG_FORMAT: condensed
+  SRC_TRACE_LOG: false
   # Set this to true to show an iTerm link to the file:line where the log message came from
   SRC_LOG_SOURCE_LINK: false
   SRC_GIT_SERVER_1: 127.0.0.1:3178


### PR DESCRIPTION
Explicit logging of trace logs was added because Datadog does not support OT/OTel trace logs/events at INFO level because we do not want these logs to be lost if we have no other way of seeing trace log events. This PR disables it for dev environments, and optionally for other environments, because it can get a bit noisy.

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

```
sg start
```

no more `trace.log` logs
