### PR TITLE
codeintel: Add 25m maximum time per LSIF job

### DIFF
--- a/enterprise/cmd/precise-code-intel-worker/config.go
+++ b/enterprise/cmd/precise-code-intel-worker/config.go
@@ -14,6 +14,7 @@ type Config struct {
 	WorkerPollInterval    time.Duration
 	WorkerConcurrency     int
 	WorkerBudget          int64
+	MaximumRuntimePerJob  time.Duration
 	LSIFUploadStoreConfig *lsifuploadstore.Config
 }
 
@@ -24,6 +25,7 @@ func (c *Config) Load() {
 	c.WorkerPollInterval = c.GetInterval("PRECISE_CODE_INTEL_WORKER_POLL_INTERVAL", "1s", "Interval between queries to the upload queue.")
 	c.WorkerConcurrency = c.GetInt("PRECISE_CODE_INTEL_WORKER_CONCURRENCY", "1", "The maximum number of indexes that can be processed concurrently.")
 	c.WorkerBudget = int64(c.GetInt("PRECISE_CODE_INTEL_WORKER_BUDGET", "0", "The amount of compressed input data (in bytes) a worker can process concurrently. Zero acts as an infinite budget."))
+	c.MaximumRuntimePerJob = c.GetInterval("PRECISE_CODE_INTEL_WORKER_MAXIMUM_RUNTIME_PER_JOB", "25m", "The maximum time a single LSIF processing job can take.")
 }
 
 func (c *Config) Validate() error {

--- a/enterprise/cmd/precise-code-intel-worker/internal/worker/worker.go
+++ b/enterprise/cmd/precise-code-intel-worker/internal/worker/worker.go
@@ -28,6 +28,7 @@ func NewWorker(
 	pollInterval time.Duration,
 	numProcessorRoutines int,
 	budgetMax int64,
+	maximumRuntimePerJob time.Duration,
 	workerMetrics workerutil.WorkerMetrics,
 ) *workerutil.Worker {
 	rootContext := actor.WithActor(context.Background(), &actor.Actor{Internal: true})
@@ -58,10 +59,11 @@ func NewWorker(
 	}
 
 	return dbworker.NewWorker(rootContext, workerStore, handler, workerutil.WorkerOptions{
-		Name:              "precise_code_intel_upload_worker",
-		NumHandlers:       numProcessorRoutines,
-		Interval:          pollInterval,
-		HeartbeatInterval: UploadHeartbeatInterval,
-		Metrics:           workerMetrics,
+		Name:                 "precise_code_intel_upload_worker",
+		NumHandlers:          numProcessorRoutines,
+		Interval:             pollInterval,
+		HeartbeatInterval:    UploadHeartbeatInterval,
+		Metrics:              workerMetrics,
+		MaximumRuntimePerJob: maximumRuntimePerJob,
 	})
 }

--- a/enterprise/cmd/precise-code-intel-worker/main.go
+++ b/enterprise/cmd/precise-code-intel-worker/main.go
@@ -128,6 +128,7 @@ func main() {
 		config.WorkerPollInterval,
 		config.WorkerConcurrency,
 		config.WorkerBudget,
+		config.MaximumRuntimePerJob,
 		makeWorkerMetrics(observationContext),
 	)
 


### PR DESCRIPTION
Add a maximum runtime for LSIF jobs.

## Test plan

Checked honeycomb dataset to ensure that 25m is reasonable on Cloud. The last day of data shows that we barely hit over 90s on the 99th percentile. 25m should be more than enough by default here.