### PR TITLE
Improve Percy + accessibilityAudit `View Extension Detail Page` and `Extension Create Form Page`

### DIFF
--- a/client/web/src/enterprise/extensions/registry/RegistryNewExtensionPage.tsx
+++ b/client/web/src/enterprise/extensions/registry/RegistryNewExtensionPage.tsx
@@ -128,20 +128,28 @@ export const RegistryNewExtensionPage = withAuthenticatedUser(
                 <div className="container col-8">
                     <PageTitle title="Create new extension" />
                     <PageHeader
-                        path={[{ icon: PuzzleOutlineIcon, to: '/extensions' }, { text: 'Create extension' }]}
+                        path={[
+                            { icon: PuzzleOutlineIcon, to: '/extensions', ariaLabel: 'Extensions' },
+                            { text: 'Create extension' },
+                        ]}
                         description={
                             <>
                                 <Link target="_blank" rel="noopener" to="/help/extensions/authoring">
                                     Learn more
                                 </Link>{' '}
                                 about authoring Sourcegraph extensions{' '}
-                                <Link target="_blank" rel="noopener" to="/help/extensions/authoring">
+                                <Link
+                                    aria-label="Learn more about extensions authoring"
+                                    target="_blank"
+                                    rel="noopener"
+                                    to="/help/extensions/authoring"
+                                >
                                     <Icon as={HelpCircleOutline} />
                                 </Link>
                             </>
                         }
                     />
-                    <Form onSubmit={this.onSubmit} className="my-4 pb-5">
+                    <Form onSubmit={this.onSubmit} className="my-4 pb-5 test-registry-new-extension">
                         <Container className="mb-4">
                             <RegistryPublisherFormGroup
                                 value={this.state.publisher}

--- a/client/web/src/extensions/extension/ExtensionAreaHeader.tsx
+++ b/client/web/src/extensions/extension/ExtensionAreaHeader.tsx
@@ -95,7 +95,11 @@ export const ExtensionAreaHeader: React.FunctionComponent<React.PropsWithChildre
                                     />
                                 )
                             }
-                            path={[{ to: '/extensions', icon: PuzzleOutlineIcon }, { text: publisher }, { text: name }]}
+                            path={[
+                                { to: '/extensions', icon: PuzzleOutlineIcon, ariaLabel: 'Extensions' },
+                                { text: publisher },
+                                { text: name },
+                            ]}
                             description={
                                 manifest &&
                                 (manifest.description || isWorkInProgress) && (

--- a/client/web/src/extensions/extension/RegistryExtensionOverviewPage.tsx
+++ b/client/web/src/extensions/extension/RegistryExtensionOverviewPage.tsx
@@ -9,7 +9,7 @@ import GithubIcon from 'mdi-react/GithubIcon'
 import { isErrorLike, isDefined, isEncodedImage } from '@sourcegraph/common'
 import { splitExtensionID } from '@sourcegraph/shared/src/extensions/extension'
 import { ExtensionCategory, ExtensionManifest } from '@sourcegraph/shared/src/schema/extensionSchema'
-import { Button, Link, Icon } from '@sourcegraph/wildcard'
+import { Button, Link, Icon, H2, H3 } from '@sourcegraph/wildcard'
 
 import { PageTitle } from '../../components/PageTitle'
 import { Timestamp } from '../../components/time/Timestamp'
@@ -108,7 +108,7 @@ export const RegistryExtensionOverviewPage: React.FunctionComponent<React.PropsW
                 {/* Publisher */}
                 {publisher && (
                     <div className="pt-2 pb-3">
-                        <h3>Publisher</h3>
+                        <H3 as={H2}>Publisher</H3>
                         <small
                             data-tooltip={isSourcegraphExtension ? 'Created and maintained by Sourcegraph' : undefined}
                         >

--- a/client/web/src/extensions/extension/RegistryExtensionReadme.tsx
+++ b/client/web/src/extensions/extension/RegistryExtensionReadme.tsx
@@ -69,7 +69,7 @@ export const ExtensionReadme: React.FunctionComponent<
 
     try {
         const html = renderMarkdown(manifest.readme)
-        return <Markdown dangerousInnerHTML={html} />
+        return <Markdown testId="registry-extension-overview" dangerousInnerHTML={html} />
     } catch {
         return (
             <PublishNewManifestAlert

--- a/client/web/src/extensions/extension/__snapshots__/RegistryExtensionOverviewPage.test.tsx.snap
+++ b/client/web/src/extensions/extension/__snapshots__/RegistryExtensionOverviewPage.test.tsx.snap
@@ -10,6 +10,7 @@ exports[`RegistryExtensionOverviewPage renders 1`] = `
     >
       <div
         class="markdown"
+        data-testid="registry-extension-overview"
       >
         <p>
           <strong>
@@ -39,9 +40,11 @@ exports[`RegistryExtensionOverviewPage renders 1`] = `
       <div
         class="pt-2 pb-3"
       >
-        <h3>
+        <h2
+          class="h2 h3"
+        >
           Publisher
-        </h3>
+        </h2>
         <small>
           x
         </small>
@@ -168,6 +171,7 @@ exports[`RegistryExtensionOverviewPage renders with no tags 1`] = `
     >
       <div
         class="markdown"
+        data-testid="registry-extension-overview"
       >
         <p>
           <strong>
@@ -197,9 +201,11 @@ exports[`RegistryExtensionOverviewPage renders with no tags 1`] = `
       <div
         class="pt-2 pb-3"
       >
-        <h3>
+        <h2
+          class="h2 h3"
+        >
           Publisher
-        </h3>
+        </h2>
         <small>
           x
         </small>

--- a/client/web/src/integration/extension-registry.test.ts
+++ b/client/web/src/integration/extension-registry.test.ts
@@ -23,7 +23,8 @@ const typescriptRawManifest = JSON.stringify({
     main: 'dist/extension.js',
     name: 'typescript',
     publisher: 'sourcegraph',
-    readme: '# Code intelligence for TypeScript/JavaScript',
+    readme:
+        '# Codecov Sourcegraph extension \n\n A [Sourcegraph extension](https://docs.sourcegraph.com/extensions) for showing code coverage information from [Codecov](https://codecov.io) on GitHub, Sourcegraph, and other tools. \n\n ## Features \n\n - Support for GitHub.com and Sourcegraph.com \n - Line coverage overlays on files (with green/yellow/red background colors) \n - Line branches/hits annotations on files \n - File coverage ratio indicator (`Coverage: N%`) and toggle button \n - Support for using a Codecov API token to see coverage for private repositories \n - File and directory coverage decorations on Sourcegraph \n\n ## Usage \n\n ### On GitHub using the Chrome extension \n 1. Install [Sourcegraph for Chrome](https://chrome.google.com/webstore/detail/sourcegraph/dgjhfomjieaadpoljlnidmbgkdffpack) \n 2. [Enable the Codecov extension on Sourcegraph](https://sourcegraph.com/extensions/sourcegraph/codecov) \n 3. Visit [tuf_store.go in theupdateframework/notary on GitHub](https://github.com/theupdateframework/notary/blob/master/server/storage/tuf_store.go) (or any other file in a public repository that has Codecov code coverage) \n 4. Click the `Coverage: N%` button to toggle Codecov test coverage background colors on the file (scroll down if they aren’t immediately visible) \n\n',
     scripts: {},
     tags: [],
     url:
@@ -200,6 +201,12 @@ describe('Extension Registry', () => {
                     featuredExtensions: null,
                 },
             }),
+            RegistryExtension: () => ({
+                extensionRegistry: {
+                    __typename: 'ExtensionRegistry',
+                    extension: { ...registryExtensionNodes[0], publishedAt: '2018-10-28T22:33:08Z' },
+                },
+            }),
             Extensions: () => ({
                 extensionRegistry: {
                     __typename: 'ExtensionRegistry',
@@ -329,6 +336,32 @@ describe('Extension Registry', () => {
                     value: !enabled,
                 },
             })
+        })
+    })
+    describe('Accessibility', () => {
+        it('View extension detail page', async () => {
+            overrideGraphQLExtensionRegistry({ enabled: false })
+            await driver.page.goto(driver.sourcegraphBaseUrl + '/extensions/sourcegraph/typescript')
+            await driver.page.waitForSelector("[data-testid='registry-extension-overview']")
+
+            await percySnapshotWithVariants(driver.page, 'Extension registry list page')
+            await accessibilityAudit(driver.page)
+        })
+        it('Create extension page', async () => {
+            testContext.overrideGraphQL({
+                ...commonWebGraphQlResults,
+                ViewerRegistryPublishers: () => ({
+                    extensionRegistry: {
+                        viewerPublishers: [{ __typename: 'User', id: 'VXNlcjo0ODA4OQ==', username: 'Alice' }],
+                        localExtensionIDPrefix: null,
+                    },
+                }),
+            })
+            await driver.page.goto(driver.sourcegraphBaseUrl + '/extensions/registry/new?toast=integrations')
+            await driver.page.waitForSelector('.test-registry-new-extension')
+
+            await percySnapshotWithVariants(driver.page, 'Extension registry create page')
+            await accessibilityAudit(driver.page)
         })
     })
 })


### PR DESCRIPTION
## Description
We currently have visual regression + accessibility audit tests on a series of user journeys within Sourcegraph. A lot of core functionality is still not covered, it reduces our confidence in shipping changes as UI/accessibility bugs can be introduced without our awareness.

## Implementation
For  [view extension detail page](https://sourcegraph.com/extensions/sourcegraph/codecov) and [extension create form page](https://sourcegraph.com/extensions/registry/new)
1. Add percySnapshotWithVariants to store a visual snapshot for the test.
2. Add accessibilityAudit to run our accessibility tests, and fix any identified problems.

## Refs
[Sourcegraph Issue](https://github.com/sourcegraph/sourcegraph/issues/34403)
[Gitstart Ticket](https://app.gitstart.com/clients/sourcegraph/tickets/SG-34403)

## Test plan
Run `ENTERPRISE=1 yarn build-web`
Run `ENTERPRISE=1 HEADLESS=true yarn _test-integration client/web/src/integration/extension-registry.test.ts`
Test should pass successfully

## App preview:

- [Web](https://sg-web-contractors-sg-34403-2.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-xrksjgtity.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
