### PR TITLE
RFC 624: (M2) Harden recognizer gitserver client

### DIFF
--- a/internal/codeintel/autoindexing/internal/inference/init.go
+++ b/internal/codeintel/autoindexing/internal/inference/init.go
@@ -5,8 +5,10 @@ import (
 
 	"github.com/opentracing/opentracing-go"
 	"github.com/prometheus/client_golang/prometheus"
+	"golang.org/x/time/rate"
 
 	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/luasandbox"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
@@ -16,6 +18,10 @@ import (
 var (
 	svc     *Service
 	svcOnce sync.Once
+)
+
+var (
+	gitserverRequestRateLimit = env.MustGetInt("CODEINTEL_AUTOINDEXING_INFERENCE_GITSERVER_REQUEST_LIMIT", 20, "The maximum number of request to gitserver per second that can be made from this service.")
 )
 
 func GetService(db database.DB) *Service {
@@ -29,6 +35,7 @@ func GetService(db database.DB) *Service {
 		svc = newService(
 			luasandbox.GetService(),
 			NewDefaultGitService(nil, db),
+			rate.NewLimiter(rate.Limit(gitserverRequestRateLimit), 1),
 			observationContext,
 		)
 	})

--- a/internal/codeintel/autoindexing/internal/inference/init.go
+++ b/internal/codeintel/autoindexing/internal/inference/init.go
@@ -21,7 +21,7 @@ var (
 )
 
 var (
-gitserverRequestRateLimit = env.MustGetInt("CODEINTEL_AUTOINDEXING_INFERENCE_GITSERVER_REQUEST_LIMIT", 20, "The maximum number of request to gitserver per second that can be made from the autoindexing inference service.")
+gitserverRequestRateLimit = env.MustGetInt("CODEINTEL_AUTOINDEXING_INFERENCE_GITSERVER_REQUEST_LIMIT", 100, "The maximum number of request to gitserver per second that can be made from the autoindexing inference service.")
 )
 
 func GetService(db database.DB) *Service {

--- a/internal/codeintel/autoindexing/internal/inference/init.go
+++ b/internal/codeintel/autoindexing/internal/inference/init.go
@@ -21,7 +21,7 @@ var (
 )
 
 var (
-gitserverRequestRateLimit = env.MustGetInt("CODEINTEL_AUTOINDEXING_INFERENCE_GITSERVER_REQUEST_LIMIT", 100, "The maximum number of request to gitserver per second that can be made from the autoindexing inference service.")
+	gitserverRequestRateLimit = env.MustGetInt("CODEINTEL_AUTOINDEXING_INFERENCE_GITSERVER_REQUEST_LIMIT", 100, "The maximum number of request to gitserver per second that can be made from the autoindexing inference service.")
 )
 
 func GetService(db database.DB) *Service {

--- a/internal/codeintel/autoindexing/internal/inference/init.go
+++ b/internal/codeintel/autoindexing/internal/inference/init.go
@@ -21,7 +21,7 @@ var (
 )
 
 var (
-	gitserverRequestRateLimit = env.MustGetInt("CODEINTEL_AUTOINDEXING_INFERENCE_GITSERVER_REQUEST_LIMIT", 20, "The maximum number of request to gitserver per second that can be made from this service.")
+gitserverRequestRateLimit = env.MustGetInt("CODEINTEL_AUTOINDEXING_INFERENCE_GITSERVER_REQUEST_LIMIT", 20, "The maximum number of request to gitserver per second that can be made from the autoindexing inference service.")
 )
 
 func GetService(db database.DB) *Service {

--- a/internal/codeintel/autoindexing/internal/inference/service_test.go
+++ b/internal/codeintel/autoindexing/internal/inference/service_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/grafana/regexp"
+	"golang.org/x/time/rate"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
@@ -67,7 +68,7 @@ func testRecognizer(t *testing.T, testCase recognizerTestCase) {
 			return unpacktest.CreateZipArchive(t, files)
 		})
 
-		jobs, err := newService(sandboxService, gitService, &observation.TestContext).InferIndexJobs(
+		jobs, err := newService(sandboxService, gitService, rate.NewLimiter(rate.Limit(100), 1), &observation.TestContext).InferIndexJobs(
 			context.Background(),
 			api.RepoName("github.com/test/test"),
 			"HEAD",


### PR DESCRIPTION
Add limits to gitserver calls made from the autoindexing inference service. Closes #33044. In the future if we see issues with large payloads from auto-inference we may want to implement some of the additional ideas described in the linked ticket (large files, maximum number of files per repo, etc). I think rate limiting alone gives excellent coverage today.

## Test plan

Adjusted value in unit tests locally to ensure it was hit.