### PR TITLE
patch release - 2.2.2 - fix file path bug on windows, display version number, remove basePath restriction

### DIFF
--- a/client/vscode/CHANGELOG.md
+++ b/client/vscode/CHANGELOG.md
@@ -6,9 +6,13 @@ The Sourcegraph extension uses major.EVEN_NUMBER.patch (eg. 2.0.1) for release v
 
 ### Changes
 
+- Display current extension version and instance version in frontend [issues/3](https://github.com/sourcegraph/sourcegraph/issues/)
+
 ### Fixes
 
 - Remove incorrect unsupported instance error messages on first load [issues/34207](https://github.com/sourcegraph/sourcegraph/issues/34207)
+- Links to open remote file in Sourcegraph web are now decoded correctly [34630](https://github.com/sourcegraph/sourcegraph/issues/34630)
+- Remove pattern restriction basePath [issues/](https://github.com/sourcegraph/sourcegraph/issues/)
 
 ## 2.2.1
 

--- a/client/vscode/CONTRIBUTING.md
+++ b/client/vscode/CONTRIBUTING.md
@@ -10,7 +10,7 @@ Your feedback is important to us and is greatly appreciated. Please do not hesit
 
 ## Issues / Bugs
 
-New issues and feature requests can be filed through our [issue tracker](https://github.com/sourcegraph/sourcegraph/issues/new/choose) using the `vscode-extension` label.
+New issues and feature requests can be filed through our [issue tracker](https://github.com/sourcegraph/sourcegraph/issues/new?labels=team/integrations,vscode-extension&title=VSCode+Bug+report:+&projects=Integrations%20Project%20Board) using the `vscode-extension` & `team/integrations` label.
 
 ## Development
 
@@ -48,6 +48,7 @@ If you need guidance or have any questions regarding Sourcegraph or the extensio
 - [Developing the web clients](https://docs.sourcegraph.com/dev/background-information/web)
 - [Issue Tracker](https://github.com/sourcegraph/sourcegraph/labels/vscode-extension)
 - [Troubleshooting docs](https://docs.sourcegraph.com/admin/how-to/troubleshoot-sg-extension#vs-code-extension)
+- [Report a bug](https://github.com/sourcegraph/sourcegraph/issues/new?labels=team/integrations,vscode-extension&title=VSCode+Bug+report:+&projects=Integrations%20Project%20Board)
 
 ## License
 

--- a/client/vscode/package.json
+++ b/client/vscode/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "@sourcegraph/vscode",
   "displayName": "Sourcegraph",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "Sourcegraph for VS Code",
   "publisher": "sourcegraph",
   "sideEffects": false,
@@ -14,7 +14,7 @@
     "directory": "client/vscode"
   },
   "bugs": {
-    "url": "https://github.com/sourcegraph/sourcegraph/issues"
+    "url": "https://github.com/sourcegraph/sourcegraph/issues/new?labels=team/integrations,vscode-extension&title=VSCode+Bug+report:+&projects=Integrations%20Project%20Board"
   },
   "engines": {
     "vscode": "^1.63.2"

--- a/client/vscode/src/link-commands/browserActionsNode.ts
+++ b/client/vscode/src/link-commands/browserActionsNode.ts
@@ -31,19 +31,25 @@ export async function browserActions(action: string, logRedirectEvent: (uri: str
         const instanceUrl = vscode.workspace.getConfiguration('sourcegraph').get('url')
         if (typeof instanceUrl === 'string') {
             // construct sourcegraph url for current file
-            sourcegraphUrl = getSourcegraphFileUrl(instanceUrl, remoteURL, branch, fileRelative, editor) + vsceUtms
+            sourcegraphUrl =
+                getSourcegraphFileUrl(instanceUrl, remoteURL, branch, fileRelative.replaceAll('\\', '/'), editor) +
+                vsceUtms
         }
     }
+    const decodedUri = decodeURIComponent(sourcegraphUrl)
+
     // Log redirect events
     logRedirectEvent(sourcegraphUrl)
 
     // Open in browser or Copy file link
-    if (action === 'open' && sourcegraphUrl) {
-        await vscode.env.openExternal(vscode.Uri.parse(sourcegraphUrl))
-    } else if (action === 'copy' && sourcegraphUrl) {
-        const decodedUri = decodeURIComponent(sourcegraphUrl)
-        await env.clipboard.writeText(decodedUri).then(() => vscode.window.showInformationMessage('Copied!'))
-    } else {
-        throw new Error(`Failed to ${action} file link: invalid URL`)
+    switch (action) {
+        case 'open':
+            await vscode.env.openExternal(vscode.Uri.parse(decodedUri))
+            break
+        case 'copy':
+            await env.clipboard.writeText(decodedUri).then(() => vscode.window.showInformationMessage('Copied!'))
+            break
+        default:
+            throw new Error(`Failed to ${action} file link: invalid URL`)
     }
 }

--- a/client/vscode/src/webview/sidebars/help/HelpSidebarView.tsx
+++ b/client/vscode/src/webview/sidebars/help/HelpSidebarView.tsx
@@ -2,6 +2,7 @@ import React, { useMemo, useState } from 'react'
 
 import classNames from 'classnames'
 
+import { version } from '../../../../package.json'
 import { WebviewPageProps } from '../../platform/context'
 import { AuthSidebarView } from '../auth/AuthSidebarView'
 
@@ -47,7 +48,7 @@ export const HelpSidebarView: React.FunctionComponent<HelpSidebarViewProps> = ({
                 type="button"
                 onClick={() =>
                     onHelpItemClick(
-                        'https://github.com/sourcegraph/sourcegraph/issues/new?assignees=&labels=&template=bug_report.md&title=',
+                        'https://github.com/sourcegraph/sourcegraph/issues/new?labels=team/integrations,vscode-extension&title=VSCode+Bug+report:+&projects=Integrations%20Project%20Board',
                         'Issues'
                     )
                 }
@@ -94,7 +95,6 @@ export const HelpSidebarView: React.FunctionComponent<HelpSidebarViewProps> = ({
                 <i className="codicon codicon-account" />
                 <span>Authenticate account</span>
             </button>
-
             {hasAccount && (
                 <div className="ml-3 mt-1">
                     {!authenticatedUser ? (
@@ -111,6 +111,10 @@ export const HelpSidebarView: React.FunctionComponent<HelpSidebarViewProps> = ({
                     )}
                 </div>
             )}
+            <button type="button" className={classNames(styles.itemContainer, 'btn btn-text text-left')}>
+                <i className="codicon codicon-calendar" />
+                <span>Version v{version}</span>
+            </button>
         </div>
     )
 }


### PR DESCRIPTION
This PR closes: 
- https://github.com/sourcegraph/sourcegraph/issues/34630
- https://github.com/sourcegraph/sourcegraph/issues/34713
- https://github.com/sourcegraph/sourcegraph/issues/34729
- https://github.com/sourcegraph/sourcegraph/issues/34731

As reported by a user in https://github.com/sourcegraph/sourcegraph/issues/34630, the "Open file in Sourcegraph Web" option from Windows VSCode fails. 
After looking more into this issue, I can confirm that this issue happens to both "Open file in Sourcegraph Web"  and "Copy link to Sourcegraph" functions when running with local files.

I suspect this is because the file path format on Windows uses `\` which is not supported by any Sourcegraph instances, so when we generate a Sourcegraph URL using the file path retrieved from windows machine, the current implementation would return a sourcegraph url with forward slashes in the file path.

For example,  the copied URL shows`file=schema\bitbucket_cloud.schema.json` from https://sourcegraph.com/-/editor?remote_url=https://github.com/abeatrix/sourcegraph.git&branch=main&file=schema\bitbucket_cloud.schema.json&editor=VSCode&version=2.2.1&start_row=28&start_col=30&end_row=28&end_col=30&utm_campaign=vscode-extension&utm_medium=direct_traffic&utm_source=vscode-extension&utm_content=vsce-commands

As a result, trying to open the link would redirect user to a 404 page because of the file path:
![Image](https://user-images.githubusercontent.com/68532117/166073641-6f2bbeaa-3ad7-43bb-9c12-908c763934cd.png)

Changing the double \\ into / would take me to the correct page:
![Image](https://user-images.githubusercontent.com/68532117/166073799-35e74653-ce9c-48ee-b92b-f511b43a6b8d.png)


A patch release 2.2.2 will be published after this PR is closed.


## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

Package built from this PR fixes all the listed issue.
