### PR TITLE
Reference panel: highlight token in lines

### DIFF
--- a/client/web/src/codeintel/ReferencesPanel.test.tsx
+++ b/client/web/src/codeintel/ReferencesPanel.test.tsx
@@ -91,11 +91,16 @@ describe('ReferencesPanel', () => {
 
         expect(result.getByText('Definitions')).toBeVisible()
 
-        const definitions = ['OrigName string']
+        const definitions = [['', 'string']]
 
         const definitionsList = result.getByTestId('definitions')
         for (const line of definitions) {
-            expect(within(definitionsList).getByText(line)).toBeVisible()
+            for (const surrounding of line) {
+                if (surrounding === '') {
+                    continue
+                }
+                expect(within(definitionsList).getByText(surrounding)).toBeVisible()
+            }
         }
     })
 
@@ -105,14 +110,19 @@ describe('ReferencesPanel', () => {
         expect(result.getByText('References')).toBeVisible()
 
         const references = [
-            'OrigName string',
-            'label = fmt.Sprintf("orig(%s) new(%s)", fdiff.OrigName, fdiff.NewName)',
-            'if err := printFileHeader(&buf, "--- ", d.OrigName, d.OrigTime); err != nil {',
+            ['', 'string'],
+            ['label = fmt.Sprintf("orig(%s) new(%s)", fdiff.', ', fdiff.NewName)'],
+            ['if err := printFileHeader(&buf, "--- ", d.', ', d.OrigTime); err != nil {'],
         ]
 
         const referencesList = result.getByTestId('references')
         for (const line of references) {
-            expect(within(referencesList).getByText(line)).toBeVisible()
+            for (const surrounding of line) {
+                if (surrounding === '') {
+                    continue
+                }
+                expect(within(referencesList).getByText(surrounding)).toBeVisible()
+            }
         }
     })
 

--- a/client/web/src/codeintel/ReferencesPanel.tsx
+++ b/client/web/src/codeintel/ReferencesPanel.tsx
@@ -469,6 +469,10 @@ export const ReferencesList: React.FunctionComponent<
     )
 }
 
+interface SearchTokenProps {
+    searchToken: string
+}
+
 interface CollapseProps {
     isOpen: (id: string) => boolean | undefined
     handleOpenChange: (id: string, isOpen: boolean) => void
@@ -479,7 +483,7 @@ interface ActiveLocationProps {
     setActiveLocation: (reference: Location | undefined) => void
 }
 
-interface CollapsibleLocationListProps extends ActiveLocationProps, CollapseProps {
+interface CollapsibleLocationListProps extends ActiveLocationProps, CollapseProps, SearchTokenProps {
     name: string
     locations: Location[]
     filter: string | undefined
@@ -517,6 +521,7 @@ const CollapsibleLocationList: React.FunctionComponent<CollapsibleLocationListPr
                 <CollapsePanel id={props.name} data-testid={props.name}>
                     {props.locations.length > 0 ? (
                         <LocationsList
+                            searchToken={props.searchToken}
                             locations={props.locations}
                             isActiveLocation={props.isActiveLocation}
                             setActiveLocation={props.setActiveLocation}
@@ -645,7 +650,7 @@ const SideBlob: React.FunctionComponent<
     )
 }
 
-interface LocationsListProps extends ActiveLocationProps, CollapseProps {
+interface LocationsListProps extends ActiveLocationProps, CollapseProps, SearchTokenProps {
     locations: Location[]
     filter: string | undefined
     navigateToUrl: (url: string) => void
@@ -659,6 +664,7 @@ const LocationsList: React.FunctionComponent<LocationsListProps> = ({
     navigateToUrl,
     handleOpenChange,
     isOpen,
+    searchToken,
 }) => {
     const repoLocationGroups = useMemo(() => buildRepoLocationGroups(locations), [locations])
     const openByDefault = repoLocationGroups.length === 1
@@ -668,6 +674,7 @@ const LocationsList: React.FunctionComponent<LocationsListProps> = ({
             {repoLocationGroups.map(group => (
                 <CollapsibleRepoLocationGroup
                     key={group.repoName}
+                    searchToken={searchToken}
                     repoLocationGroup={group}
                     openByDefault={openByDefault}
                     isActiveLocation={isActiveLocation}
@@ -684,7 +691,8 @@ const LocationsList: React.FunctionComponent<LocationsListProps> = ({
 
 const CollapsibleRepoLocationGroup: React.FunctionComponent<
     ActiveLocationProps &
-        CollapseProps & {
+        CollapseProps &
+        SearchTokenProps & {
             filter: string | undefined
             navigateToUrl: (url: string) => void
             repoLocationGroup: RepoLocationGroup
@@ -699,6 +707,7 @@ const CollapsibleRepoLocationGroup: React.FunctionComponent<
     openByDefault,
     isOpen,
     handleOpenChange,
+    searchToken,
 }) => {
     const repoUrl = `/${repoLocationGroup.repoName}`
     const open = isOpen(repoLocationGroup.repoName) ?? openByDefault
@@ -735,6 +744,7 @@ const CollapsibleRepoLocationGroup: React.FunctionComponent<
                     {repoLocationGroup.referenceGroups.map(group => (
                         <CollapsibleLocationGroup
                             key={group.path + group.repoName}
+                            searchToken={searchToken}
                             group={group}
                             isActiveLocation={isActiveLocation}
                             setActiveLocation={setActiveLocation}
@@ -751,11 +761,12 @@ const CollapsibleRepoLocationGroup: React.FunctionComponent<
 
 const CollapsibleLocationGroup: React.FunctionComponent<
     ActiveLocationProps &
-        CollapseProps & {
+        CollapseProps &
+        SearchTokenProps & {
             group: LocationGroup
             filter: string | undefined
         }
-> = ({ group, setActiveLocation, isActiveLocation, filter, isOpen, handleOpenChange }) => {
+> = ({ group, setActiveLocation, isActiveLocation, filter, isOpen, handleOpenChange, searchToken }) => {
     let highlighted = [group.path]
     if (filter !== undefined) {
         highlighted = group.path.split(filter)
@@ -804,6 +815,29 @@ const CollapsibleLocationGroup: React.FunctionComponent<
                         {group.locations.map(reference => {
                             const className = isActiveLocation(reference) ? styles.locationActive : ''
 
+                            const locationLine = getPrePostLineContent(reference)
+                            const lineWithHighlightedToken = locationLine.prePostToken ? (
+                                <>
+                                    {locationLine.prePostToken.pre === '' ? (
+                                        <></>
+                                    ) : (
+                                        <code>{locationLine.prePostToken.pre}</code>
+                                    )}
+                                    <span className="selection-highlight sourcegraph-document-highlight">
+                                        <code>{searchToken}</code>
+                                    </span>
+                                    {locationLine.prePostToken.post === '' ? (
+                                        <></>
+                                    ) : (
+                                        <code>{locationLine.prePostToken.post}</code>
+                                    )}
+                                </>
+                            ) : locationLine.line ? (
+                                <code>{locationLine.line}</code>
+                            ) : (
+                                ''
+                            )
+
                             return (
                                 <li
                                     key={reference.url}
@@ -822,7 +856,7 @@ const CollapsibleLocationGroup: React.FunctionComponent<
                                             {(reference.range?.start?.line ?? 0) + 1}
                                             {': '}
                                         </span>
-                                        <code>{getLineContent(reference)}</code>
+                                        {lineWithHighlightedToken}
                                     </Link>
                                 </li>
                             )
@@ -834,12 +868,31 @@ const CollapsibleLocationGroup: React.FunctionComponent<
     )
 }
 
-const getLineContent = (location: Location): string => {
+interface LocationLine {
+    prePostToken?: { pre: string; post: string }
+    line?: string
+}
+
+const getPrePostLineContent = (location: Location): LocationLine => {
     const range = location.range
     if (range !== undefined) {
-        return location.lines[range.start?.line].trim()
+        const line = location.lines[range.start.line]
+
+        if (range.end.line === range.start.line) {
+            return {
+                prePostToken: {
+                    pre: line.slice(0, range.start.character).trim(),
+                    post: line.slice(range.end.character),
+                },
+                line: line.trim(),
+            }
+        }
+        return {
+            prePostToken: { pre: line.slice(0, range.start.character).trim(), post: '' },
+            line: line.trim(),
+        }
     }
-    return ''
+    return {}
 }
 
 const LoadingCodeIntel: React.FunctionComponent<{}> = () => (

--- a/client/web/src/codeintel/ReferencesPanel.tsx
+++ b/client/web/src/codeintel/ReferencesPanel.tsx
@@ -823,9 +823,9 @@ const CollapsibleLocationGroup: React.FunctionComponent<
                                     ) : (
                                         <code>{locationLine.prePostToken.pre}</code>
                                     )}
-                                    <span className="selection-highlight sourcegraph-document-highlight">
+                                    <mark className="p-0 selection-highlight sourcegraph-document-highlight">
                                         <code>{searchToken}</code>
-                                    </span>
+                                    </mark>
                                     {locationLine.prePostToken.post === '' ? (
                                         <></>
                                     ) : (
@@ -881,15 +881,15 @@ const getPrePostLineContent = (location: Location): LocationLine => {
         if (range.end.line === range.start.line) {
             return {
                 prePostToken: {
-                    pre: line.slice(0, range.start.character).trim(),
+                    pre: line.slice(0, range.start.character).trimStart(),
                     post: line.slice(range.end.character),
                 },
-                line: line.trim(),
+                line: line.trimStart(),
             }
         }
         return {
             prePostToken: { pre: line.slice(0, range.start.character).trim(), post: '' },
-            line: line.trim(),
+            line: line.trimStart(),
         }
     }
     return {}


### PR DESCRIPTION
This highlights the token in the results of the reference panel

![screenshot_2022-05-02_10 31 49@2x](https://user-images.githubusercontent.com/1185253/166206793-d7344e1f-6958-40e6-b46f-df08a824d0bf.png)


This is the outcome of [this discussion in Slack](https://sourcegraph.slack.com/archives/CHXHX7XAS/p1651179539693929) in which @rrhyne and @jjinnii OK'd this approach.

## Test plan

- Existing tests
- Tested manually


## App preview:

- [Web](https://sg-web-mrn-highlight-token.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-idkmiotbjt.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

