### PR TITLE
Pin protobuf-codegen version to 2.X

### DIFF
--- a/dev/proto-generate.sh
+++ b/dev/proto-generate.sh
@@ -9,7 +9,7 @@ echo "--- yarn in root"
 yarn --mutex network --frozen-lockfile --network-timeout 60000
 
 echo "--- cargo install rust-protobuf"
-which ./.bin/bin/protoc-gen-rust || cargo install --root .bin protobuf-codegen
+which ./.bin/bin/protoc-gen-rust || cargo install --root .bin protobuf-codegen --version v2.27.1
 
 echo "--- buf"
 

--- a/dev/proto-generate.sh
+++ b/dev/proto-generate.sh
@@ -9,7 +9,7 @@ echo "--- yarn in root"
 yarn --mutex network --frozen-lockfile --network-timeout 60000
 
 echo "--- cargo install rust-protobuf"
-which ./.bin/bin/protoc-gen-rust || cargo install --root .bin protobuf-codegen --version v2.27.1
+which ./.bin/bin/protoc-gen-rust || cargo install --root .bin protobuf-codegen --version 2.27.1
 
 echo "--- buf"
 


### PR DESCRIPTION
The latest release from today, 3.X breaks on dependencies issues.

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

Green build. 