### PR TITLE
Enable new reference panel & code intel badge in dev env

### DIFF
--- a/dev/global-settings.json
+++ b/dev/global-settings.json
@@ -4,7 +4,9 @@
     "showRepogroupHomepage": true,
     "showMultilineSearchConsole": true,
     "codeMonitoring": true,
-    "codeInsights": true
+    "codeInsights": true,
+    "codeIntelRepositoryBadge": {"enabled": true},
+    "coolCodeIntel": true
   },
   "insights": [
     {

--- a/dev/global-settings.json
+++ b/dev/global-settings.json
@@ -5,7 +5,7 @@
     "showMultilineSearchConsole": true,
     "codeMonitoring": true,
     "codeInsights": true,
-    "codeIntelRepositoryBadge": {"enabled": true},
+    "codeIntelRepositoryBadge": { "enabled": true },
     "coolCodeIntel": true
   },
   "insights": [


### PR DESCRIPTION
This changes the default settings used in our dev env to enable the new reference panel and the code intel badge.

## Test plan

- Existing tests


