### PR TITLE
Wildcard Tabs: support longTabList property to make it scrollable

### DIFF
--- a/client/wildcard/src/components/Tabs/Tabs.module.scss
+++ b/client/wildcard/src/components/Tabs/Tabs.module.scss
@@ -61,6 +61,10 @@
         }
     }
 
+    .tab-nowrap {
+        white-space: nowrap;
+    }
+
     [data-reach-tab-list] {
         background: transparent;
     }
@@ -77,6 +81,11 @@
         display: flex;
         flex-wrap: wrap;
         gap: 0.75rem;
+    }
+
+    .tab-list-scroll {
+        flex-wrap: nowrap;
+        overflow-y: scroll;
     }
 
     .small {

--- a/client/wildcard/src/components/Tabs/Tabs.story.tsx
+++ b/client/wildcard/src/components/Tabs/Tabs.story.tsx
@@ -8,19 +8,19 @@ import { Tabs, Tab, TabList, TabPanel, TabPanels, TabsProps } from '.'
 export const TabsStory: Story<TabsProps & { actions: boolean }> = args => {
     usePrependStyles('branded-story-styles', brandedStyles)
 
-    const { actions, lazy, behavior, size, ...props } = args
-
     return (
-        <Tabs lazy={lazy} behavior={behavior} size={size} {...props}>
-            <TabList actions={actions ? <div>custom component rendered</div> : null}>
-                <Tab>Tab 1</Tab>
-                <Tab>Tab 2</Tab>
-            </TabList>
-            <TabPanels>
-                <TabPanel>Panel 1</TabPanel>
-                <TabPanel>Panel 2</TabPanel>
-            </TabPanels>
-        </Tabs>
+        <>
+            <h1>Tabs</h1>
+            <Container title="Standard">
+                <TabsVariant {...args} />
+            </Container>
+            <Container width={300} title="Limited width">
+                <TabsVariant {...args} />
+            </Container>
+            <Container width={300} title="Scrolled tab list">
+                <TabsVariant {...args} longTabList="scroll" />
+            </Container>
+        </>
     )
 }
 
@@ -67,5 +67,36 @@ const config: Meta = {
         },
     },
 }
+
+const TabsVariant: Story<TabsProps & { actions: boolean }> = args => {
+    const { actions, lazy, behavior, size, ...props } = args
+    return (
+        <Tabs lazy={lazy} behavior={behavior} size={size} {...props}>
+            <TabList actions={actions ? <div>custom component rendered</div> : null}>
+                <Tab>Tab 1</Tab>
+                <Tab>Tab 2</Tab>
+                <Tab>Third tab</Tab>
+                <Tab>Fourth tab</Tab>
+                <Tab>Fifth tab</Tab>
+                <Tab>Sixth tab</Tab>
+            </TabList>
+            <TabPanels>
+                <TabPanel>Panel 1</TabPanel>
+                <TabPanel>Panel 2</TabPanel>
+                <TabPanel>Panel 3</TabPanel>
+                <TabPanel>Panel 4</TabPanel>
+                <TabPanel>Panel 5</TabPanel>
+                <TabPanel>Panel 6</TabPanel>
+            </TabPanels>
+        </Tabs>
+    )
+}
+
+const Container: React.FunctionComponent<{ title: string; width?: number }> = ({ title, width, children }) => (
+    <>
+        <h2 style={{ margin: '30px 0 10px 0' }}>{title}</h2>
+        <div style={{ width: width ? `${width}px` : undefined }}>{children}</div>
+    </>
+)
 
 export default config

--- a/client/wildcard/src/components/Tabs/Tabs.tsx
+++ b/client/wildcard/src/components/Tabs/Tabs.tsx
@@ -110,11 +110,7 @@ export const TabList = React.forwardRef((props, reference) => {
                 data-testid="wildcard-tab-list"
                 as={as}
                 ref={reference}
-                className={classNames(
-                    className,
-                    styles.tabList,
-                    longTabList === 'scroll' ? styles.tabListScroll : undefined
-                )}
+                className={classNames(className, styles.tabList, longTabList === 'scroll' && styles.tabListScroll)}
                 {...reachProps}
             />
             {actions}
@@ -129,7 +125,7 @@ export const Tab = React.forwardRef((props, reference) => {
 
     return (
         <ReachTab
-            className={classNames(styles[size], longTabList === 'scroll' ? styles.tabNowrap : undefined)}
+            className={classNames(styles[size], longTabList === 'scroll' && styles.tabNowrap)}
             data-testid="wildcard-tab"
             as={as}
             ref={reference}

--- a/client/wildcard/src/components/Tabs/Tabs.tsx
+++ b/client/wildcard/src/components/Tabs/Tabs.tsx
@@ -44,6 +44,12 @@ export interface TabsSettings {
      * Default is "forceRender"
      */
     behavior?: 'memoize' | 'forceRender'
+
+    /**
+     * Controls the behavior in case tab list doesn't fit into a container.
+     * Default is "wrap"
+     */
+    longTabList?: 'wrap' | 'scroll'
 }
 
 export interface TabsProps extends ReachTabsProps, TabsSettings {
@@ -72,9 +78,17 @@ export interface TabPanelProps extends ReachTabPanelProps {}
  * See: https://reach.tech/tabs/
  */
 export const Tabs = React.forwardRef((props, reference) => {
-    const { lazy = false, size, behavior = 'forceRender', className, as = 'div', ...reachProps } = props
+    const {
+        lazy = false,
+        size = 'small',
+        behavior = 'forceRender',
+        className,
+        as = 'div',
+        longTabList = 'wrap',
+        ...reachProps
+    } = props
     return (
-        <TabsSettingsContext.Provider value={{ lazy, size, behavior }}>
+        <TabsSettingsContext.Provider value={{ lazy, size, behavior, longTabList }}>
             <ReachTabs
                 className={classNames(styles.wildcardTabs, className)}
                 data-testid="wildcard-tabs"
@@ -88,13 +102,19 @@ export const Tabs = React.forwardRef((props, reference) => {
 
 export const TabList = React.forwardRef((props, reference) => {
     const { actions, as = 'div', wrapperClassName, className, ...reachProps } = props
+    const { longTabList } = useTabsSettings()
+
     return (
         <div className={classNames(styles.tablistWrapper, wrapperClassName)}>
             <ReachTabList
                 data-testid="wildcard-tab-list"
                 as={as}
                 ref={reference}
-                className={classNames(className, styles.tabList)}
+                className={classNames(
+                    className,
+                    styles.tabList,
+                    longTabList === 'scroll' ? styles.tabListScroll : undefined
+                )}
                 {...reachProps}
             />
             {actions}
@@ -104,9 +124,17 @@ export const TabList = React.forwardRef((props, reference) => {
 
 export const Tab = React.forwardRef((props, reference) => {
     const { as = 'button', ...reachProps } = props
-    const { size = 'small' } = useTabsSettings()
+    const { size } = useTabsSettings()
+    const { longTabList } = useTabsSettings()
+
     return (
-        <ReachTab className={styles[size]} data-testid="wildcard-tab" as={as} ref={reference} {...reachProps}>
+        <ReachTab
+            className={classNames(styles[size], longTabList === 'scroll' ? styles.tabNowrap : undefined)}
+            data-testid="wildcard-tab"
+            as={as}
+            ref={reference}
+            {...reachProps}
+        >
             <span className={styles.tabLabel}>{props.children}</span>
         </ReachTab>
     )

--- a/client/wildcard/src/components/Tabs/context.ts
+++ b/client/wildcard/src/components/Tabs/context.ts
@@ -2,15 +2,14 @@ import React from 'react'
 
 import { TabsSettings } from '.'
 
-export const TabsSettingsContext = React.createContext<TabsSettings | null>(null)
+export const TabsSettingsContext = React.createContext<Required<TabsSettings> | null>(null)
 TabsSettingsContext.displayName = 'TabsSettingsContext'
 
-export const useTabsSettings = (): TabsSettings => {
+export const useTabsSettings = (): Required<TabsSettings> => {
     const context = React.useContext(TabsSettingsContext)
     if (!context) {
         throw new Error('useTabsSettingsContext or Tabs inner components cannot be used outside <Tabs> sub-tree')
     }
-
     return context
 }
 


### PR DESCRIPTION
## Problem
Based on @eseliger's report, Tab List (toggles) may contain too many elements that are wrapped onto a new line, which isn't what's sometimes expected - and doesn't look good too. 

<img width="320" alt="Screenshot 2022-05-02 at 13 46 11" src="https://user-images.githubusercontent.com/2196347/166222620-4d1ac5f0-6652-436e-acf9-1dd6ff8ae7d1.png">

## Solution
Add a `longTabList` property with two possible values - `wrap` (default) and `scroll`, which toggles native horizontal scrolling for long tab lists.


https://user-images.githubusercontent.com/2196347/166222892-8e67ced3-999d-4321-890d-383260d139b7.mov

### Scroll bar size issues
The scroll bar is fairly thick and blocks access to content.
@AlicjaSuska wdyt we should do with that? I can try customizing its height, although it won't be "standard" anymore, or maybe increasing padding so that tab bottom borders aren't obscured by the scroll bar.

## Test plan
1. Check out the branch
2. Open storybook `yarn storybook:wildcard`
3. Check that tabs behave as described

## App preview:

- [Web](https://sg-web-og-tabs-scroll.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-uptooykrci.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
