### PR TITLE
Search backend: simplify `ToEvaluateJob`

### DIFF
--- a/internal/search/commit/commit_test.go
+++ b/internal/search/commit/commit_test.go
@@ -17,23 +17,23 @@ import (
 func TestQueryToGitQuery(t *testing.T) {
 	type testCase struct {
 		name   string
-		input  query.Q
+		input  query.Basic
 		diff   bool
 		output protocol.Node
 	}
 
 	cases := []testCase{{
 		name: "negated repo does not result in nil node (#26032)",
-		input: []query.Node{
-			query.Parameter{Field: query.FieldRepo, Negated: true},
+		input: query.Basic{
+			Parameters: []query.Parameter{{Field: query.FieldRepo, Negated: true}},
 		},
 		diff:   false,
 		output: &protocol.Boolean{Value: true},
 	}, {
 		name: "expensive nodes are placed last",
-		input: []query.Node{
-			query.Pattern{Value: "a"},
-			query.Parameter{Field: query.FieldAuthor, Value: "b"},
+		input: query.Basic{
+			Parameters: []query.Parameter{{Field: query.FieldAuthor, Value: "b"}},
+			Pattern:    query.Pattern{Value: "a"},
 		},
 		diff: true,
 		output: protocol.NewAnd(
@@ -42,14 +42,16 @@ func TestQueryToGitQuery(t *testing.T) {
 		),
 	}, {
 		name: "all supported nodes are converted",
-		input: []query.Node{
-			query.Parameter{Field: query.FieldAuthor, Value: "author"},
-			query.Parameter{Field: query.FieldCommitter, Value: "committer"},
-			query.Parameter{Field: query.FieldBefore, Value: "2021-09-10"},
-			query.Parameter{Field: query.FieldAfter, Value: "2021-09-08"},
-			query.Parameter{Field: query.FieldFile, Value: "file"},
-			query.Parameter{Field: query.FieldMessage, Value: "message1"},
-			query.Pattern{Value: "message2"},
+		input: query.Basic{
+			Parameters: []query.Parameter{
+				{Field: query.FieldAuthor, Value: "author"},
+				{Field: query.FieldCommitter, Value: "committer"},
+				{Field: query.FieldBefore, Value: "2021-09-10"},
+				{Field: query.FieldAfter, Value: "2021-09-08"},
+				{Field: query.FieldFile, Value: "file"},
+				{Field: query.FieldMessage, Value: "message1"},
+			},
+			Pattern: query.Pattern{Value: "message2"},
 		},
 		diff: false,
 		output: protocol.NewAnd(

--- a/internal/search/job/jobutil/job.go
+++ b/internal/search/job/jobutil/job.go
@@ -694,20 +694,11 @@ func toPatternExpressionJob(inputs *run.SearchInputs, q query.Basic) (job.Job, e
 }
 
 func ToEvaluateJob(inputs *run.SearchInputs, q query.Basic) (job.Job, error) {
-	var (
-		job job.Job
-		err error
-	)
 	if q.Pattern == nil {
-		job, err = ToSearchJob(inputs, q)
+		return ToSearchJob(inputs, q)
 	} else {
-		job, err = toPatternExpressionJob(inputs, q)
+		return toPatternExpressionJob(inputs, q)
 	}
-	if err != nil {
-		return nil, err
-	}
-
-	return job, nil
 }
 
 // optimizeJobs optimizes a baseJob query with respect to an incoming basic

--- a/internal/search/job/jobutil/job.go
+++ b/internal/search/job/jobutil/job.go
@@ -168,7 +168,7 @@ func ToSearchJob(searchInputs *run.SearchInputs, b query.Basic) (job.Job, error)
 				required = resultTypes.Without(result.TypeCommit) == 0
 			}
 			addJob(required, &commit.CommitSearch{
-				Query:                commit.QueryToGitQuery(b.ToParseTree(), diff),
+				Query:                commit.QueryToGitQuery(b, diff),
 				RepoOpts:             repoOptions,
 				Diff:                 diff,
 				HasTimeFilter:        b.Exists("after") || b.Exists("before"),


### PR DESCRIPTION
Just simplifies the logic of `ToEvaluateJob` to make it easier to read.

Stacked on https://github.com/sourcegraph/sourcegraph/pull/34770

## Test plan

Semantics-preserving.

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


