### PR TITLE
Search backend: introduce `query.Flat`

### DIFF
--- a/internal/search/commit/commit_test.go
+++ b/internal/search/commit/commit_test.go
@@ -17,23 +17,23 @@ import (
 func TestQueryToGitQuery(t *testing.T) {
 	type testCase struct {
 		name   string
-		input  query.Q
+		input  query.Basic
 		diff   bool
 		output protocol.Node
 	}
 
 	cases := []testCase{{
 		name: "negated repo does not result in nil node (#26032)",
-		input: []query.Node{
-			query.Parameter{Field: query.FieldRepo, Negated: true},
+		input: query.Basic{
+			Parameters: []query.Parameter{{Field: query.FieldRepo, Negated: true}},
 		},
 		diff:   false,
 		output: &protocol.Boolean{Value: true},
 	}, {
 		name: "expensive nodes are placed last",
-		input: []query.Node{
-			query.Pattern{Value: "a"},
-			query.Parameter{Field: query.FieldAuthor, Value: "b"},
+		input: query.Basic{
+			Parameters: []query.Parameter{{Field: query.FieldAuthor, Value: "b"}},
+			Pattern:    query.Pattern{Value: "a"},
 		},
 		diff: true,
 		output: protocol.NewAnd(
@@ -42,14 +42,16 @@ func TestQueryToGitQuery(t *testing.T) {
 		),
 	}, {
 		name: "all supported nodes are converted",
-		input: []query.Node{
-			query.Parameter{Field: query.FieldAuthor, Value: "author"},
-			query.Parameter{Field: query.FieldCommitter, Value: "committer"},
-			query.Parameter{Field: query.FieldBefore, Value: "2021-09-10"},
-			query.Parameter{Field: query.FieldAfter, Value: "2021-09-08"},
-			query.Parameter{Field: query.FieldFile, Value: "file"},
-			query.Parameter{Field: query.FieldMessage, Value: "message1"},
-			query.Pattern{Value: "message2"},
+		input: query.Basic{
+			Parameters: []query.Parameter{
+				{Field: query.FieldAuthor, Value: "author"},
+				{Field: query.FieldCommitter, Value: "committer"},
+				{Field: query.FieldBefore, Value: "2021-09-10"},
+				{Field: query.FieldAfter, Value: "2021-09-08"},
+				{Field: query.FieldFile, Value: "file"},
+				{Field: query.FieldMessage, Value: "message1"},
+			},
+			Pattern: query.Pattern{Value: "message2"},
 		},
 		diff: false,
 		output: protocol.NewAnd(

--- a/internal/search/job/jobutil/job.go
+++ b/internal/search/job/jobutil/job.go
@@ -694,20 +694,11 @@ func toPatternExpressionJob(inputs *run.SearchInputs, q query.Basic) (job.Job, e
 }
 
 func ToEvaluateJob(inputs *run.SearchInputs, q query.Basic) (job.Job, error) {
-	var (
-		job job.Job
-		err error
-	)
 	if q.Pattern == nil {
-		job, err = ToSearchJob(inputs, q)
+		return ToSearchJob(inputs, q)
 	} else {
-		job, err = toPatternExpressionJob(inputs, q)
+		return toPatternExpressionJob(inputs, q)
 	}
-	if err != nil {
-		return nil, err
-	}
-
-	return job, nil
 }
 
 // optimizeJobs optimizes a baseJob query with respect to an incoming basic

--- a/internal/search/job/jobutil/job.go
+++ b/internal/search/job/jobutil/job.go
@@ -168,7 +168,7 @@ func ToSearchJob(searchInputs *run.SearchInputs, b query.Basic) (job.Job, error)
 				required = resultTypes.Without(result.TypeCommit) == 0
 			}
 			addJob(required, &commit.CommitSearch{
-				Query:                commit.QueryToGitQuery(b.ToParseTree(), diff),
+				Query:                commit.QueryToGitQuery(b, diff),
 				RepoOpts:             repoOptions,
 				Diff:                 diff,
 				HasTimeFilter:        b.Exists("after") || b.Exists("before"),

--- a/internal/search/query/types.go
+++ b/internal/search/query/types.go
@@ -68,8 +68,8 @@ func (p Plan) ToParseTree() Q {
 //   (2) parameters that scope the evaluation of search
 //       patterns (e.g., to repos, files, etc.).
 type Basic struct {
-	Pattern    Node
-	Parameters []Parameter
+	Parameters
+	Pattern Node
 }
 
 func (b Basic) ToParseTree() Q {
@@ -164,6 +164,8 @@ func (b Basic) IsEmptyPattern() bool {
 	}
 	return false
 }
+
+type Parameters []Parameter
 
 // IncludeExcludeValues partitions multiple values of a field into positive
 // (include) and negated (exclude) values.
@@ -269,7 +271,6 @@ func (b Basic) Visibility() RepoVisibility {
 	visibilityStr := b.FindValue(FieldVisibility)
 	return ParseVisibility(visibilityStr)
 }
-
 
 // FindValue returns the first value of a parameter matching field in b. It
 // doesn't inspect whether the field is negated.


### PR DESCRIPTION
Stacked on https://github.com/sourcegraph/sourcegraph/pull/34771

Currently, we have two query types in the backend: 
- `query.Q` represents the full tree structure of a query
- `query.Basic` restricts tree structure to only the pattern nodes

We split a `query.Q` into a set of `query.Basic` so that we can query
backends that don't support full tree-shaped queries. 

However, we also have an implicit third type, which I'm calling `query.Flat`. 
A `query.Flat` has a flat list of parameters and zero or one pattern nodes.
Stated differently, `query.Flat` is the subset of `query.Basic` that has no
`and` or `or` expressions in the pattern node.

There is a certain point in our job planning where the meaning of `query.Basic`
shifts from "the only and/or expressions are in the pattern node" to "there
are no and/or expressions anywhere in the query." In particular, `ToTextPatternInfo`
requires that the basic query passed to it is a `query.Flat`. If this is not the
case, it will just silently fail to generate a valid `PatternInfo`. However, during
the `optimize` step of our job generation, we violate this expectation by passing
in a tree-shaped `query.Basic` in `ToSearchJob`. This turns out okay because we
end up throwing away any jobs that depend on the broken parts of `TextPatternInfo`,
but it leads to a very confusing flow of information.

This PR introduces `query.Flat` to enforce the flat query shape with our type
system. It does this in four steps (represented by the four commits in this PR).
- Reorganize methods on `query.Basic` so that all the methods that depend on just the parameters are grouped together
- Create a new `Parameters` type that is embedded in `query.Basic`
- Move relevant methods from `query.Basic` to `query.Parameters`
- Mint `query.Flat`, which embeds `query.Parameters`, allowing it to expose all those methods without duplication.

This allows us to continue using `query.Basic` as we were before (all the methods 
moved to `Parameters` are available through `query.Basic` because `Parameters` is embedded).

<details>
<summary><strong>Proposed next steps:</strong></summary>
The first thing I'd like to do with this is to make the contract of `toTextParameters` and `ToSearchJob` more explicit. This is not currently possible because, even though parts of those methods depend on the query being a `query.Flat`, we use them with tree-structured `query.Basic` to generate optimized queries as well, and just throw away the non-optimized parts.

So, in order to actually make that possible, I think we also need to shift how we're doing query optimization a bit. I think it would probably be more clear if we generate jobs in a two-step process:
1) For each basic query in `Plan`, generate jobs for backends that can use a `query.Basic` directly. This will be commit search and zoekt jobs. 
2) Decompose `query.Basic` into a set of `query.Flat` wrapped in `AndJob` and `OrJob`, then generate jobs for backends that require a flat query. 

I think this is considerably easier to follow than the current paradigm of:
1) generate all jobs from `query.Flat` composed with `AndJob` and `OrJob`
2) generate optimized jobs and replace the unoptimized jobs with `NoopJob`. 
</details>

## Test plan

Should be semantics-preserving. Depending on tests to catch any typos.

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


