### PR TITLE
JetBrains: Add minimal strategy to load file content

### DIFF
--- a/client/jetbrains/webview/src/search/index.tsx
+++ b/client/jetbrains/webview/src/search/index.tsx
@@ -4,6 +4,7 @@ import { ContentMatch } from '@sourcegraph/shared/src/search/stream'
 import { setLinkComponent, AnchorLink } from '@sourcegraph/wildcard'
 
 import { App } from './App'
+import { loadContent } from './lib/blob'
 import { callJava } from './mockJavaInterface'
 
 setLinkComponent(AnchorLink)
@@ -21,21 +22,16 @@ declare global {
     }
 }
 
-// @TODO: We need a mechanism for fetching the whole file for the follwoing two functions and make
-// sure to cache the result (so that any given file is only ever downloaded once). A simple Map
-// should do the trick.
-//
-// When we have this, these callbacks should just link through to our Java bridge.
-function onOpen(match: ContentMatch, lineIndex: number): void {
-    const line = match.lineMatches[lineIndex]
-    console.log('open', match, line)
+async function onOpen(match: ContentMatch, lineIndex: number): Promise<void> {
+    console.log('open', await loadContent(match), match.lineMatches[lineIndex])
 }
-function onPreviewChange(match: ContentMatch, lineIndex: number): void {
-    const line = match.lineMatches[lineIndex]
-    console.log('preview', match, line)
+
+async function onPreviewChange(match: ContentMatch, lineIndex: number): Promise<void> {
+    console.log('preview', await loadContent(match), match.lineMatches[lineIndex])
 }
+
 function onPreviewClear(): void {
-    // nothing
+    console.log('clear preview')
 }
 
 function renderReactApp(): void {

--- a/client/jetbrains/webview/src/search/lib/blob.ts
+++ b/client/jetbrains/webview/src/search/lib/blob.ts
@@ -1,0 +1,45 @@
+const cachedContentRequests = new Map<string, Promise<string>>()
+
+import { ContentMatch } from '@sourcegraph/shared/src/search/stream'
+
+import { getIdForMatch } from '../results/utils'
+
+export async function loadContent(match: ContentMatch): Promise<string> {
+    const cacheKey = getIdForMatch(match)
+
+    if (cachedContentRequests.has(cacheKey)) {
+        return cachedContentRequests.get(cacheKey) as Promise<string>
+    }
+
+    const loadPromise = fetchBlobContent(match)
+    cachedContentRequests.set(cacheKey, loadPromise)
+
+    return loadPromise
+}
+
+async function fetchBlobContent(match: ContentMatch): Promise<string> {
+    console.log('Starting request for', getIdForMatch(match))
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-explicit-any
+    const response: any = await fetch('https://sourcegraph.com/.api/graphql', {
+        method: 'post',
+        body: JSON.stringify({
+            query: `
+                query Blob($repoName: String!, $commitID: String!, $filePath: String!) {
+                    repository(name: $repoName) {
+                        commit(rev: $commitID) {
+                            file(path: $filePath) {
+                                content
+                            }
+                        }
+                    }
+                }`,
+            variables: {
+                commitID: match.commit,
+                filePath: match.path,
+                repoName: match.repository,
+            },
+        }),
+    }).then(response => response.json())
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-member-access
+    return response.data.repository.commit.file.content
+}


### PR DESCRIPTION
Part of #34368

We need a way to load search match file contents. To be efficient, we also want to only load every file only once (otherwise scrolling though a list of multiple results in a single file would cause unnecessary loading indicators).

This data in combination with the matched line information can now be sent over to Java to render the preview dialog

## Test plan

Manually verified the console output: 

![Screenshot 2022-05-02 at 16 25 32](https://user-images.githubusercontent.com/458591/166251069-49b9cf32-fe81-49ee-87ef-33ed4d251e64.png)


<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->



## App preview:

- [Web](https://sg-web-ps-jetbrains-load-data.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-gxokmjnbvl.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
