### PR TITLE
Code Insights: [FE] Add scaffolding for the insight standalone page

### DIFF
--- a/client/web/src/enterprise/insights/CodeInsightsRouter.tsx
+++ b/client/web/src/enterprise/insights/CodeInsightsRouter.tsx
@@ -39,10 +39,7 @@ export const CodeInsightsRouter: React.FunctionComponent<CodeInsightsRouterProps
     return (
         <CodeInsightsBackendContext.Provider value={api}>
             {props.isSourcegraphDotCom ? (
-                <CodeInsightsDotComGetStartedLazy
-                    settingsCascade={props.settingsCascade}
-                    telemetryService={props.telemetryService}
-                />
+                <CodeInsightsDotComGetStartedLazy telemetryService={props.telemetryService} />
             ) : (
                 <CodeInsightsAppLazyRouter {...props} />
             )}

--- a/client/web/src/enterprise/insights/CodeInsightsRouter.tsx
+++ b/client/web/src/enterprise/insights/CodeInsightsRouter.tsx
@@ -1,7 +1,5 @@
 import React from 'react'
 
-import { Settings } from '@sourcegraph/shared/src/schema/settings.schema'
-import { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { lazyComponent } from '@sourcegraph/shared/src/util/lazyComponent'
 
@@ -22,7 +20,7 @@ const CodeInsightsDotComGetStartedLazy = lazyComponent(
  * Because we need to pass all required prop from main Sourcegraph.tsx component to
  * subcomponents withing app tree.
  */
-export interface CodeInsightsRouterProps extends SettingsCascadeProps<Settings>, TelemetryProps {
+export interface CodeInsightsRouterProps extends TelemetryProps {
     /**
      * Authenticated user info, Used to decide where code insight will appear
      * in personal dashboard (private) or in organisation dashboard (public)

--- a/client/web/src/enterprise/insights/components/insights-view-grid/SmartInsightsViewGrid.story.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/SmartInsightsViewGrid.story.tsx
@@ -573,10 +573,6 @@ const codeInsightsApiWithManyLines = {
 
 export const SmartInsightsViewGridExample = (): JSX.Element => (
     <CodeInsightsBackendStoryMock mocks={codeInsightsApiWithManyLines}>
-        <SmartInsightsViewGrid
-            settingsCascade={{ final: null, subjects: null }}
-            insights={insightsWithManyLines}
-            telemetryService={NOOP_TELEMETRY_SERVICE}
-        />
+        <SmartInsightsViewGrid insights={insightsWithManyLines} telemetryService={NOOP_TELEMETRY_SERVICE} />
     </CodeInsightsBackendStoryMock>
 )

--- a/client/web/src/enterprise/insights/components/insights-view-grid/SmartInsightsViewGrid.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/SmartInsightsViewGrid.tsx
@@ -3,8 +3,6 @@ import React, { memo, useCallback, useEffect, useState } from 'react'
 import { isEqual } from 'lodash'
 import { Layout, Layouts } from 'react-grid-layout'
 
-import { Settings } from '@sourcegraph/shared/src/schema/settings.schema'
-import { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 
 import { ViewGrid } from '../../../../views'
@@ -14,7 +12,7 @@ import { getTrackingTypeByInsightType } from '../../pings'
 import { SmartInsight } from './components/SmartInsight'
 import { insightLayoutGenerator, recalculateGridLayout } from './utils/grid-layout-generator'
 
-interface SmartInsightsViewGridProps extends TelemetryProps, SettingsCascadeProps<Settings> {
+interface SmartInsightsViewGridProps extends TelemetryProps {
     /**
      * List of built-in insights such as backend insight, FE search and code-stats
      * insights.
@@ -84,7 +82,6 @@ export const SmartInsightsViewGrid: React.FunctionComponent<SmartInsightsViewGri
         >
             {insights.map(insight => (
                 <SmartInsight
-                    settingsCascade={props.settingsCascade}
                     key={insight.id}
                     insight={insight}
                     telemetryService={telemetryService}

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/BuiltInInsight.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/BuiltInInsight.tsx
@@ -3,8 +3,6 @@ import React, { Ref, useContext, useMemo, useRef, useState } from 'react'
 import { useMergeRefs } from 'use-callback-ref'
 
 import { ErrorAlert } from '@sourcegraph/branded/src/components/alerts'
-import { Settings } from '@sourcegraph/shared/src/schema/settings.schema'
-import { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { useDeepMemo } from '@sourcegraph/wildcard'
 
@@ -31,10 +29,7 @@ import { useInsightData } from '../hooks/use-insight-data'
 import { InsightContextMenu } from './insight-context-menu/InsightContextMenu'
 import { InsightContext } from './InsightContext'
 
-interface BuiltInInsightProps
-    extends TelemetryProps,
-        SettingsCascadeProps<Settings>,
-        React.HTMLAttributes<HTMLElement> {
+interface BuiltInInsightProps extends TelemetryProps, React.HTMLAttributes<HTMLElement> {
     insight: SearchRuntimeBasedInsight | LangStatsInsight
     innerRef: Ref<HTMLElement>
     resizing: boolean
@@ -84,7 +79,6 @@ export function BuiltInInsight(props: BuiltInInsightProps): React.ReactElement {
             <InsightCardHeader title={insight.title}>
                 {isVisible && (
                     <InsightContextMenu
-                        settingsCascade={props.settingsCascade}
                         insight={insight}
                         dashboard={dashboard}
                         menuButtonClassName="ml-1 d-inline-flex"

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/SmartInsight.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/SmartInsight.tsx
@@ -1,7 +1,5 @@
 import React, { forwardRef } from 'react'
 
-import { Settings } from '@sourcegraph/shared/src/schema/settings.schema'
-import { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 
 import { Insight, isBackendInsight } from '../../../core'
@@ -9,10 +7,7 @@ import { Insight, isBackendInsight } from '../../../core'
 import { BackendInsightView } from './backend-insight/BackendInsight'
 import { BuiltInInsight } from './BuiltInInsight'
 
-export interface SmartInsightProps
-    extends TelemetryProps,
-        SettingsCascadeProps<Settings>,
-        React.HTMLAttributes<HTMLElement> {
+export interface SmartInsightProps extends TelemetryProps, React.HTMLAttributes<HTMLElement> {
     insight: Insight
     resizing?: boolean
 }

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/BackendInsight.story.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/BackendInsight.story.tsx
@@ -132,7 +132,6 @@ const TestBackendInsight: React.FunctionComponent = () => (
         insight={INSIGHT_CONFIGURATION_MOCK}
         telemetryService={NOOP_TELEMETRY_SERVICE}
         innerRef={() => {}}
-        settingsCascade={{ final: null, subjects: null }}
     />
 )
 
@@ -172,7 +171,6 @@ export const BackendInsight: Story = () => (
             <h2>Locked Card insight</h2>
             <CodeInsightsBackendStoryMock mocks={mockInsightAPI()}>
                 <BackendInsightView
-                    settingsCascade={{ final: null, subjects: null }}
                     style={{ width: 400, height: 400 }}
                     insight={{ ...INSIGHT_CONFIGURATION_MOCK, isFrozen: true }}
                     telemetryService={NOOP_TELEMETRY_SERVICE}

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/BackendInsight.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/BackendInsight.tsx
@@ -4,8 +4,6 @@ import classNames from 'classnames'
 import { useMergeRefs } from 'use-callback-ref'
 
 import { asError } from '@sourcegraph/common'
-import { Settings } from '@sourcegraph/shared/src/schema/settings.schema'
-import { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { useDebounce, useDeepMemo } from '@sourcegraph/wildcard'
 
@@ -29,7 +27,6 @@ import styles from './BackendInsight.module.scss'
 
 interface BackendInsightProps
     extends TelemetryProps,
-        SettingsCascadeProps<Settings>,
         React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement> {
     insight: BackendInsight
 
@@ -155,7 +152,6 @@ export const BackendInsightView: React.FunctionComponent<BackendInsightProps> = 
                             onVisibilityChange={setIsFiltersOpen}
                         />
                         <InsightContextMenu
-                            settingsCascade={props.settingsCascade}
                             insight={insight}
                             dashboard={dashboard}
                             menuButtonClassName="ml-1 d-inline-flex"

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/insight-context-menu/InsightContextMenu.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/insight-context-menu/InsightContextMenu.tsx
@@ -4,9 +4,6 @@ import classNames from 'classnames'
 import { noop } from 'lodash'
 import DotsVerticalIcon from 'mdi-react/DotsVerticalIcon'
 
-import { isErrorLike } from '@sourcegraph/common'
-import { Settings } from '@sourcegraph/shared/src/schema/settings.schema'
-import { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
 import {
     Link,
     Menu,
@@ -19,6 +16,7 @@ import {
     Checkbox,
 } from '@sourcegraph/wildcard'
 
+import { useExperimentalFeatures } from '../../../../../../stores'
 import { Insight, InsightDashboard, InsightType, isVirtualDashboard } from '../../../../core'
 import { useUiFeatures } from '../../../../hooks/use-ui-features'
 
@@ -27,7 +25,7 @@ import { ConfirmRemoveModal } from './ConfirmRemoveModal'
 
 import styles from './InsightContextMenu.module.scss'
 
-export interface InsightCardMenuProps extends SettingsCascadeProps<Settings> {
+export interface InsightCardMenuProps {
     insight: Insight
     dashboard: InsightDashboard | null
     zeroYAxisMin: boolean
@@ -51,11 +49,10 @@ export const InsightContextMenu: React.FunctionComponent<InsightCardMenuProps> =
     const editUrl = dashboard?.id
         ? `/insights/edit/${insightID}?dashboardId=${dashboard.id}`
         : `/insights/edit/${insightID}`
-    const showQuickFix =
-        insight.title.includes('[quickfix]') &&
-        props.settingsCascade.final !== null &&
-        !isErrorLike(props.settingsCascade.final) &&
-        props.settingsCascade.final.experimentalFeatures?.goCodeCheckerTemplates
+
+    const features = useExperimentalFeatures()
+    const showQuickFix = insight.title.includes('[quickfix]') && features?.goCodeCheckerTemplates
+
     const quickFixUrl =
         insight.type === InsightType.SearchBased
             ? `/batch-changes/create?kind=goChecker${insight.series[0]?.name}&title=${insight.title}`

--- a/client/web/src/enterprise/insights/pages/CodeInsightsRootPage.test.tsx
+++ b/client/web/src/enterprise/insights/pages/CodeInsightsRootPage.test.tsx
@@ -9,8 +9,6 @@ import { Route } from 'react-router-dom'
 import { of } from 'rxjs'
 import sinon from 'sinon'
 
-import { Settings } from '@sourcegraph/shared/src/schema/settings.schema'
-import { SettingsCascadeOrError } from '@sourcegraph/shared/src/settings/settings'
 import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
 import { MockIntersectionObserver } from '@sourcegraph/shared/src/testing/MockIntersectionObserver'
 
@@ -22,11 +20,6 @@ import {
 } from '../core'
 
 import { CodeInsightsRootPage, CodeInsightsRootPageTab } from './CodeInsightsRootPage'
-
-const mockSettingsCascade: SettingsCascadeOrError<Settings> = {
-    final: null,
-    subjects: null,
-}
 
 interface ReactRouterMock {
     useHistory: () => unknown
@@ -96,7 +89,6 @@ describe('CodeInsightsRootPage', () => {
     it('should redirect to "All insights" page if no dashboardId is provided', () => {
         const { testLocation } = renderWithBrandedContext(
             <CodeInsightsRootPage
-                settingsCascade={mockSettingsCascade}
                 activeView={CodeInsightsRootPageTab.CodeInsights}
                 telemetryService={mockTelemetryService}
             />,
@@ -115,7 +107,6 @@ describe('CodeInsightsRootPage', () => {
     it('should render dashboard not found page when id is not found', () => {
         renderWithBrandedContext(
             <CodeInsightsRootPage
-                settingsCascade={mockSettingsCascade}
                 activeView={CodeInsightsRootPageTab.CodeInsights}
                 telemetryService={mockTelemetryService}
             />,
@@ -135,7 +126,6 @@ describe('CodeInsightsRootPage', () => {
     it('should log events', () => {
         renderWithBrandedContext(
             <CodeInsightsRootPage
-                settingsCascade={mockSettingsCascade}
                 activeView={CodeInsightsRootPageTab.CodeInsights}
                 telemetryService={mockTelemetryService}
             />,

--- a/client/web/src/enterprise/insights/pages/CodeInsightsRootPage.tsx
+++ b/client/web/src/enterprise/insights/pages/CodeInsightsRootPage.tsx
@@ -4,8 +4,6 @@ import PlusIcon from 'mdi-react/PlusIcon'
 import { matchPath, useHistory } from 'react-router'
 import { useLocation } from 'react-router-dom'
 
-import { Settings } from '@sourcegraph/shared/src/schema/settings.schema'
-import { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
 import { useTemporarySetting } from '@sourcegraph/shared/src/settings/temporary/useTemporarySetting'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { lazyComponent } from '@sourcegraph/shared/src/util/lazyComponent'
@@ -13,7 +11,7 @@ import { Button, Link, PageHeader, Tabs, TabList, Tab, Icon, TabPanels, TabPanel
 
 import { CodeInsightsIcon } from '../../../insights/Icons'
 import { CodeInsightsPage } from '../components/code-insights-page/CodeInsightsPage'
-import { ALL_INSIGHTS_DASHBOARD } from '../core/constants'
+import { ALL_INSIGHTS_DASHBOARD } from '../core'
 
 import { DashboardsContentPage } from './dashboards/dashboard-page/DashboardsContentPage'
 
@@ -38,7 +36,7 @@ function useQuery(): URLSearchParams {
     return React.useMemo(() => new URLSearchParams(search), [search])
 }
 
-interface CodeInsightsRootPageProps extends TelemetryProps, SettingsCascadeProps<Settings> {
+interface CodeInsightsRootPageProps extends TelemetryProps {
     activeView: CodeInsightsRootPageTab
 }
 
@@ -103,17 +101,10 @@ export const CodeInsightsRootPage: React.FunctionComponent<CodeInsightsRootPageP
                 </TabList>
                 <TabPanels className="mt-3">
                     <TabPanel>
-                        <DashboardsContentPage
-                            settingsCascade={props.settingsCascade}
-                            telemetryService={telemetryService}
-                            dashboardID={params?.dashboardId}
-                        />
+                        <DashboardsContentPage telemetryService={telemetryService} dashboardID={params?.dashboardId} />
                     </TabPanel>
                     <TabPanel>
-                        <LazyCodeInsightsGettingStartedPage
-                            settingsCascade={props.settingsCascade}
-                            telemetryService={telemetryService}
-                        />
+                        <LazyCodeInsightsGettingStartedPage telemetryService={telemetryService} />
                     </TabPanel>
                 </TabPanels>
             </Tabs>

--- a/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/DashboardsContentPage.test.tsx
+++ b/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/DashboardsContentPage.test.tsx
@@ -157,11 +157,7 @@ const renderDashboardsContent = (
     ...renderWithBrandedContext(
         <MockedTestProvider mocks={mocks}>
             <Wrapper>
-                <DashboardsContentPage
-                    settingsCascade={{ final: null, subjects: null }}
-                    dashboardID={dashboardID}
-                    telemetryService={mockTelemetryService}
-                />
+                <DashboardsContentPage dashboardID={dashboardID} telemetryService={mockTelemetryService} />
             </Wrapper>
         </MockedTestProvider>
     ),

--- a/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/DashboardsContentPage.tsx
+++ b/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/DashboardsContentPage.tsx
@@ -3,8 +3,6 @@ import React, { useContext, useMemo } from 'react'
 import { useRouteMatch } from 'react-router'
 import { Redirect } from 'react-router-dom'
 
-import { Settings } from '@sourcegraph/shared/src/schema/settings.schema'
-import { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { LoadingSpinner, useObservable } from '@sourcegraph/wildcard'
 
@@ -13,7 +11,7 @@ import { CodeInsightsBackendContext, ALL_INSIGHTS_DASHBOARD } from '../../../cor
 
 import { DashboardsContent } from './components/dashboards-content/DashboardsContent'
 
-export interface DashboardsContentPageProps extends TelemetryProps, SettingsCascadeProps<Settings> {
+export interface DashboardsContentPageProps extends TelemetryProps {
     /**
      * Possible dashboard id. All insights on the page will be get from
      * dashboard's info from the user or org settings by the dashboard id.
@@ -24,7 +22,7 @@ export interface DashboardsContentPageProps extends TelemetryProps, SettingsCasc
 }
 
 export const DashboardsContentPage: React.FunctionComponent<DashboardsContentPageProps> = props => {
-    const { dashboardID, telemetryService, settingsCascade } = props
+    const { dashboardID, telemetryService } = props
     const { url } = useRouteMatch()
 
     const { getDashboards } = useContext(CodeInsightsBackendContext)
@@ -49,12 +47,7 @@ export const DashboardsContentPage: React.FunctionComponent<DashboardsContentPag
     return (
         <>
             <PageTitle title={`${currentDashboard?.title || ''} - Code Insights`} />
-            <DashboardsContent
-                settingsCascade={settingsCascade}
-                telemetryService={telemetryService}
-                dashboardID={dashboardID}
-                dashboards={dashboards}
-            />
+            <DashboardsContent telemetryService={telemetryService} dashboardID={dashboardID} dashboards={dashboards} />
         </>
     )
 }

--- a/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/dashboards-content/DashboardsContent.tsx
+++ b/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/dashboards-content/DashboardsContent.tsx
@@ -4,8 +4,6 @@ import classNames from 'classnames'
 import MapSearchIcon from 'mdi-react/MapSearchIcon'
 import { useHistory } from 'react-router-dom'
 
-import { Settings } from '@sourcegraph/shared/src/schema/settings.schema'
-import { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Button } from '@sourcegraph/wildcard'
 
@@ -25,7 +23,7 @@ import { isDashboardConfigurable } from './utils/is-dashboard-configurable'
 
 import styles from './DashboardsContent.module.scss'
 
-export interface DashboardsContentProps extends TelemetryProps, SettingsCascadeProps<Settings> {
+export interface DashboardsContentProps extends TelemetryProps {
     /**
      * Possible dashboard id. All insights on the page will be get from
      * dashboard's info from the user or org settings by the dashboard id.
@@ -139,7 +137,6 @@ export const DashboardsContent: React.FunctionComponent<DashboardsContentProps> 
 
             {currentDashboard ? (
                 <DashboardInsights
-                    settingsCascade={props.settingsCascade}
                     dashboard={currentDashboard}
                     telemetryService={telemetryService}
                     className={styles.insights}

--- a/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/dashboards-content/components/dashboard-inisghts/DashboardInsights.tsx
+++ b/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/dashboards-content/components/dashboard-inisghts/DashboardInsights.tsx
@@ -1,7 +1,5 @@
 import React, { useContext, useMemo } from 'react'
 
-import { Settings } from '@sourcegraph/shared/src/schema/settings.schema'
-import { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { LoadingSpinner, useObservable } from '@sourcegraph/wildcard'
 
@@ -9,7 +7,7 @@ import { SmartInsightsViewGrid, InsightContext } from '../../../../../../../comp
 import { CodeInsightsBackendContext, InsightDashboard } from '../../../../../../../core'
 import { EmptyInsightDashboard } from '../empty-insight-dashboard/EmptyInsightDashboard'
 
-interface DashboardInsightsProps extends TelemetryProps, SettingsCascadeProps<Settings> {
+interface DashboardInsightsProps extends TelemetryProps {
     dashboard: InsightDashboard
     className?: string
     onAddInsightRequest: () => void
@@ -31,12 +29,7 @@ export const DashboardInsights: React.FunctionComponent<DashboardInsightsProps> 
     return (
         <InsightContext.Provider value={{ dashboard }}>
             {insights.length > 0 ? (
-                <SmartInsightsViewGrid
-                    settingsCascade={props.settingsCascade}
-                    insights={insights}
-                    telemetryService={telemetryService}
-                    className={className}
-                />
+                <SmartInsightsViewGrid insights={insights} telemetryService={telemetryService} className={className} />
             ) : (
                 <EmptyInsightDashboard dashboard={dashboard} onAddInsight={onAddInsightRequest} />
             )}

--- a/client/web/src/enterprise/insights/pages/insights/insight/CodeInsightIndependentPage.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/insight/CodeInsightIndependentPage.tsx
@@ -1,0 +1,23 @@
+import { FunctionComponent } from 'react'
+
+import { PageHeader } from '@sourcegraph/wildcard'
+
+import { PageTitle } from '../../../../../components/PageTitle'
+import { CodeInsightsIcon } from '../../../../../insights/Icons'
+import { CodeInsightsPage } from '../../../components/code-insights-page/CodeInsightsPage'
+
+interface CodeInsightIndependentPage {
+    insightId: string
+}
+
+export const CodeInsightIndependentPage: FunctionComponent<CodeInsightIndependentPage> = props => {
+    const { insightId } = props
+
+    return (
+        <CodeInsightsPage>
+            <PageTitle title={`Configure ${insightId} - Code Insights`} />
+
+            <PageHeader path={[{ icon: CodeInsightsIcon }, { text: insightId }]} />
+        </CodeInsightsPage>
+    )
+}

--- a/client/web/src/enterprise/insights/pages/landing/dot-com-get-started/CodeInsightsDotComGetStarted.story.tsx
+++ b/client/web/src/enterprise/insights/pages/landing/dot-com-get-started/CodeInsightsDotComGetStarted.story.tsx
@@ -12,8 +12,5 @@ export default {
 } as Meta
 
 export const CodeInsightsDotComGetStartedStory = () => (
-    <CodeInsightsDotComGetStarted
-        telemetryService={NOOP_TELEMETRY_SERVICE}
-        settingsCascade={{ subjects: null, final: null }}
-    />
+    <CodeInsightsDotComGetStarted telemetryService={NOOP_TELEMETRY_SERVICE} />
 )

--- a/client/web/src/enterprise/insights/pages/landing/dot-com-get-started/CodeInsightsDotComGetStarted.tsx
+++ b/client/web/src/enterprise/insights/pages/landing/dot-com-get-started/CodeInsightsDotComGetStarted.tsx
@@ -2,8 +2,6 @@ import React, { useEffect } from 'react'
 
 import classNames from 'classnames'
 
-import { Settings } from '@sourcegraph/shared/src/schema/settings.schema'
-import { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Button, Card, CardBody, Link, PageHeader } from '@sourcegraph/wildcard'
 
@@ -21,7 +19,7 @@ import styles from './CodeInsightsDotComGetStarted.module.scss'
 
 const DOT_COM_CONTEXT = { mode: CodeInsightsLandingPageType.Cloud }
 
-export interface CodeInsightsDotComGetStartedProps extends TelemetryProps, SettingsCascadeProps<Settings> {}
+export interface CodeInsightsDotComGetStartedProps extends TelemetryProps {}
 
 export const CodeInsightsDotComGetStarted: React.FunctionComponent<CodeInsightsDotComGetStartedProps> = props => {
     const { telemetryService } = props
@@ -171,11 +169,7 @@ export const CodeInsightsDotComGetStarted: React.FunctionComponent<CodeInsightsD
                         </Card>
                     </section>
 
-                    <CodeInsightsTemplates
-                        className={styles.templateSection}
-                        settingsCascade={props.settingsCascade}
-                        telemetryService={telemetryService}
-                    />
+                    <CodeInsightsTemplates className={styles.templateSection} telemetryService={telemetryService} />
 
                     <iframe
                         src="https://www.youtube.com/embed/fMCUJQHfbUA"

--- a/client/web/src/enterprise/insights/pages/landing/getting-started/CodeInsightsGettingStartedPage.tsx
+++ b/client/web/src/enterprise/insights/pages/landing/getting-started/CodeInsightsGettingStartedPage.tsx
@@ -1,7 +1,5 @@
 import React, { useEffect } from 'react'
 
-import { Settings } from '@sourcegraph/shared/src/schema/settings.schema'
-import { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 
 import { PageTitle } from '../../../../../components/PageTitle'
@@ -13,7 +11,7 @@ import { DynamicCodeInsightExample } from './components/dynamic-code-insight-exa
 
 import styles from './CodeInsightsGettingStartedPage.module.scss'
 
-interface CodeInsightsGettingStartedPageProps extends TelemetryProps, SettingsCascadeProps<Settings> {}
+interface CodeInsightsGettingStartedPageProps extends TelemetryProps {}
 
 export const CodeInsightsGettingStartedPage: React.FunctionComponent<CodeInsightsGettingStartedPageProps> = props => {
     const { telemetryService } = props
@@ -27,11 +25,7 @@ export const CodeInsightsGettingStartedPage: React.FunctionComponent<CodeInsight
             <PageTitle title="Code Insights" />
             <DynamicCodeInsightExample telemetryService={telemetryService} />
             <CodeInsightsExamples telemetryService={telemetryService} className={styles.section} />
-            <CodeInsightsTemplates
-                telemetryService={telemetryService}
-                settingsCascade={props.settingsCascade}
-                className={styles.section}
-            />
+            <CodeInsightsTemplates telemetryService={telemetryService} className={styles.section} />
             <CodeInsightsLearnMore telemetryService={telemetryService} className={styles.section} />
         </main>
     )

--- a/client/web/src/enterprise/insights/pages/landing/getting-started/components/code-insights-templates/CodeInsightsTemplates.tsx
+++ b/client/web/src/enterprise/insights/pages/landing/getting-started/components/code-insights-templates/CodeInsightsTemplates.tsx
@@ -4,8 +4,6 @@ import copy from 'copy-to-clipboard'
 import ContentCopyIcon from 'mdi-react/ContentCopyIcon'
 
 import { SyntaxHighlightedSearchQuery } from '@sourcegraph/search-ui'
-import { Settings } from '@sourcegraph/shared/src/schema/settings.schema'
-import { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import {
     Button,
@@ -24,6 +22,7 @@ import {
     ProductStatusBadge,
 } from '@sourcegraph/wildcard'
 
+import { useExperimentalFeatures } from '../../../../../../../stores'
 import { CodeInsightsBackendContext, InsightType } from '../../../../../core'
 import { encodeCaptureInsightURL } from '../../../../insights/creation/capture-group'
 import { encodeSearchInsightUrl } from '../../../../insights/creation/search-insight'
@@ -47,16 +46,13 @@ function getTemplateURL(template: Template): string {
     }
 }
 
-interface CodeInsightsTemplates
-    extends TelemetryProps,
-        React.HTMLAttributes<HTMLElement>,
-        SettingsCascadeProps<Settings> {}
+interface CodeInsightsTemplates extends TelemetryProps, React.HTMLAttributes<HTMLElement> {}
 
 export const CodeInsightsTemplates: React.FunctionComponent<CodeInsightsTemplates> = props => {
     const { telemetryService, ...otherProps } = props
     const tabChangePingName = useLogEventName('InsightsGetStartedTabClick')
-
-    const templateSections = getTemplateSections(props)
+    const features = useExperimentalFeatures()
+    const templateSections = getTemplateSections(features)
 
     const handleTabChange = (index: number): void => {
         const template = templateSections[index]

--- a/client/web/src/enterprise/insights/pages/landing/getting-started/components/code-insights-templates/constants.ts
+++ b/client/web/src/enterprise/insights/pages/landing/getting-started/components/code-insights-templates/constants.ts
@@ -1,8 +1,6 @@
-import { isErrorLike } from '@sourcegraph/common'
-import { Settings } from '@sourcegraph/shared/src/schema/settings.schema'
-import { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
+import { SettingsExperimentalFeatures } from '@sourcegraph/shared/src/schema/settings.schema'
 
-import { InsightType } from '../../../../../core/types'
+import { InsightType } from '../../../../../core'
 import { CaptureInsightUrlValues } from '../../../../insights/creation/capture-group'
 import { DATA_SERIES_COLORS, SearchInsightURLValues } from '../../../../insights/creation/search-insight'
 
@@ -1263,7 +1261,7 @@ const GO_STATIC_CHECK_S1039: Template = {
     },
 }
 
-export const getTemplateSections = (props: SettingsCascadeProps<Settings>): TemplateSection[] => {
+export const getTemplateSections = (features: SettingsExperimentalFeatures): TemplateSection[] => {
     const allButGoChecker: TemplateSection[] = [
         {
             title: 'Popular',
@@ -1349,14 +1347,13 @@ export const getTemplateSections = (props: SettingsCascadeProps<Settings>): Temp
             templates: [TS_VS_GO, IOS_APP_SCREENS, ADOPTING_NEW_API, PROBLEMATIC_API_BY_TEAM, DATA_FETCHING_GQL],
         },
     ]
-    if (
-        props.settingsCascade.final !== null &&
-        !isErrorLike(props.settingsCascade.final) &&
-        !props.settingsCascade.final.experimentalFeatures?.goCodeCheckerTemplates
-    ) {
+
+    if (!features?.goCodeCheckerTemplates) {
         return allButGoChecker
     }
+
     const all = [...allButGoChecker]
+
     all.splice(-1, 0, {
         title: 'Go code checker',
         experimental: true,
@@ -1383,5 +1380,6 @@ export const getTemplateSections = (props: SettingsCascadeProps<Settings>): Temp
             GO_STATIC_CHECK_S1039,
         ],
     })
+
     return all
 }


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/34758

This PR simply adds some template components for the insight standalone page. I hide this page by local js variable in the main root component just to avoid introducing another experimental feature that we will deprecate/remove anyway in the next two weeks. 


## Test plan
- Make sure that you can see the new insight page if you enabled the feature flag local variable for it

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->



## App preview:

- [Web](https://sg-web-vk-add-insight-page-route.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-buprkxojph.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
