### PR TITLE
dev/ci: make dev docs more user-friendly, pipeline reference more prominent

### DIFF
--- a/doc/dev/background-information/ci/development.md
+++ b/doc/dev/background-information/ci/development.md
@@ -12,9 +12,17 @@ Internally, the pipeline generator determines what gets run over contributions b
 
 The above factors are then used to determine the appropriate [operations](#operations), composed of [step options](#step-options), that translate into steps in the resulting pipeline.
 
+If you are looking to modify the pipeline, some good rules of thumbs for which construct to look at for implementing something are:
+
+- Adding a new check? Try a new [operation](#operations) or additional [step options](#step-options).
+- Adding a set of changes to run when particular files are changed? Start with a new or updated [diff type](#diff-types).
+- Adding an entirely new pipeline type for the `sourcegraph/sourcegraph` repository? Take a look at how [run types](#run-types) are implemented.
+
 > WARNING: Sourcegraph's pipeline generator and its generated output are under the [Sourcegraph Enterprise license](https://github.com/sourcegraph/sourcegraph/blob/main/LICENSE.enterprise).
 
 ### Run types
+
+> NOTE: A full reference of what our existing run types do is available in the [Pipeline reference](reference.md).
 
 <div class="embed">
   <iframe src="https://sourcegraph.com/embed/notebooks/Tm90ZWJvb2s6MTU5"
@@ -49,7 +57,17 @@ For more advanced pipelines, see [Run types](#run-types).
 
 ### Step options
 
-> NOTE: Coming soon!
+Each [operation](#operations) is composed of steps that are built via step options, defined as [implementations of the `StepOpt` interface](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/enterprise/dev/ci/internal/buildkite/buildkite.go?L229:6#tab=implementations_go). The core step option is `Cmd`, which defines a command to run when added to a pipeline via `AddStep`:
+
+```go
+func addGoBuild(pipeline *bk.Pipeline) {
+  pipeline.AddStep(":go: Build",
+    bk.Cmd("./dev/ci/go-build.sh"),
+  )
+}
+```
+
+> NOTE: More details coming soon!
 
 #### Creating annotations
 

--- a/doc/dev/background-information/ci/index.md
+++ b/doc/dev/background-information/ci/index.md
@@ -31,16 +31,14 @@ Sourcegraph also maintains a variety of tooling on [GitHub Actions](#github-acti
 ## Buildkite pipelines
 
 [Tests](../../how-to/testing.md) are automatically run in our [various Buildkite pipelines](https://buildkite.com/sourcegraph) when you push your changes (i.e. when you run `git push`) to the `sourcegraph/sourcegraph` GitHub repository.
-Pipeline steps are generated on the fly using the [pipeline generator](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@main/-/tree/enterprise/dev/ci).
+Pipeline steps are generated on the fly using the [pipeline generator](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@main/-/tree/enterprise/dev/ci) - a complete reference of all available pipeline types and steps is available in the generated [Pipeline reference](./reference.md).
+You can also see these docs locally with `sg ci docs`.
 
 To see what checks will get run against your current branch, use [`sg`](../../setup/quickstart.md):
 
 ```sh
 sg ci preview
 ```
-
-A complete reference of all available pipeline types and steps is available in the generated [Pipeline reference](./reference.md).
-You can also see these docs locally with `sg ci docs`.
 
 You can also request builds manually for your builds using `sg ci build`.
 


### PR DESCRIPTION
Some updates to the CI docs to hopefully make it a bit more approachable! From discussion with @abeatrix 

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

`sg run docsite`, review output
