### PR TITLE
Search backend: tidy up `internal/search/query` package

### DIFF
--- a/internal/search/query/validate.go
+++ b/internal/search/query/validate.go
@@ -200,7 +200,7 @@ func validateField(field, value string, negated bool, seen map[string]struct{}) 
 	}
 
 	isYesNoOnly := func() error {
-		v := ParseYesNoOnly(value)
+		v := parseYesNoOnly(value)
 		if v == Invalid {
 			return errors.Errorf("invalid value %q for field %q. Valid values are: yes, only, no", value, field)
 		}
@@ -384,7 +384,7 @@ func validateRefGlobs(nodes []Node) error {
 	VisitField(nodes, FieldIndex, func(value string, _ bool, _ Annotation) {
 		indexValue = value
 	})
-	if ParseYesNoOnly(indexValue) == Only {
+	if parseYesNoOnly(indexValue) == Only {
 		return errors.Errorf("invalid index:%s (revisions with glob pattern cannot be resolved for indexed searches)", indexValue)
 	}
 	return nil
@@ -509,7 +509,7 @@ const (
 	Invalid YesNoOnly = "invalid"
 )
 
-func ParseYesNoOnly(s string) YesNoOnly {
+func parseYesNoOnly(s string) YesNoOnly {
 	switch s {
 	case "y", "Y", "yes", "YES", "Yes":
 		return Yes

--- a/internal/search/query/validate_test.go
+++ b/internal/search/query/validate_test.go
@@ -161,38 +161,6 @@ func TestIsCaseSensitive(t *testing.T) {
 	}
 }
 
-func TestRegexpPatterns(t *testing.T) {
-	type want struct {
-		values        []string
-		negatedValues []string
-	}
-	c := struct {
-		query string
-		field string
-		want
-	}{
-		query: "r:a r:b -r:c",
-		field: "repo",
-		want: want{
-			values:        []string{"a", "b"},
-			negatedValues: []string{"c"},
-		},
-	}
-	t.Run("for regexp field", func(t *testing.T) {
-		query, err := ParseRegexp(c.query)
-		if err != nil {
-			t.Fatal(err)
-		}
-		gotValues, gotNegatedValues := query.RegexpPatterns(c.field)
-		if diff := cmp.Diff(c.want.values, gotValues); diff != "" {
-			t.Error(diff)
-		}
-		if diff := cmp.Diff(c.want.negatedValues, gotNegatedValues); diff != "" {
-			t.Error(diff)
-		}
-	})
-}
-
 func TestPartitionSearchPattern(t *testing.T) {
 	cases := []struct {
 		input string
@@ -273,7 +241,7 @@ func TestPartitionSearchPattern(t *testing.T) {
 				}
 				return
 			}
-			result := ToNodes(scopeParameters)
+			result := toNodes(scopeParameters)
 			if pattern != nil {
 				result = append(result, pattern)
 			}


### PR DESCRIPTION
Just removes some unused methods/functions and makes some
private that aren't used outside the package.

Stacked on https://github.com/sourcegraph/sourcegraph/pull/34780

## Test plan

All semantics-preserving. Any issues should be caught statically.

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


