### PR TITLE
search-blitz: add queries for megarepo on k8s.sgdev.org

### DIFF
--- a/internal/cmd/search-blitz/queries_dogfood.txt
+++ b/internal/cmd/search-blitz/queries_dogfood.txt
@@ -39,3 +39,84 @@ repo:^gigarepo$ patterntype:literal lang:go -file:vendor/ count:1000 TempDir
 
 # giga_rev_literal_large
 repo:^gigarepo$ patterntype:literal lang:go -file:vendor/ count:1000 TempDir rev:main
+
+## mega_incremental_ queries consist of standard queries that run against two versions of
+## github.com/sgtest/megarepo that use different indexing strategies:
+##
+## - mega_incremental_delta_  queries run against a fork of sgtest/megarepo uses the experimental delta
+##                            indexing strategy
+##
+## - mega_incremental_normal_ queries run against a fork of the sgtest/megarepo repository that uses the "normal"
+##                            (non-delta) indexing strategy
+
+# mega_incremental_delta_regex_small
+repo:^megarepo-incremental-indexing-fork$ patterntype:regexp se[arc]{3}hZoekt
+
+# mega_incremental_delta_rev_regex_small
+repo:^megarepo-incremental-indexing-fork$ patterntype:regexp se[arc]{3}hZoekt rev:main
+
+# mega_incremental_delta_structural_small
+repo:^megarepo-incremental-indexing-fork$ patterntype:structural strings.ToUpper(...)
+
+# mega_incremental_delta_rev_structural_small
+repo:^megarepo-incremental-indexing-fork$ patterntype:structural strings.ToUpper(...) rev:main
+
+# mega_incremental_delta_symbol_small
+repo:^megarepo-incremental-indexing-fork$ type:symbol IndexFormatVersion
+
+# mega_incremental_delta_rev_symbol_small
+repo:^megarepo-incremental-indexing-fork$ type:symbol IndexFormatVersion rev:main
+
+# mega_incremental_delta_diff_small
+repo:^megarepo-incremental-indexing-fork$ type:diff   author:camden before:"february 1 2021"
+
+# mega_incremental_delta_commit_small
+repo:^megarepo-incremental-indexing-fork$ type:commit author:camden before:"february 1 2021"
+
+# mega_incremental_delta_literal_small
+repo:^megarepo-incremental-indexing-fork$ patterntype:literal --exclude-task=test
+
+# mega_incremental_delta_rev_literal_small
+repo:^megarepo-incremental-indexing-fork$ patterntype:literal --exclude-task=test rev:main
+
+# mega_incremental_delta_literal_large
+repo:^megarepo-incremental-indexing-fork$ patterntype:literal lang:go -file:vendor/ count:1000 TempDir
+
+# mega_incremental_delta_rev_literal_large
+repo:^megarepo-incremental-indexing-fork$ patterntype:literal lang:go -file:vendor/ count:1000 TempDir rev:main
+
+# mega_incremental_normal_regex_small
+repo:^megarepo-normal-indexing$ patterntype:regexp se[arc]{3}hZoekt
+
+# mega_incremental_normal_rev_regex_small
+repo:^megarepo-normal-indexing$ patterntype:regexp se[arc]{3}hZoekt rev:main
+
+# mega_incremental_normal_structural_small
+repo:^megarepo-normal-indexing$ patterntype:structural strings.ToUpper(...)
+
+# mega_incremental_normal_rev_structural_small
+repo:^megarepo-normal-indexing$ patterntype:structural strings.ToUpper(...) rev:main
+
+# mega_incremental_normal_symbol_small
+repo:^megarepo-normal-indexing$ type:symbol IndexFormatVersion
+
+# mega_incremental_normal_rev_symbol_small
+repo:^megarepo-normal-indexing$ type:symbol IndexFormatVersion rev:main
+
+# mega_incremental_normal_diff_small
+repo:^megarepo-normal-indexing$ type:diff   author:camden before:"february 1 2021"
+
+# mega_incremental_normal_commit_small
+repo:^megarepo-normal-indexing$ type:commit author:camden before:"february 1 2021"
+
+# mega_incremental_normal_literal_small
+repo:^megarepo-normal-indexing$ patterntype:literal --exclude-task=test
+
+# mega_incremental_normal_rev_literal_small
+repo:^megarepo-normal-indexing$ patterntype:literal --exclude-task=test rev:main
+
+# mega_incremental_normal_literal_large
+repo:^megarepo-normal-indexing$ patterntype:literal lang:go -file:vendor/ count:1000 TempDir
+
+# mega_incremental_normal_rev_literal_large
+repo:^megarepo-normal-indexing$ patterntype:literal lang:go -file:vendor/ count:1000 TempDir rev:main


### PR DESCRIPTION
This PR adds queries that target the github.com/sgtest/megarepo forks on k8s.sgdev.org:
- https://k8s.sgdev.org/megarepo-normal-indexing (using the normal indexing strategy)
- https://k8s.sgdev.org/megarepo-incremental-indexing-fork (using the experimental delta indexing strategy). 

This allows us to collect metrics that allow us to compare search times that use two use two different indexing strategies. 

## Test plan

search-blitz has its own unit tests


