### PR TITLE
[Search Page] fix CTA banner late rendering

### DIFF
--- a/client/web/src/search/results/StreamingSearchResults.tsx
+++ b/client/web/src/search/results/StreamingSearchResults.tsx
@@ -115,9 +115,6 @@ function useCtaAlert(
     const tourQueryParameters = useTourQueryParameters()
 
     const ctaToDisplay = useMemo<CtaToDisplay | undefined>((): CtaToDisplay | undefined => {
-        if (!areResultsFound) {
-            return
-        }
         if (tourQueryParameters?.isTour) {
             return
         }
@@ -127,25 +124,20 @@ function useCtaAlert(
         }
 
         if (
-            hasDismissedBrowserExtensionAlert === false &&
+            !hasDismissedBrowserExtensionAlert &&
             isAuthenticated &&
-            isBrowserExtensionActiveUser === false &&
+            !isBrowserExtensionActiveUser &&
             displaySignupAndBrowserExtensionCTAsBasedOnCadence
         ) {
             return 'browser'
         }
 
-        if (
-            isUsingIdeIntegration === false &&
-            displayIDEExtensionCTABasedOnCadence &&
-            hasDismissedIDEExtensionAlert === false
-        ) {
+        if (!isUsingIdeIntegration && displayIDEExtensionCTABasedOnCadence && !hasDismissedIDEExtensionAlert) {
             return 'ide'
         }
 
         return
     }, [
-        areResultsFound,
         tourQueryParameters?.isTour,
         hasDismissedSignupAlert,
         isAuthenticated,


### PR DESCRIPTION
fixes: #34688

Show browser extensions cta box even when results on search page are not loaded yet.

before: https://sourcegraph.slack.com/files/UHTSAHETD/F03CW4B7JF9/screenshot_2022-04-28_11.33.02.mp4
after: https://www.loom.com/share/3aa6fcedb07f48c38e279ab700ce6df2

## Test plan
- visit any search page
- the CTA banner for extensions should appear even before the results load up and not after