### PR TITLE
fix incorrect line chart size in FireFox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ All notable changes to Sourcegraph are documented in this file.
 
 ## Unreleased
 
+- Code Insights: Fixed incorrect Line Chart size calculation in FireFox
+
 ### Added
 
 - Code Insights: Added fuzzy search filter for dashboard select drop down

--- a/client/web/src/charts/components/line-chart/LineChart.tsx
+++ b/client/web/src/charts/components/line-chart/LineChart.tsx
@@ -63,8 +63,8 @@ export function LineChart<D>(props: LineChartContentProps<D>): ReactElement | nu
                 margin: {
                     top: 10,
                     right: 20,
-                    left: yAxisElement?.getBoundingClientRect().width,
-                    bottom: xAxisReference?.getBoundingClientRect().height,
+                    left: yAxisElement?.getBBox().width,
+                    bottom: xAxisReference?.getBBox().height,
                 },
             }),
         [yAxisElement, xAxisReference, outerWidth, outerHeight]


### PR DESCRIPTION
Swap `getBoundingClientRect` for `getBBox`. There are known differences in how FireFox calculated bounding rectangle width using `getBoundingClientRect`. Switching to `getBBox` offers similiar enough functionality for our use case as well as consistent results across browsers.

## Test plan

Open any dashboard with insights 
Resize the screen
Charts should resize proportionally across all browsers.

Closes https://github.com/sourcegraph/sourcegraph/issues/34668

## App preview:

- [Web](https://sg-web-jdb-fix-line-chart-size.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-diojbdedld.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
