### PR TITLE
lib/log: add logtest.NoOp

### DIFF
--- a/lib/log/logtest/logtest.go
+++ b/lib/log/logtest/logtest.go
@@ -36,6 +36,9 @@ func Init(_ *testing.M) {
 // InitWithLevel does the same thing as Init, but uses the provided log level to configur
 // the log level for this package's tests, which can be helpful for exceptionally noisy
 // tests.
+//
+// If your loggers are parameterized, you can also use logtest.NoOp to silence output for
+// specific tests.
 func InitWithLevel(_ *testing.M, level log.Level) {
 	initGlobal(level.Parse())
 }
@@ -113,4 +116,4 @@ var _ log.Logger = &noopAdapter{}
 func (n *noopAdapter) Scoped(string, string) log.Logger      { return n }
 func (n *noopAdapter) With(...log.Field) log.Logger          { return n }
 func (n *noopAdapter) WithTrace(log.TraceContext) log.Logger { return n }
-func (n *noopAdapter) AddCallerSkip(skip int) log.Logger     { return n }
+func (n *noopAdapter) AddCallerSkip(int) log.Logger          { return n }

--- a/lib/log/logtest/logtest.go
+++ b/lib/log/logtest/logtest.go
@@ -100,3 +100,17 @@ func Captured(t testing.TB) (logger log.Logger, exportLogs func() []CapturedLog)
 		return logs
 	}
 }
+
+// NoOp returns a no-op Logger, useful for silencing all output in a specific test.
+func NoOp() log.Logger {
+	return &noopAdapter{zap.NewNop()}
+}
+
+type noopAdapter struct{ *zap.Logger }
+
+var _ log.Logger = &noopAdapter{}
+
+func (n *noopAdapter) Scoped(string, string) log.Logger      { return n }
+func (n *noopAdapter) With(...log.Field) log.Logger          { return n }
+func (n *noopAdapter) WithTrace(log.TraceContext) log.Logger { return n }
+func (n *noopAdapter) AddCallerSkip(skip int) log.Logger     { return n }


### PR DESCRIPTION
`logtest.NoOp` is an implementation of `log.Logger` that does not do anything. Useful for silencing a specific test, because we only have package-wide level configuration right now via `logtest.InitWithLevel()`

There are some usage patterns of a log15 `discardLogger`, which this hopes to provide an equivalent for

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


n/a