### PR TITLE
JetBrains: Create Java→JS bridge

### DIFF
--- a/client/jetbrains/src/main/java/com/sourcegraph/browser/JavaToJSBridge.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/browser/JavaToJSBridge.java
@@ -13,7 +13,7 @@ public class JavaToJSBridge {
     private final JBCefBrowserBase browser;
     private final Logger logger = Logger.getInstance(JavaToJSBridge.class);
     private final JBCefJSQuery query;
-    Function<String, JBCefJSQuery.Response> handler = null;
+    private Function<String, JBCefJSQuery.Response> handler = null;
     private boolean isQueryRunning = false;
 
     public JavaToJSBridge(JBCefBrowserBase browser) {

--- a/client/jetbrains/src/main/java/com/sourcegraph/browser/JavaToJSBridge.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/browser/JavaToJSBridge.java
@@ -1,0 +1,60 @@
+package com.sourcegraph.browser;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.ui.jcef.JBCefBrowserBase;
+import com.intellij.ui.jcef.JBCefJSQuery;
+
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+public class JavaToJSBridge {
+    private final JBCefBrowserBase browser;
+    private final Logger logger = Logger.getInstance(JavaToJSBridge.class);
+    private final JBCefJSQuery query;
+    Function<String, JBCefJSQuery.Response> handler = null;
+    private boolean isQueryRunning = false;
+
+    public JavaToJSBridge(JBCefBrowserBase browser) {
+        this.browser = browser;
+        this.query = JBCefJSQuery.create(browser);
+    }
+
+    public void callJS(String action, JsonObject arguments) {
+        this.callJS(action, arguments, null);
+    }
+
+    public void callJS(String action, JsonObject arguments, Consumer<JsonObject> callback) {
+        // Reason for the locking:
+        // JBCefJSQuery objects MUST be created before the browser is loaded, otherwise an error is thrown.
+        // As there is only one JBCefJSQuery object, and we need to wait for the result of the last execution,
+        // we can only run one query at a time.
+        // If this becomes a bottleneck, we can create a pool of JBCefJSQuery objects to bridge this,
+        // or find a different solution.
+        if (!isQueryRunning) {
+            isQueryRunning = true;
+            String js = "window.callJS('" + action + "', '" + (arguments != null ? arguments.toString() : "null") + "', (result) => {" +
+                "    " + query.inject("result") +
+                "});";
+
+            handler = responseAsString -> {
+                if (callback != null) {
+                    callback.accept(JsonParser.parseString(responseAsString).getAsJsonObject());
+                }
+                query.removeHandler(handler);
+                handler = null;
+                isQueryRunning = false;
+                return null;
+            };
+            query.addHandler(handler);
+            browser.getCefBrowser().executeJavaScript(js, browser.getCefBrowser().getURL(), 0);
+        } else {
+            logger.error("Query is already running, ignoring callJS");
+        }
+    }
+
+    public boolean isQueryRunning() {
+        return isQueryRunning;
+    }
+}

--- a/client/jetbrains/src/main/java/com/sourcegraph/browser/SourcegraphJBCefBrowser.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/browser/SourcegraphJBCefBrowser.java
@@ -6,6 +6,8 @@ import com.sourcegraph.config.ThemeUtil;
 import org.cef.CefApp;
 import org.jetbrains.annotations.NotNull;
 
+import javax.swing.*;
+
 public class SourcegraphJBCefBrowser extends JBCefBrowser {
     public SourcegraphJBCefBrowser(@NotNull JSToJavaBridgeRequestHandler requestHandler) {
         super("http://sourcegraph/html/index.html");
@@ -13,10 +15,19 @@ public class SourcegraphJBCefBrowser extends JBCefBrowser {
         CefApp.getInstance().registerSchemeHandlerFactory("http", "sourcegraph", new HttpSchemeHandlerFactory());
         this.setPageBackgroundColor(ThemeUtil.getPanelBackgroundColorHexString());
 
-        // Create bridge, set up handlers, then run init function
+        // Create bridges, set up handlers, then run init function
         String initJSCode = "window.initializeSourcegraph();";
         JSToJavaBridge jsToJavaBridge = new JSToJavaBridge(this, requestHandler, initJSCode);
         Disposer.register(this, jsToJavaBridge);
+        JavaToJSBridge javaToJSBridge = new JavaToJSBridge(this);
+
+        UIManager.addPropertyChangeListener(propertyChangeEvent -> {
+            if (propertyChangeEvent.getPropertyName().equals("lookAndFeel")) {
+                if (!javaToJSBridge.isQueryRunning()) {
+                    javaToJSBridge.callJS("themeChanged", ThemeUtil.getCurrentThemeAsJson());
+                }
+            }
+        });
     }
 
     public void focus() {

--- a/client/jetbrains/src/main/java/com/sourcegraph/find/SourcegraphWindow.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/find/SourcegraphWindow.java
@@ -2,6 +2,7 @@ package com.sourcegraph.find;
 
 import com.intellij.openapi.Disposable;
 import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.popup.ActiveIcon;
 import com.intellij.openapi.ui.popup.ComponentPopupBuilder;
@@ -13,8 +14,6 @@ import org.cef.browser.CefBrowser;
 import org.cef.handler.CefKeyboardHandler;
 import org.cef.misc.BoolRef;
 import org.jetbrains.annotations.NotNull;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.awt.*;
 import java.awt.event.KeyEvent;
@@ -25,7 +24,7 @@ public class SourcegraphWindow implements Disposable {
     private final Project project;
     private final FindPopupPanel mainPanel;
     private JBPopup popup;
-    private static final Logger logger = LoggerFactory.getLogger(SourcegraphWindow.class);
+    private static final Logger logger = Logger.getInstance(SourcegraphWindow.class);
 
     public SourcegraphWindow(@NotNull Project project) {
         this.project = project;

--- a/client/jetbrains/webview/src/search/index.tsx
+++ b/client/jetbrains/webview/src/search/index.tsx
@@ -7,6 +7,7 @@ import { AnchorLink, setLinkComponent } from '@sourcegraph/wildcard'
 import { getAuthenticatedUser } from '../sourcegraph-api-access/api-gateway'
 
 import { App } from './App'
+import { handleRequest } from './java-to-js-bridge'
 import {
     getConfig,
     getTheme,
@@ -50,7 +51,9 @@ window.initializeSourcegraph = async () => {
     await indicateFinishedLoading()
 }
 
-function renderReactApp(): void {
+window.callJS = handleRequest
+
+export function renderReactApp(): void {
     const node = document.querySelector('#main') as HTMLDivElement
     render(
         <App
@@ -68,13 +71,13 @@ function renderReactApp(): void {
     )
 }
 
-function applyConfig(config: PluginConfig): void {
+export function applyConfig(config: PluginConfig): void {
     instanceURL = config.instanceURL
     isGlobbingEnabled = config.isGlobbingEnabled || false
     accessToken = config.accessToken || null
 }
 
-function applyTheme(theme: Theme): void {
+export function applyTheme(theme: Theme): void {
     // Dark/light theme
     document.documentElement.classList.add('theme')
     document.documentElement.classList.remove(theme.isDarkTheme ? 'theme-light' : 'theme-dark')

--- a/client/jetbrains/webview/src/search/java-to-js-bridge.ts
+++ b/client/jetbrains/webview/src/search/java-to-js-bridge.ts
@@ -1,0 +1,31 @@
+import { PluginConfig, Theme } from './types'
+
+import { applyConfig, applyTheme, renderReactApp } from './index'
+
+export type ActionName = 'themeChanged' | 'pluginSettingsChanged'
+
+type ThemeChangedRequestArguments = Theme
+type PluginSettingsChangedRequestArguments = PluginConfig
+
+type JavaToJSRequestArguments = ThemeChangedRequestArguments | PluginSettingsChangedRequestArguments
+
+export function handleRequest(
+    action: ActionName,
+    argumentsAsJsonString: string,
+    callback: (result: string) => void
+): void {
+    const argumentsAsObject = JSON.parse(argumentsAsJsonString) as JavaToJSRequestArguments
+    if (action === 'themeChanged') {
+        applyTheme(argumentsAsObject as ThemeChangedRequestArguments)
+        renderReactApp()
+        return callback(JSON.stringify(null))
+    }
+
+    if (action === 'pluginSettingsChanged') {
+        applyConfig(argumentsAsObject as PluginSettingsChangedRequestArguments)
+        renderReactApp()
+        return callback(JSON.stringify(null))
+    }
+
+    return callback('Unknown action.')
+}

--- a/client/jetbrains/webview/src/search/types.d.ts
+++ b/client/jetbrains/webview/src/search/types.d.ts
@@ -1,5 +1,6 @@
 import type { SearchPatternType } from '@sourcegraph/search'
 
+import type { ActionName } from './java-to-js-bridge'
 import type { Request } from './js-to-java-bridge'
 
 /* Add global functions to global window object */
@@ -7,6 +8,7 @@ declare global {
     interface Window {
         initializeSourcegraph: () => Promise<void>
         callJava: (request: Request) => Promise<object>
+        callJS: (action: ActionName, data: string, callback: (result: string) => void) => void
     }
 }
 


### PR DESCRIPTION
Closes #34797
Closes https://github.com/sourcegraph/sourcegraph/issues/34812

Creates a way to call JS from the Java side.
This is not trivial because the `JBCefJSQuery` object that runs the `executeJavaScript()` calls on the Java side has to be create _before_ the browser gets created.

[17 sec Loom where I enthusiastically demo the theme change](https://www.loom.com/share/e94e44742fa14c918c6cf66e311c3d3c)

Caveats:
 - The `JavaToJSBridge` is not shared as a service. I was lucky with the theme change event, because that actually travels through the IDE's event bus and I could set up an event listener in `SourcegraphJBCefBrowser` for it. But for our plugin setting change and other events, we'll either use the event bus, or share the bridge as a service so that it's accessible at arbitrary places.
 - I had to export a few things from the main `index.ts` file. This is not a nice direction of dependencies and will result in unwanted interdependencies if it's left this way. I think it's fine for now, as it's easy to refactor later.

## Test plan

- Watch the Loom
- Check the code
- The standalone version is not affected as it's not getting any calls from the (nonexistent) Java side.

## App preview:

- [Web](https://sg-web-dv-jetbrains-java-to-js-bridge.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-zmifvjdicf.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
