### PR TITLE
Fix link to docs on empty-auto-indexing page

### DIFF
--- a/client/web/src/enterprise/codeintel/indexes/components/EmptyAutoIndex.tsx
+++ b/client/web/src/enterprise/codeintel/indexes/components/EmptyAutoIndex.tsx
@@ -9,7 +9,7 @@ export const EmptyAutoIndex: React.FunctionComponent = () => (
         <MapSearchIcon className="mb-2" />
         <br />
         {'No indexes yet.  Enable precise code intelligence by '}
-        <Link to="/help/code_intelligence/how-to/index_a_go_repository" target="_blank" rel="noreferrer noopener">
+        <Link to="/help/code_intelligence/how-to/enable_auto_indexing" target="_blank" rel="noreferrer noopener">
             auto-indexing LSIF data
         </Link>
         .


### PR DESCRIPTION
I ran into this when recording the demo for auto-indexing yesterday. I
was surprised that the link didn't lead me anywhere close to
*auto*-indexing, but just to indexing a Go repository. I suspect it was
once a placeholder?

This now links to the "enable auto-indexing" page from which users can
either directly go to enable it or read up on what it is.

## Test plan

- Existing tests. It's a link.

## App preview:

- [Web](https://sg-web-mrn-link-auto-indexing.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-bqvynuosmg.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
