### PR TITLE
[Nav] fix integration tests

### DIFF
--- a/client/web/src/integration/nav.test.ts
+++ b/client/web/src/integration/nav.test.ts
@@ -43,12 +43,11 @@ const commonSearchGraphQLResults: Partial<WebGraphQlOperations & SharedGraphQlOp
         ),
     TreeEntries: () => createTreeEntriesResult('/github.com/sourcegraph/sourcegraph', ['README.md']),
     Blob: ({ filePath }) => createBlobContentResult(`content for: ${filePath}\nsecond line\nthird line`),
-    ListNotebooks: () => ({
-        notebooks: {
-            totalCount: 1,
-            nodes: [notebookFixture('id', 'Title', [])],
-            pageInfo: { endCursor: null, hasNextPage: false },
-        },
+    FetchNotebook: ({ id }) => ({
+        node: notebookFixture(id, 'Notebook Title', [
+            { __typename: 'MarkdownBlock', id: '1', markdownInput: '# Title' },
+            { __typename: 'QueryBlock', id: '2', queryInput: 'query' },
+        ]),
     }),
 }
 
@@ -124,8 +123,8 @@ describe('GlobalNavbar', () => {
             expect(active).toEqual('true')
         })
 
-        test('is not highlighted on batch changes page', async () => {
-            await driver.page.goto(driver.sourcegraphBaseUrl + '/batch-changes')
+        test('is not highlighted on notebook page', async () => {
+            await driver.page.goto(driver.sourcegraphBaseUrl + '/notebooks/id')
 
             const active = await driver.page.evaluate(() =>
                 document.querySelector('[data-test-id="/search"]')?.getAttribute('data-test-active')


### PR DESCRIPTION
Fix navbar code search highlight integration tests. 

https://sourcegraph.slack.com/archives/C02FLQDD3TQ/p1651528028103239

## Test plan

`yarn test-integration --grep 'GlobalNavbar'` should be green.

## App preview:

- [Web](https://sg-web-naman-fix-nav-integration-tests.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-mdfqqixxqn.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
