### PR TITLE
Code Insights: Ignore minutes in series data point dateTime field

### DIFF
--- a/client/web/src/enterprise/insights/core/backend/utils/create-line-chart-content.ts
+++ b/client/web/src/enterprise/insights/core/backend/utils/create-line-chart-content.ts
@@ -39,17 +39,26 @@ export function createLineChartContent(
         series: series
             .map<Series<BackendInsightDatum>>(line => ({
                 id: line.seriesId,
-                data: line.points.map((point, index) => ({
-                    dateTime: new Date(point.dateTime),
-                    value: point.value,
-                    link: generateLinkURL({
-                        previousPoint: line.points[index - 1],
-                        series: seriesDefinitionMap[line.seriesId],
-                        point,
-                        includeRepoRegexp,
-                        excludeRepoRegexp,
-                    }),
-                })),
+                data: line.points.map((point, index) => {
+                    const parsedDate = new Date(point.dateTime)
+
+                    return {
+                        dateTime: new Date(
+                            parsedDate.getFullYear(),
+                            parsedDate.getMonth(),
+                            parsedDate.getDay(),
+                            parsedDate.getHours()
+                        ),
+                        value: point.value,
+                        link: generateLinkURL({
+                            previousPoint: line.points[index - 1],
+                            series: seriesDefinitionMap[line.seriesId],
+                            point,
+                            includeRepoRegexp,
+                            excludeRepoRegexp,
+                        }),
+                    }
+                }),
                 name: seriesDefinitionMap[line.seriesId]?.name ?? line.label,
                 color: seriesDefinitionMap[line.seriesId]?.stroke,
                 getYValue: datum => datum.value,


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/30642

In this PR we ignore minutes in the series data points DateTime field. This fixes points grouping in the LineChart logic. 

Point from @Joelkw 
>Arbitrarily, if two points are within 10 minutes of each other, I think we should show the same tooltip (we could do more than 10 minutes as well – the threshold seems the easier part to change than just building this feature).

I think this is actually a great idea but this also will introduce a few perf problems if we have a lot of insights on the frontend. Related comment in the original issue thread https://github.com/sourcegraph/sourcegraph/issues/30642#issuecomment-1116072360

## Test plan
- Make sure that all insights in your account on k8s look fine 
<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->



## App preview:

- [Web](https://sg-web-vk-small-insight-time-differences.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-lxyfghzigr.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
