### PR TITLE
Jg experiment whitescreen

### DIFF
--- a/client/web/src/jscontext.ts
+++ b/client/web/src/jscontext.ts
@@ -148,6 +148,9 @@ export interface SourcegraphContext extends Pick<Required<SiteConfiguration>, 'e
 
     /** The publishable key for the billing service (Stripe). */
     billingPublishableKey?: string
+
+    /** Prompt users with browsers that would crash to download a modern browser. */
+    RedirectUnsupportedBrowser?: boolean
 }
 
 export interface BrandAssets {

--- a/cmd/frontend/internal/app/jscontext/jscontext.go
+++ b/cmd/frontend/internal/app/jscontext/jscontext.go
@@ -97,6 +97,8 @@ type JSContext struct {
 
 	CodeInsightsGQLApiEnabled bool `json:"codeInsightsGqlApiEnabled"`
 
+	RedirectUnsupportedBrowser bool `json:"RedirectUnsupportedBrowser"`
+
 	ProductResearchPageEnabled bool `json:"productResearchPageEnabled"`
 
 	ExperimentalFeatures schema.ExperimentalFeatures `json:"experimentalFeatures"`
@@ -143,6 +145,7 @@ func NewJSContextFromRequest(req *http.Request, db database.DB) JSContext {
 
 	var sentryDSN *string
 	siteConfig := conf.Get().SiteConfiguration
+
 	if siteConfig.Log != nil && siteConfig.Log.Sentry != nil && siteConfig.Log.Sentry.Dsn != "" {
 		sentryDSN = &siteConfig.Log.Sentry.Dsn
 	}
@@ -165,16 +168,17 @@ func NewJSContextFromRequest(req *http.Request, db database.DB) JSContext {
 	// authentication above, but do not include e.g. hard-coded secrets about
 	// the server instance here as they would be sent to anonymous users.
 	return JSContext{
-		ExternalURL:         globals.ExternalURL().String(),
-		XHRHeaders:          headers,
-		UserAgentIsBot:      isBot(req.UserAgent()),
-		AssetsRoot:          assetsutil.URL("").String(),
-		Version:             version.Version(),
-		IsAuthenticatedUser: actor.IsAuthenticated(),
-		Datadog:             datadogRUM,
-		SentryDSN:           sentryDSN,
-		Debug:               env.InsecureDev,
-		SiteID:              siteID,
+		ExternalURL:                globals.ExternalURL().String(),
+		XHRHeaders:                 headers,
+		UserAgentIsBot:             isBot(req.UserAgent()),
+		AssetsRoot:                 assetsutil.URL("").String(),
+		Version:                    version.Version(),
+		IsAuthenticatedUser:        actor.IsAuthenticated(),
+		Datadog:                    datadogRUM,
+		SentryDSN:                  sentryDSN,
+		RedirectUnsupportedBrowser: siteConfig.RedirectUnsupportedBrowser,
+		Debug:                      env.InsecureDev,
+		SiteID:                     siteID,
 
 		SiteGQLID: string(graphqlbackend.SiteGQLID()),
 

--- a/cmd/frontend/internal/app/ui/app.html
+++ b/cmd/frontend/internal/app/ui/app.html
@@ -2,7 +2,6 @@
 <html lang="en" class="base">
 
 <head>
-
 	{{.Injected.HeadTop}}
 	<meta charset="utf-8">
 	<meta http-equiv="x-ua-compatible" content="ie=edge">
@@ -44,10 +43,10 @@
 	<script src='https://js.sentry-cdn.com/ae2f74442b154faf90b5ff0f7cd1c618.min.js' crossorigin="anonymous"></script>
 	<!-- End Sentry -->
 	<!-- Datadog RUM -->
-    <script ignore-csp>(function(h,o,u,n,d) { h=h[d]=h[d]||{q:[],onReady:function(c){h.q.push(c)}}
-    d=o.createElement(u);d.async=1;d.src=n;n=o.getElementsByTagName(u)[0];
-    n.parentNode.insertBefore(d,n)})(window,document,'script',
-    'https://www.datadoghq-browser-agent.com/datadog-rum-v4.js','DD_RUM');</script>
+	<script ignore-csp>(function(h,o,u,n,d) { h=h[d]=h[d]||{q:[],onReady:function(c){h.q.push(c)}}
+	d=o.createElement(u);d.async=1;d.src=n;n=o.getElementsByTagName(u)[0];
+	n.parentNode.insertBefore(d,n)})(window,document,'script',
+	'https://www.datadoghq-browser-agent.com/datadog-rum-v4.js','DD_RUM');</script>
 	<!-- End Datadog RUM -->
 	{{ end }}
 	<script ignore-csp>
@@ -84,7 +83,19 @@
 
 	{{ end }}
 	{{.Injected.BodyTop}}
-	<div id="root"></div>
+	<div id="root">
+		{{ if .Context.RedirectUnsupportedBrowser }}
+			 <script ignore-csp>
+				function canRunSourceGraph(){"use strict";if("undefined"==typeof Symbol)return!1;try{eval("class Foo {}"),eval("var bar = (x) => x+1")}catch(r){return!1}return!0}
+				if (!canRunSourceGraph()) {
+					document.write("<h1 ignore-csp style=\"padding: 10px;\">It looks like Sourcegraph does not support your browser. Upgrade or install a JavaScript ES6 supported browser (<a href=\"https://www.microsoft.com/en-us/edge\">Edge</a>, <a href=\"https://www.apple.com/safari/\">Safari</a>, <a href=\"https://www.google.com/chrome/downloads\">Chrome</a>, <a href=\"https://www.mozilla.org/en-US/firefox/new/\">Firefox</a>)</h1>")
+
+					// makes everything below disabled so no crashes
+					document.write('<!--');
+				}
+			</script>
+		{{ end }}
+	</div>
 	<noscript>
 		<p>Sourcegraph is a web-based code search and navigation tool for dev teams. Search, navigate, and review code. Find answers.</p>
 

--- a/dev/check/template-inlines.sh
+++ b/dev/check/template-inlines.sh
@@ -17,7 +17,7 @@ main() {
     exit 1
   fi
   local found
-  found=$(grep -EHnr '(<script|<style|style=)' "${template_dir}" | grep -v '<script src=' | grep -v '<script ignore-csp' | grep -v '<div ignore-csp' | grep -v '<style ignore-csp' | grep -v '<iframe ignore-csp' || echo -n)
+  found=$(grep -EHnr '(<script|<style|style=)' "${template_dir}" | grep -v '<script src=' | grep -v '<script ignore-csp' | grep -v '<h1 ignore-csp' | grep -v '<div ignore-csp' | grep -v '<style ignore-csp' | grep -v '<iframe ignore-csp' || echo -n)
 
   if [[ ! "$found" == "" ]]; then
     echo '!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!'

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1757,6 +1757,8 @@ type SettingsExperimentalFeatures struct {
 
 // SiteConfiguration description: Configuration for a Sourcegraph site.
 type SiteConfiguration struct {
+	// RedirectUnsupportedBrowser description: Prompts user to install new browser for non es5
+	RedirectUnsupportedBrowser bool `json:"RedirectUnsupportedBrowser,omitempty"`
 	// ApiRatelimit description: Configuration for API rate limiting
 	ApiRatelimit *ApiRatelimit `json:"api.ratelimit,omitempty"`
 	// ApidocsSearchIndexSizeLimitFactor description: Deprecated.

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -60,6 +60,11 @@
       "type": "number",
       "default": -1
     },
+    "RedirectUnsupportedBrowser": {
+      "description": "Prompts user to install new browser for non es5",
+      "type": "boolean",
+      "default": false
+    },
     "experimentalFeatures": {
       "description": "Experimental features to enable or disable. Features that are now enabled by default are marked as deprecated.",
       "type": "object",


### PR DESCRIPTION
### Whitescreen prevention PR


this PR aims to give an action to users who would normally entirely whitescreen to upgrade their browser. This doubles with preventing the load of the main app itself which should remove many impossible to fix errors or "noise" from our logs.

Goals:
1. Save money on datapoints from these errors
2. Give users an action to upgrade
3. Prevent a whitescreen (bad user experience)

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


Use ngrok and test IE11 to make sure the browser doesn't entirely whitescreen