### PR TITLE
fix: filters do not work on featured extensions

### DIFF
--- a/client/web/src/extensions/ExtensionsList.tsx
+++ b/client/web/src/extensions/ExtensionsList.tsx
@@ -276,7 +276,7 @@ export const ExtensionsList: React.FunctionComponent<Props> = ({
     return (
         <>
             {error && <ErrorAlert className="mb-2" error={error} />}
-            {featuredExtensionsSection}
+            {enablementFilter === 'all' && featuredExtensionsSection}
             {categorySections.length > 0 ? (
                 categorySections
             ) : (


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/34799, this issue was identified while auditing https://github.com/sourcegraph/sourcegraph/issues/34052


## Before

Visit our[ extension registry page ](https://sourcegraph.com/extensions?category=All), under `All` Categories, select the filter at the bottom:

| Filter Enabled | Screenshot | Filtered Result |
| ------------------------------ |  ---------------- | -------- |
| All                           | ![image](https://user-images.githubusercontent.com/68532117/166488685-f928ce94-e90f-4288-8030-f5c065fefbfb.png)   |  All extensions are displayed         |
| Show enabled extensions | ![Screen Shot 2022-05-03 at 8 52 07 AM](https://user-images.githubusercontent.com/68532117/166489164-96b68c43-e561-43cf-9512-0a6a9187c249.png)  | The filtered result does not match the filter that is enabled. Disabled extensions from the Featured section is still showing up. |
| Show disabled extension |   ![image](https://user-images.githubusercontent.com/68532117/166489759-279b72b6-662f-4140-9707-2bd37dc18e52.png)  | The filtered result does not match the filter that is enabled. Enabled extensions from the Featured section is still showing up.  | 
 
## After

The issue was that the featured section shows up as a standalone even if the filter is enabled. Only display the featured section when the filter is set to `all` has resolve the issue:

| Filter Enabled | Screenshot | Filtered Result |
| ------------------------------ |  ---------------- | -------- |
| All                           | ![image](https://user-images.githubusercontent.com/68532117/166490040-d3862e92-6b00-4364-9913-999c662d6bef.png)   |  All extensions are displayed         |
| Show enabled extensions | ![image](https://user-images.githubusercontent.com/68532117/166490272-e4c89b29-1334-40ae-81ff-0545a469957b.png)  | Only enabled extensions are displayed |
| Show disabled extension |   ![image](https://user-images.githubusercontent.com/68532117/166490532-d347edf8-b6e9-4fea-93d7-18840d2f09be.png)  | Only disabled extensions are displayed  | 


## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

See screenshot above


## App preview:

- [Web](https://sg-web-bee-fix-featured.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-trgkhdyrqh.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
