### PR TITLE
observation: only trace.log if trace is present

### DIFF
--- a/internal/observation/observation.go
+++ b/internal/observation/observation.go
@@ -231,11 +231,11 @@ func (t *traceLogger) Log(fields ...otlog.Field) {
 	}
 	if t.trace != nil {
 		t.trace.LogFields(fields...)
-	}
-	if enableTraceLog {
-		t.Logger.
-			AddCallerSkip(1). // Log() -> Logger
-			Info("trace.log", toLogFields(fields)...)
+		if enableTraceLog {
+			t.Logger.
+				AddCallerSkip(1). // Log() -> Logger
+				Info("trace.log", toLogFields(fields)...)
+		}
 	}
 }
 


### PR DESCRIPTION
A trace isn't always present, `trace.log` should not emit anything if there's no trace attached. Maybe?

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

n/a
