### PR TITLE
fix: extension update and publish buttons accessibility issue

### DIFF
--- a/client/web/src/enterprise/extensions/extension/RegistryExtensionManagePage.tsx
+++ b/client/web/src/enterprise/extensions/extension/RegistryExtensionManagePage.tsx
@@ -3,6 +3,7 @@ import * as React from 'react'
 import classNames from 'classnames'
 import * as H from 'history'
 import AlertCircleIcon from 'mdi-react/AlertCircleIcon'
+import CheckCircleIcon from 'mdi-react/CheckCircleIcon'
 import { RouteComponentProps } from 'react-router'
 import { concat, Observable, Subject, Subscription } from 'rxjs'
 import { catchError, concatMap, map, tap } from 'rxjs/operators'
@@ -12,7 +13,7 @@ import { Form } from '@sourcegraph/branded/src/components/Form'
 import { asError, createAggregateError, ErrorLike, isErrorLike } from '@sourcegraph/common'
 import { gql } from '@sourcegraph/http-client'
 import * as GQL from '@sourcegraph/shared/src/schema'
-import { Button, LoadingSpinner, Link, CardHeader, CardBody, Card, Alert } from '@sourcegraph/wildcard'
+import { Button, LoadingSpinner, Link, CardHeader, CardBody, Card, Alert, Icon } from '@sourcegraph/wildcard'
 
 import { AuthenticatedUser } from '../../../auth'
 import { withAuthenticatedUser } from '../../../auth/withAuthenticatedUser'
@@ -178,9 +179,25 @@ export const RegistryExtensionManagePage = withAuthenticatedUser(
                                     </code>
                                 </Alert>
                             )}
-                        <Button type="submit" disabled={this.state.updateOrError === 'loading'} variant="primary">
-                            {this.state.updateOrError === 'loading' ? <LoadingSpinner /> : 'Update extension'}
-                        </Button>
+                        <div aria-live="polite">
+                            <Button
+                                type="submit"
+                                disabled={this.state.updateOrError === 'loading'}
+                                variant="primary"
+                                aria-label="Update Extension"
+                            >
+                                {this.state.updateOrError === 'loading' ? <LoadingSpinner /> : 'Update extension'}
+                            </Button>
+                            {this.state.updateOrError &&
+                                !isErrorLike(this.state.updateOrError) &&
+                                (this.state.updateOrError === 'loading' ? (
+                                    <LoadingSpinner />
+                                ) : (
+                                    <span className="text-success ml-2">
+                                        <Icon as={CheckCircleIcon} /> Updated extension successfully.
+                                    </span>
+                                ))}
+                        </div>
                     </Form>
                     {isErrorLike(this.state.updateOrError) && <ErrorAlert error={this.state.updateOrError} />}
                     <Card className={classNames('mt-5', styles.otherActions)}>

--- a/client/web/src/enterprise/extensions/extension/RegistryExtensionNewReleasePage.tsx
+++ b/client/web/src/enterprise/extensions/extension/RegistryExtensionNewReleasePage.tsx
@@ -201,7 +201,7 @@ export const RegistryExtensionNewReleasePage = withAuthenticatedUser<Props>(
                                     </div>
                                 </div>
                             </div>
-                            <div className="d-flex align-items-center">
+                            <div aria-live="polite" className="d-flex align-items-center">
                                 <Button
                                     type="submit"
                                     disabled={updateOrError === LOADING || isErrorLike(bundleOrError)}


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/34851 + https://github.com/sourcegraph/sourcegraph/issues/34839, these are bugs identified while performing an accessibility audit https://github.com/sourcegraph/sourcegraph/issues/34050

## Summary

When trying to `Update the name of the extension` & `Publish the extension`, I noticed:

The Update Extension button does not trigger anything after the form has been submitted. This caused confusion when using the Voice Over feature to navigate this task because I was not able to confirm whether I have clicked on the button correctly and if the extension has been updated after the button click. To fix this, I updated the “Update Extension” button  (the one used by the Publish button) to display if the extension has been updated successfully, and the screen reader will then read the message via the [aria-live](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions) option.

### Before 
![image](https://user-images.githubusercontent.com/68532117/166563517-2afd1952-915b-4a4d-a4e9-bcdf89465f0d.png)

### After
![image](https://user-images.githubusercontent.com/68532117/166563470-57d8dd77-c0f1-4e23-9500-b66123ece7a5.png)

For the Publish button, since the page does not re-render after the button is clicked, we should add the [aria-live](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions) option to read the status message after the button is clicked to let the users know if the extension is published successfully or not.

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

Tested using [screen reader](https://docs.sourcegraph.com/dev/background-information/web/accessibility/how-to-screen-reader)


## App preview:

- [Web](https://sg-web-bee-fix-aduit-publish.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-bsioniqtdg.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
