### PR TITLE
Bump src-cli version for new release.

### DIFF
--- a/doc/cli/references/lsif/upload.md
+++ b/doc/cli/references/lsif/upload.md
@@ -9,7 +9,7 @@
 | `-commit` | The 40-character hash of the commit. Defaults to the currently checked-out commit. |  |
 | `-file` | The path to the LSIF dump file. | `./dump.lsif` |
 | `-github-token` | A GitHub access token with 'public_repo' scope that Sourcegraph uses to verify you have access to the repository. |  |
-| `-gitlab-token` | A Gitlab access token with read and write repository scope that Sourcegraph uses to verify you have access to the repository. |  |
+| `-gitlab-token` | A GitLab access token with TODO that Sourcegraph uses to verify you have access to the repository. |  |
 | `-ignore-upload-failure` | Exit with status code zero on upload failure. | `false` |
 | `-indexer` | The name of the indexer that generated the dump. This will override the 'toolInfo.name' field in the metadata vertex of the LSIF dump file. This must be supplied if the indexer does not set this field (in which case the upload will fail with an explicit message). |  |
 | `-indexerVersion` | The version of the indexer that generated the dump. This will override the 'toolInfo.version' field in the metadata vertex of the LSIF dump file. This must be supplied if the indexer does not set this field (in which case the upload will fail with an explicit message). |  |
@@ -37,7 +37,7 @@ Usage of 'src lsif upload':
   -github-token string
     	A GitHub access token with 'public_repo' scope that Sourcegraph uses to verify you have access to the repository.
   -gitlab-token string
-    	A Gitlab access token with read and write repository scope that Sourcegraph uses to verify you have access to the repository.      
+    	A GitLab access token with TODO that Sourcegraph uses to verify you have access to the repository.
   -ignore-upload-failure
     	Exit with status code zero on upload failure.
   -indexer string
@@ -74,10 +74,9 @@ Examples:
     	$ src lsif upload -root=cmd/
 
   Upload an LSIF dump when lsifEnforceAuth is enabled:
-  
-      $ src lsif upload -github-token=BAZ   // for Github Code Host
 
-      $ src lsif upload -gitlab-token=BAZ  // for Gitlab Code Host
+    	$ src lsif upload -github-token=BAZ, or
+    	$ src lsif upload -gitlab-token=BAZ
 
   Upload an LSIF dump when the LSIF indexer does not not declare a tool name.
 

--- a/doc/cli/references/lsif/upload.md
+++ b/doc/cli/references/lsif/upload.md
@@ -9,7 +9,7 @@
 | `-commit` | The 40-character hash of the commit. Defaults to the currently checked-out commit. |  |
 | `-file` | The path to the LSIF dump file. | `./dump.lsif` |
 | `-github-token` | A GitHub access token with 'public_repo' scope that Sourcegraph uses to verify you have access to the repository. |  |
-| `-gitlab-token` | A GitLab access token with TODO that Sourcegraph uses to verify you have access to the repository. |  |
+| `-gitlab-token` | A GitLab access token with 'read_api' scope that Sourcegraph uses to verify you have access to the repository. |  |
 | `-ignore-upload-failure` | Exit with status code zero on upload failure. | `false` |
 | `-indexer` | The name of the indexer that generated the dump. This will override the 'toolInfo.name' field in the metadata vertex of the LSIF dump file. This must be supplied if the indexer does not set this field (in which case the upload will fail with an explicit message). |  |
 | `-indexerVersion` | The version of the indexer that generated the dump. This will override the 'toolInfo.version' field in the metadata vertex of the LSIF dump file. This must be supplied if the indexer does not set this field (in which case the upload will fail with an explicit message). |  |
@@ -37,7 +37,7 @@ Usage of 'src lsif upload':
   -github-token string
     	A GitHub access token with 'public_repo' scope that Sourcegraph uses to verify you have access to the repository.
   -gitlab-token string
-    	A GitLab access token with TODO that Sourcegraph uses to verify you have access to the repository.
+    	A GitLab access token with 'read_api' scope that Sourcegraph uses to verify you have access to the repository.
   -ignore-upload-failure
     	Exit with status code zero on upload failure.
   -indexer string

--- a/internal/src-cli/consts.go
+++ b/internal/src-cli/consts.go
@@ -6,4 +6,4 @@ package srccli
 // as the suggested download with this instance.
 //
 // At the time of a Sourcegraph release, this is always the latest src-cli version.
-const MinimumVersion = "3.39.0"
+const MinimumVersion = "3.39.1"

--- a/internal/src-cli/consts.go
+++ b/internal/src-cli/consts.go
@@ -6,4 +6,4 @@ package srccli
 // as the suggested download with this instance.
 //
 // At the time of a Sourcegraph release, this is always the latest src-cli version.
-const MinimumVersion = "3.39.1"
+const MinimumVersion = "3.39.2"


### PR DESCRIPTION
Following instructions for a release.
https://github.com/sourcegraph/src-cli/blob/main/DEVELOPMENT.md#releasing

## Test plan

Ran `curl` for the latest `src-cli` and checked the version.