### PR TITLE
Fix hover reposition jank 2

### DIFF
--- a/client/browser/src/shared/code-hosts/shared/codeHost.tsx
+++ b/client/browser/src/shared/code-hosts/shared/codeHost.tsx
@@ -136,10 +136,7 @@ import styles from './codeHost.module.scss'
 
 registerHighlightContributions()
 
-export interface OverlayPosition {
-    top: number
-    left: number
-}
+export type OverlayPosition = { left: number } & ({ top: number } | { bottom: number })
 
 export type ObserveMutations = (
     target: Node,

--- a/client/browser/src/shared/code-hosts/shared/codeHost.tsx
+++ b/client/browser/src/shared/code-hosts/shared/codeHost.tsx
@@ -382,8 +382,6 @@ function initCodeIntelligence({
     /** Emits whenever the ref callback for the hover element is called */
     const hoverOverlayElements = new Subject<HTMLElement | null>()
 
-    const relativeElement = document.body
-
     const containerComponentUpdates = new Subject<void>()
 
     subscription.add(
@@ -404,7 +402,7 @@ function initCodeIntelligence({
         hoverOverlayElements,
         hoverOverlayRerenders: containerComponentUpdates.pipe(
             withLatestFrom(hoverOverlayElements),
-            map(([, hoverOverlayElement]) => ({ hoverOverlayElement, relativeElement })),
+            map(([, hoverOverlayElement]) => ({ hoverOverlayElement })),
             filter(property('hoverOverlayElement', isDefined))
         ),
         getHover: ({ line, character, part, ...rest }) =>

--- a/client/codeintellify/src/hoverifier.ts
+++ b/client/codeintellify/src/hoverifier.ts
@@ -272,7 +272,7 @@ interface InternalHoverifierState<C extends object, D, A> {
     hoverOrError?: typeof LOADING | (HoverAttachment & D) | null | ErrorLike
 
     /** The desired position of the hover overlay */
-    hoverOverlayPosition?: { left: number; top: number }
+    hoverOverlayPosition?: { left: number } & ({ top: number } | { bottom: number })
 
     /** The currently hovered token */
     hoveredToken?: HoveredToken & C

--- a/client/codeintellify/src/hoverifier.ts
+++ b/client/codeintellify/src/hoverifier.ts
@@ -75,7 +75,7 @@ export interface HoverifierOptions<C extends object, D, A> {
         /**
          * The closest parent element that is `position: relative`
          */
-        relativeElement: HTMLElement
+        relativeElement?: HTMLElement
     }>
 
     hoverOverlayElements: Subscribable<HTMLElement | null>
@@ -569,7 +569,15 @@ export function createHoverifier<C extends object, D, A>({
                     ...rest,
                 })),
                 map(({ hoverOverlayElement, relativeElement, target }) =>
-                    target ? calculateOverlayPosition({ relativeElement, target, hoverOverlayElement }) : undefined
+                    target
+                        ? calculateOverlayPosition({
+                              relativeElement,
+                              target,
+                              hoverOverlayElement,
+                              windowInnerHeight: window.innerHeight,
+                              windowScrollY: window.scrollY,
+                          })
+                        : undefined
                 )
             )
             .subscribe(hoverOverlayPosition => {

--- a/client/codeintellify/src/overlayPosition.test.ts
+++ b/client/codeintellify/src/overlayPosition.test.ts
@@ -31,7 +31,7 @@ describe('overlay_position', () => {
                             target: rectangle(128, 220, 60, 16),
                             hoverOverlayElement: rectangle(28, 38, 350, 150),
                         }),
-                        { left: 100, top: 50 }
+                        { left: 100, bottom: 400 }
                     )
                 })
 
@@ -62,7 +62,7 @@ describe('overlay_position', () => {
                             target: rectangle(128, 220, 60, 16),
                             hoverOverlayElement: rectangle(28, -362, 350, 150),
                         }),
-                        { left: 100, top: 450 }
+                        { left: 100, bottom: 2400 }
                     )
                 })
 
@@ -96,7 +96,7 @@ describe('overlay_position', () => {
                             target: rectangle(128, 220, 60, 16),
                             hoverOverlayElement: rectangle(28, 38, 350, 150),
                         }),
-                        { left: 100, top: 50 }
+                        { left: 100, bottom: 400 }
                     )
                 })
 
@@ -127,7 +127,7 @@ describe('overlay_position', () => {
                             target: rectangle(128, 220, 60, 16),
                             hoverOverlayElement: rectangle(-172, -362, 350, 150),
                         }),
-                        { left: 300, top: 450 }
+                        { left: 300, bottom: 0 }
                     )
                 })
 

--- a/client/codeintellify/src/overlayPosition.test.ts
+++ b/client/codeintellify/src/overlayPosition.test.ts
@@ -30,6 +30,8 @@ describe('overlay_position', () => {
                             },
                             target: rectangle(128, 220, 60, 16),
                             hoverOverlayElement: rectangle(28, 38, 350, 150),
+                            windowInnerHeight: 500,
+                            windowScrollY: 0,
                         }),
                         { left: 100, bottom: 400 }
                     )
@@ -45,6 +47,8 @@ describe('overlay_position', () => {
                             },
                             target: rectangle(128, 120, 60, 16),
                             hoverOverlayElement: rectangle(28, 38, 350, 150),
+                            windowInnerHeight: 500,
+                            windowScrollY: 0,
                         }),
                         { left: 100, top: 116 }
                     )
@@ -61,6 +65,8 @@ describe('overlay_position', () => {
                             },
                             target: rectangle(128, 220, 60, 16),
                             hoverOverlayElement: rectangle(28, -362, 350, 150),
+                            windowInnerHeight: 500,
+                            windowScrollY: 0,
                         }),
                         { left: 100, bottom: 2400 }
                     )
@@ -76,6 +82,8 @@ describe('overlay_position', () => {
                             },
                             target: rectangle(128, 70, 60, 16),
                             hoverOverlayElement: rectangle(28, -362, 350, 150),
+                            windowInnerHeight: 500,
+                            windowScrollY: 0,
                         }),
                         { left: 100, top: 466 }
                     )
@@ -95,6 +103,8 @@ describe('overlay_position', () => {
                             },
                             target: rectangle(128, 220, 60, 16),
                             hoverOverlayElement: rectangle(28, 38, 350, 150),
+                            windowInnerHeight: 500,
+                            windowScrollY: 0,
                         }),
                         { left: 100, bottom: 400 }
                     )
@@ -110,6 +120,8 @@ describe('overlay_position', () => {
                             },
                             target: rectangle(128, 160, 60, 16),
                             hoverOverlayElement: rectangle(28, 38, 350, 150),
+                            windowInnerHeight: 500,
+                            windowScrollY: 0,
                         }),
                         { left: 100, top: 156 }
                     )
@@ -126,6 +138,8 @@ describe('overlay_position', () => {
                             },
                             target: rectangle(128, 220, 60, 16),
                             hoverOverlayElement: rectangle(-172, -362, 350, 150),
+                            windowInnerHeight: 500,
+                            windowScrollY: 0,
                         }),
                         { left: 300, bottom: 0 }
                     )
@@ -141,10 +155,40 @@ describe('overlay_position', () => {
                             },
                             target: rectangle(128, 70, 60, 16),
                             hoverOverlayElement: rectangle(-172, -362, 350, 150),
+                            windowInnerHeight: 500,
+                            windowScrollY: 0,
                         }),
                         { left: 300, top: 466 }
                     )
                 })
+            })
+        })
+
+        describe('without a relativeElement', () => {
+            it('should return a position above the given target if the overlay fits above', () => {
+                assert.deepStrictEqual(
+                    calculateOverlayPosition({
+                        relativeElement: undefined,
+                        target: rectangle(128, 220, 60, 16),
+                        hoverOverlayElement: rectangle(-172, -362, 350, 150),
+                        windowInnerHeight: 500,
+                        windowScrollY: 0,
+                    }),
+                    { left: 128, bottom: 280 }
+                )
+            })
+
+            it('should return a position below the a given target if the overlay does not fit above', () => {
+                assert.deepStrictEqual(
+                    calculateOverlayPosition({
+                        relativeElement: undefined,
+                        target: rectangle(128, 70, 60, 16),
+                        hoverOverlayElement: rectangle(-172, -362, 350, 150),
+                        windowInnerHeight: 500,
+                        windowScrollY: 0,
+                    }),
+                    { left: 128, top: 86 }
+                )
             })
         })
     })

--- a/client/codeintellify/src/overlayPosition.ts
+++ b/client/codeintellify/src/overlayPosition.ts
@@ -12,12 +12,7 @@ export interface CalculateOverlayPositionOptions {
     hoverOverlayElement: HasGetBoundingClientRect
 }
 
-export interface CSSOffsets {
-    /** Offset from the left in pixel */
-    left: number
-    /** Offset from the top in pixel */
-    top: number
-}
+export type CSSOffsets = { left: number } & ({ top: number } | { bottom: number })
 
 /**
  * Calculates the desired position of the hover overlay depending on the container,
@@ -35,19 +30,21 @@ export const calculateOverlayPosition = ({
     // If the relativeElement is scrolled horizontally, we need to account for the offset (if not scrollLeft will be 0)
     const relativeHoverOverlayLeft = targetBounds.left + relativeElement.scrollLeft - relativeElementBounds.left
 
-    let relativeHoverOverlayTop: number
     // Check if the top of the hover overlay would be outside of the relative element or the viewport
     if (targetBounds.top - hoverOverlayBounds.height < Math.max(relativeElementBounds.top, 0)) {
         // Position it below the target
         // If the relativeElement is scrolled, we need to account for the offset (if not scrollTop will be 0)
-        relativeHoverOverlayTop = targetBounds.bottom - relativeElementBounds.top + relativeElement.scrollTop
-    } else {
-        // Else position it above the target
-        // Caculate the offset from the top of the relativeElement content to the top of the target
-        // If the relativeElement is scrolled, we need to account for the offset (if not scrollTop will be 0)
-        const relativeTargetTop = targetBounds.top - relativeElementBounds.top + relativeElement.scrollTop
-        relativeHoverOverlayTop = relativeTargetTop - hoverOverlayBounds.height
+        return {
+            left: relativeHoverOverlayLeft,
+            top: targetBounds.bottom - relativeElementBounds.top + relativeElement.scrollTop,
+        }
     }
 
-    return { left: relativeHoverOverlayLeft, top: relativeHoverOverlayTop }
+    // Else position it above the target
+    // If the relativeElement is scrolled, we need to account for the offset (if not scrollTop will be 0)
+    return {
+        left: relativeHoverOverlayLeft,
+        bottom:
+            relativeElementBounds.height - (targetBounds.top - relativeElementBounds.top + relativeElement.scrollTop),
+    }
 }

--- a/client/codeintellify/src/types.ts
+++ b/client/codeintellify/src/types.ts
@@ -14,7 +14,7 @@ export interface HoverOverlayProps<C extends object, D, A> {
     hoverOrError?: typeof LOADING | (HoverAttachment & D) | null | ErrorLike
 
     /** The position of the tooltip (assigned to `style`) */
-    overlayPosition?: { left: number; top: number }
+    overlayPosition?: { left: number } & ({ top: number } | { bottom: number })
 
     /**
      * The hovered token (position and word).

--- a/client/shared/src/hover/HoverOverlay.tsx
+++ b/client/shared/src/hover/HoverOverlay.tsx
@@ -62,18 +62,24 @@ export interface HoverOverlayProps
     useBrandedLogo?: boolean
 }
 
-const getOverlayStyle = (overlayPosition: HoverOverlayProps['overlayPosition']): CSSProperties =>
-    overlayPosition
-        ? {
-              opacity: 1,
-              visibility: 'visible',
-              left: `${overlayPosition.left}px`,
-              top: `${overlayPosition.top}px`,
-          }
-        : {
-              opacity: 0,
-              visibility: 'hidden',
-          }
+const getOverlayStyle = (overlayPosition: HoverOverlayProps['overlayPosition']): CSSProperties => {
+    if (!overlayPosition) {
+        return {
+            opacity: 0,
+            visibility: 'hidden',
+        }
+    }
+
+    const topOrBottom = 'top' in overlayPosition ? 'top' : 'bottom'
+    const topOrBottomValue = 'top' in overlayPosition ? overlayPosition.top : overlayPosition.bottom
+
+    return {
+        opacity: 1,
+        visibility: 'visible',
+        left: `${overlayPosition.left}px`,
+        [topOrBottom]: `${topOrBottomValue}px`,
+    }
+}
 
 export const HoverOverlay: React.FunctionComponent<HoverOverlayProps> = props => {
     const {


### PR DESCRIPTION
- https://github.com/sourcegraph/sourcegraph/pull/34028 Original PR
- https://github.com/sourcegraph/sourcegraph/pull/34206 Revert
- This PR reapplies the original PR with a fix that avoids the [bug](https://github.com/sourcegraph/sourcegraph/issues/34184) in the original

Only the "fix" commit needs to be reviewed (and subsequent commits if there are any).

Fixes https://github.com/sourcegraph/sourcegraph/issues/33987

## Test plan

Manual + automated tests

## App preview:

- [Web](https://sg-web-fix-hover-reposition-jank-2.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-niyqlxildk.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
