### PR TITLE
Search backend: Rename `commit.CommitSearch` to `commit.CommitSearchJob`

### DIFF
--- a/enterprise/internal/codemonitors/search.go
+++ b/enterprise/internal/codemonitors/search.go
@@ -192,7 +192,7 @@ func addCodeMonitorHook(in job.Job, hook commit.CodeMonitorHook) (_ job.Job, err
 	commitSearchJobCount := 0
 	return jobutil.MapAtom(in, func(atom job.Job) job.Job {
 		switch typedAtom := atom.(type) {
-		case *commit.CommitSearch:
+		case *commit.CommitSearchJob:
 			commitSearchJobCount++
 			if commitSearchJobCount > 1 {
 				err = errors.Append(err, ErrInvalidMonitorQuery)

--- a/enterprise/internal/codemonitors/search_test.go
+++ b/enterprise/internal/codemonitors/search_test.go
@@ -25,9 +25,9 @@ func TestAddCodeMonitorHook(t *testing.T) {
 
 	t.Run("errors on non-commit search", func(t *testing.T) {
 		erroringJobs := []job.Job{
-			jobutil.NewParallelJob(&run.RepoSearch{}, &commit.CommitSearch{}),
+			jobutil.NewParallelJob(&run.RepoSearch{}, &commit.CommitSearchJob{}),
 			&run.RepoSearch{},
-			jobutil.NewAndJob(&searcher.SymbolSearcher{}, &commit.CommitSearch{}),
+			jobutil.NewAndJob(&searcher.SymbolSearcher{}, &commit.CommitSearchJob{}),
 			jobutil.NewTimeoutJob(0, &run.RepoSearch{}),
 		}
 
@@ -40,15 +40,15 @@ func TestAddCodeMonitorHook(t *testing.T) {
 	})
 
 	t.Run("error on multiple commit search jobs", func(t *testing.T) {
-		_, err := addCodeMonitorHook(jobutil.NewAndJob(&commit.CommitSearch{}, &commit.CommitSearch{}), nil)
+		_, err := addCodeMonitorHook(jobutil.NewAndJob(&commit.CommitSearchJob{}, &commit.CommitSearchJob{}), nil)
 		require.Error(t, err)
 	})
 
 	t.Run("no errors on only commit search", func(t *testing.T) {
 		nonErroringJobs := []job.Job{
-			jobutil.NewLimitJob(1000, &commit.CommitSearch{}),
-			&commit.CommitSearch{},
-			jobutil.NewTimeoutJob(0, &commit.CommitSearch{}),
+			jobutil.NewLimitJob(1000, &commit.CommitSearchJob{}),
+			&commit.CommitSearchJob{},
+			jobutil.NewTimeoutJob(0, &commit.CommitSearchJob{}),
 		}
 
 		for _, j := range nonErroringJobs {

--- a/internal/search/job/jobutil/job.go
+++ b/internal/search/job/jobutil/job.go
@@ -763,7 +763,7 @@ func optimizeJobs(baseJob job.Job, inputs *run.SearchInputs, q query.Basic) (job
 				return currentJob
 
 			case *commit.CommitSearchJob:
-				if exists("Commit") || exists("Diff") {
+				if exists("CommitSearchJob") || exists("DiffSearchJob") {
 					return &noopJob{}
 				}
 				return currentJob

--- a/internal/search/job/jobutil/job.go
+++ b/internal/search/job/jobutil/job.go
@@ -154,7 +154,7 @@ func ToSearchJob(searchInputs *run.SearchInputs, b query.Basic) (job.Job, error)
 
 		if resultTypes.Has(result.TypeCommit) || resultTypes.Has(result.TypeDiff) {
 			diff := resultTypes.Has(result.TypeDiff)
-			addJob(&commit.CommitSearch{
+			addJob(&commit.CommitSearchJob{
 				Query:                commit.QueryToGitQuery(b, diff),
 				RepoOpts:             repoOptions,
 				Diff:                 diff,
@@ -710,7 +710,7 @@ func optimizeJobs(baseJob job.Job, inputs *run.SearchInputs, q query.Basic) (job
 				*symbol.RepoUniverseSymbolSearch,
 				*zoekt.ZoektRepoSubsetSearch,
 				*zoekt.ZoektSymbolSearch,
-				*commit.CommitSearch:
+				*commit.CommitSearchJob:
 				optimizedJobs = append(optimizedJobs, currentJob)
 				return currentJob
 			default:
@@ -762,7 +762,7 @@ func optimizeJobs(baseJob job.Job, inputs *run.SearchInputs, q query.Basic) (job
 				}
 				return currentJob
 
-			case *commit.CommitSearch:
+			case *commit.CommitSearchJob:
 				if exists("Commit") || exists("Diff") {
 					return &noopJob{}
 				}

--- a/internal/search/job/jobutil/job_test.go
+++ b/internal/search/job/jobutil/job_test.go
@@ -110,20 +110,20 @@ func TestToSearchInputs(t *testing.T) {
 
 	autogold.Want("commit", `
 (PARALLEL
-  Commit
+  CommitSearchJob
   ComputeExcludedRepos)
 `).Equal(t, test("type:commit test", search.Streaming, query.ParseRegexp))
 
 	autogold.Want("diff", `
 (PARALLEL
-  Diff
+  DiffSearchJob
   ComputeExcludedRepos)
 `).Equal(t, test("type:diff test", search.Streaming, query.ParseRegexp))
 
 	autogold.Want("Streaming: file or commit", `
 (PARALLEL
   ZoektGlobalSearch
-  Commit
+  CommitSearchJob
   ComputeExcludedRepos)
 `).Equal(t, test("type:file type:commit test", search.Streaming, query.ParseRegexp))
 
@@ -137,7 +137,7 @@ func TestToSearchInputs(t *testing.T) {
     (PARALLEL
       ZoektSymbolSearch
       SymbolSearcher))
-  Commit
+  CommitSearchJob
   RepoSearch
   ComputeExcludedRepos)
 `).Equal(t, test("type:file type:path type:repo type:commit type:symbol repo:test test", search.Streaming, query.ParseRegexp))
@@ -146,7 +146,7 @@ func TestToSearchInputs(t *testing.T) {
 	autogold.Want("Batched: file or commit", `
 (PARALLEL
   ZoektGlobalSearch
-  Commit
+  CommitSearchJob
   ComputeExcludedRepos)
 `).Equal(t, test("type:file type:commit test", search.Batch, query.ParseRegexp))
 
@@ -160,7 +160,7 @@ func TestToSearchInputs(t *testing.T) {
     (PARALLEL
       ZoektSymbolSearch
       SymbolSearcher))
-  Commit
+  CommitSearchJob
   RepoSearch
   ComputeExcludedRepos)
 `).Equal(t, test("type:file type:path type:repo type:commit type:symbol repo:test test", search.Batch, query.ParseRegexp))

--- a/internal/search/job/jobutil/mapper.go
+++ b/internal/search/job/jobutil/mapper.go
@@ -26,7 +26,7 @@ type Mapper struct {
 	MapRepoSearchJob               func(*run.RepoSearch) *run.RepoSearch
 	MapRepoUniverseTextSearchJob   func(*zoekt.GlobalSearch) *zoekt.GlobalSearch
 	MapStructuralSearchJob         func(*structural.StructuralSearch) *structural.StructuralSearch
-	MapCommitSearchJob             func(*commit.CommitSearch) *commit.CommitSearch
+	MapCommitSearchJob             func(*commit.CommitSearchJob) *commit.CommitSearchJob
 	MapRepoUniverseSymbolSearchJob func(*symbol.RepoUniverseSymbolSearch) *symbol.RepoUniverseSymbolSearch
 	MapComputeExcludedReposJob     func(*repos.ComputeExcludedRepos) *repos.ComputeExcludedRepos
 
@@ -101,7 +101,7 @@ func (m *Mapper) Map(j job.Job) job.Job {
 		}
 		return j
 
-	case *commit.CommitSearch:
+	case *commit.CommitSearchJob:
 		if m.MapCommitSearchJob != nil {
 			j = m.MapCommitSearchJob(j)
 		}
@@ -225,7 +225,7 @@ func MapAtom(j job.Job, f func(job.Job) job.Job) job.Job {
 				*searcher.SymbolSearcher,
 				*run.RepoSearch,
 				*structural.StructuralSearch,
-				*commit.CommitSearch,
+				*commit.CommitSearchJob,
 				*symbol.RepoUniverseSymbolSearch,
 				*repos.ComputeExcludedRepos,
 				*noopJob:

--- a/internal/search/job/jobutil/printers.go
+++ b/internal/search/job/jobutil/printers.go
@@ -48,7 +48,7 @@ func SexpFormat(j job.Job, sep, indent string) string {
 			*run.RepoSearch,
 			*zoekt.GlobalSearch,
 			*structural.StructuralSearch,
-			*commit.CommitSearch,
+			*commit.CommitSearchJob,
 			*symbol.RepoUniverseSymbolSearch,
 			*repos.ComputeExcludedRepos,
 			*noopJob:
@@ -208,7 +208,7 @@ func PrettyMermaid(j job.Job) string {
 			*run.RepoSearch,
 			*zoekt.GlobalSearch,
 			*structural.StructuralSearch,
-			*commit.CommitSearch,
+			*commit.CommitSearchJob,
 			*symbol.RepoUniverseSymbolSearch,
 			*repos.ComputeExcludedRepos,
 			*noopJob:
@@ -326,7 +326,7 @@ func toJSON(j job.Job, verbose bool) interface{} {
 			*run.RepoSearch,
 			*zoekt.GlobalSearch,
 			*structural.StructuralSearch,
-			*commit.CommitSearch,
+			*commit.CommitSearchJob,
 			*symbol.RepoUniverseSymbolSearch,
 			*repos.ComputeExcludedRepos,
 			*noopJob:

--- a/internal/search/job/jobutil/testdata/Test_optimizeJobs/commit_with_and.golden
+++ b/internal/search/job/jobutil/testdata/Test_optimizeJobs/commit_with_and.golden
@@ -13,12 +13,12 @@ BASE:
         (LIMIT
           40000
           (PARALLEL
-            Commit
+            CommitSearchJob
             ComputeExcludedRepos))
         (LIMIT
           40000
           (PARALLEL
-            Commit
+            CommitSearchJob
             ComputeExcludedRepos))))))
 
 OPTIMIZED:
@@ -29,7 +29,7 @@ OPTIMIZED:
     (LIMIT
       500
       (PARALLEL
-        Commit
+        CommitSearchJob
         (AND
           (LIMIT
             40000

--- a/internal/search/job/jobutil/testdata/Test_optimizeJobs/commit_with_or.golden
+++ b/internal/search/job/jobutil/testdata/Test_optimizeJobs/commit_with_or.golden
@@ -11,10 +11,10 @@ BASE:
       500
       (OR
         (PARALLEL
-          Commit
+          CommitSearchJob
           ComputeExcludedRepos)
         (PARALLEL
-          Commit
+          CommitSearchJob
           ComputeExcludedRepos)))))
 
 OPTIMIZED:
@@ -25,7 +25,7 @@ OPTIMIZED:
     (LIMIT
       500
       (PARALLEL
-        Commit
+        CommitSearchJob
         (OR
           (PARALLEL
             NoopJob

--- a/internal/search/job/jobutil/testdata/Test_optimizeJobs/diff_with_and.golden
+++ b/internal/search/job/jobutil/testdata/Test_optimizeJobs/diff_with_and.golden
@@ -13,12 +13,12 @@ BASE:
         (LIMIT
           40000
           (PARALLEL
-            Diff
+            DiffSearchJob
             ComputeExcludedRepos))
         (LIMIT
           40000
           (PARALLEL
-            Diff
+            DiffSearchJob
             ComputeExcludedRepos))))))
 
 OPTIMIZED:
@@ -29,7 +29,7 @@ OPTIMIZED:
     (LIMIT
       500
       (PARALLEL
-        Diff
+        DiffSearchJob
         (AND
           (LIMIT
             40000

--- a/internal/search/job/jobutil/testdata/Test_optimizeJobs/diff_with_or.golden
+++ b/internal/search/job/jobutil/testdata/Test_optimizeJobs/diff_with_or.golden
@@ -11,10 +11,10 @@ BASE:
       500
       (OR
         (PARALLEL
-          Diff
+          DiffSearchJob
           ComputeExcludedRepos)
         (PARALLEL
-          Diff
+          DiffSearchJob
           ComputeExcludedRepos)))))
 
 OPTIMIZED:
@@ -25,7 +25,7 @@ OPTIMIZED:
     (LIMIT
       500
       (PARALLEL
-        Diff
+        DiffSearchJob
         (OR
           (PARALLEL
             NoopJob

--- a/internal/search/job/jobutil/types.go
+++ b/internal/search/job/jobutil/types.go
@@ -19,7 +19,7 @@ var allJobs = []job.Job{
 	&run.RepoSearch{},
 	&zoekt.GlobalSearch{},
 	&structural.StructuralSearch{},
-	&commit.CommitSearch{},
+	&commit.CommitSearchJob{},
 	&symbol.RepoUniverseSymbolSearch{},
 	&repos.ComputeExcludedRepos{},
 	&noopJob{},


### PR DESCRIPTION
Related to #34009

Because `commit.CommitSearch` implements `job.Job`, renaming `commit.CommitSearch` to `commit.CommitSearchJob` for clarity when reading the code and looking at traces.

## Test plan
Semantics-preserving.
