### PR TITLE
Search backend: Rename `repos.ComputeExcludedRepos` to `repos.ComputeExcludedReposJob`

### DIFF
--- a/enterprise/internal/codemonitors/search.go
+++ b/enterprise/internal/codemonitors/search.go
@@ -200,8 +200,8 @@ func addCodeMonitorHook(in job.Job, hook commit.CodeMonitorHook) (_ job.Job, err
 			jobCopy := *typedAtom
 			jobCopy.CodeMonitorSearchWrapper = hook
 			return &jobCopy
-		case *repos.ComputeExcludedRepos:
-			// ComputeExcludedRepos is fine for code monitor jobs
+		case *repos.ComputeExcludedReposJob:
+			// ComputeExcludedReposJob is fine for code monitor jobs
 			return atom
 		default:
 			err = errors.Append(err, errors.Errorf("found invalid atom job type %T for code monitor search", atom))

--- a/internal/search/job/jobutil/job.go
+++ b/internal/search/job/jobutil/job.go
@@ -286,7 +286,7 @@ func ToSearchJob(searchInputs *run.SearchInputs, b query.Basic) (job.Job, error)
 		}
 	}
 
-	addJob(&searchrepos.ComputeExcludedRepos{
+	addJob(&searchrepos.ComputeExcludedReposJob{
 		Options: repoOptions,
 	})
 

--- a/internal/search/job/jobutil/job_test.go
+++ b/internal/search/job/jobutil/job_test.go
@@ -37,21 +37,21 @@ func TestToSearchInputs(t *testing.T) {
       ZoektRepoSubset
       Searcher))
   RepoSearch
-  ComputeExcludedRepos)
+  ComputeExcludedReposJob)
 `).Equal(t, test(`foo context:@userA`, search.Streaming, query.ParseLiteral))
 
 	autogold.Want("universal (AKA global) search context", `
 (PARALLEL
   ZoektGlobalSearch
   RepoSearch
-  ComputeExcludedRepos)
+  ComputeExcludedReposJob)
 `).Equal(t, test(`foo context:global`, search.Streaming, query.ParseLiteral))
 
 	autogold.Want("universal (AKA global) search", `
 (PARALLEL
   ZoektGlobalSearch
   RepoSearch
-  ComputeExcludedRepos)
+  ComputeExcludedReposJob)
 `).Equal(t, test(`foo`, search.Streaming, query.ParseLiteral))
 
 	autogold.Want("nonglobal repo", `
@@ -61,7 +61,7 @@ func TestToSearchInputs(t *testing.T) {
       ZoektRepoSubset
       Searcher))
   RepoSearch
-  ComputeExcludedRepos)
+  ComputeExcludedReposJob)
 `).Equal(t, test(`foo repo:sourcegraph/sourcegraph`, search.Streaming, query.ParseLiteral))
 
 	autogold.Want("nonglobal repo contains", `
@@ -71,7 +71,7 @@ func TestToSearchInputs(t *testing.T) {
       ZoektRepoSubset
       Searcher))
   RepoSearch
-  ComputeExcludedRepos)
+  ComputeExcludedReposJob)
 `).Equal(t, test(`foo repo:contains(bar)`, search.Streaming, query.ParseLiteral))
 
 	// Job generation support for implied `type:repo` queries.
@@ -79,52 +79,52 @@ func TestToSearchInputs(t *testing.T) {
 (PARALLEL
   ZoektGlobalSearch
   RepoSearch
-  ComputeExcludedRepos)
+  ComputeExcludedReposJob)
 `).Equal(t, test("ok ok", search.Streaming, query.ParseRegexp))
 
 	autogold.Want("supportedRepo job literal", `
 (PARALLEL
   ZoektGlobalSearch
   RepoSearch
-  ComputeExcludedRepos)
+  ComputeExcludedReposJob)
 `).Equal(t, test("ok @thing", search.Streaming, query.ParseLiteral))
 
 	autogold.Want("unsupported Repo job prefix", `
 (PARALLEL
   ZoektGlobalSearch
-  ComputeExcludedRepos)
+  ComputeExcludedReposJob)
 `).Equal(t, test("@nope", search.Streaming, query.ParseRegexp))
 
 	autogold.Want("unsupported Repo job regexp", `
 (PARALLEL
   ZoektGlobalSearch
-  ComputeExcludedRepos)
+  ComputeExcludedReposJob)
 `).Equal(t, test("foo @bar", search.Streaming, query.ParseRegexp))
 
 	// Job generation for other types of search
 	autogold.Want("symbol", `
 (PARALLEL
   RepoUniverseSymbolSearch
-  ComputeExcludedRepos)
+  ComputeExcludedReposJob)
 `).Equal(t, test("type:symbol test", search.Streaming, query.ParseRegexp))
 
 	autogold.Want("commit", `
 (PARALLEL
   CommitSearchJob
-  ComputeExcludedRepos)
+  ComputeExcludedReposJob)
 `).Equal(t, test("type:commit test", search.Streaming, query.ParseRegexp))
 
 	autogold.Want("diff", `
 (PARALLEL
   DiffSearchJob
-  ComputeExcludedRepos)
+  ComputeExcludedReposJob)
 `).Equal(t, test("type:diff test", search.Streaming, query.ParseRegexp))
 
 	autogold.Want("Streaming: file or commit", `
 (PARALLEL
   ZoektGlobalSearch
   CommitSearchJob
-  ComputeExcludedRepos)
+  ComputeExcludedReposJob)
 `).Equal(t, test("type:file type:commit test", search.Streaming, query.ParseRegexp))
 
 	autogold.Want("Streaming: many types", `
@@ -139,7 +139,7 @@ func TestToSearchInputs(t *testing.T) {
       SymbolSearcher))
   CommitSearchJob
   RepoSearch
-  ComputeExcludedRepos)
+  ComputeExcludedReposJob)
 `).Equal(t, test("type:file type:path type:repo type:commit type:symbol repo:test test", search.Streaming, query.ParseRegexp))
 
 	// Priority jobs for Batched search.
@@ -147,7 +147,7 @@ func TestToSearchInputs(t *testing.T) {
 (PARALLEL
   ZoektGlobalSearch
   CommitSearchJob
-  ComputeExcludedRepos)
+  ComputeExcludedReposJob)
 `).Equal(t, test("type:file type:commit test", search.Batch, query.ParseRegexp))
 
 	autogold.Want("Batched: many types", `
@@ -162,7 +162,7 @@ func TestToSearchInputs(t *testing.T) {
       SymbolSearcher))
   CommitSearchJob
   RepoSearch
-  ComputeExcludedRepos)
+  ComputeExcludedReposJob)
 `).Equal(t, test("type:file type:path type:repo type:commit type:symbol repo:test test", search.Batch, query.ParseRegexp))
 }
 
@@ -185,14 +185,14 @@ func TestToEvaluateJob(t *testing.T) {
 (PARALLEL
   ZoektGlobalSearch
   RepoSearch
-  ComputeExcludedRepos)
+  ComputeExcludedReposJob)
 `).Equal(t, test("foo", search.Streaming))
 
 	autogold.Want("root limit for batch search", `
 (PARALLEL
   ZoektGlobalSearch
   RepoSearch
-  ComputeExcludedRepos)
+  ComputeExcludedReposJob)
 `).Equal(t, test("foo", search.Batch))
 }
 

--- a/internal/search/job/jobutil/mapper.go
+++ b/internal/search/job/jobutil/mapper.go
@@ -28,7 +28,7 @@ type Mapper struct {
 	MapStructuralSearchJob         func(*structural.StructuralSearch) *structural.StructuralSearch
 	MapCommitSearchJob             func(*commit.CommitSearchJob) *commit.CommitSearchJob
 	MapRepoUniverseSymbolSearchJob func(*symbol.RepoUniverseSymbolSearch) *symbol.RepoUniverseSymbolSearch
-	MapComputeExcludedReposJob     func(*repos.ComputeExcludedRepos) *repos.ComputeExcludedRepos
+	MapComputeExcludedReposJob     func(*repos.ComputeExcludedReposJob) *repos.ComputeExcludedReposJob
 
 	// Repo pager Job (pre-step for some Search Jobs)
 	MapRepoPagerJob func(*repoPagerJob) *repoPagerJob
@@ -113,7 +113,7 @@ func (m *Mapper) Map(j job.Job) job.Job {
 		}
 		return j
 
-	case *repos.ComputeExcludedRepos:
+	case *repos.ComputeExcludedReposJob:
 		if m.MapComputeExcludedReposJob != nil {
 			j = m.MapComputeExcludedReposJob(j)
 		}
@@ -227,7 +227,7 @@ func MapAtom(j job.Job, f func(job.Job) job.Job) job.Job {
 				*structural.StructuralSearch,
 				*commit.CommitSearchJob,
 				*symbol.RepoUniverseSymbolSearch,
-				*repos.ComputeExcludedRepos,
+				*repos.ComputeExcludedReposJob,
 				*noopJob:
 				return f(typedJob)
 			default:

--- a/internal/search/job/jobutil/printers.go
+++ b/internal/search/job/jobutil/printers.go
@@ -50,7 +50,7 @@ func SexpFormat(j job.Job, sep, indent string) string {
 			*structural.StructuralSearch,
 			*commit.CommitSearchJob,
 			*symbol.RepoUniverseSymbolSearch,
-			*repos.ComputeExcludedRepos,
+			*repos.ComputeExcludedReposJob,
 			*noopJob:
 			b.WriteString(j.Name())
 
@@ -210,7 +210,7 @@ func PrettyMermaid(j job.Job) string {
 			*structural.StructuralSearch,
 			*commit.CommitSearchJob,
 			*symbol.RepoUniverseSymbolSearch,
-			*repos.ComputeExcludedRepos,
+			*repos.ComputeExcludedReposJob,
 			*noopJob:
 			writeNode(b, depth, RoundedStyle, &id, j.Name())
 
@@ -328,7 +328,7 @@ func toJSON(j job.Job, verbose bool) interface{} {
 			*structural.StructuralSearch,
 			*commit.CommitSearchJob,
 			*symbol.RepoUniverseSymbolSearch,
-			*repos.ComputeExcludedRepos,
+			*repos.ComputeExcludedReposJob,
 			*noopJob:
 			if verbose {
 				return map[string]interface{}{j.Name(): j}

--- a/internal/search/job/jobutil/printers_test.go
+++ b/internal/search/job/jobutil/printers_test.go
@@ -259,7 +259,7 @@ func TestPrettyJSON(t *testing.T) {
       }
     },
     {
-      "ComputeExcludedRepos": {
+      "ComputeExcludedReposJob": {
         "Options": {
           "RepoFilters": [
             "foo"

--- a/internal/search/job/jobutil/testdata/Test_optimizeJobs/commit_with_and.golden
+++ b/internal/search/job/jobutil/testdata/Test_optimizeJobs/commit_with_and.golden
@@ -14,12 +14,12 @@ BASE:
           40000
           (PARALLEL
             CommitSearchJob
-            ComputeExcludedRepos))
+            ComputeExcludedReposJob))
         (LIMIT
           40000
           (PARALLEL
             CommitSearchJob
-            ComputeExcludedRepos))))))
+            ComputeExcludedReposJob))))))
 
 OPTIMIZED:
 
@@ -35,9 +35,9 @@ OPTIMIZED:
             40000
             (PARALLEL
               NoopJob
-              ComputeExcludedRepos))
+              ComputeExcludedReposJob))
           (LIMIT
             40000
             (PARALLEL
               NoopJob
-              ComputeExcludedRepos)))))))
+              ComputeExcludedReposJob)))))))

--- a/internal/search/job/jobutil/testdata/Test_optimizeJobs/commit_with_or.golden
+++ b/internal/search/job/jobutil/testdata/Test_optimizeJobs/commit_with_or.golden
@@ -12,10 +12,10 @@ BASE:
       (OR
         (PARALLEL
           CommitSearchJob
-          ComputeExcludedRepos)
+          ComputeExcludedReposJob)
         (PARALLEL
           CommitSearchJob
-          ComputeExcludedRepos)))))
+          ComputeExcludedReposJob)))))
 
 OPTIMIZED:
 
@@ -29,7 +29,7 @@ OPTIMIZED:
         (OR
           (PARALLEL
             NoopJob
-            ComputeExcludedRepos)
+            ComputeExcludedReposJob)
           (PARALLEL
             NoopJob
-            ComputeExcludedRepos))))))
+            ComputeExcludedReposJob))))))

--- a/internal/search/job/jobutil/testdata/Test_optimizeJobs/diff_with_and.golden
+++ b/internal/search/job/jobutil/testdata/Test_optimizeJobs/diff_with_and.golden
@@ -14,12 +14,12 @@ BASE:
           40000
           (PARALLEL
             DiffSearchJob
-            ComputeExcludedRepos))
+            ComputeExcludedReposJob))
         (LIMIT
           40000
           (PARALLEL
             DiffSearchJob
-            ComputeExcludedRepos))))))
+            ComputeExcludedReposJob))))))
 
 OPTIMIZED:
 
@@ -35,9 +35,9 @@ OPTIMIZED:
             40000
             (PARALLEL
               NoopJob
-              ComputeExcludedRepos))
+              ComputeExcludedReposJob))
           (LIMIT
             40000
             (PARALLEL
               NoopJob
-              ComputeExcludedRepos)))))))
+              ComputeExcludedReposJob)))))))

--- a/internal/search/job/jobutil/testdata/Test_optimizeJobs/diff_with_or.golden
+++ b/internal/search/job/jobutil/testdata/Test_optimizeJobs/diff_with_or.golden
@@ -12,10 +12,10 @@ BASE:
       (OR
         (PARALLEL
           DiffSearchJob
-          ComputeExcludedRepos)
+          ComputeExcludedReposJob)
         (PARALLEL
           DiffSearchJob
-          ComputeExcludedRepos)))))
+          ComputeExcludedReposJob)))))
 
 OPTIMIZED:
 
@@ -29,7 +29,7 @@ OPTIMIZED:
         (OR
           (PARALLEL
             NoopJob
-            ComputeExcludedRepos)
+            ComputeExcludedReposJob)
           (PARALLEL
             NoopJob
-            ComputeExcludedRepos))))))
+            ComputeExcludedReposJob))))))

--- a/internal/search/job/jobutil/testdata/Test_optimizeJobs/optimize_basic_expression_Zoekt_Text_Global.golden
+++ b/internal/search/job/jobutil/testdata/Test_optimizeJobs/optimize_basic_expression_Zoekt_Text_Global.golden
@@ -15,19 +15,19 @@ BASE:
           (PARALLEL
             ZoektGlobalSearch
             RepoSearch
-            ComputeExcludedRepos))
+            ComputeExcludedReposJob))
         (LIMIT
           40000
           (PARALLEL
             ZoektGlobalSearch
             RepoSearch
-            ComputeExcludedRepos))
+            ComputeExcludedReposJob))
         (LIMIT
           40000
           (PARALLEL
             ZoektGlobalSearch
             RepoSearch
-            ComputeExcludedRepos))))))
+            ComputeExcludedReposJob))))))
 
 OPTIMIZED:
 
@@ -44,16 +44,16 @@ OPTIMIZED:
             (PARALLEL
               NoopJob
               RepoSearch
-              ComputeExcludedRepos))
+              ComputeExcludedReposJob))
           (LIMIT
             40000
             (PARALLEL
               NoopJob
               RepoSearch
-              ComputeExcludedRepos))
+              ComputeExcludedReposJob))
           (LIMIT
             40000
             (PARALLEL
               NoopJob
               RepoSearch
-              ComputeExcludedRepos)))))))
+              ComputeExcludedReposJob)))))))

--- a/internal/search/job/jobutil/testdata/Test_optimizeJobs/optimize_qualified_repo_with_type:symbol_expression_Zoekt_Symbol_over_repos.golden
+++ b/internal/search/job/jobutil/testdata/Test_optimizeJobs/optimize_qualified_repo_with_type:symbol_expression_Zoekt_Symbol_over_repos.golden
@@ -17,7 +17,7 @@ BASE:
               (PARALLEL
                 ZoektSymbolSearch
                 SymbolSearcher))
-            ComputeExcludedRepos))
+            ComputeExcludedReposJob))
         (LIMIT
           40000
           (PARALLEL
@@ -25,7 +25,7 @@ BASE:
               (PARALLEL
                 ZoektSymbolSearch
                 SymbolSearcher))
-            ComputeExcludedRepos))
+            ComputeExcludedReposJob))
         (LIMIT
           40000
           (PARALLEL
@@ -33,7 +33,7 @@ BASE:
               (PARALLEL
                 ZoektSymbolSearch
                 SymbolSearcher))
-            ComputeExcludedRepos))))))
+            ComputeExcludedReposJob))))))
 
 OPTIMIZED:
 
@@ -53,7 +53,7 @@ OPTIMIZED:
                 (PARALLEL
                   NoopJob
                   SymbolSearcher))
-              ComputeExcludedRepos))
+              ComputeExcludedReposJob))
           (LIMIT
             40000
             (PARALLEL
@@ -61,7 +61,7 @@ OPTIMIZED:
                 (PARALLEL
                   NoopJob
                   SymbolSearcher))
-              ComputeExcludedRepos))
+              ComputeExcludedReposJob))
           (LIMIT
             40000
             (PARALLEL
@@ -69,4 +69,4 @@ OPTIMIZED:
                 (PARALLEL
                   NoopJob
                   SymbolSearcher))
-              ComputeExcludedRepos)))))))
+              ComputeExcludedReposJob)))))))

--- a/internal/search/job/jobutil/testdata/Test_optimizeJobs/optimize_repo-qualified_expression_Zoekt_Text_over_repos#01.golden
+++ b/internal/search/job/jobutil/testdata/Test_optimizeJobs/optimize_repo-qualified_expression_Zoekt_Text_over_repos#01.golden
@@ -18,7 +18,7 @@ BASE:
                 ZoektRepoSubset
                 Searcher))
             RepoSearch
-            ComputeExcludedRepos))
+            ComputeExcludedReposJob))
         (LIMIT
           40000
           (PARALLEL
@@ -27,7 +27,7 @@ BASE:
                 ZoektRepoSubset
                 Searcher))
             RepoSearch
-            ComputeExcludedRepos))
+            ComputeExcludedReposJob))
         (LIMIT
           40000
           (PARALLEL
@@ -36,7 +36,7 @@ BASE:
                 ZoektRepoSubset
                 Searcher))
             RepoSearch
-            ComputeExcludedRepos))))))
+            ComputeExcludedReposJob))))))
 
 OPTIMIZED:
 
@@ -57,7 +57,7 @@ OPTIMIZED:
                   NoopJob
                   Searcher))
               RepoSearch
-              ComputeExcludedRepos))
+              ComputeExcludedReposJob))
           (LIMIT
             40000
             (PARALLEL
@@ -66,7 +66,7 @@ OPTIMIZED:
                   NoopJob
                   Searcher))
               RepoSearch
-              ComputeExcludedRepos))
+              ComputeExcludedReposJob))
           (LIMIT
             40000
             (PARALLEL
@@ -75,4 +75,4 @@ OPTIMIZED:
                   NoopJob
                   Searcher))
               RepoSearch
-              ComputeExcludedRepos)))))))
+              ComputeExcludedReposJob)))))))

--- a/internal/search/job/jobutil/testdata/Test_optimizeJobs/optimize_repo-qualified_expression_Zoekt_Text_over_repos.golden
+++ b/internal/search/job/jobutil/testdata/Test_optimizeJobs/optimize_repo-qualified_expression_Zoekt_Text_over_repos.golden
@@ -18,7 +18,7 @@ BASE:
                 ZoektRepoSubset
                 Searcher))
             RepoSearch
-            ComputeExcludedRepos))
+            ComputeExcludedReposJob))
         (LIMIT
           40000
           (PARALLEL
@@ -27,7 +27,7 @@ BASE:
                 ZoektRepoSubset
                 Searcher))
             RepoSearch
-            ComputeExcludedRepos))
+            ComputeExcludedReposJob))
         (LIMIT
           40000
           (PARALLEL
@@ -36,7 +36,7 @@ BASE:
                 ZoektRepoSubset
                 Searcher))
             RepoSearch
-            ComputeExcludedRepos))))))
+            ComputeExcludedReposJob))))))
 
 OPTIMIZED:
 
@@ -57,7 +57,7 @@ OPTIMIZED:
                   NoopJob
                   Searcher))
               RepoSearch
-              ComputeExcludedRepos))
+              ComputeExcludedReposJob))
           (LIMIT
             40000
             (PARALLEL
@@ -66,7 +66,7 @@ OPTIMIZED:
                   NoopJob
                   Searcher))
               RepoSearch
-              ComputeExcludedRepos))
+              ComputeExcludedReposJob))
           (LIMIT
             40000
             (PARALLEL
@@ -75,4 +75,4 @@ OPTIMIZED:
                   NoopJob
                   Searcher))
               RepoSearch
-              ComputeExcludedRepos)))))))
+              ComputeExcludedReposJob)))))))

--- a/internal/search/job/jobutil/types.go
+++ b/internal/search/job/jobutil/types.go
@@ -21,7 +21,7 @@ var allJobs = []job.Job{
 	&structural.StructuralSearch{},
 	&commit.CommitSearchJob{},
 	&symbol.RepoUniverseSymbolSearch{},
-	&repos.ComputeExcludedRepos{},
+	&repos.ComputeExcludedReposJob{},
 	&noopJob{},
 
 	&repoPagerJob{},

--- a/internal/search/repos/excluded_job.go
+++ b/internal/search/repos/excluded_job.go
@@ -8,11 +8,11 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
 )
 
-type ComputeExcludedRepos struct {
+type ComputeExcludedReposJob struct {
 	Options search.RepoOptions
 }
 
-func (c *ComputeExcludedRepos) Run(ctx context.Context, clients job.RuntimeClients, s streaming.Sender) (alert *search.Alert, err error) {
+func (c *ComputeExcludedReposJob) Run(ctx context.Context, clients job.RuntimeClients, s streaming.Sender) (alert *search.Alert, err error) {
 	_, ctx, s, finish := job.StartSpan(ctx, s, c)
 	defer func() { finish(alert, err) }()
 
@@ -31,6 +31,6 @@ func (c *ComputeExcludedRepos) Run(ctx context.Context, clients job.RuntimeClien
 	return nil, nil
 }
 
-func (c *ComputeExcludedRepos) Name() string {
-	return "ComputeExcludedRepos"
+func (c *ComputeExcludedReposJob) Name() string {
+	return "ComputeExcludedReposJob"
 }


### PR DESCRIPTION
Stacked on https://github.com/sourcegraph/sourcegraph/pull/34863
Related to #34009

Because `repos.ComputeExcludedRepos` implements `job.Job`, renaming `repos.ComputeExcludedRepos` to `repos.ComputeExcludedReposJob` for clarity when reading the code and looking at traces.

## Test plan
Semantics-preserving.


