### PR TITLE
add sort filter panel

### DIFF
--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/sort-filter-series-panel/SortFilterSeriesPanel.module.scss
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/sort-filter-series-panel/SortFilterSeriesPanel.module.scss
@@ -1,0 +1,41 @@
+.unselected {
+    background-color: var(--body-bg);
+}
+
+.selected {
+    background-color: var(--border-color);
+}
+
+.label {
+    color: var(--text-muted);
+    margin-bottom: 0.75rem;
+}
+
+.toggles-container {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    padding: 0.5rem;
+}
+
+.toggle-group {
+    display: inline;
+    margin-left: 0.25rem;
+}
+
+.footer {
+    display: grid;
+    grid-template-columns: 1fr 4rem;
+    gap: 0.5rem;
+    align-items: center;
+    border-top: solid 1px var(--border-color-2);
+    padding: 0.5rem;
+}
+
+.container {
+    max-width: 235px;
+    border-radius: 5px;
+    border: solid 1px var(--border-color);
+    box-shadow: var(--dropdown-shadow);
+    background-color: var(--body-bg);
+}

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/sort-filter-series-panel/SortFilterSeriesPanel.story.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/sort-filter-series-panel/SortFilterSeriesPanel.story.tsx
@@ -1,0 +1,32 @@
+import { useState } from 'react'
+
+import { Meta, Story } from '@storybook/react'
+
+import { WebStory } from '../../../../../../../../components/WebStory'
+
+import { SortFilterSeriesPanel, SortFilterSeriesValue, SortSeriesBy } from './SortFilterSeriesPanel'
+
+import styles from './SortFilterSeriesPanel.module.scss'
+
+const defaultStory: Meta = {
+    title: 'web/insights/SortFilterSeriesPanel',
+    decorators: [story => <WebStory>{() => story()}</WebStory>],
+}
+
+export default defaultStory
+
+export const Primary: Story = () => {
+    const [value, setValue] = useState<SortFilterSeriesValue>({
+        selected: SortSeriesBy.CountDesc,
+        seriesCount: 20,
+    })
+
+    return (
+        <div className="d-flex">
+            <div className={styles.container}>
+                <SortFilterSeriesPanel value={value} onChange={setValue} />
+            </div>
+            <pre className="p-4">{JSON.stringify(value, null, 2)}</pre>
+        </div>
+    )
+}

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/sort-filter-series-panel/SortFilterSeriesPanel.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/sort-filter-series-panel/SortFilterSeriesPanel.tsx
@@ -1,0 +1,101 @@
+import { useState } from 'react'
+
+import classNames from 'classnames'
+
+import { Button, ButtonGroup } from '@sourcegraph/wildcard'
+
+import styles from './SortFilterSeriesPanel.module.scss'
+
+const getClasses = (selected: boolean): string =>
+    classNames({ [styles.selected]: selected, [styles.unselected]: !selected })
+
+export enum SortSeriesBy {
+    CountAsc = 'CountAsc',
+    CountDesc = 'CountDesc',
+    AlphaAsc = 'AlphaAsc',
+    AlphaDesc = 'AlphaDesc',
+    DateAsc = 'DateAsc',
+    DateDesc = 'DateDesc',
+}
+
+export interface SortFilterSeriesValue {
+    selected: SortSeriesBy
+    seriesCount: number
+}
+
+interface SortFilterSeriesPanelProps {
+    value: SortFilterSeriesValue
+    onChange: (parameter: SortFilterSeriesValue) => void
+}
+
+export const SortFilterSeriesPanel: React.FunctionComponent<SortFilterSeriesPanelProps> = ({ value, onChange }) => {
+    const [selected, setSelected] = useState(value.selected)
+    const [seriesCount, setSeriesCount] = useState(value.seriesCount)
+
+    const handleToggle = (value: SortSeriesBy): void => {
+        setSelected(value)
+        onChange({ selected: value, seriesCount })
+    }
+
+    const handleChange: React.ChangeEventHandler<HTMLInputElement> = event => {
+        const count = parseInt(event.target.value, 10)
+        setSeriesCount(count)
+        onChange({ selected, seriesCount: count })
+    }
+
+    return (
+        <section>
+            <section className={classNames(styles.togglesContainer)}>
+                <div className="d-flex flex-column">
+                    <small className={styles.label}>Sort by result count</small>
+                    <ButtonGroup className={styles.toggleGroup}>
+                        <ToggleButton selected={selected} value={SortSeriesBy.CountDesc} onClick={handleToggle}>
+                            Highest
+                        </ToggleButton>
+                        <ToggleButton selected={selected} value={SortSeriesBy.CountAsc} onClick={handleToggle}>
+                            Lowest
+                        </ToggleButton>
+                    </ButtonGroup>
+                </div>
+                <div className="d-flex flex-column">
+                    <small className={styles.label}>Sort by name</small>
+                    <ButtonGroup className={styles.toggleGroup}>
+                        <ToggleButton selected={selected} value={SortSeriesBy.AlphaAsc} onClick={handleToggle}>
+                            A-Z
+                        </ToggleButton>
+                        <ToggleButton selected={selected} value={SortSeriesBy.AlphaDesc} onClick={handleToggle}>
+                            Z-A
+                        </ToggleButton>
+                    </ButtonGroup>
+                </div>
+                <div className="d-flex flex-column">
+                    <small className={styles.label}>Sort by date added</small>
+                    <ButtonGroup className={styles.toggleGroup}>
+                        <ToggleButton selected={selected} value={SortSeriesBy.DateDesc} onClick={handleToggle}>
+                            Latest
+                        </ToggleButton>
+                        <ToggleButton selected={selected} value={SortSeriesBy.DateAsc} onClick={handleToggle}>
+                            Oldest
+                        </ToggleButton>
+                    </ButtonGroup>
+                </div>
+            </section>
+            <footer className={styles.footer}>
+                <span>Number of data series</span>
+                <input type="number" step="1" value={seriesCount} className="form-control" onChange={handleChange} />
+            </footer>
+        </section>
+    )
+}
+
+interface ToggleButtonProps {
+    selected: SortSeriesBy
+    value: SortSeriesBy
+    onClick: (value: SortSeriesBy) => void
+}
+
+const ToggleButton: React.FunctionComponent<ToggleButtonProps> = ({ selected, value, children, onClick }) => (
+    <Button variant="secondary" size="sm" className={getClasses(selected === value)} onClick={() => onClick(value)}>
+        {children}
+    </Button>
+)


### PR DESCRIPTION
Note: I've deviated from the design in regards to the number picker. In Figma we're using an icon that won't work. To keep this simple I'm leaving it as the native number picker. We can revisit later.

| PR | Figma |
| :--: | :--: |
|![PixelSnap 2022-05-03 at 19 38 50](https://user-images.githubusercontent.com/1855233/166608839-62c76baf-a0e5-476f-bca2-1d9db41962a6.png)|![PixelSnap 2022-05-03 at 19 39 57](https://user-images.githubusercontent.com/1855233/166608897-b38eabf3-0220-47c6-9760-a86f7b0f2b56.png)|

## Test plan

View component in storybook
Should match designs

Closes https://github.com/sourcegraph/sourcegraph/issues/34649