### PR TITLE
remove file tag from GoToRawAction

### DIFF
--- a/client/web/src/repo/blob/GoToRawAction.tsx
+++ b/client/web/src/repo/blob/GoToRawAction.tsx
@@ -28,13 +28,7 @@ export class GoToRawAction extends React.PureComponent<Props> {
 
         if (this.props.actionType === 'dropdown') {
             return (
-                <RepoHeaderActionAnchor
-                    to={to}
-                    target="_blank"
-                    onClick={this.onClick.bind(this)}
-                    download={true}
-                    file={true}
-                >
+                <RepoHeaderActionAnchor to={to} target="_blank" onClick={this.onClick.bind(this)} download={true}>
                     <Icon as={FileDownloadOutlineIcon} />
                     <span>{descriptiveText}</span>
                 </RepoHeaderActionAnchor>
@@ -50,7 +44,6 @@ export class GoToRawAction extends React.PureComponent<Props> {
                 data-tooltip={descriptiveText}
                 aria-label={descriptiveText}
                 download={true}
-                file={true}
             >
                 <Icon as={FileDownloadOutlineIcon} />
             </RepoHeaderActionAnchor>

--- a/client/web/src/repo/blob/GoToRawAction.tsx
+++ b/client/web/src/repo/blob/GoToRawAction.tsx
@@ -28,7 +28,13 @@ export class GoToRawAction extends React.PureComponent<Props> {
 
         if (this.props.actionType === 'dropdown') {
             return (
-                <RepoHeaderActionAnchor to={to} target="_blank" onClick={this.onClick.bind(this)} download={true}>
+                <RepoHeaderActionAnchor
+                    to={to}
+                    target="_blank"
+                    file={true}
+                    onClick={this.onClick.bind(this)}
+                    download={true}
+                >
                     <Icon as={FileDownloadOutlineIcon} />
                     <span>{descriptiveText}</span>
                 </RepoHeaderActionAnchor>


### PR DESCRIPTION
## Summary
The GoToRawAction button is current not aligned with the rest of the buttons in the repo header since it was last updated:
![Screen Shot 2022-05-03 at 5 03 20 PM](https://user-images.githubusercontent.com/68532117/166605201-e1b66d9e-5173-4685-a0e7-fa753540a73b.png)

Currently on Cloud:
![image](https://user-images.githubusercontent.com/68532117/166962819-930014f8-be9b-4ac4-8c58-1d70790b6b5e.png)

## PR fix

Removed the `file` tag has resolved the issue:
![Screen Shot 2022-05-03 at 5 02 53 PM](https://user-images.githubusercontent.com/68532117/166605258-34085cce-893c-4beb-8e8e-bfdc0be1d173.png)


## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

See screenshot above

## App preview:

- [Web](https://sg-web-bee-raw-btn.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-avgxqlyvxr.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

