### PR TITLE
codeintel: Add instance state check on query failures in codeintel-qa

### DIFF
--- a/dev/codeintel-qa/cmd/query/main.go
+++ b/dev/codeintel-qa/cmd/query/main.go
@@ -11,9 +11,11 @@ import (
 	"time"
 
 	"github.com/sourcegraph/sourcegraph/dev/codeintel-qa/internal"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 var (
+	indexDir                    string
 	numConcurrentRequests       int
 	checkQueryResult            bool
 	queryReferencesOfReferences bool
@@ -23,6 +25,8 @@ var (
 )
 
 func init() {
+	// Default assumes running from the dev/codeintel-qa directory
+	flag.StringVar(&indexDir, "index-dir", "./testdata/indexes", "The location of the testdata directory")
 	flag.IntVar(&numConcurrentRequests, "num-concurrent-requests", 5, "The maximum number of concurrent requests")
 	flag.BoolVar(&checkQueryResult, "check-query-result", true, "Whether to confirm query results are correct")
 	flag.BoolVar(&queryReferencesOfReferences, "query-references-of-references", false, "Whether to perform reference operations on test case references")
@@ -43,10 +47,21 @@ func main() {
 
 type queryFunc func(ctx context.Context) error
 
-func mainErr(ctx context.Context) error {
+func mainErr(ctx context.Context) (err error) {
 	if err := internal.InitializeGraphQLClient(); err != nil {
 		return err
 	}
+
+	if err := checkInstanceState(ctx); err != nil {
+		return err
+	}
+	defer func() {
+		if err != nil {
+			if diff, diffErr := instanceStateDiff(ctx); diffErr == nil && diff != "" {
+				err = errors.Newf("unexpected instance state: %s\n\n❌ original error: %s", diff, err)
+			}
+		}
+	}()
 
 	var wg sync.WaitGroup
 	var numRequestsFinished uint64

--- a/dev/codeintel-qa/cmd/query/queries.go
+++ b/dev/codeintel-qa/cmd/query/queries.go
@@ -82,7 +82,7 @@ func makeTestFunc(name string, f testFunc, source Location, expectedLocations []
 				repositoryToGottenResults := collectRepositoryToResults(locations)
 				repositoryToWantedResults := collectRepositoryToResults(expectedLocations)
 				for repo := range allRepos {
-					e += fmt.Sprintf("    - %s: want %d got %d locations\n", repo, repositoryToWantedResults[repo], repositoryToGottenResults[repo])
+					e += fmt.Sprintf("    - %s: want %d locations, got %d locations\n", repo, repositoryToWantedResults[repo], repositoryToGottenResults[repo])
 				}
 				e += "\n"
 

--- a/dev/codeintel-qa/cmd/query/state.go
+++ b/dev/codeintel-qa/cmd/query/state.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"context"
+	"sort"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/sourcegraph/sourcegraph/dev/codeintel-qa/internal"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+func checkInstanceState(ctx context.Context) error {
+	if diff, err := instanceStateDiff(ctx); err != nil {
+		return err
+	} else if diff != "" {
+		return errors.Newf("unexpected instance state: %s", diff)
+	}
+
+	return nil
+}
+
+func instanceStateDiff(ctx context.Context) (string, error) {
+	uploadedCommitsByRepo, err := queryUploads(ctx)
+	if err != nil {
+		return "", err
+	}
+	for _, commits := range uploadedCommitsByRepo {
+		sort.Strings(commits)
+	}
+
+	commitsByRepo, err := internal.CommitsByRepo(indexDir)
+	if err != nil {
+		return "", err
+	}
+
+	expectedCommitsByRepo := map[string][]string{}
+	for repoName, commits := range commitsByRepo {
+		sort.Strings(commits)
+		expectedCommitsByRepo[internal.MakeTestRepoName(repoName)] = commits
+	}
+
+	return cmp.Diff(expectedCommitsByRepo, uploadedCommitsByRepo), nil
+}

--- a/dev/codeintel-qa/cmd/upload/main.go
+++ b/dev/codeintel-qa/cmd/upload/main.go
@@ -12,8 +12,8 @@ import (
 )
 
 var (
-	numConcurrentUploads int
 	indexDir             string
+	numConcurrentUploads int
 	verbose              bool
 	pollInterval         time.Duration
 	timeout              time.Duration
@@ -54,7 +54,7 @@ func mainErr(ctx context.Context) error {
 		return err
 	}
 
-	commitsByRepo, err := commitsByRepo()
+	commitsByRepo, err := internal.CommitsByRepo(indexDir)
 	if err != nil {
 		return err
 	}

--- a/dev/codeintel-qa/internal/indexes.go
+++ b/dev/codeintel-qa/internal/indexes.go
@@ -1,4 +1,4 @@
-package main
+package internal
 
 import (
 	"os"
@@ -8,11 +8,11 @@ import (
 
 var indexFilenamePattern = regexp.MustCompile(`^(.+)\.\d+\.([0-9A-Fa-f]{40})\.dump$`)
 
-// commitsByRepo returns a map from repository name to a slice of commits for that repository.
+// CommitsByRepo returns a map from repository name to a slice of commits for that repository.
 // The repositories and commits are read from the filesystem state of the index directory
 // supplied by the user. This method assumes that index files have been downloaded or generated
 // locally.
-func commitsByRepo() (map[string][]string, error) {
+func CommitsByRepo(indexDir string) (map[string][]string, error) {
 	infos, err := os.ReadDir(indexDir)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Update the codeintel-qa `query` command to check the state of uploads on the instance. There should only be an explicitly allowed list of uploads with a known good state, so if there's a failure that's likely the cause and knowing exactly what set of records exist will help in debugging.

This is an effort to shed more light on the problems in [this build](https://buildkite.com/sourcegraph/deploy-sourcegraph-cloud/builds/203270#0f81cbeb-0d6e-4730-bf35-61ec570f1ea6).

## Test plan

This _is_ the test plan, man. 

![image](https://user-images.githubusercontent.com/103087/166609798-4fde5bb5-180f-421c-91d5-a02dbef3986e.png)
