### PR TITLE
web: ban `reactstrap` imports

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -71,6 +71,11 @@ const config = {
             message:
               'Our Zustand stores should be created in a single place. Create this store in client/web/src/stores',
           },
+          {
+            name: 'reactstrap',
+            message:
+              'Please use components from the Wildcard component library instead. We work on removing `reactstrap` dependency.',
+          },
         ],
         patterns: [
           {

--- a/client/search-ui/src/input/SearchContextDropdown.tsx
+++ b/client/search-ui/src/input/SearchContextDropdown.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
 
 import classNames from 'classnames'
+// eslint-disable-next-line no-restricted-imports
 import { Dropdown, DropdownMenu, DropdownToggle } from 'reactstrap'
 
 import { SearchContextInputProps, SubmitSearchProps } from '@sourcegraph/search'

--- a/client/search-ui/src/input/SearchContextMenu.test.tsx
+++ b/client/search-ui/src/input/SearchContextMenu.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { act } from 'react-dom/test-utils'
+// eslint-disable-next-line no-restricted-imports
 import { DropdownMenu, UncontrolledDropdown } from 'reactstrap'
 import { Observable, of, throwError } from 'rxjs'
 import sinon from 'sinon'

--- a/client/search-ui/src/input/SearchContextMenu.tsx
+++ b/client/search-ui/src/input/SearchContextMenu.tsx
@@ -10,6 +10,7 @@ import React, {
 
 import classNames from 'classnames'
 import CloseIcon from 'mdi-react/CloseIcon'
+// eslint-disable-next-line no-restricted-imports
 import { DropdownItem } from 'reactstrap'
 import { BehaviorSubject, combineLatest, of, timer } from 'rxjs'
 import { catchError, debounce, switchMap, tap } from 'rxjs/operators'

--- a/client/search-ui/src/results/progress/StreamingProgressSkippedPopover.tsx
+++ b/client/search-ui/src/results/progress/StreamingProgressSkippedPopover.tsx
@@ -6,14 +6,15 @@ import ChevronDownIcon from 'mdi-react/ChevronDownIcon'
 import ChevronLeftIcon from 'mdi-react/ChevronLeftIcon'
 import InformationOutlineIcon from 'mdi-react/InformationOutlineIcon'
 import SearchIcon from 'mdi-react/SearchIcon'
-import { FormGroup, Input, Label } from 'reactstrap'
+// eslint-disable-next-line no-restricted-imports
+import { Input } from 'reactstrap'
 
 import { Form } from '@sourcegraph/branded/src/components/Form'
 import { renderMarkdown } from '@sourcegraph/common'
 import { SyntaxHighlightedSearchQuery } from '@sourcegraph/search-ui'
 import { Markdown } from '@sourcegraph/shared/src/components/Markdown'
 import { Skipped } from '@sourcegraph/shared/src/search/stream'
-import { Button, Collapse, CollapseHeader, CollapsePanel, Icon } from '@sourcegraph/wildcard'
+import { Button, Collapse, CollapseHeader, CollapsePanel, Icon, Label } from '@sourcegraph/wildcard'
 
 import { StreamingProgressProps } from './StreamingProgress'
 
@@ -139,13 +140,12 @@ export const StreamingProgressSkippedPopover: React.FunctionComponent<
             {sortedSkippedItems.some(skipped => skipped.suggested) && (
                 <Form className="pb-3 px-3" onSubmit={submitHandler} data-testid="popover-form">
                     <div className="mb-2 mt-3">Search again:</div>
-                    <FormGroup check={true}>
+                    <div className="form-check">
                         {sortedSkippedItems.map(
                             skipped =>
                                 skipped.suggested && (
                                     <Label
-                                        check={true}
-                                        className="mb-1 d-block"
+                                        className="mb-1 d-block form-check-label"
                                         key={skipped.suggested.queryExpression}
                                     >
                                         <Input
@@ -159,7 +159,7 @@ export const StreamingProgressSkippedPopover: React.FunctionComponent<
                                     </Label>
                                 )
                         )}
-                    </FormGroup>
+                    </div>
 
                     <Button
                         type="submit"

--- a/client/search-ui/src/results/progress/__snapshots__/StreamingProgressSkippedPopover.test.tsx.snap
+++ b/client/search-ui/src/results/progress/__snapshots__/StreamingProgressSkippedPopover.test.tsx.snap
@@ -309,7 +309,7 @@ exports[`StreamingProgressSkippedPopover should render correctly 1`] = `
       class="form-check"
     >
       <label
-        class="mb-1 d-block form-check-label"
+        class="label mb-1 d-block form-check-label"
       >
         <input
           class="form-check-input"
@@ -336,7 +336,7 @@ exports[`StreamingProgressSkippedPopover should render correctly 1`] = `
         )
       </label>
       <label
-        class="mb-1 d-block form-check-label"
+        class="label mb-1 d-block form-check-label"
       >
         <input
           class="form-check-input"
@@ -353,7 +353,7 @@ exports[`StreamingProgressSkippedPopover should render correctly 1`] = `
         )
       </label>
       <label
-        class="mb-1 d-block form-check-label"
+        class="label mb-1 d-block form-check-label"
       >
         <input
           class="form-check-input"
@@ -380,7 +380,7 @@ exports[`StreamingProgressSkippedPopover should render correctly 1`] = `
         )
       </label>
       <label
-        class="mb-1 d-block form-check-label"
+        class="label mb-1 d-block form-check-label"
       >
         <input
           class="form-check-input"

--- a/client/vscode/src/webview/search-panel/components/ButtonDropdownCta.tsx
+++ b/client/vscode/src/webview/search-panel/components/ButtonDropdownCta.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useState } from 'react'
 
 import { VSCodeButton } from '@vscode/webview-ui-toolkit/react'
 import classNames from 'classnames'
+// eslint-disable-next-line no-restricted-imports
 import { ButtonDropdown, DropdownMenu, DropdownToggle } from 'reactstrap'
 
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'

--- a/client/web/src/nav/UserNavItem.tsx
+++ b/client/web/src/nav/UserNavItem.tsx
@@ -5,6 +5,7 @@ import classNames from 'classnames'
 import ChevronDownIcon from 'mdi-react/ChevronDownIcon'
 import ChevronUpIcon from 'mdi-react/ChevronUpIcon'
 import OpenInNewIcon from 'mdi-react/OpenInNewIcon'
+// eslint-disable-next-line no-restricted-imports
 import { Tooltip } from 'reactstrap'
 
 import { KeyboardShortcut } from '@sourcegraph/shared/src/keyboardShortcuts'

--- a/client/web/src/org/members/SearchUserAutocomplete.tsx
+++ b/client/web/src/org/members/SearchUserAutocomplete.tsx
@@ -3,6 +3,7 @@ import React, { useCallback, useEffect, useRef, useState } from 'react'
 import { useLazyQuery } from '@apollo/client'
 import classNames from 'classnames'
 import { debounce } from 'lodash'
+// eslint-disable-next-line no-restricted-imports
 import { Dropdown, DropdownItem, DropdownMenu, DropdownToggle } from 'reactstrap'
 
 import { Input } from '@sourcegraph/wildcard'

--- a/client/web/src/org/settings/codeHosts/InstallGitHubAppSuccessPage.tsx
+++ b/client/web/src/org/settings/codeHosts/InstallGitHubAppSuccessPage.tsx
@@ -3,7 +3,6 @@ import React, { useEffect, useState } from 'react'
 import classNames from 'classnames'
 import GithubIcon from 'mdi-react/GithubIcon'
 import PlusIcon from 'mdi-react/PlusIcon'
-import { Media } from 'reactstrap'
 
 import { SourcegraphIcon, Card, CardBody, Link } from '@sourcegraph/wildcard'
 
@@ -47,7 +46,11 @@ export const InstallGitHubAppSuccessPage: React.FunctionComponent<{}> = () => {
                         <SourcegraphIcon className={classNames(styles.appLogo)} />
                         <PlusIcon />
                         {data ? (
-                            <Media src={data?.account.avatar_url} className={classNames(styles.appLogo)} />
+                            <img
+                                alt="Organization logo"
+                                src={data?.account.avatar_url}
+                                className={classNames('media', styles.appLogo)}
+                            />
                         ) : (
                             <GithubIcon className={classNames(styles.appLogo)} />
                         )}

--- a/client/wildcard/src/components/Tooltip/Tooltip.tsx
+++ b/client/wildcard/src/components/Tooltip/Tooltip.tsx
@@ -2,6 +2,7 @@ import React, { ReactNode, useMemo } from 'react'
 
 import classNames from 'classnames'
 import Popper from 'popper.js'
+// eslint-disable-next-line no-restricted-imports
 import { Tooltip as BootstrapTooltip } from 'reactstrap'
 
 import { useTooltipState } from './useTooltipState'


### PR DESCRIPTION
## Context

We work on [dropping `bootstrap` and `reactstrap` dependencies](https://github.com/sourcegraph/sourcegraph/issues/29200) in favor of the Wildcard component library. 

This PR adds a linter rule that bans new `reactstrap` imports. Existing imports will be migrated as a part of the Wildcard migration effort. For now, linter errors are disabled for existing `reactstrap` imports.

## Test plan

n/a



## App preview:

- [Web](https://sg-web-vb-ban-reactrap-imports.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-hiaygscxtr.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
