### PR TITLE
sg: fix nil panic introduced in 284aba024

### DIFF
--- a/dev/sg/internal/run/command.go
+++ b/dev/sg/internal/run/command.go
@@ -133,6 +133,10 @@ func (sc *startedCmd) CapturedStderr() string {
 func getSecrets(ctx context.Context, cmd Command) (map[string]string, error) {
 	secretsEnv := map[string]string{}
 
+	if len(cmd.Secrets) == 0 {
+		return secretsEnv, nil
+	}
+
 	client, err := secretmanager.NewClient(ctx)
 	if err != nil {
 		return nil, errors.Errorf("failed to create secretmanager client: %v", err)

--- a/dev/sg/internal/run/run.go
+++ b/dev/sg/internal/run/run.go
@@ -364,11 +364,10 @@ func runWatch(
 			stdout.Out.WriteLine(output.Linef("", output.StylePending, "Running %s...", cmd.Name))
 
 			sc, err := startCmd(ctx, root, cmd, parentEnv)
-			defer sc.cancel()
-
 			if err != nil {
 				return err
 			}
+			defer sc.cancel()
 
 			cancelFuncs = append(cancelFuncs, sc.cancel)
 


### PR DESCRIPTION
Two problems:

- We'd try to build a secrets manager for _all_ commands, even if they didn't have secrets. That would fail if it wasn't configured.
- That error was not surfaced, because we'd do an `if err != nil { return err }` but the previous `defer` would run into `nil`-panic by trying to use `sc`.

## Test plan

- `go run ./dev/sg run github-proxy` failed with nil panic before, now it doesn't.


