### PR TITLE
all: use go1.18

### DIFF
--- a/.github/workflows/buildchecker-history.yml
+++ b/.github/workflows/buildchecker-history.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
-        with: { go-version: '1.17' }
+        with: { go-version: '1.18' }
 
       - run: ./dev/buildchecker/run-week-history.sh
         env:

--- a/.github/workflows/buildchecker.yml
+++ b/.github/workflows/buildchecker.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
-        with: { go-version: '1.17' }
+        with: { go-version: '1.18' }
 
       - run: ./dev/buildchecker/run-check.sh
         env:

--- a/.github/workflows/licenses-check.yml
+++ b/.github/workflows/licenses-check.yml
@@ -9,7 +9,7 @@ jobs:
     - uses: actions/setup-ruby@v1
       with: { ruby-version: '2.6' }
     - uses: actions/setup-go@v2
-      with: { go-version: '1.17' }
+      with: { go-version: '1.18' }
 
     # set up correct version of node
     - id: nvmrc

--- a/.github/workflows/licenses-update.yml
+++ b/.github/workflows/licenses-update.yml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/setup-ruby@v1
       with: { ruby-version: '2.6' }
     - uses: actions/setup-go@v2
-      with: { go-version: '1.17' }
+      with: { go-version: '1.18' }
 
     # set up correct version of node
     - id: nvmrc

--- a/.github/workflows/lsif-typescript.yml
+++ b/.github/workflows/lsif-typescript.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Run lsif-typescript
         run: lsif-typescript index --yarn-workspaces
       - uses: actions/setup-go@v2
-        with: { go-version: '1.17' }
+        with: { go-version: '1.18' }
       - name: Convert LSIF Typed into LSIF Graph
         run: go run lib/codeintel/tools/lsif-typed/main.go dump.lsif-typed > dump.lsif
       - name: Upload lsif to Cloud

--- a/.github/workflows/pr-auditor.yml
+++ b/.github/workflows/pr-auditor.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
-        with: { go-version: '1.17' }
+        with: { go-version: '1.18' }
 
       - run: ./dev/pr-auditor/check-pr.sh
         env:

--- a/.github/workflows/sg-binary-release.yml
+++ b/.github/workflows/sg-binary-release.yml
@@ -87,7 +87,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17
+          go-version: 1.18
 
       - name: Build and upload macOS
         if: startsWith(matrix.os, 'macos-') == true

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,4 @@
-golang 1.17.5
+golang 1.18.1
 nodejs 16.7.0
 yarn 1.22.17
 fd 7.4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Changed
 
--
+- Sourcegraph is now built with Go 1.18. [#34885](https://github.com/sourcegraph/sourcegraph/pull/34885)
 
 ### Fixed
 

--- a/dev/ci/go-test.sh
+++ b/dev/ci/go-test.sh
@@ -1,12 +1,16 @@
 #!/usr/bin/env bash
 
+cd "$(dirname "${BASH_SOURCE[0]}")"/../..
+
 set -euo pipefail
+
+REPO_ROOT="$PWD"
 
 function usage {
   cat <<EOF
 Usage: go-test.sh [only|exclude package-path-1 package-path-2 ...]
 
-Run go tests, optionally restricting which ones based on the only and exclude coommands.
+Run go tests, optionally restricting which ones based on the only and exclude commands.
 
 EOF
 }
@@ -43,7 +47,7 @@ function go_test() {
     set -x
     echo "~~~ Creating test failures anotation"
     RICHGO_CONFIG="./.richstyle.yml"
-    cp "./dev/ci/go-test-failures.richstyle.yml" $RICHGO_CONFIG
+    cp "$REPO_ROOT/dev/ci/go-test-failures.richstyle.yml" $RICHGO_CONFIG
     mkdir -p ./annotations
     richgo testfilter <"$tmpfile" >>./annotations/go-test
     rm -rf $RICHGO_CONFIG
@@ -88,7 +92,7 @@ echo "--- comby install"
 # not checking out the old version when the tests with the old code against the latest
 # commit database schema.
 # TODO @jhchabran remove this when we release the next version.
-if [ "v3.38.0" == "$(git describe --tags)" ];then
+if [ "v3.38.0" == "$(git describe --tags)" ]; then
   # For code insights test
   ./dev/codeinsights-db.sh &
   export CODEINSIGHTS_PGDATASOURCE=postgres://postgres:password@127.0.0.1:5435/postgres

--- a/dev/pr-auditor/batch-changes/pr-auditor-patch.yml
+++ b/dev/pr-auditor/batch-changes/pr-auditor-patch.yml
@@ -33,7 +33,7 @@ steps:
             - uses: actions/checkout@v2
               with: { repository: 'sourcegraph/sourcegraph' }
             - uses: actions/setup-go@v2
-              with: { go-version: '1.17' }
+              with: { go-version: '1.18' }
 
             - run: ./dev/pr-auditor/check-pr.sh
               env:

--- a/dev/pr-auditor/batch-changes/pr-auditor-rollout.yml
+++ b/dev/pr-auditor/batch-changes/pr-auditor-rollout.yml
@@ -63,7 +63,7 @@ steps:
             - uses: actions/checkout@v2
               with: { repository: 'sourcegraph/sourcegraph' }
             - uses: actions/setup-go@v2
-              with: { go-version: '1.17' }
+              with: { go-version: '1.18' }
 
             - run: ./dev/pr-auditor/check-pr.sh
               env:

--- a/dev/sg/checks.go
+++ b/dev/sg/checks.go
@@ -35,7 +35,7 @@ var checks = map[string]check.CheckFunc{
 	"asdf":                  check.CommandOutputContains("asdf", "version"),
 	"git":                   check.Combine(check.InPath("git"), checkGitVersion(">= 2.34.1")),
 	"yarn":                  check.Combine(check.InPath("yarn"), checkYarnVersion("~> 1.22.4")),
-	"go":                    check.Combine(check.InPath("go"), checkGoVersion("1.17.5")),
+	"go":                    check.Combine(check.InPath("go"), checkGoVersion("1.18.1")),
 	"node":                  check.Combine(check.InPath("node"), check.CommandOutputContains(`node -e "console.log(\"foobar\")"`, "foobar")),
 	"rust":                  check.Combine(check.InPath("cargo"), check.CommandOutputContains(`cargo version`, "1.58.0")),
 	"docker-installed":      check.WrapErrMessage(check.InPath("docker"), "if Docker is installed and the check fails, you might need to start Docker.app and restart terminal and 'sg setup'"),

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sourcegraph/sourcegraph
 
-go 1.17
+go 1.18
 
 require (
 	cloud.google.com/go/kms v1.1.0

--- a/internal/cmd/git-combine/Dockerfile
+++ b/internal/cmd/git-combine/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17.6-alpine AS builder
+FROM golang:1.18.1-alpine AS builder
 
 WORKDIR /go/src/app
 

--- a/internal/cmd/tracking-issue/Dockerfile
+++ b/internal/cmd/tracking-issue/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17-alpine AS builder
+FROM golang:1.18-alpine AS builder
 
 WORKDIR /go/src/tracking-issue
 COPY . .

--- a/shell.nix
+++ b/shell.nix
@@ -29,8 +29,8 @@ let
   pkgs = import
     (fetchTarball {
       url =
-        "https://github.com/NixOS/nixpkgs/archive/a5d12145047970d663764ce95bf1e459e734a014.tar.gz";
-      sha256 = "1rbnmbc3mvk5in86wx6hla54d7kkmgn6pz0zwigcchhmi2dv76h3";
+        "https://github.com/NixOS/nixpkgs/archive/cbe587c735b734405f56803e267820ee1559e6c1.tar.gz";
+      sha256 = "0jii8slqbwbvrngf9911z3al1s80v7kk8idma9p9k0d5fm3g4z7h";
     })
     { overlays = [ ctags-overlay ]; };
   # pkgs.universal-ctags installs the binary as "ctags", not "universal-ctags"


### PR DESCRIPTION
Mostly automatic updates using the below script:

``` shell
# update github actions
fastmod --hidden '(go-version.*)(\b1\.17\b)' '${1}1.18'
# only updates dev/sg version check
fastmod -e go '\b1\.17.\d\b' '1.18.1'
# other places go 1.17.x is mentioned
fastmod '\b1\.17.\d\b' '1.18.1' .tool-versions internal/cmd/git-combine/Dockerfile
```

Then also updated the go.mod version. I think this should make us build everything using go1.18 on CI.

Brew ships go 1.18.1 so this should be good to go.

Test Plan: ran `sg start oss`. main dry run on CI.
