### PR TITLE
wildcard: Fix missing caret in textarea on Firefox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Unverified primary emails no longer breaks the Emails-page for users and Users-page for Site Admin. [#34312](https://github.com/sourcegraph/sourcegraph/pull/34312)
 - Button to download raw file in blob page is now working correctly. [#34558](https://github.com/sourcegraph/sourcegraph/pull/34558)
 - Searches containing `or` expressions are now optimized to evaluate natively on the backends that support it ([#34382](https://github.com/sourcegraph/sourcegraph/pull/34382)), and both commit and diff search have been updated to run optimized `and`, `or`, and `not` queries. [#34595](https://github.com/sourcegraph/sourcegraph/pull/34595)
+- Carets in textareas in Firefox are now visible. [#34888](https://github.com/sourcegraph/sourcegraph/pull/34888)
 
 ### Removed
 

--- a/client/branded/src/global-styles/custom-forms.scss
+++ b/client/branded/src/global-styles/custom-forms.scss
@@ -72,12 +72,6 @@
     &::-ms-expand {
         display: none;
     }
-
-    // Remove outline from select box in FF
-    &:-moz-focusring {
-        color: transparent;
-        text-shadow: 0 0 0 var(--input-color);
-    }
 }
 
 .custom-select-sm {

--- a/client/branded/src/global-styles/forms.scss
+++ b/client/branded/src/global-styles/forms.scss
@@ -54,12 +54,6 @@
     border-radius: var(--border-radius);
     transition: none;
 
-    // Remove select outline from select box in FF
-    &:-moz-focusring {
-        color: transparent;
-        text-shadow: 0 0 0 var(--input-color);
-    }
-
     // Placeholder
     &::placeholder {
         color: var(--input-placeholder-color);


### PR DESCRIPTION
Fixes #34887 

The Firefox specific styles cause the caret to be transparent in textareas. The comment seems to suggest that this isn't actually intended to be used with textareas, but maybe I'm not understanding it properly. I also inspected our custom and native select components and those styles don't even seem to be applied to them.

Before:

https://user-images.githubusercontent.com/179026/166668453-1a917d6c-d3e5-405f-afac-377f0d0ca215.mp4


After:

https://user-images.githubusercontent.com/179026/166668405-87224865-9b27-4787-8b15-4394e317229f.mp4

Note: If anybody is confused what these rules actually did: They made the text (including the caret in textareas) transparent and then made the text visible again by rendering its shadow only...


## Test plan

Ran storybook locally, navigated to http://localhost:9001/?path=/story/wildcard-textarea--text-area-examples and verified that the caret is visible.

I also took a before and after screenshot and ran them through imagemagick to find differences. I couldn't find any relevant differences. 

## App preview:

- [Web](https://sg-web-fkling-34887-ff-caret.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-fysphfljnv.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

