### PR TITLE
codemirror: Fix initial pattern type not being recognized

### DIFF
--- a/client/search-ui/src/input/CodeMirrorQueryInput.tsx
+++ b/client/search-ui/src/input/CodeMirrorQueryInput.tsx
@@ -264,7 +264,7 @@ const CodeMirrorQueryInput: React.FunctionComponent<CodeMirrorQueryInputProps> =
             useMemo(
                 () => [
                     EditorView.darkTheme.of(isLightTheme === false),
-                    parseInputAsQuery(),
+                    parseInputAsQuery({ patternType, interpretComments }),
                     tokenHighlight,
                     queryDiagnostic,
                     tokenInfo(),

--- a/client/search-ui/src/input/CodeMirrorQueryInput.tsx
+++ b/client/search-ui/src/input/CodeMirrorQueryInput.tsx
@@ -271,6 +271,10 @@ const CodeMirrorQueryInput: React.FunctionComponent<CodeMirrorQueryInputProps> =
                     highlightFocusedFilter,
                     ...extensions,
                 ],
+                // patternType and interpretComments are updated via a
+                // transaction since there is no need to re-initialize all
+                // extensions
+                // eslint-disable-next-line react-hooks/exhaustive-deps
                 [isLightTheme, extensions]
             )
         )

--- a/client/search-ui/src/input/extensions/parsedQuery.ts
+++ b/client/search-ui/src/input/extensions/parsedQuery.ts
@@ -39,18 +39,21 @@ export const decoratedTokens = Facet.define<DecoratedToken[], DecoratedToken[]>(
     },
 })
 
+interface ParseOptions {
+    patternType: SearchPatternType
+    interpretComments?: boolean
+}
+
 /**
  * Creates an extension that parses the input as search query and stores the
  * result in the {@link parsedQuery} facet.
  */
-export function parseInputAsQuery(): Extension {
+export function parseInputAsQuery(initialParseOptions: ParseOptions): Extension {
     // Editor state to keep information about how to parse the query. Can be updated
     // with the `setQueryParseOptions` effect.
-    return StateField.define<{ patternType: SearchPatternType; interpretComments?: boolean }>({
+    return StateField.define<ParseOptions>({
         create() {
-            return {
-                patternType: SearchPatternType.literal,
-            }
+            return initialParseOptions
         },
         update(value, transaction) {
             for (const effect of transaction.effects) {


### PR DESCRIPTION
Fixes #34824

The root issue was that the extensions get recreated due to changes
higher up in the component tree. However, because the pattern type is
set via a transaction the current value was lost and the extension
default back to `literal`.

Order of events:

1. Editor gets initialized
    1. Pattern type defaults to `literal`
2. Transaction gets triggered (via hook) to set pattern type to `regex`
3. Editor gets initialized`
    1. Pattern type defaults to `literal`

The hook that sets the pattern type via a transaction is *not* triggered
again because its depdencies (editor instance, pattern type) didn't
change.

The fix is to pass the current pattern type when initializing the
extension.

I also looked over the code to see if there are other extension that
would exhibit the same problem, but this one seems to be the only one.


https://user-images.githubusercontent.com/179026/166674916-765f19cf-35a1-4eb5-ab8b-0022feaf025c.mp4




## Test plan

Opening the link in the issue  correctly highlights the query and shows the correct hover information.

## App preview:

- [Web](https://sg-web-fkling-34824-cm-search-input.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-yodzpfeygo.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
