### PR TITLE
sg: update audit pr and fix pagination

### DIFF
--- a/dev/sg/main.go
+++ b/dev/sg/main.go
@@ -14,12 +14,17 @@ import (
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/stdout"
 	"github.com/sourcegraph/sourcegraph/dev/sg/root"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"github.com/sourcegraph/sourcegraph/lib/log"
 )
 
 func main() {
 	if os.Args[len(os.Args)-1] == "--generate-bash-completion" {
 		batchCompletionMode = true
 	}
+
+	log.Init(log.Resource{
+		Name: "sg",
+	})
 
 	if err := sg.RunContext(context.Background(), os.Args); err != nil {
 		fmt.Printf("error: %s\n", err)

--- a/dev/sg/sg_audit.go
+++ b/dev/sg/sg_audit.go
@@ -13,13 +13,16 @@ import (
 	"github.com/google/go-github/v41/github"
 	"github.com/slack-go/slack"
 	"github.com/urfave/cli/v2"
+	"golang.org/x/oauth2"
 
 	sgslack "github.com/sourcegraph/sourcegraph/dev/sg/internal/slack"
 	"github.com/sourcegraph/sourcegraph/dev/team"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"github.com/sourcegraph/sourcegraph/lib/log"
 )
 
 var auditFormatFlag string
+var auditPRGitHubToken string
 
 var auditCommand = &cli.Command{
 	Name:      "audit",
@@ -39,11 +42,21 @@ var auditCommand = &cli.Command{
 				DefaultText: "[markdown|terminal]",
 				Destination: &auditFormatFlag,
 			},
+			&cli.StringFlag{
+				Name:        "github.token",
+				Usage:       "GitHub token to use when making API requests, defaults to $GITHUB_TOKEN.",
+				Destination: &auditPRGitHubToken,
+				Value:       os.Getenv("GITHUB_TOKEN"),
+			},
 		},
 		Action: execAdapter(func(ctx context.Context, args []string) error {
-			ghc := github.NewClient(nil)
+			ghc := github.NewClient(oauth2.NewClient(ctx, oauth2.StaticTokenSource(
+				&oauth2.Token{AccessToken: auditPRGitHubToken},
+			)))
 
-			issues, err := fetchIssues(ctx, ghc)
+			logger := log.Scoped("audit pr", "sg audit pr")
+			logger.Debug("fetching issues")
+			issues, err := fetchIssues(ctx, logger, ghc)
 			if err != nil {
 				return err
 			}
@@ -51,6 +64,7 @@ var auditCommand = &cli.Command{
 			if err != nil {
 				return err
 			}
+			logger.Debug("formatting results")
 			prAuditIssues, err := presentIssues(ctx, ghc, slack, issues)
 			if err != nil {
 				return err
@@ -78,10 +92,18 @@ var auditCommand = &cli.Command{
 	}},
 }
 
-func fetchIssues(ctx context.Context, ghc *github.Client) ([]*github.Issue, error) {
+func fetchIssues(ctx context.Context, logger log.Logger, ghc *github.Client) ([]*github.Issue, error) {
 	var issues []*github.Issue
+	nextPage := 1
 	for {
-		is, r, err := ghc.Issues.ListByRepo(ctx, "sourcegraph", "sec-pr-audit-trail", &github.IssueListByRepoOptions{State: "open", Direction: "asc"})
+		logger.Debug("Listing issues", log.Int("nextPage", nextPage))
+		is, r, err := ghc.Issues.ListByRepo(ctx, "sourcegraph", "sec-pr-audit-trail", &github.IssueListByRepoOptions{
+			State:     "open",
+			Direction: "asc",
+			ListOptions: github.ListOptions{
+				Page: nextPage,
+			},
+		})
 		if err != nil {
 			return nil, err
 		}
@@ -89,6 +111,7 @@ func fetchIssues(ctx context.Context, ghc *github.Client) ([]*github.Issue, erro
 		if r.NextPage == 0 {
 			break
 		}
+		nextPage = r.NextPage
 	}
 	return issues, nil
 }
@@ -115,7 +138,7 @@ func presentIssues(ctx context.Context, ghc *github.Client, slack *slack.Client,
 
 		author, err := resolver.ResolveByGitHubHandle(ctx, assignee.GetLogin())
 		if err != nil {
-			return nil, err
+			return nil, errors.Wrapf(err, "failed to format issue %s", issue.GetHTMLURL())
 		}
 
 		res = append(res, prAuditIssue{


### PR DESCRIPTION
1. Adds log support to `sg` 
2. Add debug logs to `sg audit pr` 
3. Fix a bug with the pagination


## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

Ran locally, used the generated output there https://sourcegraph.slack.com/archives/C01N83PS4TU/p1651665123001459 
