### PR TITLE
sg: do not error on failed gcloud secrets access

### DIFF
--- a/dev/sg/internal/run/command.go
+++ b/dev/sg/internal/run/command.go
@@ -172,7 +172,8 @@ func startCmd(ctx context.Context, dir string, cmd Command, parentEnv map[string
 
 	secretsEnv, err := getSecrets(ctx, cmd)
 	if err != nil {
-		return nil, errors.Wrapf(err, "cannot fetch secrets")
+		stdout.Out.WriteLine(output.Linef(output.EmojiWarningSign, output.StyleBold, errors.Wrapf(err, "cannot fetch secrets").Error()))
+		return nil, nil
 	}
 
 	sc.Cmd.Env = makeEnv(cmd.Env, secretsEnv, parentEnv)

--- a/dev/sg/internal/run/run.go
+++ b/dev/sg/internal/run/run.go
@@ -585,7 +585,8 @@ func Test(ctx context.Context, cmd Command, args []string, parentEnv map[string]
 
 	secretsEnv, err := getSecrets(ctx, cmd)
 	if err != nil {
-		return errors.Wrapf(err, "cannot fetch secrets")
+		stdout.Out.WriteLine(output.Linef(output.EmojiWarningSign, output.StyleBold, errors.Wrapf(err, "cannot fetch secrets").Error()))
+		return nil
 	}
 
 	if cmd.Preamble != "" {


### PR DESCRIPTION

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


