### PR TITLE
sg: Fixup precedence of cmd specific env vars

### DIFF
--- a/dev/sg/internal/run/command.go
+++ b/dev/sg/internal/run/command.go
@@ -175,7 +175,7 @@ func startCmd(ctx context.Context, dir string, cmd Command, parentEnv map[string
 		return nil, errors.Wrapf(err, "cannot fetch secrets")
 	}
 
-	sc.Cmd.Env = makeEnv(cmd.Env, secretsEnv, parentEnv)
+	sc.Cmd.Env = makeEnv(parentEnv, secretsEnv, cmd.Env)
 
 	var stdoutWriter, stderrWriter io.Writer
 	logger := newCmdLogger(commandCtx, cmd.Name, stdout.Out)

--- a/dev/sg/internal/run/run.go
+++ b/dev/sg/internal/run/run.go
@@ -312,7 +312,7 @@ func runWatch(
 				stdout.Out.WriteLine(output.Linef("", output.StylePending, "Installing %s...", cmd.Name))
 			}
 
-			cmdOut, err := BashInRoot(ctx, cmd.Install, makeEnv(cmd.Env, parentEnv))
+			cmdOut, err := BashInRoot(ctx, cmd.Install, makeEnv(parentEnv, cmd.Env))
 			if err != nil {
 				if !startedOnce {
 					return installErr{cmdName: cmd.Name, output: cmdOut, originalErr: err}


### PR DESCRIPTION
This fixes a regression introduced by https://github.com/sourcegraph/sourcegraph/pull/34627 where cmd specific vars would not have higher precedence anymore, breaking the dev env because some variables were set to wrong values now.



## Test plan

Ran sg locally to confirm the issue I saw disappears.