### PR TITLE
actions: update github workflows to use go1.18

### DIFF
--- a/.github/workflows/buildchecker-history.yml
+++ b/.github/workflows/buildchecker-history.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
-        with: { go-version: '1.17' }
+        with: { go-version: '1.18' }
 
       - run: ./dev/buildchecker/run-week-history.sh
         env:

--- a/.github/workflows/buildchecker.yml
+++ b/.github/workflows/buildchecker.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
-        with: { go-version: '1.17' }
+        with: { go-version: '1.18' }
 
       - run: ./dev/buildchecker/run-check.sh
         env:

--- a/.github/workflows/licenses-check.yml
+++ b/.github/workflows/licenses-check.yml
@@ -9,7 +9,7 @@ jobs:
     - uses: actions/setup-ruby@v1
       with: { ruby-version: '2.6' }
     - uses: actions/setup-go@v2
-      with: { go-version: '1.17' }
+      with: { go-version: '1.18' }
 
     # set up correct version of node
     - id: nvmrc

--- a/.github/workflows/licenses-update.yml
+++ b/.github/workflows/licenses-update.yml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/setup-ruby@v1
       with: { ruby-version: '2.6' }
     - uses: actions/setup-go@v2
-      with: { go-version: '1.17' }
+      with: { go-version: '1.18' }
 
     # set up correct version of node
     - id: nvmrc

--- a/.github/workflows/lsif-typescript.yml
+++ b/.github/workflows/lsif-typescript.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Run lsif-typescript
         run: lsif-typescript index --yarn-workspaces
       - uses: actions/setup-go@v2
-        with: { go-version: '1.17' }
+        with: { go-version: '1.18' }
       - name: Convert LSIF Typed into LSIF Graph
         run: go run lib/codeintel/tools/lsif-typed/main.go dump.lsif-typed > dump.lsif
       - name: Upload lsif to Cloud

--- a/.github/workflows/pr-auditor.yml
+++ b/.github/workflows/pr-auditor.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
-        with: { go-version: '1.17' }
+        with: { go-version: '1.18' }
 
       - run: ./dev/pr-auditor/check-pr.sh
         env:

--- a/.github/workflows/sg-binary-release.yml
+++ b/.github/workflows/sg-binary-release.yml
@@ -87,7 +87,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17
+          go-version: 1.18
 
       - name: Build and upload macOS
         if: startsWith(matrix.os, 'macos-') == true

--- a/dev/pr-auditor/batch-changes/pr-auditor-patch.yml
+++ b/dev/pr-auditor/batch-changes/pr-auditor-patch.yml
@@ -33,7 +33,7 @@ steps:
             - uses: actions/checkout@v2
               with: { repository: 'sourcegraph/sourcegraph' }
             - uses: actions/setup-go@v2
-              with: { go-version: '1.17' }
+              with: { go-version: '1.18' }
 
             - run: ./dev/pr-auditor/check-pr.sh
               env:

--- a/dev/pr-auditor/batch-changes/pr-auditor-rollout.yml
+++ b/dev/pr-auditor/batch-changes/pr-auditor-rollout.yml
@@ -63,7 +63,7 @@ steps:
             - uses: actions/checkout@v2
               with: { repository: 'sourcegraph/sourcegraph' }
             - uses: actions/setup-go@v2
-              with: { go-version: '1.17' }
+              with: { go-version: '1.18' }
 
             - run: ./dev/pr-auditor/check-pr.sh
               env:


### PR DESCRIPTION
We haven't yet upgraded to 1.18 on buildkite. However, we should be able
to update in github actions. There shouldn't be any issues around these
being out of sync, and this reduces the amount that changes in one go
when we move asdf to 1.18.

```
fastmod --hidden '(go-version.*)(\b1\.17\b)' '${1}1.18'
```

Test Plan: CI is green