### PR TITLE
internal: update Dockerfiles to use go 1.18

### DIFF
--- a/internal/cmd/git-combine/Dockerfile
+++ b/internal/cmd/git-combine/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17.6-alpine AS builder
+FROM golang:1.18.1-alpine AS builder
 
 WORKDIR /go/src/app
 

--- a/internal/cmd/tracking-issue/Dockerfile
+++ b/internal/cmd/tracking-issue/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17-alpine AS builder
+FROM golang:1.18-alpine AS builder
 
 WORKDIR /go/src/tracking-issue
 COPY . .


### PR DESCRIPTION
This updates the two dockerfiles that directly reference golang base images to use go1.18.

Test Plan: built images

``` shell
cd internal/cmd/git-combine
docker build .

cd ../tracking-issue
docker build .
```
