### PR TITLE
syntax-highlighter: reference sourcegraph/Packages

### DIFF
--- a/docker-images/syntax-highlighter/LICENSE.syntaxes
+++ b/docker-images/syntax-highlighter/LICENSE.syntaxes
@@ -1,5 +1,5 @@
-syntect_server includes all syntaxes from https://github.com/slimsag/Packages
+syntect_server includes all syntaxes from https://github.com/sourcegraph/Packages
 
 Please refer to the license information there to see the license for all syntaxes:
 
-https://github.com/slimsag/Packages#license
+https://github.com/sourcegraph/Packages#license

--- a/docker-images/syntax-highlighter/README.md
+++ b/docker-images/syntax-highlighter/README.md
@@ -64,7 +64,7 @@ TODO: Update these instructions once we move to sourcegraph/syntect.
 
 #### 1) Find an open-source `.tmLanguage` or `.sublime-syntax` file and send a PR to our package registry
 
-https://github.com/slimsag/Packages is the package registry we use which holds all of the syntax definitions we use in syntect_server and Sourcegraph. Send a PR there by following [these steps](https://github.com/slimsag/Packages/blob/master/README.md#adding-a-new-language)
+https://github.com/sourcegraph/Packages is the package registry we use which holds all of the syntax definitions we use in syntect_server and Sourcegraph. Send a PR there by following [these steps](https://github.com/sourcegraph/Packages/blob/master/README.md#adding-a-new-language)
 
 #### 2) Update our temporary fork of `syntect`
 


### PR DESCRIPTION
I read these outdated references to slimsag/Packages and sent a PR to the wrong repo.

Test Plan: n/a