### PR TITLE
lib/codeintel: fix newline warning in go1.18

### DIFF
--- a/lib/codeintel/tools/lsif-repl/main.go
+++ b/lib/codeintel/tools/lsif-repl/main.go
@@ -60,7 +60,7 @@ func main() {
 
 			err = queryBundle(bundles[dumpID], path, line, column)
 			if err != nil {
-				fmt.Println(helpMsg)
+				fmt.Printf("%s\n", helpMsg)
 				break
 			}
 
@@ -142,7 +142,7 @@ func main() {
 			// break
 
 		default:
-			fmt.Println(helpMsg)
+			fmt.Printf("%s\n", helpMsg)
 		}
 
 		fmt.Printf("\n> ")


### PR DESCRIPTION
go1.18 has new warnings for Println usages which trigger go test to fail:

```
codeintel/tools/lsif-repl/main.go:63:5: fmt.Println arg list ends with redundant newline
codeintel/tools/lsif-repl/main.go:145:4: fmt.Println arg list ends with redundant newline
```

I kept the same output, but made the newline explicit to avoid the failure.

Test Plan: go test with go1.18 locally
