### PR TITLE
changelog: document upgrade to alpine 3.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Changed
 
--
+- Sourcegraph's docker images are now based on Alpine Linux 3.14. [#34508](https://github.com/sourcegraph/sourcegraph/pull/34508)
 
 ### Fixed
 


### PR DESCRIPTION
I missed this in https://github.com/sourcegraph/sourcegraph/pull/34508

Test Plan: n/a