### PR TITLE
Code Insights: Implement a special layout mode for the drill down filter panel

### DIFF
--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/DrillDownInsightCreationForm.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/DrillDownInsightCreationForm.tsx
@@ -1,7 +1,5 @@
 import React from 'react'
 
-import classNames from 'classnames'
-
 import { ErrorAlert } from '@sourcegraph/branded/src/components/alerts'
 import { Button, Input } from '@sourcegraph/wildcard'
 
@@ -49,7 +47,7 @@ export const DrillDownInsightCreationForm: React.FunctionComponent<DrillDownInsi
 
     return (
         // eslint-disable-next-line react/forbid-elements
-        <form ref={ref} onSubmit={handleSubmit} noValidate={true} className={classNames(className, 'p-3')}>
+        <form ref={ref} onSubmit={handleSubmit} noValidate={true} className={className}>
             <h3 className="mb-3">Save as new view</h3>
 
             <Input

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/DrillDownInsightFilters.module.scss
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/DrillDownInsightFilters.module.scss
@@ -2,9 +2,12 @@
     display: flex;
     flex-wrap: wrap;
     align-items: baseline;
-    padding: 0.75rem 1rem;
+    padding: 0 0 0.75rem 0;
+}
+
+.header-separator {
+    margin-top: 0;
     margin-bottom: 0.25rem;
-    border-bottom: 1px solid var(--border-color);
 }
 
 .heading {
@@ -26,8 +29,20 @@
     display: block;
 }
 
+.panels {
+    display: flex;
+    flex-direction: column;
+
+    &--horizontal-mode {
+        flex-direction: row;
+        gap: 1.5rem;
+        padding-bottom: 1rem;
+    }
+}
+
 .panel {
-    padding-right: 1rem;
+    min-width: 0;
+    flex-basis: 50%;
 }
 
 .reg-exp-filters {
@@ -44,7 +59,7 @@
     gap: 1rem;
 
     margin-top: -0.25rem;
-    padding: 0.75rem 1rem;
+    padding: 0.75rem 0 0 0;
 }
 
 .buttons {

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/DrillDownInsightFilters.story.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/DrillDownInsightFilters.story.tsx
@@ -7,7 +7,7 @@ import { WebStory } from '../../../../../../../../components/WebStory'
 import { GetSearchContextsResult } from '../../../../../../../../graphql-operations'
 import { InsightFilters } from '../../../../../../core'
 
-import { DrillDownInsightFilters } from './DrillDownInsightFilters'
+import { DrillDownInsightFilters, FilterSectionVisualMode } from './DrillDownInsightFilters'
 import { SEARCH_CONTEXT_GQL } from './search-context/DrillDownSearchContextFilter'
 
 const defaultStory: Meta = {
@@ -46,6 +46,27 @@ const CONTEXTS_GQL_MOCKS: MockedResponse<GetSearchContextsResult> = {
                         query: 'repo:github.com/sourcegraph/sourcegraph2',
                         description: 'Hello this is mee, your friend context 2',
                     },
+                    {
+                        __typename: 'SearchContext',
+                        id: '004',
+                        spec: '@sourcegraph/code-insights',
+                        query: 'repo:github.com/sourcegraph/sourcegraph2',
+                        description: 'Hello this is mee, your friend context 2',
+                    },
+                    {
+                        __typename: 'SearchContext',
+                        id: '005',
+                        spec: '@sourcegraph/code-insights',
+                        query: 'repo:github.com/sourcegraph/sourcegraph2',
+                        description: 'Hello this is mee, your friend context 2',
+                    },
+                    {
+                        __typename: 'SearchContext',
+                        id: '006',
+                        spec: '@sourcegraph/code-insights',
+                        query: 'repo:github.com/sourcegraph/sourcegraph2',
+                        description: 'Hello this is mee, your friend context 2',
+                    },
                 ],
                 pageInfo: {
                     hasNextPage: false,
@@ -72,6 +93,20 @@ export const DrillDownFiltersShowcase: Story = () => (
         <DrillDownInsightFilters
             initialValues={FILTERS}
             originalValues={ORIGINAL_FILTERS}
+            visualMode={FilterSectionVisualMode.CollapseSections}
+            onFiltersChange={console.log}
+            onFilterSave={console.log}
+            onCreateInsightRequest={console.log}
+        />
+    </MockedTestProvider>
+)
+
+export const DrillDownFiltersHorizontalMode: Story = () => (
+    <MockedTestProvider mocks={[CONTEXTS_GQL_MOCKS]}>
+        <DrillDownInsightFilters
+            initialValues={FILTERS}
+            originalValues={ORIGINAL_FILTERS}
+            visualMode={FilterSectionVisualMode.HorizontalSections}
             onFiltersChange={console.log}
             onFilterSave={console.log}
             onCreateInsightRequest={console.log}

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/filter-collapse-section/FilterCollapseSection.module.scss
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/filter-collapse-section/FilterCollapseSection.module.scss
@@ -1,3 +1,19 @@
+.root {
+    &--no-collapse {
+        .collapse-icon {
+            display: none;
+        }
+
+        .collapse-button {
+            padding-left: 0;
+        }
+
+        .collapse-panel {
+            margin-left: 0;
+        }
+    }
+}
+
 .collapse-button {
     display: flex;
     align-items: center;

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/filter-collapse-section/FilterCollapseSection.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/filter-collapse-section/FilterCollapseSection.tsx
@@ -1,5 +1,6 @@
 import { PropsWithChildren, ReactElement } from 'react'
 
+import classNames from 'classnames'
 import ChevronDownIcon from 'mdi-react/ChevronDownIcon'
 import ChevronUpIcon from 'mdi-react/ChevronUpIcon'
 
@@ -16,15 +17,16 @@ interface FilterCollapseSectionProps {
     preview: string
     hasActiveFilter: boolean
     className?: string
+    withSeparators: boolean
     onOpenChange: (opened: boolean) => void
 }
 
 export function FilterCollapseSection(props: PropsWithChildren<FilterCollapseSectionProps>): ReactElement {
-    const { open, title, preview, hasActiveFilter, className, children, onOpenChange } = props
+    const { open, title, preview, hasActiveFilter, className, withSeparators, children, onOpenChange } = props
 
     return (
-        <Collapse isOpen={open} onOpenChange={onOpenChange}>
-            <div className={className}>
+        <div className={classNames(className, { [styles.rootNoCollapse]: !withSeparators })}>
+            <Collapse isOpen={open} onOpenChange={onOpenChange}>
                 <CollapseHeader
                     as={Button}
                     aria-label={open ? 'Expand' : 'Collapse'}
@@ -44,9 +46,9 @@ export function FilterCollapseSection(props: PropsWithChildren<FilterCollapseSec
                 </CollapseHeader>
 
                 {open && <CollapsePanel className={styles.collapsePanel}>{children}</CollapsePanel>}
-            </div>
 
-            <hr />
-        </Collapse>
+                {withSeparators && <hr />}
+            </Collapse>
+        </div>
     )
 }

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-popover/DrillDownFiltersPopover.module.scss
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-popover/DrillDownFiltersPopover.module.scss
@@ -59,7 +59,7 @@
     border-radius: 0;
     padding: 0.75rem 1rem;
 
-    & hr {
+    hr {
         margin-left: -1rem;
         margin-right: -1rem;
     }

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-popover/DrillDownFiltersPopover.module.scss
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-popover/DrillDownFiltersPopover.module.scss
@@ -57,6 +57,12 @@
 .popover {
     width: 100%;
     border-radius: 0;
+    padding: 0.75rem 1rem;
+
+    & hr {
+        margin-left: -1rem;
+        margin-right: -1rem;
+    }
 
     &--with-filters {
         max-width: 34.375rem;

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-popover/DrillDownFiltersPopover.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-popover/DrillDownFiltersPopover.tsx
@@ -14,6 +14,7 @@ import {
 import {
     DrillDownFiltersFormValues,
     DrillDownInsightFilters,
+    FilterSectionVisualMode,
     hasActiveFilters,
 } from '../drill-down-filters-panel/DrillDownInsightFilters'
 
@@ -96,6 +97,7 @@ export const DrillDownFiltersPopover: React.FunctionComponent<DrillDownFiltersPo
                     <DrillDownInsightFilters
                         initialValues={initialFiltersValue}
                         originalValues={originalFiltersValue}
+                        visualMode={FilterSectionVisualMode.CollapseSections}
                         onFiltersChange={handleFilterChange}
                         onFilterSave={onFilterSave}
                         onCreateInsightRequest={() => setStep(DrillDownFiltersStep.ViewCreation)}


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/34761

## Background 

This PR updates the drill down panel so we can reuse the same drill down components for the standalone page. I didn't match our initial [design](https://www.figma.com/file/Y4grZjTxnXHEQSoeB14vU1/Share-a-link-to-an-individual-code-insight-RFC-654?node-id=1228%3A16270) perfectly (we don't have a vertical separator between sections in the horizontal mode, we don't have collapse state for the drill-down filter panel on the standalone insight page) cc @Joelkw @AlicjaSuska. I will create an issue where I catch all cut off that we made for this part of UI, and we will fix them right after the 3.40.


## Test plan
- Make sure that drill down layout looks good in both modes (collapse panels and horizontal sections) 
- Make sure that drill down filter panel looks good on the dashboard page

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->



## App preview:

- [Web](https://sg-web-vk-add-new-mode-for-drill-down.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-uttrjsidbw.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
