### PR TITLE
pr-auditor: set status on ref instead of sha

### DIFF
--- a/dev/pr-auditor/main.go
+++ b/dev/pr-auditor/main.go
@@ -173,7 +173,7 @@ func preMergeAudit(ctx context.Context, ghc *github.Client, payload *EventPayloa
 	}
 
 	owner, repo := payload.Repository.GetOwnerAndName()
-	_, _, err := ghc.Repositories.CreateStatus(ctx, owner, repo, payload.PullRequest.Head.SHA, &github.RepoStatus{
+	_, _, err := ghc.Repositories.CreateStatus(ctx, owner, repo, payload.PullRequest.Head.Ref, &github.RepoStatus{
 		Context:     github.String(commitStatusPreMerge),
 		State:       github.String(prState),
 		Description: github.String(stateDescription),


### PR DESCRIPTION
This should prevent subsequent pushes from reporting a "pending" status from this check.

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

Open PR, pre-merge passes.

Push to PR, pre-merge still marked as green.
