### PR TITLE
pr-auditor: check on synchronize

### DIFF
--- a/.github/workflows/pr-auditor.yml
+++ b/.github/workflows/pr-auditor.yml
@@ -2,7 +2,7 @@
 name: pr-auditor
 on:
   pull_request:
-    types: [ closed, edited, opened ]
+    types: [ closed, edited, opened, synchronize ]
 
 jobs:
   run:


### PR DESCRIPTION
As a required check, pr-auditor's check status messes up if a subsequent push is made to a branch. It appears [we can't set a ref instead of a specific SHA](https://github.com/sourcegraph/sourcegraph/pull/34913#issuecomment-1117563565), so I guess we have to run on pushes.

I _think_ this is what the `synchronize` event does: https://github.community/t/what-is-a-pull-request-synchronize-event/14784

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


