### PR TITLE
Search backend: Return "RepoPagerJob" from (jobutil.repoPagerJob).Name()

### DIFF
--- a/internal/search/job/jobutil/repo_pager_job.go
+++ b/internal/search/job/jobutil/repo_pager_job.go
@@ -86,5 +86,5 @@ func (p *repoPagerJob) Run(ctx context.Context, clients job.RuntimeClients, stre
 }
 
 func (p *repoPagerJob) Name() string {
-	return "RepoPager"
+	return "RepoPagerJob"
 }


### PR DESCRIPTION
Stacked on https://github.com/sourcegraph/sourcegraph/pull/34923
Related to #34009

Return "RepoPagerJob" from `(jobutil.repoPagerJob).Name()` for clarity in traces.

## Test plan
Semantics-preserving.

