### PR TITLE
insights: new live preview that supports search insights and multiple series

### DIFF
--- a/cmd/frontend/graphqlbackend/insights.go
+++ b/cmd/frontend/graphqlbackend/insights.go
@@ -20,6 +20,7 @@ type InsightsResolver interface {
 	InsightViews(ctx context.Context, args *InsightViewQueryArgs) (InsightViewConnectionResolver, error)
 
 	SearchInsightLivePreview(ctx context.Context, args SearchInsightLivePreviewArgs) ([]SearchInsightLivePreviewSeriesResolver, error)
+	InsightLivePreview(ctx context.Context, args InsightLivePreviewArgs) ([]SearchInsightLivePreviewSeriesResolver, error)
 
 	// Mutations
 	CreateInsightsDashboard(ctx context.Context, args *CreateInsightsDashboardArgs) (InsightsDashboardPayloadResolver, error)
@@ -42,6 +43,22 @@ type InsightsResolver interface {
 
 type SearchInsightLivePreviewArgs struct {
 	Input SearchInsightLivePreviewInput
+}
+
+type InsightLivePreviewArgs struct {
+	Input InsightLivePreviewInput
+}
+
+type InsightLivePreviewInput struct {
+	RepositoryScope RepositoryScopeInput
+	TimeScope       TimeScopeInput
+	Series          []SeriesLivePreviewInput
+}
+
+type SeriesLivePreviewInput struct {
+	Query                      string
+	Label                      string
+	GeneratedFromCaptureGroups bool
 }
 
 type SearchInsightLivePreviewInput struct {

--- a/cmd/frontend/graphqlbackend/insights.graphql
+++ b/cmd/frontend/graphqlbackend/insights.graphql
@@ -207,6 +207,11 @@ extend type Query {
     Generate an ephemeral time series for a Search based code insight, generally for the purposes of live preview.
     """
     searchInsightLivePreview(input: SearchInsightLivePreviewInput!): [SearchInsightLivePreviewSeries!]!
+
+    """
+    Generate an ephemeral set of time series for a code insight, generally for the purposes of live preview.
+    """
+    insightLivePreview(input: InsightLivePreviewInput!): [SearchInsightLivePreviewSeries!]!
 }
 
 extend type Mutation {
@@ -986,6 +991,45 @@ input SearchInsightLivePreviewInput {
     The scope of time.
     """
     timeScope: TimeScopeInput!
+
+    """
+    Whether or not to generate the timeseries results from the query capture groups.
+    """
+    generatedFromCaptureGroups: Boolean!
+}
+
+"""
+Required input to generate a live preview for an insight.
+"""
+input InsightLivePreviewInput {
+    """
+    The scope of repositories.
+    """
+    repositoryScope: RepositoryScopeInput!
+    """
+    The scope of time.
+    """
+    timeScope: TimeScopeInput!
+
+    """
+    The series to generate previews for
+    """
+    series: [SeriesLivePreviewInput!]!
+}
+
+"""
+Required input to generate a live preview for a series.
+"""
+input SeriesLivePreviewInput {
+    """
+    The query string.
+    """
+    query: String!
+
+    """
+    The desired label for the series. Will be overwritten when series are dynamically generated.
+    """
+    label: String!
 
     """
     Whether or not to generate the timeseries results from the query capture groups.

--- a/enterprise/internal/insights/resolvers/disabled_resolver.go
+++ b/enterprise/internal/insights/resolvers/disabled_resolver.go
@@ -78,3 +78,7 @@ func (r *disabledResolver) DeleteInsightView(ctx context.Context, args *graphqlb
 func (r *disabledResolver) SearchInsightLivePreview(ctx context.Context, args graphqlbackend.SearchInsightLivePreviewArgs) ([]graphqlbackend.SearchInsightLivePreviewSeriesResolver, error) {
 	return nil, errors.New(r.reason)
 }
+
+func (r *disabledResolver) InsightLivePreview(ctx context.Context, args graphqlbackend.InsightLivePreviewArgs) ([]graphqlbackend.SearchInsightLivePreviewSeriesResolver, error) {
+	return nil, errors.New(r.reason)
+}


### PR DESCRIPTION
new live preview endpoint that supports search and capture group insights as well as mixing of the two types.

example input:
```json
{
  "input": {
    "repositoryScope": {
      "repositories": ["github.com/sourcegraph/sourcegraph"]
    },
    "timeScope": {
      "stepInterval": {
        "unit": "MONTH",
        "value": 1
      }
    },
    "series": [
      {
        "query": "TODO archived:no fork:no",
        "label": "TODO",
        "generatedFromCaptureGroups": false
      },
      {
        "query": "FIXME archived:no fork:no",
        "label": "FIXME",
        "generatedFromCaptureGroups": false
      }
    ]
  }
}

```
## Test plan
tbd
<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


