### PR TITLE
codeintel-qa: Add clear command

### DIFF
--- a/dev/codeintel-qa/README.md
+++ b/dev/codeintel-qa/README.md
@@ -42,16 +42,22 @@ Alternatively, generate them by running the following command (this takes much l
 ./scripts/clone-and-index.sh
 ```
 
-Upload the indexes to your the target instance by running the following command:
+If there is previous upload or index state on the target instance, they can be cleared by running the following command:
 
 ```
-go build ./cmd/upload && ./upload
+go run ./cmd/clear
+```
+
+Upload the indexes to the target instance by running the following command:
+
+```
+go run ./cmd/upload
 ```
 
 Then run test queries against the target instance by running the following command:
 
 ```
-go build ./cmd/query && ./query
+go run ./cmd/query
 ```
 
 ## Refreshing indexes

--- a/dev/codeintel-qa/cmd/clear/clear.go
+++ b/dev/codeintel-qa/cmd/clear/clear.go
@@ -1,0 +1,165 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/sourcegraph/sourcegraph/dev/codeintel-qa/internal"
+	"github.com/sourcegraph/sourcegraph/internal/gqltestutil"
+)
+
+// clearAllIndexes clears all indexes from the target instance.
+func clearAllIndexes(ctx context.Context) error {
+	client := internal.GraphQLClient()
+
+	for {
+		if requery, err := clearIndexesOnce(ctx, client); err != nil {
+			return err
+		} else if !requery {
+			break
+		}
+
+		<-time.After(time.Second)
+	}
+
+	fmt.Printf("[%5s] %s All indexes deleted\n", internal.TimeSince(start), internal.EmojiSuccess)
+	return nil
+}
+
+func clearIndexesOnce(ctx context.Context, client *gqltestutil.Client) (requery bool, _ error) {
+	var payload struct {
+		Data struct {
+			LSIFIndexes struct {
+				Nodes []jsonIndexResult
+			}
+		}
+	}
+	if err := client.GraphQL(internal.SourcegraphAccessToken, indexesQuery, nil, &payload); err != nil {
+		return false, err
+	}
+
+	for _, index := range payload.Data.LSIFIndexes.Nodes {
+		// TODO - display repo@commit instead
+		fmt.Printf("[%5s] %s Deleting index %s\n", internal.TimeSince(start), internal.EmojiLightbulb, index.ID)
+
+		if err := client.GraphQL(internal.SourcegraphAccessToken, deleteIndexQuery, map[string]interface{}{"id": index.ID}, nil); err != nil {
+			return false, err
+		}
+
+		requery = true
+	}
+
+	return requery, nil
+}
+
+type jsonIndexResult struct {
+	ID    string
+	State string
+}
+
+const indexesQuery = `
+query CodeIntelQA_Clear_Indexes {
+	lsifIndexes {
+		nodes {
+			id
+			state
+		}
+	}
+}
+`
+
+const deleteIndexQuery = `
+mutation CodeIntelQA_Clear_DeleteIndex($id: ID!) {
+	deleteLSIFIndex(id: $id) {
+		alwaysNil
+	}
+}
+`
+
+// clearAllUploads clears all uploads from the target instance.
+func clearAllUploads(ctx context.Context) error {
+	client := internal.GraphQLClient()
+
+	for {
+		if requery, err := clearUploadsOnce(ctx, client); err != nil {
+			return err
+		} else if !requery {
+			break
+		}
+
+		<-time.After(time.Second)
+	}
+
+	fmt.Printf("[%5s] %s All uploads deleted\n", internal.TimeSince(start), internal.EmojiSuccess)
+	return nil
+}
+
+func clearUploadsOnce(ctx context.Context, client *gqltestutil.Client) (requery bool, _ error) {
+	var payload struct {
+		Data struct {
+			LSIFUploads struct {
+				Nodes []jsonUploadResult
+			}
+		}
+	}
+	if err := client.GraphQL(internal.SourcegraphAccessToken, uploadsQuery, nil, &payload); err != nil {
+		return false, err
+	}
+
+	purging := make([]jsonUploadResult, 0, len(payload.Data.LSIFUploads.Nodes))
+	for _, upload := range payload.Data.LSIFUploads.Nodes {
+		if upload.State == "DELETED" {
+			continue
+		}
+
+		if upload.State == "DELETING" {
+			purging = append(purging, upload)
+		} else {
+			// TODO - display repo@commit instead
+			fmt.Printf("[%5s] %s Deleting upload %s\n", internal.TimeSince(start), internal.EmojiLightbulb, upload.ID)
+
+			if err := client.GraphQL(internal.SourcegraphAccessToken, deleteUploadQuery, map[string]interface{}{"id": upload.ID}, nil); err != nil {
+				return false, err
+			}
+		}
+
+		requery = true
+	}
+
+	if !requery && len(purging) > 0 {
+		for _, upload := range purging {
+			// TODO - display repo@commit instead
+			fmt.Printf("[%5s] %s Waiting for upload %s to be purged\n", internal.TimeSince(start), internal.EmojiLightbulb, upload.ID)
+
+		}
+
+		requery = true
+	}
+
+	return requery, nil
+}
+
+type jsonUploadResult struct {
+	ID    string
+	State string
+}
+
+const uploadsQuery = `
+query CodeIntelQA_Clear_Uploads {
+	lsifUploads {
+		nodes {
+			id
+			state
+		}
+	}
+}
+`
+
+const deleteUploadQuery = `
+mutation CodeIntelQA_Clear_DeleteUploads($id: ID!) {
+	deleteLSIFUpload(id: $id) {
+		alwaysNil
+	}
+}
+`

--- a/dev/codeintel-qa/cmd/clear/main.go
+++ b/dev/codeintel-qa/cmd/clear/main.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/sourcegraph/sourcegraph/dev/codeintel-qa/internal"
+)
+
+var (
+	indexDir             string
+	numConcurrentUploads int
+	verbose              bool
+	pollInterval         time.Duration
+	timeout              time.Duration
+
+	start = time.Now()
+)
+
+func init() {
+	// Default assumes running from the dev/codeintel-qa directory
+	flag.StringVar(&indexDir, "index-dir", "./testdata/indexes", "The location of the testdata directory")
+	flag.IntVar(&numConcurrentUploads, "num-concurrent-uploads", 5, "The maximum number of concurrent uploads")
+	flag.BoolVar(&verbose, "verbose", false, "Display full state from graphql")
+	flag.DurationVar(&pollInterval, "poll-interval", time.Second*5, "The time to wait between graphql requests")
+	flag.DurationVar(&timeout, "timeout", 0, "The time it should take to upload and process all targets")
+}
+
+func main() {
+	if err := flag.CommandLine.Parse(os.Args[1:]); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %s\n", err)
+		os.Exit(1)
+	}
+
+	ctx := context.Background()
+	if timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, timeout)
+		defer cancel()
+	}
+
+	if err := mainErr(ctx); err != nil {
+		fmt.Printf("%s error: %s\n", internal.EmojiFailure, err.Error())
+		os.Exit(1)
+	}
+}
+
+func mainErr(ctx context.Context) error {
+	if err := internal.InitializeGraphQLClient(); err != nil {
+		return err
+	}
+
+	if err := clearAllIndexes(ctx); err != nil {
+		if strings.Contains(err.Error(), "not enabled") {
+			fmt.Printf("[%5s] %s Auto-indexing is not enabled on this instance\n", internal.TimeSince(start), internal.EmojiProblem)
+		} else {
+			return err
+		}
+	}
+
+	if err := clearAllUploads(ctx); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/dev/codeintel-qa/cmd/query/query.go
+++ b/dev/codeintel-qa/cmd/query/query.go
@@ -40,7 +40,7 @@ func queryUploads(ctx context.Context) (_ map[string][]string, err error) {
 			} `json:"lsifUploads"`
 		} `json:"data"`
 	}
-	if err := queryGraphQL(ctx, "CodeIntelTesterUploads", uploadsQuery, map[string]interface{}{}, &payload); err != nil {
+	if err := queryGraphQL(ctx, "CodeIntelQA_Query_Uploads", uploadsQuery, map[string]interface{}{}, &payload); err != nil {
 		return nil, err
 	}
 
@@ -110,7 +110,7 @@ func queryDefinitions(ctx context.Context, location Location) (locations []Locat
 	}
 
 	var payload QueryResponse
-	if err := queryGraphQL(ctx, "CodeIntelTesterDefinitions", definitionsQuery, variables, &payload); err != nil {
+	if err := queryGraphQL(ctx, "CodeIntelQA_Query_Definitions", definitionsQuery, variables, &payload); err != nil {
 		return nil, err
 	}
 
@@ -159,7 +159,7 @@ func queryReferences(ctx context.Context, location Location) (locations []Locati
 		}
 
 		var payload QueryResponse
-		if err := queryGraphQL(ctx, "CodeIntelTesterReferences", referencesQuery, variables, &payload); err != nil {
+		if err := queryGraphQL(ctx, "CodeIntelQA_Query_References", referencesQuery, variables, &payload); err != nil {
 			return nil, err
 		}
 

--- a/dev/codeintel-qa/cmd/upload/state.go
+++ b/dev/codeintel-qa/cmd/upload/state.go
@@ -179,7 +179,7 @@ func makeRepoStateQuery(repoNames, uploadIDs []string) string {
 		fragments = append(fragments, fmt.Sprintf(uploadQueryFragment, i, id))
 	}
 
-	return fmt.Sprintf("query CodeIntelQA_Upload {%s}", strings.Join(fragments, "\n"))
+	return fmt.Sprintf("query CodeIntelQA_Upload_RepositoryState {%s}", strings.Join(fragments, "\n"))
 }
 
 const repositoryQueryFragment = `

--- a/dev/codeintel-qa/internal/emojis.go
+++ b/dev/codeintel-qa/internal/emojis.go
@@ -4,4 +4,5 @@ const (
 	EmojiSuccess   = "✅"
 	EmojiFailure   = "❌"
 	EmojiLightbulb = "💡"
+	EmojiProblem   = "⛔"
 )


### PR DESCRIPTION
Aids in #34900. This adds a `clear` command to the codeintel-qa command set which removes all index and upload records from the instance.

If applied prior to upload, it should put the instance in a "clean" state until we can do more work to make the query testing more resilient. It may take a bit more time to do this correctly, so this offers a partial solution to get the preprod workflows correct.

## Test plan

N/A; is a test utility itself.