### PR TITLE
Search backend: Format output of (search.RepoOptions).String()

### DIFF
--- a/internal/search/types.go
+++ b/internal/search/types.go
@@ -2,7 +2,6 @@ package search
 
 import (
 	"fmt"
-	"strconv"
 	"strings"
 
 	zoektquery "github.com/google/zoekt/query"
@@ -251,34 +250,42 @@ type RepoOptions struct {
 
 func (op *RepoOptions) String() string {
 	var b strings.Builder
-	b.WriteString("RepoFilters: ")
-	if len(op.RepoFilters) > 0 {
-		for i, r := range op.RepoFilters {
-			if i != 0 {
-				b.WriteByte(' ')
-			}
-			b.WriteString(strconv.Quote(r))
-		}
-	} else {
-		b.WriteString("[]")
-	}
-	b.WriteString("\n")
 
+	if len(op.RepoFilters) > 0 {
+		_, _ = fmt.Fprintf(&b, "RepoFilters: %q\n", op.RepoFilters)
+	} else {
+		b.WriteString("RepoFilters: []\n")
+	}
 	if len(op.MinusRepoFilters) > 0 {
-		_, _ = fmt.Fprintf(&b, "MinusRepoFilters: %v\n", op.MinusRepoFilters)
+		_, _ = fmt.Fprintf(&b, "MinusRepoFilters: %q\n", op.MinusRepoFilters)
 	} else {
 		b.WriteString("MinusRepoFilters: []\n")
 	}
 
 	_, _ = fmt.Fprintf(&b, "CommitAfter: %s\n", op.CommitAfter)
-	_, _ = fmt.Fprintf(&b, "CaseSensitiveRepoFilters: %t\n", op.CaseSensitiveRepoFilters)
-	_, _ = fmt.Fprintf(&b, "ForkSet: %t\n", op.ForkSet)
-	_, _ = fmt.Fprintf(&b, "NoForks: %t\n", op.NoForks)
-	_, _ = fmt.Fprintf(&b, "OnlyForks: %t\n", op.OnlyForks)
-	_, _ = fmt.Fprintf(&b, "ArchivedSet: %t\n", op.ArchivedSet)
-	_, _ = fmt.Fprintf(&b, "NoArchived: %t\n", op.NoArchived)
-	_, _ = fmt.Fprintf(&b, "OnlyArchived: %t\n", op.OnlyArchived)
 	_, _ = fmt.Fprintf(&b, "Visibility: %s\n", string(op.Visibility))
+
+	if op.CaseSensitiveRepoFilters {
+		_, _ = fmt.Fprintf(&b, "CaseSensitiveRepoFilters: %t\n", op.CaseSensitiveRepoFilters)
+	}
+	if op.ForkSet {
+		_, _ = fmt.Fprintf(&b, "ForkSet: %t\n", op.ForkSet)
+	}
+	if op.NoForks {
+		_, _ = fmt.Fprintf(&b, "NoForks: %t\n", op.NoForks)
+	}
+	if op.OnlyForks {
+		_, _ = fmt.Fprintf(&b, "OnlyForks: %t\n", op.OnlyForks)
+	}
+	if op.ArchivedSet {
+		_, _ = fmt.Fprintf(&b, "ArchivedSet: %t\n", op.ArchivedSet)
+	}
+	if op.NoArchived {
+		_, _ = fmt.Fprintf(&b, "NoArchived: %t\n", op.NoArchived)
+	}
+	if op.OnlyArchived {
+		_, _ = fmt.Fprintf(&b, "OnlyArchived: %t\n", op.OnlyArchived)
+	}
 
 	return b.String()
 }

--- a/internal/search/types.go
+++ b/internal/search/types.go
@@ -236,7 +236,7 @@ type RepoOptions struct {
 	Limit       int
 	Cursors     []*types.Cursor
 
-	// Explicit forks indicates whether `fork:` was set explicitly in the query,
+	// ForkSet indicates whether `fork:` was set explicitly in the query,
 	// or whether the values were set from defaults.
 	ForkSet   bool
 	NoForks   bool
@@ -251,42 +251,34 @@ type RepoOptions struct {
 
 func (op *RepoOptions) String() string {
 	var b strings.Builder
-	if len(op.RepoFilters) == 0 {
-		b.WriteString("r=[]")
-	}
-	for i, r := range op.RepoFilters {
-		if i != 0 {
-			b.WriteByte(' ')
+	b.WriteString("RepoFilters: ")
+	if len(op.RepoFilters) > 0 {
+		for i, r := range op.RepoFilters {
+			if i != 0 {
+				b.WriteByte(' ')
+			}
+			b.WriteString(strconv.Quote(r))
 		}
-		b.WriteString(strconv.Quote(r))
+	} else {
+		b.WriteString("[]")
 	}
+	b.WriteString("\n")
 
 	if len(op.MinusRepoFilters) > 0 {
-		_, _ = fmt.Fprintf(&b, " -r=%v", op.MinusRepoFilters)
-	}
-	if op.CommitAfter != "" {
-		_, _ = fmt.Fprintf(&b, " CommitAfter=%q", op.CommitAfter)
-	}
-
-	if op.CaseSensitiveRepoFilters {
-		b.WriteString(" CaseSensitiveRepoFilters")
+		_, _ = fmt.Fprintf(&b, "MinusRepoFilters: %v\n", op.MinusRepoFilters)
+	} else {
+		b.WriteString("MinusRepoFilters: []\n")
 	}
 
-	if op.NoForks {
-		b.WriteString(" NoForks")
-	}
-	if op.OnlyForks {
-		b.WriteString(" OnlyForks")
-	}
-	if op.NoArchived {
-		b.WriteString(" NoArchived")
-	}
-	if op.OnlyArchived {
-		b.WriteString(" OnlyArchived")
-	}
-	if op.Visibility != query.Any {
-		b.WriteString(" Visibility" + string(op.Visibility))
-	}
+	_, _ = fmt.Fprintf(&b, "CommitAfter: %s\n", op.CommitAfter)
+	_, _ = fmt.Fprintf(&b, "CaseSensitiveRepoFilters: %t\n", op.CaseSensitiveRepoFilters)
+	_, _ = fmt.Fprintf(&b, "ForkSet: %t\n", op.ForkSet)
+	_, _ = fmt.Fprintf(&b, "NoForks: %t\n", op.NoForks)
+	_, _ = fmt.Fprintf(&b, "OnlyForks: %t\n", op.OnlyForks)
+	_, _ = fmt.Fprintf(&b, "ArchivedSet: %t\n", op.ArchivedSet)
+	_, _ = fmt.Fprintf(&b, "NoArchived: %t\n", op.NoArchived)
+	_, _ = fmt.Fprintf(&b, "OnlyArchived: %t\n", op.OnlyArchived)
+	_, _ = fmt.Fprintf(&b, "Visibility: %s\n", string(op.Visibility))
 
 	return b.String()
 }


### PR DESCRIPTION
Print all relevant field values of `RepoOptions` in an easy-to-read format. This will add more detail to traces of jobs that have `RepoOptions` as a field.

## Test plan
Just updating how a tag is displayed in traces. Verified visually. 
For example, the query `repo:^github\.com/sourcegraph/sourcegraph$ type:commit fork:no archived:no query` now produces a `CommitSearchJob` trace with the `repoOpts` field formatted as such:

<img width="1073" alt="Screen Shot 2022-05-04 at 5 39 20 PM" src="https://user-images.githubusercontent.com/70350613/166836976-a176765e-275d-4852-811d-0b81b660e2d9.png">



