### PR TITLE
Repo syncer: construct stores on the fly

### DIFF
--- a/cmd/repo-updater/repoupdater/server_test.go
+++ b/cmd/repo-updater/repoupdater/server_test.go
@@ -182,11 +182,12 @@ func TestServer_EnqueueRepoUpdate(t *testing.T) {
 	testCases := []testCase{{
 		name: "returns an error on store failure",
 		init: func(realDB database.DB) repos.Store {
-			repos := database.NewMockRepoStore()
-			repos.ListFunc.SetDefaultReturn(nil, errors.New("boom"))
-			db := database.NewMockDBFrom(realDB)
-			db.ReposFunc.SetDefaultReturn(repos)
-			return initStore(db)
+			mockRepos := database.NewMockRepoStore()
+			mockRepos.ListFunc.SetDefaultReturn(nil, errors.New("boom"))
+			realStore := initStore(realDB)
+			mockStore := repos.NewMockStoreFrom(realStore)
+			mockStore.RepoStoreFunc.SetDefaultReturn(mockRepos)
+			return mockStore
 		},
 		err: `store.list-repos: boom`,
 	}, {

--- a/enterprise/cmd/repo-updater/internal/authz/perms_syncer_test.go
+++ b/enterprise/cmd/repo-updater/internal/authz/perms_syncer_test.go
@@ -156,6 +156,8 @@ func TestPermsSyncer_syncUserPerms(t *testing.T) {
 	reposStore := repos.NewMockStoreFrom(repos.NewStore(db, sql.TxOptions{}))
 	reposStore.ListExternalServiceUserIDsByRepoIDFunc.SetDefaultReturn([]int32{1}, nil)
 	reposStore.ListExternalServicePrivateRepoIDsByUserIDFunc.SetDefaultReturn([]api.RepoID{2, 3, 4}, nil)
+	reposStore.ExternalServiceStoreFunc.SetDefaultReturn(externalServices)
+	reposStore.RepoStoreFunc.SetDefaultReturn(mockRepos)
 
 	perms := edb.NewMockPermsStore()
 	perms.ListExternalAccountsFunc.SetDefaultReturn([]*extsvc.Account{&extAccount}, nil)
@@ -246,6 +248,8 @@ func TestPermsSyncer_syncUserPerms_noPerms(t *testing.T) {
 
 	reposStore := repos.NewMockStoreFrom(repos.NewStore(db, sql.TxOptions{}))
 	reposStore.ListExternalServicePrivateRepoIDsByUserIDFunc.SetDefaultReturn([]api.RepoID{}, nil)
+	reposStore.RepoStoreFunc.SetDefaultReturn(mockRepos)
+	reposStore.ExternalServiceStoreFunc.SetDefaultReturn(externalServices)
 
 	perms := edb.NewMockPermsStore()
 	perms.ListExternalAccountsFunc.SetDefaultReturn([]*extsvc.Account{&extAccount}, nil)
@@ -430,6 +434,8 @@ func TestPermsSyncer_syncUserPerms_prefixSpecs(t *testing.T) {
 
 	reposStore := repos.NewMockStoreFrom(repos.NewStore(db, sql.TxOptions{}))
 	reposStore.ListExternalServicePrivateRepoIDsByUserIDFunc.SetDefaultReturn([]api.RepoID{}, nil)
+	reposStore.RepoStoreFunc.SetDefaultReturn(mockRepos)
+	reposStore.ExternalServiceStoreFunc.SetDefaultReturn(externalServices)
 
 	perms := edb.NewMockPermsStore()
 	perms.ListExternalAccountsFunc.SetDefaultReturn([]*extsvc.Account{&extAccount}, nil)
@@ -497,6 +503,8 @@ func TestPermsSyncer_syncUserPerms_subRepoPermissions(t *testing.T) {
 
 	reposStore := repos.NewMockStoreFrom(repos.NewStore(db, sql.TxOptions{}))
 	reposStore.ListExternalServicePrivateRepoIDsByUserIDFunc.SetDefaultReturn([]api.RepoID{}, nil)
+	reposStore.RepoStoreFunc.SetDefaultReturn(mockRepos)
+	reposStore.ExternalServiceStoreFunc.SetDefaultReturn(externalServices)
 
 	perms := edb.NewMockPermsStore()
 	perms.ListExternalAccountsFunc.SetDefaultReturn([]*extsvc.Account{&extAccount}, nil)
@@ -558,6 +566,7 @@ func TestPermsSyncer_syncRepoPerms(t *testing.T) {
 
 		reposStore := repos.NewMockStoreFrom(repos.NewStore(db, sql.TxOptions{}))
 		reposStore.ListExternalServiceUserIDsByRepoIDFunc.SetDefaultReturn([]int32{}, nil)
+		reposStore.RepoStoreFunc.SetDefaultReturn(mockRepos)
 
 		perms := edb.NewMockPermsStore()
 		s := newPermsSyncer(reposStore, perms)
@@ -611,6 +620,7 @@ func TestPermsSyncer_syncRepoPerms(t *testing.T) {
 
 		reposStore := repos.NewMockStoreFrom(repos.NewStore(db, sql.TxOptions{}))
 		reposStore.ListExternalServiceUserIDsByRepoIDFunc.SetDefaultReturn([]int32{}, nil)
+		reposStore.RepoStoreFunc.SetDefaultReturn(mockRepos)
 
 		perms := edb.NewMockPermsStore()
 		perms.TransactFunc.SetDefaultReturn(perms, nil)
@@ -642,6 +652,7 @@ func TestPermsSyncer_syncRepoPerms(t *testing.T) {
 
 		reposStore := repos.NewMockStoreFrom(repos.NewStore(db, sql.TxOptions{}))
 		reposStore.ListExternalServiceUserIDsByRepoIDFunc.SetDefaultReturn([]int32{1}, nil)
+		reposStore.RepoStoreFunc.SetDefaultReturn(mockRepos)
 
 		perms := edb.NewMockPermsStore()
 		perms.TransactFunc.SetDefaultReturn(perms, nil)
@@ -687,6 +698,7 @@ func TestPermsSyncer_syncRepoPerms(t *testing.T) {
 
 	reposStore := repos.NewMockStoreFrom(repos.NewStore(db, sql.TxOptions{}))
 	reposStore.ListExternalServiceUserIDsByRepoIDFunc.SetDefaultReturn([]int32{}, nil)
+	reposStore.RepoStoreFunc.SetDefaultReturn(mockRepos)
 
 	perms := edb.NewMockPermsStore()
 	perms.TransactFunc.SetDefaultReturn(perms, nil)


### PR DESCRIPTION
This constructs other stores from repos.Store on the fly rather than
storing them on the store struct. This is just to increase confidence
that, when we start a transaction, the next time we use a store, it
holds a handle to that transaction. I was really struggling to convince
myself that it was okay that we would start a transaction on the
basestore, but then use the untransacted store that we hold a reference
to on the `store` struct. I wasn't able to construct any failures, but
this still feels safer.

Note that I'm not confident this fixes incident 99 since I couldn't 
reproduce it locally, but it might. I'm probably not going to be the
one to un-revert it and try though 🙂 

## Test plan

Depending on existing tests here, but I think this should be a safe change based on what I've read of the code. 

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


