### PR TITLE
Accessibility: Add tips for fixing common screen reader problems

### DIFF
--- a/doc/dev/background-information/web/accessibility/how-to-screen-reader.md
+++ b/doc/dev/background-information/web/accessibility/how-to-screen-reader.md
@@ -44,8 +44,8 @@ Depending on the platform, there are two widely used screen readers. Although th
 ## Tips
 
 - Use [`aria-hidden`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-hidden) to hide decorative elements from screen readers.
-- Use ReachUI's [`<VisuallyHidden />`](https://reach.tech/visually-hidden/) to provide accessible text that is visually hidden from the UI. This is useful for communicating the semantic meaning of buttons or other elements which might be visually represented with an icon or other purely graphical content.
-- Provide a more specific `aria-label` to elements who exact meaning might require context around it to understand.
-  - For example, in a list of items where each item also has a button associated with it, the button might be `aria-label`ed to more clearly indicate which item the button is for.
+- Use ReachUI's [`<VisuallyHidden />`](https://reach.tech/visually-hidden/) to provide accessible text that is visually hidden from the UI. This is useful for communicating the semantic meaning of buttons or other elements which are visually represented with an icon or other purely graphical content.
+- Provide a more specific `aria-label` to elements whose exact meaning requires context around it to understand.
+  - For example, in a list of items where each item also has a button associated with it, the button should be `aria-label`ed to more clearly indicate which item the button is for.
 - Use `screenReaderAnnounce` to communicate messages about implied changing state (e.g. form submission, async resolutions, or changes to on-screen data from polling).
 - Use [landmark roles](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/region_role) such as `role="region"` to identify areas with multiple pieces of content that users would want to navigate to easily.

--- a/doc/dev/background-information/web/accessibility/how-to-screen-reader.md
+++ b/doc/dev/background-information/web/accessibility/how-to-screen-reader.md
@@ -40,3 +40,12 @@ Depending on the platform, there are two widely used screen readers. Although th
 | <kbd>↑</kbd> | Navigate to previous line |
 | <kbd>H</kbd> | Navigate to next heading |
 | <kbd>Shift</kbd> + <kbd>H</kbd> | Navigate to previous heading |
+
+## Tips
+
+- Use [`aria-hidden`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-hidden) to hide decorative elements from screen readers.
+- Use ReachUI's [`<VisuallyHidden />`](https://reach.tech/visually-hidden/) to provide accessible text that is visually hidden from the UI. This is useful for communicating the semantic meaning of buttons or other elements which might be visually represented with an icon or other purely graphical content.
+- Provide a more specific `aria-label` to elements who exact meaning might require context around it to understand.
+  - For example, in a list of items where each item also has a button associated with it, the button might be `aria-label`ed to more clearly indicate which item the button is for.
+- Use `screenReaderAnnounce` to communicate messages about implied changing state (e.g. form submission, async resolutions, or changes to on-screen data from polling).
+- Use [landmark roles](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/region_role) such as `role="region"` to identify areas with multiple pieces of content that users would want to navigate to easily.


### PR DESCRIPTION
Some initial high-value takeaways for improving screen reader navigation, collected from the first round of accessibility audits our team completed and based around practices we're already following in our codebase. Notably, suggesting `<VisuallyHidden />` (as opposed to Bootstrap `.sr-only`) for providing "alt text" that's only exposed to accessibility tools for icon buttons and other information primarily communicated graphically (thanks @LawnGnome for surfacing this in your a11y PR, since it was basically tribal knowledge).

## Test plan

Just a docs change.

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


