### PR TITLE
web: fix insights checkbox label

### DIFF
--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/insight-context-menu/InsightContextMenu.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/insight-context-menu/InsightContextMenu.tsx
@@ -90,10 +90,7 @@ export const InsightContextMenu: React.FunctionComponent<React.PropsWithChildren
                                 <MenuItem
                                     role="menuitemcheckbox"
                                     data-testid="InsightContextMenuEditLink"
-                                    className={classNames(
-                                        'd-flex align-items-center justify-content-between',
-                                        styles.item
-                                    )}
+                                    className={classNames('d-flex align-items-center justify-content-end', styles.item)}
                                     onSelect={onToggleZeroYAxisMin}
                                     aria-checked={zeroYAxisMin}
                                 >
@@ -103,7 +100,7 @@ export const InsightContextMenu: React.FunctionComponent<React.PropsWithChildren
                                         onChange={noop}
                                         tabIndex={-1}
                                         id="InsightContextMenuEditInput"
-                                        label="Start Y Axis at 0"
+                                        label={<span className="font-weight-normal">Start Y Axis at 0</span>}
                                     />
                                 </MenuItem>
                             )}


### PR DESCRIPTION
## Context

Fixing visual regression introduced in [the migration PR](https://github.com/sourcegraph/sourcegraph/pull/34324).

## Test plan

Check out `InsightContextMenu` in the web interface.


## App preview:

- [Web](https://sg-web-vb-fix-insight-checkbox.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-oohtsiroux.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
