### PR TITLE
Code Insights: Add insight card to the standalone page

### DIFF
--- a/client/web/src/enterprise/insights/CodeInsightsAppRouter.tsx
+++ b/client/web/src/enterprise/insights/CodeInsightsAppRouter.tsx
@@ -66,7 +66,10 @@ export const CodeInsightsAppRouter = withAuthenticatedUser<CodeInsightsAppRouter
                     <Route
                         path={`${match.url}/insight/:id`}
                         render={(props: RouteComponentProps<{ id: string }>) => (
-                            <CodeInsightIndependentPage insightId={props.match.params.id} />
+                            <CodeInsightIndependentPage
+                                insightId={props.match.params.id}
+                                telemetryService={telemetryService}
+                            />
                         )}
                     />
                 )}

--- a/client/web/src/enterprise/insights/components/insights-view-grid/hooks/use-insight-data.ts
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/hooks/use-insight-data.ts
@@ -1,8 +1,7 @@
-import { RefObject, useContext, useEffect, useState } from 'react'
+import { RefObject, useEffect, useState } from 'react'
 
 import { ObservableInput } from 'rxjs'
 
-import { CodeInsightsBackendContext, CodeInsightsGqlBackend } from '../../../core'
 import { LazyQueryState, useLazyParallelRequest } from '../../../hooks/use-parallel-requests/use-parallel-request'
 
 export interface UseInsightDataResult<T> {
@@ -23,16 +22,10 @@ export function useInsightData<D>(
     request: () => ObservableInput<D>,
     reference: RefObject<HTMLElement>
 ): UseInsightDataResult<D> {
-    const api = useContext(CodeInsightsBackendContext)
-    const isGqlAPI = api instanceof CodeInsightsGqlBackend
-
     const { state, query } = useLazyParallelRequest<D>()
 
-    // All non GQL API implementations do not support partial loading,
-    // allowing insights fetching for this API whether insights are
-    // in a viewport or not.
-    const [isVisible, setVisibility] = useState<boolean>(!isGqlAPI)
-    const [hasIntersected, setHasIntersected] = useState<boolean>(!isGqlAPI)
+    const [isVisible, setVisibility] = useState<boolean>(false)
+    const [hasIntersected, setHasIntersected] = useState<boolean>(false)
 
     useEffect(() => {
         if (hasIntersected) {
@@ -51,7 +44,7 @@ export function useInsightData<D>(
         // Do not observe insights visibility for non GQL based APIs.
         // Only GQL API supports partial insights fetching based on
         // insights visibility.
-        if (!element || !isGqlAPI) {
+        if (!element) {
             return
         }
 
@@ -70,7 +63,7 @@ export function useInsightData<D>(
         observer.observe(element)
 
         return () => observer.unobserve(element)
-    }, [isGqlAPI, reference])
+    }, [reference])
 
     return { state, isVisible, query }
 }

--- a/client/web/src/enterprise/insights/core/backend/gql-backend/methods/get-backend-insight-data/get-backend-insight-data.ts
+++ b/client/web/src/enterprise/insights/core/backend/gql-backend/methods/get-backend-insight-data/get-backend-insight-data.ts
@@ -27,7 +27,7 @@ export const getBackendInsightData = (
         client.watchQuery<GetInsightViewResult>({
             query: GET_INSIGHT_VIEW_GQL,
             variables: { id: insight.id, filters },
-            // This query is set to network-only becasue the caching is not working correctly
+            // This query is set to network-only because the caching is not working correctly
             // https://github.com/sourcegraph/sourcegraph/issues/33813
             fetchPolicy: 'network-only',
         })

--- a/client/web/src/enterprise/insights/hooks/use-parallel-requests/use-parallel-request.ts
+++ b/client/web/src/enterprise/insights/hooks/use-parallel-requests/use-parallel-request.ts
@@ -157,7 +157,7 @@ export function createUseParallelRequestsHook<T>({ maxRequests } = { maxRequests
             return state
         },
         /**
-         * This provides query methods that allows to you run your request in parallel with
+         * This provides query methods that allow to you run your request in parallel with
          * other request that have been made with useParallelRequests request calls.
          */
         lazyQuery: <D>(): LazyQueryResult<D> => {

--- a/client/web/src/enterprise/insights/pages/insights/insight/CodeInsightIndependentPage.module.scss
+++ b/client/web/src/enterprise/insights/pages/insights/insight/CodeInsightIndependentPage.module.scss
@@ -1,3 +1,8 @@
 .root {
     max-width: 70rem;
 }
+
+.content {
+    padding-bottom: 4rem;
+    margin-top: 2rem;
+}

--- a/client/web/src/enterprise/insights/pages/insights/insight/CodeInsightIndependentPage.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/insight/CodeInsightIndependentPage.tsx
@@ -2,6 +2,7 @@ import { FunctionComponent, useContext, useMemo } from 'react'
 
 import MapSearchIcon from 'mdi-react/MapSearchIcon'
 
+import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { LoadingSpinner, PageHeader, useObservable } from '@sourcegraph/wildcard'
 
 import { HeroPage } from '../../../../../components/HeroPage'
@@ -11,15 +12,16 @@ import { CodeInsightsPage } from '../../../components/code-insights-page/CodeIns
 import { CodeInsightsBackendContext } from '../../../core'
 
 import { CodeInsightIndependentPageActions } from './components/actions/CodeInsightIndependentPageActions'
+import { SmartStandaloneInsight } from './components/SmartStandaloneInsight'
 
 import styles from './CodeInsightIndependentPage.module.scss'
 
-interface CodeInsightIndependentPage {
+interface CodeInsightIndependentPage extends TelemetryProps {
     insightId: string
 }
 
 export const CodeInsightIndependentPage: FunctionComponent<CodeInsightIndependentPage> = props => {
-    const { insightId } = props
+    const { insightId, telemetryService } = props
     const { getInsightById } = useContext(CodeInsightsBackendContext)
 
     const insight = useObservable(useMemo(() => getInsightById(insightId), [getInsightById, insightId]))
@@ -39,6 +41,10 @@ export const CodeInsightIndependentPage: FunctionComponent<CodeInsightIndependen
                 path={[{ to: '/insights/dashboards/all', icon: CodeInsightsIcon }, { text: insight.title }]}
                 actions={<CodeInsightIndependentPageActions insight={insight} />}
             />
+
+            <div className={styles.content}>
+                <SmartStandaloneInsight insight={insight} telemetryService={telemetryService} />
+            </div>
         </CodeInsightsPage>
     )
 }

--- a/client/web/src/enterprise/insights/pages/insights/insight/components/SmartStandaloneInsight.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/insight/components/SmartStandaloneInsight.tsx
@@ -1,0 +1,24 @@
+import { FunctionComponent } from 'react'
+
+import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
+
+import { Insight, isBackendInsight } from '../../../../core'
+
+import { StandaloneBackendInsight } from './standalone-backend-insight/StandaloneBackendInsight'
+import { StandaloneRuntimeInsight } from './standalone-runtime-insight/StandaloneRuntimeInsight'
+
+interface SmartStandaloneInsightProps extends TelemetryProps {
+    insight: Insight
+    className?: string
+}
+
+export const SmartStandaloneInsight: FunctionComponent<SmartStandaloneInsightProps> = props => {
+    const { insight, telemetryService, className } = props
+
+    if (isBackendInsight(insight)) {
+        return <StandaloneBackendInsight insight={insight} telemetryService={telemetryService} className={className} />
+    }
+
+    // Search based extension and lang stats insight are handled by built-in fetchers
+    return <StandaloneRuntimeInsight insight={insight} telemetryService={telemetryService} className={className} />
+}

--- a/client/web/src/enterprise/insights/pages/insights/insight/components/context-menu/StandaloneInsightContextMenu.module.scss
+++ b/client/web/src/enterprise/insights/pages/insights/insight/components/context-menu/StandaloneInsightContextMenu.module.scss
@@ -1,0 +1,16 @@
+.button {
+    display: inline-flex;
+    cursor: pointer;
+}
+
+.button-icon {
+    fill: var(--icon-color);
+
+    &--active {
+        fill: var(--body-color);
+    }
+}
+
+.item[data-reach-menu-item] {
+    text-align: right;
+}

--- a/client/web/src/enterprise/insights/pages/insights/insight/components/context-menu/StandaloneInsightContextMenu.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/insight/components/context-menu/StandaloneInsightContextMenu.tsx
@@ -1,0 +1,67 @@
+import React from 'react'
+
+import classNames from 'classnames'
+import { noop } from 'lodash'
+import DotsVerticalIcon from 'mdi-react/DotsVerticalIcon'
+
+import { Menu, MenuButton, MenuItem, MenuList, Position, Checkbox } from '@sourcegraph/wildcard'
+
+import { Insight } from '../../../../../core'
+import { useUiFeatures } from '../../../../../hooks/use-ui-features'
+
+import styles from './StandaloneInsightContextMenu.module.scss'
+
+export interface StandaloneInsightContextMenuProps {
+    insight: Insight
+    zeroYAxisMin: boolean
+    onToggleZeroYAxisMin: (zeroYAxisMin: boolean) => void
+}
+
+export const StandaloneInsightContextMenu: React.FunctionComponent<StandaloneInsightContextMenuProps> = props => {
+    const { insight, zeroYAxisMin, onToggleZeroYAxisMin = noop } = props
+
+    const { insight: insightPermissions } = useUiFeatures()
+    const menuPermissions = insightPermissions.getContextActionsPermissions(insight)
+
+    if (!menuPermissions.showYAxis) {
+        return null
+    }
+
+    return (
+        <Menu>
+            {({ isOpen }) => (
+                <>
+                    <MenuButton
+                        data-testid="InsightContextMenuButton"
+                        className={classNames('p-1', styles.button)}
+                        aria-label="Insight options"
+                        outline={true}
+                    >
+                        <DotsVerticalIcon
+                            className={classNames(styles.buttonIcon, { [styles.buttonIconActive]: isOpen })}
+                            size={16}
+                        />
+                    </MenuButton>
+                    <MenuList position={Position.bottomEnd} data-testid={`context-menu.${insight.id}`}>
+                        <MenuItem
+                            role="menuitemcheckbox"
+                            data-testid="InsightContextMenuEditLink"
+                            className={classNames('d-flex align-items-center justify-content-end', styles.item)}
+                            onSelect={() => onToggleZeroYAxisMin(!zeroYAxisMin)}
+                            aria-checked={zeroYAxisMin}
+                        >
+                            <Checkbox
+                                aria-hidden="true"
+                                checked={zeroYAxisMin}
+                                onChange={noop}
+                                tabIndex={-1}
+                                id="InsightContextMenuEditInput"
+                                label="Start Y Axis at 0"
+                            />
+                        </MenuItem>
+                    </MenuList>
+                </>
+            )}
+        </Menu>
+    )
+}

--- a/client/web/src/enterprise/insights/pages/insights/insight/components/standalone-backend-insight/StandaloneBackendInsight.module.scss
+++ b/client/web/src/enterprise/insights/pages/insights/insight/components/standalone-backend-insight/StandaloneBackendInsight.module.scss
@@ -1,0 +1,10 @@
+.root {
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
+}
+
+.chart {
+    min-height: 30rem;
+}

--- a/client/web/src/enterprise/insights/pages/insights/insight/components/standalone-backend-insight/StandaloneBackendInsight.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/insight/components/standalone-backend-insight/StandaloneBackendInsight.tsx
@@ -1,0 +1,84 @@
+import React, { useCallback, useContext, useRef, useState } from 'react'
+
+import classNames from 'classnames'
+
+import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
+import { useDebounce, useDeepMemo } from '@sourcegraph/wildcard'
+
+import { InsightCard, InsightCardHeader, InsightCardLoading } from '../../../../../components'
+import {
+    BackendInsightChart,
+    BackendInsightErrorAlert,
+} from '../../../../../components/insights-view-grid/components/backend-insight/components'
+import { useInsightData } from '../../../../../components/insights-view-grid/hooks/use-insight-data'
+import { BackendInsight, CodeInsightsBackendContext, InsightFilters } from '../../../../../core'
+import { LazyQueryStatus } from '../../../../../hooks/use-parallel-requests/use-parallel-request'
+import { getTrackingTypeByInsightType, useCodeInsightViewPings } from '../../../../../pings'
+import { StandaloneInsightContextMenu } from '../context-menu/StandaloneInsightContextMenu'
+
+import styles from './StandaloneBackendInsight.module.scss'
+
+interface StandaloneBackendInsight extends TelemetryProps {
+    insight: BackendInsight
+    className?: string
+}
+
+export const StandaloneBackendInsight: React.FunctionComponent<StandaloneBackendInsight> = props => {
+    const { telemetryService, insight, className } = props
+    const { getBackendInsightData } = useContext(CodeInsightsBackendContext)
+
+    // Visual line chart settings
+    const [zeroYAxisMin, setZeroYAxisMin] = useState(false)
+
+    // Original insight filters values that are stored in setting subject with insight
+    // configuration object, They are updated  whenever the user clicks update/save button
+    const [originalInsightFilters] = useState(insight.filters)
+    const insightCardReference = useRef<HTMLDivElement>(null)
+
+    // Live valid filters from filter form. They are updated whenever the user is changing
+    // filter value in filters fields.
+    const [filters] = useState<InsightFilters>(originalInsightFilters)
+    const debouncedFilters = useDebounce(useDeepMemo<InsightFilters>(filters), 500)
+
+    const { state, isVisible } = useInsightData(
+        useCallback(() => getBackendInsightData({ ...insight, filters: debouncedFilters }), [
+            insight,
+            debouncedFilters,
+            getBackendInsightData,
+        ]),
+        insightCardReference
+    )
+
+    const { trackMouseLeave, trackMouseEnter, trackDatumClicks } = useCodeInsightViewPings({
+        telemetryService,
+        insightType: getTrackingTypeByInsightType(insight.type),
+    })
+
+    return (
+        <div className={classNames(className, styles.root)}>
+            <InsightCard
+                ref={insightCardReference}
+                data-testid={`insight-standalone-card.${insight.id}`}
+                className={styles.chart}
+                onMouseEnter={trackMouseEnter}
+                onMouseLeave={trackMouseLeave}
+            >
+                <InsightCardHeader title={insight.title}>
+                    <StandaloneInsightContextMenu
+                        insight={insight}
+                        zeroYAxisMin={zeroYAxisMin}
+                        onToggleZeroYAxisMin={setZeroYAxisMin}
+                    />
+                </InsightCardHeader>
+
+                {state.status === LazyQueryStatus.Loading || !isVisible ? (
+                    <InsightCardLoading>Loading code insight</InsightCardLoading>
+                ) : state.status === LazyQueryStatus.Error ? (
+                    <BackendInsightErrorAlert error={state.error} />
+                ) : (
+                    <BackendInsightChart {...state.data} locked={insight.isFrozen} onDatumClick={trackDatumClicks} />
+                )}
+            </InsightCard>
+        </div>
+    )
+}

--- a/client/web/src/enterprise/insights/pages/insights/insight/components/standalone-runtime-insight/StandaloneRuntimeInsight.module.scss
+++ b/client/web/src/enterprise/insights/pages/insights/insight/components/standalone-runtime-insight/StandaloneRuntimeInsight.module.scss
@@ -1,0 +1,10 @@
+.chart {
+    min-height: 30rem;
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+}
+
+.chart-parent-size {
+    flex: 1;
+}

--- a/client/web/src/enterprise/insights/pages/insights/insight/components/standalone-runtime-insight/StandaloneRuntimeInsight.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/insight/components/standalone-runtime-insight/StandaloneRuntimeInsight.tsx
@@ -1,0 +1,104 @@
+import React, { useContext, useMemo, useRef, useState } from 'react'
+
+import classNames from 'classnames'
+
+import { ErrorAlert } from '@sourcegraph/branded/src/components/alerts'
+import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
+
+import { ParentSize } from '../../../../../../../charts'
+import {
+    CategoricalBasedChartTypes,
+    CategoricalChart,
+    InsightCard,
+    InsightCardHeader,
+    InsightCardLegend,
+    InsightCardLoading,
+    SeriesBasedChartTypes,
+    SeriesChart,
+} from '../../../../../components'
+import { useInsightData } from '../../../../../components/insights-view-grid/hooks/use-insight-data'
+import { CodeInsightsBackendContext, LangStatsInsight, SearchRuntimeBasedInsight } from '../../../../../core'
+import { InsightContentType } from '../../../../../core/types/insight/common'
+import { LazyQueryStatus } from '../../../../../hooks/use-parallel-requests/use-parallel-request'
+import { getTrackingTypeByInsightType, useCodeInsightViewPings } from '../../../../../pings'
+import { StandaloneInsightContextMenu } from '../context-menu/StandaloneInsightContextMenu'
+
+import styles from './StandaloneRuntimeInsight.module.scss'
+
+interface StandaloneRuntimeInsightProps extends TelemetryProps {
+    insight: SearchRuntimeBasedInsight | LangStatsInsight
+    className?: string
+}
+
+export function StandaloneRuntimeInsight(props: StandaloneRuntimeInsightProps): React.ReactElement {
+    const { insight, telemetryService, className } = props
+    const { getBuiltInInsightData } = useContext(CodeInsightsBackendContext)
+
+    const insightCardReference = useRef<HTMLDivElement>(null)
+
+    const { state, isVisible } = useInsightData(
+        useMemo(() => () => getBuiltInInsightData({ insight }), [getBuiltInInsightData, insight]),
+        insightCardReference
+    )
+
+    // Visual line chart settings
+    const [zeroYAxisMin, setZeroYAxisMin] = useState(false)
+
+    const { trackDatumClicks, trackMouseLeave, trackMouseEnter } = useCodeInsightViewPings({
+        telemetryService,
+        insightType: getTrackingTypeByInsightType(insight.type),
+    })
+
+    return (
+        <InsightCard
+            ref={insightCardReference}
+            data-testid={`insight-card.${insight.id}`}
+            className={classNames(styles.chart, className)}
+            onMouseEnter={trackMouseEnter}
+            onMouseLeave={trackMouseLeave}
+        >
+            <InsightCardHeader title={insight.title}>
+                <StandaloneInsightContextMenu
+                    insight={insight}
+                    zeroYAxisMin={zeroYAxisMin}
+                    onToggleZeroYAxisMin={setZeroYAxisMin}
+                />
+            </InsightCardHeader>
+            {state.status === LazyQueryStatus.Loading || !isVisible ? (
+                <InsightCardLoading>Loading code insight</InsightCardLoading>
+            ) : state.status === LazyQueryStatus.Error ? (
+                <ErrorAlert error={state.error} />
+            ) : (
+                <>
+                    <ParentSize className={styles.chartParentSize}>
+                        {parent =>
+                            state.data.type === InsightContentType.Series ? (
+                                <SeriesChart
+                                    type={SeriesBasedChartTypes.Line}
+                                    width={parent.width}
+                                    height={parent.height}
+                                    zeroYAxisMin={zeroYAxisMin}
+                                    locked={insight.isFrozen}
+                                    onDatumClick={trackDatumClicks}
+                                    {...state.data.content}
+                                />
+                            ) : (
+                                <CategoricalChart
+                                    type={CategoricalBasedChartTypes.Pie}
+                                    width={parent.width}
+                                    height={parent.height}
+                                    locked={insight.isFrozen}
+                                    onDatumLinkClick={trackDatumClicks}
+                                    {...state.data.content}
+                                />
+                            )
+                        }
+                    </ParentSize>
+                    {state.data.type === InsightContentType.Series && (
+                        <InsightCardLegend series={state.data.content.series} className="mt-3" />
+                    )}
+                </>
+            )}
+        </InsightCard>
+    )
+}


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/34762

This PR adds backend and runtime insight card components (including fetching functions and card layout) 

<img width="987" alt="Screenshot 2022-05-05 at 17 46 34" src="https://user-images.githubusercontent.com/18492575/166899514-14195cc7-8f4a-4e63-990e-f7c3c324a53d.png">


## Test plan
- Make sure that all (lang stats, capture group, search-based) insights look good on the standalone insight page)




## App preview:

- [Web](https://sg-web-vk-unify-runtime-and-backend.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-xzdbkxosgj.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
