### PR TITLE
ci: invalidate asdf cache before using it

### DIFF
--- a/dev/ci/asdf-install.sh
+++ b/dev/ci/asdf-install.sh
@@ -34,6 +34,7 @@ else
     echo -e "ASDF 🔥 Cache hit: $cache_key"
     aws s3 cp --profile buildkite --endpoint-url 'https://storage.googleapis.com' --region "us-central1" "s3://sourcegraph_buildkite_cache/$cache_key" "$HOME/"
     pushd "$HOME" || exit
+    rm -rf .asdf
     tar xzf "$cache_file"
     popd || exit
   else


### PR DESCRIPTION
There can be an existing .asdf directory when asdf-install.sh is run. For example in the backcompat tests we checkout an older commit then run asdf-install. The mixing of the directory leads to undefined behaviour. In particular for the go1.18 upgrade PR when running tests against the older commit we keep using the newer version of go. In this particular case this leads to the tests failing due to new lint errors in go1.18.

Test Plan: main dry run on CI