### PR TITLE
repoupdater: do not initialize database twice

### DIFF
--- a/cmd/repo-updater/repoupdater/server.go
+++ b/cmd/repo-updater/repoupdater/server.go
@@ -195,7 +195,7 @@ func (s *Server) handleExternalServiceSync(w http.ResponseWriter, r *http.Reques
 	if sourcer = s.Sourcer; sourcer == nil {
 		db := database.NewDB(s.Handle().DB())
 		depsSvc := livedependencies.GetService(db, nil)
-		sourcer = repos.NewSourcer(database.NewDB(s.Handle().DB()), httpcli.ExternalClientFactory, repos.WithDependenciesService(depsSvc))
+		sourcer = repos.NewSourcer(db, httpcli.ExternalClientFactory, repos.WithDependenciesService(depsSvc))
 	}
 	src, err := sourcer(&types.ExternalService{
 		ID:              req.ExternalService.ID,


### PR DESCRIPTION
I think someone just missed this: `db` is already initialized to a local
var 2 lines above, so no need to also call this in the `NewSourcer`
call.

## Test plan

- Existing tests


