### PR TITLE
symbols: go-build only builds target binary

### DIFF
--- a/cmd/symbols/Dockerfile
+++ b/cmd/symbols/Dockerfile
@@ -15,7 +15,7 @@ ENV GOARCH amd64
 ENV GOOS linux
 ENV CGO_ENABLED 1
 
-RUN apk add --no-cache go gcc g++
+RUN apk add --no-cache gcc g++
 
 COPY . /repo
 

--- a/cmd/symbols/Dockerfile
+++ b/cmd/symbols/Dockerfile
@@ -6,26 +6,26 @@ USER root
 COPY cmd/symbols/ctags-install-alpine.sh /ctags-install-alpine.sh
 RUN /ctags-install-alpine.sh
 
-FROM sourcegraph/alpine-3.14:142406_2022-04-14_8836ac3499f4@sha256:2a2d1cbaec78882661fe1aa5b0a4af0c23a37be2ea9ff8aadc2da5b80852c233 AS build
+FROM golang:1.18.1-alpine AS symbols-build
 # hadolint ignore=DL3002
 USER root
-
-ARG VERSION="unknown"
-ENV VERSION $VERSION
-
-ARG PKG
-ENV PKG=$PKG
 
 ENV GO111MODULE on
 ENV GOARCH amd64
 ENV GOOS linux
 ENV CGO_ENABLED 1
 
-RUN apk add go gcc g++
+RUN apk add --no-cache go gcc g++
 
 COPY . /repo
 
 WORKDIR /repo
+
+ARG VERSION="unknown"
+ENV VERSION $VERSION
+
+ARG PKG
+ENV PKG=$PKG
 
 RUN \
   --mount=type=cache,target=/root/.cache/go-build \
@@ -61,7 +61,7 @@ RUN apk add --no-cache bind-tools ca-certificates mailcap tini jansson libstdc++
 
 COPY --from=ctags /usr/local/bin/universal-ctags /usr/local/bin/universal-ctags
 
-COPY --from=build /symbols /usr/local/bin/symbols
+COPY --from=symbols-build /symbols /usr/local/bin/symbols
 
 # symbols is cgo, ensure we have the requisite dynamic libraries
 RUN env SANITY_CHECK=true /usr/local/bin/symbols
@@ -69,4 +69,4 @@ RUN env SANITY_CHECK=true /usr/local/bin/symbols
 ENV CACHE_DIR=/mnt/cache/symbols
 RUN mkdir -p ${CACHE_DIR}
 EXPOSE 3184
-ENTRYPOINT /sbin/tini -- /usr/local/bin/symbols
+ENTRYPOINT ["/sbin/tini", "--", "/usr/local/bin/symbols"]

--- a/cmd/symbols/build.sh
+++ b/cmd/symbols/build.sh
@@ -5,7 +5,7 @@
 cd "$(dirname "${BASH_SOURCE[0]}")/../.."
 set -eu
 
-echo "--- docker build"
+echo "--- docker build symbols"
 docker build -f cmd/symbols/Dockerfile -t "$IMAGE" "$(pwd)" \
   --progress=plain \
   --build-arg COMMIT_SHA \

--- a/cmd/symbols/go-build.sh
+++ b/cmd/symbols/go-build.sh
@@ -2,12 +2,25 @@
 
 # This script builds the symbols go binary.
 # Requires a single argument which is the path to the target bindir.
+#
+# To test you can run
+#
+#   VERSION=test ./cmd/symbols/go-build.sh /tmp
 
 cd "$(dirname "${BASH_SOURCE[0]}")/../.."
 set -eu
 
 OUTPUT="${1:?no output path provided}"
 
-cmd/symbols/build.sh
+echo "--- docker symbols build"
 
-docker cp "$(docker create --rm "$IMAGE")":/usr/local/bin/symbols "$OUTPUT/symbols"
+# Required due to use of RUN --mount=type=cache in Dockerfile.
+export DOCKER_BUILDKIT=1
+
+docker build -f cmd/symbols/Dockerfile -t symbols-build "$(pwd)" \
+  --target=symbols-build \
+  --progress=plain \
+  --build-arg VERSION \
+  --build-arg PKG="${PKG:-github.com/sourcegraph/sourcegraph/cmd/symbols}"
+
+docker cp "$(docker create --rm symbols-build)":/symbols "$OUTPUT/symbols"


### PR DESCRIPTION
Previously go-build.sh just built the full symbols docker image and then copied out the symbols binary. This did a lot of extra work, including building ctags. go-build.sh is called as part of building the server image, one of the slowest steps on the critical path in CI. It now just runs the build target in the Dockerfile.

There are multiple improvements to the Dockerfile. This change was motivated by switching to go1.18. Before this commit when using go1.18 the server build would fail in CI due to symbol's go-build.sh. I didn't fully root cause it, but I believe it had something to do with using alpine-3.14 as the builder image which included an older version of go.

This commits moves just symbols to use go1.18. Another commit will move everything else to go1.18.

These are the other improvements made in this commit:
- ARGs come last to prevent them invalidating caches.
- build target renamed to symbols-build to be more clear in CI.
- --no-cache used in apk add.
- ENTRYPOINT uses JSON args due to hadolint complaining.
- DOCKER_BUILDKIT=1 is set to simplify running locally.

Test Plan: main-dry-run on CI will exercise building the images and will run integration tests. To test locally I ran

```shell
VERSION=test PKG=github.com/sourcegraph/sourcegraph/enterprise/cmd/symbols ./cmd/symbols/go-build.sh /tmp
```