### PR TITLE
Search backend: Add trace tags to ComputeExcludedReposJob

### DIFF
--- a/internal/search/job/jobutil/job.go
+++ b/internal/search/job/jobutil/job.go
@@ -287,7 +287,7 @@ func ToSearchJob(searchInputs *run.SearchInputs, b query.Basic) (job.Job, error)
 	}
 
 	addJob(&searchrepos.ComputeExcludedReposJob{
-		Options: repoOptions,
+		RepoOpts: repoOptions,
 	})
 
 	job := NewParallelJob(allJobs...)

--- a/internal/search/job/jobutil/printers_test.go
+++ b/internal/search/job/jobutil/printers_test.go
@@ -260,7 +260,7 @@ func TestPrettyJSON(t *testing.T) {
     },
     {
       "ComputeExcludedReposJob": {
-        "Options": {
+        "RepoOpts": {
           "RepoFilters": [
             "foo"
           ],


### PR DESCRIPTION
Part of #34009

Rename field `Options` to `RepoOpts` (other jobs name this field either `RepoOpts` or `RepoOptions`, I chose `RepoOpts` for consistency with [CommitSearchJob](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/internal/search/commit/commit.go?L32) which is currently the only other job tracing this field).

Add field `RepoOpts` to the trace for `ComputeExcludedReposJob`.

## Test plan
New trace tags:

<img width="1289" alt="Screen Shot 2022-05-05 at 1 27 09 PM" src="https://user-images.githubusercontent.com/70350613/166992145-50724732-a919-49a7-94df-a9316ddbbee0.png">


