### PR TITLE
batches: remove redundant button

### DIFF
--- a/client/web/src/enterprise/batches/settings/AddCredentialModal.tsx
+++ b/client/web/src/enterprise/batches/settings/AddCredentialModal.tsx
@@ -246,18 +246,13 @@ export const AddCredentialModal: React.FunctionComponent<React.PropsWithChildren
                             key below and enter it on your code host.
                         </p>
                         <CodeHostSshPublicKey externalServiceKind={externalServiceKind} sshPublicKey={sshPublicKey!} />
-                        <div className="d-flex justify-content-end">
-                            <Button className="mr-2" onClick={afterCreate} outline={true} variant="secondary">
-                                Close
-                            </Button>
-                            <Button
-                                className="test-add-credential-modal-submit"
-                                onClick={afterCreate}
-                                variant="primary"
-                            >
-                                Add credential
-                            </Button>
-                        </div>
+                        <Button
+                            className="test-add-credential-modal-submit float-right"
+                            onClick={afterCreate}
+                            variant="primary"
+                        >
+                            Finish
+                        </Button>
                     </>
                 )}
             </div>


### PR DESCRIPTION
When looking at the code host credentials modal, I noticed we had a sort of redundant set of two buttons on the step of the modal where the SSH key is presented. This just de-dupes the button and gives it a more appropriate title.

![image](https://user-images.githubusercontent.com/8942601/167005724-e0b35296-4239-498f-9b90-e93ebd9eaea1.png)

## Test plan

This is primarily a visual change, since the `onClick` behavior is left alone. This modal is covered by Storybook stories.

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->



## App preview:

- [Web](https://sg-web-kr-why-have-2-buttons.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-mdxuatuivp.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
