### PR TITLE
Code monitors: fix repo-aware creation of code monitors

### DIFF
--- a/enterprise/internal/codemonitors/search.go
+++ b/enterprise/internal/codemonitors/search.go
@@ -200,7 +200,7 @@ func addCodeMonitorHook(in job.Job, hook commit.CodeMonitorHook) (_ job.Job, err
 			jobCopy := *typedAtom
 			jobCopy.CodeMonitorSearchWrapper = hook
 			return &jobCopy
-		case *repos.ComputeExcludedReposJob:
+		case *repos.ComputeExcludedReposJob, *jobutil.NoopJob:
 			// ComputeExcludedReposJob is fine for code monitor jobs
 			return atom
 		default:

--- a/internal/search/job/jobutil/alert.go
+++ b/internal/search/job/jobutil/alert.go
@@ -16,7 +16,7 @@ import (
 // NewAlertJob creates a job that translates errors from child jobs
 // into alerts when necessary.
 func NewAlertJob(inputs *run.SearchInputs, child job.Job) job.Job {
-	if _, ok := child.(*noopJob); ok {
+	if _, ok := child.(*NoopJob); ok {
 		return child
 	}
 	return &alertJob{

--- a/internal/search/job/jobutil/combinators.go
+++ b/internal/search/job/jobutil/combinators.go
@@ -17,7 +17,7 @@ import (
 // child job, it stops executing additional jobs and returns.
 func NewSequentialJob(children ...job.Job) job.Job {
 	if len(children) == 0 {
-		return &noopJob{}
+		return &NoopJob{}
 	}
 	if len(children) == 1 {
 		return children[0]
@@ -54,7 +54,7 @@ func (s *SequentialJob) Run(ctx context.Context, clients job.RuntimeClients, str
 // if any of the child jobs failed.
 func NewParallelJob(children ...job.Job) job.Job {
 	if len(children) == 0 {
-		return &noopJob{}
+		return &NoopJob{}
 	}
 	if len(children) == 1 {
 		return children[0]
@@ -92,7 +92,7 @@ func (p *ParallelJob) Run(ctx context.Context, clients job.RuntimeClients, s str
 // NewTimeoutJob creates a new job that is canceled after the
 // timeout is hit. The timer starts with `Run()` is called.
 func NewTimeoutJob(timeout time.Duration, child job.Job) job.Job {
-	if _, ok := child.(*noopJob); ok {
+	if _, ok := child.(*NoopJob); ok {
 		return child
 	}
 	return &TimeoutJob{
@@ -125,7 +125,7 @@ func (t *TimeoutJob) Name() string {
 // is incremented by the number of results in that event, and if it reaches
 // the limit, the context is canceled.
 func NewLimitJob(limit int, child job.Job) job.Job {
-	if _, ok := child.(*noopJob); ok {
+	if _, ok := child.(*NoopJob); ok {
 		return child
 	}
 	return &LimitJob{
@@ -159,14 +159,14 @@ func (l *LimitJob) Name() string {
 	return "LimitJob"
 }
 
-func NewNoopJob() *noopJob {
-	return &noopJob{}
+func NewNoopJob() *NoopJob {
+	return &NoopJob{}
 }
 
-type noopJob struct{}
+type NoopJob struct{}
 
-func (e *noopJob) Run(context.Context, job.RuntimeClients, streaming.Sender) (*search.Alert, error) {
+func (e *NoopJob) Run(context.Context, job.RuntimeClients, streaming.Sender) (*search.Alert, error) {
 	return nil, nil
 }
 
-func (e *noopJob) Name() string { return "NoopJob" }
+func (e *NoopJob) Name() string { return "NoopJob" }

--- a/internal/search/job/jobutil/job.go
+++ b/internal/search/job/jobutil/job.go
@@ -740,31 +740,31 @@ func optimizeJobs(baseJob job.Job, inputs *run.SearchInputs, q query.Basic) (job
 			switch currentJob.(type) {
 			case *zoekt.ZoektGlobalSearchJob:
 				if exists("ZoektGlobalSearchJob") {
-					return &noopJob{}
+					return &NoopJob{}
 				}
 				return currentJob
 
 			case *zoekt.ZoektRepoSubsetSearchJob:
 				if exists("ZoektRepoSubsetSearchJob") {
-					return &noopJob{}
+					return &NoopJob{}
 				}
 				return currentJob
 
 			case *zoekt.ZoektSymbolSearchJob:
 				if exists("ZoektSymbolSearchJob") {
-					return &noopJob{}
+					return &NoopJob{}
 				}
 				return currentJob
 
 			case *symbol.RepoUniverseSymbolSearchJob:
 				if exists("RepoUniverseSymbolSearchJob") {
-					return &noopJob{}
+					return &NoopJob{}
 				}
 				return currentJob
 
 			case *commit.CommitSearchJob:
 				if exists("CommitSearchJob") || exists("DiffSearchJob") {
-					return &noopJob{}
+					return &NoopJob{}
 				}
 				return currentJob
 

--- a/internal/search/job/jobutil/mapper.go
+++ b/internal/search/job/jobutil/mapper.go
@@ -206,7 +206,7 @@ func (m *Mapper) Map(j job.Job) job.Job {
 		}
 		return NewFilterJob(child)
 
-	case *noopJob:
+	case *NoopJob:
 		return j
 
 	default:
@@ -228,7 +228,7 @@ func MapAtom(j job.Job, f func(job.Job) job.Job) job.Job {
 				*commit.CommitSearchJob,
 				*symbol.RepoUniverseSymbolSearchJob,
 				*repos.ComputeExcludedReposJob,
-				*noopJob:
+				*NoopJob:
 				return f(typedJob)
 			default:
 				return currentJob

--- a/internal/search/job/jobutil/printers.go
+++ b/internal/search/job/jobutil/printers.go
@@ -51,7 +51,7 @@ func SexpFormat(j job.Job, sep, indent string) string {
 			*commit.CommitSearchJob,
 			*symbol.RepoUniverseSymbolSearchJob,
 			*repos.ComputeExcludedReposJob,
-			*noopJob:
+			*NoopJob:
 			b.WriteString(j.Name())
 
 		case *repoPagerJob:
@@ -211,7 +211,7 @@ func PrettyMermaid(j job.Job) string {
 			*commit.CommitSearchJob,
 			*symbol.RepoUniverseSymbolSearchJob,
 			*repos.ComputeExcludedReposJob,
-			*noopJob:
+			*NoopJob:
 			writeNode(b, depth, RoundedStyle, &id, j.Name())
 
 		case *repoPagerJob:
@@ -329,7 +329,7 @@ func toJSON(j job.Job, verbose bool) interface{} {
 			*commit.CommitSearchJob,
 			*symbol.RepoUniverseSymbolSearchJob,
 			*repos.ComputeExcludedReposJob,
-			*noopJob:
+			*NoopJob:
 			if verbose {
 				return map[string]interface{}{j.Name(): j}
 			}

--- a/internal/search/job/jobutil/types.go
+++ b/internal/search/job/jobutil/types.go
@@ -22,7 +22,7 @@ var allJobs = []job.Job{
 	&commit.CommitSearchJob{},
 	&symbol.RepoUniverseSymbolSearchJob{},
 	&repos.ComputeExcludedReposJob{},
-	&noopJob{},
+	&NoopJob{},
 
 	&repoPagerJob{},
 


### PR DESCRIPTION
With the new optimization passes, we'd fail to create new repo-aware code monitors because we'd have noop jobs in the job tree that were not explicitly allowed. This fixes that and adds a test that ensures that normal queries pass this validation step. 

## Test plan

Added a test. 

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


