### PR TITLE
codeintel: Fix index of a nil Lua table

### DIFF
--- a/internal/codeintel/autoindexing/internal/inference/lua/typescript.lua
+++ b/internal/codeintel/autoindexing/internal/inference/lua/typescript.lua
@@ -31,7 +31,7 @@ local can_derive_node_version = function(root, paths, contents_by_path)
 
     for i = 1, #ancestors do
         local payload = json.decode(contents_by_path[path.join(ancestors[i], "package.json")] or "")
-        if payload and payload["engines"]["node"] ~= "" then
+        if payload and payload["engines"] and payload["engines"]["node"] ~= "" then
             return true
         end
     end

--- a/internal/codeintel/autoindexing/internal/inference/lua/typescript.lua
+++ b/internal/codeintel/autoindexing/internal/inference/lua/typescript.lua
@@ -31,7 +31,7 @@ local can_derive_node_version = function(root, paths, contents_by_path)
 
     for i = 1, #ancestors do
         local payload = json.decode(contents_by_path[path.join(ancestors[i], "package.json")] or "")
-        if payload and payload["engines"] and payload["engines"]["node"] ~= "" then
+        if payload and payload["engines"] and payload["engines"]["node"] then
             return true
         end
     end


### PR DESCRIPTION
Fixes a Lua nil object index operation.

![image](https://user-images.githubusercontent.com/103087/167016033-dc215e96-c5e6-430f-8674-ad7ca90c4bfc.png)


## Test plan

Existing unit tests cover all other edge cases, this should be good.