### PR TITLE
dev/sg: do not fail on new 'log15.' reference

### DIFF
--- a/dev/sg/lints.go
+++ b/dev/sg/lints.go
@@ -163,9 +163,9 @@ func lintLoggingLibraries() lint.Runner {
 		bannedImports = []string{
 			// No standard log library
 			`"log"`,
-			// No log15
+			// No log15 - we only catch import changes for now, checking for 'log15.' is
+			// too sensitive to just code moves.
 			`"github.com/inconshreveable/log15"`,
-			`log15.`,
 			// No zap - we re-rexport everything via lib/log
 			`"go.uber.org/zap"`,
 			`"go.uber.org/zap/zapcore"`,


### PR DESCRIPTION
This is too sensitive to code moves right now like https://github.com/sourcegraph/sourcegraph/pull/34954/files#diff-25af0d5a05b8cfbaa77a680629d8e02b3d5f1ae6c8595c81448e8d97846718e3R120 . We could maybe deduplicate the added/removed diff if the line is the same after whitespace removal but for now we just loosen the check.

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

n/a
