### PR TITLE
Change ordering of access-token scopes (ergonomic)

### DIFF
--- a/doc/admin/external_service/github.md
+++ b/doc/admin/external_service/github.md
@@ -47,7 +47,7 @@ No [token scopes](https://docs.github.com/en/developers/apps/building-oauth-apps
 | [Sync private repositories](#private-repositories)    | `repo`                                                                                                         |
 | [Sync repository permissions][permissions]            | `repo`                                                                                                         |
 | [Repository permissions caching][permissions-caching] | `repo`, `write:org`                                                                                            |
-| [Batch changes][batch-changes]                        | `repo`, `read:org`, `user:email`, `read:discussion`, and `workflow` ([learn more][batch-changes-interactions]) |
+| [Batch changes][batch-changes]                        | `repo`, `workflow`, `read:org`, `user:email`, and `read:discussion` ([learn more][batch-changes-interactions]) |
 
 [permissions]: ../repo/permissions.md#github
 [permissions-caching]: ../repo/permissions.md#teams-and-organizations-permissions-caching


### PR DESCRIPTION
GitHub's access-token scope page lists `workflow` before `read:org`. This is just a slight ergonomics-motivated change.

## Test plan
No plan. Just wording for ergonomics.

The GitHub access token page, from 2022-05-05th:

![New-Personal-Access-Token](https://user-images.githubusercontent.com/7654435/167017910-0a36da9c-287a-4c20-b15d-3104b1410dd0.png)


<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


