### PR TITLE
dev/sg: fix repo state diff by comparing from merge base

### DIFF
--- a/dev/sg/internal/repo/repo.go
+++ b/dev/sg/internal/repo/repo.go
@@ -26,9 +26,9 @@ func (s *State) GetDiff(paths string) (map[string][]DiffHunk, error) {
 		paths = "**/*"
 	}
 
-	target := "origin/main"
+	target := "origin/main..." // compare from common ancestor
 	if s.Branch == "main" {
-		target = "@^"
+		target = "@^" // previous commit
 	}
 
 	diffOutput, err := run.TrimResult(run.GitCmd("diff", target, "--", paths))


### PR DESCRIPTION
Old implementation includes unmerged commits, this fixes.

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

Check out outdated branch and run `git diff origin/main... -- **/*.go`, should not see unexpected changes
