### PR TITLE
Code monitors: add transition step to switch over to repo-aware monitors

### DIFF
--- a/enterprise/internal/codemonitors/search.go
+++ b/enterprise/internal/codemonitors/search.go
@@ -128,6 +128,31 @@ func Search(ctx context.Context, db database.DB, query string, monitorID int64, 
 		hook := func(ctx context.Context, db database.DB, gs commit.GitserverClient, args *gitprotocol.SearchRequest, repoID api.RepoID, doSearch commit.DoSearchFunc) error {
 			return hookWithID(ctx, db, gs, monitorID, repoID, args, doSearch)
 		}
+		{
+			// This block is a transitional block that can be removed in a
+			// future version. We need this block to exist when we transition
+			// from timestamp-based code monitors to commit-hash-based
+			// (repo-aware) code monitors.
+			//
+			// When we flip the switch to repo-aware, all existing code
+			// monitors will start executing as repo-aware code monitors.
+			// Without this block, this  would mean all repos would be detected
+			// as "unsearched" and we would start searching from the beginning
+			// of the repo's history, flooding every code monitor user with a
+			// notification with many results.
+			//
+			// Instead, this detects if this monitor has ever been run as a
+			// repo-aware monitor before and snapshots the current state of the
+			// searched repos rather than searching them.
+			hasAnyLastSearched, err := edb.NewEnterpriseDB(db).CodeMonitors().HasAnyLastSearched(ctx, monitorID)
+			if err != nil {
+				return nil, err
+			} else if !hasAnyLastSearched {
+				hook = func(ctx context.Context, db database.DB, gs commit.GitserverClient, args *gitprotocol.SearchRequest, repoID api.RepoID, _ commit.DoSearchFunc) error {
+					return snapshotHook(ctx, db, gs, args, monitorID, repoID)
+				}
+			}
+		}
 		planJob, err = addCodeMonitorHook(planJob, hook)
 		if err != nil {
 			return nil, err
@@ -177,6 +202,7 @@ func Snapshot(ctx context.Context, db database.DB, query string, monitorID int64
 	hook := func(ctx context.Context, db database.DB, gs commit.GitserverClient, args *gitprotocol.SearchRequest, repoID api.RepoID, _ commit.DoSearchFunc) error {
 		return snapshotHook(ctx, db, gs, args, monitorID, repoID)
 	}
+
 	planJob, err = addCodeMonitorHook(planJob, hook)
 	if err != nil {
 		return err

--- a/enterprise/internal/database/code_monitor_last_searched.go
+++ b/enterprise/internal/database/code_monitor_last_searched.go
@@ -11,6 +11,18 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
+func (s *codeMonitorStore) HasAnyLastSearched(ctx context.Context, monitorID int64) (bool, error) {
+	rawQuery := `
+	SELECT COUNT(*) > 0
+	FROM cm_last_searched
+	WHERE monitor_id = %s
+	`
+
+	q := sqlf.Sprintf(rawQuery, monitorID)
+	var hasLastSearched bool
+	return hasLastSearched, s.QueryRow(ctx, q).Scan(&hasLastSearched)
+}
+
 func (s *codeMonitorStore) UpsertLastSearched(ctx context.Context, monitorID int64, repoID api.RepoID, commitOIDs []string) error {
 	rawQuery := `
 	INSERT INTO cm_last_searched (monitor_id, repo_id, commit_oids)

--- a/enterprise/internal/database/code_monitor_last_searched_test.go
+++ b/enterprise/internal/database/code_monitor_last_searched_test.go
@@ -81,3 +81,34 @@ func TestCodeMonitorStoreLastSearched(t *testing.T) {
 		require.Empty(t, lastSearched)
 	})
 }
+
+func TestCodeMonitorHasAnyLastSearched(t *testing.T) {
+	t.Parallel()
+
+	t.Run("has none", func(t *testing.T) {
+		t.Parallel()
+		ctx := context.Background()
+		db := NewEnterpriseDB(database.NewDB(dbtest.NewDB(t)))
+		fixtures := populateCodeMonitorFixtures(t, db)
+		cm := db.CodeMonitors()
+
+		hasLastSearched, err := cm.HasAnyLastSearched(ctx, fixtures.Monitor.ID)
+		require.NoError(t, err)
+		require.False(t, hasLastSearched)
+	})
+
+	t.Run("has some", func(t *testing.T) {
+		t.Parallel()
+		ctx := context.Background()
+		db := NewEnterpriseDB(database.NewDB(dbtest.NewDB(t)))
+		fixtures := populateCodeMonitorFixtures(t, db)
+		cm := db.CodeMonitors()
+
+		err := cm.UpsertLastSearched(ctx, fixtures.Monitor.ID, fixtures.Repo.ID, []string{"a", "b"})
+		require.NoError(t, err)
+
+		hasLastSearched, err := cm.HasAnyLastSearched(ctx, fixtures.Monitor.ID)
+		require.NoError(t, err)
+		require.True(t, hasLastSearched)
+	})
+}

--- a/enterprise/internal/database/code_monitors.go
+++ b/enterprise/internal/database/code_monitors.go
@@ -82,6 +82,11 @@ type CodeMonitorStore interface {
 	GetActionJob(ctx context.Context, jobID int32) (*ActionJob, error)
 	EnqueueActionJobsForMonitor(ctx context.Context, monitorID int64, triggerJob int32) ([]*ActionJob, error)
 
+	// HasAnyLastSearched returns whether there have ever been any repo-aware code monitor
+	// searches executed for this code monitor. This should only be needed during the transition
+	// version so that we don't detect every repo as a new repo and search their entire history
+	// when a code monitor transitions from non-repo-aware to repo-aware.
+	HasAnyLastSearched(ctx context.Context, monitorID int64) (bool, error)
 	UpsertLastSearched(ctx context.Context, monitorID int64, repoID api.RepoID, lastSearched []string) error
 	GetLastSearched(ctx context.Context, monitorID int64, repoID api.RepoID) ([]string, error)
 }

--- a/enterprise/internal/database/mocks.go
+++ b/enterprise/internal/database/mocks.go
@@ -129,6 +129,9 @@ type MockCodeMonitorStore struct {
 	// HandleFunc is an instance of a mock function object controlling the
 	// behavior of the method Handle.
 	HandleFunc *CodeMonitorStoreHandleFunc
+	// HasAnyLastSearchedFunc is an instance of a mock function object
+	// controlling the behavior of the method HasAnyLastSearched.
+	HasAnyLastSearchedFunc *CodeMonitorStoreHasAnyLastSearchedFunc
 	// ListActionJobsFunc is an instance of a mock function object
 	// controlling the behavior of the method ListActionJobs.
 	ListActionJobsFunc *CodeMonitorStoreListActionJobsFunc
@@ -363,6 +366,11 @@ func NewMockCodeMonitorStore() *MockCodeMonitorStore {
 		HandleFunc: &CodeMonitorStoreHandleFunc{
 			defaultHook: func() (r0 *basestore.TransactableHandle) {
 				return
+			},
+		},
+		HasAnyLastSearchedFunc: &CodeMonitorStoreHasAnyLastSearchedFunc{
+			defaultHook: func(context.Context, int64) (bool, error) {
+				return false, nil
 			},
 		},
 		ListActionJobsFunc: &CodeMonitorStoreListActionJobsFunc{
@@ -637,6 +645,11 @@ func NewStrictMockCodeMonitorStore() *MockCodeMonitorStore {
 				panic("unexpected invocation of MockCodeMonitorStore.Handle")
 			},
 		},
+		HasAnyLastSearchedFunc: &CodeMonitorStoreHasAnyLastSearchedFunc{
+			defaultHook: func(context.Context, int64) (bool, error) {
+				panic("unexpected invocation of MockCodeMonitorStore.HasAnyLastSearched")
+			},
+		},
 		ListActionJobsFunc: &CodeMonitorStoreListActionJobsFunc{
 			defaultHook: func(context.Context, ListActionJobsOpts) ([]*ActionJob, error) {
 				panic("unexpected invocation of MockCodeMonitorStore.ListActionJobs")
@@ -841,6 +854,9 @@ func NewMockCodeMonitorStoreFrom(i CodeMonitorStore) *MockCodeMonitorStore {
 		},
 		HandleFunc: &CodeMonitorStoreHandleFunc{
 			defaultHook: i.Handle,
+		},
+		HasAnyLastSearchedFunc: &CodeMonitorStoreHasAnyLastSearchedFunc{
+			defaultHook: i.HasAnyLastSearched,
 		},
 		ListActionJobsFunc: &CodeMonitorStoreListActionJobsFunc{
 			defaultHook: i.ListActionJobs,
@@ -4671,6 +4687,117 @@ func (c CodeMonitorStoreHandleFuncCall) Args() []interface{} {
 // invocation.
 func (c CodeMonitorStoreHandleFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
+}
+
+// CodeMonitorStoreHasAnyLastSearchedFunc describes the behavior when the
+// HasAnyLastSearched method of the parent MockCodeMonitorStore instance is
+// invoked.
+type CodeMonitorStoreHasAnyLastSearchedFunc struct {
+	defaultHook func(context.Context, int64) (bool, error)
+	hooks       []func(context.Context, int64) (bool, error)
+	history     []CodeMonitorStoreHasAnyLastSearchedFuncCall
+	mutex       sync.Mutex
+}
+
+// HasAnyLastSearched delegates to the next hook function in the queue and
+// stores the parameter and result values of this invocation.
+func (m *MockCodeMonitorStore) HasAnyLastSearched(v0 context.Context, v1 int64) (bool, error) {
+	r0, r1 := m.HasAnyLastSearchedFunc.nextHook()(v0, v1)
+	m.HasAnyLastSearchedFunc.appendCall(CodeMonitorStoreHasAnyLastSearchedFuncCall{v0, v1, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the HasAnyLastSearched
+// method of the parent MockCodeMonitorStore instance is invoked and the
+// hook queue is empty.
+func (f *CodeMonitorStoreHasAnyLastSearchedFunc) SetDefaultHook(hook func(context.Context, int64) (bool, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// HasAnyLastSearched method of the parent MockCodeMonitorStore instance
+// invokes the hook at the front of the queue and discards it. After the
+// queue is empty, the default hook function is invoked for any future
+// action.
+func (f *CodeMonitorStoreHasAnyLastSearchedFunc) PushHook(hook func(context.Context, int64) (bool, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *CodeMonitorStoreHasAnyLastSearchedFunc) SetDefaultReturn(r0 bool, r1 error) {
+	f.SetDefaultHook(func(context.Context, int64) (bool, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *CodeMonitorStoreHasAnyLastSearchedFunc) PushReturn(r0 bool, r1 error) {
+	f.PushHook(func(context.Context, int64) (bool, error) {
+		return r0, r1
+	})
+}
+
+func (f *CodeMonitorStoreHasAnyLastSearchedFunc) nextHook() func(context.Context, int64) (bool, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *CodeMonitorStoreHasAnyLastSearchedFunc) appendCall(r0 CodeMonitorStoreHasAnyLastSearchedFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of CodeMonitorStoreHasAnyLastSearchedFuncCall
+// objects describing the invocations of this function.
+func (f *CodeMonitorStoreHasAnyLastSearchedFunc) History() []CodeMonitorStoreHasAnyLastSearchedFuncCall {
+	f.mutex.Lock()
+	history := make([]CodeMonitorStoreHasAnyLastSearchedFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// CodeMonitorStoreHasAnyLastSearchedFuncCall is an object that describes an
+// invocation of method HasAnyLastSearched on an instance of
+// MockCodeMonitorStore.
+type CodeMonitorStoreHasAnyLastSearchedFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 int64
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 bool
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c CodeMonitorStoreHasAnyLastSearchedFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c CodeMonitorStoreHasAnyLastSearchedFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
 }
 
 // CodeMonitorStoreListActionJobsFunc describes the behavior when the

--- a/enterprise/internal/database/mocks.go
+++ b/enterprise/internal/database/mocks.go
@@ -369,8 +369,8 @@ func NewMockCodeMonitorStore() *MockCodeMonitorStore {
 			},
 		},
 		HasAnyLastSearchedFunc: &CodeMonitorStoreHasAnyLastSearchedFunc{
-			defaultHook: func(context.Context, int64) (bool, error) {
-				return false, nil
+			defaultHook: func(context.Context, int64) (r0 bool, r1 error) {
+				return
 			},
 		},
 		ListActionJobsFunc: &CodeMonitorStoreListActionJobsFunc{


### PR DESCRIPTION
This PR adds a transitional chunk of code that is required for migrating code monitors from timestamp-based to commit-hash-based.

Basically, if a user enables repo-aware monitors, that monitor doesn't have any "previously searched commits" set. This means that we will detect all the commits in every repository searched as new commits and search them from the beginning. This will mean that a user would get a spurious email when they switch to repo-aware monitors (not great).

This breaks up that issue by adding temporary chunk of code that says "if this code monitor has never been run as a repo-aware monitor before, snapshot the current state and use that for all future runs." 

This code will be deleted after a version cycle. 

Stacked on #35013

## Test plan

I manually tested that upgrading from a timestamp-based monitor to a repo-aware monitor does not trigger a new notification, and that the monitor starts at the correct place.

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


