### PR TITLE
bacthes: change r to repository for onquery or on repo error func

### DIFF
--- a/lib/batches/batch_spec.go
+++ b/lib/batches/batch_spec.go
@@ -200,7 +200,7 @@ func (on *OnQueryOrRepository) String() string {
 	if on.RepositoriesMatchingQuery != "" {
 		return on.RepositoriesMatchingQuery
 	} else if on.Repository != "" {
-		return "r:" + on.Repository
+		return "repository:" + on.Repository
 	}
 
 	return fmt.Sprintf("%v", *on)


### PR DESCRIPTION
as a result of [this issue](https://github.com/sourcegraph/src-cli/pull/736) created to change the error message that results from incorrect repository name feedback. This will first change this error:

![image](https://user-images.githubusercontent.com/67931373/167028265-90cd8bbf-f45b-47ef-9bd8-c540d5d9e26c.png)

to fully write out the word `repository` after the first 'resolving respositories' part of the error


## Test plan
 tested on local machine
<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


