### PR TITLE
codeintel: Add `-allow-dirty-instance` to codeintel-qa test

### DIFF
--- a/dev/codeintel-qa/cmd/query/main.go
+++ b/dev/codeintel-qa/cmd/query/main.go
@@ -18,6 +18,7 @@ var (
 	indexDir                    string
 	numConcurrentRequests       int
 	checkQueryResult            bool
+	allowDirtyInstance          bool
 	queryReferencesOfReferences bool
 	verbose                     bool
 
@@ -29,6 +30,7 @@ func init() {
 	flag.StringVar(&indexDir, "index-dir", "./testdata/indexes", "The location of the testdata directory")
 	flag.IntVar(&numConcurrentRequests, "num-concurrent-requests", 5, "The maximum number of concurrent requests")
 	flag.BoolVar(&checkQueryResult, "check-query-result", true, "Whether to confirm query results are correct")
+	flag.BoolVar(&allowDirtyInstance, "allow-dirty-instance", false, "Allow additional uploads on the test instance")
 	flag.BoolVar(&queryReferencesOfReferences, "query-references-of-references", false, "Whether to perform reference operations on test case references")
 	flag.BoolVar(&verbose, "verbose", false, "Print every request")
 }

--- a/dev/codeintel-qa/cmd/query/queries.go
+++ b/dev/codeintel-qa/cmd/query/queries.go
@@ -65,16 +65,13 @@ func makeTestFunc(name string, f testFunc, source Location, expectedLocations []
 				// us a superset of the expected output.
 
 				filteredLocations := locations[:0]
+			outer:
 				for _, location := range locations {
-					found := false
-					for _, l := range expectedLocations {
-						if l == location {
-							found = true
+					for _, expectedLocation := range expectedLocations {
+						if expectedLocation == location {
+							filteredLocations = append(filteredLocations, location)
+							continue outer
 						}
-					}
-
-					if found {
-						filteredLocations = append(filteredLocations, location)
 					}
 				}
 

--- a/dev/codeintel-qa/cmd/query/queries.go
+++ b/dev/codeintel-qa/cmd/query/queries.go
@@ -58,6 +58,29 @@ func makeTestFunc(name string, f testFunc, source Location, expectedLocations []
 		if checkQueryResult {
 			sortLocations(locations)
 
+			if allowDirtyInstance {
+				// We allow other upload records to exist on the instance, so we might have
+				// additional locations. Here, we trim down the set of returned locations
+				// to only include the expected values, and check only that the instance gave
+				// us a superset of the expected output.
+
+				filteredLocations := locations[:0]
+				for _, location := range locations {
+					found := false
+					for _, l := range expectedLocations {
+						if l == location {
+							found = true
+						}
+					}
+
+					if found {
+						filteredLocations = append(filteredLocations, location)
+					}
+				}
+
+				locations = filteredLocations
+			}
+
 			if diff := cmp.Diff(expectedLocations, locations); diff != "" {
 				collectRepositoryToResults := func(locations []Location) map[string]int {
 					repositoryToResults := map[string]int{}

--- a/dev/codeintel-qa/cmd/query/state.go
+++ b/dev/codeintel-qa/cmd/query/state.go
@@ -21,6 +21,16 @@ func checkInstanceState(ctx context.Context) error {
 }
 
 func instanceStateDiff(ctx context.Context) (string, error) {
+	commitsByRepo, err := internal.CommitsByRepo(indexDir)
+	if err != nil {
+		return "", err
+	}
+	expectedCommitsByRepo := map[string][]string{}
+	for repoName, commits := range commitsByRepo {
+		sort.Strings(commits)
+		expectedCommitsByRepo[internal.MakeTestRepoName(repoName)] = commits
+	}
+
 	uploadedCommitsByRepo, err := queryUploads(ctx)
 	if err != nil {
 		return "", err
@@ -28,16 +38,27 @@ func instanceStateDiff(ctx context.Context) (string, error) {
 	for _, commits := range uploadedCommitsByRepo {
 		sort.Strings(commits)
 	}
+	if allowDirtyInstance {
+		// We allow other upload records to exist on the instance, but we still
+		// need to ensure that the set of uploads we require for the tests remain
+		// accessible on the instance. Here, we remove references to uploads and
+		// commits that don't exist in our expected list, and check only that we
+		// have a superset of our expected state.
 
-	commitsByRepo, err := internal.CommitsByRepo(indexDir)
-	if err != nil {
-		return "", err
-	}
+		for repoName, commits := range uploadedCommitsByRepo {
+			if expectedCommits, ok := expectedCommitsByRepo[repoName]; !ok {
+				delete(uploadedCommitsByRepo, repoName)
+			} else {
+				filtered := commits[:0]
+				for _, commit := range commits {
+					if i := sort.SearchStrings(expectedCommits, commit); i < len(expectedCommits) && expectedCommits[i] == commit {
+						filtered = append(filtered, commit)
+					}
 
-	expectedCommitsByRepo := map[string][]string{}
-	for repoName, commits := range commitsByRepo {
-		sort.Strings(commits)
-		expectedCommitsByRepo[internal.MakeTestRepoName(repoName)] = commits
+					uploadedCommitsByRepo[repoName] = filtered
+				}
+			}
+		}
 	}
 
 	return cmp.Diff(expectedCommitsByRepo, uploadedCommitsByRepo), nil


### PR DESCRIPTION
Add a flag that should (in theory...) allow us to accept additional uploads on an instance under test. This may not hold for all valid conditions of an instance, but should be a good start to help us track down those rough edges.

## Test plan

![image](https://user-images.githubusercontent.com/103087/167030267-5b1c46fd-3cb3-4f2f-b480-90815f5aa05c.png)