### PR TITLE
extsvc/github: delete mock function

### DIFF
--- a/internal/extsvc/github/common.go
+++ b/internal/extsvc/github/common.go
@@ -1734,9 +1734,6 @@ type Repository struct {
 	Visibility Visibility `json:",omitempty"`
 }
 
-// GetRepositoryMock is set by tests to mock (*Client).GetRepository.
-var GetRepositoryMock func(ctx context.Context, owner, name string) (*Repository, error)
-
 type restRepositoryPermissions struct {
 	Admin bool `json:"admin"`
 	Push  bool `json:"push"`


### PR DESCRIPTION
This was left over from previous cleanup/migration efforts in https://github.com/sourcegraph/sourcegraph/pull/34985

## Test plan

A green PR on this will suffice, as this is no longer called anywhere

