### PR TITLE
Add gclid to allow list of marketing parameters

### DIFF
--- a/internal/usagestats/event_handlers.go
+++ b/internal/usagestats/event_handlers.go
@@ -258,6 +258,7 @@ func redactSensitiveInfoFromCloudURL(rawURL string) (string, error) {
 		"campaign_id":  {},
 		"ad_id":        {},
 		"offer":        {},
+		"gclid":		{},
 	}
 	urlQueryParams, err := url.ParseQuery(parsedURL.RawQuery)
 	if err != nil {

--- a/internal/usagestats/event_handlers.go
+++ b/internal/usagestats/event_handlers.go
@@ -258,7 +258,7 @@ func redactSensitiveInfoFromCloudURL(rawURL string) (string, error) {
 		"campaign_id":  {},
 		"ad_id":        {},
 		"offer":        {},
-		"gclid":		{},
+		"gclid":        {},
 	}
 	urlQueryParams, err := url.ParseQuery(parsedURL.RawQuery)
 	if err != nil {


### PR DESCRIPTION

## Test plan

Based on the current URLs, I found multiple page view events where the gclid is redacted.  By adding the gclid to the list, we will start sending through this id as desired.  Followed up with the marketing ops team that this is always an id sent from google on click and will never contain anything that needs to be redacted.

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


