### PR TITLE
Search backend: Add trace tags to RepoSearchJob

### DIFF
--- a/internal/search/job/jobutil/job.go
+++ b/internal/search/job/jobutil/job.go
@@ -275,7 +275,7 @@ func ToSearchJob(searchInputs *run.SearchInputs, b query.Basic) (job.Job, error)
 						mode = search.SkipUnindexed
 					}
 					addJob(&run.RepoSearchJob{
-						RepoOptions:                  repoOptions,
+						RepoOpts:                     repoOptions,
 						Features:                     features,
 						FilePatternsReposMustInclude: patternInfo.FilePatternsReposMustInclude,
 						FilePatternsReposMustExclude: patternInfo.FilePatternsReposMustExclude,

--- a/internal/search/job/jobutil/printers_test.go
+++ b/internal/search/job/jobutil/printers_test.go
@@ -230,7 +230,7 @@ func TestPrettyJSON(t *testing.T) {
     },
     {
       "RepoSearchJob": {
-        "RepoOptions": {
+        "RepoOpts": {
           "RepoFilters": [
             "foo",
             "bar"


### PR DESCRIPTION
Part of #34009 

Adds `RepoSearchJob` struct fields to its trace.

## Test plan
Verified new trace is as expected:

<img width="1235" alt="Screen Shot 2022-05-05 at 7 59 29 PM" src="https://user-images.githubusercontent.com/70350613/167050030-1b2e4f48-7402-4a72-aa18-3f92ab061696.png">


