### PR TITLE
dev/okay: add metrics constructors, make UniqueKeys and Properties required

### DIFF
--- a/dev/okay/event.go
+++ b/dev/okay/event.go
@@ -50,19 +50,17 @@ type Event struct {
 	// Sending another event with the same UniqueKey results in overwritting the previous event,
 	// enabling to replay events with historical data or to correct incorrect events that were previously sent.
 	UniqueKey []string
+	// Properties are a map of additonal metadata to enable filtering and grouping metrics.
+	// Property names cannot have ".", please use "_" instead.
+	Properties map[string]string
 
 	// Optional fields below
 
-	// Properties are a map of additonal metadata to enable filtering and grouping metrics
-	// (optional).
-	//
-	// Property names cannot have ".", please use "_" instead.
-	Properties map[string]string
 	// GitHub login this event is attached to (optional).
-	GitHubLogin string
+	GitHubLogin string `json:",omitempty"`
 	// OkayURL is used to generate a clickable link in OkayHQ's UI when browsing this
 	// event (optional).
 	//
 	// Usually a link to get more information about the event from the system that generated it.
-	OkayURL string
+	OkayURL string `json:",omitempty"`
 }

--- a/dev/okay/event.go
+++ b/dev/okay/event.go
@@ -1,0 +1,68 @@
+package okay
+
+import "time"
+
+// customEvent represents a custom event sent to the OkayHQ API.
+type customEvent struct {
+	// Event is the event type, should be always set to "custom".
+	Event string `json:"event"`
+	// Name is the custom event name, used to select those events amonst others to build dashboards.
+	Name string `json:"customEventName"`
+	// Timestamp is the time at which this event occured.
+	Timestamp time.Time `json:"timestamp"`
+	// Identity ties this specific event to a particular user, enabling to filter events on various group predicates
+	// such as teams, organizations, etc ... (optional).
+	Identity *eventIdentity `json:"identity,omitempty"`
+	// UniqueKey lists the property keys that are used to uniquely identify this event.
+	//
+	// Sending another event with the same UniqueKey results in overwritting the previous event,
+	// enabling to replay events with historical data or to correct incorrect events that were previously sent.
+	UniqueKey []string `json:"uniqueKey,omitempty"`
+	// Metrics are a map of okayMetric whose keys are the metric name.
+	Metrics map[string]Metric `json:"metrics"`
+	// Properties are a map of additonal metadata (optional).
+	Properties map[string]string `json:"properties,omitempty"`
+	// Labels are a list of strings used to tag the event.
+	Labels []string `json:"labels,omitempty"`
+}
+
+// eventIdentity represents the identity to attach to an event.
+type eventIdentity struct {
+	// Type represents from where this identity is registered, should always be "sourceControlLogin".
+	Type string `json:"type"`
+	// User is the unique identifier to reference this identity amongst its Type.
+	User string `json:"user"`
+}
+
+// Event represents a custom Event to be sent to OkayHQ.
+type Event struct {
+	// Name is the custom event name, used to select those events amonst others to build dashboards.
+	Name string
+	// Timestamp is the time at which this event occured.
+	Timestamp time.Time
+	// Metrics are a map of okayMetric whose keys are the metric name.
+	Metrics map[string]Metric
+	// Labels are used to enable advanced filtering and group bys.
+	Labels []string
+	// UniqueKey lists the property keys that are used to uniquely identify this event.
+	// This will allow versioning and replaying events to correct errors or add new metadata.
+	//
+	// Sending another event with the same UniqueKey results in overwritting the previous event,
+	// enabling to replay events with historical data or to correct incorrect events that were previously sent.
+	UniqueKey []string
+
+	// Optional fields below
+
+	// Properties are a map of additonal metadata to enable filtering and grouping metrics
+	// (optional).
+	//
+	// Property names cannot have ".", please use "_" instead.
+	Properties map[string]string
+	// GitHub login this event is attached to (optional).
+	GitHubLogin string
+	// OkayURL is used to generate a clickable link in OkayHQ's UI when browsing this
+	// event (optional).
+	//
+	// Usually a link to get more information about the event from the system that generated it.
+	OkayURL string
+}

--- a/dev/okay/metric.go
+++ b/dev/okay/metric.go
@@ -1,6 +1,9 @@
 package okay
 
-import "time"
+import (
+	"fmt"
+	"time"
+)
 
 // Metric represents a particular metric attached to an event.
 type Metric struct {
@@ -20,4 +23,17 @@ func Duration(duration time.Duration) Metric {
 
 func Number(number int) Metric {
 	return Metric{Type: "number", Value: float64(number)}
+}
+
+func (m *Metric) String() string {
+	if m == nil {
+		return "<nil>"
+	}
+	switch m.Type {
+	case "count", "number":
+		return fmt.Sprintf("%+v", m.Value)
+	case "durationMs":
+		return time.Duration(int64(m.Value)).String()
+	}
+	return "invalid"
 }

--- a/dev/okay/metric.go
+++ b/dev/okay/metric.go
@@ -25,7 +25,7 @@ func Number(number int) Metric {
 	return Metric{Type: "number", Value: float64(number)}
 }
 
-func (m *Metric) String() string {
+func (m *Metric) ValueString() string {
 	if m == nil {
 		return "<nil>"
 	}
@@ -35,5 +35,5 @@ func (m *Metric) String() string {
 	case "durationMs":
 		return time.Duration(int64(m.Value)).String()
 	}
-	return "invalid"
+	return fmt.Sprintf("invalid type %q", m.Type)
 }

--- a/dev/okay/metric.go
+++ b/dev/okay/metric.go
@@ -1,0 +1,23 @@
+package okay
+
+import "time"
+
+// Metric represents a particular metric attached to an event.
+type Metric struct {
+	// Type is either "count", "durationMs" or "number".
+	Type string `json:"type"`
+	// Value is the actual value reported for this metric in a given event.
+	Value float64 `json:"value"`
+}
+
+func Count(value int) Metric {
+	return Metric{Type: "count", Value: float64(value)}
+}
+
+func Duration(duration time.Duration) Metric {
+	return Metric{Type: "durationMs", Value: float64(duration.Milliseconds())}
+}
+
+func Number(number int) Metric {
+	return Metric{Type: "number", Value: float64(number)}
+}

--- a/dev/okay/okay.go
+++ b/dev/okay/okay.go
@@ -11,76 +11,12 @@ import (
 	"io"
 	"net/http"
 	"sync"
-	"time"
 
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 	"github.com/sourcegraph/sourcegraph/lib/log"
 )
 
 var okayhqAPIEndpoint = "https://app.okayhq.com/api/events/v1"
-
-// Metric represents a particular metric attached to an event.
-type Metric struct {
-	// Type is either "count", "durationMs" or "number".
-	Type string `json:"type"`
-	// Value is the actual value reported for this metric in a given event.
-	Value float64 `json:"value"`
-}
-
-// customEvent represents a custom event sent to the OkayHQ API.
-type customEvent struct {
-	// Event is the event type, should be always set to "custom".
-	Event string `json:"event"`
-	// Name is the custom event name, used to select those events amonst others to build dashboards.
-	Name string `json:"customEventName"`
-	// Timestamp is the time at which this event occured.
-	Timestamp time.Time `json:"timestamp"`
-	// Identity ties this specific event to a particular user, enabling to filter events on various group predicates
-	// such as teams, organizations, etc ... (optional).
-	Identity *eventIdentity `json:"identity,omitempty"`
-	// UniqueKey lists the property keys that are used to uniquely identify this event (optional).
-	//
-	// Sending another event with the same UniqueKey results in overwritting the previous event,
-	// enabling to replay events with historical data or to correct incorrect events that were previously sent.
-	UniqueKey []string `json:"uniqueKey,omitempty"`
-	// Metrics are a map of okayMetric whose keys are the metric name.
-	Metrics map[string]Metric `json:"metrics"`
-	// Properties are a map of additonal metadata (optional).
-	Properties map[string]string `json:"properties,omitempty"`
-	// Labels are a list of strings used to tag the event.
-	Labels []string `json:"labels,omitempty"`
-}
-
-// eventIdentity represents the identity to attach to an event.
-type eventIdentity struct {
-	// Type represents from where this identity is registered, should always be "sourceControlLogin".
-	Type string `json:"type"`
-	// User is the unique identifier to reference this identity amongst its Type.
-	User string `json:"user"`
-}
-
-// Event represents a custom Event to be sent to OkayHQ.
-type Event struct {
-	// Name is the custom event name, used to select those events amonst others to build dashboards.
-	Name string
-	// Timestamp is the time at which this event occured.
-	Timestamp time.Time
-	// OkayURL is used to generate a clickable link in OkayHQ's UI when browsing this event.
-	OkayURL string
-	// GitHub login this event is attached to (optional).
-	GitHubLogin string
-	// UniqueKey lists the property keys that are used to uniquely identify this event (optional).
-	//
-	// Sending another event with the same UniqueKey results in overwritting the previous event,
-	// enabling to replay events with historical data or to correct incorrect events that were previously sent.
-	UniqueKey []string
-	// Properties are a map of additonal metadata (optional).
-	Properties map[string]string
-	// Metrics are a map of okayMetric whose keys are the metric name.
-	Metrics map[string]Metric
-	// Labels are a list of strings used to tag the event.
-	Labels []string
-}
 
 // Client collects and submit metrics to the OkayHQ custom events API and is safe to use
 // concurrently.
@@ -161,6 +97,9 @@ func (c *Client) Push(event *Event) error {
 	}
 	if len(event.Metrics) == 0 {
 		return errors.New("okayhq: event must have metrics")
+	}
+	if len(event.UniqueKey) == 0 {
+		return errors.New("okayhq: event must have unqiue property keys")
 	}
 	for _, k := range event.UniqueKey {
 		if _, ok := event.Properties[k]; !ok {

--- a/dev/okay/okay_test.go
+++ b/dev/okay/okay_test.go
@@ -9,9 +9,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/sourcegraph/sourcegraph/dev/okay"
 	"github.com/sourcegraph/sourcegraph/lib/log/logtest"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestMain(m *testing.M) {


### PR DESCRIPTION
1. Split into multiple files for readability
2. Add constructors for metric types
3. `UniqueKeys` is actually documented as required in the API docs: https://app.okayhq.com/help/_api/events#flexible-custom-events

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


n/a