### PR TITLE
dev/sg: track local sg analytics that can be submitted manually

### DIFF
--- a/dev/sg/analytics.go
+++ b/dev/sg/analytics.go
@@ -59,8 +59,7 @@ func addAnalyticsHooks(start time.Time, commandPath []string, commands []*cli.Co
 func makeAnalyticsHook(start time.Time, commandPath []string) func(*cli.Context, ...string) {
 	return func(cmd *cli.Context, events ...string) {
 		// Log an sg usage occurrence
-		totalDuration := time.Since(start)
-		analytics.LogEvent(cmd.Context, "sg_action", commandPath, totalDuration, events...)
+		analytics.LogEvent(cmd.Context, "sg_action", commandPath, start, events...)
 
 		// Persist all tracked to disk
 		flagsUsed := cmd.FlagNames()

--- a/dev/sg/analytics.go
+++ b/dev/sg/analytics.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/urfave/cli/v2"
+
+	"github.com/sourcegraph/sourcegraph/dev/sg/internal/analytics"
+)
+
+func addAnalyticsHooks(start time.Time, commandPath []string, commands []*cli.Command) {
+	if len(commands) == 0 {
+		return
+	}
+	for _, command := range commands {
+		if len(command.Subcommands) > 0 {
+			addAnalyticsHooks(start, append(commandPath, command.Name), command.Subcommands)
+			continue
+		}
+
+		analyticsHook := makeAnalyticsHook(start, append(commandPath, command.Name))
+
+		// This command has no subcommands, so we add analytics hook to indicate it has
+		// been used.
+		command.After = analyticsHook
+
+		// Make sure analytics hook is called even on interrupts. Note that this only
+		// works if you 'go build' sg, not if you 'go run'.
+		var wrappedBeforeHook cli.BeforeFunc
+		if command.Before == nil {
+			wrappedBeforeHook = command.Before
+		}
+		command.Before = func(cmd *cli.Context) error {
+			c := make(chan os.Signal, 1)
+			signal.Notify(c, os.Interrupt, syscall.SIGTERM)
+			go func() {
+				<-c
+				analyticsHook(cmd)
+				os.Exit(1)
+			}()
+
+			if wrappedBeforeHook != nil {
+				return wrappedBeforeHook(cmd)
+			}
+			return nil
+		}
+	}
+}
+
+func makeAnalyticsHook(start time.Time, commandPath []string) func(cmd *cli.Context) error {
+	return func(cmd *cli.Context) error {
+		// Log an sg usage occurrence
+		totalDuration := time.Since(start)
+		analytics.LogDuration(cmd.Context, "sg_action", commandPath, totalDuration)
+
+		// Persist all tracked to disk
+		flagsUsed := cmd.FlagNames()
+		if err := analytics.Persist(cmd.Context, strings.Join(commandPath, " "), flagsUsed); err != nil {
+			writeSkippedLinef("failed to persist events: %s", err)
+		}
+
+		return nil
+	}
+}

--- a/dev/sg/internal/analytics/actions.go
+++ b/dev/sg/internal/analytics/actions.go
@@ -1,0 +1,81 @@
+package analytics
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"net/http"
+	"os"
+
+	"github.com/sourcegraph/sourcegraph/dev/okay"
+)
+
+// Submit pushes all persisted events to OkayHQ.
+func Submit(okayToken string, gitHubLogin string) error {
+	events, err := Load()
+	if err != nil {
+		return err
+	}
+
+	client := okay.NewClient(http.DefaultClient, okayToken)
+	for _, ev := range events {
+		// clean up data
+		ev.Labels = append(ev.Labels, "sg-analytics")
+		for k, v := range ev.Properties {
+			if len(v) == 0 {
+				delete(ev.Properties, k)
+			}
+		}
+
+		// push to okayhq
+		if err := client.Push(ev); err != nil {
+			return err
+		}
+	}
+
+	return client.Flush()
+}
+
+// Persist stores all events in context to disk.
+func Persist(ctx context.Context, command string, flags []string) error {
+	store, ok := ctx.Value(analyticsStoreKey{}).(*eventStore)
+	if !ok {
+		return nil
+	}
+	return store.Persist(command, flags)
+}
+
+// Reset deletes all persisted events.
+func Reset() error {
+	p, err := eventsPath()
+	if err != nil {
+		return err
+	}
+	return os.Remove(p)
+}
+
+// Load retrieves all persisted events.
+func Load() ([]*okay.Event, error) {
+	p, err := eventsPath()
+	if err != nil {
+		return nil, err
+	}
+
+	file, err := os.Open(p)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	var events []*okay.Event
+	for scanner.Scan() {
+		// Don't worry too much about malformed events, analytics are relatively optional
+		// so just grab what we can.
+		var event okay.Event
+		if err := json.Unmarshal(scanner.Bytes(), &event); err == nil {
+			events = append(events, &event)
+		}
+	}
+	return events, nil
+}

--- a/dev/sg/internal/analytics/actions.go
+++ b/dev/sg/internal/analytics/actions.go
@@ -19,6 +19,12 @@ func Submit(okayToken string, gitHubLogin string) error {
 
 	client := okay.NewClient(http.DefaultClient, okayToken)
 	for _, ev := range events {
+		// discard everything but the latest version of events. if event versions are
+		// migrate-able, do the migrations here.
+		if ev.Properties["event_version"] != eventVersion {
+			continue
+		}
+
 		// clean up data
 		ev.Labels = append(ev.Labels, "sg-analytics")
 		for k, v := range ev.Properties {

--- a/dev/sg/internal/analytics/actions.go
+++ b/dev/sg/internal/analytics/actions.go
@@ -44,8 +44,8 @@ func Submit(okayToken string, gitHubLogin string) error {
 
 // Persist stores all events in context to disk.
 func Persist(ctx context.Context, command string, flags []string) error {
-	store, ok := ctx.Value(analyticsStoreKey{}).(*eventStore)
-	if !ok {
+	store := getStore(ctx)
+	if store == nil {
 		return nil
 	}
 	return store.Persist(command, flags)

--- a/dev/sg/internal/analytics/context.go
+++ b/dev/sg/internal/analytics/context.go
@@ -9,14 +9,24 @@ import (
 	"github.com/sourcegraph/sourcegraph/dev/okay"
 )
 
-type analyticsStoreKey struct{}
+type eventStoreKey struct{}
 
 // WithContext enables analytics in this context.
 func WithContext(ctx context.Context, sgVersion string) context.Context {
-	return context.WithValue(ctx, analyticsStoreKey{}, &eventStore{
+	return context.WithValue(ctx, eventStoreKey{}, &eventStore{
 		sgVersion: sgVersion,
 		events:    make([]*okay.Event, 0, 10),
 	})
+}
+
+// getStore retrieves the events store from context if it exists. Callers should check
+// that the store is non-nil before attempting to use it.
+func getStore(ctx context.Context) *eventStore {
+	store, ok := ctx.Value(eventStoreKey{}).(*eventStore)
+	if !ok {
+		return nil
+	}
+	return store
 }
 
 // LogEvent tracks an event in the per-run analytics store, if analytics are enabled,
@@ -25,8 +35,8 @@ func WithContext(ctx context.Context, sgVersion string) context.Context {
 // Events can also be provided to indicate that something happened - for example, and
 // error or cancellation. These are treated as metrics with a count of 1.
 func LogEvent(ctx context.Context, name string, labels []string, startedAt time.Time, events ...string) {
-	store, ok := ctx.Value(analyticsStoreKey{}).(*eventStore)
-	if !ok {
+	store := getStore(ctx)
+	if store == nil {
 		return
 	}
 

--- a/dev/sg/internal/analytics/context.go
+++ b/dev/sg/internal/analytics/context.go
@@ -1,0 +1,35 @@
+package analytics
+
+import (
+	"context"
+	"time"
+
+	"github.com/sourcegraph/sourcegraph/dev/okay"
+)
+
+type analyticsStoreKey struct{}
+
+// WithContext enables analytics in this context.
+func WithContext(ctx context.Context, sgVersion string) context.Context {
+	return context.WithValue(ctx, analyticsStoreKey{}, &eventStore{
+		sgVersion: sgVersion,
+		events:    make([]*okay.Event, 0, 10),
+	})
+}
+
+// LogDuration tracks an event in the per-run analytics store, if analytics are enabled,
+// in the context of a command.
+func LogDuration(ctx context.Context, name string, labels []string, duration time.Duration) {
+	store, ok := ctx.Value(analyticsStoreKey{}).(*eventStore)
+	if !ok {
+		return
+	}
+	store.events = append(store.events, &okay.Event{
+		Name:      name,
+		Labels:    labels,
+		Timestamp: time.Now().Add(-duration), // Timestamp as start of event
+		Metrics: map[string]okay.Metric{
+			"duration": okay.Duration(duration),
+		},
+	})
+}

--- a/dev/sg/internal/analytics/context.go
+++ b/dev/sg/internal/analytics/context.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"time"
 
+	"github.com/google/uuid"
+
 	"github.com/sourcegraph/sourcegraph/dev/okay"
 )
 
@@ -30,6 +32,10 @@ func LogDuration(ctx context.Context, name string, labels []string, duration tim
 		Timestamp: time.Now().Add(-duration), // Timestamp as start of event
 		Metrics: map[string]okay.Metric{
 			"duration": okay.Duration(duration),
+		},
+		UniqueKey: []string{"event_id"},
+		Properties: map[string]string{
+			"event_id": uuid.NewString(),
 		},
 	})
 }

--- a/dev/sg/internal/analytics/context.go
+++ b/dev/sg/internal/analytics/context.go
@@ -24,14 +24,14 @@ func WithContext(ctx context.Context, sgVersion string) context.Context {
 //
 // Events can also be provided to indicate that something happened - for example, and
 // error or cancellation. These are treated as metrics with a count of 1.
-func LogEvent(ctx context.Context, name string, labels []string, duration time.Duration, events ...string) {
+func LogEvent(ctx context.Context, name string, labels []string, startedAt time.Time, events ...string) {
 	store, ok := ctx.Value(analyticsStoreKey{}).(*eventStore)
 	if !ok {
 		return
 	}
 
 	metrics := map[string]okay.Metric{
-		"duration": okay.Duration(duration),
+		"duration": okay.Duration(time.Since(startedAt)),
 	}
 	for _, event := range events {
 		metrics[event] = okay.Count(1)
@@ -40,7 +40,7 @@ func LogEvent(ctx context.Context, name string, labels []string, duration time.D
 	store.events = append(store.events, &okay.Event{
 		Name:      name,
 		Labels:    labels,
-		Timestamp: time.Now().Add(-duration), // Timestamp as start of event
+		Timestamp: startedAt, // Timestamp as start of event
 		Metrics:   metrics,
 		UniqueKey: []string{"event_id"},
 		Properties: map[string]string{

--- a/dev/sg/internal/analytics/events.go
+++ b/dev/sg/internal/analytics/events.go
@@ -1,0 +1,76 @@
+package analytics
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/google/uuid"
+
+	"github.com/sourcegraph/sourcegraph/dev/okay"
+	"github.com/sourcegraph/sourcegraph/dev/sg/root"
+)
+
+// eventStore tracks events for a single sg command run.
+type eventStore struct {
+	sgVersion string
+	events    []*okay.Event
+}
+
+func (s *eventStore) Persist(command string, flags []string) error {
+	// Finalize events
+	for _, ev := range s.events {
+		ev.UniqueKey = append(ev.UniqueKey,
+			"context",
+			"command",
+			"event_name",
+			"event_id")
+		ev.Properties = map[string]string{
+			// Unique keys
+			"context":    "sg",
+			"command":    command,
+			"event_name": ev.Name,
+			"event_id":   uuid.NewString(),
+
+			// Context
+			"sg_version": s.sgVersion,
+			"flags_used": strings.Join(flags, ","),
+		}
+	}
+	// Persist events to disk
+	return storeEvents(s.events)
+}
+
+func eventsPath() (string, error) {
+	home, err := root.GetSGHomePath()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, "events"), nil
+}
+
+func storeEvents(events []*okay.Event) error {
+	p, err := eventsPath()
+	if err != nil {
+		return err
+	}
+
+	// If the file doesn't exist, create it, or append to the file
+	f, err := os.OpenFile(p, os.O_APPEND|os.O_CREATE|os.O_WRONLY, os.ModePerm)
+	if err != nil {
+		return err
+	}
+
+	// Generate newline-separated representation of events
+	for _, ev := range events {
+		b, err := json.Marshal(ev)
+		if err != nil {
+			return err
+		}
+		f.Write(b)
+		f.WriteString("\n")
+	}
+
+	return nil
+}

--- a/dev/sg/internal/run/run.go
+++ b/dev/sg/internal/run/run.go
@@ -128,7 +128,7 @@ func waitForInstallation(ctx context.Context, cmdNames map[string]struct{}, inst
 
 			delete(cmdNames, cmdName)
 			done += 1.0
-			analytics.LogDuration(ctx, "install_command", []string{cmdName}, time.Since(installationStart))
+			analytics.LogEvent(ctx, "install_command", []string{cmdName}, time.Since(installationStart), "succeeded")
 
 			progress.WriteLine(output.Linef("", output.StyleSuccess, "%s installed", cmdName))
 
@@ -149,6 +149,7 @@ func waitForInstallation(ctx context.Context, cmdNames map[string]struct{}, inst
 
 		case failure := <-failures:
 			progress.Destroy()
+			analytics.LogEvent(ctx, "install_command", []string{failure.cmdName}, time.Since(installationStart), "failed")
 
 			// Something went wrong with an installation, no need to wait for the others
 			printCmdError(stdout.Out, failure.cmdName, failure.err)

--- a/dev/sg/internal/run/run.go
+++ b/dev/sg/internal/run/run.go
@@ -128,7 +128,7 @@ func waitForInstallation(ctx context.Context, cmdNames map[string]struct{}, inst
 
 			delete(cmdNames, cmdName)
 			done += 1.0
-			analytics.LogEvent(ctx, "install_command", []string{cmdName}, time.Since(installationStart), "succeeded")
+			analytics.LogEvent(ctx, "install_command", []string{cmdName}, installationStart, "succeeded")
 
 			progress.WriteLine(output.Linef("", output.StyleSuccess, "%s installed", cmdName))
 
@@ -149,7 +149,7 @@ func waitForInstallation(ctx context.Context, cmdNames map[string]struct{}, inst
 
 		case failure := <-failures:
 			progress.Destroy()
-			analytics.LogEvent(ctx, "install_command", []string{failure.cmdName}, time.Since(installationStart), "failed")
+			analytics.LogEvent(ctx, "install_command", []string{failure.cmdName}, installationStart, "failed")
 
 			// Something went wrong with an installation, no need to wait for the others
 			printCmdError(stdout.Out, failure.cmdName, failure.err)

--- a/dev/sg/internal/run/run.go
+++ b/dev/sg/internal/run/run.go
@@ -15,6 +15,7 @@ import (
 	"github.com/grafana/regexp"
 	"github.com/rjeczalik/notify"
 
+	"github.com/sourcegraph/sourcegraph/dev/sg/internal/analytics"
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/stdout"
 	"github.com/sourcegraph/sourcegraph/dev/sg/root"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
@@ -76,7 +77,7 @@ func Commands(ctx context.Context, parentEnv map[string]string, verbose bool, cm
 		}(cmd, chs[i])
 	}
 
-	err = waitForInstallation(cmdNames, installed, failures, okayToStart)
+	err = waitForInstallation(ctx, cmdNames, installed, failures, okayToStart)
 	if err != nil {
 		return err
 	}
@@ -92,7 +93,9 @@ func Commands(ctx context.Context, parentEnv map[string]string, verbose bool, cm
 	}
 }
 
-func waitForInstallation(cmdNames map[string]struct{}, installed chan string, failures chan failedRun, okayToStart chan struct{}) error {
+func waitForInstallation(ctx context.Context, cmdNames map[string]struct{}, installed chan string, failures chan failedRun, okayToStart chan struct{}) error {
+	installationStart := time.Now()
+
 	stdout.Out.Write("")
 	stdout.Out.WriteLine(output.Linef(output.EmojiLightbulb, output.StyleBold, "Installing %d commands...", len(cmdNames)))
 	stdout.Out.Write("")
@@ -125,6 +128,7 @@ func waitForInstallation(cmdNames map[string]struct{}, installed chan string, fa
 
 			delete(cmdNames, cmdName)
 			done += 1.0
+			analytics.LogDuration(ctx, "install_command", []string{cmdName}, time.Since(installationStart))
 
 			progress.WriteLine(output.Linef("", output.StyleSuccess, "%s installed", cmdName))
 

--- a/dev/sg/main.go
+++ b/dev/sg/main.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/urfave/cli/v2"
 
+	"github.com/sourcegraph/sourcegraph/dev/sg/internal/analytics"
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/secrets"
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/sgconf"
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/stdout"
@@ -18,14 +19,10 @@ import (
 )
 
 func main() {
+	// Do not add initialization here, do all setup in sg.Before.
 	if os.Args[len(os.Args)-1] == "--generate-bash-completion" {
 		batchCompletionMode = true
 	}
-
-	log.Init(log.Resource{
-		Name: "sg",
-	})
-
 	if err := sg.RunContext(context.Background(), os.Args); err != nil {
 		fmt.Printf("error: %s\n", err)
 		os.Exit(1)
@@ -99,6 +96,12 @@ var sg = &cli.App{
 			EnvVars: []string{"SG_SKIP_AUTO_UPDATE"},
 			Value:   BuildCommit == "dev", // Default to skip in dev, otherwise don't
 		},
+		&cli.BoolFlag{
+			Name:    "disable-analytics",
+			Usage:   "disable event logging (logged to '~/.sourcegraph/events')",
+			EnvVars: []string{"SG_DISABLE_ANALYTICS"},
+			// Value:   BuildCommit == "dev", // Default to skip in dev, otherwise don't
+		},
 	},
 	Before: func(cmd *cli.Context) error {
 		if batchCompletionMode {
@@ -107,6 +110,13 @@ var sg = &cli.App{
 			return nil
 		}
 
+		if !cmd.Bool("disable-analytics") {
+			cmd.Context = analytics.WithContext(cmd.Context, cmd.App.Version)
+			start := time.Now()
+			addAnalyticsHooks(start, []string{"sg"}, cmd.App.Commands)
+		}
+
+		log.Init(log.Resource{Name: "sg"})
 		if verbose {
 			stdout.Out.SetVerbose()
 		}
@@ -171,6 +181,7 @@ var sg = &cli.App{
 		liveCommand,
 		opsCommand,
 		auditCommand,
+		analyticsCommand,
 
 		// Util
 		helpCommand,

--- a/dev/sg/main.go
+++ b/dev/sg/main.go
@@ -110,12 +110,17 @@ var sg = &cli.App{
 			return nil
 		}
 
+		// Configure analytics - this should be the first thing to be configured.
 		if !cmd.Bool("disable-analytics") {
 			cmd.Context = analytics.WithContext(cmd.Context, cmd.App.Version)
-			start := time.Now()
+			start := time.Now() // Start the clock immediately
 			addAnalyticsHooks(start, []string{"sg"}, cmd.App.Commands)
 		}
 
+		// Add autosuggestion hooks to commands with subcommands but no action
+		addSuggestionHooks(cmd.App.Commands)
+
+		// Configure output
 		log.Init(log.Resource{Name: "sg"})
 		if verbose {
 			stdout.Out.SetVerbose()

--- a/dev/sg/main_test.go
+++ b/dev/sg/main_test.go
@@ -53,7 +53,9 @@ func testCommandFormatting(t *testing.T, cmd *cli.Command) {
 		assert.NotEmpty(t, cmd.Name, "Name should be set")
 		assert.NotEmpty(t, cmd.Usage, "Usage should be set")
 		assert.False(t, strings.HasSuffix(cmd.Usage, "."), "Usage should not end with period")
-		assert.NotNil(t, cmd.Action, "Action must be provided (for parent commands, use 'suggestSubcommandsAction')")
+		if len(cmd.Subcommands) == 0 {
+			assert.NotNil(t, cmd.Action, "Action must be provided for command without subcommands")
+		}
 		assert.Nil(t, cmd.After, "After should not be used for simplicity")
 
 		for _, subCmd := range cmd.Subcommands {

--- a/dev/sg/main_test.go
+++ b/dev/sg/main_test.go
@@ -23,7 +23,13 @@ func TestAppRun(t *testing.T) {
 	sg.Writer = &out
 	sg.ErrWriter = &err
 	// Check app starts up correctly
-	assert.NoError(t, sg.Run([]string{"help"}))
+	assert.NoError(t, sg.Run([]string{
+		"help",
+		// We must disable the addition of analytics hooks here because that messes with
+		// other tests that assert that no other .After hooks have been added by default,
+		// since all commands are defined as pointers.
+		"--disable-analytics",
+	}))
 	assert.Contains(t, out.String(), "The Sourcegraph developer tool!")
 	// We do not want errors anywhere
 	assert.NotContains(t, out.String(), "error")
@@ -47,7 +53,8 @@ func testCommandFormatting(t *testing.T, cmd *cli.Command) {
 		assert.NotEmpty(t, cmd.Name, "Name should be set")
 		assert.NotEmpty(t, cmd.Usage, "Usage should be set")
 		assert.False(t, strings.HasSuffix(cmd.Usage, "."), "Usage should not end with period")
-		assert.NotNil(t, cmd.Action, "Action must be provided (for parent commands, 'suggestSubcommandsAction'")
+		assert.NotNil(t, cmd.Action, "Action must be provided (for parent commands, use 'suggestSubcommandsAction')")
+		assert.Nil(t, cmd.After, "After should not be used for simplicity")
 
 		for _, subCmd := range cmd.Subcommands {
 			testCommandFormatting(t, subCmd)

--- a/dev/sg/sg_analytics.go
+++ b/dev/sg/sg_analytics.go
@@ -89,7 +89,7 @@ var analyticsCommand = &cli.Command{
 						ts := ev.Timestamp.Local().Format("2006-01-02 03:04:05PM")
 						var metrics []string
 						for k, v := range ev.Metrics {
-							metrics = append(metrics, fmt.Sprintf("%s: %s", k, v.Type))
+							metrics = append(metrics, fmt.Sprintf("%s: %s", k, v.String()))
 						}
 
 						entry := fmt.Sprintf("- [%s] `%s`: %s _(%s)_",

--- a/dev/sg/sg_analytics.go
+++ b/dev/sg/sg_analytics.go
@@ -89,7 +89,7 @@ var analyticsCommand = &cli.Command{
 						ts := ev.Timestamp.Local().Format("2006-01-02 03:04:05PM")
 						var metrics []string
 						for k, v := range ev.Metrics {
-							metrics = append(metrics, fmt.Sprintf("%s: %s", k, v.String()))
+							metrics = append(metrics, fmt.Sprintf("%s: %s", k, v.ValueString()))
 						}
 
 						entry := fmt.Sprintf("- [%s] `%s`: %s _(%s)_",

--- a/dev/sg/sg_analytics.go
+++ b/dev/sg/sg_analytics.go
@@ -16,7 +16,6 @@ var analyticsCommand = &cli.Command{
 	Name:     "analytics",
 	Usage:    "Manage analytics collected by sg",
 	Category: CategoryCompany,
-	Action:   suggestSubcommandsAction,
 	Subcommands: []*cli.Command{
 		{
 			Name:        "submit",

--- a/dev/sg/sg_analytics.go
+++ b/dev/sg/sg_analytics.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/urfave/cli/v2"
+
+	"github.com/sourcegraph/sourcegraph/dev/sg/internal/analytics"
+	"github.com/sourcegraph/sourcegraph/dev/sg/internal/secrets"
+)
+
+var analyticsCommand = &cli.Command{
+	Name:     "analytics",
+	Usage:    "Manage analytics collected by sg",
+	Category: CategoryCompany,
+	Action:   suggestSubcommandsAction,
+	Subcommands: []*cli.Command{
+		{
+			Name:        "submit",
+			ArgsUsage:   "[github username]",
+			Usage:       "Make sg better by submitting all analytics stored locally!",
+			Description: "Uses OKAYHQ_TOKEN, or fetches a token from gcloud.",
+			Action: func(cmd *cli.Context) error {
+				if cmd.Args().Len() != 1 {
+					return cli.ShowSubcommandHelp(cmd)
+				}
+
+				okayToken := os.Getenv("OKAYHQ_TOKEN")
+				if okayToken == "" {
+					store, err := secrets.FromContext(cmd.Context)
+					if err != nil {
+						return err
+					}
+					okayToken, err = store.GetExternal(cmd.Context, secrets.ExternalSecret{
+						Provider: "gcloud",
+						Project:  "sourcegraph-ci",
+						Name:     "CI_OKAYHQ_TOKEN",
+					})
+					if err != nil {
+						return err
+					}
+				}
+
+				if err := analytics.Submit(okayToken, cmd.Args().First()); err != nil {
+					return err
+				}
+				writeSuccessLinef("Analytics successfully submitted!")
+				return analytics.Reset()
+			},
+		},
+		{
+			Name:  "reset",
+			Usage: "Delete all analytics stored locally",
+			Action: func(cmd *cli.Context) error {
+				if err := analytics.Reset(); err != nil {
+					return err
+				}
+				writeSuccessLinef("Analytics reset!")
+				return nil
+			},
+		},
+		{
+			Name:  "view",
+			Usage: "View all analytics stored locally",
+			Flags: []cli.Flag{
+				&cli.BoolFlag{
+					Name:  "raw",
+					Usage: "view raw data",
+				},
+			},
+			Action: func(cmd *cli.Context) error {
+				events, err := analytics.Load()
+				if err != nil {
+					writeSkippedLinef("No analytics found: %s", err.Error())
+					return nil
+				}
+
+				var out strings.Builder
+				out.WriteString(fmt.Sprintf("%d events found:\n", len(events)))
+
+				for _, ev := range events {
+					if cmd.Bool("raw") {
+						b, _ := json.MarshalIndent(ev, "", "  ")
+						out.WriteString(fmt.Sprintf("\n```json\n%s\n```", string(b)))
+						out.WriteString("\n")
+					} else {
+						ts := ev.Timestamp.Local().Format("2006-01-02 03:04:05PM")
+						var metrics []string
+						for k, v := range ev.Metrics {
+							metrics = append(metrics, fmt.Sprintf("%s: %s", k, v.Type))
+						}
+
+						entry := fmt.Sprintf("- [%s] `%s`: %s _(%s)_",
+							ts, ev.Name, strings.Join(ev.Labels, ", "), strings.Join(metrics, ", "))
+						out.WriteString(entry)
+
+						out.WriteString("\n")
+					}
+				}
+
+				out.WriteString("\nTo submit these events, use `sg analytics submit`.\n")
+
+				return writePrettyMarkdown(out.String())
+			},
+		},
+	},
+}

--- a/dev/sg/sg_audit.go
+++ b/dev/sg/sg_audit.go
@@ -30,7 +30,6 @@ var auditCommand = &cli.Command{
 	ArgsUsage: "[target]",
 	Hidden:    true,
 	Category:  CategoryCompany,
-	Action:    suggestSubcommandsAction,
 	Subcommands: []*cli.Command{{
 		Name:  "pr",
 		Usage: "Display audit trail for pull requests",

--- a/dev/sg/sg_ci.go
+++ b/dev/sg/sg_ci.go
@@ -74,7 +74,6 @@ var ciCommand = &cli.Command{
 
 Note that Sourcegraph's CI pipelines are under our enterprise license: https://github.com/sourcegraph/sourcegraph/blob/main/LICENSE.enterprise`,
 	Category: CategoryDev,
-	Action:   suggestSubcommandsAction,
 	Subcommands: []*cli.Command{{
 		Name:    "preview",
 		Aliases: []string{"plan"},

--- a/dev/sg/sg_db.go
+++ b/dev/sg/sg_db.go
@@ -30,7 +30,6 @@ var (
 	dbCommand = &cli.Command{
 		Name:     "db",
 		Usage:    "Interact with local Sourcegraph databases for development",
-		Action:   suggestSubcommandsAction,
 		Category: CategoryDev,
 		Subcommands: []*cli.Command{
 			{

--- a/dev/sg/sg_migration.go
+++ b/dev/sg/sg_migration.go
@@ -82,7 +82,6 @@ var (
 		Name:     "migration",
 		Usage:    "Modifies and runs database migrations",
 		Category: CategoryDev,
-		Action:   suggestSubcommandsAction,
 		Subcommands: []*cli.Command{
 			addCommand,
 			revertCommand,

--- a/dev/sg/sg_ops.go
+++ b/dev/sg/sg_ops.go
@@ -22,7 +22,6 @@ var (
 		Usage:       "Commands used by operations teams to perform common tasks",
 		Description: constructOpsCmdLongHelp(),
 		Category:    CategoryCompany,
-		Action:      suggestSubcommandsAction,
 		Subcommands: []*cli.Command{opsUpdateImagesCommand},
 	}
 

--- a/dev/sg/sg_secret.go
+++ b/dev/sg/sg_secret.go
@@ -21,7 +21,6 @@ var (
 		ArgsUsage: "<...subcommand>",
 		Usage:     "Manipulate secrets stored in memory and in file",
 		Category:  CategoryEnv,
-		Action:    suggestSubcommandsAction,
 		Subcommands: []*cli.Command{
 			{
 				Name:      "reset",

--- a/dev/sg/sg_teammate.go
+++ b/dev/sg/sg_teammate.go
@@ -32,7 +32,6 @@ var (
 		Usage:       "Get information about Sourcegraph teammates",
 		Description: `Get information about Sourcegraph teammates, such as their current time and handbook page!`,
 		Category:    CategoryCompany,
-		Action:      suggestSubcommandsAction,
 		Subcommands: []*cli.Command{{
 			Name:      "time",
 			ArgsUsage: "<nickname>",

--- a/dev/sg/sg_version.go
+++ b/dev/sg/sg_version.go
@@ -136,9 +136,6 @@ func checkSgVersionAndUpdate(ctx context.Context, skipUpdate bool) error {
 	out = strings.TrimSpace(out)
 	if out == "" {
 		// No newer commits found. sg is up to date.
-		if !skipUpdate {
-			analytics.LogEvent(ctx, "auto_update", []string{"up-to-date"}, start)
-		}
 		return nil
 	}
 
@@ -156,6 +153,7 @@ func checkSgVersionAndUpdate(ctx context.Context, skipUpdate bool) error {
 	stdout.Out.WriteLine(output.Line(output.EmojiInfo, output.StyleSuggestion, "Auto updating sg ..."))
 	newPath, err := updateToPrebuiltSG(ctx)
 	if err != nil {
+		analytics.LogEvent(ctx, "auto_update", []string{"failed"}, start)
 		return errors.Newf("failed to install update: %s", err)
 	}
 	writeSuccessLinef("sg has been updated!")

--- a/dev/sg/sg_version.go
+++ b/dev/sg/sg_version.go
@@ -136,7 +136,9 @@ func checkSgVersionAndUpdate(ctx context.Context, skipUpdate bool) error {
 	out = strings.TrimSpace(out)
 	if out == "" {
 		// No newer commits found. sg is up to date.
-		analytics.LogEvent(ctx, "auto_update", []string{"up-to-date"}, time.Since(start))
+		if !skipUpdate {
+			analytics.LogEvent(ctx, "auto_update", []string{"up-to-date"}, start)
+		}
 		return nil
 	}
 
@@ -159,7 +161,7 @@ func checkSgVersionAndUpdate(ctx context.Context, skipUpdate bool) error {
 	writeSuccessLinef("sg has been updated!")
 	stdout.Out.Write("To see what's new, run 'sg version changelog'.")
 
-	analytics.LogEvent(ctx, "auto_update", []string{"updated"}, time.Since(start))
+	analytics.LogEvent(ctx, "auto_update", []string{"updated"}, start)
 
 	// Run command with new binary
 	return syscall.Exec(newPath, os.Args, os.Environ())


### PR DESCRIPTION
Extends `sg` such that:

1. Each run of `sg` will now aggregate events in context via `analytics.LogEvent` calls
2. Each run of `sg` now logs an overall command duration event with `analytics.LogEvent`, with optional events that happened (error, cancellation, success)
3. As a demonstration, log time-to-install for each command in `sg start` and time to check for updates in the auto-updater
4. At the end of each run of `sg`, aggregated events will be stored to disk (`~/.sourcegraph/events`), **not** submitted to OkayHQ, and will attach command context (command names) and the names of flags that are used. We **do not** log arguments and values that could be sensitive.
5. Analytics collection can be disabled with `--disable-analytics` or `SG_DISABLE_ANALYTICS`

Introduces the following commands:

- `sg analytics view`: List all analytics events currently on disk.
- `sg analytics reset`: Delete all analytics events currently on disk.
- `sg analytics submit`: Submit all analytics currently on disk to OkayHQ using `OKAYHQ_TOKEN` or `CI_OKAYHQ_TOKEN` from `gcloud` (we can change this but for now this seems most convenient)

This PR is scoped to duration events. We can perhaps extend this to track errors as well in a follow-up.

Currently, we do **not** automatically submit these events, and I would prefer that to be enabled in a follow-up.

Kicks off https://github.com/sourcegraph/sourcegraph/issues/33447

## API usage

`sg start` install success:

```go
analytics.LogEvent(ctx, "install_command", []string{cmdName}, time.Since(installationStart), "succeeded")
```

`sg start` install fail:

```go
analytics.LogEvent(ctx, "install_command", []string{failure.cmdName}, time.Since(installationStart), "failed")
```

## Schema

See `sg analytics view --raw`

Action event:

```json
    {                                                                                                                 
      "Name": "sg_action",                                                                                            
      "Timestamp": "2022-05-06T05:00:07.352442Z",                                                                     
      "Metrics": {                                                                                                    
        "cancelled": {                                                                                                
          "type": "count",                                                                                            
          "value": 1                                                                                                  
        },                                                                                                            
        "duration": {                                                                                                 
          "type": "durationMs",                                                                                       
          "value": 3638                                                                                               
        }                                                                                                             
      },                                                                                                              
      "Labels": [                                                                                                     
        "sg",                                                                                                         
        "start"                                                                                                       
      ],                                                                                                              
      "UniqueKey": [                                                                                                  
        "event_id",                                                                                                   
        "context",                                                                                                    
        "event_name",                                                                                                 
        "event_version",                                                                                              
        "run_id"                                                                                                      
      ],                                                                                                              
      "Properties": {                                                                                                 
        "command": "sg start",                                                                                        
        "context": "sg",                                                                                              
        "event_id": "565d6044-a7d7-4ee6-9ba1-b84c2a98c135",                                                           
        "event_name": "sg_action",                                                                                    
        "event_version": "v0",                                                                                        
        "flags_used": "",                                                                                             
        "run_id": "0c7c66ac-b264-453d-b9b1-39a70b1a3d3e",                                                             
        "sg_version": "dev"                                                                                           
      }                                                                                                               
    }   
```

Command install event:

```json                                                                                                                      
    {                                                                                                                 
      "Name": "install_command",                                                                                      
      "Timestamp": "2022-05-06T05:00:07.803753Z",                                                                     
      "Metrics": {                                                                                                    
        "duration": {                                                                                                 
          "type": "durationMs",                                                                                       
          "value": 3129                                                                                               
        },                                                                                                            
        "succeeded": {                                                                                                
          "type": "count",                                                                                            
          "value": 1                                                                                                  
        }                                                                                                             
      },                                                                                                              
      "Labels": [                                                                                                     
        "zoekt-webserver-0"                                                                                           
      ],                                                                                                              
      "UniqueKey": [                                                                                                  
        "event_id",                                                                                                   
        "context",                                                                                                    
        "event_name",                                                                                                 
        "event_version",                                                                                              
        "run_id"                                                                                                      
      ],                                                                                                              
      "Properties": {                                                                                                 
        "command": "sg start",                                                                                        
        "context": "sg",                                                                                              
        "event_id": "24a2f245-6966-482a-8a0a-7335c1bc3214",                                                           
        "event_name": "install_command",                                                                              
        "event_version": "v0",                                                                                        
        "flags_used": "",                                                                                             
        "run_id": "0c7c66ac-b264-453d-b9b1-39a70b1a3d3e",                                                             
        "sg_version": "dev"                                                                                           
      }                                                                                                               
    } 
```

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

<img width="743" alt="image" src="https://user-images.githubusercontent.com/23356519/167073219-9cc522e6-4bb1-4984-bdce-809573148491.png">

I don't actually see the events in OkayHQ at the moment despite the API telling me I'm good. I am going to schedule a time with an OkayHQ rep to chat about events next week