### PR TITLE
dx: enable VSCode search for `.go` files inside of the `ui/assets/` folder

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,7 +3,7 @@
     "**/node_modules": true,
     "**/bower_components": true,
     "dist": true,
-    "ui/assets": true,
+    "ui/assets/!(*.go)": true,
     "client/browser/build": true,
     "**/coverage": true,
     "**/out": true,


### PR DESCRIPTION
## Context

Search is disabled for `.go` files inside the `ui/assets` folder.

## Test plan

n/a


