### PR TITLE
batches: fix error handling for github CreateChangeset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Button to download raw file in blob page is now working correctly. [#34558](https://github.com/sourcegraph/sourcegraph/pull/34558)
 - Searches containing `or` expressions are now optimized to evaluate natively on the backends that support it ([#34382](https://github.com/sourcegraph/sourcegraph/pull/34382)), and both commit and diff search have been updated to run optimized `and`, `or`, and `not` queries. [#34595](https://github.com/sourcegraph/sourcegraph/pull/34595)
 - Carets in textareas in Firefox are now visible. [#34888](https://github.com/sourcegraph/sourcegraph/pull/34888)
+- Changesets to GitHub code hosts could fail with a confusing, non actionable error message. [#XXX](https://github.com/sourcegraph/sourcegraph/pull/XXX)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Button to download raw file in blob page is now working correctly. [#34558](https://github.com/sourcegraph/sourcegraph/pull/34558)
 - Searches containing `or` expressions are now optimized to evaluate natively on the backends that support it ([#34382](https://github.com/sourcegraph/sourcegraph/pull/34382)), and both commit and diff search have been updated to run optimized `and`, `or`, and `not` queries. [#34595](https://github.com/sourcegraph/sourcegraph/pull/34595)
 - Carets in textareas in Firefox are now visible. [#34888](https://github.com/sourcegraph/sourcegraph/pull/34888)
-- Changesets to GitHub code hosts could fail with a confusing, non actionable error message. [#XXX](https://github.com/sourcegraph/sourcegraph/pull/XXX)
+- Changesets to GitHub code hosts could fail with a confusing, non actionable error message. [#35048](https://github.com/sourcegraph/sourcegraph/pull/35048)
 
 ### Removed
 

--- a/internal/extsvc/github/common.go
+++ b/internal/extsvc/github/common.go
@@ -585,11 +585,10 @@ func (c *V4Client) CreatePullRequest(ctx context.Context, in *CreatePullRequestI
 	input := map[string]interface{}{"input": compatibleInput}
 	err = c.requestGraphQL(ctx, q.String(), input, &result)
 	if err != nil {
-		var errs graphqlErrors
-		if errors.As(err, &errs) && len(errs) == 1 && strings.Contains(errs[0].Message, "A pull request already exists for") {
+		if isPullRequestAlreadyExistsError(err) {
 			return nil, ErrPullRequestAlreadyExists
 		}
-		return nil, errs
+		return nil, err
 	}
 
 	ti := result.CreatePullRequest.PullRequest.TimelineItems
@@ -648,8 +647,7 @@ func (c *V4Client) UpdatePullRequest(ctx context.Context, in *UpdatePullRequestI
 	input := map[string]interface{}{"input": in}
 	err = c.requestGraphQL(ctx, q.String(), input, &result)
 	if err != nil {
-		var errs graphqlErrors
-		if errors.As(err, &errs) && len(errs) == 1 && strings.Contains(errs[0].Message, "A pull request already exists for") {
+		if isPullRequestAlreadyExistsError(err) {
 			return nil, ErrPullRequestAlreadyExists
 		}
 		return nil, err
@@ -1958,4 +1956,12 @@ func normalizeURL(rawURL string) string {
 		parsed.Path += "/"
 	}
 	return parsed.String()
+}
+
+func isPullRequestAlreadyExistsError(err error) bool {
+	var errs graphqlErrors
+	if !errors.As(err, &errs) {
+		return false
+	}
+	return len(errs) == 1 && strings.Contains(errs[0].Message, "A pull request already exists for")
 }


### PR DESCRIPTION
When the error is NOT a graphqlErrors, the errors.As returns false and does not populate the variable. We then returned it, and the errors.Wrap method further up calls .Error() on the nil slice the graphqlErrors type is under the hood, and in the Error() handler we access e[0]. This panics and causes the confusing error message customers reported:
```
Creating changeset: %!v(PANIC=Error method: runtime error: index out of range [0] with length 0)
```

This is not fixing publishing for those changesets, but if fixes that the error is useless. Next up after this fix, we can look into why it's failing and why the returned err doesn't comply with the graphqlErrors type.

This seems to have accidentally slipped in about 11 months ago during an errors refactor. https://github.com/sourcegraph/sourcegraph/pull/22704/files#r866758789

## Test plan

Validated that a non graphqlErrors error is not causing this confusing error message anymore by throwing an arbitrary error and comparing before and after the code change results. Works.


