### PR TITLE
JetBrains: Update README.md

### DIFF
--- a/client/jetbrains/README.md
+++ b/client/jetbrains/README.md
@@ -2,12 +2,16 @@
 
 # Sourcegraph for JetBrains IDEs [![JetBrains Plugin](https://img.shields.io/badge/JetBrains-Sourcegraph-green.svg)](https://plugins.jetbrains.com/plugin/9682-sourcegraph)
 
-- Search snippets of code on Sourcegraph.
-- Copy and share a link to code on Sourcegraph.
-- Quickly go from files in your editor to Sourcegraph.
+- Instantly search in all open source repos and your private code.
+- Peek into any remote repo in the IDE, without checking it out.
+- Create URLs to specific code blocks to share them with your teammates.
+- Open your files on Sourcegraph.
+
 <!-- Plugin description end -->
 
-The plugin works with all JetBrains IDEs including:
+## Supported IDEs
+
+The plugin works with all JetBrains IDEs, including:
 
 - IntelliJ IDEA
 - IntelliJ IDEA Community Edition
@@ -25,11 +29,13 @@ The plugin works with all JetBrains IDEs including:
 
 ## Installation
 
-- Select `IntelliJ IDEA` then `Preferences` (or use <kbd>⌘,</kbd>)
-- Click `Plugins` in the left-hand pane.
-- Choose `Browse repositories...`
-- Search for `Sourcegraph` -> `Install`
-- Restart your IDE if needed, then select some code and choose `Sourcegraph` in the right-click context menu to see actions and keyboard shortcuts.
+- Open settings
+  - Mac: Go to `IntelliJ IDEA | Preferences` (or use <kbd>⌘,</kbd>)
+  - Windows: Go to `File | Settings` (or use <kb>Ctrl+Alt+S</kb>)
+- Click `Plugins` in the left-hand pane, then the `Marketplace` tab at the top
+- Search for `Sourcegraph`, then click the `Install` button
+- Restart your IDE if needed
+- To try the plugin, press <kbd>Alt+A</kbd> (<kbd>⌥A</kbd> on Mac) then select some code and choose `Sourcegraph` in the right-click context menu to see actions and keyboard shortcuts.
 
 ## Configuring for use with a private Sourcegraph instance
 
@@ -41,7 +47,7 @@ defaultBranch = example-branch
 remoteUrlReplacements = git.example.com, git-web.example.com
 ```
 
-You may also choose to configure it _per repository_ using a `.idea/sourcegraph.xml` (or `idea/sourcegraph.xml` pre-v1.2.2) file in your repository like so:
+You may also choose to configure it _per project_ using a `.idea/sourcegraph.xml` file in your project like so:
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
@@ -54,35 +60,43 @@ You may also choose to configure it _per repository_ using a `.idea/sourcegraph.
 </project>
 ```
 
-By default, the plugin will use the `origin` git remote to determine which repository on Sourcegraph corresponds to your local repository. If your `origin` remote doesn't match Sourcegraph, you may instead configure a `sourcegraph` Git remote which will take priority.
+By default, the plugin will use the git remote called `origin` to determine which repository on Sourcegraph corresponds to your local repository. If your `origin` remote doesn’t match Sourcegraph, you may instead configure a Git remote by the name of `sourcegraph`, and it will take priority.
 
 ## Questions & Feedback
 
-Please file an issue: https://github.com/sourcegraph/sourcegraph-jetbrains/issues/new
+If you have any questions, feedback, or bug report, we appreciate if you [open an issue on GitHub](https://github.com/sourcegraph/sourcegraph/issues/new?title=JetBrains:+&labels=jetbrains-ide).
 
 ## Uninstallation
 
-- Select `IntelliJ IDEA` then `Preferences` (or use <kbd>⌘,</kbd>)
-- Click `Plugins` in the left-hand pane.
-- Search for `Sourcegraph` -> Right click -> `Uninstall` (or uncheck to disable)
+- Open settings
+  - Mac: Go to `IntelliJ IDEA | Preferences` (or use <kbd>⌘,</kbd>)
+  - Windows: Go to `File | Settings` (or use <kb>Ctrl+Alt+S</kb>)
+- Click `Plugins` in the left-hand pane, then the `Installed` tab at the top
+- Find `Sourcegraph` → Right click → `Uninstall` (or uncheck to disable)
 
 ## Development
 
-- Start IntelliJ and choose `Check out from Version Control` -> `Git` -> `https://github.com/sourcegraph/sourcegraph-jetbrains`
-- Develop as you would normally (hit Debug icon in top right of IntelliJ) or using gradlew commands:
-  1. `./gradlew runIde` to run an IDE instance with sourcegraph plugin installed. This will start the platform with the versions defined in [`gradle.properties`](https://github.com/sourcegraph/sourcegraph-jetbrains/blob/main/gradle.properties#L14-L16). _Note: 2021.3 is required for M1 Macs._
-  2. `./gradlew buildPlugin` to build plugin artifact (`build/distributions/Sourcegraph.zip`)
+- Clone `https://github.com/sourcegraph/sourcegraph`
+- Run `yarn install` in the root directory to get all dependencies
+- Run `yarn generate` in the root directory to generate graphql files
+- Go to `client/jetbrains/` and run `yarn build` to generate the JS files
+- You can test the “Find on Sourcegraph” window by running `yarn standalone` in the `client/jetbrains/` directory and opening [http://localhost:3000/](http://localhost:3000/) in your browser.
+- Run the plugin in a sandboxed IDE by running `./gradlew runIde`. This will start the platform with the versions defined in `gradle.properties`, [here](https://github.com/sourcegraph/sourcegraph/blob/main/client/jetbrains/gradle.properties#L14-L16).
+  - Note: 2021.3 or later is required for Macs with Apple Silicon chips.
+- Build a deployable plugin artifact by running `./gradlew buildPlugin`. The output file is `build/distributions/Sourcegraph.zip`.
 
 ## Publishing a new version
 
-The publishing process is based on the actions outlined in the [`intellij-platform-plugin-template`](https://github.com/JetBrains/intellij-platform-plugin-template).
+The publishing process is based on the [intellij-platform-plugin-template](https://github.com/JetBrains/intellij-platform-plugin-template).
 
-1. Update `gradle.properties` and set the version number for this release (e.g. `1.2.3`).
-2. Create a [new release](https://github.com/sourcegraph/sourcegraph-jetbrains/releases/new) on GitHub.
-3. Pick the new version number as the git tag (e.g. `v1.2.3`).
-4. Copy/paste the `[Unreleased]` section of the [`CHANGELOG.md`](https://github.com/sourcegraph/sourcegraph-jetbrains/blob/main/CHANGELOG.md) into the GitHub release text.
-5. Once published, a GitHub action is triggered that will publish the release automatically and create a PR to update the changelog and version text. You may need to manually fix the content.
+1. Update `pluginVersion` in `gradle.properties`.
+2. Describe the changes in the `[Unreleased]` section of `client/jetbrains/CHANGELOG.md`.
+3. **TODO: The following steps are obsolete now that we merged the project in the monorepo. Figure out a new process!**
+4. ~~Create a [new release](https://github.com/sourcegraph/sourcegraph/releases/new) on GitHub.~~
+5. ~~Pick the new version number as the git tag (e.g. `v1.2.3`).~~
+6. ~~Copy/paste the `[Unreleased]` section of [`CHANGELOG.md`](https://github.com/sourcegraph/sourcegraph/blob/main/client/jetbrains/CHANGELOG.md) into the GitHub release text.~~
+7. ~~Once published, a GitHub action is triggered that will publish the release automatically and create a PR to update the changelog and version text. You may need to manually fix the content.~~
 
 ## Version History
 
-See [`CHANGELOG.md`](https://github.com/sourcegraph/sourcegraph-jetbrains/blob/main/CHANGELOG.md).
+See [`CHANGELOG.md`](https://github.com/sourcegraph/sourcegraph/blob/main/client/jetbrains/CHANGELOG.md).


### PR DESCRIPTION
- Mention “Search on Sourcegraph” feature in the plugin description
- Update install/uninstall process descriptions for newer IDE versions
- Add missing steps from the “development” section
- Invalidate old “Publishing” section (the monorepo move made the old process obsolete.)
- Fix some links and do other minor changes
- Note: the new “Publishing” process is still missing, we’ll add it later.

## Test plan

Only doc change, so just see if the new version makes more sense for the current state of the project than the old one.