### PR TITLE
codeintel: Add file content limits to inference service

### DIFF
--- a/internal/codeintel/autoindexing/internal/inference/init.go
+++ b/internal/codeintel/autoindexing/internal/inference/init.go
@@ -21,7 +21,9 @@ var (
 )
 
 var (
-	gitserverRequestRateLimit = env.MustGetInt("CODEINTEL_AUTOINDEXING_INFERENCE_GITSERVER_REQUEST_LIMIT", 100, "The maximum number of request to gitserver per second that can be made from the autoindexing inference service.")
+	gitserverRequestRateLimit       = env.MustGetInt("CODEINTEL_AUTOINDEXING_INFERENCE_GITSERVER_REQUEST_LIMIT", 100, "The maximum number of request to gitserver per second that can be made from the autoindexing inference service.")
+	maximumFilesWithContentCount    = env.MustGetInt("CODEINTEL_AUTOINDEXING_INFERENCE_MAXIMUM_FILE_WITH_COUNT", 100, "The maximum number of files that can be requested by the inference script. Inference operations exceeding this limit will fail.")
+	maximumFileWithContentSizeBytes = env.MustGetInt("CODEINTEL_AUTOINDEXING_INFERENCE_MAXIMUM_FILE_WITH_CONTENT_SIZE_BYTES", 1024*1024, "The maximum size of the content of a single file requested by the inference script. Inference operations exceeding this limit will fail.")
 )
 
 func GetService(db database.DB) *Service {
@@ -36,6 +38,8 @@ func GetService(db database.DB) *Service {
 			luasandbox.GetService(),
 			NewDefaultGitService(nil, db),
 			rate.NewLimiter(rate.Limit(gitserverRequestRateLimit), 1),
+			maximumFilesWithContentCount,
+			maximumFileWithContentSizeBytes,
 			observationContext,
 		)
 	})

--- a/internal/codeintel/autoindexing/internal/inference/service.go
+++ b/internal/codeintel/autoindexing/internal/inference/service.go
@@ -333,6 +333,9 @@ func (s *Service) resolveFileContents(
 
 	contentsByPath := map[string]string{}
 
+	N := 50
+	M := 5000
+
 	tr := tar.NewReader(rc)
 	for {
 		header, err := tr.Next()
@@ -342,6 +345,13 @@ func (s *Service) resolveFileContents(
 			}
 
 			break
+		}
+
+		if int(header.Size) > M {
+			return nil, errors.Newf("file too big man")
+		}
+		if len(contentsByPath) > N {
+			return nil, errors.Newf("repo too big man")
 		}
 
 		var buf bytes.Buffer

--- a/internal/codeintel/autoindexing/internal/inference/service.go
+++ b/internal/codeintel/autoindexing/internal/inference/service.go
@@ -314,9 +314,8 @@ func (s *Service) resolveFileContents(
 	if err != nil {
 		return nil, err
 	}
-	pathspecs := make([]gitserver.Pathspec, 0, len(relevantPaths))
-	for _, p := range relevantPaths {
-		pathspecs = append(pathspecs, gitserver.PathspecLiteral(p))
+	if len(relevantPaths) == 0 {
+		return nil, nil
 	}
 
 	start := time.Now()
@@ -326,6 +325,10 @@ func (s *Service) resolveFileContents(
 		return nil, err
 	}
 
+	pathspecs := make([]gitserver.Pathspec, 0, len(relevantPaths))
+	for _, p := range relevantPaths {
+		pathspecs = append(pathspecs, gitserver.PathspecLiteral(p))
+	}
 	opts := gitserver.ArchiveOptions{
 		Treeish:   invocationContext.commit,
 		Format:    "tar",

--- a/internal/codeintel/autoindexing/internal/inference/service_test.go
+++ b/internal/codeintel/autoindexing/internal/inference/service_test.go
@@ -42,5 +42,5 @@ func testService(t *testing.T, repositoryContents map[string]string) *Service {
 		return unpacktest.CreateTarArchive(t, files), nil
 	})
 
-	return newService(sandboxService, gitService, rate.NewLimiter(rate.Limit(100), 1), &observation.TestContext)
+	return newService(sandboxService, gitService, rate.NewLimiter(rate.Limit(100), 1), 100, 1024*1024, &observation.TestContext)
 }


### PR DESCRIPTION
The introduction of the Lua inference service has ballooned worker memory because we're reading an unbounded amount of content from a tar archive of the target repo. This PR adds a configurable maximum number of files as well as a configurable maximum file size when trying to infer project structure. Additionally, we ensure that we don't call Archive with an empty list of paths (which, unfortunately, returns the entire content).

## Test plan

Existing unit tests. Also tested locally to make sure default limits were reasonable.