### PR TITLE
Search backend: fix user-facing error strings

### DIFF
--- a/internal/search/run/run.go
+++ b/internal/search/run/run.go
@@ -129,7 +129,7 @@ func detectSearchType(version string, patternType *string) (query.SearchType, er
 		case "structural":
 			searchType = query.SearchTypeStructural
 		default:
-			return -1, errors.Errorf("unrecognized patternType: %v", patternType)
+			return -1, errors.Errorf("unrecognized patternType %q", *patternType)
 		}
 	} else {
 		switch version {
@@ -138,7 +138,7 @@ func detectSearchType(version string, patternType *string) (query.SearchType, er
 		case "V2":
 			searchType = query.SearchTypeLiteral
 		default:
-			return -1, errors.Errorf("unrecognized version want \"V1\" or \"V2\": %v", version)
+			return -1, errors.Errorf("unrecognized version: want \"V1\" or \"V2\", got %q", version)
 		}
 	}
 	return searchType, nil

--- a/internal/search/run/run_test.go
+++ b/internal/search/run/run_test.go
@@ -3,6 +3,8 @@ package run
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
 )
 
@@ -42,4 +44,30 @@ func TestDetectSearchType(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("errors", func(t *testing.T) {
+		typeInvalid := "invalid"
+
+		cases := []struct {
+			version     string
+			patternType *string
+			errorString string
+		}{{
+			version:     "",
+			patternType: &typeInvalid,
+			errorString: `unrecognized patternType "invalid"`,
+		}, {
+			version:     "V3",
+			patternType: nil,
+			errorString: `unrecognized version: want "V1" or "V2", got "V3"`,
+		}}
+
+		for _, tc := range cases {
+			t.Run("", func(t *testing.T) {
+				_, err := detectSearchType(tc.version, tc.patternType)
+				require.Error(t, err)
+				require.Equal(t, tc.errorString, err.Error())
+			})
+		}
+	})
 }


### PR DESCRIPTION
When a user enters an invalid patterntype, the formatting directive `%v` does not actually show the string contents of the pointer, [just the pointer value](https://play.golang.com/p/slSIW5y0cwq). These end up being user-facing errors, so they should look nice.

[Slack thread](https://sourcegraph.slack.com/archives/C014ZCKMCAV/p1651834160603549?thread_ts=1651828515.436109&cid=C014ZCKMCAV)

## Test plan

Added a probably-unnecessary test for the formatting of the errors in this function, but since they are user-facing, seemed maybe worth the few lines.

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


