### PR TITLE
Product Education: Add some redirect links to address recent doc changes

### DIFF
--- a/doc/_resources/assets/redirects
+++ b/doc/_resources/assets/redirects
@@ -263,3 +263,7 @@
 /admin/install/managed /admin/deploy/managed 308
 /admin/install/migrate-backup /admin/deploy/migrate-backup 308
 /admin/install/resource_estimator /admin/deploy/resource_estimator 308
+
+/admin/install/cluster.md /admin/deploy 308
+
+/admin/deploy/docker /admin/deploy/docker-single-container 308

--- a/doc/_resources/assets/redirects
+++ b/doc/_resources/assets/redirects
@@ -265,5 +265,6 @@
 /admin/install/resource_estimator /admin/deploy/resource_estimator 308
 
 /admin/install/cluster.md /admin/deploy 308
+/admin/deploy/cluster /admin/deploy 308
 
 /admin/deploy/docker /admin/deploy/docker-single-container 308


### PR DESCRIPTION
There were a number of recent doc changes to the folder structure (install -> deploy). Impact is mostly to some very old links to Cluster deployment, and related to a change from docker to docker-single-container. This created a few odd areas where existing redirect might not work including some related to batch changes. Added a couple of redirects to address this.

## Test plan

Tested redirects locally.

