### PR TITLE
Code monitors: ignore context errors

### DIFF
--- a/enterprise/internal/codemonitors/search.go
+++ b/enterprise/internal/codemonitors/search.go
@@ -253,6 +253,8 @@ func hookWithID(
 
 	// Execute the search
 	err = doSearch(&argsCopy)
+	// ignore any errors from early cancellation
+	err = errors.Ignore(err, errors.IsContextError)
 	if err != nil {
 		return err
 	}

--- a/lib/errors/filter.go
+++ b/lib/errors/filter.go
@@ -49,4 +49,14 @@ func IsPred(target error) ErrorPredicate {
 	}
 }
 
-var IsContextCanceled = IsPred(context.Canceled)
+func IsContextCanceled(err error) bool {
+	return Is(err, context.Canceled)
+}
+
+func IsDeadlineExceeded(err error) bool {
+	return Is(err, context.DeadlineExceeded)
+}
+
+func IsContextError(err error) bool {
+	return IsAny(err, context.Canceled, context.DeadlineExceeded)
+}


### PR DESCRIPTION
This ignores any context errors when determining whether to save the 
commit hashes currently being searched. This just protects us from retry
loops when a chunk of commits is too many to search without hitting timeout
or we hit the result limit. In both of these (rare) cases, it's preferable to continue
working rather than breaking.

## Test plan

Tested that monitor retry loops no longer happen from context errors. Retries will
still happen with any hard error.

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


