### PR TITLE
batches: update PAT label for Bitbucket Cloud

### DIFF
--- a/client/web/src/enterprise/batches/settings/AddCredentialModal.tsx
+++ b/client/web/src/enterprise/batches/settings/AddCredentialModal.tsx
@@ -134,6 +134,9 @@ export const AddCredentialModal: React.FunctionComponent<React.PropsWithChildren
         ]
     )
 
+    const patLabel =
+        externalServiceKind === ExternalServiceKind.BITBUCKETCLOUD ? 'App password' : 'Personal access token'
+
     return (
         <Modal onDismiss={onCancel} aria-labelledby={labelId}>
             <div className="test-add-credential-modal">
@@ -191,7 +194,7 @@ export const AddCredentialModal: React.FunctionComponent<React.PropsWithChildren
                                         />
                                     </>
                                 )}
-                                <label htmlFor="token">Personal access token</label>
+                                <label htmlFor="token">{patLabel}</label>
                                 <input
                                     id="token"
                                     name="token"
@@ -209,9 +212,9 @@ export const AddCredentialModal: React.FunctionComponent<React.PropsWithChildren
                                         to={HELP_TEXT_LINK_URL}
                                         rel="noreferrer noopener"
                                         target="_blank"
-                                        aria-label="Follow our docs to learn how to create a new access token on this code host"
+                                        aria-label={`Follow our docs to learn how to create a new ${patLabel.toLocaleLowerCase()} on this code host`}
                                     >
-                                        Create a new access token
+                                        Create a new {patLabel.toLocaleLowerCase()}
                                     </Link>{' '}
                                     {scopeRequirements[externalServiceKind]}
                                 </p>


### PR DESCRIPTION
As noticed [by @eseliger in Slack](https://sourcegraph.slack.com/archives/C01LJ9DK8ES/p1651774785020759), we weren't using the right terminology for Bitbucket Cloud.

## Test plan

Ran through the usual workflows on my local development instance for multiple code host kinds to create and update credentials.


## App preview:

- [Web](https://sg-web-aharvey-bb-cloud-label.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-gbkstqunll.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
