### PR TITLE
batches: Address race condition for search result paths

### DIFF
--- a/enterprise/internal/batches/service/workspace_resolver.go
+++ b/enterprise/internal/batches/service/workspace_resolver.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/gobwas/glob"
 	"github.com/grafana/regexp"
+	"github.com/inconshreveable/log15"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/store"
 	btypes "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
@@ -315,8 +316,18 @@ func (wr *workspaceResolver) resolveRepositoriesMatchingQuery(ctx context.Contex
 	query = setDefaultQueryCount(query)
 
 	repoIDs := []api.RepoID{}
+	repoRevisions := make(map[api.RepoID]string)
 	repoFileMatches := make(map[api.RepoID]map[string]bool)
-	addRepoFilePatch := func(repoID api.RepoID, path string) {
+	addRepoFilePatch := func(repoID api.RepoID, commit, path string) {
+		if knownRev, ok := repoRevisions[repoID]; ok && knownRev != commit {
+			log15.Warn("Got repo results for multiple commits, this is unexpected", "repo", repoID, "rev1", knownRev, "rev2", commit)
+			// And live on and overwrite the known revision.
+			// TODO: Can this happen when the repo has multiple searchable branches.
+			repoRevisions[repoID] = commit
+		} else {
+			repoRevisions[repoID] = commit
+		}
+
 		repoMap, ok := repoFileMatches[repoID]
 		if !ok {
 			repoMap = make(map[string]bool)
@@ -333,13 +344,13 @@ func (wr *workspaceResolver) resolveRepositoriesMatchingQuery(ctx context.Contex
 				repoIDs = append(repoIDs, api.RepoID(m.RepositoryID))
 			case *streamhttp.EventContentMatch:
 				repoIDs = append(repoIDs, api.RepoID(m.RepositoryID))
-				addRepoFilePatch(api.RepoID(m.RepositoryID), m.Path)
+				addRepoFilePatch(api.RepoID(m.RepositoryID), m.Commit, m.Path)
 			case *streamhttp.EventPathMatch:
 				repoIDs = append(repoIDs, api.RepoID(m.RepositoryID))
-				addRepoFilePatch(api.RepoID(m.RepositoryID), m.Path)
+				addRepoFilePatch(api.RepoID(m.RepositoryID), m.Commit, m.Path)
 			case *streamhttp.EventSymbolMatch:
 				repoIDs = append(repoIDs, api.RepoID(m.RepositoryID))
-				addRepoFilePatch(api.RepoID(m.RepositoryID), m.Path)
+				addRepoFilePatch(api.RepoID(m.RepositoryID), m.Commit, m.Path)
 			}
 		}
 	}); err != nil {
@@ -366,6 +377,7 @@ func (wr *workspaceResolver) resolveRepositoriesMatchingQuery(ctx context.Contex
 			fileMatches = append(fileMatches, path)
 		}
 		sort.Strings(fileMatches)
+
 		rev, err := repoToRepoRevisionWithDefaultBranch(ctx, database.NewDBWith(wr.store), repo, fileMatches)
 		if err != nil {
 			// There is an edge-case where a repo might be returned by a search query that does not exist in gitserver yet.
@@ -373,6 +385,14 @@ func (wr *workspaceResolver) resolveRepositoriesMatchingQuery(ctx context.Contex
 				continue
 			}
 			return nil, err
+		}
+		// If we have searched a different commit than the default branch commit, we overwrite it here.
+		// There can be cases where indexed search lags behind latest main and then the search result paths
+		// can be incorrect for the latest head of the repo.
+		// TODO: This is not ideal. It does not verify the commit is actually part of the default branch.
+		// What if the user searched a different branch?
+		if commit, ok := repoRevisions[repo.ID]; ok {
+			rev.Commit = api.CommitID(commit)
 		}
 		revs = append(revs, rev)
 	}


### PR DESCRIPTION
Indexed search is constantly playing catch up with commits being pushed to repos. Now, when I add a new commit, it takes a couple seconds to minutes (depending on the repo) until the latest commit is actually indexed and hence searched when running a search. We knew there can be discrepancies between search results when the preview ran and when the execution starts, so we do persist the commit hash along with the search result paths, but we do not take the commit from the search result, we simply take latest commit on HEAD. So there’s this discrepancy between commits while zoekt indexes, where running the search and fetching latest head for a repo returns results for different states.

That can likely be fixed - played around with it a little in this PR.
But it also raised two more questions - what if there are multiple searchable branches configured for a repo, and what if a user does `r:repo@rev`. Those cases likely also won’t work with search result paths today.
More investigation to be done!



## Test plan

