### PR TITLE
fix vsce: open local copy and web on windows

### DIFF
--- a/client/vscode/CHANGELOG.md
+++ b/client/vscode/CHANGELOG.md
@@ -2,7 +2,15 @@
 
 The Sourcegraph extension uses major.EVEN_NUMBER.patch (eg. 2.0.1) for release versions and major.ODD_NUMBER.patch (eg. 2.1.1) for pre-release versions.
 
-## Next Release - 2.2.3
+## Next Release
+
+### Changes
+
+- Update Access Token headers setting method --thanks @ptxmac for the contribution! [issues/34338](https://github.com/sourcegraph/sourcegraph/issues/34338)
+
+### Fixes
+
+- Windows file path issue [issues/34788](https://github.com/sourcegraph/sourcegraph/issues/34788)
 
 ## 2.2.2
 

--- a/client/vscode/src/backend/requestGraphQl.ts
+++ b/client/vscode/src/backend/requestGraphQl.ts
@@ -24,33 +24,23 @@ export const requestGraphQLFromVSCode = async <R, V = object>(
             'Sourcegraph GraphQL Client has been invalidated due to instance URL change. Restart VS Code to fix.'
         )
     }
-
+    const sourcegraphURL = overrideSourcegraphURL || endpointSetting()
+    const accessToken = overrideAccessToken || accessTokenSetting()
     const nameMatch = request.match(/^\s*(?:query|mutation)\s+(\w+)/)
     const apiURL = `${GRAPHQL_URI}${nameMatch ? '?' + nameMatch[1] : ''}`
-    // load custom headers from user setting if any
     const customHeaders = endpointRequestHeadersSetting()
     // create a headers container based on the custom headers configuration if there are any
+    // then add Access Token to request header, contributed by @ptxmac!
     const headers = new Headers(customHeaders as HeadersInit)
-    const sourcegraphURL = overrideSourcegraphURL || endpointSetting()
-    const accessToken = accessTokenSetting()
-
-    // Add Access Token to request header
-    // Used to validate access token.
-    if (overrideAccessToken) {
-        headers.set('Authorization', `token ${overrideAccessToken}`)
-    } else if (accessToken) {
+    headers.set('Content-Type', 'application/json')
+    if (accessToken) {
         headers.set('Authorization', `token ${accessToken}`)
     }
-
-    headers.set('Content-Type', 'application/json')
-
     try {
         const url = new URL(apiURL, sourcegraphURL).href
-
         // Debt: intercepted requests in integration tests
         // have 0 status codes, so don't check in test environment.
         const checkFunction = process.env.IS_TEST ? <T>(value: T): T => value : checkOk
-
         const response = checkFunction(
             await fetch(url, {
                 body: JSON.stringify({
@@ -62,7 +52,6 @@ export const requestGraphQLFromVSCode = async <R, V = object>(
             })
         )
         // TODO request cancellation w/ VS Code cancellation tokens.
-
         // eslint-disable-next-line @typescript-eslint/return-await
         return response.json() as Promise<GraphQLResult<any>>
     } catch (error) {

--- a/client/vscode/src/file-system/commands.ts
+++ b/client/vscode/src/file-system/commands.ts
@@ -42,7 +42,7 @@ async function getLocalCopy(remoteUri: SourcegraphUri): Promise<vscode.TextDocum
         .then(result => result[0]?.path || null)
     // If basePath is not configured, we will try to find file in the current workspace
     const absolutePath = basePath
-        ? vscode.Uri.joinPath(vscode.Uri.parse(basePath), repoName, filePath)
+        ? vscode.Uri.file(vscode.Uri.joinPath(vscode.Uri.parse(basePath), repoName, filePath).path)
         : workspaceFilePath
         ? vscode.Uri.file(workspaceFilePath)
         : null
@@ -56,7 +56,7 @@ async function getLocalCopy(remoteUri: SourcegraphUri): Promise<vscode.TextDocum
         const workspaceFolderUri = vscode.workspace.getWorkspaceFolder(vscode.Uri.file(workspaceFilePath))?.uri
         if (workspaceFolderUri) {
             // go one level up and set that as the new basePath
-            const newBasePath = vscode.workspace.asRelativePath(vscode.Uri.joinPath(workspaceFolderUri, '../'))
+            const newBasePath = vscode.Uri.file(vscode.Uri.joinPath(workspaceFolderUri, '../').fsPath).path
             await vscode.workspace
                 .getConfiguration('sourcegraph')
                 .update('basePath', newBasePath, vscode.ConfigurationTarget.Global)
@@ -73,7 +73,6 @@ function getSelection(uri: SourcegraphUri, textDocument: vscode.TextDocument): v
     if (typeof uri?.position?.line !== 'undefined') {
         return offsetRange(uri.position.line, 0)
     }
-
     // There's no explicitly provided line number. Instead of focusing on the
     // first line (which usually contains lots of imports), we use a heuristic
     // to guess the location where the "main symbol" is defined (a
@@ -89,7 +88,6 @@ function getSelection(uri: SourcegraphUri, textDocument: vscode.TextDocument): v
             return new vscode.Range(position, position)
         }
     }
-
     return undefined
 }
 

--- a/client/vscode/src/link-commands/browserActionsNode.ts
+++ b/client/vscode/src/link-commands/browserActionsNode.ts
@@ -23,17 +23,20 @@ export async function browserActions(action: string, logRedirectEvent: (uri: str
             editor.selection.end.character
         )
     } else {
-        const repositoryInfo = await repoInfo(editor.document.uri.fsPath)
-        if (!repositoryInfo) {
-            return
-        }
-        const { remoteURL, branch, fileRelative } = repositoryInfo
-        const instanceUrl = vscode.workspace.getConfiguration('sourcegraph').get('url')
-        if (typeof instanceUrl === 'string') {
-            // construct sourcegraph url for current file
-            sourcegraphUrl =
-                getSourcegraphFileUrl(instanceUrl, remoteURL, branch, fileRelative.replaceAll('\\', '/'), editor) +
-                vsceUtms
+        try {
+            const repositoryInfo = await repoInfo(editor.document.uri.fsPath)
+            if (!repositoryInfo) {
+                await vscode.window.showErrorMessage('Failed to get info for this repository.')
+                return
+            }
+            const { remoteURL, branch, fileRelative } = repositoryInfo
+            const instanceUrl = vscode.workspace.getConfiguration('sourcegraph').get('url')
+            if (typeof instanceUrl === 'string') {
+                // construct sourcegraph url for current file
+                sourcegraphUrl = getSourcegraphFileUrl(instanceUrl, remoteURL, branch, fileRelative, editor) + vsceUtms
+            }
+        } catch (error) {
+            console.error(error)
         }
     }
     const decodedUri = decodeURIComponent(sourcegraphUrl)

--- a/client/vscode/src/link-commands/git-helpers.ts
+++ b/client/vscode/src/link-commands/git-helpers.ts
@@ -42,8 +42,9 @@ export async function repoInfo(filePath: string): Promise<RepositoryInfo | undef
         const fileDirectory = path.dirname(filePath)
         const repoRoot = await gitHelpers.rootDirectory(fileDirectory)
 
-        // Determine file path relative to repository root.
-        let fileRelative = filePath.slice(repoRoot.length + 1)
+        // Determine file path relative to repository root, then replace slashes
+        // as \\ does not work in Sourcegraphl links
+        const fileRelative = filePath.slice(repoRoot.length + 1).replace(/\\/g, '/')
 
         let { branch, remoteName } = await gitRemoteNameAndBranch(repoRoot, gitHelpers, log)
 
@@ -51,9 +52,6 @@ export async function repoInfo(filePath: string): Promise<RepositoryInfo | undef
 
         const remoteURL = await gitRemoteUrlWithReplacements(repoRoot, remoteName, gitHelpers, log)
 
-        if (process.platform === 'win32') {
-            fileRelative = fileRelative.replace(/\\/g, '/')
-        }
         return { remoteURL, branch, fileRelative, remoteName }
     } catch {
         return undefined


### PR DESCRIPTION
Close https://github.com/sourcegraph/sourcegraph/issues/34788 & https://github.com/sourcegraph/sourcegraph/pull/34389

## Issue 34788

The file path we retrieve from the configuration setting was not being parsed correctly in the final uri to open on Web:
![image](https://user-images.githubusercontent.com/68532117/167033352-471b1519-a642-4eca-92a4-ac6cee811e97.png)
![image](https://user-images.githubusercontent.com/68532117/167033369-8500167d-725c-4740-a66d-3151b70d13a8.png)

### Solution

Using the [VS Code URI File API ](https://github.com/sourcegraph/sourcegraph/pull/35035/files#diff-dbe64ba24c9d926a30cbc5e21de094a72618416f7ca8a20fdf92dfc6e3389903L45) to parse the file path has resolved the issue. It should now also work with all systems.

## Issue 34389

User @[ptxmac](https://github.com/ptxmac) has reported an issue related to how the access token is sent, and has suggested a fix in his [PR](https://github.com/sourcegraph/sourcegraph/pull/34389) that is blocked by build failing. 
I have merged his fix into this PR  

## Test plan



<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

Tested manually on both Windows and Mac.

Follow the guide here to set up a testing environment to test this build: https://github.com/sourcegraph/sourcegraph/blob/main/client/vscode/CONTRIBUTING.md#build-and-run

## App preview:

- [Web](https://sg-web-bee-vsce-windows-localcopy.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-evrtxhibxi.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

