### PR TITLE
lint: Add lint for incorrect Go compiler directives.

### DIFF
--- a/dev/check/all.sh
+++ b/dev/check/all.sh
@@ -15,6 +15,7 @@ CHECKS=(
   ./template-inlines.sh
   ./go-enterprise-import.sh
   ./go-dbconn-import.sh
+  ./go-directive.sh
   ./go-generate.sh
   ./go-lint.sh
   ./no-localhost-guard.sh

--- a/dev/check/go-directive.sh
+++ b/dev/check/go-directive.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+if git --no-pager grep -E '^// go:[a-z]+' -- '**.go'; then
+    echo "error: Go compiler directives must have no spaces between the // and 'go'"
+    exit 1
+fi


### PR DESCRIPTION
@jhchabran pointed out in the lang-go Slack channel today: ([Slack link](https://sourcegraph.slack.com/archives/C3B3SDBMY/p1651868973848439))

> Need a linter for those `// go:embed ...` directives that are silently ignored :oldmanyellsatcloud:. Damn space before in between  the `//` and `go:embed ...` every damn time, I forget it :facepalm:

As a [great man once said](https://www.youtube.com/watch?v=ZXsQAXx_ao0), don't let your dreams be dreams.

## Test plan

Manually ran the lint. It doesn't fail right now, but it flags errors if you remove the space from the regex.