### PR TITLE
batches: clean up detail page tabs

### DIFF
--- a/client/web/src/enterprise/batches/detail/BatchChangeDetailsTabs.tsx
+++ b/client/web/src/enterprise/batches/detail/BatchChangeDetailsTabs.tsx
@@ -139,14 +139,12 @@ export const BatchChangeDetailsTabs: React.FunctionComponent<React.PropsWithChil
                             <Icon className="text-muted mr-2" as={FileDocumentIcon} />
                             <span className="text-content" data-tab-content="Executions">
                                 Executions
-                            </span>{' '}
-                            <Badge
-                                variant={executingCount === 0 ? 'secondary' : 'warning'}
-                                pill={true}
-                                className="ml-1"
-                            >
-                                {executingCount} {batchChange.batchSpecs.pageInfo.hasNextPage && <>+</>}
-                            </Badge>
+                            </span>
+                            {executingCount > 0 && (
+                                <Badge variant="warning" pill={true} className="ml-2">
+                                    {executingCount} {batchChange.batchSpecs.pageInfo.hasNextPage && <>+</>}
+                                </Badge>
+                            )}
                         </span>
                     </BatchChangeTab>
                 )}

--- a/client/web/src/enterprise/batches/detail/BatchChangeDetailsTabs.tsx
+++ b/client/web/src/enterprise/batches/detail/BatchChangeDetailsTabs.tsx
@@ -106,18 +106,18 @@ export const BatchChangeDetailsTabs: React.FunctionComponent<React.PropsWithChil
             <BatchChangeTabList>
                 <BatchChangeTab index={0} name={TabName.Changesets}>
                     <span>
-                        <Icon className="text-muted mr-1" as={SourceBranchIcon} />
+                        <Icon className="text-muted mr-2" as={SourceBranchIcon} />
                         <span className="text-content" data-tab-content="Changesets">
                             Changesets
-                        </span>{' '}
-                        <Badge variant="secondary" pill={true} className="ml-1">
+                        </span>
+                        <Badge variant="secondary" pill={true} className="ml-2">
                             {batchChange.changesetsStats.total - batchChange.changesetsStats.archived}
                         </Badge>
                     </span>
                 </BatchChangeTab>
                 <BatchChangeTab index={1} name={TabName.Chart}>
                     <span>
-                        <Icon className="text-muted mr-1" as={ChartLineVariantIcon} />{' '}
+                        <Icon className="text-muted mr-2" as={ChartLineVariantIcon} />
                         <span className="text-content" data-tab-content="Burndown chart">
                             Burndown chart
                         </span>
@@ -126,7 +126,7 @@ export const BatchChangeDetailsTabs: React.FunctionComponent<React.PropsWithChil
                 {!isExecutionEnabled && (
                     <BatchChangeTab index={2} name={TabName.Spec}>
                         <span>
-                            <Icon className="text-muted mr-1" as={FileDocumentIcon} />{' '}
+                            <Icon className="text-muted mr-2" as={FileDocumentIcon} />
                             <span className="text-content" data-tab-content="Spec">
                                 Spec
                             </span>
@@ -136,7 +136,7 @@ export const BatchChangeDetailsTabs: React.FunctionComponent<React.PropsWithChil
                 {isExecutionEnabled && (
                     <BatchChangeTab index={2} name={TabName.Executions} customPath="/executions">
                         <span>
-                            <Icon className="text-muted mr-1" as={FileDocumentIcon} />{' '}
+                            <Icon className="text-muted mr-2" as={FileDocumentIcon} />
                             <span className="text-content" data-tab-content="Executions">
                                 Executions
                             </span>{' '}
@@ -152,22 +152,22 @@ export const BatchChangeDetailsTabs: React.FunctionComponent<React.PropsWithChil
                 )}
                 <BatchChangeTab index={3} name={TabName.Archived}>
                     <span>
-                        <Icon className="text-muted mr-1" as={ArchiveIcon} />{' '}
+                        <Icon className="text-muted mr-2" as={ArchiveIcon} />
                         <span className="text-content" data-tab-content="Archived">
                             Archived
-                        </span>{' '}
-                        <Badge variant="secondary" pill={true} className="ml-1">
+                        </span>
+                        <Badge variant="secondary" pill={true} className="ml-2">
                             {batchChange.changesetsStats.archived}
                         </Badge>
                     </span>
                 </BatchChangeTab>
                 <BatchChangeTab index={4} name={TabName.BulkOperations}>
                     <span>
-                        <Icon className="text-muted mr-1" as={MonitorStarIcon} />{' '}
+                        <Icon className="text-muted mr-2" as={MonitorStarIcon} />
                         <span className="text-content" data-tab-content="Bulk operations">
                             Bulk operations
-                        </span>{' '}
-                        <Badge variant="secondary" pill={true} className="ml-1">
+                        </span>
+                        <Badge variant="secondary" pill={true} className="ml-2">
                             {batchChange.bulkOperations.totalCount}
                         </Badge>
                     </span>


### PR DESCRIPTION
This PR does two things:
- Gets rid of usage of `' '` for spacing, replacing it with larger margins (characters can render inconsistently across environments, whereas margin enforces consistency)
- Hides the executions count badge when there aren't any active executions (I think this feels a bit more natural than seeing it a 0 most of the time)


![Screen Shot 2022-05-07 at 5 22 44 PM](https://user-images.githubusercontent.com/8942601/167276489-5dda6130-0fb1-4c26-8c2b-448fbfb025ec.png)


## Test plan

This screen is covered by storybook stories as well as Chromatic diffing. It should report a diff for exactly what I have changed here.

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->



## App preview:

- [Web](https://sg-web-kr-clean-up-tabs.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-ginqxzxcif.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
