### PR TITLE
Migrations <Icon /> accessibility: `client/browser`, `client/branded`, `client/jetbrains`, `client/vscode`

### DIFF
--- a/client/branded/src/components/panel/TabbedPanelContent.tsx
+++ b/client/branded/src/components/panel/TabbedPanelContent.tsx
@@ -325,7 +325,7 @@ export const TabbedPanelContent = React.memo<TabbedPanelContentProps>(props => {
                             data-tooltip="Close panel"
                             data-placement="left"
                         >
-                            <Icon as={CloseIcon} />
+                            <Icon role="img" as={CloseIcon} aria-hidden={true} />
                         </Button>
                     </div>
                 }

--- a/client/branded/src/components/panel/views/EmptyPanelView.tsx
+++ b/client/branded/src/components/panel/views/EmptyPanelView.tsx
@@ -18,7 +18,7 @@ export const EmptyPanelView: React.FunctionComponent<React.PropsWithChildren<Emp
         <div className={classNames(styles.emptyPanel, className)}>
             {children || (
                 <>
-                    <Icon className="mr-2" as={CancelIcon} /> Nothing to show here
+                    <Icon role="img" className="mr-2" as={CancelIcon} aria-hidden={true} /> Nothing to show here
                 </>
             )}
         </div>

--- a/client/branded/src/components/panel/views/ExtensionsLoadingView.tsx
+++ b/client/branded/src/components/panel/views/ExtensionsLoadingView.tsx
@@ -19,7 +19,7 @@ export const ExtensionsLoadingPanelView: React.FunctionComponent<
         <EmptyPanelView className={className}>
             <LoadingSpinner inline={false} />
             <span className="mx-2">Loading Sourcegraph extensions</span>
-            <Icon as={PuzzleIcon} />
+            <Icon role="img" as={PuzzleIcon} aria-hidden={true} />
         </EmptyPanelView>
     )
 }

--- a/client/branded/src/components/panel/views/FileLocations.tsx
+++ b/client/branded/src/components/panel/views/FileLocations.tsx
@@ -31,13 +31,13 @@ export const FileLocationsError: React.FunctionComponent<React.PropsWithChildren
 
 export const FileLocationsNotFound: React.FunctionComponent<React.PropsWithChildren<unknown>> = () => (
     <div className={classNames('m-2', styles.notFound)}>
-        <Icon as={MapSearchIcon} /> No locations found
+        <Icon role="img" as={MapSearchIcon} aria-hidden={true} /> No locations found
     </div>
 )
 
 export const FileLocationsNoGroupSelected: React.FunctionComponent<React.PropsWithChildren<unknown>> = () => (
     <div className="m-2">
-        <Icon as={MapSearchIcon} /> No locations found in the current repository
+        <Icon role="img" as={MapSearchIcon} aria-hidden={true} /> No locations found in the current repository
     </div>
 )
 

--- a/client/browser/src/browser-extension/after-install-page/AfterInstallPageContent.tsx
+++ b/client/browser/src/browser-extension/after-install-page/AfterInstallPageContent.tsx
@@ -61,7 +61,7 @@ export const AfterInstallPageContent: React.FunctionComponent<React.PropsWithChi
                     <SourcegraphLogo className={styles.sourcegraphLogo} />
                 </Link>
                 <Link to="https://docs.sourcegraph.com/integration/browser_extension" target="_blank" rel="noopener">
-                    Browser extension docs <Icon as={ExternalLinkIcon} />
+                    Browser extension docs <Icon role="img" as={ExternalLinkIcon} aria-hidden={true} />
                 </Link>
             </div>
 
@@ -104,25 +104,56 @@ export const AfterInstallPageContent: React.FunctionComponent<React.PropsWithChi
                             <h2 className="mb-4">Make it work on your codehost</h2>
                             <div className="bg-2 rounded p-3 mb-3 d-flex flex-column justify-content-center">
                                 <h3 className={classNames('mb-3', styles.codeHostTitles)}>
-                                    <Icon className={styles.codeHostLogo} as={GithubIcon} /> github.com
+                                    <Icon
+                                        role="img"
+                                        className={styles.codeHostLogo}
+                                        as={GithubIcon}
+                                        title="Github logo"
+                                    />{' '}
+                                    github.com
                                 </h3>
                                 <p className="m-0">
-                                    <Icon as={CheckIcon} /> No action required.Your extension works here by default.
+                                    <Icon role="img" as={CheckIcon} aria-hidden={true} /> No action required.Your
+                                    extension works here by default.
                                 </p>
                             </div>
                             <div className="bg-2 rounded p-3 d-flex flex-column justify-content-center">
                                 <h3 className={classNames('d-flex flex-wrap', styles.codeHostTitles)}>
                                     <div className="mr-5 mb-3">
-                                        <Icon className={styles.codeHostLogo} as={GithubIcon} /> GitHub Enterprise
+                                        <Icon
+                                            role="img"
+                                            className={styles.codeHostLogo}
+                                            as={GithubIcon}
+                                            aria-hidden={true}
+                                        />{' '}
+                                        GitHub Enterprise
                                     </div>
                                     <div className="mr-5 mb-3">
-                                        <Icon className={styles.codeHostLogo} as={GitlabIcon} /> GitLab
+                                        <Icon
+                                            role="img"
+                                            className={styles.codeHostLogo}
+                                            as={GitlabIcon}
+                                            aria-hidden={true}
+                                        />{' '}
+                                        GitLab
                                     </div>
                                     <div className="mr-5 mb-3">
-                                        <Icon className={styles.codeHostLogo} as={BitbucketIcon} /> Bitbucket Server
+                                        <Icon
+                                            role="img"
+                                            className={styles.codeHostLogo}
+                                            as={BitbucketIcon}
+                                            aria-hidden={true}
+                                        />{' '}
+                                        Bitbucket Server
                                     </div>
                                     <div className="mr-5 mb-3">
-                                        <Icon className={styles.codeHostLogo} as={PhabricatorIcon} /> Phabricator
+                                        <Icon
+                                            role="img"
+                                            className={styles.codeHostLogo}
+                                            as={PhabricatorIcon}
+                                            aria-hidden={true}
+                                        />{' '}
+                                        Phabricator
                                     </div>
                                 </h3>
                                 <p>Your extension needs explicit permissions to your code host:</p>
@@ -160,7 +191,7 @@ export const AfterInstallPageContent: React.FunctionComponent<React.PropsWithChi
                             <p>By default, the browser extension works only for public code.</p>
                             <div className="d-flex align-items-center">
                                 <div className="bg-3 rounded-circle p-2">
-                                    <Icon as={LockIcon} />
+                                    <Icon role="img" as={LockIcon} aria-hidden={true} />
                                 </div>
                                 <p className="m-0 ml-3">
                                     To use the browser extension with your private repositories, you need to set up a{' '}
@@ -208,7 +239,7 @@ export const AfterInstallPageContent: React.FunctionComponent<React.PropsWithChi
                     <h2 className="mb-4">Additional resources</h2>
                     <div className="d-flex w-100 align-items-center">
                         <div className="bg-3 rounded-circle p-2">
-                            <Icon as={BookOpenPageVariantIcon} />
+                            <Icon role="img" as={BookOpenPageVariantIcon} aria-hidden={true} />
                         </div>
                         <p className="m-0 ml-3">
                             Read the{' '}

--- a/client/browser/src/browser-extension/after-install-page/AfterInstallPageContent.tsx
+++ b/client/browser/src/browser-extension/after-install-page/AfterInstallPageContent.tsx
@@ -108,7 +108,7 @@ export const AfterInstallPageContent: React.FunctionComponent<React.PropsWithChi
                                         role="img"
                                         className={styles.codeHostLogo}
                                         as={GithubIcon}
-                                        title="Github logo"
+                                        aria-hidden={true}
                                     />{' '}
                                     github.com
                                 </h3>

--- a/client/browser/src/browser-extension/options-menu/OptionsPage.tsx
+++ b/client/browser/src/browser-extension/options-menu/OptionsPage.tsx
@@ -159,13 +159,13 @@ export const OptionsPage: React.FunctionComponent<React.PropsWithChildren<Option
             <section className="d-flex">
                 <div className={styles.splitSectionPart}>
                     <Link to="https://sourcegraph.com/search" {...NEW_TAB_LINK_PROPS}>
-                        <Icon className="mr-2" as={EarthIcon} />
+                        <Icon role="img" className="mr-2" as={EarthIcon} aria-hidden={true} />
                         Sourcegraph Cloud
                     </Link>
                 </div>
                 <div className={styles.splitSectionPart}>
                     <Link to="https://docs.sourcegraph.com" {...NEW_TAB_LINK_PROPS}>
-                        <Icon className="mr-2" as={BookOpenPageVariantIcon} />
+                        <Icon role="img" className="mr-2" as={BookOpenPageVariantIcon} aria-hidden={true} />
                         Documentation
                     </Link>
                 </div>
@@ -187,7 +187,7 @@ const PermissionAlert: React.FunctionComponent<React.PropsWithChildren<Permissio
 }) => (
     <section className={classNames('bg-2', styles.section)}>
         <h4>
-            {AlertIcon && <Icon className="mr-2" as={AlertIcon} />} <span>{name}</span>
+            {AlertIcon && <Icon role="img" className="mr-2" as={AlertIcon} aria-hidden={true} />} <span>{name}</span>
         </h4>
         <p className={styles.permissionText}>
             <strong>Grant permissions</strong> to use the Sourcegraph extension on {name}.
@@ -213,7 +213,7 @@ const RepoSyncErrorAlert: React.FunctionComponent<
     return (
         <section className={classNames('bg-2', styles.section)}>
             <h4>
-                <Icon className="mr-2" as={isDefaultURL ? LockIcon : BlockHelperIcon} />
+                <Icon role="img" aria-hidden={true} className="mr-2" as={isDefaultURL ? LockIcon : BlockHelperIcon} />
                 {isDefaultURL ? 'Private repository' : 'Repository not found'}
             </h4>
             <p className="mb-0">
@@ -263,7 +263,7 @@ const RepoSyncErrorAlert: React.FunctionComponent<
 const SourcegraphCloudAlert: React.FunctionComponent<React.PropsWithChildren<unknown>> = () => (
     <section className={classNames('bg-2', styles.section)}>
         <h4>
-            <Icon className="mr-2" as={CheckCircleOutlineIcon} />
+            <Icon aria-hidden={true} role="img" className="mr-2" as={CheckCircleOutlineIcon} />
             You're on Sourcegraph Cloud
         </h4>
         <p>Naturally, the browser extension is not necessary to browse public code on sourcegraph.com.</p>

--- a/client/browser/src/browser-extension/options-menu/OptionsPage.tsx
+++ b/client/browser/src/browser-extension/options-menu/OptionsPage.tsx
@@ -263,7 +263,7 @@ const RepoSyncErrorAlert: React.FunctionComponent<
 const SourcegraphCloudAlert: React.FunctionComponent<React.PropsWithChildren<unknown>> = () => (
     <section className={classNames('bg-2', styles.section)}>
         <h4>
-            <Icon aria-hidden={true} role="img" className="mr-2" as={CheckCircleOutlineIcon} />
+            <Icon role="img" aria-hidden={true} className="mr-2" as={CheckCircleOutlineIcon} />
             You're on Sourcegraph Cloud
         </h4>
         <p>Naturally, the browser extension is not necessary to browse public code on sourcegraph.com.</p>

--- a/client/jetbrains/webview/src/search/results/FileSearchResult.tsx
+++ b/client/jetbrains/webview/src/search/results/FileSearchResult.tsx
@@ -59,7 +59,7 @@ export const FileSearchResult: React.FunctionComponent<Props> = ({
         // eslint-disable-next-line jsx-a11y/no-static-element-interactions
         <div className={styles.header} onMouseDown={preventAll}>
             <div className={classNames(styles.headerTitle)} data-testid="result-container-header">
-                <Icon className="flex-shrink-0" as={FileDocumentIcon} />
+                <Icon role="img" title="Search result file path" className="flex-shrink-0" as={FileDocumentIcon} />
                 <div className={classNames('mx-1', styles.headerDivider)} />
                 <RepoIcon repoName={result.repository} className="text-muted flex-shrink-0" />
                 <RepoFileLink

--- a/client/jetbrains/webview/src/search/results/FileSearchResult.tsx
+++ b/client/jetbrains/webview/src/search/results/FileSearchResult.tsx
@@ -59,7 +59,7 @@ export const FileSearchResult: React.FunctionComponent<Props> = ({
         // eslint-disable-next-line jsx-a11y/no-static-element-interactions
         <div className={styles.header} onMouseDown={preventAll}>
             <div className={classNames(styles.headerTitle)} data-testid="result-container-header">
-                <Icon role="img" title="Search result file path" className="flex-shrink-0" as={FileDocumentIcon} />
+                <Icon role="img" title="File" className="flex-shrink-0" as={FileDocumentIcon} />
                 <div className={classNames('mx-1', styles.headerDivider)} />
                 <RepoIcon repoName={result.repository} className="text-muted flex-shrink-0" />
                 <RepoFileLink

--- a/client/vscode/src/webview/search-panel/RepoView.tsx
+++ b/client/vscode/src/webview/search-panel/RepoView.tsx
@@ -134,7 +134,7 @@ export const RepoView: React.FunctionComponent<React.PropsWithChildren<RepoViewP
                                     <span>
                                         <Icon
                                             role="img"
-                                            aria-hidden={true}
+                                            title={entry.isDirectory ? 'Folder' : 'File'}
                                             className="mr-1 text-muted"
                                             as={entry.isDirectory ? FolderOutlineIcon : FileDocumentOutlineIcon}
                                         />

--- a/client/vscode/src/webview/search-panel/RepoView.tsx
+++ b/client/vscode/src/webview/search-panel/RepoView.tsx
@@ -86,7 +86,7 @@ export const RepoView: React.FunctionComponent<React.PropsWithChildren<RepoViewP
                 onClick={onBackToSearchResults}
                 className="test-back-to-search-view-btn btn btn-sm btn-link btn-outline-secondary text-decoration-none border-0"
             >
-                <Icon className="mr-1" as={ArrowLeftIcon} />
+                <Icon role="img" aria-hidden={true} className="mr-1" as={ArrowLeftIcon} />
                 Back to search view
             </button>
             {directoryStack.length > 0 && (
@@ -95,7 +95,7 @@ export const RepoView: React.FunctionComponent<React.PropsWithChildren<RepoViewP
                     onClick={onPreviousDirectory}
                     className="btn btn-sm btn-link btn-outline-secondary text-decoration-none border-0"
                 >
-                    <Icon className="mr-1" as={ArrowLeftIcon} />
+                    <Icon role="img" aria-hidden={true} className="mr-1" as={ArrowLeftIcon} />
                     Back to previous directory
                 </button>
             )}
@@ -132,12 +132,12 @@ export const RepoView: React.FunctionComponent<React.PropsWithChildren<RepoViewP
                                     )}
                                 >
                                     <span>
-                                        {entry.isDirectory && (
-                                            <Icon className="mr-1 text-muted" as={FolderOutlineIcon} />
-                                        )}
-                                        {!entry.isDirectory && (
-                                            <Icon className="mr-1 text-muted" as={FileDocumentOutlineIcon} />
-                                        )}
+                                        <Icon
+                                            role="img"
+                                            aria-hidden={true}
+                                            className="mr-1 text-muted"
+                                            as={entry.isDirectory ? FolderOutlineIcon : FileDocumentOutlineIcon}
+                                        />
                                         {entry.name}
                                         {entry.isDirectory && '/'}
                                     </span>

--- a/client/vscode/src/webview/search-panel/components/SearchResultsInfoBar.tsx
+++ b/client/vscode/src/webview/search-panel/components/SearchResultsInfoBar.tsx
@@ -73,7 +73,7 @@ const QuotesInterpretedLiterallyNotice: React.FunctionComponent<
             data-tooltip="Your search query is interpreted literally, including the quotes. Use the .* toggle to switch between literal and regular expression search."
         >
             <span>
-                <Icon className="mr-1" as={FormatQuoteOpenIcon} />
+                <Icon role="img" aria-hidden={true} className="mr-1" as={FormatQuoteOpenIcon} />
                 Searching literally <strong>(including quotes)</strong>
             </span>
         </small>
@@ -149,7 +149,7 @@ export const SearchResultsInfoBar: React.FunctionComponent<
                     }
                     button={
                         <>
-                            <Icon className="mr-1" as={CodeMonitoringLogo} />
+                            <Icon role="img" aria-hidden={true} className="mr-1" as={CodeMonitoringLogo} />
                             Monitor
                         </>
                     }
@@ -186,7 +186,7 @@ export const SearchResultsInfoBar: React.FunctionComponent<
                     className="test-save-search-link"
                     button={
                         <>
-                            <Icon className="mr-1" as={BookmarkOutlineIcon} />
+                            <Icon role="img" aria-hidden={true} className="mr-1" as={BookmarkOutlineIcon} />
                             Save search
                         </>
                     }
@@ -222,7 +222,7 @@ export const SearchResultsInfoBar: React.FunctionComponent<
                     className="btn btn-sm btn-outline-secondary text-decoration-none"
                     onClick={onShareResultsClick}
                 >
-                    <Icon className="mr-1" as={LinkIcon} />
+                    <Icon role="img" aria-hidden={true} className="mr-1" as={LinkIcon} />
                     Share
                 </button>
             </li>

--- a/client/vscode/src/webview/sidebars/history/components/RecentFilesSection.tsx
+++ b/client/vscode/src/webview/sidebars/history/components/RecentFilesSection.tsx
@@ -59,13 +59,15 @@ export const RecentFilesSection: React.FunctionComponent<React.PropsWithChildren
                 type="button"
                 className={classNames('btn btn-outline-secondary', styles.sidebarSectionCollapseButton)}
                 onClick={() => setCollapsed(!collapsed)}
+                aria-label="Expand recent files"
             >
                 <h5 className="flex-grow-1">Recent Files</h5>
-                {collapsed ? (
-                    <Icon className="mr-1" as={ChevronLeftIcon} />
-                ) : (
-                    <Icon className="mr-1" as={ChevronDownIcon} />
-                )}
+                <Icon
+                    role="img"
+                    aria-hidden={true}
+                    className="mr-1"
+                    as={collapsed ? ChevronLeftIcon : ChevronDownIcon}
+                />
             </button>
 
             {!collapsed && (

--- a/client/vscode/src/webview/sidebars/history/components/RecentFilesSection.tsx
+++ b/client/vscode/src/webview/sidebars/history/components/RecentFilesSection.tsx
@@ -59,7 +59,7 @@ export const RecentFilesSection: React.FunctionComponent<React.PropsWithChildren
                 type="button"
                 className={classNames('btn btn-outline-secondary', styles.sidebarSectionCollapseButton)}
                 onClick={() => setCollapsed(!collapsed)}
-                aria-label="Expand recent files"
+                aria-label={`${collapsed ? 'Expand' : 'Collapse'} recent files`}
             >
                 <h5 className="flex-grow-1">Recent Files</h5>
                 <Icon

--- a/client/vscode/src/webview/sidebars/history/components/RecentRepositoriesSection.tsx
+++ b/client/vscode/src/webview/sidebars/history/components/RecentRepositoriesSection.tsx
@@ -65,7 +65,7 @@ export const RecentRepositoriesSection: React.FunctionComponent<React.PropsWithC
                 type="button"
                 className={classNames('btn btn-outline-secondary', styles.sidebarSectionCollapseButton)}
                 onClick={() => setCollapsed(!collapsed)}
-                aria-label="Expand recent repositories"
+                aria-label={`${collapsed ? 'Expand' : 'Collapse'} recent files`}
             >
                 <h5 className="flex-grow-1">Recent Repositories</h5>
                 <Icon

--- a/client/vscode/src/webview/sidebars/history/components/RecentRepositoriesSection.tsx
+++ b/client/vscode/src/webview/sidebars/history/components/RecentRepositoriesSection.tsx
@@ -65,13 +65,15 @@ export const RecentRepositoriesSection: React.FunctionComponent<React.PropsWithC
                 type="button"
                 className={classNames('btn btn-outline-secondary', styles.sidebarSectionCollapseButton)}
                 onClick={() => setCollapsed(!collapsed)}
+                aria-label="Expand recent repositories"
             >
                 <h5 className="flex-grow-1">Recent Repositories</h5>
-                {collapsed ? (
-                    <Icon className="mr-1" as={ChevronLeftIcon} />
-                ) : (
-                    <Icon className="mr-1" as={ChevronDownIcon} />
-                )}
+                <Icon
+                    role="img"
+                    aria-hidden={true}
+                    className="mr-1"
+                    as={collapsed ? ChevronLeftIcon : ChevronDownIcon}
+                />
             </button>
 
             {!collapsed && (

--- a/client/vscode/src/webview/sidebars/history/components/RecentSearchesSection.tsx
+++ b/client/vscode/src/webview/sidebars/history/components/RecentSearchesSection.tsx
@@ -61,7 +61,7 @@ export const RecentSearchesSection: React.FunctionComponent<React.PropsWithChild
                 type="button"
                 className={classNames('btn btn-outline-secondary', styles.sidebarSectionCollapseButton)}
                 onClick={() => setCollapsed(!collapsed)}
-                aria-label="Expand recent searches"
+                aria-label={`${collapsed ? 'Expand' : 'Collapse'} recent searches`}
             >
                 <h5 className="flex-grow-1">Recent Searches</h5>
                 <Icon

--- a/client/vscode/src/webview/sidebars/history/components/RecentSearchesSection.tsx
+++ b/client/vscode/src/webview/sidebars/history/components/RecentSearchesSection.tsx
@@ -61,13 +61,15 @@ export const RecentSearchesSection: React.FunctionComponent<React.PropsWithChild
                 type="button"
                 className={classNames('btn btn-outline-secondary', styles.sidebarSectionCollapseButton)}
                 onClick={() => setCollapsed(!collapsed)}
+                aria-label="Expand recent searches"
             >
                 <h5 className="flex-grow-1">Recent Searches</h5>
-                {collapsed ? (
-                    <Icon className="mr-1" as={ChevronLeftIcon} />
-                ) : (
-                    <Icon className="mr-1" as={ChevronDownIcon} />
-                )}
+                <Icon
+                    role="img"
+                    className="mr-1"
+                    as={collapsed ? ChevronLeftIcon : ChevronDownIcon}
+                    aria-hidden={true}
+                />
             </button>
 
             {!collapsed && (

--- a/client/vscode/src/webview/sidebars/history/components/SavedSearchesSection.tsx
+++ b/client/vscode/src/webview/sidebars/history/components/SavedSearchesSection.tsx
@@ -89,13 +89,15 @@ export const SavedSearchesSection: React.FunctionComponent<React.PropsWithChildr
                 type="button"
                 className={classNames('btn btn-outline-secondary', styles.sidebarSectionCollapseButton)}
                 onClick={() => setCollapsed(!collapsed)}
+                aria-label="Expand Collapse'} saved searches"
             >
                 <h5 className="flex-grow-1">Saved Searches</h5>
-                {collapsed ? (
-                    <Icon className="mr-1" as={ChevronLeftIcon} />
-                ) : (
-                    <Icon className="mr-1" as={ChevronDownIcon} />
-                )}
+                <Icon
+                    role="img"
+                    aria-hidden={true}
+                    className="mr-1"
+                    as={collapsed ? ChevronLeftIcon : ChevronDownIcon}
+                />
             </button>
 
             {!collapsed && savedSearches && (

--- a/client/vscode/src/webview/sidebars/history/components/SavedSearchesSection.tsx
+++ b/client/vscode/src/webview/sidebars/history/components/SavedSearchesSection.tsx
@@ -89,7 +89,7 @@ export const SavedSearchesSection: React.FunctionComponent<React.PropsWithChildr
                 type="button"
                 className={classNames('btn btn-outline-secondary', styles.sidebarSectionCollapseButton)}
                 onClick={() => setCollapsed(!collapsed)}
-                aria-label="Expand Collapse'} saved searches"
+                aria-label={`${collapsed ? 'Expand' : 'Collapse'} saved searches`}
             >
                 <h5 className="flex-grow-1">Saved Searches</h5>
                 <Icon

--- a/client/wildcard/src/components/Icon/Icon.story.tsx
+++ b/client/wildcard/src/components/Icon/Icon.story.tsx
@@ -34,9 +34,9 @@ export default config
 export const Simple: Story = () => (
     <>
         <h3>Small Icon</h3>
-        <Icon as={SourcegraphIcon} size="sm" />
+        <Icon as={SourcegraphIcon} size="sm" title="Sourcegraph logo" />
 
         <h3>Medium Icon</h3>
-        <Icon as={SourcegraphIcon} size="md" />
+        <Icon as={SourcegraphIcon} size="md" title="Sourcegraph logo" />
     </>
 )

--- a/client/wildcard/src/components/Icon/Icon.tsx
+++ b/client/wildcard/src/components/Icon/Icon.tsx
@@ -9,7 +9,7 @@ import { ICON_SIZES } from './constants'
 
 import styles from './Icon.module.scss'
 
-export interface IconProps extends Omit<MdiReactIconProps, 'children'> {
+interface BaseIconProps extends Omit<MdiReactIconProps, 'children'> {
     className?: string
     /**
      * The variant style of the icon. defaults to 'sm'
@@ -17,18 +17,27 @@ export interface IconProps extends Omit<MdiReactIconProps, 'children'> {
     size?: typeof ICON_SIZES[number]
 }
 
+interface ScreenReaderIconProps extends BaseIconProps {
+    title?: string
+}
+
+interface HiddenIconProps extends BaseIconProps {
+    'aria-hidden'?: true | 'true'
+}
+
+// We're currently migrating our icons to provide a descriptive label or use aria-hidden to be excluded from screen readers.
+// Migration issue: https://github.com/sourcegraph/sourcegraph/issues/34582
+// TODO: We should enforce that these props are provided once that migration is complete.
+export type IconProps = HiddenIconProps | ScreenReaderIconProps
+
 export const Icon = React.forwardRef((props, reference) => {
-    // TODO: role should have a default value of "img", but most of our Icons don't
-    // provide an aria-label, title, or other form of alternative text, and so setting it
-    // causes accessibility audits to fail in our integration test suite. Once we've added
-    // text to all of our icons, we should restore this as the default value.
-    // const { children, inline = true, className, size, as: Component = 'svg', role = 'img', ...attributes } = props
-    const { children, inline = true, className, size, as: Component = 'svg', ...attributes } = props
+    const { children, inline = true, className, size, as: Component = 'svg', role, ...attributes } = props
 
     return (
         <Component
             className={classNames(styles.iconInline, size === 'md' && styles.iconInlineMd, className)}
             ref={reference}
+            role={role}
             {...attributes}
         >
             {children}


### PR DESCRIPTION
## Description
Our Icon component is not currently accessible and will cause issues across our application.
Screen readers will report each icon as "unlabelled image" - which isn't helpful to anyone.

Migrate the rest of the codebase to use either title or aria-hidden="true"

## Expected behavior
For decorative icons, we should set aria-hidden="true". This will ensure screen readers completely ignore the icon, as it adds no value to the user journey.

For icons that add useful information to the page, we should set role="img" and title="Some descriptive text". This will ensure screen readers are able to properly understand to meaning of the icon.

## Ref
[SG Issue](https://github.com/sourcegraph/sourcegraph/issues/34961)
[Gitstart Ticket](https://app.gitstart.com/clients/sourcegraph/tickets/SG-34961)

## Implementation Detail
1. Add role="img" to <Icon /> and fix all of the integration test issues.
2. Migrate the rest of the codebase to use either title or aria-hidden="true" 

## Test Plan
Run integration tests to ensure that there are no unresolved accessibility issues reported

## Affected areas
1. `client/browser`
2. `client/branded`
3. `client/jetbrains`

## App preview:

- [Web](https://sg-web-contractors-sg-34961.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-osisixvcco.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
