### PR TITLE
Refactor dependencies source

### DIFF
--- a/cmd/gitserver/main.go
+++ b/cmd/gitserver/main.go
@@ -41,6 +41,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/auth"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/github"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/gomodproxy"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/npm"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/pypi"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
 	"github.com/sourcegraph/sourcegraph/internal/hostname"
@@ -450,7 +451,8 @@ func getVCSSyncer(
 		if err != nil {
 			return nil, err
 		}
-		return server.NewNpmPackagesSyncer(c, depsSvc, nil, urn), nil
+		cli := npm.NewHTTPClient(urn, c.Registry, c.Credentials, httpcli.ExternalDoer)
+		return server.NewNpmPackagesSyncer(c, depsSvc, cli), nil
 	case extsvc.TypeGoModules:
 		var c schema.GoModulesConnection
 		urn, err := extractOptions(&c)

--- a/cmd/gitserver/server/vcs_dependencies_syncer_test.go
+++ b/cmd/gitserver/server/vcs_dependencies_syncer_test.go
@@ -242,6 +242,11 @@ func (f fakeDep) GitTagFromVersion() string    { return "v" + f.version }
 func (f fakeDep) Less(other reposource.PackageDependency) bool {
 	return f.PackageManagerSyntax() > other.PackageManagerSyntax()
 }
+func (f fakeDep) Description() string { return f.name + "@" + f.version }
+func (f fakeDep) Metadata() interface{} {
+	pkg, _ := reposource.NewNpmPackage("", f.name)
+	return reposource.NpmMetadata{pkg}
+}
 
 func (s vcsDependenciesSyncer) runCloneCommand(t *testing.T, examplePackageURL, bareGitDirectory string, dependencies []string) {
 	u := vcs.URL{

--- a/cmd/gitserver/server/vcs_syncer_npm_packages.go
+++ b/cmd/gitserver/server/vcs_syncer_npm_packages.go
@@ -23,14 +23,8 @@ import (
 func NewNpmPackagesSyncer(
 	connection schema.NpmPackagesConnection,
 	svc *dependencies.Service,
-	customClient npm.Client,
-	urn string,
+	client npm.Client,
 ) VCSSyncer {
-	var client = customClient
-	if client == nil {
-		client = npm.NewHTTPClient(urn, connection.Registry, connection.Credentials)
-	}
-
 	placeholder, err := reposource.ParseNpmDependency("@sourcegraph/placeholder@1.0.0")
 	if err != nil {
 		panic(fmt.Sprintf("expected placeholder package to parse but got %v", err))

--- a/cmd/gitserver/server/vcs_syncer_npm_packages_test.go
+++ b/cmd/gitserver/server/vcs_syncer_npm_packages_test.go
@@ -106,7 +106,6 @@ func TestNpmCloneCommand(t *testing.T) {
 		schema.NpmPackagesConnection{Dependencies: []string{}},
 		depsSvc,
 		&client,
-		"urn",
 	).(*vcsDependenciesSyncer)
 
 	bareGitDirectory := path.Join(dir, "git")

--- a/cmd/repo-updater/repoupdater/server_test.go
+++ b/cmd/repo-updater/repoupdater/server_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/awscodecommit"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/github"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/gitlab"
-	"github.com/sourcegraph/sourcegraph/internal/extsvc/npm/npmpackages"
 	"github.com/sourcegraph/sourcegraph/internal/repos"
 	"github.com/sourcegraph/sourcegraph/internal/repoupdater"
 	"github.com/sourcegraph/sourcegraph/internal/repoupdater/protocol"
@@ -364,7 +363,7 @@ func TestServer_RepoLookup(t *testing.T) {
 				CloneURL: "npm/package",
 			},
 		},
-		Metadata: &npmpackages.Metadata{Package: func() *reposource.NpmPackage {
+		Metadata: &reposource.NpmMetadata{Package: func() *reposource.NpmPackage {
 			p, _ := reposource.NewNpmPackage("", "package")
 			return p
 		}()},

--- a/internal/conf/reposource/go_modules.go
+++ b/internal/conf/reposource/go_modules.go
@@ -84,6 +84,8 @@ func (d *GoDependency) RepoName() api.RepoName {
 	return api.RepoName("go/" + d.Module.Path)
 }
 
+func (d *GoDependency) Description() string { return "" }
+
 func (d *GoDependency) GitTagFromVersion() string {
 	return d.Module.Version
 }

--- a/internal/conf/reposource/jvm_packages.go
+++ b/internal/conf/reposource/jvm_packages.go
@@ -47,6 +47,10 @@ func (m *MavenModule) LsifJavaKind() string {
 
 func (m *MavenModule) Description() string { return "" }
 
+type MavenMetadata struct {
+	Module *MavenModule
+}
+
 func (m *MavenModule) RepoName() api.RepoName {
 	if m.IsJDK() {
 		return "jdk"

--- a/internal/conf/reposource/jvm_packages.go
+++ b/internal/conf/reposource/jvm_packages.go
@@ -45,6 +45,8 @@ func (m *MavenModule) LsifJavaKind() string {
 	return "maven"
 }
 
+func (m *MavenModule) Description() string { return "" }
+
 func (m *MavenModule) RepoName() api.RepoName {
 	if m.IsJDK() {
 		return "jdk"

--- a/internal/conf/reposource/npm_packages.go
+++ b/internal/conf/reposource/npm_packages.go
@@ -192,6 +192,10 @@ func (d *NpmDependency) Description() string {
 	return d.PackageDescription
 }
 
+type NpmMetadata struct {
+	Package *NpmPackage
+}
+
 // PackageManagerSyntax returns the dependency in npm/Yarn syntax. The returned
 // string can (for example) be passed to `npm install`.
 func (d *NpmDependency) PackageManagerSyntax() string {

--- a/internal/conf/reposource/npm_packages.go
+++ b/internal/conf/reposource/npm_packages.go
@@ -152,6 +152,9 @@ type NpmDependency struct {
 
 	// The URL of the tarball to download. Possibly empty.
 	TarballURL string
+
+	// The description of the package. Possibly empty.
+	PackageDescription string
 }
 
 // ParseNpmDependency parses a string in a '(@scope/)?module@version' format into an NpmDependency.
@@ -183,6 +186,10 @@ func ParseNpmDependency(dependency string) (*NpmDependency, error) {
 	}
 	scope, name, version := result["scope"], result["name"], result["version"]
 	return &NpmDependency{NpmPackage: &NpmPackage{scope, name}, Version: version}, nil
+}
+
+func (d *NpmDependency) Description() string {
+	return d.PackageDescription
 }
 
 // PackageManagerSyntax returns the dependency in npm/Yarn syntax. The returned

--- a/internal/conf/reposource/package_dependency.go
+++ b/internal/conf/reposource/package_dependency.go
@@ -36,6 +36,11 @@ type PackageDependency interface {
 	// RepoName provides a name that is "globally unique" for a Sourcegraph instance.
 	// The returned value is used for repo:... in queries.
 	RepoName() api.RepoName
+
+	// Description provides a human readable description of the package's purpose.
+	// May be empty.
+	Description() string
+
 	// Returns the git tag associated with the given dependency version, used
 	// rev: or repo:foo@rev
 	GitTagFromVersion() string
@@ -48,4 +53,5 @@ var (
 	_ PackageDependency = (*MavenDependency)(nil)
 	_ PackageDependency = (*NpmDependency)(nil)
 	_ PackageDependency = (*GoDependency)(nil)
+	_ PackageDependency = (*PythonDependency)(nil)
 )

--- a/internal/conf/reposource/python_packages.go
+++ b/internal/conf/reposource/python_packages.go
@@ -64,6 +64,8 @@ func (p *PythonDependency) PackageVersion() string {
 	return p.Version
 }
 
+func (p *PythonDependency) Description() string { return "" }
+
 func (p *PythonDependency) RepoName() api.RepoName {
 	return api.RepoName("python/" + p.Name)
 }

--- a/internal/database/repos.go
+++ b/internal/database/repos.go
@@ -21,6 +21,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/internal/conf/reposource"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/env"
@@ -32,8 +33,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/github"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/gitlab"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/gitolite"
-	"github.com/sourcegraph/sourcegraph/internal/extsvc/jvmpackages"
-	"github.com/sourcegraph/sourcegraph/internal/extsvc/npm/npmpackages"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/pagure"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/perforce"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/phabricator"
@@ -494,9 +493,9 @@ func scanRepo(rows *sql.Rows, r *types.Repo) (err error) {
 	case extsvc.TypeOther:
 		r.Metadata = new(extsvc.OtherRepoMetadata)
 	case extsvc.TypeJVMPackages:
-		r.Metadata = new(jvmpackages.Metadata)
+		r.Metadata = new(reposource.MavenMetadata)
 	case extsvc.TypeNpmPackages:
-		r.Metadata = new(npmpackages.Metadata)
+		r.Metadata = new(reposource.NpmMetadata)
 	case extsvc.TypeGoModules:
 		r.Metadata = &struct{}{}
 	case extsvc.TypePythonPackages:

--- a/internal/extsvc/jvmpackages/repos.go
+++ b/internal/extsvc/jvmpackages/repos.go
@@ -1,7 +1,0 @@
-package jvmpackages
-
-import "github.com/sourcegraph/sourcegraph/internal/conf/reposource"
-
-type Metadata struct {
-	Module *reposource.MavenModule
-}

--- a/internal/extsvc/npm/npm.go
+++ b/internal/extsvc/npm/npm.go
@@ -94,7 +94,8 @@ func (client *HTTPClient) GetPackageInfo(ctx context.Context, pkg *reposource.Np
 }
 
 type DependencyInfo struct {
-	Dist DependencyInfoDist `json:"dist"`
+	Description string             `json:"description"`
+	Dist        DependencyInfoDist `json:"dist"`
 }
 
 type DependencyInfoDist struct {

--- a/internal/extsvc/npm/npm.go
+++ b/internal/extsvc/npm/npm.go
@@ -63,10 +63,10 @@ type HTTPClient struct {
 	credentials string
 }
 
-func NewHTTPClient(urn string, registryURL string, credentials string) *HTTPClient {
+func NewHTTPClient(urn string, registryURL string, credentials string, doer httpcli.Doer) *HTTPClient {
 	return &HTTPClient{
 		registryURL: registryURL,
-		doer:        httpcli.ExternalDoer,
+		doer:        doer,
 		limiter:     ratelimit.DefaultRegistry.Get(urn),
 		credentials: credentials,
 	}

--- a/internal/extsvc/npm/npm_test.go
+++ b/internal/extsvc/npm/npm_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/sourcegraph/sourcegraph/internal/conf/reposource"
+	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/internal/httptestutil"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
@@ -34,10 +35,11 @@ var updateRecordings = flag.Bool("update", false, "make npm API calls, record an
 func newTestHTTPClient(t *testing.T) (client *HTTPClient, stop func()) {
 	t.Helper()
 	recorderFactory, stop := httptestutil.NewRecorderFactory(t, *updateRecordings, t.Name())
-	client = NewHTTPClient("urn", "https://registry.npmjs.org", "")
+
 	doer, err := recorderFactory.Doer()
 	require.Nil(t, err)
-	client.doer = doer
+
+	client = NewHTTPClient("urn", "https://registry.npmjs.org", "", doer)
 	return client, stop
 }
 
@@ -76,7 +78,7 @@ func TestCredentials(t *testing.T) {
 	defer server.Close()
 
 	ctx := context.Background()
-	client := NewHTTPClient("urn", server.URL, credentials)
+	client := NewHTTPClient("urn", server.URL, credentials, httpcli.ExternalDoer)
 
 	presentDep, err := reposource.ParseNpmDependency("left-pad@1.3.0")
 	require.NoError(t, err)

--- a/internal/extsvc/npm/npmpackages/repos.go
+++ b/internal/extsvc/npm/npmpackages/repos.go
@@ -1,7 +1,1 @@
 package npmpackages
-
-import "github.com/sourcegraph/sourcegraph/internal/conf/reposource"
-
-type Metadata struct {
-	Package *reposource.NpmPackage
-}

--- a/internal/extsvc/types.go
+++ b/internal/extsvc/types.go
@@ -172,6 +172,8 @@ func KindToType(kind string) string {
 		return TypeJVMPackages
 	case KindPythonPackages:
 		return TypePythonPackages
+	case KindNpmPackages:
+		return TypeNpmPackages
 	case KindGoModules:
 		return TypeGoModules
 	case KindPagure:

--- a/internal/repos/clone_url.go
+++ b/internal/repos/clone_url.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/inconshreveable/log15"
 
+	"github.com/sourcegraph/sourcegraph/internal/conf/reposource"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/awscodecommit"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/bitbucketcloud"
@@ -15,8 +16,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/github"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/gitlab"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/gitolite"
-	"github.com/sourcegraph/sourcegraph/internal/extsvc/jvmpackages"
-	"github.com/sourcegraph/sourcegraph/internal/extsvc/npm/npmpackages"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/pagure"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/perforce"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/phabricator"
@@ -84,11 +83,11 @@ func CloneURL(kind, config string, repo *types.Repo) (string, error) {
 	case *schema.PythonPackagesConnection:
 		return string(repo.Name), nil
 	case *schema.JVMPackagesConnection:
-		if r, ok := repo.Metadata.(*jvmpackages.Metadata); ok {
+		if r, ok := repo.Metadata.(*reposource.MavenMetadata); ok {
 			return r.Module.CloneURL(), nil
 		}
 	case *schema.NpmPackagesConnection:
-		if r, ok := repo.Metadata.(*npmpackages.Metadata); ok {
+		if r, ok := repo.Metadata.(*reposource.NpmMetadata); ok {
 			return r.Package.CloneURL(), nil
 		}
 	default:

--- a/internal/repos/dependencies.go
+++ b/internal/repos/dependencies.go
@@ -1,0 +1,177 @@
+package repos
+
+import (
+	"context"
+	"sync"
+
+	"golang.org/x/sync/errgroup"
+	"golang.org/x/sync/semaphore"
+
+	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/codeintel/dependencies"
+	"github.com/sourcegraph/sourcegraph/internal/conf/reposource"
+	"github.com/sourcegraph/sourcegraph/internal/errcode"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc"
+	"github.com/sourcegraph/sourcegraph/internal/types"
+)
+
+type DependenciesSource struct {
+	svc        *types.ExternalService
+	configDeps []string
+	scheme     string
+	depsSvc    *dependencies.Service
+	src        dependenciesSource
+}
+
+type dependenciesSource interface {
+	Get(ctx context.Context, name, version string) (reposource.PackageDependency, error)
+	ParseDependency(dep string) (reposource.PackageDependency, error)
+	ParseDependencyFromRepoName(repoName string) (reposource.PackageDependency, error)
+}
+
+var _ Source = &DependenciesSource{}
+
+func (s *DependenciesSource) ListRepos(ctx context.Context, results chan SourceResult) {
+	deps, err := s.configDependencies(s.configDeps)
+	if err != nil {
+		results <- SourceResult{Source: s, Err: err}
+		return
+	}
+
+	var mu sync.Mutex
+	set := make(map[string]struct{})
+
+	for _, dep := range deps {
+		_, err := s.src.Get(ctx, dep.PackageSyntax(), dep.PackageVersion())
+		if err != nil {
+			results <- SourceResult{Source: s, Err: err}
+			continue
+		}
+
+		if _, ok := set[dep.PackageSyntax()]; !ok {
+			repo := s.makeRepo(dep)
+			results <- SourceResult{Source: s, Repo: repo}
+			set[dep.PackageSyntax()] = struct{}{}
+		}
+	}
+
+	lastID := 0
+
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	sem := semaphore.NewWeighted(32)
+	g, ctx := errgroup.WithContext(ctx)
+
+	defer func() {
+		if err := g.Wait(); err != nil && err != context.Canceled {
+			results <- SourceResult{Source: s, Err: err}
+		}
+	}()
+
+	for {
+		depRepos, err := s.depsSvc.ListDependencyRepos(ctx, dependencies.ListDependencyReposOpts{
+			Scheme:      s.scheme,
+			After:       lastID,
+			Limit:       100,
+			NewestFirst: true,
+		})
+		if err != nil {
+			results <- SourceResult{Source: s, Err: err}
+			return
+		}
+		if len(depRepos) == 0 {
+			break
+		}
+
+		lastID = depRepos[len(depRepos)-1].ID
+
+		for _, depRepo := range depRepos {
+			if err := sem.Acquire(ctx, 1); err != nil {
+				return
+			}
+
+			depRepo := depRepo
+			g.Go(func() error {
+				defer sem.Release(1)
+
+				dep, err := s.src.Get(ctx, depRepo.Name, depRepo.Version)
+				if err != nil {
+					if errcode.IsNotFound(err) {
+						return nil
+					}
+					return err
+				}
+
+				mu.Lock()
+				if _, ok := set[depRepo.Name]; !ok {
+					set[depRepo.Name] = struct{}{}
+					mu.Unlock()
+					repo := s.makeRepo(dep)
+					results <- SourceResult{Source: s, Repo: repo}
+				} else {
+					mu.Unlock()
+				}
+
+				return nil
+			})
+		}
+	}
+}
+
+func (s *DependenciesSource) GetRepo(ctx context.Context, name string) (*types.Repo, error) {
+	dep, err := s.src.ParseDependencyFromRepoName(name)
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = s.src.Get(ctx, dep.PackageSyntax(), "")
+	if err != nil {
+		return nil, err
+	}
+
+	return s.makeRepo(dep), nil
+}
+
+func (s *DependenciesSource) makeRepo(dep reposource.PackageDependency) *types.Repo {
+	urn := s.svc.URN()
+	repoName := dep.RepoName()
+	return &types.Repo{
+		Name:        repoName,
+		Description: dep.Description(),
+		URI:         string(repoName),
+		ExternalRepo: api.ExternalRepoSpec{
+			ID:          string(repoName),
+			ServiceID:   extsvc.KindToType(s.svc.Kind),
+			ServiceType: extsvc.KindToType(s.svc.Kind),
+		},
+		Private: false,
+		Sources: map[string]*types.SourceInfo{
+			urn: {
+				ID:       urn,
+				CloneURL: string(repoName),
+			},
+		},
+		Metadata: &struct{}{},
+	}
+}
+
+// ExternalServices returns a singleton slice containing the external service.
+func (s *DependenciesSource) ExternalServices() types.ExternalServices {
+	return types.ExternalServices{s.svc}
+}
+
+func (s *DependenciesSource) SetDependenciesService(depsSvc *dependencies.Service) {
+	s.depsSvc = depsSvc
+}
+
+func (s *DependenciesSource) configDependencies(deps []string) (dependencies []reposource.PackageDependency, err error) {
+	for _, dep := range deps {
+		dependency, err := s.src.ParseDependency(dep)
+		if err != nil {
+			return nil, err
+		}
+		dependencies = append(dependencies, dependency)
+	}
+	return dependencies, nil
+}

--- a/internal/repos/dependencies.go
+++ b/internal/repos/dependencies.go
@@ -152,7 +152,22 @@ func (s *DependenciesSource) makeRepo(dep reposource.PackageDependency) *types.R
 				CloneURL: string(repoName),
 			},
 		},
-		Metadata: &struct{}{},
+		Metadata: metadata(dep),
+	}
+}
+
+func metadata(dep reposource.PackageDependency) any {
+	switch d := dep.(type) {
+	case *reposource.MavenDependency:
+		return &reposource.MavenMetadata{
+			Module: d.MavenModule,
+		}
+	case *reposource.NpmDependency:
+		return &reposource.NpmMetadata{
+			Package: d.NpmPackage,
+		}
+	default:
+		return &struct{}{}
 	}
 }
 

--- a/internal/repos/go_modules.go
+++ b/internal/repos/go_modules.go
@@ -2,16 +2,9 @@ package repos
 
 import (
 	"context"
-	"sync"
 
-	"golang.org/x/sync/errgroup"
-	"golang.org/x/sync/semaphore"
-
-	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/dependencies"
 	"github.com/sourcegraph/sourcegraph/internal/conf/reposource"
-	"github.com/sourcegraph/sourcegraph/internal/errcode"
-	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/gomodproxy"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/internal/jsonc"
@@ -20,17 +13,8 @@ import (
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
-// A GoModulesSource creates git repositories from go module zip files of
-// published go dependencies from the Go ecosystem.
-type GoModulesSource struct {
-	svc     *types.ExternalService
-	config  *schema.GoModulesConnection
-	depsSvc *dependencies.Service
-	client  *gomodproxy.Client
-}
-
 // NewGoModulesSource returns a new GoModulesSource from the given external service.
-func NewGoModulesSource(svc *types.ExternalService, cf *httpcli.Factory) (*GoModulesSource, error) {
+func NewGoModulesSource(svc *types.ExternalService, cf *httpcli.Factory) (*DependenciesSource, error) {
 	var c schema.GoModulesConnection
 	if err := jsonc.Unmarshal(svc.Config, &c); err != nil {
 		return nil, errors.Errorf("external service id=%d config error: %s", svc.ID, err)
@@ -41,157 +25,34 @@ func NewGoModulesSource(svc *types.ExternalService, cf *httpcli.Factory) (*GoMod
 		return nil, err
 	}
 
-	return &GoModulesSource{
-		svc:    svc,
-		config: &c,
-		/* depsSvc initialized in SetDependenciesService */
-		client: gomodproxy.NewClient(svc.URN(), c.Urls, cli),
+	return &DependenciesSource{
+		svc:        svc,
+		configDeps: c.Dependencies,
+		scheme:     dependencies.GoModulesScheme,
+		src: &goModulesSource{
+			client: gomodproxy.NewClient(svc.URN(), c.Urls, cli),
+		},
 	}, nil
 }
 
-var _ Source = &GoModulesSource{}
-
-func (s *GoModulesSource) ListRepos(ctx context.Context, results chan SourceResult) {
-	deps, err := goDependencies(s.config)
-	if err != nil {
-		results <- SourceResult{Source: s, Err: err}
-		return
-	}
-
-	var mu sync.Mutex
-	set := make(map[string]struct{})
-
-	for _, dep := range deps {
-		_, err := s.client.GetVersion(ctx, dep.PackageSyntax(), dep.PackageVersion())
-		if err != nil {
-			results <- SourceResult{Source: s, Err: err}
-			continue
-		}
-
-		if _, ok := set[dep.PackageSyntax()]; !ok {
-			repo := s.makeRepo(dep)
-			results <- SourceResult{Source: s, Repo: repo}
-			set[dep.PackageSyntax()] = struct{}{}
-		}
-	}
-
-	lastID := 0
-
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
-	sem := semaphore.NewWeighted(32)
-	g, ctx := errgroup.WithContext(ctx)
-
-	defer func() {
-		if err := g.Wait(); err != nil && err != context.Canceled {
-			results <- SourceResult{Source: s, Err: err}
-		}
-	}()
-
-	for {
-		depRepos, err := s.depsSvc.ListDependencyRepos(ctx, dependencies.ListDependencyReposOpts{
-			Scheme:      dependencies.GoModulesScheme,
-			After:       lastID,
-			Limit:       100,
-			NewestFirst: true,
-		})
-		if err != nil {
-			results <- SourceResult{Source: s, Err: err}
-			return
-		}
-		if len(depRepos) == 0 {
-			break
-		}
-
-		lastID = depRepos[len(depRepos)-1].ID
-
-		for _, depRepo := range depRepos {
-			if err := sem.Acquire(ctx, 1); err != nil {
-				return
-			}
-
-			depRepo := depRepo
-			g.Go(func() error {
-				defer sem.Release(1)
-
-				mod, err := s.client.GetVersion(ctx, depRepo.Name, depRepo.Version)
-				if err != nil {
-					if errcode.IsNotFound(err) {
-						return nil
-					}
-					return err
-				}
-
-				mu.Lock()
-				if _, ok := set[depRepo.Name]; !ok {
-					set[depRepo.Name] = struct{}{}
-					mu.Unlock()
-					dep := reposource.NewGoDependency(*mod)
-					repo := s.makeRepo(dep)
-					results <- SourceResult{Source: s, Repo: repo}
-				} else {
-					mu.Unlock()
-				}
-
-				return nil
-			})
-		}
-	}
+type goModulesSource struct {
+	client *gomodproxy.Client
 }
 
-func (s *GoModulesSource) GetRepo(ctx context.Context, name string) (*types.Repo, error) {
-	dep, err := reposource.ParseGoDependencyFromRepoName(name)
+var _ dependenciesSource = &goModulesSource{}
+
+func (s *goModulesSource) Get(ctx context.Context, name, version string) (reposource.PackageDependency, error) {
+	mod, err := s.client.GetVersion(ctx, name, version)
 	if err != nil {
 		return nil, err
 	}
-
-	_, err = s.client.GetVersion(ctx, dep.PackageSyntax(), "")
-	if err != nil {
-		return nil, err
-	}
-
-	return s.makeRepo(dep), nil
+	return reposource.NewGoDependency(*mod), nil
 }
 
-func (s *GoModulesSource) makeRepo(dep *reposource.GoDependency) *types.Repo {
-	urn := s.svc.URN()
-	repoName := dep.RepoName()
-	return &types.Repo{
-		Name: repoName,
-		URI:  string(repoName),
-		ExternalRepo: api.ExternalRepoSpec{
-			ID:          string(repoName),
-			ServiceID:   extsvc.TypeGoModules,
-			ServiceType: extsvc.TypeGoModules,
-		},
-		Private: false,
-		Sources: map[string]*types.SourceInfo{
-			urn: {
-				ID:       urn,
-				CloneURL: string(repoName),
-			},
-		},
-		Metadata: &struct{}{},
-	}
+func (goModulesSource) ParseDependency(dep string) (reposource.PackageDependency, error) {
+	return reposource.ParseGoDependency(dep)
 }
 
-// ExternalServices returns a singleton slice containing the external service.
-func (s *GoModulesSource) ExternalServices() types.ExternalServices {
-	return types.ExternalServices{s.svc}
-}
-
-func (s *GoModulesSource) SetDependenciesService(depsSvc *dependencies.Service) {
-	s.depsSvc = depsSvc
-}
-
-func goDependencies(connection *schema.GoModulesConnection) (dependencies []*reposource.GoDependency, err error) {
-	for _, dep := range connection.Dependencies {
-		dependency, err := reposource.ParseGoDependency(dep)
-		if err != nil {
-			return nil, err
-		}
-		dependencies = append(dependencies, dependency)
-	}
-	return dependencies, nil
+func (goModulesSource) ParseDependencyFromRepoName(repoName string) (reposource.PackageDependency, error) {
+	return reposource.ParseGoDependencyFromRepoName(repoName)
 }

--- a/internal/repos/jvm_packages.go
+++ b/internal/repos/jvm_packages.go
@@ -28,7 +28,7 @@ func NewJVMPackagesSource(svc *types.ExternalService) (*DependenciesSource, erro
 	return &DependenciesSource{
 		svc:        svc,
 		configDeps: configDeps,
-		scheme:     dependencies.NpmPackagesScheme,
+		scheme:     dependencies.JVMPackagesScheme,
 		src:        &jvmPackagesSource{config: &c},
 	}, nil
 }
@@ -38,6 +38,8 @@ func NewJVMPackagesSource(svc *types.ExternalService) (*DependenciesSource, erro
 type jvmPackagesSource struct {
 	config *schema.JVMPackagesConnection
 }
+
+var _ dependenciesSource = &jvmPackagesSource{}
 
 func (s *jvmPackagesSource) Get(ctx context.Context, name, version string) (reposource.PackageDependency, error) {
 	mavenDependency, err := reposource.ParseMavenDependency(name + ":" + version)

--- a/internal/repos/jvm_packages.go
+++ b/internal/repos/jvm_packages.go
@@ -3,12 +3,8 @@ package repos
 import (
 	"context"
 
-	"github.com/inconshreveable/log15"
-
-	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/dependencies"
 	"github.com/sourcegraph/sourcegraph/internal/conf/reposource"
-	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/jvmpackages/coursier"
 	"github.com/sourcegraph/sourcegraph/internal/jsonc"
 	"github.com/sourcegraph/sourcegraph/internal/types"
@@ -16,165 +12,50 @@ import (
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
-// A JVMPackagesSource creates git repositories from `*-sources.jar` files of
-// published Maven dependencies from the JVM ecosystem.
-type JVMPackagesSource struct {
-	svc     *types.ExternalService
-	config  *schema.JVMPackagesConnection
-	depsSvc *dependencies.Service
-}
-
 // NewJVMPackagesSource returns a new MavenSource from the given external
 // service.
-func NewJVMPackagesSource(svc *types.ExternalService) (*JVMPackagesSource, error) {
+func NewJVMPackagesSource(svc *types.ExternalService) (*DependenciesSource, error) {
 	var c schema.JVMPackagesConnection
 	if err := jsonc.Unmarshal(svc.Config, &c); err != nil {
-		return nil, errors.Newf("external service id=%d config error: %s", svc.ID, err)
+		return nil, errors.Errorf("external service id=%d config error: %s", svc.ID, err)
 	}
-	return newJVMPackagesSource(svc, &c)
-}
 
-func (s *JVMPackagesSource) SetDependenciesService(depsSvc *dependencies.Service) {
-	s.depsSvc = depsSvc
-}
+	var configDeps []string
+	if c.Maven != nil {
+		configDeps = c.Maven.Dependencies
+	}
 
-func newJVMPackagesSource(svc *types.ExternalService, c *schema.JVMPackagesConnection) (*JVMPackagesSource, error) {
-	return &JVMPackagesSource{
-		svc:     svc,
-		config:  c,
-		depsSvc: nil, // set via SetDependenciesService decorator
+	return &DependenciesSource{
+		svc:        svc,
+		configDeps: configDeps,
+		scheme:     dependencies.NpmPackagesScheme,
+		src:        &jvmPackagesSource{config: &c},
 	}, nil
 }
 
-// ListRepos returns all Maven artifacts accessible to all connections
-// configured in Sourcegraph via the external services configuration.
-//
-// [FIXME: deduplicate-listed-repos] The current implementation will return
-// multiple repos with the same URL if there are different versions of it.
-func (s *JVMPackagesSource) ListRepos(ctx context.Context, results chan SourceResult) {
-	s.listDependentRepos(ctx, results)
+// A jvmPackagesSource creates git repositories from `*-sources.jar` files of
+// published Maven dependencies from the JVM ecosystem.
+type jvmPackagesSource struct {
+	config *schema.JVMPackagesConnection
 }
 
-func (s *JVMPackagesSource) listDependentRepos(ctx context.Context, results chan SourceResult) {
-	modules, err := MavenModules(*s.config)
-	if err != nil {
-		results <- SourceResult{Err: err}
-		return
-	}
-	for _, module := range modules {
-		repo := s.makeRepo(module)
-		results <- SourceResult{
-			Source: s,
-			Repo:   repo,
-		}
-	}
-
-	var (
-		totalDBFetched  int
-		totalDBResolved int
-		lastID          int
-	)
-	for {
-		dbDeps, err := s.depsSvc.ListDependencyRepos(ctx, dependencies.ListDependencyReposOpts{
-			Scheme:      dependencies.JVMPackagesScheme,
-			After:       lastID,
-			Limit:       100,
-			NewestFirst: true,
-		})
-		if err != nil {
-			results <- SourceResult{Err: err}
-			return
-		}
-
-		if len(dbDeps) == 0 {
-			break
-		}
-
-		totalDBFetched += len(dbDeps)
-
-		lastID = dbDeps[len(dbDeps)-1].ID
-
-		for _, dep := range dbDeps {
-			mavenDependency, err := reposource.ParseMavenDependency(dep.Name + ":" + dep.Version)
-			if err != nil {
-				log15.Warn("error parsing maven module", "error", err, "module", dep.Name)
-				continue
-			}
-
-			// We dont return anything that isnt resolvable here, to reduce logspam from gitserver. This codepath
-			// should be hit much less frequently than gitservers attempts to get packages, so there should be less
-			// logspam. This may no longer hold true if the extsvc syncs more often than gitserver would, but I
-			// don't foresee that happening (not soon at least).
-			err = coursier.Exists(ctx, s.config, mavenDependency)
-			if err != nil {
-				log15.Warn("jvm package not resolvable from coursier", "package", mavenDependency.PackageManagerSyntax())
-				continue
-			}
-
-			repo := s.makeRepo(mavenDependency.MavenModule)
-			totalDBResolved++
-			results <- SourceResult{
-				Source: s,
-				Repo:   repo,
-			}
-		}
-	}
-
-	log15.Info("finished listing resolvable maven artifacts", "totalDB", totalDBFetched, "resolvedDB", totalDBResolved, "totalConfig", len(modules))
-}
-
-func (s *JVMPackagesSource) makeRepo(module *reposource.MavenModule) *types.Repo {
-	urn := s.svc.URN()
-	cloneURL := module.CloneURL()
-	return &types.Repo{
-		Name: module.RepoName(),
-		URI:  string(module.RepoName()),
-		ExternalRepo: api.ExternalRepoSpec{
-			ID:          string(module.RepoName()),
-			ServiceID:   extsvc.TypeJVMPackages,
-			ServiceType: extsvc.TypeJVMPackages,
-		},
-		Private: false,
-		Sources: map[string]*types.SourceInfo{
-			urn: {
-				ID:       urn,
-				CloneURL: cloneURL,
-			},
-		},
-		Metadata: &reposource.MavenMetadata{
-			Module: module,
-		},
-	}
-}
-
-// ExternalServices returns a singleton slice containing the external service.
-func (s *JVMPackagesSource) ExternalServices() types.ExternalServices {
-	return types.ExternalServices{s.svc}
-}
-
-func MavenDependencies(connection schema.JVMPackagesConnection) (dependencies []*reposource.MavenDependency, err error) {
-	for _, dep := range connection.Maven.Dependencies {
-		dependency, err := reposource.ParseMavenDependency(dep)
-		if err != nil {
-			return nil, err
-		}
-		dependencies = append(dependencies, dependency)
-	}
-	return dependencies, nil
-}
-
-func MavenModules(connection schema.JVMPackagesConnection) ([]*reposource.MavenModule, error) {
-	isAdded := make(map[string]bool)
-	modules := []*reposource.MavenModule{}
-	dependencies, err := MavenDependencies(connection)
+func (s *jvmPackagesSource) Get(ctx context.Context, name, version string) (reposource.PackageDependency, error) {
+	mavenDependency, err := reposource.ParseMavenDependency(name + ":" + version)
 	if err != nil {
 		return nil, err
 	}
-	for _, dep := range dependencies {
-		if key := dep.PackageSyntax(); !isAdded[key] {
-			modules = append(modules, dep.MavenModule)
-			isAdded[key] = true
-		}
+
+	err = coursier.Exists(ctx, s.config, mavenDependency)
+	if err != nil {
+		return nil, err
 	}
-	return modules, nil
+	return mavenDependency, nil
+}
+
+func (jvmPackagesSource) ParseDependency(dep string) (reposource.PackageDependency, error) {
+	return reposource.ParseMavenDependency(dep)
+}
+
+func (jvmPackagesSource) ParseDependencyFromRepoName(repoName string) (reposource.PackageDependency, error) {
+	return reposource.ParseMavenDependencyFromRepoName(repoName)
 }

--- a/internal/repos/jvm_packages.go
+++ b/internal/repos/jvm_packages.go
@@ -9,7 +9,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/dependencies"
 	"github.com/sourcegraph/sourcegraph/internal/conf/reposource"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
-	"github.com/sourcegraph/sourcegraph/internal/extsvc/jvmpackages"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/jvmpackages/coursier"
 	"github.com/sourcegraph/sourcegraph/internal/jsonc"
 	"github.com/sourcegraph/sourcegraph/internal/types"
@@ -142,7 +141,7 @@ func (s *JVMPackagesSource) makeRepo(module *reposource.MavenModule) *types.Repo
 				CloneURL: cloneURL,
 			},
 		},
-		Metadata: &jvmpackages.Metadata{
+		Metadata: &reposource.MavenMetadata{
 			Module: module,
 		},
 	}

--- a/internal/repos/npm_packages.go
+++ b/internal/repos/npm_packages.go
@@ -3,197 +3,64 @@ package repos
 import (
 	"context"
 
-	"github.com/inconshreveable/log15"
-
-	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/dependencies"
 	"github.com/sourcegraph/sourcegraph/internal/conf/reposource"
-	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/npm"
-	"github.com/sourcegraph/sourcegraph/internal/extsvc/npm/npmpackages"
 	"github.com/sourcegraph/sourcegraph/internal/jsonc"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
-// A NpmPackagesSource creates git repositories from `*-sources.tar.gz` files of
-// published npm dependencies from the JS ecosystem.
-type NpmPackagesSource struct {
-	svc        *types.ExternalService
-	connection schema.NpmPackagesConnection
-	depsSvc    *dependencies.Service
-	client     npm.Client
-}
-
-// NewNpmPackagesSource returns a new NpmSource from the given external
+// NewNpmPackagesSource returns a new DependenciesSource from the given external
 // service.
-func NewNpmPackagesSource(svc *types.ExternalService) (*NpmPackagesSource, error) {
+func NewNpmPackagesSource(svc *types.ExternalService) (*DependenciesSource, error) {
 	var c schema.NpmPackagesConnection
 	if err := jsonc.Unmarshal(svc.Config, &c); err != nil {
 		return nil, errors.Errorf("external service id=%d config error: %s", svc.ID, err)
 	}
-	return &NpmPackagesSource{
+	return &DependenciesSource{
 		svc:        svc,
-		connection: c,
+		configDeps: c.Dependencies,
+		scheme:     dependencies.NpmPackagesScheme,
 		/* depsSvc initialized in SetDependenciesService */
-		client: npm.NewHTTPClient(svc.URN(), c.Registry, c.Credentials),
+		src: &npmPackagesSource{
+			client: npm.NewHTTPClient(svc.URN(), c.Registry, c.Credentials),
+		},
 	}, nil
 }
 
-var _ Source = &NpmPackagesSource{}
+var _ dependenciesSource = &npmPackagesSource{}
 
-// ListRepos returns all npm artifacts accessible to all connections
-// configured in Sourcegraph via the external services configuration.
-//
-// [FIXME: deduplicate-listed-repos] The current implementation will return
-// multiple repos with the same URL if there are different versions of it.
-func (s *NpmPackagesSource) ListRepos(ctx context.Context, results chan SourceResult) {
-	npmPackages, err := npmPackages(s.connection)
-	if err != nil {
-		results <- SourceResult{Err: err}
-		return
-	}
-
-	for _, npmPackage := range npmPackages {
-		info, err := s.client.GetPackageInfo(ctx, npmPackage)
-		if err != nil {
-			results <- SourceResult{Err: err}
-			continue
-		}
-
-		repo := s.makeRepo(npmPackage, info.Description)
-		results <- SourceResult{
-			Source: s,
-			Repo:   repo,
-		}
-	}
-
-	totalDBFetched, totalDBResolved, lastID := 0, 0, 0
-	pkgVersions := map[string]*npm.PackageInfo{}
-	for {
-		dbDeps, err := s.depsSvc.ListDependencyRepos(ctx, dependencies.ListDependencyReposOpts{
-			Scheme:      dependencies.NpmPackagesScheme,
-			After:       lastID,
-			Limit:       100,
-			NewestFirst: true,
-		})
-		if err != nil {
-			results <- SourceResult{Err: err}
-			return
-		}
-		if len(dbDeps) == 0 {
-			break
-		}
-		totalDBFetched += len(dbDeps)
-		lastID = dbDeps[len(dbDeps)-1].ID
-		for _, dbDep := range dbDeps {
-			parsedDbPackage, err := reposource.ParseNpmPackageFromPackageSyntax(dbDep.Name)
-			if err != nil {
-				log15.Error("failed to parse npm package name retrieved from database", "package", dbDep.Name, "error", err)
-				continue
-			}
-
-			npmDependency := reposource.NpmDependency{NpmPackage: parsedDbPackage, Version: dbDep.Version}
-			pkgKey := npmDependency.PackageSyntax()
-			info := pkgVersions[pkgKey]
-
-			if info == nil {
-				info, err = s.client.GetPackageInfo(ctx, npmDependency.NpmPackage)
-				if err != nil {
-					pkgVersions[pkgKey] = &npm.PackageInfo{Versions: map[string]*npm.DependencyInfo{}}
-					continue
-				}
-
-				pkgVersions[pkgKey] = info
-			}
-
-			if _, hasVersion := info.Versions[npmDependency.Version]; !hasVersion {
-				continue
-			}
-
-			repo := s.makeRepo(npmDependency.NpmPackage, info.Description)
-			totalDBResolved++
-			results <- SourceResult{Source: s, Repo: repo}
-		}
-	}
-	log15.Info("finish resolving npm artifacts", "totalDB", totalDBFetched, "totalDBResolved", totalDBResolved, "totalConfig", len(npmPackages))
+type npmPackagesSource struct {
+	client npm.Client
 }
 
-func (s *NpmPackagesSource) GetRepo(ctx context.Context, name string) (*types.Repo, error) {
-	pkg, err := reposource.ParseNpmPackageFromRepoURL(name)
+func (npmPackagesSource) ParseDependency(dep string) (reposource.PackageDependency, error) {
+	return reposource.ParseNpmDependency(dep)
+}
+
+func (npmPackagesSource) ParseDependencyFromRepoName(repoName string) (reposource.PackageDependency, error) {
+	pkg, err := reposource.ParseNpmPackageFromRepoURL(repoName)
+	if err != nil {
+		return nil, err
+	}
+	return &reposource.NpmDependency{NpmPackage: pkg}, nil
+}
+
+func (s *npmPackagesSource) Get(ctx context.Context, name, version string) (reposource.PackageDependency, error) {
+	dep, err := reposource.ParseNpmDependency(name + "@" + version)
 	if err != nil {
 		return nil, err
 	}
 
-	info, err := s.client.GetPackageInfo(ctx, pkg)
+	info, err := s.client.GetDependencyInfo(ctx, dep)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.makeRepo(pkg, info.Description), nil
-}
+	dep.PackageDescription = info.Description
+	dep.TarballURL = info.Dist.TarballURL
 
-func (s *NpmPackagesSource) makeRepo(npmPackage *reposource.NpmPackage, description string) *types.Repo {
-	urn := s.svc.URN()
-	cloneURL := npmPackage.CloneURL()
-	repoName := npmPackage.RepoName()
-	return &types.Repo{
-		Name:        repoName,
-		Description: description,
-		URI:         string(repoName),
-		ExternalRepo: api.ExternalRepoSpec{
-			ID:          string(repoName),
-			ServiceID:   extsvc.TypeNpmPackages,
-			ServiceType: extsvc.TypeNpmPackages,
-		},
-		Private: false,
-		Sources: map[string]*types.SourceInfo{
-			urn: {
-				ID:       urn,
-				CloneURL: cloneURL,
-			},
-		},
-		Metadata: &npmpackages.Metadata{
-			Package: npmPackage,
-		},
-	}
-}
-
-// ExternalServices returns a singleton slice containing the external service.
-func (s *NpmPackagesSource) ExternalServices() types.ExternalServices {
-	return types.ExternalServices{s.svc}
-}
-
-func (s *NpmPackagesSource) SetDependenciesService(depsSvc *dependencies.Service) {
-	s.depsSvc = depsSvc
-}
-
-// npmPackages gets the list of applicable packages by de-duplicating dependencies
-// present in the configuration.
-func npmPackages(connection schema.NpmPackagesConnection) ([]*reposource.NpmPackage, error) {
-	dependencies, err := npmDependencies(connection)
-	if err != nil {
-		return nil, err
-	}
-	npmPackages := []*reposource.NpmPackage{}
-	isAdded := make(map[string]bool)
-	for _, dep := range dependencies {
-		if key := dep.PackageSyntax(); !isAdded[key] {
-			npmPackages = append(npmPackages, dep.NpmPackage)
-			isAdded[key] = true
-		}
-	}
-	return npmPackages, nil
-}
-
-func npmDependencies(connection schema.NpmPackagesConnection) (dependencies []*reposource.NpmDependency, err error) {
-	for _, dep := range connection.Dependencies {
-		dependency, err := reposource.ParseNpmDependency(dep)
-		if err != nil {
-			return nil, err
-		}
-		dependencies = append(dependencies, dependency)
-	}
-	return dependencies, nil
+	return dep, nil
 }

--- a/internal/repos/npm_packages_test.go
+++ b/internal/repos/npm_packages_test.go
@@ -7,16 +7,15 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/dependencies"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/dependencies/live"
 	"github.com/sourcegraph/sourcegraph/internal/conf/reposource"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
-	"github.com/sourcegraph/sourcegraph/internal/extsvc/npm/npmpackages"
-	"github.com/sourcegraph/sourcegraph/internal/extsvc/npm/npmtest"
+	"github.com/sourcegraph/sourcegraph/internal/testutil"
 	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/schema"
 )
 
 func TestGetNpmDependencyRepos(t *testing.T) {
@@ -117,63 +116,60 @@ var testDependencyRepos = func() []dependencies.Repo {
 	return dependencyRepos
 }()
 
-func TestListRepos(t *testing.T) {
+func TestNPMPackagesSource_ListRepos(t *testing.T) {
 	ctx := context.Background()
-	depsSvc := testDependenciesService(ctx, t, testDependencyRepos)
+	depsSvc := testDependenciesService(ctx, t, []dependencies.Repo{
+		{
+			ID:      1,
+			Scheme:  dependencies.NpmPackagesScheme,
+			Name:    "react",
+			Version: "18.1.0", // test deduplication with version from config
+		},
+		{
+			ID:      2,
+			Scheme:  dependencies.NpmPackagesScheme,
+			Name:    "react",
+			Version: "18.0.0", // test deduplication with version from config
+		},
+		{
+			ID:      3,
+			Scheme:  dependencies.NpmPackagesScheme,
+			Name:    "async",
+			Version: "3.2.3",
+		},
+		{
+			ID:      4,
+			Scheme:  dependencies.NpmPackagesScheme,
+			Name:    "fastq",
+			Version: "0.9.9", // Test missing modules are skipped.
+		},
+	})
 
 	svc := types.ExternalService{
-		Kind:   extsvc.KindNpmPackages,
-		Config: `{"registry": "https://placeholder.lol", "rateLimit": {"enabled": false}}`,
-	}
-	packageSource, err := NewNpmPackagesSource(&svc)
-	require.Nil(t, err)
-	packageSource.SetDependenciesService(depsSvc)
-	packageSource.client = npmtest.NewMockClient(t, testDependencies...)
-	results := make(chan SourceResult, 10)
-	go func() {
-		packageSource.ListRepos(ctx, results)
-		close(results)
-	}()
-
-	var have []*types.Repo
-	for r := range results {
-		if r.Err != nil {
-			t.Fatal(r.Err)
-		}
-		have = append(have, r.Repo)
+		Kind: extsvc.KindNpmPackages,
+		Config: marshalJSON(t, &schema.NpmPackagesConnection{
+			Registry: "https://registry.npmjs.org",
+			Dependencies: []string{
+				"urql@2.2.0",
+				"lodash@4.17.15",
+			},
+		}),
 	}
 
-	sort.Sort(types.Repos(have))
+	cf, save := newClientFactory(t, t.Name())
+	t.Cleanup(func() { save(t) })
 
-	var want []*types.Repo
-	for _, dep := range testDependencies {
-		dep, err := reposource.ParseNpmDependency(dep)
-		if err != nil {
-			t.Fatal(err)
-		}
-		want = append(want, &types.Repo{
-			Name:        dep.RepoName(),
-			Description: dep.PackageSyntax() + " description",
-			URI:         string(dep.RepoName()),
-			ExternalRepo: api.ExternalRepoSpec{
-				ID:          string(dep.RepoName()),
-				ServiceID:   extsvc.TypeNpmPackages,
-				ServiceType: extsvc.TypeNpmPackages,
-			},
-			Sources: map[string]*types.SourceInfo{
-				packageSource.svc.URN(): {
-					ID:       packageSource.svc.URN(),
-					CloneURL: dep.CloneURL(),
-				},
-			},
-			Metadata: &npmpackages.Metadata{
-				Package: dep.NpmPackage,
-			},
-		})
+	src, err := NewNpmPackagesSource(&svc, cf)
+	if err != nil {
+		t.Fatal(err)
 	}
 
-	sort.Sort(types.Repos(want))
+	src.SetDependenciesService(depsSvc)
 
-	// Compare after uniquing after addressing [FIXME: deduplicate-listed-repos].
-	require.Equal(t, want, have)
+	repos, err := listAll(ctx, src)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	testutil.AssertGolden(t, "testdata/sources/"+t.Name(), update(t.Name()), repos)
 }

--- a/internal/repos/python_packages.go
+++ b/internal/repos/python_packages.go
@@ -2,16 +2,9 @@ package repos
 
 import (
 	"context"
-	"sync"
 
-	"golang.org/x/sync/errgroup"
-	"golang.org/x/sync/semaphore"
-
-	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/dependencies"
 	"github.com/sourcegraph/sourcegraph/internal/conf/reposource"
-	"github.com/sourcegraph/sourcegraph/internal/errcode"
-	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/pypi"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/internal/jsonc"
@@ -20,17 +13,8 @@ import (
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
-// A PythonPackagesSource creates git repositories from python files of
-// published python dependencies.
-type PythonPackagesSource struct {
-	svc     *types.ExternalService
-	config  *schema.PythonPackagesConnection
-	depsSvc *dependencies.Service
-	client  *pypi.Client
-}
-
 // NewPythonPackagesSource returns a new PythonPackagesSource from the given external service.
-func NewPythonPackagesSource(svc *types.ExternalService, cf *httpcli.Factory) (*PythonPackagesSource, error) {
+func NewPythonPackagesSource(svc *types.ExternalService, cf *httpcli.Factory) (*DependenciesSource, error) {
 	var c schema.PythonPackagesConnection
 	if err := jsonc.Unmarshal(svc.Config, &c); err != nil {
 		return nil, errors.Errorf("external service id=%d config error: %s", svc.ID, err)
@@ -41,160 +25,32 @@ func NewPythonPackagesSource(svc *types.ExternalService, cf *httpcli.Factory) (*
 		return nil, err
 	}
 
-	return &PythonPackagesSource{
-		svc:    svc,
-		config: &c,
-		/* depsSvc initialized in SetDependenciesService */
-		client: pypi.NewClient(svc.URN(), c.Urls, cli),
+	return &DependenciesSource{
+		svc:        svc,
+		configDeps: c.Dependencies,
+		scheme:     dependencies.PythonPackagesScheme,
+		src:        &pythonPackagesSource{client: pypi.NewClient(svc.URN(), c.Urls, cli)},
 	}, nil
 }
 
-var _ Source = &PythonPackagesSource{}
-
-func (s *PythonPackagesSource) ListRepos(ctx context.Context, results chan SourceResult) {
-	deps, err := pythonDependencies(s.config)
-	if err != nil {
-		results <- SourceResult{Source: s, Err: err}
-		return
-	}
-
-	var mu sync.Mutex
-	set := make(map[string]struct{})
-
-	for _, dep := range deps {
-		if _, ok := set[dep.PackageSyntax()]; ok {
-			continue
-		}
-
-		_, err := s.client.Version(ctx, dep.PackageSyntax(), dep.PackageVersion())
-		if err != nil {
-			results <- SourceResult{Source: s, Err: err}
-			continue
-		}
-
-		repo := s.makeRepo(dep)
-		results <- SourceResult{Source: s, Repo: repo}
-		set[dep.PackageSyntax()] = struct{}{}
-	}
-
-	lastID := 0
-
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
-	sem := semaphore.NewWeighted(32)
-	g, ctx := errgroup.WithContext(ctx)
-
-	defer func() {
-		if err := g.Wait(); err != nil && err != context.Canceled {
-			results <- SourceResult{Source: s, Err: err}
-		}
-	}()
-
-	for {
-		depRepos, err := s.depsSvc.ListDependencyRepos(ctx, dependencies.ListDependencyReposOpts{
-			Scheme:      dependencies.PythonPackagesScheme,
-			After:       lastID,
-			Limit:       100,
-			NewestFirst: true,
-		})
-		if err != nil {
-			results <- SourceResult{Source: s, Err: err}
-			return
-		}
-		if len(depRepos) == 0 {
-			break
-		}
-
-		lastID = depRepos[len(depRepos)-1].ID
-
-		for _, depRepo := range depRepos {
-			if err := sem.Acquire(ctx, 1); err != nil {
-				return
-			}
-
-			depRepo := depRepo
-			g.Go(func() error {
-				defer sem.Release(1)
-
-				_, err := s.client.Version(ctx, depRepo.Name, depRepo.Version)
-				if err != nil {
-					if errcode.IsNotFound(err) {
-						return nil
-					}
-					return err
-				}
-
-				mu.Lock()
-				if _, ok := set[depRepo.Name]; !ok {
-					set[depRepo.Name] = struct{}{}
-					mu.Unlock()
-					dep := reposource.NewPythonDependency(depRepo.Name, depRepo.Version)
-
-					repo := s.makeRepo(dep)
-					results <- SourceResult{Source: s, Repo: repo}
-				} else {
-					mu.Unlock()
-				}
-
-				return nil
-			})
-		}
-	}
+type pythonPackagesSource struct {
+	client *pypi.Client
 }
 
-func (s *PythonPackagesSource) GetRepo(ctx context.Context, name string) (*types.Repo, error) {
-	dep, err := reposource.ParsePythonDependencyFromRepoName(name)
+var _ dependenciesSource = &pythonPackagesSource{}
+
+func (s *pythonPackagesSource) Get(ctx context.Context, name, version string) (reposource.PackageDependency, error) {
+	_, err := s.client.Version(ctx, name, version)
 	if err != nil {
 		return nil, err
 	}
-
-	_, err = s.client.Project(ctx, dep.PackageSyntax())
-	if err != nil {
-		return nil, err
-	}
-
-	return s.makeRepo(dep), nil
+	return reposource.NewPythonDependency(name, version), nil
 }
 
-func (s *PythonPackagesSource) makeRepo(dep *reposource.PythonDependency) *types.Repo {
-	urn := s.svc.URN()
-	repoName := dep.RepoName()
-	return &types.Repo{
-		Name: repoName,
-		URI:  string(repoName),
-		ExternalRepo: api.ExternalRepoSpec{
-			ID:          string(repoName),
-			ServiceID:   extsvc.TypePythonPackages,
-			ServiceType: extsvc.TypePythonPackages,
-		},
-		Private: false,
-		Sources: map[string]*types.SourceInfo{
-			urn: {
-				ID:       urn,
-				CloneURL: dep.Name,
-			},
-		},
-		Metadata: &struct{}{},
-	}
+func (pythonPackagesSource) ParseDependency(dep string) (reposource.PackageDependency, error) {
+	return reposource.ParsePythonDependency(dep)
 }
 
-// ExternalServices returns a singleton slice containing the external service.
-func (s *PythonPackagesSource) ExternalServices() types.ExternalServices {
-	return types.ExternalServices{s.svc}
-}
-
-func (s *PythonPackagesSource) SetDependenciesService(depsSvc *dependencies.Service) {
-	s.depsSvc = depsSvc
-}
-
-func pythonDependencies(connection *schema.PythonPackagesConnection) (dependencies []*reposource.PythonDependency, err error) {
-	for _, dep := range connection.Dependencies {
-		dependency, err := reposource.ParsePythonDependency(dep)
-		if err != nil {
-			return nil, err
-		}
-		dependencies = append(dependencies, dependency)
-	}
-	return dependencies, nil
+func (pythonPackagesSource) ParseDependencyFromRepoName(repoName string) (reposource.PackageDependency, error) {
+	return reposource.ParsePythonDependencyFromRepoName(repoName)
 }

--- a/internal/repos/sources.go
+++ b/internal/repos/sources.go
@@ -68,7 +68,7 @@ func NewSource(db database.DB, svc *types.ExternalService, cf *httpcli.Factory) 
 	case extsvc.KindPagure:
 		return NewPagureSource(svc, cf)
 	case extsvc.KindNpmPackages:
-		return NewNpmPackagesSource(svc)
+		return NewNpmPackagesSource(svc, cf)
 	case extsvc.KindPythonPackages:
 		return NewPythonPackagesSource(svc, cf)
 	case extsvc.KindOther:

--- a/internal/repos/sources.go
+++ b/internal/repos/sources.go
@@ -64,6 +64,7 @@ func NewSource(db database.DB, svc *types.ExternalService, cf *httpcli.Factory) 
 	case extsvc.KindGoModules:
 		return NewGoModulesSource(svc, cf)
 	case extsvc.KindJVMPackages:
+		// JVM doesn't need a client factory because we use coursier.
 		return NewJVMPackagesSource(svc)
 	case extsvc.KindPagure:
 		return NewPagureSource(svc, cf)

--- a/internal/repos/testdata/sources/TestNPMPackagesSource_ListRepos
+++ b/internal/repos/testdata/sources/TestNPMPackagesSource_ListRepos
@@ -1,0 +1,118 @@
+[
+  {
+   "ID": 0,
+   "Name": "npm/urql",
+   "URI": "npm/urql",
+   "Description": "",
+   "Fork": false,
+   "Archived": false,
+   "Private": false,
+   "CreatedAt": "0001-01-01T00:00:00Z",
+   "UpdatedAt": "0001-01-01T00:00:00Z",
+   "DeletedAt": "0001-01-01T00:00:00Z",
+   "ExternalRepo": {
+    "ID": "npm/urql",
+    "ServiceType": "npmPackages",
+    "ServiceID": "npmPackages"
+   },
+   "Sources": {
+    "extsvc:npmpackages:0": {
+     "ID": "extsvc:npmpackages:0",
+     "CloneURL": "npm/urql"
+    }
+   },
+   "Metadata": {
+    "Package": {
+     "Scope": "",
+     "Name": "urql"
+    }
+   }
+  },
+  {
+   "ID": 0,
+   "Name": "npm/lodash",
+   "URI": "npm/lodash",
+   "Description": "",
+   "Fork": false,
+   "Archived": false,
+   "Private": false,
+   "CreatedAt": "0001-01-01T00:00:00Z",
+   "UpdatedAt": "0001-01-01T00:00:00Z",
+   "DeletedAt": "0001-01-01T00:00:00Z",
+   "ExternalRepo": {
+    "ID": "npm/lodash",
+    "ServiceType": "npmPackages",
+    "ServiceID": "npmPackages"
+   },
+   "Sources": {
+    "extsvc:npmpackages:0": {
+     "ID": "extsvc:npmpackages:0",
+     "CloneURL": "npm/lodash"
+    }
+   },
+   "Metadata": {
+    "Package": {
+     "Scope": "",
+     "Name": "lodash"
+    }
+   }
+  },
+  {
+   "ID": 0,
+   "Name": "npm/async",
+   "URI": "npm/async",
+   "Description": "Higher-order functions and common patterns for asynchronous code",
+   "Fork": false,
+   "Archived": false,
+   "Private": false,
+   "CreatedAt": "0001-01-01T00:00:00Z",
+   "UpdatedAt": "0001-01-01T00:00:00Z",
+   "DeletedAt": "0001-01-01T00:00:00Z",
+   "ExternalRepo": {
+    "ID": "npm/async",
+    "ServiceType": "npmPackages",
+    "ServiceID": "npmPackages"
+   },
+   "Sources": {
+    "extsvc:npmpackages:0": {
+     "ID": "extsvc:npmpackages:0",
+     "CloneURL": "npm/async"
+    }
+   },
+   "Metadata": {
+    "Package": {
+     "Scope": "",
+     "Name": "async"
+    }
+   }
+  },
+  {
+   "ID": 0,
+   "Name": "npm/react",
+   "URI": "npm/react",
+   "Description": "React is a JavaScript library for building user interfaces.",
+   "Fork": false,
+   "Archived": false,
+   "Private": false,
+   "CreatedAt": "0001-01-01T00:00:00Z",
+   "UpdatedAt": "0001-01-01T00:00:00Z",
+   "DeletedAt": "0001-01-01T00:00:00Z",
+   "ExternalRepo": {
+    "ID": "npm/react",
+    "ServiceType": "npmPackages",
+    "ServiceID": "npmPackages"
+   },
+   "Sources": {
+    "extsvc:npmpackages:0": {
+     "ID": "extsvc:npmpackages:0",
+     "CloneURL": "npm/react"
+    }
+   },
+   "Metadata": {
+    "Package": {
+     "Scope": "",
+     "Name": "react"
+    }
+   }
+  }
+ ]

--- a/internal/repos/testdata/sources/TestNPMPackagesSource_ListRepos.yaml
+++ b/internal/repos/testdata/sources/TestNPMPackagesSource_ListRepos.yaml
@@ -1,0 +1,210 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers: {}
+    url: https://registry.npmjs.org/urql/2.2.0
+    method: GET
+  response:
+    body: '{"name":"urql","version":"2.2.0","description":"A highly customizable and
+      versatile GraphQL client for React","sideEffects":false,"homepage":"https://formidable.com/open-source/urql/docs/","bugs":{"url":"https://github.com/FormidableLabs/urql/issues"},"license":"MIT","repository":{"type":"git","url":"git+https://github.com/FormidableLabs/urql.git","directory":"packages/react-urql"},"keywords":["graphql
+      client","state management","cache","formidablelabs","exchanges","react"],"main":"dist/urql.js","module":"dist/urql.es.js","types":"dist/types/index.d.ts","source":"src/index.ts","scripts":{"test":"jest","clean":"rimraf
+      dist","check":"tsc --noEmit","lint":"eslint --ext=js,jsx,ts,tsx .","build":"rollup
+      -c ../../scripts/rollup/config.js","prepare":"node ../../scripts/prepare/index.js","prepublishOnly":"run-s
+      clean build"},"jest":{"preset":"../../scripts/jest/preset"},"devDependencies":{"@testing-library/react":"^11.1.1","@testing-library/react-hooks":"^5.1.2","@types/react":"^17.0.4","@types/react-test-renderer":"^17.0.1","graphql":"^16.0.0","react":"^17.0.1","react-dom":"^17.0.1","react-is":"^17.0.1","react-ssr-prepass":"^1.1.2","react-test-renderer":"^17.0.1"},"peerDependencies":{"graphql":"^0.11.0
+      || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0","react":">= 16.8.0"},"dependencies":{"@urql/core":"^2.4.3","wonka":"^4.0.14"},"_id":"urql@2.2.0","_nodeVersion":"14.19.0","_npmVersion":"6.14.16","dist":{"integrity":"sha512-36wnWqDrpXqhwT5r2/qRSZXhb7Y4sXA0nLlYEd3uLgvfIdOA8kUaPdfTujzfrvfCcfiVVFxhzqVAhc8r17NMwQ==","shasum":"5eade2813f5b61497086a5038ecc7c6e7cbd7153","tarball":"https://registry.npmjs.org/urql/-/urql-2.2.0.tgz","fileCount":31,"unpackedSize":149897,"npm-signature":"-----BEGIN
+      PGP SIGNATURE-----\r\nVersion: OpenPGP.js v4.10.10\r\nComment: https://openpgpjs.org\r\n\r\nwsFzBAEBCAAGBQJiGWgGACEJED1NWxICdlZqFiEECWMYAoorWMhJKdjhPU1b\r\nEgJ2VmpUtxAAoD1+OjBQDz3Jhd0TMo20oWC8I+Mx4YTYUF0WLbRwr2xlYceu\r\nWrJEunLuTKi6+HHXIvxgKgAqd8NXNpaAkJ1eFUecghdHPiW8iicoyEJXo22r\r\nmmIYwQjmotevC6tToQsVCKCVeOR+S7iXK1h9sUtq6RWMoEcgcuhU/B8p27P6\r\nsJuV+7PnPx4d4oFpybrUWxaiJgcFn+S0cdnXVLwSI0u6u0dCValMXWJ79FH4\r\ndw5v0/To9YqaHjNHyypx5zKD8ukwQ1iNiMCf+duE9A5JcSdcmM1cZed5EpOQ\r\nGGnquaEYI5oZ1B3KL0n28rwqgJejveEmTJPykBF2vLmoJDWn7670OmI/75FD\r\noDMdekbQwHyAtF2DF43OhzxMKAJwO2oHbT9CMkDOHtdvc6wCdTv9VnAw6dNe\r\nBrgDxOwYtF/QNHUvXHARxqgIyAeoU7lVAO1QW8Jq0XOv2j3+VDAcpKyuT2wy\r\nWwmYjxZJVt5Sm6Brco+OziCN9bIWjcK9q2WKaTckSoshh/+dNHS0Jdw3plc4\r\n4mdkbRzUH+BBai51l2KTG/K0yUwV82Fnr60EYpm3PP6AYtkHC2fbUgf2G9F3\r\n49RlPlDNFbChrfjGEa21DyKU/XnMSo3O6WPDaBmL0f3e8RKLw0rLJioPlQ3R\r\nUIr8mmahmQHWO/In85+CtSXhA68aXUTqf08=\r\n=Dzpj\r\n-----END
+      PGP SIGNATURE-----\r\n"},"_npmUser":{"name":"npm-urql","email":"npm-urql@formidable.com"},"directories":{},"maintainers":[{"name":"jpdriver","email":"jpsdriver@gmail.com"},{"name":"yankovalera","email":"yankovalera@gmail.com"},{"name":"valgeorgiev","email":"valentin.al.georgiev@gmail.com"},{"name":"michaelmerrill","email":"michael@michaelmerrill.me"},{"name":"sarmeyer","email":"sarahmichellemeyer@gmail.com"},{"name":"mariano-formidable","email":"mariano.martinez@formidable.com"},{"name":"carlospaelinck","email":"me@carlos.dev"},{"name":"ryanisinallofus","email":"ryanrray@gmail.com"},{"name":"samwhale","email":"samuelestrella226@gmail.com"},{"name":"ryan.roemer","email":"ryan@loose-bits.com"},{"name":"formidable-owner","email":"admin@formidablelabs.com"},{"name":"eastridge","email":"ryan@eastridge.me"},{"name":"exogen","email":"exogen@gmail.com"},{"name":"beccanelson","email":"becca.bailey@formidable.com"},{"name":"philpl","email":"phil@kitten.sh"},{"name":"hartzis","email":"brianhartz@gmail.com"},{"name":"mfulgham","email":"monet.fulgham@formidable.com"},{"name":"jmcbee1","email":"jmcbee1@gmail.com"},{"name":"formidablelabs","email":"npm@formidablelabs.com"},{"name":"carbonrobot","email":"carbonrobot@gmail.com"},{"name":"manosim","email":"hello@manos.im"},{"name":"masiddee","email":"mansoor@msiddeeq.com"},{"name":"andyrichardson","email":"andy.john.richardson@gmail.com"},{"name":"jdecroock","email":"decroockjovi@gmail.com"},{"name":"parkerziegler","email":"parkerellisziegler@gmail.com"},{"name":"npm-urql","email":"npm-urql@formidable.com"},{"name":"thekenwheeler","email":"ken_wheeler@me.com"}],"_npmOperationalInternal":{"host":"s3://npm-registry-packages","tmp":"tmp/urql_2.2.0_1645832198372_0.6535972224370645"},"_hasShrinkwrap":false}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=300
+      Cf-Cache-Status:
+      - DYNAMIC
+      Cf-Ray:
+      - 7089291f3ef7aca4-TXL
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 09 May 2022 08:45:44 GMT
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding, accept
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers: {}
+    url: https://registry.npmjs.org/lodash/4.17.15
+    method: GET
+  response:
+    body: '{"name":"lodash","version":"4.17.15","description":"Lodash modular utilities.","keywords":["modules","stdlib","util"],"homepage":"https://lodash.com/","repository":{"type":"git","url":"git+https://github.com/lodash/lodash.git"},"icon":"https://lodash.com/icon.svg","license":"MIT","main":"lodash.js","author":{"name":"John-David
+      Dalton","email":"john.david.dalton@gmail.com"},"contributors":[{"name":"John-David
+      Dalton","email":"john.david.dalton@gmail.com"},{"name":"Mathias Bynens","email":"mathias@qiwi.be"}],"scripts":{"test":"echo
+      \"See https://travis-ci.org/lodash-archive/lodash-cli for testing details.\""},"bugs":{"url":"https://github.com/lodash/lodash/issues"},"_id":"lodash@4.17.15","_nodeVersion":"12.2.0","_npmVersion":"6.10.1","dist":{"integrity":"sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==","shasum":"b447f6670a0455bbfeedd11392eff330ea097548","tarball":"https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz","fileCount":1049,"unpackedSize":1401029,"npm-signature":"-----BEGIN
+      PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdMSrfCRA9TVsSAnZWagAAwdsP/RhUWg82MeFBHu0zHeQd\nhslgH/+xAkHR3SGuT5q9t6qqkNsqgSl25RdtEJqqlV69Ni2W8y5YgNfrQTVq\ntcmjDoJejlU4qnNiUNP/R81Ph+bNKh0+DcCCo+2YKMEk5XVCNxTWxETyasYR\n0PNuRR6dbvhWij0AEL6Uk2VF0vI9T/hFje7NeNnNf9CLk+mfKtxydB62cTtZ\ntojexG52iH5w4Lk35gjyOgAoWCFSk09GRgOW3RmmiPU8Cg7gizcW/7ynimbV\nPXY/GpdZ4EcmZSb7F47TBl/Ymv4TE2+H8LEvdxdtFfsaCyu0i/9wyi34j6ja\nujYyWCiie2IkJYSONWc0UxIBtq6tjLrXanuhsL7caXZWyljvqLRPYcfWJVWQ\nheL1YGLBOWtZtM51h7uHfnz/3YViQxkT55z5eziAWFGKX/x8ByUO2LU+LGjv\nwzRb8fqi5l7Wz3BjNbDxLyA8X8FsSu2rzPogz9bHvqc5WYknpoPJp/aRUADz\nlLoO+fwQRA9PYKhTcLMDMJQ+NIxaA++6eJ8ZIokp5Qx9RvhIbr3pMgg13PbN\nuiV1LT6I2H7y9NC6yucgE4/siQmcRSi5y5XT3G1jx6SLOvTFa5d4Ae5CSk1L\nSUqRZ+/x8uDI7fr/DZP9gCUgKrhd/ATikrR2wloqOyv0x27KB1WzDsNie3am\nyCB9\r\n=KaV2\r\n-----END
+      PGP SIGNATURE-----\r\n","signatures":[{"keyid":"SHA256:jl3bwswu80PjjokCgh0o2w5c2U4LhQAE57gj9cz1kzA","sig":"MEQCIFbxnpX3GT/QFjnCfbrXnvHQn6m6hAQozAKbkZ08lXA3AiAqcTSxmEMqNHzpSpZrzp3rwW0Imc2nMNB6lTSMmVnukg=="}]},"maintainers":[{"name":"jdalton","email":"john.david.dalton@gmail.com"},{"name":"mathias","email":"mathias@qiwi.be"}],"_npmUser":{"name":"jdalton","email":"john.david.dalton@gmail.com"},"directories":{},"_npmOperationalInternal":{"host":"s3://npm-registry-packages","tmp":"tmp/lodash_4.17.15_1563503326395_0.45150483878351166"},"_hasShrinkwrap":false}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=300
+      Cf-Cache-Status:
+      - DYNAMIC
+      Cf-Ray:
+      - 70892920d9c3aca4-TXL
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 09 May 2022 08:45:44 GMT
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding, accept
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers: {}
+    url: https://registry.npmjs.org/fastq/0.9.9
+    method: GET
+  response:
+    body: '"version not found: 0.9.9"'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Cf-Ray:
+      - 708929225cf7aca4-TXL
+      Content-Length:
+      - "26"
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 09 May 2022 08:45:44 GMT
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Vary:
+      - Accept-Encoding
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers: {}
+    url: https://registry.npmjs.org/async/3.2.3
+    method: GET
+  response:
+    body: '{"name":"async","description":"Higher-order functions and common patterns
+      for asynchronous code","version":"3.2.3","main":"dist/async.js","author":{"name":"Caolan
+      McMahon"},"homepage":"https://caolan.github.io/async/","repository":{"type":"git","url":"git+https://github.com/caolan/async.git"},"bugs":{"url":"https://github.com/caolan/async/issues"},"keywords":["async","callback","module","utility"],"devDependencies":{"babel-core":"^6.26.3","babel-eslint":"^8.2.6","babel-minify":"^0.5.0","babel-plugin-add-module-exports":"^0.2.1","babel-plugin-istanbul":"^5.1.4","babel-plugin-syntax-async-generators":"^6.13.0","babel-plugin-transform-es2015-modules-commonjs":"^6.26.2","babel-preset-es2015":"^6.3.13","babel-preset-es2017":"^6.22.0","babel-register":"^6.26.0","babelify":"^8.0.0","benchmark":"^2.1.1","bluebird":"^3.4.6","browserify":"^16.2.3","chai":"^4.2.0","cheerio":"^0.22.0","coveralls":"^3.0.4","es6-promise":"^2.3.0","eslint":"^6.0.1","eslint-plugin-prefer-arrow":"^1.1.5","fs-extra":"^0.26.7","jsdoc":"^3.6.2","karma":"^4.1.0","karma-browserify":"^5.3.0","karma-edge-launcher":"^0.4.2","karma-firefox-launcher":"^1.1.0","karma-junit-reporter":"^1.2.0","karma-mocha":"^1.2.0","karma-mocha-reporter":"^2.2.0","karma-safari-launcher":"^1.0.0","mocha":"^6.1.4","mocha-junit-reporter":"^1.18.0","native-promise-only":"^0.8.0-a","nyc":"^14.1.1","rollup":"^0.63.4","rollup-plugin-node-resolve":"^2.0.0","rollup-plugin-npm":"^2.0.0","rsvp":"^3.0.18","semver":"^5.5.0","yargs":"^11.0.0"},"scripts":{"coverage":"nyc
+      npm run mocha-node-test -- --grep @nycinvalid --invert","coveralls":"npm run
+      coverage && nyc report --reporter=text-lcov | coveralls","jsdoc":"jsdoc -c ./support/jsdoc/jsdoc.json
+      && node support/jsdoc/jsdoc-fix-html.js","lint":"eslint --fix lib/ test/ perf/memory.js
+      perf/suites.js perf/benchmark.js support/build/ support/*.js karma.conf.js","mocha-browser-test":"karma
+      start","mocha-node-test":"mocha","mocha-test":"npm run mocha-node-test && npm
+      run mocha-browser-test","test":"npm run lint && npm run mocha-node-test"},"license":"MIT","nyc":{"exclude":["test"]},"module":"dist/async.mjs","_id":"async@3.2.3","_nodeVersion":"14.7.0","_npmVersion":"6.14.7","dist":{"integrity":"sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g==","shasum":"ac53dafd3f4720ee9e8a160628f18ea91df196c9","tarball":"https://registry.npmjs.org/async/-/async-3.2.3.tgz","fileCount":137,"unpackedSize":820507,"npm-signature":"-----BEGIN
+      PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJh24AMCRA9TVsSAnZWagAA+loP/3QXGjSCmmNkz04uWaPt\n9PQJ2uycfydYdkUm96nVoMJZltSO2y6DbfhmdeqndRoKTQtnbwlmfq9ng6vz\n+srcqm4vjelRHPpYlZlTp2fBfNAw7uY4zlFsBUjAgYM4GE8L4wnHW4ARq84K\nuGLn1pDIUb2nzydrWwj3LFnooaPSTNwtkEGjBxgBjROpxJf/JmXX2XMWKw4G\nzq89y/5OK4LXIixgpl7m/5CvkETElVbqSTk/VPxFgRYw48vzEF4MZh+w79s9\nkrEWwmqiVxsWNB5E1+HtCfDKxh5cjmUpdx8DybAGRxb6Jfrg3gNuFXesIGeI\nE31+rIMD23oesDoVtx23ISotkGid2w7Eh7PTJMx1hDd6b39uwxDYJ+62UOvL\nEntW4t821oEbRTp6UUjuMZC2eimhygmy+FASQic5loGMcFwn91iCGGj4d3e5\nLJQmE+9ykucdgDL6/We/OyeLmiXYVjjmSP8HulioZw5eEuLMYlNZ5FO6Ijro\nOy8NxA+ngSBdOA8QPIjHYYkPIUqFalWTV2CciuHQAUtaou3TqRFRnLP/3OZ0\nLbqreVlOlv73s4g7UVwBny4yuJ0JI0DvzGlbX9kYbjvlWDWqBx6cQSiD39Qz\nPx8mWVs/hwgJBAxKB0Q8tm8sAyAKvqBmSWHsmTEpARF0JqkBGK+rQz2MvW19\n/2zV\r\n=8M/Z\r\n-----END
+      PGP SIGNATURE-----\r\n","signatures":[{"keyid":"SHA256:jl3bwswu80PjjokCgh0o2w5c2U4LhQAE57gj9cz1kzA","sig":"MEUCIQDz66uC2MbtiqkGR5ZPK2R3LyfFtEWXsF6SgdU49u/JrAIgeZ1T9uXz4rYbh3LsTK6ZMWbEHJFc66aiXvOwr58D3XU="}]},"_npmUser":{"name":"aearly","email":"alexander.early@gmail.com"},"directories":{},"maintainers":[{"name":"beaugunderson","email":"beau@beaugunderson.com"},{"name":"caolan","email":"caolan.mcmahon@gmail.com"},{"name":"aearly","email":"alexander.early@gmail.com"},{"name":"megawac","email":"megawac@gmail.com"},{"name":"hargasinski","email":"argasinski.hubert@gmail.com"}],"_npmOperationalInternal":{"host":"s3://npm-registry-packages","tmp":"tmp/async_3.2.3_1641775116794_0.1623085249174283"},"_hasShrinkwrap":false}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=300
+      Cf-Cache-Status:
+      - DYNAMIC
+      Cf-Ray:
+      - 708929225cf5aca4-TXL
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 09 May 2022 08:45:44 GMT
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding, accept
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers: {}
+    url: https://registry.npmjs.org/react/18.1.0
+    method: GET
+  response:
+    body: '{"name":"react","description":"React is a JavaScript library for building
+      user interfaces.","keywords":["react"],"version":"18.1.0","homepage":"https://reactjs.org/","bugs":{"url":"https://github.com/facebook/react/issues"},"license":"MIT","main":"index.js","exports":{".":{"react-server":"./react.shared-subset.js","default":"./index.js"},"./package.json":"./package.json","./jsx-runtime":"./jsx-runtime.js","./jsx-dev-runtime":"./jsx-dev-runtime.js"},"repository":{"type":"git","url":"git+https://github.com/facebook/react.git","directory":"packages/react"},"engines":{"node":">=0.10.0"},"dependencies":{"loose-envify":"^1.1.0"},"browserify":{"transform":["loose-envify"]},"_id":"react@18.1.0","_nodeVersion":"14.19.0","_npmVersion":"6.14.16","dist":{"integrity":"sha512-4oL8ivCz5ZEPyclFQXaNksK3adutVS8l2xzZU0cqEFrE9Sb7fC0EFK5uEk74wIreL1DERyjvsU915j1pcT2uEQ==","shasum":"6f8620382decb17fdc5cc223a115e2adbf104890","tarball":"https://registry.npmjs.org/react/-/react-18.1.0.tgz","fileCount":20,"unpackedSize":315446,"signatures":[{"keyid":"SHA256:jl3bwswu80PjjokCgh0o2w5c2U4LhQAE57gj9cz1kzA","sig":"MEUCIQDGNJzg3daqQRyPUhTn3m06Ipa9a5hPzgl376UhhaSfzQIgaTI4w6/saWci7iZye1lc9nEJvcz0B1jdorXmvOqSxnM="}],"npm-signature":"-----BEGIN
+      PGP SIGNATURE-----\r\nVersion: OpenPGP.js v4.10.10\r\nComment: https://openpgpjs.org\r\n\r\nwsFzBAEBCAAGBQJiaFiuACEJED1NWxICdlZqFiEECWMYAoorWMhJKdjhPU1b\r\nEgJ2Vmrl3A/8CuKXr+86gafR8a7kECK9EfGE04qRQgbYeoRV98LU/0ILUuNH\r\n4fhkCYi3/dqtIgnoYL9BBAXnA2MAbNbXnGM6U3PhOEp1vZMesLFff5ne9bZ8\r\nFrubrVUoxTmrLj14mGp5q8kw4vYzNAVBw72QBZ2jfY0F1WA05AuGGBr+g2Lu\r\npRBVsaW9nnvLAHDdtRfLzzGCi8QbVxveqglWwoCPi3BiE4UCiSikCbKKI8pa\r\nkdw7nfnNXS1InPtcAipLdDUScW8jt22IhCCMirD6SMQZ0+i2PATwtmT9GKhH\r\nHbx8QPnenzoIABIrSbwEdi91xLH+/IhROobzFp/FPDA3X3oaI10xQGd4eIn6\r\nWoAfP9fIEeezwSgYfT8TBhOj5SisGyw82oVT/FRLFCu9HU6WMvQl74Vk/2S/\r\nXVX+n+WrjYsssllhYOxb6oxnfQgRSoBmyldZqsySlmC+ndK/CejrTgE/5Vzb\r\nmmACGD+ZOQWTWkXJskvfJNUUVvxxoSiXFyIbBqGvgbcdgn2OfY5CbcTI8Uc/\r\nE+x9bKZyXWObqzagXyG4/RLWjjtn87s7INoQybJtsQbpOFooxRgLvqlGVFSp\r\nW1dcEVPj3X17OyYiWSHESyshpxv+o9+8wPj/x33XGpdGxFIW4tVPF01djHtn\r\n0cXcESemvyJ13+veP8SzFWZ3ayT+6EWp5SQ=\r\n=Vi0c\r\n-----END
+      PGP SIGNATURE-----\r\n"},"_npmUser":{"name":"acdlite","email":"npm@andrewclark.io"},"directories":{},"maintainers":[{"name":"gaearon","email":"dan.abramov@gmail.com"},{"name":"acdlite","email":"npm@andrewclark.io"},{"name":"fb","email":"opensource+npm@fb.com"},{"name":"trueadm","email":"dg@domgan.com"},{"name":"sophiebits","email":"npm@sophiebits.com"},{"name":"lunaruan","email":"lunaris.ruan@gmail.com"}],"_npmOperationalInternal":{"host":"s3://npm-registry-packages","tmp":"tmp/react_18.1.0_1651005614236_0.013028299650699626"},"_hasShrinkwrap":false}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=300
+      Cf-Cache-Status:
+      - DYNAMIC
+      Cf-Ray:
+      - 708929225cf2aca4-TXL
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 09 May 2022 08:45:44 GMT
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding, accept
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers: {}
+    url: https://registry.npmjs.org/react/18.0.0
+    method: GET
+  response:
+    body: '{"name":"react","description":"React is a JavaScript library for building
+      user interfaces.","keywords":["react"],"version":"18.0.0","homepage":"https://reactjs.org/","bugs":{"url":"https://github.com/facebook/react/issues"},"license":"MIT","main":"index.js","exports":{".":{"react-server":"./react.shared-subset.js","default":"./index.js"},"./package.json":"./package.json","./jsx-runtime":"./jsx-runtime.js","./jsx-dev-runtime":"./jsx-dev-runtime.js"},"repository":{"type":"git","url":"git+https://github.com/facebook/react.git","directory":"packages/react"},"engines":{"node":">=0.10.0"},"dependencies":{"loose-envify":"^1.1.0"},"browserify":{"transform":["loose-envify"]},"_id":"react@18.0.0","_nodeVersion":"14.19.0","_npmVersion":"6.14.16","dist":{"integrity":"sha512-x+VL6wbT4JRVPm7EGxXhZ8w8LTROaxPXOqhlGyVSrv0sB1jkyFGgXxJ8LVoPRLvPR6/CIZGFmfzqUa2NYeMr2A==","shasum":"b468736d1f4a5891f38585ba8e8fb29f91c3cb96","tarball":"https://registry.npmjs.org/react/-/react-18.0.0.tgz","fileCount":20,"unpackedSize":315644,"npm-signature":"-----BEGIN
+      PGP SIGNATURE-----\r\nVersion: OpenPGP.js v4.10.10\r\nComment: https://openpgpjs.org\r\n\r\nwsFzBAEBCAAGBQJiQy0EACEJED1NWxICdlZqFiEECWMYAoorWMhJKdjhPU1b\r\nEgJ2Vmo2XBAAjFIUnS0JM35cS4xV6WKyVKM2fX8dlY9Cu286N+To3vRpDulw\r\nFh9jaSzMKVUEGua4teSpGpJE/niInMryih61E5HSZ6UhVdUc+tiPfZ3zJZjG\r\nUyIl8GHKAFyOXW/OQcrxLOS+9nqL8uxF0HkYsUAKX2yvyWWyAtu8J35JMa1K\r\nV6L9BKdvcBwGHLt5KHF8VcqTzlBxKmDJeCGA6BmU+DaPdaQmZHBxHRqQ1SR9\r\n24cRzAenA6pHn84Tqq/LCp31Sq70XiHSg0PjhdeJk7psi+031hU5BT2/R6hp\r\n0GcQcaISNdJ7CafbXcWET/J7WmGTEqk/99E27PKYfqwWxd1fUPBrjxJ6va6K\r\nizv9y6Qp5/ddIdJudR+CbfOKsV/K5V9rCb99VR81SJmVNtF3zgTz4j9A+gxx\r\nqz/AdD1KZ7x3xg4ChzLXEk+6m/GU01tIHe9E4ciOa8O+a5WLPvKDJ2TXDHva\r\nVyU9gQ2fuiYsHePW2432xF2Aeufh0nNl4dQGOaa4oVjENk//XBqmEEx/ojiR\r\n/i6kSZPX/XK29zTp0S7kvdVuDuR6/Bk5PsMtpC+talzOH6C1XWznLkdTq4gO\r\nDsB+iNN9Ks8xFlprNYuCqW9kv+cafJxfOzQc8QSBCSYPIwlUrOV4Tv0bucuJ\r\n2Lg2tqfOFXzpu2fx14oPQh7VynajyVGvwiA=\r\n=hoXG\r\n-----END
+      PGP SIGNATURE-----\r\n"},"_npmUser":{"name":"acdlite","email":"npm@andrewclark.io"},"directories":{},"maintainers":[{"name":"gaearon","email":"dan.abramov@gmail.com"},{"name":"acdlite","email":"npm@andrewclark.io"},{"name":"brianvaughn","email":"briandavidvaughn@gmail.com"},{"name":"fb","email":"opensource+npm@fb.com"},{"name":"trueadm","email":"dg@domgan.com"},{"name":"sophiebits","email":"npm@sophiebits.com"},{"name":"lunaruan","email":"lunaris.ruan@gmail.com"}],"_npmOperationalInternal":{"host":"s3://npm-registry-packages","tmp":"tmp/react_18.0.0_1648569603893_0.9485444480797844"},"_hasShrinkwrap":false}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=300
+      Cf-Cache-Status:
+      - DYNAMIC
+      Cf-Ray:
+      - 708929225cf4aca4-TXL
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 09 May 2022 08:45:44 GMT
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding, accept
+    status: 200 OK
+    code: 200
+    duration: ""

--- a/internal/repos/testdata/sources/TestPythonPackageSource_ListRepos
+++ b/internal/repos/testdata/sources/TestPythonPackageSource_ListRepos
@@ -18,7 +18,7 @@
    "Sources": {
     "extsvc:pythonpackages:0": {
      "ID": "extsvc:pythonpackages:0",
-     "CloneURL": "requests"
+     "CloneURL": "python/requests"
     }
    },
    "Metadata": {}
@@ -42,7 +42,7 @@
    "Sources": {
     "extsvc:pythonpackages:0": {
      "ID": "extsvc:pythonpackages:0",
-     "CloneURL": "lavaclient"
+     "CloneURL": "python/lavaclient"
     }
    },
    "Metadata": {}
@@ -66,7 +66,7 @@
    "Sources": {
     "extsvc:pythonpackages:0": {
      "ID": "extsvc:pythonpackages:0",
-     "CloneURL": "randio"
+     "CloneURL": "python/randio"
     }
    },
    "Metadata": {}
@@ -90,7 +90,7 @@
    "Sources": {
     "extsvc:pythonpackages:0": {
      "ID": "extsvc:pythonpackages:0",
-     "CloneURL": "pytimeparse"
+     "CloneURL": "python/pytimeparse"
     }
    },
    "Metadata": {}
@@ -114,7 +114,7 @@
    "Sources": {
     "extsvc:pythonpackages:0": {
      "ID": "extsvc:pythonpackages:0",
-     "CloneURL": "numpy"
+     "CloneURL": "python/numpy"
     }
    },
    "Metadata": {}

--- a/internal/repos/testdata/sources/TestPythonPackageSource_ListRepos.yaml
+++ b/internal/repos/testdata/sources/TestPythonPackageSource_ListRepos.yaml
@@ -238,7 +238,7 @@ interactions:
       Content-Type:
       - text/html; charset=UTF-8
       Date:
-      - Wed, 04 May 2022 12:25:56 GMT
+      - Mon, 09 May 2022 10:11:10 GMT
       Etag:
       - '"OAut2BCNOxqNKCH4+GWy5w"'
       Referrer-Policy:
@@ -252,7 +252,7 @@ interactions:
       X-Cache:
       - HIT, HIT
       X-Cache-Hits:
-      - 1, 77
+      - 2, 4
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
@@ -262,9 +262,9 @@ interactions:
       X-Pypi-Last-Serial:
       - "13685488"
       X-Served-By:
-      - cache-iad-kiad7000095-IAD, cache-fra19143-FRA
+      - cache-iad-kjyo7100030-IAD, cache-hhn4041-HHN
       X-Timer:
-      - S1651667156.169171,VS0,VE0
+      - S1652091071.789190,VS0,VE0
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -335,7 +335,7 @@ interactions:
       Content-Type:
       - text/html; charset=UTF-8
       Date:
-      - Wed, 04 May 2022 12:25:56 GMT
+      - Mon, 09 May 2022 10:11:10 GMT
       Etag:
       - '"t7HtD5ysFuoiZFgXIkNgUw"'
       Referrer-Policy:
@@ -359,9 +359,9 @@ interactions:
       X-Pypi-Last-Serial:
       - "1961594"
       X-Served-By:
-      - cache-iad-kcgs7200114-IAD, cache-fra19143-FRA
+      - cache-iad-kiad7000148-IAD, cache-hhn4041-HHN
       X-Timer:
-      - S1651667156.200240,VS0,VE1
+      - S1652091071.817966,VS0,VE1
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -398,7 +398,7 @@ interactions:
       Content-Type:
       - text/html; charset=UTF-8
       Date:
-      - Wed, 04 May 2022 12:25:56 GMT
+      - Mon, 09 May 2022 10:11:10 GMT
       Etag:
       - '"3TtwsNnv70w+G85t79VHRg"'
       Referrer-Policy:
@@ -422,9 +422,9 @@ interactions:
       X-Pypi-Last-Serial:
       - "798462"
       X-Served-By:
-      - cache-iad-kiad7000058-IAD, cache-fra19143-FRA
+      - cache-iad-kiad7000131-IAD, cache-hhn4041-HHN
       X-Timer:
-      - S1651667156.223861,VS0,VE1
+      - S1652091071.843867,VS0,VE1
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -478,7 +478,7 @@ interactions:
       Content-Type:
       - text/html; charset=UTF-8
       Date:
-      - Wed, 04 May 2022 12:25:56 GMT
+      - Mon, 09 May 2022 10:11:10 GMT
       Etag:
       - '"8HlLEmgXdyz9T3ejdWyFDA"'
       Referrer-Policy:
@@ -492,7 +492,7 @@ interactions:
       X-Cache:
       - HIT, HIT
       X-Cache-Hits:
-      - 89, 1
+      - 159, 1
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
@@ -502,9 +502,324 @@ interactions:
       X-Pypi-Last-Serial:
       - "8878543"
       X-Served-By:
-      - cache-iad-kjyo7100159-IAD, cache-fra19143-FRA
+      - cache-iad-kiad7000027-IAD, cache-hhn4041-HHN
       X-Timer:
-      - S1651667156.245320,VS0,VE1
+      - S1652091071.873047,VS0,VE1
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers: {}
+    url: https://pypi.org/simple/lofi/
+    method: GET
+  response:
+    body: 404 Not Found
+    headers:
+      Accept-Ranges:
+      - bytes
+      Content-Length:
+      - "13"
+      Content-Security-Policy:
+      - default-src 'none'; sandbox allow-top-navigation
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Date:
+      - Mon, 09 May 2022 10:11:10 GMT
+      Referrer-Policy:
+      - origin-when-cross-origin
+      Server:
+      - nginx/1.13.9
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Vary:
+      - Accept-Encoding
+      X-Cache:
+      - MISS, HIT
+      X-Cache-Hits:
+      - 0, 1
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Served-By:
+      - cache-iad-kiad7000023-IAD, cache-hhn4041-HHN
+      X-Timer:
+      - S1652091071.902614,VS0,VE1
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers: {}
+    url: https://pypi.org/simple/requests/
+    method: GET
+  response:
+    body: |-
+      <!DOCTYPE html>
+      <html>
+        <head>
+          <meta name="pypi:repository-version" content="1.0">
+          <title>Links for requests</title>
+        </head>
+        <body>
+          <h1>Links for requests</h1>
+          <a href="https://files.pythonhosted.org/packages/ba/bb/dfa0141a32d773c47e4dede1a617c59a23b74dd302e449cf85413fc96bc4/requests-0.2.0.tar.gz#sha256=813202ace4d9301a3c00740c700e012fb9f3f8c73ddcfe02ab558a8df6f175fd">requests-0.2.0.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/4b/ad/d536b2e572e843fda13e4458c67f937b05ce359722c1e4cdad35ba05b6e3/requests-0.2.1.tar.gz#sha256=d54eb33499f018fc6bd297613bf866f8d134629c8e02964aab6ef951f460e41e">requests-0.2.1.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/82/3c/3b5beca192da920c0c2ba67119d66ba1e4b1e766f40898e5e684d697ca1c/requests-0.2.2.tar.gz#sha256=b3289694b2ddf6adb4f7e1f470b9771330c76125611222b9c702f0e2e9733cbc">requests-0.2.2.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/6f/7e/5c2d7d9102c6ab847bd1215f96255e894fbfc81c8abf2c1714ae2a504913/requests-0.2.3.tar.gz#sha256=8e374b75aaae7f85325e9bb126e96cb77a3bfc17e81ee74a0e96916aac1cc2ba">requests-0.2.3.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/dc/02/789859c27162bb91ecf6b72ed4ce1af3ed1710255265ad0901c4d4e25666/requests-0.2.4.tar.gz#sha256=ef1bd1a81022e9bf574ecfe69cbd8597e79371b890d29bd3847dd946102c8eed">requests-0.2.4.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/96/2b/88e9d6bf2e9d75cda77bf4fdc03720f4ba262beb532f9510a4a7f3e45660/requests-0.3.0.tar.gz#sha256=57eed745eb2a2e3c7e1dd935ccd49eb2eac51cfcdace4a97fb44de5da70f0035">requests-0.3.0.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/5e/c0/76fac9445cd8b6394eacae1e098ca0c97767cc0112e45e68521f553df003/requests-0.3.1.tar.gz#sha256=05dddfd656d25b7738778d2b4e8fa72e53b5357a2f80a319e6e1fa59edb03339">requests-0.3.1.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/d5/f1/16b57088f11cd5c6c82834bad6475826309cee44edaae860e9f65c084703/requests-0.3.2.tar.gz#sha256=78ecf812ee865b62be106100a3c6f24058c7901ad995351b8818f18ea97ce848">requests-0.3.2.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/f1/64/8a2ba81294381bb90e8fb4b6fa750e0dca3f2d19e8caaeeae5e7bb6b3753/requests-0.3.3.tar.gz#sha256=ccbbc41c4c009baecf41e993727048c65c440fefadb217b11e73f63cd0cae09a">requests-0.3.3.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/ed/1b/8682a0cfe92f67e30fb9ac7982cb785a1230ca4385dc1353513f5b87b9f4/requests-0.3.4.tar.gz#sha256=e72a42a0317f33114b48c972d3056bad3265b92450d4e0e51ad0b384e43bc6d9">requests-0.3.4.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/56/c3/0887d5d6c18a366308b3dc7024210b4c89ff9ae92ae5fb87cf8fe58bcae2/requests-0.4.0.tar.gz#sha256=35185852569456de25a654c5f9a43a1b8e4dc18a2a676985bbb9d5e7e5a9703e">requests-0.4.0.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/b3/54/dbc9b89a66a15ab9f3e2595de1b1ebd1da954efcb30a329c98710e014c05/requests-0.4.1.tar.gz#sha256=f978616765803e9e0e9943136b34be0da69d74ba8fbd064cbfcf28f33ca54d8a">requests-0.4.1.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/0c/4d/d67bd4e4b17148aad88e6d75c62763ec27363d18038ed75019239e1516d0/requests-0.5.0.tar.gz#sha256=747c8c79e9c75ba8608c7628e39d533a0234ff78a80569e40ba64865abc0e521">requests-0.5.0.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/5f/1c/8d145fbdb23986063a8a0c954d484a793024137a99ac7f3da603717fe64a/requests-0.5.1.tar.gz#sha256=cfed662472d48e7bd6bfd8d7f79fe9072fc873b2e372fe3b9178a26daabebccc">requests-0.5.1.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/0b/b8/932de3bc1b8630357de85bc0c794ee1a7d343cb8008b470a0c9d15e84341/requests-0.6.0.tar.gz#sha256=2c5036387b75dfb0ff3971604bd1e691cf6a55dc6c397df7adf9fc4804bc7f48">requests-0.6.0.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/a6/1f/f948fb7ba68b69b13a1fbbb70d7706e889c7b7d3e9867b498ca7971126db/requests-0.6.1.tar.gz#sha256=2656b23db25398e990e6f5d75dfbd960454a1fe573aeedc651773ddd2a8a3bbc">requests-0.6.1.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/55/19/986305b95fae17c58c95e191943a282bce19f82535af4530890c483937ad/requests-0.6.2.tar.gz#sha256=b5419f909fc21b8eb037dc4bade29530c28993610b68213b7f7633bf10bcabbc">requests-0.6.2.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/e1/3f/9235f98536b1393ef8a8e2dbd27273588fc3246000b93b0d763325b2e30c/requests-0.6.3.tar.gz#sha256=bde3e2ea45f6e47acd24ff55628fc7325cacd75746ee2d2b63c093554131fe41">requests-0.6.3.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/97/e0/a2bc7317b13caf227a75c8151b562b62a2e9f5d4ab4ad59694bfdbf5c35c/requests-0.6.4.tar.gz#sha256=151f105506913a6b84f6119400ca94732ec39f5b4e0991ca2fc840ddb4e37816">requests-0.6.4.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/a8/a6/38b9de830719e4cd62ddf51f240654200658d0315aa9e908eda90ee64879/requests-0.6.5.tar.gz#sha256=bb332c171913c2f57cea805d013601af86a46b9aef9b7ef76bdcbed14f939bd7">requests-0.6.5.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/df/8d/4b1bb15e8814fefa2cdf8f971a479b459d07f8176094bd59742720f31270/requests-0.6.6.tar.gz#sha256=6670aee5fe3bb545e1f7e8bb073a06be65344b467cd698b0ad58e7d7792dc2bb">requests-0.6.6.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/5c/8c/0399c9554b04b2b267d81239773657ddc720799a08565b6c21f7aed652df/requests-0.7.0.tar.gz#sha256=13570c41a218affafe3f3e01db16d1f6cd238d3bd7a1d52cc435bf9de3df099a">requests-0.7.0.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/00/c8/8cf0f078100ce5fe7ff35927d8861e2e36daed9be2db56690f3ad80ccec4/requests-0.7.1.tar.gz#sha256=6795818f5f46d7ecf53965d96e2ceae66bf652c79703292973b7c56afb88b946">requests-0.7.1.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/7c/af/b46199ae37c032801bcdc5dbb1c82a59613883ee690ff4fd2b5dc3140130/requests-0.7.2.tar.gz#sha256=7e58616c2c943116c7fb7595ebc3b00c5016ede5e6b14cf4bd72a812a5534aef">requests-0.7.2.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/3d/54/c4a7dcfccac9e6dd738e9ed86848a9a5b07a4345e5949f8795cfdc0ea95f/requests-0.7.3.tar.gz#sha256=2e7a0cb6251da5dd8c185f5d404e110d29e47afec7c8e60d78806436360a40d7">requests-0.7.3.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/64/50/219c9ff86e6fecfb89bdfe1093aea523f14882657186f806462887220267/requests-0.7.4.tar.gz#sha256=3101a857831c6b6ec1f88ccebc8a19d38af6a10372537f437cd978c5775b4286">requests-0.7.4.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/2b/9e/1be659005a6bb394b02e12804fcaf8cd85050958a459945708b21e362b32/requests-0.7.5.tar.gz#sha256=ae10f2c5d112768a2e62282dd6b33db230c10ef7a2c3b1cf404806598bacd0b6">requests-0.7.5.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/de/f0/8fc024ef4f25ef5690c2121215029f88e1895b60c867c1a39134045b181e/requests-0.7.6.tar.gz#sha256=667f9c9cc447c9ee09d34d891db488f2695c99d025fae3ec8d02e235eb7eba95">requests-0.7.6.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/6a/85/32d23f3dbc43e54631bb9bd76d34c2448cc2f2f0de29babfb1a6a79b4d60/requests-0.8.0.tar.gz#sha256=62b557533f685c4a0af4e38dddc598c38f5ce0bd8e3b15b20809d1606f3843dd">requests-0.8.0.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/ae/fb/b1d6916b5278c44a1a2beb919d7ab96327051c3d47db9d6ee6978743444e/requests-0.8.1.tar.gz#sha256=23756d85cbf7dec36dd624853e76b380c2b538c21769adba1dcced9de0409f68">requests-0.8.1.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/65/5d/e69bad1f71d5284113165738d563a997d0d1ac968f939d1375f3df7c59fc/requests-0.8.2.tar.gz#sha256=826244e9612aa9a548d1289bef7bbce07eee4872ca21ca80631094d1c512b121">requests-0.8.2.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/f8/17/42ab05005c88e8d301fe0ee9b24e34139422268d0d7b8b11f98107c2a794/requests-0.8.3.tar.gz#sha256=7277ec1fc8b8251bc1ce628651cbfad886704a77aea9f6203dcc042a4f12d214">requests-0.8.3.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/aa/a7/ec41790a8fb50f8d359568f82cd37a994af5d0159cccb543d147a7eea751/requests-0.8.4.tar.gz#sha256=3ef7efbe083bcb6f7b1144c7665b5b1f6bd4fc7043dc50ccd564edf62b814c2b">requests-0.8.4.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/fc/f8/329450760dddd7e437eef0cd16a8d48582405e72495cf79a77a82e2f0047/requests-0.8.5.tar.gz#sha256=1db43116f612b016169d9a994d16aea9c166c55355bac2e05fae75e0ff610f4c">requests-0.8.5.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/4e/9b/a78a3bb2913576fad3ec6f18b8d26dd9579268f6b2191d73f4ec40e09490/requests-0.8.6.tar.gz#sha256=b9ad56ff5971b7a4005598e5a9588584ee1153fbf027ed76a7d13585f71489f7">requests-0.8.6.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/a7/83/bb447075090f4a3a60082765051d476b62f375d0f8174ebe9545d4bb8938/requests-0.8.7.tar.gz#sha256=2c5b08f7afe8d5ffc1c4f7819e74d5309a52b2f2eb1d78cc144cb57aa10380fe">requests-0.8.7.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/b7/1d/5c7973ca22bc95d53eba28a7dab7088f1ded7db0d174ea467afaaf898dfc/requests-0.8.8.tar.gz#sha256=70352c48f106fe4a15537bdb4a029ebbb80c1ae1b6836a9033f2b3d7e52e01fd">requests-0.8.8.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/3a/72/9f39b173ee93645013563df119d28841f47b0ca2ebe04afcefd438e42f30/requests-0.8.9.tar.gz#sha256=870780642a14f5e30a9ef8c419aeb405e5bd4340d4fefbf1e8493dde39225337">requests-0.8.9.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/89/ce/0115444a1f9d833768160e678c21483e271466918966c11212f040b5f2af/requests-0.9.0.tar.gz#sha256=43b26edb5c47e0ccf9612d3cf13639a1e7e6c774af5375a684cfa00e747f21b1">requests-0.9.0.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/48/aa/1077a5fef0c4fbdad8ce127166ca474c67788b7609137d26e17ab46ee16d/requests-0.9.1.tar.gz#sha256=0c6fc89ce4f8976dd8ddb1a9e896315a47fb3f1dba95417fd3fa8e626ca9a1e7">requests-0.9.1.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/68/a1/fac8e1fa783d167cc49debc5b5328ca57eac9d53b58c34d17ce7592cdc6d/requests-0.9.2.tar.gz#sha256=eb9a3b0031af396fb6825be897655546f4c54e19669fddb5df72a4a688ae0555">requests-0.9.2.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/62/12/0840d1bba04e5d60e469610ad78e02e89e6828e776adaef4116413cf5fd0/requests-0.9.3.tar.gz#sha256=3c0dd7c014474e0cdd00cad661abd74c88c14183d260d0555dfa51fc5b29abc5">requests-0.9.3.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/62/35/0230421b8c4efad6624518028163329ad0c2df9e58e6b3bee013427bf8f6/requests-0.10.0.tar.gz#sha256=210a82e678c45d433a4ad1f105974b3102a8ab5198872dc0a3238a8750d4c65e">requests-0.10.0.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/b4/56/ba2d803383ec32d70f8faa7df5eb37ee9b3fc662ff68b7ab01ad9740b83a/requests-0.10.1.tar.gz#sha256=da6031575a30c7b65ea99465183468349b3645e6bf5322e49d53f565b27ed2b5">requests-0.10.1.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/58/1e/6b84552b6553f5beaf7cb0fe15115e7e4673326ed9188ad5338559ee8285/requests-0.10.2.tar.gz#sha256=1546ef1e291ae337086369b621096fb0f69f88f6f67f60b1f6b7c18d1ca278e1">requests-0.10.2.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/01/44/39988315e036b79fe70428273053617266bf20d1363e91082346fae8450d/requests-0.10.3.tar.gz#sha256=8eeb24328304b015cbd59a49670e2738b77034b225b566729ddb19941899e490">requests-0.10.3.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/94/ac/5fa21e435ba8050d14db92ce29763c28196b727d4079dc608d39177fbf9b/requests-0.10.4.tar.gz#sha256=2ad4cc51d7595ca6f97373a0d697999e0cbdbbf1ba665d18f0f3dcec12b8be77">requests-0.10.4.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/b4/1f/8f5430040fcf4391dc5bd324424a569e2e0d96595952b21eb82403602d98/requests-0.10.6.tar.gz#sha256=31134b4f35951730dcce59f2af334478b68caa5728902a1d6bd5e115ec677d8b">requests-0.10.6.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/c5/cd/0597f9c040db24ca6d23cc74faa102554cb0a93bdbffb855d7749547921f/requests-0.10.7.tar.gz#sha256=80f32a74bed8cf081a3a25512f8725e09ceda217101ea706efced262bb05aec6">requests-0.10.7.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/9a/05/4ab34c6aae63a01aef2fd8be3573a99c197cc76a67f8cee751cb3a7784fb/requests-0.10.8.tar.gz#sha256=bec280d924a8be87b3377ee78a976334a6e7c944a8fe09bbd9447e669b984dae">requests-0.10.8.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/d7/ee/6826f31ae3e0e68606cb9086c3904582b3982bbccc73f34d6dc9912b48ad/requests-0.11.1.tar.gz#sha256=fd4260541d0e559c78e2b3072bd79f36e0f8ef935bcbbadaa8c98cd8b5a62897">requests-0.11.1.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/b6/52/ad2911cf5586f2372a296a93a94d0324e4ffdd225975241562c450594795/requests-0.11.2.tar.gz#sha256=547bf78a774a6018271d6e5c40613ec554642ba4d6cdf45813e7894145293c57">requests-0.11.2.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/3a/ac/0372d6b7fbde19444d5cc560f296e70b26283d2bac0665b576dd3f5e6b60/requests-0.12.0.tar.gz#sha256=8a88a291599444be608940c227b6114212220d8126c512af821f1ab207fe5072">requests-0.12.0.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/3a/0a/7c62c06702ddb4d3bc50d27f5b8e094d6e66a3374fc2eedf264742f84805/requests-0.12.1.tar.gz#sha256=9ce56b87180c06728d96ca734055675abf8f5cc3136e0d7712a6260430685589">requests-0.12.1.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/86/1b/88d3753931419a226bb4e4c1d354cd2d40acff3482b37e30dd84ba8a243b/requests-0.13.0.tar.gz#sha256=03a2001843546147ddb6972d0661e2002b9be4ccbbbd2177ee10f05bd1910109">requests-0.13.0.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/0d/63/0e6c6b817ab38fb3e38a192d6631d698fe78308a68659af3aa523cd736d4/requests-0.13.1.tar.gz#sha256=31f3ae96787fe74a78c7dd9626bf997fd4eabacc040b7b33fbd8632d2c2a97f6">requests-0.13.1.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/62/ca/338cf287e172099e4500cfa2cb580d2c9a1874427a8a14324d7a4c9d01b1/requests-0.13.2.tar.gz#sha256=37684324da8aca40e88fa2f7faa526cc116d74e979c2ac5d9119fe6e1bb5ced5">requests-0.13.2.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/54/9d/1ee0bd44e9334b6382ed5226d4bc33518d0d0b03ed806af6444d1c80ed83/requests-0.13.3.tar.gz#sha256=79503a14a43d6ae0b0b2e92f88ed0b01015528b8a8ab47721c28aa993aa4db2b">requests-0.13.3.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/04/75/52e169351e24a9faa8bfac69a07ea3551b845ca6354f22da15c5da3d5100/requests-0.13.4.tar.gz#sha256=94672e92c23fefe516c5310b84d97b4ea19ef373003a7ba7af1057102a87f345">requests-0.13.4.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/ba/d1/919f6240a37ce5aade82da39809e1f28a5f2899a29a0ca10c381ba70efbb/requests-0.13.5.tar.gz#sha256=c6abb4b15a3f2aaad18c22b214b9b35d69ec4e2730c5b922f95f17a88981f957">requests-0.13.5.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/02/56/a6203485b552f9e8e8f16bd4e576446f94737ccbc563957e7510c8e401e4/requests-0.13.6.tar.gz#sha256=3cca63908f1b941d2da61ef0e8baf7bf014cc0df6512e172b8d2ac87be82b916">requests-0.13.6.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/b4/48/e82ded36a3cee7c0ef9605b44c4615ffe4a37f8b6c8b17fdbc15fae18daa/requests-0.13.7.tar.gz#sha256=d9c6cf2890a0dc1200407f99130d334ef5ab5270bed3d9b4c14b0bb9c6cc3400">requests-0.13.7.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/db/1e/1f37495384a628887e10ecd61d45dba455ceec4b8b5b463512b4700e5b3d/requests-0.13.8.tar.gz#sha256=3ef37004f6394b111a27f0b6d0a64be83f7e4bccfbbbcdd21455400af5f4fbd4">requests-0.13.8.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/01/da/da83c242c5a77c58aa86072d68fd2855aa9b4d3b1a8bac4b402531b25ff1/requests-0.13.9.tar.gz#sha256=d887bb1c06948a8930d6e73a1f942f9febe9157a299a984994c20c84b2c21e20">requests-0.13.9.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/4e/31/50a12e5b5e585e0b00ce2592c9b45f2ae109575e3707a341afd7550a8d1a/requests-0.14.0.tar.gz#sha256=4e690ba0275ab4a8c9a5c7a6eb14e79e1adad0f84331fc638a18d7751f41ac3b">requests-0.14.0.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/40/1d/63a729208e1e93cf2cbda953b9f20ec9b101eb964e3f6205d1c2e294f294/requests-0.14.1.tar.gz#sha256=4f563b907782b2c95dd2cbaf882a96133e567d46290a0e7aafa0c6f3efad19ba">requests-0.14.1.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/fa/d1/0dd60e1146e79e7b193e7b0189d8c13ef100d55cbfe65e1825ac5f03c397/requests-0.14.2.tar.gz#sha256=0e3345a8ac0d712bf17bd9d3276415050c5f972265ab62993cd4540a3a1aaaef">requests-0.14.2.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/46/da/94c0fd6ff79b85befc3b528cf3771700def274c52b347bf12eeaa466f34c/requests-1.0.0.tar.gz#sha256=f10d8fbcc02a58056ab44f79ff9b3f9fe78e410296527885250bbb36d15be8c6">requests-1.0.0.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/b8/03/fb15922d14fa0b01a0ff4e2920bb8c08546d970ff387454ba892a67d5243/requests-1.0.1.tar.gz#sha256=c69222b7c02a8e46d61c3b986e6a3e766db0539235aaafc056c75b8dcf6f5eec">requests-1.0.1.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/32/35/f2908b62b155b1737ab80b1a69142d007522bb0d1b3a0d3f8909595762f5/requests-1.0.2.tar.gz#sha256=3c81f3ae43916161b8d98d7b329b19533b0d0332b7a774794964e6b08760b0c7">requests-1.0.2.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/7f/76/66c01dd9afe4c5062e0c838bbd98ead7fa6b52984c7e26100a42c3eb965a/requests-1.0.3.tar.gz#sha256=c7b50dc01b751e5ef8785951a74d0c2373bb0f87b45dca75dc2c5477b7e30f44">requests-1.0.3.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/5d/e8/f27e0868b9a49946b3f800722e02b19efebde22ae534276df3e5f6cca41d/requests-1.0.4.tar.gz#sha256=f363690a47dd4d6d6e7605fc686b668097a114cd946dffdf21fe0c6a6a46f9e6">requests-1.0.4.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/e8/ff/d19b7461d84a5804c5cdc29791305530a2b774fe928b497e74ac9b304c79/requests-1.1.0.tar.gz#sha256=21a81ddf1a3c2f956524538966ae19c38cae251f5629821588cdc8246a1335f7">requests-1.1.0.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/37/e4/74cb55b3da7777a1dc7cd7985c3cb12e83e213c03b0f9ca20d2c0e92b3c3/requests-1.2.0.tar.gz#sha256=cfa615644ae38efe8423ce9edb23470a4615a9147fa3cea5026afb47c9bb3913">requests-1.2.0.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/3b/9e/bfa03431335e778854da3d562697e067df40870a78ca81b35089822c6583/requests-1.2.1.tar.gz#sha256=946b7c856aa62f4ad31de2b9bb501cfdcdb4afdc882ee76bd4664f57caefaa44">requests-1.2.1.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/c0/44/84a4b7a4e9d5fd1b358dbabd03f17e3dd91ce8881fc3446fbd2fd996be88/requests-1.2.2.tar.gz#sha256=56929d7b5dec9b37a9a8520f15202bada0ad55d2888a7c3243b9b194f2ef603d">requests-1.2.2.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/61/79/efc316760a906763de872d7328c9bf8c5af28708a35fdae57fbb4ee005f7/requests-1.2.3.tar.gz#sha256=156bf3ec27ba9ec7e0cf8fbe02808718099d218de403eb64a714d73ba1a29ab1">requests-1.2.3.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/bf/78/be2b4c440ea767336d8448fe671fe1d78ca499e49d77dac90f92191cca0e/requests-2.0.0-py2.py3-none-any.whl#sha256=2ef65639cb9600443f85451df487818c31f993ab288f313d29cc9db4f3cbe6ed">requests-2.0.0-py2.py3-none-any.whl</a><br/>
+          <a href="https://files.pythonhosted.org/packages/8e/88/102742c48605aef8d39fa719d932c67783d789679628fa1433cb4b2c7a2a/requests-2.0.0.tar.gz#sha256=78536038f54cff6ade3be6863403146665b5a3923dd61108c98d8b64141f9d70">requests-2.0.0.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/8f/ea/140f18072bbcd81885a9490abb171792fd2961fd7f366be58396f4c6d634/requests-2.0.1-py2.py3-none-any.whl#sha256=f4ebc402e0ea5a87a3d42e300b76c292612d8467024f45f9858a8768f9fb6f6e">requests-2.0.1-py2.py3-none-any.whl</a><br/>
+          <a href="https://files.pythonhosted.org/packages/1c/8e/376c93bb72bdae6a754797b8e31370df1e996e8b7dcc928e66691dbf611a/requests-2.0.1.tar.gz#sha256=8cfddb97667c2a9edaf28b506d2479f1b8dc0631cbdcd0ea8c8864def59c698b">requests-2.0.1.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/1e/97/f0a8e5e71c75a2abf5ec91438b84ec1a40a5e1b5f985c06721a3ebe57c0a/requests-2.1.0-py2.py3-none-any.whl#sha256=fcef306d62b1c061eb00b8402cf136ff0ea1daf7a53b60cdef9563a22850072c">requests-2.1.0-py2.py3-none-any.whl</a><br/>
+          <a href="https://files.pythonhosted.org/packages/51/5d/3729c242ed7693f29941fd9d40e936d4994b0aa704dfd0c023312fcce8a3/requests-2.1.0.tar.gz#sha256=a57307f3a5f35ec9e1254aaf3e0484063ee3ee6b5f123fb35c5b2673492efa71">requests-2.1.0.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/3b/99/a8acc0c986281232f9476575c27a81ab697afbf089f42f05c196f51892c0/requests-2.2.0-py2.py3-none-any.whl#sha256=889d334044cd3364d07419c37671ba4f213d0f59601109dcb54c8a7ebdde38ee">requests-2.2.0-py2.py3-none-any.whl</a><br/>
+          <a href="https://files.pythonhosted.org/packages/c9/5a/aa687599abd76de72ae5a554e2e70328fc311d59e0b1e999263fb094baf3/requests-2.2.0.tar.gz#sha256=1ff74f88bbfddf94f92aa20bd8473c7d46d3398c95b1842d81b2f3c475d5625d">requests-2.2.0.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/7d/15/6efffc6aee666e1456852c2bf1d483b46bf971a2d509b35a98fc3eae1c60/requests-2.2.1-py2.py3-none-any.whl#sha256=b5bd2e1b78d28051108ebaa6248750221f9ccef52b4f054cb727de61b0406de0">requests-2.2.1-py2.py3-none-any.whl</a><br/>
+          <a href="https://files.pythonhosted.org/packages/d1/0c/2dc2996268bc64b531a5a2dc6f4ec04552f3a8a2a86e88aeedcb92987741/requests-2.2.1.tar.gz#sha256=1266921f1bed5fbf364cd83cf239b6d7b3ea5c32ccccbc93980d9ba12cdcfd02">requests-2.2.1.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/f7/51/7aa1e337862118bee783c0249debd64cb07b8fbdfef154b1e185754b02d5/requests-2.3.0-py2.py3-none-any.whl#sha256=3648802492e955ffeb28f6dab864ad714059f5438bf6798d82f9d477c666aca3">requests-2.3.0-py2.py3-none-any.whl</a><br/>
+          <a href="https://files.pythonhosted.org/packages/ab/f9/4425c8410faf7c7d420dbd64e127f2cfb68cfef869a374b332610b6abc09/requests-2.3.0.tar.gz#sha256=1c1473875d846fe563d70868acf05b1953a4472f4695b7b3566d1d978957b8fc">requests-2.3.0.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/78/14/23cf8ede304c7c8b69b929b17074292073827239c31659ab8c7beb22a059/requests-2.4.0-py2.py3-none-any.whl#sha256=8b2cc9e334b3e66aa5df15f2e4967f2c95b5164a4e6df7e92dd70ca67400912a">requests-2.4.0-py2.py3-none-any.whl</a><br/>
+          <a href="https://files.pythonhosted.org/packages/ef/a0/9863b20b6a87e45cd4353c10277d9674f9ddfd7c28c58e61a339e273a119/requests-2.4.0.tar.gz#sha256=7007e03cbc73e357b5055c6ea0ad6e447e2afa00f1a1f843cd792a1ebaa3763e">requests-2.4.0.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/bf/81/22c8ed95e8088c0a7c022969534c8157930f0bed6ae77e12e86fdc2e855c/requests-2.4.1-py2.py3-none-any.whl#sha256=b9e3c10e5092b444bb4c1b0b337f57e6c3d7680ad7c5192f597e84dd931fb598">requests-2.4.1-py2.py3-none-any.whl</a><br/>
+          <a href="https://files.pythonhosted.org/packages/0f/d0/e80371e64a7a7bafa303ea50465456e5292d9436504ce39b9619b6ba24be/requests-2.4.1.tar.gz#sha256=35d890b0aaa6e09ec40d49361d823b998ced86cc7673a9ce70bbc4f986e13ad8">requests-2.4.1.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/a2/87/afb7990b87f76ec9d11fd15668c2362a8fbe8436e0a780c7fe5aedf1a299/requests-2.4.2-py2.py3-none-any.whl#sha256=49df4571ecd49d00a4587237b7d8be9664bb326052e06d2c488255b34f13393d">requests-2.4.2-py2.py3-none-any.whl</a><br/>
+          <a href="https://files.pythonhosted.org/packages/f8/25/1599a06d261fdd84256829d88f7a415c80a6e249988f9e17ba5016119b6f/requests-2.4.2.tar.gz#sha256=b98a76df30e95ef636af5e040ff7c5d0bc0b482899fd7a187b0ae525e41fe8f1">requests-2.4.2.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/8a/98/bf72c7bd3ecfaf46dc2de3e59dcda6e61766526d3cf5897e9edd599795fc/requests-2.4.3-py2.py3-none-any.whl#sha256=124890f41723c85aa82dfe0807432aea46d24aeb0dafce340969d2089548c2c3">requests-2.4.3-py2.py3-none-any.whl</a><br/>
+          <a href="https://files.pythonhosted.org/packages/f4/ff/34a5a2eb91e35280e65585c48304094b61b58f9966de74ab72673c2fde9d/requests-2.4.3.tar.gz#sha256=53c68313c5c6149b1a899234c000296e60a8900682accf73d6f0c6d608afc6b1">requests-2.4.3.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/32/0e/11cfb3a5e269605d0bbe3bbca9845da9b57aed90e75bd489e5e7e3509c13/requests-2.5.0-py2.py3-none-any.whl#sha256=66cbb850987e47177a3b4112392490bcb76eb75b37cc53da007e35f3ec894bc1">requests-2.5.0-py2.py3-none-any.whl</a><br/>
+          <a href="https://files.pythonhosted.org/packages/c8/fb/d14d1c5166a8449d36c9a3b2656706c506a2cf261d37a79d16c18c37b646/requests-2.5.0.tar.gz#sha256=d2daef4919fc87262b8b3cb5a9d214cac8ce1e50950f8423bbc1d31c2e63d38e">requests-2.5.0.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/54/9a/ee6051b19c62728d5467dead279c532798c287e39c3bc8becb1cfa9f525a/requests-2.5.1-py2.py3-none-any.whl#sha256=1f046dcf5ec712ed3be8684b9f33c95b76e28cd1c825db0f5e1557bfd87b3745">requests-2.5.1-py2.py3-none-any.whl</a><br/>
+          <a href="https://files.pythonhosted.org/packages/61/fe/2c0a4ca99c68ea24eec65d3094d6539d54635562678ee7a58420005c12b6/requests-2.5.1.tar.gz#sha256=7b7735efd3b1e2323dc9fcef060b380d05f5f18bd0f247f5e9e74a628279de66">requests-2.5.1.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/20/fc/53f45b9bdfa8bd5f11b7d60b50052a8e4729346fcc8d5854e0e1449d92b5/requests-2.5.2-py2.py3-none-any.whl#sha256=b4d1a981c443e19ee3f527b352022d698e16a298913d9b78ea1133f089eeb779">requests-2.5.2-py2.py3-none-any.whl</a><br/>
+          <a href="https://files.pythonhosted.org/packages/d6/f7/1a4c1cae7618ad3d9fe5536ef74f47b2cb1028938e12d6dfe0a9806a8e1b/requests-2.5.2.tar.gz#sha256=306ead91d47a48b6a25d495d2495de99694641bd7d2cac5bcc405a8837c7a612">requests-2.5.2.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/95/54/44dc83b5f11c6da06bf9abd18c8a0905e0e297e0a9c3bfbc0c6ee4bdd33d/requests-2.5.3-py2.py3-none-any.whl#sha256=3e66d7ba78e7a6a8eccd2e901079ab8d24e408b5375cf32eb51f291306302418">requests-2.5.3-py2.py3-none-any.whl</a><br/>
+          <a href="https://files.pythonhosted.org/packages/a6/36/06a7d4261f91552f21f017fe162d69df95ca7925d1436c8acf73283ee3d0/requests-2.5.3.tar.gz#sha256=55d7f5619daae94ec49ee81ed8c865e5a2a47f0bbf8e06cf94636bee103eaf65">requests-2.5.3.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/73/63/b0729be549494a3e31316437053bc4e0a8bb71a07a6ee6059434b8f1cd5f/requests-2.6.0-py2.py3-none-any.whl#sha256=fdb9af60d47ca57a80df0a213336019a34ff6192d8fff361c349f2c8398fe460">requests-2.6.0-py2.py3-none-any.whl</a><br/>
+          <a href="https://files.pythonhosted.org/packages/eb/70/237e11db04807a9409ed39997097118208e7814309d9bc3da7bb98d1fe3d/requests-2.6.0.tar.gz#sha256=1cdbed1f0e236f35ef54e919982c7a338e4fea3786310933d3a7887a04b74d75">requests-2.6.0.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/64/74/5bedd762987b5cb4ad5de4901d12942ad7635bffa5ae4f6b5e725d1b2068/requests-2.6.1-py2.py3-none-any.whl#sha256=79515d60eae4f5d426b8813ffd60ed874169d78b8815844e8e85798ef27a599f">requests-2.6.1-py2.py3-none-any.whl</a><br/>
+          <a href="https://files.pythonhosted.org/packages/08/d5/3dfb95813d697d1e5a3eccb9b88f9d91a233fc35b0ddbb5bc238142f9de0/requests-2.6.1.tar.gz#sha256=490b111c824d64b84797a899a4c22618bbc45323ac24a0a0bb4b73a8758e943c">requests-2.6.1.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/9f/3e/c09023432b822a09d965878640de63f8126d77c948f45c24dcad13d42721/requests-2.6.2-py2.py3-none-any.whl#sha256=8f0f56813f82d0c27d9578221268ac9af48f076c71ee69693305ceca6ca355bd">requests-2.6.2-py2.py3-none-any.whl</a><br/>
+          <a href="https://files.pythonhosted.org/packages/37/b3/d1a5d9768240a1104a620730a1226975ceb9dd3882a8cfd8935b314ee0ca/requests-2.6.2.tar.gz#sha256=0577249d4b6c4b11fd97c28037e98664bfaa0559022fee7bcef6b752a106e505">requests-2.6.2.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/26/ff/c71b3943bebdd9f7ceb9e137296370587eb0b33fe2eb3732ae168bc45204/requests-2.7.0-py2.py3-none-any.whl#sha256=20f976cdce02a42b69ce80e9e03897a51814b36d448b37288546086ebc473146">requests-2.7.0-py2.py3-none-any.whl</a><br/>
+          <a href="https://files.pythonhosted.org/packages/0a/00/8cc925deac3a87046a4148d7846b571cf433515872b5430de4cd9dea83cb/requests-2.7.0.tar.gz#sha256=398a3db6d61899d25fd4a06c6ca12051b0ce171d705decd7ed5511517b4bb93d">requests-2.7.0.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/5d/a6/90f822c17b4fc905da67aed49b511f110207242ff164aeda926461101dc6/requests-2.8.0-py2.py3-none-any.whl#sha256=3a34af0dd06fed021286d93da464bbb76dcc0c709d02e7d3cdca195b1341c380">requests-2.8.0-py2.py3-none-any.whl</a><br/>
+          <a href="https://files.pythonhosted.org/packages/1b/92/0632a7eb5e94bfedd300a3a5f4ebbf8505fd9768ba00ab259b5bf786de5f/requests-2.8.0.tar.gz#sha256=b2f003589b60924909c0acde472590c5ea83906986a7a25b6f7929eb20923b7b">requests-2.8.0.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/c0/0f/a911a44c89ba01b23d8fe3defbdfca1e962de6f11a11da32658902cdc2a4/requests-2.8.1-py2.py3-none-any.whl#sha256=89f1b1f25dcd7b68f514e8d341a5b2eb466f960ae756822eaab480a3c1a81c28">requests-2.8.1-py2.py3-none-any.whl</a><br/>
+          <a href="https://files.pythonhosted.org/packages/38/2d/290d33417c079a5248fcd06b0b8492acdd1851e54e4bdad54c3859dab600/requests-2.8.1.tar.gz#sha256=84fe8d5bf4dcdcc49002446c47a146d17ac10facf00d9086659064ac43b6c25b">requests-2.8.1.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/bf/b7/c0b5a7fcf561577178ffd65af9af37c412cf6fbb1a2a198b9308b343d63f/requests-2.9.0-py2.py3-none-any.whl#sha256=1f4726bc7636edcbd141ba9c868dd92ecb77dbc869f68a28c32e9e149b070854">requests-2.9.0-py2.py3-none-any.whl</a><br/>
+          <a href="https://files.pythonhosted.org/packages/e4/99/3e33bfe263894278a094c374f87031554406e57fd0b1ad22520357556627/requests-2.9.0.tar.gz#sha256=4881966532b5a36c552244fd909de66d1b8c4a26086f56fd5837cfcde63f8eb8">requests-2.9.0.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/b8/f7/3bb4d18c234a8ce7044d5ee2e1082b7d72bf6c550afb8d51ae266dea56f1/requests-2.9.1-py2.py3-none-any.whl#sha256=113fbba5531a9e34945b7d36b33a084e8ba5d0664b703c81a7c572d91919a5b8">requests-2.9.1-py2.py3-none-any.whl</a><br/>
+          <a href="https://files.pythonhosted.org/packages/f9/6d/07c44fb1ebe04d069459a189e7dab9e4abfe9432adcd4477367c25332748/requests-2.9.1.tar.gz#sha256=c577815dd00f1394203fc44eb979724b098f88264a9ef898ee45b8e5e9cf587f">requests-2.9.1.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/8b/e7/229a428b8eb9a7f925ef16ff09ab25856efe789410d661f10157919f2ae2/requests-2.9.2-py2.py3-none-any.whl#sha256=22a8c72dfc7fc18db1aca6784e97a638e9d09abe2cd387be473f88bd6dcba22f">requests-2.9.2-py2.py3-none-any.whl</a><br/>
+          <a href="https://files.pythonhosted.org/packages/64/20/2133a092a0e87d1c250fe48704974b73a1341b7e4f800edecf40462a825d/requests-2.9.2.tar.gz#sha256=d8be941a08cf36e4f424ac76073eb911e5e646a33fcb3402e1642c426bf34682">requests-2.9.2.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/99/b4/63d99ba8e189c47d906b43bae18af4396e336f2b1bfec86af31efe2d2cb8/requests-2.10.0-py2.py3-none-any.whl#sha256=09bc1b5f3a56cd8c48d433213a8cba51a67d12936568f73b5f1793fcb0c0979e">requests-2.10.0-py2.py3-none-any.whl</a><br/>
+          <a href="https://files.pythonhosted.org/packages/49/6f/183063f01aae1e025cf0130772b55848750a2f3a89bfa11b385b35d7329d/requests-2.10.0.tar.gz#sha256=63f1815788157130cee16a933b2ee184038e975f0017306d723ac326b5525b54">requests-2.10.0.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/f8/90/42d5e0d9b5c4c3629a3d99823bbc3748fb85616f0f7a45e79ba7908d4642/requests-2.11.0-py2.py3-none-any.whl#sha256=8b9b147f3dff1fc4055ff794ff931f735ed25e87efe667ed7c845a4bafae9b73">requests-2.11.0-py2.py3-none-any.whl</a><br/>
+          <a href="https://files.pythonhosted.org/packages/8d/66/649f861f980c0a168dd4cccc4dd0ed8fa5bd6c1bed3bea9a286434632771/requests-2.11.0.tar.gz#sha256=b2ff053e93ef11ea08b0e596a1618487c4e4c5f1006d7a1706e3671c57dea385">requests-2.11.0.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/ea/03/92d3278bf8287c5caa07dbd9ea139027d5a3592b0f4d14abf072f890fab2/requests-2.11.1-py2.py3-none-any.whl#sha256=545c4855cd9d7c12671444326337013766f4eea6068c3f0307fb2dc2696d580e">requests-2.11.1-py2.py3-none-any.whl</a><br/>
+          <a href="https://files.pythonhosted.org/packages/2e/ad/e627446492cc374c284e82381215dcd9a0a87c4f6e90e9789afefe6da0ad/requests-2.11.1.tar.gz#sha256=5acf980358283faba0b897c73959cecf8b841205bb4b2ad3ef545f46eae1a133">requests-2.11.1.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/00/93/9c5c04821578c2ee11af83189c5cbd8338724b5e04e1de5dc3643bbc5bbf/requests-2.12.0-py2.py3-none-any.whl#sha256=a7d8f8f46603b78f03a925227f33988276fbe6c1f3c8cb20174ba9bfc5114c4d">requests-2.12.0-py2.py3-none-any.whl</a><br/>
+          <a href="https://files.pythonhosted.org/packages/6a/97/7b856a8c8a0efebebb0bbba70c7ee879ee3f9654f28928665b64026ef09a/requests-2.12.0.tar.gz#sha256=57b6c314a2c5f014dce634a0e1eeeb1707741b2e30bc7fee9c5b01fa216d57a3">requests-2.12.0.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/9b/31/e9925a2b9a06f97c3450bac6107928d3533bfe64ca5615442504104321e8/requests-2.12.1-py2.py3-none-any.whl#sha256=3f3f27a9d0f9092935efc78054ef324eb9f8166718270aefe036dfa1e4f68e1e">requests-2.12.1-py2.py3-none-any.whl</a><br/>
+          <a href="https://files.pythonhosted.org/packages/6e/40/7434b2d9fe24107ada25ec90a1fc646e97f346130a2c51aa6a2b1aba28de/requests-2.12.1.tar.gz#sha256=2109ecea94df90980be040490ff1d879971b024861539abb00054062388b612e">requests-2.12.1.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/59/dc/54d39bef11678853ca78fc6167cc1b57becf491548942246dd2226bf2bd2/requests-2.12.2-py2.py3-none-any.whl#sha256=e5a102790b234bde8f949090e50e294490c2be0d81e3d55530fd91f3b5eded63">requests-2.12.2-py2.py3-none-any.whl</a><br/>
+          <a href="https://files.pythonhosted.org/packages/18/87/3c46a06df7b29cd3ab51f055cae2a954758ee3dcbd075d7f4c9a4e8aafbc/requests-2.12.2.tar.gz#sha256=09dadb7c5c4210ebbc7f1b14a351a754f1191bd7cd5a5b60ee1929b8c7dcbbe6">requests-2.12.2.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/84/68/f0acceafe80354aa9ff4ae49de0572d27929b6d262f0c55196424eb86b2f/requests-2.12.3-py2.py3-none-any.whl#sha256=d92ed9912bab3f5e52d8e231be82c106650f648185e952f83c44ab4f2be55c0c">requests-2.12.3-py2.py3-none-any.whl</a><br/>
+          <a href="https://files.pythonhosted.org/packages/d9/03/155b3e67fe35fe5b6f4227a8d9e96a14fda828b18199800d161bcefc1359/requests-2.12.3.tar.gz#sha256=de5d266953875e9647e37ef7bfe6ef1a46ff8ddfe61b5b3652edf7ea717ee2b2">requests-2.12.3.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/ed/9e/60cc074968c095f728f0d8d28370e8d396fa60afb7582735563cccf223dd/requests-2.12.4-py2.py3-none-any.whl#sha256=000748df49e087784441b2621c50fb81046c5c8e80e0d91674ffad65b9e13844">requests-2.12.4-py2.py3-none-any.whl</a><br/>
+          <a href="https://files.pythonhosted.org/packages/5b/0b/34be574b1ec997247796e5d516f3a6b6509c4e064f2885a96ed885ce7579/requests-2.12.4.tar.gz#sha256=ed98431a0631e309bb4b63c81d561c1654822cb103de1ac7b47e45c26be7ae34">requests-2.12.4.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/bf/99/af6139323bac0ca0c6023eabbdc526579525f5584278d001dd2e169f8300/requests-2.12.5-py2.py3-none-any.whl#sha256=d57dae49f4267e8cb378aff9e426c9304a78794d03e945e39bfc607355715658">requests-2.12.5-py2.py3-none-any.whl</a><br/>
+          <a href="https://files.pythonhosted.org/packages/b6/61/7b374462d5b6b1d824977182db287758d549d8680444bad8d530195acba2/requests-2.12.5.tar.gz#sha256=d902a54f08d086a7cc6e58c20e2bb225b1ae82c19c35e5925269ee94fb9fce00">requests-2.12.5.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/7e/ac/a80ed043485a3764053f59ca92f809cc8a18344692817152b0e8bd3ca891/requests-2.13.0-py2.py3-none-any.whl#sha256=1a720e8862a41aa22e339373b526f508ef0c8988baf48b84d3fc891a8e237efb">requests-2.13.0-py2.py3-none-any.whl</a><br/>
+          <a href="https://files.pythonhosted.org/packages/16/09/37b69de7c924d318e51ece1c4ceb679bf93be9d05973bb30c35babd596e2/requests-2.13.0.tar.gz#sha256=5722cd09762faa01276230270ff16af7acf7c5c45d623868d9ba116f15791ce8">requests-2.13.0.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/1b/d3/f2541f2965e78f139bff9f001594d41ed90f4b2ce4b61bca387e60c1d3b4/requests-2.14.0-py2.py3-none-any.whl#sha256=a90555c0be723f5c711de36f256b21a65fc599602274fb3d5c4f83ac23aae3c5">requests-2.14.0-py2.py3-none-any.whl</a><br/>
+          <a href="https://files.pythonhosted.org/packages/0b/ac/ffd3674211bc47ae3bf55c7cd4a8fe484b7289af2ffd9cfed5683708690a/requests-2.14.0.tar.gz#sha256=8c4f778459cb4a6bad7ceff4aa65a75697db28c21a6b41ea9a6c371df2a822c2">requests-2.14.0.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/74/ac/789eb98e0f5431d6d1ce36549ead88b2ab3154260f37c7dac9a34fd170b1/requests-2.14.1-py2.py3-none-any.whl#sha256=c5a42004b9cd384e5ad0f868b1cc968a3c2bb0276dccc12e4bdc7330591b5f51">requests-2.14.1-py2.py3-none-any.whl</a><br/>
+          <a href="https://files.pythonhosted.org/packages/8c/ff/78297074b9b4cf102f9bbd71b62508965dd5c1876e016ef131e5b15c16a4/requests-2.14.1.tar.gz#sha256=b3b191d677e526c1e512db86bc7387ccb8356e8826bcc7faa07f78f09afe68dd">requests-2.14.1.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/e4/b0/286e8a936158e5cc5791d5fa3bc4b1d5a7e1ff4e5b3f3766b63d8e97708a/requests-2.14.2-py2.py3-none-any.whl#sha256=3b39cde35be51762885631cf586f4dc2284951b44d479a4454020758d767cc2f">requests-2.14.2-py2.py3-none-any.whl</a><br/>
+          <a href="https://files.pythonhosted.org/packages/72/46/4abc3f5aaf7bf16a52206bb0c68677a26c216c1e6625c78c5aef695b5359/requests-2.14.2.tar.gz#sha256=a274abba399a23e8713ffd2b5706535ae280ebe2b8069ee6a941cb089440d153">requests-2.14.2.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/fa/a5/e04c4607dc96e3e6b22dfa13ba8776c64bb65cb97ab90f05a3ee14096a0a/requests-2.15.1-py2.py3-none-any.whl#sha256=ff753b2196cd18b1bbeddc9dcd5c864056599f7a7d9a4fb5677e723efa2b7fb9">requests-2.15.1-py2.py3-none-any.whl</a><br/>
+          <a href="https://files.pythonhosted.org/packages/6d/ed/3adebdc29ca33f11bca00c38c72125cd4a51091e13685375ba4426fb59dc/requests-2.15.1.tar.gz#sha256=e5659b9315a0610505e050bb7190bf6fa2ccee1ac295f2b760ef9d8a03ebbb2e">requests-2.15.1.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/35/b8/8ff3310309beb5fbca033b56504f869b0c65c1f284ae2a7900593b5acd3c/requests-2.16.0-py2.py3-none-any.whl#sha256=012cddec41f96a1ce4bab4b0a0ed40263ae6b2b03aa4bc4711e00418e7f3157c">requests-2.16.0-py2.py3-none-any.whl</a><br/>
+          <a href="https://files.pythonhosted.org/packages/26/e7/4f1ec439ecbcfe3989bb79a9c323d2482e7beea3d8d453e07443302648ec/requests-2.16.0.tar.gz#sha256=88eee720e83bc1dcb009ad5e2a8f1d41e903892121ec2a36eba7bf5a2d3ac2a0">requests-2.16.0.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/c7/5d/7711f9fc9b028dc7572f84589e206220f0072e29fd9c7ae3507e7d17d8a6/requests-2.16.1-py2.py3-none-any.whl#sha256=b81b3651a206f02709e374c52071b4ac9bdf463c193701a560ce8e25c9ecc80b">requests-2.16.1-py2.py3-none-any.whl</a><br/>
+          <a href="https://files.pythonhosted.org/packages/4c/54/1d3abddbd4c7544138b88e8329ef5294ffdc6c5d7ea965bf42e3cc4c9c39/requests-2.16.1.tar.gz#sha256=14d663571c66410a7c3634f4cb9040b16a1c083078e37a0f8cc3710eae63411e">requests-2.16.1.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/67/91/b3893b0db7c645b9f92aa827ce3db630eef2dd3a2ad3109c2a28cdc9e6b7/requests-2.16.2-py2.py3-none-any.whl#sha256=afebb4fcabd66ba6e3188fd31f09915f5afd213b204014ea02448011eca1e49a">requests-2.16.2-py2.py3-none-any.whl</a><br/>
+          <a href="https://files.pythonhosted.org/packages/3c/69/d49fd9a7be23c55278c92e60af6d57336c463d8593afe7260a1665346965/requests-2.16.2.tar.gz#sha256=a2956efcf8dd2d526286431fdb0ec78eff25ab8db8a03c4f9d66f5fe6024f168">requests-2.16.2.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/76/b6/e3035b7baa98e20d248fe17af2097b882ec7724d9a8ee7ae195ad7110f82/requests-2.16.3-py2.py3-none-any.whl#sha256=bcdc06ebfc25f2a198274ae4710c3217fb968c5f9468dc410cd603a59c47bff2">requests-2.16.3-py2.py3-none-any.whl</a><br/>
+          <a href="https://files.pythonhosted.org/packages/07/db/3ed266e9cd3e3f69af3af38f56a0b4e21dadf3065521b2860030889284d7/requests-2.16.3.tar.gz#sha256=7fda55400281de8fba713dd120b4614eabc10c0b096c22bfc88ccc671227c3d4">requests-2.16.3.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/13/52/41fb28aa332ed68cd616cd1fc44d9e9c4bb85aa60c28d275f8857da561e5/requests-2.16.4-py2.py3-none-any.whl#sha256=784213e164287b403497195cf7f45071ae5eec60ae260cbc9a26368a91445f57">requests-2.16.4-py2.py3-none-any.whl</a><br/>
+          <a href="https://files.pythonhosted.org/packages/47/68/4fe8c7e9e95133d15e342b1403a1751909cddb814a5a9cced2ba4c63487d/requests-2.16.4.tar.gz#sha256=14db43bfaa61fd3102eecaf447a593e0650ba0dc261c72597109a973c23091ab">requests-2.16.4.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/65/9c/57484d6ac262af20a10b52cd95ebc99843f282342ef008997ef60f9eeb9c/requests-2.16.5-py2.py3-none-any.whl#sha256=3a27020d547958f5270fd5e9d62250119ee7db7454644599b65fda20cb542ded">requests-2.16.5-py2.py3-none-any.whl</a><br/>
+          <a href="https://files.pythonhosted.org/packages/de/4c/7c36954d002030c82df31d000338d40fd91b4a993941a8f3c2dbe523c749/requests-2.16.5.tar.gz#sha256=f717303ebff661099cc5b73ce723ae1246f19ac39faa4c8005be56744d1a1006">requests-2.16.5.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/5b/b6/9a18db79553524246aa1b081829e6f977667ec558cef684988895c1092d9/requests-2.17.0-py2.py3-none-any.whl#sha256=73b4088c05f7fb5ca8e68651ed802df3ca40621281acf74bb321b4a8408aab7e">requests-2.17.0-py2.py3-none-any.whl</a><br/>
+          <a href="https://files.pythonhosted.org/packages/7c/84/617aaa311f6504489459c016daff4c66df6bbd54ee35b4cbed3e994f322d/requests-2.17.0.tar.gz#sha256=eff227db5864238d44270cbadc8ac4133e69b69a2e7092b7b316ed1e4761cbd6">requests-2.17.0.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/50/41/f6fdaf24a80c726a72f76b15869a20734b7a527081129a380ddce99ffae0/requests-2.17.1-py2.py3-none-any.whl#sha256=02242978c6aaee47953da9e4d20d9d9929a1284a6b3a8a63a243ac1b842bd12c">requests-2.17.1-py2.py3-none-any.whl</a><br/>
+          <a href="https://files.pythonhosted.org/packages/d0/c0/f66d080e64a361382ed665023b9925e274d833f410f8c7282fb878e9c60e/requests-2.17.1.tar.gz#sha256=9cf3698006012c000af2804fe4186042a4d55df0303552dd190a74f5eaafe69b">requests-2.17.1.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/9a/0b/7a65b391bde96d7b1749dc3562ce22f9cc86f37bd37122f71162304e3164/requests-2.17.2-py2.py3-none-any.whl#sha256=76d2f962485ebb3b3c380f146d56f5475310e53fd0defd6df0eb1c014187d45c">requests-2.17.2-py2.py3-none-any.whl</a><br/>
+          <a href="https://files.pythonhosted.org/packages/23/c2/99fe3c5c15f3d06f0620bc0867bee95ec64074cbd7c9805bb5ad3010411e/requests-2.17.2.tar.gz#sha256=3cc7a584aad15e84d193a6d7c9176af0cf49bc6611f24ec2e04be6b05957c96d">requests-2.17.2.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/29/b9/d26a6ab2ee178415ab8c0c591d2a1eb782a50c42a417ae390055f86a63c1/requests-2.17.3-py2.py3-none-any.whl#sha256=baf701b4a9d4cbe40169e8ab77816f7abadbad502ba459c30f7a2bc138e4d612">requests-2.17.3-py2.py3-none-any.whl</a><br/>
+          <a href="https://files.pythonhosted.org/packages/27/c7/a45641c83c6e28f4922ba6af3d4ae4d79b41932c2f3d77fed9e0bf878149/requests-2.17.3.tar.gz#sha256=8d29f97ed1541709b57caddb77bb20592411d7ca10ec4f03275f49ee8456e225">requests-2.17.3.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/e2/f0/c81405acbf53d0412b984eb3fc578cdd10e347374e1aec074638a500c186/requests-2.18.0-py2.py3-none-any.whl#sha256=5e88d64aa56ac0fda54e77fb9762ebc65879e171b746d5479a33c4082519d6c6">requests-2.18.0-py2.py3-none-any.whl</a><br/>
+          <a href="https://files.pythonhosted.org/packages/e0/97/e2f972b6826c9cfe57b6934e3773d2783733bc2d345d810bafd309df3d15/requests-2.18.0.tar.gz#sha256=cd0189f962787284bff715fddaad478eb4d9c15aa167bd64e52ea0f661e7ea5c">requests-2.18.0.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/5a/58/671011e3ff4a06e2969322267d78dcfda1bf4d1576551df1cce93cd7239d/requests-2.18.1-py2.py3-none-any.whl#sha256=6afd3371c1f4c1970497cdcace5c5ecbbe58267bf05ca1abd93d99d170803ab7">requests-2.18.1-py2.py3-none-any.whl</a><br/>
+          <a href="https://files.pythonhosted.org/packages/2c/b5/2b6e8ef8dd18203b6399e9f28c7d54f6de7b7549853fe36d575bd31e29a7/requests-2.18.1.tar.gz#sha256=c6f3bdf4a4323ac7b45d01e04a6f6c20e32a052cd04de81e05103abc049ad9b9">requests-2.18.1.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/cf/fa/31b222e4b44975de1b5ac3e1a725abdfeb00e0d761567ab426ee28a7fc73/requests-2.18.2-py2.py3-none-any.whl#sha256=414459f05392835d4d653b57b8e58f98aea9c6ff2782e37de0a1ee92891ce900">requests-2.18.2-py2.py3-none-any.whl</a><br/>
+          <a href="https://files.pythonhosted.org/packages/07/2e/81fdfdfac91cf3cb2518fb149ac67caf0e081b485eab68e9aee63396f7e8/requests-2.18.2.tar.gz#sha256=5b26fcc5e72757a867e4d562333f841eddcef93548908a1bb1a9207260618da9">requests-2.18.2.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/ba/92/c35ed010e8f96781f08dfa6d9a6a19445a175a9304aceedece77cd48b68f/requests-2.18.3-py2.py3-none-any.whl#sha256=b62be4ec5999c24d10c98d248a136e7db20ca6616a2b65060cd9399417331e8a">requests-2.18.3-py2.py3-none-any.whl</a><br/>
+          <a href="https://files.pythonhosted.org/packages/c3/38/d95ddb6cc8558930600be088e174a2152261a1e0708a18bf91b5b8c90b22/requests-2.18.3.tar.gz#sha256=fb68a7baef4965c12d9cd67c0f5a46e6e28be3d8c7b6910c758fbcc99880b518">requests-2.18.3.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/49/df/50aa1999ab9bde74656c2919d9c0c085fd2b3775fd3eca826012bef76d8c/requests-2.18.4-py2.py3-none-any.whl#sha256=6a1b267aa90cac58ac3a765d067950e7dbbf75b1da07e895d1f594193a40a38b">requests-2.18.4-py2.py3-none-any.whl</a><br/>
+          <a href="https://files.pythonhosted.org/packages/b0/e1/eab4fc3752e3d240468a8c0b284607899d2fbfb236a56b7377a329aa8d09/requests-2.18.4.tar.gz#sha256=9c443e7324ba5b85070c4a818ade28bfabedf16ea10206da1132edaa6dda237e">requests-2.18.4.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/cc/15/e1c318dbc20032ffbe5628837ca0de2d5b116ffd1b849c699634010f6a5d/requests-2.19.0-py2.py3-none-any.whl#sha256=421cfc8d9dde7d6aff68196420afd86b88c65d77d8da9cf83f4ecad785d7b9d6" data-requires-python="&gt;=2.6, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*">requests-2.19.0-py2.py3-none-any.whl</a><br/>
+          <a href="https://files.pythonhosted.org/packages/75/27/82da3fa4ea7a8c3526c48eaafe427352ff9c931633b917c2251826a43697/requests-2.19.0.tar.gz#sha256=cc408268d0e21589bcc2b2c248e42932b8c4d112f499c12c92e99e2178a6134c" data-requires-python="&gt;=2.6, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*">requests-2.19.0.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/65/47/7e02164a2a3db50ed6d8a6ab1d6d60b69c4c3fdf57a284257925dfc12bda/requests-2.19.1-py2.py3-none-any.whl#sha256=63b52e3c866428a224f97cab011de738c36aec0185aa91cfacd418b5d58911d1" data-requires-python="&gt;=2.6, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*">requests-2.19.1-py2.py3-none-any.whl</a><br/>
+          <a href="https://files.pythonhosted.org/packages/54/1f/782a5734931ddf2e1494e4cd615a51ff98e1879cbe9eecbdfeaf09aa75e9/requests-2.19.1.tar.gz#sha256=ec22d826a36ed72a7358ff3fe56cbd4ba69dd7a6718ffd450ff0e9df7a47ce6a" data-requires-python="&gt;=2.6, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*">requests-2.19.1.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/f1/ca/10332a30cb25b627192b4ea272c351bce3ca1091e541245cccbace6051d8/requests-2.20.0-py2.py3-none-any.whl#sha256=a84b8c9ab6239b578f22d1c21d51b696dcfe004032bb80ea832398d6909d7279" data-requires-python="&gt;=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*">requests-2.20.0-py2.py3-none-any.whl</a><br/>
+          <a href="https://files.pythonhosted.org/packages/97/10/92d25b93e9c266c94b76a5548f020f3f1dd0eb40649cb1993532c0af8f4c/requests-2.20.0.tar.gz#sha256=99dcfdaaeb17caf6e526f32b6a7b780461512ab3f1d992187801694cba42770c" data-requires-python="&gt;=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*">requests-2.20.0.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/ff/17/5cbb026005115301a8fb2f9b0e3e8d32313142fe8b617070e7baad20554f/requests-2.20.1-py2.py3-none-any.whl#sha256=65b3a120e4329e33c9889db89c80976c5272f56ea92d3e74da8a463992e3ff54" data-requires-python="&gt;=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*">requests-2.20.1-py2.py3-none-any.whl</a><br/>
+          <a href="https://files.pythonhosted.org/packages/40/35/298c36d839547b50822985a2cf0611b3b978a5ab7a5af5562b8ebe3e1369/requests-2.20.1.tar.gz#sha256=ea881206e59f41dbd0bd445437d792e43906703fff75ca8ff43ccdb11f33f263" data-requires-python="&gt;=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*">requests-2.20.1.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/7d/e3/20f3d364d6c8e5d2353c72a67778eb189176f08e873c9900e10c0287b84b/requests-2.21.0-py2.py3-none-any.whl#sha256=7bf2a778576d825600030a110f3c0e3e8edc51dfaafe1c146e39a2027784957b" data-requires-python="&gt;=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*">requests-2.21.0-py2.py3-none-any.whl</a><br/>
+          <a href="https://files.pythonhosted.org/packages/52/2c/514e4ac25da2b08ca5a464c50463682126385c4272c18193876e91f4bc38/requests-2.21.0.tar.gz#sha256=502a824f31acdacb3a35b6690b5fbf0bc41d63a24a45c4004352b0242707598e" data-requires-python="&gt;=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*">requests-2.21.0.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/51/bd/23c926cd341ea6b7dd0b2a00aba99ae0f828be89d72b2190f27c11d4b7fb/requests-2.22.0-py2.py3-none-any.whl#sha256=9cf5292fcd0f598c671cfc1e0d7d1a7f13bb8085e9a590f48c010551dc6c4b31" data-requires-python="&gt;=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*">requests-2.22.0-py2.py3-none-any.whl</a><br/>
+          <a href="https://files.pythonhosted.org/packages/01/62/ddcf76d1d19885e8579acb1b1df26a852b03472c0e46d2b959a714c90608/requests-2.22.0.tar.gz#sha256=11e007a8a2aa0323f5a921e9e6a2d7e4e67d9877e85773fba9ba6419025cbeb4" data-requires-python="&gt;=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*">requests-2.22.0.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/19/0a/6efa24d3589a8595a7293bd9716bbd4608fcc668a27aa83fff9043c515f7/requests-2.23.0-py2.7.egg#sha256=5d2d0ffbb515f39417009a46c14256291061ac01ba8f875b90cad137de83beb4" data-requires-python="&gt;=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*">requests-2.23.0-py2.7.egg</a><br/>
+          <a href="https://files.pythonhosted.org/packages/1a/70/1935c770cb3be6e3a8b78ced23d7e0f3b187f5cbfab4749523ed65d7c9b1/requests-2.23.0-py2.py3-none-any.whl#sha256=43999036bfa82904b6af1d99e4882b560e5e2c68e5c4b0aa03b655f3d7d73fee" data-requires-python="&gt;=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*">requests-2.23.0-py2.py3-none-any.whl</a><br/>
+          <a href="https://files.pythonhosted.org/packages/f5/4f/280162d4bd4d8aad241a21aecff7a6e46891b905a4341e7ab549ebaf7915/requests-2.23.0.tar.gz#sha256=b3f43d496c6daba4493e7c431722aeb7dbc6288f52a6e04e7b6023b0247817e6" data-requires-python="&gt;=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*">requests-2.23.0.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/45/1e/0c169c6a5381e241ba7404532c16a21d86ab872c9bed8bdcd4c423954103/requests-2.24.0-py2.py3-none-any.whl#sha256=fe75cc94a9443b9246fc7049224f75604b113c36acb93f87b80ed42c44cbb898" data-requires-python="&gt;=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*">requests-2.24.0-py2.py3-none-any.whl</a><br/>
+          <a href="https://files.pythonhosted.org/packages/da/67/672b422d9daf07365259958912ba533a0ecab839d4084c487a5fe9a5405f/requests-2.24.0.tar.gz#sha256=b3559a131db72c33ee969480840fff4bb6dd111de7dd27c8ee1f820f4f00231b" data-requires-python="&gt;=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*">requests-2.24.0.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/39/fc/f91eac5a39a65f75a7adb58eac7fa78871ea9872283fb9c44e6545998134/requests-2.25.0-py2.py3-none-any.whl#sha256=e786fa28d8c9154e6a4de5d46a1d921b8749f8b74e28bde23768e5e16eece998" data-requires-python="&gt;=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*">requests-2.25.0-py2.py3-none-any.whl</a><br/>
+          <a href="https://files.pythonhosted.org/packages/9f/14/4a6542a078773957aa83101336375c9597e6fe5889d20abda9c38f9f3ff2/requests-2.25.0.tar.gz#sha256=7f1a0b932f4a60a1a65caa4263921bb7d9ee911957e0ae4a23a6dd08185ad5f8" data-requires-python="&gt;=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*">requests-2.25.0.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/29/c1/24814557f1d22c56d50280771a17307e6bf87b70727d975fd6b2ce6b014a/requests-2.25.1-py2.py3-none-any.whl#sha256=c210084e36a42ae6b9219e00e48287def368a26d03a048ddad7bfee44f75871e" data-requires-python="&gt;=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*">requests-2.25.1-py2.py3-none-any.whl</a><br/>
+          <a href="https://files.pythonhosted.org/packages/6b/47/c14abc08432ab22dc18b9892252efaf005ab44066de871e72a38d6af464b/requests-2.25.1.tar.gz#sha256=27973dd4a904a4f13b263a19c866c13b92a39ed1c964655f025f3f8d3d75b804" data-requires-python="&gt;=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*">requests-2.25.1.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/92/96/144f70b972a9c0eabbd4391ef93ccd49d0f2747f4f6a2a2738e99e5adc65/requests-2.26.0-py2.py3-none-any.whl#sha256=6c1246513ecd5ecd4528a0906f910e8f0f9c6b8ec72030dc9fd154dc1a6efd24" data-requires-python="&gt;=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*">requests-2.26.0-py2.py3-none-any.whl</a><br/>
+          <a href="https://files.pythonhosted.org/packages/e7/01/3569e0b535fb2e4a6c384bdbed00c55b9d78b5084e0fb7f4d0bf523d7670/requests-2.26.0.tar.gz#sha256=b8aa58f8cf793ffd8782d3d8cb19e66ef36f7aba4353eec859e74678b01b07a7" data-requires-python="&gt;=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*">requests-2.26.0.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/47/01/f420e7add78110940639a958e5af0e3f8e07a8a8b62049bac55ee117aa91/requests-2.27.0-py2.py3-none-any.whl#sha256=f71a09d7feba4a6b64ffd8e9d9bc60f9bf7d7e19fd0e04362acb1cfc2e3d98df" data-requires-python="&gt;=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*">requests-2.27.0-py2.py3-none-any.whl</a><br/>
+          <a href="https://files.pythonhosted.org/packages/c0/e3/826e27b942352a74b656e8f58b4dc7ed9495ce2d4eeb498181167c615303/requests-2.27.0.tar.gz#sha256=8e5643905bf20a308e25e4c1dd379117c09000bf8a82ebccc462cfb1b34a16b5" data-requires-python="&gt;=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*">requests-2.27.0.tar.gz</a><br/>
+          <a href="https://files.pythonhosted.org/packages/2d/61/08076519c80041bc0ffa1a8af0cbd3bf3e2b62af10435d269a9d0f40564d/requests-2.27.1-py2.py3-none-any.whl#sha256=f22fa1e554c9ddfd16e6e41ac79759e17be9e492b3587efa038054674760e72d" data-requires-python="&gt;=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*">requests-2.27.1-py2.py3-none-any.whl</a><br/>
+          <a href="https://files.pythonhosted.org/packages/60/f3/26ff3767f099b73e0efa138a9998da67890793bfa475d8278f84a30fec77/requests-2.27.1.tar.gz#sha256=68d7c56fd5a8999887728ef304a6d12edc7be74f1cfa47714fc8b414525c9a61" data-requires-python="&gt;=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*">requests-2.27.1.tar.gz</a><br/>
+          </body>
+      </html>
+      <!--SERIAL 13685488-->
+    headers:
+      Accept-Ranges:
+      - bytes
+      Cache-Control:
+      - max-age=600, public
+      Content-Security-Policy:
+      - default-src 'none'; sandbox allow-top-navigation
+      Content-Type:
+      - text/html; charset=UTF-8
+      Date:
+      - Mon, 09 May 2022 10:11:10 GMT
+      Etag:
+      - '"OAut2BCNOxqNKCH4+GWy5w"'
+      Referrer-Policy:
+      - origin-when-cross-origin
+      Server:
+      - nginx/1.13.9
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Vary:
+      - Accept-Encoding
+      X-Cache:
+      - HIT, HIT
+      X-Cache-Hits:
+      - 2, 6
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Pypi-Last-Serial:
+      - "13685488"
+      X-Served-By:
+      - cache-iad-kjyo7100030-IAD, cache-hhn4041-HHN
+      X-Timer:
+      - S1652091071.907921,VS0,VE0
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -747,7 +1062,7 @@ interactions:
       Content-Type:
       - text/html; charset=UTF-8
       Date:
-      - Wed, 04 May 2022 12:25:56 GMT
+      - Mon, 09 May 2022 10:11:10 GMT
       Etag:
       - '"OAut2BCNOxqNKCH4+GWy5w"'
       Referrer-Policy:
@@ -761,7 +1076,7 @@ interactions:
       X-Cache:
       - HIT, HIT
       X-Cache-Hits:
-      - 1, 79
+      - 2, 6
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
@@ -771,278 +1086,9 @@ interactions:
       X-Pypi-Last-Serial:
       - "13685488"
       X-Served-By:
-      - cache-iad-kiad7000095-IAD, cache-fra19143-FRA
+      - cache-iad-kjyo7100030-IAD, cache-hhn4041-HHN
       X-Timer:
-      - S1651667156.268189,VS0,VE0
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers: {}
-    url: https://pypi.org/simple/requests/
-    method: GET
-  response:
-    body: |-
-      <!DOCTYPE html>
-      <html>
-        <head>
-          <meta name="pypi:repository-version" content="1.0">
-          <title>Links for requests</title>
-        </head>
-        <body>
-          <h1>Links for requests</h1>
-          <a href="https://files.pythonhosted.org/packages/ba/bb/dfa0141a32d773c47e4dede1a617c59a23b74dd302e449cf85413fc96bc4/requests-0.2.0.tar.gz#sha256=813202ace4d9301a3c00740c700e012fb9f3f8c73ddcfe02ab558a8df6f175fd">requests-0.2.0.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/4b/ad/d536b2e572e843fda13e4458c67f937b05ce359722c1e4cdad35ba05b6e3/requests-0.2.1.tar.gz#sha256=d54eb33499f018fc6bd297613bf866f8d134629c8e02964aab6ef951f460e41e">requests-0.2.1.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/82/3c/3b5beca192da920c0c2ba67119d66ba1e4b1e766f40898e5e684d697ca1c/requests-0.2.2.tar.gz#sha256=b3289694b2ddf6adb4f7e1f470b9771330c76125611222b9c702f0e2e9733cbc">requests-0.2.2.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/6f/7e/5c2d7d9102c6ab847bd1215f96255e894fbfc81c8abf2c1714ae2a504913/requests-0.2.3.tar.gz#sha256=8e374b75aaae7f85325e9bb126e96cb77a3bfc17e81ee74a0e96916aac1cc2ba">requests-0.2.3.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/dc/02/789859c27162bb91ecf6b72ed4ce1af3ed1710255265ad0901c4d4e25666/requests-0.2.4.tar.gz#sha256=ef1bd1a81022e9bf574ecfe69cbd8597e79371b890d29bd3847dd946102c8eed">requests-0.2.4.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/96/2b/88e9d6bf2e9d75cda77bf4fdc03720f4ba262beb532f9510a4a7f3e45660/requests-0.3.0.tar.gz#sha256=57eed745eb2a2e3c7e1dd935ccd49eb2eac51cfcdace4a97fb44de5da70f0035">requests-0.3.0.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/5e/c0/76fac9445cd8b6394eacae1e098ca0c97767cc0112e45e68521f553df003/requests-0.3.1.tar.gz#sha256=05dddfd656d25b7738778d2b4e8fa72e53b5357a2f80a319e6e1fa59edb03339">requests-0.3.1.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/d5/f1/16b57088f11cd5c6c82834bad6475826309cee44edaae860e9f65c084703/requests-0.3.2.tar.gz#sha256=78ecf812ee865b62be106100a3c6f24058c7901ad995351b8818f18ea97ce848">requests-0.3.2.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/f1/64/8a2ba81294381bb90e8fb4b6fa750e0dca3f2d19e8caaeeae5e7bb6b3753/requests-0.3.3.tar.gz#sha256=ccbbc41c4c009baecf41e993727048c65c440fefadb217b11e73f63cd0cae09a">requests-0.3.3.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/ed/1b/8682a0cfe92f67e30fb9ac7982cb785a1230ca4385dc1353513f5b87b9f4/requests-0.3.4.tar.gz#sha256=e72a42a0317f33114b48c972d3056bad3265b92450d4e0e51ad0b384e43bc6d9">requests-0.3.4.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/56/c3/0887d5d6c18a366308b3dc7024210b4c89ff9ae92ae5fb87cf8fe58bcae2/requests-0.4.0.tar.gz#sha256=35185852569456de25a654c5f9a43a1b8e4dc18a2a676985bbb9d5e7e5a9703e">requests-0.4.0.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/b3/54/dbc9b89a66a15ab9f3e2595de1b1ebd1da954efcb30a329c98710e014c05/requests-0.4.1.tar.gz#sha256=f978616765803e9e0e9943136b34be0da69d74ba8fbd064cbfcf28f33ca54d8a">requests-0.4.1.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/0c/4d/d67bd4e4b17148aad88e6d75c62763ec27363d18038ed75019239e1516d0/requests-0.5.0.tar.gz#sha256=747c8c79e9c75ba8608c7628e39d533a0234ff78a80569e40ba64865abc0e521">requests-0.5.0.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/5f/1c/8d145fbdb23986063a8a0c954d484a793024137a99ac7f3da603717fe64a/requests-0.5.1.tar.gz#sha256=cfed662472d48e7bd6bfd8d7f79fe9072fc873b2e372fe3b9178a26daabebccc">requests-0.5.1.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/0b/b8/932de3bc1b8630357de85bc0c794ee1a7d343cb8008b470a0c9d15e84341/requests-0.6.0.tar.gz#sha256=2c5036387b75dfb0ff3971604bd1e691cf6a55dc6c397df7adf9fc4804bc7f48">requests-0.6.0.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/a6/1f/f948fb7ba68b69b13a1fbbb70d7706e889c7b7d3e9867b498ca7971126db/requests-0.6.1.tar.gz#sha256=2656b23db25398e990e6f5d75dfbd960454a1fe573aeedc651773ddd2a8a3bbc">requests-0.6.1.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/55/19/986305b95fae17c58c95e191943a282bce19f82535af4530890c483937ad/requests-0.6.2.tar.gz#sha256=b5419f909fc21b8eb037dc4bade29530c28993610b68213b7f7633bf10bcabbc">requests-0.6.2.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/e1/3f/9235f98536b1393ef8a8e2dbd27273588fc3246000b93b0d763325b2e30c/requests-0.6.3.tar.gz#sha256=bde3e2ea45f6e47acd24ff55628fc7325cacd75746ee2d2b63c093554131fe41">requests-0.6.3.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/97/e0/a2bc7317b13caf227a75c8151b562b62a2e9f5d4ab4ad59694bfdbf5c35c/requests-0.6.4.tar.gz#sha256=151f105506913a6b84f6119400ca94732ec39f5b4e0991ca2fc840ddb4e37816">requests-0.6.4.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/a8/a6/38b9de830719e4cd62ddf51f240654200658d0315aa9e908eda90ee64879/requests-0.6.5.tar.gz#sha256=bb332c171913c2f57cea805d013601af86a46b9aef9b7ef76bdcbed14f939bd7">requests-0.6.5.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/df/8d/4b1bb15e8814fefa2cdf8f971a479b459d07f8176094bd59742720f31270/requests-0.6.6.tar.gz#sha256=6670aee5fe3bb545e1f7e8bb073a06be65344b467cd698b0ad58e7d7792dc2bb">requests-0.6.6.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/5c/8c/0399c9554b04b2b267d81239773657ddc720799a08565b6c21f7aed652df/requests-0.7.0.tar.gz#sha256=13570c41a218affafe3f3e01db16d1f6cd238d3bd7a1d52cc435bf9de3df099a">requests-0.7.0.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/00/c8/8cf0f078100ce5fe7ff35927d8861e2e36daed9be2db56690f3ad80ccec4/requests-0.7.1.tar.gz#sha256=6795818f5f46d7ecf53965d96e2ceae66bf652c79703292973b7c56afb88b946">requests-0.7.1.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/7c/af/b46199ae37c032801bcdc5dbb1c82a59613883ee690ff4fd2b5dc3140130/requests-0.7.2.tar.gz#sha256=7e58616c2c943116c7fb7595ebc3b00c5016ede5e6b14cf4bd72a812a5534aef">requests-0.7.2.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/3d/54/c4a7dcfccac9e6dd738e9ed86848a9a5b07a4345e5949f8795cfdc0ea95f/requests-0.7.3.tar.gz#sha256=2e7a0cb6251da5dd8c185f5d404e110d29e47afec7c8e60d78806436360a40d7">requests-0.7.3.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/64/50/219c9ff86e6fecfb89bdfe1093aea523f14882657186f806462887220267/requests-0.7.4.tar.gz#sha256=3101a857831c6b6ec1f88ccebc8a19d38af6a10372537f437cd978c5775b4286">requests-0.7.4.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/2b/9e/1be659005a6bb394b02e12804fcaf8cd85050958a459945708b21e362b32/requests-0.7.5.tar.gz#sha256=ae10f2c5d112768a2e62282dd6b33db230c10ef7a2c3b1cf404806598bacd0b6">requests-0.7.5.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/de/f0/8fc024ef4f25ef5690c2121215029f88e1895b60c867c1a39134045b181e/requests-0.7.6.tar.gz#sha256=667f9c9cc447c9ee09d34d891db488f2695c99d025fae3ec8d02e235eb7eba95">requests-0.7.6.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/6a/85/32d23f3dbc43e54631bb9bd76d34c2448cc2f2f0de29babfb1a6a79b4d60/requests-0.8.0.tar.gz#sha256=62b557533f685c4a0af4e38dddc598c38f5ce0bd8e3b15b20809d1606f3843dd">requests-0.8.0.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/ae/fb/b1d6916b5278c44a1a2beb919d7ab96327051c3d47db9d6ee6978743444e/requests-0.8.1.tar.gz#sha256=23756d85cbf7dec36dd624853e76b380c2b538c21769adba1dcced9de0409f68">requests-0.8.1.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/65/5d/e69bad1f71d5284113165738d563a997d0d1ac968f939d1375f3df7c59fc/requests-0.8.2.tar.gz#sha256=826244e9612aa9a548d1289bef7bbce07eee4872ca21ca80631094d1c512b121">requests-0.8.2.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/f8/17/42ab05005c88e8d301fe0ee9b24e34139422268d0d7b8b11f98107c2a794/requests-0.8.3.tar.gz#sha256=7277ec1fc8b8251bc1ce628651cbfad886704a77aea9f6203dcc042a4f12d214">requests-0.8.3.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/aa/a7/ec41790a8fb50f8d359568f82cd37a994af5d0159cccb543d147a7eea751/requests-0.8.4.tar.gz#sha256=3ef7efbe083bcb6f7b1144c7665b5b1f6bd4fc7043dc50ccd564edf62b814c2b">requests-0.8.4.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/fc/f8/329450760dddd7e437eef0cd16a8d48582405e72495cf79a77a82e2f0047/requests-0.8.5.tar.gz#sha256=1db43116f612b016169d9a994d16aea9c166c55355bac2e05fae75e0ff610f4c">requests-0.8.5.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/4e/9b/a78a3bb2913576fad3ec6f18b8d26dd9579268f6b2191d73f4ec40e09490/requests-0.8.6.tar.gz#sha256=b9ad56ff5971b7a4005598e5a9588584ee1153fbf027ed76a7d13585f71489f7">requests-0.8.6.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/a7/83/bb447075090f4a3a60082765051d476b62f375d0f8174ebe9545d4bb8938/requests-0.8.7.tar.gz#sha256=2c5b08f7afe8d5ffc1c4f7819e74d5309a52b2f2eb1d78cc144cb57aa10380fe">requests-0.8.7.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/b7/1d/5c7973ca22bc95d53eba28a7dab7088f1ded7db0d174ea467afaaf898dfc/requests-0.8.8.tar.gz#sha256=70352c48f106fe4a15537bdb4a029ebbb80c1ae1b6836a9033f2b3d7e52e01fd">requests-0.8.8.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/3a/72/9f39b173ee93645013563df119d28841f47b0ca2ebe04afcefd438e42f30/requests-0.8.9.tar.gz#sha256=870780642a14f5e30a9ef8c419aeb405e5bd4340d4fefbf1e8493dde39225337">requests-0.8.9.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/89/ce/0115444a1f9d833768160e678c21483e271466918966c11212f040b5f2af/requests-0.9.0.tar.gz#sha256=43b26edb5c47e0ccf9612d3cf13639a1e7e6c774af5375a684cfa00e747f21b1">requests-0.9.0.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/48/aa/1077a5fef0c4fbdad8ce127166ca474c67788b7609137d26e17ab46ee16d/requests-0.9.1.tar.gz#sha256=0c6fc89ce4f8976dd8ddb1a9e896315a47fb3f1dba95417fd3fa8e626ca9a1e7">requests-0.9.1.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/68/a1/fac8e1fa783d167cc49debc5b5328ca57eac9d53b58c34d17ce7592cdc6d/requests-0.9.2.tar.gz#sha256=eb9a3b0031af396fb6825be897655546f4c54e19669fddb5df72a4a688ae0555">requests-0.9.2.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/62/12/0840d1bba04e5d60e469610ad78e02e89e6828e776adaef4116413cf5fd0/requests-0.9.3.tar.gz#sha256=3c0dd7c014474e0cdd00cad661abd74c88c14183d260d0555dfa51fc5b29abc5">requests-0.9.3.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/62/35/0230421b8c4efad6624518028163329ad0c2df9e58e6b3bee013427bf8f6/requests-0.10.0.tar.gz#sha256=210a82e678c45d433a4ad1f105974b3102a8ab5198872dc0a3238a8750d4c65e">requests-0.10.0.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/b4/56/ba2d803383ec32d70f8faa7df5eb37ee9b3fc662ff68b7ab01ad9740b83a/requests-0.10.1.tar.gz#sha256=da6031575a30c7b65ea99465183468349b3645e6bf5322e49d53f565b27ed2b5">requests-0.10.1.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/58/1e/6b84552b6553f5beaf7cb0fe15115e7e4673326ed9188ad5338559ee8285/requests-0.10.2.tar.gz#sha256=1546ef1e291ae337086369b621096fb0f69f88f6f67f60b1f6b7c18d1ca278e1">requests-0.10.2.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/01/44/39988315e036b79fe70428273053617266bf20d1363e91082346fae8450d/requests-0.10.3.tar.gz#sha256=8eeb24328304b015cbd59a49670e2738b77034b225b566729ddb19941899e490">requests-0.10.3.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/94/ac/5fa21e435ba8050d14db92ce29763c28196b727d4079dc608d39177fbf9b/requests-0.10.4.tar.gz#sha256=2ad4cc51d7595ca6f97373a0d697999e0cbdbbf1ba665d18f0f3dcec12b8be77">requests-0.10.4.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/b4/1f/8f5430040fcf4391dc5bd324424a569e2e0d96595952b21eb82403602d98/requests-0.10.6.tar.gz#sha256=31134b4f35951730dcce59f2af334478b68caa5728902a1d6bd5e115ec677d8b">requests-0.10.6.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/c5/cd/0597f9c040db24ca6d23cc74faa102554cb0a93bdbffb855d7749547921f/requests-0.10.7.tar.gz#sha256=80f32a74bed8cf081a3a25512f8725e09ceda217101ea706efced262bb05aec6">requests-0.10.7.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/9a/05/4ab34c6aae63a01aef2fd8be3573a99c197cc76a67f8cee751cb3a7784fb/requests-0.10.8.tar.gz#sha256=bec280d924a8be87b3377ee78a976334a6e7c944a8fe09bbd9447e669b984dae">requests-0.10.8.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/d7/ee/6826f31ae3e0e68606cb9086c3904582b3982bbccc73f34d6dc9912b48ad/requests-0.11.1.tar.gz#sha256=fd4260541d0e559c78e2b3072bd79f36e0f8ef935bcbbadaa8c98cd8b5a62897">requests-0.11.1.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/b6/52/ad2911cf5586f2372a296a93a94d0324e4ffdd225975241562c450594795/requests-0.11.2.tar.gz#sha256=547bf78a774a6018271d6e5c40613ec554642ba4d6cdf45813e7894145293c57">requests-0.11.2.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/3a/ac/0372d6b7fbde19444d5cc560f296e70b26283d2bac0665b576dd3f5e6b60/requests-0.12.0.tar.gz#sha256=8a88a291599444be608940c227b6114212220d8126c512af821f1ab207fe5072">requests-0.12.0.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/3a/0a/7c62c06702ddb4d3bc50d27f5b8e094d6e66a3374fc2eedf264742f84805/requests-0.12.1.tar.gz#sha256=9ce56b87180c06728d96ca734055675abf8f5cc3136e0d7712a6260430685589">requests-0.12.1.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/86/1b/88d3753931419a226bb4e4c1d354cd2d40acff3482b37e30dd84ba8a243b/requests-0.13.0.tar.gz#sha256=03a2001843546147ddb6972d0661e2002b9be4ccbbbd2177ee10f05bd1910109">requests-0.13.0.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/0d/63/0e6c6b817ab38fb3e38a192d6631d698fe78308a68659af3aa523cd736d4/requests-0.13.1.tar.gz#sha256=31f3ae96787fe74a78c7dd9626bf997fd4eabacc040b7b33fbd8632d2c2a97f6">requests-0.13.1.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/62/ca/338cf287e172099e4500cfa2cb580d2c9a1874427a8a14324d7a4c9d01b1/requests-0.13.2.tar.gz#sha256=37684324da8aca40e88fa2f7faa526cc116d74e979c2ac5d9119fe6e1bb5ced5">requests-0.13.2.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/54/9d/1ee0bd44e9334b6382ed5226d4bc33518d0d0b03ed806af6444d1c80ed83/requests-0.13.3.tar.gz#sha256=79503a14a43d6ae0b0b2e92f88ed0b01015528b8a8ab47721c28aa993aa4db2b">requests-0.13.3.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/04/75/52e169351e24a9faa8bfac69a07ea3551b845ca6354f22da15c5da3d5100/requests-0.13.4.tar.gz#sha256=94672e92c23fefe516c5310b84d97b4ea19ef373003a7ba7af1057102a87f345">requests-0.13.4.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/ba/d1/919f6240a37ce5aade82da39809e1f28a5f2899a29a0ca10c381ba70efbb/requests-0.13.5.tar.gz#sha256=c6abb4b15a3f2aaad18c22b214b9b35d69ec4e2730c5b922f95f17a88981f957">requests-0.13.5.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/02/56/a6203485b552f9e8e8f16bd4e576446f94737ccbc563957e7510c8e401e4/requests-0.13.6.tar.gz#sha256=3cca63908f1b941d2da61ef0e8baf7bf014cc0df6512e172b8d2ac87be82b916">requests-0.13.6.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/b4/48/e82ded36a3cee7c0ef9605b44c4615ffe4a37f8b6c8b17fdbc15fae18daa/requests-0.13.7.tar.gz#sha256=d9c6cf2890a0dc1200407f99130d334ef5ab5270bed3d9b4c14b0bb9c6cc3400">requests-0.13.7.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/db/1e/1f37495384a628887e10ecd61d45dba455ceec4b8b5b463512b4700e5b3d/requests-0.13.8.tar.gz#sha256=3ef37004f6394b111a27f0b6d0a64be83f7e4bccfbbbcdd21455400af5f4fbd4">requests-0.13.8.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/01/da/da83c242c5a77c58aa86072d68fd2855aa9b4d3b1a8bac4b402531b25ff1/requests-0.13.9.tar.gz#sha256=d887bb1c06948a8930d6e73a1f942f9febe9157a299a984994c20c84b2c21e20">requests-0.13.9.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/4e/31/50a12e5b5e585e0b00ce2592c9b45f2ae109575e3707a341afd7550a8d1a/requests-0.14.0.tar.gz#sha256=4e690ba0275ab4a8c9a5c7a6eb14e79e1adad0f84331fc638a18d7751f41ac3b">requests-0.14.0.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/40/1d/63a729208e1e93cf2cbda953b9f20ec9b101eb964e3f6205d1c2e294f294/requests-0.14.1.tar.gz#sha256=4f563b907782b2c95dd2cbaf882a96133e567d46290a0e7aafa0c6f3efad19ba">requests-0.14.1.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/fa/d1/0dd60e1146e79e7b193e7b0189d8c13ef100d55cbfe65e1825ac5f03c397/requests-0.14.2.tar.gz#sha256=0e3345a8ac0d712bf17bd9d3276415050c5f972265ab62993cd4540a3a1aaaef">requests-0.14.2.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/46/da/94c0fd6ff79b85befc3b528cf3771700def274c52b347bf12eeaa466f34c/requests-1.0.0.tar.gz#sha256=f10d8fbcc02a58056ab44f79ff9b3f9fe78e410296527885250bbb36d15be8c6">requests-1.0.0.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/b8/03/fb15922d14fa0b01a0ff4e2920bb8c08546d970ff387454ba892a67d5243/requests-1.0.1.tar.gz#sha256=c69222b7c02a8e46d61c3b986e6a3e766db0539235aaafc056c75b8dcf6f5eec">requests-1.0.1.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/32/35/f2908b62b155b1737ab80b1a69142d007522bb0d1b3a0d3f8909595762f5/requests-1.0.2.tar.gz#sha256=3c81f3ae43916161b8d98d7b329b19533b0d0332b7a774794964e6b08760b0c7">requests-1.0.2.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/7f/76/66c01dd9afe4c5062e0c838bbd98ead7fa6b52984c7e26100a42c3eb965a/requests-1.0.3.tar.gz#sha256=c7b50dc01b751e5ef8785951a74d0c2373bb0f87b45dca75dc2c5477b7e30f44">requests-1.0.3.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/5d/e8/f27e0868b9a49946b3f800722e02b19efebde22ae534276df3e5f6cca41d/requests-1.0.4.tar.gz#sha256=f363690a47dd4d6d6e7605fc686b668097a114cd946dffdf21fe0c6a6a46f9e6">requests-1.0.4.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/e8/ff/d19b7461d84a5804c5cdc29791305530a2b774fe928b497e74ac9b304c79/requests-1.1.0.tar.gz#sha256=21a81ddf1a3c2f956524538966ae19c38cae251f5629821588cdc8246a1335f7">requests-1.1.0.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/37/e4/74cb55b3da7777a1dc7cd7985c3cb12e83e213c03b0f9ca20d2c0e92b3c3/requests-1.2.0.tar.gz#sha256=cfa615644ae38efe8423ce9edb23470a4615a9147fa3cea5026afb47c9bb3913">requests-1.2.0.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/3b/9e/bfa03431335e778854da3d562697e067df40870a78ca81b35089822c6583/requests-1.2.1.tar.gz#sha256=946b7c856aa62f4ad31de2b9bb501cfdcdb4afdc882ee76bd4664f57caefaa44">requests-1.2.1.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/c0/44/84a4b7a4e9d5fd1b358dbabd03f17e3dd91ce8881fc3446fbd2fd996be88/requests-1.2.2.tar.gz#sha256=56929d7b5dec9b37a9a8520f15202bada0ad55d2888a7c3243b9b194f2ef603d">requests-1.2.2.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/61/79/efc316760a906763de872d7328c9bf8c5af28708a35fdae57fbb4ee005f7/requests-1.2.3.tar.gz#sha256=156bf3ec27ba9ec7e0cf8fbe02808718099d218de403eb64a714d73ba1a29ab1">requests-1.2.3.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/bf/78/be2b4c440ea767336d8448fe671fe1d78ca499e49d77dac90f92191cca0e/requests-2.0.0-py2.py3-none-any.whl#sha256=2ef65639cb9600443f85451df487818c31f993ab288f313d29cc9db4f3cbe6ed">requests-2.0.0-py2.py3-none-any.whl</a><br/>
-          <a href="https://files.pythonhosted.org/packages/8e/88/102742c48605aef8d39fa719d932c67783d789679628fa1433cb4b2c7a2a/requests-2.0.0.tar.gz#sha256=78536038f54cff6ade3be6863403146665b5a3923dd61108c98d8b64141f9d70">requests-2.0.0.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/8f/ea/140f18072bbcd81885a9490abb171792fd2961fd7f366be58396f4c6d634/requests-2.0.1-py2.py3-none-any.whl#sha256=f4ebc402e0ea5a87a3d42e300b76c292612d8467024f45f9858a8768f9fb6f6e">requests-2.0.1-py2.py3-none-any.whl</a><br/>
-          <a href="https://files.pythonhosted.org/packages/1c/8e/376c93bb72bdae6a754797b8e31370df1e996e8b7dcc928e66691dbf611a/requests-2.0.1.tar.gz#sha256=8cfddb97667c2a9edaf28b506d2479f1b8dc0631cbdcd0ea8c8864def59c698b">requests-2.0.1.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/1e/97/f0a8e5e71c75a2abf5ec91438b84ec1a40a5e1b5f985c06721a3ebe57c0a/requests-2.1.0-py2.py3-none-any.whl#sha256=fcef306d62b1c061eb00b8402cf136ff0ea1daf7a53b60cdef9563a22850072c">requests-2.1.0-py2.py3-none-any.whl</a><br/>
-          <a href="https://files.pythonhosted.org/packages/51/5d/3729c242ed7693f29941fd9d40e936d4994b0aa704dfd0c023312fcce8a3/requests-2.1.0.tar.gz#sha256=a57307f3a5f35ec9e1254aaf3e0484063ee3ee6b5f123fb35c5b2673492efa71">requests-2.1.0.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/3b/99/a8acc0c986281232f9476575c27a81ab697afbf089f42f05c196f51892c0/requests-2.2.0-py2.py3-none-any.whl#sha256=889d334044cd3364d07419c37671ba4f213d0f59601109dcb54c8a7ebdde38ee">requests-2.2.0-py2.py3-none-any.whl</a><br/>
-          <a href="https://files.pythonhosted.org/packages/c9/5a/aa687599abd76de72ae5a554e2e70328fc311d59e0b1e999263fb094baf3/requests-2.2.0.tar.gz#sha256=1ff74f88bbfddf94f92aa20bd8473c7d46d3398c95b1842d81b2f3c475d5625d">requests-2.2.0.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/7d/15/6efffc6aee666e1456852c2bf1d483b46bf971a2d509b35a98fc3eae1c60/requests-2.2.1-py2.py3-none-any.whl#sha256=b5bd2e1b78d28051108ebaa6248750221f9ccef52b4f054cb727de61b0406de0">requests-2.2.1-py2.py3-none-any.whl</a><br/>
-          <a href="https://files.pythonhosted.org/packages/d1/0c/2dc2996268bc64b531a5a2dc6f4ec04552f3a8a2a86e88aeedcb92987741/requests-2.2.1.tar.gz#sha256=1266921f1bed5fbf364cd83cf239b6d7b3ea5c32ccccbc93980d9ba12cdcfd02">requests-2.2.1.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/f7/51/7aa1e337862118bee783c0249debd64cb07b8fbdfef154b1e185754b02d5/requests-2.3.0-py2.py3-none-any.whl#sha256=3648802492e955ffeb28f6dab864ad714059f5438bf6798d82f9d477c666aca3">requests-2.3.0-py2.py3-none-any.whl</a><br/>
-          <a href="https://files.pythonhosted.org/packages/ab/f9/4425c8410faf7c7d420dbd64e127f2cfb68cfef869a374b332610b6abc09/requests-2.3.0.tar.gz#sha256=1c1473875d846fe563d70868acf05b1953a4472f4695b7b3566d1d978957b8fc">requests-2.3.0.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/78/14/23cf8ede304c7c8b69b929b17074292073827239c31659ab8c7beb22a059/requests-2.4.0-py2.py3-none-any.whl#sha256=8b2cc9e334b3e66aa5df15f2e4967f2c95b5164a4e6df7e92dd70ca67400912a">requests-2.4.0-py2.py3-none-any.whl</a><br/>
-          <a href="https://files.pythonhosted.org/packages/ef/a0/9863b20b6a87e45cd4353c10277d9674f9ddfd7c28c58e61a339e273a119/requests-2.4.0.tar.gz#sha256=7007e03cbc73e357b5055c6ea0ad6e447e2afa00f1a1f843cd792a1ebaa3763e">requests-2.4.0.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/bf/81/22c8ed95e8088c0a7c022969534c8157930f0bed6ae77e12e86fdc2e855c/requests-2.4.1-py2.py3-none-any.whl#sha256=b9e3c10e5092b444bb4c1b0b337f57e6c3d7680ad7c5192f597e84dd931fb598">requests-2.4.1-py2.py3-none-any.whl</a><br/>
-          <a href="https://files.pythonhosted.org/packages/0f/d0/e80371e64a7a7bafa303ea50465456e5292d9436504ce39b9619b6ba24be/requests-2.4.1.tar.gz#sha256=35d890b0aaa6e09ec40d49361d823b998ced86cc7673a9ce70bbc4f986e13ad8">requests-2.4.1.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/a2/87/afb7990b87f76ec9d11fd15668c2362a8fbe8436e0a780c7fe5aedf1a299/requests-2.4.2-py2.py3-none-any.whl#sha256=49df4571ecd49d00a4587237b7d8be9664bb326052e06d2c488255b34f13393d">requests-2.4.2-py2.py3-none-any.whl</a><br/>
-          <a href="https://files.pythonhosted.org/packages/f8/25/1599a06d261fdd84256829d88f7a415c80a6e249988f9e17ba5016119b6f/requests-2.4.2.tar.gz#sha256=b98a76df30e95ef636af5e040ff7c5d0bc0b482899fd7a187b0ae525e41fe8f1">requests-2.4.2.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/8a/98/bf72c7bd3ecfaf46dc2de3e59dcda6e61766526d3cf5897e9edd599795fc/requests-2.4.3-py2.py3-none-any.whl#sha256=124890f41723c85aa82dfe0807432aea46d24aeb0dafce340969d2089548c2c3">requests-2.4.3-py2.py3-none-any.whl</a><br/>
-          <a href="https://files.pythonhosted.org/packages/f4/ff/34a5a2eb91e35280e65585c48304094b61b58f9966de74ab72673c2fde9d/requests-2.4.3.tar.gz#sha256=53c68313c5c6149b1a899234c000296e60a8900682accf73d6f0c6d608afc6b1">requests-2.4.3.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/32/0e/11cfb3a5e269605d0bbe3bbca9845da9b57aed90e75bd489e5e7e3509c13/requests-2.5.0-py2.py3-none-any.whl#sha256=66cbb850987e47177a3b4112392490bcb76eb75b37cc53da007e35f3ec894bc1">requests-2.5.0-py2.py3-none-any.whl</a><br/>
-          <a href="https://files.pythonhosted.org/packages/c8/fb/d14d1c5166a8449d36c9a3b2656706c506a2cf261d37a79d16c18c37b646/requests-2.5.0.tar.gz#sha256=d2daef4919fc87262b8b3cb5a9d214cac8ce1e50950f8423bbc1d31c2e63d38e">requests-2.5.0.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/54/9a/ee6051b19c62728d5467dead279c532798c287e39c3bc8becb1cfa9f525a/requests-2.5.1-py2.py3-none-any.whl#sha256=1f046dcf5ec712ed3be8684b9f33c95b76e28cd1c825db0f5e1557bfd87b3745">requests-2.5.1-py2.py3-none-any.whl</a><br/>
-          <a href="https://files.pythonhosted.org/packages/61/fe/2c0a4ca99c68ea24eec65d3094d6539d54635562678ee7a58420005c12b6/requests-2.5.1.tar.gz#sha256=7b7735efd3b1e2323dc9fcef060b380d05f5f18bd0f247f5e9e74a628279de66">requests-2.5.1.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/20/fc/53f45b9bdfa8bd5f11b7d60b50052a8e4729346fcc8d5854e0e1449d92b5/requests-2.5.2-py2.py3-none-any.whl#sha256=b4d1a981c443e19ee3f527b352022d698e16a298913d9b78ea1133f089eeb779">requests-2.5.2-py2.py3-none-any.whl</a><br/>
-          <a href="https://files.pythonhosted.org/packages/d6/f7/1a4c1cae7618ad3d9fe5536ef74f47b2cb1028938e12d6dfe0a9806a8e1b/requests-2.5.2.tar.gz#sha256=306ead91d47a48b6a25d495d2495de99694641bd7d2cac5bcc405a8837c7a612">requests-2.5.2.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/95/54/44dc83b5f11c6da06bf9abd18c8a0905e0e297e0a9c3bfbc0c6ee4bdd33d/requests-2.5.3-py2.py3-none-any.whl#sha256=3e66d7ba78e7a6a8eccd2e901079ab8d24e408b5375cf32eb51f291306302418">requests-2.5.3-py2.py3-none-any.whl</a><br/>
-          <a href="https://files.pythonhosted.org/packages/a6/36/06a7d4261f91552f21f017fe162d69df95ca7925d1436c8acf73283ee3d0/requests-2.5.3.tar.gz#sha256=55d7f5619daae94ec49ee81ed8c865e5a2a47f0bbf8e06cf94636bee103eaf65">requests-2.5.3.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/73/63/b0729be549494a3e31316437053bc4e0a8bb71a07a6ee6059434b8f1cd5f/requests-2.6.0-py2.py3-none-any.whl#sha256=fdb9af60d47ca57a80df0a213336019a34ff6192d8fff361c349f2c8398fe460">requests-2.6.0-py2.py3-none-any.whl</a><br/>
-          <a href="https://files.pythonhosted.org/packages/eb/70/237e11db04807a9409ed39997097118208e7814309d9bc3da7bb98d1fe3d/requests-2.6.0.tar.gz#sha256=1cdbed1f0e236f35ef54e919982c7a338e4fea3786310933d3a7887a04b74d75">requests-2.6.0.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/64/74/5bedd762987b5cb4ad5de4901d12942ad7635bffa5ae4f6b5e725d1b2068/requests-2.6.1-py2.py3-none-any.whl#sha256=79515d60eae4f5d426b8813ffd60ed874169d78b8815844e8e85798ef27a599f">requests-2.6.1-py2.py3-none-any.whl</a><br/>
-          <a href="https://files.pythonhosted.org/packages/08/d5/3dfb95813d697d1e5a3eccb9b88f9d91a233fc35b0ddbb5bc238142f9de0/requests-2.6.1.tar.gz#sha256=490b111c824d64b84797a899a4c22618bbc45323ac24a0a0bb4b73a8758e943c">requests-2.6.1.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/9f/3e/c09023432b822a09d965878640de63f8126d77c948f45c24dcad13d42721/requests-2.6.2-py2.py3-none-any.whl#sha256=8f0f56813f82d0c27d9578221268ac9af48f076c71ee69693305ceca6ca355bd">requests-2.6.2-py2.py3-none-any.whl</a><br/>
-          <a href="https://files.pythonhosted.org/packages/37/b3/d1a5d9768240a1104a620730a1226975ceb9dd3882a8cfd8935b314ee0ca/requests-2.6.2.tar.gz#sha256=0577249d4b6c4b11fd97c28037e98664bfaa0559022fee7bcef6b752a106e505">requests-2.6.2.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/26/ff/c71b3943bebdd9f7ceb9e137296370587eb0b33fe2eb3732ae168bc45204/requests-2.7.0-py2.py3-none-any.whl#sha256=20f976cdce02a42b69ce80e9e03897a51814b36d448b37288546086ebc473146">requests-2.7.0-py2.py3-none-any.whl</a><br/>
-          <a href="https://files.pythonhosted.org/packages/0a/00/8cc925deac3a87046a4148d7846b571cf433515872b5430de4cd9dea83cb/requests-2.7.0.tar.gz#sha256=398a3db6d61899d25fd4a06c6ca12051b0ce171d705decd7ed5511517b4bb93d">requests-2.7.0.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/5d/a6/90f822c17b4fc905da67aed49b511f110207242ff164aeda926461101dc6/requests-2.8.0-py2.py3-none-any.whl#sha256=3a34af0dd06fed021286d93da464bbb76dcc0c709d02e7d3cdca195b1341c380">requests-2.8.0-py2.py3-none-any.whl</a><br/>
-          <a href="https://files.pythonhosted.org/packages/1b/92/0632a7eb5e94bfedd300a3a5f4ebbf8505fd9768ba00ab259b5bf786de5f/requests-2.8.0.tar.gz#sha256=b2f003589b60924909c0acde472590c5ea83906986a7a25b6f7929eb20923b7b">requests-2.8.0.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/c0/0f/a911a44c89ba01b23d8fe3defbdfca1e962de6f11a11da32658902cdc2a4/requests-2.8.1-py2.py3-none-any.whl#sha256=89f1b1f25dcd7b68f514e8d341a5b2eb466f960ae756822eaab480a3c1a81c28">requests-2.8.1-py2.py3-none-any.whl</a><br/>
-          <a href="https://files.pythonhosted.org/packages/38/2d/290d33417c079a5248fcd06b0b8492acdd1851e54e4bdad54c3859dab600/requests-2.8.1.tar.gz#sha256=84fe8d5bf4dcdcc49002446c47a146d17ac10facf00d9086659064ac43b6c25b">requests-2.8.1.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/bf/b7/c0b5a7fcf561577178ffd65af9af37c412cf6fbb1a2a198b9308b343d63f/requests-2.9.0-py2.py3-none-any.whl#sha256=1f4726bc7636edcbd141ba9c868dd92ecb77dbc869f68a28c32e9e149b070854">requests-2.9.0-py2.py3-none-any.whl</a><br/>
-          <a href="https://files.pythonhosted.org/packages/e4/99/3e33bfe263894278a094c374f87031554406e57fd0b1ad22520357556627/requests-2.9.0.tar.gz#sha256=4881966532b5a36c552244fd909de66d1b8c4a26086f56fd5837cfcde63f8eb8">requests-2.9.0.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/b8/f7/3bb4d18c234a8ce7044d5ee2e1082b7d72bf6c550afb8d51ae266dea56f1/requests-2.9.1-py2.py3-none-any.whl#sha256=113fbba5531a9e34945b7d36b33a084e8ba5d0664b703c81a7c572d91919a5b8">requests-2.9.1-py2.py3-none-any.whl</a><br/>
-          <a href="https://files.pythonhosted.org/packages/f9/6d/07c44fb1ebe04d069459a189e7dab9e4abfe9432adcd4477367c25332748/requests-2.9.1.tar.gz#sha256=c577815dd00f1394203fc44eb979724b098f88264a9ef898ee45b8e5e9cf587f">requests-2.9.1.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/8b/e7/229a428b8eb9a7f925ef16ff09ab25856efe789410d661f10157919f2ae2/requests-2.9.2-py2.py3-none-any.whl#sha256=22a8c72dfc7fc18db1aca6784e97a638e9d09abe2cd387be473f88bd6dcba22f">requests-2.9.2-py2.py3-none-any.whl</a><br/>
-          <a href="https://files.pythonhosted.org/packages/64/20/2133a092a0e87d1c250fe48704974b73a1341b7e4f800edecf40462a825d/requests-2.9.2.tar.gz#sha256=d8be941a08cf36e4f424ac76073eb911e5e646a33fcb3402e1642c426bf34682">requests-2.9.2.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/99/b4/63d99ba8e189c47d906b43bae18af4396e336f2b1bfec86af31efe2d2cb8/requests-2.10.0-py2.py3-none-any.whl#sha256=09bc1b5f3a56cd8c48d433213a8cba51a67d12936568f73b5f1793fcb0c0979e">requests-2.10.0-py2.py3-none-any.whl</a><br/>
-          <a href="https://files.pythonhosted.org/packages/49/6f/183063f01aae1e025cf0130772b55848750a2f3a89bfa11b385b35d7329d/requests-2.10.0.tar.gz#sha256=63f1815788157130cee16a933b2ee184038e975f0017306d723ac326b5525b54">requests-2.10.0.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/f8/90/42d5e0d9b5c4c3629a3d99823bbc3748fb85616f0f7a45e79ba7908d4642/requests-2.11.0-py2.py3-none-any.whl#sha256=8b9b147f3dff1fc4055ff794ff931f735ed25e87efe667ed7c845a4bafae9b73">requests-2.11.0-py2.py3-none-any.whl</a><br/>
-          <a href="https://files.pythonhosted.org/packages/8d/66/649f861f980c0a168dd4cccc4dd0ed8fa5bd6c1bed3bea9a286434632771/requests-2.11.0.tar.gz#sha256=b2ff053e93ef11ea08b0e596a1618487c4e4c5f1006d7a1706e3671c57dea385">requests-2.11.0.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/ea/03/92d3278bf8287c5caa07dbd9ea139027d5a3592b0f4d14abf072f890fab2/requests-2.11.1-py2.py3-none-any.whl#sha256=545c4855cd9d7c12671444326337013766f4eea6068c3f0307fb2dc2696d580e">requests-2.11.1-py2.py3-none-any.whl</a><br/>
-          <a href="https://files.pythonhosted.org/packages/2e/ad/e627446492cc374c284e82381215dcd9a0a87c4f6e90e9789afefe6da0ad/requests-2.11.1.tar.gz#sha256=5acf980358283faba0b897c73959cecf8b841205bb4b2ad3ef545f46eae1a133">requests-2.11.1.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/00/93/9c5c04821578c2ee11af83189c5cbd8338724b5e04e1de5dc3643bbc5bbf/requests-2.12.0-py2.py3-none-any.whl#sha256=a7d8f8f46603b78f03a925227f33988276fbe6c1f3c8cb20174ba9bfc5114c4d">requests-2.12.0-py2.py3-none-any.whl</a><br/>
-          <a href="https://files.pythonhosted.org/packages/6a/97/7b856a8c8a0efebebb0bbba70c7ee879ee3f9654f28928665b64026ef09a/requests-2.12.0.tar.gz#sha256=57b6c314a2c5f014dce634a0e1eeeb1707741b2e30bc7fee9c5b01fa216d57a3">requests-2.12.0.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/9b/31/e9925a2b9a06f97c3450bac6107928d3533bfe64ca5615442504104321e8/requests-2.12.1-py2.py3-none-any.whl#sha256=3f3f27a9d0f9092935efc78054ef324eb9f8166718270aefe036dfa1e4f68e1e">requests-2.12.1-py2.py3-none-any.whl</a><br/>
-          <a href="https://files.pythonhosted.org/packages/6e/40/7434b2d9fe24107ada25ec90a1fc646e97f346130a2c51aa6a2b1aba28de/requests-2.12.1.tar.gz#sha256=2109ecea94df90980be040490ff1d879971b024861539abb00054062388b612e">requests-2.12.1.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/59/dc/54d39bef11678853ca78fc6167cc1b57becf491548942246dd2226bf2bd2/requests-2.12.2-py2.py3-none-any.whl#sha256=e5a102790b234bde8f949090e50e294490c2be0d81e3d55530fd91f3b5eded63">requests-2.12.2-py2.py3-none-any.whl</a><br/>
-          <a href="https://files.pythonhosted.org/packages/18/87/3c46a06df7b29cd3ab51f055cae2a954758ee3dcbd075d7f4c9a4e8aafbc/requests-2.12.2.tar.gz#sha256=09dadb7c5c4210ebbc7f1b14a351a754f1191bd7cd5a5b60ee1929b8c7dcbbe6">requests-2.12.2.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/84/68/f0acceafe80354aa9ff4ae49de0572d27929b6d262f0c55196424eb86b2f/requests-2.12.3-py2.py3-none-any.whl#sha256=d92ed9912bab3f5e52d8e231be82c106650f648185e952f83c44ab4f2be55c0c">requests-2.12.3-py2.py3-none-any.whl</a><br/>
-          <a href="https://files.pythonhosted.org/packages/d9/03/155b3e67fe35fe5b6f4227a8d9e96a14fda828b18199800d161bcefc1359/requests-2.12.3.tar.gz#sha256=de5d266953875e9647e37ef7bfe6ef1a46ff8ddfe61b5b3652edf7ea717ee2b2">requests-2.12.3.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/ed/9e/60cc074968c095f728f0d8d28370e8d396fa60afb7582735563cccf223dd/requests-2.12.4-py2.py3-none-any.whl#sha256=000748df49e087784441b2621c50fb81046c5c8e80e0d91674ffad65b9e13844">requests-2.12.4-py2.py3-none-any.whl</a><br/>
-          <a href="https://files.pythonhosted.org/packages/5b/0b/34be574b1ec997247796e5d516f3a6b6509c4e064f2885a96ed885ce7579/requests-2.12.4.tar.gz#sha256=ed98431a0631e309bb4b63c81d561c1654822cb103de1ac7b47e45c26be7ae34">requests-2.12.4.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/bf/99/af6139323bac0ca0c6023eabbdc526579525f5584278d001dd2e169f8300/requests-2.12.5-py2.py3-none-any.whl#sha256=d57dae49f4267e8cb378aff9e426c9304a78794d03e945e39bfc607355715658">requests-2.12.5-py2.py3-none-any.whl</a><br/>
-          <a href="https://files.pythonhosted.org/packages/b6/61/7b374462d5b6b1d824977182db287758d549d8680444bad8d530195acba2/requests-2.12.5.tar.gz#sha256=d902a54f08d086a7cc6e58c20e2bb225b1ae82c19c35e5925269ee94fb9fce00">requests-2.12.5.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/7e/ac/a80ed043485a3764053f59ca92f809cc8a18344692817152b0e8bd3ca891/requests-2.13.0-py2.py3-none-any.whl#sha256=1a720e8862a41aa22e339373b526f508ef0c8988baf48b84d3fc891a8e237efb">requests-2.13.0-py2.py3-none-any.whl</a><br/>
-          <a href="https://files.pythonhosted.org/packages/16/09/37b69de7c924d318e51ece1c4ceb679bf93be9d05973bb30c35babd596e2/requests-2.13.0.tar.gz#sha256=5722cd09762faa01276230270ff16af7acf7c5c45d623868d9ba116f15791ce8">requests-2.13.0.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/1b/d3/f2541f2965e78f139bff9f001594d41ed90f4b2ce4b61bca387e60c1d3b4/requests-2.14.0-py2.py3-none-any.whl#sha256=a90555c0be723f5c711de36f256b21a65fc599602274fb3d5c4f83ac23aae3c5">requests-2.14.0-py2.py3-none-any.whl</a><br/>
-          <a href="https://files.pythonhosted.org/packages/0b/ac/ffd3674211bc47ae3bf55c7cd4a8fe484b7289af2ffd9cfed5683708690a/requests-2.14.0.tar.gz#sha256=8c4f778459cb4a6bad7ceff4aa65a75697db28c21a6b41ea9a6c371df2a822c2">requests-2.14.0.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/74/ac/789eb98e0f5431d6d1ce36549ead88b2ab3154260f37c7dac9a34fd170b1/requests-2.14.1-py2.py3-none-any.whl#sha256=c5a42004b9cd384e5ad0f868b1cc968a3c2bb0276dccc12e4bdc7330591b5f51">requests-2.14.1-py2.py3-none-any.whl</a><br/>
-          <a href="https://files.pythonhosted.org/packages/8c/ff/78297074b9b4cf102f9bbd71b62508965dd5c1876e016ef131e5b15c16a4/requests-2.14.1.tar.gz#sha256=b3b191d677e526c1e512db86bc7387ccb8356e8826bcc7faa07f78f09afe68dd">requests-2.14.1.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/e4/b0/286e8a936158e5cc5791d5fa3bc4b1d5a7e1ff4e5b3f3766b63d8e97708a/requests-2.14.2-py2.py3-none-any.whl#sha256=3b39cde35be51762885631cf586f4dc2284951b44d479a4454020758d767cc2f">requests-2.14.2-py2.py3-none-any.whl</a><br/>
-          <a href="https://files.pythonhosted.org/packages/72/46/4abc3f5aaf7bf16a52206bb0c68677a26c216c1e6625c78c5aef695b5359/requests-2.14.2.tar.gz#sha256=a274abba399a23e8713ffd2b5706535ae280ebe2b8069ee6a941cb089440d153">requests-2.14.2.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/fa/a5/e04c4607dc96e3e6b22dfa13ba8776c64bb65cb97ab90f05a3ee14096a0a/requests-2.15.1-py2.py3-none-any.whl#sha256=ff753b2196cd18b1bbeddc9dcd5c864056599f7a7d9a4fb5677e723efa2b7fb9">requests-2.15.1-py2.py3-none-any.whl</a><br/>
-          <a href="https://files.pythonhosted.org/packages/6d/ed/3adebdc29ca33f11bca00c38c72125cd4a51091e13685375ba4426fb59dc/requests-2.15.1.tar.gz#sha256=e5659b9315a0610505e050bb7190bf6fa2ccee1ac295f2b760ef9d8a03ebbb2e">requests-2.15.1.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/35/b8/8ff3310309beb5fbca033b56504f869b0c65c1f284ae2a7900593b5acd3c/requests-2.16.0-py2.py3-none-any.whl#sha256=012cddec41f96a1ce4bab4b0a0ed40263ae6b2b03aa4bc4711e00418e7f3157c">requests-2.16.0-py2.py3-none-any.whl</a><br/>
-          <a href="https://files.pythonhosted.org/packages/26/e7/4f1ec439ecbcfe3989bb79a9c323d2482e7beea3d8d453e07443302648ec/requests-2.16.0.tar.gz#sha256=88eee720e83bc1dcb009ad5e2a8f1d41e903892121ec2a36eba7bf5a2d3ac2a0">requests-2.16.0.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/c7/5d/7711f9fc9b028dc7572f84589e206220f0072e29fd9c7ae3507e7d17d8a6/requests-2.16.1-py2.py3-none-any.whl#sha256=b81b3651a206f02709e374c52071b4ac9bdf463c193701a560ce8e25c9ecc80b">requests-2.16.1-py2.py3-none-any.whl</a><br/>
-          <a href="https://files.pythonhosted.org/packages/4c/54/1d3abddbd4c7544138b88e8329ef5294ffdc6c5d7ea965bf42e3cc4c9c39/requests-2.16.1.tar.gz#sha256=14d663571c66410a7c3634f4cb9040b16a1c083078e37a0f8cc3710eae63411e">requests-2.16.1.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/67/91/b3893b0db7c645b9f92aa827ce3db630eef2dd3a2ad3109c2a28cdc9e6b7/requests-2.16.2-py2.py3-none-any.whl#sha256=afebb4fcabd66ba6e3188fd31f09915f5afd213b204014ea02448011eca1e49a">requests-2.16.2-py2.py3-none-any.whl</a><br/>
-          <a href="https://files.pythonhosted.org/packages/3c/69/d49fd9a7be23c55278c92e60af6d57336c463d8593afe7260a1665346965/requests-2.16.2.tar.gz#sha256=a2956efcf8dd2d526286431fdb0ec78eff25ab8db8a03c4f9d66f5fe6024f168">requests-2.16.2.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/76/b6/e3035b7baa98e20d248fe17af2097b882ec7724d9a8ee7ae195ad7110f82/requests-2.16.3-py2.py3-none-any.whl#sha256=bcdc06ebfc25f2a198274ae4710c3217fb968c5f9468dc410cd603a59c47bff2">requests-2.16.3-py2.py3-none-any.whl</a><br/>
-          <a href="https://files.pythonhosted.org/packages/07/db/3ed266e9cd3e3f69af3af38f56a0b4e21dadf3065521b2860030889284d7/requests-2.16.3.tar.gz#sha256=7fda55400281de8fba713dd120b4614eabc10c0b096c22bfc88ccc671227c3d4">requests-2.16.3.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/13/52/41fb28aa332ed68cd616cd1fc44d9e9c4bb85aa60c28d275f8857da561e5/requests-2.16.4-py2.py3-none-any.whl#sha256=784213e164287b403497195cf7f45071ae5eec60ae260cbc9a26368a91445f57">requests-2.16.4-py2.py3-none-any.whl</a><br/>
-          <a href="https://files.pythonhosted.org/packages/47/68/4fe8c7e9e95133d15e342b1403a1751909cddb814a5a9cced2ba4c63487d/requests-2.16.4.tar.gz#sha256=14db43bfaa61fd3102eecaf447a593e0650ba0dc261c72597109a973c23091ab">requests-2.16.4.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/65/9c/57484d6ac262af20a10b52cd95ebc99843f282342ef008997ef60f9eeb9c/requests-2.16.5-py2.py3-none-any.whl#sha256=3a27020d547958f5270fd5e9d62250119ee7db7454644599b65fda20cb542ded">requests-2.16.5-py2.py3-none-any.whl</a><br/>
-          <a href="https://files.pythonhosted.org/packages/de/4c/7c36954d002030c82df31d000338d40fd91b4a993941a8f3c2dbe523c749/requests-2.16.5.tar.gz#sha256=f717303ebff661099cc5b73ce723ae1246f19ac39faa4c8005be56744d1a1006">requests-2.16.5.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/5b/b6/9a18db79553524246aa1b081829e6f977667ec558cef684988895c1092d9/requests-2.17.0-py2.py3-none-any.whl#sha256=73b4088c05f7fb5ca8e68651ed802df3ca40621281acf74bb321b4a8408aab7e">requests-2.17.0-py2.py3-none-any.whl</a><br/>
-          <a href="https://files.pythonhosted.org/packages/7c/84/617aaa311f6504489459c016daff4c66df6bbd54ee35b4cbed3e994f322d/requests-2.17.0.tar.gz#sha256=eff227db5864238d44270cbadc8ac4133e69b69a2e7092b7b316ed1e4761cbd6">requests-2.17.0.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/50/41/f6fdaf24a80c726a72f76b15869a20734b7a527081129a380ddce99ffae0/requests-2.17.1-py2.py3-none-any.whl#sha256=02242978c6aaee47953da9e4d20d9d9929a1284a6b3a8a63a243ac1b842bd12c">requests-2.17.1-py2.py3-none-any.whl</a><br/>
-          <a href="https://files.pythonhosted.org/packages/d0/c0/f66d080e64a361382ed665023b9925e274d833f410f8c7282fb878e9c60e/requests-2.17.1.tar.gz#sha256=9cf3698006012c000af2804fe4186042a4d55df0303552dd190a74f5eaafe69b">requests-2.17.1.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/9a/0b/7a65b391bde96d7b1749dc3562ce22f9cc86f37bd37122f71162304e3164/requests-2.17.2-py2.py3-none-any.whl#sha256=76d2f962485ebb3b3c380f146d56f5475310e53fd0defd6df0eb1c014187d45c">requests-2.17.2-py2.py3-none-any.whl</a><br/>
-          <a href="https://files.pythonhosted.org/packages/23/c2/99fe3c5c15f3d06f0620bc0867bee95ec64074cbd7c9805bb5ad3010411e/requests-2.17.2.tar.gz#sha256=3cc7a584aad15e84d193a6d7c9176af0cf49bc6611f24ec2e04be6b05957c96d">requests-2.17.2.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/29/b9/d26a6ab2ee178415ab8c0c591d2a1eb782a50c42a417ae390055f86a63c1/requests-2.17.3-py2.py3-none-any.whl#sha256=baf701b4a9d4cbe40169e8ab77816f7abadbad502ba459c30f7a2bc138e4d612">requests-2.17.3-py2.py3-none-any.whl</a><br/>
-          <a href="https://files.pythonhosted.org/packages/27/c7/a45641c83c6e28f4922ba6af3d4ae4d79b41932c2f3d77fed9e0bf878149/requests-2.17.3.tar.gz#sha256=8d29f97ed1541709b57caddb77bb20592411d7ca10ec4f03275f49ee8456e225">requests-2.17.3.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/e2/f0/c81405acbf53d0412b984eb3fc578cdd10e347374e1aec074638a500c186/requests-2.18.0-py2.py3-none-any.whl#sha256=5e88d64aa56ac0fda54e77fb9762ebc65879e171b746d5479a33c4082519d6c6">requests-2.18.0-py2.py3-none-any.whl</a><br/>
-          <a href="https://files.pythonhosted.org/packages/e0/97/e2f972b6826c9cfe57b6934e3773d2783733bc2d345d810bafd309df3d15/requests-2.18.0.tar.gz#sha256=cd0189f962787284bff715fddaad478eb4d9c15aa167bd64e52ea0f661e7ea5c">requests-2.18.0.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/5a/58/671011e3ff4a06e2969322267d78dcfda1bf4d1576551df1cce93cd7239d/requests-2.18.1-py2.py3-none-any.whl#sha256=6afd3371c1f4c1970497cdcace5c5ecbbe58267bf05ca1abd93d99d170803ab7">requests-2.18.1-py2.py3-none-any.whl</a><br/>
-          <a href="https://files.pythonhosted.org/packages/2c/b5/2b6e8ef8dd18203b6399e9f28c7d54f6de7b7549853fe36d575bd31e29a7/requests-2.18.1.tar.gz#sha256=c6f3bdf4a4323ac7b45d01e04a6f6c20e32a052cd04de81e05103abc049ad9b9">requests-2.18.1.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/cf/fa/31b222e4b44975de1b5ac3e1a725abdfeb00e0d761567ab426ee28a7fc73/requests-2.18.2-py2.py3-none-any.whl#sha256=414459f05392835d4d653b57b8e58f98aea9c6ff2782e37de0a1ee92891ce900">requests-2.18.2-py2.py3-none-any.whl</a><br/>
-          <a href="https://files.pythonhosted.org/packages/07/2e/81fdfdfac91cf3cb2518fb149ac67caf0e081b485eab68e9aee63396f7e8/requests-2.18.2.tar.gz#sha256=5b26fcc5e72757a867e4d562333f841eddcef93548908a1bb1a9207260618da9">requests-2.18.2.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/ba/92/c35ed010e8f96781f08dfa6d9a6a19445a175a9304aceedece77cd48b68f/requests-2.18.3-py2.py3-none-any.whl#sha256=b62be4ec5999c24d10c98d248a136e7db20ca6616a2b65060cd9399417331e8a">requests-2.18.3-py2.py3-none-any.whl</a><br/>
-          <a href="https://files.pythonhosted.org/packages/c3/38/d95ddb6cc8558930600be088e174a2152261a1e0708a18bf91b5b8c90b22/requests-2.18.3.tar.gz#sha256=fb68a7baef4965c12d9cd67c0f5a46e6e28be3d8c7b6910c758fbcc99880b518">requests-2.18.3.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/49/df/50aa1999ab9bde74656c2919d9c0c085fd2b3775fd3eca826012bef76d8c/requests-2.18.4-py2.py3-none-any.whl#sha256=6a1b267aa90cac58ac3a765d067950e7dbbf75b1da07e895d1f594193a40a38b">requests-2.18.4-py2.py3-none-any.whl</a><br/>
-          <a href="https://files.pythonhosted.org/packages/b0/e1/eab4fc3752e3d240468a8c0b284607899d2fbfb236a56b7377a329aa8d09/requests-2.18.4.tar.gz#sha256=9c443e7324ba5b85070c4a818ade28bfabedf16ea10206da1132edaa6dda237e">requests-2.18.4.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/cc/15/e1c318dbc20032ffbe5628837ca0de2d5b116ffd1b849c699634010f6a5d/requests-2.19.0-py2.py3-none-any.whl#sha256=421cfc8d9dde7d6aff68196420afd86b88c65d77d8da9cf83f4ecad785d7b9d6" data-requires-python="&gt;=2.6, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*">requests-2.19.0-py2.py3-none-any.whl</a><br/>
-          <a href="https://files.pythonhosted.org/packages/75/27/82da3fa4ea7a8c3526c48eaafe427352ff9c931633b917c2251826a43697/requests-2.19.0.tar.gz#sha256=cc408268d0e21589bcc2b2c248e42932b8c4d112f499c12c92e99e2178a6134c" data-requires-python="&gt;=2.6, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*">requests-2.19.0.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/65/47/7e02164a2a3db50ed6d8a6ab1d6d60b69c4c3fdf57a284257925dfc12bda/requests-2.19.1-py2.py3-none-any.whl#sha256=63b52e3c866428a224f97cab011de738c36aec0185aa91cfacd418b5d58911d1" data-requires-python="&gt;=2.6, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*">requests-2.19.1-py2.py3-none-any.whl</a><br/>
-          <a href="https://files.pythonhosted.org/packages/54/1f/782a5734931ddf2e1494e4cd615a51ff98e1879cbe9eecbdfeaf09aa75e9/requests-2.19.1.tar.gz#sha256=ec22d826a36ed72a7358ff3fe56cbd4ba69dd7a6718ffd450ff0e9df7a47ce6a" data-requires-python="&gt;=2.6, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*">requests-2.19.1.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/f1/ca/10332a30cb25b627192b4ea272c351bce3ca1091e541245cccbace6051d8/requests-2.20.0-py2.py3-none-any.whl#sha256=a84b8c9ab6239b578f22d1c21d51b696dcfe004032bb80ea832398d6909d7279" data-requires-python="&gt;=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*">requests-2.20.0-py2.py3-none-any.whl</a><br/>
-          <a href="https://files.pythonhosted.org/packages/97/10/92d25b93e9c266c94b76a5548f020f3f1dd0eb40649cb1993532c0af8f4c/requests-2.20.0.tar.gz#sha256=99dcfdaaeb17caf6e526f32b6a7b780461512ab3f1d992187801694cba42770c" data-requires-python="&gt;=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*">requests-2.20.0.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/ff/17/5cbb026005115301a8fb2f9b0e3e8d32313142fe8b617070e7baad20554f/requests-2.20.1-py2.py3-none-any.whl#sha256=65b3a120e4329e33c9889db89c80976c5272f56ea92d3e74da8a463992e3ff54" data-requires-python="&gt;=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*">requests-2.20.1-py2.py3-none-any.whl</a><br/>
-          <a href="https://files.pythonhosted.org/packages/40/35/298c36d839547b50822985a2cf0611b3b978a5ab7a5af5562b8ebe3e1369/requests-2.20.1.tar.gz#sha256=ea881206e59f41dbd0bd445437d792e43906703fff75ca8ff43ccdb11f33f263" data-requires-python="&gt;=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*">requests-2.20.1.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/7d/e3/20f3d364d6c8e5d2353c72a67778eb189176f08e873c9900e10c0287b84b/requests-2.21.0-py2.py3-none-any.whl#sha256=7bf2a778576d825600030a110f3c0e3e8edc51dfaafe1c146e39a2027784957b" data-requires-python="&gt;=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*">requests-2.21.0-py2.py3-none-any.whl</a><br/>
-          <a href="https://files.pythonhosted.org/packages/52/2c/514e4ac25da2b08ca5a464c50463682126385c4272c18193876e91f4bc38/requests-2.21.0.tar.gz#sha256=502a824f31acdacb3a35b6690b5fbf0bc41d63a24a45c4004352b0242707598e" data-requires-python="&gt;=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*">requests-2.21.0.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/51/bd/23c926cd341ea6b7dd0b2a00aba99ae0f828be89d72b2190f27c11d4b7fb/requests-2.22.0-py2.py3-none-any.whl#sha256=9cf5292fcd0f598c671cfc1e0d7d1a7f13bb8085e9a590f48c010551dc6c4b31" data-requires-python="&gt;=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*">requests-2.22.0-py2.py3-none-any.whl</a><br/>
-          <a href="https://files.pythonhosted.org/packages/01/62/ddcf76d1d19885e8579acb1b1df26a852b03472c0e46d2b959a714c90608/requests-2.22.0.tar.gz#sha256=11e007a8a2aa0323f5a921e9e6a2d7e4e67d9877e85773fba9ba6419025cbeb4" data-requires-python="&gt;=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*">requests-2.22.0.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/19/0a/6efa24d3589a8595a7293bd9716bbd4608fcc668a27aa83fff9043c515f7/requests-2.23.0-py2.7.egg#sha256=5d2d0ffbb515f39417009a46c14256291061ac01ba8f875b90cad137de83beb4" data-requires-python="&gt;=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*">requests-2.23.0-py2.7.egg</a><br/>
-          <a href="https://files.pythonhosted.org/packages/1a/70/1935c770cb3be6e3a8b78ced23d7e0f3b187f5cbfab4749523ed65d7c9b1/requests-2.23.0-py2.py3-none-any.whl#sha256=43999036bfa82904b6af1d99e4882b560e5e2c68e5c4b0aa03b655f3d7d73fee" data-requires-python="&gt;=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*">requests-2.23.0-py2.py3-none-any.whl</a><br/>
-          <a href="https://files.pythonhosted.org/packages/f5/4f/280162d4bd4d8aad241a21aecff7a6e46891b905a4341e7ab549ebaf7915/requests-2.23.0.tar.gz#sha256=b3f43d496c6daba4493e7c431722aeb7dbc6288f52a6e04e7b6023b0247817e6" data-requires-python="&gt;=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*">requests-2.23.0.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/45/1e/0c169c6a5381e241ba7404532c16a21d86ab872c9bed8bdcd4c423954103/requests-2.24.0-py2.py3-none-any.whl#sha256=fe75cc94a9443b9246fc7049224f75604b113c36acb93f87b80ed42c44cbb898" data-requires-python="&gt;=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*">requests-2.24.0-py2.py3-none-any.whl</a><br/>
-          <a href="https://files.pythonhosted.org/packages/da/67/672b422d9daf07365259958912ba533a0ecab839d4084c487a5fe9a5405f/requests-2.24.0.tar.gz#sha256=b3559a131db72c33ee969480840fff4bb6dd111de7dd27c8ee1f820f4f00231b" data-requires-python="&gt;=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*">requests-2.24.0.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/39/fc/f91eac5a39a65f75a7adb58eac7fa78871ea9872283fb9c44e6545998134/requests-2.25.0-py2.py3-none-any.whl#sha256=e786fa28d8c9154e6a4de5d46a1d921b8749f8b74e28bde23768e5e16eece998" data-requires-python="&gt;=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*">requests-2.25.0-py2.py3-none-any.whl</a><br/>
-          <a href="https://files.pythonhosted.org/packages/9f/14/4a6542a078773957aa83101336375c9597e6fe5889d20abda9c38f9f3ff2/requests-2.25.0.tar.gz#sha256=7f1a0b932f4a60a1a65caa4263921bb7d9ee911957e0ae4a23a6dd08185ad5f8" data-requires-python="&gt;=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*">requests-2.25.0.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/29/c1/24814557f1d22c56d50280771a17307e6bf87b70727d975fd6b2ce6b014a/requests-2.25.1-py2.py3-none-any.whl#sha256=c210084e36a42ae6b9219e00e48287def368a26d03a048ddad7bfee44f75871e" data-requires-python="&gt;=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*">requests-2.25.1-py2.py3-none-any.whl</a><br/>
-          <a href="https://files.pythonhosted.org/packages/6b/47/c14abc08432ab22dc18b9892252efaf005ab44066de871e72a38d6af464b/requests-2.25.1.tar.gz#sha256=27973dd4a904a4f13b263a19c866c13b92a39ed1c964655f025f3f8d3d75b804" data-requires-python="&gt;=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*">requests-2.25.1.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/92/96/144f70b972a9c0eabbd4391ef93ccd49d0f2747f4f6a2a2738e99e5adc65/requests-2.26.0-py2.py3-none-any.whl#sha256=6c1246513ecd5ecd4528a0906f910e8f0f9c6b8ec72030dc9fd154dc1a6efd24" data-requires-python="&gt;=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*">requests-2.26.0-py2.py3-none-any.whl</a><br/>
-          <a href="https://files.pythonhosted.org/packages/e7/01/3569e0b535fb2e4a6c384bdbed00c55b9d78b5084e0fb7f4d0bf523d7670/requests-2.26.0.tar.gz#sha256=b8aa58f8cf793ffd8782d3d8cb19e66ef36f7aba4353eec859e74678b01b07a7" data-requires-python="&gt;=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*">requests-2.26.0.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/47/01/f420e7add78110940639a958e5af0e3f8e07a8a8b62049bac55ee117aa91/requests-2.27.0-py2.py3-none-any.whl#sha256=f71a09d7feba4a6b64ffd8e9d9bc60f9bf7d7e19fd0e04362acb1cfc2e3d98df" data-requires-python="&gt;=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*">requests-2.27.0-py2.py3-none-any.whl</a><br/>
-          <a href="https://files.pythonhosted.org/packages/c0/e3/826e27b942352a74b656e8f58b4dc7ed9495ce2d4eeb498181167c615303/requests-2.27.0.tar.gz#sha256=8e5643905bf20a308e25e4c1dd379117c09000bf8a82ebccc462cfb1b34a16b5" data-requires-python="&gt;=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*">requests-2.27.0.tar.gz</a><br/>
-          <a href="https://files.pythonhosted.org/packages/2d/61/08076519c80041bc0ffa1a8af0cbd3bf3e2b62af10435d269a9d0f40564d/requests-2.27.1-py2.py3-none-any.whl#sha256=f22fa1e554c9ddfd16e6e41ac79759e17be9e492b3587efa038054674760e72d" data-requires-python="&gt;=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*">requests-2.27.1-py2.py3-none-any.whl</a><br/>
-          <a href="https://files.pythonhosted.org/packages/60/f3/26ff3767f099b73e0efa138a9998da67890793bfa475d8278f84a30fec77/requests-2.27.1.tar.gz#sha256=68d7c56fd5a8999887728ef304a6d12edc7be74f1cfa47714fc8b414525c9a61" data-requires-python="&gt;=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*">requests-2.27.1.tar.gz</a><br/>
-          </body>
-      </html>
-      <!--SERIAL 13685488-->
-    headers:
-      Accept-Ranges:
-      - bytes
-      Cache-Control:
-      - max-age=600, public
-      Content-Security-Policy:
-      - default-src 'none'; sandbox allow-top-navigation
-      Content-Type:
-      - text/html; charset=UTF-8
-      Date:
-      - Wed, 04 May 2022 12:25:56 GMT
-      Etag:
-      - '"OAut2BCNOxqNKCH4+GWy5w"'
-      Referrer-Policy:
-      - origin-when-cross-origin
-      Server:
-      - nginx/1.13.9
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains; preload
-      Vary:
-      - Accept-Encoding
-      X-Cache:
-      - HIT, HIT
-      X-Cache-Hits:
-      - 1, 79
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - deny
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Pypi-Last-Serial:
-      - "13685488"
-      X-Served-By:
-      - cache-iad-kiad7000095-IAD, cache-fra19143-FRA
-      X-Timer:
-      - S1651667156.268189,VS0,VE0
+      - S1652091071.907917,VS0,VE0
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -3212,7 +3258,7 @@ interactions:
       Content-Type:
       - text/html; charset=UTF-8
       Date:
-      - Wed, 04 May 2022 12:25:56 GMT
+      - Mon, 09 May 2022 10:11:10 GMT
       Etag:
       - '"CkuiktTz35x9pJvwIaq2eg"'
       Referrer-Policy:
@@ -3226,7 +3272,7 @@ interactions:
       X-Cache:
       - HIT, HIT
       X-Cache-Hits:
-      - 3169, 24
+      - 3435, 41
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
@@ -3236,57 +3282,11 @@ interactions:
       X-Pypi-Last-Serial:
       - "13638933"
       X-Served-By:
-      - cache-iad-kcgs7200128-IAD, cache-fra19143-FRA
+      - cache-iad-kjyo7100168-IAD, cache-hhn4041-HHN
       X-Timer:
-      - S1651667156.268021,VS0,VE0
+      - S1652091071.907936,VS0,VE0
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
     code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers: {}
-    url: https://pypi.org/simple/lofi/
-    method: GET
-  response:
-    body: 404 Not Found
-    headers:
-      Accept-Ranges:
-      - bytes
-      Content-Length:
-      - "13"
-      Content-Security-Policy:
-      - default-src 'none'; sandbox allow-top-navigation
-      Content-Type:
-      - text/plain; charset=UTF-8
-      Date:
-      - Wed, 04 May 2022 12:25:56 GMT
-      Referrer-Policy:
-      - origin-when-cross-origin
-      Server:
-      - nginx/1.13.9
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains; preload
-      Vary:
-      - Accept-Encoding
-      X-Cache:
-      - MISS, MISS
-      X-Cache-Hits:
-      - 0, 0
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - deny
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Served-By:
-      - cache-iad-kcgs7200026-IAD, cache-fra19143-FRA
-      X-Timer:
-      - S1651667156.267644,VS0,VE148
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 404 Not Found
-    code: 404
     duration: ""


### PR DESCRIPTION
## Context

This PR factors out a `repos.DependenciesSource` that all different dependency repo sources now use to share code. This is similar to what we have done in gitserver with #34289.

This paves the way to store valid versions in `repo.metadata` and avoid redundant API calls in gitserver.

Part of #34350

## Test plan

Existing integration and unit tests + manual testing.


