### PR TITLE
preprod: port the codeintel-qa script to this repo

### DIFF
--- a/dev/ci/integration/code-intel/preprod-run.sh
+++ b/dev/ci/integration/code-intel/preprod-run.sh
@@ -6,11 +6,10 @@
 set -eux
 
 cd "$(dirname "${BASH_SOURCE[0]}")/../../../.."
-root_dir=$(pwd)
 
 SOURCEGRAPH_BASE_URL="https://preview.sgdev.dev"
 TEST_USER_EMAIL="testadmin@preview.sgdev.dev"
-SOURCEGRAPH_SUDO_USER=admin
+SOURCEGRAPH_SUDO_USER="admin"
 TEST_USER_PASSWORD="$(gcloud secrets versions access latest --project=sourcegraph-ci --secret="PREPROD_TESTADMIN_PASSWORD" --quiet)"
 SOURCEGRAPH_SUDO_TOKEN="$(gcloud secrets versions access latest --project=sourcegraph-ci --secret="PREPROD_TESTADMIN_SG_TOKEN" --quiet)"
 export SOURCEGRAPH_BASE_URL

--- a/dev/ci/integration/code-intel/preprod-run.sh
+++ b/dev/ci/integration/code-intel/preprod-run.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# This script is called by a step in the sourcegraph/deploy-sourcegraph-cloud pipeline, to run the codeintel-qa test suite
+# against the preprod.
+
+set -eux
+
+cd "$(dirname "${BASH_SOURCE[0]}")/../../../.."
+root_dir=$(pwd)
+
+SOURCEGRAPH_BASE_URL="https://preview.sgdev.dev"
+TEST_USER_EMAIL="testadmin@preview.sgdev.dev"
+SOURCEGRAPH_SUDO_USER=admin
+TEST_USER_PASSWORD="$(gcloud secrets versions access latest --project=sourcegraph-ci --secret="PREPROD_TESTADMIN_PASSWORD" --quiet)"
+SOURCEGRAPH_SUDO_TOKEN="$(gcloud secrets versions access latest --project=sourcegraph-ci --secret="PREPROD_TESTADMIN_SG_TOKEN" --quiet)"
+export SOURCEGRAPH_BASE_URL
+export TEST_USER_EMAIL
+export SOURCEGRAPH_SUDO_USER
+export TEST_USER_PASSWORD
+export SOURCEGRAPH_SUDO_TOKEN
+
+echo "--- :go: Building init-sg"
+go build -o init-sg ./internal/cmd/init-sg/...
+
+echo "--- :horse: Running init-sg addRepos"
+./init-sg addRepos -config ./dev/ci/integration/code-intel/repos.json
+
+pushd dev/codeintel-qa
+
+echo "--- :brain: Running the test suite"
+echo '--- :zero: downloading test data from GCS'
+./scripts/download.sh
+echo '--- :one: clearing existing state'
+go run ./cmd/clear
+echo '--- :two: integration test ./dev/codeintel-qa/cmd/upload'
+go run ./cmd/upload --timeout=5m
+echo '--- :three: integration test ./dev/codeintel-qa/cmd/query'
+go run ./cmd/query -check-query-result=false # make queries but do not assert against expected locations
+popd || exit 1


### PR DESCRIPTION
To ease the maintenance, the main part of this script is ported here,
while the preprod part of the script only handles cloning the
sourcegraph repo and checking out the right commit.

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

Script itself was already tested on the staging (https://buildkite.com/sourcegraph/deploy-sourcegraph-cloud/builds/204905). As for the plumbing of running this script from the preprod build, that will be tested in the `sourcegraph/deploy-sourcegraph-cloud` sister PR. 