### PR TITLE
Accessibility: Nav bar: Hide horizontal splitter from screen readers

### DIFF
--- a/client/web/src/nav/NavBar/NavBar.tsx
+++ b/client/web/src/nav/NavBar/NavBar.tsx
@@ -66,7 +66,7 @@ export const NavBar = ({ children, logo }: NavBarProps): JSX.Element => (
                 {logo}
             </RouterLink>
         </h1>
-        <hr className={navBarStyles.divider} />
+        <hr className={navBarStyles.divider} aria-hidden={true} />
         {children}
     </nav>
 )

--- a/client/web/src/nav/__snapshots__/GlobalNavbar.test.tsx.snap
+++ b/client/web/src/nav/__snapshots__/GlobalNavbar.test.tsx.snap
@@ -20,6 +20,7 @@ exports[`GlobalNavbar default 1`] = `
       </a>
     </h1>
     <hr
+      aria-hidden="true"
       class="divider"
     />
     <div
@@ -281,6 +282,7 @@ exports[`GlobalNavbar low-profile 1`] = `
       </a>
     </h1>
     <hr
+      aria-hidden="true"
       class="divider"
     />
     <div


### PR DESCRIPTION
## Description

The second item a screen reader reads on Sourcegraph.com is "horizontal splitter". This can be useful for dividing key sections of a page, but isn't relevant here.

Related to https://github.com/sourcegraph/sourcegraph/issues/34411

## Test plan

1. Run locally
2. Enable a screen reader and parse the navigation bar

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->



## App preview:

- [Web](https://sg-web-tr-hide-horizontal-splitter.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-pxtpnltowh.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
