### PR TITLE
lib: use any instead of interface{}

### DIFF
--- a/lib/batches/batch_spec.go
+++ b/lib/batches/batch_spec.go
@@ -58,8 +58,8 @@ type ExpandedGitCommitDescription struct {
 }
 
 type ImportChangeset struct {
-	Repository  string        `json:"repository" yaml:"repository"`
-	ExternalIDs []interface{} `json:"externalIDs" yaml:"externalIDs"`
+	Repository  string `json:"repository" yaml:"repository"`
+	ExternalIDs []any  `json:"externalIDs" yaml:"externalIDs"`
 }
 
 type WorkspaceConfiguration struct {
@@ -94,7 +94,7 @@ type Step struct {
 	Files     map[string]string `json:"files,omitempty" yaml:"files,omitempty"`
 	Outputs   Outputs           `json:"outputs,omitempty" yaml:"outputs,omitempty"`
 
-	If interface{} `json:"if,omitempty" yaml:"if,omitempty"`
+	If any `json:"if,omitempty" yaml:"if,omitempty"`
 }
 
 func (s *Step) IfCondition() string {

--- a/lib/batches/changeset_spec.go
+++ b/lib/batches/changeset_spec.go
@@ -35,7 +35,7 @@ func ParseChangesetSpec(rawSpec []byte) (*ChangesetSpec, error) {
 
 // ParseChangesetSpecExternalID attempts to parse the ID of a changeset in the
 // batch spec that should be imported.
-func ParseChangesetSpecExternalID(id interface{}) (string, error) {
+func ParseChangesetSpecExternalID(id any) (string, error) {
 	var sid string
 
 	switch tid := id.(type) {

--- a/lib/batches/changeset_specs.go
+++ b/lib/batches/changeset_specs.go
@@ -101,7 +101,7 @@ func BuildChangesetSpecs(input *ChangesetSpecInput, features ChangesetSpecFeatur
 	}
 
 	newSpec := func(branch, diff string) (*ChangesetSpec, error) {
-		var published interface{} = nil
+		var published any = nil
 		if input.Template.Published != nil {
 			published = input.Template.Published.ValueWithSuffix(input.Repository.Name, branch)
 

--- a/lib/batches/changeset_specs_test.go
+++ b/lib/batches/changeset_specs_test.go
@@ -75,7 +75,7 @@ func TestCreateChangesetSpecs(t *testing.T) {
 			ChangedFiles: &git.Changes{
 				Modified: []string{"README.md"},
 			},
-			Outputs: map[string]interface{}{},
+			Outputs: map[string]any{},
 		},
 	}
 

--- a/lib/batches/env/env.go
+++ b/lib/batches/env/env.go
@@ -68,7 +68,7 @@ func (e *Environment) UnmarshalJSON(data []byte) error {
 
 // UnmarshalYAML unmarshals an environment from one of the two supported YAML
 // forms: an array, or a string→string object.
-func (e *Environment) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (e *Environment) UnmarshalYAML(unmarshal func(any) error) error {
 	// data is either an array or object. (Or invalid.) Let's start by trying to
 	// unmarshal it as an array.
 	if err := unmarshal(&e.vars); err == nil {

--- a/lib/batches/env/var.go
+++ b/lib/batches/env/var.go
@@ -58,7 +58,7 @@ func (v *variable) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func (v *variable) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (v *variable) UnmarshalYAML(unmarshal func(any) error) error {
 	// This can be a string or an object with one property. Let's try the string
 	// case first.
 	var k string

--- a/lib/batches/execution/results.go
+++ b/lib/batches/execution/results.go
@@ -56,7 +56,7 @@ type AfterStepResult struct {
 	// Diff is the cumulative `git diff` after executing the Step.
 	Diff string `json:"diff"`
 	// Outputs is a copy of the Outputs after executing the Step.
-	Outputs map[string]interface{} `json:"outputs"`
+	Outputs map[string]any `json:"outputs"`
 	// PreviousStepResult is the StepResult of the step before Step, if
 	// StepIndex != 0.
 	PreviousStepResult StepResult `json:"previousStepResult"`
@@ -71,7 +71,7 @@ type Result struct {
 	ChangedFiles *git.Changes `json:"changedFiles"`
 
 	// Outputs are the outputs produced by all steps.
-	Outputs map[string]interface{} `json:"outputs"`
+	Outputs map[string]any `json:"outputs"`
 
 	// Path relative to the repository's root directory in which the steps
 	// have been executed.

--- a/lib/batches/json/validate.go
+++ b/lib/batches/json/validate.go
@@ -10,7 +10,7 @@ import (
 // UnmarshalValidate validates the JSON input against the provided JSON schema.
 // If the validation is successful the validated input is unmarshalled into the
 // target.
-func UnmarshalValidate(schema string, input []byte, target interface{}) error {
+func UnmarshalValidate(schema string, input []byte, target any) error {
 	var errs error
 	if err := jsonschema.Validate(schema, input); err != nil {
 		errs = errors.Append(errs, err)

--- a/lib/batches/json_logs.go
+++ b/lib/batches/json_logs.go
@@ -14,7 +14,7 @@ type LogEvent struct {
 	Timestamp time.Time `json:"timestamp"`
 
 	Status   LogEventStatus `json:"status"`
-	Metadata interface{}    `json:"metadata,omitempty"`
+	Metadata any            `json:"metadata,omitempty"`
 }
 
 type logEventJSON struct {
@@ -86,7 +86,7 @@ func (l *LogEvent) UnmarshalJSON(data []byte) error {
 	}
 
 	wrapper := struct {
-		Metadata interface{} `json:"metadata"`
+		Metadata any `json:"metadata"`
 	}{
 		Metadata: l.Metadata,
 	}
@@ -245,8 +245,8 @@ type TaskStepMetadata struct {
 
 	Out string `json:"out,omitempty"`
 
-	Diff    string                 `json:"diff,omitempty"`
-	Outputs map[string]interface{} `json:"outputs,omitempty"`
+	Diff    string         `json:"diff,omitempty"`
+	Outputs map[string]any `json:"outputs,omitempty"`
 
 	ExitCode int    `json:"exitCode,omitempty"`
 	Error    string `json:"error,omitempty"`

--- a/lib/batches/on/aggregator.go
+++ b/lib/batches/on/aggregator.go
@@ -17,8 +17,8 @@ type RepoRevisionAggregator struct {
 	results []*RuleRevisions
 }
 
-type RepoID interface{}
-type Revision interface{}
+type RepoID any
+type Revision any
 
 func NewRepoRevisionAggregator() *RepoRevisionAggregator {
 	return &RepoRevisionAggregator{

--- a/lib/batches/overridable/bool.go
+++ b/lib/batches/overridable/bool.go
@@ -48,7 +48,7 @@ func (b *Bool) UnmarshalJSON(data []byte) error {
 }
 
 // UnmarshalYAML unmarshalls a YAML value into a Bool.
-func (b *Bool) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (b *Bool) UnmarshalYAML(unmarshal func(any) error) error {
 	var all bool
 	if err := unmarshal(&all); err == nil {
 		*b = Bool{rules: rules{simpleRule(all)}}

--- a/lib/batches/overridable/bool_or_string.go
+++ b/lib/batches/overridable/bool_or_string.go
@@ -10,19 +10,19 @@ type BoolOrString struct {
 }
 
 // FromBoolOrString creates a BoolOrString representing a static, scalar value.
-func FromBoolOrString(v interface{}) BoolOrString {
+func FromBoolOrString(v any) BoolOrString {
 	return BoolOrString{
 		rules: rules{simpleRule(v)},
 	}
 }
 
 // Value returns the value for the given repository.
-func (bs *BoolOrString) Value(name string) interface{} {
+func (bs *BoolOrString) Value(name string) any {
 	return bs.rules.Match(name)
 }
 
 // ValueWithSuffix returns the value for the given repository and branch name.
-func (bs *BoolOrString) ValueWithSuffix(name, suffix string) interface{} {
+func (bs *BoolOrString) ValueWithSuffix(name, suffix string) any {
 	return bs.rules.MatchWithSuffix(name, suffix)
 }
 
@@ -56,7 +56,7 @@ func (bs *BoolOrString) UnmarshalJSON(data []byte) error {
 }
 
 // UnmarshalYAML unmarshalls a YAML value into a Publish.
-func (bs *BoolOrString) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (bs *BoolOrString) UnmarshalYAML(unmarshal func(any) error) error {
 	var b bool
 	if err := unmarshal(&b); err == nil {
 		*bs = BoolOrString{rules: rules{simpleRule(b)}}

--- a/lib/batches/overridable/bool_or_string_test.go
+++ b/lib/batches/overridable/bool_or_string_test.go
@@ -12,7 +12,7 @@ func TestBoolOrStringIs(t *testing.T) {
 	for name, tc := range map[string]struct {
 		def        BoolOrString
 		input      string
-		wantParsed interface{}
+		wantParsed any
 	}{
 		"wildcard false": {
 			def: BoolOrString{
@@ -89,7 +89,7 @@ func TestBoolOrStringWithSuffix(t *testing.T) {
 		inputName   string
 		inputSuffix string
 
-		wantParsed interface{}
+		wantParsed any
 	}{
 		"pattern and suffix match": {
 			def: BoolOrString{

--- a/lib/batches/overridable/overridable.go
+++ b/lib/batches/overridable/overridable.go
@@ -15,7 +15,7 @@ import (
 const allPattern = "*"
 
 // simpleRule creates the simplest of rules for the given value: `"*": value`.
-func simpleRule(v interface{}) *rule {
+func simpleRule(v any) *rule {
 	r, err := newRule(allPattern, v)
 	if err != nil {
 		// Since we control the pattern being compiled, an error should never
@@ -26,7 +26,7 @@ func simpleRule(v interface{}) *rule {
 	return r
 }
 
-type complex []map[string]interface{}
+type complex []map[string]any
 
 type rule struct {
 	// pattern is the glob-syntax pattern, such as "a/b/ceee-*"
@@ -35,12 +35,12 @@ type rule struct {
 	patternSuffix string
 
 	compiled glob.Glob
-	value    interface{}
+	value    any
 }
 
 // newRule builds a new rule instance, ensuring that the glob pattern
 // is compiled.
-func newRule(pattern string, value interface{}) (*rule, error) {
+func newRule(pattern string, value any) (*rule, error) {
 	var suffix string
 	split := strings.SplitN(pattern, "@", 2)
 	if len(split) > 1 {
@@ -68,7 +68,7 @@ func (a rule) Equal(b rule) bool {
 type rules []*rule
 
 // Match matches the given repository name against all rules, returning the rule value that matches at last, or nil if none match.
-func (r rules) Match(name string) interface{} {
+func (r rules) Match(name string) any {
 	// We want the last match to win, so we'll iterate in reverse order.
 	for i := len(r) - 1; i >= 0; i-- {
 		if r[i].compiled.Match(name) {
@@ -81,7 +81,7 @@ func (r rules) Match(name string) interface{} {
 // MatchWithSuffix matches the given repository name against all rules and the
 // suffix against provided pattern suffix, returning the rule value that matches
 // at last, or nil if none match.
-func (r rules) MatchWithSuffix(name, suffix string) interface{} {
+func (r rules) MatchWithSuffix(name, suffix string) any {
 	// We want the last match to win, so we'll iterate in reverse order.
 	for i := len(r) - 1; i >= 0; i-- {
 		if r[i].compiled.Match(name) && (r[i].patternSuffix == "" || r[i].patternSuffix == suffix) {
@@ -98,9 +98,9 @@ func (r rules) MarshalJSON() ([]byte, error) {
 		return json.Marshal(r[0].value)
 	}
 
-	rules := []map[string]interface{}{}
+	rules := []map[string]any{}
 	for _, rule := range r {
-		rules = append(rules, map[string]interface{}{
+		rules = append(rules, map[string]any{
 			rule.pattern: rule.value,
 		})
 	}
@@ -108,7 +108,7 @@ func (r rules) MarshalJSON() ([]byte, error) {
 }
 
 // hydrateFromComplex builds an array of rules out of a complex value.
-func (r *rules) hydrateFromComplex(c []map[string]interface{}) error {
+func (r *rules) hydrateFromComplex(c []map[string]any) error {
 	*r = make(rules, len(c))
 	for i, rule := range c {
 		if len(rule) != 1 {

--- a/lib/batches/overridable/overridable_test.go
+++ b/lib/batches/overridable/overridable_test.go
@@ -52,7 +52,7 @@ func TestRulesMarshalJSON(t *testing.T) {
 func TestMatchWithSuffix(t *testing.T) {
 	type ruleInputs struct {
 		pattern string
-		value   interface{}
+		value   any
 	}
 	compileInputs := func(t *testing.T, inputs []ruleInputs) (rs rules) {
 		for _, input := range inputs {
@@ -68,7 +68,7 @@ func TestMatchWithSuffix(t *testing.T) {
 	for name, tc := range map[string]struct {
 		rules []ruleInputs
 		args  []string
-		want  interface{}
+		want  any
 	}{
 		"no rules": {
 			rules: []ruleInputs{},

--- a/lib/batches/published.go
+++ b/lib/batches/published.go
@@ -9,7 +9,7 @@ import (
 // PublishedValue is a wrapper type that supports the quadruple `true`, `false`,
 // `"draft"`, `nil`.
 type PublishedValue struct {
-	Val interface{}
+	Val any
 }
 
 // True is true if the enclosed value is a bool being true.
@@ -47,7 +47,7 @@ func (p *PublishedValue) Valid() bool {
 }
 
 // Value returns the underlying value stored in this wrapper.
-func (p *PublishedValue) Value() interface{} {
+func (p *PublishedValue) Value() any {
 	return p.Val
 }
 
@@ -76,7 +76,7 @@ func (p *PublishedValue) UnmarshalJSON(b []byte) error {
 }
 
 // UnmarshalYAML unmarshalls a YAML value into a Publish.
-func (p *PublishedValue) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (p *PublishedValue) UnmarshalYAML(unmarshal func(any) error) error {
 	if err := unmarshal(&p.Val); err != nil {
 		return err
 	}
@@ -84,7 +84,7 @@ func (p *PublishedValue) UnmarshalYAML(unmarshal func(interface{}) error) error 
 	return nil
 }
 
-func (p *PublishedValue) UnmarshalGraphQL(input interface{}) error {
+func (p *PublishedValue) UnmarshalGraphQL(input any) error {
 	p.Val = input
 	if !p.Valid() {
 		return errors.Errorf("invalid PublishedValue: %v", input)

--- a/lib/batches/published_test.go
+++ b/lib/batches/published_test.go
@@ -10,7 +10,7 @@ import (
 func TestPublishedValue(t *testing.T) {
 	tests := []struct {
 		name    string
-		val     interface{}
+		val     any
 		True    bool
 		False   bool
 		Draft   bool
@@ -46,7 +46,7 @@ func TestPublishedValue(t *testing.T) {
 	t.Run("JSON marshal", func(t *testing.T) {
 		tests := []struct {
 			name     string
-			val      interface{}
+			val      any
 			expected string
 		}{
 			{name: "true", val: true, expected: "true"},
@@ -71,7 +71,7 @@ func TestPublishedValue(t *testing.T) {
 		tests := []struct {
 			name     string
 			val      string
-			expected interface{}
+			expected any
 		}{
 			{name: "true", val: "true", expected: true},
 			{name: "false", val: "false", expected: false},
@@ -94,7 +94,7 @@ func TestPublishedValue(t *testing.T) {
 		tests := []struct {
 			name     string
 			val      string
-			expected interface{}
+			expected any
 		}{
 			{name: "true", val: "true", expected: true},
 			{name: "true", val: "yes", expected: true},

--- a/lib/batches/template/templating.go
+++ b/lib/batches/template/templating.go
@@ -108,7 +108,7 @@ type StepContext struct {
 	// BatchChange are the attributes in the BatchSpec that are set on the BatchChange.
 	BatchChange BatchChangeAttributes
 	// Outputs are the outputs set by the current and all previous steps.
-	Outputs map[string]interface{}
+	Outputs map[string]any
 	// Step is the result of the current step. Empty when evaluating the "run" field
 	// but filled when evaluating the "outputs" field.
 	Step execution.StepResult
@@ -125,8 +125,8 @@ type StepContext struct {
 // ToFuncMap returns a template.FuncMap to access fields on the StepContext in a
 // text/template.
 func (stepCtx *StepContext) ToFuncMap() template.FuncMap {
-	newStepResult := func(res *execution.StepResult) map[string]interface{} {
-		m := map[string]interface{}{
+	newStepResult := func(res *execution.StepResult) map[string]any {
+		m := map[string]any{
 			"modified_files": "",
 			"added_files":    "",
 			"deleted_files":  "",
@@ -155,29 +155,29 @@ func (stepCtx *StepContext) ToFuncMap() template.FuncMap {
 	}
 
 	return template.FuncMap{
-		"previous_step": func() map[string]interface{} {
+		"previous_step": func() map[string]any {
 			return newStepResult(&stepCtx.PreviousStep)
 		},
-		"step": func() map[string]interface{} {
+		"step": func() map[string]any {
 			return newStepResult(&stepCtx.Step)
 		},
-		"steps": func() map[string]interface{} {
+		"steps": func() map[string]any {
 			res := newStepResult(&execution.StepResult{Files: stepCtx.Steps.Changes})
 			res["path"] = stepCtx.Steps.Path
 			return res
 		},
-		"outputs": func() map[string]interface{} {
+		"outputs": func() map[string]any {
 			return stepCtx.Outputs
 		},
-		"repository": func() map[string]interface{} {
-			return map[string]interface{}{
+		"repository": func() map[string]any {
+			return map[string]any{
 				"search_result_paths": stepCtx.Repository.SearchResultPaths(),
 				"name":                stepCtx.Repository.Name,
 				"branch":              stepCtx.Repository.Branch,
 			}
 		},
-		"batch_change": func() map[string]interface{} {
-			return map[string]interface{}{
+		"batch_change": func() map[string]any {
+			return map[string]any{
 				"name":        stepCtx.BatchChange.Name,
 				"description": stepCtx.BatchChange.Description,
 			}
@@ -204,7 +204,7 @@ type ChangesetTemplateContext struct {
 	Steps StepsContext
 
 	// Outputs are the outputs defined and initialized by the steps.
-	Outputs map[string]interface{}
+	Outputs map[string]any
 
 	// Repository is the repository in which the steps were executed.
 	Repository Repository
@@ -214,28 +214,28 @@ type ChangesetTemplateContext struct {
 // text/template.
 func (tmplCtx *ChangesetTemplateContext) ToFuncMap() template.FuncMap {
 	return template.FuncMap{
-		"repository": func() map[string]interface{} {
-			return map[string]interface{}{
+		"repository": func() map[string]any {
+			return map[string]any{
 				"search_result_paths": tmplCtx.Repository.SearchResultPaths(),
 				"name":                tmplCtx.Repository.Name,
 				"branch":              tmplCtx.Repository.Branch,
 			}
 		},
-		"batch_change": func() map[string]interface{} {
-			return map[string]interface{}{
+		"batch_change": func() map[string]any {
+			return map[string]any{
 				"name":        tmplCtx.BatchChangeAttributes.Name,
 				"description": tmplCtx.BatchChangeAttributes.Description,
 			}
 		},
-		"outputs": func() map[string]interface{} {
+		"outputs": func() map[string]any {
 			return tmplCtx.Outputs
 		},
-		"steps": func() map[string]interface{} {
+		"steps": func() map[string]any {
 			// Wrap the *StepChanges in a execution.StepResult so we can use nil-safe
 			// methods.
 			res := execution.StepResult{Files: tmplCtx.Steps.Changes}
 
-			return map[string]interface{}{
+			return map[string]any{
 				"modified_files": res.ModifiedFiles(),
 				"added_files":    res.AddedFiles(),
 				"deleted_files":  res.DeletedFiles(),

--- a/lib/batches/template/templating_test.go
+++ b/lib/batches/template/templating_test.go
@@ -33,7 +33,7 @@ func TestEvalStepCondition(t *testing.T) {
 			Changes: testChanges,
 			Path:    "sub/directory/of/repo",
 		},
-		Outputs: map[string]interface{}{},
+		Outputs: map[string]any{},
 		// Step is not set when evalStepCondition is called
 		Repository: *testRepo1,
 	}
@@ -79,7 +79,7 @@ func TestRenderStepTemplate(t *testing.T) {
 	// To avoid bugs due to differences between test setup and actual code, we
 	// do the actual parsing of YAML here to get an interface{} which we'll put
 	// in the StepContext.
-	var parsedYaml interface{}
+	var parsedYaml any
 	if err := yaml.Unmarshal([]byte(rawYaml), &parsedYaml); err != nil {
 		t.Fatalf("failed to parse YAML: %s", err)
 	}
@@ -94,7 +94,7 @@ func TestRenderStepTemplate(t *testing.T) {
 			Stdout: bytes.NewBufferString("this is previous step's stdout"),
 			Stderr: bytes.NewBufferString("this is previous step's stderr"),
 		},
-		Outputs: map[string]interface{}{
+		Outputs: map[string]any{
 			"lastLine": "lastLine is this",
 			"project":  parsedYaml,
 		},
@@ -238,7 +238,7 @@ func TestRenderStepMap(t *testing.T) {
 			Stdout: bytes.NewBufferString("this is previous step's stdout"),
 			Stderr: bytes.NewBufferString("this is previous step's stderr"),
 		},
-		Outputs:    map[string]interface{}{},
+		Outputs:    map[string]any{},
 		Repository: *testRepo1,
 	}
 
@@ -268,7 +268,7 @@ func TestRenderChangesetTemplateField(t *testing.T) {
 	// To avoid bugs due to differences between test setup and actual code, we
 	// do the actual parsing of YAML here to get an interface{} which we'll put
 	// in the StepContext.
-	var parsedYaml interface{}
+	var parsedYaml any
 	if err := yaml.Unmarshal([]byte(rawYaml), &parsedYaml); err != nil {
 		t.Fatalf("failed to parse YAML: %s", err)
 	}
@@ -278,7 +278,7 @@ func TestRenderChangesetTemplateField(t *testing.T) {
 			Name:        "test-batch-change",
 			Description: "This batch change is just an experiment",
 		},
-		Outputs: map[string]interface{}{
+		Outputs: map[string]any{
 			"lastLine": "lastLine is this",
 			"project":  parsedYaml,
 		},

--- a/lib/batches/yaml/validate.go
+++ b/lib/batches/yaml/validate.go
@@ -14,7 +14,7 @@ import (
 // UnmarshalValidate validates the input, which can be YAML or JSON, against
 // the provided JSON schema. If the validation is successful the validated
 // input is unmarshalled into the target.
-func UnmarshalValidate(schema string, input []byte, target interface{}) error {
+func UnmarshalValidate(schema string, input []byte, target any) error {
 	normalized, err := yaml.YAMLToJSONCustom(input, yamlv3.Unmarshal)
 	if err != nil {
 		return errors.Wrapf(err, "failed to normalize JSON")

--- a/lib/codeintel/autoindex/config/json.go
+++ b/lib/codeintel/autoindex/config/json.go
@@ -53,7 +53,7 @@ func UnmarshalJSON(data []byte) (IndexConfiguration, error) {
 
 // jsonUnmarshal unmarshals the JSON using a fault-tolerant parser that allows comments
 // and trailing commas. If any unrecoverable faults are found, an error is returned.
-func jsonUnmarshal(text string, v interface{}) error {
+func jsonUnmarshal(text string, v any) error {
 	data, errs := jsonx.Parse(text, jsonx.ParseOptions{Comments: true, TrailingCommas: true})
 	if len(errs) > 0 {
 		return errors.Errorf("failed to parse JSON: %v", errs)

--- a/lib/codeintel/autoindex/config/json_test.go
+++ b/lib/codeintel/autoindex/config/json_test.go
@@ -87,12 +87,12 @@ func TestJsonUnmarshal(t *testing.T) {
 		"hello": "world",
 	}`
 
-	var actual interface{}
+	var actual any
 	if err := jsonUnmarshal(input, &actual); err != nil {
 		t.Fatalf("unexpected error unmarshalling payload: %s", err)
 	}
 
-	if diff := cmp.Diff(map[string]interface{}{"hello": "world"}, actual); diff != "" {
+	if diff := cmp.Diff(map[string]any{"hello": "world"}, actual); diff != "" {
 		t.Errorf("unexpected configuration (-want +got):\n%s", diff)
 	}
 }

--- a/lib/codeintel/lsif/conversion/reader.go
+++ b/lib/codeintel/lsif/conversion/reader.go
@@ -35,7 +35,7 @@ func Read(ctx context.Context, r io.Reader) <-chan Pair {
 	return elements
 }
 
-func translatePayload(payload interface{}) interface{} {
+func translatePayload(payload any) any {
 	switch v := payload.(type) {
 	case reader.Edge:
 		return Edge(v)

--- a/lib/codeintel/lsif/protocol/reader/lsif_typed.go
+++ b/lib/codeintel/lsif/protocol/reader/lsif_typed.go
@@ -308,7 +308,7 @@ func (g *graph) emitRange(lsifRange []int32) (int, error) {
 	}), nil
 }
 
-func (g *graph) emitVertex(label string, payload interface{}) int {
+func (g *graph) emitVertex(label string, payload any) int {
 	return g.emit("vertex", label, payload)
 }
 
@@ -319,7 +319,7 @@ func (g *graph) emitEdge(label string, payload Edge) {
 	g.emit("edge", label, payload)
 }
 
-func (g *graph) emit(ty, label string, payload interface{}) int {
+func (g *graph) emit(ty, label string, payload any) int {
 	g.ID++
 	g.Elements = append(g.Elements, Element{
 		ID:      g.ID,

--- a/lib/codeintel/lsif/protocol/reader/reader.go
+++ b/lib/codeintel/lsif/protocol/reader/reader.go
@@ -45,7 +45,7 @@ func readLines(ctx context.Context, r io.Reader, unmarshal func(line []byte) (El
 	scanner.Buffer(make([]byte, LineBufferSize), LineBufferSize)
 
 	// Pool of buffers used to transfer copies of the scanner slice to unmarshal workers
-	pool := sync.Pool{New: func() interface{} { return new(bytes.Buffer) }}
+	pool := sync.Pool{New: func() any { return new(bytes.Buffer) }}
 
 	// Read the document in a separate go-routine.
 	lineCh := make(chan *bytes.Buffer, ChannelBufferSize)

--- a/lib/codeintel/lsif/protocol/reader/types.go
+++ b/lib/codeintel/lsif/protocol/reader/types.go
@@ -6,7 +6,7 @@ type Element struct {
 	ID      int
 	Type    string
 	Label   string
-	Payload interface{}
+	Payload any
 }
 
 type Edge struct {

--- a/lib/codeintel/lsif/protocol/reader/unmarshal.go
+++ b/lib/codeintel/lsif/protocol/reader/unmarshal.go
@@ -49,7 +49,7 @@ func unmarshalElement(interner *Interner, line []byte) (_ Element, err error) {
 	return element, err
 }
 
-func unmarshalEdge(interner *Interner, line []byte) (interface{}, error) {
+func unmarshalEdge(interner *Interner, line []byte) (any, error) {
 	if edge, ok := unmarshalEdgeFast(line); ok {
 		return edge, nil
 	}
@@ -136,9 +136,9 @@ func unmarshalEdgeFast(line []byte) (Edge, bool) {
 	return edge, true
 }
 
-var edgeUnmarshalers = map[string]func(line []byte) (interface{}, error){}
+var edgeUnmarshalers = map[string]func(line []byte) (any, error){}
 
-var vertexUnmarshalers = map[string]func(line []byte) (interface{}, error){
+var vertexUnmarshalers = map[string]func(line []byte) (any, error){
 	"metaData":             unmarshalMetaData,
 	"document":             unmarshalDocument,
 	"documentSymbolResult": unmarshalDocumentSymbolResult,
@@ -149,7 +149,7 @@ var vertexUnmarshalers = map[string]func(line []byte) (interface{}, error){
 	"diagnosticResult":     unmarshalDiagnosticResult,
 }
 
-func unmarshalMetaData(line []byte) (interface{}, error) {
+func unmarshalMetaData(line []byte) (any, error) {
 	var payload struct {
 		Version     string `json:"version"`
 		ProjectRoot string `json:"projectRoot"`
@@ -164,7 +164,7 @@ func unmarshalMetaData(line []byte) (interface{}, error) {
 	}, nil
 }
 
-func unmarshalDocumentSymbolResult(line []byte) (interface{}, error) {
+func unmarshalDocumentSymbolResult(line []byte) (any, error) {
 	var payload struct {
 		Result []*protocol.RangeBasedDocumentSymbol `json:"result"`
 	}
@@ -174,7 +174,7 @@ func unmarshalDocumentSymbolResult(line []byte) (interface{}, error) {
 	return payload.Result, nil
 }
 
-func unmarshalDocument(line []byte) (interface{}, error) {
+func unmarshalDocument(line []byte) (any, error) {
 	var payload struct {
 		URI string `json:"uri"`
 	}
@@ -185,7 +185,7 @@ func unmarshalDocument(line []byte) (interface{}, error) {
 	return payload.URI, nil
 }
 
-func unmarshalRange(line []byte) (interface{}, error) {
+func unmarshalRange(line []byte) (any, error) {
 	type _position struct {
 		Line      int `json:"line"`
 		Character int `json:"character"`
@@ -254,7 +254,7 @@ func unmarshalRange(line []byte) (interface{}, error) {
 
 var HoverPartSeparator = "\n\n---\n\n"
 
-func unmarshalHover(line []byte) (interface{}, error) {
+func unmarshalHover(line []byte) (any, error) {
 	type _hoverResult struct {
 		Contents json.RawMessage `json:"contents"`
 	}
@@ -322,7 +322,7 @@ func unmarshalHoverPart(raw json.RawMessage) (*string, error) {
 	return &marked, nil
 }
 
-func unmarshalMoniker(line []byte) (interface{}, error) {
+func unmarshalMoniker(line []byte) (any, error) {
 	var payload struct {
 		Kind       string `json:"kind"`
 		Scheme     string `json:"scheme"`
@@ -343,7 +343,7 @@ func unmarshalMoniker(line []byte) (interface{}, error) {
 	}, nil
 }
 
-func unmarshalPackageInformation(line []byte) (interface{}, error) {
+func unmarshalPackageInformation(line []byte) (any, error) {
 	var payload struct {
 		Name    string `json:"name"`
 		Version string `json:"version"`
@@ -358,7 +358,7 @@ func unmarshalPackageInformation(line []byte) (interface{}, error) {
 	}, nil
 }
 
-func unmarshalDiagnosticResult(line []byte) (interface{}, error) {
+func unmarshalDiagnosticResult(line []byte) (any, error) {
 	type _position struct {
 		Line      int `json:"line"`
 		Character int `json:"character"`

--- a/lib/codeintel/lsif/protocol/reader/unmarshal_documentation.go
+++ b/lib/codeintel/lsif/protocol/reader/unmarshal_documentation.go
@@ -13,7 +13,7 @@ func init() {
 	edgeUnmarshalers[string(protocol.EdgeSourcegraphDocumentationString)] = unmarshalDocumentationStringEdge
 }
 
-func unmarshalDocumentationResult(line []byte) (interface{}, error) {
+func unmarshalDocumentationResult(line []byte) (any, error) {
 	var payload struct {
 		Result protocol.Documentation `json:"result"`
 	}
@@ -23,7 +23,7 @@ func unmarshalDocumentationResult(line []byte) (interface{}, error) {
 	return payload.Result, nil
 }
 
-func unmarshalDocumentationString(line []byte) (interface{}, error) {
+func unmarshalDocumentationString(line []byte) (any, error) {
 	var payload struct {
 		Result protocol.MarkupContent `json:"result"`
 	}
@@ -39,7 +39,7 @@ type DocumentationStringEdge struct {
 	Kind protocol.DocumentationStringKind
 }
 
-func unmarshalDocumentationStringEdge(line []byte) (interface{}, error) {
+func unmarshalDocumentationStringEdge(line []byte) (any, error) {
 	var payload struct {
 		OutV int    `json:"outV"`
 		InV  int    `json:"inV"`

--- a/lib/codeintel/lsif/protocol/reader/unmarshal_test.go
+++ b/lib/codeintel/lsif/protocol/reader/unmarshal_test.go
@@ -198,7 +198,7 @@ func TestUnmarshalRangeWithTag(t *testing.T) {
 	}
 }
 
-var result interface{}
+var result any
 
 func BenchmarkUnmarshalHover(b *testing.B) {
 	for i := 0; i < b.N; i++ {

--- a/lib/codeintel/lsif/protocol/writer/writer.go
+++ b/lib/codeintel/lsif/protocol/writer/writer.go
@@ -14,7 +14,7 @@ var marshaller = jsoniter.ConfigFastest
 // underlying writer as newline-delimited JSON.
 type JSONWriter interface {
 	// Write emits a single vertex or edge value.
-	Write(v interface{})
+	Write(v any)
 
 	// Flush ensures that all elements have been written to the underlying writer.
 	Flush() error
@@ -22,7 +22,7 @@ type JSONWriter interface {
 
 type jsonWriter struct {
 	wg             sync.WaitGroup
-	ch             chan interface{}
+	ch             chan any
 	bufferedWriter *bufio.Writer
 	err            error
 }
@@ -37,7 +37,7 @@ const writerBufferSize = 4096
 
 // NewJSONWriter creates a new JSONWriter wrapping the given writer.
 func NewJSONWriter(w io.Writer) JSONWriter {
-	ch := make(chan interface{}, channelBufferSize)
+	ch := make(chan any, channelBufferSize)
 	bufferedWriter := bufio.NewWriterSize(w, writerBufferSize)
 	jw := &jsonWriter{ch: ch, bufferedWriter: bufferedWriter}
 	encoder := marshaller.NewEncoder(bufferedWriter)
@@ -61,7 +61,7 @@ func NewJSONWriter(w io.Writer) JSONWriter {
 }
 
 // Write emits a single vertex or edge value.
-func (jw *jsonWriter) Write(v interface{}) {
+func (jw *jsonWriter) Write(v any) {
 	jw.ch <- v
 }
 

--- a/lib/codeintel/lsif/reader/errors.go
+++ b/lib/codeintel/lsif/reader/errors.go
@@ -12,7 +12,7 @@ type ValidationError struct {
 }
 
 // NewValidationError creates a new validation error with the given error message.
-func NewValidationError(format string, args ...interface{}) *ValidationError {
+func NewValidationError(format string, args ...any) *ValidationError {
 	return &ValidationError{
 		Message: fmt.Sprintf(format, args...),
 	}

--- a/lib/codeintel/lsif/validation/context.go
+++ b/lib/codeintel/lsif/validation/context.go
@@ -30,7 +30,7 @@ func NewValidationContext() *ValidationContext {
 }
 
 // AddError creates a new validaton error and saves it in the validation context.
-func (ctx *ValidationContext) AddError(message string, args ...interface{}) *reader.ValidationError {
+func (ctx *ValidationContext) AddError(message string, args ...any) *reader.ValidationError {
 	err := reader.NewValidationError(message, args...)
 
 	ctx.ErrorsLock.Lock()

--- a/lib/codeintel/lsiftyped/lsif.pb.go
+++ b/lib/codeintel/lsiftyped/lsif.pb.go
@@ -1679,7 +1679,7 @@ func file_lib_codeintel_lsiftyped_lsif_proto_rawDescGZIP() []byte {
 
 var file_lib_codeintel_lsiftyped_lsif_proto_enumTypes = make([]protoimpl.EnumInfo, 7)
 var file_lib_codeintel_lsiftyped_lsif_proto_msgTypes = make([]protoimpl.MessageInfo, 11)
-var file_lib_codeintel_lsiftyped_lsif_proto_goTypes = []any{
+var file_lib_codeintel_lsiftyped_lsif_proto_goTypes = []interface{}{
 	(ProtocolVersion)(0),      // 0: lib.codeintel.lsiftyped.ProtocolVersion
 	(TextEncoding)(0),         // 1: lib.codeintel.lsiftyped.TextEncoding
 	(SymbolRole)(0),           // 2: lib.codeintel.lsiftyped.SymbolRole
@@ -1729,7 +1729,7 @@ func file_lib_codeintel_lsiftyped_lsif_proto_init() {
 		return
 	}
 	if !protoimpl.UnsafeEnabled {
-		file_lib_codeintel_lsiftyped_lsif_proto_msgTypes[0].Exporter = func(v any, i int) any {
+		file_lib_codeintel_lsiftyped_lsif_proto_msgTypes[0].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*Index); i {
 			case 0:
 				return &v.state
@@ -1741,7 +1741,7 @@ func file_lib_codeintel_lsiftyped_lsif_proto_init() {
 				return nil
 			}
 		}
-		file_lib_codeintel_lsiftyped_lsif_proto_msgTypes[1].Exporter = func(v any, i int) any {
+		file_lib_codeintel_lsiftyped_lsif_proto_msgTypes[1].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*Metadata); i {
 			case 0:
 				return &v.state
@@ -1753,7 +1753,7 @@ func file_lib_codeintel_lsiftyped_lsif_proto_init() {
 				return nil
 			}
 		}
-		file_lib_codeintel_lsiftyped_lsif_proto_msgTypes[2].Exporter = func(v any, i int) any {
+		file_lib_codeintel_lsiftyped_lsif_proto_msgTypes[2].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*ToolInfo); i {
 			case 0:
 				return &v.state
@@ -1765,7 +1765,7 @@ func file_lib_codeintel_lsiftyped_lsif_proto_init() {
 				return nil
 			}
 		}
-		file_lib_codeintel_lsiftyped_lsif_proto_msgTypes[3].Exporter = func(v any, i int) any {
+		file_lib_codeintel_lsiftyped_lsif_proto_msgTypes[3].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*Document); i {
 			case 0:
 				return &v.state
@@ -1777,7 +1777,7 @@ func file_lib_codeintel_lsiftyped_lsif_proto_init() {
 				return nil
 			}
 		}
-		file_lib_codeintel_lsiftyped_lsif_proto_msgTypes[4].Exporter = func(v any, i int) any {
+		file_lib_codeintel_lsiftyped_lsif_proto_msgTypes[4].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*Symbol); i {
 			case 0:
 				return &v.state
@@ -1789,7 +1789,7 @@ func file_lib_codeintel_lsiftyped_lsif_proto_init() {
 				return nil
 			}
 		}
-		file_lib_codeintel_lsiftyped_lsif_proto_msgTypes[5].Exporter = func(v any, i int) any {
+		file_lib_codeintel_lsiftyped_lsif_proto_msgTypes[5].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*Package); i {
 			case 0:
 				return &v.state
@@ -1801,7 +1801,7 @@ func file_lib_codeintel_lsiftyped_lsif_proto_init() {
 				return nil
 			}
 		}
-		file_lib_codeintel_lsiftyped_lsif_proto_msgTypes[6].Exporter = func(v any, i int) any {
+		file_lib_codeintel_lsiftyped_lsif_proto_msgTypes[6].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*Descriptor); i {
 			case 0:
 				return &v.state
@@ -1813,7 +1813,7 @@ func file_lib_codeintel_lsiftyped_lsif_proto_init() {
 				return nil
 			}
 		}
-		file_lib_codeintel_lsiftyped_lsif_proto_msgTypes[7].Exporter = func(v any, i int) any {
+		file_lib_codeintel_lsiftyped_lsif_proto_msgTypes[7].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*SymbolInformation); i {
 			case 0:
 				return &v.state
@@ -1825,7 +1825,7 @@ func file_lib_codeintel_lsiftyped_lsif_proto_init() {
 				return nil
 			}
 		}
-		file_lib_codeintel_lsiftyped_lsif_proto_msgTypes[8].Exporter = func(v any, i int) any {
+		file_lib_codeintel_lsiftyped_lsif_proto_msgTypes[8].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*Relationship); i {
 			case 0:
 				return &v.state
@@ -1837,7 +1837,7 @@ func file_lib_codeintel_lsiftyped_lsif_proto_init() {
 				return nil
 			}
 		}
-		file_lib_codeintel_lsiftyped_lsif_proto_msgTypes[9].Exporter = func(v any, i int) any {
+		file_lib_codeintel_lsiftyped_lsif_proto_msgTypes[9].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*Occurrence); i {
 			case 0:
 				return &v.state
@@ -1849,7 +1849,7 @@ func file_lib_codeintel_lsiftyped_lsif_proto_init() {
 				return nil
 			}
 		}
-		file_lib_codeintel_lsiftyped_lsif_proto_msgTypes[10].Exporter = func(v any, i int) any {
+		file_lib_codeintel_lsiftyped_lsif_proto_msgTypes[10].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*Diagnostic); i {
 			case 0:
 				return &v.state

--- a/lib/codeintel/lsiftyped/lsif.pb.go
+++ b/lib/codeintel/lsiftyped/lsif.pb.go
@@ -1679,7 +1679,7 @@ func file_lib_codeintel_lsiftyped_lsif_proto_rawDescGZIP() []byte {
 
 var file_lib_codeintel_lsiftyped_lsif_proto_enumTypes = make([]protoimpl.EnumInfo, 7)
 var file_lib_codeintel_lsiftyped_lsif_proto_msgTypes = make([]protoimpl.MessageInfo, 11)
-var file_lib_codeintel_lsiftyped_lsif_proto_goTypes = []interface{}{
+var file_lib_codeintel_lsiftyped_lsif_proto_goTypes = []any{
 	(ProtocolVersion)(0),      // 0: lib.codeintel.lsiftyped.ProtocolVersion
 	(TextEncoding)(0),         // 1: lib.codeintel.lsiftyped.TextEncoding
 	(SymbolRole)(0),           // 2: lib.codeintel.lsiftyped.SymbolRole
@@ -1729,7 +1729,7 @@ func file_lib_codeintel_lsiftyped_lsif_proto_init() {
 		return
 	}
 	if !protoimpl.UnsafeEnabled {
-		file_lib_codeintel_lsiftyped_lsif_proto_msgTypes[0].Exporter = func(v interface{}, i int) interface{} {
+		file_lib_codeintel_lsiftyped_lsif_proto_msgTypes[0].Exporter = func(v any, i int) any {
 			switch v := v.(*Index); i {
 			case 0:
 				return &v.state
@@ -1741,7 +1741,7 @@ func file_lib_codeintel_lsiftyped_lsif_proto_init() {
 				return nil
 			}
 		}
-		file_lib_codeintel_lsiftyped_lsif_proto_msgTypes[1].Exporter = func(v interface{}, i int) interface{} {
+		file_lib_codeintel_lsiftyped_lsif_proto_msgTypes[1].Exporter = func(v any, i int) any {
 			switch v := v.(*Metadata); i {
 			case 0:
 				return &v.state
@@ -1753,7 +1753,7 @@ func file_lib_codeintel_lsiftyped_lsif_proto_init() {
 				return nil
 			}
 		}
-		file_lib_codeintel_lsiftyped_lsif_proto_msgTypes[2].Exporter = func(v interface{}, i int) interface{} {
+		file_lib_codeintel_lsiftyped_lsif_proto_msgTypes[2].Exporter = func(v any, i int) any {
 			switch v := v.(*ToolInfo); i {
 			case 0:
 				return &v.state
@@ -1765,7 +1765,7 @@ func file_lib_codeintel_lsiftyped_lsif_proto_init() {
 				return nil
 			}
 		}
-		file_lib_codeintel_lsiftyped_lsif_proto_msgTypes[3].Exporter = func(v interface{}, i int) interface{} {
+		file_lib_codeintel_lsiftyped_lsif_proto_msgTypes[3].Exporter = func(v any, i int) any {
 			switch v := v.(*Document); i {
 			case 0:
 				return &v.state
@@ -1777,7 +1777,7 @@ func file_lib_codeintel_lsiftyped_lsif_proto_init() {
 				return nil
 			}
 		}
-		file_lib_codeintel_lsiftyped_lsif_proto_msgTypes[4].Exporter = func(v interface{}, i int) interface{} {
+		file_lib_codeintel_lsiftyped_lsif_proto_msgTypes[4].Exporter = func(v any, i int) any {
 			switch v := v.(*Symbol); i {
 			case 0:
 				return &v.state
@@ -1789,7 +1789,7 @@ func file_lib_codeintel_lsiftyped_lsif_proto_init() {
 				return nil
 			}
 		}
-		file_lib_codeintel_lsiftyped_lsif_proto_msgTypes[5].Exporter = func(v interface{}, i int) interface{} {
+		file_lib_codeintel_lsiftyped_lsif_proto_msgTypes[5].Exporter = func(v any, i int) any {
 			switch v := v.(*Package); i {
 			case 0:
 				return &v.state
@@ -1801,7 +1801,7 @@ func file_lib_codeintel_lsiftyped_lsif_proto_init() {
 				return nil
 			}
 		}
-		file_lib_codeintel_lsiftyped_lsif_proto_msgTypes[6].Exporter = func(v interface{}, i int) interface{} {
+		file_lib_codeintel_lsiftyped_lsif_proto_msgTypes[6].Exporter = func(v any, i int) any {
 			switch v := v.(*Descriptor); i {
 			case 0:
 				return &v.state
@@ -1813,7 +1813,7 @@ func file_lib_codeintel_lsiftyped_lsif_proto_init() {
 				return nil
 			}
 		}
-		file_lib_codeintel_lsiftyped_lsif_proto_msgTypes[7].Exporter = func(v interface{}, i int) interface{} {
+		file_lib_codeintel_lsiftyped_lsif_proto_msgTypes[7].Exporter = func(v any, i int) any {
 			switch v := v.(*SymbolInformation); i {
 			case 0:
 				return &v.state
@@ -1825,7 +1825,7 @@ func file_lib_codeintel_lsiftyped_lsif_proto_init() {
 				return nil
 			}
 		}
-		file_lib_codeintel_lsiftyped_lsif_proto_msgTypes[8].Exporter = func(v interface{}, i int) interface{} {
+		file_lib_codeintel_lsiftyped_lsif_proto_msgTypes[8].Exporter = func(v any, i int) any {
 			switch v := v.(*Relationship); i {
 			case 0:
 				return &v.state
@@ -1837,7 +1837,7 @@ func file_lib_codeintel_lsiftyped_lsif_proto_init() {
 				return nil
 			}
 		}
-		file_lib_codeintel_lsiftyped_lsif_proto_msgTypes[9].Exporter = func(v interface{}, i int) interface{} {
+		file_lib_codeintel_lsiftyped_lsif_proto_msgTypes[9].Exporter = func(v any, i int) any {
 			switch v := v.(*Occurrence); i {
 			case 0:
 				return &v.state
@@ -1849,7 +1849,7 @@ func file_lib_codeintel_lsiftyped_lsif_proto_init() {
 				return nil
 			}
 		}
-		file_lib_codeintel_lsiftyped_lsif_proto_msgTypes[10].Exporter = func(v interface{}, i int) interface{} {
+		file_lib_codeintel_lsiftyped_lsif_proto_msgTypes[10].Exporter = func(v any, i int) any {
 			switch v := v.(*Diagnostic); i {
 			case 0:
 				return &v.state

--- a/lib/codeintel/tools/lsif-index-tester/main.go
+++ b/lib/codeintel/tools/lsif-index-tester/main.go
@@ -66,7 +66,7 @@ var debug bool
 // TODO: Do more monitoring of the process.
 // var monitor bool
 
-func logFatal(msg string, args ...interface{}) {
+func logFatal(msg string, args ...any) {
 	log15.Error(msg, args...)
 	os.Exit(1)
 }

--- a/lib/codeintel/tools/lsif-index-tester/proc_profiling.go
+++ b/lib/codeintel/tools/lsif-index-tester/proc_profiling.go
@@ -11,7 +11,7 @@ import (
 // different results.
 // Something to consider for later. That's why the code lives in a separate place though.
 
-func MaxMemoryInKB(usage interface{}) (int64, error) {
+func MaxMemoryInKB(usage any) (int64, error) {
 	sysUsage, ok := usage.(*syscall.Rusage)
 
 	if !ok {

--- a/lib/errors/errors.go
+++ b/lib/errors/errors.go
@@ -94,7 +94,7 @@ func (e *multiError) Is(refError error) bool {
 	return false
 }
 
-func (e *multiError) As(target interface{}) bool {
+func (e *multiError) As(target any) bool {
 	if m, ok := target.(*multiError); ok {
 		*m = *e
 		return true

--- a/lib/log/logger_test.go
+++ b/lib/log/logger_test.go
@@ -34,20 +34,20 @@ func TestInitLogger(t *testing.T) {
 		assert.Equal(t, l.Scope, "TestInitLogger") // scope is always applied
 	}
 
-	assert.Equal(t, map[string]interface{}{
+	assert.Equal(t, map[string]any{
 		"some":  "field",
 		"hello": "world",
 	}, logs[1].Fields["Attributes"])
 
 	assert.Equal(t, "asdf", logs[2].Fields["TraceId"])
-	assert.Equal(t, map[string]interface{}{
+	assert.Equal(t, map[string]any{
 		"some":  "field",
 		"world": "hello",
 	}, logs[2].Fields["Attributes"])
 
-	assert.Equal(t, map[string]interface{}{
+	assert.Equal(t, map[string]any{
 		"some": "field",
-		"object": map[string]interface{}{
+		"object": map[string]any{
 			"field1": "value",
 			"field2": "value",
 		},

--- a/lib/log/logtest/logtest.go
+++ b/lib/log/logtest/logtest.go
@@ -60,7 +60,7 @@ type CapturedLog struct {
 	Scope   string
 	Level   log.Level
 	Message string
-	Fields  map[string]interface{}
+	Fields  map[string]any
 }
 
 // Get retrieves a logger from scoped to the the given test.

--- a/lib/log/logtest/logtest_test.go
+++ b/lib/log/logtest/logtest_test.go
@@ -18,5 +18,5 @@ func TestExport(t *testing.T) {
 	assert.Len(t, logs, 1)
 	assert.Equal(t, logs[0].Scope, "TestExport")
 	assert.Equal(t, logs[0].Message, "hello world")
-	assert.Equal(t, logs[0].Fields["Attributes"], map[string]interface{}{"key": "value"})
+	assert.Equal(t, logs[0].Fields["Attributes"], map[string]any{"key": "value"})
 }

--- a/lib/output/capabilities.go
+++ b/lib/output/capabilities.go
@@ -58,8 +58,8 @@ func detectColor(atty bool) bool {
 	return true
 }
 
-func (c *capabilities) formatArgs(args []interface{}) []interface{} {
-	out := make([]interface{}, len(args))
+func (c *capabilities) formatArgs(args []any) []any {
+	out := make([]any, len(args))
 	for i, arg := range args {
 		if _, ok := arg.(Style); ok && !c.Color {
 			out[i] = ""

--- a/lib/output/line.go
+++ b/lib/output/line.go
@@ -10,7 +10,7 @@ type FancyLine struct {
 	emoji  string
 	style  Style
 	format string
-	args   []interface{}
+	args   []any
 }
 
 // Line creates a new FancyLine without a format string.
@@ -19,13 +19,13 @@ func Line(emoji string, style Style, s string) FancyLine {
 		emoji:  emoji,
 		style:  style,
 		format: "%s",
-		args:   []interface{}{s},
+		args:   []any{s},
 	}
 }
 
 // Line creates a new FancyLine with a format string. As with Writer, the
 // arguments may include Style instances with the %s specifier.
-func Linef(emoji string, style Style, format string, a ...interface{}) FancyLine {
+func Linef(emoji string, style Style, format string, a ...any) FancyLine {
 	return FancyLine{
 		emoji:  emoji,
 		style:  style,
@@ -39,6 +39,6 @@ func (ol FancyLine) write(w io.Writer, caps capabilities) {
 		fmt.Fprint(w, ol.emoji+" ")
 	}
 
-	fmt.Fprintf(w, "%s"+ol.format+"%s", caps.formatArgs(append(append([]interface{}{ol.style}, ol.args...), StyleReset))...)
+	fmt.Fprintf(w, "%s"+ol.format+"%s", caps.formatArgs(append(append([]any{ol.style}, ol.args...), StyleReset))...)
 	_, _ = w.Write([]byte("\n"))
 }

--- a/lib/output/noop_writer.go
+++ b/lib/output/noop_writer.go
@@ -2,9 +2,9 @@ package output
 
 type NoopWriter struct{}
 
-func (NoopWriter) Write(s string)                              {}
-func (NoopWriter) Writef(format string, args ...interface{})   {}
-func (NoopWriter) WriteLine(line FancyLine)                    {}
-func (NoopWriter) Verbose(s string)                            {}
-func (NoopWriter) Verbosef(format string, args ...interface{}) {}
-func (NoopWriter) VerboseLine(line FancyLine)                  {}
+func (NoopWriter) Write(s string)                      {}
+func (NoopWriter) Writef(format string, args ...any)   {}
+func (NoopWriter) WriteLine(line FancyLine)            {}
+func (NoopWriter) Verbose(s string)                    {}
+func (NoopWriter) Verbosef(format string, args ...any) {}
+func (NoopWriter) VerboseLine(line FancyLine)          {}

--- a/lib/output/output.go
+++ b/lib/output/output.go
@@ -18,12 +18,12 @@ import (
 type Writer interface {
 	// These methods only write the given message if verbose mode is enabled.
 	Verbose(s string)
-	Verbosef(format string, args ...interface{})
+	Verbosef(format string, args ...any)
 	VerboseLine(line FancyLine)
 
 	// These methods write their messages unconditionally.
 	Write(s string)
-	Writef(format string, args ...interface{})
+	Writef(format string, args ...any)
 	WriteLine(line FancyLine)
 }
 
@@ -153,7 +153,7 @@ func (o *Output) Verbose(s string) {
 	}
 }
 
-func (o *Output) Verbosef(format string, args ...interface{}) {
+func (o *Output) Verbosef(format string, args ...any) {
 	if o.opts.Verbose {
 		o.Writef(format, args...)
 	}
@@ -171,7 +171,7 @@ func (o *Output) Write(s string) {
 	fmt.Fprintln(o.w, s)
 }
 
-func (o *Output) Writef(format string, args ...interface{}) {
+func (o *Output) Writef(format string, args ...any) {
 	o.Lock()
 	defer o.Unlock()
 	fmt.Fprintf(o.w, format, o.caps.formatArgs(args)...)
@@ -245,7 +245,7 @@ func (o *Output) MoveUpLines(lines int) {
 // writeStyle is a helper to write a style while respecting the terminal
 // capabilities.
 func (o *Output) writeStyle(style Style) {
-	fmt.Fprintf(o.w, "%s", o.caps.formatArgs([]interface{}{style})...)
+	fmt.Fprintf(o.w, "%s", o.caps.formatArgs([]any{style})...)
 }
 
 func (o *Output) ClearScreen() {

--- a/lib/output/pending.go
+++ b/lib/output/pending.go
@@ -7,7 +7,7 @@ type Pending interface {
 
 	// Update and Updatef change the message shown after the spinner.
 	Update(s string)
-	Updatef(format string, args ...interface{})
+	Updatef(format string, args ...any)
 
 	// Complete stops the spinner and replaces the pending line with the given
 	// message.

--- a/lib/output/pending_simple.go
+++ b/lib/output/pending_simple.go
@@ -8,7 +8,7 @@ func (p *pendingSimple) Update(s string) {
 	p.Write(s + "...")
 }
 
-func (p *pendingSimple) Updatef(format string, args ...interface{}) {
+func (p *pendingSimple) Updatef(format string, args ...any) {
 	p.Writef(format+"...", args...)
 }
 

--- a/lib/output/pending_tty.go
+++ b/lib/output/pending_tty.go
@@ -20,7 +20,7 @@ func (p *pendingTTY) Verbose(s string) {
 	}
 }
 
-func (p *pendingTTY) Verbosef(format string, args ...interface{}) {
+func (p *pendingTTY) Verbosef(format string, args ...any) {
 	if p.o.opts.Verbose {
 		p.Writef(format, args...)
 	}
@@ -42,7 +42,7 @@ func (p *pendingTTY) Write(s string) {
 	p.write(p.line)
 }
 
-func (p *pendingTTY) Writef(format string, args ...interface{}) {
+func (p *pendingTTY) Writef(format string, args ...any) {
 	p.o.Lock()
 	defer p.o.Unlock()
 
@@ -68,14 +68,14 @@ func (p *pendingTTY) Update(s string) {
 	defer p.o.Unlock()
 
 	p.line.format = "%s"
-	p.line.args = []interface{}{s}
+	p.line.args = []any{s}
 
 	p.o.moveUp(1)
 	p.o.clearCurrentLine()
 	p.write(p.line)
 }
 
-func (p *pendingTTY) Updatef(format string, args ...interface{}) {
+func (p *pendingTTY) Updatef(format string, args ...any) {
 	p.o.Lock()
 	defer p.o.Unlock()
 
@@ -141,7 +141,7 @@ func (p *pendingTTY) updateEmoji(emoji string) {
 	// We add an extra space because the Braille characters are single width,
 	// but emoji are generally double width and that's what will most likely be
 	// used in the completion message, if any.
-	p.line.emoji = fmt.Sprintf("%s%s ", p.o.caps.formatArgs([]interface{}{
+	p.line.emoji = fmt.Sprintf("%s%s ", p.o.caps.formatArgs([]any{
 		p.line.style,
 		emoji,
 	})...)

--- a/lib/output/progress_tty.go
+++ b/lib/output/progress_tty.go
@@ -90,7 +90,7 @@ func (p *progressTTY) Verbose(s string) {
 	}
 }
 
-func (p *progressTTY) Verbosef(format string, args ...interface{}) {
+func (p *progressTTY) Verbosef(format string, args ...any) {
 	if p.o.opts.Verbose {
 		p.Writef(format, args...)
 	}
@@ -112,7 +112,7 @@ func (p *progressTTY) Write(s string) {
 	p.draw()
 }
 
-func (p *progressTTY) Writef(format string, args ...interface{}) {
+func (p *progressTTY) Writef(format string, args ...any) {
 	p.o.Lock()
 	defer p.o.Unlock()
 

--- a/lib/output/progress_with_status_bars.go
+++ b/lib/output/progress_with_status_bars.go
@@ -3,10 +3,10 @@ package output
 type ProgressWithStatusBars interface {
 	Progress
 
-	StatusBarUpdatef(i int, format string, args ...interface{})
-	StatusBarCompletef(i int, format string, args ...interface{})
-	StatusBarFailf(i int, format string, args ...interface{})
-	StatusBarResetf(i int, label, format string, args ...interface{})
+	StatusBarUpdatef(i int, format string, args ...any)
+	StatusBarCompletef(i int, format string, args ...any)
+	StatusBarFailf(i int, format string, args ...any)
+	StatusBarResetf(i int, label, format string, args ...any)
 }
 
 func newProgressWithStatusBars(bars []ProgressBar, statusBars []*StatusBar, o *Output, opts *ProgressOpts) ProgressWithStatusBars {

--- a/lib/output/progress_with_status_bars_simple.go
+++ b/lib/output/progress_with_status_bars_simple.go
@@ -16,13 +16,13 @@ func (p *progressWithStatusBarsSimple) Complete() {
 	writeStatusBars(p.Output, p.statusBars)
 }
 
-func (p *progressWithStatusBarsSimple) StatusBarUpdatef(i int, format string, args ...interface{}) {
+func (p *progressWithStatusBarsSimple) StatusBarUpdatef(i int, format string, args ...any) {
 	if p.statusBars[i] != nil {
 		p.statusBars[i].Updatef(format, args...)
 	}
 }
 
-func (p *progressWithStatusBarsSimple) StatusBarCompletef(i int, format string, args ...interface{}) {
+func (p *progressWithStatusBarsSimple) StatusBarCompletef(i int, format string, args ...any) {
 	if p.statusBars[i] != nil {
 		wasComplete := p.statusBars[i].completed
 		p.statusBars[i].Completef(format, args...)
@@ -32,7 +32,7 @@ func (p *progressWithStatusBarsSimple) StatusBarCompletef(i int, format string, 
 	}
 }
 
-func (p *progressWithStatusBarsSimple) StatusBarFailf(i int, format string, args ...interface{}) {
+func (p *progressWithStatusBarsSimple) StatusBarFailf(i int, format string, args ...any) {
 	if p.statusBars[i] != nil {
 		wasCompleted := p.statusBars[i].completed
 		p.statusBars[i].Failf(format, args...)
@@ -42,7 +42,7 @@ func (p *progressWithStatusBarsSimple) StatusBarFailf(i int, format string, args
 	}
 }
 
-func (p *progressWithStatusBarsSimple) StatusBarResetf(i int, label, format string, args ...interface{}) {
+func (p *progressWithStatusBarsSimple) StatusBarResetf(i int, label, format string, args ...any) {
 	if p.statusBars[i] != nil {
 		p.statusBars[i].Resetf(label, format, args...)
 	}
@@ -89,7 +89,7 @@ func newProgressWithStatusBarsSimple(bars []*ProgressBar, statusBars []*StatusBa
 }
 
 func writeStatusBar(w Writer, bar *StatusBar) {
-	w.Writef("%s: "+bar.format, append([]interface{}{bar.label}, bar.args...)...)
+	w.Writef("%s: "+bar.format, append([]any{bar.label}, bar.args...)...)
 }
 
 func writeStatusBars(o *Output, bars []*StatusBar) {

--- a/lib/output/progress_with_status_bars_tty.go
+++ b/lib/output/progress_with_status_bars_tty.go
@@ -122,7 +122,7 @@ func (p *progressWithStatusBarsTTY) SetValue(i int, v float64) {
 	p.drawInSitu()
 }
 
-func (p *progressWithStatusBarsTTY) StatusBarResetf(i int, label, format string, args ...interface{}) {
+func (p *progressWithStatusBarsTTY) StatusBarResetf(i int, label, format string, args ...any) {
 	p.o.Lock()
 	defer p.o.Unlock()
 
@@ -134,7 +134,7 @@ func (p *progressWithStatusBarsTTY) StatusBarResetf(i int, label, format string,
 	p.drawInSitu()
 }
 
-func (p *progressWithStatusBarsTTY) StatusBarUpdatef(i int, format string, args ...interface{}) {
+func (p *progressWithStatusBarsTTY) StatusBarUpdatef(i int, format string, args ...any) {
 	p.o.Lock()
 	defer p.o.Unlock()
 
@@ -145,7 +145,7 @@ func (p *progressWithStatusBarsTTY) StatusBarUpdatef(i int, format string, args 
 	p.drawInSitu()
 }
 
-func (p *progressWithStatusBarsTTY) StatusBarCompletef(i int, format string, args ...interface{}) {
+func (p *progressWithStatusBarsTTY) StatusBarCompletef(i int, format string, args ...any) {
 	p.o.Lock()
 	defer p.o.Unlock()
 
@@ -156,7 +156,7 @@ func (p *progressWithStatusBarsTTY) StatusBarCompletef(i int, format string, arg
 	p.drawInSitu()
 }
 
-func (p *progressWithStatusBarsTTY) StatusBarFailf(i int, format string, args ...interface{}) {
+func (p *progressWithStatusBarsTTY) StatusBarFailf(i int, format string, args ...any) {
 	p.o.Lock()
 	defer p.o.Unlock()
 
@@ -259,7 +259,7 @@ func (p *progressWithStatusBarsTTY) Verbose(s string) {
 	}
 }
 
-func (p *progressWithStatusBarsTTY) Verbosef(format string, args ...interface{}) {
+func (p *progressWithStatusBarsTTY) Verbosef(format string, args ...any) {
 	if p.o.opts.Verbose {
 		p.Writef(format, args...)
 	}
@@ -281,7 +281,7 @@ func (p *progressWithStatusBarsTTY) Write(s string) {
 	p.draw()
 }
 
-func (p *progressWithStatusBarsTTY) Writef(format string, args ...interface{}) {
+func (p *progressWithStatusBarsTTY) Writef(format string, args ...any) {
 	p.o.Lock()
 	defer p.o.Unlock()
 

--- a/lib/output/status_bar.go
+++ b/lib/output/status_bar.go
@@ -10,7 +10,7 @@ type StatusBar struct {
 
 	label  string
 	format string
-	args   []interface{}
+	args   []any
 
 	initialized bool
 	startedAt   time.Time
@@ -18,7 +18,7 @@ type StatusBar struct {
 }
 
 // Completef sets the StatusBar to completed and updates its text.
-func (sb *StatusBar) Completef(format string, args ...interface{}) {
+func (sb *StatusBar) Completef(format string, args ...any) {
 	sb.completed = true
 	sb.format = format
 	sb.args = args
@@ -26,13 +26,13 @@ func (sb *StatusBar) Completef(format string, args ...interface{}) {
 }
 
 // Failf sets the StatusBar to completed and failed and updates its text.
-func (sb *StatusBar) Failf(format string, args ...interface{}) {
+func (sb *StatusBar) Failf(format string, args ...any) {
 	sb.Completef(format, args...)
 	sb.failed = true
 }
 
 // Resetf sets the status of the StatusBar to incomplete and updates its label and text.
-func (sb *StatusBar) Resetf(label, format string, args ...interface{}) {
+func (sb *StatusBar) Resetf(label, format string, args ...any) {
 	sb.initialized = true
 	sb.completed = false
 	sb.failed = false
@@ -44,7 +44,7 @@ func (sb *StatusBar) Resetf(label, format string, args ...interface{}) {
 }
 
 // Updatef updates the StatusBar's text.
-func (sb *StatusBar) Updatef(format string, args ...interface{}) {
+func (sb *StatusBar) Updatef(format string, args ...any) {
 	sb.initialized = true
 	sb.format = format
 	sb.args = args


### PR DESCRIPTION
Now that lib is on go1.18 we can use the type alias "any" instead of "interface{}".

Test Plan: cd lib && go test ./...