### PR TITLE
search: support expressions on zoekt symbol search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Searches containing `or` expressions are now optimized to evaluate natively on the backends that support it ([#34382](https://github.com/sourcegraph/sourcegraph/pull/34382)), and both commit and diff search have been updated to run optimized `and`, `or`, and `not` queries. [#34595](https://github.com/sourcegraph/sourcegraph/pull/34595)
 - Carets in textareas in Firefox are now visible. [#34888](https://github.com/sourcegraph/sourcegraph/pull/34888)
 - Changesets to GitHub code hosts could fail with a confusing, non actionable error message. [#35048](https://github.com/sourcegraph/sourcegraph/pull/35048)
+- An issue causing search expressions to not work in conjunction with `type:symbol`. [#35126](https://github.com/sourcegraph/sourcegraph/pull/35126)
 
 ### Removed
 

--- a/internal/search/zoekt/query_test.go
+++ b/internal/search/zoekt/query_test.go
@@ -128,12 +128,12 @@ func TestQueryToZoektQuery(t *testing.T) {
 }
 
 func Test_toZoektPattern(t *testing.T) {
-	test := func(input string, searchType query.SearchType) string {
+	test := func(input string, searchType query.SearchType, typ search.IndexedRequestType) string {
 		p, err := query.Pipeline(query.Init(input, searchType))
 		if err != nil {
 			return err.Error()
 		}
-		zoektQuery, err := toZoektPattern(p[0].Pattern, false, false, false)
+		zoektQuery, err := toZoektPattern(p[0].Pattern, false, false, false, typ)
 		if err != nil {
 			return err.Error()
 		}
@@ -142,19 +142,23 @@ func Test_toZoektPattern(t *testing.T) {
 
 	autogold.Want("basic string",
 		`substr:"a"`).
-		Equal(t, test(`a`, query.SearchTypeLiteral))
+		Equal(t, test(`a`, query.SearchTypeLiteral, search.TextRequest))
 
 	autogold.Want("basic and-expression",
 		`(or (and substr:"a" substr:"b" (not substr:"c")) substr:"d")`).
-		Equal(t, test(`a and b and not c or d`, query.SearchTypeLiteral))
+		Equal(t, test(`a and b and not c or d`, query.SearchTypeLiteral, search.TextRequest))
 
 	autogold.Want("quoted string in literal escapes quotes (regexp meta and string escaping)",
 		`substr:"\"func main() {\\n\""`).
-		Equal(t, test(`"func main() {\n"`, query.SearchTypeLiteral))
+		Equal(t, test(`"func main() {\n"`, query.SearchTypeLiteral, search.TextRequest))
 
 	autogold.Want("quoted string in regexp interpreted as string (regexp meta escaped)",
 		`substr:"func main() {\n"`).
-		Equal(t, test(`"func main() {\n"`, query.SearchTypeRegex))
+		Equal(t, test(`"func main() {\n"`, query.SearchTypeRegex, search.TextRequest))
+
+	autogold.Want("zoekt symbol nodes are atoms",
+		`(and sym:substr:"foo" (not sym:substr:"bar"))`).
+		Equal(t, test(`type:symbol (foo and not bar)`, query.SearchTypeLiteral, search.SymbolRequest))
 }
 
 func queryEqual(a, b zoekt.Q) bool {


### PR DESCRIPTION
This makes expressions work on symbols in Zoekt, e.g., 

`(foo and bar) type:symbol`

`(foo and not bar) type:symbol`

`(foo or bar) type:symbol`

## Test plan
Added unit tests

