### PR TITLE
permissions: Add basic backoff for permissions syncing.

### DIFF
--- a/enterprise/internal/database/mocks.go
+++ b/enterprise/internal/database/mocks.go
@@ -11324,7 +11324,7 @@ func NewMockPermsStore() *MockPermsStore {
 			},
 		},
 		ReposIDsWithOldestPermsFunc: &PermsStoreReposIDsWithOldestPermsFunc{
-			defaultHook: func(context.Context, int) (r0 map[api.RepoID]time.Time, r1 error) {
+			defaultHook: func(context.Context, int, time.Duration) (r0 map[api.RepoID]time.Time, r1 error) {
 				return
 			},
 		},
@@ -11359,7 +11359,7 @@ func NewMockPermsStore() *MockPermsStore {
 			},
 		},
 		UserIDsWithOldestPermsFunc: &PermsStoreUserIDsWithOldestPermsFunc{
-			defaultHook: func(context.Context, int) (r0 map[int32]time.Time, r1 error) {
+			defaultHook: func(context.Context, int, time.Duration) (r0 map[int32]time.Time, r1 error) {
 				return
 			},
 		},
@@ -11451,7 +11451,7 @@ func NewStrictMockPermsStore() *MockPermsStore {
 			},
 		},
 		ReposIDsWithOldestPermsFunc: &PermsStoreReposIDsWithOldestPermsFunc{
-			defaultHook: func(context.Context, int) (map[api.RepoID]time.Time, error) {
+			defaultHook: func(context.Context, int, time.Duration) (map[api.RepoID]time.Time, error) {
 				panic("unexpected invocation of MockPermsStore.ReposIDsWithOldestPerms")
 			},
 		},
@@ -11486,7 +11486,7 @@ func NewStrictMockPermsStore() *MockPermsStore {
 			},
 		},
 		UserIDsWithOldestPermsFunc: &PermsStoreUserIDsWithOldestPermsFunc{
-			defaultHook: func(context.Context, int) (map[int32]time.Time, error) {
+			defaultHook: func(context.Context, int, time.Duration) (map[int32]time.Time, error) {
 				panic("unexpected invocation of MockPermsStore.UserIDsWithOldestPerms")
 			},
 		},
@@ -12988,24 +12988,24 @@ func (c PermsStoreRepoIDsWithNoPermsFuncCall) Results() []interface{} {
 // ReposIDsWithOldestPerms method of the parent MockPermsStore instance is
 // invoked.
 type PermsStoreReposIDsWithOldestPermsFunc struct {
-	defaultHook func(context.Context, int) (map[api.RepoID]time.Time, error)
-	hooks       []func(context.Context, int) (map[api.RepoID]time.Time, error)
+	defaultHook func(context.Context, int, time.Duration) (map[api.RepoID]time.Time, error)
+	hooks       []func(context.Context, int, time.Duration) (map[api.RepoID]time.Time, error)
 	history     []PermsStoreReposIDsWithOldestPermsFuncCall
 	mutex       sync.Mutex
 }
 
 // ReposIDsWithOldestPerms delegates to the next hook function in the queue
 // and stores the parameter and result values of this invocation.
-func (m *MockPermsStore) ReposIDsWithOldestPerms(v0 context.Context, v1 int) (map[api.RepoID]time.Time, error) {
-	r0, r1 := m.ReposIDsWithOldestPermsFunc.nextHook()(v0, v1)
-	m.ReposIDsWithOldestPermsFunc.appendCall(PermsStoreReposIDsWithOldestPermsFuncCall{v0, v1, r0, r1})
+func (m *MockPermsStore) ReposIDsWithOldestPerms(v0 context.Context, v1 int, v2 time.Duration) (map[api.RepoID]time.Time, error) {
+	r0, r1 := m.ReposIDsWithOldestPermsFunc.nextHook()(v0, v1, v2)
+	m.ReposIDsWithOldestPermsFunc.appendCall(PermsStoreReposIDsWithOldestPermsFuncCall{v0, v1, v2, r0, r1})
 	return r0, r1
 }
 
 // SetDefaultHook sets function that is called when the
 // ReposIDsWithOldestPerms method of the parent MockPermsStore instance is
 // invoked and the hook queue is empty.
-func (f *PermsStoreReposIDsWithOldestPermsFunc) SetDefaultHook(hook func(context.Context, int) (map[api.RepoID]time.Time, error)) {
+func (f *PermsStoreReposIDsWithOldestPermsFunc) SetDefaultHook(hook func(context.Context, int, time.Duration) (map[api.RepoID]time.Time, error)) {
 	f.defaultHook = hook
 }
 
@@ -13014,7 +13014,7 @@ func (f *PermsStoreReposIDsWithOldestPermsFunc) SetDefaultHook(hook func(context
 // invokes the hook at the front of the queue and discards it. After the
 // queue is empty, the default hook function is invoked for any future
 // action.
-func (f *PermsStoreReposIDsWithOldestPermsFunc) PushHook(hook func(context.Context, int) (map[api.RepoID]time.Time, error)) {
+func (f *PermsStoreReposIDsWithOldestPermsFunc) PushHook(hook func(context.Context, int, time.Duration) (map[api.RepoID]time.Time, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -13023,19 +13023,19 @@ func (f *PermsStoreReposIDsWithOldestPermsFunc) PushHook(hook func(context.Conte
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
 func (f *PermsStoreReposIDsWithOldestPermsFunc) SetDefaultReturn(r0 map[api.RepoID]time.Time, r1 error) {
-	f.SetDefaultHook(func(context.Context, int) (map[api.RepoID]time.Time, error) {
+	f.SetDefaultHook(func(context.Context, int, time.Duration) (map[api.RepoID]time.Time, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
 func (f *PermsStoreReposIDsWithOldestPermsFunc) PushReturn(r0 map[api.RepoID]time.Time, r1 error) {
-	f.PushHook(func(context.Context, int) (map[api.RepoID]time.Time, error) {
+	f.PushHook(func(context.Context, int, time.Duration) (map[api.RepoID]time.Time, error) {
 		return r0, r1
 	})
 }
 
-func (f *PermsStoreReposIDsWithOldestPermsFunc) nextHook() func(context.Context, int) (map[api.RepoID]time.Time, error) {
+func (f *PermsStoreReposIDsWithOldestPermsFunc) nextHook() func(context.Context, int, time.Duration) (map[api.RepoID]time.Time, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -13075,6 +13075,9 @@ type PermsStoreReposIDsWithOldestPermsFuncCall struct {
 	// Arg1 is the value of the 2nd argument passed to this method
 	// invocation.
 	Arg1 int
+	// Arg2 is the value of the 3rd argument passed to this method
+	// invocation.
+	Arg2 time.Duration
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 map[api.RepoID]time.Time
@@ -13086,7 +13089,7 @@ type PermsStoreReposIDsWithOldestPermsFuncCall struct {
 // Args returns an interface slice containing the arguments of this
 // invocation.
 func (c PermsStoreReposIDsWithOldestPermsFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
 }
 
 // Results returns an interface slice containing the results of this
@@ -13740,24 +13743,24 @@ func (c PermsStoreUserIDsWithNoPermsFuncCall) Results() []interface{} {
 // UserIDsWithOldestPerms method of the parent MockPermsStore instance is
 // invoked.
 type PermsStoreUserIDsWithOldestPermsFunc struct {
-	defaultHook func(context.Context, int) (map[int32]time.Time, error)
-	hooks       []func(context.Context, int) (map[int32]time.Time, error)
+	defaultHook func(context.Context, int, time.Duration) (map[int32]time.Time, error)
+	hooks       []func(context.Context, int, time.Duration) (map[int32]time.Time, error)
 	history     []PermsStoreUserIDsWithOldestPermsFuncCall
 	mutex       sync.Mutex
 }
 
 // UserIDsWithOldestPerms delegates to the next hook function in the queue
 // and stores the parameter and result values of this invocation.
-func (m *MockPermsStore) UserIDsWithOldestPerms(v0 context.Context, v1 int) (map[int32]time.Time, error) {
-	r0, r1 := m.UserIDsWithOldestPermsFunc.nextHook()(v0, v1)
-	m.UserIDsWithOldestPermsFunc.appendCall(PermsStoreUserIDsWithOldestPermsFuncCall{v0, v1, r0, r1})
+func (m *MockPermsStore) UserIDsWithOldestPerms(v0 context.Context, v1 int, v2 time.Duration) (map[int32]time.Time, error) {
+	r0, r1 := m.UserIDsWithOldestPermsFunc.nextHook()(v0, v1, v2)
+	m.UserIDsWithOldestPermsFunc.appendCall(PermsStoreUserIDsWithOldestPermsFuncCall{v0, v1, v2, r0, r1})
 	return r0, r1
 }
 
 // SetDefaultHook sets function that is called when the
 // UserIDsWithOldestPerms method of the parent MockPermsStore instance is
 // invoked and the hook queue is empty.
-func (f *PermsStoreUserIDsWithOldestPermsFunc) SetDefaultHook(hook func(context.Context, int) (map[int32]time.Time, error)) {
+func (f *PermsStoreUserIDsWithOldestPermsFunc) SetDefaultHook(hook func(context.Context, int, time.Duration) (map[int32]time.Time, error)) {
 	f.defaultHook = hook
 }
 
@@ -13766,7 +13769,7 @@ func (f *PermsStoreUserIDsWithOldestPermsFunc) SetDefaultHook(hook func(context.
 // invokes the hook at the front of the queue and discards it. After the
 // queue is empty, the default hook function is invoked for any future
 // action.
-func (f *PermsStoreUserIDsWithOldestPermsFunc) PushHook(hook func(context.Context, int) (map[int32]time.Time, error)) {
+func (f *PermsStoreUserIDsWithOldestPermsFunc) PushHook(hook func(context.Context, int, time.Duration) (map[int32]time.Time, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -13775,19 +13778,19 @@ func (f *PermsStoreUserIDsWithOldestPermsFunc) PushHook(hook func(context.Contex
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
 func (f *PermsStoreUserIDsWithOldestPermsFunc) SetDefaultReturn(r0 map[int32]time.Time, r1 error) {
-	f.SetDefaultHook(func(context.Context, int) (map[int32]time.Time, error) {
+	f.SetDefaultHook(func(context.Context, int, time.Duration) (map[int32]time.Time, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
 func (f *PermsStoreUserIDsWithOldestPermsFunc) PushReturn(r0 map[int32]time.Time, r1 error) {
-	f.PushHook(func(context.Context, int) (map[int32]time.Time, error) {
+	f.PushHook(func(context.Context, int, time.Duration) (map[int32]time.Time, error) {
 		return r0, r1
 	})
 }
 
-func (f *PermsStoreUserIDsWithOldestPermsFunc) nextHook() func(context.Context, int) (map[int32]time.Time, error) {
+func (f *PermsStoreUserIDsWithOldestPermsFunc) nextHook() func(context.Context, int, time.Duration) (map[int32]time.Time, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -13827,6 +13830,9 @@ type PermsStoreUserIDsWithOldestPermsFuncCall struct {
 	// Arg1 is the value of the 2nd argument passed to this method
 	// invocation.
 	Arg1 int
+	// Arg2 is the value of the 3rd argument passed to this method
+	// invocation.
+	Arg2 time.Duration
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 map[int32]time.Time
@@ -13838,7 +13844,7 @@ type PermsStoreUserIDsWithOldestPermsFuncCall struct {
 // Args returns an interface slice containing the arguments of this
 // invocation.
 func (c PermsStoreUserIDsWithOldestPermsFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
 }
 
 // Results returns an interface slice containing the results of this

--- a/enterprise/internal/database/perms_store.go
+++ b/enterprise/internal/database/perms_store.go
@@ -1616,7 +1616,7 @@ func (s *permsStore) ReposIDsWithOldestPerms(ctx context.Context, limit int, age
 	cutoffClause := sqlf.Sprintf("TRUE")
 	if age > 0 {
 		cutoff := s.clock().Add(-1 * age)
-		cutoffClause = sqlf.Sprintf("(perms.synced_at IS NULL OR (perms.synced_at IS NOT NULL AND perms.synced_at < %s))", cutoff)
+		cutoffClause = sqlf.Sprintf("(perms.synced_at IS NULL OR perms.synced_at < %s)", cutoff)
 	}
 	q := sqlf.Sprintf(`
 -- source: enterprise/internal/database/perms_store.go:PermsStore.ReposIDsWithOldestPerms

--- a/enterprise/internal/database/perms_store.go
+++ b/enterprise/internal/database/perms_store.go
@@ -1597,7 +1597,7 @@ func (s *permsStore) UserIDsWithOldestPerms(ctx context.Context, limit int, age 
 	cutoffClause := sqlf.Sprintf("TRUE")
 	if age > 0 {
 		cutoff := s.clock().Add(-1 * age)
-		cutoffClause = sqlf.Sprintf("(perms.synced_at IS NULL OR (perms.synced_at IS NOT NULL AND perms.synced_at < %s))", cutoff)
+		cutoffClause = sqlf.Sprintf("(perms.synced_at IS NULL OR perms.synced_at < %s)", cutoff)
 	}
 	q := sqlf.Sprintf(`
 -- source: enterprise/internal/database/perms_store.go:PermsStore.UserIDsWithOldestPerms

--- a/enterprise/internal/database/perms_store.go
+++ b/enterprise/internal/database/perms_store.go
@@ -168,12 +168,14 @@ type PermsStore interface {
 	RepoIDsWithNoPerms(ctx context.Context) ([]api.RepoID, error)
 	// UserIDsWithOldestPerms returns a list of user ID and last updated pairs for
 	// users who have the least recent synced permissions in the database and capped
-	// results by the limit.
-	UserIDsWithOldestPerms(ctx context.Context, limit int) (map[int32]time.Time, error)
+	// results by the limit. If a user's permissions have been recently synced, based
+	// on "age" they are ignored.
+	UserIDsWithOldestPerms(ctx context.Context, limit int, age time.Duration) (map[int32]time.Time, error)
 	// ReposIDsWithOldestPerms returns a list of repository ID and last updated pairs
 	// for repositories that have the least recent synced permissions in the database
-	// and caps results by the limit.
-	ReposIDsWithOldestPerms(ctx context.Context, limit int) (map[api.RepoID]time.Time, error)
+	// and caps results by the limit. If a repo's permissions have been recently
+	// synced, based on "age" they are ignored.
+	ReposIDsWithOldestPerms(ctx context.Context, limit int, age time.Duration) (map[api.RepoID]time.Time, error)
 	// UserIsMemberOfOrgHasCodeHostConnection returns true if the user is a member of
 	// any organization that has added code host connection.
 	UserIsMemberOfOrgHasCodeHostConnection(ctx context.Context, userID int32) (has bool, err error)
@@ -1588,29 +1590,44 @@ AND repo.id NOT IN
 	return ids, nil
 }
 
-func (s *permsStore) UserIDsWithOldestPerms(ctx context.Context, limit int) (map[int32]time.Time, error) {
+// UserIDsWithOldestPerms lists the users with the oldest synced perms, limited
+// to limit. If age is non-zero, users that have synced within "age" since now
+// will be filtered out.
+func (s *permsStore) UserIDsWithOldestPerms(ctx context.Context, limit int, age time.Duration) (map[int32]time.Time, error) {
+	cutoffClause := sqlf.Sprintf("TRUE")
+	if age > 0 {
+		cutoff := s.clock().Add(-1 * age)
+		cutoffClause = sqlf.Sprintf("(perms.synced_at IS NULL OR (perms.synced_at IS NOT NULL AND perms.synced_at < %s))", cutoff)
+	}
 	q := sqlf.Sprintf(`
 -- source: enterprise/internal/database/perms_store.go:PermsStore.UserIDsWithOldestPerms
 SELECT perms.user_id, perms.synced_at FROM user_permissions AS perms
 WHERE perms.user_id IN
 	(SELECT users.id FROM users
 	 WHERE users.deleted_at IS NULL)
+AND %s
 ORDER BY perms.synced_at ASC NULLS FIRST
 LIMIT %s
-`, limit)
+`, cutoffClause, limit)
 	return s.loadIDsWithTime(ctx, q)
 }
 
-func (s *permsStore) ReposIDsWithOldestPerms(ctx context.Context, limit int) (map[api.RepoID]time.Time, error) {
+func (s *permsStore) ReposIDsWithOldestPerms(ctx context.Context, limit int, age time.Duration) (map[api.RepoID]time.Time, error) {
+	cutoffClause := sqlf.Sprintf("TRUE")
+	if age > 0 {
+		cutoff := s.clock().Add(-1 * age)
+		cutoffClause = sqlf.Sprintf("(perms.synced_at IS NULL OR (perms.synced_at IS NOT NULL AND perms.synced_at < %s))", cutoff)
+	}
 	q := sqlf.Sprintf(`
 -- source: enterprise/internal/database/perms_store.go:PermsStore.ReposIDsWithOldestPerms
 SELECT perms.repo_id, perms.synced_at FROM repo_permissions AS perms
 WHERE perms.repo_id IN
 	(SELECT repo.id FROM repo
 	 WHERE repo.deleted_at IS NULL)
+AND %s
 ORDER BY perms.synced_at ASC NULLS FIRST
 LIMIT %s
-`, limit)
+`, cutoffClause, limit)
 
 	pairs, err := s.loadIDsWithTime(ctx, q)
 	if err != nil {

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1923,8 +1923,12 @@ type SiteConfiguration struct {
 	PermissionsSyncOldestRepos int `json:"permissions.syncOldestRepos,omitempty"`
 	// PermissionsSyncOldestUsers description: Number of user permissions to schedule for syncing in single scheduler iteration
 	PermissionsSyncOldestUsers int `json:"permissions.syncOldestUsers,omitempty"`
+	// PermissionsSyncReposBackoffSeconds description: Don't sync a repo's permissions if it has synced within the last n seconds
+	PermissionsSyncReposBackoffSeconds int `json:"permissions.syncReposBackoffSeconds,omitempty"`
 	// PermissionsSyncScheduleInterval description: Time interval (in seconds) of how often each component picks up authorization changes in external services.
 	PermissionsSyncScheduleInterval int `json:"permissions.syncScheduleInterval,omitempty"`
+	// PermissionsSyncUsersBackoffSeconds description: Don't sync a user's permissions if they have synced within the last n seconds
+	PermissionsSyncUsersBackoffSeconds int `json:"permissions.syncUsersBackoffSeconds,omitempty"`
 	// PermissionsUserMapping description: Settings for Sourcegraph permissions, which allow the site admin to explicitly manage repository permissions via the GraphQL API. This setting cannot be enabled if repository permissions for any specific external service are enabled (i.e., when the external service's `authorization` field is set).
 	PermissionsUserMapping *PermissionsUserMapping `json:"permissions.userMapping,omitempty"`
 	// ProductResearchPageEnabled description: Enables users access to the product research page in their settings.

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -888,6 +888,16 @@
       "type": "integer",
       "default": 10
     },
+    "permissions.syncUsersBackoffSeconds": {
+      "description": "Don't sync a user's permissions if they have synced within the last n seconds",
+      "type": "integer",
+      "default": 60
+    },
+    "permissions.syncReposBackoffSeconds": {
+      "description": "Don't sync a repo's permissions if it has synced within the last n seconds",
+      "type": "integer",
+      "default": 60
+    },
     "branding": {
       "description": "Customize Sourcegraph homepage logo and search icon.\n\nOnly available in Sourcegraph Enterprise.",
       "type": "object",


### PR DESCRIPTION
The backoff period for repo and user permissions syncing is configurable
using the `permissions.syncUsersBackoffSeconds` and
`permissions.syncReposBackoffSeconds` config values.

When set, we will not schedule users or repos for permissions syncing
based on their last sync time if they have synced recently, based on the
backoff value.

## Test plan

Unit tests updated