### PR TITLE
lib/log: only log err.Error() for error fields

### DIFF
--- a/internal/observation/fields.go
+++ b/internal/observation/fields.go
@@ -10,8 +10,15 @@ import (
 func toLogFields(otFields []otlog.Field) []log.Field {
 	fields := make([]log.Field, len(otFields))
 	for i, field := range otFields {
-		// Allow usage of zap.Any here for ease of interop.
-		fields[i] = zap.Any(field.Key(), field.Value())
+		switch value := field.Value().(type) {
+		case error:
+			// Special handling for errors, since we have a custom error field implementation
+			fields[i] = log.NamedError(field.Key(), value)
+
+		default:
+			// Allow usage of zap.Any here for ease of interop.
+			fields[i] = zap.Any(field.Key(), value)
+		}
 	}
 	return fields
 }

--- a/internal/observation/observation.go
+++ b/internal/observation/observation.go
@@ -11,7 +11,6 @@ import (
 
 	otlog "github.com/opentracing/opentracing-go/log"
 	"github.com/prometheus/client_golang/prometheus"
-	"go.uber.org/zap"
 
 	"github.com/sourcegraph/sourcegraph/internal/honey"
 	"github.com/sourcegraph/sourcegraph/internal/hostname"
@@ -361,11 +360,11 @@ func (op *Operation) emitErrorLogs(trLogger TraceLogger, err *error, logFields [
 	if err == nil || *err == nil {
 		return
 	}
-	fields := append(toLogFields(logFields), zap.Error(*err))
+	fields := append(toLogFields(logFields), log.Error(*err))
 
 	trLogger.
 		AddCallerSkip(2). // callback() -> emitErrorLogs() -> Logger
-		Error(op.name, fields...)
+		Error("operation.error", fields...)
 }
 
 func (op *Operation) emitHoneyEvent(err *error, opName string, event honey.Event, logFields []otlog.Field, duration int64) {

--- a/lib/log/fields.go
+++ b/lib/log/fields.go
@@ -41,16 +41,6 @@ var (
 	// time is serialized.
 	Time = zap.Time
 
-	// Error is shorthand for the common idiom NamedError("error", err).
-	Error = zap.Error
-	// NamedError constructs a field that lazily stores err.Error() under the provided key.
-	// Errors which also implement fmt.Formatter (like those produced by github.com/pkg/errors)
-	// will also have their verbose representation stored under key+"Verbose". If passed a
-	// nil error, the field is a no-op.
-	//
-	// For the common case in which the key is simply "error", the Error function is shorter and less repetitive.
-	NamedError = zap.NamedError
-
 	// Namespace creates a named, isolated scope within the logger's context. All subsequent
 	// fields will be added to the new namespace.
 	//
@@ -63,4 +53,19 @@ var (
 // namespace.
 func Object(key string, fields ...Field) Field {
 	return zap.Object(key, encoders.FieldsObjectEncoder(fields))
+}
+
+// Error is shorthand for the common idiom NamedError("error", err).
+func Error(err error) Field {
+	return NamedError("error", err)
+}
+
+// NamedError constructs a field that logs err.Error() under the provided key.
+//
+// For the common case in which the key is simply "error", the Error function is shorter and less repetitive.
+//
+// This is currently intentionally different from the zap.NamedError implementation since
+// we don't want the additional verbosity at the moment.
+func NamedError(key string, err error) Field {
+	return String(key, err.Error())
 }


### PR DESCRIPTION
`zap.NamedError` dives deep into an error to get additional information out, [e.g. getting `Errors() []error` and applying `fmt.Stringer`](https://sourcegraph.com/github.com/uber-go/zap/-/blob/zapcore/error.go?L66-77&utm_campaign=search&utm_source=raycast-sourcegraph). In `lib/error` a core assumption is that `.Error()` should provide most important information, so for now we replace the underlying implementation that simply logs a string so that we don't get [very noisy output](https://github.com/sourcegraph/sourcegraph/pull/35105#issuecomment-1120849947)

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

<img width="1270" alt="image" src="https://user-images.githubusercontent.com/23356519/167459680-71bfd497-5578-4919-b745-db9d9558b827.png">

