### PR TITLE
lib/log: do not include OTel 'Attributes' namespace in dev

### DIFF
--- a/lib/log/logger.go
+++ b/lib/log/logger.go
@@ -72,6 +72,11 @@ func Scoped(scope string, description string) Logger {
 	safeGet := !development // do not panic in prod
 	adapted := &zapAdapter{Logger: globallogger.Get(safeGet), fromPackageScoped: true}
 
+	if development {
+		// In development, don't add the OpenTelemetry "Attributes" namespace which gets
+		// rather difficult to read.
+		return adapted.Scoped(scope, description)
+	}
 	return adapted.Scoped(scope, description).With(otfields.AttributesNamespace)
 }
 


### PR DESCRIPTION
The `Attributes` namespace is added to comply with OpenTelemetry's log data format - this is [rather noisy in dev](https://github.com/sourcegraph/sourcegraph/pull/35105#issuecomment-1120849947), and we already omit other OTel fields (`Resource`) based on `SRC_DEVELOPMENT`, so we continue that trend here

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

<img width="1248" alt="image" src="https://user-images.githubusercontent.com/23356519/167461301-f2c77147-6f2a-4c8b-8848-3d68715ccce7.png">

(above test output includes https://github.com/sourcegraph/sourcegraph/pull/35131)