### PR TITLE
sg: Install GNU find on macOS.

### DIFF
--- a/dev/generate.sh
+++ b/dev/generate.sh
@@ -7,6 +7,10 @@ cd "$(dirname "${BASH_SOURCE[0]}")/.." # cd to repo root dir
 # relatively high cost of fetching and building src-cli.
 go list ./... | grep -v 'doc/cli/references' | xargs go generate -x
 
+FIND="find"
+if [ "$(uname)" = "Darwin" ]; then
+    FIND="gfind"
+fi
 # Ignore the submodules in docker-images syntax-highlighter.
 #
 # Disable shellcheck for this line because we actually want them to be space separated
@@ -15,7 +19,7 @@ go list ./... | grep -v 'doc/cli/references' | xargs go generate -x
 # shellcheck disable=SC2046
 GOBIN="$PWD/.bin" go install golang.org/x/tools/cmd/goimports && \
     ./.bin/goimports -w $(
-        comm -12 <(git ls-files | sort) <(find . -type f -name '*.go' -printf "%P\n" | sort)
+        comm -12 <(git ls-files | sort) <("$FIND" . -type f -name '*.go' -printf "%P\n" | sort)
     )
 
 go mod tidy

--- a/dev/sg/sg_setup_mac.go
+++ b/dev/sg/sg_setup_mac.go
@@ -28,6 +28,7 @@ var macOSDependencies = []dependencyCategory{
 		dependencies: []*dependency{
 			{name: "git", check: getCheck("git"), instructionsCommands: `brew install git`},
 			{name: "gnu-sed", check: check.InPath("gsed"), instructionsCommands: "brew install gnu-sed"},
+			{name: "findutils", check: check.InPath("gfind"), instructionsCommands: "brew install findutils"},
 			{name: "comby", check: check.InPath("comby"), instructionsCommands: "brew install comby"},
 			{name: "pcre", check: check.InPath("pcregrep"), instructionsCommands: `brew install pcre`},
 			{name: "sqlite", check: check.InPath("sqlite3"), instructionsCommands: `brew install sqlite`},


### PR DESCRIPTION
At the moment, this is needed by the ./dev/generated.sh script,
since it uses GNU find's printf flag which is not supported
by BSD find.

## Test plan

Manually tested that it works. Still need to fix the script which uses `find` though.

Before:
![before picture showing findutils being missing](https://user-images.githubusercontent.com/93103176/167501467-43e44041-b1fe-4b1e-9633-b6ada934c173.png)

After `sg` magic:
![after picture showing GNU find being installed](https://user-images.githubusercontent.com/93103176/167501547-6c2af7e6-51c4-4156-84ec-153db1c94e38.png)
