### PR TITLE
Debug apollo fetch more issues

### DIFF
--- a/client/http-client/src/graphql/apollo/cache.ts
+++ b/client/http-client/src/graphql/apollo/cache.ts
@@ -1,4 +1,5 @@
 import { InMemoryCache } from '@apollo/client'
+import { relayStylePagination } from '@apollo/client/utilities'
 
 import { TypedTypePolicies } from '@sourcegraph/shared/src/graphql-operations'
 import { IExtensionRegistry, IPerson } from '@sourcegraph/shared/src/schema'
@@ -18,6 +19,11 @@ const typePolicies: TypedTypePolicies = {
         // Required because of the missing `id` on the `Person` field.
         merge(existing: IPerson, incoming: IPerson): IPerson {
             return incoming
+        },
+    },
+    BatchSpecWorkspaceResolution: {
+        fields: {
+            workspaces: relayStylePagination(),
         },
     },
     Query: {

--- a/client/web/src/enterprise/batches/create/backend.ts
+++ b/client/web/src/enterprise/batches/create/backend.ts
@@ -101,6 +101,8 @@ export const WORKSPACE_RESOLUTION_STATUS = gql`
             __typename
             ... on BatchSpec {
                 workspaceResolution {
+                    __typename
+                    id
                     state
                     failureMessage
                 }
@@ -116,6 +118,7 @@ export const WORKSPACES = gql`
             ... on BatchSpec {
                 workspaceResolution {
                     __typename
+                    id
                     workspaces(first: $first, after: $after, search: $search) {
                         __typename
                         totalCount

--- a/client/web/src/enterprise/batches/execution/backend.ts
+++ b/client/web/src/enterprise/batches/execution/backend.ts
@@ -194,6 +194,7 @@ const batchSpecExecutionFieldsFragment = gql`
         }
         viewerCanRetry
         workspaceResolution {
+            id
             workspaces {
                 stats {
                     errored
@@ -369,6 +370,7 @@ const BATCH_SPEC_WORKSPACES = gql`
             ... on BatchSpec {
                 id
                 workspaceResolution {
+                    id
                     workspaces(first: $first, after: $after, search: $search, state: $state) {
                         ...BatchSpecWorkspacesConnectionFields
                     }
@@ -448,9 +450,8 @@ export const useWorkspacesListConnection = (
         },
         options: {
             useURL: true,
-            // For some reason caching caused flickering here. Will need to investigate
-            // further why.
-            fetchPolicy: 'no-cache',
+            fetchPolicy: 'network-only',
+            // fetchPolicy: 'cache-and-network',
             pollInterval: 1000,
         },
         getConnection: result => {

--- a/cmd/frontend/graphqlbackend/batches.go
+++ b/cmd/frontend/graphqlbackend/batches.go
@@ -765,6 +765,7 @@ type ChangesetCountsResolver interface {
 }
 
 type BatchSpecWorkspaceResolutionResolver interface {
+	ID() graphql.ID
 	State() string
 	StartedAt() *DateTime
 	FinishedAt() *DateTime

--- a/cmd/frontend/graphqlbackend/batches.graphql
+++ b/cmd/frontend/graphqlbackend/batches.graphql
@@ -1888,7 +1888,12 @@ enum WorkspacesSortOrder {
 """
 A bag for all info around resolving workspaces.
 """
-type BatchSpecWorkspaceResolution {
+type BatchSpecWorkspaceResolution implements Node {
+    """
+    An ID for apollo, but doesn't implement node. This can not be queried individually.
+    """
+    id: ID!
+
     """
     Error message, if the evaluation failed.
     """

--- a/cmd/frontend/graphqlbackend/node.go
+++ b/cmd/frontend/graphqlbackend/node.go
@@ -278,3 +278,8 @@ func (r *NodeResolver) ToExecutor() (*executor.ExecutorResolver, bool) {
 	n, ok := r.Node.(*executor.ExecutorResolver)
 	return n, ok
 }
+
+func (r *NodeResolver) ToBatchSpecWorkspaceResolution() (BatchSpecWorkspaceResolutionResolver, bool) {
+	n, ok := r.Node.(BatchSpecWorkspaceResolutionResolver)
+	return n, ok
+}

--- a/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec_workspace_resolution.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec_workspace_resolution.go
@@ -5,6 +5,9 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/graph-gophers/graphql-go"
+	"github.com/graph-gophers/graphql-go/relay"
+
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/search"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/store"
@@ -18,6 +21,10 @@ type batchSpecWorkspaceResolutionResolver struct {
 }
 
 var _ graphqlbackend.BatchSpecWorkspaceResolutionResolver = &batchSpecWorkspaceResolutionResolver{}
+
+func (r *batchSpecWorkspaceResolutionResolver) ID() graphql.ID {
+	return relay.MarshalID("BatchSpecWorkspaceResolution", r.resolution.ID)
+}
 
 func (r *batchSpecWorkspaceResolutionResolver) State() string {
 	return r.resolution.State.ToGraphQL()

--- a/enterprise/cmd/frontend/internal/batches/resolvers/resolver.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/resolver.go
@@ -125,6 +125,9 @@ func (r *Resolver) NodeResolvers() map[string]graphqlbackend.NodeByIDFunc {
 		batchSpecWorkspaceIDKind: func(ctx context.Context, id graphql.ID) (graphqlbackend.Node, error) {
 			return r.batchSpecWorkspaceByID(ctx, id)
 		},
+		"BatchSpecWorkspaceResolution": func(ctx context.Context, id graphql.ID) (graphqlbackend.Node, error) {
+			return nil, nil
+		},
 	}
 }
 


### PR DESCRIPTION
Observations:

Monitoring the networkStatus, we get
`refetch`
and
`ready`
all the time for the refetches. This is alright, as we do polling on this list.
*

Then, when we hit `fetchMore`, while it's refetching, we get the following:

```
networkStatus refetch
networkStatus ready
networkStatus ready
networkStatus ready
```
.. So for some reason the ready event is emitted thrice. This caused the flickering we saw before.
When we don't `notifyOnNetworkStatusChange`, the flickering is entirely gone.

When the flag is ON, we see the following:

```
networkStatus refetch
networkStatus fetchMore # additional
networkStatus refetch # additional
networkStatus ready
networkStatus ready
networkStatus ready
networkStatus setVariables # from here on more state changes
networkStatus refetch # probably from polling
networkStatus ready
networkStatus setVariables # why this 3 more times?
networkStatus setVariables
networkStatus setVariables
networkStatus ready # after this, no more flickering and the regular refetch -> ready loop starts again
```

---

When switching from no-cache to network-only, apollo starts logging a warning about the fact that the workspace resolution has no ID.
I went ahead adding that, and the warning went away. I don't really want to expose an ID on it, but I guess I have to?

---

Using `no-cache` logs an error in our useConnection hook. Using the debugger, it seems that the previousResult is lacking fields. When no-cache is on,
the previous result would never be written to the cache.. so why is this function ever called with something?

---

When using `network-only` with the same debug halting point as above, the list does NOT properly update. When the debugger is off, it works.
Is there a race condition?

---

The `notifyOnNetworkStatusChange` according to apollo docs is REQUIRED for the loading state to be correct ..
First, why is that, that is very counterintuitive
Second, when it's on WAY more events are emitted though and some of them seem useless for what we want to achieve.
3x setVariables in a row? But AFTER the refetch has finished?

---

*
.. Actually, the docs say it should be `poll` -> `ready`, not `refetch` -> `ready`
OKAY, seems like we run refetch on an interval, instead of actual apollo polling.
That is, because we want to refresh ALL pages.
Could there be some race condition here?
I just added a condition that we don't refetch when some other request is currently ongoing, and that reduced the flicker by a bit
Now we have only one weird `setVariables` call left.
.. when `notifyOnNetworkStatusChange` is set to false, we have no more weird state refreshes.
.. according to the docs, `notifyOnNetworkStatusChange` only returns the networkState but shouldn't alter `loading`? So is it unnecessary here?

---

Now for the first time since starting this debugging endeavor, I got a warning message that updateQuery is deprecated.



## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


