### PR TITLE
monitoring: rename container to dashboard

### DIFF
--- a/monitoring/definitions/codeintel_autoindexing.go
+++ b/monitoring/definitions/codeintel_autoindexing.go
@@ -5,8 +5,8 @@ import (
 	"github.com/sourcegraph/sourcegraph/monitoring/monitoring"
 )
 
-func CodeIntelAutoIndexing() *monitoring.Container {
-	return &monitoring.Container{
+func CodeIntelAutoIndexing() *monitoring.Dashboard {
+	return &monitoring.Dashboard{
 		Name:        "codeintel-autoindexing",
 		Title:       "Code Intelligence > Autoindexing",
 		Description: "The service at `internal/codeintel/autoindexing`.",

--- a/monitoring/definitions/codeintel_policies.go
+++ b/monitoring/definitions/codeintel_policies.go
@@ -5,8 +5,8 @@ import (
 	"github.com/sourcegraph/sourcegraph/monitoring/monitoring"
 )
 
-func CodeIntelPolicies() *monitoring.Container {
-	return &monitoring.Container{
+func CodeIntelPolicies() *monitoring.Dashboard {
+	return &monitoring.Dashboard{
 		Name:        "codeintel-policies",
 		Title:       "Code Intelligence > Policies",
 		Description: "The service at `internal/codeintel/policies`.",

--- a/monitoring/definitions/codeintel_uploads.go
+++ b/monitoring/definitions/codeintel_uploads.go
@@ -5,8 +5,8 @@ import (
 	"github.com/sourcegraph/sourcegraph/monitoring/monitoring"
 )
 
-func CodeIntelUploads() *monitoring.Container {
-	return &monitoring.Container{
+func CodeIntelUploads() *monitoring.Dashboard {
+	return &monitoring.Dashboard{
 		Name:        "codeintel-uploads",
 		Title:       "Code Intelligence > Uploads",
 		Description: "The service at `internal/codeintel/uploads`.",

--- a/monitoring/definitions/containers.go
+++ b/monitoring/definitions/containers.go
@@ -7,7 +7,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/monitoring/monitoring"
 )
 
-func Containers() *monitoring.Container {
+func Containers() *monitoring.Dashboard {
 	var (
 		// HACK:
 		// Image names are defined in enterprise package
@@ -26,7 +26,7 @@ func Containers() *monitoring.Container {
 		containerNameQuery = shared.CadvisorContainerNameMatcher("(frontend|sourcegraph-frontend|gitserver|github-proxy|pgsql|codeintel-db|codeinsights|precise-code-intel-worker|prometheus|redis-cache|redis-store|redis-exporter|repo-updater|searcher|symbols|syntect-server|worker|zoekt-indexserver|zoekt-webserver|indexed-search|grafana|minio|jaeger)")
 	)
 
-	return &monitoring.Container{
+	return &monitoring.Dashboard{
 		Name:                     "containers",
 		Title:                    "Global Containers Resource Usage",
 		Description:              "Container usage and provisioning indicators of all services.",

--- a/monitoring/definitions/executor.go
+++ b/monitoring/definitions/executor.go
@@ -5,13 +5,13 @@ import (
 	"github.com/sourcegraph/sourcegraph/monitoring/monitoring"
 )
 
-func Executor() *monitoring.Container {
+func Executor() *monitoring.Dashboard {
 	const containerName = "(executor|sourcegraph-code-intel-indexers|executor-batches|sourcegraph-executors)"
 
 	// frontend is sometimes called sourcegraph-frontend in various contexts
 	const queueContainerName = "(executor|sourcegraph-code-intel-indexers|executor-batches|frontend|sourcegraph-frontend|worker|sourcegraph-executors)"
 
-	return &monitoring.Container{
+	return &monitoring.Dashboard{
 		Name:        "executor",
 		Title:       "Executor",
 		Description: `Executes jobs in an isolated environment.`,

--- a/monitoring/definitions/frontend.go
+++ b/monitoring/definitions/frontend.go
@@ -9,7 +9,7 @@ import (
 	"github.com/grafana-tools/sdk"
 )
 
-func Frontend() *monitoring.Container {
+func Frontend() *monitoring.Dashboard {
 	// frontend is sometimes called sourcegraph-frontend in various contexts
 	const containerName = "(frontend|sourcegraph-frontend)"
 
@@ -37,7 +37,7 @@ func Frontend() *monitoring.Container {
 		{"org_repositories", "OrgRepositories", "API requests to list repositories owned by an org"},
 	}
 
-	return &monitoring.Container{
+	return &monitoring.Dashboard{
 		Name:        "frontend",
 		Title:       "Frontend",
 		Description: "Serves all end-user browser and API requests.",

--- a/monitoring/definitions/git_server.go
+++ b/monitoring/definitions/git_server.go
@@ -7,7 +7,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/monitoring/monitoring"
 )
 
-func GitServer() *monitoring.Container {
+func GitServer() *monitoring.Dashboard {
 	const containerName = "gitserver"
 
 	gitserverHighMemoryNoAlertTransformer := func(observable shared.Observable) shared.Observable {
@@ -19,7 +19,7 @@ func GitServer() *monitoring.Container {
 		ShortTermMemoryUsage: gitserverHighMemoryNoAlertTransformer,
 	}
 
-	return &monitoring.Container{
+	return &monitoring.Dashboard{
 		Name:        "gitserver",
 		Title:       "Git Server",
 		Description: "Stores, manages, and operates Git repositories.",

--- a/monitoring/definitions/github_proxy.go
+++ b/monitoring/definitions/github_proxy.go
@@ -7,10 +7,10 @@ import (
 	"github.com/sourcegraph/sourcegraph/monitoring/monitoring"
 )
 
-func GitHubProxy() *monitoring.Container {
+func GitHubProxy() *monitoring.Dashboard {
 	const containerName = "github-proxy"
 
-	return &monitoring.Container{
+	return &monitoring.Dashboard{
 		Name:        "github-proxy",
 		Title:       "GitHub Proxy",
 		Description: "Proxies all requests to github.com, keeping track of and managing rate limits.",

--- a/monitoring/definitions/postgres.go
+++ b/monitoring/definitions/postgres.go
@@ -7,7 +7,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/monitoring/monitoring"
 )
 
-func Postgres() *monitoring.Container {
+func Postgres() *monitoring.Dashboard {
 	const (
 		// In docker-compose, codeintel-db container is called pgsql. In Kubernetes,
 		// codeintel-db container is called codeintel-db Because of this, we track
@@ -15,7 +15,7 @@ func Postgres() *monitoring.Container {
 		// name regex to ensure we have observability on all platforms.
 		containerName = "(pgsql|codeintel-db|codeinsights)"
 	)
-	return &monitoring.Container{
+	return &monitoring.Dashboard{
 		Name:                     "postgres",
 		Title:                    "Postgres",
 		Description:              "Postgres metrics, exported from postgres_exporter (not available on server).",

--- a/monitoring/definitions/precise_code_intel_worker.go
+++ b/monitoring/definitions/precise_code_intel_worker.go
@@ -5,10 +5,10 @@ import (
 	"github.com/sourcegraph/sourcegraph/monitoring/monitoring"
 )
 
-func PreciseCodeIntelWorker() *monitoring.Container {
+func PreciseCodeIntelWorker() *monitoring.Dashboard {
 	const containerName = "precise-code-intel-worker"
 
-	return &monitoring.Container{
+	return &monitoring.Dashboard{
 		Name:        "precise-code-intel-worker",
 		Title:       "Precise Code Intel Worker",
 		Description: "Handles conversion of uploaded precise code intelligence bundles.",

--- a/monitoring/definitions/prometheus.go
+++ b/monitoring/definitions/prometheus.go
@@ -7,7 +7,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/monitoring/monitoring"
 )
 
-func Prometheus() *monitoring.Container {
+func Prometheus() *monitoring.Dashboard {
 	const (
 		containerName = "prometheus"
 
@@ -15,7 +15,7 @@ func Prometheus() *monitoring.Container {
 		ruleGroupInterpretation = `Rules that Sourcegraph ships with are grouped under '/sg_config_prometheus'. [Custom rules are grouped under '/sg_prometheus_addons'](https://docs.sourcegraph.com/admin/observability/metrics#prometheus-configuration).`
 	)
 
-	return &monitoring.Container{
+	return &monitoring.Dashboard{
 		Name:                     "prometheus",
 		Title:                    "Prometheus",
 		Description:              "Sourcegraph's all-in-one Prometheus and Alertmanager service.",

--- a/monitoring/definitions/redis.go
+++ b/monitoring/definitions/redis.go
@@ -7,13 +7,13 @@ import (
 	"github.com/sourcegraph/sourcegraph/monitoring/monitoring"
 )
 
-func Redis() *monitoring.Container {
+func Redis() *monitoring.Dashboard {
 	const (
 		redisCache = "redis-cache"
 		redisStore = "redis-store"
 	)
 
-	return &monitoring.Container{
+	return &monitoring.Dashboard{
 		Name:                     "redis",
 		Title:                    "Redis",
 		Description:              "Metrics from both redis databases.",

--- a/monitoring/definitions/repo_updater.go
+++ b/monitoring/definitions/repo_updater.go
@@ -8,7 +8,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/monitoring/monitoring"
 )
 
-func RepoUpdater() *monitoring.Container {
+func RepoUpdater() *monitoring.Dashboard {
 	const (
 		containerName = "repo-updater"
 
@@ -22,7 +22,7 @@ func RepoUpdater() *monitoring.Container {
 		},
 	}
 
-	return &monitoring.Container{
+	return &monitoring.Dashboard{
 		Name:        "repo-updater",
 		Title:       "Repo Updater",
 		Description: "Manages interaction with code hosts, instructs Gitserver to update repositories.",

--- a/monitoring/definitions/searcher.go
+++ b/monitoring/definitions/searcher.go
@@ -7,10 +7,10 @@ import (
 	"github.com/sourcegraph/sourcegraph/monitoring/monitoring"
 )
 
-func Searcher() *monitoring.Container {
+func Searcher() *monitoring.Dashboard {
 	const containerName = "searcher"
 
-	return &monitoring.Container{
+	return &monitoring.Dashboard{
 		Name:        "searcher",
 		Title:       "Searcher",
 		Description: "Performs unindexed searches (diff and commit search, text search for unindexed branches).",

--- a/monitoring/definitions/symbols.go
+++ b/monitoring/definitions/symbols.go
@@ -5,10 +5,10 @@ import (
 	"github.com/sourcegraph/sourcegraph/monitoring/monitoring"
 )
 
-func Symbols() *monitoring.Container {
+func Symbols() *monitoring.Dashboard {
 	const containerName = "symbols"
 
-	return &monitoring.Container{
+	return &monitoring.Dashboard{
 		Name:        "symbols",
 		Title:       "Symbols",
 		Description: "Handles symbol searches for unindexed branches.",

--- a/monitoring/definitions/syntect_server.go
+++ b/monitoring/definitions/syntect_server.go
@@ -5,10 +5,10 @@ import (
 	"github.com/sourcegraph/sourcegraph/monitoring/monitoring"
 )
 
-func SyntectServer() *monitoring.Container {
+func SyntectServer() *monitoring.Dashboard {
 	const containerName = "syntect-server"
 
-	return &monitoring.Container{
+	return &monitoring.Dashboard{
 		Name:                     "syntect-server",
 		Title:                    "Syntect Server",
 		Description:              "Handles syntax highlighting for code files.",

--- a/monitoring/definitions/worker.go
+++ b/monitoring/definitions/worker.go
@@ -8,7 +8,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/monitoring/monitoring"
 )
 
-func Worker() *monitoring.Container {
+func Worker() *monitoring.Dashboard {
 	const containerName = "worker"
 
 	workerJobs := []struct {
@@ -80,7 +80,7 @@ func Worker() *monitoring.Container {
 		),
 	}
 
-	return &monitoring.Container{
+	return &monitoring.Dashboard{
 		Name:        "worker",
 		Title:       "Worker",
 		Description: "Manages background processes.",

--- a/monitoring/definitions/zoekt.go
+++ b/monitoring/definitions/zoekt.go
@@ -10,14 +10,14 @@ import (
 	"github.com/sourcegraph/sourcegraph/monitoring/monitoring"
 )
 
-func Zoekt() *monitoring.Container {
+func Zoekt() *monitoring.Dashboard {
 	const (
 		indexServerContainerName = "zoekt-indexserver"
 		webserverContainerName   = "zoekt-webserver"
 		bundledContainerName     = "indexed-search"
 	)
 
-	return &monitoring.Container{
+	return &monitoring.Dashboard{
 		Name:                     "zoekt",
 		Title:                    "Zoekt",
 		Description:              "Indexes repositories, populates the search index, and responds to indexed search queries.",

--- a/monitoring/monitoring/documentation.go
+++ b/monitoring/monitoring/documentation.go
@@ -46,7 +46,7 @@ func fprintSubtitle(w io.Writer, text string) {
 // Write a standardized Observable header that one can reliably generate an anchor link for.
 //
 // See `observableAnchor`.
-func fprintObservableHeader(w io.Writer, c *Container, o *Observable, headerLevel int) {
+func fprintObservableHeader(w io.Writer, c *Dashboard, o *Observable, headerLevel int) {
 	fmt.Fprint(w, strings.Repeat("#", headerLevel))
 	fmt.Fprintf(w, " %s: %s\n\n", c.Name, o.Name)
 }
@@ -59,7 +59,7 @@ func fprintOwnedBy(w io.Writer, owner ObservableOwner) {
 // Create an anchor link that matches `fprintObservableHeader`
 //
 // Must match Prometheus template in `docker-images/prometheus/cmd/prom-wrapper/receivers.go`
-func observableDocAnchor(c *Container, o Observable) string {
+func observableDocAnchor(c *Dashboard, o Observable) string {
 	observableAnchor := strings.ReplaceAll(o.Name, "_", "-")
 	return fmt.Sprintf("%s-%s", c.Name, observableAnchor)
 }
@@ -69,7 +69,7 @@ type documentation struct {
 	dashboards     bytes.Buffer
 }
 
-func renderDocumentation(containers []*Container) (*documentation, error) {
+func renderDocumentation(containers []*Dashboard) (*documentation, error) {
 	var docs documentation
 
 	fmt.Fprint(&docs.alertSolutions, alertSolutionsHeader)
@@ -101,7 +101,7 @@ func renderDocumentation(containers []*Container) (*documentation, error) {
 	return &docs, nil
 }
 
-func (d *documentation) renderAlertSolutionEntry(c *Container, o Observable) error {
+func (d *documentation) renderAlertSolutionEntry(c *Dashboard, o Observable) error {
 	if o.Warning == nil && o.Critical == nil {
 		return nil
 	}
@@ -161,7 +161,7 @@ func (d *documentation) renderAlertSolutionEntry(c *Container, o Observable) err
 	return nil
 }
 
-func (d *documentation) renderDashboardPanelEntry(c *Container, o Observable, panelID uint) {
+func (d *documentation) renderDashboardPanelEntry(c *Dashboard, o Observable, panelID uint) {
 	fprintObservableHeader(&d.dashboards, c, &o, 4)
 	fprintSubtitle(&d.dashboards, upperFirst(o.Description))
 

--- a/monitoring/monitoring/generator.go
+++ b/monitoring/monitoring/generator.go
@@ -36,7 +36,7 @@ type GenerateOptions struct {
 }
 
 // Generate is the main Sourcegraph monitoring generator entrypoint.
-func Generate(logger log15.Logger, opts GenerateOptions, containers ...*Container) error {
+func Generate(logger log15.Logger, opts GenerateOptions, containers ...*Dashboard) error {
 	logger.Info("Regenerating monitoring", "options", opts, "containers", len(containers))
 
 	var generatedAssets []string


### PR DESCRIPTION
there has been need to create dashboard that are not tied to a specific service or containers, so we might as well rename `Container` to `Dashboard` to better describe its purpose.

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

rename stuff
