### PR TITLE
dev/sg: remove lint.Report.Duration, clarify usage of Output and Err

### DIFF
--- a/dev/sg/internal/lint/lint.go
+++ b/dev/sg/internal/lint/lint.go
@@ -2,7 +2,6 @@ package lint
 
 import (
 	"context"
-	"time"
 
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/repo"
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/run"
@@ -17,13 +16,19 @@ type Runner func(context.Context, *repo.State) *Report
 type Report struct {
 	// Header is the title for this report.
 	Header string
-	// Output will be expanded on failure. This is also used to create annotations with
-	// sg lint -annotate.
+	// Output will be expanded on failure. Optional if Err is provided.
 	Output string
-	// Err indicates a failure has been detected.
+	// Err indicates a failure has been detected, and is mainly used to detect if an the
+	// check has failed - its contents are only presented when Output is not provided.
 	Err error
-	// Duration indicates the time spent on a script.
-	Duration time.Duration
+}
+
+// Summary renders a summary of the report based on Output or Err.
+func (r *Report) Summary() string {
+	if r.Output == "" && r.Err != nil {
+		return r.Err.Error()
+	}
+	return r.Output
 }
 
 // Target denotes a linter task that can be run by `sg lint`
@@ -36,13 +41,11 @@ type Target struct {
 // RunScript runs the given script from the root of sourcegraph/sourcegraph.
 func RunScript(header string, script string) Runner {
 	return Runner(func(ctx context.Context, state *repo.State) *Report {
-		start := time.Now()
 		out, err := run.BashInRoot(ctx, script, nil)
 		return &Report{
-			Header:   header,
-			Output:   out,
-			Err:      err,
-			Duration: time.Since(start),
+			Header: header,
+			Output: out,
+			Err:    err,
 		}
 	})
 }


### PR DESCRIPTION
Setting `Report.Duration` is a lot of boilerplate in non-script `lint.Runner` for something that could easily be unified, so this changes `sg lint` to automatically infer a duration.

The first few times I built linters when `Output` and `Err` gets used was pretty confusing - IMO there's some room for improvement here still, but I just added some docs and a helper to get the summary to try and clarify a bit.

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

`go run ./dev/sg lint`
