### PR TITLE
ci: Sync schema changes to code-intel-extensions.

### DIFF
--- a/.github/workflows/push-schema.yml
+++ b/.github/workflows/push-schema.yml
@@ -1,0 +1,34 @@
+name: 'Sync GraphQL schema to sourcegraph/code-intel-extensions'
+
+on:
+  push:
+    paths:
+      - 'cmd/frontend/graphqlbackend/schema.graphql'
+    branches:
+      - main
+
+  workflow_dispatch:
+    branches:
+      - main
+
+jobs:
+  sync-schema:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          repository: 'sourcegraph/code-intel-extensions'
+        env:
+          GITHUB_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
+      - name: Create PR if applicable
+        run: |
+          wget -o schema/schema.graphql https://github.com/sourcegraph/sourcegraph/blob/main/cmd/frontend/graphqlbackend/schema.graphql
+          if ! git diff --quiet; then
+            git config user.name sourcegraph-bot
+            git config user.email sourcegraph-bot-github@sourcegraph.com
+            git checkout -b "sync-bot/$(date -Iminutes)"
+            git add schema/schema.graphql
+            TITLE="schema: Sync GraphQL schema from sourcegraph/sourcegraph."
+            git commit -m "$TITLE"
+            gh pr create --fill --body "Created by GitHub Action.\n\n### Test Plan\n\nRun CI testing."
+          fi


### PR DESCRIPTION
Based on Robert's suggestion in sourcegraph/code-intel-extensions#791.

## Test plan

Test in ~prod~ CI.