### PR TITLE
repo-updater: Don't alert on npm path errors

### DIFF
--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -11019,7 +11019,7 @@ To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel
 <details>
 <summary>Technical details</summary>
 
-Query: `max by (family) (rate(src_repoupdater_syncer_sync_errors_total{owner!="user"}[5m]))`
+Query: `max by (family) (rate(src_repoupdater_syncer_sync_errors_total{owner!="user",reason!="invalid_npm_path"}[5m]))`
 
 </details>
 

--- a/internal/repos/syncer.go
+++ b/internal/repos/syncer.go
@@ -868,6 +868,9 @@ func syncErrorReason(err error) string {
 		return "forbidden"
 	case errcode.IsTemporary(err):
 		return "temporary"
+	case strings.Contains(err.Error(), "expected path in npm/(scope/)?name"):
+		// This is a known issue which we can filter out for now
+		return "invalid_npm_path"
 	default:
 		return "unknown"
 	}

--- a/monitoring/definitions/repo_updater.go
+++ b/monitoring/definitions/repo_updater.go
@@ -63,7 +63,7 @@ func RepoUpdater() *monitoring.Container {
 						{
 							Name:        "src_repoupdater_syncer_sync_errors_total",
 							Description: "site level external service sync error rate",
-							Query:       `max by (family) (rate(src_repoupdater_syncer_sync_errors_total{owner!="user"}[5m]))`,
+							Query:       `max by (family) (rate(src_repoupdater_syncer_sync_errors_total{owner!="user",reason!="invalid_npm_path"}[5m]))`,
 							Warning:     monitoring.Alert().Greater(0.5).For(10 * time.Minute),
 							Critical:    monitoring.Alert().Greater(1).For(10 * time.Minute),
 							Panel:       monitoring.Panel().Unit(monitoring.Number).With(monitoring.PanelOptions.ZeroIfNoData()),


### PR DESCRIPTION
These are knownn issues which we can ignore and should not cause us to
trigger sync error alerts.

## Test plan

Confirm metrics drop after deployment