### PR TITLE
rs/repo permissions unrestricted

### DIFF
--- a/internal/database/repos_perm.go
+++ b/internal/database/repos_perm.go
@@ -62,6 +62,15 @@ func AuthzQueryConds(ctx context.Context, db DB) (*sqlf.Query, error) {
 func authzQuery(bypassAuthz, usePermissionsUserMapping bool, authenticatedUserID int32, perms authz.Perms) *sqlf.Query {
 	const queryFmtString = `(
     %s                            -- TRUE or FALSE to indicate whether to bypass the check
+OR (
+  -- Unrestricted repos are visible to all users
+  EXISTS (
+    SELECT
+      FROM repo_permissions
+      WHERE repo_id = repo.id
+      AND unrestricted
+  )
+)
 OR  (
 	NOT %s                        -- Disregard unrestricted state when permissions user mapping is enabled
 	AND (

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -2172,8 +2172,10 @@ Indexes:
  updated_at    | timestamp with time zone |           | not null | 
  synced_at     | timestamp with time zone |           |          | 
  user_ids_ints | integer[]                |           | not null | '{}'::integer[]
+ unrestricted  | boolean                  |           | not null | false
 Indexes:
     "repo_permissions_perm_unique" UNIQUE CONSTRAINT, btree (repo_id, permission)
+    "repo_permissions_unrestricted_true_idx" btree (unrestricted) WHERE unrestricted
 
 ```
 

--- a/migrations/frontend/1652175864/down.sql
+++ b/migrations/frontend/1652175864/down.sql
@@ -1,0 +1,6 @@
+ALTER TABLE
+    repo_permissions
+    DROP
+        COLUMN IF EXISTS unrestricted;
+
+DROP INDEX IF EXISTS repo_permissions_unrestricted_true_idx;

--- a/migrations/frontend/1652175864/metadata.yaml
+++ b/migrations/frontend/1652175864/metadata.yaml
@@ -1,0 +1,2 @@
+name: add-unrestricted-to-repo-permissions
+parents: [1650456734, 1651061363, 1651159431]

--- a/migrations/frontend/1652175864/up.sql
+++ b/migrations/frontend/1652175864/up.sql
@@ -1,0 +1,8 @@
+ALTER TABLE
+    repo_permissions
+ADD
+    COLUMN IF NOT EXISTS unrestricted boolean NOT NULL DEFAULT false;
+
+CREATE INDEX IF NOT EXISTS repo_permissions_unrestricted_true_idx ON repo_permissions
+    USING btree (unrestricted) WHERE unrestricted;
+


### PR DESCRIPTION
- migration: Add the unrestricted column for repo_permissions
- Check for unrestricted repos in AuthzQuery
