### PR TITLE
Accessibility: Fix footer issues

### DIFF
--- a/client/web/src/search/home/SearchPageFooter.module.scss
+++ b/client/web/src/search/home/SearchPageFooter.module.scss
@@ -9,6 +9,11 @@
     justify-content: center;
     align-items: flex-start;
 
+    @media (--xs-breakpoint-down) {
+        flex-direction: column;
+        gap: 1rem;
+    }
+
     :global(.theme-light) & {
         --footer-bg: rgba(230, 235, 242, 0.4);
         --footer-border: var(--border-color);

--- a/client/web/src/search/home/SearchPageFooter.tsx
+++ b/client/web/src/search/home/SearchPageFooter.tsx
@@ -107,7 +107,7 @@ export const SearchPageFooter: React.FunctionComponent<
                     >
                         <img
                             src={`${assetsRoot}/img/devtooltime-logo.svg`}
-                            alt="DevToolTime logo"
+                            alt=""
                             className={styles.devToolTimeImage}
                         />
                         <div className={styles.devToolTimeText}>


### PR DESCRIPTION
## Description

Issue 1: Footer wasn't fully readable on 320px. Fix is pretty minor but makes it readable.

| BEFORE             |  AFTER |
:-------------------------:|:-------------------------:
<img width="372" alt="image" src="https://user-images.githubusercontent.com/9516420/167629480-77a4fa92-9ef2-4920-89dd-5d2262d537a4.png"> | <img width="380" alt="image" src="https://user-images.githubusercontent.com/9516420/167629579-9cf3597f-5c58-46e4-b53f-f01ef3cdccc3.png">


Issue 2: Alt text was unnecessary on DevTools time logo (repeated)


## Test plan
1. Run locally with a screen reader/mobile screen


