### PR TITLE
Fix `<GitCommitNode />` `<li>` usage

### DIFF
--- a/client/web/src/repo/RepoRevisionSidebarCommits.tsx
+++ b/client/web/src/repo/RepoRevisionSidebarCommits.tsx
@@ -38,7 +38,7 @@ const CommitNode: React.FunctionComponent<React.PropsWithChildren<CommitNodeProp
     location,
     preferAbsoluteTimestamps,
 }) => (
-    <li className={classNames(styles.commitContainer, 'list-group-item p-0')}>
+    <div className={classNames(styles.commitContainer, 'list-group-item p-0')}>
         <GitCommitNode
             className={styles.commitNode}
             compact={true}
@@ -55,7 +55,7 @@ const CommitNode: React.FunctionComponent<React.PropsWithChildren<CommitNodeProp
                 </Link>
             }
         />
-    </li>
+    </div>
 )
 
 interface Props extends Partial<RevisionSpec>, FileSpec {

--- a/client/web/src/repo/commit/RepositoryCommitPage.tsx
+++ b/client/web/src/repo/commit/RepositoryCommitPage.tsx
@@ -275,6 +275,7 @@ export class RepositoryCommitPage extends React.Component<Props, State> {
                         <div className="border-bottom pb-2">
                             <div>
                                 <GitCommitNode
+                                    wrapperElement="div"
                                     node={this.state.commitOrError}
                                     expandCommitMessageBody={true}
                                     showSHAAndParentsRow={true}

--- a/client/web/src/repo/commits/GitCommitNode.tsx
+++ b/client/web/src/repo/commits/GitCommitNode.tsx
@@ -54,6 +54,9 @@ export interface GitCommitNodeProps {
 
     /** An optional additional css class name to apply this to commit node message subject */
     messageSubjectClassName?: string
+
+    /** Element that should wrap the commit data. Only use 'div' when rendering the component on its own */
+    wrapperElement?: 'li' | 'div'
 }
 
 /** Displays a Git commit. */
@@ -70,6 +73,7 @@ export const GitCommitNode: React.FunctionComponent<React.PropsWithChildren<GitC
     preferAbsoluteTimestamps,
     diffMode,
     onHandleDiffMode,
+    wrapperElement: WrapperElement,
 }) => {
     const [showCommitMessageBody, setShowCommitMessageBody] = useState<boolean>(false)
     const [flashCopiedToClipboardMessage, setFlashCopiedToClipboardMessage] = useState<boolean>(false)
@@ -232,7 +236,10 @@ export const GitCommitNode: React.FunctionComponent<React.PropsWithChildren<GitC
 
     if (sidebar) {
         return (
-            <li key={node.id} className={classNames(styles.gitCommitNode, styles.gitCommitNodeCompact, className)}>
+            <WrapperElement
+                key={node.id}
+                className={classNames(styles.gitCommitNode, styles.gitCommitNodeCompact, className)}
+            >
                 <div className="w-100 d-flex justify-content-between align-items-center flex-wrap-reverse">
                     {bylineElement}
                     <small className={classNames('text-muted', styles.messageTimestamp)}>
@@ -244,12 +251,12 @@ export const GitCommitNode: React.FunctionComponent<React.PropsWithChildren<GitC
                     </small>
                     <Link to={node.canonicalURL}>{oidElement}</Link>
                 </div>
-            </li>
+            </WrapperElement>
         )
     }
 
     return (
-        <li
+        <WrapperElement
             key={node.id}
             className={classNames(styles.gitCommitNode, compact && styles.gitCommitNodeCompact, className)}
         >
@@ -315,6 +322,6 @@ export const GitCommitNode: React.FunctionComponent<React.PropsWithChildren<GitC
                     </div>
                 )}
             </>
-        </li>
+        </WrapperElement>
     )
 }

--- a/client/web/src/repo/commits/GitCommitNode.tsx
+++ b/client/web/src/repo/commits/GitCommitNode.tsx
@@ -73,7 +73,7 @@ export const GitCommitNode: React.FunctionComponent<React.PropsWithChildren<GitC
     preferAbsoluteTimestamps,
     diffMode,
     onHandleDiffMode,
-    wrapperElement: WrapperElement,
+    wrapperElement: WrapperElement = 'li',
 }) => {
     const [showCommitMessageBody, setShowCommitMessageBody] = useState<boolean>(false)
     const [flashCopiedToClipboardMessage, setFlashCopiedToClipboardMessage] = useState<boolean>(false)


### PR DESCRIPTION
## Description

This PR: https://github.com/sourcegraph/sourcegraph/pull/34960 defaulted `GitCommitNode` to use the `<li>` wrapper. This fixes a lot of issues as we almost always use this component in a list. 

However we have one regression where we render it on its own:
<img width="495" alt="image" src="https://user-images.githubusercontent.com/9516420/167635954-263db667-2288-491a-bc29-e509bbd1728c.png">

This PR adds a prop that lets us override it in this case.

Note: It'd be better just to let consumers wrap this in `<li>` where suitable, but this gets tricky due to `FilteredConnection` expecting a reference to a React component (we'd have to duplicate this component each time just to wrap it)

Once fixed:
<img width="518" alt="image" src="https://user-images.githubusercontent.com/9516420/167636286-cfa9feaa-a857-4fb3-ab70-00fa01702a84.png">



## Test plan
1. Ran locally and checked all usage of `<GitCommitNode />`
2. 
<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


