### PR TITLE
[SG-35109] Wildcard V2: <Typography /> Manual migration `H5/H6`

### DIFF
--- a/client/search-ui/src/results/sidebar/SearchSidebarSection.tsx
+++ b/client/search-ui/src/results/sidebar/SearchSidebarSection.tsx
@@ -4,7 +4,7 @@ import classNames from 'classnames'
 import ChevronDownIcon from 'mdi-react/ChevronDownIcon'
 import ChevronLeftIcon from 'mdi-react/ChevronLeftIcon'
 
-import { Button, Collapse, CollapseHeader, CollapsePanel, H2, H5, Icon } from '@sourcegraph/wildcard'
+import { Button, Collapse, CollapseHeader, CollapsePanel, H2, Icon, Typography } from '@sourcegraph/wildcard'
 
 import { FilterLink, FilterLinkProps } from './FilterLink'
 
@@ -113,9 +113,9 @@ export const SearchSidebarSection: React.FunctionComponent<
                         outline={true}
                         variant="secondary"
                     >
-                        <H5 as={H2} className="flex-grow-1">
+                        <Typography.H5 as={H2} className="flex-grow-1">
                             {header}
-                        </H5>
+                        </Typography.H5>
                         <Icon className="mr-1" as={isOpened ? ChevronDownIcon : ChevronLeftIcon} />
                     </CollapseHeader>
 

--- a/client/vscode/src/webview/sidebars/auth/AuthSidebarView.tsx
+++ b/client/vscode/src/webview/sidebars/auth/AuthSidebarView.tsx
@@ -6,7 +6,7 @@ import { Form } from '@sourcegraph/branded/src/components/Form'
 import { LoaderInput } from '@sourcegraph/branded/src/components/LoaderInput'
 import { currentAuthStateQuery } from '@sourcegraph/shared/src/auth'
 import { CurrentAuthStateResult, CurrentAuthStateVariables } from '@sourcegraph/shared/src/graphql-operations'
-import { Alert } from '@sourcegraph/wildcard'
+import { Alert, Typography } from '@sourcegraph/wildcard'
 
 import { WebviewPageProps } from '../../platform/context'
 
@@ -92,7 +92,7 @@ export const AuthSidebarView: React.FunctionComponent<React.PropsWithChildren<Au
             <div className={classNames(styles.ctaContainer)}>
                 <Form onSubmit={validateAccessToken}>
                     <button type="button" className={classNames('btn btn-outline-secondary', styles.ctaTitle)}>
-                        <h5 className="flex-grow-1">Search your private code</h5>
+                        <Typography.H5 className="flex-grow-1">Search your private code</Typography.H5>
                     </button>
                     {content}
                 </Form>
@@ -223,7 +223,7 @@ export const AuthSidebarCta: React.FunctionComponent<React.PropsWithChildren<Aut
     return (
         <div>
             <button type="button" className={classNames('btn btn-outline-secondary', styles.ctaTitle)}>
-                <h5 className="flex-grow-1">Welcome</h5>
+                <Typography.H5 className="flex-grow-1">Welcome</Typography.H5>
             </button>
             <p className={classNames(styles.ctaParagraph)}>
                 The Sourcegraph extension allows you to search millions of open source repositories without cloning them

--- a/client/vscode/src/webview/sidebars/history/components/RecentFilesSection.tsx
+++ b/client/vscode/src/webview/sidebars/history/components/RecentFilesSection.tsx
@@ -5,7 +5,7 @@ import ChevronDownIcon from 'mdi-react/ChevronDownIcon'
 import ChevronLeftIcon from 'mdi-react/ChevronLeftIcon'
 
 import { EventLogResult, fetchRecentFileViews } from '@sourcegraph/search'
-import { Icon, Link, useObservable } from '@sourcegraph/wildcard'
+import { Icon, Link, Typography, useObservable } from '@sourcegraph/wildcard'
 
 import { HistorySidebarProps } from '../HistorySidebarView'
 
@@ -61,7 +61,7 @@ export const RecentFilesSection: React.FunctionComponent<React.PropsWithChildren
                 onClick={() => setCollapsed(!collapsed)}
                 aria-label={`${collapsed ? 'Expand' : 'Collapse'} recent files`}
             >
-                <h5 className="flex-grow-1">Recent Files</h5>
+                <Typography.H5 className="flex-grow-1">Recent Files</Typography.H5>
                 <Icon
                     role="img"
                     aria-hidden={true}

--- a/client/vscode/src/webview/sidebars/history/components/RecentRepositoriesSection.tsx
+++ b/client/vscode/src/webview/sidebars/history/components/RecentRepositoriesSection.tsx
@@ -9,7 +9,7 @@ import { SyntaxHighlightedSearchQuery } from '@sourcegraph/search-ui'
 import { scanSearchQuery } from '@sourcegraph/shared/src/search/query/scanner'
 import { isRepoFilter } from '@sourcegraph/shared/src/search/query/validate'
 import { LATEST_VERSION } from '@sourcegraph/shared/src/search/stream'
-import { Icon, useObservable } from '@sourcegraph/wildcard'
+import { Icon, Typography, useObservable } from '@sourcegraph/wildcard'
 
 import { SearchPatternType } from '../../../../graphql-operations'
 import { HistorySidebarProps } from '../HistorySidebarView'
@@ -67,7 +67,7 @@ export const RecentRepositoriesSection: React.FunctionComponent<React.PropsWithC
                 onClick={() => setCollapsed(!collapsed)}
                 aria-label={`${collapsed ? 'Expand' : 'Collapse'} recent files`}
             >
-                <h5 className="flex-grow-1">Recent Repositories</h5>
+                <Typography.H5 className="flex-grow-1">Recent Repositories</Typography.H5>
                 <Icon
                     role="img"
                     aria-hidden={true}

--- a/client/vscode/src/webview/sidebars/history/components/RecentSearchesSection.tsx
+++ b/client/vscode/src/webview/sidebars/history/components/RecentSearchesSection.tsx
@@ -7,7 +7,7 @@ import ChevronLeftIcon from 'mdi-react/ChevronLeftIcon'
 import { EventLogResult, fetchRecentSearches } from '@sourcegraph/search'
 import { SyntaxHighlightedSearchQuery } from '@sourcegraph/search-ui'
 import { LATEST_VERSION } from '@sourcegraph/shared/src/search/stream'
-import { Icon, useObservable } from '@sourcegraph/wildcard'
+import { Icon, Typography, useObservable } from '@sourcegraph/wildcard'
 
 import { SearchPatternType } from '../../../../graphql-operations'
 import { HistorySidebarProps } from '../HistorySidebarView'
@@ -63,7 +63,7 @@ export const RecentSearchesSection: React.FunctionComponent<React.PropsWithChild
                 onClick={() => setCollapsed(!collapsed)}
                 aria-label={`${collapsed ? 'Expand' : 'Collapse'} recent searches`}
             >
-                <h5 className="flex-grow-1">Recent Searches</h5>
+                <Typography.H5 className="flex-grow-1">Recent Searches</Typography.H5>
                 <Icon
                     role="img"
                     className="mr-1"

--- a/client/vscode/src/webview/sidebars/history/components/SavedSearchesSection.tsx
+++ b/client/vscode/src/webview/sidebars/history/components/SavedSearchesSection.tsx
@@ -7,7 +7,7 @@ import { catchError } from 'rxjs/operators'
 
 import { gql } from '@sourcegraph/http-client'
 import { LATEST_VERSION } from '@sourcegraph/shared/src/search/stream'
-import { Icon, useObservable } from '@sourcegraph/wildcard'
+import { Icon, Typography, useObservable } from '@sourcegraph/wildcard'
 
 import { SavedSearchesResult, SavedSearchesVariables, SearchPatternType } from '../../../../graphql-operations'
 import { HistorySidebarProps } from '../HistorySidebarView'
@@ -91,7 +91,7 @@ export const SavedSearchesSection: React.FunctionComponent<React.PropsWithChildr
                 onClick={() => setCollapsed(!collapsed)}
                 aria-label={`${collapsed ? 'Expand' : 'Collapse'} saved searches`}
             >
-                <h5 className="flex-grow-1">Saved Searches</h5>
+                <Typography.H5 className="flex-grow-1">Saved Searches</Typography.H5>
                 <Icon
                     role="img"
                     aria-hidden={true}

--- a/client/vscode/src/webview/sidebars/search/ContextInvalidatedSidebarView.tsx
+++ b/client/vscode/src/webview/sidebars/search/ContextInvalidatedSidebarView.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { Button } from '@sourcegraph/wildcard'
+import { Button, Typography } from '@sourcegraph/wildcard'
 
 import { WebviewPageProps } from '../../platform/context'
 
@@ -10,7 +10,7 @@ export const ContextInvalidatedSidebarView: React.FunctionComponent<
     React.PropsWithChildren<ContextInvalidatedSidebarViewProps>
 > = ({ extensionCoreAPI }) => (
     <div>
-        <h5 className="mt-3 mb-2">Your Sourcegraph instance URL has changed.</h5>
+        <Typography.H5 className="mt-3 mb-2">Your Sourcegraph instance URL has changed.</Typography.H5>
         <p>Please reload VS Code to use to Sourcegraph extension.</p>
         <Button
             variant="primary"

--- a/client/web/src/enterprise/batches/BatchSpecsPage.tsx
+++ b/client/web/src/enterprise/batches/BatchSpecsPage.tsx
@@ -4,7 +4,7 @@ import MapSearchIcon from 'mdi-react/MapSearchIcon'
 import { RouteComponentProps } from 'react-router'
 
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
-import { Container, PageHeader } from '@sourcegraph/wildcard'
+import { Container, PageHeader, Typography } from '@sourcegraph/wildcard'
 
 import { FilteredConnection, FilteredConnectionQueryArguments } from '../../components/FilteredConnection'
 import { PageTitle } from '../../components/PageTitle'
@@ -116,9 +116,11 @@ export const BatchSpecList: React.FunctionComponent<React.PropsWithChildren<Batc
 const Header: React.FunctionComponent<React.PropsWithChildren<{}>> = () => (
     <>
         <span className="d-none d-md-block" />
-        <h5 className="p-2 d-none d-md-block text-uppercase text-center text-nowrap">State</h5>
-        <h5 className="p-2 d-none d-md-block text-uppercase text-nowrap">Batch spec</h5>
-        <h5 className="d-none d-md-block text-uppercase text-center text-nowrap">Execution time</h5>
+        <Typography.H5 className="p-2 d-none d-md-block text-uppercase text-center text-nowrap">State</Typography.H5>
+        <Typography.H5 className="p-2 d-none d-md-block text-uppercase text-nowrap">Batch spec</Typography.H5>
+        <Typography.H5 className="d-none d-md-block text-uppercase text-center text-nowrap">
+            Execution time
+        </Typography.H5>
     </>
 )
 

--- a/client/web/src/enterprise/batches/close/BatchChangeCloseHeader.tsx
+++ b/client/web/src/enterprise/batches/close/BatchChangeCloseHeader.tsx
@@ -2,6 +2,8 @@ import React from 'react'
 
 import classNames from 'classnames'
 
+import { Typography } from '@sourcegraph/wildcard'
+
 import styles from './BatchChangeCloseHeader.module.scss'
 
 export interface BatchChangeCloseHeaderProps {
@@ -11,11 +13,11 @@ export interface BatchChangeCloseHeaderProps {
 const BatchChangeCloseHeader: React.FunctionComponent<React.PropsWithChildren<BatchChangeCloseHeaderProps>> = () => (
     <>
         <span className="d-none d-md-block" />
-        <h5 className="d-none d-md-block text-uppercase text-center text-nowrap">Action</h5>
-        <h5 className="d-none d-md-block text-uppercase text-nowrap">Changeset information</h5>
-        <h5 className="d-none d-md-block text-uppercase text-center text-nowrap">Check state</h5>
-        <h5 className="d-none d-md-block text-uppercase text-center text-nowrap">Review state</h5>
-        <h5 className="d-none d-md-block text-uppercase text-center text-nowrap">Changes</h5>
+        <Typography.H5 className="d-none d-md-block text-uppercase text-center text-nowrap">Action</Typography.H5>
+        <Typography.H5 className="d-none d-md-block text-uppercase text-nowrap">Changeset information</Typography.H5>
+        <Typography.H5 className="d-none d-md-block text-uppercase text-center text-nowrap">Check state</Typography.H5>
+        <Typography.H5 className="d-none d-md-block text-uppercase text-center text-nowrap">Review state</Typography.H5>
+        <Typography.H5 className="d-none d-md-block text-uppercase text-center text-nowrap">Changes</Typography.H5>
     </>
 )
 

--- a/client/web/src/enterprise/batches/detail/changesets/BatchChangeChangesetsHeader.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/BatchChangeChangesetsHeader.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { H3, H5 } from '@sourcegraph/wildcard'
+import { H3, Typography } from '@sourcegraph/wildcard'
 
 import { InputTooltip } from '../../../../components/InputTooltip'
 
@@ -30,20 +30,20 @@ export const BatchChangeChangesetsHeader: React.FunctionComponent<
                 }
             />
         )}
-        <H5 as={H3} className="p-2 d-none d-md-block text-uppercase text-center text-nowrap">
+        <Typography.H5 as={H3} className="p-2 d-none d-md-block text-uppercase text-center text-nowrap">
             Status
-        </H5>
-        <H5 as={H3} className="p-2 d-none d-md-block text-uppercase text-nowrap">
+        </Typography.H5>
+        <Typography.H5 as={H3} className="p-2 d-none d-md-block text-uppercase text-nowrap">
             Changeset information
-        </H5>
-        <H5 as={H3} className="p-2 d-none d-md-block text-uppercase text-center text-nowrap">
+        </Typography.H5>
+        <Typography.H5 as={H3} className="p-2 d-none d-md-block text-uppercase text-center text-nowrap">
             Check state
-        </H5>
-        <H5 as={H3} className="p-2 d-none d-md-block text-uppercase text-center text-nowrap">
+        </Typography.H5>
+        <Typography.H5 as={H3} className="p-2 d-none d-md-block text-uppercase text-center text-nowrap">
             Review state
-        </H5>
-        <H5 as={H3} className="p-2 d-none d-md-block text-uppercase text-center text-nowrap">
+        </Typography.H5>
+        <Typography.H5 as={H3} className="p-2 d-none d-md-block text-uppercase text-center text-nowrap">
             Changes
-        </H5>
+        </Typography.H5>
     </>
 )

--- a/client/web/src/enterprise/batches/preview/list/PreviewListHeader.tsx
+++ b/client/web/src/enterprise/batches/preview/list/PreviewListHeader.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { H5, H3 } from '@sourcegraph/wildcard'
+import { H3, Typography } from '@sourcegraph/wildcard'
 
 import { InputTooltip } from '../../../../components/InputTooltip'
 
@@ -27,23 +27,23 @@ export const PreviewListHeader: React.FunctionComponent<React.PropsWithChildren<
                 <span className="pl-2 d-block d-sm-none">Select all</span>
             </div>
         )}
-        <H5 as={H3} className="p-2 d-none d-sm-block text-uppercase text-center">
+        <Typography.H5 as={H3} className="p-2 d-none d-sm-block text-uppercase text-center">
             Current state
-        </H5>
-        <H5 as={H3} className="d-none d-sm-block text-uppercase text-center">
+        </Typography.H5>
+        <Typography.H5 as={H3} className="d-none d-sm-block text-uppercase text-center">
             +<br />-
-        </H5>
-        <H5 as={H3} className="p-2 d-none d-sm-block text-uppercase text-nowrap">
+        </Typography.H5>
+        <Typography.H5 as={H3} className="p-2 d-none d-sm-block text-uppercase text-nowrap">
             Actions
-        </H5>
-        <H5 as={H3} className="p-2 d-none d-sm-block text-uppercase text-nowrap">
+        </Typography.H5>
+        <Typography.H5 as={H3} className="p-2 d-none d-sm-block text-uppercase text-nowrap">
             Changeset information
-        </H5>
-        <H5 as={H3} className="p-2 d-none d-sm-block text-uppercase text-center text-nowrap">
+        </Typography.H5>
+        <Typography.H5 as={H3} className="p-2 d-none d-sm-block text-uppercase text-center text-nowrap">
             Commit changes
-        </H5>
-        <H5 as={H3} className="p-2 d-none d-sm-block text-uppercase text-center text-nowrap">
+        </Typography.H5>
+        <Typography.H5 as={H3} className="p-2 d-none d-sm-block text-uppercase text-center text-nowrap">
             Change state
-        </H5>
+        </Typography.H5>
     </>
 )

--- a/client/web/src/enterprise/batches/repo/RepoBatchChanges.tsx
+++ b/client/web/src/enterprise/batches/repo/RepoBatchChanges.tsx
@@ -4,7 +4,7 @@ import * as H from 'history'
 import { map } from 'rxjs/operators'
 
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
-import { Container } from '@sourcegraph/wildcard'
+import { Container, Typography } from '@sourcegraph/wildcard'
 
 import { FilteredConnection, FilteredConnectionQueryArguments } from '../../../components/FilteredConnection'
 import { RepoBatchChange, RepositoryFields } from '../../../graphql-operations'
@@ -89,10 +89,16 @@ export const RepoBatchChangesHeader: React.FunctionComponent<React.PropsWithChil
         {/* Empty filler elements for the spaces in the grid that don't need headers */}
         <span />
         <span />
-        <h5 className="p-2 d-none d-md-block text-uppercase text-center text-nowrap">Status</h5>
-        <h5 className="p-2 d-none d-md-block text-uppercase text-nowrap">Changeset information</h5>
-        <h5 className="p-2 d-none d-md-block text-uppercase text-center text-nowrap">Check state</h5>
-        <h5 className="p-2 d-none d-md-block text-uppercase text-center text-nowrap">Review state</h5>
-        <h5 className="p-2 d-none d-md-block text-uppercase text-center text-nowrap">Changes</h5>
+        <Typography.H5 className="p-2 d-none d-md-block text-uppercase text-center text-nowrap">Status</Typography.H5>
+        <Typography.H5 className="p-2 d-none d-md-block text-uppercase text-nowrap">
+            Changeset information
+        </Typography.H5>
+        <Typography.H5 className="p-2 d-none d-md-block text-uppercase text-center text-nowrap">
+            Check state
+        </Typography.H5>
+        <Typography.H5 className="p-2 d-none d-md-block text-uppercase text-center text-nowrap">
+            Review state
+        </Typography.H5>
+        <Typography.H5 className="p-2 d-none d-md-block text-uppercase text-center text-nowrap">Changes</Typography.H5>
     </>
 )

--- a/client/web/src/enterprise/code-monitoring/components/logs/CodeMonitorLogsHeader.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/logs/CodeMonitorLogsHeader.tsx
@@ -2,11 +2,15 @@ import React from 'react'
 
 import classNames from 'classnames'
 
+import { Typography } from '@sourcegraph/wildcard'
+
 import styles from './CodeMonitorLogsHeader.module.scss'
 
 export const CodeMonitorLogsHeader: React.FunctionComponent<React.PropsWithChildren<{}>> = () => (
     <>
-        <h5 className={classNames(styles.nameColumn, 'text-uppercase text-nowrap')}>Monitor name</h5>
-        <h5 className="text-uppercase text-nowrap">Last run</h5>
+        <Typography.H5 className={classNames(styles.nameColumn, 'text-uppercase text-nowrap')}>
+            Monitor name
+        </Typography.H5>
+        <Typography.H5 className="text-uppercase text-nowrap">Last run</Typography.H5>
     </>
 )

--- a/client/web/src/settings/tokens/AccessTokenCreatedAlert.tsx
+++ b/client/web/src/settings/tokens/AccessTokenCreatedAlert.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import classNames from 'classnames'
 
 import { CodeSnippet } from '@sourcegraph/branded/src/components/CodeSnippet'
-import { Alert } from '@sourcegraph/wildcard'
+import { Alert, Typography } from '@sourcegraph/wildcard'
 
 import { AccessTokenScopes } from '../../auth/accessToken'
 import { CopyableText } from '../../components/CopyableText'
@@ -26,9 +26,9 @@ export const AccessTokenCreatedAlert: React.FunctionComponent<
         <Alert className={classNames('access-token-created-alert', className)} variant="success">
             <p>Copy the new access token now. You won't be able to see it again.</p>
             <CopyableText className="test-access-token" text={tokenSecret} size={48} />
-            <h5 className="mt-4 mb-2">
+            <Typography.H5 className="mt-4 mb-2">
                 <strong>Example usage</strong>
-            </h5>
+            </Typography.H5>
             <CodeSnippet code={curlExampleCommand(tokenSecret, isSudoToken)} className="mb-0" language="bash" />
         </Alert>
     )

--- a/client/web/src/site-admin/SiteAdminAlert.tsx
+++ b/client/web/src/site-admin/SiteAdminAlert.tsx
@@ -3,7 +3,7 @@ import * as React from 'react'
 import classNames from 'classnames'
 import LockIcon from 'mdi-react/LockIcon'
 
-import { Alert, AlertProps, Icon, H5, H2 } from '@sourcegraph/wildcard'
+import { Alert, AlertProps, Icon, H2, Typography } from '@sourcegraph/wildcard'
 
 import styles from './SiteAdminAlert.module.scss'
 
@@ -21,9 +21,9 @@ export const SiteAdminAlert: React.FunctionComponent<React.PropsWithChildren<Sit
     variant = 'warning',
 }) => (
     <Alert className={classNames(styles.siteAdminAlert, className)} variant={variant}>
-        <H5 as={H2}>
+        <Typography.H5 as={H2}>
             <Icon as={LockIcon} /> Site admin
-        </H5>
+        </Typography.H5>
         <div>{children}</div>
     </Alert>
 )

--- a/client/web/src/site-admin/webhooks/WebhookLogPage.tsx
+++ b/client/web/src/site-admin/webhooks/WebhookLogPage.tsx
@@ -3,7 +3,7 @@ import React, { useCallback, useState } from 'react'
 import classNames from 'classnames'
 import { RouteComponentProps } from 'react-router'
 
-import { Container, PageHeader } from '@sourcegraph/wildcard'
+import { Container, PageHeader, Typography } from '@sourcegraph/wildcard'
 
 import { FilteredConnection, FilteredConnectionQueryArguments } from '../../components/FilteredConnection'
 import { PageTitle } from '../../components/PageTitle'
@@ -75,8 +75,8 @@ export const WebhookLogPage: React.FunctionComponent<React.PropsWithChildren<Pro
 const Header: React.FunctionComponent<React.PropsWithChildren<{}>> = () => (
     <>
         <span className="d-none d-md-block" />
-        <h5 className="d-none d-md-block text-uppercase text-center text-nowrap">Status code</h5>
-        <h5 className="d-none d-md-block text-uppercase text-nowrap">External service</h5>
-        <h5 className="d-none d-md-block text-uppercase text-center text-nowrap">Received at</h5>
+        <Typography.H5 className="d-none d-md-block text-uppercase text-center text-nowrap">Status code</Typography.H5>
+        <Typography.H5 className="d-none d-md-block text-uppercase text-nowrap">External service</Typography.H5>
+        <Typography.H5 className="d-none d-md-block text-uppercase text-center text-nowrap">Received at</Typography.H5>
     </>
 )


### PR DESCRIPTION
Manual migration required to update our code to use the <Typography /> Wildcard component.
See [Wildcard V2 - Planned work](https://docs.google.com/document/d/1NisbJPiadtt5jQw4vUUYJOr8dD6Urwn5V0mVq2wt6bE/edit#heading=h.g4cw92w3ouhw) for more context

Note: Before doing this, we should check if there is scope for a codemod to automate this migration. If so, the codemod should be implemented and ran before starting work on this issue.

### Ref
https://github.com/sourcegraph/sourcegraph/issues/27677

### Acceptance criteria
 All incorrect usage of the previous pattern has been updated to use the Wildcard component
Time estimate
Pull requests with ~450 lines changed should take 2-3 hours at maximum. Ping the reviewer in the spec pull request if time-consuming changes are required.
Split the work into multiple pull requests if the total diff is bigger than 450 lines of code.

### Implementation Detail
Migrate all usage of h5/h6 on codebase to wildcard's H5/H6

## Test plan
Ensure there are no UI changes on both storybook and application

## App preview:

- [Web](https://sg-web-contractors-sg-35109.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-lfkyqoquxr.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
