### PR TITLE
external services: Add a ToAPIService method

### DIFF
--- a/cmd/frontend/backend/external_services.go
+++ b/cmd/frontend/backend/external_services.go
@@ -136,19 +136,7 @@ func SyncExternalService(ctx context.Context, svc *types.ExternalService, timeou
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	_, err := client.SyncExternalService(ctx, api.ExternalService{
-		ID:              svc.ID,
-		Kind:            svc.Kind,
-		DisplayName:     svc.DisplayName,
-		Config:          svc.Config,
-		CreatedAt:       svc.CreatedAt,
-		UpdatedAt:       svc.UpdatedAt,
-		DeletedAt:       svc.DeletedAt,
-		LastSyncAt:      svc.LastSyncAt,
-		NextSyncAt:      svc.NextSyncAt,
-		NamespaceUserID: svc.NamespaceUserID,
-		NamespaceOrgID:  svc.NamespaceOrgID,
-	})
+	_, err := client.SyncExternalService(ctx, svc.ToAPIService())
 
 	// If context error is anything but a deadline exceeded error, we do not want to propagate
 	// it. But we definitely want to log the error as a warning.

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -157,7 +157,7 @@ type Settings struct {
 	CreatedAt    time.Time       // the date when this settings value was created
 }
 
-// ExternalService represents an complete external service record.
+// ExternalService represents a complete external service record.
 type ExternalService struct {
 	ID              int64
 	Kind            string

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -482,6 +482,8 @@ type ExternalService struct {
 	CloudDefault    bool       // Whether this external service is our default public service on Cloud
 	HasWebhooks     *bool      // Whether this external service has webhooks configured; calculated from Config
 	TokenExpiresAt  *time.Time // Whether the token in this external services expires, nil indicates never expires.
+
+	// Remember to update ToAPIService if you add more fields
 }
 
 // ExternalServiceSyncJob represents an sync job for an external service
@@ -566,6 +568,24 @@ func (e *ExternalService) With(opts ...func(*ExternalService)) *ExternalService 
 	clone := e.Clone()
 	clone.Apply(opts...)
 	return clone
+}
+
+func (e *ExternalService) ToAPIService() api.ExternalService {
+	return api.ExternalService{
+		ID:              e.ID,
+		Kind:            e.Kind,
+		DisplayName:     e.DisplayName,
+		Config:          e.Config,
+		CreatedAt:       e.CreatedAt,
+		UpdatedAt:       e.UpdatedAt,
+		DeletedAt:       e.DeletedAt,
+		LastSyncAt:      e.LastSyncAt,
+		NextSyncAt:      e.NextSyncAt,
+		NamespaceUserID: e.NamespaceUserID,
+		NamespaceOrgID:  e.NamespaceOrgID,
+		Unrestricted:    e.Unrestricted,
+		CloudDefault:    e.CloudDefault,
+	}
 }
 
 // ExternalServices is an utility type with

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -482,8 +482,6 @@ type ExternalService struct {
 	CloudDefault    bool       // Whether this external service is our default public service on Cloud
 	HasWebhooks     *bool      // Whether this external service has webhooks configured; calculated from Config
 	TokenExpiresAt  *time.Time // Whether the token in this external services expires, nil indicates never expires.
-
-	// Remember to update ToAPIService if you add more fields
 }
 
 // ExternalServiceSyncJob represents an sync job for an external service

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -588,8 +588,8 @@ func (e *ExternalService) ToAPIService() api.ExternalService {
 	}
 }
 
-// ExternalServices is an utility type with
-// convenience methods for operating on lists of ExternalServices.
+// ExternalServices is a utility type with convenience methods for operating on
+// lists of ExternalServices.
 type ExternalServices []*ExternalService
 
 // IDs returns the list of ids from all ExternalServices.

--- a/internal/types/types_test.go
+++ b/internal/types/types_test.go
@@ -1,0 +1,19 @@
+package types
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestExternalServiceFields confirms will fail if a new field is added to
+// ExternalService to ensure that we update ToAPIService
+func TestExternalServiceFields(t *testing.T) {
+	v := reflect.ValueOf(ExternalService{})
+	// If this test fails it means that fields have changed on types.ExternalService.
+	// Ensure that types.ExternalService and api.ExternalService are consistent and
+	// also that types,ExternalService.ToAPIService has been updated.
+	wantFieldCount := 15
+	if wantFieldCount != v.NumField() {
+		t.Fatalf("Expected %d fields, got %d. See comments in failing test", wantFieldCount, v.NumField())
+	}
+}

--- a/internal/types/types_test.go
+++ b/internal/types/types_test.go
@@ -11,7 +11,7 @@ func TestExternalServiceFields(t *testing.T) {
 	v := reflect.ValueOf(ExternalService{})
 	// If this test fails it means that fields have changed on types.ExternalService.
 	// Ensure that types.ExternalService and api.ExternalService are consistent and
-	// also that types,ExternalService.ToAPIService has been updated.
+	// also that types.ExternalService.ToAPIService has been updated.
 	wantFieldCount := 15
 	if wantFieldCount != v.NumField() {
 		t.Fatalf("Expected %d fields, got %d. See comments in failing test", wantFieldCount, v.NumField())

--- a/internal/types/types_test.go
+++ b/internal/types/types_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-// TestExternalServiceFields confirms will fail if a new field is added to
+// TestExternalServiceFields will fail if a new field is added to
 // ExternalService to ensure that we update ToAPIService
 func TestExternalServiceFields(t *testing.T) {
 	v := reflect.ValueOf(ExternalService{})


### PR DESCRIPTION
This just moves the logic into a more central place so that it's harder
to forget to update the code when we add more fields.

Simpler approach to close https://github.com/sourcegraph/sourcegraph/issues/33997

It also avoid a second load from the db which is not free for external services as in
some cases we need to decrypt config.

## Test plan

No code changed, just moved.