### PR TITLE
Search backend: optimize jobs by construction

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -599,7 +599,7 @@ func (r *searchResolver) Stats(ctx context.Context) (stats *searchResultsStats, 
 		if err != nil {
 			return nil, err
 		}
-		j, err := jobutil.ToSearchJob(r.SearchInputs, b)
+		j, err := jobutil.NewBasicJob(r.SearchInputs, b)
 		if err != nil {
 			return nil, err
 		}

--- a/enterprise/internal/codemonitors/search_test.go
+++ b/enterprise/internal/codemonitors/search_test.go
@@ -72,7 +72,7 @@ func TestAddCodeMonitorHook(t *testing.T) {
 				Protocol:            search.Streaming,
 				OnSourcegraphDotCom: true,
 			}
-			j, err := jobutil.NewJob(inputs, plan, jobutil.IdentityPass)
+			j, err := jobutil.NewJob(inputs, plan)
 			require.NoError(t, err)
 			addCodeMonitorHook(j, nil)
 		}

--- a/internal/search/job/jobutil/job.go
+++ b/internal/search/job/jobutil/job.go
@@ -677,7 +677,7 @@ func toPatternExpressionJob(inputs *run.SearchInputs, q query.Basic) (job.Job, e
 	return nil, errors.Errorf("unrecognized type %T in evaluatePatternExpression", q.Pattern)
 }
 
-func ToEvaluateJob(inputs *run.SearchInputs, q query.Basic) (job.Job, error) {
+func toFlatJobs(inputs *run.SearchInputs, q query.Basic) (job.Job, error) {
 	if q.Pattern == nil {
 		return ToSearchJob(inputs, q)
 	} else {
@@ -826,7 +826,7 @@ func NewJob(inputs *run.SearchInputs, plan query.Plan, optimize Pass) (job.Job, 
 }
 
 func NewBasicJob(inputs *run.SearchInputs, q query.Basic, optimize Pass) (job.Job, error) {
-	child, err := ToEvaluateJob(inputs, q)
+	child, err := toFlatJobs(inputs, q)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/search/job/jobutil/job.go
+++ b/internal/search/job/jobutil/job.go
@@ -228,9 +228,7 @@ func ToSearchJob(searchInputs *run.SearchInputs, b query.Basic) (job.Job, error)
 		}
 	}
 
-	job := NewParallelJob(allJobs...)
-
-	return job, nil
+	return NewParallelJob(allJobs...), nil
 }
 
 func mapSlice(values []string, f func(string) string) []string {

--- a/internal/search/job/jobutil/job.go
+++ b/internal/search/job/jobutil/job.go
@@ -228,10 +228,6 @@ func ToSearchJob(searchInputs *run.SearchInputs, b query.Basic) (job.Job, error)
 		}
 	}
 
-	addJob(&searchrepos.ComputeExcludedReposJob{
-		RepoOpts: repoOptions,
-	})
-
 	job := NewParallelJob(allJobs...)
 
 	return job, nil
@@ -720,6 +716,10 @@ func NewBasicJob(inputs *run.SearchInputs, q query.Basic) (job.Job, error) {
 				IncludeModifiedFiles: authz.SubRepoEnabled(authz.DefaultSubRepoPermsChecker),
 			})
 		}
+
+		addJob(&searchrepos.ComputeExcludedReposJob{
+			RepoOpts: repoOptions,
+		})
 	}
 
 	{

--- a/internal/search/job/jobutil/job_test.go
+++ b/internal/search/job/jobutil/job_test.go
@@ -34,63 +34,44 @@ func TestToSearchInputs(t *testing.T) {
 (PARALLEL
   REPOPAGER
     SearcherJob)
-  RepoSearchJob
-  ComputeExcludedReposJob)
+  RepoSearchJob)
 `).Equal(t, test(`foo context:@userA`, search.Streaming, query.ParseLiteral))
 
-	autogold.Want("universal (AKA global) search context", `
-(PARALLEL
-  RepoSearchJob
-  ComputeExcludedReposJob)
-`).Equal(t, test(`foo context:global`, search.Streaming, query.ParseLiteral))
+	autogold.Want("universal (AKA global) search context", "\nRepoSearchJob\n").Equal(t, test(`foo context:global`, search.Streaming, query.ParseLiteral))
 
-	autogold.Want("universal (AKA global) search", `
-(PARALLEL
-  RepoSearchJob
-  ComputeExcludedReposJob)
-`).Equal(t, test(`foo`, search.Streaming, query.ParseLiteral))
+	autogold.Want("universal (AKA global) search", "\nRepoSearchJob\n").Equal(t, test(`foo`, search.Streaming, query.ParseLiteral))
 
 	autogold.Want("nonglobal repo", `
 (PARALLEL
   REPOPAGER
     SearcherJob)
-  RepoSearchJob
-  ComputeExcludedReposJob)
+  RepoSearchJob)
 `).Equal(t, test(`foo repo:sourcegraph/sourcegraph`, search.Streaming, query.ParseLiteral))
 
 	autogold.Want("nonglobal repo contains", `
 (PARALLEL
   REPOPAGER
     SearcherJob)
-  RepoSearchJob
-  ComputeExcludedReposJob)
+  RepoSearchJob)
 `).Equal(t, test(`foo repo:contains(bar)`, search.Streaming, query.ParseLiteral))
 
 	// Job generation support for implied `type:repo` queries.
-	autogold.Want("supported Repo job", `
-(PARALLEL
-  RepoSearchJob
-  ComputeExcludedReposJob)
-`).Equal(t, test("ok ok", search.Streaming, query.ParseRegexp))
+	autogold.Want("supported Repo job", "\nRepoSearchJob\n").Equal(t, test("ok ok", search.Streaming, query.ParseRegexp))
 
-	autogold.Want("supportedRepo job literal", `
-(PARALLEL
-  RepoSearchJob
-  ComputeExcludedReposJob)
-`).Equal(t, test("ok @thing", search.Streaming, query.ParseLiteral))
+	autogold.Want("supportedRepo job literal", "\nRepoSearchJob\n").Equal(t, test("ok @thing", search.Streaming, query.ParseLiteral))
 
-	autogold.Want("unsupported Repo job prefix", "\nComputeExcludedReposJob\n").Equal(t, test("@nope", search.Streaming, query.ParseRegexp))
+	autogold.Want("unsupported Repo job prefix", "\nNoopJob\n").Equal(t, test("@nope", search.Streaming, query.ParseRegexp))
 
-	autogold.Want("unsupported Repo job regexp", "\nComputeExcludedReposJob\n").Equal(t, test("foo @bar", search.Streaming, query.ParseRegexp))
+	autogold.Want("unsupported Repo job regexp", "\nNoopJob\n").Equal(t, test("foo @bar", search.Streaming, query.ParseRegexp))
 
 	// Job generation for other types of search
-	autogold.Want("symbol", "\nComputeExcludedReposJob\n").Equal(t, test("type:symbol test", search.Streaming, query.ParseRegexp))
+	autogold.Want("symbol", "\nNoopJob\n").Equal(t, test("type:symbol test", search.Streaming, query.ParseRegexp))
 
-	autogold.Want("commit", "\nComputeExcludedReposJob\n").Equal(t, test("type:commit test", search.Streaming, query.ParseRegexp))
+	autogold.Want("commit", "\nNoopJob\n").Equal(t, test("type:commit test", search.Streaming, query.ParseRegexp))
 
-	autogold.Want("diff", "\nComputeExcludedReposJob\n").Equal(t, test("type:diff test", search.Streaming, query.ParseRegexp))
+	autogold.Want("diff", "\nNoopJob\n").Equal(t, test("type:diff test", search.Streaming, query.ParseRegexp))
 
-	autogold.Want("Streaming: file or commit", "\nComputeExcludedReposJob\n").Equal(t, test("type:file type:commit test", search.Streaming, query.ParseRegexp))
+	autogold.Want("Streaming: file or commit", "\nNoopJob\n").Equal(t, test("type:file type:commit test", search.Streaming, query.ParseRegexp))
 
 	autogold.Want("Streaming: many types", `
 (PARALLEL
@@ -98,12 +79,11 @@ func TestToSearchInputs(t *testing.T) {
     SearcherJob)
   REPOPAGER
     SymbolSearcherJob)
-  RepoSearchJob
-  ComputeExcludedReposJob)
+  RepoSearchJob)
 `).Equal(t, test("type:file type:path type:repo type:commit type:symbol repo:test test", search.Streaming, query.ParseRegexp))
 
 	// Priority jobs for Batched search.
-	autogold.Want("Batched: file or commit", "\nComputeExcludedReposJob\n").Equal(t, test("type:file type:commit test", search.Batch, query.ParseRegexp))
+	autogold.Want("Batched: file or commit", "\nNoopJob\n").Equal(t, test("type:file type:commit test", search.Batch, query.ParseRegexp))
 
 	autogold.Want("Batched: many types", `
 (PARALLEL
@@ -111,8 +91,7 @@ func TestToSearchInputs(t *testing.T) {
     SearcherJob)
   REPOPAGER
     SymbolSearcherJob)
-  RepoSearchJob
-  ComputeExcludedReposJob)
+  RepoSearchJob)
 `).Equal(t, test("type:file type:path type:repo type:commit type:symbol repo:test test", search.Batch, query.ParseRegexp))
 }
 
@@ -131,17 +110,9 @@ func TestToEvaluateJob(t *testing.T) {
 		return "\n" + PrettySexp(j) + "\n"
 	}
 
-	autogold.Want("root limit for streaming search", `
-(PARALLEL
-  RepoSearchJob
-  ComputeExcludedReposJob)
-`).Equal(t, test("foo", search.Streaming))
+	autogold.Want("root limit for streaming search", "\nRepoSearchJob\n").Equal(t, test("foo", search.Streaming))
 
-	autogold.Want("root limit for batch search", `
-(PARALLEL
-  RepoSearchJob
-  ComputeExcludedReposJob)
-`).Equal(t, test("foo", search.Batch))
+	autogold.Want("root limit for batch search", "\nRepoSearchJob\n").Equal(t, test("foo", search.Batch))
 }
 
 func TestToTextPatternInfo(t *testing.T) {

--- a/internal/search/job/jobutil/job_test.go
+++ b/internal/search/job/jobutil/job_test.go
@@ -33,9 +33,7 @@ func TestToSearchInputs(t *testing.T) {
 	autogold.Want("user search context", `
 (PARALLEL
   REPOPAGER
-    (PARALLEL
-      ZoektRepoSubsetSearchJob
-      SearcherJob))
+    SearcherJob)
   RepoSearchJob
   ComputeExcludedReposJob)
 `).Equal(t, test(`foo context:@userA`, search.Streaming, query.ParseLiteral))
@@ -55,9 +53,7 @@ func TestToSearchInputs(t *testing.T) {
 	autogold.Want("nonglobal repo", `
 (PARALLEL
   REPOPAGER
-    (PARALLEL
-      ZoektRepoSubsetSearchJob
-      SearcherJob))
+    SearcherJob)
   RepoSearchJob
   ComputeExcludedReposJob)
 `).Equal(t, test(`foo repo:sourcegraph/sourcegraph`, search.Streaming, query.ParseLiteral))
@@ -65,9 +61,7 @@ func TestToSearchInputs(t *testing.T) {
 	autogold.Want("nonglobal repo contains", `
 (PARALLEL
   REPOPAGER
-    (PARALLEL
-      ZoektRepoSubsetSearchJob
-      SearcherJob))
+    SearcherJob)
   RepoSearchJob
   ComputeExcludedReposJob)
 `).Equal(t, test(`foo repo:contains(bar)`, search.Streaming, query.ParseLiteral))
@@ -117,9 +111,7 @@ func TestToSearchInputs(t *testing.T) {
 	autogold.Want("Streaming: many types", `
 (PARALLEL
   REPOPAGER
-    (PARALLEL
-      ZoektRepoSubsetSearchJob
-      SearcherJob))
+    SearcherJob)
   REPOPAGER
     (PARALLEL
       ZoektSymbolSearchJob
@@ -139,9 +131,7 @@ func TestToSearchInputs(t *testing.T) {
 	autogold.Want("Batched: many types", `
 (PARALLEL
   REPOPAGER
-    (PARALLEL
-      ZoektRepoSubsetSearchJob
-      SearcherJob))
+    SearcherJob)
   REPOPAGER
     (PARALLEL
       ZoektSymbolSearchJob

--- a/internal/search/job/jobutil/job_test.go
+++ b/internal/search/job/jobutil/job_test.go
@@ -86,23 +86,11 @@ func TestToSearchInputs(t *testing.T) {
 	// Job generation for other types of search
 	autogold.Want("symbol", "\nComputeExcludedReposJob\n").Equal(t, test("type:symbol test", search.Streaming, query.ParseRegexp))
 
-	autogold.Want("commit", `
-(PARALLEL
-  CommitSearchJob
-  ComputeExcludedReposJob)
-`).Equal(t, test("type:commit test", search.Streaming, query.ParseRegexp))
+	autogold.Want("commit", "\nComputeExcludedReposJob\n").Equal(t, test("type:commit test", search.Streaming, query.ParseRegexp))
 
-	autogold.Want("diff", `
-(PARALLEL
-  DiffSearchJob
-  ComputeExcludedReposJob)
-`).Equal(t, test("type:diff test", search.Streaming, query.ParseRegexp))
+	autogold.Want("diff", "\nComputeExcludedReposJob\n").Equal(t, test("type:diff test", search.Streaming, query.ParseRegexp))
 
-	autogold.Want("Streaming: file or commit", `
-(PARALLEL
-  CommitSearchJob
-  ComputeExcludedReposJob)
-`).Equal(t, test("type:file type:commit test", search.Streaming, query.ParseRegexp))
+	autogold.Want("Streaming: file or commit", "\nComputeExcludedReposJob\n").Equal(t, test("type:file type:commit test", search.Streaming, query.ParseRegexp))
 
 	autogold.Want("Streaming: many types", `
 (PARALLEL
@@ -110,17 +98,12 @@ func TestToSearchInputs(t *testing.T) {
     SearcherJob)
   REPOPAGER
     SymbolSearcherJob)
-  CommitSearchJob
   RepoSearchJob
   ComputeExcludedReposJob)
 `).Equal(t, test("type:file type:path type:repo type:commit type:symbol repo:test test", search.Streaming, query.ParseRegexp))
 
 	// Priority jobs for Batched search.
-	autogold.Want("Batched: file or commit", `
-(PARALLEL
-  CommitSearchJob
-  ComputeExcludedReposJob)
-`).Equal(t, test("type:file type:commit test", search.Batch, query.ParseRegexp))
+	autogold.Want("Batched: file or commit", "\nComputeExcludedReposJob\n").Equal(t, test("type:file type:commit test", search.Batch, query.ParseRegexp))
 
 	autogold.Want("Batched: many types", `
 (PARALLEL
@@ -128,7 +111,6 @@ func TestToSearchInputs(t *testing.T) {
     SearcherJob)
   REPOPAGER
     SymbolSearcherJob)
-  CommitSearchJob
   RepoSearchJob
   ComputeExcludedReposJob)
 `).Equal(t, test("type:file type:path type:repo type:commit type:symbol repo:test test", search.Batch, query.ParseRegexp))

--- a/internal/search/job/jobutil/job_test.go
+++ b/internal/search/job/jobutil/job_test.go
@@ -177,7 +177,7 @@ func TestToEvaluateJob(t *testing.T) {
 		}
 
 		b, _ := query.ToBasicQuery(q)
-		j, _ := ToEvaluateJob(inputs, b)
+		j, _ := toFlatJobs(inputs, b)
 		return "\n" + PrettySexp(j) + "\n"
 	}
 

--- a/internal/search/job/jobutil/job_test.go
+++ b/internal/search/job/jobutil/job_test.go
@@ -84,11 +84,7 @@ func TestToSearchInputs(t *testing.T) {
 	autogold.Want("unsupported Repo job regexp", "\nComputeExcludedReposJob\n").Equal(t, test("foo @bar", search.Streaming, query.ParseRegexp))
 
 	// Job generation for other types of search
-	autogold.Want("symbol", `
-(PARALLEL
-  RepoUniverseSymbolSearchJob
-  ComputeExcludedReposJob)
-`).Equal(t, test("type:symbol test", search.Streaming, query.ParseRegexp))
+	autogold.Want("symbol", "\nComputeExcludedReposJob\n").Equal(t, test("type:symbol test", search.Streaming, query.ParseRegexp))
 
 	autogold.Want("commit", `
 (PARALLEL

--- a/internal/search/job/jobutil/job_test.go
+++ b/internal/search/job/jobutil/job_test.go
@@ -144,57 +144,6 @@ func TestToEvaluateJob(t *testing.T) {
 `).Equal(t, test("foo", search.Batch))
 }
 
-func Test_optimizeJobs(t *testing.T) {
-	test := func(input string) string {
-		plan, _ := query.Pipeline(query.InitLiteral(input))
-		inputs := &run.SearchInputs{
-			UserSettings:        &schema.Settings{},
-			PatternType:         query.SearchTypeLiteralDefault,
-			Protocol:            search.Streaming,
-			OnSourcegraphDotCom: true,
-		}
-
-		baseJob, _ := NewJob(inputs, plan, IdentityPass)
-		optimizedJob, _ := NewJob(inputs, plan, OptimizationPass)
-		return "INPUT:\n\n" + input + "\n\nBASE:\n\n" + PrettySexp(baseJob) + "\n\nOPTIMIZED:\n\n" + PrettySexp(optimizedJob) + "\n"
-	}
-
-	cases := []struct {
-		name  string
-		query string
-	}{{
-		name:  "optimize basic expression Zoekt Text Global",
-		query: "foo and bar and not baz",
-	}, {
-		name:  "optimize repo-qualified expression Zoekt Text over repos",
-		query: "repo:derp foo and bar not baz",
-	}, {
-		name:  "optimize repo-qualified expression Zoekt Text over repos",
-		query: "repo:derp foo and bar not baz",
-	}, {
-		name:  "optimize qualified repo with type:symbol expression Zoekt Symbol over repos",
-		query: "repo:derp foo and bar not baz type:symbol",
-	}, {
-		name:  "commit with and",
-		query: "type:commit a and b",
-	}, {
-		name:  "commit with or",
-		query: "type:commit a or b",
-	}, {
-		name:  "diff with and",
-		query: "type:diff a and b",
-	}, {
-		name:  "diff with or",
-		query: "type:diff a or b",
-	}}
-
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			autogold.Equal(t, autogold.Raw(test(tc.query)))
-		})
-	}
-}
-
 func TestToTextPatternInfo(t *testing.T) {
 	cases := []struct {
 		input  string

--- a/internal/search/job/jobutil/job_test.go
+++ b/internal/search/job/jobutil/job_test.go
@@ -42,14 +42,12 @@ func TestToSearchInputs(t *testing.T) {
 
 	autogold.Want("universal (AKA global) search context", `
 (PARALLEL
-  ZoektGlobalSearchJob
   RepoSearchJob
   ComputeExcludedReposJob)
 `).Equal(t, test(`foo context:global`, search.Streaming, query.ParseLiteral))
 
 	autogold.Want("universal (AKA global) search", `
 (PARALLEL
-  ZoektGlobalSearchJob
   RepoSearchJob
   ComputeExcludedReposJob)
 `).Equal(t, test(`foo`, search.Streaming, query.ParseLiteral))
@@ -77,29 +75,19 @@ func TestToSearchInputs(t *testing.T) {
 	// Job generation support for implied `type:repo` queries.
 	autogold.Want("supported Repo job", `
 (PARALLEL
-  ZoektGlobalSearchJob
   RepoSearchJob
   ComputeExcludedReposJob)
 `).Equal(t, test("ok ok", search.Streaming, query.ParseRegexp))
 
 	autogold.Want("supportedRepo job literal", `
 (PARALLEL
-  ZoektGlobalSearchJob
   RepoSearchJob
   ComputeExcludedReposJob)
 `).Equal(t, test("ok @thing", search.Streaming, query.ParseLiteral))
 
-	autogold.Want("unsupported Repo job prefix", `
-(PARALLEL
-  ZoektGlobalSearchJob
-  ComputeExcludedReposJob)
-`).Equal(t, test("@nope", search.Streaming, query.ParseRegexp))
+	autogold.Want("unsupported Repo job prefix", "\nComputeExcludedReposJob\n").Equal(t, test("@nope", search.Streaming, query.ParseRegexp))
 
-	autogold.Want("unsupported Repo job regexp", `
-(PARALLEL
-  ZoektGlobalSearchJob
-  ComputeExcludedReposJob)
-`).Equal(t, test("foo @bar", search.Streaming, query.ParseRegexp))
+	autogold.Want("unsupported Repo job regexp", "\nComputeExcludedReposJob\n").Equal(t, test("foo @bar", search.Streaming, query.ParseRegexp))
 
 	// Job generation for other types of search
 	autogold.Want("symbol", `
@@ -122,7 +110,6 @@ func TestToSearchInputs(t *testing.T) {
 
 	autogold.Want("Streaming: file or commit", `
 (PARALLEL
-  ZoektGlobalSearchJob
   CommitSearchJob
   ComputeExcludedReposJob)
 `).Equal(t, test("type:file type:commit test", search.Streaming, query.ParseRegexp))
@@ -145,7 +132,6 @@ func TestToSearchInputs(t *testing.T) {
 	// Priority jobs for Batched search.
 	autogold.Want("Batched: file or commit", `
 (PARALLEL
-  ZoektGlobalSearchJob
   CommitSearchJob
   ComputeExcludedReposJob)
 `).Equal(t, test("type:file type:commit test", search.Batch, query.ParseRegexp))
@@ -183,14 +169,12 @@ func TestToEvaluateJob(t *testing.T) {
 
 	autogold.Want("root limit for streaming search", `
 (PARALLEL
-  ZoektGlobalSearchJob
   RepoSearchJob
   ComputeExcludedReposJob)
 `).Equal(t, test("foo", search.Streaming))
 
 	autogold.Want("root limit for batch search", `
 (PARALLEL
-  ZoektGlobalSearchJob
   RepoSearchJob
   ComputeExcludedReposJob)
 `).Equal(t, test("foo", search.Batch))

--- a/internal/search/job/jobutil/job_test.go
+++ b/internal/search/job/jobutil/job_test.go
@@ -109,9 +109,7 @@ func TestToSearchInputs(t *testing.T) {
   REPOPAGER
     SearcherJob)
   REPOPAGER
-    (PARALLEL
-      ZoektSymbolSearchJob
-      SymbolSearcherJob))
+    SymbolSearcherJob)
   CommitSearchJob
   RepoSearchJob
   ComputeExcludedReposJob)
@@ -129,9 +127,7 @@ func TestToSearchInputs(t *testing.T) {
   REPOPAGER
     SearcherJob)
   REPOPAGER
-    (PARALLEL
-      ZoektSymbolSearchJob
-      SymbolSearcherJob))
+    SymbolSearcherJob)
   CommitSearchJob
   RepoSearchJob
   ComputeExcludedReposJob)

--- a/internal/search/job/jobutil/printers_test.go
+++ b/internal/search/job/jobutil/printers_test.go
@@ -239,29 +239,6 @@ func TestPrettyJSON(t *testing.T) {
         },
         "Mode": 0
       }
-    },
-    {
-      "ComputeExcludedReposJob": {
-        "RepoOpts": {
-          "RepoFilters": [
-            "foo"
-          ],
-          "MinusRepoFilters": null,
-          "Dependencies": null,
-          "CaseSensitiveRepoFilters": false,
-          "SearchContextSpec": "",
-          "CommitAfter": "",
-          "Visibility": "Any",
-          "Limit": 0,
-          "Cursors": null,
-          "ForkSet": false,
-          "NoForks": true,
-          "OnlyForks": false,
-          "ArchivedSet": false,
-          "NoArchived": true,
-          "OnlyArchived": false
-        }
-      }
     }
   ]
 }`).Equal(t, fmt.Sprintf("\n%s", test("repo:foo bar")))

--- a/internal/search/job/jobutil/printers_test.go
+++ b/internal/search/job/jobutil/printers_test.go
@@ -183,49 +183,31 @@ func TestPrettyJSON(t *testing.T) {
   "PARALLEL": [
     {
       "REPOPAGER": {
-        "PARALLEL": [
-          {
-            "ZoektRepoSubsetSearchJob": {
-              "Repos": null,
-              "Query": {
-                "Pattern": "bar",
-                "CaseSensitive": false,
-                "FileName": false,
-                "Content": false
-              },
-              "Typ": "text",
-              "FileMatchLimit": 500,
-              "Select": []
-            }
+        "SearcherJob": {
+          "PatternInfo": {
+            "Pattern": "bar",
+            "IsNegated": false,
+            "IsRegExp": true,
+            "IsStructuralPat": false,
+            "CombyRule": "",
+            "IsWordMatch": false,
+            "IsCaseSensitive": false,
+            "FileMatchLimit": 500,
+            "Index": "yes",
+            "Select": [],
+            "IncludePatterns": null,
+            "ExcludePattern": "",
+            "FilePatternsReposMustInclude": null,
+            "FilePatternsReposMustExclude": null,
+            "PathPatternsAreCaseSensitive": false,
+            "PatternMatchesContent": true,
+            "PatternMatchesPath": true,
+            "Languages": null
           },
-          {
-            "SearcherJob": {
-              "PatternInfo": {
-                "Pattern": "bar",
-                "IsNegated": false,
-                "IsRegExp": true,
-                "IsStructuralPat": false,
-                "CombyRule": "",
-                "IsWordMatch": false,
-                "IsCaseSensitive": false,
-                "FileMatchLimit": 500,
-                "Index": "yes",
-                "Select": [],
-                "IncludePatterns": null,
-                "ExcludePattern": "",
-                "FilePatternsReposMustInclude": null,
-                "FilePatternsReposMustExclude": null,
-                "PathPatternsAreCaseSensitive": false,
-                "PatternMatchesContent": true,
-                "PatternMatchesPath": true,
-                "Languages": null
-              },
-              "Repos": null,
-              "Indexed": false,
-              "UseFullDeadline": true
-            }
-          }
-        ]
+          "Repos": null,
+          "Indexed": false,
+          "UseFullDeadline": true
+        }
       }
     },
     {

--- a/internal/search/job/jobutil/testdata/Test_optimizeJobs/commit_with_and.golden
+++ b/internal/search/job/jobutil/testdata/Test_optimizeJobs/commit_with_and.golden
@@ -9,16 +9,14 @@ BASE:
     20s
     (LIMIT
       500
-      (AND
-        (LIMIT
-          40000
-          (PARALLEL
-            CommitSearchJob
-            ComputeExcludedReposJob))
-        (LIMIT
-          40000
-          (PARALLEL
-            CommitSearchJob
+      (PARALLEL
+        CommitSearchJob
+        (AND
+          (LIMIT
+            40000
+            ComputeExcludedReposJob)
+          (LIMIT
+            40000
             ComputeExcludedReposJob))))))
 
 OPTIMIZED:
@@ -30,14 +28,12 @@ OPTIMIZED:
       500
       (PARALLEL
         CommitSearchJob
-        (AND
-          (LIMIT
-            40000
-            (PARALLEL
-              NoopJob
-              ComputeExcludedReposJob))
-          (LIMIT
-            40000
-            (PARALLEL
-              NoopJob
+        (PARALLEL
+          NoopJob
+          (AND
+            (LIMIT
+              40000
+              ComputeExcludedReposJob)
+            (LIMIT
+              40000
               ComputeExcludedReposJob)))))))

--- a/internal/search/job/jobutil/testdata/Test_optimizeJobs/commit_with_or.golden
+++ b/internal/search/job/jobutil/testdata/Test_optimizeJobs/commit_with_or.golden
@@ -9,12 +9,10 @@ BASE:
     20s
     (LIMIT
       500
-      (OR
-        (PARALLEL
-          CommitSearchJob
-          ComputeExcludedReposJob)
-        (PARALLEL
-          CommitSearchJob
+      (PARALLEL
+        CommitSearchJob
+        (OR
+          ComputeExcludedReposJob
           ComputeExcludedReposJob)))))
 
 OPTIMIZED:
@@ -26,10 +24,8 @@ OPTIMIZED:
       500
       (PARALLEL
         CommitSearchJob
-        (OR
-          (PARALLEL
-            NoopJob
-            ComputeExcludedReposJob)
-          (PARALLEL
-            NoopJob
+        (PARALLEL
+          NoopJob
+          (OR
+            ComputeExcludedReposJob
             ComputeExcludedReposJob))))))

--- a/internal/search/job/jobutil/testdata/Test_optimizeJobs/diff_with_and.golden
+++ b/internal/search/job/jobutil/testdata/Test_optimizeJobs/diff_with_and.golden
@@ -9,16 +9,14 @@ BASE:
     20s
     (LIMIT
       500
-      (AND
-        (LIMIT
-          40000
-          (PARALLEL
-            DiffSearchJob
-            ComputeExcludedReposJob))
-        (LIMIT
-          40000
-          (PARALLEL
-            DiffSearchJob
+      (PARALLEL
+        DiffSearchJob
+        (AND
+          (LIMIT
+            40000
+            ComputeExcludedReposJob)
+          (LIMIT
+            40000
             ComputeExcludedReposJob))))))
 
 OPTIMIZED:
@@ -30,14 +28,12 @@ OPTIMIZED:
       500
       (PARALLEL
         DiffSearchJob
-        (AND
-          (LIMIT
-            40000
-            (PARALLEL
-              NoopJob
-              ComputeExcludedReposJob))
-          (LIMIT
-            40000
-            (PARALLEL
-              NoopJob
+        (PARALLEL
+          NoopJob
+          (AND
+            (LIMIT
+              40000
+              ComputeExcludedReposJob)
+            (LIMIT
+              40000
               ComputeExcludedReposJob)))))))

--- a/internal/search/job/jobutil/testdata/Test_optimizeJobs/diff_with_or.golden
+++ b/internal/search/job/jobutil/testdata/Test_optimizeJobs/diff_with_or.golden
@@ -9,12 +9,10 @@ BASE:
     20s
     (LIMIT
       500
-      (OR
-        (PARALLEL
-          DiffSearchJob
-          ComputeExcludedReposJob)
-        (PARALLEL
-          DiffSearchJob
+      (PARALLEL
+        DiffSearchJob
+        (OR
+          ComputeExcludedReposJob
           ComputeExcludedReposJob)))))
 
 OPTIMIZED:
@@ -26,10 +24,8 @@ OPTIMIZED:
       500
       (PARALLEL
         DiffSearchJob
-        (OR
-          (PARALLEL
-            NoopJob
-            ComputeExcludedReposJob)
-          (PARALLEL
-            NoopJob
+        (PARALLEL
+          NoopJob
+          (OR
+            ComputeExcludedReposJob
             ComputeExcludedReposJob))))))

--- a/internal/search/job/jobutil/testdata/Test_optimizeJobs/optimize_basic_expression_Zoekt_Text_Global.golden
+++ b/internal/search/job/jobutil/testdata/Test_optimizeJobs/optimize_basic_expression_Zoekt_Text_Global.golden
@@ -9,25 +9,24 @@ BASE:
     20s
     (LIMIT
       500
-      (AND
-        (LIMIT
-          40000
-          (PARALLEL
-            ZoektGlobalSearchJob
-            RepoSearchJob
-            ComputeExcludedReposJob))
-        (LIMIT
-          40000
-          (PARALLEL
-            ZoektGlobalSearchJob
-            RepoSearchJob
-            ComputeExcludedReposJob))
-        (LIMIT
-          40000
-          (PARALLEL
-            ZoektGlobalSearchJob
-            RepoSearchJob
-            ComputeExcludedReposJob))))))
+      (PARALLEL
+        ZoektGlobalSearchJob
+        (AND
+          (LIMIT
+            40000
+            (PARALLEL
+              RepoSearchJob
+              ComputeExcludedReposJob))
+          (LIMIT
+            40000
+            (PARALLEL
+              RepoSearchJob
+              ComputeExcludedReposJob))
+          (LIMIT
+            40000
+            (PARALLEL
+              RepoSearchJob
+              ComputeExcludedReposJob)))))))
 
 OPTIMIZED:
 
@@ -38,22 +37,21 @@ OPTIMIZED:
       500
       (PARALLEL
         ZoektGlobalSearchJob
-        (AND
-          (LIMIT
-            40000
-            (PARALLEL
-              NoopJob
-              RepoSearchJob
-              ComputeExcludedReposJob))
-          (LIMIT
-            40000
-            (PARALLEL
-              NoopJob
-              RepoSearchJob
-              ComputeExcludedReposJob))
-          (LIMIT
-            40000
-            (PARALLEL
-              NoopJob
-              RepoSearchJob
-              ComputeExcludedReposJob)))))))
+        (PARALLEL
+          NoopJob
+          (AND
+            (LIMIT
+              40000
+              (PARALLEL
+                RepoSearchJob
+                ComputeExcludedReposJob))
+            (LIMIT
+              40000
+              (PARALLEL
+                RepoSearchJob
+                ComputeExcludedReposJob))
+            (LIMIT
+              40000
+              (PARALLEL
+                RepoSearchJob
+                ComputeExcludedReposJob))))))))

--- a/internal/search/job/jobutil/testdata/Test_optimizeJobs/optimize_qualified_repo_with_type:symbol_expression_Zoekt_Symbol_over_repos.golden
+++ b/internal/search/job/jobutil/testdata/Test_optimizeJobs/optimize_qualified_repo_with_type:symbol_expression_Zoekt_Symbol_over_repos.golden
@@ -9,31 +9,28 @@ BASE:
     20s
     (LIMIT
       500
-      (AND
-        (LIMIT
-          40000
-          (PARALLEL
-            REPOPAGER
-              (PARALLEL
-                ZoektSymbolSearchJob
-                SymbolSearcherJob))
-            ComputeExcludedReposJob))
-        (LIMIT
-          40000
-          (PARALLEL
-            REPOPAGER
-              (PARALLEL
-                ZoektSymbolSearchJob
-                SymbolSearcherJob))
-            ComputeExcludedReposJob))
-        (LIMIT
-          40000
-          (PARALLEL
-            REPOPAGER
-              (PARALLEL
-                ZoektSymbolSearchJob
-                SymbolSearcherJob))
-            ComputeExcludedReposJob))))))
+      (PARALLEL
+        REPOPAGER
+          ZoektSymbolSearchJob)
+        (AND
+          (LIMIT
+            40000
+            (PARALLEL
+              REPOPAGER
+                SymbolSearcherJob)
+              ComputeExcludedReposJob))
+          (LIMIT
+            40000
+            (PARALLEL
+              REPOPAGER
+                SymbolSearcherJob)
+              ComputeExcludedReposJob))
+          (LIMIT
+            40000
+            (PARALLEL
+              REPOPAGER
+                SymbolSearcherJob)
+              ComputeExcludedReposJob)))))))
 
 OPTIMIZED:
 
@@ -45,28 +42,24 @@ OPTIMIZED:
       (PARALLEL
         REPOPAGER
           ZoektSymbolSearchJob)
-        (AND
-          (LIMIT
-            40000
-            (PARALLEL
-              REPOPAGER
-                (PARALLEL
-                  NoopJob
-                  SymbolSearcherJob))
-              ComputeExcludedReposJob))
-          (LIMIT
-            40000
-            (PARALLEL
-              REPOPAGER
-                (PARALLEL
-                  NoopJob
-                  SymbolSearcherJob))
-              ComputeExcludedReposJob))
-          (LIMIT
-            40000
-            (PARALLEL
-              REPOPAGER
-                (PARALLEL
-                  NoopJob
-                  SymbolSearcherJob))
-              ComputeExcludedReposJob)))))))
+        (PARALLEL
+          NoopJob
+          (AND
+            (LIMIT
+              40000
+              (PARALLEL
+                REPOPAGER
+                  SymbolSearcherJob)
+                ComputeExcludedReposJob))
+            (LIMIT
+              40000
+              (PARALLEL
+                REPOPAGER
+                  SymbolSearcherJob)
+                ComputeExcludedReposJob))
+            (LIMIT
+              40000
+              (PARALLEL
+                REPOPAGER
+                  SymbolSearcherJob)
+                ComputeExcludedReposJob))))))))

--- a/internal/search/job/jobutil/testdata/Test_optimizeJobs/optimize_repo-qualified_expression_Zoekt_Text_over_repos#01.golden
+++ b/internal/search/job/jobutil/testdata/Test_optimizeJobs/optimize_repo-qualified_expression_Zoekt_Text_over_repos#01.golden
@@ -9,34 +9,31 @@ BASE:
     20s
     (LIMIT
       500
-      (AND
-        (LIMIT
-          40000
-          (PARALLEL
-            REPOPAGER
-              (PARALLEL
-                ZoektRepoSubsetSearchJob
-                SearcherJob))
-            RepoSearchJob
-            ComputeExcludedReposJob))
-        (LIMIT
-          40000
-          (PARALLEL
-            REPOPAGER
-              (PARALLEL
-                ZoektRepoSubsetSearchJob
-                SearcherJob))
-            RepoSearchJob
-            ComputeExcludedReposJob))
-        (LIMIT
-          40000
-          (PARALLEL
-            REPOPAGER
-              (PARALLEL
-                ZoektRepoSubsetSearchJob
-                SearcherJob))
-            RepoSearchJob
-            ComputeExcludedReposJob))))))
+      (PARALLEL
+        REPOPAGER
+          ZoektRepoSubsetSearchJob)
+        (AND
+          (LIMIT
+            40000
+            (PARALLEL
+              REPOPAGER
+                SearcherJob)
+              RepoSearchJob
+              ComputeExcludedReposJob))
+          (LIMIT
+            40000
+            (PARALLEL
+              REPOPAGER
+                SearcherJob)
+              RepoSearchJob
+              ComputeExcludedReposJob))
+          (LIMIT
+            40000
+            (PARALLEL
+              REPOPAGER
+                SearcherJob)
+              RepoSearchJob
+              ComputeExcludedReposJob)))))))
 
 OPTIMIZED:
 
@@ -48,31 +45,27 @@ OPTIMIZED:
       (PARALLEL
         REPOPAGER
           ZoektRepoSubsetSearchJob)
-        (AND
-          (LIMIT
-            40000
-            (PARALLEL
-              REPOPAGER
-                (PARALLEL
-                  NoopJob
-                  SearcherJob))
-              RepoSearchJob
-              ComputeExcludedReposJob))
-          (LIMIT
-            40000
-            (PARALLEL
-              REPOPAGER
-                (PARALLEL
-                  NoopJob
-                  SearcherJob))
-              RepoSearchJob
-              ComputeExcludedReposJob))
-          (LIMIT
-            40000
-            (PARALLEL
-              REPOPAGER
-                (PARALLEL
-                  NoopJob
-                  SearcherJob))
-              RepoSearchJob
-              ComputeExcludedReposJob)))))))
+        (PARALLEL
+          NoopJob
+          (AND
+            (LIMIT
+              40000
+              (PARALLEL
+                REPOPAGER
+                  SearcherJob)
+                RepoSearchJob
+                ComputeExcludedReposJob))
+            (LIMIT
+              40000
+              (PARALLEL
+                REPOPAGER
+                  SearcherJob)
+                RepoSearchJob
+                ComputeExcludedReposJob))
+            (LIMIT
+              40000
+              (PARALLEL
+                REPOPAGER
+                  SearcherJob)
+                RepoSearchJob
+                ComputeExcludedReposJob))))))))

--- a/internal/search/job/jobutil/testdata/Test_optimizeJobs/optimize_repo-qualified_expression_Zoekt_Text_over_repos.golden
+++ b/internal/search/job/jobutil/testdata/Test_optimizeJobs/optimize_repo-qualified_expression_Zoekt_Text_over_repos.golden
@@ -9,34 +9,31 @@ BASE:
     20s
     (LIMIT
       500
-      (AND
-        (LIMIT
-          40000
-          (PARALLEL
-            REPOPAGER
-              (PARALLEL
-                ZoektRepoSubsetSearchJob
-                SearcherJob))
-            RepoSearchJob
-            ComputeExcludedReposJob))
-        (LIMIT
-          40000
-          (PARALLEL
-            REPOPAGER
-              (PARALLEL
-                ZoektRepoSubsetSearchJob
-                SearcherJob))
-            RepoSearchJob
-            ComputeExcludedReposJob))
-        (LIMIT
-          40000
-          (PARALLEL
-            REPOPAGER
-              (PARALLEL
-                ZoektRepoSubsetSearchJob
-                SearcherJob))
-            RepoSearchJob
-            ComputeExcludedReposJob))))))
+      (PARALLEL
+        REPOPAGER
+          ZoektRepoSubsetSearchJob)
+        (AND
+          (LIMIT
+            40000
+            (PARALLEL
+              REPOPAGER
+                SearcherJob)
+              RepoSearchJob
+              ComputeExcludedReposJob))
+          (LIMIT
+            40000
+            (PARALLEL
+              REPOPAGER
+                SearcherJob)
+              RepoSearchJob
+              ComputeExcludedReposJob))
+          (LIMIT
+            40000
+            (PARALLEL
+              REPOPAGER
+                SearcherJob)
+              RepoSearchJob
+              ComputeExcludedReposJob)))))))
 
 OPTIMIZED:
 
@@ -48,31 +45,27 @@ OPTIMIZED:
       (PARALLEL
         REPOPAGER
           ZoektRepoSubsetSearchJob)
-        (AND
-          (LIMIT
-            40000
-            (PARALLEL
-              REPOPAGER
-                (PARALLEL
-                  NoopJob
-                  SearcherJob))
-              RepoSearchJob
-              ComputeExcludedReposJob))
-          (LIMIT
-            40000
-            (PARALLEL
-              REPOPAGER
-                (PARALLEL
-                  NoopJob
-                  SearcherJob))
-              RepoSearchJob
-              ComputeExcludedReposJob))
-          (LIMIT
-            40000
-            (PARALLEL
-              REPOPAGER
-                (PARALLEL
-                  NoopJob
-                  SearcherJob))
-              RepoSearchJob
-              ComputeExcludedReposJob)))))))
+        (PARALLEL
+          NoopJob
+          (AND
+            (LIMIT
+              40000
+              (PARALLEL
+                REPOPAGER
+                  SearcherJob)
+                RepoSearchJob
+                ComputeExcludedReposJob))
+            (LIMIT
+              40000
+              (PARALLEL
+                REPOPAGER
+                  SearcherJob)
+                RepoSearchJob
+                ComputeExcludedReposJob))
+            (LIMIT
+              40000
+              (PARALLEL
+                REPOPAGER
+                  SearcherJob)
+                RepoSearchJob
+                ComputeExcludedReposJob))))))))


### PR DESCRIPTION
In order to create queries that are optimized for Zoekt, we currently run an optimization pass over the generated job tree, regenerating jobs that can use a `query.Basic` directly and replacing them with a `NoopJob`. 

This modifies that flow to instead generate jobs before splitting a `query.Basic` into `query.Flat`. The basic idea is that now `NewBasicJob` generates jobs directly if those jobs can use the structure of a basic query. Otherwise, we split the basic query into flat queries (formalized as `query.Flat` in the followup PR) and create jobs from flat queries then add them to the basic job.

I'd recommend scanning through the commits in order since they're atomic changes that have self-describing messages.

## Test plan

Each commit passes tests individually, and I've tested manually. Additionally, in a followup PR, I did a bunch of renames and extensions of existing tests that all pass. I triggered backend integration tests.

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


