### PR TITLE
Search backend: renames and reorganize

### DIFF
--- a/cmd/frontend/graphqlbackend/parse_search_query.go
+++ b/cmd/frontend/graphqlbackend/parse_search_query.go
@@ -91,7 +91,7 @@ func (r *schemaResolver) ParseSearchQuery(ctx context.Context, args *struct {
 	}
 
 	var jsons []any
-	for _, node := range plan.ToParseTree() {
+	for _, node := range plan.ToQ() {
 		jsons = append(jsons, toJSON(node))
 	}
 	json, err := json.Marshal(jsons)

--- a/cmd/frontend/graphqlbackend/search_test.go
+++ b/cmd/frontend/graphqlbackend/search_test.go
@@ -335,7 +335,7 @@ func BenchmarkSearchResults(b *testing.B) {
 			db: db,
 			SearchInputs: &run.SearchInputs{
 				Plan:         plan,
-				Query:        plan.ToParseTree(),
+				Query:        plan.ToQ(),
 				UserSettings: &schema.Settings{},
 			},
 			zoekt: z,

--- a/enterprise/internal/codemonitors/search.go
+++ b/enterprise/internal/codemonitors/search.go
@@ -120,7 +120,7 @@ func Search(ctx context.Context, db database.DB, query string, monitorID int64, 
 		return nil, err
 	}
 
-	planJob, err := jobutil.FromExpandedPlan(inputs, plan)
+	planJob, err := jobutil.NewPlanJob(inputs, plan)
 	if err != nil {
 		return nil, err
 	}
@@ -195,7 +195,7 @@ func Snapshot(ctx context.Context, db database.DB, query string, monitorID int64
 		return err
 	}
 
-	planJob, err := jobutil.FromExpandedPlan(inputs, plan)
+	planJob, err := jobutil.NewPlanJob(inputs, plan)
 	if err != nil {
 		return err
 	}

--- a/enterprise/internal/codemonitors/search_test.go
+++ b/enterprise/internal/codemonitors/search_test.go
@@ -72,7 +72,7 @@ func TestAddCodeMonitorHook(t *testing.T) {
 				Protocol:            search.Streaming,
 				OnSourcegraphDotCom: true,
 			}
-			j, err := jobutil.NewJob(inputs, plan)
+			j, err := jobutil.NewPlanJob(inputs, plan)
 			require.NoError(t, err)
 			addCodeMonitorHook(j, nil)
 		}

--- a/enterprise/internal/compute/query.go
+++ b/enterprise/internal/compute/query.go
@@ -270,7 +270,7 @@ func toComputeQuery(plan query.Plan) (*Query, error) {
 		return nil, err
 	}
 
-	parameters := query.MapPattern(plan.ToParseTree(), func(_ string, _ bool, _ query.Annotation) query.Node {
+	parameters := query.MapPattern(plan.ToQ(), func(_ string, _ bool, _ query.Annotation) query.Node {
 		// remove the pattern node.
 		return nil
 	})

--- a/enterprise/internal/insights/query/querybuilder/builder.go
+++ b/enterprise/internal/insights/query/querybuilder/builder.go
@@ -33,7 +33,7 @@ func withDefaults(inputQuery string, defaults searchquery.Parameters) (string, e
 		modified = append(modified, basic.MapParameters(p))
 	}
 
-	return searchquery.StringHuman(modified.ToParseTree()), nil
+	return searchquery.StringHuman(modified.ToQ()), nil
 }
 
 // codeInsightsQueryDefaults returns the default query parameters for a Code Insights generated Sourcegraph query.

--- a/enterprise/internal/insights/resolvers/insight_series_resolver.go
+++ b/enterprise/internal/insights/resolvers/insight_series_resolver.go
@@ -135,7 +135,7 @@ func unwrapSearchContexts(ctx context.Context, loader SearchContextLoader, rawCo
 			if err != nil {
 				return nil, nil, errors.Wrapf(err, "failed to parse search query for search context: %s", rawContext)
 			}
-			inc, exc := plan.ToParseTree().Repositories()
+			inc, exc := plan.ToQ().Repositories()
 			include = append(include, inc...)
 			exclude = append(exclude, exc...)
 		}

--- a/internal/search/execute/execute.go
+++ b/internal/search/execute/execute.go
@@ -32,7 +32,7 @@ func Execute(
 		return nil, err
 	}
 
-	planJob, err := jobutil.FromExpandedPlan(inputs, plan)
+	planJob, err := jobutil.NewPlanJob(inputs, plan)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/search/job/jobutil/job.go
+++ b/internal/search/job/jobutil/job.go
@@ -614,7 +614,7 @@ func toFlatJobs(inputs *run.SearchInputs, q query.Basic) (job.Job, error) {
 	}
 }
 
-func NewJob(inputs *run.SearchInputs, plan query.Plan) (job.Job, error) {
+func NewPlanJob(inputs *run.SearchInputs, plan query.Plan) (job.Job, error) {
 	children := make([]job.Job, 0, len(plan))
 	for _, q := range plan {
 		child, err := NewBasicJob(inputs, q)
@@ -760,7 +760,7 @@ func NewBasicJob(inputs *run.SearchInputs, q query.Basic) (job.Job, error) {
 // FromExpandedPlan takes a query plan that has had all predicates expanded,
 // and converts it to a job.
 func FromExpandedPlan(inputs *run.SearchInputs, plan query.Plan) (job.Job, error) {
-	return NewJob(inputs, plan)
+	return NewPlanJob(inputs, plan)
 }
 
 var metricFeatureFlagUnavailable = promauto.NewCounter(prometheus.CounterOpts{

--- a/internal/search/job/jobutil/job.go
+++ b/internal/search/job/jobutil/job.go
@@ -757,12 +757,6 @@ func NewBasicJob(inputs *run.SearchInputs, q query.Basic) (job.Job, error) {
 	return basicJob, nil
 }
 
-// FromExpandedPlan takes a query plan that has had all predicates expanded,
-// and converts it to a job.
-func FromExpandedPlan(inputs *run.SearchInputs, plan query.Plan) (job.Job, error) {
-	return NewPlanJob(inputs, plan)
-}
-
 var metricFeatureFlagUnavailable = promauto.NewCounter(prometheus.CounterOpts{
 	Name: "src_search_featureflag_unavailable",
 	Help: "temporary counter to check if we have feature flag available in practice.",

--- a/internal/search/job/jobutil/job.go
+++ b/internal/search/job/jobutil/job.go
@@ -166,7 +166,7 @@ func NewBasicJob(inputs *run.SearchInputs, q query.Basic) (job.Job, error) {
 	}
 
 	{ // Apply timeout
-		timeout := TimeoutDuration(q)
+		timeout := timeoutDuration(q)
 		basicJob = NewTimeoutJob(timeout, basicJob)
 	}
 
@@ -397,7 +397,7 @@ func computeFileMatchLimit(q query.Basic, p search.Protocol) int {
 	panic("unreachable")
 }
 
-func TimeoutDuration(b query.Basic) time.Duration {
+func timeoutDuration(b query.Basic) time.Duration {
 	d := limits.DefaultTimeout
 	maxTimeout := time.Duration(limits.SearchLimits(conf.Get()).MaxTimeoutSeconds) * time.Second
 	timeout := b.GetTimeout()

--- a/internal/search/job/jobutil/job_test.go
+++ b/internal/search/job/jobutil/job_test.go
@@ -14,23 +14,6 @@ import (
 )
 
 func TestNewPlanJob(t *testing.T) {
-	test := func(t *testing.T, input string, protocol search.Protocol, searchType query.SearchType) string {
-		plan, err := query.Pipeline(query.Init(input, searchType))
-		require.NoError(t, err)
-
-		inputs := &run.SearchInputs{
-			UserSettings:        &schema.Settings{},
-			PatternType:         query.SearchTypeLiteralDefault,
-			Protocol:            protocol,
-			OnSourcegraphDotCom: true,
-		}
-
-		j, err := NewPlanJob(inputs, plan)
-		require.NoError(t, err)
-
-		return "\n" + PrettySexp(j)
-	}
-
 	cases := []struct {
 		query      string
 		protocol   search.Protocol
@@ -39,7 +22,7 @@ func TestNewPlanJob(t *testing.T) {
 	}{{
 		query:      `foo context:@userA`,
 		protocol:   search.Streaming,
-		searchType: query.SearchTypeLiteral,
+		searchType: query.SearchTypeLiteralDefault,
 		want: autogold.Want("user search context", `
 (ALERT
   (TIMEOUT
@@ -57,7 +40,7 @@ func TestNewPlanJob(t *testing.T) {
 	}, {
 		query:      `foo context:global`,
 		protocol:   search.Streaming,
-		searchType: query.SearchTypeLiteral,
+		searchType: query.SearchTypeLiteralDefault,
 		want: autogold.Want("global search explicit context", `
 (ALERT
   (TIMEOUT
@@ -71,7 +54,7 @@ func TestNewPlanJob(t *testing.T) {
 	}, {
 		query:      `foo`,
 		protocol:   search.Streaming,
-		searchType: query.SearchTypeLiteral,
+		searchType: query.SearchTypeLiteralDefault,
 		want: autogold.Want("global search implicit context", `
 (ALERT
   (TIMEOUT
@@ -85,7 +68,7 @@ func TestNewPlanJob(t *testing.T) {
 	}, {
 		query:      `foo repo:sourcegraph/sourcegraph`,
 		protocol:   search.Streaming,
-		searchType: query.SearchTypeLiteral,
+		searchType: query.SearchTypeLiteralDefault,
 		want: autogold.Want("nonglobal repo", `
 (ALERT
   (TIMEOUT
@@ -115,14 +98,9 @@ func TestNewPlanJob(t *testing.T) {
         ComputeExcludedReposJob
         RepoSearchJob))))`),
 	}, {
-		query:      `ok ok`,
-		protocol:   search.Streaming,
-		searchType: query.SearchTypeLiteral,
-		want:       autogold.Want("supported repo job", nil),
-	}, {
 		query:      `ok @thing`,
 		protocol:   search.Streaming,
-		searchType: query.SearchTypeLiteral,
+		searchType: query.SearchTypeLiteralDefault,
 		want: autogold.Want("supported repo job literal", `
 (ALERT
   (TIMEOUT
@@ -279,11 +257,90 @@ func TestNewPlanJob(t *testing.T) {
           REPOPAGER
             SymbolSearcherJob)
           RepoSearchJob)))))`),
+	}, {
+		query:      `(type:commit or type:diff) (a or b)`,
+		protocol:   search.Streaming,
+		searchType: query.SearchTypeRegex,
+		// TODO this output doesn't look right. There shouldn't be any zoekt or repo jobs
+		want: autogold.Want("complex commit diff", `
+(ALERT
+  (OR
+    (TIMEOUT
+      20s
+      (LIMIT
+        500
+        (PARALLEL
+          CommitSearchJob
+          ComputeExcludedReposJob
+          (OR
+            NoopJob
+            NoopJob))))
+    (TIMEOUT
+      20s
+      (LIMIT
+        500
+        (PARALLEL
+          DiffSearchJob
+          ComputeExcludedReposJob
+          (OR
+            NoopJob
+            NoopJob))))))`),
+	}, {
+		query:      `(type:repo a) or (type:file b)`,
+		protocol:   search.Streaming,
+		searchType: query.SearchTypeRegex,
+		want: autogold.Want("disjunct types", `
+(ALERT
+  (OR
+    (TIMEOUT
+      20s
+      (LIMIT
+        500
+        (PARALLEL
+          ComputeExcludedReposJob
+          RepoSearchJob)))
+    (TIMEOUT
+      20s
+      (LIMIT
+        500
+        (PARALLEL
+          ZoektGlobalSearchJob
+          ComputeExcludedReposJob
+          NoopJob)))))`),
+	}, {
+		query:      `type:symbol a or b`,
+		protocol:   search.Streaming,
+		searchType: query.SearchTypeRegex,
+		want: autogold.Want("symbol with or", `
+(ALERT
+  (TIMEOUT
+    20s
+    (LIMIT
+      500
+      (PARALLEL
+        RepoUniverseSymbolSearchJob
+        ComputeExcludedReposJob
+        (OR
+          NoopJob
+          NoopJob)))))`),
 	}}
 
 	for _, tc := range cases {
 		t.Run(tc.want.Name(), func(t *testing.T) {
-			tc.want.Equal(t, test(t, tc.query, tc.protocol, tc.searchType))
+			plan, err := query.Pipeline(query.Init(tc.query, tc.searchType))
+			require.NoError(t, err)
+
+			inputs := &run.SearchInputs{
+				UserSettings:        &schema.Settings{},
+				PatternType:         query.SearchTypeLiteralDefault,
+				Protocol:            tc.protocol,
+				OnSourcegraphDotCom: true,
+			}
+
+			j, err := NewPlanJob(inputs, plan)
+			require.NoError(t, err)
+
+			tc.want.Equal(t, "\n"+PrettySexp(j))
 		})
 	}
 }

--- a/internal/search/job/jobutil/job_test.go
+++ b/internal/search/job/jobutil/job_test.go
@@ -25,7 +25,7 @@ func TestToSearchInputs(t *testing.T) {
 			OnSourcegraphDotCom: true,
 		}
 
-		j, _ := ToSearchJob(inputs, b)
+		j, _ := NewFlatJob(inputs, b)
 		return "\n" + PrettySexp(j) + "\n"
 	}
 

--- a/internal/search/job/jobutil/printers_test.go
+++ b/internal/search/job/jobutil/printers_test.go
@@ -174,7 +174,7 @@ func TestPrettyJSON(t *testing.T) {
 			UserSettings: &schema.Settings{},
 			Protocol:     search.Streaming,
 		}
-		j, _ := ToSearchJob(inputs, b)
+		j, _ := NewFlatJob(inputs, b)
 		return PrettyJSONVerbose(j)
 	}
 

--- a/internal/search/job/jobutil/printers_test.go
+++ b/internal/search/job/jobutil/printers_test.go
@@ -174,72 +174,121 @@ func TestPrettyJSON(t *testing.T) {
 			UserSettings: &schema.Settings{},
 			Protocol:     search.Streaming,
 		}
-		j, _ := NewFlatJob(inputs, b)
+		j, _ := NewBasicJob(inputs, b)
 		return PrettyJSONVerbose(j)
 	}
 
 	autogold.Want("full fidelity JSON output", `
 {
-  "PARALLEL": [
-    {
-      "REPOPAGER": {
-        "SearcherJob": {
-          "PatternInfo": {
-            "Pattern": "bar",
-            "IsNegated": false,
-            "IsRegExp": true,
-            "IsStructuralPat": false,
-            "CombyRule": "",
-            "IsWordMatch": false,
-            "IsCaseSensitive": false,
-            "FileMatchLimit": 500,
-            "Index": "yes",
-            "Select": [],
-            "IncludePatterns": null,
-            "ExcludePattern": "",
-            "FilePatternsReposMustInclude": null,
-            "FilePatternsReposMustExclude": null,
-            "PathPatternsAreCaseSensitive": false,
-            "PatternMatchesContent": true,
-            "PatternMatchesPath": true,
-            "Languages": null
-          },
-          "Repos": null,
-          "Indexed": false,
-          "UseFullDeadline": true
+  "TIMEOUT": {
+    "LIMIT": {
+      "PARALLEL": [
+        {
+          "REPOPAGER": {
+            "ZoektRepoSubsetSearchJob": {
+              "Repos": null,
+              "Query": {
+                "Pattern": "bar",
+                "CaseSensitive": false,
+                "FileName": false,
+                "Content": false
+              },
+              "Typ": "text",
+              "FileMatchLimit": 500,
+              "Select": []
+            }
+          }
+        },
+        {
+          "ComputeExcludedReposJob": {
+            "RepoOpts": {
+              "RepoFilters": [
+                "foo"
+              ],
+              "MinusRepoFilters": null,
+              "Dependencies": null,
+              "CaseSensitiveRepoFilters": false,
+              "SearchContextSpec": "",
+              "CommitAfter": "",
+              "Visibility": "Any",
+              "Limit": 0,
+              "Cursors": null,
+              "ForkSet": false,
+              "NoForks": true,
+              "OnlyForks": false,
+              "ArchivedSet": false,
+              "NoArchived": true,
+              "OnlyArchived": false
+            }
+          }
+        },
+        {
+          "PARALLEL": [
+            {
+              "REPOPAGER": {
+                "SearcherJob": {
+                  "PatternInfo": {
+                    "Pattern": "bar",
+                    "IsNegated": false,
+                    "IsRegExp": true,
+                    "IsStructuralPat": false,
+                    "CombyRule": "",
+                    "IsWordMatch": false,
+                    "IsCaseSensitive": false,
+                    "FileMatchLimit": 500,
+                    "Index": "yes",
+                    "Select": [],
+                    "IncludePatterns": null,
+                    "ExcludePattern": "",
+                    "FilePatternsReposMustInclude": null,
+                    "FilePatternsReposMustExclude": null,
+                    "PathPatternsAreCaseSensitive": false,
+                    "PatternMatchesContent": true,
+                    "PatternMatchesPath": true,
+                    "Languages": null
+                  },
+                  "Repos": null,
+                  "Indexed": false,
+                  "UseFullDeadline": true
+                }
+              }
+            },
+            {
+              "RepoSearchJob": {
+                "RepoOpts": {
+                  "RepoFilters": [
+                    "foo",
+                    "bar"
+                  ],
+                  "MinusRepoFilters": null,
+                  "Dependencies": null,
+                  "CaseSensitiveRepoFilters": false,
+                  "SearchContextSpec": "",
+                  "CommitAfter": "",
+                  "Visibility": "Any",
+                  "Limit": 0,
+                  "Cursors": null,
+                  "ForkSet": false,
+                  "NoForks": true,
+                  "OnlyForks": false,
+                  "ArchivedSet": false,
+                  "NoArchived": true,
+                  "OnlyArchived": false
+                },
+                "FilePatternsReposMustInclude": null,
+                "FilePatternsReposMustExclude": null,
+                "Features": {
+                  "ContentBasedLangFilters": false
+                },
+                "Mode": 0
+              }
+            }
+          ]
         }
-      }
+      ]
     },
-    {
-      "RepoSearchJob": {
-        "RepoOpts": {
-          "RepoFilters": [
-            "foo",
-            "bar"
-          ],
-          "MinusRepoFilters": null,
-          "Dependencies": null,
-          "CaseSensitiveRepoFilters": false,
-          "SearchContextSpec": "",
-          "CommitAfter": "",
-          "Visibility": "Any",
-          "Limit": 0,
-          "Cursors": null,
-          "ForkSet": false,
-          "NoForks": true,
-          "OnlyForks": false,
-          "ArchivedSet": false,
-          "NoArchived": true,
-          "OnlyArchived": false
-        },
-        "FilePatternsReposMustInclude": null,
-        "FilePatternsReposMustExclude": null,
-        "Features": {
-          "ContentBasedLangFilters": false
-        },
-        "Mode": 0
-      }
-    }
-  ]
+    "value": 500
+  },
+  "value": "20s"
 }`).Equal(t, fmt.Sprintf("\n%s", test("repo:foo bar")))
 }

--- a/internal/search/predicate/substitute.go
+++ b/internal/search/predicate/substitute.go
@@ -38,7 +38,7 @@ func Expand(ctx context.Context, clients job.RuntimeClients, inputs *run.SearchI
 		q := q
 		g.Go(func() error {
 			predicatePlan, err := Substitute(q, func(plan query.Plan) (result.Matches, error) {
-				predicateJob, err := jobutil.FromExpandedPlan(inputs, plan)
+				predicateJob, err := jobutil.NewPlanJob(inputs, plan)
 				if err != nil {
 					return nil, err
 				}

--- a/internal/search/predicate/substitute_test.go
+++ b/internal/search/predicate/substitute_test.go
@@ -105,7 +105,7 @@ func TestSubstitute(t *testing.T) {
 		plan, _ := Substitute(b, func(p query.Plan) (result.Matches, error) {
 			return []result.Match{&result.RepoMatch{Name: "contains-foo"}}, nil
 		})
-		return query.StringHuman(plan.ToParseTree())
+		return query.StringHuman(plan.ToQ())
 	}
 
 	autogold.Want("predicate that generates a plan is replaced by values",

--- a/internal/search/query/query_test.go
+++ b/internal/search/query/query_test.go
@@ -10,7 +10,7 @@ import (
 func TestPipelineStructural(t *testing.T) {
 	test := func(input string) string {
 		pipelinePlan, _ := Pipeline(InitStructural(input))
-		return pipelinePlan.ToParseTree().String()
+		return pipelinePlan.ToQ().String()
 	}
 
 	autogold.Want("contains(...) spans newlines", `"repo:contains.file(\nfoo\n)"`).Equal(t, test("repo:contains.file(\nfoo\n)"))
@@ -39,9 +39,9 @@ func TestSubstituteSearchContexts(t *testing.T) {
 		}
 
 		if verbose {
-			return jsonFormatted(plan.ToParseTree())
+			return jsonFormatted(plan.ToQ())
 		}
-		return plan.ToParseTree().String()
+		return plan.ToQ().String()
 	}
 
 	autogold.Want("failing", `(or (and "repo:primary" "repo:protobuf" "select:repo") (and "repo:secondary" "repo:protobuf" "select:repo") (and "repo:primary" "repo:PROTOBUF" "select:repo") (and "repo:secondary" "repo:PROTOBUF" "select:repo"))`).Equal(t, test("context:go-deps (r:protobuf OR r:PROTOBUF) select:repo", false))

--- a/internal/search/query/transformer_test.go
+++ b/internal/search/query/transformer_test.go
@@ -459,7 +459,7 @@ func TestPipeline(t *testing.T) {
 		t.Run("Map query", func(t *testing.T) {
 			plan, err := Pipeline(Init(c.input, SearchTypeLiteralDefault))
 			require.NoError(t, err)
-			got := plan.ToParseTree().String()
+			got := plan.ToQ().String()
 			if diff := cmp.Diff(c.want, got); diff != "" {
 				t.Fatal(diff)
 			}
@@ -941,7 +941,7 @@ func TestConcatRevFiltersTopLevelAnd(t *testing.T) {
 		t.Run(c.input, func(t *testing.T) {
 			plan, _ := Pipeline(InitRegexp(c.input))
 			p := MapPlan(plan, ConcatRevFilters)
-			if diff := cmp.Diff(c.want, toString(p.ToParseTree())); diff != "" {
+			if diff := cmp.Diff(c.want, toString(p.ToQ())); diff != "" {
 				t.Error(diff)
 			}
 		})

--- a/internal/search/query/types.go
+++ b/internal/search/query/types.go
@@ -172,8 +172,8 @@ func (q Q) MaxResults(defaultLimit int) int {
 // execute. The result of executing a plan is the union of individual query results.
 type Plan []Basic
 
-// ToParseTree models a plan as a parse tree of an Or-expression on plan queries.
-func (p Plan) ToParseTree() Q {
+// ToQ models a plan as a parse tree of an Or-expression on plan queries.
+func (p Plan) ToQ() Q {
 	nodes := make([]Node, 0, len(p))
 	for _, basic := range p {
 		operands := basic.ToParseTree()

--- a/internal/search/query/types.go
+++ b/internal/search/query/types.go
@@ -444,8 +444,8 @@ func (p Parameters) FindParameter(field string, f func(value string, negated boo
 	}
 }
 
-// Flat is a more restricted form of Basic that has exactly one atomic pattern
-// node. This is used to
+// Flat is a more restricted form of Basic that has exactly zero or one atomic
+// pattern nodes.
 type Flat struct {
 	Parameters
 	Pattern *Pattern

--- a/internal/search/query/types.go
+++ b/internal/search/query/types.go
@@ -61,6 +61,19 @@ func (p Plan) ToParseTree() Q {
 	return Q(newOperator(nodes, Or))
 }
 
+type Flat struct {
+	Parameters
+	Pattern *Pattern
+}
+
+func (f *Flat) ToBasic() Basic {
+	var pattern Node
+	if f.Pattern != nil {
+		pattern = *f.Pattern
+	}
+	return Basic{Parameters: f.Parameters, Pattern: pattern}
+}
+
 // Basic represents a leaf expression to evaluate in our search engine. A basic
 // query comprises:
 //   (1) a single search pattern expression, which may contain

--- a/internal/search/run/run.go
+++ b/internal/search/run/run.go
@@ -90,7 +90,7 @@ func NewSearchInputs(
 
 	inputs := &SearchInputs{
 		Plan:                plan,
-		Query:               plan.ToParseTree(),
+		Query:               plan.ToQ(),
 		OriginalQuery:       searchQuery,
 		UserSettings:        settings,
 		OnSourcegraphDotCom: sourcegraphDotComMode,

--- a/internal/search/searchcontexts/search_contexts.go
+++ b/internal/search/searchcontexts/search_contexts.go
@@ -201,7 +201,7 @@ func validateSearchContextQuery(contextQuery string) error {
 		return err
 	}
 
-	q := plan.ToParseTree()
+	q := plan.ToQ()
 	var errs error
 
 	query.VisitParameter(q, func(field, value string, negated bool, a query.Annotation) {


### PR DESCRIPTION
This is a followup from https://github.com/sourcegraph/sourcegraph/pull/35241 that takes the new changes and updates the code with some renames and reorganizations that take advantage of the new structure. 

Stacked on #35241

Basic summary of the changes:
- We now have `query.Q > query.Basic > query.Flat`
- We have associated functions `NewJob`, `NewBasicJob`, and `NewFlatJob`
- Reorganizations try to make associated files hierarchical
- Comments are updated
- The method `ToParseTree` is renamed to `ToQ` to parallel `ToBasic`
- Updated tests to use `NewJob` so we have autogold tests that capture the full job tree rather than just a subtree. 

Each commit is atomic, self-describing, and passes tests. 

## Test plan

I added a few tests and updated tests to capture the broader behavior. All the changes should be semantics-preserving and just narrow types, reorganize, or rename.

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


