### PR TITLE
search: rename literal search type to default

### DIFF
--- a/cmd/frontend/graphqlbackend/parse_search_query.go
+++ b/cmd/frontend/graphqlbackend/parse_search_query.go
@@ -76,13 +76,13 @@ func (r *schemaResolver) ParseSearchQuery(ctx context.Context, args *struct {
 	var searchType query.SearchType
 	switch args.PatternType {
 	case "literal":
-		searchType = query.SearchTypeLiteral
+		searchType = query.SearchTypeLiteralDefault
 	case "structural":
 		searchType = query.SearchTypeStructural
 	case "regexp", "regex":
 		searchType = query.SearchTypeRegex
 	default:
-		searchType = query.SearchTypeLiteral
+		searchType = query.SearchTypeLiteralDefault
 	}
 
 	plan, err := query.Pipeline(query.Init(args.Query, searchType))

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -375,7 +375,7 @@ func LogSearchLatency(ctx context.Context, db database.DB, wg *sync.WaitGroup, s
 			switch {
 			case si.PatternType == query.SearchTypeStructural:
 				types = append(types, "structural")
-			case si.PatternType == query.SearchTypeLiteral:
+			case si.PatternType == query.SearchTypeLiteralDefault:
 				types = append(types, "literal")
 			case si.PatternType == query.SearchTypeRegex:
 				types = append(types, "regexp")

--- a/cmd/frontend/internal/search/search_test.go
+++ b/cmd/frontend/internal/search/search_test.go
@@ -118,7 +118,7 @@ func TestDisplayLimit(t *testing.T) {
 			mockInput := make(chan streaming.SearchEvent)
 			mock := client.NewMockSearchClient()
 			mock.PlanFunc.SetDefaultHook(func(_ context.Context, _ string, _ *string, queryString string, _ search.Protocol, _ *schema.Settings, _ bool) (*run.SearchInputs, error) {
-				q, err := query.Parse(queryString, query.SearchTypeLiteral)
+				q, err := query.Parse(queryString, query.SearchTypeLiteralDefault)
 				require.NoError(t, err)
 				return &run.SearchInputs{
 					Query: q,

--- a/enterprise/internal/codemonitors/search_test.go
+++ b/enterprise/internal/codemonitors/search_test.go
@@ -68,7 +68,7 @@ func TestAddCodeMonitorHook(t *testing.T) {
 			require.NoError(t, err)
 			inputs := &run.SearchInputs{
 				UserSettings:        &schema.Settings{},
-				PatternType:         query.SearchTypeLiteral,
+				PatternType:         query.SearchTypeLiteralDefault,
 				Protocol:            search.Streaming,
 				OnSourcegraphDotCom: true,
 			}

--- a/internal/search/alert.go
+++ b/internal/search/alert.go
@@ -56,7 +56,7 @@ func (q *ProposedQuery) QueryString() string {
 		switch q.PatternType {
 		case query.SearchTypeRegex:
 			return q.Query + " patternType:regexp"
-		case query.SearchTypeLiteral:
+		case query.SearchTypeLiteralDefault:
 			return q.Query + " patternType:literal"
 		case query.SearchTypeStructural:
 			return q.Query + " patternType:structural"

--- a/internal/search/job/jobutil/job_test.go
+++ b/internal/search/job/jobutil/job_test.go
@@ -20,7 +20,7 @@ func TestToSearchInputs(t *testing.T) {
 		require.NoError(t, err)
 		inputs := &run.SearchInputs{
 			UserSettings:        &schema.Settings{},
-			PatternType:         query.SearchTypeLiteral,
+			PatternType:         query.SearchTypeLiteralDefault,
 			Protocol:            protocol,
 			OnSourcegraphDotCom: true,
 		}
@@ -171,7 +171,7 @@ func TestToEvaluateJob(t *testing.T) {
 		q, _ := query.ParseLiteral(input)
 		inputs := &run.SearchInputs{
 			UserSettings:        &schema.Settings{},
-			PatternType:         query.SearchTypeLiteral,
+			PatternType:         query.SearchTypeLiteralDefault,
 			Protocol:            protocol,
 			OnSourcegraphDotCom: true,
 		}
@@ -201,7 +201,7 @@ func Test_optimizeJobs(t *testing.T) {
 		plan, _ := query.Pipeline(query.InitLiteral(input))
 		inputs := &run.SearchInputs{
 			UserSettings:        &schema.Settings{},
-			PatternType:         query.SearchTypeLiteral,
+			PatternType:         query.SearchTypeLiteralDefault,
 			Protocol:            search.Streaming,
 			OnSourcegraphDotCom: true,
 		}
@@ -386,7 +386,7 @@ func TestToTextPatternInfo(t *testing.T) {
 	}}
 
 	test := func(input string) string {
-		searchType := overrideSearchType(input, query.SearchTypeLiteral)
+		searchType := overrideSearchType(input, query.SearchTypeLiteralDefault)
 		plan, err := query.Pipeline(query.Init(input, searchType))
 		if err != nil {
 			return "Error"
@@ -397,7 +397,7 @@ func TestToTextPatternInfo(t *testing.T) {
 		b := plan[0]
 		types, _ := b.ToParseTree().StringValues(query.FieldType)
 		mode := search.Batch
-		resultTypes := computeResultTypes(types, b, query.SearchTypeLiteral)
+		resultTypes := computeResultTypes(types, b, query.SearchTypeLiteralDefault)
 		p := toTextPatternInfo(b, resultTypes, mode)
 		v, _ := json.Marshal(p)
 		return string(v)
@@ -411,7 +411,7 @@ func TestToTextPatternInfo(t *testing.T) {
 }
 
 func overrideSearchType(input string, searchType query.SearchType) query.SearchType {
-	q, err := query.Parse(input, query.SearchTypeLiteral)
+	q, err := query.Parse(input, query.SearchTypeLiteralDefault)
 	q = query.LowercaseFieldNames(q)
 	if err != nil {
 		// If parsing fails, return the default search type. Any actual
@@ -423,7 +423,7 @@ func overrideSearchType(input string, searchType query.SearchType) query.SearchT
 		case "regex", "regexp":
 			searchType = query.SearchTypeRegex
 		case "literal":
-			searchType = query.SearchTypeLiteral
+			searchType = query.SearchTypeLiteralDefault
 		case "structural":
 			searchType = query.SearchTypeStructural
 		}

--- a/internal/search/query/parser.go
+++ b/internal/search/query/parser.go
@@ -1164,7 +1164,7 @@ func Parse(in string, searchType SearchType) ([]Node, error) {
 			nodes = hoistedNodes
 		}
 	}
-	if searchType == SearchTypeLiteral {
+	if searchType == SearchTypeLiteralDefault {
 		err = validatePureLiteralPattern(nodes, parser.balanced == 0)
 		if err != nil {
 			return nil, err
@@ -1178,7 +1178,7 @@ func ParseSearchType(in string, searchType SearchType) (Q, error) {
 }
 
 func ParseLiteral(in string) (Q, error) {
-	return Run(Init(in, SearchTypeLiteral))
+	return Run(Init(in, SearchTypeLiteralDefault))
 }
 
 func ParseRegexp(in string) (Q, error) {

--- a/internal/search/query/parser_test.go
+++ b/internal/search/query/parser_test.go
@@ -607,7 +607,7 @@ func TestMatchUnaryKeyword(t *testing.T) {
 
 func TestParseAndOrLiteral(t *testing.T) {
 	test := func(input string) string {
-		result, err := Parse(input, SearchTypeLiteral)
+		result, err := Parse(input, SearchTypeLiteralDefault)
 		if err != nil {
 			return fmt.Sprintf("ERROR: %s", err.Error())
 		}

--- a/internal/search/query/query.go
+++ b/internal/search/query/query.go
@@ -93,7 +93,7 @@ func SubstituteSearchContexts(lookupQueryString func(contextValue string) (strin
 func For(searchType SearchType) step {
 	var processType step
 	switch searchType {
-	case SearchTypeLiteral:
+	case SearchTypeLiteralDefault:
 		processType = succeeds(substituteConcat(space))
 	case SearchTypeRegex:
 		processType = succeeds(escapeParensHeuristic, substituteConcat(fuzzyRegexp))
@@ -115,7 +115,7 @@ func Init(in string, searchType SearchType) step {
 
 // InitLiteral is Init where SearchType is Literal.
 func InitLiteral(in string) step {
-	return Init(in, SearchTypeLiteral)
+	return Init(in, SearchTypeLiteralDefault)
 }
 
 // InitRegexp is Init where SearchType is Regex.

--- a/internal/search/query/transformer_test.go
+++ b/internal/search/query/transformer_test.go
@@ -97,12 +97,12 @@ func TestSubstituteAliases(t *testing.T) {
 	autogold.Want(
 		"substitution honors literal search pattern",
 		`[{"and":[{"field":"repo","value":"repo","negated":false,"labels":["IsAlias"]},{"value":"^not-actually-a-regexp:tbf$","negated":false,"labels":["IsAlias","Literal"]}]}]`).
-		Equal(t, test("r:repo content:^not-actually-a-regexp:tbf$", SearchTypeLiteral))
+		Equal(t, test("r:repo content:^not-actually-a-regexp:tbf$", SearchTypeLiteralDefault))
 
 	autogold.Want(
 		"substitution honors path",
 		`[{"field":"file","value":"foo","negated":false,"labels":["IsAlias"]}]`).
-		Equal(t, test("path:foo", SearchTypeLiteral))
+		Equal(t, test("path:foo", SearchTypeLiteralDefault))
 }
 
 func TestLowercaseFieldNames(t *testing.T) {
@@ -457,7 +457,7 @@ func TestPipeline(t *testing.T) {
 	}}
 	for _, c := range cases {
 		t.Run("Map query", func(t *testing.T) {
-			plan, err := Pipeline(Init(c.input, SearchTypeLiteral))
+			plan, err := Pipeline(Init(c.input, SearchTypeLiteralDefault))
 			require.NoError(t, err)
 			got := plan.ToParseTree().String()
 			if diff := cmp.Diff(c.want, got); diff != "" {
@@ -960,7 +960,7 @@ func TestQueryField(t *testing.T) {
 
 func TestSubstituteCountAll(t *testing.T) {
 	test := func(input string) string {
-		query, _ := Parse(input, SearchTypeLiteral)
+		query, _ := Parse(input, SearchTypeLiteralDefault)
 		q := SubstituteCountAll(query)
 		return toString(q)
 	}

--- a/internal/search/query/types.go
+++ b/internal/search/query/types.go
@@ -30,7 +30,7 @@ type SearchType int
 
 const (
 	SearchTypeRegex SearchType = iota
-	SearchTypeLiteral
+	SearchTypeLiteralDefault
 	SearchTypeStructural
 )
 
@@ -38,7 +38,7 @@ func (s SearchType) String() string {
 	switch s {
 	case SearchTypeRegex:
 		return "regex"
-	case SearchTypeLiteral:
+	case SearchTypeLiteralDefault:
 		return "literal"
 	case SearchTypeStructural:
 		return "structural"

--- a/internal/search/query/validate_test.go
+++ b/internal/search/query/validate_test.go
@@ -315,7 +315,7 @@ func TestContainsRefGlobs(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.input, func(t *testing.T) {
 			query, err := Run(sequence(
-				Init(c.input, SearchTypeLiteral),
+				Init(c.input, SearchTypeLiteralDefault),
 				Globbing,
 			))
 			if err != nil {

--- a/internal/search/run/run.go
+++ b/internal/search/run/run.go
@@ -123,7 +123,7 @@ func detectSearchType(version string, patternType *string) (query.SearchType, er
 	if patternType != nil {
 		switch *patternType {
 		case "literal":
-			searchType = query.SearchTypeLiteral
+			searchType = query.SearchTypeLiteralDefault
 		case "regexp":
 			searchType = query.SearchTypeRegex
 		case "structural":
@@ -136,7 +136,7 @@ func detectSearchType(version string, patternType *string) (query.SearchType, er
 		case "V1":
 			searchType = query.SearchTypeRegex
 		case "V2":
-			searchType = query.SearchTypeLiteral
+			searchType = query.SearchTypeLiteralDefault
 		default:
 			return -1, errors.Errorf("unrecognized version: want \"V1\" or \"V2\", got %q", version)
 		}
@@ -145,7 +145,7 @@ func detectSearchType(version string, patternType *string) (query.SearchType, er
 }
 
 func overrideSearchType(input string, searchType query.SearchType) query.SearchType {
-	q, err := query.Parse(input, query.SearchTypeLiteral)
+	q, err := query.Parse(input, query.SearchTypeLiteralDefault)
 	q = query.LowercaseFieldNames(q)
 	if err != nil {
 		// If parsing fails, return the default search type. Any actual
@@ -157,7 +157,7 @@ func overrideSearchType(input string, searchType query.SearchType) query.SearchT
 		case "regex", "regexp":
 			searchType = query.SearchTypeRegex
 		case "literal":
-			searchType = query.SearchTypeLiteral
+			searchType = query.SearchTypeLiteralDefault
 		case "structural":
 			searchType = query.SearchTypeStructural
 		}

--- a/internal/search/run/run_test.go
+++ b/internal/search/run/run_test.go
@@ -19,17 +19,17 @@ func TestDetectSearchType(t *testing.T) {
 		want        query.SearchType
 	}{
 		{"V1, no pattern type", "V1", nil, "", query.SearchTypeRegex},
-		{"V2, no pattern type", "V2", nil, "", query.SearchTypeLiteral},
-		{"V2, no pattern type, input does not produce parse error", "V2", nil, "/-/godoc", query.SearchTypeLiteral},
+		{"V2, no pattern type", "V2", nil, "", query.SearchTypeLiteralDefault},
+		{"V2, no pattern type, input does not produce parse error", "V2", nil, "/-/godoc", query.SearchTypeLiteralDefault},
 		{"V1, regexp pattern type", "V1", &typeRegexp, "", query.SearchTypeRegex},
 		{"V2, regexp pattern type", "V2", &typeRegexp, "", query.SearchTypeRegex},
-		{"V1, literal pattern type", "V1", &typeLiteral, "", query.SearchTypeLiteral},
+		{"V1, literal pattern type", "V1", &typeLiteral, "", query.SearchTypeLiteralDefault},
 		{"V2, override regexp pattern type", "V2", &typeLiteral, "patterntype:regexp", query.SearchTypeRegex},
 		{"V2, override regex variant pattern type", "V2", &typeLiteral, "patterntype:regex", query.SearchTypeRegex},
 		{"V2, override regex variant pattern type with double quotes", "V2", &typeLiteral, `patterntype:"regex"`, query.SearchTypeRegex},
 		{"V2, override regex variant pattern type with single quotes", "V2", &typeLiteral, `patterntype:'regex'`, query.SearchTypeRegex},
-		{"V1, override literal pattern type", "V1", &typeRegexp, "patterntype:literal", query.SearchTypeLiteral},
-		{"V1, override literal pattern type, with case-insensitive query", "V1", &typeRegexp, "pAtTErNTypE:literal", query.SearchTypeLiteral},
+		{"V1, override literal pattern type", "V1", &typeRegexp, "patterntype:literal", query.SearchTypeLiteralDefault},
+		{"V1, override literal pattern type, with case-insensitive query", "V1", &typeRegexp, "pAtTErNTypE:literal", query.SearchTypeLiteralDefault},
 	}
 
 	for _, test := range testCases {

--- a/internal/search/zoekt/query_test.go
+++ b/internal/search/zoekt/query_test.go
@@ -142,15 +142,15 @@ func Test_toZoektPattern(t *testing.T) {
 
 	autogold.Want("basic string",
 		`substr:"a"`).
-		Equal(t, test(`a`, query.SearchTypeLiteral, search.TextRequest))
+		Equal(t, test(`a`, query.SearchTypeLiteralDefault, search.TextRequest))
 
 	autogold.Want("basic and-expression",
 		`(or (and substr:"a" substr:"b" (not substr:"c")) substr:"d")`).
-		Equal(t, test(`a and b and not c or d`, query.SearchTypeLiteral, search.TextRequest))
+		Equal(t, test(`a and b and not c or d`, query.SearchTypeLiteralDefault, search.TextRequest))
 
 	autogold.Want("quoted string in literal escapes quotes (regexp meta and string escaping)",
 		`substr:"\"func main() {\\n\""`).
-		Equal(t, test(`"func main() {\n"`, query.SearchTypeLiteral, search.TextRequest))
+		Equal(t, test(`"func main() {\n"`, query.SearchTypeLiteralDefault, search.TextRequest))
 
 	autogold.Want("quoted string in regexp interpreted as string (regexp meta escaped)",
 		`substr:"func main() {\n"`).
@@ -158,7 +158,7 @@ func Test_toZoektPattern(t *testing.T) {
 
 	autogold.Want("zoekt symbol nodes are atoms",
 		`(and sym:substr:"foo" (not sym:substr:"bar"))`).
-		Equal(t, test(`type:symbol (foo and not bar)`, query.SearchTypeLiteral, search.SymbolRequest))
+		Equal(t, test(`type:symbol (foo and not bar)`, query.SearchTypeLiteralDefault, search.SymbolRequest))
 }
 
 func queryEqual(a, b zoekt.Q) bool {


### PR DESCRIPTION
Setup for supporting `/<regex>/` syntax in "literal" (now default) search. Don't want to call it `SearchTypeDefault` yet since we have a GQL value tied to this called "literal" that we can't/shouldn't change for compat reasons.

Context: [RFC 675](https://docs.google.com/document/d/1KebTihO_jrPcLblgeT4X428kfgs42NkFz_3kCr8bT0M/edit#heading=h.hbwoxn8m6e4u)

## Test plan
Semantics-preserving


