### PR TITLE
compute: add diff result type

### DIFF
--- a/enterprise/cmd/frontend/internal/compute/streaming/compute.go
+++ b/enterprise/cmd/frontend/internal/compute/streaming/compute.go
@@ -16,7 +16,7 @@ import (
 func toComputeResultStream(ctx context.Context, db database.DB, cmd compute.Command, matches []result.Match, f func(compute.Result)) error {
 	for _, m := range matches {
 		if v, ok := m.(*result.CommitMatch); ok && v.DiffPreview != nil {
-			for _, diffMatch := range v.ToDiffMatches() {
+			for _, diffMatch := range v.CommitToDiffMatches() {
 				result, err := cmd.Run(ctx, db, diffMatch)
 				if err != nil {
 					return err

--- a/enterprise/internal/compute/output_command.go
+++ b/enterprise/internal/compute/output_command.go
@@ -75,6 +75,14 @@ func resultContent(ctx context.Context, db database.DB, r result.Match, onlyPath
 			return "", false, err
 		}
 		return string(contentBytes), true, nil
+	case *result.CommitDiffMatch:
+		var sb strings.Builder
+		for _, h := range m.Hunks {
+			for _, l := range h.Lines {
+				sb.WriteString(l)
+			}
+		}
+		return sb.String(), true, nil
 	case *result.CommitMatch:
 		var content string
 		if m.DiffPreview != nil {

--- a/enterprise/internal/compute/template.go
+++ b/enterprise/internal/compute/template.go
@@ -267,6 +267,19 @@ func NewMetaEnvironment(r result.Match, content string) *MetaEnvironment {
 			Email:   m.Commit.Author.Email,
 			Content: content,
 		}
+	case *result.CommitDiffMatch:
+		path := m.Path()
+		lang, _ := enry.GetLanguageByExtension(path)
+		return &MetaEnvironment{
+			Repo:    string(m.Repo.Name),
+			Commit:  string(m.Commit.ID),
+			Author:  m.Commit.Author.Name,
+			Date:    m.Commit.Committer.Date.Format("2006-01-02"),
+			Email:   m.Commit.Author.Email,
+			Path:    path,
+			Lang:    lang,
+			Content: content,
+		}
 	}
 	return &MetaEnvironment{}
 }

--- a/internal/search/result/commit.go
+++ b/internal/search/result/commit.go
@@ -243,3 +243,25 @@ func selectCommitDiffKind(diffPreview *MatchedString, field string) *MatchedStri
 }
 
 func (r *CommitMatch) searchResultMarker() {}
+
+// ToDiffMatch is a helper function to narrow a CommitMatch to a a set of
+// CommitDiffMatch. Callers should validate whether a CommitMatch can be
+// converted. In time, we should directly create CommitDiffMatch and this helper
+// function should not, ideally, exist.
+func (r *CommitMatch) ToDiffMatches() []*CommitDiffMatch {
+	var matches []*CommitDiffMatch
+	fileDiffs, err := ParseDiffString(r.DiffPreview.Content)
+	if err != nil {
+		return nil
+	}
+	for _, diff := range fileDiffs {
+		diff := diff
+		matches = append(matches, &CommitDiffMatch{
+			Commit:   r.Commit,
+			Repo:     r.Repo,
+			Preview:  r.DiffPreview,
+			DiffFile: &diff,
+		})
+	}
+	return matches
+}

--- a/internal/search/result/commit.go
+++ b/internal/search/result/commit.go
@@ -244,11 +244,11 @@ func selectCommitDiffKind(diffPreview *MatchedString, field string) *MatchedStri
 
 func (r *CommitMatch) searchResultMarker() {}
 
-// ToDiffMatch is a helper function to narrow a CommitMatch to a a set of
+// CommitToDiffMatches is a helper function to narrow a CommitMatch to a a set of
 // CommitDiffMatch. Callers should validate whether a CommitMatch can be
 // converted. In time, we should directly create CommitDiffMatch and this helper
 // function should not, ideally, exist.
-func (r *CommitMatch) ToDiffMatches() []*CommitDiffMatch {
+func (r *CommitMatch) CommitToDiffMatches() []*CommitDiffMatch {
 	var matches []*CommitDiffMatch
 	fileDiffs, err := ParseDiffString(r.DiffPreview.Content)
 	if err != nil {

--- a/internal/search/result/commit_diff.go
+++ b/internal/search/result/commit_diff.go
@@ -1,0 +1,215 @@
+package result
+
+import (
+	"errors"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
+	"github.com/sourcegraph/sourcegraph/internal/search/filter"
+	"github.com/sourcegraph/sourcegraph/internal/types"
+)
+
+type CommitDiffMatch struct {
+	Commit  gitdomain.Commit
+	Repo    types.MinimalRepo
+	Preview *MatchedString
+	*DiffFile
+}
+
+func (cd *CommitDiffMatch) RepoName() types.MinimalRepo {
+	return cd.Repo
+}
+
+// Path returns a nonempty path associated with a diff. This value is the usual
+// path when the associated file is modified. When it is created or removed, it
+// returns the path of the associated file being created or removed.
+func (cm *CommitDiffMatch) Path() string {
+	var nonEmptyPath string
+	if cm.OrigName == "/dev/null" {
+		nonEmptyPath = cm.NewName
+	}
+	if cm.NewName == "/dev/null" {
+		nonEmptyPath = cm.OrigName
+	}
+	return nonEmptyPath
+}
+
+func (cm *CommitDiffMatch) PathStatus() PathStatus {
+	if cm.OrigName == "/dev/null" {
+		return Added
+	}
+
+	if cm.NewName == "/dev/null" {
+		return Deleted
+	}
+
+	return Modified
+}
+
+// Key implements Match interface's Key() method
+func (cm *CommitDiffMatch) Key() Key {
+	return Key{
+		TypeRank:   rankDiffMatch,
+		Repo:       cm.Repo.Name,
+		AuthorDate: cm.Commit.Author.Date,
+		Commit:     cm.Commit.ID,
+		Path:       cm.Path(),
+	}
+}
+
+func (cm *CommitDiffMatch) ResultCount() int {
+	matchCount := len(cm.Preview.MatchedRanges)
+	if matchCount > 0 {
+		return matchCount
+	}
+	// Queries such as type:diff after:"1 week ago" don't have highlights. We count
+	// those results as 1.
+	return 1
+}
+
+func (cm *CommitDiffMatch) Limit(limit int) int {
+	limitMatchedString := func(ms *MatchedString) int {
+		if len(ms.MatchedRanges) == 0 {
+			return limit - 1
+		} else if len(ms.MatchedRanges) > limit {
+			ms.MatchedRanges = ms.MatchedRanges[:limit]
+			return 0
+		}
+		return limit - len(ms.MatchedRanges)
+	}
+
+	return limitMatchedString(cm.Preview)
+}
+
+func (cm *CommitDiffMatch) Select(path filter.SelectPath) Match {
+	switch path.Root() {
+	case filter.Repository:
+		return &RepoMatch{
+			Name: cm.Repo.Name,
+			ID:   cm.Repo.ID,
+		}
+	case filter.Commit:
+		fields := path[1:]
+		if len(fields) > 0 && fields[0] == "diff" {
+			if len(fields) == 1 {
+				return cm
+			}
+			if len(fields) == 2 {
+				filteredMatch := selectCommitDiffKind(cm.Preview, fields[1])
+				if filteredMatch == nil {
+					// no result after selecting, propagate no result.
+					return nil
+				}
+				cm.Preview = filteredMatch
+				return cm
+			}
+			return nil
+		}
+		return cm
+	}
+	return nil
+}
+
+func (cm *CommitDiffMatch) searchResultMarker() {}
+
+func ParseDiffString(diff string) (res []DiffFile, err error) {
+	const (
+		INIT = iota
+		IN_DIFF
+		IN_HUNK
+	)
+
+	state := INIT
+	var currentDiff DiffFile
+	var currentHunk Hunk
+	for _, line := range strings.Split(diff, "\n") {
+		if len(line) == 0 {
+			continue
+		}
+		switch state {
+		case INIT:
+			currentDiff.OrigName, currentDiff.NewName, err = splitDiffFiles(line)
+			state = IN_DIFF
+		case IN_DIFF:
+			currentHunk.OldStart, currentHunk.OldCount, currentHunk.NewStart, currentHunk.NewCount, currentHunk.Header, err = parseHunkHeader(line)
+			state = IN_HUNK
+		case IN_HUNK:
+			switch line[0] {
+			case '-', '+', ' ':
+				currentHunk.Lines = append(currentHunk.Lines, line)
+			case '@':
+				currentDiff.Hunks = append(currentDiff.Hunks, currentHunk)
+				currentHunk = Hunk{}
+				currentHunk.OldStart, currentHunk.OldCount, currentHunk.NewStart, currentHunk.NewCount, currentHunk.Header, err = parseHunkHeader(line)
+				state = IN_HUNK
+			default:
+				res = append(res, currentDiff)
+				currentDiff.OrigName, currentDiff.NewName, err = splitDiffFiles(line)
+				state = IN_DIFF
+			}
+		}
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return res, nil
+}
+
+var errInvalidDiff = errors.New("invalid diff format")
+
+func splitDiffFiles(fileLine string) (oldFile, newFile string, err error) {
+	split := strings.Fields(fileLine)
+	if len(split) != 2 {
+		return "", "", errInvalidDiff
+	}
+	return split[0], split[1], nil
+}
+
+var headerRegex = regexp.MustCompile(`@@ -(\d+),(\d+) \+(\d+),(\d+) @@\ ?(.*)`)
+
+func parseHunkHeader(headerLine string) (oldStart, oldCount, newStart, newCount int, header string, err error) {
+	groups := headerRegex.FindStringSubmatch(headerLine)
+	if groups == nil {
+		return 0, 0, 0, 0, "", errInvalidDiff
+	}
+	oldStart, err = strconv.Atoi(groups[1])
+	if err != nil {
+		return 0, 0, 0, 0, "", err
+	}
+	oldCount, err = strconv.Atoi(groups[2])
+	if err != nil {
+		return 0, 0, 0, 0, "", err
+	}
+	newStart, err = strconv.Atoi(groups[3])
+	if err != nil {
+		return 0, 0, 0, 0, "", err
+	}
+	newCount, err = strconv.Atoi(groups[4])
+	if err != nil {
+		return 0, 0, 0, 0, "", err
+	}
+	return oldStart, oldCount, newStart, newCount, groups[5], nil
+}
+
+type DiffFile struct {
+	OrigName, NewName string
+	Hunks             []Hunk
+}
+
+type Hunk struct {
+	OldStart, NewStart int
+	OldCount, NewCount int
+	Header             string
+	Lines              []string
+}
+
+type PathStatus int
+
+const (
+	Modified PathStatus = iota
+	Added
+	Deleted
+)

--- a/internal/search/result/commit_diff_test.go
+++ b/internal/search/result/commit_diff_test.go
@@ -1,0 +1,49 @@
+package result
+
+import (
+	"testing"
+
+	"github.com/hexops/autogold"
+)
+
+func TestParseDiffString(t *testing.T) {
+	input := `client/web/src/enterprise/codeintel/badge/components/IndexerSummary.module.scss client/web/src/enterprise/codeintel/badge/components/IndexerSummary.module.scss
+@@ -1,2 +1,6 @@ ... +1
++.badge-wrapper {
++    font-size: 0.75rem;
++}
++
+ .telemetric-redirect {
+-    display: inline !important;
++    font-size: 0.75rem;
+client/web/src/enterprise/codeintel/badge/components/IndexerSummary.tsx client/web/src/enterprise/codeintel/badge/components/IndexerSummary.tsx
+@@ -57,3 +57,3 @@ export const IndexerSummary: React.FunctionComponent<IndexerSummaryProps> = ({
+     return (
+-        <div className="px-2 py-1">
++        <div className={classNames('px-2 py-1', styles.badgeWrapper)}>
+             <div className="d-flex align-items-center">
+@@ -61,3 +61,3 @@ export const IndexerSummary: React.FunctionComponent<IndexerSummaryProps> = ({
+                     {summary.uploads.length + summary.indexes.length > 0 ? (
+-                        <Badge variant="success" className={className}>
++                        <Badge variant="success" small={true} className={className}>
+                             Enabled
+@@ -65,3 +65,3 @@ export const IndexerSummary: React.FunctionComponent<IndexerSummaryProps> = ({
+                     ) : summary.indexer?.url ? (
+-                        <Badge variant="secondary" className={className}>
++                        <Badge variant="secondary" small={true} className={className}>
+                             Configurable
+client/web/src/enterprise/codeintel/badge/components/RequestLink.module.scss client/web/src/enterprise/codeintel/badge/components/RequestLink.module.scss
+@@ -1,3 +1,5 @@
+ .language-request {
++    font-size: 0.75rem;
+     font-weight: normal;
++    display: inline !important;
+ }
+`
+
+	res, err := ParseDiffString(input)
+	if err != nil {
+		panic(err)
+	}
+	autogold.Equal(t, res)
+}

--- a/internal/search/result/match.go
+++ b/internal/search/result/match.go
@@ -33,6 +33,7 @@ var (
 	_ Match = (*FileMatch)(nil)
 	_ Match = (*RepoMatch)(nil)
 	_ Match = (*CommitMatch)(nil)
+	_ Match = (*CommitDiffMatch)(nil)
 )
 
 // Match ranks are used for sorting the different match types.

--- a/internal/search/result/testdata/TestParseDiffString.golden
+++ b/internal/search/result/testdata/TestParseDiffString.golden
@@ -1,0 +1,45 @@
+[]result.DiffFile{
+	{
+		OrigName: "client/web/src/enterprise/codeintel/badge/components/IndexerSummary.module.scss",
+		NewName:  "client/web/src/enterprise/codeintel/badge/components/IndexerSummary.module.scss",
+	},
+	{
+		OrigName: "client/web/src/enterprise/codeintel/badge/components/IndexerSummary.tsx",
+		NewName:  "client/web/src/enterprise/codeintel/badge/components/IndexerSummary.tsx",
+		Hunks: []result.Hunk{
+			{
+				OldStart: 57,
+				NewStart: 57,
+				OldCount: 3,
+				NewCount: 3,
+				Header:   "export const IndexerSummary: React.FunctionComponent<IndexerSummaryProps> = ({",
+				Lines: []string{
+					"+.badge-wrapper {",
+					"+    font-size: 0.75rem;",
+					"+}",
+					"+",
+					" .telemetric-redirect {",
+					"-    display: inline !important;",
+					"+    font-size: 0.75rem;",
+					"     return (",
+					`-        <div className="px-2 py-1">`,
+					"+        <div className={classNames('px-2 py-1', styles.badgeWrapper)}>",
+					`             <div className="d-flex align-items-center">`,
+				},
+			},
+			{
+				OldStart: 61,
+				NewStart: 61,
+				OldCount: 3,
+				NewCount: 3,
+				Header:   "export const IndexerSummary: React.FunctionComponent<IndexerSummaryProps> = ({",
+				Lines: []string{
+					"                     {summary.uploads.length + summary.indexes.length > 0 ? (",
+					`-                        <Badge variant="success" className={className}>`,
+					`+                        <Badge variant="success" small={true} className={className}>`,
+					"                             Enabled",
+				},
+			},
+		},
+	},
+}


### PR DESCRIPTION
Add dedicated diff result type. It is currently only used/generated by compute. I implemented the result methods even though I don't need them, and they're not used yet, so that in time we should migrate to using this diff result type and not proxy via `CommitMatch`.

Thanks @camdencheek for the diff parsing code in https://github.com/sourcegraph/sourcegraph/tree/cc/diff-parser!

## Test plan
Added unit tests.