### PR TITLE
gitserver: add experimental feature to read gitserver addr from db

### DIFF
--- a/internal/gitserver/client.go
+++ b/internal/gitserver/client.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/md5"
+	"database/sql"
 	"encoding/binary"
 	"encoding/gob"
 	"encoding/json"
@@ -16,6 +17,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/cespare/xxhash/v2"
@@ -33,6 +35,7 @@ import (
 	"github.com/sourcegraph/go-diff/diff"
 	"github.com/sourcegraph/go-rendezvous"
 
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
@@ -304,6 +307,18 @@ var addrForRepoInvoked = promauto.NewCounterVec(prometheus.CounterOpts{
 	Help: "Number of times gitserver.AddrForRepo was invoked",
 }, []string{"user_agent"})
 
+// AddrForRepoCounter is used to track the number of times AddrForRepo is called
+// and is used to determine if we can read the gitserver location from the database.
+// See AddrForRepo for more details.
+var AddrForRepoCounter uint64
+
+// addrForRepoAddrMismatch is used to count the number of times the state of
+// the gitserver_repos table and the hashing algorithm disagree.
+var addrForRepoAddrMismatch = promauto.NewCounterVec(prometheus.CounterOpts{
+	Name: "src_gitserver_addr_for_repo_addr_mismatch",
+	Help: "Number of times the gitserver_repos state and the result of gitserver.AddrForRepo are mismatched",
+}, []string{"user_agent"})
+
 // AddrForRepo returns the gitserver address to use for the given repo name.
 // It should never be called with a nil addresses pointer.
 func AddrForRepo(ctx context.Context, userAgent string, db database.DB, repo api.RepoName, addresses GitServerAddresses) (string, error) {
@@ -327,6 +342,48 @@ func AddrForRepo(ctx context.Context, userAgent string, db database.DB, repo api
 	}
 	if err != nil {
 		return "", err
+	}
+
+	// This is an experiment to determine the impact on using the database to determine the location of a repo.
+	// It is meant to be used exclusively on Cloud and the rate will be increased progressively.
+	// Once we determine the impact of this experiment, we can remove it.
+	cfg := conf.Get()
+	if envvar.SourcegraphDotComMode() && cfg.ExperimentalFeatures != nil && cfg.ExperimentalFeatures.EnableGitserverClientLookupTable {
+		// get the rate from the configuration. The rate is a percentage, and defaults to 0.
+		var rate uint64 = uint64(conf.Get().ExperimentalFeatures.GitserverClientLookupTableRate)
+		if rate > 100 {
+			rate = 0
+		}
+
+		// We are using a modulo operation to spread the calls to the database across the rate.
+		var mod uint64
+		if rate > 0 {
+			mod = 100 / rate
+		}
+
+		if rate != 0 && atomic.AddUint64(&AddrForRepoCounter, 1)%mod == 0 {
+			span, ctx := ot.StartSpanFromContext(ctx, "GitserverClient.AddrForRepoFromDB")
+			span.SetTag("Repo", repo)
+			defer func() {
+				if err != nil {
+					ext.Error.Set(span, true)
+					span.LogFields(otlog.Error(err))
+				}
+				span.Finish()
+			}()
+
+			gr, err := db.GitserverRepos().GetByName(ctx, repo)
+			switch {
+			case err == nil:
+				// if there is a difference between the database state and the hashing result
+				// we should observe it.
+				if gr.ShardID != shardID {
+					addrForRepoAddrMismatch.WithLabelValues(userAgent).Inc()
+				}
+			case !errors.Is(err, sql.ErrNoRows):
+				log15.Warn("gitserver.AddrForRepo: failed to get gitserver repo from the database", "repo", repo, "err", err)
+			}
+		}
 	}
 
 	return shardID, nil

--- a/internal/gitserver/client_test.go
+++ b/internal/gitserver/client_test.go
@@ -22,12 +22,14 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/migration"
+	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/schema"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/require"
 
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/cmd/gitserver/server"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database"
@@ -383,6 +385,197 @@ func TestAddrForRepo(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestAddrForRepoFromDB(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
+	// enable feature flag
+	conf.Mock(&conf.Unified{
+		SiteConfiguration: schema.SiteConfiguration{
+			ExperimentalFeatures: &schema.ExperimentalFeatures{
+				EnableGitserverClientLookupTable: true,
+				// Set the rate at 100% for this test
+				GitserverClientLookupTableRate: 100,
+			},
+		},
+	})
+	defer conf.Mock(nil)
+
+	// enable dotCom mode
+	envvar.MockSourcegraphDotComMode(true)
+	defer envvar.MockSourcegraphDotComMode(false)
+
+	addrs := []string{"gitserver-1", "gitserver-2", "gitserver-3"}
+	pinned := map[string]string{
+		"github.com/sourcegraph/repo2": "gitserver-1",
+	}
+
+	testCases := []struct {
+		name           string
+		repo           api.RepoName
+		want           string
+		dotComDisabled bool
+		dbNotCalled    bool
+	}{
+		{
+			name: "repo1",
+			repo: api.RepoName("github.com/sourcegraph/repo1"),
+			want: "gitserver-2",
+		},
+		{
+			name: "normalisation",
+			repo: api.RepoName("github.com/sourcegraph/repo1.git"),
+			want: "gitserver-2",
+		},
+		{
+			name: "repo not in the DB",
+			repo: api.RepoName("github.com/sourcegraph/sourcegraph.git"),
+			want: "gitserver-2",
+		},
+		{
+			name:        "pinned repo", // different server address that the hashing function would normally yield
+			repo:        api.RepoName("github.com/sourcegraph/repo2"),
+			want:        "gitserver-1",
+			dbNotCalled: true,
+		},
+		{
+			name:           "repo1",
+			repo:           api.RepoName("github.com/sourcegraph/repo1"),
+			want:           "gitserver-2",
+			dotComDisabled: true,
+			dbNotCalled:    true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.dotComDisabled {
+				envvar.MockSourcegraphDotComMode(false)
+			} else {
+				envvar.MockSourcegraphDotComMode(true)
+			}
+
+			db := database.NewMockDB()
+
+			store := database.NewMockGitserverRepoStore()
+			store.GetByNameFunc.SetDefaultReturn(&types.GitserverRepo{
+				RepoID:        1,
+				ShardID:       "gitserver-1",
+				CloneStatus:   types.CloneStatusNotCloned,
+				RepoSizeBytes: 100,
+			}, nil)
+			db.GitserverReposFunc.SetDefaultReturn(store)
+
+			got, err := gitserver.AddrForRepo(context.Background(), "gitserver", db, tc.repo, gitserver.GitServerAddresses{
+				Addresses:     addrs,
+				PinnedServers: pinned,
+			})
+			if err != nil {
+				t.Fatal("Error during getting gitserver address")
+			}
+			if got != tc.want {
+				t.Fatalf("Want %q, got %q", tc.want, got)
+			}
+			if tc.dbNotCalled && len(db.GitserverReposFunc.History()) > 0 {
+				t.Fatalf("Should not have called the database")
+			} else if !tc.dbNotCalled && len(db.GitserverReposFunc.History()) == 0 {
+				t.Fatalf("Should have called the database")
+			}
+		})
+	}
+}
+
+func TestAddrForRepoFromDBRates(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
+	gitserver.AddrForRepoCounter = 0
+
+	// enable dotCom mode
+	envvar.MockSourcegraphDotComMode(true)
+	defer envvar.MockSourcegraphDotComMode(false)
+
+	addrs := []string{"gitserver-1", "gitserver-2", "gitserver-3"}
+	pinned := map[string]string{
+		"github.com/sourcegraph/repo2": "gitserver-1",
+	}
+
+	defer conf.Mock(nil)
+
+	// enable feature flag with 50% rate
+	conf.Mock(&conf.Unified{
+		SiteConfiguration: schema.SiteConfiguration{
+			ExperimentalFeatures: &schema.ExperimentalFeatures{
+				EnableGitserverClientLookupTable: true,
+				GitserverClientLookupTableRate:   50,
+			},
+		},
+	})
+
+	check := func(repo string, dbCalled bool) {
+		t.Helper()
+
+		db := database.NewMockDB()
+		store := database.NewMockGitserverRepoStore()
+		store.GetByNameFunc.SetDefaultReturn(&types.GitserverRepo{
+			RepoID:        1,
+			ShardID:       "gitserver-1",
+			CloneStatus:   types.CloneStatusNotCloned,
+			RepoSizeBytes: 100,
+		}, nil)
+		db.GitserverReposFunc.SetDefaultReturn(store)
+
+		_, err := gitserver.AddrForRepo(context.Background(), "gitserver", db, api.RepoName(repo), gitserver.GitServerAddresses{
+			Addresses:     addrs,
+			PinnedServers: pinned,
+		})
+		if err != nil {
+			t.Fatal("Error during getting gitserver address")
+		}
+		if dbCalled && len(db.GitserverReposFunc.History()) == 0 {
+			t.Fatalf("Should have called the database")
+		} else if !dbCalled && len(db.GitserverReposFunc.History()) > 0 {
+			t.Fatalf("Should not have called the database")
+		}
+	}
+
+	// first request should be served from the hash
+	// Rate: 50%, Counter: 1, Mod: 100 / 50 = 2, Result: 1 % 2 = 1
+	check("github.com/sourcegraph/repo1", false)
+
+	// second request should be served from the DB
+	// Rate: 50%, Counter: 2, Mod: 100 / 50 = 2, Result: 2 % 2 = 0
+	check("github.com/sourcegraph/repo1", true)
+
+	// third request should be served from the hash
+	// Rate: 50%, Counter: 3, Mod: 100 / 50 = 2, Result: 3 % 2 = 1
+	check("github.com/sourcegraph/repo1", false)
+
+	// Let's change the rate to 30%
+	conf.Mock(&conf.Unified{
+		SiteConfiguration: schema.SiteConfiguration{
+			ExperimentalFeatures: &schema.ExperimentalFeatures{
+				EnableGitserverClientLookupTable: true,
+				GitserverClientLookupTableRate:   30,
+			},
+		},
+	})
+
+	// next request should be served from the hash
+	// Rate: 30%, Counter: 4, Mod: 100 / 30 = 3, Result: 4 % 3 = 1
+	check("github.com/sourcegraph/repo1", false)
+
+	// next request should be served from the hash
+	// Rate: 30%, Counter: 5, Mod: 100 / 30 = 3, Result: 5 % 3 = 2
+	check("github.com/sourcegraph/repo1", false)
+
+	// next request should be served from the DB
+	// Rate: 30%, Counter: 6, Mod: 100 / 30 = 3, Result: 6 % 3 = 0
+	check("github.com/sourcegraph/repo1", true)
 }
 
 func TestRendezvousAddrForRepo(t *testing.T) {

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -597,6 +597,8 @@ type ExperimentalFeatures struct {
 	EnableGitServerCommandExecFilter bool `json:"enableGitServerCommandExecFilter,omitempty"`
 	// EnableGithubInternalRepoVisibility description: Enable support for visilibity of internal Github repositories
 	EnableGithubInternalRepoVisibility bool `json:"enableGithubInternalRepoVisibility,omitempty"`
+	// EnableGitserverClientLookupTable description: Enable getting repository location from the database. Works only on Cloud.
+	EnableGitserverClientLookupTable bool `json:"enableGitserverClientLookupTable,omitempty"`
 	// EnablePermissionsWebhooks description: Enables webhook consumers to sync permissions from external services faster than the defaults schedule
 	EnablePermissionsWebhooks bool `json:"enablePermissionsWebhooks,omitempty"`
 	// EnablePostSignupFlow description: Enables post sign-up user flow to add code hosts and sync code
@@ -607,6 +609,8 @@ type ExperimentalFeatures struct {
 	Gerrit string `json:"gerrit,omitempty"`
 	// GitServerPinnedRepos description: List of repositories pinned to specific gitserver instances. The specified repositories will remain at their pinned servers on scaling the cluster. If the specified pinned server differs from the current server that stores the repository, then it must be re-cloned to the specified server.
 	GitServerPinnedRepos map[string]string `json:"gitServerPinnedRepos,omitempty"`
+	// GitserverClientLookupTableRate description: Percentage of calls to AddrFromRepo that read from the database. Only used if enableGitserverClientLookupTable is true.
+	GitserverClientLookupTableRate int `json:"gitserverClientLookupTable.Rate,omitempty"`
 	// JvmPackages description: Allow adding JVM packages code host connections
 	JvmPackages string `json:"jvmPackages,omitempty"`
 	// NpmPackages description: Allow adding npm packages code host connections

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -426,6 +426,18 @@
           "type": "boolean",
           "default": true
         },
+        "enableGitserverClientLookupTable": {
+          "description": "Enable getting repository location from the database. Works only on Cloud.",
+          "type": "boolean",
+          "default": false
+        },
+        "gitserverClientLookupTable.Rate": {
+          "description": "Percentage of calls to AddrFromRepo that read from the database. Only used if enableGitserverClientLookupTable is true.",
+          "type": "integer",
+          "default": 0,
+          "minimum": 0,
+          "maximum": 100
+        },
         "gitServerPinnedRepos": {
           "description": "List of repositories pinned to specific gitserver instances. The specified repositories will remain at their pinned servers on scaling the cluster. If the specified pinned server differs from the current server that stores the repository, then it must be re-cloned to the specified server.",
           "type": "object",


### PR DESCRIPTION
This re-enables the gitserver experiment, we will complete it before pausing the work on Gitserver HA.

## Test plan

Unit tests


