### PR TITLE
ci: soft fail CI preview

### DIFF
--- a/enterprise/dev/ci/internal/ci/operations.go
+++ b/enterprise/dev/ci/internal/ci/operations.go
@@ -900,8 +900,7 @@ func uploadBuildeventTrace() operations.Operation {
 func prPreview() operations.Operation {
 	return func(pipeline *bk.Pipeline) {
 		pipeline.AddStep(":globe_with_meridians: Client PR preview",
-			// Soft-fail with code 222 if nothing has changed
-			bk.SoftFail(222),
+			bk.SoftFail(),
 			bk.Cmd("dev/ci/render-pr-preview.sh"))
 	}
 }


### PR DESCRIPTION
## Context

> If you want it to soft-fail in all conditions, you need to remove the exit code from https://github.com/sourcegraph/sourcegraph/blob/main/enterprise/dev/ci/internal/ci/operations.go#L904

This PR does that ^
[Slack thread for context](https://sourcegraph.slack.com/archives/C07KZF47K/p1651864364537269).

## Test plan

n/a

