### PR TITLE
Add a How-to page for writing ADRs

### DIFF
--- a/doc/dev/adr/how-to.md
+++ b/doc/dev/adr/how-to.md
@@ -1,0 +1,20 @@
+# How to write an ADR?
+
+Great! You've decided to write an ADR. This process will likely improve in the future, but here are the recommended steps for now:
+
+1. Add a new ADR file to this folder (`.md` format)
+2. Use the following name: `{{timestamp}}-short-decision-summary.md`
+  1. Grab the `timestamp` from [this page](https://www.unixtimestamp.com)
+3. Use the template below for writing an ADR
+4. Keep it short and sweet; ADRs are meant to be brief and easy to digest. Check out the other ADRs for inspiration!
+5. Open a PR and ask for feedback. Tag the people familiar with the specific area to verify that your decision record correctly captures the decision made.
+
+### ADR template
+
+```
+{{date}}
+
+### Context
+### Decision
+### Consequences
+```

--- a/doc/dev/adr/index.md
+++ b/doc/dev/adr/index.md
@@ -2,6 +2,8 @@
 
 This page is an ADR log. Read the first entry to learn about the reasoning and context behind the adoption of ADRs.
 
+Are you considering adding an ADR? Check out the [How-to page](how-to.md)!
+
 To preserve order, individual documents are prefixed by the **current epoch Unix timestamp**.
 
 1. [Record architecture decisions](1650968652-record-architecture-decisions.md)


### PR DESCRIPTION
Add a helpful page with steps for adding a new Architecture Decision Record (ADR).

## Test plan

Documentation only.


