### PR TITLE
ci: add a direct link to guide in buildchecker msg

### DIFF
--- a/dev/buildchecker/slack.go
+++ b/dev/buildchecker/slack.go
@@ -45,7 +45,9 @@ The authors of the following failed commits who are Sourcegraph teammates have b
 
 The branch will automatically be unlocked once a green build has run on %s.
 Please head over to %s for relevant discussion about this branch lock.
-Refer to the <https://handbook.sourcegraph.com/departments/product-engineering/engineering/process/incidents/playbooks/ci|CI incident playbook> for help.
+:bulb: First time being mentioned by this bot? :point_right: <https://handbook.sourcegraph.com/departments/product-engineering/engineering/process/incidents/playbooks/ci/#build-has-failed-on-the-main-branch|Follow this step by step guide!>.
+
+For more, refer to the <https://handbook.sourcegraph.com/departments/product-engineering/engineering/process/incidents/playbooks/ci|CI incident playbook> for help.
 
 If unable to resolve the issue, please start an incident with the '/incident' Slack command.
 


### PR DESCRIPTION
Being on support duty and seeing some buildkite-main failures made me rethink about our slack message from Build checker. We are mentioning the CI playbook, but it's a bit daunting and does not tell a possible newcomer that the playbook contains a step by step guide to help themself. 

The emoji and the direct link could improve this.

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->

N/A, purely textual change. 