### PR TITLE
Accessibility: Fix small tree page issues

### DIFF
--- a/client/web/src/enterprise/codeintel/badge/components/UserFacingCodeIntelligenceBadgeContent.module.scss
+++ b/client/web/src/enterprise/codeintel/badge/components/UserFacingCodeIntelligenceBadgeContent.module.scss
@@ -1,3 +1,9 @@
+.list {
+    padding: 0;
+    margin: 0;
+    list-style: none;
+}
+
 .badge-multiple {
     min-width: 7rem;
 }

--- a/client/web/src/enterprise/codeintel/badge/components/UserFacingCodeIntelligenceBadgeContent.tsx
+++ b/client/web/src/enterprise/codeintel/badge/components/UserFacingCodeIntelligenceBadgeContent.tsx
@@ -60,9 +60,9 @@ export const UserFacingCodeIntelligenceBadgeContent: React.FunctionComponent<
     return indexerNames.length === 0 ? (
         <Unsupported />
     ) : (
-        <>
+        <ul className={styles.list}>
             {indexerNames.map((name, index) => (
-                <React.Fragment key={`indexer-${name}`}>
+                <li key={`indexer-${name}`}>
                     {index > 0 && <MenuDivider />}
                     <IndexerSummary
                         repoName={repoName}
@@ -77,8 +77,8 @@ export const UserFacingCodeIntelligenceBadgeContent: React.FunctionComponent<
                         useRequestedLanguageSupportQuery={useRequestedLanguageSupportQuery}
                         useRequestLanguageSupportQuery={useRequestLanguageSupportQuery}
                     />
-                </React.Fragment>
+                </li>
             ))}
-        </>
+        </ul>
     )
 }

--- a/client/web/src/repo/tree/HomeTab.module.scss
+++ b/client/web/src/repo/tree/HomeTab.module.scss
@@ -51,6 +51,12 @@
     padding-bottom: 1rem;
 }
 
+.list {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+}
+
 .item-badge {
     height: fit-content;
 }

--- a/client/web/src/repo/tree/HomeTab.tsx
+++ b/client/web/src/repo/tree/HomeTab.tsx
@@ -400,7 +400,7 @@ export const HomeTabBatchChangeBadge: React.FunctionComponent<
             const summaryTexts = summaries.map(({ value, name }) => `${value} ${name}`)
 
             return (
-                <div className={styles.item} key={id}>
+                <li className={styles.item} key={id}>
                     <Badge variant="success" className={badgeClassNames}>
                         OPEN
                     </Badge>
@@ -410,13 +410,13 @@ export const HomeTabBatchChangeBadge: React.FunctionComponent<
                         </Link>
                         <div>{summaryTexts.join(', ')}</div>
                     </div>
-                </div>
+                </li>
             )
         }
     )
     return (
         <>
-            {items}
+            <ul className={styles.list}>{items}</ul>
             {allBatchChanges}
         </>
     )

--- a/client/web/src/repo/tree/TreePage.tsx
+++ b/client/web/src/repo/tree/TreePage.tsx
@@ -302,8 +302,9 @@ export const TreePage: React.FunctionComponent<React.PropsWithChildren<Props>> =
                                 outline={true}
                                 as={Link}
                                 className="ml-1"
+                                aria-label="Repository settings"
                             >
-                                <Icon as={SettingsIcon} />
+                                <Icon as={SettingsIcon} role="img" aria-hidden={true} />
                             </Button>
                         )}
                     </ButtonGroup>


### PR DESCRIPTION
Audit issue: https://github.com/sourcegraph/sourcegraph/issues/34422

## Description

Fixes a few issues reported when auditing the (post-redesign) Tree page:
1. Settings button isn't reported correctly on screen readers (only reads "Image")
<img width="298" alt="image" src="https://user-images.githubusercontent.com/9516420/167852584-de9b4725-74d7-4e07-bc8c-52cb3f5c15cc.png">

2. Batch changes summary isn't rendered as a list
<img width="422" alt="image" src="https://user-images.githubusercontent.com/9516420/167852637-bef704ef-1f0e-4d16-a310-b6529c097a16.png">

3. Code intel summary isn't rendered as a list
<img width="452" alt="image" src="https://user-images.githubusercontent.com/9516420/167852712-24d04006-3dfc-4025-9bb7-cf3c339363b5.png">

**Note:** This page is still only enabled via a feature flag (not used in production yet)

## Test plan
1. Ran locally, checked for visual regressions and ensured functionality works as expected

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->



## App preview:

- [Web](https://sg-web-tr-tree-page-a11y.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-nvmrnvamio.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
