### PR TITLE
codeintel: fix use of 'index' to refer to 'upload'

### DIFF
--- a/client/web/src/enterprise/codeintel/indexes/components/CodeIntelAssociatedUpload.tsx
+++ b/client/web/src/enterprise/codeintel/indexes/components/CodeIntelAssociatedUpload.tsx
@@ -30,7 +30,7 @@ export const CodeIntelAssociatedUpload: FunctionComponent<React.PropsWithChildre
                     <div className={classNames(styles.information, 'd-flex flex-column')}>
                         <div className="m-0">
                             <h3 className="m-0 d-block d-md-inline">
-                                This job uploaded an index{' '}
+                                This job performed an upload{' '}
                                 <Timestamp date={node.associatedUpload.uploadedAt} now={now} />
                             </h3>
                         </div>


### PR DESCRIPTION
Does what it says on the tin

## Test plan

N/A, wording fix



## App preview:

- [Web](https://sg-web-nsc-fix-wording.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-epfbypktbp.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
