### PR TITLE
logtest: default to DPanicLevel for tests

### DIFF
--- a/lib/log/logtest/logtest.go
+++ b/lib/log/logtest/logtest.go
@@ -29,7 +29,7 @@ func Init(_ *testing.M) {
 	if testing.Verbose() {
 		initGlobal(zapcore.DebugLevel)
 	} else {
-		initGlobal(zapcore.WarnLevel)
+		initGlobal(zapcore.DPanicLevel)
 	}
 }
 


### PR DESCRIPTION
Unit tests are often testing error conditions, which leads to log spam
due to error logs. We can instead raise the log level to those which
atleast cause panics which unlikely is part of the happy path in a test.

This follows the same pattern we see often in our tests for log15. In
those we use the DiscardHandler unless verbose testing is enabled.

Test Plan: go test ./cmd/searcher/internal/search had no output.