### PR TITLE
github: shorten test plan description in template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,13 +2,4 @@
 
 ## Test plan
 
-<!--
-  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
-  provide a "test plan". A test plan is a loose explanation of what you have done or
-  implemented to test this, or why this change does not need testing, as outlined in our
-  Testing principles and guidelines:
-  https://docs.sourcegraph.com/dev/background-information/testing_principles
-  Write your test plan here after the "## Test plan" header.
--->
-
-
+<!-- all pull requests REQUIRE a test plan.   https://docs.sourcegraph.com/dev/background-information/testing_principles -->


### PR DESCRIPTION
I want to make it easier to delete the multiple lines of test plan reminder. Now that devs are aware of this change, we can use a more succinct message. The link to testing principles explains what a test plan is, which can help new developers.

Test Plan: n/a