### PR TITLE
searcher: use log instead of log15 for Store

### DIFF
--- a/cmd/searcher/internal/search/search.go
+++ b/cmd/searcher/internal/search/search.go
@@ -46,7 +46,6 @@ const (
 // Service is the search service. It is an http.Handler.
 type Service struct {
 	Store *Store
-	Log   sglog.Logger
 }
 
 // ServeHTTP handles HTTP based search requests
@@ -165,24 +164,22 @@ func (s *Service) search(ctx context.Context, p *protocol.Request, sender matchS
 		span.LogFields(otlog.Int("matches.len", sender.SentCount()))
 		span.SetTag("limitHit", sender.LimitHit())
 		span.Finish()
-		if s.Log != nil {
-			s.Log.Debug("search request",
-				sglog.String("repo", string(p.Repo)),
-				sglog.String("commit", string(p.Commit)),
-				sglog.String("pattern", p.Pattern),
-				sglog.Bool("isRegExp", p.IsRegExp),
-				sglog.Bool("isStructuralPat", p.IsStructuralPat),
-				sglog.Strings("languages", p.Languages),
-				sglog.Bool("isWordMatch", p.IsWordMatch),
-				sglog.Bool("isCaseSensitive", p.IsCaseSensitive),
-				sglog.Bool("patternMatchesContent", p.PatternMatchesContent),
-				sglog.Bool("patternMatchesPath", p.PatternMatchesPath),
-				sglog.Int("matches", sender.SentCount()),
-				sglog.String("code", code),
-				sglog.Duration("duration", time.Since(start)),
-				sglog.Strings("indexerEndpoints", p.IndexerEndpoints),
-				sglog.Error(err))
-		}
+		s.Store.Log.Debug("search request",
+			sglog.String("repo", string(p.Repo)),
+			sglog.String("commit", string(p.Commit)),
+			sglog.String("pattern", p.Pattern),
+			sglog.Bool("isRegExp", p.IsRegExp),
+			sglog.Bool("isStructuralPat", p.IsStructuralPat),
+			sglog.Strings("languages", p.Languages),
+			sglog.Bool("isWordMatch", p.IsWordMatch),
+			sglog.Bool("isCaseSensitive", p.IsCaseSensitive),
+			sglog.Bool("patternMatchesContent", p.PatternMatchesContent),
+			sglog.Bool("patternMatchesPath", p.PatternMatchesPath),
+			sglog.Int("matches", sender.SentCount()),
+			sglog.String("code", code),
+			sglog.Duration("duration", time.Since(start)),
+			sglog.Strings("indexerEndpoints", p.IndexerEndpoints),
+			sglog.Error(err))
 	}(time.Now())
 
 	if p.IsStructuralPat && p.Indexed {

--- a/cmd/searcher/internal/search/search_test.go
+++ b/cmd/searcher/internal/search/search_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/search/searcher"
 	"github.com/sourcegraph/sourcegraph/internal/testutil"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"github.com/sourcegraph/sourcegraph/lib/log/logtest"
 )
 
 type fileType int
@@ -517,6 +518,7 @@ func newStore(t *testing.T, files map[string]struct {
 			return r, nil
 		},
 		Path: t.TempDir(),
+		Log:  logtest.Scoped(t),
 	}
 }
 

--- a/cmd/searcher/internal/search/store_test.go
+++ b/cmd/searcher/internal/search/store_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"github.com/sourcegraph/sourcegraph/lib/log/logtest"
 )
 
 func TestPrepareZip(t *testing.T) {
@@ -262,6 +263,7 @@ func tmpStore(t *testing.T) *Store {
 	d := t.TempDir()
 	return &Store{
 		Path: d,
+		Log:  logtest.Scoped(t),
 	}
 }
 

--- a/cmd/searcher/main.go
+++ b/cmd/searcher/main.go
@@ -126,9 +126,9 @@ func run(logger log.Logger) error {
 			FilterTar:         search.NewFilter,
 			Path:              filepath.Join(cacheDir, "searcher-archives"),
 			MaxCacheSizeBytes: cacheSizeBytes,
+			Log:               logger,
 			DB:                db,
 		},
-		Log: logger,
 	}
 	service.Store.Start()
 


### PR DESCRIPTION
Small change helping us unify towards lib/log. We also make it so that Log is a required field.

Only thing I am uncertain about in this PR is Service using the logger from the Store instead of passing a logger to both Store and the Service struct.

Test Plan: `go test ./cmd/searcher/...`