### PR TITLE
minio: bump to latest version

### DIFF
--- a/docker-images/minio/build.sh
+++ b/docker-images/minio/build.sh
@@ -3,7 +3,7 @@
 set -ex
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
-# Retag the 2022-02-24 MinIO release
-MINIO_RELEASE="RELEASE.2022-02-24T22-12-01Z"
+# Retag the 2022-05-08 MinIO release
+MINIO_RELEASE="RELEASE.2022-05-08T23-50-31Z"
 docker pull minio/minio:$MINIO_RELEASE
 docker tag minio/minio:$MINIO_RELEASE "$IMAGE"


### PR DESCRIPTION
Updates minio to the latest to patch against fixable CVEs identified by Trivy.

Changelog is here https://github.com/minio/minio/compare/RELEASE.2022-02-24T22-12-01Z...RELEASE.2022-05-08T23-50-31Z

## Test plan
* CI end-to-end tests and deployment smoke tests

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


