### PR TITLE
Properly pluralize tooltip for repo changesets

### DIFF
--- a/client/web/src/batches/RepoBatchChangesButton.tsx
+++ b/client/web/src/batches/RepoBatchChangesButton.tsx
@@ -48,7 +48,7 @@ export const RepoBatchChangesButton: FC<React.PropsWithChildren<RepoBatchChanges
             )}
             {merged > 0 && (
                 <Badge
-                    tooltip={`${merged} merged ${pluralize('batch changeset', open)}`}
+                    tooltip={`${merged} merged ${pluralize('batch changeset', merged)}`}
                     variant="merged"
                     className="d-inline-block batch-change-badge ml-2"
                 >

--- a/client/web/src/batches/RepoBatchChangesButton.tsx
+++ b/client/web/src/batches/RepoBatchChangesButton.tsx
@@ -1,6 +1,6 @@
 import { FC, useMemo } from 'react'
 
-import { encodeURIPathComponent } from '@sourcegraph/common'
+import { encodeURIPathComponent, pluralize } from '@sourcegraph/common'
 import { Badge, useObservable, Button, Link, Icon } from '@sourcegraph/wildcard'
 
 import { queryRepoChangesetsStats as _queryRepoChangesetsStats } from './backend'
@@ -39,7 +39,7 @@ export const RepoBatchChangesButton: FC<React.PropsWithChildren<RepoBatchChanges
             <Icon as={BatchChangesIcon} /> Batch Changes
             {open > 0 && (
                 <Badge
-                    tooltip={`${open} open batch changesets`}
+                    tooltip={`${open} open ${pluralize('batch changeset', open)}`}
                     variant="success"
                     className="d-inline-block batch-change-badge ml-2"
                 >
@@ -48,7 +48,7 @@ export const RepoBatchChangesButton: FC<React.PropsWithChildren<RepoBatchChanges
             )}
             {merged > 0 && (
                 <Badge
-                    tooltip={`${merged} merged batch changesets`}
+                    tooltip={`${merged} merged ${pluralize('batch changeset', open)}`}
                     variant="merged"
                     className="d-inline-block batch-change-badge ml-2"
                 >


### PR DESCRIPTION
Small oversight here 😬 

## Test plan

Validated the pluralization now works properly. 


## App preview:

- [Web](https://sg-web-es-fix-plural.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-mefficyaje.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
