### PR TITLE
ci: re-enable cache and use plugin fork

### DIFF
--- a/enterprise/dev/ci/internal/buildkite/cache.go
+++ b/enterprise/dev/ci/internal/buildkite/cache.go
@@ -1,7 +1,6 @@
 package buildkite
 
-// const cachePluginName = "gencer/cache#v2.4.10"
-// Follow-up to INC-101, this fork uses bsdtar instead of tar.
+// Follow-up to INC-101, this fork of 'gencer/cache#v2.4.10' uses bsdtar instead of tar.
 const cachePluginName = "https://github.com/jhchabran/cache-buildkite-plugin.git#master"
 
 // CacheConfig represents the configuration data for https://github.com/gencer/cache-buildkite-plugin

--- a/enterprise/dev/ci/internal/buildkite/cache.go
+++ b/enterprise/dev/ci/internal/buildkite/cache.go
@@ -1,6 +1,8 @@
 package buildkite
 
-const cachePluginName = "gencer/cache#v2.4.10"
+// const cachePluginName = "gencer/cache#v2.4.10"
+// Follow-up to INC-101, this fork uses bsdtar instead of tar.
+const cachePluginName = "https://github.com/jhchabran/cache-buildkite-plugin.git#master"
 
 // CacheConfig represents the configuration data for https://github.com/gencer/cache-buildkite-plugin
 type CacheConfigPayload struct {

--- a/enterprise/dev/ci/internal/ci/cache_helpers.go
+++ b/enterprise/dev/ci/internal/ci/cache_helpers.go
@@ -3,13 +3,12 @@ package ci
 import "github.com/sourcegraph/sourcegraph/enterprise/dev/ci/internal/buildkite"
 
 func withYarnCache() buildkite.StepOpt {
-	return buildkite.RawCmd(`echo "temporarily disabled yarn cache, see https://app.incident.io/incidents/101"`)
-	// return buildkite.Cache(&buildkite.CacheOptions{
-	// 	ID:          "node_modules",
-	// 	Key:         "cache-node_modules-{{ checksum 'yarn.lock' }}",
-	// 	RestoreKeys: []string{"cache-node_modules-{{ checksum 'yarn.lock' }}"},
-	// 	Paths:       []string{"node_modules", "client/extension-api/node_modules", "client/eslint-plugin-sourcegraph/node_modules"},
-	// 	// TODO: @jhchabran, check the numbers, but in my last run it seemed to be clear that compression is really slow (+3/4m IIRC)
-	// 	Compress: false,
-	// })
+	return buildkite.Cache(&buildkite.CacheOptions{
+		ID:          "node_modules",
+		Key:         "cache-node_modules-{{ checksum 'yarn.lock' }}",
+		RestoreKeys: []string{"cache-node_modules-{{ checksum 'yarn.lock' }}"},
+		Paths:       []string{"node_modules", "client/extension-api/node_modules", "client/eslint-plugin-sourcegraph/node_modules"},
+		// TODO: @jhchabran, check the numbers, but in my last run it seemed to be clear that compression is really slow (+3/4m IIRC)
+		Compress: false,
+	})
 }


### PR DESCRIPTION
Follow-up to INC-101. See also
https://github.com/sourcegraph/infrastructure/pull/3316 and https://github.com/jhchabran/cache-buildkite-plugin/commit/6652014df9051ad71e988d6bfd0a39ced47dd567

## Test plan

<!-- all pull requests REQUIRE a test plan.   https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Main-dry-run + yarn cache working