### PR TITLE
search: Fix "search again" checkboxes

### DIFF
--- a/client/search-ui/src/results/progress/StreamingProgressSkippedButton.test.tsx
+++ b/client/search-ui/src/results/progress/StreamingProgressSkippedButton.test.tsx
@@ -196,7 +196,7 @@ describe('StreamingProgressSkippedButton', () => {
 
         // Trigger onSearchAgain event and check for changes
         // Find `archived:yes` checkbox
-        userEvent.click(screen.getAllByTestId('streaming-progress-skipped-suggest-check')[1], undefined, {
+        userEvent.click(screen.getAllByTestId(/^streaming-progress-skipped-suggest-check/)[1], undefined, {
             skipPointerEventsCheck: true,
         })
         userEvent.click(screen.getByTestId('skipped-popover-form-submit-btn'), undefined, {

--- a/client/search-ui/src/results/progress/StreamingProgressSkippedPopover.test.tsx
+++ b/client/search-ui/src/results/progress/StreamingProgressSkippedPopover.test.tsx
@@ -157,7 +157,7 @@ describe('StreamingProgressSkippedPopover', () => {
 
         renderWithBrandedContext(<StreamingProgressSkippedPopover progress={progress} onSearchAgain={sinon.spy()} />)
 
-        const checkboxes = screen.getAllByTestId(/streaming-progress-skipped-suggest-check/)
+        const checkboxes = screen.getAllByTestId(/^streaming-progress-skipped-suggest-check/)
         expect(checkboxes).toHaveLength(3)
         userEvent.click(checkboxes[1])
 
@@ -208,7 +208,7 @@ describe('StreamingProgressSkippedPopover', () => {
 
         renderWithBrandedContext(<StreamingProgressSkippedPopover progress={progress} onSearchAgain={sinon.spy()} />)
 
-        const checkboxes = screen.getAllByTestId(/streaming-progress-skipped-suggest-check/)
+        const checkboxes = screen.getAllByTestId(/^streaming-progress-skipped-suggest-check/)
         expect(checkboxes).toHaveLength(3)
         userEvent.click(checkboxes[1])
 
@@ -263,7 +263,7 @@ describe('StreamingProgressSkippedPopover', () => {
 
         renderWithBrandedContext(<StreamingProgressSkippedPopover progress={progress} onSearchAgain={searchAgain} />)
 
-        const checkboxes = screen.getAllByTestId(/streaming-progress-skipped-suggest-check/)
+        const checkboxes = screen.getAllByTestId(/^streaming-progress-skipped-suggest-check/)
         expect(checkboxes).toHaveLength(3)
         const checkbox1 = checkboxes[1]
         userEvent.click(checkbox1)

--- a/client/search-ui/src/results/progress/StreamingProgressSkippedPopover.test.tsx
+++ b/client/search-ui/src/results/progress/StreamingProgressSkippedPopover.test.tsx
@@ -157,7 +157,7 @@ describe('StreamingProgressSkippedPopover', () => {
 
         renderWithBrandedContext(<StreamingProgressSkippedPopover progress={progress} onSearchAgain={sinon.spy()} />)
 
-        const checkboxes = screen.getAllByTestId('streaming-progress-skipped-suggest-check')
+        const checkboxes = screen.getAllByTestId(/streaming-progress-skipped-suggest-check/)
         expect(checkboxes).toHaveLength(3)
         userEvent.click(checkboxes[1])
 
@@ -208,7 +208,7 @@ describe('StreamingProgressSkippedPopover', () => {
 
         renderWithBrandedContext(<StreamingProgressSkippedPopover progress={progress} onSearchAgain={sinon.spy()} />)
 
-        const checkboxes = screen.getAllByTestId('streaming-progress-skipped-suggest-check')
+        const checkboxes = screen.getAllByTestId(/streaming-progress-skipped-suggest-check/)
         expect(checkboxes).toHaveLength(3)
         userEvent.click(checkboxes[1])
 
@@ -263,7 +263,7 @@ describe('StreamingProgressSkippedPopover', () => {
 
         renderWithBrandedContext(<StreamingProgressSkippedPopover progress={progress} onSearchAgain={searchAgain} />)
 
-        const checkboxes = screen.getAllByTestId('streaming-progress-skipped-suggest-check')
+        const checkboxes = screen.getAllByTestId(/streaming-progress-skipped-suggest-check/)
         expect(checkboxes).toHaveLength(3)
         const checkbox1 = checkboxes[1]
         userEvent.click(checkbox1)

--- a/client/search-ui/src/results/progress/StreamingProgressSkippedPopover.tsx
+++ b/client/search-ui/src/results/progress/StreamingProgressSkippedPopover.tsx
@@ -144,14 +144,14 @@ export const StreamingProgressSkippedPopover: React.FunctionComponent<
                     <div className="mb-2 mt-3">Search again:</div>
                     <div className="form-check">
                         {sortedSkippedItems.map(
-                            skipped =>
+                            (skipped, index) =>
                                 skipped.suggested && (
                                     <Checkbox
                                         key={skipped.suggested.queryExpression}
                                         value={skipped.suggested.queryExpression}
                                         onChange={checkboxHandler}
-                                        data-testid="streaming-progress-skipped-suggest-check"
-                                        id="streaming-progress-skipped-suggest-check"
+                                        data-testid={`streaming-progress-skipped-suggest-check-${index}`}
+                                        id={`streaming-progress-skipped-suggest-check-${index}`}
                                         wrapperClassName="mb-1 d-block"
                                         label={
                                             <>

--- a/client/search-ui/src/results/progress/__snapshots__/StreamingProgressSkippedPopover.test.tsx.snap
+++ b/client/search-ui/src/results/progress/__snapshots__/StreamingProgressSkippedPopover.test.tsx.snap
@@ -313,15 +313,15 @@ exports[`StreamingProgressSkippedPopover should render correctly 1`] = `
       >
         <input
           class="form-check-input"
-          data-testid="streaming-progress-skipped-suggest-check"
-          id="streaming-progress-skipped-suggest-check"
+          data-testid="streaming-progress-skipped-suggest-check-1"
+          id="streaming-progress-skipped-suggest-check-1"
           label="[object Object]"
           type="checkbox"
           value="timeout:2m"
         />
         <label
           class="label form-check-label label"
-          for="streaming-progress-skipped-suggest-check"
+          for="streaming-progress-skipped-suggest-check-1"
         >
           timeout:2m (
           <span
@@ -347,15 +347,15 @@ exports[`StreamingProgressSkippedPopover should render correctly 1`] = `
       >
         <input
           class="form-check-input"
-          data-testid="streaming-progress-skipped-suggest-check"
-          id="streaming-progress-skipped-suggest-check"
+          data-testid="streaming-progress-skipped-suggest-check-2"
+          id="streaming-progress-skipped-suggest-check-2"
           label="[object Object]"
           type="checkbox"
           value="forked:yes"
         />
         <label
           class="label form-check-label label"
-          for="streaming-progress-skipped-suggest-check"
+          for="streaming-progress-skipped-suggest-check-2"
         >
           forked:yes (
           <span
@@ -371,15 +371,15 @@ exports[`StreamingProgressSkippedPopover should render correctly 1`] = `
       >
         <input
           class="form-check-input"
-          data-testid="streaming-progress-skipped-suggest-check"
-          id="streaming-progress-skipped-suggest-check"
+          data-testid="streaming-progress-skipped-suggest-check-3"
+          id="streaming-progress-skipped-suggest-check-3"
           label="[object Object]"
           type="checkbox"
           value="archived:yes"
         />
         <label
           class="label form-check-label label"
-          for="streaming-progress-skipped-suggest-check"
+          for="streaming-progress-skipped-suggest-check-3"
         >
           archived:yes (
           <span
@@ -405,15 +405,15 @@ exports[`StreamingProgressSkippedPopover should render correctly 1`] = `
       >
         <input
           class="form-check-input"
-          data-testid="streaming-progress-skipped-suggest-check"
-          id="streaming-progress-skipped-suggest-check"
+          data-testid="streaming-progress-skipped-suggest-check-4"
+          id="streaming-progress-skipped-suggest-check-4"
           label="[object Object]"
           type="checkbox"
           value="archived:yes"
         />
         <label
           class="label form-check-label label"
-          for="streaming-progress-skipped-suggest-check"
+          for="streaming-progress-skipped-suggest-check-4"
         >
           include archived (
           <span

--- a/client/web/src/search/results/StreamingSearchResults.test.tsx
+++ b/client/web/src/search/results/StreamingSearchResults.test.tsx
@@ -270,7 +270,7 @@ describe('StreamingSearchResults', () => {
             renderWrapper(<StreamingSearchResults {...defaultProps} streamSearch={() => of(results)} />)
 
             userEvent.click(await screen.findByText(/some results excluded/i))
-            const allChecks = await screen.findAllByTestId('streaming-progress-skipped-suggest-check')
+            const allChecks = await screen.findAllByTestId(/^streaming-progress-skipped-suggest-check/)
 
             for (const check of allChecks) {
                 userEvent.click(check, undefined, { skipPointerEventsCheck: true })


### PR DESCRIPTION
As reported in [slack](https://sourcegraph.slack.com/archives/CHEKCRWKV/p1652282095262509), clicking any of the labels was always selecting the first one. That's because we use the same ID for all checkboxes and labels are associated with checkboxes via ID.

This PR fixes it by appending an index to the ID to make it unique.


## Test plan

Updated unit test.

Manual verification by executing https://sourcegraph.com/search?q=context:%40sourcegraph/all+record&patternType=literal locally, verifying that multiple checkboxes are rendered and selecting each by clicking on the label.

## App preview:

- [Web](https://sg-web-fkling-fix-stream-search.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-ujynehlqpb.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
