### PR TITLE
dev/ci: set -e on asdf-install.sh

### DIFF
--- a/dev/ci/asdf-install.sh
+++ b/dev/ci/asdf-install.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e
+
 # ASDF setup that either does a simple install, or pulls it from cache, geared towards
 # usage in CI.
 # In most cases you should not need to call this script directly.


### PR DESCRIPTION
Looks like asdf-install.sh does not fail with a non-zero exit code if installation fails? https://buildkite.com/sourcegraph/sourcegraph/builds/147001#dd36d5f3-b7d7-45ba-aa43-d2bd3b6e39d6/141-163

## Test plan

CI passes
