### PR TITLE
batches: refactor insights go code checker banner

### DIFF
--- a/client/web/src/batches/index.ts
+++ b/client/web/src/batches/index.ts
@@ -3,18 +3,29 @@ import { Settings, SettingsCascadeOrError } from '@sourcegraph/shared/src/settin
 
 /**
  * Utility for checking if a user has the experimental feature, batch change server-side
- * execution, enabled in their settings
+ * execution, enabled in their settings.
  */
 export const isBatchChangesExecutionEnabled = (settingsCascade: SettingsCascadeOrError<Settings>): boolean =>
     Boolean(
-        settingsCascade !== null &&
+        settingsCascade.final !== null &&
             !isErrorLike(settingsCascade.final) &&
-            settingsCascade.final?.experimentalFeatures?.batchChangesExecution
+            settingsCascade.final.experimentalFeatures?.batchChangesExecution
+    )
+
+/**
+ * Utility for checking if a user has the experimental feature flag for the code insights
+ * integration with batch changes enabled in their settings.
+ */
+export const isGoCodeCheckerTemplatesEnabled = (settingsCascade: SettingsCascadeOrError<Settings>): boolean =>
+    Boolean(
+        settingsCascade.final !== null &&
+            !isErrorLike(settingsCascade.final) &&
+            settingsCascade.final.experimentalFeatures?.goCodeCheckerTemplates
     )
 
 /**
  * Common props for components needing to decide whether to show content related to Batch
- * Changes
+ * Changes.
  */
 export interface BatchChangesProps {
     batchChangesExecutionEnabled: boolean

--- a/client/web/src/batches/index.ts
+++ b/client/web/src/batches/index.ts
@@ -1,5 +1,6 @@
 import { isErrorLike } from '@sourcegraph/common'
-import { Settings, SettingsCascadeOrError } from '@sourcegraph/shared/src/settings/settings'
+import { Settings } from '@sourcegraph/shared/src/schema/settings.schema'
+import { SettingsCascadeOrError } from '@sourcegraph/shared/src/settings/settings'
 
 /**
  * Utility for checking if a user has the experimental feature, batch change server-side

--- a/client/web/src/enterprise/batches/create/CreateOrEditBatchChangePage.tsx
+++ b/client/web/src/enterprise/batches/create/CreateOrEditBatchChangePage.tsx
@@ -168,7 +168,7 @@ const CreatePage: React.FunctionComponent<React.PropsWithChildren<CreatePageProp
     return (
         <div className="w-100 p-4">
             <PageTitle title="Create new batch change" />
-            {insightTitle && <InsightTemplatesBanner insightTitle={insightTitle} type="create" />}
+            {insightTitle && <InsightTemplatesBanner insightTitle={insightTitle} type="create" className="mb-5" />}
             <PageHeader
                 path={[{ icon: BatchChangesIcon, to: '.' }, { text: 'Create batch change' }]}
                 className="flex-1 pb-2"
@@ -545,7 +545,9 @@ const EditPage: React.FunctionComponent<React.PropsWithChildren<EditPageProps>> 
                 <LibraryPane name={batchChange.name} onReplaceItem={clearErrorsAndHandleCodeChange} />
                 <div className={styles.editorContainer}>
                     <h4 className={styles.header}>Batch spec</h4>
-                    {insightTitle && <InsightTemplatesBanner insightTitle={insightTitle} type="edit" />}
+                    {insightTitle && (
+                        <InsightTemplatesBanner insightTitle={insightTitle} type="edit" className="mb-3" />
+                    )}
                     <MonacoBatchSpecEditor
                         batchChangeName={batchChange.name}
                         className={styles.editor}

--- a/client/web/src/enterprise/batches/create/CreateOrEditBatchChangePage.tsx
+++ b/client/web/src/enterprise/batches/create/CreateOrEditBatchChangePage.tsx
@@ -6,11 +6,10 @@ import { noop } from 'lodash'
 import AlertCircleIcon from 'mdi-react/AlertCircleIcon'
 import InfoCircleOutlineIcon from 'mdi-react/InfoCircleOutlineIcon'
 import LockIcon from 'mdi-react/LockIcon'
-import { useHistory, useLocation } from 'react-router'
+import { useHistory } from 'react-router'
 
 import { ErrorAlert } from '@sourcegraph/branded/src/components/alerts'
 import { Form } from '@sourcegraph/branded/src/components/Form'
-import { isErrorLike } from '@sourcegraph/common'
 import { useMutation, useQuery } from '@sourcegraph/http-client'
 import { Settings } from '@sourcegraph/shared/src/schema/settings.schema'
 import {
@@ -35,8 +34,6 @@ import {
     TabPanel,
     TabPanels,
     RadioButton,
-    Card,
-    CardBody,
     Typography,
 } from '@sourcegraph/wildcard'
 
@@ -70,9 +67,9 @@ import { useBatchSpecCode } from '../batch-spec/useBatchSpecCode'
 import { BatchSpecDownloadLink } from '../BatchSpec'
 
 import { GET_BATCH_CHANGE_TO_EDIT, CREATE_EMPTY_BATCH_CHANGE, CREATE_BATCH_SPEC_FROM_RAW } from './backend'
-import { CodeInsightsBatchesIcon } from './CodeInsightsBatchesIcon'
-import { getTemplateRenderer } from './go-checker-templates'
+import { InsightTemplatesBanner } from './InsightTemplatesBanner'
 import { NamespaceSelector } from './NamespaceSelector'
+import { useInsightTemplates } from './useInsightTemplates'
 import { useNamespaces } from './useNamespaces'
 
 import styles from './CreateOrEditBatchChangePage.module.scss'
@@ -166,38 +163,12 @@ interface CreatePageProps extends SettingsCascadeProps<Settings> {
 const CreatePage: React.FunctionComponent<React.PropsWithChildren<CreatePageProps>> = props => {
     const isNewBatchChange = props.batchChangeName === undefined && !props.isReadOnly
 
-    const location = useLocation()
-    const parameters = new URLSearchParams(location.search)
-    const templateRenderer = getTemplateRenderer(parameters.get('kind'))
-    const codeInsightTitle = parameters.get('title') ?? undefined
-
-    const enableInsightsTemplates =
-        (codeInsightTitle &&
-            templateRenderer &&
-            props.settingsCascade.final !== null &&
-            !isErrorLike(props.settingsCascade.final) &&
-            props.settingsCascade.final.experimentalFeatures?.goCodeCheckerTemplates) ??
-        false
+    const { renderTemplate, insightTitle } = useInsightTemplates(props.settingsCascade)
 
     return (
         <div className="w-100 p-4">
             <PageTitle title="Create new batch change" />
-            {enableInsightsTemplates && (
-                <Card className={classNames('mb-5', styles.codeInsightsBanner)}>
-                    <CardBody>
-                        <div className="d-flex justify-content-between align-items-center">
-                            <CodeInsightsBatchesIcon className="mr-4" />
-                            <div className="flex-grow-1">
-                                <Typography.H4>You are creating a batch change from a code insight</Typography.H4>
-                                <p className="mb-0">
-                                    Let Sourcegraph help you with <strong>{codeInsightTitle}</strong> by preparing a
-                                    relevant <strong>batch change</strong>.
-                                </p>
-                            </div>
-                        </div>
-                    </CardBody>
-                </Card>
-            )}
+            {insightTitle && <InsightTemplatesBanner insightTitle={insightTitle} type="create" />}
             <PageHeader
                 path={[{ icon: BatchChangesIcon, to: '.' }, { text: 'Create batch change' }]}
                 className="flex-1 pb-2"
@@ -219,11 +190,7 @@ const CreatePage: React.FunctionComponent<React.PropsWithChildren<CreatePageProp
                 </TabList>
                 <TabPanels>
                     <TabPanel>
-                        <BatchConfigurationPage
-                            {...props}
-                            renderTemplate={templateRenderer}
-                            insightName={codeInsightTitle}
-                        />
+                        <BatchConfigurationPage {...props} renderTemplate={renderTemplate} insightName={insightTitle} />
                     </TabPanel>
 
                     <TabPanel>
@@ -414,7 +381,7 @@ const BatchConfigurationPage: React.FunctionComponent<React.PropsWithChildren<Ba
 const INVALID_BATCH_SPEC_TOOLTIP = "There's a problem with your batch spec."
 const WORKSPACES_PREVIEW_SIZE = 'batch-changes.ssbc-workspaces-preview-size'
 
-interface EditPageProps extends ThemeProps {
+interface EditPageProps extends ThemeProps, SettingsCascadeProps<Settings> {
     batchChange: EditBatchChangeFields
     refetchBatchChange: () => Promise<ApolloQueryResult<GetBatchChangeToEditResult>>
 }
@@ -423,10 +390,9 @@ const EditPage: React.FunctionComponent<React.PropsWithChildren<EditPageProps>> 
     batchChange,
     refetchBatchChange,
     isLightTheme,
+    settingsCascade,
 }) => {
-    const location = useLocation()
-    const parameters = new URLSearchParams(location.search)
-    const codeInsightTitle = parameters.get('title')
+    const { insightTitle } = useInsightTemplates(settingsCascade)
 
     // Get the latest batch spec for the batch change.
     const { batchSpec, isApplied: isLatestBatchSpecApplied, initialCode: initialBatchSpecCode } = useInitialBatchSpec(
@@ -578,23 +544,8 @@ const EditPage: React.FunctionComponent<React.PropsWithChildren<EditPageProps>> 
             <div className={classNames(styles.editorLayoutContainer, 'd-flex flex-1 mt-2')}>
                 <LibraryPane name={batchChange.name} onReplaceItem={clearErrorsAndHandleCodeChange} />
                 <div className={styles.editorContainer}>
-                    <Typography.H4 className={styles.header}>Batch spec</Typography.H4>
-                    {codeInsightTitle && (
-                        <Card className={classNames('mb-3', styles.codeInsightsBanner)}>
-                            <CardBody>
-                                <div className="d-flex justify-content-between align-items-center">
-                                    <CodeInsightsBatchesIcon className="mr-4" />
-                                    <div className="flex-grow-1">
-                                        <Typography.H4>Start from template for the {codeInsightTitle}</Typography.H4>
-                                        <p className="mb-0">
-                                            Sourcegraph pre-selected a Batch Specification for the batch change started
-                                            from {codeInsightTitle}.
-                                        </p>
-                                    </div>
-                                </div>
-                            </CardBody>
-                        </Card>
-                    )}
+                    <h4 className={styles.header}>Batch spec</h4>
+                    {insightTitle && <InsightTemplatesBanner insightTitle={insightTitle} type="edit" />}
                     <MonacoBatchSpecEditor
                         batchChangeName={batchChange.name}
                         className={styles.editor}

--- a/client/web/src/enterprise/batches/create/InsightTemplatesBanner.module.scss
+++ b/client/web/src/enterprise/batches/create/InsightTemplatesBanner.module.scss
@@ -1,0 +1,3 @@
+.banner {
+    box-shadow: var(--box-shadow);
+}

--- a/client/web/src/enterprise/batches/create/InsightTemplatesBanner.story.tsx
+++ b/client/web/src/enterprise/batches/create/InsightTemplatesBanner.story.tsx
@@ -4,13 +4,9 @@ import { WebStory } from '../../../components/WebStory'
 
 import { InsightTemplatesBanner } from './InsightTemplatesBanner'
 
-const { add } = storiesOf('web/batches/create/InsightTemplatesBanner', module)
-    .addDecorator(story => <div className="p-3 container">{story()}</div>)
-    .addParameters({
-        chromatic: {
-            disableSnapshot: false,
-        },
-    })
+const { add } = storiesOf('web/batches/create/InsightTemplatesBanner', module).addDecorator(story => (
+    <div className="p-3 container">{story()}</div>
+))
 
 add('creating new batch change from insight', () => (
     <WebStory>{props => <InsightTemplatesBanner {...props} insightTitle="My Go Insight" type="create" />}</WebStory>

--- a/client/web/src/enterprise/batches/create/InsightTemplatesBanner.story.tsx
+++ b/client/web/src/enterprise/batches/create/InsightTemplatesBanner.story.tsx
@@ -4,7 +4,7 @@ import { WebStory } from '../../../components/WebStory'
 
 import { InsightTemplatesBanner } from './InsightTemplatesBanner'
 
-const { add } = storiesOf('web/batches/create', module)
+const { add } = storiesOf('web/batches/create/InsightTemplatesBanner', module)
     .addDecorator(story => <div className="p-3 container">{story()}</div>)
     .addParameters({
         chromatic: {
@@ -12,6 +12,10 @@ const { add } = storiesOf('web/batches/create', module)
         },
     })
 
-add('InsightTemplatesBanner', () => (
-    <WebStory>{props => <InsightTemplatesBanner {...props} insightTitle="My Go Insight" />}</WebStory>
+add('creating new batch change from insight', () => (
+    <WebStory>{props => <InsightTemplatesBanner {...props} insightTitle="My Go Insight" type="create" />}</WebStory>
+))
+
+add('editing a batch spec from an insight template', () => (
+    <WebStory>{props => <InsightTemplatesBanner {...props} insightTitle="My Go Insight" type="edit" />}</WebStory>
 ))

--- a/client/web/src/enterprise/batches/create/InsightTemplatesBanner.story.tsx
+++ b/client/web/src/enterprise/batches/create/InsightTemplatesBanner.story.tsx
@@ -1,0 +1,17 @@
+import { storiesOf } from '@storybook/react'
+
+import { WebStory } from '../../../components/WebStory'
+
+import { InsightTemplatesBanner } from './InsightTemplatesBanner'
+
+const { add } = storiesOf('web/batches/create', module)
+    .addDecorator(story => <div className="p-3 container">{story()}</div>)
+    .addParameters({
+        chromatic: {
+            disableSnapshot: false,
+        },
+    })
+
+add('InsightTemplatesBanner', () => (
+    <WebStory>{props => <InsightTemplatesBanner {...props} insightTitle="My Go Insight" />}</WebStory>
+))

--- a/client/web/src/enterprise/batches/create/InsightTemplatesBanner.tsx
+++ b/client/web/src/enterprise/batches/create/InsightTemplatesBanner.tsx
@@ -2,25 +2,41 @@ import React from 'react'
 
 import classNames from 'classnames'
 
-import { Card, CardBody, H4 } from '@sourcegraph/wildcard'
+import { Card, CardBody, Typography } from '@sourcegraph/wildcard'
 
 import { CodeInsightsBatchesIcon } from './CodeInsightsBatchesIcon'
 
 import styles from './InsightTemplatesBanner.module.scss'
 
-export const InsightTemplatesBanner: React.FunctionComponent<{ insightTitle: string }> = ({ insightTitle }) => (
-    <Card className={classNames('mb-5', styles.banner)}>
-        <CardBody>
-            <div className="d-flex justify-content-between align-items-center">
-                <CodeInsightsBatchesIcon className="mr-4" />
-                <div className="flex-grow-1">
-                    <H4>You are creating a batch change from a code insight</H4>
-                    <p className="mb-0">
-                        Let Sourcegraph help you with <strong>{insightTitle}</strong> by preparing a relevant{' '}
-                        <strong>batch change</strong>.
-                    </p>
+export const InsightTemplatesBanner: React.FunctionComponent<{ insightTitle: string; type: 'create' | 'edit' }> = ({
+    insightTitle,
+    type,
+}) => {
+    const [heading, paragraph]: [React.ReactNode, React.ReactNode] =
+        type === 'create'
+            ? [
+                  'You are creating a batch change from a code insight',
+                  <>
+                      Let Sourcegraph help you with <strong>{insightTitle}</strong> by preparing a relevant{' '}
+                      <strong>batch change</strong>.
+                  </>,
+              ]
+            : [
+                  `Start from template for the ${insightTitle}`,
+                  `Sourcegraph pre-selected a batch spec for the batch change started from ${insightTitle}.`,
+              ]
+
+    return (
+        <Card className={classNames('mb-5', styles.banner)}>
+            <CardBody>
+                <div className="d-flex justify-content-between align-items-center">
+                    <CodeInsightsBatchesIcon className="mr-4" />
+                    <div className="flex-grow-1">
+                        <Typography.H4>{heading}</Typography.H4>
+                        <p className="mb-0">{paragraph}</p>
+                    </div>
                 </div>
-            </div>
-        </CardBody>
-    </Card>
-)
+            </CardBody>
+        </Card>
+    )
+}

--- a/client/web/src/enterprise/batches/create/InsightTemplatesBanner.tsx
+++ b/client/web/src/enterprise/batches/create/InsightTemplatesBanner.tsx
@@ -8,8 +8,15 @@ import { CodeInsightsBatchesIcon } from './CodeInsightsBatchesIcon'
 
 import styles from './InsightTemplatesBanner.module.scss'
 
-export const InsightTemplatesBanner: React.FunctionComponent<{ insightTitle: string; type: 'create' | 'edit' }> = ({
+interface InsightTemplatesBannerProps {
+    insightTitle: string
+    type: 'create' | 'edit'
+    className?: string
+}
+
+export const InsightTemplatesBanner: React.FunctionComponent<InsightTemplatesBannerProps> = ({
     insightTitle,
+    className,
     type,
 }) => {
     const [heading, paragraph]: [React.ReactNode, React.ReactNode] =
@@ -27,7 +34,7 @@ export const InsightTemplatesBanner: React.FunctionComponent<{ insightTitle: str
               ]
 
     return (
-        <Card className={classNames('mb-5', styles.banner)}>
+        <Card className={classNames(className, styles.banner)}>
             <CardBody>
                 <div className="d-flex justify-content-between align-items-center">
                     <CodeInsightsBatchesIcon className="mr-4" />

--- a/client/web/src/enterprise/batches/create/InsightTemplatesBanner.tsx
+++ b/client/web/src/enterprise/batches/create/InsightTemplatesBanner.tsx
@@ -1,0 +1,26 @@
+import React from 'react'
+
+import classNames from 'classnames'
+
+import { Card, CardBody, H4 } from '@sourcegraph/wildcard'
+
+import { CodeInsightsBatchesIcon } from './CodeInsightsBatchesIcon'
+
+import styles from './InsightTemplatesBanner.module.scss'
+
+export const InsightTemplatesBanner: React.FunctionComponent<{ insightTitle: string }> = ({ insightTitle }) => (
+    <Card className={classNames('mb-5', styles.banner)}>
+        <CardBody>
+            <div className="d-flex justify-content-between align-items-center">
+                <CodeInsightsBatchesIcon className="mr-4" />
+                <div className="flex-grow-1">
+                    <H4>You are creating a batch change from a code insight</H4>
+                    <p className="mb-0">
+                        Let Sourcegraph help you with <strong>{insightTitle}</strong> by preparing a relevant{' '}
+                        <strong>batch change</strong>.
+                    </p>
+                </div>
+            </div>
+        </CardBody>
+    </Card>
+)

--- a/client/web/src/enterprise/batches/create/useInsightTemplates.ts
+++ b/client/web/src/enterprise/batches/create/useInsightTemplates.ts
@@ -1,0 +1,38 @@
+import { useLocation } from 'react-router'
+
+import { Settings, SettingsCascadeOrError } from '@sourcegraph/shared/src/settings/settings'
+
+import { isGoCodeCheckerTemplatesEnabled } from '../../../batches'
+
+import { getTemplateRenderer } from './go-checker-templates'
+
+type UseInsightTemplatesResult =
+    | {
+          renderTemplate: undefined
+          insightTitle: undefined
+      }
+    | {
+          renderTemplate: (title: string) => string
+          insightTitle: string
+      }
+
+/**
+ * Custom hook for create page which checks if a user has enabled the experimental code
+ * insights integration with batch changes and is creating a batch change from a Go code
+ * checker insight.
+ *
+ * @param settingsCascade The user's current settings.
+ */
+export const useInsightTemplates = (settingsCascade: SettingsCascadeOrError<Settings>): UseInsightTemplatesResult => {
+    const location = useLocation()
+    const parameters = new URLSearchParams(location.search)
+    const renderTemplate = getTemplateRenderer(parameters.get('kind'))
+    const insightTitle = parameters.get('title') ?? undefined
+
+    return isGoCodeCheckerTemplatesEnabled(settingsCascade) && renderTemplate && insightTitle
+        ? {
+              renderTemplate,
+              insightTitle,
+          }
+        : { renderTemplate: undefined, insightTitle: undefined }
+}

--- a/client/web/src/enterprise/batches/create/useInsightTemplates.ts
+++ b/client/web/src/enterprise/batches/create/useInsightTemplates.ts
@@ -6,15 +6,10 @@ import { isGoCodeCheckerTemplatesEnabled } from '../../../batches'
 
 import { getTemplateRenderer } from './go-checker-templates'
 
-type UseInsightTemplatesResult =
-    | {
-          renderTemplate: undefined
-          insightTitle: undefined
-      }
-    | {
-          renderTemplate: (title: string) => string
-          insightTitle: string
-      }
+interface UseInsightTemplatesResult {
+    renderTemplate?: (title: string) => string
+    insightTitle?: string
+}
 
 /**
  * Custom hook for create page which checks if a user has enabled the experimental code
@@ -29,10 +24,7 @@ export const useInsightTemplates = (settingsCascade: SettingsCascadeOrError<Sett
     const renderTemplate = getTemplateRenderer(parameters.get('kind'))
     const insightTitle = parameters.get('title') ?? undefined
 
-    return isGoCodeCheckerTemplatesEnabled(settingsCascade) && renderTemplate && insightTitle
-        ? {
-              renderTemplate,
-              insightTitle,
-          }
+    return isGoCodeCheckerTemplatesEnabled(settingsCascade)
+        ? { renderTemplate, insightTitle }
         : { renderTemplate: undefined, insightTitle: undefined }
 }


### PR DESCRIPTION
Note: This PR is temporarily based on #35338 to prevent merge conflicts. After that is merged, I will rebase and update this one.

This PR is a light refactor on the code insights integration for go code checkers to reduce duplicate logic and decouple the logic from the extremely heavy SSBC page components by putting it in a hook instead. It also improves the consistency of variable names, adds more code comments, and introduces a story for the banner component. None of the logic about how the banner is displayed is changed. I completed this in conjunction with https://github.com/sourcegraph/sourcegraph/issues/33395, but separated it out into its own branch since it's not particularly related to that ticket. 

## Test plan

None of the logic about how the banner is displayed is changed. The banner itself now has storybook coverage. I enabled the experimental flag and verified the presence of the banner on both the create and edit pages locally:

<img width="1702" alt="Screen Shot 2022-05-11 at 7 52 07 PM" src="https://user-images.githubusercontent.com/8942601/167966124-4d553f09-d51f-41c7-a6ae-cd6b4e238e03.png">

<img width="1017" alt="Screen Shot 2022-05-11 at 7 51 52 PM" src="https://user-images.githubusercontent.com/8942601/167966130-3e8fae93-fb19-4e48-a65c-61cc6a22fd71.png">


<!-- all pull requests REQUIRE a test plan.   https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-kr-insights-banner-cleanup.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-lslonliwut.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
