### PR TITLE
[SG-35214] Wildcard V2: <Typography /> Manual migration Label

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -142,6 +142,10 @@ See https://handbook.sourcegraph.com/community/faq#is-all-of-sourcegraph-open-so
             element: 'h6',
             message: 'Use the <Typography.H6 /> component from @sourcegraph/wildcard instead.',
           },
+          {
+            element: 'label',
+            message: 'Use the <Typography.Label /> component from @sourcegraph/wildcard instead.',
+          },
         ],
       },
     ],

--- a/client/branded/src/components/Toggle.story.tsx
+++ b/client/branded/src/components/Toggle.story.tsx
@@ -4,6 +4,7 @@ import { action } from '@storybook/addon-actions'
 import { DecoratorFn, Meta, Story } from '@storybook/react'
 
 import webStyles from '@sourcegraph/web/src/SourcegraphWebApp.scss'
+import { Typography } from '@sourcegraph/wildcard'
 
 import { Toggle } from './Toggle'
 
@@ -11,9 +12,9 @@ const ToggleExample: typeof Toggle = ({ value, disabled, onToggle }) => (
     <div className="d-flex align-items-baseline mb-2">
         <Toggle value={value} onToggle={onToggle} disabled={disabled} title="Hello" className="mr-2" />
         <div>
-            <label className="mb-0">
+            <Typography.Label className="mb-0">
                 {disabled ? 'Disabled ' : ''}Toggle {value ? 'on' : 'off'}
-            </label>
+            </Typography.Label>
             <small className="field-message mt-0">This is helper text as needed</small>
         </div>
     </div>

--- a/client/branded/src/global-styles/GlobalStylesStory/GlobalStyles.story.tsx
+++ b/client/branded/src/global-styles/GlobalStylesStory/GlobalStyles.story.tsx
@@ -406,7 +406,7 @@ export const Forms: Story = () => (
         </p>
         <Form onSubmit={preventDefault}>
             <div className="form-group">
-                <label htmlFor="example-email-input">Email address</label>
+                <Typography.Label htmlFor="example-email-input">Email address</Typography.Label>
                 <input
                     type="email"
                     className="form-control"
@@ -419,7 +419,7 @@ export const Forms: Story = () => (
                 </small>
             </div>
             <div className="form-group">
-                <label htmlFor="example-input-password">Password</label>
+                <Typography.Label htmlFor="example-input-password">Password</Typography.Label>
                 <input type="password" className="form-control" id="example-input-password" />
             </div>
 
@@ -444,7 +444,7 @@ export const Forms: Story = () => (
         <Form>
             <fieldset disabled={true}>
                 <div className="form-group">
-                    <label htmlFor="disabledTextInput">Disabled input</label>
+                    <Typography.Label htmlFor="disabledTextInput">Disabled input</Typography.Label>
                     <input type="text" id="disabledTextInput" className="form-control" placeholder="Disabled input" />
                 </div>
 

--- a/client/browser/src/browser-extension/options-menu/OptionsPage.tsx
+++ b/client/browser/src/browser-extension/options-menu/OptionsPage.tsx
@@ -332,7 +332,7 @@ export const SourcegraphURLForm: React.FunctionComponent<React.PropsWithChildren
     return (
         // eslint-disable-next-line react/forbid-elements
         <form onSubmit={preventDefault} noValidate={true}>
-            <label htmlFor="sourcegraph-url">Sourcegraph URL</label>
+            <Typography.Label htmlFor="sourcegraph-url">Sourcegraph URL</Typography.Label>
             <Combobox openOnFocus={true} onSelect={nextUrlFieldChange}>
                 <LoaderInput loading={urlState.kind === 'LOADING'} className={deriveInputClassName(urlState)}>
                     <ComboboxInput

--- a/client/shared/src/commandPalette/CommandList.tsx
+++ b/client/shared/src/commandPalette/CommandList.tsx
@@ -19,7 +19,7 @@ import { Key } from 'ts-key-enum'
 
 import { ContributableMenu, Contributions, Evaluated } from '@sourcegraph/client-api'
 import { memoizeObservable } from '@sourcegraph/common'
-import { Button, ButtonProps, LoadingSpinner, Icon } from '@sourcegraph/wildcard'
+import { Button, ButtonProps, LoadingSpinner, Icon, Typography } from '@sourcegraph/wildcard'
 
 import { ActionItem, ActionItemAction } from '../actions/ActionItem'
 import { wrapRemoteObservable } from '../api/client/api/common'
@@ -212,9 +212,9 @@ export class CommandList extends React.PureComponent<CommandListProps, State> {
                 <header>
                     {/* eslint-disable-next-line react/forbid-elements */}
                     <form className={this.props.formClassName} onSubmit={this.onSubmit}>
-                        <label className="sr-only" htmlFor="command-list-input">
+                        <Typography.Label className="sr-only" htmlFor="command-list-input">
                             Command
-                        </label>
+                        </Typography.Label>
                         <input
                             id="command-list-input"
                             ref={input => input && this.state.autoFocus && input.focus({ preventScroll: true })}

--- a/client/vscode/src/webview/search-panel/components/SavedSearchForm.tsx
+++ b/client/vscode/src/webview/search-panel/components/SavedSearchForm.tsx
@@ -10,7 +10,7 @@ import { ErrorAlert } from '@sourcegraph/branded/src/components/alerts'
 import { Form } from '@sourcegraph/branded/src/components/Form'
 import { dataOrThrowErrors, gql } from '@sourcegraph/http-client'
 import { AuthenticatedUser } from '@sourcegraph/shared/src/auth'
-import { Checkbox, Container, Icon, PageHeader } from '@sourcegraph/wildcard'
+import { Checkbox, Container, Icon, PageHeader, Typography } from '@sourcegraph/wildcard'
 
 import { CreateSavedSearchResult, CreateSavedSearchVariables, SavedSearchFields } from '../../../graphql-operations'
 import { WebviewPageProps } from '../../platform/context'
@@ -179,9 +179,9 @@ const SavedSearchForm: React.FunctionComponent<React.PropsWithChildren<SavedSear
                         className="mb-3"
                     />
                     <div className="form-group">
-                        <label className={styles.label} htmlFor="saved-search-form-input-description">
+                        <Typography.Label className={styles.label} htmlFor="saved-search-form-input-description">
                             Description
-                        </label>
+                        </Typography.Label>
                         <input
                             id="saved-search-form-input-description"
                             type="text"
@@ -194,9 +194,9 @@ const SavedSearchForm: React.FunctionComponent<React.PropsWithChildren<SavedSear
                         />
                     </div>
                     <div className="form-group">
-                        <label className={styles.label} htmlFor="saved-search-form-input-query">
+                        <Typography.Label className={styles.label} htmlFor="saved-search-form-input-query">
                             Query
-                        </label>
+                        </Typography.Label>
                         <input
                             id="saved-search-form-input-query"
                             type="text"
@@ -213,9 +213,9 @@ const SavedSearchForm: React.FunctionComponent<React.PropsWithChildren<SavedSear
                         <div className="form-group mb-0">
                             {/* Label is for visual benefit, input has more specific label attached */}
                             {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
-                            <label className={styles.label} id="saved-search-form-email-notifications">
+                            <Typography.Label className={styles.label} id="saved-search-form-email-notifications">
                                 Email notifications
-                            </label>
+                            </Typography.Label>
                             <div aria-labelledby="saved-search-form-email-notifications">
                                 <Checkbox
                                     name="Notify owner"
@@ -232,9 +232,9 @@ const SavedSearchForm: React.FunctionComponent<React.PropsWithChildren<SavedSear
 
                     {notifySlack && slackWebhookURL && (
                         <div className="form-group mt-3 mb-0">
-                            <label className={styles.label} htmlFor="saved-search-form-input-slack">
+                            <Typography.Label className={styles.label} htmlFor="saved-search-form-input-slack">
                                 Slack notifications
-                            </label>
+                            </Typography.Label>
                             <input
                                 id="saved-search-form-input-slack"
                                 type="text"

--- a/client/vscode/src/webview/sidebars/auth/AuthSidebarView.tsx
+++ b/client/vscode/src/webview/sidebars/auth/AuthSidebarView.tsx
@@ -140,7 +140,7 @@ export const AuthSidebarView: React.FunctionComponent<React.PropsWithChildren<Au
             </p>
             <p className={classNames(styles.ctaButtonWrapperWithContextBelow)}>
                 <LoaderInput loading={state === 'validating'}>
-                    <label htmlFor="access-token-input">Access Token</label>
+                    <Typography.Label htmlFor="access-token-input">Access Token</Typography.Label>
                     <input
                         className={classNames('input form-control', styles.ctaInput)}
                         id="access-token-input"
@@ -157,7 +157,7 @@ export const AuthSidebarView: React.FunctionComponent<React.PropsWithChildren<Au
             {usePrivateInstance && (
                 <p className={classNames(styles.ctaButtonWrapperWithContextBelow)}>
                     <LoaderInput loading={state === 'validating'}>
-                        <label htmlFor="instance-url-input">Sourcegraph Instance URL</label>
+                        <Typography.Label htmlFor="instance-url-input">Sourcegraph Instance URL</Typography.Label>
                         <input
                             className={classNames('input form-control', styles.ctaInput)}
                             id="instance-url-input"

--- a/client/web/src/auth/SignUpForm.tsx
+++ b/client/web/src/auth/SignUpForm.tsx
@@ -17,7 +17,7 @@ import {
     ValidationOptions,
     deriveInputClassName,
 } from '@sourcegraph/shared/src/util/useInputValidation'
-import { Button, Link, Icon, Checkbox } from '@sourcegraph/wildcard'
+import { Button, Link, Icon, Checkbox, Typography } from '@sourcegraph/wildcard'
 
 import { LoaderButton } from '../components/LoaderButton'
 import { FeatureFlagProps } from '../featureFlags/featureFlags'
@@ -204,14 +204,14 @@ export const SignUpForm: React.FunctionComponent<React.PropsWithChildren<SignUpF
                     emailInputReference={emailInputReference}
                 />
                 <div className="form-group d-flex flex-column align-content-start">
-                    <label
+                    <Typography.Label
                         htmlFor="username"
                         className={classNames('align-self-start', {
                             'text-danger font-weight-bold': usernameState.kind === 'INVALID',
                         })}
                     >
                         Username
-                    </label>
+                    </Typography.Label>
                     <LoaderInput
                         className={classNames(deriveInputClassName(usernameState))}
                         loading={usernameState.kind === 'LOADING'}
@@ -233,14 +233,14 @@ export const SignUpForm: React.FunctionComponent<React.PropsWithChildren<SignUpF
                     )}
                 </div>
                 <div className="form-group d-flex flex-column align-content-start">
-                    <label
+                    <Typography.Label
                         htmlFor="password"
                         className={classNames('align-self-start', {
                             'text-danger font-weight-bold': passwordState.kind === 'INVALID',
                         })}
                     >
                         Password
-                    </label>
+                    </Typography.Label>
                     <LoaderInput
                         className={classNames(deriveInputClassName(passwordState))}
                         loading={passwordState.kind === 'LOADING'}

--- a/client/web/src/auth/SignupEmailField.tsx
+++ b/client/web/src/auth/SignupEmailField.tsx
@@ -4,6 +4,7 @@ import classNames from 'classnames'
 
 import { LoaderInput } from '@sourcegraph/branded/src/components/LoaderInput'
 import { deriveInputClassName, InputValidationState } from '@sourcegraph/shared/src/util/useInputValidation'
+import { Typography } from '@sourcegraph/wildcard'
 
 import { EmailInput } from './SignInSignUpCommon'
 
@@ -23,14 +24,14 @@ export const SignupEmailField: React.FunctionComponent<React.PropsWithChildren<S
     emailInputReference,
 }) => (
     <div className="form-group d-flex flex-column align-content-start">
-        <label
+        <Typography.Label
             htmlFor="email"
             className={classNames('align-self-start', {
                 'text-danger font-weight-bold': emailState.kind === 'INVALID',
             })}
         >
             {label}
-        </label>
+        </Typography.Label>
         <LoaderInput className={deriveInputClassName(emailState)} loading={emailState.kind === 'LOADING'}>
             <EmailInput
                 className={deriveInputClassName(emailState)}

--- a/client/web/src/auth/UsernamePasswordSignInForm.tsx
+++ b/client/web/src/auth/UsernamePasswordSignInForm.tsx
@@ -5,7 +5,7 @@ import * as H from 'history'
 
 import { Form } from '@sourcegraph/branded/src/components/Form'
 import { asError } from '@sourcegraph/common'
-import { Button, LoadingSpinner, Link } from '@sourcegraph/wildcard'
+import { Button, LoadingSpinner, Link, Typography } from '@sourcegraph/wildcard'
 
 import { SourcegraphContext } from '../jscontext'
 import { eventLogger } from '../tracking/eventLogger'
@@ -95,9 +95,9 @@ export const UsernamePasswordSignInForm: React.FunctionComponent<React.PropsWith
         <>
             <Form onSubmit={handleSubmit}>
                 <div className="form-group d-flex flex-column align-content-start">
-                    <label htmlFor="username-or-email" className="align-self-start">
+                    <Typography.Label htmlFor="username-or-email" className="align-self-start">
                         Username or email
-                    </label>
+                    </Typography.Label>
                     <input
                         id="username-or-email"
                         className="form-control"
@@ -115,9 +115,9 @@ export const UsernamePasswordSignInForm: React.FunctionComponent<React.PropsWith
                     />
                 </div>
                 <div className="form-group d-flex flex-column align-content-start position-relative">
-                    <label htmlFor="password" className="align-self-start">
+                    <Typography.Label htmlFor="password" className="align-self-start">
                         Password
-                    </label>
+                    </Typography.Label>
                     <PasswordInput
                         onChange={onPasswordFieldChange}
                         value={password}

--- a/client/web/src/auth/__snapshots__/SignInPage.test.tsx.snap
+++ b/client/web/src/auth/__snapshots__/SignInPage.test.tsx.snap
@@ -57,7 +57,7 @@ exports[`SignInPage renders sign in page (cloud) 1`] = `
               class="form-group d-flex flex-column align-content-start"
             >
               <label
-                class="align-self-start"
+                class="label align-self-start"
                 for="username-or-email"
               >
                 Username or email
@@ -76,7 +76,7 @@ exports[`SignInPage renders sign in page (cloud) 1`] = `
               class="form-group d-flex flex-column align-content-start position-relative"
             >
               <label
-                class="align-self-start"
+                class="label align-self-start"
                 for="password"
               >
                 Password
@@ -215,7 +215,7 @@ exports[`SignInPage renders sign in page (server) 1`] = `
               class="form-group d-flex flex-column align-content-start"
             >
               <label
-                class="align-self-start"
+                class="label align-self-start"
                 for="username-or-email"
               >
                 Username or email
@@ -234,7 +234,7 @@ exports[`SignInPage renders sign in page (server) 1`] = `
               class="form-group d-flex flex-column align-content-start position-relative"
             >
               <label
-                class="align-self-start"
+                class="label align-self-start"
                 for="password"
               >
                 Password

--- a/client/web/src/auth/__snapshots__/SignUpPage.test.tsx.snap
+++ b/client/web/src/auth/__snapshots__/SignUpPage.test.tsx.snap
@@ -179,7 +179,7 @@ exports[`SignUpPage renders sign up page (server) 1`] = `
             class="form-group d-flex flex-column align-content-start"
           >
             <label
-              class="align-self-start"
+              class="label align-self-start"
               for="email"
             >
               Email
@@ -204,7 +204,7 @@ exports[`SignUpPage renders sign up page (server) 1`] = `
             class="form-group d-flex flex-column align-content-start"
           >
             <label
-              class="align-self-start"
+              class="label align-self-start"
               for="username"
             >
               Username
@@ -232,7 +232,7 @@ exports[`SignUpPage renders sign up page (server) 1`] = `
             class="form-group d-flex flex-column align-content-start"
           >
             <label
-              class="align-self-start"
+              class="label align-self-start"
               for="password"
             >
               Password

--- a/client/web/src/components/externalServices/ExternalServiceForm.tsx
+++ b/client/web/src/components/externalServices/ExternalServiceForm.tsx
@@ -73,9 +73,9 @@ export const ExternalServiceForm: React.FunctionComponent<React.PropsWithChildre
             )}
             {hideDisplayNameField || (
                 <div className="form-group">
-                    <label className="font-weight-bold" htmlFor="test-external-service-form-display-name">
+                    <Typography.Label weight="bold" htmlFor="test-external-service-form-display-name">
                         Display name:
-                    </label>
+                    </Typography.Label>
                     <input
                         id="test-external-service-form-display-name"
                         type="text"

--- a/client/web/src/components/externalServices/__snapshots__/ExternalServiceForm.test.tsx.snap
+++ b/client/web/src/components/externalServices/__snapshots__/ExternalServiceForm.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`ExternalServiceForm create GitHub 1`] = `
       class="form-group"
     >
       <label
-        class="font-weight-bold"
+        class="label fontWeightBold"
         for="test-external-service-form-display-name"
       >
         Display name:
@@ -56,7 +56,7 @@ exports[`ExternalServiceForm edit GitHub 1`] = `
       class="form-group"
     >
       <label
-        class="font-weight-bold"
+        class="label fontWeightBold"
         for="test-external-service-form-display-name"
       >
         Display name:
@@ -103,7 +103,7 @@ exports[`ExternalServiceForm edit GitHub, loading 1`] = `
       class="form-group"
     >
       <label
-        class="font-weight-bold"
+        class="label fontWeightBold"
         for="test-external-service-form-display-name"
       >
         Display name:

--- a/client/web/src/enterprise/batches/detail/BatchChangeBurndownChart.tsx
+++ b/client/web/src/enterprise/batches/detail/BatchChangeBurndownChart.tsx
@@ -15,7 +15,7 @@ import {
 } from 'recharts'
 
 import { Toggle } from '@sourcegraph/branded/src/components/Toggle'
-import { Checkbox, Container, LoadingSpinner, useObservable } from '@sourcegraph/wildcard'
+import { Checkbox, Container, LoadingSpinner, Typography, useObservable } from '@sourcegraph/wildcard'
 
 import { ChangesetCountsOverTimeFields, Scalars } from '../../../graphql-operations'
 
@@ -239,9 +239,9 @@ const IncludeArchivedToggle: React.FunctionComponent<
     }>
 > = ({ includeArchived, onToggle }) => (
     <div className="d-flex align-items-center justify-content-between text-nowrap mb-2 pt-1">
-        <label htmlFor="include-archived" className="mb-0">
+        <Typography.Label htmlFor="include-archived" className="mb-0">
             Include archived
-        </label>
+        </Typography.Label>
         <Toggle
             id="include-archived"
             value={includeArchived}

--- a/client/web/src/enterprise/batches/settings/AddCredentialModal.tsx
+++ b/client/web/src/enterprise/batches/settings/AddCredentialModal.tsx
@@ -4,7 +4,7 @@ import classNames from 'classnames'
 
 import { ErrorAlert } from '@sourcegraph/branded/src/components/alerts'
 import { Form } from '@sourcegraph/branded/src/components/Form'
-import { Button, Modal, Link } from '@sourcegraph/wildcard'
+import { Button, Modal, Link, Typography } from '@sourcegraph/wildcard'
 
 import { LoaderButton } from '../../../components/LoaderButton'
 import { ExternalServiceKind, Scalars } from '../../../graphql-operations'
@@ -179,7 +179,7 @@ export const AddCredentialModal: React.FunctionComponent<React.PropsWithChildren
                             <div className="form-group">
                                 {requiresUsername && (
                                     <>
-                                        <label htmlFor="username">Username</label>
+                                        <Typography.Label htmlFor="username">Username</Typography.Label>
                                         <input
                                             id="username"
                                             name="username"
@@ -194,7 +194,7 @@ export const AddCredentialModal: React.FunctionComponent<React.PropsWithChildren
                                         />
                                     </>
                                 )}
-                                <label htmlFor="token">{patLabel}</label>
+                                <Typography.Label htmlFor="token">{patLabel}</Typography.Label>
                                 <input
                                     id="token"
                                     name="token"

--- a/client/web/src/enterprise/batches/settings/CodeHostSshPublicKey.tsx
+++ b/client/web/src/enterprise/batches/settings/CodeHostSshPublicKey.tsx
@@ -4,7 +4,7 @@ import copy from 'copy-to-clipboard'
 import { noop } from 'lodash'
 import ContentCopyIcon from 'mdi-react/ContentCopyIcon'
 
-import { Button, TextArea, Link, Icon } from '@sourcegraph/wildcard'
+import { Button, TextArea, Link, Icon, Typography } from '@sourcegraph/wildcard'
 
 import { ExternalServiceKind } from '../../../graphql-operations'
 
@@ -51,7 +51,7 @@ export const CodeHostSshPublicKey: React.FunctionComponent<React.PropsWithChildr
     return (
         <>
             <div className="d-flex justify-content-between align-items-end mb-2">
-                <label htmlFor={LABEL_ID}>{label}</label>
+                <Typography.Label htmlFor={LABEL_ID}>{label}</Typography.Label>
                 {showCopyButton && (
                     <Button onClick={onCopy} variant="secondary">
                         <Icon as={ContentCopyIcon} />

--- a/client/web/src/enterprise/code-monitoring/components/CodeMonitorForm.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/CodeMonitorForm.tsx
@@ -10,7 +10,7 @@ import { Form } from '@sourcegraph/branded/src/components/Form'
 import { Toggle } from '@sourcegraph/branded/src/components/Toggle'
 import { asError, isErrorLike } from '@sourcegraph/common'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
-import { Container, Button, useEventObservable, Alert, Link, Select } from '@sourcegraph/wildcard'
+import { Container, Button, useEventObservable, Alert, Link, Select, Typography } from '@sourcegraph/wildcard'
 
 import { AuthenticatedUser } from '../../../auth'
 import { CodeMonitorFields } from '../../../graphql-operations'
@@ -158,7 +158,7 @@ export const CodeMonitorForm: React.FunctionComponent<React.PropsWithChildren<Co
             <Form className="my-4 pb-5" data-testid="monitor-form" onSubmit={requestOnSubmit}>
                 <Container className="mb-3">
                     <div className="form-group">
-                        <label htmlFor="code-monitor-form-name">Name</label>
+                        <Typography.Label htmlFor="code-monitor-form-name">Name</Typography.Label>
                         <input
                             id="code-monitor-form-name"
                             type="text"

--- a/client/web/src/enterprise/code-monitoring/components/__snapshots__/FormActionArea.test.tsx.snap
+++ b/client/web/src/enterprise/code-monitoring/components/__snapshots__/FormActionArea.test.tsx.snap
@@ -30,6 +30,7 @@ exports[`FormActionArea Error is shown if code monitor has empty description 1`]
       data-testid="action-form-email"
     >
       <label
+        class="label"
         for="code-monitoring-form-actions-recipients"
       >
         Recipients

--- a/client/web/src/enterprise/code-monitoring/components/actions/EmailAction.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/actions/EmailAction.tsx
@@ -3,6 +3,8 @@ import React, { useState, useCallback } from 'react'
 import { gql, useMutation } from '@apollo/client'
 import { noop } from 'lodash'
 
+import { Typography } from '@sourcegraph/wildcard'
+
 import { MonitorEmailPriority, SendTestEmailResult, SendTestEmailVariables } from '../../../../graphql-operations'
 import { ActionProps } from '../FormActionArea'
 
@@ -116,7 +118,7 @@ export const EmailAction: React.FunctionComponent<React.PropsWithChildren<Action
             _testStartOpen={_testStartOpen}
         >
             <div className="form-group mt-4 test-action-form-email" data-testid="action-form-email">
-                <label htmlFor="code-monitoring-form-actions-recipients">Recipients</label>
+                <Typography.Label htmlFor="code-monitoring-form-actions-recipients">Recipients</Typography.Label>
                 <input
                     id="code-monitoring-form-actions-recipients"
                     type="text"

--- a/client/web/src/enterprise/code-monitoring/components/actions/SlackWebhookAction.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/actions/SlackWebhookAction.tsx
@@ -3,7 +3,7 @@ import React, { useCallback, useMemo, useState } from 'react'
 import { gql, useMutation } from '@apollo/client'
 import { noop } from 'lodash'
 
-import { Alert, Input, Link, ProductStatusBadge } from '@sourcegraph/wildcard'
+import { Alert, Input, Link, ProductStatusBadge, Typography } from '@sourcegraph/wildcard'
 
 import { SendTestSlackWebhookResult, SendTestSlackWebhookVariables } from '../../../../graphql-operations'
 import { ActionProps } from '../FormActionArea'
@@ -140,7 +140,7 @@ export const SlackWebhookAction: React.FunctionComponent<React.PropsWithChildren
                 </Link>
             </Alert>
             <div className="form-group">
-                <label htmlFor="code-monitor-slack-webhook-url">Webhook URL</label>
+                <Typography.Label htmlFor="code-monitor-slack-webhook-url">Webhook URL</Typography.Label>
                 <Input
                     id="code-monitor-slack-webhook-url"
                     type="url"

--- a/client/web/src/enterprise/code-monitoring/components/actions/WebhookAction.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/actions/WebhookAction.tsx
@@ -3,7 +3,7 @@ import React, { useCallback, useMemo, useState } from 'react'
 import { gql, useMutation } from '@apollo/client'
 import { noop } from 'lodash'
 
-import { Alert, Input, ProductStatusBadge } from '@sourcegraph/wildcard'
+import { Alert, Input, ProductStatusBadge, Typography } from '@sourcegraph/wildcard'
 
 import { SendTestWebhookResult, SendTestWebhookVariables } from '../../../../graphql-operations'
 import { ActionProps } from '../FormActionArea'
@@ -132,7 +132,7 @@ export const WebhookAction: React.FunctionComponent<React.PropsWithChildren<Acti
                 being modified. Once it is decided on, documentation will be available.
             </Alert>
             <div className="form-group">
-                <label htmlFor="code-monitor-webhook-url">Webhook URL</label>
+                <Typography.Label htmlFor="code-monitor-webhook-url">Webhook URL</Typography.Label>
                 <Input
                     id="code-monitor-webhook-url"
                     type="url"

--- a/client/web/src/enterprise/codeintel/configuration/components/BranchTargetSettings.tsx
+++ b/client/web/src/enterprise/codeintel/configuration/components/BranchTargetSettings.tsx
@@ -1,6 +1,7 @@
 import { FunctionComponent } from 'react'
 
 import { GitObjectType } from '@sourcegraph/shared/src/graphql-operations'
+import { Typography } from '@sourcegraph/wildcard'
 
 import { CodeIntelligenceConfigurationPolicyFields } from '../../../../graphql-operations'
 import { nullPolicy } from '../hooks/types'
@@ -35,7 +36,7 @@ export const BranchTargetSettings: FunctionComponent<React.PropsWithChildren<Bra
     return (
         <>
             <div className="form-group">
-                <label htmlFor="name">Name</label>
+                <Typography.Label htmlFor="name">Name</Typography.Label>
                 <input
                     id="name"
                     type="text"

--- a/client/web/src/enterprise/codeintel/configuration/components/IndexSettings.tsx
+++ b/client/web/src/enterprise/codeintel/configuration/components/IndexSettings.tsx
@@ -73,9 +73,9 @@ export const IndexingSettings: FunctionComponent<React.PropsWithChildren<Indexin
                         </Alert>
                     )}
 
-                <label className="ml-4" htmlFor="index-commit-max-age">
+                <Typography.Label className="ml-4" htmlFor="index-commit-max-age">
                     Commit max age
-                </label>
+                </Typography.Label>
                 <DurationSelect
                     id="index-commit-max-age"
                     value={policy.indexCommitMaxAgeHours ? `${policy.indexCommitMaxAgeHours}` : null}
@@ -94,9 +94,9 @@ export const IndexingSettings: FunctionComponent<React.PropsWithChildren<Indexin
                         onToggle={indexIntermediateCommits => updatePolicy({ indexIntermediateCommits })}
                         disabled={!policy.indexingEnabled}
                     />
-                    <label htmlFor="index-intermediate-commits" className="ml-2">
+                    <Typography.Label htmlFor="index-intermediate-commits" className="ml-2">
                         Index intermediate commits
-                    </label>
+                    </Typography.Label>
                 </div>
             )}
         </div>

--- a/client/web/src/enterprise/codeintel/configuration/components/ObjectsMatchingGitPattern.tsx
+++ b/client/web/src/enterprise/codeintel/configuration/components/ObjectsMatchingGitPattern.tsx
@@ -2,6 +2,8 @@ import { FunctionComponent, useEffect, useMemo, useState } from 'react'
 
 import { debounce } from 'lodash'
 
+import { Typography } from '@sourcegraph/wildcard'
+
 import { GitObjectType } from '../../../../graphql-operations'
 
 import { GitObjectPreviewWrapper } from './GitObjectPreview'
@@ -32,7 +34,7 @@ export const ObjectsMatchingGitPattern: FunctionComponent<React.PropsWithChildre
         <>
             {type !== GitObjectType.GIT_COMMIT && (
                 <div className="form-group">
-                    <label htmlFor="pattern">Pattern</label>
+                    <Typography.Label htmlFor="pattern">Pattern</Typography.Label>
                     <input
                         id="pattern"
                         type="text"

--- a/client/web/src/enterprise/codeintel/configuration/components/ReposMatchingPattern.tsx
+++ b/client/web/src/enterprise/codeintel/configuration/components/ReposMatchingPattern.tsx
@@ -4,7 +4,7 @@ import classNames from 'classnames'
 import { debounce } from 'lodash'
 import TrashIcon from 'mdi-react/TrashIcon'
 
-import { Button, Icon } from '@sourcegraph/wildcard'
+import { Button, Icon, Typography } from '@sourcegraph/wildcard'
 
 import styles from './ReposMatchingPattern.module.scss'
 
@@ -33,7 +33,7 @@ export const ReposMatchingPattern: FunctionComponent<React.PropsWithChildren<Rep
     return (
         <>
             <div className="form-group d-flex flex-column mb-0">
-                <label htmlFor="repo-pattern">Repository pattern #{index + 1}</label>
+                <Typography.Label htmlFor="repo-pattern">Repository pattern #{index + 1}</Typography.Label>
                 <input
                     type="text"
                     className="form-control text-monospace"

--- a/client/web/src/enterprise/codeintel/configuration/components/RetentionSettings.tsx
+++ b/client/web/src/enterprise/codeintel/configuration/components/RetentionSettings.tsx
@@ -59,9 +59,9 @@ export const RetentionSettings: FunctionComponent<React.PropsWithChildren<Retent
                     className={styles.radioButtons}
                 />
 
-                <label className="ml-4" htmlFor="retention-duration">
+                <Typography.Label className="ml-4" htmlFor="retention-duration">
                     Duration
-                </label>
+                </Typography.Label>
                 <DurationSelect
                     id="retention-duration"
                     value={policy.retentionDurationHours ? `${policy.retentionDurationHours}` : null}
@@ -80,9 +80,9 @@ export const RetentionSettings: FunctionComponent<React.PropsWithChildren<Retent
                         onToggle={retainIntermediateCommits => updatePolicy({ retainIntermediateCommits })}
                         disabled={policy.protected || !policy.retentionEnabled}
                     />
-                    <label htmlFor="retain-intermediate-commits" className="ml-2">
+                    <Typography.Label htmlFor="retain-intermediate-commits" className="ml-2">
                         Retain intermediate commits
-                    </label>
+                    </Typography.Label>
                 </div>
             )}
         </div>

--- a/client/web/src/enterprise/codeintel/indexes/components/EnqueueForm.tsx
+++ b/client/web/src/enterprise/codeintel/indexes/components/EnqueueForm.tsx
@@ -3,7 +3,7 @@ import { FunctionComponent, useCallback, useState } from 'react'
 import { Subject } from 'rxjs'
 
 import { ErrorAlert } from '@sourcegraph/branded/src/components/alerts'
-import { Button, Alert } from '@sourcegraph/wildcard'
+import { Button, Alert, Typography } from '@sourcegraph/wildcard'
 
 import { useEnqueueIndexJob } from '../hooks/useEnqueueIndexJob'
 
@@ -53,7 +53,7 @@ export const EnqueueForm: FunctionComponent<React.PropsWithChildren<EnqueueFormP
             {enqueueError && <ErrorAlert prefix="Error enqueueing index job" error={enqueueError} />}
 
             <div className="form-inline">
-                <label htmlFor="revlike">Git revlike</label>
+                <Typography.Label htmlFor="revlike">Git revlike</Typography.Label>
 
                 <input
                     type="text"

--- a/client/web/src/enterprise/dotcom/productPlans/ProductSubscriptionUserCountFormControl.tsx
+++ b/client/web/src/enterprise/dotcom/productPlans/ProductSubscriptionUserCountFormControl.tsx
@@ -2,6 +2,8 @@ import React, { useCallback } from 'react'
 
 import classNames from 'classnames'
 
+import { Typography } from '@sourcegraph/wildcard'
+
 interface Props {
     /** The user count input by the user. */
     value: number | null
@@ -42,9 +44,13 @@ export const ProductSubscriptionUserCountFormControl: React.FunctionComponent<Re
 
     return (
         <div className={classNames('product-subscription-user-count-control form-group align-items-center', className)}>
-            <label htmlFor="product-subscription-user-count-control__userCount" className="mb-0 mr-2 font-weight-bold">
+            <Typography.Label
+                htmlFor="product-subscription-user-count-control__userCount"
+                className="mb-0 mr-2"
+                weight="bold"
+            >
                 Users
-            </label>
+            </Typography.Label>
             <div className="d-flex align-items-center">
                 <input
                     id="product-subscription-user-count-control__userCount"

--- a/client/web/src/enterprise/dotcom/productPlans/__snapshots__/ProductSubscriptionUserCountFormControl.test.tsx.snap
+++ b/client/web/src/enterprise/dotcom/productPlans/__snapshots__/ProductSubscriptionUserCountFormControl.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`ProductSubscriptionUserCountFormControl renders 1`] = `
     class="product-subscription-user-count-control form-group align-items-center"
   >
     <label
-      class="mb-0 mr-2 font-weight-bold"
+      class="label fontWeightBold mb-0 mr-2"
       for="product-subscription-user-count-control__userCount"
     >
       Users

--- a/client/web/src/enterprise/extensions/extension/RegistryExtensionNewReleasePage.tsx
+++ b/client/web/src/enterprise/extensions/extension/RegistryExtensionNewReleasePage.tsx
@@ -163,9 +163,9 @@ export const RegistryExtensionNewReleasePage = withAuthenticatedUser<Props>(
                             <div className="row">
                                 <div className="col-lg-6">
                                     <div className="form-group">
-                                        <label htmlFor="registry-extension-new-release-page__manifest">
+                                        <Typography.Label htmlFor="registry-extension-new-release-page__manifest">
                                             <Typography.H3>Manifest</Typography.H3>
-                                        </label>
+                                        </Typography.Label>
                                         <DynamicallyImportedMonacoSettingsEditor
                                             id="registry-extension-new-release-page__manifest"
                                             className="d-block"
@@ -181,9 +181,9 @@ export const RegistryExtensionNewReleasePage = withAuthenticatedUser<Props>(
                                 </div>
                                 <div className="col-lg-6">
                                     <div className="form-group">
-                                        <label htmlFor="registry-extension-new-release-page__bundle">
+                                        <Typography.Label htmlFor="registry-extension-new-release-page__bundle">
                                             <Typography.H3>Source</Typography.H3>
-                                        </label>
+                                        </Typography.Label>
                                         {bundleOrError === undefined ? (
                                             <div>
                                                 <LoadingSpinner />

--- a/client/web/src/enterprise/extensions/registry/RegistryNewExtensionPage.tsx
+++ b/client/web/src/enterprise/extensions/registry/RegistryNewExtensionPage.tsx
@@ -13,7 +13,7 @@ import { Form } from '@sourcegraph/branded/src/components/Form'
 import { asError, ErrorLike, isErrorLike } from '@sourcegraph/common'
 import { Scalars } from '@sourcegraph/shared/src/graphql-operations'
 import * as GQL from '@sourcegraph/shared/src/schema'
-import { LoadingSpinner, Button, Link, PageHeader, Container, Icon } from '@sourcegraph/wildcard'
+import { LoadingSpinner, Button, Link, PageHeader, Container, Icon, Typography } from '@sourcegraph/wildcard'
 
 import { AuthenticatedUser } from '../../../auth'
 import { withAuthenticatedUser } from '../../../auth/withAuthenticatedUser'
@@ -164,12 +164,12 @@ export const RegistryNewExtensionPage = withAuthenticatedUser(
                             />
                             {extensionID && (
                                 <div className="form-group d-flex flex-wrap align-items-baseline mb-0">
-                                    <label
+                                    <Typography.Label
                                         htmlFor="extension-registry-create-extension-page__extensionID"
                                         className="mr-1 mb-0 mt-1"
                                     >
                                         Extension ID:
-                                    </label>
+                                    </Typography.Label>
                                     <code
                                         id="extension-registry-create-extension-page__extensionID"
                                         className={classNames('mt-1', styles.extensionId)}

--- a/client/web/src/enterprise/insights/components/form/form-radio-input/FormRadioInput.tsx
+++ b/client/web/src/enterprise/insights/components/form/form-radio-input/FormRadioInput.tsx
@@ -2,6 +2,8 @@ import React, { InputHTMLAttributes } from 'react'
 
 import classNames from 'classnames'
 
+import { Typography } from '@sourcegraph/wildcard'
+
 interface RadioInputProps extends InputHTMLAttributes<HTMLInputElement> {
     /** Title of radio input. */
     title: string
@@ -20,7 +22,7 @@ export const FormRadioInput: React.FunctionComponent<React.PropsWithChildren<Rad
     const { title, description, className, labelTooltipText, labelTooltipPosition, ...otherProps } = props
 
     return (
-        <label
+        <Typography.Label
             data-placement={labelTooltipPosition}
             data-tooltip={labelTooltipText}
             className={classNames('d-flex flex-wrap align-items-center', className, {
@@ -37,6 +39,6 @@ export const FormRadioInput: React.FunctionComponent<React.PropsWithChildren<Rad
                     <span className="text-muted">{description}</span>
                 </>
             )}
-        </label>
+        </Typography.Label>
     )
 }

--- a/client/web/src/enterprise/insights/components/limited-access-label/LimitedAccessLabel.tsx
+++ b/client/web/src/enterprise/insights/components/limited-access-label/LimitedAccessLabel.tsx
@@ -2,6 +2,8 @@ import React from 'react'
 
 import classNames from 'classnames'
 
+import { Typography } from '@sourcegraph/wildcard'
+
 import styles from './LimitedAccessLabel.module.scss'
 
 interface LimitedAccessLabelProps {
@@ -16,9 +18,9 @@ export const LimitedAccessLabel: React.FunctionComponent<React.PropsWithChildren
     className,
 }) => (
     <div className={classNames(styles.wrapper, className)}>
-        <label className={classNames(styles.label, 'text-uppercase')}>
+        <Typography.Label className={styles.label} isUppercase={true}>
             <small>{label || 'Limited access'}</small>
-        </label>
+        </Typography.Label>
         <span className={classNames(styles.message, 'small')}>{message}</span>
     </div>
 )

--- a/client/web/src/enterprise/insights/pages/insights/creation/search-insight/components/form-color-input/FormColorInput.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/search-insight/components/form-color-input/FormColorInput.tsx
@@ -4,6 +4,8 @@ import classNames from 'classnames'
 import { startCase } from 'lodash'
 import { noop } from 'rxjs'
 
+import { Typography } from '@sourcegraph/wildcard'
+
 import { DATA_SERIES_COLORS } from '../../constants'
 
 import styles from './FormColorInput.module.scss'
@@ -33,7 +35,7 @@ export const FormColorInput: React.FunctionComponent<React.PropsWithChildren<For
 
             <div>
                 {COLORS_KEYS.map(key => (
-                    <label
+                    <Typography.Label
                         key={key}
                         /* eslint-disable-next-line react/forbid-dom-props */
                         style={{ color: DATA_SERIES_COLORS[key] }}
@@ -51,7 +53,7 @@ export const FormColorInput: React.FunctionComponent<React.PropsWithChildren<For
                         />
 
                         <span className={styles.formColorPickerRadioControl} />
-                    </label>
+                    </Typography.Label>
                 ))}
             </div>
         </fieldset>

--- a/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminGenerateProductLicenseForSubscriptionForm.tsx
+++ b/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminGenerateProductLicenseForSubscriptionForm.tsx
@@ -11,7 +11,7 @@ import { asError, createAggregateError, isErrorLike } from '@sourcegraph/common'
 import { gql } from '@sourcegraph/http-client'
 import { Scalars } from '@sourcegraph/shared/src/graphql-operations'
 import * as GQL from '@sourcegraph/shared/src/schema'
-import { Alert, Button, useEventObservable, Link } from '@sourcegraph/wildcard'
+import { Alert, Button, useEventObservable, Link, Typography } from '@sourcegraph/wildcard'
 
 import { mutateGraphQL } from '../../../../backend/graphql'
 import { ExpirationDate } from '../../../productSubscription/ExpirationDate'
@@ -138,7 +138,9 @@ export const SiteAdminGenerateProductLicenseForSubscriptionForm: React.FunctionC
             ) : (
                 <Form onSubmit={onSubmit}>
                     <div className="form-group">
-                        <label htmlFor="site-admin-create-product-subscription-page__tags">Tags</label>
+                        <Typography.Label htmlFor="site-admin-create-product-subscription-page__tags">
+                            Tags
+                        </Typography.Label>
                         <input
                             type="text"
                             className="form-control"
@@ -168,7 +170,9 @@ export const SiteAdminGenerateProductLicenseForSubscriptionForm: React.FunctionC
                         </small>
                     </div>
                     <div className="form-group">
-                        <label htmlFor="site-admin-create-product-subscription-page__userCount">Users</label>
+                        <Typography.Label htmlFor="site-admin-create-product-subscription-page__userCount">
+                            Users
+                        </Typography.Label>
                         <input
                             type="number"
                             min={1}
@@ -180,7 +184,9 @@ export const SiteAdminGenerateProductLicenseForSubscriptionForm: React.FunctionC
                         />
                     </div>
                     <div className="form-group">
-                        <label htmlFor="site-admin-create-product-subscription-page__validDays">Valid for (days)</label>
+                        <Typography.Label htmlFor="site-admin-create-product-subscription-page__validDays">
+                            Valid for (days)
+                        </Typography.Label>
                         <input
                             type="number"
                             className="form-control"

--- a/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/__snapshots__/SiteAdminGenerateProductLicenseForSubscriptionForm.test.tsx.snap
+++ b/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/__snapshots__/SiteAdminGenerateProductLicenseForSubscriptionForm.test.tsx.snap
@@ -12,6 +12,7 @@ exports[`SiteAdminGenerateProductLicenseForSubscriptionForm renders 1`] = `
         class="form-group"
       >
         <label
+          class="label"
           for="site-admin-create-product-subscription-page__tags"
         >
           Tags
@@ -68,6 +69,7 @@ exports[`SiteAdminGenerateProductLicenseForSubscriptionForm renders 1`] = `
         class="form-group"
       >
         <label
+          class="label"
           for="site-admin-create-product-subscription-page__userCount"
         >
           Users
@@ -84,6 +86,7 @@ exports[`SiteAdminGenerateProductLicenseForSubscriptionForm renders 1`] = `
         class="form-group"
       >
         <label
+          class="label"
           for="site-admin-create-product-subscription-page__validDays"
         >
           Valid for (days)

--- a/client/web/src/enterprise/user/productSubscriptions/__snapshots__/ProductSubscriptionForm.test.tsx.snap
+++ b/client/web/src/enterprise/user/productSubscriptions/__snapshots__/ProductSubscriptionForm.test.tsx.snap
@@ -18,7 +18,7 @@ exports[`ProductSubscriptionForm edit existing subscription 1`] = `
             class="product-subscription-user-count-control form-group align-items-center"
           >
             <label
-              class="mb-0 mr-2 font-weight-bold"
+              class="label fontWeightBold mb-0 mr-2"
               for="product-subscription-user-count-control__userCount"
             >
               Users
@@ -114,7 +114,7 @@ exports[`ProductSubscriptionForm new subscription for anonymous viewer (no accou
             class="product-subscription-user-count-control form-group align-items-center"
           >
             <label
-              class="mb-0 mr-2 font-weight-bold"
+              class="label fontWeightBold mb-0 mr-2"
               for="product-subscription-user-count-control__userCount"
             >
               Users
@@ -231,7 +231,7 @@ exports[`ProductSubscriptionForm new subscription for existing account 1`] = `
             class="product-subscription-user-count-control form-group align-items-center"
           >
             <label
-              class="mb-0 mr-2 font-weight-bold"
+              class="label fontWeightBold mb-0 mr-2"
               for="product-subscription-user-count-control__userCount"
             >
               Users

--- a/client/web/src/marketing/SurveyForm.tsx
+++ b/client/web/src/marketing/SurveyForm.tsx
@@ -4,7 +4,7 @@ import { useHistory } from 'react-router'
 
 import { Form } from '@sourcegraph/branded/src/components/Form'
 import { useMutation, gql } from '@sourcegraph/http-client'
-import { Button, LoadingSpinner, TextArea } from '@sourcegraph/wildcard'
+import { Button, LoadingSpinner, TextArea, Typography } from '@sourcegraph/wildcard'
 
 import { AuthenticatedUser } from '../auth'
 import { SubmitSurveyResult, SubmitSurveyVariables } from '../graphql-operations'
@@ -93,9 +93,9 @@ export const SurveyForm: React.FunctionComponent<React.PropsWithChildren<SurveyF
             {error && <p className={styles.error}>{error.message}</p>}
             {/* Label is associated with control through aria-labelledby */}
             {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
-            <label id="survey-form-scores" className={styles.label}>
+            <Typography.Label id="survey-form-scores" className={styles.label}>
                 How likely is it that you would recommend Sourcegraph to a friend?
-            </label>
+            </Typography.Label>
             <SurveyRatingRadio ariaLabelledby="survey-form-scores" onChange={handleScoreChange} score={score} />
             {!authenticatedUser && (
                 <div className="form-group">

--- a/client/web/src/notebooks/blocks/file/NotebookFileBlockInputs.tsx
+++ b/client/web/src/notebooks/blocks/file/NotebookFileBlockInputs.tsx
@@ -9,7 +9,7 @@ import { isMacPlatform as isMacPlatformFn } from '@sourcegraph/common'
 import { IHighlightLineRange } from '@sourcegraph/shared/src/schema'
 import { PathMatch } from '@sourcegraph/shared/src/search/stream'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
-import { Icon, Button } from '@sourcegraph/wildcard'
+import { Icon, Button, Typography } from '@sourcegraph/wildcard'
 
 import { BlockProps, FileBlockInput } from '../..'
 import { parseLineRange, serializeLineRange } from '../../serialize'
@@ -106,7 +106,7 @@ export const NotebookFileBlockInputs: React.FunctionComponent<
                 {...props}
             />
             <div className="mt-2">
-                <label htmlFor={`${id}-line-range-input`}>Line range</label>
+                <Typography.Label htmlFor={`${id}-line-range-input`}>Line range</Typography.Label>
                 <input
                     id={`${id}-line-range-input`}
                     type="text"

--- a/client/web/src/notebooks/blocks/suggestions/SearchTypeSuggestionsInput.tsx
+++ b/client/web/src/notebooks/blocks/suggestions/SearchTypeSuggestionsInput.tsx
@@ -14,7 +14,7 @@ import { FilterType } from '@sourcegraph/shared/src/search/query/filters'
 import { toMonacoRange } from '@sourcegraph/shared/src/search/query/monaco'
 import { PathMatch, SymbolMatch } from '@sourcegraph/shared/src/search/stream'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
-import { Button, useObservable } from '@sourcegraph/wildcard'
+import { Button, Typography, useObservable } from '@sourcegraph/wildcard'
 
 import { BlockProps } from '../..'
 import { MONACO_BLOCK_INPUT_OPTIONS, useMonacoBlockInput } from '../useMonacoBlockInput'
@@ -113,7 +113,7 @@ export const SearchTypeSuggestionsInput = <S extends SymbolMatch | PathMatch>({
 
     return (
         <div>
-            <label htmlFor={`${id}-search-type-query-input`}>{label}</label>
+            <Typography.Label htmlFor={`${id}-search-type-query-input`}>{label}</Typography.Label>
             <div
                 id={`${id}-search-type-query-input`}
                 className={classNames(blockStyles.monacoWrapper, styles.queryInputMonacoWrapper)}

--- a/client/web/src/org/new/NewOrganizationPage.tsx
+++ b/client/web/src/org/new/NewOrganizationPage.tsx
@@ -5,7 +5,7 @@ import * as H from 'history'
 import { ErrorAlert } from '@sourcegraph/branded/src/components/alerts'
 import { Form } from '@sourcegraph/branded/src/components/Form'
 import { asError, isErrorLike } from '@sourcegraph/common'
-import { Button, Container, PageHeader, LoadingSpinner, Link } from '@sourcegraph/wildcard'
+import { Button, Container, PageHeader, LoadingSpinner, Link, Typography } from '@sourcegraph/wildcard'
 
 import { ORG_NAME_MAX_LENGTH, VALID_ORG_NAME_REGEXP } from '..'
 import { Page } from '../../components/Page'
@@ -73,7 +73,7 @@ export const NewOrganizationPage: React.FunctionComponent<React.PropsWithChildre
                 <Container className="mb-3">
                     {isErrorLike(loading) && <ErrorAlert className="mb-3" error={loading} />}
                     <div className="form-group">
-                        <label htmlFor="new-org-page__form-name">Organization name</label>
+                        <Typography.Label htmlFor="new-org-page__form-name">Organization name</Typography.Label>
                         <input
                             id="new-org-page__form-name"
                             type="text"
@@ -97,7 +97,7 @@ export const NewOrganizationPage: React.FunctionComponent<React.PropsWithChildre
                     </div>
 
                     <div className="form-group mb-0">
-                        <label htmlFor="new-org-page__form-display-name">Display name</label>
+                        <Typography.Label htmlFor="new-org-page__form-display-name">Display name</Typography.Label>
                         <input
                             id="new-org-page__form-display-name"
                             type="text"

--- a/client/web/src/org/openBeta/JoinOpenBetaPage.tsx
+++ b/client/web/src/org/openBeta/JoinOpenBetaPage.tsx
@@ -206,7 +206,9 @@ export const JoinOpenBetaPage: React.FunctionComponent<React.PropsWithChildren<P
             <Form className="mb-5" onSubmit={onSubmit}>
                 {error && <ErrorAlert className="mb-3" error={error} />}
                 <div className={classNames('form-group', styles.formItem)}>
-                    <label htmlFor="company_employees_band">About how many developers work for your company?</label>
+                    <Typography.Label htmlFor="company_employees_band">
+                        About how many developers work for your company?
+                    </Typography.Label>
 
                     <div className="mt-2">
                         {CompanyDevsSize.map(item => (
@@ -231,9 +233,9 @@ export const JoinOpenBetaPage: React.FunctionComponent<React.PropsWithChildren<P
                         showOtherRepo ? styles.otherBottom : undefined
                     )}
                 >
-                    <label className={styles.cbLabel} htmlFor="company_code_repo">
+                    <Typography.Label className={styles.cbLabel} htmlFor="company_code_repo">
                         Where does your company store your code today?
-                    </label>
+                    </Typography.Label>
                     <span className={classNames('text-muted d-block', styles.cbSubLabel)}>
                         <small>Select all that apply</small>
                     </span>
@@ -276,9 +278,9 @@ export const JoinOpenBetaPage: React.FunctionComponent<React.PropsWithChildren<P
                         showOtherPlan ? styles.otherBottom : undefined
                     )}
                 >
-                    <label className={styles.cbLabel} htmlFor="sg_usage_plan">
+                    <Typography.Label className={styles.cbLabel} htmlFor="sg_usage_plan">
                         What do you plan to use Sourcegraph to do?
-                    </label>
+                    </Typography.Label>
                     <span className={classNames('text-muted d-block', styles.cbSubLabel)}>
                         <small>Select all that apply</small>
                     </span>

--- a/client/web/src/org/openBeta/NewOrganizationPage.tsx
+++ b/client/web/src/org/openBeta/NewOrganizationPage.tsx
@@ -210,7 +210,7 @@ export const NewOrgOpenBetaPage: React.FunctionComponent<React.PropsWithChildren
             <Form className="mb-3" onSubmit={onSubmit}>
                 {error && <ErrorAlert className="mb-3" error={getError(error)} />}
                 <div className={classNames('form-group', styles.formItem)}>
-                    <label htmlFor="new-org-page__form-name">Organization name</label>
+                    <Typography.Label htmlFor="new-org-page__form-name">Organization name</Typography.Label>
                     <input
                         id="new-org-page__form-name"
                         type="text"

--- a/client/web/src/org/settings/members-v1/InviteForm.tsx
+++ b/client/web/src/org/settings/members-v1/InviteForm.tsx
@@ -11,7 +11,7 @@ import { Form } from '@sourcegraph/branded/src/components/Form'
 import { asError, createAggregateError, isErrorLike } from '@sourcegraph/common'
 import { gql } from '@sourcegraph/http-client'
 import { Scalars } from '@sourcegraph/shared/src/graphql-operations'
-import { LoadingSpinner, Button, Link, Alert, Icon } from '@sourcegraph/wildcard'
+import { LoadingSpinner, Button, Link, Alert, Icon, Typography } from '@sourcegraph/wildcard'
 
 import { AuthenticatedUser } from '../../../auth'
 import { requestGraphQL } from '../../../backend/graphql'
@@ -104,9 +104,9 @@ export const InviteForm: React.FunctionComponent<React.PropsWithChildren<Props>>
     return (
         <div>
             <div className={styles.container}>
-                <label htmlFor="invite-form__username">
+                <Typography.Label htmlFor="invite-form__username">
                     {viewerCanAddUserToOrganization ? 'Add or invite member' : 'Invite member'}
-                </label>
+                </Typography.Label>
                 <Form className="form-inline align-items-start" onSubmit={onSubmit}>
                     <input
                         type="text"

--- a/client/web/src/org/settings/profile/OrgSettingsProfilePage.tsx
+++ b/client/web/src/org/settings/profile/OrgSettingsProfilePage.tsx
@@ -3,7 +3,7 @@ import React, { useCallback, useEffect, useState } from 'react'
 import { ErrorAlert } from '@sourcegraph/branded/src/components/alerts'
 import { Form } from '@sourcegraph/branded/src/components/Form'
 import { asError, isErrorLike } from '@sourcegraph/common'
-import { Container, PageHeader, Button, LoadingSpinner } from '@sourcegraph/wildcard'
+import { Container, PageHeader, Button, LoadingSpinner, Typography } from '@sourcegraph/wildcard'
 
 import { ORG_DISPLAY_NAME_MAX_LENGTH } from '../..'
 import { PageTitle } from '../../../components/PageTitle'
@@ -88,7 +88,9 @@ export const OrgSettingsProfilePage: React.FunctionComponent<React.PropsWithChil
             <Container>
                 <Form className="org-settings-profile-page" onSubmit={onSubmit}>
                     <div className="form-group">
-                        <label htmlFor="org-settings-profile-page-display-name">Display name</label>
+                        <Typography.Label htmlFor="org-settings-profile-page-display-name">
+                            Display name
+                        </Typography.Label>
                         <input
                             id="org-settings-profile-page-display-name"
                             type="text"

--- a/client/web/src/repo/settings/RepoSettingsMirrorPage.tsx
+++ b/client/web/src/repo/settings/RepoSettingsMirrorPage.tsx
@@ -10,7 +10,17 @@ import { catchError, switchMap, tap } from 'rxjs/operators'
 import { ErrorAlert } from '@sourcegraph/branded/src/components/alerts'
 import { asError } from '@sourcegraph/common'
 import * as GQL from '@sourcegraph/shared/src/schema'
-import { Container, PageHeader, LoadingSpinner, FeedbackText, Button, Link, Alert, Icon } from '@sourcegraph/wildcard'
+import {
+    Container,
+    PageHeader,
+    LoadingSpinner,
+    FeedbackText,
+    Button,
+    Link,
+    Alert,
+    Icon,
+    Typography,
+} from '@sourcegraph/wildcard'
 
 import { PageTitle } from '../../components/PageTitle'
 import { Timestamp } from '../../components/time/Timestamp'
@@ -302,12 +312,12 @@ export class RepoSettingsMirrorPage extends React.PureComponent<
                     {this.state.loading && <LoadingSpinner />}
                     {this.state.error && <ErrorAlert error={this.state.error} />}
                     <div className="form-group">
-                        <label>
+                        <Typography.Label>
                             Remote repository URL{' '}
                             <small className="text-info">
                                 <Icon as={LockIcon} /> Only visible to site admins
                             </small>
-                        </label>
+                        </Typography.Label>
                         <input
                             className="form-control"
                             value={this.props.repo.mirrorInfo.remoteURL || '(unknown)'}

--- a/client/web/src/repo/settings/RepoSettingsOptionsPage.tsx
+++ b/client/web/src/repo/settings/RepoSettingsOptionsPage.tsx
@@ -7,7 +7,7 @@ import { switchMap } from 'rxjs/operators'
 import { ErrorAlert } from '@sourcegraph/branded/src/components/alerts'
 import { Form } from '@sourcegraph/branded/src/components/Form'
 import { asError } from '@sourcegraph/common'
-import { Container, PageHeader, LoadingSpinner } from '@sourcegraph/wildcard'
+import { Container, PageHeader, LoadingSpinner, Typography } from '@sourcegraph/wildcard'
 
 import { ExternalServiceCard } from '../../components/externalServices/ExternalServiceCard'
 import { defaultExternalServices } from '../../components/externalServices/externalServices'
@@ -95,7 +95,9 @@ export class RepoSettingsOptionsPage extends React.PureComponent<Props, State> {
                     )}
                     <Form>
                         <div className="form-group mb-0">
-                            <label htmlFor="repo-settings-options-page__name">Repository name</label>
+                            <Typography.Label htmlFor="repo-settings-options-page__name">
+                                Repository name
+                            </Typography.Label>
                             <input
                                 id="repo-settings-options-page__name"
                                 type="text"

--- a/client/web/src/repo/stats/RepositoryStatsContributorsPage.tsx
+++ b/client/web/src/repo/stats/RepositoryStatsContributorsPage.tsx
@@ -12,7 +12,7 @@ import { gql } from '@sourcegraph/http-client'
 import { Scalars, SearchPatternType } from '@sourcegraph/shared/src/graphql-operations'
 import * as GQL from '@sourcegraph/shared/src/schema'
 import { buildSearchURLQuery } from '@sourcegraph/shared/src/util/url'
-import { Button, ButtonGroup, Link, CardHeader, CardBody, Card } from '@sourcegraph/wildcard'
+import { Button, ButtonGroup, Link, CardHeader, CardBody, Card, Typography } from '@sourcegraph/wildcard'
 
 import { queryGraphQL } from '../../backend/graphql'
 import { FilteredConnection } from '../../components/FilteredConnection'
@@ -229,12 +229,12 @@ export class RepositoryStatsContributorsPage extends React.PureComponent<Props, 
                             <div className={classNames(styles.row, 'form-inline')}>
                                 <div className="input-group mb-2 mr-sm-2">
                                     <div className="input-group-prepend">
-                                        <label
+                                        <Typography.Label
                                             htmlFor={RepositoryStatsContributorsPage.AFTER_INPUT_ID}
                                             className="input-group-text"
                                         >
                                             Time period
-                                        </label>
+                                        </Typography.Label>
                                     </div>
                                     <input
                                         type="text"
@@ -286,12 +286,12 @@ export class RepositoryStatsContributorsPage extends React.PureComponent<Props, 
                             <div className={classNames(styles.row, 'form-inline')}>
                                 <div className="input-group mt-2 mr-sm-2">
                                     <div className="input-group-prepend">
-                                        <label
+                                        <Typography.Label
                                             htmlFor={RepositoryStatsContributorsPage.REVISION_RANGE_INPUT_ID}
                                             className="input-group-text"
                                         >
                                             Revision range
-                                        </label>
+                                        </Typography.Label>
                                     </div>
                                     <input
                                         type="text"
@@ -310,12 +310,12 @@ export class RepositoryStatsContributorsPage extends React.PureComponent<Props, 
                                 </div>
                                 <div className="input-group mt-2 mr-sm-2">
                                     <div className="input-group-prepend">
-                                        <label
+                                        <Typography.Label
                                             htmlFor={RepositoryStatsContributorsPage.PATH_INPUT_ID}
                                             className="input-group-text"
                                         >
                                             Path
-                                        </label>
+                                        </Typography.Label>
                                     </div>
                                     <input
                                         type="text"

--- a/client/web/src/savedSearches/SavedSearchForm.tsx
+++ b/client/web/src/savedSearches/SavedSearchForm.tsx
@@ -6,7 +6,16 @@ import { Omit } from 'utility-types'
 import { ErrorAlert } from '@sourcegraph/branded/src/components/alerts'
 import { Form } from '@sourcegraph/branded/src/components/Form'
 import { Scalars } from '@sourcegraph/shared/src/graphql-operations'
-import { Container, PageHeader, ProductStatusBadge, Button, Link, Alert, Checkbox } from '@sourcegraph/wildcard'
+import {
+    Container,
+    PageHeader,
+    ProductStatusBadge,
+    Button,
+    Link,
+    Alert,
+    Checkbox,
+    Typography,
+} from '@sourcegraph/wildcard'
 
 import { AuthenticatedUser } from '../auth'
 import { NamespaceProps } from '../namespaces'
@@ -89,9 +98,9 @@ export const SavedSearchForm: React.FunctionComponent<React.PropsWithChildren<Sa
             <Form onSubmit={handleSubmit}>
                 <Container className="mb-3">
                     <div className="form-group">
-                        <label className={styles.label} htmlFor="saved-search-form-input-description">
+                        <Typography.Label className={styles.label} htmlFor="saved-search-form-input-description">
                             Description
-                        </label>
+                        </Typography.Label>
                         <input
                             id="saved-search-form-input-description"
                             type="text"
@@ -104,9 +113,9 @@ export const SavedSearchForm: React.FunctionComponent<React.PropsWithChildren<Sa
                         />
                     </div>
                     <div className="form-group">
-                        <label className={styles.label} htmlFor="saved-search-form-input-query">
+                        <Typography.Label className={styles.label} htmlFor="saved-search-form-input-query">
                             Query
-                        </label>
+                        </Typography.Label>
                         <input
                             id="saved-search-form-input-query"
                             type="text"
@@ -123,9 +132,9 @@ export const SavedSearchForm: React.FunctionComponent<React.PropsWithChildren<Sa
                         <div className="form-group mb-0">
                             {/* Label is for visual benefit, input has more specific label attached */}
                             {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
-                            <label className={styles.label} id="saved-search-form-email-notifications">
+                            <Typography.Label className={styles.label} id="saved-search-form-email-notifications">
                                 Email notifications
-                            </label>
+                            </Typography.Label>
                             <div aria-labelledby="saved-search-form-email-notifications">
                                 <Checkbox
                                     name="Notify owner"
@@ -160,9 +169,9 @@ export const SavedSearchForm: React.FunctionComponent<React.PropsWithChildren<Sa
 
                     {notifySlack && slackWebhookURL && (
                         <div className="form-group mt-3 mb-0">
-                            <label className={styles.label} htmlFor="saved-search-form-input-slack">
+                            <Typography.Label className={styles.label} htmlFor="saved-search-form-input-slack">
                                 Slack notifications
-                            </label>
+                            </Typography.Label>
                             <input
                                 id="saved-search-form-input-slack"
                                 type="text"

--- a/client/web/src/site-admin/SiteAdminCreateUserPage.tsx
+++ b/client/web/src/site-admin/SiteAdminCreateUserPage.tsx
@@ -125,7 +125,9 @@ export class SiteAdminCreateUserPage extends React.Component<RouteComponentProps
                 ) : (
                     <Form onSubmit={this.onSubmit} className="site-admin-create-user-page__form">
                         <div className={classNames('form-group', styles.formGroup)}>
-                            <label htmlFor="site-admin-create-user-page__form-username">Username</label>
+                            <Typography.Label htmlFor="site-admin-create-user-page__form-username">
+                                Username
+                            </Typography.Label>
                             <UsernameInput
                                 id="site-admin-create-user-page__form-username"
                                 onChange={this.onUsernameFieldChange}
@@ -140,7 +142,7 @@ export class SiteAdminCreateUserPage extends React.Component<RouteComponentProps
                             </small>
                         </div>
                         <div className={classNames('form-group', styles.formGroup)}>
-                            <label htmlFor="site-admin-create-user-page__form-email">Email</label>
+                            <Typography.Label htmlFor="site-admin-create-user-page__form-email">Email</Typography.Label>
                             <EmailInput
                                 id="site-admin-create-user-page__form-email"
                                 onChange={this.onEmailFieldChange}

--- a/client/web/src/site-admin/SiteAdminFeatureFlagConfigurationPage.tsx
+++ b/client/web/src/site-admin/SiteAdminFeatureFlagConfigurationPage.tsx
@@ -620,9 +620,9 @@ const CreateFeatureFlag: React.FunctionComponent<
 > = ({ name, setFlagName, type, setFlagType, value, setFlagValue }) => (
     <>
         <div className="form-group d-flex flex-column">
-            <label htmlFor="name">
+            <Typography.Label htmlFor="name">
                 <Typography.H3>Name</Typography.H3>
-            </label>
+            </Typography.Label>
             <input
                 id="name"
                 type="text"
@@ -704,9 +704,9 @@ const FeatureFlagRolloutValueSettings: React.FunctionComponent<
     }>
 > = ({ value, update }) => (
     <div className="form-group d-flex flex-column">
-        <label htmlFor="rollout-value">
+        <Typography.Label htmlFor="rollout-value">
             <Typography.H3>Value</Typography.H3>
-        </label>
+        </Typography.Label>
         <input
             type="range"
             id="rollout-value"
@@ -737,9 +737,9 @@ const FeatureFlagBooleanValueSettings: React.FunctionComponent<
     }>
 > = ({ value, update }) => (
     <div className="form-group d-flex flex-column">
-        <label htmlFor="bool-value">
+        <Typography.Label htmlFor="bool-value">
             <Typography.H3>Value</Typography.H3>
-        </label>
+        </Typography.Label>
         <div className="d-flex">
             <div>
                 <Toggle

--- a/client/web/src/site-admin/init/__snapshots__/SiteInitPage.test.tsx.snap
+++ b/client/web/src/site-admin/init/__snapshots__/SiteInitPage.test.tsx.snap
@@ -32,7 +32,7 @@ exports[`SiteInitPage normal 1`] = `
             class="form-group d-flex flex-column align-content-start"
           >
             <label
-              class="align-self-start"
+              class="label align-self-start"
               for="email"
             >
               Email
@@ -57,7 +57,7 @@ exports[`SiteInitPage normal 1`] = `
             class="form-group d-flex flex-column align-content-start"
           >
             <label
-              class="align-self-start"
+              class="label align-self-start"
               for="username"
             >
               Username
@@ -85,7 +85,7 @@ exports[`SiteInitPage normal 1`] = `
             class="form-group d-flex flex-column align-content-start"
           >
             <label
-              class="align-self-start"
+              class="label align-self-start"
               for="password"
             >
               Password

--- a/client/web/src/user/settings/accessTokens/UserSettingsCreateAccessTokenPage.tsx
+++ b/client/web/src/user/settings/accessTokens/UserSettingsCreateAccessTokenPage.tsx
@@ -19,6 +19,7 @@ import {
     Link,
     Icon,
     Checkbox,
+    Typography,
 } from '@sourcegraph/wildcard'
 
 import { AccessTokenScopes } from '../../../auth/accessToken'
@@ -138,7 +139,9 @@ export const UserSettingsCreateAccessTokenPage: React.FunctionComponent<React.Pr
             <Form onSubmit={onSubmit}>
                 <Container className="mb-3">
                     <div className="form-group">
-                        <label htmlFor="user-settings-create-access-token-page__note">Token description</label>
+                        <Typography.Label htmlFor="user-settings-create-access-token-page__note">
+                            Token description
+                        </Typography.Label>
                         <input
                             type="text"
                             className="form-control test-create-access-token-description"
@@ -150,9 +153,12 @@ export const UserSettingsCreateAccessTokenPage: React.FunctionComponent<React.Pr
                         />
                     </div>
                     <div className="form-group mb-0">
-                        <label htmlFor="user-settings-create-access-token-page__scope-user:all" className="mb-0">
+                        <Typography.Label
+                            htmlFor="user-settings-create-access-token-page__scope-user:all"
+                            className="mb-0"
+                        >
                             Token scope
-                        </label>
+                        </Typography.Label>
                         <p>
                             <small className="form-help text-muted">
                                 Tokens with limited user scopes are not yet supported.

--- a/client/web/src/user/settings/auth/UserSettingsPasswordPage.tsx
+++ b/client/web/src/user/settings/auth/UserSettingsPasswordPage.tsx
@@ -6,7 +6,7 @@ import { catchError, filter, mergeMap, tap } from 'rxjs/operators'
 
 import { ErrorAlert } from '@sourcegraph/branded/src/components/alerts'
 import { Form } from '@sourcegraph/branded/src/components/Form'
-import { Button, Container, PageHeader, LoadingSpinner, Link, Alert } from '@sourcegraph/wildcard'
+import { Button, Container, PageHeader, LoadingSpinner, Link, Alert, Typography } from '@sourcegraph/wildcard'
 
 import { AuthenticatedUser } from '../../../auth'
 import { PasswordInput } from '../../../auth/SignInSignUpCommon'
@@ -159,7 +159,7 @@ export class UserSettingsPasswordPage extends React.Component<Props, State> {
                                     hidden={true}
                                 />
                                 <div className="form-group">
-                                    <label htmlFor="oldPassword">Old password</label>
+                                    <Typography.Label htmlFor="oldPassword">Old password</Typography.Label>
                                     <PasswordInput
                                         value={this.state.oldPassword}
                                         onChange={this.onOldPasswordFieldChange}
@@ -174,7 +174,7 @@ export class UserSettingsPasswordPage extends React.Component<Props, State> {
                                 </div>
 
                                 <div className="form-group">
-                                    <label htmlFor="newPassword">New password</label>
+                                    <Typography.Label htmlFor="newPassword">New password</Typography.Label>
                                     <PasswordInput
                                         value={this.state.newPassword}
                                         onChange={this.onNewPasswordFieldChange}
@@ -196,7 +196,9 @@ export class UserSettingsPasswordPage extends React.Component<Props, State> {
                                     {this.getPasswordRequirements()}
                                 </div>
                                 <div className="form-group mb-0">
-                                    <label htmlFor="newPasswordConfirmation">Confirm new password</label>
+                                    <Typography.Label htmlFor="newPasswordConfirmation">
+                                        Confirm new password
+                                    </Typography.Label>
                                     <PasswordInput
                                         value={this.state.newPasswordConfirmation}
                                         onChange={this.onNewPasswordConfirmationFieldChange}

--- a/client/web/src/user/settings/auth/UserSettingsSecurityPage.tsx
+++ b/client/web/src/user/settings/auth/UserSettingsSecurityPage.tsx
@@ -293,7 +293,7 @@ export class UserSettingsSecurityPage extends React.Component<Props, State> {
                                 />
                                 {this.shouldShowOldPasswordInput() && (
                                     <div className="form-group">
-                                        <label htmlFor="oldPassword">Old password</label>
+                                        <Typography.Label htmlFor="oldPassword">Old password</Typography.Label>
                                         <PasswordInput
                                             value={this.state.oldPassword}
                                             onChange={this.onOldPasswordFieldChange}
@@ -308,7 +308,7 @@ export class UserSettingsSecurityPage extends React.Component<Props, State> {
                                 )}
 
                                 <div className="form-group">
-                                    <label htmlFor="newPassword">New password</label>
+                                    <Typography.Label htmlFor="newPassword">New password</Typography.Label>
                                     <PasswordInput
                                         value={this.state.newPassword}
                                         onChange={this.onNewPasswordFieldChange}
@@ -329,7 +329,9 @@ export class UserSettingsSecurityPage extends React.Component<Props, State> {
                                     {this.getPasswordRequirements()}
                                 </div>
                                 <div className="form-group">
-                                    <label htmlFor="newPasswordConfirmation">Confirm new password</label>
+                                    <Typography.Label htmlFor="newPasswordConfirmation">
+                                        Confirm new password
+                                    </Typography.Label>
                                     <PasswordInput
                                         value={this.state.newPasswordConfirmation}
                                         onChange={this.onNewPasswordConfirmationFieldChange}

--- a/client/web/src/user/settings/codeHosts/AddCodeHostConnectionModal.tsx
+++ b/client/web/src/user/settings/codeHosts/AddCodeHostConnectionModal.tsx
@@ -93,7 +93,7 @@ export const AddCodeHostConnectionModal: React.FunctionComponent<
                     <div className="form-group mb-4">
                         {didAckMachineUserHint ? (
                             <>
-                                <label htmlFor="code-host-token">Access token</label>
+                                <Typography.Label htmlFor="code-host-token">Access token</Typography.Label>
                                 <div className="position-relative">
                                     <input
                                         id="code-host-token"

--- a/client/web/src/user/settings/codeHosts/UpdateCodeHostConnectionModal.tsx
+++ b/client/web/src/user/settings/codeHosts/UpdateCodeHostConnectionModal.tsx
@@ -98,7 +98,7 @@ export const UpdateCodeHostConnectionModal: React.FunctionComponent<
                         {didAckMachineUserHint ? (
                             <>
                                 {' '}
-                                <label htmlFor="code-host-token">Access token</label>
+                                <Typography.Label htmlFor="code-host-token">Access token</Typography.Label>
                                 <div className="position-relative">
                                     <input
                                         id="code-host-token"

--- a/client/web/src/user/settings/emails/AddUserEmailForm.tsx
+++ b/client/web/src/user/settings/emails/AddUserEmailForm.tsx
@@ -7,7 +7,7 @@ import { LoaderInput } from '@sourcegraph/branded/src/components/LoaderInput'
 import { asError, isErrorLike, ErrorLike } from '@sourcegraph/common'
 import { gql, dataOrThrowErrors } from '@sourcegraph/http-client'
 import { useInputValidation, deriveInputClassName } from '@sourcegraph/shared/src/util/useInputValidation'
-import { screenReaderAnnounce } from '@sourcegraph/wildcard'
+import { screenReaderAnnounce, Typography } from '@sourcegraph/wildcard'
 
 import { requestGraphQL } from '../../../backend/graphql'
 import { LoaderButton } from '../../../components/LoaderButton'
@@ -73,14 +73,14 @@ export const AddUserEmailForm: FunctionComponent<React.PropsWithChildren<Props>>
 
     return (
         <div className={classNames('add-user-email-form', className)}>
-            <label
+            <Typography.Label
                 htmlFor="AddUserEmailForm-email"
                 className={classNames('align-self-start', {
                     'text-danger font-weight-bold': emailState.kind === 'INVALID',
                 })}
             >
                 Add email address
-            </label>
+            </Typography.Label>
             {/* eslint-disable-next-line react/forbid-elements */}
             <form className="form-inline" onSubmit={onSubmit} noValidate={true}>
                 <LoaderInput

--- a/client/web/src/user/settings/profile/UserProfileFormFields.tsx
+++ b/client/web/src/user/settings/profile/UserProfileFormFields.tsx
@@ -3,6 +3,7 @@ import React, { useCallback } from 'react'
 import classNames from 'classnames'
 
 import * as GQL from '@sourcegraph/shared/src/schema'
+import { Typography } from '@sourcegraph/wildcard'
 
 import { USER_DISPLAY_NAME_MAX_LENGTH } from '../..'
 import { UsernameInput } from '../../../auth/SignInSignUpCommon'
@@ -41,7 +42,7 @@ export const UserProfileFormFields: React.FunctionComponent<React.PropsWithChild
     return (
         <div data-testid="user-profile-form-fields">
             <div className="form-group">
-                <label htmlFor="UserProfileFormFields__username">Username</label>
+                <Typography.Label htmlFor="UserProfileFormFields__username">Username</Typography.Label>
                 <UsernameInput
                     id="UserProfileFormFields__username"
                     className="test-UserProfileFormFields-username"
@@ -57,7 +58,7 @@ export const UserProfileFormFields: React.FunctionComponent<React.PropsWithChild
                 </small>
             </div>
             <div className="form-group">
-                <label htmlFor="UserProfileFormFields__displayName">Display name</label>
+                <Typography.Label htmlFor="UserProfileFormFields__displayName">Display name</Typography.Label>
                 <input
                     id="UserProfileFormFields__displayName"
                     type="text"
@@ -72,7 +73,7 @@ export const UserProfileFormFields: React.FunctionComponent<React.PropsWithChild
             </div>
             <div className="d-flex align-items-center">
                 <div className="form-group w-100">
-                    <label htmlFor="UserProfileFormFields__avatarURL">Avatar URL</label>
+                    <Typography.Label htmlFor="UserProfileFormFields__avatarURL">Avatar URL</Typography.Label>
                     <input
                         id="UserProfileFormFields__avatarURL"
                         type="url"

--- a/client/wildcard/src/components/Feedback/FeedbackPrompt/IconRadioButtons.tsx
+++ b/client/wildcard/src/components/Feedback/FeedbackPrompt/IconRadioButtons.tsx
@@ -2,7 +2,7 @@ import React, { useCallback } from 'react'
 
 import classNames from 'classnames'
 
-import { Label } from '../../Typography/Label'
+import { Typography } from '../..'
 
 import styles from './IconRadioButtons.module.scss'
 
@@ -41,7 +41,7 @@ export const IconRadioButtons: React.FunctionComponent<React.PropsWithChildren<P
         <ul className={classNames(className, styles.buttons)}>
             {Object.values(icons).map(({ icon: Icon, name: iconName, value }) => (
                 <li key={iconName} className="d-flex">
-                    <Label className={styles.label}>
+                    <Typography.Label className={styles.label}>
                         <input
                             disabled={disabled}
                             type="radio"
@@ -67,7 +67,7 @@ export const IconRadioButtons: React.FunctionComponent<React.PropsWithChildren<P
                         >
                             <Icon />
                         </span>
-                    </Label>
+                    </Typography.Label>
                 </li>
             ))}
         </ul>

--- a/client/wildcard/src/components/Form/Input/Input.tsx
+++ b/client/wildcard/src/components/Form/Input/Input.tsx
@@ -5,9 +5,9 @@ import { useMergeRefs } from 'use-callback-ref'
 
 import { LoaderInput } from '@sourcegraph/branded/src/components/LoaderInput'
 
+import { Typography } from '../..'
 import { useAutoFocus } from '../../../hooks/useAutoFocus'
 import { ForwardReferenceComponent } from '../../../types'
-import { Label } from '../../Typography/Label'
 
 import styles from './Input.module.scss'
 
@@ -94,10 +94,10 @@ export const Input = forwardRef((props, reference) => {
 
     if (label) {
         return (
-            <Label className={classNames('w-100', className)}>
+            <Typography.Label className={classNames('w-100', className)}>
                 {label && <div className="mb-2">{variant === 'regular' ? label : <small>{label}</small>}</div>}
                 {inputWithMessage}
-            </Label>
+            </Typography.Label>
         )
     }
 

--- a/client/wildcard/src/components/Form/TextArea/TextArea.tsx
+++ b/client/wildcard/src/components/Form/TextArea/TextArea.tsx
@@ -2,7 +2,7 @@ import { forwardRef, ForwardRefExoticComponent, ReactNode, RefAttributes, Textar
 
 import classNames from 'classnames'
 
-import { Label } from '../../Typography/Label'
+import { Typography } from '../..'
 import { FormFieldMessage } from '../internal/FormFieldMessage'
 import { getValidStyle } from '../internal/utils'
 
@@ -53,7 +53,7 @@ export const TextArea: ForwardRefExoticComponent<TextAreaProps & RefAttributes<H
         } = props
 
         return (
-            <Label className={classNames(styles.label, className)}>
+            <Typography.Label className={classNames(styles.label, className)}>
                 {label && <div className="mb-2">{size === 'small' ? <small>{label}</small> : label}</div>}
 
                 {/* eslint-disable-next-line react/forbid-elements */}
@@ -71,7 +71,7 @@ export const TextArea: ForwardRefExoticComponent<TextAreaProps & RefAttributes<H
                     ref={reference}
                 />
                 {message && <FormFieldMessage isValid={isValid}>{message}</FormFieldMessage>}
-            </Label>
+            </Typography.Label>
         )
     }
 )

--- a/client/wildcard/src/components/Form/internal/FormFieldLabel.tsx
+++ b/client/wildcard/src/components/Form/internal/FormFieldLabel.tsx
@@ -1,7 +1,7 @@
 import { forwardRef } from 'react'
 
+import { Typography } from '../..'
 import { ForwardReferenceComponent } from '../../../types'
-import { Label } from '../../Typography/Label'
 
 export interface FormFieldLabelProps {
     /**
@@ -15,7 +15,7 @@ export interface FormFieldLabelProps {
  * A simple label to render alongside a form field.
  */
 export const FormFieldLabel = forwardRef(({ htmlFor, className, children, ...rest }, reference) => (
-    <Label htmlFor={htmlFor} className={className} ref={reference} {...rest}>
+    <Typography.Label htmlFor={htmlFor} className={className} ref={reference} {...rest}>
         {children}
-    </Label>
+    </Typography.Label>
 )) as ForwardReferenceComponent<'label', FormFieldLabelProps>


### PR DESCRIPTION
## Description
Manual migration required to update our code to use the <Typography /> Wildcard component.
See [Wildcard V2 - Planned work](https://docs.google.com/document/d/1NisbJPiadtt5jQw4vUUYJOr8dD6Urwn5V0mVq2wt6bE/edit#heading=h.g4cw92w3ouhw) for more context

**Note**: Before doing this, we should check if there is scope for a codemod to automate this migration. If so, the codemod should be implemented and ran before starting work on this issue.

## Test Plan
- Ensure there are no UI changes on both `storybook` and `application`

## Ref
[Parent Issue](https://github.com/sourcegraph/sourcegraph/issues/27677)
[SG Issue](https://github.com/sourcegraph/sourcegraph/issues/35214)
[GitStart Issue](https://app.gitstart.com/clients/sourcegraph/tickets/SG-35214)

## Acceptance criteria
 - [ ] All incorrect usage of the previous pattern has been updated to use the Wildcard component
 
### Time estimate
- Pull requests with ~450 lines changed should take 2-3 hours at maximum. Ping the reviewer in the spec pull request if time-consuming changes are required.
- Split the work into multiple pull requests if the total diff is bigger than 450 lines of code.

### Implementation Detail
- Migrate all usage of `native label element` on codebase to wildcard's `Typography.Label`

## App preview:

- [Web](https://sg-web-contractors-sg-35214.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-famjbagwgr.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
