### PR TITLE
Accessibility: Fix small issues on contributors page

### DIFF
--- a/client/web/src/repo/stats/RepositoryStatsContributorsPage.tsx
+++ b/client/web/src/repo/stats/RepositoryStatsContributorsPage.tsx
@@ -60,7 +60,7 @@ const RepositoryContributorNode: React.FunctionComponent<React.PropsWithChildren
         .replace(/\s+/, ' ')
 
     return (
-        <div className={classNames('list-group-item py-2', styles.repositoryContributorNode)}>
+        <li className={classNames('list-group-item py-2', styles.repositoryContributorNode)}>
             <div className={styles.person}>
                 <UserAvatar inline={true} className="mr-2" user={node.person} />
                 <PersonLink userClassName="font-weight-bold" person={node.person} />
@@ -93,7 +93,7 @@ const RepositoryContributorNode: React.FunctionComponent<React.PropsWithChildren
                     </Link>
                 </div>
             </div>
-        </div>
+        </li>
     )
 }
 
@@ -247,7 +247,7 @@ export class RepositoryStatsContributorsPage extends React.PureComponent<Props, 
                                         onChange={this.onChange}
                                     />
                                     <div className="input-group-append">
-                                        <ButtonGroup>
+                                        <ButtonGroup aria-label="Time period presets">
                                             <Button
                                                 className={classNames(
                                                     styles.btnNoLeftRoundedCorners,
@@ -355,7 +355,6 @@ export class RepositoryStatsContributorsPage extends React.PureComponent<Props, 
                     listClassName="list-group list-group-flush test-filtered-contributors-connection"
                     noun="contributor"
                     pluralNoun="contributors"
-                    listComponent="div"
                     queryConnection={this.queryRepositoryContributors}
                     nodeComponent={RepositoryContributorNode}
                     nodeComponentProps={{


### PR DESCRIPTION
Related audit issue: https://github.com/sourcegraph/sourcegraph/issues/34427
Closes https://github.com/sourcegraph/sourcegraph/issues/35356

## Description

1. Uses the correct `<li>` element for listing commits
2. Adds an aria-label to the <ButtonGroup> for filter controls. [Related guidance here](https://www.w3.org/TR/WCAG20-TECHS/ARIA17.html)

## Test plan

Tested locally with a screen reader, and through visual tests
 
<!-- all pull requests REQUIRE a test plan.   https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-tr-a11y-contributors-page.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-jfuvmhvsto.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
