### PR TITLE
Add check to make sure remote and local release branch are synced

### DIFF
--- a/dev/release/src/release.ts
+++ b/dev/release/src/release.ts
@@ -23,7 +23,15 @@ import {
 } from './github'
 import { ensureEvent, getClient, EventOptions, calendarTime } from './google-calendar'
 import { postMessage, slackURL } from './slack'
-import { cacheFolder, formatDate, timezoneLink, hubSpotFeedbackFormStub, ensureDocker, changelogURL } from './util'
+import {
+    cacheFolder,
+    formatDate,
+    timezoneLink,
+    hubSpotFeedbackFormStub,
+    ensureDocker,
+    changelogURL,
+    ensureReleaseBranchUpToDate,
+} from './util'
 
 const sed = process.platform === 'linux' ? 'sed' : 'gsed'
 
@@ -287,6 +295,7 @@ ${trackingIssues.map(index => `- ${slackURL(index.title, index.url)}`).join('\n'
             const { upcoming: release } = await releaseVersions(config)
             const branch = `${release.major}.${release.minor}`
             const tag = `v${release.version}${candidate === 'final' ? '' : `-rc.${candidate}`}`
+            ensureReleaseBranchUpToDate(branch)
             await createTag(
                 await getAuthenticatedGitHubClient(),
                 {


### PR DESCRIPTION
- move branch check function to `ensureBranchUpToDate()` to make sure it can be done on any branch
- accomodate existing `ensureMainBranchUpToDate()`
- make sure release branch can be checked as well
- a new pr to replicate https://github.com/sourcegraph/sourcegraph/pull/34200

Solve: https://github.com/sourcegraph/sourcegraph/issues/32783



## Test plan
@marsblkm tested locally and **manually** by doing the following:
1. Checkout to branch `3.39` and randomly commit something (to simulate the scenario)
2. Checkout to `main`
3. Merge `jm/check-local-and-remote-release-branch` into `main`.
4. Set up dry run mode and execute `yarn release release:create-candidate final`

<img width="703" alt="image" src="https://user-images.githubusercontent.com/11640534/164342889-2cf253b8-3346-4334-a951-ca97c984731f.png">



<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, or why this change does not need testing, as outlined in our
  Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->


