### PR TITLE
codeintel: Add GitService requirement to dependencies service

### DIFF
--- a/internal/codeintel/dependencies/gen.go
+++ b/internal/codeintel/dependencies/gen.go
@@ -1,3 +1,3 @@
 package dependencies
 
-//go:generate ../../../dev/mockgen.sh github.com/sourcegraph/sourcegraph/internal/codeintel/dependencies -i Store -i LockfilesService -i Syncer -o mock_iface_test.go
+//go:generate ../../../dev/mockgen.sh github.com/sourcegraph/sourcegraph/internal/codeintel/dependencies -i Store -i localGitService -i LockfilesService -i Syncer -o mock_iface_test.go

--- a/internal/codeintel/dependencies/iface.go
+++ b/internal/codeintel/dependencies/iface.go
@@ -7,6 +7,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/dependencies/internal/lockfiles"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/dependencies/internal/store"
 	"github.com/sourcegraph/sourcegraph/internal/conf/reposource"
+	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 )
 
 type Store interface {
@@ -15,11 +16,18 @@ type Store interface {
 	DeleteDependencyReposByID(ctx context.Context, ids ...int) error
 }
 
+type localGitService interface {
+	GetCommits(ctx context.Context, repoCommits []api.RepoCommit, ignoreErrors bool) ([]*gitdomain.Commit, error)
+}
+
+type GitService interface {
+	localGitService
+	lockfiles.GitService
+}
+
 type LockfilesService interface {
 	ListDependencies(ctx context.Context, repo api.RepoName, rev string) ([]reposource.PackageDependency, error)
 }
-
-type GitService = lockfiles.GitService
 
 type Syncer interface {
 	// Sync will lazily sync the repos that have been inserted into the database but have not yet been

--- a/internal/codeintel/dependencies/init.go
+++ b/internal/codeintel/dependencies/init.go
@@ -42,6 +42,7 @@ func GetService(db database.DB, gitService GitService, syncer Syncer) *Service {
 
 		svc = newService(
 			store.GetStore(db),
+			gitService,
 			lockfilesService,
 			lockfilesSemaphore,
 			syncer,
@@ -62,6 +63,7 @@ func TestService(db database.DB, gitService GitService, syncer Syncer) *Service 
 
 	return newService(
 		store.GetStore(db),
+		gitService,
 		lockfilesService,
 		lockfilesSemaphore,
 		syncer,

--- a/internal/codeintel/dependencies/live/git.go
+++ b/internal/codeintel/dependencies/live/git.go
@@ -9,6 +9,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/dependencies"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
+	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 )
 
@@ -22,6 +23,10 @@ func NewGitService(db database.DB) dependencies.GitService {
 		db:      db,
 		checker: authz.DefaultSubRepoPermsChecker,
 	}
+}
+
+func (s *gitService) GetCommits(ctx context.Context, repoCommits []api.RepoCommit, ignoreErrors bool) ([]*gitdomain.Commit, error) {
+	return git.GetCommits(ctx, s.db, repoCommits, ignoreErrors, s.checker)
 }
 
 func (s *gitService) LsFiles(ctx context.Context, repo api.RepoName, commits api.CommitID, pathspecs ...gitserver.Pathspec) ([]string, error) {

--- a/internal/codeintel/dependencies/mock_iface_test.go
+++ b/internal/codeintel/dependencies/mock_iface_test.go
@@ -10,6 +10,7 @@ import (
 	store "github.com/sourcegraph/sourcegraph/internal/codeintel/dependencies/internal/store"
 	shared "github.com/sourcegraph/sourcegraph/internal/codeintel/dependencies/shared"
 	reposource "github.com/sourcegraph/sourcegraph/internal/conf/reposource"
+	gitdomain "github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 )
 
 // MockLockfilesService is a mock implementation of the LockfilesService
@@ -725,4 +726,169 @@ func (c SyncerSyncFuncCall) Args() []interface{} {
 // invocation.
 func (c SyncerSyncFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
+}
+
+// MockLocalGitService is a mock implementation of the localGitService
+// interface (from the package
+// github.com/sourcegraph/sourcegraph/internal/codeintel/dependencies) used
+// for unit testing.
+type MockLocalGitService struct {
+	// GetCommitsFunc is an instance of a mock function object controlling
+	// the behavior of the method GetCommits.
+	GetCommitsFunc *LocalGitServiceGetCommitsFunc
+}
+
+// NewMockLocalGitService creates a new mock of the localGitService
+// interface. All methods return zero values for all results, unless
+// overwritten.
+func NewMockLocalGitService() *MockLocalGitService {
+	return &MockLocalGitService{
+		GetCommitsFunc: &LocalGitServiceGetCommitsFunc{
+			defaultHook: func(context.Context, []api.RepoCommit, bool) (r0 []*gitdomain.Commit, r1 error) {
+				return
+			},
+		},
+	}
+}
+
+// NewStrictMockLocalGitService creates a new mock of the localGitService
+// interface. All methods panic on invocation, unless overwritten.
+func NewStrictMockLocalGitService() *MockLocalGitService {
+	return &MockLocalGitService{
+		GetCommitsFunc: &LocalGitServiceGetCommitsFunc{
+			defaultHook: func(context.Context, []api.RepoCommit, bool) ([]*gitdomain.Commit, error) {
+				panic("unexpected invocation of MockLocalGitService.GetCommits")
+			},
+		},
+	}
+}
+
+// surrogateMockLocalGitService is a copy of the localGitService interface
+// (from the package
+// github.com/sourcegraph/sourcegraph/internal/codeintel/dependencies). It
+// is redefined here as it is unexported in the source package.
+type surrogateMockLocalGitService interface {
+	GetCommits(context.Context, []api.RepoCommit, bool) ([]*gitdomain.Commit, error)
+}
+
+// NewMockLocalGitServiceFrom creates a new mock of the MockLocalGitService
+// interface. All methods delegate to the given implementation, unless
+// overwritten.
+func NewMockLocalGitServiceFrom(i surrogateMockLocalGitService) *MockLocalGitService {
+	return &MockLocalGitService{
+		GetCommitsFunc: &LocalGitServiceGetCommitsFunc{
+			defaultHook: i.GetCommits,
+		},
+	}
+}
+
+// LocalGitServiceGetCommitsFunc describes the behavior when the GetCommits
+// method of the parent MockLocalGitService instance is invoked.
+type LocalGitServiceGetCommitsFunc struct {
+	defaultHook func(context.Context, []api.RepoCommit, bool) ([]*gitdomain.Commit, error)
+	hooks       []func(context.Context, []api.RepoCommit, bool) ([]*gitdomain.Commit, error)
+	history     []LocalGitServiceGetCommitsFuncCall
+	mutex       sync.Mutex
+}
+
+// GetCommits delegates to the next hook function in the queue and stores
+// the parameter and result values of this invocation.
+func (m *MockLocalGitService) GetCommits(v0 context.Context, v1 []api.RepoCommit, v2 bool) ([]*gitdomain.Commit, error) {
+	r0, r1 := m.GetCommitsFunc.nextHook()(v0, v1, v2)
+	m.GetCommitsFunc.appendCall(LocalGitServiceGetCommitsFuncCall{v0, v1, v2, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the GetCommits method of
+// the parent MockLocalGitService instance is invoked and the hook queue is
+// empty.
+func (f *LocalGitServiceGetCommitsFunc) SetDefaultHook(hook func(context.Context, []api.RepoCommit, bool) ([]*gitdomain.Commit, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// GetCommits method of the parent MockLocalGitService instance invokes the
+// hook at the front of the queue and discards it. After the queue is empty,
+// the default hook function is invoked for any future action.
+func (f *LocalGitServiceGetCommitsFunc) PushHook(hook func(context.Context, []api.RepoCommit, bool) ([]*gitdomain.Commit, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *LocalGitServiceGetCommitsFunc) SetDefaultReturn(r0 []*gitdomain.Commit, r1 error) {
+	f.SetDefaultHook(func(context.Context, []api.RepoCommit, bool) ([]*gitdomain.Commit, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *LocalGitServiceGetCommitsFunc) PushReturn(r0 []*gitdomain.Commit, r1 error) {
+	f.PushHook(func(context.Context, []api.RepoCommit, bool) ([]*gitdomain.Commit, error) {
+		return r0, r1
+	})
+}
+
+func (f *LocalGitServiceGetCommitsFunc) nextHook() func(context.Context, []api.RepoCommit, bool) ([]*gitdomain.Commit, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *LocalGitServiceGetCommitsFunc) appendCall(r0 LocalGitServiceGetCommitsFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of LocalGitServiceGetCommitsFuncCall objects
+// describing the invocations of this function.
+func (f *LocalGitServiceGetCommitsFunc) History() []LocalGitServiceGetCommitsFuncCall {
+	f.mutex.Lock()
+	history := make([]LocalGitServiceGetCommitsFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// LocalGitServiceGetCommitsFuncCall is an object that describes an
+// invocation of method GetCommits on an instance of MockLocalGitService.
+type LocalGitServiceGetCommitsFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 []api.RepoCommit
+	// Arg2 is the value of the 3rd argument passed to this method
+	// invocation.
+	Arg2 bool
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 []*gitdomain.Commit
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c LocalGitServiceGetCommitsFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c LocalGitServiceGetCommitsFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
 }

--- a/internal/codeintel/dependencies/service.go
+++ b/internal/codeintel/dependencies/service.go
@@ -21,6 +21,7 @@ import (
 // Service encapsulates the resolution and persistence of dependencies at the repository and package levels.
 type Service struct {
 	dependenciesStore  Store
+	gitSvc             localGitService
 	lockfilesSvc       LockfilesService
 	lockfilesSemaphore *semaphore.Weighted
 	syncer             Syncer
@@ -30,6 +31,7 @@ type Service struct {
 
 func newService(
 	dependenciesStore Store,
+	gitSvc localGitService,
 	lockfilesSvc LockfilesService,
 	lockfilesSemaphore *semaphore.Weighted,
 	syncer Syncer,
@@ -38,6 +40,7 @@ func newService(
 ) *Service {
 	return &Service{
 		dependenciesStore:  dependenciesStore,
+		gitSvc:             gitSvc,
 		lockfilesSvc:       lockfilesSvc,
 		lockfilesSemaphore: lockfilesSemaphore,
 		syncer:             syncer,

--- a/internal/codeintel/dependencies/service_test.go
+++ b/internal/codeintel/dependencies/service_test.go
@@ -13,15 +13,17 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/types"
 	"github.com/sourcegraph/sourcegraph/internal/conf/reposource"
+	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 )
 
 func TestDependencies(t *testing.T) {
 	ctx := context.Background()
 	mockStore := NewMockStore()
+	gitService := NewMockLocalGitService()
 	lockfilesService := NewMockLockfilesService()
 	syncer := NewMockSyncer()
-	service := testService(mockStore, lockfilesService, syncer)
+	service := testService(mockStore, gitService, lockfilesService, syncer)
 
 	endsWithEvenDigit := func(name string) bool {
 		if name == "" {
@@ -113,9 +115,10 @@ func TestDependencies(t *testing.T) {
 	}
 }
 
-func testService(store Store, lockfilesService LockfilesService, syncer Syncer) *Service {
+func testService(store Store, gitService localGitService, lockfilesService LockfilesService, syncer Syncer) *Service {
 	return newService(
 		store,
+		gitService,
 		lockfilesService,
 		semaphore.NewWeighted(100),
 		syncer,

--- a/internal/codeintel/dependencies/service_test.go
+++ b/internal/codeintel/dependencies/service_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/types"
 	"github.com/sourcegraph/sourcegraph/internal/conf/reposource"
-	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 )
 

--- a/internal/vcs/git/commits.go
+++ b/internal/vcs/git/commits.go
@@ -538,6 +538,8 @@ func CommitsExist(ctx context.Context, db database.DB, repoCommits []api.RepoCom
 	return exists, nil
 }
 
+var GetCommits = getCommits
+
 // getCommits returns a git commit object describing each of the give repository and commit pairs. This
 // function returns a slice of the same size as the input slice. Values in the output slice may be nil if
 // their associated repository or commit are unresolvable.


### PR DESCRIPTION
Add a `GitService` interface to the Dependencies API service with a (currently unused) `GetCommits` method. This method will be used when solving #31639, as we need to resolve symbolic commits (e.g. `HEAD`) into a stable commit for persistence.

## Test plan

Existing pipelines should catch any uninitialized uses.