### PR TITLE
codeintel: migrating more scanning to basestore utilities

### DIFF
--- a/enterprise/internal/codeintel/stores/dbstore/indexes.go
+++ b/enterprise/internal/codeintel/stores/dbstore/indexes.go
@@ -46,69 +46,51 @@ func (i Index) RecordID() int {
 	return i.ID
 }
 
-// scanIndexes scans a slice of indexes from the return value of `*Store.query`.
-func scanIndexes(rows *sql.Rows, queryErr error) (_ []Index, err error) {
-	if queryErr != nil {
-		return nil, queryErr
-	}
-	defer func() { err = basestore.CloseRows(rows, err) }()
-
-	var indexes []Index
-	for rows.Next() {
-		var index Index
-		var executionLogs []dbworkerstore.ExecutionLogEntry
-
-		if err := rows.Scan(
-			&index.ID,
-			&index.Commit,
-			&index.QueuedAt,
-			&index.State,
-			&index.FailureMessage,
-			&index.StartedAt,
-			&index.FinishedAt,
-			&index.ProcessAfter,
-			&index.NumResets,
-			&index.NumFailures,
-			&index.RepositoryID,
-			&index.RepositoryName,
-			pq.Array(&index.DockerSteps),
-			&index.Root,
-			&index.Indexer,
-			pq.Array(&index.IndexerArgs),
-			&index.Outfile,
-			pq.Array(&executionLogs),
-			&index.Rank,
-			pq.Array(&index.LocalSteps),
-			&index.AssociatedUploadID,
-		); err != nil {
-			return nil, err
-		}
-
-		for _, entry := range executionLogs {
-			index.ExecutionLogs = append(index.ExecutionLogs, workerutil.ExecutionLogEntry(entry))
-		}
-
-		indexes = append(indexes, index)
+func scanIndex(s dbutil.Scanner) (index Index, err error) {
+	var executionLogs []dbworkerstore.ExecutionLogEntry
+	if err := s.Scan(
+		&index.ID,
+		&index.Commit,
+		&index.QueuedAt,
+		&index.State,
+		&index.FailureMessage,
+		&index.StartedAt,
+		&index.FinishedAt,
+		&index.ProcessAfter,
+		&index.NumResets,
+		&index.NumFailures,
+		&index.RepositoryID,
+		&index.RepositoryName,
+		pq.Array(&index.DockerSteps),
+		&index.Root,
+		&index.Indexer,
+		pq.Array(&index.IndexerArgs),
+		&index.Outfile,
+		pq.Array(&executionLogs),
+		&index.Rank,
+		pq.Array(&index.LocalSteps),
+		&index.AssociatedUploadID,
+	); err != nil {
+		return index, err
 	}
 
-	return indexes, nil
+	for _, entry := range executionLogs {
+		index.ExecutionLogs = append(index.ExecutionLogs, workerutil.ExecutionLogEntry(entry))
+	}
+
+	return index, nil
 }
+
+// scanIndexes scans a slice of indexes from the return value of `*Store.query`.
+var scanIndexes = basestore.NewSliceScanner(scanIndex)
 
 // scanFirstIndex scans a slice of indexes from the return value of `*Store.query` and returns the first.
-func scanFirstIndex(rows *sql.Rows, err error) (Index, bool, error) {
-	indexes, err := scanIndexes(rows, err)
-	if err != nil || len(indexes) == 0 {
-		return Index{}, false, err
-	}
-	return indexes[0], true, nil
-}
+var scanFirstIndex = basestore.NewFirstScanner(scanIndex)
 
 // scanFirstIndexInterface scans a slice of indexes from the return value of `*Store.query` and returns the first.
 func scanFirstIndexRecord(rows *sql.Rows, err error) (workerutil.Record, bool, error) {
 	return scanFirstIndex(rows, err)
 }
-
-var ScanFirstIndexRecord = scanFirstIndexRecord
 
 // GetIndexByID returns an index by its identifier and boolean flag indicating its existence.
 func (s *Store) GetIndexByID(ctx context.Context, id int) (_ Index, _ bool, err error) {

--- a/internal/codeintel/autoindexing/internal/store/scan.go
+++ b/internal/codeintel/autoindexing/internal/store/scan.go
@@ -1,29 +1,15 @@
 package store
 
 import (
-	"database/sql"
-
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/autoindexing/shared"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 )
 
-func scanIndexJobs(rows *sql.Rows, queryErr error) (indexJobs []shared.IndexJob, err error) {
-	if queryErr != nil {
-		return nil, queryErr
-	}
-	defer func() { err = basestore.CloseRows(rows, err) }()
-
-	for rows.Next() {
-		var indexJob shared.IndexJob
-
-		if err = rows.Scan(
-			&indexJob.Indexer,
-		); err != nil {
-			return nil, err
-		}
-
-		indexJobs = append(indexJobs, indexJob)
-	}
-
-	return indexJobs, nil
+func scanIndexJob(s dbutil.Scanner) (indexJob shared.IndexJob, err error) {
+	return indexJob, s.Scan(
+		&indexJob.Indexer,
+	)
 }
+
+var scanIndexJobs = basestore.NewSliceScanner(scanIndexJob)

--- a/internal/codeintel/dependencies/internal/store/scan.go
+++ b/internal/codeintel/dependencies/internal/store/scan.go
@@ -6,10 +6,13 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 )
 
-var scanDependencyRepos = basestore.NewSliceScanner(scanDependencyRepo)
-
-func scanDependencyRepo(s dbutil.Scanner) (shared.Repo, error) {
-	var v shared.Repo
-	err := s.Scan(&v.ID, &v.Scheme, &v.Name, &v.Version)
-	return v, err
+func scanDependencyRepo(s dbutil.Scanner) (dependencyRepo shared.Repo, err error) {
+	return dependencyRepo, s.Scan(
+		&dependencyRepo.ID,
+		&dependencyRepo.Scheme,
+		&dependencyRepo.Name,
+		&dependencyRepo.Version,
+	)
 }
+
+var scanDependencyRepos = basestore.NewSliceScanner(scanDependencyRepo)

--- a/internal/codeintel/documents/internal/store/scan.go
+++ b/internal/codeintel/documents/internal/store/scan.go
@@ -1,29 +1,15 @@
 package store
 
 import (
-	"database/sql"
-
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/documents/shared"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 )
 
-func scanDocuments(rows *sql.Rows, queryErr error) (documents []shared.Document, err error) {
-	if queryErr != nil {
-		return nil, queryErr
-	}
-	defer func() { err = basestore.CloseRows(rows, err) }()
-
-	for rows.Next() {
-		var document shared.Document
-
-		if err = rows.Scan(
-			&document.Path,
-		); err != nil {
-			return nil, err
-		}
-
-		documents = append(documents, document)
-	}
-
-	return documents, nil
+func scanDocument(s dbutil.Scanner) (document shared.Document, err error) {
+	return document, s.Scan(
+		&document.Path,
+	)
 }
+
+var scanDocuments = basestore.NewSliceScanner(scanDocument)

--- a/internal/codeintel/policies/internal/store/scan.go
+++ b/internal/codeintel/policies/internal/store/scan.go
@@ -1,29 +1,15 @@
 package store
 
 import (
-	"database/sql"
-
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/policies/shared"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 )
 
-func scanPolicies(rows *sql.Rows, queryErr error) (policies []shared.Policy, err error) {
-	if queryErr != nil {
-		return nil, queryErr
-	}
-	defer func() { err = basestore.CloseRows(rows, err) }()
-
-	for rows.Next() {
-		var policy shared.Policy
-
-		if err = rows.Scan(
-			&policy.ID,
-		); err != nil {
-			return nil, err
-		}
-
-		policies = append(policies, policy)
-	}
-
-	return policies, nil
+func scanPolicy(s dbutil.Scanner) (policy shared.Policy, err error) {
+	return policy, s.Scan(
+		&policy.ID,
+	)
 }
+
+var scanPolicies = basestore.NewSliceScanner(scanPolicy)

--- a/internal/codeintel/symbols/internal/store/scan.go
+++ b/internal/codeintel/symbols/internal/store/scan.go
@@ -1,29 +1,15 @@
 package store
 
 import (
-	"database/sql"
-
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/symbols/shared"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 )
 
-func scanSymbols(rows *sql.Rows, queryErr error) (symbols []shared.Symbol, err error) {
-	if queryErr != nil {
-		return nil, queryErr
-	}
-	defer func() { err = basestore.CloseRows(rows, err) }()
-
-	for rows.Next() {
-		var symbol shared.Symbol
-
-		if err = rows.Scan(
-			&symbol.Name,
-		); err != nil {
-			return nil, err
-		}
-
-		symbols = append(symbols, symbol)
-	}
-
-	return symbols, nil
+func scanSymbol(s dbutil.Scanner) (symbol shared.Symbol, err error) {
+	return symbol, s.Scan(
+		&symbol.Name,
+	)
 }
+
+var scanSymbols = basestore.NewSliceScanner(scanSymbol)

--- a/internal/codeintel/uploads/internal/store/scan.go
+++ b/internal/codeintel/uploads/internal/store/scan.go
@@ -1,29 +1,15 @@
 package store
 
 import (
-	"database/sql"
-
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/uploads/shared"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 )
 
-func scanUploads(rows *sql.Rows, queryErr error) (uploads []shared.Upload, err error) {
-	if queryErr != nil {
-		return nil, queryErr
-	}
-	defer func() { err = basestore.CloseRows(rows, err) }()
-
-	for rows.Next() {
-		var upload shared.Upload
-
-		if err = rows.Scan(
-			&upload.ID,
-		); err != nil {
-			return nil, err
-		}
-
-		uploads = append(uploads, upload)
-	}
-
-	return uploads, nil
+func scanUpload(s dbutil.Scanner) (upload shared.Upload, err error) {
+	return upload, s.Scan(
+		&upload.ID,
+	)
 }
+
+var scanUploads = basestore.NewSliceScanner(scanUpload)


### PR DESCRIPTION
Some tidying up of our DB accesses to use more of the `basestore` scanner utilities.

## Test plan

Covered by existing test coverage and da compiler
