### PR TITLE
Accessibility: Use correct label strings in FilteredConnection

### DIFF
--- a/client/web/src/components/FilteredConnection/FilterControl.tsx
+++ b/client/web/src/components/FilteredConnection/FilterControl.tsx
@@ -83,15 +83,18 @@ export const FilterControl: React.FunctionComponent<React.PropsWithChildren<Filt
                 }
 
                 if (filter.type === 'select') {
+                    const filterLabelId = `filtered-select-label-${filter.id}`
                     return (
                         <div
                             key={filter.id}
                             className={classNames('d-inline-flex flex-row align-center flex-wrap', styles.select)}
                         >
                             <div className="d-inline-flex flex-row mr-3 align-items-baseline">
-                                <p className="text-xl-center text-nowrap mr-2">{filter.label}:</p>
+                                <p className="text-xl-center text-nowrap mr-2" id={filterLabelId}>
+                                    {filter.label}:
+                                </p>
                                 <Select
-                                    aria-label="Sort notebooks"
+                                    aria-labelledby={filterLabelId}
                                     id=""
                                     name={filter.id}
                                     onChange={event => onChange(filter, event.currentTarget.value)}


### PR DESCRIPTION
## Description

closes https://github.com/sourcegraph/sourcegraph/issues/35192

We don't want a hardcoded label here, as this component is used in multiple places. We can use the accompanying text instead.

## Test plan

Tested locally with a screen reader

<!-- all pull requests REQUIRE a test plan.   https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-tr-filtered-connection-filter-labe.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-jztjhymlpc.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
