### PR TITLE
release-tool: add calendar event for sec-team of container images

### DIFF
--- a/dev/release/release-config.jsonc
+++ b/dev/release/release-config.jsonc
@@ -16,6 +16,7 @@
     "previousRelease": "3.39.0",
     "upcomingRelease": "3.39.1",
     // Release dates
+    "oneWorkingWeekBeforeRelease": "18 April 2022 10:00 PST",
     "oneWorkingDayBeforeRelease": "25 April 2022 10:00 PST",
     "releaseDate": "26 April 2022 10:00 PST",
     "oneWorkingDayAfterRelease": "27 April 2022 10:00 PST",

--- a/dev/release/release-config.jsonc
+++ b/dev/release/release-config.jsonc
@@ -10,16 +10,16 @@
  */
 {
     // Captain information
-    "captainSlackUsername": "coury",
-    "captainGitHubUsername": "coury-clark",
+    "captainSlackUsername": "Joe Chen",
+    "captainGitHubUsername": "unknwon",
     // Release versions
-    "previousRelease": "3.39.0",
-    "upcomingRelease": "3.39.1",
+    "previousRelease": "3.39.1",
+    "upcomingRelease": "3.40.0",
     // Release dates
-    "oneWorkingWeekBeforeRelease": "18 April 2022 10:00 PST",
-    "oneWorkingDayBeforeRelease": "25 April 2022 10:00 PST",
-    "releaseDate": "26 April 2022 10:00 PST",
-    "oneWorkingDayAfterRelease": "27 April 2022 10:00 PST",
+    "oneWorkingWeekBeforeRelease": "13 May 2022 10:00 PST",
+    "oneWorkingDayBeforeRelease": "19 May 2022 10:00 PST",
+    "releaseDate": "20 April 2022 10:00 PST",
+    "oneWorkingDayAfterRelease": "23 April 2022 10:00 PST",
     // Channel where messages from the tooling are posted
     "slackAnnounceChannel": "prod-eng-announce",
     // Email for preparing calendar events

--- a/dev/release/src/config.ts
+++ b/dev/release/src/config.ts
@@ -17,6 +17,7 @@ export interface Config {
     previousRelease: string
     upcomingRelease: string
 
+    oneWorkingWeekBeforeRelease: string
     oneWorkingDayBeforeRelease: string
     releaseDate: string
     oneWorkingDayAfterRelease: string

--- a/dev/release/src/release.ts
+++ b/dev/release/src/release.ts
@@ -110,6 +110,14 @@ const steps: Step[] = [
             const name = releaseName(release)
             const events: EventOptions[] = [
                 {
+                    title: `Security Team to Review Release Container Image Scans ${name}`,
+                    description: '(This is not an actual event to attend, just a calendar marker.)',
+                    anyoneCanAddSelf: true,
+                    attendees: [config.teamEmail],
+                    transparency: 'transparent',
+                    ...calendarTime(config.oneWorkingWeekBeforeRelease),
+                },
+                {
                     title: `Cut Sourcegraph ${name}`,
                     description: '(This is not an actual event to attend, just a calendar marker.)',
                     anyoneCanAddSelf: true,


### PR DESCRIPTION
Adds a calendar event to nudge the security team to review Sourcegraph container image scan results and provide guidance on resolution. This should give enough lead time to prevent a release-blocker situation.

See [RFC 678 for more details](https://docs.google.com/document/d/1v0TXVLPCNA42cQwIYeGLICoy6zfK9KprMRpMa2Fn6IE/edit#).


## Test plan
* CI testing to make sure it doesn't break anything in critical path
* Manual testing by release captain

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
