### PR TITLE
dependencies: Persist lockfile parsing result to database

### DIFF
--- a/internal/codeintel/dependencies/iface.go
+++ b/internal/codeintel/dependencies/iface.go
@@ -12,7 +12,7 @@ import (
 )
 
 type Store interface {
-	LockfileDependencies(ctx context.Context, repoName, commit string) ([]shared.PackageDependency, error)
+	LockfileDependencies(ctx context.Context, repoName, commit string) ([]shared.PackageDependency, bool, error)
 	UpsertLockfileDependencies(ctx context.Context, repoName, commit string, deps []shared.PackageDependency) error
 	ListDependencyRepos(ctx context.Context, opts store.ListDependencyReposOpts) ([]Repo, error)
 	UpsertDependencyRepos(ctx context.Context, deps []Repo) ([]Repo, error)

--- a/internal/codeintel/dependencies/iface.go
+++ b/internal/codeintel/dependencies/iface.go
@@ -6,11 +6,14 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/dependencies/internal/lockfiles"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/dependencies/internal/store"
+	"github.com/sourcegraph/sourcegraph/internal/codeintel/dependencies/shared"
 	"github.com/sourcegraph/sourcegraph/internal/conf/reposource"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 )
 
 type Store interface {
+	LockfileDependencies(ctx context.Context, repoName, commit string) ([]shared.PackageDependency, error)
+	UpsertLockfileDependencies(ctx context.Context, repoName, commit string, deps []shared.PackageDependency) error
 	ListDependencyRepos(ctx context.Context, opts store.ListDependencyReposOpts) ([]Repo, error)
 	UpsertDependencyRepos(ctx context.Context, deps []Repo) ([]Repo, error)
 	DeleteDependencyReposByID(ctx context.Context, ids ...int) error

--- a/internal/codeintel/dependencies/init.go
+++ b/internal/codeintel/dependencies/init.go
@@ -1,6 +1,7 @@
 package dependencies
 
 import (
+	"context"
 	"sync"
 
 	"github.com/opentracing/opentracing-go"
@@ -9,6 +10,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/dependencies/internal/lockfiles"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/dependencies/internal/store"
+	"github.com/sourcegraph/sourcegraph/internal/codeintel/dependencies/shared"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
@@ -24,16 +26,25 @@ var (
 var (
 	lockfilesSemaphoreWeight = env.MustGetInt("CODEINTEL_DEPENDENCIES_LOCKFILES_SEMAPHORE_WEIGHT", 64, "The maximum number of concurrent routines parsing lockfile contents.")
 	syncerSemaphoreWeight    = env.MustGetInt("CODEINTEL_DEPENDENCIES_LOCKFILES_SYNCER_WEIGHT", 64, "The maximum number of concurrent routines actively syncing repositories.")
+	enableUpserts            = env.Get("CODEINTEL_DEPENDENCIES_ENABLE_UPSERTS", "", "Disable writes of lockfile results to the database from the dependencies service.") != ""
 )
 
 // GetService creates or returns an already-initialized dependencies service. If the service is
 // new, it will use the given database handle and git/syncer instances.
 func GetService(db database.DB, gitService GitService, syncer Syncer) *Service {
+	logger := log.Scoped("dependencies.service", "codeintel dependencies service")
+
 	svcOnce.Do(func() {
 		observationContext := &observation.Context{
-			Logger:     log.Scoped("dependencies.service", "codeintel dependencies service"),
+			Logger:     logger,
 			Tracer:     &trace.Tracer{Tracer: opentracing.GlobalTracer()},
 			Registerer: prometheus.DefaultRegisterer,
+		}
+
+		var store Store = store.GetStore(db)
+		if !enableUpserts {
+			logger.Warn("Disabling dependencies.store.UpsertLockfileDependencies")
+			store = &shim{store}
 		}
 
 		lockfilesService := lockfiles.GetService(gitService)
@@ -41,7 +52,7 @@ func GetService(db database.DB, gitService GitService, syncer Syncer) *Service {
 		syncerSemaphore := semaphore.NewWeighted(int64(syncerSemaphoreWeight))
 
 		svc = newService(
-			store.GetStore(db),
+			store,
 			gitService,
 			lockfilesService,
 			lockfilesSemaphore,
@@ -70,4 +81,10 @@ func TestService(db database.DB, gitService GitService, syncer Syncer) *Service 
 		syncerSemaphore,
 		&observation.TestContext,
 	)
+}
+
+type shim struct{ Store }
+
+func (s *shim) UpsertLockfileDependencies(ctx context.Context, repoName, commit string, deps []shared.PackageDependency) error {
+	return nil
 }

--- a/internal/codeintel/dependencies/internal/store/observability.go
+++ b/internal/codeintel/dependencies/internal/store/observability.go
@@ -8,9 +8,11 @@ import (
 )
 
 type operations struct {
-	deleteDependencyReposByID *observation.Operation
-	listDependencyRepos       *observation.Operation
-	upsertDependencyRepos     *observation.Operation
+	deleteDependencyReposByID  *observation.Operation
+	listDependencyRepos        *observation.Operation
+	lockfileDependencies       *observation.Operation
+	upsertDependencyRepos      *observation.Operation
+	upsertLockfileDependencies *observation.Operation
 }
 
 func newOperations(observationContext *observation.Context) *operations {
@@ -30,8 +32,10 @@ func newOperations(observationContext *observation.Context) *operations {
 	}
 
 	return &operations{
-		deleteDependencyReposByID: op("DeleteDependencyReposByID"),
-		listDependencyRepos:       op("ListDependencyRepos"),
-		upsertDependencyRepos:     op("UpsertDependencyRepos"),
+		deleteDependencyReposByID:  op("DeleteDependencyReposByID"),
+		listDependencyRepos:        op("ListDependencyRepos"),
+		lockfileDependencies:       op("LockfileDependencies"),
+		upsertDependencyRepos:      op("UpsertDependencyRepos"),
+		upsertLockfileDependencies: op("UpsertLockfileDependencies"),
 	}
 }

--- a/internal/codeintel/dependencies/internal/store/scan.go
+++ b/internal/codeintel/dependencies/internal/store/scan.go
@@ -6,13 +6,10 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 )
 
-func scanDependencyRepo(s dbutil.Scanner) (dependencyRepo shared.Repo, err error) {
-	return dependencyRepo, s.Scan(
-		&dependencyRepo.ID,
-		&dependencyRepo.Scheme,
-		&dependencyRepo.Name,
-		&dependencyRepo.Version,
-	)
+func scanDependencyRepo(s dbutil.Scanner) (shared.Repo, error) {
+	var v shared.Repo
+	err := s.Scan(&v.ID, &v.Scheme, &v.Name, &v.Version)
+	return v, err
 }
 
 var scanDependencyRepos = basestore.NewSliceScanner(scanDependencyRepo)

--- a/internal/codeintel/dependencies/internal/store/scan.go
+++ b/internal/codeintel/dependencies/internal/store/scan.go
@@ -6,6 +6,12 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 )
 
+var scanPackageDependencies = basestore.NewSliceScanner(func(s dbutil.Scanner) (shared.PackageDependency, error) {
+	var v shared.PackageDependencyLiteral
+	err := s.Scan(&v.RepoNameValue, &v.GitTagFromVersionValue, &v.SchemeValue, &v.PackageSyntaxValue, &v.PackageVersionValue)
+	return v, err
+})
+
 func scanDependencyRepo(s dbutil.Scanner) (shared.Repo, error) {
 	var v shared.Repo
 	err := s.Scan(&v.ID, &v.Scheme, &v.Name, &v.Version)

--- a/internal/codeintel/dependencies/internal/store/store.go
+++ b/internal/codeintel/dependencies/internal/store/store.go
@@ -49,22 +49,47 @@ func (s *Store) Transact(ctx context.Context) (*Store, error) {
 // LockfileDependencies returns package dependencies from a previous lockfiles result for
 // the given repository and commit. It is assumed that the given commit is the canonical
 // 40-character hash.
-func (s *Store) LockfileDependencies(ctx context.Context, repoName, commit string) (deps []shared.PackageDependency, err error) {
+func (s *Store) LockfileDependencies(ctx context.Context, repoName, commit string) (deps []shared.PackageDependency, found bool, err error) {
 	ctx, _, endObservation := s.operations.lockfileDependencies.With(ctx, &err, observation.Args{LogFields: []log.Field{
 		log.String("repoName", repoName),
 		log.String("commit", commit),
 	}})
 	defer func() {
 		endObservation(1, observation.Args{LogFields: []log.Field{
+			log.Bool("found", found),
 			log.Int("numDeps", len(deps)),
 		}})
 	}()
 
-	return scanPackageDependencies(s.Query(ctx, sqlf.Sprintf(
+	tx, err := s.Transact(ctx)
+	if err != nil {
+		return nil, false, err
+	}
+	defer func() { err = tx.Done(err) }()
+
+	deps, err = scanPackageDependencies(tx.Query(ctx, sqlf.Sprintf(
 		lockfileDependenciesQuery,
 		repoName,
 		dbutil.CommitBytea(commit),
 	)))
+	if err != nil {
+		return nil, false, err
+	}
+	if len(deps) == 0 {
+		// No dependencies were found, but we could have already written a record
+		// that just had an empty references list. Check to see if this is the case
+		// so we don't attempt to re-parse the lockfiles of this repo/commit from the
+		// dependencies service.
+		_, found, err = basestore.ScanFirstInt(tx.Query(ctx, sqlf.Sprintf(
+			lockfileDependenciesExistsQuery,
+			repoName,
+			dbutil.CommitBytea(commit),
+		)))
+
+		return nil, found, err
+	}
+
+	return deps, true, nil
 }
 
 const lockfileDependenciesQuery = `
@@ -81,6 +106,13 @@ WHERE id IN (
 	FROM codeintel_lockfiles
 	WHERE repository_id = (SELECT id FROM repo WHERE name = %s) AND commit_bytea = %s
 )
+`
+
+const lockfileDependenciesExistsQuery = `
+-- source: internal/codeintel/dependencies/internal/store/store.go:LockfileDependencies
+SELECT 1
+FROM codeintel_lockfiles
+WHERE repository_id = (SELECT id FROM repo WHERE name = %s) AND commit_bytea = %s
 `
 
 // UpsertLockfileDependencies inserts the given package dependencies if they do not exist
@@ -122,17 +154,15 @@ func (s *Store) UpsertLockfileDependencies(ctx context.Context, repoName, commit
 	if ids == nil {
 		ids = []int{}
 	}
+	idsArray := pq.Array(ids)
 
-	if err := tx.Exec(ctx, sqlf.Sprintf(
+	return tx.Exec(ctx, sqlf.Sprintf(
 		insertLockfilesQuery,
 		dbutil.CommitBytea(commit),
-		pq.Array(ids),
+		idsArray,
 		repoName,
-	)); err != nil {
-		return err
-	}
-
-	return nil
+		idsArray,
+	))
 }
 
 const temporaryLockfileReferencesTableQuery = `
@@ -180,6 +210,9 @@ INSERT INTO codeintel_lockfiles (
 SELECT id, %s, %s
 FROM repo
 WHERE name = %s
+-- Last write wins
+ON CONFLICT (repository_id, commit_bytea) DO UPDATE
+SET codeintel_lockfile_reference_ids = %s
 `
 
 // populatePackageDependencyChannel populates a channel with the given dependencies for bulk insertion.

--- a/internal/codeintel/dependencies/internal/store/store.go
+++ b/internal/codeintel/dependencies/internal/store/store.go
@@ -46,6 +46,160 @@ func (s *Store) Transact(ctx context.Context) (*Store, error) {
 	}, nil
 }
 
+// LockfileDependencies returns package dependencies from a previous lockfiles result for
+// the given repository and commit. It is assumed that the given commit is the canonical
+// 40-character hash.
+func (s *Store) LockfileDependencies(ctx context.Context, repoName, commit string) (deps []shared.PackageDependency, err error) {
+	ctx, _, endObservation := s.operations.lockfileDependencies.With(ctx, &err, observation.Args{LogFields: []log.Field{
+		log.String("repoName", repoName),
+		log.String("commit", commit),
+	}})
+	defer func() {
+		endObservation(1, observation.Args{LogFields: []log.Field{
+			log.Int("numDeps", len(deps)),
+		}})
+	}()
+
+	return scanPackageDependencies(s.Query(ctx, sqlf.Sprintf(
+		lockfileDependenciesQuery,
+		repoName,
+		dbutil.CommitBytea(commit),
+	)))
+}
+
+const lockfileDependenciesQuery = `
+-- source: internal/codeintel/dependencies/internal/store/store.go:LockfileDependencies
+SELECT
+	repository_name,
+	revspec,
+	package_scheme,
+	package_name,
+	package_version
+FROM codeintel_lockfile_references
+WHERE id IN (
+	SELECT DISTINCT unnest(codeintel_lockfile_reference_ids) AS id
+	FROM codeintel_lockfiles
+	WHERE repository_id = (SELECT id FROM repo WHERE name = %s) AND commit_bytea = %s
+)
+`
+
+// UpsertLockfileDependencies inserts the given package dependencies if they do not exist
+// and inserts a new lockfiles result for the given repository and commit. It is assumed
+// that the given commit is the canonical 40-character hash.
+func (s *Store) UpsertLockfileDependencies(ctx context.Context, repoName, commit string, deps []shared.PackageDependency) (err error) {
+	ctx, _, endObservation := s.operations.upsertLockfileDependencies.With(ctx, &err, observation.Args{LogFields: []log.Field{
+		log.String("repoName", repoName),
+		log.String("commit", commit),
+		log.Int("numDeps", len(deps)),
+	}})
+	defer endObservation(1, observation.Args{})
+
+	tx, err := s.Transact(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() { err = tx.Done(err) }()
+
+	if err := tx.Exec(ctx, sqlf.Sprintf(temporaryLockfileReferencesTableQuery)); err != nil {
+		return err
+	}
+
+	if err := batch.InsertValues(
+		ctx,
+		tx.Handle().DB(),
+		"t_codeintel_lockfile_references",
+		batch.MaxNumPostgresParameters,
+		[]string{"repository_name", "revspec", "package_scheme", "package_name", "package_version"},
+		populatePackageDependencyChannel(deps),
+	); err != nil {
+		return err
+	}
+
+	ids, err := basestore.ScanInts(tx.Query(ctx, sqlf.Sprintf(upsertLockfileReferencesQuery)))
+	if err != nil {
+		return err
+	}
+
+	if err := tx.Exec(ctx, sqlf.Sprintf(
+		insertLockfilesQuery,
+		dbutil.CommitBytea(commit),
+		pq.Array(ids),
+		repoName,
+	)); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+const temporaryLockfileReferencesTableQuery = `
+-- source: internal/codeintel/dependencies/internal/store/store.go:UpsertLockfileDependencies
+CREATE TEMPORARY TABLE t_codeintel_lockfile_references (
+	repository_name text NOT NULL,
+	revspec text NOT NULL,
+	package_scheme text NOT NULL,
+	package_name text NOT NULL,
+	package_version text NOT NULL
+) ON COMMIT DROP
+`
+
+const upsertLockfileReferencesQuery = `
+-- source: internal/codeintel/dependencies/internal/store/store.go:UpsertLockfileDependencies
+WITH ins AS (
+	INSERT INTO codeintel_lockfile_references (repository_name, revspec, package_scheme, package_name, package_version)
+	SELECT repository_name, revspec, package_scheme, package_name, package_version FROM t_codeintel_lockfile_references
+	ON CONFLICT DO NOTHING
+	RETURNING id
+),
+duplicates AS (
+	SELECT id
+	FROM t_codeintel_lockfile_references t
+	JOIN codeintel_lockfile_references r
+	ON
+		r.repository_name = t.repository_name AND
+		r.revspec = t.revspec AND
+		r.package_scheme = t.package_scheme AND
+		r.package_name = t.package_name AND
+		r.package_version = t.package_version
+)
+SELECT id FROM ins UNION
+SELECT id FROM duplicates
+ORDER BY id
+`
+
+const insertLockfilesQuery = `
+-- source: internal/codeintel/dependencies/internal/store/store.go:UpsertLockfileDependencies
+INSERT INTO codeintel_lockfiles (
+	repository_id,
+	commit_bytea,
+	codeintel_lockfile_reference_ids
+)
+SELECT id, %s, %s
+FROM repo
+WHERE name = %s
+`
+
+// populatePackageDependencyChannel populates a channel with the given dependencies for bulk insertion.
+func populatePackageDependencyChannel(deps []shared.PackageDependency) <-chan []any {
+	ch := make(chan []any, len(deps))
+
+	go func() {
+		defer close(ch)
+
+		for _, dep := range deps {
+			ch <- []any{
+				dep.RepoName(),
+				dep.GitTagFromVersion(),
+				dep.Scheme(),
+				dep.PackageSyntax(),
+				dep.PackageVersion(),
+			}
+		}
+	}()
+
+	return ch
+}
+
 type ListDependencyReposOpts struct {
 	Scheme      string
 	Name        string

--- a/internal/codeintel/dependencies/internal/store/store.go
+++ b/internal/codeintel/dependencies/internal/store/store.go
@@ -60,19 +60,11 @@ func (s *Store) LockfileDependencies(ctx context.Context, repoName, commit strin
 		}})
 	}()
 
-	deps, err = scanPackageDependencies(s.Query(ctx, sqlf.Sprintf(
+	return scanPackageDependencies(s.Query(ctx, sqlf.Sprintf(
 		lockfileDependenciesQuery,
 		repoName,
 		dbutil.CommitBytea(commit),
 	)))
-	if err != nil {
-		return nil, err
-	}
-	if deps == nil {
-		return []shared.PackageDependency{}, nil
-	}
-
-	return deps, err
 }
 
 const lockfileDependenciesQuery = `

--- a/internal/codeintel/dependencies/internal/store/store_test.go
+++ b/internal/codeintel/dependencies/internal/store/store_test.go
@@ -6,10 +6,55 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
+	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/dependencies/shared"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 )
+
+func TestLockfileDependencies(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
+	ctx := context.Background()
+	db := database.NewDB(dbtest.NewDB(t))
+	store := TestStore(db)
+
+	if _, err := db.ExecContext(ctx, `INSERT INTO repo (name) VALUES ('foo')`); err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	packageA := shared.TestPackageDependencyLiteral(api.RepoName("A"), "1", "2", "3", "4")
+	packageB := shared.TestPackageDependencyLiteral(api.RepoName("B"), "2", "3", "4", "5")
+	packageC := shared.TestPackageDependencyLiteral(api.RepoName("C"), "3", "4", "5", "6")
+	packageD := shared.TestPackageDependencyLiteral(api.RepoName("D"), "4", "5", "6", "7")
+	packageE := shared.TestPackageDependencyLiteral(api.RepoName("E"), "5", "6", "7", "8")
+	packageF := shared.TestPackageDependencyLiteral(api.RepoName("F"), "6", "7", "8", "9")
+
+	commits := map[string][]shared.PackageDependency{
+		"cafebabe": {packageA, packageB, packageC},
+		"deadbeef": {packageA, packageB, packageD, packageE},
+		"deadc0de": {packageB, packageF},
+	}
+
+	for commit, deps := range commits {
+		if err := store.UpsertLockfileDependencies(ctx, "foo", commit, deps); err != nil {
+			t.Fatalf("unexpected error upserting lockfile dependencies: %s", err)
+		}
+	}
+
+	for commit, expectedDeps := range commits {
+		deps, err := store.LockfileDependencies(ctx, "foo", commit)
+		if err != nil {
+			t.Fatalf("unexpected error querying lockfile dependencies: %s", err)
+		}
+
+		if diff := cmp.Diff(expectedDeps, deps); diff != "" {
+			t.Fatalf("mismatch (-have, +want): %s", diff)
+		}
+	}
+}
 
 func TestUpsertDependencyRepo(t *testing.T) {
 	if testing.Short() {

--- a/internal/codeintel/dependencies/internal/store/store_test.go
+++ b/internal/codeintel/dependencies/internal/store/store_test.go
@@ -36,7 +36,7 @@ func TestLockfileDependencies(t *testing.T) {
 		"cafebabe": {packageA, packageB, packageC},
 		"deadbeef": {packageA, packageB, packageD, packageE},
 		"deadc0de": {packageB, packageF},
-		"deadd00d": {},
+		"deadd00d": nil,
 	}
 
 	for commit, deps := range commits {

--- a/internal/codeintel/dependencies/internal/store/store_test.go
+++ b/internal/codeintel/dependencies/internal/store/store_test.go
@@ -52,7 +52,7 @@ func TestLockfileDependencies(t *testing.T) {
 		}
 
 		if diff := cmp.Diff(expectedDeps, deps); diff != "" {
-			t.Fatalf("commit %s - mismatch (-have, +want): %s", commit, diff)
+			t.Fatalf("unexpected dependencies for commit %s (-have, +want): %s", commit, diff)
 		}
 	}
 }

--- a/internal/codeintel/dependencies/internal/store/store_test.go
+++ b/internal/codeintel/dependencies/internal/store/store_test.go
@@ -36,6 +36,7 @@ func TestLockfileDependencies(t *testing.T) {
 		"cafebabe": {packageA, packageB, packageC},
 		"deadbeef": {packageA, packageB, packageD, packageE},
 		"deadc0de": {packageB, packageF},
+		"deadd00d": {},
 	}
 
 	for commit, deps := range commits {
@@ -51,7 +52,7 @@ func TestLockfileDependencies(t *testing.T) {
 		}
 
 		if diff := cmp.Diff(expectedDeps, deps); diff != "" {
-			t.Fatalf("mismatch (-have, +want): %s", diff)
+			t.Fatalf("commit %s - mismatch (-have, +want): %s", commit, diff)
 		}
 	}
 }

--- a/internal/codeintel/dependencies/mock_iface_test.go
+++ b/internal/codeintel/dependencies/mock_iface_test.go
@@ -185,9 +185,16 @@ type MockStore struct {
 	// ListDependencyReposFunc is an instance of a mock function object
 	// controlling the behavior of the method ListDependencyRepos.
 	ListDependencyReposFunc *StoreListDependencyReposFunc
+	// LockfileDependenciesFunc is an instance of a mock function object
+	// controlling the behavior of the method LockfileDependencies.
+	LockfileDependenciesFunc *StoreLockfileDependenciesFunc
 	// UpsertDependencyReposFunc is an instance of a mock function object
 	// controlling the behavior of the method UpsertDependencyRepos.
 	UpsertDependencyReposFunc *StoreUpsertDependencyReposFunc
+	// UpsertLockfileDependenciesFunc is an instance of a mock function
+	// object controlling the behavior of the method
+	// UpsertLockfileDependencies.
+	UpsertLockfileDependenciesFunc *StoreUpsertLockfileDependenciesFunc
 }
 
 // NewMockStore creates a new mock of the Store interface. All methods
@@ -204,8 +211,18 @@ func NewMockStore() *MockStore {
 				return
 			},
 		},
+		LockfileDependenciesFunc: &StoreLockfileDependenciesFunc{
+			defaultHook: func(context.Context, string, string) (r0 []shared.PackageDependency, r1 error) {
+				return
+			},
+		},
 		UpsertDependencyReposFunc: &StoreUpsertDependencyReposFunc{
 			defaultHook: func(context.Context, []shared.Repo) (r0 []shared.Repo, r1 error) {
+				return
+			},
+		},
+		UpsertLockfileDependenciesFunc: &StoreUpsertLockfileDependenciesFunc{
+			defaultHook: func(context.Context, string, string, []shared.PackageDependency) (r0 error) {
 				return
 			},
 		},
@@ -226,9 +243,19 @@ func NewStrictMockStore() *MockStore {
 				panic("unexpected invocation of MockStore.ListDependencyRepos")
 			},
 		},
+		LockfileDependenciesFunc: &StoreLockfileDependenciesFunc{
+			defaultHook: func(context.Context, string, string) ([]shared.PackageDependency, error) {
+				panic("unexpected invocation of MockStore.LockfileDependencies")
+			},
+		},
 		UpsertDependencyReposFunc: &StoreUpsertDependencyReposFunc{
 			defaultHook: func(context.Context, []shared.Repo) ([]shared.Repo, error) {
 				panic("unexpected invocation of MockStore.UpsertDependencyRepos")
+			},
+		},
+		UpsertLockfileDependenciesFunc: &StoreUpsertLockfileDependenciesFunc{
+			defaultHook: func(context.Context, string, string, []shared.PackageDependency) error {
+				panic("unexpected invocation of MockStore.UpsertLockfileDependencies")
 			},
 		},
 	}
@@ -244,8 +271,14 @@ func NewMockStoreFrom(i Store) *MockStore {
 		ListDependencyReposFunc: &StoreListDependencyReposFunc{
 			defaultHook: i.ListDependencyRepos,
 		},
+		LockfileDependenciesFunc: &StoreLockfileDependenciesFunc{
+			defaultHook: i.LockfileDependencies,
+		},
 		UpsertDependencyReposFunc: &StoreUpsertDependencyReposFunc{
 			defaultHook: i.UpsertDependencyRepos,
+		},
+		UpsertLockfileDependenciesFunc: &StoreUpsertLockfileDependenciesFunc{
+			defaultHook: i.UpsertLockfileDependencies,
 		},
 	}
 }
@@ -472,6 +505,117 @@ func (c StoreListDependencyReposFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 
+// StoreLockfileDependenciesFunc describes the behavior when the
+// LockfileDependencies method of the parent MockStore instance is invoked.
+type StoreLockfileDependenciesFunc struct {
+	defaultHook func(context.Context, string, string) ([]shared.PackageDependency, error)
+	hooks       []func(context.Context, string, string) ([]shared.PackageDependency, error)
+	history     []StoreLockfileDependenciesFuncCall
+	mutex       sync.Mutex
+}
+
+// LockfileDependencies delegates to the next hook function in the queue and
+// stores the parameter and result values of this invocation.
+func (m *MockStore) LockfileDependencies(v0 context.Context, v1 string, v2 string) ([]shared.PackageDependency, error) {
+	r0, r1 := m.LockfileDependenciesFunc.nextHook()(v0, v1, v2)
+	m.LockfileDependenciesFunc.appendCall(StoreLockfileDependenciesFuncCall{v0, v1, v2, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the LockfileDependencies
+// method of the parent MockStore instance is invoked and the hook queue is
+// empty.
+func (f *StoreLockfileDependenciesFunc) SetDefaultHook(hook func(context.Context, string, string) ([]shared.PackageDependency, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// LockfileDependencies method of the parent MockStore instance invokes the
+// hook at the front of the queue and discards it. After the queue is empty,
+// the default hook function is invoked for any future action.
+func (f *StoreLockfileDependenciesFunc) PushHook(hook func(context.Context, string, string) ([]shared.PackageDependency, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *StoreLockfileDependenciesFunc) SetDefaultReturn(r0 []shared.PackageDependency, r1 error) {
+	f.SetDefaultHook(func(context.Context, string, string) ([]shared.PackageDependency, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *StoreLockfileDependenciesFunc) PushReturn(r0 []shared.PackageDependency, r1 error) {
+	f.PushHook(func(context.Context, string, string) ([]shared.PackageDependency, error) {
+		return r0, r1
+	})
+}
+
+func (f *StoreLockfileDependenciesFunc) nextHook() func(context.Context, string, string) ([]shared.PackageDependency, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *StoreLockfileDependenciesFunc) appendCall(r0 StoreLockfileDependenciesFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of StoreLockfileDependenciesFuncCall objects
+// describing the invocations of this function.
+func (f *StoreLockfileDependenciesFunc) History() []StoreLockfileDependenciesFuncCall {
+	f.mutex.Lock()
+	history := make([]StoreLockfileDependenciesFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// StoreLockfileDependenciesFuncCall is an object that describes an
+// invocation of method LockfileDependencies on an instance of MockStore.
+type StoreLockfileDependenciesFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 string
+	// Arg2 is the value of the 3rd argument passed to this method
+	// invocation.
+	Arg2 string
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 []shared.PackageDependency
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c StoreLockfileDependenciesFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c StoreLockfileDependenciesFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
+}
+
 // StoreUpsertDependencyReposFunc describes the behavior when the
 // UpsertDependencyRepos method of the parent MockStore instance is invoked.
 type StoreUpsertDependencyReposFunc struct {
@@ -578,6 +722,120 @@ func (c StoreUpsertDependencyReposFuncCall) Args() []interface{} {
 // invocation.
 func (c StoreUpsertDependencyReposFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
+}
+
+// StoreUpsertLockfileDependenciesFunc describes the behavior when the
+// UpsertLockfileDependencies method of the parent MockStore instance is
+// invoked.
+type StoreUpsertLockfileDependenciesFunc struct {
+	defaultHook func(context.Context, string, string, []shared.PackageDependency) error
+	hooks       []func(context.Context, string, string, []shared.PackageDependency) error
+	history     []StoreUpsertLockfileDependenciesFuncCall
+	mutex       sync.Mutex
+}
+
+// UpsertLockfileDependencies delegates to the next hook function in the
+// queue and stores the parameter and result values of this invocation.
+func (m *MockStore) UpsertLockfileDependencies(v0 context.Context, v1 string, v2 string, v3 []shared.PackageDependency) error {
+	r0 := m.UpsertLockfileDependenciesFunc.nextHook()(v0, v1, v2, v3)
+	m.UpsertLockfileDependenciesFunc.appendCall(StoreUpsertLockfileDependenciesFuncCall{v0, v1, v2, v3, r0})
+	return r0
+}
+
+// SetDefaultHook sets function that is called when the
+// UpsertLockfileDependencies method of the parent MockStore instance is
+// invoked and the hook queue is empty.
+func (f *StoreUpsertLockfileDependenciesFunc) SetDefaultHook(hook func(context.Context, string, string, []shared.PackageDependency) error) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// UpsertLockfileDependencies method of the parent MockStore instance
+// invokes the hook at the front of the queue and discards it. After the
+// queue is empty, the default hook function is invoked for any future
+// action.
+func (f *StoreUpsertLockfileDependenciesFunc) PushHook(hook func(context.Context, string, string, []shared.PackageDependency) error) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *StoreUpsertLockfileDependenciesFunc) SetDefaultReturn(r0 error) {
+	f.SetDefaultHook(func(context.Context, string, string, []shared.PackageDependency) error {
+		return r0
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *StoreUpsertLockfileDependenciesFunc) PushReturn(r0 error) {
+	f.PushHook(func(context.Context, string, string, []shared.PackageDependency) error {
+		return r0
+	})
+}
+
+func (f *StoreUpsertLockfileDependenciesFunc) nextHook() func(context.Context, string, string, []shared.PackageDependency) error {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *StoreUpsertLockfileDependenciesFunc) appendCall(r0 StoreUpsertLockfileDependenciesFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of StoreUpsertLockfileDependenciesFuncCall
+// objects describing the invocations of this function.
+func (f *StoreUpsertLockfileDependenciesFunc) History() []StoreUpsertLockfileDependenciesFuncCall {
+	f.mutex.Lock()
+	history := make([]StoreUpsertLockfileDependenciesFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// StoreUpsertLockfileDependenciesFuncCall is an object that describes an
+// invocation of method UpsertLockfileDependencies on an instance of
+// MockStore.
+type StoreUpsertLockfileDependenciesFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 string
+	// Arg2 is the value of the 3rd argument passed to this method
+	// invocation.
+	Arg2 string
+	// Arg3 is the value of the 4th argument passed to this method
+	// invocation.
+	Arg3 []shared.PackageDependency
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c StoreUpsertLockfileDependenciesFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c StoreUpsertLockfileDependenciesFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0}
 }
 
 // MockSyncer is a mock implementation of the Syncer interface (from the

--- a/internal/codeintel/dependencies/observability.go
+++ b/internal/codeintel/dependencies/observability.go
@@ -8,7 +8,9 @@ import (
 )
 
 type operations struct {
-	dependencies *observation.Operation
+	dependencies                           *observation.Operation
+	resolveLockfileDependenciesFromArchive *observation.Operation
+	resolveLockfileDependenciesFromStore   *observation.Operation
 }
 
 func newOperations(observationContext *observation.Context) *operations {
@@ -28,6 +30,8 @@ func newOperations(observationContext *observation.Context) *operations {
 	}
 
 	return &operations{
-		dependencies: op("Dependencies"),
+		dependencies:                           op("Dependencies"),
+		resolveLockfileDependenciesFromArchive: op("resolveLockfileDependenciesFromArchive"),
+		resolveLockfileDependenciesFromStore:   op("resolveLockfileDependenciesFromStore"),
 	}
 }

--- a/internal/codeintel/dependencies/service.go
+++ b/internal/codeintel/dependencies/service.go
@@ -199,9 +199,9 @@ func (s *Service) lockfileDependencies(ctx context.Context, repoCommits []repoCo
 		g.Go(func() error {
 			defer s.lockfilesSemaphore.Release(1)
 
-			repoDeps, err := s.lockfilesSvc.ListDependencies(ctx, repoCommit.Repo, string(repoCommit.CommitID))
+			repoDeps, err := s.listDependencies(ctx, repoCommit)
 			if err != nil {
-				return errors.Wrap(err, "lockfiles.ListDependencies")
+				return err
 			}
 
 			mu.Lock()
@@ -217,6 +217,16 @@ func (s *Service) lockfileDependencies(ctx context.Context, repoCommits []repoCo
 	}
 
 	return deps, nil
+}
+
+// listDependencies gathers dependencies from the lockfiles service for the given repo-commit pair.
+func (s *Service) listDependencies(ctx context.Context, repoCommit repoCommitResolvedCommit) ([]reposource.PackageDependency, error) {
+	repoDeps, err := s.lockfilesSvc.ListDependencies(ctx, repoCommit.Repo, string(repoCommit.CommitID))
+	if err != nil {
+		return nil, errors.Wrap(err, "lockfiles.ListDependencies")
+	}
+
+	return repoDeps, nil
 }
 
 // sync invokes the Syncer for every repo in the supplied slice.

--- a/internal/codeintel/dependencies/service.go
+++ b/internal/codeintel/dependencies/service.go
@@ -183,9 +183,9 @@ func (s *Service) lockfileDependencies(ctx context.Context, repoCommits []repoCo
 	)
 
 	ctx, cancel := context.WithCancel(ctx)
+	g, ctx := errgroup.WithContext(ctx)
 	defer cancel()
 
-	g, ctx := errgroup.WithContext(ctx)
 	for _, repoCommit := range repoCommits {
 		// Capture outside of goroutine below
 		repoName, rev := repoCommit.Repo, repoCommit.CommitID
@@ -221,7 +221,10 @@ func (s *Service) lockfileDependencies(ctx context.Context, repoCommits []repoCo
 
 // sync invokes the Syncer for every repo in the supplied slice.
 func (s *Service) sync(ctx context.Context, repos []api.RepoName) error {
+	ctx, cancel := context.WithCancel(ctx)
 	g, ctx := errgroup.WithContext(ctx)
+	defer cancel()
+
 	for _, repo := range repos {
 		// Capture outside of goroutine below
 		repo := repo

--- a/internal/codeintel/dependencies/service.go
+++ b/internal/codeintel/dependencies/service.go
@@ -227,7 +227,7 @@ func (s *Service) resolveLockfileDependenciesFromStore(ctx context.Context, repo
 		}
 	}
 
-	return nil, len(unqueried), nil
+	return deps, len(unqueried), nil
 }
 
 // resolveLockfileDependenciesFromArchive is a resolverFunc. It returns a flattened list of package dependencies

--- a/internal/codeintel/dependencies/service.go
+++ b/internal/codeintel/dependencies/service.go
@@ -216,14 +216,12 @@ func (s *Service) resolveLockfileDependenciesFromStore(ctx context.Context, repo
 
 	for _, repoCommit := range repoCommits {
 		// TODO - batch these requests in the store layer
-		repoDeps, err := s.dependenciesStore.LockfileDependencies(ctx, string(repoCommit.Repo), repoCommit.ResolvedCommit)
-		if err != nil {
+		if repoDeps, ok, err := s.dependenciesStore.LockfileDependencies(ctx, string(repoCommit.Repo), repoCommit.ResolvedCommit); err != nil {
 			return nil, 0, errors.Wrap(err, "store.LockfileDependencies")
-		}
-		if len(repoDeps) > 0 {
-			deps = append(deps, repoDeps...)
-		} else {
+		} else if !ok {
 			unqueried = append(unqueried, repoCommit)
+		} else {
+			deps = append(deps, repoDeps...)
 		}
 	}
 

--- a/internal/codeintel/dependencies/service.go
+++ b/internal/codeintel/dependencies/service.go
@@ -176,15 +176,13 @@ func (s *Service) resolveRepoCommits(ctx context.Context, repoRevs map[api.RepoN
 
 // lockfileDependencies returns a flattened list of package dependencies for every repo and
 // revision pair specified in the given map.
-func (s *Service) lockfileDependencies(ctx context.Context, repoCommits []repoCommitResolvedCommit) ([]reposource.PackageDependency, error) {
-	var (
-		mu   sync.Mutex
-		deps []reposource.PackageDependency
-	)
-
+func (s *Service) lockfileDependencies(ctx context.Context, repoCommits []repoCommitResolvedCommit) (deps []reposource.PackageDependency, _ error) {
 	ctx, cancel := context.WithCancel(ctx)
 	g, ctx := errgroup.WithContext(ctx)
 	defer cancel()
+
+	// Protects appending to deps
+	var mu sync.Mutex
 
 	for _, repoCommit := range repoCommits {
 		// Capture outside of goroutine below

--- a/internal/codeintel/dependencies/service.go
+++ b/internal/codeintel/dependencies/service.go
@@ -188,7 +188,7 @@ func (s *Service) lockfileDependencies(ctx context.Context, repoCommits []repoCo
 
 	for _, repoCommit := range repoCommits {
 		// Capture outside of goroutine below
-		repoName, rev := repoCommit.Repo, repoCommit.CommitID
+		repoCommit := repoCommit
 
 		// Acquire semaphore before spawning goroutine to ensure that we limit the total number
 		// of concurrent _routines_, whether they are actively processing lockfiles or not.
@@ -199,7 +199,7 @@ func (s *Service) lockfileDependencies(ctx context.Context, repoCommits []repoCo
 		g.Go(func() error {
 			defer s.lockfilesSemaphore.Release(1)
 
-			repoDeps, err := s.lockfilesSvc.ListDependencies(ctx, repoName, string(rev))
+			repoDeps, err := s.lockfilesSvc.ListDependencies(ctx, repoCommit.Repo, string(repoCommit.CommitID))
 			if err != nil {
 				return errors.Wrap(err, "lockfiles.ListDependencies")
 			}

--- a/internal/codeintel/dependencies/service.go
+++ b/internal/codeintel/dependencies/service.go
@@ -14,7 +14,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/dependencies/internal/store"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/dependencies/shared"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/types"
-	"github.com/sourcegraph/sourcegraph/internal/conf/reposource"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
@@ -176,7 +175,7 @@ func (s *Service) resolveRepoCommits(ctx context.Context, repoRevs map[api.RepoN
 
 // lockfileDependencies returns a flattened list of package dependencies for every repo and
 // revision pair specified in the given map.
-func (s *Service) lockfileDependencies(ctx context.Context, repoCommits []repoCommitResolvedCommit) (deps []reposource.PackageDependency, _ error) {
+func (s *Service) lockfileDependencies(ctx context.Context, repoCommits []repoCommitResolvedCommit) (deps []shared.PackageDependency, _ error) {
 	ctx, cancel := context.WithCancel(ctx)
 	g, ctx := errgroup.WithContext(ctx)
 	defer cancel()
@@ -218,13 +217,13 @@ func (s *Service) lockfileDependencies(ctx context.Context, repoCommits []repoCo
 }
 
 // listDependencies gathers dependencies from the lockfiles service for the given repo-commit pair.
-func (s *Service) listDependencies(ctx context.Context, repoCommit repoCommitResolvedCommit) ([]reposource.PackageDependency, error) {
+func (s *Service) listDependencies(ctx context.Context, repoCommit repoCommitResolvedCommit) ([]shared.PackageDependency, error) {
 	repoDeps, err := s.lockfilesSvc.ListDependencies(ctx, repoCommit.Repo, string(repoCommit.CommitID))
 	if err != nil {
 		return nil, errors.Wrap(err, "lockfiles.ListDependencies")
 	}
 
-	return repoDeps, nil
+	return shared.SerializePackageDependencies(repoDeps), nil
 }
 
 // sync invokes the Syncer for every repo in the supplied slice.

--- a/internal/codeintel/dependencies/service_test.go
+++ b/internal/codeintel/dependencies/service_test.go
@@ -7,10 +7,12 @@ import (
 	"strconv"
 	"testing"
 
+	mockassert "github.com/derision-test/go-mockgen/testutil/assert"
 	"github.com/google/go-cmp/cmp"
 	"golang.org/x/sync/semaphore"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/codeintel/dependencies/shared"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/types"
 	"github.com/sourcegraph/sourcegraph/internal/conf/reposource"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
@@ -36,6 +38,7 @@ func TestDependencies(t *testing.T) {
 		return v%2 == 0
 	}
 
+	// UpsertDependencyRepos influences the value that syncer.Sync is called with (asserted below)
 	mockStore.UpsertDependencyReposFunc.SetDefaultHook(func(ctx context.Context, dependencyRepos []Repo) ([]Repo, error) {
 		filtered := dependencyRepos[:0]
 		for _, dependencyRepo := range dependencyRepos {
@@ -51,6 +54,7 @@ func TestDependencies(t *testing.T) {
 		return filtered, nil
 	})
 
+	// GetCommits returns the same values as input; no errors
 	gitService.GetCommitsFunc.SetDefaultHook(func(ctx context.Context, repoCommits []api.RepoCommit, _ bool) (commits []*gitdomain.Commit, _ error) {
 		for _, repoCommit := range repoCommits {
 			commits = append(commits, &gitdomain.Commit{ID: repoCommit.CommitID})
@@ -58,11 +62,29 @@ func TestDependencies(t *testing.T) {
 		return commits, nil
 	})
 
+	// Return archive dependencies for repos `foo` and `bar`
 	lockfilesService.ListDependenciesFunc.SetDefaultHook(func(ctx context.Context, repoName api.RepoName, rev string) ([]reposource.PackageDependency, error) {
+		if repoName != "github.com/example/foo" && repoName != "github.com/example/bar" {
+			return nil, nil
+		}
+
 		return []reposource.PackageDependency{
 			&reposource.MavenDependency{MavenModule: &reposource.MavenModule{GroupID: "g1", ArtifactID: "a1"}, Version: fmt.Sprintf("1-%s-%s", repoName, rev)},
 			&reposource.MavenDependency{MavenModule: &reposource.MavenModule{GroupID: "g2", ArtifactID: "a2"}, Version: fmt.Sprintf("2-%s-%s", repoName, rev)},
 			&reposource.MavenDependency{MavenModule: &reposource.MavenModule{GroupID: "g3", ArtifactID: "a3"}, Version: fmt.Sprintf("3-%s-%s", repoName, rev)},
+		}, nil
+	})
+
+	// Return canned dependencies for repo `baz`
+	mockStore.LockfileDependenciesFunc.SetDefaultHook(func(ctx context.Context, repoName, commit string) ([]shared.PackageDependency, error) {
+		if repoName != "github.com/example/baz" {
+			return nil, nil
+		}
+
+		return []shared.PackageDependency{
+			shared.TestPackageDependencyLiteral("npm/leftpad", "1", "2", "3", "4"),
+			shared.TestPackageDependencyLiteral("npm/rightpad", "2", "3", "4", "5"),
+			shared.TestPackageDependencyLiteral("npm/centerpad", "3", "4", "5", "6"),
 		}, nil
 	})
 
@@ -75,6 +97,10 @@ func TestDependencies(t *testing.T) {
 			api.RevSpec("deadbeef3"): struct{}{},
 			api.RevSpec("deadbeef4"): struct{}{},
 		},
+		api.RepoName("github.com/example/baz"): {
+			api.RevSpec("deadbeef5"): struct{}{},
+			api.RevSpec("deadbeef6"): struct{}{},
+		},
 	}
 	dependencies, err := service.Dependencies(ctx, repoRevs)
 	if err != nil {
@@ -82,6 +108,12 @@ func TestDependencies(t *testing.T) {
 	}
 
 	expectedDepencies := map[api.RepoName]types.RevSpecSet{
+		// From store
+		("npm/leftpad"):   {"1": struct{}{}},
+		("npm/rightpad"):  {"2": struct{}{}},
+		("npm/centerpad"): {"3": struct{}{}},
+
+		// From lockfiles
 		"maven/g1/a1": {
 			"v1-github.com/example/bar-deadbeef3": struct{}{},
 			"v1-github.com/example/bar-deadbeef4": struct{}{},
@@ -105,6 +137,14 @@ func TestDependencies(t *testing.T) {
 		t.Errorf("unexpected dependencies (-want +got):\n%s", diff)
 	}
 
+	// Assert `store.UpsertLockfileDependencies` was called
+	mockassert.CalledN(t, mockStore.UpsertLockfileDependenciesFunc, 4)
+	mockassert.CalledOnceWith(t, mockStore.UpsertLockfileDependenciesFunc, mockassert.Values(mockassert.Skip, "github.com/example/foo", "deadbeef1", mockassert.Skip))
+	mockassert.CalledOnceWith(t, mockStore.UpsertLockfileDependenciesFunc, mockassert.Values(mockassert.Skip, "github.com/example/foo", "deadbeef2", mockassert.Skip))
+	mockassert.CalledOnceWith(t, mockStore.UpsertLockfileDependenciesFunc, mockassert.Values(mockassert.Skip, "github.com/example/bar", "deadbeef3", mockassert.Skip))
+	mockassert.CalledOnceWith(t, mockStore.UpsertLockfileDependenciesFunc, mockassert.Values(mockassert.Skip, "github.com/example/bar", "deadbeef4", mockassert.Skip))
+
+	// Assert `syncer.Sync` was called correctly
 	syncHistory := syncer.SyncFunc.History()
 	syncedRepoNames := make([]string, 0, len(syncHistory))
 	for _, call := range syncHistory {

--- a/internal/codeintel/dependencies/service_test.go
+++ b/internal/codeintel/dependencies/service_test.go
@@ -76,16 +76,16 @@ func TestDependencies(t *testing.T) {
 	})
 
 	// Return canned dependencies for repo `baz`
-	mockStore.LockfileDependenciesFunc.SetDefaultHook(func(ctx context.Context, repoName, commit string) ([]shared.PackageDependency, error) {
+	mockStore.LockfileDependenciesFunc.SetDefaultHook(func(ctx context.Context, repoName, commit string) ([]shared.PackageDependency, bool, error) {
 		if repoName != "github.com/example/baz" {
-			return nil, nil
+			return nil, false, nil
 		}
 
 		return []shared.PackageDependency{
 			shared.TestPackageDependencyLiteral("npm/leftpad", "1", "2", "3", "4"),
 			shared.TestPackageDependencyLiteral("npm/rightpad", "2", "3", "4", "5"),
 			shared.TestPackageDependencyLiteral("npm/centerpad", "3", "4", "5", "6"),
-		}, nil
+		}, true, nil
 	})
 
 	repoRevs := map[api.RepoName]types.RevSpecSet{

--- a/internal/codeintel/dependencies/shared/types.go
+++ b/internal/codeintel/dependencies/shared/types.go
@@ -1,8 +1,48 @@
 package shared
 
+import "github.com/sourcegraph/sourcegraph/internal/api"
+
 type Repo struct {
 	ID      int
 	Scheme  string
 	Name    string
 	Version string
 }
+
+type PackageDependency interface {
+	RepoName() api.RepoName
+	GitTagFromVersion() string
+	Scheme() string
+	PackageSyntax() string
+	PackageVersion() string
+}
+
+type PackageDependencyLiteral struct {
+	RepoNameValue          api.RepoName
+	GitTagFromVersionValue string
+	SchemeValue            string
+	PackageSyntaxValue     string
+	PackageVersionValue    string
+}
+
+func TestPackageDependencyLiteral(
+	repoNameValue api.RepoName,
+	gitTagFromVersionValue string,
+	schemeValue string,
+	packageSyntaxValue string,
+	packageVersionValue string,
+) PackageDependency {
+	return PackageDependencyLiteral{
+		RepoNameValue:          repoNameValue,
+		GitTagFromVersionValue: gitTagFromVersionValue,
+		SchemeValue:            schemeValue,
+		PackageSyntaxValue:     packageSyntaxValue,
+		PackageVersionValue:    packageVersionValue,
+	}
+}
+
+func (d PackageDependencyLiteral) RepoName() api.RepoName    { return d.RepoNameValue }
+func (d PackageDependencyLiteral) GitTagFromVersion() string { return d.GitTagFromVersionValue }
+func (d PackageDependencyLiteral) Scheme() string            { return d.SchemeValue }
+func (d PackageDependencyLiteral) PackageSyntax() string     { return d.PackageSyntaxValue }
+func (d PackageDependencyLiteral) PackageVersion() string    { return d.PackageVersionValue }

--- a/internal/codeintel/dependencies/shared/types.go
+++ b/internal/codeintel/dependencies/shared/types.go
@@ -1,6 +1,9 @@
 package shared
 
-import "github.com/sourcegraph/sourcegraph/internal/api"
+import (
+	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/conf/reposource"
+)
 
 type Repo struct {
 	ID      int
@@ -46,3 +49,22 @@ func (d PackageDependencyLiteral) GitTagFromVersion() string { return d.GitTagFr
 func (d PackageDependencyLiteral) Scheme() string            { return d.SchemeValue }
 func (d PackageDependencyLiteral) PackageSyntax() string     { return d.PackageSyntaxValue }
 func (d PackageDependencyLiteral) PackageVersion() string    { return d.PackageVersionValue }
+
+func SerializePackageDependencies(deps []reposource.PackageDependency) []PackageDependency {
+	serializableRepoDeps := make([]PackageDependency, 0, len(deps))
+	for _, dep := range deps {
+		serializableRepoDeps = append(serializableRepoDeps, SerializePackageDependency(dep))
+	}
+
+	return serializableRepoDeps
+}
+
+func SerializePackageDependency(dep reposource.PackageDependency) PackageDependency {
+	return PackageDependencyLiteral{
+		RepoNameValue:          dep.RepoName(),
+		GitTagFromVersionValue: dep.GitTagFromVersion(),
+		SchemeValue:            dep.Scheme(),
+		PackageSyntaxValue:     dep.PackageSyntax(),
+		PackageVersionValue:    dep.PackageVersion(),
+	}
+}

--- a/migrations/frontend/1652189866/down.sql
+++ b/migrations/frontend/1652189866/down.sql
@@ -1,0 +1,3 @@
+DROP TABLE IF EXISTS codeintel_lockfile_references;
+
+DROP TABLE IF EXISTS codeintel_lockfiles;

--- a/migrations/frontend/1652189866/metadata.yaml
+++ b/migrations/frontend/1652189866/metadata.yaml
@@ -1,0 +1,2 @@
+name: Add lockfiles tables
+parents: [1650456734, 1651061363, 1651159431]

--- a/migrations/frontend/1652189866/up.sql
+++ b/migrations/frontend/1652189866/up.sql
@@ -1,0 +1,58 @@
+CREATE TABLE IF NOT EXISTS codeintel_lockfiles (
+    id SERIAL PRIMARY KEY,
+    repository_id integer NOT NULL,
+    commit_bytea bytea NOT NULL,
+    codeintel_lockfile_reference_ids integer [] NOT NULL
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS codeintel_lockfiles_repository_id_commit_bytea ON codeintel_lockfiles USING btree (repository_id, commit_bytea);
+
+CREATE INDEX IF NOT EXISTS codeintel_lockfiles_codeintel_lockfile_reference_ids ON codeintel_lockfiles USING GIN (
+    codeintel_lockfile_reference_ids gin__int_ops
+);
+
+COMMENT ON TABLE codeintel_lockfiles IS 'Associates a repository-commit pair with the set of repository-level dependencies parsed from lockfiles.';
+
+COMMENT ON COLUMN codeintel_lockfiles.commit_bytea IS 'A 40-char revhash. Note that this commit may not be resolvable in the future.';
+
+COMMENT ON COLUMN codeintel_lockfiles.codeintel_lockfile_reference_ids IS 'A key to a resolved repository name-revspec pair. Not all repository names and revspecs are resolvable.';
+
+CREATE TABLE IF NOT EXISTS codeintel_lockfile_references (
+    id SERIAL PRIMARY KEY,
+    repository_name text NOT NULL,
+    revspec text NOT NULL,
+    package_scheme text NOT NULL,
+    package_name text NOT NULL,
+    package_version text NOT NULL,
+    repository_id integer,
+    commit_bytea bytea
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS codeintel_lockfile_references_repository_name_revspec_package ON codeintel_lockfile_references USING btree (
+    repository_name,
+    revspec,
+    package_scheme,
+    package_name,
+    package_version
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS codeintel_lockfile_references_repository_id_commit_bytea ON codeintel_lockfile_references USING btree (repository_id, commit_bytea)
+WHERE
+    repository_id IS NOT NULL
+    AND commit_bytea IS NOT NULL;
+
+COMMENT ON TABLE codeintel_lockfile_references IS 'Tracks a lockfile dependency that might be resolvable to a specific repository-commit pair.';
+
+COMMENT ON COLUMN codeintel_lockfile_references.repository_name IS 'Encodes `reposource.PackageDependency.RepoName`. A name that is "globally unique" for a Sourcegraph instance. Used in `repo:...` queries.';
+
+COMMENT ON COLUMN codeintel_lockfile_references.revspec IS 'Encodes `reposource.PackageDependency.GitTagFromVersion`. Returns the git tag associated with the given dependency version, used in `rev:` or `repo:foo@rev` queries.';
+
+COMMENT ON COLUMN codeintel_lockfile_references.package_scheme IS 'Encodes `reposource.PackageDependency.Scheme`. The scheme of the dependency (e.g., semanticdb, npm).';
+
+COMMENT ON COLUMN codeintel_lockfile_references.package_name IS 'Encodes `reposource.PackageDependency.PackageSyntax`. The name of the dependency as used by the package manager, excluding version information.';
+
+COMMENT ON COLUMN codeintel_lockfile_references.package_version IS 'Encodes `reposource.PackageDependency.PackageVersion`. The version of the package.';
+
+COMMENT ON COLUMN codeintel_lockfile_references.repository_id IS 'The identifier of the repo that resolves the associated name, if it is resolvable on this instance.';
+
+COMMENT ON COLUMN codeintel_lockfile_references.commit_bytea IS 'The resolved 40-char revhash of the associated revspec, if it is resolvable on this instance.';


### PR DESCRIPTION
Fixes #31639. This PR adds tables to the pgsql database that act as a write through cache for the lockfiles service.

**Reviewers**: Please review by commit.

## Test plan

New unit tests / tested locally.