### PR TITLE
codeintel: use COUNT OVER() window function for getting uploads/indexes total count

### DIFF
--- a/enterprise/internal/codeintel/stores/dbstore/indexes.go
+++ b/enterprise/internal/codeintel/stores/dbstore/indexes.go
@@ -83,7 +83,47 @@ func scanIndex(s dbutil.Scanner) (index Index, err error) {
 }
 
 // scanIndexes scans a slice of indexes from the return value of `*Store.query`.
+func scanIndexWithCount(s dbutil.Scanner) (index Index, count int, err error) {
+	var executionLogs []dbworkerstore.ExecutionLogEntry
+
+	if err := s.Scan(
+		&index.ID,
+		&index.Commit,
+		&index.QueuedAt,
+		&index.State,
+		&index.FailureMessage,
+		&index.StartedAt,
+		&index.FinishedAt,
+		&index.ProcessAfter,
+		&index.NumResets,
+		&index.NumFailures,
+		&index.RepositoryID,
+		&index.RepositoryName,
+		pq.Array(&index.DockerSteps),
+		&index.Root,
+		&index.Indexer,
+		pq.Array(&index.IndexerArgs),
+		&index.Outfile,
+		pq.Array(&executionLogs),
+		&index.Rank,
+		pq.Array(&index.LocalSteps),
+		&index.AssociatedUploadID,
+		&count,
+	); err != nil {
+		return index, 0, err
+	}
+
+	for _, entry := range executionLogs {
+		index.ExecutionLogs = append(index.ExecutionLogs, workerutil.ExecutionLogEntry(entry))
+	}
+
+	return index, count, nil
+}
+
+// scanIndexes scans a slice of indexes from the return value of `*Store.query`.
 var scanIndexes = basestore.NewSliceScanner(scanIndex)
+
+var scanIndexesWithCount = basestore.NewSliceWithCountScanner(scanIndexWithCount)
 
 // scanFirstIndex scans a slice of indexes from the return value of `*Store.query` and returns the first.
 var scanFirstIndex = basestore.NewFirstScanner(scanIndex)
@@ -145,7 +185,8 @@ SELECT
 	u.execution_logs,
 	s.rank,
 	u.local_steps,
-	` + indexAssociatedUploadIDQueryFragment + `
+	` + indexAssociatedUploadIDQueryFragment + `,
+	COUNT(*) OVER() AS count
 FROM lsif_indexes u
 LEFT JOIN (` + indexRankQueryFragment + `) s
 ON u.id = s.id
@@ -253,12 +294,7 @@ func (s *Store) GetIndexes(ctx context.Context, opts GetIndexesOptions) (_ []Ind
 	}
 	conds = append(conds, authzConds)
 
-	totalCount, _, err := basestore.ScanFirstInt(tx.Store.Query(ctx, sqlf.Sprintf(getIndexesCountQuery, sqlf.Join(conds, " AND "))))
-	if err != nil {
-		return nil, 0, err
-	}
-
-	indexes, err := scanIndexes(tx.Store.Query(ctx, sqlf.Sprintf(getIndexesQuery, sqlf.Join(conds, " AND "), opts.Limit, opts.Offset)))
+	indexes, totalCount, err := scanIndexesWithCount(tx.Store.Query(ctx, sqlf.Sprintf(getIndexesQuery, sqlf.Join(conds, " AND "), opts.Limit, opts.Offset)))
 	if err != nil {
 		return nil, 0, err
 	}
@@ -269,14 +305,6 @@ func (s *Store) GetIndexes(ctx context.Context, opts GetIndexesOptions) (_ []Ind
 
 	return indexes, totalCount, nil
 }
-
-const getIndexesCountQuery = `
--- source: enterprise/internal/codeintel/stores/dbstore/indexes.go:GetIndexes
-SELECT COUNT(*)
-FROM lsif_indexes u
-JOIN repo ON repo.id = u.repository_id
-WHERE repo.deleted_at IS NULL AND %s
-`
 
 const getIndexesQuery = `
 -- source: enterprise/internal/codeintel/stores/dbstore/indexes.go:GetIndexes

--- a/enterprise/internal/codeintel/stores/dbstore/indexes.go
+++ b/enterprise/internal/codeintel/stores/dbstore/indexes.go
@@ -185,8 +185,7 @@ SELECT
 	u.execution_logs,
 	s.rank,
 	u.local_steps,
-	` + indexAssociatedUploadIDQueryFragment + `,
-	COUNT(*) OVER() AS count
+	` + indexAssociatedUploadIDQueryFragment + `
 FROM lsif_indexes u
 LEFT JOIN (` + indexRankQueryFragment + `) s
 ON u.id = s.id
@@ -329,7 +328,8 @@ SELECT
 	u.execution_logs,
 	s.rank,
 	u.local_steps,
-	` + indexAssociatedUploadIDQueryFragment + `
+	` + indexAssociatedUploadIDQueryFragment + `,
+	COUNT(*) OVER() AS count
 FROM lsif_indexes u
 LEFT JOIN (` + indexRankQueryFragment + `) s
 ON u.id = s.id

--- a/internal/database/basestore/rows.go
+++ b/internal/database/basestore/rows.go
@@ -57,6 +57,9 @@ func NewSliceScanner[T any](f func(dbutil.Scanner) (T, error)) func(rows *sql.Ro
 // the values of the query result, as well as the count from the `COUNT(*) OVER()`
 // window function. The given function is invoked multiple times with a SQL rows
 // object to scan a single value.
+// Example query that would avail of this function, where we want only 10 rows but still
+// the count of everything that would have been returned, without performing two separate queries:
+// SELECT u.id, COUNT(*) OVER() as count FROM users LIMIT 10
 func NewSliceWithCountScanner[T any](f func(dbutil.Scanner) (T, int, error)) func(rows *sql.Rows, queryErr error) ([]T, int, error) {
 	return func(rows *sql.Rows, queryErr error) (values []T, totalCount int, err error) {
 		if queryErr != nil {

--- a/internal/database/basestore/rows.go
+++ b/internal/database/basestore/rows.go
@@ -30,8 +30,8 @@ func CloseRows(rows *sql.Rows, err error) error {
 	return combineErrors(err, rows.Close(), rows.Err())
 }
 
-// NewSliceScanner returns a basestore scanner function that returns the
-// all values of a query result. The given function is invoked multiple
+// NewSliceScanner returns a basestore scanner function that returns all
+// the values of a query result. The given function is invoked multiple
 // times with a SQL rows object to scan a single value.
 func NewSliceScanner[T any](f func(dbutil.Scanner) (T, error)) func(rows *sql.Rows, queryErr error) ([]T, error) {
 	return func(rows *sql.Rows, queryErr error) (values []T, err error) {
@@ -50,6 +50,31 @@ func NewSliceScanner[T any](f func(dbutil.Scanner) (T, error)) func(rows *sql.Ro
 		}
 
 		return values, nil
+	}
+}
+
+// NewSliceWithCountScanner returns a basestore scanner function that returns all
+// the values of the query result, as well as the count from the `COUNT(*) OVER()`
+// window function. The given function is invoked multiple times with a SQL rows
+// object to scan a single value.
+func NewSliceWithCountScanner[T any](f func(dbutil.Scanner) (T, int, error)) func(rows *sql.Rows, queryErr error) ([]T, int, error) {
+	return func(rows *sql.Rows, queryErr error) (values []T, totalCount int, err error) {
+		if queryErr != nil {
+			return nil, 0, queryErr
+		}
+		defer func() { err = CloseRows(rows, err) }()
+
+		for rows.Next() {
+			value, count, err := f(rows)
+			if err != nil {
+				return nil, 0, err
+			}
+
+			totalCount = count
+			values = append(values, value)
+		}
+
+		return values, totalCount, nil
 	}
 }
 


### PR DESCRIPTION
May or may not close #34915 by implementing the approach from the linked stackoverflow issue. Performance improvements weren't stable (sometimes faster, sometimes on-par), so I want to observe this in production for a while to see how the average case does, given we're only having to make one query here instead of two, the overhead saved may work in its favour.

## Test plan

Covered by existing tests and dashboards
