### PR TITLE
dev/ci: disable svg check for now

### DIFF
--- a/doc/dev/background-information/ci/reference.md
+++ b/doc/dev/background-information/ci/reference.md
@@ -59,7 +59,7 @@ The default run type.
   - Upload build trace
 
 - Pipeline for `SVG` changes:
-  - **Linters and static analysis**: Prettier, Run sg lint
+  - **Linters and static analysis**: Prettier
   - Upload build trace
 
 - Pipeline for `Shell` changes:

--- a/enterprise/dev/ci/internal/ci/changed/linters.go
+++ b/enterprise/dev/ci/internal/ci/changed/linters.go
@@ -8,7 +8,8 @@ var diffsWithLinters = []Diff{
 	Go,
 	Dockerfiles,
 	Docs,
-	SVG,
+	// Doesn't seem to work, TODO(@bobheadxi)
+	// SVG,
 	Client,
 	Shell,
 }


### PR DESCRIPTION
This check works for me locally but looks like it's failing in CI (https://buildkite.com/sourcegraph/sourcegraph/builds/147269#f327c668-63dc-4fab-ae35-3e1f743d32e5), I'll circle back to this ASAP

Related: https://github.com/sourcegraph/sourcegraph/pull/35331

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

n/a