### PR TITLE
release-tool: add tracking issue for sec-team review

### DIFF
--- a/dev/release/src/github.ts
+++ b/dev/release/src/github.ts
@@ -38,12 +38,14 @@ export enum IssueLabel {
     PATCH = 'patch',
     MANAGED = 'managed-instances',
     DEVOPS_TEAM = 'team/devops',
+    SECURITY_TEAM = 'team/security'
 }
 
 enum IssueTitleSuffix {
     RELEASE_TRACKING = 'release tracking issue',
     PATCH_TRACKING = 'patch release tracking issue',
     MANAGED_TRACKING = 'upgrade managed instances tracking issue',
+    SECURITY_TRACKING = 'container image vulnerability assessment tracking issue'
 }
 
 /**
@@ -118,7 +120,14 @@ const getTemplates = () => {
         titleSuffix: IssueTitleSuffix.MANAGED_TRACKING,
         labels: [IssueLabel.RELEASE_TRACKING, IssueLabel.MANAGED, IssueLabel.DEVOPS_TEAM],
     }
-    return { releaseIssue, patchReleaseIssue, upgradeManagedInstanceIssue }
+    const securityAssessmentIssue: IssueTemplate = {
+        owner: 'sourcegraph',
+        repo: 'handbook',
+        path: 'content/departments/product-engineering/engineering/process/releases/security_assessment.md',
+        titleSuffix: IssueTitleSuffix.SECURITY_TRACKING,
+        labels: [IssueLabel.RELEASE_TRACKING, IssueLabel.SECURITY_TEAM],
+    }
+    return { releaseIssue, patchReleaseIssue, upgradeManagedInstanceIssue, securityAssessmentIssue }
 }
 
 function dateMarkdown(date: Date, name: string): string {

--- a/dev/release/src/github.ts
+++ b/dev/release/src/github.ts
@@ -39,14 +39,14 @@ export enum IssueLabel {
     MANAGED = 'managed-instances',
     DEVOPS_TEAM = 'team/devops',
     SECURITY_TEAM = 'team/security',
-    RELEASE_BLOCKER = 'release-blocker'
+    RELEASE_BLOCKER = 'release-blocker',
 }
 
 enum IssueTitleSuffix {
     RELEASE_TRACKING = 'release tracking issue',
     PATCH_TRACKING = 'patch release tracking issue',
     MANAGED_TRACKING = 'upgrade managed instances tracking issue',
-    SECURITY_TRACKING = 'container image vulnerability assessment tracking issue'
+    SECURITY_TRACKING = 'container image vulnerability assessment tracking issue',
 }
 
 /**

--- a/dev/release/src/github.ts
+++ b/dev/release/src/github.ts
@@ -38,7 +38,8 @@ export enum IssueLabel {
     PATCH = 'patch',
     MANAGED = 'managed-instances',
     DEVOPS_TEAM = 'team/devops',
-    SECURITY_TEAM = 'team/security'
+    SECURITY_TEAM = 'team/security',
+    RELEASE_BLOCKER = 'release-blocker'
 }
 
 enum IssueTitleSuffix {
@@ -125,7 +126,7 @@ const getTemplates = () => {
         repo: 'handbook',
         path: 'content/departments/product-engineering/engineering/process/releases/security_assessment.md',
         titleSuffix: IssueTitleSuffix.SECURITY_TRACKING,
-        labels: [IssueLabel.RELEASE_TRACKING, IssueLabel.SECURITY_TEAM],
+        labels: [IssueLabel.RELEASE_TRACKING, IssueLabel.SECURITY_TEAM, IssueLabel.RELEASE_BLOCKER],
     }
     return { releaseIssue, patchReleaseIssue, upgradeManagedInstanceIssue, securityAssessmentIssue }
 }


### PR DESCRIPTION
This adds a tracking issue to each release as a reminder to the security team and release captain to review Trivy security scans before proceeding with the release.

## Test plan

- CI testing to make sure it doesn't break anything in critical path
- Manual testing by release captain

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
