### PR TITLE
Revert about.sourcegraph.com redirect changes from PR #23983

### DIFF
--- a/client/web/src/routes.tsx
+++ b/client/web/src/routes.tsx
@@ -74,7 +74,12 @@ function passThroughToServer(): React.ReactNode {
 export const routes: readonly LayoutRouteProps<any>[] = [
     {
         path: PageRoutes.Index,
-        render: () => <Redirect to={PageRoutes.Search} />,
+        render: props =>
+            window.context.sourcegraphDotComMode && !props.authenticatedUser ? (
+                <Redirect to="https://about.sourcegraph.com" />
+            ) : (
+                <Redirect to={PageRoutes.Search} />
+            ),
         exact: true,
     },
     {

--- a/cmd/frontend/internal/app/ui/handlers.go
+++ b/cmd/frontend/internal/app/ui/handlers.go
@@ -317,7 +317,7 @@ func serveHome(db database.DB) handlerFunc {
 			return nil
 		}
 
-		// Homepage redirects to /search.
+		// On non-Sourcegraph.com instances, there is no separate homepage, so redirect to /search.
 		r.URL.Path = "/search"
 		http.Redirect(w, r, r.URL.String(), http.StatusTemporaryRedirect)
 		return nil

--- a/cmd/frontend/internal/app/ui/handlers.go
+++ b/cmd/frontend/internal/app/ui/handlers.go
@@ -26,6 +26,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/app/jscontext"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/handlerutil"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/routevar"
+	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
@@ -306,6 +307,14 @@ func serveHome(db database.DB) handlerFunc {
 		}
 		if common == nil {
 			return nil // request was handled
+		}
+
+		if envvar.SourcegraphDotComMode() && !actor.FromContext(r.Context()).IsAuthenticated() && !strings.Contains(r.UserAgent(), "Cookiebot") {
+			// The user is not signed in and tried to access Sourcegraph.com.
+			// Redirect to about.sourcegraph.com so they see general info page.
+			// Don't redirect Cookiebot so it can scan the website without authentication.
+			http.Redirect(w, r, (&url.URL{Scheme: aboutRedirectScheme, Host: aboutRedirectHost}).String(), http.StatusTemporaryRedirect)
+			return nil
 		}
 
 		// Homepage redirects to /search.

--- a/cmd/frontend/internal/app/ui/handlers_test.go
+++ b/cmd/frontend/internal/app/ui/handlers_test.go
@@ -64,7 +64,7 @@ func TestRedirects(t *testing.T) {
 		envvar.MockSourcegraphDotComMode(true)
 		defer envvar.MockSourcegraphDotComMode(orig) // reset
 		t.Run("root", func(t *testing.T) {
-			check(t, "/", http.StatusTemporaryRedirect, "/search", "Mozilla/5.0")
+			check(t, "/", http.StatusTemporaryRedirect, "https://about.sourcegraph.com", "Mozilla/5.0")
 		})
 	})
 


### PR DESCRIPTION
This reverts changes made in #23983 and re-implements the redirect to [about.sourcegraph.com](https://about.sourcegraph.com) if users are logged in.

This closes sourcegraph/about#5284.

## Test plan
- The client redirects non-logged-in users to `about.sourcegraph.com`
- The client redirects logged-in users to `/search`
- The server redirects logged-in users to `about.sourcegraph.com`, otherwise do nothing
- The Go test passes