### PR TITLE
dev/sg: fix sg auto-update analytics

### DIFF
--- a/dev/sg/analytics.go
+++ b/dev/sg/analytics.go
@@ -57,7 +57,7 @@ func addAnalyticsHooks(start time.Time, commandPath []string, commands []*cli.Co
 	}
 }
 
-func makeAnalyticsHook(start time.Time, commandPath []string) func(*cli.Context, ...string) {
+func makeAnalyticsHook(start time.Time, commandPath []string) func(ctx *cli.Context, events ...string) {
 	return func(cmd *cli.Context, events ...string) {
 		// Log an sg usage occurrence
 		analytics.LogEvent(cmd.Context, "sg_action", commandPath, start, events...)

--- a/dev/sg/internal/analytics/events.go
+++ b/dev/sg/internal/analytics/events.go
@@ -43,7 +43,9 @@ func (s *eventStore) Persist(command string, flagsUsed []string) error {
 		// Context
 		ev.Properties["command"] = command
 		ev.Properties["sg_version"] = s.sgVersion
-		ev.Properties["flags_used"] = strings.Join(flagsUsed, ",")
+		if len(flagsUsed) > 0 {
+			ev.Properties["flags_used"] = strings.Join(flagsUsed, ",")
+		}
 	}
 
 	// Persist events to disk

--- a/dev/sg/sg_version.go
+++ b/dev/sg/sg_version.go
@@ -147,6 +147,8 @@ func checkSgVersionAndUpdate(ctx context.Context, skipUpdate bool) error {
 		std.Out.WriteLine(output.Styled(output.StyleSearchMatch, "│                                                                  │░░"))
 		std.Out.WriteLine(output.Styled(output.StyleSearchMatch, "╰──────────────────────────────────────────────────────────────────╯░░"))
 		std.Out.WriteLine(output.Styled(output.StyleSearchMatch, "  ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░"))
+
+		analytics.LogEvent(ctx, "auto_update", []string{"skipped"}, start)
 		return nil
 	}
 

--- a/dev/sg/sg_version.go
+++ b/dev/sg/sg_version.go
@@ -130,6 +130,9 @@ func checkSgVersionAndUpdate(ctx context.Context, skipUpdate bool) error {
 			// user to eventually do a fetch
 			return errors.New("current sg version not found - you may want to run 'git fetch origin main'.")
 		}
+
+		// Unexpected error occured
+		analytics.LogEvent(ctx, "auto_update", []string{"check_error"}, start)
 		return err
 	}
 

--- a/dev/sg/sg_version.go
+++ b/dev/sg/sg_version.go
@@ -161,6 +161,10 @@ func checkSgVersionAndUpdate(ctx context.Context, skipUpdate bool) error {
 
 	analytics.LogEvent(ctx, "auto_update", []string{"updated"}, start)
 
+	// syscall.Exec will cause the current command's finalizer to not run, so we make a
+	// custom call to persist to make sure the auto_update event is tracked.
+	analytics.Persist(ctx, "sg", nil)
+
 	// Run command with new binary
 	return syscall.Exec(newPath, os.Args, os.Environ())
 }


### PR DESCRIPTION
syscall.Exec will cause the current command's finalizer to not run, so we make a custom call to Persist to make sure the `auto_update` event is tracked in success scenarios.

Also logs unexpected error events (https://github.com/sourcegraph/sourcegraph/issues/32562) and skip events during auto-updates

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Persist works in other scenarios already!