### PR TITLE
batches: don't show DRAFT state pill if SSBC is not enabled

### DIFF
--- a/client/web/src/enterprise/batches/list/BatchChangeNode.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangeNode.tsx
@@ -37,6 +37,9 @@ export interface BatchChangeNodeProps {
 const StateBadge: React.FunctionComponent<React.PropsWithChildren<{ state: BatchChangeState }>> = ({ state }) => {
     switch (state) {
         case BatchChangeState.OPEN:
+        // DRAFT should only be possible if SSBC is enabled; if we do find a batch change
+        // in this state when it isn't, just treat it as OPEN
+        case BatchChangeState.DRAFT:
             return (
                 /*
                         a11y-ignore
@@ -54,13 +57,6 @@ const StateBadge: React.FunctionComponent<React.PropsWithChildren<{ state: Batch
             return (
                 <Badge variant="danger" className={classNames(styles.batchChangeNodeBadge, 'text-uppercase')}>
                     Closed
-                </Badge>
-            )
-        case BatchChangeState.DRAFT:
-        default:
-            return (
-                <Badge variant="secondary" className={classNames(styles.batchChangeNodeBadge, 'text-uppercase')}>
-                    Draft
                 </Badge>
             )
     }


### PR DESCRIPTION
We shouldn't have batch changes in a DRAFT state unless the experimental feature flag is on. If we do come across one, we should just treat it as OPEN.

## Test plan

This component has storybook coverage. Verified locally that badges appeared in the right state.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-kr-no-drafts.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-aovllclkzg.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
