### PR TITLE
fix: bext gitlab hover-overlay issue

### DIFF
--- a/client/browser/CHANGELOG.md
+++ b/client/browser/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to Sourcegraph [Browser Extensions](./README.md) are documen
 - Fix repo visibility check logic: [issues/29244](https://github.com/sourcegraph/sourcegraph/issues/29244), [pull/33352](https://github.com/sourcegraph/sourcegraph/pull/33352)
 - Add different browser extension icons for development mode builds: [issue/33587](https://github.com/sourcegraph/sourcegraph/issues/33587), [pull/34353](https://github.com/sourcegraph/sourcegraph/pull/34353)
 - Fix git-extras extension blame for selected lines issue on the code hosts: [issues/34700](https://github.com/sourcegraph/sourcegraph/issues/34700), [pull/34698](https://github.com/sourcegraph/sourcegraph/pull/34698)
+- Fix hover-overlay styling issue on GitLab: [issues/35315](https://github.com/sourcegraph/sourcegraph/issues/35315), [pull/35403](https://github.com/sourcegraph/sourcegraph/pull/35403)
 
 ## Chrome & Firefox 22.4.7.1712, Safari v1.13
 

--- a/client/browser/src/shared/code-hosts/shared/codeHost.module.scss
+++ b/client/browser/src/shared/code-hosts/shared/codeHost.module.scss
@@ -1,4 +1,4 @@
 .hover-overlay {
     isolation: isolate;
-    z-index: 2000;
+    z-index: 2000 !important;
 }


### PR DESCRIPTION
## Summary

Close https://github.com/sourcegraph/sourcegraph/issues/35315

User has reported that the hover overlay is hidden by other elements when checking out diff on GitLab. 
It looks like it is because a smaller z-index (100) from the[ general hover module ](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/client/shared/src/hover/HoverOverlay.module.scss?L16%3A1-16%3A18=)overtook the one that is supposed to work in the code host (2000)
Setting the z-index for the code host overlay module as `!important` has resolved the issue.

## Before
Using z-index of `100` instead of `2000`
![Screen Shot 2022-05-12 at 3 44 02 PM](https://user-images.githubusercontent.com/68532117/168179569-4550714c-3c44-4808-8a82-59c51d7c5a79.png)


## After
Using z-index of `2000` instead of `100`
![Screen Shot 2022-05-12 at 3 41 14 PM](https://user-images.githubusercontent.com/68532117/168179553-b185c6cf-a6cb-4c3f-9d42-cc65d1286edf.png)

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
Manually tested

## App preview:

- [Web](https://sg-web-bee-fix-gitlab.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-cjlumjeimm.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
