### PR TITLE
Fix Navbar on desktop+ screen when having many nav items

### DIFF
--- a/client/web/src/batches/BatchChangesNavItem.tsx
+++ b/client/web/src/batches/BatchChangesNavItem.tsx
@@ -1,18 +1,21 @@
 import React from 'react'
 
 import { NavItem, NavLink } from '../nav'
+import { NavLinkProps } from '../nav/NavBar'
 
 import { BatchChangesIconNav } from './icons'
 
-interface Props {
+interface Props extends Pick<NavLinkProps, 'variant'> {
     // Nothing for now.
 }
 
 /**
  * An item in {@link GlobalNavbar} that links to the batch changes area.
  */
-export const BatchChangesNavItem: React.FunctionComponent<React.PropsWithChildren<Props>> = () => (
+export const BatchChangesNavItem: React.FunctionComponent<React.PropsWithChildren<Props>> = ({ variant }) => (
     <NavItem icon={BatchChangesIconNav}>
-        <NavLink to="/batch-changes">Batch Changes</NavLink>
+        <NavLink to="/batch-changes" variant={variant}>
+            Batch Changes
+        </NavLink>
     </NavItem>
 )

--- a/client/web/src/nav/GlobalNavbar.tsx
+++ b/client/web/src/nav/GlobalNavbar.tsx
@@ -108,6 +108,7 @@ export const GlobalNavbar: React.FunctionComponent<React.PropsWithChildren<Props
     isRepositoryRelatedPage,
     codeInsightsEnabled,
     searchContextsEnabled,
+    activation,
     ...props
 }) => {
     // Workaround: can't put this in optional parameter value because of https://github.com/babel/babel/issues/11166
@@ -204,6 +205,10 @@ export const GlobalNavbar: React.FunctionComponent<React.PropsWithChildren<Props
         return items.filter<NavDropdownItem>((item): item is NavDropdownItem => !!item)
     }, [searchContextsEnabled, showSearchContext])
 
+    activation = undefined
+    const shouldShowBatchChanges = true // props.batchChangesEnabled || isSourcegraphDotCom
+    const navLinkVariant = shouldShowBatchChanges && activation ? 'compact' : undefined
+
     return (
         <>
             <NavBar
@@ -223,6 +228,7 @@ export const GlobalNavbar: React.FunctionComponent<React.PropsWithChildren<Props
                             altPath: PageRoutes.RepoContainer,
                             icon: MagnifyIcon,
                             content: 'Code Search',
+                            variant: navLinkVariant,
                         }}
                         routeMatch={routeMatch}
                         mobileHomeItem={{ content: 'Search home' }}
@@ -230,29 +236,37 @@ export const GlobalNavbar: React.FunctionComponent<React.PropsWithChildren<Props
                     />
                     {showSearchNotebook && (
                         <NavItem icon={BookOutlineIcon}>
-                            <NavLink to={PageRoutes.Notebooks}>Notebooks</NavLink>
+                            <NavLink variant={navLinkVariant} to={PageRoutes.Notebooks}>
+                                Notebooks
+                            </NavLink>
                         </NavItem>
                     )}
                     {enableCodeMonitoring && (
                         <NavItem icon={CodeMonitoringLogo}>
-                            <NavLink to="/code-monitoring">Monitoring</NavLink>
+                            <NavLink variant={navLinkVariant} to="/code-monitoring">
+                                Monitoring
+                            </NavLink>
                         </NavItem>
                     )}
                     {/* This is the only circumstance where we show something
                          batch-changes-related even if the instance does not have batch
                          changes enabled, for marketing purposes on sourcegraph.com */}
-                    {(props.batchChangesEnabled || isSourcegraphDotCom) && <BatchChangesNavItem />}
+                    {shouldShowBatchChanges && <BatchChangesNavItem variant={navLinkVariant} />}
                     {codeInsights && (
                         <NavItem icon={BarChartIcon}>
-                            <NavLink to="/insights">Insights</NavLink>
+                            <NavLink variant={navLinkVariant} to="/insights">
+                                Insights
+                            </NavLink>
                         </NavItem>
                     )}
                     <NavItem icon={PuzzleOutlineIcon}>
-                        <NavLink to="/extensions">Extensions</NavLink>
+                        <NavLink variant={navLinkVariant} to="/extensions">
+                            Extensions
+                        </NavLink>
                     </NavItem>
-                    {props.activation && (
+                    {activation && (
                         <NavItem>
-                            <ActivationDropdown activation={props.activation} history={history} />
+                            <ActivationDropdown activation={activation} history={history} />
                         </NavItem>
                     )}
                 </NavGroup>

--- a/client/web/src/nav/NavBar/NavBar.module.scss
+++ b/client/web/src/nav/NavBar/NavBar.module.scss
@@ -10,6 +10,7 @@
     background: var(--color-bg-1);
     padding: 0 1rem;
     align-items: center;
+    white-space: nowrap;
 }
 
 .menu {

--- a/client/web/src/nav/NavBar/NavBar.tsx
+++ b/client/web/src/nav/NavBar/NavBar.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react'
+import React, { useEffect, useRef, useState, forwardRef } from 'react'
 
 import classNames from 'classnames'
 import H from 'history'
@@ -7,7 +7,7 @@ import ChevronUpIcon from 'mdi-react/ChevronUpIcon'
 import MenuIcon from 'mdi-react/MenuIcon'
 import { LinkProps, NavLink as RouterLink } from 'react-router-dom'
 
-import { Button, Link, Icon, Typography } from '@sourcegraph/wildcard'
+import { Button, Link, Icon, Typography, ForwardReferenceComponent } from '@sourcegraph/wildcard'
 
 import { PageRoutes } from '../../routes.constants'
 
@@ -60,17 +60,19 @@ const useOutsideClickDetector = (
     return [outsideClick, setOutsideClick]
 }
 
-export const NavBar = ({ children, logo }: NavBarProps): JSX.Element => (
-    <nav aria-label="Main Menu" className={navBarStyles.navbar}>
-        <Typography.H1 className={navBarStyles.logo}>
-            <RouterLink className="d-flex align-items-center" to={PageRoutes.Search}>
-                {logo}
-            </RouterLink>
-        </Typography.H1>
-        <hr className={navBarStyles.divider} aria-hidden={true} />
-        {children}
-    </nav>
-)
+export const NavBar = forwardRef(
+    ({ children, logo }, reference): JSX.Element => (
+        <nav aria-label="Main Menu" className={navBarStyles.navbar} ref={reference}>
+            <Typography.H1 className={navBarStyles.logo}>
+                <RouterLink className="d-flex align-items-center" to={PageRoutes.Search}>
+                    {logo}
+                </RouterLink>
+            </Typography.H1>
+            <hr className={navBarStyles.divider} aria-hidden={true} />
+            {children}
+        </nav>
+    )
+) as ForwardReferenceComponent<'div', NavBarProps>
 
 export const NavGroup = ({ children }: NavGroupProps): JSX.Element => {
     const menuReference = useRef<HTMLDivElement>(null)

--- a/client/web/src/nav/NavBar/NavBar.tsx
+++ b/client/web/src/nav/NavBar/NavBar.tsx
@@ -34,9 +34,10 @@ interface NavActionsProps {
     children: React.ReactNode
 }
 
-interface NavLinkProps extends NavItemProps, Pick<LinkProps<H.LocationState>, 'to'> {
+export interface NavLinkProps extends NavItemProps, Pick<LinkProps<H.LocationState>, 'to'> {
     external?: boolean
     className?: string
+    variant?: 'compact'
 }
 
 const useOutsideClickDetector = (
@@ -123,6 +124,7 @@ export const NavLink: React.FunctionComponent<React.PropsWithChildren<NavLinkPro
     children,
     to,
     external,
+    variant,
     className,
 }) => {
     const content = (
@@ -131,6 +133,7 @@ export const NavLink: React.FunctionComponent<React.PropsWithChildren<NavLinkPro
             <span
                 className={classNames(navItemStyles.text, {
                     [navItemStyles.iconIncluded]: Icon,
+                    [navItemStyles.isCompact]: variant === 'compact',
                 })}
             >
                 {children}

--- a/client/web/src/nav/NavBar/NavDropdown.tsx
+++ b/client/web/src/nav/NavBar/NavDropdown.tsx
@@ -7,7 +7,7 @@ import { useLocation } from 'react-router'
 
 import { Link, Menu, MenuButton, MenuLink, MenuList, EMPTY_RECTANGLE, Icon } from '@sourcegraph/wildcard'
 
-import { NavItem, NavLink } from '.'
+import { NavItem, NavLink, NavLinkProps } from '.'
 
 import styles from './NavDropdown.module.scss'
 import navItemStyles from './NavItem.module.scss'
@@ -22,7 +22,7 @@ interface NavDropdownProps {
         icon: React.ComponentType<{ className?: string }>
         // Alternative path to match against if item is active
         altPath?: string
-    }
+    } & Pick<NavLinkProps, 'variant'>
     // An extra item on mobile devices in the dropdown menu that serves as the "home" item instead of the toggle item.
     // It uses the path from the toggleItem.
     mobileHomeItem: Omit<NavDropdownItem, 'path'>
@@ -143,7 +143,9 @@ export const NavDropdown: React.FunctionComponent<React.PropsWithChildren<NavDro
                                                 aria-hidden={true}
                                             />
                                             <span
-                                                className={classNames(navItemStyles.text, navItemStyles.iconIncluded)}
+                                                className={classNames(navItemStyles.text, navItemStyles.iconIncluded, {
+                                                    [navItemStyles.isCompact]: toggleItem.variant === 'compact',
+                                                })}
                                             >
                                                 {toggleItem.content}
                                             </span>

--- a/client/web/src/nav/NavBar/NavItem.module.scss
+++ b/client/web/src/nav/NavBar/NavItem.module.scss
@@ -129,6 +129,11 @@
     }
 }
 
+.is-compact {
+    @media (--lg-breakpoint-down) {
+        display: none;
+    }
+}
 .text {
     color: var(--body-color);
 }

--- a/client/web/src/nav/NavBar/NavItem.module.scss
+++ b/client/web/src/nav/NavBar/NavItem.module.scss
@@ -121,6 +121,11 @@
 .icon-included {
     margin-left: 0.25rem;
     display: inline-flex;
+    &.is-compact {
+        @media (--md-breakpoint-up) {
+            display: none;
+        }
+    }
     @media (--md-breakpoint-down) {
         display: none;
     }
@@ -129,11 +134,6 @@
     }
 }
 
-.is-compact {
-    @media (--lg-breakpoint-down) {
-        display: none;
-    }
-}
 .text {
     color: var(--body-color);
 }

--- a/client/wildcard/src/hooks/index.ts
+++ b/client/wildcard/src/hooks/index.ts
@@ -19,3 +19,4 @@ export { useTimeoutManager } from './useTimeoutManager'
 export { WildcardThemeContext, useWildcardTheme } from './useWildcardTheme'
 // Export type is required to avoid Webpack warnings.
 export type { WildcardTheme } from './useWildcardTheme'
+export { useWindowSize } from './useWindowSize'

--- a/client/wildcard/src/hooks/useWindowSize.ts
+++ b/client/wildcard/src/hooks/useWindowSize.ts
@@ -1,0 +1,19 @@
+import { useState, useEffect } from 'react'
+
+/**
+ * Returns width and height of current window width.
+ * Updates accordingly when window resizes.
+ */
+export function useWindowSize(): { width: number; height: number } {
+    const [size, setSize] = useState({ height: window.innerHeight, width: window.innerWidth })
+
+    useEffect(() => {
+        function onResize(): void {
+            setSize({ height: window.innerHeight, width: window.innerWidth })
+        }
+        window.addEventListener('resize', onResize)
+        return () => window.removeEventListener('resize', onResize)
+    }, [])
+
+    return size
+}


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/35408

## Description
This PR:
- Changes Navbar to fallback on `lg-breakpoint-down` screens to compact view if both "Getting started" and "Batch Changes" is shown
- Otherwise, it will still show the full-wide version until `md-breakpoint-down`

## Test plan
- Run locally and check with different modes (features enabled)

## Screenshots
| BEFORE | AFTER |
| --: | :-- |
| ![image](https://user-images.githubusercontent.com/6717049/168251963-eb235d9e-5a99-492a-ad33-e98e2b4cd355.png) |  ![image](https://user-images.githubusercontent.com/6717049/168251885-9f4013b2-0ae5-471f-a323-11c6bb8c2678.png) |


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-erzhtor-fix-navbar-on-desktop-and.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-hdtcdvridh.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
