### PR TITLE
Accessibility: Fix `<Alert />` `role` usage

### DIFF
--- a/client/shared/src/hover/__snapshots__/HoverOverlay.test.tsx.snap
+++ b/client/shared/src/hover/__snapshots__/HoverOverlay.test.tsx.snap
@@ -34,7 +34,6 @@ exports[`HoverOverlay actions and hover error 1`] = `
     >
       <div
         class="hoverError"
-        role="alert"
       >
         M2
       </div>
@@ -265,7 +264,6 @@ exports[`HoverOverlay actions, hover and alert present 1`] = `
     >
       <div
         class="alert"
-        role="alert"
       >
         <span
           class="hoverOverlayContent hoverOverlayContent"
@@ -331,7 +329,6 @@ exports[`HoverOverlay hover error 1`] = `
     >
       <div
         class="hoverError"
-        role="alert"
       >
         M
       </div>
@@ -353,7 +350,6 @@ exports[`HoverOverlay hover error, actions present 1`] = `
     >
       <div
         class="hoverError"
-        role="alert"
       >
         M
       </div>

--- a/client/web/src/global/__snapshots__/Notices.test.tsx.snap
+++ b/client/web/src/global/__snapshots__/Notices.test.tsx.snap
@@ -10,7 +10,6 @@ exports[`Notices shows notices for location 1`] = `
     <div
       class="alert bg transparent border p-2"
       data-testid="notice-alert"
-      role="alert"
     >
       <div
         class="markdown"
@@ -24,7 +23,6 @@ exports[`Notices shows notices for location 1`] = `
     </div>
     <div
       class="alert container bg transparent border p-2"
-      role="alert"
     >
       <div
         class="content"

--- a/client/wildcard/src/components/Alert/Alert.test.tsx
+++ b/client/wildcard/src/components/Alert/Alert.test.tsx
@@ -11,7 +11,6 @@ describe('Alert', () => {
         expect(container.firstChild).toMatchInlineSnapshot(`
             <div
               class=""
-              role="alert"
             >
               Simple Alert
             </div>

--- a/client/wildcard/src/components/Alert/Alert.tsx
+++ b/client/wildcard/src/components/Alert/Alert.tsx
@@ -10,17 +10,27 @@ import { getAlertStyle } from './utils'
 
 import styles from './Alert.module.scss'
 
+type AlertVariant = typeof ALERT_VARIANTS[number]
+
 export interface AlertProps extends React.HTMLAttributes<HTMLDivElement> {
-    variant?: typeof ALERT_VARIANTS[number]
+    variant?: AlertVariant
 }
 
+const userShouldBeNotified = (variant?: AlertVariant): boolean => variant === 'danger' || variant === 'warning'
+
 export const Alert = React.forwardRef(
-    ({ children, as: Component = 'div', variant, className, ...attributes }, reference) => {
+    ({ children, as: Component = 'div', variant, className, role, ...attributes }, reference) => {
         const { isBranded } = useWildcardTheme()
         const brandedClassName = isBranded && classNames(styles.alert, variant && getAlertStyle({ variant }))
+        const alertRole = role || userShouldBeNotified(variant) ? 'alert' : undefined
 
         return (
-            <Component ref={reference} className={classNames(brandedClassName, className)} role="alert" {...attributes}>
+            <Component
+                ref={reference}
+                className={classNames(brandedClassName, className)}
+                role={alertRole}
+                {...attributes}
+            >
                 {children}
             </Component>
         )

--- a/client/wildcard/src/components/Alert/__snapshots__/Alert.test.tsx.snap
+++ b/client/wildcard/src/components/Alert/__snapshots__/Alert.test.tsx.snap
@@ -17,7 +17,6 @@ exports[`Alert renders variant 'danger' correctly 1`] = `
 exports[`Alert renders variant 'info' correctly 1`] = `
 <div
   class=""
-  role="alert"
 >
   <h4
     class="h4"
@@ -31,7 +30,6 @@ exports[`Alert renders variant 'info' correctly 1`] = `
 exports[`Alert renders variant 'merged' correctly 1`] = `
 <div
   class=""
-  role="alert"
 >
   <h4
     class="h4"
@@ -45,7 +43,6 @@ exports[`Alert renders variant 'merged' correctly 1`] = `
 exports[`Alert renders variant 'note' correctly 1`] = `
 <div
   class=""
-  role="alert"
 >
   <h4
     class="h4"
@@ -59,7 +56,6 @@ exports[`Alert renders variant 'note' correctly 1`] = `
 exports[`Alert renders variant 'primary' correctly 1`] = `
 <div
   class=""
-  role="alert"
 >
   <h4
     class="h4"
@@ -73,7 +69,6 @@ exports[`Alert renders variant 'primary' correctly 1`] = `
 exports[`Alert renders variant 'secondary' correctly 1`] = `
 <div
   class=""
-  role="alert"
 >
   <h4
     class="h4"
@@ -87,7 +82,6 @@ exports[`Alert renders variant 'secondary' correctly 1`] = `
 exports[`Alert renders variant 'success' correctly 1`] = `
 <div
   class=""
-  role="alert"
 >
   <h4
     class="h4"
@@ -101,7 +95,6 @@ exports[`Alert renders variant 'success' correctly 1`] = `
 exports[`Alert renders variant 'waiting' correctly 1`] = `
 <div
   class=""
-  role="alert"
 >
   <h4
     class="h4"


### PR DESCRIPTION
closes https://github.com/sourcegraph/sourcegraph/issues/35259

## Description

Our `Alert` components have the role set to "alert" by default. This can cause some issues with certain alerts, for example: 
<img width="756" alt="image" src="https://user-images.githubusercontent.com/9516420/168256112-d5b2509b-a995-43da-8536-8669be40c5da.png">

This isn't urgent for the user to be notified. In these cases we should _not_ set the alert role.

MDN guidance on `role="alert`: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/alert_role
> Warning: Because of its intrusive nature, the alert role must be used sparingly and only in situations where the user's immediate attention is required.

I think only setting in when the variant is `danger | warning` is a good middle ground. We might still have some areas where we need to override it, but for most cases this should be the desired behavior.

## Test plan

Tested locally with a screen reader

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-tr-global-alert-role.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-cubgpwkxbn.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

