### PR TITLE
Accessibility: Announce on `<PageTitle />` changes

### DIFF
--- a/client/web/src/components/PageTitle.tsx
+++ b/client/web/src/components/PageTitle.tsx
@@ -29,9 +29,7 @@ export const PageTitle: React.FunctionComponent<PageTitleProps> = ({ title }) =>
             titleSet = false
             document.title = getBrandName()
         }
-        // Only run once, on mount
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [])
+    }, [title])
 
     return null
 }

--- a/client/web/src/components/PageTitle.tsx
+++ b/client/web/src/components/PageTitle.tsx
@@ -1,42 +1,35 @@
-import * as React from 'react'
+import React, { useEffect, useCallback } from 'react'
 
-interface Props {
+import { screenReaderAnnounce } from '@sourcegraph/wildcard'
+
+interface PageTitleProps {
     title?: string
 }
 
-export class PageTitle extends React.Component<Props, {}> {
-    public static titleSet = false
+let titleSet = false
 
-    public componentDidMount(): void {
-        if (PageTitle.titleSet) {
-            console.error('more than one PageTitle used at the same time')
-        }
-        PageTitle.titleSet = true
-        this.updateTitle(this.props.title)
-    }
-
-    public componentDidUpdate(): void {
-        this.updateTitle(this.props.title)
-    }
-
-    public componentWillUnmount(): void {
-        PageTitle.titleSet = false
-        document.title = this.brandName()
-    }
-
-    public render(): JSX.Element | null {
-        return null
-    }
-
-    private brandName(): string {
+export const PageTitle: React.FunctionComponent<PageTitleProps> = ({ title }) => {
+    const getBrandName = useCallback(() => {
         if (!window.context) {
             return 'Sourcegraph'
         }
         const { branding } = window.context
         return branding ? branding.brandName : 'Sourcegraph'
-    }
+    }, [])
 
-    private updateTitle(title?: string): void {
-        document.title = title ? `${title} - ${this.brandName()}` : this.brandName()
-    }
+    useEffect(() => {
+        if (titleSet) {
+            console.error('more than one PageTitle used at the same time')
+        }
+        titleSet = true
+        document.title = title ? `${title} - ${getBrandName()}` : getBrandName()
+        screenReaderAnnounce(document.title)
+
+        return () => {
+            titleSet = false
+            document.title = getBrandName()
+        }
+    }, [getBrandName, title])
+
+    return null
 }

--- a/client/web/src/components/PageTitle.tsx
+++ b/client/web/src/components/PageTitle.tsx
@@ -27,6 +27,9 @@ export const PageTitle: React.FunctionComponent<PageTitleProps> = ({ title }) =>
 
         return () => {
             titleSet = false
+
+            // This is a fallback, in case the next page does *not* set the title.
+            // Ideally, we should always overwrite this, so we don't announce it to screen readers to reduce noise.
             document.title = getBrandName()
         }
     }, [title])

--- a/client/web/src/components/PageTitle.tsx
+++ b/client/web/src/components/PageTitle.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useCallback } from 'react'
+import React, { useEffect } from 'react'
 
 import { screenReaderAnnounce } from '@sourcegraph/wildcard'
 
@@ -6,17 +6,17 @@ interface PageTitleProps {
     title?: string
 }
 
+const getBrandName = (): string => {
+    if (!window.context) {
+        return 'Sourcegraph'
+    }
+    const { branding } = window.context
+    return branding ? branding.brandName : 'Sourcegraph'
+}
+
 let titleSet = false
 
 export const PageTitle: React.FunctionComponent<PageTitleProps> = ({ title }) => {
-    const getBrandName = useCallback(() => {
-        if (!window.context) {
-            return 'Sourcegraph'
-        }
-        const { branding } = window.context
-        return branding ? branding.brandName : 'Sourcegraph'
-    }, [])
-
     useEffect(() => {
         if (titleSet) {
             console.error('more than one PageTitle used at the same time')
@@ -29,7 +29,9 @@ export const PageTitle: React.FunctionComponent<PageTitleProps> = ({ title }) =>
             titleSet = false
             document.title = getBrandName()
         }
-    }, [getBrandName, title])
+        // Only run once, on mount
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [])
 
     return null
 }

--- a/client/web/src/extensions/extension/RegistryExtensionOverviewPage.test.tsx
+++ b/client/web/src/extensions/extension/RegistryExtensionOverviewPage.test.tsx
@@ -3,16 +3,11 @@ import { createMemoryHistory } from 'history'
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { renderWithBrandedContext } from '@sourcegraph/shared/src/testing'
 
-import { PageTitle } from '../../components/PageTitle'
-
 import { RegistryExtensionOverviewPage } from './RegistryExtensionOverviewPage'
 
 jest.mock('mdi-react/GithubIcon', () => 'GithubIcon')
 
 describe('RegistryExtensionOverviewPage', () => {
-    afterEach(() => {
-        PageTitle.titleSet = false
-    })
     test('renders', () => {
         const history = createMemoryHistory()
         expect(

--- a/client/web/src/site-admin/overview/SiteAdminOverviewPage.test.tsx
+++ b/client/web/src/site-admin/overview/SiteAdminOverviewPage.test.tsx
@@ -6,15 +6,9 @@ import sinon from 'sinon'
 import { ISiteUsagePeriod } from '@sourcegraph/shared/src/schema'
 import { renderWithBrandedContext } from '@sourcegraph/shared/src/testing'
 
-import { PageTitle } from '../../components/PageTitle'
-
 import { SiteAdminOverviewPage } from './SiteAdminOverviewPage'
 
 describe('SiteAdminOverviewPage', () => {
-    afterEach(() => {
-        PageTitle.titleSet = false
-    })
-
     const baseProps = {
         history: H.createMemoryHistory(),
         isLightTheme: true,


### PR DESCRIPTION
## Description

Screen readers do not update when `document.title` changes. This makes it very difficult for users to be aware that the content of the page has changed, particularly when navigating through a sidebar or a navbar. It seems the best approaches here are:
1. Move focus to next relevant part of page (if suitable)
2. Announce document.title changes to the screen reader through `aria-live`.

This PR focuses on the latter, it's also a [recommended approach by deque (creators of axe)](https://www.deque.com/blog/accessibility-tips-in-single-page-applications/).

![ScreenReaderTitle](https://user-images.githubusercontent.com/9516420/168293972-ceb527db-b974-46f4-8a43-f78c6cc59d18.gif)

Related issues (need checking):
- https://github.com/sourcegraph/sourcegraph/issues/34452
- https://github.com/sourcegraph/sourcegraph/issues/34481
- https://github.com/sourcegraph/sourcegraph/issues/35181
- https://github.com/sourcegraph/sourcegraph/issues/35143
- https://github.com/sourcegraph/sourcegraph/issues/35094

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-tr-page-title-sr.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-heubjttrjg.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

