### PR TITLE
[SG-35282]: Wildcard V2: Apply <Input /> Codemod on `client/web/enterprise`

### DIFF
--- a/client/web/src/enterprise/batches/detail/changesets/ChangesetFilterRow.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/ChangesetFilterRow.tsx
@@ -3,6 +3,7 @@ import React, { useState, useEffect, useRef, useCallback } from 'react'
 import * as H from 'history'
 
 import { Form } from '@sourcegraph/branded/src/components/Form'
+import { Input } from '@sourcegraph/wildcard'
 
 import { ChangesetReviewState, ChangesetCheckState, ChangesetState } from '../../../../graphql-operations'
 import { ChangesetFilter } from '../../ChangesetFilter'
@@ -90,8 +91,9 @@ export const ChangesetFilterRow: React.FunctionComponent<React.PropsWithChildren
             <div className="row no-gutters">
                 <div className="m-0 col">
                     <Form className="form-inline d-flex mb-2" onSubmit={onSubmit}>
-                        <input
-                            className="form-control flex-grow-1"
+                        <Input
+                            className="flex-grow-1"
+                            inputClassName="flex-grow-1"
                             type="search"
                             ref={searchElement}
                             defaultValue={search}

--- a/client/web/src/enterprise/batches/preview/list/PreviewFilterRow.tsx
+++ b/client/web/src/enterprise/batches/preview/list/PreviewFilterRow.tsx
@@ -3,6 +3,7 @@ import React, { useCallback, useContext, useEffect, useRef } from 'react'
 import * as H from 'history'
 
 import { Form } from '@sourcegraph/branded/src/components/Form'
+import { Input } from '@sourcegraph/wildcard'
 
 import { ChangesetSpecOperation, ChangesetState } from '../../../../graphql-operations'
 import { ChangesetFilter } from '../../ChangesetFilter'
@@ -85,8 +86,9 @@ export const PreviewFilterRow: React.FunctionComponent<React.PropsWithChildren<P
         <div className="row no-gutters">
             <div className="m-0 col">
                 <Form className="form-inline d-flex mb-2" onSubmit={onSubmit}>
-                    <input
-                        className="form-control flex-grow-1"
+                    <Input
+                        className="flex-grow-1"
+                        inputClassName="flex-grow-1"
                         type="search"
                         ref={searchElement}
                         defaultValue={filters.search ?? undefined}

--- a/client/web/src/enterprise/batches/settings/AddCredentialModal.tsx
+++ b/client/web/src/enterprise/batches/settings/AddCredentialModal.tsx
@@ -4,7 +4,7 @@ import classNames from 'classnames'
 
 import { ErrorAlert } from '@sourcegraph/branded/src/components/alerts'
 import { Form } from '@sourcegraph/branded/src/components/Form'
-import { Button, Modal, Link, Typography, Text } from '@sourcegraph/wildcard'
+import { Button, Modal, Link, Typography, Text, Input } from '@sourcegraph/wildcard'
 
 import { LoaderButton } from '../../../components/LoaderButton'
 import { ExternalServiceKind, Scalars } from '../../../graphql-operations'
@@ -183,12 +183,11 @@ export const AddCredentialModal: React.FunctionComponent<React.PropsWithChildren
                                 {requiresUsername && (
                                     <>
                                         <Typography.Label htmlFor="username">Username</Typography.Label>
-                                        <input
+                                        <Input
                                             id="username"
                                             name="username"
-                                            type="text"
                                             autoComplete="off"
-                                            className="form-control mb-2"
+                                            className="mb-2"
                                             required={true}
                                             spellCheck="false"
                                             minLength={1}
@@ -198,12 +197,12 @@ export const AddCredentialModal: React.FunctionComponent<React.PropsWithChildren
                                     </>
                                 )}
                                 <Typography.Label htmlFor="token">{patLabel}</Typography.Label>
-                                <input
+                                <Input
                                     id="token"
                                     name="token"
                                     type="password"
                                     autoComplete="off"
-                                    className="form-control test-add-credential-modal-input"
+                                    data-testid="test-add-credential-modal-input"
                                     required={true}
                                     spellCheck="false"
                                     minLength={1}

--- a/client/web/src/enterprise/batches/settings/ViewCredentialModal.tsx
+++ b/client/web/src/enterprise/batches/settings/ViewCredentialModal.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { Button, Modal, Typography } from '@sourcegraph/wildcard'
+import { Button, Modal, Typography, Input } from '@sourcegraph/wildcard'
 
 import { BatchChangesCodeHostFields, BatchChangesCredentialFields } from '../../../graphql-operations'
 
@@ -29,14 +29,7 @@ export const ViewCredentialModal: React.FunctionComponent<React.PropsWithChildre
             />
 
             <Typography.H4>Personal access token</Typography.H4>
-            <div className="form-group">
-                <input
-                    type="text"
-                    value="PATs cannot be viewed after entering."
-                    className="form-control"
-                    disabled={true}
-                />
-            </div>
+            <Input className="form-group" value="PATs cannot be viewed after entering." disabled={true} />
 
             <hr className="mb-3" />
 

--- a/client/web/src/enterprise/code-monitoring/components/CodeMonitorForm.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/CodeMonitorForm.tsx
@@ -10,7 +10,7 @@ import { Form } from '@sourcegraph/branded/src/components/Form'
 import { Toggle } from '@sourcegraph/branded/src/components/Toggle'
 import { asError, isErrorLike } from '@sourcegraph/common'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
-import { Container, Button, useEventObservable, Alert, Link, Select, Typography } from '@sourcegraph/wildcard'
+import { Container, Button, useEventObservable, Alert, Link, Select, Input } from '@sourcegraph/wildcard'
 
 import { AuthenticatedUser } from '../../../auth'
 import { CodeMonitorFields } from '../../../graphql-operations'
@@ -158,16 +158,15 @@ export const CodeMonitorForm: React.FunctionComponent<React.PropsWithChildren<Co
             <Form className="my-4 pb-5" data-testid="monitor-form" onSubmit={requestOnSubmit}>
                 <Container className="mb-3">
                     <div className="form-group">
-                        <Typography.Label htmlFor="code-monitor-form-name">Name</Typography.Label>
-                        <input
+                        <Input
                             id="code-monitor-form-name"
-                            type="text"
-                            className="form-control mb-2 test-name-input"
+                            className="mb-2"
                             data-testid="name-input"
                             required={true}
                             onChange={event => {
                                 onNameChange(event.target.value)
                             }}
+                            label="Name"
                             value={currentCodeMonitorState.description}
                             autoFocus={true}
                             spellCheck={false}

--- a/client/web/src/enterprise/code-monitoring/components/__snapshots__/FormActionArea.test.tsx.snap
+++ b/client/web/src/enterprise/code-monitoring/components/__snapshots__/FormActionArea.test.tsx.snap
@@ -30,19 +30,26 @@ exports[`FormActionArea Error is shown if code monitor has empty description 1`]
       data-testid="action-form-email"
     >
       <label
-        class="label"
-        for="code-monitoring-form-actions-recipients"
+        class="label w-100 mb-2"
       >
-        Recipients
+        <div
+          class="mb-2"
+        >
+          Recipients
+        </div>
+        <div
+          class="container d-flex"
+        >
+          <input
+            class="form-control with-invalid-icon"
+            disabled=""
+            id="code-monitoring-form-actions-recipients"
+            required=""
+            type="text"
+            value="user@me.com (you)"
+          />
+        </div>
       </label>
-      <input
-        class="form-control mb-2"
-        disabled=""
-        id="code-monitoring-form-actions-recipients"
-        required=""
-        type="text"
-        value="user@me.com (you)"
-      />
       <small
         class="text-muted"
       >

--- a/client/web/src/enterprise/code-monitoring/components/actions/EmailAction.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/actions/EmailAction.tsx
@@ -3,7 +3,7 @@ import React, { useState, useCallback } from 'react'
 import { gql, useMutation } from '@apollo/client'
 import { noop } from 'lodash'
 
-import { Typography } from '@sourcegraph/wildcard'
+import { Input } from '@sourcegraph/wildcard'
 
 import { MonitorEmailPriority, SendTestEmailResult, SendTestEmailVariables } from '../../../../graphql-operations'
 import { ActionProps } from '../FormActionArea'
@@ -118,11 +118,10 @@ export const EmailAction: React.FunctionComponent<React.PropsWithChildren<Action
             _testStartOpen={_testStartOpen}
         >
             <div className="form-group mt-4 test-action-form-email" data-testid="action-form-email">
-                <Typography.Label htmlFor="code-monitoring-form-actions-recipients">Recipients</Typography.Label>
-                <input
+                <Input
                     id="code-monitoring-form-actions-recipients"
-                    type="text"
-                    className="form-control mb-2"
+                    className="mb-2"
+                    label="Recipients"
                     value={`${authenticatedUser.email || ''} (you)`}
                     disabled={true}
                     autoFocus={true}

--- a/client/web/src/enterprise/codeintel/configuration/components/BranchTargetSettings.tsx
+++ b/client/web/src/enterprise/codeintel/configuration/components/BranchTargetSettings.tsx
@@ -1,7 +1,7 @@
 import { FunctionComponent } from 'react'
 
 import { GitObjectType } from '@sourcegraph/shared/src/graphql-operations'
-import { Typography } from '@sourcegraph/wildcard'
+import { Input } from '@sourcegraph/wildcard'
 
 import { CodeIntelligenceConfigurationPolicyFields } from '../../../../graphql-operations'
 import { nullPolicy } from '../hooks/types'
@@ -35,19 +35,16 @@ export const BranchTargetSettings: FunctionComponent<React.PropsWithChildren<Bra
 
     return (
         <>
-            <div className="form-group">
-                <Typography.Label htmlFor="name">Name</Typography.Label>
-                <input
-                    id="name"
-                    type="text"
-                    className="form-control"
-                    value={policy.name}
-                    onChange={({ target: { value: name } }) => updatePolicy({ name })}
-                    disabled={disabled}
-                    required={true}
-                />
-                <small className="form-text text-muted">Required.</small>
-            </div>
+            <Input
+                id="name"
+                className="form-group"
+                value={policy.name}
+                onChange={({ target: { value: name } }) => updatePolicy({ name })}
+                disabled={disabled}
+                required={true}
+                label="Name"
+                message="Required."
+            />
 
             {repoId || policy.repository ? (
                 <div className="mb-3">

--- a/client/web/src/enterprise/codeintel/configuration/components/DurationSelect.tsx
+++ b/client/web/src/enterprise/codeintel/configuration/components/DurationSelect.tsx
@@ -2,7 +2,7 @@ import { FunctionComponent, useState } from 'react'
 
 import classNames from 'classnames'
 
-import { Select } from '@sourcegraph/wildcard'
+import { Select, Input } from '@sourcegraph/wildcard'
 
 import { defaultDurationValues } from '../shared'
 
@@ -59,9 +59,9 @@ export const DurationSelect: FunctionComponent<React.PropsWithChildren<DurationS
 
             {isCustom && (
                 <>
-                    <input
+                    <Input
                         type="number"
-                        className="form-control ml-2"
+                        className="ml-2"
                         value={value || defaultCustomValue}
                         min="1"
                         max="219150"

--- a/client/web/src/enterprise/codeintel/configuration/components/ObjectsMatchingGitPattern.tsx
+++ b/client/web/src/enterprise/codeintel/configuration/components/ObjectsMatchingGitPattern.tsx
@@ -2,7 +2,7 @@ import { FunctionComponent, useEffect, useMemo, useState } from 'react'
 
 import { debounce } from 'lodash'
 
-import { Typography } from '@sourcegraph/wildcard'
+import { Input } from '@sourcegraph/wildcard'
 
 import { GitObjectType } from '../../../../graphql-operations'
 
@@ -33,22 +33,20 @@ export const ObjectsMatchingGitPattern: FunctionComponent<React.PropsWithChildre
     return (
         <>
             {type !== GitObjectType.GIT_COMMIT && (
-                <div className="form-group">
-                    <Typography.Label htmlFor="pattern">Pattern</Typography.Label>
-                    <input
-                        id="pattern"
-                        type="text"
-                        className="form-control text-monospace"
-                        value={localPattern}
-                        onChange={({ target: { value } }) => {
-                            setLocalPattern(value)
-                            debouncedSetPattern(value)
-                        }}
-                        disabled={disabled}
-                        required={true}
-                    />
-                    <small className="form-text text-muted">Required.</small>
-                </div>
+                <Input
+                    id="pattern"
+                    label="Pattern"
+                    className="form-group"
+                    inputClassName="text-monospace"
+                    value={localPattern}
+                    onChange={({ target: { value } }) => {
+                        setLocalPattern(value)
+                        debouncedSetPattern(value)
+                    }}
+                    disabled={disabled}
+                    required={true}
+                    message="Required"
+                />
             )}
             {repoId && <GitObjectPreviewWrapper repoId={repoId} type={type} pattern={pattern} />}
         </>

--- a/client/web/src/enterprise/codeintel/configuration/components/ReposMatchingPattern.tsx
+++ b/client/web/src/enterprise/codeintel/configuration/components/ReposMatchingPattern.tsx
@@ -4,7 +4,7 @@ import classNames from 'classnames'
 import { debounce } from 'lodash'
 import TrashIcon from 'mdi-react/TrashIcon'
 
-import { Button, Icon, Typography } from '@sourcegraph/wildcard'
+import { Button, Icon, Input } from '@sourcegraph/wildcard'
 
 import styles from './ReposMatchingPattern.module.scss'
 
@@ -32,11 +32,10 @@ export const ReposMatchingPattern: FunctionComponent<React.PropsWithChildren<Rep
 
     return (
         <>
-            <div className="form-group d-flex flex-column mb-0">
-                <Typography.Label htmlFor="repo-pattern">Repository pattern #{index + 1}</Typography.Label>
-                <input
+            <div className="d-flex mb-0">
+                <Input
                     type="text"
-                    className="form-control text-monospace"
+                    inputClassName="text-monospace"
                     value={localPattern}
                     onChange={({ target: { value } }) => {
                         setLocalPattern(value)
@@ -44,12 +43,12 @@ export const ReposMatchingPattern: FunctionComponent<React.PropsWithChildren<Rep
                     }}
                     disabled={disabled}
                     required={true}
+                    label={`Repository pattern #${index + 1}`}
+                    message="Required."
                 />
-                <small className="form-text text-muted">Required.</small>
             </div>
-
-            <span className={classNames(styles.button, 'd-none d-md-inline')}>
-                <Button onClick={() => onDelete()} className="p-0 m-0 pt-2" disabled={disabled}>
+            <span className={classNames(styles.button, 'd-none d-md-inline-flex align-items-center')}>
+                <Button variant="icon" onClick={() => onDelete()} className="p-0" disabled={disabled}>
                     <Icon className="text-danger" data-tooltip="Delete the repository pattern" as={TrashIcon} />
                 </Button>
             </span>

--- a/client/web/src/enterprise/codeintel/indexes/components/EnqueueForm.tsx
+++ b/client/web/src/enterprise/codeintel/indexes/components/EnqueueForm.tsx
@@ -3,7 +3,7 @@ import { FunctionComponent, useCallback, useState } from 'react'
 import { Subject } from 'rxjs'
 
 import { ErrorAlert } from '@sourcegraph/branded/src/components/alerts'
-import { Button, Alert, Typography } from '@sourcegraph/wildcard'
+import { Button, Alert, Input, Typography } from '@sourcegraph/wildcard'
 
 import { useEnqueueIndexJob } from '../hooks/useEnqueueIndexJob'
 
@@ -55,10 +55,9 @@ export const EnqueueForm: FunctionComponent<React.PropsWithChildren<EnqueueFormP
             <div className="form-inline">
                 <Typography.Label htmlFor="revlike">Git revlike</Typography.Label>
 
-                <input
-                    type="text"
+                <Input
                     id="revlike"
-                    className="form-control ml-2"
+                    className="ml-2"
                     value={revlike}
                     onChange={event => setRevlike(event.target.value)}
                 />

--- a/client/web/src/enterprise/dotcom/productPlans/ProductSubscriptionUserCountFormControl.tsx
+++ b/client/web/src/enterprise/dotcom/productPlans/ProductSubscriptionUserCountFormControl.tsx
@@ -2,7 +2,7 @@ import React, { useCallback } from 'react'
 
 import classNames from 'classnames'
 
-import { Typography } from '@sourcegraph/wildcard'
+import { Typography, Input } from '@sourcegraph/wildcard'
 
 interface Props {
     /** The user count input by the user. */
@@ -52,10 +52,10 @@ export const ProductSubscriptionUserCountFormControl: React.FunctionComponent<Re
                 Users
             </Typography.Label>
             <div className="d-flex align-items-center">
-                <input
+                <Input
                     id="product-subscription-user-count-control__userCount"
                     type="number"
-                    className="form-control w-auto"
+                    className="w-auto"
                     min={MIN_USER_COUNT}
                     step={USER_COUNT_STEP}
                     max={50000}

--- a/client/web/src/enterprise/dotcom/productPlans/__snapshots__/ProductSubscriptionUserCountFormControl.test.tsx.snap
+++ b/client/web/src/enterprise/dotcom/productPlans/__snapshots__/ProductSubscriptionUserCountFormControl.test.tsx.snap
@@ -14,16 +14,20 @@ exports[`ProductSubscriptionUserCountFormControl renders 1`] = `
     <div
       class="d-flex align-items-center"
     >
-      <input
-        class="form-control w-auto"
-        id="product-subscription-user-count-control__userCount"
-        max="50000"
-        min="25"
-        required=""
-        step="25"
-        type="number"
-        value="123"
-      />
+      <div
+        class="container d-flex w-auto"
+      >
+        <input
+          class="form-control with-invalid-icon"
+          id="product-subscription-user-count-control__userCount"
+          max="50000"
+          min="25"
+          required=""
+          step="25"
+          type="number"
+          value="123"
+        />
+      </div>
     </div>
   </div>
 </DocumentFragment>

--- a/client/web/src/enterprise/insights/components/form/form-radio-input/FormRadioInput.tsx
+++ b/client/web/src/enterprise/insights/components/form/form-radio-input/FormRadioInput.tsx
@@ -29,6 +29,7 @@ export const FormRadioInput: React.FunctionComponent<React.PropsWithChildren<Rad
                 'text-muted': otherProps.disabled,
             })}
         >
+            {/* eslint-disable-next-line react/forbid-elements */}
             <input type="radio" {...otherProps} />
 
             <span className="pl-2">{title}</span>

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/sort-filter-series-panel/SortFilterSeriesPanel.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/sort-filter-series-panel/SortFilterSeriesPanel.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react'
 
 import classNames from 'classnames'
 
-import { Button, ButtonGroup } from '@sourcegraph/wildcard'
+import { Button, ButtonGroup, Input } from '@sourcegraph/wildcard'
 
 import styles from './SortFilterSeriesPanel.module.scss'
 
@@ -82,13 +82,7 @@ export const SortFilterSeriesPanel: React.FunctionComponent<SortFilterSeriesPane
             </section>
             <footer className={styles.footer}>
                 <span>Number of data series</span>
-                <input
-                    type="number"
-                    step="1"
-                    value={seriesCount}
-                    className="form-control form-control-sm"
-                    onChange={handleChange}
-                />
+                <Input type="number" step="1" value={seriesCount} onChange={handleChange} variant="small" />
             </footer>
         </section>
     )

--- a/client/web/src/enterprise/insights/pages/insights/creation/search-insight/components/form-color-input/FormColorInput.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/search-insight/components/form-color-input/FormColorInput.tsx
@@ -42,6 +42,7 @@ export const FormColorInput: React.FunctionComponent<React.PropsWithChildren<For
                         title={startCase(key.toLocaleLowerCase())}
                         className={styles.formColorPickerColorBlock}
                     >
+                        {/* eslint-disable-next-line react/forbid-elements */}
                         <input
                             type="radio"
                             name={name}

--- a/client/web/src/enterprise/search/stats/SearchStatsPage.tsx
+++ b/client/web/src/enterprise/search/stats/SearchStatsPage.tsx
@@ -7,7 +7,7 @@ import { catchError } from 'rxjs/operators'
 
 import { Form } from '@sourcegraph/branded/src/components/Form'
 import { asError, isErrorLike, ErrorLike } from '@sourcegraph/common'
-import { Badge, Button, LoadingSpinner, useObservable, Alert, Icon, Typography } from '@sourcegraph/wildcard'
+import { Badge, LoadingSpinner, useObservable, Alert, Icon, Typography, Input, Button } from '@sourcegraph/wildcard'
 
 import { querySearchResultsStats } from './backend'
 import { SearchStatsLanguages } from './SearchStatsLanguages'
@@ -63,10 +63,10 @@ export const SearchStatsPage: React.FunctionComponent<React.PropsWithChildren<Pr
                 </Typography.H2>
             </header>
             <Form onSubmit={onSubmit} className="form">
-                <div className="form-group d-flex align-items-stretch">
-                    <input
+                <div className="form-group d-flex">
+                    <Input
                         id="stats-page__query"
-                        className="form-control flex-1 test-stats-query"
+                        className="mb-0 w-100"
                         type="search"
                         placeholder="Enter a Sourcegraph search query"
                         value={uncommittedQuery}
@@ -77,7 +77,7 @@ export const SearchStatsPage: React.FunctionComponent<React.PropsWithChildren<Pr
                         autoComplete="off"
                     />
                     {uncommittedQuery !== query && (
-                        <Button type="submit" className="ml-2 test-stats-query-update" variant="primary">
+                        <Button type="submit" className="ml-2" variant="primary">
                             Update
                         </Button>
                     )}

--- a/client/web/src/enterprise/search/stats/__snapshots__/SearchStatsPage.test.tsx.snap
+++ b/client/web/src/enterprise/search/stats/__snapshots__/SearchStatsPage.test.tsx.snap
@@ -34,19 +34,23 @@ exports[`SearchStatsPage limitHit 1`] = `
       class="form"
     >
       <div
-        class="form-group d-flex align-items-stretch"
+        class="form-group d-flex"
       >
-        <input
-          autocapitalize="off"
-          autocomplete="off"
-          autocorrect="off"
-          class="form-control flex-1 test-stats-query"
-          id="stats-page__query"
-          placeholder="Enter a Sourcegraph search query"
-          spellcheck="false"
-          type="search"
-          value="abc"
-        />
+        <div
+          class="container d-flex mb-0 w-100"
+        >
+          <input
+            autocapitalize="off"
+            autocomplete="off"
+            autocorrect="off"
+            class="form-control with-invalid-icon"
+            id="stats-page__query"
+            placeholder="Enter a Sourcegraph search query"
+            spellcheck="false"
+            type="search"
+            value="abc"
+          />
+        </div>
       </div>
     </form>
     <hr
@@ -103,19 +107,23 @@ exports[`SearchStatsPage renders 1`] = `
       class="form"
     >
       <div
-        class="form-group d-flex align-items-stretch"
+        class="form-group d-flex"
       >
-        <input
-          autocapitalize="off"
-          autocomplete="off"
-          autocorrect="off"
-          class="form-control flex-1 test-stats-query"
-          id="stats-page__query"
-          placeholder="Enter a Sourcegraph search query"
-          spellcheck="false"
-          type="search"
-          value="abc"
-        />
+        <div
+          class="container d-flex mb-0 w-100"
+        >
+          <input
+            autocapitalize="off"
+            autocomplete="off"
+            autocorrect="off"
+            class="form-control with-invalid-icon"
+            id="stats-page__query"
+            placeholder="Enter a Sourcegraph search query"
+            spellcheck="false"
+            type="search"
+            value="abc"
+          />
+        </div>
       </div>
     </form>
     <hr

--- a/client/web/src/enterprise/searchContexts/SearchContextForm.tsx
+++ b/client/web/src/enterprise/searchContexts/SearchContextForm.tsx
@@ -28,6 +28,7 @@ import {
     Alert,
     ProductStatusBadge,
     Link,
+    Input,
     Typography,
 } from '@sourcegraph/wildcard'
 
@@ -336,24 +337,20 @@ export const SearchContextForm: React.FunctionComponent<React.PropsWithChildren<
                             authenticatedUser={authenticatedUser}
                         />
                     </div>
-                    <div className="flex-1">
-                        <div id="context-name-label" className="mb-2">
-                            Context name
-                        </div>
-                        <input
-                            className={classNames('w-100', 'form-control', styles.searchContextFormNameInput)}
-                            aria-labelledby="context-name-label"
-                            data-testid="search-context-name-input"
-                            value={name}
-                            type="text"
-                            pattern="^[a-zA-Z0-9_\-\/\.]+$"
-                            required={true}
-                            maxLength={MAX_NAME_LENGTH}
-                            onChange={event => {
-                                setName(event.target.value)
-                            }}
-                        />
-                    </div>
+                    <Input
+                        className="flex-1 mb-0"
+                        inputClassName={styles.searchContextFormNameInput}
+                        aria-labelledby="context-name-label"
+                        label={<span className="font-weight-normal">Context name</span>}
+                        data-testid="search-context-name-input"
+                        value={name}
+                        pattern="^[a-zA-Z0-9_\-\/\.]+$"
+                        required={true}
+                        maxLength={MAX_NAME_LENGTH}
+                        onChange={event => {
+                            setName(event.target.value)
+                        }}
+                    />
                 </div>
                 <div className="text-muted my-2">
                     <small>

--- a/client/web/src/enterprise/searchContexts/SearchContextPage.tsx
+++ b/client/web/src/enterprise/searchContexts/SearchContextPage.tsx
@@ -24,6 +24,7 @@ import {
     Button,
     Link,
     Alert,
+    Input,
     Typography,
 } from '@sourcegraph/wildcard'
 
@@ -106,9 +107,8 @@ const SearchContextRepositories: React.FunctionComponent<
                     </Typography.H3>
                 )}
                 {repositories.length > 0 && (
-                    <input
-                        type="text"
-                        className="form-control form-control-md w-50"
+                    <Input
+                        className="w-50"
                         placeholder="Search repositories and revisions"
                         onChange={event => debouncedSetFilterQuery(event.target.value)}
                     />

--- a/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminGenerateProductLicenseForSubscriptionForm.tsx
+++ b/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminGenerateProductLicenseForSubscriptionForm.tsx
@@ -11,7 +11,7 @@ import { asError, createAggregateError, isErrorLike } from '@sourcegraph/common'
 import { gql } from '@sourcegraph/http-client'
 import { Scalars } from '@sourcegraph/shared/src/graphql-operations'
 import * as GQL from '@sourcegraph/shared/src/schema'
-import { Alert, Button, useEventObservable, Link, Typography } from '@sourcegraph/wildcard'
+import { Alert, Button, useEventObservable, Link, Typography, Input } from '@sourcegraph/wildcard'
 
 import { mutateGraphQL } from '../../../../backend/graphql'
 import { ExpirationDate } from '../../../productSubscription/ExpirationDate'
@@ -141,7 +141,7 @@ export const SiteAdminGenerateProductLicenseForSubscriptionForm: React.FunctionC
                         <Typography.Label htmlFor="site-admin-create-product-subscription-page__tags">
                             Tags
                         </Typography.Label>
-                        <input
+                        <Input
                             type="text"
                             className="form-control"
                             id="site-admin-create-product-subscription-page__tags"
@@ -174,10 +174,9 @@ export const SiteAdminGenerateProductLicenseForSubscriptionForm: React.FunctionC
                         <Typography.Label htmlFor="site-admin-create-product-subscription-page__userCount">
                             Users
                         </Typography.Label>
-                        <input
+                        <Input
                             type="number"
                             min={1}
-                            className="form-control"
                             id="site-admin-create-product-subscription-page__userCount"
                             disabled={disableForm}
                             value={formData.userCount || ''}
@@ -188,9 +187,8 @@ export const SiteAdminGenerateProductLicenseForSubscriptionForm: React.FunctionC
                         <Typography.Label htmlFor="site-admin-create-product-subscription-page__validDays">
                             Valid for (days)
                         </Typography.Label>
-                        <input
+                        <Input
                             type="number"
-                            className="form-control"
                             id="site-admin-create-product-subscription-page__validDays"
                             disabled={disableForm}
                             value={formData.validDays || ''}

--- a/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/__snapshots__/SiteAdminGenerateProductLicenseForSubscriptionForm.test.tsx.snap
+++ b/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/__snapshots__/SiteAdminGenerateProductLicenseForSubscriptionForm.test.tsx.snap
@@ -17,13 +17,17 @@ exports[`SiteAdminGenerateProductLicenseForSubscriptionForm renders 1`] = `
         >
           Tags
         </label>
-        <input
-          class="form-control"
-          id="site-admin-create-product-subscription-page__tags"
-          list="knownPlans"
-          type="text"
-          value=""
-        />
+        <div
+          class="container d-flex form-control"
+        >
+          <input
+            class="form-control with-invalid-icon"
+            id="site-admin-create-product-subscription-page__tags"
+            list="knownPlans"
+            type="text"
+            value=""
+          />
+        </div>
         <datalist
           id="knownPlans"
         >
@@ -76,13 +80,17 @@ exports[`SiteAdminGenerateProductLicenseForSubscriptionForm renders 1`] = `
         >
           Users
         </label>
-        <input
-          class="form-control"
-          id="site-admin-create-product-subscription-page__userCount"
-          min="1"
-          type="number"
-          value="1"
-        />
+        <div
+          class="container d-flex"
+        >
+          <input
+            class="form-control with-invalid-icon"
+            id="site-admin-create-product-subscription-page__userCount"
+            min="1"
+            type="number"
+            value="1"
+          />
+        </div>
       </div>
       <div
         class="form-group"
@@ -93,14 +101,18 @@ exports[`SiteAdminGenerateProductLicenseForSubscriptionForm renders 1`] = `
         >
           Valid for (days)
         </label>
-        <input
-          class="form-control"
-          id="site-admin-create-product-subscription-page__validDays"
-          max="2000"
-          min="1"
-          type="number"
-          value="1"
-        />
+        <div
+          class="container d-flex"
+        >
+          <input
+            class="form-control with-invalid-icon"
+            id="site-admin-create-product-subscription-page__validDays"
+            max="2000"
+            min="1"
+            type="number"
+            value="1"
+          />
+        </div>
         <small
           class="form-text text-muted"
         >

--- a/client/web/src/enterprise/user/productSubscriptions/__snapshots__/ProductSubscriptionForm.test.tsx.snap
+++ b/client/web/src/enterprise/user/productSubscriptions/__snapshots__/ProductSubscriptionForm.test.tsx.snap
@@ -26,16 +26,20 @@ exports[`ProductSubscriptionForm edit existing subscription 1`] = `
             <div
               class="d-flex align-items-center"
             >
-              <input
-                class="form-control w-auto"
-                id="product-subscription-user-count-control__userCount"
-                max="50000"
-                min="25"
-                required=""
-                step="25"
-                type="number"
-                value="123"
-              />
+              <div
+                class="container d-flex w-auto"
+              >
+                <input
+                  class="form-control with-invalid-icon"
+                  id="product-subscription-user-count-control__userCount"
+                  max="50000"
+                  min="25"
+                  required=""
+                  step="25"
+                  type="number"
+                  value="123"
+                />
+              </div>
             </div>
           </div>
           <h4
@@ -112,16 +116,20 @@ exports[`ProductSubscriptionForm new subscription for anonymous viewer (no accou
             <div
               class="d-flex align-items-center"
             >
-              <input
-                class="form-control w-auto"
-                id="product-subscription-user-count-control__userCount"
-                max="50000"
-                min="25"
-                required=""
-                step="25"
-                type="number"
-                value="25"
-              />
+              <div
+                class="container d-flex w-auto"
+              >
+                <input
+                  class="form-control with-invalid-icon"
+                  id="product-subscription-user-count-control__userCount"
+                  max="50000"
+                  min="25"
+                  required=""
+                  step="25"
+                  type="number"
+                  value="25"
+                />
+              </div>
             </div>
           </div>
           <h4
@@ -215,16 +223,20 @@ exports[`ProductSubscriptionForm new subscription for existing account 1`] = `
             <div
               class="d-flex align-items-center"
             >
-              <input
-                class="form-control w-auto"
-                id="product-subscription-user-count-control__userCount"
-                max="50000"
-                min="25"
-                required=""
-                step="25"
-                type="number"
-                value="25"
-              />
+              <div
+                class="container d-flex w-auto"
+              >
+                <input
+                  class="form-control with-invalid-icon"
+                  id="product-subscription-user-count-control__userCount"
+                  max="50000"
+                  min="25"
+                  required=""
+                  step="25"
+                  type="number"
+                  value="25"
+                />
+              </div>
             </div>
           </div>
           <h4

--- a/client/web/src/enterprise/user/productSubscriptions/__snapshots__/UserSubscriptionsEditProductSubscriptionPage.test.tsx.snap
+++ b/client/web/src/enterprise/user/productSubscriptions/__snapshots__/UserSubscriptionsEditProductSubscriptionPage.test.tsx.snap
@@ -43,16 +43,20 @@ exports[`UserSubscriptionsEditProductSubscriptionPage renders 1`] = `
               <div
                 class="d-flex align-items-center"
               >
-                <input
-                  class="form-control w-auto"
-                  id="product-subscription-user-count-control__userCount"
-                  max="50000"
-                  min="25"
-                  required=""
-                  step="25"
-                  type="number"
-                  value="123"
-                />
+                <div
+                  class="container d-flex w-auto"
+                >
+                  <input
+                    class="form-control with-invalid-icon"
+                    id="product-subscription-user-count-control__userCount"
+                    max="50000"
+                    min="25"
+                    required=""
+                    step="25"
+                    type="number"
+                    value="123"
+                  />
+                </div>
               </div>
             </div>
             <h4

--- a/client/web/src/integration/batches.test.ts
+++ b/client/web/src/integration/batches.test.ts
@@ -956,7 +956,7 @@ describe('Batches', () => {
             // Wait for modal to appear.
             await driver.page.waitForSelector('.test-add-credential-modal')
             // Enter token.
-            await driver.page.type('.test-add-credential-modal-input', 'SUPER SECRET')
+            await driver.page.type('[data-testid="test-add-credential-modal-input"]', 'SUPER SECRET')
             // Click add.
             await driver.page.click('.test-add-credential-modal-submit')
             // Await list reload and expect to be enabled.

--- a/client/web/src/integration/code-monitoring.test.ts
+++ b/client/web/src/integration/code-monitoring.test.ts
@@ -116,12 +116,12 @@ describe('Code monitoring', () => {
     describe('Code monitoring form advances sequentially', () => {
         it('validates trigger query input', async () => {
             await driver.page.goto(driver.sourcegraphBaseUrl + '/code-monitoring/new')
-            await driver.page.waitForSelector('.test-name-input')
+            await driver.page.waitForSelector('[data-testid="name-input"]')
 
             await percySnapshotWithVariants(driver.page, 'Code monitoring - Form')
             await accessibilityAudit(driver.page)
 
-            await driver.page.type('.test-name-input', 'test monitor')
+            await driver.page.type('[data-testid="name-input"]', 'test monitor')
 
             await driver.page.waitForSelector('.test-action-button-email')
             assert.strictEqual(
@@ -152,8 +152,8 @@ describe('Code monitoring', () => {
 
         it('disables the actions area until trigger is complete', async () => {
             await driver.page.goto(driver.sourcegraphBaseUrl + '/code-monitoring/new')
-            await driver.page.waitForSelector('.test-name-input')
-            await driver.page.type('.test-name-input', 'test monitor')
+            await driver.page.waitForSelector('[data-testid="name-input"]')
+            await driver.page.type('[data-testid="name-input"]', 'test monitor')
 
             await driver.page.waitForSelector('.test-action-button-email')
             assert.strictEqual(
@@ -189,8 +189,8 @@ describe('Code monitoring', () => {
 
         it('disables submitting the code monitor area until trigger and action are complete', async () => {
             await driver.page.goto(driver.sourcegraphBaseUrl + '/code-monitoring/new')
-            await driver.page.waitForSelector('.test-name-input')
-            await driver.page.type('.test-name-input', 'test monitor')
+            await driver.page.waitForSelector('[data-testid="name-input"]')
+            await driver.page.type('[data-testid="name-input"]', 'test monitor')
 
             await driver.page.waitForSelector('.test-submit-monitor')
             assert.strictEqual(

--- a/client/wildcard/src/components/Form/Input/Input.module.scss
+++ b/client/wildcard/src/components/Form/Input/Input.module.scss
@@ -1,3 +1,3 @@
-.input {
+.input-loading {
     padding-right: 2rem;
 }

--- a/client/wildcard/src/components/Form/Input/Input.test.tsx
+++ b/client/wildcard/src/components/Form/Input/Input.test.tsx
@@ -21,7 +21,7 @@ describe('Input', () => {
               class="container d-flex"
             >
               <input
-                class="input form-control with-invalid-icon"
+                class="inputLoading form-control with-invalid-icon"
                 placeholder="loading status input"
                 title="Input loading"
                 type="text"
@@ -59,7 +59,7 @@ describe('Input', () => {
                 class="container d-flex"
               >
                 <input
-                  class="input form-control with-invalid-icon"
+                  class="inputLoading form-control with-invalid-icon"
                   placeholder="loading status input"
                   title="Input loading"
                   type="text"

--- a/client/wildcard/src/components/Form/Input/Input.tsx
+++ b/client/wildcard/src/components/Form/Input/Input.tsx
@@ -70,11 +70,17 @@ export const Input = forwardRef((props, reference) => {
                 <Component
                     disabled={disabled}
                     type={type}
-                    className={classNames(styles.input, inputClassName, 'form-control', 'with-invalid-icon', {
-                        'is-valid': status === InputStatus.valid,
-                        'is-invalid': error || status === InputStatus.error,
-                        'form-control-sm': variant === 'small',
-                    })}
+                    className={classNames(
+                        inputClassName,
+                        status === InputStatus.loading && styles.inputLoading,
+                        'form-control',
+                        'with-invalid-icon',
+                        {
+                            'is-valid': status === InputStatus.valid,
+                            'is-invalid': error || status === InputStatus.error,
+                            'form-control-sm': variant === 'small',
+                        }
+                    )}
                     {...otherProps}
                     ref={mergedReference}
                     autoFocus={autoFocus}

--- a/client/wildcard/src/components/Form/Input/__snapshots__/Input.test.tsx.snap
+++ b/client/wildcard/src/components/Form/Input/__snapshots__/Input.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`Input Renders status 'error' correctly 1`] = `
   class="container d-flex"
 >
   <input
-    class="input form-control with-invalid-icon is-invalid"
+    class="form-control with-invalid-icon is-invalid"
     type="text"
     value=""
   />
@@ -17,7 +17,7 @@ exports[`Input Renders status 'loading' correctly 1`] = `
   class="container d-flex"
 >
   <input
-    class="input form-control with-invalid-icon"
+    class="inputLoading form-control with-invalid-icon"
     type="text"
     value=""
   />
@@ -32,7 +32,7 @@ exports[`Input Renders status 'valid' correctly 1`] = `
   class="container d-flex"
 >
   <input
-    class="input form-control with-invalid-icon is-valid"
+    class="form-control with-invalid-icon is-valid"
     type="text"
     value=""
   />


### PR DESCRIPTION
## Problem statement

Migration is required to update our code to use the `<Input />` Wildcard component.
See [parent issue](https://github.com/sourcegraph/sourcegraph/issues/27722) for more context. 

## Success criteria

All occurrences of the `<input />` element are replaced with the `<Input />` Wildcard component.

## Implementation details

- Rename the `Input` component `variant` prop to `size`.
- Use the `Input` codemod created [here](https://github.com/sourcegraph/codemod/pull/94) to speed up the migration.

## Refs
[Sourcegraph Issue](https://github.com/sourcegraph/sourcegraph/issues/35282)
[Gitstart Ticket](https://app.gitstart.com/clients/sourcegraph/tickets/SG-35282)

## Test Plan
- All `<input/>` elements are migrated to `<Input/>` wildcard component.
- No UI diff available

## App preview:

- [Web](https://sg-web-contractors-sg-35282.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-cmgcrwqaez.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
