### PR TITLE
adr: Generate index automatically

### DIFF
--- a/dev/adr-docs/index.md.tmpl
+++ b/dev/adr-docs/index.md.tmpl
@@ -1,0 +1,11 @@
+# Usage of Architecture Decision Records (ADRs)
+
+This page is an ADR log. Read the first entry to learn about the reasoning and context behind the adoption of ADRs.
+
+Are you considering adding an ADR? Check out the [How-to page](how-to.md)!
+
+To preserve order, individual documents are prefixed by the **current epoch Unix timestamp**.
+
+{{- range .Adrs }}
+{{ .Number }}. _{{ .Date }}_ [{{ .Title }}]({{ .Path }})
+{{- end }}

--- a/dev/adr-docs/index.md.tmpl
+++ b/dev/adr-docs/index.md.tmpl
@@ -5,7 +5,7 @@ This page is an ADR log. Read the first entry to learn about the reasoning and c
 Are you considering adding an ADR? Check out the [How-to page](how-to.md)!
 
 To preserve order, individual documents are prefixed by the **current epoch Unix timestamp**.
-
+{{""}}
 {{- range .Adrs }}
 {{ .Number }}. _{{ .Date }}_ [{{ .Title }}]({{ .Path }})
 {{- end }}

--- a/dev/adr-docs/main.go
+++ b/dev/adr-docs/main.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"text/template"
+	"time"
+
+	"github.com/sourcegraph/sourcegraph/dev/sg/root"
+)
+
+type adr struct {
+	Number int
+	Title  string
+	Path   string
+	Date   string
+}
+
+type presenter struct {
+	Adrs []adr
+}
+
+//go:generate sh -c "cd ../.. && echo <!-- DO NOT EDIT: generated via: go generate ./enterprise/dev/ci -->\n > doc/dev/adr/index.md"
+//go:generate sh -c "cd ../.. && go run ./dev/adr-docs/main.go >> doc/dev/adr/index.md"
+func main() {
+	repoRoot, err := root.RepositoryRoot()
+	if err != nil {
+		panic(err)
+	}
+	tmpl, err := template.ParseFiles(filepath.Join(repoRoot, "dev", "adr-docs", "index.md.tmpl"))
+	if err != nil {
+		panic(err)
+	}
+	entries, err := os.ReadDir(filepath.Join(repoRoot, "doc", "dev", "adr"))
+	if err != nil {
+		panic(err)
+	}
+
+	var adrs []adr
+	re := regexp.MustCompile(`(\d+)-.+\.md`)
+	for _, entry := range entries {
+		if !re.MatchString(entry.Name()) {
+			continue
+		}
+		b, err := os.ReadFile(filepath.Join(repoRoot, "doc", "dev", "adr", entry.Name()))
+		if err != nil {
+			panic(err)
+		}
+		m := re.FindAllStringSubmatch(entry.Name(), 1)
+		ts, _ := strconv.Atoi(m[0][1]) // We can ignore the err because we know from the regexp it's only digits.
+
+		reHeader := regexp.MustCompile(`#\s+(\d+)\.\s+(.*)$`)
+		s := bufio.NewScanner(bytes.NewReader(b))
+		var title string
+		var number int
+		for s.Scan() {
+			matches := reHeader.FindAllStringSubmatch(s.Text(), 1)
+			if len(matches) > 0 {
+				fmt.Println(matches)
+				number, _ = strconv.Atoi(matches[0][1]) // We can ignore the err because we know from the regexp it's only digits.
+				title = matches[0][2]
+				adrs = append(adrs, adr{
+					Title:  title,
+					Number: number,
+					Path:   "./" + entry.Name(),
+					Date:   time.Unix(int64(ts), 0).Format("2006-01-02"),
+				})
+				break
+			}
+		}
+	}
+
+	presenter := presenter{
+		Adrs: adrs,
+	}
+
+	err = tmpl.Execute(os.Stdout, &presenter)
+	if err != nil {
+		panic(err)
+	}
+}

--- a/dev/adr-docs/main.go
+++ b/dev/adr-docs/main.go
@@ -41,7 +41,7 @@ func main() {
 	}
 
 	var adrs []adr
-	re := regexp.MustCompile(`(\d+)-.+\.md`)
+	re := regexp.MustCompile(`^(\d+)-.+\.md`)
 	for _, entry := range entries {
 		if !re.MatchString(entry.Name()) {
 			continue

--- a/dev/adr-docs/main.go
+++ b/dev/adr-docs/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"bufio"
 	"bytes"
-	"fmt"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -25,7 +24,7 @@ type presenter struct {
 	Adrs []adr
 }
 
-//go:generate sh -c "cd ../.. && echo <!-- DO NOT EDIT: generated via: go generate ./enterprise/dev/ci -->\n > doc/dev/adr/index.md"
+//go:generate sh -c "cd ../.. && echo '<!-- DO NOT EDIT: generated via: go generate ./dev/adr-docs -->\n' > doc/dev/adr/index.md"
 //go:generate sh -c "cd ../.. && go run ./dev/adr-docs/main.go >> doc/dev/adr/index.md"
 func main() {
 	repoRoot, err := root.RepositoryRoot()
@@ -61,7 +60,6 @@ func main() {
 		for s.Scan() {
 			matches := reHeader.FindAllStringSubmatch(s.Text(), 1)
 			if len(matches) > 0 {
-				fmt.Println(matches)
 				number, _ = strconv.Atoi(matches[0][1]) // We can ignore the err because we know from the regexp it's only digits.
 				title = matches[0][2]
 				adrs = append(adrs, adr{

--- a/dev/adr-docs/main.go
+++ b/dev/adr-docs/main.go
@@ -20,7 +20,7 @@ type adr struct {
 	Date   string
 }
 
-type presenter struct {
+type templateData struct {
 	Adrs []adr
 }
 
@@ -73,7 +73,7 @@ func main() {
 		}
 	}
 
-	presenter := presenter{
+	presenter := templateData{
 		Adrs: adrs,
 	}
 

--- a/doc/dev/adr/index.md
+++ b/doc/dev/adr/index.md
@@ -1,6 +1,5 @@
 <!-- DO NOT EDIT: generated via: go generate ./dev/adr-docs -->
 
-[[# 1. Record architecture decisions 1 Record architecture decisions]]
 # Usage of Architecture Decision Records (ADRs)
 
 This page is an ADR log. Read the first entry to learn about the reasoning and context behind the adoption of ADRs.

--- a/doc/dev/adr/index.md
+++ b/doc/dev/adr/index.md
@@ -1,3 +1,6 @@
+<!-- DO NOT EDIT: generated via: go generate ./dev/adr-docs -->
+
+[[# 1. Record architecture decisions 1 Record architecture decisions]]
 # Usage of Architecture Decision Records (ADRs)
 
 This page is an ADR log. Read the first entry to learn about the reasoning and context behind the adoption of ADRs.
@@ -6,4 +9,4 @@ Are you considering adding an ADR? Check out the [How-to page](how-to.md)!
 
 To preserve order, individual documents are prefixed by the **current epoch Unix timestamp**.
 
-1. [Record architecture decisions](1650968652-record-architecture-decisions.md)
+1. _2022-04-26_ [Record architecture decisions](./1650968652-record-architecture-decisions.md)


### PR DESCRIPTION
I'm testing the Graphite CLI, inspired by @bobheadxi recent uses which are really nice. Took this opportunity to add a generator for the index as a way to play around it. 

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Tested locally. 