### PR TITLE
Heading usage: Fix lint

### DIFF
--- a/client/web/src/enterprise/batches/create/CreateOrEditBatchChangePage.tsx
+++ b/client/web/src/enterprise/batches/create/CreateOrEditBatchChangePage.tsx
@@ -37,7 +37,6 @@ import {
     Typography,
 } from '@sourcegraph/wildcard'
 
-import { H4 } from '@sourcegraph/wildcard/src/components/Typography'
 import { BatchChangesIcon } from '../../../batches/icons'
 import { HeroPage } from '../../../components/HeroPage'
 import { PageTitle } from '../../../components/PageTitle'
@@ -545,7 +544,7 @@ const EditPage: React.FunctionComponent<React.PropsWithChildren<EditPageProps>> 
             <div className={classNames(styles.editorLayoutContainer, 'd-flex flex-1 mt-2')}>
                 <LibraryPane name={batchChange.name} onReplaceItem={clearErrorsAndHandleCodeChange} />
                 <div className={styles.editorContainer}>
-                    <H4 className={styles.header}>Batch spec</H4>
+                    <Typography.H4 className={styles.header}>Batch spec</Typography.H4>
                     {insightTitle && (
                         <InsightTemplatesBanner insightTitle={insightTitle} type="edit" className="mb-3" />
                     )}

--- a/client/web/src/enterprise/batches/create/CreateOrEditBatchChangePage.tsx
+++ b/client/web/src/enterprise/batches/create/CreateOrEditBatchChangePage.tsx
@@ -37,6 +37,7 @@ import {
     Typography,
 } from '@sourcegraph/wildcard'
 
+import { H4 } from '@sourcegraph/wildcard/src/components/Typography'
 import { BatchChangesIcon } from '../../../batches/icons'
 import { HeroPage } from '../../../components/HeroPage'
 import { PageTitle } from '../../../components/PageTitle'
@@ -544,7 +545,7 @@ const EditPage: React.FunctionComponent<React.PropsWithChildren<EditPageProps>> 
             <div className={classNames(styles.editorLayoutContainer, 'd-flex flex-1 mt-2')}>
                 <LibraryPane name={batchChange.name} onReplaceItem={clearErrorsAndHandleCodeChange} />
                 <div className={styles.editorContainer}>
-                    <h4 className={styles.header}>Batch spec</h4>
+                    <H4 className={styles.header}>Batch spec</H4>
                     {insightTitle && (
                         <InsightTemplatesBanner insightTitle={insightTitle} type="edit" className="mb-3" />
                     )}

--- a/doc/dev/background-information/ci/reference.md
+++ b/doc/dev/background-information/ci/reference.md
@@ -23,12 +23,12 @@ The default run type.
   - **Pipeline setup**: Trigger async
   - Client PR preview
   - **Linters and static analysis**: Prettier, Run sg lint
-  - **Client checks**: Puppeteer tests prep, Puppeteer tests for chrome extension, Puppeteer tests chunk #1, Puppeteer tests chunk #2, Puppeteer tests chunk #3, Puppeteer tests chunk #4, Puppeteer tests chunk #5, Puppeteer tests chunk #6, Puppeteer tests chunk #7, Puppeteer tests chunk #8, Puppeteer tests chunk #9, Puppeteer tests chunk #10, Upload Storybook to Chromatic, Test (all), Build, Enterprise build, Test (client/web), Test (client/browser), Build TS, ESLint (changed), Stylelint (changed)
+  - **Client checks**: Puppeteer tests prep, Puppeteer tests for chrome extension, Puppeteer tests chunk #1, Puppeteer tests chunk #2, Puppeteer tests chunk #3, Puppeteer tests chunk #4, Puppeteer tests chunk #5, Puppeteer tests chunk #6, Puppeteer tests chunk #7, Puppeteer tests chunk #8, Puppeteer tests chunk #9, Puppeteer tests chunk #10, Upload Storybook to Chromatic, Test (all), Build, Enterprise build, Test (client/web), Test (client/browser), Build TS, ESLint (all), Stylelint (all)
   - Upload build trace
 
 - Pipeline for `GraphQL` changes:
   - **Linters and static analysis**: Prettier, GraphQL lint
-  - **Client checks**: Puppeteer tests prep, Puppeteer tests for chrome extension, Puppeteer tests chunk #1, Puppeteer tests chunk #2, Puppeteer tests chunk #3, Puppeteer tests chunk #4, Puppeteer tests chunk #5, Puppeteer tests chunk #6, Puppeteer tests chunk #7, Puppeteer tests chunk #8, Puppeteer tests chunk #9, Puppeteer tests chunk #10, Upload Storybook to Chromatic, Test (all), Build, Enterprise build, Test (client/web), Test (client/browser), Build TS, ESLint (changed), Stylelint (changed)
+  - **Client checks**: Puppeteer tests prep, Puppeteer tests for chrome extension, Puppeteer tests chunk #1, Puppeteer tests chunk #2, Puppeteer tests chunk #3, Puppeteer tests chunk #4, Puppeteer tests chunk #5, Puppeteer tests chunk #6, Puppeteer tests chunk #7, Puppeteer tests chunk #8, Puppeteer tests chunk #9, Puppeteer tests chunk #10, Upload Storybook to Chromatic, Test (all), Build, Enterprise build, Test (client/web), Test (client/browser), Build TS, ESLint (all), Stylelint (all)
   - **Go checks**: Test (all), Test (enterprise/internal/codeintel/stores/dbstore), Test (enterprise/internal/codeintel/stores/lsifstore), Test (enterprise/internal/insights), Test (internal/database), Test (internal/repos), Test (enterprise/internal/batches), Test (cmd/frontend), Test (enterprise/internal/database), Test (enterprise/cmd/frontend/internal/batches/resolvers), Build
   - Upload build trace
 

--- a/enterprise/dev/ci/internal/ci/pipeline.go
+++ b/enterprise/dev/ci/internal/ci/pipeline.go
@@ -100,8 +100,9 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 			}
 		}
 		ops.Merge(CoreTestOperations(c.Diff, CoreTestOperationsOptions{
-			MinimumUpgradeableVersion:  minimumUpgradeableVersion,
-			ClientLintOnlyChangedFiles: c.RunType.Is(runtype.PullRequest),
+			MinimumUpgradeableVersion: minimumUpgradeableVersion,
+			// TODO: (@umpox, @valerybugakov) Figure out if we can reliably enable this in PRs.
+			ClientLintOnlyChangedFiles: false,
 		}))
 
 	case runtype.ReleaseNightly:


### PR DESCRIPTION
Fixes locked CI.

Need to investigate why this wasn't caught at the PR stage.

This PR https://github.com/sourcegraph/sourcegraph/pull/35345 should have failed, but because we only lint changed files the issue wasn't caught

## Test plan

n/a - minor change to fix CI

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-tr-fix-ci-build.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-ihuzcdaxld.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

