### PR TITLE
ci: document cache expiration

### DIFF
--- a/doc/dev/background-information/ci/development.md
+++ b/doc/dev/background-information/ci/development.md
@@ -99,6 +99,8 @@ For more details about best practices and additional features and capabilities, 
 
 For caching artefacts in steps to speed up steps, see [How to cache CI artefacts](../../how-to/cache_ci_artefacts.md).
 
+Cached artefacts are *automatically expired after 30 days* (by an object lifecycle policy on the bucket).
+
 ### Observability
 
 > NOTE: Sourcegraph teammates should refer to the [CI incidents playbook](https://handbook.sourcegraph.com/departments/product-engineering/engineering/process/incidents/playbooks/ci#scenarios) for help managing issues with [pipeline health](./index.md#pipeline-health).

--- a/doc/dev/how-to/cache_ci_artefacts.md
+++ b/doc/dev/how-to/cache_ci_artefacts.md
@@ -10,6 +10,8 @@ Because [Buildkite agents are stateless](../background-information/ci/developmen
 
 A common strategy to address this problem of having to rebuild everything is to store objects that are commonly reused accross jobs and to download them again rather than rebuilding everything from scratch. 
 
+Cached artefacts *are automatically expired after 30 days* (by an object lifecycle policy on the bucket).
+
 ## What and when to cache?
 
 In order to determine what we can cache and when to do it, we need to make sure to cover the following questions:


### PR DESCRIPTION
Adds a paragraph about the lifecycle of cached artifacts. 

We recently hit the quota and putting in place a mechanism to clear the cache was long due. I added a policy on the bucket to delete the items automatically after 30 days.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

rendered the docs locally. 