### PR TITLE
Download caddy and unarchive it

### DIFF
--- a/dev/sg/internal/download/download.go
+++ b/dev/sg/internal/download/download.go
@@ -2,6 +2,7 @@ package download
 
 import (
 	"bytes"
+	"context"
 	"io/fs"
 	"net/http"
 	"os"
@@ -13,9 +14,9 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
-// Exeuctable downloads a binary from the given URL, updates the given path if different, and
+// Executable downloads a binary from the given URL, updates the given path if different, and
 // makes the downloaded file executable.
-func Exeuctable(url string, path string) error {
+func Executable(url string, path string) error {
 	resp, err := http.Get(url)
 	if err != nil {
 		return err
@@ -41,13 +42,19 @@ func Exeuctable(url string, path string) error {
 	return nil
 }
 
-// ArchivedExeuctable
-func ArchivedExeuctable(url, targetFile, fileInArchive string) error {
+// ArchivedExecutable downloads an executable that's in an archive and extracts
+// it.
+func ArchivedExecutable(ctx context.Context, url, targetFile, fileInArchive string) error {
 	if ok, _ := fileExists(targetFile); ok {
 		return nil
 	}
 
-	resp, err := http.Get(url)
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return err
+	}
+
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return err
 	}

--- a/dev/sg/internal/download/download.go
+++ b/dev/sg/internal/download/download.go
@@ -2,10 +2,14 @@ package download
 
 import (
 	"bytes"
+	"io/fs"
 	"net/http"
+	"os"
 	"os/exec"
+	"path/filepath"
 
 	"github.com/sourcegraph/sourcegraph/internal/fileutil"
+	"github.com/sourcegraph/sourcegraph/internal/unpack"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
@@ -35,4 +39,63 @@ func Exeuctable(url string, path string) error {
 	}
 
 	return nil
+}
+
+// ArchivedExeuctable
+func ArchivedExeuctable(url, targetFile, fileInArchive string) error {
+	if ok, _ := fileExists(targetFile); ok {
+		return nil
+	}
+
+	resp, err := http.Get(url)
+	if err != nil {
+		return err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return errors.Newf("GET %s failed, status code is not OK: %d", url, resp.StatusCode)
+	}
+	defer resp.Body.Close()
+
+	// Create a temp directory to unarchive files to
+	tmpDirName, err := os.MkdirTemp("", "sg-binary-download*")
+	if err != nil {
+		return err
+	}
+	defer func() {
+		// Clean up the temporary directory but ignore any possible errors
+		_ = os.Remove(tmpDirName)
+	}()
+
+	// Only extract the file that we want
+	opts := unpack.Opts{
+		Filter: func(path string, file fs.FileInfo) bool {
+			return path == fileInArchive && !file.IsDir()
+		},
+	}
+	if err := unpack.Tgz(resp.Body, tmpDirName, opts); err != nil {
+		return errors.Wrap(err, "unpacking archive failed")
+	}
+
+	fileInArchivePath := filepath.Join(tmpDirName, fileInArchive)
+	if ok, err := fileExists(fileInArchivePath); !ok || err != nil {
+		return errors.Newf("expected %s to exist in extracted archive at %s, but does not", fileInArchivePath, tmpDirName)
+	}
+
+	if err := os.Rename(fileInArchivePath, targetFile); err != nil {
+		return err
+	}
+
+	return exec.Command("chmod", "+x", targetFile).Run()
+}
+
+func fileExists(path string) (bool, error) {
+	_, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
 }

--- a/dev/sg/internal/run/command.go
+++ b/dev/sg/internal/run/command.go
@@ -18,6 +18,7 @@ type Command struct {
 	Name                string
 	Cmd                 string            `yaml:"cmd"`
 	Install             string            `yaml:"install"`
+	InstallFunc         string            `yaml:"install_func"`
 	CheckBinary         string            `yaml:"checkBinary"`
 	Env                 map[string]string `yaml:"env"`
 	Watch               []string          `yaml:"watch"`
@@ -45,6 +46,9 @@ func (c Command) Merge(other Command) Command {
 	}
 	if other.Install != merged.Install && other.Install != "" {
 		merged.Install = other.Install
+	}
+	if other.InstallFunc != merged.InstallFunc && other.InstallFunc != "" {
+		merged.InstallFunc = other.InstallFunc
 	}
 	if other.IgnoreStdout != merged.IgnoreStdout && !merged.IgnoreStdout {
 		merged.IgnoreStdout = other.IgnoreStdout

--- a/dev/sg/internal/run/run.go
+++ b/dev/sg/internal/run/run.go
@@ -282,18 +282,6 @@ type installFunc func(context.Context, map[string]string) error
 
 var installFuncs = map[string]installFunc{
 	"installCaddy": func(ctx context.Context, env map[string]string) error {
-		//  name="caddy_${CADDY_VERSION}_${os}_$(go env GOARCH)"
-		//  target="$PWD/.bin/caddy_${CADDY_VERSION}"
-		//  url="https://github.com/caddyserver/caddy/releases/download/v${CADDY_VERSION}/${name}.tar.gz"
-
-		//  if [ ! -f "${target}" ]; then
-		//    echo "downloading ${url}" 1>&2
-		//    curl -sS -L -f "${url}" | tar -xz --to-stdout "caddy" >"${target}.tmp"
-		//    mv "${target}.tmp" "${target}"
-		//    chmod +x "${target}"
-		//  fi
-		//
-
 		version := env["CADDY_VERSION"]
 		if version == "" {
 			return errors.New("could not find CADDY_VERSION in env")
@@ -317,7 +305,7 @@ var installFuncs = map[string]installFunc{
 
 		target := filepath.Join(root, fmt.Sprintf(".bin/caddy_%s", version))
 
-		return download.ArchivedExeuctable(url, target, "caddy")
+		return download.ArchivedExecutable(ctx, url, target, "caddy")
 	},
 }
 

--- a/dev/sg/internal/run/run.go
+++ b/dev/sg/internal/run/run.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"time"
@@ -16,6 +17,7 @@ import (
 	"github.com/rjeczalik/notify"
 
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/analytics"
+	"github.com/sourcegraph/sourcegraph/dev/sg/internal/download"
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/std"
 	"github.com/sourcegraph/sourcegraph/dev/sg/root"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
@@ -276,6 +278,49 @@ func printCmdError(out *output.Output, cmdName string, err error) {
 	}
 }
 
+type installFunc func(context.Context, map[string]string) error
+
+var installFuncs = map[string]installFunc{
+	"installCaddy": func(ctx context.Context, env map[string]string) error {
+		//  name="caddy_${CADDY_VERSION}_${os}_$(go env GOARCH)"
+		//  target="$PWD/.bin/caddy_${CADDY_VERSION}"
+		//  url="https://github.com/caddyserver/caddy/releases/download/v${CADDY_VERSION}/${name}.tar.gz"
+
+		//  if [ ! -f "${target}" ]; then
+		//    echo "downloading ${url}" 1>&2
+		//    curl -sS -L -f "${url}" | tar -xz --to-stdout "caddy" >"${target}.tmp"
+		//    mv "${target}.tmp" "${target}"
+		//    chmod +x "${target}"
+		//  fi
+		//
+
+		version := env["CADDY_VERSION"]
+		if version == "" {
+			return errors.New("could not find CADDY_VERSION in env")
+		}
+
+		root, err := root.RepositoryRoot()
+		if err != nil {
+			return err
+		}
+
+		var os string
+		switch runtime.GOOS {
+		case "linux":
+			os = "linux"
+		case "darwin":
+			os = "mac"
+		}
+
+		archiveName := fmt.Sprintf("caddy_%s_%s_%s", version, os, runtime.GOARCH)
+		url := fmt.Sprintf("https://github.com/caddyserver/caddy/releases/download/v%s/%s.tar.gz", version, archiveName)
+
+		target := filepath.Join(root, fmt.Sprintf(".bin/caddy_%s", version))
+
+		return download.ArchivedExeuctable(url, target, "caddy")
+	},
+}
+
 func runWatch(
 	ctx context.Context,
 	cmd Command,
@@ -312,12 +357,23 @@ func runWatch(
 
 	for {
 		// Build it
-		if cmd.Install != "" {
+		if cmd.Install != "" || cmd.InstallFunc != "" {
 			if startedOnce {
 				std.Out.WriteLine(output.Styledf(output.StylePending, "Installing %s...", cmd.Name))
 			}
 
-			cmdOut, err := BashInRoot(ctx, cmd.Install, makeEnv(parentEnv, cmd.Env))
+			var cmdOut string
+			var err error
+			if cmd.Install != "" && cmd.InstallFunc == "" {
+				cmdOut, err = BashInRoot(ctx, cmd.Install, makeEnv(parentEnv, cmd.Env))
+			} else if cmd.Install == "" && cmd.InstallFunc != "" {
+				fn, ok := installFuncs[cmd.InstallFunc]
+				if !ok {
+					return errors.New("nope, no install func with that name")
+				}
+				err = fn(ctx, makeEnvMap(parentEnv, cmd.Env))
+			}
+
 			if err != nil {
 				if !startedOnce {
 					return installErr{cmdName: cmd.Name, output: cmdOut, originalErr: err}
@@ -425,9 +481,23 @@ func runWatch(
 // makeEnv merges environments starting from the left, meaning the first environment will be overriden by the second one, skipping
 // any key that has been explicitly defined in the current environment of this process. This enables users to manually overrides
 // environment variables explictly, i.e FOO=1 sg start will have FOO=1 set even if a command or commandset sets FOO.
-func makeEnv(envs ...map[string]string) []string {
-	combined := os.Environ()
-	expandedEnv := map[string]string{}
+func makeEnv(envs ...map[string]string) (combined []string) {
+	for k, v := range makeEnvMap(envs...) {
+		combined = append(combined, fmt.Sprintf("%s=%s", k, v))
+	}
+	return combined
+}
+
+func makeEnvMap(envs ...map[string]string) map[string]string {
+	combined := map[string]string{}
+	for _, pair := range os.Environ() {
+		elems := strings.SplitN(pair, "=", 2)
+		if len(elems) != 2 {
+			panic("space/time continuum wrong")
+		}
+
+		combined[elems[0]] = elems[1]
+	}
 
 	for _, env := range envs {
 		for k, v := range env {
@@ -457,8 +527,7 @@ func makeEnv(envs ...map[string]string) []string {
 				}
 				return os.Getenv(lookup)
 			})
-			expandedEnv[k] = expanded
-			combined = append(combined, fmt.Sprintf("%s=%s", k, expanded))
+			combined[k] = expanded
 		}
 	}
 

--- a/dev/sg/linters/hadolint.go
+++ b/dev/sg/linters/hadolint.go
@@ -78,7 +78,7 @@ func hadolint() lint.Runner {
 		// Download
 		os.MkdirAll("./.bin", os.ModePerm)
 		std.Out.WriteNoticef("Downloading hadolint from %s", url)
-		if err := download.Exeuctable(url, hadolintBinary); err != nil {
+		if err := download.Executable(url, hadolintBinary); err != nil {
 			return &lint.Report{
 				Header: header,
 				Err:    errors.Wrap(err, "downloading hadolint"),

--- a/dev/sg/sg_update.go
+++ b/dev/sg/sg_update.go
@@ -59,7 +59,7 @@ func updateToPrebuiltSG(ctx context.Context) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	if err := download.Exeuctable(downloadURL, currentExecPath); err != nil {
+	if err := download.Executable(downloadURL, currentExecPath); err != nil {
 		return "", err
 	}
 	return currentExecPath, nil

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -303,25 +303,6 @@ commands:
     ignoreStderr: true
     cmd: .bin/caddy_${CADDY_VERSION} run --watch --config=dev/Caddyfile
     install_func: installCaddy
-    # install: |
-    #   case "$(go env GOOS)" in
-    #     linux)
-    #       os="linux"
-    #       ;;
-    #     darwin)
-    #       os="mac"
-    #       ;;
-    #   esac
-    #   name="caddy_${CADDY_VERSION}_${os}_$(go env GOARCH)"
-    #   target="$PWD/.bin/caddy_${CADDY_VERSION}"
-    #   url="https://github.com/caddyserver/caddy/releases/download/v${CADDY_VERSION}/${name}.tar.gz"
-
-    #   if [ ! -f "${target}" ]; then
-    #     echo "downloading ${url}" 1>&2
-    #     curl -sS -L -f "${url}" | tar -xz --to-stdout "caddy" >"${target}.tmp"
-    #     mv "${target}.tmp" "${target}"
-    #     chmod +x "${target}"
-    #   fi
     env:
       CADDY_VERSION: 2.4.5
 

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -302,25 +302,26 @@ commands:
     ignoreStdout: true
     ignoreStderr: true
     cmd: .bin/caddy_${CADDY_VERSION} run --watch --config=dev/Caddyfile
-    install: |
-      case "$(go env GOOS)" in
-        linux)
-          os="linux"
-          ;;
-        darwin)
-          os="mac"
-          ;;
-      esac
-      name="caddy_${CADDY_VERSION}_${os}_$(go env GOARCH)"
-      target="$PWD/.bin/caddy_${CADDY_VERSION}"
-      url="https://github.com/caddyserver/caddy/releases/download/v${CADDY_VERSION}/${name}.tar.gz"
+    install_func: installCaddy
+    # install: |
+    #   case "$(go env GOOS)" in
+    #     linux)
+    #       os="linux"
+    #       ;;
+    #     darwin)
+    #       os="mac"
+    #       ;;
+    #   esac
+    #   name="caddy_${CADDY_VERSION}_${os}_$(go env GOARCH)"
+    #   target="$PWD/.bin/caddy_${CADDY_VERSION}"
+    #   url="https://github.com/caddyserver/caddy/releases/download/v${CADDY_VERSION}/${name}.tar.gz"
 
-      if [ ! -f "${target}" ]; then
-        echo "downloading ${url}" 1>&2
-        curl -sS -L -f "${url}" | tar -xz --to-stdout "caddy" >"${target}.tmp"
-        mv "${target}.tmp" "${target}"
-        chmod +x "${target}"
-      fi
+    #   if [ ! -f "${target}" ]; then
+    #     echo "downloading ${url}" 1>&2
+    #     curl -sS -L -f "${url}" | tar -xz --to-stdout "caddy" >"${target}.tmp"
+    #     mv "${target}.tmp" "${target}"
+    #     chmod +x "${target}"
+    #   fi
     env:
       CADDY_VERSION: 2.4.5
 


### PR DESCRIPTION
This removes the Caddy install script in bash from `sg.config.yaml` and replaces it with a built-in Go function that downloads the archive, extracts it and renames the binary.

## Test plan

- Tested this locally by running `rm -rf .bin/caddy-2.4.5 && go run ./dev/sg run caddy`
