### PR TITLE
fix creation of SG Home

### DIFF
--- a/dev/sg/root/root.go
+++ b/dev/sg/root/root.go
@@ -73,13 +73,17 @@ func findRoot(wd string) (string, error) {
 }
 
 func GetSGHomePath() (string, error) {
-	homedir, err := os.UserHomeDir()
+	homeDir, err := os.UserHomeDir()
 	if err != nil {
 		return "", err
 	}
 
-	path := filepath.Join(homedir, ".sourcegraph")
-	if err := os.MkdirAll(filepath.Dir(path), os.ModePerm); err != nil {
+    return createSGHome(homeDir)
+}
+
+func createSGHome(home string) (string, error) {
+	path := filepath.Join(home, ".sourcegraph")
+	if err := os.MkdirAll(path, os.ModePerm); err != nil {
 		return "", err
 	}
 	return path, nil

--- a/dev/sg/root/root_test.go
+++ b/dev/sg/root/root_test.go
@@ -1,0 +1,27 @@
+package root
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+
+
+func TestCreateSGHome(t *testing.T) {
+    testHome := os.TempDir()
+    actualHome, err := createSGHome(testHome)
+    defer func() {
+        os.Remove(actualHome)
+    }()
+
+    if err != nil {
+        t.Fatalf("error creating SG Home dir(.sourcegraph) at %q: %q", testHome, err)
+    }
+
+    wantedHome := filepath.Join(testHome, ".sourcegraph")
+    _, err = os.Stat(wantedHome)
+    if err != nil {
+        t.Errorf("failed to stat SG Home %q. Expected directory to be created\n", err)
+    }
+}


### PR DESCRIPTION
`filepath.Dir(path)` returned the users home directory and not `$HOME/.sourcegraph` ... so MkdirAll was a noop since the home directory existed. Removed the `filepath.Dir` 😄 

## Test plan
Added Unit test

