### PR TITLE
migration: Update use of `strings.Split`

### DIFF
--- a/internal/database/migration/cliutil/addlog.go
+++ b/internal/database/migration/cliutil/addlog.go
@@ -39,22 +39,22 @@ func AddLog(commandName string, factory RunnerFactory, outFactory OutputFactory)
 		}
 
 		var (
-			schemaNameFlag = cmd.String("db")
-			versionFlag    = cmd.Int("version")
-			upFlag         = cmd.Bool("up")
+			schemaName  = cmd.String("db")
+			versionFlag = cmd.Int("version")
+			upFlag      = cmd.Bool("up")
 		)
 
 		ctx := cmd.Context
-		r, err := factory(ctx, []string{schemaNameFlag})
+		r, err := factory(ctx, []string{schemaName})
 		if err != nil {
 			return err
 		}
-		store, err := r.Store(ctx, schemaNameFlag)
+		store, err := r.Store(ctx, schemaName)
 		if err != nil {
 			return err
 		}
 
-		log15.Info("Writing new completed migration log", "schema", schemaNameFlag, "version", versionFlag, "up", upFlag)
+		log15.Info("Writing new completed migration log", "schema", schemaName, "version", versionFlag, "up", upFlag)
 		return store.WithMigrationLog(ctx, definition.Definition{ID: versionFlag}, upFlag, noop)
 	}
 

--- a/internal/database/migration/cliutil/downto.go
+++ b/internal/database/migration/cliutil/downto.go
@@ -3,7 +3,6 @@ package cliutil
 import (
 	"flag"
 	"fmt"
-	"strconv"
 
 	"github.com/urfave/cli/v2"
 
@@ -50,22 +49,9 @@ func DownTo(commandName string, factory RunnerFactory, outFactory func() *output
 			targets                  = cmd.StringSlice("target")
 		)
 
-		if len(targets) == 1 || targets[0] == "" {
-			targets = nil
-		}
-		if len(targets) == 0 {
-			out.WriteLine(output.Linef("", output.StyleWarning, "ERROR: supply a target via -target"))
-			return flag.ErrHelp
-		}
-
-		versions := make([]int, 0, len(targets))
-		for _, target := range targets {
-			version, err := strconv.Atoi(target)
-			if err != nil {
-				return err
-			}
-
-			versions = append(versions, version)
+		versions, err := parseTargets(targets, out)
+		if err != nil {
+			return err
 		}
 
 		ctx := cmd.Context

--- a/internal/database/migration/cliutil/downto.go
+++ b/internal/database/migration/cliutil/downto.go
@@ -4,7 +4,6 @@ import (
 	"flag"
 	"fmt"
 	"strconv"
-	"strings"
 
 	"github.com/urfave/cli/v2"
 
@@ -19,7 +18,7 @@ func DownTo(commandName string, factory RunnerFactory, outFactory func() *output
 			Usage:    "The target `schema` to modify.",
 			Required: true,
 		},
-		&cli.StringFlag{
+		&cli.StringSliceFlag{
 			Name:     "target",
 			Usage:    `The migration to apply. Comma-separated values are accepted.`,
 			Required: true,
@@ -48,14 +47,16 @@ func DownTo(commandName string, factory RunnerFactory, outFactory func() *output
 			schemaNameFlag           = cmd.String("db")
 			unprivilegedOnlyFlag     = cmd.Bool("unprivileged-only")
 			ignoreSingleDirtyLogFlag = cmd.Bool("ignore-single-dirty-log")
-			targetsFlag              = cmd.String("target")
+			targets                  = cmd.StringSlice("target")
 		)
 
-		if targetsFlag == "" {
+		if len(targets) == 1 || targets[0] == "" {
+			targets = nil
+		}
+		if len(targets) == 0 {
 			out.WriteLine(output.Linef("", output.StyleWarning, "ERROR: supply a target via -target"))
 			return flag.ErrHelp
 		}
-		targets := strings.Split(targetsFlag, ",")
 
 		versions := make([]int, 0, len(targets))
 		for _, target := range targets {

--- a/internal/database/migration/cliutil/downto.go
+++ b/internal/database/migration/cliutil/downto.go
@@ -51,6 +51,10 @@ func DownTo(commandName string, factory RunnerFactory, outFactory func() *output
 			targetsFlag              = cmd.String("target")
 		)
 
+		if targetsFlag == "" {
+			out.WriteLine(output.Linef("", output.StyleWarning, "ERROR: supply a target via -target"))
+			return flag.ErrHelp
+		}
 		targets := strings.Split(targetsFlag, ",")
 
 		versions := make([]int, 0, len(targets))

--- a/internal/database/migration/cliutil/downto.go
+++ b/internal/database/migration/cliutil/downto.go
@@ -43,7 +43,7 @@ func DownTo(commandName string, factory RunnerFactory, outFactory func() *output
 		}
 
 		var (
-			schemaNameFlag           = cmd.String("db")
+			schemaName               = cmd.String("db")
 			unprivilegedOnlyFlag     = cmd.Bool("unprivileged-only")
 			ignoreSingleDirtyLogFlag = cmd.Bool("ignore-single-dirty-log")
 			targets                  = cmd.StringSlice("target")
@@ -55,7 +55,7 @@ func DownTo(commandName string, factory RunnerFactory, outFactory func() *output
 		}
 
 		ctx := cmd.Context
-		r, err := factory(ctx, []string{schemaNameFlag})
+		r, err := factory(ctx, []string{schemaName})
 		if err != nil {
 			return err
 		}
@@ -63,7 +63,7 @@ func DownTo(commandName string, factory RunnerFactory, outFactory func() *output
 		return r.Run(ctx, runner.Options{
 			Operations: []runner.MigrationOperation{
 				{
-					SchemaName:     schemaNameFlag,
+					SchemaName:     schemaName,
 					Type:           runner.MigrationOperationTypeTargetedDown,
 					TargetVersions: versions,
 				},

--- a/internal/database/migration/cliutil/undo.go
+++ b/internal/database/migration/cliutil/undo.go
@@ -33,17 +33,12 @@ func Undo(commandName string, factory RunnerFactory, outFactory func() *output.O
 		}
 
 		var (
-			schemaNameFlag           = cmd.String("db")
+			schemaName               = cmd.String("db")
 			ignoreSingleDirtyLogFlag = cmd.Bool("ignore-single-dirty-log")
 		)
 
-		if schemaNameFlag == "" {
-			out.WriteLine(output.Linef("", output.StyleWarning, "ERROR: supply a schema via -db"))
-			return flag.ErrHelp
-		}
-
 		ctx := cmd.Context
-		r, err := factory(ctx, []string{schemaNameFlag})
+		r, err := factory(ctx, []string{schemaName})
 		if err != nil {
 			return err
 		}
@@ -51,7 +46,7 @@ func Undo(commandName string, factory RunnerFactory, outFactory func() *output.O
 		return r.Run(ctx, runner.Options{
 			Operations: []runner.MigrationOperation{
 				{
-					SchemaName: schemaNameFlag,
+					SchemaName: schemaName,
 					Type:       runner.MigrationOperationTypeRevert,
 				},
 			},

--- a/internal/database/migration/cliutil/up.go
+++ b/internal/database/migration/cliutil/up.go
@@ -46,15 +46,11 @@ func Up(commandName string, factory RunnerFactory, outFactory func() *output.Out
 			ignoreSingleDirtyLogFlag = cmd.Bool("ignore-single-dirty-log")
 		)
 
-		schemaNames := strings.Split(schemaNameFlag, ",")
-		if len(schemaNames) == 0 {
+		if schemaNameFlag == "" {
 			out.WriteLine(output.Linef("", output.StyleWarning, "ERROR: supply a schema via -db"))
 			return flag.ErrHelp
 		}
-		if len(schemaNames) == 1 && schemaNames[0] == "all" {
-			schemaNames = schemas.SchemaNames
-		}
-		sort.Strings(schemaNames)
+		schemaNames := parseSchemas(schemaNameFlag)
 
 		operations := []runner.MigrationOperation{}
 		for _, schemaName := range schemaNames {
@@ -85,4 +81,14 @@ func Up(commandName string, factory RunnerFactory, outFactory func() *output.Out
 		Action:      action,
 		Description: ConstructLongHelp(),
 	}
+}
+
+func parseSchemas(schemaNameFlag string) []string {
+	if schemaNames := strings.Split(schemaNameFlag, ","); len(schemaNames) != 1 || schemaNames[0] != "all" {
+		sort.Strings(schemaNames)
+		return schemaNames
+	}
+
+	// Return "all" schemas
+	return schemas.SchemaNames
 }

--- a/internal/database/migration/cliutil/up.go
+++ b/internal/database/migration/cliutil/up.go
@@ -44,15 +44,9 @@ func Up(commandName string, factory RunnerFactory, outFactory func() *output.Out
 			ignoreSingleDirtyLogFlag = cmd.Bool("ignore-single-dirty-log")
 		)
 
-		if len(schemaNames) == 1 || schemaNames[0] == "" {
-			schemaNames = nil
-		}
-		if len(schemaNames) == 1 || schemaNames[0] == "all" {
-			schemaNames = schemas.SchemaNames
-		}
-		if len(schemaNames) == 0 {
-			out.WriteLine(output.Linef("", output.StyleWarning, "ERROR: supply a schema via -db"))
-			return flag.ErrHelp
+		schemaNames, err := parseSchemaNames(schemaNames, out)
+		if err != nil {
+			return err
 		}
 
 		operations := []runner.MigrationOperation{}
@@ -84,4 +78,21 @@ func Up(commandName string, factory RunnerFactory, outFactory func() *output.Out
 		Action:      action,
 		Description: ConstructLongHelp(),
 	}
+}
+
+func parseSchemaNames(schemaNames []string, out *output.Output) ([]string, error) {
+	if len(schemaNames) == 1 && schemaNames[0] == "" {
+		schemaNames = nil
+	}
+
+	if len(schemaNames) == 1 && schemaNames[0] == "all" {
+		schemaNames = schemas.SchemaNames
+	}
+
+	if len(schemaNames) == 0 {
+		out.WriteLine(output.Linef("", output.StyleWarning, "ERROR: supply a schema via -db"))
+		return nil, flag.ErrHelp
+	}
+
+	return schemaNames, nil
 }

--- a/internal/database/migration/cliutil/upto.go
+++ b/internal/database/migration/cliutil/upto.go
@@ -4,7 +4,6 @@ import (
 	"flag"
 	"fmt"
 	"strconv"
-	"strings"
 
 	"github.com/urfave/cli/v2"
 
@@ -19,7 +18,7 @@ func UpTo(commandName string, factory RunnerFactory, outFactory func() *output.O
 			Usage:    "The target `schema` to modify.",
 			Required: true,
 		},
-		&cli.StringFlag{
+		&cli.StringSliceFlag{
 			Name:     "target",
 			Usage:    "The `migration` to apply. Comma-separated values are accepted.",
 			Required: true,
@@ -48,14 +47,16 @@ func UpTo(commandName string, factory RunnerFactory, outFactory func() *output.O
 			schemaNameFlag           = cmd.String("db")
 			unprivilegedOnlyFlag     = cmd.Bool("unprivileged-only")
 			ignoreSingleDirtyLogFlag = cmd.Bool("ignore-single-dirty-log")
-			targetsFlag              = cmd.String("target")
+			targets                  = cmd.StringSlice("target")
 		)
 
-		if targetsFlag == "" {
+		if len(targets) == 1 || targets[0] == "" {
+			targets = nil
+		}
+		if len(targets) == 0 {
 			out.WriteLine(output.Linef("", output.StyleWarning, "ERROR: supply a target via -target"))
 			return flag.ErrHelp
 		}
-		targets := strings.Split(targetsFlag, ",")
 
 		versions := make([]int, 0, len(targets))
 		for _, target := range targets {

--- a/internal/database/migration/cliutil/upto.go
+++ b/internal/database/migration/cliutil/upto.go
@@ -51,6 +51,10 @@ func UpTo(commandName string, factory RunnerFactory, outFactory func() *output.O
 			targetsFlag              = cmd.String("target")
 		)
 
+		if targetsFlag == "" {
+			out.WriteLine(output.Linef("", output.StyleWarning, "ERROR: supply a target via -target"))
+			return flag.ErrHelp
+		}
 		targets := strings.Split(targetsFlag, ",")
 
 		versions := make([]int, 0, len(targets))

--- a/internal/database/migration/cliutil/upto.go
+++ b/internal/database/migration/cliutil/upto.go
@@ -44,7 +44,7 @@ func UpTo(commandName string, factory RunnerFactory, outFactory func() *output.O
 		}
 
 		var (
-			schemaNameFlag           = cmd.String("db")
+			schemaName               = cmd.String("db")
 			unprivilegedOnlyFlag     = cmd.Bool("unprivileged-only")
 			ignoreSingleDirtyLogFlag = cmd.Bool("ignore-single-dirty-log")
 			targets                  = cmd.StringSlice("target")
@@ -56,7 +56,7 @@ func UpTo(commandName string, factory RunnerFactory, outFactory func() *output.O
 		}
 
 		ctx := cmd.Context
-		r, err := factory(ctx, []string{schemaNameFlag})
+		r, err := factory(ctx, []string{schemaName})
 		if err != nil {
 			return err
 		}
@@ -64,7 +64,7 @@ func UpTo(commandName string, factory RunnerFactory, outFactory func() *output.O
 		return r.Run(ctx, runner.Options{
 			Operations: []runner.MigrationOperation{
 				{
-					SchemaName:     schemaNameFlag,
+					SchemaName:     schemaName,
 					Type:           runner.MigrationOperationTypeTargetedUp,
 					TargetVersions: versions,
 				},
@@ -85,7 +85,7 @@ func UpTo(commandName string, factory RunnerFactory, outFactory func() *output.O
 }
 
 func parseTargets(targets []string, out *output.Output) ([]int, error) {
-	if len(targets) == 1 || targets[0] == "" {
+	if len(targets) == 1 && targets[0] == "" {
 		targets = nil
 	}
 	if len(targets) == 0 {

--- a/internal/database/migration/cliutil/upto.go
+++ b/internal/database/migration/cliutil/upto.go
@@ -50,22 +50,9 @@ func UpTo(commandName string, factory RunnerFactory, outFactory func() *output.O
 			targets                  = cmd.StringSlice("target")
 		)
 
-		if len(targets) == 1 || targets[0] == "" {
-			targets = nil
-		}
-		if len(targets) == 0 {
-			out.WriteLine(output.Linef("", output.StyleWarning, "ERROR: supply a target via -target"))
-			return flag.ErrHelp
-		}
-
-		versions := make([]int, 0, len(targets))
-		for _, target := range targets {
-			version, err := strconv.Atoi(target)
-			if err != nil {
-				return err
-			}
-
-			versions = append(versions, version)
+		versions, err := parseTargets(targets, out)
+		if err != nil {
+			return err
 		}
 
 		ctx := cmd.Context
@@ -95,4 +82,26 @@ func UpTo(commandName string, factory RunnerFactory, outFactory func() *output.O
 		Flags:       flags,
 		Action:      exec,
 	}
+}
+
+func parseTargets(targets []string, out *output.Output) ([]int, error) {
+	if len(targets) == 1 || targets[0] == "" {
+		targets = nil
+	}
+	if len(targets) == 0 {
+		out.WriteLine(output.Linef("", output.StyleWarning, "ERROR: supply a target via -target"))
+		return nil, flag.ErrHelp
+	}
+
+	versions := make([]int, 0, len(targets))
+	for _, target := range targets {
+		version, err := strconv.Atoi(target)
+		if err != nil {
+			return nil, err
+		}
+
+		versions = append(versions, version)
+	}
+
+	return versions, nil
 }

--- a/internal/database/migration/cliutil/validate.go
+++ b/internal/database/migration/cliutil/validate.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/urfave/cli/v2"
 
-	"github.com/sourcegraph/sourcegraph/internal/database/migration/schemas"
 	"github.com/sourcegraph/sourcegraph/lib/output"
 )
 
@@ -26,17 +25,13 @@ func Validate(commandName string, factory RunnerFactory, outFactory func() *outp
 			return flag.ErrHelp
 		}
 
-		var schemaNames = cmd.StringSlice("db")
+		var (
+			schemaNames = cmd.StringSlice("db")
+		)
 
-		if len(schemaNames) == 1 || schemaNames[0] == "" {
-			schemaNames = nil
-		}
-		if len(schemaNames) == 1 || schemaNames[0] == "all" {
-			schemaNames = schemas.SchemaNames
-		}
-		if len(schemaNames) == 0 {
-			out.WriteLine(output.Linef("", output.StyleWarning, "ERROR: supply a schema via -db"))
-			return flag.ErrHelp
+		schemaNames, err := parseSchemaNames(schemaNames, out)
+		if err != nil {
+			return err
 		}
 
 		ctx := cmd.Context

--- a/internal/database/migration/cliutil/validate.go
+++ b/internal/database/migration/cliutil/validate.go
@@ -2,12 +2,9 @@ package cliutil
 
 import (
 	"flag"
-	"sort"
-	"strings"
 
 	"github.com/urfave/cli/v2"
 
-	"github.com/sourcegraph/sourcegraph/internal/database/migration/schemas"
 	"github.com/sourcegraph/sourcegraph/lib/output"
 )
 
@@ -30,15 +27,11 @@ func Validate(commandName string, factory RunnerFactory, outFactory func() *outp
 
 		var schemaNameFlag = cmd.String("db")
 
-		schemaNames := strings.Split(schemaNameFlag, ",")
-		if len(schemaNames) == 0 {
+		if schemaNameFlag == "" {
 			out.WriteLine(output.Linef("", output.StyleWarning, "ERROR: supply a schema via -db"))
 			return flag.ErrHelp
 		}
-		if len(schemaNames) == 1 && schemaNames[0] == "all" {
-			schemaNames = schemas.SchemaNames
-		}
-		sort.Strings(schemaNames)
+		schemaNames := parseSchemas(schemaNameFlag)
 
 		ctx := cmd.Context
 		r, err := factory(ctx, schemaNames)


### PR DESCRIPTION
Use `strings.Split` correctly in the migrator flag parser.

## Test plan

Ran operations by hand via sg.