### PR TITLE
dev/sg: remove parseCSV from flags

### DIFF
--- a/dev/sg/sg_start.go
+++ b/dev/sg/sg_start.go
@@ -221,11 +221,11 @@ func startCommandSet(ctx context.Context, set *sgconf.Commandset, conf *sgconf.C
 // logLevelOverrides builds a map of commands -> log level that should be overridden in the environment.
 func logLevelOverrides() map[string]string {
 	levelServices := make(map[string][]string)
-	levelServices["debug"] = parseCsvs(debugStartServices.Value())
-	levelServices["info"] = parseCsvs(infoStartServices.Value())
-	levelServices["warn"] = parseCsvs(warnStartServices.Value())
-	levelServices["error"] = parseCsvs(errorStartServices.Value())
-	levelServices["crit"] = parseCsvs(critStartServices.Value())
+	levelServices["debug"] = debugStartServices.Value()
+	levelServices["info"] = infoStartServices.Value()
+	levelServices["warn"] = warnStartServices.Value()
+	levelServices["error"] = errorStartServices.Value()
+	levelServices["crit"] = critStartServices.Value()
 
 	overrides := make(map[string]string)
 	for level, services := range levelServices {
@@ -260,23 +260,4 @@ func pathExists(path string) (bool, error) {
 		return false, nil
 	}
 	return false, err
-}
-
-func parseCsvs(inputs []string) []string {
-	var allValues []string
-	for _, i := range inputs {
-		values := parseCsv(i)
-		allValues = append(allValues, values...)
-	}
-	return allValues
-}
-
-// parseCsv takes an input comma seperated string and returns a list of tokens each trimmed for whitespace
-func parseCsv(input string) []string {
-	tokens := strings.Split(input, ",")
-	results := make([]string, 0, len(tokens))
-	for _, token := range tokens {
-		results = append(results, strings.TrimSpace(token))
-	}
-	return results
 }


### PR DESCRIPTION
Both comma-delimited and multiple arguments are supported out of the box :)

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Comma-delimited:

```
➜  sourcegraph git:(main) ✗ go run ./dev/sg start -e enterprise-frontend,enterprise-worker
💡 Running 4 checks...
✅ Check "redis" success!
✅ Check "postgres" success!
✅ Check "git" success!
✅ Check "docker" success!
Setting log level: error for command enterprise-frontend.
Setting log level: error for command enterprise-worker.
```

Multiple args:

```
➜  sourcegraph git:(main) ✗ go run ./dev/sg start -e enterprise-frontend -e enterprise-worker
💡 Running 4 checks...
✅ Check "git" success!
✅ Check "docker" success!
✅ Check "redis" success!
✅ Check "postgres" success!
Setting log level: error for command enterprise-frontend.
Setting log level: error for command enterprise-worker.
```
