### PR TITLE
squirrel: Add boilerplate for tree-sitter traversals

### DIFF
--- a/cmd/symbols/squirrel/hover_test.go
+++ b/cmd/symbols/squirrel/hover_test.go
@@ -97,9 +97,3 @@ namespace Foo {
 		}
 	}
 }
-
-func fatalIfError(t *testing.T, err error) {
-	if err != nil {
-		t.Fatal(err)
-	}
-}

--- a/cmd/symbols/squirrel/hover_test.go
+++ b/cmd/symbols/squirrel/hover_test.go
@@ -65,7 +65,7 @@ namespace Foo {
 		return nil, errors.Newf("path %s not found", path.Path)
 	}
 
-	squirrel := NewSquirrelService(readFile)
+	squirrel := NewSquirrelService(readFile, nil)
 	defer squirrel.Close()
 
 	for _, test := range tests {

--- a/cmd/symbols/squirrel/http_handlers.go
+++ b/cmd/symbols/squirrel/http_handlers.go
@@ -36,7 +36,7 @@ func LocalCodeIntelHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	squirrel := NewSquirrelService(readFileFromGitserver)
+	squirrel := NewSquirrelService(readFileFromGitserver, nil)
 	defer squirrel.Close()
 
 	// Compute the local code intel payload.
@@ -94,8 +94,29 @@ func NewSymbolInfoHandler(symbolSearch symbolsTypes.SearchFunc) func(w http.Resp
 			return
 		}
 
-		// TODO find the symbol.
-		var result *types.SymbolInfo
+		// Find the symbol.
+		squirrel := NewSquirrelService(readFileFromGitserver, symbolSearch)
+		defer squirrel.Close()
+		result, err := squirrel.symbolInfo(r.Context(), args)
+		if os.Getenv("SQUIRREL_DEBUG") == "true" {
+			debugStringBuilder := &strings.Builder{}
+			fmt.Fprintln(debugStringBuilder, "👉 /symbolInfo repo:", args.Repo, "commit:", args.Commit, "path:", args.Path, "row:", args.Row, "column:", args.Column)
+			prettyPrintBreadcrumbs(debugStringBuilder, squirrel.breadcrumbs, readFileFromGitserver)
+			if result == nil {
+				fmt.Fprintln(debugStringBuilder, "❌ no definition found")
+			} else {
+				fmt.Fprintln(debugStringBuilder, "✅ /symbolInfo", *result)
+			}
+
+			fmt.Println(" ")
+			fmt.Println(bracket(debugStringBuilder.String()))
+			fmt.Println(" ")
+		}
+		if err != nil {
+			_ = json.NewEncoder(w).Encode(nil)
+			log15.Error("failed to get definition", "err", err)
+			return
+		}
 
 		// Write the response.
 		w.Header().Set("Content-Type", "application/json")
@@ -130,7 +151,7 @@ func DebugLocalCodeIntelHandler(w http.ResponseWriter, r *http.Request) {
 		return os.ReadFile("/tmp/squirrel-example.txt")
 	}
 
-	squirrel := NewSquirrelService(readFile)
+	squirrel := NewSquirrelService(readFile, nil)
 	defer squirrel.Close()
 
 	rangeToSymbolIx := map[types.Range]int{}

--- a/cmd/symbols/squirrel/languages.go
+++ b/cmd/symbols/squirrel/languages.go
@@ -46,6 +46,7 @@ var extToLang = func() map[string]string {
 
 // Info about a language.
 type LangSpec struct {
+	name         string
 	language     *sitter.Language
 	commentStyle CommentStyle
 	// localsQuery is a tree-sitter localsQuery that finds scopes and defs.
@@ -67,6 +68,7 @@ var javaStyleIgnoreRegex = regexp.MustCompile(`^\s*(/\*\*|\*/)\s*$`)
 // Mapping from language name to language specification.
 var langToLangSpec = map[string]LangSpec{
 	"java": {
+		name:     "java",
 		language: java.GetLanguage(),
 		commentStyle: CommentStyle{
 			nodeTypes:     []string{"comment"},
@@ -93,6 +95,7 @@ var langToLangSpec = map[string]LangSpec{
 `,
 	},
 	"go": {
+		name:     "go",
 		language: golang.GetLanguage(),
 		commentStyle: CommentStyle{
 			nodeTypes:     []string{"comment"},
@@ -118,6 +121,7 @@ var langToLangSpec = map[string]LangSpec{
 `,
 	},
 	"csharp": {
+		name:     "csharp",
 		language: csharp.GetLanguage(),
 		commentStyle: CommentStyle{
 			nodeTypes:     []string{"comment"},
@@ -142,6 +146,7 @@ var langToLangSpec = map[string]LangSpec{
 `,
 	},
 	"python": {
+		name:     "python",
 		language: python.GetLanguage(),
 		commentStyle: CommentStyle{
 			nodeTypes:     []string{"comment"},
@@ -168,6 +173,7 @@ var langToLangSpec = map[string]LangSpec{
 `,
 	},
 	"javascript": {
+		name:     "javascript",
 		language: javascript.GetLanguage(),
 		commentStyle: CommentStyle{
 			nodeTypes:     []string{"comment"},
@@ -201,6 +207,7 @@ var langToLangSpec = map[string]LangSpec{
 `,
 	},
 	"typescript": {
+		name:     "typescript",
 		language: tsx.GetLanguage(),
 		commentStyle: CommentStyle{
 			nodeTypes:     []string{"comment"},
@@ -234,6 +241,7 @@ var langToLangSpec = map[string]LangSpec{
 `,
 	},
 	"cpp": {
+		name:     "cpp",
 		language: cpp.GetLanguage(),
 		commentStyle: CommentStyle{
 			nodeTypes:     []string{"comment"},
@@ -258,6 +266,7 @@ var langToLangSpec = map[string]LangSpec{
 `,
 	},
 	"ruby": {
+		name:     "ruby",
 		language: ruby.GetLanguage(),
 		commentStyle: CommentStyle{
 			nodeTypes:     []string{"comment"},

--- a/cmd/symbols/squirrel/local_code_intel_test.go
+++ b/cmd/symbols/squirrel/local_code_intel_test.go
@@ -386,7 +386,7 @@ func getLocalCodeIntel(t *testing.T, path types.RepoCommitPath, contents string)
 		return []byte(contents), nil
 	}
 
-	squirrel := NewSquirrelService(readFile)
+	squirrel := NewSquirrelService(readFile, nil)
 	defer squirrel.Close()
 
 	payload, err := squirrel.localCodeIntel(context.Background(), path)

--- a/cmd/symbols/squirrel/service.go
+++ b/cmd/symbols/squirrel/service.go
@@ -5,6 +5,7 @@ import (
 
 	sitter "github.com/smacker/go-tree-sitter"
 
+	symbolsTypes "github.com/sourcegraph/sourcegraph/cmd/symbols/types"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/types"
@@ -14,19 +15,24 @@ import (
 // How to read a file.
 type ReadFileFunc func(context.Context, types.RepoCommitPath) ([]byte, error)
 
-// SquirrelService uses tree-sitter to analyze code and collect symbols.
+// SquirrelService uses tree-sitter and the symbols service to analyze and traverse files to find
+// symbols.
 type SquirrelService struct {
-	readFile  ReadFileFunc
-	parser    *sitter.Parser
-	closables []func()
+	readFile     ReadFileFunc
+	symbolSearch symbolsTypes.SearchFunc
+	breadcrumbs  []Breadcrumb
+	parser       *sitter.Parser
+	closables    []func()
 }
 
 // Creates a new SquirrelService.
-func NewSquirrelService(readFile ReadFileFunc) *SquirrelService {
+func NewSquirrelService(readFile ReadFileFunc, symbolSearch symbolsTypes.SearchFunc) *SquirrelService {
 	return &SquirrelService{
-		readFile:  readFile,
-		parser:    sitter.NewParser(),
-		closables: []func(){},
+		readFile:     readFile,
+		symbolSearch: symbolSearch,
+		breadcrumbs:  []Breadcrumb{},
+		parser:       sitter.NewParser(),
+		closables:    []func(){},
 	}
 }
 
@@ -38,6 +44,68 @@ func (squirrel *SquirrelService) Close() {
 	squirrel.parser.Close()
 }
 
+// symbolInfo finds the symbol at the given point in a file.
+func (squirrel *SquirrelService) symbolInfo(ctx context.Context, point types.RepoCommitPathPoint) (*types.SymbolInfo, error) {
+	// First, find the definition.
+	var def *types.RepoCommitPathRange
+	{
+		// Parse the file and find the starting node.
+		root, err := squirrel.parse(ctx, point.RepoCommitPath)
+		if err != nil {
+			return nil, err
+		}
+		startNode := root.NamedDescendantForPointRange(
+			sitter.Point{Row: uint32(point.Row), Column: uint32(point.Column)},
+			sitter.Point{Row: uint32(point.Row), Column: uint32(point.Column)},
+		)
+		if startNode == nil {
+			return nil, errors.New("node is nil")
+		}
+
+		// Now find the definition.
+		foundPkgOrNode, err := squirrel.getDef(ctx, WithNodePtr(*root, startNode))
+		if err != nil {
+			return nil, err
+		}
+		if foundPkgOrNode == nil {
+			return nil, nil
+		}
+		if foundPkgOrNode.Node != nil {
+			def = &types.RepoCommitPathRange{
+				RepoCommitPath: foundPkgOrNode.Node.RepoCommitPath,
+				Range:          nodeToRange(foundPkgOrNode.Node.Node),
+			}
+		}
+	}
+
+	// Then get the hover if it exists.
+	var hover *string
+	if def != nil {
+		// Parse the END file and find the end node.
+		root, err := squirrel.parse(ctx, def.RepoCommitPath)
+		if err != nil {
+			return nil, err
+		}
+		endNode := root.NamedDescendantForPointRange(
+			sitter.Point{Row: uint32(def.Row), Column: uint32(def.Column)},
+			sitter.Point{Row: uint32(def.Row), Column: uint32(def.Column)},
+		)
+		if endNode == nil {
+			return nil, errors.Newf("no node at %d:%d", def.Row, def.Column)
+		}
+
+		// Now find the hover.
+		s := findHover(WithNode(*root, endNode))
+		hover = &s
+	}
+
+	// We have a def, and maybe a hover.
+	return &types.SymbolInfo{
+		Definition: *def,
+		Hover:      hover,
+	}, nil
+}
+
 // How to read a file from gitserver.
 func readFileFromGitserver(ctx context.Context, repoCommitPath types.RepoCommitPath) ([]byte, error) {
 	cmd := gitserver.NewClient(nil).GitCommand(api.RepoName(repoCommitPath.Repo), "cat-file", "blob", repoCommitPath.Commit+":"+repoCommitPath.Path)
@@ -46,4 +114,29 @@ func readFileFromGitserver(ctx context.Context, repoCommitPath types.RepoCommitP
 		return nil, errors.Newf("failed to get file contents: %s\n\nstdout:\n\n%s\n\nstderr:\n\n%s", err, stdout, stderr)
 	}
 	return stdout, nil
+}
+
+// DirOrNode is a union type that can either be a directory or a node. It's returned by getDef().
+//
+// - It's usually   a Node, e.g. when finding the definition of an identifier
+// - It's sometimes a Dir , e.g. when finding the definition of a  Go package
+type DirOrNode struct {
+	Dir  *types.RepoCommitPath
+	Node *Node
+}
+
+func (squirrel *SquirrelService) getDef(ctx context.Context, node *Node) (*DirOrNode, error) {
+	switch node.LangSpec.name {
+	// case "java":
+	// case "go":
+	// case "csharp":
+	// case "python":
+	// case "javascript":
+	// case "typescript":
+	// case "cpp":
+	// case "ruby":
+	default:
+		// Language not implemented yet
+		return nil, nil
+	}
 }

--- a/cmd/symbols/squirrel/service_test.go
+++ b/cmd/symbols/squirrel/service_test.go
@@ -1,0 +1,112 @@
+package squirrel
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/sourcegraph/sourcegraph/internal/types"
+)
+
+func TestNonLocalDefinition(t *testing.T) {
+	repoDirs, err := os.ReadDir("test_repos")
+	fatalIfErrorLabel(t, err, "reading test_repos")
+
+	annotations := []annotation{}
+
+	for _, repoDir := range repoDirs {
+		if !repoDir.IsDir() {
+			t.Fatalf("unexpected file %s", repoDir.Name())
+		}
+
+		base := filepath.Join("test_repos", repoDir.Name())
+		err := filepath.Walk(base, func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+
+			if info.IsDir() {
+				return nil
+			}
+
+			contents, err := os.ReadFile(path)
+			fatalIfErrorLabel(t, err, "reading annotations from a file")
+
+			rel, err := filepath.Rel(base, path)
+			fatalIfErrorLabel(t, err, "getting relative path")
+			repoCommitPath := types.RepoCommitPath{Repo: repoDir.Name(), Commit: "abc", Path: rel}
+
+			annotations = append(annotations, collectAnnotations(repoCommitPath, string(contents))...)
+
+			return nil
+		})
+		fatalIfErrorLabel(t, err, "walking a repo dir")
+	}
+
+	readFile := func(ctx context.Context, path types.RepoCommitPath) ([]byte, error) {
+		contents, err := os.ReadFile(filepath.Join("test_repos", path.Repo, path.Path))
+		fatalIfErrorLabel(t, err, "reading a file")
+		return contents, nil
+	}
+
+	squirrel := NewSquirrelService(readFile, nil)
+	defer squirrel.Close()
+
+	for symbol, m := range groupBySymbolAndKind(annotations) {
+		var wantDef *annotation
+		for _, ann := range m["def"] {
+			if wantDef != nil {
+				t.Fatalf("multiple definitions for symbol %s", symbol)
+			}
+
+			annCopy := ann
+			wantDef = &annCopy
+		}
+
+		if wantDef == nil {
+			t.Fatalf("no definition for symbol %s", symbol)
+		}
+
+		for _, ref := range m["ref"] {
+			got, err := squirrel.symbolInfo(context.Background(), ref.repoCommitPathPoint)
+			fatalIfErrorLabel(t, err, "symbolInfo")
+
+			if got == nil {
+				t.Fatalf("no symbolInfo for symbol %s", symbol)
+			}
+
+			gotDef := types.RepoCommitPathPoint{
+				RepoCommitPath: got.Definition.RepoCommitPath,
+				Point: types.Point{
+					Row:    got.Definition.Row,
+					Column: got.Definition.Column,
+				},
+			}
+
+			if diff := cmp.Diff(wantDef.repoCommitPathPoint, gotDef); diff != "" {
+				t.Fatalf("wrong definition (-want +got):\n%s", diff)
+			}
+		}
+	}
+}
+
+func groupBySymbolAndKind(annotations []annotation) map[string]map[string][]annotation {
+	grouped := map[string]map[string][]annotation{}
+
+	for _, a := range annotations {
+		if _, ok := grouped[a.symbol]; !ok {
+			grouped[a.symbol] = map[string][]annotation{}
+		}
+
+		if _, ok := grouped[a.symbol][a.kind]; !ok {
+			grouped[a.symbol][a.kind] = []annotation{}
+		}
+
+		grouped[a.symbol][a.kind] = append(grouped[a.symbol][a.kind], a)
+	}
+
+	return grouped
+}

--- a/cmd/symbols/squirrel/util.go
+++ b/cmd/symbols/squirrel/util.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"strings"
+	"testing"
 
 	sitter "github.com/smacker/go-tree-sitter"
 
@@ -243,4 +244,16 @@ func (s *SquirrelService) parse(ctx context.Context, repoCommitPath types.RepoCo
 	}
 
 	return &Node{RepoCommitPath: repoCommitPath, Node: root, Contents: contents, LangSpec: langSpec}, nil
+}
+
+func fatalIfError(t *testing.T, err error) {
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func fatalIfErrorLabel(t *testing.T, err error, label string) {
+	if err != nil {
+		t.Fatalf("%s: %s", label, err)
+	}
 }


### PR DESCRIPTION
Part of https://github.com/sourcegraph/sourcegraph/issues/35031

- Adds a test framework for defs
- Fills in the HTTP handler
- Adds a stub `getDef()` method

## Test plan

N/A