### PR TITLE
dependencies: Supplement dependencies requests with existing LSIF data

### DIFF
--- a/internal/codeintel/dependencies/iface.go
+++ b/internal/codeintel/dependencies/iface.go
@@ -8,11 +8,14 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/dependencies/internal/lockfiles"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/dependencies/internal/store"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/dependencies/shared"
+	"github.com/sourcegraph/sourcegraph/internal/codeintel/types"
 	"github.com/sourcegraph/sourcegraph/internal/conf/reposource"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 )
 
 type Store interface {
+	PreciseDependencies(ctx context.Context, repoName, commit string) (map[api.RepoName]types.RevSpecSet, error)
+	PreciseDependents(ctx context.Context, repoName, commit string) (map[api.RepoName]types.RevSpecSet, error)
 	LockfileDependencies(ctx context.Context, repoName, commit string) ([]shared.PackageDependency, bool, error)
 	UpsertLockfileDependencies(ctx context.Context, repoName, commit string, deps []shared.PackageDependency) error
 	SelectRepoRevisionsToResolve(ctx context.Context, batchSize int, minimumCheckInterval time.Duration) (map[string][]string, error)

--- a/internal/codeintel/dependencies/init.go
+++ b/internal/codeintel/dependencies/init.go
@@ -26,7 +26,8 @@ var (
 var (
 	lockfilesSemaphoreWeight = env.MustGetInt("CODEINTEL_DEPENDENCIES_LOCKFILES_SEMAPHORE_WEIGHT", 64, "The maximum number of concurrent routines parsing lockfile contents.")
 	syncerSemaphoreWeight    = env.MustGetInt("CODEINTEL_DEPENDENCIES_LOCKFILES_SYNCER_WEIGHT", 64, "The maximum number of concurrent routines actively syncing repositories.")
-	enableUpserts            = env.Get("CODEINTEL_DEPENDENCIES_ENABLE_UPSERTS", "", "Disable writes of lockfile results to the database from the dependencies service.") != ""
+	enableUpserts            = env.Get("CODEINTEL_DEPENDENCIES_ENABLE_UPSERTS", "", "Enables writes of lockfile results to the database from the dependencies service.") != ""
+	enablePreciseQueries     = env.Get("CODEINTEL_DEPENDENCIES_ENABLE_PRECISE_QUERIES", "", "Enables queries of precise code intelligence results from the database from the dependencies service.") != ""
 )
 
 // GetService creates or returns an already-initialized dependencies service. If the service is

--- a/internal/codeintel/dependencies/internal/store/observability.go
+++ b/internal/codeintel/dependencies/internal/store/observability.go
@@ -12,6 +12,8 @@ type operations struct {
 	listDependencyRepos          *observation.Operation
 	lockfileDependencies         *observation.Operation
 	lockfileDependents           *observation.Operation
+	preciseDependencies          *observation.Operation
+	preciseDependents            *observation.Operation
 	selectRepoRevisionsToResolve *observation.Operation
 	updateResolvedRevisions      *observation.Operation
 	upsertDependencyRepos        *observation.Operation
@@ -39,6 +41,8 @@ func newOperations(observationContext *observation.Context) *operations {
 		listDependencyRepos:          op("ListDependencyRepos"),
 		lockfileDependencies:         op("LockfileDependencies"),
 		lockfileDependents:           op("LockfileDependents"),
+		preciseDependencies:          op("PreciseDependencies"),
+		preciseDependents:            op("PreciseDependents"),
 		selectRepoRevisionsToResolve: op("SelectRepoRevisionsToResolve"),
 		updateResolvedRevisions:      op("UpdateResolvedRevisions"),
 		upsertDependencyRepos:        op("UpsertDependencyRepos"),

--- a/internal/codeintel/dependencies/internal/store/scan.go
+++ b/internal/codeintel/dependencies/internal/store/scan.go
@@ -3,9 +3,13 @@ package store
 import (
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/dependencies/shared"
+	"github.com/sourcegraph/sourcegraph/internal/codeintel/types"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 )
+
+//
+// Scans `[]shared.PackageDepencency`
 
 var scanPackageDependencies = basestore.NewSliceScanner(func(s dbutil.Scanner) (shared.PackageDependency, error) {
 	var v shared.PackageDependencyLiteral
@@ -13,16 +17,46 @@ var scanPackageDependencies = basestore.NewSliceScanner(func(s dbutil.Scanner) (
 	return v, err
 })
 
+//
+// Scans `[]api.RepoCommit`
+
 var scanRepoCommits = basestore.NewSliceScanner(func(s dbutil.Scanner) (api.RepoCommit, error) {
 	var v api.RepoCommit
 	err := s.Scan(&v.Repo, &v.CommitID)
 	return v, err
 })
 
+//
+// Scans `map[api.RepoName]types.RevSpecSet`
+
+var scanRepoRevSpecSets = basestore.NewKeyedCollectionScanner[api.RepoName, api.RevSpec, types.RevSpecSet](scanRepoNameRevSpecPair, revSpecSetReducer{})
+
+var scanRepoNameRevSpecPair = func(s dbutil.Scanner) (repoName api.RepoName, revSpec api.RevSpec, _ error) {
+	err := s.Scan(&repoName, &revSpec)
+	return repoName, revSpec, err
+}
+
+type revSpecSetReducer struct{}
+
+func (r revSpecSetReducer) Create() types.RevSpecSet {
+	return types.RevSpecSet{}
+}
+
+func (r revSpecSetReducer) Reduce(collection types.RevSpecSet, value api.RevSpec) types.RevSpecSet {
+	collection[value] = struct{}{}
+	return collection
+}
+
+//
+// Scans `shared.Repo`
+
 func scanDependencyRepo(s dbutil.Scanner) (shared.Repo, error) {
 	var v shared.Repo
 	err := s.Scan(&v.ID, &v.Scheme, &v.Name, &v.Version)
 	return v, err
 }
+
+//
+// Scans `[]shared.Repo`
 
 var scanDependencyRepos = basestore.NewSliceScanner(scanDependencyRepo)

--- a/internal/codeintel/dependencies/internal/store/store.go
+++ b/internal/codeintel/dependencies/internal/store/store.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/dependencies/shared"
+	"github.com/sourcegraph/sourcegraph/internal/codeintel/types"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/database/batch"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
@@ -47,6 +48,54 @@ func (s *Store) Transact(ctx context.Context) (*Store, error) {
 		operations: s.operations,
 	}, nil
 }
+
+// PreciseDependencies returns package dependencies from precise indexes. It is assumed that
+// the given commit is the canonical 40-character hash.
+func (s *Store) PreciseDependencies(ctx context.Context, repoName, commit string) (deps map[api.RepoName]types.RevSpecSet, err error) {
+	ctx, _, endObservation := s.operations.preciseDependencies.With(ctx, &err, observation.Args{LogFields: []log.Field{
+		log.String("repoName", repoName),
+		log.String("commit", commit),
+	}})
+	defer endObservation(1, observation.Args{})
+
+	return scanRepoRevSpecSets(s.Query(ctx, sqlf.Sprintf(preciseDependenciesQuery, repoName, commit)))
+}
+
+const preciseDependenciesQuery = `
+-- source: internal/codeintel/dependencies/internal/store/store.go:PreciseDependencies
+SELECT pr.name, pu.commit
+FROM lsif_packages lp
+JOIN lsif_uploads pu ON pu.id = lp.dump_id
+JOIN repo pr ON pr.id = pu.repository_id
+JOIN lsif_references lr ON lr.scheme = lp.scheme AND lr.name = lp.name AND lr.version = lp.version
+JOIN lsif_uploads ru ON ru.id = lr.dump_id
+JOIN repo rr ON rr.id = ru.repository_id
+WHERE rr.name = %s AND ru.commit = %s
+`
+
+// PreciseDependents returns package dependents from precise indexes. It is assumed that
+// the given commit is the canonical 40-character hash.
+func (s *Store) PreciseDependents(ctx context.Context, repoName, commit string) (deps map[api.RepoName]types.RevSpecSet, err error) {
+	ctx, _, endObservation := s.operations.preciseDependents.With(ctx, &err, observation.Args{LogFields: []log.Field{
+		log.String("repoName", repoName),
+		log.String("commit", commit),
+	}})
+	defer endObservation(1, observation.Args{})
+
+	return scanRepoRevSpecSets(s.Query(ctx, sqlf.Sprintf(preciseDependentsQuery, repoName, commit)))
+}
+
+const preciseDependentsQuery = `
+-- source: internal/codeintel/dependencies/internal/store/store.go:PreciseDependents
+SELECT rr.name, ru.commit
+FROM lsif_packages lp
+JOIN lsif_uploads pu ON pu.id = lp.dump_id
+JOIN repo pr ON pr.id = pu.repository_id
+JOIN lsif_references lr ON lr.scheme = lp.scheme AND lr.name = lp.name AND lr.version = lp.version
+JOIN lsif_uploads ru ON ru.id = lr.dump_id
+JOIN repo rr ON rr.id = ru.repository_id
+WHERE pr.name = %s AND pu.commit = %s
+`
 
 // LockfileDependencies returns package dependencies from a previous lockfiles result for
 // the given repository and commit. It is assumed that the given commit is the canonical

--- a/internal/codeintel/dependencies/mock_iface_test.go
+++ b/internal/codeintel/dependencies/mock_iface_test.go
@@ -10,6 +10,7 @@ import (
 	api "github.com/sourcegraph/sourcegraph/internal/api"
 	store "github.com/sourcegraph/sourcegraph/internal/codeintel/dependencies/internal/store"
 	shared "github.com/sourcegraph/sourcegraph/internal/codeintel/dependencies/shared"
+	types "github.com/sourcegraph/sourcegraph/internal/codeintel/types"
 	reposource "github.com/sourcegraph/sourcegraph/internal/conf/reposource"
 	gitdomain "github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 )
@@ -192,6 +193,12 @@ type MockStore struct {
 	// LockfileDependentsFunc is an instance of a mock function object
 	// controlling the behavior of the method LockfileDependents.
 	LockfileDependentsFunc *StoreLockfileDependentsFunc
+	// PreciseDependenciesFunc is an instance of a mock function object
+	// controlling the behavior of the method PreciseDependencies.
+	PreciseDependenciesFunc *StorePreciseDependenciesFunc
+	// PreciseDependentsFunc is an instance of a mock function object
+	// controlling the behavior of the method PreciseDependents.
+	PreciseDependentsFunc *StorePreciseDependentsFunc
 	// SelectRepoRevisionsToResolveFunc is an instance of a mock function
 	// object controlling the behavior of the method
 	// SelectRepoRevisionsToResolve.
@@ -229,6 +236,16 @@ func NewMockStore() *MockStore {
 		},
 		LockfileDependentsFunc: &StoreLockfileDependentsFunc{
 			defaultHook: func(context.Context, string, string) (r0 []api.RepoCommit, r1 error) {
+				return
+			},
+		},
+		PreciseDependenciesFunc: &StorePreciseDependenciesFunc{
+			defaultHook: func(context.Context, string, string) (r0 map[api.RepoName]types.RevSpecSet, r1 error) {
+				return
+			},
+		},
+		PreciseDependentsFunc: &StorePreciseDependentsFunc{
+			defaultHook: func(context.Context, string, string) (r0 map[api.RepoName]types.RevSpecSet, r1 error) {
 				return
 			},
 		},
@@ -279,6 +296,16 @@ func NewStrictMockStore() *MockStore {
 				panic("unexpected invocation of MockStore.LockfileDependents")
 			},
 		},
+		PreciseDependenciesFunc: &StorePreciseDependenciesFunc{
+			defaultHook: func(context.Context, string, string) (map[api.RepoName]types.RevSpecSet, error) {
+				panic("unexpected invocation of MockStore.PreciseDependencies")
+			},
+		},
+		PreciseDependentsFunc: &StorePreciseDependentsFunc{
+			defaultHook: func(context.Context, string, string) (map[api.RepoName]types.RevSpecSet, error) {
+				panic("unexpected invocation of MockStore.PreciseDependents")
+			},
+		},
 		SelectRepoRevisionsToResolveFunc: &StoreSelectRepoRevisionsToResolveFunc{
 			defaultHook: func(context.Context, int, time.Duration) (map[string][]string, error) {
 				panic("unexpected invocation of MockStore.SelectRepoRevisionsToResolve")
@@ -317,6 +344,12 @@ func NewMockStoreFrom(i Store) *MockStore {
 		},
 		LockfileDependentsFunc: &StoreLockfileDependentsFunc{
 			defaultHook: i.LockfileDependents,
+		},
+		PreciseDependenciesFunc: &StorePreciseDependenciesFunc{
+			defaultHook: i.PreciseDependencies,
+		},
+		PreciseDependentsFunc: &StorePreciseDependentsFunc{
+			defaultHook: i.PreciseDependents,
 		},
 		SelectRepoRevisionsToResolveFunc: &StoreSelectRepoRevisionsToResolveFunc{
 			defaultHook: i.SelectRepoRevisionsToResolve,
@@ -777,6 +810,228 @@ func (c StoreLockfileDependentsFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c StoreLockfileDependentsFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
+}
+
+// StorePreciseDependenciesFunc describes the behavior when the
+// PreciseDependencies method of the parent MockStore instance is invoked.
+type StorePreciseDependenciesFunc struct {
+	defaultHook func(context.Context, string, string) (map[api.RepoName]types.RevSpecSet, error)
+	hooks       []func(context.Context, string, string) (map[api.RepoName]types.RevSpecSet, error)
+	history     []StorePreciseDependenciesFuncCall
+	mutex       sync.Mutex
+}
+
+// PreciseDependencies delegates to the next hook function in the queue and
+// stores the parameter and result values of this invocation.
+func (m *MockStore) PreciseDependencies(v0 context.Context, v1 string, v2 string) (map[api.RepoName]types.RevSpecSet, error) {
+	r0, r1 := m.PreciseDependenciesFunc.nextHook()(v0, v1, v2)
+	m.PreciseDependenciesFunc.appendCall(StorePreciseDependenciesFuncCall{v0, v1, v2, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the PreciseDependencies
+// method of the parent MockStore instance is invoked and the hook queue is
+// empty.
+func (f *StorePreciseDependenciesFunc) SetDefaultHook(hook func(context.Context, string, string) (map[api.RepoName]types.RevSpecSet, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// PreciseDependencies method of the parent MockStore instance invokes the
+// hook at the front of the queue and discards it. After the queue is empty,
+// the default hook function is invoked for any future action.
+func (f *StorePreciseDependenciesFunc) PushHook(hook func(context.Context, string, string) (map[api.RepoName]types.RevSpecSet, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *StorePreciseDependenciesFunc) SetDefaultReturn(r0 map[api.RepoName]types.RevSpecSet, r1 error) {
+	f.SetDefaultHook(func(context.Context, string, string) (map[api.RepoName]types.RevSpecSet, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *StorePreciseDependenciesFunc) PushReturn(r0 map[api.RepoName]types.RevSpecSet, r1 error) {
+	f.PushHook(func(context.Context, string, string) (map[api.RepoName]types.RevSpecSet, error) {
+		return r0, r1
+	})
+}
+
+func (f *StorePreciseDependenciesFunc) nextHook() func(context.Context, string, string) (map[api.RepoName]types.RevSpecSet, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *StorePreciseDependenciesFunc) appendCall(r0 StorePreciseDependenciesFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of StorePreciseDependenciesFuncCall objects
+// describing the invocations of this function.
+func (f *StorePreciseDependenciesFunc) History() []StorePreciseDependenciesFuncCall {
+	f.mutex.Lock()
+	history := make([]StorePreciseDependenciesFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// StorePreciseDependenciesFuncCall is an object that describes an
+// invocation of method PreciseDependencies on an instance of MockStore.
+type StorePreciseDependenciesFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 string
+	// Arg2 is the value of the 3rd argument passed to this method
+	// invocation.
+	Arg2 string
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 map[api.RepoName]types.RevSpecSet
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c StorePreciseDependenciesFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c StorePreciseDependenciesFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
+}
+
+// StorePreciseDependentsFunc describes the behavior when the
+// PreciseDependents method of the parent MockStore instance is invoked.
+type StorePreciseDependentsFunc struct {
+	defaultHook func(context.Context, string, string) (map[api.RepoName]types.RevSpecSet, error)
+	hooks       []func(context.Context, string, string) (map[api.RepoName]types.RevSpecSet, error)
+	history     []StorePreciseDependentsFuncCall
+	mutex       sync.Mutex
+}
+
+// PreciseDependents delegates to the next hook function in the queue and
+// stores the parameter and result values of this invocation.
+func (m *MockStore) PreciseDependents(v0 context.Context, v1 string, v2 string) (map[api.RepoName]types.RevSpecSet, error) {
+	r0, r1 := m.PreciseDependentsFunc.nextHook()(v0, v1, v2)
+	m.PreciseDependentsFunc.appendCall(StorePreciseDependentsFuncCall{v0, v1, v2, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the PreciseDependents
+// method of the parent MockStore instance is invoked and the hook queue is
+// empty.
+func (f *StorePreciseDependentsFunc) SetDefaultHook(hook func(context.Context, string, string) (map[api.RepoName]types.RevSpecSet, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// PreciseDependents method of the parent MockStore instance invokes the
+// hook at the front of the queue and discards it. After the queue is empty,
+// the default hook function is invoked for any future action.
+func (f *StorePreciseDependentsFunc) PushHook(hook func(context.Context, string, string) (map[api.RepoName]types.RevSpecSet, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *StorePreciseDependentsFunc) SetDefaultReturn(r0 map[api.RepoName]types.RevSpecSet, r1 error) {
+	f.SetDefaultHook(func(context.Context, string, string) (map[api.RepoName]types.RevSpecSet, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *StorePreciseDependentsFunc) PushReturn(r0 map[api.RepoName]types.RevSpecSet, r1 error) {
+	f.PushHook(func(context.Context, string, string) (map[api.RepoName]types.RevSpecSet, error) {
+		return r0, r1
+	})
+}
+
+func (f *StorePreciseDependentsFunc) nextHook() func(context.Context, string, string) (map[api.RepoName]types.RevSpecSet, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *StorePreciseDependentsFunc) appendCall(r0 StorePreciseDependentsFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of StorePreciseDependentsFuncCall objects
+// describing the invocations of this function.
+func (f *StorePreciseDependentsFunc) History() []StorePreciseDependentsFuncCall {
+	f.mutex.Lock()
+	history := make([]StorePreciseDependentsFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// StorePreciseDependentsFuncCall is an object that describes an invocation
+// of method PreciseDependents on an instance of MockStore.
+type StorePreciseDependentsFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 string
+	// Arg2 is the value of the 3rd argument passed to this method
+	// invocation.
+	Arg2 string
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 map[api.RepoName]types.RevSpecSet
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c StorePreciseDependentsFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c StorePreciseDependentsFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 

--- a/internal/codeintel/dependencies/service_test.go
+++ b/internal/codeintel/dependencies/service_test.go
@@ -20,6 +20,9 @@ import (
 )
 
 func TestDependencies(t *testing.T) {
+	// Ensure the precise flag is enabled
+	enablePreciseQueries = true
+
 	ctx := context.Background()
 	mockStore := NewMockStore()
 	gitService := NewMockLocalGitService()
@@ -180,6 +183,9 @@ func TestDependencies(t *testing.T) {
 }
 
 func TestDependents(t *testing.T) {
+	// Ensure the precise flag is enabled
+	enablePreciseQueries = true
+
 	ctx := context.Background()
 	mockStore := NewMockStore()
 	gitService := NewMockLocalGitService()

--- a/internal/codeintel/dependencies/service_test.go
+++ b/internal/codeintel/dependencies/service_test.go
@@ -38,6 +38,18 @@ func TestDependencies(t *testing.T) {
 		return v%2 == 0
 	}
 
+	mockStore.PreciseDependenciesFunc.SetDefaultHook(func(ctx context.Context, repoName, commit string) (map[api.RepoName]types.RevSpecSet, error) {
+		if repoName != "github.com/example/baz" {
+			return nil, nil
+		}
+
+		return map[api.RepoName]types.RevSpecSet{
+			api.RepoName(fmt.Sprintf("%s-depA", repoName)): {"deadbeef1": struct{}{}},
+			api.RepoName(fmt.Sprintf("%s-depB", repoName)): {"deadbeef2": struct{}{}},
+			api.RepoName(fmt.Sprintf("%s-depC", repoName)): {"deadbeef3": struct{}{}},
+		}, nil
+	})
+
 	// UpsertDependencyRepos influences the value that syncer.Sync is called with (asserted below)
 	mockStore.UpsertDependencyReposFunc.SetDefaultHook(func(ctx context.Context, dependencyRepos []Repo) ([]Repo, error) {
 		filtered := dependencyRepos[:0]
@@ -52,6 +64,19 @@ func TestDependencies(t *testing.T) {
 		}
 
 		return filtered, nil
+	})
+
+	// Return canned dependencies for repo `baz`
+	mockStore.LockfileDependenciesFunc.SetDefaultHook(func(ctx context.Context, repoName, commit string) ([]shared.PackageDependency, bool, error) {
+		if repoName != "github.com/example/baz" {
+			return nil, false, nil
+		}
+
+		return []shared.PackageDependency{
+			shared.TestPackageDependencyLiteral("npm/leftpad", "1", "2", "3", "4"),
+			shared.TestPackageDependencyLiteral("npm/rightpad", "2", "3", "4", "5"),
+			shared.TestPackageDependencyLiteral("npm/centerpad", "3", "4", "5", "6"),
+		}, true, nil
 	})
 
 	// GetCommits returns the same values as input; no errors
@@ -75,19 +100,6 @@ func TestDependencies(t *testing.T) {
 		}, nil
 	})
 
-	// Return canned dependencies for repo `baz`
-	mockStore.LockfileDependenciesFunc.SetDefaultHook(func(ctx context.Context, repoName, commit string) ([]shared.PackageDependency, bool, error) {
-		if repoName != "github.com/example/baz" {
-			return nil, false, nil
-		}
-
-		return []shared.PackageDependency{
-			shared.TestPackageDependencyLiteral("npm/leftpad", "1", "2", "3", "4"),
-			shared.TestPackageDependencyLiteral("npm/rightpad", "2", "3", "4", "5"),
-			shared.TestPackageDependencyLiteral("npm/centerpad", "3", "4", "5", "6"),
-		}, true, nil
-	})
-
 	repoRevs := map[api.RepoName]types.RevSpecSet{
 		api.RepoName("github.com/example/foo"): {
 			api.RevSpec("deadbeef1"): struct{}{},
@@ -108,6 +120,11 @@ func TestDependencies(t *testing.T) {
 	}
 
 	expectedDepencies := map[api.RepoName]types.RevSpecSet{
+		// From precise dependencies
+		"github.com/example/baz-depA": {"deadbeef1": struct{}{}},
+		"github.com/example/baz-depB": {"deadbeef2": struct{}{}},
+		"github.com/example/baz-depC": {"deadbeef3": struct{}{}},
+
 		// From store
 		("npm/leftpad"):   {"1": struct{}{}},
 		("npm/rightpad"):  {"2": struct{}{}},
@@ -178,6 +195,18 @@ func TestDependents(t *testing.T) {
 		return commits, nil
 	})
 
+	mockStore.PreciseDependentsFunc.SetDefaultHook(func(ctx context.Context, repoName, commit string) (map[api.RepoName]types.RevSpecSet, error) {
+		if repoName != "github.com/example/baz" {
+			return nil, nil
+		}
+
+		return map[api.RepoName]types.RevSpecSet{
+			api.RepoName(fmt.Sprintf("%s-depA", repoName)): {"deadbeef1": struct{}{}},
+			api.RepoName(fmt.Sprintf("%s-depB", repoName)): {"deadbeef2": struct{}{}},
+			api.RepoName(fmt.Sprintf("%s-depC", repoName)): {"deadbeef3": struct{}{}},
+		}, nil
+	})
+
 	mockStore.LockfileDependentsFunc.SetDefaultHook(func(ctx context.Context, repoName, commit string) ([]api.RepoCommit, error) {
 		return []api.RepoCommit{
 			{Repo: api.RepoName(fmt.Sprintf("dep-a-%s", repoName)), CommitID: api.CommitID(fmt.Sprintf("c-%s", commit))},
@@ -205,6 +234,12 @@ func TestDependents(t *testing.T) {
 	}
 
 	expectedDependents := map[api.RepoName]types.RevSpecSet{
+		// From precise dependents
+		"github.com/example/baz-depA": {"deadbeef1": struct{}{}},
+		"github.com/example/baz-depB": {"deadbeef2": struct{}{}},
+		"github.com/example/baz-depC": {"deadbeef3": struct{}{}},
+
+		// From lockfile dependents
 		api.RepoName("dep-a-github.com/example/foo"): {
 			api.RevSpec("c-deadbeef1"): struct{}{},
 			api.RevSpec("c-deadbeef2"): struct{}{},

--- a/internal/database/basestore/rows.go
+++ b/internal/database/basestore/rows.go
@@ -53,6 +53,75 @@ func NewSliceScanner[T any](f func(dbutil.Scanner) (T, error)) func(rows *sql.Ro
 	}
 }
 
+// CollectionReducer configures how scanners created by `NewCollectionReducerScanner` will
+// group values belonging to the same map key.
+type CollectionReducer[V, Vs any] interface {
+	Create() Vs
+	Reduce(collection Vs, value V) Vs
+}
+
+// SliceReducer can be used as a collection reducer for `NewCollectionReducerScanner` to
+// collect values belonging to each key into a slice.
+type SliceReducer[T any] struct{}
+
+func (r SliceReducer[T]) Create() []T                        { return nil }
+func (r SliceReducer[T]) Reduce(collection []T, value T) []T { return append(collection, value) }
+
+// SingleValueReducer can be used as a collection reducer for `NewCollectionReducerScanner` to
+// return the single value belonging to each key into a slice. If there are duplicates, the last
+// value scanned will "win" for each key.
+type SingleValueReducer[T any] struct{}
+
+func (r SingleValueReducer[T]) Create() (_ T)                  { return }
+func (r SingleValueReducer[T]) Reduce(collection T, value T) T { return value }
+
+// NewKeyedCollectionScanner returns a basestore scanner function that returns the values of a
+// query result organized as a map. The given function is invoked multiple times with a SQL rows
+// object to scan a single map value. The given reducer provides a way to customize how multiple
+// values are reduced into a collection.
+func NewKeyedCollectionScanner[K comparable, V, Vs any](
+	scanPair func(dbutil.Scanner) (K, V, error),
+	reducer CollectionReducer[V, Vs],
+) func(rows *sql.Rows, queryErr error) (map[K]Vs, error) {
+	return func(rows *sql.Rows, queryErr error) (values map[K]Vs, err error) {
+		if queryErr != nil {
+			return nil, queryErr
+		}
+		defer func() { err = CloseRows(rows, err) }()
+
+		values = map[K]Vs{}
+		for rows.Next() {
+			key, value, err := scanPair(rows)
+			if err != nil {
+				return nil, err
+			}
+
+			collection, ok := values[key]
+			if !ok {
+				collection = reducer.Create()
+			}
+
+			values[key] = reducer.Reduce(collection, value)
+		}
+
+		return values, nil
+	}
+}
+
+// NewMapScanner returns a basestore scanner function that returns the values of a
+// query result organized as a map. The given function is invoked multiple times with
+// a SQL rows object to scan a single map value.
+func NewMapScanner[K comparable, V any](f func(dbutil.Scanner) (K, V, error)) func(rows *sql.Rows, queryErr error) (map[K]V, error) {
+	return NewKeyedCollectionScanner[K, V, V](f, SingleValueReducer[V]{})
+}
+
+// NewMapSliceScanner returns a basestore scanner function that returns the values
+// of a query result organized as a map of slice values. The given function is invoked
+// multiple times with a SQL rows object to scan a single map key value.
+func NewMapSliceScanner[K comparable, V any](f func(dbutil.Scanner) (K, V, error)) func(rows *sql.Rows, queryErr error) (map[K][]V, error) {
+	return NewKeyedCollectionScanner[K, V, []V](f, SliceReducer[V]{})
+}
+
 // NewSliceWithCountScanner returns a basestore scanner function that returns all
 // the values of the query result, as well as the count from the `COUNT(*) OVER()`
 // window function. The given function is invoked multiple times with a SQL rows


### PR DESCRIPTION
Fixes #31638. This PR makes an additional request after each `Dependencies` and `Dependents` function that adds additional relationships based on the content of the `lsif_packages`/`lsif_references` tables.

## Test plan

New unit tests. Also tested on a local instance.