### PR TITLE
dependencies: Implement `Dependents`

### DIFF
--- a/internal/codeintel/dependencies/iface.go
+++ b/internal/codeintel/dependencies/iface.go
@@ -17,6 +17,7 @@ type Store interface {
 	UpsertLockfileDependencies(ctx context.Context, repoName, commit string, deps []shared.PackageDependency) error
 	SelectRepoRevisionsToResolve(ctx context.Context, batchSize int, minimumCheckInterval time.Duration) (map[string][]string, error)
 	UpdateResolvedRevisions(ctx context.Context, repoRevsToResolvedRevs map[string]map[string]string) error
+	LockfileDependents(ctx context.Context, repoName, commit string) ([]api.RepoCommit, error)
 	ListDependencyRepos(ctx context.Context, opts store.ListDependencyReposOpts) ([]Repo, error)
 	UpsertDependencyRepos(ctx context.Context, deps []Repo) ([]Repo, error)
 	DeleteDependencyReposByID(ctx context.Context, ids ...int) error

--- a/internal/codeintel/dependencies/internal/store/observability.go
+++ b/internal/codeintel/dependencies/internal/store/observability.go
@@ -11,10 +11,11 @@ type operations struct {
 	deleteDependencyReposByID    *observation.Operation
 	listDependencyRepos          *observation.Operation
 	lockfileDependencies         *observation.Operation
-	upsertDependencyRepos        *observation.Operation
-	upsertLockfileDependencies   *observation.Operation
+	lockfileDependents           *observation.Operation
 	selectRepoRevisionsToResolve *observation.Operation
 	updateResolvedRevisions      *observation.Operation
+	upsertDependencyRepos        *observation.Operation
+	upsertLockfileDependencies   *observation.Operation
 }
 
 func newOperations(observationContext *observation.Context) *operations {
@@ -37,9 +38,10 @@ func newOperations(observationContext *observation.Context) *operations {
 		deleteDependencyReposByID:    op("DeleteDependencyReposByID"),
 		listDependencyRepos:          op("ListDependencyRepos"),
 		lockfileDependencies:         op("LockfileDependencies"),
-		upsertDependencyRepos:        op("UpsertDependencyRepos"),
-		upsertLockfileDependencies:   op("UpsertLockfileDependencies"),
+		lockfileDependents:           op("LockfileDependents"),
 		selectRepoRevisionsToResolve: op("SelectRepoRevisionsToResolve"),
 		updateResolvedRevisions:      op("UpdateResolvedRevisions"),
+		upsertDependencyRepos:        op("UpsertDependencyRepos"),
+		upsertLockfileDependencies:   op("UpsertLockfileDependencies"),
 	}
 }

--- a/internal/codeintel/dependencies/internal/store/scan.go
+++ b/internal/codeintel/dependencies/internal/store/scan.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/dependencies/shared"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
@@ -9,6 +10,12 @@ import (
 var scanPackageDependencies = basestore.NewSliceScanner(func(s dbutil.Scanner) (shared.PackageDependency, error) {
 	var v shared.PackageDependencyLiteral
 	err := s.Scan(&v.RepoNameValue, &v.GitTagFromVersionValue, &v.SchemeValue, &v.PackageSyntaxValue, &v.PackageVersionValue)
+	return v, err
+})
+
+var scanRepoCommits = basestore.NewSliceScanner(func(s dbutil.Scanner) (api.RepoCommit, error) {
+	var v api.RepoCommit
+	err := s.Scan(&v.Repo, &v.CommitID)
 	return v, err
 })
 

--- a/internal/codeintel/dependencies/internal/store/store_test.go
+++ b/internal/codeintel/dependencies/internal/store/store_test.go
@@ -217,7 +217,7 @@ func TestSelectRepoRevisionsToResolve(t *testing.T) {
 		"C": {"v3"},
 	}
 	if diff := cmp.Diff(selected, expectedRepoRevisions); diff != "" {
-		t.Errorf("unexpected sourced commits (-want +got):\n%s", diff)
+		t.Errorf("unexpected repo revisions (-want +got):\n%s", diff)
 	}
 
 	selected, err = store.selectRepoRevisionsToResolve(ctx, 3, 24*time.Hour, now)
@@ -230,7 +230,7 @@ func TestSelectRepoRevisionsToResolve(t *testing.T) {
 		"E": {"v5"},
 	}
 	if diff := cmp.Diff(selected, expectedRepoRevisions); diff != "" {
-		t.Errorf("unexpected sourced commits (-want +got):\n%s", diff)
+		t.Errorf("unexpected repo revisions (-want +got):\n%s", diff)
 	}
 
 	// Run it again, but all should be resolved in timeframe
@@ -241,7 +241,7 @@ func TestSelectRepoRevisionsToResolve(t *testing.T) {
 
 	expectedRepoRevisions = map[string][]string{}
 	if diff := cmp.Diff(selected, expectedRepoRevisions); diff != "" {
-		t.Errorf("unexpected sourced commits (-want +got):\n%s", diff)
+		t.Errorf("unexpected repo revisions (-want +got):\n%s", diff)
 	}
 
 	// Run it again, but in the future, all should be resolved in timeframe
@@ -273,30 +273,27 @@ func TestUpdateResolvedRevisions(t *testing.T) {
 	db := database.NewDB(dbtest.NewDB(t))
 	store := TestStore(db)
 
-	for _, repo := range []string{"repo-1", "repo-2", "repo-3"} {
+	for _, repo := range []string{"repo-1", "repo-2", "repo-3", "pkg-1", "pkg-2", "pkg-3", "pkg-4"} {
 		if err := store.Exec(ctx, sqlf.Sprintf(`INSERT INTO repo (name) VALUES (%s)`, repo)); err != nil {
 			t.Fatalf(err.Error())
 		}
 	}
 
-	packageA := shared.TestPackageDependencyLiteral(api.RepoName("A"), "v1", "2", "3", "4")
-	packageB := shared.TestPackageDependencyLiteral(api.RepoName("repo-2"), "v2", "3", "4", "5")
-	packageC := shared.TestPackageDependencyLiteral(api.RepoName("repo-3"), "v3", "4", "5", "6")
-	packageD := shared.TestPackageDependencyLiteral(api.RepoName("D"), "v4", "5", "6", "7")
+	var (
+		packageA = shared.TestPackageDependencyLiteral(api.RepoName("pkg-1"), "v1", "2", "3", "4")
+		packageB = shared.TestPackageDependencyLiteral(api.RepoName("pkg-2"), "v2", "3", "4", "5")
+		packageC = shared.TestPackageDependencyLiteral(api.RepoName("pkg-3"), "v3", "4", "5", "6")
+		packageD = shared.TestPackageDependencyLiteral(api.RepoName("pkg-4"), "v4", "5", "6", "7")
+	)
 
-	commit := "d34df00d"
-	repoName := "repo-1"
-	packages := []shared.PackageDependency{packageA, packageB, packageC, packageD}
-
-	if err := store.UpsertLockfileDependencies(ctx, repoName, commit, packages); err != nil {
+	if err := store.UpsertLockfileDependencies(ctx, "repo-1", "cafebabe", []shared.PackageDependency{packageA, packageB, packageC, packageD}); err != nil {
 		t.Fatalf("unexpected error upserting lockfile dependencies: %s", err)
 	}
 
 	resolvedRevisions := map[string]map[string]string{
-		"repo-2": {"v2": "d34df00d"},
-		"repo-3": {"v3": "d34db33f"},
+		"pkg-2": {"v2": "deadbeef"},
+		"pkg-3": {"v3": "deadd00d"},
 	}
-
 	if err := store.UpdateResolvedRevisions(ctx, resolvedRevisions); err != nil {
 		t.Fatalf("unexpected error updating resolved revisions: %s", err)
 	}
@@ -304,13 +301,10 @@ func TestUpdateResolvedRevisions(t *testing.T) {
 	for repoName, resolvedRevs := range resolvedRevisions {
 		for revspec, commit := range resolvedRevs {
 			q := sqlf.Sprintf(`
-			SELECT 1 FROM codeintel_lockfile_references
-			WHERE
-				repository_id = (SELECT id FROM repo WHERE name = %s)
-			AND
-				revspec = %s
-			AND
-				commit_bytea = %s
+				SELECT 1
+				FROM codeintel_lockfile_references lr
+				JOIN repo r ON r.id = lr.repository_id
+				WHERE r.name = %s AND lr.revspec = %s AND lr.commit_bytea = %s
 			`,
 				repoName,
 				revspec,
@@ -325,5 +319,81 @@ func TestUpdateResolvedRevisions(t *testing.T) {
 				t.Fatalf("revspec %q for repo %q was not updated to commit %s", revspec, repoName, commit)
 			}
 		}
+	}
+}
+
+func TestLockfileDependents(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
+	ctx := context.Background()
+	db := database.NewDB(dbtest.NewDB(t))
+	store := TestStore(db)
+
+	for _, repo := range []string{"repo-1", "repo-2", "repo-3", "pkg-1", "pkg-2", "pkg-3", "pkg-4"} {
+		if err := store.Exec(ctx, sqlf.Sprintf(`INSERT INTO repo (name) VALUES (%s)`, repo)); err != nil {
+			t.Fatalf(err.Error())
+		}
+	}
+
+	var (
+		packageA = shared.TestPackageDependencyLiteral(api.RepoName("pkg-1"), "v1", "2", "3", "4")
+		packageB = shared.TestPackageDependencyLiteral(api.RepoName("pkg-2"), "v2", "3", "4", "5")
+		packageC = shared.TestPackageDependencyLiteral(api.RepoName("pkg-3"), "v3", "4", "5", "6")
+		packageD = shared.TestPackageDependencyLiteral(api.RepoName("pkg-4"), "v4", "5", "6", "7")
+	)
+
+	if err := store.UpsertLockfileDependencies(ctx, "repo-1", "cafebabe", []shared.PackageDependency{packageA, packageB, packageC, packageD}); err != nil {
+		t.Fatalf("unexpected error upserting lockfile dependencies: %s", err)
+	}
+	if err := store.UpsertLockfileDependencies(ctx, "repo-2", "cafebeef", []shared.PackageDependency{packageB}); err != nil {
+		t.Fatalf("unexpected error upserting lockfile dependencies: %s", err)
+	}
+	if err := store.UpsertLockfileDependencies(ctx, "repo-3", "d00dd00d", []shared.PackageDependency{packageC}); err != nil {
+		t.Fatalf("unexpected error upserting lockfile dependencies: %s", err)
+	}
+
+	resolvedRevisions := map[string]map[string]string{
+		"pkg-2": {"v2": "deadbeef"},
+		"pkg-3": {"v3": "deadd00d"},
+	}
+	if err := store.UpdateResolvedRevisions(ctx, resolvedRevisions); err != nil {
+		t.Fatalf("unexpected error updating resolved revisions: %s", err)
+	}
+
+	// Should be empty; nothing resolved here
+	deps, err := store.LockfileDependents(ctx, "pkg-1", "cafecafe")
+	if err != nil {
+		t.Fatalf("unexpected error listing lockfile dependents: %s", err)
+	}
+	if diff := cmp.Diff([]api.RepoCommit(nil), deps); diff != "" {
+		t.Errorf("unexpected lockfile dependents (-want +got):\n%s", diff)
+	}
+
+	// Should include repo-1 and repo-2
+	deps, err = store.LockfileDependents(ctx, "pkg-2", "deadbeef")
+	if err != nil {
+		t.Fatalf("unexpected error listing lockfile dependents: %s", err)
+	}
+	expectedDeps := []api.RepoCommit{
+		{Repo: api.RepoName("repo-1"), CommitID: api.CommitID("cafebabe")},
+		{Repo: api.RepoName("repo-2"), CommitID: api.CommitID("cafebeef")},
+	}
+	if diff := cmp.Diff(expectedDeps, deps); diff != "" {
+		t.Errorf("unexpected lockfile dependents (-want +got):\n%s", diff)
+	}
+
+	// Should include repo-1 and repo-3
+	deps, err = store.LockfileDependents(ctx, "pkg-3", "deadd00d")
+	if err != nil {
+		t.Fatalf("unexpected error listing lockfile dependents: %s", err)
+	}
+	expectedDeps = []api.RepoCommit{
+		{Repo: api.RepoName("repo-1"), CommitID: api.CommitID("cafebabe")},
+		{Repo: api.RepoName("repo-3"), CommitID: api.CommitID("d00dd00d")},
+	}
+	if diff := cmp.Diff(expectedDeps, deps); diff != "" {
+		t.Errorf("unexpected lockfile dependents (-want +got):\n%s", diff)
 	}
 }


### PR DESCRIPTION
Fixes #35436. This PR adds an initial implementation for the dependencies service `Dependents` method. This is much simpler than the other direction (but does require a lot of background machinery added in previous PRs). This new method does a reverse lookup in the database and returns matching results.

## Test plan

Additional unit tests.