### PR TITLE
RFC 624: Add envvar to backdoor inference override script

### DIFF
--- a/enterprise/internal/codeintel/autoindex/enqueuer/enqueuer.go
+++ b/enterprise/internal/codeintel/autoindex/enqueuer/enqueuer.go
@@ -2,6 +2,7 @@ package enqueuer
 
 import (
 	"context"
+	"os"
 
 	"github.com/inconshreveable/log15"
 	"github.com/opentracing/opentracing-go/log"
@@ -214,6 +215,8 @@ func (s *IndexEnqueuer) queueIndexForRepositoryAndCommit(ctx context.Context, re
 	return s.dbStore.InsertIndexes(ctx, indexes)
 }
 
+var overrideScript = os.Getenv("SRC_CODEINTEL_INFERENCE_OVERRIDE_SCRIPT")
+
 // inferIndexJobsFromRepositoryStructure collects the result of  InferIndexJobs over all registered recognizers.
 func (s *IndexEnqueuer) inferIndexJobsFromRepositoryStructure(ctx context.Context, repositoryID int, commit string) ([]config.IndexJob, error) {
 	if err := s.gitserverLimiter.Wait(ctx); err != nil {
@@ -225,7 +228,7 @@ func (s *IndexEnqueuer) inferIndexJobsFromRepositoryStructure(ctx context.Contex
 		return nil, err
 	}
 
-	indexes, err := s.inferenceService.InferIndexJobs(ctx, api.RepoName(repoName), commit, "")
+	indexes, err := s.inferenceService.InferIndexJobs(ctx, api.RepoName(repoName), commit, overrideScript)
 	if err != nil {
 		return nil, err
 	}
@@ -249,7 +252,7 @@ func (s *IndexEnqueuer) inferIndexJobHintsFromRepositoryStructure(ctx context.Co
 		return nil, err
 	}
 
-	indexes, err := s.inferenceService.InferIndexJobHints(ctx, api.RepoName(repoName), commit, "")
+	indexes, err := s.inferenceService.InferIndexJobHints(ctx, api.RepoName(repoName), commit, overrideScript)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/codeintel/autoindexing/internal/inference/lua/recognizers.lua
+++ b/internal/codeintel/autoindexing/internal/inference/lua/recognizers.lua
@@ -3,6 +3,7 @@ local languages = {
     "go",
     "java",
     "rust",
+    "test",
     "typescript",
 }
 

--- a/internal/codeintel/autoindexing/internal/inference/lua/test.lua
+++ b/internal/codeintel/autoindexing/internal/inference/lua/test.lua
@@ -1,0 +1,23 @@
+local path = require("path")
+local patterns = require("sg.patterns")
+local recognizers = require("sg.recognizers")
+
+return recognizers.path_recognizer {
+    patterns = { patterns.path_basename("sg-test") },
+
+    -- Invoked as part of unit tests for the autoindexing service
+    generate = function(_, paths)
+        local jobs = {}
+        for i = 1, #paths do
+            table.insert(jobs, {
+                steps = {},
+                root = path.dirname(paths[i]),
+                indexer = "test",
+                indexer_args = {},
+                outfile = "",
+            })
+        end
+
+        return jobs
+    end,
+}

--- a/internal/codeintel/autoindexing/internal/inference/service.go
+++ b/internal/codeintel/autoindexing/internal/inference/service.go
@@ -217,15 +217,34 @@ func (s *Service) setupRecognizers(ctx context.Context, sandbox *luasandbox.Sand
 		return nil, err
 	}
 
-	recognizers, err := luatypes.RecognizersFromUserDataMap(rawRecognizers)
+	recognizerMap, err := luatypes.NamedRecognizersFromUserDataMap(rawRecognizers, false)
 	if err != nil {
 		return nil, err
 	}
 
 	if overrideScript != "" {
-		// TODO - run this script and merge recognizer results
-		// See https://github.com/sourcegraph/sourcegraph/issues/33046
-		return nil, errors.Newf("unimplemented")
+		rawRecognizers, err := sandbox.RunScript(ctx, opts, overrideScript)
+		if err != nil {
+			return nil, err
+		}
+
+		overrideRecognizerMap, err := luatypes.NamedRecognizersFromUserDataMap(rawRecognizers, true)
+		if err != nil {
+			return nil, err
+		}
+
+		for name, recognizer := range overrideRecognizerMap {
+			if recognizer == nil {
+				delete(recognizerMap, name)
+			} else {
+				recognizerMap[name] = recognizer
+			}
+		}
+	}
+
+	recognizers := make([]*luatypes.Recognizer, 0, len(recognizerMap))
+	for _, recognizer := range recognizerMap {
+		recognizers = append(recognizers, recognizer)
 	}
 
 	return recognizers, nil

--- a/internal/codeintel/autoindexing/internal/inference/service.go
+++ b/internal/codeintel/autoindexing/internal/inference/service.go
@@ -228,6 +228,10 @@ func (s *Service) setupRecognizers(ctx context.Context, sandbox *luasandbox.Sand
 			return nil, err
 		}
 
+		// Allow false values here, which will be indicated by a nil recognizer. In the loop below we will
+		// add (or replace) any recognizer with the same name. To _unset_ a recognize, we allow a user to
+		// add nil as the table value.
+
 		overrideRecognizerMap, err := luatypes.NamedRecognizersFromUserDataMap(rawRecognizers, true)
 		if err != nil {
 			return nil, err

--- a/internal/codeintel/autoindexing/internal/inference/service.go
+++ b/internal/codeintel/autoindexing/internal/inference/service.go
@@ -229,7 +229,7 @@ func (s *Service) setupRecognizers(ctx context.Context, sandbox *luasandbox.Sand
 		}
 
 		// Allow false values here, which will be indicated by a nil recognizer. In the loop below we will
-		// add (or replace) any recognizer with the same name. To _unset_ a recognize, we allow a user to
+		// add (or replace) any recognizer with the same name. To _unset_ a recognizer, we allow a user to
 		// add nil as the table value.
 
 		overrideRecognizerMap, err := luatypes.NamedRecognizersFromUserDataMap(rawRecognizers, true)

--- a/internal/codeintel/autoindexing/internal/inference/service_generator_test.go
+++ b/internal/codeintel/autoindexing/internal/inference/service_generator_test.go
@@ -21,8 +21,107 @@ func TestEmptyGenerators(t *testing.T) {
 	)
 }
 
+func TestOverrideGenerators(t *testing.T) {
+	testGenerators(t,
+		generatorTestCase{
+			description: "override",
+			overrideScript: `
+				local path = require("path")
+				local patterns = require("sg.patterns")
+				local recognizers = require("sg.recognizers")
+
+				local custom_recognizer = recognizers.path_recognizer {
+					patterns = { patterns.path_basename("sg-test") },
+
+					-- Invoked when go.mod files exist
+					generate = function(_, paths)
+						local jobs = {}
+						for i = 1, #paths do
+							table.insert(jobs, {
+								steps = {},
+								root = path.dirname(paths[i]),
+								indexer = "test-override",
+								indexer_args = {},
+								outfile = "",
+							})
+						end
+
+						return jobs
+					end,
+				}
+
+				local recognizers = {}
+				recognizers["custom.test"] = custom_recognizer
+				return recognizers
+			`,
+			repositoryContents: map[string]string{
+				"sg-test":     "",
+				"foo/sg-test": "",
+				"bar/sg-test": "",
+				"baz/sg-test": "",
+			},
+			expected: []config.IndexJob{
+				{Indexer: "test", Root: ""},
+				{Indexer: "test", Root: "bar"},
+				{Indexer: "test", Root: "baz"},
+				{Indexer: "test", Root: "foo"},
+				{Indexer: "test-override", Root: ""},
+				{Indexer: "test-override", Root: "bar"},
+				{Indexer: "test-override", Root: "baz"},
+				{Indexer: "test-override", Root: "foo"},
+			},
+		},
+		generatorTestCase{
+			description: "disable default",
+			overrideScript: `
+				local path = require("path")
+				local patterns = require("sg.patterns")
+				local recognizers = require("sg.recognizers")
+
+				local custom_recognizer = recognizers.path_recognizer {
+					patterns = { patterns.path_basename("sg-test") },
+
+					-- Invoked when go.mod files exist
+					generate = function(_, paths)
+						local jobs = {}
+						for i = 1, #paths do
+							table.insert(jobs, {
+								steps = {},
+								root = path.dirname(paths[i]),
+								indexer = "test-override",
+								indexer_args = {},
+								outfile = "",
+							})
+						end
+
+						return jobs
+					end,
+				}
+
+				local recognizers = {}
+				recognizers["sg.test"] = false
+				recognizers["custom.test"] = custom_recognizer
+				return recognizers
+			`,
+			repositoryContents: map[string]string{
+				"sg-test":     "",
+				"foo/sg-test": "",
+				"bar/sg-test": "",
+				"baz/sg-test": "",
+			},
+			expected: []config.IndexJob{
+				{Indexer: "test-override", Root: ""},
+				{Indexer: "test-override", Root: "bar"},
+				{Indexer: "test-override", Root: "baz"},
+				{Indexer: "test-override", Root: "foo"},
+			},
+		},
+	)
+}
+
 type generatorTestCase struct {
 	description        string
+	overrideScript     string
 	repositoryContents map[string]string
 	expected           []config.IndexJob
 }
@@ -41,8 +140,7 @@ func testGenerator(t *testing.T, testCase generatorTestCase) {
 			context.Background(),
 			api.RepoName("github.com/test/test"),
 			"HEAD",
-			// To be implemented in // See https://github.com/sourcegraph/sourcegraph/issues/33046
-			"",
+			testCase.overrideScript,
 		)
 		if err != nil {
 			t.Fatalf("unexpected error inferring jobs: %s", err)

--- a/internal/codeintel/autoindexing/internal/inference/service_hinter_test.go
+++ b/internal/codeintel/autoindexing/internal/inference/service_hinter_test.go
@@ -41,7 +41,6 @@ func testHinter(t *testing.T, testCase hinterTestCase) {
 			context.Background(),
 			api.RepoName("github.com/test/test"),
 			"HEAD",
-			// To be implemented in // See https://github.com/sourcegraph/sourcegraph/issues/33046
 			"",
 		)
 		if err != nil {


### PR DESCRIPTION
Fixes #35451. This PR adds an envvar to provide an override inference script. This will allow us to (in the next release) supply envvar values to site-admins to help them automatically index all of their repositories.

## Test plan

New unit tests.