### PR TITLE
chore: add GitHub automation for IAM and Admin Exp team

### DIFF
--- a/.github/teams.yml
+++ b/.github/teams.yml
@@ -4,3 +4,14 @@ team/frontend-platform:
   - '@valerybugakov'
   - '@pdubroy'
   - '@oleggromov'
+
+team/iam-admin-experience:
+  - '@unknwon'
+  - '@RafLeszczynski'
+  - '@rafax'
+  - '@miveronese'
+  - '@ryphil'
+  - '@pietrorosa77'
+  - '@quinnkeast'
+  - '@pjlast'
+  - '@kopancek'

--- a/.github/workflows/label-move.yml
+++ b/.github/workflows/label-move.yml
@@ -187,7 +187,7 @@ jobs:
       env:
         NODE_ID: ${{ github.event.pull_request.node_id }}
       run: echo 'NODE_ID='$NODE_ID >> $GITHUB_ENV
-    - name: Add to Distribution board
+    - name: Add to Delivery board
       if: ${{ env.NODE_ID != '' }}
       run: |
         gh api graphql --header 'GraphQL-Features: projects_next_graphql' -f query='
@@ -237,6 +237,33 @@ jobs:
         NODE_ID: ${{ github.event.pull_request.node_id }}
       run: echo 'NODE_ID='$NODE_ID >> $GITHUB_ENV
     - name: Add to Growth board
+      if: ${{ env.NODE_ID != '' }}
+      run: |
+        gh api graphql --header 'GraphQL-Features: projects_next_graphql' -f query='
+          mutation($project:ID!, $node_id:ID!) {
+            addProjectNextItem(input: {projectId: $project, contentId: $node_id}) {
+              projectNextItem {
+                id
+              }
+            }
+          }' -f project=$PROJECT_ID -f node_id=$NODE_ID
+  iam-and-admin-exp-board:
+    runs-on: ubuntu-latest
+    env:
+      PROJECT_ID: PN_kwDOADy5QM4ABlJF # https://github.com/orgs/sourcegraph/projects/259
+      GITHUB_TOKEN: ${{ secrets.GH_PROJECTS_ACTION_TOKEN }}
+    steps:
+    - name: Get issue if relevant
+      if: ${{ contains(github.event.issue.labels.*.name, 'team/iam-admin-experience') }}
+      env:
+        NODE_ID: ${{ github.event.issue.node_id }}
+      run: echo 'NODE_ID='$NODE_ID >> $GITHUB_ENV
+    - name: Get pull request if relevant
+      if: ${{ contains(github.event.pull_request.labels.*.name, 'team/iam-admin-experience') }}
+      env:
+        NODE_ID: ${{ github.event.pull_request.node_id }}
+      run: echo 'NODE_ID='$NODE_ID >> $GITHUB_ENV
+    - name: Add to IAM and Admin Exp board
       if: ${{ env.NODE_ID != '' }}
       run: |
         gh api graphql --header 'GraphQL-Features: projects_next_graphql' -f query='

--- a/.github/workflows/label-notify.yml
+++ b/.github/workflows/label-notify.yml
@@ -25,3 +25,4 @@ jobs:
                   team/dev-experience=@taylorsperry @jhchabran @kstretch9
                   team/repo-management=@jplahn
                   team/devops=@sourcegraph/cloud-devops
+                  team/iam-admin-experience=@sourcegraph/iam-and-admin-experience


### PR DESCRIPTION
Three parts of GitHub automation have been added for the IAM and Admin Exp team:

1. `.github/teams.yml`: Automatically label the PR with the label `team/iam-admin-experience` if the author is one of defined people.
2. `.github/workflows/label-move.yml`: Automatically add issues and PRs with the label `team/iam-admin-experience` to the IAM and Admin Exp GitHub project.
3. `.github/workflows/label-notify.yml`: Automatically tag `@sourcegraph/iam-and-admin-experience team` when an issue is labeled with `team/iam-admin-experience`
	- This could be a bit controversial, there will be times with some issue storm, we can change it to only individuals if we want. Let's start with it see how things go.

## Test plan

Not code related.