### PR TITLE
Accessibility: Alert assertiveness

### DIFF
--- a/client/branded/src/components/__snapshots__/alerts.test.tsx.snap
+++ b/client/branded/src/components/__snapshots__/alerts.test.tsx.snap
@@ -3,6 +3,7 @@
 exports[`ErrorAlert should add a prefix if given 1`] = `
 <DocumentFragment>
   <div
+    aria-live="assertive"
     class=""
     role="alert"
   >
@@ -22,6 +23,7 @@ exports[`ErrorAlert should add a prefix if given 1`] = `
 exports[`ErrorAlert should omit the icon if icon={false} 1`] = `
 <DocumentFragment>
   <div
+    aria-live="assertive"
     class=""
     role="alert"
   >
@@ -38,6 +40,7 @@ exports[`ErrorAlert should omit the icon if icon={false} 1`] = `
 exports[`ErrorAlert should render a Go multierror nicely 1`] = `
 <DocumentFragment>
   <div
+    aria-live="assertive"
     class=""
     role="alert"
   >
@@ -67,6 +70,7 @@ exports[`ErrorAlert should render a Go multierror nicely 1`] = `
 exports[`ErrorAlert should render an Error object as an alert 1`] = `
 <DocumentFragment>
   <div
+    aria-live="assertive"
     class=""
     role="alert"
   >

--- a/client/shared/src/hover/__snapshots__/HoverOverlay.test.tsx.snap
+++ b/client/shared/src/hover/__snapshots__/HoverOverlay.test.tsx.snap
@@ -33,7 +33,9 @@ exports[`HoverOverlay actions and hover error 1`] = `
       data-testid="hover-overlay-contents"
     >
       <div
+        aria-live="polite"
         class="hoverError"
+        role="alert"
       >
         M2
       </div>
@@ -263,7 +265,9 @@ exports[`HoverOverlay actions, hover and alert present 1`] = `
       class="hoverOverlayAlerts"
     >
       <div
+        aria-live="polite"
         class="alert"
+        role="alert"
       >
         <span
           class="hoverOverlayContent hoverOverlayContent"
@@ -328,7 +332,9 @@ exports[`HoverOverlay hover error 1`] = `
       data-testid="hover-overlay-contents"
     >
       <div
+        aria-live="polite"
         class="hoverError"
+        role="alert"
       >
         M
       </div>
@@ -349,7 +355,9 @@ exports[`HoverOverlay hover error, actions present 1`] = `
       data-testid="hover-overlay-contents"
     >
       <div
+        aria-live="polite"
         class="hoverError"
+        role="alert"
       >
         M
       </div>

--- a/client/web/src/enterprise/codeintel/uploads/components/CommitGraphMetadata.tsx
+++ b/client/web/src/enterprise/codeintel/uploads/components/CommitGraphMetadata.tsx
@@ -18,7 +18,7 @@ export const CommitGraphMetadata: FunctionComponent<React.PropsWithChildren<Comm
     now,
 }) => (
     <>
-        <Alert variant={stale ? 'primary' : 'success'} className={className}>
+        <Alert variant={stale ? 'primary' : 'success'} className={className} aria-live="off">
             {stale ? <StaleRepository /> : <FreshRepository />}{' '}
             {updatedAt && <LastUpdated updatedAt={updatedAt} now={now} />}
         </Alert>

--- a/client/web/src/enterprise/search/stats/__snapshots__/SearchStatsPage.test.tsx.snap
+++ b/client/web/src/enterprise/search/stats/__snapshots__/SearchStatsPage.test.tsx.snap
@@ -53,6 +53,7 @@ exports[`SearchStatsPage limitHit 1`] = `
       class="my-3"
     />
     <div
+      aria-live="assertive"
       class=""
       role="alert"
     >

--- a/client/web/src/enterprise/user/productSubscriptions/__snapshots__/NewProductSubscriptionPaymentSection.test.tsx.snap
+++ b/client/web/src/enterprise/user/productSubscriptions/__snapshots__/NewProductSubscriptionPaymentSection.test.tsx.snap
@@ -27,6 +27,7 @@ exports[`NewProductSubscriptionPaymentSection downgrade to existing subscription
         </li>
       </ul>
       <div
+        aria-live="assertive"
         class="mb-2"
         role="alert"
       >

--- a/client/web/src/global/__snapshots__/Notices.test.tsx.snap
+++ b/client/web/src/global/__snapshots__/Notices.test.tsx.snap
@@ -8,8 +8,10 @@ exports[`Notices shows notices for location 1`] = `
     class="notices"
   >
     <div
+      aria-live="polite"
       class="alert bg transparent border p-2"
       data-testid="notice-alert"
+      role="alert"
     >
       <div
         class="markdown"
@@ -22,7 +24,9 @@ exports[`Notices shows notices for location 1`] = `
       </div>
     </div>
     <div
+      aria-live="polite"
       class="alert container bg transparent border p-2"
+      role="alert"
     >
       <div
         class="content"

--- a/client/web/src/site/__snapshots__/LicenseExpirationAlert.test.tsx.snap
+++ b/client/web/src/site/__snapshots__/LicenseExpirationAlert.test.tsx.snap
@@ -3,6 +3,7 @@
 exports[`LicenseExpirationAlert expired 1`] = `
 <DocumentFragment>
   <div
+    aria-live="assertive"
     class="alert alertWarning container align-items-center"
     role="alert"
   >
@@ -56,6 +57,7 @@ exports[`LicenseExpirationAlert expired 1`] = `
 exports[`LicenseExpirationAlert expiring soon 1`] = `
 <DocumentFragment>
   <div
+    aria-live="assertive"
     class="alert alertWarning container align-items-center"
     role="alert"
   >

--- a/client/wildcard/src/components/Alert/Alert.test.tsx
+++ b/client/wildcard/src/components/Alert/Alert.test.tsx
@@ -10,7 +10,9 @@ describe('Alert', () => {
         const { container } = render(<Alert>Simple Alert</Alert>)
         expect(container.firstChild).toMatchInlineSnapshot(`
             <div
+              aria-live="polite"
               class=""
+              role="alert"
             >
               Simple Alert
             </div>

--- a/client/wildcard/src/components/Alert/Alert.tsx
+++ b/client/wildcard/src/components/Alert/Alert.tsx
@@ -16,19 +16,27 @@ export interface AlertProps extends React.HTMLAttributes<HTMLDivElement> {
     variant?: AlertVariant
 }
 
-const userShouldBeNotified = (variant?: AlertVariant): boolean => variant === 'danger' || variant === 'warning'
+const userShouldBeImmediatelyNotified = (variant?: AlertVariant): boolean =>
+    variant === 'danger' || variant === 'warning'
 
 export const Alert = React.forwardRef(
-    ({ children, as: Component = 'div', variant, className, role, ...attributes }, reference) => {
+    ({ children, as: Component = 'div', variant, className, role = 'alert', ...attributes }, reference) => {
         const { isBranded } = useWildcardTheme()
         const brandedClassName = isBranded && classNames(styles.alert, variant && getAlertStyle({ variant }))
-        const alertRole = role || userShouldBeNotified(variant) ? 'alert' : undefined
+
+        /**
+         * Set the assertiveness setting on the alert.
+         * Assertive: The alert will interrupt any current screen reader announcements.
+         * Polite: The alert will be read out by the screen reader when the user is idle.
+         */
+        const alertAssertiveness = userShouldBeImmediatelyNotified(variant) ? 'assertive' : 'polite'
 
         return (
             <Component
                 ref={reference}
                 className={classNames(brandedClassName, className)}
-                role={alertRole}
+                role={role}
+                aria-live={alertAssertiveness}
                 {...attributes}
             >
                 {children}

--- a/client/wildcard/src/components/Alert/Alert.tsx
+++ b/client/wildcard/src/components/Alert/Alert.tsx
@@ -19,6 +19,13 @@ export interface AlertProps extends React.HTMLAttributes<HTMLDivElement> {
 const userShouldBeImmediatelyNotified = (variant?: AlertVariant): boolean =>
     variant === 'danger' || variant === 'warning'
 
+/**
+ * Renders a styled alert on the page.
+ *
+ * Note: These alerts will be automatically read out by screen readers.
+ * If this is not desired behavior, you should pass `aria-live="off"` to this component.
+ * Further details: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/alert_role
+ */
 export const Alert = React.forwardRef(
     ({ children, as: Component = 'div', variant, className, role = 'alert', ...attributes }, reference) => {
         const { isBranded } = useWildcardTheme()

--- a/client/wildcard/src/components/Alert/__snapshots__/Alert.test.tsx.snap
+++ b/client/wildcard/src/components/Alert/__snapshots__/Alert.test.tsx.snap
@@ -2,6 +2,7 @@
 
 exports[`Alert renders variant 'danger' correctly 1`] = `
 <div
+  aria-live="assertive"
   class=""
   role="alert"
 >
@@ -16,7 +17,9 @@ exports[`Alert renders variant 'danger' correctly 1`] = `
 
 exports[`Alert renders variant 'info' correctly 1`] = `
 <div
+  aria-live="polite"
   class=""
+  role="alert"
 >
   <h4
     class="h4"
@@ -29,7 +32,9 @@ exports[`Alert renders variant 'info' correctly 1`] = `
 
 exports[`Alert renders variant 'merged' correctly 1`] = `
 <div
+  aria-live="polite"
   class=""
+  role="alert"
 >
   <h4
     class="h4"
@@ -42,7 +47,9 @@ exports[`Alert renders variant 'merged' correctly 1`] = `
 
 exports[`Alert renders variant 'note' correctly 1`] = `
 <div
+  aria-live="polite"
   class=""
+  role="alert"
 >
   <h4
     class="h4"
@@ -55,7 +62,9 @@ exports[`Alert renders variant 'note' correctly 1`] = `
 
 exports[`Alert renders variant 'primary' correctly 1`] = `
 <div
+  aria-live="polite"
   class=""
+  role="alert"
 >
   <h4
     class="h4"
@@ -68,7 +77,9 @@ exports[`Alert renders variant 'primary' correctly 1`] = `
 
 exports[`Alert renders variant 'secondary' correctly 1`] = `
 <div
+  aria-live="polite"
   class=""
+  role="alert"
 >
   <h4
     class="h4"
@@ -81,7 +92,9 @@ exports[`Alert renders variant 'secondary' correctly 1`] = `
 
 exports[`Alert renders variant 'success' correctly 1`] = `
 <div
+  aria-live="polite"
   class=""
+  role="alert"
 >
   <h4
     class="h4"
@@ -94,7 +107,9 @@ exports[`Alert renders variant 'success' correctly 1`] = `
 
 exports[`Alert renders variant 'waiting' correctly 1`] = `
 <div
+  aria-live="polite"
   class=""
+  role="alert"
 >
   <h4
     class="h4"
@@ -107,6 +122,7 @@ exports[`Alert renders variant 'waiting' correctly 1`] = `
 
 exports[`Alert renders variant 'warning' correctly 1`] = `
 <div
+  aria-live="assertive"
   class=""
   role="alert"
 >

--- a/client/wildcard/src/components/Feedback/FeedbackPrompt/__snapshots__/FeedbackPrompt.test.tsx.snap
+++ b/client/wildcard/src/components/Feedback/FeedbackPrompt/__snapshots__/FeedbackPrompt.test.tsx.snap
@@ -514,6 +514,7 @@ exports[`FeedbackPrompt should render submit error correctly 1`] = `
             </li>
           </ul>
           <div
+            aria-live="assertive"
             class="mt-3"
             role="alert"
           >


### PR DESCRIPTION
## Description

We disabled `role="alert"` by default in this PR: https://github.com/sourcegraph/sourcegraph/pull/35410

That fixes a lot of areas where our alerts are a bit too eager (example: loading a page for the first time, like https://sourcegraph.com/code-monitoring).

It means that we have to remember to opt-in for other valid alerts (like form submission). Instead of enforcing this, we can make it opt-out as there should (hopefully) be less problematic uses in our app.


## Test plan

Tested with a screen reader in local development

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-tr-alert-assertiveness.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-wdbnktysho.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
