### PR TITLE
database: remove dbutil-based constructors

### DIFF
--- a/cmd/frontend/internal/app/updatecheck/client.go
+++ b/cmd/frontend/internal/app/updatecheck/client.go
@@ -579,7 +579,7 @@ func updateBody(ctx context.Context, db database.DB) (io.Reader, error) {
 		return nil, err
 	}
 
-	err = database.EventLogs(db).Insert(ctx, &database.Event{
+	err = db.EventLogs().Insert(ctx, &database.Event{
 		UserID:          0,
 		Name:            "ping",
 		URL:             "",

--- a/cmd/frontend/internal/auth/userpasswd/handlers.go
+++ b/cmd/frontend/internal/auth/userpasswd/handlers.go
@@ -190,7 +190,7 @@ func handleSignUp(db database.DB, w http.ResponseWriter, r *http.Request, failIf
 		return
 	}
 
-	if err = database.Authz(db).GrantPendingPermissions(r.Context(), &database.GrantPendingPermissionsArgs{
+	if err = db.Authz().GrantPendingPermissions(r.Context(), &database.GrantPendingPermissionsArgs{
 		UserID: usr.ID,
 		Perm:   authz.Read,
 		Type:   authz.PermRepos,

--- a/cmd/frontend/internal/usagestatsdeprecated/action_handlers.go
+++ b/cmd/frontend/internal/usagestatsdeprecated/action_handlers.go
@@ -177,5 +177,5 @@ func LogEvent(ctx context.Context, db database.DB, name, url string, userID int3
 		Argument:        argument,
 		FeatureFlags:    featureFlags,
 	}
-	return database.EventLogs(db).Insert(ctx, info)
+	return db.EventLogs().Insert(ctx, info)
 }

--- a/enterprise/cmd/frontend/internal/authz/init.go
+++ b/enterprise/cmd/frontend/internal/authz/init.go
@@ -24,7 +24,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/timeutil"
@@ -34,9 +33,6 @@ var clock = timeutil.Now
 
 func Init(ctx context.Context, db database.DB, _ conftypes.UnifiedWatchable, enterpriseServices *enterprise.Services, observationContext *observation.Context) error {
 	database.ValidateExternalServiceConfig = edb.ValidateExternalServiceConfig
-	database.Authz = func(db dbutil.DB) database.AuthzStore {
-		return edb.NewAuthzStore(db, clock)
-	}
 	database.AuthzWith = func(other basestore.ShareableStore) database.AuthzStore {
 		return edb.NewAuthzStore(db, clock)
 	}

--- a/enterprise/internal/insights/background/pings/insights_ping_emitter.go
+++ b/enterprise/internal/insights/background/pings/insights_ping_emitter.go
@@ -204,7 +204,7 @@ func (e *InsightsPingEmitter) emitInsightsPerDashboard(ctx context.Context) erro
 }
 
 func (e *InsightsPingEmitter) SaveEvent(ctx context.Context, name string, argument json.RawMessage) error {
-	store := database.NewDB(e.PostgresDb).EventLogs()
+	store := database.NewDB(e.postgresDb).EventLogs()
 
 	err := store.Insert(ctx, &database.Event{
 		Name:            name,

--- a/enterprise/internal/insights/background/pings/insights_ping_emitter.go
+++ b/enterprise/internal/insights/background/pings/insights_ping_emitter.go
@@ -204,7 +204,7 @@ func (e *InsightsPingEmitter) emitInsightsPerDashboard(ctx context.Context) erro
 }
 
 func (e *InsightsPingEmitter) SaveEvent(ctx context.Context, name string, argument json.RawMessage) error {
-	store := database.EventLogs(e.postgresDb)
+	store := database.EventLogsWith(database.NewDB(e.postgresDb))
 
 	err := store.Insert(ctx, &database.Event{
 		Name:            name,

--- a/enterprise/internal/insights/background/pings/insights_ping_emitter.go
+++ b/enterprise/internal/insights/background/pings/insights_ping_emitter.go
@@ -204,7 +204,7 @@ func (e *InsightsPingEmitter) emitInsightsPerDashboard(ctx context.Context) erro
 }
 
 func (e *InsightsPingEmitter) SaveEvent(ctx context.Context, name string, argument json.RawMessage) error {
-	store := database.EventLogsWith(database.NewDB(e.postgresDb))
+	store := database.NewDB(e.PostgresDb).EventLogs()
 
 	err := store.Insert(ctx, &database.Event{
 		Name:            name,

--- a/internal/database/access_tokens.go
+++ b/internal/database/access_tokens.go
@@ -13,7 +13,6 @@ import (
 	"github.com/lib/pq"
 
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
@@ -129,11 +128,6 @@ type accessTokenStore struct {
 }
 
 var _ AccessTokenStore = (*accessTokenStore)(nil)
-
-// AccessTokens instantiates and returns a new AccessTokenStore with prepared statements.
-func AccessTokens(db dbutil.DB) AccessTokenStore {
-	return &accessTokenStore{Store: basestore.NewWithDB(db, sql.TxOptions{})}
-}
 
 // AccessTokensWith instantiates and returns a new AccessTokenStore using the other store handle.
 func AccessTokensWith(other basestore.ShareableStore) AccessTokenStore {

--- a/internal/database/access_tokens_test.go
+++ b/internal/database/access_tokens_test.go
@@ -12,7 +12,7 @@ import (
 // to the user.
 func TestAccessTokens_Create(t *testing.T) {
 	t.Parallel()
-	db := dbtest.NewDB(t)
+	db := NewDB(dbtest.NewDB(t))
 	ctx := context.Background()
 
 	subject, err := Users(db).Create(ctx, NewUser{
@@ -35,12 +35,12 @@ func TestAccessTokens_Create(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	tid0, tv0, err := AccessTokens(db).Create(ctx, subject.ID, []string{"a", "b"}, "n0", creator.ID)
+	tid0, tv0, err := db.AccessTokens().Create(ctx, subject.ID, []string{"a", "b"}, "n0", creator.ID)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	got, err := AccessTokens(db).GetByID(ctx, tid0)
+	got, err := db.AccessTokens().GetByID(ctx, tid0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -54,7 +54,7 @@ func TestAccessTokens_Create(t *testing.T) {
 		t.Errorf("got %q, want %q", got.Note, want)
 	}
 
-	gotSubjectUserID, err := AccessTokens(db).Lookup(ctx, tv0, "a")
+	gotSubjectUserID, err := db.AccessTokens().Lookup(ctx, tv0, "a")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -62,7 +62,7 @@ func TestAccessTokens_Create(t *testing.T) {
 		t.Errorf("got %v, want %v", gotSubjectUserID, want)
 	}
 
-	ts, err := AccessTokens(db).List(ctx, AccessTokensListOptions{SubjectUserID: subject.ID})
+	ts, err := db.AccessTokens().List(ctx, AccessTokensListOptions{SubjectUserID: subject.ID})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -74,7 +74,7 @@ func TestAccessTokens_Create(t *testing.T) {
 	}
 
 	// Accidentally passing the creator's UID in SubjectUserID should not return anything.
-	ts, err = AccessTokens(db).List(ctx, AccessTokensListOptions{SubjectUserID: creator.ID})
+	ts, err = db.AccessTokens().List(ctx, AccessTokensListOptions{SubjectUserID: creator.ID})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -88,7 +88,7 @@ func TestAccessTokens_List(t *testing.T) {
 		t.Skip()
 	}
 	t.Parallel()
-	db := dbtest.NewDB(t)
+	db := NewDB(dbtest.NewDB(t))
 	ctx := context.Background()
 
 	subject1, err := Users(db).Create(ctx, NewUser{
@@ -110,25 +110,25 @@ func TestAccessTokens_List(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, _, err = AccessTokens(db).Create(ctx, subject1.ID, []string{"a", "b"}, "n0", subject1.ID)
+	_, _, err = db.AccessTokens().Create(ctx, subject1.ID, []string{"a", "b"}, "n0", subject1.ID)
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, _, err = AccessTokens(db).Create(ctx, subject1.ID, []string{"a", "b"}, "n1", subject1.ID)
+	_, _, err = db.AccessTokens().Create(ctx, subject1.ID, []string{"a", "b"}, "n1", subject1.ID)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	{
 		// List all tokens.
-		ts, err := AccessTokens(db).List(ctx, AccessTokensListOptions{})
+		ts, err := db.AccessTokens().List(ctx, AccessTokensListOptions{})
 		if err != nil {
 			t.Fatal(err)
 		}
 		if want := 2; len(ts) != want {
 			t.Errorf("got %d access tokens, want %d", len(ts), want)
 		}
-		count, err := AccessTokens(db).Count(ctx, AccessTokensListOptions{})
+		count, err := db.AccessTokens().Count(ctx, AccessTokensListOptions{})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -139,7 +139,7 @@ func TestAccessTokens_List(t *testing.T) {
 
 	{
 		// List subject1's tokens.
-		ts, err := AccessTokens(db).List(ctx, AccessTokensListOptions{SubjectUserID: subject1.ID})
+		ts, err := db.AccessTokens().List(ctx, AccessTokensListOptions{SubjectUserID: subject1.ID})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -150,7 +150,7 @@ func TestAccessTokens_List(t *testing.T) {
 
 	{
 		// List subject2's tokens.
-		ts, err := AccessTokens(db).List(ctx, AccessTokensListOptions{SubjectUserID: subject2.ID})
+		ts, err := db.AccessTokens().List(ctx, AccessTokensListOptions{SubjectUserID: subject2.ID})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -167,7 +167,7 @@ func TestAccessTokens_Lookup(t *testing.T) {
 		t.Skip()
 	}
 	t.Parallel()
-	db := dbtest.NewDB(t)
+	db := NewDB(dbtest.NewDB(t))
 	ctx := context.Background()
 
 	subject, err := Users(db).Create(ctx, NewUser{
@@ -190,13 +190,13 @@ func TestAccessTokens_Lookup(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	tid0, tv0, err := AccessTokens(db).Create(ctx, subject.ID, []string{"a", "b"}, "n0", creator.ID)
+	tid0, tv0, err := db.AccessTokens().Create(ctx, subject.ID, []string{"a", "b"}, "n0", creator.ID)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	for _, scope := range []string{"a", "b"} {
-		gotSubjectUserID, err := AccessTokens(db).Lookup(ctx, tv0, scope)
+		gotSubjectUserID, err := db.AccessTokens().Lookup(ctx, tv0, scope)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -206,25 +206,25 @@ func TestAccessTokens_Lookup(t *testing.T) {
 	}
 
 	// Lookup with a nonexistent scope and ensure it fails.
-	if _, err := AccessTokens(db).Lookup(ctx, tv0, "x"); err == nil {
+	if _, err := db.AccessTokens().Lookup(ctx, tv0, "x"); err == nil {
 		t.Fatal(err)
 	}
 
 	// Lookup with an empty scope and ensure it fails.
-	if _, err := AccessTokens(db).Lookup(ctx, tv0, ""); err == nil {
+	if _, err := db.AccessTokens().Lookup(ctx, tv0, ""); err == nil {
 		t.Fatal(err)
 	}
 
 	// Delete a token and ensure Lookup fails on it.
-	if err := AccessTokens(db).DeleteByID(ctx, tid0); err != nil {
+	if err := db.AccessTokens().DeleteByID(ctx, tid0); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := AccessTokens(db).Lookup(ctx, tv0, "a"); err == nil {
+	if _, err := db.AccessTokens().Lookup(ctx, tv0, "a"); err == nil {
 		t.Fatal(err)
 	}
 
 	// Try to Lookup a token that was never created.
-	if _, err := AccessTokens(db).Lookup(ctx, "abcdefg" /* this token value was never created */, "a"); err == nil {
+	if _, err := db.AccessTokens().Lookup(ctx, "abcdefg" /* this token value was never created */, "a"); err == nil {
 		t.Fatal(err)
 	}
 }
@@ -236,7 +236,7 @@ func TestAccessTokens_Lookup_deletedUser(t *testing.T) {
 		t.Skip()
 	}
 	t.Parallel()
-	db := dbtest.NewDB(t)
+	db := NewDB(dbtest.NewDB(t))
 	ctx := context.Background()
 
 	t.Run("subject", func(t *testing.T) {
@@ -259,18 +259,18 @@ func TestAccessTokens_Lookup_deletedUser(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		_, tv0, err := AccessTokens(db).Create(ctx, subject.ID, []string{"a"}, "n0", creator.ID)
+		_, tv0, err := db.AccessTokens().Create(ctx, subject.ID, []string{"a"}, "n0", creator.ID)
 		if err != nil {
 			t.Fatal(err)
 		}
 		if err := Users(db).Delete(ctx, subject.ID); err != nil {
 			t.Fatal(err)
 		}
-		if _, err := AccessTokens(db).Lookup(ctx, tv0, "a"); err == nil {
+		if _, err := db.AccessTokens().Lookup(ctx, tv0, "a"); err == nil {
 			t.Fatal("Lookup: want error looking up token for deleted subject user")
 		}
 
-		if _, _, err := AccessTokens(db).Create(ctx, subject.ID, nil, "n0", creator.ID); err == nil {
+		if _, _, err := db.AccessTokens().Create(ctx, subject.ID, nil, "n0", creator.ID); err == nil {
 			t.Fatal("Create: want error creating token for deleted subject user")
 		}
 	})
@@ -295,18 +295,18 @@ func TestAccessTokens_Lookup_deletedUser(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		_, tv0, err := AccessTokens(db).Create(ctx, subject.ID, []string{"a"}, "n0", creator.ID)
+		_, tv0, err := db.AccessTokens().Create(ctx, subject.ID, []string{"a"}, "n0", creator.ID)
 		if err != nil {
 			t.Fatal(err)
 		}
 		if err := Users(db).Delete(ctx, creator.ID); err != nil {
 			t.Fatal(err)
 		}
-		if _, err := AccessTokens(db).Lookup(ctx, tv0, "a"); err == nil {
+		if _, err := db.AccessTokens().Lookup(ctx, tv0, "a"); err == nil {
 			t.Fatal("Lookup: want error looking up token for deleted creator user")
 		}
 
-		if _, _, err := AccessTokens(db).Create(ctx, subject.ID, nil, "n0", creator.ID); err == nil {
+		if _, _, err := db.AccessTokens().Create(ctx, subject.ID, nil, "n0", creator.ID); err == nil {
 			t.Fatal("Create: want error creating token for deleted creator user")
 		}
 	})

--- a/internal/database/authz.go
+++ b/internal/database/authz.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
@@ -57,12 +56,9 @@ type AuthzStore interface {
 	RevokeUserPermissions(ctx context.Context, args *RevokeUserPermissionsArgs) error
 }
 
-// Authz instantiates and returns a new AuthzStore. In the OSS version, this is a no-op AuthzStore, but
-// this constructor is overridden in enterprise versions.
-var Authz = func(db dbutil.DB) AuthzStore {
-	return &authzStore{}
-}
-
+// AuthzWith instantiates and returns a new AuthzStore using the other store
+// handle. In the OSS version, this is a no-op AuthzStore, but this constructor
+// is overridden in enterprise versions.
 var AuthzWith = func(other basestore.ShareableStore) AuthzStore {
 	return &authzStore{}
 }

--- a/internal/database/event_logs.go
+++ b/internal/database/event_logs.go
@@ -134,12 +134,7 @@ type eventLogStore struct {
 	*basestore.Store
 }
 
-// EventLogs instantiates and returns a new EventLogStore with prepared statements.
-func EventLogs(db dbutil.DB) EventLogStore {
-	return &eventLogStore{Store: basestore.NewWithDB(db, sql.TxOptions{})}
-}
-
-// NewEventLogStoreWithDB instantiates and returns a new EventLogStore using the other store handle.
+// EventLogsWith instantiates and returns a new EventLogStore using the other store handle.
 func EventLogsWith(other basestore.ShareableStore) EventLogStore {
 	return &eventLogStore{Store: basestore.NewWithHandle(other.Handle())}
 }

--- a/internal/database/users_test.go
+++ b/internal/database/users_test.go
@@ -494,7 +494,7 @@ func TestUsers_Delete(t *testing.T) {
 				t.Skip()
 			}
 			t.Parallel()
-			db := dbtest.NewDB(t)
+			db := NewDB(dbtest.NewDB(t))
 			ctx := context.Background()
 			ctx = actor.WithActor(ctx, &actor.Actor{UID: 1, Internal: true})
 
@@ -550,7 +550,7 @@ func TestUsers_Delete(t *testing.T) {
 			}
 
 			// Create an event log
-			err = EventLogs(db).Insert(ctx, &Event{
+			err = db.EventLogs().Insert(ctx, &Event{
 				Name:            "something",
 				URL:             "http://example.com",
 				UserID:          uint32(user.ID),
@@ -619,7 +619,7 @@ func TestUsers_Delete(t *testing.T) {
 			}
 
 			// Check event logs
-			eventLogs, err := EventLogs(db).ListAll(ctx, EventLogsListOptions{})
+			eventLogs, err := db.EventLogs().ListAll(ctx, EventLogsListOptions{})
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/usagestats/aggregated.go
+++ b/internal/usagestats/aggregated.go
@@ -8,7 +8,7 @@ import (
 )
 
 func GetSiteUsageStats(ctx context.Context, db database.DB, monthsOnly bool) (*types.SiteUsageStatistics, error) {
-	summary, err := database.EventLogs(db).SiteUsage(ctx)
+	summary, err := db.EventLogs().SiteUsage(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/usagestats/aggregated_codeintel.go
+++ b/internal/usagestats/aggregated_codeintel.go
@@ -11,7 +11,7 @@ import (
 
 // GetAggregatedCodeIntelStats returns aggregated statistics for code intelligence usage.
 func GetAggregatedCodeIntelStats(ctx context.Context, db database.DB) (*types.NewCodeIntelUsageStatistics, error) {
-	eventLogs := database.EventLogs(db)
+	eventLogs := db.EventLogs()
 
 	codeIntelEvents, err := eventLogs.AggregatedCodeIntelEvents(ctx)
 	if err != nil {

--- a/internal/usagestats/aggregated_search.go
+++ b/internal/usagestats/aggregated_search.go
@@ -11,7 +11,7 @@ import (
 // GetAggregatedSearchStats queries the database for search usage and returns
 // the aggregates statistics in the format of our BigQuery schema.
 func GetAggregatedSearchStats(ctx context.Context, db database.DB) (*types.SearchUsageStatistics, error) {
-	events, err := database.EventLogs(db).AggregatedSearchEvents(ctx, time.Now().UTC())
+	events, err := db.EventLogs().AggregatedSearchEvents(ctx, time.Now().UTC())
 	if err != nil {
 		return nil, err
 	}

--- a/internal/usagestats/code_insights.go
+++ b/internal/usagestats/code_insights.go
@@ -196,7 +196,7 @@ func GetWeeklyTabClicks(ctx context.Context, db database.DB, sql string) ([]type
 }
 
 func GetTotalInsightCounts(ctx context.Context, db database.DB) (types.InsightTotalCounts, error) {
-	store := database.EventLogs(db)
+	store := db.EventLogs()
 	name := InsightsTotalCountPingName
 	all, err := store.ListAll(ctx, database.EventLogsListOptions{
 		LimitOffset: &database.LimitOffset{
@@ -221,7 +221,7 @@ func GetTotalInsightCounts(ctx context.Context, db database.DB) (types.InsightTo
 }
 
 func GetTimeStepCounts(ctx context.Context, db database.DB) ([]types.InsightTimeIntervalPing, error) {
-	store := database.EventLogs(db)
+	store := db.EventLogs()
 	name := InsightsIntervalCountsPingName
 	all, err := store.ListAll(ctx, database.EventLogsListOptions{
 		LimitOffset: &database.LimitOffset{
@@ -246,7 +246,7 @@ func GetTimeStepCounts(ctx context.Context, db database.DB) ([]types.InsightTime
 }
 
 func GetOrgInsightCounts(ctx context.Context, db database.DB) ([]types.OrgVisibleInsightPing, error) {
-	store := database.EventLogs(db)
+	store := db.EventLogs()
 	name := InsightsOrgVisibleInsightsPingName
 	all, err := store.ListAll(ctx, database.EventLogsListOptions{
 		LimitOffset: &database.LimitOffset{
@@ -271,7 +271,7 @@ func GetOrgInsightCounts(ctx context.Context, db database.DB) ([]types.OrgVisibl
 }
 
 func GetIntCount(ctx context.Context, db database.DB, pingName string) (int32, error) {
-	store := database.EventLogs(db)
+	store := db.EventLogs()
 	all, err := store.ListAll(ctx, database.EventLogsListOptions{
 		LimitOffset: &database.LimitOffset{
 			Limit:  1,
@@ -304,7 +304,7 @@ func GetCreationViewUsage(ctx context.Context, db database.DB, timeSupplier func
 }
 
 func GetInsightsPerDashboard(ctx context.Context, db database.DB) (types.InsightsPerDashboardPing, error) {
-	store := database.EventLogs(db)
+	store := db.EventLogs()
 	name := InsightsPerDashboardPingName
 	all, err := store.ListAll(ctx, database.EventLogsListOptions{
 		LimitOffset: &database.LimitOffset{

--- a/internal/usagestats/code_insights_critical.go
+++ b/internal/usagestats/code_insights_critical.go
@@ -19,7 +19,7 @@ func GetCodeInsightsCriticalTelemetry(ctx context.Context, db database.DB) (_ *t
 }
 
 func totalCountCritical(ctx context.Context, db database.DB) (types.CodeInsightsCriticalTelemetry, error) {
-	store := database.EventLogs(db)
+	store := db.EventLogs()
 	name := InsightsTotalCountCriticalPingName
 	all, err := store.ListAll(ctx, database.EventLogsListOptions{
 		LimitOffset: &database.LimitOffset{

--- a/internal/usagestats/retention_test.go
+++ b/internal/usagestats/retention_test.go
@@ -40,7 +40,7 @@ func TestRetentionUsageStatistics(t *testing.T) {
 	}}
 
 	for _, event := range events {
-		err := database.EventLogs(db).Insert(ctx, &event)
+		err := db.EventLogs().Insert(ctx, &event)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/usagestats/usage_stats.go
+++ b/internal/usagestats/usage_stats.go
@@ -22,7 +22,7 @@ var (
 // GetArchive generates and returns a usage statistics ZIP archive containing the CSV
 // files defined in RFC 145, or an error in case of failure.
 func GetArchive(ctx context.Context, db database.DB) ([]byte, error) {
-	counts, err := database.EventLogs(db).UsersUsageCounts(ctx)
+	counts, err := db.EventLogs().UsersUsageCounts(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -113,27 +113,27 @@ func GetByUserID(ctx context.Context, db database.DB, userID int32) (*types.User
 		return MockGetByUserID(userID)
 	}
 
-	pageViews, err := database.EventLogs(db).CountByUserIDAndEventNamePrefix(ctx, userID, "View")
+	pageViews, err := db.EventLogs().CountByUserIDAndEventNamePrefix(ctx, userID, "View")
 	if err != nil {
 		return nil, err
 	}
-	searchQueries, err := database.EventLogs(db).CountByUserIDAndEventName(ctx, userID, "SearchResultsQueried")
+	searchQueries, err := db.EventLogs().CountByUserIDAndEventName(ctx, userID, "SearchResultsQueried")
 	if err != nil {
 		return nil, err
 	}
-	codeIntelligenceActions, err := database.EventLogs(db).CountByUserIDAndEventNames(ctx, userID, []string{"hover", "findReferences", "goToDefinition.preloaded", "goToDefinition"})
+	codeIntelligenceActions, err := db.EventLogs().CountByUserIDAndEventNames(ctx, userID, []string{"hover", "findReferences", "goToDefinition.preloaded", "goToDefinition"})
 	if err != nil {
 		return nil, err
 	}
-	findReferencesActions, err := database.EventLogs(db).CountByUserIDAndEventName(ctx, userID, "findReferences")
+	findReferencesActions, err := db.EventLogs().CountByUserIDAndEventName(ctx, userID, "findReferences")
 	if err != nil {
 		return nil, err
 	}
-	lastActiveTime, err := database.EventLogs(db).MaxTimestampByUserID(ctx, userID)
+	lastActiveTime, err := db.EventLogs().MaxTimestampByUserID(ctx, userID)
 	if err != nil {
 		return nil, err
 	}
-	lastCodeHostIntegrationTime, err := database.EventLogs(db).MaxTimestampByUserIDAndSource(ctx, userID, "CODEHOSTINTEGRATION")
+	lastCodeHostIntegrationTime, err := db.EventLogs().MaxTimestampByUserIDAndSource(ctx, userID, "CODEHOSTINTEGRATION")
 	if err != nil {
 		return nil, err
 	}
@@ -152,27 +152,27 @@ func GetByUserID(ctx context.Context, db database.DB, userID int32) (*types.User
 func GetUsersActiveTodayCount(ctx context.Context, db database.DB) (int, error) {
 	now := timeNow().UTC()
 	today := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)
-	return database.EventLogs(db).CountUniqueUsersAll(ctx, today, today.AddDate(0, 0, 1))
+	return db.EventLogs().CountUniqueUsersAll(ctx, today, today.AddDate(0, 0, 1))
 }
 
 // ListRegisteredUsersToday returns a list of the registered users that were active today.
 func ListRegisteredUsersToday(ctx context.Context, db database.DB) ([]int32, error) {
 	now := timeNow().UTC()
 	start := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)
-	return database.EventLogs(db).ListUniqueUsersAll(ctx, start, start.AddDate(0, 0, 1))
+	return db.EventLogs().ListUniqueUsersAll(ctx, start, start.AddDate(0, 0, 1))
 }
 
 // ListRegisteredUsersThisWeek returns a list of the registered users that were active this week.
 func ListRegisteredUsersThisWeek(ctx context.Context, db database.DB) ([]int32, error) {
 	start := timeutil.StartOfWeek(timeNow().UTC(), 0)
-	return database.EventLogs(db).ListUniqueUsersAll(ctx, start, start.AddDate(0, 0, 7))
+	return db.EventLogs().ListUniqueUsersAll(ctx, start, start.AddDate(0, 0, 7))
 }
 
 // ListRegisteredUsersThisMonth returns a list of the registered users that were active this month.
 func ListRegisteredUsersThisMonth(ctx context.Context, db database.DB) ([]int32, error) {
 	now := timeNow().UTC()
 	start := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC)
-	return database.EventLogs(db).ListUniqueUsersAll(ctx, start, start.AddDate(0, 1, 0))
+	return db.EventLogs().ListUniqueUsersAll(ctx, start, start.AddDate(0, 1, 0))
 }
 
 // SiteUsageStatisticsOptions contains options for the number of daily, weekly, and monthly periods in
@@ -229,17 +229,17 @@ func activeUsers(ctx context.Context, db database.DB, periodType database.Period
 		return []*types.SiteActivityPeriod{}, nil
 	}
 
-	uniqueUsers, err := database.EventLogs(db).CountUniqueUsersPerPeriod(ctx, periodType, timeNow().UTC(), periods, nil)
+	uniqueUsers, err := db.EventLogs().CountUniqueUsersPerPeriod(ctx, periodType, timeNow().UTC(), periods, nil)
 	if err != nil {
 		return nil, err
 	}
-	registeredUniqueUsers, err := database.EventLogs(db).CountUniqueUsersPerPeriod(ctx, periodType, timeNow().UTC(), periods, &database.CountUniqueUsersOptions{
+	registeredUniqueUsers, err := db.EventLogs().CountUniqueUsersPerPeriod(ctx, periodType, timeNow().UTC(), periods, &database.CountUniqueUsersOptions{
 		RegisteredOnly: true,
 	})
 	if err != nil {
 		return nil, err
 	}
-	integrationUniqueUsers, err := database.EventLogs(db).CountUniqueUsersPerPeriod(ctx, periodType, timeNow().UTC(), periods, &database.CountUniqueUsersOptions{
+	integrationUniqueUsers, err := db.EventLogs().CountUniqueUsersPerPeriod(ctx, periodType, timeNow().UTC(), periods, &database.CountUniqueUsersOptions{
 		IntegrationOnly: true,
 	})
 	if err != nil {

--- a/internal/usagestats/usage_stats_test.go
+++ b/internal/usagestats/usage_stats_test.go
@@ -40,7 +40,7 @@ func TestGetArchive(t *testing.T) {
 		Timestamp: now,
 	}
 
-	err = database.EventLogs(db).Insert(ctx, event)
+	err = db.EventLogs().Insert(ctx, event)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Remove few dbutil-based constructors in our database package, as they are not mockable in our tests.

This is a result of a time-boxed effort.

## Test plan

Unit tests

---

Part of https://github.com/sourcegraph/sourcegraph/issues/26113