### PR TITLE
Bump src cli for 3.40 release

### DIFF
--- a/internal/src-cli/consts.go
+++ b/internal/src-cli/consts.go
@@ -6,4 +6,4 @@ package srccli
 // as the suggested download with this instance.
 //
 // At the time of a Sourcegraph release, this is always the latest src-cli version.
-const MinimumVersion = "3.39.2"
+const MinimumVersion = "3.40.0"


### PR DESCRIPTION
## Test plan

This bumps src-cli to 3.40. This will be used in executor images that yet have to be built and deployed to dogfood.
