### PR TITLE
force run of chromatic with commt msg

### DIFF
--- a/enterprise/dev/ci/internal/ci/config.go
+++ b/enterprise/dev/ci/internal/ci/config.go
@@ -192,12 +192,16 @@ type MessageFlags struct {
 	// SkipHashCompare, if true, tells buildkite to disable skipping of steps that compare
 	// hash output.
 	SkipHashCompare bool
+
+	//Force run the Chromatic step to run. This allows a user to run the job without marking their PR as ready for review
+	ForceRunStepChromatic bool
 }
 
 // parseMessageFlags gets MessageFlags from the given commit message.
 func parseMessageFlags(msg string) MessageFlags {
 	return MessageFlags{
-		ProfilingEnabled: strings.Contains(msg, "[buildkite-enable-profiling]"),
-		SkipHashCompare:  strings.Contains(msg, "[skip-hash-compare]"),
+		ProfilingEnabled:      strings.Contains(msg, "[buildkite-enable-profiling]"),
+		SkipHashCompare:       strings.Contains(msg, "[skip-hash-compare]"),
+		ForceRunStepChromatic: strings.Contains(msg, "[force-run-step-chromatic]"),
 	}
 }

--- a/enterprise/dev/ci/internal/ci/operations.go
+++ b/enterprise/dev/ci/internal/ci/operations.go
@@ -25,6 +25,7 @@ type CoreTestOperationsOptions struct {
 	ChromaticShouldAutoAccept  bool
 	MinimumUpgradeableVersion  string
 	ClientLintOnlyChangedFiles bool
+	ForceRunChromatic          bool
 }
 
 // CoreTestOperations is a core set of tests that should be run in most CI cases. More
@@ -59,7 +60,7 @@ func CoreTestOperations(diff changed.Diff, opts CoreTestOperationsOptions) *oper
 		// If there are any Graphql changes, they are impacting the client as well.
 		clientChecks := operations.NewNamedSet("Client checks",
 			clientIntegrationTests,
-			clientChromaticTests(opts.ChromaticShouldAutoAccept),
+			clientChromaticTests(opts),
 			frontendTests,                // ~4.5m
 			addWebApp,                    // ~5.5m
 			addBrowserExtensionUnitTests, // ~4.5m
@@ -324,7 +325,7 @@ func clientIntegrationTests(pipeline *bk.Pipeline) {
 	}
 }
 
-func clientChromaticTests(autoAcceptChanges bool) operations.Operation {
+func clientChromaticTests(opts CoreTestOperationsOptions) operations.Operation {
 	return func(pipeline *bk.Pipeline) {
 		stepOpts := []bk.StepOpt{
 			withYarnCache(),
@@ -336,8 +337,10 @@ func clientChromaticTests(autoAcceptChanges bool) operations.Operation {
 
 		// Upload storybook to Chromatic
 		chromaticCommand := "yarn chromatic --exit-zero-on-changes --exit-once-uploaded"
-		if autoAcceptChanges {
+		if opts.ChromaticShouldAutoAccept {
 			chromaticCommand += " --auto-accept-changes"
+		} else if opts.ForceRunChromatic {
+			chromaticCommand += " | ./dev/ci/post-chromatic.sh"
 		} else {
 			// Unless we plan on automatically accepting these changes, we only run this
 			// step on ready-for-review pull requests.

--- a/enterprise/dev/ci/internal/ci/pipeline.go
+++ b/enterprise/dev/ci/internal/ci/pipeline.go
@@ -235,6 +235,7 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 		ops.Merge(CoreTestOperations(changed.All, CoreTestOperationsOptions{
 			ChromaticShouldAutoAccept: c.RunType.Is(runtype.MainBranch),
 			MinimumUpgradeableVersion: minimumUpgradeableVersion,
+			ForceRunChromatic:         c.MessageFlags.ForceRunStepChromatic,
 		}))
 
 		// Integration tests


### PR DESCRIPTION
By specifying [force-run-step-chromatic] in the commit message a dev can now force the pipeline to run the chromatic step instead of marking their PR as ready for review

## Test plan
Manual testing

