### PR TITLE
Search query parsing: fix bug in `reduce` causing issues with search contexts

### DIFF
--- a/internal/search/query/parser.go
+++ b/internal/search/query/parser.go
@@ -1021,9 +1021,11 @@ func reduce(left, right []Node, kind operatorKind) ([]Node, bool) {
 			}
 			return left, true
 		}
-		if operator, ok := left[0].(Operator); ok && operator.Kind == kind {
-			// Reduce left node.
-			return append(operator.Operands, right...), true
+		if len(left) == 1 {
+			if operator, ok := left[0].(Operator); ok && operator.Kind == kind {
+				// Reduce left node.
+				return append(operator.Operands, right...), true
+			}
 		}
 	case Pattern:
 		if term.Value == "" {
@@ -1033,9 +1035,11 @@ func reduce(left, right []Node, kind operatorKind) ([]Node, bool) {
 			}
 			return left, true
 		}
-		if operator, ok := left[0].(Operator); ok && operator.Kind == kind {
-			// Reduce left node.
-			return append(operator.Operands, right...), true
+		if len(left) == 1 {
+			if operator, ok := left[0].(Operator); ok && operator.Kind == kind {
+				// Reduce left node.
+				return append(operator.Operands, right...), true
+			}
 		}
 	}
 	if len(right) > 1 {

--- a/internal/search/query/parser.go
+++ b/internal/search/query/parser.go
@@ -1021,11 +1021,9 @@ func reduce(left, right []Node, kind operatorKind) ([]Node, bool) {
 			}
 			return left, true
 		}
-		if len(left) == 1 {
-			if operator, ok := left[0].(Operator); ok && operator.Kind == kind {
-				// Reduce left node.
-				return append(operator.Operands, right...), true
-			}
+		if operator, ok := left[0].(Operator); ok && operator.Kind == kind {
+			// Reduce left node.
+			return append(operator.Operands, right...), true
 		}
 	case Pattern:
 		if term.Value == "" {
@@ -1035,18 +1033,16 @@ func reduce(left, right []Node, kind operatorKind) ([]Node, bool) {
 			}
 			return left, true
 		}
-		if len(left) == 1 {
-			if operator, ok := left[0].(Operator); ok && operator.Kind == kind {
-				// Reduce left node.
-				return append(operator.Operands, right...), true
-			}
+		if operator, ok := left[0].(Operator); ok && operator.Kind == kind {
+			// Reduce left node.
+			return append(operator.Operands, right...), true
 		}
 	}
 	if len(right) > 1 {
 		// Reduce right list.
-		reduced, changed := reduce(append(left, right[0]), right[1:], kind)
+		reduced, changed := reduce([]Node{right[0]}, right[1:], kind)
 		if changed {
-			return reduced, true
+			return append(left, reduced...), true
 		}
 	}
 	return append(left, right...), false

--- a/internal/search/query/parser_test.go
+++ b/internal/search/query/parser_test.go
@@ -729,7 +729,13 @@ func Test_newOperator(t *testing.T) {
 		want  autogold.Value
 	}{{
 		query: `(repo:a and repo:b) (repo:d or repo:e) repo:f`,
-		want:  autogold.Want("failing", `(and (and "repo:a" "repo:b") (or "repo:d" "repo:e") "repo:f")`),
+		want:  autogold.Want("parameters", `(and (and "repo:a" "repo:b") (or "repo:d" "repo:e") "repo:f")`),
+	}, {
+		query: `(a and b) and (d or e) and f`,
+		want:  autogold.Want("patterns", `(and (and "a" "b") (or "d" "e") "f")`),
+	}, {
+		query: `a and (b and c)`,
+		want:  autogold.Want("reducible", `(and "a" "b" "c")`),
 	}}
 
 	for _, tc := range cases {

--- a/internal/search/query/parser_test.go
+++ b/internal/search/query/parser_test.go
@@ -729,7 +729,7 @@ func Test_newOperator(t *testing.T) {
 		want  autogold.Value
 	}{{
 		query: `(repo:a and repo:b) (repo:d or repo:e) repo:f`,
-		want:  autogold.Want("failing", `(and "repo:a" "repo:b" "repo:f")`),
+		want:  autogold.Want("failing", `(and (and "repo:a" "repo:b") (or "repo:d" "repo:e") "repo:f")`),
 	}}
 
 	for _, tc := range cases {

--- a/internal/search/query/query_test.go
+++ b/internal/search/query/query_test.go
@@ -44,6 +44,7 @@ func TestSubstituteSearchContexts(t *testing.T) {
 		return plan.ToParseTree().String()
 	}
 
+	autogold.Want("failing", `(or (and "repo:primary" "repo:protobuf" "select:repo") (and "repo:secondary" "repo:protobuf" "select:repo") (and "repo:primary" "repo:PROTOBUF" "select:repo") (and "repo:secondary" "repo:PROTOBUF" "select:repo"))`).Equal(t, test("context:go-deps (r:protobuf OR r:PROTOBUF) select:repo", false))
 	autogold.Want("basic", `(or (and "repo:primary" "scamaz") (and "repo:secondary" "scamaz"))`).Equal(t, test("context:gordo scamaz", false))
 
 	autogold.Want("preserve predicate label", `[


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/35096

Explanation of changes inline. 

First commit adds a minimal test case reproducing the issue. Second commit adds a fix with updated test output.

## Test plan

Added a test. We may want to consider testing this a bit more rigorously, but this will cover regression. 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
