### PR TITLE
Add in-app changelog entries for Sourcegraph 3.40

### DIFF
--- a/client/web/src/enterprise/batches/list/BatchChangesChangelogAlert.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangesChangelogAlert.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 import classNames from 'classnames'
 
-import { CardBody, Card, Typography } from '@sourcegraph/wildcard'
+import { CardBody, Card, Typography, Link } from '@sourcegraph/wildcard'
 
 import { DismissibleAlert } from '../../../components/DismissibleAlert'
 
@@ -11,15 +11,20 @@ import styles from './BatchChangesListIntro.module.scss'
 export const BatchChangesChangelogAlert: React.FunctionComponent<React.PropsWithChildren<unknown>> = () => (
     <DismissibleAlert
         className={styles.batchChangesListIntroAlert}
-        partialStorageKey="batch-changes-list-intro-changelog-3.39"
+        partialStorageKey="batch-changes-list-intro-changelog-3.40"
     >
         <Card className={classNames(styles.batchChangesListIntroCard, 'h-100')}>
             <CardBody>
-                <Typography.H4 as={Typography.H2}>Batch Changes updates in version 3.39</Typography.H4>
+                <Typography.H4 as={Typography.H2}>Batch Changes updates in version 3.40</Typography.H4>
                 <ul className="mb-0 pl-3">
                     <li>
-                        Bulk actions are now visible regardless of filtering. Previously, you had to filter by status to
-                        see them.
+                        <Link
+                            to="https://docs.sourcegraph.com/batch_changes/explanations/introduction_to_batch_changes#supported-code-hosts-and-changeset-types"
+                            rel="noopener"
+                            target="_blank"
+                        >
+                            Bitbucket Cloud is now supported with Batch Changes
+                        </Link>
                     </li>
                 </ul>
             </CardBody>

--- a/client/web/src/enterprise/batches/list/BatchChangesChangelogAlert.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangesChangelogAlert.tsx
@@ -23,7 +23,7 @@ export const BatchChangesChangelogAlert: React.FunctionComponent<React.PropsWith
                             rel="noopener"
                             target="_blank"
                         >
-                            Bitbucket Cloud is now supported with Batch Changes
+                            Bitbucket Cloud is now supported with Batch Changes.
                         </Link>
                     </li>
                 </ul>


### PR DESCRIPTION

## Test plan

Tested it renders correctly manually. 

## App preview:

- [Web](https://sg-web-es-changelog-340.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-jznfzqplmi.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
