### PR TITLE
batches: ensure we hit an index when listing conflicting specs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Carets in textareas in Firefox are now visible. [#34888](https://github.com/sourcegraph/sourcegraph/pull/34888)
 - Changesets to GitHub code hosts could fail with a confusing, non actionable error message. [#35048](https://github.com/sourcegraph/sourcegraph/pull/35048)
 - An issue causing search expressions to not work in conjunction with `type:symbol`. [#35126](https://github.com/sourcegraph/sourcegraph/pull/35126)
+- Reduced database load when viewing or previewing a batch change. [#35501](https://github.com/sourcegraph/sourcegraph/pull/35501)
 
 ### Removed
 

--- a/enterprise/internal/batches/store/changeset_specs.go
+++ b/enterprise/internal/batches/store/changeset_specs.go
@@ -393,16 +393,16 @@ var listChangesetSpecsWithConflictingHeadQueryFmtstr = `
 -- source: enterprise/internal/batches/store/changeset_specs.go:ListChangesetSpecsWithConflictingHeadRef
 SELECT
 	repo_id,
-	spec->>'headRef' AS head_ref,
+	head_ref,
 	COUNT(*) AS count
 FROM
 	changeset_specs
 WHERE
 	batch_spec_id = %s
 AND
-	spec->>'headRef' IS NOT NULL
+	head_ref IS NOT NULL
 GROUP BY
-	repo_id, spec->>'headRef'
+	repo_id, head_ref
 HAVING COUNT(*) > 1
 ORDER BY repo_id ASC, head_ref ASC
 `


### PR DESCRIPTION
We already had an indexed, denormalised field here. We just weren't using it. 😬 

Hopefully helps with sourcegraph/customer#953.

## Test plan

We have good unit test coverage here.