### PR TITLE
fix broken link in buildkite cta

### DIFF
--- a/dev/ci/go-backcompat/test.sh
+++ b/dev/ci/go-backcompat/test.sh
@@ -143,7 +143,7 @@ if ! ./dev/ci/go-test.sh "$@"; then
 This commit contains database schema definitions that caused an unexpected
 failure of one or more unit tests at tagged commit \`${latest_minor_release_tag}\`.
 Rewrite these schema changes to be backwards compatible. For help,
-see [the migrations guide](docs.sourcegraph.com/dev/background-information/sql/migrations).
+see [the migrations guide](https://docs.sourcegraph.com/dev/background-information/sql/migrations).
 
 If this backwards incompatibility is intentional or if the test is flaky,
 an exception for this test can be added to the following flakefile:


### PR DESCRIPTION
Just a quick fix for a broken link in buildkite.

<img width="741" alt="Screen Shot 2022-05-10 at 9 48 49 PM" src="https://user-images.githubusercontent.com/6225160/168644847-b0465b27-7e68-4f3a-bd75-ce59ff78d33c.png">

## Test plan
Manually tested.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
