### PR TITLE
batches: Fix show more button on workspaces list

### DIFF
--- a/client/web/src/enterprise/batches/batch-spec/execute/backend.ts
+++ b/client/web/src/enterprise/batches/batch-spec/execute/backend.ts
@@ -448,10 +448,8 @@ export const useWorkspacesListConnection = (
         },
         options: {
             useURL: true,
-            // For some reason caching caused flickering here. Will need to investigate
-            // further why.
-            fetchPolicy: 'no-cache',
-            pollInterval: 1000,
+            fetchPolicy: 'cache-and-network',
+            pollInterval: 2500,
         },
         getConnection: result => {
             const data = dataOrThrowErrors(result)


### PR DESCRIPTION
This doesn't fix the flickering issue, but we are aware of it and it is not specific to this component. So this is still an improvement, although not the outcome we had wished to see here. `no-cache` doesn't work currently, so we switch back to the version that flickers. Increasing the poll interval makes it less likely to happen though. 

I will keep the issue open until we have written down our learnings, but that's for after the offsite :) 

## Test plan

Validated locally that the button actually works now.

## App preview:

- [Web](https://sg-web-es-fix-show-more.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-tiaqqnoelq.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
