### PR TITLE
Removes unecessary patch 3.38.1 notes

### DIFF
--- a/doc/admin/updates/kubernetes.md
+++ b/doc/admin/updates/kubernetes.md
@@ -29,12 +29,6 @@ To upgrade your deployment follow either:
 
 *How smooth was this upgrade process for you? You can give us your feedback on this upgrade by filling out [this feedback form](https://share.hsforms.com/1aGeG7ALQQEGO6zyfauIiCA1n7ku?update_version=3.39).*
 
-## 3.38.0 -> 3.38.1
-
-Follow the [standard upgrade procedure](../deploy/kubernetes/update.md) to upgrade your deployment.
-
-*How smooth was this upgrade process for you? You can give us your feedback on this upgrade by filling out [this feedback form](https://share.hsforms.com/1aGeG7ALQQEGO6zyfauIiCA1n7ku?update_version=3.38).*
-
 ## 3.37 -> 3.38
 
 Follow the [standard upgrade procedure](../deploy/kubernetes/update.md) to upgrade your deployment.


### PR DESCRIPTION
We don't have notes for minor version upgrades anywhere else in this doc, but there currently are notes showing 3.38.0 -> 3.38.1.  This introduces lack of clarity for customers on whether or not moving from 3.38.0 -> 3.38.1 is necessary before they proceed to upgrade to 3.39



## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
Docs update, no test necessary