### PR TITLE
extsvc/github: use injected log.Logger in v3 client

### DIFF
--- a/cmd/gitserver/main.go
+++ b/cmd/gitserver/main.go
@@ -378,7 +378,7 @@ func editGitHubAppExternalServiceConfigToken(
 		return "", errors.Wrap(err, "new authenticator with GitHub App")
 	}
 
-	client := github.NewV3Client(svc.URN(), apiURL, auther, cli)
+	client := github.NewV3Client(log.Scoped("github.v3", "github v3 client"), svc.URN(), apiURL, auther, cli)
 
 	token, err := repos.GetOrRenewGitHubAppInstallationAccessToken(ctx, externalServiceStore, svc, client, installationID)
 	if err != nil {

--- a/enterprise/cmd/frontend/internal/app/app.go
+++ b/enterprise/cmd/frontend/internal/app/app.go
@@ -33,6 +33,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/repos"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"github.com/sourcegraph/sourcegraph/lib/log"
 )
 
 // Init initializes the app endpoints.
@@ -76,7 +77,7 @@ func Init(
 	if err != nil {
 		return errors.Wrap(err, "parse github.com")
 	}
-	client := github.NewV3Client(extsvc.URNGitHubAppCloud, apiURL, auther, nil)
+	client := github.NewV3Client(log.Scoped("app.github.v3", "github v3 client for frontend app"), extsvc.URNGitHubAppCloud, apiURL, auther, nil)
 
 	enterpriseServices.NewGitHubAppCloudSetupHandler = func() http.Handler {
 		return newGitHubAppCloudSetupHandler(db, apiURL, client)

--- a/enterprise/cmd/frontend/internal/auth/githuboauth/session.go
+++ b/enterprise/cmd/frontend/internal/auth/githuboauth/session.go
@@ -25,6 +25,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/jsonc"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"github.com/sourcegraph/sourcegraph/lib/log"
 )
 
 type sessionIssuerHelper struct {
@@ -245,7 +246,8 @@ func derefInt64(i *int64) int64 {
 
 func (s *sessionIssuerHelper) newClient(token string) *githubsvc.V3Client {
 	apiURL, _ := githubsvc.APIRoot(s.BaseURL)
-	return githubsvc.NewV3Client(extsvc.URNGitHubOAuth, apiURL, &esauth.OAuthBearerToken{Token: token}, nil)
+	return githubsvc.NewV3Client(log.Scoped("session.github.v3", "github v3 client for session issuer"),
+		extsvc.URNGitHubOAuth, apiURL, &esauth.OAuthBearerToken{Token: token}, nil)
 }
 
 // getVerifiedEmails returns the list of user emails that are verified. If the primary email is verified,

--- a/enterprise/cmd/frontend/internal/auth/oauth/middleware.go
+++ b/enterprise/cmd/frontend/internal/auth/oauth/middleware.go
@@ -6,7 +6,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"io"
-	"log"
+	stdlog "log"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -29,6 +29,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/internal/repos"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"github.com/sourcegraph/sourcegraph/lib/log"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
@@ -101,6 +102,8 @@ func newOAuthFlowHandler(db database.DB, serviceType string) http.Handler {
 		p.Callback(p.OAuth2Config()).ServeHTTP(w, req)
 	}))
 	mux.Handle("/get-user-orgs", http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		logger := log.Scoped("get-user-orgs", "handler for getting github user orgs")
+
 		dotcomConfig := conf.SiteConfig().Dotcom
 		// if not on Sourcegraph.com with GitHub App enabled, this page does not exist
 		if !envvar.SourcegraphDotComMode() || !repos.IsGitHubAppCloudEnabled(dotcomConfig) {
@@ -121,7 +124,7 @@ func newOAuthFlowHandler(db database.DB, serviceType string) http.Handler {
 			Kinds:           []string{extsvc.KindGitHub},
 		})
 		if err != nil {
-			log15.Error("Unexpected error while fetching user's external services.", "error", err)
+			logger.Error("Unexpected error while fetching user's external services.", log.Error(err))
 			http.Error(w, "Unexpected error while fetching GitHub connection.", http.StatusBadRequest)
 			return
 		}
@@ -132,25 +135,26 @@ func newOAuthFlowHandler(db database.DB, serviceType string) http.Handler {
 
 		esConfg, err := extsvc.ParseConfig("github", externalServices[0].Config)
 		if err != nil {
-			log15.Error("Unexpected error while parsing external service config.", "error", err)
+			logger.Error("Unexpected error while parsing external service config.", log.Error(err))
 			http.Error(w, "Unexpected error while processing external service connection.", http.StatusBadRequest)
 			return
 		}
 
 		conn := esConfg.(*schema.GitHubConnection)
 		auther := &eauth.OAuthBearerToken{Token: conn.Token}
-		client := github.NewV3Client(extsvc.URNGitHubAppCloud, &url.URL{Host: "github.com"}, auther, nil)
+		client := github.NewV3Client(logger.Scoped("github.v3", "github v3 client for getting user orgs"),
+			extsvc.URNGitHubAppCloud, &url.URL{Host: "github.com"}, auther, nil)
 
 		installs, err := client.GetUserInstallations(req.Context())
 		if err != nil {
-			log15.Error("Unexpected error while fetching app installs.", "error", err)
+			logger.Error("Unexpected error while fetching app installs.", log.Error(err))
 			http.Error(w, "Unexpected error while fetching list of GitHub organizations.", http.StatusBadRequest)
 			return
 		}
 
 		err = json.NewEncoder(w).Encode(installs)
 		if err != nil {
-			log15.Error("Failed to encode the list of GitHub organizations.", "error", err)
+			logger.Error("Failed to encode the list of GitHub organizations.", log.Error(err))
 		}
 	}))
 	mux.Handle("/install-github-app", http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
@@ -165,11 +169,13 @@ func newOAuthFlowHandler(db database.DB, serviceType string) http.Handler {
 		http.Redirect(w, req, "/install-github-app-select-org?state="+state, http.StatusFound)
 	}))
 	mux.Handle("/get-github-app-installation", http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		logger := log.Scoped("get-github-app-installation", "handler for getting github app installations")
+
 		dotcomConfig := conf.SiteConfig().Dotcom
 
 		privateKey, err := base64.StdEncoding.DecodeString(dotcomConfig.GithubAppCloud.PrivateKey)
 		if err != nil {
-			log15.Error("Unexpected error while decoding GitHub App private key.", "error", err)
+			logger.Error("Unexpected error while decoding GitHub App private key.", log.Error(err))
 			http.Error(w, "Unexpected error while fetching installation data.", http.StatusBadRequest)
 			return
 		}
@@ -178,44 +184,45 @@ func newOAuthFlowHandler(db database.DB, serviceType string) http.Handler {
 
 		installationIDParam, err := base64.StdEncoding.DecodeString(installationIDQueryUnecoded)
 		if err != nil {
-			log15.Error("Unexpected error while decoding base64 encoded installation ID.", "error", err)
+			logger.Error("Unexpected error while decoding base64 encoded installation ID.", log.Error(err))
 			http.Error(w, "Unexpected error while fetching installation data.", http.StatusBadRequest)
 			return
 		}
 
 		installationIDDecoded, err := app.DecryptWithPrivateKey(string(installationIDParam), privateKey)
 		if err != nil {
-			log15.Error("Unexpected error while decrypting installation ID.", "error", err)
+			logger.Error("Unexpected error while decrypting installation ID.", log.Error(err))
 			http.Error(w, "Unexpected error while fetching installation data.", http.StatusBadRequest)
 			return
 		}
 
 		installationID, err := strconv.ParseInt(installationIDDecoded, 10, 64)
 		if err != nil {
-			log15.Error("Unexpected error while creating parsing installation ID.", "error", err)
+			logger.Error("Unexpected error while creating parsing installation ID.", log.Error(err))
 			http.Error(w, "Unexpected error while fetching installation data.", http.StatusBadRequest)
 			return
 		}
 
 		auther, err := eauth.NewOAuthBearerTokenWithGitHubApp(dotcomConfig.GithubAppCloud.AppID, privateKey)
 		if err != nil {
-			log15.Error("Unexpected error while creating Auth token.", "error", err)
+			logger.Error("Unexpected error while creating Auth token.", log.Error(err))
 			http.Error(w, "Unexpected error while fetching installation data.", http.StatusBadRequest)
 			return
 		}
 
-		client := github.NewV3Client(extsvc.URNGitHubAppCloud, &url.URL{Host: "github.com"}, auther, nil)
+		client := github.NewV3Client(logger.Scoped("github.v3", "github v3 client for getting github app installations"),
+			extsvc.URNGitHubAppCloud, &url.URL{Host: "github.com"}, auther, nil)
 
 		installation, err := client.GetAppInstallation(req.Context(), installationID)
 		if err != nil {
-			log15.Error("Unexpected error while fetching installation.", "error", err)
+			logger.Error("Unexpected error while fetching installation.", log.Error(err))
 			http.Error(w, "Unexpected error while fetching installation data.", http.StatusBadRequest)
 			return
 		}
 
 		err = json.NewEncoder(w).Encode(installation)
 		if err != nil {
-			log15.Error("Failed to encode installation data.", "error", err)
+			logger.Error("Failed to encode installation data.", log.Error(err))
 		}
 	}))
 	return mux
@@ -299,12 +306,12 @@ func (l *loggingRoundTripper) RoundTrip(req *http.Request) (*http.Response, erro
 			log15.Error("Unexpected error in OAuth2 debug log", "operation", "reading request body", "error", err)
 			return nil, errors.Wrap(err, "Unexpected error in OAuth2 debug log, reading request body")
 		}
-		log.Printf(">>>>> HTTP Request: %s %s\n      Header: %v\n      Body: %s", req.Method, req.URL.String(), req.Header, preview)
+		stdlog.Printf(">>>>> HTTP Request: %s %s\n      Header: %v\n      Body: %s", req.Method, req.URL.String(), req.Header, preview)
 	}
 
 	resp, err := l.underlying.RoundTrip(req)
 	if err != nil {
-		log.Printf("<<<<< Error getting HTTP response: %s", err)
+		stdlog.Printf("<<<<< Error getting HTTP response: %s", err)
 		return resp, err
 	}
 
@@ -316,7 +323,7 @@ func (l *loggingRoundTripper) RoundTrip(req *http.Request) (*http.Response, erro
 			log15.Error("Unexpected error in OAuth2 debug log", "operation", "reading response body", "error", err)
 			return nil, errors.Wrap(err, "Unexpected error in OAuth2 debug log, reading response body")
 		}
-		log.Printf("<<<<< HTTP Response: %s %s\n      Header: %v\n      Body: %s", req.Method, req.URL.String(), resp.Header, preview)
+		stdlog.Printf("<<<<< HTTP Response: %s %s\n      Header: %v\n      Body: %s", req.Method, req.URL.String(), resp.Header, preview)
 		return resp, err
 	}
 }

--- a/enterprise/cmd/repo-updater/internal/authz/integration_test.go
+++ b/enterprise/cmd/repo-updater/internal/authz/integration_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/repos"
 	"github.com/sourcegraph/sourcegraph/internal/timeutil"
 	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/lib/log/logtest"
 )
 
 var updateRegex = flag.String("update", "", "Update testdata of tests matching the given regex")
@@ -85,7 +86,7 @@ func TestIntegration_GitHubPermissions(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			cli := extsvcGitHub.NewV3Client(svc.URN(), uri, &auth.OAuthBearerToken{Token: token}, doer)
+			cli := extsvcGitHub.NewV3Client(logtest.Scoped(t), svc.URN(), uri, &auth.OAuthBearerToken{Token: token}, doer)
 
 			testDB := dbtest.NewDB(t)
 			ctx := actor.WithInternalActor(context.Background())
@@ -166,7 +167,7 @@ func TestIntegration_GitHubPermissions(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			cli := extsvcGitHub.NewV3Client(svc.URN(), uri, &auth.OAuthBearerToken{Token: token}, doer)
+			cli := extsvcGitHub.NewV3Client(logtest.Scoped(t), svc.URN(), uri, &auth.OAuthBearerToken{Token: token}, doer)
 
 			testDB := dbtest.NewDB(t)
 			ctx := actor.WithInternalActor(context.Background())
@@ -270,7 +271,7 @@ func TestIntegration_GitHubPermissions(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			cli := extsvcGitHub.NewV3Client(svc.URN(), uri, &auth.OAuthBearerToken{Token: token}, doer)
+			cli := extsvcGitHub.NewV3Client(logtest.Scoped(t), svc.URN(), uri, &auth.OAuthBearerToken{Token: token}, doer)
 
 			testDB := dbtest.NewDB(t)
 			ctx := actor.WithInternalActor(context.Background())
@@ -354,7 +355,7 @@ func TestIntegration_GitHubPermissions(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			cli := extsvcGitHub.NewV3Client(svc.URN(), uri, &auth.OAuthBearerToken{Token: token}, doer)
+			cli := extsvcGitHub.NewV3Client(logtest.Scoped(t), svc.URN(), uri, &auth.OAuthBearerToken{Token: token}, doer)
 
 			testDB := dbtest.NewDB(t)
 			ctx := actor.WithInternalActor(context.Background())

--- a/enterprise/internal/authz/github/github.go
+++ b/enterprise/internal/authz/github/github.go
@@ -17,6 +17,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/rcache"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"github.com/sourcegraph/sourcegraph/lib/log"
 )
 
 // Provider implements authz.Provider for GitHub repository permissions.
@@ -48,7 +49,8 @@ type ProviderOptions struct {
 func NewProvider(urn string, opts ProviderOptions) *Provider {
 	if opts.GitHubClient == nil {
 		apiURL, _ := github.APIRoot(opts.GitHubURL)
-		opts.GitHubClient = github.NewV3Client(urn, apiURL, &auth.OAuthBearerToken{Token: opts.BaseToken}, nil)
+		opts.GitHubClient = github.NewV3Client(log.Scoped("provider.github.v3", "provider github client"),
+			urn, apiURL, &auth.OAuthBearerToken{Token: opts.BaseToken}, nil)
 	}
 
 	codeHost := extsvc.NewCodeHost(opts.GitHubURL, extsvc.TypeGitHub)

--- a/internal/extsvc/github/v3_test.go
+++ b/internal/extsvc/github/v3_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/httptestutil"
 	"github.com/sourcegraph/sourcegraph/internal/rcache"
 	"github.com/sourcegraph/sourcegraph/internal/testutil"
+	"github.com/sourcegraph/sourcegraph/lib/log/logtest"
 )
 
 func newTestClient(t *testing.T, cli httpcli.Doer) *V3Client {
@@ -30,7 +31,7 @@ func newTestClientWithAuthenticator(t *testing.T, auth auth.Authenticator, cli h
 	rcache.SetupForTest(t)
 
 	apiURL := &url.URL{Scheme: "https", Host: "example.com", Path: "/"}
-	return NewV3Client("Test", apiURL, auth, cli)
+	return NewV3Client(logtest.Scoped(t), "Test", apiURL, auth, cli)
 }
 
 func TestNewRepoCache(t *testing.T) {
@@ -625,7 +626,7 @@ func TestListOrganizations(t *testing.T) {
 		}))
 
 		uri, _ := url.Parse(testServer.URL)
-		testCli := NewV3Client("Test", uri, gheToken, testServer.Client())
+		testCli := NewV3Client(logtest.Scoped(t), "Test", uri, gheToken, testServer.Client())
 
 		runTest := func(since int, expectedNextSince int, expectedOrgs []*Org) {
 			orgs, nextSince, err := testCli.ListOrganizations(context.Background(), since)
@@ -793,7 +794,7 @@ func newV3TestClient(t testing.TB, name string) (*V3Client, func()) {
 		t.Fatal(err)
 	}
 
-	return NewV3Client("Test", uri, vcrToken, doer), save
+	return NewV3Client(logtest.Scoped(t), "Test", uri, vcrToken, doer), save
 }
 
 func newV3TestEnterpriseClient(t testing.TB, name string) (*V3Client, func()) {
@@ -810,7 +811,7 @@ func newV3TestEnterpriseClient(t testing.TB, name string) (*V3Client, func()) {
 		t.Fatal(err)
 	}
 
-	return NewV3Client("Test", uri, gheToken, doer), save
+	return NewV3Client(logtest.Scoped(t), "Test", uri, gheToken, doer), save
 }
 
 func strPtr(s string) *string { return &s }

--- a/internal/extsvc/github/v4.go
+++ b/internal/extsvc/github/v4.go
@@ -23,6 +23,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/internal/ratelimit"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"github.com/sourcegraph/sourcegraph/lib/log"
 )
 
 // V4Client is a GitHub GraphQL API client.
@@ -339,7 +340,8 @@ func (c *V4Client) fetchGitHubVersion(ctx context.Context) (version *semver.Vers
 	}
 
 	// Initiate a v3Client since this requires a V3 API request.
-	v3Client := NewV3Client(c.urn, c.apiURL, c.auth, c.httpClient)
+	logger := log.Scoped("v4.fetchGitHubVersion", "temporary client for fetching github version")
+	v3Client := NewV3Client(logger, c.urn, c.apiURL, c.auth, c.httpClient)
 	v, err := v3Client.GetVersion(ctx)
 	if err != nil {
 		log15.Warn("Failed to fetch GitHub enterprise version",
@@ -588,7 +590,8 @@ fragment RepositoryFields on Repository {
 func (c *V4Client) Fork(ctx context.Context, owner, repo string, org *string) (*Repository, error) {
 	// Unfortunately, the GraphQL API doesn't provide a mutation to fork as of
 	// December 2021, so we have to fall back to the REST API.
-	return NewV3Client(c.urn, c.apiURL, c.auth, c.httpClient).Fork(ctx, owner, repo, org)
+	logger := log.Scoped("v4.Fork", "temporary client for forking GitHub repository")
+	return NewV3Client(logger, c.urn, c.apiURL, c.auth, c.httpClient).Fork(ctx, owner, repo, org)
 }
 
 type RecentCommittersParams struct {

--- a/internal/repos/github_test.go
+++ b/internal/repos/github_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/internal/types/typestest"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"github.com/sourcegraph/sourcegraph/lib/log/logtest"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
@@ -821,7 +822,7 @@ func TestGetOrRenewGitHubAppInstallationAccessToken(t *testing.T) {
 			}, nil
 		},
 	}
-	client := github.NewV3Client("Test", baseURL, &auth.OAuthBearerToken{Token: "oauth-token"}, doer)
+	client := github.NewV3Client(logtest.Scoped(t), "Test", baseURL, &auth.OAuthBearerToken{Token: "oauth-token"}, doer)
 
 	tests := []struct {
 		name           string


### PR DESCRIPTION
This PR migrates GitHub v3 clients to use inject loggers. This allows users to provide a scope to identify which part of the codebase is using a particular client to make logging output more useful and more easily identify where API requests and API logs might be coming from.

This PR is also intended to serve as a reference migration for delegating further migrations to GitStart, e.g. https://github.com/sourcegraph/sourcegraph/issues/35514

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

```
sg start
sg start dotcom
```

and tests pass