### PR TITLE
Search backend: Add trace tags to jobs in package zoekt

### DIFF
--- a/internal/search/job/jobutil/job.go
+++ b/internal/search/job/jobutil/job.go
@@ -510,7 +510,7 @@ func (b *jobBuilder) newZoektGlobalSearch(typ search.IndexedRequestType) (job.Jo
 		return &zoekt.ZoektGlobalSearchJob{
 			GlobalZoektQuery: globalZoektQuery,
 			ZoektArgs:        zoektArgs,
-			RepoOptions:      b.repoOptions,
+			RepoOpts:         b.repoOptions,
 		}, nil
 	}
 	return nil, errors.Errorf("attempt to create unrecognized zoekt global search with value %v", typ)


### PR DESCRIPTION
Part of #34009

Add trace tags to `ZoektGlobalSearchJob`, `ZoektRepoSubsetSearchJob`, and `ZoektSymbolSearchJob`.

## Test plan
All existing tests pass. Example trace output:

`ZoektGlobalSearchJob`:
![Screen Shot 2022-05-16 at 4 23 11 PM](https://user-images.githubusercontent.com/70350613/168684873-5ad0e36b-19b5-4363-afc4-bd7bc432f1b7.png)

`ZoektRepoSubsetSearchJob`:
![Screen Shot 2022-05-16 at 4 03 52 PM](https://user-images.githubusercontent.com/70350613/168682686-2585f164-73c8-44c3-9a42-cdf45c42f271.png)

`ZoektSymbolSearchJob`:
![Screen Shot 2022-05-16 at 4 01 13 PM](https://user-images.githubusercontent.com/70350613/168682709-0186fb87-1360-4ce6-866a-4df5be9acf60.png)

