### PR TITLE
Code monitors: fix error handling

### DIFF
--- a/enterprise/internal/codemonitors/background/workers.go
+++ b/enterprise/internal/codemonitors/background/workers.go
@@ -192,6 +192,11 @@ func (r *queryRunner) Handle(ctx context.Context, logger log.Logger, record work
 		return err
 	}
 
+	// After setting the next run, check the error value
+	if searchErr != nil {
+		return errors.Wrap(searchErr, "execute search")
+	}
+
 	// Log the actual query we ran and whether we got any new results.
 	err = s.UpdateTriggerJobWithResults(ctx, triggerJob.ID, query, results)
 	if err != nil {


### PR DESCRIPTION
This fixes an issue where errors from search would be swallowed, causing
confusing things on the logs page because there would be complete runs
that aren't showing their errors.

## Test plan

Tested that the error message now appears in the logs page.
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
