### PR TITLE
database: remove dbutil-based constructors

### DIFF
--- a/cmd/frontend/graphqlbackend/graphqlbackend.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend.go
@@ -738,5 +738,5 @@ func (r *schemaResolver) CodeHostSyncDue(ctx context.Context, args *struct {
 		}
 		ids[i] = id
 	}
-	return database.ExternalServices(r.db).SyncDue(ctx, ids, time.Duration(args.Seconds)*time.Second)
+	return r.db.ExternalServices().SyncDue(ctx, ids, time.Duration(args.Seconds)*time.Second)
 }

--- a/cmd/frontend/graphqlbackend/site_admin.go
+++ b/cmd/frontend/graphqlbackend/site_admin.go
@@ -277,5 +277,5 @@ func logRoleChangeAttempt(ctx context.Context, db database.DB, name *database.Se
 		Timestamp:       time.Now(),
 	}
 
-	database.SecurityEventLogs(db).LogEvent(ctx, event)
+	db.SecurityEventLogs().LogEvent(ctx, event)
 }

--- a/cmd/frontend/graphqlbackend/site_flags.go
+++ b/cmd/frontend/graphqlbackend/site_flags.go
@@ -33,7 +33,7 @@ func needsRepositoryConfiguration(ctx context.Context, db database.DB) (bool, er
 		}
 	}
 
-	count, err := database.ExternalServices(db).Count(ctx, database.ExternalServicesListOptions{
+	count, err := db.ExternalServices().Count(ctx, database.ExternalServicesListOptions{
 		Kinds: kinds,
 	})
 	if err != nil {

--- a/cmd/frontend/internal/app/sign_out.go
+++ b/cmd/frontend/internal/app/sign_out.go
@@ -86,5 +86,5 @@ func logSignOutEvent(r *http.Request, db database.DB, name database.SecurityEven
 	// Safe to ignore this error
 	event.AnonymousUserID, _ = cookie.AnonymousUID(r)
 
-	database.SecurityEventLogs(db).LogEvent(ctx, event)
+	db.SecurityEventLogs().LogEvent(ctx, event)
 }

--- a/cmd/frontend/internal/app/updatecheck/client.go
+++ b/cmd/frontend/internal/app/updatecheck/client.go
@@ -620,7 +620,7 @@ func authProviderTypes() []string {
 
 func externalServiceKinds(ctx context.Context, db database.DB) (kinds []string, err error) {
 	defer recordOperation("externalServiceKinds")(&err)
-	kinds, err = database.ExternalServices(db).DistinctKinds(ctx)
+	kinds, err = db.ExternalServices().DistinctKinds(ctx)
 	return kinds, err
 }
 

--- a/cmd/frontend/internal/app/verify_email.go
+++ b/cmd/frontend/internal/app/verify_email.go
@@ -86,7 +86,7 @@ func logEmailVerified(ctx context.Context, db database.DB, r *http.Request, user
 	}
 	event.AnonymousUserID, _ = cookie.AnonymousUID(r)
 
-	database.SecurityEventLogs(db).LogEvent(ctx, event)
+	db.SecurityEventLogs().LogEvent(ctx, event)
 }
 
 func httpLogAndError(w http.ResponseWriter, msg string, code int, errArgs ...any) {

--- a/cmd/frontend/internal/app/verify_email_test.go
+++ b/cmd/frontend/internal/app/verify_email_test.go
@@ -32,6 +32,7 @@ func TestServeVerifyEmail(t *testing.T) {
 		db.UsersFunc.SetDefaultReturn(users)
 		db.UserEmailsFunc.SetDefaultReturn(userEmails)
 		db.AuthzFunc.SetDefaultReturn(authz)
+		db.SecurityEventLogsFunc.SetDefaultReturn(database.NewMockSecurityEventLogsStore())
 
 		ctx := context.Background()
 		ctx = actor.WithActor(ctx, &actor.Actor{UID: 1})
@@ -63,6 +64,7 @@ func TestServeVerifyEmail(t *testing.T) {
 		db.UsersFunc.SetDefaultReturn(users)
 		db.UserEmailsFunc.SetDefaultReturn(userEmails)
 		db.AuthzFunc.SetDefaultReturn(authz)
+		db.SecurityEventLogsFunc.SetDefaultReturn(database.NewMockSecurityEventLogsStore())
 
 		ctx := context.Background()
 		ctx = actor.WithActor(ctx, &actor.Actor{UID: 1})

--- a/cmd/frontend/internal/cli/config.go
+++ b/cmd/frontend/internal/cli/config.go
@@ -179,7 +179,7 @@ func overrideExtSvcConfig(ctx context.Context, db database.DB) error {
 	if path == "" {
 		return nil
 	}
-	extsvcs := database.ExternalServices(db)
+	extsvcs := db.ExternalServices()
 	cs := &configurationSource{db: db}
 
 	update := func(ctx context.Context) error {

--- a/cmd/frontend/internal/httpapi/httpapi.go
+++ b/cmd/frontend/internal/httpapi/httpapi.go
@@ -72,7 +72,7 @@ func NewHandler(
 	m.Get(apirouter.RepoRefresh).Handler(trace.Route(handler(serveRepoRefresh(db))))
 
 	gh := webhooks.GitHubWebhook{
-		ExternalServices: database.ExternalServices(db),
+		ExternalServices: db.ExternalServices(),
 	}
 
 	webhookhandlers.Init(db, &gh)

--- a/cmd/frontend/internal/httpapi/internal.go
+++ b/cmd/frontend/internal/httpapi/internal.go
@@ -84,7 +84,7 @@ func serveExternalServiceConfigs(db database.DB) func(w http.ResponseWriter, r *
 			}
 		}
 
-		services, err := database.ExternalServices(db).List(r.Context(), options)
+		services, err := db.ExternalServices().List(r.Context(), options)
 		if err != nil {
 			return err
 		}
@@ -138,7 +138,7 @@ func serveExternalServicesList(db database.DB) func(w http.ResponseWriter, r *ht
 			}
 		}
 
-		services, err := database.ExternalServices(db).List(r.Context(), options)
+		services, err := db.ExternalServices().List(r.Context(), options)
 		if err != nil {
 			return err
 		}

--- a/cmd/frontend/webhooks/github_webhooks_test.go
+++ b/cmd/frontend/webhooks/github_webhooks_test.go
@@ -108,12 +108,12 @@ func TestGithubWebhookExternalServices(t *testing.T) {
 
 	t.Parallel()
 
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 
 	ctx := context.Background()
 
 	secret := "secret"
-	esStore := database.ExternalServices(db)
+	esStore := db.ExternalServices()
 	extSvc := &types.ExternalService{
 		Kind:        extsvc.KindGitHub,
 		DisplayName: "GitHub",

--- a/cmd/gitserver/main.go
+++ b/cmd/gitserver/main.go
@@ -117,7 +117,7 @@ func main() {
 
 	repoStore := database.Repos(db)
 	depsSvc := livedependencies.GetService(db, nil)
-	externalServiceStore := database.ExternalServices(db)
+	externalServiceStore := db.ExternalServices()
 
 	err = keyring.Init(ctx)
 	if err != nil {

--- a/cmd/worker/internal/migrations/migrators/extsvc_migrator_test.go
+++ b/cmd/worker/internal/migrations/migrators/extsvc_migrator_test.go
@@ -33,7 +33,7 @@ func TestExternalServiceConfigMigrator(t *testing.T) {
 	}
 
 	t.Run("Up/Down/Progress", func(t *testing.T) {
-		db := dbtest.NewDB(t)
+		db := database.NewDB(dbtest.NewDB(t))
 
 		migrator := NewExternalServiceConfigMigratorWithDB(db)
 		migrator.BatchSize = 2
@@ -60,7 +60,7 @@ func TestExternalServiceConfigMigrator(t *testing.T) {
 			return &conf.Unified{}
 		}
 		for _, svc := range svcs {
-			if err := database.ExternalServices(db).Create(ctx, confGet, svc); err != nil {
+			if err := db.ExternalServices().Create(ctx, confGet, svc); err != nil {
 				t.Fatal(err)
 			}
 		}
@@ -111,7 +111,7 @@ func TestExternalServiceConfigMigrator(t *testing.T) {
 	})
 
 	t.Run("Up/Encryption", func(t *testing.T) {
-		db := dbtest.NewDB(t)
+		db := database.NewDB(dbtest.NewDB(t))
 
 		migrator := NewExternalServiceConfigMigratorWithDB(db)
 		migrator.BatchSize = 10
@@ -122,7 +122,7 @@ func TestExternalServiceConfigMigrator(t *testing.T) {
 			return &conf.Unified{}
 		}
 		for _, svc := range svcs {
-			if err := database.ExternalServices(db).Create(ctx, confGet, svc); err != nil {
+			if err := db.ExternalServices().Create(ctx, confGet, svc); err != nil {
 				t.Fatal(err)
 			}
 		}
@@ -136,7 +136,7 @@ func TestExternalServiceConfigMigrator(t *testing.T) {
 		}
 
 		// was the config actually encrypted?
-		rows, err := db.Query("SELECT config, encryption_key_id FROM external_services ORDER BY id")
+		rows, err := db.Handle().DB().QueryContext(ctx, "SELECT config, encryption_key_id FROM external_services ORDER BY id")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -178,7 +178,7 @@ func TestExternalServiceConfigMigrator(t *testing.T) {
 	})
 
 	t.Run("Down/Decryption", func(t *testing.T) {
-		db := dbtest.NewDB(t)
+		db := database.NewDB(dbtest.NewDB(t))
 
 		migrator := NewExternalServiceConfigMigratorWithDB(db)
 		migrator.BatchSize = 10
@@ -190,7 +190,7 @@ func TestExternalServiceConfigMigrator(t *testing.T) {
 			return &conf.Unified{}
 		}
 		for _, svc := range svcs {
-			if err := database.ExternalServices(db).Create(ctx, confGet, svc); err != nil {
+			if err := db.ExternalServices().Create(ctx, confGet, svc); err != nil {
 				t.Fatal(err)
 			}
 		}
@@ -209,7 +209,7 @@ func TestExternalServiceConfigMigrator(t *testing.T) {
 		}
 
 		// was the config actually reverted?
-		rows, err := db.Query("SELECT config, encryption_key_id FROM external_services ORDER BY id")
+		rows, err := db.Handle().DB().QueryContext(ctx, "SELECT config, encryption_key_id FROM external_services ORDER BY id")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -240,7 +240,7 @@ func TestExternalServiceConfigMigrator(t *testing.T) {
 	})
 
 	t.Run("Up/InvalidKey", func(t *testing.T) {
-		db := dbtest.NewDB(t)
+		db := database.NewDB(dbtest.NewDB(t))
 
 		migrator := NewExternalServiceConfigMigratorWithDB(db)
 		migrator.BatchSize = 10
@@ -251,7 +251,7 @@ func TestExternalServiceConfigMigrator(t *testing.T) {
 			return &conf.Unified{}
 		}
 		for _, svc := range svcs {
-			if err := database.ExternalServices(db).Create(ctx, confGet, svc); err != nil {
+			if err := db.ExternalServices().Create(ctx, confGet, svc); err != nil {
 				t.Fatal(err)
 			}
 		}
@@ -271,7 +271,7 @@ func TestExternalServiceConfigMigrator(t *testing.T) {
 	})
 
 	t.Run("Down/Disabled Decryption", func(t *testing.T) {
-		db := dbtest.NewDB(t)
+		db := database.NewDB(dbtest.NewDB(t))
 
 		migrator := NewExternalServiceConfigMigratorWithDB(db)
 		migrator.BatchSize = 10
@@ -282,7 +282,7 @@ func TestExternalServiceConfigMigrator(t *testing.T) {
 			return &conf.Unified{}
 		}
 		for _, svc := range svcs {
-			if err := database.ExternalServices(db).Create(ctx, confGet, svc); err != nil {
+			if err := db.ExternalServices().Create(ctx, confGet, svc); err != nil {
 				t.Fatal(err)
 			}
 		}
@@ -301,7 +301,7 @@ func TestExternalServiceConfigMigrator(t *testing.T) {
 		}
 
 		// was the config actually reverted?
-		rows, err := db.Query("SELECT config, encryption_key_id FROM external_services ORDER BY id")
+		rows, err := db.Handle().DB().QueryContext(ctx, "SELECT config, encryption_key_id FROM external_services ORDER BY id")
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/cmd/worker/internal/migrations/migrators/extsvc_webhook_migrator_test.go
+++ b/cmd/worker/internal/migrations/migrators/extsvc_webhook_migrator_test.go
@@ -24,11 +24,11 @@ func TestExternalServiceWebhookMigrator(t *testing.T) {
 	}
 	ctx := context.Background()
 
-	createExternalServices := func(t *testing.T, ctx context.Context, db dbutil.DB) []*types.ExternalService {
+	createExternalServices := func(t *testing.T, ctx context.Context, db database.DB) []*types.ExternalService {
 		t.Helper()
 		var svcs []*types.ExternalService
 
-		es := database.ExternalServices(db)
+		es := db.ExternalServices()
 		basestore := basestore.NewWithDB(db, sql.TxOptions{})
 
 		// Create a trivial external service of each kind, as well as duplicate
@@ -162,7 +162,7 @@ func TestExternalServiceWebhookMigrator(t *testing.T) {
 	}
 
 	t.Run("Progress", func(t *testing.T) {
-		db := dbtest.NewDB(t)
+		db := database.NewDB(dbtest.NewDB(t))
 		createExternalServices(t, ctx, db)
 
 		m := NewExternalServiceWebhookMigratorWithDB(db)
@@ -181,9 +181,9 @@ func TestExternalServiceWebhookMigrator(t *testing.T) {
 	})
 
 	t.Run("Up", func(t *testing.T) {
-		db := dbtest.NewDB(t)
+		db := database.NewDB(dbtest.NewDB(t))
 		initSvcs := createExternalServices(t, ctx, db)
-		es := database.ExternalServices(db)
+		es := db.ExternalServices()
 
 		m := NewExternalServiceWebhookMigratorWithDB(db)
 		// Ensure that we have to run two Ups.

--- a/enterprise/cmd/frontend/internal/authz/init.go
+++ b/enterprise/cmd/frontend/internal/authz/init.go
@@ -37,7 +37,7 @@ func Init(ctx context.Context, db database.DB, _ conftypes.UnifiedWatchable, ent
 		return edb.NewAuthzStore(db, clock)
 	}
 
-	extsvcStore := database.ExternalServices(db)
+	extsvcStore := db.ExternalServices()
 
 	// TODO(nsc): use c
 	// Report any authz provider problems in external configs.

--- a/enterprise/cmd/frontend/internal/batches/resolvers/changeset_counts_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/changeset_counts_test.go
@@ -80,7 +80,7 @@ func TestChangesetCountsOverTimeIntegration(t *testing.T) {
 	userID := ct.CreateTestUser(t, db, false).ID
 
 	repoStore := database.Repos(db)
-	esStore := database.ExternalServices(db)
+	esStore := db.ExternalServices()
 
 	gitHubToken := os.Getenv("GITHUB_TOKEN")
 	if gitHubToken == "" {

--- a/enterprise/cmd/frontend/internal/batches/webhooks/bitbucketserver_test.go
+++ b/enterprise/cmd/frontend/internal/batches/webhooks/bitbucketserver_test.go
@@ -51,7 +51,7 @@ func testBitbucketWebhook(db *sql.DB, userID int32) func(*testing.T) {
 
 		secret := "secret"
 		repoStore := database.Repos(db)
-		esStore := database.ExternalServices(db)
+		esStore := database.NewDB(db).ExternalServices()
 		bitbucketServerToken := os.Getenv("BITBUCKET_SERVER_TOKEN")
 		if bitbucketServerToken == "" {
 			bitbucketServerToken = "test-token"

--- a/enterprise/cmd/frontend/internal/batches/webhooks/github_test.go
+++ b/enterprise/cmd/frontend/internal/batches/webhooks/github_test.go
@@ -57,7 +57,7 @@ func testGitHubWebhook(db *sql.DB, userID int32) func(*testing.T) {
 			token = "no-GITHUB_TOKEN-set"
 		}
 		repoStore := database.Repos(db)
-		esStore := database.ExternalServices(db)
+		esStore := database.NewDB(db).ExternalServices()
 		extSvc := &types.ExternalService{
 			Kind:        extsvc.KindGitHub,
 			DisplayName: "GitHub",

--- a/enterprise/cmd/precise-code-intel-worker/main.go
+++ b/enterprise/cmd/precise-code-intel-worker/main.go
@@ -158,9 +158,10 @@ func mustInitializeDB() *sql.DB {
 	// START FLAILING
 
 	ctx := context.Background()
+	db := database.NewDB(sqlDB)
 	go func() {
 		for range time.NewTicker(eiauthz.RefreshInterval()).C {
-			allowAccessByDefault, authzProviders, _, _ := eiauthz.ProvidersFromConfig(ctx, conf.Get(), database.ExternalServices(sqlDB), database.NewDB(sqlDB))
+			allowAccessByDefault, authzProviders, _, _ := eiauthz.ProvidersFromConfig(ctx, conf.Get(), db.ExternalServices(), db)
 			authz.SetProviders(allowAccessByDefault, authzProviders)
 		}
 	}()

--- a/enterprise/cmd/repo-updater/main.go
+++ b/enterprise/cmd/repo-updater/main.go
@@ -76,7 +76,7 @@ func startBackgroundPermsSync(ctx context.Context, syncer *authz.PermsSyncer, db
 				frontendAuthz.ProvidersFromConfig(
 					ctx,
 					conf.Get(),
-					ossDB.ExternalServices(db),
+					db.ExternalServices(),
 					db,
 				)
 			ossAuthz.SetProviders(allowAccessByDefault, authzProviders)

--- a/enterprise/cmd/worker/internal/codeintel/indexing_job.go
+++ b/enterprise/cmd/worker/internal/codeintel/indexing_job.go
@@ -71,7 +71,7 @@ func (j *indexingJob) Routines(ctx context.Context, logger log.Logger) ([]gorout
 	dbworker.InitPrometheusMetric(observationContext, dependencySyncStore, "codeintel", "dependency_index", nil)
 
 	repoUpdaterClient := InitRepoUpdaterClient()
-	extSvcStore := database.ExternalServices(db)
+	extSvcStore := database.NewDB(db).ExternalServices()
 	dbStoreShim := &indexing.DBStoreShim{Store: dbStore}
 	enqueuerDBStoreShim := &enqueuer.DBStoreShim{Store: dbStore}
 	policyMatcher := policies.NewMatcher(gitserverClient, policies.IndexingExtractor, false, true)

--- a/enterprise/cmd/worker/main.go
+++ b/enterprise/cmd/worker/main.go
@@ -68,15 +68,16 @@ func init() {
 // the jobs configured in this service. This also enables repository update operations to fetch
 // permissions from code hosts.
 func setAuthzProviders() {
-	db, err := workerdb.Init()
+	sqlDB, err := workerdb.Init()
 	if err != nil {
 		return
 	}
 
 	ctx := context.Background()
+	db := database.NewDB(sqlDB)
 
 	for range time.NewTicker(eiauthz.RefreshInterval()).C {
-		allowAccessByDefault, authzProviders, _, _ := eiauthz.ProvidersFromConfig(ctx, conf.Get(), database.ExternalServices(db), database.NewDB(db))
+		allowAccessByDefault, authzProviders, _, _ := eiauthz.ProvidersFromConfig(ctx, conf.Get(), db.ExternalServices(), db)
 		authz.SetProviders(allowAccessByDefault, authzProviders)
 	}
 }

--- a/enterprise/internal/batches/testing/repos.go
+++ b/enterprise/internal/batches/testing/repos.go
@@ -73,7 +73,7 @@ func CreateTestRepos(t *testing.T, ctx context.Context, db database.DB, count in
 	t.Helper()
 
 	repoStore := database.Repos(db)
-	esStore := database.ExternalServices(db)
+	esStore := db.ExternalServices()
 
 	ext := &types.ExternalService{
 		Kind:        extsvc.KindGitHub,
@@ -118,7 +118,7 @@ func CreateGitlabTestRepos(t *testing.T, ctx context.Context, db database.DB, co
 	t.Helper()
 
 	repoStore := database.Repos(db)
-	esStore := database.ExternalServices(db)
+	esStore := db.ExternalServices()
 
 	ext := &types.ExternalService{
 		Kind:        extsvc.KindGitLab,
@@ -179,7 +179,7 @@ func CreateGitHubSSHTestRepos(t *testing.T, ctx context.Context, db database.DB,
 			GitURLType: "ssh",
 		}),
 	}
-	esStore := database.ExternalServices(db)
+	esStore := db.ExternalServices()
 	if err := esStore.Upsert(ctx, ext); err != nil {
 		t.Fatal(err)
 	}
@@ -222,7 +222,7 @@ func createBbsRepos(t *testing.T, ctx context.Context, db database.DB, ext *type
 	t.Helper()
 
 	repoStore := database.Repos(db)
-	esStore := database.ExternalServices(db)
+	esStore := db.ExternalServices()
 
 	if err := esStore.Upsert(ctx, ext); err != nil {
 		t.Fatal(err)
@@ -259,7 +259,7 @@ func CreateAWSCodeCommitTestRepos(t *testing.T, ctx context.Context, db database
 	t.Helper()
 
 	repoStore := database.Repos(db)
-	esStore := database.ExternalServices(db)
+	esStore := db.ExternalServices()
 
 	ext := &types.ExternalService{
 		Kind:        extsvc.KindAWSCodeCommit,

--- a/enterprise/internal/database/perms_store_test.go
+++ b/enterprise/internal/database/perms_store_test.go
@@ -2958,6 +2958,7 @@ WHERE repo_id = 2`, clock().AddDate(-1, 0, 0))
 
 func testPermsStore_UserIsMemberOfOrgHasCodeHostConnection(db *sql.DB) func(*testing.T) {
 	return func(t *testing.T) {
+		db := database.NewDB(db)
 		s := perms(db, clock)
 		ctx := context.Background()
 		t.Cleanup(func() {
@@ -3013,7 +3014,7 @@ func testPermsStore_UserIsMemberOfOrgHasCodeHostConnection(db *sql.DB) func(*tes
 		_, err = orgMembers.Create(ctx, cindyOrg.ID, cindy.ID)
 		require.NoError(t, err)
 
-		err = database.ExternalServices(db).Create(ctx,
+		err = db.ExternalServices().Create(ctx,
 			func() *conf.Unified { return &conf.Unified{} },
 			&types.ExternalService{
 				Kind:           extsvc.KindGitHub,

--- a/internal/database/dbcache/cached_indexable_repos_test.go
+++ b/internal/database/dbcache/cached_indexable_repos_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
@@ -21,7 +20,7 @@ func TestListIndexableRepos(t *testing.T) {
 		t.Skip()
 	}
 
-	createExternalService := func(ctx context.Context, db dbutil.DB) *types.ExternalService {
+	createExternalService := func(ctx context.Context, db database.DB) *types.ExternalService {
 		confGet := func() *conf.Unified {
 			return &conf.Unified{}
 		}
@@ -30,7 +29,7 @@ func TestListIndexableRepos(t *testing.T) {
 			DisplayName: "GITHUB #1",
 			Config:      `{"url": "https://github.com", "repositoryQuery": ["none"], "token": "abc"}`,
 		}
-		err := database.ExternalServices(db).Create(ctx, confGet, es)
+		err := db.ExternalServices().Create(ctx, confGet, es)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -38,7 +37,7 @@ func TestListIndexableRepos(t *testing.T) {
 	}
 
 	t.Run("user-added repos", func(t *testing.T) {
-		db := dbtest.NewDB(t)
+		db := database.NewDB(dbtest.NewDB(t))
 		ctx := context.Background()
 
 		es := createExternalService(ctx, db)

--- a/internal/database/external_services.go
+++ b/internal/database/external_services.go
@@ -150,11 +150,6 @@ func (e *externalServiceStore) copy() *externalServiceStore {
 	}
 }
 
-// ExternalServices instantiates and returns a new ExternalServicesStore with prepared statements.
-func ExternalServices(db dbutil.DB) ExternalServiceStore {
-	return &externalServiceStore{Store: basestore.NewWithDB(db, sql.TxOptions{})}
-}
-
 // ExternalServicesWith instantiates and returns a new ExternalServicesStore with prepared statements.
 func ExternalServicesWith(other basestore.ShareableStore) ExternalServiceStore {
 	return &externalServiceStore{Store: basestore.NewWithHandle(other.Handle())}

--- a/internal/database/external_services_test.go
+++ b/internal/database/external_services_test.go
@@ -297,7 +297,7 @@ func TestExternalServicesStore_Create(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	db := dbtest.NewDB(t)
+	db := NewDB(dbtest.NewDB(t))
 	ctx := context.Background()
 
 	envvar.MockSourcegraphDotComMode(true)
@@ -429,13 +429,13 @@ func TestExternalServicesStore_Create(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			err := ExternalServices(db).Create(ctx, confGet, test.externalService)
+			err := db.ExternalServices().Create(ctx, confGet, test.externalService)
 			if err != nil {
 				t.Fatal(err)
 			}
 
 			// Should get back the same one
-			got, err := ExternalServices(db).GetByID(ctx, test.externalService.ID)
+			got, err := db.ExternalServices().GetByID(ctx, test.externalService.ID)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -454,7 +454,7 @@ func TestExternalServicesStore_Create(t *testing.T) {
 				t.Fatalf("Wanted has_webhooks = %v, but got %v", test.wantHasWebhooks, *got.HasWebhooks)
 			}
 
-			err = ExternalServices(db).Delete(ctx, test.externalService.ID)
+			err = db.ExternalServices().Delete(ctx, test.externalService.ID)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -466,7 +466,7 @@ func TestExternalServicesStore_CreateWithTierEnforcement(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	db := dbtest.NewDB(t)
+	db := NewDB(dbtest.NewDB(t))
 
 	ctx := context.Background()
 	confGet := func() *conf.Unified { return &conf.Unified{} }
@@ -475,7 +475,7 @@ func TestExternalServicesStore_CreateWithTierEnforcement(t *testing.T) {
 		DisplayName: "GITHUB #1",
 		Config:      `{"url": "https://github.com", "repositoryQuery": ["none"], "token": "abc"}`,
 	}
-	store := ExternalServices(db)
+	store := db.ExternalServices()
 	BeforeCreateExternalService = func(ctx context.Context, _ ExternalServiceStore) error {
 		return errcode.NewPresentationError("test plan limit exceeded")
 	}
@@ -489,7 +489,7 @@ func TestExternalServicesStore_Update(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	db := dbtest.NewDB(t)
+	db := NewDB(dbtest.NewDB(t))
 	ctx := context.Background()
 
 	envvar.MockSourcegraphDotComMode(true)
@@ -504,7 +504,7 @@ func TestExternalServicesStore_Update(t *testing.T) {
 		DisplayName: "GITHUB #1",
 		Config:      `{"url": "https://github.com", "repositoryQuery": ["none"], "token": "abc", "authorization": {}}`,
 	}
-	err := ExternalServices(db).Create(ctx, confGet, es)
+	err := db.ExternalServices().Create(ctx, confGet, es)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -585,13 +585,13 @@ func TestExternalServicesStore_Update(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			err = ExternalServices(db).Update(ctx, nil, es.ID, test.update)
+			err = db.ExternalServices().Update(ctx, nil, es.ID, test.update)
 			if err != nil {
 				t.Fatal(err)
 			}
 
 			// Get and verify update
-			got, err := ExternalServices(db).GetByID(ctx, es.ID)
+			got, err := db.ExternalServices().GetByID(ctx, es.ID)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -740,7 +740,7 @@ func TestExternalServicesStore_upsertAuthorizationToExternalService(t *testing.T
 	if testing.Short() {
 		t.Skip()
 	}
-	db := dbtest.NewDB(t)
+	db := NewDB(dbtest.NewDB(t))
 	ctx := context.Background()
 
 	envvar.MockSourcegraphDotComMode(true)
@@ -749,7 +749,7 @@ func TestExternalServicesStore_upsertAuthorizationToExternalService(t *testing.T
 	confGet := func() *conf.Unified {
 		return &conf.Unified{}
 	}
-	externalServices := ExternalServices(db)
+	externalServices := db.ExternalServices()
 
 	// Test Create method
 	es := &types.ExternalService{
@@ -797,7 +797,7 @@ func TestCountRepoCount(t *testing.T) {
 		t.Skip()
 	}
 	t.Parallel()
-	db := dbtest.NewDB(t)
+	db := NewDB(dbtest.NewDB(t))
 	ctx := actor.WithInternalActor(context.Background())
 
 	// Create a new external service
@@ -809,7 +809,7 @@ func TestCountRepoCount(t *testing.T) {
 		DisplayName: "GITHUB #1",
 		Config:      `{"url": "https://github.com", "repositoryQuery": ["none"], "token": "abc"}`,
 	}
-	err := ExternalServices(db).Create(ctx, confGet, es1)
+	err := db.ExternalServices().Create(ctx, confGet, es1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -832,7 +832,7 @@ VALUES (%d, 1, '')
 		t.Fatal(err)
 	}
 
-	count, err := ExternalServices(db).RepoCount(ctx, es1.ID)
+	count, err := db.ExternalServices().RepoCount(ctx, es1.ID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -847,7 +847,7 @@ func TestExternalServicesStore_Delete(t *testing.T) {
 		t.Skip()
 	}
 	t.Parallel()
-	db := dbtest.NewDB(t)
+	db := NewDB(dbtest.NewDB(t))
 	ctx := actor.WithInternalActor(context.Background())
 
 	// Create a new external service
@@ -859,7 +859,7 @@ func TestExternalServicesStore_Delete(t *testing.T) {
 		DisplayName: "GITHUB #1",
 		Config:      `{"url": "https://github.com", "repositoryQuery": ["none"], "token": "abc"}`,
 	}
-	err := ExternalServices(db).Create(ctx, confGet, es1)
+	err := db.ExternalServices().Create(ctx, confGet, es1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -869,7 +869,7 @@ func TestExternalServicesStore_Delete(t *testing.T) {
 		DisplayName: "GITHUB #2",
 		Config:      `{"url": "https://github.com", "repositoryQuery": ["none"], "token": "def"}`,
 	}
-	err = ExternalServices(db).Create(ctx, confGet, es2)
+	err = db.ExternalServices().Create(ctx, confGet, es2)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -898,20 +898,20 @@ VALUES (%d, 1, ''), (%d, 2, '')
 	}
 
 	// Delete this external service
-	err = ExternalServices(db).Delete(ctx, es1.ID)
+	err = db.ExternalServices().Delete(ctx, es1.ID)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// Delete again should get externalServiceNotFoundError
-	err = ExternalServices(db).Delete(ctx, es1.ID)
+	err = db.ExternalServices().Delete(ctx, es1.ID)
 	gotErr := fmt.Sprintf("%v", err)
 	wantErr := fmt.Sprintf("external service not found: %v", es1.ID)
 	if gotErr != wantErr {
 		t.Errorf("error: want %q but got %q", wantErr, gotErr)
 	}
 
-	_, err = ExternalServices(db).GetByID(ctx, es1.ID)
+	_, err = db.ExternalServices().GetByID(ctx, es1.ID)
 	if err == nil {
 		t.Fatal("expected an error")
 	}
@@ -947,7 +947,7 @@ func TestExternalServicesStore_DeleteExtServiceWithManyRepos(t *testing.T) {
 		t.Skip()
 	}
 	t.Parallel()
-	db := dbtest.NewDB(t)
+	db := NewDB(dbtest.NewDB(t))
 	ctx := actor.WithInternalActor(context.Background())
 
 	// Create a new external service
@@ -959,7 +959,7 @@ func TestExternalServicesStore_DeleteExtServiceWithManyRepos(t *testing.T) {
 		DisplayName: "GITHUB #1",
 		Config:      `{"url": "https://github.com", "repositoryQuery": ["none"], "token": "abc"}`,
 	}
-	servicesStore := ExternalServices(db)
+	servicesStore := db.ExternalServices()
 	err := servicesStore.Create(ctx, confGet, extSvc)
 	if err != nil {
 		t.Fatal(err)
@@ -1066,7 +1066,7 @@ func TestExternalServicesStore_DeleteExtServiceWithManyRepos(t *testing.T) {
 		t.Fatal("External service is not deleted")
 	}
 
-	rows, err := db.Query(`select * from repo where deleted_at is null`)
+	rows, err := db.Handle().DB().QueryContext(ctx, `select * from repo where deleted_at is null`)
 	if err != nil {
 		t.Fatal("Error during fetching repos from the DB")
 	}
@@ -1080,7 +1080,7 @@ func TestExternalServicesStore_GetByID(t *testing.T) {
 		t.Skip()
 	}
 	t.Parallel()
-	db := dbtest.NewDB(t)
+	db := NewDB(dbtest.NewDB(t))
 	ctx := context.Background()
 
 	// Create a new external service
@@ -1092,25 +1092,25 @@ func TestExternalServicesStore_GetByID(t *testing.T) {
 		DisplayName: "GITHUB #1",
 		Config:      `{"url": "https://github.com", "repositoryQuery": ["none"], "token": "abc"}`,
 	}
-	err := ExternalServices(db).Create(ctx, confGet, es)
+	err := db.ExternalServices().Create(ctx, confGet, es)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// Should be able to get back by its ID
-	_, err = ExternalServices(db).GetByID(ctx, es.ID)
+	_, err = db.ExternalServices().GetByID(ctx, es.ID)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// Delete this external service
-	err = ExternalServices(db).Delete(ctx, es.ID)
+	err = db.ExternalServices().Delete(ctx, es.ID)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// Should now get externalServiceNotFoundError
-	_, err = ExternalServices(db).GetByID(ctx, es.ID)
+	_, err = db.ExternalServices().GetByID(ctx, es.ID)
 	gotErr := fmt.Sprintf("%v", err)
 	wantErr := fmt.Sprintf("external service not found: %v", es.ID)
 	if gotErr != wantErr {
@@ -1123,7 +1123,7 @@ func TestExternalServicesStore_GetByID_Encrypted(t *testing.T) {
 		t.Skip()
 	}
 	t.Parallel()
-	db := dbtest.NewDB(t)
+	db := NewDB(dbtest.NewDB(t))
 	ctx := context.Background()
 
 	// Create a new external service
@@ -1136,7 +1136,7 @@ func TestExternalServicesStore_GetByID_Encrypted(t *testing.T) {
 		Config:      `{"url": "https://github.com", "repositoryQuery": ["none"], "token": "abc"}`,
 	}
 
-	store := ExternalServices(db).WithEncryptionKey(et.TestKey{})
+	store := db.ExternalServices().WithEncryptionKey(et.TestKey{})
 
 	err := store.Create(ctx, confGet, es)
 	if err != nil {
@@ -1144,7 +1144,7 @@ func TestExternalServicesStore_GetByID_Encrypted(t *testing.T) {
 	}
 
 	// create a store with a NoopKey to read the raw encrypted value
-	noopStore := ExternalServices(db).WithEncryptionKey(&encryption.NoopKey{})
+	noopStore := db.ExternalServices().WithEncryptionKey(&encryption.NoopKey{})
 	encrypted, err := noopStore.GetByID(ctx, es.ID)
 	if err != nil {
 		t.Fatal(err)
@@ -1180,7 +1180,7 @@ func TestGetAffiliatedSyncErrors(t *testing.T) {
 		t.Skip()
 	}
 	t.Parallel()
-	db := dbtest.NewDB(t)
+	db := NewDB(dbtest.NewDB(t))
 	ctx := context.Background()
 
 	// Create a new external service
@@ -1228,7 +1228,7 @@ func TestGetAffiliatedSyncErrors(t *testing.T) {
 			svc.NamespaceOrgID = o.ID
 		}
 
-		err = ExternalServices(db).Create(ctx, confGet, svc)
+		err = db.ExternalServices().Create(ctx, confGet, svc)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1250,7 +1250,7 @@ func TestGetAffiliatedSyncErrors(t *testing.T) {
 	userOwned := createService(user2, nil, "GITHUB #3")
 
 	// Listing errors now should return an empty map as none have been added yet
-	results, err := ExternalServices(db).GetAffiliatedSyncErrors(ctx, admin)
+	results, err := db.ExternalServices().GetAffiliatedSyncErrors(ctx, admin)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1264,7 +1264,7 @@ func TestGetAffiliatedSyncErrors(t *testing.T) {
 
 	// Add two failures for the same service
 	failure1 := "oops"
-	_, err = db.Exec(`
+	_, err = db.Handle().DB().ExecContext(ctx, `
 INSERT INTO external_service_sync_jobs (external_service_id, state, finished_at, failure_message)
 VALUES ($1,'errored', now(), $2)
 `, siteLevel.ID, failure1)
@@ -1272,7 +1272,7 @@ VALUES ($1,'errored', now(), $2)
 		t.Fatal(err)
 	}
 	failure2 := "oops again"
-	_, err = db.Exec(`
+	_, err = db.Handle().DB().ExecContext(ctx, `
 INSERT INTO external_service_sync_jobs (external_service_id, state, finished_at, failure_message)
 VALUES ($1,'errored', now(), $2)
 `, siteLevel.ID, failure2)
@@ -1281,7 +1281,7 @@ VALUES ($1,'errored', now(), $2)
 	}
 
 	// We should get the latest failure
-	results, err = ExternalServices(db).GetAffiliatedSyncErrors(ctx, admin)
+	results, err = db.ExternalServices().GetAffiliatedSyncErrors(ctx, admin)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1298,7 +1298,7 @@ VALUES ($1,'errored', now(), $2)
 	}
 
 	// Adding a second failing service
-	_, err = db.Exec(`
+	_, err = db.Handle().DB().ExecContext(ctx, `
 INSERT INTO external_service_sync_jobs (external_service_id, state, finished_at, failure_message)
 VALUES ($1,'errored', now(), $2)
 `, adminOwned.ID, failure1)
@@ -1306,7 +1306,7 @@ VALUES ($1,'errored', now(), $2)
 		t.Fatal(err)
 	}
 
-	results, err = ExternalServices(db).GetAffiliatedSyncErrors(ctx, admin)
+	results, err = db.ExternalServices().GetAffiliatedSyncErrors(ctx, admin)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1319,7 +1319,7 @@ VALUES ($1,'errored', now(), $2)
 	}
 
 	// User should not see any failures as they don't own any services
-	results, err = ExternalServices(db).GetAffiliatedSyncErrors(ctx, user2)
+	results, err = db.ExternalServices().GetAffiliatedSyncErrors(ctx, user2)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1333,7 +1333,7 @@ VALUES ($1,'errored', now(), $2)
 
 	// Add a failure to user service
 	failure3 := "user failure"
-	_, err = db.Exec(`
+	_, err = db.Handle().DB().ExecContext(ctx, `
 INSERT INTO external_service_sync_jobs (external_service_id, state, finished_at, failure_message)
 VALUES ($1,'errored', now(), $2)
 `, userOwned.ID, failure3)
@@ -1342,7 +1342,7 @@ VALUES ($1,'errored', now(), $2)
 	}
 
 	// We should get the latest failure
-	results, err = ExternalServices(db).GetAffiliatedSyncErrors(ctx, user2)
+	results, err = db.ExternalServices().GetAffiliatedSyncErrors(ctx, user2)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1361,7 +1361,7 @@ VALUES ($1,'errored', now(), $2)
 	// Add a failure to org service
 	orgOwned := createService(nil, org1, "GITHUB Org owned")
 
-	_, err = db.Exec(`
+	_, err = db.Handle().DB().ExecContext(ctx, `
 INSERT INTO external_service_sync_jobs (external_service_id, state, finished_at, failure_message)
 VALUES ($1,'errored', now(), $2)
 `, orgOwned.ID, "org failure")
@@ -1371,7 +1371,7 @@ VALUES ($1,'errored', now(), $2)
 
 	// Assert that site-admin should only get errors for site level external services
 	// or self owned external services.
-	results, err = ExternalServices(db).GetAffiliatedSyncErrors(ctx, admin)
+	results, err = db.ExternalServices().GetAffiliatedSyncErrors(ctx, admin)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1394,7 +1394,7 @@ func TestGetLastSyncError(t *testing.T) {
 		t.Skip()
 	}
 	t.Parallel()
-	db := dbtest.NewDB(t)
+	db := NewDB(dbtest.NewDB(t))
 	ctx := context.Background()
 
 	// Create a new external service
@@ -1406,18 +1406,18 @@ func TestGetLastSyncError(t *testing.T) {
 		DisplayName: "GITHUB #1",
 		Config:      `{"url": "https://github.com", "repositoryQuery": ["none"], "token": "abc"}`,
 	}
-	err := ExternalServices(db).Create(ctx, confGet, es)
+	err := db.ExternalServices().Create(ctx, confGet, es)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// Should be able to get back by its ID
-	_, err = ExternalServices(db).GetByID(ctx, es.ID)
+	_, err = db.ExternalServices().GetByID(ctx, es.ID)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	lastSyncError, err := ExternalServices(db).GetLastSyncError(ctx, es.ID)
+	lastSyncError, err := db.ExternalServices().GetLastSyncError(ctx, es.ID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1426,7 +1426,7 @@ func TestGetLastSyncError(t *testing.T) {
 	}
 
 	// Could have failure message
-	_, err = db.Exec(`
+	_, err = db.Handle().DB().ExecContext(ctx, `
 INSERT INTO external_service_sync_jobs (external_service_id, state, finished_at)
 VALUES ($1,'errored', now())
 `, es.ID)
@@ -1435,7 +1435,7 @@ VALUES ($1,'errored', now())
 		t.Fatal(err)
 	}
 
-	lastSyncError, err = ExternalServices(db).GetLastSyncError(ctx, es.ID)
+	lastSyncError, err = db.ExternalServices().GetLastSyncError(ctx, es.ID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1445,7 +1445,7 @@ VALUES ($1,'errored', now())
 
 	// Add sync error
 	expectedError := "oops"
-	_, err = db.Exec(`
+	_, err = db.Handle().DB().ExecContext(ctx, `
 INSERT INTO external_service_sync_jobs (external_service_id, failure_message, state, finished_at)
 VALUES ($1,$2,'errored', now())
 `, es.ID, expectedError)
@@ -1454,7 +1454,7 @@ VALUES ($1,$2,'errored', now())
 		t.Fatal(err)
 	}
 
-	lastSyncError, err = ExternalServices(db).GetLastSyncError(ctx, es.ID)
+	lastSyncError, err = db.ExternalServices().GetLastSyncError(ctx, es.ID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1468,7 +1468,7 @@ func TestExternalServicesStore_List(t *testing.T) {
 		t.Skip()
 	}
 	t.Parallel()
-	db := dbtest.NewDB(t)
+	db := NewDB(dbtest.NewDB(t))
 	ctx := context.Background()
 
 	// Create test user
@@ -1514,7 +1514,7 @@ func TestExternalServicesStore_List(t *testing.T) {
 	}
 
 	for _, es := range ess {
-		err := ExternalServices(db).Create(ctx, confGet, es)
+		err := db.ExternalServices().Create(ctx, confGet, es)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1522,7 +1522,7 @@ func TestExternalServicesStore_List(t *testing.T) {
 	createdAt := time.Now()
 
 	t.Run("list all external services", func(t *testing.T) {
-		got, err := ExternalServices(db).List(ctx, ExternalServicesListOptions{})
+		got, err := db.ExternalServices().List(ctx, ExternalServicesListOptions{})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1534,7 +1534,7 @@ func TestExternalServicesStore_List(t *testing.T) {
 	})
 
 	t.Run("list all external services in ascending order", func(t *testing.T) {
-		got, err := ExternalServices(db).List(ctx, ExternalServicesListOptions{OrderByDirection: "ASC"})
+		got, err := db.ExternalServices().List(ctx, ExternalServicesListOptions{OrderByDirection: "ASC"})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1547,7 +1547,7 @@ func TestExternalServicesStore_List(t *testing.T) {
 	})
 
 	t.Run("list all external services in descending order", func(t *testing.T) {
-		got, err := ExternalServices(db).List(ctx, ExternalServicesListOptions{})
+		got, err := db.ExternalServices().List(ctx, ExternalServicesListOptions{})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1560,7 +1560,7 @@ func TestExternalServicesStore_List(t *testing.T) {
 	})
 
 	t.Run("list external services with certain IDs", func(t *testing.T) {
-		got, err := ExternalServices(db).List(ctx, ExternalServicesListOptions{
+		got, err := db.ExternalServices().List(ctx, ExternalServicesListOptions{
 			IDs: []int64{ess[1].ID},
 		})
 		if err != nil {
@@ -1574,7 +1574,7 @@ func TestExternalServicesStore_List(t *testing.T) {
 	})
 
 	t.Run("list external services with no namespace", func(t *testing.T) {
-		got, err := ExternalServices(db).List(ctx, ExternalServicesListOptions{
+		got, err := db.ExternalServices().List(ctx, ExternalServicesListOptions{
 			NoNamespace: true,
 		})
 		if err != nil {
@@ -1589,7 +1589,7 @@ func TestExternalServicesStore_List(t *testing.T) {
 	})
 
 	t.Run("list only test user's external services", func(t *testing.T) {
-		got, err := ExternalServices(db).List(ctx, ExternalServicesListOptions{
+		got, err := db.ExternalServices().List(ctx, ExternalServicesListOptions{
 			NamespaceUserID: user.ID,
 		})
 		if err != nil {
@@ -1604,7 +1604,7 @@ func TestExternalServicesStore_List(t *testing.T) {
 	})
 
 	t.Run("list non-exist user's external services", func(t *testing.T) {
-		ess, err := ExternalServices(db).List(ctx, ExternalServicesListOptions{
+		ess, err := db.ExternalServices().List(ctx, ExternalServicesListOptions{
 			NamespaceUserID: 404,
 		})
 		if err != nil {
@@ -1617,7 +1617,7 @@ func TestExternalServicesStore_List(t *testing.T) {
 	})
 
 	t.Run("list only test org's external services", func(t *testing.T) {
-		got, err := ExternalServices(db).List(ctx, ExternalServicesListOptions{
+		got, err := db.ExternalServices().List(ctx, ExternalServicesListOptions{
 			NamespaceOrgID: org.ID,
 		})
 		if err != nil {
@@ -1632,7 +1632,7 @@ func TestExternalServicesStore_List(t *testing.T) {
 	})
 
 	t.Run("list non-existing org external services", func(t *testing.T) {
-		ess, err := ExternalServices(db).List(ctx, ExternalServicesListOptions{
+		ess, err := db.ExternalServices().List(ctx, ExternalServicesListOptions{
 			NamespaceOrgID: 404,
 		})
 		if err != nil {
@@ -1645,7 +1645,7 @@ func TestExternalServicesStore_List(t *testing.T) {
 	})
 
 	t.Run("list services updated after a certain date, expect 0", func(t *testing.T) {
-		ess, err := ExternalServices(db).List(ctx, ExternalServicesListOptions{
+		ess, err := db.ExternalServices().List(ctx, ExternalServicesListOptions{
 			UpdatedAfter: createdAt,
 		})
 		if err != nil {
@@ -1658,7 +1658,7 @@ func TestExternalServicesStore_List(t *testing.T) {
 	})
 
 	t.Run("list services updated after a certain date, expect 3", func(t *testing.T) {
-		ess, err := ExternalServices(db).List(ctx, ExternalServicesListOptions{
+		ess, err := db.ExternalServices().List(ctx, ExternalServicesListOptions{
 			UpdatedAfter: createdAt.Add(-5 * time.Minute),
 		})
 		if err != nil {
@@ -1676,11 +1676,11 @@ func TestExternalServicesStore_DistinctKinds(t *testing.T) {
 		t.Skip()
 	}
 	t.Parallel()
-	db := dbtest.NewDB(t)
+	db := NewDB(dbtest.NewDB(t))
 	ctx := context.Background()
 
 	t.Run("no external service won't blow up", func(t *testing.T) {
-		kinds, err := ExternalServices(db).DistinctKinds(ctx)
+		kinds, err := db.ExternalServices().DistinctKinds(ctx)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1716,19 +1716,19 @@ func TestExternalServicesStore_DistinctKinds(t *testing.T) {
 		},
 	}
 	for _, es := range ess {
-		err := ExternalServices(db).Create(ctx, confGet, es)
+		err := db.ExternalServices().Create(ctx, confGet, es)
 		if err != nil {
 			t.Fatal(err)
 		}
 	}
 
 	// Delete the last external service which should be excluded from the result
-	err := ExternalServices(db).Delete(ctx, ess[3].ID)
+	err := db.ExternalServices().Delete(ctx, ess[3].ID)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	kinds, err := ExternalServices(db).DistinctKinds(ctx)
+	kinds, err := db.ExternalServices().DistinctKinds(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1744,7 +1744,7 @@ func TestExternalServicesStore_Count(t *testing.T) {
 		t.Skip()
 	}
 	t.Parallel()
-	db := dbtest.NewDB(t)
+	db := NewDB(dbtest.NewDB(t))
 	ctx := context.Background()
 
 	// Create a new external service
@@ -1756,12 +1756,12 @@ func TestExternalServicesStore_Count(t *testing.T) {
 		DisplayName: "GITHUB #1",
 		Config:      `{"url": "https://github.com", "repositoryQuery": ["none"], "token": "abc"}`,
 	}
-	err := ExternalServices(db).Create(ctx, confGet, es)
+	err := db.ExternalServices().Create(ctx, confGet, es)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	count, err := ExternalServices(db).Count(ctx, ExternalServicesListOptions{})
+	count, err := db.ExternalServices().Count(ctx, ExternalServicesListOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1776,7 +1776,7 @@ func TestExternalServicesStore_Upsert(t *testing.T) {
 		t.Skip()
 	}
 	t.Parallel()
-	db := dbtest.NewDB(t)
+	db := NewDB(dbtest.NewDB(t))
 	ctx := context.Background()
 
 	clock := timeutil.NewFakeClock(time.Now(), 0)
@@ -1784,13 +1784,13 @@ func TestExternalServicesStore_Upsert(t *testing.T) {
 	svcs := typestest.MakeExternalServices()
 
 	t.Run("no external services", func(t *testing.T) {
-		if err := ExternalServices(db).Upsert(ctx); err != nil {
+		if err := db.ExternalServices().Upsert(ctx); err != nil {
 			t.Fatalf("Upsert error: %s", err)
 		}
 	})
 
 	t.Run("one external service", func(t *testing.T) {
-		tx, err := ExternalServices(db).Transact(ctx)
+		tx, err := db.ExternalServices().Transact(ctx)
 		if err != nil {
 			t.Fatalf("Transact error: %s", err)
 		}
@@ -1835,7 +1835,7 @@ func TestExternalServicesStore_Upsert(t *testing.T) {
 
 		namespacedSvcs := typestest.MakeNamespacedExternalServices(user.ID, org.ID)
 
-		tx, err := ExternalServices(db).Transact(ctx)
+		tx, err := db.ExternalServices().Transact(ctx)
 		if err != nil {
 			t.Fatalf("Transact error: %s", err)
 		}
@@ -1920,7 +1920,7 @@ func TestExternalServicesStore_Upsert(t *testing.T) {
 	})
 
 	t.Run("with encryption key", func(t *testing.T) {
-		tx, err := ExternalServices(db).WithEncryptionKey(et.TestKey{}).Transact(ctx)
+		tx, err := db.ExternalServices().WithEncryptionKey(et.TestKey{}).Transact(ctx)
 		if err != nil {
 			t.Fatalf("Transact error: %s", err)
 		}
@@ -2020,7 +2020,7 @@ func TestExternalServiceStore_GetExternalServiceSyncJobs(t *testing.T) {
 		t.Skip()
 	}
 	t.Parallel()
-	db := dbtest.NewDB(t)
+	db := NewDB(dbtest.NewDB(t))
 	ctx := context.Background()
 
 	// Create a new external service
@@ -2032,17 +2032,17 @@ func TestExternalServiceStore_GetExternalServiceSyncJobs(t *testing.T) {
 		DisplayName: "GITHUB #1",
 		Config:      `{"url": "https://github.com", "repositoryQuery": ["none"], "token": "abc"}`,
 	}
-	err := ExternalServices(db).Create(ctx, confGet, es)
+	err := db.ExternalServices().Create(ctx, confGet, es)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	_, err = db.ExecContext(ctx, "INSERT INTO external_service_sync_jobs (external_service_id) VALUES ($1)", es.ID)
+	_, err = db.Handle().DB().ExecContext(ctx, "INSERT INTO external_service_sync_jobs (external_service_id) VALUES ($1)", es.ID)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	have, err := ExternalServices(db).GetSyncJobs(ctx)
+	have, err := db.ExternalServices().GetSyncJobs(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2065,7 +2065,7 @@ func TestExternalServicesStore_OneCloudDefaultPerKind(t *testing.T) {
 		t.Skip()
 	}
 	t.Parallel()
-	db := dbtest.NewDB(t)
+	db := NewDB(dbtest.NewDB(t))
 	ctx := context.Background()
 
 	now := time.Now()
@@ -2085,21 +2085,21 @@ func TestExternalServicesStore_OneCloudDefaultPerKind(t *testing.T) {
 
 	t.Run("non default", func(t *testing.T) {
 		gh := makeService(false)
-		if err := ExternalServices(db).Upsert(ctx, gh); err != nil {
+		if err := db.ExternalServices().Upsert(ctx, gh); err != nil {
 			t.Fatalf("Upsert error: %s", err)
 		}
 	})
 
 	t.Run("first default", func(t *testing.T) {
 		gh := makeService(true)
-		if err := ExternalServices(db).Upsert(ctx, gh); err != nil {
+		if err := db.ExternalServices().Upsert(ctx, gh); err != nil {
 			t.Fatalf("Upsert error: %s", err)
 		}
 	})
 
 	t.Run("second default", func(t *testing.T) {
 		gh := makeService(true)
-		if err := ExternalServices(db).Upsert(ctx, gh); err == nil {
+		if err := db.ExternalServices().Upsert(ctx, gh); err == nil {
 			t.Fatal("Expected an error")
 		}
 	})
@@ -2110,7 +2110,7 @@ func TestExternalServiceStore_SyncDue(t *testing.T) {
 		t.Skip()
 	}
 	t.Parallel()
-	db := dbtest.NewDB(t)
+	db := NewDB(dbtest.NewDB(t))
 	ctx := context.Background()
 
 	now := time.Now()
@@ -2128,7 +2128,7 @@ func TestExternalServiceStore_SyncDue(t *testing.T) {
 	}
 	svc1 := makeService()
 	svc2 := makeService()
-	err := ExternalServices(db).Upsert(ctx, svc1, svc2)
+	err := db.ExternalServices().Upsert(ctx, svc1, svc2)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2136,7 +2136,7 @@ func TestExternalServiceStore_SyncDue(t *testing.T) {
 	assertDue := func(d time.Duration, want bool) {
 		t.Helper()
 		ids := []int64{svc1.ID, svc2.ID}
-		due, err := ExternalServices(db).SyncDue(ctx, ids, d)
+		due, err := db.ExternalServices().SyncDue(ctx, ids, d)
 		if err != nil {
 			t.Error(err)
 		}
@@ -2146,7 +2146,7 @@ func TestExternalServiceStore_SyncDue(t *testing.T) {
 	}
 
 	makeSyncJob := func(svcID int64, state string) {
-		_, err = db.Exec(`
+		_, err = db.Handle().DB().ExecContext(ctx, `
 INSERT INTO external_service_sync_jobs (external_service_id, state)
 VALUES ($1,$2)
 `, svcID, state)
@@ -2159,7 +2159,7 @@ VALUES ($1,$2)
 	assertDue(1*time.Second, true)
 
 	// next_sync_at in the future
-	_, err = db.Exec("UPDATE external_services SET next_sync_at = $1", now.Add(10*time.Minute))
+	_, err = db.Handle().DB().ExecContext(ctx, "UPDATE external_services SET next_sync_at = $1", now.Add(10*time.Minute))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2172,7 +2172,7 @@ VALUES ($1,$2)
 	assertDue(1*time.Minute, true)
 
 	// Sync jobs not running
-	_, err = db.Exec("UPDATE external_service_sync_jobs SET state = 'completed'")
+	_, err = db.Handle().DB().ExecContext(ctx, "UPDATE external_service_sync_jobs SET state = 'completed'")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/database/gitserver_repos_test.go
+++ b/internal/database/gitserver_repos_test.go
@@ -116,7 +116,7 @@ func TestIterateRepoGitserverStatus(t *testing.T) {
 
 func TestIteratePurgeableRepos(t *testing.T) {
 	ctx := context.Background()
-	db := dbtest.NewDB(t)
+	db := NewDB(dbtest.NewDB(t))
 
 	normalRepo := &types.Repo{
 		Name: "normal",
@@ -289,7 +289,7 @@ func TestIterateWithNonemptyLastError(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := context.Background()
-			db := dbtest.NewDB(t)
+			db := NewDB(dbtest.NewDB(t))
 			now := time.Now()
 
 			cloudDefaultService := createTestExternalService(ctx, t, now, db, true)
@@ -349,7 +349,7 @@ func TestIterateWithNonemptyLastError(t *testing.T) {
 	}
 }
 
-func createTestExternalService(ctx context.Context, t *testing.T, now time.Time, db *sql.DB, cloudDefault bool) types.ExternalService {
+func createTestExternalService(ctx context.Context, t *testing.T, now time.Time, db DB, cloudDefault bool) types.ExternalService {
 	service := types.ExternalService{
 		Kind:         extsvc.KindGitHub,
 		DisplayName:  "Github - Test",
@@ -364,7 +364,7 @@ func createTestExternalService(ctx context.Context, t *testing.T, now time.Time,
 		return &conf.Unified{}
 	}
 
-	err := ExternalServices(db).Create(ctx, confGet, &service)
+	err := db.ExternalServices().Create(ctx, confGet, &service)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1043,7 +1043,7 @@ func createTestRepos(ctx context.Context, t *testing.T, db dbutil.DB, repos type
 	}
 }
 
-func createTestGitserverRepos(ctx context.Context, t *testing.T, db *sql.DB, hasLastError bool, cloneStatus types.CloneStatus, repoID api.RepoID) {
+func createTestGitserverRepos(ctx context.Context, t *testing.T, db DB, hasLastError bool, cloneStatus types.CloneStatus, repoID api.RepoID) {
 	t.Helper()
 	gitserverRepo := &types.GitserverRepo{
 		RepoID:      repoID,

--- a/internal/database/orgs_test.go
+++ b/internal/database/orgs_test.go
@@ -200,7 +200,7 @@ func TestOrgs_GetByID(t *testing.T) {
 }
 
 func TestOrgs_GetOrgsWithRepositoriesByUserID(t *testing.T) {
-	createOrg := func(ctx context.Context, db *sql.DB, name string, displayName string) *types.Org {
+	createOrg := func(ctx context.Context, db DB, name string, displayName string) *types.Org {
 		org, err := Orgs(db).Create(ctx, name, &displayName)
 		if err != nil {
 			t.Fatal(err)
@@ -209,7 +209,7 @@ func TestOrgs_GetOrgsWithRepositoriesByUserID(t *testing.T) {
 		return org
 	}
 
-	createUser := func(ctx context.Context, db *sql.DB, name string) *types.User {
+	createUser := func(ctx context.Context, db DB, name string) *types.User {
 		user, err := Users(db).Create(ctx, NewUser{
 			Username: name,
 		})
@@ -220,7 +220,7 @@ func TestOrgs_GetOrgsWithRepositoriesByUserID(t *testing.T) {
 		return user
 	}
 
-	createOrgMember := func(ctx context.Context, db *sql.DB, userID int32, orgID int32) {
+	createOrgMember := func(ctx context.Context, db DB, userID int32, orgID int32) {
 		_, err := OrgMembers(db).Create(ctx, orgID, userID)
 		if err != nil {
 			t.Fatal(err)
@@ -228,7 +228,7 @@ func TestOrgs_GetOrgsWithRepositoriesByUserID(t *testing.T) {
 	}
 
 	t.Parallel()
-	db := dbtest.NewDB(t)
+	db := NewDB(dbtest.NewDB(t))
 	ctx := context.Background()
 
 	org1 := createOrg(ctx, db, "org1", "org1")
@@ -246,7 +246,7 @@ func TestOrgs_GetOrgsWithRepositoriesByUserID(t *testing.T) {
 	confGet := func() *conf.Unified {
 		return &conf.Unified{}
 	}
-	if err := ExternalServices(db).Create(ctx, confGet, service); err != nil {
+	if err := db.ExternalServices().Create(ctx, confGet, service); err != nil {
 		t.Fatal(err)
 	}
 	repo := typestest.MakeGithubRepo(service)

--- a/internal/database/repos.go
+++ b/internal/database/repos.go
@@ -176,7 +176,7 @@ func logPrivateRepoAccessGranted(ctx context.Context, db dbutil.DB, ids []api.Re
 		event.AnonymousUserID = "internal"
 	}
 
-	SecurityEventLogs(db).LogEvent(ctx, event)
+	NewDB(db).SecurityEventLogs().LogEvent(ctx, event)
 }
 
 // GetByName returns the repository with the given nameOrUri from the

--- a/internal/database/repos_perm_test.go
+++ b/internal/database/repos_perm_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/schema"
@@ -171,7 +170,7 @@ func TestAuthzQueryConds(t *testing.T) {
 }
 
 func TestRepoStore_nonSiteAdminCanViewOwnPrivateCode(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := NewDB(dbtest.NewDB(t))
 	ctx := context.Background()
 
 	// Add a single user who is NOT a site admin
@@ -221,7 +220,7 @@ func TestRepoStore_nonSiteAdminCanViewOwnPrivateCode(t *testing.T) {
 		DisplayName: "GITHUB #1",
 		Config:      `{"url": "https://github.com", "repositoryQuery": ["none"], "token": "abc", "authorization": {}}`,
 	}
-	err = ExternalServices(db).Create(ctx, confGet, aliceExternalService)
+	err = db.ExternalServices().Create(ctx, confGet, aliceExternalService)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -268,7 +267,7 @@ func TestRepoStore_userCanSeeUnrestricedRepo(t *testing.T) {
 		t.Skip()
 	}
 
-	db := dbtest.NewDB(t)
+	db := NewDB(dbtest.NewDB(t))
 	ctx := context.Background()
 
 	// Add a single user who is NOT a site admin
@@ -310,7 +309,7 @@ func TestRepoStore_userCanSeeUnrestricedRepo(t *testing.T) {
 		DisplayName: "GITHUB #1",
 		Config:      `{"url": "https://github.com", "repositoryQuery": ["none"], "token": "abc", "authorization": {}}`,
 	}
-	err = ExternalServices(db).Create(ctx, confGet, extsvc)
+	err = db.ExternalServices().Create(ctx, confGet, extsvc)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -376,7 +375,7 @@ func TestRepoStore_nonSiteAdminCanViewOrgPrivateCode(t *testing.T) {
 		t.Skip()
 	}
 
-	db := dbtest.NewDB(t)
+	db := NewDB(dbtest.NewDB(t))
 	ctx := context.Background()
 
 	// Add a single user who is NOT a site admin
@@ -442,7 +441,7 @@ func TestRepoStore_nonSiteAdminCanViewOrgPrivateCode(t *testing.T) {
 		Config:         `{"url": "https://github.com", "repositoryQuery": ["none"], "token": "abc", "authorization": {}}`,
 		NamespaceOrgID: org.ID,
 	}
-	err = ExternalServices(db).Create(ctx, confGet, extsvc)
+	err = db.ExternalServices().Create(ctx, confGet, extsvc)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -483,7 +482,7 @@ VALUES
 	}
 }
 
-func createGitHubExternalService(t *testing.T, db dbutil.DB, userID int32) *types.ExternalService {
+func createGitHubExternalService(t *testing.T, db DB, userID int32) *types.ExternalService {
 	now := time.Now()
 	svc := &types.ExternalService{
 		Kind:            extsvc.KindGitHub,
@@ -494,7 +493,7 @@ func createGitHubExternalService(t *testing.T, db dbutil.DB, userID int32) *type
 		UpdatedAt:       now,
 	}
 
-	if err := ExternalServices(db).Upsert(context.Background(), svc); err != nil {
+	if err := db.ExternalServices().Upsert(context.Background(), svc); err != nil {
 		t.Fatal(err)
 	}
 
@@ -507,7 +506,7 @@ func TestRepoStore_List_checkPermissions(t *testing.T) {
 		t.Skip()
 	}
 
-	db := dbtest.NewDB(t)
+	db := NewDB(dbtest.NewDB(t))
 	ctx := context.Background()
 
 	// Set up three users: alice, bob and admin
@@ -650,7 +649,7 @@ VALUES (%s, %s, '')
 		Config:       `{"url": "https://github.com", "repositoryQuery": ["none"], "token": "abc"}`,
 		Unrestricted: true,
 	}
-	err = ExternalServices(db).Create(ctx, confGet, cindyExternalService)
+	err = db.ExternalServices().Create(ctx, confGet, cindyExternalService)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -768,7 +767,7 @@ func TestRepoStore_List_permissionsUserMapping(t *testing.T) {
 		t.Skip()
 	}
 
-	db := dbtest.NewDB(t)
+	db := NewDB(dbtest.NewDB(t))
 	ctx := context.Background()
 
 	// Set up three users: alice, bob and admin

--- a/internal/database/repos_test.go
+++ b/internal/database/repos_test.go
@@ -138,7 +138,7 @@ func TestRepos_Count(t *testing.T) {
 		t.Skip()
 	}
 	t.Parallel()
-	db := dbtest.NewDB(t)
+	db := NewDB(dbtest.NewDB(t))
 	ctx := context.Background()
 	ctx = actor.WithActor(ctx, &actor.Actor{UID: 1, Internal: true})
 
@@ -190,7 +190,7 @@ func TestRepos_Delete(t *testing.T) {
 		t.Skip()
 	}
 	t.Parallel()
-	db := dbtest.NewDB(t)
+	db := NewDB(dbtest.NewDB(t))
 	ctx := context.Background()
 	ctx = actor.WithActor(ctx, &actor.Actor{UID: 1, Internal: true})
 
@@ -224,7 +224,7 @@ func TestRepos_Upsert(t *testing.T) {
 		t.Skip()
 	}
 	t.Parallel()
-	db := dbtest.NewDB(t)
+	db := NewDB(dbtest.NewDB(t))
 	ctx := context.Background()
 	ctx = actor.WithActor(ctx, &actor.Actor{UID: 1, Internal: true})
 
@@ -307,7 +307,7 @@ func TestRepos_UpsertForkAndArchivedFields(t *testing.T) {
 		t.Skip()
 	}
 	t.Parallel()
-	db := dbtest.NewDB(t)
+	db := NewDB(dbtest.NewDB(t))
 	ctx := context.Background()
 	ctx = actor.WithActor(ctx, &actor.Actor{UID: 1, Internal: true})
 
@@ -345,12 +345,12 @@ func TestRepos_Create(t *testing.T) {
 		t.Skip()
 	}
 	t.Parallel()
-	db := dbtest.NewDB(t)
+	db := NewDB(dbtest.NewDB(t))
 	ctx := context.Background()
 	ctx = actor.WithActor(ctx, &actor.Actor{UID: 1, Internal: true})
 
 	svcs := typestest.MakeExternalServices()
-	if err := ExternalServices(db).Upsert(ctx, svcs...); err != nil {
+	if err := db.ExternalServices().Upsert(ctx, svcs...); err != nil {
 		t.Fatalf("Upsert error: %s", err)
 	}
 
@@ -395,7 +395,7 @@ func TestListIndexableRepos(t *testing.T) {
 	}
 
 	t.Parallel()
-	db := dbtest.NewDB(t)
+	db := NewDB(dbtest.NewDB(t))
 
 	reposToAdd := []types.Repo{
 		{
@@ -523,7 +523,7 @@ func TestRepoStore_Metadata(t *testing.T) {
 	}
 
 	t.Parallel()
-	db := dbtest.NewDB(t)
+	db := NewDB(dbtest.NewDB(t))
 
 	ctx := context.Background()
 

--- a/internal/database/security_event_logs.go
+++ b/internal/database/security_event_logs.go
@@ -2,7 +2,6 @@ package database
 
 import (
 	"context"
-	"database/sql"
 	"encoding/json"
 	"time"
 
@@ -10,7 +9,6 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/sentry"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/internal/version"
@@ -69,12 +67,6 @@ type SecurityEventLogsStore interface {
 
 type securityEventLogsStore struct {
 	*basestore.Store
-}
-
-// SecurityEventLogs instantiates and returns a new SecurityEventLogsStore with
-// prepared statements.
-func SecurityEventLogs(db dbutil.DB) SecurityEventLogsStore {
-	return &securityEventLogsStore{Store: basestore.NewWithDB(db, sql.TxOptions{})}
 }
 
 // SecurityEventLogsWith instantiates and returns a new SecurityEventLogsStore

--- a/internal/database/security_event_logs_test.go
+++ b/internal/database/security_event_logs_test.go
@@ -15,7 +15,7 @@ func TestSecurityEventLogs_ValidInfo(t *testing.T) {
 		t.Skip()
 	}
 	t.Parallel()
-	db := dbtest.NewDB(t)
+	db := NewDB(dbtest.NewDB(t))
 	ctx := context.Background()
 
 	var testCases = []struct {
@@ -61,7 +61,7 @@ func TestSecurityEventLogs_ValidInfo(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			err := SecurityEventLogs(db).Insert(ctx, tc.event)
+			err := db.SecurityEventLogs().Insert(ctx, tc.event)
 			got := fmt.Sprintf("%v", err)
 			assert.Equal(t, tc.err, got)
 		})

--- a/internal/database/users.go
+++ b/internal/database/users.go
@@ -401,7 +401,7 @@ func logAccountCreatedEvent(ctx context.Context, db dbutil.DB, u *types.User, se
 		Timestamp:       time.Now(),
 	}
 
-	SecurityEventLogs(db).LogEvent(ctx, event)
+	NewDB(db).SecurityEventLogs().LogEvent(ctx, event)
 }
 
 // orgsForAllUsersToJoin returns the list of org names that all users should be joined to. The second return value
@@ -628,7 +628,7 @@ func logUserDeletionEvent(ctx context.Context, db dbutil.DB, id int32, name Secu
 		Timestamp:       time.Now(),
 	}
 
-	SecurityEventLogs(db).LogEvent(ctx, event)
+	NewDB(db).SecurityEventLogs().LogEvent(ctx, event)
 }
 
 // SetIsSiteAdmin sets the user with the given ID to be or not to be the site admin.
@@ -1072,7 +1072,7 @@ func LogPasswordEvent(ctx context.Context, db dbutil.DB, r *http.Request, name S
 	}
 	event.AnonymousUserID, _ = cookie.AnonymousUID(r)
 
-	SecurityEventLogs(db).LogEvent(ctx, event)
+	NewDB(db).SecurityEventLogs().LogEvent(ctx, event)
 }
 
 func hashPassword(password string) (sql.NullString, error) {

--- a/internal/database/users_test.go
+++ b/internal/database/users_test.go
@@ -517,7 +517,7 @@ func TestUsers_Delete(t *testing.T) {
 			confGet := func() *conf.Unified {
 				return &conf.Unified{}
 			}
-			err = ExternalServices(db).Create(ctx, confGet, &types.ExternalService{
+			err = db.ExternalServices().Create(ctx, confGet, &types.ExternalService{
 				Kind:            extsvc.KindGitHub,
 				DisplayName:     "GITHUB #1",
 				Config:          `{"url": "https://github.com", "repositoryQuery": ["none"], "token": "abc", "authorization": {}}`,
@@ -602,7 +602,7 @@ func TestUsers_Delete(t *testing.T) {
 			}
 
 			// User's external services no longer exist
-			ess, err := ExternalServices(db).List(ctx, ExternalServicesListOptions{
+			ess, err := db.ExternalServices().List(ctx, ExternalServicesListOptions{
 				NamespaceUserID: user.ID,
 			})
 			if err != nil {

--- a/internal/database/webhook_logs_test.go
+++ b/internal/database/webhook_logs_test.go
@@ -136,7 +136,7 @@ func TestWebhookLogStore(t *testing.T) {
 		assert.Nil(t, err)
 		defer tx.Rollback()
 
-		esStore := ExternalServices(tx)
+		esStore := NewDB(tx).ExternalServices()
 		es := &types.ExternalService{
 			Kind:        extsvc.KindGitLab,
 			DisplayName: "GitLab",
@@ -252,7 +252,7 @@ func TestWebhookLogStore(t *testing.T) {
 		assert.Nil(t, err)
 		defer tx.Rollback()
 
-		esStore := ExternalServices(tx)
+		esStore := NewDB(tx).ExternalServices()
 		es := &types.ExternalService{
 			Kind:        extsvc.KindGitLab,
 			DisplayName: "GitLab",

--- a/internal/repos/scheduler.go
+++ b/internal/repos/scheduler.go
@@ -436,7 +436,7 @@ func (s *UpdateScheduler) DebugDump(ctx context.Context, db database.DB) any {
 	}
 
 	var err error
-	data.SyncJobs, err = database.ExternalServices(db).GetSyncJobs(ctx)
+	data.SyncJobs, err = db.ExternalServices().GetSyncJobs(ctx)
 	if err != nil {
 		log15.Warn("Getting external service sync jobs foe debug page", "error", err)
 	}

--- a/internal/repos/status_messages_test.go
+++ b/internal/repos/status_messages_test.go
@@ -27,7 +27,7 @@ func TestStatusMessages(t *testing.T) {
 		t.Skip()
 	}
 	ctx := context.Background()
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	store := NewStore(database.NewDB(db), sql.TxOptions{})
 
 	admin, err := database.Users(db).Create(ctx, database.NewUser{
@@ -52,7 +52,7 @@ func TestStatusMessages(t *testing.T) {
 		Kind:        extsvc.KindGitHub,
 		DisplayName: "github.com - site",
 	}
-	err = database.ExternalServices(db).Upsert(ctx, siteLevelService)
+	err = db.ExternalServices().Upsert(ctx, siteLevelService)
 	require.NoError(t, err)
 
 	userService := &types.ExternalService{
@@ -62,7 +62,7 @@ func TestStatusMessages(t *testing.T) {
 		DisplayName:     "github.com - user",
 		NamespaceUserID: nonAdmin.ID,
 	}
-	err = database.ExternalServices(db).Upsert(ctx, userService)
+	err = db.ExternalServices().Upsert(ctx, userService)
 	require.NoError(t, err)
 
 	testCases := []struct {

--- a/internal/search/alert/observer.go
+++ b/internal/search/alert/observer.go
@@ -345,7 +345,7 @@ func needsRepositoryConfiguration(ctx context.Context, db database.DB) (bool, er
 		}
 	}
 
-	count, err := database.ExternalServices(db).Count(ctx, database.ExternalServicesListOptions{
+	count, err := db.ExternalServices().Count(ctx, database.ExternalServicesListOptions{
 		Kinds: kinds,
 	})
 	if err != nil {
@@ -355,7 +355,7 @@ func needsRepositoryConfiguration(ctx context.Context, db database.DB) (bool, er
 }
 
 func needsPackageHostConfiguration(ctx context.Context, db database.DB) (bool, error) {
-	count, err := database.ExternalServices(db).Count(ctx, database.ExternalServicesListOptions{
+	count, err := db.ExternalServices().Count(ctx, database.ExternalServicesListOptions{
 		Kinds: []string{
 			extsvc.KindNpmPackages,
 			extsvc.KindGoModules,

--- a/internal/usagestats/batches_test.go
+++ b/internal/usagestats/batches_test.go
@@ -21,7 +21,7 @@ func TestGetBatchChangesUsageStatistics(t *testing.T) {
 
 	// Create stub repo.
 	repoStore := database.Repos(db)
-	esStore := database.ExternalServices(db)
+	esStore := db.ExternalServices()
 
 	now := time.Now()
 	svc := types.ExternalService{


### PR DESCRIPTION
Remove a few dbutil-based constructors in our database package, as they are not mockable in our tests.

This is a result of a time-boxed effort.

## Test plan

Unit tests

---

Part of https://github.com/sourcegraph/sourcegraph/issues/26113