### PR TITLE
codenotify: update action version

### DIFF
--- a/.github/workflows/codenotify.yml
+++ b/.github/workflows/codenotify.yml
@@ -12,13 +12,13 @@ jobs:
       - uses: actions/checkout@v2
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-      - uses: sourcegraph/codenotify@v0.6.0
+      - uses: sourcegraph/codenotify@v0.6.1
         with:
           filename: 'CODENOTIFY'
           subscriber-threshold: '15'
         env:
           GITHUB_TOKEN: ${{ secrets.CODENOTIFY_GITHUB_TOKEN }}
-      - uses: sourcegraph/codenotify@v0.6.0
+      - uses: sourcegraph/codenotify@v0.6.1
         with:
           filename: 'OWNERS'
           subscriber-threshold: '15'


### PR DESCRIPTION
The previous version did not actually read the "subscriber-threshold" env var.

Sister PR: https://github.com/sourcegraph/codenotify/pull/20

## Test plan

n/a
