### PR TITLE
Code Insights: Fix add insights modal checkbox layout

### DIFF
--- a/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/add-insight-modal/components/add-insight-modal-content/AddInsightModalContent.module.scss
+++ b/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/add-insight-modal/components/add-insight-modal-content/AddInsightModalContent.module.scss
@@ -1,15 +1,10 @@
 .insights-container {
+    margin-top: 0.5rem;
     max-height: 14rem;
     overflow: auto;
 }
 
 .insight-item {
-    /*
-       According to our global styles all small tags have font-weight: 500
-       but it makes this description difficult to read, so for now we override
-       this insight items label and make them with normal font-weight.
-    */
-    font-weight: normal !important;
     display: flex;
     align-items: center;
     width: 100%;
@@ -23,7 +18,6 @@
     }
 }
 
-.insight-owner-name {
-    max-width: 40%;
-    margin-left: 1rem;
+.insight-name {
+    margin-left: 0.5rem;
 }

--- a/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/add-insight-modal/components/add-insight-modal-content/AddInsightModalContent.tsx
+++ b/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/add-insight-modal/components/add-insight-modal-content/AddInsightModalContent.tsx
@@ -1,10 +1,9 @@
 import React from 'react'
 
-import classNames from 'classnames'
 import { escapeRegExp } from 'lodash'
 
 import { ErrorAlert } from '@sourcegraph/branded/src/components/alerts'
-import { Button, Checkbox, Input, Link } from '@sourcegraph/wildcard'
+import { Button, Typography, Input, Link } from '@sourcegraph/wildcard'
 
 import { LoaderButton } from '../../../../../../../../../components/LoaderButton'
 import { TruncatedText } from '../../../../../../../components'
@@ -66,20 +65,20 @@ export const AddInsightModalContent: React.FunctionComponent<
                 {...searchInput.input}
             />
 
-            <fieldset className={classNames('mt-2', styles.insightsContainer)}>
+            <fieldset className={styles.insightsContainer}>
                 {filteredInsights.map(insight => (
-                    <Checkbox
-                        key={insight.id}
-                        id={insight.id}
-                        name="insightIds"
-                        checked={isChecked(insight.id)}
-                        value={insight.id}
-                        onChange={onChange}
-                        onBlur={onBlur}
-                        wrapperClassName={styles.insightItem}
-                        className="mr-2"
-                        label={<TruncatedText>{insight.title}</TruncatedText>}
-                    />
+                    <Typography.Label key={insight.id} weight="medium" className={styles.insightItem}>
+                        <input
+                            type="checkbox"
+                            name="insightIds"
+                            value={insight.id}
+                            checked={isChecked(insight.id)}
+                            onChange={onChange}
+                            onBlur={onBlur}
+                        />
+
+                        <TruncatedText className={styles.insightName}>{insight.title}</TruncatedText>
+                    </Typography.Label>
                 ))}
             </fieldset>
 


### PR DESCRIPTION
Fix https://github.com/sourcegraph/sourcegraph/issues/35163

<table>
  <tr><th>Before</th><th>After</th></tr>
    <tr>
       <th><img width="1195" alt="Screenshot 2022-05-17 at 19 34 27" src="https://user-images.githubusercontent.com/18492575/168803410-b4fbe468-d10a-4184-ade3-8670f960a018.png"></th>
       <th><img width="1195" alt="Screenshot 2022-05-17 at 19 34 08" src="https://user-images.githubusercontent.com/18492575/168803442-07583cb4-2b92-4b06-bcb5-5d5bb80061cd.png"></th>
    </tr>
</table>

## Test plan
- Make sure that add insights layout looks fine

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vk-fix-insight-checkbox-control.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-jiudiquvdl.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
