### PR TITLE
move git LsFiles and ListFiles to gitserver client

### DIFF
--- a/cmd/frontend/graphqlbackend/git_commit.go
+++ b/cmd/frontend/graphqlbackend/git_commit.go
@@ -270,7 +270,7 @@ func (r *GitCommitResolver) path(ctx context.Context, path string, validate func
 }
 
 func (r *GitCommitResolver) FileNames(ctx context.Context) ([]string, error) {
-	return git.LsFiles(ctx, r.db, authz.DefaultSubRepoPermsChecker, r.gitRepo, api.CommitID(r.oid))
+	return gitserver.NewClient(r.db).LsFiles(ctx, authz.DefaultSubRepoPermsChecker, r.gitRepo, api.CommitID(r.oid))
 }
 
 func (r *GitCommitResolver) Languages(ctx context.Context) ([]string, error) {

--- a/cmd/frontend/graphqlbackend/git_commit_test.go
+++ b/cmd/frontend/graphqlbackend/git_commit_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
@@ -150,12 +151,13 @@ func TestGitCommitFileNames(t *testing.T) {
 		return exampleCommitSHA1, nil
 	}
 	backend.Mocks.Repos.MockGetCommit_Return_NoCheck(t, &gitdomain.Commit{ID: exampleCommitSHA1})
-	git.Mocks.LsFiles = func(repo api.RepoName, commit api.CommitID) ([]string, error) {
+	gitserver.Mocks.LsFiles = func(repo api.RepoName, commit api.CommitID) ([]string, error) {
 		return []string{"a", "b"}, nil
 	}
 	defer func() {
 		backend.Mocks = backend.MockServices{}
 		git.ResetMocks()
+		gitserver.ResetMocks()
 	}()
 
 	RunTests(t, []*Test{

--- a/enterprise/internal/codeintel/gitserver/client.go
+++ b/enterprise/internal/codeintel/gitserver/client.go
@@ -422,7 +422,7 @@ func (c *Client) ListFiles(ctx context.Context, repositoryID int, commit string,
 		return nil, err
 	}
 
-	matching, err := git.ListFiles(ctx, c.db, repo, api.CommitID(commit), pattern, authz.DefaultSubRepoPermsChecker)
+	matching, err := gitserver.NewClient(c.db).ListFiles(ctx, repo, api.CommitID(commit), pattern, authz.DefaultSubRepoPermsChecker)
 	if err == nil {
 		return matching, nil
 	}

--- a/internal/codeintel/autoindexing/internal/inference/iface.go
+++ b/internal/codeintel/autoindexing/internal/inference/iface.go
@@ -40,7 +40,7 @@ func NewDefaultGitService(checker authz.SubRepoPermissionChecker, db database.DB
 }
 
 func (s *gitService) ListFiles(ctx context.Context, repo api.RepoName, commit string, pattern *regexp.Regexp) ([]string, error) {
-	return git.ListFiles(ctx, s.db, repo, api.CommitID(commit), pattern, authz.DefaultSubRepoPermsChecker)
+	return gitserver.NewClient(s.db).ListFiles(ctx, repo, api.CommitID(commit), pattern, authz.DefaultSubRepoPermsChecker)
 }
 
 func (s *gitService) Archive(ctx context.Context, repo api.RepoName, opts gitserver.ArchiveOptions) (io.ReadCloser, error) {

--- a/internal/codeintel/dependencies/live/git.go
+++ b/internal/codeintel/dependencies/live/git.go
@@ -30,7 +30,7 @@ func (s *gitService) GetCommits(ctx context.Context, repoCommits []api.RepoCommi
 }
 
 func (s *gitService) LsFiles(ctx context.Context, repo api.RepoName, commits api.CommitID, pathspecs ...gitserver.Pathspec) ([]string, error) {
-	return git.LsFiles(ctx, s.db, s.checker, repo, commits, pathspecs...)
+	return gitserver.NewClient(s.db).LsFiles(ctx, s.checker, repo, commits, pathspecs...)
 }
 
 func (s *gitService) Archive(ctx context.Context, repo api.RepoName, opts gitserver.ArchiveOptions) (io.ReadCloser, error) {

--- a/internal/gitserver/commands.go
+++ b/internal/gitserver/commands.go
@@ -16,12 +16,12 @@ import (
 	"sync"
 	"time"
 
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
-
 	"github.com/go-git/go-git/v5/plumbing/format/config"
 	"github.com/golang/groupcache/lru"
+	"github.com/grafana/regexp"
 	"github.com/opentracing/opentracing-go/log"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 
 	"github.com/sourcegraph/go-diff/diff"
 
@@ -919,4 +919,72 @@ func runRevParse(ctx context.Context, cmd GitCommand, spec string) (api.CommitID
 		return "", gitdomain.BadCommitError{Spec: spec, Commit: commit, Repo: cmd.Repo()}
 	}
 	return commit, nil
+}
+
+// LsFiles returns the output of `git ls-files`
+func (c *ClientImplementor) LsFiles(ctx context.Context, checker authz.SubRepoPermissionChecker, repo api.RepoName, commit api.CommitID, pathspecs ...Pathspec) ([]string, error) {
+	// TODO: mocks
+	//if Mocks.LsFiles != nil {
+	//	return Mocks.LsFiles(repo, commit)
+	//}
+	args := []string{
+		"ls-files",
+		"-z",
+		"--with-tree",
+		string(commit),
+	}
+
+	if len(pathspecs) > 0 {
+		args = append(args, "--")
+		for _, pathspec := range pathspecs {
+			args = append(args, string(pathspec))
+		}
+	}
+
+	cmd := c.GitCommand(repo, args...)
+	out, err := cmd.CombinedOutput(ctx)
+	if err != nil {
+		return nil, errors.WithMessage(err, fmt.Sprintf("git command %v failed (output: %q)", cmd.Args(), out))
+	}
+
+	files := strings.Split(string(out), "\x00")
+	// Drop trailing empty string
+	if len(files) > 0 && files[len(files)-1] == "" {
+		files = files[:len(files)-1]
+	}
+	return filterPaths(ctx, repo, checker, files)
+}
+
+// ListFiles returns a list of root-relative file paths matching the given
+// pattern in a particular commit of a repository.
+func (c *ClientImplementor) ListFiles(ctx context.Context, repo api.RepoName, commit api.CommitID, pattern *regexp.Regexp, checker authz.SubRepoPermissionChecker) (_ []string, err error) {
+	cmd := c.GitCommand(repo, "ls-tree", "--name-only", "-r", string(commit), "--")
+
+	out, err := cmd.CombinedOutput(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var matching []string
+	for _, path := range strings.Split(string(out), "\n") {
+		if pattern.MatchString(path) {
+			matching = append(matching, path)
+		}
+	}
+
+	return filterPaths(ctx, repo, checker, matching)
+}
+
+// 🚨 SECURITY: All git methods that deal with file or path access need to have
+// sub-repo permissions applied
+func filterPaths(ctx context.Context, repo api.RepoName, checker authz.SubRepoPermissionChecker, paths []string) ([]string, error) {
+	if !authz.SubRepoEnabled(checker) {
+		return paths, nil
+	}
+	a := actor.FromContext(ctx)
+	filtered, err := authz.FilterActorPaths(ctx, checker, a, repo, paths)
+	if err != nil {
+		return nil, errors.Wrap(err, "filtering paths")
+	}
+	return filtered, nil
 }

--- a/internal/gitserver/commands.go
+++ b/internal/gitserver/commands.go
@@ -923,10 +923,9 @@ func runRevParse(ctx context.Context, cmd GitCommand, spec string) (api.CommitID
 
 // LsFiles returns the output of `git ls-files`
 func (c *ClientImplementor) LsFiles(ctx context.Context, checker authz.SubRepoPermissionChecker, repo api.RepoName, commit api.CommitID, pathspecs ...Pathspec) ([]string, error) {
-	// TODO: mocks
-	//if Mocks.LsFiles != nil {
-	//	return Mocks.LsFiles(repo, commit)
-	//}
+	if Mocks.LsFiles != nil {
+		return Mocks.LsFiles(repo, commit)
+	}
 	args := []string{
 		"ls-files",
 		"-z",

--- a/internal/gitserver/mocks.go
+++ b/internal/gitserver/mocks.go
@@ -20,6 +20,7 @@ var Mocks, emptyMocks struct {
 	ExecReader      func(args []string) (reader io.ReadCloser, err error)
 	ReadDir         func(commit api.CommitID, name string, recurse bool) ([]fs.FileInfo, error)
 	ResolveRevision func(spec string, opt ResolveRevisionOptions) (api.CommitID, error)
+	LsFiles         func(repo api.RepoName, commit api.CommitID) ([]string, error)
 }
 
 // ResetMocks clears the mock functions set on Mocks (so that subsequent tests don't inadvertently

--- a/internal/vcs/git/mocks.go
+++ b/internal/vcs/git/mocks.go
@@ -18,7 +18,6 @@ var Mocks, emptyMocks struct {
 	ExecReader            func(args []string) (reader io.ReadCloser, err error)
 	NewFileReader         func(commit api.CommitID, name string) (io.ReadCloser, error)
 	ReadFile              func(commit api.CommitID, name string) ([]byte, error)
-	LsFiles               func(repo api.RepoName, commit api.CommitID) ([]string, error)
 	Stat                  func(commit api.CommitID, name string) (fs.FileInfo, error)
 	Commits               func(repo api.RepoName, opt CommitsOptions) ([]*gitdomain.Commit, error)
 	MergeBase             func(repo api.RepoName, a, b api.CommitID) (api.CommitID, error)

--- a/internal/vcs/git/tree_test.go
+++ b/internal/vcs/git/tree_test.go
@@ -13,7 +13,6 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/grafana/regexp"
 
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/api"
@@ -525,83 +524,6 @@ func TestRepository_FileSystem_gitSubmodules(t *testing.T) {
 			t.Errorf("%s: fs.Open(submod): %s", label, err)
 			continue
 		}
-	}
-}
-
-func TestListFiles(t *testing.T) {
-	t.Parallel()
-
-	pattern := regexp.MustCompile("file")
-
-	runFileListingTest(t, func(ctx context.Context, checker authz.SubRepoPermissionChecker, repo api.RepoName) ([]string, error) {
-		return ListFiles(ctx, database.NewMockDB(), repo, "HEAD", pattern, checker)
-	})
-}
-
-func TestLsFiles(t *testing.T) {
-	t.Parallel()
-
-	runFileListingTest(t, func(ctx context.Context, checker authz.SubRepoPermissionChecker, repo api.RepoName) ([]string, error) {
-		return LsFiles(ctx, database.NewMockDB(), checker, repo, "HEAD")
-	})
-}
-
-// runFileListingTest tests the specified function which must return a list of filenames and an error. The test first
-// tests the basic case (all paths returned), then the case with sub-repo permissions specified.
-func runFileListingTest(t *testing.T,
-	listingFunctionToTest func(context.Context, authz.SubRepoPermissionChecker, api.RepoName) ([]string, error)) {
-	t.Helper()
-	gitCommands := []string{
-		"touch file1",
-		"touch file2",
-		"touch file3",
-		"git add file1 file2 file3",
-		"GIT_COMMITTER_NAME=a GIT_COMMITTER_EMAIL=a@a.com GIT_COMMITTER_DATE=2006-01-02T15:04:05Z git commit -m commit1 --author='a <a@a.com>' --date 2006-01-02T15:04:05Z",
-	}
-
-	repo := MakeGitRepository(t, gitCommands...)
-
-	ctx := context.Background()
-
-	checker := authz.NewMockSubRepoPermissionChecker()
-	// Start disabled
-	checker.EnabledFunc.SetDefaultHook(func() bool {
-		return false
-	})
-
-	files, err := listingFunctionToTest(ctx, checker, repo)
-	if err != nil {
-		t.Fatal(err)
-	}
-	want := []string{
-		"file1", "file2", "file3",
-	}
-	if diff := cmp.Diff(want, files); diff != "" {
-		t.Fatal(diff)
-	}
-
-	// With filtering
-	checker.EnabledFunc.SetDefaultHook(func() bool {
-		return true
-	})
-	checker.PermissionsFunc.SetDefaultHook(func(ctx context.Context, i int32, content authz.RepoContent) (authz.Perms, error) {
-		if content.Path == "file1" {
-			return authz.Read, nil
-		}
-		return authz.None, nil
-	})
-	ctx = actor.WithActor(ctx, &actor.Actor{
-		UID: 1,
-	})
-	files, err = listingFunctionToTest(ctx, checker, repo)
-	if err != nil {
-		t.Fatal(err)
-	}
-	want = []string{
-		"file1",
-	}
-	if diff := cmp.Diff(want, files); diff != "" {
-		t.Fatal(diff)
 	}
 }
 


### PR DESCRIPTION
Part of https://github.com/sourcegraph/sourcegraph/issues/33280  

Move LsFiles and ListFiles from git package to gitserver client

## Test plan

all existing/updated unit tests should pass.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
