### PR TITLE
Fix Repo GetByID returning all repos if no IDs was specified

### DIFF
--- a/enterprise/cmd/frontend/internal/authz/resolvers/repositories.go
+++ b/enterprise/cmd/frontend/internal/authz/resolvers/repositories.go
@@ -62,12 +62,12 @@ func (r *repositoryConnectionResolver) compute(ctx context.Context) ([]*types.Re
 					break
 				}
 			}
-			if len(idSubset) == 0 {
-				// r.after is set, but there are no elements larger than it, so return empty slice.
-				r.repos = []*types.Repo{}
-				r.pageInfo = graphqlutil.HasNextPage(false)
-				return
-			}
+		}
+		// No IDs to find, return early
+		if len(idSubset) == 0 {
+			r.repos = []*types.Repo{}
+			r.pageInfo = graphqlutil.HasNextPage(false)
+			return
 		}
 		// If we have more ids than we need, trim them
 		if int32(len(idSubset)) > r.first {

--- a/internal/database/repos.go
+++ b/internal/database/repos.go
@@ -262,6 +262,11 @@ func (s *repoStore) GetByIDs(ctx context.Context, ids ...api.RepoID) (_ []*types
 		tr.Finish()
 	}()
 
+	// listRepos will return a list of all repos if we pass in an empty ID list,
+	// so it is better to just return here rather than leak repo info.
+	if len(ids) == 0 {
+		return []*types.Repo{}, nil
+	}
 	return s.listRepos(ctx, tr, ReposListOptions{IDs: ids})
 }
 

--- a/internal/database/repos_db_test.go
+++ b/internal/database/repos_db_test.go
@@ -307,6 +307,7 @@ func TestRepos_GetByIDs(t *testing.T) {
 		t.Errorf("got %v, want %v", repos[0], want[0])
 	}
 }
+
 func TestRepos_GetByIDs_EmptyIDs(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
@@ -325,6 +326,7 @@ func TestRepos_GetByIDs_EmptyIDs(t *testing.T) {
 	}
 
 }
+
 func TestRepos_List(t *testing.T) {
 	if testing.Short() {
 		t.Skip()

--- a/internal/database/repos_db_test.go
+++ b/internal/database/repos_db_test.go
@@ -307,7 +307,24 @@ func TestRepos_GetByIDs(t *testing.T) {
 		t.Errorf("got %v, want %v", repos[0], want[0])
 	}
 }
+func TestRepos_GetByIDs_EmptyIDs(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
 
+	t.Parallel()
+	db := dbtest.NewDB(t)
+	ctx := actor.WithInternalActor(context.Background())
+
+	repos, err := Repos(db).GetByIDs(ctx, []api.RepoID{}...)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(repos) != 0 {
+		t.Fatalf("got %d repos, but want 0", len(repos))
+	}
+
+}
 func TestRepos_List(t *testing.T) {
 	if testing.Short() {
 		t.Skip()


### PR DESCRIPTION
Resolves https://github.com/sourcegraph/customer/issues/936

Repo GetByIDs had a bug when given an empty list of IDs, it would return all repos.
## Test plan
Added a test to capture the bug scenario.