### PR TITLE
gitserver: Properly set clone state after removing a repo

### DIFF
--- a/internal/gitserver/client.go
+++ b/internal/gitserver/client.go
@@ -1329,12 +1329,13 @@ func (c *ClientImplementor) doReposStats(ctx context.Context, addr string) (*pro
 }
 
 func (c *ClientImplementor) Remove(ctx context.Context, repo api.RepoName) error {
-	addrForRepo, err := c.AddrForRepo(ctx, repo)
+	// In case the repo has already been deleted from the database we need to pass
+	// the old name in order to land on the correct gitserver instance.
+	addr, err := c.AddrForRepo(ctx, api.UndeletedRepoName(repo))
 	if err != nil {
 		return err
 	}
-
-	return c.RemoveFrom(ctx, repo, addrForRepo)
+	return c.RemoveFrom(ctx, repo, addr)
 }
 
 func (c *ClientImplementor) RemoveFrom(ctx context.Context, repo api.RepoName, from string) error {

--- a/internal/repos/purge.go
+++ b/internal/repos/purge.go
@@ -13,7 +13,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
-	"github.com/sourcegraph/sourcegraph/internal/gitserver/protocol"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
@@ -82,9 +81,6 @@ func purge(ctx context.Context, db database.DB, log log15.Logger, options databa
 			}
 		}
 		total++
-		// The repo may have been deleted, we want its old name
-		repo = api.UndeletedRepoName(repo)
-		repo = protocol.NormalizeRepo(repo)
 		if err := gitserverClient.Remove(ctx, repo); err != nil {
 			// Do not fail at this point, just log so we can remove other repos.
 			log.Warn("failed to remove repository", "repo", repo, "error", err)


### PR DESCRIPTION
Previously we always received the undeleted repo name which meant that
when we tried to update the clone state by repo name it would not find a
match since the name in the database inludes the 'DELETED-' prefix.

Now, we only pass the undeleted name to addForRepo in order to map to the
correct gitserver instance. From that point we pass around the full
"deleted" name so that we can update the status correctly.
