### PR TITLE
dev/sg: add linter for unversioned docs links

### DIFF
--- a/dev/sg/linters/client.go
+++ b/dev/sg/linters/client.go
@@ -27,7 +27,7 @@ func checkUnversionedDocsLinks() lint.Runner {
 			for _, hunk := range hunks {
 				for _, l := range hunk.AddedLines {
 					if strings.Contains(l, `to="https://docs.sourcegraph.com`) {
-						mErr = errors.Append(mErr, errors.Newf(`%s:%d: found link to 'https://docs.sourcegraph.com', use a '/help' link instead`,
+						mErr = errors.Append(mErr, errors.Newf(`%s:%d: found link to 'https://docs.sourcegraph.com', use a '/help' relative path in the link instead`,
 							file, hunk.StartLine))
 					}
 				}

--- a/dev/sg/linters/client.go
+++ b/dev/sg/linters/client.go
@@ -17,7 +17,7 @@ func checkUnversionedDocsLinks() lint.Runner {
 	const header = "Literal unversioned docs links"
 
 	return func(ctx context.Context, s *repo.State) *lint.Report {
-		diff, err := s.GetDiff("**/*.tsx")
+		diff, err := s.GetDiff("client/web/***.tsx")
 		if err != nil {
 			return &lint.Report{Header: header, Err: err}
 		}

--- a/dev/sg/linters/client.go
+++ b/dev/sg/linters/client.go
@@ -1,7 +1,39 @@
 package linters
 
-import "github.com/sourcegraph/sourcegraph/dev/sg/internal/lint"
+import (
+	"context"
+	"strings"
+
+	"github.com/sourcegraph/sourcegraph/dev/sg/internal/lint"
+	"github.com/sourcegraph/sourcegraph/dev/sg/internal/repo"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
 
 var (
 	inlineTemplates = lint.RunScript("Inline templates", "dev/check/template-inlines.sh")
 )
+
+func checkUnversionedDocsLinks() lint.Runner {
+	const header = "Literal unversioned docs links"
+
+	return func(ctx context.Context, s *repo.State) *lint.Report {
+		diff, err := s.GetDiff("**/*.tsx")
+		if err != nil {
+			return &lint.Report{Header: header, Err: err}
+		}
+
+		var mErr error
+		for file, hunks := range diff {
+			for _, hunk := range hunks {
+				for _, l := range hunk.AddedLines {
+					if strings.Contains(l, `to="https://docs.sourcegraph.com`) {
+						mErr = errors.Append(mErr, errors.Newf(`%s:%d: found link to 'https://docs.sourcegraph.com', use a '/help' link instead`,
+							file, hunk.StartLine))
+					}
+				}
+			}
+		}
+
+		return &lint.Report{Header: header, Err: mErr}
+	}
+}

--- a/dev/sg/linters/linters.go
+++ b/dev/sg/linters/linters.go
@@ -53,6 +53,7 @@ var Targets = []lint.Target{
 			tsEnterpriseImport,
 			inlineTemplates,
 			lint.RunScript("Yarn duplicate", "dev/check/yarn-deduplicate.sh"),
+			checkUnversionedDocsLinks(),
 		},
 	},
 	{


### PR DESCRIPTION
Enforces [this code monitor](https://sourcegraph.slack.com/archives/C01C3NCGD40/p1652719890461199), which seems to go largely ignored

Related: https://github.com/sourcegraph/sourcegraph/pull/35592

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

<img width="1202" alt="image" src="https://user-images.githubusercontent.com/23356519/168909071-b2e6b92d-c4df-4f04-803a-619e4c8a9b3c.png">
