### PR TITLE
frontend/help: send /help links to MAJOR.MINOR instead of full version

### DIFF
--- a/cmd/frontend/internal/app/ui/help_test.go
+++ b/cmd/frontend/internal/app/ui/help_test.go
@@ -44,18 +44,18 @@ func TestServeHelp(t *testing.T) {
 		}
 		{
 			orig := version.Version()
-			version.Mock("1.2.3")
+			version.Mock("3.39.1")
 			defer version.Mock(orig) // reset
 		}
 
 		rw := httptest.NewRecorder()
-		req, _ := http.NewRequest("GET", "/help/foo/bar", nil)
+		req, _ := http.NewRequest("GET", "/help/dev", nil)
 		serveHelp(rw, req)
 
 		if want := http.StatusTemporaryRedirect; rw.Code != want {
 			t.Errorf("got %d, want %d", rw.Code, want)
 		}
-		if got, want := rw.Header().Get("Location"), "https://docs.sourcegraph.com/@v1.2.3/foo/bar"; got != want {
+		if got, want := rw.Header().Get("Location"), "https://docs.sourcegraph.com/@3.39/dev"; got != want {
 			t.Errorf("got %q, want %q", got, want)
 		}
 	})


### PR DESCRIPTION
Before: https://docs.sourcegraph.com/@v3.39.1/dev

After: https://docs.sourcegraph.com/@3.39/dev

This allows us to "patch" docs for released versions.

Related: https://github.com/sourcegraph/sourcegraph/pull/35590

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Unit tests, made sure generated links e.g. the above works