### PR TITLE
Code monitors: list all trigger jobs

### DIFF
--- a/enterprise/internal/database/code_monitor_trigger_jobs.go
+++ b/enterprise/internal/database/code_monitor_trigger_jobs.go
@@ -133,8 +133,7 @@ func (o ListTriggerJobsOpts) Limit() *sqlf.Query {
 const getEventsForQueryIDInt64FmtStr = `
 SELECT %s
 FROM cm_trigger_jobs
-WHERE ((state = 'completed' AND jsonb_array_length(search_results) > 0) OR (state != 'completed'))
-AND %s
+WHERE %s
 ORDER BY id DESC
 LIMIT %s;
 `

--- a/enterprise/internal/database/code_monitor_trigger_jobs_test.go
+++ b/enterprise/internal/database/code_monitor_trigger_jobs_test.go
@@ -82,3 +82,18 @@ func TestUpdateTriggerJob(t *testing.T) {
 		require.NoError(t, err)
 	})
 }
+
+func TestListTriggerJobs(t *testing.T) {
+	t.Run("handles null results", func(t *testing.T) {
+		ctx := context.Background()
+		db := NewEnterpriseDB(database.NewDB(dbtest.NewDB(t)))
+		f := populateCodeMonitorFixtures(t, db)
+		jobs, err := db.CodeMonitors().EnqueueQueryTriggerJobs(ctx)
+		require.NoError(t, err)
+		require.Len(t, jobs, 1)
+
+		js, err := db.CodeMonitors().ListQueryTriggerJobs(ctx, ListTriggerJobsOpts{QueryID: &f.Query.ID})
+		require.NoError(t, err)
+		require.Len(t, js, 1)
+	})
+}


### PR DESCRIPTION
I think I crossed some wires at some point and was only listing code monitor runs that had were not in a `complete` state or had some results. This is problematic because you'll never see the most recent run. 

This updates the list query to include all code monitor trigger jobs. 

Pinging @limitedmage to make sure this is actually what the frontend expects. Just based on my experiments, the logs page behaves much more intuitively now.

## Test plan

Added unit test and manually checked the logs page.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
