### PR TITLE
Code monitors: run in parallel and add worker timeout

### DIFF
--- a/enterprise/internal/codemonitors/background/workers.go
+++ b/enterprise/internal/codemonitors/background/workers.go
@@ -29,7 +29,7 @@ const (
 func newTriggerQueryRunner(ctx context.Context, db edb.EnterpriseDB, metrics codeMonitorsMetrics) *workerutil.Worker {
 	options := workerutil.WorkerOptions{
 		Name:              "code_monitors_trigger_jobs_worker",
-		NumHandlers:       1,
+		NumHandlers:       4,
 		Interval:          5 * time.Second,
 		HeartbeatInterval: 15 * time.Second,
 		Metrics:           metrics.workerMetrics,

--- a/enterprise/internal/codemonitors/background/workers.go
+++ b/enterprise/internal/codemonitors/background/workers.go
@@ -28,11 +28,12 @@ const (
 
 func newTriggerQueryRunner(ctx context.Context, db edb.EnterpriseDB, metrics codeMonitorsMetrics) *workerutil.Worker {
 	options := workerutil.WorkerOptions{
-		Name:              "code_monitors_trigger_jobs_worker",
-		NumHandlers:       4,
-		Interval:          5 * time.Second,
-		HeartbeatInterval: 15 * time.Second,
-		Metrics:           metrics.workerMetrics,
+		Name:                 "code_monitors_trigger_jobs_worker",
+		NumHandlers:          4,
+		Interval:             5 * time.Second,
+		HeartbeatInterval:    15 * time.Second,
+		Metrics:              metrics.workerMetrics,
+		MaximumRuntimePerJob: time.Minute,
 	}
 	worker := dbworker.NewWorker(ctx, createDBWorkerStoreForTriggerJobs(db), &queryRunner{db: db}, options)
 	return worker

--- a/enterprise/internal/database/code_monitor_trigger_jobs.go
+++ b/enterprise/internal/database/code_monitor_trigger_jobs.go
@@ -133,8 +133,7 @@ func (o ListTriggerJobsOpts) Limit() *sqlf.Query {
 const getEventsForQueryIDInt64FmtStr = `
 SELECT %s
 FROM cm_trigger_jobs
-WHERE ((state = 'completed' AND jsonb_array_length(search_results) > 0) OR (state != 'completed'))
-AND %s
+WHERE %s
 ORDER BY id DESC
 LIMIT %s;
 `

--- a/enterprise/internal/database/code_monitor_trigger_jobs_test.go
+++ b/enterprise/internal/database/code_monitor_trigger_jobs_test.go
@@ -82,3 +82,18 @@ func TestUpdateTriggerJob(t *testing.T) {
 		require.NoError(t, err)
 	})
 }
+
+func TestListTriggerJobs(t *testing.T) {
+	t.Run("handles null results", func(t *testing.T) {
+		ctx := context.Background()
+		db := NewEnterpriseDB(database.NewDB(dbtest.NewDB(t)))
+		f := populateCodeMonitorFixtures(t, db)
+		jobs, err := db.CodeMonitors().EnqueueQueryTriggerJobs(ctx)
+		require.NoError(t, err)
+		require.Len(t, jobs, 1)
+
+		js, err := db.CodeMonitors().ListQueryTriggerJobs(ctx, ListTriggerJobsOpts{QueryID: &f.Query.ID})
+		require.NoError(t, err)
+		require.Len(t, js, 1)
+	})
+}


### PR DESCRIPTION
The current worker settings limit code monitors to only run a single in parallel. There is no reason we can't run monitors in parallel, so this ups the parallelism to 4. This is useful when there are many code monitors.

Additionally, it adds a timeout to the worker jobs to catch any blocked jobs that aren't covered by the query timeout. This is useful for things like stalled db queries before the execution starts.

Stacked on #35597 

## Test plan

Just tuning worker params.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
