### PR TITLE
mod: fix github.com/dghubble/gologin to github.com/dghubble/gologin/v2

### DIFF
--- a/enterprise/cmd/frontend/internal/auth/githuboauth/config.go
+++ b/enterprise/cmd/frontend/internal/auth/githuboauth/config.go
@@ -1,7 +1,7 @@
 package githuboauth
 
 import (
-	"github.com/dghubble/gologin"
+	"github.com/dghubble/gologin/v2"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/auth/providers"
 	"github.com/sourcegraph/sourcegraph/internal/conf"

--- a/enterprise/cmd/frontend/internal/auth/githuboauth/middleware_test.go
+++ b/enterprise/cmd/frontend/internal/auth/githuboauth/middleware_test.go
@@ -24,7 +24,7 @@ import (
 // TestMiddleware exercises the Middleware with requests that simulate the OAuth 2 login flow on
 // GitHub. This tests the logic between the client-issued HTTP requests and the responses from the
 // various endpoints, but does NOT cover the logic that is contained within `golang.org/x/oauth2`
-// and `github.com/dghubble/gologin` which ensures the correctness of the `/callback` handler.
+// and `github.com/dghubble/gologin/v2` which ensures the correctness of the `/callback` handler.
 func TestMiddleware(t *testing.T) {
 	cleanup := session.ResetMockSessionStore(t)
 	defer cleanup()

--- a/enterprise/cmd/frontend/internal/auth/githuboauth/provider.go
+++ b/enterprise/cmd/frontend/internal/auth/githuboauth/provider.go
@@ -5,9 +5,9 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/dghubble/gologin"
-	"github.com/dghubble/gologin/github"
-	goauth2 "github.com/dghubble/gologin/oauth2"
+	"github.com/dghubble/gologin/v2"
+	"github.com/dghubble/gologin/v2/github"
+	goauth2 "github.com/dghubble/gologin/v2/oauth2"
 	"github.com/inconshreveable/log15"
 	"golang.org/x/oauth2"
 

--- a/enterprise/cmd/frontend/internal/auth/githuboauth/session.go
+++ b/enterprise/cmd/frontend/internal/auth/githuboauth/session.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/dghubble/gologin/github"
+	"github.com/dghubble/gologin/v2/github"
 	"github.com/inconshreveable/log15"
 	"golang.org/x/oauth2"
 

--- a/enterprise/cmd/frontend/internal/auth/githuboauth/session_test.go
+++ b/enterprise/cmd/frontend/internal/auth/githuboauth/session_test.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/davecgh/go-spew/spew"
-	githublogin "github.com/dghubble/gologin/github"
+	githublogin "github.com/dghubble/gologin/v2/github"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-github/github"
 	"github.com/stretchr/testify/assert"

--- a/enterprise/cmd/frontend/internal/auth/gitlaboauth/login.go
+++ b/enterprise/cmd/frontend/internal/auth/gitlaboauth/login.go
@@ -4,8 +4,8 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/dghubble/gologin"
-	oauth2Login "github.com/dghubble/gologin/oauth2"
+	"github.com/dghubble/gologin/v2"
+	oauth2Login "github.com/dghubble/gologin/v2/oauth2"
 	"golang.org/x/oauth2"
 
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"

--- a/enterprise/cmd/frontend/internal/auth/gitlaboauth/middleware_test.go
+++ b/enterprise/cmd/frontend/internal/auth/gitlaboauth/middleware_test.go
@@ -25,7 +25,7 @@ import (
 // TestMiddleware exercises the Middleware with requests that simulate the OAuth 2 login flow on
 // GitLab. This tests the logic between the client-issued HTTP requests and the responses from the
 // various endpoints, but does NOT cover the logic that is contained within `golang.org/x/oauth2`
-// and `github.com/dghubble/gologin` which ensures the correctness of the `/callback` handler.
+// and `github.com/dghubble/gologin/v2` which ensures the correctness of the `/callback` handler.
 func TestMiddleware(t *testing.T) {
 	cleanup := session.ResetMockSessionStore(t)
 	defer cleanup()

--- a/enterprise/cmd/frontend/internal/auth/gitlaboauth/provider.go
+++ b/enterprise/cmd/frontend/internal/auth/gitlaboauth/provider.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/dghubble/gologin"
+	"github.com/dghubble/gologin/v2"
 	"golang.org/x/oauth2"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"

--- a/enterprise/cmd/frontend/internal/auth/oauth/cookie.go
+++ b/enterprise/cmd/frontend/internal/auth/oauth/cookie.go
@@ -4,11 +4,11 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/dghubble/gologin"
+	"github.com/dghubble/gologin/v2"
 )
 
 /*
-This code is copied from https://sourcegraph.com/github.com/dghubble/gologin/-/blob/internal/cookie.go
+This code is copied from https://sourcegraph.com/github.com/dghubble/gologin/v2/-/blob/internal/cookie.go
 */
 
 // NewCookie returns a new http.Cookie with the given value and CookieConfig

--- a/enterprise/cmd/frontend/internal/auth/oauth/provider.go
+++ b/enterprise/cmd/frontend/internal/auth/oauth/provider.go
@@ -9,8 +9,8 @@ import (
 	"net/url"
 	"path"
 
-	"github.com/dghubble/gologin"
-	goauth2 "github.com/dghubble/gologin/oauth2"
+	"github.com/dghubble/gologin/v2"
+	goauth2 "github.com/dghubble/gologin/v2/oauth2"
 	"github.com/inconshreveable/log15"
 	"golang.org/x/oauth2"
 

--- a/enterprise/cmd/frontend/internal/auth/oauth/session.go
+++ b/enterprise/cmd/frontend/internal/auth/oauth/session.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"time"
 
-	goauth2 "github.com/dghubble/gologin/oauth2"
+	goauth2 "github.com/dghubble/gologin/v2/oauth2"
 	"github.com/inconshreveable/log15"
 	"golang.org/x/oauth2"
 

--- a/go.mod
+++ b/go.mod
@@ -37,7 +37,7 @@ require (
 	github.com/daviddengcn/go-colortext v1.0.0
 	github.com/derision-test/glock v1.0.0
 	github.com/derision-test/go-mockgen v1.2.0
-	github.com/dghubble/gologin v2.0.1-0.20181120070955-e2bffa01eb28+incompatible
+	github.com/dghubble/gologin/v2 v2.3.0
 	github.com/dgraph-io/ristretto v0.1.0
 	github.com/dineshappavoo/basex v0.0.0-20170425072625-481a6f6dc663
 	github.com/distribution/distribution/v3 v3.0.0-20220128175647-b60926597a1b

--- a/go.sum
+++ b/go.sum
@@ -415,6 +415,7 @@ github.com/caarlos0/ctrlc v1.0.0/go.mod h1:CdXpj4rmq0q/1Eb44M9zi2nKB0QraNKuRGYGr
 github.com/campoy/unique v0.0.0-20180121183637-88950e537e7e/go.mod h1:9IOqJGCPMSc6E5ydlp5NIonxObaeu/Iub/X03EKPVYo=
 github.com/cavaliercoder/go-cpio v0.0.0-20180626203310-925f9528c45e/go.mod h1:oDpT4efm8tSYHXV5tHSdRvBet/b/QzxZ+XyyPehvm3A=
 github.com/cenkalti/backoff v1.1.1-0.20171020064038-309aa717adbf/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
+github.com/cenkalti/backoff v2.1.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/cenkalti/backoff/v4 v4.1.1/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
@@ -634,8 +635,11 @@ github.com/derision-test/glock v1.0.0/go.mod h1:jKtLdBMrF+XQatqvg46wiWdDfDSSDjdh
 github.com/derision-test/go-mockgen v1.2.0 h1:SCF7p4FuO6IZId3CMjSHH9K0SMDVXNz7jc3AOeJaBd8=
 github.com/derision-test/go-mockgen v1.2.0/go.mod h1:/TXUePlhtHmDDCaDAi/a4g6xOHqMDz3Wf0r2NPGskB4=
 github.com/devigned/tab v0.1.1/go.mod h1:XG9mPq0dFghrYvoBF3xdRrJzSTX1b7IQrvaL9mzjeJY=
-github.com/dghubble/gologin v2.0.1-0.20181120070955-e2bffa01eb28+incompatible h1:wd+j36BZFfmN6k961BejbuiB8xBavLSVy79r8Rz4sK4=
-github.com/dghubble/gologin v2.0.1-0.20181120070955-e2bffa01eb28+incompatible/go.mod h1:+EjjX5AiOREcyqxhz0c6I8OsL+6F9/38WD1CDcClx+Y=
+github.com/dghubble/go-twitter v0.0.0-20190719072343-39e5462e111f/go.mod h1:xfg4uS5LEzOj8PgZV7SQYRHbG7jPUnelEiaAVJxmhJE=
+github.com/dghubble/gologin/v2 v2.3.0 h1:SMHahscgKmgrv4X+OAwFCJCuJ6mbLxOqB+FAVU+tOSA=
+github.com/dghubble/gologin/v2 v2.3.0/go.mod h1:qGAUHuIYV0WP3kwoPjLhG+YIlGqy8O13YjItosCBKdo=
+github.com/dghubble/oauth1 v0.6.0/go.mod h1:8pFdfPkv/jr8mkChVbNVuJ0suiHe278BtWI4Tk1ujxk=
+github.com/dghubble/sling v1.3.0/go.mod h1:XXShWaBWKzNLhu2OxikSNFrlsvowtz4kyRuXUG7oQKY=
 github.com/dgraph-io/badger v1.6.0/go.mod h1:zwt7syl517jmP8s94KqSxTlM6IMsdhYy6psNgSztDR4=
 github.com/dgraph-io/ristretto v0.1.0 h1:Jv3CGQHp9OjuMBSne1485aDpUkTKEcUqF+jm/LuerPI=
 github.com/dgraph-io/ristretto v0.1.0/go.mod h1:fux0lOrBhrVCJd3lcTHsIJhq1T2rokOu6v9Vcb3Q9ug=


### PR DESCRIPTION
`github.com/dghubble/gologin/v2` is the correct import path for the version of this module that we should be using, since are at v2+ already: https://github.com/dghubble/gologin/blob/v2.3.0/go.mod#L1



## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

CI passes