### PR TITLE
dev/sg/repo: add IterateHunks

### DIFF
--- a/dev/sg/internal/repo/repo.go
+++ b/dev/sg/internal/repo/repo.go
@@ -6,12 +6,29 @@ import (
 	"github.com/sourcegraph/go-diff/diff"
 
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/run"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 // State represents the state of the repository.
 type State struct {
 	// Branch is the currently checked out branch.
 	Branch string
+}
+
+type Diff map[string][]DiffHunk
+
+// IterateHunks calls cb over each hunk in this diff, collects all errors encountered, and
+// wraps each error with the file name and the position of each hunk.
+func (d Diff) IterateHunks(cb func(file string, hunk DiffHunk) error) error {
+	var mErr error
+	for file, hunks := range d {
+		for _, hunk := range hunks {
+			if err := cb(file, hunk); err != nil {
+				mErr = errors.Append(mErr, errors.Wrapf(err, "%s:%d", file, hunk.StartLine))
+			}
+		}
+	}
+	return mErr
 }
 
 type DiffHunk struct {
@@ -21,7 +38,7 @@ type DiffHunk struct {
 	AddedLines []string
 }
 
-func (s *State) GetDiff(paths string) (map[string][]DiffHunk, error) {
+func (s *State) GetDiff(paths string) (Diff, error) {
 	if paths == "" {
 		paths = "**/*"
 	}

--- a/dev/sg/linters/client.go
+++ b/dev/sg/linters/client.go
@@ -22,18 +22,16 @@ func checkUnversionedDocsLinks() lint.Runner {
 			return &lint.Report{Header: header, Err: err}
 		}
 
-		var mErr error
-		for file, hunks := range diff {
-			for _, hunk := range hunks {
-				for _, l := range hunk.AddedLines {
-					if strings.Contains(l, `to="https://docs.sourcegraph.com`) {
-						mErr = errors.Append(mErr, errors.Newf(`%s:%d: found link to 'https://docs.sourcegraph.com', use a '/help' relative path in the link instead`,
-							file, hunk.StartLine))
-					}
+		errs := diff.IterateHunks(func(file string, hunk repo.DiffHunk) error {
+			for _, l := range hunk.AddedLines {
+				if strings.Contains(l, `to="https://docs.sourcegraph.com`) {
+					return errors.Newf(`found link to 'https://docs.sourcegraph.com', use a '/help' link instead: %s`,
+						strings.TrimSpace(l))
 				}
 			}
-		}
+			return nil
+		})
 
-		return &lint.Report{Header: header, Err: mErr}
+		return &lint.Report{Header: header, Err: errs}
 	}
 }

--- a/dev/sg/linters/client.go
+++ b/dev/sg/linters/client.go
@@ -25,7 +25,7 @@ func checkUnversionedDocsLinks() lint.Runner {
 		errs := diff.IterateHunks(func(file string, hunk repo.DiffHunk) error {
 			for _, l := range hunk.AddedLines {
 				if strings.Contains(l, `to="https://docs.sourcegraph.com`) {
-					return errors.Newf(`found link to 'https://docs.sourcegraph.com', use a '/help' link instead: %s`,
+					return errors.Newf(`found link to 'https://docs.sourcegraph.com', use a '/help' relative path for the link instead: %s`,
 						strings.TrimSpace(l))
 				}
 			}

--- a/dev/sg/linters/godirective.go
+++ b/dev/sg/linters/godirective.go
@@ -19,15 +19,12 @@ func lintGoDirectives(ctx context.Context, state *repo.State) *lint.Report {
 		return &lint.Report{Header: header, Err: err}
 	}
 
-	var errs error
-	for file, hunks := range diff {
-		for _, hunk := range hunks {
-			if directivesRegexp.MatchString(strings.Join(hunk.AddedLines, "\n")) {
-				errs = errors.Append(errors.Newf(`%s:%d: Go compiler directives must have no spaces between the // and 'go'`,
-					file, hunk.StartLine))
-			}
+	errs := diff.IterateHunks(func(file string, hunk repo.DiffHunk) error {
+		if directivesRegexp.MatchString(strings.Join(hunk.AddedLines, "\n")) {
+			return errors.New("Go compiler directives must have no spaces between the // and 'go'")
 		}
-	}
+		return nil
+	})
 
 	return &lint.Report{
 		Header: header,

--- a/dev/sg/linters/liblog.go
+++ b/dev/sg/linters/liblog.go
@@ -46,8 +46,8 @@ func lintLoggingLibraries() lint.Runner {
 		for _, l := range hunk.AddedLines {
 			for _, banned := range bannedImports {
 				if strings.Contains(l, banned) {
-					return errors.Newf(`%s:%d: banned usage of '%s': use "github.com/sourcegraph/sourcegraph/lib/log" instead`,
-						file, hunk.StartLine, banned)
+					return errors.Newf(`banned usage of '%s': use "github.com/sourcegraph/sourcegraph/lib/log" instead`,
+						banned)
 				}
 			}
 		}
@@ -63,14 +63,7 @@ func lintLoggingLibraries() lint.Runner {
 			}
 		}
 
-		var errs error
-		for file, hunks := range diffs {
-			for _, hunk := range hunks {
-				if err := checkHunk(file, hunk); err != nil {
-					errs = errors.Append(errs, err)
-				}
-			}
-		}
+		errs := diffs.IterateHunks(checkHunk)
 
 		return &lint.Report{
 			Header: header,


### PR DESCRIPTION
Adds an iterator for convenience that iterates over hunks and annotates errors with the position of the hunk. Makes it more convenient to add linters.

## Test plan

`sg lint`

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
