### PR TITLE
docs: mark API docs as superseded by doctree

### DIFF
--- a/doc/code_intelligence/apidocs/index.md
+++ b/doc/code_intelligence/apidocs/index.md
@@ -1,42 +1,5 @@
 # API docs for your code
 
-<p class="subtitle">API documentation generated for all your code</p>
+This is experiment is over, and has been removed in Sourcegraph v3.40.
 
-<p class="lead">
-Sourcegraph uses <a href="../../code_intelligence">LSIF code intelligence</a> to generate API documentation for all your code, giving you the ability to navigate and explore the APIs provided by repositories.
-</p>
-
-## 🚀 Try it out
-
-You can try out API docs on Sourcegraph.com here:
-
-* [encoding/json](https://sourcegraph.com/github.com/golang/go/-/docs/encoding/json)
-* [net/http](https://sourcegraph.com/github.com/golang/go/-/docs/net/http)
-* [github.com/sourcegraph/sourcegraph](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/docs)
-
-## ✨ Try API docs on your repository
-
-Tweet us your Go repository name to @slimsag @sourcegraph and we'll index and upload LSIF data for you, so you can try API docs on your repository! 🎉 -- or [do it yourself](../index.md).
-
-## ⚠️ Experimental status
-
-API docs is an experimental feature of Sourcegraph. If you like this idea, have any feedback, please reach out:
-
-* (lead engineer) stephen@sourcegraph.com
-* (entire team) twitter:@sourcegraph support@sourcegraph.com
-
-We're working hard to improve it rapidly, so your feedback will influence the future direction a lot!
-
-## ✅ Supported languages
-
-| Language | LSIF indexer                              | Tutorial                                                 |
-|----------|-------------------------------------------|----------------------------------------------------------|
-| Go       | [lsif-go](https://github.com/sourcegraph/lsif-go) | [Index a Go repository](../how-to/index_a_go_repository.md) |
-
-
-## ⏱️ Coming soon
-
-If you're interested in any of the following topics, please reach out - we're still working on material for them as things are progressing quickly:
-
-* ...how to add support for API docs to an LSIF indexer
-* ...troubleshooting
+The next generation of this work will be available as [doctree](https://github.com/sourcegraph/doctree), a standalone 100% open source tool from Sourcegraph.


### PR DESCRIPTION

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

None required.
