### PR TITLE
Add trace tags to jobs in package jobutil

### DIFF
--- a/internal/featureflag/flagset.go
+++ b/internal/featureflag/flagset.go
@@ -1,5 +1,10 @@
 package featureflag
 
+import (
+	"fmt"
+	"strings"
+)
+
 type FlagSet map[string]bool
 
 func (f FlagSet) GetBool(flag string) (bool, bool) {
@@ -12,4 +17,14 @@ func (f FlagSet) GetBoolOr(flag string, defaultVal bool) bool {
 		return v
 	}
 	return defaultVal
+}
+
+func (f FlagSet) String() string {
+	var sb strings.Builder
+	for k, v := range f {
+		if v {
+			fmt.Fprintf(&sb, "%q: %v\n", k, v)
+		}
+	}
+	return sb.String()
 }

--- a/internal/search/job/jobutil/job.go
+++ b/internal/search/job/jobutil/job.go
@@ -88,7 +88,7 @@ func NewBasicJob(inputs *run.SearchInputs, b query.Basic) (job.Job, error) {
 				}
 				addJob(&repoPagerJob{
 					child:            job,
-					repoOptions:      repoOptions,
+					repoOpts:         repoOptions,
 					useIndex:         b.Index(),
 					containsRefGlobs: query.ContainsRefGlobs(b.ToParseTree()),
 				})
@@ -112,7 +112,7 @@ func NewBasicJob(inputs *run.SearchInputs, b query.Basic) (job.Job, error) {
 				}
 				addJob(&repoPagerJob{
 					child:            job,
-					repoOptions:      repoOptions,
+					repoOpts:         repoOptions,
 					useIndex:         b.Index(),
 					containsRefGlobs: query.ContainsRefGlobs(b.ToParseTree()),
 				})
@@ -218,7 +218,7 @@ func NewFlatJob(searchInputs *run.SearchInputs, f query.Flat) (job.Job, error) {
 
 				addJob(&repoPagerJob{
 					child:            searcherJob,
-					repoOptions:      repoOptions,
+					repoOpts:         repoOptions,
 					useIndex:         f.Index(),
 					containsRefGlobs: query.ContainsRefGlobs(f.ToBasic().ToParseTree()),
 				})
@@ -236,7 +236,7 @@ func NewFlatJob(searchInputs *run.SearchInputs, f query.Flat) (job.Job, error) {
 
 				addJob(&repoPagerJob{
 					child:            symbolSearchJob,
-					repoOptions:      repoOptions,
+					repoOpts:         repoOptions,
 					useIndex:         f.Index(),
 					containsRefGlobs: query.ContainsRefGlobs(f.ToBasic().ToParseTree()),
 				})

--- a/internal/search/job/jobutil/select.go
+++ b/internal/search/job/jobutil/select.go
@@ -3,10 +3,13 @@ package jobutil
 import (
 	"context"
 
+	"github.com/opentracing/opentracing-go/log"
+
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/search/filter"
 	"github.com/sourcegraph/sourcegraph/internal/search/job"
 	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
+	"github.com/sourcegraph/sourcegraph/internal/trace"
 )
 
 // NewSelectJob creates a job that transforms streamed results with
@@ -21,8 +24,9 @@ type selectJob struct {
 }
 
 func (j *selectJob) Run(ctx context.Context, clients job.RuntimeClients, stream streaming.Sender) (alert *search.Alert, err error) {
-	_, ctx, stream, finish := job.StartSpan(ctx, stream, j)
+	tr, ctx, stream, finish := job.StartSpan(ctx, stream, j)
 	defer func() { finish(alert, err) }()
+	tr.TagFields(trace.LazyFields(j.Tags))
 
 	selectingStream := streaming.WithSelect(stream, j.path)
 	return j.child.Run(ctx, clients, selectingStream)
@@ -30,4 +34,9 @@ func (j *selectJob) Run(ctx context.Context, clients job.RuntimeClients, stream 
 
 func (j *selectJob) Name() string {
 	return "SelectJob"
+}
+func (j *selectJob) Tags() []log.Field {
+	return []log.Field{
+		trace.Printf("select", "%q", j.path),
+	}
 }

--- a/internal/search/types.go
+++ b/internal/search/types.go
@@ -19,6 +19,17 @@ const (
 	Batch
 )
 
+func (p Protocol) String() string {
+	switch p {
+	case Streaming:
+		return "Streaming"
+	case Batch:
+		return "Batch"
+	default:
+		return fmt.Sprintf("unknown{%d}", p)
+	}
+}
+
 type SymbolsParameters struct {
 	// Repo is the name of the repository to search in.
 	Repo api.RepoName `json:"repo"`


### PR DESCRIPTION
Stacked on https://github.com/sourcegraph/sourcegraph/pull/35608
Part of #34009

Add trace tags to jobs in package `jobutil` which have fields outside of wrapping their child jobs.

Add `String()` methods to types `Protocol` and `FlagSet` for ease of tracing them as struct fields.

## Test plan
All existing `jobutil` tests pass, visually verify trace output.

<img width="1120" alt="Screen Shot 2022-05-17 at 9 27 43 PM" src="https://user-images.githubusercontent.com/70350613/168944919-e8dfd431-662b-4d1e-989e-5f6ba5d4a871.png">

<img width="1126" alt="Screen Shot 2022-05-17 at 9 27 52 PM" src="https://user-images.githubusercontent.com/70350613/168944930-e4c63231-847c-4b19-9269-e9df41555ae3.png">

<img width="1133" alt="Screen Shot 2022-05-17 at 9 28 04 PM" src="https://user-images.githubusercontent.com/70350613/168944955-b5223f97-9752-4988-a985-31f9c4d968ba.png">

<img width="1123" alt="Screen Shot 2022-05-17 at 9 28 11 PM" src="https://user-images.githubusercontent.com/70350613/168944979-67305d0f-cc52-4a99-8d1c-1ec9a8fe6315.png">

<img width="1121" alt="Screen Shot 2022-05-17 at 9 28 18 PM" src="https://user-images.githubusercontent.com/70350613/168944992-2801d1cf-c324-426a-8241-8e13f3921784.png">

