### PR TITLE
[SG-34582.2]: Migrations <Icon /> accessibility: `client/search-ui`, `client/wildcard`

### DIFF
--- a/client/search-ui/src/components/RepoSearchResult.tsx
+++ b/client/search-ui/src/components/RepoSearchResult.tsx
@@ -74,6 +74,8 @@ export const RepoSearchResult: React.FunctionComponent<RepoSearchResultProps> = 
                             <div className={styles.divider} />
                             <div>
                                 <Icon
+                                    role="img"
+                                    aria-label="Forked repository"
                                     className={classNames('flex-shrink-0 text-muted', styles.icon)}
                                     as={SourceForkIcon}
                                 />
@@ -88,6 +90,8 @@ export const RepoSearchResult: React.FunctionComponent<RepoSearchResultProps> = 
                             <div className={styles.divider} />
                             <div>
                                 <Icon
+                                    role="img"
+                                    aria-label="Archived repository"
                                     className={classNames('flex-shrink-0 text-muted', styles.icon)}
                                     as={ArchiveIcon}
                                 />
@@ -101,7 +105,12 @@ export const RepoSearchResult: React.FunctionComponent<RepoSearchResultProps> = 
                         <>
                             <div className={styles.divider} />
                             <div>
-                                <Icon className={classNames('flex-shrink-0 text-muted', styles.icon)} as={LockIcon} />
+                                <Icon
+                                    role="img"
+                                    aria-label="Private repository"
+                                    className={classNames('flex-shrink-0 text-muted', styles.icon)}
+                                    as={LockIcon}
+                                />
                             </div>
                             <div>
                                 <small>Private</small>

--- a/client/search-ui/src/documentation/ModalVideo.tsx
+++ b/client/search-ui/src/documentation/ModalVideo.tsx
@@ -87,7 +87,7 @@ export const ModalVideo: React.FunctionComponent<React.PropsWithChildren<ModalVi
                                 onClick={() => toggleDialog(false)}
                                 aria-label="Close"
                             >
-                                <Icon as={CloseIcon} />
+                                <Icon role="img" aria-hidden={true} as={CloseIcon} />
                             </Button>
                         </div>
                         <div className="w-100">

--- a/client/search-ui/src/input/SearchButton.tsx
+++ b/client/search-ui/src/input/SearchButton.tsx
@@ -35,7 +35,7 @@ export const SearchButton: React.FunctionComponent<React.PropsWithChildren<Props
             aria-label="Search"
             variant="primary"
         >
-            <Icon aria-hidden="true" as={SearchIcon} />
+            <Icon role="img" aria-hidden="true" as={SearchIcon} />
         </Button>
         {!hideHelpButton && (
             <SearchHelpDropdownButton isSourcegraphDotCom={isSourcegraphDotCom} telemetryService={telemetryService} />

--- a/client/search-ui/src/input/SearchContextMenu.tsx
+++ b/client/search-ui/src/input/SearchContextMenu.tsx
@@ -293,7 +293,7 @@ export const SearchContextMenu: React.FunctionComponent<React.PropsWithChildren<
             <div className={styles.title}>
                 <small>Choose search context</small>
                 <Button onClick={() => closeMenu()} variant="icon" className={styles.titleClose} aria-label="Close">
-                    <Icon as={CloseIcon} />
+                    <Icon role="img" aria-hidden={true} as={CloseIcon} />
                 </Button>
             </div>
             <div className={classNames('d-flex', styles.header)}>

--- a/client/search-ui/src/input/SearchHelpDropdownButton.tsx
+++ b/client/search-ui/src/input/SearchHelpDropdownButton.tsx
@@ -47,7 +47,12 @@ export const SearchHelpDropdownButton: React.FunctionComponent<
                 className={classNames('px-2 d-flex align-items-center cursor-pointer', styles.triggerButton)}
                 aria-label="Quick help for search"
             >
-                <Icon className="test-search-help-dropdown-button-icon" aria-hidden="true" as={HelpCircleOutlineIcon} />
+                <Icon
+                    role="img"
+                    aria-hidden={true}
+                    className="test-search-help-dropdown-button-icon"
+                    as={HelpCircleOutlineIcon}
+                />
             </PopoverTrigger>
             <PopoverContent position={Position.bottomEnd} className={classNames('pb-0', styles.content)}>
                 <MenuHeader>
@@ -132,7 +137,7 @@ export const SearchHelpDropdownButton: React.FunctionComponent<
                     className="dropdown-item"
                     onClick={onQueryDocumentationLinkClicked}
                 >
-                    <Icon className="small" as={ExternalLinkIcon} /> All search keywords
+                    <Icon role="img" aria-hidden={true} className="small" as={ExternalLinkIcon} /> All search keywords
                 </Link>
                 {isSourcegraphDotCom && (
                     <Alert className="small rounded-0 mb-0 mt-1" variant="info">

--- a/client/search-ui/src/input/toggles/CopyQueryButton.tsx
+++ b/client/search-ui/src/input/toggles/CopyQueryButton.tsx
@@ -55,7 +55,7 @@ export const CopyQueryButton: React.FunctionComponent<React.PropsWithChildren<Pr
                 aria-live="polite"
                 onClick={nextClick}
             >
-                <Icon as={ClipboardOutlineIcon} />
+                <Icon role="img" aria-hidden={true} as={ClipboardOutlineIcon} />
             </Button>
             {props.keyboardShortcutForFullCopy.keybindings.map((keybinding, index) => (
                 <Shortcut key={index} {...keybinding} onMatch={copyFullQuery} allowDefault={false} ignoreInput={true} />

--- a/client/search-ui/src/input/toggles/QueryInputToggle.tsx
+++ b/client/search-ui/src/input/toggles/QueryInputToggle.tsx
@@ -96,7 +96,7 @@ export const QueryInputToggle: React.FunctionComponent<React.PropsWithChildren<T
             aria-label={`${props.title} toggle`}
             {...interactiveProps}
         >
-            <Icon as={props.icon} />
+            <Icon role="img" aria-hidden={true} as={props.icon} />
         </Button>
     )
 }

--- a/client/search-ui/src/input/toggles/__snapshots__/Toggles.test.tsx.snap
+++ b/client/search-ui/src/input/toggles/__snapshots__/Toggles.test.tsx.snap
@@ -12,9 +12,11 @@ Array [
     tabindex="0"
   >
     <svg
+      aria-hidden="true"
       class="mdi-icon iconInline"
       fill="currentColor"
       height="24"
+      role="img"
       viewBox="0 0 24 24"
       width="24"
     >
@@ -38,9 +40,11 @@ Array [
     tabindex="0"
   >
     <svg
+      aria-hidden="true"
       class="mdi-icon iconInline"
       fill="currentColor"
       height="24"
+      role="img"
       viewBox="0 0 24 24"
       width="24"
     >
@@ -64,9 +68,11 @@ Array [
     tabindex="0"
   >
     <svg
+      aria-hidden="true"
       class="mdi-icon iconInline"
       fill="currentColor"
       height="24"
+      role="img"
       viewBox="0 0 24 24"
       width="24"
     >

--- a/client/search-ui/src/results/AnnotatedSearchExample.tsx
+++ b/client/search-ui/src/results/AnnotatedSearchExample.tsx
@@ -71,6 +71,8 @@ export const AnnotatedSearchInput: React.FunctionComponent<
         // the viewBox is adjusted to "crop" the image to its content
         // Original width and height of the image was 800x270
         <svg
+            role="img"
+            aria-hidden={true}
             className={styles.annotatedSearchInput}
             width={width}
             height={height}
@@ -102,14 +104,14 @@ export const AnnotatedSearchInput: React.FunctionComponent<
                     <tspan className={styles.metaRegexpRangeQuantifier}>*</tspan>
                     <tspan> function auth(){'{'} </tspan>
                 </text>
-                <Icon x="590" y="115" as={FormatLetterCaseIcon} />
-                <Icon x="620" y="115" as={RegexIcon} />
-                <Icon x="650" y="115" as={CodeBracketsIcon} />
+                <Icon role="img" aria-hidden={true} x="590" y="115" as={FormatLetterCaseIcon} />
+                <Icon role="img" aria-hidden={true} x="620" y="115" as={RegexIcon} />
+                <Icon role="img" aria-hidden={true} x="650" y="115" as={CodeBracketsIcon} />
                 <path
                     d="M688 110H731C732.105 110 733 110.895 733 112V142C733 143.105 732.105 144 731 144H688V110Z"
                     fill="#1475CF"
                 />
-                <Icon className={styles.searchIcon} x="698" y="115" as={SearchIcon} />
+                <Icon role="img" aria-hidden={true} className={styles.searchIcon} x="698" y="115" as={SearchIcon} />
 
                 {arrow(188, 30, 'above')}
                 <text transform={`translate(${filterTextStart}, 44)`}>

--- a/client/search-ui/src/results/NoResultsPage.tsx
+++ b/client/search-ui/src/results/NoResultsPage.tsx
@@ -141,7 +141,7 @@ const Container: React.FunctionComponent<React.PropsWithChildren<ContainerProps>
             <span className="flex-1">{title}</span>
             {sectionID && (
                 <Button variant="icon" aria-label="Hide Section" onClick={() => onClose?.(sectionID)}>
-                    <Icon as={CloseIcon} />
+                    <Icon role="img" aria-hidden={true} as={CloseIcon} />
                 </Button>
             )}
         </Typography.H3>
@@ -311,7 +311,7 @@ export const NoResultsPage: React.FunctionComponent<React.PropsWithChildren<NoRe
                                         target="blank"
                                         to="https://learn.sourcegraph.com/how-to-search-code-with-sourcegraph-a-cheat-sheet#searching-an-organizations-repository"
                                     >
-                                        Learn more <Icon as={ExternalLinkIcon} />
+                                        Learn more <Icon role="img" aria-hidden={true} as={ExternalLinkIcon} />
                                     </Link>
                                 </small>
                             </p>
@@ -350,7 +350,7 @@ export const NoResultsPage: React.FunctionComponent<React.PropsWithChildren<NoRe
                                 target="blank"
                                 to="https://learn.sourcegraph.com/"
                             >
-                                Sourcegraph Learn <Icon as={ExternalLinkIcon} />
+                                Sourcegraph Learn <Icon role="img" aria-hidden={true} as={ExternalLinkIcon} />
                             </Link>
                             <br />
                             <Link
@@ -358,7 +358,7 @@ export const NoResultsPage: React.FunctionComponent<React.PropsWithChildren<NoRe
                                 target="blank"
                                 to="https://learn.sourcegraph.com/how-to-search-code-with-sourcegraph-a-cheat-sheet"
                             >
-                                Sourcegraph cheat sheet <Icon as={ExternalLinkIcon} />
+                                Sourcegraph cheat sheet <Icon role="img" aria-hidden={true} as={ExternalLinkIcon} />
                             </Link>
                         </p>
                     </Container>

--- a/client/search-ui/src/results/progress/StreamingProgressCount.tsx
+++ b/client/search-ui/src/results/progress/StreamingProgressCount.tsx
@@ -45,6 +45,7 @@ export const StreamingProgressCount: React.FunctionComponent<
             {(progress.durationMs / 1000).toFixed(2)}s
             {progress.repositoriesCount !== undefined && (
                 <Icon
+                    role="img"
                     className="ml-1"
                     data-tooltip={`From ${abbreviateNumber(progress.repositoriesCount)} ${pluralize(
                         'repository',
@@ -52,13 +53,18 @@ export const StreamingProgressCount: React.FunctionComponent<
                         'repositories'
                     )}`}
                     as={InformationOutlineIcon}
+                    aria-label={`From ${abbreviateNumber(progress.repositoriesCount)} ${pluralize(
+                        'repository',
+                        progress.repositoriesCount,
+                        'repositories'
+                    )}`}
                 />
             )}
         </small>
         {showTrace && progress.trace && (
             <small className="d-flex ml-2">
                 <Link to={progress.trace}>
-                    <Icon className="mr-2" as={ClipboardPulseOutlineIcon} />
+                    <Icon role="img" aria-hidden={true} className="mr-2" as={ClipboardPulseOutlineIcon} />
                     View trace
                 </Link>
             </small>

--- a/client/search-ui/src/results/progress/StreamingProgressSkippedButton.tsx
+++ b/client/search-ui/src/results/progress/StreamingProgressSkippedButton.tsx
@@ -40,9 +40,13 @@ export const StreamingProgressSkippedButton: React.FunctionComponent<
                         data-testid="streaming-progress-skipped"
                         as={Button}
                         aria-expanded={isOpen}
+                        aria-label="Open excluded results"
                     >
-                        {skippedWithWarningOrError ? <Icon className="mr-2" as={AlertCircleIcon} /> : null}
-                        Some results excluded <Icon data-caret={true} className="mr-0" as={ChevronDownIcon} />
+                        {skippedWithWarningOrError ? (
+                            <Icon role="img" aria-hidden={true} className="mr-2" as={AlertCircleIcon} />
+                        ) : null}
+                        Some results excluded{' '}
+                        <Icon role="img" aria-hidden={true} data-caret={true} className="mr-0" as={ChevronDownIcon} />
                     </PopoverTrigger>
                     <PopoverContent
                         position={Position.bottomStart}

--- a/client/search-ui/src/results/progress/StreamingProgressSkippedPopover.tsx
+++ b/client/search-ui/src/results/progress/StreamingProgressSkippedPopover.tsx
@@ -71,6 +71,8 @@ const SkippedMessage: React.FunctionComponent<React.PropsWithChildren<{ skipped:
                         >
                             <Typography.H4 className="d-flex align-items-center mb-0 w-100">
                                 <Icon
+                                    role="img"
+                                    aria-hidden={true}
                                     className={classNames(styles.icon, 'flex-shrink-0')}
                                     as={skipped.severity === 'info' ? InformationOutlineIcon : AlertCircleIcon}
                                 />
@@ -79,6 +81,8 @@ const SkippedMessage: React.FunctionComponent<React.PropsWithChildren<{ skipped:
 
                                 {skipped.message && (
                                     <Icon
+                                        role="img"
+                                        aria-hidden={true}
                                         className={classNames('flex-shrink-0', styles.chevron)}
                                         as={isOpen ? ChevronDownIcon : ChevronLeftIcon}
                                     />
@@ -174,7 +178,7 @@ export const StreamingProgressSkippedPopover: React.FunctionComponent<
                         disabled={selectedSuggestedSearches.size === 0}
                         data-testid="skipped-popover-form-submit-btn"
                     >
-                        <Icon className="mr-1" as={SearchIcon} />
+                        <Icon role="img" aria-hidden={true} className="mr-1" as={SearchIcon} />
                         Search again
                     </Button>
                 </Form>

--- a/client/search-ui/src/results/progress/__snapshots__/StreamingProgressCount.test.tsx.snap
+++ b/client/search-ui/src/results/progress/__snapshots__/StreamingProgressCount.test.tsx.snap
@@ -30,10 +30,12 @@ exports[`StreamingProgressCount should render correctly for 0 repositories 1`] =
   >
     0 results in 0.00s
     <svg
+      aria-label="From 0 repositories"
       class="mdi-icon iconInline ml-1"
       data-tooltip="From 0 repositories"
       fill="currentColor"
       height="24"
+      role="img"
       viewBox="0 0 24 24"
       width="24"
     >
@@ -53,10 +55,12 @@ exports[`StreamingProgressCount should render correctly for 1 item complete 1`] 
   >
     1 result in 1.25s
     <svg
+      aria-label="From 1 repository"
       class="mdi-icon iconInline ml-1"
       data-tooltip="From 1 repository"
       fill="currentColor"
       height="24"
+      role="img"
       viewBox="0 0 24 24"
       width="24"
     >
@@ -76,10 +80,12 @@ exports[`StreamingProgressCount should render correctly for 123 items complete 1
   >
     123 results in 1.25s
     <svg
+      aria-label="From 500 repositories"
       class="mdi-icon iconInline ml-1"
       data-tooltip="From 500 repositories"
       fill="currentColor"
       height="24"
+      role="img"
       viewBox="0 0 24 24"
       width="24"
     >
@@ -99,10 +105,12 @@ exports[`StreamingProgressCount should render correctly for big numbers complete
   >
     1.2m results in 52.50s
     <svg
+      aria-label="From 8.9k repositories"
       class="mdi-icon iconInline ml-1"
       data-tooltip="From 8.9k repositories"
       fill="currentColor"
       height="24"
+      role="img"
       viewBox="0 0 24 24"
       width="24"
     >
@@ -122,10 +130,12 @@ exports[`StreamingProgressCount should render correctly for limithit 1`] = `
   >
     123+ results in 1.25s
     <svg
+      aria-label="From 500 repositories"
       class="mdi-icon iconInline ml-1"
       data-tooltip="From 500 repositories"
       fill="currentColor"
       height="24"
+      role="img"
       viewBox="0 0 24 24"
       width="24"
     >
@@ -153,9 +163,11 @@ exports[`StreamingProgressCount should render correctly when a trace url is prov
       href="https://sourcegraph.test:3443/-/debug/jaeger/trace/abcdefg"
     >
       <svg
+        aria-hidden="true"
         class="mdi-icon iconInline mr-2"
         fill="currentColor"
         height="24"
+        role="img"
         viewBox="0 0 24 24"
         width="24"
       >

--- a/client/search-ui/src/results/progress/__snapshots__/StreamingProgressSkippedPopover.test.tsx.snap
+++ b/client/search-ui/src/results/progress/__snapshots__/StreamingProgressSkippedPopover.test.tsx.snap
@@ -15,9 +15,11 @@ exports[`StreamingProgressSkippedPopover should render correctly 1`] = `
         class="h4 d-flex align-items-center mb-0 w-100"
       >
         <svg
+          aria-hidden="true"
           class="mdi-icon iconInline icon flex-shrink-0"
           fill="currentColor"
           height="24"
+          role="img"
           viewBox="0 0 24 24"
           width="24"
         >
@@ -31,9 +33,11 @@ exports[`StreamingProgressSkippedPopover should render correctly 1`] = `
           Error loading results
         </span>
         <svg
+          aria-hidden="true"
           class="mdi-icon iconInline flex-shrink-0 chevron"
           fill="currentColor"
           height="24"
+          role="img"
           viewBox="0 0 24 24"
           width="24"
         >
@@ -73,9 +77,11 @@ exports[`StreamingProgressSkippedPopover should render correctly 1`] = `
         class="h4 d-flex align-items-center mb-0 w-100"
       >
         <svg
+          aria-hidden="true"
           class="mdi-icon iconInline icon flex-shrink-0"
           fill="currentColor"
           height="24"
+          role="img"
           viewBox="0 0 24 24"
           width="24"
         >
@@ -89,9 +95,11 @@ exports[`StreamingProgressSkippedPopover should render correctly 1`] = `
           Search timed out
         </span>
         <svg
+          aria-hidden="true"
           class="mdi-icon iconInline flex-shrink-0 chevron"
           fill="currentColor"
           height="24"
+          role="img"
           viewBox="0 0 24 24"
           width="24"
         >
@@ -131,9 +139,11 @@ exports[`StreamingProgressSkippedPopover should render correctly 1`] = `
         class="h4 d-flex align-items-center mb-0 w-100"
       >
         <svg
+          aria-hidden="true"
           class="mdi-icon iconInline icon flex-shrink-0"
           fill="currentColor"
           height="24"
+          role="img"
           viewBox="0 0 24 24"
           width="24"
         >
@@ -147,9 +157,11 @@ exports[`StreamingProgressSkippedPopover should render correctly 1`] = `
           10k forked repositories excluded
         </span>
         <svg
+          aria-hidden="true"
           class="mdi-icon iconInline flex-shrink-0 chevron"
           fill="currentColor"
           height="24"
+          role="img"
           viewBox="0 0 24 24"
           width="24"
         >
@@ -189,9 +201,11 @@ exports[`StreamingProgressSkippedPopover should render correctly 1`] = `
         class="h4 d-flex align-items-center mb-0 w-100"
       >
         <svg
+          aria-hidden="true"
           class="mdi-icon iconInline icon flex-shrink-0"
           fill="currentColor"
           height="24"
+          role="img"
           viewBox="0 0 24 24"
           width="24"
         >
@@ -205,9 +219,11 @@ exports[`StreamingProgressSkippedPopover should render correctly 1`] = `
           60k archived repositories excluded
         </span>
         <svg
+          aria-hidden="true"
           class="mdi-icon iconInline flex-shrink-0 chevron"
           fill="currentColor"
           height="24"
+          role="img"
           viewBox="0 0 24 24"
           width="24"
         >
@@ -247,9 +263,11 @@ exports[`StreamingProgressSkippedPopover should render correctly 1`] = `
         class="h4 d-flex align-items-center mb-0 w-100"
       >
         <svg
+          aria-hidden="true"
           class="mdi-icon iconInline icon flex-shrink-0"
           fill="currentColor"
           height="24"
+          role="img"
           viewBox="0 0 24 24"
           width="24"
         >
@@ -263,9 +281,11 @@ exports[`StreamingProgressSkippedPopover should render correctly 1`] = `
           1 archived
         </span>
         <svg
+          aria-hidden="true"
           class="mdi-icon iconInline flex-shrink-0 chevron"
           fill="currentColor"
           height="24"
+          role="img"
           viewBox="0 0 24 24"
           width="24"
         >
@@ -442,9 +462,11 @@ exports[`StreamingProgressSkippedPopover should render correctly 1`] = `
       type="submit"
     >
       <svg
+        aria-hidden="true"
         class="mdi-icon iconInline mr-1"
         fill="currentColor"
         height="24"
+        role="img"
         viewBox="0 0 24 24"
         width="24"
       >

--- a/client/search-ui/src/results/sidebar/QuickLink.tsx
+++ b/client/search-ui/src/results/sidebar/QuickLink.tsx
@@ -22,7 +22,7 @@ export const getQuickLinks = (settingsCascade: SettingsCascadeProps['settingsCas
             data-placement="right"
             className={styles.sidebarSectionListItem}
         >
-            <Icon className="pr-1 flex-shrink-0" as={LinkIcon} />
+            <Icon role="img" aria-hidden={true} className="pr-1 flex-shrink-0" as={LinkIcon} />
             {quickLink.name}
         </Link>
     ))

--- a/client/search-ui/src/results/sidebar/SearchReference.tsx
+++ b/client/search-ui/src/results/sidebar/SearchReference.tsx
@@ -422,7 +422,7 @@ const SearchReferenceEntry = <T extends SearchReferenceInfo>({
                         aria-label={collapsed ? 'Show filter description' : 'Hide filter description'}
                     >
                         <small className="text-monospace">i</small>
-                        <Icon as={CollapseIcon} />
+                        <Icon role="img" aria-hidden={true} as={CollapseIcon} />
                     </CollapseHeader>
                 </span>
                 <CollapsePanel>
@@ -594,7 +594,7 @@ const SearchReference = React.memo(
                 <p className={sidebarStyles.sidebarSectionFooter}>
                     <small>
                         <Link target="blank" to="https://docs.sourcegraph.com/code_search/reference/queries">
-                            Search syntax <Icon as={ExternalLinkIcon} />
+                            Search syntax <Icon role="img" aria-hidden={true} as={ExternalLinkIcon} />
                         </Link>
                     </small>
                 </p>

--- a/client/search-ui/src/results/sidebar/SearchSidebarSection.tsx
+++ b/client/search-ui/src/results/sidebar/SearchSidebarSection.tsx
@@ -116,7 +116,12 @@ export const SearchSidebarSection: React.FunctionComponent<
                         <Typography.H5 as={Typography.H2} className="flex-grow-1">
                             {header}
                         </Typography.H5>
-                        <Icon className="mr-1" as={isOpened ? ChevronDownIcon : ChevronLeftIcon} />
+                        <Icon
+                            role="img"
+                            aria-hidden={true}
+                            className="mr-1"
+                            as={isOpened ? ChevronDownIcon : ChevronLeftIcon}
+                        />
                     </CollapseHeader>
 
                     <CollapsePanel>

--- a/client/search-ui/src/results/sidebar/__snapshots__/QuickLink.test.tsx.snap
+++ b/client/search-ui/src/results/sidebar/__snapshots__/QuickLink.test.tsx.snap
@@ -8,9 +8,11 @@ exports[`QuickLink should have correct links when quicklinks present 1`] = `
     href="/"
   >
     <svg
+      aria-hidden="true"
       class="mdi-icon iconInline pr-1 flex-shrink-0"
       fill="currentColor"
       height="24"
+      role="img"
       viewBox="0 0 24 24"
       width="24"
     >
@@ -27,9 +29,11 @@ exports[`QuickLink should have correct links when quicklinks present 1`] = `
     href="http://example.com"
   >
     <svg
+      aria-hidden="true"
       class="mdi-icon iconInline pr-1 flex-shrink-0"
       fill="currentColor"
       height="24"
+      role="img"
       viewBox="0 0 24 24"
       width="24"
     >

--- a/client/wildcard/src/components/Button/story/ButtonVariants.tsx
+++ b/client/wildcard/src/components/Button/story/ButtonVariants.tsx
@@ -24,15 +24,15 @@ export const ButtonVariants: React.FunctionComponent<React.PropsWithChildren<But
         {variants.map(variant => (
             <React.Fragment key={variant}>
                 <Button variant={variant} size={size} outline={outline} onClick={console.log}>
-                    {ButtonIcon && <Icon as={ButtonIcon} className="mr-1" />}
+                    {ButtonIcon && <Icon role="img" aria-hidden={true} as={ButtonIcon} className="mr-1" />}
                     {startCase(variant)}
                 </Button>
                 <Button variant={variant} size={size} outline={outline} onClick={console.log} className="focus">
-                    {ButtonIcon && <Icon as={ButtonIcon} className="mr-1" />}
+                    {ButtonIcon && <Icon role="img" aria-hidden={true} as={ButtonIcon} className="mr-1" />}
                     Focus
                 </Button>
                 <Button variant={variant} size={size} outline={outline} onClick={console.log} disabled={true}>
-                    {ButtonIcon && <Icon as={ButtonIcon} className="mr-1" />}
+                    {ButtonIcon && <Icon role="img" aria-hidden={true} as={ButtonIcon} className="mr-1" />}
                     Disabled
                 </Button>
             </React.Fragment>

--- a/client/wildcard/src/components/ButtonLink/ButtonLink.story.tsx
+++ b/client/wildcard/src/components/ButtonLink/ButtonLink.story.tsx
@@ -75,7 +75,7 @@ export const Overview: Story = () => (
             onClick={console.log}
             className="mb-2"
         >
-            <Icon as={SearchIcon} className="mr-1" />
+            <Icon role="img" aria-hidden={true} as={SearchIcon} className="mr-1" />
             Search
         </ButtonLink>
         <Typography.H2>Smaller</Typography.H2>

--- a/client/wildcard/src/components/Collapse/Collapse.story.tsx
+++ b/client/wildcard/src/components/Collapse/Collapse.story.tsx
@@ -40,7 +40,12 @@ export const Simple: Story = () => {
             <Collapse isOpen={isOpened} onOpenChange={handleOpenChange}>
                 <CollapseHeader as={Button} outline={true} focusLocked={true} variant="secondary" className="w-50">
                     Collapsable
-                    <Icon as={isOpened ? ChevronDownIcon : ChevronLeftIcon} className="mr-1" />
+                    <Icon
+                        role="img"
+                        aria-hidden={true}
+                        as={isOpened ? ChevronDownIcon : ChevronLeftIcon}
+                        className="mr-1"
+                    />
                 </CollapseHeader>
                 <CollapsePanel className="w-50">
                     <Input placeholder="testing this one" />
@@ -59,7 +64,12 @@ export const Simple: Story = () => {
                             className="w-50"
                         >
                             Collapsable
-                            <Icon as={isOpen ? ChevronDownIcon : ChevronLeftIcon} className="mr-1" />
+                            <Icon
+                                role="img"
+                                aria-hidden={true}
+                                as={isOpen ? ChevronDownIcon : ChevronLeftIcon}
+                                className="mr-1"
+                            />
                         </CollapseHeader>
                         <CollapsePanel className="w-50">
                             <Input placeholder="testing this one" />
@@ -80,7 +90,12 @@ export const Simple: Story = () => {
                             className="w-50"
                         >
                             Collapsable
-                            <Icon as={isOpen ? ChevronDownIcon : ChevronLeftIcon} className="mr-1" />
+                            <Icon
+                                role="img"
+                                aria-hidden={true}
+                                as={isOpen ? ChevronDownIcon : ChevronLeftIcon}
+                                className="mr-1"
+                            />
                         </CollapseHeader>
                         <CollapsePanel className="w-50">
                             <Input placeholder="testing this one" />

--- a/client/wildcard/src/components/Icon/Icon.story.tsx
+++ b/client/wildcard/src/components/Icon/Icon.story.tsx
@@ -35,9 +35,9 @@ export default config
 export const Simple: Story = () => (
     <>
         <Typography.H3>Small Icon</Typography.H3>
-        <Icon as={SourcegraphIcon} size="sm" title="Sourcegraph logo" />
+        <Icon role="img" as={SourcegraphIcon} size="sm" aria-label="Sourcegraph logo" />
 
         <Typography.H3>Medium Icon</Typography.H3>
-        <Icon as={SourcegraphIcon} size="md" aria-label="Sourcegraph logo" />
+        <Icon role="img" as={SourcegraphIcon} size="md" aria-label="Sourcegraph logo" />
     </>
 )

--- a/client/wildcard/src/components/NavMenu/NavMenu.story.tsx
+++ b/client/wildcard/src/components/NavMenu/NavMenu.story.tsx
@@ -159,8 +159,8 @@ export const UserNav: Story = () => (
             triggerContent: {
                 trigger: isOpen => (
                     <>
-                        <Icon as="img" className={styles.avatar} src={avatarUrl} />
-                        <Icon as={isOpen ? MenuUpIcon : MenuDownIcon} />
+                        <Icon role="img" aria-hidden={true} as="img" className={styles.avatar} src={avatarUrl} />
+                        <Icon role="img" aria-hidden={true} as={isOpen ? MenuUpIcon : MenuDownIcon} />
                     </>
                 ),
             },
@@ -176,7 +176,7 @@ const singleSectionNavItems: NavMenuSectionProps[] = [
             {
                 content: (
                     <Button variant="link" className="w-100 text-left">
-                        <Icon as={BarChartIcon} /> Insight
+                        <Icon role="img" aria-hidden={true} as={BarChartIcon} /> Insight
                     </Button>
                 ),
                 key: 'Insight',
@@ -184,7 +184,7 @@ const singleSectionNavItems: NavMenuSectionProps[] = [
             {
                 content: (
                     <Button variant="link" className="w-100 text-left">
-                        <Icon as={AntennaIcon} /> Monitoring
+                        <Icon role="img" aria-hidden={true} as={AntennaIcon} /> Monitoring
                     </Button>
                 ),
                 key: 'Monitoring',
@@ -201,8 +201,8 @@ export const SingleSectionNavMenuExample: Story = () => (
             triggerContent: {
                 trigger: isOpen => (
                     <>
-                        <Icon as={MenuIcon} />
-                        <Icon as={isOpen ? MenuUpIcon : MenuDownIcon} />
+                        <Icon role="img" aria-hidden={true} as={MenuIcon} />
+                        <Icon role="img" aria-hidden={true} as={isOpen ? MenuUpIcon : MenuDownIcon} />
                     </>
                 ),
             },

--- a/client/wildcard/src/components/NavMenu/NavMenu.tsx
+++ b/client/wildcard/src/components/NavMenu/NavMenu.tsx
@@ -66,9 +66,9 @@ interface NavItemProps extends Omit<MenuItemProps, 'children' | 'onSelect'> {
 const NavMenuItem = forwardRef(({ content, prefixIcon, suffixIcon, onSelect, to, itemAs, ...rest }, reference) => {
     const contentWithIcon = (
         <>
-            {prefixIcon && <Icon as={prefixIcon} className="mr-1" />}
+            {prefixIcon && <Icon role="img" aria-hidden={true} as={prefixIcon} className="mr-1" />}
             {content}
-            {suffixIcon && <Icon as={suffixIcon} className="ml-1" />}
+            {suffixIcon && <Icon role="img" aria-hidden={true} as={suffixIcon} className="ml-1" />}
         </>
     )
 

--- a/client/wildcard/src/components/PageHeader/PageHeader.story.tsx
+++ b/client/wildcard/src/components/PageHeader/PageHeader.story.tsx
@@ -30,7 +30,7 @@ export const BasicHeader: Story = () => (
         path={[{ icon: PuzzleOutlineIcon, text: 'Header' }]}
         actions={
             <Button to={`${location.pathname}/close`} className="mr-1" variant="secondary" as={Link}>
-                <Icon as={SearchIcon} /> Button with icon
+                <Icon role="img" aria-hidden={true} as={SearchIcon} /> Button with icon
             </Button>
         }
     />
@@ -63,7 +63,7 @@ export const ComplexHeader: Story = () => (
                     Secondary
                 </Button>
                 <Button as={Link} to="/page" variant="primary" className="text-nowrap">
-                    <Icon as={PlusIcon} /> Create
+                    <Icon role="img" aria-hidden={true} as={PlusIcon} /> Create
                 </Button>
             </div>
         }

--- a/client/wildcard/src/components/PageHeader/PageHeader.tsx
+++ b/client/wildcard/src/components/PageHeader/PageHeader.tsx
@@ -61,7 +61,7 @@ export const PageHeader: React.FunctionComponent<React.PropsWithChildren<Props>>
                         <React.Fragment key={index}>
                             {index !== 0 && <span className={styles.divider}>/</span>}
                             <LinkOrSpan to={to} className={styles.path} aria-label={ariaLabel}>
-                                {Icon && <Icon className={styles.pathIcon} />}
+                                {Icon && <Icon className={styles.pathIcon} aria-hidden={true} />}
                                 {text && <span className={styles.pathText}>{text}</span>}
                             </LinkOrSpan>
                         </React.Fragment>

--- a/client/wildcard/src/components/PageHeader/__snapshots__/PageHeader.test.tsx.snap
+++ b/client/wildcard/src/components/PageHeader/__snapshots__/PageHeader.test.tsx.snap
@@ -15,6 +15,7 @@ exports[`PageHeader renders correctly 1`] = `
             href="/link-0"
           >
             <svg
+              aria-hidden="true"
               class="mdi-icon pathIcon"
               fill="currentColor"
               height="24"

--- a/client/wildcard/src/components/PageSelector/PageSelector.tsx
+++ b/client/wildcard/src/components/PageSelector/PageSelector.tsx
@@ -93,9 +93,13 @@ export const PageSelector: React.FunctionComponent<React.PropsWithChildren<PageS
                         return (
                             <li key={key}>
                                 <PageButton {...omit(page, 'type')}>
-                                    {page.type === 'previous' && <Icon as={ChevronLeftIcon} aria-hidden={true} />}
+                                    {page.type === 'previous' && (
+                                        <Icon role="img" as={ChevronLeftIcon} aria-hidden={true} />
+                                    )}
                                     <span className={classNames(shouldShrink && 'd-none')}>{page.content}</span>
-                                    {page.type === 'next' && <Icon as={ChevronRightIcon} aria-hidden={true} />}
+                                    {page.type === 'next' && (
+                                        <Icon role="img" as={ChevronRightIcon} aria-hidden={true} />
+                                    )}
                                 </PageButton>
                             </li>
                         )

--- a/client/wildcard/src/components/Panel/story/Panel.story.tsx
+++ b/client/wildcard/src/components/Panel/story/Panel.story.tsx
@@ -146,7 +146,7 @@ export const WithChildren: Story = props => {
                             data-placement="left"
                             variant="icon"
                         >
-                            <Icon as={CloseIcon} />
+                            <Icon role="img" aria-hidden={true} as={CloseIcon} />
                         </Button>
                     </div>
                 </div>


### PR DESCRIPTION
## Description
Our Icon component is not currently accessible and will cause issues across our application.
Screen readers will report each icon as "unlabelled image" - which isn't helpful to anyone.

Migrate the rest of the codebase to use either title or aria-hidden="true"

## Expected behavior
For decorative icons, we should set aria-hidden="true". This will ensure screen readers completely ignore the icon, as it adds no value to the user journey.

For icons that add useful information to the page, we should set role="img" and title="Some descriptive text". This will ensure screen readers are able to properly understand to meaning of the icon.

## Ref
[SG Issue](https://github.com/sourcegraph/sourcegraph/issues/34582)
[Gitstart Ticket](https://app.gitstart.com/clients/sourcegraph/tickets/SG-34582)

## Implementation Detail
2. Migrate the rest of the codebase to use either title or aria-hidden="true" 

## Test Plan
Run integration tests to ensure that there are no unresolved accessibility issues reported

## Affected areas
1. `client/search-ui`
2. `client/wildcard`