### PR TITLE
database: remove dbutil-based constructors

### DIFF
--- a/cmd/frontend/graphqlbackend/feature_flags.go
+++ b/cmd/frontend/graphqlbackend/feature_flags.go
@@ -41,7 +41,7 @@ type FeatureFlagBooleanResolver struct {
 func (f *FeatureFlagBooleanResolver) Name() string { return f.inner.Name }
 func (f *FeatureFlagBooleanResolver) Value() bool  { return f.inner.Bool.Value }
 func (f *FeatureFlagBooleanResolver) Overrides(ctx context.Context) ([]*FeatureFlagOverrideResolver, error) {
-	overrides, err := database.FeatureFlags(f.db).GetOverridesForFlag(ctx, f.inner.Name)
+	overrides, err := f.db.FeatureFlags().GetOverridesForFlag(ctx, f.inner.Name)
 	if err != nil {
 		return nil, err
 	}
@@ -57,7 +57,7 @@ type FeatureFlagRolloutResolver struct {
 func (f *FeatureFlagRolloutResolver) Name() string              { return f.inner.Name }
 func (f *FeatureFlagRolloutResolver) RolloutBasisPoints() int32 { return f.inner.Rollout.Rollout }
 func (f *FeatureFlagRolloutResolver) Overrides(ctx context.Context) ([]*FeatureFlagOverrideResolver, error) {
-	overrides, err := database.FeatureFlags(f.db).GetOverridesForFlag(ctx, f.inner.Name)
+	overrides, err := f.db.FeatureFlags().GetOverridesForFlag(ctx, f.inner.Name)
 	if err != nil {
 		return nil, err
 	}
@@ -203,7 +203,7 @@ func (r *schemaResolver) CreateFeatureFlag(ctx context.Context, args struct {
 		return nil, err
 	}
 
-	ff := database.FeatureFlags(r.db)
+	ff := r.db.FeatureFlags()
 
 	var res *featureflag.FeatureFlag
 	var err error
@@ -224,7 +224,7 @@ func (r *schemaResolver) DeleteFeatureFlag(ctx context.Context, args struct {
 	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
 		return nil, err
 	}
-	return &EmptyResponse{}, database.FeatureFlags(r.db).DeleteFeatureFlag(ctx, args.Name)
+	return &EmptyResponse{}, r.db.FeatureFlags().DeleteFeatureFlag(ctx, args.Name)
 }
 
 func (r *schemaResolver) UpdateFeatureFlag(ctx context.Context, args struct {
@@ -244,7 +244,7 @@ func (r *schemaResolver) UpdateFeatureFlag(ctx context.Context, args struct {
 		return nil, errors.Errorf("either 'value' or 'rolloutBasisPoints' must be set")
 	}
 
-	res, err := database.FeatureFlags(r.db).UpdateFeatureFlag(ctx, ff)
+	res, err := r.db.FeatureFlags().UpdateFeatureFlag(ctx, ff)
 	return &FeatureFlagResolver{r.db, res}, err
 }
 
@@ -272,7 +272,7 @@ func (r *schemaResolver) CreateFeatureFlagOverride(ctx context.Context, args str
 	} else if oid != 0 {
 		fo.OrgID = &oid
 	}
-	res, err := database.FeatureFlags(r.db).CreateOverride(ctx, fo)
+	res, err := r.db.FeatureFlags().CreateOverride(ctx, fo)
 	return &FeatureFlagOverrideResolver{r.db, res}, err
 }
 
@@ -286,7 +286,7 @@ func (r *schemaResolver) DeleteFeatureFlagOverride(ctx context.Context, args str
 	if err != nil {
 		return &EmptyResponse{}, err
 	}
-	return &EmptyResponse{}, database.FeatureFlags(r.db).DeleteOverride(ctx, spec.OrgID, spec.UserID, spec.FlagName)
+	return &EmptyResponse{}, r.db.FeatureFlags().DeleteOverride(ctx, spec.OrgID, spec.UserID, spec.FlagName)
 }
 
 func (r *schemaResolver) UpdateFeatureFlagOverride(ctx context.Context, args struct {
@@ -301,6 +301,6 @@ func (r *schemaResolver) UpdateFeatureFlagOverride(ctx context.Context, args str
 		return nil, err
 	}
 
-	res, err := database.FeatureFlags(r.db).UpdateOverride(ctx, spec.OrgID, spec.UserID, spec.FlagName, args.Value)
+	res, err := r.db.FeatureFlags().UpdateOverride(ctx, spec.OrgID, spec.UserID, spec.FlagName, args.Value)
 	return &FeatureFlagOverrideResolver{r.db, res}, err
 }

--- a/cmd/frontend/internal/auth/userpasswd/handlers.go
+++ b/cmd/frontend/internal/auth/userpasswd/handlers.go
@@ -408,7 +408,7 @@ func HandleCheckUsernameTaken(db database.DB) func(w http.ResponseWriter, r *htt
 			return
 		}
 
-		_, err = database.Namespaces(db).GetByName(r.Context(), username)
+		_, err = db.Namespaces().GetByName(r.Context(), username)
 		if err == database.ErrNamespaceNotFound {
 			w.WriteHeader(http.StatusNotFound)
 			return

--- a/cmd/frontend/internal/cli/http.go
+++ b/cmd/frontend/internal/cli/http.go
@@ -52,7 +52,7 @@ func newExternalHTTPHandler(
 		// 🚨 SECURITY: These all run after the auth handler so the client is authenticated.
 		apiHandler = hooks.PostAuthMiddleware(apiHandler)
 	}
-	apiHandler = featureflag.Middleware(database.FeatureFlags(db), apiHandler)
+	apiHandler = featureflag.Middleware(db.FeatureFlags(), apiHandler)
 	apiHandler = actor.AnonymousUIDMiddleware(apiHandler)
 	apiHandler = authMiddlewares.API(apiHandler) // 🚨 SECURITY: auth middleware
 	// 🚨 SECURITY: The HTTP API should not accept cookies as authentication, except from trusted
@@ -75,7 +75,7 @@ func newExternalHTTPHandler(
 		// 🚨 SECURITY: These all run after the auth handler so the client is authenticated.
 		appHandler = hooks.PostAuthMiddleware(appHandler)
 	}
-	appHandler = featureflag.Middleware(database.FeatureFlags(db), appHandler)
+	appHandler = featureflag.Middleware(db.FeatureFlags(), appHandler)
 	appHandler = actor.AnonymousUIDMiddleware(appHandler)
 	appHandler = authMiddlewares.App(appHandler)                           // 🚨 SECURITY: auth middleware
 	appHandler = session.CookieMiddleware(db, appHandler)                  // app accepts cookies
@@ -128,7 +128,7 @@ func newInternalHTTPHandler(schema *graphql.Schema, db database.DB, newCodeIntel
 	internalMux := http.NewServeMux()
 	internalMux.Handle("/.internal/", gziphandler.GzipHandler(
 		actor.HTTPMiddleware(
-			featureflag.Middleware(database.FeatureFlags(db),
+			featureflag.Middleware(db.FeatureFlags(),
 				internalhttpapi.NewInternalHandler(
 					router.NewInternal(mux.NewRouter().PathPrefix("/.internal/").Subrouter()),
 					db,

--- a/cmd/gitserver/server/cleanup_test.go
+++ b/cmd/gitserver/server/cleanup_test.go
@@ -596,7 +596,7 @@ func TestRemoveRepoDirectory(t *testing.T) {
 		if err := database.Repos(db).Create(ctx, repo); err != nil {
 			t.Fatal(err)
 		}
-		if err := database.GitserverRepos(db).Upsert(ctx, &types.GitserverRepo{
+		if err := db.GitserverRepos().Upsert(ctx, &types.GitserverRepo{
 			RepoID:      repo.ID,
 			ShardID:     "test",
 			CloneStatus: types.CloneStatusCloned,
@@ -641,7 +641,7 @@ func TestRemoveRepoDirectory(t *testing.T) {
 		if !ok {
 			t.Fatal("id mapping not found")
 		}
-		r, err := database.GitserverRepos(db).GetByID(ctx, id)
+		r, err := db.GitserverRepos().GetByID(ctx, id)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -559,7 +559,7 @@ func (s *Server) syncRepoState(gitServerAddrs gitserver.GitServerAddresses, batc
 	}
 
 	ctx := s.ctx
-	store := database.GitserverRepos(s.DB)
+	store := s.DB.GitserverRepos()
 
 	// The rate limit should be enforced across all instances
 	perSecond = perSecond / len(addrs)
@@ -1730,7 +1730,7 @@ func (s *Server) setLastError(ctx context.Context, name api.RepoName, error stri
 	if s.DB == nil {
 		return nil
 	}
-	return database.GitserverRepos(s.DB).SetLastError(ctx, name, error, s.Hostname)
+	return s.DB.GitserverRepos().SetLastError(ctx, name, error, s.Hostname)
 }
 
 func (s *Server) setLastFetched(ctx context.Context, name api.RepoName) error {
@@ -1750,7 +1750,7 @@ func (s *Server) setLastFetched(ctx context.Context, name api.RepoName) error {
 		return errors.Wrapf(err, "failed to get last changed for %s", name)
 	}
 
-	return database.GitserverRepos(s.DB).SetLastFetched(ctx, name, database.GitserverFetchData{
+	return s.DB.GitserverRepos().SetLastFetched(ctx, name, database.GitserverFetchData{
 		LastFetched: lastFetched,
 		LastChanged: lastChanged,
 		ShardID:     s.Hostname,
@@ -1772,7 +1772,7 @@ func (s *Server) setCloneStatus(ctx context.Context, name api.RepoName, status t
 	if s.DB == nil {
 		return nil
 	}
-	return database.GitserverRepos(s.DB).SetCloneStatus(ctx, name, status, s.Hostname)
+	return s.DB.GitserverRepos().SetCloneStatus(ctx, name, status, s.Hostname)
 }
 
 // setCloneStatusNonFatal is the same as setCloneStatus but only logs errors
@@ -1788,7 +1788,7 @@ func (s *Server) setRepoSize(ctx context.Context, name api.RepoName) error {
 		return nil
 	}
 
-	return database.GitserverRepos(s.DB).SetRepoSize(ctx, name, dirSize(s.dir(name).Path(".")), s.Hostname)
+	return s.DB.GitserverRepos().SetRepoSize(ctx, name, dirSize(s.dir(name).Path(".")), s.Hostname)
 }
 
 // setGitAttributes writes our global gitattributes to

--- a/cmd/gitserver/server/server_test.go
+++ b/cmd/gitserver/server/server_test.go
@@ -540,7 +540,7 @@ func TestCloneRepo(t *testing.T) {
 	}
 	assertRepoState := func(status types.CloneStatus, size int64) {
 		t.Helper()
-		fromDB, err := database.GitserverRepos(db).GetByID(ctx, dbRepo.ID)
+		fromDB, err := db.GitserverRepos().GetByID(ctx, dbRepo.ID)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -557,7 +557,7 @@ func TestCloneRepo(t *testing.T) {
 		ShardID:     "test",
 		CloneStatus: types.CloneStatusNotCloned,
 	}
-	if err := database.GitserverRepos(db).Upsert(ctx, &gr); err != nil {
+	if err := db.GitserverRepos().Upsert(ctx, &gr); err != nil {
 		t.Fatal(err)
 	}
 	assertRepoState(types.CloneStatusNotCloned, 0)
@@ -691,7 +691,7 @@ func testHandleRepoDelete(t *testing.T, deletedInDB bool) {
 		CloneStatus:   types.CloneStatusCloned,
 		RepoSizeBytes: size,
 	}
-	fromDB, err := database.GitserverRepos(db).GetByID(ctx, dbRepo.ID)
+	fromDB, err := db.GitserverRepos().GetByID(ctx, dbRepo.ID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -740,7 +740,7 @@ func testHandleRepoDelete(t *testing.T, deletedInDB bool) {
 		CloneStatus:   types.CloneStatusNotCloned,
 		RepoSizeBytes: size,
 	}
-	fromDB, err = database.GitserverRepos(db).GetByID(ctx, dbRepo.ID)
+	fromDB, err = db.GitserverRepos().GetByID(ctx, dbRepo.ID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -807,7 +807,7 @@ func TestHandleRepoUpdate(t *testing.T) {
 		CloneStatus:   types.CloneStatusCloned,
 		RepoSizeBytes: size,
 	}
-	fromDB, err := database.GitserverRepos(db).GetByID(ctx, dbRepo.ID)
+	fromDB, err := db.GitserverRepos().GetByID(ctx, dbRepo.ID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -836,7 +836,7 @@ func TestHandleRepoUpdate(t *testing.T) {
 		LastError:     "fail",
 		RepoSizeBytes: size,
 	}
-	fromDB, err = database.GitserverRepos(db).GetByID(ctx, dbRepo.ID)
+	fromDB, err = db.GitserverRepos().GetByID(ctx, dbRepo.ID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -859,7 +859,7 @@ func TestHandleRepoUpdate(t *testing.T) {
 		CloneStatus:   types.CloneStatusCloned,
 		RepoSizeBytes: dirSize(s.dir(repoName).Path(".")), // we compute the new size
 	}
-	fromDB, err = database.GitserverRepos(db).GetByID(ctx, dbRepo.ID)
+	fromDB, err = db.GitserverRepos().GetByID(ctx, dbRepo.ID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -948,7 +948,7 @@ func TestHandleRepoUpdateFromShard(t *testing.T) {
 		CloneStatus:   types.CloneStatusCloned,
 		RepoSizeBytes: size,
 	}
-	fromDB, err := database.GitserverRepos(db).GetByID(ctx, dbRepo.ID)
+	fromDB, err := db.GitserverRepos().GetByID(ctx, dbRepo.ID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1234,7 +1234,7 @@ func TestSyncRepoState(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = database.GitserverRepos(db).GetByID(ctx, dbRepo.ID)
+	_, err = db.GitserverRepos().GetByID(ctx, dbRepo.ID)
 	if err != nil {
 		// GitserverRepo should exist after updating the lastFetched time
 		t.Fatal(err)
@@ -1245,7 +1245,7 @@ func TestSyncRepoState(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	gr, err := database.GitserverRepos(db).GetByID(ctx, dbRepo.ID)
+	gr, err := db.GitserverRepos().GetByID(ctx, dbRepo.ID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1256,7 +1256,7 @@ func TestSyncRepoState(t *testing.T) {
 
 	t.Run("sync deleted repo", func(t *testing.T) {
 		// Fake setting an incorrect status
-		if err := database.GitserverRepos(db).SetCloneStatus(ctx, dbRepo.Name, types.CloneStatusUnknown, hostname); err != nil {
+		if err := db.GitserverRepos().SetCloneStatus(ctx, dbRepo.Name, types.CloneStatusUnknown, hostname); err != nil {
 			t.Fatal(err)
 		}
 
@@ -1270,7 +1270,7 @@ func TestSyncRepoState(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		gr, err := database.GitserverRepos(db).GetByID(ctx, dbRepo.ID)
+		gr, err := db.GitserverRepos().GetByID(ctx, dbRepo.ID)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -120,15 +120,15 @@ func (d *db) FeatureFlags() FeatureFlagStore {
 }
 
 func (d *db) GitserverRepos() GitserverRepoStore {
-	return NewGitserverReposWith(d.Store)
+	return GitserverReposWith(d.Store)
 }
 
 func (d *db) GitserverLocalClone() GitserverLocalCloneStore {
-	return NewGitserverLocalCloneStoreWith(d.Store)
+	return GitserverLocalCloneStoreWith(d.Store)
 }
 
 func (d *db) GlobalState() GlobalStateStore {
-	return &globalStateStore{Store: basestore.NewWithHandle(d.Handle())}
+	return GlobalStateWith(d.Store)
 }
 
 func (d *db) Namespaces() NamespaceStore {

--- a/internal/database/feature_flags.go
+++ b/internal/database/feature_flags.go
@@ -8,7 +8,6 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	ff "github.com/sourcegraph/sourcegraph/internal/featureflag"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
@@ -39,10 +38,6 @@ type FeatureFlagStore interface {
 
 type featureFlagStore struct {
 	*basestore.Store
-}
-
-func FeatureFlags(db dbutil.DB) FeatureFlagStore {
-	return &featureFlagStore{Store: basestore.NewWithDB(db, sql.TxOptions{})}
 }
 
 func FeatureFlagsWith(other basestore.ShareableStore) FeatureFlagStore {

--- a/internal/database/feature_flags_test.go
+++ b/internal/database/feature_flags_test.go
@@ -38,20 +38,23 @@ func errorContains(s string) require.ErrorAssertionFunc {
 	}
 }
 
-func cleanup(t *testing.T, db *sql.DB) func() {
+func cleanup(t *testing.T, db DB) func() {
 	return func() {
 		if t.Failed() {
 			// Retain content on failed tests
 			return
 		}
-		_, err := db.Exec(`truncate feature_flags, feature_flag_overrides, users, orgs, org_members cascade;`)
+		_, err := db.Handle().DB().ExecContext(
+			context.Background(),
+			`truncate feature_flags, feature_flag_overrides, users, orgs, org_members cascade;`,
+		)
 		require.NoError(t, err)
 	}
 }
 
 func testNewFeatureFlagRoundtrip(t *testing.T) {
 	t.Parallel()
-	flagStore := FeatureFlags(dbtest.NewDB(t))
+	flagStore := NewDB(dbtest.NewDB(t)).FeatureFlags()
 	ctx := actor.WithInternalActor(context.Background())
 
 	cases := []struct {
@@ -141,8 +144,8 @@ func testListFeatureFlags(t *testing.T) {
 
 func testNewOverrideRoundtrip(t *testing.T) {
 	t.Parallel()
-	db := dbtest.NewDB(t)
-	flagStore := FeatureFlags(db)
+	db := NewDB(dbtest.NewDB(t))
+	flagStore := db.FeatureFlags()
 	users := Users(db)
 	ctx := actor.WithInternalActor(context.Background())
 
@@ -190,7 +193,7 @@ func testNewOverrideRoundtrip(t *testing.T) {
 
 func testListUserOverrides(t *testing.T) {
 	t.Parallel()
-	db := dbtest.NewDB(t)
+	db := NewDB(dbtest.NewDB(t))
 	flagStore := &featureFlagStore{Store: basestore.NewWithDB(db, sql.TxOptions{})}
 	users := Users(db)
 	ctx := actor.WithInternalActor(context.Background())
@@ -269,7 +272,7 @@ func testListUserOverrides(t *testing.T) {
 
 func testListOrgOverrides(t *testing.T) {
 	t.Parallel()
-	db := dbtest.NewDB(t)
+	db := NewDB(dbtest.NewDB(t))
 	flagStore := &featureFlagStore{Store: basestore.NewWithDB(db, sql.TxOptions{})}
 	users := Users(db)
 	orgs := Orgs(db)
@@ -354,8 +357,8 @@ func testListOrgOverrides(t *testing.T) {
 
 func testUserFlags(t *testing.T) {
 	t.Parallel()
-	db := dbtest.NewDB(t)
-	flagStore := FeatureFlags(db)
+	db := NewDB(dbtest.NewDB(t))
+	flagStore := db.FeatureFlags()
 	users := Users(db)
 	orgs := Orgs(db)
 	orgMembers := OrgMembers(db)
@@ -512,8 +515,8 @@ func testUserFlags(t *testing.T) {
 
 func testAnonymousUserFlags(t *testing.T) {
 	t.Parallel()
-	db := dbtest.NewDB(t)
-	flagStore := FeatureFlags(db)
+	db := NewDB(dbtest.NewDB(t))
+	flagStore := db.FeatureFlags()
 	ctx := actor.WithInternalActor(context.Background())
 
 	mkFFBool := func(name string, val bool) *ff.FeatureFlag {
@@ -556,8 +559,8 @@ func testAnonymousUserFlags(t *testing.T) {
 
 func testUserlessFeatureFlags(t *testing.T) {
 	t.Parallel()
-	db := dbtest.NewDB(t)
-	flagStore := FeatureFlags(db)
+	db := NewDB(dbtest.NewDB(t))
+	flagStore := db.FeatureFlags()
 	ctx := actor.WithInternalActor(context.Background())
 
 	mkFFBool := func(name string, val bool) *ff.FeatureFlag {
@@ -604,8 +607,8 @@ func testUserlessFeatureFlags(t *testing.T) {
 
 func testOrgFeatureFlag(t *testing.T) {
 	t.Parallel()
-	db := dbtest.NewDB(t)
-	flagStore := FeatureFlags(db)
+	db := NewDB(dbtest.NewDB(t))
+	flagStore := db.FeatureFlags()
 	orgs := Orgs(db)
 	ctx := actor.WithInternalActor(context.Background())
 

--- a/internal/database/gitserver_localclone_jobs.go
+++ b/internal/database/gitserver_localclone_jobs.go
@@ -2,7 +2,6 @@ package database
 
 import (
 	"context"
-	"database/sql"
 
 	"github.com/keegancsmith/sqlf"
 
@@ -20,14 +19,9 @@ type gitserverLocalCloneStore struct {
 	*basestore.Store
 }
 
-// GitserverLocalClone instantiates and returns a new gitserverRepoStore.
-func GitserverLocalClone(db DB) GitserverLocalCloneStore {
-	return &gitserverLocalCloneStore{Store: basestore.NewWithDB(db, sql.TxOptions{})}
-}
-
-// NewGitserverLocalCloneStoreWith instantiates and returns a new gitserverLocalCloneStore using
+// GitserverLocalCloneStoreWith instantiates and returns a new gitserverLocalCloneStore using
 // the other store handle.
-func NewGitserverLocalCloneStoreWith(other basestore.ShareableStore) GitserverLocalCloneStore {
+func GitserverLocalCloneStoreWith(other basestore.ShareableStore) GitserverLocalCloneStore {
 	return &gitserverLocalCloneStore{Store: basestore.NewWithHandle(other.Handle())}
 }
 

--- a/internal/database/gitserver_localclone_jobs_test.go
+++ b/internal/database/gitserver_localclone_jobs_test.go
@@ -15,7 +15,7 @@ func TestGitserverLocalCloneEnqueue(t *testing.T) {
 	db := NewDB(dbtest.NewDB(t))
 	ctx := context.Background()
 
-	jobid, err := GitserverLocalClone(db).Enqueue(ctx, 1, "gitserver1", "gitserver2", true)
+	jobid, err := db.GitserverLocalClone().Enqueue(ctx, 1, "gitserver1", "gitserver2", true)
 	if err != nil {
 		t.Fatal("failed to enqueue job", err)
 	}

--- a/internal/database/gitserver_repos.go
+++ b/internal/database/gitserver_repos.go
@@ -2,7 +2,6 @@ package database
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
 	"strings"
 	"time"
@@ -44,14 +43,9 @@ type gitserverRepoStore struct {
 	*basestore.Store
 }
 
-// GitserverRepos instantiates and returns a new gitserverRepoStore.
-func GitserverRepos(db dbutil.DB) GitserverRepoStore {
-	return &gitserverRepoStore{Store: basestore.NewWithDB(db, sql.TxOptions{})}
-}
-
-// NewGitserverReposWith instantiates and returns a new gitserverRepoStore using
+// GitserverReposWith instantiates and returns a new gitserverRepoStore using
 // the other store handle.
-func NewGitserverReposWith(other basestore.ShareableStore) GitserverRepoStore {
+func GitserverReposWith(other basestore.ShareableStore) GitserverRepoStore {
 	return &gitserverRepoStore{Store: basestore.NewWithHandle(other.Handle())}
 }
 

--- a/internal/database/gitserver_repos_test.go
+++ b/internal/database/gitserver_repos_test.go
@@ -28,7 +28,7 @@ func TestIterateRepoGitserverStatus(t *testing.T) {
 		t.Skip()
 	}
 
-	db := dbtest.NewDB(t)
+	db := NewDB(dbtest.NewDB(t))
 	ctx := context.Background()
 
 	repos := types.Repos{
@@ -64,7 +64,7 @@ func TestIterateRepoGitserverStatus(t *testing.T) {
 	}
 
 	// Create one GitServerRepo
-	if err := GitserverRepos(db).Upsert(ctx, gitserverRepo); err != nil {
+	if err := db.GitserverRepos().Upsert(ctx, gitserverRepo); err != nil {
 		t.Fatal(err)
 	}
 
@@ -76,7 +76,7 @@ func TestIterateRepoGitserverStatus(t *testing.T) {
 	assert := func(t *testing.T, wantRepoCount, wantStatusCount int, options IterateRepoGitserverStatusOptions) {
 		var statusCount int
 		var seen []api.RepoName
-		err := GitserverRepos(db).IterateRepoGitserverStatus(ctx, options, func(repo types.RepoGitserverStatus) error {
+		err := db.GitserverRepos().IterateRepoGitserverStatus(ctx, options, func(repo types.RepoGitserverStatus) error {
 			seen = append(seen, repo.Name)
 			if repo.GitserverRepo != nil {
 				statusCount++
@@ -199,7 +199,7 @@ func TestIteratePurgeableRepos(t *testing.T) {
 			var have []api.RepoName
 			var blockedCount int
 			var deletedCount int
-			if err := GitserverRepos(db).IteratePurgeableRepos(ctx, tt.options, func(repo api.RepoName) error {
+			if err := db.GitserverRepos().IteratePurgeableRepos(ctx, tt.options, func(repo api.RepoName) error {
 				if repo == "blocked" {
 					blockedCount++
 				}
@@ -321,7 +321,7 @@ func TestIterateWithNonemptyLastError(t *testing.T) {
 			foundRepos := make([]types.RepoGitserverStatus, 0, len(tc.testRepos))
 
 			// Iterate and collect repos
-			err := GitserverRepos(db).IterateWithNonemptyLastError(ctx, func(repo types.RepoGitserverStatus) error {
+			err := db.GitserverRepos().IterateWithNonemptyLastError(ctx, func(repo types.RepoGitserverStatus) error {
 				foundRepos = append(foundRepos, repo)
 				return nil
 			})
@@ -338,7 +338,7 @@ func TestIterateWithNonemptyLastError(t *testing.T) {
 				}
 			}
 
-			total, err := GitserverRepos(db).TotalErroredCloudDefaultRepos(ctx)
+			total, err := db.GitserverRepos().TotalErroredCloudDefaultRepos(ctx)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -376,7 +376,7 @@ func TestGitserverReposGetByID(t *testing.T) {
 		t.Skip()
 	}
 
-	db := dbtest.NewDB(t)
+	db := NewDB(dbtest.NewDB(t))
 	ctx := context.Background()
 
 	// Create one test repo
@@ -389,7 +389,7 @@ func TestGitserverReposGetByID(t *testing.T) {
 	})
 
 	// GetByID should now work
-	fromDB, err := GitserverRepos(db).GetByID(ctx, gitserverRepo.RepoID)
+	fromDB, err := db.GitserverRepos().GetByID(ctx, gitserverRepo.RepoID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -404,7 +404,7 @@ func TestGitserverReposGetByName(t *testing.T) {
 		t.Skip()
 	}
 
-	db := dbtest.NewDB(t)
+	db := NewDB(dbtest.NewDB(t))
 	ctx := context.Background()
 
 	// Create one test repo
@@ -417,7 +417,7 @@ func TestGitserverReposGetByName(t *testing.T) {
 	})
 
 	// GetByName should now work
-	fromDB, err := GitserverRepos(db).GetByName(ctx, repo.Name)
+	fromDB, err := db.GitserverRepos().GetByName(ctx, repo.Name)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -432,7 +432,7 @@ func TestGitserverReposGetByNames(t *testing.T) {
 		t.Skip()
 	}
 
-	db := dbtest.NewDB(t)
+	db := NewDB(dbtest.NewDB(t))
 	ctx := context.Background()
 
 	type testCase struct {
@@ -503,7 +503,7 @@ func TestSetCloneStatus(t *testing.T) {
 		t.Skip()
 	}
 
-	db := dbtest.NewDB(t)
+	db := NewDB(dbtest.NewDB(t))
 	ctx := context.Background()
 
 	// Create one test repo
@@ -517,12 +517,12 @@ func TestSetCloneStatus(t *testing.T) {
 	})
 
 	// Set cloned
-	err := GitserverRepos(db).SetCloneStatus(ctx, repo.Name, types.CloneStatusCloned, shardID)
+	err := db.GitserverRepos().SetCloneStatus(ctx, repo.Name, types.CloneStatusCloned, shardID)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	fromDB, err := GitserverRepos(db).GetByID(ctx, gitserverRepo.RepoID)
+	fromDB, err := db.GitserverRepos().GetByID(ctx, gitserverRepo.RepoID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -545,10 +545,10 @@ func TestSetCloneStatus(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := GitserverRepos(db).SetCloneStatus(ctx, repo2.Name, types.CloneStatusCloned, shardID); err != nil {
+	if err := db.GitserverRepos().SetCloneStatus(ctx, repo2.Name, types.CloneStatusCloned, shardID); err != nil {
 		t.Fatal(err)
 	}
-	fromDB, err = GitserverRepos(db).GetByID(ctx, repo2.ID)
+	fromDB, err = db.GitserverRepos().GetByID(ctx, repo2.ID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -562,10 +562,10 @@ func TestSetCloneStatus(t *testing.T) {
 	}
 
 	// Setting the same status again should not touch the row
-	if err := GitserverRepos(db).SetCloneStatus(ctx, repo2.Name, types.CloneStatusCloned, shardID); err != nil {
+	if err := db.GitserverRepos().SetCloneStatus(ctx, repo2.Name, types.CloneStatusCloned, shardID); err != nil {
 		t.Fatal(err)
 	}
-	after, err := GitserverRepos(db).GetByID(ctx, repo2.ID)
+	after, err := db.GitserverRepos().GetByID(ctx, repo2.ID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -579,7 +579,7 @@ func TestSetLastError(t *testing.T) {
 		t.Skip()
 	}
 
-	db := dbtest.NewDB(t)
+	db := NewDB(dbtest.NewDB(t))
 	ctx := context.Background()
 
 	// Create one test repo
@@ -596,12 +596,12 @@ func TestSetLastError(t *testing.T) {
 	//
 	// We are using a null terminated string for the last_error column. See
 	// https://stackoverflow.com/a/38008565/1773961 on how to set null terminated strings in Go.
-	err := GitserverRepos(db).SetLastError(ctx, repo.Name, "oops\x00", shardID)
+	err := db.GitserverRepos().SetLastError(ctx, repo.Name, "oops\x00", shardID)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	fromDB, err := GitserverRepos(db).GetByID(ctx, gitserverRepo.RepoID)
+	fromDB, err := db.GitserverRepos().GetByID(ctx, gitserverRepo.RepoID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -613,12 +613,12 @@ func TestSetLastError(t *testing.T) {
 
 	// Remove error
 	const emptyErr = ""
-	err = GitserverRepos(db).SetLastError(ctx, repo.Name, emptyErr, shardID)
+	err = db.GitserverRepos().SetLastError(ctx, repo.Name, emptyErr, shardID)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	fromDB, err = GitserverRepos(db).GetByID(ctx, gitserverRepo.RepoID)
+	fromDB, err = db.GitserverRepos().GetByID(ctx, gitserverRepo.RepoID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -629,12 +629,12 @@ func TestSetLastError(t *testing.T) {
 	}
 
 	// Set again to same value, updated_at should not change
-	err = GitserverRepos(db).SetLastError(ctx, repo.Name, emptyErr, shardID)
+	err = db.GitserverRepos().SetLastError(ctx, repo.Name, emptyErr, shardID)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	after, err := GitserverRepos(db).GetByID(ctx, gitserverRepo.RepoID)
+	after, err := db.GitserverRepos().GetByID(ctx, gitserverRepo.RepoID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -660,7 +660,7 @@ func TestSetRepoSize(t *testing.T) {
 		t.Skip()
 	}
 
-	db := dbtest.NewDB(t)
+	db := NewDB(dbtest.NewDB(t))
 	ctx := context.Background()
 
 	// Create one test repo
@@ -673,12 +673,12 @@ func TestSetRepoSize(t *testing.T) {
 	})
 
 	// Set repo size
-	err := GitserverRepos(db).SetRepoSize(ctx, repo.Name, 200, shardID)
+	err := db.GitserverRepos().SetRepoSize(ctx, repo.Name, 200, shardID)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	fromDB, err := GitserverRepos(db).GetByID(ctx, gitserverRepo.RepoID)
+	fromDB, err := db.GitserverRepos().GetByID(ctx, gitserverRepo.RepoID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -701,10 +701,10 @@ func TestSetRepoSize(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := GitserverRepos(db).SetRepoSize(ctx, repo2.Name, 300, shardID); err != nil {
+	if err := db.GitserverRepos().SetRepoSize(ctx, repo2.Name, 300, shardID); err != nil {
 		t.Fatal(err)
 	}
-	fromDB, err = GitserverRepos(db).GetByID(ctx, repo2.ID)
+	fromDB, err = db.GitserverRepos().GetByID(ctx, repo2.ID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -718,10 +718,10 @@ func TestSetRepoSize(t *testing.T) {
 	}
 
 	// Setting the same size should not touch the row
-	if err := GitserverRepos(db).SetRepoSize(ctx, repo2.Name, 300, shardID); err != nil {
+	if err := db.GitserverRepos().SetRepoSize(ctx, repo2.Name, 300, shardID); err != nil {
 		t.Fatal(err)
 	}
-	after, err := GitserverRepos(db).GetByID(ctx, repo2.ID)
+	after, err := db.GitserverRepos().GetByID(ctx, repo2.ID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -735,7 +735,7 @@ func TestGitserverRepoUpsertNullShard(t *testing.T) {
 		t.Skip()
 	}
 
-	db := dbtest.NewDB(t)
+	db := NewDB(dbtest.NewDB(t))
 	ctx := context.Background()
 
 	repo1 := &types.Repo{
@@ -760,7 +760,7 @@ func TestGitserverRepoUpsertNullShard(t *testing.T) {
 	}
 
 	// Create one GitServerRepo
-	if err := GitserverRepos(db).Upsert(ctx, gitserverRepo); err == nil {
+	if err := db.GitserverRepos().Upsert(ctx, gitserverRepo); err == nil {
 		t.Fatal("Expected an error")
 	}
 }
@@ -770,7 +770,7 @@ func TestGitserverRepoUpsert(t *testing.T) {
 		t.Skip()
 	}
 
-	db := dbtest.NewDB(t)
+	db := NewDB(dbtest.NewDB(t))
 	ctx := context.Background()
 
 	// Create one test repo
@@ -785,10 +785,10 @@ func TestGitserverRepoUpsert(t *testing.T) {
 
 	// Change clone status
 	gitserverRepo.CloneStatus = types.CloneStatusCloned
-	if err := GitserverRepos(db).Upsert(ctx, gitserverRepo); err != nil {
+	if err := db.GitserverRepos().Upsert(ctx, gitserverRepo); err != nil {
 		t.Fatal(err)
 	}
-	fromDB, err := GitserverRepos(db).GetByID(ctx, repo.ID)
+	fromDB, err := db.GitserverRepos().GetByID(ctx, repo.ID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -802,10 +802,10 @@ func TestGitserverRepoUpsert(t *testing.T) {
 	// column. See https://stackoverflow.com/a/38008565/1773961 on how to set null terminated
 	// strings in Go.
 	gitserverRepo.LastError = "Oops\x00"
-	if err := GitserverRepos(db).Upsert(ctx, gitserverRepo); err != nil {
+	if err := db.GitserverRepos().Upsert(ctx, gitserverRepo); err != nil {
 		t.Fatal(err)
 	}
-	fromDB, err = GitserverRepos(db).GetByID(ctx, repo.ID)
+	fromDB, err = db.GitserverRepos().GetByID(ctx, repo.ID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -819,10 +819,10 @@ func TestGitserverRepoUpsert(t *testing.T) {
 
 	// Remove error
 	gitserverRepo.LastError = ""
-	if err := GitserverRepos(db).Upsert(ctx, gitserverRepo); err != nil {
+	if err := db.GitserverRepos().Upsert(ctx, gitserverRepo); err != nil {
 		t.Fatal(err)
 	}
-	fromDB, err = GitserverRepos(db).GetByID(ctx, repo.ID)
+	fromDB, err = db.GitserverRepos().GetByID(ctx, repo.ID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -836,7 +836,7 @@ func TestGitserverRepoUpsertMany(t *testing.T) {
 		t.Skip()
 	}
 
-	db := dbtest.NewDB(t)
+	db := NewDB(dbtest.NewDB(t))
 	ctx := context.Background()
 
 	// Create two test repos
@@ -860,13 +860,13 @@ func TestGitserverRepoUpsertMany(t *testing.T) {
 	// Change their clone statuses
 	gitserverRepo1.CloneStatus = types.CloneStatusCloned
 	gitserverRepo2.CloneStatus = types.CloneStatusCloning
-	if err := GitserverRepos(db).Upsert(ctx, gitserverRepo1, gitserverRepo2); err != nil {
+	if err := db.GitserverRepos().Upsert(ctx, gitserverRepo1, gitserverRepo2); err != nil {
 		t.Fatal(err)
 	}
 
 	// Confirm
 	t.Run("repo1", func(t *testing.T) {
-		fromDB, err := GitserverRepos(db).GetByID(ctx, repo1.ID)
+		fromDB, err := db.GitserverRepos().GetByID(ctx, repo1.ID)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -875,7 +875,7 @@ func TestGitserverRepoUpsertMany(t *testing.T) {
 		}
 	})
 	t.Run("repo2", func(t *testing.T) {
-		fromDB, err := GitserverRepos(db).GetByID(ctx, repo2.ID)
+		fromDB, err := db.GitserverRepos().GetByID(ctx, repo2.ID)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -905,7 +905,7 @@ func TestGitserverRepoListReposWithoutSize(t *testing.T) {
 		t.Skip()
 	}
 
-	db := dbtest.NewDB(t)
+	db := NewDB(dbtest.NewDB(t))
 	ctx := context.Background()
 
 	// Create one test repo
@@ -918,17 +918,17 @@ func TestGitserverRepoListReposWithoutSize(t *testing.T) {
 	})
 
 	// Create one GitServerRepo without repo_size_bytes
-	if err := GitserverRepos(db).Upsert(ctx, gitserverRepo); err != nil {
+	if err := db.GitserverRepos().Upsert(ctx, gitserverRepo); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := db.Exec(fmt.Sprintf(
+	if _, err := db.Handle().DB().ExecContext(ctx, fmt.Sprintf(
 		`update gitserver_repos set repo_size_bytes = null where repo_id = %d;`,
 		gitserverRepo.RepoID)); err != nil {
 		t.Fatalf("unexpected error while updating gitserver repo: %s", err)
 	}
 
 	// Get it back from the db
-	fromDB, err := GitserverRepos(db).GetByID(ctx, repo.ID)
+	fromDB, err := db.GitserverRepos().GetByID(ctx, repo.ID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -938,7 +938,7 @@ func TestGitserverRepoListReposWithoutSize(t *testing.T) {
 	}
 
 	// Check that this repo is returned from ListReposWithoutSize
-	if reposWithoutSize, err := GitserverRepos(db).ListReposWithoutSize(ctx); err != nil {
+	if reposWithoutSize, err := db.GitserverRepos().ListReposWithoutSize(ctx); err != nil {
 		t.Fatal(err)
 	} else if len(reposWithoutSize) != 1 {
 		t.Fatal("One repo without size should be returned")
@@ -946,12 +946,12 @@ func TestGitserverRepoListReposWithoutSize(t *testing.T) {
 
 	// Setting the size
 	gitserverRepo.RepoSizeBytes = 4040
-	if err := GitserverRepos(db).Upsert(ctx, gitserverRepo); err != nil {
+	if err := db.GitserverRepos().Upsert(ctx, gitserverRepo); err != nil {
 		t.Fatal(err)
 	}
 
 	// Check that this repo is not returned now from ListReposWithoutSize
-	if reposWithoutSize, err := GitserverRepos(db).ListReposWithoutSize(ctx); err != nil {
+	if reposWithoutSize, err := db.GitserverRepos().ListReposWithoutSize(ctx); err != nil {
 		t.Fatal(err)
 	} else if len(reposWithoutSize) != 0 {
 		t.Fatal("There should be no repos without size")
@@ -968,7 +968,7 @@ func TestGitserverUpdateRepoSizes(t *testing.T) {
 		t.Skip()
 	}
 
-	db := dbtest.NewDB(t)
+	db := NewDB(dbtest.NewDB(t))
 	ctx := context.Background()
 
 	repo1, gitserverRepo1 := createTestRepo(ctx, t, db, &createTestRepoPayload{
@@ -992,7 +992,7 @@ func TestGitserverUpdateRepoSizes(t *testing.T) {
 		repo1.ID: 100,
 		repo2.ID: 500,
 	}
-	if err := GitserverRepos(db).UpdateRepoSizes(ctx, shardID, sizes); err != nil {
+	if err := db.GitserverRepos().UpdateRepoSizes(ctx, shardID, sizes); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1002,7 +1002,7 @@ func TestGitserverUpdateRepoSizes(t *testing.T) {
 
 	// Checking repo diffs, excluding UpdatedAt. This is to verify that nothing except repo_size_bytes
 	// has changed
-	after1, err := GitserverRepos(db).GetByID(ctx, repo1.ID)
+	after1, err := db.GitserverRepos().GetByID(ctx, repo1.ID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1010,7 +1010,7 @@ func TestGitserverUpdateRepoSizes(t *testing.T) {
 		t.Fatal(diff)
 	}
 
-	after2, err := GitserverRepos(db).GetByID(ctx, repo2.ID)
+	after2, err := db.GitserverRepos().GetByID(ctx, repo2.ID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1019,7 +1019,7 @@ func TestGitserverUpdateRepoSizes(t *testing.T) {
 	}
 }
 
-func createTestRepo(ctx context.Context, t *testing.T, db dbutil.DB, payload *createTestRepoPayload) (*types.Repo, *types.GitserverRepo) {
+func createTestRepo(ctx context.Context, t *testing.T, db DB, payload *createTestRepoPayload) (*types.Repo, *types.GitserverRepo) {
 	t.Helper()
 
 	repo := &types.Repo{
@@ -1042,12 +1042,12 @@ func createTestRepo(ctx context.Context, t *testing.T, db dbutil.DB, payload *cr
 	}
 
 	// Create GitServerRepo
-	if err := GitserverRepos(db).Upsert(ctx, gitserverRepo); err != nil {
+	if err := db.GitserverRepos().Upsert(ctx, gitserverRepo); err != nil {
 		t.Fatal(err)
 	}
 
 	// Get it back and check whether it is not corrupted
-	fromDB, err := GitserverRepos(db).GetByID(ctx, gitserverRepo.RepoID)
+	fromDB, err := db.GitserverRepos().GetByID(ctx, gitserverRepo.RepoID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1107,7 +1107,7 @@ func createTestGitserverRepos(ctx context.Context, t *testing.T, db DB, hasLastE
 	if hasLastError {
 		gitserverRepo.LastError = "an error occurred"
 	}
-	if err := GitserverRepos(db).Upsert(ctx, gitserverRepo); err != nil {
+	if err := db.GitserverRepos().Upsert(ctx, gitserverRepo); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/internal/database/namespaces.go
+++ b/internal/database/namespaces.go
@@ -7,7 +7,6 @@ import (
 	"github.com/keegancsmith/sqlf"
 
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
@@ -41,12 +40,7 @@ type namespaceStore struct {
 	*basestore.Store
 }
 
-// Namespaces instantiates and returns a new NamespaceStore with prepared statements.
-func Namespaces(db dbutil.DB) NamespaceStore {
-	return &namespaceStore{Store: basestore.NewWithDB(db, sql.TxOptions{})}
-}
-
-// NewNamespaceStoreWithDB instantiates and returns a new NamespaceStore using the other store handle.
+// NamespacesWith instantiates and returns a new NamespaceStore using the other store handle.
 func NamespacesWith(other basestore.ShareableStore) NamespaceStore {
 	return &namespaceStore{Store: basestore.NewWithHandle(other.Handle())}
 }

--- a/internal/database/namespaces_test.go
+++ b/internal/database/namespaces_test.go
@@ -13,7 +13,7 @@ func TestNamespaces(t *testing.T) {
 		t.Skip()
 	}
 	t.Parallel()
-	db := dbtest.NewDB(t)
+	db := NewDB(dbtest.NewDB(t))
 	ctx := context.Background()
 
 	// Create user and organization to test lookups.
@@ -28,7 +28,7 @@ func TestNamespaces(t *testing.T) {
 
 	t.Run("GetByID", func(t *testing.T) {
 		t.Run("no ID", func(t *testing.T) {
-			ns, err := Namespaces(db).GetByID(ctx, 0, 0)
+			ns, err := db.Namespaces().GetByID(ctx, 0, 0)
 			if ns != nil {
 				t.Errorf("unexpected non-nil namespace: %v", ns)
 			}
@@ -38,7 +38,7 @@ func TestNamespaces(t *testing.T) {
 		})
 
 		t.Run("multiple IDs", func(t *testing.T) {
-			ns, err := Namespaces(db).GetByID(ctx, 123, 456)
+			ns, err := db.Namespaces().GetByID(ctx, 123, 456)
 			if ns != nil {
 				t.Errorf("unexpected non-nil namespace: %v", ns)
 			}
@@ -48,7 +48,7 @@ func TestNamespaces(t *testing.T) {
 		})
 
 		t.Run("user not found", func(t *testing.T) {
-			ns, err := Namespaces(db).GetByID(ctx, user.ID+1, 0)
+			ns, err := db.Namespaces().GetByID(ctx, user.ID+1, 0)
 			if ns != nil {
 				t.Errorf("unexpected non-nil namespace: %v", ns)
 			}
@@ -58,7 +58,7 @@ func TestNamespaces(t *testing.T) {
 		})
 
 		t.Run("organization not found", func(t *testing.T) {
-			ns, err := Namespaces(db).GetByID(ctx, 0, org.ID+1)
+			ns, err := db.Namespaces().GetByID(ctx, 0, org.ID+1)
 			if ns != nil {
 				t.Errorf("unexpected non-nil namespace: %v", ns)
 			}
@@ -68,7 +68,7 @@ func TestNamespaces(t *testing.T) {
 		})
 
 		t.Run("user", func(t *testing.T) {
-			ns, err := Namespaces(db).GetByID(ctx, 0, user.ID)
+			ns, err := db.Namespaces().GetByID(ctx, 0, user.ID)
 			if err != nil {
 				t.Errorf("unexpected non-nil error: %v", err)
 			}
@@ -78,7 +78,7 @@ func TestNamespaces(t *testing.T) {
 		})
 
 		t.Run("organization", func(t *testing.T) {
-			ns, err := Namespaces(db).GetByID(ctx, org.ID, 0)
+			ns, err := db.Namespaces().GetByID(ctx, org.ID, 0)
 			if err != nil {
 				t.Errorf("unexpected non-nil error: %v", err)
 			}
@@ -90,7 +90,7 @@ func TestNamespaces(t *testing.T) {
 
 	t.Run("GetByName", func(t *testing.T) {
 		t.Run("user", func(t *testing.T) {
-			ns, err := Namespaces(db).GetByName(ctx, "Alice")
+			ns, err := db.Namespaces().GetByName(ctx, "Alice")
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -99,7 +99,7 @@ func TestNamespaces(t *testing.T) {
 			}
 		})
 		t.Run("organization", func(t *testing.T) {
-			ns, err := Namespaces(db).GetByName(ctx, "acme")
+			ns, err := db.Namespaces().GetByName(ctx, "acme")
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -108,7 +108,7 @@ func TestNamespaces(t *testing.T) {
 			}
 		})
 		t.Run("not found", func(t *testing.T) {
-			if _, err := Namespaces(db).GetByName(ctx, "doesntexist"); err != ErrNamespaceNotFound {
+			if _, err := db.Namespaces().GetByName(ctx, "doesntexist"); err != ErrNamespaceNotFound {
 				t.Fatal(err)
 			}
 		})

--- a/internal/database/repos_db_test.go
+++ b/internal/database/repos_db_test.go
@@ -85,7 +85,7 @@ func mustCreateGitserverRepo(ctx context.Context, t *testing.T, db DB, repo *typ
 	}
 
 	// Add a row in gitserver_repos
-	if err := GitserverRepos(db).Upsert(ctx, &gitserver); err != nil {
+	if err := db.GitserverRepos().Upsert(ctx, &gitserver); err != nil {
 		t.Fatal(err)
 	}
 
@@ -663,7 +663,7 @@ func TestRepos_List_FailedSync(t *testing.T) {
 	assertCount(t, ReposListOptions{FailedFetch: true}, 0)
 
 	repo := created[0]
-	if err := GitserverRepos(db).SetLastError(ctx, repo.Name, "Oops", "test"); err != nil {
+	if err := db.GitserverRepos().SetLastError(ctx, repo.Name, "Oops", "test"); err != nil {
 		t.Fatal(err)
 	}
 	assertCount(t, ReposListOptions{}, 1)

--- a/internal/database/repos_test.go
+++ b/internal/database/repos_test.go
@@ -570,7 +570,7 @@ func TestRepoStore_Metadata(t *testing.T) {
 		},
 	}
 
-	gr := GitserverRepos(db)
+	gr := db.GitserverRepos()
 	require.NoError(t, gr.Upsert(ctx, gitserverRepos...))
 
 	expected := []*types.SearchedRepo{

--- a/internal/repos/status_messages_test.go
+++ b/internal/repos/status_messages_test.go
@@ -264,7 +264,7 @@ func TestStatusMessages(t *testing.T) {
 				if tc.gitserverFailure != nil && tc.gitserverFailure[toClone] {
 					lastError = "Oops"
 				}
-				err := database.GitserverRepos(db).Upsert(ctx, &types.GitserverRepo{
+				err := db.GitserverRepos().Upsert(ctx, &types.GitserverRepo{
 					RepoID:      id,
 					ShardID:     "test",
 					CloneStatus: types.CloneStatusCloned,

--- a/internal/repos/store.go
+++ b/internal/repos/store.go
@@ -127,7 +127,7 @@ func (s *store) RepoStore() database.RepoStore {
 }
 
 func (s *store) GitserverReposStore() database.GitserverRepoStore {
-	return database.NewGitserverReposWith(s)
+	return database.GitserverReposWith(s)
 }
 
 func (s *store) ExternalServiceStore() database.ExternalServiceStore {


### PR DESCRIPTION
Remove a few dbutil-based constructors in our database package, as they are not mockable in our tests.

This is the result of a time-boxed effort.

## Test plan

Unit tests

---

Part of https://github.com/sourcegraph/sourcegraph/issues/26113