### PR TITLE
Fix: Use Typography.H3 instead of native HTML element h3

### DIFF
--- a/client/web/src/enterprise/insights/components/modals/ShareLinkModal/ShareLinkModal.tsx
+++ b/client/web/src/enterprise/insights/components/modals/ShareLinkModal/ShareLinkModal.tsx
@@ -5,7 +5,7 @@ import classNames from 'classnames'
 import { noop } from 'lodash'
 
 import { ErrorAlert } from '@sourcegraph/branded/src/components/alerts'
-import { Badge, Button, Input, LoadingSpinner, Modal, ModalProps } from '@sourcegraph/wildcard'
+import { Badge, Button, Input, LoadingSpinner, Modal, ModalProps, Typography } from '@sourcegraph/wildcard'
 
 import { GetSharableInsightInfoResult } from '../../../../../graphql-operations'
 import {
@@ -49,7 +49,7 @@ export const ShareLinkModal: FunctionComponent<ShareLinkModalProps> = props => {
 
     return (
         <Modal className={classNames(styles.container)} {...attributes} isOpen={isOpen} onDismiss={onDismiss}>
-            <h3>Get shareable link</h3>
+            <Typography.H3>Get shareable link</Typography.H3>
 
             <ShareLinkModalContent insight={insight} dashboards={dashboards} />
 


### PR DESCRIPTION
Follow up for https://github.com/sourcegraph/sourcegraph/pull/35441#issuecomment-1129691856

## Test plan
- Make sure that CI doesn't have any lint problems

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vk-fix-main-use-typography.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-wctpdxgjdg.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
