### PR TITLE
Code Insights: [GQL API] Add first naive version of new GQL Code Insights API

### DIFF
--- a/client/web/src/enterprise/insights/new-insights-gql-examples.ts
+++ b/client/web/src/enterprise/insights/new-insights-gql-examples.ts
@@ -1,0 +1,147 @@
+import { gql } from '@apollo/client';
+
+/**
+ * This query will run when we open the dashboard page
+ * At mount of this page we don't need insight data because it will be loaded
+ * later on demands (by lazy fetching or based on virtual scrolling parameters)
+ *
+ * In this query we load only vital information for insight card with loading state
+ * all other fields/info will be loaded later.
+ */
+export const GET_INSIGHT_CONFIGURATIONS = gql`
+    query GetInsightConfiguration {
+        newInsights {
+            nodes {
+                id
+                title
+                isFrozen
+                filters
+
+                configuration {
+                    ... on SearchBasedInsightConfiguration {
+                        series {
+                            id
+                            title
+                            visualSettings {
+                                color
+                            }
+                        }
+                    }
+
+                   # All other insight types don't have important
+                   # settings for the dashboard page mount
+                }
+            }
+        }
+    }
+`
+
+/**
+ * This query is used when we want to load data for particular insight
+ * on the dashboard or standalone insight pages. As you can see we do
+ * not load anything about insight configuration but fetch insight data
+ * (lines, categories, ...etc)
+ */
+export const GET_INSIGHT_DATA = gql`
+    query GetInsightData($id: ID! $filters: NewInsightFilters) {
+        newInsights(id: $id, filters: $filters) {
+            nodes {
+                id
+
+                # Since we're carrying only about insight data here
+                # we use data separation here SeriesLikeInsight and
+                # CategoricalLikeInsight interfaces
+                configuration {
+                    ... on SeriesLikeInsight {
+                        series {
+                            id
+                            title
+                            status {
+                                pendingJobs
+                                backfillQueuedAt
+                            }
+                            points {
+                                value
+                                dateTime
+                            }
+                            visualSettings {
+                                color
+                                chartType
+                                pattern
+                            }
+                        }
+                    }
+
+                    ... on CategoricalLikeInsight {
+                        data {
+                            value
+                            title
+                            color
+                            link
+                        }
+                    }
+                }
+            }
+        }
+    }
+`
+
+/**
+ * This query is used for the EDIT UI pages, it contains only insight
+ * configuration and all top level base information that is required for
+ * the edit UI.
+ */
+export const GET_INSIGHT_EDIT_INFORMATION = gql`
+    query GetInsightEditInformation {
+        newInsights {
+            nodes {
+                id
+                title
+                dashboards {
+                    nodes {
+                        id
+                        title
+                    }
+                }
+
+                # Here we use insight type separation because this is
+                # how we separate insight in the product so it makes sense
+                # to separate them in a similar way in API for consumers
+                # As you can see there is no FE/consumer mapping here between
+                # insight series and its configuration
+                configuration {
+                    ... on SearchBasedInsightConfiguration {
+                        series {
+                            id
+                            title
+                            query
+                            repositoryScope {
+                                repositories
+                            }
+                            timeScope
+                            visualSettings {
+                                color
+                                chartType
+                            }
+                        }
+                    }
+
+                    ... on CaptureGroupInsightConfiguration {
+                        query
+                        repositories
+                        timeScope
+                    }
+
+                    ... on LangStatsInsightConfiguration {
+                        otherThreshold
+                        repositories
+                    }
+                }
+            }
+        }
+    }
+`
+
+// Mutation examples is kind of straightforward, so I assume that the
+// examples of GQL schema would be enough to understand my proposal
+

--- a/client/web/src/enterprise/insights/new-insights-gql-examples.ts
+++ b/client/web/src/enterprise/insights/new-insights-gql-examples.ts
@@ -17,8 +17,8 @@ export const GET_INSIGHT_CONFIGURATIONS = gql`
                 isFrozen
                 filters
 
-                configuration {
-                    ... on SearchBasedInsightConfiguration {
+                data {
+                    ... on SearchBasedInsightInfo {
                         series {
                             id
                             title
@@ -28,8 +28,8 @@ export const GET_INSIGHT_CONFIGURATIONS = gql`
                         }
                     }
 
-                   # All other insight types don't have important
-                   # settings for the dashboard page mount
+                    # All other insight types don't have important
+                    # settings for the dashboard page mount
                 }
             }
         }
@@ -51,8 +51,8 @@ export const GET_INSIGHT_DATA = gql`
                 # Since we're carrying only about insight data here
                 # we use data separation here SeriesLikeInsight and
                 # CategoricalLikeInsight interfaces
-                configuration {
-                    ... on SeriesLikeInsight {
+                data {
+                    ... on SeriesLikeData {
                         series {
                             id
                             title
@@ -72,8 +72,8 @@ export const GET_INSIGHT_DATA = gql`
                         }
                     }
 
-                    ... on CategoricalLikeInsight {
-                        data {
+                    ... on CategoricalLikeData {
+                        categories {
                             value
                             title
                             color
@@ -109,8 +109,8 @@ export const GET_INSIGHT_EDIT_INFORMATION = gql`
                 # to separate them in a similar way in API for consumers
                 # As you can see there is no FE/consumer mapping here between
                 # insight series and its configuration
-                configuration {
-                    ... on SearchBasedInsightConfiguration {
+                data {
+                    ... on SearchBasedInsightInfo {
                         series {
                             id
                             title
@@ -126,13 +126,13 @@ export const GET_INSIGHT_EDIT_INFORMATION = gql`
                         }
                     }
 
-                    ... on CaptureGroupInsightConfiguration {
+                    ... on CaptureGroupInsightInfo {
                         query
                         repositories
                         timeScope
                     }
 
-                    ... on LangStatsInsightConfiguration {
+                    ... on LangStatsInsightInfo {
                         otherThreshold
                         repositories
                     }

--- a/cmd/frontend/graphqlbackend/new-insights.graphql
+++ b/cmd/frontend/graphqlbackend/new-insights.graphql
@@ -1,0 +1,158 @@
+
+extend type Query {
+    newInsights(
+        id: ID
+        first: Int
+        after: String
+        filters: NewInsightViewFiltersInput
+    ): NewInsightConnection
+}
+
+
+type NewInsightConnection {
+    nodes: [NewInsight!]!
+    totalCount: Int!
+    pageInfo: PageInfo!
+}
+
+union NewInsight = SeriesLikeInsight | CategoricalLikeInsight
+
+# ---------- Base Insight types ----------- #
+interface BaseInsight {
+    id: ID!
+    title: String!
+    isFrozen: Boolean!
+    defaultFilters: NewInsightFilters
+    appliedFilters: NewInsightFilters!
+    dashboards(id: ID, first: Int, after: String): InsightsDashboardConnection
+}
+
+type NewInsightFilters {
+    includeRepoRegex: String
+    excludeRepoRegex: String
+    searchContexts: SearchContextConnection
+}
+
+# --------- Series-like insight types -------------- #
+type SeriesLikeInsight implements BaseInsight & Node {
+    id: ID!
+    title: String!
+    isFrozen: Boolean!
+    defaultFilters: NewInsightFilters
+    appliedFilters: NewInsightFilters!
+    dashboards(id: ID, first: Int, after: String): InsightsDashboardConnection
+    series: [NewInsightSeries!]!
+}
+
+type NewInsightSeries implements Node {
+    id: ID!
+    title: String!
+    color: String!
+    query: String!
+    chartType: SeriesLikeChartType
+    repositoryScope: InsightRepositoryScope!
+    timeScope: InsightTimeScope!
+    isGenerated: Boolean!
+    status: NewInsightSeriesStatus
+    points(from: DateTime, to: DateTime): [NewInsightDataPoint!]!
+}
+
+enum SeriesLikeChartType {
+    LINE
+    BAR
+}
+
+type NewInsightDataPoint {
+    dateTime: DateTime!
+    value: Float!
+}
+
+type NewInsightSeriesStatus {
+    totalPoints: Int!
+    pendingJobs: Int!
+    completedJobs: Int!
+    failedJobs: Int!
+    backfillQueuedAt: DateTime
+}
+
+# ----------- Categorical like insight ------------ #
+type CategoricalLikeInsight implements BaseInsight & Node {
+    id: ID!
+    title: String!
+    isFrozen: Boolean!
+    defaultFilters: NewInsightFilters
+    appliedFilters: NewInsightFilters!
+    dashboards(id: ID, first: Int, after: String): InsightsDashboardConnection
+    data: [NewInsightCategoricalDatum!]!
+    otherThreshold: Float!
+    chartType: CategoricalLikeChartTYpe
+}
+
+type NewInsightCategoricalDatum {
+    value: Float!
+    title: String!
+    color: String!
+    link: String!
+}
+
+enum CategoricalLikeChartTYpe {
+    PIE
+    BAR
+    SCATTERPLOT
+    BUBBLE
+}
+
+
+# ----------- Insight mutations ------------- #
+extend type Mutation {
+    createSearchInsight(input: SearchInsightInput): SeriesLikeInsight
+    createCaptureGroupInsight(input: CaptureGroupInsightInput): SeriesLikeInsight
+    createLangStatsInsight(input: LangStatsInsightInput): CategoricalLikeInsight
+
+    updateSearchBasedInsight(input: SearchInsightInput): SeriesLikeInsight
+    updateCaptureGroupInsight(input: CaptureGroupInsightInput): SeriesLikeInsight
+    updateLangStatsInsight(input: LangStatsInsightInput): CategoricalLikeInsight
+
+    deleteInsight(id: ID!): EmptyResponse!
+}
+
+# ----------- Search based insight input types ---------- #
+input SearchInsightInput {
+    title: String!
+    dashboards: [ID!]
+    filters: NewInsightViewFiltersInput!
+    series: [SearchInsightSeriesInput!]!
+}
+
+input SearchInsightSeriesInput {
+    id: ID
+    query: String!
+    title: String!
+    color: String!
+    repositoryScope: RepositoryScopeInput!
+    timeScope: TimeScopeInput!
+}
+
+input NewInsightViewFiltersInput {
+    includeRepoRegex: String
+    excludeRepoRegex: String
+    searchContexts: [ID!]
+}
+
+# ----------- Capture group insight input types ---------- #
+input CaptureGroupInsightInput {
+    title: String!
+    dashboards: [ID!]
+    filters: NewInsightViewFiltersInput!
+    query: String!
+    repositoryScope: RepositoryScopeInput!
+    timeScope: TimeScopeInput!
+}
+
+# ------------ LangStats insight input types ------------ #
+input LangStatsInsightInput {
+    title: String!
+    otherThreshold: Float!
+    repositoryScope: RepositoryScopeInput!
+    dashboards: [ID!]
+}

--- a/cmd/frontend/graphqlbackend/new-insights.graphql
+++ b/cmd/frontend/graphqlbackend/new-insights.graphql
@@ -39,14 +39,27 @@ union BaseInsightConfiguration =
     CaptureGroupInsightConfiguration |
     LangStatsInsightConfiguration
 
+# These two (SeriesLikeInsight and CategoricalLikeInsight) are
+# kind of synthetic interfaces that we introduce in order to
+# simplify data querying in consumers.
+#
+# See client/web/src/enterprise/insights/new-insights-gql-examples.ts
+interface SeriesLikeInsight {
+    series: [NewInsightSeries!]!
+}
+
+interface CategoricalLikeInsight {
+    data: [NewInsightCategoricalDatum!]!
+}
+
 # --------- Insight configurations  ------------ #
-type SearchBasedInsightConfiguration {
+type SearchBasedInsightConfiguration implements SeriesLikeInsight {
     # All important to the edit UI (insight configurations) for Search-Based
     # insight fields are contained inside of series.
     series: [NewInsightSeries!]!
 }
 
-type CaptureGroupInsightConfiguration {
+type CaptureGroupInsightConfiguration implements SeriesLikeInsight {
     # In Capture Group insight there is no a performant way to get
     # insight configuration from series because series here are generated
     # so we have to extract vital settings from the series.
@@ -56,7 +69,7 @@ type CaptureGroupInsightConfiguration {
     series: [NewInsightSeries!]!
 }
 
-type LangStatsInsightConfiguration {
+type LangStatsInsightConfiguration implements CategoricalLikeInsight {
     # Since Lang Stats insight as any other insights doesn't have series
     # we provide setting data on the top level.
     repositories: [String!]!
@@ -73,9 +86,9 @@ type SeriesLikeInsightData {
 type NewInsightSeries implements Node {
     id: ID!
     title: String!
-    color: String!
     query: String!
-    chartType: SeriesLikeChartType
+
+    visualSettings: NewInsightSeriesVisualSettings!
     repositoryScope: InsightRepositoryScope!
     timeScope: InsightTimeScope!
     # this is true when series generated on the backend in query time

--- a/cmd/frontend/graphqlbackend/new-insights.graphql
+++ b/cmd/frontend/graphqlbackend/new-insights.graphql
@@ -17,15 +17,15 @@ type NewInsightConnection {
 
 # ---------- Base Insight types ----------- #
 interface BaseInsight {
+    # id title and all other shared across all insights fields
     id: ID!
-    # title and all other shared across all insight fields
     title: String!
     isFrozen: Boolean!
     filters: NewInsightFilters
     dashboards(id: ID, first: Int, after: String): InsightsDashboardConnection
 
-    # Insight-define information
-    configuration: BaseInsightConfiguration!
+    # Specific info based on insight and data types
+    data: BaseInsightInfo!
 }
 
 type NewInsightFilters {
@@ -34,32 +34,38 @@ type NewInsightFilters {
     searchContexts: SearchContextConnection
 }
 
-union BaseInsightConfiguration =
-    SearchBasedInsightConfiguration |
-    CaptureGroupInsightConfiguration |
-    LangStatsInsightConfiguration
+union BaseInsightInfo =
+    SearchBasedInsightInfo |
+    CaptureGroupInsightInfo |
+    LangStatsInsightInfo
 
 # These two (SeriesLikeInsight and CategoricalLikeInsight) are
 # kind of synthetic interfaces that we introduce in order to
 # simplify data querying in consumers.
 #
 # See client/web/src/enterprise/insights/new-insights-gql-examples.ts
-interface SeriesLikeInsight {
+interface SeriesLikeData {
+    # Standard list of series (data that represent moving over time)
     series: [NewInsightSeries!]!
+
+    # Additional series API that provides snapshots for all series in
+    # a particular moment of time
+    seriesSlice(x: DateTime!): [NewInsightCategoricalDatum!]
 }
 
-interface CategoricalLikeInsight {
-    data: [NewInsightCategoricalDatum!]!
+interface CategoricalLikeData {
+    categories: [NewInsightCategoricalDatum!]!
 }
 
 # --------- Insight configurations  ------------ #
-type SearchBasedInsightConfiguration implements SeriesLikeInsight {
+type SearchBasedInsightInfo implements SeriesLikeData {
     # All important to the edit UI (insight configurations) for Search-Based
     # insight fields are contained inside of series.
     series: [NewInsightSeries!]!
+    seriesSlice(x: DateTime!): [NewInsightCategoricalDatum!]
 }
 
-type CaptureGroupInsightConfiguration implements SeriesLikeInsight {
+type CaptureGroupInsightInfo implements SeriesLikeData {
     # In Capture Group insight there is no a performant way to get
     # insight configuration from series because series here are generated
     # so we have to extract vital settings from the series.
@@ -67,15 +73,16 @@ type CaptureGroupInsightConfiguration implements SeriesLikeInsight {
     repositories: [String!]!
     timeScope: InsightTimeScope!
     series: [NewInsightSeries!]!
+    seriesSlice(x: DateTime!): [NewInsightCategoricalDatum!]
 }
 
-type LangStatsInsightConfiguration implements CategoricalLikeInsight {
+type LangStatsInsightInfo implements CategoricalLikeData {
     # Since Lang Stats insight as any other insights doesn't have series
     # we provide setting data on the top level.
     repositories: [String!]!
     otherThreshold: Float!
     chartType: CategoricalLikeChartTYpe
-    data: [NewInsightCategoricalDatum!]!
+    categories: [NewInsightCategoricalDatum!]!
 }
 
 # --------- Series-like data types -------------- #
@@ -87,7 +94,6 @@ type NewInsightSeries implements Node {
     id: ID!
     title: String!
     query: String!
-
     visualSettings: NewInsightSeriesVisualSettings!
     repositoryScope: InsightRepositoryScope!
     timeScope: InsightTimeScope!

--- a/cmd/frontend/graphqlbackend/new-insights.graphql
+++ b/cmd/frontend/graphqlbackend/new-insights.graphql
@@ -129,6 +129,7 @@ input SearchInsightSeriesInput {
     query: String!
     title: String!
     color: String!
+    chartType: SeriesLikeChartType
     repositoryScope: RepositoryScopeInput!
     timeScope: TimeScopeInput!
 }
@@ -145,6 +146,7 @@ input CaptureGroupInsightInput {
     dashboards: [ID!]
     filters: NewInsightViewFiltersInput!
     query: String!
+    chartType: SeriesLikeChartType
     repositoryScope: RepositoryScopeInput!
     timeScope: TimeScopeInput!
 }
@@ -153,6 +155,7 @@ input CaptureGroupInsightInput {
 input LangStatsInsightInput {
     title: String!
     otherThreshold: Float!
+    chartType: CategoricalLikeChartTYpe
     repositoryScope: RepositoryScopeInput!
     dashboards: [ID!]
 }

--- a/cmd/frontend/graphqlbackend/new-insights.graphql
+++ b/cmd/frontend/graphqlbackend/new-insights.graphql
@@ -10,21 +10,22 @@ extend type Query {
 
 
 type NewInsightConnection {
-    nodes: [NewInsight!]!
+    nodes: [BaseInsight!]!
     totalCount: Int!
     pageInfo: PageInfo!
 }
 
-union NewInsight = SeriesLikeInsight | CategoricalLikeInsight
-
 # ---------- Base Insight types ----------- #
 interface BaseInsight {
     id: ID!
+    # title and all other shared across all insight fields
     title: String!
     isFrozen: Boolean!
-    defaultFilters: NewInsightFilters
-    appliedFilters: NewInsightFilters!
+    filters: NewInsightFilters
     dashboards(id: ID, first: Int, after: String): InsightsDashboardConnection
+
+    # Insight-define information
+    configuration: BaseInsightConfiguration!
 }
 
 type NewInsightFilters {
@@ -33,14 +34,39 @@ type NewInsightFilters {
     searchContexts: SearchContextConnection
 }
 
-# --------- Series-like insight types -------------- #
-type SeriesLikeInsight implements BaseInsight & Node {
-    id: ID!
-    title: String!
-    isFrozen: Boolean!
-    defaultFilters: NewInsightFilters
-    appliedFilters: NewInsightFilters!
-    dashboards(id: ID, first: Int, after: String): InsightsDashboardConnection
+union BaseInsightConfiguration =
+    SearchBasedInsightConfiguration |
+    CaptureGroupInsightConfiguration |
+    LangStatsInsightConfiguration
+
+# --------- Insight configurations  ------------ #
+type SearchBasedInsightConfiguration {
+    # All important to the edit UI (insight configurations) for Search-Based
+    # insight fields are contained inside of series.
+    series: [NewInsightSeries!]!
+}
+
+type CaptureGroupInsightConfiguration {
+    # In Capture Group insight there is no a performant way to get
+    # insight configuration from series because series here are generated
+    # so we have to extract vital settings from the series.
+    query: String!
+    repositories: [String!]!
+    timeScope: InsightTimeScope!
+    series: [NewInsightSeries!]!
+}
+
+type LangStatsInsightConfiguration {
+    # Since Lang Stats insight as any other insights doesn't have series
+    # we provide setting data on the top level.
+    repositories: [String!]!
+    otherThreshold: Float!
+    chartType: CategoricalLikeChartTYpe
+    data: [NewInsightCategoricalDatum!]!
+}
+
+# --------- Series-like data types -------------- #
+type SeriesLikeInsightData {
     series: [NewInsightSeries!]!
 }
 
@@ -52,9 +78,22 @@ type NewInsightSeries implements Node {
     chartType: SeriesLikeChartType
     repositoryScope: InsightRepositoryScope!
     timeScope: InsightTimeScope!
+    # this is true when series generated on the backend in query time
+    # Capture group insight case
     isGenerated: Boolean!
     status: NewInsightSeriesStatus
     points(from: DateTime, to: DateTime): [NewInsightDataPoint!]!
+}
+
+type NewInsightSeriesVisualSettings {
+    color: String!
+    pattern: String
+    chartType: SeriesLikeChartType
+    border: String!
+    # ... any other visual settings here, as we found out chart type
+    # doesn't change set of settings for the series, the only that can
+    # change visual settings is data shape and for all series data shape
+    # is series-like (thought time)
 }
 
 enum SeriesLikeChartType {
@@ -75,19 +114,7 @@ type NewInsightSeriesStatus {
     backfillQueuedAt: DateTime
 }
 
-# ----------- Categorical like insight ------------ #
-type CategoricalLikeInsight implements BaseInsight & Node {
-    id: ID!
-    title: String!
-    isFrozen: Boolean!
-    defaultFilters: NewInsightFilters
-    appliedFilters: NewInsightFilters!
-    dashboards(id: ID, first: Int, after: String): InsightsDashboardConnection
-    data: [NewInsightCategoricalDatum!]!
-    otherThreshold: Float!
-    chartType: CategoricalLikeChartTYpe
-}
-
+# ----------- Categorical like data ------------ #
 type NewInsightCategoricalDatum {
     value: Float!
     title: String!
@@ -105,13 +132,13 @@ enum CategoricalLikeChartTYpe {
 
 # ----------- Insight mutations ------------- #
 extend type Mutation {
-    createSearchInsight(input: SearchInsightInput): SeriesLikeInsight
-    createCaptureGroupInsight(input: CaptureGroupInsightInput): SeriesLikeInsight
-    createLangStatsInsight(input: LangStatsInsightInput): CategoricalLikeInsight
+    createSearchInsight(input: SearchInsightInput): BaseInsight
+    createCaptureGroupInsight(input: CaptureGroupInsightInput): BaseInsight
+    createLangStatsInsight(input: LangStatsInsightInput): BaseInsight
 
-    updateSearchBasedInsight(input: SearchInsightInput): SeriesLikeInsight
-    updateCaptureGroupInsight(input: CaptureGroupInsightInput): SeriesLikeInsight
-    updateLangStatsInsight(input: LangStatsInsightInput): CategoricalLikeInsight
+    updateSearchBasedInsight(input: SearchInsightInput): BaseInsight
+    updateCaptureGroupInsight(input: CaptureGroupInsightInput): BaseInsight
+    updateLangStatsInsight(input: LangStatsInsightInput): BaseInsight
 
     deleteInsight(id: ID!): EmptyResponse!
 }
@@ -134,12 +161,6 @@ input SearchInsightSeriesInput {
     timeScope: TimeScopeInput!
 }
 
-input NewInsightViewFiltersInput {
-    includeRepoRegex: String
-    excludeRepoRegex: String
-    searchContexts: [ID!]
-}
-
 # ----------- Capture group insight input types ---------- #
 input CaptureGroupInsightInput {
     title: String!
@@ -158,4 +179,11 @@ input LangStatsInsightInput {
     chartType: CategoricalLikeChartTYpe
     repositoryScope: RepositoryScopeInput!
     dashboards: [ID!]
+    filters: NewInsightViewFiltersInput!
+}
+
+input NewInsightViewFiltersInput {
+    includeRepoRegex: String
+    excludeRepoRegex: String
+    searchContexts: [ID!]
 }


### PR DESCRIPTION
Related to https://github.com/sourcegraph/sourcegraph/issues/33933

# Background

I'm just trying to develop a more straightforward API than our existing one in this PR. By this I mean going away from chart type abstraction in our mutations (createLineChart, createBarChart, cratePieChart ...etc) and moving to mutation that are based on our domain insight model (create<SearchInsight | Capture group | Lang stats | ... > mutations) 

This PR aims to solve only the insight entity part in our GQL API. The dashboard model is outside of the scope of this PR. This should be used for informational purposes only and should not be used or merged anywhere in the backend codebase.

## Data types

So, in a nutshell, in this PR schema, I split all insights that we have into two categories 
- Series like (data that represents points through time) 
- Categorical like (data that doesn't have any timeline-like information and has a clear set of categories and their values) 

After that, we can express all possible insights that we currently have through those types. 
- Capture group insight - series-like
- Search based insight - series-like
- Lang stats insight - categorical like
- Compute? - categorical like 

If we need to add a new type of insight - let's say treemap we won't change anything about the existing API and extend our API with another type. See `NewInsight` union type in this PR schema. 

## Chart types

We can determine a set of visual settings for the insight model based on data types. This means that the data type determines the set of possible chart types. 

- Series-like data - line chart, bar chart
- Categorical-like data - pie chart, bar chart (but with ordinary x axis), bubble chart ...

By this, we force only possible chart types for insight data that we have in our API. For example, it doesn't make sense to have Pie Chart for series-like data. (In theory, we could introduce another presentation chart type as a series of pie chart snapshots, but this is out of this PR's scope) 

Another good thing is in this system, it is possible to have a strict set of chart type settings in GQL types because charts from one group should have the same amount of settings. [See related slack message about this](https://sourcegraph.slack.com/archives/C01RVEVPWLC/p1652855353130719)

**From this slack message**
> From my understanding, if we have data that goes through time (series-like data),
there is no difference between different chart types in terms of their visual settings.

> For example, if we have a line chart and we change it to a bar chart, then
- line colour becomes bar colour
- stacked line setting (when we stacked one line on another) becomes a stacked bar
- start from zero setting is also applicable for the bar (maybe not, not sure, maybe it always should be active for the bar chart)

> Same thing for categorical line chart? Let's say we change the pie chart to the bar chart
- pie arc colour becomes bar colour 
- ... something else?

Also, here is another issue in which we may want to introduce new chart/insight settings https://github.com/sourcegraph/sourcegraph/issues/33327

## Mutations

Well, here, things have been simplified dramatically. Data types and chart types are related to feature details and the settings world. 

The insight model itself comes from the domain model of our product. So I decided to pick this abstraction for the mutations rather than implement mutation with data-type and chart-type attributes because it makes more sense when creating entities and matches our domain better, for example.

We have different pages for each insight type (search-based, capture group, lang-stats), which means we have a clear separation between insight types, and this is good because each type has a different amount of domain settings. 

So mutations look like 
```gql
createSearchInsight(input: SearchInsightInput): SeriesLikeInsight
createCaptureGroupInsight(input: CaptureGroupInsightInput): SeriesLikeInsight
createLangStatsInsight(input: LangStatsInsightInput): CategoricalLikeInsight

updateSearchBasedInsight(input: SearchInsightInput): SeriesLikeInsight
updateCaptureGroupInsight(input: CaptureGroupInsightInput): SeriesLikeInsight
updateLangStatsInsight(input: LangStatsInsightInput): CategoricalLikeInsight
```

`SearchInsightInput`, `CaptureGroupInsightInput`, `LangStatsInsightInput` contain business and view logic, in output we have data-type models. 
