### PR TITLE
insights: fix bug where JIT capture groups return values only for 1 repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ All notable changes to Sourcegraph are documented in this file.
 - An issue causing search expressions to not work in conjunction with `type:symbol`. [#35126](https://github.com/sourcegraph/sourcegraph/pull/35126)
 - A non-descriptive error message that would be returned when using `on.repository` if it is not a valid repository path [#35023](https://github.com/sourcegraph/sourcegraph/pull/35023)
 - Reduced database load when viewing or previewing a batch change. [#35501](https://github.com/sourcegraph/sourcegraph/pull/35501)
+- Fixed a bug where Capture Group Code Insights generated just in time only returned data for the latest repository in the list. [#35624](https://github.com/sourcegraph/sourcegraph/pull/35624)
 
 ### Removed
 

--- a/enterprise/internal/insights/query/capture_group_executor.go
+++ b/enterprise/internal/insights/query/capture_group_executor.go
@@ -135,7 +135,7 @@ func (c *CaptureGroupExecutor) Execute(ctx context.Context, query string, reposi
 				if _, ok := pivoted[value]; !ok {
 					pivoted[value] = generateTimes(plan)
 				}
-				pivoted[value][execution.RecordingTime] = timeGroupElement.Count
+				pivoted[value][execution.RecordingTime] += timeGroupElement.Count
 				for _, children := range execution.SharedRecordings {
 					pivoted[value][children] += timeGroupElement.Count
 				}


### PR DESCRIPTION
closes #35602, see the issue for more details + findings.

When collating the data together for all repos we were re-initialising the pivoted value at each timestamp on each iteration, essentially only keeping the data for the last repo search. 

## Test plan
Tested manually by creating an insight and checking correctness, and checking the values returned by `GetInsightView` on the graphQL API.

1. Create a JIT capture group insight: https://sourcegraph.test:3443/insights/create/capture-group?dashboardId=all
2. The query I picked was `var\(--(color-bg-\d)\)` for ease of correctness checking. 
3. Add these repos: `github.com/sourcegraph/about, github.com/sourcegraph/sourcegraph, github.com/sourcegraph-testing/demo-sourcegraph` (add them in `dev-private/external-services-config.json` if required
4. Compare values to search queries
<img width="629" alt="image" src="https://user-images.githubusercontent.com/29406849/169018234-1e35e663-19cd-42f6-bc30-76aa751ee05d.png">
<img width="467" alt="image" src="https://user-images.githubusercontent.com/29406849/169018327-e8e48817-5fa8-4822-9d17-72d7d85de496.png">

If you run this locally you can see that for the individual queries and individual repos they are correct as well.

For GraphQL, the following query:
```
query GetInsightView($id: ID, $filters: InsightViewFiltersInput) {
  insightViews(id: $id, filters: $filters) {
    nodes {
      ...InsightDataNode
      __typename
    }
    __typename
  }
}

fragment InsightDataNode on InsightView {
  id
  dataSeries {
    ...InsightDataSeries
    __typename
  }
  __typename
}

fragment InsightDataSeries on InsightsSeries {
  seriesId
  label
  points {
    dateTime
    value
    __typename
  }
  status {
    backfillQueuedAt
    completedJobs
    pendingJobs
    failedJobs
    __typename
  }
  __typename
}
```
with the id of the insight you have just created, returns correct values as well.