### PR TITLE
codemirror: Fix search query syntax highlighting

### DIFF
--- a/client/search-ui/src/input/CodeMirrorQueryInput.module.scss
+++ b/client/search-ui/src/input/CodeMirrorQueryInput.module.scss
@@ -121,67 +121,164 @@
     }
 }
 
-.identifier,
-.metaStructuralVariable,
-.metaRevisionCommitHash,
-.metaRevisionLabel,
-.metaRevisionReferencePath {
+// Search query syntax highlighting
+
+// Base language tokens
+.identifier {
     color: var(--search-query-text-color);
 }
-
-.metaRevisionWildcard {
-    color: var(--oc-cyan-7);
-}
-
-.field,
-.metaRepoRevisionSeparator,
-.metaPredicateDot {
+.field {
     color: var(--search-filter-keyword-color);
 }
-
 .keyword,
 .openingParen,
-.closingParen,
+.closingParen {
+    color: var(--search-keyword-color);
+}
+.comment {
+    color: var(--oc-orange-9);
+}
+
+// Decorated language tokens
+.metaFilterSeparator {
+    color: var(--oc-gray-6);
+}
+.metaRepoRevisionSeparator {
+    color: var(--search-filter-keyword-color);
+}
 .metaContextPrefix,
 .metaPredicateNameAccess {
     color: var(--search-keyword-color);
 }
+.metaPredicateDot {
+    color: var(--search-query-text-color);
+}
+.metaPredicateParenthesis {
+    color: var(--oc-orange-9);
+}
 
+// Regexp pattern
 .metaRegexp {
+    &Delimited,
+    &Assertion,
+    &LazyQualifier {
+        color: var(--oc-red-9);
+    }
+
+    &EscapedCharacter {
+        color: var(--oc-orange-9);
+    }
+
     &CharacterSet,
     &CharacterClass,
     &CharacterClassRangeHyphen {
         color: var(--search-keyword-color);
     }
 
+    &CharacterClassMember,
+    &CharacterClassRange {
+        color: var(--search-query-text-color);
+    }
+
     &Alternative,
     &RangeQuantifier {
         color: var(--oc-cyan-7);
     }
+}
 
-    &Delimited,
-    &Assertion,
-    &LazyQualifier {
+// Structural pattern highlighting
+.metaStructural {
+    &Hole,
+    &RegexpHole {
         color: var(--oc-red-9);
+    }
+
+    &Variable {
+        color: var(--search-query-text-color);
+    }
+
+    &RegexpSeparator {
+        color: var(--oc-orange-9);
     }
 }
 
-.comment,
-.metaPredicateParenthesis,
-.metaRegexpEscapedCharacter,
-.metaStructuralRegexpSeparator,
-.metaRevisionSeparator {
-    color: var(--oc-orange-9);
+// Revision highlighting
+.metaRevision {
+    &Separator {
+        color: var(--oc-orange-9);
+    }
+
+    &IncludeGlobMarker,
+    &ExcludeGlobaMarker {
+        color: var(--oc-red-9);
+    }
+
+    &CommitHash,
+    &Label,
+    &ReferencePath {
+        color: var(--search-query-text-color);
+    }
+
+    &Wildcard {
+        color: var(--oc-cyan-7);
+    }
 }
 
-.metaFilterSeparator,
+// Path-like highlighting
 .metaPathSeparator {
     color: var(--oc-gray-6);
 }
 
-.metaStructuralHole,
-.metaStructuralRegexpHole,
-.metaRevisionIncludeGlobMarker,
-.metaRevisionExcludeGlobMarker {
-    color: var(--oc-red-9);
+:global(.theme-dark) {
+    .comment,
+    .metaPredicateParenthesis {
+        color: var(--oc-orange-4);
+    }
+
+    .metaRegexp {
+        &Delimited,
+        &Assertion,
+        &LazyQualifier {
+            color: var(--oc-red-5);
+        }
+
+        &EscapedCharacter {
+            color: var(--oc-red-3);
+        }
+
+        &CharacterClass {
+            color: var(--oc-grape-4);
+        }
+
+        &Alternative,
+        &RangeQuantifier {
+            color: var(--oc-cyan-4);
+        }
+    }
+
+    .metaStructural {
+        &Hole,
+        &RegexpHole {
+            color: var(--oc-red-5);
+        }
+
+        &RegexpSeparator {
+            color: var(--oc-orange-4);
+        }
+    }
+
+    .metaRevision {
+        &Separator {
+            color: var(--oc-orange-4);
+        }
+
+        &IncludeGlobMarker,
+        &ExcludeGlobaMarker {
+            color: var(--oc-red-5);
+        }
+
+        &Wildcard {
+            color: var(--oc-cyan-4);
+        }
+    }
 }


### PR DESCRIPTION
Fixes #35587 


I didn't port the colors correctly, especially the dark mode ones.

Instead of trying to consolidate the classes with the same color as much as possible I went through the [Monaco colors](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@1e03ba58adf43a31874f2c3f80ce897e14e4f848/-/blob/client/shared/src/components/MonacoEditor.tsx?L42-145) and mapped them 1:1.


## Test plan

Inspected regex syntax highlighting in dark mode.

![2022-05-18_14-39](https://user-images.githubusercontent.com/179026/169041540-403b2010-cdf2-4048-8d8c-3a37cd4d60c1.png)


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-fkling-35587-search-query-syntax.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-bwignyajtz.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
