### PR TITLE
search/query: guard against nil Pattern in PatternString

### DIFF
--- a/internal/search/query/types.go
+++ b/internal/search/query/types.go
@@ -265,6 +265,9 @@ func (b Basic) IsStructural() bool {
 // PatternString returns the simple string pattern of a basic query. It assumes
 // there is only on pattern atom.
 func (b Basic) PatternString() string {
+	if b.Pattern == nil {
+		return ""
+	}
 	if p, ok := b.Pattern.(Pattern); ok {
 		if b.IsLiteral() {
 			// Escape regexp meta characters if this pattern should be treated literally.


### PR DESCRIPTION
I noticed this while reading the code. I don't know if this can happen in practice, but we gaurd against nil everywhere else.

Test Plan: CI