### PR TITLE
migration: add a trigger to repo table to insert gitserver_repo

### DIFF
--- a/cmd/gitserver/server/cleanup_test.go
+++ b/cmd/gitserver/server/cleanup_test.go
@@ -67,8 +67,8 @@ func TestCleanup_computeStats(t *testing.T) {
 
 	if _, err := s.DB.ExecContext(context.Background(), `
 insert into repo(id, name) values (1, 'a'), (2, 'b/d'), (3, 'c');
-insert into gitserver_repos(repo_id, shard_id) values (1, 1), (2, 1);
-insert into gitserver_repos(repo_id, shard_id, repo_size_bytes) values (3, 1, 228);
+update gitserver_repos set shard_id = 1;
+update gitserver_repos set repo_size_bytes = 228 where repo_id = 3;
 `); err != nil {
 		t.Fatalf("unexpected error while inserting test data: %s", err)
 	}
@@ -1240,8 +1240,8 @@ insert into repo(id, name)
 values (1, 'ghe.sgdev.org/sourcegraph/gorilla-websocket'),
        (2, 'ghe.sgdev.org/sourcegraph/gorilla-mux'),
        (3, 'ghe.sgdev.org/sourcegraph/gorilla-sessions');
-insert into gitserver_repos(repo_id, shard_id) values (2, 1), (3, 1);
-insert into gitserver_repos(repo_id, shard_id, repo_size_bytes) values (1, 1, 228);
+update gitserver_repos set shard_id = 1;
+update gitserver_repos set repo_size_bytes = 228 where repo_id = 1;
 `); err != nil {
 		t.Fatalf("unexpected error while inserting test data: %s", err)
 	}

--- a/dev/ci/go-backcompat/flakefiles/v3.39.0.json
+++ b/dev/ci/go-backcompat/flakefiles/v3.39.0.json
@@ -1,0 +1,27 @@
+[
+  {
+    "path": "cmd/gitserver/server",
+    "prefix": "TestCleanup_computeStats",
+    "reason": "Database semantics changed: every created repo has a corresponding gitserver_repo entry right after being inserted in repo table (https://github.com/sourcegraph/sourcegraph/pull/35633)"
+  },
+  {
+    "path": "cmd/gitserver/server",
+    "prefix": "TestCleanup_setRepoSizes",
+    "reason": "Database semantics changed: every created repo has a corresponding gitserver_repo entry right after being inserted in repo table (https://github.com/sourcegraph/sourcegraph/pull/35633)"
+  },
+  {
+    "path": "internal/database",
+    "prefix": "TestIterateRepoGitserverStatus",
+    "reason": "Database semantics changed: every created repo has a corresponding gitserver_repo entry right after being inserted in repo table (https://github.com/sourcegraph/sourcegraph/pull/35633)"
+  },
+  {
+    "path": "internal/database",
+    "prefix": "TestSetRepoSize",
+    "reason": "Database semantics changed: every created repo has a corresponding gitserver_repo entry right after being inserted in repo table (https://github.com/sourcegraph/sourcegraph/pull/35633)"
+  },
+  {
+    "path": "internal/database",
+    "prefix": "TestListIndexableRepos",
+    "reason": "Database semantics changed: every created repo has a corresponding gitserver_repo entry right after being inserted in repo table (https://github.com/sourcegraph/sourcegraph/pull/35633)"
+  }
+]

--- a/internal/database/gitserver_repos.go
+++ b/internal/database/gitserver_repos.go
@@ -237,9 +237,9 @@ type IterateRepoGitserverStatusOptions struct {
 }
 
 // IterateRepoGitserverStatus iterates over the status of all repos by joining
-// our repo and gitserver_repos table. It is possible for us not to have a
-// corresponding row in gitserver_repos yet. repoFn will be called once for each
-// row. If it returns an error we'll abort iteration.
+// our repo and gitserver_repos table. It is impossible for us not to have a
+// corresponding row in gitserver_repos because of the trigger on repos table.
+// repoFn will be called once for each row. If it returns an error we'll abort iteration.
 func (s *gitserverRepoStore) IterateRepoGitserverStatus(ctx context.Context, options IterateRepoGitserverStatusOptions, repoFn func(repo types.RepoGitserverStatus) error) error {
 	if repoFn == nil {
 		return errors.New("nil repoFn")

--- a/internal/database/gitserver_repos_test.go
+++ b/internal/database/gitserver_repos_test.go
@@ -101,16 +101,16 @@ func TestIterateRepoGitserverStatus(t *testing.T) {
 	}
 
 	t.Run("iterate with default options", func(t *testing.T) {
-		assert(t, 2, 1, IterateRepoGitserverStatusOptions{})
+		assert(t, 2, 2, IterateRepoGitserverStatusOptions{})
 	})
 	t.Run("iterate only repos without shard", func(t *testing.T) {
-		assert(t, 1, 0, IterateRepoGitserverStatusOptions{OnlyWithoutShard: true})
+		assert(t, 1, 1, IterateRepoGitserverStatusOptions{OnlyWithoutShard: true})
 	})
 	t.Run("include deleted", func(t *testing.T) {
-		assert(t, 3, 1, IterateRepoGitserverStatusOptions{IncludeDeleted: true})
+		assert(t, 3, 3, IterateRepoGitserverStatusOptions{IncludeDeleted: true})
 	})
 	t.Run("include deleted and without shard", func(t *testing.T) {
-		assert(t, 2, 0, IterateRepoGitserverStatusOptions{OnlyWithoutShard: true, IncludeDeleted: true})
+		assert(t, 2, 2, IterateRepoGitserverStatusOptions{OnlyWithoutShard: true, IncludeDeleted: true})
 	})
 }
 
@@ -710,7 +710,7 @@ func TestSetRepoSize(t *testing.T) {
 	}
 	gitserverRepo2 := &types.GitserverRepo{
 		RepoID:        repo2.ID,
-		ShardID:       shardID,
+		ShardID:       "",
 		RepoSizeBytes: 300,
 	}
 	if diff := cmp.Diff(gitserverRepo2, fromDB, cmpopts.IgnoreFields(types.GitserverRepo{}, "UpdatedAt", "LastFetched", "LastChanged", "CloneStatus")); diff != "" {

--- a/internal/database/repos_test.go
+++ b/internal/database/repos_test.go
@@ -466,7 +466,7 @@ func TestListIndexableRepos(t *testing.T) {
 		if !cloned {
 			cloneStatus = types.CloneStatusNotCloned
 		}
-		if _, err := db.ExecContext(ctx, `INSERT INTO gitserver_repos(repo_id, clone_status, shard_id) VALUES ($1, $2, 'test');`, r.ID, cloneStatus); err != nil {
+		if _, err := db.ExecContext(ctx, `UPDATE gitserver_repos SET clone_status = $2, shard_id = 'test' WHERE repo_id = $1;`, r.ID, cloneStatus); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/internal/database/schema.json
+++ b/internal/database/schema.json
@@ -93,6 +93,10 @@
       "Definition": "CREATE OR REPLACE FUNCTION public.func_configuration_policies_update()\n RETURNS trigger\n LANGUAGE plpgsql\nAS $function$\n    DECLARE\n        diff hstore[];\n    BEGIN\n        diff = func_configuration_policies_transition_columns_diff(\n            func_row_to_configuration_policies_transition_columns(OLD),\n            func_row_to_configuration_policies_transition_columns(NEW)\n        );\n\n        IF (array_length(diff, 1) \u003e 0) THEN\n            INSERT INTO configuration_policies_audit_logs\n            (policy_id, transition_columns)\n            VALUES (\n                NEW.id,\n                diff\n            );\n        END IF;\n\n        RETURN NEW;\n    END;\n$function$\n"
     },
     {
+      "Name": "func_insert_gitserver_repo",
+      "Definition": "CREATE OR REPLACE FUNCTION public.func_insert_gitserver_repo()\n RETURNS trigger\n LANGUAGE plpgsql\nAS $function$\nBEGIN\nINSERT INTO gitserver_repos\n(repo_id, shard_id)\nVALUES (NEW.id, '');\nRETURN NULL;\nEND;\n$function$\n"
+    },
+    {
       "Name": "func_lsif_uploads_delete",
       "Definition": "CREATE OR REPLACE FUNCTION public.func_lsif_uploads_delete()\n RETURNS trigger\n LANGUAGE plpgsql\nAS $function$\n    BEGIN\n        UPDATE lsif_uploads_audit_logs\n        SET record_deleted_at = NOW()\n        WHERE upload_id IN (\n            SELECT id FROM OLD\n        );\n\n        RETURN NULL;\n    END;\n$function$\n"
     },
@@ -14228,6 +14232,10 @@
         {
           "Name": "trig_delete_repo_ref_on_external_service_repos",
           "Definition": "CREATE TRIGGER trig_delete_repo_ref_on_external_service_repos AFTER UPDATE OF deleted_at ON repo FOR EACH ROW EXECUTE FUNCTION delete_repo_ref_on_external_service_repos()"
+        },
+        {
+          "Name": "trigger_gitserver_repo_insert",
+          "Definition": "CREATE TRIGGER trigger_gitserver_repo_insert AFTER INSERT ON repo FOR EACH ROW EXECUTE FUNCTION func_insert_gitserver_repo()"
         }
       ]
     },

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -2208,6 +2208,7 @@ Referenced by:
     TABLE "user_public_repos" CONSTRAINT "user_public_repos_repo_id_fkey" FOREIGN KEY (repo_id) REFERENCES repo(id) ON DELETE CASCADE
 Triggers:
     trig_delete_repo_ref_on_external_service_repos AFTER UPDATE OF deleted_at ON repo FOR EACH ROW EXECUTE FUNCTION delete_repo_ref_on_external_service_repos()
+    trigger_gitserver_repo_insert AFTER INSERT ON repo FOR EACH ROW EXECUTE FUNCTION func_insert_gitserver_repo()
 
 ```
 

--- a/migrations/frontend/1652946496/down.sql
+++ b/migrations/frontend/1652946496/down.sql
@@ -1,0 +1,2 @@
+DROP TRIGGER IF EXISTS trigger_gitserver_repo_insert ON repo;
+DROP FUNCTION IF EXISTS func_insert_gitserver_repo;

--- a/migrations/frontend/1652946496/metadata.yaml
+++ b/migrations/frontend/1652946496/metadata.yaml
@@ -1,0 +1,2 @@
+name: add_trigger_to_insert_gitserver_repo
+parents: [1652228814, 1652707934]

--- a/migrations/frontend/1652946496/up.sql
+++ b/migrations/frontend/1652946496/up.sql
@@ -4,7 +4,8 @@ SELECT repo.id, ''
 FROM repo
 LEFT JOIN gitserver_repos gr
 ON repo.id = gr.repo_id
-WHERE gr.repo_id IS NULL;
+WHERE gr.repo_id IS NULL
+ON CONFLICT (repo_id) DO NOTHING;
 
 CREATE OR REPLACE FUNCTION func_insert_gitserver_repo() RETURNS TRIGGER AS $$
 BEGIN

--- a/migrations/frontend/1652946496/up.sql
+++ b/migrations/frontend/1652946496/up.sql
@@ -16,6 +16,8 @@ RETURN NULL;
 END;
 $$ LANGUAGE plpgsql;
 
+DROP TRIGGER IF EXISTS trigger_gitserver_repo_insert on repo;
+
 CREATE TRIGGER trigger_gitserver_repo_insert
     AFTER INSERT
     ON repo

--- a/migrations/frontend/1652946496/up.sql
+++ b/migrations/frontend/1652946496/up.sql
@@ -1,0 +1,22 @@
+-- batch insert repos which don't have a corresponding row in gitserver_repos table
+INSERT INTO gitserver_repos(repo_id, shard_id)
+SELECT repo.id, ''
+FROM repo
+LEFT JOIN gitserver_repos gr
+ON repo.id = gr.repo_id
+WHERE gr.repo_id IS NULL;
+
+CREATE OR REPLACE FUNCTION func_insert_gitserver_repo() RETURNS TRIGGER AS $$
+BEGIN
+INSERT INTO gitserver_repos
+(repo_id, shard_id)
+VALUES (NEW.id, '');
+RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trigger_gitserver_repo_insert
+    AFTER INSERT
+    ON repo
+    FOR EACH ROW
+    EXECUTE FUNCTION func_insert_gitserver_repo();


### PR DESCRIPTION
~~Previous version of SQL predicate was checking for non-existent rows in `gitserver_repos` table (`gr.clone_status IS NULL`) which resulted in a slow anti-join with `gitserver_repos` table.~~

~~Current change resolves this performance issue introducing one logical issue: it redefines "not cloned repos" definition. Now these are repos that exist in `gitserver_repos` and have either `not_cloned` or `cloning` clone status. Repos which are not yet added to `gitserver_repos` table are skipped for the sake of performance, however they are in fact fall under "not cloned" definition too.~~

### Updated description
This PR adds a migration with a trigger which inserts a `gitserver_repo` as soon as `repo` is inserted.

Part of https://github.com/sourcegraph/sourcegraph/issues/34110

## Test plan
Existing tests should pass
`sg migration up` and `sg migration downto -db=frontend -target=1652707934` and `sg migration up` commands have been run

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
