### PR TITLE
Code monitors: fix transaction rollbacks

### DIFF
--- a/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers.go
+++ b/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers.go
@@ -113,7 +113,7 @@ func (r *Resolver) MonitorByID(ctx context.Context, id graphql.ID) (graphqlbacke
 	}, nil
 }
 
-func (r *Resolver) CreateCodeMonitor(ctx context.Context, args *graphqlbackend.CreateCodeMonitorArgs) (graphqlbackend.MonitorResolver, error) {
+func (r *Resolver) CreateCodeMonitor(ctx context.Context, args *graphqlbackend.CreateCodeMonitorArgs) (_ graphqlbackend.MonitorResolver, err error) {
 	if err := r.isAllowedToCreate(ctx, args.Monitor.Namespace); err != nil {
 		return nil, err
 	}

--- a/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers_test.go
+++ b/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers_test.go
@@ -40,28 +40,30 @@ func TestCreateCodeMonitor(t *testing.T) {
 		Enabled:     true,
 		UserID:      user.ID,
 	}
-
-	// Create a monitor.
 	ctx = actor.WithActor(ctx, actor.FromUser(user.ID))
-	got, err := r.insertTestMonitorWithOpts(ctx, t)
-	require.NoError(t, err)
-	castGot := got.(*monitor).Monitor
-	castGot.CreatedAt, castGot.ChangedAt = want.CreatedAt, want.ChangedAt // overwrite after comparing with time equality
-	require.EqualValues(t, want, castGot)
 
-	// Toggle field enabled from true to false.
-	got, err = r.ToggleCodeMonitor(ctx, &graphqlbackend.ToggleCodeMonitorArgs{
-		Id:      relay.MarshalID(MonitorKind, got.(*monitor).Monitor.ID),
-		Enabled: false,
+	t.Run("create monitor", func(t *testing.T) {
+		got, err := r.insertTestMonitorWithOpts(ctx, t)
+		require.NoError(t, err)
+		castGot := got.(*monitor).Monitor
+		castGot.CreatedAt, castGot.ChangedAt = want.CreatedAt, want.ChangedAt // overwrite after comparing with time equality
+		require.EqualValues(t, want, castGot)
+
+		// Toggle field enabled from true to false.
+		got, err = r.ToggleCodeMonitor(ctx, &graphqlbackend.ToggleCodeMonitorArgs{
+			Id:      relay.MarshalID(MonitorKind, got.(*monitor).Monitor.ID),
+			Enabled: false,
+		})
+		require.NoError(t, err)
+		require.False(t, got.(*monitor).Monitor.Enabled)
+
+		// Delete code monitor.
+		_, err = r.DeleteCodeMonitor(ctx, &graphqlbackend.DeleteCodeMonitorArgs{Id: got.ID()})
+		require.NoError(t, err)
+		_, err = r.db.CodeMonitors().GetMonitor(ctx, got.(*monitor).Monitor.ID)
+		require.Error(t, err, "monitor should have been deleted")
+
 	})
-	require.NoError(t, err)
-	require.False(t, got.(*monitor).Monitor.Enabled)
-
-	// Delete code monitor.
-	_, err = r.DeleteCodeMonitor(ctx, &graphqlbackend.DeleteCodeMonitorArgs{Id: got.ID()})
-	require.NoError(t, err)
-	_, err = r.db.CodeMonitors().GetMonitor(ctx, got.(*monitor).Monitor.ID)
-	require.Error(t, err, "monitor should have been deleted")
 
 	t.Run("invalid slack webhook", func(t *testing.T) {
 		namespace := relay.MarshalID("User", user.ID)
@@ -75,6 +77,23 @@ func TestCreateCodeMonitor(t *testing.T) {
 			}},
 		})
 		require.Error(t, err)
+	})
+
+	t.Run("invalid query", func(t *testing.T) {
+		namespace := relay.MarshalID("User", user.ID)
+		_, err := r.CreateCodeMonitor(ctx, &graphqlbackend.CreateCodeMonitorArgs{
+			Monitor: &graphqlbackend.CreateMonitorArgs{Namespace: namespace},
+			Trigger: &graphqlbackend.CreateTriggerArgs{Query: "type:commit (repo:a b) or (repo:c d)"}, // invalid query
+			Actions: []*graphqlbackend.CreateActionArgs{{
+				SlackWebhook: &graphqlbackend.CreateActionSlackWebhookArgs{
+					URL: "https://internal:3443",
+				},
+			}},
+		})
+		require.Error(t, err)
+		monitors, err := r.Monitors(ctx, user.ID, &graphqlbackend.ListMonitorsArgs{First: 10})
+		require.NoError(t, err)
+		require.Len(t, monitors.Nodes(), 0) // the transaction should have been rolled back
 	})
 }
 
@@ -734,80 +753,80 @@ func TestEditCodeMonitor(t *testing.T) {
 
 const editMonitor = `
 fragment u on User {
-  id
-  username
+	id
+	username
 }
 
 fragment o on Org {
-  id
-  name
+	id
+	name
 }
 
 mutation ($monitorID: ID!, $triggerID: ID!, $actionID: ID!, $user1ID: ID!, $user2ID: ID!, $webhookID: ID!) {
-  updateCodeMonitor(
-    monitor: {id: $monitorID, update: {description: "updated test monitor", enabled: false, namespace: $user1ID}},
-	trigger: {id: $triggerID, update: {query: "repo:bar"}},
-	actions: [
-	  {email: {id: $actionID, update: {enabled: false, priority: CRITICAL, recipients: [$user2ID], header: "updated header action 1"}}}
-	  {webhook: {id: $webhookID, update: {enabled: true, url: "https://generic.webhook.com"}}}
-	  {slackWebhook: {update: {enabled: true, url: "https://slack.webhook.com"}}}
-    ]
-  )
-  {
-	id
-	description
-	enabled
-	owner {
-	  ... on User {
-		...u
-	  }
-	  ... on Org {
-		...o
-	  }
-	}
-	createdBy {
-	  ...u
-	}
-	createdAt
-	trigger {
-	  ... on MonitorQuery {
-		  __typename
+	updateCodeMonitor(
+		monitor: {id: $monitorID, update: {description: "updated test monitor", enabled: false, namespace: $user1ID}},
+		trigger: {id: $triggerID, update: {query: "repo:bar"}},
+		actions: [
+		{email: {id: $actionID, update: {enabled: false, priority: CRITICAL, recipients: [$user2ID], header: "updated header action 1"}}}
+		{webhook: {id: $webhookID, update: {enabled: true, url: "https://generic.webhook.com"}}}
+		{slackWebhook: {update: {enabled: true, url: "https://slack.webhook.com"}}}
+		]
+	)
+	{
 		id
-		query
-	  }
-	}
-	actions {
-	  nodes {
-		... on MonitorEmail {
-			__typename
-		  id
-		  enabled
-		  priority
-		  header
-		  recipients {
-			nodes {
-			  ... on User {
-				username
-			  }
-			  ... on Org {
-				name
-			  }
+		description
+		enabled
+		owner {
+			... on User {
+				...u
 			}
-		  }
+			... on Org {
+				...o
+			}
 		}
-		... on MonitorWebhook {
-			__typename
-		  enabled
-		  url
+		createdBy {
+			...u
 		}
-		... on MonitorSlackWebhook {
-			__typename
-		  enabled
-		  url
+		createdAt
+		trigger {
+			... on MonitorQuery {
+				__typename
+				id
+				query
+			}
 		}
-	  }
+		actions {
+			nodes {
+				... on MonitorEmail {
+					__typename
+					id
+					enabled
+					priority
+					header
+					recipients {
+						nodes {
+							... on User {
+								username
+							}
+							... on Org {
+								name
+							}
+						}
+					}
+				}
+				... on MonitorWebhook {
+					__typename
+					enabled
+					url
+				}
+				... on MonitorSlackWebhook {
+					__typename
+					enabled
+					url
+				}
+			}
+		}
 	}
-  }
 }
 `
 
@@ -960,68 +979,68 @@ fragment u on User { id, username }
 fragment o on Org { id, name }
 
 query ($id: ID!) {
-  node(id: $id) {
-    ... on Monitor {
-		__typename
-      id
-      description
-      enabled
-      owner {
-        ... on User {
-          ...u
-        }
-        ... on Org {
-          ...o
-        }
-      }
-      createdBy {
-        ...u
-      }
-      createdAt
-      trigger {
-        ... on MonitorQuery {
+	node(id: $id) {
+		... on Monitor {
 			__typename
-          id
-          query
-        }
-      }
-      actions {
-        totalCount
-        nodes {
-          ... on MonitorEmail {
-			  __typename
-            id
-            priority
-            header
-            enabled
-            recipients {
-              totalCount
-              nodes {
-                ... on User {
-                  ...u
-                }
-                ... on Org {
-                  ...o
-                }
-              }
-            }
-          }
-		  ... on MonitorWebhook {
-			  __typename
-			  id
-			  enabled
-			  url
-		  }
-		  ... on MonitorSlackWebhook {
-			  __typename
-			  id
-			  enabled
-			  url
-		  }
-        }
-      }
-    }
-  }
+			id
+			description
+			enabled
+			owner {
+				... on User {
+					...u
+				}
+				... on Org {
+					...o
+				}
+			}
+			createdBy {
+				...u
+			}
+			createdAt
+			trigger {
+				... on MonitorQuery {
+					__typename
+					id
+					query
+				}
+			}
+			actions {
+				totalCount
+				nodes {
+					... on MonitorEmail {
+						__typename
+						id
+						priority
+						header
+						enabled
+						recipients {
+							totalCount
+							nodes {
+								... on User {
+									...u
+								}
+								... on Org {
+									...o
+								}
+							}
+						}
+					}
+					... on MonitorWebhook {
+						__typename
+						id
+						enabled
+						url
+					}
+					... on MonitorSlackWebhook {
+						__typename
+						id
+						enabled
+						url
+					}
+				}
+			}
+		}
+	}
 }
 `
 
@@ -1151,7 +1170,7 @@ query($userName: String!, $triggerEventCursor: String!){
 						events(first:1, after:$triggerEventCursor) {
 							totalCount
 							nodes {
-									id
+								id
 							}
 						}
 					}


### PR DESCRIPTION
This is a fun one.

I was seeing an issue where, when I create a code monitor, even if it failed, the monitor would still be created. We supposedly have transactional semantics in the creation code, so the transaction should be rolled back if there is a failure, but apparently that wasn't happening. Scary 👻 

Turns out the issue was that `err` was being declared in the function body, and the `defer func() { err = tx.Done(err) }` was referring to that declared `err` variable. This would be fine, _except_ we make a new scope on line 150, which makes the declaration on line 151 create a new variable. This means when we assign to it, we aren't assigning to the variable that is being read by `tx.Done()`. 

I fixed this by declaring the variable in the method signature so that the error referenced by `tx.Done()` will always be whatever error is returned with `return`. 

## Test plan

Added a test to make sure that a failed create actually rolls back the transaction. 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
