### PR TITLE
Backend: fix instances of `tx.Done(err)` referencing wrong `err`

### DIFF
--- a/enterprise/cmd/worker/internal/batches/migrations/ssh_migrator.go
+++ b/enterprise/cmd/worker/internal/batches/migrations/ssh_migrator.go
@@ -48,7 +48,7 @@ SELECT CASE c2.count WHEN 0 THEN 1 ELSE CAST((c2.count - c1.count) AS float) / C
 
 // Up loops over all credentials and finds authenticators that are missing
 // SSH credentials, generates a keypair for them and upgrades them.
-func (m *sshMigrator) Up(ctx context.Context) error {
+func (m *sshMigrator) Up(ctx context.Context) (err error) {
 	tx, err := m.store.Transact(ctx)
 	if err != nil {
 		return err
@@ -113,7 +113,7 @@ func (m *sshMigrator) Up(ctx context.Context) error {
 
 // Down converts all credentials that have an SSH key back to a version without, so
 // an older version of Sourcegraph would be able to match those credentials again.
-func (m *sshMigrator) Down(ctx context.Context) error {
+func (m *sshMigrator) Down(ctx context.Context) (err error) {
 	tx, err := m.store.Transact(ctx)
 	if err != nil {
 		return err

--- a/enterprise/internal/insights/resolvers/dashboard_resolvers.go
+++ b/enterprise/internal/insights/resolvers/dashboard_resolvers.go
@@ -452,9 +452,9 @@ func (r *Resolver) AddInsightViewToDashboard(ctx context.Context, args *graphqlb
 	return &insightsDashboardPayloadResolver{dashboard: dashboards[0], baseInsightResolver: r.baseInsightResolver}, nil
 }
 
-func (r *Resolver) RemoveInsightViewFromDashboard(ctx context.Context, args *graphqlbackend.RemoveInsightViewFromDashboardArgs) (graphqlbackend.InsightsDashboardPayloadResolver, error) {
+func (r *Resolver) RemoveInsightViewFromDashboard(ctx context.Context, args *graphqlbackend.RemoveInsightViewFromDashboardArgs) (_ graphqlbackend.InsightsDashboardPayloadResolver, err error) {
 	var viewID string
-	err := relay.UnmarshalSpec(args.Input.InsightViewID, &viewID)
+	err = relay.UnmarshalSpec(args.Input.InsightViewID, &viewID)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to unmarshal insight view id")
 	}

--- a/enterprise/internal/insights/store/dashboard_store.go
+++ b/enterprise/internal/insights/store/dashboard_store.go
@@ -356,7 +356,7 @@ func (s *DBDashboardStore) AddDashboardGrants(ctx context.Context, dashboardId i
 	return nil
 }
 
-func (s *DBDashboardStore) EnsureLimitedAccessModeDashboard(ctx context.Context) (int, error) {
+func (s *DBDashboardStore) EnsureLimitedAccessModeDashboard(ctx context.Context) (_ int, err error) {
 	tx, err := s.Transact(ctx)
 	if err != nil {
 		return 0, err

--- a/internal/database/conf.go
+++ b/internal/database/conf.go
@@ -93,7 +93,7 @@ func (s *confStore) SiteCreateIfUpToDate(ctx context.Context, lastID *int32, con
 	return tx.createIfUpToDate(ctx, lastID, contents)
 }
 
-func (s *confStore) SiteGetLatest(ctx context.Context) (*SiteConfig, error) {
+func (s *confStore) SiteGetLatest(ctx context.Context) (_ *SiteConfig, err error) {
 	tx, err := s.transact(ctx)
 	if err != nil {
 		return nil, err

--- a/internal/database/gitserver_repos.go
+++ b/internal/database/gitserver_repos.go
@@ -609,7 +609,7 @@ WHERE gr.repo_size_bytes IS NULL
 `
 
 // UpdateRepoSizes sets repo sizes according to input map. Key is repoID, value is repo_size_bytes.
-func (s *gitserverRepoStore) UpdateRepoSizes(ctx context.Context, shardID string, repos map[api.RepoID]int64) error {
+func (s *gitserverRepoStore) UpdateRepoSizes(ctx context.Context, shardID string, repos map[api.RepoID]int64) (err error) {
 
 	inserter := func(inserter *batch.Inserter) error {
 		for repo, size := range repos {

--- a/internal/database/user_emails.go
+++ b/internal/database/user_emails.go
@@ -117,7 +117,7 @@ func (s *userEmailsStore) GetPrimaryEmail(ctx context.Context, id int32) (email 
 // SetPrimaryEmail sets the primary email for a user.
 // The address must be verified.
 // All other addresses for the user will be set as not primary.
-func (s *userEmailsStore) SetPrimaryEmail(ctx context.Context, userID int32, email string) error {
+func (s *userEmailsStore) SetPrimaryEmail(ctx context.Context, userID int32, email string) (err error) {
 	tx, err := s.Transact(ctx)
 	if err != nil {
 		return err
@@ -169,7 +169,7 @@ func (s *userEmailsStore) Add(ctx context.Context, userID int32, email string, v
 
 // Remove removes a user email. It returns an error if there is no such email associated with the user or the email
 // is the user's primary address
-func (s *userEmailsStore) Remove(ctx context.Context, userID int32, email string) error {
+func (s *userEmailsStore) Remove(ctx context.Context, userID int32, email string) (err error) {
 	tx, err := s.Transact(ctx)
 	if err != nil {
 		return err


### PR DESCRIPTION
Hi @sourcegraph/backend-devs! This is a PSA PR from your friendly neighborhood me. 

I ran into [a bug](https://github.com/sourcegraph/sourcegraph/pull/35642) caused by a `tx.Done(err)` that was referencing the wrong error. It was subtle and something super easy to miss, so I did a quick audit of our codebase to find other instances where this might be happening. The audit turned up a handful of places that could be susceptible to this same issue, all fixed by this PR. 

I don't think we can create a lint check for this, so instead I'm **pinging you all to raise awareness** so we can hopefully avoid introducing more of these in the future. 

<details>
<summary>In case you want to learn more about the problem (I think it's an interesting exploration of go's variable scoping rules)</summary>
<br>

In our codebase, database transactions must be explicitly closed, otherwise we will leak transactions, which is not good. A very common pattern to avoid that is `defer`-ing `tx.Done(err)` so we can guarantee that `tx.Done(err)` will always be called.

For those unfamiliar with the semantics of `tx.Done(err)`, it will either commit or roll back the transaction depending on whether `err == nil`. It returns the error that was passed to it if non-nil or any error returned from calling commit/rollback.

The problem comes along when the `err` variable referenced by `tx.Done(err)` is not set. It's really easy to do this by re-declaring `err` and updating the new `err` rather than the old `err` referenced by `tx.Done(err)`.

```go
func doTheThing(ctx context.Context, db database.DB) error {
	tx, err := db.Transact(ctx)
	if err != nil {
		return err
	}
	defer func() { err = tx.Done(err) }()

	err2 := tx.DoTheThing(ctx)
	if err2 != nil {
		// Even though we errored, this will not roll the
		// transaction back because `err` is still `nil`.
		return err2
	}
	
	return nil
}
```

You might be thinking "But Camden, I always use `err` as my variable name, so I'm fine!" Consider the following:

```go
func getTheThingAndMaybeDo(ctx context.Context, db database.DB) error {
	tx, err := db.Transact(ctx)
	if err != nil {
		return err
	}
	defer func() { err = tx.Done(err) }()

	// Believe it or not, the following line does not redeclare `err`,
	// so this will work as expected.
	// https://go.dev/ref/spec#Short_variable_declarations
	got, err := tx.GetTheThing(ctx)
	if err != nil {
		return err
	}

	if got.IsTruthy() {
		// However, since we're in a new scope here, this `err` is a new
		// variable. Confusing, right? If we get a non-nil error here,
		// the transaction will still be committed because the `err` 
		// on the first line of this function has not been changed.
		err := tx.DoTheThing(ctx)
		if err != nil {
			return err
		}
	}
	
	return nil
}
```

Okay, so how can we commit/rollback transactions correctly? Try the following:

```go
func getTheThingAndMaybeDo(ctx context.Context, db database.DB) (err error) {
	// declare err in the function signature ----------------^^^

	tx, err := db.Transact(ctx)
	if err != nil {
		return err
	}
	// This `err` refers to the `err` declared in the function signature. 
	// As a bonus, setting `err` in this line actually overwrites the 
	// returned error, so we aren't silently ignoring any errors returned
	// from the database like in the other examples.
	defer func() { err = tx.Done(err) }()

	got, err := tx.GetTheThing(ctx)
	if err != nil {
		return err
	}

	if got.IsTruthy() {
		err := tx.DoTheThing(ctx)
		if err != nil {
			// Even though the `err` here is not referring to the same 
			// variable as the `err` in the function signature, by returning
			// an error, you are implicitly setting the `err` in the function
			// signature, which means that `tx.Done` will see the updated
			// error value.
			return err
		}
	}

	return nil
}
```
</details>


## Test plan

Depending on existing tests.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
