### PR TITLE
vsce: add sideload extension to GitPod instruction

### DIFF
--- a/client/vscode/CONTRIBUTING.md
+++ b/client/vscode/CONTRIBUTING.md
@@ -16,6 +16,8 @@ New issues and feature requests can be filed through our [issue tracker](https:/
 
 ### Build and run
 
+#### Desktop Version
+
 1. `git clone` the [Sourcegraph repository](https://github.com/sourcegraph/sourcegraph)
 1. Install dependencies via `yarn` for the Sourcegraph repository
 1. Run `yarn generate` at the root directory to generate the required schemas
@@ -23,7 +25,9 @@ New issues and feature requests can be filed through our [issue tracker](https:/
 1. Run `yarn build-vsce` to build or `yarn watch-vsce` to build and watch the tasks from the `root` directory
 1. Select `Launch VS Code Extension` (`Launch VS Code Web Extension` for VS Code Web) from the dropdown menu in the `Run and Debug` sidebar view to see your changes
 
-### Tests
+### Integration Tests
+
+To perform integration tests:
 
 1. In the Sourcegraph repository:
    1. `yarn`
@@ -31,6 +35,24 @@ New issues and feature requests can be filed through our [issue tracker](https:/
 2. In the `client/vscode` directory:
    1. `yarn build:test` or `yarn watch:test`
    2. `yarn test-integration`
+
+## GitPod
+
+#### Web Version
+
+To run and test the web extension on GitPod Web (as well as VS Code and GitHub for the web), you must sideload the extension from your local machine as suggested in the following steps:
+1. `git clone` the [Sourcegraph repository](https://github.com/sourcegraph/sourcegraph)
+1. Run `yarn && yarn generate` at the root directory to install dependencies and generate the required schemas
+1. Run `yarn build-vsce` at root to build the Sourcegraph VS Code extension for Web
+1. Once the build has been completed, move to the extension’s directory: `cd client/vscode`
+1. Start an HTTP server inside the extension’s path to host the extension locally: `npx serve --cors -l 8988`
+1. In another terminal, generate a publicly-accessible URL from your locally running HTTP server with the localtunnel tool: `npx localtunnel -p 8988`
+   - A publicly-accessible URL will be generated for you in the output followed by “your url is:”
+1. Copy and then open the newly generated URL in a browser and then select “Click to Continue”
+1. Open the Command Palette in GitPod Web (a GitPod Workspace using the Open in Browser setting)
+1. Select  “Developer: Install Web Extension…”
+1. Paste the newly generated URL in the input area and select Install
+1. The extension is now installed
 
 ### Debugging
 


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/35494

Add instruction on how to sideload extension to GitPod. 

Note: the instruction is the same as for VS Code Web and GitPod Web.

![image](https://user-images.githubusercontent.com/68532117/169129570-663352b8-a900-435d-bf9f-e83d109f9df5.png)


## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

N/A for docs update