### PR TITLE
Move RepoUniverseSymbolJob to package zoekt, rename job, and add tracing

### DIFF
--- a/internal/search/job/jobutil/job.go
+++ b/internal/search/job/jobutil/job.go
@@ -611,7 +611,7 @@ func (b *jobBuilder) newZoektGlobalSearch(typ search.IndexedRequestType) (job.Jo
 		return &zoekt.ZoektGlobalSymbolSearchJob{
 			GlobalZoektQuery: globalZoektQuery,
 			ZoektArgs:        zoektArgs,
-			RepoOptions:      b.repoOptions,
+			RepoOpts:         b.repoOptions,
 		}, nil
 	case search.TextRequest:
 		return &zoekt.ZoektGlobalSearchJob{

--- a/internal/search/job/jobutil/job.go
+++ b/internal/search/job/jobutil/job.go
@@ -24,7 +24,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/search/searchcontexts"
 	"github.com/sourcegraph/sourcegraph/internal/search/searcher"
 	"github.com/sourcegraph/sourcegraph/internal/search/structural"
-	"github.com/sourcegraph/sourcegraph/internal/search/symbol"
 	"github.com/sourcegraph/sourcegraph/internal/search/zoekt"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 	"github.com/sourcegraph/sourcegraph/schema"
@@ -609,7 +608,7 @@ func (b *jobBuilder) newZoektGlobalSearch(typ search.IndexedRequestType) (job.Jo
 
 	switch typ {
 	case search.SymbolRequest:
-		return &symbol.RepoUniverseSymbolSearchJob{
+		return &zoekt.RepoUniverseSymbolSearchJob{
 			GlobalZoektQuery: globalZoektQuery,
 			ZoektArgs:        zoektArgs,
 			RepoOptions:      b.repoOptions,

--- a/internal/search/job/jobutil/job.go
+++ b/internal/search/job/jobutil/job.go
@@ -608,7 +608,7 @@ func (b *jobBuilder) newZoektGlobalSearch(typ search.IndexedRequestType) (job.Jo
 
 	switch typ {
 	case search.SymbolRequest:
-		return &zoekt.RepoUniverseSymbolSearchJob{
+		return &zoekt.ZoektGlobalSymbolSearchJob{
 			GlobalZoektQuery: globalZoektQuery,
 			ZoektArgs:        zoektArgs,
 			RepoOptions:      b.repoOptions,

--- a/internal/search/job/jobutil/mapper.go
+++ b/internal/search/job/jobutil/mapper.go
@@ -18,16 +18,16 @@ type Mapper struct {
 	MapJob func(job job.Job) job.Job
 
 	// Search Jobs (leaf nodes)
-	MapZoektRepoSubsetSearchJob    func(*zoekt.ZoektRepoSubsetSearchJob) *zoekt.ZoektRepoSubsetSearchJob
-	MapZoektSymbolSearchJob        func(*zoekt.ZoektSymbolSearchJob) *zoekt.ZoektSymbolSearchJob
-	MapSearcherJob                 func(*searcher.SearcherJob) *searcher.SearcherJob
-	MapSymbolSearcherJob           func(*searcher.SymbolSearcherJob) *searcher.SymbolSearcherJob
-	MapRepoSearchJob               func(*run.RepoSearchJob) *run.RepoSearchJob
-	MapRepoUniverseTextSearchJob   func(*zoekt.ZoektGlobalSearchJob) *zoekt.ZoektGlobalSearchJob
-	MapStructuralSearchJob         func(*structural.StructuralSearchJob) *structural.StructuralSearchJob
-	MapCommitSearchJob             func(*commit.CommitSearchJob) *commit.CommitSearchJob
-	MapRepoUniverseSymbolSearchJob func(*zoekt.RepoUniverseSymbolSearchJob) *zoekt.RepoUniverseSymbolSearchJob
-	MapComputeExcludedReposJob     func(*repos.ComputeExcludedReposJob) *repos.ComputeExcludedReposJob
+	MapZoektRepoSubsetSearchJob   func(*zoekt.ZoektRepoSubsetSearchJob) *zoekt.ZoektRepoSubsetSearchJob
+	MapZoektSymbolSearchJob       func(*zoekt.ZoektSymbolSearchJob) *zoekt.ZoektSymbolSearchJob
+	MapZoektGlobalSymbolSearchJob func(*zoekt.ZoektGlobalSymbolSearchJob) *zoekt.ZoektGlobalSymbolSearchJob
+	MapSearcherJob                func(*searcher.SearcherJob) *searcher.SearcherJob
+	MapSymbolSearcherJob          func(*searcher.SymbolSearcherJob) *searcher.SymbolSearcherJob
+	MapRepoSearchJob              func(*run.RepoSearchJob) *run.RepoSearchJob
+	MapRepoUniverseTextSearchJob  func(*zoekt.ZoektGlobalSearchJob) *zoekt.ZoektGlobalSearchJob
+	MapStructuralSearchJob        func(*structural.StructuralSearchJob) *structural.StructuralSearchJob
+	MapCommitSearchJob            func(*commit.CommitSearchJob) *commit.CommitSearchJob
+	MapComputeExcludedReposJob    func(*repos.ComputeExcludedReposJob) *repos.ComputeExcludedReposJob
 
 	// Repo pager Job (pre-step for some Search Jobs)
 	MapRepoPagerJob func(*repoPagerJob) *repoPagerJob
@@ -106,9 +106,9 @@ func (m *Mapper) Map(j job.Job) job.Job {
 		}
 		return j
 
-	case *zoekt.RepoUniverseSymbolSearchJob:
-		if m.MapRepoUniverseSymbolSearchJob != nil {
-			j = m.MapRepoUniverseSymbolSearchJob(j)
+	case *zoekt.ZoektGlobalSymbolSearchJob:
+		if m.MapZoektGlobalSymbolSearchJob != nil {
+			j = m.MapZoektGlobalSymbolSearchJob(j)
 		}
 		return j
 
@@ -225,7 +225,7 @@ func MapAtom(j job.Job, f func(job.Job) job.Job) job.Job {
 				*run.RepoSearchJob,
 				*structural.StructuralSearchJob,
 				*commit.CommitSearchJob,
-				*zoekt.RepoUniverseSymbolSearchJob,
+				*zoekt.ZoektGlobalSymbolSearchJob,
 				*repos.ComputeExcludedReposJob,
 				*NoopJob:
 				return f(typedJob)

--- a/internal/search/job/jobutil/mapper.go
+++ b/internal/search/job/jobutil/mapper.go
@@ -11,7 +11,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/search/run"
 	"github.com/sourcegraph/sourcegraph/internal/search/searcher"
 	"github.com/sourcegraph/sourcegraph/internal/search/structural"
-	"github.com/sourcegraph/sourcegraph/internal/search/symbol"
 	"github.com/sourcegraph/sourcegraph/internal/search/zoekt"
 )
 
@@ -27,7 +26,7 @@ type Mapper struct {
 	MapRepoUniverseTextSearchJob   func(*zoekt.ZoektGlobalSearchJob) *zoekt.ZoektGlobalSearchJob
 	MapStructuralSearchJob         func(*structural.StructuralSearchJob) *structural.StructuralSearchJob
 	MapCommitSearchJob             func(*commit.CommitSearchJob) *commit.CommitSearchJob
-	MapRepoUniverseSymbolSearchJob func(*symbol.RepoUniverseSymbolSearchJob) *symbol.RepoUniverseSymbolSearchJob
+	MapRepoUniverseSymbolSearchJob func(*zoekt.RepoUniverseSymbolSearchJob) *zoekt.RepoUniverseSymbolSearchJob
 	MapComputeExcludedReposJob     func(*repos.ComputeExcludedReposJob) *repos.ComputeExcludedReposJob
 
 	// Repo pager Job (pre-step for some Search Jobs)
@@ -107,7 +106,7 @@ func (m *Mapper) Map(j job.Job) job.Job {
 		}
 		return j
 
-	case *symbol.RepoUniverseSymbolSearchJob:
+	case *zoekt.RepoUniverseSymbolSearchJob:
 		if m.MapRepoUniverseSymbolSearchJob != nil {
 			j = m.MapRepoUniverseSymbolSearchJob(j)
 		}
@@ -226,7 +225,7 @@ func MapAtom(j job.Job, f func(job.Job) job.Job) job.Job {
 				*run.RepoSearchJob,
 				*structural.StructuralSearchJob,
 				*commit.CommitSearchJob,
-				*symbol.RepoUniverseSymbolSearchJob,
+				*zoekt.RepoUniverseSymbolSearchJob,
 				*repos.ComputeExcludedReposJob,
 				*NoopJob:
 				return f(typedJob)

--- a/internal/search/job/jobutil/printers.go
+++ b/internal/search/job/jobutil/printers.go
@@ -12,7 +12,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/search/run"
 	"github.com/sourcegraph/sourcegraph/internal/search/searcher"
 	"github.com/sourcegraph/sourcegraph/internal/search/structural"
-	"github.com/sourcegraph/sourcegraph/internal/search/symbol"
 	"github.com/sourcegraph/sourcegraph/internal/search/zoekt"
 )
 
@@ -49,7 +48,7 @@ func SexpFormat(j job.Job, sep, indent string) string {
 			*zoekt.ZoektGlobalSearchJob,
 			*structural.StructuralSearchJob,
 			*commit.CommitSearchJob,
-			*symbol.RepoUniverseSymbolSearchJob,
+			*zoekt.RepoUniverseSymbolSearchJob,
 			*repos.ComputeExcludedReposJob,
 			*NoopJob:
 			b.WriteString(j.Name())
@@ -209,7 +208,7 @@ func PrettyMermaid(j job.Job) string {
 			*zoekt.ZoektGlobalSearchJob,
 			*structural.StructuralSearchJob,
 			*commit.CommitSearchJob,
-			*symbol.RepoUniverseSymbolSearchJob,
+			*zoekt.RepoUniverseSymbolSearchJob,
 			*repos.ComputeExcludedReposJob,
 			*NoopJob:
 			writeNode(b, depth, RoundedStyle, &id, j.Name())
@@ -327,7 +326,7 @@ func toJSON(j job.Job, verbose bool) any {
 			*zoekt.ZoektGlobalSearchJob,
 			*structural.StructuralSearchJob,
 			*commit.CommitSearchJob,
-			*symbol.RepoUniverseSymbolSearchJob,
+			*zoekt.RepoUniverseSymbolSearchJob,
 			*repos.ComputeExcludedReposJob,
 			*NoopJob:
 			if verbose {

--- a/internal/search/job/jobutil/printers.go
+++ b/internal/search/job/jobutil/printers.go
@@ -48,7 +48,7 @@ func SexpFormat(j job.Job, sep, indent string) string {
 			*zoekt.ZoektGlobalSearchJob,
 			*structural.StructuralSearchJob,
 			*commit.CommitSearchJob,
-			*zoekt.RepoUniverseSymbolSearchJob,
+			*zoekt.ZoektGlobalSymbolSearchJob,
 			*repos.ComputeExcludedReposJob,
 			*NoopJob:
 			b.WriteString(j.Name())
@@ -208,7 +208,7 @@ func PrettyMermaid(j job.Job) string {
 			*zoekt.ZoektGlobalSearchJob,
 			*structural.StructuralSearchJob,
 			*commit.CommitSearchJob,
-			*zoekt.RepoUniverseSymbolSearchJob,
+			*zoekt.ZoektGlobalSymbolSearchJob,
 			*repos.ComputeExcludedReposJob,
 			*NoopJob:
 			writeNode(b, depth, RoundedStyle, &id, j.Name())
@@ -326,7 +326,7 @@ func toJSON(j job.Job, verbose bool) any {
 			*zoekt.ZoektGlobalSearchJob,
 			*structural.StructuralSearchJob,
 			*commit.CommitSearchJob,
-			*zoekt.RepoUniverseSymbolSearchJob,
+			*zoekt.ZoektGlobalSymbolSearchJob,
 			*repos.ComputeExcludedReposJob,
 			*NoopJob:
 			if verbose {

--- a/internal/search/job/jobutil/types.go
+++ b/internal/search/job/jobutil/types.go
@@ -7,7 +7,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/search/run"
 	"github.com/sourcegraph/sourcegraph/internal/search/searcher"
 	"github.com/sourcegraph/sourcegraph/internal/search/structural"
-	"github.com/sourcegraph/sourcegraph/internal/search/symbol"
 	"github.com/sourcegraph/sourcegraph/internal/search/zoekt"
 )
 
@@ -20,7 +19,7 @@ var allJobs = []job.Job{
 	&zoekt.ZoektGlobalSearchJob{},
 	&structural.StructuralSearchJob{},
 	&commit.CommitSearchJob{},
-	&symbol.RepoUniverseSymbolSearchJob{},
+	&zoekt.RepoUniverseSymbolSearchJob{},
 	&repos.ComputeExcludedReposJob{},
 	&NoopJob{},
 

--- a/internal/search/job/jobutil/types.go
+++ b/internal/search/job/jobutil/types.go
@@ -19,7 +19,7 @@ var allJobs = []job.Job{
 	&zoekt.ZoektGlobalSearchJob{},
 	&structural.StructuralSearchJob{},
 	&commit.CommitSearchJob{},
-	&zoekt.RepoUniverseSymbolSearchJob{},
+	&zoekt.ZoektGlobalSymbolSearchJob{},
 	&repos.ComputeExcludedReposJob{},
 	&NoopJob{},
 

--- a/internal/search/zoekt/symbol_search.go
+++ b/internal/search/zoekt/symbol_search.go
@@ -2,7 +2,6 @@ package zoekt
 
 import (
 	"context"
-	"github.com/sourcegraph/sourcegraph/internal/search/repos"
 	"time"
 
 	zoektquery "github.com/google/zoekt/query"
@@ -11,6 +10,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/search/filter"
 	"github.com/sourcegraph/sourcegraph/internal/search/job"
+	"github.com/sourcegraph/sourcegraph/internal/search/repos"
 	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 )

--- a/internal/search/zoekt/symbol_search_job.go
+++ b/internal/search/zoekt/symbol_search_job.go
@@ -74,13 +74,13 @@ func (z *ZoektSymbolSearchJob) Tags() []log.Field {
 	return tags
 }
 
-type RepoUniverseSymbolSearchJob struct {
+type ZoektGlobalSymbolSearchJob struct {
 	GlobalZoektQuery *GlobalZoektQuery
 	ZoektArgs        *search.ZoektParameters
 	RepoOptions      search.RepoOptions
 }
 
-func (s *RepoUniverseSymbolSearchJob) Run(ctx context.Context, clients job.RuntimeClients, stream streaming.Sender) (alert *search.Alert, err error) {
+func (s *ZoektGlobalSymbolSearchJob) Run(ctx context.Context, clients job.RuntimeClients, stream streaming.Sender) (alert *search.Alert, err error) {
 	tr, ctx, stream, finish := job.StartSpan(ctx, stream, s)
 	defer func() { finish(alert, err) }()
 
@@ -101,6 +101,6 @@ func (s *RepoUniverseSymbolSearchJob) Run(ctx context.Context, clients job.Runti
 	return nil, nil
 }
 
-func (*RepoUniverseSymbolSearchJob) Name() string {
-	return "RepoUniverseSymbolSearchJob"
+func (*ZoektGlobalSymbolSearchJob) Name() string {
+	return "ZoektGlobalSymbolSearchJob"
 }


### PR DESCRIPTION
Part of #34009

Since `RepoUniverseSymbolSearchJob` runs a global symbol search via Zoekt, it seems more appropriate for it to live in the `zoekt` package alongside `ZoektSymbolSearchJob`.

This PR:
- Moves `RepoUniverseSymbolSearchJob` into `symbol_search_job.go` alongside `ZoektSymbolSearchJob`
- Renames `RepoUniverseSymbolSearchJob` to `ZoektGlobalSymbolSearchJob`
- Adds trace tags to `ZoektGlobalSymbolSearchJob`
- Renames `symbol_search_job.go` to `symbol_search.go`

## Test plan
Manually verify that `ZoektGlobalSymbolSearchJob` is still constructed & run when expected and that behavior is the same. Visually verify trace output.

<img width="1230" alt="Screen Shot 2022-05-18 at 2 29 38 PM" src="https://user-images.githubusercontent.com/70350613/169140912-6f14e0d2-5012-484e-91a6-6a0e54044c21.png">
