### PR TITLE
ci: update github action to push metrics to okayhq

### DIFF
--- a/.github/workflows/buildchecker-history.yml
+++ b/.github/workflows/buildchecker-history.yml
@@ -23,3 +23,4 @@ jobs:
         env:
           BUILDKITE_TOKEN: ${{ secrets.AUTOBUILDSHERRIF_BUILDKITE_TOKEN }}
           HONEYCOMB_TOKEN: ${{ secrets.AUTOBUILDSHERRIF_HONEYCOMB_TOKEN }}
+          OKAYHQ_TOKEN: ${{secrets.CI_OKAYHQ_TOKEN}}

--- a/dev/buildchecker/run-week-history.sh
+++ b/dev/buildchecker/run-week-history.sh
@@ -15,4 +15,5 @@ go run ./dev/buildchecker/ \
   -created.to="$created_to" \
   -honeycomb.dataset="buildkite-history" \
   -honeycomb.token="$HONEYCOMB_TOKEN" \
+  -okayhq.token="$CI_OKAYHQ_TOKEN" \
   history


### PR DESCRIPTION
Add okayhq token to github action for ci metrics

Depends on https://github.com/sourcegraph/sourcegraph/pull/35666


## Test plan

Just adds a new flag that has now been merged. Script works locally