### PR TITLE
Insights/unify/remove unused field

### DIFF
--- a/enterprise/internal/insights/background/historical_enqueuer.go
+++ b/enterprise/internal/insights/background/historical_enqueuer.go
@@ -136,7 +136,6 @@ func newInsightHistoricalEnqueuer(ctx context.Context, workerBaseStore *basestor
 	historicalEnqueuer := &historicalEnqueuer{
 		now:             time.Now,
 		insightsStore:   insightsStore,
-		repoStore:       repoStore,
 		db:              dbConn,
 		dataSeriesStore: dataSeriesStore,
 		limiter:         limiter,
@@ -248,7 +247,6 @@ type historicalEnqueuer struct {
 	insightsStore         store.Interface
 	dataSeriesStore       store.DataSeriesStore
 	db                    database.DB
-	repoStore             RepoStore
 	enqueueQueryRunnerJob func(ctx context.Context, job *queryrunner.Job) error
 	gitFirstEverCommit    func(ctx context.Context, db database.DB, repoName api.RepoName) (*gitdomain.Commit, error)
 	gitFindRecentCommit   func(ctx context.Context, repoName api.RepoName, target time.Time) ([]*gitdomain.Commit, error)

--- a/enterprise/internal/insights/background/historical_enqueuer.go
+++ b/enterprise/internal/insights/background/historical_enqueuer.go
@@ -13,7 +13,6 @@ import (
 	"github.com/inconshreveable/log15"
 	"github.com/opentracing/opentracing-go/log"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/xhit/go-str2duration/v2"
 	"golang.org/x/time/rate"
 
 	"github.com/sourcegraph/sourcegraph/internal/actor"
@@ -98,26 +97,6 @@ func newInsightHistoricalEnqueuer(ctx context.Context, workerBaseStore *basestor
 	db := workerBaseStore.Handle().DB()
 	repoStore := database.Repos(db)
 
-	framesToBackfill := func() int {
-		if frames := conf.Get().InsightsHistoricalFrames; frames != 0 {
-			return frames
-		}
-		return 12 // 1 year by default
-	}
-
-	frameLength := func() time.Duration {
-		defaultLen := 30 * 24 * time.Hour
-		if s := conf.Get().InsightsHistoricalFrameLength; s != "" {
-			parsed, err := str2duration.ParseDuration(s)
-			if err != nil {
-				log15.Error("insights: failed to parse site config insights.historical.frameLength", "error", err)
-				return defaultLen
-			}
-			return parsed
-		}
-		return defaultLen
-	}
-
 	iterator := discovery.NewAllReposIterator(
 		dbcache.NewIndexableReposLister(repoStore),
 		repoStore,
@@ -130,7 +109,7 @@ func newInsightHistoricalEnqueuer(ctx context.Context, workerBaseStore *basestor
 			Help:      "Counter of the number of repositories analyzed and queued for processing for insights.",
 		})
 
-	maxTime := time.Now().Add(-time.Duration(framesToBackfill()) * frameLength())
+	maxTime := time.Now().Add(-1 * 365 * 24 * time.Hour)
 
 	dbConn := database.NewDB(db)
 	historicalEnqueuer := &historicalEnqueuer{
@@ -147,10 +126,6 @@ func newInsightHistoricalEnqueuer(ctx context.Context, workerBaseStore *basestor
 		gitFindRecentCommit: func(ctx context.Context, repoName api.RepoName, target time.Time) ([]*gitdomain.Commit, error) {
 			return git.Commits(ctx, dbConn, repoName, git.CommitsOptions{N: 1, Before: target.Format(time.RFC3339), DateOrder: true}, authz.DefaultSubRepoPermsChecker)
 		},
-
-		// Fill e.g. the last 52 weeks of data, recording 1 point per week.
-		framesToBackfill: framesToBackfill,
-		frameLength:      frameLength,
 
 		frameFilter: compression.NewHistoricalFilter(true, maxTime, insightsStore.Handle().DB()),
 

--- a/enterprise/internal/insights/background/historical_enqueuer_test.go
+++ b/enterprise/internal/insights/background/historical_enqueuer_test.go
@@ -136,7 +136,6 @@ func testHistoricalEnqueuer(t *testing.T, p *testParams) *testResults {
 	historicalEnqueuer := &historicalEnqueuer{
 		now:                   clock,
 		insightsStore:         insightsStore,
-		repoStore:             repoStore,
 		enqueueQueryRunnerJob: enqueueQueryRunnerJob,
 		allReposIterator:      allReposIterator,
 		gitFirstEverCommit:    gitFirstEverCommit,

--- a/go.mod
+++ b/go.mod
@@ -158,7 +158,6 @@ require (
 	github.com/urfave/cli/v2 v2.6.0
 	github.com/xeipuuv/gojsonschema v1.2.0
 	github.com/xeonx/timeago v1.0.0-rc4
-	github.com/xhit/go-str2duration/v2 v2.0.0
 	github.com/yuin/gopher-lua v0.0.0-20210529063254-f4c35e4016d9
 	go.etcd.io/bbolt v1.3.6
 	go.uber.org/atomic v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -2369,8 +2369,6 @@ github.com/xeipuuv/gojsonschema v1.2.0 h1:LhYJRs+L4fBtjZUfuSZIKGeVu0QRy8e5Xi7D17
 github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQluxsYJ78Id3Y=
 github.com/xeonx/timeago v1.0.0-rc4 h1:9rRzv48GlJC0vm+iBpLcWAr8YbETyN9Vij+7h2ammz4=
 github.com/xeonx/timeago v1.0.0-rc4/go.mod h1:qDLrYEFynLO7y5Ho7w3GwgtYgpy5UfhcXIIQvMKVDkA=
-github.com/xhit/go-str2duration/v2 v2.0.0 h1:uFtk6FWB375bP7ewQl+/1wBcn840GPhnySOdcz/okPE=
-github.com/xhit/go-str2duration/v2 v2.0.0/go.mod h1:ohY8p+0f07DiV6Em5LKB0s2YpLtXVyJfNt1+BlmyAsU=
 github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8/go.mod h1:HUYIGzjTL3rfEspMxjDjgmT5uz5wzYJKVo23qUhYTos=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xlab/treeprint v0.0.0-20181112141820-a009c3971eca/go.mod h1:ce1O1j6UtZfjr22oyGxGLbauSBp2YVXpARAosm7dHBg=


### PR DESCRIPTION
There is some old crust left over from past iterations of the historical backfiller. These fields aren't truly in use anymore, so I'm removing them to facilitate the refactor in https://github.com/sourcegraph/sourcegraph/issues/35580

## Test plan

Tests pass, and I've run an insight locally 
<img width="550" alt="image" src="https://user-images.githubusercontent.com/5090588/169163912-efc915e8-4ae9-4b4e-b504-938ed046ddf7.png">
