### PR TITLE
pr-auditor: run against pull_request_target

### DIFF
--- a/.github/workflows/pr-auditor.yml
+++ b/.github/workflows/pr-auditor.yml
@@ -1,7 +1,7 @@
 # See dev/pr-auditor/README.md
 name: pr-auditor
 on:
-  pull_request:
+  pull_request_target:
     types: [ closed, edited, opened, synchronize ]
 
 jobs:


### PR DESCRIPTION
This allows us to set status on forks. Found the documentation here completely by chance: https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/

closes https://github.com/sourcegraph/sourcegraph/issues/32427 , reveals need for potentially https://github.com/sourcegraph/sourcegraph/issues/35683

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

<img width="843" alt="image" src="https://user-images.githubusercontent.com/23356519/169164498-05aafe57-fb7e-4e36-9069-27ebdf9ee2ef.png">
<img width="893" alt="image" src="https://user-images.githubusercontent.com/23356519/169164798-e5b6609e-f71d-42b0-9e67-9feb4cb5babe.png">
