### PR TITLE
dev/sg: migrate sg generate to use sg/run, render nice diff, do not lint generate in dirty dir

### DIFF
--- a/dev/sg/linters/gogenerate.go
+++ b/dev/sg/linters/gogenerate.go
@@ -1,38 +1,63 @@
 package linters
 
 import (
+	"bytes"
 	"context"
-	"os/exec"
+	"fmt"
 	"strings"
+
+	"github.com/sourcegraph/run"
 
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/generate/golang"
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/lint"
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/repo"
+	"github.com/sourcegraph/sourcegraph/dev/sg/internal/std"
+	"github.com/sourcegraph/sourcegraph/dev/sg/root"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 	"github.com/sourcegraph/sourcegraph/lib/output"
 )
 
-func lintGoGenerate(ctx context.Context, _ *repo.State) *lint.Report {
+func lintGoGenerate(ctx context.Context, state *repo.State) *lint.Report {
+	const header = "Go generate check"
+
+	// Do not run in dirty state, because the diff check we do later will be inaccurate
+	diff, err := state.GetDiff("**/*")
+	if err != nil {
+		return &lint.Report{
+			Header: header,
+			Err:    err,
+		}
+	}
+	if len(diff) > 0 {
+		var files []string
+		for file := range diff {
+			files = append(files, file)
+		}
+		return &lint.Report{
+			Header: header,
+			Err:    errors.Newf("cannot run go generate check with uncommitted changes: %+v", files),
+		}
+	}
+
 	report := golang.Generate(ctx, nil, golang.QuietOutput)
 	if report.Err != nil {
 		return &lint.Report{
-			Header: "Go generate check",
+			Header: header,
 			Err:    report.Err,
 		}
 	}
 
-	cmd := exec.CommandContext(ctx, "git", "diff", "--exit-code", "--", ".", ":!go.sum")
-	out, err := cmd.CombinedOutput()
 	r := lint.Report{
-		Header: "Go generate check",
+		Header: header,
 	}
+
+	var out bytes.Buffer
+	err = root.Run(run.Cmd(ctx, "git", "diff", "--exit-code", "--", ".", ":!go.sum")).Stream(&out)
 	if err != nil {
 		var sb strings.Builder
-		reportOut := output.NewOutput(&sb, output.OutputOpts{
-			ForceColor: true,
-			ForceTTY:   true,
-		})
+		reportOut := std.NewOutput(&sb, true)
 		reportOut.WriteLine(output.Line(output.EmojiFailure, output.StyleWarning, "Uncommitted changes found after running go generate:"))
-		sb.WriteString(string(out))
+		reportOut.WriteMarkdown(fmt.Sprintf("```diff\n%s\n```", out.String()))
 		r.Err = err
 		r.Output = sb.String()
 		return &r

--- a/dev/sg/linters/gogenerate.go
+++ b/dev/sg/linters/gogenerate.go
@@ -58,6 +58,7 @@ func lintGoGenerate(ctx context.Context, state *repo.State) *lint.Report {
 		reportOut := std.NewOutput(&sb, true)
 		reportOut.WriteLine(output.Line(output.EmojiFailure, output.StyleWarning, "Uncommitted changes found after running go generate:"))
 		reportOut.WriteMarkdown(fmt.Sprintf("```diff\n%s\n```", out.String()))
+		reportOut.Write("To fix this, run 'sg generate'.")
 		r.Err = err
 		r.Output = sb.String()
 		return &r

--- a/go.mod
+++ b/go.mod
@@ -141,7 +141,7 @@ require (
 	github.com/sourcegraph/go-lsp v0.0.0-20200429204803-219e11d77f5d
 	github.com/sourcegraph/go-rendezvous v0.0.0-20210910070954-ef39ade5591d
 	github.com/sourcegraph/jsonx v0.0.0-20200629203448-1a936bd500cf
-	github.com/sourcegraph/run v0.4.0
+	github.com/sourcegraph/run v0.6.0
 	github.com/sourcegraph/sourcegraph/enterprise/dev/ci/images v0.0.0-20220203145655-4d2a39d3038a
 	github.com/sourcegraph/sourcegraph/lib v0.0.0-20220203145655-4d2a39d3038a
 	github.com/stretchr/testify v1.7.1
@@ -199,6 +199,8 @@ require (
 	github.com/cockroachdb/errors v1.8.9 // indirect
 	github.com/containerd/typeurl v1.0.2 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.1 // indirect
+	github.com/djherbis/buffer v1.2.0 // indirect
+	github.com/djherbis/nio/v3 v3.0.1 // indirect
 	github.com/dlclark/regexp2 v1.4.0 // indirect
 	github.com/docker/docker v20.10.7+incompatible // indirect
 	github.com/docker/go-connections v0.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -655,6 +655,11 @@ github.com/dineshappavoo/basex v0.0.0-20170425072625-481a6f6dc663 h1:fctNkSsavbX
 github.com/dineshappavoo/basex v0.0.0-20170425072625-481a6f6dc663/go.mod h1:Kad2hux31v/IyD4Rf4wAwIyK48995rs3qAl9IUAhc2k=
 github.com/distribution/distribution/v3 v3.0.0-20220128175647-b60926597a1b h1:ou+y/Ko923eBli6zJ/TeB2iH38PmytV2UkHJnVdaPtU=
 github.com/distribution/distribution/v3 v3.0.0-20220128175647-b60926597a1b/go.mod h1:N8Wvr/4EfOTcDc6vF1l5OFe0Mw+rdYh+WtLrS69sjTU=
+github.com/djherbis/buffer v1.1.0/go.mod h1:VwN8VdFkMY0DCALdY8o00d3IZ6Amz/UNVMWcSaJT44o=
+github.com/djherbis/buffer v1.2.0 h1:PH5Dd2ss0C7CRRhQCZ2u7MssF+No9ide8Ye71nPHcrQ=
+github.com/djherbis/buffer v1.2.0/go.mod h1:fjnebbZjCUpPinBRD+TDwXSOeNQ7fPQWLfGQqiAiUyE=
+github.com/djherbis/nio/v3 v3.0.1 h1:6wxhnuppteMa6RHA4L81Dq7ThkZH8SwnDzXDYy95vB4=
+github.com/djherbis/nio/v3 v3.0.1/go.mod h1:Ng4h80pbZFMla1yKzm61cF0tqqilXZYrogmWgZxOcmg=
 github.com/dlclark/regexp2 v1.4.0 h1:F1rxgk7p4uKjwIQxBs9oAXe5CqrXlCduYEJvrF4u93E=
 github.com/dlclark/regexp2 v1.4.0/go.mod h1:2pZnwuY/m+8K6iRw6wQdMtk+rH5tNGR1i55kozfMjCc=
 github.com/dnaeon/go-vcr v1.0.1/go.mod h1:aBB1+wY4s93YsC3HHjMBMrwTj2R9FHDzUr9KyGc8n1E=
@@ -2163,8 +2168,8 @@ github.com/sourcegraph/jsonx v0.0.0-20200629203448-1a936bd500cf h1:oAdWFqhStsWii
 github.com/sourcegraph/jsonx v0.0.0-20200629203448-1a936bd500cf/go.mod h1:ppFaPm6kpcHnZGqQTFhUIAQRIEhdQDWP1PCv4/ON354=
 github.com/sourcegraph/oauth2 v0.0.0-20210825125341-77c1d99ece3c h1:HGa4iJr6MGKnB5qbU7tI511NdGuHUHnNCqP67G6KmfE=
 github.com/sourcegraph/oauth2 v0.0.0-20210825125341-77c1d99ece3c/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
-github.com/sourcegraph/run v0.4.0 h1:O+Fn1WhfEqII0vISeCJt4yuYwAKu86JWOE3M1IvXkHs=
-github.com/sourcegraph/run v0.4.0/go.mod h1:tiCENR4q/qc+3+Kyzfwine52XA1HNQL87O1L6NgoUT0=
+github.com/sourcegraph/run v0.6.0 h1:u8lXiaWwhQlhpxwOuW9qnxp1tDDrJs7bQjTvI1OE8Jc=
+github.com/sourcegraph/run v0.6.0/go.mod h1:j6Do38ccF+w/rSWgOuu4Ou/eOIDiU6pC87BZmq0DXDY=
 github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e h1:qpG93cPwA5f7s/ZPBJnGOYQNK/vKsaDaseuKT5Asee8=
 github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e/go.mod h1:HuIsMU8RRBOtsCgI77wP899iHVBQpCmg4ErYMZB+2IA=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152 h1:z/MpntplPaW6QW95pzcAR/72Z5TWDyDnSo0EOcyij9o=


### PR DESCRIPTION
With uncommitted changes, `sg lint go` is inaccurate because it reports all your code changes as generated changes. Maybe we can do some kind of stashing first, but that will affect other lints, so let's just do this for now.

Tangential effort trying to see where we might be losing output from https://sourcegraph.slack.com/archives/C01N83PS4TU/p1652912619242789

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

<img width="601" alt="Screenshot 2022-05-18 at 3 54 03 PM" src="https://user-images.githubusercontent.com/23356519/169168683-3f601ffc-ff59-43b1-95d0-2b2ce106458f.png">
