### PR TITLE
Search backend: Unify job tracing in observe.go

### DIFF
--- a/internal/search/commit/commit.go
+++ b/internal/search/commit/commit.go
@@ -50,9 +50,8 @@ type GitserverClient interface {
 }
 
 func (j *CommitSearchJob) Run(ctx context.Context, clients job.RuntimeClients, stream streaming.Sender) (alert *search.Alert, err error) {
-	tr, ctx, stream, finish := job.StartSpan(ctx, stream, j)
+	_, ctx, stream, finish := job.StartSpan(ctx, stream, j)
 	defer func() { finish(alert, err) }()
-	tr.TagFields(trace.LazyFields(j.Tags))
 
 	if err := j.ExpandUsernames(ctx, clients.DB); err != nil {
 		return nil, err

--- a/internal/search/job/job.go
+++ b/internal/search/job/job.go
@@ -7,6 +7,7 @@ import (
 	"context"
 
 	"github.com/google/zoekt"
+	"github.com/opentracing/opentracing-go/log"
 
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/endpoint"
@@ -23,6 +24,7 @@ import (
 type Job interface {
 	Run(context.Context, RuntimeClients, streaming.Sender) (*search.Alert, error)
 	Name() string
+	Tags() []log.Field
 }
 
 type RuntimeClients struct {

--- a/internal/search/job/jobutil/alert.go
+++ b/internal/search/job/jobutil/alert.go
@@ -34,9 +34,8 @@ type alertJob struct {
 }
 
 func (j *alertJob) Run(ctx context.Context, clients job.RuntimeClients, stream streaming.Sender) (alert *search.Alert, err error) {
-	tr, ctx, stream, finish := job.StartSpan(ctx, stream, j)
+	_, ctx, stream, finish := job.StartSpan(ctx, stream, j)
 	defer func() { finish(alert, err) }()
-	tr.TagFields(trace.LazyFields(j.Tags))
 
 	start := time.Now()
 	countingStream := streaming.NewResultCountingStream(stream)

--- a/internal/search/job/jobutil/combinators.go
+++ b/internal/search/job/jobutil/combinators.go
@@ -118,9 +118,8 @@ type TimeoutJob struct {
 }
 
 func (t *TimeoutJob) Run(ctx context.Context, clients job.RuntimeClients, s streaming.Sender) (alert *search.Alert, err error) {
-	tr, ctx, s, finish := job.StartSpan(ctx, s, t)
+	_, ctx, s, finish := job.StartSpan(ctx, s, t)
 	defer func() { finish(alert, err) }()
-	tr.TagFields(trace.LazyFields(t.Tags))
 
 	ctx, cancel := context.WithTimeout(ctx, t.timeout)
 	defer cancel()
@@ -158,9 +157,8 @@ type LimitJob struct {
 }
 
 func (l *LimitJob) Run(ctx context.Context, clients job.RuntimeClients, s streaming.Sender) (alert *search.Alert, err error) {
-	tr, ctx, s, finish := job.StartSpan(ctx, s, l)
+	_, ctx, s, finish := job.StartSpan(ctx, s, l)
 	defer func() { finish(alert, err) }()
-	tr.TagFields(trace.LazyFields(l.Tags))
 
 	ctx, s, cancel := streaming.WithLimit(ctx, s, l.limit)
 	defer cancel()

--- a/internal/search/job/jobutil/combinators.go
+++ b/internal/search/job/jobutil/combinators.go
@@ -36,6 +36,10 @@ func (s *SequentialJob) Name() string {
 	return "SequentialJob"
 }
 
+func (s *SequentialJob) Tags() []log.Field {
+	return []log.Field{}
+}
+
 func (s *SequentialJob) Run(ctx context.Context, clients job.RuntimeClients, stream streaming.Sender) (alert *search.Alert, err error) {
 	var maxAlerter search.MaxAlerter
 	var errs errors.MultiError
@@ -71,6 +75,10 @@ type ParallelJob struct {
 
 func (p *ParallelJob) Name() string {
 	return "ParallelJob"
+}
+
+func (p *ParallelJob) Tags() []log.Field {
+	return []log.Field{}
 }
 
 func (p *ParallelJob) Run(ctx context.Context, clients job.RuntimeClients, s streaming.Sender) (alert *search.Alert, err error) {

--- a/internal/search/job/jobutil/combinators.go
+++ b/internal/search/job/jobutil/combinators.go
@@ -193,3 +193,7 @@ func (e *NoopJob) Run(context.Context, job.RuntimeClients, streaming.Sender) (*s
 }
 
 func (e *NoopJob) Name() string { return "NoopJob" }
+
+func (e *NoopJob) Tags() []log.Field {
+	return []log.Field{}
+}

--- a/internal/search/job/jobutil/expression_job.go
+++ b/internal/search/job/jobutil/expression_job.go
@@ -3,6 +3,7 @@ package jobutil
 import (
 	"context"
 
+	"github.com/opentracing/opentracing-go/log"
 	"go.uber.org/atomic"
 	"golang.org/x/sync/semaphore"
 
@@ -77,6 +78,10 @@ func (a *AndJob) Run(ctx context.Context, clients job.RuntimeClients, stream str
 
 func (a *AndJob) Name() string {
 	return "AndJob"
+}
+
+func (a *AndJob) Tags() []log.Field {
+	return []log.Field{}
 }
 
 // NewAndJob creates a job that will run each of its child jobs and stream
@@ -170,4 +175,8 @@ func (j *OrJob) Run(ctx context.Context, clients job.RuntimeClients, stream stre
 
 func (j *OrJob) Name() string {
 	return "OrJob"
+}
+
+func (j *OrJob) Tags() []log.Field {
+	return []log.Field{}
 }

--- a/internal/search/job/jobutil/repo_pager_job.go
+++ b/internal/search/job/jobutil/repo_pager_job.go
@@ -60,9 +60,8 @@ func setRepos(job job.Job, indexed *zoekt.IndexedRepoRevs, unindexed []*search.R
 }
 
 func (p *repoPagerJob) Run(ctx context.Context, clients job.RuntimeClients, stream streaming.Sender) (alert *search.Alert, err error) {
-	tr, ctx, stream, finish := job.StartSpan(ctx, stream, p)
+	_, ctx, stream, finish := job.StartSpan(ctx, stream, p)
 	defer func() { finish(alert, err) }()
-	tr.TagFields(trace.LazyFields(p.Tags))
 
 	var maxAlerter search.MaxAlerter
 

--- a/internal/search/job/jobutil/select.go
+++ b/internal/search/job/jobutil/select.go
@@ -24,9 +24,8 @@ type selectJob struct {
 }
 
 func (j *selectJob) Run(ctx context.Context, clients job.RuntimeClients, stream streaming.Sender) (alert *search.Alert, err error) {
-	tr, ctx, stream, finish := job.StartSpan(ctx, stream, j)
+	_, ctx, stream, finish := job.StartSpan(ctx, stream, j)
 	defer func() { finish(alert, err) }()
-	tr.TagFields(trace.LazyFields(j.Tags))
 
 	selectingStream := streaming.WithSelect(stream, j.path)
 	return j.child.Run(ctx, clients, selectingStream)

--- a/internal/search/job/jobutil/sub_repo_perms_job.go
+++ b/internal/search/job/jobutil/sub_repo_perms_job.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 
 	"github.com/inconshreveable/log15"
+	"github.com/opentracing/opentracing-go/log"
 
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
@@ -56,6 +57,10 @@ func (s *subRepoPermsFilterJob) Run(ctx context.Context, clients job.RuntimeClie
 
 func (s *subRepoPermsFilterJob) Name() string {
 	return "SubRepoPermsFilterJob"
+}
+
+func (s *subRepoPermsFilterJob) Tags() []log.Field {
+	return []log.Field{}
 }
 
 // applySubRepoFiltering filters a set of matches using the provided

--- a/internal/search/job/observe.go
+++ b/internal/search/job/observe.go
@@ -13,12 +13,14 @@ import (
 
 type observableJob interface {
 	Name() string
+	Tags() []log.Field
 }
 
 type finishSpanFunc func(*search.Alert, error)
 
 func StartSpan(ctx context.Context, stream streaming.Sender, job observableJob) (*trace.Trace, context.Context, streaming.Sender, finishSpanFunc) {
 	tr, ctx := trace.New(ctx, job.Name(), "")
+	tr.TagFields(trace.LazyFields(job.Tags))
 
 	observingStream := newObservingStream(tr, stream)
 

--- a/internal/search/job/observe.go
+++ b/internal/search/job/observe.go
@@ -11,14 +11,9 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 )
 
-type observableJob interface {
-	Name() string
-	Tags() []log.Field
-}
-
 type finishSpanFunc func(*search.Alert, error)
 
-func StartSpan(ctx context.Context, stream streaming.Sender, job observableJob) (*trace.Trace, context.Context, streaming.Sender, finishSpanFunc) {
+func StartSpan(ctx context.Context, stream streaming.Sender, job Job) (*trace.Trace, context.Context, streaming.Sender, finishSpanFunc) {
 	tr, ctx := trace.New(ctx, job.Name(), "")
 	tr.TagFields(trace.LazyFields(job.Tags))
 

--- a/internal/search/repos/excluded_job.go
+++ b/internal/search/repos/excluded_job.go
@@ -16,9 +16,8 @@ type ComputeExcludedReposJob struct {
 }
 
 func (c *ComputeExcludedReposJob) Run(ctx context.Context, clients job.RuntimeClients, s streaming.Sender) (alert *search.Alert, err error) {
-	tr, ctx, s, finish := job.StartSpan(ctx, s, c)
+	_, ctx, s, finish := job.StartSpan(ctx, s, c)
 	defer func() { finish(alert, err) }()
-	tr.TagFields(trace.LazyFields(c.Tags))
 
 	excluded, err := computeExcludedRepos(ctx, clients.DB, c.RepoOpts)
 	if err != nil {

--- a/internal/search/run/repository.go
+++ b/internal/search/run/repository.go
@@ -27,7 +27,6 @@ type RepoSearchJob struct {
 func (s *RepoSearchJob) Run(ctx context.Context, clients job.RuntimeClients, stream streaming.Sender) (alert *search.Alert, err error) {
 	tr, ctx, stream, finish := job.StartSpan(ctx, stream, s)
 	defer func() { finish(alert, err) }()
-	tr.TagFields(trace.LazyFields(s.Tags))
 
 	repos := &searchrepos.Resolver{DB: clients.DB, Opts: s.RepoOpts}
 	err = repos.Paginate(ctx, func(page *searchrepos.Resolved) error {

--- a/internal/search/searcher/search.go
+++ b/internal/search/searcher/search.go
@@ -49,7 +49,6 @@ type SearcherJob struct {
 func (s *SearcherJob) Run(ctx context.Context, clients job.RuntimeClients, stream streaming.Sender) (alert *search.Alert, err error) {
 	tr, ctx, stream, finish := job.StartSpan(ctx, stream, s)
 	defer func() { finish(alert, err) }()
-	tr.TagFields(trace.LazyFields(s.Tags))
 
 	var fetchTimeout time.Duration
 	if len(s.Repos) == 1 || s.UseFullDeadline {

--- a/internal/search/searcher/symbol_search_job.go
+++ b/internal/search/searcher/symbol_search_job.go
@@ -33,7 +33,6 @@ type SymbolSearcherJob struct {
 func (s *SymbolSearcherJob) Run(ctx context.Context, clients job.RuntimeClients, stream streaming.Sender) (alert *search.Alert, err error) {
 	tr, ctx, stream, finish := job.StartSpan(ctx, stream, s)
 	defer func() { finish(alert, err) }()
-	tr.TagFields(trace.LazyFields(s.Tags))
 
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()

--- a/internal/search/structural/structural.go
+++ b/internal/search/structural/structural.go
@@ -161,9 +161,8 @@ type StructuralSearchJob struct {
 }
 
 func (s *StructuralSearchJob) Run(ctx context.Context, clients job.RuntimeClients, stream streaming.Sender) (alert *search.Alert, err error) {
-	tr, ctx, stream, finish := job.StartSpan(ctx, stream, s)
+	_, ctx, stream, finish := job.StartSpan(ctx, stream, s)
 	defer func() { finish(alert, err) }()
-	tr.TagFields(trace.LazyFields(s.Tags))
 
 	repos := &searchrepos.Resolver{DB: clients.DB, Opts: s.RepoOpts}
 	return nil, repos.Paginate(ctx, func(page *searchrepos.Resolved) error {

--- a/internal/search/zoekt/indexed_search.go
+++ b/internal/search/zoekt/indexed_search.go
@@ -527,9 +527,8 @@ type ZoektRepoSubsetSearchJob struct {
 
 // ZoektSearch is a job that searches repositories using zoekt.
 func (z *ZoektRepoSubsetSearchJob) Run(ctx context.Context, clients job.RuntimeClients, stream streaming.Sender) (alert *search.Alert, err error) {
-	tr, ctx, stream, finish := job.StartSpan(ctx, stream, z)
+	_, ctx, stream, finish := job.StartSpan(ctx, stream, z)
 	defer func() { finish(alert, err) }()
-	tr.TagFields(trace.LazyFields(z.Tags))
 
 	if z.Repos == nil {
 		return nil, nil
@@ -572,9 +571,8 @@ type ZoektGlobalSearchJob struct {
 }
 
 func (t *ZoektGlobalSearchJob) Run(ctx context.Context, clients job.RuntimeClients, stream streaming.Sender) (alert *search.Alert, err error) {
-	tr, ctx, stream, finish := job.StartSpan(ctx, stream, t)
+	_, ctx, stream, finish := job.StartSpan(ctx, stream, t)
 	defer func() { finish(alert, err) }()
-	tr.TagFields(trace.LazyFields(t.Tags))
 
 	userPrivateRepos := searchrepos.PrivateReposForActor(ctx, clients.DB, t.RepoOpts)
 	t.GlobalZoektQuery.ApplyPrivateFilter(userPrivateRepos)

--- a/internal/search/zoekt/symbol_search.go
+++ b/internal/search/zoekt/symbol_search.go
@@ -27,7 +27,6 @@ type ZoektSymbolSearchJob struct {
 func (z *ZoektSymbolSearchJob) Run(ctx context.Context, clients job.RuntimeClients, stream streaming.Sender) (alert *search.Alert, err error) {
 	tr, ctx, stream, finish := job.StartSpan(ctx, stream, z)
 	defer func() { finish(alert, err) }()
-	tr.TagFields(trace.LazyFields(z.Tags))
 
 	if z.Repos == nil {
 		return nil, nil
@@ -83,7 +82,6 @@ type ZoektGlobalSymbolSearchJob struct {
 func (s *ZoektGlobalSymbolSearchJob) Run(ctx context.Context, clients job.RuntimeClients, stream streaming.Sender) (alert *search.Alert, err error) {
 	tr, ctx, stream, finish := job.StartSpan(ctx, stream, s)
 	defer func() { finish(alert, err) }()
-	tr.TagFields(trace.LazyFields(s.Tags))
 
 	userPrivateRepos := repos.PrivateReposForActor(ctx, clients.DB, s.RepoOpts)
 	s.GlobalZoektQuery.ApplyPrivateFilter(userPrivateRepos)


### PR DESCRIPTION
Completes #34009

This PR unifies job tracing in `observe.go`. With these changes, all jobs now have their fields added to their span automatically in `job.StartSpan()`.

## Test plan
N/A, just a refactor