### PR TITLE
database: remove dbutil-based constructors

### DIFF
--- a/cmd/frontend/graphqlbackend/org.go
+++ b/cmd/frontend/graphqlbackend/org.go
@@ -360,7 +360,7 @@ func (r *schemaResolver) RemoveUserFromOrganization(ctx context.Context, args *s
 	if err := backend.CheckOrgAccessOrSiteAdmin(ctx, r.db, orgID); err != nil {
 		return nil, err
 	}
-	memberCount, err := database.OrgMembers(r.db).MemberCount(ctx, orgID)
+	memberCount, err := r.db.OrgMembers().MemberCount(ctx, orgID)
 	if err != nil {
 		return nil, err
 	}
@@ -368,7 +368,7 @@ func (r *schemaResolver) RemoveUserFromOrganization(ctx context.Context, args *s
 		return nil, errors.New("you can’t remove the only member of an organization")
 	}
 	log15.Info("removing user from org", "user", userID, "org", orgID)
-	if err := database.OrgMembers(r.db).Remove(ctx, orgID, userID); err != nil {
+	if err := r.db.OrgMembers().Remove(ctx, orgID, userID); err != nil {
 		return nil, err
 	}
 

--- a/cmd/frontend/graphqlbackend/org_invitation.go
+++ b/cmd/frontend/graphqlbackend/org_invitation.go
@@ -28,7 +28,7 @@ func orgInvitationByID(ctx context.Context, db database.DB, id graphql.ID) (*org
 }
 
 func orgInvitationByIDInt64(ctx context.Context, db database.DB, id int64) (*organizationInvitationResolver, error) {
-	orgInvitation, err := database.OrgInvitations(db).GetByID(ctx, id)
+	orgInvitation, err := db.OrgInvitations().GetByID(ctx, id)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/graphqlbackend/org_members.go
+++ b/cmd/frontend/graphqlbackend/org_members.go
@@ -19,7 +19,7 @@ func (r *UserResolver) OrganizationMemberships(ctx context.Context) (*organizati
 	if err := backend.CheckSiteAdminOrSameUser(ctx, r.db, r.user.ID); err != nil {
 		return nil, err
 	}
-	memberships, err := database.OrgMembers(r.db).GetByUserID(ctx, r.user.ID)
+	memberships, err := r.db.OrgMembers().GetByUserID(ctx, r.user.ID)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/internal/httpapi/internal.go
+++ b/cmd/frontend/internal/httpapi/internal.go
@@ -181,7 +181,7 @@ func serveOrgsListUsers(db database.DB) func(w http.ResponseWriter, r *http.Requ
 		if err != nil {
 			return errors.Wrap(err, "Decode")
 		}
-		orgMembers, err := database.OrgMembers(db).GetByOrgID(r.Context(), orgID)
+		orgMembers, err := db.OrgMembers().GetByOrgID(r.Context(), orgID)
 		if err != nil {
 			return errors.Wrap(err, "OrgMembers.GetByOrgID")
 		}

--- a/enterprise/cmd/frontend/internal/notebooks/resolvers/resolvers_test.go
+++ b/enterprise/cmd/frontend/internal/notebooks/resolvers/resolvers_test.go
@@ -2,7 +2,6 @@ package resolvers
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
 	"strings"
 	"testing"
@@ -180,11 +179,11 @@ func compareNotebookAPIResponses(t *testing.T, wantNotebookResponse notebooksapi
 
 func TestSingleNotebookCRUD(t *testing.T) {
 	internalCtx := actor.WithInternalActor(context.Background())
-	testdb := dbtest.NewDB(t)
+	testdb := database.NewDB(dbtest.NewDB(t))
 	db := database.NewDB(testdb)
 	u := database.Users(db)
 	o := database.Orgs(db)
-	om := database.OrgMembers(db)
+	om := db.OrgMembers()
 
 	user1, err := u.Create(internalCtx, database.NewUser{Username: "u1", Password: "p"})
 	if err != nil {
@@ -521,7 +520,7 @@ func testDeleteNotebook(t *testing.T, db database.DB, schema *graphql.Schema, us
 	}
 }
 
-func createNotebooks(t *testing.T, db *sql.DB, notebooksToCreate []*notebooks.Notebook) []*notebooks.Notebook {
+func createNotebooks(t *testing.T, db database.DB, notebooksToCreate []*notebooks.Notebook) []*notebooks.Notebook {
 	t.Helper()
 	n := notebooks.Notebooks(db)
 	internalCtx := actor.WithInternalActor(context.Background())
@@ -536,7 +535,7 @@ func createNotebooks(t *testing.T, db *sql.DB, notebooksToCreate []*notebooks.No
 	return createdNotebooks
 }
 
-func createNotebookStars(t *testing.T, db *sql.DB, notebookID int64, userIDs ...int32) {
+func createNotebookStars(t *testing.T, db database.DB, notebookID int64, userIDs ...int32) {
 	t.Helper()
 	n := notebooks.Notebooks(db)
 	internalCtx := actor.WithInternalActor(context.Background())
@@ -549,11 +548,11 @@ func createNotebookStars(t *testing.T, db *sql.DB, notebookID int64, userIDs ...
 }
 
 func TestListNotebooks(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	internalCtx := actor.WithInternalActor(context.Background())
 	u := database.Users(db)
 	o := database.Orgs(db)
-	om := database.OrgMembers(db)
+	om := db.OrgMembers()
 
 	user1, err := u.Create(internalCtx, database.NewUser{Username: "u1", Password: "p"})
 	if err != nil {

--- a/enterprise/cmd/frontend/internal/notebooks/resolvers/stars_resolvers_test.go
+++ b/enterprise/cmd/frontend/internal/notebooks/resolvers/stars_resolvers_test.go
@@ -60,7 +60,7 @@ query NotebookStars($id: ID!, $first: Int!, $after: String) {
 `, notebookStarFields)
 
 func TestCreateAndDeleteNotebookStars(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	internalCtx := actor.WithInternalActor(context.Background())
 	u := database.Users(db)
 
@@ -136,7 +136,7 @@ func createAPINotebookStars(t *testing.T, schema *graphql.Schema, notebookID int
 }
 
 func TestListNotebookStars(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	internalCtx := actor.WithInternalActor(context.Background())
 	u := database.Users(db)
 

--- a/enterprise/internal/batches/service/service_test.go
+++ b/enterprise/internal/batches/service/service_test.go
@@ -534,7 +534,7 @@ func TestService(t *testing.T) {
 			}
 
 			// Create org membership and try again
-			if _, err := database.OrgMembers(db).Create(ctx, orgID, user.ID); err != nil {
+			if _, err := db.OrgMembers().Create(ctx, orgID, user.ID); err != nil {
 				t.Fatal(err)
 			}
 

--- a/enterprise/internal/database/perms_store_test.go
+++ b/enterprise/internal/database/perms_store_test.go
@@ -3008,7 +3008,7 @@ func testPermsStore_UserIsMemberOfOrgHasCodeHostConnection(db *sql.DB) func(*tes
 		cindyOrg, err := orgs.Create(ctx, "cindy-org", nil)
 		require.NoError(t, err)
 
-		orgMembers := database.OrgMembers(db)
+		orgMembers := db.OrgMembers()
 		_, err = orgMembers.Create(ctx, bobOrg.ID, bob.ID)
 		require.NoError(t, err)
 		_, err = orgMembers.Create(ctx, cindyOrg.ID, cindy.ID)

--- a/enterprise/internal/notebooks/store_test.go
+++ b/enterprise/internal/notebooks/store_test.go
@@ -39,7 +39,7 @@ func notebookByOrg(notebook *Notebook, creatorID int32, orgID int32) *Notebook {
 
 func TestCreateAndGetNotebook(t *testing.T) {
 	t.Parallel()
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	ctx := actor.WithInternalActor(context.Background())
 	u := database.Users(db)
 	n := Notebooks(db)
@@ -79,7 +79,7 @@ func TestCreateAndGetNotebook(t *testing.T) {
 
 func TestUpdateNotebook(t *testing.T) {
 	t.Parallel()
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	ctx := actor.WithInternalActor(context.Background())
 	u := database.Users(db)
 	n := Notebooks(db)
@@ -116,7 +116,7 @@ func TestUpdateNotebook(t *testing.T) {
 
 func TestDeleteNotebook(t *testing.T) {
 	t.Parallel()
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	ctx := actor.WithInternalActor(context.Background())
 	u := database.Users(db)
 	n := Notebooks(db)
@@ -189,11 +189,11 @@ func createNotebookStars(ctx context.Context, store NotebooksStore, userID int32
 
 func TestListingAndCountingNotebooks(t *testing.T) {
 	t.Parallel()
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	internalCtx := actor.WithInternalActor(context.Background())
 	u := database.Users(db)
 	o := database.Orgs(db)
-	om := database.OrgMembers(db)
+	om := db.OrgMembers()
 	n := Notebooks(db)
 
 	user1, err := u.Create(internalCtx, database.NewUser{Username: "u1", Password: "p"})
@@ -447,7 +447,7 @@ func TestListingAndCountingNotebooks(t *testing.T) {
 
 func TestCreatingNotebookWithInvalidBlock(t *testing.T) {
 	t.Parallel()
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	ctx := actor.WithInternalActor(context.Background())
 	u := database.Users(db)
 	n := Notebooks(db)
@@ -471,11 +471,11 @@ func TestCreatingNotebookWithInvalidBlock(t *testing.T) {
 
 func TestNotebookPermissions(t *testing.T) {
 	t.Parallel()
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	internalCtx := actor.WithInternalActor(context.Background())
 	u := database.Users(db)
 	o := database.Orgs(db)
-	om := database.OrgMembers(db)
+	om := db.OrgMembers()
 	n := Notebooks(db)
 
 	user1, err := u.Create(internalCtx, database.NewUser{Username: "u1", Password: "p"})
@@ -541,7 +541,7 @@ func TestNotebookPermissions(t *testing.T) {
 
 func TestListingNotebookStars(t *testing.T) {
 	t.Parallel()
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	internalCtx := actor.WithInternalActor(context.Background())
 	u := database.Users(db)
 	n := Notebooks(db)
@@ -627,7 +627,7 @@ func TestListingNotebookStars(t *testing.T) {
 
 func TestCreatingAndDeletingNotebookStars(t *testing.T) {
 	t.Parallel()
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	internalCtx := actor.WithInternalActor(context.Background())
 	u := database.Users(db)
 	n := Notebooks(db)

--- a/internal/database/feature_flags_test.go
+++ b/internal/database/feature_flags_test.go
@@ -276,7 +276,7 @@ func testListOrgOverrides(t *testing.T) {
 	flagStore := &featureFlagStore{Store: basestore.NewWithDB(db, sql.TxOptions{})}
 	users := Users(db)
 	orgs := Orgs(db)
-	orgMembers := OrgMembers(db)
+	orgMembers := db.OrgMembers()
 	ctx := actor.WithInternalActor(context.Background())
 
 	mkUser := func(name string, orgIDs ...int32) *types.User {
@@ -361,7 +361,7 @@ func testUserFlags(t *testing.T) {
 	flagStore := db.FeatureFlags()
 	users := Users(db)
 	orgs := Orgs(db)
-	orgMembers := OrgMembers(db)
+	orgMembers := db.OrgMembers()
 	ctx := actor.WithInternalActor(context.Background())
 
 	mkUser := func(name string, orgIDs ...int32) *types.User {

--- a/internal/database/org_invitations.go
+++ b/internal/database/org_invitations.go
@@ -76,12 +76,7 @@ type orgInvitationStore struct {
 	*basestore.Store
 }
 
-// OrgInvitations instantiates and returns a new OrgInvitationStore with prepared statements.
-func OrgInvitations(db dbutil.DB) OrgInvitationStore {
-	return &orgInvitationStore{Store: basestore.NewWithDB(db, sql.TxOptions{})}
-}
-
-// NewOrgInvitationStoreWithDB instantiates and returns a new OrgInvitationStore using the other store handle.
+// OrgInvitationsWith instantiates and returns a new OrgInvitationStore using the other store handle.
 func OrgInvitationsWith(other basestore.ShareableStore) OrgInvitationStore {
 	return &orgInvitationStore{Store: basestore.NewWithHandle(other.Handle())}
 }

--- a/internal/database/org_invitations_test.go
+++ b/internal/database/org_invitations_test.go
@@ -324,7 +324,7 @@ func TestOrgInvitations(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		toRevokeInvite, err := OrgInvitations(db).Create(ctx, org3.ID, sender.ID, recipient.ID, "", timeNow().Add(time.Hour))
+		toRevokeInvite, err := db.OrgInvitations().Create(ctx, org3.ID, sender.ID, recipient.ID, "", timeNow().Add(time.Hour))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -347,7 +347,7 @@ func TestOrgInvitations(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		toUpdateInvite, err := OrgInvitations(db).Create(ctx, org4.ID, sender.ID, recipient.ID, "", timeNow().Add(time.Hour))
+		toUpdateInvite, err := db.OrgInvitations().Create(ctx, org4.ID, sender.ID, recipient.ID, "", timeNow().Add(time.Hour))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -358,7 +358,7 @@ func TestOrgInvitations(t *testing.T) {
 		}
 
 		// After updating, the new expiry time on invite should be the same as we expect
-		updatedInvite, err := OrgInvitations(db).GetByID(ctx, toUpdateInvite.ID)
+		updatedInvite, err := db.OrgInvitations().GetByID(ctx, toUpdateInvite.ID)
 		if err != nil {
 			t.Fatalf("cannot get invite by id %d", toUpdateInvite.ID)
 		}

--- a/internal/database/org_members.go
+++ b/internal/database/org_members.go
@@ -9,7 +9,6 @@ import (
 	"github.com/keegancsmith/sqlf"
 
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
@@ -32,12 +31,7 @@ type orgMemberStore struct {
 	*basestore.Store
 }
 
-// OrgMembers instantiates and returns a new OrgMemberStore with prepared statements.
-func OrgMembers(db dbutil.DB) OrgMemberStore {
-	return &orgMemberStore{Store: basestore.NewWithDB(db, sql.TxOptions{})}
-}
-
-// NewOrgMemberStoreWithDB instantiates and returns a new OrgMemberStore using the other store handle.
+// OrgMembersWith instantiates and returns a new OrgMemberStore using the other store handle.
 func OrgMembersWith(other basestore.ShareableStore) OrgMemberStore {
 	return &orgMemberStore{Store: basestore.NewWithHandle(other.Handle())}
 }

--- a/internal/database/org_members_db_test.go
+++ b/internal/database/org_members_db_test.go
@@ -16,7 +16,7 @@ func TestOrgMembers_CreateMembershipInOrgsForAllUsers(t *testing.T) {
 	}
 
 	t.Parallel()
-	db := dbtest.NewDB(t)
+	db := NewDB(dbtest.NewDB(t))
 	ctx := context.Background()
 
 	// Create fixtures.
@@ -50,7 +50,7 @@ func TestOrgMembers_CreateMembershipInOrgsForAllUsers(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := OrgMembers(db).Create(ctx, org1.ID, user1.ID); err != nil {
+	if _, err := db.OrgMembers().Create(ctx, org1.ID, user1.ID); err != nil {
 		t.Fatal(err)
 	}
 
@@ -62,7 +62,7 @@ func TestOrgMembers_CreateMembershipInOrgsForAllUsers(t *testing.T) {
 		}
 		got := map[string][]int32{}
 		for _, org := range []*types.Org{org1, org2, org3} {
-			members, err := OrgMembers(db).GetByOrgID(ctx, org.ID)
+			members, err := db.OrgMembers().GetByOrgID(ctx, org.ID)
 			if err != nil {
 				return err
 			}
@@ -80,13 +80,13 @@ func TestOrgMembers_CreateMembershipInOrgsForAllUsers(t *testing.T) {
 	}
 
 	// Try twice; it should be idempotent.
-	if err := OrgMembers(db).CreateMembershipInOrgsForAllUsers(ctx, []string{"org1", "org3"}); err != nil {
+	if err := db.OrgMembers().CreateMembershipInOrgsForAllUsers(ctx, []string{"org1", "org3"}); err != nil {
 		t.Fatal(err)
 	}
 	if err := check(); err != nil {
 		t.Fatal(err)
 	}
-	if err := OrgMembers(db).CreateMembershipInOrgsForAllUsers(ctx, []string{"org1", "org3"}); err != nil {
+	if err := db.OrgMembers().CreateMembershipInOrgsForAllUsers(ctx, []string{"org1", "org3"}); err != nil {
 		t.Fatal(err)
 	}
 	if err := check(); err != nil {
@@ -94,7 +94,7 @@ func TestOrgMembers_CreateMembershipInOrgsForAllUsers(t *testing.T) {
 	}
 
 	// Passing an org that does not exist should not be an error.
-	if err := OrgMembers(db).CreateMembershipInOrgsForAllUsers(ctx, []string{"doesntexist"}); err != nil {
+	if err := db.OrgMembers().CreateMembershipInOrgsForAllUsers(ctx, []string{"doesntexist"}); err != nil {
 		t.Fatal(err)
 	}
 	if err := check(); err != nil {
@@ -102,7 +102,7 @@ func TestOrgMembers_CreateMembershipInOrgsForAllUsers(t *testing.T) {
 	}
 
 	// An empty list shouldn't be an error.
-	if err := OrgMembers(db).CreateMembershipInOrgsForAllUsers(ctx, []string{}); err != nil {
+	if err := db.OrgMembers().CreateMembershipInOrgsForAllUsers(ctx, []string{}); err != nil {
 		t.Fatal(err)
 	}
 	if err := check(); err != nil {
@@ -114,7 +114,7 @@ func TestOrgMembers_MemberCount(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	db := dbtest.NewDB(t)
+	db := NewDB(dbtest.NewDB(t))
 	ctx := context.Background()
 	// Create fixtures.
 	org1, err := Orgs(db).Create(ctx, "org1", nil)
@@ -156,11 +156,11 @@ func TestOrgMembers_MemberCount(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	OrgMembers(db).Create(ctx, org1.ID, user1.ID)
-	OrgMembers(db).Create(ctx, org2.ID, user1.ID)
-	OrgMembers(db).Create(ctx, org2.ID, user2.ID)
-	OrgMembers(db).Create(ctx, org3.ID, user1.ID)
-	OrgMembers(db).Create(ctx, org3.ID, deletedUser.ID)
+	db.OrgMembers().Create(ctx, org1.ID, user1.ID)
+	db.OrgMembers().Create(ctx, org2.ID, user1.ID)
+	db.OrgMembers().Create(ctx, org2.ID, user2.ID)
+	db.OrgMembers().Create(ctx, org3.ID, user1.ID)
+	db.OrgMembers().Create(ctx, org3.ID, deletedUser.ID)
 	err = Users(db).Delete(ctx, deletedUser.ID)
 	if err != nil {
 		t.Fatal(err)
@@ -174,7 +174,7 @@ func TestOrgMembers_MemberCount(t *testing.T) {
 		{"org with two members", org2.ID, 2},
 		{"org with one deleted member", org3.ID, 1}} {
 		t.Run(test.name, func(*testing.T) {
-			got, err := OrgMembers(db).MemberCount(ctx, test.orgID)
+			got, err := db.OrgMembers().MemberCount(ctx, test.orgID)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -192,7 +192,7 @@ func TestOrgMembers_AutocompleteMembersSearch(t *testing.T) {
 		t.Skip()
 	}
 	t.Parallel()
-	db := dbtest.NewDB(t)
+	db := NewDB(dbtest.NewDB(t))
 	ctx := context.Background()
 
 	tests := []struct {
@@ -282,7 +282,7 @@ func TestOrgMembers_AutocompleteMembersSearch(t *testing.T) {
 		})
 	}
 
-	users, err := OrgMembers(db).AutocompleteMembersSearch(ctx, 1, "testus")
+	users, err := db.OrgMembers().AutocompleteMembersSearch(ctx, 1, "testus")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -299,7 +299,7 @@ func TestOrgMembers_AutocompleteMembersSearch(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	users2, err := OrgMembers(db).AutocompleteMembersSearch(ctx, 1, "searchable")
+	users2, err := db.OrgMembers().AutocompleteMembersSearch(ctx, 1, "searchable")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/database/orgs_test.go
+++ b/internal/database/orgs_test.go
@@ -2,7 +2,6 @@ package database
 
 import (
 	"context"
-	"database/sql"
 	"encoding/json"
 	"strings"
 	"testing"
@@ -20,7 +19,7 @@ import (
 
 func TestOrgs_ValidNames(t *testing.T) {
 	t.Parallel()
-	db := dbtest.NewDB(t)
+	db := NewDB(dbtest.NewDB(t))
 	ctx := context.Background()
 
 	for _, test := range usernamesForTests {
@@ -42,7 +41,7 @@ func TestOrgs_ValidNames(t *testing.T) {
 
 func TestOrgs_Count(t *testing.T) {
 	t.Parallel()
-	db := dbtest.NewDB(t)
+	db := NewDB(dbtest.NewDB(t))
 	ctx := context.Background()
 
 	org, err := Orgs(db).Create(ctx, "a", nil)
@@ -69,7 +68,7 @@ func TestOrgs_Count(t *testing.T) {
 
 func TestOrgs_Delete(t *testing.T) {
 	t.Parallel()
-	db := dbtest.NewDB(t)
+	db := NewDB(dbtest.NewDB(t))
 	ctx := context.Background()
 
 	displayName := "a"
@@ -105,7 +104,7 @@ func TestOrgs_Delete(t *testing.T) {
 
 func TestOrgs_HardDelete(t *testing.T) {
 	t.Parallel()
-	db := dbtest.NewDB(t)
+	db := NewDB(dbtest.NewDB(t))
 	ctx := context.Background()
 
 	displayName := "org1"
@@ -148,7 +147,7 @@ func TestOrgs_HardDelete(t *testing.T) {
 }
 
 func TestOrgs_GetByID(t *testing.T) {
-	createOrg := func(ctx context.Context, db *sql.DB, name string, displayName string) *types.Org {
+	createOrg := func(ctx context.Context, db DB, name string, displayName string) *types.Org {
 		org, err := Orgs(db).Create(ctx, name, &displayName)
 		if err != nil {
 			t.Fatal(err)
@@ -157,7 +156,7 @@ func TestOrgs_GetByID(t *testing.T) {
 		return org
 	}
 
-	createUser := func(ctx context.Context, db *sql.DB, name string) *types.User {
+	createUser := func(ctx context.Context, db DB, name string) *types.User {
 		user, err := Users(db).Create(ctx, NewUser{
 			Username: name,
 		})
@@ -168,8 +167,8 @@ func TestOrgs_GetByID(t *testing.T) {
 		return user
 	}
 
-	createOrgMember := func(ctx context.Context, db *sql.DB, userID int32, orgID int32) *types.OrgMembership {
-		member, err := OrgMembers(db).Create(ctx, orgID, userID)
+	createOrgMember := func(ctx context.Context, db DB, userID int32, orgID int32) *types.OrgMembership {
+		member, err := db.OrgMembers().Create(ctx, orgID, userID)
 		if err != nil {
 			t.Fatal(err)
 			return nil
@@ -178,7 +177,7 @@ func TestOrgs_GetByID(t *testing.T) {
 	}
 
 	t.Parallel()
-	db := dbtest.NewDB(t)
+	db := NewDB(dbtest.NewDB(t))
 	ctx := context.Background()
 
 	createOrg(ctx, db, "org1", "org1")
@@ -221,7 +220,7 @@ func TestOrgs_GetOrgsWithRepositoriesByUserID(t *testing.T) {
 	}
 
 	createOrgMember := func(ctx context.Context, db DB, userID int32, orgID int32) {
-		_, err := OrgMembers(db).Create(ctx, orgID, userID)
+		_, err := db.OrgMembers().Create(ctx, orgID, userID)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -268,7 +267,7 @@ func TestOrgs_GetOrgsWithRepositoriesByUserID(t *testing.T) {
 
 func TestOrgs_AddOrgsOpenBetaStats(t *testing.T) {
 	t.Parallel()
-	db := dbtest.NewDB(t)
+	db := NewDB(dbtest.NewDB(t))
 	ctx := context.Background()
 
 	userID := int32(42)
@@ -307,7 +306,7 @@ func TestOrgs_AddOrgsOpenBetaStats(t *testing.T) {
 
 func TestOrgs_UpdateOrgsOpenBetaStats(t *testing.T) {
 	t.Parallel()
-	db := dbtest.NewDB(t)
+	db := NewDB(dbtest.NewDB(t))
 	ctx := context.Background()
 
 	userID := int32(42)

--- a/internal/database/repos_perm_test.go
+++ b/internal/database/repos_perm_test.go
@@ -427,7 +427,7 @@ func TestRepoStore_nonSiteAdminCanViewOrgPrivateCode(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = OrgMembers(db).Create(ctx, org.ID, alice.ID)
+	_, err = db.OrgMembers().Create(ctx, org.ID, alice.ID)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/database/saved_searches_test.go
+++ b/internal/database/saved_searches_test.go
@@ -18,7 +18,7 @@ func TestSavedSearchesIsEmpty(t *testing.T) {
 	}
 
 	t.Parallel()
-	db := dbtest.NewDB(t)
+	db := NewDB(dbtest.NewDB(t))
 	ctx := context.Background()
 	isEmpty, err := SavedSearches(db).IsEmpty(ctx)
 	if err != nil {
@@ -61,7 +61,7 @@ func TestSavedSearchesCreate(t *testing.T) {
 	}
 
 	t.Parallel()
-	db := dbtest.NewDB(t)
+	db := NewDB(dbtest.NewDB(t))
 	ctx := context.Background()
 	_, err := Users(db).Create(ctx, NewUser{DisplayName: "test", Email: "test@test.com", Username: "test", Password: "test", EmailVerificationCode: "c2"})
 	if err != nil {
@@ -100,7 +100,7 @@ func TestSavedSearchesUpdate(t *testing.T) {
 	}
 
 	t.Parallel()
-	db := dbtest.NewDB(t)
+	db := NewDB(dbtest.NewDB(t))
 	ctx := context.Background()
 	_, err := Users(db).Create(ctx, NewUser{DisplayName: "test", Email: "test@test.com", Username: "test", Password: "test", EmailVerificationCode: "c2"})
 	if err != nil {
@@ -142,7 +142,7 @@ func TestSavedSearchesDelete(t *testing.T) {
 	}
 
 	t.Parallel()
-	db := dbtest.NewDB(t)
+	db := NewDB(dbtest.NewDB(t))
 	ctx := context.Background()
 	_, err := Users(db).Create(ctx, NewUser{DisplayName: "test", Email: "test@test.com", Username: "test", Password: "test", EmailVerificationCode: "c2"})
 	if err != nil {
@@ -181,7 +181,7 @@ func TestSavedSearchesGetByUserID(t *testing.T) {
 	}
 
 	t.Parallel()
-	db := dbtest.NewDB(t)
+	db := NewDB(dbtest.NewDB(t))
 	ctx := context.Background()
 	_, err := Users(db).Create(ctx, NewUser{DisplayName: "test", Email: "test@test.com", Username: "test", Password: "test", EmailVerificationCode: "c2"})
 	if err != nil {
@@ -224,7 +224,7 @@ func TestSavedSearchesGetByID(t *testing.T) {
 	}
 
 	t.Parallel()
-	db := dbtest.NewDB(t)
+	db := NewDB(dbtest.NewDB(t))
 	ctx := context.Background()
 	_, err := Users(db).Create(ctx, NewUser{DisplayName: "test", Email: "test@test.com", Username: "test", Password: "test", EmailVerificationCode: "c2"})
 	if err != nil {
@@ -268,7 +268,7 @@ func TestListSavedSearchesByUserID(t *testing.T) {
 	}
 
 	t.Parallel()
-	db := dbtest.NewDB(t)
+	db := NewDB(dbtest.NewDB(t))
 	ctx := context.Background()
 	_, err := Users(db).Create(ctx, NewUser{DisplayName: "test", Email: "test@test.com", Username: "test", Password: "test", EmailVerificationCode: "c2"})
 	if err != nil {
@@ -327,11 +327,11 @@ func TestListSavedSearchesByUserID(t *testing.T) {
 		t.Fatalf("no saved search returned, org2 saved search create failed")
 	}
 
-	_, err = OrgMembers(db).Create(ctx, org1.ID, userID)
+	_, err = db.OrgMembers().Create(ctx, org1.ID, userID)
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = OrgMembers(db).Create(ctx, org2.ID, userID)
+	_, err = db.OrgMembers().Create(ctx, org2.ID, userID)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/database/search_contexts_test.go
+++ b/internal/database/search_contexts_test.go
@@ -28,7 +28,7 @@ func createSearchContexts(ctx context.Context, store SearchContextsStore, search
 }
 
 func TestSearchContexts_Get(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := NewDB(dbtest.NewDB(t))
 	t.Parallel()
 	ctx := actor.WithInternalActor(context.Background())
 	u := Users(db)
@@ -80,7 +80,7 @@ func TestSearchContexts_Get(t *testing.T) {
 }
 
 func TestSearchContexts_Update(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := NewDB(dbtest.NewDB(t))
 	t.Parallel()
 	ctx := actor.WithInternalActor(context.Background())
 	u := Users(db)
@@ -152,7 +152,7 @@ func TestSearchContexts_Update(t *testing.T) {
 }
 
 func TestSearchContexts_List(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := NewDB(dbtest.NewDB(t))
 	t.Parallel()
 	ctx := actor.WithInternalActor(context.Background())
 	u := Users(db)
@@ -199,7 +199,7 @@ func TestSearchContexts_List(t *testing.T) {
 }
 
 func TestSearchContexts_PaginationAndCount(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := NewDB(dbtest.NewDB(t))
 	t.Parallel()
 	ctx := actor.WithInternalActor(context.Background())
 	u := Users(db)
@@ -297,7 +297,7 @@ func TestSearchContexts_PaginationAndCount(t *testing.T) {
 }
 
 func TestSearchContexts_CaseInsensitiveNames(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := NewDB(dbtest.NewDB(t))
 	t.Parallel()
 	ctx := actor.WithInternalActor(context.Background())
 	u := Users(db)
@@ -358,7 +358,7 @@ func TestSearchContexts_CaseInsensitiveNames(t *testing.T) {
 }
 
 func TestSearchContexts_CreateAndSetRepositoryRevisions(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := NewDB(dbtest.NewDB(t))
 	t.Parallel()
 	ctx := actor.WithInternalActor(context.Background())
 	sc := SearchContexts(db)
@@ -420,12 +420,12 @@ func TestSearchContexts_CreateAndSetRepositoryRevisions(t *testing.T) {
 }
 
 func TestSearchContexts_Permissions(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := NewDB(dbtest.NewDB(t))
 	t.Parallel()
 	internalCtx := actor.WithInternalActor(context.Background())
 	u := Users(db)
 	o := Orgs(db)
-	om := OrgMembers(db)
+	om := db.OrgMembers()
 	sc := SearchContexts(db)
 
 	user1, err := u.Create(internalCtx, NewUser{Username: "u1", Password: "p"})
@@ -623,7 +623,7 @@ func TestSearchContexts_Permissions(t *testing.T) {
 }
 
 func TestSearchContexts_Delete(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := NewDB(dbtest.NewDB(t))
 	t.Parallel()
 	ctx := context.Background()
 	sc := SearchContexts(db)
@@ -673,12 +673,12 @@ func getSearchContextNames(s []*types.SearchContext) []string {
 }
 
 func TestSearchContexts_OrderBy(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := NewDB(dbtest.NewDB(t))
 	t.Parallel()
 	internalCtx := actor.WithInternalActor(context.Background())
 	u := Users(db)
 	o := Orgs(db)
-	om := OrgMembers(db)
+	om := db.OrgMembers()
 	sc := SearchContexts(db)
 
 	user1, err := u.Create(internalCtx, NewUser{Username: "u1", Password: "p"})
@@ -785,7 +785,7 @@ func TestSearchContexts_OrderBy(t *testing.T) {
 }
 
 func TestSearchContexts_GetAllRevisionsForRepos(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := NewDB(dbtest.NewDB(t))
 	t.Parallel()
 	// Required for this DB query.
 	internalCtx := actor.WithInternalActor(context.Background())

--- a/internal/search/searchcontexts/search_contexts_test.go
+++ b/internal/search/searchcontexts/search_contexts_test.go
@@ -289,7 +289,7 @@ func TestSearchContextWriteAccessValidation(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Expected no error, got %s", err)
 	}
-	database.OrgMembers(db).Create(internalCtx, org.ID, user2.ID)
+	db.OrgMembers().Create(internalCtx, org.ID, user2.ID)
 	// Third user is not a site-admin and is not a member of the org
 	user3, err := u.Create(internalCtx, database.NewUser{Username: "u3", Password: "p"})
 	if err != nil {


### PR DESCRIPTION
Remove a few dbutil-based constructors in our database package, as they are not mockable in our tests.

This is the result of a time-boxed effort.

## Test plan

Unit tests

---

Part of https://github.com/sourcegraph/sourcegraph/issues/26113