### PR TITLE
Code Insights: Improve code insights loading layout

### DIFF
--- a/client/web/src/enterprise/insights/pages/CodeInsightsRootPage.tsx
+++ b/client/web/src/enterprise/insights/pages/CodeInsightsRootPage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react'
+import React, { useEffect, Suspense } from 'react'
 
 import PlusIcon from 'mdi-react/PlusIcon'
 import { matchPath, useHistory } from 'react-router'
@@ -7,7 +7,18 @@ import { useLocation } from 'react-router-dom'
 import { useTemporarySetting } from '@sourcegraph/shared/src/settings/temporary/useTemporarySetting'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { lazyComponent } from '@sourcegraph/shared/src/util/lazyComponent'
-import { Button, Link, PageHeader, Tabs, TabList, Tab, Icon, TabPanels, TabPanel } from '@sourcegraph/wildcard'
+import {
+    Button,
+    Link,
+    PageHeader,
+    Tabs,
+    TabList,
+    Tab,
+    Icon,
+    TabPanels,
+    TabPanel,
+    LoadingSpinner,
+} from '@sourcegraph/wildcard'
 
 import { CodeInsightsIcon } from '../../../insights/Icons'
 import { CodeInsightsPage } from '../components/code-insights-page/CodeInsightsPage'
@@ -106,7 +117,9 @@ export const CodeInsightsRootPage: React.FunctionComponent<
                         <DashboardsContentPage telemetryService={telemetryService} dashboardID={params?.dashboardId} />
                     </TabPanel>
                     <TabPanel>
-                        <LazyCodeInsightsGettingStartedPage telemetryService={telemetryService} />
+                        <Suspense fallback={<LoadingSpinner />}>
+                            <LazyCodeInsightsGettingStartedPage telemetryService={telemetryService} />
+                        </Suspense>
                     </TabPanel>
                 </TabPanels>
             </Tabs>


### PR DESCRIPTION
| Before  | After |
| ------------- | ------------- |
|  <video src="https://user-images.githubusercontent.com/18492575/169289250-1fde989f-8fee-4038-bb13-203cb5359220.mov" />  | <video src="https://user-images.githubusercontent.com/18492575/169289328-df245527-5204-4e12-bb48-1121bc70fa71.mov" />  |

## Test plan
- Make sure that the code insight landing page doesn't have any layout shifts during the first mount of the page

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vk-improve-loading-layout-of.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-useqxdetnm.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
