### PR TITLE
codemirror: Fix crash caused by token highlight

### DIFF
--- a/client/search-ui/src/input/CodeMirrorQueryInput.tsx
+++ b/client/search-ui/src/input/CodeMirrorQueryInput.tsx
@@ -11,6 +11,7 @@ import {
     StateField,
     Prec,
     RangeSetBuilder,
+    MapMode,
 } from '@codemirror/state'
 import {
     EditorView,
@@ -466,132 +467,197 @@ const highlightFocusedFilter = ViewPlugin.define(
 
 // Tooltip information.
 function tokenInfo(): Extension[] {
-    const setHighlighedToken = StateEffect.define<DecoratedToken | null>()
-    const highlightedToken = StateField.define<DecoratedToken | null>({
+    const setHighlighedTokenPosition = StateEffect.define<number | null>()
+    const highlightedTokenPosition = StateField.define<number | null>({
         create() {
             return null
         },
-        update(value, transaction) {
-            const effect = transaction.effects.find((effect): effect is StateEffect<DecoratedToken | null> =>
-                effect.is(setHighlighedToken)
+        update(position, transaction) {
+            const effect = transaction.effects.find((effect): effect is StateEffect<number | null> =>
+                effect.is(setHighlighedTokenPosition)
             )
-            return effect ? effect.value : value
+            if (effect) {
+                position = effect?.value
+            }
+            if (position !== null) {
+                // MapMode.TrackDel causes mapPos to return null if content at
+                // this position was deleted (in which case we want to remove
+                // the highlight)
+                return transaction.changes.mapPos(position, 0, MapMode.TrackDel)
+            }
+            return position
         },
         provide(field) {
-            return EditorView.decorations.from(field, token =>
-                token
+            return EditorView.decorations.compute([field, decoratedTokens], state => {
+                const position = state.field(field)
+                if (position === null) {
+                    return Decoration.none
+                }
+                let tokenAtPosition = state.facet(decoratedTokens).find(token => isTokenInRange(position, token))
+
+                switch (tokenAtPosition?.type) {
+                    case 'field':
+                    case 'pattern':
+                    case 'metaRevision':
+                    case 'metaRepoRevisionSeparator':
+                    case 'metaSelector':
+                    case 'metaRegexp':
+                    case 'metaStructural':
+                    case 'metaPredicate':
+                        // These are the tokens we show hover information for
+                        break
+                    default:
+                        tokenAtPosition = undefined
+                        break
+                }
+                return tokenAtPosition
                     ? Decoration.set([
                           focusedFilterDeco.range(
-                              token.range.start,
-                              token.range.end + (token.type === 'field' ? 1 : 0)
+                              tokenAtPosition.range.start,
+                              tokenAtPosition.range.end + (tokenAtPosition.type === 'field' ? 1 : 0)
                           ),
                       ])
                     : Decoration.none
-            )
+            })
         },
     })
 
     return [
-        highlightedToken,
+        highlightedTokenPosition,
         // Highlights the hovered token
         EditorView.domEventHandlers({
             mousemove(event, view) {
                 const position = view.posAtCoords(event)
-                let token: DecoratedToken | null = null
-
-                if (position) {
-                    const tokenAtCursor = view.state
-                        .facet(decoratedTokens)
-                        .find(token => isTokenInRange(position, token))
-
-                    // These are the tokens we show hover information for
-                    switch (tokenAtCursor?.type) {
-                        case 'field':
-                        case 'pattern':
-                        case 'metaRevision':
-                        case 'metaRepoRevisionSeparator':
-                        case 'metaSelector':
-                        case 'metaRegexp':
-                        case 'metaStructural':
-                        case 'metaPredicate':
-                            token = tokenAtCursor ?? null
-                            break
-                    }
-                }
-
-                if (token !== view.state.field(highlightedToken)) {
-                    view.dispatch({ effects: [setHighlighedToken.of(token)] })
+                if (position && position !== view.state.field(highlightedTokenPosition)) {
+                    view.dispatch({ effects: [setHighlighedTokenPosition.of(position)] })
                 }
             },
             mouseleave(_event, view) {
-                if (view.state.field(highlightedToken)) {
-                    view.dispatch({ effects: [setHighlighedToken.of(null)] })
+                if (view.state.field(highlightedTokenPosition) !== null) {
+                    view.dispatch({ effects: [setHighlighedTokenPosition.of(null)] })
                 }
             },
         }),
         // Shows information about the hovered token
         hoverTooltip(
             (view, position) => {
-                const tokensAtCursor = view.state
-                    .facet(decoratedTokens)
-                    .filter(token => isTokenInRange(position, token))
-
-                if (tokensAtCursor?.length === 0) {
+                const tooltipInfo = getTokensTooltipInformation(view.state.facet(decoratedTokens), position)
+                if (!tooltipInfo) {
                     return null
                 }
 
-                const values: string[] = []
-                let range: { start: number; end: number } | undefined
+                return {
+                    pos: tooltipInfo.range.start,
+                    end: tooltipInfo.range.end,
+                    create(): TooltipView {
+                        const dom = document.createElement('div')
+                        dom.innerHTML = renderMarkdown(tooltipInfo.value)
 
-                // Copied and adapated from getHoverResult (hover.ts)
-                tokensAtCursor.map(token => {
-                    switch (token.type) {
-                        case 'field': {
-                            const resolvedFilter = resolveFilter(token.value)
-                            if (resolvedFilter) {
-                                values.push(
-                                    'negated' in resolvedFilter
-                                        ? resolvedFilter.definition.description(resolvedFilter.negated)
-                                        : resolvedFilter.definition.description
-                                )
-                                // Add 3 to end of range to include the ':'.
-                                // (there seems to be a bug with computing the correct
-                                // range end)
-                                range = { start: token.range.start, end: token.range.end + 3 }
-                            }
-                            break
+                        // To show correct token information in the case the hovered token changes, we keep track of the token's
+                        // start position and get the new token tooltip text from that position. Together with CM's ability to map
+                        // positions across document changes this gives correct results if a token changes anywhere (beginning, middle, end).
+                        // NOTE: If new content is inserted right at the start of the hovered token, the tooltip might not get
+                        // repositioned.
+                        let tokenStart = tooltipInfo.range.start
+
+                        return {
+                            dom,
+                            update(update) {
+                                if (update.docChanged) {
+                                    // Passing 1 here is necessary to get the information for the "right" (the initial token).
+                                    // Otherwise if a new character is inserted at the `tokenStart` position and that character results in a new token, it would show information about that new token instead.
+                                    // This might seem reasonable but causes problems if the new token is a token for which we don't show tooltip information (e.g. whitespace).
+                                    //
+                                    // Examples:
+                                    // (| indicates `tokenPosition`)
+                                    //
+                                    // Input: "|foo" (shows information about "foo")
+                                    //
+                                    // Without 1: "| foo" would show an empty tooltip
+                                    // With 1: " |foo" will continue showing tooltip info for "foo"
+                                    //
+                                    // (regex mode)
+                                    // Without 1: ""|.foo" would show information about the dot
+                                    // With 1: ".|foo" will continue showing tooltip info for "foo"
+                                    //
+                                    // Input (regex mode): "|." (shows information about the dot)
+                                    //
+                                    // With or without 1: "|\." shows information about escaped character '.' because "\." is a single token
+                                    const newPosition = update.changes.mapPos(tokenStart, 1)
+
+                                    const tooltipInfo = getTokensTooltipInformation(
+                                        update.state.facet(decoratedTokens),
+                                        newPosition
+                                    )
+                                    if (tooltipInfo) {
+                                        tokenStart = tooltipInfo.range.start
+                                    }
+                                    dom.innerHTML = tooltipInfo ? renderMarkdown(tooltipInfo.value) : ''
+                                }
+                            },
                         }
-                        case 'pattern':
-                        case 'metaRevision':
-                        case 'metaRepoRevisionSeparator':
-                        case 'metaSelector':
-                            values.push(toHover(token))
-                            range = token.range
-                            break
-                        case 'metaRegexp':
-                        case 'metaStructural':
-                        case 'metaPredicate':
-                            values.push(toHover(token))
-                            range = token.groupRange ? token.groupRange : token.range
-                            break
-                    }
-                })
-                if (range) {
-                    return {
-                        pos: range.start,
-                        end: range.end,
-                        create(): TooltipView {
-                            const dom = document.createElement('div')
-                            dom.innerHTML = renderMarkdown(values.join(''))
-                            return { dom }
-                        },
-                    }
+                    },
                 }
-                return null
             },
-            { hoverTime: 100 }
+            {
+                hoverTime: 100,
+            }
         ),
     ]
+}
+
+function getTokensTooltipInformation(
+    tokens: DecoratedToken[],
+    position: number
+): { range: { start: number; end: number }; value: string } | null {
+    const tokensAtCursor = tokens.filter(token => isTokenInRange(position, token))
+    console.log(tokensAtCursor, position)
+
+    if (tokensAtCursor?.length === 0) {
+        return null
+    }
+    const values: string[] = []
+    let range: { start: number; end: number } | undefined
+
+    // Copied and adapated from getHoverResult (hover.ts)
+    for (const token of tokensAtCursor) {
+        switch (token.type) {
+            case 'field': {
+                const resolvedFilter = resolveFilter(token.value)
+                if (resolvedFilter) {
+                    values.push(
+                        'negated' in resolvedFilter
+                            ? resolvedFilter.definition.description(resolvedFilter.negated)
+                            : resolvedFilter.definition.description
+                    )
+                    // Add 3 to end of range to include the ':'.
+                    // (there seems to be a bug with computing the correct
+                    // range end)
+                    range = { start: token.range.start, end: token.range.end + 3 }
+                }
+                break
+            }
+            case 'pattern':
+            case 'metaRevision':
+            case 'metaRepoRevisionSeparator':
+            case 'metaSelector':
+                values.push(toHover(token))
+                range = token.range
+                break
+            case 'metaRegexp':
+            case 'metaStructural':
+            case 'metaPredicate':
+                values.push(toHover(token))
+                range = token.groupRange ? token.groupRange : token.range
+                break
+        }
+    }
+
+    if (!range) {
+        return null
+    }
+
+    return { range, value: values.join('') }
 }
 
 // Hooks query diagnostics into the editor.
@@ -642,7 +708,14 @@ const queryDiagnostic: Extension[] = [
                 },
             }
         },
-        { hoverTime: 100 }
+        {
+            hoverTime: 100,
+            // Making changes elsewhere in the query might invalidate a specific
+            // diagnostic (e.g. adding type:commit to a query that contains
+            // author:...), so generally hiding them on any change seems
+            // reasonable.
+            hideOnChange: true,
+        }
     ),
 ]
 


### PR DESCRIPTION
Fixes #35491, #35555

**Problem**

In hindsight this bug is "obvious" but it was quite obscure first. The core problem is that the extension which is responsible for highlighting the currently hovered token holds onto the token object even if token doesn't exist anymore. Should the token refer to a position outside of the new/current document, an error is thrown (video from the issue):


https://user-images.githubusercontent.com/179026/169289368-6b24bad8-90fc-4960-a628-e8ec13af4cc5.mp4

This only happens when the user hovers over a token and then continues to edit the input without moving mouse: We only cleared the token when the mouse leaves the input.

**Solution**

There are two parts to the solution:

1. Instead of storing the hovered token, I'm just storing the hover position and look up the token when the decoration is created. This prevents storing stale data in the extension. Even if the stored position is invalid, looking up a token at that position wouldn't yield any result and thus wouldn't create a decoration.
2. The hover position is now cleared when the document changes, i.e. the token highlight is removed when the input changes. This replicates Monaco's behavior. I also made the necessary changes to also hide the tooltip information.

**Note:** The first commit implements an alternative version: Instead of hiding the highlight and tooltip, they would both update themselves when the input changes. While this is nice, I feel like removing the additional "clutter" while the user is typing feels a bit better overall.

New behavior:


https://user-images.githubusercontent.com/179026/169290627-42753306-c239-499f-9c33-0ecc0a0dafe4.mp4

Since I was working on tooltips anyway, I also fixed the how/when tooltips are triggered. It feels more correct now:


https://user-images.githubusercontent.com/179026/169290763-b557b233-a36f-460e-aa6e-2ad3b784dd28.mp4



## Test plan

Go to search page, enter `foo bar` in the search input. Hover over `bar` with the mouse cursor and let go of the mouse. Start deleting ` bar` from the input (with backspace). The highlight and the tootip should hide immediately and no error should be thrown.