### PR TITLE
[a11y] Add aria-hidden to an hr element in user settings -> emails page

### DIFF
--- a/client/web/src/user/settings/emails/UserSettingsEmailsPage.tsx
+++ b/client/web/src/user/settings/emails/UserSettingsEmailsPage.tsx
@@ -109,7 +109,7 @@ export const UserSettingsEmailsPage: FunctionComponent<React.PropsWithChildren<P
             </Container>
             {/* re-fetch emails on onDidAdd to guarantee correct state */}
             <AddUserEmailForm className={styles.emailForm} user={user.id} onDidAdd={fetchEmails} />
-            <hr className="my-4" />
+            <hr className="my-4" aria-hidden="true" />
             <SetUserPrimaryEmailForm user={user.id} emails={emails} onDidSet={fetchEmails} />
         </div>
     )


### PR DESCRIPTION
# Description
Add aria-hidden to an hr element in user settings -> emails page

# Related issue
#34115

## Test plan

Tested locally. The change just adds an attribute to ignore an <hr> element for reading out loud in screen readers.

## App preview:

- [Web](https://sg-web-milan-accessibility.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-vnaubrjhmm.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
