### PR TITLE
Revert "Search: remove references to line preview from client code"

### DIFF
--- a/client/search/src/integration/streaming-search-mocks.ts
+++ b/client/search/src/integration/streaming-search-mocks.ts
@@ -100,13 +100,11 @@ export const mixedSearchStreamEvents: SearchEvent[] = [
                 commit: '2e3569cf60646c9ce4e37a43e5cf698a00cbd41a',
                 lineMatches: [
                     {
+                        line: "test('does not emit items with duplicate IDs', async () => {",
                         lineNumber: 38,
                         offsetAndLengths: [[0, 4]],
                     },
-                    {
-                        lineNumber: 63,
-                        offsetAndLengths: [[0, 4]],
-                    },
+                    { line: "test('five', async () => {", lineNumber: 63, offsetAndLengths: [[0, 4]] },
                 ],
             },
         ],

--- a/client/shared/src/components/FileSearchResult.test.tsx
+++ b/client/shared/src/components/FileSearchResult.test.tsx
@@ -48,6 +48,7 @@ describe('FileSearchResult', () => {
             repository: 'github.com/golang/oauth2',
             lineMatches: [
                 {
+                    line: '  - go test -v golang.org/x/oauth2/...',
                     lineNumber: 4,
                     offsetAndLengths: [[7, 4]],
                 },

--- a/client/shared/src/components/FileSearchResult.tsx
+++ b/client/shared/src/components/FileSearchResult.tsx
@@ -136,6 +136,7 @@ export const FileSearchResult: React.FunctionComponent<React.PropsWithChildren<P
                           start,
                           highlightLength,
                       })),
+                      preview: match.line,
                       line: match.lineNumber,
                       aggregableBadges: match.aggregableBadges,
                   })) || []

--- a/client/shared/src/components/ranking/PerFileResultRanking.ts
+++ b/client/shared/src/components/ranking/PerFileResultRanking.ts
@@ -26,6 +26,7 @@ export interface MatchItem extends ExtensionBadgeType {
         start: number
         highlightLength: number
     }[]
+    preview: string
     /**
      * The 0-based line number of this match.
      */

--- a/client/shared/src/components/ranking/PerFileResultRankingTestHelpers.ts
+++ b/client/shared/src/components/ranking/PerFileResultRankingTestHelpers.ts
@@ -4,338 +4,422 @@ import { MatchItem } from './PerFileResultRanking'
 export const testDataRealMatches: MatchItem[] = [
     {
         highlightRanges: [{ start: 51, highlightLength: 5 }],
+        preview: '// Package errwrap implements methods to formalize error wrapping in Go.',
         line: 0,
     },
     {
         highlightRanges: [{ start: 48, highlightLength: 5 }],
+        preview: '// All of the top-level functions that take an `error` are built to be able',
         line: 2,
     },
     {
         highlightRanges: [{ start: 15, highlightLength: 5 }],
+        preview: '// to take any error, not just wrapped errors. This allows you to use errwrap',
         line: 3,
     },
     {
         highlightRanges: [{ start: 39, highlightLength: 5 }],
+        preview: '// to take any error, not just wrapped errors. This allows you to use errwrap',
         line: 3,
     },
     {
         highlightRanges: [{ start: 2, highlightLength: 5 }],
+        preview: '\t"errors"',
         line: 8,
     },
     {
         highlightRanges: [{ start: 19, highlightLength: 5 }],
+        preview: 'type WalkFunc func(error)',
         line: 14,
     },
     {
         highlightRanges: [{ start: 11, highlightLength: 5 }],
+        preview: '// wrapped error in addition to the wrapper itself. Since all the top-level',
         line: 20,
     },
     {
         highlightRanges: [{ start: 8, highlightLength: 5 }],
+        preview: '\tWrappedErrors() []error',
         line: 24,
     },
     {
         highlightRanges: [{ start: 19, highlightLength: 5 }],
+        preview: '\tWrappedErrors() []error',
         line: 24,
     },
     {
         highlightRanges: [{ start: 53, highlightLength: 5 }],
+        preview: '// Wrap defines that outer wraps inner, returning an error type that',
         line: 27,
     },
     {
         highlightRanges: [{ start: 3, highlightLength: 5 }],
+        preview: '// error be cleanly used with the other methods in this package, such as',
         line: 28,
     },
     {
         highlightRanges: [{ start: 13, highlightLength: 5 }],
+        preview: '// Contains, error, etc.',
         line: 29,
     },
     {
         highlightRanges: [{ start: 2, highlightLength: 5 }],
+        preview: '//error',
         line: 30,
     },
     {
         highlightRanges: [{ start: 8, highlightLength: 5 }],
+        preview: "// This error won't modify the error message at all (the outer message",
         line: 31,
     },
     {
         highlightRanges: [{ start: 31, highlightLength: 5 }],
+        preview: "// This error won't modify the error message at all (the outer message",
         line: 31,
     },
     {
         highlightRanges: [{ start: 11, highlightLength: 5 }],
+        preview: '// will be error).',
         line: 32,
     },
     {
         highlightRanges: [{ start: 23, highlightLength: 5 }],
+        preview: 'func Wrap(outer, inner error) error {',
         line: 33,
     },
     {
         highlightRanges: [{ start: 30, highlightLength: 5 }],
+        preview: 'func Wrap(outer, inner error) error {',
         line: 33,
     },
     {
         highlightRanges: [{ start: 16, highlightLength: 5 }],
+        preview: '\treturn &wrappedError{',
         line: 34,
     },
     {
         highlightRanges: [{ start: 2, highlightLength: 5 }],
+        preview: '\t\terror: outer,',
         line: 35,
     },
     {
         highlightRanges: [{ start: 18, highlightLength: 5 }],
+        preview: '// Wrapf wraps an error with a formatting message. This is similar to using',
         line: 40,
     },
     {
         highlightRanges: [{ start: 8, highlightLength: 5 }],
+        preview: "// `fmt.Errorf` to wrap an error. If you're using `fmt.Errorf` to wrap",
         line: 41,
     },
     {
         highlightRanges: [{ start: 27, highlightLength: 5 }],
+        preview: "// `fmt.Errorf` to wrap an error. If you're using `fmt.Errorf` to wrap",
         line: 41,
     },
     {
         highlightRanges: [{ start: 55, highlightLength: 5 }],
+        preview: "// `fmt.Errorf` to wrap an error. If you're using `fmt.Errorf` to wrap",
         line: 41,
     },
     {
         highlightRanges: [{ start: 3, highlightLength: 5 }],
+        preview: '// errors, you should replace it with this.',
         line: 42,
     },
     {
         highlightRanges: [{ start: 31, highlightLength: 5 }],
+        preview: "// format is the format of the error message. The string '{{err}}' will",
         line: 44,
     },
     {
         highlightRanges: [{ start: 33, highlightLength: 5 }],
+        preview: '// be replaced with the original error message.',
         line: 45,
     },
     {
         highlightRanges: [{ start: 23, highlightLength: 5 }],
+        preview: '// Deprecated: Use fmt.Errorf()',
         line: 47,
     },
     {
         highlightRanges: [{ start: 30, highlightLength: 5 }],
+        preview: 'func Wrapf(format string, err error) error {',
         line: 48,
     },
     {
         highlightRanges: [{ start: 37, highlightLength: 5 }],
+        preview: 'func Wrapf(format string, err error) error {',
         line: 48,
     },
     {
         highlightRanges: [{ start: 17, highlightLength: 5 }],
+        preview: '\t\touterMsg = err.Error()',
         line: 51,
     },
     {
         highlightRanges: [{ start: 10, highlightLength: 5 }],
+        preview: '\touter := errors.New(strings.Replace(',
         line: 54,
     },
     {
         highlightRanges: [{ start: 32, highlightLength: 5 }],
+        preview: '// Contains checks if the given error contains an error with the',
         line: 60,
     },
     {
         highlightRanges: [{ start: 50, highlightLength: 5 }],
+        preview: '// Contains checks if the given error contains an error with the',
         line: 60,
     },
     {
         highlightRanges: [{ start: 40, highlightLength: 5 }],
+        preview: '// message msg. If err is not a wrapped error, this will always return',
         line: 61,
     },
     {
         highlightRanges: [{ start: 20, highlightLength: 5 }],
+        preview: '// false unless the error itself happens to match this msg.',
         line: 62,
     },
     {
         highlightRanges: [{ start: 18, highlightLength: 5 }],
+        preview: 'func Contains(err error, msg string) bool {',
         line: 63,
     },
     {
         highlightRanges: [{ start: 36, highlightLength: 5 }],
+        preview: '// ContainsType checks if the given error contains an error with',
         line: 67,
     },
     {
         highlightRanges: [{ start: 54, highlightLength: 5 }],
+        preview: '// ContainsType checks if the given error contains an error with',
         line: 67,
     },
     {
         highlightRanges: [{ start: 56, highlightLength: 5 }],
+        preview: '// the same concrete type as v. If err is not a wrapped error, this will',
         line: 68,
     },
     {
         highlightRanges: [{ start: 22, highlightLength: 5 }],
+        preview: 'func ContainsType(err error, v interface{}) bool {',
         line: 70,
     },
     {
         highlightRanges: [{ start: 62, highlightLength: 5 }],
+        preview: '// Get is the same as GetAll but returns the deepest matching error.',
         line: 74,
     },
     {
         highlightRanges: [{ start: 13, highlightLength: 5 }],
+        preview: 'func Get(err error, msg string) error {',
         line: 75,
     },
     {
         highlightRanges: [{ start: 32, highlightLength: 5 }],
+        preview: 'func Get(err error, msg string) error {',
         line: 75,
     },
     {
         highlightRanges: [{ start: 70, highlightLength: 5 }],
+        preview: '// GetType is the same as GetAllType but returns the deepest matching error.',
         line: 84,
     },
     {
         highlightRanges: [{ start: 17, highlightLength: 5 }],
+        preview: 'func GetType(err error, v interface{}) error {',
         line: 85,
     },
     {
         highlightRanges: [{ start: 39, highlightLength: 5 }],
+        preview: 'func GetType(err error, v interface{}) error {',
         line: 85,
     },
     {
         highlightRanges: [{ start: 23, highlightLength: 5 }],
+        preview: '// GetAll gets all the errors that might be wrapped in err with the',
         line: 94,
     },
     {
         highlightRanges: [{ start: 35, highlightLength: 5 }],
+        preview: '// given message. The order of the errors is such that the outermost',
         line: 95,
     },
     {
         highlightRanges: [{ start: 12, highlightLength: 5 }],
+        preview: '// matching error (the most recent wrap) is index zero, and so on.',
         line: 96,
     },
     {
         highlightRanges: [{ start: 16, highlightLength: 5 }],
+        preview: 'func GetAll(err error, msg string) []error {',
         line: 97,
     },
     {
         highlightRanges: [{ start: 37, highlightLength: 5 }],
+        preview: 'func GetAll(err error, msg string) []error {',
         line: 97,
     },
     {
         highlightRanges: [{ start: 14, highlightLength: 5 }],
+        preview: '\tvar result []error',
         line: 98,
     },
     {
         highlightRanges: [{ start: 20, highlightLength: 5 }],
+        preview: '\tWalk(err, func(err error) {',
         line: 100,
     },
     {
         highlightRanges: [{ start: 9, highlightLength: 5 }],
+        preview: '\t\tif err.Error() == msg {',
         line: 101,
     },
     {
         highlightRanges: [{ start: 27, highlightLength: 5 }],
+        preview: '// GetAllType gets all the errors that are the same type as v.',
         line: 109,
     },
     {
         highlightRanges: [{ start: 20, highlightLength: 5 }],
+        preview: 'func GetAllType(err error, v interface{}) []error {',
         line: 112,
     },
     {
         highlightRanges: [{ start: 44, highlightLength: 5 }],
+        preview: 'func GetAllType(err error, v interface{}) []error {',
         line: 112,
     },
     {
         highlightRanges: [{ start: 14, highlightLength: 5 }],
+        preview: '\tvar result []error',
         line: 113,
     },
     {
         highlightRanges: [{ start: 20, highlightLength: 5 }],
+        preview: '\tWalk(err, func(err error) {',
         line: 119,
     },
     {
         highlightRanges: [{ start: 30, highlightLength: 5 }],
+        preview: '// Walk walks all the wrapped errors in err and calls the callback. If',
         line: 133,
     },
     {
         highlightRanges: [{ start: 23, highlightLength: 5 }],
+        preview: "// err isn't a wrapped error, this will be called once for err. If err",
         line: 134,
     },
     {
         highlightRanges: [{ start: 16, highlightLength: 5 }],
+        preview: '// is a wrapped error, the callback will be called for both the wrapper',
         line: 135,
     },
     {
         highlightRanges: [{ start: 19, highlightLength: 5 }],
+        preview: '// that implements error as well as the wrapped error itself.',
         line: 136,
     },
     {
         highlightRanges: [{ start: 48, highlightLength: 5 }],
+        preview: '// that implements error as well as the wrapped error itself.',
         line: 136,
     },
     {
         highlightRanges: [{ start: 14, highlightLength: 5 }],
+        preview: 'func Walk(err error, cb WalkFunc) {',
         line: 137,
     },
     {
         highlightRanges: [{ start: 14, highlightLength: 5 }],
+        preview: '\tcase *wrappedError:',
         line: 143,
     },
     {
         highlightRanges: [{ start: 31, highlightLength: 5 }],
+        preview: '\t\tfor _, err := range e.WrappedErrors() {',
         line: 149,
     },
     {
         highlightRanges: [{ start: 26, highlightLength: 5 }],
+        preview: '\tcase interface{ Unwrap() error }:',
         line: 152,
     },
     {
         highlightRanges: [{ start: 10, highlightLength: 5 }],
+        preview: '// wrappedError is an implementation of error that has both the',
         line: 160,
     },
     {
         highlightRanges: [{ start: 40, highlightLength: 5 }],
+        preview: '// wrappedError is an implementation of error that has both the',
         line: 160,
     },
     {
         highlightRanges: [{ start: 19, highlightLength: 5 }],
+        preview: '// outer and inner errors.',
         line: 161,
     },
     {
         highlightRanges: [{ start: 12, highlightLength: 5 }],
+        preview: 'type wrappedError struct {',
         line: 162,
     },
     {
         highlightRanges: [{ start: 7, highlightLength: 5 }],
+        preview: '\tOuter error',
         line: 163,
     },
     {
         highlightRanges: [{ start: 7, highlightLength: 5 }],
+        preview: '\tInner error',
         line: 164,
     },
     {
         highlightRanges: [{ start: 16, highlightLength: 5 }],
+        preview: 'func (w *wrappedError) Error() string {',
         line: 167,
     },
     {
         highlightRanges: [{ start: 23, highlightLength: 5 }],
+        preview: 'func (w *wrappedError) Error() string {',
         line: 167,
     },
     {
         highlightRanges: [{ start: 16, highlightLength: 5 }],
+        preview: '\treturn w.Outer.Error()',
         line: 168,
     },
     {
         highlightRanges: [{ start: 16, highlightLength: 5 }],
+        preview: 'func (w *wrappedError) WrappedErrors() []error {',
         line: 171,
     },
     {
         highlightRanges: [{ start: 30, highlightLength: 5 }],
+        preview: 'func (w *wrappedError) WrappedErrors() []error {',
         line: 171,
     },
     {
         highlightRanges: [{ start: 41, highlightLength: 5 }],
+        preview: 'func (w *wrappedError) WrappedErrors() []error {',
         line: 171,
     },
     {
         highlightRanges: [{ start: 10, highlightLength: 5 }],
+        preview: '\treturn []error{w.Outer, w.Inner}',
         line: 172,
     },
     {
         highlightRanges: [{ start: 16, highlightLength: 5 }],
+        preview: 'func (w *wrappedError) Unwrap() error {',
         line: 175,
     },
     {
         highlightRanges: [{ start: 32, highlightLength: 5 }],
+        preview: 'func (w *wrappedError) Unwrap() error {',
         line: 175,
     },
 ]

--- a/client/shared/src/search/stream.ts
+++ b/client/shared/src/search/stream.ts
@@ -72,6 +72,7 @@ export interface Location {
 }
 
 interface LineMatch {
+    line: string
     lineNumber: number
     offsetAndLengths: number[][]
     aggregableBadges?: AggregableBadge[]

--- a/client/shared/src/testing/searchTestHelpers.ts
+++ b/client/shared/src/testing/searchTestHelpers.ts
@@ -14,6 +14,7 @@ export const RESULT: ContentMatch = {
     repository: 'github.com/golang/oauth2',
     lineMatches: [
         {
+            line: '  - go test -v golang.org/x/oauth2/...',
             lineNumber: 12,
             offsetAndLengths: [[7, 4]],
         },
@@ -55,14 +56,17 @@ export const MULTIPLE_MATCH_RESULT: ContentMatch = {
     repository: 'github.com/golang/oauth2',
     lineMatches: [
         {
+            line: '\t"net/http/httptest"',
             lineNumber: 11,
             offsetAndLengths: [[15, 4]],
         },
         {
+            line: '\t"testing"',
             lineNumber: 13,
             offsetAndLengths: [[2, 4]],
         },
         {
+            line: 'func TestTokenSourceGrantTypeOverride(t *testing.T) {',
             lineNumber: 36,
             offsetAndLengths: [
                 [5, 4],
@@ -70,10 +74,12 @@ export const MULTIPLE_MATCH_RESULT: ContentMatch = {
             ],
         },
         {
+            line: '\tts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {',
             lineNumber: 39,
             offsetAndLengths: [[11, 4]],
         },
         {
+            line: 'func TestTokenRequest(t *testing.T) {',
             lineNumber: 73,
             offsetAndLengths: [
                 [5, 4],
@@ -81,10 +87,12 @@ export const MULTIPLE_MATCH_RESULT: ContentMatch = {
             ],
         },
         {
+            line: '\tts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {',
             lineNumber: 74,
             offsetAndLengths: [[11, 4]],
         },
         {
+            line: 'func TestTokenRefreshRequest(t *testing.T) {',
             lineNumber: 115,
             offsetAndLengths: [
                 [5, 4],
@@ -92,10 +100,12 @@ export const MULTIPLE_MATCH_RESULT: ContentMatch = {
             ],
         },
         {
+            line: '\tts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {',
             lineNumber: 117,
             offsetAndLengths: [[11, 4]],
         },
         {
+            line: '\t\tio.WriteString(w, `{"access_token": "foo", "refresh_token": "bar"}`)',
             lineNumber: 134,
             offsetAndLengths: [[8, 4]],
         },
@@ -140,6 +150,7 @@ export const MULTIPLE_SEARCH_RESULT: AggregateStreamingSearchResults = {
             repository: 'github.com/golang/oauth2',
             lineMatches: [
                 {
+                    line: 'package oauth2_test',
                     lineNumber: 4,
                     offsetAndLengths: [[15, 4]],
                 },
@@ -167,46 +178,57 @@ export const COLLAPSABLE_SEARCH_RESULT: AggregateStreamingSearchResults = {
             repository: 'github.com/golang/oauth2',
             lineMatches: [
                 {
+                    line: 'package oauth2_test',
                     lineNumber: 4,
                     offsetAndLengths: [[15, 4]],
                 },
                 {
+                    line: 'package oauth2_test',
                     lineNumber: 4,
                     offsetAndLengths: [[15, 4]],
                 },
                 {
+                    line: 'package oauth2_test',
                     lineNumber: 4,
                     offsetAndLengths: [[15, 4]],
                 },
                 {
+                    line: 'package oauth2_test',
                     lineNumber: 4,
                     offsetAndLengths: [[15, 4]],
                 },
                 {
+                    line: 'package oauth2_test',
                     lineNumber: 4,
                     offsetAndLengths: [[15, 4]],
                 },
                 {
+                    line: 'package oauth2_test',
                     lineNumber: 4,
                     offsetAndLengths: [[15, 4]],
                 },
                 {
+                    line: 'package oauth2_test',
                     lineNumber: 4,
                     offsetAndLengths: [[15, 4]],
                 },
                 {
+                    line: 'package oauth2_test',
                     lineNumber: 4,
                     offsetAndLengths: [[15, 4]],
                 },
                 {
+                    line: 'package oauth2_test',
                     lineNumber: 4,
                     offsetAndLengths: [[15, 4]],
                 },
                 {
+                    line: 'package oauth2_test',
                     lineNumber: 4,
                     offsetAndLengths: [[15, 4]],
                 },
                 {
+                    line: 'package oauth2_test',
                     lineNumber: 4,
                     offsetAndLengths: [[15, 4]],
                 },


### PR DESCRIPTION
Reverts sourcegraph/sourcegraph#35522. See that PR for context

@philipp-spiess @vdavid I'm about to step away for a few, but feel free to merge this if/when it passes

## App preview:

- [Web](https://sg-web-revert-35522-cc-remove-line-from.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-osppxicujl.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
