### PR TITLE
gomod: bump zoekt to prevent multi-writers on index dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ All notable changes to Sourcegraph are documented in this file.
 - The `repo:deps(...)` predicate can now search through the [Python dependencies of your repositories](https://docs.sourcegraph.com/code_search/how-to/dependencies_search). [#32659](https://github.com/sourcegraph/sourcegraph/issues/32659)
 - Batch Changes are now supported on [Bitbucket Cloud](https://bitbucket.org/). [#24199](https://github.com/sourcegraph/sourcegraph/issues/24199)
 - Pings for server-side batch changes [#34308](https://github.com/sourcegraph/sourcegraph/pull/34308)
+- Indexed search will detect when it is misconfigured and has multiple replicas writing to the same directory. [#35513](https://github.com/sourcegraph/sourcegraph/pull/35513)
 
 ### Changed
 

--- a/go.mod
+++ b/go.mod
@@ -413,7 +413,7 @@ require (
 // or intentional forks.
 replace (
 	// We maintain our own fork of Zoekt. Update with ./dev/zoekt/update
-	github.com/google/zoekt => github.com/sourcegraph/zoekt v0.0.0-20220518195015-92148cf913e5
+	github.com/google/zoekt => github.com/sourcegraph/zoekt v0.0.0-20220519151725-3bb00e7d99bf
 	// We use a fork of Alertmanager to allow prom-wrapper to better manipulate Alertmanager configuration.
 	// See https://docs.sourcegraph.com/dev/background-information/observability/prometheus
 	github.com/prometheus/alertmanager => github.com/sourcegraph/alertmanager v0.21.1-0.20211110092431-863f5b1ee51b

--- a/go.sum
+++ b/go.sum
@@ -2169,8 +2169,8 @@ github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e h1:qpG
 github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e/go.mod h1:HuIsMU8RRBOtsCgI77wP899iHVBQpCmg4ErYMZB+2IA=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152 h1:z/MpntplPaW6QW95pzcAR/72Z5TWDyDnSo0EOcyij9o=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152/go.mod h1:GIjDIg/heH5DOkXY3YJ/wNhfHsQHoXGjl8G8amsYQ1I=
-github.com/sourcegraph/zoekt v0.0.0-20220518195015-92148cf913e5 h1:p6v7s98Ru/O1GId7qGxtAJaCby5uJgN/6/PA9emjwBg=
-github.com/sourcegraph/zoekt v0.0.0-20220518195015-92148cf913e5/go.mod h1:rgFjt/X6KBEMkJj2X0FOPG+e3DcXN60zrr1e/zOdQkU=
+github.com/sourcegraph/zoekt v0.0.0-20220519151725-3bb00e7d99bf h1:0ireQszy40RVun0I/jojRhOzDUEMyX1BgrEE+tnDG7w=
+github.com/sourcegraph/zoekt v0.0.0-20220519151725-3bb00e7d99bf/go.mod h1:rgFjt/X6KBEMkJj2X0FOPG+e3DcXN60zrr1e/zOdQkU=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=
 github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=


### PR DESCRIPTION
Includes commits:

- https://github.com/sourcegraph/zoekt/commit/3bb00e7 indexserver: assert and check for ownership on index directory
- https://github.com/sourcegraph/zoekt/commit/ec4be9d tests: make the code pass the go vet checks
- https://github.com/sourcegraph/zoekt/commit/cdb5037 all: minor refactoring

Test Plan: CI