### PR TITLE
sg: allow newer patch versions for Go

### DIFF
--- a/dev/sg/checks.go
+++ b/dev/sg/checks.go
@@ -35,7 +35,7 @@ var checks = map[string]check.CheckFunc{
 	"asdf":                  check.CommandOutputContains("asdf", "version"),
 	"git":                   check.Combine(check.InPath("git"), checkGitVersion(">= 2.34.1")),
 	"yarn":                  check.Combine(check.InPath("yarn"), checkYarnVersion("~> 1.22.4")),
-	"go":                    check.Combine(check.InPath("go"), checkGoVersion("1.18.1")),
+	"go":                    check.Combine(check.InPath("go"), checkGoVersion("~> 1.18.1")),
 	"node":                  check.Combine(check.InPath("node"), check.CommandOutputContains(`node -e "console.log(\"foobar\")"`, "foobar")),
 	"rust":                  check.Combine(check.InPath("cargo"), check.CommandOutputContains(`cargo version`, "1.58.0")),
 	"docker-installed":      check.WrapErrMessage(check.InPath("docker"), "if Docker is installed and the check fails, you might need to start Docker.app and restart terminal and 'sg setup'"),


### PR DESCRIPTION
This is fowards-compatible, I think.

## Test plan

```
$ asdf install golang 1.18.2
Platform 'darwin' supported!
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  131M  100  131M    0     0  29.8M      0  0:00:04  0:00:04 --:--:-- 29.9M
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100    64  100    64    0     0    510      0 --:--:-- --:--:-- --:--:--   528
verifying checksum
/Users/thorstenball/.asdf/downloads/golang/1.18.2/archive.tar.gz: OK
checksum verified
$ asdf local golang 1.18.2
$ go run ./dev/sg start
....
```
