### PR TITLE
sg: exit 'sg setup' when user hits ctrl-c

### DIFF
--- a/dev/sg/sg_setup.go
+++ b/dev/sg/sg_setup.go
@@ -51,6 +51,7 @@ func setupExec(ctx context.Context, args []string) error {
 		for range c {
 			std.Out.WriteAlertf("\n💡 You may need to restart your shell for the changes to work in this terminal.")
 			std.Out.WriteAlertf("   Close this terminal and open a new one or type the following command and press ENTER: %s", filepath.Base(usershell.ShellPath(ctx)))
+			os.Exit(0)
 		}
 	}()
 


### PR DESCRIPTION
This was a regression introduced by 4abaacec730d00ccf59f4e972ea22fbc80c80287.

I don't think we can easily return that EmptyExitErr from the goroutine,
so `os.Exit(0)` still seems like the cleanest way of doing it.



## Test plan

- Manually test it