### PR TITLE
migration: Add colorization to describe output

### DIFF
--- a/internal/database/migration/cliutil/describe.go
+++ b/internal/database/migration/cliutil/describe.go
@@ -38,16 +38,17 @@ func Describe(commandName string, factory RunnerFactory, outFactory func() *outp
 	}
 
 	action := makeAction(outFactory, func(ctx context.Context, cmd *cli.Context, out *output.Output) error {
-		formatter := getFormatter(formatFlag.Get(cmd))
-		if formatter == nil {
-			return flagHelp(out, "unrecognized format %q (must be json or psql)", formatFlag.Get(cmd))
-		}
 
-		output, err := getOutput(out, outFlag.Get(cmd), forceFlag.Get(cmd), noColorFlag.Get(cmd))
+		output, shouldDecorate, err := getOutput(out, outFlag.Get(cmd), forceFlag.Get(cmd), noColorFlag.Get(cmd))
 		if err != nil {
 			return err
 		}
 		defer output.Close()
+
+		formatter := getFormatter(formatFlag.Get(cmd), shouldDecorate)
+		if formatter == nil {
+			return flagHelp(out, "unrecognized format %q (must be json or psql)", formatFlag.Get(cmd))
+		}
 
 		_, store, err := setupStore(ctx, factory, schemaNameFlag.Get(cmd))
 		if err != nil {

--- a/internal/database/migration/cliutil/describe_util.go
+++ b/internal/database/migration/cliutil/describe_util.go
@@ -1,6 +1,7 @@
 package cliutil
 
 import (
+	"fmt"
 	"io"
 	"os"
 
@@ -9,15 +10,45 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/output"
 )
 
-// outputWriter is an io.WriteCloser over an *output.Output object.
+// getOutput return a write target from the given descriptions. If no filename is
+// supplied, then the given output writer is used. The shouldDecorate return value
+// hints to the formatter that it will be rendered as markdown and should envelope
+// its output if necessary.
+func getOutput(out *output.Output, filename string, force, noColor bool) (_ io.WriteCloser, shouldDecorate bool, _ error) {
+	if filename == "" {
+		writeFunc := out.WriteMarkdown
+		if noColor {
+			writeFunc = func(s string) error {
+				out.Write(s)
+				return nil
+			}
+		}
+
+		return &outputWriter{write: writeFunc}, !noColor, nil
+	}
+
+	if !force {
+		if _, err := os.Stat(filename); err == nil {
+			return nil, false, errors.Newf("file %q already exists", filename)
+		} else if !os.IsNotExist(err) {
+			return nil, false, err
+		}
+	}
+
+	f, err := os.OpenFile(filename, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, os.ModePerm)
+	return f, false, err
+}
+
+// outputWriter is an io.WriteCloser over a single write method.
 type outputWriter struct {
-	out     *output.Output
-	noColor bool
+	write func(string) error
 }
 
 func (w *outputWriter) Write(b []byte) (int, error) {
-	// Color currently unimplemented
-	w.out.Write(string(b))
+	if err := w.write(string(b)); err != nil {
+		return 0, err
+	}
+
 	return len(b), nil
 }
 
@@ -26,11 +57,20 @@ func (w *outputWriter) Close() error {
 }
 
 // getFormatter returns the schema formatter with a given name, or nil if the given
-// name is unrecognized.
-func getFormatter(format string) descriptions.SchemaFormatter {
+// name is unrecognized. If shouldDecorate is true, then the output should be wrapped
+// in a markdown envelope for rendering, if necessary.
+func getFormatter(format string, shouldDecorate bool) descriptions.SchemaFormatter {
 	switch format {
 	case "json":
-		return descriptions.NewJSONFormatter()
+		jsonFormatter := descriptions.NewJSONFormatter()
+		if shouldDecorate {
+			jsonFormatter = markdownCodeFormatter{
+				languageID: "json",
+				formatter:  jsonFormatter,
+			}
+		}
+
+		return jsonFormatter
 	case "psql":
 		return descriptions.NewPSQLFormatter()
 	default:
@@ -39,25 +79,17 @@ func getFormatter(format string) descriptions.SchemaFormatter {
 	return nil
 }
 
-// getOutput return a write target from the given descriptions. If no filename is
-// supplied, then the given output writer is used.
-func getOutput(
-	out *output.Output,
-	filename string,
-	force bool,
-	noColor bool,
-) (io.WriteCloser, error) {
-	if filename == "" {
-		return &outputWriter{out, noColor}, nil
-	}
+type markdownCodeFormatter struct {
+	languageID string
+	formatter  descriptions.SchemaFormatter
+}
 
-	if !force {
-		if _, err := os.Stat(filename); err == nil {
-			return nil, errors.Newf("file %q already exists", filename)
-		} else if !os.IsNotExist(err) {
-			return nil, err
-		}
-	}
-
-	return os.OpenFile(filename, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, os.ModePerm)
+func (f markdownCodeFormatter) Format(schemaDescription descriptions.SchemaDescription) string {
+	return fmt.Sprintf(
+		"%s%s\n%s\n%s",
+		"```",
+		f.languageID,
+		f.formatter.Format(schemaDescription),
+		"```",
+	)
 }


### PR DESCRIPTION
Adds invocation to `WriteMarkdown` when stdout is the target and colorization is not disabled in the `sg migration describe` and `migrator describe` commands.

## Test plan

Tested locally.