### PR TITLE
dev/sg: unify interrupt handling

### DIFF
--- a/dev/sg/analytics.go
+++ b/dev/sg/analytics.go
@@ -1,16 +1,14 @@
 package main
 
 import (
-	"os"
-	"os/signal"
 	"strings"
-	"syscall"
 	"time"
 
 	"github.com/urfave/cli/v2"
 
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/analytics"
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/std"
+	"github.com/sourcegraph/sourcegraph/dev/sg/interrupt"
 )
 
 // addAnalyticsHooks wraps command actions with analytics hooks. We reconstruct commandPath
@@ -32,15 +30,8 @@ func addAnalyticsHooks(start time.Time, commandPath []string, commands []*cli.Co
 		// Wrap action with analytics
 		wrappedAction := command.Action
 		command.Action = func(cmd *cli.Context) error {
-			// Make sure analytics hook is called even on interrupts. Note that this only
-			// works if you 'go build' sg, not if you 'go run'.
-			interrupt := make(chan os.Signal, 1)
-			signal.Notify(interrupt, os.Interrupt, syscall.SIGTERM)
-			go func() {
-				<-interrupt
-				analyticsHook(cmd, "cancelled")
-				os.Exit(1)
-			}()
+			// Make sure analytics hook gets called before exit
+			interrupt.Register(func() { analyticsHook(cmd, "cancelled") })
 
 			// Call the underlying action
 			actionErr := wrappedAction(cmd)
@@ -59,6 +50,8 @@ func addAnalyticsHooks(start time.Time, commandPath []string, commands []*cli.Co
 
 func makeAnalyticsHook(start time.Time, commandPath []string) func(ctx *cli.Context, events ...string) {
 	return func(cmd *cli.Context, events ...string) {
+		println("im doing analytics!")
+
 		// Log an sg usage occurrence
 		analytics.LogEvent(cmd.Context, "sg_action", commandPath, start, events...)
 

--- a/dev/sg/analytics.go
+++ b/dev/sg/analytics.go
@@ -50,8 +50,6 @@ func addAnalyticsHooks(start time.Time, commandPath []string, commands []*cli.Co
 
 func makeAnalyticsHook(start time.Time, commandPath []string) func(ctx *cli.Context, events ...string) {
 	return func(cmd *cli.Context, events ...string) {
-		println("im doing analytics!")
-
 		// Log an sg usage occurrence
 		analytics.LogEvent(cmd.Context, "sg_action", commandPath, start, events...)
 

--- a/dev/sg/interrupt/interrupt.go
+++ b/dev/sg/interrupt/interrupt.go
@@ -1,0 +1,29 @@
+package interrupt
+
+import (
+	"os"
+	"os/signal"
+	"syscall"
+)
+
+var hooks []func()
+
+// Register adds a hook to be executed before program exit. The most recently added hooks
+// are added first.
+func Register(hook func()) {
+	hooks = append([]func(){hook}, hooks...)
+}
+
+// Listen starts a goroutine that listens for interrupts and executes registered hooks
+// before exiting with status 1.
+func Listen() {
+	interrupt := make(chan os.Signal, 1)
+	signal.Notify(interrupt, os.Interrupt, syscall.SIGTERM, syscall.SIGINT)
+	go func() {
+		<-interrupt
+		for _, h := range hooks {
+			h()
+		}
+		os.Exit(1)
+	}()
+}


### PR DESCRIPTION
All `sg` components should now register pre-interrupt-exit hooks with `interrupt.Register(func())`

Closes https://github.com/sourcegraph/sourcegraph/pull/35720

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
<img width="688" alt="image" src="https://user-images.githubusercontent.com/23356519/169360441-77332468-0902-4d9d-862e-fe994f613175.png">
