### PR TITLE
migration: Add colorization to drift output

### DIFF
--- a/internal/database/migration/cliutil/drift.go
+++ b/internal/database/migration/cliutil/drift.go
@@ -3,7 +3,6 @@ package cliutil
 import (
 	"context"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/urfave/cli/v2"
 
 	"github.com/sourcegraph/sourcegraph/lib/output"
@@ -38,13 +37,7 @@ func Drift(commandName string, factory RunnerFactory, outFactory func() *output.
 			return err
 		}
 
-		if diff := cmp.Diff(prepareForSchemaComparison(schema, expected), expected); diff == "" {
-			out.Write("No drift detected!")
-		} else {
-			out.Writef("Database schema drift detected: %s", diff)
-		}
-
-		return nil
+		return compareSchemaDescriptions(out, schema, expected)
 	})
 
 	return &cli.Command{

--- a/internal/database/migration/cliutil/drift.go
+++ b/internal/database/migration/cliutil/drift.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/urfave/cli/v2"
 
+	descriptions "github.com/sourcegraph/sourcegraph/internal/database/migration/schemas"
 	"github.com/sourcegraph/sourcegraph/lib/output"
 )
 
@@ -37,6 +38,7 @@ func Drift(commandName string, factory RunnerFactory, outFactory func() *output.
 			return err
 		}
 
+		descriptions.Canonicalize(schema)
 		return compareSchemaDescriptions(out, schema, expected)
 	})
 

--- a/internal/database/migration/cliutil/drift_util.go
+++ b/internal/database/migration/cliutil/drift_util.go
@@ -62,11 +62,9 @@ var errOutOfSync = errors.Newf("database schema is out of sync")
 
 func compareSchemaDescriptions(out *output.Output, actual, expected schemas.SchemaDescription) (err error) {
 	missing := func(typeName, name string, value any) {
-		diff := cmp.Diff(nil, value)
 		out.WriteLine(output.Line(output.EmojiFailure, output.StyleBold, fmt.Sprintf("Missing %s %q", typeName, name)))
-		if diff != "" {
-			out.WriteMarkdown(fmt.Sprintf("```diff\n%s```", diff))
-		}
+		jsonValue, _ := json.MarshalIndent(value, "", "    ")
+		out.WriteMarkdown(fmt.Sprintf("```json\n%s\n```", string(jsonValue)))
 		err = errOutOfSync
 	}
 
@@ -168,7 +166,10 @@ func compareSchemaDescriptions(out *output.Output, actual, expected schemas.Sche
 		if table, ok := actualTables[name]; !ok {
 			missing("table", name, expectedTable)
 		} else {
-			diff("table", "definition", name, expectedTable, table)
+			diff("table", "columns", name, expectedTable.Columns, table.Columns)
+			diff("table", "columns", name, expectedTable.Constraints, table.Constraints)
+			diff("table", "columns", name, expectedTable.Indexes, table.Indexes)
+			diff("table", "columns", name, expectedTable.Triggers, table.Triggers)
 		}
 	}
 


### PR DESCRIPTION
Adds invocation to `WriteMarkdown` in the `sg migration drift` and `migrator drift` commands.

![ssssyeah](https://user-images.githubusercontent.com/103087/169413862-28f11b8e-5a94-4ce3-abdc-9147e48d2235.png)

## Test plan

Tested locally.