### PR TITLE
Commit/diff search: run only over cloned repos

### DIFF
--- a/internal/search/job/jobutil/job.go
+++ b/internal/search/job/jobutil/job.go
@@ -120,9 +120,11 @@ func NewBasicJob(inputs *run.SearchInputs, b query.Basic) (job.Job, error) {
 
 		if resultTypes.Has(result.TypeCommit) || resultTypes.Has(result.TypeDiff) {
 			diff := resultTypes.Has(result.TypeDiff)
+			repoOptionsCopy := repoOptions
+			repoOptionsCopy.OnlyCloned = true
 			addJob(&commit.CommitSearchJob{
 				Query:                commit.QueryToGitQuery(b, diff),
-				RepoOpts:             repoOptions,
+				RepoOpts:             repoOptionsCopy,
 				Diff:                 diff,
 				HasTimeFilter:        b.Exists("after") || b.Exists("before"),
 				Limit:                int(fileMatchLimit),

--- a/internal/search/job/jobutil/printers_test.go
+++ b/internal/search/job/jobutil/printers_test.go
@@ -217,6 +217,7 @@ func TestPrettyJSON(t *testing.T) {
               "ForkSet": false,
               "NoForks": true,
               "OnlyForks": false,
+              "OnlyCloned": false,
               "ArchivedSet": false,
               "NoArchived": true,
               "OnlyArchived": false
@@ -273,6 +274,7 @@ func TestPrettyJSON(t *testing.T) {
                   "ForkSet": false,
                   "NoForks": true,
                   "OnlyForks": false,
+                  "OnlyCloned": false,
                   "ArchivedSet": false,
                   "NoArchived": true,
                   "OnlyArchived": false

--- a/internal/search/repos/repos.go
+++ b/internal/search/repos/repos.go
@@ -180,6 +180,8 @@ func (r *Resolver) Resolve(ctx context.Context, op search.RepoOptions) (Resolved
 		OnlyArchived: op.OnlyArchived,
 		NoPrivate:    op.Visibility == query.Public,
 		OnlyPrivate:  op.Visibility == query.Private,
+		NoCloned: op.NoCloned,
+		OnlyCloned: op.OnlyCloned,
 		OrderBy: database.RepoListOrderBy{
 			{
 				Field:      database.RepoListStars,

--- a/internal/search/repos/repos.go
+++ b/internal/search/repos/repos.go
@@ -180,8 +180,7 @@ func (r *Resolver) Resolve(ctx context.Context, op search.RepoOptions) (Resolved
 		OnlyArchived: op.OnlyArchived,
 		NoPrivate:    op.Visibility == query.Public,
 		OnlyPrivate:  op.Visibility == query.Private,
-		NoCloned: op.NoCloned,
-		OnlyCloned: op.OnlyCloned,
+		OnlyCloned:   op.OnlyCloned,
 		OrderBy: database.RepoListOrderBy{
 			{
 				Field:      database.RepoListStars,

--- a/internal/search/types.go
+++ b/internal/search/types.go
@@ -254,6 +254,9 @@ type RepoOptions struct {
 	NoForks   bool
 	OnlyForks bool
 
+	OnlyCloned bool
+	NoCloned   bool
+
 	// ArchivedSet indicates whether `archived:` was set explicitly in the query,
 	// or whether the values were set from defaults.
 	ArchivedSet  bool
@@ -289,6 +292,12 @@ func (op *RepoOptions) String() string {
 	}
 	if op.OnlyForks {
 		fmt.Fprintf(&b, "OnlyForks: %t\n", op.OnlyForks)
+	}
+	if op.NoCloned {
+		fmt.Fprintf(&b, "NoCloned: %t\n", op.NoCloned)
+	}
+	if op.OnlyCloned {
+		fmt.Fprintf(&b, "OnlyCloned: %t\n", op.OnlyCloned)
 	}
 	if op.ArchivedSet {
 		fmt.Fprintf(&b, "ArchivedSet: %t\n", op.ArchivedSet)

--- a/internal/search/types.go
+++ b/internal/search/types.go
@@ -255,7 +255,6 @@ type RepoOptions struct {
 	OnlyForks bool
 
 	OnlyCloned bool
-	NoCloned   bool
 
 	// ArchivedSet indicates whether `archived:` was set explicitly in the query,
 	// or whether the values were set from defaults.
@@ -292,9 +291,6 @@ func (op *RepoOptions) String() string {
 	}
 	if op.OnlyForks {
 		fmt.Fprintf(&b, "OnlyForks: %t\n", op.OnlyForks)
-	}
-	if op.NoCloned {
-		fmt.Fprintf(&b, "NoCloned: %t\n", op.NoCloned)
 	}
 	if op.OnlyCloned {
 		fmt.Fprintf(&b, "OnlyCloned: %t\n", op.OnlyCloned)


### PR DESCRIPTION
Commit and diff search currently do not exclude repos that are not cloned. This means we're getting spurious errors in code monitors that are actually just because the repo isn't cloned (for whatever reason). 

## Test plan

Manually tested with Thomas.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
