### PR TITLE
FetchAccount method implementation for Gerrit

### DIFF
--- a/enterprise/internal/authz/gerrit/authz.go
+++ b/enterprise/internal/authz/gerrit/authz.go
@@ -1,0 +1,17 @@
+package gerrit
+
+import (
+	"github.com/sourcegraph/sourcegraph/internal/authz"
+	"github.com/sourcegraph/sourcegraph/internal/types"
+)
+
+// NewAuthzProviders returns the set of Gerrit authz providers derived from the connections.
+func NewAuthzProviders(conns []*types.GerritConnection) (ps []authz.Provider) {
+	for _, c := range conns {
+		p := NewProvider(c)
+		if p != nil {
+			ps = append(ps, p)
+		}
+	}
+	return ps
+}

--- a/enterprise/internal/authz/gerrit/authz.go
+++ b/enterprise/internal/authz/gerrit/authz.go
@@ -8,7 +8,7 @@ import (
 // NewAuthzProviders returns the set of Gerrit authz providers derived from the connections.
 func NewAuthzProviders(conns []*types.GerritConnection) (ps []authz.Provider) {
 	for _, c := range conns {
-		p := NewProvider(c)
+		p, _ := NewProvider(c)
 		if p != nil {
 			ps = append(ps, p)
 		}

--- a/enterprise/internal/authz/gerrit/client.go
+++ b/enterprise/internal/authz/gerrit/client.go
@@ -1,0 +1,38 @@
+package gerrit
+
+import (
+	"context"
+
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/gerrit"
+)
+
+type client interface {
+	ListAccountsByEmail(ctx context.Context, email string) (gerrit.ListAccountsResponse, error)
+	ListAccountsByUsername(ctx context.Context, username string) (gerrit.ListAccountsResponse, error)
+}
+
+var _ client = (*ClientAdapter)(nil)
+
+// ClientAdapter is an adapter for GitHub API client.
+type ClientAdapter struct {
+	*gerrit.Client
+}
+
+type mockClient struct {
+	mockListAccountsByEmail    func(ctx context.Context, email string) (gerrit.ListAccountsResponse, error)
+	mockListAccountsByUsername func(ctx context.Context, username string) (gerrit.ListAccountsResponse, error)
+}
+
+func (m *mockClient) ListAccountsByEmail(ctx context.Context, email string) (gerrit.ListAccountsResponse, error) {
+	if m.mockListAccountsByEmail != nil {
+		return m.mockListAccountsByEmail(ctx, email)
+	}
+	return nil, nil
+}
+
+func (m *mockClient) ListAccountsByUsername(ctx context.Context, username string) (gerrit.ListAccountsResponse, error) {
+	if m.mockListAccountsByUsername != nil {
+		return m.mockListAccountsByUsername(ctx, username)
+	}
+	return nil, nil
+}

--- a/enterprise/internal/authz/gerrit/client.go
+++ b/enterprise/internal/authz/gerrit/client.go
@@ -13,7 +13,7 @@ type client interface {
 
 var _ client = (*ClientAdapter)(nil)
 
-// ClientAdapter is an adapter for GitHub API client.
+// ClientAdapter is an adapter for Gerrit API client.
 type ClientAdapter struct {
 	*gerrit.Client
 }

--- a/enterprise/internal/authz/gerrit/gerrit.go
+++ b/enterprise/internal/authz/gerrit/gerrit.go
@@ -20,17 +20,17 @@ type Provider struct {
 	codeHost *extsvc.CodeHost
 }
 
-func NewProvider(conn *types.GerritConnection) *Provider {
+func NewProvider(conn *types.GerritConnection) (*Provider, error) {
 	baseURL, _ := url.Parse(conn.Url)
 	gClient, err := gerrit.NewClient(conn.URN, conn.GerritConnection, nil)
 	if err != nil {
-		//TODO: handle error
+		return nil, err
 	}
 	return &Provider{
 		urn:      conn.URN,
 		client:   gClient,
 		codeHost: extsvc.NewCodeHost(baseURL, extsvc.TypeGerrit),
-	}
+	}, nil
 }
 
 func (p Provider) FetchAccount(ctx context.Context, user *types.User, current []*extsvc.Account, verifiedEmails []string) (*extsvc.Account, error) {
@@ -40,7 +40,7 @@ func (p Provider) FetchAccount(ctx context.Context, user *types.User, current []
 		return nil, err
 	}
 	// Check that this account from Gerrit correlates to a verified email
-	if acct, found := p.checkAccountsAgainstVerifiedEmails(accts, user, verifiedEmails); found {
+	if acct, found, err := p.checkAccountsAgainstVerifiedEmails(accts, user, verifiedEmails); found && err == nil {
 		return acct, nil
 	}
 
@@ -51,30 +51,29 @@ func (p Provider) FetchAccount(ctx context.Context, user *types.User, current []
 			return nil, err
 		}
 		for _, acct := range accts {
-			return p.createAccount(acct, user, email)
+			return p.buildExtsvcAccount(acct, user, email)
 		}
 	}
 
 	return nil, nil
 }
 
-func (p Provider) checkAccountsAgainstVerifiedEmails(accts gerrit.ListAccountsResponse, user *types.User, verifiedEmails []string) (*extsvc.Account, bool) {
-	if accts != nil || len(accts) > 0 {
-		for _, email := range verifiedEmails {
-			for _, acct := range accts {
-				if acct.Email == email && acct.Username == user.Username {
-					foundAcct, _ := p.createAccount(acct, user, email)
-					// todo: handle error
-					return foundAcct, true
-				}
+func (p Provider) checkAccountsAgainstVerifiedEmails(accts gerrit.ListAccountsResponse, user *types.User, verifiedEmails []string) (*extsvc.Account, bool, error) {
+	if accts == nil || len(accts) == 0 {
+		return nil, false, nil
+	}
+	for _, email := range verifiedEmails {
+		for _, acct := range accts {
+			if acct.Email == email && acct.Username == user.Username {
+				foundAcct, err := p.buildExtsvcAccount(acct, user, email)
+				return foundAcct, true, err
 			}
 		}
 	}
-	return nil, false
+	return nil, false, nil
 }
 
-// TODO: better naming. This seems to imply we're actually making something (i.e. storing in a db) but we're just creating the object
-func (p Provider) createAccount(acct gerrit.Account, user *types.User, email string) (*extsvc.Account, error) {
+func (p Provider) buildExtsvcAccount(acct gerrit.Account, user *types.User, email string) (*extsvc.Account, error) {
 	acctData, err := marshalAccountData(acct.Username, acct.Email, acct.ID)
 	if err != nil {
 		return nil, errors.Wrap(err, "marshaling account data")

--- a/enterprise/internal/authz/gerrit/gerrit.go
+++ b/enterprise/internal/authz/gerrit/gerrit.go
@@ -2,28 +2,111 @@ package gerrit
 
 import (
 	"context"
+	"encoding/json"
 	"net/url"
+
+	jsoniter "github.com/json-iterator/go"
 
 	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/gerrit"
 	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 type Provider struct {
 	urn      string
+	client   client
 	codeHost *extsvc.CodeHost
 }
 
-func NewProvider(urn, host string) *Provider {
-	baseURL, _ := url.Parse(host)
+func NewProvider(conn *types.GerritConnection) *Provider {
+	baseURL, _ := url.Parse(conn.Url)
+	gClient, err := gerrit.NewClient(conn.URN, conn.GerritConnection, nil)
+	if err != nil {
+		//TODO: handle error
+	}
 	return &Provider{
-		urn:      urn,
+		urn:      conn.URN,
+		client:   gClient,
 		codeHost: extsvc.NewCodeHost(baseURL, extsvc.TypeGerrit),
 	}
 }
 
-func (p Provider) FetchAccount(ctx context.Context, user *types.User, current []*extsvc.Account, verifiedEmails []string) (mine *extsvc.Account, err error) {
-	return nil, &authz.ErrUnimplemented{Feature: "gerrit.FetchAccount"}
+func (p Provider) FetchAccount(ctx context.Context, user *types.User, current []*extsvc.Account, verifiedEmails []string) (*extsvc.Account, error) {
+	// First try to fetch Gerrit account for this username
+	accts, err := p.client.ListAccountsByUsername(ctx, user.Username)
+	if err != nil {
+		return nil, err
+	}
+	// Check that this account from Gerrit correlates to a verified email
+	if acct, found := p.checkAccountsAgainstVerifiedEmails(accts, user, verifiedEmails); found {
+		return acct, nil
+	}
+
+	// If no account was found via the user's Sourcegraph username, attempt to find an account via one of the verified emails.
+	for _, email := range verifiedEmails {
+		accts, err := p.client.ListAccountsByEmail(ctx, email)
+		if err != nil {
+			return nil, err
+		}
+		for _, acct := range accts {
+			return p.createAccount(acct, user, email)
+		}
+	}
+
+	return nil, nil
+}
+
+func (p Provider) checkAccountsAgainstVerifiedEmails(accts gerrit.ListAccountsResponse, user *types.User, verifiedEmails []string) (*extsvc.Account, bool) {
+	if accts != nil || len(accts) > 0 {
+		for _, email := range verifiedEmails {
+			for _, acct := range accts {
+				if acct.Email == email && acct.Username == user.Username {
+					foundAcct, _ := p.createAccount(acct, user, email)
+					// todo: handle error
+					return foundAcct, true
+				}
+			}
+		}
+	}
+	return nil, false
+}
+
+// TODO: better naming. This seems to imply we're actually making something (i.e. storing in a db) but we're just creating the object
+func (p Provider) createAccount(acct gerrit.Account, user *types.User, email string) (*extsvc.Account, error) {
+	acctData, err := marshalAccountData(acct.Username, acct.Email, acct.ID)
+	if err != nil {
+		return nil, errors.Wrap(err, "marshaling account data")
+	}
+	return &extsvc.Account{
+		ID:     acct.ID, // TODO: do we need this?
+		UserID: user.ID,
+		AccountSpec: extsvc.AccountSpec{
+			ServiceType: p.codeHost.ServiceType,
+			ServiceID:   p.codeHost.ServiceID,
+			AccountID:   email,
+		},
+		AccountData: extsvc.AccountData{
+			Data: acctData,
+		},
+		CreatedAt: user.CreatedAt,
+		UpdatedAt: user.UpdatedAt,
+	}, nil
+}
+
+func marshalAccountData(username, email string, acctID int32) (*json.RawMessage, error) {
+	accountData, err := jsoniter.Marshal(
+		gerrit.AccountData{
+			Username:  username,
+			Email:     email,
+			AccountID: acctID,
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+	return (*json.RawMessage)(&accountData), nil
 }
 
 func (p Provider) FetchUserPerms(ctx context.Context, account *extsvc.Account, opts authz.FetchPermsOptions) (*authz.ExternalUserPermissions, error) {

--- a/enterprise/internal/authz/gerrit/gerrit.go
+++ b/enterprise/internal/authz/gerrit/gerrit.go
@@ -21,7 +21,10 @@ type Provider struct {
 }
 
 func NewProvider(conn *types.GerritConnection) (*Provider, error) {
-	baseURL, _ := url.Parse(conn.Url)
+	baseURL, err := url.Parse(conn.Url)
+	if err != nil {
+		return nil, err
+	}
 	gClient, err := gerrit.NewClient(conn.URN, conn.GerritConnection, nil)
 	if err != nil {
 		return nil, err
@@ -79,7 +82,6 @@ func (p Provider) buildExtsvcAccount(acct gerrit.Account, user *types.User, emai
 		return nil, errors.Wrap(err, "marshaling account data")
 	}
 	return &extsvc.Account{
-		ID:     acct.ID, // TODO: do we need this?
 		UserID: user.ID,
 		AccountSpec: extsvc.AccountSpec{
 			ServiceType: p.codeHost.ServiceType,

--- a/enterprise/internal/authz/gerrit/gerrit_test.go
+++ b/enterprise/internal/authz/gerrit/gerrit_test.go
@@ -1,0 +1,77 @@
+package gerrit
+
+import (
+	"context"
+	"net/url"
+	"testing"
+
+	"github.com/sourcegraph/sourcegraph/internal/extsvc"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/gerrit"
+
+	"github.com/sourcegraph/sourcegraph/internal/types"
+)
+
+func TestProvider_FetchAccount(t *testing.T) {
+	userEmail := "test-email@example.com"
+	userName := "test-user"
+	testCases := []struct {
+		name   string
+		client mockClient
+	}{
+		{
+			name: "no matching username but email match",
+			client: mockClient{
+				mockListAccountsByEmail: func(ctx context.Context, email string) (gerrit.ListAccountsResponse, error) {
+					return []gerrit.Account{
+						{
+							Email: userEmail,
+						},
+					}, nil
+				},
+				mockListAccountsByUsername: nil,
+			},
+		},
+		{
+			name: "username matches and email valid",
+			client: mockClient{
+				mockListAccountsByEmail: nil,
+				mockListAccountsByUsername: func(ctx context.Context, username string) (gerrit.ListAccountsResponse, error) {
+					return []gerrit.Account{
+						{
+							Email:    userEmail,
+							Username: username,
+						},
+					}, nil
+				},
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := NewTestProvider(&tc.client)
+			user := types.User{
+				Username: userName,
+			}
+			verifiedEmails := []string{
+				userEmail,
+			}
+			acct, err := p.FetchAccount(context.Background(), &user, nil, verifiedEmails)
+			if err != nil {
+				t.Fatalf("error fetching account: %s", err)
+			}
+			if acct == nil {
+				t.Fatalf("account was nil")
+			}
+			// TODO: validate account
+		})
+	}
+}
+
+func NewTestProvider(client client) *Provider {
+	baseURL, _ := url.Parse("https://gerrit.sgdev.org")
+	return &Provider{
+		urn:      "Gerrit",
+		client:   client,
+		codeHost: extsvc.NewCodeHost(baseURL, extsvc.TypeGerrit),
+	}
+}

--- a/internal/extsvc/gerrit/account.go
+++ b/internal/extsvc/gerrit/account.go
@@ -1,0 +1,22 @@
+package gerrit
+
+import "github.com/sourcegraph/sourcegraph/internal/extsvc"
+
+// AccountData stores information of a Gerrit account.
+type AccountData struct {
+	Username  string `json:"username"`
+	Email     string `json:"email"`
+	AccountID int32  `json:"account_id"`
+}
+
+// GetExternalAccountData extracts account data for the external account.
+func GetExternalAccountData(data *extsvc.AccountData) (accountData *AccountData, err error) {
+	if data.Data != nil {
+		var d AccountData
+		if err = data.GetAccountData(&d); err != nil {
+			return nil, err
+		}
+		accountData = &d
+	}
+	return accountData, nil
+}

--- a/internal/extsvc/gerrit/client.go
+++ b/internal/extsvc/gerrit/client.go
@@ -56,6 +56,39 @@ func NewClient(urn string, config *schema.GerritConnection, httpClient httpcli.D
 	}, nil
 }
 
+type ListAccountsResponse []Account
+
+func (c *Client) ListAccountsByEmail(ctx context.Context, email string) (ListAccountsResponse, error) {
+	qsAccounts := make(url.Values)
+	qsAccounts.Set("q", fmt.Sprintf("email:%s", email)) // TODO: what query should we run?
+	return c.listAccounts(ctx, qsAccounts)
+}
+
+func (c *Client) ListAccountsByUsername(ctx context.Context, username string) (ListAccountsResponse, error) {
+	qsAccounts := make(url.Values)
+	qsAccounts.Set("q", fmt.Sprintf("username:%s", username)) // TODO: what query should we run?
+	return c.listAccounts(ctx, qsAccounts)
+}
+
+func (c *Client) listAccounts(ctx context.Context, qsAccounts url.Values) (ListAccountsResponse, error) {
+	qsAccounts.Set("o", "details")
+
+	urlPath := "a/accounts/"
+
+	uAllProjects := url.URL{Path: urlPath, RawQuery: qsAccounts.Encode()}
+
+	reqAllAccounts, err := http.NewRequest("GET", uAllProjects.String(), nil)
+
+	if err != nil {
+		return nil, err
+	}
+	respAllAccts := ListAccountsResponse{}
+	if _, err = c.do(ctx, reqAllAccounts, &respAllAccts); err != nil {
+		return respAllAccts, err
+	}
+	return respAllAccts, nil
+}
+
 // ListProjectsArgs defines options to be set on ListProjects method calls.
 type ListProjectsArgs struct {
 	Cursor *Pagination
@@ -167,6 +200,14 @@ func (c *Client) do(ctx context.Context, req *http.Request, result any) (*http.R
 		}
 	}
 	return resp, json.Unmarshal(bs[4:], result)
+}
+
+type Account struct {
+	ID          int32  `json:"_account_id"`
+	Name        string `json:"name"`
+	DisplayName string `json:"display_name"`
+	Email       string `json:"email"`
+	Username    string `json:"username"`
 }
 
 type Project struct {

--- a/internal/types/external_services.go
+++ b/internal/types/external_services.go
@@ -27,3 +27,9 @@ type PerforceConnection struct {
 	URN string
 	*schema.PerforceConnection
 }
+
+type GerritConnection struct {
+	// The unique resource identifier of the external service.
+	URN string
+	*schema.GerritConnection
+}


### PR DESCRIPTION
Implementing FetchAccount for the Gerrit auth provider.

Closes https://github.com/sourcegraph/sourcegraph/issues/35743

Outstanding questions/thoughts:
- What exactly should we be pulling in from Gerrit for each account? It seems that username, email, and account id is sufficient (and might be more than we need). I'm guessing as we implement the other methods of the provider interface it will become more clear what exactly we need.
- Does the approach of querying the Gerrit api first for the username matching the sourcegraph user and _then_ querying for accounts matching one of the verified emails make sense? We basically return as soon as we find something that matches, which seems to go along with the implementation for [Perforce](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/enterprise/internal/authz/perforce/perforce.go?L67-141) I'm happy to adjust this if we want or if there's a better approach.

## Test plan
- Manual testing locally against dogfood Gerrit instance
- Unit tests 
- Eventual end-to-end/integration tests once the rest of the methods for this provider are implemented and the approach is solidified.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
