### PR TITLE
Clarify wording in code monitor logs when runs are pending

### DIFF
--- a/client/web/src/enterprise/code-monitoring/components/logs/TriggerEvent.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/logs/TriggerEvent.tsx
@@ -66,7 +66,8 @@ export const TriggerEvent: React.FunctionComponent<
                 {hasError ? <Icon className={classNames(styles.errorIcon, 'mr-2')} as={AlertCircleIcon} /> : <span />}
 
                 <span>
-                    Run <Timestamp date={triggerEvent.timestamp} noAbout={true} now={now} />
+                    {triggerEvent.status === EventStatus.PENDING ? 'Scheduled' : 'Ran'}{' '}
+                    <Timestamp date={triggerEvent.timestamp} noAbout={true} now={now} />
                     {triggerEvent.query && (
                         <Link
                             to={`/search?${buildSearchURLQuery(triggerEvent.query, SearchPatternType.literal, false)}`}

--- a/client/web/src/enterprise/code-monitoring/testing/util.ts
+++ b/client/web/src/enterprise/code-monitoring/testing/util.ts
@@ -573,9 +573,9 @@ export const mockLogs: MonitorTriggerEventsResult = {
                                     id: 'f',
                                     status: EventStatus.PENDING,
                                     message: null,
-                                    timestamp: '2022-02-14T16:29:16Z',
-                                    query: 'test type:diff',
-                                    resultCount: 5,
+                                    timestamp: '2022-02-14T16:20:16Z',
+                                    query: '',
+                                    resultCount: 0,
                                     actions: {
                                         __typename: 'MonitorActionConnection',
                                         nodes: [
@@ -596,7 +596,7 @@ export const mockLogs: MonitorTriggerEventsResult = {
                                                             __typename: 'MonitorActionEvent',
                                                             status: EventStatus.PENDING,
                                                             message: null,
-                                                            timestamp: '2022-02-14T16:29:16Z',
+                                                            timestamp: '2022-02-14T16:20:16Z',
                                                         },
                                                     ],
                                                 },

--- a/client/web/src/enterprise/code-monitoring/testing/util.ts
+++ b/client/web/src/enterprise/code-monitoring/testing/util.ts
@@ -558,6 +558,58 @@ export const mockLogs: MonitorTriggerEventsResult = {
                         },
                     },
                 },
+                {
+                    __typename: 'Monitor',
+                    description: 'Fifth test code monitor (only pending events)',
+                    id: '131415',
+                    trigger: {
+                        __typename: 'MonitorQuery',
+                        query: 'test type:commit',
+                        events: {
+                            __typename: 'MonitorTriggerEventConnection',
+                            nodes: [
+                                {
+                                    __typename: 'MonitorTriggerEvent',
+                                    id: 'f',
+                                    status: EventStatus.PENDING,
+                                    message: null,
+                                    timestamp: '2022-02-14T16:29:16Z',
+                                    query: 'test type:diff',
+                                    resultCount: 5,
+                                    actions: {
+                                        __typename: 'MonitorActionConnection',
+                                        nodes: [
+                                            {
+                                                __typename: 'MonitorEmail',
+                                                events: {
+                                                    __typename: 'MonitorActionEventConnection',
+                                                    nodes: [],
+                                                },
+                                            },
+                                            {
+                                                __typename: 'MonitorSlackWebhook',
+                                                events: {
+                                                    __typename: 'MonitorActionEventConnection',
+                                                    nodes: [
+                                                        {
+                                                            id: 'af',
+                                                            __typename: 'MonitorActionEvent',
+                                                            status: EventStatus.PENDING,
+                                                            message: null,
+                                                            timestamp: '2022-02-14T16:29:16Z',
+                                                        },
+                                                    ],
+                                                },
+                                            },
+                                        ],
+                                    },
+                                },
+                            ],
+                            totalCount: 1,
+                            pageInfo: { endCursor: '', hasNextPage: false },
+                        },
+                    },
+                },
             ],
             pageInfo: {
                 endCursor: '123',


### PR DESCRIPTION
Pending jobs in the code monitoring logs will now state they are "Scheduled" instead of "Ran" next to the timestamp

![image](https://user-images.githubusercontent.com/206864/169415194-35221992-e4a9-4518-bc55-34b2d15584b8.png)

## Test plan

Added storybook tests for the pending state

## App preview:

- [Web](https://sg-web-jp-codemonitoringpending.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-wchtcxivey.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
