### PR TITLE
extsvc/github: remove log15 usage

### DIFF
--- a/enterprise/internal/authz/github/app.go
+++ b/enterprise/internal/authz/github/app.go
@@ -38,7 +38,9 @@ func newAppProvider(
 	}
 
 	apiURL, _ := github.APIRoot(baseURL)
-	appClient := github.NewV3Client(log.Scoped("app.github.v3", "github v3 client for github app"),
+	appClient := github.NewV3Client(
+		log.Scoped("app.github.v3", "github v3 client for github app").
+			With(log.String("appID", appID)),
 		urn, apiURL, auther, cli)
 	return &Provider{
 		urn:      urn,
@@ -49,9 +51,11 @@ func newAppProvider(
 				return nil, errors.Wrap(err, "get or renew GitHub App installation access token")
 			}
 
+			logger := log.Scoped("installation.github.v3", "github v3 client for installation").
+				With(log.String("appID", appID), log.Int64("installationID", installationID))
+
 			return &ClientAdapter{
-				V3Client: github.NewV3Client(log.Scoped("installation.github.v3", "github v3 client for installation"),
-					urn, apiURL, &auth.OAuthBearerToken{Token: token}, cli),
+				V3Client: github.NewV3Client(logger, urn, apiURL, &auth.OAuthBearerToken{Token: token}, cli),
 			}, nil
 		},
 	}, nil

--- a/internal/extsvc/github/common.go
+++ b/internal/extsvc/github/common.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
 	"net/http"
 	"net/url"
 	"path"
@@ -16,7 +15,6 @@ import (
 
 	"github.com/Masterminds/semver"
 	"github.com/google/go-github/github"
-	"github.com/inconshreveable/log15"
 	"github.com/segmentio/fasthash/fnv1"
 	"golang.org/x/oauth2"
 
@@ -30,6 +28,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/ratelimit"
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"github.com/sourcegraph/sourcegraph/lib/log"
 )
 
 // PageInfo contains the paging information based on the Redux conventions.
@@ -1469,17 +1468,21 @@ func ExternalRepoSpec(repo *Repository, baseURL *url.URL) api.ExternalRepoSpec {
 
 var (
 	gitHubDisable, _ = strconv.ParseBool(env.Get("SRC_GITHUB_DISABLE", "false", "disables communication with GitHub instances. Used to test GitHub service degradation"))
-	githubProxyURL   = func() *url.URL {
-		url, err := url.Parse(env.Get("GITHUB_BASE_URL", "http://github-proxy", "base URL for GitHub.com API (used for github-proxy)"))
-		if err != nil {
-			log.Fatal("Error parsing GITHUB_BASE_URL:", err)
-		}
-		return url
-	}()
 
 	// The metric generated here will be named as "src_github_requests_total".
 	requestCounter = metrics.NewRequestMeter("github", "Total number of requests sent to the GitHub API.")
+
+	// Get raw proxy URL at service startup, but only get parsed URL at runtime with getGithubProxyURL
+	githubProxyRawURL = env.Get("GITHUB_BASE_URL", "http://github-proxy", "base URL for GitHub.com API (used for github-proxy)")
 )
+
+func getGithubProxyURL() *url.URL {
+	url, err := url.Parse(githubProxyRawURL)
+	if err != nil {
+		log.Scoped("extsvc.github", "github package").Fatal("Error parsing GITHUB_BASE_URL", log.Error(err))
+	}
+	return url
+}
 
 // APIRoot returns the root URL of the API using the base URL of the GitHub instance.
 func APIRoot(baseURL *url.URL) (apiURL *url.URL, githubDotCom bool) {
@@ -1506,7 +1509,7 @@ func newHttpResponseState(statusCode int, headers http.Header) *httpResponseStat
 	}
 }
 
-func doRequest(ctx context.Context, apiURL *url.URL, auth auth.Authenticator, rateLimitMonitor *ratelimit.Monitor, httpClient httpcli.Doer, req *http.Request, result any) (responseState *httpResponseState, err error) {
+func doRequest(ctx context.Context, logger log.Logger, apiURL *url.URL, auth auth.Authenticator, rateLimitMonitor *ratelimit.Monitor, httpClient httpcli.Doer, req *http.Request, result any) (responseState *httpResponseState, err error) {
 	req.URL.Path = path.Join(apiURL.Path, req.URL.Path)
 	req.URL = apiURL.ResolveReference(req.URL)
 	req.Header.Set("Content-Type", "application/json; charset=utf-8")
@@ -1536,7 +1539,9 @@ func doRequest(ctx context.Context, apiURL *url.URL, auth auth.Authenticator, ra
 	}
 	defer resp.Body.Close()
 
-	log15.Debug("doRequest", "status", resp.Status, "x-ratelimit-remaining", resp.Header.Get("x-ratelimit-remaining"))
+	logger.Debug("doRequest",
+		log.String("status", resp.Status),
+		log.String("x-ratelimit-remaining", resp.Header.Get("x-ratelimit-remaining")))
 
 	// For 401 responses we receive a remaining limit of 0. This will cause the next
 	// call to block for up to an hour because it believes we have run out of tokens.
@@ -1573,14 +1578,14 @@ func canonicalizedURL(apiURL *url.URL) *url.URL {
 	if urlIsGitHubDotCom(apiURL) {
 		// For GitHub.com API requests, use github-proxy (which adds our OAuth2 client ID/secret to get a much higher
 		// rate limit).
-		return githubProxyURL
+		return getGithubProxyURL()
 	}
 	return apiURL
 }
 
 func urlIsGitHubDotCom(apiURL *url.URL) bool {
 	hostname := strings.ToLower(apiURL.Hostname())
-	return hostname == "api.github.com" || hostname == "github.com" || hostname == "www.github.com" || apiURL.String() == githubProxyURL.String()
+	return hostname == "api.github.com" || hostname == "github.com" || hostname == "www.github.com" || apiURL.String() == getGithubProxyURL().String()
 }
 
 var ErrRepoNotFound = &RepoNotFoundError{}

--- a/internal/extsvc/github/v3_test.go
+++ b/internal/extsvc/github/v3_test.go
@@ -716,6 +716,7 @@ func TestV3Client_WithAuthenticator(t *testing.T) {
 	}
 
 	old := &V3Client{
+		log:    logtest.Scoped(t),
 		apiURL: uri,
 		auth:   &auth.OAuthBearerToken{Token: "old_token"},
 	}


### PR DESCRIPTION
This is a follow-up to https://github.com/sourcegraph/sourcegraph/pull/35516 to completely remove log15 usage from extsvc/github - I realized I missed quite a few spots as I was re-reviewing the PR for GitStart.

I decided not to parameterize the GitHub V4 loggers yet to minimize the change for now.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

```
sg start
```

and tests pass