### PR TITLE
dev/sg: improve diff evaluation

### DIFF
--- a/dev/sg/internal/repo/repo.go
+++ b/dev/sg/internal/repo/repo.go
@@ -11,8 +11,12 @@ import (
 
 // State represents the state of the repository.
 type State struct {
-	// Branch is the currently checked out branch.
-	Branch string
+	// Dirty indicates if the current working directory has uncommitted changes.
+	Dirty bool
+	// Ref is the currently checked out ref.
+	Ref string
+	// MergeBase is the common ancestor between Ref and main.
+	MergeBase string
 }
 
 type Diff map[string][]DiffHunk
@@ -38,22 +42,16 @@ type DiffHunk struct {
 	AddedLines []string
 }
 
-func (s *State) GetDiff(paths string) (Diff, error) {
-	if paths == "" {
-		paths = "**/*"
+// GetDiff retrieves a parsed diff from the workspace, filtered by the given path glob.
+func (s *State) GetDiff(glob string) (Diff, error) {
+	// Compare from common ancestor by default
+	target := s.MergeBase
+	if !s.Dirty && s.Ref == s.MergeBase {
+		// Compare previous commit, if we are already at merge base and in a clean workdir
+		target = "@^"
 	}
 
-	mergeBase, err := run.TrimResult(run.GitCmd("merge-base", "main", "HEAD"))
-	if err != nil {
-		return nil, err
-	}
-
-	target := mergeBase // compare from common ancestor
-	if s.Branch == "main" {
-		target = "@^" // previous commit
-	}
-
-	diffOutput, err := run.TrimResult(run.GitCmd("diff", target, "--", paths))
+	diffOutput, err := run.TrimResult(run.GitCmd("diff", target, "--", glob))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Damn I'm not sure why this is so hard to get right, but this makes a minor improvement to running `sg lint` on `main` - instead of checking for the branch, we now check if merge-base is the same as your checked out ref, _and_ check if your workspace is dirty.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

`spew.Dump` some diffs. Seems right