### PR TITLE
dev/sg: initialize lib/log with SRC_DEVELOPMENT and SRC_LOG_FORMAT

### DIFF
--- a/dev/sg/main.go
+++ b/dev/sg/main.go
@@ -117,6 +117,8 @@ var sg = &cli.App{
 
 		// Configure output
 		std.Out = std.NewOutput(cmd.App.Writer, verbose)
+		os.Setenv("SRC_DEVELOPMENT", "true")
+		os.Setenv("SRC_LOG_FORMAT", "console")
 		syncLogs := log.Init(log.Resource{Name: "sg"})
 		interrupt.Register(func() { syncLogs() })
 


### PR DESCRIPTION
Makes `sg migration` output nicer, see below

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
❌  Before:

<img width="1348" alt="image" src="https://user-images.githubusercontent.com/23356519/169424705-c8d073ba-9c32-4bfd-bb92-c29e0d5ac5e6.png">

✅  After:

<img width="1195" alt="image" src="https://user-images.githubusercontent.com/23356519/169424681-45518ebc-2813-4c34-ac04-e190db653439.png">
