### PR TITLE
Revert "compute: use authenticated endpoint via POST method"

### DIFF
--- a/client/web/src/notebooks/blocks/compute/NotebookComputeBlock.tsx
+++ b/client/web/src/notebooks/blocks/compute/NotebookComputeBlock.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 
-import { fetchEventSource } from '@microsoft/fetch-event-source'
 import ElmComponent from 'react-elm-components'
 
 import { PlatformContext } from '@sourcegraph/shared/src/platform/context'
@@ -43,52 +42,48 @@ const updateBlockInput = (id: string, onBlockInputChange: (id: string, blockInpu
     onBlockInputChange(id, blockInput)
 }
 
-const setupPorts = (sourcegraphURL: string, updateBlockInputWithID: (blockInput: BlockInput) => void) => (
-    ports: Ports
-): void => {
-    const openRequests: AbortController[] = []
+const setupPorts = (updateBlockInputWithID: (blockInput: BlockInput) => void) => (ports: Ports): void => {
+    const sources: { [key: string]: EventSource } = {}
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     function sendEventToElm(event: any): void {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
-        const elmEvent = { data: event.data, eventType: event.event || null, id: event.id || null }
+        const elmEvent = { data: event.data, eventType: event.type || null, id: event.id || null }
         ports.receiveEvent.send(elmEvent)
     }
 
+    function newEventSource(address: string): EventSource {
+        sources[address] = new EventSource(address)
+        return sources[address]
+    }
+
+    function deleteAllEventSources(): void {
+        for (const [key] of Object.entries(sources)) {
+            deleteEventSource(key)
+        }
+    }
+
+    function deleteEventSource(address: string): void {
+        sources[address].close()
+        delete sources[address]
+    }
+
     ports.openStream.subscribe((args: string[]) => {
+        deleteAllEventSources() // Close any open streams if we receive a request to open a new stream before seeing 'done'.
         console.log(`stream: ${args[0]}`)
         const address = args[0]
 
-        // Close any open streams if we receive a request to open a new stream before seeing 'done'.
-        for (const request of openRequests) {
-            request.abort()
-        }
-
-        const ctrl = new AbortController()
-        openRequests.push(ctrl)
-        async function fetch(): Promise<void> {
-            await fetchEventSource(address, {
-                method: 'POST',
-                headers: {
-                    origin: sourcegraphURL,
-                },
-                signal: ctrl.signal,
-                onerror(error) {
-                    console.log(`Compute EventSource error: ${JSON.stringify(error)}`)
-                },
-                onclose() {
-                    // Note: 'done:true' is sent in progress too. But we want a 'done' for the entire stream in case we don't see it.
-                    sendEventToElm({ type: 'done', data: '' })
-                    openRequests.splice(0)
-                },
-                onmessage(event) {
-                    sendEventToElm(event)
-                },
-            })
-        }
-
-        fetch().catch(error => {
-            console.log(`Compute fetch error: ${JSON.stringify(error)}`)
+        const eventSource = newEventSource(address)
+        eventSource.addEventListener('error', () => {
+            console.log('EventSource failed')
+        })
+        eventSource.addEventListener('results', sendEventToElm)
+        eventSource.addEventListener('alert', sendEventToElm)
+        eventSource.addEventListener('error', sendEventToElm)
+        eventSource.addEventListener('done', () => {
+            deleteEventSource(address)
+            // Note: 'done:true' is sent in progress too. But we want a 'done' for the entire stream in case we don't see it.
+            sendEventToElm({ type: 'done', data: '' })
         })
     })
 
@@ -124,7 +119,7 @@ export const NotebookComputeBlock: React.FunctionComponent<React.PropsWithChildr
                 <div className="elm">
                     <ElmComponent
                         src={Elm.Main}
-                        ports={setupPorts(platformContext.sourcegraphURL, updateBlockInput(id, onBlockInputChange))}
+                        ports={setupPorts(updateBlockInput(id, onBlockInputChange))}
                         flags={{
                             sourcegraphURL: platformContext.sourcegraphURL,
                             isLightTheme,

--- a/cmd/frontend/internal/httpapi/router/router.go
+++ b/cmd/frontend/internal/httpapi/router/router.go
@@ -73,7 +73,6 @@ func New(base *mux.Router) *mux.Router {
 	base.Path("/lsif/upload").Methods("POST").Name(LSIFUpload)
 	base.Path("/search/stream").Methods("GET").Name(SearchStream)
 	base.Path("/compute/stream").Methods("GET").Name(ComputeStream)
-	base.Path("/compute/stream").Methods("POST").Name(ComputeStream)
 	base.Path("/src-cli/version").Methods("GET").Name(SrcCliVersion)
 	base.Path("/src-cli/{rest:.*}").Methods("GET").Name(SrcCliDownload)
 

--- a/package.json
+++ b/package.json
@@ -360,7 +360,6 @@
     "@codemirror/state": "^0.20.0",
     "@codemirror/view": "^0.20.4",
     "@lezer/highlight": "^0.16.0",
-    "@microsoft/fetch-event-source": "^2.0.1",
     "@reach/accordion": "^0.16.1",
     "@reach/combobox": "^0.16.5",
     "@reach/dialog": "^0.16.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2962,11 +2962,6 @@
   dependencies:
     exenv-es6 "^1.0.0"
 
-"@microsoft/fetch-event-source@^2.0.1":
-  version "2.0.1"
-  resolved "https://registry.npmjs.org/@microsoft/fetch-event-source/-/fetch-event-source-2.0.1.tgz#9ceecc94b49fbaa15666e38ae8587f64acce007d"
-  integrity sha512-W6CLUJ2eBMw3Rec70qrsEW0jOm/3twwJv21mrmj2yORiaVmVYGS4sSS5yUwvQc1ZlDLYGPnClVWmUUMagKNsfA==
-
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"
   resolved "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz#524af240d1a360527b730475ecfa1344aa540dde"


### PR DESCRIPTION
Reverts sourcegraph/sourcegraph#35758. Currently breaking main.

---

Details:

Adding `POST` handler somehow breaking integration test (?). Reverting so I can investigate, probably something dumb.

```
--- FAIL: TestCompute/stream (0.00s)
--
  | --- FAIL: TestCompute/stream/compute_endpoint_returns_results (0.00s)
  | compute_test.go:18: unexpected error: malformed event, expected event: 404 page not found
  | (1) attached stack trace
  | -- stack trace:
  | \| github.com/sourcegraph/sourcegraph/internal/search/streaming/http.(*Decoder).Scan
  | \| 	/root/buildkite/build/sourcegraph/internal/search/streaming/http/decoder.go:67
  | \| github.com/sourcegraph/sourcegraph/internal/gqltestutil.ComputeMatchContextStreamDecoder.ReadAll
  | \| 	/root/buildkite/build/sourcegraph/internal/gqltestutil/compute.go:66
  | \| github.com/sourcegraph/sourcegraph/internal/gqltestutil.(*ComputeStreamClient).Compute
  | \| 	/root/buildkite/build/sourcegraph/internal/gqltestutil/compute.go:41
  | \| github.com/sourcegraph/sourcegraph/dev/gqltest.testComputeClient.func1
  | \| 	/root/buildkite/build/sourcegraph/dev/gqltest/compute_test.go:16
  | \| testing.tRunner
  | \| 	/root/.asdf/installs/golang/1.18.1/go/src/testing/testing.go:1439
  | \| runtime.goexit
  | \| 	/root/.asdf/installs/golang/1.18.1/go/src/runtime/asm_amd64.s:1571
  | Wraps: (2) malformed event, expected event: 404 page not found
  | Error types: (1) *withstack.withStack (2) *errutil.leafError
  | compute_test.go:21: Expected results, got none
```

## Test plan
It's a revert
