### PR TITLE
Revert "dependencies: Do not hard fail when a commit cannot be resolved"

### DIFF
--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -1376,7 +1376,6 @@ func testDependenciesSearch(client, streamClient searchClient) func(*testing.T) 
 				Repos: []string{
 					"sgtest/pipenv-hw",
 					"sgtest/poetry-hw",
-					"sgtest/empty",
 				},
 				RepositoryPathPattern: "github.com/{nameWithOwner}",
 			}),
@@ -1450,7 +1449,6 @@ func testDependenciesSearch(client, streamClient searchClient) func(*testing.T) 
 			"python/rich",
 			"github.com/sgtest/pipenv-hw",
 			"github.com/sgtest/poetry-hw",
-			"github.com/sgtest/empty",
 		)
 		if err != nil {
 			t.Fatal(err)
@@ -1497,7 +1495,6 @@ func testDependenciesSearch(client, streamClient searchClient) func(*testing.T) 
 					"/python/requests@v2.27.1",
 					"/python/urllib3@v1.26.9",
 				}},
-				{"empty", `r:deps(^github\.com/sgtest/empty$)`, nil},
 			} {
 				listDepsTc := listDepsTc
 

--- a/internal/codeintel/dependencies/service.go
+++ b/internal/codeintel/dependencies/service.go
@@ -60,9 +60,8 @@ func (s *Service) Dependencies(ctx context.Context, repoRevs map[api.RepoName]ty
 		}})
 	}()
 
-	// Resolve the revhashes for the source repo-commit pairs.
-	// TODO - Process unresolved commits.
-	repoCommits, _, err := s.resolveRepoCommits(ctx, repoRevs)
+	// Resolve the revhashes for the source repo-commit pairs
+	repoCommits, err := s.resolveRepoCommits(ctx, repoRevs)
 	if err != nil {
 		return nil, err
 	}
@@ -158,8 +157,8 @@ type repoCommitResolvedCommit struct {
 
 // resolveRepoCommits flattens the given map into a slice of api.RepoCommits with an extra
 // field indicating the canonical 40-character commit hash of the given revlike, which is
-// often symbolic. The commits that failed to resolve are returned in a separate slice.
-func (s *Service) resolveRepoCommits(ctx context.Context, repoRevs map[api.RepoName]types.RevSpecSet) ([]repoCommitResolvedCommit, []api.RepoCommit, error) {
+// often symbolic.
+func (s *Service) resolveRepoCommits(ctx context.Context, repoRevs map[api.RepoName]types.RevSpecSet) ([]repoCommitResolvedCommit, error) {
 	n := 0
 	for _, revs := range repoRevs {
 		n += len(revs)
@@ -175,30 +174,25 @@ func (s *Service) resolveRepoCommits(ctx context.Context, repoRevs map[api.RepoN
 		}
 	}
 
-	commits, err := s.gitSvc.GetCommits(ctx, repoCommits, true)
+	commits, err := s.gitSvc.GetCommits(ctx, repoCommits, false)
 	if err != nil {
-		return nil, nil, errors.Wrap(err, "git.GetCommits")
+		return nil, errors.Wrap(err, "git.GetCommits")
 	}
 	if len(commits) != len(repoCommits) {
 		// Add assertion here so that the blast radius of new or newly discovered errors
 		// southbound from the internal/vcs/git package does not leak into code intelligence.
-		return nil, nil, errors.Newf("expected slice returned from git.GetCommits to have len %d, but has len %d", len(repoCommits), len(commits))
+		return nil, errors.Newf("expected slice returned from git.GetCommits to have len %d, but has len %d", len(repoCommits), len(commits))
 	}
 
 	resolvedCommits := make([]repoCommitResolvedCommit, 0, len(repoCommits))
-	var unresolvedCommits []api.RepoCommit
 	for i, repoCommit := range repoCommits {
-		if commits[i] == nil {
-			unresolvedCommits = append(unresolvedCommits, repoCommit)
-			continue
-		}
 		resolvedCommits = append(resolvedCommits, repoCommitResolvedCommit{
 			RepoCommit:     repoCommit,
 			ResolvedCommit: string(commits[i].ID),
 		})
 	}
 
-	return resolvedCommits, unresolvedCommits, nil
+	return resolvedCommits, nil
 }
 
 // lockfileDependencies returns a flattened list of package dependencies for every repo-commit pair.
@@ -369,9 +363,8 @@ func (s *Service) sync(ctx context.Context, repos []api.RepoName) error {
 // Dependents resolves the (transitive) inverse dependencies for a set of repository and revisions.
 // Both the input repoRevs and the output dependencyRevs are a map from repository names to revspecs.
 func (s *Service) Dependents(ctx context.Context, repoRevs map[api.RepoName]types.RevSpecSet) (dependentsRevs map[api.RepoName]types.RevSpecSet, err error) {
-	// Resolve the revhashes for the source repo-commit pairs.
-	// TODO - Process unresolved commits.
-	repoCommits, _, err := s.resolveRepoCommits(ctx, repoRevs)
+	// Resolve the revhashes for the source repo-commit pairs
+	repoCommits, err := s.resolveRepoCommits(ctx, repoRevs)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/vcs/git/commits.go
+++ b/internal/vcs/git/commits.go
@@ -540,7 +540,7 @@ func CommitsExist(ctx context.Context, db database.DB, repoCommits []api.RepoCom
 
 var GetCommits = getCommits
 
-// getCommits returns a git commit object describing each of the given repository and commit pairs. This
+// getCommits returns a git commit object describing each of the give repository and commit pairs. This
 // function returns a slice of the same size as the input slice. Values in the output slice may be nil if
 // their associated repository or commit are unresolvable.
 //
@@ -580,7 +580,6 @@ func getCommits(ctx context.Context, db database.DB, repoCommits []api.RepoCommi
 				// Treat as not-found
 				return nil
 			}
-
 			return errors.Wrap(err, "failed to perform git log")
 		}
 


### PR DESCRIPTION
Reverts sourcegraph/sourcegraph#35679

I just had this flake ~3x~ **4x** on a single build, and I've seen this across several PRs today:

<img width="1167" alt="image" src="https://user-images.githubusercontent.com/23356519/169444276-5c6aae3d-aeb4-413e-aa85-85bc459f6e30.png">

- https://buildkite.com/sourcegraph/sourcegraph/builds/148610#38bc5b67-295c-4198-b346-8c44183e59fb
- https://buildkite.com/sourcegraph/sourcegraph/builds/148629#57c98ffd-c19b-4fe9-8656-515ad92b9bef
- branch cut failed as well on this flake: https://buildkite.com/sourcegraph/sourcegraph/builds/148645#726f3d74-9e19-4d64-bdfd-4f0a76308169

Test plan: this build passes 