### PR TITLE
web: snapshot before text input to avoid flakes

### DIFF
--- a/client/web/src/integration/search-contexts.test.ts
+++ b/client/web/src/integration/search-contexts.test.ts
@@ -306,6 +306,9 @@ describe('Search contexts', () => {
         await driver.page.waitForSelector(searchQueryInputSelector)
         await driver.page.click(searchQueryInputSelector)
 
+        // Take Snapshot
+        await percySnapshotWithVariants(driver.page, 'Create dynamic query search context page')
+
         // Enter search query
         await driver.replaceText({
             selector: searchQueryInputSelector,
@@ -314,8 +317,6 @@ describe('Search contexts', () => {
             enterTextMethod: 'paste',
         })
 
-        // Take Snapshot
-        await percySnapshotWithVariants(driver.page, 'Create dynamic query search context page')
         await accessibilityAudit(driver.page)
         // Click create
         await driver.page.click('[data-testid="search-context-submit-button"]')


### PR DESCRIPTION
## Context

Fixing flake that's still there despite https://github.com/sourcegraph/sourcegraph/issues/33545.

## Test plan

The `Create dynamic query search context page` snapshot doesn't contain search query text.

## App preview:

- [Web](https://sg-web-vb-percy-flake.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-qcxbonqixz.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
