### PR TITLE
dependencies: Fix a flaky test.

### DIFF
--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -1376,6 +1376,7 @@ func testDependenciesSearch(client, streamClient searchClient) func(*testing.T) 
 				Repos: []string{
 					"sgtest/pipenv-hw",
 					"sgtest/poetry-hw",
+					"sgtest/empty",
 				},
 				RepositoryPathPattern: "github.com/{nameWithOwner}",
 			}),
@@ -1449,6 +1450,7 @@ func testDependenciesSearch(client, streamClient searchClient) func(*testing.T) 
 			"python/rich",
 			"github.com/sgtest/pipenv-hw",
 			"github.com/sgtest/poetry-hw",
+			"github.com/sgtest/empty",
 		)
 		if err != nil {
 			t.Fatal(err)
@@ -1495,6 +1497,7 @@ func testDependenciesSearch(client, streamClient searchClient) func(*testing.T) 
 					"/python/requests@v2.27.1",
 					"/python/urllib3@v1.26.9",
 				}},
+				{"empty", `r:deps(^github\.com/sgtest/empty$)`, nil},
 			} {
 				listDepsTc := listDepsTc
 

--- a/internal/codeintel/dependencies/service.go
+++ b/internal/codeintel/dependencies/service.go
@@ -60,8 +60,9 @@ func (s *Service) Dependencies(ctx context.Context, repoRevs map[api.RepoName]ty
 		}})
 	}()
 
-	// Resolve the revhashes for the source repo-commit pairs
-	repoCommits, err := s.resolveRepoCommits(ctx, repoRevs)
+	// Resolve the revhashes for the source repo-commit pairs.
+	// TODO - Process unresolved commits.
+	repoCommits, _, err := s.resolveRepoCommits(ctx, repoRevs)
 	if err != nil {
 		return nil, err
 	}
@@ -157,8 +158,8 @@ type repoCommitResolvedCommit struct {
 
 // resolveRepoCommits flattens the given map into a slice of api.RepoCommits with an extra
 // field indicating the canonical 40-character commit hash of the given revlike, which is
-// often symbolic.
-func (s *Service) resolveRepoCommits(ctx context.Context, repoRevs map[api.RepoName]types.RevSpecSet) ([]repoCommitResolvedCommit, error) {
+// often symbolic. The commits that failed to resolve are returned in a separate slice.
+func (s *Service) resolveRepoCommits(ctx context.Context, repoRevs map[api.RepoName]types.RevSpecSet) ([]repoCommitResolvedCommit, []api.RepoCommit, error) {
 	n := 0
 	for _, revs := range repoRevs {
 		n += len(revs)
@@ -174,25 +175,30 @@ func (s *Service) resolveRepoCommits(ctx context.Context, repoRevs map[api.RepoN
 		}
 	}
 
-	commits, err := s.gitSvc.GetCommits(ctx, repoCommits, false)
+	commits, err := s.gitSvc.GetCommits(ctx, repoCommits, true)
 	if err != nil {
-		return nil, errors.Wrap(err, "git.GetCommits")
+		return nil, nil, errors.Wrap(err, "git.GetCommits")
 	}
 	if len(commits) != len(repoCommits) {
 		// Add assertion here so that the blast radius of new or newly discovered errors
 		// southbound from the internal/vcs/git package does not leak into code intelligence.
-		return nil, errors.Newf("expected slice returned from git.GetCommits to have len %d, but has len %d", len(repoCommits), len(commits))
+		return nil, nil, errors.Newf("expected slice returned from git.GetCommits to have len %d, but has len %d", len(repoCommits), len(commits))
 	}
 
 	resolvedCommits := make([]repoCommitResolvedCommit, 0, len(repoCommits))
+	var unresolvedCommits []api.RepoCommit
 	for i, repoCommit := range repoCommits {
+		if commits[i] == nil {
+			unresolvedCommits = append(unresolvedCommits, repoCommit)
+			continue
+		}
 		resolvedCommits = append(resolvedCommits, repoCommitResolvedCommit{
 			RepoCommit:     repoCommit,
 			ResolvedCommit: string(commits[i].ID),
 		})
 	}
 
-	return resolvedCommits, nil
+	return resolvedCommits, unresolvedCommits, nil
 }
 
 // lockfileDependencies returns a flattened list of package dependencies for every repo-commit pair.
@@ -363,8 +369,9 @@ func (s *Service) sync(ctx context.Context, repos []api.RepoName) error {
 // Dependents resolves the (transitive) inverse dependencies for a set of repository and revisions.
 // Both the input repoRevs and the output dependencyRevs are a map from repository names to revspecs.
 func (s *Service) Dependents(ctx context.Context, repoRevs map[api.RepoName]types.RevSpecSet) (dependentsRevs map[api.RepoName]types.RevSpecSet, err error) {
-	// Resolve the revhashes for the source repo-commit pairs
-	repoCommits, err := s.resolveRepoCommits(ctx, repoRevs)
+	// Resolve the revhashes for the source repo-commit pairs.
+	// TODO - Process unresolved commits.
+	repoCommits, _, err := s.resolveRepoCommits(ctx, repoRevs)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/codeintel/dependencies/service_test.go
+++ b/internal/codeintel/dependencies/service_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/conf/reposource"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 func TestDependencies(t *testing.T) {
@@ -43,15 +44,21 @@ func TestDependencies(t *testing.T) {
 	}
 
 	mockStore.PreciseDependenciesFunc.SetDefaultHook(func(ctx context.Context, repoName, commit string) (map[api.RepoName]types.RevSpecSet, error) {
-		if repoName != "github.com/example/baz" {
-			return nil, nil
+		switch repoName {
+		case "github.com/example/baz":
+			return map[api.RepoName]types.RevSpecSet{
+				api.RepoName(fmt.Sprintf("%s-depA", repoName)): {"deadbeef1": struct{}{}},
+				api.RepoName(fmt.Sprintf("%s-depB", repoName)): {"deadbeef2": struct{}{}},
+				api.RepoName(fmt.Sprintf("%s-depC", repoName)): {"deadbeef3": struct{}{}},
+			}, nil
+		case "github.com/example/quux":
+			return map[api.RepoName]types.RevSpecSet{
+				api.RepoName(fmt.Sprintf("%s-depA", repoName)): {"deadbeef1": struct{}{}},
+				api.RepoName(fmt.Sprintf("%s-depB", repoName)): {"deadbeef2": struct{}{}},
+			}, nil
 		}
 
-		return map[api.RepoName]types.RevSpecSet{
-			api.RepoName(fmt.Sprintf("%s-depA", repoName)): {"deadbeef1": struct{}{}},
-			api.RepoName(fmt.Sprintf("%s-depB", repoName)): {"deadbeef2": struct{}{}},
-			api.RepoName(fmt.Sprintf("%s-depC", repoName)): {"deadbeef3": struct{}{}},
-		}, nil
+		return nil, nil
 	})
 
 	// UpsertDependencyRepos influences the value that syncer.Sync is called with (asserted below)
@@ -181,6 +188,47 @@ func TestDependencies(t *testing.T) {
 	if diff := cmp.Diff(expectedNames, syncedRepoNames); diff != "" {
 		t.Errorf("unexpected names (-want +got):\n%s", diff)
 	}
+
+	// Located in the end so as not to interfere with Upsert call counting.
+	t.Run("get-commits-error", func(t *testing.T) {
+		getCommitsErr := errors.New("get commits failed for at least one commit")
+
+		gitService.GetCommitsFunc.PushHook(func(ctx context.Context, repoCommits []api.RepoCommit, ignoreErrors bool) (commits []*gitdomain.Commit, _ error) {
+			for i, repoCommit := range repoCommits {
+				if i%2 == 0 {
+					// Even-numbered commits do not resolve in this test.
+					if ignoreErrors {
+						commits = append(commits, nil)
+						continue
+					}
+					return nil, getCommitsErr
+				}
+				commits = append(commits, &gitdomain.Commit{ID: repoCommit.CommitID})
+			}
+			return commits, nil
+		})
+
+		repoRevs := map[api.RepoName]types.RevSpecSet{
+			api.RepoName("github.com/example/foo"): {
+				api.RevSpec("deadbeef1"): struct{}{},
+			},
+			api.RepoName("github.com/example/quux"): {
+				api.RevSpec("deadbeef1"): struct{}{},
+			},
+		}
+
+		dependencies, err := service.Dependencies(ctx, repoRevs)
+		if err != nil {
+			t.Fatalf("unexpected error querying dependencies: %s", err)
+		}
+		expectedDepencies := map[api.RepoName]types.RevSpecSet{
+			"github.com/example/quux-depA": {"deadbeef1": struct{}{}},
+			"github.com/example/quux-depB": {"deadbeef2": struct{}{}},
+		}
+		if diff := cmp.Diff(expectedDepencies, dependencies); diff != "" {
+			t.Errorf("unexpected dependencies (-want +got):\n%s", diff)
+		}
+	})
 }
 
 func TestDependents(t *testing.T) {

--- a/internal/codeintel/dependencies/service_test.go
+++ b/internal/codeintel/dependencies/service_test.go
@@ -194,9 +194,8 @@ func TestDependencies(t *testing.T) {
 		getCommitsErr := errors.New("get commits failed for at least one commit")
 
 		gitService.GetCommitsFunc.PushHook(func(ctx context.Context, repoCommits []api.RepoCommit, ignoreErrors bool) (commits []*gitdomain.Commit, _ error) {
-			for i, repoCommit := range repoCommits {
-				if i%2 == 0 {
-					// Even-numbered commits do not resolve in this test.
+			for _, repoCommit := range repoCommits {
+				if repoCommit.Repo != "github.com/example/quux" {
 					if ignoreErrors {
 						commits = append(commits, nil)
 						continue

--- a/internal/vcs/git/commits.go
+++ b/internal/vcs/git/commits.go
@@ -540,7 +540,7 @@ func CommitsExist(ctx context.Context, db database.DB, repoCommits []api.RepoCom
 
 var GetCommits = getCommits
 
-// getCommits returns a git commit object describing each of the give repository and commit pairs. This
+// getCommits returns a git commit object describing each of the given repository and commit pairs. This
 // function returns a slice of the same size as the input slice. Values in the output slice may be nil if
 // their associated repository or commit are unresolvable.
 //
@@ -580,6 +580,7 @@ func getCommits(ctx context.Context, db database.DB, repoCommits []api.RepoCommi
 				// Treat as not-found
 				return nil
 			}
+
 			return errors.Wrap(err, "failed to perform git log")
 		}
 


### PR DESCRIPTION
This test used to rely on map iteration order, now it does not.

Original PR: https://github.com/sourcegraph/sourcegraph/pull/35679
Revert PR: https://github.com/sourcegraph/sourcegraph/pull/35768
This PR: Reverts the revert + fixes the test

Test plan: CI, at least two times.