### PR TITLE
JetBrains: Force recreation of JCEF browser on every modal show

### DIFF
--- a/client/jetbrains/src/main/java/com/sourcegraph/find/FindPopupPanel.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/find/FindPopupPanel.java
@@ -22,7 +22,7 @@ import java.awt.*;
 public class FindPopupPanel extends JBPanel<FindPopupPanel> implements Disposable {
     private SourcegraphJBCefBrowser browser;
     private final Project project;
-    private Splitter splitter;
+    private final Splitter splitter;
     private PreviewPanel previewPanel;
 
     public FindPopupPanel(@NotNull Project project) {
@@ -37,13 +37,13 @@ public class FindPopupPanel extends JBPanel<FindPopupPanel> implements Disposabl
         splitter = new OnePixelSplitter(true, 0.5f, 0.1f, 0.9f);
         add(splitter, BorderLayout.CENTER);
 
-        this.createPreviewPanel();
-        this.createBrowserPanel();
+        createPreviewPanel();
+        createBrowserPanel();
     }
 
     public void createBrowserPanel() {
         JBPanelWithEmptyText jcefPanel = new JBPanelWithEmptyText(new BorderLayout()).withEmptyText("Unfortunately, the browser is not available on your system. Try running the IDE with the default OpenJDK.");
-        this.browser = JBCefApp.isSupported() ? new SourcegraphJBCefBrowser(new JSToJavaBridgeRequestHandler(project, previewPanel)) : null;
+        browser = JBCefApp.isSupported() ? new SourcegraphJBCefBrowser(new JSToJavaBridgeRequestHandler(project, previewPanel)) : null;
         if (browser != null) {
             jcefPanel.add(browser.getComponent(), BorderLayout.CENTER);
         }
@@ -51,7 +51,7 @@ public class FindPopupPanel extends JBPanel<FindPopupPanel> implements Disposabl
     }
 
     private void createPreviewPanel() {
-        this.previewPanel = new PreviewPanel(this.project);
+        previewPanel = new PreviewPanel(project);
         splitter.setSecondComponent(previewPanel);
     }
 

--- a/client/jetbrains/src/main/java/com/sourcegraph/find/FindPopupPanel.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/find/FindPopupPanel.java
@@ -20,28 +20,38 @@ import java.awt.*;
  * Inspired by <a href="https://sourcegraph.com/github.com/JetBrains/intellij-community/-/blob/platform/lang-impl/src/com/intellij/find/impl/FindPopupPanel.java">FindPopupPanel.java</a>
  */
 public class FindPopupPanel extends JBPanel<FindPopupPanel> implements Disposable {
-    private final SourcegraphJBCefBrowser browser;
+    private SourcegraphJBCefBrowser browser;
+    private final Project project;
+    private Splitter splitter;
+    private PreviewPanel previewPanel;
 
     public FindPopupPanel(@NotNull Project project) {
         super(new BorderLayout());
+
+        this.project = project;
 
         setPreferredSize(JBUI.size(1200, 800));
         setBorder(PopupBorder.Factory.create(true, true));
         setFocusCycleRoot(true);
 
-        // Create splitter
-        Splitter splitter = new OnePixelSplitter(true, 0.5f, 0.1f, 0.9f);
+        splitter = new OnePixelSplitter(true, 0.5f, 0.1f, 0.9f);
         add(splitter, BorderLayout.CENTER);
 
-        PreviewPanel previewPanel = new PreviewPanel(project);
+        this.createPreviewPanel();
+        this.createBrowserPanel();
+    }
 
+    public void createBrowserPanel() {
         JBPanelWithEmptyText jcefPanel = new JBPanelWithEmptyText(new BorderLayout()).withEmptyText("Unfortunately, the browser is not available on your system. Try running the IDE with the default OpenJDK.");
-        browser = JBCefApp.isSupported() ? new SourcegraphJBCefBrowser(new JSToJavaBridgeRequestHandler(project, previewPanel)) : null;
+        this.browser = JBCefApp.isSupported() ? new SourcegraphJBCefBrowser(new JSToJavaBridgeRequestHandler(project, previewPanel)) : null;
         if (browser != null) {
             jcefPanel.add(browser.getComponent(), BorderLayout.CENTER);
         }
-
         splitter.setFirstComponent(jcefPanel);
+    }
+
+    private void createPreviewPanel() {
+        this.previewPanel = new PreviewPanel(this.project);
         splitter.setSecondComponent(previewPanel);
     }
 

--- a/client/jetbrains/src/main/java/com/sourcegraph/find/SourcegraphWindow.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/find/SourcegraphWindow.java
@@ -51,7 +51,7 @@ public class SourcegraphWindow implements Disposable {
             mainPanel.createBrowserPanel();
         }
 
-        this.isFirstRender = false;
+        isFirstRender = false;
     }
 
     @NotNull

--- a/client/jetbrains/src/main/java/com/sourcegraph/find/SourcegraphWindow.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/find/SourcegraphWindow.java
@@ -11,6 +11,7 @@ public class SourcegraphWindow implements Disposable {
     private final Project project;
     private final FindPopupPanel mainPanel;
     private JBPopup popup;
+    private boolean isFirstRender = true;
 
     public SourcegraphWindow(@NotNull Project project) {
         this.project = project;
@@ -27,11 +28,30 @@ public class SourcegraphWindow implements Disposable {
             popup.showCenteredInCurrentWindow(project);
         }
 
+        this.recreateBrowserIfNeeded();
+
         // If the popup is already shown, hitting alt + a gain should behave the same as the native find in files
         // feature and focus the search field.
         if (mainPanel.getBrowser() != null) {
             mainPanel.getBrowser().focus();
         }
+    }
+
+    /**
+     * This is a workaround for #34773: On Mac OS, the web view is empty after opening and closing the popover
+     * repeatedly.
+     *
+     * We work around the issue by forcing a recreation of the JCEF browser window whenever we open the popover. This
+     * increases the modal opening times drastically and adds noticeable lag.
+     */
+    private void recreateBrowserIfNeeded() {
+        boolean isMacOS = System.getProperty("os.name").equals("Mac OS X");
+
+        if (!isFirstRender && isMacOS) {
+            mainPanel.createBrowserPanel();
+        }
+
+        this.isFirstRender = false;
     }
 
     @NotNull


### PR DESCRIPTION
This is a workaround for #34773: On Mac OS, the web view is empty after opening and closing the popover repeatedly.

We work around the issue by forcing a recreation of the JCEF browser window whenever we open the popover. 

**Note:** This fix is only meant to be temporary since it increases the modal opening times drastically and adds noticeable lag.

## Test plan

https://user-images.githubusercontent.com/458591/169494988-ffca8a36-821f-4992-ba70-9feaad01a41d.mov


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-jetbrains-mac-jcef-issue.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-vxixtcebrj.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
