### PR TITLE
batches: fix missing typenames on mock data

### DIFF
--- a/client/web/src/enterprise/batches/batch-spec/batch-spec.mock.ts
+++ b/client/web/src/enterprise/batches/batch-spec/batch-spec.mock.ts
@@ -433,7 +433,9 @@ export const mockWorkspaces = (
         __typename: 'BatchSpec',
         id: 'spec1234',
         workspaceResolution: {
+            __typename: 'BatchSpecWorkspaceResolution',
             workspaces: {
+                __typename: 'BatchSpecWorkspaceConnection',
                 totalCount: count,
                 pageInfo: {
                     endCursor: 'cursor',


### PR DESCRIPTION
Apollo doesn't like data without `typename`s, which my mock data was guilty of.

## Test plan

Verified storybooks are working again.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-kr-missing-typename.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-uwrzznlzgu.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
