### PR TITLE
JetBrains: Hide popover instead of recreating the browser on Mac OS

### DIFF
--- a/client/jetbrains/src/main/java/com/sourcegraph/find/FindPopupPanel.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/find/FindPopupPanel.java
@@ -41,7 +41,7 @@ public class FindPopupPanel extends JBPanel<FindPopupPanel> implements Disposabl
         createBrowserPanel();
     }
 
-    public void createBrowserPanel() {
+    private void createBrowserPanel() {
         JBPanelWithEmptyText jcefPanel = new JBPanelWithEmptyText(new BorderLayout()).withEmptyText("Unfortunately, the browser is not available on your system. Try running the IDE with the default OpenJDK.");
         browser = JBCefApp.isSupported() ? new SourcegraphJBCefBrowser(new JSToJavaBridgeRequestHandler(project, previewPanel)) : null;
         if (browser != null) {

--- a/client/jetbrains/src/main/java/com/sourcegraph/find/SourcegraphWindow.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/find/SourcegraphWindow.java
@@ -18,7 +18,6 @@ public class SourcegraphWindow implements Disposable {
     private final Project project;
     private final FindPopupPanel mainPanel;
     private JBPopup popup;
-    private boolean isFirstRender = true;
 
     public SourcegraphWindow(@NotNull Project project) {
         this.project = project;

--- a/client/jetbrains/src/main/java/com/sourcegraph/find/SourcegraphWindow.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/find/SourcegraphWindow.java
@@ -2,10 +2,17 @@ package com.sourcegraph.find;
 
 import com.intellij.openapi.Disposable;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.ui.popup.ComponentPopupBuilder;
 import com.intellij.openapi.ui.popup.JBPopup;
 import com.intellij.openapi.ui.popup.JBPopupFactory;
 import com.intellij.openapi.util.Disposer;
+import org.cef.browser.CefBrowser;
+import org.cef.handler.CefKeyboardHandler;
+import org.cef.misc.BoolRef;
 import org.jetbrains.annotations.NotNull;
+
+import java.awt.event.KeyAdapter;
+import java.awt.event.KeyEvent;
 
 public class SourcegraphWindow implements Disposable {
     private final Project project;
@@ -28,7 +35,11 @@ public class SourcegraphWindow implements Disposable {
             popup.showCenteredInCurrentWindow(project);
         }
 
-        this.recreateBrowserIfNeeded();
+        if (shouldHideInsteadOfCancel()) {
+            popup.setUiVisible(true);
+            popup.showInFocusCenter();
+        }
+
 
         // If the popup is already shown, hitting alt + a gain should behave the same as the native find in files
         // feature and focus the search field.
@@ -41,22 +52,16 @@ public class SourcegraphWindow implements Disposable {
      * This is a workaround for #34773: On Mac OS, the web view is empty after opening and closing the popover
      * repeatedly.
      *
-     * We work around the issue by forcing a recreation of the JCEF browser window whenever we open the popover. This
-     * increases the modal opening times drastically and adds noticeable lag.
+     * We work around the issue by forcing hiding the Popover instead of clearing it on Mac OS. This slightly increases
+     * resources consumption but allows us to reuse the JCEF window on this platform.
      */
-    private void recreateBrowserIfNeeded() {
-        boolean isMacOS = System.getProperty("os.name").equals("Mac OS X");
-
-        if (!isFirstRender && isMacOS) {
-            mainPanel.createBrowserPanel();
-        }
-
-        isFirstRender = false;
+    private boolean shouldHideInsteadOfCancel() {
+        return System.getProperty("os.name").equals("Mac OS X");
     }
 
     @NotNull
     private JBPopup createPopup() {
-        return JBPopupFactory.getInstance().createComponentPopupBuilder(mainPanel, mainPanel)
+        ComponentPopupBuilder builder = JBPopupFactory.getInstance().createComponentPopupBuilder(mainPanel, mainPanel)
             .setTitle("Find on Sourcegraph")
             .setCancelOnClickOutside(true)
             .setResizable(true)
@@ -67,8 +72,41 @@ public class SourcegraphWindow implements Disposable {
             .setBelongsToGlobalPopupStack(true)
             .setCancelOnOtherWindowOpen(true)
             .setCancelKeyEnabled(true)
-            .setNormalWindowLevel(true)
-            .createPopup();
+            .setNormalWindowLevel(true);
+
+        if (shouldHideInsteadOfCancel()) {
+            builder = builder.setCancelCallback(() -> {
+                popup.setUiVisible(false);
+                // We return false to prevent the default cancellation behavior.
+                return false;
+            });
+
+            // For some reason, adding a cancelCallback will prevent the cancel event to fire when using the escape
+            // key. To work around this, we add a manual listener to both the popup panel and the browser panel for this
+            // scenario.
+            mainPanel.addKeyListener(new KeyAdapter() {
+                public void keyPressed(KeyEvent event) {
+                    if (event.getKeyCode() == KeyEvent.VK_ESCAPE) {
+                        popup.setUiVisible(false);
+                    }
+                }
+            });
+            mainPanel.getBrowser().getJBCefClient().addKeyboardHandler(new CefKeyboardHandler() {
+                @Override
+                public boolean onPreKeyEvent(CefBrowser browser, CefKeyEvent event, BoolRef is_keyboard_shortcut) {
+                    return false;
+                }
+                @Override
+                public boolean onKeyEvent(CefBrowser browser, CefKeyEvent event) {
+                    if (event.windows_key_code == KeyEvent.VK_ESCAPE) {
+                        popup.setUiVisible(false);
+                    }
+                    return false;
+                }
+            }, mainPanel.getBrowser().getCefBrowser());
+        }
+
+        return builder.createPopup();
     }
 
     @Override


### PR DESCRIPTION
Closes #34694

This is another attempt to work around #34694. This time, we do not sacrifice performance.

Instead of recreating the JCEF browser whenever the popup is shown, we instead use a feature on the popup to _hide_ it. This means that the popup _will not dispose_ and we can easily show it again later.

Instead of the previous workaround in #35779, this increases the resource usage slightly as we keep the popup in memory. However since we already keep the JCEF window in memory anyway, I do not think this is a large overhead.

Note: Adding the manual cancellation callback prevented the events to fire properly when the escape key is pressed. To work around this, I've added manual event listeners for the escape key in this scenario. 

I also verified that this works with multiple projects open at once (as you can see in the test plan).

## Test plan

https://user-images.githubusercontent.com/458591/169521284-80e8df59-7087-451a-9605-d79343bb97ef.mov

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-jetbrains-mac-jcef-issue.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-hoaqzmffut.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
