### PR TITLE
dependencies: remove streamDependencies

### DIFF
--- a/internal/codeintel/dependencies/internal/lockfiles/observability.go
+++ b/internal/codeintel/dependencies/internal/lockfiles/observability.go
@@ -8,8 +8,7 @@ import (
 )
 
 type operations struct {
-	listDependencies   *observation.Operation
-	streamDependencies *observation.Operation
+	listDependencies *observation.Operation
 }
 
 func newOperations(observationContext *observation.Context) *operations {
@@ -29,7 +28,6 @@ func newOperations(observationContext *observation.Context) *operations {
 	}
 
 	return &operations{
-		listDependencies:   op("ListDependencies"),
-		streamDependencies: op("StreamDependencies"),
+		listDependencies: op("ListDependencies"),
 	}
 }


### PR DESCRIPTION
This is a pure refactor.

There was only one call site for streamDependencies and that call site
just collected the stream in a slice.

Any objections to removing it?



## Test plan
Existing tests

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
