### PR TITLE
Show “Loading” overlay while the browsers loads

### DIFF
--- a/client/jetbrains/src/main/java/com/sourcegraph/browser/JSToJavaBridgeRequestHandler.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/browser/JSToJavaBridgeRequestHandler.java
@@ -6,6 +6,7 @@ import com.intellij.openapi.project.Project;
 import com.intellij.ui.jcef.JBCefJSQuery;
 import com.sourcegraph.config.ConfigUtil;
 import com.sourcegraph.config.ThemeUtil;
+import com.sourcegraph.find.BrowserAndLoadingPanel;
 import com.sourcegraph.find.PreviewContent;
 import com.sourcegraph.find.PreviewPanel;
 import com.sourcegraph.find.Search;
@@ -16,10 +17,12 @@ import javax.annotation.Nullable;
 public class JSToJavaBridgeRequestHandler {
     private final Project project;
     private final PreviewPanel previewPanel;
+    private final BrowserAndLoadingPanel topPanel;
 
-    public JSToJavaBridgeRequestHandler(@NotNull Project project, @NotNull PreviewPanel previewPanel) {
+    public JSToJavaBridgeRequestHandler(@NotNull Project project, @NotNull PreviewPanel previewPanel, @NotNull BrowserAndLoadingPanel topPanel) {
         this.project = project;
         this.previewPanel = previewPanel;
+        this.topPanel = topPanel;
     }
 
     public JBCefJSQuery.Response handle(@NotNull JsonObject request) {
@@ -96,6 +99,12 @@ public class JSToJavaBridgeRequestHandler {
                     return createSuccessResponse(null);
                 } catch (Exception e) {
                     return createErrorResponse(9, e.getClass().getName() + ": " + e.getMessage());
+                }
+            case "indicateFinishedLoading":
+                try {
+                    topPanel.setBrowserVisible(true);
+                } catch (Exception e) {
+                    return createErrorResponse(10, e.getClass().getName() + ": " + e.getMessage());
                 }
             default:
                 return createErrorResponse(2, "Unknown action: " + action);

--- a/client/jetbrains/src/main/java/com/sourcegraph/find/BrowserAndLoadingPanel.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/find/BrowserAndLoadingPanel.java
@@ -1,0 +1,42 @@
+package com.sourcegraph.find;
+
+import com.intellij.ui.components.JBPanelWithEmptyText;
+import org.jetbrains.annotations.NotNull;
+
+import javax.swing.*;
+import java.awt.*;
+
+/**
+ * Inspired by <a href="https://sourcegraph.com/github.com/JetBrains/intellij-community/-/blob/platform/lang-impl/src/com/intellij/find/impl/FindPopupPanel.java">FindPopupPanel.java</a>
+ */
+public class BrowserAndLoadingPanel extends JLayeredPane {
+    private boolean isBrowserVisible = false;
+
+    public BrowserAndLoadingPanel(@NotNull JBPanelWithEmptyText jcefPanel, @NotNull JBPanelWithEmptyText overlayPanel) {
+        add(overlayPanel, 0);
+        add(jcefPanel, 1);
+    }
+
+    @Override
+    public void doLayout() {
+        Component overlay = getComponent(0);
+        Component browser = getComponent(1);
+        if (isBrowserVisible) {
+            browser.setBounds(0, 0, getWidth(), getHeight());
+        } else {
+            browser.setBounds(0, 0, 1, 1);
+        }
+        overlay.setBounds(0, 0, getWidth(), getHeight());
+    }
+
+    @Override
+    public Dimension getPreferredSize() {
+        return getBounds().getSize();
+    }
+
+    public void setBrowserVisible(boolean browserVisible) {
+        isBrowserVisible = browserVisible;
+        revalidate();
+        repaint();
+    }
+}

--- a/client/jetbrains/src/main/java/com/sourcegraph/find/FindPopupPanel.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/find/FindPopupPanel.java
@@ -42,12 +42,19 @@ public class FindPopupPanel extends JBPanel<FindPopupPanel> implements Disposabl
     }
 
     private void createBrowserPanel() {
+        JBPanelWithEmptyText overlayPanel = new JBPanelWithEmptyText();
+        //noinspection DialogTitleCapitalization
+        overlayPanel.getEmptyText().setText("Loading Sourcegraph...");
+
         JBPanelWithEmptyText jcefPanel = new JBPanelWithEmptyText(new BorderLayout()).withEmptyText("Unfortunately, the browser is not available on your system. Try running the IDE with the default OpenJDK.");
-        browser = JBCefApp.isSupported() ? new SourcegraphJBCefBrowser(new JSToJavaBridgeRequestHandler(project, previewPanel)) : null;
+
+        BrowserAndLoadingPanel topPanel = new BrowserAndLoadingPanel(jcefPanel, overlayPanel);
+
+        browser = JBCefApp.isSupported() ? new SourcegraphJBCefBrowser(new JSToJavaBridgeRequestHandler(project, previewPanel, topPanel)) : null;
         if (browser != null) {
-            jcefPanel.add(browser.getComponent(), BorderLayout.CENTER);
+            jcefPanel.add(browser.getComponent());
         }
-        splitter.setFirstComponent(jcefPanel);
+        splitter.setFirstComponent(topPanel);
     }
 
     private void createPreviewPanel() {

--- a/client/jetbrains/webview/src/search/index.tsx
+++ b/client/jetbrains/webview/src/search/index.tsx
@@ -116,6 +116,7 @@ window.initializeSourcegraph = async () => {
     applyConfig(config)
     applyTheme(theme)
     renderReactApp()
+    await window.callJava({ action: 'indicateFinishedLoading', arguments: {} })
 }
 
 /* Initialize app for standalone server */

--- a/client/jetbrains/webview/src/search/jsToJavaBridgeUtil.ts
+++ b/client/jetbrains/webview/src/search/jsToJavaBridgeUtil.ts
@@ -11,6 +11,7 @@ type RequestToJavaAction =
     | 'preview'
     | 'clearPreview'
     | 'open'
+    | 'indicateFinishedLoading'
 
 export interface RequestToJava {
     action: RequestToJavaAction

--- a/client/jetbrains/webview/src/search/mockJavaInterface.ts
+++ b/client/jetbrains/webview/src/search/mockJavaInterface.ts
@@ -66,6 +66,8 @@ function handleRequest(
         onSuccessCallback('{}')
     } else if (request.action === 'loadLastSearch') {
         onSuccessCallback(JSON.stringify(savedSearch))
+    } else if (request.action === 'indicateFinishedLoading') {
+        onSuccessCallback('{}')
     } else {
         onFailureCallback(2, `Unknown action: ${request.action as string}`)
     }


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/34694

I've fixed it by using a JLayeredPane (suggested by @madppiper)—or actually, a class extended from that one—and “hiding” the browser window by making in 1x1 pixel big while the web page is loading. Once we loaded the config, theme, and initiated a React render, we display the browser.

Might be even better if we waited for the first React render. So there's still room for improvement.

Another thing: I'm a bit confused with the naming "pane" and "panel" and couldn't learn it efficiently, so it might include bad naming in the class and variable names. This is very easy to fix later, however, so I went ahead and created the PR.

## Test plan

Open the popup, see if the browser flickers. It should not flicker.

[30-sec Loom](https://www.loom.com/share/43e67f22e01e4f64a17b57cc9d04517d)

## App preview:

- [Web](https://sg-web-dv-jetbrains-prevent-web-view.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-robcpukwjq.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
