### PR TITLE
Update cadvisor base image

### DIFF
--- a/docker-images/cadvisor/Dockerfile
+++ b/docker-images/cadvisor/Dockerfile
@@ -12,6 +12,7 @@ LABEL org.opencontainers.image.url=https://sourcegraph.com/
 LABEL org.opencontainers.image.source=https://github.com/sourcegraph/sourcegraph/
 LABEL org.opencontainers.image.documentation=https://docs.sourcegraph.com/
 
+# hadolint ignore=SC2261
 RUN apk add --upgrade --no-cache apk-tools>=2.10.8-r0 krb5-libs>=1.18.4-r0 \
     busybox \
     wget

--- a/docker-images/cadvisor/Dockerfile
+++ b/docker-images/cadvisor/Dockerfile
@@ -1,5 +1,5 @@
-FROM gcr.io/cadvisor/cadvisor:v0.42.0@sha256:f240a164f49ec49c5e633c1871c24e641e5dfdd8d2ea54aeb2f2b06d7e7cc980
-LABEL com.sourcegraph.cadvisor.version=v0.42.0
+FROM gcr.io/cadvisor/cadvisor@sha256:3b712bca0d42fa33352e81e4023dbbc15a7d0f1e6fadecf990db46e8d6b3fee4
+LABEL com.sourcegraph.cadvisor.version=v0.44.0
 
 ARG COMMIT_SHA="unknown"
 ARG DATE="unknown"

--- a/docker-images/cadvisor/Dockerfile
+++ b/docker-images/cadvisor/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/cadvisor/cadvisor@sha256:3b712bca0d42fa33352e81e4023dbbc15a7d0f1e6fadecf990db46e8d6b3fee4
+FROM gcr.io/cadvisor/cadvisor@sha256:ef1e224267584fc9cb8d189867f178598443c122d9068686f9c3898c735b711f
 LABEL com.sourcegraph.cadvisor.version=v0.44.0
 
 ARG COMMIT_SHA="unknown"

--- a/docker-images/cadvisor/Dockerfile
+++ b/docker-images/cadvisor/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/cadvisor/cadvisor@sha256:ef1e224267584fc9cb8d189867f178598443c122d9068686f9c3898c735b711f
+FROM gcr.io/cadvisor/cadvisor@sha256:3b712bca0d42fa33352e81e4023dbbc15a7d0f1e6fadecf990db46e8d6b3fee4
 LABEL com.sourcegraph.cadvisor.version=v0.44.0
 
 ARG COMMIT_SHA="unknown"


### PR DESCRIPTION
cadvisor has a few open CVEs that don't directly affect us but are quick to get rid of. I used the last cadvisor image that doesn't have a `test` tag. I built the new image locally and trivy found no CVEs:
```
trivy image --severity "HIGH,CRITICAL" andre/cadvisor-test
2022-05-20T11:27:03.578-0300	INFO	Detected OS: alpine
2022-05-20T11:27:03.578-0300	INFO	Detecting Alpine vulnerabilities...
2022-05-20T11:27:03.579-0300	INFO	Number of language-specific files: 0

andre/cadvisor-test (alpine 3.15.4)
===================================
Total: 0 (HIGH: 0, CRITICAL: 0)
```
## Test plan
I'm trusting CI checks. If any further testing is necessary let me know.
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
