### PR TITLE
Update jaeger all-in-one base image

### DIFF
--- a/docker-images/jaeger-all-in-one/build.sh
+++ b/docker-images/jaeger-all-in-one/build.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
-export JAEGER_VERSION="${JAEGER_VERSION:-1.24.0}"
+export JAEGER_VERSION="${JAEGER_VERSION:-1.34.1}"
 IMAGE=${IMAGE:-sourcegraph/jaeger-all-in-one}
 
 echo "Building image ${IMAGE} from Jaeger ${JAEGER_VERSION}"


### PR DESCRIPTION
This clears a few CVEs from Jaeger. It's a big version bump (1.24 -> 1.34.1).

```
trivy image --severity "HIGH,CRITICAL" sourcegraph/jaeger-all-in-one:latest
2022-05-20T12:11:35.201-0300	INFO	Detected OS: alpine
2022-05-20T12:11:35.201-0300	INFO	Detecting Alpine vulnerabilities...
2022-05-20T12:11:35.204-0300	INFO	Number of language-specific files: 0

sourcegraph/jaeger-all-in-one:latest (alpine 3.14.6)
====================================================
Total: 0 (HIGH: 0, CRITICAL: 0)
```
## Test plan
CI tests
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
