### PR TITLE
dev/sg: make os.Exit check more granular, apply review comments

### DIFF
--- a/dev/sg/internal/repo/repo.go
+++ b/dev/sg/internal/repo/repo.go
@@ -44,7 +44,7 @@ type DiffHunk struct {
 
 // GetDiff retrieves a parsed diff from the workspace, filtered by the given path glob.
 func (s *State) GetDiff(glob string) (Diff, error) {
-	// Compare from common ancestor by default
+	// Compare with common ancestor by default
 	target := s.MergeBase
 	if !s.Dirty && s.Ref == s.MergeBase {
 		// Compare previous commit, if we are already at merge base and in a clean workdir

--- a/dev/sg/linters/go_checks.go
+++ b/dev/sg/linters/go_checks.go
@@ -25,13 +25,19 @@ func lintSGExit() lint.Runner {
 		}
 
 		mErr := diff.IterateHunks(func(file string, hunk repo.DiffHunk) error {
-			if strings.HasPrefix(file, "dev/sg/interrupt") || strings.HasPrefix(file, "dev/sg/linters/go_checks.go") {
+			if strings.HasPrefix(file, "dev/sg/interrupt") || file == "dev/sg/linters/go_checks.go" {
 				return nil
 			}
 
-			added := strings.Join(hunk.AddedLines, "\n")
-			if strings.Contains(added, "os.Exit") || strings.Contains(added, "signal.Notify") {
-				return errors.New("do not use 'os.Exit' or 'signal.Notify', use the 'dev/sg/internal/interrupt' package instead")
+			for _, added := range hunk.AddedLines {
+				// Ignore comments
+				if strings.HasPrefix(strings.TrimSpace(added), "//") {
+					continue
+				}
+
+				if strings.Contains(added, "os.Exit") || strings.Contains(added, "signal.Notify") {
+					return errors.New("do not use 'os.Exit' or 'signal.Notify', use the 'dev/sg/internal/interrupt' package instead")
+				}
 			}
 
 			return nil


### PR DESCRIPTION
Applies review comments from https://github.com/sourcegraph/sourcegraph/pull/35761 and https://github.com/sourcegraph/sourcegraph/pull/35760 

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

n/a