### PR TITLE
chore: Do not blow up processing LSIF indexes with unrecognized edges

### DIFF
--- a/lib/codeintel/lsif/conversion/correlate.go
+++ b/lib/codeintel/lsif/conversion/correlate.go
@@ -235,7 +235,7 @@ func correlateEdge(state *wrappedState, element Element) error {
 		}
 		return handler(state, element.ID, payload)
 	default:
-		// return ErrUnexpectedPayload
+		return nil
 	}
 }
 

--- a/lib/codeintel/lsif/conversion/correlate.go
+++ b/lib/codeintel/lsif/conversion/correlate.go
@@ -235,7 +235,7 @@ func correlateEdge(state *wrappedState, element Element) error {
 		}
 		return handler(state, element.ID, payload)
 	default:
-		return ErrUnexpectedPayload
+		// return ErrUnexpectedPayload
 	}
 }
 


### PR DESCRIPTION
Allow unrecognized edges during correlation. When we removed API doc processing we broke lsif-go uploads.

## Test plan

CI.