### PR TITLE
Specify where code monitor flag is set and fix syntax

### DIFF
--- a/doc/code_monitoring/how-tos/slack.md
+++ b/doc/code_monitoring/how-tos/slack.md
@@ -16,7 +16,7 @@ use that webhook's URL.
 
 ## Prerequisites
 
-- You must have the experimental feature flag `experimentalFeatures.codeMonitoringWebHooks` set to `true` in your Sourcegraph settings
+- You must have the feature flag `  "experimentalFeatures": { "codeMonitoringWebHooks": true } ` set in your Global Settings
 - You must have permission to create apps inside of your organization's Slack workspace
 
 ## Creating a Slack webhook

--- a/doc/code_monitoring/how-tos/slack.md
+++ b/doc/code_monitoring/how-tos/slack.md
@@ -16,7 +16,7 @@ use that webhook's URL.
 
 ## Prerequisites
 
-- You must have the feature flag `  "experimentalFeatures": { "codeMonitoringWebHooks": true } ` set in your Global Settings
+- You must have the experimental feature flag `  "experimentalFeatures": { "codeMonitoringWebHooks": true } ` set in your user, org, or global settings.
 - You must have permission to create apps inside of your organization's Slack workspace
 
 ## Creating a Slack webhook


### PR DESCRIPTION
The previous version does not specify where the feature flag needed to be configured (Global Settings) and the provided syntax did not work


