### PR TITLE
JetBrains: Implement file previewing in standalone mode

### DIFF
--- a/client/jetbrains/standalone/src/index.html
+++ b/client/jetbrains/standalone/src/index.html
@@ -43,14 +43,25 @@
             height: 320px;
             margin: 0;
             padding: 5px;
+            overflow: auto;
+            font-family: monospace;
+            white-space: pre;
+        }
+
+        #code-details-highlight {
+            background-color: #ebcb8b;
+            color:#4f5b66;
+            border-radius: 2px;
         }
     </style>
 </head>
 <body>
 <div id="modal">
     <div id="title">Sourcegraph for JetBrains</div>
-    <iframe height="100%" id="webview" src="/html/index.html?standalone=true" width="100%"></iframe>
-    <pre id="code-details"></div>
+    <iframe height="100%" id="webview" src="/html/index.html" width="100%"></iframe>
+    <div id="code-details"></div>
+
+    <script src="/dist/bridgeMock.js"></script>
 </body>
 </html>
 

--- a/client/jetbrains/webpack.config.js
+++ b/client/jetbrains/webpack.config.js
@@ -36,6 +36,7 @@ const webviewConfig = {
   target: 'web',
   entry: {
     search: path.resolve(webviewSourcePath, 'search', 'index.tsx'),
+    bridgeMock: path.resolve(webviewSourcePath, 'bridge-mock', 'index.ts'),
     style: path.join(webviewSourcePath, 'index.scss'),
   },
   devtool: 'source-map',

--- a/client/jetbrains/webview/src/bridge-mock/index.ts
+++ b/client/jetbrains/webview/src/bridge-mock/index.ts
@@ -62,7 +62,6 @@ function handleRequest(
         }
 
         case 'preview': {
-            console.log(request.arguments)
             const { content, absoluteOffsetAndLengths } = request.arguments
 
             const start = absoluteOffsetAndLengths[0][0]

--- a/client/jetbrains/webview/src/bridge-mock/index.ts
+++ b/client/jetbrains/webview/src/bridge-mock/index.ts
@@ -1,7 +1,7 @@
 import { SearchPatternType } from '@sourcegraph/shared/src/graphql-operations'
 
-import { Search } from './App'
-import { Request } from './jsToJavaBridgeUtil'
+import { Search } from '../search/App'
+import { Request } from '../search/jsToJavaBridgeUtil'
 
 let savedSearch: Search = {
     query: '',
@@ -10,7 +10,10 @@ let savedSearch: Search = {
     selectedSearchContextSpec: 'global',
 }
 
-export function callJava(request: Request): Promise<object> {
+const codeDetailsNode = document.querySelector('#code-details') as HTMLPreElement
+const iframeNode = document.querySelector('#webview') as HTMLIFrameElement
+
+function callJava(request: Request): Promise<object> {
     return new Promise((resolve, reject) => {
         const requestAsString = JSON.stringify(request)
         const onSuccessCallback = (responseAsString: string): void => {
@@ -59,21 +62,35 @@ function handleRequest(
         }
 
         case 'preview': {
-            const { path } = request.arguments
-            console.log(`Previewing "${path}"`)
+            console.log(request.arguments)
+            const { content, absoluteOffsetAndLengths } = request.arguments
+
+            const start = absoluteOffsetAndLengths[0][0]
+            const length = absoluteOffsetAndLengths[0][1]
+
+            let htmlContent: string = escapeHTML(content.slice(0, start))
+            htmlContent += `<span id="code-details-highlight">${escapeHTML(
+                content.slice(start, start + length)
+            )}</span>`
+            htmlContent += escapeHTML(content.slice(start + length))
+
+            codeDetailsNode.innerHTML = htmlContent
+
+            document.querySelector('#code-details-highlight')?.scrollIntoView({ block: 'center', inline: 'center' })
+
             onSuccessCallback('{}')
             break
         }
 
         case 'clearPreview': {
-            console.log('Clearing preview.')
+            codeDetailsNode.textContent = ''
             onSuccessCallback('{}')
             break
         }
 
         case 'open': {
             const { path } = request.arguments
-            console.log(`Opening "${path}"`)
+            alert(`Opening ${path}`)
             onSuccessCallback('{}')
             break
         }
@@ -99,4 +116,20 @@ function handleRequest(
             onFailureCallback(2, `Unknown action: ${exhaustiveCheck as string}`)
         }
     }
+}
+
+/* Initialize app for standalone server */
+iframeNode.addEventListener('load', () => {
+    const iframeWindow = iframeNode.contentWindow
+    if (iframeWindow !== null) {
+        iframeWindow.callJava = callJava
+        iframeWindow.initializeSourcegraph()
+    }
+})
+
+function escapeHTML(unsafe: string): string {
+    return unsafe.replace(
+        /[\u0000-\u002F\u003A-\u0040\u005B-\u0060\u007B-\u00FF]/g,
+        c => '&#' + ('000' + c.charCodeAt(0)).slice(-4) + ';'
+    )
 }

--- a/client/jetbrains/webview/src/search/index.tsx
+++ b/client/jetbrains/webview/src/search/index.tsx
@@ -5,7 +5,6 @@ import { AnchorLink, setLinkComponent } from '@sourcegraph/wildcard'
 
 import { App } from './App'
 import { createRequestForMatch, Request } from './jsToJavaBridgeUtil'
-import { callJava } from './mockJavaInterface'
 
 setLinkComponent(AnchorLink)
 
@@ -117,10 +116,4 @@ window.initializeSourcegraph = async () => {
     applyTheme(theme)
     renderReactApp()
     await window.callJava({ action: 'indicateFinishedLoading' })
-}
-
-/* Initialize app for standalone server */
-if (window.location.search.includes('standalone=true')) {
-    window.callJava = callJava
-    window.initializeSourcegraph()
 }


### PR DESCRIPTION
Fixes #35556

This implements the file previewing in standalone mode.

In addition to that, I removed the JS -> Java bridge mock from the search JavaScript bundle into their own. The reason is that we need an easy way for the mock to access both the underlying web view context as well as the host content (i.e the preview panel). 

As a nice side effect we have also removed the code related to the bridge mock from our production bundle 🙂 

## Test plan

https://user-images.githubusercontent.com/458591/169570734-3437b6cd-00a6-4db8-a856-f3cf19777532.mov


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-jetbrains-file-preview.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-hicytjqrad.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
