### PR TITLE
dev/sg: make linter for lib/log more granular

### DIFF
--- a/dev/sg/linters/liblog.go
+++ b/dev/sg/linters/liblog.go
@@ -45,7 +45,7 @@ func lintLoggingLibraries() lint.Runner {
 
 		for _, l := range hunk.AddedLines {
 			for _, banned := range bannedImports {
-				if strings.Contains(l, banned) {
+				if strings.TrimSpace(l) == banned {
 					return errors.Newf(`banned usage of '%s': use "github.com/sourcegraph/sourcegraph/lib/log" instead`,
 						banned)
 				}


### PR DESCRIPTION
Avoids catching non-import things.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

n/a, import lines are just the package name in 99% of cases