### PR TITLE
dev/sg: trim out go download output from go-lint.sh

### DIFF
--- a/dev/sg/linters/go_checks.go
+++ b/dev/sg/linters/go_checks.go
@@ -1,19 +1,44 @@
 package linters
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"io"
 	"strings"
+
+	"github.com/sourcegraph/run"
 
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/lint"
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/repo"
+	"github.com/sourcegraph/sourcegraph/dev/sg/root"
 )
 
 var (
 	goFmt          = lint.RunScript("Go format", "dev/check/gofmt.sh")
-	goLint         = lint.RunScript("Go lint", "dev/check/go-lint.sh")
 	goDBConnImport = lint.RunScript("Go pkg/database/dbconn", "dev/check/go-dbconn-import.sh")
 )
+
+func goLint() lint.Runner {
+	return func(ctx context.Context, _ *repo.State) *lint.Report {
+		var dst bytes.Buffer
+		err := root.Run(run.Bash(ctx, "dev/check/go-lint.sh")).
+			Map(func(ctx context.Context, line []byte, dst io.Writer) (int, error) {
+				// Ignore go mod download stuff
+				if bytes.HasPrefix(line, []byte("go: downloading ")) {
+					return 0, nil
+				}
+				return dst.Write(line)
+			}).
+			Stream(&dst)
+
+		return &lint.Report{
+			Header: "Go lint",
+			Output: dst.String(),
+			Err:    err,
+		}
+	}
+}
 
 func lintSGExit() lint.Runner {
 	const header = "Lint dev/sg exit signals"

--- a/dev/sg/linters/linters.go
+++ b/dev/sg/linters/linters.go
@@ -22,7 +22,7 @@ var Targets = []lint.Target{
 		Linters: []lint.Runner{
 			goFmt,
 			lintGoGenerate,
-			goLint,
+			goLint(),
 			goDBConnImport,
 			goEnterpriseImport,
 			noLocalHost,


### PR DESCRIPTION
Removes all this noise - if an error happens, a line _not_ starting with `go: downloading` will be printed so we still have that.

<img width="759" alt="image" src="https://user-images.githubusercontent.com/23356519/169588782-1425e36b-1ad1-473b-8883-ab57e10ff286.png">



## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

`go run ./dev/sg lint` still works