### PR TITLE
sg: Use git as source of truth for `sg migration drift`

### DIFF
--- a/cmd/migrator/main.go
+++ b/cmd/migrator/main.go
@@ -3,8 +3,11 @@ package main
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"fmt"
+	"net/http"
 	"os"
+	"regexp"
 
 	"github.com/opentracing/opentracing-go"
 	"github.com/prometheus/client_golang/prometheus"
@@ -12,6 +15,7 @@ import (
 
 	connections "github.com/sourcegraph/sourcegraph/internal/database/connections/live"
 	"github.com/sourcegraph/sourcegraph/internal/database/migration/cliutil"
+	descriptions "github.com/sourcegraph/sourcegraph/internal/database/migration/schemas"
 	"github.com/sourcegraph/sourcegraph/internal/database/migration/store"
 	"github.com/sourcegraph/sourcegraph/internal/database/postgresdsn"
 	"github.com/sourcegraph/sourcegraph/internal/env"
@@ -19,6 +23,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/internal/version"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 	sglog "github.com/sourcegraph/sourcegraph/lib/log"
 	"github.com/sourcegraph/sourcegraph/lib/output"
 )
@@ -52,6 +57,25 @@ func mainErr(ctx context.Context, args []string) error {
 
 	runnerFactory := newRunnerFactory()
 	outputFactory := func() *output.Output { return out }
+	expectedSchemaFactory := func(filename, version string) (descriptions.SchemaDescription, error) {
+		if !regexp.MustCompile(`(^v\d+\.\d+\.\d+$)|($[a-z0-9]{40}^)`).MatchString(version) {
+			return descriptions.SchemaDescription{}, errors.Newf("failed to parse %q - expected a version of the form `vX.Y.Z` or a 40-character commit hash", v)
+		}
+
+		resp, err := http.Get(fmt.Sprintf("https://raw.githubusercontent.com/sourcegraph/sourcegraph/%s/%s", version, filename))
+		if err != nil {
+			return descriptions.SchemaDescription{}, err
+		}
+		defer resp.Body.Close()
+
+		var schemaDescription descriptions.SchemaDescription
+		if err := json.NewDecoder(resp.Body).Decode(&schemaDescription); err != nil {
+			return descriptions.SchemaDescription{}, err
+		}
+
+		return schemaDescription, nil
+	}
+
 	command := &cli.App{
 		Name:   appName,
 		Usage:  "Validates and runs schema migrations",
@@ -62,7 +86,7 @@ func mainErr(ctx context.Context, args []string) error {
 			cliutil.DownTo(appName, runnerFactory, outputFactory, false),
 			cliutil.Validate(appName, runnerFactory, outputFactory),
 			cliutil.Describe(appName, runnerFactory, outputFactory),
-			cliutil.Drift(appName, runnerFactory, outputFactory),
+			cliutil.Drift(appName, runnerFactory, outputFactory, expectedSchemaFactory),
 			cliutil.AddLog(appName, runnerFactory, outputFactory),
 		},
 	}

--- a/cmd/migrator/main.go
+++ b/cmd/migrator/main.go
@@ -68,6 +68,10 @@ func mainErr(ctx context.Context, args []string) error {
 		}
 		defer resp.Body.Close()
 
+		if resp.StatusCode != http.StatusOK {
+			return descriptions.SchemaDescription{}, errors.Newf("unexpected status %d from github", resp.StatusCode)
+		}
+
 		var schemaDescription descriptions.SchemaDescription
 		if err := json.NewDecoder(resp.Body).Decode(&schemaDescription); err != nil {
 			return descriptions.SchemaDescription{}, err

--- a/cmd/migrator/main.go
+++ b/cmd/migrator/main.go
@@ -58,8 +58,8 @@ func mainErr(ctx context.Context, args []string) error {
 	runnerFactory := newRunnerFactory()
 	outputFactory := func() *output.Output { return out }
 	expectedSchemaFactory := func(filename, version string) (descriptions.SchemaDescription, error) {
-		if !regexp.MustCompile(`(^v\d+\.\d+\.\d+$)|($[a-z0-9]{40}^)`).MatchString(version) {
-			return descriptions.SchemaDescription{}, errors.Newf("failed to parse %q - expected a version of the form `vX.Y.Z` or a 40-character commit hash", v)
+		if !regexp.MustCompile(`(^v\d+\.\d+\.\d+$)|(^[A-Fa-f0-9]{40}$)`).MatchString(version) {
+			return descriptions.SchemaDescription{}, errors.Newf("failed to parse %q - expected a version of the form `vX.Y.Z` or a 40-character commit hash", version)
 		}
 
 		resp, err := http.Get(fmt.Sprintf("https://raw.githubusercontent.com/sourcegraph/sourcegraph/%s/%s", version, filename))

--- a/dev/sg/sg_migration.go
+++ b/dev/sg/sg_migration.go
@@ -3,22 +3,27 @@ package main
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"flag"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strings"
 
 	"github.com/Masterminds/semver"
 	"github.com/urfave/cli/v2"
 
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/db"
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/migration"
+	"github.com/sourcegraph/sourcegraph/dev/sg/internal/run"
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/sgconf"
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/std"
 	"github.com/sourcegraph/sourcegraph/dev/sg/root"
 	connections "github.com/sourcegraph/sourcegraph/internal/database/connections/live"
 	"github.com/sourcegraph/sourcegraph/internal/database/migration/cliutil"
 	"github.com/sourcegraph/sourcegraph/internal/database/migration/schemas"
+	descriptions "github.com/sourcegraph/sourcegraph/internal/database/migration/schemas"
 	"github.com/sourcegraph/sourcegraph/internal/database/migration/store"
 	"github.com/sourcegraph/sourcegraph/internal/database/postgresdsn"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
@@ -58,13 +63,32 @@ var (
 	// at compile-time in sg.
 	outputFactory = func() *output.Output { return std.Out.Output }
 
+	// expectedSchemaFactory returns the description of the given schema at the given version via
+	// the local git clone. If the version is not resolvable as a git rev-like, then an error is
+	// returned.
+	expectedSchemaFactory = func(filename, version string) (descriptions.SchemaDescription, error) {
+		gitShow := exec.Command("git", "show", fmt.Sprintf("%s^:%s", version, filename))
+		gitShow.Env = os.Environ()
+		content, err := run.InRoot(gitShow)
+		if err != nil {
+			return descriptions.SchemaDescription{}, err
+		}
+
+		var schemaDescription descriptions.SchemaDescription
+		if err := json.NewDecoder(strings.NewReader(content)).Decode(&schemaDescription); err != nil {
+			return schemaDescription, err
+		}
+
+		return schemaDescription, nil
+	}
+
 	upCommand       = cliutil.Up("sg migration", makeRunner, outputFactory, true)
 	upToCommand     = cliutil.UpTo("sg migration", makeRunner, outputFactory, true)
 	undoCommand     = cliutil.Undo("sg migration", makeRunner, outputFactory, true)
 	downToCommand   = cliutil.DownTo("sg migration", makeRunner, outputFactory, true)
 	validateCommand = cliutil.Validate("sg migration", makeRunner, outputFactory)
 	describeCommand = cliutil.Describe("sg migration", makeRunner, outputFactory)
-	driftCommand    = cliutil.Drift("sg migration", makeRunner, outputFactory)
+	driftCommand    = cliutil.Drift("sg migration", makeRunner, outputFactory, expectedSchemaFactory)
 	addLogCommand   = cliutil.AddLog("sg migration", makeRunner, outputFactory)
 
 	leavesCommand = &cli.Command{

--- a/dev/sg/sg_migration.go
+++ b/dev/sg/sg_migration.go
@@ -68,7 +68,6 @@ var (
 	// returned.
 	expectedSchemaFactory = func(filename, version string) (descriptions.SchemaDescription, error) {
 		gitShow := exec.Command("git", "show", fmt.Sprintf("%s^:%s", version, filename))
-		gitShow.Env = os.Environ()
 		content, err := run.InRoot(gitShow)
 		if err != nil {
 			return descriptions.SchemaDescription{}, err

--- a/internal/database/migration/cliutil/describe.go
+++ b/internal/database/migration/cliutil/describe.go
@@ -10,7 +10,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/output"
 )
 
-func Describe(commandName string, factory RunnerFactory, outFactory func() *output.Output) *cli.Command {
+func Describe(commandName string, factory RunnerFactory, outFactory OutputFactory) *cli.Command {
 	schemaNameFlag := &cli.StringFlag{
 		Name:     "db",
 		Usage:    "The target `schema` to describe.",

--- a/internal/database/migration/cliutil/downto.go
+++ b/internal/database/migration/cliutil/downto.go
@@ -10,7 +10,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/output"
 )
 
-func DownTo(commandName string, factory RunnerFactory, outFactory func() *output.Output, development bool) *cli.Command {
+func DownTo(commandName string, factory RunnerFactory, outFactory OutputFactory, development bool) *cli.Command {
 	schemaNameFlag := &cli.StringFlag{
 		Name:     "db",
 		Usage:    "The target `schema` to modify.",

--- a/internal/database/migration/cliutil/drift.go
+++ b/internal/database/migration/cliutil/drift.go
@@ -9,7 +9,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/output"
 )
 
-func Drift(commandName string, factory RunnerFactory, outFactory func() *output.Output) *cli.Command {
+func Drift(commandName string, factory RunnerFactory, outFactory OutputFactory) *cli.Command {
 	schemaNameFlag := &cli.StringFlag{
 		Name:     "db",
 		Usage:    "The target `schema` to compare.",

--- a/internal/database/migration/cliutil/drift.go
+++ b/internal/database/migration/cliutil/drift.go
@@ -38,10 +38,7 @@ func Drift(commandName string, factory RunnerFactory, outFactory OutputFactory) 
 			return err
 		}
 
-		canonicalize(schema)
-		canonicalize(expected)
-
-		return compareSchemaDescriptions(out, schema, expected)
+		return compareSchemaDescriptions(out, canonicalize(schema), canonicalize(expected))
 	})
 
 	return &cli.Command{
@@ -56,12 +53,14 @@ func Drift(commandName string, factory RunnerFactory, outFactory OutputFactory) 
 	}
 }
 
-func canonicalize(schema descriptions.SchemaDescription) {
-	descriptions.Canonicalize(schema)
+func canonicalize(schemaDescription descriptions.SchemaDescription) descriptions.SchemaDescription {
+	descriptions.Canonicalize(schemaDescription)
 
-	for i, table := range schema.Tables {
+	for i, table := range schemaDescription.Tables {
 		for j := range table.Columns {
-			schema.Tables[i].Columns[j].Index = -1
+			schemaDescription.Tables[i].Columns[j].Index = -1
 		}
 	}
+
+	return schemaDescription
 }

--- a/internal/database/migration/cliutil/drift_util.go
+++ b/internal/database/migration/cliutil/drift_util.go
@@ -3,56 +3,23 @@ package cliutil
 import (
 	"encoding/json"
 	"fmt"
-	"net/http"
 
 	"github.com/google/go-cmp/cmp"
 
 	"github.com/sourcegraph/sourcegraph/internal/database/migration/schemas"
-	descriptions "github.com/sourcegraph/sourcegraph/internal/database/migration/schemas"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 	"github.com/sourcegraph/sourcegraph/lib/output"
 )
 
-// fetchSchema returns the schema description of the given schema at the given version. If the version
-// is not resolvable as a git rev-like, then an error is returned.
-func fetchSchema(schemaName, version string) (schemaDescription descriptions.SchemaDescription, _ error) {
-	url, err := getSchemaURL(schemaName, version)
-	if err != nil {
-		return schemaDescription, err
-	}
-	resp, err := http.Get(url)
-	if err != nil {
-		return schemaDescription, err
-	}
-	defer resp.Body.Close()
-
-	if err := json.NewDecoder(resp.Body).Decode(&schemaDescription); err != nil {
-		return schemaDescription, err
-	}
-
-	return schemaDescription, nil
-}
-
-// getSchemaURL returns the GitHub raw URL for the JSON-serialized version of the given schema at
-// the given version.
-func getSchemaURL(schemaName, version string) (string, error) {
-	filename, err := getSchemaJSONFilename(schemaName, version)
-	if err != nil {
-		return "", err
-	}
-
-	return fmt.Sprintf("https://raw.githubusercontent.com/sourcegraph/sourcegraph/%s/internal/database/%s", version, filename), nil
-}
-
 // getSchemaJSONFilename returns the basename of the JSON-serialized schema in the sg/sg repository.
-func getSchemaJSONFilename(schemaName, version string) (string, error) {
+func getSchemaJSONFilename(schemaName string) (string, error) {
 	switch schemaName {
 	case "frontend":
-		return "schema.json", nil
+		return "internal/database/schema.json", nil
 	case "codeintel":
 		fallthrough
 	case "codeinsights":
-		return fmt.Sprintf("schema.%s.json", schemaName), nil
+		return fmt.Sprintf("internal/database/schema.%s.json", schemaName), nil
 	}
 
 	return "", errors.Newf("unknown schema name %q", schemaName)

--- a/internal/database/migration/cliutil/undo.go
+++ b/internal/database/migration/cliutil/undo.go
@@ -10,7 +10,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/output"
 )
 
-func Undo(commandName string, factory RunnerFactory, outFactory func() *output.Output, development bool) *cli.Command {
+func Undo(commandName string, factory RunnerFactory, outFactory OutputFactory, development bool) *cli.Command {
 	schemaNameFlag := &cli.StringFlag{
 		Name:     "db",
 		Usage:    "The target `schema` to modify.",

--- a/internal/database/migration/cliutil/up.go
+++ b/internal/database/migration/cliutil/up.go
@@ -10,7 +10,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/output"
 )
 
-func Up(commandName string, factory RunnerFactory, outFactory func() *output.Output, development bool) *cli.Command {
+func Up(commandName string, factory RunnerFactory, outFactory OutputFactory, development bool) *cli.Command {
 	schemaNamesFlag := &cli.StringSliceFlag{
 		Name:  "db",
 		Usage: "The target `schema(s)` to modify. Comma-separated values are accepted. Supply \"all\" to migrate all schemas.",

--- a/internal/database/migration/cliutil/upto.go
+++ b/internal/database/migration/cliutil/upto.go
@@ -10,7 +10,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/output"
 )
 
-func UpTo(commandName string, factory RunnerFactory, outFactory func() *output.Output, development bool) *cli.Command {
+func UpTo(commandName string, factory RunnerFactory, outFactory OutputFactory, development bool) *cli.Command {
 	schemaNameFlag := &cli.StringFlag{
 		Name:     "db",
 		Usage:    "The target `schema` to modify.",

--- a/internal/database/migration/cliutil/util.go
+++ b/internal/database/migration/cliutil/util.go
@@ -11,12 +11,11 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/output"
 )
 
+type actionFunction func(ctx context.Context, cmd *cli.Context, out *output.Output) error
+
 // makeAction creates a new migration action function. It is expected that these
 // commands accept zero arguments and define their own flags.
-func makeAction(
-	outFactory func() *output.Output,
-	f func(ctx context.Context, cmd *cli.Context, out *output.Output) error,
-) func(cmd *cli.Context) error {
+func makeAction(outFactory OutputFactory, f actionFunction) func(cmd *cli.Context) error {
 	return func(cmd *cli.Context) error {
 		if cmd.NArg() != 0 {
 			return flagHelp(outFactory(), "too many arguments")

--- a/internal/database/migration/cliutil/validate.go
+++ b/internal/database/migration/cliutil/validate.go
@@ -8,7 +8,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/output"
 )
 
-func Validate(commandName string, factory RunnerFactory, outFactory func() *output.Output) *cli.Command {
+func Validate(commandName string, factory RunnerFactory, outFactory OutputFactory) *cli.Command {
 	schemaNamesFlag := &cli.StringSliceFlag{
 		Name:  "db",
 		Usage: "The target `schema(s)` to modify. Comma-separated values are accepted. Supply \"all\" to migrate all schemas.",


### PR DESCRIPTION
Refactor the drift command to use the current git checkout when using `sg migration` and the GitHub raw API when using the migrator.

## Test plan

Tested locally (both migrator and sg commands)