### PR TITLE
Search backend: Enable multi-line matches

### DIFF
--- a/cmd/frontend/graphqlbackend/file_match.go
+++ b/cmd/frontend/graphqlbackend/file_match.go
@@ -56,8 +56,9 @@ func (fm *FileMatchResolver) Symbols() []symbolResolver {
 }
 
 func (fm *FileMatchResolver) LineMatches() []lineMatchResolver {
-	r := make([]lineMatchResolver, 0, len(fm.FileMatch.LineMatches))
-	for _, lm := range fm.FileMatch.LineMatches {
+	lineMatches := result.MultilineSliceAsLineMatchSlice(fm.FileMatch.MultilineMatches)
+	r := make([]lineMatchResolver, 0, len(lineMatches))
+	for _, lm := range lineMatches {
 		r = append(r, lineMatchResolver{lm})
 	}
 	return r

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -248,15 +248,15 @@ func (sr *SearchResultsResolver) blameFileMatch(ctx context.Context, fm *result.
 	}()
 
 	// Blame the first line match.
-	if len(fm.LineMatches) == 0 {
+	if len(fm.MultilineMatches) == 0 {
 		// No line match
 		return time.Time{}, nil
 	}
-	lm := fm.LineMatches[0]
+	lm := fm.MultilineMatches[0]
 	hunks, err := gitserver.NewClient(sr.db).BlameFile(ctx, fm.Repo.Name, fm.Path, &gitserver.BlameOptions{
 		NewestCommit: fm.CommitID,
-		StartLine:    int(lm.LineNumber),
-		EndLine:      int(lm.LineNumber),
+		StartLine:    int(lm.Start.Line),
+		EndLine:      int(lm.Start.Line),
 	}, authz.DefaultSubRepoPermsChecker)
 	if err != nil {
 		return time.Time{}, err

--- a/cmd/frontend/graphqlbackend/search_results_stats_languages.go
+++ b/cmd/frontend/graphqlbackend/search_results_stats_languages.go
@@ -111,12 +111,12 @@ func searchResultsStatsLanguages(ctx context.Context, db database.DB, matches []
 				filesMap[key] = &fileStatsWork{}
 			}
 
-			if len(fileMatch.LineMatches) > 0 {
+			if len(fileMatch.MultilineMatches) > 0 {
 				// Only count matching lines. TODO(sqs): bytes are not counted for these files
 				if filesMap[key].partialFiles == nil {
 					filesMap[key].partialFiles = map[string]uint64{}
 				}
-				filesMap[key].partialFiles[fileMatch.Path] += uint64(len(fileMatch.LineMatches))
+				filesMap[key].partialFiles[fileMatch.Path] += uint64(len(fileMatch.MultilineMatches))
 			} else {
 				// Count entire file.
 				filesMap[key].fullEntries = append(filesMap[key].fullEntries, &fileInfo{

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -52,7 +52,7 @@ func TestSearchResults(t *testing.T) {
 			case *result.RepoMatch:
 				resultDescriptions[i] = fmt.Sprintf("repo:%s", m.Name)
 			case *result.FileMatch:
-				resultDescriptions[i] = fmt.Sprintf("%s:%d", m.Path, m.LineMatches[0].LineNumber)
+				resultDescriptions[i] = fmt.Sprintf("%s:%d", m.Path, m.MultilineMatches[0].Start.Line)
 			default:
 				t.Fatal("unexpected result type:", match)
 			}

--- a/cmd/frontend/graphqlbackend/search_test.go
+++ b/cmd/frontend/graphqlbackend/search_test.go
@@ -293,16 +293,20 @@ func TestExactlyOneRepo(t *testing.T) {
 }
 
 func mkFileMatch(repo types.MinimalRepo, path string, lineNumbers ...int32) *result.FileMatch {
-	var lines []*result.LineMatch
+	var lines []result.MultilineMatch
 	for _, n := range lineNumbers {
-		lines = append(lines, &result.LineMatch{LineNumber: n})
+		lines = append(lines, result.MultilineMatch{
+			Start: result.LineColumn{Line: n},
+			End:   result.LineColumn{Line: n},
+		})
 	}
+
 	return &result.FileMatch{
 		File: result.File{
 			Path: path,
 			Repo: repo,
 		},
-		LineMatches: lines,
+		MultilineMatches: lines,
 	}
 }
 

--- a/cmd/frontend/internal/search/decorate.go
+++ b/cmd/frontend/internal/search/decorate.go
@@ -153,7 +153,7 @@ func DecorateFileHunksHTML(ctx context.Context, db database.DB, fm *result.FileM
 		return tableRows
 	}
 
-	groups := groupLineMatches(fm.LineMatches)
+	groups := groupLineMatches(result.MultilineSliceAsLineMatchSlice(fm.MultilineMatches))
 	hunks := make([]stream.DecoratedHunk, 0, len(groups))
 	for _, group := range groups {
 		rows := spliceRows(int(group[0].LineNumber), int(group[0].LineNumber)+len(group))

--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -427,7 +427,7 @@ func fromMatch(match result.Match, repoCache map[api.RepoID]*types.SearchedRepo)
 func fromFileMatch(fm *result.FileMatch, repoCache map[api.RepoID]*types.SearchedRepo) streamhttp.EventMatch {
 	if len(fm.Symbols) > 0 {
 		return fromSymbolMatch(fm, repoCache)
-	} else if len(fm.LineMatches) > 0 {
+	} else if len(fm.MultilineMatches) > 0 {
 		return fromContentMatch(fm, repoCache)
 	}
 	return fromPathMatch(fm, repoCache)
@@ -455,9 +455,10 @@ func fromPathMatch(fm *result.FileMatch, repoCache map[api.RepoID]*types.Searche
 }
 
 func fromContentMatch(fm *result.FileMatch, repoCache map[api.RepoID]*types.SearchedRepo) *streamhttp.EventContentMatch {
-	lineMatches := make([]streamhttp.EventLineMatch, 0, len(fm.LineMatches))
-	for _, lm := range fm.LineMatches {
-		lineMatches = append(lineMatches, streamhttp.EventLineMatch{
+	lineMatches := result.MultilineSliceAsLineMatchSlice(fm.MultilineMatches)
+	eventLineMatches := make([]streamhttp.EventLineMatch, 0, len(lineMatches))
+	for _, lm := range lineMatches {
+		eventLineMatches = append(eventLineMatches, streamhttp.EventLineMatch{
 			Line:             lm.Preview,
 			LineNumber:       lm.LineNumber,
 			OffsetAndLengths: lm.OffsetAndLengths,
@@ -470,7 +471,7 @@ func fromContentMatch(fm *result.FileMatch, repoCache map[api.RepoID]*types.Sear
 		RepositoryID: int32(fm.Repo.ID),
 		Repository:   string(fm.Repo.Name),
 		Commit:       string(fm.CommitID),
-		LineMatches:  lineMatches,
+		LineMatches:  eventLineMatches,
 	}
 
 	if fm.InputRev != nil {

--- a/cmd/searcher/internal/search/search_structural_test.go
+++ b/cmd/searcher/internal/search/search_structural_test.go
@@ -528,6 +528,24 @@ func TestHighlightMultipleLines(t *testing.T) {
 				},
 			},
 		},
+		{
+			Name: "newline split",
+			Match: &comby.Match{
+				Range: comby.Range{
+					Start: comby.Location{
+						Offset: 11448,
+						Line:   470,
+						Column: 21,
+					},
+					End: comby.Location{
+						Offset: 11619,
+						Line:   481,
+						Column: 5,
+					},
+				},
+				Matched: "LineMatch{\n\t\t\t\t{\n\t\t\t\t\tLineNumber: 0,\n\t\t\t\t\tOffsetAndLengths: [][2]int{\n\t\t\t\t\t\t{\n\t\t\t\t\t\t\t0,\n\t\t\t\t\t\t\t1,\n\t\t\t\t\t\t},\n\t\t\t\t\t},\n\t\t\t\t\tPreview: \"this is a single line match\",\n\t\t\t\t},\n\t\t\t}",
+			},
+		},
 	}
 	for _, tt := range cases {
 		t.Run(tt.Name, func(t *testing.T) {

--- a/cmd/searcher/internal/search/search_structural_test.go
+++ b/cmd/searcher/internal/search/search_structural_test.go
@@ -528,24 +528,6 @@ func TestHighlightMultipleLines(t *testing.T) {
 				},
 			},
 		},
-		{
-			Name: "newline split",
-			Match: &comby.Match{
-				Range: comby.Range{
-					Start: comby.Location{
-						Offset: 11448,
-						Line:   470,
-						Column: 21,
-					},
-					End: comby.Location{
-						Offset: 11619,
-						Line:   481,
-						Column: 5,
-					},
-				},
-				Matched: "LineMatch{\n\t\t\t\t{\n\t\t\t\t\tLineNumber: 0,\n\t\t\t\t\tOffsetAndLengths: [][2]int{\n\t\t\t\t\t\t{\n\t\t\t\t\t\t\t0,\n\t\t\t\t\t\t\t1,\n\t\t\t\t\t\t},\n\t\t\t\t\t},\n\t\t\t\t\tPreview: \"this is a single line match\",\n\t\t\t\t},\n\t\t\t}",
-			},
-		},
 	}
 	for _, tt := range cases {
 		t.Run(tt.Name, func(t *testing.T) {

--- a/enterprise/cmd/frontend/internal/compute/resolvers/resolvers_test.go
+++ b/enterprise/cmd/frontend/internal/compute/resolvers/resolvers_test.go
@@ -35,7 +35,7 @@ func TestToResultResolverList(t *testing.T) {
 
 	nonNilMatches := []result.Match{
 		&result.FileMatch{
-			LineMatches: []*result.LineMatch{
+			MultilineMatches: []result.MultilineMatch{
 				{Preview: "a"},
 				{Preview: "b"},
 			},

--- a/enterprise/internal/compute/match_only_command.go
+++ b/enterprise/internal/compute/match_only_command.go
@@ -70,8 +70,9 @@ func fromRegexpMatches(submatches []int, namedGroups []string, lineValue string,
 }
 
 func matchOnly(fm *result.FileMatch, r *regexp.Regexp) *MatchContext {
-	matches := make([]Match, 0, len(fm.LineMatches))
-	for _, l := range fm.LineMatches {
+	lineMatches := result.MultilineSliceAsLineMatchSlice(fm.MultilineMatches)
+	matches := make([]Match, 0, len(lineMatches))
+	for _, l := range lineMatches {
 		for _, submatches := range r.FindAllStringSubmatchIndex(l.Preview, -1) {
 			matches = append(matches, fromRegexpMatches(submatches, r.SubexpNames(), l.Preview, int(l.LineNumber)))
 		}

--- a/enterprise/internal/compute/match_only_command_test.go
+++ b/enterprise/internal/compute/match_only_command_test.go
@@ -34,10 +34,11 @@ func Test_matchOnly(t *testing.T) {
 			ID:   5,
 			Name: "codehost.com/myorg/myrepo",
 		}},
-		LineMatches: []*result.LineMatch{
+		MultilineMatches: []result.MultilineMatch{
 			{
-				Preview:    "abcdefgh",
-				LineNumber: 1,
+				Preview: "abcdefgh",
+				Start:   result.LineColumn{Line: 1},
+				End:     result.LineColumn{Line: 1},
 			},
 		},
 	}

--- a/internal/search/result/deduper_test.go
+++ b/internal/search/result/deduper_test.go
@@ -41,7 +41,7 @@ func TestDeduper(t *testing.T) {
 		}
 	}
 
-	file := func(repo, commit, path string, lines []*LineMatch) *FileMatch {
+	file := func(repo, commit, path string, lines []MultilineMatch) *FileMatch {
 		return &FileMatch{
 			File: File{
 				Repo: types.MinimalRepo{
@@ -50,12 +50,12 @@ func TestDeduper(t *testing.T) {
 				CommitID: api.CommitID(commit),
 				Path:     path,
 			},
-			LineMatches: lines,
+			MultilineMatches: lines,
 		}
 	}
 
-	lm := func(s string) *LineMatch {
-		return &LineMatch{
+	lm := func(s string) MultilineMatch {
+		return MultilineMatch{
 			Preview: s,
 		}
 	}
@@ -83,11 +83,11 @@ func TestDeduper(t *testing.T) {
 		{
 			name: "merge files",
 			input: []Match{
-				file("a", "b", "c", []*LineMatch{lm("a"), lm("b")}),
-				file("a", "b", "c", []*LineMatch{lm("c"), lm("d")}),
+				file("a", "b", "c", []MultilineMatch{lm("a"), lm("b")}),
+				file("a", "b", "c", []MultilineMatch{lm("c"), lm("d")}),
 			},
 			expected: []Match{
-				file("a", "b", "c", []*LineMatch{lm("a"), lm("b"), lm("c"), lm("d")}),
+				file("a", "b", "c", []MultilineMatch{lm("a"), lm("b"), lm("c"), lm("d")}),
 			},
 		},
 		{

--- a/internal/search/result/file.go
+++ b/internal/search/result/file.go
@@ -188,6 +188,7 @@ func (m MultilineMatch) AsLineMatches() []LineMatch {
 	lineMatches := make([]LineMatch, 0, len(lines))
 	for i, line := range lines {
 		// TODO include the newline character?
+		// TODO read this very carefully
 		offset := int32(0)
 		if i == 0 {
 			offset = m.Start.Column

--- a/internal/search/result/file.go
+++ b/internal/search/result/file.go
@@ -125,6 +125,13 @@ func (fm *FileMatch) AppendMatches(src *FileMatch) {
 //   if limit < ResultCount then ResultCount becomes limit and we return 0.
 func (fm *FileMatch) Limit(limit int) int {
 	matchCount := len(fm.MultilineMatches)
+	symbolCount := len(fm.Symbols)
+
+	// An empty FileMatch should still count against the limit -- see *FileMatch.ResultCount()
+	if matchCount == 0 && symbolCount == 0 {
+		return limit - 1
+	}
+
 	if limit < matchCount {
 		fm.MultilineMatches = fm.MultilineMatches[:limit]
 		limit = 0
@@ -133,7 +140,6 @@ func (fm *FileMatch) Limit(limit int) int {
 		limit -= matchCount
 	}
 
-	symbolCount := len(fm.Symbols)
 	if limit < symbolCount {
 		fm.Symbols = fm.Symbols[:limit]
 		limit = 0

--- a/internal/search/result/file.go
+++ b/internal/search/result/file.go
@@ -163,7 +163,8 @@ func (fm *FileMatch) Key() Key {
 // have the rune offset necessary to build a full Location yet.
 // Eventually, the two structs should be merged.
 type LineColumn struct {
-	// Line is the count of newlines before the offset in the matched text
+	// Line is the count of newlines before the offset in the matched text.
+	// Line is 0-based.
 	Line int32
 
 	// Column is the count of unicode code points after the last newline in the matched text

--- a/internal/search/result/file.go
+++ b/internal/search/result/file.go
@@ -189,8 +189,6 @@ func (m MultilineMatch) AsLineMatches() []*LineMatch {
 	lines := strings.Split(m.Preview, "\n")
 	lineMatches := make([]*LineMatch, 0, len(lines))
 	for i, line := range lines {
-		// TODO include the newline character?
-		// TODO read this very carefully
 		offset := int32(0)
 		if i == 0 {
 			offset = m.Start.Column

--- a/internal/search/result/file.go
+++ b/internal/search/result/file.go
@@ -128,6 +128,7 @@ func (fm *FileMatch) Limit(limit int) int {
 	if limit < matchCount {
 		fm.MultilineMatches = fm.MultilineMatches[:limit]
 		limit = 0
+		fm.LimitHit = true
 	} else {
 		limit -= matchCount
 	}
@@ -136,6 +137,7 @@ func (fm *FileMatch) Limit(limit int) int {
 	if limit < symbolCount {
 		fm.Symbols = fm.Symbols[:limit]
 		limit = 0
+		fm.LimitHit = true
 	} else {
 		limit -= symbolCount
 	}

--- a/internal/search/result/file.go
+++ b/internal/search/result/file.go
@@ -188,12 +188,13 @@ func (m MultilineMatch) AsLineMatches() []LineMatch {
 	lineMatches := make([]LineMatch, 0, len(lines))
 	for i, line := range lines {
 		// TODO include the newline character?
-		offset, length := int32(0), int32(utf8.RuneCountInString(line))
+		offset := int32(0)
 		if i == 0 {
 			offset = m.Start.Column
 		}
+		length := int32(utf8.RuneCountInString(line)) - offset
 		if i == len(lines)-1 {
-			length = m.End.Column - m.Start.Column
+			length = m.End.Column - offset
 		}
 		lineMatches = append(lineMatches, LineMatch{
 			Preview:          line,

--- a/internal/search/result/file.go
+++ b/internal/search/result/file.go
@@ -124,17 +124,22 @@ func (fm *FileMatch) AppendMatches(src *FileMatch) {
 //   if limit >= ResultCount then nothing is done and we return limit - ResultCount.
 //   if limit < ResultCount then ResultCount becomes limit and we return 0.
 func (fm *FileMatch) Limit(limit int) int {
-	// Check if we need to limit.
-	if after := limit - fm.ResultCount(); after >= 0 {
-		return after
+	matchCount := len(fm.MultilineMatches)
+	if limit < matchCount {
+		fm.MultilineMatches = fm.MultilineMatches[:limit]
+		limit = 0
+	} else {
+		limit -= matchCount
 	}
 
-	if limit < len(fm.MultilineMatches) {
-		fm.MultilineMatches = fm.MultilineMatches[:limit]
+	symbolCount := len(fm.Symbols)
+	if limit < symbolCount {
+		fm.Symbols = fm.Symbols[:limit]
+		limit = 0
+	} else {
+		limit -= symbolCount
 	}
-	// TODO: why is this not panicking in prod?
-	fm.Symbols = fm.Symbols[:limit]
-	return 0
+	return limit
 }
 
 func (fm *FileMatch) Key() Key {

--- a/internal/search/result/file_test.go
+++ b/internal/search/result/file_test.go
@@ -85,6 +85,19 @@ func TestConvertMatches(t *testing.T) {
 				LineNumber:       3,
 				OffsetAndLengths: [][2]int32{{0, 1}},
 			}},
+		}, {
+			input: MultilineMatch{
+				Preview: "line1",
+				Start:   LineColumn{1, 1},
+				End:     LineColumn{1, 3},
+			},
+			output: []*LineMatch{
+				{
+					Preview:          "line1",
+					LineNumber:       1,
+					OffsetAndLengths: [][2]int32{{1, 2}},
+				},
+			},
 		}}
 
 		for _, tc := range cases {

--- a/internal/search/result/file_test.go
+++ b/internal/search/result/file_test.go
@@ -36,7 +36,7 @@ func TestConvertMatches(t *testing.T) {
 		})
 
 		t.Run("oneline", func(t *testing.T) {
-			cases := []LineMatch{{
+			cases := []*LineMatch{{
 				Preview:          "abcd",
 				LineNumber:       0,
 				OffsetAndLengths: [][2]int32{{0, 4}},
@@ -65,14 +65,14 @@ func TestConvertMatches(t *testing.T) {
 	t.Run("AsLineMatches", func(t *testing.T) {
 		cases := []struct {
 			input  MultilineMatch
-			output []LineMatch
+			output []*LineMatch
 		}{{
 			input: MultilineMatch{
 				Preview: "line1\nline2\nline3",
 				Start:   LineColumn{1, 1},
 				End:     LineColumn{3, 1},
 			},
-			output: []LineMatch{{
+			output: []*LineMatch{{
 				Preview:          "line1",
 				LineNumber:       1,
 				OffsetAndLengths: [][2]int32{{1, 4}},

--- a/internal/search/result/file_test.go
+++ b/internal/search/result/file_test.go
@@ -86,6 +86,12 @@ func TestConvertMatches(t *testing.T) {
 				OffsetAndLengths: [][2]int32{{0, 1}},
 			}},
 		}}
+
+		for _, tc := range cases {
+			t.Run("", func(t *testing.T) {
+				require.Equal(t, tc.input.AsLineMatches(), tc.output)
+			})
+		}
 	})
 
 	t.Run("AsMultilineMatches", func(t *testing.T) {
@@ -93,24 +99,26 @@ func TestConvertMatches(t *testing.T) {
 			input  LineMatch
 			output []MultilineMatch
 		}{{
-			input: MultilineMatch{
-				Preview: "0.2.4.6.8.10.13.16.19",
-				Line: 42,
-				OffsetAndLengths: [][2]{{2,4}, {8,13}}
+			input: LineMatch{
+				Preview:          "0.2.4.6.8.10.13.16.19",
+				LineNumber:       42,
+				OffsetAndLengths: [][2]int32{{2, 2}, {8, 5}},
 			},
-			output: []LineMatch{{
-				Preview:          "line1",
-				LineNumber:       1,
-				OffsetAndLengths: [][2]int32{{1, 4}},
+			output: []MultilineMatch{{
+				Preview: "0.2.4.6.8.10.13.16.19",
+				Start:   LineColumn{42, 2},
+				End:     LineColumn{42, 4},
 			}, {
-				Preview:          "line2",
-				LineNumber:       2,
-				OffsetAndLengths: [][2]int32{{0, 5}},
-			}, {
-				Preview:          "line3",
-				LineNumber:       3,
-				OffsetAndLengths: [][2]int32{{0, 1}},
+				Preview: "0.2.4.6.8.10.13.16.19",
+				Start:   LineColumn{42, 8},
+				End:     LineColumn{42, 13},
 			}},
 		}}
+
+		for _, tc := range cases {
+			t.Run("", func(t *testing.T) {
+				require.Equal(t, tc.output, tc.input.AsMultilineMatches())
+			})
+		}
 	})
 }

--- a/internal/search/result/file_test.go
+++ b/internal/search/result/file_test.go
@@ -1,0 +1,116 @@
+package result
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestConvertMatches(t *testing.T) {
+	// single line matches should always be roundtrippable
+	t.Run("roundtrip", func(t *testing.T) {
+		t.Run("multiline", func(t *testing.T) {
+			cases := []MultilineMatch{{
+				Preview: "abcd",
+				Start:   LineColumn{0, 0},
+				End:     LineColumn{0, 4},
+			}, {
+				Preview: "abcd",
+				Start:   LineColumn{0, 0},
+				End:     LineColumn{0, 3},
+			}, {
+				Preview: "abcd",
+				Start:   LineColumn{3, 1},
+				End:     LineColumn{3, 2},
+			}}
+
+			for _, tc := range cases {
+				t.Run("", func(t *testing.T) {
+					lineMatches := tc.AsLineMatches()
+					require.Len(t, lineMatches, 1)
+					multilineMatches := lineMatches[0].AsMultilineMatches()
+					require.Len(t, multilineMatches, 1)
+					require.Equal(t, tc, multilineMatches[0])
+				})
+			}
+		})
+
+		t.Run("oneline", func(t *testing.T) {
+			cases := []LineMatch{{
+				Preview:          "abcd",
+				LineNumber:       0,
+				OffsetAndLengths: [][2]int32{{0, 4}},
+			}, {
+				Preview:          "abcd",
+				LineNumber:       0,
+				OffsetAndLengths: [][2]int32{{0, 3}},
+			}, {
+				Preview:          "abcd",
+				LineNumber:       3,
+				OffsetAndLengths: [][2]int32{{1, 1}},
+			}}
+
+			for _, tc := range cases {
+				t.Run("", func(t *testing.T) {
+					multilineMatches := tc.AsMultilineMatches()
+					require.Len(t, multilineMatches, 1)
+					lineMatches := multilineMatches[0].AsLineMatches()
+					require.Len(t, lineMatches, 1)
+					require.Equal(t, tc, lineMatches[0])
+				})
+			}
+		})
+	})
+
+	t.Run("AsLineMatches", func(t *testing.T) {
+		cases := []struct {
+			input  MultilineMatch
+			output []LineMatch
+		}{{
+			input: MultilineMatch{
+				Preview: "line1\nline2\nline3",
+				Start:   LineColumn{1, 1},
+				End:     LineColumn{3, 1},
+			},
+			output: []LineMatch{{
+				Preview:          "line1",
+				LineNumber:       1,
+				OffsetAndLengths: [][2]int32{{1, 4}},
+			}, {
+				Preview:          "line2",
+				LineNumber:       2,
+				OffsetAndLengths: [][2]int32{{0, 5}},
+			}, {
+				Preview:          "line3",
+				LineNumber:       3,
+				OffsetAndLengths: [][2]int32{{0, 1}},
+			}},
+		}}
+	})
+
+	t.Run("AsMultilineMatches", func(t *testing.T) {
+		cases := []struct {
+			input  LineMatch
+			output []MultilineMatch
+		}{{
+			input: MultilineMatch{
+				Preview: "0.2.4.6.8.10.13.16.19",
+				Line: 42,
+				OffsetAndLengths: [][2]{{2,4}, {8,13}}
+			},
+			output: []LineMatch{{
+				Preview:          "line1",
+				LineNumber:       1,
+				OffsetAndLengths: [][2]int32{{1, 4}},
+			}, {
+				Preview:          "line2",
+				LineNumber:       2,
+				OffsetAndLengths: [][2]int32{{0, 5}},
+			}, {
+				Preview:          "line3",
+				LineNumber:       3,
+				OffsetAndLengths: [][2]int32{{0, 1}},
+			}},
+		}}
+	})
+}

--- a/internal/search/searcher/search.go
+++ b/internal/search/searcher/search.go
@@ -2,7 +2,6 @@ package searcher
 
 import (
 	"context"
-	"strings"
 	"time"
 
 	"github.com/inconshreveable/log15"
@@ -216,14 +215,13 @@ func newToMatches(repo types.MinimalRepo, commit api.CommitID, rev *string) func
 			lineMatches := make([]result.MultilineMatch, 0, len(fm.LineMatches))
 			for _, lm := range fm.LineMatches {
 				for _, ol := range lm.OffsetAndLengths {
-					newlineCount := strings.Count(lm.Preview, "\n")
 					lineMatches = append(lineMatches, result.MultilineMatch{
 						Start: result.LineColumn{
 							Line:   int32(lm.LineNumber),
 							Column: int32(ol[0]),
 						},
 						End: result.LineColumn{
-							Line:   int32(lm.LineNumber + newlineCount),
+							Line:   int32(lm.LineNumber),
 							Column: int32(ol[0] + ol[1]),
 						},
 						Preview: lm.Preview,

--- a/internal/search/searcher/search.go
+++ b/internal/search/searcher/search.go
@@ -2,6 +2,7 @@ package searcher
 
 import (
 	"context"
+	"strings"
 	"time"
 
 	"github.com/inconshreveable/log15"
@@ -215,13 +216,14 @@ func newToMatches(repo types.MinimalRepo, commit api.CommitID, rev *string) func
 			lineMatches := make([]result.MultilineMatch, 0, len(fm.LineMatches))
 			for _, lm := range fm.LineMatches {
 				for _, ol := range lm.OffsetAndLengths {
+					newlineCount := strings.Count(lm.Preview, "\n")
 					lineMatches = append(lineMatches, result.MultilineMatch{
 						Start: result.LineColumn{
 							Line:   int32(lm.LineNumber),
 							Column: int32(ol[0]),
 						},
 						End: result.LineColumn{
-							Line:   int32(lm.LineNumber),
+							Line:   int32(lm.LineNumber + newlineCount),
 							Column: int32(ol[0] + ol[1]),
 						},
 						Preview: lm.Preview,

--- a/internal/search/searcher/search.go
+++ b/internal/search/searcher/search.go
@@ -212,17 +212,21 @@ func newToMatches(repo types.MinimalRepo, commit api.CommitID, rev *string) func
 	return func(searcherMatches []*protocol.FileMatch) []result.Match {
 		matches := make([]result.Match, 0, len(searcherMatches))
 		for _, fm := range searcherMatches {
-			lineMatches := make([]*result.LineMatch, 0, len(fm.LineMatches))
+			lineMatches := make([]result.MultilineMatch, 0, len(fm.LineMatches))
 			for _, lm := range fm.LineMatches {
-				ranges := make([][2]int32, 0, len(lm.OffsetAndLengths))
 				for _, ol := range lm.OffsetAndLengths {
-					ranges = append(ranges, [2]int32{int32(ol[0]), int32(ol[1])})
+					lineMatches = append(lineMatches, result.MultilineMatch{
+						Start: result.LineColumn{
+							Line:   int32(lm.LineNumber),
+							Column: int32(ol[0]),
+						},
+						End: result.LineColumn{
+							Line:   int32(lm.LineNumber),
+							Column: int32(ol[0] + ol[1]),
+						},
+						Preview: lm.Preview,
+					})
 				}
-				lineMatches = append(lineMatches, &result.LineMatch{
-					Preview:          lm.Preview,
-					OffsetAndLengths: ranges,
-					LineNumber:       int32(lm.LineNumber),
-				})
 			}
 
 			matches = append(matches, &result.FileMatch{
@@ -232,8 +236,8 @@ func newToMatches(repo types.MinimalRepo, commit api.CommitID, rev *string) func
 					CommitID: commit,
 					InputRev: rev,
 				},
-				LineMatches: lineMatches,
-				LimitHit:    fm.LimitHit,
+				MultilineMatches: lineMatches,
+				LimitHit:         fm.LimitHit,
 			})
 		}
 		return matches

--- a/internal/search/streaming/search_filters_test.go
+++ b/internal/search/streaming/search_filters_test.go
@@ -60,9 +60,7 @@ func TestSearchFiltersUpdate(t *testing.T) {
 							File: result.File{
 								Repo: repo,
 							},
-							LineMatches: []*result.LineMatch{{
-								OffsetAndLengths: make([][2]int32, 2),
-							}},
+							MultilineMatches: make([]result.MultilineMatch, 2),
 						},
 					},
 				},

--- a/internal/search/streaming/stream_test.go
+++ b/internal/search/streaming/stream_test.go
@@ -173,13 +173,11 @@ func TestWithSelect(t *testing.T) {
   {
     "Path": "pokeman/",
     "MultilineMatches": null,
-    "LineMatches": null,
     "LimitHit": false
   },
   {
     "Path": "digiman/",
     "MultilineMatches": null,
-    "LineMatches": null,
     "LimitHit": false
   }
 ]`).Equal(t, test("file.directory"))
@@ -188,19 +186,16 @@ func TestWithSelect(t *testing.T) {
   {
     "Path": "pokeman/charmandar",
     "MultilineMatches": null,
-    "LineMatches": null,
     "LimitHit": false
   },
   {
     "Path": "pokeman/bulbosaur",
     "MultilineMatches": null,
-    "LineMatches": null,
     "LimitHit": false
   },
   {
     "Path": "digiman/ummm",
     "MultilineMatches": null,
-    "LineMatches": null,
     "LimitHit": false
   }
 ]`).Equal(t, test("file"))
@@ -232,7 +227,6 @@ func TestWithSelect(t *testing.T) {
         }
       }
     ],
-    "LineMatches": null,
     "LimitHit": false
   },
   {
@@ -250,7 +244,6 @@ func TestWithSelect(t *testing.T) {
         }
       }
     ],
-    "LineMatches": null,
     "LimitHit": false
   },
   {
@@ -268,7 +261,6 @@ func TestWithSelect(t *testing.T) {
         }
       }
     ],
-    "LineMatches": null,
     "LimitHit": false
   },
   {
@@ -286,7 +278,6 @@ func TestWithSelect(t *testing.T) {
         }
       }
     ],
-    "LineMatches": null,
     "LimitHit": false
   }
 ]`).Equal(t, test("content"))

--- a/internal/search/streaming/stream_test.go
+++ b/internal/search/streaming/stream_test.go
@@ -141,28 +141,20 @@ func TestWithSelect(t *testing.T) {
 		return SearchEvent{
 			Results: []result.Match{
 				&result.FileMatch{
-					File: result.File{Path: "pokeman/charmandar"},
-					LineMatches: []*result.LineMatch{{
-						OffsetAndLengths: make([][2]int32, 1),
-					}},
+					File:             result.File{Path: "pokeman/charmandar"},
+					MultilineMatches: make([]result.MultilineMatch, 1),
 				},
 				&result.FileMatch{
-					File: result.File{Path: "pokeman/charmandar"},
-					LineMatches: []*result.LineMatch{{
-						OffsetAndLengths: make([][2]int32, 1),
-					}},
+					File:             result.File{Path: "pokeman/charmandar"},
+					MultilineMatches: make([]result.MultilineMatch, 1),
 				},
 				&result.FileMatch{
-					File: result.File{Path: "pokeman/bulbosaur"},
-					LineMatches: []*result.LineMatch{{
-						OffsetAndLengths: make([][2]int32, 1),
-					}},
+					File:             result.File{Path: "pokeman/bulbosaur"},
+					MultilineMatches: make([]result.MultilineMatch, 1),
 				},
 				&result.FileMatch{
-					File: result.File{Path: "digiman/ummm"},
-					LineMatches: []*result.LineMatch{{
-						OffsetAndLengths: make([][2]int32, 1),
-					}},
+					File:             result.File{Path: "digiman/ummm"},
+					MultilineMatches: make([]result.MultilineMatch, 1),
 				},
 			},
 		}
@@ -180,11 +172,13 @@ func TestWithSelect(t *testing.T) {
 	autogold.Want("dedupe paths for select:file.directory", `[
   {
     "Path": "pokeman/",
+    "MultilineMatches": null,
     "LineMatches": null,
     "LimitHit": false
   },
   {
     "Path": "digiman/",
+    "MultilineMatches": null,
     "LineMatches": null,
     "LimitHit": false
   }
@@ -193,16 +187,19 @@ func TestWithSelect(t *testing.T) {
 	autogold.Want("dedupe paths select:file", `[
   {
     "Path": "pokeman/charmandar",
+    "MultilineMatches": null,
     "LineMatches": null,
     "LimitHit": false
   },
   {
     "Path": "pokeman/bulbosaur",
+    "MultilineMatches": null,
     "LineMatches": null,
     "LimitHit": false
   },
   {
     "Path": "digiman/ummm",
+    "MultilineMatches": null,
     "LineMatches": null,
     "LimitHit": false
   }
@@ -211,76 +208,85 @@ func TestWithSelect(t *testing.T) {
 	autogold.Want("don't dedupe file matches for select:content", `[
   {
     "Path": "pokeman/charmandar",
-    "LineMatches": [
+    "MultilineMatches": [
       {
         "Preview": "",
-        "OffsetAndLengths": [
-          [
-            0,
-            0
-          ]
-        ],
-        "LineNumber": 0
+        "Start": {
+          "Line": 0,
+          "Column": 0
+        },
+        "End": {
+          "Line": 0,
+          "Column": 0
+        }
       },
       {
         "Preview": "",
-        "OffsetAndLengths": [
-          [
-            0,
-            0
-          ]
-        ],
-        "LineNumber": 0
+        "Start": {
+          "Line": 0,
+          "Column": 0
+        },
+        "End": {
+          "Line": 0,
+          "Column": 0
+        }
       }
     ],
+    "LineMatches": null,
     "LimitHit": false
   },
   {
     "Path": "pokeman/charmandar",
-    "LineMatches": [
+    "MultilineMatches": [
       {
         "Preview": "",
-        "OffsetAndLengths": [
-          [
-            0,
-            0
-          ]
-        ],
-        "LineNumber": 0
+        "Start": {
+          "Line": 0,
+          "Column": 0
+        },
+        "End": {
+          "Line": 0,
+          "Column": 0
+        }
       }
     ],
+    "LineMatches": null,
     "LimitHit": false
   },
   {
     "Path": "pokeman/bulbosaur",
-    "LineMatches": [
+    "MultilineMatches": [
       {
         "Preview": "",
-        "OffsetAndLengths": [
-          [
-            0,
-            0
-          ]
-        ],
-        "LineNumber": 0
+        "Start": {
+          "Line": 0,
+          "Column": 0
+        },
+        "End": {
+          "Line": 0,
+          "Column": 0
+        }
       }
     ],
+    "LineMatches": null,
     "LimitHit": false
   },
   {
     "Path": "digiman/ummm",
-    "LineMatches": [
+    "MultilineMatches": [
       {
         "Preview": "",
-        "OffsetAndLengths": [
-          [
-            0,
-            0
-          ]
-        ],
-        "LineNumber": 0
+        "Start": {
+          "Line": 0,
+          "Column": 0
+        },
+        "End": {
+          "Line": 0,
+          "Column": 0
+        }
       }
     ],
+    "LineMatches": null,
     "LimitHit": false
   }
 ]`).Equal(t, test("content"))

--- a/internal/search/textsearch/textsearch_test.go
+++ b/internal/search/textsearch/textsearch_test.go
@@ -390,6 +390,15 @@ func TestFileMatch_Limit(t *testing.T) {
 			expRemainingLimit:   0,
 			wantLimitHit:        false,
 		},
+		{
+			// An empty FileMatch should still count against the limit
+			numMultilineMatches:    0,
+			numSymbolMatches:       0,
+			limit:                  1,
+			expNumSymbolMatches:    0,
+			expNumMultilineMatches: 0,
+			wantLimitHit:           true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/search/textsearch/textsearch_test.go
+++ b/internal/search/textsearch/textsearch_test.go
@@ -340,6 +340,7 @@ func TestFileMatch_Limit(t *testing.T) {
 		expNumMultilineMatches int
 		expNumSymbolMatches    int
 		expRemainingLimit      int
+		wantLimitHit           bool
 	}{
 		{
 			numMultilineMatches:    3,
@@ -347,6 +348,7 @@ func TestFileMatch_Limit(t *testing.T) {
 			limit:                  1,
 			expNumMultilineMatches: 1,
 			expRemainingLimit:      0,
+			wantLimitHit:           true,
 		},
 		{
 			numMultilineMatches: 0,
@@ -354,6 +356,7 @@ func TestFileMatch_Limit(t *testing.T) {
 			limit:               1,
 			expNumSymbolMatches: 1,
 			expRemainingLimit:   0,
+			wantLimitHit:        true,
 		},
 		{
 			numMultilineMatches:    3,
@@ -361,6 +364,7 @@ func TestFileMatch_Limit(t *testing.T) {
 			limit:                  5,
 			expNumMultilineMatches: 3,
 			expRemainingLimit:      2,
+			wantLimitHit:           false,
 		},
 		{
 			numMultilineMatches: 0,
@@ -368,6 +372,7 @@ func TestFileMatch_Limit(t *testing.T) {
 			limit:               5,
 			expNumSymbolMatches: 3,
 			expRemainingLimit:   2,
+			wantLimitHit:        false,
 		},
 		{
 			numMultilineMatches:    3,
@@ -375,6 +380,7 @@ func TestFileMatch_Limit(t *testing.T) {
 			limit:                  3,
 			expNumMultilineMatches: 3,
 			expRemainingLimit:      0,
+			wantLimitHit:           false,
 		},
 		{
 			numMultilineMatches: 0,
@@ -382,6 +388,7 @@ func TestFileMatch_Limit(t *testing.T) {
 			limit:               3,
 			expNumSymbolMatches: 3,
 			expRemainingLimit:   0,
+			wantLimitHit:        false,
 		},
 	}
 

--- a/internal/search/textsearch/textsearch_test.go
+++ b/internal/search/textsearch/textsearch_test.go
@@ -397,7 +397,7 @@ func TestFileMatch_Limit(t *testing.T) {
 			limit:                  1,
 			expNumSymbolMatches:    0,
 			expNumMultilineMatches: 0,
-			wantLimitHit:           true,
+			wantLimitHit:           false,
 		},
 	}
 
@@ -415,6 +415,7 @@ func TestFileMatch_Limit(t *testing.T) {
 			require.Equal(t, tt.expNumMultilineMatches, len(fileMatch.MultilineMatches))
 			require.Equal(t, tt.expNumSymbolMatches, len(fileMatch.Symbols))
 			require.Equal(t, tt.expRemainingLimit, got)
+			require.Equal(t, tt.wantLimitHit, fileMatch.LimitHit)
 		})
 	}
 }

--- a/internal/search/textsearch/textsearch_test.go
+++ b/internal/search/textsearch/textsearch_test.go
@@ -5,13 +5,13 @@ import (
 	"crypto/md5"
 	"encoding/binary"
 	"fmt"
-	"github.com/stretchr/testify/require"
 	"reflect"
 	"sort"
 	"testing"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"

--- a/internal/search/textsearch/textsearch_test.go
+++ b/internal/search/textsearch/textsearch_test.go
@@ -7,9 +7,7 @@ import (
 	"fmt"
 	"reflect"
 	"sort"
-	"strings"
 	"testing"
-	"testing/quick"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
@@ -333,78 +331,80 @@ func mkRepos(names ...string) []types.MinimalRepo {
 	return repos
 }
 
-func TestFileMatch_Limit(t *testing.T) {
-	desc := func(fm *result.FileMatch) string {
-		parts := []string{fmt.Sprintf("symbols=%d", len(fm.Symbols))}
-		for _, lm := range fm.LineMatches {
-			parts = append(parts, fmt.Sprintf("lm=%d", len(lm.OffsetAndLengths)))
-		}
-		return strings.Join(parts, " ")
-	}
-
-	f := func(lineMatches []result.LineMatch, symbols []int, limitInput uint32) bool {
-		fm := &result.FileMatch{
-			// SearchSymbolResult fails to generate due to private fields. So
-			// we just generate a slice of ints and use its length. This is
-			// fine for limit which only looks at the slice and not in it.
-			Symbols: make([]*result.SymbolMatch, len(symbols)),
-		}
-		// We don't use *LineMatch as args since quick can generate nil.
-		for _, lm := range lineMatches {
-			lm := lm
-			fm.LineMatches = append(fm.LineMatches, &lm)
-		}
-		beforeDesc := desc(fm)
-
-		// It isn't interesting to test limit > ResultCount, so we bound it to
-		// [1, ResultCount]
-		count := fm.ResultCount()
-		limit := (int(limitInput) % count) + 1
-
-		after := fm.Limit(limit)
-		newCount := fm.ResultCount()
-
-		if after == 0 && newCount == limit {
-			return true
-		}
-
-		afterDesc := desc(fm)
-		t.Logf("failed limit=%d count=%d => after=%d newCount=%d:\nbeforeDesc: %s\nafterDesc:  %s", limit, count, after, newCount, beforeDesc, afterDesc)
-		return false
-	}
-	t.Run("quick", func(t *testing.T) {
-		if err := quick.Check(f, nil); err != nil {
-			t.Error("quick check failed")
-		}
-	})
-
-	cases := []struct {
-		Name        string
-		LineMatches []result.LineMatch
-		Symbols     int
-		Limit       int
-	}{{
-		Name: "1 line match",
-		LineMatches: []result.LineMatch{{
-			OffsetAndLengths: [][2]int32{{1, 1}},
-		}},
-		Limit: 1,
-	}, {
-		Name:  "file path match",
-		Limit: 1,
-	}, {
-		Name:  "file path match 2",
-		Limit: 2,
-	}}
-
-	for _, c := range cases {
-		t.Run(c.Name, func(t *testing.T) {
-			if !f(c.LineMatches, make([]int, c.Symbols), uint32(c.Limit)) {
-				t.Error("failed")
-			}
-		})
-	}
-}
+//func TestFileMatch_Limit(t *testing.T) {
+//	desc := func(fm *result.FileMatch) string {
+//		parts := []string{fmt.Sprintf("symbols=%d", len(fm.Symbols))}
+//		// TODO: fix this test after switching to MultilineMatch
+//		for _, lm := range fm.LineMatches {
+//			parts = append(parts, fmt.Sprintf("lm=%d", len(lm.OffsetAndLengths)))
+//		}
+//		return strings.Join(parts, " ")
+//	}
+//
+//	f := func(lineMatches []result.LineMatch, symbols []int, limitInput uint32) bool {
+//		fm := &result.FileMatch{
+//			// SearchSymbolResult fails to generate due to private fields. So
+//			// we just generate a slice of ints and use its length. This is
+//			// fine for limit which only looks at the slice and not in it.
+//			Symbols: make([]*result.SymbolMatch, len(symbols)),
+//		}
+//		// We don't use *LineMatch as args since quick can generate nil.
+//		for _, lm := range lineMatches {
+//			lm := lm
+//			fm.LineMatches = append(fm.LineMatches, &lm)
+//		}
+//		beforeDesc := desc(fm)
+//
+//		// It isn't interesting to test limit > ResultCount, so we bound it to
+//		// [1, ResultCount]
+//		count := fm.ResultCount()
+//		limit := (int(limitInput) % count) + 1
+//
+//		after := fm.Limit(limit)
+//		newCount := fm.ResultCount()
+//
+//		if after == 0 && newCount == limit {
+//			return true
+//		}
+//
+//		afterDesc := desc(fm)
+//		t.Logf("failed limit=%d count=%d => after=%d newCount=%d:\nbeforeDesc: %s\nafterDesc:  %s", limit, count, after, newCount, beforeDesc, afterDesc)
+//		return false
+//	}
+//	t.Run("quick", func(t *testing.T) {
+//		if err := quick.Check(f, nil); err != nil {
+//			t.Error("quick check failed")
+//		}
+//	})
+//
+//	cases := []struct {
+//		Name        string
+//		LineMatches []result.LineMatch
+//		Symbols     int
+//		Limit       int
+//	}{{
+//		Name: "1 line match",
+//		LineMatches: []result.LineMatch{{
+//			OffsetAndLengths: [][2]int32{{1, 1}},
+//		}},
+//		Limit: 1,
+//	}, {
+//		Name:  "file path match",
+//		Limit: 1,
+//	}, {
+//		Name:  "file path match 2",
+//		Limit: 2,
+//	}}
+//	// TODO: add test case for limit > len(Symbols)
+//
+//	for _, c := range cases {
+//		t.Run(c.Name, func(t *testing.T) {
+//			if !f(c.LineMatches, make([]int, c.Symbols), uint32(c.Limit)) {
+//				t.Error("failed")
+//			}
+//		})
+//	}
+//}
 
 // RunRepoSubsetTextSearch is a convenience function that simulates the RepoSubsetTextSearch job.
 func RunRepoSubsetTextSearch(

--- a/internal/search/zoekt/indexed_search.go
+++ b/internal/search/zoekt/indexed_search.go
@@ -408,15 +408,14 @@ func zoektFileMatchToMultilineMatches(file *zoekt.FileMatch) []result.MultilineM
 			continue
 		}
 
-		offsets := make([][2]int32, len(l.LineFragments))
-		for k, m := range l.LineFragments {
+		for _, m := range l.LineFragments {
 			offset := utf8.RuneCount(l.Line[:m.LineOffset])
 			length := utf8.RuneCount(l.Line[m.LineOffset : m.LineOffset+m.MatchLength])
-			offsets[k] = [2]int32{int32(offset), int32(length)}
 
 			lines = append(lines, result.MultilineMatch{
 				Preview: string(l.Line),
 				Start: result.LineColumn{
+					// zoekt line numbers are 1-based rather than 0-based so subtract 1
 					Line:   int32(l.LineNumber - 1),
 					Column: int32(offset),
 				},

--- a/internal/search/zoekt/indexed_search.go
+++ b/internal/search/zoekt/indexed_search.go
@@ -366,7 +366,7 @@ func sendMatches(event *zoekt.SearchResult, getRepoInputRev repoRevFunc, typ sea
 			continue
 		}
 
-		var lines []*result.LineMatch
+		var lines []result.MultilineMatch
 		if typ != search.SymbolRequest {
 			lines = zoektFileMatchToLineMatches(&file)
 		}
@@ -379,8 +379,8 @@ func sendMatches(event *zoekt.SearchResult, getRepoInputRev repoRevFunc, typ sea
 				symbols = zoektFileMatchToSymbolResults(repo, inputRev, &file)
 			}
 			fm := result.FileMatch{
-				LineMatches: lines,
-				Symbols:     symbols,
+				MultilineMatches: lines,
+				Symbols:          symbols,
 				File: result.File{
 					InputRev: &inputRev,
 					CommitID: api.CommitID(file.Version),
@@ -400,8 +400,8 @@ func sendMatches(event *zoekt.SearchResult, getRepoInputRev repoRevFunc, typ sea
 	})
 }
 
-func zoektFileMatchToLineMatches(file *zoekt.FileMatch) []*result.LineMatch {
-	lines := make([]*result.LineMatch, 0, len(file.LineMatches))
+func zoektFileMatchToLineMatches(file *zoekt.FileMatch) []result.MultilineMatch {
+	lines := make([]result.MultilineMatch, 0, len(file.LineMatches))
 
 	for _, l := range file.LineMatches {
 		if l.FileName {
@@ -413,12 +413,19 @@ func zoektFileMatchToLineMatches(file *zoekt.FileMatch) []*result.LineMatch {
 			offset := utf8.RuneCount(l.Line[:m.LineOffset])
 			length := utf8.RuneCount(l.Line[m.LineOffset : m.LineOffset+m.MatchLength])
 			offsets[k] = [2]int32{int32(offset), int32(length)}
+
+			lines = append(lines, result.MultilineMatch{
+				Preview: string(l.Line),
+				Start: result.LineColumn{
+					Line:   int32(l.LineNumber),
+					Column: int32(offset),
+				},
+				End: result.LineColumn{
+					Line:   int32(l.LineNumber),
+					Column: int32(offset + length),
+				},
+			})
 		}
-		lines = append(lines, &result.LineMatch{
-			Preview:          string(l.Line),
-			LineNumber:       int32(l.LineNumber - 1),
-			OffsetAndLengths: offsets,
-		})
 	}
 
 	return lines

--- a/internal/search/zoekt/indexed_search.go
+++ b/internal/search/zoekt/indexed_search.go
@@ -368,7 +368,7 @@ func sendMatches(event *zoekt.SearchResult, getRepoInputRev repoRevFunc, typ sea
 
 		var lines []result.MultilineMatch
 		if typ != search.SymbolRequest {
-			lines = zoektFileMatchToLineMatches(&file)
+			lines = zoektFileMatchToMultilineMatches(&file)
 		}
 
 		for _, inputRev := range inputRevs {
@@ -400,7 +400,7 @@ func sendMatches(event *zoekt.SearchResult, getRepoInputRev repoRevFunc, typ sea
 	})
 }
 
-func zoektFileMatchToLineMatches(file *zoekt.FileMatch) []result.MultilineMatch {
+func zoektFileMatchToMultilineMatches(file *zoekt.FileMatch) []result.MultilineMatch {
 	lines := make([]result.MultilineMatch, 0, len(file.LineMatches))
 
 	for _, l := range file.LineMatches {

--- a/internal/search/zoekt/indexed_search.go
+++ b/internal/search/zoekt/indexed_search.go
@@ -417,11 +417,11 @@ func zoektFileMatchToLineMatches(file *zoekt.FileMatch) []result.MultilineMatch 
 			lines = append(lines, result.MultilineMatch{
 				Preview: string(l.Line),
 				Start: result.LineColumn{
-					Line:   int32(l.LineNumber),
+					Line:   int32(l.LineNumber - 1),
 					Column: int32(offset),
 				},
 				End: result.LineColumn{
-					Line:   int32(l.LineNumber),
+					Line:   int32(l.LineNumber - 1),
 					Column: int32(offset + length),
 				},
 			})


### PR DESCRIPTION
This PR introduces the `MultilineMatch` type and transitions `result.FileMatch` to use that instead of `LineMatch`.

Change overview:
- Introduce the `MultilineMatch` type
- Replace `FileMatch.LineMatches` with `FileMatch.MultilineMatches` in the search backend
- Provide methods `AsLineMatches()`, `AsMultilineMatches()`, and `MultilineSliceAsLineMatchSlice()` to convert between `LineMatch` and `MultilineMatch`, so other services which still rely on `LineMatch` can remain unchanged for now
- Fix result limiting, which previously did not limit symbol results at all

A noteworthy thing here is that we can birectionally convert between `LineMatch` and `MultilineMatch`. The important thing about this is that we can start using `MultilineMatch` throughout the `frontend` process without changing any of the APIs into or out of `frontend`. That then allows us to merge this change independently from any changes to zoekt, searcher, gitserver, or search clients. Yay!

The next steps will be to update the search backends (particularly zoekt and searcher) to return multiline matches. Following that, we we update the GraphQL and streaming APIs to return multiline matches and deprecate the `LineMatch` API. 

This PR depends on a [change to Comby](https://github.com/comby-tools/comby/pull/337), so cannot be merged until the sourcegraph deployment has been updated to use that version.

## Test plan
Unit tests for new functionality. Manually verify correct preview and highlight range for multi-line structural and regex search results.