### PR TITLE
Insights/unify/non global iterator

### DIFF
--- a/enterprise/internal/insights/discovery/all_repos_iterator.go
+++ b/enterprise/internal/insights/discovery/all_repos_iterator.go
@@ -15,7 +15,7 @@ import (
 )
 
 type RepoIterator interface {
-	ForEach() func(ctx context.Context, each func(repoName string, id api.RepoID) error) error
+	ForEach(ctx context.Context, each func(repoName string, id api.RepoID) error) error
 }
 
 // IndexableReposLister is a subset of the API exposed by the backend.ListIndexable.

--- a/enterprise/internal/insights/discovery/all_repos_iterator.go
+++ b/enterprise/internal/insights/discovery/all_repos_iterator.go
@@ -14,6 +14,10 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
+type RepoIterator interface {
+	ForEach() func(ctx context.Context, each func(repoName string, id api.RepoID) error) error
+}
+
 // IndexableReposLister is a subset of the API exposed by the backend.ListIndexable.
 type IndexableReposLister interface {
 	List(ctx context.Context) ([]types.MinimalRepo, error)

--- a/enterprise/internal/insights/discovery/scoped_repo_iterator.go
+++ b/enterprise/internal/insights/discovery/scoped_repo_iterator.go
@@ -17,16 +17,14 @@ type ScopedRepoIterator struct {
 	repos []simpleRepo
 }
 
-func (s *ScopedRepoIterator) ForEach() func(ctx context.Context, each func(repoName string, id api.RepoID) error) error {
-	return func(ctx context.Context, each func(repoName string, id api.RepoID) error) error {
-		for _, repo := range s.repos {
-			err := each(repo.name, repo.id)
-			if err != nil {
-				return err
-			}
+func (s *ScopedRepoIterator) ForEach(ctx context.Context, each func(repoName string, id api.RepoID) error) error {
+	for _, repo := range s.repos {
+		err := each(repo.name, repo.id)
+		if err != nil {
+			return err
 		}
-		return nil
 	}
+	return nil
 }
 
 func NewScopedRepoIterator(ctx context.Context, repoNames []string, store RepoStore) (*ScopedRepoIterator, error) {

--- a/enterprise/internal/insights/discovery/scoped_repo_iterator.go
+++ b/enterprise/internal/insights/discovery/scoped_repo_iterator.go
@@ -1,0 +1,53 @@
+package discovery
+
+import (
+	"context"
+
+	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+type simpleRepo struct {
+	name string
+	id   api.RepoID
+}
+
+type ScopedRepoIterator struct {
+	repos []simpleRepo
+}
+
+func (s *ScopedRepoIterator) ForEach() func(ctx context.Context, each func(repoName string, id api.RepoID) error) error {
+	return func(ctx context.Context, each func(repoName string, id api.RepoID) error) error {
+		for _, repo := range s.repos {
+			err := each(repo.name, repo.id)
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+}
+
+func NewScopedRepoIterator(ctx context.Context, repoNames []string, store RepoStore) (*ScopedRepoIterator, error) {
+	repos, err := loadRepoIds(ctx, repoNames, store)
+	if err != nil {
+		return nil, err
+	}
+	return &ScopedRepoIterator{repos: repos}, nil
+}
+
+func loadRepoIds(ctx context.Context, repoNames []string, repoStore RepoStore) ([]simpleRepo, error) {
+	list, err := repoStore.List(ctx, database.ReposListOptions{Names: repoNames})
+	if err != nil {
+		return nil, errors.Wrap(err, "repoStore.List")
+	}
+	var results []simpleRepo
+	for _, repo := range list {
+		results = append(results, simpleRepo{
+			name: string(repo.Name),
+			id:   repo.ID,
+		})
+	}
+	return results, nil
+}

--- a/enterprise/internal/insights/discovery/scoped_repo_iterator_test.go
+++ b/enterprise/internal/insights/discovery/scoped_repo_iterator_test.go
@@ -1,0 +1,57 @@
+package discovery
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/hexops/autogold"
+	"github.com/sourcegraph/sourcegraph/internal/api"
+
+	"github.com/sourcegraph/sourcegraph/internal/types"
+)
+
+func TestScopedRepoIteratorForEach(t *testing.T) {
+	repoStore := NewMockRepoStore()
+	mockResponse := []*types.Repo{{
+		ID:   5,
+		Name: "github.com/org/repo",
+	}, {
+		ID:   6,
+		Name: "gitlab.com/org1/repo1",
+	}}
+	repoStore.ListFunc.SetDefaultReturn(mockResponse, nil)
+
+	var names []string
+	for _, repo := range mockResponse {
+		names = append(names, string(repo.Name))
+	}
+
+	iterator, err := NewScopedRepoIterator(context.Background(), names, repoStore)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// verify the names argument actually matches what is expected and we arent just trusting a mock blindly
+	if !reflect.DeepEqual(repoStore.ListFunc.History()[0].Arg1.Names, names) {
+		t.Error("argument mismatch on repo names")
+	}
+
+	var gotNames []string
+	var gotIds []api.RepoID
+	err = iterator.ForEach(context.Background(), func(repoName string, id api.RepoID) error {
+		gotNames = append(gotNames, repoName)
+		gotIds = append(gotIds, id)
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("expect_equal_repo_names", func(t *testing.T) {
+		autogold.Want("expect_equal_repo_names", []string{"github.com/org/repo", "gitlab.com/org1/repo1"}).Equal(t, gotNames)
+	})
+	t.Run("expect_equal_repo_ids", func(t *testing.T) {
+		autogold.Want("expect_equal_repo_ids", []api.RepoID{api.RepoID(5), api.RepoID(6)}).Equal(t, gotIds)
+	})
+}


### PR DESCRIPTION
Part of https://github.com/sourcegraph/sourcegraph/issues/35580

Adds a new iterator that will preload necessary repo metadata from a set of repository names, and satisfy the interface of the repository iterator that the backfiller uses.


## Test plan

I loaded this up and replaced the `allRepoIterator` in the `historical_enqueuer` with a scoped iterator to a single repo., and generated a backend insight. As expected, it only ran over the single repository.

<img width="829" alt="image" src="https://user-images.githubusercontent.com/5090588/169615235-a6713d12-ab56-4e1f-b2ff-506ea4584460.png">

