### PR TITLE
Revert "bump comby version to 1.7.1"

### DIFF
--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -11,5 +11,3 @@ ignored:
 - DL3018
 # Noisy: Multiple consecutive `RUN` instructions. Consider consolidation.
 - DL3059
-# Noisy: this lint triggers after unrelated changes are made, so @rvantonder decided to suppress it.
-- DL3047

--- a/cmd/searcher/Dockerfile
+++ b/cmd/searcher/Dockerfile
@@ -5,12 +5,12 @@
 
 FROM sourcegraph/alpine-3.14:142406_2022-04-14_8836ac3499f4@sha256:2a2d1cbaec78882661fe1aa5b0a4af0c23a37be2ea9ff8aadc2da5b80852c233
 
-RUN apk --no-cache add pcre sqlite-libs libev
+RUN apk --no-cache add pcre sqlite-libs
 
 # The comby/comby image is a small binary-only distribution. See the bin and src directories
 # here: https://github.com/comby-tools/comby/tree/master/dockerfiles/alpine
 # hadolint ignore=DL3022
-COPY --from=comby/comby:1.7.1@sha256:6a581342b15e0032e6293ea2f4827af70f33646106b7c8900315bcc7d4b63b1a /usr/local/bin/comby /usr/local/bin/comby
+COPY --from=comby/comby:0.18.4@sha256:b47ce282778bfea7f80d45f5ef0cc546ba0d6347baccebaf171a7866143b2593 /usr/local/bin/comby /usr/local/bin/comby
 
 ARG COMMIT_SHA="unknown"
 ARG DATE="unknown"

--- a/cmd/server/Dockerfile
+++ b/cmd/server/Dockerfile
@@ -60,7 +60,7 @@ RUN apk add --no-cache --verbose \
     'redis>=5.0' \
     python2 \
     python3 \
-    'nginx>=1.18.0' openssh-client pcre sqlite-libs libev su-exec 'nodejs-current>=14.5.0' \
+    'nginx>=1.18.0' openssh-client pcre sqlite-libs su-exec 'nodejs-current>=14.5.0' \
     # We require libstdc++ for p4-fusion
     libstdc++
 
@@ -68,7 +68,7 @@ RUN apk add --no-cache --verbose \
 # the ENV variables from its Dockerfile (https://github.com/sourcegraph/syntect_server/blob/master/Dockerfile)
 # have been appropriately set in cmd/server/shared/shared.go.
 # hadolint ignore=DL3022
-COPY --from=comby/comby:1.7.1@sha256:6a581342b15e0032e6293ea2f4827af70f33646106b7c8900315bcc7d4b63b1a /usr/local/bin/comby /usr/local/bin/comby
+COPY --from=comby/comby:0.18.4@sha256:b47ce282778bfea7f80d45f5ef0cc546ba0d6347baccebaf171a7866143b2593 /usr/local/bin/comby /usr/local/bin/comby
 # hadolint ignore=DL3022
 COPY --from=docker.io/sourcegraph/syntect_server:21-08-31_c330964@sha256:759f331a474d2a67b811a1b374b0b24a4661446a2d8e9b211f51ea8ae95e1130 /syntect_server /usr/local/bin/
 
@@ -114,7 +114,6 @@ COPY --from=coursier /usr/local/bin/coursier /usr/local/bin/coursier
 
 # This is a trick to include libraries required by p4,
 # please refer to https://blog.tilander.org/docker-perforce/
-# hadolint ignore=DL4006
 RUN wget -O - https://github.com/jtilander/p4d/raw/4600d741720f85d77852dcca7c182e96ad613358/lib/lib-x64.tgz | tar zx --directory /
 
 # hadolint ignore=DL3022


### PR DESCRIPTION
Reverts sourcegraph/sourcegraph#35830

Something doesn't look right but don't want to debug. Will look at next week.

## Test plan
Revert.