### PR TITLE
database: remove dbutil-based constructors

### DIFF
--- a/cmd/frontend/graphqlbackend/org.go
+++ b/cmd/frontend/graphqlbackend/org.go
@@ -334,7 +334,7 @@ func (r *schemaResolver) UpdateOrganization(ctx context.Context, args *struct {
 		return nil, err
 	}
 
-	updatedOrg, err := database.Orgs(r.db).Update(ctx, orgID, args.DisplayName)
+	updatedOrg, err := r.db.Orgs().Update(ctx, orgID, args.DisplayName)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/graphqlbackend/org_invitation.go
+++ b/cmd/frontend/graphqlbackend/org_invitation.go
@@ -92,7 +92,7 @@ func (r *organizationInvitationResolver) RespondURL(ctx context.Context) (*strin
 		if orgInvitationConfigDefined() {
 			url, err = orgInvitationURL(*r.v, true)
 		} else { // TODO: remove this fallback once signing key is enforced for on-prem instances
-			org, err := database.Orgs(r.db).GetByID(ctx, r.v.OrgID)
+			org, err := r.db.Orgs().GetByID(ctx, r.v.OrgID)
 			if err != nil {
 				return nil, err
 			}

--- a/cmd/frontend/internal/app/updatecheck/client.go
+++ b/cmd/frontend/internal/app/updatecheck/client.go
@@ -103,7 +103,7 @@ func getTotalUsersCount(ctx context.Context, db database.DB) (_ int, err error) 
 
 func getTotalOrgsCount(ctx context.Context, db database.DB) (_ int, err error) {
 	defer recordOperation("getTotalUsersCount")(&err)
-	return database.Orgs(db).Count(ctx, database.OrgsListOptions{})
+	return db.Orgs().Count(ctx, database.OrgsListOptions{})
 }
 
 // hasRepo returns true when the instance has at least one repository that isn't

--- a/cmd/frontend/internal/httpapi/internal.go
+++ b/cmd/frontend/internal/httpapi/internal.go
@@ -203,7 +203,7 @@ func serveOrgsGetByName(db database.DB) func(w http.ResponseWriter, r *http.Requ
 		if err != nil {
 			return errors.Wrap(err, "Decode")
 		}
-		org, err := database.Orgs(db).GetByName(r.Context(), orgName)
+		org, err := db.Orgs().GetByName(r.Context(), orgName)
 		if err != nil {
 			return errors.Wrap(err, "Orgs.GetByName")
 		}

--- a/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers_test.go
+++ b/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers_test.go
@@ -212,7 +212,7 @@ func TestIsAllowedToCreate(t *testing.T) {
 	siteAdmin := insertTestUser(t, db, "cm-user3", true)
 
 	admContext := actor.WithActor(context.Background(), actor.FromUser(siteAdmin.ID))
-	org, err := database.Orgs(db).Create(admContext, "cm-test-org", nil)
+	org, err := db.Orgs().Create(admContext, "cm-test-org", nil)
 	require.NoError(t, err)
 	addUserToOrg(t, db, member.ID, org.ID)
 

--- a/enterprise/cmd/frontend/internal/notebooks/resolvers/resolvers_test.go
+++ b/enterprise/cmd/frontend/internal/notebooks/resolvers/resolvers_test.go
@@ -182,7 +182,7 @@ func TestSingleNotebookCRUD(t *testing.T) {
 	testdb := database.NewDB(dbtest.NewDB(t))
 	db := database.NewDB(testdb)
 	u := database.Users(db)
-	o := database.Orgs(db)
+	o := db.Orgs()
 	om := db.OrgMembers()
 
 	user1, err := u.Create(internalCtx, database.NewUser{Username: "u1", Password: "p"})
@@ -551,7 +551,7 @@ func TestListNotebooks(t *testing.T) {
 	db := database.NewDB(dbtest.NewDB(t))
 	internalCtx := actor.WithInternalActor(context.Background())
 	u := database.Users(db)
-	o := database.Orgs(db)
+	o := db.Orgs()
 	om := db.OrgMembers()
 
 	user1, err := u.Create(internalCtx, database.NewUser{Username: "u1", Password: "p"})

--- a/enterprise/cmd/frontend/internal/registry/publisher_graphql.go
+++ b/enterprise/cmd/frontend/internal/registry/publisher_graphql.go
@@ -33,7 +33,7 @@ func extensionRegistryViewerPublishers(ctx context.Context, db database.DB) ([]g
 	}
 	publishers = append(publishers, &registryPublisher{user: user})
 
-	orgs, err := database.Orgs(db).GetByUserID(ctx, user.DatabaseID())
+	orgs, err := db.Orgs().GetByUserID(ctx, user.DatabaseID())
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/cmd/frontend/internal/registry/stores/extensions_test.go
+++ b/enterprise/cmd/frontend/internal/registry/stores/extensions_test.go
@@ -42,7 +42,7 @@ var registryExtensionNamesForTests = []struct {
 }
 
 func TestRegistryExtensions_validNames(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	ctx := context.Background()
 
 	s := Extensions(db)
@@ -71,7 +71,7 @@ func TestRegistryExtensions_validNames(t *testing.T) {
 }
 
 func TestRegistryExtensions(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	ctx := context.Background()
 
 	releases := Releases(db)
@@ -125,7 +125,7 @@ func TestRegistryExtensions(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	org, err := database.Orgs(db).Create(ctx, "o", nil)
+	org, err := db.Orgs().Create(ctx, "o", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -329,7 +329,7 @@ func TestRegistryExtensions(t *testing.T) {
 }
 
 func TestRegistryExtensions_ListCount(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	ctx := context.Background()
 
 	releases := Releases(db)
@@ -418,7 +418,7 @@ func TestRegistryExtensions_ListCount(t *testing.T) {
 }
 
 func TestFeaturedExtensions(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	ctx := context.Background()
 
 	releases := Releases(db)

--- a/enterprise/cmd/frontend/internal/searchcontexts/resolvers/resolvers.go
+++ b/enterprise/cmd/frontend/internal/searchcontexts/resolvers/resolvers.go
@@ -307,7 +307,7 @@ func (r *Resolver) IsSearchContextAvailable(ctx context.Context, args graphqlbac
 		return a.UID == searchContext.NamespaceUserID, nil
 	} else {
 		// Is search context created by one of the users' organizations
-		orgs, err := database.Orgs(r.db).GetByUserID(ctx, a.UID)
+		orgs, err := r.db.Orgs().GetByUserID(ctx, a.UID)
 		if err != nil {
 			return false, err
 		}

--- a/enterprise/internal/database/perms_store_test.go
+++ b/enterprise/internal/database/perms_store_test.go
@@ -3002,7 +3002,7 @@ func testPermsStore_UserIsMemberOfOrgHasCodeHostConnection(db *sql.DB) func(*tes
 		)
 		require.NoError(t, err)
 
-		orgs := database.Orgs(db)
+		orgs := db.Orgs()
 		bobOrg, err := orgs.Create(ctx, "bob-org", nil)
 		require.NoError(t, err)
 		cindyOrg, err := orgs.Create(ctx, "cindy-org", nil)

--- a/enterprise/internal/insights/migration/migration.go
+++ b/enterprise/internal/insights/migration/migration.go
@@ -30,7 +30,7 @@ const (
 
 type migrator struct {
 	insightsDB dbutil.DB
-	postgresDB dbutil.DB
+	postgresDB database.DB
 
 	settingsMigrationJobsStore *store.DBSettingsMigrationJobsStore
 	settingsStore              database.SettingsStore
@@ -40,7 +40,7 @@ type migrator struct {
 	workerBaseStore            *basestore.Store
 }
 
-func NewMigrator(insightsDB dbutil.DB, postgresDB dbutil.DB) oobmigration.Migrator {
+func NewMigrator(insightsDB dbutil.DB, postgresDB database.DB) oobmigration.Migrator {
 	return &migrator{
 		insightsDB:                 insightsDB,
 		postgresDB:                 postgresDB,
@@ -48,7 +48,7 @@ func NewMigrator(insightsDB dbutil.DB, postgresDB dbutil.DB) oobmigration.Migrat
 		settingsStore:              database.Settings(postgresDB),
 		insightStore:               store.NewInsightStore(insightsDB),
 		dashboardStore:             store.NewDashboardStore(insightsDB),
-		orgStore:                   database.Orgs(postgresDB),
+		orgStore:                   postgresDB.Orgs(),
 		workerBaseStore:            basestore.NewWithDB(postgresDB, sql.TxOptions{}),
 	}
 }
@@ -138,7 +138,7 @@ func (m *migrator) performMigrationForRow(ctx context.Context, jobStoreTx *store
 	var subject api.SettingsSubject
 	var migrationContext migrationContext
 	var subjectName string
-	orgStore := database.Orgs(m.postgresDB)
+	orgStore := m.postgresDB.Orgs()
 
 	defer func() {
 		jobStoreTx.UpdateRuns(ctx, job.UserId, job.OrgId, job.Runs+1)

--- a/enterprise/internal/insights/resolvers/dashboard_resolvers.go
+++ b/enterprise/internal/insights/resolvers/dashboard_resolvers.go
@@ -240,7 +240,7 @@ func (r *Resolver) CreateInsightsDashboard(ctx context.Context, args *graphqlbac
 		return nil, errors.New("dashboard must be created with at least one grant")
 	}
 
-	userIds, orgIds, err := getUserPermissions(ctx, database.Orgs(r.workerBaseStore.Handle().DB()))
+	userIds, orgIds, err := getUserPermissions(ctx, database.NewDB(r.workerBaseStore.Handle().DB()).Orgs())
 	if err != nil {
 		return nil, errors.Wrap(err, "getUserPermissions")
 	}

--- a/enterprise/internal/insights/resolvers/insight_connection_resolver_test.go
+++ b/enterprise/internal/insights/resolvers/insight_connection_resolver_test.go
@@ -39,7 +39,7 @@ func TestResolver_InsightConnection(t *testing.T) {
 		now := time.Now().UTC().Truncate(time.Microsecond)
 		clock := func() time.Time { return now }
 
-		postgres := dbtest.NewDB(t)
+		postgres := database.NewDB(dbtest.NewDB(t))
 		resolver := newWithClock(insightsDB, postgres, clock)
 
 		insightMetadataStore := store.NewMockInsightMetadataStore()

--- a/enterprise/internal/insights/resolvers/insight_series_resolver_test.go
+++ b/enterprise/internal/insights/resolvers/insight_series_resolver_test.go
@@ -5,13 +5,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/types"
-
 	"github.com/hexops/autogold"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/store"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/types"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 )
 
@@ -23,7 +23,7 @@ func TestResolver_InsightSeries(t *testing.T) {
 		now := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC).Truncate(time.Microsecond)
 		clock := func() time.Time { return now }
 		insightsDB := dbtest.NewInsightsDB(t)
-		postgres := dbtest.NewDB(t)
+		postgres := database.NewDB(dbtest.NewDB(t))
 		resolver := newWithClock(insightsDB, postgres, clock)
 
 		insightMetadataStore := store.NewMockInsightMetadataStore()

--- a/enterprise/internal/insights/resolvers/insight_view_resolvers.go
+++ b/enterprise/internal/insights/resolvers/insight_view_resolvers.go
@@ -154,7 +154,7 @@ func (i *insightViewResolver) DataSeries(ctx context.Context) ([]graphqlbackend.
 
 func (i *insightViewResolver) Dashboards(ctx context.Context, args *graphqlbackend.InsightsDashboardsArgs) graphqlbackend.InsightsDashboardConnectionResolver {
 	return &dashboardConnectionResolver{baseInsightResolver: i.baseInsightResolver,
-		orgStore:         database.Orgs(i.postgresDB),
+		orgStore:         i.postgresDB.Orgs(),
 		args:             args,
 		withViewUniqueID: &i.view.UniqueID,
 	}
@@ -424,7 +424,7 @@ func (r *Resolver) CreateLineChartSearchInsight(ctx context.Context, args *graph
 
 	if len(dashboardIds) > 0 {
 		if args.Input.Dashboards != nil {
-			err := validateUserDashboardPermissions(ctx, dashboardTx, *args.Input.Dashboards, database.Orgs(r.postgresDB))
+			err := validateUserDashboardPermissions(ctx, dashboardTx, *args.Input.Dashboards, r.postgresDB.Orgs())
 			if err != nil {
 				return nil, err
 			}
@@ -599,7 +599,7 @@ func (r *Resolver) CreatePieChartSearchInsight(ctx context.Context, args *graphq
 
 	if len(dashboardIds) > 0 {
 		if args.Input.Dashboards != nil {
-			err := validateUserDashboardPermissions(ctx, dashboardTx, *args.Input.Dashboards, database.Orgs(r.postgresDB))
+			err := validateUserDashboardPermissions(ctx, dashboardTx, *args.Input.Dashboards, r.postgresDB.Orgs())
 			if err != nil {
 				return nil, err
 			}
@@ -810,7 +810,7 @@ func (d *InsightViewQueryConnectionResolver) PageInfo(ctx context.Context) (*gra
 
 func (r *InsightViewQueryConnectionResolver) computeViews(ctx context.Context) ([]types.Insight, string, error) {
 	r.once.Do(func() {
-		orgStore := database.Orgs(r.postgresDB)
+		orgStore := r.postgresDB.Orgs()
 
 		args := store.InsightQueryArgs{}
 		if r.args.After != nil {

--- a/enterprise/internal/insights/resolvers/insight_view_resolvers_test.go
+++ b/enterprise/internal/insights/resolvers/insight_view_resolvers_test.go
@@ -6,18 +6,17 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
-	"github.com/sourcegraph/sourcegraph/internal/actor"
-	"github.com/sourcegraph/sourcegraph/internal/timeutil"
-	internalTypes "github.com/sourcegraph/sourcegraph/internal/types"
-
-	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/store"
-	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
-
 	"github.com/google/go-cmp/cmp"
 
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/store"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/types"
+	"github.com/sourcegraph/sourcegraph/internal/actor"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
+	"github.com/sourcegraph/sourcegraph/internal/timeutil"
+	internalTypes "github.com/sourcegraph/sourcegraph/internal/types"
 )
 
 func addrStr(input string) *string {
@@ -167,7 +166,7 @@ func TestFrozenInsightDataSeriesResolver(t *testing.T) {
 	})
 	t.Run("insight_is_not_frozen_returns_real_resolvers", func(t *testing.T) {
 		insightsDB := dbtest.NewInsightsDB(t)
-		postgres := dbtest.NewDB(t)
+		postgres := database.NewDB(dbtest.NewDB(t))
 		permStore := store.NewInsightPermissionStore(postgres)
 		clock := timeutil.Now
 		timeseriesStore := store.NewWithClock(insightsDB, permStore, clock)
@@ -231,7 +230,7 @@ func TestInsightViewDashboardConnections(t *testing.T) {
 	ctx := actor.WithActor(context.Background(), a)
 
 	insightsDB := dbtest.NewInsightsDB(t)
-	postgresDB := dbtest.NewDB(t)
+	postgresDB := database.NewDB(dbtest.NewDB(t))
 	base := baseInsightResolver{
 		insightStore:   store.NewInsightStore(insightsDB),
 		dashboardStore: store.NewDashboardStore(insightsDB),

--- a/enterprise/internal/insights/resolvers/resolver_test.go
+++ b/enterprise/internal/insights/resolvers/resolver_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/sourcegraph/sourcegraph/internal/actor"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 )
 
@@ -18,7 +19,7 @@ func TestResolver_Insights(t *testing.T) {
 	now := time.Now().UTC().Truncate(time.Microsecond)
 	clock := func() time.Time { return now }
 	insightsDB := dbtest.NewInsightsDB(t)
-	postgres := dbtest.NewDB(t)
+	postgres := database.NewDB(dbtest.NewDB(t))
 	resolver := newWithClock(insightsDB, postgres, clock)
 
 	insightsConnection, err := resolver.Insights(ctx, nil)

--- a/enterprise/internal/insights/resolvers/validator.go
+++ b/enterprise/internal/insights/resolvers/validator.go
@@ -29,7 +29,7 @@ func PermissionsValidatorFromBase(base *baseInsightResolver) *InsightPermissions
 	return &InsightPermissionsValidator{
 		insightStore:   base.insightStore,
 		dashboardStore: base.dashboardStore,
-		orgStore:       database.Orgs(base.postgresDB),
+		orgStore:       base.postgresDB.Orgs(),
 	}
 }
 

--- a/enterprise/internal/notebooks/store_test.go
+++ b/enterprise/internal/notebooks/store_test.go
@@ -192,7 +192,7 @@ func TestListingAndCountingNotebooks(t *testing.T) {
 	db := database.NewDB(dbtest.NewDB(t))
 	internalCtx := actor.WithInternalActor(context.Background())
 	u := database.Users(db)
-	o := database.Orgs(db)
+	o := db.Orgs()
 	om := db.OrgMembers()
 	n := Notebooks(db)
 
@@ -474,7 +474,7 @@ func TestNotebookPermissions(t *testing.T) {
 	db := database.NewDB(dbtest.NewDB(t))
 	internalCtx := actor.WithInternalActor(context.Background())
 	u := database.Users(db)
-	o := database.Orgs(db)
+	o := db.Orgs()
 	om := db.OrgMembers()
 	n := Notebooks(db)
 

--- a/internal/database/external_services_test.go
+++ b/internal/database/external_services_test.go
@@ -316,7 +316,7 @@ func TestExternalServicesStore_Create(t *testing.T) {
 	}
 
 	displayName := "Acme org"
-	org, err := Orgs(db).Create(ctx, "acme", &displayName)
+	org, err := db.Orgs().Create(ctx, "acme", &displayName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1208,7 +1208,7 @@ func TestGetAffiliatedSyncErrors(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	org1, err := Orgs(db).Create(ctx, "ACME", nil)
+	org1, err := db.Orgs().Create(ctx, "ACME", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1484,7 +1484,7 @@ func TestExternalServicesStore_List(t *testing.T) {
 
 	// Create test org
 	displayName := "Acme Org"
-	org, err := Orgs(db).Create(ctx, "acme", &displayName)
+	org, err := db.Orgs().Create(ctx, "acme", &displayName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1828,7 +1828,7 @@ func TestExternalServicesStore_Upsert(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Test setup error %s", err)
 		}
-		org, err := Orgs(db).Create(ctx, "acme", nil)
+		org, err := db.Orgs().Create(ctx, "acme", nil)
 		if err != nil {
 			t.Fatalf("Test setup error %s", err)
 		}

--- a/internal/database/feature_flags_test.go
+++ b/internal/database/feature_flags_test.go
@@ -275,7 +275,7 @@ func testListOrgOverrides(t *testing.T) {
 	db := NewDB(dbtest.NewDB(t))
 	flagStore := &featureFlagStore{Store: basestore.NewWithDB(db, sql.TxOptions{})}
 	users := Users(db)
-	orgs := Orgs(db)
+	orgs := db.Orgs()
 	orgMembers := db.OrgMembers()
 	ctx := actor.WithInternalActor(context.Background())
 
@@ -360,7 +360,7 @@ func testUserFlags(t *testing.T) {
 	db := NewDB(dbtest.NewDB(t))
 	flagStore := db.FeatureFlags()
 	users := Users(db)
-	orgs := Orgs(db)
+	orgs := db.Orgs()
 	orgMembers := db.OrgMembers()
 	ctx := actor.WithInternalActor(context.Background())
 
@@ -609,7 +609,7 @@ func testOrgFeatureFlag(t *testing.T) {
 	t.Parallel()
 	db := NewDB(dbtest.NewDB(t))
 	flagStore := db.FeatureFlags()
-	orgs := Orgs(db)
+	orgs := db.Orgs()
 	ctx := actor.WithInternalActor(context.Background())
 
 	mkFFBool := func(name string, val bool) *ff.FeatureFlag {

--- a/internal/database/namespaces_test.go
+++ b/internal/database/namespaces_test.go
@@ -21,7 +21,7 @@ func TestNamespaces(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	org, err := Orgs(db).Create(ctx, "Acme", nil)
+	org, err := db.Orgs().Create(ctx, "Acme", nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/database/org_members_db_test.go
+++ b/internal/database/org_members_db_test.go
@@ -20,15 +20,15 @@ func TestOrgMembers_CreateMembershipInOrgsForAllUsers(t *testing.T) {
 	ctx := context.Background()
 
 	// Create fixtures.
-	org1, err := Orgs(db).Create(ctx, "org1", nil)
+	org1, err := db.Orgs().Create(ctx, "org1", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-	org2, err := Orgs(db).Create(ctx, "org2", nil)
+	org2, err := db.Orgs().Create(ctx, "org2", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-	org3, err := Orgs(db).Create(ctx, "org3", nil)
+	org3, err := db.Orgs().Create(ctx, "org3", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -117,15 +117,15 @@ func TestOrgMembers_MemberCount(t *testing.T) {
 	db := NewDB(dbtest.NewDB(t))
 	ctx := context.Background()
 	// Create fixtures.
-	org1, err := Orgs(db).Create(ctx, "org1", nil)
+	org1, err := db.Orgs().Create(ctx, "org1", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-	org2, err := Orgs(db).Create(ctx, "org2", nil)
+	org2, err := db.Orgs().Create(ctx, "org2", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-	org3, err := Orgs(db).Create(ctx, "org3", nil)
+	org3, err := db.Orgs().Create(ctx, "org3", nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/database/org_stats_test.go
+++ b/internal/database/org_stats_test.go
@@ -8,10 +8,10 @@ import (
 )
 
 func TestOrgStats_Upsert(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := NewDB(dbtest.NewDB(t))
 	ctx := context.Background()
 
-	org, err := Orgs(db).Create(ctx, "org1", nil)
+	org, err := db.Orgs().Create(ctx, "org1", nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/database/orgs.go
+++ b/internal/database/orgs.go
@@ -2,7 +2,6 @@ package database
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
 	"time"
 
@@ -10,7 +9,6 @@ import (
 	"github.com/keegancsmith/sqlf"
 
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
@@ -51,11 +49,6 @@ type OrgStore interface {
 
 type orgStore struct {
 	*basestore.Store
-}
-
-// Orgs instantiates and returns a new OrgStore with prepared statements.
-func Orgs(db dbutil.DB) OrgStore {
-	return &orgStore{Store: basestore.NewWithDB(db, sql.TxOptions{})}
 }
 
 // OrgsWith instantiates and returns a new OrgStore using the other store handle.

--- a/internal/database/orgs_test.go
+++ b/internal/database/orgs_test.go
@@ -25,7 +25,7 @@ func TestOrgs_ValidNames(t *testing.T) {
 	for _, test := range usernamesForTests {
 		t.Run(test.name, func(t *testing.T) {
 			valid := true
-			if _, err := Orgs(db).Create(ctx, test.name, nil); err != nil {
+			if _, err := db.Orgs().Create(ctx, test.name, nil); err != nil {
 				if strings.Contains(err.Error(), "org name invalid") {
 					valid = false
 				} else {
@@ -44,22 +44,22 @@ func TestOrgs_Count(t *testing.T) {
 	db := NewDB(dbtest.NewDB(t))
 	ctx := context.Background()
 
-	org, err := Orgs(db).Create(ctx, "a", nil)
+	org, err := db.Orgs().Create(ctx, "a", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if count, err := Orgs(db).Count(ctx, OrgsListOptions{}); err != nil {
+	if count, err := db.Orgs().Count(ctx, OrgsListOptions{}); err != nil {
 		t.Fatal(err)
 	} else if want := 1; count != want {
 		t.Errorf("got %d, want %d", count, want)
 	}
 
-	if err := Orgs(db).Delete(ctx, org.ID); err != nil {
+	if err := db.Orgs().Delete(ctx, org.ID); err != nil {
 		t.Fatal(err)
 	}
 
-	if count, err := Orgs(db).Count(ctx, OrgsListOptions{}); err != nil {
+	if count, err := db.Orgs().Count(ctx, OrgsListOptions{}); err != nil {
 		t.Fatal(err)
 	} else if want := 0; count != want {
 		t.Errorf("got %d, want %d", count, want)
@@ -72,22 +72,22 @@ func TestOrgs_Delete(t *testing.T) {
 	ctx := context.Background()
 
 	displayName := "a"
-	org, err := Orgs(db).Create(ctx, "a", &displayName)
+	org, err := db.Orgs().Create(ctx, "a", &displayName)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// Delete org.
-	if err := Orgs(db).Delete(ctx, org.ID); err != nil {
+	if err := db.Orgs().Delete(ctx, org.ID); err != nil {
 		t.Fatal(err)
 	}
 
 	// Org no longer exists.
-	_, err = Orgs(db).GetByID(ctx, org.ID)
+	_, err = db.Orgs().GetByID(ctx, org.ID)
 	if !errors.HasType(err, &OrgNotFoundError{}) {
 		t.Errorf("got error %v, want *OrgNotFoundError", err)
 	}
-	orgs, err := Orgs(db).List(ctx, &OrgsListOptions{Query: "a"})
+	orgs, err := db.Orgs().List(ctx, &OrgsListOptions{Query: "a"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -96,7 +96,7 @@ func TestOrgs_Delete(t *testing.T) {
 	}
 
 	// Can't delete already-deleted org.
-	err = Orgs(db).Delete(ctx, org.ID)
+	err = db.Orgs().Delete(ctx, org.ID)
 	if !errors.HasType(err, &OrgNotFoundError{}) {
 		t.Errorf("got error %v, want *OrgNotFoundError", err)
 	}
@@ -108,47 +108,47 @@ func TestOrgs_HardDelete(t *testing.T) {
 	ctx := context.Background()
 
 	displayName := "org1"
-	org, err := Orgs(db).Create(ctx, "org1", &displayName)
+	org, err := db.Orgs().Create(ctx, "org1", &displayName)
 	require.NoError(t, err)
 
 	// Hard Delete org.
-	if err := Orgs(db).HardDelete(ctx, org.ID); err != nil {
+	if err := db.Orgs().HardDelete(ctx, org.ID); err != nil {
 		t.Fatal(err)
 	}
 
 	// Org no longer exists.
-	_, err = Orgs(db).GetByID(ctx, org.ID)
+	_, err = db.Orgs().GetByID(ctx, org.ID)
 	if !errors.HasType(err, &OrgNotFoundError{}) {
 		t.Errorf("got error %v, want *OrgNotFoundError", err)
 	}
 
-	orgs, err := Orgs(db).List(ctx, &OrgsListOptions{Query: "org1"})
+	orgs, err := db.Orgs().List(ctx, &OrgsListOptions{Query: "org1"})
 	require.NoError(t, err)
 	if len(orgs) > 0 {
 		t.Errorf("got %d orgs, want 0", len(orgs))
 	}
 
 	// Cannot hard delete an org that doesn't exist.
-	err = Orgs(db).HardDelete(ctx, org.ID)
+	err = db.Orgs().HardDelete(ctx, org.ID)
 	if !errors.HasType(err, &OrgNotFoundError{}) {
 		t.Errorf("got error %v, want *OrgNotFoundError", err)
 	}
 
 	// Can hard delete an org that has been soft deleted.
 	displayName2 := "org2"
-	org2, err := Orgs(db).Create(ctx, "org2", &displayName2)
+	org2, err := db.Orgs().Create(ctx, "org2", &displayName2)
 	require.NoError(t, err)
 
-	err = Orgs(db).Delete(ctx, org2.ID)
+	err = db.Orgs().Delete(ctx, org2.ID)
 	require.NoError(t, err)
 
-	err = Orgs(db).HardDelete(ctx, org2.ID)
+	err = db.Orgs().HardDelete(ctx, org2.ID)
 	require.NoError(t, err)
 }
 
 func TestOrgs_GetByID(t *testing.T) {
 	createOrg := func(ctx context.Context, db DB, name string, displayName string) *types.Org {
-		org, err := Orgs(db).Create(ctx, name, &displayName)
+		org, err := db.Orgs().Create(ctx, name, &displayName)
 		if err != nil {
 			t.Fatal(err)
 			return nil
@@ -186,7 +186,7 @@ func TestOrgs_GetByID(t *testing.T) {
 	user := createUser(ctx, db, "user")
 	createOrgMember(ctx, db, user.ID, org2.ID)
 
-	orgs, err := Orgs(db).GetByUserID(ctx, user.ID)
+	orgs, err := db.Orgs().GetByUserID(ctx, user.ID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -200,7 +200,7 @@ func TestOrgs_GetByID(t *testing.T) {
 
 func TestOrgs_GetOrgsWithRepositoriesByUserID(t *testing.T) {
 	createOrg := func(ctx context.Context, db DB, name string, displayName string) *types.Org {
-		org, err := Orgs(db).Create(ctx, name, &displayName)
+		org, err := db.Orgs().Create(ctx, name, &displayName)
 		if err != nil {
 			t.Fatal(err)
 			return nil
@@ -253,7 +253,7 @@ func TestOrgs_GetOrgsWithRepositoriesByUserID(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	orgs, err := Orgs(db).GetOrgsWithRepositoriesByUserID(ctx, user.ID)
+	orgs, err := db.Orgs().GetOrgsWithRepositoriesByUserID(ctx, user.ID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -282,7 +282,7 @@ func TestOrgs_AddOrgsOpenBetaStats(t *testing.T) {
 	}
 
 	t.Run("When adding stats, returns valid UUID", func(t *testing.T) {
-		id, err := Orgs(db).AddOrgsOpenBetaStats(ctx, userID, string(data))
+		id, err := db.Orgs().AddOrgsOpenBetaStats(ctx, userID, string(data))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -293,11 +293,11 @@ func TestOrgs_AddOrgsOpenBetaStats(t *testing.T) {
 	})
 
 	t.Run("Can add stats multiple times by the same user", func(t *testing.T) {
-		_, err := Orgs(db).AddOrgsOpenBetaStats(ctx, userID, string(data))
+		_, err := db.Orgs().AddOrgsOpenBetaStats(ctx, userID, string(data))
 		if err != nil {
 			t.Fatal(err)
 		}
-		_, err = Orgs(db).AddOrgsOpenBetaStats(ctx, userID, string(data))
+		_, err = db.Orgs().AddOrgsOpenBetaStats(ctx, userID, string(data))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -311,13 +311,13 @@ func TestOrgs_UpdateOrgsOpenBetaStats(t *testing.T) {
 
 	userID := int32(42)
 	orgID := int32(10)
-	statsID, err := Orgs(db).AddOrgsOpenBetaStats(ctx, userID, "{}")
+	statsID, err := db.Orgs().AddOrgsOpenBetaStats(ctx, userID, "{}")
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	t.Run("Updates stats with orgID if the UUID exists in the DB", func(t *testing.T) {
-		err := Orgs(db).UpdateOrgsOpenBetaStats(ctx, statsID, orgID)
+		err := db.Orgs().UpdateOrgsOpenBetaStats(ctx, statsID, orgID)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -328,7 +328,7 @@ func TestOrgs_UpdateOrgsOpenBetaStats(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		err = Orgs(db).UpdateOrgsOpenBetaStats(ctx, randomUUID.String(), orgID)
+		err = db.Orgs().UpdateOrgsOpenBetaStats(ctx, randomUUID.String(), orgID)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/database/repos_db_test.go
+++ b/internal/database/repos_db_test.go
@@ -507,7 +507,7 @@ func TestRepos_ListMinimalRepos_orgID(t *testing.T) {
 
 	// Create an org
 	displayName := "Acme Corp"
-	org, err := Orgs(db).Create(ctx, "acme", &displayName)
+	org, err := db.Orgs().Create(ctx, "acme", &displayName)
 	require.NoError(t, err)
 
 	now := time.Now()

--- a/internal/database/repos_perm_test.go
+++ b/internal/database/repos_perm_test.go
@@ -423,7 +423,7 @@ func TestRepoStore_nonSiteAdminCanViewOrgPrivateCode(t *testing.T) {
 	)[0]
 
 	// Create an organization and add alice as a member
-	org, err := Orgs(db).Create(ctx, "org", nil)
+	org, err := db.Orgs().Create(ctx, "org", nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/database/saved_searches_test.go
+++ b/internal/database/saved_searches_test.go
@@ -290,11 +290,11 @@ func TestListSavedSearchesByUserID(t *testing.T) {
 		t.Fatalf("no saved search returned, create failed")
 	}
 
-	org1, err := Orgs(db).Create(ctx, "org1", nil)
+	org1, err := db.Orgs().Create(ctx, "org1", nil)
 	if err != nil {
 		t.Fatal("can't create org1", err)
 	}
-	org2, err := Orgs(db).Create(ctx, "org2", nil)
+	org2, err := db.Orgs().Create(ctx, "org2", nil)
 	if err != nil {
 		t.Fatal("can't create org2", err)
 	}

--- a/internal/database/search_contexts_test.go
+++ b/internal/database/search_contexts_test.go
@@ -32,7 +32,7 @@ func TestSearchContexts_Get(t *testing.T) {
 	t.Parallel()
 	ctx := actor.WithInternalActor(context.Background())
 	u := Users(db)
-	o := Orgs(db)
+	o := db.Orgs()
 	sc := SearchContexts(db)
 
 	user, err := u.Create(ctx, NewUser{Username: "u", Password: "p"})
@@ -84,7 +84,7 @@ func TestSearchContexts_Update(t *testing.T) {
 	t.Parallel()
 	ctx := actor.WithInternalActor(context.Background())
 	u := Users(db)
-	o := Orgs(db)
+	o := db.Orgs()
 	sc := SearchContexts(db)
 
 	user, err := u.Create(ctx, NewUser{Username: "u", Password: "p"})
@@ -203,7 +203,7 @@ func TestSearchContexts_PaginationAndCount(t *testing.T) {
 	t.Parallel()
 	ctx := actor.WithInternalActor(context.Background())
 	u := Users(db)
-	o := Orgs(db)
+	o := db.Orgs()
 	sc := SearchContexts(db)
 
 	user, err := u.Create(ctx, NewUser{Username: "u", Password: "p"})
@@ -301,7 +301,7 @@ func TestSearchContexts_CaseInsensitiveNames(t *testing.T) {
 	t.Parallel()
 	ctx := actor.WithInternalActor(context.Background())
 	u := Users(db)
-	o := Orgs(db)
+	o := db.Orgs()
 	sc := SearchContexts(db)
 
 	user, err := u.Create(ctx, NewUser{Username: "u", Password: "p"})
@@ -424,7 +424,7 @@ func TestSearchContexts_Permissions(t *testing.T) {
 	t.Parallel()
 	internalCtx := actor.WithInternalActor(context.Background())
 	u := Users(db)
-	o := Orgs(db)
+	o := db.Orgs()
 	om := db.OrgMembers()
 	sc := SearchContexts(db)
 
@@ -677,7 +677,7 @@ func TestSearchContexts_OrderBy(t *testing.T) {
 	t.Parallel()
 	internalCtx := actor.WithInternalActor(context.Background())
 	u := Users(db)
-	o := Orgs(db)
+	o := db.Orgs()
 	om := db.OrgMembers()
 	sc := SearchContexts(db)
 

--- a/internal/search/searchcontexts/search_contexts_test.go
+++ b/internal/search/searchcontexts/search_contexts_test.go
@@ -275,7 +275,7 @@ func TestSearchContextWriteAccessValidation(t *testing.T) {
 	db := database.NewDB(dbtest.NewDB(t))
 	u := database.Users(db)
 
-	org, err := database.Orgs(db).Create(internalCtx, "myorg", nil)
+	org, err := db.Orgs().Create(internalCtx, "myorg", nil)
 	if err != nil {
 		t.Fatalf("Expected no error, got %s", err)
 	}


### PR DESCRIPTION
Remove a few dbutil-based constructors in our database package, as they are not mockable in our tests.

This is the result of a time-boxed effort.

## Test plan

Unit tests

---

Part of https://github.com/sourcegraph/sourcegraph/issues/26113