### PR TITLE
Add collapse visual state to the drill-down panel for the independent insight page

### DIFF
--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/drill-down-filters/DrillDownInsightFilters.module.scss
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/drill-down-filters/DrillDownInsightFilters.module.scss
@@ -56,8 +56,11 @@
 
 .panel {
     min-width: 0;
-    flex-basis: 22rem;
     flex-grow: 1;
+
+    &--horizontal-mode {
+        flex-basis: 22rem;
+    }
 }
 
 .reg-exp-filters {

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/drill-down-filters/DrillDownInsightFilters.module.scss
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/drill-down-filters/DrillDownInsightFilters.module.scss
@@ -47,15 +47,17 @@
     flex-direction: column;
 
     &--horizontal-mode {
+        flex-wrap: wrap;
         flex-direction: row;
-        gap: 1.5rem;
         padding-bottom: 1rem;
+        gap: 1.5rem;
     }
 }
 
 .panel {
     min-width: 0;
-    flex-basis: 50%;
+    flex-basis: 22rem;
+    flex-grow: 1;
 }
 
 .reg-exp-filters {
@@ -70,8 +72,6 @@
     flex-wrap: wrap;
     align-items: center;
     gap: 1rem;
-
-    margin-top: -0.25rem;
     padding: 0.75rem 0 0 0;
 }
 

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/drill-down-filters/DrillDownInsightFilters.module.scss
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/drill-down-filters/DrillDownInsightFilters.module.scss
@@ -1,22 +1,35 @@
 .header {
     display: flex;
-    flex-wrap: wrap;
-    align-items: baseline;
-    padding: 0 0 0.75rem 0;
+    align-items: center;
+    gap: 0.5rem;
 }
 
 .header-separator {
-    margin-top: 0;
+    margin-top: 0.75rem;
     margin-bottom: 0.25rem;
 }
 
 .heading {
-    margin: 0;
+    flex-shrink: 0;
+    margin-top: 0;
+    margin-bottom: 0;
+
+    &--with-expanded-content {
+        margin-right: auto;
+    }
 }
 
-.clear-filters {
-    margin-left: auto;
+.preview-pills {
+    flex: 1;
+}
+
+.action-button {
     padding: 0;
+    flex-shrink: 0;
+
+    &--with-collapsed {
+        margin-left: auto;
+    }
 }
 
 .input {

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/drill-down-filters/DrillDownInsightFilters.story.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/drill-down-filters/DrillDownInsightFilters.story.tsx
@@ -1,3 +1,5 @@
+import { useState } from 'react'
+
 import { MockedResponse } from '@apollo/client/testing/core/mocking/mockLink'
 import { Meta, Story } from '@storybook/react'
 
@@ -101,15 +103,20 @@ export const DrillDownFiltersShowcase: Story = () => (
     </MockedTestProvider>
 )
 
-export const DrillDownFiltersHorizontalMode: Story = () => (
-    <MockedTestProvider mocks={[CONTEXTS_GQL_MOCKS]}>
-        <DrillDownInsightFilters
-            initialValues={FILTERS}
-            originalValues={ORIGINAL_FILTERS}
-            visualMode={FilterSectionVisualMode.HorizontalSections}
-            onFiltersChange={console.log}
-            onFilterSave={console.log}
-            onCreateInsightRequest={console.log}
-        />
-    </MockedTestProvider>
-)
+export const DrillDownFiltersHorizontalMode: Story = () => {
+    const [mode, setMode] = useState<FilterSectionVisualMode>(FilterSectionVisualMode.HorizontalSections)
+
+    return (
+        <MockedTestProvider mocks={[CONTEXTS_GQL_MOCKS]}>
+            <DrillDownInsightFilters
+                initialValues={FILTERS}
+                originalValues={ORIGINAL_FILTERS}
+                visualMode={mode}
+                onVisualModeChange={setMode}
+                onFiltersChange={console.log}
+                onFilterSave={console.log}
+                onCreateInsightRequest={console.log}
+            />
+        </MockedTestProvider>
+    )
+}

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/drill-down-filters/DrillDownInsightFilters.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/drill-down-filters/DrillDownInsightFilters.tsx
@@ -178,8 +178,8 @@ export const DrillDownInsightFilters: FunctionComponent<DrillDownInsightFilters>
                     title="Search context"
                     preview={getSerializedSearchContextFilter(contexts.input.value)}
                     hasActiveFilter={hasActiveUnaryFilter(contexts.input.value)}
-                    className={styles.panel}
                     withSeparators={!isHorizontalMode}
+                    className={classNames(styles.panel, { [styles.panelHorizontalMode]: isHorizontalMode })}
                     onOpenChange={opened => handleCollapseState(FilterSection.SearchContext, opened)}
                 >
                     <small className={styles.sectionDescription}>
@@ -197,7 +197,7 @@ export const DrillDownInsightFilters: FunctionComponent<DrillDownInsightFilters>
                     <DrillDownSearchContextFilter
                         spellCheck={false}
                         autoComplete="off"
-                        autoFocus={true}
+                        autoFocus={!isHorizontalMode}
                         className={styles.input}
                         status={getFilterInputStatus(contexts)}
                         {...contexts.input}
@@ -211,8 +211,8 @@ export const DrillDownInsightFilters: FunctionComponent<DrillDownInsightFilters>
                     hasActiveFilter={
                         hasActiveUnaryFilter(includeRegex.input.value) || hasActiveUnaryFilter(excludeRegex.input.value)
                     }
-                    className={styles.panel}
                     withSeparators={!isHorizontalMode}
+                    className={classNames(styles.panel, { [styles.panelHorizontalMode]: isHorizontalMode })}
                     onOpenChange={opened => handleCollapseState(FilterSection.RegularExpressions, opened)}
                 >
                     <small className={styles.sectionDescription}>

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/drill-down-filters/DrillDownInsightFilters.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/drill-down-filters/DrillDownInsightFilters.tsx
@@ -127,7 +127,7 @@ export const DrillDownInsightFilters: FunctionComponent<DrillDownInsightFilters>
             <header className={classNames(className, styles.header)}>
                 <Typography.H4 className={styles.heading}>Filter repositories</Typography.H4>
 
-                <FilterPreviewPill text={getSerializedSearchContextFilter(contexts.input.value)} />
+                <FilterPreviewPill text={getSerializedSearchContextFilter(contexts.input.value, true)} />
                 <FilterPreviewPill text={getSerializedRepositoriesFilter(currentRepositoriesFilters)} />
 
                 <Button

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/drill-down-filters/utils.ts
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/drill-down-filters/utils.ts
@@ -29,6 +29,11 @@ export function getSerializedRepositoriesFilter(filter: InsightRepositoriesFilte
 
 type InsightContextsFilter = string
 
-export function getSerializedSearchContextFilter(filter: InsightContextsFilter): string {
-    return filter !== '' ? filter : 'global (default)'
+export function getSerializedSearchContextFilter(
+    filter: InsightContextsFilter,
+    withContextPrefix: boolean = true
+): string {
+    const filterValue = filter !== '' ? filter : 'global (default)'
+
+    return withContextPrefix ? `context:${filterValue}` : filterValue
 }

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/filter-collapse-section/FilterCollapseSection.module.scss
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/filter-collapse-section/FilterCollapseSection.module.scss
@@ -46,8 +46,11 @@
     background-color: var(--purple);
 }
 
-.filter-badge {
+.panel-preview {
     margin-left: 0.5rem;
+}
+
+.filter-badge {
     border-radius: var(--border-radius);
     background-color: var(--subtle-bg);
     padding: 0 0.25rem;

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/filter-collapse-section/FilterCollapseSection.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/filter-collapse-section/FilterCollapseSection.tsx
@@ -1,4 +1,4 @@
-import { PropsWithChildren, ReactElement } from 'react'
+import { FunctionComponent, PropsWithChildren, ReactElement } from 'react'
 
 import classNames from 'classnames'
 import ChevronDownIcon from 'mdi-react/ChevronDownIcon'
@@ -37,11 +37,7 @@ export function FilterCollapseSection(props: PropsWithChildren<FilterCollapseSec
 
                     <span className={styles.buttonText}>{title}</span>
 
-                    {!open && preview && (
-                        <TruncatedText className={styles.filterBadge}>
-                            <SyntaxHighlightedSearchQuery query={preview} />
-                        </TruncatedText>
-                    )}
+                    {!open && preview && <FilterPreviewPill text={preview} className={styles.panelPreview} />}
                     {hasActiveFilter && <div className={styles.changedFilterMarker} />}
                 </CollapseHeader>
 
@@ -50,5 +46,20 @@ export function FilterCollapseSection(props: PropsWithChildren<FilterCollapseSec
                 {withSeparators && <hr />}
             </Collapse>
         </div>
+    )
+}
+
+export interface FilterPreviewPillProps {
+    text: string
+    className?: string
+}
+
+export const FilterPreviewPill: FunctionComponent<FilterPreviewPillProps> = props => {
+    const { text, className } = props
+
+    return (
+        <TruncatedText className={classNames(className, styles.filterBadge)}>
+            <SyntaxHighlightedSearchQuery query={text} />
+        </TruncatedText>
     )
 }

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/search-context/DrillDownSearchContextFilter.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/search-context/DrillDownSearchContextFilter.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, FunctionComponent, memo, useState } from 'react'
+import { ChangeEvent, forwardRef, memo, useState } from 'react'
 
 import { gql, useQuery } from '@apollo/client'
 import { Combobox, ComboboxInput, ComboboxList, ComboboxOption, ComboboxOptionText } from '@reach/combobox'
@@ -33,41 +33,44 @@ export const SEARCH_CONTEXT_GQL = gql`
 
 interface DrillDownSearchContextFilter extends InputProps {}
 
-export const DrillDownSearchContextFilter: FunctionComponent<DrillDownSearchContextFilter> = props => {
-    const { value = '', className, onChange = noop, ...attributes } = props
-    const [showSuggest, setShowSuggest] = useState<boolean>(true)
-    const debouncedQuery = useDebounce(value, 700)
+export const DrillDownSearchContextFilter = forwardRef<HTMLInputElement, DrillDownSearchContextFilter>(
+    (props, reference) => {
+        const { value = '', className, onChange = noop, ...attributes } = props
+        const [showSuggest, setShowSuggest] = useState<boolean>(true)
+        const debouncedQuery = useDebounce(value, 700)
 
-    const handleSelect = (value: string): void => {
-        setShowSuggest(false)
-        onChange(value)
+        const handleSelect = (value: string): void => {
+            setShowSuggest(false)
+            onChange(value)
+        }
+
+        const handleChange = (event: ChangeEvent<HTMLInputElement>): void => {
+            setShowSuggest(true)
+            onChange(event)
+        }
+
+        return (
+            <Combobox onSelect={handleSelect}>
+                <ComboboxInput
+                    {...attributes}
+                    ref={reference}
+                    as={DrillDownInput}
+                    placeholder="global (default)"
+                    prefix="context:"
+                    value={value.toString()}
+                    className={classNames(className, styles.input)}
+                    onChange={handleChange}
+                />
+
+                {showSuggest && (
+                    <ComboboxList className={styles.suggestionList}>
+                        <SuggestPanel query={debouncedQuery.toString()} />
+                    </ComboboxList>
+                )}
+            </Combobox>
+        )
     }
-
-    const handleChange = (event: ChangeEvent<HTMLInputElement>): void => {
-        setShowSuggest(true)
-        onChange(event)
-    }
-
-    return (
-        <Combobox onSelect={handleSelect}>
-            <ComboboxInput
-                {...attributes}
-                as={DrillDownInput}
-                placeholder="global (default)"
-                prefix="context:"
-                value={value.toString()}
-                className={classNames(className, styles.input)}
-                onChange={handleChange}
-            />
-
-            {showSuggest && (
-                <ComboboxList className={styles.suggestionList}>
-                    <SuggestPanel query={debouncedQuery.toString()} />
-                </ComboboxList>
-            )}
-        </Combobox>
-    )
-}
+)
 
 interface SuggestPanelProps {
     query: string

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/search-context/DrillDownSearchContextFilter.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/search-context/DrillDownSearchContextFilter.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, forwardRef, memo, useState } from 'react'
+import { ChangeEvent, FocusEvent, forwardRef, memo, useState } from 'react'
 
 import { gql, useQuery } from '@apollo/client'
 import { Combobox, ComboboxInput, ComboboxList, ComboboxOption, ComboboxOptionText } from '@reach/combobox'
@@ -35,8 +35,8 @@ interface DrillDownSearchContextFilter extends InputProps {}
 
 export const DrillDownSearchContextFilter = forwardRef<HTMLInputElement, DrillDownSearchContextFilter>(
     (props, reference) => {
-        const { value = '', className, onChange = noop, ...attributes } = props
-        const [showSuggest, setShowSuggest] = useState<boolean>(true)
+        const { value = '', className, onChange = noop, onFocus = noop, ...attributes } = props
+        const [showSuggest, setShowSuggest] = useState<boolean>(false)
         const debouncedQuery = useDebounce(value, 700)
 
         const handleSelect = (value: string): void => {
@@ -47,6 +47,11 @@ export const DrillDownSearchContextFilter = forwardRef<HTMLInputElement, DrillDo
         const handleChange = (event: ChangeEvent<HTMLInputElement>): void => {
             setShowSuggest(true)
             onChange(event)
+        }
+
+        const handleFocus = (event: FocusEvent<HTMLInputElement>): void => {
+            setShowSuggest(true)
+            onFocus(event)
         }
 
         return (
@@ -60,6 +65,7 @@ export const DrillDownSearchContextFilter = forwardRef<HTMLInputElement, DrillDo
                     value={value.toString()}
                     className={classNames(className, styles.input)}
                     onChange={handleChange}
+                    onFocus={handleFocus}
                 />
 
                 {showSuggest && (

--- a/client/web/src/enterprise/insights/pages/insights/insight/components/standalone-backend-insight/StandaloneBackendInsight.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/insight/components/standalone-backend-insight/StandaloneBackendInsight.tsx
@@ -51,6 +51,7 @@ export const StandaloneBackendInsight: React.FunctionComponent<StandaloneBackend
     // Live valid filters from filter form. They are updated whenever the user is changing
     // filter value in filters fields.
     const [filters, setFilters] = useState<InsightFilters>(originalInsightFilters)
+    const [filterVisualMode, setFilterVisialMode] = useState<FilterSectionVisualMode>(FilterSectionVisualMode.Preview)
     const debouncedFilters = useDebounce(useDeepMemo<InsightFilters>(filters), 500)
 
     const { state, isVisible } = useInsightData(
@@ -115,7 +116,8 @@ export const StandaloneBackendInsight: React.FunctionComponent<StandaloneBackend
                     <DrillDownInsightFilters
                         initialValues={filters}
                         originalValues={originalInsightFilters}
-                        visualMode={FilterSectionVisualMode.HorizontalSections}
+                        visualMode={filterVisualMode}
+                        onVisualModeChange={setFilterVisialMode}
                         onFiltersChange={handleFilterChange}
                         onFilterSave={handleFilterSave}
                         onCreateInsightRequest={() => setStep(DrillDownFiltersStep.ViewCreation)}


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/35044

This PR simply adds collapsed visual state for the drill down panel.


## Test plan
- Make sure that the dashboard page filter panel layout doesn't have any visual regression
- Make sure that the filters section on the insight independent page matches [the design](https://www.figma.com/file/Y4grZjTxnXHEQSoeB14vU1/Share-a-link-to-an-individual-code-insight-RFC-654?node-id=1228%3A16270)

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vk-add-collapse-expand-state-to.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-kdsvqwhycq.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
