### PR TITLE
[Accessibility]: Improve screen reader compatibility with copy path button

### DIFF
--- a/client/web/src/repo/actions/CopyPathAction.tsx
+++ b/client/web/src/repo/actions/CopyPathAction.tsx
@@ -4,7 +4,7 @@ import copy from 'copy-to-clipboard'
 import ContentCopyIcon from 'mdi-react/ContentCopyIcon'
 import { useLocation } from 'react-router'
 
-import { Button, TooltipController, Icon } from '@sourcegraph/wildcard'
+import { Button, TooltipController, Icon, screenReaderAnnounce } from '@sourcegraph/wildcard'
 
 import { eventLogger } from '../../tracking/eventLogger'
 import { parseBrowserRepoURL } from '../../util/url'
@@ -28,21 +28,17 @@ export const CopyPathAction: React.FunctionComponent<React.PropsWithChildren<unk
         const { repoName, filePath } = parseBrowserRepoURL(location.pathname)
         copy(filePath || repoName) // copy the file path if present; else it's the repo path.
         setCopied(true)
+        screenReaderAnnounce('Path copied to clipboard')
 
         setTimeout(() => {
             setCopied(false)
         }, 1000)
     }
 
+    const label = copied ? 'Copied!' : 'Copy path to clipboard'
+
     return (
-        <Button
-            variant="icon"
-            className="p-2"
-            data-tooltip={copied ? 'Copied!' : 'Copy path to clipboard'}
-            aria-label="Copy path"
-            onClick={onClick}
-            size="sm"
-        >
+        <Button variant="icon" className="p-2" data-tooltip={label} aria-label={label} onClick={onClick} size="sm">
             <Icon className={styles.copyIcon} as={ContentCopyIcon} />
         </Button>
     )


### PR DESCRIPTION
1. Adds a label to the button, so screen readers can understand what clicking the button will do.
2. Adds a `screenReaderAnnounce` to inform screen readers that the action was successful.

Audit issue: https://github.com/sourcegraph/sourcegraph/issues/34418

## Test plan

Tested locally with a screen reader
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-tr-copy-path-screen-reader.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-uymlewirfg.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
