### PR TITLE
[Accessibility]: Improve settings screen reader navigation

### DIFF
--- a/client/web/src/settings/SettingsArea.tsx
+++ b/client/web/src/settings/SettingsArea.tsx
@@ -24,6 +24,7 @@ import { PageHeader } from '@sourcegraph/wildcard'
 import { AuthenticatedUser } from '../auth'
 import { queryGraphQL } from '../backend/graphql'
 import { HeroPage } from '../components/HeroPage'
+import { PageTitle } from '../components/PageTitle'
 import { eventLogger } from '../tracking/eventLogger'
 
 import { mergeSettingsSchemas } from './configuration'
@@ -169,6 +170,7 @@ export class SettingsArea extends React.Component<Props, State> {
 
         return (
             <div className={classNames('h-100 d-flex flex-column', this.props.className)}>
+                <PageTitle title="Settings" />
                 <PageHeader headingElement="h2" path={[{ text: `${term} settings` }]} className="mb-3" />
                 {this.props.extraHeader}
                 <Switch>

--- a/client/web/src/user/settings/privacy/UserSettingsPrivacyPage.tsx
+++ b/client/web/src/user/settings/privacy/UserSettingsPrivacyPage.tsx
@@ -64,7 +64,7 @@ export const UserSettingsPrivacyPage: React.FunctionComponent<React.PropsWithChi
 
     return (
         <div>
-            <PageTitle title="Profile" />
+            <PageTitle title="Privacy" />
             <PageHeader path={[{ text: 'Privacy' }]} headingElement="h2" className={styles.heading} />
             <Container>
                 <Checkbox

--- a/client/web/src/user/settings/research/ProductResearch.tsx
+++ b/client/web/src/user/settings/research/ProductResearch.tsx
@@ -6,6 +6,7 @@ import { TelemetryService } from '@sourcegraph/shared/src/telemetry/telemetrySer
 import { Container, PageHeader, ButtonLink, Icon } from '@sourcegraph/wildcard'
 
 import { AuthenticatedUser } from '../../../auth'
+import { PageTitle } from '../../../components/PageTitle'
 
 interface Props {
     telemetryService: TelemetryService
@@ -27,6 +28,7 @@ export const ProductResearchPage: React.FunctionComponent<React.PropsWithChildre
 
     return (
         <>
+            <PageTitle title="Product research" />
             <PageHeader headingElement="h2" path={[{ text: 'Product research and feedback' }]} className="mb-3" />
             <Container>
                 <p>


### PR DESCRIPTION
closes https://github.com/sourcegraph/sourcegraph/issues/34454
related to https://github.com/sourcegraph/sourcegraph/issues/34429

A previous PR: https://github.com/sourcegraph/sourcegraph/pull/35413 implemented logic to ensure that screen readers are updated on `document.title` changes.

This PR adds additional page titles to our setting pages to ensure we have proper coverage here.


## Test plan

Tested locally with a screen reader

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-tr-improve-settings-navigation.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-xgakkummtv.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
