### PR TITLE
instrumentation: Replace noisy rate limit logs with metrics

### DIFF
--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -11708,6 +11708,48 @@ Query: `max by(name) (rate(src_gitlab_rate_limit_wait_duration_seconds{resource=
 
 <br />
 
+#### repo-updater: src_internal_rate_limit_wait_duration_bucket
+
+<p class="subtitle">95th percentile time spent successfully waiting on our internal rate limiter</p>
+
+Indicates how long we`re waiting on our internal rate limiter when communicating with a code host
+
+This panel has no related alerts.
+
+To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel=100250` on your Sourcegraph instance.
+
+<sub>*Managed by the [Sourcegraph Repo Management team](https://handbook.sourcegraph.com/departments/product-engineering/engineering/enablement/repo-management).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Query: `histogram_quantile(0.95, sum(rate(src_internal_rate_limit_wait_duration_bucket{failed="false"}[5m])) by (le, urn))`
+
+</details>
+
+<br />
+
+#### repo-updater: src_internal_rate_limit_wait_error_count
+
+<p class="subtitle">Rate of failures waiting on our internal rate limiter</p>
+
+The rate at which we fail our internal rate limiter.
+
+This panel has no related alerts.
+
+To see this panel, visit `/-/debug/grafana/d/repo-updater/repo-updater?viewPanel=100251` on your Sourcegraph instance.
+
+<sub>*Managed by the [Sourcegraph Repo Management team](https://handbook.sourcegraph.com/departments/product-engineering/engineering/enablement/repo-management).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Query: `sum by (urn) (rate(src_internal_rate_limit_wait_duration_count{failed="true"}[5m]))`
+
+</details>
+
+<br />
+
 ### Repo Updater: Batches: dbstore stats
 
 #### repo-updater: batches_dbstore_total

--- a/internal/extsvc/bitbucketserver/client_test.go
+++ b/internal/extsvc/bitbucketserver/client_test.go
@@ -24,6 +24,7 @@ import (
 	"golang.org/x/time/rate"
 
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/auth"
+	"github.com/sourcegraph/sourcegraph/internal/ratelimit"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
@@ -1215,7 +1216,7 @@ func TestClient_WithAuthenticator(t *testing.T) {
 
 	old := &Client{
 		URL:       uri,
-		rateLimit: rate.NewLimiter(10, 10),
+		rateLimit: &ratelimit.InstrumentedLimiter{Limiter: rate.NewLimiter(10, 10)},
 		Auth:      &auth.BasicAuth{Username: "johnsson", Password: "mothersmaidenname"},
 	}
 

--- a/internal/extsvc/gerrit/client.go
+++ b/internal/extsvc/gerrit/client.go
@@ -9,10 +9,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"time"
-
-	"github.com/inconshreveable/log15"
-	"golang.org/x/time/rate"
 
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/internal/ratelimit"
@@ -32,7 +28,7 @@ type Client struct {
 
 	// RateLimit is the self-imposed rate limiter (since Gerrit does not have a concept
 	// of rate limiting in HTTP response headers).
-	rateLimit *rate.Limiter
+	rateLimit *ratelimit.InstrumentedLimiter
 }
 
 // NewClient returns an authenticated Gerrit API client with
@@ -127,13 +123,8 @@ func (c *Client) do(ctx context.Context, req *http.Request, result any) (*http.R
 	// Add Basic Auth headers for authenticated requests.
 	req.Header.Add("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(c.Config.Username+":"+c.Config.Password)))
 
-	startWait := time.Now()
 	if err := c.rateLimit.Wait(ctx); err != nil {
 		return nil, err
-	}
-
-	if d := time.Since(startWait); d > 200*time.Millisecond {
-		log15.Warn("Gerrit self-enforced API rate limit: request delayed longer than expected due to rate limit", "delay", d)
 	}
 
 	resp, err := c.httpClient.Do(req)

--- a/internal/extsvc/github/v3.go
+++ b/internal/extsvc/github/v3.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/google/go-github/v41/github"
-	"golang.org/x/time/rate"
 
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/auth"
@@ -57,7 +56,7 @@ type V3Client struct {
 	rateLimitMonitor *ratelimit.Monitor
 
 	// rateLimit is our self imposed rate limiter
-	rateLimit *rate.Limiter
+	rateLimit *ratelimit.InstrumentedLimiter
 
 	// resource specifies which API this client is intended for.
 	// One of 'rest' or 'search'.

--- a/internal/extsvc/github/v4.go
+++ b/internal/extsvc/github/v4.go
@@ -15,7 +15,6 @@ import (
 	"github.com/graphql-go/graphql/language/ast"
 	"github.com/graphql-go/graphql/language/parser"
 	"github.com/graphql-go/graphql/language/visitor"
-	"golang.org/x/time/rate"
 
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/auth"
@@ -54,7 +53,7 @@ type V4Client struct {
 	rateLimitMonitor *ratelimit.Monitor
 
 	// rateLimit is our self imposed rate limiter.
-	rateLimit *rate.Limiter
+	rateLimit *ratelimit.InstrumentedLimiter
 }
 
 // NewV4Client creates a new GitHub GraphQL API client with an optional default

--- a/internal/extsvc/gitlab/client.go
+++ b/internal/extsvc/gitlab/client.go
@@ -14,7 +14,6 @@ import (
 	"time"
 
 	"github.com/inconshreveable/log15"
-	"golang.org/x/time/rate"
 
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/auth"
@@ -175,7 +174,7 @@ type Client struct {
 	projCache        *rcache.Cache
 	Auth             auth.Authenticator
 	rateLimitMonitor *ratelimit.Monitor
-	rateLimiter      *rate.Limiter // Our internal rate limiter
+	rateLimiter      *ratelimit.InstrumentedLimiter // Our internal rate limiter
 }
 
 // newClient creates a new GitLab API client with an optional personal access token to authenticate requests.

--- a/internal/extsvc/npm/npm.go
+++ b/internal/extsvc/npm/npm.go
@@ -9,12 +9,9 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"time"
 
-	"github.com/inconshreveable/log15"
 	"github.com/opentracing-contrib/go-stdlib/nethttp"
 	otlog "github.com/opentracing/opentracing-go/log"
-	"golang.org/x/time/rate"
 
 	"github.com/sourcegraph/sourcegraph/internal/conf/reposource"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
@@ -59,7 +56,7 @@ func FetchSources(ctx context.Context, client Client, dependency *reposource.Npm
 type HTTPClient struct {
 	registryURL string
 	doer        httpcli.Doer
-	limiter     *rate.Limiter
+	limiter     *ratelimit.InstrumentedLimiter
 	credentials string
 }
 
@@ -116,12 +113,8 @@ func (client *HTTPClient) do(ctx context.Context, req *http.Request) (*http.Resp
 		nethttp.OperationName("npm"),
 		nethttp.ClientTrace(false))
 	defer ht.Finish()
-	startWait := time.Now()
 	if err := client.limiter.Wait(ctx); err != nil {
 		return nil, err
-	}
-	if d := time.Since(startWait); d > 200*time.Millisecond {
-		log15.Warn("npm self-enforced API rate limit: request delayed longer than expected due to rate limit", "delay", d)
 	}
 	return client.doer.Do(req)
 }

--- a/internal/ratelimit/rate_limit.go
+++ b/internal/ratelimit/rate_limit.go
@@ -1,12 +1,18 @@
 package ratelimit
 
 import (
+	"context"
 	"math"
 	"sync"
+	"time"
 
-	"github.com/sourcegraph/sourcegraph/internal/conf"
-
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 	"golang.org/x/time/rate"
+
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 )
 
 // DefaultRegistry is the default global rate limit registry, which holds rate
@@ -19,7 +25,7 @@ const defaultBurst = 10
 // rate limiter will be added.
 func NewRegistry() *Registry {
 	return &Registry{
-		rateLimiters: make(map[string]*rate.Limiter),
+		rateLimiters: make(map[string]*InstrumentedLimiter),
 	}
 }
 
@@ -28,7 +34,7 @@ type Registry struct {
 	mu sync.Mutex
 	// rateLimiters contains mappings of external service to its *rate.Limiter. The
 	// key should be the URN of the external service.
-	rateLimiters map[string]*rate.Limiter
+	rateLimiters map[string]*InstrumentedLimiter
 }
 
 // Get returns the rate limiter configured for the given URN of an external
@@ -37,34 +43,34 @@ type Registry struct {
 // limiter specified in the config.
 //
 // Modifications to the returned rate limiter takes effect on all call sites.
-func (r *Registry) Get(urn string) *rate.Limiter {
-	return r.GetOrSet(urn, nil)
+func (r *Registry) Get(urn string) *InstrumentedLimiter {
+	return r.getOrSet(urn, nil)
 }
 
-// GetOrSet returns the rate limiter configured for the given URN of an external
+// getOrSet returns the rate limiter configured for the given URN of an external
 // service, and sets the `fallback` to be the rate limiter if no rate limiter has
 // been configured for the URN. A nil `fallback` indicates an infinite limiter.
 //
 // Modifications to the returned rate limiter takes effect on all call sites.
-func (r *Registry) GetOrSet(urn string, fallback *rate.Limiter) *rate.Limiter {
+func (r *Registry) getOrSet(urn string, fallback *InstrumentedLimiter) *InstrumentedLimiter {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	l := r.rateLimiters[urn]
-	if l == nil {
-		if fallback == nil {
-			defaultRateLimit := conf.Get().DefaultRateLimit
-			// the rate limit in the config is in requests per hour, whereas rate.Limit is in
-			// requests per second.
-			fallbackRateLimit := rate.Limit(defaultRateLimit / 3600.0)
-			if defaultRateLimit <= 0 {
-				fallbackRateLimit = rate.Inf
-			}
-			fallback = rate.NewLimiter(fallbackRateLimit, defaultBurst)
-		}
-		r.rateLimiters[urn] = fallback
-		return fallback
+	if l != nil {
+		return l
 	}
-	return l
+	if fallback == nil {
+		defaultRateLimit := conf.Get().DefaultRateLimit
+		// the rate limit in the config is in requests per hour, whereas rate.Limit is in
+		// requests per second.
+		fallbackRateLimit := rate.Limit(defaultRateLimit / 3600.0)
+		if defaultRateLimit <= 0 {
+			fallbackRateLimit = rate.Inf
+		}
+		fallback = &InstrumentedLimiter{urn: urn, Limiter: rate.NewLimiter(fallbackRateLimit, defaultBurst)}
+	}
+	r.rateLimiters[urn] = fallback
+	return fallback
 }
 
 // Count returns the total number of rate limiters in the registry.
@@ -106,3 +112,46 @@ func (r *Registry) LimitInfo() map[string]LimitInfo {
 	}
 	return m
 }
+
+// InstrumentedLimiter is wraps a *rate.Limiter with instrumentation
+type InstrumentedLimiter struct {
+	urn string
+	*rate.Limiter
+}
+
+// Wait is shorthand for WaitN(ctx, 1).
+func (i *InstrumentedLimiter) Wait(ctx context.Context) error {
+	return i.WaitN(ctx, 1)
+}
+
+// WaitN blocks until lim permits n events to happen.
+// It returns an error if n exceeds the Limiter's burst size, the Context is
+// canceled, or the expected wait time exceeds the Context's Deadline.
+// The burst limit is ignored if the rate limit is Inf.
+func (i *InstrumentedLimiter) WaitN(ctx context.Context, n int) error {
+	start := time.Now()
+	err := i.Limiter.WaitN(ctx, n)
+	d := time.Since(start)
+	failedLabel := "false"
+	if err != nil {
+		failedLabel = "true"
+	}
+	urn := i.urn
+
+	// On sourcegraph.com the cardinality of code hosts is too high, so instead just
+	// group by kind
+	if envvar.SourcegraphDotComMode() {
+		if kind, _ := extsvc.DecodeURN(urn); kind != "" {
+			urn = kind
+		}
+	}
+
+	metricWaitDuration.WithLabelValues(urn, failedLabel).Observe(d.Seconds())
+	return err
+}
+
+var metricWaitDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
+	Name:    "src_internal_rate_limit_wait_duration",
+	Help:    "Time spent waiting for our internal rate limiter",
+	Buckets: []float64{0.2, 0.5, 1, 2, 5, 10, 30, 60},
+}, []string{"urn", "failed"})

--- a/internal/ratelimit/rate_limit_test.go
+++ b/internal/ratelimit/rate_limit_test.go
@@ -19,8 +19,8 @@ func TestDefaultRateLimiter(t *testing.T) {
 	defer conf.Mock(nil)
 
 	r := NewRegistry()
-	got := r.Get("Unknown")
-	want := rate.NewLimiter(rate.Limit(2), defaultBurst)
+	got := r.Get("unknown")
+	want := &InstrumentedLimiter{urn: "unknown", Limiter: rate.NewLimiter(rate.Limit(2), defaultBurst)}
 	assert.Equal(t, want, got)
 }
 
@@ -28,14 +28,14 @@ func TestRegistry(t *testing.T) {
 	r := NewRegistry()
 
 	got := r.Get("404")
-	want := rate.NewLimiter(rate.Inf, defaultBurst)
+	want := &InstrumentedLimiter{urn: "404", Limiter: rate.NewLimiter(rate.Inf, defaultBurst)}
 	assert.Equal(t, want, got)
 
-	rl := rate.NewLimiter(10, 10)
-	got = r.GetOrSet("extsvc:github:1", rl)
+	rl := &InstrumentedLimiter{urn: "extsvc:github:1", Limiter: rate.NewLimiter(10, 10)}
+	got = r.getOrSet("extsvc:github:1", rl)
 	assert.Equal(t, rl, got)
 
-	got = r.GetOrSet("extsvc:github:1", rate.NewLimiter(1000, 10))
+	got = r.getOrSet("extsvc:github:1", &InstrumentedLimiter{urn: "extsvc:githu:1", Limiter: rate.NewLimiter(1000, 10)})
 	assert.Equal(t, rl, got)
 
 	assert.Equal(t, 2, r.Count())
@@ -43,8 +43,8 @@ func TestRegistry(t *testing.T) {
 
 func TestLimitInfo(t *testing.T) {
 	r := NewRegistry()
-	r.GetOrSet("extsvc:github:1", rate.NewLimiter(rate.Inf, 1))
-	r.GetOrSet("extsvc:github:2", rate.NewLimiter(10, 1))
+	r.getOrSet("extsvc:github:1", &InstrumentedLimiter{urn: "extsvc:github:1", Limiter: rate.NewLimiter(rate.Inf, 1)})
+	r.getOrSet("extsvc:github:2", &InstrumentedLimiter{urn: "extsvc:github:2", Limiter: rate.NewLimiter(10, 1)})
 
 	info := r.LimitInfo()
 

--- a/monitoring/definitions/repo_updater.go
+++ b/monitoring/definitions/repo_updater.go
@@ -467,6 +467,26 @@ func RepoUpdater() *monitoring.Container {
 							Interpretation: "Indicates how long we're waiting on the rate limit once it has been exceeded",
 						},
 					},
+					{
+						{
+							Name:           "src_internal_rate_limit_wait_duration_bucket",
+							Description:    "95th percentile time spent successfully waiting on our internal rate limiter",
+							Query:          `histogram_quantile(0.95, sum(rate(src_internal_rate_limit_wait_duration_bucket{failed="false"}[5m])) by (le, urn))`,
+							Panel:          monitoring.Panel().LegendFormat("{{urn}}").Unit(monitoring.Seconds),
+							Owner:          monitoring.ObservableOwnerRepoManagement,
+							NoAlert:        true,
+							Interpretation: "Indicates how long we're waiting on our internal rate limiter when communicating with a code host",
+						},
+						{
+							Name:           "src_internal_rate_limit_wait_error_count",
+							Description:    "rate of failures waiting on our internal rate limiter",
+							Query:          `sum by (urn) (rate(src_internal_rate_limit_wait_duration_count{failed="true"}[5m]))`,
+							Panel:          monitoring.Panel().LegendFormat("{{urn}}"),
+							Owner:          monitoring.ObservableOwnerRepoManagement,
+							NoAlert:        true,
+							Interpretation: "The rate at which we fail our internal rate limiter.",
+						},
+					},
 				},
 			},
 


### PR DESCRIPTION
Instead of logging every time there is a small wait on our internal rate
limiter we now record all wait times and intrument the 95th percetile
wait per code host.

Note that on sourcegraph.com we have too many code hosts so we instead
group the wait time by code host kind.

## Test plan

All tests pass and checked dashboards locally