### PR TITLE
[SG-35514] logging(gitstart): migrate gitserver logging

### DIFF
--- a/cmd/gitserver/server/cleanup_test.go
+++ b/cmd/gitserver/server/cleanup_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
+	logger "github.com/sourcegraph/sourcegraph/lib/log"
 )
 
 const (
@@ -62,7 +63,9 @@ func TestCleanup_computeStats(t *testing.T) {
 
 	// We run cleanupRepos because we want to test as a side-effect it creates
 	// the correct file in the correct place.
-	s := &Server{ReposDir: root}
+	s := &Server{ReposDir: root,
+		Log: logger.Scoped("Server", "a gitserver server"),
+	}
 	s.testSetup(t)
 
 	if _, err := s.DB.ExecContext(context.Background(), `
@@ -124,7 +127,9 @@ func TestCleanupInactive(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	s := &Server{ReposDir: root}
+	s := &Server{ReposDir: root,
+		Log: logger.Scoped("Server", "a gitserver server"),
+	}
 	s.testSetup(t)
 	s.cleanupRepos()
 
@@ -186,7 +191,9 @@ func TestGitGCAuto(t *testing.T) {
 	}
 
 	// Handler must be invoked for Server side-effects.
-	s := &Server{ReposDir: root}
+	s := &Server{ReposDir: root,
+		Log: logger.Scoped("Server", "a gitserver server"),
+	}
 	s.testSetup(t)
 	s.cleanupRepos()
 
@@ -300,6 +307,7 @@ func TestCleanupExpired(t *testing.T) {
 	}
 
 	s := &Server{
+		Log:              logger.Scoped("Server", "a gitserver server"),
 		ReposDir:         root,
 		GetRemoteURLFunc: getRemoteURL,
 		GetVCSSyncer: func(ctx context.Context, name api.RepoName) (VCSSyncer, error) {
@@ -468,7 +476,7 @@ func TestCleanupOldLocks(t *testing.T) {
 		}
 	}
 
-	s := &Server{ReposDir: root}
+	s := &Server{ReposDir: root, Log: logger.Scoped("Server", "a gitserver server")}
 	s.testSetup(t)
 	s.cleanupRepos()
 
@@ -492,7 +500,7 @@ func TestCleanupOldLocks(t *testing.T) {
 func TestSetupAndClearTmp(t *testing.T) {
 	root := t.TempDir()
 
-	s := &Server{ReposDir: root}
+	s := &Server{ReposDir: root, Log: logger.Scoped("Server", "a gitserver server")}
 
 	// All non .git paths should become .git
 	mkFiles(t, root,
@@ -554,7 +562,7 @@ func TestSetupAndClearTmp(t *testing.T) {
 func TestSetupAndClearTmp_Empty(t *testing.T) {
 	root := t.TempDir()
 
-	s := &Server{ReposDir: root}
+	s := &Server{ReposDir: root, Log: logger.Scoped("Server", "a gitserver server")}
 
 	_, err := s.SetupAndClearTmp()
 	if err != nil {
@@ -607,6 +615,7 @@ func TestRemoveRepoDirectory(t *testing.T) {
 	}
 
 	s := &Server{
+		Log:      logger.Scoped("Server", "a gitserver server"),
 		ReposDir: root,
 		DB:       db,
 		ctx:      ctx,
@@ -669,6 +678,7 @@ func TestRemoveRepoDirectory_Empty(t *testing.T) {
 		"github.com/foo/baz/.git/HEAD",
 	)
 	s := &Server{
+		Log:      logger.Scoped("Server", "a gitserver server"),
 		ReposDir: root,
 	}
 
@@ -684,6 +694,7 @@ func TestRemoveRepoDirectory_Empty(t *testing.T) {
 func TestHowManyBytesToFree(t *testing.T) {
 	const G = 1024 * 1024 * 1024
 	s := &Server{
+		Log:                logger.Scoped("Server", "a gitserver server"),
 		DesiredPercentFree: 10,
 	}
 
@@ -825,13 +836,13 @@ func isEmptyDir(path string) (bool, error) {
 
 func TestFreeUpSpace(t *testing.T) {
 	t.Run("no error if no space requested and no repos", func(t *testing.T) {
-		s := &Server{DiskSizer: &fakeDiskSizer{}}
+		s := &Server{DiskSizer: &fakeDiskSizer{}, Log: logger.Scoped("Server", "a gitserver server")}
 		if err := s.freeUpSpace(0); err != nil {
 			t.Fatal(err)
 		}
 	})
 	t.Run("error if space requested and no repos", func(t *testing.T) {
-		s := &Server{DiskSizer: &fakeDiskSizer{}}
+		s := &Server{DiskSizer: &fakeDiskSizer{}, Log: logger.Scoped("Server", "a gitserver server")}
 		if err := s.freeUpSpace(1); err == nil {
 			t.Fatal("want error")
 		}
@@ -860,6 +871,7 @@ func TestFreeUpSpace(t *testing.T) {
 
 		// Run.
 		s := Server{
+			Log:       logger.Scoped("Server", "a gitserver server"),
 			ReposDir:  rd,
 			DiskSizer: &fakeDiskSizer{},
 		}
@@ -1229,7 +1241,7 @@ func TestCleanup_setRepoSizes(t *testing.T) {
 
 	// We run cleanupRepos because we want to test as a side-effect it creates
 	// the correct file in the correct place.
-	s := &Server{ReposDir: root}
+	s := &Server{ReposDir: root, Log: logger.Scoped("Server", "a gitserver server")}
 	s.Handler() // Handler as a side-effect sets up Server
 	db := dbtest.NewDB(t)
 	s.DB = database.NewDB(db)

--- a/cmd/gitserver/server/commands.go
+++ b/cmd/gitserver/server/commands.go
@@ -4,26 +4,26 @@ import (
 	"encoding/json"
 	"net/http"
 
-	"github.com/inconshreveable/log15"
-
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/protocol"
+	"github.com/sourcegraph/sourcegraph/lib/log"
 )
 
 func handleGetObject(getObject gitdomain.GetObjectFunc) func(w http.ResponseWriter, r *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 		var req protocol.GetObjectRequest
+		logger := log.Scoped("handleGetObject", "handles get object")
 
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 			http.Error(w, "decoding body", http.StatusBadRequest)
-			log15.Error("handleGetObject: decoding body", "error", err)
+			logger.Error("handleGetObject: decoding body", log.Error(err))
 			return
 		}
 
 		obj, err := getObject(r.Context(), req.Repo, req.ObjectName)
 		if err != nil {
 			http.Error(w, "getting object", http.StatusInternalServerError)
-			log15.Error("handleGetObject: getting object", "error", err)
+			logger.Error("handleGetObject: getting object", log.Error(err))
 			return
 		}
 
@@ -32,7 +32,7 @@ func handleGetObject(getObject gitdomain.GetObjectFunc) func(w http.ResponseWrit
 		}
 
 		if err := json.NewEncoder(w).Encode(resp); err != nil {
-			log15.Error("handleGetObject: sending response", "error", err)
+			logger.Error("handleGetObject: sending response", log.Error(err))
 		}
 	}
 }

--- a/cmd/gitserver/server/patch.go
+++ b/cmd/gitserver/server/patch.go
@@ -14,11 +14,10 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/inconshreveable/log15"
-
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/vcs"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"github.com/sourcegraph/sourcegraph/lib/log"
 )
 
 var patchID uint64
@@ -70,7 +69,7 @@ func (s *Server) createCommitFromPatch(ctx context.Context, req protocol.CreateC
 	}
 
 	if err != nil {
-		log15.Error("Failed to get remote URL", "ref", ref, "err", err)
+		s.Log.Error("Failed to get remote URL", log.String("ref", ref), log.Error(err))
 		resp.SetError(repo, "", "", errors.Wrap(err, "repoRemoteURL"))
 		return http.StatusInternalServerError, resp
 	}
@@ -105,9 +104,20 @@ func (s *Server) createCommitFromPatch(ctx context.Context, req protocol.CreateC
 		out, err := runWith(ctx, cmd, true, nil)
 		if err != nil {
 			resp.SetError(repo, argsToString(cmd.Args), string(out), errors.Wrap(err, "gitserver: "+reason))
-			log15.Info("command failed", "prefix", prefix, "command", argsToString(cmd.Args), "duration", time.Since(t), "error", err, "output", string(out))
+			s.Log.Info("command failed",
+				log.String("prefix", prefix),
+				log.String("command", argsToString(cmd.Args)),
+				log.String("duration", fmt.Sprint(time.Since(t))),
+				log.Error(err),
+				log.String("output", string(out)),
+			)
 		} else {
-			log15.Info("command ran successfully", "prefix", prefix, "command", argsToString(cmd.Args), "duration", time.Since(t), "output", string(out))
+			s.Log.Info("command ran successfully",
+				log.String("prefix", prefix),
+				log.String("command", argsToString(cmd.Args)),
+				log.String("duration", fmt.Sprint(time.Since(t))),
+				log.String("output", string(out)),
+			)
 		}
 		return out, err
 	}
@@ -115,7 +125,7 @@ func (s *Server) createCommitFromPatch(ctx context.Context, req protocol.CreateC
 	if req.UniqueRef {
 		refs, err := repoRemoteRefs(ctx, remoteURL, ref)
 		if err != nil {
-			log15.Error("Failed to get remote refs", "ref", ref, "err", err)
+			s.Log.Error("Failed to get remote refs", log.String("ref", ref), log.Error(err))
 			resp.SetError(repo, "", "", errors.Wrap(err, "repoRemoteRefs"))
 			return http.StatusInternalServerError, resp
 		}
@@ -156,7 +166,11 @@ func (s *Server) createCommitFromPatch(ctx context.Context, req protocol.CreateC
 	cmd.Env = append(os.Environ(), tmpGitPathEnv, altObjectsEnv)
 
 	if out, err := run(cmd, "basing staging on base rev"); err != nil {
-		log15.Error("Failed to base the temporary repo on the base revision.", "ref", ref, "base", req.BaseCommit, "output", string(out))
+		s.Log.Error("Failed to base the temporary repo on the base revision.",
+			log.String("ref", ref),
+			log.String("base", string(req.BaseCommit)),
+			log.String("output", string(out)),
+		)
 		return http.StatusInternalServerError, resp
 	}
 
@@ -167,7 +181,7 @@ func (s *Server) createCommitFromPatch(ctx context.Context, req protocol.CreateC
 	cmd.Stdin = strings.NewReader(req.Patch)
 
 	if out, err := run(cmd, "applying patch"); err != nil {
-		log15.Error("Failed to apply patch.", "ref", ref, "output", string(out))
+		s.Log.Error("Failed to apply patch.", log.String("ref", ref), log.String("output", string(out)))
 		return http.StatusInternalServerError, resp
 	}
 
@@ -206,7 +220,7 @@ func (s *Server) createCommitFromPatch(ctx context.Context, req protocol.CreateC
 	}...)
 
 	if out, err := run(cmd, "committing patch"); err != nil {
-		log15.Error("Failed to commit patch.", "ref", ref, "output", out)
+		s.Log.Error("Failed to commit patch.", log.String("ref", ref), log.String("output", string(out)))
 		return http.StatusInternalServerError, resp
 	}
 
@@ -280,7 +294,7 @@ func (s *Server) createCommitFromPatch(ctx context.Context, req protocol.CreateC
 		}
 
 		if out, err = run(cmd, "pushing ref"); err != nil {
-			log15.Error("Failed to push", "ref", ref, "commit", cmtHash, "output", string(out))
+			s.Log.Error("Failed to push", log.String("ref", ref), log.String("commit", cmtHash), log.String("output", string(out)))
 			return http.StatusInternalServerError, resp
 		}
 	}
@@ -291,7 +305,7 @@ func (s *Server) createCommitFromPatch(ctx context.Context, req protocol.CreateC
 	cmd.Dir = repoGitDir
 
 	if out, err = run(cmd, "creating ref"); err != nil {
-		log15.Error("Failed to create ref for commit.", "ref", ref, "commit", cmtHash, "output", string(out))
+		s.Log.Error("Failed to create ref for commit.", log.String("ref", ref), log.String("commit", cmtHash), log.String("output", string(out)))
 		return http.StatusInternalServerError, resp
 	}
 
@@ -300,8 +314,9 @@ func (s *Server) createCommitFromPatch(ctx context.Context, req protocol.CreateC
 
 func cleanUpTmpRepo(path string) {
 	err := os.RemoveAll(path)
+	logger := log.Scoped("cleanUpTmpRepo", "cleans up temp Repo")
 	if err != nil {
-		log15.Info("unable to clean up tmp repo", "path", path, "err", err)
+		logger.Info("unable to clean up tmp repo", log.String("path", path), log.Error(err))
 	}
 }
 

--- a/cmd/gitserver/server/server_test.go
+++ b/cmd/gitserver/server/server_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/internal/vcs"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
+	logger "github.com/sourcegraph/sourcegraph/lib/log"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
@@ -146,6 +147,7 @@ func TestRequest(t *testing.T) {
 	}
 
 	s := &Server{
+		Log:               logger.Scoped("Server", "a gitserver server"),
 		ReposDir:          "/testroot",
 		skipCloneForTests: true,
 		GetRemoteURLFunc: func(ctx context.Context, name api.RepoName) (string, error) {
@@ -504,6 +506,7 @@ func addCommitToRepo(cmd func(string, ...string) string) string {
 
 func makeTestServer(ctx context.Context, repoDir, remote string, db database.DB) *Server {
 	s := &Server{
+		Log:              logger.Scoped("Server", "a gitserver server"),
 		ReposDir:         repoDir,
 		GetRemoteURLFunc: staticGetRemoteURL(remote),
 		GetVCSSyncer: func(ctx context.Context, name api.RepoName) (VCSSyncer, error) {

--- a/cmd/gitserver/server/ssh_agent.go
+++ b/cmd/gitserver/server/ssh_agent.go
@@ -9,16 +9,17 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/inconshreveable/log15"
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/agent"
 
 	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"github.com/sourcegraph/sourcegraph/lib/log"
 )
 
 // sshAgent speaks the ssh-agent protocol and can be used by gitserver
 // to provide a private key to ssh when talking to the code host.
 type sshAgent struct {
+	log     log.Logger
 	l       net.Listener
 	sock    string
 	keyring agent.Agent
@@ -55,6 +56,7 @@ func newSSHAgent(raw, passphrase []byte) (*sshAgent, error) {
 
 	// Set up the type we're going to return.
 	a := &sshAgent{
+		log:     log.Scoped("ssh Agent", "speaks the ssh-agent protocol and can be used by gitserver"),
 		l:       l,
 		sock:    socketName,
 		keyring: keyring,
@@ -73,7 +75,7 @@ func (a *sshAgent) Listen() {
 			case <-a.done:
 				return
 			default:
-				log15.Error("error accepting socket connection", "err", err)
+				a.log.Error("error accepting socket connection", log.Error(err))
 				return
 			}
 		}
@@ -86,7 +88,7 @@ func (a *sshAgent) Listen() {
 			defer conn.Close()
 
 			if err := agent.ServeAgent(a.keyring, conn); err != nil && err != io.EOF {
-				log15.Error("error serving SSH agent", "err", err)
+				a.log.Error("error serving SSH agent", log.Error(err))
 			}
 		}(conn)
 	}

--- a/cmd/gitserver/server/vcs_dependencies_syncer.go
+++ b/cmd/gitserver/server/vcs_dependencies_syncer.go
@@ -8,18 +8,18 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/inconshreveable/log15"
-
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/dependencies"
 	"github.com/sourcegraph/sourcegraph/internal/conf/reposource"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
 	"github.com/sourcegraph/sourcegraph/internal/vcs"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"github.com/sourcegraph/sourcegraph/lib/log"
 )
 
 // vcsDependenciesSyncer implements the VCSSyncer interface for dependency repos
 // of different types.
 type vcsDependenciesSyncer struct {
+	log    log.Logger
 	typ    string
 	scheme string
 
@@ -107,7 +107,11 @@ func (s *vcsDependenciesSyncer) Fetch(ctx context.Context, remoteURL *vcs.URL, d
 	for _, version := range versions {
 		if d, err := s.source.Get(ctx, depName, version); err != nil {
 			if errcode.IsNotFound(err) {
-				log15.Warn("skipping missing dependency", "dep", depName, "version", version, "type", s.typ)
+				s.log.Warn("skipping missing dependency",
+					log.String("dep", depName),
+					log.String("version", version),
+					log.String("type", s.typ),
+				)
 			} else {
 				errs = errors.Append(errs, err)
 			}
@@ -172,7 +176,10 @@ func (s *vcsDependenciesSyncer) Fetch(ctx context.Context, remoteURL *vcs.URL, d
 		if _, isDependencyTag := dependencyTags[tag]; !isDependencyTag {
 			cmd := exec.CommandContext(ctx, "git", "tag", "-d", tag)
 			if _, err := runCommandInDirectory(ctx, cmd, string(dir), s.placeholder); err != nil {
-				log15.Error("failed to delete git tag", "error", err, "tag", tag)
+				s.log.Error("failed to delete git tag",
+					log.Error(err),
+					log.String("tag", tag),
+				)
 				continue
 			}
 		}
@@ -247,7 +254,7 @@ func (s *vcsDependenciesSyncer) versions(ctx context.Context, packageName string
 	for _, d := range s.configDeps {
 		dep, err := s.source.ParseDependency(d)
 		if err != nil {
-			log15.Warn("skipping malformed dependency", "dep", d, "error", err)
+			s.log.Warn("skipping malformed dependency", log.String("dep", d), log.Error(err))
 			continue
 		}
 

--- a/cmd/gitserver/server/vcs_dependencies_syncer_test.go
+++ b/cmd/gitserver/server/vcs_dependencies_syncer_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/conf/reposource"
 	"github.com/sourcegraph/sourcegraph/internal/vcs"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
+	logger "github.com/sourcegraph/sourcegraph/lib/log"
 )
 
 func TestVcsDependenciesSyncer_Fetch(t *testing.T) {
@@ -33,6 +34,7 @@ func TestVcsDependenciesSyncer_Fetch(t *testing.T) {
 	depsService := &fakeDepsService{deps: map[string][]dependencies.Repo{}}
 
 	s := vcsDependenciesSyncer{
+		log:         logger.Scoped("vcs syncer", "csDependenciesSyncer implements the VCSSyncer interface for dependency repos"),
 		typ:         "fake",
 		scheme:      "fake",
 		placeholder: placeholder,

--- a/cmd/gitserver/server/vcs_syncer_go_modules.go
+++ b/cmd/gitserver/server/vcs_syncer_go_modules.go
@@ -16,6 +16,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/gomodproxy"
 	"github.com/sourcegraph/sourcegraph/internal/unpack"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
+	logger "github.com/sourcegraph/sourcegraph/lib/log"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
@@ -30,6 +31,7 @@ func NewGoModulesSyncer(
 	}
 
 	return &vcsDependenciesSyncer{
+		log:         logger.Scoped("vcs syncer", "csDependenciesSyncer implements the VCSSyncer interface for dependency repos"),
 		typ:         "go_modules",
 		scheme:      dependencies.GoModulesScheme,
 		placeholder: placeholder,

--- a/cmd/gitserver/server/vcs_syncer_jvm_packages.go
+++ b/cmd/gitserver/server/vcs_syncer_jvm_packages.go
@@ -18,6 +18,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/conf/reposource"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/jvmpackages/coursier"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
+	logger "github.com/sourcegraph/sourcegraph/lib/log"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
@@ -43,6 +44,7 @@ func NewJVMPackagesSyncer(connection *schema.JVMPackagesConnection, svc *depende
 	}
 
 	return &vcsDependenciesSyncer{
+		log:         logger.Scoped("vcs syncer", "csDependenciesSyncer implements the VCSSyncer interface for dependency repos"),
 		typ:         "jvm_packages",
 		scheme:      dependencies.JVMPackagesScheme,
 		placeholder: placeholder,

--- a/cmd/gitserver/server/vcs_syncer_npm_packages.go
+++ b/cmd/gitserver/server/vcs_syncer_npm_packages.go
@@ -8,13 +8,13 @@ import (
 	"os"
 	"path"
 
-	"github.com/inconshreveable/log15"
-
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/dependencies"
 	"github.com/sourcegraph/sourcegraph/internal/conf/reposource"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/npm"
 	"github.com/sourcegraph/sourcegraph/internal/unpack"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"github.com/sourcegraph/sourcegraph/lib/log"
+	logger "github.com/sourcegraph/sourcegraph/lib/log"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
@@ -31,6 +31,7 @@ func NewNpmPackagesSyncer(
 	}
 
 	return &vcsDependenciesSyncer{
+		log:         logger.Scoped("vcs syncer", "csDependenciesSyncer implements the VCSSyncer interface for dependency repos"),
 		typ:         "npm_packages",
 		scheme:      dependencies.NpmPackagesScheme,
 		placeholder: placeholder,
@@ -91,6 +92,7 @@ func (s *npmPackagesSyncer) Download(ctx context.Context, dir string, dep reposo
 // Additionally, if all the files in the tarball have paths of the form
 // dir/<blah> for the same directory 'dir', the 'dir' will be stripped.
 func decompressTgz(tgz io.Reader, destination string) error {
+	logger := log.Scoped("decompressTgz", "Decompress a tarball at tgzPath, putting the files under destination.")
 	err := unpack.Tgz(tgz, destination, unpack.Opts{
 		SkipInvalid: true,
 		Filter: func(path string, file fs.FileInfo) bool {
@@ -98,10 +100,10 @@ func decompressTgz(tgz io.Reader, destination string) error {
 
 			const sizeLimit = 15 * 1024 * 1024
 			if size >= sizeLimit {
-				log15.Warn("skipping large file in npm package",
-					"path", file.Name(),
-					"size", size,
-					"limit", sizeLimit,
+				logger.Warn("skipping large file in npm package",
+					log.String("path", file.Name()),
+					log.Int64("size", size),
+					log.Int("limit", sizeLimit),
 				)
 				return false
 			}


### PR DESCRIPTION
## Description

The main existing logger usage to replace are calls to log15.

## Test plan

All ~125 occurrences of log15 calls in files that appear related to gitserver are replaced with logging calls to an appropriately scoped log.Logger instance, e.g. ones held by the parent struct:

https://sourcegraph.com/search?q=context:global+r:%5Egithub%5C.com/sourcegraph/sourcegraph%24++content:%22log15.%22+lang:go+f:gitserver&patternType=literal

Green CI builds.

## Refs

- [SourceGraph Issue](https://github.com/sourcegraph/sourcegraph/issues/35514)
- [GitStart ticket](https://app.gitstart.com/clients/sourcegraph/tickets/SG-35514)
