### PR TITLE
JetBrains: Add back GitHub workflow to test Java side of integration

### DIFF
--- a/.github/workflows/jetbrains-tests.yml
+++ b/.github/workflows/jetbrains-tests.yml
@@ -23,6 +23,9 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: client/jetbrains
     outputs:
       version: ${{ steps.properties.outputs.version }}
       changelog: ${{ steps.properties.outputs.changelog }}

--- a/.github/workflows/jetbrains-tests.yml
+++ b/.github/workflows/jetbrains-tests.yml
@@ -1,10 +1,8 @@
 # GitHub Actions Workflow created for testing the JetBrains extension plugin in following steps:
-# - validate Gradle Wrapper,
-# - run 'test' and 'verifyPlugin' tasks,
-# - run Qodana inspections,
-# - run 'buildPlugin' task and prepare artifact for the further tests,
-# - run 'runPluginVerifier' task,
-# - create a draft release.
+# - validate Gradle Wrapper
+# - run 'test' tasks
+# - run 'runPluginVerifier' task
+# - run Qodana inspections
 #
 # Note: This workflow works in isolation to the JavaScript artifacts necessary for full testing. It
 #       is intended to only test if the Java plugin compiles without issues.
@@ -88,10 +86,6 @@ jobs:
       # Run Verify Plugin task and IntelliJ Plugin Verifier tool
       - name: Run Plugin Verification tasks
         run: ./gradlew runPluginVerifier -Pplugin.verifier.home.dir=${{ steps.properties.outputs.pluginVerifierHomeDir }}
-
-      # Build plugin
-      - name: Build Plugin
-        run: ./gradlew buildPlugin
 
       # Collect Plugin Verifier Result
       - name: Collect Plugin Verifier Result

--- a/.github/workflows/jetbrains-tests.yml
+++ b/.github/workflows/jetbrains-tests.yml
@@ -2,7 +2,6 @@
 # - validate Gradle Wrapper
 # - run 'test' tasks
 # - run 'runPluginVerifier' task
-# - run Qodana inspections
 #
 # Note: This workflow works in isolation to the JavaScript artifacts necessary for full testing. It
 #       is intended to only test if the Java plugin compiles without issues.
@@ -45,56 +44,27 @@ jobs:
           cache: gradle
 
       # Set environment variables
-      - name: Export Properties
-        id: properties
-        shell: bash
-        run: |
-          PROPERTIES="$(./gradlew properties --console=plain -q)"
-          VERSION="$(echo "$PROPERTIES" | grep "^version:" | cut -f2- -d ' ')"
-          NAME="$(echo "$PROPERTIES" | grep "^pluginName:" | cut -f2- -d ' ')"
-          CHANGELOG="$(./gradlew getChangelog --unreleased --no-header --console=plain -q)"
-          CHANGELOG="${CHANGELOG//'%'/'%25'}"
-          CHANGELOG="${CHANGELOG//$'\n'/'%0A'}"
-          CHANGELOG="${CHANGELOG//$'\r'/'%0D'}"
+      # - name: Export Properties
+      #   id: properties
+      #   shell: bash
+      #   run: |
+      #       PROPERTIES="$(./gradlew properties --console=plain -q)"
+      #       VERSION="$(echo "$PROPERTIES" | grep "^version:" | cut -f2- -d ' ')"
+      #       NAME="$(echo "$PROPERTIES" | grep "^pluginName:" | cut -f2- -d ' ')"
+      #       CHANGELOG="$(./gradlew getChangelog --unreleased --no-header --console=plain -q)"
+      #       CHANGELOG="${CHANGELOG//'%'/'%25'}"
+      #       CHANGELOG="${CHANGELOG//$'\n'/'%0A'}"
+      #       CHANGELOG="${CHANGELOG//$'\r'/'%0D'}"
 
-          echo "::set-output name=version::$VERSION"
-          echo "::set-output name=name::$NAME"
-          echo "::set-output name=changelog::$CHANGELOG"
-          echo "::set-output name=pluginVerifierHomeDir::~/.pluginVerifier"
+      #       echo "::set-output name=version::$VERSION"
+      #       echo "::set-output name=name::$NAME"
+      #       echo "::set-output name=changelog::$CHANGELOG"
+      #       echo "::set-output name=pluginVerifierHomeDir::~/.pluginVerifier"
 
-          ./gradlew listProductsReleases # prepare list of IDEs for Plugin Verifier
+      #     ./gradlew listProductsReleases # prepare list of IDEs for Plugin Verifier
 
-      # Run tests
       - name: Run Tests
         run: ./gradlew test
 
-      # Collect Tests Result of failed tests
-      - name: Collect Tests Result
-        if: ${{ failure() }}
-        uses: actions/upload-artifact@v2
-        with:
-          name: tests-result
-          path: ${{ github.workspace }}/build/reports/tests
-
-      # Cache Plugin Verifier IDEs
-      - name: Setup Plugin Verifier IDEs Cache
-        uses: actions/cache@v2.1.7
-        with:
-          path: ${{ steps.properties.outputs.pluginVerifierHomeDir }}/ides
-          key: plugin-verifier-${{ hashFiles('client/jetbrains/build/listProductsReleases.txt') }}
-
-      # Run Verify Plugin task and IntelliJ Plugin Verifier tool
-      - name: Run Plugin Verification tasks
-        run: ./gradlew runPluginVerifier -Pplugin.verifier.home.dir=${{ steps.properties.outputs.pluginVerifierHomeDir }}
-
-      # Collect Plugin Verifier Result
-      - name: Collect Plugin Verifier Result
-        if: ${{ always() }}
-        uses: actions/upload-artifact@v2
-        with:
-          name: pluginVerifier-result
-          path: ${{ github.workspace }}/build/reports/pluginVerifier
-
-      # Run Qodana inspections
-      - name: Qodana - Code Inspection
-        uses: JetBrains/qodana-action@v4.2.3
+      - name: Run Plugin Verifier
+        run: ./gradlew runPluginVerifier

--- a/.github/workflows/jetbrains-tests.yml
+++ b/.github/workflows/jetbrains-tests.yml
@@ -1,7 +1,8 @@
 # GitHub Actions Workflow created for testing the JetBrains extension plugin in following steps:
+#
 # - validate Gradle Wrapper
 # - run 'test' tasks
-# - run 'runPluginVerifier' task
+# - run 'buildPlugin' task
 #
 # Note: This workflow works in isolation to the JavaScript artifacts necessary for full testing. It
 #       is intended to only test if the Java plugin compiles without issues.
@@ -14,11 +15,8 @@ on:
        - client/jetbrains/**
 
 jobs:
-  # Run Gradle Wrapper Validation Action to verify the wrapper's checksum
-  # Run verifyPlugin, IntelliJ Plugin Verifier, and test Gradle tasks
-  # Build plugin and provide the artifact for the next workflow jobs
-  build:
-    name: Build
+  test:
+    name: Test
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -43,28 +41,8 @@ jobs:
           java-version: 11
           cache: gradle
 
-      # Set environment variables
-      # - name: Export Properties
-      #   id: properties
-      #   shell: bash
-      #   run: |
-      #       PROPERTIES="$(./gradlew properties --console=plain -q)"
-      #       VERSION="$(echo "$PROPERTIES" | grep "^version:" | cut -f2- -d ' ')"
-      #       NAME="$(echo "$PROPERTIES" | grep "^pluginName:" | cut -f2- -d ' ')"
-      #       CHANGELOG="$(./gradlew getChangelog --unreleased --no-header --console=plain -q)"
-      #       CHANGELOG="${CHANGELOG//'%'/'%25'}"
-      #       CHANGELOG="${CHANGELOG//$'\n'/'%0A'}"
-      #       CHANGELOG="${CHANGELOG//$'\r'/'%0D'}"
-
-      #       echo "::set-output name=version::$VERSION"
-      #       echo "::set-output name=name::$NAME"
-      #       echo "::set-output name=changelog::$CHANGELOG"
-      #       echo "::set-output name=pluginVerifierHomeDir::~/.pluginVerifier"
-
-      #     ./gradlew listProductsReleases # prepare list of IDEs for Plugin Verifier
-
       - name: Run Tests
         run: ./gradlew test
 
-      - name: Run Plugin Verifier
-        run: ./gradlew runPluginVerifier
+      - name: Run Build Plugin
+        run: ./gradlew buildPlugin

--- a/.github/workflows/jetbrains-tests.yml
+++ b/.github/workflows/jetbrains-tests.yml
@@ -1,0 +1,103 @@
+# GitHub Actions Workflow created for testing the JetBrains extension plugin in following steps:
+# - validate Gradle Wrapper,
+# - run 'test' and 'verifyPlugin' tasks,
+# - run Qodana inspections,
+# - run 'buildPlugin' task and prepare artifact for the further tests,
+# - run 'runPluginVerifier' task,
+# - create a draft release.
+#
+# Note: This workflow works in isolation to the JavaScript artifacts necessary for full testing. It
+#       is intended to only test if the Java plugin compiles without issues.
+
+name: JetBrains Tests
+on:
+  # Trigger the workflow on any pull request that touches the jetbrains src folder
+  pull_request:
+      paths:
+       - client/jetbrains/src/**
+
+jobs:
+  # Run Gradle Wrapper Validation Action to verify the wrapper's checksum
+  # Run verifyPlugin, IntelliJ Plugin Verifier, and test Gradle tasks
+  # Build plugin and provide the artifact for the next workflow jobs
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.properties.outputs.version }}
+      changelog: ${{ steps.properties.outputs.changelog }}
+    steps:
+      # Check out current repository
+      - name: Fetch Sources
+        uses: actions/checkout@v2.4.0
+
+      # Validate wrapper
+      - name: Gradle Wrapper Validation
+        uses: gradle/wrapper-validation-action@v1.0.4
+
+      # Setup Java 11 environment for the next steps
+      - name: Setup Java
+        uses: actions/setup-java@v2
+        with:
+          distribution: zulu
+          java-version: 11
+          cache: gradle
+
+      # Set environment variables
+      - name: Export Properties
+        id: properties
+        shell: bash
+        run: |
+          PROPERTIES="$(./gradlew properties --console=plain -q)"
+          VERSION="$(echo "$PROPERTIES" | grep "^version:" | cut -f2- -d ' ')"
+          NAME="$(echo "$PROPERTIES" | grep "^pluginName:" | cut -f2- -d ' ')"
+          CHANGELOG="$(./gradlew getChangelog --unreleased --no-header --console=plain -q)"
+          CHANGELOG="${CHANGELOG//'%'/'%25'}"
+          CHANGELOG="${CHANGELOG//$'\n'/'%0A'}"
+          CHANGELOG="${CHANGELOG//$'\r'/'%0D'}"
+
+          echo "::set-output name=version::$VERSION"
+          echo "::set-output name=name::$NAME"
+          echo "::set-output name=changelog::$CHANGELOG"
+          echo "::set-output name=pluginVerifierHomeDir::~/.pluginVerifier"
+
+          ./gradlew listProductsReleases # prepare list of IDEs for Plugin Verifier
+
+      # Run tests
+      - name: Run Tests
+        run: ./gradlew test
+
+      # Collect Tests Result of failed tests
+      - name: Collect Tests Result
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: tests-result
+          path: ${{ github.workspace }}/build/reports/tests
+
+      # Cache Plugin Verifier IDEs
+      - name: Setup Plugin Verifier IDEs Cache
+        uses: actions/cache@v2.1.7
+        with:
+          path: ${{ steps.properties.outputs.pluginVerifierHomeDir }}/ides
+          key: plugin-verifier-${{ hashFiles('build/listProductsReleases.txt') }}
+
+      # Run Verify Plugin task and IntelliJ Plugin Verifier tool
+      - name: Run Plugin Verification tasks
+        run: ./gradlew runPluginVerifier -Pplugin.verifier.home.dir=${{ steps.properties.outputs.pluginVerifierHomeDir }}
+
+      # Build plugin
+      - name: Build Plugin
+        run: ./gradlew buildPlugin
+
+      # Collect Plugin Verifier Result
+      - name: Collect Plugin Verifier Result
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: pluginVerifier-result
+          path: ${{ github.workspace }}/build/reports/pluginVerifier
+
+      # Run Qodana inspections
+      - name: Qodana - Code Inspection
+        uses: JetBrains/qodana-action@v4.2.3

--- a/.github/workflows/jetbrains-tests.yml
+++ b/.github/workflows/jetbrains-tests.yml
@@ -81,7 +81,7 @@ jobs:
         uses: actions/cache@v2.1.7
         with:
           path: ${{ steps.properties.outputs.pluginVerifierHomeDir }}/ides
-          key: plugin-verifier-${{ hashFiles('build/listProductsReleases.txt') }}
+          key: plugin-verifier-${{ hashFiles('client/jetbrains/build/listProductsReleases.txt') }}
 
       # Run Verify Plugin task and IntelliJ Plugin Verifier tool
       - name: Run Plugin Verification tasks

--- a/.github/workflows/jetbrains-tests.yml
+++ b/.github/workflows/jetbrains-tests.yml
@@ -21,9 +21,6 @@ jobs:
     defaults:
       run:
         working-directory: client/jetbrains
-    outputs:
-      version: ${{ steps.properties.outputs.version }}
-      changelog: ${{ steps.properties.outputs.changelog }}
     steps:
       # Check out current repository
       - name: Fetch Sources

--- a/.github/workflows/jetbrains-tests.yml
+++ b/.github/workflows/jetbrains-tests.yml
@@ -14,7 +14,7 @@ on:
   # Trigger the workflow on any pull request that touches the jetbrains src folder
   pull_request:
       paths:
-       - client/jetbrains/src/**
+       - client/jetbrains/**
 
 jobs:
   # Run Gradle Wrapper Validation Action to verify the wrapper's checksum

--- a/client/jetbrains/README.md
+++ b/client/jetbrains/README.md
@@ -1,3 +1,5 @@
+deleteme
+
 <!-- Plugin description -->
 
 # Sourcegraph for JetBrains IDEs [![JetBrains Plugin](https://img.shields.io/badge/JetBrains-Sourcegraph-green.svg)](https://plugins.jetbrains.com/plugin/9682-sourcegraph)

--- a/client/jetbrains/README.md
+++ b/client/jetbrains/README.md
@@ -1,5 +1,3 @@
-deleteme
-
 <!-- Plugin description -->
 
 # Sourcegraph for JetBrains IDEs [![JetBrains Plugin](https://img.shields.io/badge/JetBrains-Sourcegraph-green.svg)](https://plugins.jetbrains.com/plugin/9682-sourcegraph)


### PR DESCRIPTION
Part of [#35787](https://github.com/sourcegraph/sourcegraph/issues/35787)

This brings back the GitHub workflow tests that build the JetBrains extensions and runs some rudimentary checks. We used a similar script in the previous repo: https://github.com/sourcegraph/sourcegraph-jetbrains/blob/main/.github/workflows/build.yml, however this version has a bunch of tasks removed that never worked (also not in the previous repo). 

To ensure this does not use a lot of resources, these workflow current only runs on pull requests that change _anything_ inside the `client/jetbrains` folder. So I do not anticipate any heaver usage compared to the one we had in the previous repo.

Note that this workflow works in isolation to the JavaScript artifacts necessary for full testing. It is intended to only test if the Java plugin compiles without issues and I've went with the GitHub workflow to avoid us having to figure out how to add the right Java versions to our CI systems. We will need to do this at a later point for full featured E2E tests.

For now the plan is to have a separate CI step added in parallel to the VSCode ones that verifies that our JavaScript changes are good. 

## Test plan

- Green GitHub status 🙂 

[![Screenshot 2022-05-23 at 15 21 50](https://user-images.githubusercontent.com/458591/169828846-57b7b58c-9291-4938-b1cc-0a13680c86ba.png)](https://github.com/sourcegraph/sourcegraph/runs/6555928132?check_suite_focus=true)

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
