### PR TITLE
sg: better output when using 'sg live' wrong

### DIFF
--- a/dev/sg/main.go
+++ b/dev/sg/main.go
@@ -208,8 +208,7 @@ var sg = &cli.App{
 
 		// Show help text only
 		if errors.Is(err, flag.ErrHelp) {
-			cli.ShowAppHelp(cmd)
-			os.Exit(1)
+			cli.ShowSubcommandHelpAndExit(cmd, 1)
 		}
 
 		// Render error

--- a/dev/sg/sg_live.go
+++ b/dev/sg/sg_live.go
@@ -15,7 +15,7 @@ import (
 
 var liveCommand = &cli.Command{
 	Name:        "live",
-	ArgsUsage:   "<environment>",
+	ArgsUsage:   "<environment-name-or-url>",
 	Usage:       "Reports which version of Sourcegraph is currently live in the given environment",
 	Category:    CategoryCompany,
 	Description: constructLiveCmdLongHelp(),
@@ -42,21 +42,21 @@ func constructLiveCmdLongHelp() string {
 
 func liveExec(ctx context.Context, args []string) error {
 	if len(args) == 0 {
-		std.Out.WriteLine(output.Styled(output.StyleWarning, "No environment specified"))
+		std.Out.WriteLine(output.Styled(output.StyleWarning, "ERROR: No environment specified"))
 		return flag.ErrHelp
 	}
 
 	if len(args) != 1 {
-		std.Out.WriteLine(output.Styled(output.StyleWarning, "ERROR: too many arguments"))
+		std.Out.WriteLine(output.Styled(output.StyleWarning, "ERROR: Too many arguments"))
 		return flag.ErrHelp
 	}
 
 	e, ok := getEnvironment(args[0])
 	if !ok {
-		if customURL, err := url.Parse(args[0]); err == nil {
+		if customURL, err := url.Parse(args[0]); err == nil && customURL.Scheme != "" {
 			e = environment{Name: customURL.Host, URL: customURL.String()}
 		} else {
-			std.Out.WriteLine(output.Styledf(output.StyleWarning, "ERROR: environment %q not found, or is not a valid URL :(", args[0]))
+			std.Out.WriteLine(output.Styledf(output.StyleWarning, "ERROR: Environment %q not found, or is not a valid URL :(", args[0]))
 			return flag.ErrHelp
 		}
 	}


### PR DESCRIPTION
Before this change `sg live` would print the helptext for `sg` on error. That output is not only super long and hides the error, but it also doesn't tell you anything about `sg live`.

So I changed the error handler to print the helptext for subcommands, which is what we want in 99% of cases, I think, since `sg` itself is not a useful command, only its subcommands.

I also changed the error output of `sg live` to be a bit more consistent and more helpful.

## Before
<img width="556" alt="screenshot_2022-05-23_14 31 20@2x" src="https://user-images.githubusercontent.com/1185253/169820327-69ddc3a1-28a2-4420-a518-bab23efbd9bf.png">

## After

<img width="862" alt="screenshot_2022-05-23_14 32 07@2x" src="https://user-images.githubusercontent.com/1185253/169820348-73ff9e25-b66d-49d5-a4ae-11e45b3a62f8.png">

## Test plan

- Tested locally with `go run . live cloud` and `go run . live dotcom`
