### PR TITLE
vsce: update selection background color for default light theme

### DIFF
--- a/client/vscode/CHANGELOG.md
+++ b/client/vscode/CHANGELOG.md
@@ -14,6 +14,7 @@ The Sourcegraph extension uses major.EVEN_NUMBER.patch (eg. 2.0.1) for release v
 
 - Windows file path issue [issues/34788](https://github.com/sourcegraph/sourcegraph/issues/34788)
 - Sourcegraph icon in help sidebar now shows on light theme [issues/35672](https://github.com/sourcegraph/sourcegraph/issues/35672)
+- Highlight background color for VS Code Light & Light+ Theme [issues/35767](https://github.com/sourcegraph/sourcegraph/issues/35767)
 
 ## 2.2.2
 

--- a/client/vscode/src/webview/theming/highlight.scss
+++ b/client/vscode/src/webview/theming/highlight.scss
@@ -267,6 +267,10 @@ body[data-vscode-theme-name^='Dark (Visual Studio)'].sourcegraph-extension.theme
 
 // Default Light VS Code theme.
 body[data-vscode-theme-name^='Light+ (default light)'].sourcegraph-extension.theme-light {
+    .monaco-list.list_id_1 .monaco-list-row.focused {
+        background-color: var(--vscode-editor-selectionBackground);
+    }
+
     // Functions
     .hl-entity.hl-name.hl-function,
     .hl-meta.hl-require,
@@ -315,6 +319,10 @@ body[data-vscode-theme-name^='Light+ (default light)'].sourcegraph-extension.the
 
 // Light Visual Studio (minimalistic) theme
 body[data-vscode-theme-name^='Light (Visual Studio)'].sourcegraph-extension.theme-light {
+    .monaco-list.list_id_1 .monaco-list-row.focused {
+        background-color: var(--vscode-editor-selectionBackground);
+    }
+
     .hl-keyword {
         color: var(--vscode-debugTokenExpression-boolean);
     }


### PR DESCRIPTION
Close https://github.com/sourcegraph/sourcegraph/issues/35767

As reported by a user in https://github.com/sourcegraph/sourcegraph/issues/35767, there is a color conflict between the highlighted word and highlighted background in our suggestion widget that makes the highlighted suggestion unreadable in Light & Light+ theme:
![image](https://user-images.githubusercontent.com/68532117/169875622-f7550044-ccb9-4ee0-ae59-4ca708eb0deb.png)


I have updated the color use for the selection background in Light theme to resolve this issue:
![image](https://user-images.githubusercontent.com/68532117/169875398-6a9de9da-47d4-450d-ac08-e3a485101506.png)


## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
See screenshot above

## App preview:

- [Web](https://sg-web-bee-vsce-light-theme.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-huheukyxfj.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
