### PR TITLE
nix: disable fortify due to issues with delve

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -87,6 +87,8 @@ pkgs.mkShell {
     . ./dev/nix/shell-hook.sh
   '';
 
+  hardeningDisable = [ "fortify" ];
+
   # By explicitly setting this environment variable we avoid starting up
   # universal-ctags via docker.
   CTAGS_COMMAND = "${universal-ctags}/bin/universal-ctags";


### PR DESCRIPTION
Attempting to debug in VSCode with Delve in a Nix environment would result in `#warning _FORTIFY_SOURCE requires compiling with optimization`. https://github.com/NixOS/nixpkgs/issues/18995#issuecomment-429051832

## Test plan

N/A