### PR TITLE
authz: fix isTest check for debugging

### DIFF
--- a/internal/authz/register.go
+++ b/internal/authz/register.go
@@ -72,5 +72,6 @@ func GetProviders() (authzAllowByDefault bool, providers []Provider) {
 var isTest = (func() bool {
 	path, _ := os.Executable()
 	return filepath.Ext(path) == ".test" ||
-		strings.Contains(path, "/T/___") // Test path used by GoLand
+		strings.Contains(path, "/T/___") || // Test path used by GoLand
+		filepath.Base(path) == "__debug_bin" // Debug binary used by VSCode
 })()


### PR DESCRIPTION
VSCode debugging results in a file called `__debug_bin` that wasnt being caught by this, resulting in `GetProviders` hanging indefinitely when debugging (but not when testing)

## Test plan

N/A