### PR TITLE
chore: rename `RepoIcon` to `CodeHostIcon`

### DIFF
--- a/client/search-ui/src/components/CommitSearchResult.tsx
+++ b/client/search-ui/src/components/CommitSearchResult.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 
+import { CodeHostIcon } from '@sourcegraph/shared/src/components/CodeHostIcon'
 import { displayRepoName } from '@sourcegraph/shared/src/components/RepoFileLink'
-import { RepoIcon } from '@sourcegraph/shared/src/components/RepoIcon'
 import { ResultContainer } from '@sourcegraph/shared/src/components/ResultContainer'
 import { SearchResultStar } from '@sourcegraph/shared/src/components/SearchResultStar'
 import { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
@@ -45,7 +45,7 @@ export const CommitSearchResult: React.FunctionComponent<Props> = ({
         const formattedRepositoryStarCount = formatRepositoryStarCount(result.repoStars)
         return (
             <div className={styles.title}>
-                <RepoIcon repoName={repoName} className="text-muted flex-shrink-0" />
+                <CodeHostIcon repoName={repoName} className="text-muted flex-shrink-0" />
                 <span
                     onMouseEnter={checkTruncation}
                     className="test-search-result-label ml-1 flex-shrink-past-contents text-truncate"

--- a/client/search-ui/src/components/RepoSearchResult.tsx
+++ b/client/search-ui/src/components/RepoSearchResult.tsx
@@ -6,9 +6,9 @@ import LockIcon from 'mdi-react/LockIcon'
 import SourceForkIcon from 'mdi-react/SourceForkIcon'
 import SourceRepositoryIcon from 'mdi-react/SourceRepositoryIcon'
 
+import { CodeHostIcon } from '@sourcegraph/shared/src/components/CodeHostIcon'
 import { LastSyncedIcon } from '@sourcegraph/shared/src/components/LastSyncedIcon'
 import { displayRepoName } from '@sourcegraph/shared/src/components/RepoFileLink'
-import { RepoIcon } from '@sourcegraph/shared/src/components/RepoIcon'
 import { ResultContainer } from '@sourcegraph/shared/src/components/ResultContainer'
 import { SearchResultStar } from '@sourcegraph/shared/src/components/SearchResultStar'
 import { getRepoMatchLabel, getRepoMatchUrl, RepositoryMatch } from '@sourcegraph/shared/src/search/stream'
@@ -41,7 +41,7 @@ export const RepoSearchResult: React.FunctionComponent<RepoSearchResultProps> = 
         const formattedRepositoryStarCount = formatRepositoryStarCount(result.repoStars)
         return (
             <div className={styles.title}>
-                <RepoIcon repoName={repoName} className="text-muted flex-shrink-0" />
+                <CodeHostIcon repoName={repoName} className="text-muted flex-shrink-0" />
                 <span
                     onMouseEnter={checkTruncation}
                     className="test-search-result-label ml-1 flex-shrink-past-contents text-truncate"

--- a/client/search-ui/src/results/sidebar/FilterLink.tsx
+++ b/client/search-ui/src/results/sidebar/FilterLink.tsx
@@ -4,8 +4,8 @@ import classNames from 'classnames'
 
 import { pluralize } from '@sourcegraph/common'
 import { SyntaxHighlightedSearchQuery } from '@sourcegraph/search-ui'
+import { CodeHostIcon } from '@sourcegraph/shared/src/components/CodeHostIcon'
 import { displayRepoName } from '@sourcegraph/shared/src/components/RepoFileLink'
-import { RepoIcon } from '@sourcegraph/shared/src/components/RepoIcon'
 import { Settings } from '@sourcegraph/shared/src/schema/settings.schema'
 import { FilterType } from '@sourcegraph/shared/src/search/query/filters'
 import { Filter } from '@sourcegraph/shared/src/search/stream'
@@ -58,7 +58,7 @@ export const getRepoFilterLinks = (
     onFilterChosen: (value: string) => void
 ): React.ReactElement[] => {
     function repoLabelConverter(label: string): JSX.Element {
-        const Icon = RepoIcon({
+        const Icon = CodeHostIcon({
             repoName: label,
             className: classNames('text-muted', styles.sidebarSectionIcon),
         })

--- a/client/shared/src/components/CodeHostIcon.tsx
+++ b/client/shared/src/components/CodeHostIcon.tsx
@@ -10,10 +10,9 @@ import { Icon } from '@sourcegraph/wildcard'
 /**
  * Returns the icon for the repository's code host
  */
-export const RepoIcon: React.FunctionComponent<React.PropsWithChildren<{ repoName: string; className?: string }>> = ({
-    repoName,
-    className,
-}) => {
+export const CodeHostIcon: React.FunctionComponent<
+    React.PropsWithChildren<{ repoName: string; className?: string }>
+> = ({ repoName, className }) => {
     const iconMap: { [key: string]: React.ComponentType<React.PropsWithChildren<MdiReactIconProps>> } = {
         'github.com': GithubIcon,
         'gitlab.com': GitlabIcon,

--- a/client/shared/src/components/FileSearchResult.tsx
+++ b/client/shared/src/components/FileSearchResult.tsx
@@ -17,12 +17,12 @@ import { isSettingsValid, SettingsCascadeProps } from '../settings/settings'
 import { TelemetryProps } from '../telemetry/telemetryService'
 
 import { FetchFileParameters } from './CodeExcerpt'
+import { CodeHostIcon } from './CodeHostIcon'
 import { FileMatchChildren } from './FileMatchChildren'
 import { LineRanking } from './ranking/LineRanking'
 import { MatchGroup, MatchItem } from './ranking/PerFileResultRanking'
 import { ZoektRanking } from './ranking/ZoektRanking'
 import { RepoFileLink } from './RepoFileLink'
-import { RepoIcon } from './RepoIcon'
 import { Props as ResultContainerProps, ResultContainer } from './ResultContainer'
 
 interface Props extends SettingsCascadeProps, TelemetryProps {
@@ -96,7 +96,7 @@ export const FileSearchResult: React.FunctionComponent<React.PropsWithChildren<P
     }, [settings])
     const renderTitle = (): JSX.Element => (
         <>
-            <RepoIcon repoName={result.repository} className="text-muted flex-shrink-0" />
+            <CodeHostIcon repoName={result.repository} className="text-muted flex-shrink-0" />
             <RepoFileLink
                 repoName={result.repository}
                 repoURL={repoAtRevisionURL}

--- a/client/vscode/src/webview/search-panel/alias/CommitSearchResult.tsx
+++ b/client/vscode/src/webview/search-panel/alias/CommitSearchResult.tsx
@@ -4,8 +4,8 @@ import React from 'react'
 import { CommitSearchResultMatch } from '@sourcegraph/search-ui/src/components/CommitSearchResultMatch'
 // eslint-disable-next-line no-restricted-imports
 import styles from '@sourcegraph/search-ui/src/components/SearchResult.module.scss'
+import { CodeHostIcon } from '@sourcegraph/shared/src/components/CodeHostIcon'
 import { displayRepoName } from '@sourcegraph/shared/src/components/RepoFileLink'
-import { RepoIcon } from '@sourcegraph/shared/src/components/RepoIcon'
 import { ResultContainer } from '@sourcegraph/shared/src/components/ResultContainer'
 import { SearchResultStar } from '@sourcegraph/shared/src/components/SearchResultStar'
 import { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
@@ -45,7 +45,7 @@ export const CommitSearchResult: React.FunctionComponent<Props> = ({
         const formattedRepositoryStarCount = formatRepositoryStarCount(result.repoStars)
         return (
             <div className={styles.title}>
-                <RepoIcon repoName={repoName} className="text-muted flex-shrink-0" />
+                <CodeHostIcon repoName={repoName} className="text-muted flex-shrink-0" />
                 <span className="test-search-result-label ml-1 flex-shrink-past-contents text-truncate">
                     <>
                         <button

--- a/client/vscode/src/webview/search-panel/alias/RepoSearchResult.tsx
+++ b/client/vscode/src/webview/search-panel/alias/RepoSearchResult.tsx
@@ -8,9 +8,9 @@ import SourceRepositoryIcon from 'mdi-react/SourceRepositoryIcon'
 
 // eslint-disable-next-line no-restricted-imports
 import styles from '@sourcegraph/search-ui/src/components/SearchResult.module.scss'
+import { CodeHostIcon } from '@sourcegraph/shared/src/components/CodeHostIcon'
 import { LastSyncedIcon } from '@sourcegraph/shared/src/components/LastSyncedIcon'
 import { displayRepoName } from '@sourcegraph/shared/src/components/RepoFileLink'
-import { RepoIcon } from '@sourcegraph/shared/src/components/RepoIcon'
 import { ResultContainer } from '@sourcegraph/shared/src/components/ResultContainer'
 import { SearchResultStar } from '@sourcegraph/shared/src/components/SearchResultStar'
 import { getRepoMatchLabel, RepositoryMatch } from '@sourcegraph/shared/src/search/stream'
@@ -42,7 +42,7 @@ export const RepoSearchResult: React.FunctionComponent<RepoSearchResultProps> = 
         const formattedRepositoryStarCount = formatRepositoryStarCount(result.repoStars)
         return (
             <div className={styles.title}>
-                <RepoIcon repoName={repoName} className="text-muted flex-shrink-0" />
+                <CodeHostIcon repoName={repoName} className="text-muted flex-shrink-0" />
                 <span className="test-search-result-label ml-1 flex-shrink-past-contents text-truncate">
                     <button type="button" className="btn btn-text-link" onClick={() => openRepo(result)}>
                         {displayRepoName(getRepoMatchLabel(result))}


### PR DESCRIPTION
Part of #34237

The name `RepoIcon` is confusing (it could refer to either of the two icons shown next to the repo in search results). Renaming to clarify that this is the icon of the code host (GitHub, GitLab, etc).

## Test plan

Rename change only, CI checks should be enough.

## App preview:

- [Web](https://sg-web-jp-codehosticonrename.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-ntbnxukauv.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
