### PR TITLE
sg migration add: Make output paths copyable for vscode

### DIFF
--- a/dev/sg/internal/migration/util.go
+++ b/dev/sg/internal/migration/util.go
@@ -116,7 +116,9 @@ func parseVersions(lines []string, migrationsDir string) []int {
 // rootRelative removes the repo root prefix from the given path.
 func rootRelative(path string) string {
 	if root, _ := root.RepositoryRoot(); root != "" {
-		return strings.TrimPrefix(path, root)
+		sep := string(os.PathSeparator)
+		rootWithTrailingSep := strings.TrimRight(root, sep) + sep
+		return strings.TrimPrefix(path, rootWithTrailingSep)
 	}
 
 	return path


### PR DESCRIPTION
Before we would print something like `Up query file: /foo/bar/baz.sql`, but the leading slash made it hard to copy and open in an editor, which doesn't expect that character.

This PR removes it.

## Test plan

Tested locally.