### PR TITLE
migration: Make squash deterministic

### DIFF
--- a/doc/dev/background-information/oobmigrations.md
+++ b/doc/dev/background-information/oobmigrations.md
@@ -72,12 +72,15 @@ The first step is to register the migration in the database. This should be done
 ```sql
 BEGIN;
 
-INSERT INTO out_of_band_migrations (id, team, component, description, introduced_version_major, introduced_version_minor, non_destructive)
+INSERT INTO out_of_band_migrations (id, team, component, description, created, introduced_version_major, introduced_version_minor, non_destructive)
 VALUES (
     42,                           -- This must be consistent across all Sourcegraph instances
     'skunkworks',                 -- Team owning migration
     'db.skunk_payloads',          -- Component being migrated
     'Re-encode our skunky data',  -- Description
+    '2022-05-23 19:35:01.249518', -- The approximate date this migration was added. Hard-code this date in this table in order to make our
+                                  -- squashed migrations deterministic. If we use NOW() then we can't compare old and new versions via textual
+                                  -- diff alone.
     3,                            -- The current major release
     34,                           -- The current minor release
     true                          -- Can be read with previous version without down migration

--- a/internal/database/schema.json
+++ b/internal/database/schema.json
@@ -12807,7 +12807,7 @@
           "Index": 6,
           "TypeName": "timestamp with time zone",
           "IsNullable": false,
-          "Default": "now()",
+          "Default": "",
           "CharacterMaximumLength": 0,
           "IsIdentity": false,
           "IdentityGeneration": "",

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -1971,7 +1971,7 @@ Indexes:
  component                | text                     |           | not null | 
  description              | text                     |           | not null | 
  progress                 | double precision         |           | not null | 0
- created                  | timestamp with time zone |           | not null | now()
+ created                  | timestamp with time zone |           | not null | 
  last_updated             | timestamp with time zone |           |          | 
  non_destructive          | boolean                  |           | not null | 
  apply_reverse            | boolean                  |           | not null | false

--- a/migrations/frontend/1528395963/up.sql
+++ b/migrations/frontend/1528395963/up.sql
@@ -41,9 +41,10 @@ WHERE user_id IS NOT NULL
 ORDER BY user_id, id DESC;
 
 
-INSERT INTO out_of_band_migrations(id, team, component, description, non_destructive,
+INSERT INTO out_of_band_migrations(id, team, component, description, created, non_destructive,
                                    apply_reverse, is_enterprise, introduced_version_major, introduced_version_minor)
 VALUES (14, 'code-insights', 'db.insights_settings_migration_jobs',
         'Migrating insight definitions from settings files to database tables as a last stage to use the GraphQL API.',
+        '2021-12-02 09:39:00.000000',
         TRUE, FALSE, TRUE, 3, 35)
 ON CONFLICT DO NOTHING;

--- a/migrations/frontend/1653334014/down.sql
+++ b/migrations/frontend/1653334014/down.sql
@@ -1,0 +1,6 @@
+ALTER TABLE
+    out_of_band_migrations
+ALTER COLUMN
+    created
+SET
+    DEFAULT NOW();

--- a/migrations/frontend/1653334014/metadata.yaml
+++ b/migrations/frontend/1653334014/metadata.yaml
@@ -1,0 +1,2 @@
+name: Remove default from out_of_band_migrations created timestamp
+parents: [1652964210]

--- a/migrations/frontend/1653334014/up.sql
+++ b/migrations/frontend/1653334014/up.sql
@@ -1,0 +1,4 @@
+ALTER TABLE
+    out_of_band_migrations
+ALTER COLUMN
+    created DROP DEFAULT;


### PR DESCRIPTION
#35831 is currently blocked because multiple squashes give different timestamps in a *single* column of the out of band migrations table.

This PR makes the timestamps deterministic. Left a docs note on the new format, fixed the existing copyable paths, and dropped the default to discourage the use of `NOW`.

## Test plan

CI should catch any breaking issues.