### PR TITLE
insights: add more prominent notes single docker insights not supported

### DIFF
--- a/doc/admin/deploy/docker-single-container/index.md
+++ b/doc/admin/deploy/docker-single-container/index.md
@@ -1,6 +1,8 @@
 # Docker Single Container Deployment
 
-The Docker Single Container deployment type is a way to very quickly get an instance of Sourcegraph set up locally to experiment with its features. However, it is **not recommended** for a production instance, and **has limitations** depending on the OS you are deploying to, as well as the associated resources. See the [troubleshooting secton](#troubleshooting) for additional information.
+The Docker Single Container deployment type is a way to very quickly get an instance of Sourcegraph set up locally to experiment with many of its features. However, it is **not recommended** for a production instance, and **has limitations** depending on the OS you are deploying to, as well as the associated resources. See the [troubleshooting secton](#troubleshooting) for additional information.
+
+[Code Insights](../../../code_insights/index.md) is not supported in Single Container deployments. To try Code Insights you must deploy using [Docker Compose](../docker-compose/index.md) or [Kubernetes](../kubernetes/index.md). 
 
 ## Installation
 

--- a/doc/admin/deploy/index.md
+++ b/doc/admin/deploy/index.md
@@ -25,7 +25,7 @@ We recommend the Kubernetes deployment type if your deployment scenario includes
 | [Kubernetes with Helm](kubernetes/helm.md) | Production deployments of any size | 5 - 90 minutes | YES | YES | YES | Easy - Hard |
 | [Docker Compose](docker-compose/index.md) | Production deployments where Kubernetes with Helm is not viable | 5 - 30 minutes | YES | YES | NO | Easy - Medium |
 | [Kubernetes without Helm](kubernetes/index.md) | Production deployments of any size | 30 - 90 minutes | YES | YES | YES| Medium - Hard |
-| [Docker Single Container](docker-single-container/index.md) | Local testing _(Not recommended for production)_ | 1 minute | NO | NO | NO | Easy |
+| [Docker Single Container](docker-single-container/index.md) | Local testing _(Not recommended for production; no Code Insights support)_ | 1 minute | NO | NO | NO | Easy |
 
 Each of the deployment types listed in the table above provides a different level of capability. As mentioned previously, base your deployment type on the needs of your business. However, you should also consider the technical expertise available for your deployment. The sections below provide more detailed recommendations for each deployment type.
 

--- a/doc/code_insights/index.md
+++ b/doc/code_insights/index.md
@@ -45,6 +45,7 @@ Code Insights is based on our universal code search, making it precise and confi
 <div class="cta-group">
 <a class="btn btn-primary" href="quickstart">★ Quickstart</a>
 <a class="btn" href="language_insight_quickstart">Language Insight Quickstart</a>
+<a class="btn" href="references/requirements">Requirements</a>
 </div>
 
 ## [Explanations](explanations/index.md)
@@ -67,3 +68,4 @@ Code Insights is based on our universal code search, making it precise and confi
 - [Common reasons code insights may not match search results](references/common_reasons_code_insights_may_not_match_search_results.md)
 - [Licensing and limited access](references/license.md)
 - [Managing code insights with the API](../api/graphql/managing-code-insights-with-api.md)
+- [Requirements](references/requirements.md)

--- a/doc/code_insights/quickstart.md
+++ b/doc/code_insights/quickstart.md
@@ -14,8 +14,9 @@ For more information about Code Insights see the [Code Insights](index.md) docum
 
 - You are a Sourcegraph enterprise customer. (Want code insights but aren't enterprise? [Let us know](mailto:feedback@sourcegraph.com).)
 - Your Sourcegraph instance has at least 1 repository. (See "[Quickstart](../index.md#quick-install)" on how to setup a Sourcegraph instance.)
-- You are running Sourcegraph version 3.28 (May 2021 release) or later.
-    - Note: If you're on Sourcegraph version 3.24 or later, you can instead follow [this gist](https://gist.github.com/Joelkw/f0582b164578aabc3ac936dee43f23e0) to create an insight. Due to the early stage of the product, it's more likely you'll run into trouble, though, so we recommend that you either upgrade your Sourcegraph or reach out to your Sourcegraph reps for help.
+- Your Sourcegraph instance is deployed via [Docker Compose](../admin/deploy/docker-compose/index.md) or [Kubernetes](../admin/deploy/kubernetes/index.md). 
+- You are running Sourcegraph version 3.31.1 (August 2021 release) or later.
+    - Note: If you're on Sourcegraph version 3.24 to 3.28, you can instead follow [this gist](https://gist.github.com/Joelkw/f0582b164578aabc3ac936dee43f23e0) to create an insight. Due to the early stage of the product, it's more likely you'll run into trouble, though, so we recommend that you either upgrade your Sourcegraph or reach out to your Sourcegraph reps for help.
 
 ## Enable Code Insights
 

--- a/doc/code_insights/references/index.md
+++ b/doc/code_insights/references/index.md
@@ -5,3 +5,4 @@ The following is a list of reference documents for [Code Insights](../index.md):
 - [Common use cases and recipes](common_use_cases.md)
 - [Common reasons code insights may not match search results](common_reasons_code_insights_may_not_match_search_results.md)
 - [Licensing and limited access](license.md)
+- [Requirements](requirements.md)

--- a/doc/code_insights/references/requirements.md
+++ b/doc/code_insights/references/requirements.md
@@ -1,0 +1,20 @@
+# Requirements
+
+Code Insights has requirements for the Sourcegraph server version, its deployment type, and its connected code hosts. 
+
+## Sourcegraph server
+
+While the latest version of Sourcegraph server is always recommended: 
+
+- Version 3.28 is the minimum version required to use Code Insights over individual repositories
+- Version 3.31.1 is the minimum version required to use Code Insights over all repositories
+
+## Sourcegraph deployment 
+
+You can only use Code Insights on a [Docker Compose](../../admin/deploy/docker-compose/index.md) or [Kubernetes](../../admin/deploy/kubernetes/index.md) Sourcegraph deployment. 
+
+## Code hosts
+
+Sourcegraph Code Insights is compatible with any [Sourcegraph-compatible code host](../../admin/repo/index.md), except: 
+
+* Perforce repositories making use of sub-repo permissions are not supported 


### PR DESCRIPTION
A few additional docs updates to ensure anyone looking to try code insights locally gets pointed to the right deploy type. [Slack discussion catalyst](https://sourcegraph.slack.com/archives/C0W2E592M/p1653057871650819).  

## Test plan

Review a local deployment of the docsite. 