### PR TITLE
Search backend: update searcher client to accept multiline matches

### DIFF
--- a/cmd/searcher/protocol/searcher.go
+++ b/cmd/searcher/protocol/searcher.go
@@ -192,11 +192,15 @@ type Response struct {
 
 // FileMatch is the struct used by vscode to receive search results
 type FileMatch struct {
-	Path        string
-	LineMatches []LineMatch
+	Path string
+
+	MultilineMatches []MultilineMatch
+	LineMatches      []LineMatch
 
 	// MatchCount is the number of matches.  Different from len(LineMatches), as multiple
 	// lines may correspond to one logical match when doing a structural search
+	// TODO remove this because it's not used by any clients and will no longer
+	// be useful once we migrate to use only MultilineMatches
 	MatchCount int
 
 	// LimitHit is true if LineMatches may not include all LineMatches.
@@ -216,4 +220,25 @@ type LineMatch struct {
 	// representing each match on a line.
 	// Offsets and lengths are measured in characters, not bytes.
 	OffsetAndLengths [][2]int
+}
+
+// LineColumn is a subset of the fields on Location because we don't
+// have the rune offset necessary to build a full Location yet.
+// Eventually, the two structs should be merged.
+type LineColumn struct {
+	// Line is the count of newlines before the offset in the matched text.
+	// Line is 0-based.
+	Line int32
+
+	// Column is the count of unicode code points after the last newline in the matched text
+	Column int32
+}
+
+type MultilineMatch struct {
+	// Preview is a possibly-multiline string that contains all the
+	// lines that the match overlaps.
+	// The number of lines in Preview should be End.Line - Start.Line + 1
+	Preview string
+	Start   LineColumn
+	End     LineColumn
 }

--- a/internal/search/searcher/search.go
+++ b/internal/search/searcher/search.go
@@ -211,10 +211,10 @@ func newToMatches(repo types.MinimalRepo, commit api.CommitID, rev *string) func
 	return func(searcherMatches []*protocol.FileMatch) []result.Match {
 		matches := make([]result.Match, 0, len(searcherMatches))
 		for _, fm := range searcherMatches {
-			lineMatches := make([]result.MultilineMatch, 0, len(fm.LineMatches))
+			multilineMatches := make([]result.MultilineMatch, 0, len(fm.LineMatches))
 			for _, lm := range fm.LineMatches {
 				for _, ol := range lm.OffsetAndLengths {
-					lineMatches = append(lineMatches, result.MultilineMatch{
+					multilineMatches = append(multilineMatches, result.MultilineMatch{
 						Start: result.LineColumn{
 							Line:   int32(lm.LineNumber),
 							Column: int32(ol[0]),
@@ -227,6 +227,13 @@ func newToMatches(repo types.MinimalRepo, commit api.CommitID, rev *string) func
 					})
 				}
 			}
+			for _, mm := range fm.MultilineMatches {
+				multilineMatches = append(multilineMatches, result.MultilineMatch{
+					Preview: mm.Preview,
+					Start:   result.LineColumn{Line: mm.Start.Line, Column: mm.Start.Column},
+					End:     result.LineColumn{Line: mm.End.Line, Column: mm.End.Column},
+				})
+			}
 
 			matches = append(matches, &result.FileMatch{
 				File: result.File{
@@ -235,7 +242,7 @@ func newToMatches(repo types.MinimalRepo, commit api.CommitID, rev *string) func
 					CommitID: commit,
 					InputRev: rev,
 				},
-				MultilineMatches: lineMatches,
+				MultilineMatches: multilineMatches,
 				LimitHit:         fm.LimitHit,
 			})
 		}


### PR DESCRIPTION
This updates the types in the searcher protocol to have an optional
multiline return type. Right now, the client will accept both
single-line or multiline results, re-interpreting single-line as the
multiline type. Once we merge this and roll searcher out, we can update
the server to actually send multiline matches.

Stacked on #35897
## Test plan

This is currently unexercised, so I'm just depending on tests to catch any typos. 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
