### PR TITLE
New ref panel: fix JS

### DIFF
--- a/client/web/src/codeintel/language-specs/languages.ts
+++ b/client/web/src/codeintel/language-specs/languages.ts
@@ -384,7 +384,9 @@ export const languageSpecs: LanguageSpec[] = [
  * matches is configured with the given identifier an error is thrown.
  */
 export function findLanguageSpec(languageID: string): LanguageSpec {
-    const languageSpec = languageSpecs.find(spec => spec.languageID === languageID)
+    const languageSpec = languageSpecs.find(
+        spec => spec.languageID === languageID || spec.additionalLanguages?.includes(languageID)
+    )
     if (languageSpec) {
         return languageSpec
     }


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/35902

Looks like JS was missed in https://github.com/sourcegraph/code-intel-extensions/pull/223. It was later fixed in https://github.com/sourcegraph/code-intel-extensions/pull/685 and the new ref panel needs to mimic that behavior.

## Test plan

Ran locally

## App preview:

- [Web](https://sg-web-fix-new-ref-panel-js.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-mujmfmbeqp.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
