### PR TITLE
Code Insights: Add 404 screen for the standalone insight page

### DIFF
--- a/client/web/src/enterprise/insights/core/backend/gql-backend/code-insights-gql-backend.ts
+++ b/client/web/src/enterprise/insights/core/backend/gql-backend/code-insights-gql-backend.ts
@@ -1,6 +1,6 @@
 import { ApolloCache, ApolloClient, ApolloQueryResult, gql } from '@apollo/client'
 import { from, Observable, of } from 'rxjs'
-import { map, mapTo, switchMap } from 'rxjs/operators'
+import { catchError, map, mapTo, switchMap } from 'rxjs/operators'
 import {
     AddInsightViewToDashboardResult,
     DeleteDashboardResult,
@@ -106,7 +106,8 @@ export class CodeInsightsGqlBackend implements CodeInsightsBackend {
                 }
 
                 return createInsightView(insightData) ?? null
-            })
+            }),
+            catchError(() => of(null))
         )
 
     public hasInsights = (first: number): Observable<boolean> =>

--- a/client/web/src/enterprise/insights/pages/insights/insight/CodeInsightIndependentPage.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/insight/CodeInsightIndependentPage.tsx
@@ -1,11 +1,8 @@
 import { FunctionComponent, useContext, useMemo } from 'react'
 
-import MapSearchIcon from 'mdi-react/MapSearchIcon'
-
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { LoadingSpinner, PageHeader, useObservable } from '@sourcegraph/wildcard'
 
-import { HeroPage } from '../../../../../components/HeroPage'
 import { PageTitle } from '../../../../../components/PageTitle'
 import { CodeInsightsIcon } from '../../../../../insights/Icons'
 import { CodeInsightsPage } from '../../../components/code-insights-page/CodeInsightsPage'
@@ -13,6 +10,7 @@ import { CodeInsightsBackendContext } from '../../../core'
 
 import { CodeInsightIndependentPageActions } from './components/actions/CodeInsightIndependentPageActions'
 import { SmartStandaloneInsight } from './components/SmartStandaloneInsight'
+import { Standalone404Insight } from './components/standalone-404-insight/Standalone404Insight'
 
 import styles from './CodeInsightIndependentPage.module.scss'
 
@@ -31,7 +29,7 @@ export const CodeInsightIndependentPage: FunctionComponent<CodeInsightIndependen
     }
 
     if (!insight) {
-        return <HeroPage icon={MapSearchIcon} title="Oops, we couldn't find that insight" />
+        return <Standalone404Insight />
     }
 
     return (

--- a/client/web/src/enterprise/insights/pages/insights/insight/components/standalone-404-insight/Standalone404Insight.module.scss
+++ b/client/web/src/enterprise/insights/pages/insights/insight/components/standalone-404-insight/Standalone404Insight.module.scss
@@ -1,0 +1,16 @@
+.container {
+    width: 100%;
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+}
+
+.chart {
+    margin-bottom: 5rem;
+}
+
+.redirect-button {
+    margin-top: 2rem;
+}

--- a/client/web/src/enterprise/insights/pages/insights/insight/components/standalone-404-insight/Standalone404Insight.module.scss
+++ b/client/web/src/enterprise/insights/pages/insights/insight/components/standalone-404-insight/Standalone404Insight.module.scss
@@ -9,6 +9,16 @@
 
 .chart {
     margin-bottom: 5rem;
+
+    --static-chart-purple: #e3c0fc;
+    --static-chart-orange: #fbd1cd;
+    --static-chart-blue: #bbeef7;
+
+    :global(.theme-dark) & {
+        --static-chart-purple: #4c1579;
+        --static-chart-orange: #72302d;
+        --static-chart-blue: var(--logo-blue);
+    }
 }
 
 .redirect-button {

--- a/client/web/src/enterprise/insights/pages/insights/insight/components/standalone-404-insight/Standalone404Insight.story.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/insight/components/standalone-404-insight/Standalone404Insight.story.tsx
@@ -1,0 +1,18 @@
+import { Meta, Story } from '@storybook/react'
+
+import { BrandedStory } from '@sourcegraph/branded/src/components/BrandedStory'
+import { Popover } from '@sourcegraph/wildcard'
+
+import { Standalone404Insight } from './Standalone404Insight'
+
+import webStyles from '../../../../../../../SourcegraphWebApp.scss'
+
+const config: Meta = {
+    title: '/web/insights/StandaloneInsight',
+    component: Popover,
+    decorators: [story => <BrandedStory styles={webStyles}>{() => story()}</BrandedStory>],
+}
+
+export default config
+
+export const Standalone404InsightExample: Story = () => <Standalone404Insight />

--- a/client/web/src/enterprise/insights/pages/insights/insight/components/standalone-404-insight/Standalone404Insight.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/insight/components/standalone-404-insight/Standalone404Insight.tsx
@@ -1,0 +1,72 @@
+import { FunctionComponent } from 'react'
+
+import { Button, Link, Typography } from '@sourcegraph/wildcard'
+
+import styles from './Standalone404Insight.module.scss'
+
+export const Standalone404Insight: FunctionComponent = () => {
+    return (
+        <div className={styles.container}>
+            <GraphicInsightChart className={styles.chart} />
+
+            <Typography.H2 className="mb-3">Insight not found</Typography.H2>
+            <Typography.Text>Insight may not exist or you may not have permission to view it.</Typography.Text>
+
+            <Button as={Link} to="/insights/dashboards/all" variant="primary" className={styles.redirectButton}>
+                Go to 'All insights'
+            </Button>
+        </div>
+    )
+}
+
+const GraphicInsightChart: FunctionComponent<{ className: string }> = ({ className }) => (
+    <svg width="263" height="134" fill="none" xmlns="http://www.w3.org/2000/svg" className={className}>
+        <path
+            opacity=".25"
+            d="M6.715 129.3H90.01l41.91-42.957 42.957-34.052 41.909-19.383 41.386-23.05"
+            stroke="var(--logo-blue)"
+            strokeWidth="3"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+        />
+
+        <path
+            opacity=".25"
+            d="M6.19 46.529 48.1 5.143h42.434l42.433 3.143 41.909 100.583 40.862 4.715h41.909"
+            stroke="var(--logo-purple)"
+            strokeWidth="3"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+        />
+
+        <path
+            opacity=".25"
+            d="M6.19 7.763 48.1 41.29l41.91-3.143 42.433 3.143 42.433 19.907 41.386 3.143 41.385 2.096"
+            stroke="var(--logo-orange)"
+            strokeWidth="3"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+        />
+
+        <circle cx="48.624" cy="5.667" r="3.619" fill="var(--body-bg)" stroke="#F0E1F8" strokeWidth="2" />
+        <circle cx="90.533" cy="4.619" r="3.619" fill="var(--body-bg)" stroke="#F0E1F8" strokeWidth="2" />
+        <circle cx="131.395" cy="8.81" r="3.619" fill="var(--body-bg)" stroke="#F0E1F8" strokeWidth="2" />
+        <circle cx="5.667" cy="47.577" r="3.619" fill="var(--body-bg)" stroke="#F0E1F8" strokeWidth="2" />
+        <circle cx="214.166" cy="113.583" r="3.619" fill="var(--body-bg)" stroke="#F0E1F8" strokeWidth="2" />
+        <circle cx="258.171" cy="113.583" r="3.619" fill="var(--body-bg)" stroke="#F0E1F8" strokeWidth="2" />
+        <circle cx="174.352" cy="108.345" r="3.619" fill="var(--body-bg)" stroke="#F0E1F8" strokeWidth="2" />
+        <circle cx="4.619" cy="7.763" r="3.619" fill="var(--body-bg)" stroke="#F9EBE4" strokeWidth="2" />
+        <circle cx="48.624" cy="42.338" r="3.619" fill="var(--body-bg)" stroke="#F9EBE4" strokeWidth="2" />
+        <circle cx="92.629" cy="39.194" r="3.619" fill="var(--body-bg)" stroke="#F9EBE4" strokeWidth="2" />
+        <circle cx="131.395" cy="41.29" r="3.619" fill="var(--body-bg)" stroke="#F9EBE4" strokeWidth="2" />
+        <circle cx="177.495" cy="62.245" r="3.619" fill="var(--body-bg)" stroke="#F9EBE4" strokeWidth="2" />
+        <circle cx="216.262" cy="64.34" r="3.619" fill="var(--body-bg)" stroke="#F9EBE4" strokeWidth="2" />
+        <circle cx="256.076" cy="65.388" r="3.619" fill="var(--body-bg)" stroke="#F9EBE4" strokeWidth="2" />
+        <circle cx="174.352" cy="52.815" r="3.619" fill="var(--body-bg)" stroke="#E0F3FA" strokeWidth="2" />
+        <circle cx="132.443" cy="85.295" r="3.619" fill="var(--body-bg)" stroke="#E0F3FA" strokeWidth="2" />
+        <circle cx="89.486" cy="129.299" r="3.619" fill="var(--body-bg)" stroke="#E0F3FA" strokeWidth="2" />
+        <circle cx="6.715" cy="129.299" r="3.619" fill="var(--body-bg)" stroke="#E0F3FA" strokeWidth="2" />
+        <circle cx="258.171" cy="10.906" r="3.619" fill="var(--body-bg)" stroke="#E0F3FA" strokeWidth="2" />
+        <circle cx="219.405" cy="30.813" r="3.619" fill="var(--body-bg)" stroke="#E0F3FA" strokeWidth="2" />
+    </svg>
+)

--- a/client/web/src/enterprise/insights/pages/insights/insight/components/standalone-404-insight/Standalone404Insight.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/insight/components/standalone-404-insight/Standalone404Insight.tsx
@@ -4,69 +4,206 @@ import { Button, Link, Typography } from '@sourcegraph/wildcard'
 
 import styles from './Standalone404Insight.module.scss'
 
-export const Standalone404Insight: FunctionComponent = () => {
-    return (
-        <div className={styles.container}>
-            <GraphicInsightChart className={styles.chart} />
+export const Standalone404Insight: FunctionComponent = () => (
+    <div className={styles.container}>
+        <GraphicInsightChart className={styles.chart} />
 
-            <Typography.H2 className="mb-3">Insight not found</Typography.H2>
-            <Typography.Text>Insight may not exist or you may not have permission to view it.</Typography.Text>
+        <Typography.H2 className="mb-3">Insight not found</Typography.H2>
+        <Typography.Text>Insight may not exist or you may not have permission to view it.</Typography.Text>
 
-            <Button as={Link} to="/insights/dashboards/all" variant="primary" className={styles.redirectButton}>
-                Go to 'All insights'
-            </Button>
-        </div>
-    )
-}
+        <Button as={Link} to="/insights/dashboards/all" variant="primary" className={styles.redirectButton}>
+            Go to 'All insights'
+        </Button>
+    </div>
+)
 
 const GraphicInsightChart: FunctionComponent<{ className: string }> = ({ className }) => (
     <svg width="263" height="134" fill="none" xmlns="http://www.w3.org/2000/svg" className={className}>
         <path
-            opacity=".25"
             d="M6.715 129.3H90.01l41.91-42.957 42.957-34.052 41.909-19.383 41.386-23.05"
-            stroke="var(--logo-blue)"
+            stroke="var(--static-chart-blue)"
             strokeWidth="3"
             strokeLinecap="round"
             strokeLinejoin="round"
         />
 
         <path
-            opacity=".25"
             d="M6.19 46.529 48.1 5.143h42.434l42.433 3.143 41.909 100.583 40.862 4.715h41.909"
-            stroke="var(--logo-purple)"
+            stroke="var(--static-chart-purple)"
             strokeWidth="3"
             strokeLinecap="round"
             strokeLinejoin="round"
         />
 
         <path
-            opacity=".25"
             d="M6.19 7.763 48.1 41.29l41.91-3.143 42.433 3.143 42.433 19.907 41.386 3.143 41.385 2.096"
-            stroke="var(--logo-orange)"
+            stroke="var(--static-chart-orange)"
             strokeWidth="3"
             strokeLinecap="round"
             strokeLinejoin="round"
         />
 
-        <circle cx="48.624" cy="5.667" r="3.619" fill="var(--body-bg)" stroke="#F0E1F8" strokeWidth="2" />
-        <circle cx="90.533" cy="4.619" r="3.619" fill="var(--body-bg)" stroke="#F0E1F8" strokeWidth="2" />
-        <circle cx="131.395" cy="8.81" r="3.619" fill="var(--body-bg)" stroke="#F0E1F8" strokeWidth="2" />
-        <circle cx="5.667" cy="47.577" r="3.619" fill="var(--body-bg)" stroke="#F0E1F8" strokeWidth="2" />
-        <circle cx="214.166" cy="113.583" r="3.619" fill="var(--body-bg)" stroke="#F0E1F8" strokeWidth="2" />
-        <circle cx="258.171" cy="113.583" r="3.619" fill="var(--body-bg)" stroke="#F0E1F8" strokeWidth="2" />
-        <circle cx="174.352" cy="108.345" r="3.619" fill="var(--body-bg)" stroke="#F0E1F8" strokeWidth="2" />
-        <circle cx="4.619" cy="7.763" r="3.619" fill="var(--body-bg)" stroke="#F9EBE4" strokeWidth="2" />
-        <circle cx="48.624" cy="42.338" r="3.619" fill="var(--body-bg)" stroke="#F9EBE4" strokeWidth="2" />
-        <circle cx="92.629" cy="39.194" r="3.619" fill="var(--body-bg)" stroke="#F9EBE4" strokeWidth="2" />
-        <circle cx="131.395" cy="41.29" r="3.619" fill="var(--body-bg)" stroke="#F9EBE4" strokeWidth="2" />
-        <circle cx="177.495" cy="62.245" r="3.619" fill="var(--body-bg)" stroke="#F9EBE4" strokeWidth="2" />
-        <circle cx="216.262" cy="64.34" r="3.619" fill="var(--body-bg)" stroke="#F9EBE4" strokeWidth="2" />
-        <circle cx="256.076" cy="65.388" r="3.619" fill="var(--body-bg)" stroke="#F9EBE4" strokeWidth="2" />
-        <circle cx="174.352" cy="52.815" r="3.619" fill="var(--body-bg)" stroke="#E0F3FA" strokeWidth="2" />
-        <circle cx="132.443" cy="85.295" r="3.619" fill="var(--body-bg)" stroke="#E0F3FA" strokeWidth="2" />
-        <circle cx="89.486" cy="129.299" r="3.619" fill="var(--body-bg)" stroke="#E0F3FA" strokeWidth="2" />
-        <circle cx="6.715" cy="129.299" r="3.619" fill="var(--body-bg)" stroke="#E0F3FA" strokeWidth="2" />
-        <circle cx="258.171" cy="10.906" r="3.619" fill="var(--body-bg)" stroke="#E0F3FA" strokeWidth="2" />
-        <circle cx="219.405" cy="30.813" r="3.619" fill="var(--body-bg)" stroke="#E0F3FA" strokeWidth="2" />
+        <circle
+            cx="48.624"
+            cy="5.667"
+            r="3.619"
+            fill="var(--body-bg)"
+            stroke="var(--static-chart-purple)"
+            strokeWidth="2"
+        />
+        <circle
+            cx="90.533"
+            cy="4.619"
+            r="3.619"
+            fill="var(--body-bg)"
+            stroke="var(--static-chart-purple)"
+            strokeWidth="2"
+        />
+        <circle
+            cx="131.395"
+            cy="8.81"
+            r="3.619"
+            fill="var(--body-bg)"
+            stroke="var(--static-chart-purple)"
+            strokeWidth="2"
+        />
+        <circle
+            cx="5.667"
+            cy="47.577"
+            r="3.619"
+            fill="var(--body-bg)"
+            stroke="var(--static-chart-purple)"
+            strokeWidth="2"
+        />
+        <circle
+            cx="214.166"
+            cy="113.583"
+            r="3.619"
+            fill="var(--body-bg)"
+            stroke="var(--static-chart-purple)"
+            strokeWidth="2"
+        />
+        <circle
+            cx="258.171"
+            cy="113.583"
+            r="3.619"
+            fill="var(--body-bg)"
+            stroke="var(--static-chart-purple)"
+            strokeWidth="2"
+        />
+        <circle
+            cx="174.352"
+            cy="108.345"
+            r="3.619"
+            fill="var(--body-bg)"
+            stroke="var(--static-chart-purple)"
+            strokeWidth="2"
+        />
+
+        <circle
+            cx="4.619"
+            cy="7.763"
+            r="3.619"
+            fill="var(--body-bg)"
+            stroke="var(--static-chart-orange)"
+            strokeWidth="2"
+        />
+        <circle
+            cx="48.624"
+            cy="42.338"
+            r="3.619"
+            fill="var(--body-bg)"
+            stroke="var(--static-chart-orange)"
+            strokeWidth="2"
+        />
+        <circle
+            cx="92.629"
+            cy="39.194"
+            r="3.619"
+            fill="var(--body-bg)"
+            stroke="var(--static-chart-orange)"
+            strokeWidth="2"
+        />
+        <circle
+            cx="131.395"
+            cy="41.29"
+            r="3.619"
+            fill="var(--body-bg)"
+            stroke="var(--static-chart-orange)"
+            strokeWidth="2"
+        />
+        <circle
+            cx="177.495"
+            cy="62.245"
+            r="3.619"
+            fill="var(--body-bg)"
+            stroke="var(--static-chart-orange)"
+            strokeWidth="2"
+        />
+        <circle
+            cx="216.262"
+            cy="64.34"
+            r="3.619"
+            fill="var(--body-bg)"
+            stroke="var(--static-chart-orange)"
+            strokeWidth="2"
+        />
+        <circle
+            cx="256.076"
+            cy="65.388"
+            r="3.619"
+            fill="var(--body-bg)"
+            stroke="var(--static-chart-orange)"
+            strokeWidth="2"
+        />
+
+        <circle
+            cx="174.352"
+            cy="52.815"
+            r="3.619"
+            fill="var(--body-bg)"
+            stroke="var(--static-chart-blue)"
+            strokeWidth="2"
+        />
+        <circle
+            cx="132.443"
+            cy="85.295"
+            r="3.619"
+            fill="var(--body-bg)"
+            stroke="var(--static-chart-blue)"
+            strokeWidth="2"
+        />
+        <circle
+            cx="89.486"
+            cy="129.299"
+            r="3.619"
+            fill="var(--body-bg)"
+            stroke="var(--static-chart-blue)"
+            strokeWidth="2"
+        />
+        <circle
+            cx="6.715"
+            cy="129.299"
+            r="3.619"
+            fill="var(--body-bg)"
+            stroke="var(--static-chart-blue)"
+            strokeWidth="2"
+        />
+        <circle
+            cx="258.171"
+            cy="10.906"
+            r="3.619"
+            fill="var(--body-bg)"
+            stroke="var(--static-chart-blue)"
+            strokeWidth="2"
+        />
+        <circle
+            cx="219.405"
+            cy="30.813"
+            r="3.619"
+            fill="var(--body-bg)"
+            stroke="var(--static-chart-blue)"
+            strokeWidth="2"
+        />
     </svg>
 )


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/35045

<img width="1205" alt="Screenshot 2022-05-24 at 13 37 38" src="https://user-images.githubusercontent.com/18492575/169957146-20ad1704-9e83-4af3-a687-8d0cea85aef4.png">

## Test plan
- Make sure that we handle not found insight properly on the standalone insight page
- Make sure that other fetch logic doesn't have regressions 

@AlicjaSuska I think we still need to discuss the original dashboard like 404 page. In this PR I implemented the first version where we have only 404 screen without additional dashboard-like UI (select, action buttons, ...etc) 

Also can you please add colors for the chart for our dark mode color schema

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vk-add-404-for-the-insight.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-tgyavwmaym.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
