### PR TITLE
JetBrains: Rename RepoIcon to CodeHostIcon

### DIFF
--- a/client/jetbrains/webview/src/search/results/FileSearchResult.tsx
+++ b/client/jetbrains/webview/src/search/results/FileSearchResult.tsx
@@ -3,8 +3,8 @@ import React from 'react'
 import classNames from 'classnames'
 import FileDocumentIcon from 'mdi-react/FileDocumentIcon'
 
+import { CodeHostIcon } from '@sourcegraph/shared/src/components/CodeHostIcon'
 import { RepoFileLink } from '@sourcegraph/shared/src/components/RepoFileLink'
-import { RepoIcon } from '@sourcegraph/shared/src/components/RepoIcon'
 import { SearchResultStar } from '@sourcegraph/shared/src/components/SearchResultStar'
 import { ContentMatch, getFileMatchUrl } from '@sourcegraph/shared/src/search/stream'
 import { formatRepositoryStarCount } from '@sourcegraph/shared/src/util/stars'
@@ -61,7 +61,7 @@ export const FileSearchResult: React.FunctionComponent<Props> = ({
             <div className={classNames(styles.headerTitle)} data-testid="result-container-header">
                 <Icon role="img" aria-label="File" className="flex-shrink-0" as={FileDocumentIcon} />
                 <div className={classNames('mx-1', styles.headerDivider)} />
-                <RepoIcon repoName={result.repository} className="text-muted flex-shrink-0" />
+                <CodeHostIcon repoName={result.repository} className="text-muted flex-shrink-0" />
                 <RepoFileLink
                     repoName={result.repository}
                     repoURL={repoAtRevisionURL}


### PR DESCRIPTION
This fixes an issue added by missing to apply #35891 inside the JetBrains code. 

I have only merged the changes to run JetBrains code in our CI today so this slipped through yesterday.
 
## Test plan

The codebase builds again.

```
[10:44:06] Finished 'webpack' after 36 s
✨  Done in 37.81s.
```


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-jetbrains-repotocodehost.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-rewrdxdbnx.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
