### PR TITLE
[SG-35730] Accessibility : In Code Monitors add/edit page, "Learn more" link should read better for screen readers

### DIFF
--- a/client/web/src/enterprise/code-monitoring/CreateCodeMonitorPage.tsx
+++ b/client/web/src/enterprise/code-monitoring/CreateCodeMonitorPage.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useMemo } from 'react'
 
+import VisuallyHidden from '@reach/visually-hidden'
 import * as H from 'history'
 import { Observable } from 'rxjs'
 
@@ -83,7 +84,8 @@ const AuthenticatedCreateCodeMonitorPage: React.FunctionComponent<
                     <>
                         Code monitors watch your code for specific triggers and run actions in response.{' '}
                         <Link to="/help/code_monitoring/how-tos/starting_points" target="_blank" rel="noopener">
-                            Learn more
+                            <VisuallyHidden>Learn more about code monitors</VisuallyHidden>
+                            <span aria-hidden={true}>Learn more</span>
                         </Link>
                     </>
                 }

--- a/client/web/src/enterprise/code-monitoring/ManageCodeMonitorPage.tsx
+++ b/client/web/src/enterprise/code-monitoring/ManageCodeMonitorPage.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect } from 'react'
 
+import VisuallyHidden from '@reach/visually-hidden'
 import * as H from 'history'
 import { RouteComponentProps } from 'react-router'
 import { Observable } from 'rxjs'
@@ -104,7 +105,8 @@ const AuthenticatedManageCodeMonitorPage: React.FunctionComponent<
                     <>
                         Code monitors watch your code for specific triggers and run actions in response.{' '}
                         <Link to="/help/code_monitoring" target="_blank" rel="noopener">
-                            Learn more
+                            <VisuallyHidden>Learn more about code monitors</VisuallyHidden>
+                            <span aria-hidden={true}>Learn more</span>
                         </Link>
                     </>
                 }


### PR DESCRIPTION
### Audit type

Screen reader navigation

### User journey audit issue

https://github.com/sourcegraph/sourcegraph/issues/34195

### Problem description

https://sourcegraph.com/code-monitoring/new
"Learn more" is not a descriptive link

![CleanShot 2022-05-19 at 11 15 43](https://user-images.githubusercontent.com/206864/169371789-86251e73-881b-4d7a-8f87-16dbaf1de767.png)


### Expected behavior

Use visually hidden elements so the link reads "Learn more about code monitors" to screen readers

## Refs
[Sourcegraph Issue](https://github.com/sourcegraph/sourcegraph/issues/35730)
[Gitstart Ticket](https://app.gitstart.com/clients/sourcegraph/tickets/SG-35730)

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->
Visit https://sourcegraph.com/code-monitoring/new
Enable screen reader and listened to Learn More content read by screen reader

## App preview:

- [Web](https://sg-web-contractors-sg-35730.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-cxdymujzfd.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
