### PR TITLE
add -v to sg lint when sg lint step is retried

### DIFF
--- a/enterprise/dev/ci/internal/ci/operations.go
+++ b/enterprise/dev/ci/internal/ci/operations.go
@@ -102,7 +102,13 @@ func CoreTestOperations(diff changed.Diff, opts CoreTestOperationsOptions) *oper
 
 // addSgLints runs linters for the given targets.
 func addSgLints(targets []string) func(pipeline *bk.Pipeline) {
-	cmd := "go run ./dev/sg lint -annotations " + strings.Join(targets, " ")
+	cmd := "go run ./dev/sg lint -annotations "
+
+	if retryCount := os.Getenv("BUILDKITE_RETRY_COUNT"); retryCount != "" && retryCount != "0" {
+		cmd = cmd + "-v "
+	}
+
+	cmd = cmd + strings.Join(targets, " ")
 
 	return func(pipeline *bk.Pipeline) {
 		pipeline.AddStep(":pineapple::lint-roller: Run sg lint",


### PR DESCRIPTION
Buildkite exposes an environment variable that counts how many times a step has been retried namely `BUILDKITE_RETRY_COUNT`. If `retry_count > 0` then we add `-v` to `sg lint`

Closes #35887 
## Test plan
Generated the pipeline with BUILDKITE_RETRY_COUNT

### Without env var
```
$ go run ./enterprise/dev/ci/gen-pipeline.go | grep "sg lint" -A 4
          "label": ":pineapple::lint-roller: Run sg lint",
          "key": "pineapplelintrollerRunsglint",
          "command": [
            "./an \"./tr go run ./dev/sg lint -annotations go\""
          ],
          "timeout_in_minutes": "60",
          "env": {
            "ANNOTATE_OPTS": "true -t error",
```
### With `BUILDKITE_RETRY_COUNT = 0`
```
$ BUILDKITE_RETRY_COUNT=0 go run ./enterprise/dev/ci/gen-pipeline.go | grep "sg lint" -A 4
          "label": ":pineapple::lint-roller: Run sg lint",
          "key": "pineapplelintrollerRunsglint",
          "command": [
            "./an \"./tr go run ./dev/sg lint -annotations go\""
          ],
          "timeout_in_minutes": "60",
          "env": {
            "ANNOTATE_OPTS": "true -t error",
```
### With `BUILDKITE_RETRY_COUNT=1`
```
$ BUILDKITE_RETRY_COUNT=0 go run ./enterprise/dev/ci/gen-pipeline.go | grep "sg lint" -A 4
          "label": ":pineapple::lint-roller: Run sg lint",
          "key": "pineapplelintrollerRunsglint",
          "command": [
            "./an \"./tr go run ./dev/sg lint -annotations -v go\""
          ],
          "timeout_in_minutes": "60",
          "env": {
            "ANNOTATE_OPTS": "true -t error",
```