### PR TITLE
JetBrains: Fix last search loading

### DIFF
--- a/client/jetbrains/webview/src/bridge-mock/index.ts
+++ b/client/jetbrains/webview/src/bridge-mock/index.ts
@@ -4,7 +4,7 @@ import { Search } from '../search/App'
 import { Request } from '../search/jsToJavaBridgeUtil'
 
 let savedSearch: Search = {
-    query: '',
+    query: 'r:github.com/sourcegraph/sourcegraph jetbrains',
     caseSensitive: false,
     patternType: SearchPatternType.literal,
     selectedSearchContextSpec: 'global',

--- a/client/jetbrains/webview/src/bridge-mock/index.ts
+++ b/client/jetbrains/webview/src/bridge-mock/index.ts
@@ -1,7 +1,7 @@
 import { SearchPatternType } from '@sourcegraph/shared/src/graphql-operations'
 
-import { Search } from '../search/App'
 import { Request } from '../search/jsToJavaBridgeUtil'
+import type { Search } from '../search/types'
 
 let savedSearch: Search = {
     query: 'r:github.com/sourcegraph/sourcegraph jetbrains',

--- a/client/jetbrains/webview/src/search/App.tsx
+++ b/client/jetbrains/webview/src/search/App.tsx
@@ -142,7 +142,6 @@ export const App: React.FunctionComponent<React.PropsWithChildren<Props>> = ({
             // When we submit a search that is already the last search, do nothing. This prevents the
             // search results from being reloaded and reapplied in a different order when a user
             // accidentally hits enter thinking that this would open the file
-            console.log({ forceNewSearch })
             if (
                 forceNewSearch !== true &&
                 query === lastSearch.query &&
@@ -152,7 +151,7 @@ export const App: React.FunctionComponent<React.PropsWithChildren<Props>> = ({
             ) {
                 return
             }
-            console.log('oh y')
+
             // If we don't unsubscribe, the previous search will be continued after the new search and search results will be mixed
             subscription?.unsubscribe()
             setSubscription(
@@ -167,7 +166,6 @@ export const App: React.FunctionComponent<React.PropsWithChildren<Props>> = ({
                         decorationContextLines: 0,
                     }
                 ).subscribe(searchResults => {
-                    console.log(searchResults)
                     setResults(searchResults.results)
                 })
             )
@@ -189,7 +187,6 @@ export const App: React.FunctionComponent<React.PropsWithChildren<Props>> = ({
         }
         setDidInitialSubmit(true)
         if (initialSearch !== null) {
-            console.log('oh hi', initialSearch, didInitialSubmit)
             onSubmit({
                 caseSensitive: initialSearch.caseSensitive,
                 patternType: initialSearch.patternType,

--- a/client/jetbrains/webview/src/search/App.tsx
+++ b/client/jetbrains/webview/src/search/App.tsx
@@ -249,10 +249,10 @@ export const App: React.FunctionComponent<React.PropsWithChildren<Props>> = ({
                     </form>
                 </div>
                 <div>Auth state: {authState}</div>
-                {/* We reset the search result list whenever a new search is started using key={lastSearchedQuery} */}
+                {/* We reset the search result list whenever a new search is initiated using key={getStableKeyForLastSearch(lastSearch)} */}
                 <SearchResultList
                     results={results}
-                    key={lastSearch.query}
+                    key={getStableKeyForLastSearch(lastSearch)}
                     onPreviewChange={onPreviewChange}
                     onPreviewClear={onPreviewClear}
                     onOpen={onOpen}
@@ -260,4 +260,10 @@ export const App: React.FunctionComponent<React.PropsWithChildren<Props>> = ({
             </div>
         </WildcardThemeContext.Provider>
     )
+}
+
+function getStableKeyForLastSearch(lastSearch: Search): string {
+    return `${lastSearch.query ?? ''}-${lastSearch.caseSensitive}-${String(lastSearch.patternType)}-${
+        lastSearch.selectedSearchContextSpec
+    }`
 }

--- a/client/jetbrains/webview/src/search/App.tsx
+++ b/client/jetbrains/webview/src/search/App.tsx
@@ -30,6 +30,7 @@ import { initializeSourcegraphSettings } from '../sourcegraphSettings'
 
 import { saveLastSearch } from './jsToJavaBridgeUtil'
 import { SearchResultList } from './results/SearchResultList'
+import { Search } from './types'
 
 import styles from './App.module.scss'
 
@@ -46,13 +47,6 @@ interface Props {
 
 function fetchStreamSuggestionsWithStaticUrl(query: string): Observable<SearchMatch[]> {
     return fetchStreamSuggestions(query, 'https://sourcegraph.com/.api')
-}
-
-export interface Search {
-    query: string | null
-    caseSensitive: boolean
-    patternType: SearchPatternType
-    selectedSearchContextSpec: string
 }
 
 export const App: React.FunctionComponent<React.PropsWithChildren<Props>> = ({

--- a/client/jetbrains/webview/src/search/App.tsx
+++ b/client/jetbrains/webview/src/search/App.tsx
@@ -28,7 +28,7 @@ import { useObservable, WildcardThemeContext } from '@sourcegraph/wildcard'
 
 import { initializeSourcegraphSettings } from '../sourcegraphSettings'
 
-import { callJava } from './jsToJavaBridgeUtil'
+import { saveLastSearch } from './jsToJavaBridgeUtil'
 import { SearchResultList } from './results/SearchResultList'
 
 import styles from './App.module.scss'
@@ -180,13 +180,7 @@ export const App: React.FunctionComponent<React.PropsWithChildren<Props>> = ({
     )
 
     useEffect(() => {
-        callJava({ action: 'saveLastSearch', arguments: lastSearch })
-            .then(() => {
-                console.log(`Saved last search: ${JSON.stringify(lastSearch)}`)
-            })
-            .catch((error: Error) => {
-                console.error(`Failed to save last search: ${error.message}`)
-            })
+        saveLastSearch(lastSearch)
     }, [lastSearch, userQueryState])
 
     useEffect(() => {

--- a/client/jetbrains/webview/src/search/index.tsx
+++ b/client/jetbrains/webview/src/search/index.tsx
@@ -1,5 +1,6 @@
 import { render } from 'react-dom'
 
+import polyfillEventSource from '@sourcegraph/shared/src/polyfills/vendor/eventSource'
 import { AnchorLink, setLinkComponent } from '@sourcegraph/wildcard'
 
 import { App } from './App'
@@ -28,6 +29,8 @@ window.initializeSourcegraph = async () => {
     applyConfig(config)
     applyTheme(theme)
     applyLastSearch(lastSearch)
+
+    polyfillEventSource(accessToken ? { Authorization: `token ${accessToken}` } : {})
 
     renderReactApp()
 

--- a/client/jetbrains/webview/src/search/index.tsx
+++ b/client/jetbrains/webview/src/search/index.tsx
@@ -2,7 +2,7 @@ import { render } from 'react-dom'
 
 import { AnchorLink, setLinkComponent } from '@sourcegraph/wildcard'
 
-import { App, Search } from './App'
+import { App } from './App'
 import {
     getConfig,
     getTheme,
@@ -12,7 +12,7 @@ import {
     onPreviewChange,
     onPreviewClear,
 } from './jsToJavaBridgeUtil'
-import type { Theme, PluginConfig } from './types'
+import type { Theme, PluginConfig, Search } from './types'
 
 setLinkComponent(AnchorLink)
 

--- a/client/jetbrains/webview/src/search/jsToJavaBridgeUtil.ts
+++ b/client/jetbrains/webview/src/search/jsToJavaBridgeUtil.ts
@@ -3,6 +3,7 @@ import { ContentMatch } from '@sourcegraph/shared/src/search/stream'
 
 import { Search } from './App'
 import { loadContent } from './lib/blob'
+import { PluginConfig, Theme } from './types'
 
 interface MatchRequest {
     action: 'preview' | 'open'
@@ -38,17 +39,6 @@ interface ClearPreviewRequest {
 
 interface IndicateFinishedLoadingRequest {
     action: 'indicateFinishedLoading'
-}
-
-export interface Theme {
-    isDarkTheme: boolean
-    buttonColor: string
-}
-
-export interface PluginConfig {
-    instanceURL: string
-    isGlobbingEnabled: boolean
-    accessToken: string | null
 }
 
 export type Request =
@@ -125,6 +115,16 @@ export async function loadLastSearch(): Promise<Search | null> {
         console.error(`Failed to get last search: ${(error as Error).message}`)
         return null
     }
+}
+
+export function saveLastSearch(lastSearch: Search): void {
+    callJava({ action: 'saveLastSearch', arguments: lastSearch })
+        .then(() => {
+            console.log(`Saved last search: ${JSON.stringify(lastSearch)}`)
+        })
+        .catch((error: Error) => {
+            console.error(`Failed to save last search: ${error.message}`)
+        })
 }
 
 async function callJava(request: Request): Promise<object> {

--- a/client/jetbrains/webview/src/search/jsToJavaBridgeUtil.ts
+++ b/client/jetbrains/webview/src/search/jsToJavaBridgeUtil.ts
@@ -62,7 +62,7 @@ export type Request =
 
 export async function getConfig(): Promise<PluginConfig> {
     try {
-        return (await window.callJava({ action: 'getConfig' })) as PluginConfig
+        return (await callJava({ action: 'getConfig' })) as PluginConfig
     } catch (error) {
         console.error(`Failed to get config: ${(error as Error).message}`)
         return {
@@ -75,7 +75,7 @@ export async function getConfig(): Promise<PluginConfig> {
 
 export async function getTheme(): Promise<Theme> {
     try {
-        return (await window.callJava({ action: 'getTheme' })) as Theme
+        return (await callJava({ action: 'getTheme' })) as Theme
     } catch (error) {
         console.error(`Failed to get theme: ${(error as Error).message}`)
         return {
@@ -87,7 +87,7 @@ export async function getTheme(): Promise<Theme> {
 
 export async function indicateFinishedLoading(): Promise<void> {
     try {
-        await window.callJava({ action: 'indicateFinishedLoading' })
+        await callJava({ action: 'indicateFinishedLoading' })
     } catch (error) {
         console.error(`Failed to indicate “finished loading”: ${(error as Error).message}`)
     }
@@ -96,7 +96,7 @@ export async function indicateFinishedLoading(): Promise<void> {
 export async function onPreviewChange(match: ContentMatch, lineMatchIndex: number): Promise<void> {
     const request = await createRequestForMatch(match, lineMatchIndex, 'preview')
     try {
-        await window.callJava(request)
+        await callJava(request)
     } catch (error) {
         console.error(`Failed to preview match: ${(error as Error).message}`, request)
     }
@@ -104,7 +104,7 @@ export async function onPreviewChange(match: ContentMatch, lineMatchIndex: numbe
 
 export async function onPreviewClear(): Promise<void> {
     try {
-        await window.callJava({ action: 'clearPreview' })
+        await callJava({ action: 'clearPreview' })
     } catch (error) {
         console.error(`Failed to clear preview: ${(error as Error).message}`)
     }
@@ -112,10 +112,23 @@ export async function onPreviewClear(): Promise<void> {
 
 export async function onOpen(match: ContentMatch, lineMatchIndex: number): Promise<void> {
     try {
-        await window.callJava(await createRequestForMatch(match, lineMatchIndex, 'open'))
+        await callJava(await createRequestForMatch(match, lineMatchIndex, 'open'))
     } catch (error) {
         console.error(`Failed to open match: ${(error as Error).message}`)
     }
+}
+
+export async function loadLastSearch(): Promise<Search | null> {
+    try {
+        return (await callJava({ action: 'loadLastSearch' })) as Search
+    } catch (error) {
+        console.error(`Failed to get last search: ${(error as Error).message}`)
+        return null
+    }
+}
+
+async function callJava(request: Request): Promise<object> {
+    return window.callJava(request)
 }
 
 export async function createRequestForMatch(

--- a/client/jetbrains/webview/src/search/jsToJavaBridgeUtil.ts
+++ b/client/jetbrains/webview/src/search/jsToJavaBridgeUtil.ts
@@ -1,9 +1,8 @@
 import { splitPath } from '@sourcegraph/shared/src/components/RepoFileLink'
 import { ContentMatch } from '@sourcegraph/shared/src/search/stream'
 
-import { Search } from './App'
 import { loadContent } from './lib/blob'
-import { PluginConfig, Theme } from './types'
+import { PluginConfig, Theme, Search } from './types'
 
 interface MatchRequest {
     action: 'preview' | 'open'

--- a/client/jetbrains/webview/src/search/types.d.ts
+++ b/client/jetbrains/webview/src/search/types.d.ts
@@ -1,0 +1,20 @@
+import type { Request } from './jsToJavaBridgeUtil'
+
+/* Add global functions to global window object */
+declare global {
+    interface Window {
+        initializeSourcegraph: () => void
+        callJava: (request: Request) => Promise<object>
+    }
+}
+
+export interface Theme {
+    isDarkTheme: boolean
+    buttonColor: string
+}
+
+export interface PluginConfig {
+    instanceURL: string
+    isGlobbingEnabled: boolean
+    accessToken: string | null
+}

--- a/client/jetbrains/webview/src/search/types.d.ts
+++ b/client/jetbrains/webview/src/search/types.d.ts
@@ -18,3 +18,10 @@ export interface PluginConfig {
     isGlobbingEnabled: boolean
     accessToken: string | null
 }
+
+export interface Search {
+    query: string | null
+    caseSensitive: boolean
+    patternType: SearchPatternType
+    selectedSearchContextSpec: string
+}


### PR DESCRIPTION
Fixes [#35583](https://github.com/sourcegraph/sourcegraph/issues/35583)

The issue was that we loaded the last search _asynchronously_ after we have rendered the search form. That, however, is when we already rendered the search form with an empty value and hence we have the conflict.

To fix this, I moved the initial search loading to the rest of the initializers so they are run before React is included in the equation. 


## Test plan

We can now pre-populate with the previous search term.

![Screenshot 2022-05-24 at 11 39 46](https://user-images.githubusercontent.com/458591/170010301-96ccd591-ca7a-44ea-853c-e911007ab7e8.png)


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-jetbrains-load-last-search.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-usmxqgfnyy.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
