### PR TITLE
Fix external service resolver erroring when webhooks not supported

### DIFF
--- a/cmd/frontend/graphqlbackend/external_service.go
+++ b/cmd/frontend/graphqlbackend/external_service.go
@@ -113,6 +113,10 @@ func (r *externalServiceResolver) WebhookURL() (*string, error) {
 		if err != nil {
 			r.webhookErr = errors.Wrap(err, "building webhook URL")
 		}
+		// If no webhook URL can be built for the kind, we bail out and don't throw an error.
+		if u == "" {
+			return
+		}
 		switch c := parsed.(type) {
 		case *schema.BitbucketCloudConnection:
 			if c.WebhookSecret != "" {

--- a/internal/extsvc/types.go
+++ b/internal/extsvc/types.go
@@ -364,6 +364,8 @@ func ParseConfig(kind, config string) (cfg any, _ error) {
 
 const IDParam = "externalServiceID"
 
+// WebhookURL returns an endpoint URL for the given external service. If the kind
+// of external service does not support webhooks it returns an empty string.
 func WebhookURL(kind string, externalServiceID int64, cfg any, externalURL string) (string, error) {
 	var path, extra string
 	switch strings.ToUpper(kind) {
@@ -386,7 +388,8 @@ func WebhookURL(kind string, externalServiceID int64, cfg any, externalURL strin
 			return "", errors.Newf("external service with id=%d claims to be a Bitbucket Cloud service, but the configuration is of type %T", cfg)
 		}
 	default:
-		return "", errors.Newf("webhooks cannot be handled for external service kind: %q", kind)
+		// If not a supported kind, bail out.
+		return "", nil
 	}
 	// eg. https://example.com/.api/github-webhooks?externalServiceID=1
 	return fmt.Sprintf("%s/.api/%s?%s=%d%s", externalURL, path, IDParam, externalServiceID, extra), nil

--- a/internal/extsvc/types_test.go
+++ b/internal/extsvc/types_test.go
@@ -337,8 +337,9 @@ func TestWebhookURL(t *testing.T) {
 	const externalURL = "https://sourcegraph.com"
 
 	t.Run("unknown kind", func(t *testing.T) {
-		_, err := WebhookURL(KindOther, externalServiceID, nil, externalURL)
-		assert.NotNil(t, err)
+		u, err := WebhookURL(KindOther, externalServiceID, nil, externalURL)
+		assert.Nil(t, err)
+		assert.Equal(t, u, "")
 	})
 
 	t.Run("basic kinds", func(t *testing.T) {


### PR DESCRIPTION
Before, when requesting the webhook URL field, it would error out for external services for which we don't support webhooks.

Reported in Slack here: https://sourcegraph.slack.com/archives/C03CSAER9LK/p1653311222557759

Q: Should we do a patch release with this fix in? It breaks the external service config page.

## Test plan

Verified manually the error Taras was seeing is no longer happening.