### PR TITLE
fix(ui): Add space between 'Create code monitor' btn icon-label

### DIFF
--- a/client/web/src/enterprise/code-monitoring/CodeMonitoringPage.tsx
+++ b/client/web/src/enterprise/code-monitoring/CodeMonitoringPage.tsx
@@ -104,8 +104,7 @@ export const CodeMonitoringPage: React.FunctionComponent<React.PropsWithChildren
                 actions={
                     authenticatedUser && (
                         <Button to="/code-monitoring/new" variant="primary" as={Link}>
-                            <Icon role="img" as={PlusIcon} aria-hidden={true} />
-                            Create code monitor
+                            <Icon role="img" as={PlusIcon} aria-hidden={true} /> Create code monitor
                         </Button>
                     )
                 }


### PR DESCRIPTION
Adds a space character between the Plus icon and label of the "Create code 
monitor" button on Code monitoring page.

Closes #35889

## Test plan

For now, can be manually verified that there is space between the icon and 
label. Later, visual testing can be added to spot these regressions.
