### PR TITLE
search: rename searcher.SearcherJob to searcher.Job

### DIFF
--- a/internal/search/job/jobutil/job.go
+++ b/internal/search/job/jobutil/job.go
@@ -211,7 +211,7 @@ func NewFlatJob(searchInputs *run.SearchInputs, f query.Flat) (job.Job, error) {
 		if resultTypes.Has(result.TypeFile | result.TypePath) {
 			// Create Text Search jobs over repo set.
 			if !skipRepoSubsetSearch {
-				searcherJob := &searcher.SearcherJob{
+				searcherJob := &searcher.Job{
 					PatternInfo:     patternInfo,
 					Indexed:         false,
 					UseFullDeadline: useFullDeadline,

--- a/internal/search/job/jobutil/mapper.go
+++ b/internal/search/job/jobutil/mapper.go
@@ -21,7 +21,7 @@ type Mapper struct {
 	MapZoektRepoSubsetSearchJob   func(*zoekt.ZoektRepoSubsetSearchJob) *zoekt.ZoektRepoSubsetSearchJob
 	MapZoektSymbolSearchJob       func(*zoekt.ZoektSymbolSearchJob) *zoekt.ZoektSymbolSearchJob
 	MapZoektGlobalSymbolSearchJob func(*zoekt.ZoektGlobalSymbolSearchJob) *zoekt.ZoektGlobalSymbolSearchJob
-	MapSearcherJob                func(*searcher.SearcherJob) *searcher.SearcherJob
+	MapSearcherJob                func(*searcher.Job) *searcher.Job
 	MapSymbolSearcherJob          func(*searcher.SymbolSearcherJob) *searcher.SymbolSearcherJob
 	MapRepoSearchJob              func(*run.RepoSearchJob) *run.RepoSearchJob
 	MapRepoUniverseTextSearchJob  func(*zoekt.ZoektGlobalSearchJob) *zoekt.ZoektGlobalSearchJob
@@ -70,7 +70,7 @@ func (m *Mapper) Map(j job.Job) job.Job {
 		}
 		return j
 
-	case *searcher.SearcherJob:
+	case *searcher.Job:
 		if m.MapSearcherJob != nil {
 			j = m.MapSearcherJob(j)
 		}
@@ -220,7 +220,7 @@ func MapAtom(j job.Job, f func(job.Job) job.Job) job.Job {
 			case
 				*zoekt.ZoektRepoSubsetSearchJob,
 				*zoekt.ZoektSymbolSearchJob,
-				*searcher.SearcherJob,
+				*searcher.Job,
 				*searcher.SymbolSearcherJob,
 				*run.RepoSearchJob,
 				*structural.StructuralSearchJob,

--- a/internal/search/job/jobutil/printers.go
+++ b/internal/search/job/jobutil/printers.go
@@ -42,7 +42,7 @@ func SexpFormat(j job.Job, sep, indent string) string {
 		case
 			*zoekt.ZoektRepoSubsetSearchJob,
 			*zoekt.ZoektSymbolSearchJob,
-			*searcher.SearcherJob,
+			*searcher.Job,
 			*searcher.SymbolSearcherJob,
 			*run.RepoSearchJob,
 			*zoekt.ZoektGlobalSearchJob,
@@ -202,7 +202,7 @@ func PrettyMermaid(j job.Job) string {
 		case
 			*zoekt.ZoektRepoSubsetSearchJob,
 			*zoekt.ZoektSymbolSearchJob,
-			*searcher.SearcherJob,
+			*searcher.Job,
 			*searcher.SymbolSearcherJob,
 			*run.RepoSearchJob,
 			*zoekt.ZoektGlobalSearchJob,
@@ -320,7 +320,7 @@ func toJSON(j job.Job, verbose bool) any {
 		case
 			*zoekt.ZoektRepoSubsetSearchJob,
 			*zoekt.ZoektSymbolSearchJob,
-			*searcher.SearcherJob,
+			*searcher.Job,
 			*searcher.SymbolSearcherJob,
 			*run.RepoSearchJob,
 			*zoekt.ZoektGlobalSearchJob,

--- a/internal/search/job/jobutil/repo_pager_job.go
+++ b/internal/search/job/jobutil/repo_pager_job.go
@@ -31,7 +31,7 @@ func setRepos(job job.Job, indexed *zoekt.IndexedRepoRevs, unindexed []*search.R
 		return &jobCopy
 	}
 
-	setSearcherRepos := func(job *searcher.SearcherJob) *searcher.SearcherJob {
+	setSearcherRepos := func(job *searcher.Job) *searcher.Job {
 		jobCopy := *job
 		jobCopy.Repos = unindexed
 		return &jobCopy

--- a/internal/search/job/jobutil/repo_pager_job_test.go
+++ b/internal/search/job/jobutil/repo_pager_job_test.go
@@ -73,7 +73,7 @@ func Test_setRepos(t *testing.T) {
 }`).Equal(t, test(
 		NewParallelJob(
 			&zoekt.ZoektRepoSubsetSearchJob{},
-			&searcher.SearcherJob{},
+			&searcher.Job{},
 		),
 	))
 }

--- a/internal/search/job/jobutil/types.go
+++ b/internal/search/job/jobutil/types.go
@@ -13,7 +13,7 @@ import (
 var allJobs = []job.Job{
 	&zoekt.ZoektRepoSubsetSearchJob{},
 	&zoekt.ZoektSymbolSearchJob{},
-	&searcher.SearcherJob{},
+	&searcher.Job{},
 	&searcher.SymbolSearcherJob{},
 	&run.RepoSearchJob{},
 	&zoekt.ZoektGlobalSearchJob{},

--- a/internal/search/run/repo_has_file.go
+++ b/internal/search/run/repo_has_file.go
@@ -101,7 +101,7 @@ func (s *RepoSearchJob) reposContainingPath(ctx context.Context, clients job.Run
 
 	// Concurrently run searcher for all unindexed repos regardless whether text or regexp.
 	g.Go(func() error {
-		searcherJob := &searcher.SearcherJob{
+		searcherJob := &searcher.Job{
 			PatternInfo:     searcherArgs.PatternInfo,
 			Repos:           unindexed,
 			Indexed:         false,

--- a/internal/search/searcher/search.go
+++ b/internal/search/searcher/search.go
@@ -26,7 +26,7 @@ import (
 // A global limiter on number of concurrent searcher searches.
 var textSearchLimiter = mutablelimiter.New(32)
 
-type SearcherJob struct {
+type Job struct {
 	PatternInfo *search.TextPatternInfo
 	Repos       []*search.RepositoryRevisions // the set of repositories to search with searcher.
 
@@ -46,7 +46,7 @@ type SearcherJob struct {
 }
 
 // Run calls the searcher service on a set of repositories.
-func (s *SearcherJob) Run(ctx context.Context, clients job.RuntimeClients, stream streaming.Sender) (alert *search.Alert, err error) {
+func (s *Job) Run(ctx context.Context, clients job.RuntimeClients, stream streaming.Sender) (alert *search.Alert, err error) {
 	tr, ctx, stream, finish := job.StartSpan(ctx, stream, s)
 	defer func() { finish(alert, err) }()
 
@@ -132,11 +132,11 @@ func (s *SearcherJob) Run(ctx context.Context, clients job.RuntimeClients, strea
 	return nil, g.Wait()
 }
 
-func (s *SearcherJob) Name() string {
+func (s *Job) Name() string {
 	return "SearcherJob"
 }
 
-func (s *SearcherJob) Tags() []log.Field {
+func (s *Job) Tags() []log.Field {
 	return []log.Field{
 		trace.Stringer("patternInfo", s.PatternInfo),
 		log.Int("numRepos", len(s.Repos)),

--- a/internal/search/structural/structural.go
+++ b/internal/search/structural/structural.go
@@ -62,7 +62,7 @@ type searchRepos struct {
 // getJob returns a function parameterized by ctx to search over repos.
 func (s *searchRepos) getJob(ctx context.Context) func() error {
 	return func() error {
-		searcherJob := &searcher.SearcherJob{
+		searcherJob := &searcher.Job{
 			PatternInfo:     s.args.PatternInfo,
 			Repos:           s.repoSet.AsList(),
 			Indexed:         s.repoSet.IsIndexed(),

--- a/internal/search/textsearch/textsearch_test.go
+++ b/internal/search/textsearch/textsearch_test.go
@@ -493,7 +493,7 @@ func RunRepoSubsetTextSearch(
 
 	// Concurrently run searcher for all unindexed repos regardless whether text or regexp.
 	g.Go(func() error {
-		searcherJob := &searcher.SearcherJob{
+		searcherJob := &searcher.Job{
 			PatternInfo:     searcherArgs.PatternInfo,
 			Repos:           unindexed,
 			Indexed:         false,


### PR DESCRIPTION
This is to remove the stutter. This commit is more of an RFC. If people
like the removal of the stutter, I will go ahead and rename most of the
jobs we have to avoid the stutter.

The description is all that really needs reviewing. The code is just the
output of gopls renaming the symbol.

Test Plan: `go test ./internal/search/...`
