### PR TITLE
refactor(scheduler): update logging to use lib/log

### DIFF
--- a/cmd/repo-updater/repoupdater/server_test.go
+++ b/cmd/repo-updater/repoupdater/server_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/internal/types/typestest"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"github.com/sourcegraph/sourcegraph/lib/log/logtest"
 )
 
 func TestServer_handleRepoLookup(t *testing.T) {
@@ -621,7 +622,7 @@ func TestServer_RepoLookup(t *testing.T) {
 				Sourcer: repos.NewFakeSourcer(nil, tc.src),
 			}
 
-			scheduler := repos.NewUpdateScheduler(database.NewMockDB())
+			scheduler := repos.NewUpdateScheduler(database.NewMockDB(), logtest.Scoped(t))
 
 			s := &Server{
 				Syncer:    syncer,

--- a/cmd/repo-updater/repoupdater/server_test.go
+++ b/cmd/repo-updater/repoupdater/server_test.go
@@ -622,7 +622,7 @@ func TestServer_RepoLookup(t *testing.T) {
 				Sourcer: repos.NewFakeSourcer(nil, tc.src),
 			}
 
-			scheduler := repos.NewUpdateScheduler(database.NewMockDB(), logtest.Scoped(t))
+			scheduler := repos.NewUpdateScheduler(logtest.Scoped(t), database.NewMockDB())
 
 			s := &Server{
 				Syncer:    syncer,

--- a/cmd/repo-updater/shared/main.go
+++ b/cmd/repo-updater/shared/main.go
@@ -91,6 +91,8 @@ func Main(enterpriseInit EnterpriseInit) {
 	trace.Init()
 	profiler.Init()
 
+	logger := sglog.Scoped("repo updater", "repo updater service")
+
 	// Signals health of startup
 	ready := make(chan struct{})
 
@@ -139,7 +141,7 @@ func Main(enterpriseInit EnterpriseInit) {
 		src = repos.NewSourcer(db, cf, repos.WithDependenciesService(depsSvc), repos.ObservedSource(log15.Root(), m))
 	}
 
-	updateScheduler := repos.NewUpdateScheduler(db)
+	updateScheduler := repos.NewUpdateScheduler(db, logger)
 	server := &repoupdater.Server{
 		Store:                 store,
 		Scheduler:             updateScheduler,
@@ -197,8 +199,8 @@ func Main(enterpriseInit EnterpriseInit) {
 	}
 
 	// Git fetches scheduler
-	go repos.RunScheduler(ctx, updateScheduler)
-	log15.Debug("started scheduler")
+	go repos.RunScheduler(ctx, updateScheduler, logger)
+	logger.Debug("started scheduler")
 
 	host := ""
 	if env.InsecureDev {
@@ -206,7 +208,7 @@ func Main(enterpriseInit EnterpriseInit) {
 	}
 
 	addr := net.JoinHostPort(host, port)
-	log15.Info("repo-updater: listening", "addr", addr)
+	logger.Info("listening", sglog.String("addr", addr))
 
 	var handler http.Handler
 	{

--- a/cmd/repo-updater/shared/main.go
+++ b/cmd/repo-updater/shared/main.go
@@ -141,7 +141,7 @@ func Main(enterpriseInit EnterpriseInit) {
 		src = repos.NewSourcer(db, cf, repos.WithDependenciesService(depsSvc), repos.ObservedSource(log15.Root(), m))
 	}
 
-	updateScheduler := repos.NewUpdateScheduler(db, logger)
+	updateScheduler := repos.NewUpdateScheduler(logger, db)
 	server := &repoupdater.Server{
 		Store:                 store,
 		Scheduler:             updateScheduler,
@@ -199,7 +199,7 @@ func Main(enterpriseInit EnterpriseInit) {
 	}
 
 	// Git fetches scheduler
-	go repos.RunScheduler(ctx, updateScheduler, logger)
+	go repos.RunScheduler(ctx, logger, updateScheduler)
 	logger.Debug("started scheduler")
 
 	host := ""

--- a/internal/repos/scheduler.go
+++ b/internal/repos/scheduler.go
@@ -221,7 +221,7 @@ func (s *UpdateScheduler) runUpdateLoop(ctx context.Context) {
 					subLogger.Error("error updating repo", log.String("err", resp.Error), log.String("uri", string(repo.Name)))
 				}
 
-				if interval := getCustomInterval(subLogger, conf.Get(), string(repo.Name)); interval > 0 {
+				if interval := getCustomInterval(conf.Get(), string(repo.Name), subLogger); interval > 0 {
 					s.schedule.updateInterval(repo, interval)
 					return
 				}
@@ -243,7 +243,7 @@ func (s *UpdateScheduler) runUpdateLoop(ctx context.Context) {
 	}
 }
 
-func getCustomInterval(logger log.Logger, c *conf.Unified, repoName string) time.Duration {
+func getCustomInterval(c *conf.Unified, repoName string, logger log.Logger) time.Duration {
 	if c == nil {
 		return 0
 	}

--- a/internal/repos/scheduler.go
+++ b/internal/repos/scheduler.go
@@ -29,7 +29,7 @@ type schedulerConfig struct {
 }
 
 // RunScheduler runs the worker that schedules git fetches of synced repositories in git-server.
-func RunScheduler(ctx context.Context, scheduler *UpdateScheduler, logger log.Logger) {
+func RunScheduler(ctx context.Context, logger log.Logger, scheduler *UpdateScheduler) {
 	var (
 		have schedulerConfig
 		stop context.CancelFunc
@@ -125,7 +125,7 @@ type configuredRepo struct {
 const notifyChanBuffer = 1
 
 // NewUpdateScheduler returns a new scheduler.
-func NewUpdateScheduler(db database.DB, logger log.Logger) *UpdateScheduler {
+func NewUpdateScheduler(logger log.Logger, db database.DB) *UpdateScheduler {
 	updateSchedLogger := logger.Scoped("UpdateScheduler", "repo update scheduler")
 
 	return &UpdateScheduler{

--- a/internal/repos/scheduler.go
+++ b/internal/repos/scheduler.go
@@ -221,7 +221,7 @@ func (s *UpdateScheduler) runUpdateLoop(ctx context.Context) {
 					subLogger.Error("error updating repo", log.String("err", resp.Error), log.String("uri", string(repo.Name)))
 				}
 
-				if interval := getCustomInterval(conf.Get(), string(repo.Name), subLogger); interval > 0 {
+				if interval := getCustomInterval(subLogger, conf.Get(), string(repo.Name)); interval > 0 {
 					s.schedule.updateInterval(repo, interval)
 					return
 				}
@@ -243,7 +243,7 @@ func (s *UpdateScheduler) runUpdateLoop(ctx context.Context) {
 	}
 }
 
-func getCustomInterval(c *conf.Unified, repoName string, logger log.Logger) time.Duration {
+func getCustomInterval(logger log.Logger, c *conf.Unified, repoName string) time.Duration {
 	if c == nil {
 		return 0
 	}

--- a/internal/repos/scheduler.go
+++ b/internal/repos/scheduler.go
@@ -9,7 +9,8 @@ import (
 	"time"
 
 	"github.com/grafana/regexp"
-	"github.com/inconshreveable/log15"
+
+	"github.com/sourcegraph/sourcegraph/lib/log"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
@@ -28,7 +29,7 @@ type schedulerConfig struct {
 }
 
 // RunScheduler runs the worker that schedules git fetches of synced repositories in git-server.
-func RunScheduler(ctx context.Context, scheduler *UpdateScheduler) {
+func RunScheduler(ctx context.Context, scheduler *UpdateScheduler, logger log.Logger) {
 	var (
 		have schedulerConfig
 		stop context.CancelFunc
@@ -48,7 +49,7 @@ func RunScheduler(ctx context.Context, scheduler *UpdateScheduler) {
 
 		if stop != nil {
 			stop()
-			log15.Info("stopped previous scheduler")
+			logger.Info("stopped previous scheduler")
 		}
 
 		// We setup a separate sub-context so that we can reuse the original
@@ -63,10 +64,10 @@ func RunScheduler(ctx context.Context, scheduler *UpdateScheduler) {
 			go scheduler.runScheduleLoop(ctx2)
 		}
 
-		log15.Debug(
+		logger.Debug(
 			"started configured scheduler",
-			"version", "new",
-			"auto-git-updates", want.autoGitUpdatesEnabled,
+			log.String("version", "new"),
+			log.Bool("auto-git-updates", want.autoGitUpdatesEnabled),
 		)
 
 		// We converged to the desired configuration.
@@ -107,6 +108,7 @@ type UpdateScheduler struct {
 	db          database.DB
 	updateQueue *updateQueue
 	schedule    *schedule
+	logger      log.Logger
 }
 
 // A configuredRepo represents the configuration data for a given repo from
@@ -123,7 +125,9 @@ type configuredRepo struct {
 const notifyChanBuffer = 1
 
 // NewUpdateScheduler returns a new scheduler.
-func NewUpdateScheduler(db database.DB) *UpdateScheduler {
+func NewUpdateScheduler(db database.DB, logger log.Logger) *UpdateScheduler {
+	updateSchedLogger := logger.Scoped("UpdateScheduler", "repo update scheduler")
+
 	return &UpdateScheduler{
 		db: db,
 		updateQueue: &updateQueue{
@@ -134,7 +138,9 @@ func NewUpdateScheduler(db database.DB) *UpdateScheduler {
 			index:         make(map[api.RepoID]*scheduledRepoUpdate),
 			wakeup:        make(chan struct{}, notifyChanBuffer),
 			randGenerator: rand.New(rand.NewSource(time.Now().UnixNano())),
+			logger:        updateSchedLogger.Scoped("schedule", ""),
 		},
+		logger: updateSchedLogger,
 	}
 }
 
@@ -196,6 +202,8 @@ func (s *UpdateScheduler) runUpdateLoop(ctx context.Context) {
 				break
 			}
 
+			subLogger := s.logger.Scoped("runUpdateLoop", "")
+
 			go func(ctx context.Context, repo configuredRepo, cancel context.CancelFunc) {
 				defer cancel()
 				defer s.updateQueue.remove(repo, true)
@@ -207,13 +215,13 @@ func (s *UpdateScheduler) runUpdateLoop(ctx context.Context) {
 				resp, err := requestRepoUpdate(ctx, s.db, repo, 1*time.Second)
 				if err != nil {
 					schedError.WithLabelValues("requestRepoUpdate").Inc()
-					log15.Error("runUpdateLoop: error requesting repo update", "uri", repo.Name, "err", err)
+					subLogger.Error("error requesting repo update", log.Error(err), log.String("uri", string(repo.Name)))
 				} else if resp != nil && resp.Error != "" {
 					schedError.WithLabelValues("repoUpdateResponse").Inc()
-					log15.Error("runUpdateLoop: error updating repo", "uri", repo.Name, "err", resp.Error)
+					subLogger.Error("error updating repo", log.String("err", resp.Error), log.String("uri", string(repo.Name)))
 				}
 
-				if interval := getCustomInterval(conf.Get(), string(repo.Name)); interval > 0 {
+				if interval := getCustomInterval(subLogger, conf.Get(), string(repo.Name)); interval > 0 {
 					s.schedule.updateInterval(repo, interval)
 					return
 				}
@@ -235,14 +243,14 @@ func (s *UpdateScheduler) runUpdateLoop(ctx context.Context) {
 	}
 }
 
-func getCustomInterval(c *conf.Unified, repoName string) time.Duration {
+func getCustomInterval(logger log.Logger, c *conf.Unified, repoName string) time.Duration {
 	if c == nil {
 		return 0
 	}
 	for _, rule := range c.GitUpdateInterval {
 		re, err := regexp.Compile(rule.Pattern)
 		if err != nil {
-			log15.Warn("error compiling GitUpdateInterval pattern", "error", err)
+			logger.Warn("error compiling GitUpdateInterval pattern", log.Error(err))
 			continue
 		}
 		if re.MatchString(repoName) {
@@ -343,26 +351,28 @@ func (s *UpdateScheduler) ListRepoIDs() []api.RepoID {
 // fetch/clone soon.
 func (s *UpdateScheduler) upsert(r *types.Repo, enqueue bool) {
 	repo := configuredRepoFromRepo(r)
+	logger := s.logger.With(log.String("repo", string(r.Name)))
 
 	updated := s.schedule.upsert(repo)
-	log15.Debug("scheduler.schedule.upserted", "repo", r.Name, "updated", updated)
+	logger.Debug("scheduler.schedule.upserted", log.Bool("updated", updated))
 
 	if !enqueue {
 		return
 	}
 	updated = s.updateQueue.enqueue(repo, priorityLow)
-	log15.Debug("scheduler.updateQueue.enqueued", "repo", r.Name, "updated", updated)
+	logger.Debug("scheduler.updateQueue.enqueued", log.Bool("updated", updated))
 }
 
 func (s *UpdateScheduler) remove(r *types.Repo) {
 	repo := configuredRepoFromRepo(r)
+	logger := s.logger.With(log.String("repo", string(r.Name)))
 
 	if s.schedule.remove(repo) {
-		log15.Debug("scheduler.schedule.removed", "repo", r.Name)
+		logger.Debug("scheduler.schedule.removed")
 	}
 
 	if s.updateQueue.remove(repo, false) {
-		log15.Debug("scheduler.updateQueue.removed", "repo", r.Name)
+		logger.Debug("scheduler.updateQueue.removed")
 	}
 }
 
@@ -438,7 +448,7 @@ func (s *UpdateScheduler) DebugDump(ctx context.Context, db database.DB) any {
 	var err error
 	data.SyncJobs, err = db.ExternalServices().GetSyncJobs(ctx)
 	if err != nil {
-		log15.Warn("Getting external service sync jobs foe debug page", "error", err)
+		s.logger.Warn("Getting external service sync jobs for debug page", log.Error(err))
 	}
 
 	return &data
@@ -667,6 +677,7 @@ type schedule struct {
 	// timer sends a value on the wakeup channel when it is time
 	timer  *time.Timer
 	wakeup chan struct{}
+	logger log.Logger
 
 	// random source used to add jitter to repo update intervals.
 	randGenerator interface {
@@ -802,7 +813,7 @@ func (s *schedule) updateInterval(repo configuredRepo, interval time.Duration) {
 		update.Interval = update.Interval + time.Duration(s.randGenerator.Int63n(2*delta)-delta)
 
 		update.Due = timeNow().Add(update.Interval)
-		log15.Debug("updated repo", "repo", repo.Name, "due", update.Due.Sub(timeNow()))
+		s.logger.Debug("updated repo", log.String("repo", string(repo.Name)), log.Duration("due", update.Due.Sub(timeNow())))
 		heap.Fix(s, update.Index)
 		s.rescheduleTimer()
 	}
@@ -872,7 +883,7 @@ func (s *schedule) reset() {
 		s.timer = nil
 	}
 
-	log15.Debug("schedKnownRepos reset")
+	s.logger.Debug("schedKnownRepos reset")
 	schedKnownRepos.Set(0)
 }
 

--- a/internal/repos/scheduler_test.go
+++ b/internal/repos/scheduler_test.go
@@ -1623,7 +1623,7 @@ func TestGetCustomInterval(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			interval := getCustomInterval(tc.c, tc.repoName, testLogger)
+			interval := getCustomInterval(testLogger, tc.c, tc.repoName)
 			if tc.want != interval {
 				t.Fatalf("Want %v, got %v", tc.want, interval)
 			}

--- a/internal/repos/scheduler_test.go
+++ b/internal/repos/scheduler_test.go
@@ -16,6 +16,7 @@ import (
 	gitserverprotocol "github.com/sourcegraph/sourcegraph/internal/gitserver/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/mutablelimiter"
 	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/lib/log/logtest"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
@@ -271,12 +272,14 @@ func TestUpdateQueue_enqueue(t *testing.T) {
 		},
 	}
 
+	testLogger := logtest.Scoped(t)
+
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			r, stop := startRecording()
 			defer stop()
 
-			s := NewUpdateScheduler(db)
+			s := NewUpdateScheduler(db, testLogger)
 
 			for _, call := range test.calls {
 				s.updateQueue.enqueue(call.repo, call.priority)
@@ -437,12 +440,14 @@ func TestUpdateQueue_remove(t *testing.T) {
 		},
 	}
 
+	testLogger := logtest.Scoped(t)
+
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			r, stop := startRecording()
 			defer stop()
 
-			s := NewUpdateScheduler(database.NewMockDB())
+			s := NewUpdateScheduler(database.NewMockDB(), testLogger)
 			setupInitialQueue(s, test.initialQueue)
 
 			// Perform the removals.
@@ -509,12 +514,14 @@ func TestUpdateQueue_acquireNext(t *testing.T) {
 		},
 	}
 
+	testLogger := logtest.Scoped(t)
+
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			r, stop := startRecording()
 			defer stop()
 
-			s := NewUpdateScheduler(database.NewMockDB())
+			s := NewUpdateScheduler(database.NewMockDB(), testLogger)
 			setupInitialQueue(s, test.initialQueue)
 
 			// Test aquireNext.
@@ -638,13 +645,15 @@ func Test_updateScheduler_UpdateFromDiff(t *testing.T) {
 			},
 		},
 	}
+
+	testLogger := logtest.Scoped(t)
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			// The recording is not important for testing this method, but we want to mock and clean up timers.
 			_, stop := startRecording()
 			defer stop()
 
-			s := NewUpdateScheduler(database.NewMockDB())
+			s := NewUpdateScheduler(database.NewMockDB(), testLogger)
 			setupInitialSchedule(s, test.initialSchedule)
 			setupInitialQueue(s, test.initialQueue)
 
@@ -785,12 +794,14 @@ func TestSchedule_upsert(t *testing.T) {
 		},
 	}
 
+	testLogger := logtest.Scoped(t)
+
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			r, stop := startRecording()
 			defer stop()
 
-			s := NewUpdateScheduler(database.NewMockDB())
+			s := NewUpdateScheduler(database.NewMockDB(), testLogger)
 			setupInitialSchedule(s, test.initialSchedule)
 
 			for _, call := range test.upsertCalls {
@@ -812,7 +823,7 @@ func TestUpdateQueue_PrioritiseUncloned(t *testing.T) {
 	_, stop := startRecording()
 	defer stop()
 
-	s := NewUpdateScheduler(database.NewMockDB())
+	s := NewUpdateScheduler(database.NewMockDB(), logtest.Scoped(t))
 
 	assertFront := func(name api.RepoName) {
 		t.Helper()
@@ -850,7 +861,7 @@ func TestScheduleInsertNew(t *testing.T) {
 	_, stop := startRecording()
 	defer stop()
 
-	s := NewUpdateScheduler(database.NewMockDB())
+	s := NewUpdateScheduler(database.NewMockDB(), logtest.Scoped(t))
 
 	assertFront := func(name api.RepoName) {
 		t.Helper()
@@ -1036,12 +1047,14 @@ func TestSchedule_updateInterval(t *testing.T) {
 		},
 	}
 
+	testLogger := logtest.Scoped(t)
+
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			r, stop := startRecording()
 			defer stop()
 
-			s := NewUpdateScheduler(database.NewMockDB())
+			s := NewUpdateScheduler(database.NewMockDB(), testLogger)
 			setupInitialSchedule(s, test.initialSchedule)
 			s.schedule.randGenerator = &mockRandomGenerator{}
 
@@ -1135,12 +1148,14 @@ func TestSchedule_remove(t *testing.T) {
 		},
 	}
 
+	testLogger := logtest.Scoped(t)
+
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			r, stop := startRecording()
 			defer stop()
 
-			s := NewUpdateScheduler(database.NewMockDB())
+			s := NewUpdateScheduler(database.NewMockDB(), testLogger)
 			setupInitialSchedule(s, test.initialSchedule)
 
 			for _, call := range test.removeCalls {
@@ -1297,12 +1312,14 @@ func TestUpdateScheduler_runSchedule(t *testing.T) {
 		},
 	}
 
+	testLogger := logtest.Scoped(t)
+
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			r, stop := startRecording()
 			defer stop()
 
-			s := NewUpdateScheduler(database.NewMockDB())
+			s := NewUpdateScheduler(database.NewMockDB(), testLogger)
 
 			setupInitialSchedule(s, test.initialSchedule)
 
@@ -1399,6 +1416,8 @@ func TestUpdateScheduler_runUpdateLoop(t *testing.T) {
 		},
 	}
 
+	testLogger := logtest.Scoped(t)
+
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			r, stop := startRecording()
@@ -1433,7 +1452,7 @@ func TestUpdateScheduler_runUpdateLoop(t *testing.T) {
 			}
 			defer func() { requestRepoUpdate = nil }()
 
-			s := NewUpdateScheduler(database.NewMockDB())
+			s := NewUpdateScheduler(database.NewMockDB(), testLogger)
 			s.schedule.randGenerator = &mockRandomGenerator{}
 
 			// unbuffer the channel
@@ -1539,6 +1558,8 @@ func Test_updateQueue_Less(t *testing.T) {
 }
 
 func TestGetCustomInterval(t *testing.T) {
+	testLogger := logtest.Scoped(t)
+
 	for _, tc := range []struct {
 		name     string
 		c        *conf.Unified
@@ -1602,7 +1623,7 @@ func TestGetCustomInterval(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			interval := getCustomInterval(tc.c, tc.repoName)
+			interval := getCustomInterval(tc.c, tc.repoName, testLogger)
 			if tc.want != interval {
 				t.Fatalf("Want %v, got %v", tc.want, interval)
 			}

--- a/internal/repos/scheduler_test.go
+++ b/internal/repos/scheduler_test.go
@@ -279,7 +279,7 @@ func TestUpdateQueue_enqueue(t *testing.T) {
 			r, stop := startRecording()
 			defer stop()
 
-			s := NewUpdateScheduler(db, testLogger)
+			s := NewUpdateScheduler(testLogger, db)
 
 			for _, call := range test.calls {
 				s.updateQueue.enqueue(call.repo, call.priority)
@@ -447,7 +447,7 @@ func TestUpdateQueue_remove(t *testing.T) {
 			r, stop := startRecording()
 			defer stop()
 
-			s := NewUpdateScheduler(database.NewMockDB(), testLogger)
+			s := NewUpdateScheduler(testLogger, database.NewMockDB())
 			setupInitialQueue(s, test.initialQueue)
 
 			// Perform the removals.
@@ -521,7 +521,7 @@ func TestUpdateQueue_acquireNext(t *testing.T) {
 			r, stop := startRecording()
 			defer stop()
 
-			s := NewUpdateScheduler(database.NewMockDB(), testLogger)
+			s := NewUpdateScheduler(testLogger, database.NewMockDB())
 			setupInitialQueue(s, test.initialQueue)
 
 			// Test aquireNext.
@@ -653,7 +653,7 @@ func Test_updateScheduler_UpdateFromDiff(t *testing.T) {
 			_, stop := startRecording()
 			defer stop()
 
-			s := NewUpdateScheduler(database.NewMockDB(), testLogger)
+			s := NewUpdateScheduler(testLogger, database.NewMockDB())
 			setupInitialSchedule(s, test.initialSchedule)
 			setupInitialQueue(s, test.initialQueue)
 
@@ -801,7 +801,7 @@ func TestSchedule_upsert(t *testing.T) {
 			r, stop := startRecording()
 			defer stop()
 
-			s := NewUpdateScheduler(database.NewMockDB(), testLogger)
+			s := NewUpdateScheduler(testLogger, database.NewMockDB())
 			setupInitialSchedule(s, test.initialSchedule)
 
 			for _, call := range test.upsertCalls {
@@ -823,7 +823,7 @@ func TestUpdateQueue_PrioritiseUncloned(t *testing.T) {
 	_, stop := startRecording()
 	defer stop()
 
-	s := NewUpdateScheduler(database.NewMockDB(), logtest.Scoped(t))
+	s := NewUpdateScheduler(logtest.Scoped(t), database.NewMockDB())
 
 	assertFront := func(name api.RepoName) {
 		t.Helper()
@@ -861,7 +861,7 @@ func TestScheduleInsertNew(t *testing.T) {
 	_, stop := startRecording()
 	defer stop()
 
-	s := NewUpdateScheduler(database.NewMockDB(), logtest.Scoped(t))
+	s := NewUpdateScheduler(logtest.Scoped(t), database.NewMockDB())
 
 	assertFront := func(name api.RepoName) {
 		t.Helper()
@@ -1054,7 +1054,7 @@ func TestSchedule_updateInterval(t *testing.T) {
 			r, stop := startRecording()
 			defer stop()
 
-			s := NewUpdateScheduler(database.NewMockDB(), testLogger)
+			s := NewUpdateScheduler(testLogger, database.NewMockDB())
 			setupInitialSchedule(s, test.initialSchedule)
 			s.schedule.randGenerator = &mockRandomGenerator{}
 
@@ -1155,7 +1155,7 @@ func TestSchedule_remove(t *testing.T) {
 			r, stop := startRecording()
 			defer stop()
 
-			s := NewUpdateScheduler(database.NewMockDB(), testLogger)
+			s := NewUpdateScheduler(testLogger, database.NewMockDB())
 			setupInitialSchedule(s, test.initialSchedule)
 
 			for _, call := range test.removeCalls {
@@ -1319,7 +1319,7 @@ func TestUpdateScheduler_runSchedule(t *testing.T) {
 			r, stop := startRecording()
 			defer stop()
 
-			s := NewUpdateScheduler(database.NewMockDB(), testLogger)
+			s := NewUpdateScheduler(testLogger, database.NewMockDB())
 
 			setupInitialSchedule(s, test.initialSchedule)
 
@@ -1452,7 +1452,7 @@ func TestUpdateScheduler_runUpdateLoop(t *testing.T) {
 			}
 			defer func() { requestRepoUpdate = nil }()
 
-			s := NewUpdateScheduler(database.NewMockDB(), testLogger)
+			s := NewUpdateScheduler(testLogger, database.NewMockDB())
 			s.schedule.randGenerator = &mockRandomGenerator{}
 
 			// unbuffer the channel


### PR DESCRIPTION
Part of #34607

Migrate from `log15` module to module [lib/log](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/tree/lib/log?_ga=2.243930117.1079701360.1653293646-1160494772.1653293646)

Some changes were needed in 
## Test plan
Unit tests
```
ok  	github.com/sourcegraph/sourcegraph/internal/repos
```
Also checked startup with
```
sg run frontend gitserver repo-updater
```