### PR TITLE
codemirror: Fix line wrapping in Code Monitor's query input

### DIFF
--- a/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.tsx
@@ -231,9 +231,8 @@ export const FormTriggerArea: React.FunctionComponent<React.PropsWithChildren<Tr
                                     caseSensitive={false}
                                     queryState={queryState}
                                     onChange={setQueryState}
-                                    onSubmit={() => {}}
                                     globbing={false}
-                                    preventNewLine={false}
+                                    preventNewLine={true}
                                     autoFocus={true}
                                 />
                             </div>


### PR DESCRIPTION
Setting `preventNewLine={true}` fixing the line wrapping issue. Passing an empty `onSubmit` is not necessary anymore.

## Test plan

Manually tested with CodeMirror turned on and off.

<img width="584" alt="2022-05-24_12-12" src="https://user-images.githubusercontent.com/179026/170038881-a97ea58d-f640-478d-9674-af40162ab4c9.png">
