### PR TITLE
fix: remove off-by-one for highlighting in search results

### DIFF
--- a/cmd/frontend/internal/highlight/html.go
+++ b/cmd/frontend/internal/highlight/html.go
@@ -173,7 +173,7 @@ func lsifToHTML(
 				addRow(row)
 				addText(occ.SyntaxKind, safeSlice(line, 0, endCharacter))
 			} else {
-				addText(occ.SyntaxKind, safeSlice(line, startCharacter, endCharacter-1))
+				addText(occ.SyntaxKind, safeSlice(line, startCharacter, endCharacter))
 			}
 
 			lineCharacter = endCharacter


### PR DESCRIPTION
I had an uncommitted change locally that I didn't realize from #35738 . 

Cloud:

![image](https://user-images.githubusercontent.com/4466899/170047113-9ed94704-873b-4016-8567-0fd313ffbcff.png)

Fixed:

![image](https://user-images.githubusercontent.com/4466899/170047168-af294718-2302-41c3-b810-5121437e69f9.png)

Sadness:

![image](https://user-images.githubusercontent.com/4466899/170047387-5af3d621-75ca-4aec-8e98-e95083bbff45.png)


## Test plan

- confirm that highlights aren't shortened by one in search results
