### PR TITLE
Port flakefiles from previous version

### DIFF
--- a/dev/ci/go-backcompat/flakefiles/v3.40.0.json
+++ b/dev/ci/go-backcompat/flakefiles/v3.40.0.json
@@ -1,0 +1,27 @@
+[
+  {
+    "path": "cmd/gitserver/server",
+    "prefix": "TestCleanup_computeStats",
+    "reason": "Database semantics changed: every created repo has a corresponding gitserver_repo entry right after being inserted in repo table (https://github.com/sourcegraph/sourcegraph/pull/35633)"
+  },
+  {
+    "path": "cmd/gitserver/server",
+    "prefix": "TestCleanup_setRepoSizes",
+    "reason": "Database semantics changed: every created repo has a corresponding gitserver_repo entry right after being inserted in repo table (https://github.com/sourcegraph/sourcegraph/pull/35633)"
+  },
+  {
+    "path": "internal/database",
+    "prefix": "TestIterateRepoGitserverStatus",
+    "reason": "Database semantics changed: every created repo has a corresponding gitserver_repo entry right after being inserted in repo table (https://github.com/sourcegraph/sourcegraph/pull/35633)"
+  },
+  {
+    "path": "internal/database",
+    "prefix": "TestSetRepoSize",
+    "reason": "Database semantics changed: every created repo has a corresponding gitserver_repo entry right after being inserted in repo table (https://github.com/sourcegraph/sourcegraph/pull/35633)"
+  },
+  {
+    "path": "internal/database",
+    "prefix": "TestListIndexableRepos",
+    "reason": "Database semantics changed: every created repo has a corresponding gitserver_repo entry right after being inserted in repo table (https://github.com/sourcegraph/sourcegraph/pull/35633)"
+  }
+]


### PR DESCRIPTION
https://github.com/sourcegraph/sourcegraph/pull/35633 introduced a backward incompatible change into the codetree, but the flakefile was only added for 3.39.0, not 3.40.0. This change was meant to be released in 3.41.0. 

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Green Backcompat tests
