### PR TITLE
JetBrains: Remove second popover show call

### DIFF
--- a/client/jetbrains/src/main/java/com/sourcegraph/find/SourcegraphWindow.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/find/SourcegraphWindow.java
@@ -36,9 +36,7 @@ public class SourcegraphWindow implements Disposable {
 
         if (shouldHideInsteadOfCancel()) {
             popup.setUiVisible(true);
-            popup.showInFocusCenter();
         }
-
 
         // If the popup is already shown, hitting alt + a gain should behave the same as the native find in files
         // feature and focus the search field.


### PR DESCRIPTION
Fixes #35922

The popover fix that I've added contained an unnecessary call to `showInFocusCenter` which is not necessary as the popover is already aligned because of the first time it is shown. The workaround remains in tact

## Test plan

I manually tested this by opening the app on macOS and verified that no more error is thrown neither on the first opening nor on a later one:

https://user-images.githubusercontent.com/458591/170053987-039ac422-2487-446e-9c76-145d4360d62a.mov


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-jetbrains-open-popup-error.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-xsnjbndqqn.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
