### PR TITLE
ci: warn about edge case on back compat tests

### DIFF
--- a/dev/ci/go-backcompat/test.sh
+++ b/dev/ci/go-backcompat/test.sh
@@ -152,6 +152,8 @@ an exception for this test can be added to the following flakefile:
 ${flakefile}
 \`\`\`
 
+⚠️ If by the time you are adding an exception, the release has already been cut, but it has not
+been published yet, the best course of action is to wait until that is the case.
 EOF
   )
   mkdir -p ./annotations/

--- a/dev/ci/go-backcompat/test.sh
+++ b/dev/ci/go-backcompat/test.sh
@@ -153,7 +153,8 @@ ${flakefile}
 \`\`\`
 
 ⚠️ If by the time you are adding an exception, the release has already been cut, but it has not
-been published yet, the best course of action is to wait until that is the case.
+been published yet, the best course of action is to postpone merging the commit creating the issue
+until the release process is complete.
 EOF
   )
   mkdir -p ./annotations/


### PR DESCRIPTION
[Context](https://sourcegraph.slack.com/archives/C032Z79NZQC/p1653399008176829) TL;DR, a commit was made on main, after the release cut, but before it was actually released, which included a change on the flake files for back compat tests. 

When the release was actually made, the latest version to test against in the back compat test was bumped and therefore the flakes that were added were not taken in account anymore. 

This is an edge case and the best solution is simply to wait for the release process to be complete. 

This PR warns about this explicitly to avoid falling in the same trap. 

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

n/a purely textual change of CI annotation.