### PR TITLE
JetBrains: Fix JavaScript console errors

### DIFF
--- a/client/jetbrains/src/main/java/com/sourcegraph/browser/JSToJavaBridgeRequestHandler.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/browser/JSToJavaBridgeRequestHandler.java
@@ -77,6 +77,7 @@ public class JSToJavaBridgeRequestHandler {
                     return createSuccessResponse(null);
                 case "indicateFinishedLoading":
                     topPanel.setBrowserVisible(true);
+                    return createSuccessResponse(null);
                 default:
                     return createErrorResponse(2, "Unknown action: " + action);
             }
@@ -91,7 +92,7 @@ public class JSToJavaBridgeRequestHandler {
 
     @NotNull
     private JBCefJSQuery.Response createSuccessResponse(@Nullable JsonObject result) {
-        return new JBCefJSQuery.Response(result != null ? result.toString() : null);
+        return new JBCefJSQuery.Response(result != null ? result.toString() : "{}");
     }
 
     @NotNull

--- a/client/jetbrains/webview/src/search/jsToJavaBridgeUtil.ts
+++ b/client/jetbrains/webview/src/search/jsToJavaBridgeUtil.ts
@@ -89,7 +89,7 @@ export async function indicateFinishedLoading(): Promise<void> {
     try {
         await window.callJava({ action: 'indicateFinishedLoading' })
     } catch (error) {
-        console.error(`Failed to indicate “finished loading”: ${(error as Error).message}`, error)
+        console.error(`Failed to indicate “finished loading”: ${(error as Error).message}`)
     }
 }
 
@@ -106,7 +106,7 @@ export async function onPreviewClear(): Promise<void> {
     try {
         await window.callJava({ action: 'clearPreview' })
     } catch (error) {
-        console.error(`Failed to clear preview: ${(error as Error).message}`, error)
+        console.error(`Failed to clear preview: ${(error as Error).message}`)
     }
 }
 

--- a/client/jetbrains/webview/src/search/jsToJavaBridgeUtil.ts
+++ b/client/jetbrains/webview/src/search/jsToJavaBridgeUtil.ts
@@ -89,7 +89,7 @@ export async function indicateFinishedLoading(): Promise<void> {
     try {
         await window.callJava({ action: 'indicateFinishedLoading' })
     } catch (error) {
-        console.error(`Failed to indicate “finished loading”: ${(error as Error).message}`)
+        console.error(`Failed to indicate “finished loading”: ${(error as Error).message}`, error)
     }
 }
 
@@ -106,7 +106,7 @@ export async function onPreviewClear(): Promise<void> {
     try {
         await window.callJava({ action: 'clearPreview' })
     } catch (error) {
-        console.error(`Failed to clear preview: ${(error as Error).message}`)
+        console.error(`Failed to clear preview: ${(error as Error).message}`, error)
     }
 }
 


### PR DESCRIPTION
Fixes #35934

There were two issues:

1. The `indicateFinishedLoading` case in the switch statement was not returning and thus falling through to the error case.
2. The JS side of the bridge is built to always have a return string that can be deserialized. So instead of returning nothing we are now returning an empty object like we expect on the JS side.

## Test plan

![Screenshot 2022-05-24 at 16 13 50](https://user-images.githubusercontent.com/458591/170057481-06667d77-e836-4a68-813d-06b0c40fa384.png)


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-jetbrains-js-errors.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-uzcfkjfzwh.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
