### PR TITLE
Wildcard/Tabs: Add scrolling back to active tab

### DIFF
--- a/client/wildcard/src/components/Tabs/Tabs.module.scss
+++ b/client/wildcard/src/components/Tabs/Tabs.module.scss
@@ -122,7 +122,6 @@
     .tab-list {
         display: flex;
         flex-wrap: wrap;
-        align-items: flex-start;
         gap: 0.75rem;
     }
 

--- a/client/wildcard/src/components/Tabs/context.ts
+++ b/client/wildcard/src/components/Tabs/context.ts
@@ -2,13 +2,18 @@ import React from 'react'
 
 import { TabsSettings } from '.'
 
-export const TabsSettingsContext = React.createContext<Required<TabsSettings> | null>(null)
-TabsSettingsContext.displayName = 'TabsSettingsContext'
+export interface TabsState {
+    settings: Required<TabsSettings>
+    activeIndex: number
+}
 
-export const useTabsSettings = (): Required<TabsSettings> => {
-    const context = React.useContext(TabsSettingsContext)
+export const TabsStateContext = React.createContext<TabsState | null>(null)
+TabsStateContext.displayName = 'TabsStateContext'
+
+export const useTabsState = (): TabsState => {
+    const context = React.useContext(TabsStateContext)
     if (!context) {
-        throw new Error('useTabsSettingsContext or Tabs inner components cannot be used outside <Tabs> sub-tree')
+        throw new Error('useTabsState or Tabs inner components cannot be used outside <Tabs> sub-tree')
     }
     return context
 }

--- a/client/wildcard/src/components/Tabs/useScrollBackToActive.ts
+++ b/client/wildcard/src/components/Tabs/useScrollBackToActive.ts
@@ -1,0 +1,29 @@
+import React from 'react'
+
+import { useMatchMedia } from '@sourcegraph/wildcard'
+
+import { useTabsState } from './context'
+
+export function useScrollBackToActive<T extends HTMLElement>(
+    containerReference: React.MutableRefObject<T | null>
+): void {
+    const { activeIndex } = useTabsState()
+    const isReducedMotion = useMatchMedia('(prefers-reduced-motion: reduce)')
+
+    const scrollBack = React.useCallback(() => {
+        if (containerReference?.current) {
+            containerReference.current.children.item(activeIndex)?.scrollIntoView({
+                behavior: isReducedMotion ? 'auto' : 'smooth',
+                inline: 'center',
+            })
+        }
+    }, [activeIndex, containerReference, isReducedMotion])
+
+    React.useEffect(() => {
+        const container = containerReference?.current
+        container?.addEventListener('mouseleave', scrollBack)
+        return () => {
+            container?.removeEventListener('mouseleave', scrollBack)
+        }
+    }, [containerReference, scrollBack])
+}

--- a/client/wildcard/src/components/Tabs/useShouldPanelRender.ts
+++ b/client/wildcard/src/components/Tabs/useShouldPanelRender.ts
@@ -2,12 +2,14 @@ import { useEffect, useRef, useState } from 'react'
 
 import { useTabsContext as useReachTabsContext } from '@reach/tabs'
 
-import { useTablePanelIndex, useTabsSettings } from './context'
+import { useTablePanelIndex, useTabsState } from './context'
 
 export function useShouldPanelRender(children: React.ReactNode): boolean {
     const { selectedIndex } = useReachTabsContext()
     const index = useTablePanelIndex()
-    const { lazy, behavior } = useTabsSettings()
+    const {
+        settings: { lazy, behavior },
+    } = useTabsState()
     const [wasRendered, setWasRendered] = useState(selectedIndex === index)
     const previousChildren = useRef(children)
 

--- a/client/wildcard/src/hooks/useElementObscuredArea.ts
+++ b/client/wildcard/src/hooks/useElementObscuredArea.ts
@@ -15,7 +15,10 @@ const SCROLL_THROTTLE_WAIT = 50
 export function useElementObscuredArea<T extends HTMLElement>(
     elementReference: React.MutableRefObject<T | null>
 ): ElementObscuredArea {
-    const [obscured, setObscured] = React.useState<ElementObscuredArea>({ left: 0, right: 0 })
+    const [obscured, setObscured] = React.useState<ElementObscuredArea>({
+        left: 0,
+        right: 0,
+    })
 
     const calculate = React.useMemo(
         () =>
@@ -37,15 +40,12 @@ export function useElementObscuredArea<T extends HTMLElement>(
 
     React.useEffect(() => {
         const element = elementReference?.current
-
         if (element) {
             calculate()
             element.addEventListener('scroll', calculate, { passive: true })
         }
         return () => {
-            if (element) {
-                element.removeEventListener('scroll', calculate)
-            }
+            element?.removeEventListener('scroll', calculate)
         }
     }, [elementReference, calculate])
 


### PR DESCRIPTION
The [previous PR](https://github.com/sourcegraph/sourcegraph/pull/35860) added fades on the right and left when scrolling Tabs, but we realized that active tab may be hidden by scroll. So it's being scrolled back now after `mouseleave`.

Also this PR fixes two small things - an unneeded CSS property and a bug with passing references to `TabList`.

https://user-images.githubusercontent.com/2196347/170273981-495b0e6f-7615-42d0-9b24-f4bdfec05162.mov



## Test plan
1. Pull the branch
2. Run `yarn storybook:wildcard`
3. Make sure tabs are being scrolled back without any weirdness
4. Additionally, you may check that passed to `TabList` refs work as expected

## App preview:

- [Web](https://sg-web-og-tabs-scroll-back.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-ihggtqvnay.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
