### PR TITLE
Fix 404 URLs on k8s install/deploy docs index

### DIFF
--- a/doc/admin/deploy/kubernetes/index.md
+++ b/doc/admin/deploy/kubernetes/index.md
@@ -101,7 +101,7 @@ table.
 |[AWS EC2](https://kubernetes.io/docs/getting-started-guides/aws/)|m5.4xlarge|  100 GB (SSD preferred) |
 |[Google Kubernetes Engine (GKE)](https://cloud.google.com/kubernetes-engine/docs/quickstart)|n1-standard-16|100 GB (default)|
 |[Azure](azure.md)|D16 v3|100 GB (SSD preferred)|
-|[Other](https://kubernetes.io/docs/setup/pick-right-solution/)|16 vCPU, 60 GiB memory per node|100 GB (SSD preferred)|
+|[Other]([https://kubernetes.io/docs/setup/pick-right-solution/](https://kubernetes.io/docs/setup/production-environment/turnkey-solutions/))|16 vCPU, 60 GiB memory per node|100 GB (SSD preferred)|
 
 <span class="virtual-br"></span>
 

--- a/doc/admin/deploy/kubernetes/index.md
+++ b/doc/admin/deploy/kubernetes/index.md
@@ -101,7 +101,7 @@ table.
 |[AWS EC2](https://kubernetes.io/docs/getting-started-guides/aws/)|m5.4xlarge|  100 GB (SSD preferred) |
 |[Google Kubernetes Engine (GKE)](https://cloud.google.com/kubernetes-engine/docs/quickstart)|n1-standard-16|100 GB (default)|
 |[Azure](azure.md)|D16 v3|100 GB (SSD preferred)|
-|[Other]([https://kubernetes.io/docs/setup/pick-right-solution/](https://kubernetes.io/docs/setup/production-environment/turnkey-solutions/))|16 vCPU, 60 GiB memory per node|100 GB (SSD preferred)|
+|[Other](https://kubernetes.io/docs/setup/production-environment/turnkey-solutions/)|16 vCPU, 60 GiB memory per node|100 GB (SSD preferred)|
 
 <span class="virtual-br"></span>
 

--- a/doc/admin/deploy/kubernetes/index.md
+++ b/doc/admin/deploy/kubernetes/index.md
@@ -38,7 +38,7 @@ Before starting, we recommend reading the [configuration guide](configure.md#get
 - [Customization](./configure.md#customizations)
 - [Storage class](./configure.md#configure-a-storage-class)
 - [Network Access](./configure.md#configure-network-access)
-- [PostgreSQL Database](./configure.md#sourcegraph-databases)
+- [PostgreSQL Database](./configure.md#configure-external-databases)
 - [Scaling services](./scale.md#tuning-replica-counts-for-horizontal-scalability)
 - [Cluster role administrator access](https://kubernetes.io/docs/reference/access-authn-authz/rbac/)
 


### PR DESCRIPTION
Simple PR to change the `Other` link for k8s setup/deploy from a 404'd link to the updated link from the official k8s documentation.

Additionally updates the link for external DBs to point to the proper markdown header as the previous header was renamed.

## Test plan
just a doc change