### PR TITLE
Search backend: send multiline matches for structural search

### DIFF
--- a/cmd/searcher/internal/search/search_structural.go
+++ b/cmd/searcher/internal/search/search_structural.go
@@ -22,68 +22,30 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
 )
 
-// The Sourcegraph frontend and interface only allow LineMatches (matches on a
-// single line) and it isn't possible to specify a line and column range
-// spanning multiple lines for highlighting. This function chops up potentially
-// multiline matches into multiple LineMatches.
-func highlightMultipleLines(r *comby.Match) (matches []protocol.LineMatch) {
-	lineSpan := r.Range.End.Line - r.Range.Start.Line + 1
-	if lineSpan == 1 {
-		return []protocol.LineMatch{
-			{
-				LineNumber: r.Range.Start.Line - 1,
-				OffsetAndLengths: [][2]int{
-					{
-						r.Range.Start.Column - 1,
-						r.Range.End.Column - r.Range.Start.Column,
-					},
-				},
-				Preview: r.Matched,
+func toFileMatch(combyMatch *comby.FileMatch) protocol.FileMatch {
+	multilineMatches := make([]protocol.MultilineMatch, 0, len(combyMatch.Matches))
+	for _, r := range combyMatch.Matches {
+		multilineMatches = append(multilineMatches, protocol.MultilineMatch{
+			// NOTE: this is not strictly correct since the return value of a comby
+			// match does not extend to the previous line start and next line end.
+			// If possible, we should look at using the file content to extend the match.
+			Preview: r.Matched,
+			Start: protocol.LineColumn{
+				// Comby returns 1-based line numbers and columns
+				Line:   int32(r.Range.Start.Line) - 1,
+				Column: int32(r.Range.Start.Column) - 1,
 			},
-		}
-	}
-
-	contentLines := strings.Split(r.Matched, "\n")
-	for i, line := range contentLines {
-		var columnStart, columnEnd int
-		if i == 0 {
-			// First line.
-			columnStart = r.Range.Start.Column - 1
-			columnEnd = len(line)
-		} else if i == (lineSpan - 1) {
-			// Last line.
-			columnStart = 0
-			columnEnd = r.Range.End.Column - 1 // don't include trailing newline
-		} else {
-			// In between line.
-			columnStart = 0
-			columnEnd = len(line)
-		}
-
-		matches = append(matches, protocol.LineMatch{
-			LineNumber: r.Range.Start.Line + i - 1,
-			OffsetAndLengths: [][2]int{
-				{
-					columnStart,
-					columnEnd,
-				},
+			End: protocol.LineColumn{
+				Line:   int32(r.Range.End.Line) - 1,
+				Column: int32(r.Range.End.Column) - 1,
 			},
-			Preview: line,
 		})
 	}
-	return matches
-}
-
-func toFileMatch(combyMatch *comby.FileMatch) protocol.FileMatch {
-	var lineMatches []protocol.LineMatch
-	for _, r := range combyMatch.Matches {
-		lineMatches = append(lineMatches, highlightMultipleLines(&r)...)
-	}
 	return protocol.FileMatch{
-		Path:        combyMatch.URI,
-		LineMatches: lineMatches,
-		MatchCount:  len(combyMatch.Matches),
-		LimitHit:    false,
+		Path:             combyMatch.URI,
+		MultilineMatches: multilineMatches,
+		MatchCount:       len(multilineMatches),
+		LimitHit:         false,
 	}
 }
 

--- a/cmd/searcher/internal/search/search_structural.go
+++ b/cmd/searcher/internal/search/search_structural.go
@@ -26,7 +26,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
-func toFileMatch(zipReader zip.Reader, combyMatch *comby.FileMatch) (protocol.FileMatch, error) {
+func toFileMatch(zipReader *zip.Reader, combyMatch *comby.FileMatch) (protocol.FileMatch, error) {
 	file, err := zipReader.Open(combyMatch.URI)
 	if err != nil {
 		return protocol.FileMatch{}, err
@@ -281,7 +281,7 @@ func structuralSearch(ctx context.Context, zipPath string, paths filePatterns, e
 		if ctx.Err() != nil {
 			return nil
 		}
-		fm, err := toFileMatch(zipReader.Reader, combyMatch)
+		fm, err := toFileMatch(&zipReader.Reader, combyMatch)
 		if err != nil {
 			return err
 		}

--- a/cmd/searcher/internal/search/search_structural.go
+++ b/cmd/searcher/internal/search/search_structural.go
@@ -41,7 +41,7 @@ func toFileMatch(zipReader *zip.Reader, combyMatch *comby.FileMatch) (protocol.F
 	multilineMatches := make([]protocol.MultilineMatch, 0, len(combyMatch.Matches))
 	for _, r := range combyMatch.Matches {
 		// trust, but verify
-		if r.Range.Start.Offset != r.Range.End.Offset && r.Range.Start.Offset >= len(fileBuf) || r.Range.End.Offset > len(fileBuf) {
+		if r.Range.Start.Offset > len(fileBuf) || r.Range.End.Offset > len(fileBuf) {
 			return protocol.FileMatch{}, errors.New("comby match range does not fit in file")
 		}
 

--- a/cmd/searcher/internal/search/search_structural.go
+++ b/cmd/searcher/internal/search/search_structural.go
@@ -246,7 +246,7 @@ func structuralSearch(ctx context.Context, zipPath string, paths filePatterns, e
 	}()
 
 	// Cap the number of forked processes to limit the size of zip contents being mapped to memory. Resolving #7133 could help to lift this restriction.
-	numWorkers := 4
+	numWorkers := 0
 
 	matcher := toMatcher(languages, extensionHint)
 

--- a/cmd/searcher/internal/search/search_structural.go
+++ b/cmd/searcher/internal/search/search_structural.go
@@ -246,7 +246,7 @@ func structuralSearch(ctx context.Context, zipPath string, paths filePatterns, e
 	}()
 
 	// Cap the number of forked processes to limit the size of zip contents being mapped to memory. Resolving #7133 could help to lift this restriction.
-	numWorkers := 0
+	numWorkers := 4
 
 	matcher := toMatcher(languages, extensionHint)
 

--- a/cmd/searcher/internal/search/search_structural.go
+++ b/cmd/searcher/internal/search/search_structural.go
@@ -56,9 +56,9 @@ func toFileMatch(zipReader zip.Reader, combyMatch *comby.FileMatch) (protocol.Fi
 		}
 
 		multilineMatches = append(multilineMatches, protocol.MultilineMatch{
-			// NOTE: this is not strictly correct since the return value of a comby
-			// match does not extend to the previous line start and next line end.
-			// If possible, we should look at using the file content to extend the match.
+			// We don't use Comby's return value because it does not contain the full
+			// line contents. Instead, we use the ranges from comby to pull all the
+			// overlapped lines from the file contents.
 			Preview: string(fileBuf[firstLineStart:lastLineEnd]),
 			Start: protocol.LineColumn{
 				// Comby returns 1-based line numbers and columns

--- a/cmd/searcher/internal/search/search_structural.go
+++ b/cmd/searcher/internal/search/search_structural.go
@@ -41,7 +41,7 @@ func toFileMatch(zipReader zip.Reader, combyMatch *comby.FileMatch) (protocol.Fi
 	multilineMatches := make([]protocol.MultilineMatch, 0, len(combyMatch.Matches))
 	for _, r := range combyMatch.Matches {
 		// trust, but verify
-		if r.Range.Start.Offset >= len(fileBuf) || r.Range.End.Offset > len(fileBuf) {
+		if r.Range.Start.Offset != r.Range.End.Offset && r.Range.Start.Offset >= len(fileBuf) || r.Range.End.Offset > len(fileBuf) {
 			return protocol.FileMatch{}, errors.New("comby match range does not fit in file")
 		}
 

--- a/cmd/searcher/internal/search/search_structural_test.go
+++ b/cmd/searcher/internal/search/search_structural_test.go
@@ -99,15 +99,15 @@ func TestMatcherLookupByExtension(t *testing.T) {
 
 	input := map[string]string{
 		"file_without_extension": `
-/* comment foo(plain.empty) {} */
+/* This foo(plain.empty) {} is in a Go comment should not match in Go, but should match in plaintext */
 func foo(go.empty) {}
 `,
 		"file.go": `
-/* comment containing foo(plain.go) {} */
+/* This foo(plain.go) {} is in a Go comment should not match in Go, but should match in plaintext */
 func foo(go.go) {}
 `,
 		"file.txt": `
-/* comment containing foo(plain.txt) {} */
+/* This foo(plain.txt) {} is in a Go comment should not match in Go, but should match in plaintext */
 func foo(go.txt) {}
 `,
 	}
@@ -149,9 +149,9 @@ func foo(go.txt) {}
 	}{{
 		name: "No language and no file extension => .generic matcher",
 		want: []string{
-			"/* comment containing foo(plain.go) {} */",
-			"/* comment containing foo(plain.txt) {} */",
-			"/* comment foo(plain.empty) {} */",
+			"/* This foo(plain.empty) {} is in a Go comment should not match in Go, but should match in plaintext */",
+			"/* This foo(plain.go) {} is in a Go comment should not match in Go, but should match in plaintext */",
+			"/* This foo(plain.txt) {} is in a Go comment should not match in Go, but should match in plaintext */",
 			"func foo(go.empty) {}",
 			"func foo(go.go) {}",
 			"func foo(go.txt) {}",

--- a/cmd/searcher/internal/search/search_structural_test.go
+++ b/cmd/searcher/internal/search/search_structural_test.go
@@ -2,7 +2,6 @@ package search
 
 import (
 	"context"
-	"encoding/json"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -14,7 +13,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/sourcegraph/sourcegraph/cmd/searcher/protocol"
-	"github.com/sourcegraph/sourcegraph/internal/comby"
 	"github.com/sourcegraph/sourcegraph/internal/search"
 )
 
@@ -444,101 +442,6 @@ func bar() {
 	t.Run("exact limit", test(4, 4, &protocol.PatternInfo{Pattern: "{:[body]}"}))
 	t.Run("limited", test(2, 2, &protocol.PatternInfo{Pattern: "{:[body]}"}))
 	t.Run("many", test(12, 8, &protocol.PatternInfo{Pattern: "(:[_])"}))
-}
-
-func TestHighlightMultipleLines(t *testing.T) {
-	cases := []struct {
-		Name  string
-		Match *comby.Match
-		Want  []protocol.LineMatch
-	}{
-		{
-			Name: "Single line",
-			Match: &comby.Match{
-				Range: comby.Range{
-					Start: comby.Location{
-						Line:   1,
-						Column: 1,
-					},
-					End: comby.Location{
-						Line:   1,
-						Column: 2,
-					},
-				},
-				Matched: "this is a single line match",
-			},
-			Want: []protocol.LineMatch{
-				{
-					LineNumber: 0,
-					OffsetAndLengths: [][2]int{
-						{
-							0,
-							1,
-						},
-					},
-					Preview: "this is a single line match",
-				},
-			},
-		},
-		{
-			Name: "Three lines",
-			Match: &comby.Match{
-				Range: comby.Range{
-					Start: comby.Location{
-						Line:   1,
-						Column: 1,
-					},
-					End: comby.Location{
-						Line:   3,
-						Column: 5,
-					},
-				},
-				Matched: "this is a match across\nthree\nlines",
-			},
-			Want: []protocol.LineMatch{
-				{
-					LineNumber: 0,
-					OffsetAndLengths: [][2]int{
-						{
-							0,
-							22,
-						},
-					},
-					Preview: "this is a match across",
-				},
-				{
-					LineNumber: 1,
-					OffsetAndLengths: [][2]int{
-						{
-							0,
-							5,
-						},
-					},
-					Preview: "three",
-				},
-				{
-					LineNumber: 2,
-					OffsetAndLengths: [][2]int{
-						{
-							0,
-							4, // don't include trailing newline
-						},
-					},
-					Preview: "lines",
-				},
-			},
-		},
-	}
-	for _, tt := range cases {
-		t.Run(tt.Name, func(t *testing.T) {
-			got := highlightMultipleLines(tt.Match)
-			if !reflect.DeepEqual(got, tt.Want) {
-				jsonGot, _ := json.Marshal(got)
-				jsonWant, _ := json.Marshal(tt.Want)
-				t.Errorf("got: %s, want: %s", jsonGot, jsonWant)
-			}
-		})
-	}
 }
 
 func TestMatchCountForMultilineMatches(t *testing.T) {

--- a/cmd/searcher/internal/search/search_structural_test.go
+++ b/cmd/searcher/internal/search/search_structural_test.go
@@ -344,7 +344,7 @@ func TestRule(t *testing.T) {
 	}
 
 	input := map[string]string{
-		"file.go": "func foo(success) {}\nfunc bar(fail) {}",
+		"file.go": "func foo(success) {} func bar(fail) {}",
 	}
 
 	zipData, err := createZip(input)
@@ -371,7 +371,7 @@ func TestRule(t *testing.T) {
 		Path:     "file.go",
 		LimitHit: false,
 		MultilineMatches: []protocol.MultilineMatch{{
-			Preview: "func foo(success) {}",
+			Preview: "func foo(success) {} func bar(fail) {}",
 			Start:   protocol.LineColumn{Line: 0, Column: 0},
 			End:     protocol.LineColumn{Line: 0, Column: 17},
 		}},

--- a/cmd/searcher/internal/search/search_test.go
+++ b/cmd/searcher/internal/search/search_test.go
@@ -536,7 +536,7 @@ func fetchTimeoutForCI(t *testing.T) string {
 func toString(m []protocol.FileMatch) string {
 	buf := new(bytes.Buffer)
 	for _, f := range m {
-		if len(f.LineMatches) == 0 {
+		if len(f.LineMatches) == 0 && len(f.MultilineMatches) == 0 {
 			buf.WriteString(f.Path)
 			buf.WriteByte('\n')
 		}
@@ -544,6 +544,14 @@ func toString(m []protocol.FileMatch) string {
 			buf.WriteString(f.Path)
 			buf.WriteByte(':')
 			buf.WriteString(strconv.Itoa(l.LineNumber + 1))
+			buf.WriteByte(':')
+			buf.WriteString(l.Preview)
+			buf.WriteByte('\n')
+		}
+		for _, l := range f.MultilineMatches {
+			buf.WriteString(f.Path)
+			buf.WriteByte(':')
+			buf.WriteString(strconv.Itoa(int(l.Start.Line) + 1))
 			buf.WriteByte(':')
 			buf.WriteString(l.Preview)
 			buf.WriteByte('\n')

--- a/cmd/searcher/protocol/searcher.go
+++ b/cmd/searcher/protocol/searcher.go
@@ -242,3 +242,15 @@ type MultilineMatch struct {
 	Start   LineColumn
 	End     LineColumn
 }
+
+func (m MultilineMatch) MatchedContent() string {
+	runePreview := []rune(m.Preview)
+	lastLineStart := 0
+	for i := len(runePreview) - 1; i >= 0; i-- {
+		if runePreview[i] == rune('\n') {
+			lastLineStart = i + 1
+			break
+		}
+	}
+	return string(runePreview[m.Start.Column : lastLineStart+int(m.End.Column)])
+}


### PR DESCRIPTION
This PR builds on https://github.com/sourcegraph/sourcegraph/pull/35897 (accepts multiline matches in the searcher client) and updates structural search to send multiline matches. 

## Test plan

Manually tested a few searches for both indexed and unindexed structural search and manually checked changed test outputs. 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
