### PR TITLE
Fix TelemetricRedirect targeting wrong URL

### DIFF
--- a/client/web/src/enterprise/codeintel/badge/components/IndexerSummary.tsx
+++ b/client/web/src/enterprise/codeintel/badge/components/IndexerSummary.tsx
@@ -15,7 +15,7 @@ import {
     LSIFUploadState,
     LSIFIndexState,
 } from '../../../../graphql-operations'
-import { TelemetricRedirect } from '../../../../tracking/TelemetricRedirect'
+import { TelemetricLink } from '../../../../tracking/TelemetricLink'
 import {
     useRequestedLanguageSupportQuery as defaultUseRequestedLanguageSupportQuery,
     useRequestLanguageSupportQuery as defaultUseRequestLanguageSupportQuery,
@@ -84,7 +84,7 @@ export const IndexerSummary: React.FunctionComponent<React.PropsWithChildren<Ind
 
                     {summary.uploads.length + summary.indexes.length === 0 ? (
                         summary.indexer?.url ? (
-                            <TelemetricRedirect
+                            <TelemetricLink
                                 to={summary.indexer.url}
                                 label="Set up for this repository"
                                 alwaysShowLabel={true}
@@ -108,7 +108,7 @@ export const IndexerSummary: React.FunctionComponent<React.PropsWithChildren<Ind
                             {failedUploads.length > 0 && (
                                 <p className="mb-1 text-muted">
                                     <AlertIcon size={16} className="text-danger" />{' '}
-                                    <TelemetricRedirect
+                                    <TelemetricLink
                                         to={`/${repoName}/-/code-intelligence/uploads?filters=errored`}
                                         label="Latest upload processing"
                                         alwaysShowLabel={true}
@@ -121,7 +121,7 @@ export const IndexerSummary: React.FunctionComponent<React.PropsWithChildren<Ind
                             {failedIndexes.length > 0 && (
                                 <p className="mb-1 text-muted">
                                     <AlertIcon size={16} className="text-danger" />{' '}
-                                    <TelemetricRedirect
+                                    <TelemetricLink
                                         to={`/${repoName}/-/code-intelligence/indexes?filters=errored`}
                                         label="Latest indexing"
                                         alwaysShowLabel={true}

--- a/client/web/src/tracking/TelemetricLink.tsx
+++ b/client/web/src/tracking/TelemetricLink.tsx
@@ -1,11 +1,9 @@
 import React, { useCallback, useState } from 'react'
 
-import { Redirect } from 'react-router'
-
 import { LoaderButton } from '../components/LoaderButton'
 import { logEventSynchronously } from '../user/settings/backend'
 
-export interface TelemetricRedirectProps {
+export interface TelemetricLinkProps {
     to: string
     label: string
     alwaysShowLabel: boolean
@@ -15,7 +13,7 @@ export interface TelemetricRedirectProps {
 
 const MAXIMUM_TELEMETRY_DELAY = 5000
 
-export const TelemetricRedirect: React.FunctionComponent<React.PropsWithChildren<TelemetricRedirectProps>> = ({
+export const TelemetricLink: React.FunctionComponent<React.PropsWithChildren<TelemetricLinkProps>> = ({
     to,
     label,
     alwaysShowLabel,
@@ -23,7 +21,6 @@ export const TelemetricRedirect: React.FunctionComponent<React.PropsWithChildren
     className,
 }) => {
     const [loading, setLoading] = useState(false)
-    const [redirect, setRedirect] = useState(false)
 
     const onClick = useCallback(() => {
         if (loading) {
@@ -32,26 +29,28 @@ export const TelemetricRedirect: React.FunctionComponent<React.PropsWithChildren
 
         setLoading(true)
 
+        const navigate = (): void => {
+            window.location.href = to
+        }
+
         Promise.race([
             // Begin to log event
             logEventSynchronously(eventName),
-            // If the event takes >5s, then we go ahead with the redirect
+            // If the event takes >5s, then we go ahead with the navigation unconditionally
             new Promise(resolve => setTimeout(resolve, MAXIMUM_TELEMETRY_DELAY)),
         ])
             .then(
-                // Redirect unconditionally
-                () => setRedirect(true),
-                () => setRedirect(true)
+                // Navigate unconditionally
+                () => navigate(),
+                () => navigate()
             )
             .then(
                 () => setLoading(false),
                 () => {}
             )
-    }, [setRedirect, eventName, loading])
+    }, [eventName, loading, to])
 
-    return redirect ? (
-        <Redirect to={to} />
-    ) : (
+    return (
         <LoaderButton
             variant="link"
             label={label}


### PR DESCRIPTION
And not name it "redirect", since we actually want a Link here, history should not be replaced.

## Test plan

Validated the "Set up for this repository" link now works correctly. It showed a 404 before.

## App preview:

- [Web](https://sg-web-es-fix-redirect.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-yzhcyojghk.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
