### PR TITLE
add context and repo filter warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Changed
 
--
+- Code Insights: Added warnings about adding `context:` and `repo:` filters in search query.
 
 ### Fixed
 

--- a/client/web/src/enterprise/insights/pages/insights/creation/capture-group/utils/search-query-validator.test.ts
+++ b/client/web/src/enterprise/insights/pages/insights/creation/capture-group/utils/search-query-validator.test.ts
@@ -6,6 +6,7 @@ const PASSING_VALIDATION = {
     isValidOperator: true,
     isValidPatternType: true,
     isNotRepo: true,
+    isNotContext: true,
     isNotCommitOrDiff: true,
     isNoNewLines: true,
 }

--- a/client/web/src/enterprise/insights/pages/insights/creation/capture-group/utils/search-query-validator.ts
+++ b/client/web/src/enterprise/insights/pages/insights/creation/capture-group/utils/search-query-validator.ts
@@ -6,6 +6,7 @@ export interface Checks {
     isValidOperator: true | false | undefined
     isValidPatternType: true | false | undefined
     isNotRepo: true | false | undefined
+    isNotContext: true | false | undefined
     isNotCommitOrDiff: true | false | undefined
     isNoNewLines: true | false | undefined
 }
@@ -16,6 +17,7 @@ export const searchQueryValidator = (value: string, touched: boolean): Checks =>
             isValidOperator: undefined,
             isValidPatternType: undefined,
             isNotRepo: undefined,
+            isNotContext: undefined,
             isNotCommitOrDiff: undefined,
             isNoNewLines: undefined,
         }
@@ -47,6 +49,10 @@ export const searchQueryValidator = (value: string, touched: boolean): Checks =>
             filter => resolveFilter(filter.field.value)?.type === FilterType.repo && filter.value
         )
 
+        const hasContext = filters.some(
+            filter => resolveFilter(filter.field.value)?.type === FilterType.context && filter.value
+        )
+
         const hasCommit = filters.some(
             filter => resolveFilter(filter.field.value)?.type === FilterType.type && filter.value?.value === 'commit'
         )
@@ -61,6 +67,7 @@ export const searchQueryValidator = (value: string, touched: boolean): Checks =>
             isValidOperator: !hasAnd && !hasOr && !hasNot,
             isValidPatternType: !hasLiteralPattern && !hasStructuralPattern,
             isNotRepo: !hasRepo,
+            isNotContext: !hasContext,
             isNotCommitOrDiff: !hasCommit && !hasDiff,
             isNoNewLines: !hasNewLines,
         }
@@ -70,6 +77,7 @@ export const searchQueryValidator = (value: string, touched: boolean): Checks =>
         isValidOperator: false,
         isValidPatternType: false,
         isNotRepo: false,
+        isNotContext: false,
         isNotCommitOrDiff: false,
         isNoNewLines: false,
     }

--- a/client/web/src/enterprise/insights/pages/insights/creation/search-insight/components/form-series-input/FormSeriesInput.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/search-insight/components/form-series-input/FormSeriesInput.tsx
@@ -7,9 +7,10 @@ import { Button, Card, Input, Typography } from '@sourcegraph/wildcard'
 
 import { getDefaultInputProps } from '../../../../../../components/form/getDefaultInputProps'
 import { useField } from '../../../../../../components/form/hooks/useField'
-import { useForm } from '../../../../../../components/form/hooks/useForm'
+import { useForm, ValidationResult } from '../../../../../../components/form/hooks/useForm'
 import { InsightQueryInput } from '../../../../../../components/form/query-input/InsightQueryInput'
 import { createRequiredValidator } from '../../../../../../components/form/validators'
+import { searchQueryValidator } from '../../../capture-group/utils/search-query-validator'
 import { DEFAULT_DATA_SERIES_COLOR } from '../../constants'
 import { EditableDataSeries } from '../../types'
 import { FormColorInput } from '../form-color-input/FormColorInput'
@@ -17,7 +18,21 @@ import { FormColorInput } from '../form-color-input/FormColorInput'
 import { getQueryPatternTypeFilter } from './get-pattern-type-filter'
 
 const requiredNameField = createRequiredValidator('Name is a required field for data series.')
-const validQuery = createRequiredValidator('Query is a required field for data series.')
+const validQuery = (value: string | undefined, validity: ValidityState | null | undefined): ValidationResult => {
+    const result = createRequiredValidator('Query is a required field for data series.')(value, validity)
+    if (result) {
+        return result
+    }
+    const { isNotContext, isNotRepo } = searchQueryValidator(value || '', true)
+
+    if (!isNotContext) {
+        return 'The `context:` filter is not currently supported.'
+    }
+
+    if (!isNotRepo) {
+        return 'Do not include the `repo:` filter; if needed `repo:` will be added automatically.'
+    }
+}
 
 interface FormSeriesInputProps {
     /** Series index. */

--- a/client/web/src/enterprise/insights/pages/insights/creation/search-insight/components/form-series-input/FormSeriesInput.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/search-insight/components/form-series-input/FormSeriesInput.tsx
@@ -26,7 +26,7 @@ const validQuery = (value: string | undefined, validity: ValidityState | null | 
     const { isNotContext, isNotRepo } = searchQueryValidator(value || '', true)
 
     if (!isNotContext) {
-        return 'The `context:` filter is not currently supported.'
+        return 'The `context:` filter is not supported; instead, run over all repositories and use the `context:` on the filter panel after creation'
     }
 
     if (!isNotRepo) {

--- a/client/web/src/enterprise/insights/pages/insights/creation/search-insight/components/form-series-input/FormSeriesInput.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/search-insight/components/form-series-input/FormSeriesInput.tsx
@@ -30,7 +30,7 @@ const validQuery = (value: string | undefined, validity: ValidityState | null | 
     }
 
     if (!isNotRepo) {
-        return 'Do not include the `repo:` filter; if needed `repo:` will be added automatically.'
+        return 'Do not include a `repo:` filter; add targeted repositories above, or filter repos on the filter panel after creation'
     }
 }
 


### PR DESCRIPTION
Closes: https://github.com/sourcegraph/sourcegraph/issues/26977

https://user-images.githubusercontent.com/1855233/170144906-dbad1384-8038-42e2-aaac-448ad715f5be.mov

## Test plan

- Go to create new insight screen
- Add a context or repo filter
- Should give error for both
- Remove context or repo filter and add plain text
- Error should be removed

## App preview:

- [Web](https://sg-web-insights-warn-incorrect-search.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-cbajntykot.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
