### PR TITLE
Search backend: send multiline matches for unindexed search

### DIFF
--- a/cmd/searcher/internal/search/search_regex.go
+++ b/cmd/searcher/internal/search/search_regex.go
@@ -194,8 +194,8 @@ func (rg *readerGrep) Find(zf *zipFile, f *srcFile, limit int) (matches []protoc
 
 // rangesToMatches converts the output of `regexp.FindAllIndex` to a set of
 // multiline matches given the contents of the matched file.
-// Invariant: `ranges` is consecutive, non-overlapping, and not range is outside
-// the bounds of `buf`
+// Invariant: `ranges` is consecutive, non-overlapping, and none of the ranges
+// extend outside the bounds of `buf`.
 func rangesToMatches(buf []byte, ranges [][]int) []protocol.MultilineMatch {
 	var prev struct {
 		end            int32 // end of the last match range

--- a/cmd/searcher/internal/search/search_regex.go
+++ b/cmd/searcher/internal/search/search_regex.go
@@ -275,7 +275,6 @@ func (rg *readerGrep) FindZip(zf *zipFile, f *srcFile, limit int) (protocol.File
 	return protocol.FileMatch{
 		Path:             f.Name,
 		MultilineMatches: mm,
-		MatchCount:       len(mm),
 		LimitHit:         false,
 	}, err
 }
@@ -333,7 +332,7 @@ func regexSearch(ctx context.Context, rg *readerGrep, zf *zipFile, patternMatche
 				if ctx.Err() != nil {
 					return ctx.Err()
 				}
-				fm := protocol.FileMatch{Path: f.Name, MatchCount: 1}
+				fm := protocol.FileMatch{Path: f.Name}
 				sender.Send(fm)
 			}
 		}

--- a/cmd/searcher/internal/search/search_regex.go
+++ b/cmd/searcher/internal/search/search_regex.go
@@ -215,12 +215,14 @@ func rangesToMatches(buf []byte, ranges [][]int) []protocol.MultilineMatch {
 			firstLineStart = int32(off) + prev.end + 1
 		}
 
-		lastLineStart := prev.lastLineStart
+		lastLineStart := firstLineStart
 		if off := bytes.LastIndexByte(buf[:end], '\n'); off >= 0 {
 			lastLineStart = int32(off) + 1
 		}
 
-		lastLineEnd := int32(len(buf)) // pessimistically end the line at the end of the file
+		// pessimistically end the line at the end of the file
+		// in case there is no trailing newline
+		lastLineEnd := int32(len(buf))
 		if off := bytes.IndexByte(buf[end:], '\n'); off >= 0 {
 			lastLineEnd = int32(off) + end
 		}

--- a/cmd/searcher/internal/search/search_regex.go
+++ b/cmd/searcher/internal/search/search_regex.go
@@ -325,7 +325,7 @@ func regexSearch(ctx context.Context, rg *readerGrep, zf *zipFile, patternMatche
 	g, ctx := errgroup.WithContext(ctx)
 
 	// Start workers. They read from files and write to matches.
-	for i := 0; i < 1; i++ {
+	for i := 0; i < numWorkers; i++ {
 		rg := rg.Copy()
 		g.Go(func() error {
 			for ctx.Err() == nil {

--- a/cmd/searcher/internal/search/search_regex_test.go
+++ b/cmd/searcher/internal/search/search_regex_test.go
@@ -333,7 +333,7 @@ func TestMaxMatches(t *testing.T) {
 
 	totalMatches := 0
 	for _, match := range fileMatches {
-		totalMatches += match.MatchCount
+		totalMatches += match.MatchCount()
 	}
 
 	if totalMatches != maxMatches {
@@ -444,12 +444,7 @@ func TestRegexSearch(t *testing.T) {
 				patternMatchesContent: true,
 				limit:                 5,
 			},
-			wantFm: []protocol.FileMatch{
-				{
-					Path:       "a.go",
-					MatchCount: 1,
-				},
-			},
+			wantFm: []protocol.FileMatch{{Path: "a.go"}},
 		},
 	}
 	for _, tt := range tests {

--- a/cmd/searcher/internal/search/search_structural.go
+++ b/cmd/searcher/internal/search/search_structural.go
@@ -74,7 +74,6 @@ func toFileMatch(zipReader *zip.Reader, combyMatch *comby.FileMatch) (protocol.F
 	return protocol.FileMatch{
 		Path:             combyMatch.URI,
 		MultilineMatches: multilineMatches,
-		MatchCount:       len(multilineMatches),
 		LimitHit:         false,
 	}, nil
 }

--- a/cmd/searcher/internal/search/search_structural_test.go
+++ b/cmd/searcher/internal/search/search_structural_test.go
@@ -375,7 +375,6 @@ func TestRule(t *testing.T) {
 			Start:   protocol.LineColumn{Line: 0, Column: 0},
 			End:     protocol.LineColumn{Line: 0, Column: 17},
 		}},
-		MatchCount: 1,
 	}}
 
 	if !reflect.DeepEqual(got, want) {
@@ -418,7 +417,7 @@ func bar() {
 	count := func(matches []protocol.FileMatch) int {
 		c := 0
 		for _, match := range matches {
-			c += match.MatchCount
+			c += match.MatchCount()
 		}
 		return c
 	}
@@ -478,7 +477,7 @@ func bar() {
 		matches := sender.collected
 		var gotMatchCount int
 		for _, fileMatches := range matches {
-			gotMatchCount += fileMatches.MatchCount
+			gotMatchCount += fileMatches.MatchCount()
 		}
 		if gotMatchCount != wantMatchCount {
 			t.Fatalf("got match count %d, want %d", gotMatchCount, wantMatchCount)
@@ -521,8 +520,7 @@ func bar() {
 		}
 		matches := sender.collected
 		expected := []protocol.FileMatch{{
-			Path:       "main.go",
-			MatchCount: 2,
+			Path: "main.go",
 			MultilineMatches: []protocol.MultilineMatch{{
 				Preview: "func foo() {\n    fmt.Println(\"foo\")\n}",
 				Start:   protocol.LineColumn{Line: 1, Column: 11},

--- a/cmd/searcher/internal/search/search_test.go
+++ b/cmd/searcher/internal/search/search_test.go
@@ -536,16 +536,8 @@ func fetchTimeoutForCI(t *testing.T) string {
 func toString(m []protocol.FileMatch) string {
 	buf := new(bytes.Buffer)
 	for _, f := range m {
-		if len(f.LineMatches) == 0 && len(f.MultilineMatches) == 0 {
+		if len(f.MultilineMatches) == 0 {
 			buf.WriteString(f.Path)
-			buf.WriteByte('\n')
-		}
-		for _, l := range f.LineMatches {
-			buf.WriteString(f.Path)
-			buf.WriteByte(':')
-			buf.WriteString(strconv.Itoa(l.LineNumber + 1))
-			buf.WriteByte(':')
-			buf.WriteString(l.Preview)
 			buf.WriteByte('\n')
 		}
 		for _, l := range f.MultilineMatches {
@@ -569,14 +561,9 @@ func sanityCheckSorted(m []protocol.FileMatch) error {
 		if i > 0 && m[i].Path == m[i-1].Path {
 			return errors.Errorf("duplicate FileMatch on %s", m[i].Path)
 		}
-		lm := m[i].LineMatches
+		lm := m[i].MultilineMatches
 		if !sort.IsSorted(sortByLineNumber(lm)) {
 			return errors.Errorf("unsorted LineMatches for %s", m[i].Path)
-		}
-		for j := range lm {
-			if j > 0 && lm[j].LineNumber == lm[j-1].LineNumber {
-				return errors.Errorf("duplicate LineNumber on %s:%d", m[i].Path, lm[j].LineNumber)
-			}
 		}
 	}
 	return nil
@@ -588,8 +575,8 @@ func (m sortByPath) Len() int           { return len(m) }
 func (m sortByPath) Less(i, j int) bool { return m[i].Path < m[j].Path }
 func (m sortByPath) Swap(i, j int)      { m[i], m[j] = m[j], m[i] }
 
-type sortByLineNumber []protocol.LineMatch
+type sortByLineNumber []protocol.MultilineMatch
 
 func (m sortByLineNumber) Len() int           { return len(m) }
-func (m sortByLineNumber) Less(i, j int) bool { return m[i].LineNumber < m[j].LineNumber }
+func (m sortByLineNumber) Less(i, j int) bool { return m[i].Start.Line < m[j].Start.Line }
 func (m sortByLineNumber) Swap(i, j int)      { m[i], m[j] = m[j], m[i] }

--- a/cmd/searcher/internal/search/search_test.go
+++ b/cmd/searcher/internal/search/search_test.go
@@ -64,77 +64,100 @@ func main() {
 		{protocol.PatternInfo{Pattern: "foo"}, ""},
 
 		{protocol.PatternInfo{Pattern: "World", IsCaseSensitive: true}, `
-README.md:1:# Hello World
+README.md:1:1
+# Hello World
 `},
 
 		{protocol.PatternInfo{Pattern: "world", IsCaseSensitive: true}, `
-README.md:3:Hello world example in go
-main.go:6:	fmt.Println("Hello world")
+README.md:3:3
+Hello world example in go
+main.go:6:6
+	fmt.Println("Hello world")
 `},
 
 		{protocol.PatternInfo{Pattern: "world"}, `
-README.md:1:# Hello World
-README.md:3:Hello world example in go
-main.go:6:	fmt.Println("Hello world")
+README.md:1:1
+# Hello World
+README.md:3:3
+Hello world example in go
+main.go:6:6
+	fmt.Println("Hello world")
 `},
 
 		{protocol.PatternInfo{Pattern: "func.*main"}, ""},
 
 		{protocol.PatternInfo{Pattern: "func.*main", IsRegExp: true}, `
-main.go:5:func main() {
+main.go:5:5
+func main() {
 `},
 
 		// https://github.com/sourcegraph/sourcegraph/issues/8155
 		{protocol.PatternInfo{Pattern: "^func", IsRegExp: true}, `
-main.go:5:func main() {
+main.go:5:5
+func main() {
 `},
 		{protocol.PatternInfo{Pattern: "^FuNc", IsRegExp: true}, `
-main.go:5:func main() {
+main.go:5:5
+func main() {
 `},
 
 		{protocol.PatternInfo{Pattern: "mai", IsWordMatch: true}, ""},
 
 		{protocol.PatternInfo{Pattern: "main", IsWordMatch: true}, `
-main.go:1:package main
-main.go:5:func main() {
+main.go:1:1
+package main
+main.go:5:5
+func main() {
 `},
 
 		// Ensure we handle CaseInsensitive regexp searches with
 		// special uppercase chars in pattern.
 		{protocol.PatternInfo{Pattern: `printL\B`, IsRegExp: true}, `
-main.go:6:	fmt.Println("Hello world")
+main.go:6:6
+	fmt.Println("Hello world")
 `},
 
 		{protocol.PatternInfo{Pattern: "world", ExcludePattern: "README.md"}, `
-main.go:6:	fmt.Println("Hello world")
+main.go:6:6
+	fmt.Println("Hello world")
 `},
 		{protocol.PatternInfo{Pattern: "world", IncludePatterns: []string{"*.md"}}, `
-README.md:1:# Hello World
-README.md:3:Hello world example in go
+README.md:1:1
+# Hello World
+README.md:3:3
+Hello world example in go
 `},
 
 		{protocol.PatternInfo{Pattern: "w", IncludePatterns: []string{"*.{md,txt}", "*.txt"}}, `
-abc.txt:1:w
+abc.txt:1:1
+w
 `},
 
 		{protocol.PatternInfo{Pattern: "world", ExcludePattern: "README\\.md", PathPatternsAreRegExps: true}, `
-main.go:6:	fmt.Println("Hello world")
+main.go:6:6
+	fmt.Println("Hello world")
 `},
 		{protocol.PatternInfo{Pattern: "world", IncludePatterns: []string{"\\.md"}, PathPatternsAreRegExps: true}, `
-README.md:1:# Hello World
-README.md:3:Hello world example in go
+README.md:1:1
+# Hello World
+README.md:3:3
+Hello world example in go
 `},
 
 		{protocol.PatternInfo{Pattern: "w", IncludePatterns: []string{"\\.(md|txt)", "README"}, PathPatternsAreRegExps: true}, `
-README.md:1:# Hello World
-README.md:3:Hello world example in go
+README.md:1:1
+# Hello World
+README.md:3:3
+Hello world example in go
 `},
 
 		{protocol.PatternInfo{Pattern: "world", IncludePatterns: []string{"*.{MD,go}"}, PathPatternsAreCaseSensitive: true}, `
-main.go:6:	fmt.Println("Hello world")
+main.go:6:6
+	fmt.Println("Hello world")
 `},
 		{protocol.PatternInfo{Pattern: "world", IncludePatterns: []string{`\.(MD|go)`}, PathPatternsAreRegExps: true, PathPatternsAreCaseSensitive: true}, `
-main.go:6:	fmt.Println("Hello world")
+main.go:6:6
+	fmt.Println("Hello world")
 `},
 
 		{protocol.PatternInfo{Pattern: "doesnotmatch"}, ""},
@@ -142,62 +165,97 @@ main.go:6:	fmt.Println("Hello world")
 milton.png
 `},
 		{protocol.PatternInfo{Pattern: "package main\n\nimport \"fmt\"", IsCaseSensitive: false, IsRegExp: true, PathPatternsAreRegExps: true, PatternMatchesPath: true, PatternMatchesContent: true}, `
-main.go:1:package main
-main.go:2:
-main.go:3:import "fmt"
+main.go:1:3
+package main
+
+import "fmt"
 `},
 		{protocol.PatternInfo{Pattern: "package main\n\\s*import \"fmt\"", IsCaseSensitive: false, IsRegExp: true, PathPatternsAreRegExps: true, PatternMatchesPath: true, PatternMatchesContent: true}, `
-main.go:1:package main
-main.go:2:
-main.go:3:import "fmt"
+main.go:1:3
+package main
+
+import "fmt"
 `},
 		{protocol.PatternInfo{Pattern: "package main\n", IsCaseSensitive: false, IsRegExp: true, PathPatternsAreRegExps: true, PatternMatchesPath: true, PatternMatchesContent: true}, `
-main.go:1:package main
+main.go:1:2
+package main
+
 `},
 		{protocol.PatternInfo{Pattern: "package main\n\\s*", IsCaseSensitive: false, IsRegExp: true, PathPatternsAreRegExps: true, PatternMatchesPath: true, PatternMatchesContent: true}, `
-main.go:1:package main
-main.go:2:
-`},
-		{protocol.PatternInfo{Pattern: "package main\n\\s*", IsCaseSensitive: false, IsRegExp: true, PathPatternsAreRegExps: true, PatternMatchesPath: true, PatternMatchesContent: true}, `
-main.go:1:package main
-main.go:2:
+main.go:1:3
+package main
+
+import "fmt"
 `},
 		{protocol.PatternInfo{Pattern: "\nfunc", IsCaseSensitive: false, IsRegExp: true, PathPatternsAreRegExps: true, PatternMatchesPath: true, PatternMatchesContent: true}, `
-main.go:4:
-main.go:5:func main() {
+main.go:4:5
+
+func main() {
 `},
 		{protocol.PatternInfo{Pattern: "\n\\s*func", IsCaseSensitive: false, IsRegExp: true, PathPatternsAreRegExps: true, PatternMatchesPath: true, PatternMatchesContent: true}, `
-main.go:3:import "fmt"
-main.go:4:
-main.go:5:func main() {
+main.go:3:5
+import "fmt"
+
+func main() {
 `},
 		{protocol.PatternInfo{Pattern: "package main\n\nimport \"fmt\"\n\nfunc main\\(\\) {", IsCaseSensitive: false, IsRegExp: true, PathPatternsAreRegExps: true, PatternMatchesPath: true, PatternMatchesContent: true}, `
-main.go:1:package main
-main.go:2:
-main.go:3:import "fmt"
-main.go:4:
-main.go:5:func main() {
+main.go:1:5
+package main
+
+import "fmt"
+
+func main() {
 `},
 		{protocol.PatternInfo{Pattern: "\n", IsCaseSensitive: false, IsRegExp: true, PathPatternsAreRegExps: true, PatternMatchesPath: true, PatternMatchesContent: true}, `
-README.md:1:# Hello World
-README.md:2:
-main.go:1:package main
-main.go:2:
-main.go:3:import "fmt"
-main.go:4:
-main.go:5:func main() {
-main.go:6:	fmt.Println("Hello world")
-main.go:7:}
+README.md:1:2
+# Hello World
+
+README.md:2:3
+
+Hello world example in go
+main.go:1:2
+package main
+
+main.go:2:3
+
+import "fmt"
+main.go:3:4
+import "fmt"
+
+main.go:4:5
+
+func main() {
+main.go:5:6
+func main() {
+	fmt.Println("Hello world")
+main.go:6:7
+	fmt.Println("Hello world")
+}
+main.go:7:8
+}
+
 `},
 
-		{protocol.PatternInfo{Pattern: "^$", IsRegExp: true}, ``},
+		{protocol.PatternInfo{Pattern: "^$", IsRegExp: true}, `
+README.md:2:2
+
+main.go:2:2
+
+main.go:4:4
+
+main.go:8:8
+
+milton.png:1:1
+
+`},
 		{protocol.PatternInfo{
 			Pattern:         "filename contains regex metachars",
 			IncludePatterns: []string{"file++.plus"},
 			IsStructuralPat: true,
 			IsRegExp:        true, // To test for a regression, imply that IsStructuralPat takes precedence.
 		}, `
-file++.plus:1:filename contains regex metachars
+file++.plus:1:1
+filename contains regex metachars
 `},
 
 		{protocol.PatternInfo{Pattern: "World", IsNegated: true}, `
@@ -224,10 +282,12 @@ symlink
 `},
 		{protocol.PatternInfo{Pattern: "abc", PatternMatchesPath: true, PatternMatchesContent: true}, `
 abc.txt
-symlink:1:abc.txt
+symlink:1:1
+abc.txt
 `},
 		{protocol.PatternInfo{Pattern: "abc", PatternMatchesPath: false, PatternMatchesContent: true}, `
-symlink:1:abc.txt
+symlink:1:1
+abc.txt
 `},
 		{protocol.PatternInfo{Pattern: "abc", PatternMatchesPath: true, PatternMatchesContent: false}, `
 abc.txt
@@ -545,6 +605,8 @@ func toString(m []protocol.FileMatch) string {
 			buf.WriteByte(':')
 			buf.WriteString(strconv.Itoa(int(l.Start.Line) + 1))
 			buf.WriteByte(':')
+			buf.WriteString(strconv.Itoa(int(l.End.Line) + 1))
+			buf.WriteByte('\n')
 			buf.WriteString(l.Preview)
 			buf.WriteByte('\n')
 		}

--- a/cmd/searcher/internal/search/sender.go
+++ b/cmd/searcher/internal/search/sender.go
@@ -46,18 +46,12 @@ func (m *limitedStreamCollector) Send(match protocol.FileMatch) {
 	m.cancel()
 
 	// Can't truncate a path match
-	if len(match.LineMatches) == 0 {
+	if len(match.MultilineMatches) == 0 {
 		m.mux.Unlock()
 		return
 	}
 
-	// NOTE: this isn't strictly correct for structural search matches
-	// since a single match can be multiple lines. However, by the time we
-	// convert a structural search to a protocol.FileMatch, we lose the
-	// information required to properly limit. However, multiline matches
-	// are also not limited correctly in the frontend, so doing it correctly
-	// here won't fix that.
-	match.LineMatches = match.LineMatches[:m.remaining]
+	match.MultilineMatches = match.MultilineMatches[:m.remaining]
 	match.LimitHit = true
 	match.MatchCount = m.remaining
 	m.sentCount += m.remaining
@@ -125,18 +119,12 @@ func (m *limitedStream) Send(match protocol.FileMatch) {
 	m.cancel()
 
 	// Can't truncate a path match
-	if len(match.LineMatches) == 0 {
+	if len(match.MultilineMatches) == 0 {
 		m.mux.Unlock()
 		return
 	}
 
-	// NOTE: this isn't strictly correct for structural search matches
-	// since a single match can be multiple lines. However, by the time we
-	// convert a structural search to a protocol.FileMatch, we lose the
-	// information required to properly limit. However, multiline matches
-	// are also not limited correctly in the frontend, so doing it correctly
-	// here won't fix that.
-	match.LineMatches = match.LineMatches[:m.remaining]
+	match.MultilineMatches = match.MultilineMatches[:m.remaining]
 	match.LimitHit = true
 	match.MatchCount = m.remaining
 	m.sentCount += m.remaining

--- a/cmd/searcher/internal/search/sender.go
+++ b/cmd/searcher/internal/search/sender.go
@@ -55,7 +55,9 @@ func (m *limitedStreamCollector) Send(match protocol.FileMatch) {
 	match.LimitHit = true
 	m.sentCount += m.remaining
 	m.remaining = 0
-	m.collected = append(m.collected, match)
+	if len(match.MultilineMatches) > 0 {
+		m.collected = append(m.collected, match)
+	}
 	m.mux.Unlock()
 }
 

--- a/cmd/searcher/internal/search/sender.go
+++ b/cmd/searcher/internal/search/sender.go
@@ -34,10 +34,10 @@ func newLimitedStreamCollector(ctx context.Context, limit int) (context.Context,
 
 func (m *limitedStreamCollector) Send(match protocol.FileMatch) {
 	m.mux.Lock()
-	if match.MatchCount <= m.remaining {
+	if mc := match.MatchCount(); mc <= m.remaining {
 		m.collected = append(m.collected, match)
-		m.remaining -= match.MatchCount
-		m.sentCount += match.MatchCount
+		m.remaining -= mc
+		m.sentCount += mc
 		m.mux.Unlock()
 		return
 	}
@@ -53,7 +53,6 @@ func (m *limitedStreamCollector) Send(match protocol.FileMatch) {
 
 	match.MultilineMatches = match.MultilineMatches[:m.remaining]
 	match.LimitHit = true
-	match.MatchCount = m.remaining
 	m.sentCount += m.remaining
 	m.remaining = 0
 	m.collected = append(m.collected, match)
@@ -107,9 +106,9 @@ func newLimitedStream(ctx context.Context, limit int, cb func(protocol.FileMatch
 
 func (m *limitedStream) Send(match protocol.FileMatch) {
 	m.mux.Lock()
-	if match.MatchCount <= m.remaining {
-		m.remaining -= match.MatchCount
-		m.sentCount += match.MatchCount
+	if mc := match.MatchCount(); mc <= m.remaining {
+		m.remaining -= mc
+		m.sentCount += mc
 		m.cb(match)
 		m.mux.Unlock()
 		return
@@ -126,7 +125,6 @@ func (m *limitedStream) Send(match protocol.FileMatch) {
 
 	match.MultilineMatches = match.MultilineMatches[:m.remaining]
 	match.LimitHit = true
-	match.MatchCount = m.remaining
 	m.sentCount += m.remaining
 	m.remaining = 0
 	m.cb(match)

--- a/cmd/searcher/protocol/searcher.go
+++ b/cmd/searcher/protocol/searcher.go
@@ -54,8 +54,7 @@ type Request struct {
 	Indexed bool
 }
 
-// PatternInfo describes a search request on a repo. Most of the fields
-// are based on PatternInfo used in vscode.
+// PatternInfo describes a search request on a repo
 type PatternInfo struct {
 	// Pattern is the search query. It is a regular expression if IsRegExp
 	// is true, otherwise a fixed string. eg "route variable"
@@ -190,7 +189,6 @@ type Response struct {
 	DeadlineHit bool
 }
 
-// FileMatch is the struct used by vscode to receive search results
 type FileMatch struct {
 	Path string
 
@@ -210,13 +208,11 @@ func (fm FileMatch) MatchCount() int {
 	return 1
 }
 
-// LineMatch is the struct used by vscode to receive search results for a line.
 type LineMatch struct {
 	// Preview is the matched line.
 	Preview string
 
-	// LineNumber is the 0-based line number. Note: Our editors present
-	// 1-based line numbers, but internally vscode uses 0-based.
+	// LineNumber is the 0-based line number.
 	LineNumber int
 
 	// OffsetAndLengths is a slice of 2-tuples (Offset, Length)

--- a/cmd/searcher/protocol/searcher.go
+++ b/cmd/searcher/protocol/searcher.go
@@ -195,7 +195,6 @@ type FileMatch struct {
 	Path string
 
 	MultilineMatches []MultilineMatch
-	LineMatches      []LineMatch
 
 	// MatchCount is the number of matches.  Different from len(LineMatches), as multiple
 	// lines may correspond to one logical match when doing a structural search

--- a/cmd/searcher/protocol/searcher.go
+++ b/cmd/searcher/protocol/searcher.go
@@ -196,14 +196,18 @@ type FileMatch struct {
 
 	MultilineMatches []MultilineMatch
 
-	// MatchCount is the number of matches.  Different from len(LineMatches), as multiple
-	// lines may correspond to one logical match when doing a structural search
-	// TODO remove this because it's not used by any clients and will no longer
-	// be useful once we migrate to use only MultilineMatches
-	MatchCount int
-
 	// LimitHit is true if LineMatches may not include all LineMatches.
 	LimitHit bool
+}
+
+func (fm FileMatch) MatchCount() int {
+	if l := len(fm.MultilineMatches); l > 0 {
+		return l
+	}
+
+	// a FileMatch with no matched ranges is a path match,
+	// so it still counts as a match.
+	return 1
 }
 
 // LineMatch is the struct used by vscode to receive search results for a line.

--- a/internal/search/searcher/search.go
+++ b/internal/search/searcher/search.go
@@ -211,22 +211,7 @@ func newToMatches(repo types.MinimalRepo, commit api.CommitID, rev *string) func
 	return func(searcherMatches []*protocol.FileMatch) []result.Match {
 		matches := make([]result.Match, 0, len(searcherMatches))
 		for _, fm := range searcherMatches {
-			multilineMatches := make([]result.MultilineMatch, 0, len(fm.LineMatches))
-			for _, lm := range fm.LineMatches {
-				for _, ol := range lm.OffsetAndLengths {
-					multilineMatches = append(multilineMatches, result.MultilineMatch{
-						Start: result.LineColumn{
-							Line:   int32(lm.LineNumber),
-							Column: int32(ol[0]),
-						},
-						End: result.LineColumn{
-							Line:   int32(lm.LineNumber),
-							Column: int32(ol[0] + ol[1]),
-						},
-						Preview: lm.Preview,
-					})
-				}
-			}
+			multilineMatches := make([]result.MultilineMatch, 0, len(fm.MultilineMatches))
 			for _, mm := range fm.MultilineMatches {
 				multilineMatches = append(multilineMatches, result.MultilineMatch{
 					Preview: mm.Preview,


### PR DESCRIPTION
This builds on https://github.com/sourcegraph/sourcegraph/pull/35963 to return multiline matches instead of `LineMatch` from searcher for all results, not just structural search results. See inline comments for notes.

Stacked on #35963 

## Test plan

Running backend integration tests, manually tested, and updated all tests, carefully checking correctness. 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
