### PR TITLE
web: remove `eslint-plugin-sourcegraph` references

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -5,7 +5,6 @@
 - **web**: The web application deployed to http://sourcegraph.com/
 - **browser**: The Sourcegraph browser extension adds tooltips to code on different code hosts.
 - **vscode**: The Sourcegraph [VS Code extension](https://marketplace.visualstudio.com/items?itemName=sourcegraph.sourcegraph).
-- **eslint-plugin-sourcegraph**: Not published package with custom ESLint rules for Sourcegraph. Isn't intended for reuse by other repositories in the Sourcegraph org.
 - **extension-api**: The Sourcegraph extension API types for the _Sourcegraph extensions_. Published as `sourcegraph`.
 - **extension-api-types**: The Sourcegraph extension API types for _client applications_ that embed Sourcegraph extensions and need to communicate with them. Published as `@sourcegraph/extension-api-types`.
 - **sandboxes**: All demos-mvp (minimum viable product) for the Sourcegraph web application.

--- a/dev/foreach-ts-project.sh
+++ b/dev/foreach-ts-project.sh
@@ -24,7 +24,6 @@ DIRS=(
   client/wildcard
   client/template-parser
   client/extension-api
-  client/eslint-plugin-sourcegraph
   client/extension-api-types
   client/storybook
   client/client-api

--- a/doc/dev/how-to/cache_ci_artefacts.md
+++ b/doc/dev/how-to/cache_ci_artefacts.md
@@ -8,7 +8,7 @@ This guide documents how to cache build artefacts in order to speed up build tim
 
 Because [Buildkite agents are stateless](../background-information/ci/development.md#buildkite-infrastructure) and start with a blank slate, this means that all dependencies and binaries have to rebuild on each job. This is the price to pay for complete isolation from one job to the other.
 
-A common strategy to address this problem of having to rebuild everything is to store objects that are commonly reused accross jobs and to download them again rather than rebuilding everything from scratch. 
+A common strategy to address this problem of having to rebuild everything is to store objects that are commonly reused accross jobs and to download them again rather than rebuilding everything from scratch.
 
 Cached artefacts *are automatically expired after 30 days* (by an object lifecycle policy on the bucket).
 
@@ -17,16 +17,16 @@ Cached artefacts *are automatically expired after 30 days* (by an object lifecyc
 In order to determine what we can cache and when to do it, we need to make sure to cover the following questions:
 
 1. Will it be faster to download a cached version rather than building it?
-1. Can we come up with an identifier that represents accurately what version of the cache is needed, before building anything? 
-  - Ex: the checksum of `yarn.lock` accurately tells us which version of the dependencies cache needs to be downloaded if it exists. 
-1. Is what is being cached, not the end result of that test? 
-  - If it were the case, it means we would be caching the result of the test, which is defeating the purpose of a continuous integration process. 
+1. Can we come up with an identifier that represents accurately what version of the cache is needed, before building anything?
+  - Ex: the checksum of `yarn.lock` accurately tells us which version of the dependencies cache needs to be downloaded if it exists.
+1. Is what is being cached, not the end result of that test?
+  - If it were the case, it means we would be caching the result of the test, which is defeating the purpose of a continuous integration process.
 
 ## How to write a step that caches an artefact?
 
-In the [CI pipeline generator](../background-information/ci/development.md), when defining a step you can use the `buildkite.Cache()` function to define what needs to be cached and under which key to store it. 
+In the [CI pipeline generator](../background-information/ci/development.md), when defining a step you can use the `buildkite.Cache()` function to define what needs to be cached and under which key to store it.
 
-For example: we want to cache the `node_modules` folder to avoid dowloading again all dependencies for the front-end. 
+For example: we want to cache the `node_modules` folder to avoid dowloading again all dependencies for the front-end.
 
 ```go
 // Browser extension unit tests
@@ -35,25 +35,25 @@ pipeline.AddStep(":jest::chrome: Test browser extension",
 		ID:          "node_modules",
 		Key:         "cache-node_modules-{{ checksum 'yarn.lock' }}",
 		RestoreKeys: []string{"cache-node_modules-{{ checksum 'yarn.lock' }}"},
-		Paths:       []string{"node_modules", "client/extension-api/node_modules", "client/eslint-plugin-sourcegraph/node_modules"},
+		Paths:       []string{"node_modules", "client/extension-api/node_modules"},
 	})
   bk.Cmd("dev/ci/yarn-test.sh client/browser"),
   bk.Cmd("dev/ci/codecov.sh -c -F typescript -F unit"))
 ```
 
-The important part here are: 
+The important part here are:
 
-- The `Key` which defines how the cached version is named, so we can find it again on ulterior builds. 
-  - It includes a `{{ checkusm 'yarn.lock' }}` segment in its name, which means that any changes in the `yarn.lock` will be reflected in the key name. 
-  - It means that if the `yarn.lock` checksum would change because dependencies have changed, it should use a different version of the cached dependencies. If those were to not be present on the cache, it will simply rebuild them and upload the result to the cache. 
+- The `Key` which defines how the cached version is named, so we can find it again on ulterior builds.
+  - It includes a `{{ checkusm 'yarn.lock' }}` segment in its name, which means that any changes in the `yarn.lock` will be reflected in the key name.
+  - It means that if the `yarn.lock` checksum would change because dependencies have changed, it should use a different version of the cached dependencies. If those were to not be present on the cache, it will simply rebuild them and upload the result to the cache.
 - The `RestoreKeys` lists the keys we can use to know if there is a cached version or not available. 99% of the time, that's the same exact thing as the `Key`.
 - The `Paths` lists the path to the files that needs to be cached. They **must be within the repository**, not outside.
 
-Please note that from the perspective of the commands ran in that step, it's not possible to know if the cache was hit or missed. So the code using what has been cached must be able to understand it on its own (example, checking for the presence of folders defined in the `Paths` keys). Most build systems will handle that on their own, but if you were to cache test data you'll probably have to handle that yourself. 
+Please note that from the perspective of the commands ran in that step, it's not possible to know if the cache was hit or missed. So the code using what has been cached must be able to understand it on its own (example, checking for the presence of folders defined in the `Paths` keys). Most build systems will handle that on their own, but if you were to cache test data you'll probably have to handle that yourself.
 
 ## How to make sure that caching is faster?
 
-When a build is finished and successful, you will find an annotation with a link to the trace of that build on HoneyComb. You can compare the timings of your build before and after adding the cache (with a cache hit of course, otherwise you would compare no cache with a cache miss, which will often be longer because there is time spent uploading the cache result). 
+When a build is finished and successful, you will find an annotation with a link to the trace of that build on HoneyComb. You can compare the timings of your build before and after adding the cache (with a cache hit of course, otherwise you would compare no cache with a cache miss, which will often be longer because there is time spent uploading the cache result).
 
 ## How to purge the cache from a given key?
 

--- a/enterprise/dev/ci/internal/ci/cache_helpers.go
+++ b/enterprise/dev/ci/internal/ci/cache_helpers.go
@@ -7,7 +7,7 @@ func withYarnCache() buildkite.StepOpt {
 		ID:          "node_modules",
 		Key:         "cache-node_modules-{{ checksum 'yarn.lock' }}",
 		RestoreKeys: []string{"cache-node_modules-{{ checksum 'yarn.lock' }}"},
-		Paths:       []string{"node_modules", "client/extension-api/node_modules", "client/eslint-plugin-sourcegraph/node_modules"},
+		Paths:       []string{"node_modules", "client/extension-api/node_modules"},
 		// TODO: @jhchabran, check the numbers, but in my last run it seemed to be clear that compression is really slow (+3/4m IIRC)
 		Compress: false,
 	})


### PR DESCRIPTION
## Context

Failed build https://buildkite.com/sourcegraph/sourcegraph/builds/149524 because the plugin [was removed](https://github.com/sourcegraph/sourcegraph/pull/35040) from the codebase but it's still referenced in a couple of places.

## Test plan

`sg lint` should work
