### PR TITLE
Fix chart size tracking when window/viewport resizing is happening

### DIFF
--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/SmartInsight.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/SmartInsight.tsx
@@ -5,7 +5,7 @@ import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryServi
 import { Insight, isBackendInsight } from '../../../core'
 
 import { BackendInsightView } from './backend-insight/BackendInsight'
-import { BuiltInInsight } from './BuiltInInsight'
+import { BuiltInInsight } from './built-in-insight/BuiltInInsight'
 
 export interface SmartInsightProps extends TelemetryProps, React.HTMLAttributes<HTMLElement> {
     insight: Insight

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/backend-insight-chart/BackendInsightChart.module.scss
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/backend-insight-chart/BackendInsightChart.module.scss
@@ -1,4 +1,4 @@
-.chart {
+.root {
     flex: 1;
     min-height: 0;
     position: relative;
@@ -38,9 +38,9 @@
 }
 
 .chart {
-    position: absolute;
     width: 100%;
     height: 100%;
+    position: absolute;
 }
 
 .legend-list-container {

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/backend-insight-chart/BackendInsightChart.module.scss
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/backend-insight-chart/BackendInsightChart.module.scss
@@ -37,6 +37,12 @@
     }
 }
 
+.chart {
+    position: absolute;
+    width: 100%;
+    height: 100%;
+}
+
 .legend-list-container {
     grid-area: legend;
     overflow-x: hidden;

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/backend-insight-chart/BackendInsightChart.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/backend-insight-chart/BackendInsightChart.tsx
@@ -55,7 +55,7 @@ export function BackendInsightChart<Datum>(props: BackendInsightChartProps<Datum
     const isHorizontalMode = hasViewManySeries && hasEnoughXSpace
 
     return (
-        <div ref={ref} className={classNames(className, styles.chart, { [styles.chartHorizontal]: isHorizontalMode })}>
+        <div ref={ref} className={classNames(className, styles.root, { [styles.rootHorizontal]: isHorizontalMode })}>
             {width && (
                 <>
                     <ParentSize

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/backend-insight-chart/BackendInsightChart.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/backend-insight-chart/BackendInsightChart.tsx
@@ -76,6 +76,7 @@ export function BackendInsightChart<Datum>(props: BackendInsightChartProps<Datum
                                     width={parent.width}
                                     height={parent.height}
                                     locked={locked}
+                                    className={styles.chart}
                                     onDatumClick={onDatumClick}
                                     {...content}
                                 />

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/built-in-insight/BuiltInInsight.module.scss
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/built-in-insight/BuiltInInsight.module.scss
@@ -1,4 +1,3 @@
-
 .chart-container {
     position: relative;
     flex: 1;

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/built-in-insight/BuiltInInsight.module.scss
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/built-in-insight/BuiltInInsight.module.scss
@@ -1,0 +1,11 @@
+
+.chart-container {
+    position: relative;
+    flex: 1;
+}
+
+.chart {
+    position: absolute;
+    width: 100%;
+    height: 100%;
+}

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/built-in-insight/BuiltInInsight.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/built-in-insight/BuiltInInsight.tsx
@@ -2,15 +2,15 @@ import React, { Ref, useContext, useMemo, useRef, useState } from 'react'
 
 import { useMergeRefs } from 'use-callback-ref'
 
-import { ErrorAlert } from '@sourcegraph/branded/src/components/alerts'
-import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
-import { useDeepMemo } from '@sourcegraph/wildcard'
+import { ErrorAlert } from '@sourcegraph/branded/out/src/components/alerts'
+import { TelemetryProps } from '@sourcegraph/shared/out/src/telemetry/telemetryService'
+import { useDeepMemo } from '@sourcegraph/wildcard/out/src'
 
-import { ParentSize } from '../../../../../charts'
-import { CodeInsightsBackendContext, LangStatsInsight } from '../../../core'
-import { InsightContentType } from '../../../core/types/insight/common'
-import { LazyQueryStatus } from '../../../hooks/use-parallel-requests/use-parallel-request'
-import { getTrackingTypeByInsightType, useCodeInsightViewPings } from '../../../pings'
+import { ParentSize } from '../../../../../../charts'
+import { CodeInsightsBackendContext, LangStatsInsight } from '../../../../core'
+import { InsightContentType } from '../../../../core/types/insight/common'
+import { LazyQueryStatus } from '../../../../hooks/use-parallel-requests/use-parallel-request'
+import { getTrackingTypeByInsightType, useCodeInsightViewPings } from '../../../../pings'
 import {
     CategoricalBasedChartTypes,
     CategoricalChart,
@@ -21,11 +21,12 @@ import {
     InsightCardLoading,
     SeriesBasedChartTypes,
     SeriesChart,
-} from '../../views'
-import { useInsightData } from '../hooks/use-insight-data'
+} from '../../../views'
+import { useInsightData } from '../../hooks/use-insight-data'
+import { InsightContextMenu } from '../insight-context-menu/InsightContextMenu'
+import { InsightContext } from '../InsightContext'
 
-import { InsightContextMenu } from './insight-context-menu/InsightContextMenu'
-import { InsightContext } from './InsightContext'
+import styles from './BuiltInInsight.module.scss'
 
 interface BuiltInInsightProps extends TelemetryProps, React.HTMLAttributes<HTMLElement> {
     insight: LangStatsInsight
@@ -91,7 +92,7 @@ export function BuiltInInsight(props: BuiltInInsightProps): React.ReactElement {
                 <ErrorAlert error={state.error} />
             ) : (
                 <>
-                    <ParentSize>
+                    <ParentSize className={styles.chartContainer}>
                         {parent =>
                             state.data.type === InsightContentType.Series ? (
                                 <SeriesChart
@@ -100,6 +101,7 @@ export function BuiltInInsight(props: BuiltInInsightProps): React.ReactElement {
                                     height={parent.height}
                                     zeroYAxisMin={zeroYAxisMin}
                                     locked={insight.isFrozen}
+                                    className={styles.chart}
                                     onDatumClick={trackDatumClicks}
                                     {...state.data.content}
                                 />
@@ -109,6 +111,7 @@ export function BuiltInInsight(props: BuiltInInsightProps): React.ReactElement {
                                     width={parent.width}
                                     height={parent.height}
                                     locked={insight.isFrozen}
+                                    className={styles.chart}
                                     onDatumLinkClick={trackDatumClicks}
                                     {...state.data.content}
                                 />

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/built-in-insight/BuiltInInsight.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/built-in-insight/BuiltInInsight.tsx
@@ -2,9 +2,9 @@ import React, { Ref, useContext, useMemo, useRef, useState } from 'react'
 
 import { useMergeRefs } from 'use-callback-ref'
 
-import { ErrorAlert } from '@sourcegraph/branded/out/src/components/alerts'
-import { TelemetryProps } from '@sourcegraph/shared/out/src/telemetry/telemetryService'
-import { useDeepMemo } from '@sourcegraph/wildcard/out/src'
+import { ErrorAlert } from '@sourcegraph/branded/src/components/alerts'
+import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
+import { useDeepMemo } from '@sourcegraph/wildcard'
 
 import { ParentSize } from '../../../../../../charts'
 import { CodeInsightsBackendContext, LangStatsInsight } from '../../../../core'


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/35458

| Before  | After |
| ------------- | ------------- |
| ![](https://user-images.githubusercontent.com/18492575/168560775-1b8ca7fb-3805-4f2f-a243-98c2b5b358df.png)  | <video src="https://user-images.githubusercontent.com/18492575/170205021-395d01d8-d369-47c0-82fb-c5e7946279c1.mov" />  |








## Test plan
- Make sure that charts look good for all screen sizes 
- Make sure that chart block tracks its size correctly when window/viewport width/height is changing 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vk-fix-chart-resizing.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-gfkmhzyfnj.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
