### PR TITLE
Re-enable new ref panel by default in dev mode

### DIFF
--- a/dev/global-settings.json
+++ b/dev/global-settings.json
@@ -6,7 +6,7 @@
     "codeMonitoring": true,
     "codeInsights": true,
     "codeIntelRepositoryBadge": { "enabled": true },
-    "coolCodeIntel": false
+    "coolCodeIntel": true
   },
   "insights": [
     {


### PR DESCRIPTION
I think this was changed by accident in #35333 by @Numbers88s 

## Test plan

- Test it manually
