### PR TITLE
search: include leading paran for REPOPAGER sexp output

### DIFF
--- a/internal/search/job/jobutil/job_test.go
+++ b/internal/search/job/jobutil/job_test.go
@@ -30,11 +30,11 @@ func TestNewPlanJob(t *testing.T) {
     (LIMIT
       500
       (PARALLEL
-        REPOPAGER
+        (REPOPAGER
           ZoektRepoSubsetSearchJob)
         ComputeExcludedReposJob
         (PARALLEL
-          REPOPAGER
+          (REPOPAGER
             SearcherJob)
           RepoSearchJob)))))`),
 	}, {
@@ -76,11 +76,11 @@ func TestNewPlanJob(t *testing.T) {
     (LIMIT
       500
       (PARALLEL
-        REPOPAGER
+        (REPOPAGER
           ZoektRepoSubsetSearchJob)
         ComputeExcludedReposJob
         (PARALLEL
-          REPOPAGER
+          (REPOPAGER
             SearcherJob)
           RepoSearchJob)))))`),
 	}, {
@@ -207,16 +207,16 @@ func TestNewPlanJob(t *testing.T) {
     (LIMIT
       500
       (PARALLEL
-        REPOPAGER
+        (REPOPAGER
           ZoektRepoSubsetSearchJob)
-        REPOPAGER
+        (REPOPAGER
           ZoektSymbolSearchJob)
         CommitSearchJob
         ComputeExcludedReposJob
         (PARALLEL
-          REPOPAGER
+          (REPOPAGER
             SearcherJob)
-          REPOPAGER
+          (REPOPAGER
             SymbolSearcherJob)
           RepoSearchJob)))))`),
 	}, {
@@ -245,16 +245,16 @@ func TestNewPlanJob(t *testing.T) {
     (LIMIT
       500
       (PARALLEL
-        REPOPAGER
+        (REPOPAGER
           ZoektRepoSubsetSearchJob)
-        REPOPAGER
+        (REPOPAGER
           ZoektSymbolSearchJob)
         CommitSearchJob
         ComputeExcludedReposJob
         (PARALLEL
-          REPOPAGER
+          (REPOPAGER
             SearcherJob)
-          REPOPAGER
+          (REPOPAGER
             SymbolSearcherJob)
           RepoSearchJob)))))`),
 	}, {

--- a/internal/search/job/jobutil/printers.go
+++ b/internal/search/job/jobutil/printers.go
@@ -54,7 +54,7 @@ func SexpFormat(j job.Job, sep, indent string) string {
 			b.WriteString(j.Name())
 
 		case *repoPagerJob:
-			b.WriteString("REPOPAGER")
+			b.WriteString("(REPOPAGER")
 			depth++
 			writeSep(b, sep, indent, depth)
 			writeSexp(j.child)


### PR DESCRIPTION
I was printing out job plans and they weren't balancing. Noticed repopager was the problem. Now paranthesis balance :)

Test Plan: manually inspected diff after `go test -update`. Copy paste expression into emacs lisp buffer, emacs is happy.
