### PR TITLE
sg: fix generate command discarding arguments

### DIFF
--- a/dev/sg/sg_generate.go
+++ b/dev/sg/sg_generate.go
@@ -85,7 +85,7 @@ func (gt generateTargets) Commands() (cmds []*cli.Command) {
 			if err != nil {
 				return err
 			}
-			report := c.Runner(cmd.Context, cmd.Args().Tail())
+			report := c.Runner(cmd.Context, cmd.Args().Slice())
 			fmt.Printf(report.Output)
 			std.Out.WriteLine(output.Linef(output.EmojiSuccess, output.StyleSuccess, "(%ds)", report.Duration/time.Second))
 			return nil


### PR DESCRIPTION
The arguments were incorrectly passed with a `.Tail()` method, whereas it should be `.Slice()`.

This re-enables to give specific packages to `sg generate go`. 

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
```
~/work/other US devx/fix-sg-generate-args $ go run ./dev/sg generate go enterprise/dev/ci
✅ go generating 1 packages  
ℹ️ go generate enterprise/dev/ci
ℹ️ goimports -w
ℹ️ go mod tidy
✅ (11s)
```