### PR TITLE
database: remove dbutil-based constructors

### DIFF
--- a/cmd/frontend/graphqlbackend/graphqlbackend.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend.go
@@ -667,7 +667,7 @@ func (r *schemaResolver) PhabricatorRepo(ctx context.Context, args *struct {
 		args.URI = args.Name
 	}
 
-	repo, err := database.Phabricator(r.db).GetByName(ctx, api.RepoName(*args.URI))
+	repo, err := r.db.Phabricator().GetByName(ctx, api.RepoName(*args.URI))
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/graphqlbackend/repository.go
+++ b/cmd/frontend/graphqlbackend/repository.go
@@ -390,7 +390,7 @@ func (r *schemaResolver) AddPhabricatorRepo(ctx context.Context, args *struct {
 		args.URI = args.Name
 	}
 
-	_, err := database.Phabricator(r.db).CreateIfNotExists(ctx, args.Callsign, api.RepoName(*args.URI), args.URL)
+	_, err := r.db.Phabricator().CreateIfNotExists(ctx, args.Callsign, api.RepoName(*args.URI), args.URL)
 	if err != nil {
 		log15.Error("adding phabricator repo", "callsign", args.Callsign, "name", args.URI, "url", args.URL)
 	}
@@ -435,7 +435,7 @@ func (r *schemaResolver) ResolvePhabricatorDiff(ctx context.Context, args *struc
 	}
 
 	origin := ""
-	if phabRepo, err := database.Phabricator(db).GetByName(ctx, api.RepoName(args.RepoName)); err == nil {
+	if phabRepo, err := db.Phabricator().GetByName(ctx, api.RepoName(args.RepoName)); err == nil {
 		origin = phabRepo.URL
 	}
 

--- a/cmd/frontend/graphqlbackend/set_user_public_repos.go
+++ b/cmd/frontend/graphqlbackend/set_user_public_repos.go
@@ -31,7 +31,7 @@ func (r *schemaResolver) SetUserPublicRepos(ctx context.Context, args struct {
 		return nil, errors.Errorf("Too many repository URLs, please specify %v or fewer", maxUserPublicRepos)
 	}
 	var (
-		repoStore = database.Repos(r.db)
+		repoStore = r.db.Repos()
 		uprs      = database.UserPublicRepos(r.db)
 		repos     = make([]database.UserPublicRepo, len(args.RepoURIs))
 		eg        errgroup.Group

--- a/cmd/frontend/internal/app/updatecheck/client.go
+++ b/cmd/frontend/internal/app/updatecheck/client.go
@@ -110,7 +110,7 @@ func getTotalOrgsCount(ctx context.Context, db database.DB) (_ int, err error) {
 // soft-deleted nor blocked.
 func hasRepos(ctx context.Context, db database.DB) (_ bool, err error) {
 	defer recordOperation("hasRepos")(&err)
-	rs, err := database.Repos(db).List(ctx, database.ReposListOptions{
+	rs, err := db.Repos().List(ctx, database.ReposListOptions{
 		LimitOffset: &database.LimitOffset{Limit: 1},
 	})
 	return len(rs) > 0, err

--- a/cmd/frontend/internal/httpapi/httpapi.go
+++ b/cmd/frontend/internal/httpapi/httpapi.go
@@ -141,7 +141,7 @@ func NewInternalHandler(m *mux.Router, db database.DB, schema *graphql.Schema, n
 	indexer := &searchIndexerServer{
 		db:            db,
 		ListIndexable: backend.NewRepos(db).ListIndexable,
-		RepoStore:     database.Repos(db),
+		RepoStore:     db.Repos(),
 		SearchContextsRepoRevs: func(ctx context.Context, repoIDs []api.RepoID) (map[api.RepoID][]string, error) {
 			return searchcontexts.RepoRevs(ctx, db, repoIDs)
 		},

--- a/cmd/frontend/internal/httpapi/internal.go
+++ b/cmd/frontend/internal/httpapi/internal.go
@@ -49,7 +49,7 @@ func servePhabricatorRepoCreate(db database.DB) func(w http.ResponseWriter, r *h
 		if err != nil {
 			return err
 		}
-		phabRepo, err := database.Phabricator(db).CreateOrUpdate(r.Context(), repo.Callsign, repo.RepoName, repo.URL)
+		phabRepo, err := db.Phabricator().CreateOrUpdate(r.Context(), repo.Callsign, repo.RepoName, repo.URL)
 		if err != nil {
 			return err
 		}
@@ -341,7 +341,7 @@ func serveGitExec(db database.DB) func(http.ResponseWriter, *http.Request) error
 		}
 
 		ctx := r.Context()
-		repo, err := database.Repos(db).Get(ctx, api.RepoID(repoID))
+		repo, err := db.Repos().Get(ctx, api.RepoID(repoID))
 		if err != nil {
 			return err
 		}

--- a/cmd/frontend/internal/httpapi/webhookhandlers/handle_repo_authz_event.go
+++ b/cmd/frontend/internal/httpapi/webhookhandlers/handle_repo_authz_event.go
@@ -54,7 +54,7 @@ func scheduleRepoUpdate(ctx context.Context, db database.DB, repo *gh.Repository
 
 	// 🚨 SECURITY: we want to be able to find any private repo here, so set internal actor
 	ctx = actor.WithInternalActor(ctx)
-	r, err := database.Repos(db).GetByName(ctx, api.RepoName("github.com/"+repo.GetFullName()))
+	r, err := db.Repos().GetByName(ctx, api.RepoName("github.com/"+repo.GetFullName()))
 	if err != nil {
 		return err
 	}

--- a/cmd/gitserver/main.go
+++ b/cmd/gitserver/main.go
@@ -115,7 +115,7 @@ func main() {
 	}
 	db := database.NewDB(sqlDB)
 
-	repoStore := database.Repos(db)
+	repoStore := db.Repos()
 	depsSvc := livedependencies.GetService(db, nil)
 	externalServiceStore := db.ExternalServices()
 

--- a/cmd/gitserver/server/cleanup_test.go
+++ b/cmd/gitserver/server/cleanup_test.go
@@ -593,7 +593,7 @@ func TestRemoveRepoDirectory(t *testing.T) {
 		repo := &types.Repo{
 			Name: api.RepoName(r),
 		}
-		if err := database.Repos(db).Create(ctx, repo); err != nil {
+		if err := db.Repos().Create(ctx, repo); err != nil {
 			t.Fatal(err)
 		}
 		if err := db.GitserverRepos().Upsert(ctx, &types.GitserverRepo{

--- a/cmd/gitserver/server/server_test.go
+++ b/cmd/gitserver/server/server_test.go
@@ -535,7 +535,7 @@ func TestCloneRepo(t *testing.T) {
 		Description: "Test",
 	}
 	// Insert the repo into our database
-	if err := database.Repos(db).Create(ctx, dbRepo); err != nil {
+	if err := db.Repos().Create(ctx, dbRepo); err != nil {
 		t.Fatal(err)
 	}
 	assertRepoState := func(status types.CloneStatus, size int64) {
@@ -650,7 +650,7 @@ func testHandleRepoDelete(t *testing.T, deletedInDB bool) {
 	}
 
 	// Insert the repo into our database
-	if err := database.Repos(db).Create(ctx, dbRepo); err != nil {
+	if err := db.Repos().Create(ctx, dbRepo); err != nil {
 		t.Fatal(err)
 	}
 
@@ -704,10 +704,10 @@ func testHandleRepoDelete(t *testing.T, deletedInDB bool) {
 	}
 
 	if deletedInDB {
-		if err := database.Repos(db).Delete(ctx, dbRepo.ID); err != nil {
+		if err := db.Repos().Delete(ctx, dbRepo.ID); err != nil {
 			t.Fatal(err)
 		}
-		repos, err := database.Repos(db).List(ctx, database.ReposListOptions{IncludeDeleted: true, IDs: []api.RepoID{dbRepo.ID}})
+		repos, err := db.Repos().List(ctx, database.ReposListOptions{IncludeDeleted: true, IDs: []api.RepoID{dbRepo.ID}})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -766,7 +766,7 @@ func TestHandleRepoUpdate(t *testing.T) {
 		Description: "Test",
 	}
 	// Insert the repo into our database
-	if err := database.Repos(db).Create(ctx, dbRepo); err != nil {
+	if err := db.Repos().Create(ctx, dbRepo); err != nil {
 		t.Fatal(err)
 	}
 
@@ -885,7 +885,7 @@ func TestHandleRepoUpdateFromShard(t *testing.T) {
 		Description: "Test",
 	}
 	// Insert the repo into our database
-	if err := database.Repos(db).Create(ctx, dbRepo); err != nil {
+	if err := db.Repos().Create(ctx, dbRepo); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1224,7 +1224,7 @@ func TestSyncRepoState(t *testing.T) {
 	}
 
 	// Insert the repo into our database
-	err := database.Repos(db).Create(ctx, dbRepo)
+	err := db.Repos().Create(ctx, dbRepo)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1261,7 +1261,7 @@ func TestSyncRepoState(t *testing.T) {
 		}
 
 		// We should continue to sync deleted repos
-		if err := database.Repos(db).Delete(ctx, dbRepo.ID); err != nil {
+		if err := db.Repos().Delete(ctx, dbRepo.ID); err != nil {
 			t.Fatal(err)
 		}
 

--- a/enterprise/cmd/frontend/internal/batches/resolvers/changeset_counts_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/changeset_counts_test.go
@@ -79,7 +79,7 @@ func TestChangesetCountsOverTimeIntegration(t *testing.T) {
 
 	userID := ct.CreateTestUser(t, db, false).ID
 
-	repoStore := database.Repos(db)
+	repoStore := db.Repos()
 	esStore := db.ExternalServices()
 
 	gitHubToken := os.Getenv("GITHUB_TOKEN")

--- a/enterprise/cmd/frontend/internal/batches/webhooks/bitbucketcloud_test.go
+++ b/enterprise/cmd/frontend/internal/batches/webhooks/bitbucketcloud_test.go
@@ -39,7 +39,7 @@ const (
 	bitbucketCloudDestinationHash    = "abcdefabcdefabcdefabcdefabcdefabcdefabcd"
 )
 
-func testBitbucketCloudWebhook(db *sql.DB, userID int32) func(*testing.T) {
+func testBitbucketCloudWebhook(db *sql.DB) func(*testing.T) {
 	return func(t *testing.T) {
 		ctx := context.Background()
 

--- a/enterprise/cmd/frontend/internal/batches/webhooks/bitbucketserver_test.go
+++ b/enterprise/cmd/frontend/internal/batches/webhooks/bitbucketserver_test.go
@@ -3,7 +3,6 @@ package webhooks
 import (
 	"bytes"
 	"context"
-	"database/sql"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -35,7 +34,7 @@ import (
 )
 
 // Run from integration_test.go
-func testBitbucketServerWebhook(db *sql.DB, userID int32) func(*testing.T) {
+func testBitbucketServerWebhook(db database.DB, userID int32) func(*testing.T) {
 	return func(t *testing.T) {
 		now := timeutil.Now()
 		clock := func() time.Time { return now }
@@ -50,8 +49,8 @@ func testBitbucketServerWebhook(db *sql.DB, userID int32) func(*testing.T) {
 		defer save()
 
 		secret := "secret"
-		repoStore := database.Repos(db)
-		esStore := database.NewDB(db).ExternalServices()
+		repoStore := db.Repos()
+		esStore := db.ExternalServices()
 		bitbucketServerToken := os.Getenv("BITBUCKET_SERVER_TOKEN")
 		if bitbucketServerToken == "" {
 			bitbucketServerToken = "test-token"

--- a/enterprise/cmd/frontend/internal/batches/webhooks/github_test.go
+++ b/enterprise/cmd/frontend/internal/batches/webhooks/github_test.go
@@ -3,7 +3,6 @@ package webhooks
 import (
 	"bytes"
 	"context"
-	"database/sql"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -37,7 +36,7 @@ import (
 )
 
 // Run from integration_test.go
-func testGitHubWebhook(db *sql.DB, userID int32) func(*testing.T) {
+func testGitHubWebhook(db database.DB, userID int32) func(*testing.T) {
 	return func(t *testing.T) {
 		now := timeutil.Now()
 		clock := func() time.Time { return now }
@@ -56,8 +55,8 @@ func testGitHubWebhook(db *sql.DB, userID int32) func(*testing.T) {
 		if token == "" {
 			token = "no-GITHUB_TOKEN-set"
 		}
-		repoStore := database.Repos(db)
-		esStore := database.NewDB(db).ExternalServices()
+		repoStore := db.Repos()
+		esStore := db.ExternalServices()
 		extSvc := &types.ExternalService{
 			Kind:        extsvc.KindGitHub,
 			DisplayName: "GitHub",

--- a/enterprise/cmd/frontend/internal/batches/webhooks/webhooks_integration_test.go
+++ b/enterprise/cmd/frontend/internal/batches/webhooks/webhooks_integration_test.go
@@ -20,8 +20,8 @@ func TestWebhooksIntegration(t *testing.T) {
 
 	user := ct.CreateTestUser(t, db, false)
 
-	t.Run("GitHubWebhook", testGitHubWebhook(sqlDB, user.ID))
-	t.Run("BitbucketServerWebhook", testBitbucketServerWebhook(sqlDB, user.ID))
+	t.Run("GitHubWebhook", testGitHubWebhook(db, user.ID))
+	t.Run("BitbucketServerWebhook", testBitbucketServerWebhook(db, user.ID))
 	t.Run("GitLabWebhook", testGitLabWebhook(sqlDB))
-	t.Run("BitbucketCloudWebhook", testBitbucketCloudWebhook(sqlDB, user.ID))
+	t.Run("BitbucketCloudWebhook", testBitbucketCloudWebhook(sqlDB))
 }

--- a/enterprise/cmd/frontend/internal/searchcontexts/resolvers/resolvers.go
+++ b/enterprise/cmd/frontend/internal/searchcontexts/resolvers/resolvers.go
@@ -151,7 +151,7 @@ func (r *Resolver) repositoryRevisionsFromInputArgs(ctx context.Context, args []
 		}
 		repoIDs = append(repoIDs, repoID)
 	}
-	idToRepo, err := database.Repos(r.db).GetReposSetByIDs(ctx, repoIDs...)
+	idToRepo, err := r.db.Repos().GetReposSetByIDs(ctx, repoIDs...)
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/internal/batches/reconciler/executor_test.go
+++ b/enterprise/internal/batches/reconciler/executor_test.go
@@ -37,8 +37,7 @@ func TestExecutor_ExecutePlan(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	sqlDB := dbtest.NewDB(t)
-	db := database.NewDB(sqlDB)
+	db := database.NewDB(dbtest.NewDB(t))
 
 	now := timeutil.Now()
 	clock := func() time.Time { return now }
@@ -586,7 +585,7 @@ func TestExecutor_ExecutePlan(t *testing.T) {
 		})
 
 		// After each test: clean up database.
-		ct.TruncateTables(t, sqlDB, "changeset_events", "changesets", "batch_changes", "batch_specs", "changeset_specs")
+		ct.TruncateTables(t, db, "changeset_events", "changesets", "batch_changes", "batch_specs", "changeset_specs")
 	}
 }
 
@@ -680,8 +679,7 @@ func TestExecutor_ExecutePlan_AvoidLoadingChangesetSource(t *testing.T) {
 
 func TestLoadChangesetSource(t *testing.T) {
 	ctx := actor.WithInternalActor(context.Background())
-	sqlDB := dbtest.NewDB(t)
-	db := database.NewDB(sqlDB)
+	db := database.NewDB(dbtest.NewDB(t))
 	token := &auth.OAuthBearerToken{Token: "abcdef"}
 
 	cstore := store.New(db, &observation.TestContext, et.TestKey{})
@@ -717,7 +715,7 @@ func TestLoadChangesetSource(t *testing.T) {
 			t.Fatal(err)
 		}
 		t.Cleanup(func() {
-			ct.TruncateTables(t, sqlDB, "batch_changes_site_credentials")
+			ct.TruncateTables(t, db, "batch_changes_site_credentials")
 		})
 		fakeSource := &sources.FakeChangesetSource{}
 		sourcer := sources.NewFakeSourcer(nil, fakeSource)
@@ -798,7 +796,7 @@ func TestLoadChangesetSource(t *testing.T) {
 			t.Fatal(err)
 		}
 		t.Cleanup(func() {
-			ct.TruncateTables(t, sqlDB, "user_credentials")
+			ct.TruncateTables(t, db, "user_credentials")
 		})
 
 		fakeSource := &sources.FakeChangesetSource{}
@@ -822,7 +820,7 @@ func TestLoadChangesetSource(t *testing.T) {
 			t.Fatal(err)
 		}
 		t.Cleanup(func() {
-			ct.TruncateTables(t, sqlDB, "batch_changes_site_credentials")
+			ct.TruncateTables(t, db, "batch_changes_site_credentials")
 		})
 
 		fakeSource := &sources.FakeChangesetSource{}

--- a/enterprise/internal/batches/reconciler/reconciler_test.go
+++ b/enterprise/internal/batches/reconciler/reconciler_test.go
@@ -25,8 +25,7 @@ func TestReconcilerProcess_IntegrationTest(t *testing.T) {
 	}
 
 	ctx := actor.WithInternalActor(context.Background())
-	sqlDB := dbtest.NewDB(t)
-	db := database.NewDB(sqlDB)
+	db := database.NewDB(dbtest.NewDB(t))
 	log := logtest.Scoped(t)
 
 	store := store.New(db, &observation.TestContext, nil)
@@ -164,6 +163,6 @@ func TestReconcilerProcess_IntegrationTest(t *testing.T) {
 		})
 
 		// Clean up database.
-		ct.TruncateTables(t, sqlDB, "changeset_events", "changesets", "batch_changes", "batch_specs", "changeset_specs")
+		ct.TruncateTables(t, db, "changeset_events", "changesets", "batch_changes", "batch_specs", "changeset_specs")
 	}
 }

--- a/enterprise/internal/batches/service/service_apply_batch_change_test.go
+++ b/enterprise/internal/batches/service/service_apply_batch_change_test.go
@@ -26,8 +26,7 @@ func TestServiceApplyBatchChange(t *testing.T) {
 	}
 
 	ctx := actor.WithInternalActor(context.Background())
-	sqlDB := dbtest.NewDB(t)
-	db := database.NewDB(sqlDB)
+	db := database.NewDB(dbtest.NewDB(t))
 
 	admin := ct.CreateTestUser(t, db, true)
 	adminCtx := actor.WithActor(context.Background(), actor.FromUser(admin.ID))
@@ -44,7 +43,7 @@ func TestServiceApplyBatchChange(t *testing.T) {
 
 	t.Run("BatchSpec without changesetSpecs", func(t *testing.T) {
 		t.Run("new batch change", func(t *testing.T) {
-			ct.TruncateTables(t, sqlDB, "changeset_events", "changesets", "batch_changes", "batch_specs", "changeset_specs")
+			ct.TruncateTables(t, db, "changeset_events", "changesets", "batch_changes", "batch_specs", "changeset_specs")
 			batchSpec := ct.CreateBatchSpec(t, ctx, store, "batchchange1", admin.ID)
 			batchChange, err := svc.ApplyBatchChange(adminCtx, ApplyBatchChangeOpts{
 				BatchSpecRandID: batchSpec.RandID,
@@ -78,7 +77,7 @@ func TestServiceApplyBatchChange(t *testing.T) {
 		})
 
 		t.Run("existing batch change", func(t *testing.T) {
-			ct.TruncateTables(t, sqlDB, "changeset_events", "changesets", "batch_changes", "batch_specs", "changeset_specs")
+			ct.TruncateTables(t, db, "changeset_events", "changesets", "batch_changes", "batch_specs", "changeset_specs")
 			batchSpec := ct.CreateBatchSpec(t, ctx, store, "batchchange2", admin.ID)
 			batchChange := ct.CreateBatchChange(t, ctx, store, "batchchange2", admin.ID, batchSpec.ID)
 
@@ -206,7 +205,7 @@ func TestServiceApplyBatchChange(t *testing.T) {
 	// covered in the tests above.
 	t.Run("batchSpec with changesetSpecs", func(t *testing.T) {
 		t.Run("new batch change", func(t *testing.T) {
-			ct.TruncateTables(t, sqlDB, "changeset_events", "changesets", "batch_changes", "batch_specs", "changeset_specs")
+			ct.TruncateTables(t, db, "changeset_events", "changesets", "batch_changes", "batch_specs", "changeset_specs")
 			batchSpec := ct.CreateBatchSpec(t, ctx, store, "batchchange3", admin.ID)
 
 			spec1 := ct.CreateChangesetSpec(t, ctx, store, ct.TestSpecOpts{
@@ -251,7 +250,7 @@ func TestServiceApplyBatchChange(t *testing.T) {
 		})
 
 		t.Run("batch change with changesets", func(t *testing.T) {
-			ct.TruncateTables(t, sqlDB, "changeset_events", "changesets", "batch_changes", "batch_specs", "changeset_specs")
+			ct.TruncateTables(t, db, "changeset_events", "changesets", "batch_changes", "batch_specs", "changeset_specs")
 			// First we create a batchSpec and apply it, so that we have
 			// changesets and changesetSpecs in the database, wired up
 			// correctly.
@@ -428,7 +427,7 @@ func TestServiceApplyBatchChange(t *testing.T) {
 		})
 
 		t.Run("batch change tracking changesets owned by another batch change", func(t *testing.T) {
-			ct.TruncateTables(t, sqlDB, "changeset_events", "changesets", "batch_changes", "batch_specs", "changeset_specs")
+			ct.TruncateTables(t, db, "changeset_events", "changesets", "batch_changes", "batch_specs", "changeset_specs")
 			batchSpec1 := ct.CreateBatchSpec(t, ctx, store, "owner-batch-change", admin.ID)
 
 			oldSpec1 := ct.CreateChangesetSpec(t, ctx, store, ct.TestSpecOpts{
@@ -504,7 +503,7 @@ func TestServiceApplyBatchChange(t *testing.T) {
 		})
 
 		t.Run("batch change with changeset that is unpublished", func(t *testing.T) {
-			ct.TruncateTables(t, sqlDB, "changeset_events", "changesets", "batch_changes", "batch_specs", "changeset_specs")
+			ct.TruncateTables(t, db, "changeset_events", "changesets", "batch_changes", "batch_specs", "changeset_specs")
 			batchSpec1 := ct.CreateBatchSpec(t, ctx, store, "unpublished-changesets", admin.ID)
 
 			ct.CreateChangesetSpec(t, ctx, store, ct.TestSpecOpts{
@@ -527,7 +526,7 @@ func TestServiceApplyBatchChange(t *testing.T) {
 		})
 
 		t.Run("batch change with changeset that wasn't processed before reapply", func(t *testing.T) {
-			ct.TruncateTables(t, sqlDB, "changeset_events", "changesets", "batch_changes", "batch_specs", "changeset_specs")
+			ct.TruncateTables(t, db, "changeset_events", "changesets", "batch_changes", "batch_specs", "changeset_specs")
 			batchSpec1 := ct.CreateBatchSpec(t, ctx, store, "queued-changesets", admin.ID)
 
 			specOpts := ct.TestSpecOpts{
@@ -681,7 +680,7 @@ func TestServiceApplyBatchChange(t *testing.T) {
 		})
 
 		t.Run("missing repository permissions", func(t *testing.T) {
-			ct.TruncateTables(t, sqlDB, "changeset_events", "changesets", "batch_changes", "batch_specs", "changeset_specs")
+			ct.TruncateTables(t, db, "changeset_events", "changesets", "batch_changes", "batch_specs", "changeset_specs")
 			ct.MockRepoPermissions(t, db, user.ID, repos[0].ID, repos[2].ID, repos[3].ID)
 
 			// NOTE: We cannot use a context with an internal actor.
@@ -717,7 +716,7 @@ func TestServiceApplyBatchChange(t *testing.T) {
 		})
 
 		t.Run("batch change with errored changeset", func(t *testing.T) {
-			ct.TruncateTables(t, sqlDB, "changeset_events", "changesets", "batch_changes", "batch_specs", "changeset_specs")
+			ct.TruncateTables(t, db, "changeset_events", "changesets", "batch_changes", "batch_specs", "changeset_specs")
 			batchSpec1 := ct.CreateBatchSpec(t, ctx, store, "errored-changeset-batch-change", admin.ID)
 
 			spec1Opts := ct.TestSpecOpts{
@@ -800,7 +799,7 @@ func TestServiceApplyBatchChange(t *testing.T) {
 		})
 
 		t.Run("closed and archived changeset not re-enqueued for close", func(t *testing.T) {
-			ct.TruncateTables(t, sqlDB, "changeset_events", "changesets", "batch_changes", "batch_specs", "changeset_specs")
+			ct.TruncateTables(t, db, "changeset_events", "changesets", "batch_changes", "batch_specs", "changeset_specs")
 			batchSpec1 := ct.CreateBatchSpec(t, ctx, store, "archived-closed-changeset", admin.ID)
 
 			specOpts := ct.TestSpecOpts{
@@ -869,7 +868,7 @@ func TestServiceApplyBatchChange(t *testing.T) {
 
 		t.Run("batch change with changeset that is archived and reattached", func(t *testing.T) {
 			t.Run("changeset has been closed before re-attaching", func(t *testing.T) {
-				ct.TruncateTables(t, sqlDB, "changeset_events", "changesets", "batch_changes", "batch_specs", "changeset_specs")
+				ct.TruncateTables(t, db, "changeset_events", "changesets", "batch_changes", "batch_specs", "changeset_specs")
 				batchSpec1 := ct.CreateBatchSpec(t, ctx, store, "detach-reattach-changeset", admin.ID)
 
 				specOpts := ct.TestSpecOpts{
@@ -951,7 +950,7 @@ func TestServiceApplyBatchChange(t *testing.T) {
 			})
 
 			t.Run("changeset has failed closing before re-attaching", func(t *testing.T) {
-				ct.TruncateTables(t, sqlDB, "changeset_events", "changesets", "batch_changes", "batch_specs", "changeset_specs")
+				ct.TruncateTables(t, db, "changeset_events", "changesets", "batch_changes", "batch_specs", "changeset_specs")
 				batchSpec1 := ct.CreateBatchSpec(t, ctx, store, "detach-reattach-failed-changeset", admin.ID)
 
 				specOpts := ct.TestSpecOpts{
@@ -1042,7 +1041,7 @@ func TestServiceApplyBatchChange(t *testing.T) {
 			})
 
 			t.Run("changeset has not been closed before re-attaching", func(t *testing.T) {
-				ct.TruncateTables(t, sqlDB, "changeset_events", "changesets", "batch_changes", "batch_specs", "changeset_specs")
+				ct.TruncateTables(t, db, "changeset_events", "changesets", "batch_changes", "batch_specs", "changeset_specs")
 				// The difference to the previous test: we DON'T update the
 				// changeset to make it look closed. We want to make sure that
 				// we also pick up enqueued-to-be-closed changesets.
@@ -1119,7 +1118,7 @@ func TestServiceApplyBatchChange(t *testing.T) {
 		})
 
 		t.Run("invalid changeset specs", func(t *testing.T) {
-			ct.TruncateTables(t, sqlDB, "changeset_events", "changesets", "batch_changes", "batch_specs", "changeset_specs")
+			ct.TruncateTables(t, db, "changeset_events", "changesets", "batch_changes", "batch_specs", "changeset_specs")
 			batchSpec := ct.CreateBatchSpec(t, ctx, store, "batchchange-invalid-specs", admin.ID)
 
 			// Both specs here have the same HeadRef in the same repository
@@ -1151,7 +1150,7 @@ func TestServiceApplyBatchChange(t *testing.T) {
 	})
 
 	t.Run("applying to closed batch change", func(t *testing.T) {
-		ct.TruncateTables(t, sqlDB, "changeset_events", "changesets", "batch_changes", "batch_specs", "changeset_specs")
+		ct.TruncateTables(t, db, "changeset_events", "changesets", "batch_changes", "batch_specs", "changeset_specs")
 		batchSpec := ct.CreateBatchSpec(t, ctx, store, "closed-batch-change", admin.ID)
 		batchChange := ct.CreateBatchChange(t, ctx, store, "closed-batch-change", admin.ID, batchSpec.ID)
 

--- a/enterprise/internal/batches/testing/db.go
+++ b/enterprise/internal/batches/testing/db.go
@@ -2,12 +2,13 @@ package testing
 
 import (
 	"context"
-	"database/sql"
 	"strings"
 	"testing"
+
+	"github.com/sourcegraph/sourcegraph/internal/database"
 )
 
-func TruncateTables(t *testing.T, db *sql.DB, tables ...string) {
+func TruncateTables(t *testing.T, db database.DB, tables ...string) {
 	t.Helper()
 
 	_, err := db.ExecContext(context.Background(), "TRUNCATE "+strings.Join(tables, ", ")+" RESTART IDENTITY CASCADE")

--- a/enterprise/internal/batches/testing/repos.go
+++ b/enterprise/internal/batches/testing/repos.go
@@ -72,7 +72,7 @@ func CreateTestRepo(t *testing.T, ctx context.Context, db database.DB) (*types.R
 func CreateTestRepos(t *testing.T, ctx context.Context, db database.DB, count int) ([]*types.Repo, *types.ExternalService) {
 	t.Helper()
 
-	repoStore := database.Repos(db)
+	repoStore := db.Repos()
 	esStore := db.ExternalServices()
 
 	ext := &types.ExternalService{
@@ -117,7 +117,7 @@ func CreateTestRepos(t *testing.T, ctx context.Context, db database.DB, count in
 func CreateGitlabTestRepos(t *testing.T, ctx context.Context, db database.DB, count int) ([]*types.Repo, *types.ExternalService) {
 	t.Helper()
 
-	repoStore := database.Repos(db)
+	repoStore := db.Repos()
 	esStore := db.ExternalServices()
 
 	ext := &types.ExternalService{
@@ -195,7 +195,7 @@ func CreateGitHubSSHTestRepos(t *testing.T, ctx context.Context, db database.DB,
 		rs = append(rs, r)
 	}
 
-	err := database.Repos(db).Create(ctx, rs...)
+	err := db.Repos().Create(ctx, rs...)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -221,7 +221,7 @@ func CreateBbsSSHTestRepos(t *testing.T, ctx context.Context, db database.DB, co
 func createBbsRepos(t *testing.T, ctx context.Context, db database.DB, ext *types.ExternalService, count int, cloneBaseURL string) ([]*types.Repo, *types.ExternalService) {
 	t.Helper()
 
-	repoStore := database.Repos(db)
+	repoStore := db.Repos()
 	esStore := db.ExternalServices()
 
 	if err := esStore.Upsert(ctx, ext); err != nil {
@@ -258,7 +258,7 @@ func createBbsRepos(t *testing.T, ctx context.Context, db database.DB, ext *type
 func CreateAWSCodeCommitTestRepos(t *testing.T, ctx context.Context, db database.DB, count int) ([]*types.Repo, *types.ExternalService) {
 	t.Helper()
 
-	repoStore := database.Repos(db)
+	repoStore := db.Repos()
 	esStore := db.ExternalServices()
 
 	ext := &types.ExternalService{

--- a/enterprise/internal/insights/background/historical_enqueuer.go
+++ b/enterprise/internal/insights/background/historical_enqueuer.go
@@ -95,7 +95,7 @@ func newInsightHistoricalEnqueuer(ctx context.Context, workerBaseStore *basestor
 	})
 
 	db := workerBaseStore.Handle().DB()
-	repoStore := database.Repos(db)
+	repoStore := database.NewDB(db).Repos()
 
 	iterator := discovery.NewAllReposIterator(
 		dbcache.NewIndexableReposLister(repoStore),

--- a/enterprise/internal/insights/compression/worker.go
+++ b/enterprise/internal/insights/compression/worker.go
@@ -46,7 +46,7 @@ func NewCommitIndexer(background context.Context, base database.DB, insights dbu
 	//TODO(insights): add a setting for historical index length
 	startTime := time.Now().AddDate(-1, 0, 0)
 
-	repoStore := database.Repos(base)
+	repoStore := base.Repos()
 
 	commitStore := NewCommitStore(insights)
 

--- a/enterprise/internal/insights/query/capture_group_executor.go
+++ b/enterprise/internal/insights/query/capture_group_executor.go
@@ -19,7 +19,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
@@ -29,11 +28,11 @@ type CaptureGroupExecutor struct {
 	computeSearch func(ctx context.Context, query string) ([]GroupedResults, error)
 }
 
-func NewCaptureGroupExecutor(postgres, insightsDb dbutil.DB, clock func() time.Time) *CaptureGroupExecutor {
+func NewCaptureGroupExecutor(postgres database.DB, clock func() time.Time) *CaptureGroupExecutor {
 	executor := CaptureGroupExecutor{
 		justInTimeExecutor: justInTimeExecutor{
 			db:        database.NewDB(postgres),
-			repoStore: database.Repos(postgres),
+			repoStore: postgres.Repos(),
 			// filter:    compression.NewHistoricalFilter(true, clock().Add(time.Hour*24*365*-1), insightsDb),
 			filter: &compression.NoopFilter{},
 			clock:  clock,

--- a/enterprise/internal/insights/query/streaming_query_executor.go
+++ b/enterprise/internal/insights/query/streaming_query_executor.go
@@ -5,17 +5,15 @@ import (
 	"sort"
 	"time"
 
-	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/query/querybuilder"
-
 	"github.com/inconshreveable/log15"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/compression"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/query/querybuilder"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/query/streaming"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/timeseries"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
@@ -24,11 +22,11 @@ type StreamingQueryExecutor struct {
 	justInTimeExecutor
 }
 
-func NewStreamingExecutor(postgres, insightsDb dbutil.DB, clock func() time.Time) *StreamingQueryExecutor {
+func NewStreamingExecutor(postgres database.DB, clock func() time.Time) *StreamingQueryExecutor {
 	return &StreamingQueryExecutor{
 		justInTimeExecutor: justInTimeExecutor{
 			db:        database.NewDB(postgres),
-			repoStore: database.Repos(postgres),
+			repoStore: postgres.Repos(),
 			filter:    &compression.NoopFilter{},
 			clock:     clock,
 		},

--- a/enterprise/internal/insights/resolvers/insight_series_resolver.go
+++ b/enterprise/internal/insights/resolvers/insight_series_resolver.go
@@ -436,7 +436,7 @@ func expandCaptureGroupSeriesRecorded(ctx context.Context, definition types.Insi
 }
 
 func expandCaptureGroupSeriesJustInTime(ctx context.Context, definition types.InsightViewSeries, r baseInsightResolver, filters types.InsightViewFilters) ([]graphqlbackend.InsightSeriesResolver, error) {
-	executor := query.NewCaptureGroupExecutor(r.postgresDB, r.insightsDB, time.Now)
+	executor := query.NewCaptureGroupExecutor(r.postgresDB, time.Now)
 	interval := timeseries.TimeInterval{
 		Unit:  types.IntervalUnit(definition.SampleIntervalUnit),
 		Value: definition.SampleIntervalValue,
@@ -462,7 +462,7 @@ func expandCaptureGroupSeriesJustInTime(ctx context.Context, definition types.In
 }
 
 func streamingSeriesJustInTime(ctx context.Context, definition types.InsightViewSeries, r baseInsightResolver, filters types.InsightViewFilters) ([]graphqlbackend.InsightSeriesResolver, error) {
-	executor := query.NewStreamingExecutor(r.postgresDB, r.insightsDB, time.Now)
+	executor := query.NewStreamingExecutor(r.postgresDB, time.Now)
 	interval := timeseries.TimeInterval{
 		Unit:  types.IntervalUnit(definition.SampleIntervalUnit),
 		Value: definition.SampleIntervalValue,

--- a/enterprise/internal/insights/resolvers/live_preview_resolvers.go
+++ b/enterprise/internal/insights/resolvers/live_preview_resolvers.go
@@ -55,13 +55,13 @@ func (r *Resolver) SearchInsightPreview(ctx context.Context, args graphqlbackend
 		var err error
 
 		if seriesArgs.GeneratedFromCaptureGroups {
-			executor := query.NewCaptureGroupExecutor(r.postgresDB, r.insightsDB, clock)
+			executor := query.NewCaptureGroupExecutor(r.postgresDB, clock)
 			series, err = executor.Execute(ctx, seriesArgs.Query, repos, interval)
 			if err != nil {
 				return nil, err
 			}
 		} else {
-			executor := query.NewStreamingExecutor(r.postgresDB, r.insightsDB, clock)
+			executor := query.NewStreamingExecutor(r.postgresDB, clock)
 			series, err = executor.Execute(ctx, seriesArgs.Query, seriesArgs.Label, seriesArgs.Label, repos, interval)
 			if err != nil {
 				return nil, err

--- a/internal/database/dbcache/cached_indexable_repos_test.go
+++ b/internal/database/dbcache/cached_indexable_repos_test.go
@@ -75,7 +75,7 @@ func TestListIndexableRepos(t *testing.T) {
 		}
 
 		t.Run("List ALL repos", func(t *testing.T) {
-			repos, err := NewIndexableReposLister(database.Repos(db)).List(ctx)
+			repos, err := NewIndexableReposLister(db.Repos()).List(ctx)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -107,7 +107,7 @@ func TestListIndexableRepos(t *testing.T) {
 		})
 
 		t.Run("List only public indexable repos", func(t *testing.T) {
-			repos, err := NewIndexableReposLister(database.Repos(db)).ListPublic(ctx)
+			repos, err := NewIndexableReposLister(db.Repos()).ListPublic(ctx)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -136,7 +136,7 @@ func TestListIndexableRepos(t *testing.T) {
 }
 
 func BenchmarkIndexableRepos_List_Empty(b *testing.B) {
-	db := dbtest.NewDB(b)
+	db := database.NewDB(dbtest.NewDB(b))
 
 	ctx := context.Background()
 	select {
@@ -146,7 +146,7 @@ func BenchmarkIndexableRepos_List_Empty(b *testing.B) {
 	}
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
-		_, err := NewIndexableReposLister(database.Repos(db)).List(ctx)
+		_, err := NewIndexableReposLister(db.Repos()).List(ctx)
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/internal/database/external_services_test.go
+++ b/internal/database/external_services_test.go
@@ -917,7 +917,7 @@ VALUES (%d, 1, ''), (%d, 2, '')
 	}
 
 	// Should only get back the repo with ID=2
-	repos, err := Repos(db).GetByIDs(ctx, 1, 2)
+	repos, err := db.Repos().GetByIDs(ctx, 1, 2)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/database/gitserver_repos_test.go
+++ b/internal/database/gitserver_repos_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/internal/types/typestest"
@@ -69,7 +68,7 @@ func TestIterateRepoGitserverStatus(t *testing.T) {
 	}
 
 	// Soft delete one of the repos
-	if err := Repos(db).Delete(ctx, repos[2].ID); err != nil {
+	if err := db.Repos().Delete(ctx, repos[2].ID); err != nil {
 		t.Fatal(err)
 	}
 
@@ -143,7 +142,7 @@ func TestIteratePurgeableRepos(t *testing.T) {
 	for _, repo := range []*types.Repo{notCloned} {
 		createTestGitserverRepos(ctx, t, db, false, types.CloneStatusNotCloned, repo.ID)
 	}
-	if err := Repos(db).Delete(ctx, deletedRepo.ID); err != nil {
+	if err := db.Repos().Delete(ctx, deletedRepo.ID); err != nil {
 		t.Fatal(err)
 	}
 	// Blocking a repo is currently done manually
@@ -540,7 +539,7 @@ func TestSetCloneStatus(t *testing.T) {
 	}
 
 	// Create one test repo
-	err = Repos(db).Create(ctx, repo2)
+	err = db.Repos().Create(ctx, repo2)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -696,7 +695,7 @@ func TestSetRepoSize(t *testing.T) {
 	}
 
 	// Create one test repo
-	err = Repos(db).Create(ctx, repo2)
+	err = db.Repos().Create(ctx, repo2)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -747,7 +746,7 @@ func TestGitserverRepoUpsertNullShard(t *testing.T) {
 	}
 
 	// Create one test repo
-	err := Repos(db).Create(ctx, repo1)
+	err := db.Repos().Create(ctx, repo1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1031,7 +1030,7 @@ func createTestRepo(ctx context.Context, t *testing.T, db DB, payload *createTes
 	}
 
 	// Create Repo
-	err := Repos(db).Create(ctx, repo)
+	err := db.Repos().Create(ctx, repo)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1089,9 +1088,9 @@ type createTestRepoPayload struct {
 	CloneStatus types.CloneStatus
 }
 
-func createTestRepos(ctx context.Context, t *testing.T, db dbutil.DB, repos types.Repos) {
+func createTestRepos(ctx context.Context, t *testing.T, db DB, repos types.Repos) {
 	t.Helper()
-	err := Repos(db).Create(ctx, repos...)
+	err := db.Repos().Create(ctx, repos...)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/database/org_stats.go
+++ b/internal/database/org_stats.go
@@ -2,10 +2,8 @@ package database
 
 import (
 	"context"
-	"database/sql"
 
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
@@ -17,11 +15,6 @@ type OrgStatsStore interface {
 
 type orgStatsStore struct {
 	*basestore.Store
-}
-
-// OrgStats instantiates and returns a new OrgStatsStore with prepared statements.
-func OrgStats(db dbutil.DB) OrgStatsStore {
-	return &orgStatsStore{Store: basestore.NewWithDB(db, sql.TxOptions{})}
 }
 
 // OrgStatsWith instantiates and returns a new OrgStatsStore using the other store handle.

--- a/internal/database/org_stats_test.go
+++ b/internal/database/org_stats_test.go
@@ -17,7 +17,7 @@ func TestOrgStats_Upsert(t *testing.T) {
 	}
 
 	t.Run("Succeeds to create stats for existing org", func(t *testing.T) {
-		stats, err := OrgStats(db).Upsert(ctx, org.ID, 42)
+		stats, err := db.OrgStats().Upsert(ctx, org.ID, 42)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -28,7 +28,7 @@ func TestOrgStats_Upsert(t *testing.T) {
 	})
 
 	t.Run("Succeeds to update stats for existing org", func(t *testing.T) {
-		stats, err := OrgStats(db).Upsert(ctx, org.ID, 1024)
+		stats, err := db.OrgStats().Upsert(ctx, org.ID, 1024)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -39,7 +39,7 @@ func TestOrgStats_Upsert(t *testing.T) {
 	})
 
 	t.Run("Fails to update stats for non-existing org", func(t *testing.T) {
-		_, err := OrgStats(db).Upsert(ctx, 42, 1)
+		_, err := db.OrgStats().Upsert(ctx, 42, 1)
 		if err == nil {
 			t.Fatal("Expected error when adding stats for non-existing organization")
 		}

--- a/internal/database/orgs_test.go
+++ b/internal/database/orgs_test.go
@@ -249,7 +249,7 @@ func TestOrgs_GetOrgsWithRepositoriesByUserID(t *testing.T) {
 		t.Fatal(err)
 	}
 	repo := typestest.MakeGithubRepo(service)
-	if err := Repos(db).Create(ctx, repo); err != nil {
+	if err := db.Repos().Create(ctx, repo); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/database/phabricator.go
+++ b/internal/database/phabricator.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
@@ -30,12 +29,7 @@ type phabricatorStore struct {
 	*basestore.Store
 }
 
-// Phabricator instantiates and returns a new PhabricatorStore with prepared statements.
-func Phabricator(db dbutil.DB) PhabricatorStore {
-	return &phabricatorStore{Store: basestore.NewWithDB(db, sql.TxOptions{})}
-}
-
-// NewPhabricatorStoreWithDB instantiates and returns a new PhabricatorStore using the other store handle.
+// PhabricatorWith instantiates and returns a new PhabricatorStore using the other store handle.
 func PhabricatorWith(other basestore.ShareableStore) PhabricatorStore {
 	return &phabricatorStore{Store: basestore.NewWithHandle(other.Handle())}
 }

--- a/internal/database/repos.go
+++ b/internal/database/repos.go
@@ -91,11 +91,6 @@ type repoStore struct {
 	*basestore.Store
 }
 
-// Repos instantiates and returns a new RepoStore with prepared statements.
-func Repos(db dbutil.DB) RepoStore {
-	return &repoStore{Store: basestore.NewWithDB(db, sql.TxOptions{})}
-}
-
 // ReposWith instantiates and returns a new RepoStore using the other
 // store handle.
 func ReposWith(other basestore.ShareableStore) RepoStore {

--- a/internal/database/repos_perm_test.go
+++ b/internal/database/repos_perm_test.go
@@ -252,7 +252,7 @@ VALUES
 
 	// Alice should be able to see both her public and private repos
 	aliceCtx := actor.WithActor(ctx, &actor.Actor{UID: alice.ID})
-	repos, err := Repos(db).List(aliceCtx, ReposListOptions{})
+	repos, err := db.Repos().List(aliceCtx, ReposListOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -339,7 +339,7 @@ VALUES (%s, 'read', %s)
 
 	// Alice should NOT be able to see the private repo
 	aliceCtx := actor.WithActor(ctx, &actor.Actor{UID: alice.ID})
-	repos, err := Repos(db).List(aliceCtx, ReposListOptions{})
+	repos, err := db.Repos().List(aliceCtx, ReposListOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -360,7 +360,7 @@ UPDATE repo_permissions SET unrestricted = true
 
 	// Alice should now be able to see the repo
 	aliceCtx = actor.WithActor(ctx, &actor.Actor{UID: alice.ID})
-	repos, err = Repos(db).List(aliceCtx, ReposListOptions{})
+	repos, err = db.Repos().List(aliceCtx, ReposListOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -472,7 +472,7 @@ VALUES
 
 	// Alice should be able to see both her public and private repos
 	aliceCtx := actor.WithActor(ctx, &actor.Actor{UID: alice.ID})
-	repos, err := Repos(db).List(aliceCtx, ReposListOptions{})
+	repos, err := db.Repos().List(aliceCtx, ReposListOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -700,7 +700,7 @@ VALUES
 	// "bob_public_repo", "cindy_private_repo". The "cindy_private_repo" comes from
 	// an unrestricted external service
 	aliceCtx := actor.WithActor(ctx, &actor.Actor{UID: alice.ID})
-	repos, err := Repos(db).List(aliceCtx, ReposListOptions{})
+	repos, err := db.Repos().List(aliceCtx, ReposListOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -713,7 +713,7 @@ VALUES
 	// "cindy_private_repo". The "cindy_private_repo" comes from an unrestricted
 	// external service
 	bobCtx := actor.WithActor(ctx, &actor.Actor{UID: bob.ID})
-	repos, err = Repos(db).List(bobCtx, ReposListOptions{})
+	repos, err = db.Repos().List(bobCtx, ReposListOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -724,7 +724,7 @@ VALUES
 
 	// By default, site admins can see all repos
 	adminCtx := actor.WithActor(ctx, &actor.Actor{UID: admin.ID})
-	repos, err = Repos(db).List(adminCtx, ReposListOptions{})
+	repos, err = db.Repos().List(adminCtx, ReposListOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -740,7 +740,7 @@ VALUES
 		conf.Get().AuthzEnforceForSiteAdmins = false
 	})
 	adminCtx = actor.WithActor(ctx, &actor.Actor{UID: admin.ID})
-	repos, err = Repos(db).List(adminCtx, ReposListOptions{})
+	repos, err = db.Repos().List(adminCtx, ReposListOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -751,7 +751,7 @@ VALUES
 
 	// A random user should only see "alice_public_repo", "bob_public_repo", "cindy_private_repo"
 	// "cindy_private_repos" comes from an unrestricted external service
-	repos, err = Repos(db).List(ctx, ReposListOptions{})
+	repos, err = db.Repos().List(ctx, ReposListOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -921,7 +921,7 @@ VALUES
 
 	// Alice should see "alice_private_repo" but not "alice_public_repo", "bob_public_repo", "bob_private_repo"
 	aliceCtx := actor.WithActor(ctx, &actor.Actor{UID: alice.ID})
-	repos, err := Repos(db).List(aliceCtx, ReposListOptions{})
+	repos, err := db.Repos().List(aliceCtx, ReposListOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -932,7 +932,7 @@ VALUES
 
 	// Bob should see "bob_private_repo" but not "alice_public_repo" or "bob_public_repo"
 	bobCtx := actor.WithActor(ctx, &actor.Actor{UID: bob.ID})
-	repos, err = Repos(db).List(bobCtx, ReposListOptions{})
+	repos, err = db.Repos().List(bobCtx, ReposListOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -943,7 +943,7 @@ VALUES
 
 	// By default, admins can see all repos
 	adminCtx := actor.WithActor(ctx, &actor.Actor{UID: admin.ID})
-	repos, err = Repos(db).List(adminCtx, ReposListOptions{})
+	repos, err = db.Repos().List(adminCtx, ReposListOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -959,7 +959,7 @@ VALUES
 		conf.Get().AuthzEnforceForSiteAdmins = false
 	})
 	adminCtx = actor.WithActor(ctx, &actor.Actor{UID: admin.ID})
-	repos, err = Repos(db).List(adminCtx, ReposListOptions{})
+	repos, err = db.Repos().List(adminCtx, ReposListOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -969,7 +969,7 @@ VALUES
 	}
 
 	// A random user sees nothing
-	repos, err = Repos(db).List(ctx, ReposListOptions{})
+	repos, err = db.Repos().List(ctx, ReposListOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/database/repos_test.go
+++ b/internal/database/repos_test.go
@@ -142,7 +142,7 @@ func TestRepos_Count(t *testing.T) {
 	ctx := context.Background()
 	ctx = actor.WithActor(ctx, &actor.Actor{UID: 1, Internal: true})
 
-	if count, err := Repos(db).Count(ctx, ReposListOptions{}); err != nil {
+	if count, err := db.Repos().Count(ctx, ReposListOptions{}); err != nil {
 		t.Fatal(err)
 	} else if want := 0; count != want {
 		t.Errorf("got %d, want %d", count, want)
@@ -152,7 +152,7 @@ func TestRepos_Count(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if count, err := Repos(db).Count(ctx, ReposListOptions{}); err != nil {
+	if count, err := db.Repos().Count(ctx, ReposListOptions{}); err != nil {
 		t.Fatal(err)
 	} else if want := 1; count != want {
 		t.Errorf("got %d, want %d", count, want)
@@ -163,22 +163,22 @@ func TestRepos_Count(t *testing.T) {
 			OrderBy:     []RepoListSort{{Field: RepoListID}},
 			LimitOffset: &LimitOffset{Limit: 1},
 		}
-		if count, err := Repos(db).Count(ctx, opts); err != nil {
+		if count, err := db.Repos().Count(ctx, opts); err != nil {
 			t.Fatal(err)
 		} else if want := 1; count != want {
 			t.Errorf("got %d, want %d", count, want)
 		}
 	})
 
-	repos, err := Repos(db).List(ctx, ReposListOptions{})
+	repos, err := db.Repos().List(ctx, ReposListOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := Repos(db).Delete(ctx, repos[0].ID); err != nil {
+	if err := db.Repos().Delete(ctx, repos[0].ID); err != nil {
 		t.Fatal(err)
 	}
 
-	if count, err := Repos(db).Count(ctx, ReposListOptions{}); err != nil {
+	if count, err := db.Repos().Count(ctx, ReposListOptions{}); err != nil {
 		t.Fatal(err)
 	} else if want := 0; count != want {
 		t.Errorf("got %d, want %d", count, want)
@@ -198,21 +198,21 @@ func TestRepos_Delete(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if count, err := Repos(db).Count(ctx, ReposListOptions{}); err != nil {
+	if count, err := db.Repos().Count(ctx, ReposListOptions{}); err != nil {
 		t.Fatal(err)
 	} else if want := 1; count != want {
 		t.Errorf("got %d, want %d", count, want)
 	}
 
-	repos, err := Repos(db).List(ctx, ReposListOptions{})
+	repos, err := db.Repos().List(ctx, ReposListOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := Repos(db).Delete(ctx, repos[0].ID); err != nil {
+	if err := db.Repos().Delete(ctx, repos[0].ID); err != nil {
 		t.Fatal(err)
 	}
 
-	if count, err := Repos(db).Count(ctx, ReposListOptions{}); err != nil {
+	if count, err := db.Repos().Count(ctx, ReposListOptions{}); err != nil {
 		t.Fatal(err)
 	} else if want := 0; count != want {
 		t.Errorf("got %d, want %d", count, want)
@@ -228,7 +228,7 @@ func TestRepos_Upsert(t *testing.T) {
 	ctx := context.Background()
 	ctx = actor.WithActor(ctx, &actor.Actor{UID: 1, Internal: true})
 
-	if _, err := Repos(db).GetByName(ctx, "myrepo"); !errcode.IsNotFound(err) {
+	if _, err := db.Repos().GetByName(ctx, "myrepo"); !errcode.IsNotFound(err) {
 		if err == nil {
 			t.Fatal("myrepo already present")
 		} else {
@@ -240,7 +240,7 @@ func TestRepos_Upsert(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	rp, err := Repos(db).GetByName(ctx, "myrepo")
+	rp, err := db.Repos().GetByName(ctx, "myrepo")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -259,7 +259,7 @@ func TestRepos_Upsert(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	rp, err = Repos(db).GetByName(ctx, "myrepo")
+	rp, err = db.Repos().GetByName(ctx, "myrepo")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -279,7 +279,7 @@ func TestRepos_Upsert(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, err := Repos(db).GetByName(ctx, "myrepo"); !errcode.IsNotFound(err) {
+	if _, err := db.Repos().GetByName(ctx, "myrepo"); !errcode.IsNotFound(err) {
 		if err == nil {
 			t.Fatal("myrepo should be renamed, but still present as myrepo")
 		} else {
@@ -287,7 +287,7 @@ func TestRepos_Upsert(t *testing.T) {
 		}
 	}
 
-	rp, err = Repos(db).GetByName(ctx, "myrepo/renamed")
+	rp, err = db.Repos().GetByName(ctx, "myrepo/renamed")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -321,7 +321,7 @@ func TestRepos_UpsertForkAndArchivedFields(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			rp, err := Repos(db).GetByName(ctx, name)
+			rp, err := db.Repos().GetByName(ctx, name)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -360,7 +360,7 @@ func TestRepos_Create(t *testing.T) {
 	repo2 := typestest.MakeGitlabRepo(msvcs[extsvc.KindGitLab])
 
 	t.Run("no repos should not fail", func(t *testing.T) {
-		if err := Repos(db).Create(ctx); err != nil {
+		if err := db.Repos().Create(ctx); err != nil {
 			t.Fatalf("Create error: %s", err)
 		}
 	})
@@ -368,7 +368,7 @@ func TestRepos_Create(t *testing.T) {
 	t.Run("many repos", func(t *testing.T) {
 		want := typestest.GenerateRepos(7, repo1, repo2)
 
-		if err := Repos(db).Create(ctx, want...); err != nil {
+		if err := db.Repos().Create(ctx, want...); err != nil {
 			t.Fatalf("Create error: %s", err)
 		}
 
@@ -378,7 +378,7 @@ func TestRepos_Create(t *testing.T) {
 			t.Fatalf("Create didn't assign an ID to all repos: %v", noID.Names())
 		}
 
-		have, err := Repos(db).List(ctx, ReposListOptions{})
+		have, err := db.Repos().List(ctx, ReposListOptions{})
 		if err != nil {
 			t.Fatalf("List error: %s", err)
 		}
@@ -500,7 +500,7 @@ func TestListIndexableRepos(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			repos, err := Repos(db).ListIndexableRepos(ctx, tc.opts)
+			repos, err := db.Repos().ListIndexableRepos(ctx, tc.opts)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -552,7 +552,7 @@ func TestRepoStore_Metadata(t *testing.T) {
 		},
 	}
 
-	r := Repos(db)
+	r := db.Repos()
 	require.NoError(t, r.Create(ctx, repos...))
 
 	d1 := time.Unix(1627945150, 0)

--- a/internal/database/search_contexts_test.go
+++ b/internal/database/search_contexts_test.go
@@ -362,7 +362,7 @@ func TestSearchContexts_CreateAndSetRepositoryRevisions(t *testing.T) {
 	t.Parallel()
 	ctx := actor.WithInternalActor(context.Background())
 	sc := SearchContexts(db)
-	r := Repos(db)
+	r := db.Repos()
 
 	err := r.Create(ctx, &types.Repo{Name: "testA", URI: "https://example.com/a"}, &types.Repo{Name: "testB", URI: "https://example.com/b"})
 	if err != nil {
@@ -790,7 +790,7 @@ func TestSearchContexts_GetAllRevisionsForRepos(t *testing.T) {
 	// Required for this DB query.
 	internalCtx := actor.WithInternalActor(context.Background())
 	sc := SearchContexts(db)
-	r := Repos(db)
+	r := db.Repos()
 
 	repos := []*types.Repo{
 		{Name: "testA", URI: "https://example.com/a"},

--- a/internal/database/user_public_repos_test.go
+++ b/internal/database/user_public_repos_test.go
@@ -11,10 +11,10 @@ import (
 
 func TestUserPublicRepos_Set(t *testing.T) {
 	t.Parallel()
-	db := dbtest.NewDB(t)
+	db := NewDB(dbtest.NewDB(t))
 	ctx := context.Background()
 	u := Users(db)
-	r := Repos(db)
+	r := db.Repos()
 	upr := UserPublicRepos(db)
 
 	user, err := u.Create(ctx, NewUser{
@@ -61,10 +61,10 @@ func TestUserPublicRepos_Set(t *testing.T) {
 
 func TestUserPublicRepos_SetUserRepos(t *testing.T) {
 	t.Parallel()
-	db := dbtest.NewDB(t)
+	db := NewDB(dbtest.NewDB(t))
 	ctx := context.Background()
 	u := Users(db)
-	r := Repos(db)
+	r := db.Repos()
 	upr := UserPublicRepos(db)
 
 	user, err := u.Create(ctx, NewUser{

--- a/internal/repos/status_messages_test.go
+++ b/internal/repos/status_messages_test.go
@@ -235,7 +235,7 @@ func TestStatusMessages(t *testing.T) {
 				}
 			}
 
-			err := database.Repos(db).Create(ctx, stored...)
+			err := db.Repos().Create(ctx, stored...)
 			require.NoError(t, err)
 
 			t.Cleanup(func() {
@@ -243,7 +243,7 @@ func TestStatusMessages(t *testing.T) {
 				for _, r := range stored {
 					ids = append(ids, r.ID)
 				}
-				err := database.Repos(db).Delete(ctx, ids...)
+				err := db.Repos().Delete(ctx, ids...)
 				require.NoError(t, err)
 			})
 

--- a/internal/search/searchcontexts/search_contexts_test.go
+++ b/internal/search/searchcontexts/search_contexts_test.go
@@ -235,7 +235,7 @@ func TestResolvingSearchContextRepoNames(t *testing.T) {
 	internalCtx := actor.WithInternalActor(context.Background())
 	db := database.NewDB(dbtest.NewDB(t))
 	u := database.Users(db)
-	r := database.Repos(db)
+	r := db.Repos()
 
 	user, err := u.Create(internalCtx, database.NewUser{Username: "u", Password: "p"})
 	if err != nil {
@@ -399,7 +399,7 @@ func TestCreatingSearchContexts(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Expected no error, got %s", err)
 	}
-	repos, err := createRepos(internalCtx, database.Repos(db))
+	repos, err := createRepos(internalCtx, db.Repos())
 	if err != nil {
 		t.Fatalf("Expected no error, got %s", err)
 	}
@@ -499,7 +499,7 @@ func TestUpdatingSearchContexts(t *testing.T) {
 	user1, err := u.Create(internalCtx, database.NewUser{Username: "u1", Password: "p"})
 	require.NoError(t, err)
 
-	repos, err := createRepos(internalCtx, database.Repos(db))
+	repos, err := createRepos(internalCtx, db.Repos())
 	require.NoError(t, err)
 
 	var scs []*types.SearchContext

--- a/internal/usagestats/batches_test.go
+++ b/internal/usagestats/batches_test.go
@@ -21,7 +21,7 @@ func TestGetBatchChangesUsageStatistics(t *testing.T) {
 	db := database.NewDB(dbtest.NewDB(t))
 
 	// Create stub repo.
-	repoStore := database.Repos(db)
+	repoStore := db.Repos()
 	esStore := db.ExternalServices()
 
 	now := time.Now()


### PR DESCRIPTION
Remove a few dbutil-based constructors in our database package, as they are not mockable in our tests.

This is the result of a time-boxed effort.

## Test plan

Unit tests

---

Part of https://github.com/sourcegraph/sourcegraph/issues/26113