### PR TITLE
[SG-35514] logging(gitstart): migrate gitserver logging

### DIFF
--- a/cmd/gitserver/main.go
+++ b/cmd/gitserver/main.go
@@ -14,7 +14,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/inconshreveable/log15"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/opentracing/opentracing-go"
 	"github.com/prometheus/client_golang/prometheus"
@@ -125,6 +124,7 @@ func main() {
 	}
 
 	gitserver := server.Server{
+		Logger:             log.Scoped("Server", "a gitserver server"),
 		ReposDir:           reposDir,
 		DesiredPercentFree: wantPctFree2,
 		GetRemoteURLFunc: func(ctx context.Context, repo api.RepoName) (string, error) {
@@ -487,6 +487,7 @@ func syncSiteLevelExternalServiceRateLimiters(ctx context.Context, store databas
 func syncRateLimiters(ctx context.Context, store database.ExternalServiceStore, perSecond int) {
 	backoff := 5 * time.Second
 	batchSize := 50
+	logger := log.Scoped("sync rate limiter", "Sync rate limiters from config.")
 
 	// perSecond should be spread across all gitserver instances and we want to wait
 	// until we know about at least one instance.
@@ -496,8 +497,8 @@ func syncRateLimiters(ctx context.Context, store database.ExternalServiceStore, 
 		if instanceCount > 0 {
 			break
 		}
-		log15.Warn("found zero gitserver instance, trying again in %s", backoff)
-		time.Sleep(backoff)
+
+		logger.Warn("found zero gitserver instance, trying again after backoff", log.Duration("backoff", backoff))
 	}
 
 	limiter := rate.NewLimiter(rate.Limit(float64(perSecond)/float64(instanceCount)), batchSize)
@@ -511,7 +512,7 @@ func syncRateLimiters(ctx context.Context, store database.ExternalServiceStore, 
 	for {
 		start := time.Now()
 		if err := syncer.SyncLimitersSince(ctx, lastSuccessfulSync); err != nil {
-			log15.Warn("syncRateLimiters: error syncing rate limits", "error", err)
+			logger.Warn("syncRateLimiters: error syncing rate limits", log.Error(err))
 		} else {
 			lastSuccessfulSync = start
 		}

--- a/cmd/gitserver/server/cleanup.go
+++ b/cmd/gitserver/server/cleanup.go
@@ -18,7 +18,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/inconshreveable/log15"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 
@@ -30,6 +29,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"github.com/sourcegraph/sourcegraph/lib/log"
 )
 
 //go:embed sg_maintenance.sh
@@ -132,6 +132,7 @@ const reposStatsName = "repos-stats.json"
 func (s *Server) cleanupRepos() {
 	janitorRunning.Set(1)
 	defer janitorRunning.Set(0)
+	cleanupLogger := s.Logger.Scoped("cleanup", "cleanup operation")
 
 	bCtx, bCancel := s.serverContext()
 	defer bCancel()
@@ -173,7 +174,7 @@ func (s *Server) cleanupRepos() {
 			return false, nil
 		}
 
-		log15.Info("removing corrupt repo", "repo", dir, "reason", reason)
+		s.Logger.Info("removing corrupt repo", log.String("repo", string(dir)), log.String("reason", reason))
 		if err := s.removeRepoDirectory(dir); err != nil {
 			return true, err
 		}
@@ -243,13 +244,19 @@ func (s *Server) cleanupRepos() {
 
 		// name is the relative path to ReposDir, but without the .git suffix.
 		repo := s.name(dir)
-		log15.Info("re-cloning expired repo", "repo", repo, "cloned", recloneTime, "reason", reason)
+		subCleanupLogger := cleanupLogger.With(
+			log.String("repo", string(repo)),
+			log.Time("cloned", recloneTime),
+			log.String("reason", reason),
+		)
+
+		subCleanupLogger.Info("re-cloning expired repo")
 
 		// update the re-clone time so that we don't constantly re-clone if cloning fails.
 		// For example if a repo fails to clone due to being large, we will constantly be
 		// doing a clone which uses up lots of resources.
 		if err := setRecloneTime(dir, recloneTime.Add(time.Since(recloneTime)/2)); err != nil {
-			log15.Warn("setting backed off re-clone time failed", "repo", repo, "cloned", recloneTime, "reason", reason, "error", err)
+			subCleanupLogger.Warn("setting backed off re-clone time failed", log.Error(err))
 		}
 
 		if _, err := s.cloneRepo(ctx, repo, &cloneOptions{Block: true, Overwrite: true}); err != nil {
@@ -303,7 +310,7 @@ func (s *Server) cleanupRepos() {
 	}
 
 	performSGMaintenance := func(dir GitDir) (done bool, err error) {
-		return false, sgMaintenance(dir)
+		return false, sgMaintenance(s.Logger, dir)
 	}
 
 	performGitPrune := func(dir GitDir) (done bool, err error) {
@@ -378,7 +385,7 @@ func (s *Server) cleanupRepos() {
 			start := time.Now()
 			done, err := cfn.Do(gitDir)
 			if err != nil {
-				log15.Error("error running cleanup command", "name", cfn.Name, "repo", gitDir, "error", err)
+				cleanupLogger.Error("error running cleanup command", log.String("name", cfn.Name), log.String("repo", string(gitDir)), log.Error(err))
 			}
 			jobTimer.WithLabelValues(strconv.FormatBool(err == nil), cfn.Name).Observe(time.Since(start).Seconds())
 			if done {
@@ -388,13 +395,13 @@ func (s *Server) cleanupRepos() {
 		return filepath.SkipDir
 	})
 	if err != nil {
-		log15.Error("cleanup: error iterating over repositories", "error", err)
+		cleanupLogger.Error("error iterating over repositories", log.Error(err))
 	}
 
 	if b, err := json.Marshal(stats); err != nil {
-		log15.Error("cleanup: failed to marshal periodic stats", "error", err)
+		cleanupLogger.Error("failed to marshal periodic stats", log.Error(err))
 	} else if err = os.WriteFile(filepath.Join(s.ReposDir, reposStatsName), b, 0666); err != nil {
-		log15.Error("cleanup: failed to write periodic stats", "error", err)
+		cleanupLogger.Error("failed to write periodic stats", log.Error(err))
 	}
 
 	// Repo sizes are set only once during the first janitor run.
@@ -402,7 +409,7 @@ func (s *Server) cleanupRepos() {
 	s.setRepoSizesOnce.Do(func() {
 		err = s.setRepoSizes(context.Background(), repoToSize)
 		if err != nil {
-			log15.Error("cleanup: setting repo sizes", "error", err)
+			cleanupLogger.Error("setting repo sizes", log.Error(err))
 		}
 	})
 
@@ -411,20 +418,21 @@ func (s *Server) cleanupRepos() {
 	}
 	b, err := s.howManyBytesToFree()
 	if err != nil {
-		log15.Error("cleanup: ensuring free disk space", "error", err)
+		cleanupLogger.Error("ensuring free disk space", log.Error(err))
 	}
 	if err := s.freeUpSpace(b); err != nil {
-		log15.Error("cleanup: error freeing up space", "error", err)
+		cleanupLogger.Error("error freeing up space", log.Error(err))
 	}
 }
 
 // setRepoSizes uses calculated sizes of repos to update database entries of repos with repo_size_bytes = NULL
 func (s *Server) setRepoSizes(ctx context.Context, repoToSize map[api.RepoName]int64) error {
 	if len(repoToSize) == 0 {
-		log15.Info("cleanup: file system walk didn't yield any directory sizes")
+		s.Logger.Info("cleanup: file system walk didn't yield any directory sizes")
 		return nil
 	}
-	log15.Info(fmt.Sprintf("cleanup: %v directory sizes calculated during file system walk", len(repoToSize)))
+
+	s.Logger.With(log.Int("repoToSize", len(repoToSize))).Info("cleanup: directory sizes calculated during file system walk")
 
 	db := s.DB
 	gitserverRepos := db.GitserverRepos()
@@ -434,7 +442,7 @@ func (s *Server) setRepoSizes(ctx context.Context, repoToSize map[api.RepoName]i
 		return err
 	}
 	if len(reposWithoutSize) == 0 {
-		log15.Info("cleanup: all repos in the DB have their sizes")
+		s.Logger.Info("cleanup: all repos in the DB have their sizes")
 		return nil
 	}
 
@@ -451,7 +459,7 @@ func (s *Server) setRepoSizes(ctx context.Context, repoToSize map[api.RepoName]i
 	if err != nil {
 		return err
 	}
-	log15.Info(fmt.Sprintf("cleanup: %v repos had their sizes updated", len(reposToUpdate)))
+	s.Logger.With(log.Int("reposToUpdate", len(reposToUpdate))).Info("cleanup: repos had their sizes updated")
 	return nil
 }
 
@@ -480,10 +488,15 @@ func (s *Server) howManyBytesToFree() (int64, error) {
 		howManyBytesToFree = 0
 	}
 	const G = float64(1024 * 1024 * 1024)
-	log15.Debug("cleanup",
-		"desired percent free", s.DesiredPercentFree,
-		"actual percent free", float64(actualFreeBytes)/float64(diskSizeBytes)*100.0,
-		"amount to free in GiB", float64(howManyBytesToFree)/G)
+
+	logger := s.Logger.With(
+		log.Int("desired percent free", s.DesiredPercentFree),
+		log.Float64("actual percent free", float64(actualFreeBytes)/float64(diskSizeBytes)*100.0),
+		log.Float64("amount to free in GiB", float64(howManyBytesToFree)/G),
+	)
+
+	logger.Debug("cleanup")
+
 	return howManyBytesToFree, nil
 }
 
@@ -556,14 +569,17 @@ func (s *Server) freeUpSpace(howManyBytesToFree int64) error {
 			return errors.Wrap(err, "finding the amount of space free on disk")
 		}
 		G := float64(1024 * 1024 * 1024)
-		log15.Warn("cleanup: removed least recently used repo",
-			"repo", d,
-			"how old", time.Since(dirModTimes[d]),
-			"free space in GiB", float64(actualFreeBytes)/G,
-			"actual percent of disk space free", float64(actualFreeBytes)/float64(diskSizeBytes)*100.0,
-			"desired percent of disk space free", float64(s.DesiredPercentFree),
-			"space freed in GiB", float64(spaceFreed)/G,
-			"how much space to free in GiB", float64(howManyBytesToFree)/G)
+
+		logger := s.Logger.With(
+			log.String("repo", string(d)),
+			log.Duration("how old", time.Since(dirModTimes[d])),
+			log.Float64("free space in GiB", float64(actualFreeBytes)/G),
+			log.Float64("actual percent of disk space free", float64(actualFreeBytes)/float64(diskSizeBytes)*100.0),
+			log.Float64("desired percent of disk space free", float64(s.DesiredPercentFree)),
+			log.Float64("space freed in GiB", float64(spaceFreed)/G),
+			log.Float64("how much space to free in GiB", float64(howManyBytesToFree)/G),
+		)
+		logger.Warn("cleanup: removed least recently used repo")
 	}
 
 	// Check.
@@ -656,7 +672,7 @@ func (s *Server) removeRepoDirectory(gitDir GitDir) error {
 	// new clone.
 	rootInfo, err := os.Stat(s.ReposDir)
 	if err != nil {
-		log15.Warn("Failed to stat ReposDir", "error", err)
+		s.Logger.Warn("Failed to stat ReposDir", log.Error(err))
 		return nil
 	}
 	current := dir
@@ -674,7 +690,7 @@ func (s *Server) removeRepoDirectory(gitDir GitDir) error {
 			break
 		}
 		if err != nil {
-			log15.Warn("failed to stat parent directory", "dir", current, "error", err)
+			s.Logger.Warn("failed to stat parent directory", log.String("dir", current), log.Error(err))
 			return nil
 		}
 		if os.SameFile(rootInfo, info) {
@@ -691,7 +707,7 @@ func (s *Server) removeRepoDirectory(gitDir GitDir) error {
 	// Delete the atomically renamed dir. We do this last since if it fails we
 	// will rely on a janitor job to clean up for us.
 	if err := os.RemoveAll(filepath.Join(tmp, "repo")); err != nil {
-		log15.Warn("failed to cleanup after removing dir", "dir", dir, "error", err)
+		s.Logger.Warn("failed to cleanup after removing dir", log.String("dir", dir), log.Error(err))
 	}
 
 	return nil
@@ -721,7 +737,7 @@ func (s *Server) cleanTmpFiles(dir GitDir) {
 		return nil
 	})
 	if err != nil {
-		log15.Error("error removing tmp_pack_* files", "error", err)
+		s.Logger.Error("error removing tmp_pack_* files", log.Error(err))
 	}
 }
 
@@ -755,7 +771,7 @@ func (s *Server) SetupAndClearTmp() (string, error) {
 	// Asynchronously remove old temporary directories
 	files, err := os.ReadDir(s.ReposDir)
 	if err != nil {
-		log15.Error("failed to do tmp cleanup", "error", err)
+		s.Logger.Error("failed to do tmp cleanup", log.Error(err))
 	} else {
 		for _, f := range files {
 			// Remove older .tmp directories as well as our older tmp-
@@ -766,7 +782,7 @@ func (s *Server) SetupAndClearTmp() (string, error) {
 			}
 			go func(path string) {
 				if err := os.RemoveAll(path); err != nil {
-					log15.Error("cleanup: failed to remove old temporary directory", "path", path, "error", err)
+					s.Logger.Error("cleanup: failed to remove old temporary directory", log.String("path", path), log.Error(err))
 				}
 			}(filepath.Join(s.ReposDir, f.Name()))
 		}
@@ -843,14 +859,15 @@ func checkMaybeCorruptRepo(repo api.RepoName, dir GitDir, stderr string) {
 	if !maybeCorruptStderrRe.MatchString(stderr) {
 		return
 	}
+	logger := log.Scoped("checkMaybeCorruptRepo", "check if repo is corrupt").With(log.String("repo", string(repo)))
 
-	log15.Warn("marking repo for re-cloning due to stderr output indicating repo corruption", "repo", repo, "stderr", stderr)
+	logger.Warn("marking repo for re-cloning due to stderr output indicating repo corruption", log.String("stderr", stderr))
 
 	// We set a flag in the config for the cleanup janitor job to fix. The janitor
 	// runs every minute.
 	err := gitConfigSet(dir, gitConfigMaybeCorrupt, strconv.FormatInt(time.Now().Unix(), 10))
 	if err != nil {
-		log15.Error("failed to set maybeCorruptRepo config", repo, "repo", "error", err)
+		logger.Error("failed to set maybeCorruptRepo config", log.Error(err))
 	}
 }
 
@@ -935,7 +952,7 @@ func bestEffortParseFailed(b []byte) int {
 // concurrently with git gc. sgMaintenance will check the state of the repository
 // to avoid running the cleanup tasks if possible. If a sgmLog file is present in
 // dir, sgMaintenance will not run unless the file is old.
-func sgMaintenance(dir GitDir) (err error) {
+func sgMaintenance(logger log.Logger, dir GitDir) (err error) {
 	// Don't run if sgmLog file is younger than sgmLogExpire hours. There is no need
 	// to report an error, because the error has already been logged in a previous
 	// run.
@@ -963,9 +980,9 @@ func sgMaintenance(dir GitDir) (err error) {
 	b, err := cmd.CombinedOutput()
 	if err != nil {
 		if err := writeSGMLog(dir, b); err != nil {
-			log15.Debug("sg maintenance failed to write log file", "file", dir.Path(sgmLog), "err", err)
+			logger.Debug("sg maintenance failed to write log file", log.String("file", dir.Path(sgmLog)), log.Error(err))
 		}
-		log15.Debug("sg maintenance", "dir", dir, "out", string(b))
+		logger.Debug("sg maintenance", log.String("dir", string(dir)), log.String("out", string(b)))
 		return errors.Wrapf(wrapCmdError(cmd, err), "failed to run sg maintenance")
 	}
 	// Remove the log file after a successful run.
@@ -1199,7 +1216,9 @@ func removeFileOlderThan(path string, maxAge time.Duration) error {
 		return nil
 	}
 
-	log15.Debug("removing stale lock file", "path", path, "age", age)
+	logger := log.Scoped("removeFileOlderThan", "removes path if its mtime is older than maxAge.")
+
+	logger.Debug("removing stale lock file", log.String("path", path), log.Duration("age", age))
 	err = os.Remove(path)
 	if err != nil && !os.IsNotExist(err) {
 		return err

--- a/cmd/gitserver/server/commands.go
+++ b/cmd/gitserver/server/commands.go
@@ -4,26 +4,26 @@ import (
 	"encoding/json"
 	"net/http"
 
-	"github.com/inconshreveable/log15"
-
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/protocol"
+	"github.com/sourcegraph/sourcegraph/lib/log"
 )
 
 func handleGetObject(getObject gitdomain.GetObjectFunc) func(w http.ResponseWriter, r *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 		var req protocol.GetObjectRequest
+		logger := log.Scoped("handleGetObject", "handles get object")
 
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 			http.Error(w, "decoding body", http.StatusBadRequest)
-			log15.Error("handleGetObject: decoding body", "error", err)
+			logger.Error("decoding body", log.Error(err))
 			return
 		}
 
 		obj, err := getObject(r.Context(), req.Repo, req.ObjectName)
 		if err != nil {
 			http.Error(w, "getting object", http.StatusInternalServerError)
-			log15.Error("handleGetObject: getting object", "error", err)
+			logger.Error("getting object", log.Error(err))
 			return
 		}
 
@@ -32,7 +32,7 @@ func handleGetObject(getObject gitdomain.GetObjectFunc) func(w http.ResponseWrit
 		}
 
 		if err := json.NewEncoder(w).Encode(resp); err != nil {
-			log15.Error("handleGetObject: sending response", "error", err)
+			logger.Error("sending response", log.Error(err))
 		}
 	}
 }

--- a/cmd/gitserver/server/gitservice.go
+++ b/cmd/gitserver/server/gitservice.go
@@ -6,7 +6,6 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/inconshreveable/log15"
 	"github.com/mxk/go-flowrate/flowrate"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
@@ -18,6 +17,7 @@ import (
 )
 
 var gitServiceMaxEgressBytesPerSecond = func() int64 {
+	logger := log.Scoped("gitServiceMaxEgressBytesPerSecond", "git service max egress bytes per second")
 	bps, err := strconv.ParseInt(env.Get(
 		"SRC_GIT_SERVICE_MAX_EGRESS_BYTES_PER_SECOND",
 		"1000000000",
@@ -26,7 +26,7 @@ var gitServiceMaxEgressBytesPerSecond = func() int64 {
 		64,
 	)
 	if err != nil {
-		log15.Error("gitservice: failed parsing SRC_GIT_SERVICE_MAX_EGRESS_BYTES_PER_SECOND. defaulting to 1Gbps", "error", err)
+		logger.Error("gitservice: failed parsing SRC_GIT_SERVICE_MAX_EGRESS_BYTES_PER_SECOND. defaulting to 1Gbps", log.Int64("bps", bps), log.Error(err))
 		bps = 1000 * 1000 * 1000 // 1Gbps
 	}
 	return bps
@@ -73,10 +73,17 @@ func (s *Server) gitServiceHandler() *gitservice.Handler {
 				metricServiceRunning.WithLabelValues(svc).Dec()
 				metricServiceDuration.WithLabelValues(svc, errLabel).Observe(time.Since(start).Seconds())
 
+				logger := s.Logger.With(
+					log.String("svc", svc),
+					log.String("repo", repo),
+					log.String("protocol", protocol),
+					log.Duration("duration", time.Since(start)),
+				)
+
 				if err != nil {
-					log15.Error("gitservice.ServeHTTP", "svc", svc, "repo", repo, "protocol", protocol, "duration", time.Since(start), "error", err.Error())
+					logger.Error("gitservice.ServeHTTP", log.Error(err))
 				} else if traceLogs {
-					log15.Debug("TRACE gitserver git service", "svc", svc, "repo", repo, "protocol", protocol, "duration", time.Since(start))
+					logger.Debug("TRACE gitserver git service")
 				}
 			}
 		},

--- a/cmd/gitserver/server/repo_info.go
+++ b/cmd/gitserver/server/repo_info.go
@@ -8,13 +8,12 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/inconshreveable/log15"
-
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"github.com/sourcegraph/sourcegraph/lib/log"
 )
 
 func (s *Server) repoInfo(ctx context.Context, repo api.RepoName) (*protocol.RepoInfo, error) {
@@ -44,19 +43,19 @@ func (s *Server) repoInfo(ctx context.Context, repo api.RepoName) (*protocol.Rep
 	}
 	if resp.Cloned {
 		if mtime, err := repoLastFetched(dir); err != nil {
-			log15.Warn("error computing last-fetched date", "repo", repo, "err", err)
+			s.Logger.Warn("error computing last-fetched date", log.String("repo", string(repo)), log.Error(err))
 		} else {
 			resp.LastFetched = &mtime
 		}
 
 		if cloneTime, err := getRecloneTime(dir); err != nil {
-			log15.Warn("error getting re-clone time", "repo", repo, "err", err)
+			s.Logger.Warn("error getting re-clone time", log.String("repo", string(repo)), log.Error(err))
 		} else {
 			resp.CloneTime = &cloneTime
 		}
 
 		if lastChanged, err := repoLastChanged(dir); err != nil {
-			log15.Warn("error getting last changed", "repo", repo, "err", err)
+			s.Logger.Warn("error getting last changed", log.String("repo", string(repo)), log.Error(err))
 		} else {
 			resp.LastChanged = &lastChanged
 		}
@@ -147,11 +146,11 @@ func (s *Server) handleRepoDelete(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := s.deleteRepo(r.Context(), req.Repo); err != nil {
-		log15.Error("failed to delete repository", "repo", req.Repo, "error", err)
+		s.Logger.Error("failed to delete repository", log.String("repo", string(req.Repo)), log.Error(err))
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	log15.Info("deleted repository", "repo", req.Repo)
+	s.Logger.Info("deleted repository", log.String("repo", string(req.Repo)))
 }
 
 func (s *Server) deleteRepo(ctx context.Context, repo api.RepoName) error {

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -27,9 +27,7 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/inconshreveable/log15"
 	"github.com/opentracing/opentracing-go/ext"
-	"github.com/opentracing/opentracing-go/log"
 	otlog "github.com/opentracing/opentracing-go/log"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
@@ -59,6 +57,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/internal/vcs"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"github.com/sourcegraph/sourcegraph/lib/log"
 )
 
 // tempDirName is the name used for the temporary directory under ReposDir.
@@ -187,6 +186,10 @@ func NewCloneQueue(jobs *list.List) *cloneQueue {
 
 // Server is a gitserver server.
 type Server struct {
+	// Logger is a standardized, strongly-typed, and structured logging interface
+	// Production output from this logger (SRC_LOG_FORMAT=json) complies with the OpenTelemetry log data model
+	Logger log.Logger
+
 	// ReposDir is the path to the base directory for gitserver storage.
 	ReposDir string
 
@@ -433,7 +436,7 @@ func (s *Server) SyncRepoState(interval time.Duration, batchSize, perSecond int)
 			gitServerAddrs.PinnedServers = cfg.ExperimentalFeatures.GitServerPinnedRepos
 		}
 		if err := s.syncRepoState(gitServerAddrs, batchSize, perSecond, fullSync); err != nil {
-			log15.Error("Syncing repo state", "error ", err)
+			s.Logger.Error("Syncing repo state", log.Error(err))
 		}
 
 		time.Sleep(interval)
@@ -474,7 +477,7 @@ func (s *Server) cloneJobProducer(ctx context.Context, jobs chan<- *cloneJob) {
 			select {
 			case jobs <- job:
 			case <-ctx.Done():
-				log15.Error("cloneJobProducer: ", "error", ctx.Err())
+				s.Logger.Error("cloneJobProducer: ", log.Error(ctx.Err()))
 				return
 			}
 		}
@@ -485,14 +488,14 @@ func (s *Server) cloneJobConsumer(ctx context.Context, jobs <-chan *cloneJob) {
 	for j := range jobs {
 		select {
 		case <-ctx.Done():
-			log15.Error("cloneJobConsumer: ", "error", ctx.Err())
+			s.Logger.Error("cloneJobConsumer: ", log.Error(ctx.Err()))
 			return
 		default:
 		}
 
 		ctx, cancel, err := s.acquireCloneLimiter(ctx)
 		if err != nil {
-			log15.Error("cloneJobConsumer: ", "error", err)
+			s.Logger.Error("cloneJobConsumer: ", log.Error(err))
 			continue
 		}
 
@@ -501,7 +504,7 @@ func (s *Server) cloneJobConsumer(ctx context.Context, jobs <-chan *cloneJob) {
 
 			err := s.doClone(ctx, job.repo, job.dir, job.syncer, job.lock, job.remoteURL, job.options)
 			if err != nil {
-				log15.Error("failed to clone repo", "repo", job.repo, "error", err)
+				s.Logger.Error("failed to clone repo", log.String("repo", string(job.repo)), log.Error(err))
 			}
 
 			s.setLastErrorNonFatal(ctx, job.repo, err)
@@ -536,7 +539,7 @@ var (
 )
 
 func (s *Server) syncRepoState(gitServerAddrs gitserver.GitServerAddresses, batchSize, perSecond int, fullSync bool) error {
-	log15.Info("starting syncRepoState", "fullSync", fullSync)
+	s.Logger.Info("starting syncRepoState", log.Bool("fullSync", fullSync))
 	addrs := gitServerAddrs.Addresses
 
 	// When fullSync is true we'll scan all repos in the database and ensure we set
@@ -586,13 +589,13 @@ func (s *Server) syncRepoState(gitServerAddrs gitserver.GitServerAddresses, batc
 		}()
 		err := limiter.WaitN(ctx, len(batch))
 		if err != nil {
-			log15.Error("Waiting for rate limiter", "error", err)
+			s.Logger.Error("Waiting for rate limiter", log.Error(err))
 			return
 		}
 
 		if err := store.Upsert(ctx, batch...); err != nil {
 			repoStateUpsertCounter.WithLabelValues("false").Add(float64(len(batch)))
-			log15.Error("Upserting GitserverRepos", "error", err)
+			s.Logger.Error("Upserting GitserverRepos", log.Error(err))
 			return
 		}
 		repoStateUpsertCounter.WithLabelValues("true").Add(float64(len(batch)))
@@ -863,7 +866,7 @@ func (s *Server) handleRepoUpdate(w http.ResponseWriter, r *http.Request) {
 		// the implementation details of cloneRepo.
 		_, err := s.cloneRepo(ctx, req.Repo, &cloneOptions{Block: true, CloneFromShard: req.CloneFromShard})
 		if err != nil {
-			log15.Warn("error cloning repo", "repo", req.Repo, "err", err)
+			s.Logger.Warn("error cloning repo", log.String("repo", string(req.Repo)), log.Error(err))
 			resp.Error = err.Error()
 		}
 	} else {
@@ -889,7 +892,7 @@ func (s *Server) handleRepoUpdate(w http.ResponseWriter, r *http.Request) {
 			resp.LastChanged = &lastChanged
 		}
 		if statusErr != nil {
-			log15.Error("failed to get status of repo", "repo", req.Repo, "error", statusErr)
+			s.Logger.Error("failed to get status of repo", log.String("repo", string(req.Repo)), log.Error(statusErr))
 			// report this error in-band, but still produce a valid response with the
 			// other information.
 			resp.Error = statusErr.Error()
@@ -919,13 +922,13 @@ func (s *Server) handleArchive(w http.ResponseWriter, r *http.Request) {
 
 	if err := checkSpecArgSafety(treeish); err != nil {
 		w.WriteHeader(http.StatusBadRequest)
-		log15.Error("gitserver.archive.CheckSpecArgSafety", "error", err)
+		s.Logger.Error("gitserver.archive.CheckSpecArgSafety", log.Error(err))
 		return
 	}
 
 	if repo == "" || format == "" {
 		w.WriteHeader(http.StatusBadRequest)
-		log15.Error("gitserver.archive", "error", "empty repo or format")
+		s.Logger.Error("gitserver.archive", log.String("error", "empty repo or format"))
 		return
 	}
 
@@ -1000,7 +1003,7 @@ func (s *Server) handleSearch(w http.ResponseWriter, r *http.Request) {
 	// Run the search
 	limitHit, searchErr := s.search(ctx, &args, matchesBuf)
 	if writeErr := eventWriter.Event("done", protocol.NewSearchEventDone(limitHit, searchErr)); writeErr != nil {
-		log15.Error("failed to send done event", "error", writeErr)
+		s.Logger.Error("failed to send done event", log.Error(writeErr))
 	}
 	tr.LogFields(otlog.Bool("limit_hit", limitHit))
 	tr.SetError(searchErr)
@@ -1031,7 +1034,7 @@ func (s *Server) handleSearch(w http.ResponseWriter, r *http.Request) {
 			_ = ev.Send()
 		}
 		if traceLogs {
-			log15.Debug("TRACE gitserver search", mapToLog15Ctx(ev.Fields())...)
+			s.Logger.Debug("TRACE gitserver search", log.Object("ev.Fields", mapToLoggerField(ev.Fields())...))
 		}
 	}
 }
@@ -1047,7 +1050,7 @@ func (s *Server) search(ctx context.Context, args *protocol.SearchRequest, match
 	dir := s.dir(args.Repo)
 	if !repoCloned(dir) {
 		if conf.Get().DisableAutoGitUpdates {
-			log15.Debug("not cloning on demand as DisableAutoGitUpdates is set")
+			s.Logger.Debug("not cloning on demand as DisableAutoGitUpdates is set")
 			return false, &gitdomain.RepoNotExistError{
 				Repo: args.Repo,
 			}
@@ -1064,7 +1067,7 @@ func (s *Server) search(ctx context.Context, args *protocol.SearchRequest, match
 
 		cloneProgress, err := s.cloneRepo(ctx, args.Repo, nil)
 		if err != nil {
-			log15.Debug("error starting repo clone", "repo", args.Repo, "err", err)
+			s.Logger.Debug("error starting repo clone", log.String("repo", string(args.Repo)), log.Error(err))
 			return false, &gitdomain.RepoNotExistError{
 				Repo:            args.Repo,
 				CloneInProgress: false,
@@ -1187,15 +1190,15 @@ func (s *Server) handleBatchLog(w http.ResponseWriter, r *http.Request) {
 	performGitLogCommand := func(ctx context.Context, repoCommit api.RepoCommit, format string) (output string, isRepoCloned bool, err error) {
 		ctx, _, endObservation := operations.batchLogSingle.With(ctx, &err, observation.Args{
 			LogFields: append(
-				[]log.Field{
-					log.String("format", format),
+				[]otlog.Field{
+					otlog.String("format", format),
 				},
 				repoCommit.LogFields()...,
 			),
 		})
 		defer func() {
-			endObservation(1, observation.Args{LogFields: []log.Field{
-				log.Bool("isRepoCloned", isRepoCloned),
+			endObservation(1, observation.Args{LogFields: []otlog.Field{
+				otlog.Bool("isRepoCloned", isRepoCloned),
 			}})
 		}()
 
@@ -1220,8 +1223,8 @@ func (s *Server) handleBatchLog(w http.ResponseWriter, r *http.Request) {
 	instrumentedHandler := func(ctx context.Context) (statusCodeOnError int, err error) {
 		ctx, logger, endObservation := operations.batchLog.With(ctx, &err, observation.Args{})
 		defer func() {
-			endObservation(1, observation.Args{LogFields: []log.Field{
-				log.Int("statusCodeOnError", statusCodeOnError),
+			endObservation(1, observation.Args{LogFields: []otlog.Field{
+				otlog.Int("statusCodeOnError", statusCodeOnError),
 			}})
 		}()
 
@@ -1348,10 +1351,10 @@ func (s *Server) exec(w http.ResponseWriter, r *http.Request, req *protocol.Exec
 
 	// 🚨 SECURITY: Ensure that only commands in the allowed list are executed.
 	// See https://github.com/sourcegraph/security-issues/issues/213.
-	if !gitdomain.IsAllowedGitCmd(req.Args) {
+	if !gitdomain.IsAllowedGitCmd(s.Logger, req.Args) {
 		blockedCommandExecutedCounter.Inc()
 
-		log15.Warn("exec: bad command", "RemoteAddr", r.RemoteAddr, "req.Args", req.Args)
+		s.Logger.Warn("exec: bad command", log.String("RemoteAddr", r.RemoteAddr), log.Strings("req.Args", req.Args))
 
 		// Temporary feature flag to disable this feature in case their are any regressions.
 		if conf.ExperimentalFeatures().EnableGitServerCommandExecFilter {
@@ -1451,14 +1454,15 @@ func (s *Server) exec(w http.ResponseWriter, r *http.Request, req *protocol.Exec
 				if honey.Enabled() {
 					_ = ev.Send()
 				}
+
 				if traceLogs {
-					log15.Debug("TRACE gitserver exec", mapToLog15Ctx(ev.Fields())...)
+					s.Logger.Debug("TRACE gitserver exec", log.Object("ev.Fields", mapToLoggerField(ev.Fields())...))
 				}
 				if isSlow {
-					log15.Warn("Long exec request", mapToLog15Ctx(ev.Fields())...)
+					s.Logger.Warn("Long exec request", log.Object("ev.Fields", mapToLoggerField(ev.Fields())...))
 				}
 				if isSlowFetch {
-					log15.Warn("Slow fetch/clone for exec request", mapToLog15Ctx(ev.Fields())...)
+					s.Logger.Warn("Slow fetch/clone for exec request", log.Object("ev.Fields", mapToLoggerField(ev.Fields())...))
 				}
 			}
 		}()
@@ -1467,7 +1471,7 @@ func (s *Server) exec(w http.ResponseWriter, r *http.Request, req *protocol.Exec
 	dir := s.dir(req.Repo)
 	if !repoCloned(dir) {
 		if conf.Get().DisableAutoGitUpdates {
-			log15.Debug("not cloning on demand as DisableAutoGitUpdates is set")
+			s.Logger.Debug("not cloning on demand as DisableAutoGitUpdates is set")
 			status = "repo-not-found"
 			w.WriteHeader(http.StatusNotFound)
 			_ = json.NewEncoder(w).Encode(&protocol.NotFoundPayload{})
@@ -1487,7 +1491,7 @@ func (s *Server) exec(w http.ResponseWriter, r *http.Request, req *protocol.Exec
 
 		cloneProgress, err := s.cloneRepo(ctx, req.Repo, nil)
 		if err != nil {
-			log15.Debug("error starting repo clone", "repo", req.Repo, "err", err)
+			s.Logger.Debug("error starting repo clone", log.String("repo", string(req.Repo)), log.Error(err))
 			status = "repo-not-found"
 			w.WriteHeader(http.StatusNotFound)
 			_ = json.NewEncoder(w).Encode(&protocol.NotFoundPayload{CloneInProgress: false})
@@ -1683,11 +1687,12 @@ func (s *Server) p4exec(w http.ResponseWriter, r *http.Request, req *protocol.P4
 				}
 
 				_ = ev.Send()
+
 				if traceLogs {
-					log15.Debug("TRACE gitserver p4exec", mapToLog15Ctx(ev.Fields())...)
+					s.Logger.Debug("TRACE gitserver p4exec", log.Object("ev.Fields", mapToLoggerField(ev.Fields())...))
 				}
 				if isSlow {
-					log15.Warn("Long p4exec request", mapToLog15Ctx(ev.Fields())...)
+					s.Logger.Warn("Long p4exec request", log.Object("ev.Fields", mapToLoggerField(ev.Fields())...))
 				}
 			}
 		}()
@@ -1764,7 +1769,7 @@ func (s *Server) setLastErrorNonFatal(ctx context.Context, name api.RepoName, er
 		errString = err.Error()
 	}
 	if err := s.setLastError(ctx, name, errString); err != nil {
-		log15.Warn("Setting last error in DB", "error", err)
+		s.Logger.Warn("Setting last error in DB", log.Error(err))
 	}
 }
 
@@ -1778,7 +1783,7 @@ func (s *Server) setCloneStatus(ctx context.Context, name api.RepoName, status t
 // setCloneStatusNonFatal is the same as setCloneStatus but only logs errors
 func (s *Server) setCloneStatusNonFatal(ctx context.Context, name api.RepoName, status types.CloneStatus) {
 	if err := s.setCloneStatus(ctx, name, status); err != nil {
-		log15.Warn("Setting clone status in DB", "error", err)
+		s.Logger.Warn("Setting clone status in DB", log.Error(err))
 	}
 }
 
@@ -1993,7 +1998,7 @@ func (s *Server) doClone(ctx context.Context, repo api.RepoName, dir GitDir, syn
 
 	// see issue #7322: skip LFS content in repositories with Git LFS configured
 	cmd.Env = append(cmd.Env, "GIT_LFS_SKIP_SMUDGE=1")
-	log15.Info("cloning repo", "repo", repo, "tmp", tmpPath, "dst", dstPath)
+	s.Logger.Info("cloning repo", log.String("repo", string(repo)), log.String("tmp", tmpPath), log.String("dst", dstPath))
 
 	pr, pw := io.Pipe()
 	defer pw.Close()
@@ -2011,7 +2016,7 @@ func (s *Server) doClone(ctx context.Context, repo api.RepoName, dir GitDir, syn
 	removeBadRefs(ctx, tmp)
 
 	if err := setHEAD(ctx, tmp, syncer, repo, remoteURL); err != nil {
-		log15.Error("Failed to ensure HEAD exists", "repo", repo, "error", err)
+		s.Logger.Error("Failed to ensure HEAD exists", log.String("repo", string(repo)), log.Error(err))
 		return errors.Wrap(err, "failed to ensure HEAD exists")
 	}
 
@@ -2047,15 +2052,15 @@ func (s *Server) doClone(ctx context.Context, repo api.RepoName, dir GitDir, syn
 	// Successfully updated, best-effort updating of db fetch state based on
 	// disk state.
 	if err := s.setLastFetched(ctx, repo); err != nil {
-		log15.Warn("failed setting last fetch in DB", "repo", repo, "error", err)
+		s.Logger.Warn("failed setting last fetch in DB", log.String("repo", string(repo)), log.Error(err))
 	}
 
 	// Successfully updated, best-effort calculation of the repo size.
 	if err := s.setRepoSize(ctx, repo); err != nil {
-		log15.Warn("failed setting repo size", "repo", repo, "error", err)
+		s.Logger.Warn("failed setting repo size", log.String("repo", string(repo)), log.Error(err))
 	}
 
-	log15.Info("repo cloned", "repo", repo)
+	s.Logger.Info("repo cloned", log.String("repo", string(repo)))
 	repoClonedCounter.Inc()
 
 	return nil
@@ -2066,13 +2071,14 @@ func (s *Server) doClone(ctx context.Context, repo api.RepoName, dir GitDir, syn
 func readCloneProgress(redactor *urlRedactor, lock *RepositoryLock, pr io.Reader, repo api.RepoName) {
 	var logFile *os.File
 	var err error
+	logger := log.Scoped("readCloneProgress", "scans the reader and saves the most recent line of output")
 
 	if conf.Get().CloneProgressLog {
 		logFile, err = os.CreateTemp("", "")
 		if err != nil {
-			log15.Warn("failed to create temporary clone log file", "error", err, "repo", repo)
+			logger.Warn("failed to create temporary clone log file", log.Error(err), log.String("repo", string(repo)))
 		} else {
-			log15.Info("logging clone output", "file", logFile.Name(), "repo", repo)
+			logger.Info("logging clone output", log.String("file", logFile.Name()), log.String("repo", string(repo)))
 			defer logFile.Close()
 		}
 	}
@@ -2100,7 +2106,7 @@ func readCloneProgress(redactor *urlRedactor, lock *RepositoryLock, pr io.Reader
 		}
 	}
 	if err := scan.Err(); err != nil {
-		log15.Error("error reporting progress", "error", err)
+		logger.Error("error reporting progress", log.Error(err))
 	}
 }
 
@@ -2260,7 +2266,7 @@ func (s *Server) doRepoUpdate(ctx context.Context, repo api.RepoName) error {
 	defer span.Finish()
 
 	if msg, ok := isPaused(filepath.Join(s.ReposDir, string(protocol.NormalizeRepo(repo)))); ok {
-		log15.Warn("doRepoUpdate paused", "repo", repo, "reason", msg)
+		s.Logger.Warn("doRepoUpdate paused", log.String("repo", string(repo)), log.String("reason", msg))
 		return nil
 	}
 
@@ -2294,7 +2300,7 @@ func (s *Server) doRepoUpdate(ctx context.Context, repo api.RepoName) error {
 
 			err = s.doBackgroundRepoUpdate(repo)
 			if err != nil {
-				log15.Error("performing background repo update", "error", err)
+				s.Logger.Error("performing background repo update", log.Error(err))
 			}
 			ctx, cancel := s.serverContext()
 			defer cancel()
@@ -2359,14 +2365,14 @@ func (s *Server) doBackgroundRepoUpdate(repo api.RepoName) error {
 
 	err = syncer.Fetch(ctx, remoteURL, dir)
 	if err != nil {
-		log15.Error("Failed to fetch", "repo", repo, "error", err)
+		s.Logger.Error("Failed to fetch", log.String("repo", string(repo)), log.Error(err))
 		return errors.Wrap(err, "failed to fetch")
 	}
 
 	removeBadRefs(ctx, dir)
 
 	if err := setHEAD(ctx, dir, syncer, repo, remoteURL); err != nil {
-		log15.Error("Failed to ensure HEAD exists", "repo", repo, "error", err)
+		s.Logger.Error("Failed to ensure HEAD exists", log.String("repo", string(repo)), log.Error(err))
 		return errors.Wrap(err, "failed to ensure HEAD exists")
 	}
 
@@ -2376,18 +2382,18 @@ func (s *Server) doBackgroundRepoUpdate(repo api.RepoName) error {
 
 	// Update the last-changed stamp.
 	if err := setLastChanged(dir); err != nil {
-		log15.Warn("Failed to update last changed time", "repo", repo, "error", err)
+		s.Logger.Warn("Failed to update last changed time", log.String("repo", string(repo)), log.Error(err))
 	}
 
 	// Successfully updated, best-effort updating of db fetch state based on
 	// disk state.
 	if err := s.setLastFetched(ctx, repo); err != nil {
-		log15.Warn("failed setting last fetch in DB", "repo", repo, "error", err)
+		s.Logger.Warn("failed setting last fetch in DB", log.String("repo", string(repo)), log.Error(err))
 	}
 
 	// Successfully updated, best-effort calculation of the repo size.
 	if err := s.setRepoSize(ctx, repo); err != nil {
-		log15.Warn("failed setting repo size", "repo", repo, "error", err)
+		s.Logger.Warn("failed setting repo size", log.String("repo", string(repo)), log.Error(err))
 	}
 
 	return nil
@@ -2452,6 +2458,7 @@ func setHEAD(ctx context.Context, dir GitDir, syncer VCSSyncer, repo api.RepoNam
 
 	// Fallback to git's default branch name if git remote show fails.
 	headBranch := "master"
+	logger := log.Scoped("setHEAD", "configures git repo defaults (such as what HEAD is) which are needed for git commands to work.")
 
 	// try to fetch HEAD from origin
 	cmd, err := syncer.RemoteShowCommand(ctx, remoteURL)
@@ -2461,7 +2468,7 @@ func setHEAD(ctx context.Context, dir GitDir, syncer VCSSyncer, repo api.RepoNam
 	dir.Set(cmd)
 	output, err := runWithRemoteOpts(ctx, cmd, nil)
 	if err != nil {
-		log15.Error("Failed to fetch remote info", "repo", repo, "error", err, "output", string(output))
+		logger.Error("Failed to fetch remote info", log.String("repo", string(repo)), log.Error(err), log.String("output", string(output)))
 		return errors.Wrap(err, "failed to fetch remote info")
 	}
 
@@ -2482,7 +2489,7 @@ func setHEAD(ctx context.Context, dir GitDir, syncer VCSSyncer, repo api.RepoNam
 		dir.Set(cmd)
 		list, err := cmd.Output()
 		if err != nil {
-			log15.Error("Failed to list branches", "repo", repo, "error", err, "output", string(output))
+			logger.Error("Failed to list branches", log.String("repo", string(repo)), log.Error(err), log.String("output", string(output)))
 			return errors.Wrap(err, "failed to list branches")
 		}
 		lines := strings.Split(string(list), "\n")
@@ -2496,7 +2503,7 @@ func setHEAD(ctx context.Context, dir GitDir, syncer VCSSyncer, repo api.RepoNam
 	cmd = exec.CommandContext(ctx, "git", "symbolic-ref", "HEAD", "refs/heads/"+headBranch)
 	dir.Set(cmd)
 	if output, err := cmd.CombinedOutput(); err != nil {
-		log15.Error("Failed to set HEAD", "repo", repo, "error", err, "output", string(output))
+		logger.Error("Failed to set HEAD", log.String("repo", string(repo)), log.Error(err), log.String("output", string(output)))
 		return errors.Wrap(err, "Failed to set HEAD")
 	}
 
@@ -2561,6 +2568,7 @@ func setLastChanged(dir GitDir) error {
 // commit if any. If there are no commits or the latest commit is in the
 // future, or there is any error, time.Now is returned.
 func computeLatestCommitTimestamp(dir GitDir) time.Time {
+	logger := log.Scoped("computeLatestCommitTimestamp", "eturns the timestamp of the most recent commit if any")
 	now := time.Now() // return current time if we don't find a more accurate time
 	cmd := exec.Command("git", "rev-list", "--all", "--timestamp", "-n", "1")
 	dir.Set(cmd)
@@ -2568,7 +2576,7 @@ func computeLatestCommitTimestamp(dir GitDir) time.Time {
 	// If we don't have a more specific stamp, we'll return the current time,
 	// and possibly an error.
 	if err != nil {
-		log15.Warn("computeLatestCommitTimestamp: failed to execute, defaulting to time.Now", "repo", dir, "error", err)
+		logger.Warn("computeLatestCommitTimestamp: failed to execute, defaulting to time.Now", log.String("repo", string(dir)), log.Error(err))
 		return now
 	}
 
@@ -2582,7 +2590,7 @@ func computeLatestCommitTimestamp(dir GitDir) time.Time {
 	// 1521316105 ff03fac223b7f16627b301e03bf604e7808989be
 	epoch, err := strconv.ParseInt(string(words[0]), 10, 64)
 	if err != nil {
-		log15.Warn("computeLatestCommitTimestamp: ignoring corrupted timestamp, defaulting to time.Now", "repo", dir, "timestamp", words[0])
+		logger.Warn("computeLatestCommitTimestamp: ignoring corrupted timestamp, defaulting to time.Now", log.String("repo", string(dir)), log.String("timestamp", string(words[0])))
 		return now
 	}
 	stamp := time.Unix(epoch, 0)
@@ -2640,7 +2648,7 @@ func (s *Server) ensureRevision(ctx context.Context, repo api.RepoName, rev stri
 	// Revision not found, update before returning.
 	err := s.doRepoUpdate(ctx, repo)
 	if err != nil {
-		log15.Warn("failed to perform background repo update", "error", err, "repo", repo, "rev", rev)
+		s.Logger.Warn("failed to perform background repo update", log.Error(err), log.String("repo", string(repo)), log.String("rev", rev))
 	}
 	return true
 }

--- a/cmd/gitserver/server/server_test.go
+++ b/cmd/gitserver/server/server_test.go
@@ -34,6 +34,8 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/internal/vcs"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
+
+	"github.com/sourcegraph/sourcegraph/lib/log/logtest"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
@@ -146,6 +148,7 @@ func TestRequest(t *testing.T) {
 	}
 
 	s := &Server{
+		Logger:            logtest.Scoped(t),
 		ReposDir:          "/testroot",
 		skipCloneForTests: true,
 		GetRemoteURLFunc: func(ctx context.Context, name api.RepoName) (string, error) {
@@ -502,8 +505,9 @@ func addCommitToRepo(cmd func(string, ...string) string) string {
 	return cmd("git", "rev-parse", "HEAD")
 }
 
-func makeTestServer(ctx context.Context, repoDir, remote string, db database.DB) *Server {
+func makeTestServer(ctx context.Context, t *testing.T, repoDir, remote string, db database.DB) *Server {
 	s := &Server{
+		Logger:           logtest.Scoped(t).Scoped("server", "test server"),
 		ReposDir:         repoDir,
 		GetRemoteURLFunc: staticGetRemoteURL(remote),
 		GetVCSSyncer: func(ctx context.Context, name api.RepoName) (VCSSyncer, error) {
@@ -572,7 +576,7 @@ func TestCloneRepo(t *testing.T) {
 	cmd("git", "tag", "HEAD")
 
 	reposDir := t.TempDir()
-	s := makeTestServer(ctx, reposDir, remote, db)
+	s := makeTestServer(ctx, t, reposDir, remote, db)
 
 	_, err := s.cloneRepo(ctx, repoName, nil)
 	if err != nil {
@@ -665,7 +669,7 @@ func testHandleRepoDelete(t *testing.T, deletedInDB bool) {
 
 	reposDir := t.TempDir()
 
-	s := makeTestServer(ctx, reposDir, remote, db)
+	s := makeTestServer(ctx, t, reposDir, remote, db)
 
 	// We need some of the side effects here
 	_ = s.Handler()
@@ -781,7 +785,7 @@ func TestHandleRepoUpdate(t *testing.T) {
 
 	reposDir := t.TempDir()
 
-	s := makeTestServer(ctx, reposDir, remote, db)
+	s := makeTestServer(ctx, t, reposDir, remote, db)
 
 	// We need some of the side effects here
 	_ = s.Handler()
@@ -899,12 +903,12 @@ func TestHandleRepoUpdateFromShard(t *testing.T) {
 	cmd("git", "tag", "HEAD")
 
 	// source server
-	srv := httptest.NewServer(makeTestServer(ctx, reposDirSource, remote, db).Handler())
+	srv := httptest.NewServer(makeTestServer(ctx, t, reposDirSource, remote, db).Handler())
 	defer srv.Close()
 
 	// dest server
 	reposDirDest := t.TempDir()
-	s := makeTestServer(ctx, reposDirDest, "", db)
+	s := makeTestServer(ctx, t, reposDirDest, "", db)
 	// We need some of the side effects here
 	_ = s.Handler()
 
@@ -1030,7 +1034,7 @@ func TestCloneRepo_EnsureValidity(t *testing.T) {
 		cmd("git", "init", ".")
 		cmd("rm", ".git/HEAD")
 
-		s := makeTestServer(ctx, reposDir, remote, nil)
+		s := makeTestServer(ctx, t, reposDir, remote, nil)
 		if _, err := s.cloneRepo(ctx, "example.com/foo/bar", nil); err == nil {
 			t.Fatal("expected an error, got none")
 		}
@@ -1048,7 +1052,7 @@ func TestCloneRepo_EnsureValidity(t *testing.T) {
 		cmd("git", "init", ".")
 		cmd("sh", "-c", ": > .git/HEAD")
 
-		s := makeTestServer(ctx, reposDir, remote, nil)
+		s := makeTestServer(ctx, t, reposDir, remote, nil)
 		if _, err := s.cloneRepo(ctx, "example.com/foo/bar", nil); err == nil {
 			t.Fatal("expected an error, got none")
 		}
@@ -1064,7 +1068,7 @@ func TestCloneRepo_EnsureValidity(t *testing.T) {
 		)
 
 		_ = makeSingleCommitRepo(cmd)
-		s := makeTestServer(ctx, reposDir, remote, nil)
+		s := makeTestServer(ctx, t, reposDir, remote, nil)
 
 		testRepoCorrupter = func(_ context.Context, tmpDir GitDir) {
 			if err := os.Remove(tmpDir.Path("HEAD")); err != nil {
@@ -1104,7 +1108,7 @@ func TestCloneRepo_EnsureValidity(t *testing.T) {
 		)
 
 		_ = makeSingleCommitRepo(cmd)
-		s := makeTestServer(ctx, reposDir, remote, nil)
+		s := makeTestServer(ctx, t, reposDir, remote, nil)
 
 		testRepoCorrupter = func(_ context.Context, tmpDir GitDir) {
 			cmd("sh", "-c", fmt.Sprintf(": > %s/HEAD", tmpDir))
@@ -1214,7 +1218,7 @@ func TestSyncRepoState(t *testing.T) {
 	repoName := api.RepoName("example.com/foo/bar")
 	hostname := "test"
 
-	s := makeTestServer(ctx, reposDir, remoteDir, db)
+	s := makeTestServer(ctx, t, reposDir, remoteDir, db)
 	s.Hostname = hostname
 
 	dbRepo := &types.Repo{

--- a/cmd/gitserver/server/servermetrics.go
+++ b/cmd/gitserver/server/servermetrics.go
@@ -6,12 +6,12 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/inconshreveable/log15"
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/metrics"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
+	"github.com/sourcegraph/sourcegraph/lib/log"
 )
 
 func (s *Server) RegisterMetrics(db dbutil.DB, observationContext *observation.Context) {
@@ -22,21 +22,21 @@ func (s *Server) RegisterMetrics(db dbutil.DB, observationContext *observation.C
 		Help: "Duration of executing the echo command.",
 	})
 	prometheus.MustRegister(echoDuration)
-	go func() {
+	go func(server *Server) {
 		for {
 			time.Sleep(10 * time.Second)
 			s := time.Now()
 			if err := exec.Command("echo").Run(); err != nil {
-				log15.Warn("exec measurement failed", "error", err)
+				server.Logger.Warn("exec measurement failed", log.Error(err))
 				continue
 			}
 			echoDuration.Set(time.Since(s).Seconds())
 		}
-	}()
+	}(s)
 
 	// report the size of the repos dir
 	if s.ReposDir == "" {
-		log15.Error("ReposDir is not set, cannot export disk_space_available metric.")
+		s.Logger.Error("ReposDir is not set, cannot export disk_space_available metric.")
 		return
 	}
 
@@ -79,7 +79,7 @@ func (s *Server) RegisterMetrics(db dbutil.DB, observationContext *observation.C
 			WHERE g.last_error IS NOT NULL AND r.deleted_at IS NULL
 		`).Scan(&count)
 		if err != nil {
-			log15.Error("failed to count repository errors", "err", err)
+			s.Logger.Error("failed to count repository errors", log.Error(err))
 			return 0
 		}
 		return float64(count)

--- a/cmd/gitserver/server/serverutil.go
+++ b/cmd/gitserver/server/serverutil.go
@@ -12,12 +12,9 @@ import (
 	"path"
 	"path/filepath"
 	"reflect"
-	"sort"
 	"strings"
 	"sync"
 	"time"
-
-	"github.com/inconshreveable/log15"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
@@ -25,6 +22,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/internal/vcs"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"github.com/sourcegraph/sourcegraph/lib/log"
 )
 
 // GitDir is an absolute path to a GIT_DIR.
@@ -107,6 +105,8 @@ var tlsExternal = conf.Cached(func() any {
 	exp := conf.ExperimentalFeatures()
 	c := exp.TlsExternal
 
+	logger := log.Scoped("tls-external", "Global TLS/SSL settings for Sourcegraph to use when communicating with code hosts.")
+
 	if c == nil {
 		return &tlsConfig{}
 	}
@@ -121,7 +121,7 @@ var tlsExternal = conf.Cached(func() any {
 		// We don't clean up the file since it has a process life time.
 		p, err := writeTempFile("gitserver*.crt", b.Bytes())
 		if err != nil {
-			log15.Error("failed to create file holding tls.external.certificates for git", "error", err)
+			logger.Error("failed to create file holding tls.external.certificates for git", log.Error(err))
 		} else {
 			sslCAInfo = p
 		}
@@ -153,6 +153,8 @@ func runWith(ctx context.Context, cmd *exec.Cmd, configRemoteOpts bool, progress
 		Bytes() []byte
 	}
 
+	logger := log.Scoped("runWith", "runWithRemoteOpts runs the command after applying the remote options.")
+
 	if progress != nil {
 		var pw progressWriter
 		r, w := io.Pipe()
@@ -162,7 +164,7 @@ func runWith(ctx context.Context, cmd *exec.Cmd, configRemoteOpts bool, progress
 		cmd.Stderr = mr
 		go func() {
 			if _, err := io.Copy(progress, r); err != nil {
-				log15.Error("error while copying progress", "error", err)
+				logger.Error("error while copying progress", log.Error(err))
 			}
 		}()
 		b = &pw
@@ -396,9 +398,10 @@ var logUnflushableResponseWriterOnce sync.Once
 func newFlushingResponseWriter(w http.ResponseWriter) *flushingResponseWriter {
 	// We panic if we don't implement the needed interfaces.
 	flusher := hackilyGetHTTPFlusher(w)
+	logger := log.Scoped("newFlushingResponseWriter", "creates a new flushing response writer")
 	if flusher == nil {
 		logUnflushableResponseWriterOnce.Do(func() {
-			log15.Warn("Unable to flush HTTP response bodies. Diff search performance and completeness will be affected.", "type", reflect.TypeOf(w).String())
+			logger.Warn("Unable to flush HTTP response bodies. Diff search performance and completeness will be affected.", log.String("type", reflect.TypeOf(w).String()))
 		})
 		return nil
 	}
@@ -532,23 +535,16 @@ func (w *progressWriter) Bytes() []byte {
 	return w.buf
 }
 
-// mapToLog15Ctx translates a map to log15 context fields.
-func mapToLog15Ctx(m map[string]any) []any {
-	// sort so its stable
-	keys := make([]string, len(m))
-	i := 0
-	for k := range m {
-		keys[i] = k
-		i++
+// mapToLoggerField translates a map to log context fields.
+func mapToLoggerField(m map[string]any) []log.Field {
+	LogFields := []log.Field{}
+
+	for i, v := range m {
+
+		LogFields = append(LogFields, log.String(i, fmt.Sprint(v)))
 	}
-	sort.Strings(keys)
-	ctx := make([]any, len(m)*2)
-	for i, k := range keys {
-		j := i * 2
-		ctx[j] = k
-		ctx[j+1] = m[k]
-	}
-	return ctx
+
+	return LogFields
 }
 
 // isPaused returns true if a file "SG_PAUSE" is present in dir. If the file is
@@ -573,13 +569,14 @@ func isPaused(dir string) (string, bool) {
 // disappears between readdir and the stat of the file. In either case this
 // error can be ignored for best effort code.
 func bestEffortWalk(root string, walkFn func(path string, info fs.FileInfo) error) error {
+	logger := log.Scoped("bestEffortWalk", "bestEffortWalk is a filepath.Walk which ignores errors that can be passed to walkFn.")
 	return filepath.Walk(root, func(path string, info fs.FileInfo, err error) error {
 		if err != nil {
 			return nil
 		}
 
 		if msg, ok := isPaused(path); ok {
-			log15.Warn("bestEffortWalk paused", "dir", path, "reason", msg)
+			logger.Warn("bestEffortWalk paused", log.String("dir", path), log.String("reason", msg))
 			return filepath.SkipDir
 		}
 

--- a/cmd/gitserver/server/ssh_agent.go
+++ b/cmd/gitserver/server/ssh_agent.go
@@ -9,16 +9,17 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/inconshreveable/log15"
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/agent"
 
 	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"github.com/sourcegraph/sourcegraph/lib/log"
 )
 
 // sshAgent speaks the ssh-agent protocol and can be used by gitserver
 // to provide a private key to ssh when talking to the code host.
 type sshAgent struct {
+	logger  log.Logger
 	l       net.Listener
 	sock    string
 	keyring agent.Agent
@@ -55,6 +56,7 @@ func newSSHAgent(raw, passphrase []byte) (*sshAgent, error) {
 
 	// Set up the type we're going to return.
 	a := &sshAgent{
+		logger:  log.Scoped("ssh Agent", "speaks the ssh-agent protocol and can be used by gitserver"),
 		l:       l,
 		sock:    socketName,
 		keyring: keyring,
@@ -73,7 +75,7 @@ func (a *sshAgent) Listen() {
 			case <-a.done:
 				return
 			default:
-				log15.Error("error accepting socket connection", "err", err)
+				a.logger.Error("error accepting socket connection", log.Error(err))
 				return
 			}
 		}
@@ -86,7 +88,7 @@ func (a *sshAgent) Listen() {
 			defer conn.Close()
 
 			if err := agent.ServeAgent(a.keyring, conn); err != nil && err != io.EOF {
-				log15.Error("error serving SSH agent", "err", err)
+				a.logger.Error("error serving SSH agent", log.Error(err))
 			}
 		}(conn)
 	}

--- a/cmd/gitserver/server/vcs_dependencies_syncer.go
+++ b/cmd/gitserver/server/vcs_dependencies_syncer.go
@@ -8,18 +8,18 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/inconshreveable/log15"
-
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/dependencies"
 	"github.com/sourcegraph/sourcegraph/internal/conf/reposource"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
 	"github.com/sourcegraph/sourcegraph/internal/vcs"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"github.com/sourcegraph/sourcegraph/lib/log"
 )
 
 // vcsDependenciesSyncer implements the VCSSyncer interface for dependency repos
 // of different types.
 type vcsDependenciesSyncer struct {
+	logger log.Logger
 	typ    string
 	scheme string
 
@@ -107,7 +107,11 @@ func (s *vcsDependenciesSyncer) Fetch(ctx context.Context, remoteURL *vcs.URL, d
 	for _, version := range versions {
 		if d, err := s.source.Get(ctx, depName, version); err != nil {
 			if errcode.IsNotFound(err) {
-				log15.Warn("skipping missing dependency", "dep", depName, "version", version, "type", s.typ)
+				s.logger.Warn("skipping missing dependency",
+					log.String("dep", depName),
+					log.String("version", version),
+					log.String("type", s.typ),
+				)
 			} else {
 				errs = errors.Append(errs, err)
 			}
@@ -172,7 +176,10 @@ func (s *vcsDependenciesSyncer) Fetch(ctx context.Context, remoteURL *vcs.URL, d
 		if _, isDependencyTag := dependencyTags[tag]; !isDependencyTag {
 			cmd := exec.CommandContext(ctx, "git", "tag", "-d", tag)
 			if _, err := runCommandInDirectory(ctx, cmd, string(dir), s.placeholder); err != nil {
-				log15.Error("failed to delete git tag", "error", err, "tag", tag)
+				s.logger.Error("failed to delete git tag",
+					log.Error(err),
+					log.String("tag", tag),
+				)
 				continue
 			}
 		}
@@ -247,7 +254,7 @@ func (s *vcsDependenciesSyncer) versions(ctx context.Context, packageName string
 	for _, d := range s.configDeps {
 		dep, err := s.source.ParseDependency(d)
 		if err != nil {
-			log15.Warn("skipping malformed dependency", "dep", d, "error", err)
+			s.logger.Warn("skipping malformed dependency", log.String("dep", d), log.Error(err))
 			continue
 		}
 

--- a/cmd/gitserver/server/vcs_dependencies_syncer_test.go
+++ b/cmd/gitserver/server/vcs_dependencies_syncer_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/conf/reposource"
 	"github.com/sourcegraph/sourcegraph/internal/vcs"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"github.com/sourcegraph/sourcegraph/lib/log/logtest"
 )
 
 func TestVcsDependenciesSyncer_Fetch(t *testing.T) {
@@ -33,6 +34,7 @@ func TestVcsDependenciesSyncer_Fetch(t *testing.T) {
 	depsService := &fakeDepsService{deps: map[string][]dependencies.Repo{}}
 
 	s := vcsDependenciesSyncer{
+		logger:      logtest.Scoped(t),
 		typ:         "fake",
 		scheme:      "fake",
 		placeholder: placeholder,

--- a/cmd/gitserver/server/vcs_syncer_go_modules.go
+++ b/cmd/gitserver/server/vcs_syncer_go_modules.go
@@ -16,6 +16,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/gomodproxy"
 	"github.com/sourcegraph/sourcegraph/internal/unpack"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"github.com/sourcegraph/sourcegraph/lib/log"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
@@ -30,6 +31,7 @@ func NewGoModulesSyncer(
 	}
 
 	return &vcsDependenciesSyncer{
+		logger:      log.Scoped("vcs syncer", "csDependenciesSyncer implements the VCSSyncer interface for dependency repos"),
 		typ:         "go_modules",
 		scheme:      dependencies.GoModulesScheme,
 		placeholder: placeholder,

--- a/cmd/gitserver/server/vcs_syncer_jvm_packages.go
+++ b/cmd/gitserver/server/vcs_syncer_jvm_packages.go
@@ -18,6 +18,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/conf/reposource"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/jvmpackages/coursier"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"github.com/sourcegraph/sourcegraph/lib/log"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
@@ -43,6 +44,7 @@ func NewJVMPackagesSyncer(connection *schema.JVMPackagesConnection, svc *depende
 	}
 
 	return &vcsDependenciesSyncer{
+		logger:      log.Scoped("vcs syncer", "csDependenciesSyncer implements the VCSSyncer interface for dependency repos"),
 		typ:         "jvm_packages",
 		scheme:      dependencies.JVMPackagesScheme,
 		placeholder: placeholder,

--- a/cmd/gitserver/server/vcs_syncer_npm_packages.go
+++ b/cmd/gitserver/server/vcs_syncer_npm_packages.go
@@ -8,13 +8,12 @@ import (
 	"os"
 	"path"
 
-	"github.com/inconshreveable/log15"
-
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/dependencies"
 	"github.com/sourcegraph/sourcegraph/internal/conf/reposource"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/npm"
 	"github.com/sourcegraph/sourcegraph/internal/unpack"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"github.com/sourcegraph/sourcegraph/lib/log"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
@@ -31,6 +30,7 @@ func NewNpmPackagesSyncer(
 	}
 
 	return &vcsDependenciesSyncer{
+		logger:      log.Scoped("vcs syncer", "csDependenciesSyncer implements the VCSSyncer interface for dependency repos"),
 		typ:         "npm_packages",
 		scheme:      dependencies.NpmPackagesScheme,
 		placeholder: placeholder,
@@ -91,18 +91,22 @@ func (s *npmPackagesSyncer) Download(ctx context.Context, dir string, dep reposo
 // Additionally, if all the files in the tarball have paths of the form
 // dir/<blah> for the same directory 'dir', the 'dir' will be stripped.
 func decompressTgz(tgz io.Reader, destination string) error {
+	logger := log.Scoped("decompressTgz", "Decompress a tarball at tgzPath, putting the files under destination.")
 	err := unpack.Tgz(tgz, destination, unpack.Opts{
 		SkipInvalid: true,
 		Filter: func(path string, file fs.FileInfo) bool {
 			size := file.Size()
 
 			const sizeLimit = 15 * 1024 * 1024
+
+			slogger := logger.With(
+				log.String("path", file.Name()),
+				log.Int64("size", size),
+				log.Int("limit", sizeLimit),
+			)
+
 			if size >= sizeLimit {
-				log15.Warn("skipping large file in npm package",
-					"path", file.Name(),
-					"size", size,
-					"limit", sizeLimit,
-				)
+				slogger.Warn("skipping large file in npm package")
 				return false
 			}
 

--- a/cmd/gitserver/server/vcs_syncer_python_packages.go
+++ b/cmd/gitserver/server/vcs_syncer_python_packages.go
@@ -9,13 +9,12 @@ import (
 	"path"
 	"strings"
 
-	"github.com/inconshreveable/log15"
-
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/dependencies"
 	"github.com/sourcegraph/sourcegraph/internal/conf/reposource"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/pypi"
 	"github.com/sourcegraph/sourcegraph/internal/unpack"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"github.com/sourcegraph/sourcegraph/lib/log"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
@@ -30,6 +29,7 @@ func NewPythonPackagesSyncer(
 	}
 
 	return &vcsDependenciesSyncer{
+		logger:      log.Scoped("vcs syncer", "csDependenciesSyncer implements the VCSSyncer interface for dependency repos"),
 		typ:         "python_packages",
 		scheme:      dependencies.PythonPackagesScheme,
 		placeholder: placeholder,
@@ -80,6 +80,7 @@ func (s *pythonPackagesSyncer) Download(ctx context.Context, dir string, dep rep
 // files that aren't valid or that are potentially malicious. It detects the kind of archive
 // and compression used with the given packageURL.
 func unpackPythonPackage(pkg []byte, packageURL, workDir string) error {
+	logger := log.Scoped("unpackPythonPackages", "unpackPythonPackages unpacks the given python package archive into workDir")
 	u, err := url.Parse(packageURL)
 	if err != nil {
 		return errors.Wrap(err, "bad python package URL")
@@ -94,12 +95,13 @@ func unpackPythonPackage(pkg []byte, packageURL, workDir string) error {
 			size := file.Size()
 
 			const sizeLimit = 15 * 1024 * 1024
+			slogger := logger.With(
+				log.String("path", file.Name()),
+				log.Int64("size", size),
+				log.Float64("limit", sizeLimit),
+			)
 			if size >= sizeLimit {
-				log15.Warn("skipping large file in npm package",
-					"path", file.Name(),
-					"size", size,
-					"limit", sizeLimit,
-				)
+				slogger.Warn("skipping large file in npm package")
 				return false
 			}
 

--- a/cmd/migrator/main.go
+++ b/cmd/migrator/main.go
@@ -24,7 +24,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/internal/version"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
-	sglog "github.com/sourcegraph/sourcegraph/lib/log"
+	"github.com/sourcegraph/sourcegraph/lib/log"
 	"github.com/sourcegraph/sourcegraph/lib/output"
 )
 
@@ -48,7 +48,7 @@ func main() {
 }
 
 func mainErr(ctx context.Context, args []string) error {
-	syncLogs := sglog.Init(sglog.Resource{
+	syncLogs := log.Init(log.Resource{
 		Name:       env.MyName,
 		Version:    version.Version(),
 		InstanceID: hostname.Get(),
@@ -100,7 +100,7 @@ func mainErr(ctx context.Context, args []string) error {
 
 func newRunnerFactory() func(ctx context.Context, schemaNames []string) (cliutil.Runner, error) {
 	observationContext := &observation.Context{
-		Logger:     sglog.Scoped("runner", ""),
+		Logger:     log.Scoped("runner", ""),
 		Tracer:     &trace.Tracer{Tracer: opentracing.GlobalTracer()},
 		Registerer: prometheus.DefaultRegisterer,
 	}

--- a/cmd/searcher/internal/search/search.go
+++ b/cmd/searcher/internal/search/search.go
@@ -33,7 +33,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 	"github.com/sourcegraph/sourcegraph/lib/log"
-	sglog "github.com/sourcegraph/sourcegraph/lib/log"
 )
 
 const (
@@ -166,21 +165,21 @@ func (s *Service) search(ctx context.Context, p *protocol.Request, sender matchS
 		span.SetTag("limitHit", sender.LimitHit())
 		span.Finish()
 		s.Log.Debug("search request",
-			sglog.String("repo", string(p.Repo)),
-			sglog.String("commit", string(p.Commit)),
-			sglog.String("pattern", p.Pattern),
-			sglog.Bool("isRegExp", p.IsRegExp),
-			sglog.Bool("isStructuralPat", p.IsStructuralPat),
-			sglog.Strings("languages", p.Languages),
-			sglog.Bool("isWordMatch", p.IsWordMatch),
-			sglog.Bool("isCaseSensitive", p.IsCaseSensitive),
-			sglog.Bool("patternMatchesContent", p.PatternMatchesContent),
-			sglog.Bool("patternMatchesPath", p.PatternMatchesPath),
-			sglog.Int("matches", sender.SentCount()),
-			sglog.String("code", code),
-			sglog.Duration("duration", time.Since(start)),
-			sglog.Strings("indexerEndpoints", p.IndexerEndpoints),
-			sglog.Error(err))
+			log.String("repo", string(p.Repo)),
+			log.String("commit", string(p.Commit)),
+			log.String("pattern", p.Pattern),
+			log.Bool("isRegExp", p.IsRegExp),
+			log.Bool("isStructuralPat", p.IsStructuralPat),
+			log.Strings("languages", p.Languages),
+			log.Bool("isWordMatch", p.IsWordMatch),
+			log.Bool("isCaseSensitive", p.IsCaseSensitive),
+			log.Bool("patternMatchesContent", p.PatternMatchesContent),
+			log.Bool("patternMatchesPath", p.PatternMatchesPath),
+			log.Int("matches", sender.SentCount()),
+			log.String("code", code),
+			log.Duration("duration", time.Since(start)),
+			log.Strings("indexerEndpoints", p.IndexerEndpoints),
+			log.Error(err))
 	}(time.Now())
 
 	if p.IsStructuralPat && p.Indexed {

--- a/internal/gitserver/client.go
+++ b/internal/gitserver/client.go
@@ -19,16 +19,16 @@ import (
 	"time"
 
 	"github.com/cespare/xxhash/v2"
-	"github.com/inconshreveable/log15"
 	"github.com/neelance/parallel"
 	"github.com/opentracing-contrib/go-stdlib/nethttp"
 	"github.com/opentracing/opentracing-go/ext"
 	"github.com/opentracing/opentracing-go/log"
-	otlog "github.com/opentracing/opentracing-go/log"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/sync/semaphore"
+
+	sglog "github.com/sourcegraph/sourcegraph/lib/log"
 
 	"github.com/sourcegraph/go-diff/diff"
 	"github.com/sourcegraph/go-rendezvous"
@@ -81,6 +81,7 @@ func ResetClientMocks() {
 // and httpcli.Doer.
 func NewClient(db database.DB) *ClientImplementor {
 	return &ClientImplementor{
+		logger: sglog.Scoped("NewClient", "returns a new gitserver.Client instantiated with default arguments and httpcli.Doer."),
 		addrs: func() []string {
 			return conf.Get().ServiceConnections().GitServers
 		},
@@ -104,6 +105,7 @@ func NewClient(db database.DB) *ClientImplementor {
 
 func NewTestClient(cli httpcli.Doer, db database.DB, addrs []string) *ClientImplementor {
 	return &ClientImplementor{
+		logger: sglog.Scoped("NewTestClient", "Test New client"),
 		addrs: func() []string {
 			return addrs
 		},
@@ -124,6 +126,9 @@ func NewTestClient(cli httpcli.Doer, db database.DB, addrs []string) *ClientImpl
 
 // ClientImplementor is a gitserver client.
 type ClientImplementor struct {
+	// logger is a standardized, strongly-typed, and structured logging interface
+	// Production output from this logger (SRC_LOG_FORMAT=json) complies with the OpenTelemetry log data model
+	logger sglog.Logger
 	// HTTP client to use
 	HTTPClient httpcli.Doer
 
@@ -446,7 +451,7 @@ func (c *ClientImplementor) Archive(ctx context.Context, repo api.RepoName, opt 
 	defer func() {
 		if err != nil {
 			ext.Error.Set(span, true)
-			span.LogFields(otlog.Error(err))
+			span.LogFields(log.Error(err))
 		}
 		span.Finish()
 	}()
@@ -1357,6 +1362,7 @@ func (c *ClientImplementor) do(ctx context.Context, repo api.RepoName, method, u
 
 func (c *ClientImplementor) CreateCommitFromPatch(ctx context.Context, req protocol.CreateCommitFromPatchRequest) (string, error) {
 	resp, err := c.httpPost(ctx, req.Repo, "create-commit-from-patch", req)
+
 	if err != nil {
 		return "", err
 	}
@@ -1364,14 +1370,14 @@ func (c *ClientImplementor) CreateCommitFromPatch(ctx context.Context, req proto
 
 	data, err := io.ReadAll(resp.Body)
 	if err != nil {
-		log15.Warn("reading gitserver create-commit-from-patch response", "err", err.Error())
+		c.logger.Warn("reading gitserver create-commit-from-patch response", sglog.Error(err))
 		return "", &url.Error{URL: resp.Request.URL.String(), Op: "CreateCommitFromPatch", Err: errors.Errorf("CreateCommitFromPatch: http status %d %s", resp.StatusCode, err.Error())}
 	}
 
 	var res protocol.CreateCommitFromPatchResponse
 	err = json.Unmarshal(data, &res)
 	if err != nil {
-		log15.Warn("decoding gitserver create-commit-from-patch response", "err", err.Error())
+		c.logger.Warn("decoding gitserver create-commit-from-patch response", sglog.Error(err))
 		return "", &url.Error{URL: resp.Request.URL.String(), Op: "CreateCommitFromPatch", Err: errors.Errorf("CreateCommitFromPatch: http status %d %s", resp.StatusCode, string(data))}
 	}
 
@@ -1398,14 +1404,14 @@ func (c *ClientImplementor) GetObject(ctx context.Context, repo api.RepoName, ob
 
 	data, err := io.ReadAll(resp.Body)
 	if err != nil {
-		log15.Warn("reading gitserver get-object response", "err", err.Error())
+		c.logger.Warn("reading gitserver get-object response", sglog.Error(err))
 		return nil, &url.Error{URL: resp.Request.URL.String(), Op: "GetObject", Err: errors.Errorf("GetObject: http status %d %s", resp.StatusCode, err.Error())}
 	}
 
 	var res protocol.GetObjectResponse
 	err = json.Unmarshal(data, &res)
 	if err != nil {
-		log15.Warn("decoding gitserver get-object response", "err", err.Error())
+		c.logger.Warn("decoding gitserver get-object response", sglog.Error(err))
 		return nil, &url.Error{URL: resp.Request.URL.String(), Op: "GetObject", Err: errors.Errorf("GetObject: http status %d %s", resp.StatusCode, string(data))}
 	}
 

--- a/internal/gitserver/client_test.go
+++ b/internal/gitserver/client_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"github.com/sourcegraph/sourcegraph/lib/log/logtest"
 )
 
 func TestClient_ListCloned(t *testing.T) {
@@ -172,6 +173,7 @@ func TestClient_Archive(t *testing.T) {
 	}
 
 	srv := httptest.NewServer((&server.Server{
+		Logger:   logtest.Scoped(t),
 		ReposDir: filepath.Join(root, "repos"),
 		GetRemoteURLFunc: func(_ context.Context, name api.RepoName) (string, error) {
 			testData := tests[name]
@@ -538,6 +540,7 @@ func TestClient_ResolveRevisions(t *testing.T) {
 	}}
 
 	srv := httptest.NewServer((&server.Server{
+		Logger:   logtest.Scoped(t),
 		ReposDir: filepath.Join(root, "repos"),
 		GetRemoteURLFunc: func(_ context.Context, name api.RepoName) (string, error) {
 			return remote, nil

--- a/internal/gitserver/commands.go
+++ b/internal/gitserver/commands.go
@@ -156,7 +156,7 @@ func (c *ClientImplementor) execReader(ctx context.Context, repo api.RepoName, a
 	span.SetTag("args", args)
 	defer span.Finish()
 
-	if !gitdomain.IsAllowedGitCmd(args) {
+	if !gitdomain.IsAllowedGitCmd(c.logger, args) {
 		return nil, errors.Errorf("command failed: %v is not a allowed git command", args)
 	}
 	cmd := c.GitCommand(repo, args...)
@@ -1206,7 +1206,7 @@ func (c *ClientImplementor) execSafe(ctx context.Context, repo api.RepoName, par
 		return nil, nil, 0, errors.New("at least one argument required")
 	}
 
-	if !gitdomain.IsAllowedGitCmd(params) {
+	if !gitdomain.IsAllowedGitCmd(c.logger, params) {
 		return nil, nil, 0, errors.Errorf("command failed: %q is not a allowed git command", params)
 	}
 

--- a/internal/gitserver/git_command.go
+++ b/internal/gitserver/git_command.go
@@ -12,7 +12,7 @@ import (
 	"strconv"
 	"syscall"
 
-	"github.com/inconshreveable/log15"
+	"github.com/sourcegraph/sourcegraph/lib/log"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/protocol"
@@ -62,6 +62,7 @@ type GitCommand interface {
 // This struct uses composition with exec.RemoteGitCommand which already provides all necessary means to run commands against
 // local system.
 type LocalGitCommand struct {
+	Logger  log.Logger
 	command *exec.Cmd
 
 	// ReposDir is needed in order to LocalGitCommand be used like RemoteGitCommand (providing only repo name without its full path)
@@ -87,7 +88,7 @@ const NoReposDirErrorMsg = "No ReposDir provided, command cannot be run without 
 
 func (l *LocalGitCommand) DividedOutput(ctx context.Context) ([]byte, []byte, error) {
 	if l.ReposDir == "" {
-		log15.Error(NoReposDirErrorMsg)
+		l.Logger.Error(NoReposDirErrorMsg)
 		return nil, nil, errors.New(NoReposDirErrorMsg)
 	}
 	// cmd is a version of the command in LocalGitCommand with given context

--- a/internal/gitserver/gitdomain/exec.go
+++ b/internal/gitserver/gitdomain/exec.go
@@ -4,7 +4,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/inconshreveable/log15"
+	"github.com/sourcegraph/sourcegraph/lib/log"
 )
 
 var (
@@ -74,7 +74,7 @@ func isAllowedGitArg(allowedArgs []string, arg string) bool {
 }
 
 // IsAllowedGitCmd checks if the cmd and arguments are allowed.
-func IsAllowedGitCmd(args []string) bool {
+func IsAllowedGitCmd(logger log.Logger, args []string) bool {
 	if len(args) == 0 || len(gitCmdAllowlist) == 0 {
 		return false
 	}
@@ -83,7 +83,7 @@ func IsAllowedGitCmd(args []string) bool {
 	allowedArgs, ok := gitCmdAllowlist[cmd]
 	if !ok {
 		// Command not allowed
-		log15.Warn("IsAllowedGitCmd: command not allowed", "cmd", cmd)
+		logger.Warn("command not allowed", log.String("cmd", cmd))
 		return false
 	}
 	for _, arg := range args[1:] {
@@ -108,7 +108,7 @@ func IsAllowedGitCmd(args []string) bool {
 			}
 
 			if !isAllowedGitArg(allowedArgs, arg) {
-				log15.Warn("IsAllowedGitCmd.isAllowedGitArgcmd", "cmd", cmd, "arg", arg)
+				logger.Warn("IsAllowedGitCmd.isAllowedGitArgcmd", log.String("cmd", cmd), log.String("arg", arg))
 				return false
 			}
 		}

--- a/internal/gitserver/search/search.go
+++ b/internal/gitserver/search/search.go
@@ -8,7 +8,8 @@ import (
 	"os/exec"
 	"strings"
 
-	"github.com/inconshreveable/log15"
+	"github.com/sourcegraph/sourcegraph/lib/log"
+
 	"golang.org/x/sync/errgroup"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
@@ -80,6 +81,9 @@ const (
 )
 
 type CommitSearcher struct {
+	// logger is a standardized, strongly-typed, and structured logging interface
+	// Production output from this logger (SRC_LOG_FORMAT=json) complies with the OpenTelemetry log data model
+	logger               log.Logger
 	RepoDir              string
 	Query                MatchTree
 	Revisions            []protocol.RevisionSpecifier
@@ -152,7 +156,7 @@ func (cs *CommitSearcher) feedBatches(ctx context.Context, jobs chan job, result
 	defer func() {
 		// Always call cmd.Wait to avoid leaving zombie processes around.
 		if e := cmd.Wait(); e != nil {
-			err = errors.Append(err, tryInterpretErrorWithStderr(ctx, err, stderrBuf.String()))
+			err = errors.Append(err, tryInterpretErrorWithStderr(ctx, err, stderrBuf.String(), cs.logger))
 		}
 	}()
 
@@ -186,7 +190,7 @@ func (cs *CommitSearcher) feedBatches(ctx context.Context, jobs chan job, result
 	return scanner.Err()
 }
 
-func tryInterpretErrorWithStderr(ctx context.Context, err error, stderr string) error {
+func tryInterpretErrorWithStderr(ctx context.Context, err error, stderr string, logger log.Logger) error {
 	if ctx.Err() != nil {
 		// Ignore errors when context is cancelled
 		return nil
@@ -195,7 +199,7 @@ func tryInterpretErrorWithStderr(ctx context.Context, err error, stderr string) 
 		// Ignore no commits error error
 		return nil
 	}
-	log15.Warn("git search command exited with non-zero status code", "stderr", stderr)
+	logger.Warn("git search command exited with non-zero status code", log.String("stderr", stderr))
 	return err
 }
 

--- a/internal/vcs/git/main_test.go
+++ b/internal/vcs/git/main_test.go
@@ -39,7 +39,7 @@ func TestMain(m *testing.M) {
 	flag.Parse()
 
 	if !testing.Verbose() {
-		logtest.Init(m)
+		logtest.InitWithLevel(m, sglog.LevelNone)
 	}
 
 	code := m.Run()

--- a/internal/vcs/git/main_test.go
+++ b/internal/vcs/git/main_test.go
@@ -17,7 +17,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/inconshreveable/log15"
 	"golang.org/x/sync/semaphore"
 
 	"github.com/sourcegraph/sourcegraph/cmd/gitserver/server"
@@ -26,6 +25,8 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
+	sglog "github.com/sourcegraph/sourcegraph/lib/log"
+	"github.com/sourcegraph/sourcegraph/lib/log/logtest"
 )
 
 var root string
@@ -38,7 +39,7 @@ func TestMain(m *testing.M) {
 	flag.Parse()
 
 	if !testing.Verbose() {
-		log15.Root().SetHandler(log15.DiscardHandler())
+		logtest.Init(m)
 	}
 
 	code := m.Run()
@@ -67,6 +68,7 @@ func init() {
 
 	srv := &http.Server{
 		Handler: (&server.Server{
+			Logger:   sglog.Scoped("gitserver", "gitserver server log"),
 			ReposDir: filepath.Join(root, "repos"),
 			GetRemoteURLFunc: func(ctx context.Context, name api.RepoName) (string, error) {
 				return filepath.Join(root, "remotes", string(name)), nil


### PR DESCRIPTION
## Description

The main existing logger usage to replace are calls to log15.

## Test plan

All ~125 occurrences of log15 calls in files that appear related to gitserver are replaced with logging calls to an appropriately scoped log.Logger instance, e.g. ones held by the parent struct:

https://sourcegraph.com/search?q=context:global+r:%5Egithub%5C.com/sourcegraph/sourcegraph%24++content:%22log15.%22+lang:go+f:gitserver&patternType=literal

Green CI builds.

## Refs

- [SourceGraph Issue](https://github.com/sourcegraph/sourcegraph/issues/35514)
- [GitStart ticket](https://app.gitstart.com/clients/sourcegraph/tickets/SG-35514)
