### PR TITLE
[a11y] Add aria-label to CopyableText elements.

### DIFF
--- a/client/web/src/components/CopyableText.tsx
+++ b/client/web/src/components/CopyableText.tsx
@@ -24,6 +24,9 @@ interface Props {
     /** Whether or not the text to be copied is a password. */
     password?: boolean
 
+    /** The label used for screen readers */
+    label?: string
+
     /** Callback for when the content is copied  */
     onCopy?: () => void
 }
@@ -48,6 +51,7 @@ export class CopyableText extends React.PureComponent<Props, State> {
                     <input
                         type={this.props.password ? 'password' : 'text'}
                         className={classNames('form-control', styles.input)}
+                        aria-label={this.props.label}
                         value={this.props.text}
                         size={this.props.size}
                         readOnly={true}

--- a/client/web/src/org/settings/members-v1/InviteForm.tsx
+++ b/client/web/src/org/settings/members-v1/InviteForm.tsx
@@ -275,7 +275,7 @@ const InvitedNotification: React.FunctionComponent<React.PropsWithChildren<Invit
             ) : (
                 <>Generated invitation link. Copy and send it to {username}:</>
             )}
-            <CopyableText text={invitationURL} size={40} className="mt-2" />
+            <CopyableText label="Invitation URL" text={invitationURL} size={40} className="mt-2" />
         </div>
         <Button variant="icon" title="Dismiss" onClick={onDismiss}>
             <Icon role="img" as={CloseIcon} aria-hidden={true} />


### PR DESCRIPTION
Otherwise we violate the constraint that each input element should have a label.

<img width="302" alt="Screenshot 2022-05-25 at 14 03 48" src="https://user-images.githubusercontent.com/9974711/170257705-9f6701ac-7d23-47d6-abf7-9478b2f6f0c8.png">


## Test plan

Tested locally. This just adds a hidden attribute that is only used in screen readers

## App preview:

- [Web](https://sg-web-milan-accessibility.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-glavbfioqz.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
