### PR TITLE
JetBrains: Improve keyboard navigation

### DIFF
--- a/client/jetbrains/webview/src/search/App.tsx
+++ b/client/jetbrains/webview/src/search/App.tsx
@@ -202,7 +202,8 @@ export const App: React.FunctionComponent<React.PropsWithChildren<Props>> = ({
 
     return (
         <WildcardThemeContext.Provider value={{ isBranded: true }}>
-            <div className={styles.root}>
+            {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions */}
+            <div className={styles.root} onMouseDown={preventAll}>
                 <div className={styles.searchBoxContainer}>
                     {/* eslint-disable-next-line react/forbid-elements */}
                     <form
@@ -266,4 +267,9 @@ function getStableKeyForLastSearch(lastSearch: Search): string {
     return `${lastSearch.query ?? ''}-${lastSearch.caseSensitive}-${String(lastSearch.patternType)}-${
         lastSearch.selectedSearchContextSpec
     }`
+}
+
+function preventAll(event: React.MouseEvent): void {
+    event.stopPropagation()
+    event.preventDefault()
 }


### PR DESCRIPTION
Closes #36004

This PR fixes two keyboard accessibility issues in the JetBrains web view:

1. We want tab navigation only to work on the search input related fields and not jump inside the result list. However since there are link components that we use to render the list items, it was previously possible to jump to them. I've fixed this by forking the React component and adding `tabIndex={-1}` to make them non intractable via tab. Keep in mind that we already have custom keyboard navigation via arrow keys set up anyways.
2. We need to prevent the focus to be moved to the `<body>` element because of #36004. This was currently only applied as an event handler for clicks in the result list but I've moved this logic to the root so that any area can now be clicked without the focus moving to the `<body>`

## Test plan

Manual testing:

https://user-images.githubusercontent.com/458591/170258702-b9be6603-481c-4633-97ea-55c825695da1.mov



<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-jetbrains-keyboard-a11y.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-vdnpuibeng.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
