### PR TITLE
New reference panel: collapse unselected sections in ref panel

### DIFF
--- a/client/web/src/codeintel/ReferencesPanel.tsx
+++ b/client/web/src/codeintel/ReferencesPanel.tsx
@@ -343,14 +343,24 @@ export const ReferencesList: React.FunctionComponent<
 
     // Manual management of the open/closed state of collapsible lists so they
     // stay open/closed across re-renders and re-mounts.
+    const location = useLocation()
+    const initialCollapseState = useMemo((): Record<string, boolean> => {
+        const { viewState } = parseQueryAndHash(location.search, location.hash)
+        return {
+            references: viewState === 'references',
+            definitions: viewState === 'definitions',
+            implementations: viewState?.startsWith('implementations_') ?? false,
+        }
+    }, [location])
     const [collapsed, setCollapsed] = useState<Record<string, boolean>>({})
     const handleOpenChange = (id: string, isOpen: boolean): void =>
         setCollapsed(previous => ({ ...previous, [id]: isOpen }))
+
     const isOpen = (id: string): boolean | undefined => collapsed[id]
     // But when the input changes, we reset the collapse state
     useEffect(() => {
-        setCollapsed({})
-    }, [props.token])
+        setCollapsed(initialCollapseState)
+    }, [props.token, initialCollapseState])
 
     if (loading && !data) {
         return <LoadingCodeIntel />


### PR DESCRIPTION
If the user clicks on "Find references" we collapse
defs/implementations, if they click on "Find implementations" we
collapse refs/defs, ...

This also works when clicking inside the peek code view.

This is based on @rrhyne's Figma designs.

## Video


https://user-images.githubusercontent.com/1185253/170265163-1bfea5e0-73cc-4875-9cc9-4970e7218877.mp4


## Test plan

- Manual testing
- Existing tests in CI

## App preview:

- [Web](https://sg-web-mrn-better-collapse-state.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-acvgeixurn.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
