### PR TITLE
refactor(repo-updater): migrate use of log15 to use lib/log

### DIFF
--- a/cmd/repo-updater/repoupdater/observability.go
+++ b/cmd/repo-updater/repoupdater/observability.go
@@ -52,7 +52,7 @@ func (m HandlerMetrics) MustRegister(r prometheus.Registerer) {
 // ObservedHandler returns a decorator that wraps an http.Handler
 // with logging, Prometheus metrics and tracing.
 func ObservedHandler(
-	log log.Logger,
+	logger log.Logger,
 	m HandlerMetrics,
 	tr opentracing.Tracer,
 ) func(http.Handler) http.Handler {
@@ -60,7 +60,7 @@ func ObservedHandler(
 		return ot.MiddlewareWithTracer(tr,
 			&observedHandler{
 				next:    next,
-				log:     log,
+				logger:  logger,
 				metrics: m,
 			},
 			nethttp.OperationNameFunc(func(r *http.Request) string {
@@ -76,7 +76,7 @@ func ObservedHandler(
 
 type observedHandler struct {
 	next    http.Handler
-	log     log.Logger
+	logger  log.Logger
 	metrics HandlerMetrics
 }
 
@@ -86,7 +86,7 @@ func (h *observedHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	defer func(begin time.Time) {
 		took := time.Since(begin)
 
-		h.log.Debug(
+		h.logger.Debug(
 			"http.request",
 			log.String("method", r.Method),
 			log.String("route", r.URL.Path),

--- a/cmd/repo-updater/repoupdater/observability.go
+++ b/cmd/repo-updater/repoupdater/observability.go
@@ -5,7 +5,6 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/inconshreveable/log15"
 	"github.com/opentracing-contrib/go-stdlib/nethttp"
 	"github.com/opentracing/opentracing-go"
 	"github.com/prometheus/client_golang/prometheus"
@@ -13,6 +12,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/metrics"
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"github.com/sourcegraph/sourcegraph/lib/log"
 )
 
 // HandlerMetrics encapsulates the Prometheus metrics of an http.Handler.
@@ -52,7 +52,7 @@ func (m HandlerMetrics) MustRegister(r prometheus.Registerer) {
 // ObservedHandler returns a decorator that wraps an http.Handler
 // with logging, Prometheus metrics and tracing.
 func ObservedHandler(
-	log log15.Logger,
+	log log.Logger,
 	m HandlerMetrics,
 	tr opentracing.Tracer,
 ) func(http.Handler) http.Handler {
@@ -76,7 +76,7 @@ func ObservedHandler(
 
 type observedHandler struct {
 	next    http.Handler
-	log     log15.Logger
+	log     log.Logger
 	metrics HandlerMetrics
 }
 
@@ -88,10 +88,10 @@ func (h *observedHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 		h.log.Debug(
 			"http.request",
-			"method", r.Method,
-			"route", r.URL.Path,
-			"code", rr.code,
-			"duration", took,
+			log.String("method", r.Method),
+			log.String("route", r.URL.Path),
+			log.Int("code", rr.code),
+			log.Duration("duration", took),
 		)
 
 		var err error

--- a/cmd/repo-updater/repoupdater/server.go
+++ b/cmd/repo-updater/repoupdater/server.go
@@ -141,7 +141,7 @@ func (s *Server) handleEnqueueRepoUpdate(w http.ResponseWriter, r *http.Request)
 	}
 	result, status, err := s.enqueueRepoUpdate(r.Context(), &req)
 	if err != nil {
-		s.Logger.Error("enqueueRepoUpdate failed", log.String("req", req.String()), log.Error(err))
+		s.Logger.Error("enqueueRepoUpdate failed", log.String("req", fmt.Sprint(req)), log.Error(err))
 		s.respond(w, status, err)
 		return
 	}
@@ -151,7 +151,7 @@ func (s *Server) handleEnqueueRepoUpdate(w http.ResponseWriter, r *http.Request)
 func (s *Server) enqueueRepoUpdate(ctx context.Context, req *protocol.RepoUpdateRequest) (resp *protocol.RepoUpdateResponse, httpStatus int, err error) {
 	tr, ctx := trace.New(ctx, "enqueueRepoUpdate", req.String())
 	defer func() {
-		s.Logger.Debug("enqueueRepoUpdate", log.Int("httpStatus", httpStatus), log.String("resp", resp.String()), log.Error(err))
+		s.Logger.Debug("enqueueRepoUpdate", log.Int("httpStatus", httpStatus), log.String("resp", fmt.Sprint(resp)), log.Error(err))
 		if resp != nil {
 			tr.LogFields(
 				otlog.Int32("resp.id", int32(resp.ID)),
@@ -300,7 +300,7 @@ func (s *Server) repoLookup(ctx context.Context, args protocol.RepoLookupArgs) (
 
 	tr, ctx := trace.New(ctx, "repoLookup", args.String())
 	defer func() {
-		s.Logger.Debug("repoLookup", log.String("result", result.String()), log.Error(err))
+		s.Logger.Debug("repoLookup", log.String("result", fmt.Sprint(result)), log.Error(err))
 		if result != nil {
 			tr.LazyPrintf("result: %s", result)
 		}

--- a/cmd/repo-updater/repoupdater/server.go
+++ b/cmd/repo-updater/repoupdater/server.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/inconshreveable/log15"
 	otlog "github.com/opentracing/opentracing-go/log"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
@@ -23,12 +22,14 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"github.com/sourcegraph/sourcegraph/lib/log"
 )
 
 // Server is a repoupdater server.
 type Server struct {
 	repos.Store
 	*repos.Syncer
+	Logger                log.Logger
 	SourcegraphDotComMode bool
 	Scheduler             interface {
 		UpdateOnce(id api.RepoID, name api.RepoName)
@@ -70,11 +71,11 @@ func (s *Server) Handler() http.Handler {
 }
 
 // TODO(tsenart): Reuse this function in all handlers.
-func respond(w http.ResponseWriter, code int, v any) {
+func (s *Server) respond(w http.ResponseWriter, code int, v any) {
 	switch val := v.(type) {
 	case error:
 		if val != nil {
-			log15.Error(val.Error())
+			s.Logger.Error("response value error", log.String("err", val.Error()))
 			w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 			w.WriteHeader(code)
 			fmt.Fprintf(w, "%v", val)
@@ -83,13 +84,13 @@ func respond(w http.ResponseWriter, code int, v any) {
 		w.Header().Set("Content-Type", "application/json")
 		bs, err := json.Marshal(v)
 		if err != nil {
-			respond(w, http.StatusInternalServerError, err)
+			s.respond(w, http.StatusInternalServerError, err)
 			return
 		}
 
 		w.WriteHeader(code)
 		if _, err = w.Write(bs); err != nil {
-			log15.Error("failed to write response", "error", err)
+			s.Logger.Error("failed to write response", log.Error(err))
 		}
 	}
 }
@@ -121,7 +122,7 @@ func (s *Server) handleRepoLookup(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "request canceled", http.StatusGatewayTimeout)
 			return
 		}
-		log15.Error("repoLookup failed", "args", &args, "error", err)
+		s.Logger.Error("repoLookup failed", log.String("args", (&args).String()), log.Error(err))
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -135,22 +136,22 @@ func (s *Server) handleRepoLookup(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleEnqueueRepoUpdate(w http.ResponseWriter, r *http.Request) {
 	var req protocol.RepoUpdateRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		respond(w, http.StatusBadRequest, err)
+		s.respond(w, http.StatusBadRequest, err)
 		return
 	}
 	result, status, err := s.enqueueRepoUpdate(r.Context(), &req)
 	if err != nil {
-		log15.Error("enqueueRepoUpdate failed", "req", req, "error", err)
-		respond(w, status, err)
+		s.Logger.Error("enqueueRepoUpdate failed", log.String("req", req.String()), log.Error(err))
+		s.respond(w, status, err)
 		return
 	}
-	respond(w, status, result)
+	s.respond(w, status, result)
 }
 
 func (s *Server) enqueueRepoUpdate(ctx context.Context, req *protocol.RepoUpdateRequest) (resp *protocol.RepoUpdateResponse, httpStatus int, err error) {
 	tr, ctx := trace.New(ctx, "enqueueRepoUpdate", req.String())
 	defer func() {
-		log15.Debug("enqueueRepoUpdate", "httpStatus", httpStatus, "resp", resp, "error", err)
+		s.Logger.Debug("enqueueRepoUpdate", log.Int("httpStatus", httpStatus), log.String("resp", resp.String()), log.Error(err))
 		if resp != nil {
 			tr.LogFields(
 				otlog.Int32("resp.id", int32(resp.ID)),
@@ -206,49 +207,49 @@ func (s *Server) handleExternalServiceSync(w http.ResponseWriter, r *http.Reques
 		NamespaceOrgID:  req.ExternalService.NamespaceOrgID,
 	})
 	if err != nil {
-		log15.Error("server.external-service-sync", "kind", req.ExternalService.Kind, "error", err)
+		s.Logger.Error("server.external-service-sync", log.String("kind", req.ExternalService.Kind), log.Error(err))
 		return
 	}
 
 	err = externalServiceValidate(ctx, req, src)
 	if err == github.ErrIncompleteResults {
-		log15.Info("server.external-service-sync", "kind", req.ExternalService.Kind, "error", err)
+		s.Logger.Info("server.external-service-sync", log.String("kind", req.ExternalService.Kind), log.Error(err))
 		syncResult := &protocol.ExternalServiceSyncResult{
 			ExternalService: req.ExternalService,
 			Error:           err.Error(),
 		}
-		respond(w, http.StatusOK, syncResult)
+		s.respond(w, http.StatusOK, syncResult)
 		return
 	} else if ctx.Err() != nil {
 		// client is gone
 		return
 	} else if err != nil {
-		log15.Error("server.external-service-sync", "kind", req.ExternalService.Kind, "error", err)
+		s.Logger.Error("server.external-service-sync", log.String("kind", req.ExternalService.Kind), log.Error(err))
 		if errcode.IsUnauthorized(err) {
-			respond(w, http.StatusUnauthorized, err)
+			s.respond(w, http.StatusUnauthorized, err)
 			return
 		}
 		if errcode.IsForbidden(err) {
-			respond(w, http.StatusForbidden, err)
+			s.respond(w, http.StatusForbidden, err)
 			return
 		}
-		respond(w, http.StatusInternalServerError, err)
+		s.respond(w, http.StatusInternalServerError, err)
 		return
 	}
 
 	if s.RateLimitSyncer != nil {
 		err = s.RateLimitSyncer.SyncRateLimiters(ctx, req.ExternalService.ID)
 		if err != nil {
-			log15.Warn("Handling rate limiter sync", "err", err, "id", req.ExternalService.ID)
+			s.Logger.Warn("Handling rate limiter sync", log.Error(err), log.Int64("id", req.ExternalService.ID))
 		}
 	}
 
 	if err := s.Syncer.TriggerExternalServiceSync(ctx, req.ExternalService.ID); err != nil {
-		log15.Warn("Enqueueing external service sync job", "error", err, "id", req.ExternalService.ID)
+		s.Logger.Warn("Enqueueing external service sync job", log.Error(err), log.Int64("id", req.ExternalService.ID))
 	}
 
-	log15.Info("server.external-service-sync", "synced", req.ExternalService.Kind)
-	respond(w, http.StatusOK, &protocol.ExternalServiceSyncResult{
+	s.Logger.Info("server.external-service-sync", log.String("synced", req.ExternalService.Kind))
+	s.respond(w, http.StatusOK, &protocol.ExternalServiceSyncResult{
 		ExternalService: req.ExternalService,
 	})
 }
@@ -299,7 +300,7 @@ func (s *Server) repoLookup(ctx context.Context, args protocol.RepoLookupArgs) (
 
 	tr, ctx := trace.New(ctx, "repoLookup", args.String())
 	defer func() {
-		log15.Debug("repoLookup", "result", result, "error", err)
+		s.Logger.Debug("repoLookup", log.String("result", result.String()), log.Error(err))
 		if result != nil {
 			tr.LazyPrintf("result: %s", result)
 		}
@@ -342,47 +343,47 @@ func (s *Server) repoLookup(ctx context.Context, args protocol.RepoLookupArgs) (
 
 func (s *Server) handleEnqueueChangesetSync(w http.ResponseWriter, r *http.Request) {
 	if s.ChangesetSyncRegistry == nil {
-		log15.Warn("ChangesetSyncer is nil")
-		respond(w, http.StatusForbidden, nil)
+		s.Logger.Warn("ChangesetSyncer is nil")
+		s.respond(w, http.StatusForbidden, nil)
 		return
 	}
 
 	var req protocol.ChangesetSyncRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		respond(w, http.StatusBadRequest, err)
+		s.respond(w, http.StatusBadRequest, err)
 		return
 	}
 	if len(req.IDs) == 0 {
-		respond(w, http.StatusBadRequest, errors.New("no ids provided"))
+		s.respond(w, http.StatusBadRequest, errors.New("no ids provided"))
 		return
 	}
 	err := s.ChangesetSyncRegistry.EnqueueChangesetSyncs(r.Context(), req.IDs)
 	if err != nil {
 		resp := protocol.ChangesetSyncResponse{Error: err.Error()}
-		respond(w, http.StatusInternalServerError, resp)
+		s.respond(w, http.StatusInternalServerError, resp)
 		return
 	}
-	respond(w, http.StatusOK, nil)
+	s.respond(w, http.StatusOK, nil)
 }
 
 func (s *Server) handleSchedulePermsSync(w http.ResponseWriter, r *http.Request) {
 	if s.PermsSyncer == nil {
-		respond(w, http.StatusForbidden, nil)
+		s.respond(w, http.StatusForbidden, nil)
 		return
 	}
 
 	var req protocol.PermsSyncRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		respond(w, http.StatusBadRequest, err)
+		s.respond(w, http.StatusBadRequest, err)
 		return
 	}
 	if len(req.UserIDs) == 0 && len(req.RepoIDs) == 0 {
-		respond(w, http.StatusBadRequest, errors.New("neither user IDs nor repo IDs was provided in request (must provide at least one)"))
+		s.respond(w, http.StatusBadRequest, errors.New("neither user IDs nor repo IDs was provided in request (must provide at least one)"))
 		return
 	}
 
 	s.PermsSyncer.ScheduleUsers(r.Context(), req.Options, req.UserIDs...)
 	s.PermsSyncer.ScheduleRepos(r.Context(), req.RepoIDs...)
 
-	respond(w, http.StatusOK, nil)
+	s.respond(w, http.StatusOK, nil)
 }

--- a/cmd/repo-updater/repoupdater/server_test.go
+++ b/cmd/repo-updater/repoupdater/server_test.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/inconshreveable/log15"
 	"github.com/opentracing/opentracing-go"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
@@ -42,7 +41,7 @@ func TestServer_handleRepoLookup(t *testing.T) {
 	s := &Server{}
 
 	h := ObservedHandler(
-		log15.Root(),
+		logtest.Scoped(t),
 		NewHandlerMetrics(),
 		opentracing.NoopTracer{},
 	)(s.Handler())

--- a/cmd/repo-updater/repoupdater/server_test.go
+++ b/cmd/repo-updater/repoupdater/server_test.go
@@ -38,10 +38,11 @@ import (
 )
 
 func TestServer_handleRepoLookup(t *testing.T) {
-	s := &Server{}
+	logger := logtest.Scoped(t)
+	s := &Server{Logger: logger}
 
 	h := ObservedHandler(
-		logtest.Scoped(t),
+		logger,
 		NewHandlerMetrics(),
 		opentracing.NoopTracer{},
 	)(s.Handler())
@@ -54,6 +55,7 @@ func TestServer_handleRepoLookup(t *testing.T) {
 			t.Fatal(err)
 		}
 		req := httptest.NewRequest("GET", "/repo-lookup", bytes.NewReader(body))
+		fmt.Printf("h: %v rr: %v req: %v\n", h, rr, req)
 		h.ServeHTTP(rr, req)
 		if rr.Code == http.StatusOK {
 			if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
@@ -204,6 +206,7 @@ func TestServer_EnqueueRepoUpdate(t *testing.T) {
 		},
 	}}
 
+	logger := logtest.Scoped(t)
 	for _, tc := range testCases {
 		tc := tc
 		ctx := context.Background()
@@ -211,7 +214,7 @@ func TestServer_EnqueueRepoUpdate(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			sqlDB := dbtest.NewDB(t)
 			store := tc.init(database.NewDB(sqlDB))
-			s := &Server{Store: store, Scheduler: &fakeScheduler{}}
+			s := &Server{Logger: logger, Store: store, Scheduler: &fakeScheduler{}}
 			srv := httptest.NewServer(s.Handler())
 			defer srv.Close()
 			cli := repoupdater.NewClient(srv.URL)
@@ -597,6 +600,7 @@ func TestServer_RepoLookup(t *testing.T) {
 		},
 	}
 
+	logger := logtest.Scoped(t)
 	for _, tc := range testCases {
 		tc := tc
 
@@ -624,6 +628,7 @@ func TestServer_RepoLookup(t *testing.T) {
 			scheduler := repos.NewUpdateScheduler(logtest.Scoped(t), database.NewMockDB())
 
 			s := &Server{
+				Logger:    logger,
 				Syncer:    syncer,
 				Store:     store,
 				Scheduler: scheduler,
@@ -733,12 +738,14 @@ func TestServer_handleSchedulePermsSync(t *testing.T) {
 			wantBody:       "null",
 		},
 	}
+
+	logger := logtest.Scoped(t)
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			r := httptest.NewRequest("POST", "/schedule-perms-sync", strings.NewReader(test.body))
 			w := httptest.NewRecorder()
 
-			s := &Server{}
+			s := &Server{Logger: logger}
 			// NOTE: An interface has nil value is not a nil interface,
 			// so should only assign to the interface when the value is not nil.
 			if test.permsSyncer != nil {
@@ -777,6 +784,9 @@ func TestServer_handleExternalServiceSync(t *testing.T) {
 			wantErrCode: 500,
 		},
 	}
+
+	logger := logtest.Scoped(t)
+
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			src := testSource{
@@ -786,7 +796,7 @@ func TestServer_handleExternalServiceSync(t *testing.T) {
 			}
 			r := httptest.NewRequest("POST", "/sync-external-service", strings.NewReader(`{"ExternalService": {"ID":1,"kind":"GITHUB"}}}`))
 			w := httptest.NewRecorder()
-			s := &Server{Syncer: &repos.Syncer{Sourcer: repos.NewFakeSourcer(nil, src)}}
+			s := &Server{Logger: logger, Syncer: &repos.Syncer{Sourcer: repos.NewFakeSourcer(nil, src)}}
 			s.handleExternalServiceSync(w, r)
 			if w.Code != test.wantErrCode {
 				t.Errorf("Code: want %v but got %v", test.wantErrCode, w.Code)

--- a/cmd/repo-updater/shared/main.go
+++ b/cmd/repo-updater/shared/main.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"html/template"
-	"log"
 	"net"
 	"net/http"
 	"strconv"
@@ -41,7 +40,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/hostname"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/internal/httpserver"
-	"github.com/sourcegraph/sourcegraph/internal/logging"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/profiler"
 	"github.com/sourcegraph/sourcegraph/internal/ratelimit"
@@ -51,7 +49,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
 	"github.com/sourcegraph/sourcegraph/internal/tracer"
 	"github.com/sourcegraph/sourcegraph/internal/version"
-	sglog "github.com/sourcegraph/sourcegraph/lib/log"
+	"github.com/sourcegraph/sourcegraph/lib/log"
 )
 
 const port = "3182"
@@ -79,8 +77,7 @@ func Main(enterpriseInit EnterpriseInit) {
 	env.HandleHelpFlag()
 
 	conf.Init()
-	logging.Init()
-	syncLogs := sglog.Init(sglog.Resource{
+	syncLogs := log.Init(log.Resource{
 		Name:       env.MyName,
 		Version:    version.Version(),
 		InstanceID: hostname.Get(),
@@ -91,7 +88,7 @@ func Main(enterpriseInit EnterpriseInit) {
 	trace.Init()
 	profiler.Init()
 
-	logger := sglog.Scoped("repo updater", "repo updater service")
+	logger := log.Scoped("repo-updater", "repo-updater service")
 
 	// Signals health of startup
 	ready := make(chan struct{})
@@ -103,7 +100,7 @@ func Main(enterpriseInit EnterpriseInit) {
 
 	clock := func() time.Time { return time.Now().UTC() }
 	if err := keyring.Init(ctx); err != nil {
-		log.Fatalf("error initialising encryption keyring: %v", err)
+		logger.Fatal("error initialising encryption keyring", log.Error(err))
 	}
 
 	dsn := conf.GetServiceConnectionValueAndRestartOnChange(func(serviceConnections conftypes.ServiceConnections) string {
@@ -111,7 +108,7 @@ func Main(enterpriseInit EnterpriseInit) {
 	})
 	sqlDB, err := connections.EnsureNewFrontendDB(dsn, "repo-updater", &observation.TestContext)
 	if err != nil {
-		log.Fatalf("failed to initialize database store: %v", err)
+		logger.Fatal("failed to initialize database store", log.Error(err))
 	}
 	db := database.NewDB(sqlDB)
 
@@ -138,11 +135,13 @@ func Main(enterpriseInit EnterpriseInit) {
 		m.MustRegister(prometheus.DefaultRegisterer)
 
 		depsSvc := livedependencies.GetService(db, nil)
+		// TODO(burmudar): update repos.ObservedSource to use lib/log
 		src = repos.NewSourcer(db, cf, repos.WithDependenciesService(depsSvc), repos.ObservedSource(log15.Root(), m))
 	}
 
 	updateScheduler := repos.NewUpdateScheduler(logger, db)
 	server := &repoupdater.Server{
+		Logger:                logger,
 		Store:                 store,
 		Scheduler:             updateScheduler,
 		GitserverClient:       gitserver.NewClient(db),
@@ -154,7 +153,7 @@ func Main(enterpriseInit EnterpriseInit) {
 	if err := server.RateLimitSyncer.SyncRateLimiters(ctx); err != nil {
 		// This is not a fatal error since the syncer has been added to the server above
 		// and will still be run whenever an external service is added or updated
-		log15.Error("Performing initial rate limit sync", "err", err)
+		logger.Error("Performing initial rate limit sync", log.Error(err))
 	}
 
 	// All dependencies ready
@@ -163,6 +162,7 @@ func Main(enterpriseInit EnterpriseInit) {
 		debugDumpers = enterpriseInit(db, store, keyring.Default(), cf, server)
 	}
 
+	// TODO(burmudar): update syncer to use lib/log
 	syncer := &repos.Syncer{
 		Sourcer: src,
 		Store:   store,
@@ -174,17 +174,20 @@ func Main(enterpriseInit EnterpriseInit) {
 		Registerer: prometheus.DefaultRegisterer,
 	}
 
-	go watchSyncer(ctx, syncer, updateScheduler, server.PermsSyncer)
+	go watchSyncer(ctx, logger, syncer, updateScheduler, server.PermsSyncer)
 	go func() {
-		log.Fatal(syncer.Run(ctx, store, repos.RunOptions{
+		err := syncer.Run(ctx, store, repos.RunOptions{
 			EnqueueInterval: repos.ConfRepoListUpdateInterval,
 			IsCloud:         envvar.SourcegraphDotComMode(),
 			MinSyncInterval: repos.ConfRepoListUpdateInterval,
-		}))
+		})
+		if err != nil {
+			logger.Fatal("syncer.Run failure", log.Error(err))
+		}
 	}()
 	server.Syncer = syncer
 
-	go syncScheduler(ctx, updateScheduler, store)
+	go syncScheduler(ctx, logger, updateScheduler, store)
 
 	if envvar.SourcegraphDotComMode() {
 		rateLimiter := rate.NewLimiter(.05, 1)
@@ -208,7 +211,7 @@ func Main(enterpriseInit EnterpriseInit) {
 	}
 
 	addr := net.JoinHostPort(host, port)
-	logger.Info("listening", sglog.String("addr", addr))
+	logger.Info("listening", log.String("addr", addr))
 
 	var handler http.Handler
 	{
@@ -216,7 +219,7 @@ func Main(enterpriseInit EnterpriseInit) {
 		m.MustRegister(prometheus.DefaultRegisterer)
 
 		handler = repoupdater.ObservedHandler(
-			log15.Root(),
+			logger,
 			m,
 			opentracing.GlobalTracer(),
 		)(server.Handler())
@@ -470,11 +473,12 @@ type permsSyncer interface {
 
 func watchSyncer(
 	ctx context.Context,
+	logger log.Logger,
 	syncer *repos.Syncer,
 	sched *repos.UpdateScheduler,
 	permsSyncer permsSyncer,
 ) {
-	log15.Debug("started new repo syncer updates scheduler relay thread")
+	logger.Debug("started new repo syncer updates scheduler relay thread")
 
 	for {
 		select {
@@ -516,7 +520,7 @@ func getPrivateAddedOrModifiedRepos(diff repos.Diff) []api.RepoID {
 // syncScheduler will periodically list the cloned repositories on gitserver and
 // update the scheduler with the list. It also ensures that if any of our default
 // repos are missing from the cloned list they will be added for cloning ASAP.
-func syncScheduler(ctx context.Context, sched *repos.UpdateScheduler, store repos.Store) {
+func syncScheduler(ctx context.Context, logger log.Logger, sched *repos.UpdateScheduler, store repos.Store) {
 	baseRepoStore := database.ReposWith(store)
 
 	doSync := func() {
@@ -532,7 +536,7 @@ func syncScheduler(ctx context.Context, sched *repos.UpdateScheduler, store repo
 			IncludePrivate: true,
 		}
 		if u, err := baseRepoStore.ListIndexableRepos(ctx, opts); err != nil {
-			log15.Error("Listing indexable repos", "error", err)
+			logger.Error("Listing indexable repos", log.Error(err))
 			return
 		} else {
 			// Ensure that uncloned indexable repos are known to the scheduler
@@ -545,7 +549,7 @@ func syncScheduler(ctx context.Context, sched *repos.UpdateScheduler, store repo
 
 		uncloned, err := baseRepoStore.ListMinimalRepos(ctx, database.ReposListOptions{IDs: managed, NoCloned: true})
 		if err != nil {
-			log15.Warn("failed to fetch list of uncloned repositories", "error", err)
+			logger.Warn("failed to fetch list of uncloned repositories", log.Error(err))
 			return
 		}
 

--- a/internal/repoupdater/protocol/repoupdater.go
+++ b/internal/repoupdater/protocol/repoupdater.go
@@ -246,6 +246,10 @@ type RepoUpdateResponse struct {
 	URL string `json:"url"`
 }
 
+func (a *RepoUpdateResponse) String() string {
+	return fmt.Sprintf("RepoUpdateResponse{ID: %d Name: %s URL: %s}", a.ID, a.Name, a.URL)
+}
+
 // ChangesetSyncRequest is a request to sync a number of changesets
 type ChangesetSyncRequest struct {
 	IDs []int64


### PR DESCRIPTION
Migrating logging from log15 to lib/log
* migrate server
* migrate observability log

Note:
Syncer will be done in a separate PR

Part of #34607 

## Test plan
Unit tests
```
ok  	github.com/sourcegraph/sourcegraph/internal/repos	(cached)
?   	github.com/sourcegraph/sourcegraph/cmd/repo-updater	[no test files]
ok  	github.com/sourcegraph/sourcegraph/cmd/repo-updater/repoupdater	(cached)
ok  	github.com/sourcegraph/sourcegraph/cmd/repo-updater/shared	(cached)
```
* Executed `sg start frontend gitserver repo-updater`