### PR TITLE
auth: Use configureable scope when refreshing GitLab token

### DIFF
--- a/enterprise/cmd/frontend/internal/auth/gitlaboauth/provider.go
+++ b/enterprise/cmd/frontend/internal/auth/gitlaboauth/provider.go
@@ -8,11 +8,11 @@ import (
 	"github.com/dghubble/gologin/v2"
 	"golang.org/x/oauth2"
 
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/auth/oauth"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/gitlab"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
@@ -37,7 +37,7 @@ func parseProvider(db database.DB, callbackURL string, p *schema.GitLabAuthProvi
 				RedirectURL:  callbackURL,
 				ClientID:     p.ClientID,
 				ClientSecret: p.ClientSecret,
-				Scopes:       requestedScopes(p.ApiScope, extraScopes),
+				Scopes:       gitlab.RequestedOAuthScopes(p.ApiScope, extraScopes),
 				Endpoint: oauth2.Endpoint{
 					AuthURL:  codeHost.BaseURL.ResolveReference(&url.URL{Path: "/oauth/authorize"}).String(),
 					TokenURL: codeHost.BaseURL.ResolveReference(&url.URL{Path: "/oauth/token"}).String(),
@@ -74,36 +74,4 @@ func getStateConfig() gologin.CookieConfig {
 		Secure:   conf.IsExternalURLSecure(),
 	}
 	return cfg
-}
-
-func requestedScopes(defaultAPIScope string, extraScopes []string) []string {
-	scopes := []string{"read_user"}
-	if defaultAPIScope == "" {
-		defaultAPIScope = "api"
-	}
-	if envvar.SourcegraphDotComMode() {
-		// By default, request `read_api`. User's who are allowed to add private code
-		// will request full `api` access via extraScopes.
-		scopes = append(scopes, "read_api")
-	} else {
-		// For customer instances we default to api scope so that they can clone private
-		// repos but in they can optionally override this in config.
-		scopes = append(scopes, defaultAPIScope)
-	}
-	// Append extra scopes and ensure there are no duplicates
-	for _, s := range extraScopes {
-		var found bool
-		for _, inner := range scopes {
-			if inner == s {
-				found = true
-				break
-			}
-		}
-
-		if !found {
-			scopes = append(scopes, s)
-		}
-	}
-
-	return scopes
 }

--- a/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
+++ b/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
@@ -253,7 +253,7 @@ func (s *PermsSyncer) maybeRefreshGitLabOAuthToken(ctx context.Context, acct *ex
 				AuthURL:  url + "/oauth/authorize",
 				TokenURL: url + "/oauth/token",
 			},
-			Scopes: []string{"read_user", "api"},
+			Scopes: gitlab.RequestedOAuthScopes(authProvider.Gitlab.ApiScope, nil),
 		}
 		break
 	}

--- a/internal/extsvc/gitlab/auth.go
+++ b/internal/extsvc/gitlab/auth.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/auth"
 )
 
@@ -27,4 +28,38 @@ func (pat *SudoableToken) Authenticate(req *http.Request) error {
 
 func (pat *SudoableToken) Hash() string {
 	return fmt.Sprintf("pat::sudoku:%s::%s", pat.Sudo, pat.Token)
+}
+
+// RequestedOAuthScopes returns the list of OAuth scopes given the default API
+// scope and any extra scopes.
+func RequestedOAuthScopes(defaultAPIScope string, extraScopes []string) []string {
+	scopes := []string{"read_user"}
+	if defaultAPIScope == "" {
+		defaultAPIScope = "api"
+	}
+	if envvar.SourcegraphDotComMode() {
+		// By default, request `read_api`. User's who are allowed to add private code
+		// will request full `api` access via extraScopes.
+		scopes = append(scopes, "read_api")
+	} else {
+		// For customer instances we default to api scope so that they can clone private
+		// repos but in they can optionally override this in config.
+		scopes = append(scopes, defaultAPIScope)
+	}
+	// Append extra scopes and ensure there are no duplicates
+	for _, s := range extraScopes {
+		var found bool
+		for _, inner := range scopes {
+			if inner == s {
+				found = true
+				break
+			}
+		}
+
+		if !found {
+			scopes = append(scopes, s)
+		}
+	}
+
+	return scopes
 }


### PR DESCRIPTION
Instead of always defaulting to 'api' scope.

# Test plan

Existing unit tests