### PR TITLE
codeintel: add sequence number and optype to audit logs

### DIFF
--- a/internal/database/schema.json
+++ b/internal/database/schema.json
@@ -9,6 +9,14 @@
   ],
   "Enums": [
     {
+      "Name": "audit_log_operation",
+      "Labels": [
+        "create",
+        "modify",
+        "delete"
+      ]
+    },
+    {
       "Name": "batch_changes_changeset_ui_publication_state",
       "Labels": [
         "UNPUBLISHED",
@@ -82,7 +90,7 @@
     },
     {
       "Name": "func_configuration_policies_insert",
-      "Definition": "CREATE OR REPLACE FUNCTION public.func_configuration_policies_insert()\n RETURNS trigger\n LANGUAGE plpgsql\nAS $function$\n    BEGIN\n        INSERT INTO configuration_policies_audit_logs\n        (policy_id, transition_columns)\n        VALUES (\n            NEW.id,\n            func_configuration_policies_transition_columns_diff(\n                (NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL),\n                func_row_to_configuration_policies_transition_columns(NEW)\n            )\n        );\n        RETURN NULL;\n    END;\n$function$\n"
+      "Definition": "CREATE OR REPLACE FUNCTION public.func_configuration_policies_insert()\n RETURNS trigger\n LANGUAGE plpgsql\nAS $function$\n    BEGIN\n        INSERT INTO configuration_policies_audit_logs\n        (policy_id, operation, transition_columns)\n        VALUES (\n            NEW.id, 'create',\n            func_configuration_policies_transition_columns_diff(\n                (NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL),\n                func_row_to_configuration_policies_transition_columns(NEW)\n            )\n        );\n        RETURN NULL;\n    END;\n$function$\n"
     },
     {
       "Name": "func_configuration_policies_transition_columns_diff",
@@ -90,7 +98,7 @@
     },
     {
       "Name": "func_configuration_policies_update",
-      "Definition": "CREATE OR REPLACE FUNCTION public.func_configuration_policies_update()\n RETURNS trigger\n LANGUAGE plpgsql\nAS $function$\n    DECLARE\n        diff hstore[];\n    BEGIN\n        diff = func_configuration_policies_transition_columns_diff(\n            func_row_to_configuration_policies_transition_columns(OLD),\n            func_row_to_configuration_policies_transition_columns(NEW)\n        );\n\n        IF (array_length(diff, 1) \u003e 0) THEN\n            INSERT INTO configuration_policies_audit_logs\n            (policy_id, transition_columns)\n            VALUES (\n                NEW.id,\n                diff\n            );\n        END IF;\n\n        RETURN NEW;\n    END;\n$function$\n"
+      "Definition": "CREATE OR REPLACE FUNCTION public.func_configuration_policies_update()\n RETURNS trigger\n LANGUAGE plpgsql\nAS $function$\n    DECLARE\n        diff hstore[];\n    BEGIN\n        diff = func_configuration_policies_transition_columns_diff(\n            func_row_to_configuration_policies_transition_columns(OLD),\n            func_row_to_configuration_policies_transition_columns(NEW)\n        );\n\n        IF (array_length(diff, 1) \u003e 0) THEN\n            INSERT INTO configuration_policies_audit_logs\n            (policy_id, operation, transition_columns)\n            VALUES (NEW.id, 'modify', diff);\n        END IF;\n\n        RETURN NEW;\n    END;\n$function$\n"
     },
     {
       "Name": "func_insert_gitserver_repo",
@@ -102,7 +110,7 @@
     },
     {
       "Name": "func_lsif_uploads_insert",
-      "Definition": "CREATE OR REPLACE FUNCTION public.func_lsif_uploads_insert()\n RETURNS trigger\n LANGUAGE plpgsql\nAS $function$\n    BEGIN\n        INSERT INTO lsif_uploads_audit_logs\n        (upload_id, commit, root, repository_id, uploaded_at,\n        indexer, indexer_version, upload_size, associated_index_id,\n        transition_columns)\n        VALUES (\n            NEW.id, NEW.commit, NEW.root, NEW.repository_id, NEW.uploaded_at,\n            NEW.indexer, NEW.indexer_version, NEW.upload_size, NEW.associated_index_id,\n            func_lsif_uploads_transition_columns_diff(\n                (NULL, NULL, NULL, NULL, NULL, NULL),\n                func_row_to_lsif_uploads_transition_columns(NEW)\n            )\n        );\n        RETURN NULL;\n    END;\n$function$\n"
+      "Definition": "CREATE OR REPLACE FUNCTION public.func_lsif_uploads_insert()\n RETURNS trigger\n LANGUAGE plpgsql\nAS $function$\n    BEGIN\n        INSERT INTO lsif_uploads_audit_logs\n        (upload_id, commit, root, repository_id, uploaded_at,\n        indexer, indexer_version, upload_size, associated_index_id,\n        operation, transition_columns)\n        VALUES (\n            NEW.id, NEW.commit, NEW.root, NEW.repository_id, NEW.uploaded_at,\n            NEW.indexer, NEW.indexer_version, NEW.upload_size, NEW.associated_index_id,\n            'create', func_lsif_uploads_transition_columns_diff(\n                (NULL, NULL, NULL, NULL, NULL, NULL),\n                func_row_to_lsif_uploads_transition_columns(NEW)\n            )\n        );\n        RETURN NULL;\n    END;\n$function$\n"
     },
     {
       "Name": "func_lsif_uploads_transition_columns_diff",
@@ -110,7 +118,7 @@
     },
     {
       "Name": "func_lsif_uploads_update",
-      "Definition": "CREATE OR REPLACE FUNCTION public.func_lsif_uploads_update()\n RETURNS trigger\n LANGUAGE plpgsql\nAS $function$\n    DECLARE\n        diff hstore[];\n    BEGIN\n        diff = func_lsif_uploads_transition_columns_diff(\n            func_row_to_lsif_uploads_transition_columns(OLD),\n            func_row_to_lsif_uploads_transition_columns(NEW)\n        );\n\n        IF (array_length(diff, 1) \u003e 0) THEN\n            INSERT INTO lsif_uploads_audit_logs\n            (reason, upload_id, commit, root, repository_id, uploaded_at,\n            indexer, indexer_version, upload_size, associated_index_id,\n            transition_columns)\n            VALUES (\n                COALESCE(current_setting('codeintel.lsif_uploads_audit.reason', true), ''),\n                NEW.id, NEW.commit, NEW.root, NEW.repository_id, NEW.uploaded_at,\n                NEW.indexer, NEW.indexer_version, NEW.upload_size, NEW.associated_index_id,\n                diff\n            );\n        END IF;\n\n        RETURN NEW;\n    END;\n$function$\n"
+      "Definition": "CREATE OR REPLACE FUNCTION public.func_lsif_uploads_update()\n RETURNS trigger\n LANGUAGE plpgsql\nAS $function$\n    DECLARE\n        diff hstore[];\n    BEGIN\n        diff = func_lsif_uploads_transition_columns_diff(\n            func_row_to_lsif_uploads_transition_columns(OLD),\n            func_row_to_lsif_uploads_transition_columns(NEW)\n        );\n\n        IF (array_length(diff, 1) \u003e 0) THEN\n            INSERT INTO lsif_uploads_audit_logs\n            (reason, upload_id, commit, root, repository_id, uploaded_at,\n            indexer, indexer_version, upload_size, associated_index_id,\n            operation, transition_columns)\n            VALUES (\n                COALESCE(current_setting('codeintel.lsif_uploads_audit.reason', true), ''),\n                NEW.id, NEW.commit, NEW.root, NEW.repository_id, NEW.uploaded_at,\n                NEW.indexer, NEW.indexer_version, NEW.upload_size, NEW.associated_index_id,\n                'modify', diff\n            );\n        END IF;\n\n        RETURN NEW;\n    END;\n$function$\n"
     },
     {
       "Name": "func_row_to_configuration_policies_transition_columns",
@@ -358,6 +366,15 @@
       "CycleOption": "NO"
     },
     {
+      "Name": "configuration_policies_audit_logs_seq",
+      "TypeName": "bigint",
+      "StartValue": 1,
+      "MinimumValue": 1,
+      "MaximumValue": 9223372036854775807,
+      "Increment": 1,
+      "CycleOption": "NO"
+    },
+    {
       "Name": "critical_and_site_config_id_seq",
       "TypeName": "bigint",
       "StartValue": 1,
@@ -552,6 +569,15 @@
       "StartValue": 1,
       "MinimumValue": 1,
       "MaximumValue": 2147483647,
+      "Increment": 1,
+      "CycleOption": "NO"
+    },
+    {
+      "Name": "lsif_uploads_audit_logs_seq",
+      "TypeName": "bigint",
+      "StartValue": 1,
+      "MinimumValue": 1,
+      "MaximumValue": 9223372036854775807,
       "Increment": 1,
       "CycleOption": "NO"
     },
@@ -5723,6 +5749,19 @@
           "Comment": "Timestamp for this log entry."
         },
         {
+          "Name": "operation",
+          "Index": 6,
+          "TypeName": "audit_log_operation",
+          "IsNullable": false,
+          "Default": "",
+          "CharacterMaximumLength": 0,
+          "IsIdentity": false,
+          "IdentityGeneration": "",
+          "IsGenerated": "NEVER",
+          "GenerationExpression": "",
+          "Comment": ""
+        },
+        {
           "Name": "policy_id",
           "Index": 3,
           "TypeName": "integer",
@@ -5747,6 +5786,19 @@
           "IsGenerated": "NEVER",
           "GenerationExpression": "",
           "Comment": "Set once the upload this entry is associated with is deleted. Once NOW() - record_deleted_at is above a certain threshold, this log entry will be deleted."
+        },
+        {
+          "Name": "sequence",
+          "Index": 5,
+          "TypeName": "bigint",
+          "IsNullable": false,
+          "Default": "nextval('configuration_policies_audit_logs_seq'::regclass)",
+          "CharacterMaximumLength": 0,
+          "IsIdentity": false,
+          "IdentityGeneration": "",
+          "IsGenerated": "NEVER",
+          "GenerationExpression": "",
+          "Comment": ""
         },
         {
           "Name": "transition_columns",
@@ -11383,6 +11435,19 @@
           "Comment": "Timestamp for this log entry."
         },
         {
+          "Name": "operation",
+          "Index": 16,
+          "TypeName": "audit_log_operation",
+          "IsNullable": false,
+          "Default": "",
+          "CharacterMaximumLength": 0,
+          "IsIdentity": false,
+          "IdentityGeneration": "",
+          "IsGenerated": "NEVER",
+          "GenerationExpression": "",
+          "Comment": ""
+        },
+        {
           "Name": "reason",
           "Index": 14,
           "TypeName": "text",
@@ -11427,6 +11492,19 @@
           "TypeName": "text",
           "IsNullable": false,
           "Default": "",
+          "CharacterMaximumLength": 0,
+          "IsIdentity": false,
+          "IdentityGeneration": "",
+          "IsGenerated": "NEVER",
+          "GenerationExpression": "",
+          "Comment": ""
+        },
+        {
+          "Name": "sequence",
+          "Index": 15,
+          "TypeName": "bigint",
+          "IsNullable": false,
+          "Default": "nextval('lsif_uploads_audit_logs_seq'::regclass)",
           "CharacterMaximumLength": 0,
           "IsIdentity": false,
           "IdentityGeneration": "",

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -724,12 +724,14 @@ Associates a repository-commit pair with the set of repository-level dependencie
 
 # Table "public.configuration_policies_audit_logs"
 ```
-       Column       |           Type           | Collation | Nullable |      Default      
---------------------+--------------------------+-----------+----------+-------------------
+       Column       |           Type           | Collation | Nullable |                          Default                           
+--------------------+--------------------------+-----------+----------+------------------------------------------------------------
  log_timestamp      | timestamp with time zone |           |          | clock_timestamp()
  record_deleted_at  | timestamp with time zone |           |          | 
  policy_id          | integer                  |           | not null | 
  transition_columns | USER-DEFINED[]           |           |          | 
+ sequence           | bigint                   |           | not null | nextval('configuration_policies_audit_logs_seq'::regclass)
+ operation          | audit_log_operation      |           | not null | 
 Indexes:
     "configuration_policies_audit_logs_policy_id" btree (policy_id)
     "configuration_policies_audit_logs_timestamp" brin (log_timestamp)
@@ -1707,8 +1709,8 @@ Stores metadata about an LSIF index uploaded by a user.
 
 # Table "public.lsif_uploads_audit_logs"
 ```
-       Column        |           Type           | Collation | Nullable | Default  
----------------------+--------------------------+-----------+----------+----------
+       Column        |           Type           | Collation | Nullable |                     Default                      
+---------------------+--------------------------+-----------+----------+--------------------------------------------------
  log_timestamp       | timestamp with time zone |           |          | now()
  record_deleted_at   | timestamp with time zone |           |          | 
  upload_id           | integer                  |           | not null | 
@@ -1722,6 +1724,8 @@ Stores metadata about an LSIF index uploaded by a user.
  associated_index_id | integer                  |           |          | 
  transition_columns  | USER-DEFINED[]           |           |          | 
  reason              | text                     |           |          | ''::text
+ sequence            | bigint                   |           | not null | nextval('lsif_uploads_audit_logs_seq'::regclass)
+ operation           | audit_log_operation      |           | not null | 
 Indexes:
     "lsif_uploads_audit_logs_timestamp" brin (log_timestamp)
     "lsif_uploads_audit_logs_upload_id" btree (upload_id)
@@ -2974,6 +2978,12 @@ Foreign-key constraints:
      JOIN repo ON ((changeset_specs.repo_id = repo.id)))
   WHERE ((changeset_specs.external_id IS NOT NULL) AND (repo.deleted_at IS NULL));
 ```
+
+# Type audit_log_operation
+
+- create
+- modify
+- delete
 
 # Type batch_changes_changeset_ui_publication_state
 

--- a/migrations/frontend/1653479179/down.sql
+++ b/migrations/frontend/1653479179/down.sql
@@ -1,0 +1,96 @@
+ALTER TABLE lsif_uploads_audit_logs
+DROP COLUMN IF EXISTS sequence,
+DROP COLUMN IF EXISTS operation;
+
+ALTER SEQUENCE IF EXISTS lsif_uploads_audit_logs_seq OWNED BY NONE;
+DROP SEQUENCE IF EXISTS lsif_uploads_audit_logs_seq;
+
+ALTER TABLE configuration_policies_audit_logs
+DROP COLUMN IF EXISTS sequence,
+DROP COLUMN IF EXISTS operation;
+
+ALTER SEQUENCE IF EXISTS configuration_policies_audit_logs_seq OWNED BY NONE;
+DROP SEQUENCE IF EXISTS configuration_policies_audit_logs_seq;
+
+DROP TYPE IF EXISTS audit_log_operation;
+
+CREATE OR REPLACE FUNCTION func_configuration_policies_update() RETURNS TRIGGER AS $$
+    DECLARE
+        diff hstore[];
+    BEGIN
+        diff = func_configuration_policies_transition_columns_diff(
+            func_row_to_configuration_policies_transition_columns(OLD),
+            func_row_to_configuration_policies_transition_columns(NEW)
+        );
+
+        IF (array_length(diff, 1) > 0) THEN
+            INSERT INTO configuration_policies_audit_logs
+            (policy_id, transition_columns)
+            VALUES (
+                NEW.id,
+                diff
+            );
+        END IF;
+
+        RETURN NEW;
+    END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION func_configuration_policies_insert() RETURNS TRIGGER AS $$
+    BEGIN
+        INSERT INTO configuration_policies_audit_logs
+        (policy_id, transition_columns)
+        VALUES (
+            NEW.id,
+            func_configuration_policies_transition_columns_diff(
+                (NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL),
+                func_row_to_configuration_policies_transition_columns(NEW)
+            )
+        );
+        RETURN NULL;
+    END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION func_lsif_uploads_update() RETURNS TRIGGER AS $$
+    DECLARE
+        diff hstore[];
+    BEGIN
+        diff = func_lsif_uploads_transition_columns_diff(
+            func_row_to_lsif_uploads_transition_columns(OLD),
+            func_row_to_lsif_uploads_transition_columns(NEW)
+        );
+
+        IF (array_length(diff, 1) > 0) THEN
+            INSERT INTO lsif_uploads_audit_logs
+            (reason, upload_id, commit, root, repository_id, uploaded_at,
+            indexer, indexer_version, upload_size, associated_index_id,
+            transition_columns)
+            VALUES (
+                COALESCE(current_setting('codeintel.lsif_uploads_audit.reason', true), ''),
+                NEW.id, NEW.commit, NEW.root, NEW.repository_id, NEW.uploaded_at,
+                NEW.indexer, NEW.indexer_version, NEW.upload_size, NEW.associated_index_id,
+                diff
+            );
+        END IF;
+
+        RETURN NEW;
+    END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION func_lsif_uploads_insert() RETURNS TRIGGER AS $$
+    BEGIN
+        INSERT INTO lsif_uploads_audit_logs
+        (upload_id, commit, root, repository_id, uploaded_at,
+        indexer, indexer_version, upload_size, associated_index_id,
+        transition_columns)
+        VALUES (
+            NEW.id, NEW.commit, NEW.root, NEW.repository_id, NEW.uploaded_at,
+            NEW.indexer, NEW.indexer_version, NEW.upload_size, NEW.associated_index_id,
+            func_lsif_uploads_transition_columns_diff(
+                (NULL, NULL, NULL, NULL, NULL, NULL),
+                func_row_to_lsif_uploads_transition_columns(NEW)
+            )
+        );
+        RETURN NULL;
+    END;
+$$ LANGUAGE plpgsql;

--- a/migrations/frontend/1653479179/down.sql
+++ b/migrations/frontend/1653479179/down.sql
@@ -2,14 +2,12 @@ ALTER TABLE lsif_uploads_audit_logs
 DROP COLUMN IF EXISTS sequence,
 DROP COLUMN IF EXISTS operation;
 
-ALTER SEQUENCE IF EXISTS lsif_uploads_audit_logs_seq OWNED BY NONE;
 DROP SEQUENCE IF EXISTS lsif_uploads_audit_logs_seq;
 
 ALTER TABLE configuration_policies_audit_logs
 DROP COLUMN IF EXISTS sequence,
 DROP COLUMN IF EXISTS operation;
 
-ALTER SEQUENCE IF EXISTS configuration_policies_audit_logs_seq OWNED BY NONE;
 DROP SEQUENCE IF EXISTS configuration_policies_audit_logs_seq;
 
 DROP TYPE IF EXISTS audit_log_operation;

--- a/migrations/frontend/1653479179/metadata.yaml
+++ b/migrations/frontend/1653479179/metadata.yaml
@@ -1,0 +1,2 @@
+name: audit_log_op_and_seq
+parents: [1652946496, 1653334014]

--- a/migrations/frontend/1653479179/up.sql
+++ b/migrations/frontend/1653479179/up.sql
@@ -1,0 +1,114 @@
+DROP TYPE IF EXISTS audit_log_operation;
+-- delete is known by record_deleted_at
+CREATE TYPE audit_log_operation AS ENUM('create', 'modify');
+
+CREATE SEQUENCE IF NOT EXISTS lsif_uploads_audit_logs_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+CREATE SEQUENCE IF NOT EXISTS configuration_policies_audit_logs_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+-- table not been used yet
+TRUNCATE TABLE lsif_uploads_audit_logs;
+TRUNCATE TABLE configuration_policies_audit_logs;
+
+ALTER TABLE lsif_uploads_audit_logs
+ADD COLUMN IF NOT EXISTS sequence BIGINT NOT NULL,
+ADD COLUMN IF NOT EXISTS operation audit_log_operation NOT NULL;
+
+ALTER TABLE configuration_policies_audit_logs
+ADD COLUMN IF NOT EXISTS sequence BIGINT NOT NULL,
+ADD COLUMN IF NOT EXISTS operation audit_log_operation NOT NULL;
+
+ALTER SEQUENCE lsif_uploads_audit_logs_seq OWNED BY lsif_uploads_audit_logs.sequence;
+ALTER SEQUENCE configuration_policies_audit_logs_seq OWNED BY configuration_policies_audit_logs.sequence;
+
+-- Start replace triggers
+
+CREATE OR REPLACE FUNCTION func_lsif_uploads_update() RETURNS TRIGGER AS $$
+    DECLARE
+        diff hstore[];
+    BEGIN
+        diff = func_lsif_uploads_transition_columns_diff(
+            func_row_to_lsif_uploads_transition_columns(OLD),
+            func_row_to_lsif_uploads_transition_columns(NEW)
+        );
+
+        IF (array_length(diff, 1) > 0) THEN
+            INSERT INTO lsif_uploads_audit_logs
+            (reason, upload_id, commit, root, repository_id, uploaded_at,
+            indexer, indexer_version, upload_size, associated_index_id,
+            operation, transition_columns)
+            VALUES (
+                COALESCE(current_setting('codeintel.lsif_uploads_audit.reason', true), ''),
+                NEW.id, NEW.commit, NEW.root, NEW.repository_id, NEW.uploaded_at,
+                NEW.indexer, NEW.indexer_version, NEW.upload_size, NEW.associated_index_id,
+                'modify', diff
+            );
+        END IF;
+
+        RETURN NEW;
+    END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION func_lsif_uploads_insert() RETURNS TRIGGER AS $$
+    BEGIN
+        INSERT INTO lsif_uploads_audit_logs
+        (upload_id, commit, root, repository_id, uploaded_at,
+        indexer, indexer_version, upload_size, associated_index_id,
+        operation, transition_columns)
+        VALUES (
+            NEW.id, NEW.commit, NEW.root, NEW.repository_id, NEW.uploaded_at,
+            NEW.indexer, NEW.indexer_version, NEW.upload_size, NEW.associated_index_id,
+            'create', func_lsif_uploads_transition_columns_diff(
+                (NULL, NULL, NULL, NULL, NULL, NULL),
+                func_row_to_lsif_uploads_transition_columns(NEW)
+            )
+        );
+        RETURN NULL;
+    END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION func_configuration_policies_update() RETURNS TRIGGER AS $$
+    DECLARE
+        diff hstore[];
+    BEGIN
+        diff = func_configuration_policies_transition_columns_diff(
+            func_row_to_configuration_policies_transition_columns(OLD),
+            func_row_to_configuration_policies_transition_columns(NEW)
+        );
+
+        IF (array_length(diff, 1) > 0) THEN
+            INSERT INTO configuration_policies_audit_logs
+            (policy_id, operation, transition_columns)
+            VALUES (NEW.id, 'modify', diff);
+        END IF;
+
+        RETURN NEW;
+    END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION func_configuration_policies_insert() RETURNS TRIGGER AS $$
+    BEGIN
+        INSERT INTO configuration_policies_audit_logs
+        (policy_id, operation, transition_columns)
+        VALUES (
+            NEW.id, 'create',
+            func_configuration_policies_transition_columns_diff(
+                (NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL),
+                func_row_to_configuration_policies_transition_columns(NEW)
+            )
+        );
+        RETURN NULL;
+    END;
+$$ LANGUAGE plpgsql;
+
+-- End replace triggers

--- a/migrations/frontend/1653479179/up.sql
+++ b/migrations/frontend/1653479179/up.sql
@@ -1,6 +1,11 @@
-DROP TYPE IF EXISTS audit_log_operation;
--- delete is known by record_deleted_at
-CREATE TYPE audit_log_operation AS ENUM('create', 'modify');
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'audit_log_operation') THEN
+        -- delete is known by record_deleted_at
+        CREATE TYPE audit_log_operation AS ENUM('create', 'modify');
+    END IF;
+END
+$$;
 
 CREATE SEQUENCE IF NOT EXISTS lsif_uploads_audit_logs_seq
     START WITH 1

--- a/migrations/frontend/1653479179/up.sql
+++ b/migrations/frontend/1653479179/up.sql
@@ -26,11 +26,11 @@ TRUNCATE TABLE lsif_uploads_audit_logs;
 TRUNCATE TABLE configuration_policies_audit_logs;
 
 ALTER TABLE lsif_uploads_audit_logs
-ADD COLUMN IF NOT EXISTS sequence BIGINT NOT NULL,
+ADD COLUMN IF NOT EXISTS sequence BIGINT NOT NULL DEFAULT nextval('lsif_uploads_audit_logs_seq'::regclass),
 ADD COLUMN IF NOT EXISTS operation audit_log_operation NOT NULL;
 
 ALTER TABLE configuration_policies_audit_logs
-ADD COLUMN IF NOT EXISTS sequence BIGINT NOT NULL,
+ADD COLUMN IF NOT EXISTS sequence BIGINT NOT NULL DEFAULT nextval('configuration_policies_audit_logs_seq'::regclass),
 ADD COLUMN IF NOT EXISTS operation audit_log_operation NOT NULL;
 
 ALTER SEQUENCE lsif_uploads_audit_logs_seq OWNED BY lsif_uploads_audit_logs.sequence;

--- a/migrations/frontend/1653479179/up.sql
+++ b/migrations/frontend/1653479179/up.sql
@@ -2,7 +2,7 @@ DO $$
 BEGIN
     IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'audit_log_operation') THEN
         -- delete is known by record_deleted_at
-        CREATE TYPE audit_log_operation AS ENUM('create', 'modify');
+        CREATE TYPE audit_log_operation AS ENUM('create', 'modify', 'delete');
     END IF;
 END
 $$;

--- a/migrations/frontend/squashed.sql
+++ b/migrations/frontend/squashed.sql
@@ -22,6 +22,12 @@ CREATE EXTENSION IF NOT EXISTS pgcrypto;
 
 COMMENT ON EXTENSION pgcrypto IS 'cryptographic functions';
 
+CREATE TYPE audit_log_operation AS ENUM (
+    'create',
+    'modify',
+    'delete'
+);
+
 CREATE TYPE batch_changes_changeset_ui_publication_state AS ENUM (
     'UNPUBLISHED',
     'DRAFT',
@@ -143,9 +149,9 @@ CREATE FUNCTION func_configuration_policies_insert() RETURNS trigger
     AS $$
     BEGIN
         INSERT INTO configuration_policies_audit_logs
-        (policy_id, transition_columns)
+        (policy_id, operation, transition_columns)
         VALUES (
-            NEW.id,
+            NEW.id, 'create',
             func_configuration_policies_transition_columns_diff(
                 (NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL),
                 func_row_to_configuration_policies_transition_columns(NEW)
@@ -224,11 +230,8 @@ CREATE FUNCTION func_configuration_policies_update() RETURNS trigger
 
         IF (array_length(diff, 1) > 0) THEN
             INSERT INTO configuration_policies_audit_logs
-            (policy_id, transition_columns)
-            VALUES (
-                NEW.id,
-                diff
-            );
+            (policy_id, operation, transition_columns)
+            VALUES (NEW.id, 'modify', diff);
         END IF;
 
         RETURN NEW;
@@ -267,11 +270,11 @@ CREATE FUNCTION func_lsif_uploads_insert() RETURNS trigger
         INSERT INTO lsif_uploads_audit_logs
         (upload_id, commit, root, repository_id, uploaded_at,
         indexer, indexer_version, upload_size, associated_index_id,
-        transition_columns)
+        operation, transition_columns)
         VALUES (
             NEW.id, NEW.commit, NEW.root, NEW.repository_id, NEW.uploaded_at,
             NEW.indexer, NEW.indexer_version, NEW.upload_size, NEW.associated_index_id,
-            func_lsif_uploads_transition_columns_diff(
+            'create', func_lsif_uploads_transition_columns_diff(
                 (NULL, NULL, NULL, NULL, NULL, NULL),
                 func_row_to_lsif_uploads_transition_columns(NEW)
             )
@@ -335,12 +338,12 @@ CREATE FUNCTION func_lsif_uploads_update() RETURNS trigger
             INSERT INTO lsif_uploads_audit_logs
             (reason, upload_id, commit, root, repository_id, uploaded_at,
             indexer, indexer_version, upload_size, associated_index_id,
-            transition_columns)
+            operation, transition_columns)
             VALUES (
                 COALESCE(current_setting('codeintel.lsif_uploads_audit.reason', true), ''),
                 NEW.id, NEW.commit, NEW.root, NEW.repository_id, NEW.uploaded_at,
                 NEW.indexer, NEW.indexer_version, NEW.upload_size, NEW.associated_index_id,
-                diff
+                'modify', diff
             );
         END IF;
 
@@ -1163,7 +1166,9 @@ CREATE TABLE configuration_policies_audit_logs (
     log_timestamp timestamp with time zone DEFAULT clock_timestamp(),
     record_deleted_at timestamp with time zone,
     policy_id integer NOT NULL,
-    transition_columns hstore[]
+    transition_columns hstore[],
+    sequence bigint NOT NULL,
+    operation audit_log_operation NOT NULL
 );
 
 COMMENT ON COLUMN configuration_policies_audit_logs.log_timestamp IS 'Timestamp for this log entry.';
@@ -1171,6 +1176,15 @@ COMMENT ON COLUMN configuration_policies_audit_logs.log_timestamp IS 'Timestamp 
 COMMENT ON COLUMN configuration_policies_audit_logs.record_deleted_at IS 'Set once the upload this entry is associated with is deleted. Once NOW() - record_deleted_at is above a certain threshold, this log entry will be deleted.';
 
 COMMENT ON COLUMN configuration_policies_audit_logs.transition_columns IS 'Array of changes that occurred to the upload for this entry, in the form of {"column"=>"<column name>", "old"=>"<previous value>", "new"=>"<new value>"}.';
+
+CREATE SEQUENCE configuration_policies_audit_logs_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+ALTER SEQUENCE configuration_policies_audit_logs_seq OWNED BY configuration_policies_audit_logs.sequence;
 
 CREATE TABLE critical_and_site_config (
     id integer NOT NULL,
@@ -2134,7 +2148,9 @@ CREATE TABLE lsif_uploads_audit_logs (
     upload_size integer,
     associated_index_id integer,
     transition_columns hstore[],
-    reason text DEFAULT ''::text
+    reason text DEFAULT ''::text,
+    sequence bigint NOT NULL,
+    operation audit_log_operation NOT NULL
 );
 
 COMMENT ON COLUMN lsif_uploads_audit_logs.log_timestamp IS 'Timestamp for this log entry.';
@@ -2144,6 +2160,15 @@ COMMENT ON COLUMN lsif_uploads_audit_logs.record_deleted_at IS 'Set once the upl
 COMMENT ON COLUMN lsif_uploads_audit_logs.transition_columns IS 'Array of changes that occurred to the upload for this entry, in the form of {"column"=>"<column name>", "old"=>"<previous value>", "new"=>"<new value>"}.';
 
 COMMENT ON COLUMN lsif_uploads_audit_logs.reason IS 'The reason/source for this entry.';
+
+CREATE SEQUENCE lsif_uploads_audit_logs_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+ALTER SEQUENCE lsif_uploads_audit_logs_seq OWNED BY lsif_uploads_audit_logs.sequence;
 
 CREATE TABLE lsif_uploads_visible_at_tip (
     repository_id integer NOT NULL,
@@ -2950,6 +2975,8 @@ ALTER TABLE ONLY codeintel_lockfile_references ALTER COLUMN id SET DEFAULT nextv
 
 ALTER TABLE ONLY codeintel_lockfiles ALTER COLUMN id SET DEFAULT nextval('codeintel_lockfiles_id_seq'::regclass);
 
+ALTER TABLE ONLY configuration_policies_audit_logs ALTER COLUMN sequence SET DEFAULT nextval('configuration_policies_audit_logs_seq'::regclass);
+
 ALTER TABLE ONLY critical_and_site_config ALTER COLUMN id SET DEFAULT nextval('critical_and_site_config_id_seq'::regclass);
 
 ALTER TABLE ONLY discussion_comments ALTER COLUMN id SET DEFAULT nextval('discussion_comments_id_seq'::regclass);
@@ -2991,6 +3018,8 @@ ALTER TABLE ONLY lsif_references ALTER COLUMN id SET DEFAULT nextval('lsif_refer
 ALTER TABLE ONLY lsif_retention_configuration ALTER COLUMN id SET DEFAULT nextval('lsif_retention_configuration_id_seq'::regclass);
 
 ALTER TABLE ONLY lsif_uploads ALTER COLUMN id SET DEFAULT nextval('lsif_dumps_id_seq'::regclass);
+
+ALTER TABLE ONLY lsif_uploads_audit_logs ALTER COLUMN sequence SET DEFAULT nextval('lsif_uploads_audit_logs_seq'::regclass);
 
 ALTER TABLE ONLY notebooks ALTER COLUMN id SET DEFAULT nextval('notebooks_id_seq'::regclass);
 


### PR DESCRIPTION
No optype for delete, as the time of delete can be trivially and unambiguously derived from `record_deleted_at` column. The rest of this is just replacing triggers and the inverse for down migration.

## Test plan

Will be caught by back-compat and existing tests as they are triggers
