### PR TITLE
sg: link to docs on migration when creating

### DIFF
--- a/dev/sg/internal/migration/add.go
+++ b/dev/sg/internal/migration/add.go
@@ -68,6 +68,9 @@ func add(database db.Database, migrationName, upMigrationFileTemplate, downMigra
 	block.Writef("Down query file: %s", rootRelative(files.DownFile))
 	block.Writef("Metadata file: %s", rootRelative(files.MetadataFile))
 	block.Close()
+	line := output.Styled(output.StyleUnderline, "https://docs.sourcegraph.com/dev/background-information/sql/migrations")
+	line.Prefix = "Checkout the development docs for migrations: "
+	std.Out.WriteLine(line)
 
 	return nil
 }


### PR DESCRIPTION
I forgot we even had these docs until @efritz reminded me of them, so I thought it'd be a good idea to link to them when creating a migration

![image](https://user-images.githubusercontent.com/18282288/170337484-9d4f12a6-8e7a-4678-b2c6-e63793bcb318.png)


## Test plan

N/A, just adding output to `sg`
