### PR TITLE
Ignore go.work.sum in addition to go.work

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -173,6 +173,7 @@ test-reports/
 
 # go workspace files shouldn't be committed
 go.work
+go.work.sum
 
 # binary
 /sg


### PR DESCRIPTION
This adds `go.work.sum` to the `.gitignore` in addition to `go.work` so that
it is not accidentally committed. These files shouldn't be commited since
they are specific to a local dev environment.

The `go.work` ignore entry was added in 738affd

## Test plan

Tested that the file is no longer tracked by git. 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
