### PR TITLE
Make the "Copy link" button fixed width to avoid jank

### DIFF
--- a/client/shared/src/hover/HoverOverlay.module.scss
+++ b/client/shared/src/hover/HoverOverlay.module.scss
@@ -111,6 +111,7 @@
     color: var(--link-color);
     border-style: none;
     background: transparent;
+    width: 5.1rem;
 
     > span:last-child {
         padding-left: 0.2rem;


### PR DESCRIPTION
> It seems [some tokens shift in popover width](https://www.loom.com/share/0919c0ae447b4d0881d28d80e8cd0ab8) when copying the link, probably due to the difference in the “Link copied” and “copied” length. But some don’t shift.

From [Slack](https://sourcegraph.slack.com/archives/CHXHX7XAS/p1653529747995279?thread_ts=1653469155.353199&cid=CHXHX7XAS).

## Test plan

Manual

## App preview:

- [Web](https://sg-web-copy-link-fixed-width.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-nvzqlqzzmz.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
