### PR TITLE
gitserver: Update JVM version check for v17.

### DIFF
--- a/cmd/gitserver/server/vcs_syncer_jvm_packages.go
+++ b/cmd/gitserver/server/vcs_syncer_jvm_packages.go
@@ -223,9 +223,8 @@ func roundJVMVersionToNearestStableVersion(javaVersion int) int {
 	if javaVersion <= 11 {
 		return 11
 	}
-	// TODO: bump this up to 17 once Java 17 LTS has been released, see https://github.com/sourcegraph/lsif-java/issues/263
-	if javaVersion <= 16 {
-		return 16
+	if javaVersion <= 17 {
+		return 17
 	}
 	// Version from the future, do not round up to the next stable release.
 	return javaVersion


### PR DESCRIPTION
v17 was released in September last year, and the linked issue was fixed.

## Test plan

Covered by existing tests.
