### PR TITLE
docs: Update lsif-java → scip-java.

### DIFF
--- a/cmd/frontend/graphqlbackend/external_service_collaborators.go
+++ b/cmd/frontend/graphqlbackend/external_service_collaborators.go
@@ -91,7 +91,7 @@ func (r *externalServiceResolver) InvitableCollaborators(ctx context.Context) ([
 	// parallel) and so that is the true limiting factor here.
 	//
 	// We search within random repositories because many follow a pattern, such as say adding a ton
-	// of `company/lsif-java`, `company/lsif-python`, `company/scip-typescript` etc repos with likely
+	// of `company/scip-java`, `company/lsif-python`, `company/scip-typescript` etc repos with likely
 	// the same collaborators, whereas random sampling may give us dissimilar repositories.
 	const maxReposToScan = 25
 	pickedRepos := pickReposToScanForCollaborators(possibleRepos, maxReposToScan)

--- a/cmd/gitserver/server/vcs_syncer_jvm_packages.go
+++ b/cmd/gitserver/server/vcs_syncer_jvm_packages.go
@@ -223,9 +223,8 @@ func roundJVMVersionToNearestStableVersion(javaVersion int) int {
 	if javaVersion <= 11 {
 		return 11
 	}
-	// TODO: bump this up to 17 once Java 17 LTS has been released, see https://github.com/sourcegraph/lsif-java/issues/263
-	if javaVersion <= 16 {
-		return 16
+	if javaVersion <= 17 {
+		return 17
 	}
 	// Version from the future, do not round up to the next stable release.
 	return javaVersion

--- a/doc/code_intelligence/how-to/index.md
+++ b/doc/code_intelligence/how-to/index.md
@@ -9,7 +9,7 @@
 - [Index a Go repository](index_a_go_repository.md)
 - [Index a TypeScript or JavaScript repository](index_a_typescript_and_javascript_repository.md)
 - [Index a C++ repository](index_a_cpp_repository.md)
-- [Index a Java, Scala & Kotlin repository](https://sourcegraph.github.io/lsif-java/docs/getting-started.html)
+- [Index a Java, Scala & Kotlin repository](https://sourcegraph.github.io/scip-java/docs/getting-started.html)
 
 ## Automate uploading LSIF data
 

--- a/doc/code_intelligence/how-to/index_other_languages.md
+++ b/doc/code_intelligence/how-to/index_other_languages.md
@@ -31,7 +31,7 @@ Install the indexer for the required programming language of your repository by 
   1. [Dart](https://github.com/sourcegraph/lsif-dart)
   1. [Go](https://github.com/sourcegraph/lsif-go)
   1. [Haskell](https://github.com/mpickering/hie-lsif)
-  1. [Java](https://github.com/sourcegraph/lsif-java)
+  1. [Java](https://github.com/sourcegraph/scip-java)
   1. [JavaScript/TypeScript](https://github.com/sourcegraph/scip-typescript)
   1. [Jsonnet](https://github.com/sourcegraph/lsif-jsonnet)
   1. [Python](https://github.com/sourcegraph/lsif-py)

--- a/doc/code_intelligence/references/indexers.md
+++ b/doc/code_intelligence/references/indexers.md
@@ -78,11 +78,11 @@ This table is maintained as an authoritative resource for users, Sales, and Cust
         <td class="indexer-implemented-y">✓</td> <!-- Cross-file -->
         <td class="indexer-implemented-y">✓*</td> <!-- Cross-repository -->
         <td class="indexer-implemented-y">✓</td> <!-- Find implementations -->
-        <td><a href="https://sourcegraph.github.io/lsif-java/docs/getting-started.html#supported-build-tools">See notes</a></td> <!-- Build tooling -->
+        <td><a href="https://sourcegraph.github.io/scip-java/docs/getting-started.html#supported-build-tools">See notes</a></td> <!-- Build tooling -->
       </tr>
       <tr>
         <td>Scala</td>
-        <td><a href="https://github.com/sourcegraph/lsif-java">lsif-java</a></td>
+        <td><a href="https://github.com/sourcegraph/scip-java">scip-java</a></td>
         <td><a href="#status-definitions" class="indexer-status">🟢</a></td>
         <td class="indexer-implemented-y">✓</td> <!-- Hover documentation -->
         <td class="indexer-implemented-y">✓</td> <!-- Go to definition -->
@@ -90,11 +90,11 @@ This table is maintained as an authoritative resource for users, Sales, and Cust
         <td class="indexer-implemented-y">✓</td> <!-- Cross-file -->
         <td class="indexer-implemented-y">✓*</td> <!-- Cross-repository -->
         <td class="indexer-implemented-y">✓</td> <!-- Find implementations -->
-        <td><a href="https://sourcegraph.github.io/lsif-java/docs/getting-started.html#supported-build-tools">See notes</a></td> <!-- Build tooling -->
+        <td><a href="https://sourcegraph.github.io/scip-java/docs/getting-started.html#supported-build-tools">See notes</a></td> <!-- Build tooling -->
       </tr>
       <tr>
         <td>Kotlin</td>
-        <td><a href="https://github.com/sourcegraph/lsif-java">lsif-java</a></td>
+        <td><a href="https://github.com/sourcegraph/scip-java">scip-java</a></td>
         <td><a href="#status-definitions" class="indexer-status">🟢</a></td>
         <td class="indexer-implemented-y">✓</td> <!-- Hover documentation -->
         <td class="indexer-implemented-y">✓</td> <!-- Go to definition -->
@@ -102,7 +102,7 @@ This table is maintained as an authoritative resource for users, Sales, and Cust
         <td class="indexer-implemented-y">✓</td> <!-- Cross-file -->
         <td class="indexer-implemented-y">✓*</td> <!-- Cross-repository -->
         <td class="indexer-implemented-n">✗</td> <!-- Find implementations -->
-        <td><a href="https://sourcegraph.github.io/lsif-java/docs/getting-started.html#supported-build-tools">See notes</a></td> <!-- Build tooling -->
+        <td><a href="https://sourcegraph.github.io/scip-java/docs/getting-started.html#supported-build-tools">See notes</a></td> <!-- Build tooling -->
       </tr>
       <tr>
         <td>Rust</td>
@@ -139,11 +139,11 @@ The next milestone provides support for cross-repository definitions and referen
 
 The indexer can emit a validated LSIF index file including import monikers for each symbol defined non-locally, and export monikers for each symbol importable by another repository. This index should be consumed without error by the latest Sourcegraph instance and Go to Definition and Find References should work on cross-repository symbols _given that both repositories are indexed at the exact commit imported_.
 
-At this point, the indexer may be generally considered **ready**. Some languages and ecosystems may require some of the additional following milestones to be considered ready due to a bad out-of-the-box developer experience or absence of a critical language features. For example, lsif-java is nearly useless without built-in support for build systems such as gradle, and some customers may reject lsif-clang if it has no support for a language feature introduced in C++ 14.
+At this point, the indexer may be generally considered **ready**. Some languages and ecosystems may require some of the additional following milestones to be considered ready due to a bad out-of-the-box developer experience or absence of a critical language features. For example, scip-java is nearly useless without built-in support for build systems such as gradle, and some customers may reject lsif-clang if it has no support for a language feature introduced in C++ 14.
 
 ### Common build tool integration
 
-The next milestone integrates the indexer with a common build tool or framework for the language and surrounding ecosystem. The priority and applicability of this milestone will vary wildly by languages. For example, lsif-go uses the standard library and the language has a built-in dependency manager; all of our customers use Gradle, making lsif-java effectively unusable without native Gradle support.
+The next milestone integrates the indexer with a common build tool or framework for the language and surrounding ecosystem. The priority and applicability of this milestone will vary wildly by languages. For example, lsif-go uses the standard library and the language has a built-in dependency manager; all of our customers use Gradle, making scip-java effectively unusable without native Gradle support.
 
 The indexer integrates natively with common mainstream build tools. We should aim to cover _at least_ the majority of build tools used by existing enterprise customers.
 

--- a/doc/code_search/how-to/dependencies_search.md
+++ b/doc/code_search/how-to/dependencies_search.md
@@ -49,7 +49,7 @@ Kind                                  | How                       | Direct | Tra
 [Python](../../integration/python.md) | `Pipfile.lock`            | ✅     | ✅
 [Go](../../integration/go.md)         | lsif-go uploads           | ❌     | ❌
 [Go](../../integration/go.md)         | `go.mod`                  | ✅     | ✅ with Go >= 1.17 go.mod files
-[JVM](../../integration/jvm.md)       | lsif-java uploads         | ❌     | ❌
+[JVM](../../integration/jvm.md)       | scip-java uploads         | ❌     | ❌
 [JVM](../../integration/jvm.md)       | `gradle.lockfile`         | ❌     | ❌
 [JVM](../../integration/jvm.md)       | `pom.xml`                 | ❌     | ❌
 

--- a/doc/integration/jvm.md
+++ b/doc/integration/jvm.md
@@ -15,7 +15,7 @@ Feature | Supported?
 
 There are two ways to sync JVM dependency repositories.
 
-* **LSIF** (recommended): run [`lsif-java`](https://sourcegraph.github.io/lsif-java/) against your JVM codebase and upload the generated index to Sourcegraph using the  [src-cli](https://github.com/sourcegraph/src-cli) command `src lsif upload`. Sourcegraph automatically synchronizes JVM dependency repositories based on the dependencies that are discovered by `lsif-java`.
+* **LSIF** (recommended): run [`scip-java`](https://sourcegraph.github.io/scip-java/) against your JVM codebase and upload the generated index to Sourcegraph using the  [src-cli](https://github.com/sourcegraph/src-cli) command `src lsif upload`. Sourcegraph automatically synchronizes JVM dependency repositories based on the dependencies that are discovered by `scip-java`.
 * **Code host configuration**: manually list dependencies in the `"dependencies"` section of the JSON configuration when creating the JVM dependency code host. This method can be useful to verify that the credentials are picked up correctly without having to upload LSIF.
 
 ## Credentials

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/indexers.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/indexers.go
@@ -32,7 +32,7 @@ var (
 		name: "scip-typescript",
 		urn:  "github.com/sourcegraph/scip-typescript",
 	}
-	lsifJava = codeIntelIndexerResolver{
+	scipJava = codeIntelIndexerResolver{
 		name: "scip-java",
 		urn:  "github.com/sourcegraph/scip-java",
 	}
@@ -98,7 +98,7 @@ var allIndexers = []gql.CodeIntelIndexerResolver{
 	&lsifNode,
 	&msftNode,
 	&lsifTypescript,
-	&lsifJava,
+	&scipJava,
 	&msftJava,
 	&lsifGo,
 	&lsifClang,
@@ -119,9 +119,9 @@ var allIndexers = []gql.CodeIntelIndexerResolver{
 // from most to least.
 var languageToIndexer = map[string][]gql.CodeIntelIndexerResolver{
 	".go":      {&lsifGo},
-	".java":    {&lsifJava, &msftJava},
-	".kt":      {&lsifJava},
-	".scala":   {&lsifJava},
+	".java":    {&scipJava, &msftJava},
+	".kt":      {&scipJava},
+	".scala":   {&scipJava},
 	".js":      {&lsifTypescript, &lsifNode, &msftNode},
 	".jsx":     {&lsifTypescript, &lsifNode, &msftNode},
 	".ts":      {&lsifTypescript, &lsifNode, &msftNode},
@@ -144,7 +144,7 @@ var languageToIndexer = map[string][]gql.CodeIntelIndexerResolver{
 }
 
 var imageToIndexer = map[string]gql.CodeIntelIndexerResolver{
-	"sourcegraph/scip-java":       &lsifJava,
+	"sourcegraph/scip-java":       &scipJava,
 	"sourcegraph/lsif-go":         &lsifGo,
 	"sourcegraph/scip-typescript": &lsifTypescript,
 	"sourcegraph/lsif-node":       &lsifNode,


### PR DESCRIPTION
Makes progress towards https://github.com/sourcegraph/scip/issues/6.

## Test plan

Regenerated docs.
