### PR TITLE
auth: add warning log for extSvc without auth.provider

### DIFF
--- a/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
+++ b/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
@@ -259,7 +259,7 @@ func (s *PermsSyncer) maybeRefreshGitLabOAuthToken(ctx context.Context, acct *ex
 	}
 	if oauthConfig == nil {
 		log15.Warn("PermsSyncer.maybeRefreshGitLabOAuthToken, external service has no auth.provider",
-			"extSvcId", acct.ID,
+			"externalAccountID", acct.ID,
 		)
 		return nil
 	}

--- a/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
+++ b/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
@@ -258,6 +258,9 @@ func (s *PermsSyncer) maybeRefreshGitLabOAuthToken(ctx context.Context, acct *ex
 		break
 	}
 	if oauthConfig == nil {
+		log15.Warn("PermsSyncer.maybeRefreshGitLabOAuthToken, external service has no auth.provider",
+			"extSvcId", acct.ID,
+		)
 		return nil
 	}
 


### PR DESCRIPTION
Added log for external service without auth provider

## Test plan
no functional change, just adding a log
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
