### PR TITLE
ci: fix deployment notifications not being sent

### DIFF
--- a/enterprise/dev/deployment-notifier/main.go
+++ b/enterprise/dev/deployment-notifier/main.go
@@ -116,7 +116,7 @@ func main() {
 	// Notifcations
 	slc := slack.New(flags.SlackToken)
 	teammates := team.NewTeammateResolver(ghc, slc)
-	if !flags.DryRun {
+	if flags.DryRun {
 		fmt.Println("Github\n---")
 		for _, pr := range report.PullRequests {
 			fmt.Println("-", pr.GetNumber())


### PR DESCRIPTION
Local dev left-over slipped past a review and ended up preventing notifications from being sent.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

n/a 