### PR TITLE
refactor(repo-updater): migrate Syncer to use lib/log

### DIFF
--- a/cmd/repo-updater/repoupdater/server_test.go
+++ b/cmd/repo-updater/repoupdater/server_test.go
@@ -620,6 +620,7 @@ func TestServer_RepoLookup(t *testing.T) {
 
 			clock := clock
 			syncer := &repos.Syncer{
+				Logger:  logger,
 				Now:     clock.Now,
 				Store:   store,
 				Sourcer: repos.NewFakeSourcer(nil, tc.src),
@@ -786,7 +787,6 @@ func TestServer_handleExternalServiceSync(t *testing.T) {
 	}
 
 	logger := logtest.Scoped(t)
-
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			src := testSource{

--- a/cmd/repo-updater/shared/main.go
+++ b/cmd/repo-updater/shared/main.go
@@ -162,14 +162,13 @@ func Main(enterpriseInit EnterpriseInit) {
 		debugDumpers = enterpriseInit(db, store, keyring.Default(), cf, server)
 	}
 
-	// TODO(burmudar): update syncer to use lib/log
 	syncer := &repos.Syncer{
+		Logger:  logger.Scoped("syncer", "repo syncer"),
 		Sourcer: src,
 		Store:   store,
 		// We always want to listen on the Synced channel since external service syncing
 		// happens on both Cloud and non Cloud instances.
 		Synced:     make(chan repos.Diff),
-		Logger:     log15.Root(),
 		Now:        clock,
 		Registerer: prometheus.DefaultRegisterer,
 	}

--- a/internal/repos/status_messages_test.go
+++ b/internal/repos/status_messages_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/timeutil"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"github.com/sourcegraph/sourcegraph/lib/log/logtest"
 )
 
 func TestStatusMessages(t *testing.T) {
@@ -221,6 +222,7 @@ func TestStatusMessages(t *testing.T) {
 		},
 	}
 
+	logger := logtest.Scoped(t)
 	for _, tc := range testCases {
 		tc := tc
 		ctx := context.Background()
@@ -302,8 +304,9 @@ func TestStatusMessages(t *testing.T) {
 
 			clock := timeutil.NewFakeClock(time.Now(), 0)
 			syncer := &Syncer{
-				Store: store,
-				Now:   clock.Now,
+				Logger: logger,
+				Store:  store,
+				Now:    clock.Now,
 			}
 
 			mockDB := database.NewMockDBFrom(database.NewDB(db))


### PR DESCRIPTION
* removed usage of module log15
* removed log() and discardLogger which was used when the logger was nil. Logger is only nil when Syncer is created in tests as per [this search](https://k8s.sgdev.org/search?q=repo:sourcegraph/sourcegraph+lang:go+-file:_test.go+%26Syncer%7B...%7D+OR+%26repos.Syncer%7B...%7D&patternType=structural)

Part of #34607
## Test plan
Unit Tests
```
$ go run ./cmd/repo-updater/...
?   	github.com/sourcegraph/sourcegraph/cmd/repo-updater	[no test files]
ok  	github.com/sourcegraph/sourcegraph/cmd/repo-updater/repoupdater	(cached)
ok  	github.com/sourcegraph/sourcegraph/cmd/repo-updater/shared	(cached)

$ go run ./internal/repoupdater/...
ok  	github.com/sourcegraph/sourcegraph/internal/repoupdater	(cached)
?   	github.com/sourcegraph/sourcegraph/internal/repoupdater/protocol	[no test files]
```
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
