### PR TITLE
Search backend: fix issue with multiline payload sizes

### DIFF
--- a/enterprise/cmd/frontend/internal/compute/resolvers/resolvers_test.go
+++ b/enterprise/cmd/frontend/internal/compute/resolvers/resolvers_test.go
@@ -35,10 +35,15 @@ func TestToResultResolverList(t *testing.T) {
 
 	nonNilMatches := []result.Match{
 		&result.FileMatch{
-			MultilineMatches: []result.MultilineMatch{
-				{Preview: "a"},
-				{Preview: "b"},
-			},
+			MultilineMatches: []result.MultilineMatch{{
+				Preview: "a",
+				Start:   result.LineColumn{Line: 1, Column: 0},
+				End:     result.LineColumn{Line: 1, Column: 1},
+			}, {
+				Preview: "b",
+				Start:   result.LineColumn{Line: 2, Column: 0},
+				End:     result.LineColumn{Line: 2, Column: 1},
+			}},
 		},
 	}
 	autogold.Want("resolver copies all match results", `["a","b"]`).Equal(t, test("a|b", nonNilMatches))

--- a/internal/search/result/file.go
+++ b/internal/search/result/file.go
@@ -3,6 +3,7 @@ package result
 import (
 	"net/url"
 	"path"
+	"sort"
 	"strings"
 	"unicode/utf8"
 
@@ -191,7 +192,23 @@ func MultilineSliceAsLineMatchSlice(matches []MultilineMatch) []*LineMatch {
 	for _, m := range matches {
 		lineMatches = append(lineMatches, m.AsLineMatches()...)
 	}
-	return lineMatches
+	sort.Slice(lineMatches, func(i, j int) bool {
+		return lineMatches[i].LineNumber < lineMatches[j].LineNumber
+	})
+	res := lineMatches[:0]
+	for i, lm := range lineMatches {
+		if i == 0 {
+			res = append(res, lm)
+			continue
+		}
+		last := len(res) - 1
+		if lm.LineNumber == res[last].LineNumber {
+			res[last].OffsetAndLengths = append(res[last].OffsetAndLengths, lm.OffsetAndLengths...)
+		} else {
+			res = append(res, lm)
+		}
+	}
+	return res
 }
 
 func (m MultilineMatch) AsLineMatches() []*LineMatch {

--- a/internal/search/result/file_test.go
+++ b/internal/search/result/file_test.go
@@ -134,4 +134,44 @@ func TestConvertMatches(t *testing.T) {
 			})
 		}
 	})
+
+	t.Run("MultilineSliceAsLineMatchSlice", func(t *testing.T) {
+		cases := []struct {
+			input  []MultilineMatch
+			output []*LineMatch
+		}{{
+			input: []MultilineMatch{{
+				Preview: "line1\nline2\nline3",
+				Start:   LineColumn{1, 1},
+				End:     LineColumn{3, 1},
+			}, {
+				Preview: "line2\nline3\nline4",
+				Start:   LineColumn{2, 1},
+				End:     LineColumn{4, 1},
+			}},
+			output: []*LineMatch{{
+				Preview:          "line1",
+				LineNumber:       1,
+				OffsetAndLengths: [][2]int32{{1, 4}},
+			}, {
+				Preview:          "line2",
+				LineNumber:       2,
+				OffsetAndLengths: [][2]int32{{0, 5}, {1, 4}},
+			}, {
+				Preview:          "line3",
+				LineNumber:       3,
+				OffsetAndLengths: [][2]int32{{0, 1}, {0, 5}},
+			}, {
+				Preview:          "line4",
+				LineNumber:       4,
+				OffsetAndLengths: [][2]int32{{0, 1}},
+			}},
+		}}
+
+		for _, tc := range cases {
+			t.Run("", func(t *testing.T) {
+				require.Equal(t, MultilineSliceAsLineMatchSlice(tc.input), tc.output)
+			})
+		}
+	})
 }

--- a/internal/search/result/file_test.go
+++ b/internal/search/result/file_test.go
@@ -166,6 +166,44 @@ func TestConvertMatches(t *testing.T) {
 				LineNumber:       4,
 				OffsetAndLengths: [][2]int32{{0, 1}},
 			}},
+		}, {
+			input: []MultilineMatch{{
+				Preview: "line1\nline2\nline3",
+				Start:   LineColumn{1, 1},
+				End:     LineColumn{3, 1},
+			}, {
+				Preview: "line4\nline5\nline6",
+				Start:   LineColumn{4, 1},
+				End:     LineColumn{6, 1},
+			}},
+			output: []*LineMatch{{
+				Preview:          "line1",
+				LineNumber:       1,
+				OffsetAndLengths: [][2]int32{{1, 4}},
+			}, {
+				Preview:          "line2",
+				LineNumber:       2,
+				OffsetAndLengths: [][2]int32{{0, 5}},
+			}, {
+				Preview:          "line3",
+				LineNumber:       3,
+				OffsetAndLengths: [][2]int32{{0, 1}},
+			}, {
+				Preview:          "line4",
+				LineNumber:       4,
+				OffsetAndLengths: [][2]int32{{1, 4}},
+			}, {
+				Preview:          "line5",
+				LineNumber:       5,
+				OffsetAndLengths: [][2]int32{{0, 5}},
+			}, {
+				Preview:          "line6",
+				LineNumber:       6,
+				OffsetAndLengths: [][2]int32{{0, 1}},
+			}},
+		}, {
+			input:  []MultilineMatch{},
+			output: []*LineMatch{},
 		}}
 
 		for _, tc := range cases {


### PR DESCRIPTION
With the introduction of multiline matches, we lost some of the
efficiency of the line match encoding because ranges are no longer
limited to a single line, so we send the overlapped lines with every
result. This meant for lines with more than one match, we would
duplicate the line content for each match.

This problem is something we'll need to solve better at the API layer
(probably by sending hunked lines rather than the full line content
for every match), but for now, this commit just re-compresses when we
convert back to line matches.

[Slack discussion](https://sourcegraph.slack.com/archives/CHEKCRWKV/p1653575241408589)

## Test plan

Added a test for merging line matches at the conversion step. 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
