### PR TITLE
searcher: add ObservationContext to diskcache

### DIFF
--- a/cmd/searcher/internal/search/search_test.go
+++ b/cmd/searcher/internal/search/search_test.go
@@ -19,6 +19,8 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/searcher/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/metrics"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/search/searcher"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 	"github.com/sourcegraph/sourcegraph/lib/log/logtest"
@@ -521,6 +523,11 @@ func newStore(t *testing.T, files map[string]struct {
 		},
 		Path: t.TempDir(),
 		Log:  logtest.Scoped(t),
+
+		ObservationContext: &observation.Context{
+			Registerer: metrics.TestRegisterer,
+			Logger:     logtest.Scoped(t),
+		},
 	}
 }
 

--- a/cmd/searcher/internal/search/store.go
+++ b/cmd/searcher/internal/search/store.go
@@ -27,6 +27,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/metrics"
 	"github.com/sourcegraph/sourcegraph/internal/mutablelimiter"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 	"github.com/sourcegraph/sourcegraph/lib/log"
@@ -81,6 +82,9 @@ type Store struct {
 	// Log is the Logger to use.
 	Log log.Logger
 
+	// ObservationContext is used to configure observability in diskcache.
+	ObservationContext *observation.Context
+
 	// once protects Start
 	once sync.Once
 
@@ -111,6 +115,7 @@ func (s *Store) Start() {
 		s.cache = diskcache.NewStore(s.Path, "store",
 			diskcache.WithBackgroundTimeout(10*time.Minute),
 			diskcache.WithBeforeEvict(s.zipCache.delete),
+			diskcache.WithObservationContext(s.ObservationContext),
 		)
 		_ = os.MkdirAll(s.Path, 0700)
 		metrics.MustRegisterDiskMonitor(s.Path)

--- a/cmd/searcher/internal/search/store_test.go
+++ b/cmd/searcher/internal/search/store_test.go
@@ -16,6 +16,8 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
+	"github.com/sourcegraph/sourcegraph/internal/metrics"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 	"github.com/sourcegraph/sourcegraph/lib/log/logtest"
 )
@@ -269,6 +271,11 @@ func tmpStore(t *testing.T) *Store {
 	return &Store{
 		Path: d,
 		Log:  logtest.Scoped(t),
+
+		ObservationContext: &observation.Context{
+			Registerer: metrics.TestRegisterer,
+			Logger:     logtest.Scoped(t),
+		},
 	}
 }
 


### PR DESCRIPTION
ObservationContext on diskcache was introduced in #28922. This means for about 5 months we haven't had metrics for it on searcher. This commit is the most minimal introduction for it. We don't yet integrate ObservationContext into searcher.

I considered just constructing an ObservationContext in Start, but then the prometheus registry would panic in tests due to multiple constructions of it.

Test Plan: go test and running an unindexed search locally.