### PR TITLE
Search backend: redefine Location.Offset as a byte offset

### DIFF
--- a/internal/gitserver/search/match_tree.go
+++ b/internal/gitserver/search/match_tree.go
@@ -287,13 +287,11 @@ func matchesToRanges(content []byte, matches [][]int) result.Ranges {
 	var (
 		unscannedOffset          = 0
 		scannedNewlines          = 0
-		scannedRunes             = 0
 		lastScannedNewlineOffset = -1
 	)
 
-	lineColumnOffset := func(byteOffset int) (line, column, offset int) {
+	lineColumnOffset := func(byteOffset int) (line, column int) {
 		unscanned := content[unscannedOffset:byteOffset]
-		scannedRunes += utf8.RuneCount(unscanned)
 		lastUnscannedNewlineOffset := bytes.LastIndexByte(unscanned, '\n')
 		if lastUnscannedNewlineOffset != -1 {
 			lastScannedNewlineOffset = unscannedOffset + lastUnscannedNewlineOffset
@@ -301,16 +299,16 @@ func matchesToRanges(content []byte, matches [][]int) result.Ranges {
 		}
 		column = utf8.RuneCount(content[lastScannedNewlineOffset+1 : byteOffset])
 		unscannedOffset = byteOffset
-		return scannedNewlines, column, scannedRunes
+		return scannedNewlines, column
 	}
 
 	res := make(result.Ranges, 0, len(matches))
 	for _, match := range matches {
-		startLine, startColumn, startOffset := lineColumnOffset(match[0])
-		endLine, endColumn, endOffset := lineColumnOffset(match[1])
+		startLine, startColumn := lineColumnOffset(match[0])
+		endLine, endColumn := lineColumnOffset(match[1])
 		res = append(res, result.Range{
-			Start: result.Location{Line: startLine, Column: startColumn, Offset: startOffset},
-			End:   result.Location{Line: endLine, Column: endColumn, Offset: endOffset},
+			Start: result.Location{Line: startLine, Column: startColumn, Offset: match[0]},
+			End:   result.Location{Line: endLine, Column: endColumn, Offset: match[1]},
 		})
 	}
 	return res

--- a/internal/gitserver/search/match_tree_test.go
+++ b/internal/gitserver/search/match_tree_test.go
@@ -76,8 +76,8 @@ func Test_matchesToRanges(t *testing.T) {
 			input:   "›a", // three-byte unicode character
 			matches: [][]int{{3, 4}},
 			expectedRanges: result.Ranges{{
-				Start: result.Location{Offset: 1, Line: 0, Column: 1},
-				End:   result.Location{Offset: 2, Line: 0, Column: 2},
+				Start: result.Location{Offset: 3, Line: 0, Column: 1},
+				End:   result.Location{Offset: 4, Line: 0, Column: 2},
 			}},
 		},
 	}

--- a/internal/search/result/range.go
+++ b/internal/search/result/range.go
@@ -59,8 +59,7 @@ func rangeToHighlights(s string, r Range) []HighlightedRange {
 }
 
 type Location struct {
-	// Offset is the number of unicode code points (not bytes) from the
-	// beginning of the matched text
+	// Offset is the number of bytes from the beginning of the matched text
 	Offset int
 
 	// Line is the count of newlines before the offset in the matched text


### PR DESCRIPTION
Location.Offset was documented as a rune offset, but a rune offset from
the beginning of the file is realistically not super useful. However,
holding on to byte offsets from the beginning of file is useful,
especially since these can then be used to safely index directly into
the associated file or preview string.

Additionally, in a few places, Location.Offset was already being treated
as a byte offset rather than a rune offset, so this makes it consistent.

## Test plan

Updated associated tests to ensure highlighted strings are still generated correctly.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
