### PR TITLE
Fix "QuickStart => TourInfo" empty space when no info present

### DIFF
--- a/client/web/src/repo/actions/InstallIntegrationsAlert.tsx
+++ b/client/web/src/repo/actions/InstallIntegrationsAlert.tsx
@@ -54,7 +54,7 @@ export const InstallIntegrationsAlert: React.FunctionComponent<
 
     const ctaToDisplay = useMemo<CtaToDisplay | undefined>(
         (): CtaToDisplay | undefined => {
-            if (tourQueryParameters?.isTour) {
+            if (tourQueryParameters.isTour) {
                 return
             }
 

--- a/client/web/src/search/results/StreamingSearchResults.tsx
+++ b/client/web/src/search/results/StreamingSearchResults.tsx
@@ -116,7 +116,7 @@ function useCtaAlert(
         if (!areResultsFound) {
             return
         }
-        if (tourQueryParameters?.isTour) {
+        if (tourQueryParameters.isTour) {
             return
         }
 

--- a/client/web/src/tour/components/Tour/TourAgent.tsx
+++ b/client/web/src/tour/components/Tour/TourAgent.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 
 import CheckCircleIcon from 'mdi-react/CheckCircleIcon'
 import ReactDOM from 'react-dom'
@@ -24,9 +24,10 @@ export function useTourQueryParameters(): ReturnType<typeof parseURIMarkers> | u
     useEffect(() => {
         const { isTour, stepId } = parseURIMarkers(location.search)
         if (!isTour || !stepId) {
-            return
+            setData(undefined)
+        } else {
+            setData({ isTour, stepId })
         }
-        setData({ isTour, stepId })
     }, [location])
 
     return data
@@ -55,17 +56,19 @@ export const TourAgent: React.FunctionComponent<React.PropsWithChildren<TourAgen
 
         useEffect(() => {
             const info = tasks.flatMap(task => task.steps).find(step => tourQueryParameters?.stepId === step.id)?.info
-            if (info) {
-                setInfo(info)
-            }
+            setInfo(info)
         }, [tasks, tourQueryParameters?.stepId])
 
-        if (!info) {
-            return null
-        }
+        const domNode = useRef(document.querySelector('#' + GETTING_STARTED_TOUR_MARKER))
+        useEffect(() => {
+            if (info) {
+                domNode.current?.classList.remove('d-none')
+            } else {
+                domNode.current?.classList.add('d-none')
+            }
+        }, [info])
 
-        const domNode = document.querySelector('.' + GETTING_STARTED_TOUR_MARKER)
-        if (!domNode) {
+        if (!info || !domNode.current) {
             return null
         }
 
@@ -74,7 +77,7 @@ export const TourAgent: React.FunctionComponent<React.PropsWithChildren<TourAgen
                 <Icon role="img" as={CheckCircleIcon} className={styles.infoIcon} aria-hidden={true} />
                 <span>{info}</span>
             </div>,
-            domNode
+            domNode.current
         )
     }
 )

--- a/client/web/src/tour/components/Tour/TourAgent.tsx
+++ b/client/web/src/tour/components/Tour/TourAgent.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react'
+import React, { useEffect, useRef, useState, useMemo } from 'react'
 
 import CheckCircleIcon from 'mdi-react/CheckCircleIcon'
 import ReactDOM from 'react-dom'
@@ -18,19 +18,9 @@ interface TourAgentProps extends TelemetryProps {
     onStepComplete: (step: TourTaskStepType) => void
 }
 
-export function useTourQueryParameters(): ReturnType<typeof parseURIMarkers> | undefined {
+export function useTourQueryParameters(): ReturnType<typeof parseURIMarkers> {
     const location = useLocation()
-    const [data, setData] = useState<ReturnType<typeof parseURIMarkers> | undefined>()
-    useEffect(() => {
-        const { isTour, stepId } = parseURIMarkers(location.search)
-        if (!isTour || !stepId) {
-            setData(undefined)
-        } else {
-            setData({ isTour, stepId })
-        }
-    }, [location])
-
-    return data
+    return useMemo(() => parseURIMarkers(location.search), [location])
 }
 
 /**
@@ -55,20 +45,20 @@ export const TourAgent: React.FunctionComponent<React.PropsWithChildren<TourAgen
         const tourQueryParameters = useTourQueryParameters()
 
         useEffect(() => {
-            const info = tasks.flatMap(task => task.steps).find(step => tourQueryParameters?.stepId === step.id)?.info
+            const info = tasks.flatMap(task => task.steps).find(step => tourQueryParameters.stepId === step.id)?.info
             setInfo(info)
-        }, [tasks, tourQueryParameters?.stepId])
+        }, [tasks, tourQueryParameters.stepId])
 
-        const domNode = useRef(document.querySelector('#' + GETTING_STARTED_TOUR_MARKER))
+        const infoContainerReference = useRef(document.querySelector('#' + GETTING_STARTED_TOUR_MARKER))
         useEffect(() => {
             if (info) {
-                domNode.current?.classList.remove('d-none')
+                infoContainerReference.current?.classList.remove('d-none')
             } else {
-                domNode.current?.classList.add('d-none')
+                infoContainerReference.current?.classList.add('d-none')
             }
         }, [info])
 
-        if (!info || !domNode.current) {
+        if (!info || !infoContainerReference.current) {
             return null
         }
 
@@ -77,7 +67,7 @@ export const TourAgent: React.FunctionComponent<React.PropsWithChildren<TourAgen
                 <Icon role="img" as={CheckCircleIcon} className={styles.infoIcon} aria-hidden={true} />
                 <span>{info}</span>
             </div>,
-            domNode.current
+            infoContainerReference.current
         )
     }
 )

--- a/client/web/src/tour/components/Tour/TourInfo.tsx
+++ b/client/web/src/tour/components/Tour/TourInfo.tsx
@@ -16,5 +16,5 @@ export const TourInfo: React.FunctionComponent<React.PropsWithChildren<TourInfoP
     if (!isSourcegraphDotCom) {
         return null
     }
-    return <div className={classNames(GETTING_STARTED_TOUR_MARKER, className)} />
+    return <div id={GETTING_STARTED_TOUR_MARKER} className={classNames('d-none', className)} />
 }


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/36111.

## Screenshots
| BEFORE | AFTER |
| --: | :-- |
| ![image](https://user-images.githubusercontent.com/6717049/170545002-ef9c7a1d-41e0-4430-b7eb-3ed062886e26.png) | ![image](https://user-images.githubusercontent.com/6717049/170544919-b7540a33-4c0a-4972-a18a-fe77cb688beb.png) |
| ![image](https://user-images.githubusercontent.com/6717049/170544763-ea2ae245-999f-4067-8650-37e7a51b79a3.png) | ![image](https://user-images.githubusercontent.com/6717049/170544854-beef92e4-8184-4b7d-a94b-aab6d9c38aa4.png) |


## Test plan
- `SOURCEGRAPH_API_URL=https://sourcegraph.com SOURCEGRAPHDOTCOM_MODE=true sg start web-standalone`
- Force show quick start tour
  - Go to https://sourcegraph.test:3443/search and sign out (if signed in)
  - Clear `quick-start-tour` local storage item (if already it previously closed)
- Search or go to any file page and make sure no empty gap is rendered on top
- Click quick start tour item and make sure info panel (green box with text) renders as previsously

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-erzhtor-fix-tour-info-empty-space.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-lcdanxohvp.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

