### PR TITLE
Searcher: add byte offset to the location definition

### DIFF
--- a/cmd/searcher/internal/search/search_structural.go
+++ b/cmd/searcher/internal/search/search_structural.go
@@ -60,12 +60,14 @@ func toFileMatch(zipReader *zip.Reader, combyMatch *comby.FileMatch) (protocol.F
 			// line contents. Instead, we use the ranges from comby to pull all the
 			// overlapped lines from the file contents.
 			Preview: string(fileBuf[firstLineStart:lastLineEnd]),
-			Start: protocol.LineColumn{
+			Start: protocol.Location{
+				Offset: int32(r.Range.Start.Offset),
 				// Comby returns 1-based line numbers and columns
 				Line:   int32(r.Range.Start.Line) - 1,
 				Column: int32(r.Range.Start.Column) - 1,
 			},
-			End: protocol.LineColumn{
+			End: protocol.Location{
+				Offset: int32(r.Range.End.Offset),
 				Line:   int32(r.Range.End.Line) - 1,
 				Column: int32(r.Range.End.Column) - 1,
 			},

--- a/cmd/searcher/internal/search/search_structural_test.go
+++ b/cmd/searcher/internal/search/search_structural_test.go
@@ -372,8 +372,8 @@ func TestRule(t *testing.T) {
 		LimitHit: false,
 		MultilineMatches: []protocol.MultilineMatch{{
 			Preview: "func foo(success) {} func bar(fail) {}",
-			Start:   protocol.LineColumn{Line: 0, Column: 0},
-			End:     protocol.LineColumn{Line: 0, Column: 17},
+			Start:   protocol.Location{Offset: 0, Line: 0, Column: 0},
+			End:     protocol.Location{Offset: 17, Line: 0, Column: 17},
 		}},
 		MatchCount: 1,
 	}}
@@ -525,12 +525,12 @@ func bar() {
 			MatchCount: 2,
 			MultilineMatches: []protocol.MultilineMatch{{
 				Preview: "func foo() {\n    fmt.Println(\"foo\")\n}",
-				Start:   protocol.LineColumn{Line: 1, Column: 11},
-				End:     protocol.LineColumn{Line: 3, Column: 1},
+				Start:   protocol.Location{Offset: 12, Line: 1, Column: 11},
+				End:     protocol.Location{Offset: 26, Line: 3, Column: 1},
 			}, {
 				Preview: "func bar() {\n    fmt.Println(\"bar\")\n}",
-				Start:   protocol.LineColumn{Line: 5, Column: 11},
-				End:     protocol.LineColumn{Line: 7, Column: 1},
+				Start:   protocol.Location{Offset: 39, Line: 5, Column: 11},
+				End:     protocol.Location{Offset: 65, Line: 7, Column: 1},
 			}},
 		}}
 		require.Equal(t, expected, matches)

--- a/cmd/searcher/protocol/searcher.go
+++ b/cmd/searcher/protocol/searcher.go
@@ -222,15 +222,15 @@ type LineMatch struct {
 	OffsetAndLengths [][2]int
 }
 
-// LineColumn is a subset of the fields on Location because we don't
-// have the rune offset necessary to build a full Location yet.
-// Eventually, the two structs should be merged.
-type LineColumn struct {
-	// Line is the count of newlines before the offset in the matched text.
+type Location struct {
+	// The byte offset from the beginning of the file.
+	Offset int32
+
+	// Line is the count of newlines before the offset in the file.
 	// Line is 0-based.
 	Line int32
 
-	// Column is the count of unicode code points after the last newline in the matched text
+	// Column is the rune offset from the beginning of the last line.
 	Column int32
 }
 
@@ -239,8 +239,8 @@ type MultilineMatch struct {
 	// lines that the match overlaps.
 	// The number of lines in Preview should be End.Line - Start.Line + 1
 	Preview string
-	Start   LineColumn
-	End     LineColumn
+	Start   Location
+	End     Location
 }
 
 func (m MultilineMatch) MatchedContent() string {


### PR DESCRIPTION
This adds the byte offset to the type returned by Searcher for multiline matches. 
This will allow us to merge `LineColumn` and `Location` into just `Location`. It just
adds it to the type, but doesn't use it yet in `frontend` because not all backends 
send that information yet.

## Test plan

Updated existing tests, but will do more testing once this is actually used in the `frontend` code. 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
