### PR TITLE
compute: fix diff Path() to not return empty string

### DIFF
--- a/internal/search/result/commit_diff.go
+++ b/internal/search/result/commit_diff.go
@@ -26,10 +26,7 @@ func (cd *CommitDiffMatch) RepoName() types.MinimalRepo {
 // path when the associated file is modified. When it is created or removed, it
 // returns the path of the associated file being created or removed.
 func (cm *CommitDiffMatch) Path() string {
-	var nonEmptyPath string
-	if cm.OrigName == "/dev/null" {
-		nonEmptyPath = cm.NewName
-	}
+	nonEmptyPath := cm.NewName
 	if cm.NewName == "/dev/null" {
 		nonEmptyPath = cm.OrigName
 	}

--- a/internal/search/result/commit_diff_test.go
+++ b/internal/search/result/commit_diff_test.go
@@ -6,8 +6,7 @@ import (
 	"github.com/hexops/autogold"
 )
 
-func TestParseDiffString(t *testing.T) {
-	input := `client/web/src/enterprise/codeintel/badge/components/IndexerSummary.module.scss client/web/src/enterprise/codeintel/badge/components/IndexerSummary.module.scss
+const input = `client/web/src/enterprise/codeintel/badge/components/IndexerSummary.module.scss client/web/src/enterprise/codeintel/badge/components/IndexerSummary.module.scss
 @@ -1,2 +1,6 @@ ... +1
 +.badge-wrapper {
 +    font-size: 0.75rem;
@@ -41,9 +40,19 @@ client/web/src/enterprise/codeintel/badge/components/RequestLink.module.scss cli
  }
 `
 
+func TestParseDiffString(t *testing.T) {
 	res, err := ParseDiffString(input)
 	if err != nil {
 		panic(err)
 	}
 	autogold.Equal(t, res)
+}
+
+func TestCommitDiffMatch(t *testing.T) {
+	res, _ := ParseDiffString(input)
+	commitDiff := &CommitDiffMatch{DiffFile: &res[0]}
+	autogold.Want(
+		"path when modified",
+		"client/web/src/enterprise/codeintel/badge/components/IndexerSummary.module.scss").
+		Equal(t, commitDiff.Path())
 }


### PR DESCRIPTION
Silly bug that returned empty string, instead of the path, for diffs where the file is modified


## Test plan
Added unit test.
