### PR TITLE
Searcher: return LineOffset in LineMatch

### DIFF
--- a/cmd/searcher/internal/search/search_regex.go
+++ b/cmd/searcher/internal/search/search_regex.go
@@ -217,7 +217,7 @@ func (rg *readerGrep) Find(zf *zipFile, f *srcFile, limit int) (matches []protoc
 
 		lastMatchIndex = matchIndex
 		lastLineNumber = lineNumber
-		matches = appendMatches(matches, fileBuf[lineStart:lineEnd], fileMatchBuf[lineStart:lineEnd], lineNumber, start-lineStart, end-lineStart)
+		matches = appendMatches(matches, fileBuf[lineStart:lineEnd], fileMatchBuf[lineStart:lineEnd], lineNumber, lineStart, start-lineStart, end-lineStart)
 	}
 	return matches, nil
 }
@@ -228,7 +228,7 @@ func hydrateLineNumbers(fileBuf []byte, lastLineNumber, lastMatchIndex, lineStar
 }
 
 // matchLineBuf is a byte slice that contains the full line(s) that the match appears on.
-func appendMatches(matches []protocol.LineMatch, fileBuf []byte, matchLineBuf []byte, lineNumber, start, end int) []protocol.LineMatch {
+func appendMatches(matches []protocol.LineMatch, fileBuf []byte, matchLineBuf []byte, lineNumber, lineOffset, start, end int) []protocol.LineMatch {
 	// If any newlines appear between start and end, we need to append multiple LineMatch.
 	// We assume there are no newlines before start.
 	for len(matchLineBuf) > 0 {
@@ -269,6 +269,7 @@ func appendMatches(matches []protocol.LineMatch, fileBuf []byte, matchLineBuf []
 				// Special care must be taken to call Close on all possible paths, including error paths.
 				Preview:          string(fileBuf[:limit]),
 				LineNumber:       lineNumber,
+				LineOffset:       lineOffset,
 				OffsetAndLengths: [][2]int{{offset, length}},
 			})
 		}

--- a/cmd/searcher/protocol/searcher.go
+++ b/cmd/searcher/protocol/searcher.go
@@ -216,6 +216,10 @@ type LineMatch struct {
 	// 1-based line numbers, but internally vscode uses 0-based.
 	LineNumber int
 
+	// LineOffset is the number of bytes from the beginning of the
+	// file to the beginning of the line.
+	LineOffset int
+
 	// OffsetAndLengths is a slice of 2-tuples (Offset, Length)
 	// representing each match on a line.
 	// Offsets and lengths are measured in characters, not bytes.


### PR DESCRIPTION
This adds LineOffset to the LineMatch in the searcher response. This
allows us to calculate the byte offset of the the offsets and lengths
so we can unify LineColumn and Location (this is the last place missing
that information).

This change will be ephemeral since I plan to get rid of `LineMatch` from the
searcher API in replacement of a hunk-based type, but for now this lets
me move forward incrementally. 

Stacked on #36114 

## Test plan

Updated tests, but it's not actually used yet. Will do so in the followup PR. 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
