### PR TITLE
Result types: unify LineColumn with Location

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -255,8 +255,8 @@ func (sr *SearchResultsResolver) blameFileMatch(ctx context.Context, fm *result.
 	mm := fm.MultilineMatches[0]
 	hunks, err := gitserver.NewClient(sr.db).BlameFile(ctx, fm.Repo.Name, fm.Path, &gitserver.BlameOptions{
 		NewestCommit: fm.CommitID,
-		StartLine:    int(mm.Range.Start.Line),
-		EndLine:      int(mm.Range.Start.Line),
+		StartLine:    mm.Range.Start.Line,
+		EndLine:      mm.Range.Start.Line,
 	}, authz.DefaultSubRepoPermsChecker)
 	if err != nil {
 		return time.Time{}, err

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -252,11 +252,11 @@ func (sr *SearchResultsResolver) blameFileMatch(ctx context.Context, fm *result.
 		// No line match
 		return time.Time{}, nil
 	}
-	lm := fm.MultilineMatches[0]
+	mm := fm.MultilineMatches[0]
 	hunks, err := gitserver.NewClient(sr.db).BlameFile(ctx, fm.Repo.Name, fm.Path, &gitserver.BlameOptions{
 		NewestCommit: fm.CommitID,
-		StartLine:    int(lm.Start.Line),
-		EndLine:      int(lm.Start.Line),
+		StartLine:    int(mm.Range.Start.Line),
+		EndLine:      int(mm.Range.Start.Line),
 	}, authz.DefaultSubRepoPermsChecker)
 	if err != nil {
 		return time.Time{}, err

--- a/cmd/frontend/graphqlbackend/search_results_stats_languages_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_stats_languages_test.go
@@ -62,7 +62,7 @@ func TestSearchResultsStatsLanguages(t *testing.T) {
 	}
 	defer gitserver.ResetClientMocks()
 
-	mkResult := func(path string, lineNumbers ...int32) *result.FileMatch {
+	mkResult := func(path string, lineNumbers ...int) *result.FileMatch {
 		rn := types.MinimalRepo{
 			Name: "r",
 		}

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -52,7 +52,7 @@ func TestSearchResults(t *testing.T) {
 			case *result.RepoMatch:
 				resultDescriptions[i] = fmt.Sprintf("repo:%s", m.Name)
 			case *result.FileMatch:
-				resultDescriptions[i] = fmt.Sprintf("%s:%d", m.Path, m.MultilineMatches[0].Start.Line)
+				resultDescriptions[i] = fmt.Sprintf("%s:%d", m.Path, m.MultilineMatches[0].Range.Start.Line)
 			default:
 				t.Fatal("unexpected result type:", match)
 			}

--- a/cmd/frontend/graphqlbackend/search_test.go
+++ b/cmd/frontend/graphqlbackend/search_test.go
@@ -292,12 +292,14 @@ func TestExactlyOneRepo(t *testing.T) {
 	}
 }
 
-func mkFileMatch(repo types.MinimalRepo, path string, lineNumbers ...int32) *result.FileMatch {
+func mkFileMatch(repo types.MinimalRepo, path string, lineNumbers ...int) *result.FileMatch {
 	var lines []result.MultilineMatch
 	for _, n := range lineNumbers {
 		lines = append(lines, result.MultilineMatch{
-			Start: result.LineColumn{Line: n},
-			End:   result.LineColumn{Line: n},
+			Range: result.Range{
+				Start: result.Location{Line: n},
+				End:   result.Location{Line: n},
+			},
 		})
 	}
 

--- a/enterprise/cmd/frontend/internal/compute/resolvers/resolvers_test.go
+++ b/enterprise/cmd/frontend/internal/compute/resolvers/resolvers_test.go
@@ -37,12 +37,16 @@ func TestToResultResolverList(t *testing.T) {
 		&result.FileMatch{
 			MultilineMatches: []result.MultilineMatch{{
 				Preview: "a",
-				Start:   result.LineColumn{Line: 1, Column: 0},
-				End:     result.LineColumn{Line: 1, Column: 1},
+				Range: result.Range{
+					Start: result.Location{Line: 1, Column: 0},
+					End:   result.Location{Line: 1, Column: 1},
+				},
 			}, {
 				Preview: "b",
-				Start:   result.LineColumn{Line: 2, Column: 0},
-				End:     result.LineColumn{Line: 2, Column: 1},
+				Range: result.Range{
+					Start: result.Location{Line: 2, Column: 0},
+					End:   result.Location{Line: 2, Column: 1},
+				},
 			}},
 		},
 	}

--- a/enterprise/internal/compute/match_only_command_test.go
+++ b/enterprise/internal/compute/match_only_command_test.go
@@ -37,8 +37,10 @@ func Test_matchOnly(t *testing.T) {
 		MultilineMatches: []result.MultilineMatch{
 			{
 				Preview: "abcdefgh",
-				Start:   result.LineColumn{Line: 1},
-				End:     result.LineColumn{Line: 1},
+				Range: result.Range{
+					Start: result.Location{Line: 1},
+					End:   result.Location{Line: 1},
+				},
 			},
 		},
 	}

--- a/internal/search/result/file_test.go
+++ b/internal/search/result/file_test.go
@@ -7,61 +7,6 @@ import (
 )
 
 func TestConvertMatches(t *testing.T) {
-	// single line matches should always be roundtrippable
-	t.Run("roundtrip", func(t *testing.T) {
-		t.Run("multiline", func(t *testing.T) {
-			cases := []MultilineMatch{{
-				Preview: "abcd",
-				Start:   LineColumn{0, 0},
-				End:     LineColumn{0, 4},
-			}, {
-				Preview: "abcd",
-				Start:   LineColumn{0, 0},
-				End:     LineColumn{0, 3},
-			}, {
-				Preview: "abcd",
-				Start:   LineColumn{3, 1},
-				End:     LineColumn{3, 2},
-			}}
-
-			for _, tc := range cases {
-				t.Run("", func(t *testing.T) {
-					lineMatches := tc.AsLineMatches()
-					require.Len(t, lineMatches, 1)
-					multilineMatches := lineMatches[0].AsMultilineMatches()
-					require.Len(t, multilineMatches, 1)
-					require.Equal(t, tc, multilineMatches[0])
-				})
-			}
-		})
-
-		t.Run("oneline", func(t *testing.T) {
-			cases := []*LineMatch{{
-				Preview:          "abcd",
-				LineNumber:       0,
-				OffsetAndLengths: [][2]int32{{0, 4}},
-			}, {
-				Preview:          "abcd",
-				LineNumber:       0,
-				OffsetAndLengths: [][2]int32{{0, 3}},
-			}, {
-				Preview:          "abcd",
-				LineNumber:       3,
-				OffsetAndLengths: [][2]int32{{1, 1}},
-			}}
-
-			for _, tc := range cases {
-				t.Run("", func(t *testing.T) {
-					multilineMatches := tc.AsMultilineMatches()
-					require.Len(t, multilineMatches, 1)
-					lineMatches := multilineMatches[0].AsLineMatches()
-					require.Len(t, lineMatches, 1)
-					require.Equal(t, tc, lineMatches[0])
-				})
-			}
-		})
-	})
-
 	t.Run("AsLineMatches", func(t *testing.T) {
 		cases := []struct {
 			input  MultilineMatch
@@ -69,8 +14,10 @@ func TestConvertMatches(t *testing.T) {
 		}{{
 			input: MultilineMatch{
 				Preview: "line1\nline2\nline3",
-				Start:   LineColumn{1, 1},
-				End:     LineColumn{3, 1},
+				Range: Range{
+					Start: Location{1, 1, 1},
+					End:   Location{13, 3, 1},
+				},
 			},
 			output: []*LineMatch{{
 				Preview:          "line1",
@@ -88,8 +35,10 @@ func TestConvertMatches(t *testing.T) {
 		}, {
 			input: MultilineMatch{
 				Preview: "line1",
-				Start:   LineColumn{1, 1},
-				End:     LineColumn{1, 3},
+				Range: Range{
+					Start: Location{1, 1, 1},
+					End:   Location{1, 1, 3},
+				},
 			},
 			output: []*LineMatch{
 				{
@@ -107,34 +56,6 @@ func TestConvertMatches(t *testing.T) {
 		}
 	})
 
-	t.Run("AsMultilineMatches", func(t *testing.T) {
-		cases := []struct {
-			input  LineMatch
-			output []MultilineMatch
-		}{{
-			input: LineMatch{
-				Preview:          "0.2.4.6.8.10.13.16.19",
-				LineNumber:       42,
-				OffsetAndLengths: [][2]int32{{2, 2}, {8, 5}},
-			},
-			output: []MultilineMatch{{
-				Preview: "0.2.4.6.8.10.13.16.19",
-				Start:   LineColumn{42, 2},
-				End:     LineColumn{42, 4},
-			}, {
-				Preview: "0.2.4.6.8.10.13.16.19",
-				Start:   LineColumn{42, 8},
-				End:     LineColumn{42, 13},
-			}},
-		}}
-
-		for _, tc := range cases {
-			t.Run("", func(t *testing.T) {
-				require.Equal(t, tc.output, tc.input.AsMultilineMatches())
-			})
-		}
-	})
-
 	t.Run("MultilineSliceAsLineMatchSlice", func(t *testing.T) {
 		cases := []struct {
 			input  []MultilineMatch
@@ -142,12 +63,16 @@ func TestConvertMatches(t *testing.T) {
 		}{{
 			input: []MultilineMatch{{
 				Preview: "line1\nline2\nline3",
-				Start:   LineColumn{1, 1},
-				End:     LineColumn{3, 1},
+				Range: Range{
+					Start: Location{1, 1, 1},
+					End:   Location{13, 3, 1},
+				},
 			}, {
 				Preview: "line2\nline3\nline4",
-				Start:   LineColumn{2, 1},
-				End:     LineColumn{4, 1},
+				Range: Range{
+					Start: Location{7, 2, 1},
+					End:   Location{13, 4, 1},
+				},
 			}},
 			output: []*LineMatch{{
 				Preview:          "line1",
@@ -169,12 +94,16 @@ func TestConvertMatches(t *testing.T) {
 		}, {
 			input: []MultilineMatch{{
 				Preview: "line1\nline2\nline3",
-				Start:   LineColumn{1, 1},
-				End:     LineColumn{3, 1},
+				Range: Range{
+					Start: Location{1, 1, 1},
+					End:   Location{13, 3, 1},
+				},
 			}, {
 				Preview: "line4\nline5\nline6",
-				Start:   LineColumn{4, 1},
-				End:     LineColumn{6, 1},
+				Range: Range{
+					Start: Location{19, 4, 1},
+					End:   Location{31, 6, 1},
+				},
 			}},
 			output: []*LineMatch{{
 				Preview:          "line1",

--- a/internal/search/searcher/search.go
+++ b/internal/search/searcher/search.go
@@ -209,7 +209,7 @@ func searchFilesInRepo(
 
 // newToMatches returns a closure that converts []*protocol.FileMatch to []result.Match.
 func newToMatches(repo types.MinimalRepo, commit api.CommitID, rev *string) func([]*protocol.FileMatch) []result.Match {
-	runeCountToByteCount := func(buf string, n int) int {
+	runeOffsetToByteOffset := func(buf string, n int) int {
 		idx := 0
 		for i := 0; i < n; i++ {
 			_, count := utf8.DecodeRuneInString(buf)
@@ -230,12 +230,12 @@ func newToMatches(repo types.MinimalRepo, commit api.CommitID, rev *string) func
 						Preview: lm.Preview,
 						Range: result.Range{
 							Start: result.Location{
-								Offset: lm.LineOffset + runeCountToByteCount(lm.Preview, offset),
+								Offset: lm.LineOffset + runeOffsetToByteOffset(lm.Preview, offset),
 								Line:   lm.LineNumber,
 								Column: offset,
 							},
 							End: result.Location{
-								Offset: lm.LineOffset + runeCountToByteCount(lm.Preview, offset+length),
+								Offset: lm.LineOffset + runeOffsetToByteOffset(lm.Preview, offset+length),
 								Line:   lm.LineNumber,
 								Column: offset + length,
 							},

--- a/internal/search/searcher/search.go
+++ b/internal/search/searcher/search.go
@@ -3,6 +3,7 @@ package searcher
 import (
 	"context"
 	"time"
+	"unicode/utf8"
 
 	"github.com/inconshreveable/log15"
 	"github.com/opentracing/opentracing-go/log"
@@ -208,30 +209,55 @@ func searchFilesInRepo(
 
 // newToMatches returns a closure that converts []*protocol.FileMatch to []result.Match.
 func newToMatches(repo types.MinimalRepo, commit api.CommitID, rev *string) func([]*protocol.FileMatch) []result.Match {
+	runeCountToByteCount := func(buf string, n int) int {
+		idx := 0
+		for i := 0; i < n; i++ {
+			_, count := utf8.DecodeRuneInString(buf)
+			buf = buf[count:]
+			idx += count
+		}
+		return idx
+	}
+
 	return func(searcherMatches []*protocol.FileMatch) []result.Match {
 		matches := make([]result.Match, 0, len(searcherMatches))
 		for _, fm := range searcherMatches {
 			multilineMatches := make([]result.MultilineMatch, 0, len(fm.LineMatches))
 			for _, lm := range fm.LineMatches {
 				for _, ol := range lm.OffsetAndLengths {
+					offset, length := ol[0], ol[1]
 					multilineMatches = append(multilineMatches, result.MultilineMatch{
-						Start: result.LineColumn{
-							Line:   int32(lm.LineNumber),
-							Column: int32(ol[0]),
-						},
-						End: result.LineColumn{
-							Line:   int32(lm.LineNumber),
-							Column: int32(ol[0] + ol[1]),
-						},
 						Preview: lm.Preview,
+						Range: result.Range{
+							Start: result.Location{
+								Offset: lm.LineOffset + runeCountToByteCount(lm.Preview, offset),
+								Line:   lm.LineNumber,
+								Column: offset,
+							},
+							End: result.Location{
+								Offset: lm.LineOffset + runeCountToByteCount(lm.Preview, offset+length),
+								Line:   lm.LineNumber,
+								Column: offset + length,
+							},
+						},
 					})
 				}
 			}
 			for _, mm := range fm.MultilineMatches {
 				multilineMatches = append(multilineMatches, result.MultilineMatch{
 					Preview: mm.Preview,
-					Start:   result.LineColumn{Line: mm.Start.Line, Column: mm.Start.Column},
-					End:     result.LineColumn{Line: mm.End.Line, Column: mm.End.Column},
+					Range: result.Range{
+						Start: result.Location{
+							Offset: int(mm.Start.Offset),
+							Line:   int(mm.Start.Line),
+							Column: int(mm.Start.Column),
+						},
+						End: result.Location{
+							Offset: int(mm.End.Offset),
+							Line:   int(mm.End.Line),
+							Column: int(mm.End.Column),
+						},
+					},
 				})
 			}
 

--- a/internal/search/streaming/stream_test.go
+++ b/internal/search/streaming/stream_test.go
@@ -206,24 +206,32 @@ func TestWithSelect(t *testing.T) {
     "MultilineMatches": [
       {
         "Preview": "",
-        "Start": {
-          "Line": 0,
-          "Column": 0
-        },
-        "End": {
-          "Line": 0,
-          "Column": 0
+        "Range": {
+          "start": [
+            0,
+            0,
+            0
+          ],
+          "end": [
+            0,
+            0,
+            0
+          ]
         }
       },
       {
         "Preview": "",
-        "Start": {
-          "Line": 0,
-          "Column": 0
-        },
-        "End": {
-          "Line": 0,
-          "Column": 0
+        "Range": {
+          "start": [
+            0,
+            0,
+            0
+          ],
+          "end": [
+            0,
+            0,
+            0
+          ]
         }
       }
     ],
@@ -234,13 +242,17 @@ func TestWithSelect(t *testing.T) {
     "MultilineMatches": [
       {
         "Preview": "",
-        "Start": {
-          "Line": 0,
-          "Column": 0
-        },
-        "End": {
-          "Line": 0,
-          "Column": 0
+        "Range": {
+          "start": [
+            0,
+            0,
+            0
+          ],
+          "end": [
+            0,
+            0,
+            0
+          ]
         }
       }
     ],
@@ -251,13 +263,17 @@ func TestWithSelect(t *testing.T) {
     "MultilineMatches": [
       {
         "Preview": "",
-        "Start": {
-          "Line": 0,
-          "Column": 0
-        },
-        "End": {
-          "Line": 0,
-          "Column": 0
+        "Range": {
+          "start": [
+            0,
+            0,
+            0
+          ],
+          "end": [
+            0,
+            0,
+            0
+          ]
         }
       }
     ],
@@ -268,13 +284,17 @@ func TestWithSelect(t *testing.T) {
     "MultilineMatches": [
       {
         "Preview": "",
-        "Start": {
-          "Line": 0,
-          "Column": 0
-        },
-        "End": {
-          "Line": 0,
-          "Column": 0
+        "Range": {
+          "start": [
+            0,
+            0,
+            0
+          ],
+          "end": [
+            0,
+            0,
+            0
+          ]
         }
       }
     ],

--- a/internal/search/zoekt/indexed_search.go
+++ b/internal/search/zoekt/indexed_search.go
@@ -414,14 +414,18 @@ func zoektFileMatchToMultilineMatches(file *zoekt.FileMatch) []result.MultilineM
 
 			lines = append(lines, result.MultilineMatch{
 				Preview: string(l.Line),
-				Start: result.LineColumn{
-					// zoekt line numbers are 1-based rather than 0-based so subtract 1
-					Line:   int32(l.LineNumber - 1),
-					Column: int32(offset),
-				},
-				End: result.LineColumn{
-					Line:   int32(l.LineNumber - 1),
-					Column: int32(offset + length),
+				Range: result.Range{
+					Start: result.Location{
+						// zoekt line numbers are 1-based rather than 0-based so subtract 1
+						Offset: int(m.Offset),
+						Line:   l.LineNumber - 1,
+						Column: offset,
+					},
+					End: result.Location{
+						Offset: int(m.Offset),
+						Line:   l.LineNumber - 1,
+						Column: offset + length,
+					},
 				},
 			})
 		}


### PR DESCRIPTION
Now that we can generate byte offsets from all our backends, we can
unify the result.LineColumn type with result.Location.

## Test plan

Updated affected tests.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
