### PR TITLE
Search backend: a better multiline type

### DIFF
--- a/cmd/frontend/graphqlbackend/file_match.go
+++ b/cmd/frontend/graphqlbackend/file_match.go
@@ -56,7 +56,7 @@ func (fm *FileMatchResolver) Symbols() []symbolResolver {
 }
 
 func (fm *FileMatchResolver) LineMatches() []lineMatchResolver {
-	lineMatches := result.MultilineSliceAsLineMatchSlice(fm.FileMatch.MultilineMatches)
+	lineMatches := fm.FileMatch.HunkMatches.AsLineMatches()
 	r := make([]lineMatchResolver, 0, len(lineMatches))
 	for _, lm := range lineMatches {
 		r = append(r, lineMatchResolver{lm})

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -248,15 +248,15 @@ func (sr *SearchResultsResolver) blameFileMatch(ctx context.Context, fm *result.
 	}()
 
 	// Blame the first line match.
-	if len(fm.MultilineMatches) == 0 {
+	if len(fm.HunkMatches) == 0 {
 		// No line match
 		return time.Time{}, nil
 	}
-	mm := fm.MultilineMatches[0]
+	hm := fm.HunkMatches[0]
 	hunks, err := gitserver.NewClient(sr.db).BlameFile(ctx, fm.Repo.Name, fm.Path, &gitserver.BlameOptions{
 		NewestCommit: fm.CommitID,
-		StartLine:    mm.Range.Start.Line,
-		EndLine:      mm.Range.Start.Line,
+		StartLine:    hm.Ranges[0].Start.Line,
+		EndLine:      hm.Ranges[0].Start.Line,
 	}, authz.DefaultSubRepoPermsChecker)
 	if err != nil {
 		return time.Time{}, err

--- a/cmd/frontend/graphqlbackend/search_results_stats_languages.go
+++ b/cmd/frontend/graphqlbackend/search_results_stats_languages.go
@@ -111,12 +111,12 @@ func searchResultsStatsLanguages(ctx context.Context, db database.DB, matches []
 				filesMap[key] = &fileStatsWork{}
 			}
 
-			if len(fileMatch.MultilineMatches) > 0 {
+			if len(fileMatch.HunkMatches) > 0 {
 				// Only count matching lines. TODO(sqs): bytes are not counted for these files
 				if filesMap[key].partialFiles == nil {
 					filesMap[key].partialFiles = map[string]uint64{}
 				}
-				filesMap[key].partialFiles[fileMatch.Path] += uint64(len(fileMatch.MultilineMatches))
+				filesMap[key].partialFiles[fileMatch.Path] += uint64(fileMatch.HunkMatches.MatchCount())
 			} else {
 				// Count entire file.
 				filesMap[key].fullEntries = append(filesMap[key].fullEntries, &fileInfo{

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -52,7 +52,7 @@ func TestSearchResults(t *testing.T) {
 			case *result.RepoMatch:
 				resultDescriptions[i] = fmt.Sprintf("repo:%s", m.Name)
 			case *result.FileMatch:
-				resultDescriptions[i] = fmt.Sprintf("%s:%d", m.Path, m.MultilineMatches[0].Range.Start.Line)
+				resultDescriptions[i] = fmt.Sprintf("%s:%d", m.Path, m.HunkMatches[0].Ranges[0].Start.Line)
 			default:
 				t.Fatal("unexpected result type:", match)
 			}

--- a/cmd/frontend/graphqlbackend/search_test.go
+++ b/cmd/frontend/graphqlbackend/search_test.go
@@ -293,13 +293,13 @@ func TestExactlyOneRepo(t *testing.T) {
 }
 
 func mkFileMatch(repo types.MinimalRepo, path string, lineNumbers ...int) *result.FileMatch {
-	var lines []result.MultilineMatch
+	var hms result.HunkMatches
 	for _, n := range lineNumbers {
-		lines = append(lines, result.MultilineMatch{
-			Range: result.Range{
+		hms = append(hms, result.HunkMatch{
+			Ranges: []result.Range{{
 				Start: result.Location{Line: n},
 				End:   result.Location{Line: n},
-			},
+			}},
 		})
 	}
 
@@ -308,7 +308,7 @@ func mkFileMatch(repo types.MinimalRepo, path string, lineNumbers ...int) *resul
 			Path: path,
 			Repo: repo,
 		},
-		MultilineMatches: lines,
+		HunkMatches: hms,
 	}
 }
 

--- a/cmd/frontend/internal/search/decorate.go
+++ b/cmd/frontend/internal/search/decorate.go
@@ -153,7 +153,7 @@ func DecorateFileHunksHTML(ctx context.Context, db database.DB, fm *result.FileM
 		return tableRows
 	}
 
-	groups := groupLineMatches(result.MultilineSliceAsLineMatchSlice(fm.MultilineMatches))
+	groups := groupLineMatches(fm.HunkMatches.AsLineMatches())
 	hunks := make([]stream.DecoratedHunk, 0, len(groups))
 	for _, group := range groups {
 		rows := spliceRows(int(group[0].LineNumber), int(group[0].LineNumber)+len(group))

--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -427,7 +427,7 @@ func fromMatch(match result.Match, repoCache map[api.RepoID]*types.SearchedRepo)
 func fromFileMatch(fm *result.FileMatch, repoCache map[api.RepoID]*types.SearchedRepo) streamhttp.EventMatch {
 	if len(fm.Symbols) > 0 {
 		return fromSymbolMatch(fm, repoCache)
-	} else if len(fm.MultilineMatches) > 0 {
+	} else if fm.HunkMatches.MatchCount() > 0 {
 		return fromContentMatch(fm, repoCache)
 	}
 	return fromPathMatch(fm, repoCache)
@@ -455,7 +455,7 @@ func fromPathMatch(fm *result.FileMatch, repoCache map[api.RepoID]*types.Searche
 }
 
 func fromContentMatch(fm *result.FileMatch, repoCache map[api.RepoID]*types.SearchedRepo) *streamhttp.EventContentMatch {
-	lineMatches := result.MultilineSliceAsLineMatchSlice(fm.MultilineMatches)
+	lineMatches := fm.HunkMatches.AsLineMatches()
 	eventLineMatches := make([]streamhttp.EventLineMatch, 0, len(lineMatches))
 	for _, lm := range lineMatches {
 		eventLineMatches = append(eventLineMatches, streamhttp.EventLineMatch{

--- a/enterprise/cmd/frontend/internal/compute/resolvers/resolvers_test.go
+++ b/enterprise/cmd/frontend/internal/compute/resolvers/resolvers_test.go
@@ -35,18 +35,18 @@ func TestToResultResolverList(t *testing.T) {
 
 	nonNilMatches := []result.Match{
 		&result.FileMatch{
-			MultilineMatches: []result.MultilineMatch{{
+			HunkMatches: result.HunkMatches{{
 				Preview: "a",
-				Range: result.Range{
+				Ranges: result.Ranges{{
 					Start: result.Location{Line: 1, Column: 0},
 					End:   result.Location{Line: 1, Column: 1},
-				},
+				}},
 			}, {
 				Preview: "b",
-				Range: result.Range{
+				Ranges: result.Ranges{{
 					Start: result.Location{Line: 2, Column: 0},
 					End:   result.Location{Line: 2, Column: 1},
-				},
+				}},
 			}},
 		},
 	}

--- a/enterprise/internal/compute/match_only_command.go
+++ b/enterprise/internal/compute/match_only_command.go
@@ -70,7 +70,7 @@ func fromRegexpMatches(submatches []int, namedGroups []string, lineValue string,
 }
 
 func matchOnly(fm *result.FileMatch, r *regexp.Regexp) *MatchContext {
-	lineMatches := result.MultilineSliceAsLineMatchSlice(fm.MultilineMatches)
+	lineMatches := fm.HunkMatches.AsLineMatches()
 	matches := make([]Match, 0, len(lineMatches))
 	for _, l := range lineMatches {
 		for _, submatches := range r.FindAllStringSubmatchIndex(l.Preview, -1) {

--- a/enterprise/internal/compute/match_only_command_test.go
+++ b/enterprise/internal/compute/match_only_command_test.go
@@ -35,12 +35,12 @@ func Test_matchOnly(t *testing.T) {
 			Name: "codehost.com/myorg/myrepo",
 		}},
 		HunkMatches: result.HunkMatches{{
-				Preview: "abcdefgh",
-				Ranges: result.Ranges{{
-					Start: result.Location{Line: 1},
-					End:   result.Location{Line: 1},
-				}},
+			Preview: "abcdefgh",
+			Ranges: result.Ranges{{
+				Start: result.Location{Line: 1},
+				End:   result.Location{Line: 1},
 			}},
+		}},
 	}
 
 	test := func(input string, serialize serializer) string {

--- a/enterprise/internal/compute/match_only_command_test.go
+++ b/enterprise/internal/compute/match_only_command_test.go
@@ -34,15 +34,13 @@ func Test_matchOnly(t *testing.T) {
 			ID:   5,
 			Name: "codehost.com/myorg/myrepo",
 		}},
-		MultilineMatches: []result.MultilineMatch{
-			{
+		HunkMatches: result.HunkMatches{{
 				Preview: "abcdefgh",
-				Range: result.Range{
+				Ranges: result.Ranges{{
 					Start: result.Location{Line: 1},
 					End:   result.Location{Line: 1},
-				},
-			},
-		},
+				}},
+			}},
 	}
 
 	test := func(input string, serialize serializer) string {

--- a/enterprise/internal/compute/match_only_command_test.go
+++ b/enterprise/internal/compute/match_only_command_test.go
@@ -35,7 +35,8 @@ func Test_matchOnly(t *testing.T) {
 			Name: "codehost.com/myorg/myrepo",
 		}},
 		HunkMatches: result.HunkMatches{{
-			Preview: "abcdefgh",
+			Preview:         "abcdefgh",
+			LineNumberStart: 1,
 			Ranges: result.Ranges{{
 				Start: result.Location{Line: 1},
 				End:   result.Location{Line: 1},

--- a/internal/search/result/deduper_test.go
+++ b/internal/search/result/deduper_test.go
@@ -41,7 +41,7 @@ func TestDeduper(t *testing.T) {
 		}
 	}
 
-	file := func(repo, commit, path string, lines []MultilineMatch) *FileMatch {
+	file := func(repo, commit, path string, hms HunkMatches) *FileMatch {
 		return &FileMatch{
 			File: File{
 				Repo: types.MinimalRepo{
@@ -50,12 +50,12 @@ func TestDeduper(t *testing.T) {
 				CommitID: api.CommitID(commit),
 				Path:     path,
 			},
-			MultilineMatches: lines,
+			HunkMatches: hms,
 		}
 	}
 
-	lm := func(s string) MultilineMatch {
-		return MultilineMatch{
+	hm := func(s string) HunkMatch {
+		return HunkMatch{
 			Preview: s,
 		}
 	}
@@ -83,11 +83,11 @@ func TestDeduper(t *testing.T) {
 		{
 			name: "merge files",
 			input: []Match{
-				file("a", "b", "c", []MultilineMatch{lm("a"), lm("b")}),
-				file("a", "b", "c", []MultilineMatch{lm("c"), lm("d")}),
+				file("a", "b", "c", HunkMatches{hm("a"), hm("b")}),
+				file("a", "b", "c", HunkMatches{hm("c"), hm("d")}),
 			},
 			expected: []Match{
-				file("a", "b", "c", []MultilineMatch{lm("a"), lm("b"), lm("c"), lm("d")}),
+				file("a", "b", "c", HunkMatches{hm("a"), hm("b"), hm("c"), hm("d")}),
 			},
 		},
 		{

--- a/internal/search/result/file.go
+++ b/internal/search/result/file.go
@@ -215,6 +215,14 @@ func (hs HunkMatches) AsLineMatches() []*LineMatch {
 	return res
 }
 
+func (hs HunkMatches) MatchCount() int {
+	count := 0
+	for _, h := range hs {
+		count += len(h.Ranges)
+	}
+	return count
+}
+
 type MultilineMatch struct {
 	// Preview is a possibly-multiline string that contains all the
 	// lines that the match overlaps.

--- a/internal/search/result/file.go
+++ b/internal/search/result/file.go
@@ -3,9 +3,7 @@ package result
 import (
 	"net/url"
 	"path"
-	"sort"
 	"strings"
-	"unicode/utf8"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/search/filter"
@@ -44,8 +42,8 @@ func (f *File) URL() *url.URL {
 type FileMatch struct {
 	File
 
-	MultilineMatches []MultilineMatch
-	Symbols          []*SymbolMatch `json:"-"`
+	HunkMatches HunkMatches
+	Symbols     []*SymbolMatch `json:"-"`
 
 	LimitHit bool
 }
@@ -57,7 +55,7 @@ func (fm *FileMatch) RepoName() types.MinimalRepo {
 func (fm *FileMatch) searchResultMarker() {}
 
 func (fm *FileMatch) ResultCount() int {
-	rc := len(fm.Symbols) + len(fm.MultilineMatches)
+	rc := len(fm.Symbols) + fm.HunkMatches.MatchCount()
 	if rc == 0 {
 		return 1 // 1 to count "empty" results like type:path results
 	}
@@ -68,7 +66,7 @@ func (fm *FileMatch) ResultCount() int {
 // the absence of a true `PathMatch` type, we use this function as a proxy
 // signal to drive `select:file` logic that deduplicates path results.
 func (fm *FileMatch) IsPathMatch() bool {
-	return len(fm.MultilineMatches) == 0 && len(fm.Symbols) == 0
+	return len(fm.HunkMatches) == 0 && len(fm.Symbols) == 0
 }
 
 func (fm *FileMatch) Select(selectPath filter.SelectPath) Match {
@@ -79,7 +77,7 @@ func (fm *FileMatch) Select(selectPath filter.SelectPath) Match {
 			ID:   fm.Repo.ID,
 		}
 	case filter.File:
-		fm.MultilineMatches = nil
+		fm.HunkMatches = nil
 		fm.Symbols = nil
 		if len(selectPath) > 1 && selectPath[1] == "directory" {
 			fm.Path = path.Clean(path.Dir(fm.Path)) + "/" // Add trailing slash for clarity.
@@ -87,7 +85,7 @@ func (fm *FileMatch) Select(selectPath filter.SelectPath) Match {
 		return fm
 	case filter.Symbol:
 		if len(fm.Symbols) > 0 {
-			fm.MultilineMatches = nil // Only return symbol match if symbols exist
+			fm.HunkMatches = nil // Only return symbol match if symbols exist
 			if len(selectPath) > 1 {
 				filteredSymbols := SelectSymbolKind(fm.Symbols, selectPath[1])
 				if len(filteredSymbols) == 0 {
@@ -100,7 +98,7 @@ func (fm *FileMatch) Select(selectPath filter.SelectPath) Match {
 		return nil
 	case filter.Content:
 		// Only return file match if line matches exist
-		if len(fm.MultilineMatches) > 0 {
+		if len(fm.HunkMatches) > 0 {
 			fm.Symbols = nil
 			return fm
 		}
@@ -114,7 +112,8 @@ func (fm *FileMatch) Select(selectPath filter.SelectPath) Match {
 // AppendMatches appends the line matches from src as well as updating match
 // counts and limit.
 func (fm *FileMatch) AppendMatches(src *FileMatch) {
-	fm.MultilineMatches = append(fm.MultilineMatches, src.MultilineMatches...)
+	// TODO merge hunk matches smartly
+	fm.HunkMatches = append(fm.HunkMatches, src.HunkMatches...)
 	fm.Symbols = append(fm.Symbols, src.Symbols...)
 	fm.LimitHit = fm.LimitHit || src.LimitHit
 }
@@ -125,7 +124,7 @@ func (fm *FileMatch) AppendMatches(src *FileMatch) {
 //   if limit >= ResultCount then nothing is done and we return limit - ResultCount.
 //   if limit < ResultCount then ResultCount becomes limit and we return 0.
 func (fm *FileMatch) Limit(limit int) int {
-	matchCount := len(fm.MultilineMatches)
+	matchCount := fm.HunkMatches.MatchCount()
 	symbolCount := len(fm.Symbols)
 
 	// An empty FileMatch should still count against the limit -- see *FileMatch.ResultCount()
@@ -134,7 +133,7 @@ func (fm *FileMatch) Limit(limit int) int {
 	}
 
 	if limit < matchCount {
-		fm.MultilineMatches = fm.MultilineMatches[:limit]
+		fm.HunkMatches.Limit(limit)
 		limit = 0
 		fm.LimitHit = true
 	} else {
@@ -222,57 +221,16 @@ func (hs HunkMatches) MatchCount() int {
 	return count
 }
 
-type MultilineMatch struct {
-	// Preview is a possibly-multiline string that contains all the
-	// lines that the match overlaps.
-	// The number of lines in Preview should be End.Line - Start.Line + 1
-	Preview string
-	Range   Range
-}
-
-func MultilineSliceAsLineMatchSlice(matches []MultilineMatch) []*LineMatch {
-	lineMatches := make([]*LineMatch, 0, len(matches))
-	for _, m := range matches {
-		lineMatches = append(lineMatches, m.AsLineMatches()...)
+func (hs *HunkMatches) Limit(limit int) {
+	matches := *hs
+	for i, match := range matches {
+		if len(match.Ranges) >= limit {
+			matches[i].Ranges = match.Ranges[:limit]
+			*hs = matches[:i+1]
+			return
+		}
+		limit -= len(match.Ranges)
 	}
-	sort.Slice(lineMatches, func(i, j int) bool {
-		return lineMatches[i].LineNumber < lineMatches[j].LineNumber
-	})
-	res := lineMatches[:0]
-	for i, lm := range lineMatches {
-		if i == 0 {
-			res = append(res, lm)
-			continue
-		}
-		last := len(res) - 1
-		if lm.LineNumber == res[last].LineNumber {
-			res[last].OffsetAndLengths = append(res[last].OffsetAndLengths, lm.OffsetAndLengths...)
-		} else {
-			res = append(res, lm)
-		}
-	}
-	return res
-}
-
-func (m MultilineMatch) AsLineMatches() []*LineMatch {
-	lines := strings.Split(m.Preview, "\n")
-	lineMatches := make([]*LineMatch, 0, len(lines))
-	for i, line := range lines {
-		offset := int32(0)
-		if i == 0 {
-			offset = int32(m.Range.Start.Column)
-		}
-		length := int32(utf8.RuneCountInString(line)) - offset
-		if i == len(lines)-1 {
-			length = int32(m.Range.End.Column) - offset
-		}
-		lineMatches = append(lineMatches, &LineMatch{
-			Preview:          line,
-			LineNumber:       int32(m.Range.Start.Line) + int32(i),
-			OffsetAndLengths: [][2]int32{{offset, length}},
-		})
-	}
-	return lineMatches
 }
 
 type LineMatch struct {

--- a/internal/search/result/file.go
+++ b/internal/search/result/file.go
@@ -168,8 +168,7 @@ func (fm *FileMatch) Key() Key {
 
 type HunkMatch struct {
 	Preview         string
-	LineNumberStart int32
-	LineNumberEnd   int32
+	LineNumberStart int
 	Ranges          Ranges
 }
 
@@ -198,7 +197,7 @@ func (h HunkMatch) AsLineMatches() []*LineMatch {
 		}
 		lineMatches[i] = &LineMatch{
 			Preview:          line,
-			LineNumber:       lineNumber,
+			LineNumber:       int32(lineNumber),
 			OffsetAndLengths: offsetAndLengths,
 		}
 	}

--- a/internal/search/result/file_test.go
+++ b/internal/search/result/file_test.go
@@ -13,7 +13,8 @@ func TestConvertMatches(t *testing.T) {
 			output []*LineMatch
 		}{{
 			input: HunkMatch{
-				Preview: "line1\nline2\nline3",
+				Preview:         "line1\nline2\nline3",
+				LineNumberStart: 1,
 				Ranges: Ranges{{
 					Start: Location{1, 1, 1},
 					End:   Location{13, 3, 1},
@@ -34,7 +35,8 @@ func TestConvertMatches(t *testing.T) {
 			}},
 		}, {
 			input: HunkMatch{
-				Preview: "line1",
+				Preview:         "line1",
+				LineNumberStart: 1,
 				Ranges: Ranges{{
 					Start: Location{1, 1, 1},
 					End:   Location{1, 1, 3},
@@ -51,25 +53,23 @@ func TestConvertMatches(t *testing.T) {
 
 		for _, tc := range cases {
 			t.Run("", func(t *testing.T) {
-				require.Equal(t, tc.input.AsLineMatches(), tc.output)
+				require.Equal(t, tc.output, tc.input.AsLineMatches())
 			})
 		}
 	})
 
-	t.Run("MultilineSliceAsLineMatchSlice", func(t *testing.T) {
+	t.Run("HunkMatchesAsLineMatches", func(t *testing.T) {
 		cases := []struct {
 			input  HunkMatches
 			output []*LineMatch
 		}{{
 			input: HunkMatches{{
-				Preview: "line1\nline2\nline3",
+				Preview:         "line1\nline2\nline3\nline4",
+				LineNumberStart: 1,
 				Ranges: Ranges{{
 					Start: Location{1, 1, 1},
 					End:   Location{13, 3, 1},
-				}},
-			}, {
-				Preview: "line2\nline3\nline4",
-				Ranges: Ranges{{
+				}, {
 					Start: Location{7, 2, 1},
 					End:   Location{13, 4, 1},
 				}},
@@ -93,13 +93,15 @@ func TestConvertMatches(t *testing.T) {
 			}},
 		}, {
 			input: HunkMatches{{
-				Preview: "line1\nline2\nline3",
+				Preview:         "line1\nline2\nline3",
+				LineNumberStart: 1,
 				Ranges: Ranges{{
 					Start: Location{1, 1, 1},
 					End:   Location{13, 3, 1},
 				}},
 			}, {
-				Preview: "line4\nline5\nline6",
+				Preview:         "line4\nline5\nline6",
+				LineNumberStart: 4,
 				Ranges: Ranges{{
 					Start: Location{19, 4, 1},
 					End:   Location{31, 6, 1},

--- a/internal/search/result/file_test.go
+++ b/internal/search/result/file_test.go
@@ -9,15 +9,15 @@ import (
 func TestConvertMatches(t *testing.T) {
 	t.Run("AsLineMatches", func(t *testing.T) {
 		cases := []struct {
-			input  MultilineMatch
+			input  HunkMatch
 			output []*LineMatch
 		}{{
-			input: MultilineMatch{
+			input: HunkMatch{
 				Preview: "line1\nline2\nline3",
-				Range: Range{
+				Ranges: Ranges{{
 					Start: Location{1, 1, 1},
 					End:   Location{13, 3, 1},
-				},
+				}},
 			},
 			output: []*LineMatch{{
 				Preview:          "line1",
@@ -33,12 +33,12 @@ func TestConvertMatches(t *testing.T) {
 				OffsetAndLengths: [][2]int32{{0, 1}},
 			}},
 		}, {
-			input: MultilineMatch{
+			input: HunkMatch{
 				Preview: "line1",
-				Range: Range{
+				Ranges: Ranges{{
 					Start: Location{1, 1, 1},
 					End:   Location{1, 1, 3},
-				},
+				}},
 			},
 			output: []*LineMatch{
 				{
@@ -58,21 +58,21 @@ func TestConvertMatches(t *testing.T) {
 
 	t.Run("MultilineSliceAsLineMatchSlice", func(t *testing.T) {
 		cases := []struct {
-			input  []MultilineMatch
+			input  HunkMatches
 			output []*LineMatch
 		}{{
-			input: []MultilineMatch{{
+			input: HunkMatches{{
 				Preview: "line1\nline2\nline3",
-				Range: Range{
+				Ranges: Ranges{{
 					Start: Location{1, 1, 1},
 					End:   Location{13, 3, 1},
-				},
+				}},
 			}, {
 				Preview: "line2\nline3\nline4",
-				Range: Range{
+				Ranges: Ranges{{
 					Start: Location{7, 2, 1},
 					End:   Location{13, 4, 1},
-				},
+				}},
 			}},
 			output: []*LineMatch{{
 				Preview:          "line1",
@@ -92,18 +92,18 @@ func TestConvertMatches(t *testing.T) {
 				OffsetAndLengths: [][2]int32{{0, 1}},
 			}},
 		}, {
-			input: []MultilineMatch{{
+			input: HunkMatches{{
 				Preview: "line1\nline2\nline3",
-				Range: Range{
+				Ranges: Ranges{{
 					Start: Location{1, 1, 1},
 					End:   Location{13, 3, 1},
-				},
+				}},
 			}, {
 				Preview: "line4\nline5\nline6",
-				Range: Range{
+				Ranges: Ranges{{
 					Start: Location{19, 4, 1},
 					End:   Location{31, 6, 1},
-				},
+				}},
 			}},
 			output: []*LineMatch{{
 				Preview:          "line1",
@@ -131,13 +131,13 @@ func TestConvertMatches(t *testing.T) {
 				OffsetAndLengths: [][2]int32{{0, 1}},
 			}},
 		}, {
-			input:  []MultilineMatch{},
+			input:  HunkMatches{},
 			output: []*LineMatch{},
 		}}
 
 		for _, tc := range cases {
 			t.Run("", func(t *testing.T) {
-				require.Equal(t, MultilineSliceAsLineMatchSlice(tc.input), tc.output)
+				require.Equal(t, tc.input.AsLineMatches(), tc.output)
 			})
 		}
 	})

--- a/internal/search/result/file_test.go
+++ b/internal/search/result/file_test.go
@@ -144,3 +144,50 @@ func TestConvertMatches(t *testing.T) {
 		}
 	})
 }
+
+func TestHunkMatches_Limit(t *testing.T) {
+	cases := []struct {
+		rangeLens         []int
+		limit             int
+		expectedRangeLens []int
+	}{{
+		rangeLens:         []int{1, 1, 1},
+		limit:             1,
+		expectedRangeLens: []int{1},
+	}, {
+		rangeLens:         []int{1, 1, 1},
+		limit:             3,
+		expectedRangeLens: []int{1, 1, 1},
+	}, {
+		rangeLens:         []int{1, 1, 1},
+		limit:             4,
+		expectedRangeLens: []int{1, 1, 1},
+	}, {
+		rangeLens:         []int{2, 2, 2},
+		limit:             4,
+		expectedRangeLens: []int{2, 2},
+	}, {
+		rangeLens:         []int{2, 2, 2},
+		limit:             3,
+		expectedRangeLens: []int{2, 1},
+	}, {
+		rangeLens:         []int{2, 2, 2},
+		limit:             1,
+		expectedRangeLens: []int{1},
+	}}
+
+	for _, tc := range cases {
+		t.Run("", func(t *testing.T) {
+			var hs HunkMatches
+			for _, i := range tc.rangeLens {
+				hs = append(hs, HunkMatch{Ranges: make(Ranges, i)})
+			}
+			hs.Limit(tc.limit)
+			var gotLens []int
+			for _, h := range hs {
+				gotLens = append(gotLens, len(h.Ranges))
+			}
+			require.Equal(t, tc.expectedRangeLens, gotLens)
+		})
+	}
+}

--- a/internal/search/searcher/search.go
+++ b/internal/search/searcher/search.go
@@ -222,31 +222,37 @@ func newToMatches(repo types.MinimalRepo, commit api.CommitID, rev *string) func
 	return func(searcherMatches []*protocol.FileMatch) []result.Match {
 		matches := make([]result.Match, 0, len(searcherMatches))
 		for _, fm := range searcherMatches {
-			multilineMatches := make([]result.MultilineMatch, 0, len(fm.LineMatches))
+			hunkMatches := make(result.HunkMatches, 0, len(fm.LineMatches))
+
 			for _, lm := range fm.LineMatches {
+				ranges := make(result.Ranges, 0, len(lm.OffsetAndLengths))
 				for _, ol := range lm.OffsetAndLengths {
 					offset, length := ol[0], ol[1]
-					multilineMatches = append(multilineMatches, result.MultilineMatch{
-						Preview: lm.Preview,
-						Range: result.Range{
-							Start: result.Location{
-								Offset: lm.LineOffset + runeOffsetToByteOffset(lm.Preview, offset),
-								Line:   lm.LineNumber,
-								Column: offset,
-							},
-							End: result.Location{
-								Offset: lm.LineOffset + runeOffsetToByteOffset(lm.Preview, offset+length),
-								Line:   lm.LineNumber,
-								Column: offset + length,
-							},
+					ranges = append(ranges, result.Range{
+						Start: result.Location{
+							Offset: lm.LineOffset + runeOffsetToByteOffset(lm.Preview, offset),
+							Line:   lm.LineNumber,
+							Column: offset,
+						},
+						End: result.Location{
+							Offset: lm.LineOffset + runeOffsetToByteOffset(lm.Preview, offset+length),
+							Line:   lm.LineNumber,
+							Column: offset + length,
 						},
 					})
 				}
+				hunkMatches = append(hunkMatches, result.HunkMatch{
+					Preview:         lm.Preview,
+					LineNumberStart: lm.LineNumber,
+					Ranges:          ranges,
+				})
 			}
+
 			for _, mm := range fm.MultilineMatches {
-				multilineMatches = append(multilineMatches, result.MultilineMatch{
-					Preview: mm.Preview,
-					Range: result.Range{
+				hunkMatches = append(hunkMatches, result.HunkMatch{
+					Preview:         mm.Preview,
+					LineNumberStart: int(mm.Start.Line),
+					Ranges: result.Ranges{{
 						Start: result.Location{
 							Offset: int(mm.Start.Offset),
 							Line:   int(mm.Start.Line),
@@ -257,7 +263,7 @@ func newToMatches(repo types.MinimalRepo, commit api.CommitID, rev *string) func
 							Line:   int(mm.End.Line),
 							Column: int(mm.End.Column),
 						},
-					},
+					}},
 				})
 			}
 
@@ -268,8 +274,8 @@ func newToMatches(repo types.MinimalRepo, commit api.CommitID, rev *string) func
 					CommitID: commit,
 					InputRev: rev,
 				},
-				MultilineMatches: multilineMatches,
-				LimitHit:         fm.LimitHit,
+				HunkMatches: hunkMatches,
+				LimitHit:    fm.LimitHit,
 			})
 		}
 		return matches

--- a/internal/search/streaming/search_filters_test.go
+++ b/internal/search/streaming/search_filters_test.go
@@ -60,7 +60,7 @@ func TestSearchFiltersUpdate(t *testing.T) {
 							File: result.File{
 								Repo: repo,
 							},
-							MultilineMatches: make([]result.MultilineMatch, 2),
+							HunkMatches: result.HunkMatches{{Ranges: make(result.Ranges, 2)}},
 						},
 					},
 				},

--- a/internal/search/streaming/stream_test.go
+++ b/internal/search/streaming/stream_test.go
@@ -172,12 +172,12 @@ func TestWithSelect(t *testing.T) {
 	autogold.Want("dedupe paths for select:file.directory", `[
   {
     "Path": "pokeman/",
-    "MultilineMatches": null,
+    "HunkMatches": null,
     "LimitHit": false
   },
   {
     "Path": "digiman/",
-    "MultilineMatches": null,
+    "HunkMatches": null,
     "LimitHit": false
   }
 ]`).Equal(t, test("file.directory"))
@@ -185,17 +185,17 @@ func TestWithSelect(t *testing.T) {
 	autogold.Want("dedupe paths select:file", `[
   {
     "Path": "pokeman/charmandar",
-    "MultilineMatches": null,
+    "HunkMatches": null,
     "LimitHit": false
   },
   {
     "Path": "pokeman/bulbosaur",
-    "MultilineMatches": null,
+    "HunkMatches": null,
     "LimitHit": false
   },
   {
     "Path": "digiman/ummm",
-    "MultilineMatches": null,
+    "HunkMatches": null,
     "LimitHit": false
   }
 ]`).Equal(t, test("file"))
@@ -203,99 +203,114 @@ func TestWithSelect(t *testing.T) {
 	autogold.Want("don't dedupe file matches for select:content", `[
   {
     "Path": "pokeman/charmandar",
-    "MultilineMatches": [
+    "HunkMatches": [
       {
         "Preview": "",
-        "Range": {
-          "start": [
-            0,
-            0,
-            0
-          ],
-          "end": [
-            0,
-            0,
-            0
-          ]
-        }
+        "LineNumberStart": 0,
+        "Ranges": [
+          {
+            "start": [
+              0,
+              0,
+              0
+            ],
+            "end": [
+              0,
+              0,
+              0
+            ]
+          }
+        ]
       },
       {
         "Preview": "",
-        "Range": {
-          "start": [
-            0,
-            0,
-            0
-          ],
-          "end": [
-            0,
-            0,
-            0
-          ]
-        }
+        "LineNumberStart": 0,
+        "Ranges": [
+          {
+            "start": [
+              0,
+              0,
+              0
+            ],
+            "end": [
+              0,
+              0,
+              0
+            ]
+          }
+        ]
       }
     ],
     "LimitHit": false
   },
   {
     "Path": "pokeman/charmandar",
-    "MultilineMatches": [
+    "HunkMatches": [
       {
         "Preview": "",
-        "Range": {
-          "start": [
-            0,
-            0,
-            0
-          ],
-          "end": [
-            0,
-            0,
-            0
-          ]
-        }
+        "LineNumberStart": 0,
+        "Ranges": [
+          {
+            "start": [
+              0,
+              0,
+              0
+            ],
+            "end": [
+              0,
+              0,
+              0
+            ]
+          }
+        ]
       }
     ],
     "LimitHit": false
   },
   {
     "Path": "pokeman/bulbosaur",
-    "MultilineMatches": [
+    "HunkMatches": [
       {
         "Preview": "",
-        "Range": {
-          "start": [
-            0,
-            0,
-            0
-          ],
-          "end": [
-            0,
-            0,
-            0
-          ]
-        }
+        "LineNumberStart": 0,
+        "Ranges": [
+          {
+            "start": [
+              0,
+              0,
+              0
+            ],
+            "end": [
+              0,
+              0,
+              0
+            ]
+          }
+        ]
       }
     ],
     "LimitHit": false
   },
   {
     "Path": "digiman/ummm",
-    "MultilineMatches": [
+    "HunkMatches": [
       {
         "Preview": "",
-        "Range": {
-          "start": [
-            0,
-            0,
-            0
-          ],
-          "end": [
-            0,
-            0,
-            0
-          ]
-        }
+        "LineNumberStart": 0,
+        "Ranges": [
+          {
+            "start": [
+              0,
+              0,
+              0
+            ],
+            "end": [
+              0,
+              0,
+              0
+            ]
+          }
+        ]
       }
     ],
     "LimitHit": false

--- a/internal/search/streaming/stream_test.go
+++ b/internal/search/streaming/stream_test.go
@@ -141,20 +141,20 @@ func TestWithSelect(t *testing.T) {
 		return SearchEvent{
 			Results: []result.Match{
 				&result.FileMatch{
-					File:             result.File{Path: "pokeman/charmandar"},
-					MultilineMatches: make([]result.MultilineMatch, 1),
+					File:        result.File{Path: "pokeman/charmandar"},
+					HunkMatches: result.HunkMatches{{Ranges: make(result.Ranges, 1)}},
 				},
 				&result.FileMatch{
-					File:             result.File{Path: "pokeman/charmandar"},
-					MultilineMatches: make([]result.MultilineMatch, 1),
+					File:        result.File{Path: "pokeman/charmandar"},
+					HunkMatches: result.HunkMatches{{Ranges: make(result.Ranges, 1)}},
 				},
 				&result.FileMatch{
-					File:             result.File{Path: "pokeman/bulbosaur"},
-					MultilineMatches: make([]result.MultilineMatch, 1),
+					File:        result.File{Path: "pokeman/bulbosaur"},
+					HunkMatches: result.HunkMatches{{Ranges: make(result.Ranges, 1)}},
 				},
 				&result.FileMatch{
-					File:             result.File{Path: "digiman/ummm"},
-					MultilineMatches: make([]result.MultilineMatch, 1),
+					File:        result.File{Path: "digiman/ummm"},
+					HunkMatches: result.HunkMatches{{Ranges: make(result.Ranges, 1)}},
 				},
 			},
 		}

--- a/internal/search/textsearch/textsearch_test.go
+++ b/internal/search/textsearch/textsearch_test.go
@@ -334,24 +334,24 @@ func mkRepos(names ...string) []types.MinimalRepo {
 
 func TestFileMatch_Limit(t *testing.T) {
 	tests := []struct {
-		numMultilineMatches    int
-		numSymbolMatches       int
-		limit                  int
-		expNumMultilineMatches int
-		expNumSymbolMatches    int
-		expRemainingLimit      int
-		wantLimitHit           bool
+		numHunkRanges       int
+		numSymbolMatches    int
+		limit               int
+		expNumHunkRanges    int
+		expNumSymbolMatches int
+		expRemainingLimit   int
+		wantLimitHit        bool
 	}{
 		{
-			numMultilineMatches:    3,
-			numSymbolMatches:       0,
-			limit:                  1,
-			expNumMultilineMatches: 1,
-			expRemainingLimit:      0,
-			wantLimitHit:           true,
+			numHunkRanges:     3,
+			numSymbolMatches:  0,
+			limit:             1,
+			expNumHunkRanges:  1,
+			expRemainingLimit: 0,
+			wantLimitHit:      true,
 		},
 		{
-			numMultilineMatches: 0,
+			numHunkRanges:       0,
 			numSymbolMatches:    3,
 			limit:               1,
 			expNumSymbolMatches: 1,
@@ -359,15 +359,15 @@ func TestFileMatch_Limit(t *testing.T) {
 			wantLimitHit:        true,
 		},
 		{
-			numMultilineMatches:    3,
-			numSymbolMatches:       0,
-			limit:                  5,
-			expNumMultilineMatches: 3,
-			expRemainingLimit:      2,
-			wantLimitHit:           false,
+			numHunkRanges:     3,
+			numSymbolMatches:  0,
+			limit:             5,
+			expNumHunkRanges:  3,
+			expRemainingLimit: 2,
+			wantLimitHit:      false,
 		},
 		{
-			numMultilineMatches: 0,
+			numHunkRanges:       0,
 			numSymbolMatches:    3,
 			limit:               5,
 			expNumSymbolMatches: 3,
@@ -375,15 +375,15 @@ func TestFileMatch_Limit(t *testing.T) {
 			wantLimitHit:        false,
 		},
 		{
-			numMultilineMatches:    3,
-			numSymbolMatches:       0,
-			limit:                  3,
-			expNumMultilineMatches: 3,
-			expRemainingLimit:      0,
-			wantLimitHit:           false,
+			numHunkRanges:     3,
+			numSymbolMatches:  0,
+			limit:             3,
+			expNumHunkRanges:  3,
+			expRemainingLimit: 0,
+			wantLimitHit:      false,
 		},
 		{
-			numMultilineMatches: 0,
+			numHunkRanges:       0,
 			numSymbolMatches:    3,
 			limit:               3,
 			expNumSymbolMatches: 3,
@@ -392,27 +392,27 @@ func TestFileMatch_Limit(t *testing.T) {
 		},
 		{
 			// An empty FileMatch should still count against the limit
-			numMultilineMatches:    0,
-			numSymbolMatches:       0,
-			limit:                  1,
-			expNumSymbolMatches:    0,
-			expNumMultilineMatches: 0,
-			wantLimitHit:           false,
+			numHunkRanges:       0,
+			numSymbolMatches:    0,
+			limit:               1,
+			expNumSymbolMatches: 0,
+			expNumHunkRanges:    0,
+			wantLimitHit:        false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run("", func(t *testing.T) {
 			fileMatch := &result.FileMatch{
-				File:             result.File{},
-				MultilineMatches: make([]result.MultilineMatch, tt.numMultilineMatches),
-				Symbols:          make([]*result.SymbolMatch, tt.numSymbolMatches),
-				LimitHit:         false,
+				File:        result.File{},
+				HunkMatches: result.HunkMatches{{Ranges: make(result.Ranges, tt.numHunkRanges)}},
+				Symbols:     make([]*result.SymbolMatch, tt.numSymbolMatches),
+				LimitHit:    false,
 			}
 
 			got := fileMatch.Limit(tt.limit)
 
-			require.Equal(t, tt.expNumMultilineMatches, len(fileMatch.MultilineMatches))
+			require.Equal(t, tt.expNumHunkRanges, fileMatch.HunkMatches.MatchCount())
 			require.Equal(t, tt.expNumSymbolMatches, len(fileMatch.Symbols))
 			require.Equal(t, tt.expRemainingLimit, got)
 			require.Equal(t, tt.wantLimitHit, fileMatch.LimitHit)

--- a/internal/search/zoekt/indexed_search.go
+++ b/internal/search/zoekt/indexed_search.go
@@ -366,9 +366,9 @@ func sendMatches(event *zoekt.SearchResult, getRepoInputRev repoRevFunc, typ sea
 			continue
 		}
 
-		var lines []result.MultilineMatch
+		var hms result.HunkMatches
 		if typ != search.SymbolRequest {
-			lines = zoektFileMatchToMultilineMatches(&file)
+			hms = zoektFileMatchToMultilineMatches(&file)
 		}
 
 		for _, inputRev := range inputRevs {
@@ -379,8 +379,8 @@ func sendMatches(event *zoekt.SearchResult, getRepoInputRev repoRevFunc, typ sea
 				symbols = zoektFileMatchToSymbolResults(repo, inputRev, &file)
 			}
 			fm := result.FileMatch{
-				MultilineMatches: lines,
-				Symbols:          symbols,
+				HunkMatches: hms,
+				Symbols:     symbols,
 				File: result.File{
 					InputRev: &inputRev,
 					CommitID: api.CommitID(file.Version),
@@ -400,8 +400,8 @@ func sendMatches(event *zoekt.SearchResult, getRepoInputRev repoRevFunc, typ sea
 	})
 }
 
-func zoektFileMatchToMultilineMatches(file *zoekt.FileMatch) []result.MultilineMatch {
-	lines := make([]result.MultilineMatch, 0, len(file.LineMatches))
+func zoektFileMatchToMultilineMatches(file *zoekt.FileMatch) result.HunkMatches {
+	hms := make(result.HunkMatches, 0, len(file.LineMatches))
 
 	for _, l := range file.LineMatches {
 		if l.FileName {
@@ -412,26 +412,27 @@ func zoektFileMatchToMultilineMatches(file *zoekt.FileMatch) []result.MultilineM
 			offset := utf8.RuneCount(l.Line[:m.LineOffset])
 			length := utf8.RuneCount(l.Line[m.LineOffset : m.LineOffset+m.MatchLength])
 
-			lines = append(lines, result.MultilineMatch{
-				Preview: string(l.Line),
-				Range: result.Range{
+			hms = append(hms, result.HunkMatch{
+				Preview:         string(l.Line),
+				// zoekt line numbers are 1-based rather than 0-based so subtract 1
+				LineNumberStart: l.LineNumber - 1,
+				Ranges: result.Ranges{{
 					Start: result.Location{
-						// zoekt line numbers are 1-based rather than 0-based so subtract 1
 						Offset: int(m.Offset),
 						Line:   l.LineNumber - 1,
 						Column: offset,
 					},
 					End: result.Location{
-						Offset: int(m.Offset),
+						Offset: int(m.Offset) + m.MatchLength,
 						Line:   l.LineNumber - 1,
 						Column: offset + length,
 					},
-				},
+				}},
 			})
 		}
 	}
 
-	return lines
+	return hms
 }
 
 func zoektFileMatchToSymbolResults(repoName types.MinimalRepo, inputRev string, file *zoekt.FileMatch) []*result.SymbolMatch {

--- a/internal/search/zoekt/indexed_search.go
+++ b/internal/search/zoekt/indexed_search.go
@@ -413,7 +413,7 @@ func zoektFileMatchToMultilineMatches(file *zoekt.FileMatch) result.HunkMatches 
 			length := utf8.RuneCount(l.Line[m.LineOffset : m.LineOffset+m.MatchLength])
 
 			hms = append(hms, result.HunkMatch{
-				Preview:         string(l.Line),
+				Preview: string(l.Line),
 				// zoekt line numbers are 1-based rather than 0-based so subtract 1
 				LineNumberStart: l.LineNumber - 1,
 				Ranges: result.Ranges{{


### PR DESCRIPTION
This replaces `MultilineMatch` with a slightly more general `HunkMatch`.

One of the design limitations of `MultilineMatch` is that it requires duplicating the content of the full line for every matched range. One of the things that is nice about `LineMatch` is that it can match the same line many times, but only send the content once. When we implemented `MultilineMatch`, this was known, but I naively thought it would be fine since we don't send _that_ many results with a bunch of matches per line. 

I was wrong. The thing is, for very large lines, there are often also very many matches. This means as the line gets longer and there are more likely matches, we also send the larger line more times. This bad $n^2$ behavior causes us to [hit our max payload size limit](https://github.com/sourcegraph/sourcegraph/pull/36095) for very long lines because they are sent very many times. 

So, instead, we get `HunkMatch`. A `HunkMatch` is like a `MultilineMatch`, except it can contain any number of matched ranges (which are allowed to cross line boundaries) within that hunk. 

This satisfies all the following design constraints:
- We can reconstruct the exact matched text for each range
- We have the extended line contents of each match available for consumers like `src` CLI
- (**NEW**) We never need to send content more than once
- All of our backends return the information needed to create this type (after the last couple of buildup PRs)
- This type can be losslessly and efficiently converted to `[]*LineMatch` to maintain compatibility with the current API contract

As a bonus, this structure should make it much easier to implement streamed highlighting since the matches are already grouped into lines, so consumers can just request the decorated version of the range represented by the hunk.

Stacked on #36119 

## Test plan

Updated all tests and double checked output. Manually tested a few queries (in particular multiline queries). Ran backend integration tests. Added a couple of unit tests.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
