### PR TITLE
batches: fix incorrect filter for draft batch changes

### DIFF
--- a/enterprise/internal/batches/store/batch_changes.go
+++ b/enterprise/internal/batches/store/batch_changes.go
@@ -213,7 +213,7 @@ func countBatchChangesQuery(opts *CountBatchChangesOpts, repoAuthzConds *sqlf.Qu
 			case btypes.BatchChangeStateClosed:
 				stateConds = append(stateConds, sqlf.Sprintf("batch_changes.closed_at IS NOT NULL"))
 			case btypes.BatchChangeStateDraft:
-				stateConds = append(stateConds, sqlf.Sprintf("batch_changes.last_applied_at IS NULL"))
+				stateConds = append(stateConds, sqlf.Sprintf("batch_changes.last_applied_at IS NULL AND batch_changes.closed_at IS NULL"))
 			}
 		}
 		if len(stateConds) > 0 {
@@ -520,7 +520,7 @@ func listBatchChangesQuery(opts *ListBatchChangesOpts, repoAuthzConds *sqlf.Quer
 			case btypes.BatchChangeStateClosed:
 				stateConds = append(stateConds, sqlf.Sprintf("batch_changes.closed_at IS NOT NULL"))
 			case btypes.BatchChangeStateDraft:
-				stateConds = append(stateConds, sqlf.Sprintf("batch_changes.last_applied_at IS NULL"))
+				stateConds = append(stateConds, sqlf.Sprintf("batch_changes.last_applied_at IS NULL AND batch_changes.closed_at IS NULL"))
 			}
 		}
 		if len(stateConds) > 0 {

--- a/enterprise/internal/batches/store/batch_changes_test.go
+++ b/enterprise/internal/batches/store/batch_changes_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 func testStoreBatchChanges(t *testing.T, ctx context.Context, s *Store, clock ct.Clock) {
-	cs := make([]*btypes.BatchChange, 0, 4)
+	cs := make([]*btypes.BatchChange, 0, 5)
 
 	t.Run("Create", func(t *testing.T) {
 		for i := 0; i < cap(cs); i++ {
@@ -39,10 +39,20 @@ func testStoreBatchChanges(t *testing.T, ctx context.Context, s *Store, clock ct
 			}
 
 			if i != 0 {
-				// The very first batch change is a draft, the rest are not
+				// The very first batch change is a draft, the rest are not.
 				c.CreatorID = int32(i) + 50
 				c.LastAppliedAt = clock.Now()
 				c.LastApplierID = int32(i) + 99
+			}
+
+			// the fifth batch change is a closed batch change that wasn't applied.
+			// it shouldn't show up in the draft batch change list, it should instead
+			// show up in the closed batch change list.
+			if i == 5 {
+				c.ClosedAt = clock.Now()
+				c.LastAppliedAt = time.Time{}
+				c.LastApplierID = 0
+				c.CreatorID = 0
 			}
 
 			if i%2 == 0 {
@@ -442,7 +452,7 @@ func testStoreBatchChanges(t *testing.T, ctx context.Context, s *Store, clock ct
 		}
 
 		draftAndClosed := []*btypes.BatchChange{}
-		draftAndClosed = append(draftAndClosed, reversedBatchChanges[:2]...)
+		draftAndClosed = append(draftAndClosed, reversedBatchChanges[:3]...)
 		draftAndClosed = append(draftAndClosed, reversedBatchChanges[len(reversedBatchChanges)-1:]...)
 
 		multiFilterTests := []struct {


### PR DESCRIPTION
# Context

While working on my local dev branch, I noticed when I toggled the filter button to display `Draft` batch changes, the list returned included a batch change that was closed.
Further investigation revealed the way we query for draft batch change is using the WHERE clause:

```sql
SELECT batch_changes.id ,  batch_changes.name ,  batch_changes.description ,  batch_changes.creator_id ,  batch_changes.last_applier_id ,  batch_changes.last_applied_at ,  batch_changes.namespace_user_id ,  batch_changes.namespace_org_id ,  batch_changes.created_at ,  batch_changes.updated_at ,  batch_changes.closed_at ,  batch_changes.batch_spec_id FROM batch_changes
LEFT JOIN users namespace_user ON batch_changes.namespace_user_id = namespace_user.id
 LEFT JOIN orgs namespace_org ON batch_changes.namespace_org_id = namespace_org.id
WHERE namespace_user.deleted_at IS NULL
 AND  namespace_org.deleted_at IS NULL
 AND  (batch_changes.last_applied_at IS NULL)
ORDER BY id DESC
LIMIT 8;
```

The culprit being ` (batch_changes.last_applied_at IS NULL)` returns an incorrect filtered list because it's possible to have a batch change that hasn't being applied (hence it being a draft) but was closed by the user.

Updating the SQL statement to

```sql
SELECT batch_changes.id ,  batch_changes.name ,  batch_changes.description ,  batch_changes.creator_id ,  batch_changes.last_applier_id ,  batch_changes.last_applied_at ,  batch_changes.namespace_user_id ,  batch_changes.namespace_org_id ,  batch_changes.created_at ,  batch_changes.updated_at ,  batch_changes.closed_at ,  batch_changes.batch_spec_id FROM batch_changes
LEFT JOIN users namespace_user ON batch_changes.namespace_user_id = namespace_user.id
 LEFT JOIN orgs namespace_org ON batch_changes.namespace_org_id = namespace_org.id
WHERE namespace_user.deleted_at IS NULL
 AND  namespace_org.deleted_at IS NULL
 AND  (batch_changes.last_applied_at IS NULL AND batch_changes.closed_at IS NULL)
ORDER BY id DESC
LIMIT 8;
```

fixes this.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
* Navigate to the batch changes list page
* Click on the `DRAFT` filter and no closed batch change should be included

### Before
![incorect-bc-filter-before](https://user-images.githubusercontent.com/25608335/170604622-9aa9e593-18eb-4cd1-941b-d4babdab1aa1.png)

### After
![incorrect-bc-filter-after](https://user-images.githubusercontent.com/25608335/170604649-e3afbf1c-41af-4d6c-af2c-d81e6c7b2937.png)

![CleanShot 2022-05-27 at 02 26 55@2x](https://user-images.githubusercontent.com/25608335/170610313-adb55a6f-4552-4fa2-b5ce-d836d89a1f8d.png)

[k8s link](https://k8s.sgdev.org/organizations/sourcegraph/batch-changes?visible=6)
