### PR TITLE
[cloud] Show update button on gitlab connection when token is expired

### DIFF
--- a/client/web/src/user/settings/cloud-ga.test.ts
+++ b/client/web/src/user/settings/cloud-ga.test.ts
@@ -1,0 +1,57 @@
+import { cleanup } from '@testing-library/react'
+
+import { gitlabTokenExpired } from './cloud-ga'
+
+describe('gitlabTokenExpired tests', () => {
+    const DATE_NOW = '1646922320064'
+
+    afterAll(cleanup)
+
+    beforeEach(() => {
+        jest.useFakeTimers()
+        jest.setSystemTime(Number(DATE_NOW))
+    })
+
+    afterEach(() => {
+        jest.runOnlyPendingTimers()
+        jest.useRealTimers()
+    })
+
+    describe('happy path', () => {
+        it('returns false if the token is not expired', () => {
+            const config = `{"token.type": "oauth", "token.oauth.expiry": ${Number(DATE_NOW) / 1000 + 3600}}`
+            expect(gitlabTokenExpired(config)).toBeFalsy()
+        })
+
+        it('returns true if the token is expired', () => {
+            const config = `{"token.type": "oauth", "token.oauth.expiry": ${Number(DATE_NOW) / 1000 - 100}}`
+            expect(gitlabTokenExpired(config)).toBeTruthy()
+        })
+
+        it('returns true if the expiry time is not defined', () => {
+            const config = '{"token.type": "oauth"}'
+            expect(gitlabTokenExpired(config)).toBeTruthy()
+        })
+    })
+
+    describe('non happy path', () => {
+        it('returns false if the token is not an oauth token', () => {
+            const config = '{"token.type": "pat"}'
+            expect(gitlabTokenExpired(config)).toBeFalsy()
+        })
+
+        it('returns false if the token type is missing', () => {
+            const config = '{"token.oauth.expiry": "123"}'
+            expect(gitlabTokenExpired(config)).toBeFalsy()
+        })
+
+        it('returns false if the config is undefined', () => {
+            expect(gitlabTokenExpired(undefined)).toBeFalsy()
+        })
+
+        it('returns false if the json config cannot be parsed', () => {
+            const invalidJSON = '{{{{{}'
+            expect(gitlabTokenExpired(invalidJSON)).toBeFalsy()
+        })
+    })
+})

--- a/client/web/src/user/settings/cloud-ga.ts
+++ b/client/web/src/user/settings/cloud-ga.ts
@@ -56,6 +56,26 @@ export const githubRepoScopeRequired = (tags: string[] = [], scopes?: Scopes): b
 export const gitlabAPIScopeRequired = (tags: string[] = [], scopes?: Scopes): boolean =>
     requiredScope('api', tags, scopes)
 
+export const gitlabTokenExpired = (config?: string): boolean => {
+    if (!config) {
+        return false
+    }
+
+    try {
+        const jsonConfig = JSON.parse(config)
+        const key = 'token.oauth.expiry'
+        if (jsonConfig['token.type'] === 'oauth') {
+            const tokenExpiry = jsonConfig[key] || 0
+            const currentTimeUnix = Math.round(new Date().getTime() / 1000) - 10
+            return !tokenExpiry || tokenExpiry < currentTimeUnix
+        }
+        return false
+    } catch {
+        // return false in case JSON cannot be parsed
+        return false
+    }
+}
+
 const requiredScope = (scope: string, tags: string[], scopes?: Scopes): boolean => {
     const allowedPrivate = externalServiceUserModeFromTags(tags) === 'all'
     if (!Array.isArray(scopes)) {

--- a/client/web/src/user/settings/codeHosts/UserAddCodeHostsPage.tsx
+++ b/client/web/src/user/settings/codeHosts/UserAddCodeHostsPage.tsx
@@ -211,7 +211,7 @@ export const UserAddCodeHostsPage: React.FunctionComponent<React.PropsWithChildr
 
         const repoCount = fetchedServices.reduce((sum, codeHost) => sum + codeHost.repoCount, 0)
         onUserExternalServicesOrRepositoriesUpdate(fetchedServices.length, repoCount)
-    }, [owner.id, onUserExternalServicesOrRepositoriesUpdate])
+    }, [owner.id, owner.tags, scopes.github, scopes.gitlab, onUserExternalServicesOrRepositoriesUpdate])
 
     const handleServiceUpsert = useCallback(
         (service: ListExternalServiceFields): void => {

--- a/client/web/src/user/settings/codeHosts/UserAddCodeHostsPage.tsx
+++ b/client/web/src/user/settings/codeHosts/UserAddCodeHostsPage.tsx
@@ -22,7 +22,7 @@ import { GET_ORG_FEATURE_FLAG_VALUE, GITHUB_APP_FEATURE_FLAG_NAME } from '../../
 import { useCodeHostScopeContext } from '../../../site/CodeHostScopeAlerts/CodeHostScopeProvider'
 import { eventLogger } from '../../../tracking/eventLogger'
 import { UserExternalServicesOrRepositoriesUpdateProps } from '../../../util'
-import { githubRepoScopeRequired, gitlabAPIScopeRequired, Owner } from '../cloud-ga'
+import { githubRepoScopeRequired, gitlabAPIScopeRequired, gitlabTokenExpired, Owner } from '../cloud-ga'
 
 import { CodeHostItem, ParentWindow } from './CodeHostItem'
 import { CodeHostListItem } from './CodeHostListItem'
@@ -151,16 +151,8 @@ export const UserAddCodeHostsPage: React.FunctionComponent<React.PropsWithChildr
     const isGitHubAppLoading = flagsOverridesResult.loading
 
     // If we have a GitHub or GitLab services, check whether we need to prompt the user to
-    // update their scope
-    const isGitHubTokenUpdateRequired = scopes.github
-        ? !isGitHubAppEnabled && githubRepoScopeRequired(owner.tags, scopes.github)
-        : false
-    const isGitLabTokenUpdateRequired = scopes.gitlab ? gitlabAPIScopeRequired(owner.tags, scopes.gitlab) : false
-
-    const isTokenUpdateRequired: Partial<Record<ExternalServiceKind, boolean | undefined>> = {
-        [ExternalServiceKind.GITHUB]: githubRepoScopeRequired(owner.tags, scopes.github),
-        [ExternalServiceKind.GITLAB]: gitlabAPIScopeRequired(owner.tags, scopes.gitlab),
-    }
+    // update their token
+    const [isTokenUpdateRequired, setTokenUpdateRequired] = useState<Partial<Record<ExternalServiceKind, boolean>>>({})
 
     useEffect(() => {
         eventLogger.logPageView('UserSettingsCodeHostConnections')
@@ -205,6 +197,13 @@ export const UserAddCodeHostsPage: React.FunctionComponent<React.PropsWithChildr
             accumulator[service.kind] = service
             return accumulator
         }, {})
+
+        setTokenUpdateRequired({
+            [ExternalServiceKind.GITHUB]: githubRepoScopeRequired(owner.tags, scopes.github),
+            [ExternalServiceKind.GITLAB]:
+                gitlabAPIScopeRequired(owner.tags, scopes.gitlab) ||
+                gitlabTokenExpired(services[ExternalServiceKind.GITLAB]?.config),
+        })
 
         setStatusOrError(services)
 
@@ -382,8 +381,8 @@ export const UserAddCodeHostsPage: React.FunctionComponent<React.PropsWithChildr
             getRequestSuccessBanner(
                 isServicesByKind(statusOrError) ? statusOrError[ExternalServiceKind.GITHUB] : undefined
             ),
-            getGitHubUpdateAuthBanner(isGitHubTokenUpdateRequired),
-            getGitLabUpdateAuthBanner(isGitLabTokenUpdateRequired),
+            getGitHubUpdateAuthBanner(isTokenUpdateRequired?.[ExternalServiceKind.GITHUB] || false),
+            getGitLabUpdateAuthBanner(isTokenUpdateRequired?.[ExternalServiceKind.GITLAB] || false),
         ]
     }
 


### PR DESCRIPTION
# Description

With gitlab now enforcing token expiry in 2 hours, this is an easier
way for the customer to renew their oauth token. Without this functionality
the customer needs to remove the code host connection and re-add it.
However removal of code host connection also removes any repos attached
to it. Which would lead to customer needing to re-add all of the repos again
as well.

Instead this PR shows an Update button when the token is expired, allowing
the customer to go over the oauth flow to get a new token without
forcing them to remove the code host connection (and repos).

# Screenshot
<img width="828" alt="Screenshot 2022-05-27 at 06 20 56" src="https://user-images.githubusercontent.com/9974711/170632179-36f1048e-0c2f-4ade-9531-8b4fc3fd707c.png">


# Related 
https://github.com/sourcegraph/customer/issues/968



## Test plan

Tested locally + with a unit test. Will verify in production after it's deployed as well.

## App preview:

- [Web](https://sg-web-milan-show-gitlab-connection.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-tarubhdozl.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
