### PR TITLE
feat: Add jsonnet highlighting support

### DIFF
--- a/docker-images/syntax-highlighter/Cargo.lock
+++ b/docker-images/syntax-highlighter/Cargo.lock
@@ -1698,6 +1698,7 @@ dependencies = [
  "tree-sitter-c-sharp",
  "tree-sitter-go",
  "tree-sitter-highlight",
+ "tree-sitter-jsonnet",
  "tree-sitter-sql",
 ]
 
@@ -2203,6 +2204,15 @@ checksum = "042342584c5a7a0b833d9fc4e2bdab3f9868ddc6c4b339a1e01451c6720868bc"
 dependencies = [
  "regex",
  "thiserror",
+ "tree-sitter",
+]
+
+[[package]]
+name = "tree-sitter-jsonnet"
+version = "0.0.1"
+source = "git+https://github.com/sourcegraph/tree-sitter-jsonnet#009e6f06266f46ae07077dd6c8026ded56ab7dd8"
+dependencies = [
+ "cc",
  "tree-sitter",
 ]
 

--- a/docker-images/syntax-highlighter/crates/sg-syntax/Cargo.toml
+++ b/docker-images/syntax-highlighter/crates/sg-syntax/Cargo.toml
@@ -37,5 +37,7 @@ tree-sitter-sql = { git = "https://github.com/sourcegraph/tree-sitter-sql" }
 # is picked by tree-sitter-c-sharp, whereas tree-sitter-go picks 0.20.x
 tree-sitter-c-sharp = { git = "https://github.com/tree-sitter/tree-sitter-c-sharp" }
 
+tree-sitter-jsonnet = { git = "https://github.com/sourcegraph/tree-sitter-jsonnet" }
+
 [dev-dependencies]
 insta = "1.11.0"

--- a/docker-images/syntax-highlighter/crates/sg-syntax/queries/jsonnet/highlights.scm
+++ b/docker-images/syntax-highlighter/crates/sg-syntax/queries/jsonnet/highlights.scm
@@ -20,15 +20,19 @@
 
 [
   (local)
+  (super)
   "function"
   "for"
   "in"
+  "import"
+  "importstr"
 ] @keyword
 
 ; Language basics
 (comment) @comment
 (number) @number
 [ (true) (false) ] @boolean
+[ (self) (dollar) ] @constant.builtin
 (binaryop) @operator
 (unaryop) @operator
 

--- a/docker-images/syntax-highlighter/crates/sg-syntax/queries/jsonnet/highlights.scm
+++ b/docker-images/syntax-highlighter/crates/sg-syntax/queries/jsonnet/highlights.scm
@@ -1,0 +1,49 @@
+(id) @variable
+(param identifier: (id) @variable.parameter)
+(bind function: (id) @function)
+(fieldname) @string.special
+[
+  "["
+  "]"
+  "{"
+  "}"
+] @punctuation.bracket
+
+[ "error" "assert" ] @identifier.function
+
+; keyword style
+[
+  "if"
+  "then"
+  "else"
+] @conditional
+
+[
+  (local)
+  "function"
+  "for"
+  "in"
+] @keyword
+
+; Language basics
+(comment) @comment
+(number) @number
+[ (true) (false) ] @boolean
+(binaryop) @operator
+(unaryop) @operator
+
+
+; It's possible for us to give a "special" highlight to
+; the triple ||| to start a string if we wanted with this query
+;; ((string_start) @comment
+;;  (#eq? @comment "|||"))
+
+[
+  (string_start)
+  (string_end)
+] @string.special
+
+(string_content) @string
+
+; Imports
+(import) @variable.module

--- a/docker-images/syntax-highlighter/crates/sg-syntax/src/sg_treesitter.rs
+++ b/docker-images/syntax-highlighter/crates/sg-syntax/src/sg_treesitter.rs
@@ -100,7 +100,7 @@ macro_rules! create_configurations {
 
 lazy_static::lazy_static! {
     static ref CONFIGURATIONS: HashMap<&'static str, HighlightConfiguration> = {
-        create_configurations!( go, sql, c_sharp )
+        create_configurations!( go, sql, c_sharp, jsonnet )
     };
 }
 

--- a/internal/gosyntect/gosyntect.go
+++ b/internal/gosyntect/gosyntect.go
@@ -110,6 +110,7 @@ var enryLanguageMappings = map[string]string{
 var supportedFiletypes = map[string]struct{}{
 	"go":      {},
 	"c_sharp": {},
+	"jsonnet": {},
 }
 
 // Client represents a client connection to a syntect_server.


### PR DESCRIPTION
Use new sourcegraph tree-sitter parser for jsonnet and use it to do
highlighting when configured with tree-sitter.

![image](https://user-images.githubusercontent.com/4466899/170634681-2ad682d2-cd03-4d76-86c2-ac88c84f7a24.png)


## Test plan

- [ ] load a jsonnet file and watch it have colors (no config required)