### PR TITLE
Reference panel: fix design tweaks in dark mode by using semantic colors

### DIFF
--- a/client/web/src/codeintel/ReferencesPanel.module.scss
+++ b/client/web/src/codeintel/ReferencesPanel.module.scss
@@ -13,7 +13,7 @@ $filter-input-height: 2.5rem;
         padding-top: 0;
         padding-bottom: 0;
         border: none;
-        border: 1px solid var(--gray-04);
+        border: 1px solid var(--border-color-2);
     }
 
     input::placeholder {
@@ -154,10 +154,10 @@ $group-divider-height: 0.25rem;
     padding-right: 1rem;
 
     ul {
-        border: 1px solid var(--gray-03);
+        border: 1px solid var(--border-color-2);
         padding: 0.5rem 0;
         border-radius: 3px;
-        background-color: var(--white);
+        background-color: var(--color-bg-1);
         overflow: scroll;
         -ms-overflow-style: none;
     }
@@ -211,7 +211,7 @@ $card-header-height: 1.5rem;
     flex: 1;
     overflow: auto;
     height: 100%;
-    background-color: var(--gray-01);
+    background-color: var(--body-bg);
 }
 
 // Right side of the panel


### PR DESCRIPTION
These now change when switching between light/dark theme.

Maybe there need to be some tweaks, but this should the big issues.

## Before
<img width="1721" alt="screenshot_2022-05-27_10 57 14@2x" src="https://user-images.githubusercontent.com/1185253/170667130-cc318c1a-dd1e-42bd-ad9d-de2aeda489b9.png">

## After
<img width="1707" alt="screenshot_2022-05-27_10 57 23@2x" src="https://user-images.githubusercontent.com/1185253/170667157-436100f0-3d05-4397-b0de-637f1b0a8dff.png">


## Test plan

- Tested locally

## App preview:

- [Web](https://sg-web-mrn-semantic-colors-ref-panel.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-nfbbuwtvon.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
