### PR TITLE
insights: poc: run integration tests against db snapshot

### DIFF
--- a/dev/gqltest/code_insights_test.go
+++ b/dev/gqltest/code_insights_test.go
@@ -245,7 +245,7 @@ func TestInsightViews(t *testing.T) {
 			t.Fatal(err)
 		}
 		if len(ids) != length {
-			t.Fatalf("Mismatch, wanted 1 got %v", len(ids))
+			t.Fatalf("Mismatch, wanted %v got %v", length, len(ids))
 		}
 	})
 }

--- a/dev/gqltest/main_test.go
+++ b/dev/gqltest/main_test.go
@@ -24,6 +24,8 @@ var (
 	username = flag.String("username", "gqltest-admin", "The username of the admin user")
 	password = flag.String("password", "supersecurepassword", "The password of the admin user")
 
+	dbDump = flag.Bool("dump", false, "Runs tests in an environment with a pre-populated database.")
+
 	githubToken           = flag.String("github-token", os.Getenv("GITHUB_TOKEN"), "The GitHub personal access token that will be used to authenticate a GitHub external service")
 	awsAccessKeyID        = flag.String("aws-access-key-id", os.Getenv("AWS_ACCESS_KEY_ID"), "The AWS access key ID")
 	awsSecretAccessKey    = flag.String("aws-secret-access-key", os.Getenv("AWS_SECRET_ACCESS_KEY"), "The AWS secret access key")

--- a/internal/gqltestutil/code_insights.go
+++ b/internal/gqltestutil/code_insights.go
@@ -4,10 +4,16 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
-func (c *Client) GetInsights() ([]string, error) {
+type InsightViewsArgs struct {
+	First *int
+	After *string
+	Id    *string
+}
+
+func (c *Client) GetInsights(args InsightViewsArgs) ([]string, error) {
 	const query = `
-		query InsightViews {
-			insightViews {
+		query InsightViews ($first: Int, $after: String, $id: ID) {
+			insightViews (first: $first, after: $after, id: $id) {
 				nodes { id }
 			}
 		}
@@ -21,7 +27,18 @@ func (c *Client) GetInsights() ([]string, error) {
 			} `json:"insightviews"`
 		} `json:"data"`
 	}
-	err := c.GraphQL("", query, map[string]any{}, &resp)
+
+	variables := map[string]any{}
+	if args.First != nil {
+		variables["first"] = args.First
+	}
+	if args.After != nil {
+		variables["after"] = args.After
+	}
+	if args.Id != nil {
+		variables["id"] = args.Id
+	}
+	err := c.GraphQL("", query, variables, &resp)
 	if err != nil {
 		return nil, errors.Wrap(err, "request GraphQL")
 	}


### PR DESCRIPTION
This investigation should close #34704. We should create more specific tickets for this.

## Test plan
Here is how you can run these tests. Right now it requires a couple drop-ins but this can be automated, this is just a rough PoC. 

Download the db dump from [here](https://console.cloud.google.com/storage/browser/_details/sg-demo-codeinsights/codeinsights_db.out;tab=live_object?authuser=0&project=sourcegraph-ci).

You need a blank slate of a sourcegraph-owned postgres database, however that might look:
```
psql -U [owner of postgres currently] -c 'drop database postgres;'
psql -U sourcegraph -c 'create database postgres;'
psql -U sourcegraph -f [dump] postgres
```

You’ll need to update your sg.config.overwrite.yaml with this:
```
commandsets:
  enterprise-codeinsights:
    env:
      EXTSVC_CONFIG_FILE: ''
      PGDATABASE: postgres
```

Then run:
```
sg start enterprise-codeinsights
```

(The query runner will be picking up a fair few jobs from the demo db queue, but you can ignore that)

The run the following:
```
go test -long -dump -base-url "https://sourcegraph.test:3443" -email "gqltest@sourcegraph.com" -username "gqltest" -password "supersecurepassword"
```
The site admin should be created automatically. 

Tests pass as expected and retrieved data from the database.
