### PR TITLE
Code Insights: Fix `zeroYaxisMin` setting for code insight charts

### DIFF
--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/BackendInsight.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/BackendInsight.tsx
@@ -174,10 +174,11 @@ export const BackendInsightView: React.FunctionComponent<React.PropsWithChildren
                 <BackendInsightChart
                     {...state.data}
                     locked={insight.isFrozen}
-                    onDatumClick={trackDatumClicks}
-                    toggle={toggle}
+                    zeroYAxisMin={zeroYAxisMin}
                     isSeriesSelected={isSeriesSelected}
                     isSeriesHovered={isSeriesHovered}
+                    onDatumClick={trackDatumClicks}
+                    onLegendItemClick={toggle}
                     setHoveredId={setHoveredId}
                 />
             )}

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/backend-insight-chart/BackendInsightChart.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/backend-insight-chart/BackendInsightChart.tsx
@@ -40,11 +40,12 @@ export const MINIMAL_SERIES_FOR_ASIDE_LEGEND = 3
 
 interface BackendInsightChartProps<Datum> extends BackendInsightData {
     locked: boolean
-    className?: string
-    onDatumClick: () => void
-    toggle: (id: string) => void
+    zeroYAxisMin: boolean
     isSeriesSelected: (id: string) => boolean
     isSeriesHovered: (id: string) => boolean
+    className?: string
+    onLegendItemClick: (id: string) => void
+    onDatumClick: () => void
     setHoveredId: Dispatch<SetStateAction<string | undefined>>
 }
 
@@ -53,11 +54,12 @@ export function BackendInsightChart<Datum>(props: BackendInsightChartProps<Datum
         locked,
         isFetchingHistoricalData,
         content,
-        className,
-        onDatumClick,
-        toggle,
+        zeroYAxisMin,
         isSeriesSelected,
         isSeriesHovered,
+        className,
+        onDatumClick,
+        onLegendItemClick,
         setHoveredId,
     } = props
     const { ref, width = 0 } = useDebounce(useResizeObserver(), 100)
@@ -93,6 +95,7 @@ export function BackendInsightChart<Datum>(props: BackendInsightChartProps<Datum
                                     onDatumClick={onDatumClick}
                                     isSeriesSelected={isSeriesSelected}
                                     isSeriesHovered={isSeriesHovered}
+                                    zeroYAxisMin={zeroYAxisMin}
                                     {...content}
                                 />
                             </>
@@ -109,7 +112,7 @@ export function BackendInsightChart<Datum>(props: BackendInsightChartProps<Datum
                                     selected={isSeriesSelected(`${series.id}`)}
                                     hovered={isSeriesHovered(`${series.id}`)}
                                     className={styles.legendListItem}
-                                    onClick={() => toggle(`${series.id}`)}
+                                    onClick={() => onLegendItemClick(`${series.id}`)}
                                     onMouseEnter={() => setHoveredId(`${series.id}`)}
                                     // prevent accidental dragging events
                                     onMouseDown={event => event.stopPropagation()}

--- a/client/web/src/enterprise/insights/pages/insights/insight/components/standalone-backend-insight/StandaloneBackendInsight.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/insight/components/standalone-backend-insight/StandaloneBackendInsight.tsx
@@ -153,10 +153,11 @@ export const StandaloneBackendInsight: React.FunctionComponent<StandaloneBackend
                     <BackendInsightChart
                         {...state.data}
                         locked={insight.isFrozen}
-                        onDatumClick={trackDatumClicks}
-                        toggle={toggle}
+                        zeroYAxisMin={zeroYAxisMin}
                         isSeriesSelected={isSeriesSelected}
                         isSeriesHovered={isSeriesHovered}
+                        onDatumClick={trackDatumClicks}
+                        onLegendItemClick={toggle}
                         setHoveredId={setHoveredId}
                     />
                 )}


### PR DESCRIPTION
This PR fixes start Y from zero chart setting in the three-dot context menu. 

<img width="545" alt="Screenshot 2022-05-27 at 18 44 12" src="https://user-images.githubusercontent.com/18492575/170684878-da8761c0-b70a-4ad0-a6fe-903a303a8d34.png">

## Test plan
- Make sure that `zeroYaxisMin` works properly for all series-like code insights chart 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vk-fix-zero-y-axis-min-setting.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-pqnqfajfiq.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
