### PR TITLE
refactor(repo-updater): use lib/log better

### DIFF
--- a/cmd/repo-updater/repoupdater/observability.go
+++ b/cmd/repo-updater/repoupdater/observability.go
@@ -88,10 +88,12 @@ func (h *observedHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 		h.logger.Debug(
 			"http.request",
-			log.String("method", r.Method),
-			log.String("route", r.URL.Path),
-			log.Int("code", rr.code),
-			log.Duration("duration", took),
+			log.Object("request",
+				log.String("method", r.Method),
+				log.String("route", r.URL.Path),
+				log.Int("code", rr.code),
+				log.Duration("duration", took),
+			),
 		)
 
 		var err error

--- a/cmd/repo-updater/repoupdater/server.go
+++ b/cmd/repo-updater/repoupdater/server.go
@@ -151,7 +151,7 @@ func (s *Server) handleEnqueueRepoUpdate(w http.ResponseWriter, r *http.Request)
 func (s *Server) enqueueRepoUpdate(ctx context.Context, req *protocol.RepoUpdateRequest) (resp *protocol.RepoUpdateResponse, httpStatus int, err error) {
 	tr, ctx := trace.New(ctx, "enqueueRepoUpdate", req.String())
 	defer func() {
-		s.Logger.Debug("enqueueRepoUpdate", log.Int("httpStatus", httpStatus), log.String("resp", fmt.Sprint(resp)), log.Error(err))
+		s.Logger.Debug("enqueueRepoUpdate", log.Object("http", log.Int("status", httpStatus), log.String("resp", fmt.Sprint(resp)), log.Error(err)))
 		if resp != nil {
 			tr.LogFields(
 				otlog.Int32("resp.id", int32(resp.ID)),
@@ -191,6 +191,9 @@ func (s *Server) handleExternalServiceSync(w http.ResponseWriter, r *http.Reques
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
+	logger := s.Logger.With(log.Object("ExternalService",
+		log.Int64("id", req.ExternalService.ID), log.String("kind", req.ExternalService.Kind)),
+	)
 
 	var sourcer repos.Sourcer
 	if sourcer = s.Sourcer; sourcer == nil {
@@ -206,14 +209,15 @@ func (s *Server) handleExternalServiceSync(w http.ResponseWriter, r *http.Reques
 		NamespaceUserID: req.ExternalService.NamespaceUserID,
 		NamespaceOrgID:  req.ExternalService.NamespaceOrgID,
 	})
+
 	if err != nil {
-		s.Logger.Error("server.external-service-sync", log.String("kind", req.ExternalService.Kind), log.Error(err))
+		logger.Error("server.external-service-sync", log.Error(err))
 		return
 	}
 
 	err = externalServiceValidate(ctx, req, src)
 	if err == github.ErrIncompleteResults {
-		s.Logger.Info("server.external-service-sync", log.String("kind", req.ExternalService.Kind), log.Error(err))
+		logger.Info("server.external-service-sync", log.Error(err))
 		syncResult := &protocol.ExternalServiceSyncResult{
 			ExternalService: req.ExternalService,
 			Error:           err.Error(),
@@ -224,7 +228,7 @@ func (s *Server) handleExternalServiceSync(w http.ResponseWriter, r *http.Reques
 		// client is gone
 		return
 	} else if err != nil {
-		s.Logger.Error("server.external-service-sync", log.String("kind", req.ExternalService.Kind), log.Error(err))
+		logger.Error("server.external-service-sync", log.Error(err))
 		if errcode.IsUnauthorized(err) {
 			s.respond(w, http.StatusUnauthorized, err)
 			return
@@ -240,15 +244,15 @@ func (s *Server) handleExternalServiceSync(w http.ResponseWriter, r *http.Reques
 	if s.RateLimitSyncer != nil {
 		err = s.RateLimitSyncer.SyncRateLimiters(ctx, req.ExternalService.ID)
 		if err != nil {
-			s.Logger.Warn("Handling rate limiter sync", log.Error(err), log.Int64("id", req.ExternalService.ID))
+			logger.Warn("Handling rate limiter sync", log.Error(err))
 		}
 	}
 
 	if err := s.Syncer.TriggerExternalServiceSync(ctx, req.ExternalService.ID); err != nil {
-		s.Logger.Warn("Enqueueing external service sync job", log.Error(err), log.Int64("id", req.ExternalService.ID))
+		logger.Warn("Enqueueing external service sync job", log.Error(err))
 	}
 
-	s.Logger.Info("server.external-service-sync", log.String("synced", req.ExternalService.Kind))
+	logger.Info("server.external-service-sync", log.Bool("synced", true))
 	s.respond(w, http.StatusOK, &protocol.ExternalServiceSyncResult{
 		ExternalService: req.ExternalService,
 	})

--- a/cmd/repo-updater/repoupdater/server.go
+++ b/cmd/repo-updater/repoupdater/server.go
@@ -122,7 +122,12 @@ func (s *Server) handleRepoLookup(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "request canceled", http.StatusGatewayTimeout)
 			return
 		}
-		s.Logger.Error("repoLookup failed", log.String("args", (&args).String()), log.Error(err))
+		s.Logger.Error("repoLookup failed",
+			log.Object("repo",
+				log.String("name", string(args.Repo)),
+				log.Bool("update", args.Update),
+			),
+			log.Error(err))
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}

--- a/cmd/repo-updater/repoupdater/server_test.go
+++ b/cmd/repo-updater/repoupdater/server_test.go
@@ -600,7 +600,6 @@ func TestServer_RepoLookup(t *testing.T) {
 		},
 	}
 
-	logger := logtest.Scoped(t)
 	for _, tc := range testCases {
 		tc := tc
 
@@ -619,6 +618,7 @@ func TestServer_RepoLookup(t *testing.T) {
 			}
 
 			clock := clock
+			logger := logtest.Scoped(t)
 			syncer := &repos.Syncer{
 				Logger:  logger,
 				Now:     clock.Now,
@@ -740,13 +740,12 @@ func TestServer_handleSchedulePermsSync(t *testing.T) {
 		},
 	}
 
-	logger := logtest.Scoped(t)
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			r := httptest.NewRequest("POST", "/schedule-perms-sync", strings.NewReader(test.body))
 			w := httptest.NewRecorder()
 
-			s := &Server{Logger: logger}
+			s := &Server{Logger: logtest.Scoped(t)}
 			// NOTE: An interface has nil value is not a nil interface,
 			// so should only assign to the interface when the value is not nil.
 			if test.permsSyncer != nil {
@@ -786,7 +785,6 @@ func TestServer_handleExternalServiceSync(t *testing.T) {
 		},
 	}
 
-	logger := logtest.Scoped(t)
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			src := testSource{
@@ -796,7 +794,7 @@ func TestServer_handleExternalServiceSync(t *testing.T) {
 			}
 			r := httptest.NewRequest("POST", "/sync-external-service", strings.NewReader(`{"ExternalService": {"ID":1,"kind":"GITHUB"}}}`))
 			w := httptest.NewRecorder()
-			s := &Server{Logger: logger, Syncer: &repos.Syncer{Sourcer: repos.NewFakeSourcer(nil, src)}}
+			s := &Server{Logger: logtest.Scoped(t), Syncer: &repos.Syncer{Sourcer: repos.NewFakeSourcer(nil, src)}}
 			s.handleExternalServiceSync(w, r)
 			if w.Code != test.wantErrCode {
 				t.Errorf("Code: want %v but got %v", test.wantErrCode, w.Code)

--- a/internal/repos/observability.go
+++ b/internal/repos/observability.go
@@ -6,20 +6,20 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 
-	"github.com/sourcegraph/sourcegraph/internal/logging"
 	"github.com/sourcegraph/sourcegraph/internal/metrics"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"github.com/sourcegraph/sourcegraph/lib/log"
 )
 
 // ObservedSource returns a decorator that wraps a Source
 // with error logging, Prometheus metrics and tracing.
-func ObservedSource(l logging.ErrorLogger, m SourceMetrics) func(Source) Source {
+func ObservedSource(l log.Logger, m SourceMetrics) func(Source) Source {
 	return func(s Source) Source {
 		return &observedSource{
 			Source:  s,
 			metrics: m,
-			log:     l,
+			logger:  l,
 		}
 	}
 }
@@ -29,7 +29,7 @@ func ObservedSource(l logging.ErrorLogger, m SourceMetrics) func(Source) Source 
 type observedSource struct {
 	Source
 	metrics SourceMetrics
-	log     logging.ErrorLogger
+	logger  log.Logger
 }
 
 // SourceMetrics encapsulates the Prometheus metrics of a Source.
@@ -94,7 +94,7 @@ func (o *observedSource) ListRepos(ctx context.Context, results chan SourceResul
 	defer func(began time.Time) {
 		secs := time.Since(began).Seconds()
 		o.metrics.ListRepos.Observe(secs, count, &err)
-		logging.Log(o.log, "source.list-repos", &err)
+		o.logger.Error("source.list-repos", log.Error(err))
 	}(time.Now())
 
 	uncounted := make(chan SourceResult)
@@ -126,7 +126,7 @@ func (o *observedSource) GetRepo(ctx context.Context, path string) (sourced *typ
 	defer func(began time.Time) {
 		secs := time.Since(began).Seconds()
 		o.metrics.GetRepo.Observe(secs, 1, &err)
-		logging.Log(o.log, "source.get-repo", &err)
+		o.logger.Error("source.get-repo", log.Error(err))
 	}(time.Now())
 
 	return rg.GetRepo(ctx, path)

--- a/internal/repos/scheduler.go
+++ b/internal/repos/scheduler.go
@@ -10,8 +10,6 @@ import (
 
 	"github.com/grafana/regexp"
 
-	"github.com/sourcegraph/sourcegraph/lib/log"
-
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
@@ -20,6 +18,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/mutablelimiter"
 	"github.com/sourcegraph/sourcegraph/internal/repoupdater/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/lib/log"
 )
 
 // schedulerConfig tracks the active scheduler configuration.
@@ -138,7 +137,7 @@ func NewUpdateScheduler(logger log.Logger, db database.DB) *UpdateScheduler {
 			index:         make(map[api.RepoID]*scheduledRepoUpdate),
 			wakeup:        make(chan struct{}, notifyChanBuffer),
 			randGenerator: rand.New(rand.NewSource(time.Now().UnixNano())),
-			logger:        updateSchedLogger.Scoped("schedule", ""),
+			logger:        updateSchedLogger.Scoped("Schedule", ""),
 		},
 		logger: updateSchedLogger,
 	}
@@ -202,7 +201,7 @@ func (s *UpdateScheduler) runUpdateLoop(ctx context.Context) {
 				break
 			}
 
-			subLogger := s.logger.Scoped("runUpdateLoop", "")
+			subLogger := s.logger.Scoped("RunUpdateLoop", "")
 
 			go func(ctx context.Context, repo configuredRepo, cancel context.CancelFunc) {
 				defer cancel()
@@ -448,7 +447,7 @@ func (s *UpdateScheduler) DebugDump(ctx context.Context, db database.DB) any {
 	var err error
 	data.SyncJobs, err = db.ExternalServices().GetSyncJobs(ctx)
 	if err != nil {
-		s.logger.Warn("Getting external service sync jobs for debug page", log.Error(err))
+		s.logger.Warn("getting external service sync jobs for debug page", log.Error(err))
 	}
 
 	return &data
@@ -813,7 +812,9 @@ func (s *schedule) updateInterval(repo configuredRepo, interval time.Duration) {
 		update.Interval = update.Interval + time.Duration(s.randGenerator.Int63n(2*delta)-delta)
 
 		update.Due = timeNow().Add(update.Interval)
-		s.logger.Debug("updated repo", log.String("repo", string(repo.Name)), log.Duration("due", update.Due.Sub(timeNow())))
+		s.logger.Debug("updated repo",
+			log.Object("repo", log.String("name", string(repo.Name)), log.Duration("due", update.Due.Sub(timeNow()))),
+		)
 		heap.Fix(s, update.Index)
 		s.rescheduleTimer()
 	}

--- a/internal/repos/scheduler_test.go
+++ b/internal/repos/scheduler_test.go
@@ -272,14 +272,12 @@ func TestUpdateQueue_enqueue(t *testing.T) {
 		},
 	}
 
-	testLogger := logtest.Scoped(t)
-
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			r, stop := startRecording()
 			defer stop()
 
-			s := NewUpdateScheduler(testLogger, db)
+			s := NewUpdateScheduler(logtest.Scoped(t), db)
 
 			for _, call := range test.calls {
 				s.updateQueue.enqueue(call.repo, call.priority)
@@ -440,14 +438,12 @@ func TestUpdateQueue_remove(t *testing.T) {
 		},
 	}
 
-	testLogger := logtest.Scoped(t)
-
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			r, stop := startRecording()
 			defer stop()
 
-			s := NewUpdateScheduler(testLogger, database.NewMockDB())
+			s := NewUpdateScheduler(logtest.Scoped(t), database.NewMockDB())
 			setupInitialQueue(s, test.initialQueue)
 
 			// Perform the removals.
@@ -514,14 +510,12 @@ func TestUpdateQueue_acquireNext(t *testing.T) {
 		},
 	}
 
-	testLogger := logtest.Scoped(t)
-
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			r, stop := startRecording()
 			defer stop()
 
-			s := NewUpdateScheduler(testLogger, database.NewMockDB())
+			s := NewUpdateScheduler(logtest.Scoped(t), database.NewMockDB())
 			setupInitialQueue(s, test.initialQueue)
 
 			// Test aquireNext.
@@ -646,14 +640,13 @@ func Test_updateScheduler_UpdateFromDiff(t *testing.T) {
 		},
 	}
 
-	testLogger := logtest.Scoped(t)
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			// The recording is not important for testing this method, but we want to mock and clean up timers.
 			_, stop := startRecording()
 			defer stop()
 
-			s := NewUpdateScheduler(testLogger, database.NewMockDB())
+			s := NewUpdateScheduler(logtest.Scoped(t), database.NewMockDB())
 			setupInitialSchedule(s, test.initialSchedule)
 			setupInitialQueue(s, test.initialQueue)
 
@@ -794,14 +787,12 @@ func TestSchedule_upsert(t *testing.T) {
 		},
 	}
 
-	testLogger := logtest.Scoped(t)
-
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			r, stop := startRecording()
 			defer stop()
 
-			s := NewUpdateScheduler(testLogger, database.NewMockDB())
+			s := NewUpdateScheduler(logtest.Scoped(t), database.NewMockDB())
 			setupInitialSchedule(s, test.initialSchedule)
 
 			for _, call := range test.upsertCalls {
@@ -1047,14 +1038,12 @@ func TestSchedule_updateInterval(t *testing.T) {
 		},
 	}
 
-	testLogger := logtest.Scoped(t)
-
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			r, stop := startRecording()
 			defer stop()
 
-			s := NewUpdateScheduler(testLogger, database.NewMockDB())
+			s := NewUpdateScheduler(logtest.Scoped(t), database.NewMockDB())
 			setupInitialSchedule(s, test.initialSchedule)
 			s.schedule.randGenerator = &mockRandomGenerator{}
 
@@ -1148,14 +1137,12 @@ func TestSchedule_remove(t *testing.T) {
 		},
 	}
 
-	testLogger := logtest.Scoped(t)
-
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			r, stop := startRecording()
 			defer stop()
 
-			s := NewUpdateScheduler(testLogger, database.NewMockDB())
+			s := NewUpdateScheduler(logtest.Scoped(t), database.NewMockDB())
 			setupInitialSchedule(s, test.initialSchedule)
 
 			for _, call := range test.removeCalls {
@@ -1312,14 +1299,12 @@ func TestUpdateScheduler_runSchedule(t *testing.T) {
 		},
 	}
 
-	testLogger := logtest.Scoped(t)
-
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			r, stop := startRecording()
 			defer stop()
 
-			s := NewUpdateScheduler(testLogger, database.NewMockDB())
+			s := NewUpdateScheduler(logtest.Scoped(t), database.NewMockDB())
 
 			setupInitialSchedule(s, test.initialSchedule)
 
@@ -1416,8 +1401,6 @@ func TestUpdateScheduler_runUpdateLoop(t *testing.T) {
 		},
 	}
 
-	testLogger := logtest.Scoped(t)
-
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			r, stop := startRecording()
@@ -1452,7 +1435,7 @@ func TestUpdateScheduler_runUpdateLoop(t *testing.T) {
 			}
 			defer func() { requestRepoUpdate = nil }()
 
-			s := NewUpdateScheduler(testLogger, database.NewMockDB())
+			s := NewUpdateScheduler(logtest.Scoped(t), database.NewMockDB())
 			s.schedule.randGenerator = &mockRandomGenerator{}
 
 			// unbuffer the channel
@@ -1558,7 +1541,6 @@ func Test_updateQueue_Less(t *testing.T) {
 }
 
 func TestGetCustomInterval(t *testing.T) {
-	testLogger := logtest.Scoped(t)
 
 	for _, tc := range []struct {
 		name     string
@@ -1623,7 +1605,7 @@ func TestGetCustomInterval(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			interval := getCustomInterval(testLogger, tc.c, tc.repoName)
+			interval := getCustomInterval(logtest.Scoped(t), tc.c, tc.repoName)
 			if tc.want != interval {
 				t.Fatalf("Want %v, got %v", tc.want, interval)
 			}

--- a/internal/repos/sources_test.go
+++ b/internal/repos/sources_test.go
@@ -620,7 +620,7 @@ func TestSources_ListRepos(t *testing.T) {
 
 				logger := logtest.Scoped(t)
 				obs := ObservedSource(logger, NewSourceMetrics())
-				src, err := NewSourcer(database.NewMockDB(), cf, obs)(svc)
+				src, err := NewSourcer(database.NewMockDB(), cf, obs)(tc.ctx, svc)
 				if err != nil {
 					t.Fatal(err)
 				}

--- a/internal/repos/sources_test.go
+++ b/internal/repos/sources_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/dnaeon/go-vcr/recorder"
 	"github.com/google/go-cmp/cmp"
 	"github.com/grafana/regexp"
-	"github.com/inconshreveable/log15"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
@@ -29,6 +28,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/httptestutil"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/internal/types/typestest"
+	"github.com/sourcegraph/sourcegraph/lib/log/logtest"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
@@ -618,11 +618,9 @@ func TestSources_ListRepos(t *testing.T) {
 				cf, save := newClientFactory(t, name)
 				defer save(t)
 
-				lg := log15.New()
-				lg.SetHandler(log15.DiscardHandler())
-
-				obs := ObservedSource(lg, NewSourceMetrics())
-				src, err := NewSourcer(database.NewMockDB(), cf, obs)(tc.ctx, svc)
+				logger := logtest.Scoped(t)
+				obs := ObservedSource(logger, NewSourceMetrics())
+				src, err := NewSourcer(database.NewMockDB(), cf, obs)(svc)
 				if err != nil {
 					t.Fatal(err)
 				}

--- a/internal/repos/syncer_test.go
+++ b/internal/repos/syncer_test.go
@@ -532,7 +532,6 @@ func testSyncerSync(s repos.Store) func(*testing.T) {
 			)
 		}
 
-		logger := logtest.Scoped(t)
 		for _, tc := range testCases {
 			if tc.name == "" {
 				t.Error("Test case name is blank")
@@ -570,7 +569,7 @@ func testSyncerSync(s repos.Store) func(*testing.T) {
 				}
 
 				syncer := &repos.Syncer{
-					Logger:  logger,
+					Logger:  logtest.Scoped(t),
 					Sourcer: tc.sourcer,
 					Store:   st,
 					Now:     now,
@@ -705,8 +704,6 @@ func testSyncRepo(s repos.Store) func(*testing.T) {
 			after:    types.Repos{repo},
 		}}
 
-		logger := logtest.Scoped(t)
-
 		for _, tc := range testCases {
 			tc := tc
 			ctx := context.Background()
@@ -725,7 +722,7 @@ func testSyncRepo(s repos.Store) func(*testing.T) {
 				}
 
 				syncer := &repos.Syncer{
-					Logger: logger,
+					Logger: logtest.Scoped(t),
 					Now:    time.Now,
 					Store:  s,
 					Synced: make(chan repos.Diff, 1),
@@ -1167,10 +1164,9 @@ func testCloudDefaultExternalServicesDontSync(store repos.Store) func(*testing.T
 			},
 		}
 
-		logger := logtest.Scoped(t)
 		syncer := &repos.Syncer{
-			Logger: logger,
-			Sourcer: func(ctx context.Context, service *types.ExternalService) (repos.Source, error) {
+			Logger: logtest.Scoped(t),
+			Sourcer: func(service *types.ExternalService) (repos.Source, error) {
 				s := repos.NewFakeSource(svc1, nil, githubRepo)
 				return s, nil
 			},
@@ -1924,12 +1920,16 @@ func testAbortSyncWhenThereIsRepoLimitError(store repos.Store) func(*testing.T) 
 			},
 		}
 
-		logger := logtest.Scoped(t)
 		for _, svc := range svcs {
 			// Sync first service
 			syncer := &repos.Syncer{
+<<<<<<< HEAD
 				Logger: logger,
 				Sourcer: func(ctx context.Context, service *types.ExternalService) (repos.Source, error) {
+=======
+				Logger: logtest.Scoped(t),
+				Sourcer: func(service *types.ExternalService) (repos.Source, error) {
+>>>>>>> 3f12a37a80 (use lib/log better in Syncer)
 					s := repos.NewFakeSource(svc, nil, githubRepo, githubRepo2)
 					return s, nil
 				},
@@ -2223,7 +2223,6 @@ func setupSyncErroredTest(ctx context.Context, s repos.Store, t *testing.T,
 		t.Fatal(err)
 	}
 
-	logger := logtest.Scoped(t)
 	for _, repoName := range repoNames {
 		dbRepo := (&types.Repo{
 			Name:        repoName,
@@ -2256,7 +2255,7 @@ func setupSyncErroredTest(ctx context.Context, s repos.Store, t *testing.T,
 	}
 
 	syncer := &repos.Syncer{
-		Logger: logger,
+		Logger: logtest.Scoped(t),
 		Now:    time.Now,
 		Store:  s,
 		Synced: make(chan repos.Diff, 1),

--- a/internal/repos/syncer_test.go
+++ b/internal/repos/syncer_test.go
@@ -1166,7 +1166,7 @@ func testCloudDefaultExternalServicesDontSync(store repos.Store) func(*testing.T
 
 		syncer := &repos.Syncer{
 			Logger: logtest.Scoped(t),
-			Sourcer: func(service *types.ExternalService) (repos.Source, error) {
+			Sourcer: func(ctx context.Context, service *types.ExternalService) (repos.Source, error) {
 				s := repos.NewFakeSource(svc1, nil, githubRepo)
 				return s, nil
 			},
@@ -1923,13 +1923,8 @@ func testAbortSyncWhenThereIsRepoLimitError(store repos.Store) func(*testing.T) 
 		for _, svc := range svcs {
 			// Sync first service
 			syncer := &repos.Syncer{
-<<<<<<< HEAD
-				Logger: logger,
-				Sourcer: func(ctx context.Context, service *types.ExternalService) (repos.Source, error) {
-=======
 				Logger: logtest.Scoped(t),
-				Sourcer: func(service *types.ExternalService) (repos.Source, error) {
->>>>>>> 3f12a37a80 (use lib/log better in Syncer)
+				Sourcer: func(ctx context.Context, service *types.ExternalService) (repos.Source, error) {
 					s := repos.NewFakeSource(svc, nil, githubRepo, githubRepo2)
 					return s, nil
 				},


### PR DESCRIPTION
Based on comments from @bobheadxi on https://github.com/sourcegraph/sourcegraph/pull/36024

* use logtest it the tighest scope
* fix naming
* use `log.With` when log lines repeatedly emit a field

Part of #34607
## Test plan
Unit tests

