### PR TITLE
searcher: prefix all prometheus variables with metric

### DIFF
--- a/cmd/searcher/internal/search/search.go
+++ b/cmd/searcher/internal/search/search.go
@@ -52,8 +52,8 @@ type Service struct {
 // ServeHTTP handles HTTP based search requests
 func (s *Service) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-	running.Inc()
-	defer running.Dec()
+	metricRunning.Inc()
+	defer metricRunning.Dec()
 
 	var p protocol.Request
 	dec := json.NewDecoder(r.Body)
@@ -161,7 +161,7 @@ func (s *Service) search(ctx context.Context, p *protocol.Request, sender matchS
 		}
 		tr.LazyPrintf("code=%s matches=%d limitHit=%v", code, sender.SentCount(), sender.LimitHit())
 		tr.Finish()
-		requestTotal.WithLabelValues(code).Inc()
+		metricRequestTotal.WithLabelValues(code).Inc()
 		span.LogFields(otlog.Int("matches.len", sender.SentCount()))
 		span.SetTag("limitHit", sender.LimitHit())
 		span.Finish()
@@ -229,8 +229,8 @@ func (s *Service) search(ctx context.Context, p *protocol.Request, sender matchS
 	span.LogFields(
 		otlog.Uint64("archive.files", nFiles),
 		otlog.Int64("archive.size", bytes))
-	archiveFiles.Observe(float64(nFiles))
-	archiveSize.Observe(float64(bytes))
+	metricArchiveFiles.Observe(float64(nFiles))
+	metricArchiveSize.Observe(float64(bytes))
 
 	if p.IsStructuralPat {
 		return filteredStructuralSearch(ctx, zipPath, zf, &p.PatternInfo, p.Repo, sender)
@@ -259,21 +259,21 @@ func validateParams(p *protocol.Request) error {
 const megabyte = float64(1000 * 1000)
 
 var (
-	running = promauto.NewGauge(prometheus.GaugeOpts{
+	metricRunning = promauto.NewGauge(prometheus.GaugeOpts{
 		Name: "searcher_service_running",
 		Help: "Number of running search requests.",
 	})
-	archiveSize = promauto.NewHistogram(prometheus.HistogramOpts{
+	metricArchiveSize = promauto.NewHistogram(prometheus.HistogramOpts{
 		Name:    "searcher_service_archive_size_bytes",
 		Help:    "Observes the size when an archive is searched.",
 		Buckets: []float64{1 * megabyte, 10 * megabyte, 100 * megabyte, 500 * megabyte, 1000 * megabyte, 5000 * megabyte},
 	})
-	archiveFiles = promauto.NewHistogram(prometheus.HistogramOpts{
+	metricArchiveFiles = promauto.NewHistogram(prometheus.HistogramOpts{
 		Name:    "searcher_service_archive_files",
 		Help:    "Observes the number of files when an archive is searched.",
 		Buckets: []float64{100, 1000, 10000, 50000, 100000},
 	})
-	requestTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+	metricRequestTotal = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "searcher_service_request_total",
 		Help: "Number of returned search requests.",
 	}, []string{"code"})

--- a/cmd/searcher/internal/search/search_structural.go
+++ b/cmd/searcher/internal/search/search_structural.go
@@ -209,16 +209,16 @@ func toMatcher(languages []string, extensionHint string) string {
 		// Pick the first language, there is no support for applying
 		// multiple language matchers in a single search query.
 		matcher := lookupMatcher(languages[0])
-		requestTotalStructuralSearch.WithLabelValues(matcher).Inc()
+		metricRequestTotalStructuralSearch.WithLabelValues(matcher).Inc()
 		return matcher
 	}
 
 	if extensionHint != "" {
 		extension := extensionToMatcher(extensionHint)
-		requestTotalStructuralSearch.WithLabelValues("inferred:" + extension).Inc()
+		metricRequestTotalStructuralSearch.WithLabelValues("inferred:" + extension).Inc()
 		return extension
 	}
-	requestTotalStructuralSearch.WithLabelValues("inferred:.generic").Inc()
+	metricRequestTotalStructuralSearch.WithLabelValues("inferred:.generic").Inc()
 	return ".generic"
 }
 
@@ -343,7 +343,7 @@ func structuralSearchWithZoekt(ctx context.Context, p *protocol.Request, sender 
 	return structuralSearch(ctx, zipFile.Name(), all, extensionHint, p.Pattern, p.CombyRule, p.Languages, p.Repo, sender)
 }
 
-var requestTotalStructuralSearch = promauto.NewCounterVec(prometheus.CounterOpts{
+var metricRequestTotalStructuralSearch = promauto.NewCounterVec(prometheus.CounterOpts{
 	Name: "searcher_service_request_total_structural_search",
 	Help: "Number of returned structural search requests.",
 }, []string{"language"})

--- a/cmd/searcher/internal/search/store.go
+++ b/cmd/searcher/internal/search/store.go
@@ -390,6 +390,8 @@ func (s *Store) String() string {
 // watchAndEvict is a loop which periodically checks the size of the cache and
 // evicts/deletes items if the store gets too large.
 func (s *Store) watchAndEvict() {
+	metricMaxCacheSizeBytes.Set(float64(s.MaxCacheSizeBytes))
+
 	if s.MaxCacheSizeBytes == 0 {
 		return
 	}
@@ -434,6 +436,10 @@ func ignoreSizeMax(name string, patterns []string) bool {
 }
 
 var (
+	metricMaxCacheSizeBytes = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "searcher_store_max_cache_size_bytes",
+		Help: "The configured maximum size of items in the on disk cache before eviction.",
+	})
 	metricCacheSizeBytes = promauto.NewGauge(prometheus.GaugeOpts{
 		Name: "searcher_store_cache_size_bytes",
 		Help: "The total size of items in the on disk cache.",

--- a/cmd/searcher/internal/search/store.go
+++ b/cmd/searcher/internal/search/store.go
@@ -139,9 +139,9 @@ func (s *Store) PrepareZip(ctx context.Context, repo api.RepoName, commit api.Co
 		span.Finish()
 		duration := time.Since(start).Seconds()
 		if cacheHit {
-			zipAccess.WithLabelValues("true").Observe(duration)
+			metricZipAccess.WithLabelValues("true").Observe(duration)
 		} else {
-			zipAccess.WithLabelValues("false").Observe(duration)
+			metricZipAccess.WithLabelValues("false").Observe(duration)
 		}
 	}()
 
@@ -209,16 +209,16 @@ func (s *Store) PrepareZip(ctx context.Context, repo api.RepoName, commit api.Co
 // not populate the in-memory cache. You should probably be calling
 // prepareZip.
 func (s *Store) fetch(ctx context.Context, repo api.RepoName, commit api.CommitID, largeFilePatterns []string) (rc io.ReadCloser, err error) {
-	fetchQueueSize.Inc()
+	metricFetchQueueSize.Inc()
 	ctx, releaseFetchLimiter, err := s.fetchLimiter.Acquire(ctx) // Acquire concurrent fetches semaphore
 	if err != nil {
 		return nil, err // err will be a context error
 	}
-	fetchQueueSize.Dec()
+	metricFetchQueueSize.Dec()
 
 	ctx, cancel := context.WithCancel(ctx)
 
-	fetching.Inc()
+	metricFetching.Inc()
 	span, ctx := ot.StartSpanFromContext(ctx, "Store.fetch")
 	ext.Component.Set(span, "store")
 	span.SetTag("repo", repo)
@@ -238,9 +238,9 @@ func (s *Store) fetch(ctx context.Context, repo api.RepoName, commit api.CommitI
 		if err != nil {
 			ext.Error.Set(span, true)
 			span.SetTag("err", err.Error())
-			fetchFailed.Inc()
+			metricFetchFailed.Inc()
 		}
-		fetching.Dec()
+		metricFetching.Dec()
 		span.Finish()
 	}
 	defer func() {
@@ -402,8 +402,8 @@ func (s *Store) watchAndEvict() {
 			s.Log.Error("failed to Evict", log.Error(err))
 			continue
 		}
-		cacheSizeBytes.Set(float64(stats.CacheSize))
-		evictions.Add(float64(stats.Evicted))
+		metricCacheSizeBytes.Set(float64(stats.CacheSize))
+		metricEvictions.Add(float64(stats.Evicted))
 	}
 }
 
@@ -434,27 +434,27 @@ func ignoreSizeMax(name string, patterns []string) bool {
 }
 
 var (
-	cacheSizeBytes = promauto.NewGauge(prometheus.GaugeOpts{
+	metricCacheSizeBytes = promauto.NewGauge(prometheus.GaugeOpts{
 		Name: "searcher_store_cache_size_bytes",
 		Help: "The total size of items in the on disk cache.",
 	})
-	evictions = promauto.NewCounter(prometheus.CounterOpts{
+	metricEvictions = promauto.NewCounter(prometheus.CounterOpts{
 		Name: "searcher_store_evictions",
 		Help: "The total number of items evicted from the cache.",
 	})
-	fetching = promauto.NewGauge(prometheus.GaugeOpts{
+	metricFetching = promauto.NewGauge(prometheus.GaugeOpts{
 		Name: "searcher_store_fetching",
 		Help: "The number of fetches currently running.",
 	})
-	fetchQueueSize = promauto.NewGauge(prometheus.GaugeOpts{
+	metricFetchQueueSize = promauto.NewGauge(prometheus.GaugeOpts{
 		Name: "searcher_store_fetch_queue_size",
 		Help: "The number of fetch jobs enqueued.",
 	})
-	fetchFailed = promauto.NewCounter(prometheus.CounterOpts{
+	metricFetchFailed = promauto.NewCounter(prometheus.CounterOpts{
 		Name: "searcher_store_fetch_failed",
 		Help: "The total number of archive fetches that failed.",
 	})
-	zipAccess = promauto.NewHistogramVec(prometheus.HistogramOpts{
+	metricZipAccess = promauto.NewHistogramVec(prometheus.HistogramOpts{
 		Name:    "searcher_store_zip_prepare_duration",
 		Help:    "Observes the duration to prepare the zip file for searching.",
 		Buckets: prometheus.DefBuckets,


### PR DESCRIPTION
This is a pattern we started using a while ago, but the code in searcher
predates that. This was done via gopls doing renames.

Test Plan: go test