### PR TITLE
searcher: prometheus gauge for SEARCHER_CACHE_SIZE_MB

### DIFF
--- a/cmd/searcher/internal/search/store.go
+++ b/cmd/searcher/internal/search/store.go
@@ -390,6 +390,8 @@ func (s *Store) String() string {
 // watchAndEvict is a loop which periodically checks the size of the cache and
 // evicts/deletes items if the store gets too large.
 func (s *Store) watchAndEvict() {
+	metricMaxCacheSizeBytes.Set(float64(s.MaxCacheSizeBytes))
+
 	if s.MaxCacheSizeBytes == 0 {
 		return
 	}
@@ -434,6 +436,10 @@ func ignoreSizeMax(name string, patterns []string) bool {
 }
 
 var (
+	metricMaxCacheSizeBytes = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "searcher_store_max_cache_size_bytes",
+		Help: "The configured maximum size of items in the on disk cache before eviction.",
+	})
 	metricCacheSizeBytes = promauto.NewGauge(prometheus.GaugeOpts{
 		Name: "searcher_store_cache_size_bytes",
 		Help: "The total size of items in the on disk cache.",


### PR DESCRIPTION
This is to allow us to create a dashboard which includes the configured
maximum size of the cache or make a percentage of cache used. This will
make it easier to check admin configurations, since we don't need to
check the configuration we can just check the dashboard.

Test Plan: started locally and checked the value of
searcher_store_max_cache_size_bytes in the metrics page for searcher.

Depends on https://github.com/sourcegraph/sourcegraph/pull/36161

Part of https://github.com/sourcegraph/sourcegraph/issues/34828