### PR TITLE
diskcache: ignore files that go missing during filepath.Walk

### DIFF
--- a/internal/diskcache/cache.go
+++ b/internal/diskcache/cache.go
@@ -313,6 +313,13 @@ func (s *store) Evict(maxCacheSizeBytes int64) (stats EvictStats, err error) {
 	err = filepath.Walk(s.dir,
 		func(path string, info os.FileInfo, err error) error {
 			if err != nil {
+				if os.IsNotExist(err) {
+					// we can race with diskcache renaming tmp files to final
+					// destination. Just ignore these files rather than returning
+					// early.
+					return nil
+				}
+
 				return err
 			}
 			entries = append(entries, absFileInfo{absPath: path, info: info})


### PR DESCRIPTION
For example this can happen when diskcache renames a temporary file. We shouldn't
bail out early, but rather lets work on best effort information.

Test Plan: this is tough to reproduce, so instead I am relying on tests
to catch any possible regressions.

Part of https://github.com/sourcegraph/sourcegraph/issues/34828