### PR TITLE
docs(logging): add lib/log conventions

### DIFF
--- a/doc/dev/how-to/add_logging.md
+++ b/doc/dev/how-to/add_logging.md
@@ -56,6 +56,24 @@ func main() {
 }
 ```
 
+### Sub-loggers
+
+In a particular scope some fields might be repeatedly emitted. Consider creating a sub-logger in the scope by using `logger.With(...fields)`.
+
+```go
+func (s *Service) MyService(ctx context.Context, logger log.Logger) {
+    subLogger := logger.With(log.Int("id", s.ID), log.String("service", s.Name))
+
+    subLogger.Info("starting up")
+
+    if err := s.Start(); err != nil {
+        subLogger.Error(err)
+    }
+
+    subLogger.Info("done")
+}
+```
+
 ### Attaching context
 
 When your service starts logging, obtain a `log.Logger` instance, attach some relevant context, and start propagating your logger for use.
@@ -118,6 +136,47 @@ func (w *Worker) DoBigThing(params ...int) {
 }
 ```
 
+## Writing log messages
+
+The message in a log line should be in lowercase.
+
+```
+log.Info("this is my lowercase log line")
+log.Debug("this is a debug log line")
+log.Error("this is an error!")
+```
+
+If each word of log message is not a sentence and referring to a func/component ex. `logger.Error("component.update"` prefer to follow the go scoping standard ie. capatalize if it is public accessible, lowercase if it is private.
+
+Furthermore, if there are more than one line that uses this naming scheme (referring to a func/component) consider creating a [sub-logger](#sub-loggers) with the component name.
+
+```go
+func (c *component) update(logger log.Logger) {
+    logger.Error("component.update")
+}
+
+
+func (p *Public) private(logger log.Logger) {
+    logger.Info("Public.private")
+}
+
+func (p *Public) Action(logger log.Logger) {
+    logger.Info("Public.Action")
+}
+
+func (p *Public) Process(logger log.Logger) {
+    pLog := logger.Scoped("Public.Process")
+
+    pLog.Info("starting tasks")
+    // ... things ...
+
+    pLog.Debug("mid checkpoint")
+
+    // ... things ...
+    p.Log.Info("finalizing some things!")
+}
+```
+
 ## Development usage
 
 With `SRC_DEVELOPMENT=true` and `SRC_LOG_FORMAT=condensed` or `SRC_LOG_FORMAT=console`, loggers will generate a human-readable summary format like the following:
@@ -132,6 +191,7 @@ WARN    TestInitLogger  log/logger_test.go:22   another message {"TraceId": "asd
 This format omits fields like OpenTelemetry Resource and renders certain field types in a more friendly manner. Levels are also coloured, and the caller link with `filename:line` should be clickable in iTerm and VS Code such that you can jump straight to the source of the log entry.
 
 Additionally, in `SRC_DEVELOPMENT=true` using `log.Scoped` without calling `log.Init` will panic (in production, a no-op logger will be returned).
+
 
 ## Testing usage
 
@@ -180,23 +240,11 @@ func TestFooBar(t *testing.T) {
   logs := exportLogs()
 }
 ```
+
+When writing a test, ensure that `logtest.Scope` in the tightest scope possible. This ensures that if a test fails, that the logging is closely tied to the test that failed. Especially if you testcase has sub tests with `t.Run`, prefer to created the test logger inside `t.Run`
+
 ## Conventions
-* The name of the scope should follow CamelCase
-* The logger parameter should either be after `ctx context.Context` or be the first parameter
-* Messages of log lines should be in lowercase ex. `log.Info("this is my lowercase log line")`
-* Capatalize each word when the log line message is not a sentence and referring to a func/component ex. `logger.Error("component.update"` prefer to capatalize each word
-* In a particular scope some fields might be repeatedly emitted. Consider creating a sub Logger in the scope by using `logger.With(...fields)`.
-```go
-func (s *Service) MyService(ctx context.Context, logger log.Logger) {
-    subLogger := logger.With(log.Int("id", s.ID), log.String("service", s.Name"))
 
-    subLogger.Info("starting up")
-
-    if err := s.Start(); err != nil {
-        subLogger.Error(err)
-    }
-
-    subLogger.Info("done")
-}
-```
-* In tests, `logtest.Scope` should be used in the tightest scope possible. This ensures that if a test fails, that the logging is closely tied to the test that failed. Especially if you testcase has sub tests with `t.Run`, prefer to created the test logger inside `t.Run`
+* The first scope of the logger should be the name of the service and following the same naming of the service. In general, if the logger is initialized as described in [handling logging](#handling-logging) the name should be correct.
+* The logger parameter should either be immediately after `ctx context.Context`, or be the first parameter.
+* In some cases there might already be a `log` module imported. Use the alias `sglog` to refer to `lib/log` as can be seen [here](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/cmd/searcher/internal/search/search.go?L35-36).

--- a/doc/dev/how-to/add_logging.md
+++ b/doc/dev/how-to/add_logging.md
@@ -180,3 +180,23 @@ func TestFooBar(t *testing.T) {
   logs := exportLogs()
 }
 ```
+## Conventions
+* The name of the scope should follow CamelCase
+* The logger parameter should either be after `ctx context.Context` or be the first parameter
+* Messages of log lines should be in lowercase ex. `log.Info("this is my lowercase log line")`
+* Capatalize each word when the log line message is not a sentence and referring to a func/component ex. `logger.Error("component.update"` prefer to capatalize each word
+* In a particular scope some fields might be repeatedly emitted. Consider creating a sub Logger in the scope by using `logger.With(...fields)`.
+```go
+func (s *Service) MyService(ctx context.Context, logger log.Logger) {
+    subLogger := logger.With(log.Int("id", s.ID), log.String("service", s.Name"))
+
+    subLogger.Info("starting up")
+
+    if err := s.Start(); err != nil {
+        subLogger.Error(err)
+    }
+
+    subLogger.Info("done")
+}
+```
+* In tests, `logtest.Scope` should be used in the tightest scope possible. This ensures that if a test fails, that the logging is closely tied to the test that failed. Especially if you testcase has sub tests with `t.Run`, prefer to created the test logger inside `t.Run`

--- a/doc/dev/how-to/add_logging.md
+++ b/doc/dev/how-to/add_logging.md
@@ -192,7 +192,6 @@ This format omits fields like OpenTelemetry Resource and renders certain field t
 
 Additionally, in `SRC_DEVELOPMENT=true` using `log.Scoped` without calling `log.Init` will panic (in production, a no-op logger will be returned).
 
-
 ## Testing usage
 
 For testing purposes, we also provide:
@@ -241,10 +240,10 @@ func TestFooBar(t *testing.T) {
 }
 ```
 
-When writing a test, ensure that `logtest.Scope` in the tightest scope possible. This ensures that if a test fails, that the logging is closely tied to the test that failed. Especially if you testcase has sub tests with `t.Run`, prefer to created the test logger inside `t.Run`
+When writing a test, ensure that `logtest.Scope` in the tightest scope possible. This ensures that if a test fails, that the logging is closely tied to the test that failed. Especially if you testcase has sub tests with `t.Run`, prefer to created the test logger inside `t.Run`.
 
 ## Conventions
 
 * The first scope of the logger should be the name of the service and following the same naming of the service. In general, if the logger is initialized as described in [handling logging](#handling-logging) the name should be correct.
 * The logger parameter should either be immediately after `ctx context.Context`, or be the first parameter.
-* In some cases there might already be a `log` module imported. Use the alias `sglog` to refer to `lib/log` as can be seen [here](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/cmd/searcher/internal/search/search.go?L35-36).
+* In some cases there might already be a `log` module imported. Use the alias `sglog` to refer to `lib/log`, for example `import sglog "github.com/sourcegraph/sourcegraph/lib/log"`.


### PR DESCRIPTION
Some conventions I have been thinking about while doing some of the logging updates.

## Test plan
Markdown looks good
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
