### PR TITLE
Handle path search results

### DIFF
--- a/client/jetbrains/webview/src/search/lib/blob.ts
+++ b/client/jetbrains/webview/src/search/lib/blob.ts
@@ -1,10 +1,10 @@
 const cachedContentRequests = new Map<string, Promise<string>>()
 
-import { ContentMatch } from '@sourcegraph/shared/src/search/stream'
+import { ContentMatch, PathMatch } from '@sourcegraph/shared/src/search/stream'
 
 import { getMatchId } from '../results/utils'
 
-export async function loadContent(match: ContentMatch): Promise<string> {
+export async function loadContent(match: ContentMatch | PathMatch): Promise<string> {
     const cacheKey = getMatchId(match)
 
     if (cachedContentRequests.has(cacheKey)) {
@@ -20,7 +20,7 @@ export async function loadContent(match: ContentMatch): Promise<string> {
     return loadPromise
 }
 
-async function fetchBlobContent(match: ContentMatch): Promise<string> {
+async function fetchBlobContent(match: ContentMatch | PathMatch): Promise<string> {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-explicit-any
     const response: any = await fetch('https://sourcegraph.com/.api/graphql', {
         method: 'post',

--- a/client/jetbrains/webview/src/search/results/PathSearchResult.tsx
+++ b/client/jetbrains/webview/src/search/results/PathSearchResult.tsx
@@ -1,0 +1,61 @@
+import React, { useCallback } from 'react'
+
+import classNames from 'classnames'
+
+import { CodeHostIcon, formatRepositoryStarCount, SearchResultStar } from '@sourcegraph/search-ui'
+import { displayRepoName, splitPath } from '@sourcegraph/shared/src/components/RepoLink'
+import { PathMatch } from '@sourcegraph/shared/src/search/stream'
+import { useIsTruncated } from '@sourcegraph/wildcard'
+
+import { getResultId } from './utils'
+
+import styles from './SearchResult.module.scss'
+
+interface Props {
+    match: PathMatch
+    selectedResult: null | string
+    selectResult: (id: string) => void
+}
+
+export const PathSearchResult: React.FunctionComponent<Props> = ({ match, selectedResult, selectResult }: Props) => {
+    const [titleReference, truncated, checkTruncation] = useIsTruncated()
+
+    const formattedRepositoryStarCount = formatRepositoryStarCount(match.repoStars)
+
+    const resultId = getResultId(match)
+    const onClick = useCallback((): void => selectResult(resultId), [selectResult, resultId])
+
+    const [fileBase, fileName] = splitPath(match.path)
+
+    return (
+        // The below element's accessibility is handled via a document level event listener.
+        //
+        // eslint-disable-next-line jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions
+        <div
+            id={`search-result-list-item-${resultId}`}
+            className={classNames(styles.line, {
+                [styles.lineActive]: resultId === selectedResult,
+            })}
+            onClick={onClick}
+            key={resultId}
+        >
+            <CodeHostIcon repoName={match.repository} className="text-muted flex-shrink-0" />
+            <div
+                ref={titleReference}
+                onMouseEnter={checkTruncation}
+                data-tooltip={truncated ? (fileBase ? `${fileBase}/${fileName}` : fileName) : null}
+            >
+                {displayRepoName(match.repository)} › {fileBase ? `${fileBase}/` : null}
+                <strong>{fileName}</strong>
+            </div>
+            <span className={styles.spacer} />
+            {formattedRepositoryStarCount && (
+                <>
+                    <div className={styles.divider} />
+                    <SearchResultStar />
+                    {formattedRepositoryStarCount}
+                </>
+            )}
+        </div>
+    )
+}

--- a/client/jetbrains/webview/src/search/results/SearchResultList.tsx
+++ b/client/jetbrains/webview/src/search/results/SearchResultList.tsx
@@ -4,6 +4,7 @@ import { SearchMatch } from '@sourcegraph/shared/src/search/stream'
 
 import { CommitSearchResult } from './CommitSearchResult'
 import { FileSearchResult } from './FileSearchResult'
+import { PathSearchResult } from './PathSearchResult'
 import { RepoSearchResult } from './RepoSearchResult'
 import {
     getFirstResultId,
@@ -35,7 +36,7 @@ export const SearchResultList: React.FunctionComponent<Props> = ({
     const matchIdToMatchMap = useMemo((): Map<string, SearchMatch> => {
         const map = new Map<string, SearchMatch>()
         for (const match of matches) {
-            if (['content', 'commit', 'repo'].includes(match.type)) {
+            if (['commit', 'content', 'path', 'repo'].includes(match.type)) {
                 map.set(getMatchId(match), match)
             }
         }
@@ -53,6 +54,8 @@ export const SearchResultList: React.FunctionComponent<Props> = ({
                         match,
                         match.type === 'content' ? getLineMatchIndexForContentMatch(resultId) : undefined
                     )
+                } else {
+                    console.log(`No match found for result id: ${resultId}`)
                 }
             } else {
                 onPreviewClear()
@@ -165,6 +168,15 @@ export const SearchResultList: React.FunctionComponent<Props> = ({
                         return (
                             <RepoSearchResult
                                 key={`${match.repository}`}
+                                match={match}
+                                selectedResult={selectedResultId}
+                                selectResult={selectResult}
+                            />
+                        )
+                    case 'path':
+                        return (
+                            <PathSearchResult
+                                key={`${match.repository}-${match.path}`}
                                 match={match}
                                 selectedResult={selectedResultId}
                                 selectResult={selectResult}

--- a/client/jetbrains/webview/src/search/results/utils.ts
+++ b/client/jetbrains/webview/src/search/results/utils.ts
@@ -13,7 +13,7 @@ export function getMatchId(match: SearchMatch): string {
         return `${match.repository}-${match.oid.slice(0, 7)}`
     }
 
-    if (match.type === 'content') {
+    if (match.type === 'content' || match.type === 'path') {
         return `${match.repository}-${match.path}`
     }
 


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/35551

Not displaying repo headers for now.
This was quicker to implement and it might be a good enough design.
We can refine the looks later, but for now, it gives us value that we can see this type of results.

## Test plan

Tested here: https://www.loom.com/share/c46ee0376b0b4f4f84e55e5479cf8017

## App preview:

- [Web](https://sg-web-dv-jetbrains-handle-path-search.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-mvsnzzgmez.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
