### PR TITLE
JetBrains: Apply popover hiding strategy for every OS

### DIFF
--- a/client/jetbrains/src/main/java/com/sourcegraph/browser/JSToJavaBridgeRequestHandler.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/browser/JSToJavaBridgeRequestHandler.java
@@ -75,7 +75,7 @@ public class JSToJavaBridgeRequestHandler {
                     topPanel.setBrowserVisible(true);
                     return createSuccessResponse(null);
                 default:
-                    return createErrorResponse("Unknown action: “" + action + "”.", "No stack trace");
+                    return createErrorResponse("Unknown action: '" + action + "'.", "No stack trace");
             }
         } catch (Exception e) {
             return createErrorResponse(action + ": " + e.getClass().getName() + ": " + e.getMessage(), convertStackTraceToString(e));

--- a/client/jetbrains/src/main/java/com/sourcegraph/find/SourcegraphWindow.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/find/SourcegraphWindow.java
@@ -34,9 +34,7 @@ public class SourcegraphWindow implements Disposable {
             popup.showCenteredInCurrentWindow(project);
         }
 
-        if (shouldHideInsteadOfCancel()) {
-            popup.setUiVisible(true);
-        }
+        popup.setUiVisible(true);
 
         // If the popup is already shown, hitting alt + a gain should behave the same as the native find in files
         // feature and focus the search field.
@@ -45,16 +43,6 @@ public class SourcegraphWindow implements Disposable {
         }
     }
 
-    /**
-     * This is a workaround for #34773: On Mac OS, the web view is empty after opening and closing the popover
-     * repeatedly.
-     *
-     * We work around the issue by forcing hiding the Popover instead of clearing it on Mac OS. This slightly increases
-     * resources consumption but allows us to reuse the JCEF window on this platform.
-     */
-    private boolean shouldHideInsteadOfCancel() {
-        return System.getProperty("os.name").equals("Mac OS X");
-    }
 
     @NotNull
     private JBPopup createPopup() {
@@ -69,39 +57,36 @@ public class SourcegraphWindow implements Disposable {
             .setBelongsToGlobalPopupStack(true)
             .setCancelOnOtherWindowOpen(true)
             .setCancelKeyEnabled(true)
-            .setNormalWindowLevel(true);
-
-        if (shouldHideInsteadOfCancel()) {
-            builder = builder.setCancelCallback(() -> {
+            .setNormalWindowLevel(true)
+            .setCancelCallback(() -> {
                 popup.setUiVisible(false);
                 // We return false to prevent the default cancellation behavior.
                 return false;
             });
 
-            // For some reason, adding a cancelCallback will prevent the cancel event to fire when using the escape
-            // key. To work around this, we add a manual listener to both the popup panel and the browser panel for this
-            // scenario.
-            mainPanel.addKeyListener(new KeyAdapter() {
-                public void keyPressed(KeyEvent event) {
-                    if (event.getKeyCode() == KeyEvent.VK_ESCAPE) {
-                        popup.setUiVisible(false);
-                    }
+        // For some reason, adding a cancelCallback will prevent the cancel event to fire when using the escape
+        // key. To work around this, we add a manual listener to both the popup panel and the browser panel for this
+        // scenario.
+        mainPanel.addKeyListener(new KeyAdapter() {
+            public void keyPressed(KeyEvent event) {
+                if (event.getKeyCode() == KeyEvent.VK_ESCAPE) {
+                    popup.setUiVisible(false);
                 }
-            });
-            mainPanel.getBrowser().getJBCefClient().addKeyboardHandler(new CefKeyboardHandler() {
-                @Override
-                public boolean onPreKeyEvent(CefBrowser browser, CefKeyEvent event, BoolRef is_keyboard_shortcut) {
-                    return false;
+            }
+        });
+        mainPanel.getBrowser().getJBCefClient().addKeyboardHandler(new CefKeyboardHandler() {
+            @Override
+            public boolean onPreKeyEvent(CefBrowser browser, CefKeyEvent event, BoolRef is_keyboard_shortcut) {
+                return false;
+            }
+            @Override
+            public boolean onKeyEvent(CefBrowser browser, CefKeyEvent event) {
+                if (event.windows_key_code == KeyEvent.VK_ESCAPE) {
+                    popup.setUiVisible(false);
                 }
-                @Override
-                public boolean onKeyEvent(CefBrowser browser, CefKeyEvent event) {
-                    if (event.windows_key_code == KeyEvent.VK_ESCAPE) {
-                        popup.setUiVisible(false);
-                    }
-                    return false;
-                }
-            }, mainPanel.getBrowser().getCefBrowser());
-        }
+                return false;
+            }
+        }, mainPanel.getBrowser().getCefBrowser());
 
         return builder.createPopup();
     }


### PR DESCRIPTION
This PR removes the conditional popover logic that we added to fix a macOS-only issue (#34773) and applies it to every OS instead.

There are multiple motivation for this:

1. We primarily develop on macOS, so any diversion of the logic would need extensive additional testing on Windows and Linux, an environment that is not easily available for us. We should thus keep the difference to the bare minimum.
2. The workaround already adds better event handling than the initial solution, causing #34893 to not be an issue with this workaround turned on while it is an issue for the native version. (Note this is pending further tests that are not scope of this issue).
3. There's only very minimal theoretical overhead, since we already reuse anything that is rendered inside the Popover component and keep that in memory. This change only adds the Popover class instance as an additional item to be kept in memory. On the other side, this has made the overall experience on macOS much better with greatly faster startup times after the initial load. We do not have data for Windows and Linux to support that, though.


## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Since I am annoyed from copy-pasting on Windows, you can take a look at the test plan video from https://github.com/sourcegraph/sourcegraph/pull/36235 which I have based on those changes.

I did some manual verification and the hiding behavior works as expected on Windows.

## App preview:

- [Web](https://sg-web-ps-hide-popover-on-every-os.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-oxjxilvmxf.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

