### PR TITLE
gitserver: pass PATH down in git command tests

### DIFF
--- a/internal/gitserver/test_utils.go
+++ b/internal/gitserver/test_utils.go
@@ -60,7 +60,7 @@ func InitGitRepository(t *testing.T, cmds ...string) string {
 	t.Helper()
 	root := CreateRepoDir(t)
 	remotes := filepath.Join(root, "remotes")
-	if err := os.MkdirAll(remotes, 0700); err != nil {
+	if err := os.MkdirAll(remotes, 0o700); err != nil {
 		t.Fatal(err)
 	}
 	dir, err := os.MkdirTemp(remotes, strings.ReplaceAll(t.Name(), "/", "__"))
@@ -85,6 +85,9 @@ func CreateGitCommand(dir, name string, args ...string) *exec.Cmd {
 	c := exec.Command(name, args...)
 	c.Dir = dir
 	c.Env = []string{"GIT_CONFIG=" + path.Join(dir, ".git", "config")}
+	if systemPath, ok := os.LookupEnv("PATH"); ok {
+		c.Env = append(c.Env, "PATH="+systemPath)
+	}
 	return c
 }
 


### PR DESCRIPTION
In certain environments with specialized PATH setups, expected binaries may not be in the default locations (like in a Nix environment). This PR fixes "bash: git: command not found" when system `$PATH` was not passed down in the tests for creating git commands.

## Test plan

Will be caught by existing testing infra, and have tested it resolves my issue