### PR TITLE
Fix colors for code in new reference panel

### DIFF
--- a/client/web/src/codeintel/ReferencesPanel.module.scss
+++ b/client/web/src/codeintel/ReferencesPanel.module.scss
@@ -115,7 +115,7 @@ $group-divider-height: 0.25rem;
     code {
         font-family: 'SF Mono', monospace;
         overflow: hidden;
-        color: var(--gray-08);
+        color: var(--body-color);
         font-weight: 400;
         font-size: 0.75rem;
     }
@@ -136,7 +136,7 @@ $group-divider-height: 0.25rem;
         &--line-number {
             font-family: 'SF Mono', monospace;
             font-weight: 400;
-            color: var(--gray-06);
+            color: var(--line-number-color);
             min-width: 2.5rem;
             text-align: right;
             display: inline-block;


### PR DESCRIPTION
This fixes the colors in the dark theme.

<img width="821" alt="screenshot_2022-05-27_16 41 36@2x" src="https://user-images.githubusercontent.com/1185253/170722096-7dc22033-7092-4c3d-b3a7-c98274ce5870.png">


## Test plan

Manual testing & existing tests.

## App preview:

- [Web](https://sg-web-mrn-ref-panel-text-color-fix.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-otubxsdbnw.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
