### PR TITLE
Site config: Ensure notices don't support additional properties

### DIFF
--- a/schema/settings.schema.json
+++ b/schema/settings.schema.json
@@ -467,6 +467,7 @@
         "title": "Notice",
         "type": "object",
         "required": ["message", "location"],
+        "additionalProperties": false,
         "properties": {
           "message": {
             "description": "The message to display. Markdown formatting is supported.",


### PR DESCRIPTION
## Description

Fixes it so we don't allow ANYTHING to be passed in. From looking [at usage of `Notice` in the codebase](https://sourcegraph.com/search?q=context:global+repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+Notice&patternType=regexp&case=yes), we don't support custom properties anyway.

<img width="597" alt="image" src="https://user-images.githubusercontent.com/9516420/170723044-71bd275d-9a09-42c8-8b40-7672ff2b5967.png">

## Test plan

Tested locally
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
