### PR TITLE
sg hacking hour: better error output in migration commands

### DIFF
--- a/dev/sg/internal/std/output.go
+++ b/dev/sg/internal/std/output.go
@@ -73,7 +73,7 @@ func (o *Output) WriteSuccessf(fmtStr string, args ...any) {
 //
 // In Buildkite it expands the previous and current section to make them visible.
 func (o *Output) WriteFailuref(fmtStr string, args ...any) {
-	o.writeExpandPrevious(output.Linef(output.EmojiFailure, output.StyleWarning, fmtStr, args...))
+	o.writeExpandPrevious(output.Linef(output.EmojiFailure, output.StyleFailure, fmtStr, args...))
 }
 
 // WriteWarningf should be used to communicate a non-blocking failure to the user.

--- a/dev/sg/main.go
+++ b/dev/sg/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"flag"
-	"fmt"
 	"os"
 	"path/filepath"
 	"time"
@@ -26,7 +25,7 @@ func main() {
 		batchCompletionMode = true
 	}
 	if err := sg.RunContext(context.Background(), os.Args); err != nil {
-		fmt.Printf("error: %s\n", err)
+		std.Out.WriteFailuref(err.Error())
 		os.Exit(1)
 	}
 }

--- a/dev/sg/sg_migration.go
+++ b/dev/sg/sg_migration.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
-	"flag"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -214,12 +213,10 @@ func resolveSchema(name string) (*schemas.Schema, error) {
 
 func addExec(ctx context.Context, args []string) error {
 	if len(args) == 0 {
-		std.Out.WriteLine(output.Styled(output.StyleWarning, "No migration name specified"))
-		return flag.ErrHelp
+		return cli.NewExitError("no migration name specified", 1)
 	}
 	if len(args) != 1 {
-		std.Out.WriteLine(output.Styled(output.StyleWarning, "ERROR: too many arguments"))
-		return flag.ErrHelp
+		return cli.NewExitError("too many arguments", 1)
 	}
 
 	var (
@@ -227,21 +224,17 @@ func addExec(ctx context.Context, args []string) error {
 		database, ok = db.DatabaseByName(databaseName)
 	)
 	if !ok {
-		std.Out.WriteLine(output.Styledf(output.StyleWarning, "ERROR: database %q not found :(", databaseName))
-		return flag.ErrHelp
+		return cli.NewExitError(fmt.Sprintf("database %q not found :(", databaseName), 1)
 	}
 
 	return migration.Add(database, args[0])
 }
-
 func revertExec(ctx context.Context, args []string) error {
 	if len(args) == 0 {
-		std.Out.WriteLine(output.Styled(output.StyleWarning, "No commit specified"))
-		return flag.ErrHelp
+		return cli.NewExitError("no commit specified", 1)
 	}
 	if len(args) != 1 {
-		std.Out.WriteLine(output.Styled(output.StyleWarning, "ERROR: too many arguments"))
-		return flag.ErrHelp
+		return cli.NewExitError("too many arguments", 1)
 	}
 
 	return migration.Revert(db.Databases(), args[0])
@@ -249,12 +242,10 @@ func revertExec(ctx context.Context, args []string) error {
 
 func squashExec(ctx context.Context, args []string) (err error) {
 	if len(args) == 0 {
-		std.Out.WriteLine(output.Styled(output.StyleWarning, "No current-version specified"))
-		return flag.ErrHelp
+		cli.NewExitError("no current-version specified", 1)
 	}
 	if len(args) != 1 {
-		std.Out.WriteLine(output.Styled(output.StyleWarning, "ERROR: too many arguments"))
-		return flag.ErrHelp
+		cli.NewExitError("too many arguments", 1)
 	}
 
 	var (
@@ -262,8 +253,7 @@ func squashExec(ctx context.Context, args []string) (err error) {
 		database, ok = db.DatabaseByName(databaseName)
 	)
 	if !ok {
-		std.Out.WriteLine(output.Styledf(output.StyleWarning, "ERROR: database %q not found :(", databaseName))
-		return flag.ErrHelp
+		cli.NewExitError(fmt.Sprintf("database %q not found :(", databaseName), 1)
 	}
 
 	// Get the last migration that existed in the version _before_ `minimumMigrationSquashDistance` releases ago
@@ -278,17 +268,16 @@ func squashExec(ctx context.Context, args []string) (err error) {
 
 func squashAllExec(ctx context.Context, args []string) (err error) {
 	if len(args) != 0 {
-		std.Out.WriteLine(output.Styled(output.StyleWarning, "ERROR: too many arguments"))
-		return flag.ErrHelp
+		cli.NewExitError("too many arguments", 1)
 	}
 
 	var (
 		databaseName = migrateTargetDatabase
 		database, ok = db.DatabaseByName(databaseName)
 	)
+
 	if !ok {
-		std.Out.WriteLine(output.Styledf(output.StyleWarning, "ERROR: database %q not found :(", databaseName))
-		return flag.ErrHelp
+		cli.NewExitError(fmt.Sprintf("database %q not found :(", databaseName), 1)
 	}
 
 	return migration.SquashAll(database, squashInContainer, skipTeardown, outputFilepath)
@@ -296,12 +285,10 @@ func squashAllExec(ctx context.Context, args []string) (err error) {
 
 func leavesExec(ctx context.Context, args []string) (err error) {
 	if len(args) == 0 {
-		std.Out.WriteLine(output.Styled(output.StyleWarning, "No commit specified"))
-		return flag.ErrHelp
+		cli.NewExitError("no commit specified", 1)
 	}
 	if len(args) != 1 {
-		std.Out.WriteLine(output.Styled(output.StyleWarning, "ERROR: too many arguments"))
-		return flag.ErrHelp
+		cli.NewExitError("too many arguments", 1)
 	}
 
 	return migration.LeavesForCommit(db.Databases(), args[0])

--- a/lib/output/style.go
+++ b/lib/output/style.go
@@ -29,6 +29,7 @@ var (
 	StyleLogo       = Fg256Color(57)
 	StylePending    = Fg256Color(4)
 	StyleWarning    = Fg256Color(124)
+	StyleFailure    = CombineStyles(StyleBold, Fg256Color(196))
 	StyleSuccess    = Fg256Color(2)
 	StyleSuggestion = Fg256Color(244)
 


### PR DESCRIPTION
Better and more consistent output.

## Test plan

- `go run ./dev/sg migration [command]` to confirm it prints the error messages