### PR TITLE
SearchBackend: refine HunkMatch to include PreviewStart

### DIFF
--- a/enterprise/internal/compute/match_only_command_test.go
+++ b/enterprise/internal/compute/match_only_command_test.go
@@ -35,8 +35,8 @@ func Test_matchOnly(t *testing.T) {
 			Name: "codehost.com/myorg/myrepo",
 		}},
 		HunkMatches: result.HunkMatches{{
-			Preview:         "abcdefgh",
-			LineNumberStart: 1,
+			Preview:      "abcdefgh",
+			PreviewStart: result.Location{Line: 1},
 			Ranges: result.Ranges{{
 				Start: result.Location{Line: 1},
 				End:   result.Location{Line: 1},

--- a/internal/search/result/file.go
+++ b/internal/search/result/file.go
@@ -166,16 +166,16 @@ func (fm *FileMatch) Key() Key {
 }
 
 type HunkMatch struct {
-	Preview         string
-	LineNumberStart int
-	Ranges          Ranges
+	Preview      string
+	PreviewStart Location
+	Ranges       Ranges
 }
 
 func (h HunkMatch) AsLineMatches() []*LineMatch {
 	lines := strings.Split(h.Preview, "\n")
 	lineMatches := make([]*LineMatch, len(lines))
 	for i, line := range lines {
-		lineNumber := h.LineNumberStart + i
+		lineNumber := h.PreviewStart.Line + i
 		var offsetAndLengths [][2]int32
 		for _, rr := range h.Ranges {
 			for rangeLine := rr.Start.Line; rangeLine <= rr.End.Line; rangeLine++ {

--- a/internal/search/result/file_test.go
+++ b/internal/search/result/file_test.go
@@ -13,8 +13,8 @@ func TestConvertMatches(t *testing.T) {
 			output []*LineMatch
 		}{{
 			input: HunkMatch{
-				Preview:         "line1\nline2\nline3",
-				LineNumberStart: 1,
+				Preview:      "line1\nline2\nline3",
+				PreviewStart: Location{Line: 1},
 				Ranges: Ranges{{
 					Start: Location{1, 1, 1},
 					End:   Location{13, 3, 1},
@@ -35,8 +35,8 @@ func TestConvertMatches(t *testing.T) {
 			}},
 		}, {
 			input: HunkMatch{
-				Preview:         "line1",
-				LineNumberStart: 1,
+				Preview:      "line1",
+				PreviewStart: Location{Line: 1},
 				Ranges: Ranges{{
 					Start: Location{1, 1, 1},
 					End:   Location{1, 1, 3},
@@ -64,8 +64,8 @@ func TestConvertMatches(t *testing.T) {
 			output []*LineMatch
 		}{{
 			input: HunkMatches{{
-				Preview:         "line1\nline2\nline3\nline4",
-				LineNumberStart: 1,
+				Preview:      "line1\nline2\nline3\nline4",
+				PreviewStart: Location{Line: 1},
 				Ranges: Ranges{{
 					Start: Location{1, 1, 1},
 					End:   Location{13, 3, 1},
@@ -93,15 +93,15 @@ func TestConvertMatches(t *testing.T) {
 			}},
 		}, {
 			input: HunkMatches{{
-				Preview:         "line1\nline2\nline3",
-				LineNumberStart: 1,
+				Preview:      "line1\nline2\nline3",
+				PreviewStart: Location{Line: 1},
 				Ranges: Ranges{{
 					Start: Location{1, 1, 1},
 					End:   Location{13, 3, 1},
 				}},
 			}, {
-				Preview:         "line4\nline5\nline6",
-				LineNumberStart: 4,
+				Preview:      "line4\nline5\nline6",
+				PreviewStart: Location{Line: 4},
 				Ranges: Ranges{{
 					Start: Location{19, 4, 1},
 					End:   Location{31, 6, 1},
@@ -139,7 +139,7 @@ func TestConvertMatches(t *testing.T) {
 
 		for _, tc := range cases {
 			t.Run("", func(t *testing.T) {
-				require.Equal(t, tc.input.AsLineMatches(), tc.output)
+				require.Equal(t, tc.output, tc.input.AsLineMatches())
 			})
 		}
 	})

--- a/internal/search/searcher/search.go
+++ b/internal/search/searcher/search.go
@@ -242,16 +242,24 @@ func newToMatches(repo types.MinimalRepo, commit api.CommitID, rev *string) func
 					})
 				}
 				hunkMatches = append(hunkMatches, result.HunkMatch{
-					Preview:         lm.Preview,
-					LineNumberStart: lm.LineNumber,
-					Ranges:          ranges,
+					Preview: lm.Preview,
+					PreviewStart: result.Location{
+						Offset: lm.LineOffset,
+						Line:   lm.LineNumber,
+						Column: 0,
+					},
+					Ranges: ranges,
 				})
 			}
 
 			for _, mm := range fm.MultilineMatches {
 				hunkMatches = append(hunkMatches, result.HunkMatch{
-					Preview:         mm.Preview,
-					LineNumberStart: int(mm.Start.Line),
+					Preview: mm.Preview,
+					PreviewStart: result.Location{
+						Offset: int(mm.Start.Offset) - runeOffsetToByteOffset(mm.Preview, int(mm.Start.Column)),
+						Line:   int(mm.Start.Line),
+						Column: 0,
+					},
 					Ranges: result.Ranges{{
 						Start: result.Location{
 							Offset: int(mm.Start.Offset),

--- a/internal/search/streaming/stream_test.go
+++ b/internal/search/streaming/stream_test.go
@@ -206,7 +206,11 @@ func TestWithSelect(t *testing.T) {
     "HunkMatches": [
       {
         "Preview": "",
-        "LineNumberStart": 0,
+        "PreviewStart": [
+          0,
+          0,
+          0
+        ],
         "Ranges": [
           {
             "start": [
@@ -224,7 +228,11 @@ func TestWithSelect(t *testing.T) {
       },
       {
         "Preview": "",
-        "LineNumberStart": 0,
+        "PreviewStart": [
+          0,
+          0,
+          0
+        ],
         "Ranges": [
           {
             "start": [
@@ -248,7 +256,11 @@ func TestWithSelect(t *testing.T) {
     "HunkMatches": [
       {
         "Preview": "",
-        "LineNumberStart": 0,
+        "PreviewStart": [
+          0,
+          0,
+          0
+        ],
         "Ranges": [
           {
             "start": [
@@ -272,7 +284,11 @@ func TestWithSelect(t *testing.T) {
     "HunkMatches": [
       {
         "Preview": "",
-        "LineNumberStart": 0,
+        "PreviewStart": [
+          0,
+          0,
+          0
+        ],
         "Ranges": [
           {
             "start": [
@@ -296,7 +312,11 @@ func TestWithSelect(t *testing.T) {
     "HunkMatches": [
       {
         "Preview": "",
-        "LineNumberStart": 0,
+        "PreviewStart": [
+          0,
+          0,
+          0
+        ],
         "Ranges": [
           {
             "start": [

--- a/internal/search/zoekt/indexed_search.go
+++ b/internal/search/zoekt/indexed_search.go
@@ -415,7 +415,11 @@ func zoektFileMatchToMultilineMatches(file *zoekt.FileMatch) result.HunkMatches 
 			hms = append(hms, result.HunkMatch{
 				Preview: string(l.Line),
 				// zoekt line numbers are 1-based rather than 0-based so subtract 1
-				LineNumberStart: l.LineNumber - 1,
+				PreviewStart: result.Location{
+					Offset: l.LineStart,
+					Line:   l.LineNumber - 1,
+					Column: 0,
+				},
 				Ranges: result.Ranges{{
 					Start: result.Location{
 						Offset: int(m.Offset),


### PR DESCRIPTION
This refines the new HunkMatch type to include PreviewStart so that
we have both the line number and the byte offset of Preview available
for further processing. PreviewEnd can always be calculated from
Preview, so I felt it was best to just provide a start location rather
than a range that is represented by Preview (orthogonal information and all).

Stacked on #36124 

## Test plan

Updated tests, still passed. 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
