### PR TITLE
internal/logging: add deprecation notices

### DIFF
--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -1,11 +1,18 @@
+// Package logging carries logic related Sourcegraph's legacy logger, and is DEPRECATED.
+// All new logging should use lib/log, and existing logging should be opportunistically
+// migrated to the new logger. See https://docs.sourcegraph.com/dev/how-to/add_logging
 package logging
 
 // ErrorLogger captures the method required for logging an error.
+//
+// Deprecated: All logging should use lib/log instead. See https://docs.sourcegraph.com/dev/how-to/add_logging
 type ErrorLogger interface {
 	Error(msg string, ctx ...any)
 }
 
 // Log logs the given message and context when the given error is defined.
+//
+// Deprecated: All logging should use lib/log instead. See https://docs.sourcegraph.com/dev/how-to/add_logging
 func Log(lg ErrorLogger, msg string, err *error, ctx ...any) {
 	if lg == nil || err == nil || *err == nil {
 		return

--- a/internal/logging/main.go
+++ b/internal/logging/main.go
@@ -58,6 +58,8 @@ func condensedFormat(r *log15.Record) []byte {
 }
 
 // Options control the behavior of a tracer.
+//
+// Deprecated: All logging should use lib/log instead. See https://docs.sourcegraph.com/dev/how-to/add_logging
 type Options struct {
 	filters     []func(*log15.Record) bool
 	serviceName string
@@ -65,14 +67,18 @@ type Options struct {
 
 // If this idiom seems strange:
 // https://github.com/tmrts/go-patterns/blob/master/idiom/functional-options.md
+//
+// Deprecated: All logging should use lib/log instead. See https://docs.sourcegraph.com/dev/how-to/add_logging
 type Option func(*Options)
 
+// Deprecated: All logging should use lib/log instead. See https://docs.sourcegraph.com/dev/how-to/add_logging
 func ServiceName(s string) Option {
 	return func(o *Options) {
 		o.serviceName = s
 	}
 }
 
+// Deprecated: All logging should use lib/log instead. See https://docs.sourcegraph.com/dev/how-to/add_logging
 func Filter(f func(*log15.Record) bool) Option {
 	return func(o *Options) {
 		o.filters = append(o.filters, f)
@@ -85,6 +91,8 @@ func init() {
 }
 
 // For severity field, see https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry
+//
+// Deprecated: All logging should use lib/log instead. See https://docs.sourcegraph.com/dev/how-to/add_logging
 func LogEntryLevelString(l log15.Lvl) string {
 	switch l {
 	case log15.LvlDebug:
@@ -104,6 +112,8 @@ func LogEntryLevelString(l log15.Lvl) string {
 
 // Init initializes log15's root logger based on Sourcegraph-wide logging configuration
 // variables. See https://docs.sourcegraph.com/admin/observability#logs
+//
+// Deprecated: All logging should use lib/log instead. See https://docs.sourcegraph.com/dev/how-to/add_logging
 func Init(options ...Option) {
 	opts := &Options{}
 	for _, setter := range options {


### PR DESCRIPTION
All logging should use lib/log instead. See https://docs.sourcegraph.com/dev/how-to/add_logging and https://github.com/sourcegraph/sourcegraph/issues/33192

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

n/a
