### PR TITLE
Search backend: add comments to HunkMatch and MatchedContent

### DIFF
--- a/enterprise/cmd/frontend/internal/compute/resolvers/resolvers_test.go
+++ b/enterprise/cmd/frontend/internal/compute/resolvers/resolvers_test.go
@@ -36,13 +36,13 @@ func TestToResultResolverList(t *testing.T) {
 	nonNilMatches := []result.Match{
 		&result.FileMatch{
 			HunkMatches: result.HunkMatches{{
-				Preview: "a",
+				Content: "a",
 				Ranges: result.Ranges{{
 					Start: result.Location{Line: 1, Column: 0},
 					End:   result.Location{Line: 1, Column: 1},
 				}},
 			}, {
-				Preview: "b",
+				Content: "b",
 				Ranges: result.Ranges{{
 					Start: result.Location{Line: 2, Column: 0},
 					End:   result.Location{Line: 2, Column: 1},

--- a/enterprise/internal/compute/match_only_command_test.go
+++ b/enterprise/internal/compute/match_only_command_test.go
@@ -35,8 +35,8 @@ func Test_matchOnly(t *testing.T) {
 			Name: "codehost.com/myorg/myrepo",
 		}},
 		HunkMatches: result.HunkMatches{{
-			Preview:      "abcdefgh",
-			PreviewStart: result.Location{Line: 1},
+			Content:      "abcdefgh",
+			ContentStart: result.Location{Line: 1},
 			Ranges: result.Ranges{{
 				Start: result.Location{Line: 1},
 				End:   result.Location{Line: 1},

--- a/internal/search/result/deduper_test.go
+++ b/internal/search/result/deduper_test.go
@@ -56,7 +56,7 @@ func TestDeduper(t *testing.T) {
 
 	hm := func(s string) HunkMatch {
 		return HunkMatch{
-			Preview: s,
+			Content: s,
 		}
 	}
 

--- a/internal/search/result/file.go
+++ b/internal/search/result/file.go
@@ -165,38 +165,41 @@ func (fm *FileMatch) Key() Key {
 	return k
 }
 
-// HunkMatch is a collection of matches of file content along with the matched
-// content. We represent it this way so we always have the complete line
-// available to clients for display purposes and we aways have the complete
-// content of the matched range available for further computation.
+// HunkMatch stores the smallest (and contiguous) line range of file content
+// corresponding to the set of ranges. We represent it this way so we always
+// have the complete line available to clients for display purposes and we
+// aways have the complete content of the matched range available for further
+// computation.
 type HunkMatch struct {
-	// Preview contains the lines overlapped by Ranges. Preview will always
+	// Content contains the lines overlapped by Ranges. Content will always
 	// contain full lines. This means the slice of file content contained
-	// in Preview will always be:
+	// in Content will always be:
 	// 1) preceded by the beginning of the file or a newline, and
 	// 2) succeeded by the end of the file or a newline.
-	Preview string
+	Content string
 
-	// PreviewStart is the location of the first character in Preview. Since
-	// Preview always starts at the beginning of a line, Column should always
+	// ContentStart is the location of the first character in Content. Since
+	// Content always starts at the beginning of a line, Column should always
 	// be set to zero.
-	PreviewStart Location
+	ContentStart Location
 
 	// Ranges is the set of matches for this hunk. Each represents a range of
 	// the matched file that is fully contained by the range represented by
-	// Preview. Ranges are relative to the beginning of the file, not the
-	// beginning of Preview.
+	// Content. Ranges are relative to the beginning of the file, not the
+	// beginning of Content. This type provides no guarantees about the
+	// ordering of ranges, and also does not guarantee that the ranges are
+	// non-overlapping.
 	Ranges Ranges
 }
 
 // MatchedContent returns the content matched by the ranges in this HunkMatch.
 func (h HunkMatch) MatchedContent() []string {
 	// Create a new set of ranges whose offsets are
-	// relative to the start of the preview.
-	relRanges := h.Ranges.Sub(h.PreviewStart)
+	// relative to the start of the content.
+	relRanges := h.Ranges.Sub(h.ContentStart)
 	res := make([]string, 0, len(relRanges))
 	for _, rr := range relRanges {
-		res = append(res, h.Preview[rr.Start.Offset:rr.End.Offset])
+		res = append(res, h.Content[rr.Start.Offset:rr.End.Offset])
 	}
 	return res
 }
@@ -206,10 +209,10 @@ func (h HunkMatch) MatchedContent() []string {
 // between lines in a multiline match, but it allows us to keep providing the
 // LineMatch representation for clients without breaking backwards compatibility.
 func (h HunkMatch) AsLineMatches() []*LineMatch {
-	lines := strings.Split(h.Preview, "\n")
+	lines := strings.Split(h.Content, "\n")
 	lineMatches := make([]*LineMatch, len(lines))
 	for i, line := range lines {
-		lineNumber := h.PreviewStart.Line + i
+		lineNumber := h.ContentStart.Line + i
 		var offsetAndLengths [][2]int32
 		for _, rr := range h.Ranges {
 			for rangeLine := rr.Start.Line; rangeLine <= rr.End.Line; rangeLine++ {

--- a/internal/search/result/file_test.go
+++ b/internal/search/result/file_test.go
@@ -191,3 +191,62 @@ func TestHunkMatches_Limit(t *testing.T) {
 		})
 	}
 }
+
+func TestHunkMatches_MatchedContent(t *testing.T) {
+	cases := []struct {
+		input  HunkMatch
+		output []string
+	}{{
+		input: HunkMatch{
+			Preview:      "abc",
+			PreviewStart: Location{0, 0, 0},
+			Ranges: Ranges{{
+				Start: Location{1, 0, 1},
+				End:   Location{2, 0, 2},
+			}},
+		},
+		output: []string{"b"},
+	}, {
+		input: HunkMatch{
+			Preview:      "def",
+			PreviewStart: Location{4, 1, 0}, // abc\ndef
+			Ranges: Ranges{{
+				Start: Location{5, 1, 1},
+				End:   Location{6, 1, 2},
+			}},
+		},
+		output: []string{"e"},
+	}, {
+		input: HunkMatch{
+			Preview:      "abc\ndef",
+			PreviewStart: Location{0, 0, 0},
+			Ranges: Ranges{{
+				Start: Location{2, 0, 2},
+				End:   Location{5, 1, 1},
+			}},
+		},
+		output: []string{"c\nd"},
+	}, {
+		input: HunkMatch{
+			Preview:      "abc\ndef",
+			PreviewStart: Location{0, 0, 0},
+			Ranges: Ranges{{
+				Start: Location{0, 0, 0},
+				End:   Location{2, 0, 2},
+			}, {
+				Start: Location{2, 0, 2},
+				End:   Location{5, 1, 1},
+			}, {
+				Start: Location{5, 1, 1},
+				End:   Location{7, 1, 3},
+			}},
+		},
+		output: []string{"ab", "c\nd", "ef"},
+	}}
+
+	for _, tc := range cases {
+		t.Run("", func(t *testing.T) {
+			require.Equal(t, tc.output, tc.input.MatchedContent())
+		})
+	}
+}

--- a/internal/search/result/file_test.go
+++ b/internal/search/result/file_test.go
@@ -13,8 +13,8 @@ func TestConvertMatches(t *testing.T) {
 			output []*LineMatch
 		}{{
 			input: HunkMatch{
-				Preview:      "line1\nline2\nline3",
-				PreviewStart: Location{Line: 1},
+				Content:      "line1\nline2\nline3",
+				ContentStart: Location{Line: 1},
 				Ranges: Ranges{{
 					Start: Location{1, 1, 1},
 					End:   Location{13, 3, 1},
@@ -35,8 +35,8 @@ func TestConvertMatches(t *testing.T) {
 			}},
 		}, {
 			input: HunkMatch{
-				Preview:      "line1",
-				PreviewStart: Location{Line: 1},
+				Content:      "line1",
+				ContentStart: Location{Line: 1},
 				Ranges: Ranges{{
 					Start: Location{1, 1, 1},
 					End:   Location{1, 1, 3},
@@ -64,8 +64,8 @@ func TestConvertMatches(t *testing.T) {
 			output []*LineMatch
 		}{{
 			input: HunkMatches{{
-				Preview:      "line1\nline2\nline3\nline4",
-				PreviewStart: Location{Line: 1},
+				Content:      "line1\nline2\nline3\nline4",
+				ContentStart: Location{Line: 1},
 				Ranges: Ranges{{
 					Start: Location{1, 1, 1},
 					End:   Location{13, 3, 1},
@@ -93,15 +93,15 @@ func TestConvertMatches(t *testing.T) {
 			}},
 		}, {
 			input: HunkMatches{{
-				Preview:      "line1\nline2\nline3",
-				PreviewStart: Location{Line: 1},
+				Content:      "line1\nline2\nline3",
+				ContentStart: Location{Line: 1},
 				Ranges: Ranges{{
 					Start: Location{1, 1, 1},
 					End:   Location{13, 3, 1},
 				}},
 			}, {
-				Preview:      "line4\nline5\nline6",
-				PreviewStart: Location{Line: 4},
+				Content:      "line4\nline5\nline6",
+				ContentStart: Location{Line: 4},
 				Ranges: Ranges{{
 					Start: Location{19, 4, 1},
 					End:   Location{31, 6, 1},
@@ -198,8 +198,8 @@ func TestHunkMatches_MatchedContent(t *testing.T) {
 		output []string
 	}{{
 		input: HunkMatch{
-			Preview:      "abc",
-			PreviewStart: Location{0, 0, 0},
+			Content:      "abc",
+			ContentStart: Location{0, 0, 0},
 			Ranges: Ranges{{
 				Start: Location{1, 0, 1},
 				End:   Location{2, 0, 2},
@@ -208,8 +208,8 @@ func TestHunkMatches_MatchedContent(t *testing.T) {
 		output: []string{"b"},
 	}, {
 		input: HunkMatch{
-			Preview:      "def",
-			PreviewStart: Location{4, 1, 0}, // abc\ndef
+			Content:      "def",
+			ContentStart: Location{4, 1, 0}, // abc\ndef
 			Ranges: Ranges{{
 				Start: Location{5, 1, 1},
 				End:   Location{6, 1, 2},
@@ -218,8 +218,8 @@ func TestHunkMatches_MatchedContent(t *testing.T) {
 		output: []string{"e"},
 	}, {
 		input: HunkMatch{
-			Preview:      "abc\ndef",
-			PreviewStart: Location{0, 0, 0},
+			Content:      "abc\ndef",
+			ContentStart: Location{0, 0, 0},
 			Ranges: Ranges{{
 				Start: Location{2, 0, 2},
 				End:   Location{5, 1, 1},
@@ -228,8 +228,8 @@ func TestHunkMatches_MatchedContent(t *testing.T) {
 		output: []string{"c\nd"},
 	}, {
 		input: HunkMatch{
-			Preview:      "abc\ndef",
-			PreviewStart: Location{0, 0, 0},
+			Content:      "abc\ndef",
+			ContentStart: Location{0, 0, 0},
 			Ranges: Ranges{{
 				Start: Location{0, 0, 0},
 				End:   Location{2, 0, 2},

--- a/internal/search/result/range.go
+++ b/internal/search/result/range.go
@@ -58,14 +58,15 @@ func rangeToHighlights(s string, r Range) []HighlightedRange {
 	return res
 }
 
+// Location represents the location of a character in some UTF-8 encoded content.
 type Location struct {
-	// Offset is the number of bytes from the beginning of the matched text
+	// Offset is the number of bytes preceding this character in the content
 	Offset int
 
 	// Line is the count of newlines before the offset in the matched text
 	Line int
 
-	// Column is the count of unicode code points after the last newline in the matched text
+	// Column is the count of UTF-8 runes after the last newline in the matched text
 	Column int
 }
 
@@ -102,6 +103,7 @@ func (l *Location) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+// Range represents a slice [start, end) of some UTF-8 encoded content.
 type Range struct {
 	Start Location `json:"start"`
 	End   Location `json:"end"`

--- a/internal/search/searcher/search.go
+++ b/internal/search/searcher/search.go
@@ -242,8 +242,8 @@ func newToMatches(repo types.MinimalRepo, commit api.CommitID, rev *string) func
 					})
 				}
 				hunkMatches = append(hunkMatches, result.HunkMatch{
-					Preview: lm.Preview,
-					PreviewStart: result.Location{
+					Content: lm.Preview,
+					ContentStart: result.Location{
 						Offset: lm.LineOffset,
 						Line:   lm.LineNumber,
 						Column: 0,
@@ -254,8 +254,8 @@ func newToMatches(repo types.MinimalRepo, commit api.CommitID, rev *string) func
 
 			for _, mm := range fm.MultilineMatches {
 				hunkMatches = append(hunkMatches, result.HunkMatch{
-					Preview: mm.Preview,
-					PreviewStart: result.Location{
+					Content: mm.Preview,
+					ContentStart: result.Location{
 						Offset: int(mm.Start.Offset) - runeOffsetToByteOffset(mm.Preview, int(mm.Start.Column)),
 						Line:   int(mm.Start.Line),
 						Column: 0,

--- a/internal/search/streaming/stream_test.go
+++ b/internal/search/streaming/stream_test.go
@@ -205,8 +205,8 @@ func TestWithSelect(t *testing.T) {
     "Path": "pokeman/charmandar",
     "HunkMatches": [
       {
-        "Preview": "",
-        "PreviewStart": [
+        "Content": "",
+        "ContentStart": [
           0,
           0,
           0
@@ -227,8 +227,8 @@ func TestWithSelect(t *testing.T) {
         ]
       },
       {
-        "Preview": "",
-        "PreviewStart": [
+        "Content": "",
+        "ContentStart": [
           0,
           0,
           0
@@ -255,8 +255,8 @@ func TestWithSelect(t *testing.T) {
     "Path": "pokeman/charmandar",
     "HunkMatches": [
       {
-        "Preview": "",
-        "PreviewStart": [
+        "Content": "",
+        "ContentStart": [
           0,
           0,
           0
@@ -283,8 +283,8 @@ func TestWithSelect(t *testing.T) {
     "Path": "pokeman/bulbosaur",
     "HunkMatches": [
       {
-        "Preview": "",
-        "PreviewStart": [
+        "Content": "",
+        "ContentStart": [
           0,
           0,
           0
@@ -311,8 +311,8 @@ func TestWithSelect(t *testing.T) {
     "Path": "digiman/ummm",
     "HunkMatches": [
       {
-        "Preview": "",
-        "PreviewStart": [
+        "Content": "",
+        "ContentStart": [
           0,
           0,
           0

--- a/internal/search/zoekt/indexed_search.go
+++ b/internal/search/zoekt/indexed_search.go
@@ -413,9 +413,9 @@ func zoektFileMatchToMultilineMatches(file *zoekt.FileMatch) result.HunkMatches 
 			length := utf8.RuneCount(l.Line[m.LineOffset : m.LineOffset+m.MatchLength])
 
 			hms = append(hms, result.HunkMatch{
-				Preview: string(l.Line),
+				Content: string(l.Line),
 				// zoekt line numbers are 1-based rather than 0-based so subtract 1
-				PreviewStart: result.Location{
+				ContentStart: result.Location{
 					Offset: l.LineStart,
 					Line:   l.LineNumber - 1,
 					Column: 0,


### PR DESCRIPTION
This adds a bunch of comments to HunkMatch since I think I'm happy with
where this design landed. Additionally, it adds MatchedContent, which
returns the exact set of strings matched by the query. It's not used
except in tests yet, but I wanted to add that now to pin that behavior
since that's critical to the design of what we store in HunkMatch.

Stacked on #36176 

## Test plan

Added a test for the one new method. The rest is comments. 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
