### PR TITLE
internal/metrics: migrate to lib/log

### DIFF
--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -30,10 +30,9 @@ var registerer = prometheus.DefaultRegisterer
 // RequestMeter wraps a Prometheus request meter (counter + duration histogram) updated by requests made by derived
 // http.RoundTrippers.
 type RequestMeter struct {
-	log       log.Logger
-	counter   *prometheus.CounterVec
-	duration  *prometheus.HistogramVec
-	subsystem string
+	log      log.Logger
+	counter  *prometheus.CounterVec
+	duration *prometheus.HistogramVec
 }
 
 const (
@@ -83,10 +82,9 @@ func NewRequestMeter(subsystem, help string) *RequestMeter {
 	registerer.MustRegister(requestDuration)
 
 	return &RequestMeter{
-		log:       log.Scoped(fmt.Sprintf("%s.RequestMeter", subsystem), help),
-		counter:   requestCounter,
-		duration:  requestDuration,
-		subsystem: subsystem,
+		log:      log.Scoped(fmt.Sprintf("%s.RequestMeter", subsystem), help),
+		counter:  requestCounter,
+		duration: requestDuration,
 	}
 }
 

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -2,16 +2,17 @@ package metrics
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/url"
 	"strconv"
 	"syscall"
 	"time"
 
-	"github.com/inconshreveable/log15"
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"github.com/sourcegraph/sourcegraph/lib/log"
 )
 
 type testRegisterer struct{}
@@ -29,6 +30,7 @@ var registerer = prometheus.DefaultRegisterer
 // RequestMeter wraps a Prometheus request meter (counter + duration histogram) updated by requests made by derived
 // http.RoundTrippers.
 type RequestMeter struct {
+	log       log.Logger
 	counter   *prometheus.CounterVec
 	duration  *prometheus.HistogramVec
 	subsystem string
@@ -80,7 +82,12 @@ func NewRequestMeter(subsystem, help string) *RequestMeter {
 	}, []string{"category", "code", "host"})
 	registerer.MustRegister(requestDuration)
 
-	return &RequestMeter{counter: requestCounter, duration: requestDuration, subsystem: subsystem}
+	return &RequestMeter{
+		log:       log.Scoped(fmt.Sprintf("%s.RequestMeter", subsystem), help),
+		counter:   requestCounter,
+		duration:  requestDuration,
+		subsystem: subsystem,
+	}
 }
 
 // Transport returns an http.RoundTripper that updates rm for each request. The categoryFunc is called to
@@ -142,7 +149,11 @@ func (t *requestCounterMiddleware) RoundTrip(r *http.Request) (resp *http.Respon
 	}).Inc()
 
 	t.meter.duration.WithLabelValues(category, code, r.URL.Host).Observe(d.Seconds())
-	log15.Debug("TRACE "+t.meter.subsystem, "host", r.URL.Host, "path", r.URL.Path, "code", code, "duration", d)
+	t.meter.log.Debug("request.trace",
+		log.String("host", r.URL.Host),
+		log.String("path", r.URL.Path),
+		log.String("code", code),
+		log.Duration("duration", d))
 	return
 }
 


### PR DESCRIPTION
Not sure if this is _the_ fix to [thread](https://sourcegraph.slack.com/archives/C01N83PS4TU/p1653664190433619), but I'm pretty sure this is the source of the log output, so might as well migrate it over for now. I don't see any spam like the one in the thread so... maybe?

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

`sg start`, watch for spam (did not see any originating from here)