### PR TITLE
propagate traces on streaming searches from insights

### DIFF
--- a/enterprise/internal/insights/query/streaming/search.go
+++ b/enterprise/internal/insights/query/streaming/search.go
@@ -3,6 +3,9 @@ package streaming
 import (
 	"context"
 
+	"github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go/log"
+
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/compute/client"
 
 	"github.com/sourcegraph/sourcegraph/internal/api/internalapi"
@@ -21,13 +24,28 @@ type Opts struct {
 
 // Search calls the streaming search endpoint and uses decoder to decode the
 // response body.
-func Search(ctx context.Context, query string, decoder streamhttp.FrontendStreamDecoder) error {
+func Search(ctx context.Context, query string, decoder streamhttp.FrontendStreamDecoder) (err error) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "InsightsStreamSearch")
+	defer func() {
+		span.LogFields(
+			log.Error(err),
+		)
+		span.Finish()
+	}()
 	req, err := streamhttp.NewRequest(internalapi.Client.URL+"/.internal", query)
 	if err != nil {
 		return err
 	}
 	req = req.WithContext(ctx)
 	req.Header.Set("User-Agent", "code-insights-backend")
+
+	if span != nil {
+		carrier := opentracing.HTTPHeadersCarrier(req.Header)
+		span.Tracer().Inject(
+			span.Context(),
+			opentracing.HTTPHeaders,
+			carrier)
+	}
 
 	resp, err := httpcli.InternalClient.Do(req)
 	if err != nil {
@@ -42,13 +60,29 @@ func Search(ctx context.Context, query string, decoder streamhttp.FrontendStream
 	return err
 }
 
-func ComputeMatchContextStream(ctx context.Context, query string, decoder client.ComputeMatchContextStreamDecoder) error {
+func ComputeMatchContextStream(ctx context.Context, query string, decoder client.ComputeMatchContextStreamDecoder) (err error) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "InsightsComputeStreamSearch")
+	defer func() {
+		span.LogFields(
+			log.Error(err),
+		)
+		span.Finish()
+	}()
+
 	req, err := client.NewMatchContextRequest(internalapi.Client.URL+"/.internal", query)
 	if err != nil {
 		return err
 	}
 	req = req.WithContext(ctx)
 	req.Header.Set("User-Agent", "code-insights-backend")
+
+	if span != nil {
+		carrier := opentracing.HTTPHeadersCarrier(req.Header)
+		span.Tracer().Inject(
+			span.Context(),
+			opentracing.HTTPHeaders,
+			carrier)
+	}
 
 	resp, err := httpcli.InternalClient.Do(req)
 	if err != nil {


### PR DESCRIPTION
When we migrated to the streaming endpoint we lost our trace propagation. This replaces it.


## Test plan
Here is an example trace running locally from a compute search:

<img width="882" alt="image" src="https://user-images.githubusercontent.com/5090588/170757847-ec80c6a8-59a3-44cb-b9fc-82219c4dc024.png">
