### PR TITLE
JetBrains: Handle symbol search results

### DIFF
--- a/client/jetbrains/webview/src/search/App.tsx
+++ b/client/jetbrains/webview/src/search/App.tsx
@@ -33,9 +33,9 @@ interface Props {
     instanceURL: string
     isGlobbingEnabled: boolean
     accessToken: string | null
-    onPreviewChange: (match: SearchMatch, lineMatchIndex?: number) => void
+    onPreviewChange: (match: SearchMatch, lineMatchIndexOrSymbolIndex?: number) => void
     onPreviewClear: () => void
-    onOpen: (match: SearchMatch, lineMatchIndex?: number) => void
+    onOpen: (match: SearchMatch, lineMatchIndexOrSymbolIndex?: number) => void
     initialSearch: Search | null
     initialAuthenticatedUser: AuthenticatedUser | null
 }

--- a/client/jetbrains/webview/src/search/js-to-java-bridge.ts
+++ b/client/jetbrains/webview/src/search/js-to-java-bridge.ts
@@ -1,5 +1,5 @@
 import { splitPath } from '@sourcegraph/shared/src/components/RepoLink'
-import { ContentMatch, SearchMatch } from '@sourcegraph/shared/src/search/stream'
+import { ContentMatch, SearchMatch, SymbolMatch } from '@sourcegraph/shared/src/search/stream'
 
 import { loadContent } from './lib/blob'
 import { PluginConfig, Search, Theme } from './types'
@@ -82,8 +82,8 @@ export async function indicateFinishedLoading(): Promise<void> {
     }
 }
 
-export async function onPreviewChange(match: SearchMatch, lineMatchIndex?: number): Promise<void> {
-    const request = await createPreviewOrOpenRequest(match, lineMatchIndex, 'preview')
+export async function onPreviewChange(match: SearchMatch, lineMatchIndexOrSymbolIndex?: number): Promise<void> {
+    const request = await createPreviewOrOpenRequest(match, lineMatchIndexOrSymbolIndex, 'preview')
     try {
         await callJava(request)
     } catch (error) {
@@ -99,9 +99,9 @@ export async function onPreviewClear(): Promise<void> {
     }
 }
 
-export async function onOpen(match: SearchMatch, lineMatchIndex?: number): Promise<void> {
+export async function onOpen(match: SearchMatch, lineMatchIndexOrSymbolIndex?: number): Promise<void> {
     try {
-        await callJava(await createPreviewOrOpenRequest(match, lineMatchIndex, 'open'))
+        await callJava(await createPreviewOrOpenRequest(match, lineMatchIndexOrSymbolIndex, 'open'))
     } catch (error) {
         console.error(`Failed to open match: ${(error as Error).message}`)
     }
@@ -132,7 +132,7 @@ async function callJava(request: Request): Promise<object> {
 
 export async function createPreviewOrOpenRequest(
     match: SearchMatch,
-    lineMatchIndex: number | undefined,
+    lineMatchIndexOrSymbolIndex: number | undefined,
     action: MatchRequest['action']
 ): Promise<MatchRequest> {
     if (match.type === 'commit') {
@@ -149,7 +149,7 @@ export async function createPreviewOrOpenRequest(
     }
 
     if (match.type === 'content') {
-        return createPreviewOrOpenRequestForContentMatch(match, lineMatchIndex as number, 'preview')
+        return createPreviewOrOpenRequestForContentMatch(match, lineMatchIndexOrSymbolIndex as number, action)
     }
 
     if (match.type === 'repo') {
@@ -163,6 +163,10 @@ export async function createPreviewOrOpenRequest(
                 absoluteOffsetAndLengths: [],
             },
         }
+    }
+
+    if (match.type === 'symbol') {
+        return createPreviewOrOpenRequestForSymbolMatch(match, lineMatchIndexOrSymbolIndex as number, action)
     }
 
     console.log(`Unknown match type: “${match.type}”`)
@@ -200,6 +204,26 @@ export async function createPreviewOrOpenRequestForContentMatch(
             content: content.replaceAll('\r\n', '\n'),
             lineNumber: match.lineMatches[lineMatchIndex].lineNumber,
             absoluteOffsetAndLengths,
+        },
+    }
+}
+
+export async function createPreviewOrOpenRequestForSymbolMatch(
+    match: SymbolMatch,
+    symbolIndex: number,
+    action: MatchRequest['action']
+): Promise<MatchRequest> {
+    const fileName = splitPath(match.path)[1]
+    const content = await loadContent(match)
+
+    return {
+        action,
+        arguments: {
+            fileName,
+            path: match.path,
+            content: content.replaceAll('\r\n', '\n'),
+            lineNumber: -1,
+            absoluteOffsetAndLengths: [],
         },
     }
 }

--- a/client/jetbrains/webview/src/search/lib/blob.ts
+++ b/client/jetbrains/webview/src/search/lib/blob.ts
@@ -1,10 +1,10 @@
 const cachedContentRequests = new Map<string, Promise<string>>()
 
-import { ContentMatch } from '@sourcegraph/shared/src/search/stream'
+import { ContentMatch, SymbolMatch } from '@sourcegraph/shared/src/search/stream'
 
 import { getMatchId } from '../results/utils'
 
-export async function loadContent(match: ContentMatch): Promise<string> {
+export async function loadContent(match: ContentMatch | SymbolMatch): Promise<string> {
     const cacheKey = getMatchId(match)
 
     if (cachedContentRequests.has(cacheKey)) {
@@ -20,7 +20,7 @@ export async function loadContent(match: ContentMatch): Promise<string> {
     return loadPromise
 }
 
-async function fetchBlobContent(match: ContentMatch): Promise<string> {
+async function fetchBlobContent(match: ContentMatch | SymbolMatch): Promise<string> {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-explicit-any
     const response: any = await fetch('https://sourcegraph.com/.api/graphql', {
         method: 'post',

--- a/client/jetbrains/webview/src/search/results/SearchResultList.tsx
+++ b/client/jetbrains/webview/src/search/results/SearchResultList.tsx
@@ -7,7 +7,7 @@ import { FileSearchResult } from './FileSearchResult'
 import { RepoSearchResult } from './RepoSearchResult'
 import {
     getFirstResultId,
-    getLineMatchIndexForContentMatch,
+    getLineMatchIndexOrSymbolIndexForContentOrSymbolResult,
     getMatchId,
     getMatchIdForResult,
     getSearchResultElement,
@@ -17,9 +17,9 @@ import {
 import styles from './SearchResultList.module.scss'
 
 interface Props {
-    onPreviewChange: (match: SearchMatch, lineMatchIndex?: number) => void
+    onPreviewChange: (match: SearchMatch, lineMatchIndexOrSymbolIndex?: number) => void
     onPreviewClear: () => void
-    onOpen: (result: SearchMatch, lineMatchIndex?: number) => void
+    onOpen: (result: SearchMatch, lineMatchIndexOrSymbolIndex?: number) => void
     matches: SearchMatch[]
 }
 
@@ -35,7 +35,7 @@ export const SearchResultList: React.FunctionComponent<Props> = ({
     const matchIdToMatchMap = useMemo((): Map<string, SearchMatch> => {
         const map = new Map<string, SearchMatch>()
         for (const match of matches) {
-            if (['content', 'commit', 'repo'].includes(match.type)) {
+            if (['content', 'commit', 'repo', 'symbol'].includes(match.type)) {
                 map.set(getMatchId(match), match)
             }
         }
@@ -51,7 +51,9 @@ export const SearchResultList: React.FunctionComponent<Props> = ({
                 if (match) {
                     onPreviewChange(
                         match,
-                        match.type === 'content' ? getLineMatchIndexForContentMatch(resultId) : undefined
+                        match.type === 'content' || match.type === 'symbol'
+                            ? getLineMatchIndexOrSymbolIndexForContentOrSymbolResult(resultId)
+                            : undefined
                     )
                 }
             } else {
@@ -101,7 +103,9 @@ export const SearchResultList: React.FunctionComponent<Props> = ({
                 if (match) {
                     onOpen(
                         match,
-                        match.type === 'content' ? getLineMatchIndexForContentMatch(selectedResultId) : undefined
+                        match.type === 'content' || match.type === 'symbol'
+                            ? getLineMatchIndexOrSymbolIndexForContentOrSymbolResult(selectedResultId)
+                            : undefined
                     )
                 }
                 return
@@ -153,6 +157,15 @@ export const SearchResultList: React.FunctionComponent<Props> = ({
                             />
                         )
                     case 'content':
+                        return (
+                            <FileSearchResult
+                                key={`${match.repository}-${match.path}`}
+                                match={match}
+                                selectedResult={selectedResultId}
+                                selectResult={selectResult}
+                            />
+                        )
+                    case 'symbol':
                         return (
                             <FileSearchResult
                                 key={`${match.repository}-${match.path}`}

--- a/client/jetbrains/webview/src/search/results/utils.ts
+++ b/client/jetbrains/webview/src/search/results/utils.ts
@@ -3,7 +3,7 @@ import { ContentMatch, SearchMatch } from '@sourcegraph/shared/src/search/stream
 export function getFirstResultId(results: SearchMatch[]): string | null {
     const firstContentMatch: null | ContentMatch = results.find(result => result.type === 'content') as ContentMatch
     if (firstContentMatch) {
-        return getResultIdForContentMatch(firstContentMatch, firstContentMatch.lineMatches[0])
+        return getResultId(firstContentMatch, firstContentMatch.lineMatches[0])
     }
     return null
 }
@@ -13,7 +13,7 @@ export function getMatchId(match: SearchMatch): string {
         return `${match.repository}-${match.oid.slice(0, 7)}`
     }
 
-    if (match.type === 'content') {
+    if (match.type === 'content' || match.type === 'symbol') {
         return `${match.repository}-${match.path}`
     }
 
@@ -29,19 +29,24 @@ export function getMatchIdForResult(resultId: string): string {
     return resultId.split('-#-')[0]
 }
 
-export function getResultIdForContentMatch(match: ContentMatch, lineMatch: ContentMatch['lineMatches'][0]): string {
-    return `${getMatchId(match)}-#-${match.lineMatches.indexOf(lineMatch)}`
-}
-
-export function getResultId(match: SearchMatch, lineMatch?: ContentMatch['lineMatches'][0]): string {
+export function getResultId(
+    match: SearchMatch,
+    lineMatchOrSymbolName?: ContentMatch['lineMatches'][0] | string
+): string {
     if (match.type === 'content') {
-        return `${getMatchId(match)}-#-${match.lineMatches.indexOf(lineMatch as ContentMatch['lineMatches'][0])}`
+        return `${getMatchId(match)}-#-${match.lineMatches.indexOf(
+            lineMatchOrSymbolName as ContentMatch['lineMatches'][0]
+        )}`
+    }
+
+    if (match.type === 'symbol') {
+        return `${getMatchId(match)}-#-${lineMatchOrSymbolName as string}`
     }
 
     return getMatchId(match)
 }
 
-export function getLineMatchIndexForContentMatch(resultId: string): number {
+export function getLineMatchIndexOrSymbolIndexForContentOrSymbolResult(resultId: string): number {
     return parseInt(resultId.split('-#-')[1], 10)
 }
 


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/35552

Another search type implemented. Once again, just like for the path search type, the design is not final, but it's something to look at and see how it feels.

## Test plan

Tested it manually; it works fine. 40-sec Loom [here](https://www.loom.com/share/c9f9eeafeb664057a2043f97945a4465)