### PR TITLE
search: run Zoekt to completion before any searcher jobs on Sourcegraph.com

### DIFF
--- a/internal/search/job/jobutil/job_test.go
+++ b/internal/search/job/jobutil/job_test.go
@@ -30,12 +30,14 @@ func TestNewPlanJob(t *testing.T) {
     (LIMIT
       500
       (PARALLEL
-        (REPOPAGER
-          ZoektRepoSubsetTextSearchJob)
+        (SEQUENTIAL
+          (REPOPAGER
+            ZoektRepoSubsetTextSearchJob)
+          (REPOPAGER
+            SearcherTextSearchJob))
         ReposComputeExcludedJob
         (PARALLEL
-          (REPOPAGER
-            SearcherTextSearchJob)
+          NoopJob
           RepoSearchJob)))))`),
 	}, {
 		query:      `foo context:global`,
@@ -76,12 +78,14 @@ func TestNewPlanJob(t *testing.T) {
     (LIMIT
       500
       (PARALLEL
-        (REPOPAGER
-          ZoektRepoSubsetTextSearchJob)
+        (SEQUENTIAL
+          (REPOPAGER
+            ZoektRepoSubsetTextSearchJob)
+          (REPOPAGER
+            SearcherTextSearchJob))
         ReposComputeExcludedJob
         (PARALLEL
-          (REPOPAGER
-            SearcherTextSearchJob)
+          NoopJob
           RepoSearchJob)))))`),
 	}, {
 		query:      `ok ok`,
@@ -207,15 +211,17 @@ func TestNewPlanJob(t *testing.T) {
     (LIMIT
       500
       (PARALLEL
-        (REPOPAGER
-          ZoektRepoSubsetTextSearchJob)
+        (SEQUENTIAL
+          (REPOPAGER
+            ZoektRepoSubsetTextSearchJob)
+          (REPOPAGER
+            SearcherTextSearchJob))
         (REPOPAGER
           ZoektSymbolSearchJob)
         CommitSearchJob
         ReposComputeExcludedJob
         (PARALLEL
-          (REPOPAGER
-            SearcherTextSearchJob)
+          NoopJob
           (REPOPAGER
             SearcherSymbolSearchJob)
           RepoSearchJob)))))`),
@@ -245,15 +251,17 @@ func TestNewPlanJob(t *testing.T) {
     (LIMIT
       500
       (PARALLEL
-        (REPOPAGER
-          ZoektRepoSubsetTextSearchJob)
+        (SEQUENTIAL
+          (REPOPAGER
+            ZoektRepoSubsetTextSearchJob)
+          (REPOPAGER
+            SearcherTextSearchJob))
         (REPOPAGER
           ZoektSymbolSearchJob)
         CommitSearchJob
         ReposComputeExcludedJob
         (PARALLEL
-          (REPOPAGER
-            SearcherTextSearchJob)
+          NoopJob
           (REPOPAGER
             SearcherSymbolSearchJob)
           RepoSearchJob)))))`),


### PR DESCRIPTION
As in title. Waiting on `backend-integration` still, but putting up for review for visibility.



## Test plan
Unit tests updated.

Fixes https://github.com/sourcegraph/sourcegraph/issues/35994