### PR TITLE
Fix token-click URL getting overwritten

### DIFF
--- a/client/web/src/repo/blob/Blob.tsx
+++ b/client/web/src/repo/blob/Blob.tsx
@@ -502,9 +502,6 @@ export const Blob: React.FunctionComponent<React.PropsWithChildren<BlobProps>> =
                                 findPositionsFromEvents({ domFunctions })
                             ),
                             positionJumps: locationPositions.pipe(
-                                tap(position => {
-                                    console.log('🟠', position)
-                                }),
                                 withLatestFrom(
                                     codeViewElements.pipe(filter(isDefined)),
                                     blobElements.pipe(filter(isDefined))

--- a/client/web/src/repo/blob/Blob.tsx
+++ b/client/web/src/repo/blob/Blob.tsx
@@ -391,10 +391,14 @@ export const Blob: React.FunctionComponent<React.PropsWithChildren<BlobProps>> =
                         parameters.delete('popover')
                         nextPopoverClose()
 
-                        props.history.push({
-                            ...location,
-                            search: formatSearchParameters(addLineRangeQueryParameter(parameters, query)),
-                        })
+                        if (position && !('character' in position)) {
+                            // Only change the URL when clicking on blank space on the line (not on
+                            // characters). Otherwise, this would interfere with go to definition.
+                            props.history.push({
+                                ...location,
+                                search: formatSearchParameters(addLineRangeQueryParameter(parameters, query)),
+                            })
+                        }
                     }),
                     mapTo(undefined)
                 ),
@@ -498,6 +502,9 @@ export const Blob: React.FunctionComponent<React.PropsWithChildren<BlobProps>> =
                                 findPositionsFromEvents({ domFunctions })
                             ),
                             positionJumps: locationPositions.pipe(
+                                tap(position => {
+                                    console.log('🟠', position)
+                                }),
                                 withLatestFrom(
                                     codeViewElements.pipe(filter(isDefined)),
                                     blobElements.pipe(filter(isDefined))


### PR DESCRIPTION
Continuation of https://github.com/sourcegraph/sourcegraph/pull/36039

Fixes https://github.com/sourcegraph/sourcegraph/issues/36131

## Test plan

Manual

## App preview:

- [Web](https://sg-web-fix-token-click-pin-conflict.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-kbinxuzjmc.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
