### PR TITLE
symbols: Ignore contents of big files from git archive

### DIFF
--- a/cmd/symbols/fetcher/repository_fetcher_test.go
+++ b/cmd/symbols/fetcher/repository_fetcher_test.go
@@ -32,7 +32,7 @@ func TestRepositoryFetcher(t *testing.T) {
 	gitserverClient := NewMockGitserverClient()
 	gitserverClient.FetchTarFunc.SetDefaultHook(gitserver.CreateTestFetchTarFunc(tarContents))
 
-	repositoryFetcher := NewRepositoryFetcher(gitserverClient, 1000, &observation.TestContext)
+	repositoryFetcher := NewRepositoryFetcher(gitserverClient, 1000, 1_000_000, &observation.TestContext)
 	args := types.SearchArgs{Repo: api.RepoName("foo"), CommitID: api.CommitID("deadbeef")}
 
 	t.Run("all paths", func(t *testing.T) {

--- a/cmd/symbols/internal/api/handler_test.go
+++ b/cmd/symbols/internal/api/handler_test.go
@@ -62,7 +62,7 @@ func TestHandler(t *testing.T) {
 	gitserverClient := NewMockGitserverClient()
 	gitserverClient.FetchTarFunc.SetDefaultHook(gitserver.CreateTestFetchTarFunc(files))
 
-	parser := parser.NewParser(parserPool, fetcher.NewRepositoryFetcher(gitserverClient, 1000, &observation.TestContext), 0, 10, &observation.TestContext)
+	parser := parser.NewParser(parserPool, fetcher.NewRepositoryFetcher(gitserverClient, 1000, 1_000_000, &observation.TestContext), 0, 10, &observation.TestContext)
 	databaseWriter := writer.NewDatabaseWriter(tmpDir, gitserverClient, parser, semaphore.NewWeighted(1))
 	cachedDatabaseWriter := writer.NewCachedDatabaseWriter(databaseWriter, cache)
 	handler := NewHandler(MakeSqliteSearchFunc(sharedobservability.NewOperations(&observation.TestContext), cachedDatabaseWriter), nil, "")

--- a/cmd/symbols/shared/main.go
+++ b/cmd/symbols/shared/main.go
@@ -67,7 +67,8 @@ func Main(setup SetupFunc) {
 
 	// Run setup
 	gitserverClient := gitserver.NewClient(observationContext)
-	repositoryFetcher := fetcher.NewRepositoryFetcher(gitserverClient, types.LoadRepositoryFetcherConfig(env.BaseConfig{}).MaxTotalPathsLength, observationContext)
+	repositoryFetcherConfig := types.LoadRepositoryFetcherConfig(env.BaseConfig{})
+	repositoryFetcher := fetcher.NewRepositoryFetcher(gitserverClient, repositoryFetcherConfig.MaxTotalPathsLength, int64(repositoryFetcherConfig.MaxFileSizeKb*1000), observationContext)
 	searchFunc, handleStatus, newRoutines, ctagsBinary, err := setup(observationContext, gitserverClient, repositoryFetcher)
 	if err != nil {
 		logger.Fatal("Failed to set up", log.Error(err))

--- a/cmd/symbols/shared/main.go
+++ b/cmd/symbols/shared/main.go
@@ -68,7 +68,7 @@ func Main(setup SetupFunc) {
 	// Run setup
 	gitserverClient := gitserver.NewClient(observationContext)
 	repositoryFetcherConfig := types.LoadRepositoryFetcherConfig(env.BaseConfig{})
-	repositoryFetcher := fetcher.NewRepositoryFetcher(gitserverClient, repositoryFetcherConfig.MaxTotalPathsLength, int64(repositoryFetcherConfig.MaxFileSizeKb*1000), observationContext)
+	repositoryFetcher := fetcher.NewRepositoryFetcher(gitserverClient, repositoryFetcherConfig.MaxTotalPathsLength, int64(repositoryFetcherConfig.MaxFileSizeKb)*1000, observationContext)
 	searchFunc, handleStatus, newRoutines, ctagsBinary, err := setup(observationContext, gitserverClient, repositoryFetcher)
 	if err != nil {
 		logger.Fatal("Failed to set up", log.Error(err))

--- a/cmd/symbols/types/types.go
+++ b/cmd/symbols/types/types.go
@@ -75,11 +75,14 @@ type RepositoryFetcherConfig struct {
 	// We want to remain well under that limit, so defaulting to 100,000 seems safe (see the
 	// MAX_TOTAL_PATHS_LENGTH environment variable below).
 	MaxTotalPathsLength int
+
+	MaxFileSizeKb int
 }
 
 func LoadRepositoryFetcherConfig(baseConfig env.BaseConfig) RepositoryFetcherConfig {
 	return RepositoryFetcherConfig{
 		MaxTotalPathsLength: baseConfig.GetInt("MAX_TOTAL_PATHS_LENGTH", "100000", "maximum sum of lengths of all paths in a single call to git archive"),
+		MaxFileSizeKb:       baseConfig.GetInt("MAX_FILE_SIZE_KB", "1000", "maximum file size in KB, the contents of bigger files are ignored"),
 	}
 }
 


### PR DESCRIPTION
Prior to this change, we were slurping every file from git archive into memory (not all at once, but one-by-one), and I'm guessing some files were huge (1GB+) and causing OOMs.

After this change, the symbols service completely ignores the contents of big files, and the threshold is configurable via `MAX_FILE_SIZE_KB`.

See https://github.com/sourcegraph/sourcegraph/issues/36107#issuecomment-1140011081

## Test plan

Manually ran with `env MAX_FILE_SIZE_KB=10 sg start` and verified the SQLite DB was smaller and no symbols were produced for [a 19KB file](https://sourcegraph.test:3443/github.com/crossplane/crossplane/-/blob/apis/pkg/v1/interfaces.go).