### PR TITLE
Rockskip: add more help info to the status page and docs

### DIFF
--- a/doc/code_intelligence/explanations/rockskip.md
+++ b/doc/code_intelligence/explanations/rockskip.md
@@ -16,7 +16,7 @@ You can always try Rockskip for a while and if it doesn't help then you can disa
 
 ## How do I enable Rockskip?
 
-**Step 1:** Set these environment variables on the `symbols` container:
+**Step 1:** Give your `codeintel-db` has a few extra GB of RAM and set environment variables on the `symbols` container:
 
 For Kubernetes:
 
@@ -28,27 +28,49 @@ spec:
       containers:
       - name: symbols
         env:
-        # Enables Rockskip
+        # 👇 Enables Rockskip
         - name: USE_ROCKSKIP
           value: "true"
-        # Uses Rockskip for the repositories in the comma separated list
+        # 👇 Uses Rockskip for the repositories in the comma separated list
         - name: ROCKSKIP_REPOS
           value: "github.com/torvalds/linux,github.com/pallets/flask"
+```
+
+```yaml
+# base/codeintel-db/codeintel-db.Deployment.yaml
+spec:
+  template:
+    spec:
+      containers:
+      - name: pgsql
+        resources:
+          limits:
+            memory: 8Gi # 👈 Increase RAM from 4g to 8g
+          requests:
+            memory: 8Gi # 👈 Increase RAM from 4g to 8g
 ```
 
 For Docker Compose:
 
 ```yaml
 services:
+
   symbols-0:
     environment:
-      # Enables Rockskip
+      # 👇 Enables Rockskip
       - USE_ROCKSKIP=true
-      # Uses Rockskip for the repositories in the comma separated list
+      # 👇 Uses Rockskip for the repositories in the comma separated list
       - ROCKSKIP_REPOS=github.com/torvalds/linux,github.com/pallets/flask
+
+  codeintel-db:
+    mem_limit: '8g' # 👈 Increase RAM from 2g to 8g
 ```
 
-For other deployments, make sure the `symbols` service has access to the codeintel DB then set the environment variables.
+For other deployments, make sure that:
+
+- The `symbols` service has access to the codeintel DB
+- The `symbols` service has the environment variables set
+- The `codeintel-db` has a few extra GB of RAM
 
 **Step 2:** Kick off indexing
 

--- a/doc/code_intelligence/explanations/rockskip.md
+++ b/doc/code_intelligence/explanations/rockskip.md
@@ -16,7 +16,7 @@ You can always try Rockskip for a while and if it doesn't help then you can disa
 
 ## How do I enable Rockskip?
 
-To enable it, set these environment variables on the `symbols` container:
+**Step 1:** Set these environment variables on the `symbols` container:
 
 For Kubernetes:
 
@@ -50,9 +50,17 @@ services:
 
 For other deployments, make sure the `symbols` service has access to the codeintel DB then set the environment variables.
 
-## How do I use Rockskip?
+**Step 2:** Kick off indexing
 
-Simply visit your repository in Sourcegraph and open the symbols sidebar to kick off indexing.
+1. Visit your repository in the Sourcegraph UI
+1. Click on the branch selector, click **Commits**, and select the second most recent commit (this avoids routing the request to Zoekt)
+1. Open the symbols sidebar to kick off indexing (it's ok to see a loading spinner, that probably means indexing is in progress)
+
+**Step 3:** See the section below to [check on the indexing status](#how-do-i-check-the-indexing-status).
+
+**Step 4:** Open the symbols sidebar again and the symbols should appear quickly. Hover popovers and jump-to-definition via search-based code intelligence should also respond quickly.
+
+That's it! New commits will be indexed automatically when users visit them.
 
 ## How long does indexing take?
 

--- a/doc/code_intelligence/explanations/rockskip.md
+++ b/doc/code_intelligence/explanations/rockskip.md
@@ -78,7 +78,7 @@ For other deployments, make sure that:
 1. Click on the branch selector, click **Commits**, and select the second most recent commit (this avoids routing the request to Zoekt)
 1. Open the symbols sidebar to kick off indexing (it's ok to see a loading spinner, that probably means indexing is in progress)
 
-**Step 3:** See the section below to [check on the indexing status](#how-do-i-check-the-indexing-status).
+**Step 3:** Check the indexing status by following the [instructions below](#how-do-i-check-the-indexing-status).
 
 **Step 4:** Open the symbols sidebar again and the symbols should appear quickly. Hover popovers and jump-to-definition via search-based code intelligence should also respond quickly.
 

--- a/enterprise/internal/rockskip/status.go
+++ b/enterprise/internal/rockskip/status.go
@@ -3,6 +3,7 @@ package rockskip
 import (
 	"fmt"
 	"net/http"
+	"os"
 	"sort"
 	"strings"
 	"sync"
@@ -94,7 +95,26 @@ func (s *Service) HandleStatus(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprintln(w, "This is the symbols service status page.")
 	fmt.Fprintln(w, "")
 
-	fmt.Fprintf(w, "Number of repositories: %d\n", repositoryCount)
+	if os.Getenv("ROCKSKIP_REPOS") == "" {
+		fmt.Fprintln(w, "⚠️ Rockskip is not enabled for any repositories. Remember to set the ROCKSKIP_REPOS environment variable and restart the symbols service.")
+		fmt.Fprintln(w, "")
+	} else {
+		fmt.Fprintln(w, "Rockskip is enabled for these repositories:")
+		for _, repo := range strings.Split(os.Getenv("ROCKSKIP_REPOS"), ",") {
+			fmt.Fprintln(w, "  "+repo)
+		}
+		fmt.Fprintln(w, "")
+
+		if repositoryCount == 0 {
+			fmt.Fprintln(w, "⚠️ None of the enabled repositories have been indexed yet!")
+			fmt.Fprintln(w, "⚠️ Open the symbols sidebar on a repository with Rockskip enabled to trigger indexing.")
+			fmt.Fprintln(w, "⚠️ Check the logs for errors if requests fail or if there are no in-flight requests below.")
+			fmt.Fprintln(w, "⚠️ Docs: https://docs.sourcegraph.com/code_intelligence/explanations/rockskip")
+			fmt.Fprintln(w, "")
+		}
+	}
+
+	fmt.Fprintf(w, "Number of rows in rockskip_repos: %d\n", repositoryCount)
 	fmt.Fprintf(w, "Size of symbols table: %s\n", symbolsSize)
 	fmt.Fprintln(w, "")
 


### PR DESCRIPTION
This should help site admins get set up.

Inspired by https://github.com/sourcegraph/customer/issues/976, also see [Slack](https://sourcegraph.slack.com/archives/C02BQBNJVL0/p1654103434295909?thread_ts=1653959717.867999&amp;cid=C02BQBNJVL0).

## Test plan

N/A