### PR TITLE
[SG-34530] Accessibility:  Focus outline on tabs pushes content down

### DIFF
--- a/client/wildcard/src/components/Tabs/Tabs.module.scss
+++ b/client/wildcard/src/components/Tabs/Tabs.module.scss
@@ -60,7 +60,7 @@
             box-shadow: none;
             > .tab-label {
                 padding: 0.125rem;
-                margin: 0 -0.125rem;
+                margin: -0.125rem;
                 border-radius: var(--border-radius);
                 outline: 1px solid transparent;
                 box-shadow: var(--focus-box-shadow);


### PR DESCRIPTION
### Audit type
Keyboard navigation

### User journey audit issue
[#34080](https://github.com/sourcegraph/sourcegraph/issues/34080)

### Problem description
<img width="1139" alt="outline2" src="https://user-images.githubusercontent.com/50766123/170456925-0bde14b5-a486-41ea-a59b-0b036ce73243.png">

<img width="1148" alt="outline2" src="https://user-images.githubusercontent.com/50766123/170456411-51159456-e504-4754-8ab2-bc75d3119bd1.png">


### Expected behavior
It doesn't cause the tab header bar to grow.

## Refs
[Sourcegraph Issue](https://github.com/sourcegraph/sourcegraph/issues/34530)
[Gitstart Ticket](https://app.gitstart.com/clients/sourcegraph/tickets/SG-34530)

## Description: Short description about changes on this PR
Removed the extra margin that is added around focus outline on tabs which pushes content down 

## Test plan
Focus outline on tabs shouldn't cause the tab header bar to grow.

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->



## App preview:

- [Web](https://sg-web-contractors-sg-34530.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-mhfubfflnj.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
