### PR TITLE
doc/integrations: add unofficial Raycast extension

### DIFF
--- a/doc/integration/index.md
+++ b/doc/integration/index.md
@@ -24,6 +24,8 @@ Sourcegraph integrates with your other tools to help you search, navigate, and r
   - [View all "External services" extensions](https://sourcegraph.com/extensions?query=category%3A%22External+services%22)
 - [Editor plugins](editor.md): jump to Sourcegraph from your editor
 - [Search shortcuts](browser_search_engine.md): quickly search from your browser
+- Launcher extensions
+  - [Sourcegraph for Raycast](https://www.raycast.com/bobheadxi/sourcegraph) (unofficial): search code, browse notebooks, and manage batch changes from the Raycast launcher
 - [GraphQL API](../api/graphql/index.md): create custom tools using Sourcegraph data
 
 ![GitHub pull request integration](img/GitHubDiff.png)


### PR DESCRIPTION
Adds my unofficial Raycast for Sourcegraph extension to the integrations list 😛 

- https://www.raycast.com/bobheadxi/sourcegraph
- Source:  https://github.com/bobheadxi/raycast-sourcegraph
- Tweet: https://twitter.com/sourcegraph/status/1512130089999376387

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

<img width="827" alt="image" src="https://user-images.githubusercontent.com/23356519/170890075-9adcc4d5-aabc-4cf4-ba17-09325526cea2.png">
