### PR TITLE
Diable flaky TestGetBatchChangesUsageStatistics

### DIFF
--- a/internal/usagestats/batches_test.go
+++ b/internal/usagestats/batches_test.go
@@ -17,6 +17,8 @@ import (
 )
 
 func TestGetBatchChangesUsageStatistics(t *testing.T) {
+	t.Skip("2022-05-30 disabled because it fails near end of month")
+
 	ctx := context.Background()
 	db := database.NewDB(dbtest.NewDB(t))
 


### PR DESCRIPTION
As per our [principles](https://docs.sourcegraph.com/dev/background-information/testing_principles#flaky-tests) I'm disabling this test for now since it was [reported as being flaky](https://sourcegraph.slack.com/archives/CMMTWQQ49/p1653877672077159).

## Test plan

- CI