### PR TITLE
ci: disable TestGetBatchChanges... in backcompat.

### DIFF
--- a/dev/ci/go-backcompat/flakefiles/v3.40.0.json
+++ b/dev/ci/go-backcompat/flakefiles/v3.40.0.json
@@ -23,5 +23,10 @@
     "path": "internal/database",
     "prefix": "TestListIndexableRepos",
     "reason": "Database semantics changed: every created repo has a corresponding gitserver_repo entry right after being inserted in repo table (https://github.com/sourcegraph/sourcegraph/pull/35633)"
+  },
+  {
+    "path": "internal/usagestats",
+    "prefix": "TestGetBatchChangesUsageStatistics",
+    "reason": "Flaky test, reflects disabling PR https://github.com/sourcegraph/sourcegraph/pull/36216 in the backcompat tests."
   }
 ]


### PR DESCRIPTION
Disables TestGetBatchChangesUsageStatistics also in backcompat.

Follow-up of https://github.com/sourcegraph/sourcegraph/pull/36216 

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Should not see flakes on that specific test anymore. 