### PR TITLE
batches: fix TestGetBatchChangesUsageStatistics flakiness

### DIFF
--- a/internal/usagestats/batches_test.go
+++ b/internal/usagestats/batches_test.go
@@ -70,9 +70,10 @@ func TestGetBatchChangesUsageStatistics(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Due to irregularity with date libraries, subtracting a month from a date most times deducts
-	// 30 days from the current date. For months like February which has 28 days and those with 31 days
-	// this poses a problem. Therefore deducting three days after the initial month deduction ensures we'd
+	// Due to irregularity in the amount of days in a month, subtracting a month from a date most times deducts
+	// 30 days from the current date which is incorrect becayse or months like February which has 28 days and those with 31 days
+	// this poses a problem.
+	//Therefore deducting three days after the initial month deduction ensures we'll
 	// always get a date that falls in the previous month regardless of the day in question.
 	lastMonthCreationDate := now.AddDate(0, -1, -3)
 	twoMonthsAgoCreationDate := now.AddDate(0, -2, -3)

--- a/internal/usagestats/batches_test.go
+++ b/internal/usagestats/batches_test.go
@@ -70,8 +70,8 @@ func TestGetBatchChangesUsageStatistics(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Due to irregularity in the amount of days in a month, subtracting a month from a date most times deducts
-	// 30 days from the current date which is incorrect becayse or months like February which has 28 days and those with 31 days
+	// Due to irregularity in the amount of days in a month, subtracting simply a month from a date can deduct
+	// 30 days, but that's incorrect because not every month has 30 days.
 	// this poses a problem.
 	// Therefore deducting three days after the initial month deduction ensures we'll
 	// always get a date that falls in the previous month regardless of the day in question.

--- a/internal/usagestats/batches_test.go
+++ b/internal/usagestats/batches_test.go
@@ -18,8 +18,6 @@ import (
 )
 
 func TestGetBatchChangesUsageStatistics(t *testing.T) {
-	t.Skip("2022-05-30 disabled because it fails near end of month")
-
 	ctx := context.Background()
 	db := database.NewDB(dbtest.NewDB(t))
 

--- a/internal/usagestats/batches_test.go
+++ b/internal/usagestats/batches_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/derision-test/glock"
 	"github.com/google/go-cmp/cmp"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
@@ -26,7 +27,11 @@ func TestGetBatchChangesUsageStatistics(t *testing.T) {
 	repoStore := db.Repos()
 	esStore := db.ExternalServices()
 
-	now := time.Now()
+	// making use of a mock clock here to ensure all time operations are appropriately mocked
+	// https://docs.sourcegraph.com/dev/background-information/languages/testing_go_code#testing-time
+	clock := glock.NewMockClock()
+	now := clock.Now()
+
 	svc := types.ExternalService{
 		Kind:        extsvc.KindGitHub,
 		DisplayName: "Github - Test",
@@ -67,8 +72,12 @@ func TestGetBatchChangesUsageStatistics(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	lastMonthCreationDate := now.AddDate(0, -1, 2)
-	twoMonthsAgoCreationDate := now.AddDate(0, -2, 2)
+	// Due to irregularity with date libraries, subtracting a month from a date most times deducts
+	// 30 days from the current date. For months like February which has 28 days and those with 31 days
+	// this poses a problem. Therefore deducting three days after the initial month deduction ensures we'd
+	// always get a date that falls in the previous month regardless of the day in question.
+	lastMonthCreationDate := now.AddDate(0, -1, -3)
+	twoMonthsAgoCreationDate := now.AddDate(0, -2, -3)
 
 	// Create batch specs
 	_, err = db.ExecContext(context.Background(), `

--- a/internal/usagestats/batches_test.go
+++ b/internal/usagestats/batches_test.go
@@ -72,8 +72,7 @@ func TestGetBatchChangesUsageStatistics(t *testing.T) {
 
 	// Due to irregularity in the amount of days in a month, subtracting simply a month from a date can deduct
 	// 30 days, but that's incorrect because not every month has 30 days.
-	// this poses a problem.
-	// Therefore deducting three days after the initial month deduction ensures we'll
+	// This poses a problem, therefore deducting three days after the initial month deduction ensures we'll
 	// always get a date that falls in the previous month regardless of the day in question.
 	lastMonthCreationDate := now.AddDate(0, -1, -3)
 	twoMonthsAgoCreationDate := now.AddDate(0, -2, -3)

--- a/internal/usagestats/batches_test.go
+++ b/internal/usagestats/batches_test.go
@@ -73,7 +73,7 @@ func TestGetBatchChangesUsageStatistics(t *testing.T) {
 	// Due to irregularity in the amount of days in a month, subtracting a month from a date most times deducts
 	// 30 days from the current date which is incorrect becayse or months like February which has 28 days and those with 31 days
 	// this poses a problem.
-	//Therefore deducting three days after the initial month deduction ensures we'll
+	// Therefore deducting three days after the initial month deduction ensures we'll
 	// always get a date that falls in the previous month regardless of the day in question.
 	lastMonthCreationDate := now.AddDate(0, -1, -3)
 	twoMonthsAgoCreationDate := now.AddDate(0, -2, -3)


### PR DESCRIPTION

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
Ensured date calculation towards the end of the month doesn't fail by adding an offset when calculating month duration.