### PR TITLE
JetBrains: Fix errors when loading with no prior search saved

### DIFF
--- a/client/jetbrains/src/main/java/com/sourcegraph/browser/JSToJavaBridgeRequestHandler.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/browser/JSToJavaBridgeRequestHandler.java
@@ -52,6 +52,11 @@ public class JSToJavaBridgeRequestHandler {
                     return createSuccessResponse(new JsonObject());
                 case "loadLastSearch":
                     Search lastSearch = ConfigUtil.getLastSearch(this.project);
+
+                    if (lastSearch != null) {
+                        return createSuccessResponse(null);
+                    }
+
                     JsonObject lastSearchAsJson = new JsonObject();
                     lastSearchAsJson.addProperty("query", lastSearch.getQuery());
                     lastSearchAsJson.addProperty("caseSensitive", lastSearch.isCaseSensitive());
@@ -94,7 +99,7 @@ public class JSToJavaBridgeRequestHandler {
 
     @NotNull
     private JBCefJSQuery.Response createSuccessResponse(@Nullable JsonObject result) {
-        return new JBCefJSQuery.Response(result != null ? result.toString() : "{}");
+        return new JBCefJSQuery.Response(result != null ? result.toString() : "null");
     }
 
     @NotNull

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/ConfigUtil.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/ConfigUtil.java
@@ -36,7 +36,6 @@ public class ConfigUtil {
         return url.endsWith("/") ? url : url + "/";
     }
 
-    @NotNull
     public static Search getLastSearch(@NotNull Project project) {
         return getProjectLevelConfig(project).getLastSearch();
     }

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/ConfigUtil.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/ConfigUtil.java
@@ -36,6 +36,7 @@ public class ConfigUtil {
         return url.endsWith("/") ? url : url + "/";
     }
 
+    @Nullable
     public static Search getLastSearch(@NotNull Project project) {
         return getProjectLevelConfig(project).getLastSearch();
     }

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/SourcegraphConfig.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/SourcegraphConfig.java
@@ -43,6 +43,7 @@ class SourcegraphConfig implements PersistentStateComponent<SourcegraphConfig> {
         return remoteUrlReplacements;
     }
 
+    @Nullable
     public Search getLastSearch() {
         if (lastSearchQuery == null) {
             return null;

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/SourcegraphConfig.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/SourcegraphConfig.java
@@ -43,9 +43,12 @@ class SourcegraphConfig implements PersistentStateComponent<SourcegraphConfig> {
         return remoteUrlReplacements;
     }
 
-    @NotNull
     public Search getLastSearch() {
-        return new Search(lastSearchQuery, lastSearchCaseSensitive, lastSearchPatternType, lastSearchContextSpec);
+        if (lastSearchQuery == null) {
+            return null;
+        } else {
+            return new Search(lastSearchQuery, lastSearchCaseSensitive, lastSearchPatternType, lastSearchContextSpec);
+        }
     }
 
     public boolean isGlobbingEnabled() {


### PR DESCRIPTION
This fixes an issue that we're seeing whenever someone is testing the extension for the first time.

The problem here is that we used to return an object for the previous search consistent of a lot of null values. E.g. `query: null`. The JS code however expects the value to be `null` _or_ a valid `LastSearch` type.

I've made changes to properly handle `null` in the bridge and return `null` in the case that there is no last search.

## Test plan

https://www.loom.com/share/6f05c9c6bbe14af18aa584c3fe06bc3e

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-jetbrains-fix-no-prev-search.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-ltokslhwan.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
