### PR TITLE
codeintel: expose tags associated with index's commit

### DIFF
--- a/client/web/src/enterprise/codeintel/indexes/components/CodeIntelIndexMeta.tsx
+++ b/client/web/src/enterprise/codeintel/indexes/components/CodeIntelIndexMeta.tsx
@@ -4,6 +4,7 @@ import { CardSubtitle, CardText, CardTitle, CardBody, Card } from '@sourcegraph/
 
 import { LsifIndexFields } from '../../../../graphql-operations'
 import { CodeIntelUploadOrIndexCommit } from '../../shared/components/CodeIntelUploadOrIndexCommit'
+import { CodeIntelUploadOrIndexCommitTags } from '../../shared/components/CodeIntelUploadOrIndexCommitTags'
 import { CodeIntelUploadOrIndexRepository } from '../../shared/components/CodeIntelUploadOrIndexerRepository'
 import { CodeIntelUploadOrIndexIndexer } from '../../shared/components/CodeIntelUploadOrIndexIndexer'
 import { CodeIntelUploadOrIndexLastActivity } from '../../shared/components/CodeIntelUploadOrIndexLastActivity'
@@ -31,6 +32,8 @@ export const CodeIntelIndexMeta: FunctionComponent<React.PropsWithChildren<CodeI
             <CardText>
                 Directory <CodeIntelUploadOrIndexRoot node={node} /> indexed at commit{' '}
                 <CodeIntelUploadOrIndexCommit node={node} /> by <CodeIntelUploadOrIndexIndexer node={node} />
+                {', '}
+                <CodeIntelUploadOrIndexCommitTags tags={node.tags} />{' '}
             </CardText>
         </CardBody>
     </Card>

--- a/client/web/src/enterprise/codeintel/indexes/components/CodeIntelIndexNode.tsx
+++ b/client/web/src/enterprise/codeintel/indexes/components/CodeIntelIndexNode.tsx
@@ -8,6 +8,7 @@ import { Link, Typography } from '@sourcegraph/wildcard'
 import { LsifIndexFields } from '../../../../graphql-operations'
 import { CodeIntelState } from '../../shared/components/CodeIntelState'
 import { CodeIntelUploadOrIndexCommit } from '../../shared/components/CodeIntelUploadOrIndexCommit'
+import { CodeIntelUploadOrIndexCommitTags } from '../../shared/components/CodeIntelUploadOrIndexCommitTags'
 import { CodeIntelUploadOrIndexRepository } from '../../shared/components/CodeIntelUploadOrIndexerRepository'
 import { CodeIntelUploadOrIndexIndexer } from '../../shared/components/CodeIntelUploadOrIndexIndexer'
 import { CodeIntelUploadOrIndexLastActivity } from '../../shared/components/CodeIntelUploadOrIndexLastActivity'
@@ -37,7 +38,13 @@ export const CodeIntelIndexNode: FunctionComponent<React.PropsWithChildren<CodeI
             <div>
                 <span className="mr-2 d-block d-mdinline-block">
                     Directory <CodeIntelUploadOrIndexRoot node={node} /> indexed at commit{' '}
-                    <CodeIntelUploadOrIndexCommit node={node} /> by <CodeIntelUploadOrIndexIndexer node={node} />
+                    <CodeIntelUploadOrIndexCommit node={node} />
+                    {node.tags.length > 0 && (
+                        <>
+                            , <CodeIntelUploadOrIndexCommitTags tags={node.tags} />,
+                        </>
+                    )}{' '}
+                    by <CodeIntelUploadOrIndexIndexer node={node} />
                 </span>
 
                 <small className="text-mute">

--- a/client/web/src/enterprise/codeintel/indexes/hooks/types.tsx
+++ b/client/web/src/enterprise/codeintel/indexes/hooks/types.tsx
@@ -5,6 +5,7 @@ export const lsifIndexFieldsFragment = gql`
         __typename
         id
         inputCommit
+        tags
         inputRoot
         inputIndexer
         indexer {

--- a/client/web/src/enterprise/codeintel/indexes/pages/CodeIntelIndexPage.story.tsx
+++ b/client/web/src/enterprise/codeintel/indexes/pages/CodeIntelIndexPage.story.tsx
@@ -365,6 +365,7 @@ const failedSteps: LsifIndexStepsFields = {
 const indexPrototype: Omit<LsifIndexFields, 'id' | 'state' | 'queuedAt' | 'steps'> = {
     __typename: 'LSIFIndex',
     inputCommit: '',
+    tags: [],
     inputRoot: 'staging/src/k8s.io/apiextensions-apiserver/',
     inputIndexer: 'sourcegraph/lsif-go:latest',
     indexer: { name: 'lsif-go', url: '' },
@@ -446,6 +447,7 @@ Completed.args = {
             ...indexPrototype,
             id: '1',
             state: LSIFIndexState.COMPLETED,
+            tags: ['v4.2.0', 'v1.0.5', 'latest-banana-phone'],
             queuedAt: '2020-06-15T17:50:01+00:00',
             startedAt: '2020-06-15T17:56:01+00:00',
             finishedAt: '2020-06-15T18:00:10+00:00',

--- a/client/web/src/enterprise/codeintel/indexes/pages/CodeIntelIndexesPage.story.tsx
+++ b/client/web/src/enterprise/codeintel/indexes/pages/CodeIntelIndexesPage.story.tsx
@@ -18,6 +18,7 @@ const executionLogPrototype: ExecutionLogEntryFields = {
 const indexPrototype: Omit<LsifIndexFields, 'id' | 'state' | 'queuedAt'> = {
     __typename: 'LSIFIndex',
     inputCommit: '',
+    tags: [],
     inputRoot: 'web/',
     inputIndexer: 'scip-typescript',
     indexer: { name: 'scip-typescript', url: '' },
@@ -74,6 +75,7 @@ const testIndexes: LsifIndexFields[] = [
         ...indexPrototype,
         id: '2',
         state: LSIFIndexState.COMPLETED,
+        tags: ['v0.4.2'],
         queuedAt: '2020-06-14T12:20:30+00:00',
         startedAt: '2020-06-14T12:25:30+00:00',
         finishedAt: '2020-06-14T12:30:30+00:00',

--- a/cmd/frontend/graphqlbackend/codeintel.go
+++ b/cmd/frontend/graphqlbackend/codeintel.go
@@ -137,6 +137,7 @@ type LSIFRepositoryIndexesQueryArgs struct {
 type LSIFIndexResolver interface {
 	ID() graphql.ID
 	InputCommit() string
+	Tags(ctx context.Context) ([]string, error)
 	InputRoot() string
 	InputIndexer() string
 	Indexer() CodeIntelIndexerResolver

--- a/cmd/frontend/graphqlbackend/codeintel.graphql
+++ b/cmd/frontend/graphqlbackend/codeintel.graphql
@@ -1113,6 +1113,11 @@ type LSIFIndex implements Node {
     inputCommit: String!
 
     """
+    The tags, if any, associated with this commit.
+    """
+    tags: [String!]!
+
+    """
     The original root supplied at index schedule time.
     """
     inputRoot: String!

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/index.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/index.go
@@ -58,6 +58,17 @@ func (r *IndexResolver) Steps() gql.IndexStepsResolver {
 }
 func (r *IndexResolver) PlaceInQueue() *int32 { return toInt32(r.index.Rank) }
 
+func (r *IndexResolver) Tags(ctx context.Context) (tagsNames []string, err error) {
+	tags, err := r.gitserver.ListTags(ctx, api.RepoName(r.index.RepositoryName), r.index.Commit)
+	if err != nil {
+		return nil, err
+	}
+	for _, tag := range tags {
+		tagsNames = append(tagsNames, tag.Name)
+	}
+	return
+}
+
 func (r *IndexResolver) State() string {
 	state := strings.ToUpper(r.index.State)
 	if state == "FAILED" {

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/index_connection.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/index_connection.go
@@ -25,6 +25,7 @@ type IndexConnectionResolver struct {
 func NewIndexConnectionResolver(db database.DB, gitserver GitserverClient, resolver resolvers.Resolver, indexesResolver *resolvers.IndexesResolver, prefetcher *Prefetcher, locationResolver *CachedLocationResolver, errTracer *observation.ErrCollector) gql.LSIFIndexConnectionResolver {
 	return &IndexConnectionResolver{
 		db:               db,
+		gitserver:        gitserver,
 		resolver:         resolver,
 		indexesResolver:  indexesResolver,
 		prefetcher:       prefetcher,


### PR DESCRIPTION
Same thing as https://github.com/sourcegraph/sourcegraph/pull/35147, except for index list/page instead of upload.

## Test plan

Storybooks updated and tested manually
