### PR TITLE
Update docsite to v1.8.7

### DIFF
--- a/dev/docsite.sh
+++ b/dev/docsite.sh
@@ -5,7 +5,7 @@ set -euf -o pipefail
 pushd "$(dirname "${BASH_SOURCE[0]}")/.." >/dev/null
 
 # Update DOCSITE_VERSION everywhere in all places (including outside this repo)
-version=v1.8.6
+version=v1.8.7
 suffix="${version}_$(go env GOOS)_$(go env GOARCH)"
 url="https://github.com/sourcegraph/docsite/releases/download/${version}/docsite_${suffix}"
 

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -340,7 +340,7 @@ commands:
         -o .bin/docsite_${DOCSITE_VERSION} && chmod +x .bin/docsite_${DOCSITE_VERSION}
       fi
     env:
-      DOCSITE_VERSION: v1.8.6 # Update DOCSITE_VERSION in all places (including outside this repo)
+      DOCSITE_VERSION: v1.8.7 # Update DOCSITE_VERSION in all places (including outside this repo)
 
   syntax-highlighter:
     ignoreStdout: true
@@ -975,4 +975,4 @@ tests:
   docsite:
     cmd: .bin/docsite_${DOCSITE_VERSION} check ./doc
     env:
-      DOCSITE_VERSION: v1.8.6 # Update DOCSITE_VERSION everywhere in all places (including outside this repo)
+      DOCSITE_VERSION: v1.8.7 # Update DOCSITE_VERSION everywhere in all places (including outside this repo)


### PR DESCRIPTION
Update docsite to 1.8.7, which fixes a small issue with the linter incorrectly picking up on csv links (see https://github.com/sourcegraph/sourcegraph/pull/35538#issuecomment-1136947293) 

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Locally ran the docsite linter and task and checked that the new release is there. 
