### PR TITLE
Wildcard/Tabs: debounce the auto scroll-back

### DIFF
--- a/client/wildcard/src/components/Tabs/useScrollBackToActive.ts
+++ b/client/wildcard/src/components/Tabs/useScrollBackToActive.ts
@@ -4,26 +4,38 @@ import { useMatchMedia } from '@sourcegraph/wildcard'
 
 import { useTabsState } from './context'
 
+import { debounce } from 'lodash'
+
+const SCROLL_BACK_WAIT = 500
+
 export function useScrollBackToActive<T extends HTMLElement>(
     containerReference: React.MutableRefObject<T | null>
 ): void {
     const { activeIndex } = useTabsState()
     const isReducedMotion = useMatchMedia('(prefers-reduced-motion: reduce)')
 
-    const scrollBack = React.useCallback(() => {
-        if (containerReference?.current) {
-            containerReference.current.children.item(activeIndex)?.scrollIntoView({
-                behavior: isReducedMotion ? 'auto' : 'smooth',
-                inline: 'center',
-            })
-        }
+    const scrollBack = React.useMemo(() => {
+        return debounce(() => {
+            if (containerReference?.current) {
+                containerReference.current.children.item(activeIndex)?.scrollIntoView({
+                    behavior: isReducedMotion ? 'auto' : 'smooth',
+                    inline: 'center',
+                })
+            }
+        }, SCROLL_BACK_WAIT)
     }, [activeIndex, containerReference, isReducedMotion])
+
+    const cancelScrollBack = React.useCallback(() => {
+        scrollBack.cancel()
+    }, [scrollBack])
 
     React.useEffect(() => {
         const container = containerReference?.current
+        container?.addEventListener('mouseenter', cancelScrollBack)
         container?.addEventListener('mouseleave', scrollBack)
         return () => {
+            container?.removeEventListener('mouseenter', cancelScrollBack)
             container?.removeEventListener('mouseleave', scrollBack)
         }
-    }, [containerReference, scrollBack])
+    }, [containerReference, scrollBack, cancelScrollBack])
 }


### PR DESCRIPTION
A follow-up to the [scroll-back PR](https://github.com/sourcegraph/sourcegraph/pull/35951). 
This debounces the scroll-back behavior by `500ms` so that it's less confusing for the users.


https://user-images.githubusercontent.com/2196347/171007422-a12966b3-cccc-4a52-a927-e2cc46602769.mov

## Test plan

1. Pull the branch
2. Run `yarn storybook:wildcard`
3. Make sure tabs aren't scrolled back immediately as the mouse leaves their area