### PR TITLE
gitserver: remove ArchiveURL

### DIFF
--- a/cmd/frontend/internal/httpapi/httpapi.go
+++ b/cmd/frontend/internal/httpapi/httpapi.go
@@ -163,7 +163,6 @@ func NewInternalHandler(m *mux.Router, db database.DB, schema *graphql.Schema, n
 	m.Get(apirouter.SendEmail).Handler(trace.Route(handler(serveSendEmail)))
 	m.Get(apirouter.GitExec).Handler(trace.Route(handler(serveGitExec(db))))
 	m.Get(apirouter.GitResolveRevision).Handler(trace.Route(handler(serveGitResolveRevision(db))))
-	m.Get(apirouter.GitTar).Handler(trace.Route(handler(serveGitTar(db))))
 	gitService := &gitServiceHandler{
 		Gitserver: gitserver.NewClient(db),
 	}

--- a/cmd/frontend/internal/httpapi/internal.go
+++ b/cmd/frontend/internal/httpapi/internal.go
@@ -292,39 +292,6 @@ func serveGitResolveRevision(db database.DB) func(w http.ResponseWriter, r *http
 	}
 }
 
-func serveGitTar(db database.DB) func(w http.ResponseWriter, r *http.Request) error {
-	return func(w http.ResponseWriter, r *http.Request) error {
-		// used by zoekt-sourcegraph-mirror
-		vars := mux.Vars(r)
-		name := vars["RepoName"]
-		spec := vars["Commit"]
-
-		// Ensure commit exists. Do not want to trigger a repo-updater lookup since this is a batch job.
-		repo := api.RepoName(name)
-		ctx := r.Context()
-		gitserverClient := gitserver.NewClient(db)
-		commit, err := gitserverClient.ResolveRevision(ctx, repo, spec, gitserver.ResolveRevisionOptions{})
-		if err != nil {
-			return err
-		}
-
-		opts := gitserver.ArchiveOptions{
-			Treeish: string(commit),
-			Format:  "tar",
-		}
-
-		location, err := gitserverClient.ArchiveURL(ctx, repo, opts)
-		if err != nil {
-			return err
-		}
-
-		w.Header().Set("Location", location.String())
-		w.WriteHeader(http.StatusFound)
-
-		return nil
-	}
-}
-
 func serveGitExec(db database.DB) func(http.ResponseWriter, *http.Request) error {
 	return func(w http.ResponseWriter, r *http.Request) error {
 		defer r.Body.Close()

--- a/cmd/frontend/internal/httpapi/router/router.go
+++ b/cmd/frontend/internal/httpapi/router/router.go
@@ -40,7 +40,6 @@ const (
 	GitExec                = "internal.git.exec"
 	GitInfoRefs            = "internal.git.info-refs"
 	GitResolveRevision     = "internal.git.resolve-revision"
-	GitTar                 = "internal.git.tar"
 	GitUploadPack          = "internal.git.upload-pack"
 	PhabricatorRepoCreate  = "internal.phabricator.repo.create"
 	ReposGetByName         = "internal.repos.get-by-name"
@@ -108,7 +107,6 @@ func NewInternal(base *mux.Router) *mux.Router {
 	base.Path("/git/{RepoID:[0-9]+}/exec").Methods("POST").Name(GitExec)
 	base.Path("/git/{RepoName:.*}/info/refs").Methods("GET").Name(GitInfoRefs)
 	base.Path("/git/{RepoName:.*}/resolve-revision/{Spec}").Methods("GET").Name(GitResolveRevision)
-	base.Path("/git/{RepoName:.*}/tar/{Commit}").Methods("GET").Name(GitTar)
 	base.Path("/git/{RepoName:.*}/git-upload-pack").Methods("GET", "POST").Name(GitUploadPack)
 	base.Path("/phabricator/repo-create").Methods("POST").Name(PhabricatorRepoCreate)
 	base.Path("/external-services/configs").Methods("POST").Name(ExternalServiceConfigs)

--- a/internal/gitserver/client.go
+++ b/internal/gitserver/client.go
@@ -169,10 +169,6 @@ type Client interface {
 	// Archive produces an archive from a Git repository.
 	Archive(context.Context, api.RepoName, ArchiveOptions) (io.ReadCloser, error)
 
-	// ArchiveURL returns a URL from which an archive of the given Git repository can
-	// be downloaded from.
-	ArchiveURL(context.Context, api.RepoName, ArchiveOptions) (*url.URL, error)
-
 	// BatchLog invokes the given callback with the `git log` output for a batch of repository
 	// and commit pairs. If the invoked callback returns a non-nil error, the operation will begin
 	// to abort processing further results.
@@ -415,9 +411,9 @@ func (a *archiveReader) Close() error {
 	return a.base.Close()
 }
 
-// ArchiveURL returns a URL from which an archive of the given Git repository can
+// archiveURL returns a URL from which an archive of the given Git repository can
 // be downloaded from.
-func (c *ClientImplementor) ArchiveURL(ctx context.Context, repo api.RepoName, opt ArchiveOptions) (*url.URL, error) {
+func (c *ClientImplementor) archiveURL(ctx context.Context, repo api.RepoName, opt ArchiveOptions) (*url.URL, error) {
 	q := url.Values{
 		"repo":    {string(repo)},
 		"treeish": {opt.Treeish},
@@ -461,7 +457,7 @@ func (c *ClientImplementor) Archive(ctx context.Context, repo api.RepoName, opt 
 		return nil, err
 	}
 
-	u, err := c.ArchiveURL(ctx, repo, opt)
+	u, err := c.archiveURL(ctx, repo, opt)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The only user of this was an internal endpoint which used to be used by
zoekt. Zoekt removed its use of Sourcegraph archive a few months ago so
it is no longer needed. Additionally, I confirmed on sourcegraph.com
that the route had not been used in the last 30 days via the prometheus
query

```promql
max_over_time(src_http_requests_last_timestamp_unixtime{route="internal.git.tar"}[30d])
```

Test Plan: CI