### PR TITLE
refactor(repo-updater): update repo.Store to use lib/log

### DIFF
--- a/cmd/repo-updater/repoupdater/server_test.go
+++ b/cmd/repo-updater/repoupdater/server_test.go
@@ -162,7 +162,7 @@ func TestServer_EnqueueRepoUpdate(t *testing.T) {
 	}
 
 	initStore := func(db database.DB) repos.Store {
-		store := repos.NewStore(db, sql.TxOptions{})
+		store := repos.NewStore(logtest.Scoped(t), db, sql.TxOptions{})
 		if err := store.ExternalServiceStore().Upsert(ctx, &svc); err != nil {
 			t.Fatal(err)
 		}
@@ -237,7 +237,7 @@ func TestServer_EnqueueRepoUpdate(t *testing.T) {
 
 func TestServer_RepoLookup(t *testing.T) {
 	db := dbtest.NewDB(t)
-	store := repos.NewStore(database.NewDB(db), sql.TxOptions{})
+	store := repos.NewStore(logtest.Scoped(t), database.NewDB(db), sql.TxOptions{})
 	ctx := context.Background()
 	clock := timeutil.NewFakeClock(time.Now(), 0)
 	now := clock.Now()

--- a/cmd/repo-updater/shared/main.go
+++ b/cmd/repo-updater/shared/main.go
@@ -119,7 +119,7 @@ func Main(enterpriseInit EnterpriseInit) {
 
 	repos.MustRegisterMetrics(db, envvar.SourcegraphDotComMode())
 
-	store := repos.NewStore(db, sql.TxOptions{Isolation: sql.LevelDefault})
+	store := repos.NewStore(logger.Scoped("store", "repo store"), db, sql.TxOptions{Isolation: sql.LevelDefault})
 	{
 		m := repos.NewStoreMetrics()
 		m.MustRegister(prometheus.DefaultRegisterer)

--- a/enterprise/cmd/repo-updater/internal/authz/integration_test.go
+++ b/enterprise/cmd/repo-updater/internal/authz/integration_test.go
@@ -91,7 +91,7 @@ func TestIntegration_GitHubPermissions(t *testing.T) {
 			testDB := dbtest.NewDB(t)
 			ctx := actor.WithInternalActor(context.Background())
 
-			reposStore := repos.NewStore(database.NewDB(testDB), sql.TxOptions{})
+			reposStore := repos.NewStore(logtest.Scoped(t), database.NewDB(testDB), sql.TxOptions{})
 
 			err = reposStore.ExternalServiceStore().Upsert(ctx, &svc)
 			if err != nil {
@@ -172,7 +172,7 @@ func TestIntegration_GitHubPermissions(t *testing.T) {
 			testDB := dbtest.NewDB(t)
 			ctx := actor.WithInternalActor(context.Background())
 
-			reposStore := repos.NewStore(database.NewDB(testDB), sql.TxOptions{})
+			reposStore := repos.NewStore(logtest.Scoped(t), database.NewDB(testDB), sql.TxOptions{})
 
 			err = reposStore.ExternalServiceStore().Upsert(ctx, &svc)
 			if err != nil {
@@ -276,7 +276,7 @@ func TestIntegration_GitHubPermissions(t *testing.T) {
 			testDB := dbtest.NewDB(t)
 			ctx := actor.WithInternalActor(context.Background())
 
-			reposStore := repos.NewStore(database.NewDB(testDB), sql.TxOptions{})
+			reposStore := repos.NewStore(logtest.Scoped(t), database.NewDB(testDB), sql.TxOptions{})
 
 			err = reposStore.ExternalServiceStore().Upsert(ctx, &svc)
 			if err != nil {
@@ -360,7 +360,7 @@ func TestIntegration_GitHubPermissions(t *testing.T) {
 			testDB := dbtest.NewDB(t)
 			ctx := actor.WithInternalActor(context.Background())
 
-			reposStore := repos.NewStore(database.NewDB(testDB), sql.TxOptions{})
+			reposStore := repos.NewStore(logtest.Scoped(t), database.NewDB(testDB), sql.TxOptions{})
 
 			err = reposStore.ExternalServiceStore().Upsert(ctx, &svc)
 			if err != nil {

--- a/enterprise/cmd/repo-updater/internal/authz/perms_syncer_test.go
+++ b/enterprise/cmd/repo-updater/internal/authz/perms_syncer_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/timeutil"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"github.com/sourcegraph/sourcegraph/lib/log/logtest"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
@@ -157,7 +158,7 @@ func TestPermsSyncer_syncUserPerms(t *testing.T) {
 	db.UserEmailsFunc.SetDefaultReturn(userEmails)
 	db.UserExternalAccountsFunc.SetDefaultReturn(externalAccounts)
 
-	reposStore := repos.NewMockStoreFrom(repos.NewStore(db, sql.TxOptions{}))
+	reposStore := repos.NewMockStoreFrom(repos.NewStore(logtest.Scoped(t), db, sql.TxOptions{}))
 	reposStore.ListExternalServiceUserIDsByRepoIDFunc.SetDefaultReturn([]int32{1}, nil)
 	reposStore.ListExternalServicePrivateRepoIDsByUserIDFunc.SetDefaultReturn([]api.RepoID{2, 3, 4}, nil)
 	reposStore.ExternalServiceStoreFunc.SetDefaultReturn(externalServices)
@@ -250,7 +251,7 @@ func TestPermsSyncer_syncUserPerms_noPerms(t *testing.T) {
 	db.UserEmailsFunc.SetDefaultReturn(userEmails)
 	db.UserExternalAccountsFunc.SetDefaultReturn(externalAccounts)
 
-	reposStore := repos.NewMockStoreFrom(repos.NewStore(db, sql.TxOptions{}))
+	reposStore := repos.NewMockStoreFrom(repos.NewStore(logtest.Scoped(t), db, sql.TxOptions{}))
 	reposStore.ListExternalServicePrivateRepoIDsByUserIDFunc.SetDefaultReturn([]api.RepoID{}, nil)
 	reposStore.RepoStoreFunc.SetDefaultReturn(mockRepos)
 	reposStore.ExternalServiceStoreFunc.SetDefaultReturn(externalServices)
@@ -436,7 +437,7 @@ func TestPermsSyncer_syncUserPerms_prefixSpecs(t *testing.T) {
 	db.UserEmailsFunc.SetDefaultReturn(userEmails)
 	db.UserExternalAccountsFunc.SetDefaultReturn(externalAccounts)
 
-	reposStore := repos.NewMockStoreFrom(repos.NewStore(db, sql.TxOptions{}))
+	reposStore := repos.NewMockStoreFrom(repos.NewStore(logtest.Scoped(t), db, sql.TxOptions{}))
 	reposStore.ListExternalServicePrivateRepoIDsByUserIDFunc.SetDefaultReturn([]api.RepoID{}, nil)
 	reposStore.RepoStoreFunc.SetDefaultReturn(mockRepos)
 	reposStore.ExternalServiceStoreFunc.SetDefaultReturn(externalServices)
@@ -505,7 +506,7 @@ func TestPermsSyncer_syncUserPerms_subRepoPermissions(t *testing.T) {
 	db.UserExternalAccountsFunc.SetDefaultReturn(externalAccounts)
 	db.SubRepoPermsFunc.SetDefaultReturn(subRepoPerms)
 
-	reposStore := repos.NewMockStoreFrom(repos.NewStore(db, sql.TxOptions{}))
+	reposStore := repos.NewMockStoreFrom(repos.NewStore(logtest.Scoped(t), db, sql.TxOptions{}))
 	reposStore.ListExternalServicePrivateRepoIDsByUserIDFunc.SetDefaultReturn([]api.RepoID{}, nil)
 	reposStore.RepoStoreFunc.SetDefaultReturn(mockRepos)
 	reposStore.ExternalServiceStoreFunc.SetDefaultReturn(externalServices)
@@ -568,7 +569,7 @@ func TestPermsSyncer_syncRepoPerms(t *testing.T) {
 			nil,
 		)
 
-		reposStore := repos.NewMockStoreFrom(repos.NewStore(db, sql.TxOptions{}))
+		reposStore := repos.NewMockStoreFrom(repos.NewStore(logtest.Scoped(t), db, sql.TxOptions{}))
 		reposStore.ListExternalServiceUserIDsByRepoIDFunc.SetDefaultReturn([]int32{}, nil)
 		reposStore.RepoStoreFunc.SetDefaultReturn(mockRepos)
 
@@ -622,7 +623,7 @@ func TestPermsSyncer_syncRepoPerms(t *testing.T) {
 			nil,
 		)
 
-		reposStore := repos.NewMockStoreFrom(repos.NewStore(db, sql.TxOptions{}))
+		reposStore := repos.NewMockStoreFrom(repos.NewStore(logtest.Scoped(t), db, sql.TxOptions{}))
 		reposStore.ListExternalServiceUserIDsByRepoIDFunc.SetDefaultReturn([]int32{}, nil)
 		reposStore.RepoStoreFunc.SetDefaultReturn(mockRepos)
 
@@ -654,7 +655,7 @@ func TestPermsSyncer_syncRepoPerms(t *testing.T) {
 			nil,
 		)
 
-		reposStore := repos.NewMockStoreFrom(repos.NewStore(db, sql.TxOptions{}))
+		reposStore := repos.NewMockStoreFrom(repos.NewStore(logtest.Scoped(t), db, sql.TxOptions{}))
 		reposStore.ListExternalServiceUserIDsByRepoIDFunc.SetDefaultReturn([]int32{1}, nil)
 		reposStore.RepoStoreFunc.SetDefaultReturn(mockRepos)
 
@@ -700,7 +701,7 @@ func TestPermsSyncer_syncRepoPerms(t *testing.T) {
 		nil,
 	)
 
-	reposStore := repos.NewMockStoreFrom(repos.NewStore(db, sql.TxOptions{}))
+	reposStore := repos.NewMockStoreFrom(repos.NewStore(logtest.Scoped(t), db, sql.TxOptions{}))
 	reposStore.ListExternalServiceUserIDsByRepoIDFunc.SetDefaultReturn([]int32{}, nil)
 	reposStore.RepoStoreFunc.SetDefaultReturn(mockRepos)
 

--- a/internal/repos/integration_test.go
+++ b/internal/repos/integration_test.go
@@ -4,7 +4,6 @@ import (
 	"database/sql"
 	"testing"
 
-	"github.com/inconshreveable/log15"
 	"github.com/opentracing/opentracing-go"
 
 	"github.com/sourcegraph/sourcegraph/internal/database"
@@ -12,6 +11,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/repos"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"github.com/sourcegraph/sourcegraph/lib/log/logtest"
 )
 
 // This error is passed to txstore.Done in order to always
@@ -53,12 +53,8 @@ func TestIntegration(t *testing.T) {
 		{"Syncer/SyncReposWithLastErrorsHitRateLimit", testSyncReposWithLastErrorsHitsRateLimiter},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			store := repos.NewStore(database.NewDB(dbtest.NewDB(t)), sql.TxOptions{Isolation: sql.LevelReadCommitted})
+			store := repos.NewStore(logtest.Scoped(t), database.NewDB(dbtest.NewDB(t)), sql.TxOptions{Isolation: sql.LevelReadCommitted})
 
-			lg := log15.New()
-			lg.SetHandler(log15.DiscardHandler())
-
-			store.SetLogger(lg)
 			store.SetMetrics(repos.NewStoreMetrics())
 			store.SetTracer(trace.Tracer{Tracer: opentracing.GlobalTracer()})
 

--- a/internal/repos/mocks.go
+++ b/internal/repos/mocks.go
@@ -11,7 +11,6 @@ import (
 	basestore "github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	trace "github.com/sourcegraph/sourcegraph/internal/trace"
 	types "github.com/sourcegraph/sourcegraph/internal/types"
-	log "github.com/sourcegraph/sourcegraph/lib/log"
 )
 
 // MockStore is a mock implementation of the Store interface (from the
@@ -65,9 +64,6 @@ type MockStore struct {
 	// RepoStoreFunc is an instance of a mock function object controlling
 	// the behavior of the method RepoStore.
 	RepoStoreFunc *StoreRepoStoreFunc
-	// SetLoggerFunc is an instance of a mock function object controlling
-	// the behavior of the method SetLogger.
-	SetLoggerFunc *StoreSetLoggerFunc
 	// SetMetricsFunc is an instance of a mock function object controlling
 	// the behavior of the method SetMetrics.
 	SetMetricsFunc *StoreSetMetricsFunc
@@ -157,11 +153,6 @@ func NewMockStore() *MockStore {
 		},
 		RepoStoreFunc: &StoreRepoStoreFunc{
 			defaultHook: func() (r0 database.RepoStore) {
-				return
-			},
-		},
-		SetLoggerFunc: &StoreSetLoggerFunc{
-			defaultHook: func(log.Logger) {
 				return
 			},
 		},
@@ -267,11 +258,6 @@ func NewStrictMockStore() *MockStore {
 				panic("unexpected invocation of MockStore.RepoStore")
 			},
 		},
-		SetLoggerFunc: &StoreSetLoggerFunc{
-			defaultHook: func(log.Logger) {
-				panic("unexpected invocation of MockStore.SetLogger")
-			},
-		},
 		SetMetricsFunc: &StoreSetMetricsFunc{
 			defaultHook: func(StoreMetrics) {
 				panic("unexpected invocation of MockStore.SetMetrics")
@@ -345,9 +331,6 @@ func NewMockStoreFrom(i Store) *MockStore {
 		},
 		RepoStoreFunc: &StoreRepoStoreFunc{
 			defaultHook: i.RepoStore,
-		},
-		SetLoggerFunc: &StoreSetLoggerFunc{
-			defaultHook: i.SetLogger,
 		},
 		SetMetricsFunc: &StoreSetMetricsFunc{
 			defaultHook: i.SetMetrics,
@@ -1845,104 +1828,6 @@ func (c StoreRepoStoreFuncCall) Args() []interface{} {
 // invocation.
 func (c StoreRepoStoreFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
-}
-
-// StoreSetLoggerFunc describes the behavior when the SetLogger method of
-// the parent MockStore instance is invoked.
-type StoreSetLoggerFunc struct {
-	defaultHook func(log.Logger)
-	hooks       []func(log.Logger)
-	history     []StoreSetLoggerFuncCall
-	mutex       sync.Mutex
-}
-
-// SetLogger delegates to the next hook function in the queue and stores the
-// parameter and result values of this invocation.
-func (m *MockStore) SetLogger(v0 log.Logger) {
-	m.SetLoggerFunc.nextHook()(v0)
-	m.SetLoggerFunc.appendCall(StoreSetLoggerFuncCall{v0})
-	return
-}
-
-// SetDefaultHook sets function that is called when the SetLogger method of
-// the parent MockStore instance is invoked and the hook queue is empty.
-func (f *StoreSetLoggerFunc) SetDefaultHook(hook func(log.Logger)) {
-	f.defaultHook = hook
-}
-
-// PushHook adds a function to the end of hook queue. Each invocation of the
-// SetLogger method of the parent MockStore instance invokes the hook at the
-// front of the queue and discards it. After the queue is empty, the default
-// hook function is invoked for any future action.
-func (f *StoreSetLoggerFunc) PushHook(hook func(log.Logger)) {
-	f.mutex.Lock()
-	f.hooks = append(f.hooks, hook)
-	f.mutex.Unlock()
-}
-
-// SetDefaultReturn calls SetDefaultHook with a function that returns the
-// given values.
-func (f *StoreSetLoggerFunc) SetDefaultReturn() {
-	f.SetDefaultHook(func(log.Logger) {
-		return
-	})
-}
-
-// PushReturn calls PushHook with a function that returns the given values.
-func (f *StoreSetLoggerFunc) PushReturn() {
-	f.PushHook(func(log.Logger) {
-		return
-	})
-}
-
-func (f *StoreSetLoggerFunc) nextHook() func(log.Logger) {
-	f.mutex.Lock()
-	defer f.mutex.Unlock()
-
-	if len(f.hooks) == 0 {
-		return f.defaultHook
-	}
-
-	hook := f.hooks[0]
-	f.hooks = f.hooks[1:]
-	return hook
-}
-
-func (f *StoreSetLoggerFunc) appendCall(r0 StoreSetLoggerFuncCall) {
-	f.mutex.Lock()
-	f.history = append(f.history, r0)
-	f.mutex.Unlock()
-}
-
-// History returns a sequence of StoreSetLoggerFuncCall objects describing
-// the invocations of this function.
-func (f *StoreSetLoggerFunc) History() []StoreSetLoggerFuncCall {
-	f.mutex.Lock()
-	history := make([]StoreSetLoggerFuncCall, len(f.history))
-	copy(history, f.history)
-	f.mutex.Unlock()
-
-	return history
-}
-
-// StoreSetLoggerFuncCall is an object that describes an invocation of
-// method SetLogger on an instance of MockStore.
-type StoreSetLoggerFuncCall struct {
-	// Arg0 is the value of the 1st argument passed to this method
-	// invocation.
-	Arg0 log.Logger
-}
-
-// Args returns an interface slice containing the arguments of this
-// invocation.
-func (c StoreSetLoggerFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0}
-}
-
-// Results returns an interface slice containing the results of this
-// invocation.
-func (c StoreSetLoggerFuncCall) Results() []interface{} {
-	return []interface{}{}
 }
 
 // StoreSetMetricsFunc describes the behavior when the SetMetrics method of

--- a/internal/repos/status_messages_test.go
+++ b/internal/repos/status_messages_test.go
@@ -29,7 +29,7 @@ func TestStatusMessages(t *testing.T) {
 	}
 	ctx := context.Background()
 	db := database.NewDB(dbtest.NewDB(t))
-	store := NewStore(database.NewDB(db), sql.TxOptions{})
+	store := NewStore(logtest.Scoped(t), database.NewDB(db), sql.TxOptions{})
 
 	admin, err := database.Users(db).Create(ctx, database.NewUser{
 		Email:                 "a1@example.com",

--- a/internal/repos/store.go
+++ b/internal/repos/store.go
@@ -180,7 +180,6 @@ func (s *store) transact(ctx context.Context) (stx *store, err error) {
 
 // Done calls into the inner Store Done method.
 func (s *store) Done(err error) error {
-
 	tr := s.txtrace
 	tr.LogFields(otlog.String("event", "Store.Done"))
 	logger := trace.Logger(s.txctx, s.Logger)

--- a/internal/repos/store.go
+++ b/internal/repos/store.go
@@ -158,12 +158,10 @@ func (s *store) transact(ctx context.Context) (stx *store, err error) {
 		secs := time.Since(began).Seconds()
 		s.Metrics.Transact.Observe(secs, 1, &err)
 
-		if err != nil {
-			logger.Error("store error", log.Error(err))
-			tr.SetError(err)
-			// Finish is called in Done in the non-error case
-			tr.Finish()
-		}
+		logger.Error("store error", log.Error(err))
+		tr.SetError(err)
+		// Finish is called in Done in the non-error case
+		tr.Finish()
 	}(time.Now())
 
 	txBase, err := s.Store.Transact(ctx)
@@ -196,9 +194,7 @@ func (s *store) Done(err error) error {
 			tr.SetError(err)
 			s.Metrics.Done.Observe(secs, 1, &err)
 
-			if err != nil {
-				logger.Error("store error", log.Error(err))
-			}
+			logger.Error("store error", log.Error(err))
 		}
 
 		if !done {
@@ -231,15 +227,12 @@ func (s *store) CountNamespacedRepos(ctx context.Context, userID, orgID int32) (
 		tr.LogFields(otlog.Int32("user-id", userID), otlog.Int32("org-id", orgID))
 		s.Metrics.CountNamespacedRepos.Observe(secs, float64(count), &err)
 
-		if err != nil {
-			logger.Error("store error", log.Object("args",
-				log.Uint64("count", count),
-				log.Int("userID", int(userID)),
-				log.Int("orgID", int(orgID)),
-			),
-				log.Error(err),
-			)
-		}
+		logger.Error("store error",
+			log.Uint64("count", count),
+			log.Int("userID", int(userID)),
+			log.Int("orgID", int(orgID)),
+			log.Error(err),
+		)
 
 		tr.SetError(err)
 		tr.Finish()
@@ -275,9 +268,7 @@ func (s *store) DeleteExternalServiceReposNotIn(ctx context.Context, svc *types.
 		secs := time.Since(began).Seconds()
 
 		s.Metrics.DeleteExternalServiceReposNotIn.Observe(secs, 1, &err)
-		if err != nil {
-			logger.Error("store error", log.Int64("externalServiceID", svc.ID), log.Int("len(ids)", len(ids)), log.Error(err))
-		}
+		logger.Error("store error", log.Int64("externalServiceID", svc.ID), log.Int("len(ids)", len(ids)), log.Error(err))
 
 		tr.SetError(err)
 		tr.Finish()
@@ -326,9 +317,7 @@ func (s *store) DeleteExternalServiceRepo(ctx context.Context, svc *types.Extern
 
 		s.Metrics.DeleteExternalServiceRepo.Observe(secs, 1, &err)
 
-		if err != nil {
-			logger.Error("store error", log.Int64("externalServiceID", svc.ID), log.Int("repoID", int(id)), log.Error(err))
-		}
+		logger.Error("store error", log.Int64("externalServiceID", svc.ID), log.Int("repoID", int(id)), log.Error(err))
 
 		tr.SetError(err)
 		tr.Finish()
@@ -385,9 +374,7 @@ func (s *store) ListExternalServiceUserIDsByRepoID(ctx context.Context, repoID a
 		secs := time.Since(began).Seconds()
 		s.Metrics.ListExternalServiceUserIDsByRepoID.Observe(secs, 1, &err)
 
-		if err != nil {
-			logger.Error("store error", log.Int("repoID", int(repoID)), log.Error(err))
-		}
+		logger.Error("store error", log.Int("repoID", int(repoID)), log.Error(err))
 
 		tr.SetError(err)
 		tr.Finish()
@@ -417,9 +404,7 @@ func (s *store) ListExternalServicePrivateRepoIDsByUserID(ctx context.Context, u
 		secs := time.Since(began).Seconds()
 		s.Metrics.ListExternalServiceRepoIDsByUserID.Observe(secs, 1, &err)
 
-		if err != nil {
-			logger.Error("store error", log.Int("userID", int(userID)), log.Error(err))
-		}
+		logger.Error("store error", log.Int("userID", int(userID)), log.Error(err))
 
 		tr.SetError(err)
 		tr.Finish()
@@ -452,18 +437,16 @@ func (s *store) CreateExternalServiceRepo(ctx context.Context, svc *types.Extern
 
 		s.Metrics.CreateExternalServiceRepo.Observe(secs, 1, &err)
 
-		if err != nil {
-			logger.Error("store error",
-				log.Int("externalServiceID", int(svc.ID)),
-				log.String("Name", string(r.Name)),
-				log.Object("ExternalRepo",
-					log.String("ID", r.ExternalRepo.ID),
-					log.String("ServiceID", r.ExternalRepo.ServiceID),
-					log.String("ServiceType", r.ExternalRepo.ServiceType),
-				),
-				log.Error(err),
-			)
-		}
+		logger.Error("store error",
+			log.Int("externalServiceID", int(svc.ID)),
+			log.String("Name", string(r.Name)),
+			log.Object("ExternalRepo",
+				log.String("ID", r.ExternalRepo.ID),
+				log.String("ServiceID", r.ExternalRepo.ServiceID),
+				log.String("ServiceType", r.ExternalRepo.ServiceType),
+			),
+			log.Error(err),
+		)
 
 		tr.SetError(err)
 		tr.Finish()
@@ -566,18 +549,16 @@ func (s *store) UpdateExternalServiceRepo(ctx context.Context, svc *types.Extern
 		secs := time.Since(began).Seconds()
 
 		s.Metrics.UpdateExternalServiceRepo.Observe(secs, 1, &err)
-		if err != nil {
-			logger.Error("store error",
-				log.Int("externalServiceID", int(svc.ID)),
-				log.String("Name", string(r.Name)),
-				log.Object("ExternalRepo",
-					log.String("ID", r.ExternalRepo.ID),
-					log.String("ServiceID", r.ExternalRepo.ServiceID),
-					log.String("ServiceType", r.ExternalRepo.ServiceType),
-				),
-				log.Error(err),
-			)
-		}
+		logger.Error("store error",
+			log.Int("externalServiceID", int(svc.ID)),
+			log.String("Name", string(r.Name)),
+			log.Object("ExternalRepo",
+				log.String("ID", r.ExternalRepo.ID),
+				log.String("ServiceID", r.ExternalRepo.ServiceID),
+				log.String("ServiceType", r.ExternalRepo.ServiceType),
+			),
+			log.Error(err),
+		)
 
 		tr.SetError(err)
 		tr.Finish()

--- a/internal/repos/store.go
+++ b/internal/repos/store.go
@@ -131,7 +131,6 @@ func (s *store) ExternalServiceStore() database.ExternalServiceStore {
 	return database.ExternalServicesWith(s)
 }
 
-func (s *store) SetLogger(l log.Logger)    { s.Logger = l }
 func (s *store) SetMetrics(m StoreMetrics) { s.Metrics = m }
 func (s *store) SetTracer(t trace.Tracer)  { s.Tracer = t }
 

--- a/internal/repos/store.go
+++ b/internal/repos/store.go
@@ -159,9 +159,12 @@ func (s *store) transact(ctx context.Context) (stx *store, err error) {
 		s.Metrics.Transact.Observe(secs, 1, &err)
 
 		logger.Error("store.transact", log.Error(err))
-		tr.SetError(err)
-		// Finish is called in Done in the non-error case
-		tr.Finish()
+
+		if err != nil {
+			tr.SetError(err)
+			// Finish is called in Done in the non-error case
+			tr.Finish()
+		}
 	}(time.Now())
 
 	txBase, err := s.Store.Transact(ctx)

--- a/internal/repos/store.go
+++ b/internal/repos/store.go
@@ -454,8 +454,8 @@ func (s *store) CreateExternalServiceRepo(ctx context.Context, svc *types.Extern
 		if err != nil {
 			logger.Error("store error",
 				log.Int("externalServiceID", int(svc.ID)),
-				log.String("name", string(r.Name)),
-				log.Object("externalRepo",
+				log.String("Name", string(r.Name)),
+				log.Object("ExternalRepo",
 					log.String("ID", r.ExternalRepo.ID),
 					log.String("ServiceID", r.ExternalRepo.ServiceID),
 					log.String("ServiceType", r.ExternalRepo.ServiceType),
@@ -568,8 +568,8 @@ func (s *store) UpdateExternalServiceRepo(ctx context.Context, svc *types.Extern
 		if err != nil {
 			logger.Error("store error",
 				log.Int("externalServiceID", int(svc.ID)),
-				log.String("name", string(r.Name)),
-				log.Object("externalRepo",
+				log.String("Name", string(r.Name)),
+				log.Object("ExternalRepo",
 					log.String("ID", r.ExternalRepo.ID),
 					log.String("ServiceID", r.ExternalRepo.ServiceID),
 					log.String("ServiceType", r.ExternalRepo.ServiceType),

--- a/internal/repos/store.go
+++ b/internal/repos/store.go
@@ -158,7 +158,7 @@ func (s *store) transact(ctx context.Context) (stx *store, err error) {
 		secs := time.Since(began).Seconds()
 		s.Metrics.Transact.Observe(secs, 1, &err)
 
-		logger.Error("store error", log.Error(err))
+		logger.Error("store.transact", log.Error(err))
 		tr.SetError(err)
 		// Finish is called in Done in the non-error case
 		tr.Finish()
@@ -194,7 +194,7 @@ func (s *store) Done(err error) error {
 			tr.SetError(err)
 			s.Metrics.Done.Observe(secs, 1, &err)
 
-			logger.Error("store error", log.Error(err))
+			logger.Error("store.done", log.Error(err))
 		}
 
 		if !done {
@@ -227,7 +227,7 @@ func (s *store) CountNamespacedRepos(ctx context.Context, userID, orgID int32) (
 		tr.LogFields(otlog.Int32("user-id", userID), otlog.Int32("org-id", orgID))
 		s.Metrics.CountNamespacedRepos.Observe(secs, float64(count), &err)
 
-		logger.Error("store error",
+		logger.Error("store.count-namespaced-repos",
 			log.Uint64("count", count),
 			log.Int("userID", int(userID)),
 			log.Int("orgID", int(orgID)),
@@ -268,7 +268,7 @@ func (s *store) DeleteExternalServiceReposNotIn(ctx context.Context, svc *types.
 		secs := time.Since(began).Seconds()
 
 		s.Metrics.DeleteExternalServiceReposNotIn.Observe(secs, 1, &err)
-		logger.Error("store error", log.Int64("externalServiceID", svc.ID), log.Int("len(ids)", len(ids)), log.Error(err))
+		logger.Error("store.delete-external-service-repos-not-in", log.Int64("externalServiceID", svc.ID), log.Int("len(ids)", len(ids)), log.Error(err))
 
 		tr.SetError(err)
 		tr.Finish()
@@ -317,7 +317,7 @@ func (s *store) DeleteExternalServiceRepo(ctx context.Context, svc *types.Extern
 
 		s.Metrics.DeleteExternalServiceRepo.Observe(secs, 1, &err)
 
-		logger.Error("store error", log.Int64("externalServiceID", svc.ID), log.Int("repoID", int(id)), log.Error(err))
+		logger.Error("store.delete-external-service-repo", log.Int64("externalServiceID", svc.ID), log.Int("repoID", int(id)), log.Error(err))
 
 		tr.SetError(err)
 		tr.Finish()
@@ -374,7 +374,7 @@ func (s *store) ListExternalServiceUserIDsByRepoID(ctx context.Context, repoID a
 		secs := time.Since(began).Seconds()
 		s.Metrics.ListExternalServiceUserIDsByRepoID.Observe(secs, 1, &err)
 
-		logger.Error("store error", log.Int("repoID", int(repoID)), log.Error(err))
+		logger.Error("store.list-external-service-user-ids-by-repo-id", log.Int("repoID", int(repoID)), log.Error(err))
 
 		tr.SetError(err)
 		tr.Finish()
@@ -404,7 +404,7 @@ func (s *store) ListExternalServicePrivateRepoIDsByUserID(ctx context.Context, u
 		secs := time.Since(began).Seconds()
 		s.Metrics.ListExternalServiceRepoIDsByUserID.Observe(secs, 1, &err)
 
-		logger.Error("store error", log.Int("userID", int(userID)), log.Error(err))
+		logger.Error("store.list-extenral-service-private-repo-id-by-user-id", log.Int("userID", int(userID)), log.Error(err))
 
 		tr.SetError(err)
 		tr.Finish()
@@ -437,7 +437,7 @@ func (s *store) CreateExternalServiceRepo(ctx context.Context, svc *types.Extern
 
 		s.Metrics.CreateExternalServiceRepo.Observe(secs, 1, &err)
 
-		logger.Error("store error",
+		logger.Error("store.create-external-service-repo",
 			log.Int("externalServiceID", int(svc.ID)),
 			log.String("Name", string(r.Name)),
 			log.Object("ExternalRepo",
@@ -549,7 +549,7 @@ func (s *store) UpdateExternalServiceRepo(ctx context.Context, svc *types.Extern
 		secs := time.Since(began).Seconds()
 
 		s.Metrics.UpdateExternalServiceRepo.Observe(secs, 1, &err)
-		logger.Error("store error",
+		logger.Error("store.update-external-service-repo",
 			log.Int("externalServiceID", int(svc.ID)),
 			log.String("Name", string(r.Name)),
 			log.Object("ExternalRepo",

--- a/internal/repos/store.go
+++ b/internal/repos/store.go
@@ -31,8 +31,6 @@ type Store interface {
 	// database handle.
 	ExternalServiceStore() database.ExternalServiceStore
 
-	// SetLogger updates logger for the store in place.
-	SetLogger(l log.Logger)
 	// SetMetrics updates metrics for the store in place.
 	SetMetrics(m StoreMetrics)
 	// SetTracer updates tracer for the store in place.

--- a/internal/repos/store.go
+++ b/internal/repos/store.go
@@ -100,7 +100,7 @@ type Store interface {
 type store struct {
 	*basestore.Store
 
-	// Logger used by the store. Defaults to log15.Root().
+	// Logger used by the store. Does not have a default - it must be provided.
 	Logger log.Logger
 	// Metrics are sent to Prometheus by default.
 	Metrics StoreMetrics

--- a/internal/repos/store.go
+++ b/internal/repos/store.go
@@ -184,7 +184,8 @@ func (s *store) transact(ctx context.Context) (stx *store, err error) {
 func (s *store) Done(err error) error {
 
 	tr := s.txtrace
-	logger := trace.Logger(s.txctx, s.Logger).With(log.String("event", "Done"))
+	tr.LogFields(otlog.String("event", "Store.Done"))
+	logger := trace.Logger(s.txctx, s.Logger)
 
 	defer func(began time.Time) {
 		secs := time.Since(began).Seconds()
@@ -194,8 +195,6 @@ func (s *store) Done(err error) error {
 			done = true
 			tr.SetError(err)
 			s.Metrics.Done.Observe(secs, 1, &err)
-
-			logger.Error("store error", log.Error(err))
 
 			if err != nil {
 				logger.Error("store error", log.Error(err))

--- a/lib/log/fields.go
+++ b/lib/log/fields.go
@@ -26,9 +26,9 @@ var (
 	// Int64 constructs a field with the given key and value.
 	Int64 = zap.Int64
 
-	//Uint constructs a field with the given key and value.
+	// Uint constructs a field with the given key and value.
 	Uint = zap.Uint
-	//Uint64 constructs a field with the given key and value.
+	// Uint64 constructs a field with the given key and value.
 	Uint64 = zap.Uint64
 
 	// Float64 constructs a field that carries a float64. The way the floating-point value

--- a/lib/log/fields.go
+++ b/lib/log/fields.go
@@ -26,6 +26,11 @@ var (
 	// Int64 constructs a field with the given key and value.
 	Int64 = zap.Int64
 
+	//Uint constructs a field with the given key and value.
+	Uint = zap.Uint
+	//Uint64 constructs a field with the given key and value.
+	Uint64 = zap.Uint64
+
 	// Float64 constructs a field that carries a float64. The way the floating-point value
 	// is represented is encoder-dependent, so marshaling is necessarily lazy.
 	Float64 = zap.Float64


### PR DESCRIPTION
Update repos.Store to use lib/log

* Removed `SetLogger` as it was only used in testing and is not needed anymore.

Closes #34607
## Test plan
Unit tests
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
