### PR TITLE
trace: update trace.Logger to set family to scope

### DIFF
--- a/internal/trace/traceutil.go
+++ b/internal/trace/traceutil.go
@@ -82,12 +82,11 @@ func ContextFromSpan(span opentracing.Span) *otfields.TraceContext {
 // trace.Context(ctx) instead.
 func Logger(ctx context.Context, l sglog.Logger) sglog.Logger {
 	if t := TraceFromContext(ctx); t != nil {
+		if t.family != "" {
+			l = l.Scoped(t.family, "trace family")
+		}
 		if tc := ContextFromSpan(t.span); tc != nil {
-			traced := l.WithTrace(*tc)
-			if t.family != "" {
-				return traced.Scoped(t.family, "trace family")
-			}
-			return traced
+			l = l.WithTrace(*tc)
 		}
 	}
 	return l

--- a/internal/trace/traceutil.go
+++ b/internal/trace/traceutil.go
@@ -83,6 +83,21 @@ func Logger(ctx context.Context, l sglog.Logger) sglog.Logger {
 	return l
 }
 
+// ScopedLogger will set the TraceContext on l if ctx has one, and also assign the trace
+// family as a scope if a trace family is found.
+func ScopedLogger(ctx context.Context, l sglog.Logger) sglog.Logger {
+	if t := TraceFromContext(ctx); t != nil {
+		if tc := ContextFromSpan(t.span); tc != nil {
+			traced := l.WithTrace(*tc)
+			if t.family != "" {
+				return traced.Scoped(t.family, "trace family")
+			}
+			return traced
+		}
+	}
+	return l
+}
+
 // URL returns a trace URL for the given trace ID at the given external URL.
 func URL(traceID, externalURL, traceProvider string) string {
 	if traceID == "" {

--- a/internal/trace/traceutil.go
+++ b/internal/trace/traceutil.go
@@ -74,18 +74,13 @@ func ContextFromSpan(span opentracing.Span) *otfields.TraceContext {
 	return nil
 }
 
-// Logger will set the TraceContext on l if ctx has one. This is a
-// convenience function around l.WithTrace for the common case.
-func Logger(ctx context.Context, l sglog.Logger) sglog.Logger {
-	if tc := Context(ctx); tc != nil {
-		return l.WithTrace(*tc)
-	}
-	return l
-}
-
 // ScopedLogger will set the TraceContext on l if ctx has one, and also assign the trace
-// family as a scope if a trace family is found.
-func ScopedLogger(ctx context.Context, l sglog.Logger) sglog.Logger {
+// family as a scope if a trace family is found. This is an expanded convenience function
+// around l.WithTrace for the common case.
+//
+// If you already set the family manually on the logger scope, then you might want to use
+// trace.Context(ctx) instead.
+func Logger(ctx context.Context, l sglog.Logger) sglog.Logger {
 	if t := TraceFromContext(ctx); t != nil {
 		if tc := ContextFromSpan(t.span); tc != nil {
 			traced := l.WithTrace(*tc)

--- a/internal/trace/traceutil.go
+++ b/internal/trace/traceutil.go
@@ -74,7 +74,7 @@ func ContextFromSpan(span opentracing.Span) *otfields.TraceContext {
 	return nil
 }
 
-// ScopedLogger will set the TraceContext on l if ctx has one, and also assign the trace
+// Logger will set the TraceContext on l if ctx has one, and also assign the trace
 // family as a scope if a trace family is found. This is an expanded convenience function
 // around l.WithTrace for the common case.
 //


### PR DESCRIPTION
Expands on https://github.com/sourcegraph/sourcegraph/pull/36139 ~with an additional util, `trace.ScopedLogger`, that~ to also set the trace family as a scope on the logger. The scenario in question is:

```go
tr, ctx := s.trace(ctx, "Store.Transact")
logger := trace.Logger(ctx, s.Logger) // `Store.Transact` might be useful info on the logger
```

I'm not sure whether this should be the default for `trace.Logger` - might need to poke around or ask about whether folks would set the scope separately from setting the logger. My inclination is probably not? There is one place where this is the case though, and that's in `internal/observation` - the family name is tracked throughout the layers of `Observation` and are set manually on the logger scope. There we don't use this utility, however

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

n/a