### PR TITLE
dev/sg: make linter timeout more generous

### DIFF
--- a/dev/sg/sg_lint.go
+++ b/dev/sg/sg_lint.go
@@ -105,9 +105,9 @@ func runCheckScriptsAndReport(ctx context.Context, dst io.Writer, fns ...lint.Ru
 	// We use a single start time for the sake of simplicity.
 	start := time.Now()
 
-	// 3 minutes is a very long time for a linter to run for, do not allow linters to take
-	// any longer.
-	linterTimeout := 3 * time.Minute
+	// linterTimeout sets the very long time for a linter to run for. We definitely do not
+	// want to allow linters to take any longer.
+	linterTimeout := 5 * time.Minute
 	runnerCtx, cancelRunners := context.WithTimeout(ctx, linterTimeout)
 	for _, fn := range fns {
 		go func(fn lint.Runner) {


### PR DESCRIPTION
I overstimated the speed of our linters in https://github.com/sourcegraph/sourcegraph/pull/36193 - there was a failure on main just now where two checks timed out: https://buildkite.com/sourcegraph/sourcegraph/builds/150604

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

n/a, I looked at the past few runs and they all take just over 3 minutes