### PR TITLE
dev/sg: log linter events, add more docs to LogEvent

### DIFF
--- a/dev/sg/internal/analytics/context.go
+++ b/dev/sg/internal/analytics/context.go
@@ -32,9 +32,16 @@ func getStore(ctx context.Context) *eventStore {
 // LogEvent tracks an event in the per-run analytics store, if analytics are enabled,
 // in the context of a command.
 //
-// Events can also be provided to indicate that something happened - for example, and
-// error or cancellation. These are treated as metrics with a count of 1.
-func LogEvent(ctx context.Context, name string, labels []string, startedAt time.Time, events ...string) {
+// In general, usage should be as follows:
+//
+// - category denotes the category of the event, such as "lint_runner:.
+// - labels denote subcategories this event belongs to, such as the specific lint runner.
+// - events denote what happened as part of this logged event, such as "failed" or
+//   "succeeded". These are treated as metrics with a count of 1.
+//
+// Events are automatically created with a duration relative to the provided start time,
+// and persisted to disk at the end of command execution.
+func LogEvent(ctx context.Context, category string, labels []string, startedAt time.Time, events ...string) {
 	store := getStore(ctx)
 	if store == nil {
 		return
@@ -48,7 +55,7 @@ func LogEvent(ctx context.Context, name string, labels []string, startedAt time.
 	}
 
 	store.events = append(store.events, &okay.Event{
-		Name:      name,
+		Name:      category,
 		Labels:    labels,
 		Timestamp: startedAt, // Timestamp as start of event
 		Metrics:   metrics,

--- a/dev/sg/sg_lint.go
+++ b/dev/sg/sg_lint.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/urfave/cli/v2"
 
+	"github.com/sourcegraph/sourcegraph/dev/sg/internal/analytics"
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/lint"
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/repo"
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/std"
@@ -131,6 +132,17 @@ func runCheckScriptsAndReport(ctx context.Context, dst io.Writer, fns ...lint.Ru
 		if report.Err != nil {
 			messages = append(messages, report.Header)
 			hasErr = true
+		}
+
+		// Log analytics for each linter
+		const eventName = "lint_runner"
+		labels := []string{report.Header}
+		if runnerCtx.Err() == context.DeadlineExceeded {
+			analytics.LogEvent(ctx, eventName, labels, start, "deadline exceeded")
+		} else if report.Err != nil {
+			analytics.LogEvent(ctx, eventName, labels, start, "failed")
+		} else {
+			analytics.LogEvent(ctx, eventName, labels, start, "succeeded")
 		}
 	}
 


### PR DESCRIPTION
Logs linter durations and whether they get cancelled or not. Inspired by https://github.com/sourcegraph/sourcegraph/pull/36250

Thought: maybe we can submit events in CI? 😲 Part of https://github.com/sourcegraph/sourcegraph/issues/33447, maybe related to https://github.com/sourcegraph/sourcegraph/issues/32562 

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

`go run ./dev/sg --disable-analytics=false lint`

<img width="780" alt="image" src="https://user-images.githubusercontent.com/23356519/171051409-c9b51485-e7ec-4db0-90f0-abd88bc6aa9c.png">
