### PR TITLE
dev/sg: recover and format panics, add bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/sg_bug.md
+++ b/.github/ISSUE_TEMPLATE/sg_bug.md
@@ -1,0 +1,10 @@
+---
+name: `sg` bug report
+about: An issue about a bug with `sg`, the Sourcegraph developer tool
+title: 'dev/sg: '
+labels:
+- 'dev/sg'
+- 'team/devx'
+- 'bug'
+assignees: ''
+---

--- a/dev/sg/analytics.go
+++ b/dev/sg/analytics.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"fmt"
+	"runtime"
 	"strings"
 	"time"
 
@@ -13,6 +15,8 @@ import (
 
 // addAnalyticsHooks wraps command actions with analytics hooks. We reconstruct commandPath
 // ourselves because the library's state (and hence .FullName()) seems to get a bit funky.
+//
+// It also handles watching for panics and formatting them in a useful manner.
 func addAnalyticsHooks(start time.Time, commandPath []string, commands []*cli.Command) {
 	for _, command := range commands {
 		if len(command.Subcommands) > 0 {
@@ -29,12 +33,23 @@ func addAnalyticsHooks(start time.Time, commandPath []string, commands []*cli.Co
 
 		// Wrap action with analytics
 		wrappedAction := command.Action
-		command.Action = func(cmd *cli.Context) error {
-			// Make sure analytics hook gets called before exit
+		command.Action = func(cmd *cli.Context) (actionErr error) {
+			// Make sure analytics hook gets called before exit (interrupts or panics)
 			interrupt.Register(func() { analyticsHook(cmd, "cancelled") })
+			defer func() {
+				if p := recover(); p != nil {
+					analyticsHook(cmd, "panic")
+
+					// Render a more elegant message
+					std.Out.WriteWarningf("Encountered panic - please open an issue with the command output:\n\t%s",
+						sgBugReportTemplate)
+					message := fmt.Sprintf("%v:\n%s", p, getRelevantStack("addAnalyticsHooks"))
+					actionErr = cli.NewExitError(message, 1)
+				}
+			}()
 
 			// Call the underlying action
-			actionErr := wrappedAction(cmd)
+			actionErr = wrappedAction(cmd)
 
 			// Capture analytics post-run
 			if actionErr != nil {
@@ -59,4 +74,42 @@ func makeAnalyticsHook(start time.Time, commandPath []string) func(ctx *cli.Cont
 			std.Out.WriteSkippedf("failed to persist events: %s", err)
 		}
 	}
+}
+
+// getRelevantStack generates a stacktrace that encapsulates the relevant parts of a
+// stacktrace for user-friendly reading.
+func getRelevantStack(excludeFunctions ...string) string {
+	callers := make([]uintptr, 32)
+	n := runtime.Callers(3, callers) // recover -> getRelevantStack -> runtime.Callers
+	frames := runtime.CallersFrames(callers[:n])
+
+	var stack strings.Builder
+	for {
+		frame, next := frames.Next()
+
+		var excludedFunction bool
+		for _, e := range excludeFunctions {
+			if strings.Contains(frame.Function, e) {
+				excludedFunction = true
+				break
+			}
+		}
+
+		// Only include frames from sg and things that are not excluded.
+		if !strings.Contains(frame.File, "dev/sg/") || excludedFunction {
+			if !next {
+				break
+			}
+			continue
+		}
+
+		stack.WriteString(frame.Function)
+		stack.WriteByte('\n')
+		stack.WriteString(fmt.Sprintf("\t%s:%d\n", frame.File, frame.Line))
+		if !next {
+			break
+		}
+	}
+
+	return stack.String()
 }

--- a/dev/sg/completions.go
+++ b/dev/sg/completions.go
@@ -6,7 +6,9 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-// completeOptions provides autocompletions based on the options returned by generateOptions
+// completeOptions provides autocompletions based on the options returned by
+// generateOptions. generateOptions must not write to output, or reference any resources
+// that are initialized elsewhere.
 func completeOptions(generateOptions func() (options []string)) cli.BashCompleteFunc {
 	return func(cmd *cli.Context) {
 		for _, opt := range generateOptions() {

--- a/dev/sg/main.go
+++ b/dev/sg/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"flag"
+	"fmt"
 	"os"
 	"path/filepath"
 	"time"
@@ -58,6 +59,8 @@ var (
 	batchCompletionMode bool
 )
 
+const sgBugReportTemplate = "https://github.com/sourcegraph/sourcegraph/issues/new?template=sg_bug.md"
+
 // sg is the main sg CLI application.
 var sg = &cli.App{
 	Usage:       "The Sourcegraph developer tool!",
@@ -109,34 +112,55 @@ var sg = &cli.App{
 			EnvVars: []string{"SG_DISBALE_OUTPUT_DETECTION"},
 		},
 	},
-	Before: func(cmd *cli.Context) error {
+	Before: func(cmd *cli.Context) (err error) {
 		if batchCompletionMode {
 			// All other setup pertains to running commands - to keep completions fast,
 			// we skip all other setup.
 			return nil
 		}
 
-		// Let sg components register pre-exit hooks
+		var (
+			start                  = time.Now()
+			disableAnalytics       = cmd.Bool("disable-analytics")
+			disableOutputDetection = cmd.Bool("disable-output-detection")
+		)
+
+		// Let sg components register pre-interrupt hooks
 		interrupt.Listen()
 
 		// Configure global output
-		if cmd.Bool("disable-output-detection") {
+		if disableOutputDetection {
 			std.Out = std.NewFixedOutput(cmd.App.Writer, verbose)
 		} else {
 			std.Out = std.NewOutput(cmd.App.Writer, verbose)
 		}
-		// Configure logger output, for components that use loggers
+
+		// Set up analytics and hooks for each command.
+		if !disableAnalytics {
+			cmd.Context = analytics.WithContext(cmd.Context, cmd.App.Version)
+			addAnalyticsHooks(start, []string{"sg"}, cmd.App.Commands)
+
+			// Lots of setup happens in Before - we want to make sure anything that
+			// happens here is tracked. We set this up here after setting up output and
+			// some initial safe setup.
+			defer func() {
+				if p := recover(); p != nil {
+					std.Out.WriteWarningf("Encountered panic - please open an issue with the command output:\n\t%s",
+						sgBugReportTemplate)
+					message := fmt.Sprintf("%v:\n%s", p, getRelevantStack())
+					err = cli.NewExitError(message, 1)
+
+					analytics.LogEvent(cmd.Context, "sg_before", nil, start, "panic")
+					analytics.Persist(cmd.Context, "sg", cmd.FlagNames())
+				}
+			}()
+		}
+
+		// Configure logger, for commands that use components that use loggers
 		os.Setenv("SRC_DEVELOPMENT", "true")
 		os.Setenv("SRC_LOG_FORMAT", "console")
 		syncLogs := log.Init(log.Resource{Name: "sg"})
 		interrupt.Register(func() { syncLogs() })
-
-		// Configure analytics - this should be the first thing to be configured.
-		if !cmd.Bool("disable-analytics") {
-			cmd.Context = analytics.WithContext(cmd.Context, cmd.App.Version)
-			start := time.Now() // Start the clock immediately
-			addAnalyticsHooks(start, []string{"sg"}, cmd.App.Commands)
-		}
 
 		// Add autosuggestion hooks to commands with subcommands but no action
 		addSuggestionHooks(cmd.App.Commands)

--- a/dev/sg/sg_analytics.go
+++ b/dev/sg/sg_analytics.go
@@ -93,9 +93,11 @@ var analyticsCommand = &cli.Command{
 							metrics = append(metrics, fmt.Sprintf("%s: %s", k, v.ValueString()))
 						}
 
-						entry := fmt.Sprintf("- [%s] `%s`: %s _(%s)_",
-							ts, ev.Name, strings.Join(ev.Labels, ", "), strings.Join(metrics, ", "))
-						out.WriteString(entry)
+						entry := fmt.Sprintf("- [%s] `%s`", ts, ev.Name)
+						if len(ev.Labels) > 0 {
+							entry += fmt.Sprintf(": %s", strings.Join(ev.Labels, ", "))
+						}
+						out.WriteString(entry + fmt.Sprintf(" _(%s)_", strings.Join(metrics, ", ")))
 
 						out.WriteString("\n")
 					}


### PR DESCRIPTION
Analytics hooks now recover from panics when executing an action - this covers most command-running cases. Also adds a similar handler in `Before`, where a lot of stuff happens, in case we run into panics there.

The stacktrace is customized to only include `dev/sg` components, for user-friendliness.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Added panics in various places and checked output + analytics logs

Example:

<img width="675" alt="image" src="https://user-images.githubusercontent.com/23356519/171060196-a09d3ba7-fa15-4484-a9a7-d735adb151bc.png">

