### PR TITLE
dev/sg: fix nil reference on build author

### DIFF
--- a/dev/sg/sg_ci.go
+++ b/dev/sg/sg_ci.go
@@ -568,8 +568,11 @@ func allLinesPrefixed(lines []string, match string) bool {
 
 func printBuildOverview(build *buildkite.Build) {
 	std.Out.WriteLine(output.Styledf(output.StyleBold, "Most recent build: %s", *build.WebURL))
-	std.Out.Writef("Commit:\t\t%s\nMessage:\t%s\nAuthor:\t\t%s <%s>",
-		*build.Commit, *build.Message, build.Author.Name, build.Author.Email)
+	std.Out.Writef("Commit:\t\t%s", *build.Commit)
+	std.Out.Writef("Message:\t%s", *build.Message)
+	if build.Author != nil {
+		std.Out.Writef("Author:\t\t%s <%s>", build.Author.Name, build.Author.Email)
+	}
 	if build.PullRequest != nil {
 		std.Out.Writef("PR:\t\thttps://github.com/sourcegraph/sourcegraph/pull/%s", *build.PullRequest.ID)
 	}


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/36239

Also inspires https://github.com/sourcegraph/sourcegraph/pull/36256

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

n/a, I just read the stacktrace and fixed the exact nil pointer that was encountered - couldn't reproduce locally (might have hit a custom build triggered via API)