### PR TITLE
dev/sg: remove redundant sg-analytics label

### DIFF
--- a/dev/sg/internal/analytics/actions.go
+++ b/dev/sg/internal/analytics/actions.go
@@ -26,7 +26,6 @@ func Submit(okayToken string, gitHubLogin string) error {
 		}
 
 		// clean up data
-		ev.Labels = append(ev.Labels, "sg-analytics")
 		for k, v := range ev.Properties {
 			if len(v) == 0 {
 				delete(ev.Properties, k)


### PR DESCRIPTION
We already have `context: sg`, this label just adds noise in the OkayHQ label view

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

n/a