### PR TITLE
lib: remove all usages of log15

### DIFF
--- a/lib/codeintel/lsif/conversion/correlate.go
+++ b/lib/codeintel/lsif/conversion/correlate.go
@@ -8,8 +8,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/inconshreveable/log15"
-
 	"github.com/sourcegraph/sourcegraph/lib/codeintel/lsif/conversion/datastructures"
 	"github.com/sourcegraph/sourcegraph/lib/codeintel/pathexistence"
 	"github.com/sourcegraph/sourcegraph/lib/codeintel/precise"
@@ -450,7 +448,6 @@ func correlateItemEdge(state *wrappedState, id int, edge Edge) error {
 		return malformedDump(id, edge.OutV, "vertex")
 	}
 
-	log15.Debug("Skipping edge from an unsupported vertex")
 	return nil
 }
 

--- a/lib/codeintel/tools/lsif-index-tester/main.go
+++ b/lib/codeintel/tools/lsif-index-tester/main.go
@@ -14,12 +14,12 @@ import (
 	"sync"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/inconshreveable/log15"
 
 	"github.com/sourcegraph/sourcegraph/lib/codeintel/lsif/conversion"
 	"github.com/sourcegraph/sourcegraph/lib/codeintel/lsif/validation"
 	"github.com/sourcegraph/sourcegraph/lib/codeintel/precise"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"github.com/sourcegraph/sourcegraph/lib/log"
 )
 
 type projectResult struct {
@@ -66,39 +66,41 @@ var debug bool
 // TODO: Do more monitoring of the process.
 // var monitor bool
 
-func logFatal(msg string, args ...any) {
-	log15.Error(msg, args...)
-	os.Exit(1)
-}
-
 func main() {
 	flag.StringVar(&directory, "dir", ".", "The directory to run the test harness over")
 	flag.StringVar(&raw_indexer, "indexer", "", "The name of the indexer that you want to test")
 	flag.BoolVar(&debug, "debug", false, "Enable debugging")
-
 	flag.Parse()
 
+	// Initialize log format and level
 	if debug {
-		log15.Root().SetHandler(log15.LvlFilterHandler(log15.LvlDebug, log15.StdoutHandler))
-	} else {
-		log15.Root().SetHandler(log15.LvlFilterHandler(log15.LvlError, log15.StdoutHandler))
+		os.Setenv("SRC_LOG_LEVEL", "debug")
 	}
+	if _, set := os.LookupEnv("SRC_LOG_FORMAT"); !set {
+		// Unless a custom log format is set, initialize to dev-friendly output
+		os.Setenv("SRC_LOG_FORMAT", "console")
+		os.Setenv("SRC_DEVELOPMENT", "true")
+	}
+	syncLogs := log.Init(log.Resource{Name: "lsif-index-tester"})
+	defer syncLogs()
+
+	logger := log.Scoped(raw_indexer, "indexer testing").With(log.String("directory", directory))
 
 	if raw_indexer == "" {
-		logFatal("Indexer is required. Pass with --indexer")
+		logger.Fatal("Indexer is required. Pass with --indexer")
 	}
 
-	log15.Info("Starting Execution: ", "directory", directory, "indexer", raw_indexer)
+	logger.Info("Starting execution")
 
 	indexer := strings.Split(raw_indexer, " ")
-	if err := testDirectory(context.Background(), indexer, directory); err != nil {
-		logFatal("Failed with", "err", err)
+	if err := testDirectory(context.Background(), logger, indexer, directory); err != nil {
+		logger.Fatal("Tests failed", log.Error(err))
 		return
 	}
-	log15.Info("Tests passed:", "directory", directory, "indexer", raw_indexer)
+	logger.Info("Tests passed")
 }
 
-func testDirectory(ctx context.Context, indexer []string, directory string) error {
+func testDirectory(ctx context.Context, logger log.Logger, indexer []string, directory string) error {
 	files, err := os.ReadDir(directory)
 	if err != nil {
 		return err
@@ -119,7 +121,7 @@ func testDirectory(ctx context.Context, indexer []string, directory string) erro
 		go func(name string) {
 			defer wg.Done()
 
-			projResult, err := testProject(ctx, indexer, path.Join(directory, name), name)
+			projResult, err := testProject(ctx, logger, indexer, path.Join(directory, name), name)
 			resultChan <- channelResult{
 				name:   name,
 				result: projResult,
@@ -138,7 +140,7 @@ func testDirectory(ctx context.Context, indexer []string, directory string) erro
 		if res.err != nil {
 			successful = false
 
-			log15.Warn("Failed to run test.", "name", res.name)
+			logger.Warn("Failed to run test", log.String("name", res.name))
 			fmt.Println(res.err)
 			continue
 		}
@@ -167,14 +169,14 @@ func testDirectory(ctx context.Context, indexer []string, directory string) erro
 	return nil
 }
 
-func testProject(ctx context.Context, indexer []string, project, name string) (projectResult, error) {
+func testProject(ctx context.Context, logger log.Logger, indexer []string, project, name string) (projectResult, error) {
 	output, err := setupProject(project)
 	if err != nil {
 		return projectResult{name: name, output: string(output)}, err
 	}
 
-	log15.Debug("... Completed setup project", "command", indexer)
-	result, err := runIndexer(ctx, indexer, project, name)
+	logger.Debug("... Completed setup project")
+	result, err := runIndexer(ctx, logger.Scoped("run", "run indexer"), indexer, project, name)
 	if err != nil {
 		return projectResult{
 			name:   name,
@@ -182,21 +184,22 @@ func testProject(ctx context.Context, indexer []string, project, name string) (p
 		}, err
 	}
 
-	log15.Debug("... \t Resource Usage:", "usage", result.usage)
+	usageData, _ := json.Marshal(result.usage)
+	logger.Debug("... \t Resource usage", log.String("usage", string(usageData)))
 
 	bundleResult, err := validateDump(project)
 	if err != nil {
 		return projectResult{}, err
 	}
-	log15.Debug("... Validated dump.lsif")
+	logger.Debug("... Validated dump.lsif")
 
 	bundle, err := readBundle(project)
 	if err != nil {
 		return projectResult{name: name}, err
 	}
-	log15.Debug("... Read bundle")
+	logger.Debug("... Read bundle")
 
-	testResult, err := validateTestCases(project, bundle)
+	testResult, err := validateTestCases(logger.Scoped("validate", "validate test cases"), project, bundle)
 	if err != nil {
 		return projectResult{name: name}, err
 	}
@@ -217,11 +220,11 @@ func setupProject(directory string) ([]byte, error) {
 	return cmd.CombinedOutput()
 }
 
-func runIndexer(ctx context.Context, indexer []string, directory, name string) (projectResult, error) {
+func runIndexer(ctx context.Context, logger log.Logger, indexer []string, directory, name string) (projectResult, error) {
 	command := indexer[0]
 	args := indexer[1:]
 
-	log15.Debug("... Generating dump.lsif")
+	logger.Debug("... Generating dump.lsif")
 	cmd := exec.CommandContext(ctx, command, args...)
 	cmd.Dir = directory
 
@@ -269,11 +272,11 @@ func validateDump(directory string) (bundleResult, error) {
 	return bundleResult{Valid: true}, nil
 }
 
-func validateTestCases(projectRoot string, bundle *precise.GroupedBundleDataMaps) (testSuiteResult, error) {
+func validateTestCases(logger log.Logger, projectRoot string, bundle *precise.GroupedBundleDataMaps) (testSuiteResult, error) {
 	testFiles, err := os.ReadDir(filepath.Join(projectRoot, "lsif_tests"))
 	if err != nil {
 		if os.IsNotExist(err) {
-			log15.Warn("No lsif test directory exists here", "directory", projectRoot)
+			logger.Warn("No lsif test directory exists here", log.String("directory", projectRoot))
 			return testSuiteResult{}, nil
 		}
 
@@ -287,9 +290,9 @@ func validateTestCases(projectRoot string, bundle *precise.GroupedBundleDataMaps
 		}
 
 		testFileName := filepath.Join(projectRoot, "lsif_tests", file.Name())
-		fileResult, err := runOneTestFile(projectRoot, testFileName, bundle)
+		fileResult, err := runOneTestFile(logger, projectRoot, testFileName, bundle)
 		if err != nil {
-			logFatal("Had an error while we do the test file", "file", testFileName, "err", err)
+			logger.Fatal("Had an error while we do the test file", log.String("file", testFileName), log.Error(err))
 		}
 
 		fileResults = append(fileResults, fileResult)
@@ -298,7 +301,7 @@ func validateTestCases(projectRoot string, bundle *precise.GroupedBundleDataMaps
 	return testSuiteResult{FileResults: fileResults}, nil
 }
 
-func runOneTestFile(projectRoot, file string, bundle *precise.GroupedBundleDataMaps) (testFileResult, error) {
+func runOneTestFile(logger log.Logger, projectRoot, file string, bundle *precise.GroupedBundleDataMaps) (testFileResult, error) {
 	doc, err := os.ReadFile(file)
 	if err != nil {
 		return testFileResult{}, errors.Wrap(err, "Failed to read file")
@@ -312,7 +315,7 @@ func runOneTestFile(projectRoot, file string, bundle *precise.GroupedBundleDataM
 	fileResult := testFileResult{Name: file}
 
 	for _, definitionTest := range testCase.Definitions {
-		if err := runOneDefinitionRequest(projectRoot, bundle, definitionTest, &fileResult); err != nil {
+		if err := runOneDefinitionRequest(logger, projectRoot, bundle, definitionTest, &fileResult); err != nil {
 			return fileResult, err
 		}
 	}
@@ -473,7 +476,7 @@ func runOneReferencesRequest(projectRoot string, bundle *precise.GroupedBundleDa
 	return nil
 }
 
-func runOneDefinitionRequest(projectRoot string, bundle *precise.GroupedBundleDataMaps, testCase DefinitionTest, fileResult *testFileResult) error {
+func runOneDefinitionRequest(logger log.Logger, projectRoot string, bundle *precise.GroupedBundleDataMaps, testCase DefinitionTest, fileResult *testFileResult) error {
 	request := testCase.Request
 
 	path := request.TextDocument
@@ -502,11 +505,13 @@ func runOneDefinitionRequest(projectRoot string, bundle *precise.GroupedBundleDa
 	}
 
 	definitions := results[0].Definitions
+	definitionsData, _ := json.Marshal(definitions)
+	definitionsField := log.String("definitions", string(definitionsData))
 
 	if len(definitions) > 1 {
-		logFatal("Had too many definitions", "definitions", definitions)
+		logger.Fatal("Had too many definitions", definitionsField)
 	} else if len(definitions) == 0 {
-		logFatal("Found no definitions", "definitions", definitions)
+		logger.Fatal("Found no definitions", definitionsField)
 	}
 
 	response := transformLocationToResponse(definitions[0])

--- a/lib/gitservice/gitservice.go
+++ b/lib/gitservice/gitservice.go
@@ -10,9 +10,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/inconshreveable/log15"
-
 	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"github.com/sourcegraph/sourcegraph/lib/log"
 )
 
 var uploadPackArgs = []string{
@@ -41,6 +40,8 @@ var uploadPackArgs = []string{
 // protocol. We aim to support modern git features such as protocol v2 to
 // minimize traffic.
 type Handler struct {
+	Logger log.Logger
+
 	// Dir is a funcion which takes a repository name and returns an absolute
 	// path to the GIT_DIR for it.
 	Dir func(string) string
@@ -145,7 +146,7 @@ func (s *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	err = cmd.Run()
 	if err != nil {
 		err = errors.Errorf("error running git service command args=%q: %w", args, err)
-		log15.Error("git-service error", "error", err, "stderr", stderr.String())
+		s.Logger.Error("git-service error", log.Error(err), log.String("stderr", stderr.String()))
 		_, _ = w.Write([]byte("\n" + err.Error() + "\n"))
 	}
 }

--- a/lib/gitservice/gitservice_test.go
+++ b/lib/gitservice/gitservice_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/sourcegraph/sourcegraph/lib/gitservice"
+	"github.com/sourcegraph/sourcegraph/lib/log/logtest"
 )
 
 // numTestCommits determines the number of files/commits/tags to create for
@@ -33,6 +34,7 @@ func TestHandler(t *testing.T) {
 	}
 
 	ts := httptest.NewServer(&gitservice.Handler{
+		Logger: logtest.Scoped(t),
 		Dir: func(s string) string {
 			return filepath.Join(root, s, ".git")
 		},

--- a/lib/go.mod
+++ b/lib/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/grafana/regexp v0.0.0-20220202152701-6a046c4caf32
 	github.com/hexops/autogold v1.3.0
-	github.com/inconshreveable/log15 v0.0.0-20201112154412-8562bdadbbac
 	github.com/json-iterator/go v1.1.12
 	github.com/klauspost/pgzip v1.2.5
 	github.com/mattn/go-isatty v0.0.14
@@ -46,7 +45,6 @@ require (
 	github.com/dlclark/regexp2 v1.4.0 // indirect
 	github.com/dustin/go-humanize v1.0.0 // indirect
 	github.com/getsentry/sentry-go v0.13.0 // indirect
-	github.com/go-stack/stack v1.8.1 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/gorilla/css v1.0.0 // indirect
 	github.com/hexops/gotextdiff v1.0.3 // indirect

--- a/lib/go.sum
+++ b/lib/go.sum
@@ -92,8 +92,6 @@ github.com/go-check/check v0.0.0-20180628173108-788fd7840127/go.mod h1:9ES+weclK
 github.com/go-errors/errors v1.0.1 h1:LUHzmkK3GUKUrL/1gfBUxAHzcev3apQlezX/+O7ma6w=
 github.com/go-errors/errors v1.0.1/go.mod h1:f4zRHt4oKfwPJE5k8C9vpYG+aDHdBFUsgrm6/TyX73Q=
 github.com/go-martini/martini v0.0.0-20170121215854-22fa46961aab/go.mod h1:/P9AEU963A2AYjv4d1V5eVL1CQbEJq6aCNHDDjibzu8=
-github.com/go-stack/stack v1.8.1 h1:ntEHSVwIt7PNXNpgPmVfMrNhLtgjlmnZha2kOpuRiDw=
-github.com/go-stack/stack v1.8.1/go.mod h1:dcoOX6HbPZSZptuspn9bctJ+N/CnF5gGygcUP3XYfe4=
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
 github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
 github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
@@ -161,8 +159,6 @@ github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpO
 github.com/hydrogen18/memlistener v0.0.0-20141126152155-54553eb933fb/go.mod h1:qEIFzExnS6016fRpRfxrExeVn2gbClQA99gQhnIcdhE=
 github.com/hydrogen18/memlistener v0.0.0-20200120041712-dcc25e7acd91/go.mod h1:qEIFzExnS6016fRpRfxrExeVn2gbClQA99gQhnIcdhE=
 github.com/imkira/go-interpol v1.1.0/go.mod h1:z0h2/2T3XF8kyEPpRgJ3kmNv+C43p+I/CoI+jC3w2iA=
-github.com/inconshreveable/log15 v0.0.0-20201112154412-8562bdadbbac h1:n1DqxAo4oWPMvH1+v+DLYlMCecgumhhgnxAPdqDIFHI=
-github.com/inconshreveable/log15 v0.0.0-20201112154412-8562bdadbbac/go.mod h1:cOaXtrgN4ScfRrD9Bre7U1thNq5RtJ8ZoP4iXVGRj6o=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/iris-contrib/blackfriday v2.0.0+incompatible/go.mod h1:UzZ2bDEoaSGPbkg6SAB4att1aAwTmVIx/5gCVqeyUdI=
 github.com/iris-contrib/go.uuid v2.0.0+incompatible/go.mod h1:iz2lgM/1UnEf1kP0L/+fafWORmlnuysV2EMP8MW+qe0=


### PR DESCRIPTION
Removes all usages of log15 from lib, so that we can drop the import completely from lib.

<img width="723" alt="image" src="https://user-images.githubusercontent.com/23356519/171063712-57e72f44-ab6e-44fe-b88d-e2f2dcc88f38.png">

I thought this would be super quick so didn't think to create a gitstart issue, but the LSIF testing ended up being a little involved... but I already started, so oh well.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Tests pass