### PR TITLE
dev/sg: improve secretmanager error messages

### DIFF
--- a/dev/sg/internal/run/command.go
+++ b/dev/sg/internal/run/command.go
@@ -136,7 +136,7 @@ func getSecrets(ctx context.Context, cmd Command) (map[string]string, error) {
 
 	secretsStore, err := secrets.FromContext(ctx)
 	if err != nil {
-		return nil, errors.Errorf("failed to create secretmanager client: %v", err)
+		return nil, errors.Errorf("failed to get secrets store: %v", err)
 	}
 
 	var errs error


### PR DESCRIPTION
Improve error messages for secretmanager, based on https://sourcegraph.slack.com/archives/C02MWRMAFR8/p1653949251004029?thread_ts=1653946332.944579&cid=C02MWRMAFR8

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

n/a