### PR TITLE
database: remove dbutil-based constructors

### DIFF
--- a/cmd/frontend/graphqlbackend/external_accounts.go
+++ b/cmd/frontend/graphqlbackend/external_accounts.go
@@ -121,7 +121,7 @@ func (r *schemaResolver) DeleteExternalAccount(ctx context.Context, args *struct
 	if err != nil {
 		return nil, err
 	}
-	account, err := database.ExternalAccounts(r.db).Get(ctx, id)
+	account, err := r.db.UserExternalAccounts().Get(ctx, id)
 	if err != nil {
 		return nil, err
 	}
@@ -131,7 +131,7 @@ func (r *schemaResolver) DeleteExternalAccount(ctx context.Context, args *struct
 		return nil, err
 	}
 
-	if err := database.ExternalAccounts(r.db).Delete(ctx, account.ID); err != nil {
+	if err := r.db.UserExternalAccounts().Delete(ctx, account.ID); err != nil {
 		return nil, err
 	}
 

--- a/cmd/frontend/graphqlbackend/external_service_collaborators.go
+++ b/cmd/frontend/graphqlbackend/external_service_collaborators.go
@@ -102,7 +102,7 @@ func (r *externalServiceResolver) InvitableCollaborators(ctx context.Context) ([
 		return nil, err
 	}
 
-	authUserEmails, err := database.UserEmails(r.db).ListByUser(ctx, database.UserEmailsListOptions{
+	authUserEmails, err := r.db.UserEmails().ListByUser(ctx, database.UserEmailsListOptions{
 		UserID: a.UID,
 	})
 	if err != nil {

--- a/cmd/frontend/graphqlbackend/org_invitations.go
+++ b/cmd/frontend/graphqlbackend/org_invitations.go
@@ -513,7 +513,7 @@ func sendOrgInvitationNotification(ctx context.Context, db database.DB, org *typ
 		// Basic abuse prevention for Sourcegraph.com.
 
 		// Only allow email-verified users to send invites.
-		if _, senderEmailVerified, err := database.UserEmails(db).GetPrimaryEmail(ctx, sender.ID); err != nil {
+		if _, senderEmailVerified, err := db.UserEmails().GetPrimaryEmail(ctx, sender.ID); err != nil {
 			return err
 		} else if !senderEmailVerified {
 			return errors.New("must verify your email address to invite a user to an organization")

--- a/cmd/frontend/graphqlbackend/survey_response.go
+++ b/cmd/frontend/graphqlbackend/survey_response.go
@@ -94,7 +94,7 @@ func (r *schemaResolver) SubmitSurvey(ctx context.Context, args *struct {
 	actor := actor.FromContext(ctx)
 	if actor.IsAuthenticated() {
 		uid = &actor.UID
-		e, _, err := database.UserEmails(r.db).GetPrimaryEmail(ctx, actor.UID)
+		e, _, err := r.db.UserEmails().GetPrimaryEmail(ctx, actor.UID)
 		if err != nil && !errcode.IsNotFound(err) {
 			return nil, err
 		}
@@ -159,7 +159,7 @@ func (r *schemaResolver) SubmitHappinessFeedback(ctx context.Context, args *stru
 
 		// If user is authenticated, use their uid and set the email field.
 		if actor.IsAuthenticated() {
-			e, _, err := database.UserEmails(r.db).GetPrimaryEmail(ctx, actor.UID)
+			e, _, err := r.db.UserEmails().GetPrimaryEmail(ctx, actor.UID)
 			if err != nil && !errcode.IsNotFound(err) {
 				return nil, err
 			}

--- a/cmd/frontend/graphqlbackend/trial_request.go
+++ b/cmd/frontend/graphqlbackend/trial_request.go
@@ -6,7 +6,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/hubspot/hubspotutil"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/siteid"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
-	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
 )
 
@@ -23,7 +22,7 @@ func (r *schemaResolver) RequestTrial(ctx context.Context, args *struct {
 
 	// If user is authenticated, use their uid and overwrite the optional email field.
 	if actor := actor.FromContext(ctx); actor.IsAuthenticated() {
-		e, _, err := database.UserEmails(r.db).GetPrimaryEmail(ctx, actor.UID)
+		e, _, err := r.db.UserEmails().GetPrimaryEmail(ctx, actor.UID)
 		if err != nil && !errcode.IsNotFound(err) {
 			return nil, err
 		}

--- a/cmd/frontend/graphqlbackend/user.go
+++ b/cmd/frontend/graphqlbackend/user.go
@@ -24,9 +24,9 @@ import (
 func (r *schemaResolver) User(
 	ctx context.Context,
 	args struct {
-	Username *string
-	Email    *string
-},
+		Username *string
+		Email    *string
+	},
 ) (*UserResolver, error) {
 	var err error
 	var user *types.User

--- a/cmd/frontend/graphqlbackend/user.go
+++ b/cmd/frontend/graphqlbackend/user.go
@@ -24,9 +24,9 @@ import (
 func (r *schemaResolver) User(
 	ctx context.Context,
 	args struct {
-		Username *string
-		Email    *string
-	},
+	Username *string
+	Email    *string
+},
 ) (*UserResolver, error) {
 	var err error
 	var user *types.User
@@ -115,7 +115,7 @@ func (r *UserResolver) Email(ctx context.Context) (string, error) {
 		}
 	}
 
-	email, _, err := database.UserEmails(r.db).GetPrimaryEmail(ctx, r.user.ID)
+	email, _, err := r.db.UserEmails().GetPrimaryEmail(ctx, r.user.ID)
 	if err != nil && !errcode.IsNotFound(err) {
 		return "", err
 	}

--- a/cmd/frontend/graphqlbackend/user_collaborators.go
+++ b/cmd/frontend/graphqlbackend/user_collaborators.go
@@ -48,7 +48,7 @@ func (r *UserResolver) InvitableCollaborators(ctx context.Context) ([]*invitable
 	// In parallel collect all recent committers info for the few repos we're going to scan.
 	recentCommitters := gitserverParallelRecentCommitters(ctx, db, pickedRepos, git.Commits)
 
-	authUserEmails, err := database.UserEmails(db).ListByUser(ctx, database.UserEmailsListOptions{
+	authUserEmails, err := db.UserEmails().ListByUser(ctx, database.UserEmailsListOptions{
 		UserID: a.UID,
 	})
 	if err != nil {

--- a/cmd/frontend/graphqlbackend/user_emails.go
+++ b/cmd/frontend/graphqlbackend/user_emails.go
@@ -24,7 +24,7 @@ func (r *UserResolver) Emails(ctx context.Context) ([]*userEmailResolver, error)
 		return nil, err
 	}
 
-	userEmails, err := database.UserEmails(r.db).ListByUser(ctx, database.UserEmailsListOptions{
+	userEmails, err := r.db.UserEmails().ListByUser(ctx, database.UserEmailsListOptions{
 		UserID: r.user.ID,
 	})
 	if err != nil {
@@ -178,7 +178,7 @@ func (r *schemaResolver) SetUserEmailPrimary(ctx context.Context, args *setUserE
 		}
 	}
 
-	if err := database.UserEmails(r.db).SetPrimaryEmail(ctx, userID, args.Email); err != nil {
+	if err := r.db.UserEmails().SetPrimaryEmail(ctx, userID, args.Email); err != nil {
 		return nil, err
 	}
 

--- a/cmd/frontend/internal/app/updatecheck/client.go
+++ b/cmd/frontend/internal/app/updatecheck/client.go
@@ -123,7 +123,7 @@ func getUsersActiveTodayCount(ctx context.Context) (_ int, err error) {
 
 func getInitialSiteAdminInfo(ctx context.Context, db database.DB) (_ string, _ bool, err error) {
 	defer recordOperation("getInitialSiteAdminInfo")(&err)
-	return database.UserEmails(db).GetInitialSiteAdminInfo(ctx)
+	return db.UserEmails().GetInitialSiteAdminInfo(ctx)
 }
 
 func getAndMarshalBatchChangesUsageJSON(ctx context.Context, db database.DB) (_ json.RawMessage, err error) {

--- a/cmd/frontend/internal/auth/userpasswd/handlers.go
+++ b/cmd/frontend/internal/auth/userpasswd/handlers.go
@@ -201,7 +201,7 @@ func handleSignUp(db database.DB, w http.ResponseWriter, r *http.Request, failIf
 	if conf.EmailVerificationRequired() && !newUserData.EmailIsVerified {
 		if err := backend.SendUserEmailVerificationEmail(r.Context(), usr.Username, creds.Email, newUserData.EmailVerificationCode); err != nil {
 			log15.Error("failed to send email verification (continuing, user's email will be unverified)", "email", creds.Email, "err", err)
-		} else if err = database.UserEmails(db).SetLastVerification(r.Context(), usr.ID, creds.Email, newUserData.EmailVerificationCode); err != nil {
+		} else if err = db.UserEmails().SetLastVerification(r.Context(), usr.ID, creds.Email, newUserData.EmailVerificationCode); err != nil {
 			log15.Error("failed to set email last verification sent at (user's email is verified)", "email", creds.Email, "err", err)
 		}
 	}

--- a/cmd/frontend/internal/httpapi/internal.go
+++ b/cmd/frontend/internal/httpapi/internal.go
@@ -239,7 +239,7 @@ func serveUserEmailsGetEmail(db database.DB) func(http.ResponseWriter, *http.Req
 		if err != nil {
 			return errors.Wrap(err, "Decode")
 		}
-		email, _, err := database.UserEmails(db).GetPrimaryEmail(r.Context(), userID)
+		email, _, err := db.UserEmails().GetPrimaryEmail(r.Context(), userID)
 		if err != nil {
 			return errors.Wrap(err, "UserEmails.GetEmail")
 		}

--- a/cmd/frontend/internal/httpapi/webhookhandlers/handle_user_authz_event.go
+++ b/cmd/frontend/internal/httpapi/webhookhandlers/handle_user_authz_event.go
@@ -60,7 +60,7 @@ func scheduleUserUpdate(ctx context.Context, db database.DB, extSvc *types.Exter
 	if githubUser == nil {
 		return nil
 	}
-	accs, err := database.ExternalAccounts(db).List(ctx, database.ExternalAccountsListOptions{
+	accs, err := db.UserExternalAccounts().List(ctx, database.ExternalAccountsListOptions{
 		ServiceID:   fmt.Sprint(extSvc.ID),
 		ServiceType: "github",
 		AccountID:   githubUser.GetID(),

--- a/cmd/worker/internal/migrations/migrators/external_accounts_migrator_test.go
+++ b/cmd/worker/internal/migrations/migrators/external_accounts_migrator_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/encryption/keyring"
 	et "github.com/sourcegraph/sourcegraph/internal/encryption/testing"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
@@ -33,7 +32,7 @@ func TestExternalAccountsMigrator(t *testing.T) {
 		}
 	}
 
-	createAccounts := func(db dbutil.DB, n int) []*extsvc.Account {
+	createAccounts := func(db database.DB, n int) []*extsvc.Account {
 		accounts := make([]*extsvc.Account, 0, n)
 
 		for i := 0; i < n; i++ {
@@ -49,7 +48,7 @@ func TestExternalAccountsMigrator(t *testing.T) {
 				AuthData: &authData,
 				Data:     &data,
 			}
-			_, err := database.ExternalAccounts(db).CreateUserAndSave(ctx, database.NewUser{Username: fmt.Sprintf("u-%d", i)}, spec, accData)
+			_, err := db.UserExternalAccounts().CreateUserAndSave(ctx, database.NewUser{Username: fmt.Sprintf("u-%d", i)}, spec, accData)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -63,7 +62,7 @@ func TestExternalAccountsMigrator(t *testing.T) {
 	}
 
 	t.Run("Up/Down/Progress", func(t *testing.T) {
-		db := dbtest.NewDB(t)
+		db := database.NewDB(dbtest.NewDB(t))
 
 		migrator := NewExternalAccountsMigratorWithDB(db)
 		migrator.BatchSize = 2
@@ -133,7 +132,7 @@ func TestExternalAccountsMigrator(t *testing.T) {
 	})
 
 	t.Run("Up/Encryption", func(t *testing.T) {
-		db := dbtest.NewDB(t)
+		db := database.NewDB(dbtest.NewDB(t))
 
 		migrator := NewExternalAccountsMigratorWithDB(db)
 		migrator.BatchSize = 10
@@ -150,7 +149,7 @@ func TestExternalAccountsMigrator(t *testing.T) {
 		}
 
 		// was the data actually encrypted?
-		rows, err := db.Query("SELECT auth_data, account_data, encryption_key_id FROM user_external_accounts ORDER BY id")
+		rows, err := db.QueryContext(ctx, "SELECT auth_data, account_data, encryption_key_id FROM user_external_accounts ORDER BY id")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -190,7 +189,7 @@ func TestExternalAccountsMigrator(t *testing.T) {
 	})
 
 	t.Run("Down/Decryption", func(t *testing.T) {
-		db := dbtest.NewDB(t)
+		db := database.NewDB(dbtest.NewDB(t))
 
 		migrator := NewExternalAccountsMigratorWithDB(db)
 		migrator.BatchSize = 10
@@ -213,7 +212,7 @@ func TestExternalAccountsMigrator(t *testing.T) {
 		}
 
 		// was the config actually reverted?
-		rows, err := db.Query("SELECT auth_data, account_data, encryption_key_id FROM user_external_accounts ORDER BY id")
+		rows, err := db.QueryContext(ctx, "SELECT auth_data, account_data, encryption_key_id FROM user_external_accounts ORDER BY id")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -244,7 +243,7 @@ func TestExternalAccountsMigrator(t *testing.T) {
 	})
 
 	t.Run("Up/InvalidKey", func(t *testing.T) {
-		db := dbtest.NewDB(t)
+		db := database.NewDB(dbtest.NewDB(t))
 
 		migrator := NewExternalAccountsMigratorWithDB(db)
 		migrator.BatchSize = 10
@@ -267,7 +266,7 @@ func TestExternalAccountsMigrator(t *testing.T) {
 	})
 
 	t.Run("Down/Disabled Decryption", func(t *testing.T) {
-		db := dbtest.NewDB(t)
+		db := database.NewDB(dbtest.NewDB(t))
 
 		migrator := NewExternalAccountsMigratorWithDB(db)
 		migrator.BatchSize = 10
@@ -289,7 +288,7 @@ func TestExternalAccountsMigrator(t *testing.T) {
 		}
 
 		// was the config actually reverted?
-		rows, err := db.Query("SELECT auth_data, account_data, encryption_key_id FROM user_external_accounts ORDER BY id")
+		rows, err := db.QueryContext(ctx, "SELECT auth_data, account_data, encryption_key_id FROM user_external_accounts ORDER BY id")
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/enterprise/cmd/frontend/internal/batches/resolvers/main_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/main_test.go
@@ -228,12 +228,12 @@ func addChangeset(t *testing.T, ctx context.Context, s *store.Store, c *btypes.C
 
 func pruneUserCredentials(t *testing.T, db database.DB, key encryption.Key) {
 	t.Helper()
-	creds, _, err := database.UserCredentials(db, key).List(context.Background(), database.UserCredentialsListOpts{})
+	creds, _, err := db.UserCredentials(key).List(context.Background(), database.UserCredentialsListOpts{})
 	if err != nil {
 		t.Fatal(err)
 	}
 	for _, c := range creds {
-		if err := database.UserCredentials(db, key).Delete(context.Background(), c.ID); err != nil {
+		if err := db.UserCredentials(key).Delete(context.Background(), c.ID); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/enterprise/cmd/repo-updater/internal/authz/integration_test.go
+++ b/enterprise/cmd/repo-updater/internal/authz/integration_test.go
@@ -88,7 +88,7 @@ func TestIntegration_GitHubPermissions(t *testing.T) {
 			}
 			cli := extsvcGitHub.NewV3Client(logtest.Scoped(t), svc.URN(), uri, &auth.OAuthBearerToken{Token: token}, doer)
 
-			testDB := dbtest.NewDB(t)
+			testDB := database.NewDB(dbtest.NewDB(t))
 			ctx := actor.WithInternalActor(context.Background())
 
 			reposStore := repos.NewStore(database.NewDB(testDB), sql.TxOptions{})
@@ -128,7 +128,7 @@ func TestIntegration_GitHubPermissions(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			userID, err := database.ExternalAccounts(testDB).CreateUserAndSave(ctx, newUser, spec, extsvc.AccountData{})
+			userID, err := testDB.UserExternalAccounts().CreateUserAndSave(ctx, newUser, spec, extsvc.AccountData{})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -169,7 +169,7 @@ func TestIntegration_GitHubPermissions(t *testing.T) {
 			}
 			cli := extsvcGitHub.NewV3Client(logtest.Scoped(t), svc.URN(), uri, &auth.OAuthBearerToken{Token: token}, doer)
 
-			testDB := dbtest.NewDB(t)
+			testDB := database.NewDB(dbtest.NewDB(t))
 			ctx := actor.WithInternalActor(context.Background())
 
 			reposStore := repos.NewStore(database.NewDB(testDB), sql.TxOptions{})
@@ -209,7 +209,7 @@ func TestIntegration_GitHubPermissions(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			userID, err := database.ExternalAccounts(testDB).CreateUserAndSave(ctx, newUser, spec, extsvc.AccountData{})
+			userID, err := testDB.UserExternalAccounts().CreateUserAndSave(ctx, newUser, spec, extsvc.AccountData{})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -273,7 +273,7 @@ func TestIntegration_GitHubPermissions(t *testing.T) {
 			}
 			cli := extsvcGitHub.NewV3Client(logtest.Scoped(t), svc.URN(), uri, &auth.OAuthBearerToken{Token: token}, doer)
 
-			testDB := dbtest.NewDB(t)
+			testDB := database.NewDB(dbtest.NewDB(t))
 			ctx := actor.WithInternalActor(context.Background())
 
 			reposStore := repos.NewStore(database.NewDB(testDB), sql.TxOptions{})
@@ -314,7 +314,7 @@ func TestIntegration_GitHubPermissions(t *testing.T) {
 			}
 
 			authData := json.RawMessage(fmt.Sprintf(`{"access_token": "%s"}`, token))
-			userID, err := database.ExternalAccounts(testDB).CreateUserAndSave(ctx, newUser, spec, extsvc.AccountData{
+			userID, err := testDB.UserExternalAccounts().CreateUserAndSave(ctx, newUser, spec, extsvc.AccountData{
 				AuthData: &authData,
 			})
 			if err != nil {
@@ -357,7 +357,7 @@ func TestIntegration_GitHubPermissions(t *testing.T) {
 			}
 			cli := extsvcGitHub.NewV3Client(logtest.Scoped(t), svc.URN(), uri, &auth.OAuthBearerToken{Token: token}, doer)
 
-			testDB := dbtest.NewDB(t)
+			testDB := database.NewDB(dbtest.NewDB(t))
 			ctx := actor.WithInternalActor(context.Background())
 
 			reposStore := repos.NewStore(database.NewDB(testDB), sql.TxOptions{})
@@ -398,7 +398,7 @@ func TestIntegration_GitHubPermissions(t *testing.T) {
 			}
 
 			authData := json.RawMessage(fmt.Sprintf(`{"access_token": "%s"}`, token))
-			userID, err := database.ExternalAccounts(testDB).CreateUserAndSave(ctx, newUser, spec, extsvc.AccountData{
+			userID, err := testDB.UserExternalAccounts().CreateUserAndSave(ctx, newUser, spec, extsvc.AccountData{
 				AuthData: &authData,
 			})
 			if err != nil {

--- a/enterprise/internal/database/authz_test.go
+++ b/enterprise/internal/database/authz_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestAuthzStore_GrantPendingPermissions(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	ctx := context.Background()
 
 	// Create user with initially verified email
@@ -30,23 +30,23 @@ func TestAuthzStore_GrantPendingPermissions(t *testing.T) {
 	code := "verify-code"
 
 	// Add and verify the second email
-	err = database.UserEmails(db).Add(ctx, user.ID, "alice2@example.com", &code)
+	err = db.UserEmails().Add(ctx, user.ID, "alice2@example.com", &code)
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = database.UserEmails(db).SetVerified(ctx, user.ID, "alice2@example.com", true)
+	err = db.UserEmails().SetVerified(ctx, user.ID, "alice2@example.com", true)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// Add third email and leave as unverified
-	err = database.UserEmails(db).Add(ctx, user.ID, "alice3@example.com", &code)
+	err = db.UserEmails().Add(ctx, user.ID, "alice3@example.com", &code)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// Add two external accounts
-	err = database.ExternalAccounts(db).AssociateUserAndSave(ctx, user.ID,
+	err = db.UserExternalAccounts().AssociateUserAndSave(ctx, user.ID,
 		extsvc.AccountSpec{
 			ServiceType: "gitlab",
 			ServiceID:   "https://gitlab.com/",
@@ -57,7 +57,7 @@ func TestAuthzStore_GrantPendingPermissions(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = database.ExternalAccounts(db).AssociateUserAndSave(ctx, user.ID,
+	err = db.UserExternalAccounts().AssociateUserAndSave(ctx, user.ID,
 		extsvc.AccountSpec{
 			ServiceType: "github",
 			ServiceID:   "https://github.com/",
@@ -221,7 +221,7 @@ func TestAuthzStore_GrantPendingPermissions(t *testing.T) {
 }
 
 func TestAuthzStore_AuthorizedRepos(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	ctx := context.Background()
 
 	s := NewAuthzStore(db, clock).(*authzStore)
@@ -315,7 +315,7 @@ func TestAuthzStore_AuthorizedRepos(t *testing.T) {
 }
 
 func TestAuthzStore_RevokeUserPermissions(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	ctx := context.Background()
 
 	s := NewAuthzStore(db, clock).(*authzStore)

--- a/internal/database/external_accounts.go
+++ b/internal/database/external_accounts.go
@@ -11,7 +11,6 @@ import (
 	otlog "github.com/opentracing/opentracing-go/log"
 
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/encryption"
 	"github.com/sourcegraph/sourcegraph/internal/encryption/keyring"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
@@ -96,11 +95,6 @@ type userExternalAccountsStore struct {
 	*basestore.Store
 
 	key encryption.Key
-}
-
-// ExternalAccounts instantiates and returns a new UserExternalAccountsStore with prepared statements.
-func ExternalAccounts(db dbutil.DB) UserExternalAccountsStore {
-	return &userExternalAccountsStore{Store: basestore.NewWithDB(db, sql.TxOptions{})}
 }
 
 // ExternalAccountsWith instantiates and returns a new UserExternalAccountsStore using the other store handle.

--- a/internal/database/external_accounts_test.go
+++ b/internal/database/external_accounts_test.go
@@ -21,7 +21,7 @@ func TestExternalAccounts_LookupUserAndSave(t *testing.T) {
 		t.Skip()
 	}
 	t.Parallel()
-	db := dbtest.NewDB(t)
+	db := NewDB(dbtest.NewDB(t))
 	ctx := context.Background()
 
 	spec := extsvc.AccountSpec{
@@ -30,12 +30,12 @@ func TestExternalAccounts_LookupUserAndSave(t *testing.T) {
 		ClientID:    "xc",
 		AccountID:   "xd",
 	}
-	userID, err := ExternalAccounts(db).CreateUserAndSave(ctx, NewUser{Username: "u"}, spec, extsvc.AccountData{})
+	userID, err := db.UserExternalAccounts().CreateUserAndSave(ctx, NewUser{Username: "u"}, spec, extsvc.AccountData{})
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	lookedUpUserID, err := ExternalAccounts(db).LookupUserAndSave(ctx, spec, extsvc.AccountData{})
+	lookedUpUserID, err := db.UserExternalAccounts().LookupUserAndSave(ctx, spec, extsvc.AccountData{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -49,7 +49,7 @@ func TestExternalAccounts_AssociateUserAndSave(t *testing.T) {
 		t.Skip()
 	}
 	t.Parallel()
-	db := dbtest.NewDB(t)
+	db := NewDB(dbtest.NewDB(t))
 	ctx := context.Background()
 
 	user, err := Users(db).Create(ctx, NewUser{Username: "u"})
@@ -70,11 +70,11 @@ func TestExternalAccounts_AssociateUserAndSave(t *testing.T) {
 		AuthData: &authData,
 		Data:     &data,
 	}
-	if err := ExternalAccounts(db).AssociateUserAndSave(ctx, user.ID, spec, accountData); err != nil {
+	if err := db.UserExternalAccounts().AssociateUserAndSave(ctx, user.ID, spec, accountData); err != nil {
 		t.Fatal(err)
 	}
 
-	accounts, err := ExternalAccounts(db).List(ctx, ExternalAccountsListOptions{})
+	accounts, err := db.UserExternalAccounts().List(ctx, ExternalAccountsListOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -100,7 +100,7 @@ func TestExternalAccounts_CreateUserAndSave(t *testing.T) {
 		t.Skip()
 	}
 	t.Parallel()
-	db := dbtest.NewDB(t)
+	db := NewDB(dbtest.NewDB(t))
 	ctx := context.Background()
 
 	spec := extsvc.AccountSpec{
@@ -116,7 +116,7 @@ func TestExternalAccounts_CreateUserAndSave(t *testing.T) {
 		AuthData: &authData,
 		Data:     &data,
 	}
-	userID, err := ExternalAccounts(db).CreateUserAndSave(ctx, NewUser{Username: "u"}, spec, accountData)
+	userID, err := db.UserExternalAccounts().CreateUserAndSave(ctx, NewUser{Username: "u"}, spec, accountData)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -129,7 +129,7 @@ func TestExternalAccounts_CreateUserAndSave(t *testing.T) {
 		t.Errorf("got %q, want %q", user.Username, want)
 	}
 
-	accounts, err := ExternalAccounts(db).List(ctx, ExternalAccountsListOptions{})
+	accounts, err := db.UserExternalAccounts().List(ctx, ExternalAccountsListOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -155,7 +155,7 @@ func TestExternalAccounts_CreateUserAndSave_NilData(t *testing.T) {
 		t.Skip()
 	}
 	t.Parallel()
-	db := dbtest.NewDB(t)
+	db := NewDB(dbtest.NewDB(t))
 	ctx := context.Background()
 
 	spec := extsvc.AccountSpec{
@@ -165,7 +165,7 @@ func TestExternalAccounts_CreateUserAndSave_NilData(t *testing.T) {
 		AccountID:   "xd",
 	}
 
-	userID, err := ExternalAccounts(db).CreateUserAndSave(ctx, NewUser{Username: "u"}, spec, extsvc.AccountData{})
+	userID, err := db.UserExternalAccounts().CreateUserAndSave(ctx, NewUser{Username: "u"}, spec, extsvc.AccountData{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -178,7 +178,7 @@ func TestExternalAccounts_CreateUserAndSave_NilData(t *testing.T) {
 		t.Errorf("got %q, want %q", user.Username, want)
 	}
 
-	accounts, err := ExternalAccounts(db).List(ctx, ExternalAccountsListOptions{})
+	accounts, err := db.UserExternalAccounts().List(ctx, ExternalAccountsListOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -203,7 +203,7 @@ func TestExternalAccounts_List(t *testing.T) {
 		t.Skip()
 	}
 	t.Parallel()
-	db := dbtest.NewDB(t)
+	db := NewDB(dbtest.NewDB(t))
 	ctx := context.Background()
 
 	specs := []extsvc.AccountSpec{
@@ -229,7 +229,7 @@ func TestExternalAccounts_List(t *testing.T) {
 	userIDs := make([]int32, 0, len(specs))
 
 	for i, spec := range specs {
-		id, err := ExternalAccounts(db).CreateUserAndSave(ctx, NewUser{Username: fmt.Sprintf("u%d", i)}, spec, extsvc.AccountData{})
+		id, err := db.UserExternalAccounts().CreateUserAndSave(ctx, NewUser{Username: fmt.Sprintf("u%d", i)}, spec, extsvc.AccountData{})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -286,7 +286,7 @@ func TestExternalAccounts_List(t *testing.T) {
 
 	for _, c := range tc {
 		t.Run(c.name, func(t *testing.T) {
-			accounts, err := ExternalAccounts(db).List(ctx, c.args)
+			accounts, err := db.UserExternalAccounts().List(ctx, c.args)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -314,10 +314,10 @@ func TestExternalAccounts_Encryption(t *testing.T) {
 		t.Skip()
 	}
 	t.Parallel()
-	db := dbtest.NewDB(t)
+	db := NewDB(dbtest.NewDB(t))
 	ctx := context.Background()
 
-	store := ExternalAccounts(db).WithEncryptionKey(et.TestKey{})
+	store := db.UserExternalAccounts().WithEncryptionKey(et.TestKey{})
 
 	spec := extsvc.AccountSpec{
 		ServiceType: "xa",
@@ -407,7 +407,7 @@ func TestExternalAccounts_expiredAt(t *testing.T) {
 		t.Skip()
 	}
 	t.Parallel()
-	db := dbtest.NewDB(t)
+	db := NewDB(dbtest.NewDB(t))
 	ctx := context.Background()
 
 	spec := extsvc.AccountSpec{
@@ -416,12 +416,12 @@ func TestExternalAccounts_expiredAt(t *testing.T) {
 		ClientID:    "xc",
 		AccountID:   "xd",
 	}
-	userID, err := ExternalAccounts(db).CreateUserAndSave(ctx, NewUser{Username: "u"}, spec, extsvc.AccountData{})
+	userID, err := db.UserExternalAccounts().CreateUserAndSave(ctx, NewUser{Username: "u"}, spec, extsvc.AccountData{})
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	accts, err := ExternalAccounts(db).List(ctx, ExternalAccountsListOptions{UserID: userID})
+	accts, err := db.UserExternalAccounts().List(ctx, ExternalAccountsListOptions{UserID: userID})
 	if err != nil {
 		t.Fatal(err)
 	} else if len(accts) != 1 {
@@ -430,12 +430,12 @@ func TestExternalAccounts_expiredAt(t *testing.T) {
 	acct := accts[0]
 
 	t.Run("Exclude expired", func(t *testing.T) {
-		err := ExternalAccounts(db).TouchExpired(ctx, acct.ID)
+		err := db.UserExternalAccounts().TouchExpired(ctx, acct.ID)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		accts, err := ExternalAccounts(db).List(ctx, ExternalAccountsListOptions{
+		accts, err := db.UserExternalAccounts().List(ctx, ExternalAccountsListOptions{
 			UserID:         userID,
 			ExcludeExpired: true,
 		})
@@ -449,17 +449,17 @@ func TestExternalAccounts_expiredAt(t *testing.T) {
 	})
 
 	t.Run("LookupUserAndSave should set expired_at to NULL", func(t *testing.T) {
-		err := ExternalAccounts(db).TouchExpired(ctx, acct.ID)
+		err := db.UserExternalAccounts().TouchExpired(ctx, acct.ID)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		_, err = ExternalAccounts(db).LookupUserAndSave(ctx, spec, extsvc.AccountData{})
+		_, err = db.UserExternalAccounts().LookupUserAndSave(ctx, spec, extsvc.AccountData{})
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		accts, err := ExternalAccounts(db).List(ctx, ExternalAccountsListOptions{
+		accts, err := db.UserExternalAccounts().List(ctx, ExternalAccountsListOptions{
 			UserID:         userID,
 			ExcludeExpired: true,
 		})
@@ -473,17 +473,17 @@ func TestExternalAccounts_expiredAt(t *testing.T) {
 	})
 
 	t.Run("AssociateUserAndSave should set expired_at to NULL", func(t *testing.T) {
-		err := ExternalAccounts(db).TouchExpired(ctx, acct.ID)
+		err := db.UserExternalAccounts().TouchExpired(ctx, acct.ID)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		err = ExternalAccounts(db).AssociateUserAndSave(ctx, userID, spec, extsvc.AccountData{})
+		err = db.UserExternalAccounts().AssociateUserAndSave(ctx, userID, spec, extsvc.AccountData{})
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		accts, err := ExternalAccounts(db).List(ctx, ExternalAccountsListOptions{
+		accts, err := db.UserExternalAccounts().List(ctx, ExternalAccountsListOptions{
 			UserID:         userID,
 			ExcludeExpired: true,
 		})
@@ -497,17 +497,17 @@ func TestExternalAccounts_expiredAt(t *testing.T) {
 	})
 
 	t.Run("TouchLastValid should set expired_at to NULL", func(t *testing.T) {
-		err := ExternalAccounts(db).TouchExpired(ctx, acct.ID)
+		err := db.UserExternalAccounts().TouchExpired(ctx, acct.ID)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		err = ExternalAccounts(db).TouchLastValid(ctx, acct.ID)
+		err = db.UserExternalAccounts().TouchLastValid(ctx, acct.ID)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		accts, err := ExternalAccounts(db).List(ctx, ExternalAccountsListOptions{
+		accts, err := db.UserExternalAccounts().List(ctx, ExternalAccountsListOptions{
 			UserID:         userID,
 			ExcludeExpired: true,
 		})

--- a/internal/database/user_credentials.go
+++ b/internal/database/user_credentials.go
@@ -9,7 +9,6 @@ import (
 	"github.com/keegancsmith/sqlf"
 
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/encryption"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/auth"
 	"github.com/sourcegraph/sourcegraph/internal/timeutil"
@@ -120,14 +119,6 @@ type UserCredentialsStore interface {
 type userCredentialsStore struct {
 	*basestore.Store
 	key encryption.Key
-}
-
-// UserCredentials instantiates and returns a new UserCredentialsStore with prepared statements.
-func UserCredentials(db dbutil.DB, key encryption.Key) UserCredentialsStore {
-	return &userCredentialsStore{
-		Store: basestore.NewWithDB(db, sql.TxOptions{}),
-		key:   key,
-	}
 }
 
 // UserCredentialsWith instantiates and returns a new UserCredentialsStore using the other store handle.

--- a/internal/database/user_credentials_test.go
+++ b/internal/database/user_credentials_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/rand"
 	"crypto/rsa"
-	"database/sql"
 	"math/big"
 	"net/http"
 	"reflect"
@@ -159,7 +158,7 @@ func TestUserCredential_SetAuthenticator(t *testing.T) {
 
 func TestUserCredentials_CreateUpdate(t *testing.T) {
 	t.Parallel()
-	db := dbtest.NewDB(t)
+	db := NewDB(dbtest.NewDB(t))
 	ctx, key, user := setUpUserCredentialTest(t, db)
 
 	// Versions of Go before 1.14.x (where 3 < x < 11) cannot diff *big.Int
@@ -183,7 +182,7 @@ func TestUserCredentials_CreateUpdate(t *testing.T) {
 				ExternalServiceID:   "https://github.com",
 			}
 
-			cred, err := UserCredentials(db, key).Create(ctx, scope, auth)
+			cred, err := db.UserCredentials(key).Create(ctx, scope, auth)
 			if err != nil {
 				t.Errorf("unexpected non-nil error: %v", err)
 			} else if cred == nil {
@@ -220,7 +219,7 @@ func TestUserCredentials_CreateUpdate(t *testing.T) {
 			}
 
 			// Ensure that trying to insert again fails.
-			if cred, err := UserCredentials(db, key).Create(ctx, scope, auth); err == nil {
+			if cred, err := db.UserCredentials(key).Create(ctx, scope, auth); err == nil {
 				t.Error("unexpected nil error")
 			} else if cred != nil {
 				t.Errorf("unexpected non-nil credential: %v", cred)
@@ -230,11 +229,11 @@ func TestUserCredentials_CreateUpdate(t *testing.T) {
 
 			cred.ExternalServiceType = newExternalServiceType
 
-			if err := UserCredentials(db, key).Update(ctx, cred); err != nil {
+			if err := db.UserCredentials(key).Update(ctx, cred); err != nil {
 				t.Errorf("unexpected non-nil error updating: %+v", err)
 			}
 
-			updatedCred, err := UserCredentials(db, key).GetByID(ctx, cred.ID)
+			updatedCred, err := db.UserCredentials(key).GetByID(ctx, cred.ID)
 			if err != nil {
 				t.Errorf("unexpected non-nil error getting credential: %+v", err)
 			}
@@ -247,11 +246,11 @@ func TestUserCredentials_CreateUpdate(t *testing.T) {
 
 func TestUserCredentials_Delete(t *testing.T) {
 	t.Parallel()
-	db := dbtest.NewDB(t)
+	db := NewDB(dbtest.NewDB(t))
 	ctx, key, user := setUpUserCredentialTest(t, db)
 
 	t.Run("nonextant", func(t *testing.T) {
-		err := UserCredentials(db, key).Delete(ctx, 1)
+		err := db.UserCredentials(key).Delete(ctx, 1)
 		if err == nil {
 			t.Error("unexpected nil error")
 		}
@@ -274,16 +273,16 @@ func TestUserCredentials_Delete(t *testing.T) {
 		}
 		token := &auth.OAuthBearerToken{Token: "abcdef"}
 
-		cred, err := UserCredentials(db, key).Create(ctx, scope, token)
+		cred, err := db.UserCredentials(key).Create(ctx, scope, token)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		if err := UserCredentials(db, key).Delete(ctx, cred.ID); err != nil {
+		if err := db.UserCredentials(key).Delete(ctx, cred.ID); err != nil {
 			t.Errorf("unexpected non-nil error: %v", err)
 		}
 
-		_, err = UserCredentials(db, key).GetByID(ctx, cred.ID)
+		_, err = db.UserCredentials(key).GetByID(ctx, cred.ID)
 		if !errors.HasType(err, UserCredentialNotFoundErr{}) {
 			t.Errorf("unexpected error retrieving credential after deletion: %v", err)
 		}
@@ -292,11 +291,11 @@ func TestUserCredentials_Delete(t *testing.T) {
 
 func TestUserCredentials_GetByID(t *testing.T) {
 	t.Parallel()
-	db := dbtest.NewDB(t)
+	db := NewDB(dbtest.NewDB(t))
 	ctx, key, user := setUpUserCredentialTest(t, db)
 
 	t.Run("nonextant", func(t *testing.T) {
-		cred, err := UserCredentials(db, key).GetByID(ctx, 1)
+		cred, err := db.UserCredentials(key).GetByID(ctx, 1)
 		if cred != nil {
 			t.Errorf("unexpected non-nil credential: %v", cred)
 		}
@@ -322,12 +321,12 @@ func TestUserCredentials_GetByID(t *testing.T) {
 		}
 		token := &auth.OAuthBearerToken{Token: "abcdef"}
 
-		want, err := UserCredentials(db, key).Create(ctx, scope, token)
+		want, err := db.UserCredentials(key).Create(ctx, scope, token)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		have, err := UserCredentials(db, key).GetByID(ctx, want.ID)
+		have, err := db.UserCredentials(key).GetByID(ctx, want.ID)
 		if err != nil {
 			t.Errorf("unexpected non-nil error: %v", err)
 		}
@@ -339,7 +338,7 @@ func TestUserCredentials_GetByID(t *testing.T) {
 
 func TestUserCredentials_GetByScope(t *testing.T) {
 	t.Parallel()
-	db := dbtest.NewDB(t)
+	db := NewDB(dbtest.NewDB(t))
 	ctx, key, user := setUpUserCredentialTest(t, db)
 
 	scope := UserCredentialScope{
@@ -351,7 +350,7 @@ func TestUserCredentials_GetByScope(t *testing.T) {
 	token := &auth.OAuthBearerToken{Token: "abcdef"}
 
 	t.Run("nonextant", func(t *testing.T) {
-		cred, err := UserCredentials(db, key).GetByScope(ctx, scope)
+		cred, err := db.UserCredentials(key).GetByScope(ctx, scope)
 		if cred != nil {
 			t.Errorf("unexpected non-nil credential: %v", cred)
 		}
@@ -369,12 +368,12 @@ func TestUserCredentials_GetByScope(t *testing.T) {
 	})
 
 	t.Run("extant", func(t *testing.T) {
-		want, err := UserCredentials(db, key).Create(ctx, scope, token)
+		want, err := db.UserCredentials(key).Create(ctx, scope, token)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		have, err := UserCredentials(db, key).GetByScope(ctx, scope)
+		have, err := db.UserCredentials(key).GetByScope(ctx, scope)
 		if err != nil {
 			t.Errorf("unexpected non-nil error: %v", err)
 		}
@@ -386,7 +385,7 @@ func TestUserCredentials_GetByScope(t *testing.T) {
 
 func TestUserCredentials_List(t *testing.T) {
 	t.Parallel()
-	db := dbtest.NewDB(t)
+	db := NewDB(dbtest.NewDB(t))
 	ctx, key, user := setUpUserCredentialTest(t, db)
 
 	githubScope := UserCredentialScope{
@@ -405,18 +404,18 @@ func TestUserCredentials_List(t *testing.T) {
 
 	// Unlike the other tests in this file, we'll set up a couple of credentials
 	// right now, and then list from there.
-	githubCred, err := UserCredentials(db, key).Create(ctx, githubScope, token)
+	githubCred, err := db.UserCredentials(key).Create(ctx, githubScope, token)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	gitlabCred, err := UserCredentials(db, key).Create(ctx, gitlabScope, token)
+	gitlabCred, err := db.UserCredentials(key).Create(ctx, gitlabScope, token)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	t.Run("not found", func(t *testing.T) {
-		creds, next, err := UserCredentials(db, key).List(ctx, UserCredentialsListOpts{
+		creds, next, err := db.UserCredentials(key).List(ctx, UserCredentialsListOpts{
 			Scope: UserCredentialScope{
 				Domain: "this is not a valid domain",
 			},
@@ -454,7 +453,7 @@ func TestUserCredentials_List(t *testing.T) {
 		},
 	} {
 		t.Run("single match on "+name, func(t *testing.T) {
-			creds, next, err := UserCredentials(db, key).List(ctx, UserCredentialsListOpts{
+			creds, next, err := db.UserCredentials(key).List(ctx, UserCredentialsListOpts{
 				Scope: tc.scope,
 			})
 			if err != nil {
@@ -481,7 +480,7 @@ func TestUserCredentials_List(t *testing.T) {
 		},
 	} {
 		t.Run("multiple matches on "+name, func(t *testing.T) {
-			creds, next, err := UserCredentials(db, key).List(ctx, opts)
+			creds, next, err := db.UserCredentials(key).List(ctx, opts)
 			if err != nil {
 				t.Errorf("unexpected non-nil error: %v", err)
 			}
@@ -496,7 +495,7 @@ func TestUserCredentials_List(t *testing.T) {
 		t.Run("pagination for "+name, func(t *testing.T) {
 			o := opts
 			o.LimitOffset = &LimitOffset{Limit: 1}
-			creds, next, err := UserCredentials(db, key).List(ctx, o)
+			creds, next, err := db.UserCredentials(key).List(ctx, o)
 			if err != nil {
 				t.Errorf("unexpected non-nil error: %v", err)
 			}
@@ -508,7 +507,7 @@ func TestUserCredentials_List(t *testing.T) {
 			}
 
 			o.LimitOffset = &LimitOffset{Limit: 1, Offset: next}
-			creds, next, err = UserCredentials(db, key).List(ctx, o)
+			creds, next, err = db.UserCredentials(key).List(ctx, o)
 			if err != nil {
 				t.Errorf("unexpected non-nil error: %v", err)
 			}
@@ -524,11 +523,11 @@ func TestUserCredentials_List(t *testing.T) {
 
 func TestUserCredentials_Invalid(t *testing.T) {
 	t.Parallel()
-	db := dbtest.NewDB(t)
+	db := NewDB(dbtest.NewDB(t))
 	ctx, key, user := setUpUserCredentialTest(t, db)
 
 	t.Run("marshal", func(t *testing.T) {
-		if _, err := UserCredentials(db, key).Create(ctx, UserCredentialScope{}, &invalidAuth{}); err == nil {
+		if _, err := db.UserCredentials(key).Create(ctx, UserCredentialScope{}, &invalidAuth{}); err == nil {
 			t.Error("unexpected nil error")
 		}
 	})
@@ -575,7 +574,7 @@ func TestUserCredentials_Invalid(t *testing.T) {
 			"malformed JSON":          insertRawCredential(t, "malformed", "this is not valid JSON"),
 		} {
 			t.Run(name, func(t *testing.T) {
-				cred, err := UserCredentials(db, key).GetByID(ctx, id)
+				cred, err := db.UserCredentials(key).GetByID(ctx, id)
 				if err != nil {
 					t.Error("unexpected error")
 				}
@@ -636,7 +635,7 @@ func createUserCredentialAuths(t *testing.T) map[string]auth.Authenticator {
 	return auths
 }
 
-func setUpUserCredentialTest(t *testing.T, db *sql.DB) (context.Context, encryption.Key, *types.User) {
+func setUpUserCredentialTest(t *testing.T, db DB) (context.Context, encryption.Key, *types.User) {
 	if testing.Short() {
 		t.Skip()
 	}

--- a/internal/database/user_emails.go
+++ b/internal/database/user_emails.go
@@ -10,7 +10,6 @@ import (
 	"github.com/keegancsmith/sqlf"
 
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
@@ -67,11 +66,6 @@ type UserEmailsStore interface {
 // userEmailsStore provides access to the `user_emails` table.
 type userEmailsStore struct {
 	*basestore.Store
-}
-
-// UserEmails instantiates and returns a new UserEmailsStore with prepared statements.
-func UserEmails(db dbutil.DB) UserEmailsStore {
-	return &userEmailsStore{Store: basestore.NewWithDB(db, sql.TxOptions{})}
 }
 
 // UserEmailsWith instantiates and returns a new UserEmailsStore using the other store handle.

--- a/internal/database/user_emails_test.go
+++ b/internal/database/user_emails_test.go
@@ -57,7 +57,7 @@ func TestUserEmails_Get(t *testing.T) {
 		t.Skip()
 	}
 	t.Parallel()
-	db := dbtest.NewDB(t)
+	db := NewDB(dbtest.NewDB(t))
 	ctx := context.Background()
 
 	user, err := Users(db).Create(ctx, NewUser{
@@ -69,11 +69,11 @@ func TestUserEmails_Get(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := UserEmails(db).Add(ctx, user.ID, "b@example.com", nil); err != nil {
+	if err := db.UserEmails().Add(ctx, user.ID, "b@example.com", nil); err != nil {
 		t.Fatal(err)
 	}
 
-	emailA, verifiedA, err := UserEmails(db).Get(ctx, user.ID, "A@EXAMPLE.com")
+	emailA, verifiedA, err := db.UserEmails().Get(ctx, user.ID, "A@EXAMPLE.com")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -84,7 +84,7 @@ func TestUserEmails_Get(t *testing.T) {
 		t.Error("want verified == false")
 	}
 
-	emailB, verifiedB, err := UserEmails(db).Get(ctx, user.ID, "B@EXAMPLE.com")
+	emailB, verifiedB, err := db.UserEmails().Get(ctx, user.ID, "B@EXAMPLE.com")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -95,7 +95,7 @@ func TestUserEmails_Get(t *testing.T) {
 		t.Error("want verified == false")
 	}
 
-	if _, _, err := UserEmails(db).Get(ctx, user.ID, "doesntexist@example.com"); !errcode.IsNotFound(err) {
+	if _, _, err := db.UserEmails().Get(ctx, user.ID, "doesntexist@example.com"); !errcode.IsNotFound(err) {
 		t.Errorf("got %v, want IsNotFound", err)
 	}
 }
@@ -105,7 +105,7 @@ func TestUserEmails_GetPrimary(t *testing.T) {
 		t.Skip()
 	}
 	t.Parallel()
-	db := dbtest.NewDB(t)
+	db := NewDB(dbtest.NewDB(t))
 	ctx := context.Background()
 
 	user, err := Users(db).Create(ctx, NewUser{
@@ -120,7 +120,7 @@ func TestUserEmails_GetPrimary(t *testing.T) {
 
 	checkPrimaryEmail := func(t *testing.T, wantEmail string, wantVerified bool) {
 		t.Helper()
-		email, verified, err := UserEmails(db).GetPrimaryEmail(ctx, user.ID)
+		email, verified, err := db.UserEmails().GetPrimaryEmail(ctx, user.ID)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -135,17 +135,17 @@ func TestUserEmails_GetPrimary(t *testing.T) {
 	// Initial address should be primary
 	checkPrimaryEmail(t, "a@example.com", false)
 	// Add a second address
-	if err := UserEmails(db).Add(ctx, user.ID, "b1@example.com", nil); err != nil {
+	if err := db.UserEmails().Add(ctx, user.ID, "b1@example.com", nil); err != nil {
 		t.Fatal(err)
 	}
 	// Primary should still be the first one
 	checkPrimaryEmail(t, "a@example.com", false)
 	// Verify second
-	if err := UserEmails(db).SetVerified(ctx, user.ID, "b1@example.com", true); err != nil {
+	if err := db.UserEmails().SetVerified(ctx, user.ID, "b1@example.com", true); err != nil {
 		t.Fatal(err)
 	}
 	// Set as primary
-	if err := UserEmails(db).SetPrimaryEmail(ctx, user.ID, "b1@example.com"); err != nil {
+	if err := db.UserEmails().SetPrimaryEmail(ctx, user.ID, "b1@example.com"); err != nil {
 		t.Fatal(err)
 	}
 	// Confirm it is now the primary
@@ -157,7 +157,7 @@ func TestUserEmails_SetPrimary(t *testing.T) {
 		t.Skip()
 	}
 	t.Parallel()
-	db := dbtest.NewDB(t)
+	db := NewDB(dbtest.NewDB(t))
 	ctx := context.Background()
 
 	user, err := Users(db).Create(ctx, NewUser{
@@ -172,7 +172,7 @@ func TestUserEmails_SetPrimary(t *testing.T) {
 
 	checkPrimaryEmail := func(t *testing.T, wantEmail string, wantVerified bool) {
 		t.Helper()
-		email, verified, err := UserEmails(db).GetPrimaryEmail(ctx, user.ID)
+		email, verified, err := db.UserEmails().GetPrimaryEmail(ctx, user.ID)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -187,11 +187,11 @@ func TestUserEmails_SetPrimary(t *testing.T) {
 	// Initial address should be primary
 	checkPrimaryEmail(t, "a@example.com", false)
 	// Add a another address
-	if err := UserEmails(db).Add(ctx, user.ID, "b1@example.com", nil); err != nil {
+	if err := db.UserEmails().Add(ctx, user.ID, "b1@example.com", nil); err != nil {
 		t.Fatal(err)
 	}
 	// Setting it as primary should fail since it is not verified
-	if err := UserEmails(db).SetPrimaryEmail(ctx, user.ID, "b1@example.com"); err == nil {
+	if err := db.UserEmails().SetPrimaryEmail(ctx, user.ID, "b1@example.com"); err == nil {
 		t.Fatal("Expected an error as address is not verified")
 	}
 }
@@ -201,7 +201,7 @@ func TestUserEmails_ListByUser(t *testing.T) {
 		t.Skip()
 	}
 	t.Parallel()
-	db := dbtest.NewDB(t)
+	db := NewDB(dbtest.NewDB(t))
 	ctx := context.Background()
 
 	user, err := Users(db).Create(ctx, NewUser{
@@ -222,7 +222,7 @@ func TestUserEmails_ListByUser(t *testing.T) {
 	}
 
 	t.Run("list all emails", func(t *testing.T) {
-		userEmails, err := UserEmails(db).ListByUser(ctx, UserEmailsListOptions{
+		userEmails, err := db.UserEmails().ListByUser(ctx, UserEmailsListOptions{
 			UserID: user.ID,
 		})
 		if err != nil {
@@ -239,7 +239,7 @@ func TestUserEmails_ListByUser(t *testing.T) {
 	})
 
 	t.Run("list only verified emails", func(t *testing.T) {
-		userEmails, err := UserEmails(db).ListByUser(ctx, UserEmailsListOptions{
+		userEmails, err := db.UserEmails().ListByUser(ctx, UserEmailsListOptions{
 			UserID:       user.ID,
 			OnlyVerified: true,
 		})
@@ -292,7 +292,7 @@ func TestUserEmails_Add_Remove(t *testing.T) {
 		t.Fatalf("got primary %v, want %v", primary, want)
 	}
 
-	if err := UserEmails(db).Add(ctx, user.ID, emailB, nil); err != nil {
+	if err := db.UserEmails().Add(ctx, user.ID, emailB, nil); err != nil {
 		t.Fatal(err)
 	}
 	if verified, err := isUserEmailVerified(ctx, db, user.ID, emailB); err != nil {
@@ -301,7 +301,7 @@ func TestUserEmails_Add_Remove(t *testing.T) {
 		t.Fatalf("got verified %v, want %v", verified, want)
 	}
 
-	if emails, err := UserEmails(db).ListByUser(ctx, UserEmailsListOptions{
+	if emails, err := db.UserEmails().ListByUser(ctx, UserEmailsListOptions{
 		UserID: user.ID,
 	}); err != nil {
 		t.Fatal(err)
@@ -309,13 +309,13 @@ func TestUserEmails_Add_Remove(t *testing.T) {
 		t.Errorf("got %d emails, want %d", len(emails), want)
 	}
 
-	if err := UserEmails(db).Add(ctx, user.ID, emailB, nil); err == nil {
+	if err := db.UserEmails().Add(ctx, user.ID, emailB, nil); err == nil {
 		t.Fatal("got err == nil for Add on existing email")
 	}
-	if err := UserEmails(db).Add(ctx, 12345 /* bad user ID */, "foo@example.com", nil); err == nil {
+	if err := db.UserEmails().Add(ctx, 12345 /* bad user ID */, "foo@example.com", nil); err == nil {
 		t.Fatal("got err == nil for Add on bad user ID")
 	}
-	if emails, err := UserEmails(db).ListByUser(ctx, UserEmailsListOptions{
+	if emails, err := db.UserEmails().ListByUser(ctx, UserEmailsListOptions{
 		UserID: user.ID,
 	}); err != nil {
 		t.Fatal(err)
@@ -324,14 +324,14 @@ func TestUserEmails_Add_Remove(t *testing.T) {
 	}
 
 	// Attempt to remove primary
-	if err := UserEmails(db).Remove(ctx, user.ID, emailA); err == nil {
+	if err := db.UserEmails().Remove(ctx, user.ID, emailA); err == nil {
 		t.Fatal("expected error, can't delete primary email")
 	}
 	// Remove non primary
-	if err := UserEmails(db).Remove(ctx, user.ID, emailB); err != nil {
+	if err := db.UserEmails().Remove(ctx, user.ID, emailB); err != nil {
 		t.Fatal(err)
 	}
-	if emails, err := UserEmails(db).ListByUser(ctx, UserEmailsListOptions{
+	if emails, err := db.UserEmails().ListByUser(ctx, UserEmailsListOptions{
 		UserID: user.ID,
 	}); err != nil {
 		t.Fatal(err)
@@ -339,10 +339,10 @@ func TestUserEmails_Add_Remove(t *testing.T) {
 		t.Errorf("got %d emails (after removing), want %d", len(emails), want)
 	}
 
-	if err := UserEmails(db).Remove(ctx, user.ID, "foo@example.com"); err == nil {
+	if err := db.UserEmails().Remove(ctx, user.ID, "foo@example.com"); err == nil {
 		t.Fatal("got err == nil for Remove on nonexistent email")
 	}
-	if err := UserEmails(db).Remove(ctx, 12345 /* bad user ID */, "foo@example.com"); err == nil {
+	if err := db.UserEmails().Remove(ctx, 12345 /* bad user ID */, "foo@example.com"); err == nil {
 		t.Fatal("got err == nil for Remove on bad user ID")
 	}
 }
@@ -372,7 +372,7 @@ func TestUserEmails_SetVerified(t *testing.T) {
 		t.Fatalf("before SetVerified, got verified %v, want %v", verified, want)
 	}
 
-	if err := UserEmails(db).SetVerified(ctx, user.ID, email, true); err != nil {
+	if err := db.UserEmails().SetVerified(ctx, user.ID, email, true); err != nil {
 		t.Fatal(err)
 	}
 	if verified, err := isUserEmailVerified(ctx, db, user.ID, email); err != nil {
@@ -381,7 +381,7 @@ func TestUserEmails_SetVerified(t *testing.T) {
 		t.Fatalf("after SetVerified true, got verified %v, want %v", verified, want)
 	}
 
-	if err := UserEmails(db).SetVerified(ctx, user.ID, email, false); err != nil {
+	if err := db.UserEmails().SetVerified(ctx, user.ID, email, false); err != nil {
 		t.Fatal(err)
 	}
 	if verified, err := isUserEmailVerified(ctx, db, user.ID, email); err != nil {
@@ -390,13 +390,13 @@ func TestUserEmails_SetVerified(t *testing.T) {
 		t.Fatalf("after SetVerified false, got verified %v, want %v", verified, want)
 	}
 
-	if err := UserEmails(db).SetVerified(ctx, user.ID, "otheremail@example.com", false); err == nil {
+	if err := db.UserEmails().SetVerified(ctx, user.ID, "otheremail@example.com", false); err == nil {
 		t.Fatal("got err == nil for SetVerified on bad email")
 	}
 }
 
 func isUserEmailVerified(ctx context.Context, db DB, userID int32, email string) (bool, error) {
-	userEmails, err := UserEmails(db).ListByUser(ctx, UserEmailsListOptions{
+	userEmails, err := db.UserEmails().ListByUser(ctx, UserEmailsListOptions{
 		UserID: userID,
 	})
 	if err != nil {
@@ -411,7 +411,7 @@ func isUserEmailVerified(ctx context.Context, db DB, userID int32, email string)
 }
 
 func isUserEmailPrimary(ctx context.Context, db DB, userID int32, email string) (bool, error) {
-	userEmails, err := UserEmails(db).ListByUser(ctx, UserEmailsListOptions{
+	userEmails, err := db.UserEmails().ListByUser(ctx, UserEmailsListOptions{
 		UserID: userID,
 	})
 	if err != nil {
@@ -430,7 +430,7 @@ func TestUserEmails_SetLastVerificationSentAt(t *testing.T) {
 		t.Skip()
 	}
 	t.Parallel()
-	db := dbtest.NewDB(t)
+	db := NewDB(dbtest.NewDB(t))
 	ctx := context.Background()
 
 	const addr = "alice@example.com"
@@ -445,7 +445,7 @@ func TestUserEmails_SetLastVerificationSentAt(t *testing.T) {
 	}
 
 	// Verify "last_verification_sent_at" column is NULL
-	emails, err := UserEmails(db).ListByUser(ctx, UserEmailsListOptions{
+	emails, err := db.UserEmails().ListByUser(ctx, UserEmailsListOptions{
 		UserID: user.ID,
 	})
 	if err != nil {
@@ -456,12 +456,12 @@ func TestUserEmails_SetLastVerificationSentAt(t *testing.T) {
 		t.Fatalf("lastVerificationSentAt: want nil but got %v", emails[0].LastVerificationSentAt)
 	}
 
-	if err = UserEmails(db).SetLastVerification(ctx, user.ID, addr, "c"); err != nil {
+	if err = db.UserEmails().SetLastVerification(ctx, user.ID, addr, "c"); err != nil {
 		t.Fatal(err)
 	}
 
 	// Verify "last_verification_sent_at" column is not NULL
-	emails, err = UserEmails(db).ListByUser(ctx, UserEmailsListOptions{
+	emails, err = db.UserEmails().ListByUser(ctx, UserEmailsListOptions{
 		UserID: user.ID,
 	})
 	if err != nil {
@@ -478,7 +478,7 @@ func TestUserEmails_GetLatestVerificationSentEmail(t *testing.T) {
 		t.Skip()
 	}
 	t.Parallel()
-	db := dbtest.NewDB(t)
+	db := NewDB(dbtest.NewDB(t))
 	ctx := context.Background()
 
 	const addr = "alice@example.com"
@@ -493,15 +493,15 @@ func TestUserEmails_GetLatestVerificationSentEmail(t *testing.T) {
 	}
 
 	// Should return "not found" because "last_verification_sent_at" column is NULL
-	_, err = UserEmails(db).GetLatestVerificationSentEmail(ctx, addr)
+	_, err = db.UserEmails().GetLatestVerificationSentEmail(ctx, addr)
 	if err == nil || !errcode.IsNotFound(err) {
 		t.Fatalf("err: want a not found error but got %v", err)
-	} else if err = UserEmails(db).SetLastVerification(ctx, user.ID, addr, "c"); err != nil {
+	} else if err = db.UserEmails().SetLastVerification(ctx, user.ID, addr, "c"); err != nil {
 		t.Fatal(err)
 	}
 
 	// Should return an email because "last_verification_sent_at" column is not NULL
-	email, err := UserEmails(db).GetLatestVerificationSentEmail(ctx, addr)
+	email, err := db.UserEmails().GetLatestVerificationSentEmail(ctx, addr)
 	if err != nil {
 		t.Fatal(err)
 	} else if email.Email != addr {
@@ -517,12 +517,12 @@ func TestUserEmails_GetLatestVerificationSentEmail(t *testing.T) {
 	})
 	if err != nil {
 		t.Fatal(err)
-	} else if err = UserEmails(db).SetLastVerification(ctx, user2.ID, addr, "c"); err != nil {
+	} else if err = db.UserEmails().SetLastVerification(ctx, user2.ID, addr, "c"); err != nil {
 		t.Fatal(err)
 	}
 
 	// Should return the email for the second user
-	email, err = UserEmails(db).GetLatestVerificationSentEmail(ctx, addr)
+	email, err = db.UserEmails().GetLatestVerificationSentEmail(ctx, addr)
 	if err != nil {
 		t.Fatal(err)
 	} else if email.Email != addr {
@@ -537,7 +537,7 @@ func TestUserEmails_GetVerifiedEmails(t *testing.T) {
 		t.Skip()
 	}
 	t.Parallel()
-	db := dbtest.NewDB(t)
+	db := NewDB(dbtest.NewDB(t))
 	ctx := context.Background()
 
 	newUsers := []NewUser{
@@ -560,7 +560,7 @@ func TestUserEmails_GetVerifiedEmails(t *testing.T) {
 		}
 	}
 
-	emails, err := UserEmails(db).GetVerifiedEmails(ctx, "alice@example.com", "bob@example.com")
+	emails, err := db.UserEmails().GetVerifiedEmails(ctx, "alice@example.com", "bob@example.com")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/database/users_builtin_auth_test.go
+++ b/internal/database/users_builtin_auth_test.go
@@ -16,7 +16,7 @@ func TestUsers_BuiltinAuth(t *testing.T) {
 		t.Skip()
 	}
 	t.Parallel()
-	db := dbtest.NewDB(t)
+	db := NewDB(dbtest.NewDB(t))
 	ctx := context.Background()
 
 	if _, err := Users(db).Create(ctx, NewUser{
@@ -38,24 +38,24 @@ func TestUsers_BuiltinAuth(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, verified, err := UserEmails(db).GetPrimaryEmail(ctx, usr.ID)
+	_, verified, err := db.UserEmails().GetPrimaryEmail(ctx, usr.ID)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if verified {
 		t.Fatal("new user should not be verified")
 	}
-	if isValid, err := UserEmails(db).Verify(ctx, usr.ID, "foo@bar.com", "wrong_email-code"); err == nil && isValid {
+	if isValid, err := db.UserEmails().Verify(ctx, usr.ID, "foo@bar.com", "wrong_email-code"); err == nil && isValid {
 		t.Fatal("should not validate email with wrong code")
 	}
-	if isValid, err := UserEmails(db).Verify(ctx, usr.ID, "foo@bar.com", "email-code"); err != nil || !isValid {
+	if isValid, err := db.UserEmails().Verify(ctx, usr.ID, "foo@bar.com", "email-code"); err != nil || !isValid {
 		t.Fatal("couldn't vaidate email")
 	}
 	usr, err = Users(db).GetByID(ctx, usr.ID)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, verified, err := UserEmails(db).GetPrimaryEmail(ctx, usr.ID); err != nil {
+	if _, verified, err := db.UserEmails().GetPrimaryEmail(ctx, usr.ID); err != nil {
 		t.Fatal(err)
 	} else if !verified {
 		t.Fatal("user should not be verified")
@@ -115,7 +115,7 @@ func TestUsers_BuiltinAuth_VerifiedEmail(t *testing.T) {
 		t.Skip()
 	}
 	t.Parallel()
-	db := dbtest.NewDB(t)
+	db := NewDB(dbtest.NewDB(t))
 	ctx := context.Background()
 
 	user, err := Users(db).Create(ctx, NewUser{
@@ -128,7 +128,7 @@ func TestUsers_BuiltinAuth_VerifiedEmail(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, verified, err := UserEmails(db).GetPrimaryEmail(ctx, user.ID)
+	_, verified, err := db.UserEmails().GetPrimaryEmail(ctx, user.ID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -141,7 +141,7 @@ func TestUsers_BuiltinAuthPasswordResetRateLimit(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	db := dbtest.NewDB(t)
+	db := NewDB(dbtest.NewDB(t))
 	ctx := context.Background()
 
 	oldPasswordResetRateLimit := passwordResetRateLimit
@@ -181,7 +181,7 @@ func TestUsers_UpdatePassword(t *testing.T) {
 		t.Skip()
 	}
 	t.Parallel()
-	db := dbtest.NewDB(t)
+	db := NewDB(dbtest.NewDB(t))
 	ctx := context.Background()
 
 	usr, err := Users(db).Create(ctx, NewUser{
@@ -229,7 +229,7 @@ func TestUsers_CreatePassword(t *testing.T) {
 		t.Skip()
 	}
 	t.Parallel()
-	db := dbtest.NewDB(t)
+	db := NewDB(dbtest.NewDB(t))
 	ctx := context.Background()
 
 	// User without a password
@@ -264,7 +264,7 @@ func TestUsers_CreatePassword(t *testing.T) {
 	}
 
 	// A new user with an external account can't create a password
-	newID, err := ExternalAccounts(db).CreateUserAndSave(ctx, NewUser{
+	newID, err := db.UserExternalAccounts().CreateUserAndSave(ctx, NewUser{
 		Email:                 "usr3@bar.com",
 		Username:              "usr3",
 		Password:              "",
@@ -295,7 +295,7 @@ func TestUsers_PasswordResetExpiry(t *testing.T) {
 		t.Skip()
 	}
 	t.Parallel()
-	db := dbtest.NewDB(t)
+	db := NewDB(dbtest.NewDB(t))
 	ctx := context.Background()
 
 	user, err := Users(db).Create(ctx, NewUser{

--- a/internal/database/users_test.go
+++ b/internal/database/users_test.go
@@ -72,7 +72,7 @@ func TestUsers_ValidUsernames(t *testing.T) {
 		t.Skip()
 	}
 	t.Parallel()
-	db := dbtest.NewDB(t)
+	db := NewDB(dbtest.NewDB(t))
 	ctx := context.Background()
 
 	for _, test := range usernamesForTests {
@@ -182,7 +182,7 @@ func TestUsers_CheckAndDecrementInviteQuota(t *testing.T) {
 		t.Skip()
 	}
 	t.Parallel()
-	db := dbtest.NewDB(t)
+	db := NewDB(dbtest.NewDB(t))
 	ctx := context.Background()
 
 	user, err := Users(db).Create(ctx, NewUser{
@@ -232,7 +232,7 @@ func TestUsers_ListCount(t *testing.T) {
 		t.Skip()
 	}
 	t.Parallel()
-	db := dbtest.NewDB(t)
+	db := NewDB(dbtest.NewDB(t))
 	ctx := context.Background()
 
 	user, err := Users(db).Create(ctx, NewUser{
@@ -290,7 +290,7 @@ func TestUsers_Update(t *testing.T) {
 		t.Skip()
 	}
 	t.Parallel()
-	db := dbtest.NewDB(t)
+	db := NewDB(dbtest.NewDB(t))
 	ctx := context.Background()
 
 	user, err := Users(db).Create(ctx, NewUser{
@@ -369,7 +369,7 @@ func TestUsers_GetByVerifiedEmail(t *testing.T) {
 		t.Skip()
 	}
 	t.Parallel()
-	db := dbtest.NewDB(t)
+	db := NewDB(dbtest.NewDB(t))
 	ctx := context.Background()
 
 	user, err := Users(db).Create(ctx, NewUser{
@@ -386,7 +386,7 @@ func TestUsers_GetByVerifiedEmail(t *testing.T) {
 		t.Errorf("for unverified email, got error %v, want IsNotFound", err)
 	}
 
-	if err := UserEmails(db).SetVerified(ctx, user.ID, "a@a.com", true); err != nil {
+	if err := db.UserEmails().SetVerified(ctx, user.ID, "a@a.com", true); err != nil {
 		t.Fatal(err)
 	}
 
@@ -404,7 +404,7 @@ func TestUsers_GetByUsername(t *testing.T) {
 		t.Skip()
 	}
 	t.Parallel()
-	db := dbtest.NewDB(t)
+	db := NewDB(dbtest.NewDB(t))
 	ctx := context.Background()
 
 	newUsers := []NewUser{
@@ -450,7 +450,7 @@ func TestUsers_GetByUsernames(t *testing.T) {
 		t.Skip()
 	}
 	t.Parallel()
-	db := dbtest.NewDB(t)
+	db := NewDB(dbtest.NewDB(t))
 	ctx := context.Background()
 
 	newUsers := []NewUser{
@@ -653,7 +653,7 @@ func TestUsers_HasTag(t *testing.T) {
 		t.Skip()
 	}
 	t.Parallel()
-	db := dbtest.NewDB(t)
+	db := NewDB(dbtest.NewDB(t))
 	ctx := context.Background()
 
 	var id int32
@@ -691,7 +691,7 @@ func TestUsers_InvalidateSessions(t *testing.T) {
 		t.Skip()
 	}
 	t.Parallel()
-	db := dbtest.NewDB(t)
+	db := NewDB(dbtest.NewDB(t))
 	ctx := context.Background()
 
 	newUsers := []NewUser{
@@ -734,7 +734,7 @@ func TestUsers_SetTag(t *testing.T) {
 		t.Skip()
 	}
 	t.Parallel()
-	db := dbtest.NewDB(t)
+	db := NewDB(dbtest.NewDB(t))
 	ctx := context.Background()
 
 	// Create user.


### PR DESCRIPTION
Remove a few dbutil-based constructors in our database package, as they are not mockable in our tests.

This is the result of a time-boxed effort.

## Test plan

Unit tests

---

Part of https://github.com/sourcegraph/sourcegraph/issues/26113