### PR TITLE
gitserver: initialize logger on gitservice.Handler

### DIFF
--- a/cmd/gitserver/server/gitservice.go
+++ b/cmd/gitserver/server/gitservice.go
@@ -10,9 +10,11 @@ import (
 	"github.com/mxk/go-flowrate/flowrate"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/lib/gitservice"
+	"github.com/sourcegraph/sourcegraph/lib/log"
 )
 
 var gitServiceMaxEgressBytesPerSecond = func() int64 {
@@ -52,6 +54,8 @@ func flowrateWriter(w io.Writer) io.Writer {
 
 func (s *Server) gitServiceHandler() *gitservice.Handler {
 	return &gitservice.Handler{
+		Logger: log.Scoped("gitservice.handler", "smart Git HTTP transfer protocol"),
+
 		Dir: func(d string) string {
 			return string(s.dir(api.RepoName(d)))
 		},


### PR DESCRIPTION
Forgot to push this to https://github.com/sourcegraph/sourcegraph/pull/36259, which makes this required  😬 

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

n/a, checked for all remaining references: https://sourcegraph.com/github.com/sourcegraph/sourcegraph@382fe4753336d6d3fb4eb87a8f2d925b06ea4fb1/-/blob/lib/gitservice/gitservice.go?L42%3A6=#tab=references

Also `sg start`