### PR TITLE
changelog: cut sourcegraph@3.40.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,12 +27,18 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Fixed
 
-- Support expiring OAuth tokens for GitLab which became the default in version 15.0. [#36003](https://github.com/sourcegraph/sourcegraph/pull/36003)
-- Fix external service resolver erroring when webhooks not supported. [#35932](https://github.com/sourcegraph/sourcegraph/pull/35932)
+-
 
 ### Removed
 
 -
+
+## 3.40.1
+
+### Fixed
+
+- Support expiring OAuth tokens for GitLab which became the default in version 15.0. [#36003](https://github.com/sourcegraph/sourcegraph/pull/36003)
+- Fix external service resolver erroring when webhooks not supported. [#35932](https://github.com/sourcegraph/sourcegraph/pull/35932)
 
 ## 3.40.0
 


### PR DESCRIPTION

## Test plan

n/a
