### PR TITLE
gitserver: disable auto-gc on fetch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable changes to Sourcegraph are documented in this file.
 ### Changed
 
 - Code Insights: Added warnings about adding `context:` and `repo:` filters in search query.
+- Gitserver: we disable automatic git-gc for invocations of git-fetch to avoid corruption of repositories by competing git-gc processes. [#36274](https://github.com/sourcegraph/sourcegraph/pull/36274)
 
 ### Fixed
 

--- a/cmd/gitserver/server/refspecoverrides.go
+++ b/cmd/gitserver/server/refspecoverrides.go
@@ -22,5 +22,5 @@ func useRefspecOverrides() bool {
 // HACK(keegancsmith) workaround to experiment with cloning less in a large
 // monorepo. https://github.com/sourcegraph/customer/issues/19
 func refspecOverridesFetchCmd(ctx context.Context, remoteURL *vcs.URL) *exec.Cmd {
-	return exec.CommandContext(ctx, "git", append([]string{"fetch", "--progress", "--prune", remoteURL.String()}, refspecOverrides...)...)
+	return exec.CommandContext(ctx, "git", append([]string{"fetch", "--no-auto-gc", "--progress", "--prune", remoteURL.String()}, refspecOverrides...)...)
 }

--- a/cmd/gitserver/server/vcs_syncer_git.go
+++ b/cmd/gitserver/server/vcs_syncer_git.go
@@ -85,6 +85,9 @@ func (s *GitRepoSyncer) fetchCommand(ctx context.Context, remoteURL *vcs.URL) (c
 		cmd = refspecOverridesFetchCmd(ctx, remoteURL)
 	} else {
 		cmd = exec.CommandContext(ctx, "git", "fetch",
+			// We already have janitor jobs that run git gc. We disable git gc here to avoid
+			// a possible corruption of repositories by competing gc processes.
+			"--no-auto-gc",
 			"--progress", "--prune", remoteURL.String(),
 			// Normal git refs
 			"+refs/heads/*:refs/heads/*", "+refs/tags/*:refs/tags/*",


### PR DESCRIPTION
We already have janitor jobs that run git gc. We disable git gc for
git-fetch to avoid a possible corruption of repositories by competing gc
processes.

## Test plan
- I ran the following command on a local repo and confirmed that "git maintenance" is not called. 

```
GIT_TRACE2=1 git fetch --no-auto-gc --progress --prune https://github.com/hashicorp/go-multierror "+refs/heads/*:refs/heads/*" "+refs/tags/*:refs/tags/*" "+refs/pull/*:refs/pull/*"
```



<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
