### PR TITLE
[SG-35699] Accessibility: Email sign up form input elements are not linked to their error states properly

### DIFF
--- a/client/web/src/auth/SignUpForm.tsx
+++ b/client/web/src/auth/SignUpForm.tsx
@@ -223,10 +223,11 @@ export const SignUpForm: React.FunctionComponent<React.PropsWithChildren<SignUpF
                             disabled={loading}
                             placeholder=" "
                             inputRef={usernameInputReference}
+                            aria-describedby="username-input-invalid-feedback"
                         />
                     </LoaderInput>
                     {usernameState.kind === 'INVALID' && (
-                        <small className="invalid-feedback" role="alert">
+                        <small className="invalid-feedback" id="username-input-invalid-feedback" role="alert">
                             {usernameState.reason}
                         </small>
                     )}
@@ -262,14 +263,17 @@ export const SignUpForm: React.FunctionComponent<React.PropsWithChildren<SignUpF
                             onInvalid={preventDefault}
                             inputRef={passwordInputReference}
                             formNoValidate={true}
+                            aria-describedby="password-input-invalid-feedback password-requirements"
                         />
                     </LoaderInput>
                     {passwordState.kind === 'INVALID' && (
-                        <small className="invalid-feedback" role="alert">
+                        <small className="invalid-feedback" id="password-input-invalid-feedback" role="alert">
                             {passwordState.reason}
                         </small>
                     )}
-                    <small className="form-help text-muted">{getPasswordRequirements(context)}</small>
+                    <small className="form-help text-muted" id="password-requirements">
+                        {getPasswordRequirements(context)}
+                    </small>
                 </div>
                 {!experimental && enterpriseTrial && (
                     <div className="form-group">

--- a/client/web/src/auth/SignupEmailField.tsx
+++ b/client/web/src/auth/SignupEmailField.tsx
@@ -42,8 +42,13 @@ export const SignupEmailField: React.FunctionComponent<React.PropsWithChildren<S
                 autoFocus={true}
                 placeholder=" "
                 inputRef={emailInputReference}
+                aria-describedby="email-input-invalid-feedback"
             />
         </LoaderInput>
-        {emailState.kind === 'INVALID' && <small className="invalid-feedback">{emailState.reason}</small>}
+        {emailState.kind === 'INVALID' && (
+            <small className="invalid-feedback" id="email-input-invalid-feedback">
+                {emailState.reason}
+            </small>
+        )}
     </div>
 )

--- a/client/web/src/auth/__snapshots__/SignUpPage.test.tsx.snap
+++ b/client/web/src/auth/__snapshots__/SignUpPage.test.tsx.snap
@@ -191,6 +191,7 @@ exports[`SignUpPage renders sign up page (server) 1`] = `
                 class="container loader-input loaderInput"
               >
                 <input
+                  aria-describedby="email-input-invalid-feedback"
                   autocomplete="email"
                   class="form-control with-invalid-icon"
                   id="email"
@@ -220,6 +221,7 @@ exports[`SignUpPage renders sign up page (server) 1`] = `
                 class="container loader-input loaderInput"
               >
                 <input
+                  aria-describedby="username-input-invalid-feedback"
                   autocapitalize="off"
                   autocomplete="username"
                   class="form-control with-invalid-icon"
@@ -252,6 +254,7 @@ exports[`SignUpPage renders sign up page (server) 1`] = `
                 class="container loader-input loaderInput"
               >
                 <input
+                  aria-describedby="password-input-invalid-feedback password-requirements"
                   autocomplete="new-password"
                   class="form-control with-invalid-icon"
                   formnovalidate=""
@@ -267,6 +270,7 @@ exports[`SignUpPage renders sign up page (server) 1`] = `
             </div>
             <small
               class="form-help text-muted"
+              id="password-requirements"
             >
               At least 12 characters
             </small>

--- a/client/web/src/site-admin/init/__snapshots__/SiteInitPage.test.tsx.snap
+++ b/client/web/src/site-admin/init/__snapshots__/SiteInitPage.test.tsx.snap
@@ -46,6 +46,7 @@ exports[`SiteInitPage normal 1`] = `
                 class="container loader-input loaderInput"
               >
                 <input
+                  aria-describedby="email-input-invalid-feedback"
                   autocomplete="email"
                   class="form-control with-invalid-icon"
                   id="email"
@@ -75,6 +76,7 @@ exports[`SiteInitPage normal 1`] = `
                 class="container loader-input loaderInput"
               >
                 <input
+                  aria-describedby="username-input-invalid-feedback"
                   autocapitalize="off"
                   autocomplete="username"
                   class="form-control with-invalid-icon"
@@ -107,6 +109,7 @@ exports[`SiteInitPage normal 1`] = `
                 class="container loader-input loaderInput"
               >
                 <input
+                  aria-describedby="password-input-invalid-feedback password-requirements"
                   autocomplete="new-password"
                   class="form-control with-invalid-icon"
                   formnovalidate=""
@@ -122,6 +125,7 @@ exports[`SiteInitPage normal 1`] = `
             </div>
             <small
               class="form-help text-muted"
+              id="password-requirements"
             >
               At least 12 characters
             </small>


### PR DESCRIPTION
### Audit type

Screen reader navigation

### User journey audit issue

https://github.com/sourcegraph/sourcegraph/issues/34111

### Problem description

The sign up form contains various inputs (email, username, password) that can have different error states, e.g. if the email is invalid or username is already taken. The HTML input elements do not have `aria-describedby` attribute attached, which means that the error state might not be read correctly by a screen reader.

### Expected behavior

All 3 elements should have proper `aria-describedby` attribute linked to the id of the correct element that actually describes the error state

## Refs
[Gitstart Ticket](https://app.gitstart.com/clients/sourcegraph/tickets/SG-35699)
[Sourcegraph Issue](https://github.com/sourcegraph/sourcegraph/issues/35699)
## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->
Open sourcgraphweb app
Navigate to SignUp page
Errors will be read by screen reader if the input doesn't match the requirements

## App preview:

- [Web](https://sg-web-contractors-sg-35699.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-lejcoeljqq.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
