### PR TITLE
search: update error message for structural query alert

### DIFF
--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -732,7 +732,7 @@ func testSearchClient(t *testing.T, client searchClient) {
 				zeroResult: true,
 				wantAlert: &gqltestutil.SearchAlert{
 					Title:       "No results",
-					Description: "It looks like you may have meant to run a structural search, but the patterntype is not specified or it is not toggled.",
+					Description: "It looks like you're trying to run a structural search, but it is not enabled using the patterntype keyword or UI toggle.",
 					ProposedQueries: []gqltestutil.ProposedQuery{
 						{
 							Description: "Activate structural search",

--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -717,7 +717,7 @@ func testSearchClient(t *testing.T, client searchClient) {
 				zeroResult: true,
 				wantAlert: &gqltestutil.SearchAlert{
 					Title:       "No results",
-					Description: "It looks like you may have meant to run a structural search, but it is not toggled.",
+					Description: "It looks like you may have meant to run a structural search, but the patterntype is not specified or it is not toggled.",
 					ProposedQueries: []gqltestutil.ProposedQuery{
 						{
 							Description: "Activate structural search",
@@ -732,7 +732,7 @@ func testSearchClient(t *testing.T, client searchClient) {
 				zeroResult: true,
 				wantAlert: &gqltestutil.SearchAlert{
 					Title:       "No results",
-					Description: "It looks like you may have meant to run a structural search, but it is not toggled.",
+					Description: "It looks like you may have meant to run a structural search, but the patterntype is not specified or it is not toggled.",
 					ProposedQueries: []gqltestutil.ProposedQuery{
 						{
 							Description: "Activate structural search",

--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -717,7 +717,7 @@ func testSearchClient(t *testing.T, client searchClient) {
 				zeroResult: true,
 				wantAlert: &gqltestutil.SearchAlert{
 					Title:       "No results",
-					Description: "It looks like you may have meant to run a structural search, but the patterntype is not specified or it is not toggled.",
+					Description: "It looks like you're trying to run a structural search, but it is not enabled using the patterntype keyword or UI toggle.",
 					ProposedQueries: []gqltestutil.ProposedQuery{
 						{
 							Description: "Activate structural search",

--- a/internal/search/alert.go
+++ b/internal/search/alert.go
@@ -140,7 +140,7 @@ func AlertForStructuralSearchNotSet(queryString string) *Alert {
 	return &Alert{
 		PrometheusType: "structural_search_not_set",
 		Title:          "No results",
-		Description:    "It looks like you may have meant to run a structural search, but it is not toggled.",
+		Description:    "It looks like you may have meant to run a structural search, but the patterntype is not specified or it is not toggled.",
 		ProposedQueries: []*ProposedQuery{
 			{
 				Description: "Activate structural search",

--- a/internal/search/alert.go
+++ b/internal/search/alert.go
@@ -140,7 +140,7 @@ func AlertForStructuralSearchNotSet(queryString string) *Alert {
 	return &Alert{
 		PrometheusType: "structural_search_not_set",
 		Title:          "No results",
-		Description:    "It looks like you may have meant to run a structural search, but the patterntype is not specified or it is not toggled.",
+		Description:    "It looks like you're trying to run a structural search, but it is not enabled using the patterntype keyword or UI toggle.",
 		ProposedQueries: []*ProposedQuery{
 			{
 				Description: "Activate structural search",


### PR DESCRIPTION
found as part of [this slack thread](https://sourcegraph.slack.com/archives/C03CSAER9LK/p1653666884809919) on #feedback-dogfood that the alert for a structural search does not make much sense in an insights context as we don't have a UI toggle for patterntype:structural.

this updates the error message so that it might be a bit more useful in those cases

## Test plan
also pushed to a backend-integration branch.

validated the new error in an insight locally: 
<img width="433" alt="Screenshot 2022-05-30 at 17 52 10" src="https://user-images.githubusercontent.com/29406849/171147193-807a1361-78dd-4ca8-ad2d-11729a0d482f.png">

using the query: `<Tooltip...content...>...</Tooltip>`
