### PR TITLE
Update dependency search docs to show we don't use scip data in search

### DIFF
--- a/doc/code_search/how-to/dependencies_search.md
+++ b/doc/code_search/how-to/dependencies_search.md
@@ -41,7 +41,7 @@ The following table outlines the kinds of dependency repositories that dependenc
 
 Kind                                  | How                       | Direct | Transitive
 -------------------------------       |-------------------------- |------- | ----------
-[npm](../../integration/npm.md)       | scip-typescript uploads   | ✅     | ✅
+[npm](../../integration/npm.md)       | scip-typescript uploads   | ❌     | ❌
 [npm](../../integration/npm.md)       | `package-lock.json`       | ✅     | ✅
 [npm](../../integration/npm.md)       | `yarn.lock`               | ✅     | ✅
 [Python](../../integration/python.md) | scip-python uploads       | ❌     | ❌


### PR DESCRIPTION
We currently don't use precise code intel data to do dependency search.
It's hidden behind a feature flag and even if enabled won't probably
show transitive dependencies as the other methods

(I think we talked about this on Slack before and I remember that it was oversight or something)

## Test plan

- Existing tests
