### PR TITLE
Add example for a GitHub code host integration

### DIFF
--- a/doc/admin/external_service/github.md
+++ b/doc/admin/external_service/github.md
@@ -5,11 +5,24 @@ Site admins can sync Git repositories hosted on [GitHub.com](https://github.com)
 To connect GitHub to Sourcegraph:
 
 1. Depending on whether you are a site admin or user:
-    1. *Site admin*: Go to **Site admin > Manage repositories > Add repositories**
+    1. *Site admin*: Go to **Site admin > Manage code hosts**
     1. *User*: Go to **Settings > Manage repositories**.
 1. Select **GitHub**.
 1. Configure the connection to GitHub using the action buttons above the text field, and additional fields can be added using <kbd>Cmd/Ctrl+Space</kbd> for auto-completion. See the [configuration documentation below](#configuration).
 1. Press **Add repositories**.
+
+In this example, the kubernetes public repository on GitHub is added by selecting **Add a singe repository** and replacing `<owner>/<repository>` with `kubernetes/kubernetes`:
+
+```
+{
+  "url": "https://github.com",
+  "token": "<access token>",
+  "orgs": [],
+  "repos": [
+    "kubernetes/kubernetes"
+  ]
+}
+```
 
 > NOTE: Adding code hosts as a user is currently in private beta.
 


### PR DESCRIPTION
This change adds a simple example of adding a public repo in Site Admin. Also corrected some interface names (manage repositories -> Manage code hosts). In part this change addresses feedback in https://sourcegraph.slack.com/archives/C0W2E592M/p1652920840870179 and it addresses, in part, the issue that is temporarily housed here: https://github.com/orgs/sourcegraph/projects/241/views/2



## Test plan
Language edit by PE team member. @blvckcoffee 
@ryanslade is suggested reviewer 
