### PR TITLE
JetBrains: add simple diff view

### DIFF
--- a/client/jetbrains/src/main/java/com/sourcegraph/browser/JSToJavaBridgeRequestHandler.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/browser/JSToJavaBridgeRequestHandler.java
@@ -13,8 +13,10 @@ import com.sourcegraph.find.Search;
 import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.Nullable;
+import java.awt.*;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.net.URI;
 
 public class JSToJavaBridgeRequestHandler {
     private final Project project;
@@ -79,6 +81,16 @@ public class JSToJavaBridgeRequestHandler {
                 case "indicateFinishedLoading":
                     topPanel.setBrowserVisible(true);
                     return createSuccessResponse(null);
+                case "openSourcegraphUrl":
+                    // Source: https://stackoverflow.com/questions/5226212/how-to-open-the-default-webbrowser-using-java
+                    if (Desktop.isDesktopSupported() && Desktop.getDesktop().isSupported(Desktop.Action.BROWSE)) {
+                        String sourcegraphUrl = ConfigUtil.getSourcegraphUrl(this.project);
+                        String relativeUrl = request.getAsJsonObject("arguments").get("relativeUrl").getAsString();
+                        Desktop.getDesktop().browse(new URI(sourcegraphUrl + "/" + relativeUrl));
+                        return createSuccessResponse(null);
+                    } else {
+                        return createErrorResponse("Can't open link. Desktop is not supported.", "No stack trace");
+                    }
                 default:
                     return createErrorResponse("Unknown action: '" + action + "'.", "No stack trace");
             }

--- a/client/jetbrains/src/main/java/com/sourcegraph/browser/JSToJavaBridgeRequestHandler.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/browser/JSToJavaBridgeRequestHandler.java
@@ -53,7 +53,7 @@ public class JSToJavaBridgeRequestHandler {
                 case "loadLastSearch":
                     Search lastSearch = ConfigUtil.getLastSearch(this.project);
 
-                    if (lastSearch != null) {
+                    if (lastSearch == null) {
                         return createSuccessResponse(null);
                     }
 

--- a/client/jetbrains/webview/src/bridge-mock/index.ts
+++ b/client/jetbrains/webview/src/bridge-mock/index.ts
@@ -1,6 +1,11 @@
 import { SearchPatternType } from '@sourcegraph/shared/src/graphql-operations'
 
-import type { MatchRequest, Request, SaveLastSearchRequest } from '../search/js-to-java-bridge'
+import type {
+    MatchRequest,
+    OpenSourcegraphUrlRequest,
+    Request,
+    SaveLastSearchRequest,
+} from '../search/js-to-java-bridge'
 import type { Search } from '../search/types'
 
 let savedSearch: Search = {
@@ -9,6 +14,8 @@ let savedSearch: Search = {
     patternType: SearchPatternType.literal,
     selectedSearchContextSpec: 'global',
 }
+
+const instanceURL = 'https://sourcegraph.com'
 
 const codeDetailsNode = document.querySelector('#code-details') as HTMLPreElement
 const iframeNode = document.querySelector('#webview') as HTMLIFrameElement
@@ -37,7 +44,7 @@ function handleRequest(
         case 'getConfig': {
             onSuccessCallback(
                 JSON.stringify({
-                    instanceURL: 'https://sourcegraph.com',
+                    instanceURL,
                     isGlobbingEnabled: true,
                     accessToken: null,
                 })
@@ -110,7 +117,15 @@ function handleRequest(
             break
         }
 
+        case 'openSourcegraphUrl': {
+            const { relativeUrl } = (request as OpenSourcegraphUrlRequest).arguments
+            window.open(instanceURL + relativeUrl, '_blank')
+            onSuccessCallback('null')
+            break
+        }
+
         default: {
+            // noinspection UnnecessaryLocalVariableJS
             const exhaustiveCheck: never = action
             onFailureCallback(2, `Unknown action: ${exhaustiveCheck as string}`)
         }

--- a/client/jetbrains/webview/src/bridge-mock/index.ts
+++ b/client/jetbrains/webview/src/bridge-mock/index.ts
@@ -69,6 +69,7 @@ function handleRequest(
         }
 
         case 'preview': {
+            // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
             const { content, absoluteOffsetAndLengths } = (request as MatchRequest).arguments
 
             const start = absoluteOffsetAndLengths.length > 0 ? absoluteOffsetAndLengths[0][0] : 0
@@ -95,6 +96,7 @@ function handleRequest(
         }
 
         case 'open': {
+            // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
             const { path } = (request as MatchRequest).arguments
             alert(`Opening ${path}`)
             onSuccessCallback('{}')
@@ -102,6 +104,7 @@ function handleRequest(
         }
 
         case 'saveLastSearch': {
+            // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
             savedSearch = (request as SaveLastSearchRequest).arguments
             onSuccessCallback('{}')
             break
@@ -118,6 +121,7 @@ function handleRequest(
         }
 
         case 'openSourcegraphUrl': {
+            // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
             const { relativeUrl } = (request as OpenSourcegraphUrlRequest).arguments
             window.open(instanceURL + relativeUrl, '_blank')
             onSuccessCallback('null')

--- a/client/jetbrains/webview/src/bridge-mock/index.ts
+++ b/client/jetbrains/webview/src/bridge-mock/index.ts
@@ -8,12 +8,15 @@ import type {
 } from '../search/js-to-java-bridge'
 import type { Search } from '../search/types'
 
-let savedSearch: Search = {
-    query: 'r:github.com/sourcegraph/sourcegraph jetbrains',
-    caseSensitive: false,
-    patternType: SearchPatternType.literal,
-    selectedSearchContextSpec: 'global',
-}
+const savedSearchFromLocalStorage = localStorage.getItem('savedSearch')
+let savedSearch: Search = savedSearchFromLocalStorage
+    ? (JSON.parse(savedSearchFromLocalStorage) as Search)
+    : {
+          query: 'r:github.com/sourcegraph/sourcegraph jetbrains',
+          caseSensitive: false,
+          patternType: SearchPatternType.literal,
+          selectedSearchContextSpec: 'global',
+      }
 
 const instanceURL = 'https://sourcegraph.com'
 
@@ -106,6 +109,7 @@ function handleRequest(
         case 'saveLastSearch': {
             // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
             savedSearch = (request as SaveLastSearchRequest).arguments
+            localStorage.setItem('savedSearch', JSON.stringify(savedSearch))
             onSuccessCallback('{}')
             break
         }

--- a/client/jetbrains/webview/src/search/js-to-java-bridge.ts
+++ b/client/jetbrains/webview/src/search/js-to-java-bridge.ts
@@ -139,12 +139,15 @@ export async function createPreviewOrOpenRequest(
     action: MatchRequest['action']
 ): Promise<MatchRequest> {
     if (match.type === 'commit') {
+        const content = match.content.startsWith('```COMMIT_EDITMSG')
+            ? match.content.replace(/^```COMMIT_EDITMSG\n([\S\s]*)\n```$/, '$1')
+            : match.content.replace(/^```diff\n([\S\s]*)\n```$/, '$1')
         return {
             action,
             arguments: {
                 fileName: '',
                 path: '',
-                content: match.message,
+                content,
                 lineNumber: -1,
                 absoluteOffsetAndLengths: [],
             },
@@ -178,7 +181,6 @@ export async function createPreviewOrOpenRequest(
 
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore This is here in preparation for future match types
-    // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
     console.log(`Unknown match type: “${match.type}”`)
 
     return {

--- a/client/jetbrains/webview/src/search/js-to-java-bridge.ts
+++ b/client/jetbrains/webview/src/search/js-to-java-bridge.ts
@@ -40,6 +40,13 @@ interface IndicateFinishedLoadingRequest {
     action: 'indicateFinishedLoading'
 }
 
+export interface OpenSourcegraphUrlRequest {
+    action: 'openSourcegraphUrl'
+    arguments: {
+        relativeUrl: string
+    }
+}
+
 export type Request =
     | MatchRequest
     | GetConfigRequest
@@ -48,6 +55,7 @@ export type Request =
     | LoadLastSearchRequest
     | ClearPreviewRequest
     | IndicateFinishedLoadingRequest
+    | OpenSourcegraphUrlRequest
 
 export async function getConfig(): Promise<PluginConfig> {
     try {
@@ -127,6 +135,14 @@ export function saveLastSearch(lastSearch: Search): void {
         .catch((error: Error) => {
             console.error(`Failed to save last search: ${error.message}`)
         })
+}
+
+export async function openSourcegraphUrlInBrowser(relativeUrl: string): Promise<void> {
+    try {
+        await callJava({ action: 'openSourcegraphUrl', arguments: { relativeUrl } })
+    } catch (error) {
+        console.error(`Failed to open sourcegraph URL: ${(error as Error).message}`)
+    }
 }
 
 async function callJava(request: Request): Promise<object> {

--- a/client/jetbrains/webview/src/search/results/CommitSearchResult.tsx
+++ b/client/jetbrains/webview/src/search/results/CommitSearchResult.tsx
@@ -46,7 +46,7 @@ export const CommitSearchResult: React.FunctionComponent<Props> = ({ match, sele
                 ref={titleReference}
                 data-tooltip={(truncated && `${match.authorName}: ${match.message.split('\n', 1)[0]}`) || null}
             >
-                {`${displayRepoName(match.repository)} › ${match.authorName}: ${match.message.split('\n', 1)[0]}`}
+                {`${displayRepoName(match.repository)} › ${match.authorName}: ${match.message.split('\n', 1)[0]} `}
                 <SourcegraphLink relativeUrl={match.url}>Open on Sourcegraph</SourcegraphLink>
             </span>
             <span className={styles.spacer} />

--- a/client/jetbrains/webview/src/search/results/CommitSearchResult.tsx
+++ b/client/jetbrains/webview/src/search/results/CommitSearchResult.tsx
@@ -9,6 +9,7 @@ import { CommitMatch } from '@sourcegraph/shared/src/search/stream'
 import { Timestamp } from '@sourcegraph/web/src/components/time/Timestamp'
 import { Typography, useIsTruncated } from '@sourcegraph/wildcard'
 
+import { SourcegraphLink } from './SourcegraphLink'
 import { getResultId } from './utils'
 
 import styles from './SearchResult.module.scss'
@@ -44,7 +45,10 @@ export const CommitSearchResult: React.FunctionComponent<Props> = ({ match, sele
                 onMouseEnter={checkTruncation}
                 ref={titleReference}
                 data-tooltip={(truncated && `${match.authorName}: ${match.message.split('\n', 1)[0]}`) || null}
-            >{`${displayRepoName(match.repository)} › ${match.authorName}: ${match.message.split('\n', 1)[0]}`}</span>
+            >
+                {`${displayRepoName(match.repository)} › ${match.authorName}: ${match.message.split('\n', 1)[0]}`}
+                <SourcegraphLink relativeUrl={match.url}>Open on Sourcegraph</SourcegraphLink>
+            </span>
             <span className={styles.spacer} />
             <Typography.Code className={styles.commitOid}>{match.oid.slice(0, 7)}</Typography.Code>{' '}
             <Timestamp date={match.authorDate} noAbout={true} strict={true} />

--- a/client/jetbrains/webview/src/search/results/RepoSearchResult.tsx
+++ b/client/jetbrains/webview/src/search/results/RepoSearchResult.tsx
@@ -7,9 +7,10 @@ import SourceForkIcon from 'mdi-react/SourceForkIcon'
 
 import { CodeHostIcon, formatRepositoryStarCount, SearchResultStar } from '@sourcegraph/search-ui'
 import { displayRepoName } from '@sourcegraph/shared/src/components/RepoLink'
-import { getRepoMatchLabel, RepositoryMatch } from '@sourcegraph/shared/src/search/stream'
+import { getRepoMatchLabel, getRepoMatchUrl, RepositoryMatch } from '@sourcegraph/shared/src/search/stream'
 import { Icon, useIsTruncated } from '@sourcegraph/wildcard'
 
+import { SourcegraphLink } from './SourcegraphLink'
 import { getResultId } from './utils'
 
 import styles from './SearchResult.module.scss'
@@ -53,11 +54,9 @@ export const RepoSearchResult: React.FunctionComponent<RepoSearchResultProps> = 
                 ref={titleReference}
                 data-tooltip={(truncated && displayRepoName(getRepoMatchLabel(match))) || null}
             >
-                {displayRepoName(getRepoMatchLabel(match))}
+                {displayRepoName(getRepoMatchLabel(match))} (Repository match){' '}
+                <SourcegraphLink relativeUrl={getRepoMatchUrl(match)}>Open on Sourcegraph</SourcegraphLink>
             </span>
-            <div className={styles.matchType}>
-                <small> (Repository match)</small>
-            </div>
             {match.fork && (
                 <>
                     <div className={styles.divider} />

--- a/client/jetbrains/webview/src/search/results/SourcegraphLink.tsx
+++ b/client/jetbrains/webview/src/search/results/SourcegraphLink.tsx
@@ -1,0 +1,24 @@
+import React from 'react'
+
+import { Link } from '@sourcegraph/wildcard'
+
+import { openSourcegraphUrlInBrowser } from '../js-to-java-bridge'
+
+interface Props {
+    relativeUrl: string
+    children: React.ReactNode
+}
+
+function onClick(event: React.MouseEvent<HTMLAnchorElement>, relativeUrl: string): void {
+    event.preventDefault()
+    event.stopPropagation()
+    openSourcegraphUrlInBrowser(relativeUrl)
+        .then(() => {})
+        .catch(() => {})
+}
+
+export const SourcegraphLink: React.FunctionComponent<Props> = ({ relativeUrl, children }: Props) => (
+    <Link to={relativeUrl} onClick={event => onClick(event, relativeUrl)}>
+        {children}
+    </Link>
+)


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/35550 in a simple way.

All changes listed:
 - Shows a raw diff in the preview for diff searches.
 - Adds an "Open on Sourcegraph" link to the `type:diff`, `type:commit` and also the `type:repo` search result types, so now we have no dead ends.
 - Fixes a bug that we previously overlooked with @philipp-spiess 
 - Implemented a simple save/load to/from localStorage for the bridge to simulate the real behavior better and perhaps make testing easier.

## Test plan

Video where I demo all the above: https://www.loom.com/share/3bc07f04cabd48ef88ccc7a8654871b1 (sorry, I blather a lot in the demo because I realized some bugs while doing the demo. The bugs are irrelevant to these changes, though: I confirmed this by testing on `main` after the vid.)