### PR TITLE
cloud: Enable the purge worker on Cloud

### DIFF
--- a/cmd/repo-updater/shared/main.go
+++ b/cmd/repo-updater/shared/main.go
@@ -194,10 +194,12 @@ func Main(enterpriseInit EnterpriseInit) {
 
 	go repos.RunPhabricatorRepositorySyncWorker(ctx, store)
 
-	if !envvar.SourcegraphDotComMode() {
-		// git-server repos purging thread
-		go repos.RunRepositoryPurgeWorker(ctx, db)
+	// git-server repos purging thread
+	var purgeTTL time.Duration
+	if envvar.SourcegraphDotComMode() {
+		purgeTTL = 14 * 24 * time.Hour // two weeks
 	}
+	go repos.RunRepositoryPurgeWorker(ctx, db, purgeTTL)
 
 	// Git fetches scheduler
 	go repos.RunScheduler(ctx, logger, updateScheduler)

--- a/internal/repos/purge.go
+++ b/internal/repos/purge.go
@@ -36,7 +36,6 @@ func RunRepositoryPurgeWorker(ctx context.Context, db database.DB, ttl time.Dura
 		// purging at a weird time to be configuring Sourcegraph.
 		now := time.Now()
 		if isSaturdayNight(now) {
-			// Set some safe default limits
 			if err := purge(ctx, db, log, database.IteratePurgableReposOptions{
 				Limit:         5000,
 				Limiter:       limiter,


### PR DESCRIPTION
It will only run on Saturday evenings and is rate limited.

Closes https://github.com/sourcegraph/sourcegraph/issues/34695

## Test plan

Purge job has been run manually many times already on cloud to get us close to zero purgable repos.
This just enables it to run in the background for 1 hour a week.