### PR TITLE
dev/ci: build sg as dev build in CI, improve lib/output error message

### DIFF
--- a/enterprise/dev/ci/scripts/upload-build-logs.sh
+++ b/enterprise/dev/ci/scripts/upload-build-logs.sh
@@ -29,7 +29,7 @@ echo "~~~ :go: Building sg"
 (
   set -x
   pushd dev/sg
-  go build -o ../../sg -ldflags "-X main.BuildCommit=$BUILDKITE_COMMIT" -mod=mod .
+  go build -o ../../sg -mod=mod .
   popd
 )
 

--- a/lib/output/capabilities.go
+++ b/lib/output/capabilities.go
@@ -49,6 +49,8 @@ func detectCapabilities(opts OutputOpts) (caps capabilities, err error) {
 			} else {
 				err = errors.New("unexpected nil size from GetWinsize")
 			}
+		} else {
+			err = errors.Wrap(err, "GetWinsize")
 		}
 	}
 	// Set overrides


### PR DESCRIPTION
Because we set the version, auto update defaults to true, which means we get `sg` attempting to update itself in CI

![image](https://user-images.githubusercontent.com/23356519/171222725-8fa4f7e1-01e4-4633-9b04-602d9647574e.png)

https://buildkite.com/sourcegraph/sourcegraph/builds/150797#01811aa2-5403-48ab-aac3-a12c29bc511f

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

yolo let's test in main