### PR TITLE
codeintel: surface upload audit logs in graphql and UI for non-deleted uploads

### DIFF
--- a/client/web/src/components/Timeline.tsx
+++ b/client/web/src/components/Timeline.tsx
@@ -19,11 +19,17 @@ export interface TimelineStage {
 
 export interface TimelineProps {
     stages: TimelineStage[]
+    withoutPreviousDate?: boolean
     now?: () => Date
     className?: string
 }
 
-export const Timeline: FunctionComponent<React.PropsWithChildren<TimelineProps>> = ({ stages, now, className }) => (
+export const Timeline: FunctionComponent<React.PropsWithChildren<TimelineProps>> = ({
+    stages,
+    now,
+    className,
+    withoutPreviousDate = false,
+}) => (
     <div className={className}>
         {stages.map((stage, stageIndex) => {
             if (!stage.date) {
@@ -47,11 +53,13 @@ export const Timeline: FunctionComponent<React.PropsWithChildren<TimelineProps>>
                             <div className="flex-0">
                                 <div className={styles.executorTaskSeparator} />
                             </div>
-                            <div className="flex-1">
-                                <span className="text-muted ml-4">
-                                    {formatDistance(new Date(stage.date), new Date(previousDate))}
-                                </span>
-                            </div>
+                            {!withoutPreviousDate && (
+                                <div className="flex-1">
+                                    <span className="text-muted ml-4">
+                                        {formatDistance(new Date(stage.date), new Date(previousDate))}
+                                    </span>
+                                </div>
+                            )}
                         </div>
                     )}
 

--- a/client/web/src/enterprise/codeintel/badge/components/CodeIntelligenceBadgeMenu.story.tsx
+++ b/client/web/src/enterprise/codeintel/badge/components/CodeIntelligenceBadgeMenu.story.tsx
@@ -41,6 +41,7 @@ const uploadPrototype: Omit<LsifUploadFields, 'id' | 'state' | 'uploadedAt'> = {
         },
     },
     associatedIndex: null,
+    auditLogs: [],
 }
 
 const executionLogPrototype: ExecutionLogEntryFields = {

--- a/client/web/src/enterprise/codeintel/uploads/components/UploadAuditLogTimeline.module.scss
+++ b/client/web/src/enterprise/codeintel/uploads/components/UploadAuditLogTimeline.module.scss
@@ -9,5 +9,5 @@ $db-column-col: 17.5%;
 }
 
 .data-column-col {
-    width: calc((100% - #{$db-column-col})/2);
+    width: calc((100% - #{$db-column-col}) / 2);
 }

--- a/client/web/src/enterprise/codeintel/uploads/components/UploadAuditLogTimeline.module.scss
+++ b/client/web/src/enterprise/codeintel/uploads/components/UploadAuditLogTimeline.module.scss
@@ -1,0 +1,13 @@
+.table-container {
+    overflow-x: scroll;
+}
+
+$db-column-col: 17.5%;
+
+.db-column-col {
+    width: $db-column-col;
+}
+
+.data-column-col {
+    width: calc((100% - #{$db-column-col})/2);
+}

--- a/client/web/src/enterprise/codeintel/uploads/components/UploadAuditLogTimeline.tsx
+++ b/client/web/src/enterprise/codeintel/uploads/components/UploadAuditLogTimeline.tsx
@@ -1,8 +1,10 @@
-import { FunctionComponent } from 'react'
+import { FunctionComponent, ReactNode } from 'react'
 
 import classNames from 'classnames'
 import DatabaseEditIcon from 'mdi-react/DatabaseEditIcon'
 import DatabasePlusIcon from 'mdi-react/DatabasePlusIcon'
+
+import { Code, Container } from '@sourcegraph/wildcard'
 
 import { Timeline } from '../../../../components/Timeline'
 import { AuditLogOperation, LsifUploadsAuditLogsFields } from '../../../../graphql-operations'
@@ -22,43 +24,83 @@ export const UploadAuditLogTimeline: FunctionComponent<React.PropsWithChildren<U
 }) => {
     const stages = logs?.map(log => ({
         icon: log.operation === AuditLogOperation.CREATE ? <DatabasePlusIcon /> : <DatabaseEditIcon />,
-        text: log.logTimestamp,
+        text: stageText(log),
         date: log.logTimestamp,
         details: (
-            <table className="table mb-0">
-                <thead>
-                    <tr>
-                        <th>Column</th>
-                        <th>Old</th>
-                        <th>New</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    {log.changedColumns.map((change, index) => (
-                        // eslint-disable-next-line react/no-array-index-key
-                        <tr key={index}>
-                            <td className="mr-2">
-                                <pre className={classNames('mb-0 position-relative')}>
-                                    {(change as stateChange).column}
-                                </pre>
-                            </td>
-                            <td className="mr-2">
-                                <pre className={classNames('mb-0 position-relative')}>
-                                    {(change as stateChange).old || 'NULL'}
-                                </pre>
-                            </td>
-                            <td className="mr-2">
-                                <pre className={classNames('mb-0 position-relative')}>
-                                    {(change as stateChange).new || 'NULL'}
-                                </pre>
-                            </td>
+            <>
+                {log.reason && (
+                    <>
+                        <Container>
+                            <b>Reason</b>: {log.reason}
+                        </Container>
+                        <br />
+                    </>
+                )}
+                <table className="table mb-0">
+                    <thead>
+                        <tr>
+                            <th>Column</th>
+                            <th>Old</th>
+                            <th>New</th>
                         </tr>
-                    ))}
-                </tbody>
-            </table>
+                    </thead>
+                    <tbody>
+                        {log.changedColumns.map((change, index) => (
+                            // eslint-disable-next-line react/no-array-index-key
+                            <tr key={index}>
+                                <td className="mr-2">
+                                    <pre className={classNames('mb-0 position-relative')}>
+                                        {(change as stateChange).column}
+                                    </pre>
+                                </td>
+                                <td className="mr-2">
+                                    <pre className={classNames('mb-0 position-relative')}>
+                                        {(change as stateChange).old || 'NULL'}
+                                    </pre>
+                                </td>
+                                <td className="mr-2">
+                                    <pre className={classNames('mb-0 position-relative')}>
+                                        {(change as stateChange).new || 'NULL'}
+                                    </pre>
+                                </td>
+                            </tr>
+                        ))}
+                    </tbody>
+                </table>
+            </>
         ),
         className: log.operation === AuditLogOperation.CREATE ? 'bg-success' : 'bg-warning',
     }))
 
     return <Timeline withoutPreviousDate={true} stages={stages} />
+}
+
+function stageText(log: LsifUploadsAuditLogsFields): ReactNode {
+    if (log.operation === AuditLogOperation.CREATE) {
+        return 'Upload created'
+    }
+
+    return (
+        <>
+            Altered columns:{' '}
+            {formatReactNodeList(
+                (log.changedColumns as stateChange[]).map(change => <Code key={change.column}>{change.column}</Code>)
+            )}
+        </>
+    )
+}
+
+function formatReactNodeList(list: ReactNode[]): ReactNode {
+    if (list.length === 0) {
+        return <></>
+    }
+    if (list.length === 1) {
+        return list[0]
+    }
+
+    return (
+        <>
+            {list.slice(0, -1).reduce((previous, current) => [previous, ', ', current])} and {list[list.length - 1]}
+        </>
+    )
 }

--- a/client/web/src/enterprise/codeintel/uploads/components/UploadAuditLogTimeline.tsx
+++ b/client/web/src/enterprise/codeintel/uploads/components/UploadAuditLogTimeline.tsx
@@ -1,0 +1,64 @@
+import { FunctionComponent } from 'react'
+
+import classNames from 'classnames'
+import DatabaseEditIcon from 'mdi-react/DatabaseEditIcon'
+import DatabasePlusIcon from 'mdi-react/DatabasePlusIcon'
+
+import { Timeline } from '../../../../components/Timeline'
+import { AuditLogOperation, LsifUploadsAuditLogsFields } from '../../../../graphql-operations'
+
+export interface UploadAuditLogTimelineProps {
+    logs: LsifUploadsAuditLogsFields[]
+}
+
+interface stateChange {
+    column: string
+    old?: string
+    new?: string
+}
+
+export const UploadAuditLogTimeline: FunctionComponent<React.PropsWithChildren<UploadAuditLogTimelineProps>> = ({
+    logs,
+}) => {
+    const stages = logs?.map(log => ({
+        icon: log.operation === AuditLogOperation.CREATE ? <DatabasePlusIcon /> : <DatabaseEditIcon />,
+        text: log.logTimestamp,
+        date: log.logTimestamp,
+        details: (
+            <table className="table mb-0">
+                <thead>
+                    <tr>
+                        <th>Column</th>
+                        <th>Old</th>
+                        <th>New</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {log.changedColumns.map((change, index) => (
+                        // eslint-disable-next-line react/no-array-index-key
+                        <tr key={index}>
+                            <td className="mr-2">
+                                <pre className={classNames('mb-0 position-relative')}>
+                                    {(change as stateChange).column}
+                                </pre>
+                            </td>
+                            <td className="mr-2">
+                                <pre className={classNames('mb-0 position-relative')}>
+                                    {(change as stateChange).old || 'NULL'}
+                                </pre>
+                            </td>
+                            <td className="mr-2">
+                                <pre className={classNames('mb-0 position-relative')}>
+                                    {(change as stateChange).new || 'NULL'}
+                                </pre>
+                            </td>
+                        </tr>
+                    ))}
+                </tbody>
+            </table>
+        ),
+        className: log.operation === AuditLogOperation.CREATE ? 'bg-success' : 'bg-warning',
+    }))
+
+    return <Timeline withoutPreviousDate={true} stages={stages} />
+}

--- a/client/web/src/enterprise/codeintel/uploads/components/UploadAuditLogTimeline.tsx
+++ b/client/web/src/enterprise/codeintel/uploads/components/UploadAuditLogTimeline.tsx
@@ -13,12 +13,6 @@ export interface UploadAuditLogTimelineProps {
     logs: LsifUploadsAuditLogsFields[]
 }
 
-interface stateChange {
-    column: string
-    old?: string
-    new?: string
-}
-
 export const UploadAuditLogTimeline: FunctionComponent<React.PropsWithChildren<UploadAuditLogTimelineProps>> = ({
     logs,
 }) => {
@@ -49,19 +43,13 @@ export const UploadAuditLogTimeline: FunctionComponent<React.PropsWithChildren<U
                             // eslint-disable-next-line react/no-array-index-key
                             <tr key={index}>
                                 <td className="mr-2">
-                                    <pre className={classNames('mb-0 position-relative')}>
-                                        {(change as stateChange).column}
-                                    </pre>
+                                    <pre className={classNames('mb-0 position-relative')}>{change.column}</pre>
                                 </td>
                                 <td className="mr-2">
-                                    <pre className={classNames('mb-0 position-relative')}>
-                                        {(change as stateChange).old || 'NULL'}
-                                    </pre>
+                                    <pre className={classNames('mb-0 position-relative')}>{change.old || 'NULL'}</pre>
                                 </td>
                                 <td className="mr-2">
-                                    <pre className={classNames('mb-0 position-relative')}>
-                                        {(change as stateChange).new || 'NULL'}
-                                    </pre>
+                                    <pre className={classNames('mb-0 position-relative')}>{change.new || 'NULL'}</pre>
                                 </td>
                             </tr>
                         ))}
@@ -83,9 +71,7 @@ function stageText(log: LsifUploadsAuditLogsFields): ReactNode {
     return (
         <>
             Altered columns:{' '}
-            {formatReactNodeList(
-                (log.changedColumns as stateChange[]).map(change => <Code key={change.column}>{change.column}</Code>)
-            )}
+            {formatReactNodeList(log.changedColumns.map(change => <Code key={change.column}>{change.column}</Code>))}
         </>
     )
 }

--- a/client/web/src/enterprise/codeintel/uploads/components/UploadAuditLogTimeline.tsx
+++ b/client/web/src/enterprise/codeintel/uploads/components/UploadAuditLogTimeline.tsx
@@ -4,7 +4,7 @@ import classNames from 'classnames'
 import DatabaseEditIcon from 'mdi-react/DatabaseEditIcon'
 import DatabasePlusIcon from 'mdi-react/DatabasePlusIcon'
 
-import { Code, Container } from '@sourcegraph/wildcard'
+import { Container } from '@sourcegraph/wildcard'
 
 import { Timeline } from '../../../../components/Timeline'
 import { AuditLogOperation, LsifUploadsAuditLogsFields } from '../../../../graphql-operations'
@@ -43,13 +43,13 @@ export const UploadAuditLogTimeline: FunctionComponent<React.PropsWithChildren<U
                             // eslint-disable-next-line react/no-array-index-key
                             <tr key={index}>
                                 <td className="mr-2">
-                                    <pre className={classNames('mb-0 position-relative')}>{change.column}</pre>
+                                    <span className={classNames('mb-0 position-relative')}>{change.column}</span>
                                 </td>
                                 <td className="mr-2">
-                                    <pre className={classNames('mb-0 position-relative')}>{change.old || 'NULL'}</pre>
+                                    <span className={classNames('mb-0 position-relative')}>{change.old || 'NULL'}</span>
                                 </td>
                                 <td className="mr-2">
-                                    <pre className={classNames('mb-0 position-relative')}>{change.new || 'NULL'}</pre>
+                                    <span className={classNames('mb-0 position-relative')}>{change.new || 'NULL'}</span>
                                 </td>
                             </tr>
                         ))}
@@ -71,7 +71,7 @@ function stageText(log: LsifUploadsAuditLogsFields): ReactNode {
     return (
         <>
             Altered columns:{' '}
-            {formatReactNodeList(log.changedColumns.map(change => <Code key={change.column}>{change.column}</Code>))}
+            {formatReactNodeList(log.changedColumns.map(change => <span key={change.column}>{change.column}</span>))}
         </>
     )
 }

--- a/client/web/src/enterprise/codeintel/uploads/components/UploadAuditLogTimeline.tsx
+++ b/client/web/src/enterprise/codeintel/uploads/components/UploadAuditLogTimeline.tsx
@@ -1,6 +1,5 @@
 import { FunctionComponent, ReactNode } from 'react'
 
-import classNames from 'classnames'
 import DatabaseEditIcon from 'mdi-react/DatabaseEditIcon'
 import DatabasePlusIcon from 'mdi-react/DatabasePlusIcon'
 
@@ -8,6 +7,8 @@ import { Container } from '@sourcegraph/wildcard'
 
 import { Timeline } from '../../../../components/Timeline'
 import { AuditLogOperation, LsifUploadsAuditLogsFields } from '../../../../graphql-operations'
+
+import styles from './UploadAuditLogTimeline.module.scss'
 
 export interface UploadAuditLogTimelineProps {
     logs: LsifUploadsAuditLogsFields[]
@@ -19,6 +20,8 @@ export const UploadAuditLogTimeline: FunctionComponent<React.PropsWithChildren<U
     const stages = logs?.map(log => ({
         icon: log.operation === AuditLogOperation.CREATE ? <DatabasePlusIcon /> : <DatabaseEditIcon />,
         text: stageText(log),
+        className: log.operation === AuditLogOperation.CREATE ? 'bg-success' : 'bg-warning',
+        expanded: true,
         date: log.logTimestamp,
         details: (
             <>
@@ -30,34 +33,33 @@ export const UploadAuditLogTimeline: FunctionComponent<React.PropsWithChildren<U
                         <br />
                     </>
                 )}
-                <table className="table mb-0">
-                    <thead>
-                        <tr>
-                            <th>Column</th>
-                            <th>Old</th>
-                            <th>New</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        {log.changedColumns.map((change, index) => (
-                            // eslint-disable-next-line react/no-array-index-key
-                            <tr key={index}>
-                                <td className="mr-2">
-                                    <span className={classNames('mb-0 position-relative')}>{change.column}</span>
-                                </td>
-                                <td className="mr-2">
-                                    <span className={classNames('mb-0 position-relative')}>{change.old || 'NULL'}</span>
-                                </td>
-                                <td className="mr-2">
-                                    <span className={classNames('mb-0 position-relative')}>{change.new || 'NULL'}</span>
-                                </td>
+                <div className={styles.tableContainer}>
+                    <table className="table mb-0 table-striped">
+                        <thead>
+                            <tr>
+                                <th className={styles.dbColumnCol} scope="column">
+                                    Column
+                                </th>
+                                <th className={styles.dataColumnCol} scope="column">
+                                    Old
+                                </th>
+                                <th scope="column">New</th>
                             </tr>
-                        ))}
-                    </tbody>
-                </table>
+                        </thead>
+                        <tbody>
+                            {log.changedColumns.map((change, index) => (
+                                // eslint-disable-next-line react/no-array-index-key
+                                <tr key={index} className="overflow-scroll">
+                                    <td className="mr-2">{change.column}</td>
+                                    <td className="mr-2">{change.old || 'NULL'}</td>
+                                    <td className="mr-2">{change.new || 'NULL'}</td>
+                                </tr>
+                            ))}
+                        </tbody>
+                    </table>
+                </div>
             </>
         ),
-        className: log.operation === AuditLogOperation.CREATE ? 'bg-success' : 'bg-warning',
     }))
 
     return <Timeline withoutPreviousDate={true} stages={stages} />

--- a/client/web/src/enterprise/codeintel/uploads/hooks/types.tsx
+++ b/client/web/src/enterprise/codeintel/uploads/hooks/types.tsx
@@ -4,7 +4,11 @@ export const lsifUploadAuditLogsFieldsFragment = gql`
     fragment LsifUploadsAuditLogsFields on LSIFUploadAuditLog {
         logTimestamp
         reason
-        changedColumns
+        changedColumns {
+            column
+            old
+            new
+        }
         operation
     }
 `

--- a/client/web/src/enterprise/codeintel/uploads/hooks/types.tsx
+++ b/client/web/src/enterprise/codeintel/uploads/hooks/types.tsx
@@ -1,5 +1,14 @@
 import { gql } from '@sourcegraph/http-client'
 
+export const lsifUploadAuditLogsFieldsFragment = gql`
+    fragment LsifUploadsAuditLogsFields on LSIFUploadAuditLog {
+        logTimestamp
+        reason
+        changedColumns
+        operation
+    }
+`
+
 export const lsifUploadFieldsFragment = gql`
     fragment LsifUploadFields on LSIFUpload {
         __typename
@@ -40,7 +49,12 @@ export const lsifUploadFieldsFragment = gql`
             finishedAt
             placeInQueue
         }
+        auditLogs {
+            ...LsifUploadsAuditLogsFields
+        }
     }
+
+    ${lsifUploadAuditLogsFieldsFragment}
 `
 
 export const lsifUploadConnectionFieldsFragment = gql`

--- a/client/web/src/enterprise/codeintel/uploads/pages/CodeIntelUploadPage.story.tsx
+++ b/client/web/src/enterprise/codeintel/uploads/pages/CodeIntelUploadPage.story.tsx
@@ -4,7 +4,7 @@ import { of } from 'rxjs'
 import { GitObjectType, LSIFIndexState } from '@sourcegraph/shared/src/schema'
 
 import { WebStory } from '../../../../components/WebStory'
-import { LsifUploadFields, LSIFUploadState } from '../../../../graphql-operations'
+import { LsifUploadFields, LSIFUploadState, AuditLogOperation } from '../../../../graphql-operations'
 
 import { CodeIntelUploadPage, CodeIntelUploadPageProps } from './CodeIntelUploadPage'
 
@@ -34,6 +34,7 @@ const uploadPrototype: Omit<LsifUploadFields, 'id' | 'state' | 'uploadedAt'> = {
         },
     },
     associatedIndex: null,
+    auditLogs: [],
 }
 
 const dependendentPrototype = {
@@ -308,5 +309,46 @@ AssociatedIndex.args = {
                 finishedAt: '2020-06-15T12:25:30+00:00',
                 placeInQueue: null,
             },
+        }),
+}
+
+export const WithAuditLogs = Template.bind({})
+WithAuditLogs.args = {
+    ...defaults,
+    queryLisfUploadFields: () =>
+        of({
+            ...uploadPrototype,
+            id: '1',
+            state: LSIFUploadState.PROCESSING,
+            uploadedAt: '2020-06-15T12:20:30+00:00',
+            startedAt: '2020-06-15T12:25:30+00:00',
+            auditLogs: [
+                {
+                    logTimestamp: '2020-06-15T12:20:30+00:00',
+                    uploadDeletedAt: null,
+                    reason: null,
+                    changedColumns: [
+                        {
+                            column: 'state',
+                            old: null,
+                            new: 'UPLOADING',
+                        },
+                    ],
+                    operation: AuditLogOperation.CREATE,
+                },
+                {
+                    logTimestamp: '2020-06-15T12:20:30+00:00',
+                    uploadDeletedAt: null,
+                    reason: null,
+                    changedColumns: [
+                        {
+                            column: 'state',
+                            old: 'UPLOADING',
+                            new: 'PROCESSING',
+                        },
+                    ],
+                    operation: AuditLogOperation.MODIFY,
+                },
+            ],
         }),
 }

--- a/client/web/src/enterprise/codeintel/uploads/pages/CodeIntelUploadPage.story.tsx
+++ b/client/web/src/enterprise/codeintel/uploads/pages/CodeIntelUploadPage.story.tsx
@@ -339,12 +339,48 @@ WithAuditLogs.args = {
                 {
                     logTimestamp: '2020-06-15T12:20:30+00:00',
                     uploadDeletedAt: null,
-                    reason: null,
+                    reason: 'because I feel like it, and it was a Wednesday evening',
                     changedColumns: [
                         {
                             column: 'state',
                             old: 'UPLOADING',
                             new: 'PROCESSING',
+                        },
+                    ],
+                    operation: AuditLogOperation.MODIFY,
+                },
+                {
+                    logTimestamp: '2020-06-16T12.00.30+00:00',
+                    uploadDeletedAt: null,
+                    reason: null,
+                    changedColumns: [
+                        {
+                            column: 'banana',
+                            old: 'hello',
+                            new: 'goodbye and good riddance',
+                        },
+                    ],
+                    operation: AuditLogOperation.MODIFY,
+                },
+                {
+                    logTimestamp: '2020-12-16T12.00.30+00:00',
+                    uploadDeletedAt: null,
+                    reason: null,
+                    changedColumns: [
+                        {
+                            column: 'sample_text',
+                            old: null,
+                            new: 'Lorem ipsum dolor sit amet.',
+                        },
+                        {
+                            column: 'ipsum',
+                            old: 'that last one was quite something',
+                            new: 'that last one was truncated before publishing',
+                        },
+                        {
+                            column: 'lorem',
+                            old: '500',
+                            new: '501',
                         },
                     ],
                     operation: AuditLogOperation.MODIFY,

--- a/client/web/src/enterprise/codeintel/uploads/pages/CodeIntelUploadPage.story.tsx
+++ b/client/web/src/enterprise/codeintel/uploads/pages/CodeIntelUploadPage.story.tsx
@@ -368,7 +368,7 @@ WithAuditLogs.args = {
                     reason: null,
                     changedColumns: [
                         {
-                            column: 'sample_text',
+                            column: 'some_long_column_name',
                             old: null,
                             new: 'Lorem ipsum dolor sit amet.',
                         },

--- a/client/web/src/enterprise/codeintel/uploads/pages/CodeIntelUploadPage.tsx
+++ b/client/web/src/enterprise/codeintel/uploads/pages/CodeIntelUploadPage.tsx
@@ -3,6 +3,7 @@ import { FunctionComponent, useCallback, useEffect, useMemo, useState } from 're
 import { useApolloClient } from '@apollo/client'
 import classNames from 'classnames'
 import InformationOutlineIcon from 'mdi-react/InformationOutlineIcon'
+import MapSearchIcon from 'mdi-react/MapSearchIcon'
 import { Redirect, RouteComponentProps } from 'react-router'
 import { Observable } from 'rxjs'
 import { takeWhile } from 'rxjs/operators'
@@ -11,7 +12,7 @@ import { ErrorAlert } from '@sourcegraph/branded/src/components/alerts'
 import { ErrorLike, isErrorLike } from '@sourcegraph/common'
 import { LSIFUploadState } from '@sourcegraph/shared/src/graphql-operations'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
-import { Button, Container, PageHeader, LoadingSpinner, useObservable, Icon, H3 } from '@sourcegraph/wildcard'
+import { Button, Container, PageHeader, LoadingSpinner, useObservable, Icon, H3, Text } from '@sourcegraph/wildcard'
 
 import { AuthenticatedUser } from '../../../../auth'
 import { Collapsible } from '../../../../components/Collapsible'
@@ -31,6 +32,7 @@ import { DependencyOrDependentNode } from '../components/DependencyOrDependentNo
 import { EmptyDependencies } from '../components/EmptyDependencies'
 import { EmptyDependents } from '../components/EmptyDependents'
 import { EmptyUploadRetentionMatchStatus } from '../components/EmptyUploadRetentionStatusNode'
+import { UploadAuditLogTimeline } from '../components/UploadAuditLogTimeline'
 import { RetentionMatchNode } from '../components/UploadRetentionStatusNode'
 import { queryLisfUploadFields as defaultQueryLisfUploadFields } from '../hooks/queryLisfUploadFields'
 import { queryLsifUploadsList as defaultQueryLsifUploadsList } from '../hooks/queryLsifUploadsList'
@@ -356,6 +358,20 @@ export const CodeIntelUploadPage: FunctionComponent<React.PropsWithChildren<Code
                             </Container>
                         </>
                     )}
+
+                    <Container className="mt-2">
+                        <Collapsible title={<H3 className="mb-0">Audit Logs</H3>} titleAtStart={true}>
+                            {uploadOrError.auditLogs?.length ?? 0 > 0 ? (
+                                <UploadAuditLogTimeline logs={uploadOrError.auditLogs || []} />
+                            ) : (
+                                <Text alignment="center" className="text-muted w-100 mb-0 mt-1">
+                                    <MapSearchIcon className="mb-2" />
+                                    <br />
+                                    This upload has no audit logs.
+                                </Text>
+                            )}
+                        </Collapsible>
+                    </Container>
                 </>
             )}
         </div>

--- a/client/web/src/enterprise/codeintel/uploads/pages/CodeIntelUploadsPage.story.tsx
+++ b/client/web/src/enterprise/codeintel/uploads/pages/CodeIntelUploadsPage.story.tsx
@@ -33,6 +33,7 @@ const uploadPrototype: Omit<LsifUploadFields, 'id' | 'state' | 'uploadedAt'> = {
         },
     },
     associatedIndex: null,
+    auditLogs: [],
 }
 
 const testUploads: LsifUploadFields[] = [

--- a/cmd/frontend/graphqlbackend/codeintel.go
+++ b/cmd/frontend/graphqlbackend/codeintel.go
@@ -127,7 +127,7 @@ type LSIFUploadsAuditLogsResolver interface {
 	LogTimestamp() DateTime
 	UploadDeletedAt() *DateTime
 	Reason() *string
-	ChangedColumns() []JSONValue
+	ChangedColumns() []AuditLogColumnChange
 	UploadID() graphql.ID
 	InputCommit() string
 	InputRoot() string
@@ -135,6 +135,12 @@ type LSIFUploadsAuditLogsResolver interface {
 	UploadedAt() DateTime
 	Operation() string
 	// AssociatedIndex(ctx context.Context) (LSIFIndexResolver, error)
+}
+
+type AuditLogColumnChange interface {
+	Column() string
+	Old() *string
+	New() *string
 }
 
 type LSIFIndexesQueryArgs struct {

--- a/cmd/frontend/graphqlbackend/codeintel.go
+++ b/cmd/frontend/graphqlbackend/codeintel.go
@@ -105,6 +105,7 @@ type LSIFUploadResolver interface {
 	ProjectRoot(ctx context.Context) (*GitTreeEntryResolver, error)
 	RetentionPolicyOverview(ctx context.Context, args *LSIFUploadRetentionPolicyMatchesArgs) (CodeIntelligenceRetentionPolicyMatchesConnectionResolver, error)
 	DocumentPaths(ctx context.Context, args *LSIFUploadDocumentPathsQueryArgs) (LSIFUploadDocumentPathsConnectionResolver, error)
+	AuditLogs(ctx context.Context) (*[]LSIFUploadsAuditLogsResolver, error)
 }
 
 type LSIFUploadConnectionResolver interface {
@@ -120,6 +121,20 @@ type LSIFUploadDocumentPathsQueryArgs struct {
 type LSIFUploadDocumentPathsConnectionResolver interface {
 	Nodes(ctx context.Context) ([]string, error)
 	TotalCount(ctx context.Context) (*int32, error)
+}
+
+type LSIFUploadsAuditLogsResolver interface {
+	LogTimestamp() DateTime
+	UploadDeletedAt() *DateTime
+	Reason() *string
+	ChangedColumns() []JSONValue
+	UploadID() graphql.ID
+	InputCommit() string
+	InputRoot() string
+	InputIndexer() string
+	UploadedAt() DateTime
+	Operation() string
+	// AssociatedIndex(ctx context.Context) (LSIFIndexResolver, error)
 }
 
 type LSIFIndexesQueryArgs struct {

--- a/cmd/frontend/graphqlbackend/codeintel.graphql
+++ b/cmd/frontend/graphqlbackend/codeintel.graphql
@@ -1031,6 +1031,11 @@ type LSIFUpload implements Node {
     pattern. Pattern type is subject to change.
     """
     documentPaths(pattern: String!): LSIFUploadDocumentPathsConnection!
+
+    """
+    Audit logs representing each state change of the upload in order from earliest to latest.
+    """
+    auditLogs: [LSIFUploadAuditLog!]
 }
 
 """
@@ -1066,6 +1071,75 @@ type LSIFUploadDocumentPathsConnection {
     The total number of docuemnt paths.
     """
     totalCount: Int
+}
+
+"""
+Contains the metadata and upload data for a single state change of an upload.
+"""
+type LSIFUploadAuditLog {
+    """
+    The timestamp the log was emitted at.
+    """
+    logTimestamp: DateTime!
+
+    """
+    The timestamp when the associated upload was deleted at.
+    """
+    uploadDeletedAt: DateTime
+
+    """
+    The reason for this change in data.
+    """
+    reason: String
+
+    """
+    A list of changed columns in the format {"column": "<colname>", "new": "<newval>", "old": "<oldval>"}
+    """
+    changedColumns: [JSONValue!]!
+
+    """
+    The ID of the upload.
+    """
+    uploadId: ID!
+
+    """
+    The original 40-character commit commit supplied at upload time.
+    """
+    inputCommit: String!
+
+    """
+    The original root supplied at upload time.
+    """
+    inputRoot: String!
+
+    """
+    The original indexer name supplied at upload time.
+    """
+    inputIndexer: String!
+
+    """
+    The time the upload was uploaded.
+    """
+    uploadedAt: DateTime!
+
+    """
+    The operation denoted by this log.
+    """
+    operation: AuditLogOperation!
+}
+
+"""
+Denotes the type of operation of a given log entry.
+"""
+enum AuditLogOperation {
+    """
+    Denotes this log entry represents an INSERT query.
+    """
+    CREATE
+    """
+    Denotes this log entry represents an UPDATE query.
+    """
+    MODIFY
 }
 
 """

--- a/cmd/frontend/graphqlbackend/codeintel.graphql
+++ b/cmd/frontend/graphqlbackend/codeintel.graphql
@@ -1095,7 +1095,7 @@ type LSIFUploadAuditLog {
     """
     A list of changed columns in the format {"column": "<colname>", "new": "<newval>", "old": "<oldval>"}
     """
-    changedColumns: [JSONValue!]!
+    changedColumns: [AuditLogColumnChange!]!
 
     """
     The ID of the upload.
@@ -1126,6 +1126,26 @@ type LSIFUploadAuditLog {
     The operation denoted by this log.
     """
     operation: AuditLogOperation!
+}
+
+"""
+Represents a state transition of a single column.
+"""
+type AuditLogColumnChange {
+    """
+    The column that is changing.
+    """
+    column: String!
+
+    """
+    The previous value of the column.
+    """
+    old: String
+
+    """
+    The new value of the column
+    """
+    new: String
 }
 
 """

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/audit_log.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/audit_log.go
@@ -1,0 +1,11 @@
+package resolvers
+
+import (
+	"context"
+
+	store "github.com/sourcegraph/sourcegraph/internal/codeintel/stores/dbstore"
+)
+
+func (r *resolver) AuditLogsForUpload(ctx context.Context, id int) ([]store.UploadLog, error) {
+	return r.dbStore.GetAuditLogsForUpload(ctx, id)
+}

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/audit_logs.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/audit_logs.go
@@ -1,0 +1,44 @@
+package graphql
+
+import (
+	"strings"
+
+	"github.com/graph-gophers/graphql-go"
+
+	gql "github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
+	"github.com/sourcegraph/sourcegraph/internal/codeintel/stores/dbstore"
+)
+
+type lsifUploadsAuditLogResolver struct {
+	log dbstore.UploadLog
+}
+
+func (r *lsifUploadsAuditLogResolver) Reason() *string { return r.log.Reason }
+func (r *lsifUploadsAuditLogResolver) ChangedColumns() (values []gql.JSONValue) {
+	for _, transition := range r.log.TransitionColumns {
+		values = append(values, gql.JSONValue{Value: transition})
+	}
+	return
+}
+
+func (r *lsifUploadsAuditLogResolver) LogTimestamp() gql.DateTime {
+	return gql.DateTime{Time: r.log.LogTimestamp}
+}
+
+func (r *lsifUploadsAuditLogResolver) UploadDeletedAt() *gql.DateTime {
+	return gql.DateTimeOrNil(r.log.RecordDeletedAt)
+}
+
+func (r *lsifUploadsAuditLogResolver) UploadID() graphql.ID {
+	return marshalLSIFUploadGQLID(int64(r.log.UploadID))
+}
+func (r *lsifUploadsAuditLogResolver) InputCommit() string  { return r.log.Commit }
+func (r *lsifUploadsAuditLogResolver) InputRoot() string    { return r.log.Root }
+func (r *lsifUploadsAuditLogResolver) InputIndexer() string { return r.log.Indexer }
+func (r *lsifUploadsAuditLogResolver) UploadedAt() gql.DateTime {
+	return gql.DateTime{Time: r.log.UploadedAt}
+}
+
+func (r *lsifUploadsAuditLogResolver) Operation() string {
+	return strings.ToUpper(r.log.Operation)
+}

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/audit_logs.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/audit_logs.go
@@ -9,14 +9,30 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/stores/dbstore"
 )
 
+type auditLogColumnChangeResolver struct {
+	columnTransition map[string]*string
+}
+
+func (r *auditLogColumnChangeResolver) Column() string {
+	return *r.columnTransition["column"]
+}
+
+func (r *auditLogColumnChangeResolver) Old() *string {
+	return r.columnTransition["old"]
+}
+
+func (r *auditLogColumnChangeResolver) New() *string {
+	return r.columnTransition["new"]
+}
+
 type lsifUploadsAuditLogResolver struct {
 	log dbstore.UploadLog
 }
 
 func (r *lsifUploadsAuditLogResolver) Reason() *string { return r.log.Reason }
-func (r *lsifUploadsAuditLogResolver) ChangedColumns() (values []gql.JSONValue) {
+func (r *lsifUploadsAuditLogResolver) ChangedColumns() (values []gql.AuditLogColumnChange) {
 	for _, transition := range r.log.TransitionColumns {
-		values = append(values, gql.JSONValue{Value: transition})
+		values = append(values, &auditLogColumnChangeResolver{transition})
 	}
 	return
 }

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/upload.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/upload.go
@@ -152,3 +152,17 @@ func (r *UploadResolver) DocumentPaths(ctx context.Context, args *gql.LSIFUpload
 		documents:  documents,
 	}, nil
 }
+
+func (r *UploadResolver) AuditLogs(ctx context.Context) (*[]gql.LSIFUploadsAuditLogsResolver, error) {
+	logs, err := r.resolver.AuditLogsForUpload(ctx, r.upload.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	resolvers := make([]gql.LSIFUploadsAuditLogsResolver, 0, len(logs))
+	for _, log := range logs {
+		resolvers = append(resolvers, &lsifUploadsAuditLogResolver{log})
+	}
+
+	return &resolvers, nil
+}

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/iface.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/iface.go
@@ -62,6 +62,7 @@ type DBStore interface {
 	LastIndexScanForRepository(ctx context.Context, repositoryID int) (*time.Time, error)
 	RequestLanguageSupport(ctx context.Context, userID int, language string) error
 	LanguagesRequestedBy(ctx context.Context, userID int) ([]string, error)
+	GetAuditLogsForUpload(ctx context.Context, uploadID int) ([]dbstore.UploadLog, error)
 }
 
 type LSIFStore interface {

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/mock_iface_test.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/mock_iface_test.go
@@ -56,6 +56,9 @@ type MockDBStore struct {
 	// function object controlling the behavior of the method
 	// FindClosestDumpsFromGraphFragment.
 	FindClosestDumpsFromGraphFragmentFunc *DBStoreFindClosestDumpsFromGraphFragmentFunc
+	// GetAuditLogsForUploadFunc is an instance of a mock function object
+	// controlling the behavior of the method GetAuditLogsForUpload.
+	GetAuditLogsForUploadFunc *DBStoreGetAuditLogsForUploadFunc
 	// GetConfigurationPoliciesFunc is an instance of a mock function object
 	// controlling the behavior of the method GetConfigurationPolicies.
 	GetConfigurationPoliciesFunc *DBStoreGetConfigurationPoliciesFunc
@@ -185,6 +188,11 @@ func NewMockDBStore() *MockDBStore {
 		},
 		FindClosestDumpsFromGraphFragmentFunc: &DBStoreFindClosestDumpsFromGraphFragmentFunc{
 			defaultHook: func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) (r0 []dbstore.Dump, r1 error) {
+				return
+			},
+		},
+		GetAuditLogsForUploadFunc: &DBStoreGetAuditLogsForUploadFunc{
+			defaultHook: func(context.Context, int) (r0 []dbstore.UploadLog, r1 error) {
 				return
 			},
 		},
@@ -365,6 +373,11 @@ func NewStrictMockDBStore() *MockDBStore {
 				panic("unexpected invocation of MockDBStore.FindClosestDumpsFromGraphFragment")
 			},
 		},
+		GetAuditLogsForUploadFunc: &DBStoreGetAuditLogsForUploadFunc{
+			defaultHook: func(context.Context, int) ([]dbstore.UploadLog, error) {
+				panic("unexpected invocation of MockDBStore.GetAuditLogsForUpload")
+			},
+		},
 		GetConfigurationPoliciesFunc: &DBStoreGetConfigurationPoliciesFunc{
 			defaultHook: func(context.Context, dbstore.GetConfigurationPoliciesOptions) ([]dbstore.ConfigurationPolicy, int, error) {
 				panic("unexpected invocation of MockDBStore.GetConfigurationPolicies")
@@ -523,6 +536,9 @@ func NewMockDBStoreFrom(i DBStore) *MockDBStore {
 		},
 		FindClosestDumpsFromGraphFragmentFunc: &DBStoreFindClosestDumpsFromGraphFragmentFunc{
 			defaultHook: i.FindClosestDumpsFromGraphFragment,
+		},
+		GetAuditLogsForUploadFunc: &DBStoreGetAuditLogsForUploadFunc{
+			defaultHook: i.GetAuditLogsForUpload,
 		},
 		GetConfigurationPoliciesFunc: &DBStoreGetConfigurationPoliciesFunc{
 			defaultHook: i.GetConfigurationPolicies,
@@ -1620,6 +1636,115 @@ func (c DBStoreFindClosestDumpsFromGraphFragmentFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c DBStoreFindClosestDumpsFromGraphFragmentFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
+}
+
+// DBStoreGetAuditLogsForUploadFunc describes the behavior when the
+// GetAuditLogsForUpload method of the parent MockDBStore instance is
+// invoked.
+type DBStoreGetAuditLogsForUploadFunc struct {
+	defaultHook func(context.Context, int) ([]dbstore.UploadLog, error)
+	hooks       []func(context.Context, int) ([]dbstore.UploadLog, error)
+	history     []DBStoreGetAuditLogsForUploadFuncCall
+	mutex       sync.Mutex
+}
+
+// GetAuditLogsForUpload delegates to the next hook function in the queue
+// and stores the parameter and result values of this invocation.
+func (m *MockDBStore) GetAuditLogsForUpload(v0 context.Context, v1 int) ([]dbstore.UploadLog, error) {
+	r0, r1 := m.GetAuditLogsForUploadFunc.nextHook()(v0, v1)
+	m.GetAuditLogsForUploadFunc.appendCall(DBStoreGetAuditLogsForUploadFuncCall{v0, v1, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the
+// GetAuditLogsForUpload method of the parent MockDBStore instance is
+// invoked and the hook queue is empty.
+func (f *DBStoreGetAuditLogsForUploadFunc) SetDefaultHook(hook func(context.Context, int) ([]dbstore.UploadLog, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// GetAuditLogsForUpload method of the parent MockDBStore instance invokes
+// the hook at the front of the queue and discards it. After the queue is
+// empty, the default hook function is invoked for any future action.
+func (f *DBStoreGetAuditLogsForUploadFunc) PushHook(hook func(context.Context, int) ([]dbstore.UploadLog, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *DBStoreGetAuditLogsForUploadFunc) SetDefaultReturn(r0 []dbstore.UploadLog, r1 error) {
+	f.SetDefaultHook(func(context.Context, int) ([]dbstore.UploadLog, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *DBStoreGetAuditLogsForUploadFunc) PushReturn(r0 []dbstore.UploadLog, r1 error) {
+	f.PushHook(func(context.Context, int) ([]dbstore.UploadLog, error) {
+		return r0, r1
+	})
+}
+
+func (f *DBStoreGetAuditLogsForUploadFunc) nextHook() func(context.Context, int) ([]dbstore.UploadLog, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *DBStoreGetAuditLogsForUploadFunc) appendCall(r0 DBStoreGetAuditLogsForUploadFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of DBStoreGetAuditLogsForUploadFuncCall
+// objects describing the invocations of this function.
+func (f *DBStoreGetAuditLogsForUploadFunc) History() []DBStoreGetAuditLogsForUploadFuncCall {
+	f.mutex.Lock()
+	history := make([]DBStoreGetAuditLogsForUploadFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// DBStoreGetAuditLogsForUploadFuncCall is an object that describes an
+// invocation of method GetAuditLogsForUpload on an instance of MockDBStore.
+type DBStoreGetAuditLogsForUploadFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 int
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 []dbstore.UploadLog
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c DBStoreGetAuditLogsForUploadFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c DBStoreGetAuditLogsForUploadFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/mocks/mock_resolver.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/mocks/mock_resolver.go
@@ -20,6 +20,9 @@ import (
 // github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/codeintel/resolvers)
 // used for unit testing.
 type MockResolver struct {
+	// AuditLogsForUploadFunc is an instance of a mock function object
+	// controlling the behavior of the method AuditLogsForUpload.
+	AuditLogsForUploadFunc *ResolverAuditLogsForUploadFunc
 	// CommitGraphFunc is an instance of a mock function object controlling
 	// the behavior of the method CommitGraph.
 	CommitGraphFunc *ResolverCommitGraphFunc
@@ -122,6 +125,11 @@ type MockResolver struct {
 // return zero values for all results, unless overwritten.
 func NewMockResolver() *MockResolver {
 	return &MockResolver{
+		AuditLogsForUploadFunc: &ResolverAuditLogsForUploadFunc{
+			defaultHook: func(context.Context, int) (r0 []dbstore.UploadLog, r1 error) {
+				return
+			},
+		},
 		CommitGraphFunc: &ResolverCommitGraphFunc{
 			defaultHook: func(context.Context, int) (r0 graphqlbackend.CodeIntelligenceCommitGraphResolver, r1 error) {
 				return
@@ -274,6 +282,11 @@ func NewMockResolver() *MockResolver {
 // methods panic on invocation, unless overwritten.
 func NewStrictMockResolver() *MockResolver {
 	return &MockResolver{
+		AuditLogsForUploadFunc: &ResolverAuditLogsForUploadFunc{
+			defaultHook: func(context.Context, int) ([]dbstore.UploadLog, error) {
+				panic("unexpected invocation of MockResolver.AuditLogsForUpload")
+			},
+		},
 		CommitGraphFunc: &ResolverCommitGraphFunc{
 			defaultHook: func(context.Context, int) (graphqlbackend.CodeIntelligenceCommitGraphResolver, error) {
 				panic("unexpected invocation of MockResolver.CommitGraph")
@@ -426,6 +439,9 @@ func NewStrictMockResolver() *MockResolver {
 // methods delegate to the given implementation, unless overwritten.
 func NewMockResolverFrom(i resolvers.Resolver) *MockResolver {
 	return &MockResolver{
+		AuditLogsForUploadFunc: &ResolverAuditLogsForUploadFunc{
+			defaultHook: i.AuditLogsForUpload,
+		},
 		CommitGraphFunc: &ResolverCommitGraphFunc{
 			defaultHook: i.CommitGraph,
 		},
@@ -514,6 +530,114 @@ func NewMockResolverFrom(i resolvers.Resolver) *MockResolver {
 			defaultHook: i.UploadConnectionResolver,
 		},
 	}
+}
+
+// ResolverAuditLogsForUploadFunc describes the behavior when the
+// AuditLogsForUpload method of the parent MockResolver instance is invoked.
+type ResolverAuditLogsForUploadFunc struct {
+	defaultHook func(context.Context, int) ([]dbstore.UploadLog, error)
+	hooks       []func(context.Context, int) ([]dbstore.UploadLog, error)
+	history     []ResolverAuditLogsForUploadFuncCall
+	mutex       sync.Mutex
+}
+
+// AuditLogsForUpload delegates to the next hook function in the queue and
+// stores the parameter and result values of this invocation.
+func (m *MockResolver) AuditLogsForUpload(v0 context.Context, v1 int) ([]dbstore.UploadLog, error) {
+	r0, r1 := m.AuditLogsForUploadFunc.nextHook()(v0, v1)
+	m.AuditLogsForUploadFunc.appendCall(ResolverAuditLogsForUploadFuncCall{v0, v1, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the AuditLogsForUpload
+// method of the parent MockResolver instance is invoked and the hook queue
+// is empty.
+func (f *ResolverAuditLogsForUploadFunc) SetDefaultHook(hook func(context.Context, int) ([]dbstore.UploadLog, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// AuditLogsForUpload method of the parent MockResolver instance invokes the
+// hook at the front of the queue and discards it. After the queue is empty,
+// the default hook function is invoked for any future action.
+func (f *ResolverAuditLogsForUploadFunc) PushHook(hook func(context.Context, int) ([]dbstore.UploadLog, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *ResolverAuditLogsForUploadFunc) SetDefaultReturn(r0 []dbstore.UploadLog, r1 error) {
+	f.SetDefaultHook(func(context.Context, int) ([]dbstore.UploadLog, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *ResolverAuditLogsForUploadFunc) PushReturn(r0 []dbstore.UploadLog, r1 error) {
+	f.PushHook(func(context.Context, int) ([]dbstore.UploadLog, error) {
+		return r0, r1
+	})
+}
+
+func (f *ResolverAuditLogsForUploadFunc) nextHook() func(context.Context, int) ([]dbstore.UploadLog, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *ResolverAuditLogsForUploadFunc) appendCall(r0 ResolverAuditLogsForUploadFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of ResolverAuditLogsForUploadFuncCall objects
+// describing the invocations of this function.
+func (f *ResolverAuditLogsForUploadFunc) History() []ResolverAuditLogsForUploadFuncCall {
+	f.mutex.Lock()
+	history := make([]ResolverAuditLogsForUploadFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// ResolverAuditLogsForUploadFuncCall is an object that describes an
+// invocation of method AuditLogsForUpload on an instance of MockResolver.
+type ResolverAuditLogsForUploadFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 int
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 []dbstore.UploadLog
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c ResolverAuditLogsForUploadFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c ResolverAuditLogsForUploadFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
 }
 
 // ResolverCommitGraphFunc describes the behavior when the CommitGraph

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/resolver.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/resolver.go
@@ -55,6 +55,8 @@ type Resolver interface {
 	SupportedByCtags(ctx context.Context, filepath string, repo api.RepoName) (bool, string, error)
 	RetentionPolicyOverview(ctx context.Context, upload store.Upload, matchesOnly bool, first int, after int64, query string, now time.Time) (matches []RetentionPolicyMatchCandidate, totalCount int, err error)
 
+	AuditLogsForUpload(ctx context.Context, id int) ([]store.UploadLog, error)
+
 	UploadConnectionResolver(opts store.GetUploadsOptions) *UploadsResolver
 	IndexConnectionResolver(opts store.GetIndexesOptions) *IndexesResolver
 	QueryResolver(ctx context.Context, args *gql.GitBlobLSIFDataArgs) (QueryResolver, error)

--- a/go.mod
+++ b/go.mod
@@ -308,7 +308,7 @@ require (
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgproto3/v2 v2.2.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20200714003250-2b9c44734f2b // indirect
-	github.com/jackc/pgtype v1.11.1-0.20220425133820-53266f029fbb // indirect
+	github.com/jackc/pgtype v1.11.1-0.20220425133820-53266f029fbb
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/jonboulle/clockwork v0.2.2 // indirect

--- a/internal/codeintel/stores/dbstore/audit_logs.go
+++ b/internal/codeintel/stores/dbstore/audit_logs.go
@@ -1,0 +1,96 @@
+package dbstore
+
+import (
+	"context"
+	"time"
+
+	"github.com/jackc/pgtype"
+	"github.com/keegancsmith/sqlf"
+
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
+)
+
+type UploadLog struct {
+	LogTimestamp      time.Time
+	RecordDeletedAt   *time.Time
+	UploadID          int
+	Commit            string
+	Root              string
+	RepositoryID      int
+	UploadedAt        time.Time
+	Indexer           string
+	IndexerVersion    *string
+	UploadSize        *int
+	AssociatedIndexID *int
+	TransitionColumns []map[string]*string
+	Reason            *string
+	Operation         string
+}
+
+func scanUploadAuditLog(s dbutil.Scanner) (log UploadLog, _ error) {
+	hstores := pgtype.HstoreArray{}
+	err := s.Scan(
+		&log.LogTimestamp,
+		&log.RecordDeletedAt,
+		&log.UploadID,
+		&log.Commit,
+		&log.Root,
+		&log.RepositoryID,
+		&log.UploadedAt,
+		&log.Indexer,
+		&log.IndexerVersion,
+		&log.UploadSize,
+		&log.AssociatedIndexID,
+		&hstores,
+		&log.Reason,
+		&log.Operation,
+	)
+
+	for _, hstore := range hstores.Elements {
+		m := make(map[string]*string)
+		if err := hstore.AssignTo(&m); err != nil {
+			return log, err
+		}
+		log.TransitionColumns = append(log.TransitionColumns, m)
+	}
+
+	return log, err
+}
+
+var scanUploadAuditLogs = basestore.NewSliceScanner(scanUploadAuditLog)
+
+// GetAuditLogsForUpload returns all the audit logs for the given upload ID in order of entry
+// from oldest to newest, according to the auto-incremented internal sequence field.
+func (s *Store) GetAuditLogsForUpload(ctx context.Context, uploadID int) (_ []UploadLog, err error) {
+	authzConds, err := database.AuthzQueryConds(ctx, database.NewDB(s.Store.Handle().DB()))
+	if err != nil {
+		return nil, err
+	}
+
+	return scanUploadAuditLogs(s.Store.Query(ctx, sqlf.Sprintf(getAuditLogsForUploadQuery, uploadID, authzConds)))
+}
+
+const getAuditLogsForUploadQuery = `
+-- source: internal/codeintel/stores/dbstore/audit_logs.go:GetAuditLogsForUpload
+SELECT
+	u.log_timestamp,
+	u.record_deleted_at,
+	u.upload_id,
+	u.commit,
+	u.root,
+	u.repository_id,
+	u.uploaded_at,
+	u.indexer,
+	u.indexer_version,
+	u.upload_size,
+	u.associated_index_id,
+	u.transition_columns,
+	u.reason,
+	u.operation
+FROM lsif_uploads_audit_logs u
+JOIN repo ON repo.id = u.repository_id
+WHERE u.upload_id = %s AND %s
+ORDER BY u.sequence
+`

--- a/internal/codeintel/stores/dbstore/audit_logs_test.go
+++ b/internal/codeintel/stores/dbstore/audit_logs_test.go
@@ -1,0 +1,40 @@
+package dbstore
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
+)
+
+func TestUploadAuditLogs(t *testing.T) {
+	db := dbtest.NewDB(t)
+	store := testStore(db)
+
+	insertUploads(t, db, Upload{ID: 1})
+	updateUploads(t, db, Upload{ID: 1, State: "deleting"})
+
+	logs, err := store.GetAuditLogsForUpload(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("unexpected error fetching audit logs: %s", err)
+	}
+	if len(logs) != 2 {
+		t.Fatalf("unexpected number of logs. want=%v have=%v", 2, len(logs))
+	}
+
+	stateTransition := transitionForColumn(t, "state", logs[1].TransitionColumns)
+	if *stateTransition["new"] != "deleting" {
+		t.Fatalf("unexpected state column transition values. want=%v got=%v", "deleting", *stateTransition["new"])
+	}
+}
+
+func transitionForColumn(t *testing.T, key string, transitions []map[string]*string) map[string]*string {
+	for _, transition := range transitions {
+		if val := transition["column"]; val != nil && *val == key {
+			return transition
+		}
+	}
+
+	t.Fatalf("no transition for key found. key=%s, transitions=%v", key, transitions)
+	return nil
+}

--- a/internal/codeintel/stores/dbstore/helpers_test.go
+++ b/internal/codeintel/stores/dbstore/helpers_test.go
@@ -111,6 +111,55 @@ func insertUploads(t testing.TB, db *sql.DB, uploads ...Upload) {
 	}
 }
 
+func updateUploads(t testing.TB, db *sql.DB, uploads ...Upload) {
+	for _, upload := range uploads {
+		query := sqlf.Sprintf(`
+			UPDATE lsif_uploads
+			SET
+				commit = COALESCE(NULLIF(%s, ''), commit),
+				root = COALESCE(NULLIF(%s, ''), root),
+				uploaded_at = COALESCE(NULLIF(%s, '0001-01-01 00:00:00+00'::timestamptz), uploaded_at),
+				state = COALESCE(NULLIF(%s, ''), state),
+				failure_message  = COALESCE(%s, failure_message),
+				started_at = COALESCE(%s, started_at),
+				finished_at = COALESCE(%s, finished_at),
+				process_after = COALESCE(%s, process_after),
+				num_resets = COALESCE(NULLIF(%s, 0), num_resets),
+				num_failures = COALESCE(NULLIF(%s, 0), num_failures),
+				repository_id = COALESCE(NULLIF(%s, 0), repository_id),
+				indexer = COALESCE(NULLIF(%s, ''), indexer),
+				indexer_version = COALESCE(NULLIF(%s, ''), indexer_version),
+				num_parts = COALESCE(NULLIF(%s, 0), num_parts),
+				uploaded_parts = COALESCE(NULLIF(%s, '{}'::integer[]), uploaded_parts),
+				upload_size = COALESCE(%s, upload_size),
+				associated_index_id = COALESCE(%s, associated_index_id)
+			WHERE id = %s
+		`,
+			upload.Commit,
+			upload.Root,
+			upload.UploadedAt,
+			upload.State,
+			upload.FailureMessage,
+			upload.StartedAt,
+			upload.FinishedAt,
+			upload.ProcessAfter,
+			upload.NumResets,
+			upload.NumFailures,
+			upload.RepositoryID,
+			upload.Indexer,
+			upload.IndexerVersion,
+			upload.NumParts,
+			pq.Array(upload.UploadedParts),
+			upload.UploadSize,
+			upload.AssociatedIndexID,
+			upload.ID)
+
+		if _, err := db.ExecContext(context.Background(), query.Query(sqlf.PostgresBindVar), query.Args()...); err != nil {
+			t.Fatalf("unexpected error while inserting upload: %s", err)
+		}
+	}
+}
+
 // insertIndexes populates the lsif_indexes table with the given index models.
 func insertIndexes(t testing.TB, db *sql.DB, indexes ...Index) {
 	for _, index := range indexes {

--- a/internal/codeintel/stores/dbstore/uploads.go
+++ b/internal/codeintel/stores/dbstore/uploads.go
@@ -25,27 +25,27 @@ import (
 // Upload is a subset of the lsif_uploads table and stores both processed and unprocessed
 // records.
 type Upload struct {
-	ID                int        `json:"id"`
-	Commit            string     `json:"commit"`
-	Root              string     `json:"root"`
-	VisibleAtTip      bool       `json:"visibleAtTip"`
-	UploadedAt        time.Time  `json:"uploadedAt"`
-	State             string     `json:"state"`
-	FailureMessage    *string    `json:"failureMessage"`
-	StartedAt         *time.Time `json:"startedAt"`
-	FinishedAt        *time.Time `json:"finishedAt"`
-	ProcessAfter      *time.Time `json:"processAfter"`
-	NumResets         int        `json:"numResets"`
-	NumFailures       int        `json:"numFailures"`
-	RepositoryID      int        `json:"repositoryId"`
-	RepositoryName    string     `json:"repositoryName"`
-	Indexer           string     `json:"indexer"`
-	IndexerVersion    string     `json:"indexer_version"`
-	NumParts          int        `json:"numParts"`
-	UploadedParts     []int      `json:"uploadedParts"`
-	UploadSize        *int64     `json:"uploadSize"`
-	Rank              *int       `json:"placeInQueue"`
-	AssociatedIndexID *int       `json:"associatedIndex"`
+	ID                int
+	Commit            string
+	Root              string
+	VisibleAtTip      bool
+	UploadedAt        time.Time
+	State             string
+	FailureMessage    *string
+	StartedAt         *time.Time
+	FinishedAt        *time.Time
+	ProcessAfter      *time.Time
+	NumResets         int
+	NumFailures       int
+	RepositoryID      int
+	RepositoryName    string
+	Indexer           string
+	IndexerVersion    string
+	NumParts          int
+	UploadedParts     []int
+	UploadSize        *int64
+	Rank              *int
+	AssociatedIndexID *int
 }
 
 func (u Upload) RecordID() int {


### PR DESCRIPTION
This PR exposes the Audit Log data from [RFC 625](https://docs.google.com/document/d/1yRPQNiLLQpXFARTd_qg4Yb9w-DrIHdyiCSKzyh1J-fU/) in the LSIF uploads page. Currently this is only visible for non-deleted  uploads, as deleted uploads' page is currently not  viewable (for now).

Link to storybook (please expand all) https://5f0f381c0e50750022dc6bf7-qwobctehux.chromatic.com/?path=/story/web-codeintel-uploads-codeinteluploadpage--with-audit-logs

## Screenshot

<details>
<summary>Expand</summary>

![image](https://user-images.githubusercontent.com/18282288/171864114-59bc7641-346d-4dbd-beb8-b908e0293a9c.png)

</details>

## Test plan

Storybooks for the new UI have been created, as well as unit tests for database access of the audit logs.
