### PR TITLE
insights: retry queries that encounter `shard-timeout` events 

### DIFF
--- a/enterprise/internal/insights/query/streaming/decoder.go
+++ b/enterprise/internal/insights/query/streaming/decoder.go
@@ -55,7 +55,14 @@ func TabulationDecoder() (streamhttp.FrontendStreamDecoder, *TabulationResult) {
 			// Skipped elements are built progressively for a Progress update until it is Done, so
 			// we want to register its contents only once it is done.
 			for _, skipped := range progress.Skipped {
-				tr.SkippedReasons = append(tr.SkippedReasons, fmt.Sprintf("%s: %s", skipped.Reason, skipped.Message))
+				// ShardTimeout is a specific skipped event that we want to retry on. Currently
+				// we only retry on Alert events so this is why we add it there. This behaviour will
+				// be uniformised eventually.
+				if skipped.Reason == streamapi.ShardTimeout {
+					tr.Alerts = append(tr.Alerts, fmt.Sprintf("%s: %s", skipped.Reason, skipped.Message))
+				} else {
+					tr.SkippedReasons = append(tr.SkippedReasons, fmt.Sprintf("%s: %s", skipped.Reason, skipped.Message))
+				}
 			}
 		},
 		OnMatches: func(matches []streamhttp.EventMatch) {

--- a/enterprise/internal/insights/query/streaming_query_executor.go
+++ b/enterprise/internal/insights/query/streaming_query_executor.go
@@ -85,6 +85,9 @@ func (c *StreamingQueryExecutor) Execute(ctx context.Context, query string, seri
 			}
 
 			tr := *tabulationResult
+			if len(tr.SkippedReasons) > 0 {
+				log15.Error("insights query issue", "reasons", tr.SkippedReasons, "query", query)
+			}
 			if len(tr.Errors) > 0 {
 				return nil, errors.Errorf("streaming search: errors: %v", tr.Errors)
 			}


### PR DESCRIPTION
closes #36226 

also adds logging for skipped reasons in the JIT path as we didn't have it there

## Test plan
Artificially added a shard timeout event in [search's progress handler](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/internal/search/streaming/api/progress.go?L20&utm_source=VSCode-2.2.2) (couldn’t figure out how to hit it locally).
```
	skipped := []Skipped{
		{
			Reason:  ShardTimeout,
			Title:   "shard-timeout-leo",
			Message: "i'm fake!",
		},
	}
```

Observed it from search:
<img width="780" alt="Screenshot 2022-05-31 at 14 27 59" src="https://user-images.githubusercontent.com/29406849/171234169-20e51544-2f25-4758-a77d-3157de6cc60b.png">

Observed it from JIT insight:
<img width="431" alt="Screenshot 2022-05-31 at 14 32 40" src="https://user-images.githubusercontent.com/29406849/171234266-44f524a6-0ca6-4b8d-be1d-c2ad3e6eb7cc.png">

And then created a backend insight, saw the error in the `insights_query_runner_job` queue, which eventually succeeded after retrying once the artificial event was removed and the retry period had passed.
<img width="508" alt="Screenshot 2022-05-31 at 15 35 40" src="https://user-images.githubusercontent.com/29406849/171234389-e8330a22-6ba7-4806-814d-37e613594e2d.png">

Once this is landed there will be a post-merge test on k8s.sgdev to see if backfill works better