### PR TITLE
checkbox misalignment fix

### DIFF
--- a/client/web/src/user/settings/repositories/RepositoryNode.tsx
+++ b/client/web/src/user/settings/repositories/RepositoryNode.tsx
@@ -190,6 +190,7 @@ export const CheckboxRepositoryNode: React.FunctionComponent<React.PropsWithChil
                         aria-label={`select ${name} repository`}
                         onChange={onClick}
                         checked={checked}
+                        label={<small></small>}
                     />
                     <StatusIcon mirrorInfo={mirrorInfo} />
                     <CodeHostIcon hostType={serviceType} />

--- a/client/web/src/user/settings/repositories/RepositoryNode.tsx
+++ b/client/web/src/user/settings/repositories/RepositoryNode.tsx
@@ -190,16 +190,17 @@ export const CheckboxRepositoryNode: React.FunctionComponent<React.PropsWithChil
                         aria-label={`select ${name} repository`}
                         onChange={onClick}
                         checked={checked}
-                        label={<small></small>}
-                    />
-                    <StatusIcon mirrorInfo={mirrorInfo} />
-                    <CodeHostIcon hostType={serviceType} />
-                    <RepoLink
-                        className="text-muted"
-                        repoClassName="text-body"
-                        repoName={name}
-                        to={null}
-                        onClick={handleOnClick}
+                        label={<>
+                            <StatusIcon mirrorInfo={mirrorInfo} />
+                            <CodeHostIcon hostType={serviceType} />
+                            <RepoLink
+                                className="text-muted"
+                                repoClassName="text-body"
+                                repoName={name}
+                                to={null}
+                                onClick={handleOnClick}
+                            />
+                        </>}
                     />
                 </div>
                 <div>

--- a/client/web/src/user/settings/repositories/RepositoryNode.tsx
+++ b/client/web/src/user/settings/repositories/RepositoryNode.tsx
@@ -190,17 +190,19 @@ export const CheckboxRepositoryNode: React.FunctionComponent<React.PropsWithChil
                         aria-label={`select ${name} repository`}
                         onChange={onClick}
                         checked={checked}
-                        label={<>
-                            <StatusIcon mirrorInfo={mirrorInfo} />
-                            <CodeHostIcon hostType={serviceType} />
-                            <RepoLink
-                                className="text-muted"
-                                repoClassName="text-body"
-                                repoName={name}
-                                to={null}
-                                onClick={handleOnClick}
-                            />
-                        </>}
+                        label={
+                            <>
+                                <StatusIcon mirrorInfo={mirrorInfo} />
+                                <CodeHostIcon hostType={serviceType} />
+                                <RepoLink
+                                    className="text-muted"
+                                    repoClassName="text-body"
+                                    repoName={name}
+                                    to={null}
+                                    onClick={handleOnClick}
+                                />
+                            </>
+                        }
                     />
                 </div>
                 <div>


### PR DESCRIPTION

## Test plan
Regarding issue #35687, "Misaligned checkboxes in "Manage Repositories" page of user profile". Upon inspecting the page, the div the checkbox is in had a height of 0. Giving it an empty label was able to assign a proper height, and forced the div to have a height of 20. Currently a work around, not sure if it's the best solution.
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-lm-checkboxfix.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-xsieatlqbx.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
