### PR TITLE
Add hb link to trivy annotation

### DIFF
--- a/dev/ci/trivy/trivy-scan-high-critical.sh
+++ b/dev/ci/trivy/trivy-scan-high-critical.sh
@@ -72,6 +72,7 @@ case "${exitCode:-"0"}" in
     ;;
   "${VULNERABILITY_EXIT_CODE}")
     # we found vulnerabilities - upload the annotation
+    echo "Trivy found issues. More information [here](https://handbook.sourcegraph.com/departments/product-engineering/engineering/cloud/security/trivy/#for-sourcegraph-engineers)" > ./annotations/trivy-scan-high-critical.md
     create_annotation "${ARTIFACT_FILE}" "${IMAGE}"
     exit "${VULNERABILITY_EXIT_CODE}"
     ;;


### PR DESCRIPTION
Minor update linking our docs to the trivy annotation. The idea is that we'll have the string `Trivy found issues. More information here` above the CVE list:
<img width="1476" alt="image" src="https://user-images.githubusercontent.com/11207474/171276188-c2bb1b89-8090-4ff5-8ed3-07d76734ad0d.png">

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
Check that the new annotation works.