### PR TITLE
web: revert DynamicallyImportedMonacoSettingsEditor change in #36033

### DIFF
--- a/client/web/src/settings/DynamicallyImportedMonacoSettingsEditor.tsx
+++ b/client/web/src/settings/DynamicallyImportedMonacoSettingsEditor.tsx
@@ -192,7 +192,7 @@ export class DynamicallyImportedMonacoSettingsEditor<T extends object = {}> exte
 
     private monacoRef = (monacoValue: typeof _monaco | null): void => {
         this.monaco = monacoValue
-        if (this.monaco && MonacoSettingsEditor._result) {
+        if (this.monaco && MonacoSettingsEditor) {
             this.subscriptions.add(
                 disposableToFunc(
                     this.monaco.editor.onDidCreateEditor(editor => {

--- a/client/web/src/settings/DynamicallyImportedMonacoSettingsEditor.tsx
+++ b/client/web/src/settings/DynamicallyImportedMonacoSettingsEditor.tsx
@@ -192,7 +192,7 @@ export class DynamicallyImportedMonacoSettingsEditor<T extends object = {}> exte
 
     private monacoRef = (monacoValue: typeof _monaco | null): void => {
         this.monaco = monacoValue
-        if (this.monaco && MonacoSettingsEditor) {
+        if (this.monaco) {
             this.subscriptions.add(
                 disposableToFunc(
                     this.monaco.editor.onDidCreateEditor(editor => {


### PR DESCRIPTION
This change broke the detection of the editor being ready, which in turn broke quick actions in the settings toolbar.

A clean revert doesn't _quite_ work, since TypeScript is now smart enough to figure out that `MonacoSettingsEditor` is always defined. Looking at the (only) caller of `monacoRef`, I think we're safe to just remove that check completely and rely on the value of `this.monaco`. It doesn't break anything in practice.

Fixes #36329.

## Test plan

Manual testing on the code host editor page.

## App preview:

- [Web](https://sg-web-aharvey-revert-monaco-settings.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-mjseogimji.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

