### PR TITLE
web: fix duplicate stories

### DIFF
--- a/client/web/src/components/ActivationDropdown/ActivationDropdown.story.tsx
+++ b/client/web/src/components/ActivationDropdown/ActivationDropdown.story.tsx
@@ -56,7 +56,7 @@ const decorator: DecoratorFn = story => (
 )
 
 const config: Meta = {
-    title: 'shared/ActivationDropdown',
+    title: 'web/ActivationDropdown',
     decorators: [decorator],
 }
 

--- a/client/web/src/enterprise/insights/pages/insights/insight/components/standalone-404-insight/Standalone404Insight.story.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/insight/components/standalone-404-insight/Standalone404Insight.story.tsx
@@ -8,7 +8,7 @@ import { Standalone404Insight } from './Standalone404Insight'
 import webStyles from '../../../../../../../SourcegraphWebApp.scss'
 
 const config: Meta = {
-    title: '/web/insights/StandaloneInsight',
+    title: 'web/insights/StandaloneInsight',
     component: Popover,
     decorators: [story => <BrandedStory styles={webStyles}>{() => story()}</BrandedStory>],
 }

--- a/client/web/src/enterprise/insights/pages/landing/dot-com-get-started/CodeInsightsDotComGetStarted.story.tsx
+++ b/client/web/src/enterprise/insights/pages/landing/dot-com-get-started/CodeInsightsDotComGetStarted.story.tsx
@@ -7,7 +7,7 @@ import { WebStory } from '../../../../../components/WebStory'
 import { CodeInsightsDotComGetStarted } from './CodeInsightsDotComGetStarted'
 
 export default {
-    title: 'insights/dot-com-landing/CodeInsightsDotComGetStarted',
+    title: 'web/insights/dot-com-landing/CodeInsightsDotComGetStarted',
     decorators: [story => <WebStory>{() => story()}</WebStory>],
 } as Meta
 

--- a/client/web/src/enterprise/insights/pages/landing/dot-com-get-started/components/code-insights-examples-picker/code-insights-examples-slider/CodeInsightsExamplesSlider.story.tsx
+++ b/client/web/src/enterprise/insights/pages/landing/dot-com-get-started/components/code-insights-examples-picker/code-insights-examples-slider/CodeInsightsExamplesSlider.story.tsx
@@ -7,7 +7,7 @@ import { WebStory } from '../../../../../../../../components/WebStory'
 import { CodeInsightsExamplesSlider } from './CodeInsightsExamplesSlider'
 
 export default {
-    title: 'insights/dot-com-landing/CodeInsightsExampleSlider',
+    title: 'web/insights/dot-com-landing/CodeInsightsExampleSlider',
     decorators: [story => <WebStory>{() => story()}</WebStory>],
 } as Meta
 


### PR DESCRIPTION
## Context

Running `yarn storybook` on `main` shows a bunch of errors in the console about duplicate story keys and two identical `web` story groups. Also, the ordering of story groups is broken — wildcard is not the first item on the list despite our configuration.

## Test plan

- Run `yarn storybook` and ensure that `wildcard` is the first story group in the sidebar.
- Run `STORIES_GLOB=client/web/src/enterprise/insights/**/*.story.tsx yarn workspace @sourcegraph/storybook run start` and ensure that there's only one `web` stories group.

| Before | After |
| -- | -- |
| <img width="287" alt="Screen Shot 2022-06-01 at 10 20 32" src="https://user-images.githubusercontent.com/3846380/171315124-c79c1f10-3092-4afe-94fc-9c307f094510.png"> | <img width="287" alt="Screen Shot 2022-06-01 at 10 20 56" src="https://user-images.githubusercontent.com/3846380/171315144-60c7db50-2b8d-4153-b1ac-7ecff3588352.png"> |

## App preview:

- [Web](https://sg-web-vb-fix-duplicate-stories.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-hgmogorpxd.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

