### PR TITLE
dev/sg: add 1pass to sg setup

### DIFF
--- a/dev/sg/sg_setup_mac.go
+++ b/dev/sg/sg_setup_mac.go
@@ -289,6 +289,15 @@ YOU NEED TO RESTART 'sg setup' AFTER RUNNING THIS COMMAND!`,
 		autoFixing: true,
 		dependencies: []*dependency{
 			dependencyGcloud,
+			{
+				name:          "1password",
+				onlyTeammates: true,
+				instructionsCommands: `
+brew install --cask 1password/tap/1password-cli
+eval $(op account add --address team-sourcegraph.1password.com --signin)
+`,
+				check: check1password,
+			},
 		},
 	},
 }

--- a/dev/sg/sg_setup_shared.go
+++ b/dev/sg/sg_setup_shared.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"strings"
 
+	"github.com/sourcegraph/run"
+
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/check"
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/usershell"
 	"github.com/sourcegraph/sourcegraph/dev/sg/root"
@@ -104,4 +106,22 @@ var dependencyGcloud = &dependency{
 	}),
 	onlyTeammates:       true,
 	instructionsComment: "NOTE: You can ignore this if you're not a Sourcegraph teammate.",
+}
+
+func check1password(ctx context.Context) error {
+	accounts, err := run.Cmd(ctx, "op account list").Run().Lines()
+	if err != nil {
+		return err
+	}
+	var found bool
+	for _, account := range accounts {
+		if strings.Contains(account, "team-sourcegraph.1password.com") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		return errors.New("No sourcegraph account detected")
+	}
+	return nil
 }

--- a/dev/sg/sg_setup_ubuntu.go
+++ b/dev/sg/sg_setup_ubuntu.go
@@ -294,6 +294,22 @@ YOU NEED TO RESTART 'sg setup' AFTER RUNNING THIS COMMAND!`,
 		autoFixing: true,
 		dependencies: []*dependency{
 			dependencyGcloud,
+			{
+				name:          "1password",
+				onlyTeammates: true,
+				// Convoluted directions from https://developer.1password.com/docs/cli/get-started/#install
+				instructionsCommands: `
+curl -sS https://downloads.1password.com/linux/keys/1password.asc | sudo gpg --dearmor --output /usr/share/keyrings/1password-archive-keyring.gpg
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/1password-archive-keyring.gpg] https://downloads.1password.com/linux/debian/$(dpkg --print-architecture) stable main" | sudo tee /etc/apt/sources.list.d/1password.list
+sudo mkdir -p /etc/debsig/policies/AC2D62742012EA22/
+curl -sS https://downloads.1password.com/linux/debian/debsig/1password.pol | sudo tee /etc/debsig/policies/AC2D62742012EA22/1password.pol
+sudo mkdir -p /usr/share/debsig/keyrings/AC2D62742012EA22
+curl -sS https://downloads.1password.com/linux/keys/1password.asc | sudo gpg --dearmor --output /usr/share/debsig/keyrings/AC2D62742012EA22/debsig.gpg
+sudo apt update && sudo apt install 1password-cli
+eval $(op account add --address team-sourcegraph.1password.com --signin)
+`,
+				check: check1password,
+			},
 		},
 	},
 }


### PR DESCRIPTION
Installation follows the steps in https://developer.1password.com/docs/cli/get-started/#install , then logs in to https://team-sourcegraph.1password.com/

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Only tested the MacOS path, the linux installation looks scary.

<img width="504" alt="image" src="https://user-images.githubusercontent.com/23356519/171329544-8655d183-1656-4aaf-9cd7-ffcfaaf09fb6.png">
