### PR TITLE
dev/sg: add 1pass secret provider, use 1pass for OkayHQ token

### DIFF
--- a/dev/sg/internal/secrets/secret.go
+++ b/dev/sg/internal/secrets/secret.go
@@ -5,14 +5,38 @@ import (
 	"time"
 )
 
+type ExternalProvider string
+
+const (
+	// ExternalProviderGCloud fetches a secret from gcloud, where:
+	//
+	// - Project: gcloud project
+	// - Name: secret name
+	// - Field: unused
+	ExternalProviderGCloud = "gcloud"
+	// ExternalProvider1Pass fetches a secret from 1password, where:
+	//
+	// - Project: 1password vault
+	// - Name: <itemName> | <itemID> | <shareLink>
+	// - Field: field in item
+	ExternalProvider1Pass = "1pass"
+)
+
 type ExternalSecret struct {
-	Provider string `yaml:"provider"`
-	Project  string `yaml:"project"`
-	Name     string `yaml:"name"`
+	Provider ExternalProvider `yaml:"provider"`
+
+	// For details on how each field is used, see the relevant ExternalProvider docstring.
+	Project string `yaml:"project"`
+	Name    string `yaml:"name"`
+	Field   string `yaml:"field,omitempty"`
 }
 
 func (s *ExternalSecret) id() string {
-	return fmt.Sprintf("%s/%s/%s", s.Provider, s.Project, s.Name)
+	id := fmt.Sprintf("%s/%s/%s", s.Provider, s.Project, s.Name)
+	if s.Field != "" {
+		id += fmt.Sprintf("/%s", s.Field)
+	}
+	return id
 }
 
 // externalSecretValue is the stored representation of an external secret's value

--- a/dev/sg/internal/secrets/store.go
+++ b/dev/sg/internal/secrets/store.go
@@ -152,7 +152,14 @@ func (s *Store) GetExternal(ctx context.Context, secret ExternalSecret) (string,
 	}
 
 	if err != nil {
-		return "", errors.Wrapf(err, "%s: failed to access secret %q from %q", secret.Provider, secret.Name, secret.Project)
+		errMessaage := fmt.Sprintf("%s: failed to access secret %q from %q",
+			secret.Provider, secret.Name, secret.Project)
+		// Some secret providers use their respective CLI, if not found the user might not
+		// have run 'sg setup' to set up the relevant tool.
+		if strings.Contains(err.Error(), "command not found") {
+			errMessaage += "- you may need to run 'sg setup' again"
+		}
+		return "", errors.Wrap(err, errMessaage)
 	}
 
 	value.Fetched = time.Now()

--- a/dev/sg/internal/secrets/store.go
+++ b/dev/sg/internal/secrets/store.go
@@ -13,6 +13,8 @@ import (
 	secretmanager "cloud.google.com/go/secretmanager/apiv1"
 	secretmanagerpb "google.golang.org/genproto/googleapis/cloud/secretmanager/v1"
 
+	"github.com/sourcegraph/run"
+
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
@@ -122,24 +124,39 @@ func (s *Store) GetExternal(ctx context.Context, secret ExternalSecret) (string,
 		return value.Value, nil
 	}
 
-	if secret.Provider != "gcloud" {
+	// Get secret from provider
+	var err error
+	switch secret.Provider {
+
+	case ExternalProviderGCloud:
+		client, err := s.getSecretmanagerClient(ctx)
+		if err != nil {
+			return "", err
+		}
+		var result *secretmanagerpb.AccessSecretVersionResponse
+		result, err = client.AccessSecretVersion(ctx, &secretmanagerpb.AccessSecretVersionRequest{
+			Name: fmt.Sprintf("projects/%s/secrets/%s/versions/latest", secret.Project, secret.Name),
+		})
+		if err == nil {
+			value.Value = string(result.Payload.Data)
+		}
+
+	case ExternalProvider1Pass:
+		value.Value, err = run.Cmd(ctx, "op item get", run.Arg(secret.Name),
+			"--vault", run.Arg(secret.Project),
+			"--field", run.Arg(secret.Field)).
+			Run().String()
+
+	default:
 		return "", errors.Newf("Unknown secrets provider %q", secret.Provider)
 	}
 
-	client, err := s.getSecretmanagerClient(ctx)
 	if err != nil {
-		return "", err
-	}
-	result, err := client.AccessSecretVersion(ctx, &secretmanagerpb.AccessSecretVersionRequest{
-		Name: fmt.Sprintf("projects/%s/secrets/%s/versions/latest", secret.Project, secret.Name),
-	})
-	if err != nil {
-		return "", errors.Wrapf(err, "failed to access secret %q from %q", secret.Name, secret.Project)
+		return "", errors.Wrapf(err, "%s: failed to access secret %q from %q", secret.Provider, secret.Name, secret.Project)
 	}
 
 	// cache value, but don't save - TBD if we want to persist these secrets
 	value.Fetched = time.Now()
-	value.Value = string(result.Payload.Data)
 	s.Put(secret.id(), &value)
 
 	return value.Value, nil

--- a/dev/sg/internal/secrets/store.go
+++ b/dev/sg/internal/secrets/store.go
@@ -155,7 +155,6 @@ func (s *Store) GetExternal(ctx context.Context, secret ExternalSecret) (string,
 		return "", errors.Wrapf(err, "%s: failed to access secret %q from %q", secret.Provider, secret.Name, secret.Project)
 	}
 
-	// cache value, but don't save - TBD if we want to persist these secrets
 	value.Fetched = time.Now()
 	s.Put(secret.id(), &value)
 

--- a/dev/sg/internal/secrets/store.go
+++ b/dev/sg/internal/secrets/store.go
@@ -142,9 +142,9 @@ func (s *Store) GetExternal(ctx context.Context, secret ExternalSecret) (string,
 		}
 
 	case ExternalProvider1Pass:
-		value.Value, err = run.Cmd(ctx, "op item get", run.Arg(secret.Name),
-			"--vault", run.Arg(secret.Project),
-			"--field", run.Arg(secret.Field)).
+		value.Value, err = run.Cmd(ctx, "op read",
+			run.Arg(fmt.Sprintf("op://%s/%s/%s", secret.Project, secret.Name, secret.Field)),
+			`--account="team-sourcegraph.1password.com"`).
 			Run().String()
 
 	default:

--- a/dev/sg/sg_analytics.go
+++ b/dev/sg/sg_analytics.go
@@ -11,6 +11,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/analytics"
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/secrets"
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/std"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 var analyticsCommand = &cli.Command{
@@ -22,7 +23,7 @@ var analyticsCommand = &cli.Command{
 			Name:        "submit",
 			ArgsUsage:   "[github username]",
 			Usage:       "Make sg better by submitting all analytics stored locally!",
-			Description: "Uses OKAYHQ_TOKEN, or fetches a token from gcloud.",
+			Description: "Uses OKAYHQ_TOKEN, or fetches a token from gcloud or 1password.",
 			Action: func(cmd *cli.Context) error {
 				if cmd.Args().Len() != 1 {
 					return cli.ShowSubcommandHelp(cmd)
@@ -34,13 +35,36 @@ var analyticsCommand = &cli.Command{
 					if err != nil {
 						return err
 					}
-					okayToken, err = store.GetExternal(cmd.Context, secrets.ExternalSecret{
-						Provider: "gcloud",
-						Project:  "sourcegraph-ci",
-						Name:     "CI_OKAYHQ_TOKEN",
-					})
-					if err != nil {
-						return err
+
+					var errs error
+					for _, secret := range []secrets.ExternalSecret{
+						{
+							Provider: secrets.ExternalProvider1Pass,
+							Project:  "Shared",
+							Name:     "ttdgfcufz3jggx3d57g6rwodwi",
+							Field:    "credential",
+						},
+						{
+							Provider: secrets.ExternalProviderGCloud,
+							Project:  "sourcegraph-ci",
+							Name:     "CI_OKAYHQ_TOKEN",
+						},
+					} {
+						okayToken, err = store.GetExternal(cmd.Context, secret)
+						if err != nil {
+							errs = errors.Append(errs, err)
+							continue // try the next provider
+						}
+						if okayToken != "" {
+							std.Out.Writef("Got OkayHQ token from %s!", secret.Provider)
+							break // done!
+						}
+					}
+
+					// If we've tried all providers and still don't have the token, we
+					// return the error.
+					if okayToken == "" {
+						return errors.Wrap(errs, "failed to get OkayHQ token")
 					}
 				}
 

--- a/doc/dev/background-information/sg/reference.md
+++ b/doc/dev/background-information/sg/reference.md
@@ -815,7 +815,7 @@ Manage analytics collected by sg.
 
 Make sg better by submitting all analytics stored locally!.
 
-Uses OKAYHQ_TOKEN, or fetches a token from gcloud.
+Uses OKAYHQ_TOKEN, or fetches a token from gcloud or 1password.
 
 Arguments: `[github username]`
 


### PR DESCRIPTION
It seems not everyone has access to gcloud, so we check both 1pass and gcloud for OkayHQ token. This also lays the
groundwork for future components to also leverage 1password for shared credentials.

This also means that `sg.config.yaml` can use `1pass` secrets now 😁 

Closes https://github.com/sourcegraph/sourcegraph/issues/33846

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

<img width="921" alt="image" src="https://user-images.githubusercontent.com/23356519/171329916-05f8c4b6-a0cf-4812-a1d0-1723801bb9ff.png">
