### PR TITLE
site_config: update editor content after loading from backend

### DIFF
--- a/client/web/src/settings/DynamicallyImportedMonacoSettingsEditor.tsx
+++ b/client/web/src/settings/DynamicallyImportedMonacoSettingsEditor.tsx
@@ -180,6 +180,10 @@ export class DynamicallyImportedMonacoSettingsEditor<T extends object = {}> exte
         })
     }
 
+    public updateContents = (contents: string): void => {
+        this.setState({ value: contents })
+    }
+
     private discard = (): void => {
         if (
             this.state.value === undefined ||

--- a/client/web/src/site-admin/SiteAdminConfigurationPage.tsx
+++ b/client/web/src/site-admin/SiteAdminConfigurationPage.tsx
@@ -230,17 +230,21 @@ export class SiteAdminConfigurationPage extends React.Component<Props, State> {
     private siteReloads = new Subject<void>()
     private subscriptions = new Subscription()
 
+    private editor = React.createRef<DynamicallyImportedMonacoSettingsEditor>()
+
     public componentDidMount(): void {
         eventLogger.logViewEvent('SiteAdminConfiguration')
 
         this.subscriptions.add(
             this.remoteRefreshes.pipe(mergeMap(() => fetchSite())).subscribe(
-                site =>
+                site => {
                     this.setState({
                         site,
                         error: undefined,
                         loading: false,
-                    }),
+                    })
+                    this.editor.current?.updateContents(site.configuration.effectiveContents)
+                },
                 error => this.setState({ error, loading: false })
             )
         )
@@ -440,6 +444,7 @@ export class SiteAdminConfigurationPage extends React.Component<Props, State> {
                 {this.state.site?.configuration && (
                     <div>
                         <DynamicallyImportedMonacoSettingsEditor
+                            ref={this.editor}
                             value={contents || ''}
                             jsonSchema={siteSchemaJSON}
                             canEdit={true}


### PR DESCRIPTION
Upon every click of "Save changes" we are getting back the up-to-date contents for site configuration (which may or may not be the same as the current editor's content). It creates a confusing UX that our web app keeps complaining about the inconsistent state (and offers to save again).

This PR updates the editor's content whenever we fetched it.

Fixes https://github.com/sourcegraph/customer/issues/979

## Test plan

Manual e2e test since this is a UX issue

![CleanShot 2022-06-01 at 15 11 24](https://user-images.githubusercontent.com/2946214/171348423-6b4a2bc0-a7e6-464c-92d8-fcda8ac406b3.gif)

