### PR TITLE
Update editor state using function callback

### DIFF
--- a/client/web/src/settings/DynamicallyImportedMonacoSettingsEditor.tsx
+++ b/client/web/src/settings/DynamicallyImportedMonacoSettingsEditor.tsx
@@ -43,7 +43,7 @@ interface Props<T extends object>
      */
     blockNavigationIfDirty?: boolean
 
-    onSave?: (value: string) => void
+    onSave?: (value: string, callbackFunc: (value: string) => void) => void
     onChange?: (value: string) => void
     onDirtyChange?: (dirty: boolean) => void
     onEditor?: (editor: _monaco.editor.ICodeEditor) => void
@@ -162,10 +162,14 @@ export class DynamicallyImportedMonacoSettingsEditor<T extends object = {}> exte
         )
     }
 
+    private updateStateValue = (value: string): void => {
+        this.setState({ value })
+    }
+
     private onSave = (): void => {
         const value = this.effectiveValue
         if (this.props.onSave) {
-            this.props.onSave(value)
+            this.props.onSave(value, this.updateStateValue)
         }
     }
 


### PR DESCRIPTION
Adds an `onSaveCallback` option to the `onSave` function that can be called once the settings response is received from the server. This allows us to update the editor's state and resync the props and state value.

Fix for https://github.com/sourcegraph/customer/issues/979

## Test plan

Manual e2e test since this is a UX issue

https://www.loom.com/share/5be1bd53db7040d4a58ffdf1b85346a2

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
