### PR TITLE
Ref panel: don't hardcode token into line contents

### DIFF
--- a/client/web/src/codeintel/ReferencesPanel.test.tsx
+++ b/client/web/src/codeintel/ReferencesPanel.test.tsx
@@ -13,7 +13,8 @@ import { NOOP_TELEMETRY_SERVICE, TelemetryProps } from '@sourcegraph/shared/src/
 import { MockedTestProvider, waitForNextApolloResponse } from '@sourcegraph/shared/src/testing/apollo'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
 
-import { ReferencesPanelWithMemoryRouter } from './ReferencesPanel'
+import { Location } from './location'
+import { getLineContent, ReferencesPanelWithMemoryRouter } from './ReferencesPanel'
 import { buildReferencePanelMocks } from './ReferencesPanel.mocks'
 
 const NOOP_SETTINGS_CASCADE = {
@@ -167,5 +168,83 @@ describe('ReferencesPanel', () => {
         // Assert the code view is rendered, by doing a partial match against its content
         const codeView = within(rightPane).getByRole('table')
         expect(codeView).toHaveTextContent('package diff import')
+    })
+})
+
+describe('getLineContent', () => {
+    const testFileLines = [
+        'package main',
+        '',
+        'import "fmt"',
+        '',
+        'type Animal interface {',
+        '\tSound() string',
+        '}',
+        '',
+        'var _ Animal = Cat{}',
+        '',
+        'type Cat struct{}',
+        '',
+        'func (c Cat) Sound() string { return "i am a cat" }',
+        '',
+        'type Dog struct{}',
+        '',
+        'func (d Dog) Sound() string { return "it is i, the dog" }',
+        '',
+        'func animalFarm() {',
+        '\tmakeSound(Cat{})',
+        '\tmakeSound(Dog{})',
+        '}',
+        '',
+        'func makeSound(a Animal) {',
+        '\tfmt.Printf("animal made a sound: %s", a.Sound())',
+        '',
+        '\tfoo := a',
+        '',
+        '\tfmt.Printf("another animal: %s", foo.Sound())',
+        '}',
+        '',
+    ]
+
+    it('returns pre/post and token of line', () => {
+        const location: Location = {
+            repo: 'a',
+            file: 'file',
+            commitID: 'f00b4r',
+            url: 'url',
+            precise: true,
+            content: '',
+            lines: testFileLines,
+            range: {
+                start: { line: 23, character: 5 },
+                end: { line: 23, character: 14 },
+            },
+        }
+
+        const content = getLineContent(location)
+        expect(content.prePostToken?.pre).toEqual('func ')
+        expect(content.prePostToken?.token).toEqual('makeSound')
+        expect(content.prePostToken?.post).toEqual('(a Animal) {')
+    })
+
+    it('handles token on multiple lines', () => {
+        const location: Location = {
+            repo: 'a',
+            file: 'file',
+            commitID: 'f00b4r',
+            url: 'url',
+            precise: true,
+            content: '',
+            lines: ['line0 start-of-tok', 'en-ends-here line1'],
+            range: {
+                start: { line: 0, character: 6 },
+                end: { line: 1, character: 12 },
+            },
+        }
+
+        const content = getLineContent(location)
+        expect(content.prePostToken?.pre).toEqual('line0 ')
+        expect(content.prePostToken?.token).toEqual('start-of-tok')
+        expect(content.prePostToken?.post).toEqual('')
     })
 })

--- a/client/web/src/codeintel/ReferencesPanel.tsx
+++ b/client/web/src/codeintel/ReferencesPanel.tsx
@@ -860,7 +860,7 @@ const CollapsibleLocationGroup: React.FunctionComponent<
                             {group.locations.map(reference => {
                                 const className = isActiveLocation(reference) ? styles.locationActive : ''
 
-                                const locationLine = getPrePostLineContent(reference)
+                                const locationLine = getLineContent(reference)
                                 const lineWithHighlightedToken = locationLine.prePostToken ? (
                                     <>
                                         {locationLine.prePostToken.pre === '' ? (
@@ -869,7 +869,7 @@ const CollapsibleLocationGroup: React.FunctionComponent<
                                             <Code>{locationLine.prePostToken.pre}</Code>
                                         )}
                                         <mark className="p-0 selection-highlight sourcegraph-document-highlight">
-                                            <Code>{searchToken}</Code>
+                                            <Code>{locationLine.prePostToken.token}</Code>
                                         </mark>
                                         {locationLine.prePostToken.post === '' ? (
                                             <></>
@@ -915,12 +915,13 @@ const CollapsibleLocationGroup: React.FunctionComponent<
 }
 
 interface LocationLine {
-    prePostToken?: { pre: string; post: string }
+    prePostToken?: { pre: string; token: string; post: string }
     line?: string
 }
 
-const getPrePostLineContent = (location: Location): LocationLine => {
+export const getLineContent = (location: Location): LocationLine => {
     const range = location.range
+    console.log(location)
     if (range !== undefined) {
         const line = location.lines[range.start.line]
 
@@ -928,13 +929,18 @@ const getPrePostLineContent = (location: Location): LocationLine => {
             return {
                 prePostToken: {
                     pre: line.slice(0, range.start.character).trimStart(),
+                    token: line.slice(range.start.character, range.end.character),
                     post: line.slice(range.end.character),
                 },
                 line: line.trimStart(),
             }
         }
         return {
-            prePostToken: { pre: line.slice(0, range.start.character).trim(), post: '' },
+            prePostToken: {
+                pre: line.slice(0, range.start.character).trimStart(),
+                token: line.slice(range.start.character),
+                post: '',
+            },
             line: line.trimStart(),
         }
     }


### PR DESCRIPTION
This fixes the bug reported here: https://github.com/sourcegraph/sourcegraph/discussions/35668#discussioncomment-2825758

Previously we assumed that the token that should be highlighted in the
line is the search token, but that's wrong. We need to look at the
location ranges.

## Test plan

- Manually tested
- Added unit tests

## App preview:

- [Web](https://sg-web-mrn-dont-hardcode-token.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-rskffhkupf.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
