### PR TITLE
Run `yarn generate` before `scip-typescript index`

### DIFF
--- a/.github/workflows/scip-typescript.yml
+++ b/.github/workflows/scip-typescript.yml
@@ -13,6 +13,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Install npm dependencies
         run: yarn --ignore-engines --ignore-scripts
+      - run: yarn generate
       - run: yarn global add @sourcegraph/scip-typescript
       - run: scip-typescript index --yarn-workspaces
       - run: cp index.scip dump.lsif-typed

--- a/.github/workflows/scip-typescript.yml
+++ b/.github/workflows/scip-typescript.yml
@@ -3,6 +3,7 @@ on:
   push:
     paths:
       - '**.ts'
+      - '**.tsx'
       - '**.js'
 
 jobs:


### PR DESCRIPTION

## Test plan

Manually verify that we no longer get `any` on this line here https://sourcegraph.com/github.com/sourcegraph/sourcegraph@4f286f652035619136498cc7b1af2bfd52c10131/-/blob/client/web/src/enterprise/codeintel/uploads/pages/CodeIntelUploadPage.tsx?L361:30&popover=pinned

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-olafurpg-yarn-generate.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-tjbiqeltia.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
