### PR TITLE
httpapi: handle empty IndexedIDs

### DIFF
--- a/cmd/frontend/internal/httpapi/search.go
+++ b/cmd/frontend/internal/httpapi/search.go
@@ -228,12 +228,13 @@ func (h *searchIndexerServer) serveList(w http.ResponseWriter, r *http.Request) 
 
 	if h.Indexers.Enabled() {
 		indexed := make(map[uint32]*zoekt.MinimalRepoListEntry, len(opt.IndexedIDs))
-		err = h.RepoStore.StreamMinimalRepos(r.Context(), database.ReposListOptions{
-			IDs: opt.IndexedIDs,
-		}, func(r *types.MinimalRepo) { indexed[uint32(r.ID)] = nil })
-
-		if err != nil {
-			return err
+		if len(opt.IndexedIDs) > 0 {
+			err = h.RepoStore.StreamMinimalRepos(r.Context(), database.ReposListOptions{
+				IDs: opt.IndexedIDs,
+			}, func(r *types.MinimalRepo) { indexed[uint32(r.ID)] = nil })
+			if err != nil {
+				return err
+			}
 		}
 
 		indexable, err = h.Indexers.ReposSubset(r.Context(), opt.Hostname, indexed, indexable)


### PR DESCRIPTION
This fixes a bug where frontend uses the list of IDs of indexed repos provided
by Zoekt as a filter for a call to the repo store.

If a Zoekt provides an empty list of IDs, the filter is empty and the
repo store returns all repos, instead of returning none.

This leads to frontend returning a list of repos that should be indexed by
that Zoekt + a list of all repos that have not yet been indexed by any other
Zoekt.

In practice this is shouldn't be a big problem, because it is rare that a Zoekt hasn't yet indexed 
anything. However, one of our debug commands calls frontend with an empty list of indexed repos
which surfaced this bug.

## Test plan
- existing tests
- manual testing
  - started a local instance of Sourcegraph
  - called `curl "http://localhost:6072/debug/list?indexed=<true,false>"`
  - inspected the variable `indexed` in `serveList` dependening on whether the list of repo IDs was empty or not.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
