### PR TITLE
migration: Simplify idempotency tests

### DIFF
--- a/internal/database/connections/live/migration_test.go
+++ b/internal/database/connections/live/migration_test.go
@@ -115,25 +115,13 @@ func testMigrations(t *testing.T, name string, schema *schemas.Schema) {
 func testMigrationIdempotency(t *testing.T, name string, schema *schemas.Schema) {
 	t.Helper()
 
-	ctx := context.Background()
 	db := dbtest.NewRawDB(t)
-	storeFactory := newStoreFactory(&observation.TestContext)
-	migrationRunner := runnerFromDB(storeFactory, db, schema)
 	all := schema.Definitions.All()
 
 	t.Run("idempotent up", func(t *testing.T) {
 		for _, definition := range all {
-			options := runner.Options{
-				Operations: []runner.MigrationOperation{
-					{
-						SchemaName:     name,
-						Type:           runner.MigrationOperationTypeTargetedUp,
-						TargetVersions: []int{definition.ID},
-					},
-				},
-			}
-			if err := migrationRunner.Run(ctx, options); err != nil {
-				t.Fatalf("failed to perform upgrade to version %d: %s", definition.ID, err)
+			if _, err := db.Exec(definition.UpQuery.Query(sqlf.PostgresBindVar)); err != nil {
+				t.Errorf("failed to perform upgrade of migration %d: %s", definition.ID, err)
 			}
 
 			if definition.NonIdempotent {
@@ -152,17 +140,8 @@ func testMigrationIdempotency(t *testing.T, name string, schema *schemas.Schema)
 		for i := len(all) - 1; i >= 0; i-- {
 			definition := all[i]
 
-			options := runner.Options{
-				Operations: []runner.MigrationOperation{
-					{
-						SchemaName:     name,
-						Type:           runner.MigrationOperationTypeTargetedDown,
-						TargetVersions: definition.Parents,
-					},
-				},
-			}
-			if err := migrationRunner.Run(ctx, options); err != nil {
-				t.Fatalf("failed to perform downgrade to versions %v: %s", definition.Parents, err)
+			if _, err := db.Exec(definition.DownQuery.Query(sqlf.PostgresBindVar)); err != nil {
+				t.Errorf("failed to perform downgrade of migration %d: %s", definition.ID, err)
 			}
 
 			if definition.NonIdempotent {


### PR DESCRIPTION
In #33543, we discovered that the idempotency test is not well-formed if there is a significant gap between adding a new migration and the state of main. This can happen with stale branches.

Failures on this PR happened because we were too strict about what we wanted from the idempotency test. We upgrade _down_ to the parent version, but that could lead to running _too many_ down migrations for the test conditions. This works in real-life scenarios, but we just got lucky in testing environments so far.

We now specifically run all migration queries _directly_ instead of relying on the migration runner to put the schema in the correct state for these assertions. I've done the same thing in the up direction for consistency.

## Test plan

Tested locally.