### PR TITLE
codeintel gitserver: do not log error if it's clone-in-progress

### DIFF
--- a/internal/codeintel/stores/gitserver/observability.go
+++ b/internal/codeintel/stores/gitserver/observability.go
@@ -43,6 +43,11 @@ func newOperations(observationContext *observation.Context) *operations {
 				if errors.HasType(err, &gitdomain.RevisionNotFoundError{}) {
 					return observation.EmitForNone
 				}
+
+				if gitdomain.IsCloneInProgress(err) {
+					return observation.EmitForNone
+				}
+
 				return observation.EmitForDefault
 			},
 		})


### PR DESCRIPTION
Clone in progress? We log less.

## Test plan

- Existing CI
