### PR TITLE
add link to standalone insight on title

### DIFF
--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/BackendInsight.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/BackendInsight.tsx
@@ -150,7 +150,7 @@ export const BackendInsightView: React.FunctionComponent<React.PropsWithChildren
             onMouseEnter={trackMouseEnter}
             onMouseLeave={trackMouseLeave}
         >
-            <InsightCardHeader title={insight.title}>
+            <InsightCardHeader title={insight.title} insightId={insight.id}>
                 {isVisible && (
                     <>
                         <DrillDownFiltersPopover

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/built-in-insight/BuiltInInsight.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/built-in-insight/BuiltInInsight.tsx
@@ -73,7 +73,7 @@ export function BuiltInInsight(props: BuiltInInsightProps): React.ReactElement {
             onMouseEnter={trackMouseEnter}
             onMouseLeave={trackMouseLeave}
         >
-            <InsightCardHeader title={insight.title}>
+            <InsightCardHeader title={insight.title} insightId={insight.id}>
                 {isVisible && (
                     <InsightContextMenu
                         insight={insight}

--- a/client/web/src/enterprise/insights/components/views/card/InsightCard.module.scss
+++ b/client/web/src/enterprise/insights/components/views/card/InsightCard.module.scss
@@ -29,6 +29,10 @@
     -webkit-line-clamp: 2;
     margin-bottom: 0.25rem;
     flex-grow: 1;
+
+    a {
+        color: inherit;
+    }
 }
 
 .action {

--- a/client/web/src/enterprise/insights/components/views/card/InsightCard.tsx
+++ b/client/web/src/enterprise/insights/components/views/card/InsightCard.tsx
@@ -24,6 +24,7 @@ const InsightCard = forwardRef((props, reference) => {
 
 export interface InsightCardTitleProps {
     title: string
+    insightId: string
     subtitle?: ReactNode
 
     /**
@@ -34,13 +35,14 @@ export interface InsightCardTitleProps {
 }
 
 const InsightCardHeader = forwardRef((props, reference) => {
-    const { as: Component = 'header', title, subtitle, className, children, ...attributes } = props
+    const { as: Component = 'header', title, insightId, subtitle, className, children, ...attributes } = props
+    const shareableUrl = `${window.location.origin}/insights/insight/${insightId}`
 
     return (
         <Component {...attributes} ref={reference} className={classNames(styles.header, className)}>
             <div className={styles.headerContent}>
                 <H4 as={H2} title={title} className={styles.title}>
-                    {title}
+                    <a href={shareableUrl}>{title}</a>
                 </H4>
 
                 {children && (

--- a/client/web/src/enterprise/insights/pages/insights/insight/components/standalone-backend-insight/StandaloneBackendInsight.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/insight/components/standalone-backend-insight/StandaloneBackendInsight.tsx
@@ -152,7 +152,7 @@ export const StandaloneBackendInsight: React.FunctionComponent<StandaloneBackend
                 onMouseEnter={trackMouseEnter}
                 onMouseLeave={trackMouseLeave}
             >
-                <InsightCardHeader title={insight.title}>
+                <InsightCardHeader title={insight.title} insightId={insight.id}>
                     <StandaloneInsightContextMenu
                         insight={insight}
                         zeroYAxisMin={zeroYAxisMin}

--- a/client/web/src/enterprise/insights/pages/insights/insight/components/standalone-runtime-insight/StandaloneRuntimeInsight.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/insight/components/standalone-runtime-insight/StandaloneRuntimeInsight.tsx
@@ -57,7 +57,7 @@ export function StandaloneRuntimeInsight(props: StandaloneRuntimeInsightProps): 
             onMouseEnter={trackMouseEnter}
             onMouseLeave={trackMouseLeave}
         >
-            <InsightCardHeader title={insight.title}>
+            <InsightCardHeader title={insight.title} insightId={insight.id}>
                 <StandaloneInsightContextMenu
                     insight={insight}
                     zeroYAxisMin={zeroYAxisMin}

--- a/client/web/src/enterprise/insights/pages/landing/getting-started/components/code-insights-examples/code-insight-example-card/CodeInsightExampleCard.tsx
+++ b/client/web/src/enterprise/insights/pages/landing/getting-started/components/code-insights-examples/code-insight-example-card/CodeInsightExampleCard.tsx
@@ -72,6 +72,7 @@ const CodeInsightSearchExample: FunctionComponent<CodeInsightSearchExampleProps>
         <InsightCard className={className} onMouseEnter={trackMouseEnter} onMouseLeave={trackMouseLeave}>
             <InsightCardHeader
                 title={content.title}
+                insightId="#"
                 subtitle={
                     <CodeInsightsQueryBlock
                         as={SyntaxHighlightedSearchQuery}
@@ -150,6 +151,7 @@ const CodeInsightCaptureExample: FunctionComponent<CodeInsightCaptureExampleProp
         <InsightCard className={className} onMouseEnter={trackMouseEnter} onMouseLeave={trackMouseLeave}>
             <InsightCardHeader
                 title={content.title}
+                insightId="#"
                 subtitle={
                     <CodeInsightsQueryBlock
                         as={SyntaxHighlightedSearchQuery}


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/36006

Add links on insight card titles to standalone page for that insight.

## Test plan

- Go to any insights dashboard
- Insight card titles should have links
- Links should go to standalone page for that insight