### PR TITLE
fix accidentally returning soft error

### DIFF
--- a/enterprise/internal/insights/background/historical_enqueuer.go
+++ b/enterprise/internal/insights/background/historical_enqueuer.go
@@ -431,7 +431,7 @@ func (h *historicalEnqueuer) buildFrames(ctx context.Context, definitions []ityp
 				multi = errors.Append(multi, err)
 			}
 		}
-		return multi
+		return nil
 	})
 	if multi != nil {
 		log15.Error("historical_enqueuer.buildFrames - multierror", "err", multi)


### PR DESCRIPTION
After refactoring the backfiller, we are accidentally exiting the global iteration after any soft error (which we typically would just skip the repository).


## Test plan

Tested locally to ensure all repos in a global insight get processed
