### PR TITLE
batches: remove ExecutionWorkspaces storybook flake

### DIFF
--- a/client/web/src/enterprise/batches/batch-spec/execute/workspaces/ExecutionWorkspaces.story.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/execute/workspaces/ExecutionWorkspaces.story.tsx
@@ -1,4 +1,5 @@
 import { storiesOf } from '@storybook/react'
+import { of } from 'rxjs'
 import { MATCH_ANY_PARAMETERS, WildcardMockLink } from 'wildcard-mock-link'
 
 import { getDocumentNode } from '@sourcegraph/http-client'
@@ -86,12 +87,18 @@ add('list', () => (
     </WebStory>
 ))
 
+const queryEmptyFileDiffs = () => of({ totalCount: 0, pageInfo: { endCursor: null, hasNextPage: false }, nodes: [] })
+
 add('with workspace selected', () => (
     <WebStory>
         {props => (
             <MockedTestProvider link={MOCKS}>
                 <BatchSpecContextProvider batchChange={mockBatchChange()} batchSpec={mockFullBatchSpec()}>
-                    <ExecutionWorkspaces {...props} selectedWorkspaceID="spec1234" />
+                    <ExecutionWorkspaces
+                        {...props}
+                        selectedWorkspaceID="spec1234"
+                        queryChangesetSpecFileDiffs={queryEmptyFileDiffs}
+                    />
                 </BatchSpecContextProvider>
             </MockedTestProvider>
         )}

--- a/client/web/src/enterprise/batches/batch-spec/execute/workspaces/ExecutionWorkspaces.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/execute/workspaces/ExecutionWorkspaces.tsx
@@ -7,7 +7,9 @@ import { ThemeProps } from '@sourcegraph/shared/src/theme'
 import { Card, CardBody, Panel, H3 } from '@sourcegraph/wildcard'
 
 import { BatchSpecExecutionFields } from '../../../../../graphql-operations'
+import { queryChangesetSpecFileDiffs as _queryChangesetSpecFileDiffs } from '../../../preview/list/backend'
 import { BatchSpecContextState, useBatchSpecContext } from '../../BatchSpecContext'
+import { queryBatchSpecWorkspaceStepFileDiffs as _queryBatchSpecWorkspaceStepFileDiffs } from '../backend'
 
 import { WorkspaceDetails } from './WorkspaceDetails'
 import { Workspaces } from './Workspaces'
@@ -18,6 +20,9 @@ const WORKSPACES_LIST_SIZE = 'batch-changes.ssbc-workspaces-list-size'
 
 interface ExecutionWorkspacesProps extends ThemeProps {
     selectedWorkspaceID?: string
+    /** For testing purposes only */
+    queryBatchSpecWorkspaceStepFileDiffs?: typeof _queryBatchSpecWorkspaceStepFileDiffs
+    queryChangesetSpecFileDiffs?: typeof _queryChangesetSpecFileDiffs
 }
 
 export const ExecutionWorkspaces: React.FunctionComponent<
@@ -32,39 +37,59 @@ type MemoizedExecutionWorkspacesProps = ExecutionWorkspacesProps & Pick<BatchSpe
 
 const MemoizedExecutionWorkspaces: React.FunctionComponent<
     React.PropsWithChildren<MemoizedExecutionWorkspacesProps>
-> = React.memo(({ selectedWorkspaceID, isLightTheme, batchSpec, errors }) => {
-    const history = useHistory()
+> = React.memo(
+    ({
+        selectedWorkspaceID,
+        isLightTheme,
+        batchSpec,
+        errors,
+        queryBatchSpecWorkspaceStepFileDiffs,
+        queryChangesetSpecFileDiffs,
+    }) => {
+        const history = useHistory()
 
-    const deselectWorkspace = useCallback(() => history.push(batchSpec.executionURL), [batchSpec.executionURL, history])
+        const deselectWorkspace = useCallback(() => history.push(batchSpec.executionURL), [
+            batchSpec.executionURL,
+            history,
+        ])
 
-    return (
-        <div className={styles.container}>
-            {errors.execute && <ErrorAlert error={errors.execute} className={styles.errors} />}
-            <div className={styles.inner}>
-                <Panel defaultSize={500} minSize={405} maxSize={1400} position="left" storageKey={WORKSPACES_LIST_SIZE}>
-                    <Workspaces
-                        batchSpecID={batchSpec.id}
-                        selectedNode={selectedWorkspaceID}
-                        executionURL={batchSpec.executionURL}
-                    />
-                </Panel>
-                <Card className="w-100 overflow-auto flex-grow-1">
-                    {/* This is necessary to prevent the margin collapse on `Card` */}
-                    <div className="w-100">
-                        <CardBody>
-                            {selectedWorkspaceID ? (
-                                <WorkspaceDetails
-                                    id={selectedWorkspaceID}
-                                    isLightTheme={isLightTheme}
-                                    deselectWorkspace={deselectWorkspace}
-                                />
-                            ) : (
-                                <H3 className="text-center my-3">Select a workspace to view details.</H3>
-                            )}
-                        </CardBody>
-                    </div>
-                </Card>
+        return (
+            <div className={styles.container}>
+                {errors.execute && <ErrorAlert error={errors.execute} className={styles.errors} />}
+                <div className={styles.inner}>
+                    <Panel
+                        defaultSize={500}
+                        minSize={405}
+                        maxSize={1400}
+                        position="left"
+                        storageKey={WORKSPACES_LIST_SIZE}
+                    >
+                        <Workspaces
+                            batchSpecID={batchSpec.id}
+                            selectedNode={selectedWorkspaceID}
+                            executionURL={batchSpec.executionURL}
+                        />
+                    </Panel>
+                    <Card className="w-100 overflow-auto flex-grow-1">
+                        {/* This is necessary to prevent the margin collapse on `Card` */}
+                        <div className="w-100">
+                            <CardBody>
+                                {selectedWorkspaceID ? (
+                                    <WorkspaceDetails
+                                        id={selectedWorkspaceID}
+                                        isLightTheme={isLightTheme}
+                                        deselectWorkspace={deselectWorkspace}
+                                        queryBatchSpecWorkspaceStepFileDiffs={queryBatchSpecWorkspaceStepFileDiffs}
+                                        queryChangesetSpecFileDiffs={queryChangesetSpecFileDiffs}
+                                    />
+                                ) : (
+                                    <H3 className="text-center my-3">Select a workspace to view details.</H3>
+                                )}
+                            </CardBody>
+                        </div>
+                    </Card>
+                </div>
             </div>
-        </div>
-    )
-})
+        )
+    }
+)


### PR DESCRIPTION
We didn't have a mock set up for retrieving the changeset diff in
`ExecutionWorkspaces`, and the error message therefore included the host
name of the Chromatic instance that was running the storybook. (See
https://www.chromatic.com/pullrequest?appId=5f0f381c0e50750022dc6bf7&number=36331&view=changes
for an example.)

## Test plan

Checked the storybook, which no longer has an error in it.