### PR TITLE
Search backend: fix multibyte line match conversion

### DIFF
--- a/internal/search/result/file.go
+++ b/internal/search/result/file.go
@@ -4,6 +4,7 @@ import (
 	"net/url"
 	"path"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/search/filter"
@@ -222,7 +223,7 @@ func (h HunkMatch) AsLineMatches() []*LineMatch {
 						start = rr.Start.Column
 					}
 
-					end := len(line)
+					end := utf8.RuneCountInString(line)
 					if rangeLine == rr.End.Line {
 						end = rr.End.Column
 					}

--- a/internal/search/result/file_test.go
+++ b/internal/search/result/file_test.go
@@ -35,6 +35,29 @@ func TestConvertMatches(t *testing.T) {
 			}},
 		}, {
 			input: HunkMatch{
+				Content:      "line1\nstart 的<-multibyte\nline3",
+				ContentStart: Location{Line: 1},
+				Ranges: Ranges{{
+					Start: Location{0, 1, 0},
+					End:   Location{32, 3, 5},
+				}},
+			},
+			output: []*LineMatch{{
+				Preview:          "line1",
+				LineNumber:       1,
+				OffsetAndLengths: [][2]int32{{0, 5}},
+			}, {
+				Preview:    "start 的<-multibyte",
+				LineNumber: 2,
+				// 18 is rune length, not the byte length
+				OffsetAndLengths: [][2]int32{{0, 18}},
+			}, {
+				Preview:          "line3",
+				LineNumber:       3,
+				OffsetAndLengths: [][2]int32{{0, 5}},
+			}},
+		}, {
+			input: HunkMatch{
 				Content:      "line1",
 				ContentStart: Location{Line: 1},
 				Ranges: Ranges{{


### PR DESCRIPTION
This fixes a bug introduced by the multiline match code that causes the length for LineMatch to be
incorrectly calculated as the number of bytes rather than the number of runes.

Before:

<img width="1009" alt="Screen Shot 2022-06-01 at 12 04 44" src="https://user-images.githubusercontent.com/12631702/171472765-46c017db-5f40-4a59-8eff-5aaecbc03c43.png">

After: 

<img width="982" alt="Screen Shot 2022-06-01 at 12 04 24" src="https://user-images.githubusercontent.com/12631702/171472760-4786a938-e6b4-4a35-bc24-02394195aa94.png">

The apostrophe in `Don't` is a multibyte character, which is what caused the breakage here.

## Test plan

Added a test to check behavior for multibyte characters on internal lines. 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
