### PR TITLE
Search backend: rename HunkMatch to ChunkMatch

### DIFF
--- a/cmd/frontend/graphqlbackend/file_match.go
+++ b/cmd/frontend/graphqlbackend/file_match.go
@@ -56,7 +56,7 @@ func (fm *FileMatchResolver) Symbols() []symbolResolver {
 }
 
 func (fm *FileMatchResolver) LineMatches() []lineMatchResolver {
-	lineMatches := fm.FileMatch.HunkMatches.AsLineMatches()
+	lineMatches := fm.FileMatch.ChunkMatches.AsLineMatches()
 	r := make([]lineMatchResolver, 0, len(lineMatches))
 	for _, lm := range lineMatches {
 		r = append(r, lineMatchResolver{lm})

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -248,11 +248,11 @@ func (sr *SearchResultsResolver) blameFileMatch(ctx context.Context, fm *result.
 	}()
 
 	// Blame the first line match.
-	if len(fm.HunkMatches) == 0 {
+	if len(fm.ChunkMatches) == 0 {
 		// No line match
 		return time.Time{}, nil
 	}
-	hm := fm.HunkMatches[0]
+	hm := fm.ChunkMatches[0]
 	hunks, err := gitserver.NewClient(sr.db).BlameFile(ctx, fm.Repo.Name, fm.Path, &gitserver.BlameOptions{
 		NewestCommit: fm.CommitID,
 		StartLine:    hm.Ranges[0].Start.Line,

--- a/cmd/frontend/graphqlbackend/search_results_stats_languages.go
+++ b/cmd/frontend/graphqlbackend/search_results_stats_languages.go
@@ -111,12 +111,12 @@ func searchResultsStatsLanguages(ctx context.Context, db database.DB, matches []
 				filesMap[key] = &fileStatsWork{}
 			}
 
-			if len(fileMatch.HunkMatches) > 0 {
+			if len(fileMatch.ChunkMatches) > 0 {
 				// Only count matching lines. TODO(sqs): bytes are not counted for these files
 				if filesMap[key].partialFiles == nil {
 					filesMap[key].partialFiles = map[string]uint64{}
 				}
-				filesMap[key].partialFiles[fileMatch.Path] += uint64(fileMatch.HunkMatches.MatchCount())
+				filesMap[key].partialFiles[fileMatch.Path] += uint64(fileMatch.ChunkMatches.MatchCount())
 			} else {
 				// Count entire file.
 				filesMap[key].fullEntries = append(filesMap[key].fullEntries, &fileInfo{

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -52,7 +52,7 @@ func TestSearchResults(t *testing.T) {
 			case *result.RepoMatch:
 				resultDescriptions[i] = fmt.Sprintf("repo:%s", m.Name)
 			case *result.FileMatch:
-				resultDescriptions[i] = fmt.Sprintf("%s:%d", m.Path, m.HunkMatches[0].Ranges[0].Start.Line)
+				resultDescriptions[i] = fmt.Sprintf("%s:%d", m.Path, m.ChunkMatches[0].Ranges[0].Start.Line)
 			default:
 				t.Fatal("unexpected result type:", match)
 			}

--- a/cmd/frontend/graphqlbackend/search_test.go
+++ b/cmd/frontend/graphqlbackend/search_test.go
@@ -293,9 +293,9 @@ func TestExactlyOneRepo(t *testing.T) {
 }
 
 func mkFileMatch(repo types.MinimalRepo, path string, lineNumbers ...int) *result.FileMatch {
-	var hms result.HunkMatches
+	var hms result.ChunkMatches
 	for _, n := range lineNumbers {
-		hms = append(hms, result.HunkMatch{
+		hms = append(hms, result.ChunkMatch{
 			Ranges: []result.Range{{
 				Start: result.Location{Line: n},
 				End:   result.Location{Line: n},
@@ -308,7 +308,7 @@ func mkFileMatch(repo types.MinimalRepo, path string, lineNumbers ...int) *resul
 			Path: path,
 			Repo: repo,
 		},
-		HunkMatches: hms,
+		ChunkMatches: hms,
 	}
 }
 

--- a/cmd/frontend/internal/search/decorate.go
+++ b/cmd/frontend/internal/search/decorate.go
@@ -153,7 +153,7 @@ func DecorateFileHunksHTML(ctx context.Context, db database.DB, fm *result.FileM
 		return tableRows
 	}
 
-	groups := groupLineMatches(fm.HunkMatches.AsLineMatches())
+	groups := groupLineMatches(fm.ChunkMatches.AsLineMatches())
 	hunks := make([]stream.DecoratedHunk, 0, len(groups))
 	for _, group := range groups {
 		rows := spliceRows(int(group[0].LineNumber), int(group[0].LineNumber)+len(group))

--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -427,7 +427,7 @@ func fromMatch(match result.Match, repoCache map[api.RepoID]*types.SearchedRepo)
 func fromFileMatch(fm *result.FileMatch, repoCache map[api.RepoID]*types.SearchedRepo) streamhttp.EventMatch {
 	if len(fm.Symbols) > 0 {
 		return fromSymbolMatch(fm, repoCache)
-	} else if fm.HunkMatches.MatchCount() > 0 {
+	} else if fm.ChunkMatches.MatchCount() > 0 {
 		return fromContentMatch(fm, repoCache)
 	}
 	return fromPathMatch(fm, repoCache)
@@ -455,7 +455,7 @@ func fromPathMatch(fm *result.FileMatch, repoCache map[api.RepoID]*types.Searche
 }
 
 func fromContentMatch(fm *result.FileMatch, repoCache map[api.RepoID]*types.SearchedRepo) *streamhttp.EventContentMatch {
-	lineMatches := fm.HunkMatches.AsLineMatches()
+	lineMatches := fm.ChunkMatches.AsLineMatches()
 	eventLineMatches := make([]streamhttp.EventLineMatch, 0, len(lineMatches))
 	for _, lm := range lineMatches {
 		eventLineMatches = append(eventLineMatches, streamhttp.EventLineMatch{

--- a/enterprise/cmd/frontend/internal/compute/resolvers/resolvers_test.go
+++ b/enterprise/cmd/frontend/internal/compute/resolvers/resolvers_test.go
@@ -35,7 +35,7 @@ func TestToResultResolverList(t *testing.T) {
 
 	nonNilMatches := []result.Match{
 		&result.FileMatch{
-			HunkMatches: result.HunkMatches{{
+			ChunkMatches: result.ChunkMatches{{
 				Content: "a",
 				Ranges: result.Ranges{{
 					Start: result.Location{Line: 1, Column: 0},

--- a/enterprise/internal/compute/match_only_command.go
+++ b/enterprise/internal/compute/match_only_command.go
@@ -70,7 +70,7 @@ func fromRegexpMatches(submatches []int, namedGroups []string, lineValue string,
 }
 
 func matchOnly(fm *result.FileMatch, r *regexp.Regexp) *MatchContext {
-	lineMatches := fm.HunkMatches.AsLineMatches()
+	lineMatches := fm.ChunkMatches.AsLineMatches()
 	matches := make([]Match, 0, len(lineMatches))
 	for _, l := range lineMatches {
 		for _, submatches := range r.FindAllStringSubmatchIndex(l.Preview, -1) {

--- a/enterprise/internal/compute/match_only_command_test.go
+++ b/enterprise/internal/compute/match_only_command_test.go
@@ -34,7 +34,7 @@ func Test_matchOnly(t *testing.T) {
 			ID:   5,
 			Name: "codehost.com/myorg/myrepo",
 		}},
-		HunkMatches: result.HunkMatches{{
+		ChunkMatches: result.ChunkMatches{{
 			Content:      "abcdefgh",
 			ContentStart: result.Location{Line: 1},
 			Ranges: result.Ranges{{

--- a/internal/search/result/deduper_test.go
+++ b/internal/search/result/deduper_test.go
@@ -41,7 +41,7 @@ func TestDeduper(t *testing.T) {
 		}
 	}
 
-	file := func(repo, commit, path string, hms HunkMatches) *FileMatch {
+	file := func(repo, commit, path string, hms ChunkMatches) *FileMatch {
 		return &FileMatch{
 			File: File{
 				Repo: types.MinimalRepo{
@@ -50,12 +50,12 @@ func TestDeduper(t *testing.T) {
 				CommitID: api.CommitID(commit),
 				Path:     path,
 			},
-			HunkMatches: hms,
+			ChunkMatches: hms,
 		}
 	}
 
-	hm := func(s string) HunkMatch {
-		return HunkMatch{
+	hm := func(s string) ChunkMatch {
+		return ChunkMatch{
 			Content: s,
 		}
 	}
@@ -83,11 +83,11 @@ func TestDeduper(t *testing.T) {
 		{
 			name: "merge files",
 			input: []Match{
-				file("a", "b", "c", HunkMatches{hm("a"), hm("b")}),
-				file("a", "b", "c", HunkMatches{hm("c"), hm("d")}),
+				file("a", "b", "c", ChunkMatches{hm("a"), hm("b")}),
+				file("a", "b", "c", ChunkMatches{hm("c"), hm("d")}),
 			},
 			expected: []Match{
-				file("a", "b", "c", HunkMatches{hm("a"), hm("b"), hm("c"), hm("d")}),
+				file("a", "b", "c", ChunkMatches{hm("a"), hm("b"), hm("c"), hm("d")}),
 			},
 		},
 		{

--- a/internal/search/result/file.go
+++ b/internal/search/result/file.go
@@ -43,8 +43,8 @@ func (f *File) URL() *url.URL {
 type FileMatch struct {
 	File
 
-	HunkMatches HunkMatches
-	Symbols     []*SymbolMatch `json:"-"`
+	ChunkMatches ChunkMatches
+	Symbols      []*SymbolMatch `json:"-"`
 
 	LimitHit bool
 }
@@ -56,7 +56,7 @@ func (fm *FileMatch) RepoName() types.MinimalRepo {
 func (fm *FileMatch) searchResultMarker() {}
 
 func (fm *FileMatch) ResultCount() int {
-	rc := len(fm.Symbols) + fm.HunkMatches.MatchCount()
+	rc := len(fm.Symbols) + fm.ChunkMatches.MatchCount()
 	if rc == 0 {
 		return 1 // 1 to count "empty" results like type:path results
 	}
@@ -67,7 +67,7 @@ func (fm *FileMatch) ResultCount() int {
 // the absence of a true `PathMatch` type, we use this function as a proxy
 // signal to drive `select:file` logic that deduplicates path results.
 func (fm *FileMatch) IsPathMatch() bool {
-	return len(fm.HunkMatches) == 0 && len(fm.Symbols) == 0
+	return len(fm.ChunkMatches) == 0 && len(fm.Symbols) == 0
 }
 
 func (fm *FileMatch) Select(selectPath filter.SelectPath) Match {
@@ -78,7 +78,7 @@ func (fm *FileMatch) Select(selectPath filter.SelectPath) Match {
 			ID:   fm.Repo.ID,
 		}
 	case filter.File:
-		fm.HunkMatches = nil
+		fm.ChunkMatches = nil
 		fm.Symbols = nil
 		if len(selectPath) > 1 && selectPath[1] == "directory" {
 			fm.Path = path.Clean(path.Dir(fm.Path)) + "/" // Add trailing slash for clarity.
@@ -86,7 +86,7 @@ func (fm *FileMatch) Select(selectPath filter.SelectPath) Match {
 		return fm
 	case filter.Symbol:
 		if len(fm.Symbols) > 0 {
-			fm.HunkMatches = nil // Only return symbol match if symbols exist
+			fm.ChunkMatches = nil // Only return symbol match if symbols exist
 			if len(selectPath) > 1 {
 				filteredSymbols := SelectSymbolKind(fm.Symbols, selectPath[1])
 				if len(filteredSymbols) == 0 {
@@ -99,7 +99,7 @@ func (fm *FileMatch) Select(selectPath filter.SelectPath) Match {
 		return nil
 	case filter.Content:
 		// Only return file match if line matches exist
-		if len(fm.HunkMatches) > 0 {
+		if len(fm.ChunkMatches) > 0 {
 			fm.Symbols = nil
 			return fm
 		}
@@ -114,7 +114,7 @@ func (fm *FileMatch) Select(selectPath filter.SelectPath) Match {
 // counts and limit.
 func (fm *FileMatch) AppendMatches(src *FileMatch) {
 	// TODO merge hunk matches smartly
-	fm.HunkMatches = append(fm.HunkMatches, src.HunkMatches...)
+	fm.ChunkMatches = append(fm.ChunkMatches, src.ChunkMatches...)
 	fm.Symbols = append(fm.Symbols, src.Symbols...)
 	fm.LimitHit = fm.LimitHit || src.LimitHit
 }
@@ -125,7 +125,7 @@ func (fm *FileMatch) AppendMatches(src *FileMatch) {
 //   if limit >= ResultCount then nothing is done and we return limit - ResultCount.
 //   if limit < ResultCount then ResultCount becomes limit and we return 0.
 func (fm *FileMatch) Limit(limit int) int {
-	matchCount := fm.HunkMatches.MatchCount()
+	matchCount := fm.ChunkMatches.MatchCount()
 	symbolCount := len(fm.Symbols)
 
 	// An empty FileMatch should still count against the limit -- see *FileMatch.ResultCount()
@@ -134,7 +134,7 @@ func (fm *FileMatch) Limit(limit int) int {
 	}
 
 	if limit < matchCount {
-		fm.HunkMatches.Limit(limit)
+		fm.ChunkMatches.Limit(limit)
 		limit = 0
 		fm.LimitHit = true
 	} else {
@@ -166,12 +166,12 @@ func (fm *FileMatch) Key() Key {
 	return k
 }
 
-// HunkMatch stores the smallest (and contiguous) line range of file content
+// ChunkMatch stores the smallest (and contiguous) line range of file content
 // corresponding to the set of ranges. We represent it this way so we always
 // have the complete line available to clients for display purposes and we
 // aways have the complete content of the matched range available for further
 // computation.
-type HunkMatch struct {
+type ChunkMatch struct {
 	// Content contains the lines overlapped by Ranges. Content will always
 	// contain full lines. This means the slice of file content contained
 	// in Content will always be:
@@ -193,8 +193,8 @@ type HunkMatch struct {
 	Ranges Ranges
 }
 
-// MatchedContent returns the content matched by the ranges in this HunkMatch.
-func (h HunkMatch) MatchedContent() []string {
+// MatchedContent returns the content matched by the ranges in this ChunkMatch.
+func (h ChunkMatch) MatchedContent() []string {
 	// Create a new set of ranges whose offsets are
 	// relative to the start of the content.
 	relRanges := h.Ranges.Sub(h.ContentStart)
@@ -205,11 +205,11 @@ func (h HunkMatch) MatchedContent() []string {
 	return res
 }
 
-// AsLineMatches facilitates converting from HunkMatch to a set of LineMatches.
+// AsLineMatches facilitates converting from ChunkMatch to a set of LineMatches.
 // This loses information like byte offsets and the logical relationship
 // between lines in a multiline match, but it allows us to keep providing the
 // LineMatch representation for clients without breaking backwards compatibility.
-func (h HunkMatch) AsLineMatches() []*LineMatch {
+func (h ChunkMatch) AsLineMatches() []*LineMatch {
 	lines := strings.Split(h.Content, "\n")
 	lineMatches := make([]*LineMatch, len(lines))
 	for i, line := range lines {
@@ -241,9 +241,9 @@ func (h HunkMatch) AsLineMatches() []*LineMatch {
 	return lineMatches
 }
 
-type HunkMatches []HunkMatch
+type ChunkMatches []ChunkMatch
 
-func (hs HunkMatches) AsLineMatches() []*LineMatch {
+func (hs ChunkMatches) AsLineMatches() []*LineMatch {
 	res := make([]*LineMatch, 0, len(hs))
 	for _, h := range hs {
 		res = append(res, h.AsLineMatches()...)
@@ -251,7 +251,7 @@ func (hs HunkMatches) AsLineMatches() []*LineMatch {
 	return res
 }
 
-func (hs HunkMatches) MatchCount() int {
+func (hs ChunkMatches) MatchCount() int {
 	count := 0
 	for _, h := range hs {
 		count += len(h.Ranges)
@@ -259,7 +259,7 @@ func (hs HunkMatches) MatchCount() int {
 	return count
 }
 
-func (hs *HunkMatches) Limit(limit int) {
+func (hs *ChunkMatches) Limit(limit int) {
 	matches := *hs
 	for i, match := range matches {
 		if len(match.Ranges) >= limit {

--- a/internal/search/result/file_test.go
+++ b/internal/search/result/file_test.go
@@ -9,10 +9,10 @@ import (
 func TestConvertMatches(t *testing.T) {
 	t.Run("AsLineMatches", func(t *testing.T) {
 		cases := []struct {
-			input  HunkMatch
+			input  ChunkMatch
 			output []*LineMatch
 		}{{
-			input: HunkMatch{
+			input: ChunkMatch{
 				Content:      "line1\nline2\nline3",
 				ContentStart: Location{Line: 1},
 				Ranges: Ranges{{
@@ -34,7 +34,7 @@ func TestConvertMatches(t *testing.T) {
 				OffsetAndLengths: [][2]int32{{0, 1}},
 			}},
 		}, {
-			input: HunkMatch{
+			input: ChunkMatch{
 				Content:      "line1\nstart 的<-multibyte\nline3",
 				ContentStart: Location{Line: 1},
 				Ranges: Ranges{{
@@ -57,7 +57,7 @@ func TestConvertMatches(t *testing.T) {
 				OffsetAndLengths: [][2]int32{{0, 5}},
 			}},
 		}, {
-			input: HunkMatch{
+			input: ChunkMatch{
 				Content:      "line1",
 				ContentStart: Location{Line: 1},
 				Ranges: Ranges{{
@@ -81,12 +81,12 @@ func TestConvertMatches(t *testing.T) {
 		}
 	})
 
-	t.Run("HunkMatchesAsLineMatches", func(t *testing.T) {
+	t.Run("ChunkMatchesAsLineMatches", func(t *testing.T) {
 		cases := []struct {
-			input  HunkMatches
+			input  ChunkMatches
 			output []*LineMatch
 		}{{
-			input: HunkMatches{{
+			input: ChunkMatches{{
 				Content:      "line1\nline2\nline3\nline4",
 				ContentStart: Location{Line: 1},
 				Ranges: Ranges{{
@@ -115,7 +115,7 @@ func TestConvertMatches(t *testing.T) {
 				OffsetAndLengths: [][2]int32{{0, 1}},
 			}},
 		}, {
-			input: HunkMatches{{
+			input: ChunkMatches{{
 				Content:      "line1\nline2\nline3",
 				ContentStart: Location{Line: 1},
 				Ranges: Ranges{{
@@ -156,7 +156,7 @@ func TestConvertMatches(t *testing.T) {
 				OffsetAndLengths: [][2]int32{{0, 1}},
 			}},
 		}, {
-			input:  HunkMatches{},
+			input:  ChunkMatches{},
 			output: []*LineMatch{},
 		}}
 
@@ -168,7 +168,7 @@ func TestConvertMatches(t *testing.T) {
 	})
 }
 
-func TestHunkMatches_Limit(t *testing.T) {
+func TestChunkMatches_Limit(t *testing.T) {
 	cases := []struct {
 		rangeLens         []int
 		limit             int
@@ -201,9 +201,9 @@ func TestHunkMatches_Limit(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run("", func(t *testing.T) {
-			var hs HunkMatches
+			var hs ChunkMatches
 			for _, i := range tc.rangeLens {
-				hs = append(hs, HunkMatch{Ranges: make(Ranges, i)})
+				hs = append(hs, ChunkMatch{Ranges: make(Ranges, i)})
 			}
 			hs.Limit(tc.limit)
 			var gotLens []int
@@ -215,12 +215,12 @@ func TestHunkMatches_Limit(t *testing.T) {
 	}
 }
 
-func TestHunkMatches_MatchedContent(t *testing.T) {
+func TestChunkMatches_MatchedContent(t *testing.T) {
 	cases := []struct {
-		input  HunkMatch
+		input  ChunkMatch
 		output []string
 	}{{
-		input: HunkMatch{
+		input: ChunkMatch{
 			Content:      "abc",
 			ContentStart: Location{0, 0, 0},
 			Ranges: Ranges{{
@@ -230,7 +230,7 @@ func TestHunkMatches_MatchedContent(t *testing.T) {
 		},
 		output: []string{"b"},
 	}, {
-		input: HunkMatch{
+		input: ChunkMatch{
 			Content:      "def",
 			ContentStart: Location{4, 1, 0}, // abc\ndef
 			Ranges: Ranges{{
@@ -240,7 +240,7 @@ func TestHunkMatches_MatchedContent(t *testing.T) {
 		},
 		output: []string{"e"},
 	}, {
-		input: HunkMatch{
+		input: ChunkMatch{
 			Content:      "abc\ndef",
 			ContentStart: Location{0, 0, 0},
 			Ranges: Ranges{{
@@ -250,7 +250,7 @@ func TestHunkMatches_MatchedContent(t *testing.T) {
 		},
 		output: []string{"c\nd"},
 	}, {
-		input: HunkMatch{
+		input: ChunkMatch{
 			Content:      "abc\ndef",
 			ContentStart: Location{0, 0, 0},
 			Ranges: Ranges{{

--- a/internal/search/searcher/search.go
+++ b/internal/search/searcher/search.go
@@ -222,7 +222,7 @@ func newToMatches(repo types.MinimalRepo, commit api.CommitID, rev *string) func
 	return func(searcherMatches []*protocol.FileMatch) []result.Match {
 		matches := make([]result.Match, 0, len(searcherMatches))
 		for _, fm := range searcherMatches {
-			hunkMatches := make(result.HunkMatches, 0, len(fm.LineMatches))
+			hunkMatches := make(result.ChunkMatches, 0, len(fm.LineMatches))
 
 			for _, lm := range fm.LineMatches {
 				ranges := make(result.Ranges, 0, len(lm.OffsetAndLengths))
@@ -241,7 +241,7 @@ func newToMatches(repo types.MinimalRepo, commit api.CommitID, rev *string) func
 						},
 					})
 				}
-				hunkMatches = append(hunkMatches, result.HunkMatch{
+				hunkMatches = append(hunkMatches, result.ChunkMatch{
 					Content: lm.Preview,
 					ContentStart: result.Location{
 						Offset: lm.LineOffset,
@@ -253,7 +253,7 @@ func newToMatches(repo types.MinimalRepo, commit api.CommitID, rev *string) func
 			}
 
 			for _, mm := range fm.MultilineMatches {
-				hunkMatches = append(hunkMatches, result.HunkMatch{
+				hunkMatches = append(hunkMatches, result.ChunkMatch{
 					Content: mm.Preview,
 					ContentStart: result.Location{
 						Offset: int(mm.Start.Offset) - runeOffsetToByteOffset(mm.Preview, int(mm.Start.Column)),
@@ -282,8 +282,8 @@ func newToMatches(repo types.MinimalRepo, commit api.CommitID, rev *string) func
 					CommitID: commit,
 					InputRev: rev,
 				},
-				HunkMatches: hunkMatches,
-				LimitHit:    fm.LimitHit,
+				ChunkMatches: hunkMatches,
+				LimitHit:     fm.LimitHit,
 			})
 		}
 		return matches

--- a/internal/search/streaming/search_filters_test.go
+++ b/internal/search/streaming/search_filters_test.go
@@ -60,7 +60,7 @@ func TestSearchFiltersUpdate(t *testing.T) {
 							File: result.File{
 								Repo: repo,
 							},
-							HunkMatches: result.HunkMatches{{Ranges: make(result.Ranges, 2)}},
+							ChunkMatches: result.ChunkMatches{{Ranges: make(result.Ranges, 2)}},
 						},
 					},
 				},

--- a/internal/search/streaming/stream_test.go
+++ b/internal/search/streaming/stream_test.go
@@ -141,20 +141,20 @@ func TestWithSelect(t *testing.T) {
 		return SearchEvent{
 			Results: []result.Match{
 				&result.FileMatch{
-					File:        result.File{Path: "pokeman/charmandar"},
-					HunkMatches: result.HunkMatches{{Ranges: make(result.Ranges, 1)}},
+					File:         result.File{Path: "pokeman/charmandar"},
+					ChunkMatches: result.ChunkMatches{{Ranges: make(result.Ranges, 1)}},
 				},
 				&result.FileMatch{
-					File:        result.File{Path: "pokeman/charmandar"},
-					HunkMatches: result.HunkMatches{{Ranges: make(result.Ranges, 1)}},
+					File:         result.File{Path: "pokeman/charmandar"},
+					ChunkMatches: result.ChunkMatches{{Ranges: make(result.Ranges, 1)}},
 				},
 				&result.FileMatch{
-					File:        result.File{Path: "pokeman/bulbosaur"},
-					HunkMatches: result.HunkMatches{{Ranges: make(result.Ranges, 1)}},
+					File:         result.File{Path: "pokeman/bulbosaur"},
+					ChunkMatches: result.ChunkMatches{{Ranges: make(result.Ranges, 1)}},
 				},
 				&result.FileMatch{
-					File:        result.File{Path: "digiman/ummm"},
-					HunkMatches: result.HunkMatches{{Ranges: make(result.Ranges, 1)}},
+					File:         result.File{Path: "digiman/ummm"},
+					ChunkMatches: result.ChunkMatches{{Ranges: make(result.Ranges, 1)}},
 				},
 			},
 		}
@@ -172,12 +172,12 @@ func TestWithSelect(t *testing.T) {
 	autogold.Want("dedupe paths for select:file.directory", `[
   {
     "Path": "pokeman/",
-    "HunkMatches": null,
+    "ChunkMatches": null,
     "LimitHit": false
   },
   {
     "Path": "digiman/",
-    "HunkMatches": null,
+    "ChunkMatches": null,
     "LimitHit": false
   }
 ]`).Equal(t, test("file.directory"))
@@ -185,17 +185,17 @@ func TestWithSelect(t *testing.T) {
 	autogold.Want("dedupe paths select:file", `[
   {
     "Path": "pokeman/charmandar",
-    "HunkMatches": null,
+    "ChunkMatches": null,
     "LimitHit": false
   },
   {
     "Path": "pokeman/bulbosaur",
-    "HunkMatches": null,
+    "ChunkMatches": null,
     "LimitHit": false
   },
   {
     "Path": "digiman/ummm",
-    "HunkMatches": null,
+    "ChunkMatches": null,
     "LimitHit": false
   }
 ]`).Equal(t, test("file"))
@@ -203,7 +203,7 @@ func TestWithSelect(t *testing.T) {
 	autogold.Want("don't dedupe file matches for select:content", `[
   {
     "Path": "pokeman/charmandar",
-    "HunkMatches": [
+    "ChunkMatches": [
       {
         "Content": "",
         "ContentStart": [
@@ -253,7 +253,7 @@ func TestWithSelect(t *testing.T) {
   },
   {
     "Path": "pokeman/charmandar",
-    "HunkMatches": [
+    "ChunkMatches": [
       {
         "Content": "",
         "ContentStart": [
@@ -281,7 +281,7 @@ func TestWithSelect(t *testing.T) {
   },
   {
     "Path": "pokeman/bulbosaur",
-    "HunkMatches": [
+    "ChunkMatches": [
       {
         "Content": "",
         "ContentStart": [
@@ -309,7 +309,7 @@ func TestWithSelect(t *testing.T) {
   },
   {
     "Path": "digiman/ummm",
-    "HunkMatches": [
+    "ChunkMatches": [
       {
         "Content": "",
         "ContentStart": [

--- a/internal/search/textsearch/textsearch_test.go
+++ b/internal/search/textsearch/textsearch_test.go
@@ -404,15 +404,15 @@ func TestFileMatch_Limit(t *testing.T) {
 	for _, tt := range tests {
 		t.Run("", func(t *testing.T) {
 			fileMatch := &result.FileMatch{
-				File:        result.File{},
-				HunkMatches: result.HunkMatches{{Ranges: make(result.Ranges, tt.numHunkRanges)}},
-				Symbols:     make([]*result.SymbolMatch, tt.numSymbolMatches),
-				LimitHit:    false,
+				File:         result.File{},
+				ChunkMatches: result.ChunkMatches{{Ranges: make(result.Ranges, tt.numHunkRanges)}},
+				Symbols:      make([]*result.SymbolMatch, tt.numSymbolMatches),
+				LimitHit:     false,
 			}
 
 			got := fileMatch.Limit(tt.limit)
 
-			require.Equal(t, tt.expNumHunkRanges, fileMatch.HunkMatches.MatchCount())
+			require.Equal(t, tt.expNumHunkRanges, fileMatch.ChunkMatches.MatchCount())
 			require.Equal(t, tt.expNumSymbolMatches, len(fileMatch.Symbols))
 			require.Equal(t, tt.expRemainingLimit, got)
 			require.Equal(t, tt.wantLimitHit, fileMatch.LimitHit)

--- a/internal/search/zoekt/indexed_search.go
+++ b/internal/search/zoekt/indexed_search.go
@@ -366,7 +366,7 @@ func sendMatches(event *zoekt.SearchResult, getRepoInputRev repoRevFunc, typ sea
 			continue
 		}
 
-		var hms result.HunkMatches
+		var hms result.ChunkMatches
 		if typ != search.SymbolRequest {
 			hms = zoektFileMatchToMultilineMatches(&file)
 		}
@@ -379,8 +379,8 @@ func sendMatches(event *zoekt.SearchResult, getRepoInputRev repoRevFunc, typ sea
 				symbols = zoektFileMatchToSymbolResults(repo, inputRev, &file)
 			}
 			fm := result.FileMatch{
-				HunkMatches: hms,
-				Symbols:     symbols,
+				ChunkMatches: hms,
+				Symbols:      symbols,
 				File: result.File{
 					InputRev: &inputRev,
 					CommitID: api.CommitID(file.Version),
@@ -400,8 +400,8 @@ func sendMatches(event *zoekt.SearchResult, getRepoInputRev repoRevFunc, typ sea
 	})
 }
 
-func zoektFileMatchToMultilineMatches(file *zoekt.FileMatch) result.HunkMatches {
-	hms := make(result.HunkMatches, 0, len(file.LineMatches))
+func zoektFileMatchToMultilineMatches(file *zoekt.FileMatch) result.ChunkMatches {
+	hms := make(result.ChunkMatches, 0, len(file.LineMatches))
 
 	for _, l := range file.LineMatches {
 		if l.FileName {
@@ -412,7 +412,7 @@ func zoektFileMatchToMultilineMatches(file *zoekt.FileMatch) result.HunkMatches 
 			offset := utf8.RuneCount(l.Line[:m.LineOffset])
 			length := utf8.RuneCount(l.Line[m.LineOffset : m.LineOffset+m.MatchLength])
 
-			hms = append(hms, result.HunkMatch{
+			hms = append(hms, result.ChunkMatch{
 				Content: string(l.Line),
 				// zoekt line numbers are 1-based rather than 0-based so subtract 1
 				ContentStart: result.Location{


### PR DESCRIPTION
This renames HunkMatch to ChunkMatch since the word "Hunk" is associated
with diffs, and I'd like to try to avoid overloading that word.

## Test plan

Just a rename. Updated tests that depend on that name. 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
