### PR TITLE
Search backend: add chunk matches to the searcher protocol

### DIFF
--- a/cmd/searcher/protocol/searcher.go
+++ b/cmd/searcher/protocol/searcher.go
@@ -194,6 +194,7 @@ type Response struct {
 type FileMatch struct {
 	Path string
 
+	ChunkMatches     []ChunkMatch
 	MultilineMatches []MultilineMatch
 	LineMatches      []LineMatch
 
@@ -257,4 +258,15 @@ func (m MultilineMatch) MatchedContent() string {
 		}
 	}
 	return string(runePreview[m.Start.Column : lastLineStart+int(m.End.Column)])
+}
+
+type ChunkMatch struct {
+	Content      string
+	ContentStart Location
+	Ranges       []Range
+}
+
+type Range struct {
+	Start Location
+	End   Location
 }


### PR DESCRIPTION
This adds adds the ChunkMatch type as an optional return type for the
searcher API. This means there are now three different result types
returnable by the searcher API, but both LineMatch and MultilineMatch
are superceded by ChunkMatch. The next steps will be to remove LineMatch
and MultilineMatch from the API.

## Test plan

Not used yet. Will be exercised when searcher is migrated to return `ChunkMatch` instead of `LineMatch` and `MultilineMatch`. 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
