### PR TITLE
Search backend: use ChunkMatch type for structural search

### DIFF
--- a/cmd/searcher/internal/search/search_structural.go
+++ b/cmd/searcher/internal/search/search_structural.go
@@ -40,7 +40,7 @@ func toFileMatch(zipReader *zip.Reader, combyMatch *comby.FileMatch) (protocol.F
 	}
 
 	// Convert comby matches to ranges
-	ranges := make([]protocol.Range, len(combyMatch.Matches))
+	ranges := make([]protocol.Range, 0, len(combyMatch.Matches))
 	for _, r := range combyMatch.Matches {
 		// trust, but verify
 		if r.Range.Start.Offset > len(fileBuf) || r.Range.End.Offset > len(fileBuf) {

--- a/cmd/searcher/internal/search/search_structural_test.go
+++ b/cmd/searcher/internal/search/search_structural_test.go
@@ -570,8 +570,10 @@ func Test_chunkRanges(t *testing.T) {
 		}},
 		mergeThreshold: 0,
 		output: []rangeChunk{{
-			minLoc: protocol.Location{Offset: 0, Line: 0, Column: 0},
-			maxLoc: protocol.Location{Offset: 20, Line: 1, Column: 10},
+			cover: protocol.Range{
+				Start: protocol.Location{Offset: 0, Line: 0, Column: 0},
+				End:   protocol.Location{Offset: 20, Line: 1, Column: 10},
+			},
 			ranges: []protocol.Range{{
 				Start: protocol.Location{Offset: 0, Line: 0, Column: 0},
 				End:   protocol.Location{Offset: 20, Line: 1, Column: 10},
@@ -588,8 +590,10 @@ func Test_chunkRanges(t *testing.T) {
 		}},
 		mergeThreshold: 0,
 		output: []rangeChunk{{
-			minLoc: protocol.Location{Offset: 0, Line: 0, Column: 0},
-			maxLoc: protocol.Location{Offset: 25, Line: 1, Column: 15},
+			cover: protocol.Range{
+				Start: protocol.Location{Offset: 0, Line: 0, Column: 0},
+				End:   protocol.Location{Offset: 25, Line: 1, Column: 15},
+			},
 			ranges: []protocol.Range{{
 				Start: protocol.Location{Offset: 0, Line: 0, Column: 0},
 				End:   protocol.Location{Offset: 20, Line: 1, Column: 10},
@@ -609,8 +613,10 @@ func Test_chunkRanges(t *testing.T) {
 		}},
 		mergeThreshold: 0,
 		output: []rangeChunk{{
-			minLoc: protocol.Location{Offset: 0, Line: 0, Column: 0},
-			maxLoc: protocol.Location{Offset: 35, Line: 2, Column: 5},
+			cover: protocol.Range{
+				Start: protocol.Location{Offset: 0, Line: 0, Column: 0},
+				End:   protocol.Location{Offset: 35, Line: 2, Column: 5},
+			},
 			ranges: []protocol.Range{{
 				Start: protocol.Location{Offset: 0, Line: 0, Column: 0},
 				End:   protocol.Location{Offset: 20, Line: 1, Column: 10},
@@ -630,15 +636,19 @@ func Test_chunkRanges(t *testing.T) {
 		}},
 		mergeThreshold: 0,
 		output: []rangeChunk{{
-			minLoc: protocol.Location{Offset: 0, Line: 0, Column: 0},
-			maxLoc: protocol.Location{Offset: 10, Line: 0, Column: 10},
+			cover: protocol.Range{
+				Start: protocol.Location{Offset: 0, Line: 0, Column: 0},
+				End:   protocol.Location{Offset: 10, Line: 0, Column: 10},
+			},
 			ranges: []protocol.Range{{
 				Start: protocol.Location{Offset: 0, Line: 0, Column: 0},
 				End:   protocol.Location{Offset: 10, Line: 0, Column: 10},
 			}},
 		}, {
-			minLoc: protocol.Location{Offset: 11, Line: 1, Column: 0},
-			maxLoc: protocol.Location{Offset: 20, Line: 1, Column: 9},
+			cover: protocol.Range{
+				Start: protocol.Location{Offset: 11, Line: 1, Column: 0},
+				End:   protocol.Location{Offset: 20, Line: 1, Column: 9},
+			},
 			ranges: []protocol.Range{{
 				Start: protocol.Location{Offset: 11, Line: 1, Column: 0},
 				End:   protocol.Location{Offset: 20, Line: 1, Column: 9},
@@ -655,8 +665,10 @@ func Test_chunkRanges(t *testing.T) {
 		}},
 		mergeThreshold: 1,
 		output: []rangeChunk{{
-			minLoc: protocol.Location{Offset: 0, Line: 0, Column: 0},
-			maxLoc: protocol.Location{Offset: 20, Line: 1, Column: 9},
+			cover: protocol.Range{
+				Start: protocol.Location{Offset: 0, Line: 0, Column: 0},
+				End:   protocol.Location{Offset: 20, Line: 1, Column: 9},
+			},
 			ranges: []protocol.Range{{
 				Start: protocol.Location{Offset: 0, Line: 0, Column: 0},
 				End:   protocol.Location{Offset: 10, Line: 0, Column: 10},

--- a/cmd/searcher/internal/search/search_test.go
+++ b/cmd/searcher/internal/search/search_test.go
@@ -543,7 +543,7 @@ func fetchTimeoutForCI(t *testing.T) string {
 func toString(m []protocol.FileMatch) string {
 	buf := new(bytes.Buffer)
 	for _, f := range m {
-		if len(f.LineMatches) == 0 && len(f.MultilineMatches) == 0 {
+		if len(f.LineMatches) == 0 && len(f.ChunkMatches) == 0 {
 			buf.WriteString(f.Path)
 			buf.WriteByte('\n')
 		}
@@ -555,15 +555,16 @@ func toString(m []protocol.FileMatch) string {
 			buf.WriteString(l.Preview)
 			buf.WriteByte('\n')
 		}
-		for _, l := range f.MultilineMatches {
-			buf.WriteString(f.Path)
-			buf.WriteByte(':')
-			buf.WriteString(strconv.Itoa(int(l.Start.Line) + 1))
-			buf.WriteByte(':')
-			buf.WriteString(l.Preview)
-			buf.WriteByte('\n')
+		for _, cm := range f.ChunkMatches {
+			for _, rr := range cm.Ranges {
+				buf.WriteString(f.Path)
+				buf.WriteByte(':')
+				buf.WriteString(strconv.Itoa(int(rr.Start.Line) + 1))
+				buf.WriteByte(':')
+				buf.WriteString(cm.Content)
+				buf.WriteByte('\n')
+			}
 		}
-
 	}
 	return buf.String()
 }

--- a/cmd/searcher/protocol/searcher.go
+++ b/cmd/searcher/protocol/searcher.go
@@ -194,9 +194,8 @@ type Response struct {
 type FileMatch struct {
 	Path string
 
-	ChunkMatches     []ChunkMatch
-	MultilineMatches []MultilineMatch
-	LineMatches      []LineMatch
+	ChunkMatches []ChunkMatch
+	LineMatches  []LineMatch
 
 	// MatchCount is the number of matches.  Different from len(LineMatches), as multiple
 	// lines may correspond to one logical match when doing a structural search
@@ -264,6 +263,14 @@ type ChunkMatch struct {
 	Content      string
 	ContentStart Location
 	Ranges       []Range
+}
+
+func (cm ChunkMatch) MatchedContent() []string {
+	res := make([]string, 0, len(cm.Ranges))
+	for _, rr := range cm.Ranges {
+		res = append(res, cm.Content[rr.Start.Offset-cm.ContentStart.Offset:rr.End.Offset-cm.ContentStart.Offset])
+	}
+	return res
 }
 
 type Range struct {

--- a/internal/search/searcher/search.go
+++ b/internal/search/searcher/search.go
@@ -252,29 +252,6 @@ func newToMatches(repo types.MinimalRepo, commit api.CommitID, rev *string) func
 				})
 			}
 
-			for _, mm := range fm.MultilineMatches {
-				chunkMatches = append(chunkMatches, result.ChunkMatch{
-					Content: mm.Preview,
-					ContentStart: result.Location{
-						Offset: int(mm.Start.Offset) - runeOffsetToByteOffset(mm.Preview, int(mm.Start.Column)),
-						Line:   int(mm.Start.Line),
-						Column: 0,
-					},
-					Ranges: result.Ranges{{
-						Start: result.Location{
-							Offset: int(mm.Start.Offset),
-							Line:   int(mm.Start.Line),
-							Column: int(mm.Start.Column),
-						},
-						End: result.Location{
-							Offset: int(mm.End.Offset),
-							Line:   int(mm.End.Line),
-							Column: int(mm.End.Column),
-						},
-					}},
-				})
-			}
-
 			for _, cm := range fm.ChunkMatches {
 				ranges := make(result.Ranges, 0, len(cm.Ranges))
 				for _, rr := range cm.Ranges {


### PR DESCRIPTION
This updates structural search to emit the `ChunkMatch` type instead of the `MultilineMatch` type. This removes the last uses of `MultilineMatch`, allowing me to get rid of that field from the protocol definition. 

The only really complex part of this change was grouping ranges into chunks. This is the complexity that I was trying to avoid with `MultilineMatch`, but it's honestly not too bad. The logic can be cleanly separated into its own function and well-tested. The efficiency and representation wins we get from this are much higher than the complexity loss IMO. 

## Test plan

Added unit tests where appropriate, updated existing tests and am running backend integration tests. 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
