### PR TITLE
Migration to add unique index to external_services

### DIFF
--- a/internal/database/schema.json
+++ b/internal/database/schema.json
@@ -7616,6 +7616,26 @@
           "ConstraintDefinition": "PRIMARY KEY (id)"
         },
         {
+          "Name": "external_services_unique_kind_org_id",
+          "IsPrimaryKey": false,
+          "IsUnique": true,
+          "IsExclusion": false,
+          "IsDeferrable": false,
+          "IndexDefinition": "CREATE UNIQUE INDEX external_services_unique_kind_org_id ON external_services USING btree (kind, namespace_org_id) WHERE deleted_at IS NULL AND namespace_user_id IS NULL AND namespace_org_id IS NOT NULL",
+          "ConstraintType": "",
+          "ConstraintDefinition": ""
+        },
+        {
+          "Name": "external_services_unique_kind_user_id",
+          "IsPrimaryKey": false,
+          "IsUnique": true,
+          "IsExclusion": false,
+          "IsDeferrable": false,
+          "IndexDefinition": "CREATE UNIQUE INDEX external_services_unique_kind_user_id ON external_services USING btree (kind, namespace_user_id) WHERE deleted_at IS NULL AND namespace_org_id IS NULL AND namespace_user_id IS NOT NULL",
+          "ConstraintType": "",
+          "ConstraintDefinition": ""
+        },
+        {
           "Name": "kind_cloud_default",
           "IsPrimaryKey": false,
           "IsUnique": true,

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -1001,6 +1001,8 @@ Foreign-key constraints:
  token_expires_at  | timestamp with time zone |           |          | 
 Indexes:
     "external_services_pkey" PRIMARY KEY, btree (id)
+    "external_services_unique_kind_org_id" UNIQUE, btree (kind, namespace_org_id) WHERE deleted_at IS NULL AND namespace_user_id IS NULL AND namespace_org_id IS NOT NULL
+    "external_services_unique_kind_user_id" UNIQUE, btree (kind, namespace_user_id) WHERE deleted_at IS NULL AND namespace_org_id IS NULL AND namespace_user_id IS NOT NULL
     "kind_cloud_default" UNIQUE, btree (kind, cloud_default) WHERE cloud_default = true AND deleted_at IS NULL
     "external_services_has_webhooks_idx" btree (has_webhooks)
     "external_services_namespace_org_id_idx" btree (namespace_org_id)

--- a/migrations/frontend/1654116265/down.sql
+++ b/migrations/frontend/1654116265/down.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS external_services_unique_kind_org_id;
+DROP INDEX IF EXISTS external_services_unique_kind_user_id;

--- a/migrations/frontend/1654116265/metadata.yaml
+++ b/migrations/frontend/1654116265/metadata.yaml
@@ -1,0 +1,2 @@
+name: add_unique_index_to_external_services
+parents: [1653479179]

--- a/migrations/frontend/1654116265/up.sql
+++ b/migrations/frontend/1654116265/up.sql
@@ -1,0 +1,2 @@
+CREATE UNIQUE INDEX IF NOT EXISTS external_services_unique_kind_org_id ON external_services (kind, namespace_org_id) WHERE (deleted_at IS NULL AND namespace_user_id IS NULL AND namespace_org_id IS NOT NULL);
+CREATE UNIQUE INDEX IF NOT EXISTS external_services_unique_kind_user_id ON external_services (kind, namespace_user_id) WHERE (deleted_at IS NULL AND namespace_org_id IS NULL AND namespace_user_id IS NOT NULL);

--- a/migrations/frontend/squashed.sql
+++ b/migrations/frontend/squashed.sql
@@ -3479,6 +3479,10 @@ CREATE INDEX external_services_namespace_org_id_idx ON external_services USING b
 
 CREATE INDEX external_services_namespace_user_id_idx ON external_services USING btree (namespace_user_id);
 
+CREATE UNIQUE INDEX external_services_unique_kind_org_id ON external_services USING btree (kind, namespace_org_id) WHERE ((deleted_at IS NULL) AND (namespace_user_id IS NULL) AND (namespace_org_id IS NOT NULL));
+
+CREATE UNIQUE INDEX external_services_unique_kind_user_id ON external_services USING btree (kind, namespace_user_id) WHERE ((deleted_at IS NULL) AND (namespace_org_id IS NULL) AND (namespace_user_id IS NOT NULL));
+
 CREATE INDEX feature_flag_overrides_org_id ON feature_flag_overrides USING btree (namespace_org_id) WHERE (namespace_org_id IS NOT NULL);
 
 CREATE INDEX feature_flag_overrides_user_id ON feature_flag_overrides USING btree (namespace_user_id) WHERE (namespace_user_id IS NOT NULL);


### PR DESCRIPTION
This PR adds a unique index on external_service.kind, external_service.namespace_org_id so we can enforce the limit also in the DB level. The API already has a check to avoid more than one external service of type Gitlab or Gitthub.
For more context, see[ Cloud-150 ](Cloud-150) and also this [old Draft PR](https://github.com/sourcegraph/sourcegraph/pull/34867/files#r864749648).
## Test plan

Tested the queries in a local instance and all worked as expected.