### PR TITLE
monitoring: allow validation errors to aggregate and return all at once

### DIFF
--- a/monitoring/main.go
+++ b/monitoring/main.go
@@ -51,8 +51,7 @@ func main() {
 		definitions.CodeIntelUploads(),
 		definitions.CodeIntelPolicies(),
 	); err != nil {
-		// Rely on the Generate function doing logging, so just exit with an appropriate
-		// error code here.
+		println(err.Error())
 		os.Exit(1)
 	}
 }

--- a/monitoring/monitoring/generator.go
+++ b/monitoring/monitoring/generator.go
@@ -11,6 +11,8 @@ import (
 	"github.com/grafana-tools/sdk"
 	"github.com/inconshreveable/log15"
 	"gopkg.in/yaml.v2"
+
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 const (
@@ -36,37 +38,41 @@ type GenerateOptions struct {
 }
 
 // Generate is the main Sourcegraph monitoring generator entrypoint.
-func Generate(logger log15.Logger, opts GenerateOptions, containers ...*Dashboard) error {
-	logger.Info("Regenerating monitoring", "options", opts, "containers", len(containers))
+func Generate(logger log15.Logger, opts GenerateOptions, dashboards ...*Dashboard) error {
+	logger.Info("Regenerating monitoring", "options", opts, "dashboards", len(dashboards))
 
 	var generatedAssets []string
 
-	// Generate output for all containers
-	for _, container := range containers {
-		// Logger for container
-		clog := logger.New("container", container.Name)
-
-		// Verify container configuration
-		if err := container.validate(); err != nil {
-			clog.Crit("Failed to validate Container", "err", err)
-			return err
+	// Verify dashboard configuration
+	var validationErrors error
+	for _, dashboard := range dashboards {
+		if err := dashboard.validate(); err != nil {
+			validationErrors = errors.Append(validationErrors,
+				errors.Wrapf(err, "Invalid dashboard %q", dashboard.Name))
 		}
+	}
+	if validationErrors != nil {
+		return errors.Wrap(validationErrors, "Validation failed")
+	}
+
+	// Generate output for all dashboards
+	for _, dashboard := range dashboards {
+		// Logger for dashboard
+		clog := logger.New("dashboard", dashboard.Name)
 
 		// Prepare Grafana assets
 		if opts.GrafanaDir != "" {
 			clog.Debug("Rendering Grafana assets")
-			board := container.renderDashboard()
+			board := dashboard.renderDashboard()
 			data, err := json.MarshalIndent(board, "", "  ")
 			if err != nil {
-				clog.Crit("Invalid dashboard", "err", err)
-				return err
+				return errors.Wrapf(err, "Invalid dashboard %q", dashboard.Name)
 			}
 			// #nosec G306  prometheus runs as nobody
-			generatedDashboard := container.Name + ".json"
+			generatedDashboard := dashboard.Name + ".json"
 			err = os.WriteFile(filepath.Join(opts.GrafanaDir, generatedDashboard), data, os.ModePerm)
 			if err != nil {
-				clog.Crit("Could not write dashboard to output", "error", err)
-				return err
+				return errors.Wrapf(err, "Could not write dashboard %q to output", dashboard.Name)
 			}
 			generatedAssets = append(generatedAssets, generatedDashboard)
 
@@ -76,13 +82,11 @@ func Generate(logger log15.Logger, opts GenerateOptions, containers ...*Dashboar
 				crlog.Debug("Reloading Grafana instance")
 				client, err := sdk.NewClient(localGrafanaURL, localGrafanaCredentials, sdk.DefaultHTTPClient)
 				if err != nil {
-					crlog.Crit("Failed to initialize Grafana client", "error", err)
-					return err
+					return errors.Wrapf(err, "Failed to initialize Grafana client for dashboard %q", dashboard.Title)
 				}
 				_, err = client.SetDashboard(context.Background(), *board, sdk.SetDashboardParams{Overwrite: true})
 				if err != nil {
-					crlog.Crit("Could not reload Grafana instance", "error", err)
-					return err
+					return errors.Wrapf(err, "Could not reload Grafana instance for dashboard %q", dashboard.Title)
 				} else {
 					crlog.Info("Reloaded Grafana instance")
 				}
@@ -92,22 +96,19 @@ func Generate(logger log15.Logger, opts GenerateOptions, containers ...*Dashboar
 		// Prepare Prometheus assets
 		if opts.PrometheusDir != "" {
 			clog.Debug("Rendering Prometheus assets")
-			promAlertsFile, err := container.renderRules()
+			promAlertsFile, err := dashboard.renderRules()
 			if err != nil {
-				clog.Crit("Unable to generate alerts", "err", err)
-				return err
+				return errors.Wrapf(err, "Unable to generate alerts for dashboard %q", dashboard.Title)
 			}
 			data, err := yaml.Marshal(promAlertsFile)
 			if err != nil {
-				clog.Crit("Invalid rules", "err", err)
-				return err
+				return errors.Wrapf(err, "Invalid rules for dashboard %q", dashboard.Title)
 			}
-			fileName := strings.ReplaceAll(container.Name, "-", "_") + alertRulesFileSuffix
+			fileName := strings.ReplaceAll(dashboard.Name, "-", "_") + alertRulesFileSuffix
 			generatedAssets = append(generatedAssets, fileName)
 			err = os.WriteFile(filepath.Join(opts.PrometheusDir, fileName), data, os.ModePerm)
 			if err != nil {
-				clog.Crit("Could not write rules to output", "error", err)
-				return err
+				return errors.Wrapf(err, "Could not write rules to output for dashboard %q", dashboard.Title)
 			}
 		}
 	}
@@ -119,13 +120,11 @@ func Generate(logger log15.Logger, opts GenerateOptions, containers ...*Dashboar
 		rlog.Debug("Reloading Prometheus instance", "instance", localPrometheusURL)
 		resp, err := http.Post(localPrometheusURL+"/-/reload", "", nil)
 		if err != nil {
-			rlog.Crit("Could not reload Prometheus", "error", err)
-			return err
+			return errors.Wrapf(err, "Could not reload Prometheus at %q", localPrometheusURL)
 		} else {
 			defer resp.Body.Close()
 			if resp.StatusCode != 200 {
-				rlog.Crit("Unexpected status code while reloading Prometheus rules", "code", resp.StatusCode)
-				return err
+				return errors.Newf("Unexpected status code %d while reloading Prometheus rules", resp.StatusCode)
 			}
 			rlog.Info("Reloaded Prometheus instance")
 		}
@@ -134,10 +133,9 @@ func Generate(logger log15.Logger, opts GenerateOptions, containers ...*Dashboar
 	// Generate documentation
 	if opts.DocsDir != "" {
 		logger.Debug("Rendering docs")
-		docs, err := renderDocumentation(containers)
+		docs, err := renderDocumentation(dashboards)
 		if err != nil {
-			logger.Crit("Failed to generate docs", "error", err)
-			return err
+			return errors.Wrap(err, "Failed to generate docs")
 		}
 		for _, docOut := range []struct {
 			path string
@@ -148,8 +146,7 @@ func Generate(logger log15.Logger, opts GenerateOptions, containers ...*Dashboar
 		} {
 			err = os.WriteFile(docOut.path, docOut.data, os.ModePerm)
 			if err != nil {
-				logger.Crit("Could not write docs to path", "path", docOut.path, "error", err)
-				return err
+				return errors.Wrapf(err, "Could not write docs to path %q", docOut.path)
 			}
 			generatedAssets = append(generatedAssets, docOut.path)
 		}
@@ -159,8 +156,7 @@ func Generate(logger log15.Logger, opts GenerateOptions, containers ...*Dashboar
 	if !opts.DisablePrune {
 		logger.Debug("Pruning dangling assets")
 		if err := pruneAssets(logger, generatedAssets, opts.GrafanaDir, opts.PrometheusDir); err != nil {
-			logger.Crit("Failed to prune assets, resolve manually or disable pruning", "error", err)
-			return err
+			return errors.Wrap(err, "Failed to prune assets, resolve manually or disable pruning")
 		}
 	}
 

--- a/monitoring/monitoring/monitoring.go
+++ b/monitoring/monitoring/monitoring.go
@@ -60,17 +60,19 @@ func (c *Dashboard) validate() error {
 	if c.Description != withPeriod(c.Description) || c.Description != upperFirst(c.Description) {
 		return errors.Errorf("Description must be sentence starting with an uppercase letter and ending with period; found \"%s\"", c.Description)
 	}
+
+	var errs error
 	for i, v := range c.Variables {
 		if err := v.validate(); err != nil {
-			return errors.Errorf("Variable %d %q: %v", i, c.Name, err)
+			errs = errors.Append(errs, errors.Errorf("Variable %d %q: %v", i, c.Name, err))
 		}
 	}
 	for i, g := range c.Groups {
 		if err := g.validate(); err != nil {
-			return errors.Errorf("Group %d %q: %v", i, g.Title, err)
+			errs = errors.Append(errs, errors.Errorf("Group %d %q: %v", i, g.Title, err))
 		}
 	}
-	return nil
+	return errs
 }
 
 // noAlertsDefined indicates if a dashboard no alerts defined.
@@ -541,12 +543,13 @@ func (g Group) validate() error {
 	if g.Title != upperFirst(g.Title) || g.Title == withPeriod(g.Title) {
 		return errors.Errorf("Title must start with an uppercase letter and not end with a period; found \"%s\"", g.Title)
 	}
+	var errs error
 	for i, r := range g.Rows {
 		if err := r.validate(); err != nil {
-			return errors.Errorf("Row %d: %v", i, err)
+			errs = errors.Append(errs, errors.Errorf("Row %d: %v", i, err))
 		}
 	}
-	return nil
+	return errs
 }
 
 // Row of observable metrics.
@@ -558,12 +561,14 @@ func (r Row) validate() error {
 	if len(r) < 1 || len(r) > 4 {
 		return errors.Errorf("row must have 1 to 4 observables only, found %v", len(r))
 	}
+
+	var errs error
 	for i, o := range r {
 		if err := o.validate(); err != nil {
-			return errors.Errorf("Observable %d %q: %v", i, o.Name, err)
+			errs = errors.Append(errs, errors.Errorf("Observable %d %q: %v", i, o.Name, err))
 		}
 	}
-	return nil
+	return errs
 }
 
 // ObservableOwner denotes a team that owns an Observable. The current teams are described in


### PR DESCRIPTION
This change allows all validation errors to be collected in a multierror and be returned all together, so that we can see everything that's wrong. Also refactors error handling in the generator to return errors instead of logging and returning, because large multierror output looks _terrible_ with structured logging.

That said, output is still a bit funky because nested multi-errors don't format correctly right now: https://github.com/sourcegraph/sourcegraph/issues/31497

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
```
sg generate go ./monitoring
```

With an added validation https://github.com/sourcegraph/sourcegraph/pull/36423 :

<img width="569" alt="image" src="https://user-images.githubusercontent.com/23356519/171509645-2921bcbd-ec46-4359-b0b6-1db5356abba5.png">
