### PR TITLE
proposal(monitoring): forbid critical alerts with no solutions

### DIFF
--- a/doc/admin/observability/alert_solutions.md
+++ b/doc/admin/observability/alert_solutions.md
@@ -68,7 +68,6 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 **Descriptions**
 
 - <span class="badge badge-warning">warning</span> frontend: 2%+ hard timeout search responses every 5m for 15m0s
-- <span class="badge badge-critical">critical</span> frontend: 5%+ hard timeout search responses every 5m for 15m0s
 
 **Possible solutions**
 
@@ -77,8 +76,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 ```json
 "observability.silenceAlerts": [
-  "warning_frontend_hard_timeout_search_responses",
-  "critical_frontend_hard_timeout_search_responses"
+  "warning_frontend_hard_timeout_search_responses"
 ]
 ```
 
@@ -93,7 +91,6 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 **Descriptions**
 
 - <span class="badge badge-warning">warning</span> frontend: 2%+ hard error search responses every 5m for 15m0s
-- <span class="badge badge-critical">critical</span> frontend: 5%+ hard error search responses every 5m for 15m0s
 
 **Possible solutions**
 
@@ -102,8 +99,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 ```json
 "observability.silenceAlerts": [
-  "warning_frontend_hard_error_search_responses",
-  "critical_frontend_hard_error_search_responses"
+  "warning_frontend_hard_error_search_responses"
 ]
 ```
 
@@ -273,7 +269,6 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 **Descriptions**
 
 - <span class="badge badge-warning">warning</span> frontend: 2%+ hard timeout search code-intel responses every 5m for 15m0s
-- <span class="badge badge-critical">critical</span> frontend: 5%+ hard timeout search code-intel responses every 5m for 15m0s
 
 **Possible solutions**
 
@@ -282,8 +277,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 ```json
 "observability.silenceAlerts": [
-  "warning_frontend_hard_timeout_search_codeintel_responses",
-  "critical_frontend_hard_timeout_search_codeintel_responses"
+  "warning_frontend_hard_timeout_search_codeintel_responses"
 ]
 ```
 
@@ -298,7 +292,6 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 **Descriptions**
 
 - <span class="badge badge-warning">warning</span> frontend: 2%+ hard error search code-intel responses every 5m for 15m0s
-- <span class="badge badge-critical">critical</span> frontend: 5%+ hard error search code-intel responses every 5m for 15m0s
 
 **Possible solutions**
 
@@ -307,8 +300,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 ```json
 "observability.silenceAlerts": [
-  "warning_frontend_hard_error_search_codeintel_responses",
-  "critical_frontend_hard_error_search_codeintel_responses"
+  "warning_frontend_hard_error_search_codeintel_responses"
 ]
 ```
 
@@ -424,7 +416,6 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 **Descriptions**
 
 - <span class="badge badge-warning">warning</span> frontend: 2%+ hard error search API responses every 5m for 15m0s
-- <span class="badge badge-critical">critical</span> frontend: 5%+ hard error search API responses every 5m for 15m0s
 
 **Possible solutions**
 
@@ -433,8 +424,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 ```json
 "observability.silenceAlerts": [
-  "warning_frontend_hard_error_search_api_responses",
-  "critical_frontend_hard_error_search_api_responses"
+  "warning_frontend_hard_error_search_api_responses"
 ]
 ```
 
@@ -939,6 +929,8 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 **Possible solutions**
 
+- Determine if the pod was OOM killed using `kubectl describe pod (frontend|sourcegraph-frontend)` (look for `OOMKilled: true`) and, if so, consider increasing the memory limit in the relevant `Deployment.yaml`.
+- Check the logs before the container restarted to see if there are `panic:` messages or similar using `kubectl logs -p (frontend|sourcegraph-frontend)`.
 - Learn more about the related dashboard panel in the [dashboards reference](./dashboards.md#frontend-pods-available-percentage).
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
@@ -1407,6 +1399,8 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 **Possible solutions**
 
+- Determine if the pod was OOM killed using `kubectl describe pod gitserver` (look for `OOMKilled: true`) and, if so, consider increasing the memory limit in the relevant `Deployment.yaml`.
+- Check the logs before the container restarted to see if there are `panic:` messages or similar using `kubectl logs -p gitserver`.
 - Learn more about the related dashboard panel in the [dashboards reference](./dashboards.md#gitserver-pods-available-percentage).
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
@@ -1676,6 +1670,8 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 **Possible solutions**
 
+- Determine if the pod was OOM killed using `kubectl describe pod github-proxy` (look for `OOMKilled: true`) and, if so, consider increasing the memory limit in the relevant `Deployment.yaml`.
+- Check the logs before the container restarted to see if there are `panic:` messages or similar using `kubectl logs -p github-proxy`.
 - Learn more about the related dashboard panel in the [dashboards reference](./dashboards.md#github-proxy-pods-available-percentage).
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
@@ -1745,7 +1741,6 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 **Descriptions**
 
 - <span class="badge badge-warning">warning</span> postgres: 0.3s+ maximum transaction durations for 5m0s
-- <span class="badge badge-critical">critical</span> postgres: 0.5s+ maximum transaction durations for 10m0s
 
 **Possible solutions**
 
@@ -1754,8 +1749,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 ```json
 "observability.silenceAlerts": [
-  "warning_postgres_transaction_durations",
-  "critical_postgres_transaction_durations"
+  "warning_postgres_transaction_durations"
 ]
 ```
 
@@ -1773,6 +1767,12 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 **Possible solutions**
 
+- **Kubernetes:**
+	- Determine if the pod was OOM killed using `kubectl describe pod {{CONTAINER_NAME}}` (look for `OOMKilled: true`) and, if so, consider increasing the memory limit in the relevant `Deployment.yaml`.
+	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `kubectl logs -p {{CONTAINER_NAME}}`.
+- **Docker Compose:**
+	- Determine if the pod was OOM killed using `docker inspect -f '{{json .State}}' {{CONTAINER_NAME}}` (look for `"OOMKilled":true`) and, if so, consider increasing the memory limit of the {{CONTAINER_NAME}} container in `docker-compose.yml`.
+	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `docker logs {{CONTAINER_NAME}}` (note this will include logs from the previous and currently running container).
 - More help interpreting this metric is available in the [dashboards reference](./dashboards.md#postgres-postgres-up).
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
@@ -1993,6 +1993,8 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 **Possible solutions**
 
+- Determine if the pod was OOM killed using `kubectl describe pod (pgsql|codeintel-db|codeinsights)` (look for `OOMKilled: true`) and, if so, consider increasing the memory limit in the relevant `Deployment.yaml`.
+- Check the logs before the container restarted to see if there are `panic:` messages or similar using `kubectl logs -p (pgsql|codeintel-db|codeinsights)`.
 - Learn more about the related dashboard panel in the [dashboards reference](./dashboards.md#postgres-pods-available-percentage).
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
@@ -2320,6 +2322,8 @@ count being required for the volume of uploads.
 
 **Possible solutions**
 
+- Determine if the pod was OOM killed using `kubectl describe pod precise-code-intel-worker` (look for `OOMKilled: true`) and, if so, consider increasing the memory limit in the relevant `Deployment.yaml`.
+- Check the logs before the container restarted to see if there are `panic:` messages or similar using `kubectl logs -p precise-code-intel-worker`.
 - Learn more about the related dashboard panel in the [dashboards reference](./dashboards.md#precise-code-intel-worker-pods-available-percentage).
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
@@ -2641,6 +2645,8 @@ count being required for the volume of uploads.
 
 **Possible solutions**
 
+- Determine if the pod was OOM killed using `kubectl describe pod redis-cache` (look for `OOMKilled: true`) and, if so, consider increasing the memory limit in the relevant `Deployment.yaml`.
+- Check the logs before the container restarted to see if there are `panic:` messages or similar using `kubectl logs -p redis-cache`.
 - Learn more about the related dashboard panel in the [dashboards reference](./dashboards.md#redis-pods-available-percentage).
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
@@ -2664,6 +2670,8 @@ count being required for the volume of uploads.
 
 **Possible solutions**
 
+- Determine if the pod was OOM killed using `kubectl describe pod redis-store` (look for `OOMKilled: true`) and, if so, consider increasing the memory limit in the relevant `Deployment.yaml`.
+- Check the logs before the container restarted to see if there are `panic:` messages or similar using `kubectl logs -p redis-store`.
 - Learn more about the related dashboard panel in the [dashboards reference](./dashboards.md#redis-pods-available-percentage).
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
@@ -3101,6 +3109,8 @@ an underprovisioned main postgres instance.
 
 **Possible solutions**
 
+- Determine if the pod was OOM killed using `kubectl describe pod worker` (look for `OOMKilled: true`) and, if so, consider increasing the memory limit in the relevant `Deployment.yaml`.
+- Check the logs before the container restarted to see if there are `panic:` messages or similar using `kubectl logs -p worker`.
 - Learn more about the related dashboard panel in the [dashboards reference](./dashboards.md#worker-pods-available-percentage).
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
@@ -4166,6 +4176,8 @@ with your code hosts connections or networking issues affecting communication wi
 
 **Possible solutions**
 
+- Determine if the pod was OOM killed using `kubectl describe pod repo-updater` (look for `OOMKilled: true`) and, if so, consider increasing the memory limit in the relevant `Deployment.yaml`.
+- Check the logs before the container restarted to see if there are `panic:` messages or similar using `kubectl logs -p repo-updater`.
 - Learn more about the related dashboard panel in the [dashboards reference](./dashboards.md#repo-updater-pods-available-percentage).
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
@@ -4513,6 +4525,8 @@ with your code hosts connections or networking issues affecting communication wi
 
 **Possible solutions**
 
+- Determine if the pod was OOM killed using `kubectl describe pod searcher` (look for `OOMKilled: true`) and, if so, consider increasing the memory limit in the relevant `Deployment.yaml`.
+- Check the logs before the container restarted to see if there are `panic:` messages or similar using `kubectl logs -p searcher`.
 - Learn more about the related dashboard panel in the [dashboards reference](./dashboards.md#searcher-pods-available-percentage).
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
@@ -4787,6 +4801,8 @@ with your code hosts connections or networking issues affecting communication wi
 
 **Possible solutions**
 
+- Determine if the pod was OOM killed using `kubectl describe pod symbols` (look for `OOMKilled: true`) and, if so, consider increasing the memory limit in the relevant `Deployment.yaml`.
+- Check the logs before the container restarted to see if there are `panic:` messages or similar using `kubectl logs -p symbols`.
 - Learn more about the related dashboard panel in the [dashboards reference](./dashboards.md#symbols-pods-available-percentage).
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
@@ -4985,6 +5001,8 @@ with your code hosts connections or networking issues affecting communication wi
 
 **Possible solutions**
 
+- Determine if the pod was OOM killed using `kubectl describe pod syntect-server` (look for `OOMKilled: true`) and, if so, consider increasing the memory limit in the relevant `Deployment.yaml`.
+- Check the logs before the container restarted to see if there are `panic:` messages or similar using `kubectl logs -p syntect-server`.
 - Learn more about the related dashboard panel in the [dashboards reference](./dashboards.md#syntect-server-pods-available-percentage).
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
@@ -5005,7 +5023,6 @@ with your code hosts connections or networking issues affecting communication wi
 **Descriptions**
 
 - <span class="badge badge-warning">warning</span> zoekt: 15s+ average resolve revision duration over 5m
-- <span class="badge badge-critical">critical</span> zoekt: 30s+ average resolve revision duration over 5m
 
 **Possible solutions**
 
@@ -5014,8 +5031,7 @@ with your code hosts connections or networking issues affecting communication wi
 
 ```json
 "observability.silenceAlerts": [
-  "warning_zoekt_average_resolve_revision_duration",
-  "critical_zoekt_average_resolve_revision_duration"
+  "warning_zoekt_average_resolve_revision_duration"
 ]
 ```
 
@@ -5434,6 +5450,8 @@ with your code hosts connections or networking issues affecting communication wi
 
 **Possible solutions**
 
+- Determine if the pod was OOM killed using `kubectl describe pod indexed-search` (look for `OOMKilled: true`) and, if so, consider increasing the memory limit in the relevant `Deployment.yaml`.
+- Check the logs before the container restarted to see if there are `panic:` messages or similar using `kubectl logs -p indexed-search`.
 - Learn more about the related dashboard panel in the [dashboards reference](./dashboards.md#zoekt-pods-available-percentage).
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
@@ -5856,6 +5874,8 @@ with your code hosts connections or networking issues affecting communication wi
 
 **Possible solutions**
 
+- Determine if the pod was OOM killed using `kubectl describe pod prometheus` (look for `OOMKilled: true`) and, if so, consider increasing the memory limit in the relevant `Deployment.yaml`.
+- Check the logs before the container restarted to see if there are `panic:` messages or similar using `kubectl logs -p prometheus`.
 - Learn more about the related dashboard panel in the [dashboards reference](./dashboards.md#prometheus-pods-available-percentage).
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 

--- a/doc/admin/observability/alert_solutions.md
+++ b/doc/admin/observability/alert_solutions.md
@@ -1768,11 +1768,15 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 **Possible solutions**
 
 - **Kubernetes:**
-	- Determine if the pod was OOM killed using `kubectl describe pod {{CONTAINER_NAME}}` (look for `OOMKilled: true`) and, if so, consider increasing the memory limit in the relevant `Deployment.yaml`.
-	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `kubectl logs -p {{CONTAINER_NAME}}`.
+	- Determine if the pod was OOM killed using `kubectl describe pod (pgsql|codeintel-db|codeinsights)` (look for `OOMKilled: true`) and, if so, consider increasing the memory limit in the relevant `Deployment.yaml`.
+	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `kubectl logs -p (pgsql|codeintel-db|codeinsights)`.
+	- Check if there is any OOMKILL event using the provisioning panels
+	- Check kernel logs using `dmesg` for OOMKILL events on worker nodes
 - **Docker Compose:**
-	- Determine if the pod was OOM killed using `docker inspect -f '{{json .State}}' {{CONTAINER_NAME}}` (look for `"OOMKilled":true`) and, if so, consider increasing the memory limit of the {{CONTAINER_NAME}} container in `docker-compose.yml`.
-	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `docker logs {{CONTAINER_NAME}}` (note this will include logs from the previous and currently running container).
+	- Determine if the pod was OOM killed using `docker inspect -f '{{json .State}}' (pgsql|codeintel-db|codeinsights)` (look for `"OOMKilled":true`) and, if so, consider increasing the memory limit of the (pgsql|codeintel-db|codeinsights) container in `docker-compose.yml`.
+	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `docker logs (pgsql|codeintel-db|codeinsights)` (note this will include logs from the previous and currently running container).
+	- Check if there is any OOMKILL event using the provisioning panels
+	- Check kernel logs using `dmesg` for OOMKILL events
 - More help interpreting this metric is available in the [dashboards reference](./dashboards.md#postgres-postgres-up).
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 

--- a/doc/admin/observability/alerting.md
+++ b/doc/admin/observability/alerting.md
@@ -6,7 +6,7 @@ Alerts can be configured to notify site admins when there is something wrong or 
 
 Alerts fall in one of two severity levels:
 
-- <span class="badge badge-critical">critical</span>: something is _definitively_ wrong with Sourcegraph. We suggest using a high-visibility notification channel for these alerts.
+- <span class="badge badge-critical">critical</span>: something is _definitively_ wrong with Sourcegraph, in a way that is very likely to be noticeable to users. We suggest using a high-visibility notification channel for these alerts.
   - **Examples:** Database inaccessible, running out of disk space, running out of memory.
   - **Suggested action:** Page a site administrator to investigate.
 - <span class="badge badge-warning">warning</span>: something _could_ be wrong with Sourcegraph. We suggest checking in on these periodically, or using a notification channel that will not bother anyone if it is spammed. Over time, as warning alerts become stable and reliable across many Sourcegraph deployments, they will also be promoted to critical alerts in an update by Sourcegraph.

--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -56,7 +56,7 @@ Query: `histogram_quantile(0.90, sum by (le)(rate(src_search_streaming_latency_s
 
 <p class="subtitle">Hard timeout search responses every 5m</p>
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-hard-timeout-search-responses) for 2 alerts related to this panel.
+Refer to the [alert solutions reference](./alert_solutions.md#frontend-hard-timeout-search-responses) for 1 alert related to this panel.
 
 To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=100010` on your Sourcegraph instance.
 
@@ -75,7 +75,7 @@ Query: `(sum(increase(src_graphql_search_response{status="timeout",source="brows
 
 <p class="subtitle">Hard error search responses every 5m</p>
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-hard-error-search-responses) for 2 alerts related to this panel.
+Refer to the [alert solutions reference](./alert_solutions.md#frontend-hard-error-search-responses) for 1 alert related to this panel.
 
 To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=100011` on your Sourcegraph instance.
 
@@ -212,7 +212,7 @@ Query: `histogram_quantile(0.90, sum by (le)(rate(src_graphql_field_seconds_buck
 
 <p class="subtitle">Hard timeout search code-intel responses every 5m</p>
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-hard-timeout-search-codeintel-responses) for 2 alerts related to this panel.
+Refer to the [alert solutions reference](./alert_solutions.md#frontend-hard-timeout-search-codeintel-responses) for 1 alert related to this panel.
 
 To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=100110` on your Sourcegraph instance.
 
@@ -231,7 +231,7 @@ Query: `(sum(increase(src_graphql_search_response{status="timeout",source="brows
 
 <p class="subtitle">Hard error search code-intel responses every 5m</p>
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-hard-error-search-codeintel-responses) for 2 alerts related to this panel.
+Refer to the [alert solutions reference](./alert_solutions.md#frontend-hard-error-search-codeintel-responses) for 1 alert related to this panel.
 
 To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=100111` on your Sourcegraph instance.
 
@@ -328,7 +328,7 @@ Query: `histogram_quantile(0.90, sum by (le)(rate(src_graphql_field_seconds_buck
 
 <p class="subtitle">Hard error search API responses every 5m</p>
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-hard-error-search-api-responses) for 2 alerts related to this panel.
+Refer to the [alert solutions reference](./alert_solutions.md#frontend-hard-error-search-api-responses) for 1 alert related to this panel.
 
 To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=100210` on your Sourcegraph instance.
 
@@ -6012,7 +6012,7 @@ Query: `sum(pg_stat_activity_count) by (job) / (sum(pg_settings_max_connections)
 
 <p class="subtitle">Maximum transaction durations</p>
 
-Refer to the [alert solutions reference](./alert_solutions.md#postgres-transaction-durations) for 2 alerts related to this panel.
+Refer to the [alert solutions reference](./alert_solutions.md#postgres-transaction-durations) for 1 alert related to this panel.
 
 To see this panel, visit `/-/debug/grafana/d/postgres/postgres?viewPanel=100002` on your Sourcegraph instance.
 
@@ -14746,7 +14746,7 @@ Query: `sum by (instance) (increase(index_num_stopped_tracking_total{instance=~`
 
 <p class="subtitle">Average resolve revision duration over 5m</p>
 
-Refer to the [alert solutions reference](./alert_solutions.md#zoekt-average-resolve-revision-duration) for 2 alerts related to this panel.
+Refer to the [alert solutions reference](./alert_solutions.md#zoekt-average-resolve-revision-duration) for 1 alert related to this panel.
 
 To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100020` on your Sourcegraph instance.
 

--- a/monitoring/definitions/frontend.go
+++ b/monitoring/definitions/frontend.go
@@ -93,7 +93,6 @@ func Frontend() *monitoring.Dashboard {
 							Query:       `(sum(increase(src_graphql_search_response{status="timeout",source="browser",request_name!="CodeIntelSearch"}[5m])) + sum(increase(src_graphql_search_response{status="alert",alert_type="timed_out",source="browser",request_name!="CodeIntelSearch"}[5m]))) / sum(increase(src_graphql_search_response{source="browser",request_name!="CodeIntelSearch"}[5m])) * 100`,
 
 							Warning:           monitoring.Alert().GreaterOrEqual(2).For(15 * time.Minute),
-							Critical:          monitoring.Alert().GreaterOrEqual(5).For(15 * time.Minute),
 							Panel:             monitoring.Panel().LegendFormat("hard timeout").Unit(monitoring.Percentage),
 							Owner:             monitoring.ObservableOwnerSearch,
 							PossibleSolutions: "none",
@@ -104,7 +103,6 @@ func Frontend() *monitoring.Dashboard {
 							Query:       `sum by (status)(increase(src_graphql_search_response{status=~"error",source="browser",request_name!="CodeIntelSearch"}[5m])) / ignoring(status) group_left sum(increase(src_graphql_search_response{source="browser",request_name!="CodeIntelSearch"}[5m])) * 100`,
 
 							Warning:           monitoring.Alert().GreaterOrEqual(2).For(15 * time.Minute),
-							Critical:          monitoring.Alert().GreaterOrEqual(5).For(15 * time.Minute),
 							Panel:             monitoring.Panel().LegendFormat("{{status}}").Unit(monitoring.Percentage),
 							Owner:             monitoring.ObservableOwnerSearch,
 							PossibleSolutions: "none",
@@ -211,7 +209,6 @@ func Frontend() *monitoring.Dashboard {
 							Query:       `(sum(increase(src_graphql_search_response{status="timeout",source="browser",request_name="CodeIntelSearch"}[5m])) + sum(increase(src_graphql_search_response{status="alert",alert_type="timed_out",source="browser",request_name="CodeIntelSearch"}[5m]))) / sum(increase(src_graphql_search_response{source="browser",request_name="CodeIntelSearch"}[5m])) * 100`,
 
 							Warning:           monitoring.Alert().GreaterOrEqual(2).For(15 * time.Minute),
-							Critical:          monitoring.Alert().GreaterOrEqual(5).For(15 * time.Minute),
 							Panel:             monitoring.Panel().LegendFormat("hard timeout").Unit(monitoring.Percentage),
 							Owner:             monitoring.ObservableOwnerSearch,
 							PossibleSolutions: "none",
@@ -222,7 +219,6 @@ func Frontend() *monitoring.Dashboard {
 							Query:       `sum by (status)(increase(src_graphql_search_response{status=~"error",source="browser",request_name="CodeIntelSearch"}[5m])) / ignoring(status) group_left sum(increase(src_graphql_search_response{source="browser",request_name="CodeIntelSearch"}[5m])) * 100`,
 
 							Warning:           monitoring.Alert().GreaterOrEqual(2).For(15 * time.Minute),
-							Critical:          monitoring.Alert().GreaterOrEqual(5).For(15 * time.Minute),
 							Panel:             monitoring.Panel().LegendFormat("hard error").Unit(monitoring.Percentage),
 							Owner:             monitoring.ObservableOwnerSearch,
 							PossibleSolutions: "none",
@@ -295,7 +291,6 @@ func Frontend() *monitoring.Dashboard {
 							Query:       `sum by (status)(increase(src_graphql_search_response{status=~"error",source="other"}[5m])) / ignoring(status) group_left sum(increase(src_graphql_search_response{source="other"}[5m]))`,
 
 							Warning:           monitoring.Alert().GreaterOrEqual(2).For(15 * time.Minute),
-							Critical:          monitoring.Alert().GreaterOrEqual(5).For(15 * time.Minute),
 							Panel:             monitoring.Panel().LegendFormat("{{status}}").Unit(monitoring.Percentage),
 							Owner:             monitoring.ObservableOwnerSearch,
 							PossibleSolutions: "none",

--- a/monitoring/definitions/postgres.go
+++ b/monitoring/definitions/postgres.go
@@ -84,6 +84,8 @@ func Postgres() *monitoring.Dashboard {
 								- **Docker Compose:**
 									- Determine if the pod was OOM killed using 'docker inspect -f \'{{json .State}}\' %[1]s' (look for '"OOMKilled":true') and, if so, consider increasing the memory limit of the %[1]s container in 'docker-compose.yml'.
 									- Check the logs before the container restarted to see if there are 'panic:' messages or similar using 'docker logs %[1]s' (note this will include logs from the previous and currently running container).
+									- Check if there is any OOMKILL event using the provisioning panels
+									- Check kernel logs using `dmesg` for OOMKILL events
 							`, "{{CONTAINER_NAME}}", containerName),
 							Interpretation: "A non-zero value indicates the database is online.",
 						},

--- a/monitoring/definitions/postgres.go
+++ b/monitoring/definitions/postgres.go
@@ -80,13 +80,13 @@ func Postgres() *monitoring.Dashboard {
 									- Determine if the pod was OOM killed using 'kubectl describe pod %[1]s' (look for 'OOMKilled: true') and, if so, consider increasing the memory limit in the relevant 'Deployment.yaml'.
 									- Check the logs before the container restarted to see if there are 'panic:' messages or similar using 'kubectl logs -p %[1]s'.
 									- Check if there is any OOMKILL event using the provisioning panels
-									- Check kernel logs using `dmesg` for OOMKILL events on worker nodes
+									- Check kernel logs using 'dmesg' for OOMKILL events on worker nodes
 								- **Docker Compose:**
 									- Determine if the pod was OOM killed using 'docker inspect -f \'{{json .State}}\' %[1]s' (look for '"OOMKilled":true') and, if so, consider increasing the memory limit of the %[1]s container in 'docker-compose.yml'.
 									- Check the logs before the container restarted to see if there are 'panic:' messages or similar using 'docker logs %[1]s' (note this will include logs from the previous and currently running container).
 									- Check if there is any OOMKILL event using the provisioning panels
-									- Check kernel logs using `dmesg` for OOMKILL events
-							`, "{{CONTAINER_NAME}}", containerName),
+									- Check kernel logs using 'dmesg' for OOMKILL events
+							`, containerName),
 							Interpretation: "A non-zero value indicates the database is online.",
 						},
 						monitoring.Observable{

--- a/monitoring/definitions/postgres.go
+++ b/monitoring/definitions/postgres.go
@@ -79,6 +79,8 @@ func Postgres() *monitoring.Dashboard {
 								- **Kubernetes:**
 									- Determine if the pod was OOM killed using 'kubectl describe pod %[1]s' (look for 'OOMKilled: true') and, if so, consider increasing the memory limit in the relevant 'Deployment.yaml'.
 									- Check the logs before the container restarted to see if there are 'panic:' messages or similar using 'kubectl logs -p %[1]s'.
+									- Check if there is any OOMKILL event using the provisioning panels
+									- Check kernel logs using `dmesg` for OOMKILL events on worker nodes
 								- **Docker Compose:**
 									- Determine if the pod was OOM killed using 'docker inspect -f \'{{json .State}}\' %[1]s' (look for '"OOMKilled":true') and, if so, consider increasing the memory limit of the %[1]s container in 'docker-compose.yml'.
 									- Check the logs before the container restarted to see if there are 'panic:' messages or similar using 'docker logs %[1]s' (note this will include logs from the previous and currently running container).

--- a/monitoring/definitions/postgres.go
+++ b/monitoring/definitions/postgres.go
@@ -1,6 +1,7 @@
 package definitions
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/sourcegraph/sourcegraph/monitoring/definitions/shared"
@@ -55,7 +56,6 @@ func Postgres() *monitoring.Dashboard {
 						Query:             `sum by (job) (pg_stat_activity_max_tx_duration{datname!~"template.*|postgres|cloudsqladmin"}) OR sum by (job) (pg_stat_activity_max_tx_duration{job="codeinsights-db", datname!~"template.*|cloudsqladmin"})`,
 						Panel:             monitoring.Panel().LegendFormat("{{datname}}").Unit(monitoring.Seconds),
 						Warning:           monitoring.Alert().GreaterOrEqual(0.3).For(5 * time.Minute),
-						Critical:          monitoring.Alert().GreaterOrEqual(0.5).For(10 * time.Minute),
 						PossibleSolutions: "none",
 					},
 				},
@@ -67,15 +67,23 @@ func Postgres() *monitoring.Dashboard {
 				Rows: []monitoring.Row{
 					{
 						monitoring.Observable{
-							Name:              "postgres_up",
-							Description:       "database availability",
-							Owner:             monitoring.ObservableOwnerDevOps,
-							DataMustExist:     false, // not deployed on docker-compose
-							Query:             "pg_up",
-							Panel:             monitoring.Panel().LegendFormat("{{app}}"),
-							Critical:          monitoring.Alert().LessOrEqual(0).For(5 * time.Minute),
-							PossibleSolutions: "none",
-							Interpretation:    "A non-zero value indicates the database is online.",
+							Name:          "postgres_up",
+							Description:   "database availability",
+							Owner:         monitoring.ObservableOwnerDevOps,
+							DataMustExist: false, // not deployed on docker-compose
+							Query:         "pg_up",
+							Panel:         monitoring.Panel().LegendFormat("{{app}}"),
+							Critical:      monitoring.Alert().LessOrEqual(0).For(5 * time.Minute),
+							// Similar to ContainerMissing solutions
+							PossibleSolutions: fmt.Sprintf(`
+								- **Kubernetes:**
+									- Determine if the pod was OOM killed using 'kubectl describe pod %[1]s' (look for 'OOMKilled: true') and, if so, consider increasing the memory limit in the relevant 'Deployment.yaml'.
+									- Check the logs before the container restarted to see if there are 'panic:' messages or similar using 'kubectl logs -p %[1]s'.
+								- **Docker Compose:**
+									- Determine if the pod was OOM killed using 'docker inspect -f \'{{json .State}}\' %[1]s' (look for '"OOMKilled":true') and, if so, consider increasing the memory limit of the %[1]s container in 'docker-compose.yml'.
+									- Check the logs before the container restarted to see if there are 'panic:' messages or similar using 'docker logs %[1]s' (note this will include logs from the previous and currently running container).
+							`, "{{CONTAINER_NAME}}", containerName),
+							Interpretation: "A non-zero value indicates the database is online.",
 						},
 						monitoring.Observable{
 							Name:          "invalid_indexes",

--- a/monitoring/definitions/shared/kubernetes.go
+++ b/monitoring/definitions/shared/kubernetes.go
@@ -19,11 +19,15 @@ var (
 			Name:        "pods_available_percentage",
 			Description: "percentage pods available",
 			// the 'app' label is only available in Kubernetes deloyments - it indicates the pod.
-			Query:             fmt.Sprintf(`sum by(app) (up{app=~".*%[1]s"}) / count by (app) (up{app=~".*%[1]s"}) * 100`, containerName),
-			Critical:          monitoring.Alert().LessOrEqual(90).For(10 * time.Minute),
-			Panel:             monitoring.Panel().LegendFormat("{{name}}").Unit(monitoring.Percentage).Max(100).Min(0),
-			Owner:             owner,
-			PossibleSolutions: "none",
+			Query:    fmt.Sprintf(`sum by(app) (up{app=~".*%[1]s"}) / count by (app) (up{app=~".*%[1]s"}) * 100`, containerName),
+			Critical: monitoring.Alert().LessOrEqual(90).For(10 * time.Minute),
+			Panel:    monitoring.Panel().LegendFormat("{{name}}").Unit(monitoring.Percentage).Max(100).Min(0),
+			Owner:    owner,
+			// Solutions similar to the ContainerMissing solutions.
+			PossibleSolutions: fmt.Sprintf(`
+				- Determine if the pod was OOM killed using 'kubectl describe pod %[1]s' (look for 'OOMKilled: true') and, if so, consider increasing the memory limit in the relevant 'Deployment.yaml'.
+				- Check the logs before the container restarted to see if there are 'panic:' messages or similar using 'kubectl logs -p %[1]s'.
+			`, containerName),
 		}
 	}
 )

--- a/monitoring/definitions/zoekt.go
+++ b/monitoring/definitions/zoekt.go
@@ -132,7 +132,6 @@ func Zoekt() *monitoring.Dashboard {
 							Description:       "average resolve revision duration over 5m",
 							Query:             `sum(rate(resolve_revision_seconds_sum[5m])) / sum(rate(resolve_revision_seconds_count[5m]))`,
 							Warning:           monitoring.Alert().GreaterOrEqual(15),
-							Critical:          monitoring.Alert().GreaterOrEqual(30),
 							Panel:             monitoring.Panel().LegendFormat("{{duration}}").Unit(monitoring.Seconds),
 							Owner:             monitoring.ObservableOwnerSearchCore,
 							PossibleSolutions: "none",

--- a/monitoring/monitoring/monitoring.go
+++ b/monitoring/monitoring/monitoring.go
@@ -703,15 +703,26 @@ type Observable struct {
 	// would not want an alert to fire if no data was present, so this will not need to be set.
 	DataMustExist bool
 
-	// Warning and Critical alert definitions.
-	// Consider adding at least a Warning or Critical alert to each Observable to make it
-	// easy to identify when the target of this metric is misbehaving. If no alerts are
-	// provided, NoAlert must be set and Interpretation must be provided.
-	Warning, Critical *ObservableAlertDefinition
+	// Warning alerts indicate that something *could* be wrong with Sourcegraph. We
+	// suggest checking in on these periodically, or using a notification channel that
+	// will not bother anyone if it is spammed.
+	//
+	// Learn more about how alerting is used: https://docs.sourcegraph.com/admin/observability/alerting
+	Warning *ObservableAlertDefinition
 
-	// NoAlerts must be set by Observables that do not have any alerts.
-	// This ensures the omission of alerts is intentional. If set to true, an Interpretation
-	// must be provided in place of PossibleSolutions.
+	// Critical alerts indicate that something is definitively wrong with Sourcegraph,
+	// in a way that is very likely to be noticeable to users. We suggest using a
+	// high-visibility notification channel, such as paging, for these alerts.
+	//
+	// Learn more about how alerting is used: https://docs.sourcegraph.com/admin/observability/alerting
+	Critical *ObservableAlertDefinition
+
+	// NoAlerts must be set by Observables that do not have any alerts. This ensures the
+	// omission of alerts is intentional. If set to true, an Interpretation must be
+	// provided in place of PossibleSolutions.
+	//
+	// Consider adding at least a Warning or Critical alert to each Observable to make it
+	// easy to identify when the target of this metric is misbehaving.
 	NoAlert bool
 
 	// PossibleSolutions is Markdown describing possible solutions in the event that the


### PR DESCRIPTION
This proposal arises from a discussion I had with @michaellzc today regarding https://github.com/sourcegraph/sourcegraph/pull/36321 , the motivation for which is basically "most critical alerts are not useful, because they are unactionable with unhelpful documentation". I think this points to a **very** serious issue with our critical alerts today - not only can they be noisy, but many do not provide site admins like @michaellzc and the DevOps team with any useful action to take, or indicate how to debug these critical alerts, to the point of one such admin deciding it is easier to [build an entire new feature for allow-listing certain alerts](https://github.com/sourcegraph/sourcegraph/pull/36321) rather than be paged night and day. The severity of a critical alert is already [outlined in our documentation](https://docs.sourcegraph.com/admin/observability/alerting):

> critical: something is _definitively_ wrong with Sourcegraph. We suggest using a high-visibility notification channel for these alerts.

When we add a critical alert, we are basically saying that we would be willing to page Sourcegraph admins from every customer if this alert goes off. IMO a reasonable expectation of adding a critical alert should be a robust debugging path for how to deal with this critical alert. Not only is this a better experience for customers, but it is useful for growing our teams as new members onboard and take on-call rotations. 

The proposal: **forbid critical alerts from being defined without any `PossibleSolutions` provided, and remove all critical alerts that currently do not have any `PossibleSolutions` defined.** Additionally, as follow-ups:

- we will [rebrand `PossibleSolutions` as `NextSteps`](https://github.com/sourcegraph/sourcegraph/pull/36423#issuecomment-1144405422) to lower the bar for this field (the instructions don't need to provide an immediate *solution*, just guide the next steps once an alert is received)
- check in with DevOps to identify other problematic critical alerts they have encountered: https://github.com/sourcegraph/sourcegraph/issues/36434

This PR adds the above restriction as a hard requirement within the generator, and fixes all the outstanding issues:

- Add `PossibleSolutions` for the `pods_available_percentage` and `pg_up`  critical alerts (we have a similar solution doc in the `container_missing` alert)
- Removes all the other critical alerts without possible solutions

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Eventually, `go generate ./monitoring` should pass.