### PR TITLE
dev/ci: run docker-images builds if docker-images has been changed

### DIFF
--- a/doc/dev/background-information/ci/reference.md
+++ b/doc/dev/background-information/ci/reference.md
@@ -20,10 +20,10 @@ The default run type.
   - Upload build trace
 
 - Pipeline for `Client` changes:
-  - **Pipeline setup**: Trigger async
-  - Client PR preview
   - **Linters and static analysis**: Prettier, Run sg lint
   - **Client checks**: Puppeteer tests prep, Puppeteer tests for chrome extension, Puppeteer tests chunk #1, Puppeteer tests chunk #2, Puppeteer tests chunk #3, Puppeteer tests chunk #4, Puppeteer tests chunk #5, Puppeteer tests chunk #6, Puppeteer tests chunk #7, Puppeteer tests chunk #8, Puppeteer tests chunk #9, Puppeteer tests chunk #10, Upload Storybook to Chromatic, Test (all), Build, Enterprise build, Test (client/web), Test (client/browser), Test (client/jetbrains), Build TS, ESLint (all), Stylelint (all)
+  - **Pipeline setup**: Trigger async
+  - Client PR preview
   - Upload build trace
 
 - Pipeline for `GraphQL` changes:
@@ -64,6 +64,12 @@ The default run type.
 
 - Pipeline for `Shell` changes:
   - **Linters and static analysis**: Prettier, Run sg lint
+  - Upload build trace
+
+- Pipeline for `DockerImages` changes:
+  - **Linters and static analysis**: Prettier
+  - **Test builds**: Build alpine-3.14, Build cadvisor, Build codeinsights-db, Build codeintel-db, Build frontend, Build github-proxy, Build gitserver, Build grafana, Build indexed-searcher, Build jaeger-agent, Build jaeger-all-in-one, Build minio, Build postgres-12-alpine, Build postgres_exporter, Build precise-code-intel-worker, Build prometheus, Build redis-cache, Build redis-store, Build redis_exporter, Build repo-updater, Build search-indexer, Build searcher, Build symbols, Build syntax-highlighter, Build worker, Build migrator, Build server, Build sg
+  - **Scan test builds**: Scan alpine-3.14, Scan cadvisor, Scan codeinsights-db, Scan codeintel-db, Scan frontend, Scan github-proxy, Scan gitserver, Scan grafana, Scan indexed-searcher, Scan jaeger-agent, Scan jaeger-all-in-one, Scan minio, Scan postgres-12-alpine, Scan postgres_exporter, Scan precise-code-intel-worker, Scan prometheus, Scan redis-cache, Scan redis-store, Scan redis_exporter, Scan repo-updater, Scan search-indexer, Scan searcher, Scan symbols, Scan syntax-highlighter, Scan worker, Scan migrator, Scan server, Scan sg
   - Upload build trace
 
 ### Release branch nightly healthcheck build

--- a/docker-images/cadvisor/build.sh
+++ b/docker-images/cadvisor/build.sh
@@ -2,8 +2,6 @@
 cd "$(dirname "${BASH_SOURCE[0]}")"
 set -ex
 
-echo "FOOBAR"
-
 docker build --no-cache -t "${IMAGE:-"sourcegraph/cadvisor"}" . \
   --progress=plain \
   --build-arg COMMIT_SHA \

--- a/docker-images/cadvisor/build.sh
+++ b/docker-images/cadvisor/build.sh
@@ -2,6 +2,8 @@
 cd "$(dirname "${BASH_SOURCE[0]}")"
 set -ex
 
+echo "FOOBAR"
+
 docker build --no-cache -t "${IMAGE:-"sourcegraph/cadvisor"}" . \
   --progress=plain \
   --build-arg COMMIT_SHA \

--- a/enterprise/dev/ci/internal/ci/changed/diff.go
+++ b/enterprise/dev/ci/internal/ci/changed/diff.go
@@ -21,6 +21,7 @@ const (
 	Terraform
 	SVG
 	Shell
+	DockerImages
 
 	// All indicates all changes should be considered included in this diff, except None.
 	All
@@ -126,6 +127,11 @@ func ParseDiff(files []string) (diff Diff) {
 		if strings.HasSuffix(p, ".sh") {
 			diff |= Shell
 		}
+
+		// Affects docker-images directories
+		if strings.HasPrefix(p, "docker-images/") {
+			diff |= DockerImages
+		}
 	}
 	return
 }
@@ -157,6 +163,8 @@ func (d Diff) String() string {
 		return "SVG"
 	case Shell:
 		return "Shell"
+	case DockerImages:
+		return "DockerImages"
 
 	case All:
 		return "All"


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/35969

If a diff in `docker-images` is detected, we run a build of all images. We just build everything for simplicity here - if we change this build to happen via a `sg` command, we can make it diff-based, but these days we intentionally do not make individual changed files available during pipeline generation, so I think this is a reasonable approach.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Generated pipeline reference confirms steps are present.

Test build with `docker-images` diff: https://buildkite.com/sourcegraph/sourcegraph/builds/151260

<img width="1210" alt="image" src="https://user-images.githubusercontent.com/23356519/171521438-20a3efd7-3f48-44cb-8464-b4b3e479a906.png">
