### PR TITLE
dev/sg: add 'sg gen' alias for generate

### DIFF
--- a/dev/sg/sg_generate.go
+++ b/dev/sg/sg_generate.go
@@ -27,6 +27,7 @@ sg --verbose generate ... # Enable verbose output
 `,
 	Usage:       "Run code and docs generation tasks",
 	Description: "If no target is provided, all target are run with default arguments.",
+	Aliases:     []string{"gen"},
 	Category:    CategoryDev,
 	Flags: []cli.Flag{
 		&cli.BoolFlag{


### PR DESCRIPTION
`sg generate go ./foobar` is longer than `go generate ./foobar`, so I'm very uninclined to use it 😛 This PR adds an alias that is more competitive in terms of length: 

```go
sg gen go ./foobar
go generate ./foobar     # this now the longer command!
```

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
<img width="496" alt="image" src="https://user-images.githubusercontent.com/23356519/171521349-2f468cb6-8b47-4178-81fa-0b89aae5c443.png">
