### PR TITLE
web: fix `CommandList` autofocus

### DIFF
--- a/client/shared/src/commandPalette/CommandList.tsx
+++ b/client/shared/src/commandPalette/CommandList.tsx
@@ -92,8 +92,6 @@ interface State {
     /** Recently invoked actions, which should be sorted first in the list. */
     recentActions: string[] | null
 
-    autoFocus?: boolean
-
     settingsCascade?: SettingsCascadeOrError
 }
 
@@ -167,12 +165,6 @@ export class CommandList extends React.PureComponent<CommandListProps, State> {
         this.subscriptions.add(
             this.props.platformContext.settings.subscribe(settingsCascade => this.setState({ settingsCascade }))
         )
-
-        // Only focus input after it has been rendered in the DOM
-        // Workaround for Firefox and Safari where preventScroll isn't compatible
-        setTimeout(() => {
-            this.setState({ autoFocus: true })
-        })
     }
 
     public componentDidUpdate(_previousProps: CommandListProps, previousState: State): void {
@@ -217,11 +209,11 @@ export class CommandList extends React.PureComponent<CommandListProps, State> {
                         </Label>
                         <Input
                             id="command-list-input"
-                            ref={input => input && this.state.autoFocus && input.focus({ preventScroll: true })}
                             inputClassName={this.props.inputClassName}
                             value={this.state.input}
                             placeholder="Run Sourcegraph action..."
                             spellCheck={false}
+                            autoFocus={true}
                             autoCorrect="off"
                             autoComplete="off"
                             onChange={this.onInputChange}

--- a/client/web/src/components/FilteredConnection/ui/ConnectionForm.module.scss
+++ b/client/web/src/components/FilteredConnection/ui/ConnectionForm.module.scss
@@ -1,3 +1,7 @@
 .noncompact {
     margin-bottom: 0.5rem;
 }
+
+.input {
+    width: 100%;
+}

--- a/client/web/src/components/FilteredConnection/ui/ConnectionForm.tsx
+++ b/client/web/src/components/FilteredConnection/ui/ConnectionForm.tsx
@@ -100,7 +100,7 @@ export const ConnectionForm = React.forwardRef<HTMLInputElement, ConnectionFormP
                 )}
                 {!hideSearch && (
                     <Input
-                        className={inputClassName}
+                        className={classNames('w-100', inputClassName)}
                         type="search"
                         placeholder={inputPlaceholder}
                         name="query"

--- a/client/web/src/components/FilteredConnection/ui/ConnectionForm.tsx
+++ b/client/web/src/components/FilteredConnection/ui/ConnectionForm.tsx
@@ -100,7 +100,7 @@ export const ConnectionForm = React.forwardRef<HTMLInputElement, ConnectionFormP
                 )}
                 {!hideSearch && (
                     <Input
-                        className={classNames('w-100', inputClassName)}
+                        className={classNames(styles.input, inputClassName)}
                         type="search"
                         placeholder={inputPlaceholder}
                         name="query"

--- a/client/web/src/repo/releases/__snapshots__/RepositoryReleasesTagsPage.test.tsx.snap
+++ b/client/web/src/repo/releases/__snapshots__/RepositoryReleasesTagsPage.test.tsx.snap
@@ -13,7 +13,7 @@ exports[`RepositoryReleasesTagsPage renders 1`] = `
         class="w-100 d-inline-flex justify-content-between flex-row noncompact"
       >
         <div
-          class="container loader-input loaderInput w-100"
+          class="container loader-input loaderInput input"
         >
           <input
             autocapitalize="off"

--- a/client/web/src/repo/releases/__snapshots__/RepositoryReleasesTagsPage.test.tsx.snap
+++ b/client/web/src/repo/releases/__snapshots__/RepositoryReleasesTagsPage.test.tsx.snap
@@ -13,7 +13,7 @@ exports[`RepositoryReleasesTagsPage renders 1`] = `
         class="w-100 d-inline-flex justify-content-between flex-row noncompact"
       >
         <div
-          class="container loader-input loaderInput"
+          class="container loader-input loaderInput w-100"
         >
           <input
             autocapitalize="off"


### PR DESCRIPTION
## Context

The `CommandList` is not autofocused on mount. Notice the missing focus state on the command input.

<img width="400" alt="Screen Shot 2022-06-02 at 11 07 39" src="https://user-images.githubusercontent.com/3846380/171544637-8ceaa52d-ac9c-41cd-b633-23e5f7d0cfc6.png">

## Test plan

The `CommandList` is autofocused on mount.

<img width="419" alt="Screen Shot 2022-06-02 at 11 08 00" src="https://user-images.githubusercontent.com/3846380/171544661-23794f4d-48bf-4ca7-b253-b98b08f95e80.png">

## App preview:

- [Web](https://sg-web-vb-input-fixes.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-itcnrxwhwr.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
