### PR TITLE
Search backend: use ChunkMatch for unindexed regex search

### DIFF
--- a/cmd/searcher/internal/search/search_regex.go
+++ b/cmd/searcher/internal/search/search_regex.go
@@ -155,7 +155,7 @@ func (rg *readerGrep) matchString(s string) bool {
 // Find returns a LineMatch for each line that matches rg in reader.
 // LimitHit is true if some matches may not have been included in the result.
 // NOTE: This is not safe to use concurrently.
-func (rg *readerGrep) Find(zf *zipFile, f *srcFile, limit int) (matches []protocol.LineMatch, err error) {
+func (rg *readerGrep) Find(zf *zipFile, f *srcFile, limit int) (matches []protocol.ChunkMatch, err error) {
 	// fileMatchBuf is what we run match on, fileBuf is the original
 	// data (for Preview).
 	fileBuf := zf.DataFor(f)
@@ -187,112 +187,87 @@ func (rg *readerGrep) Find(zf *zipFile, f *srcFile, limit int) (matches []protoc
 
 	// find limit+1 matches so we know whether we hit the limit
 	locs := rg.re.FindAllIndex(fileMatchBuf, limit+1)
-	lastStart := 0
-	lastLineNumber := 0
-	lastMatchIndex := 0
-	lastLineStartIndex := 0
-
-	for _, match := range locs {
-		start, end := match[0], match[1]
-		lineStart := lastLineStartIndex
-		if idx := bytes.LastIndex(fileMatchBuf[lastStart:start], []byte{'\n'}); idx >= 0 {
-			lineStart = lastStart + idx + 1
-		}
-		lastLineStartIndex = lineStart
-		lastStart = start
-
-		// lineEnd is the index of the next \n. If the last character of our
-		// match is already a newline, then lineEnd instead points end to
-		// include the newline in the match preview.
-		var lineEnd int
-		if end > 0 && fileMatchBuf[end-1] == '\n' {
-			lineEnd = end // Note: fileMatchBuf[lineEnd] may not be a \n
-		} else if idx := bytes.Index(fileMatchBuf[end:], []byte{'\n'}); idx >= 0 {
-			lineEnd = end + idx
-		} else {
-			lineEnd = len(fileMatchBuf)
-		}
-
-		lineNumber, matchIndex := hydrateLineNumbers(fileMatchBuf, lastLineNumber, lastMatchIndex, lineStart, match)
-
-		lastMatchIndex = matchIndex
-		lastLineNumber = lineNumber
-		matches = appendMatches(matches, fileBuf[lineStart:lineEnd], fileMatchBuf[lineStart:lineEnd], lineNumber, lineStart, start-lineStart, end-lineStart)
-	}
-	return matches, nil
+	ranges := locsToRanges(fileBuf, locs)
+	chunks := chunkRanges(ranges, 0)
+	return rangesToChunkMatches(fileBuf, chunks), nil
 }
 
-func hydrateLineNumbers(fileBuf []byte, lastLineNumber, lastMatchIndex, lineStart int, match []int) (lineNumber, matchIndex int) {
-	lineNumber = lastLineNumber + bytes.Count(fileBuf[lastMatchIndex:match[0]], []byte{'\n'})
-	return lineNumber, lineStart
+// locs must be sorted, non-overlapping, and must be valid slices of buf.
+func locsToRanges(buf []byte, locs [][]int) []protocol.Range {
+	ranges := make([]protocol.Range, 0, len(locs))
+
+	prevEnd := 0
+	prevEndLine := 0
+
+	for _, loc := range locs {
+		start, end := loc[0], loc[1]
+
+		startLine := prevEndLine + bytes.Count(buf[prevEnd:start], []byte{'\n'})
+		endLine := startLine + bytes.Count(buf[start:end], []byte{'\n'})
+
+		firstLineStart := 0
+		if off := bytes.LastIndexByte(buf[:start], '\n'); off >= 0 {
+			firstLineStart = off + 1
+		}
+
+		lastLineStart := firstLineStart
+		if off := bytes.LastIndexByte(buf[:end], '\n'); off >= 0 {
+			lastLineStart = off + 1
+		}
+
+		ranges = append(ranges, protocol.Range{
+			Start: protocol.Location{
+				Offset: int32(start),
+				Line:   int32(startLine),
+				Column: int32(utf8.RuneCount(buf[firstLineStart:start])),
+			},
+			End: protocol.Location{
+				Offset: int32(end),
+				Line:   int32(endLine),
+				Column: int32(utf8.RuneCount(buf[lastLineStart:end])),
+			},
+		})
+
+		prevEnd = end
+		prevEndLine = endLine
+	}
+
+	return ranges
 }
 
-// matchLineBuf is a byte slice that contains the full line(s) that the match appears on.
-func appendMatches(matches []protocol.LineMatch, fileBuf []byte, matchLineBuf []byte, lineNumber, lineOffset, start, end int) []protocol.LineMatch {
-	// If any newlines appear between start and end, we need to append multiple LineMatch.
-	// We assume there are no newlines before start.
-	for len(matchLineBuf) > 0 {
-		var line []byte
-		var eol int
-		if eol = bytes.Index(matchLineBuf[start:], []byte{'\n'}); eol < 0 {
-			line = matchLineBuf
-			matchLineBuf = []byte{}
-		} else {
-			eol += start
-			// start is 0 indexed, so add 1 to include the new line at the end of the line
-			line = matchLineBuf[:eol+1]
-			matchLineBuf = matchLineBuf[eol+1:]
+func rangesToChunkMatches(buf []byte, chunks []rangeChunk) []protocol.ChunkMatch {
+	chunkMatches := make([]protocol.ChunkMatch, 0, len(chunks))
+	for _, chunk := range chunks {
+		firstLineStart := int32(0)
+		if off := bytes.LastIndexByte(buf[:chunk.cover.Start.Offset], '\n'); off >= 0 {
+			firstLineStart = int32(off) + 1
 		}
 
-		e := end
-		if e > len(line) {
-			e = len(line)
+		lastLineEnd := int32(len(buf))
+		if off := bytes.IndexByte(buf[chunk.cover.End.Offset:], '\n'); off >= 0 {
+			lastLineEnd = chunk.cover.End.Offset + int32(off)
 		}
 
-		offset := utf8.RuneCount(line[:start])
-		length := utf8.RuneCount(line[start:e])
-		limit := eol
-		if limit < 0 {
-			limit = len(fileBuf)
-		}
-
-		if n := len(matches); n > 0 && matches[n-1].LineNumber == lineNumber {
-			// If the line number hasn't changed since the last match, append the offsets to that LineMatch.
-			matches[n-1].OffsetAndLengths = append(matches[n-1].OffsetAndLengths, [2]int{offset, length})
-		} else {
-			// If we are appending matches for a new line, create a new LineMatch
-			matches = append(matches, protocol.LineMatch{
-				// we are not allowed to use the fileBuf data after the ZipFile has been Closed,
-				// which currently occurs before Preview has been serialized.
-				// TODO: consider moving the call to Close until after we are
-				// done with Preview, and stop making a copy here.
-				// Special care must be taken to call Close on all possible paths, including error paths.
-				Preview:          string(fileBuf[:limit]),
-				LineNumber:       lineNumber,
-				LineOffset:       lineOffset,
-				OffsetAndLengths: [][2]int{{offset, length}},
-			})
-		}
-
-		if eol >= 0 {
-			fileBuf = fileBuf[eol+1:]
-		}
-
-		lineNumber++
-		start = 0
-		end -= e
+		chunkMatches = append(chunkMatches, protocol.ChunkMatch{
+			Content: string(buf[firstLineStart:lastLineEnd]),
+			ContentStart: protocol.Location{
+				Offset: firstLineStart,
+				Line:   chunk.cover.Start.Line,
+				Column: 0,
+			},
+			Ranges: chunk.ranges,
+		})
 	}
-	return matches
+	return chunkMatches
 }
 
 // FindZip is a convenience function to run Find on f.
 func (rg *readerGrep) FindZip(zf *zipFile, f *srcFile, limit int) (protocol.FileMatch, error) {
-	lm, err := rg.Find(zf, f, limit)
+	cms, err := rg.Find(zf, f, limit)
 	return protocol.FileMatch{
-		Path:        f.Name,
-		LineMatches: lm,
-		MatchCount:  len(lm),
-		LimitHit:    false,
+		Path:         f.Name,
+		ChunkMatches: cms,
+		LimitHit:     false,
 	}, err
 }
 
@@ -349,7 +324,7 @@ func regexSearch(ctx context.Context, rg *readerGrep, zf *zipFile, patternMatche
 				if ctx.Err() != nil {
 					return ctx.Err()
 				}
-				fm := protocol.FileMatch{Path: f.Name, MatchCount: 1}
+				fm := protocol.FileMatch{Path: f.Name}
 				sender.Send(fm)
 			}
 		}
@@ -390,7 +365,7 @@ func regexSearch(ctx context.Context, rg *readerGrep, zf *zipFile, patternMatche
 				if err != nil {
 					return err
 				}
-				match := len(fm.LineMatches) > 0
+				match := len(fm.ChunkMatches) > 0
 				if !match && patternMatchesPaths {
 					// Try matching against the file path.
 					match = rg.matchString(f.Name)

--- a/cmd/searcher/internal/search/search_regex_test.go
+++ b/cmd/searcher/internal/search/search_regex_test.go
@@ -333,7 +333,7 @@ func TestMaxMatches(t *testing.T) {
 
 	totalMatches := 0
 	for _, match := range fileMatches {
-		totalMatches += match.MatchCount
+		totalMatches += match.MatchCount()
 	}
 
 	if totalMatches != maxMatches {
@@ -444,12 +444,7 @@ func TestRegexSearch(t *testing.T) {
 				patternMatchesContent: true,
 				limit:                 5,
 			},
-			wantFm: []protocol.FileMatch{
-				{
-					Path:       "a.go",
-					MatchCount: 1,
-				},
-			},
+			wantFm: []protocol.FileMatch{{Path: "a.go"}},
 		},
 	}
 	for _, tt := range tests {

--- a/cmd/searcher/internal/search/search_structural.go
+++ b/cmd/searcher/internal/search/search_structural.go
@@ -321,7 +321,7 @@ func structuralSearch(ctx context.Context, zipPath string, paths filePatterns, e
 	}()
 
 	// Cap the number of forked processes to limit the size of zip contents being mapped to memory. Resolving #7133 could help to lift this restriction.
-	numWorkers := 0
+	numWorkers := 4
 
 	matcher := toMatcher(languages, extensionHint)
 

--- a/cmd/searcher/internal/search/search_structural.go
+++ b/cmd/searcher/internal/search/search_structural.go
@@ -92,7 +92,6 @@ func toFileMatch(zipReader *zip.Reader, combyMatch *comby.FileMatch) (protocol.F
 	return protocol.FileMatch{
 		Path:         combyMatch.URI,
 		ChunkMatches: chunkMatches,
-		MatchCount:   len(ranges),
 		LimitHit:     false,
 	}, nil
 }
@@ -322,7 +321,7 @@ func structuralSearch(ctx context.Context, zipPath string, paths filePatterns, e
 	}()
 
 	// Cap the number of forked processes to limit the size of zip contents being mapped to memory. Resolving #7133 could help to lift this restriction.
-	numWorkers := 4
+	numWorkers := 0
 
 	matcher := toMatcher(languages, extensionHint)
 

--- a/cmd/searcher/internal/search/search_structural_test.go
+++ b/cmd/searcher/internal/search/search_structural_test.go
@@ -378,7 +378,6 @@ func TestRule(t *testing.T) {
 				End:   protocol.Location{Offset: 17, Line: 0, Column: 17},
 			}},
 		}},
-		MatchCount: 1,
 	}}
 
 	if !reflect.DeepEqual(got, want) {
@@ -421,7 +420,7 @@ func bar() {
 	count := func(matches []protocol.FileMatch) int {
 		c := 0
 		for _, match := range matches {
-			c += match.MatchCount
+			c += match.MatchCount()
 		}
 		return c
 	}
@@ -481,7 +480,7 @@ func bar() {
 		matches := sender.collected
 		var gotMatchCount int
 		for _, fileMatches := range matches {
-			gotMatchCount += fileMatches.MatchCount
+			gotMatchCount += fileMatches.MatchCount()
 		}
 		if gotMatchCount != wantMatchCount {
 			t.Fatalf("got match count %d, want %d", gotMatchCount, wantMatchCount)
@@ -524,8 +523,7 @@ func bar() {
 		}
 		matches := sender.collected
 		expected := []protocol.FileMatch{{
-			Path:       "main.go",
-			MatchCount: 2,
+			Path: "main.go",
 			ChunkMatches: []protocol.ChunkMatch{{
 				Content:      "func foo() {\n    fmt.Println(\"foo\")\n}",
 				ContentStart: protocol.Location{Offset: 1, Line: 1},

--- a/cmd/searcher/internal/search/search_test.go
+++ b/cmd/searcher/internal/search/search_test.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"sort"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -66,77 +67,100 @@ func main() {
 		{protocol.PatternInfo{Pattern: "foo"}, ""},
 
 		{protocol.PatternInfo{Pattern: "World", IsCaseSensitive: true}, `
-README.md:1:# Hello World
+README.md:1:1:
+# Hello World
 `},
 
 		{protocol.PatternInfo{Pattern: "world", IsCaseSensitive: true}, `
-README.md:3:Hello world example in go
-main.go:6:	fmt.Println("Hello world")
+README.md:3:3:
+Hello world example in go
+main.go:6:6:
+	fmt.Println("Hello world")
 `},
 
 		{protocol.PatternInfo{Pattern: "world"}, `
-README.md:1:# Hello World
-README.md:3:Hello world example in go
-main.go:6:	fmt.Println("Hello world")
+README.md:1:1:
+# Hello World
+README.md:3:3:
+Hello world example in go
+main.go:6:6:
+	fmt.Println("Hello world")
 `},
 
 		{protocol.PatternInfo{Pattern: "func.*main"}, ""},
 
 		{protocol.PatternInfo{Pattern: "func.*main", IsRegExp: true}, `
-main.go:5:func main() {
+main.go:5:5:
+func main() {
 `},
 
 		// https://github.com/sourcegraph/sourcegraph/issues/8155
 		{protocol.PatternInfo{Pattern: "^func", IsRegExp: true}, `
-main.go:5:func main() {
+main.go:5:5:
+func main() {
 `},
 		{protocol.PatternInfo{Pattern: "^FuNc", IsRegExp: true}, `
-main.go:5:func main() {
+main.go:5:5:
+func main() {
 `},
 
 		{protocol.PatternInfo{Pattern: "mai", IsWordMatch: true}, ""},
 
 		{protocol.PatternInfo{Pattern: "main", IsWordMatch: true}, `
-main.go:1:package main
-main.go:5:func main() {
+main.go:1:1:
+package main
+main.go:5:5:
+func main() {
 `},
 
 		// Ensure we handle CaseInsensitive regexp searches with
 		// special uppercase chars in pattern.
 		{protocol.PatternInfo{Pattern: `printL\B`, IsRegExp: true}, `
-main.go:6:	fmt.Println("Hello world")
+main.go:6:6:
+	fmt.Println("Hello world")
 `},
 
 		{protocol.PatternInfo{Pattern: "world", ExcludePattern: "README.md"}, `
-main.go:6:	fmt.Println("Hello world")
+main.go:6:6:
+	fmt.Println("Hello world")
 `},
 		{protocol.PatternInfo{Pattern: "world", IncludePatterns: []string{"*.md"}}, `
-README.md:1:# Hello World
-README.md:3:Hello world example in go
+README.md:1:1:
+# Hello World
+README.md:3:3:
+Hello world example in go
 `},
 
 		{protocol.PatternInfo{Pattern: "w", IncludePatterns: []string{"*.{md,txt}", "*.txt"}}, `
-abc.txt:1:w
+abc.txt:1:1:
+w
 `},
 
 		{protocol.PatternInfo{Pattern: "world", ExcludePattern: "README\\.md", PathPatternsAreRegExps: true}, `
-main.go:6:	fmt.Println("Hello world")
+main.go:6:6:
+	fmt.Println("Hello world")
 `},
 		{protocol.PatternInfo{Pattern: "world", IncludePatterns: []string{"\\.md"}, PathPatternsAreRegExps: true}, `
-README.md:1:# Hello World
-README.md:3:Hello world example in go
+README.md:1:1:
+# Hello World
+README.md:3:3:
+Hello world example in go
 `},
 
 		{protocol.PatternInfo{Pattern: "w", IncludePatterns: []string{"\\.(md|txt)", "README"}, PathPatternsAreRegExps: true}, `
-README.md:1:# Hello World
-README.md:3:Hello world example in go
+README.md:1:1:
+# Hello World
+README.md:3:3:
+Hello world example in go
 `},
 
 		{protocol.PatternInfo{Pattern: "world", IncludePatterns: []string{"*.{MD,go}"}, PathPatternsAreCaseSensitive: true}, `
-main.go:6:	fmt.Println("Hello world")
+main.go:6:6:
+	fmt.Println("Hello world")
 `},
 		{protocol.PatternInfo{Pattern: "world", IncludePatterns: []string{`\.(MD|go)`}, PathPatternsAreRegExps: true, PathPatternsAreCaseSensitive: true}, `
-main.go:6:	fmt.Println("Hello world")
+main.go:6:6:
+	fmt.Println("Hello world")
 `},
 
 		{protocol.PatternInfo{Pattern: "doesnotmatch"}, ""},
@@ -144,62 +168,83 @@ main.go:6:	fmt.Println("Hello world")
 milton.png
 `},
 		{protocol.PatternInfo{Pattern: "package main\n\nimport \"fmt\"", IsCaseSensitive: false, IsRegExp: true, PathPatternsAreRegExps: true, PatternMatchesPath: true, PatternMatchesContent: true}, `
-main.go:1:package main
-main.go:2:
-main.go:3:import "fmt"
+main.go:1:3:
+package main
+
+import "fmt"
 `},
 		{protocol.PatternInfo{Pattern: "package main\n\\s*import \"fmt\"", IsCaseSensitive: false, IsRegExp: true, PathPatternsAreRegExps: true, PatternMatchesPath: true, PatternMatchesContent: true}, `
-main.go:1:package main
-main.go:2:
-main.go:3:import "fmt"
+main.go:1:3:
+package main
+
+import "fmt"
 `},
 		{protocol.PatternInfo{Pattern: "package main\n", IsCaseSensitive: false, IsRegExp: true, PathPatternsAreRegExps: true, PatternMatchesPath: true, PatternMatchesContent: true}, `
-main.go:1:package main
+main.go:1:2:
+package main
+
 `},
 		{protocol.PatternInfo{Pattern: "package main\n\\s*", IsCaseSensitive: false, IsRegExp: true, PathPatternsAreRegExps: true, PatternMatchesPath: true, PatternMatchesContent: true}, `
-main.go:1:package main
-main.go:2:
-`},
-		{protocol.PatternInfo{Pattern: "package main\n\\s*", IsCaseSensitive: false, IsRegExp: true, PathPatternsAreRegExps: true, PatternMatchesPath: true, PatternMatchesContent: true}, `
-main.go:1:package main
-main.go:2:
+main.go:1:3:
+package main
+
+import "fmt"
 `},
 		{protocol.PatternInfo{Pattern: "\nfunc", IsCaseSensitive: false, IsRegExp: true, PathPatternsAreRegExps: true, PatternMatchesPath: true, PatternMatchesContent: true}, `
-main.go:4:
-main.go:5:func main() {
+main.go:4:5:
+
+func main() {
 `},
 		{protocol.PatternInfo{Pattern: "\n\\s*func", IsCaseSensitive: false, IsRegExp: true, PathPatternsAreRegExps: true, PatternMatchesPath: true, PatternMatchesContent: true}, `
-main.go:3:import "fmt"
-main.go:4:
-main.go:5:func main() {
+main.go:3:5:
+import "fmt"
+
+func main() {
 `},
 		{protocol.PatternInfo{Pattern: "package main\n\nimport \"fmt\"\n\nfunc main\\(\\) {", IsCaseSensitive: false, IsRegExp: true, PathPatternsAreRegExps: true, PatternMatchesPath: true, PatternMatchesContent: true}, `
-main.go:1:package main
-main.go:2:
-main.go:3:import "fmt"
-main.go:4:
-main.go:5:func main() {
+main.go:1:5:
+package main
+
+import "fmt"
+
+func main() {
 `},
 		{protocol.PatternInfo{Pattern: "\n", IsCaseSensitive: false, IsRegExp: true, PathPatternsAreRegExps: true, PatternMatchesPath: true, PatternMatchesContent: true}, `
-README.md:1:# Hello World
-README.md:2:
-main.go:1:package main
-main.go:2:
-main.go:3:import "fmt"
-main.go:4:
-main.go:5:func main() {
-main.go:6:	fmt.Println("Hello world")
-main.go:7:}
+README.md:1:3:
+# Hello World
+
+Hello world example in go
+main.go:1:8:
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("Hello world")
+}
+
 `},
 
-		{protocol.PatternInfo{Pattern: "^$", IsRegExp: true}, ``},
+		{protocol.PatternInfo{Pattern: "^$", IsRegExp: true}, `
+README.md:2:2:
+
+main.go:2:2:
+
+main.go:4:4:
+
+main.go:8:8:
+
+milton.png:1:1:
+
+`},
 		{protocol.PatternInfo{
 			Pattern:         "filename contains regex metachars",
 			IncludePatterns: []string{"file++.plus"},
 			IsStructuralPat: true,
 			IsRegExp:        true, // To test for a regression, imply that IsStructuralPat takes precedence.
 		}, `
-file++.plus:1:filename contains regex metachars
+file++.plus:1:1:
+filename contains regex metachars
 `},
 
 		{protocol.PatternInfo{Pattern: "World", IsNegated: true}, `
@@ -226,10 +271,12 @@ symlink
 `},
 		{protocol.PatternInfo{Pattern: "abc", PatternMatchesPath: true, PatternMatchesContent: true}, `
 abc.txt
-symlink:1:abc.txt
+symlink:1:1:
+abc.txt
 `},
 		{protocol.PatternInfo{Pattern: "abc", PatternMatchesPath: false, PatternMatchesContent: true}, `
-symlink:1:abc.txt
+symlink:1:1:
+abc.txt
 `},
 		{protocol.PatternInfo{Pattern: "abc", PatternMatchesPath: true, PatternMatchesContent: false}, `
 abc.txt
@@ -543,27 +590,20 @@ func fetchTimeoutForCI(t *testing.T) string {
 func toString(m []protocol.FileMatch) string {
 	buf := new(bytes.Buffer)
 	for _, f := range m {
-		if len(f.LineMatches) == 0 && len(f.ChunkMatches) == 0 {
+		if len(f.ChunkMatches) == 0 {
 			buf.WriteString(f.Path)
-			buf.WriteByte('\n')
-		}
-		for _, l := range f.LineMatches {
-			buf.WriteString(f.Path)
-			buf.WriteByte(':')
-			buf.WriteString(strconv.Itoa(l.LineNumber + 1))
-			buf.WriteByte(':')
-			buf.WriteString(l.Preview)
 			buf.WriteByte('\n')
 		}
 		for _, cm := range f.ChunkMatches {
-			for _, rr := range cm.Ranges {
-				buf.WriteString(f.Path)
-				buf.WriteByte(':')
-				buf.WriteString(strconv.Itoa(int(rr.Start.Line) + 1))
-				buf.WriteByte(':')
-				buf.WriteString(cm.Content)
-				buf.WriteByte('\n')
-			}
+			buf.WriteString(f.Path)
+			buf.WriteByte(':')
+			buf.WriteString(strconv.Itoa(int(cm.ContentStart.Line) + 1))
+			buf.WriteByte(':')
+			buf.WriteString(strconv.Itoa(int(cm.ContentStart.Line) + strings.Count(cm.Content, "\n") + 1))
+			buf.WriteByte(':')
+			buf.WriteByte('\n')
+			buf.WriteString(cm.Content)
+			buf.WriteByte('\n')
 		}
 	}
 	return buf.String()
@@ -577,13 +617,13 @@ func sanityCheckSorted(m []protocol.FileMatch) error {
 		if i > 0 && m[i].Path == m[i-1].Path {
 			return errors.Errorf("duplicate FileMatch on %s", m[i].Path)
 		}
-		lm := m[i].LineMatches
-		if !sort.IsSorted(sortByLineNumber(lm)) {
+		cm := m[i].ChunkMatches
+		if !sort.IsSorted(sortByLineNumber(cm)) {
 			return errors.Errorf("unsorted LineMatches for %s", m[i].Path)
 		}
-		for j := range lm {
-			if j > 0 && lm[j].LineNumber == lm[j-1].LineNumber {
-				return errors.Errorf("duplicate LineNumber on %s:%d", m[i].Path, lm[j].LineNumber)
+		for j := range cm {
+			if j > 0 && cm[j].ContentStart.Line == cm[j-1].ContentStart.Line {
+				return errors.Errorf("duplicate LineNumber on %s:%d", m[i].Path, cm[j].ContentStart.Line)
 			}
 		}
 	}
@@ -596,8 +636,8 @@ func (m sortByPath) Len() int           { return len(m) }
 func (m sortByPath) Less(i, j int) bool { return m[i].Path < m[j].Path }
 func (m sortByPath) Swap(i, j int)      { m[i], m[j] = m[j], m[i] }
 
-type sortByLineNumber []protocol.LineMatch
+type sortByLineNumber []protocol.ChunkMatch
 
 func (m sortByLineNumber) Len() int           { return len(m) }
-func (m sortByLineNumber) Less(i, j int) bool { return m[i].LineNumber < m[j].LineNumber }
+func (m sortByLineNumber) Less(i, j int) bool { return m[i].ContentStart.Line < m[j].ContentStart.Line }
 func (m sortByLineNumber) Swap(i, j int)      { m[i], m[j] = m[j], m[i] }

--- a/cmd/searcher/protocol/searcher.go
+++ b/cmd/searcher/protocol/searcher.go
@@ -197,14 +197,19 @@ type FileMatch struct {
 	ChunkMatches []ChunkMatch
 	LineMatches  []LineMatch
 
-	// MatchCount is the number of matches.  Different from len(LineMatches), as multiple
-	// lines may correspond to one logical match when doing a structural search
-	// TODO remove this because it's not used by any clients and will no longer
-	// be useful once we migrate to use only MultilineMatches
-	MatchCount int
-
 	// LimitHit is true if LineMatches may not include all LineMatches.
 	LimitHit bool
+}
+
+func (fm FileMatch) MatchCount() int {
+	if len(fm.ChunkMatches) == 0 {
+		return 1 // path match is still one match
+	}
+	count := 0
+	for _, cm := range fm.ChunkMatches {
+		count += len(cm.Ranges)
+	}
+	return count
 }
 
 // LineMatch is the struct used by vscode to receive search results for a line.

--- a/cmd/searcher/protocol/searcher.go
+++ b/cmd/searcher/protocol/searcher.go
@@ -195,7 +195,6 @@ type FileMatch struct {
 	Path string
 
 	ChunkMatches []ChunkMatch
-	LineMatches  []LineMatch
 
 	// LimitHit is true if LineMatches may not include all LineMatches.
 	LimitHit bool
@@ -210,58 +209,6 @@ func (fm FileMatch) MatchCount() int {
 		count += len(cm.Ranges)
 	}
 	return count
-}
-
-// LineMatch is the struct used by vscode to receive search results for a line.
-type LineMatch struct {
-	// Preview is the matched line.
-	Preview string
-
-	// LineNumber is the 0-based line number. Note: Our editors present
-	// 1-based line numbers, but internally vscode uses 0-based.
-	LineNumber int
-
-	// LineOffset is the number of bytes from the beginning of the
-	// file to the beginning of the line.
-	LineOffset int
-
-	// OffsetAndLengths is a slice of 2-tuples (Offset, Length)
-	// representing each match on a line.
-	// Offsets and lengths are measured in characters, not bytes.
-	OffsetAndLengths [][2]int
-}
-
-type Location struct {
-	// The byte offset from the beginning of the file.
-	Offset int32
-
-	// Line is the count of newlines before the offset in the file.
-	// Line is 0-based.
-	Line int32
-
-	// Column is the rune offset from the beginning of the last line.
-	Column int32
-}
-
-type MultilineMatch struct {
-	// Preview is a possibly-multiline string that contains all the
-	// lines that the match overlaps.
-	// The number of lines in Preview should be End.Line - Start.Line + 1
-	Preview string
-	Start   Location
-	End     Location
-}
-
-func (m MultilineMatch) MatchedContent() string {
-	runePreview := []rune(m.Preview)
-	lastLineStart := 0
-	for i := len(runePreview) - 1; i >= 0; i-- {
-		if runePreview[i] == rune('\n') {
-			lastLineStart = i + 1
-			break
-		}
-	}
-	return string(runePreview[m.Start.Column : lastLineStart+int(m.End.Column)])
 }
 
 type ChunkMatch struct {
@@ -281,4 +228,16 @@ func (cm ChunkMatch) MatchedContent() []string {
 type Range struct {
 	Start Location
 	End   Location
+}
+
+type Location struct {
+	// The byte offset from the beginning of the file.
+	Offset int32
+
+	// Line is the count of newlines before the offset in the file.
+	// Line is 0-based.
+	Line int32
+
+	// Column is the rune offset from the beginning of the last line.
+	Column int32
 }

--- a/internal/search/searcher/search.go
+++ b/internal/search/searcher/search.go
@@ -3,7 +3,6 @@ package searcher
 import (
 	"context"
 	"time"
-	"unicode/utf8"
 
 	"github.com/inconshreveable/log15"
 	"github.com/opentracing/opentracing-go/log"
@@ -209,48 +208,10 @@ func searchFilesInRepo(
 
 // newToMatches returns a closure that converts []*protocol.FileMatch to []result.Match.
 func newToMatches(repo types.MinimalRepo, commit api.CommitID, rev *string) func([]*protocol.FileMatch) []result.Match {
-	runeOffsetToByteOffset := func(buf string, n int) int {
-		idx := 0
-		for i := 0; i < n; i++ {
-			_, count := utf8.DecodeRuneInString(buf)
-			buf = buf[count:]
-			idx += count
-		}
-		return idx
-	}
-
 	return func(searcherMatches []*protocol.FileMatch) []result.Match {
 		matches := make([]result.Match, 0, len(searcherMatches))
 		for _, fm := range searcherMatches {
-			chunkMatches := make(result.ChunkMatches, 0, len(fm.LineMatches))
-
-			for _, lm := range fm.LineMatches {
-				ranges := make(result.Ranges, 0, len(lm.OffsetAndLengths))
-				for _, ol := range lm.OffsetAndLengths {
-					offset, length := ol[0], ol[1]
-					ranges = append(ranges, result.Range{
-						Start: result.Location{
-							Offset: lm.LineOffset + runeOffsetToByteOffset(lm.Preview, offset),
-							Line:   lm.LineNumber,
-							Column: offset,
-						},
-						End: result.Location{
-							Offset: lm.LineOffset + runeOffsetToByteOffset(lm.Preview, offset+length),
-							Line:   lm.LineNumber,
-							Column: offset + length,
-						},
-					})
-				}
-				chunkMatches = append(chunkMatches, result.ChunkMatch{
-					Content: lm.Preview,
-					ContentStart: result.Location{
-						Offset: lm.LineOffset,
-						Line:   lm.LineNumber,
-						Column: 0,
-					},
-					Ranges: ranges,
-				})
-			}
+			chunkMatches := make(result.ChunkMatches, 0, len(fm.ChunkMatches))
 
 			for _, cm := range fm.ChunkMatches {
 				ranges := make(result.Ranges, 0, len(cm.Ranges))


### PR DESCRIPTION
This completes the migration of `searcher` to use the more robust, multiline `ChunkMatch` result type. Specifically, it converts regex search to return `[]ChunkMatch` instead of `[]LineMatch`. Comments inline.

## Test plan

Updated tests I expected to change manually and checked that they still passed. Running backend integration tests. Chunking logic is already tested. Added unit tests for `locsToRanges`.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
