### PR TITLE
Search backend: DRY out searcher streams

### DIFF
--- a/cmd/searcher/internal/search/search_regex.go
+++ b/cmd/searcher/internal/search/search_regex.go
@@ -249,7 +249,7 @@ func regexSearchBatch(ctx context.Context, rg *readerGrep, zf *zipFile, limit in
 	ctx, cancel, sender := newLimitedStreamCollector(ctx, limit)
 	defer cancel()
 	err := regexSearch(ctx, rg, zf, patternMatchesContent, patternMatchesPaths, isPatternNegated, sender)
-	return sender.Collected(), sender.LimitHit(), err
+	return sender.collected, sender.LimitHit(), err
 }
 
 // regexSearch concurrently searches files in zr looking for matches using rg.


### PR DESCRIPTION
We currently have two different stream limiters in searcher: one for
streaming and one for batch. I honestly don't remember why, but we can
implement the collecting stream by appending in the callback. Just
trying to reduce some maintenance costs here since I've had to change
both of these in multiple times during these multiline refactors.

Stacked on https://github.com/sourcegraph/sourcegraph/pull/36431

## Test plan

Many tests depend on this batch limit. Its behavior should be well-covered.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
