### PR TITLE
release: update release config for 3.41.0

### DIFF
--- a/dev/release/release-config.jsonc
+++ b/dev/release/release-config.jsonc
@@ -16,7 +16,7 @@
     "previousRelease": "3.40.1",
     "upcomingRelease": "3.41.0",
     // Release dates
-    "oneWorkingWeekBeforeRelease": "15 May 2022 10:00 PST",
+    "oneWorkingWeekBeforeRelease": "15 June 2022 10:00 PST",
     "oneWorkingDayBeforeRelease": "21 June 2022 10:00 PST",
     "releaseDate": "22 June 2022 10:00 PST",
     "oneWorkingDayAfterRelease": "02 June 2022 10:00 PST",

--- a/dev/release/release-config.jsonc
+++ b/dev/release/release-config.jsonc
@@ -19,7 +19,7 @@
     "oneWorkingWeekBeforeRelease": "15 June 2022 10:00 PST",
     "oneWorkingDayBeforeRelease": "21 June 2022 10:00 PST",
     "releaseDate": "22 June 2022 10:00 PST",
-    "oneWorkingDayAfterRelease": "02 June 2022 10:00 PST",
+    "oneWorkingDayAfterRelease": "23 June 2022 10:00 PST",
     // Channel where messages from the tooling are posted
     "slackAnnounceChannel": "prod-eng-announce",
     // Email for preparing calendar events

--- a/dev/release/release-config.jsonc
+++ b/dev/release/release-config.jsonc
@@ -10,15 +10,15 @@
  */
 {
     // Captain information
-    "captainSlackUsername": "Joe Chen",
+    "captainSlackUsername": "joe",
     "captainGitHubUsername": "unknwon",
     // Release versions
-    "previousRelease": "3.40.0",
-    "upcomingRelease": "3.40.1",
+    "previousRelease": "3.40.1",
+    "upcomingRelease": "3.41.0",
     // Release dates
-    "oneWorkingWeekBeforeRelease": "25 May 2022 10:00 PST",
-    "oneWorkingDayBeforeRelease": "31 May 2022 10:00 PST",
-    "releaseDate": "01 June 2022 10:00 PST",
+    "oneWorkingWeekBeforeRelease": "15 May 2022 10:00 PST",
+    "oneWorkingDayBeforeRelease": "21 June 2022 10:00 PST",
+    "releaseDate": "22 June 2022 10:00 PST",
     "oneWorkingDayAfterRelease": "02 June 2022 10:00 PST",
     // Channel where messages from the tooling are posted
     "slackAnnounceChannel": "prod-eng-announce",


### PR DESCRIPTION
The branch cut will happen on June, 17th. If I'm still going to be the release captain for 3.41.0, 3 working days buffer is _required_ with the current release process as proposed in [RFC 695: Increase the release cut duration to 72 hours](https://docs.google.com/document/d/1HedzJIzcNR5Ihy_h0PgEqfdAE0z3sSSyZL5IOw2O8qk/edit#).

## Test plan

n/a
