### PR TITLE
Settings fix follow up

### DIFF
--- a/client/web/src/site-admin/SiteAdminConfigurationPage.tsx
+++ b/client/web/src/site-admin/SiteAdminConfigurationPage.tsx
@@ -206,6 +206,7 @@ interface Props extends RouteComponentProps<{}>, ThemeProps, TelemetryProps {
 
 interface State {
     site?: GQL.ISite
+    contents: string
     loading: boolean
     error?: Error
 
@@ -222,6 +223,7 @@ const EXPECTED_RELOAD_WAIT = 7 * 1000 // 7 seconds
 export class SiteAdminConfigurationPage extends React.Component<Props, State> {
     public state: State = {
         loading: true,
+        contents: '',
         restartToApply: window.context.needServerRestart,
     }
 
@@ -229,6 +231,8 @@ export class SiteAdminConfigurationPage extends React.Component<Props, State> {
     private remoteUpdates = new Subject<string>()
     private siteReloads = new Subject<void>()
     private subscriptions = new Subscription()
+
+    private onSaveCallback: null | ((value: string) => void) = null
 
     public componentDidMount(): void {
         eventLogger.logViewEvent('SiteAdminConfiguration')

--- a/client/web/src/site-admin/SiteAdminConfigurationPage.tsx
+++ b/client/web/src/site-admin/SiteAdminConfigurationPage.tsx
@@ -226,7 +226,6 @@ export class SiteAdminConfigurationPage extends React.Component<Props, State> {
     }
 
     private remoteRefreshes = new Subject<void>()
-    private remoteUpdates = new Subject<string>()
     private siteReloads = new Subject<void>()
     private subscriptions = new Subscription()
 

--- a/client/web/src/site-admin/SiteAdminConfigurationPage.tsx
+++ b/client/web/src/site-admin/SiteAdminConfigurationPage.tsx
@@ -222,7 +222,6 @@ const EXPECTED_RELOAD_WAIT = 7 * 1000 // 7 seconds
 export class SiteAdminConfigurationPage extends React.Component<Props, State> {
     public state: State = {
         loading: true,
-        contents: '',
         restartToApply: window.context.needServerRestart,
     }
 

--- a/client/web/src/site-admin/SiteAdminConfigurationPage.tsx
+++ b/client/web/src/site-admin/SiteAdminConfigurationPage.tsx
@@ -206,7 +206,6 @@ interface Props extends RouteComponentProps<{}>, ThemeProps, TelemetryProps {
 
 interface State {
     site?: GQL.ISite
-    contents: string
     loading: boolean
     error?: Error
 

--- a/client/web/src/site-admin/SiteAdminConfigurationPage.tsx
+++ b/client/web/src/site-admin/SiteAdminConfigurationPage.tsx
@@ -230,8 +230,6 @@ export class SiteAdminConfigurationPage extends React.Component<Props, State> {
     private siteReloads = new Subject<void>()
     private subscriptions = new Subscription()
 
-    private onSaveCallback: null | ((value: string) => void) = null
-
     public componentDidMount(): void {
         eventLogger.logViewEvent('SiteAdminConfiguration')
 

--- a/client/web/src/site-admin/SiteAdminConfigurationPage.tsx
+++ b/client/web/src/site-admin/SiteAdminConfigurationPage.tsx
@@ -6,7 +6,7 @@ import classNames from 'classnames'
 import * as H from 'history'
 import { RouteComponentProps } from 'react-router'
 import { Subject, Subscription } from 'rxjs'
-import { catchError, concatMap, delay, mergeMap, retryWhen, tap, timeout } from 'rxjs/operators'
+import { delay, mergeMap, retryWhen, tap, timeout } from 'rxjs/operators'
 
 import { ErrorAlert } from '@sourcegraph/branded/src/components/alerts'
 import * as GQL from '@sourcegraph/shared/src/schema'
@@ -248,61 +248,6 @@ export class SiteAdminConfigurationPage extends React.Component<Props, State> {
         this.remoteRefreshes.next()
 
         this.subscriptions.add(
-            this.remoteUpdates
-                .pipe(
-                    tap(() => this.setState({ saving: true, error: undefined })),
-                    concatMap(newContents => {
-                        const lastConfiguration = this.state.site?.configuration
-                        const lastConfigurationID = lastConfiguration?.id || 0
-
-                        return updateSiteConfiguration(lastConfigurationID, newContents).pipe(
-                            catchError(error => {
-                                console.error(error)
-                                this.setState({ saving: false, error })
-                                return []
-                            }),
-                            tap(() => {
-                                const oldContents = lastConfiguration?.effectiveContents || ''
-                                const oldConfiguration = jsonc.parse(oldContents) as SiteConfiguration
-                                const newConfiguration = jsonc.parse(newContents) as SiteConfiguration
-
-                                // Flipping these feature flags require a reload for the
-                                // UI to be rendered correctly in the navbar and the sidebar.
-                                const keys: (keyof SiteConfiguration)[] = [
-                                    'batchChanges.enabled',
-                                    'codeIntelAutoIndexing.enabled',
-                                ]
-
-                                if (
-                                    !keys.every(
-                                        key => Boolean(oldConfiguration?.[key]) === Boolean(newConfiguration?.[key])
-                                    )
-                                ) {
-                                    window.location.reload()
-                                }
-                            })
-                        )
-                    }),
-                    tap(restartToApply => {
-                        if (restartToApply) {
-                            window.context.needServerRestart = restartToApply
-                        } else {
-                            // Refresh site flags so that global site alerts
-                            // reflect the latest configuration.
-                            // eslint-disable-next-line rxjs/no-ignored-subscription, rxjs/no-nested-subscribe
-                            refreshSiteFlags().subscribe({ error: error => console.error(error) })
-                        }
-                        this.setState({ restartToApply })
-                        this.remoteRefreshes.next()
-                    })
-                )
-                .subscribe(
-                    () => this.setState({ saving: false }),
-                    error => this.setState({ saving: false, error })
-                )
-        )
-
-        this.subscriptions.add(
             this.siteReloads
                 .pipe(
                     tap(() => this.setState({ reloadStartedAt: Date.now(), error: undefined })),
@@ -474,8 +419,9 @@ export class SiteAdminConfigurationPage extends React.Component<Props, State> {
         const lastConfiguration = this.state.site?.configuration
         const lastConfigurationID = lastConfiguration?.id || 0
 
+        let restartToApply = false
         try {
-            await updateSiteConfiguration(lastConfigurationID, newContents).toPromise<boolean>()
+            restartToApply = await updateSiteConfiguration(lastConfigurationID, newContents).toPromise<boolean>()
         } catch (error) {
             console.error(error)
             this.setState({ saving: false, error })
@@ -493,18 +439,35 @@ export class SiteAdminConfigurationPage extends React.Component<Props, State> {
             window.location.reload()
         }
 
-        this.setState({ saving: false })
+        if (restartToApply) {
+            window.context.needServerRestart = restartToApply
+        } else {
+            // Refresh site flags so that global site alerts
+            // reflect the latest configuration.
+            try {
+                await refreshSiteFlags().toPromise()
+            } catch (error) {
+                console.error(error)
+            }
+        }
+        this.setState({ restartToApply })
 
-        return fetchSite()
-            .toPromise()
-            .then(site => {
-                this.setState({
-                    site,
-                    error: undefined,
-                    loading: false,
-                })
-                return site.configuration.effectiveContents
+        try {
+            const site = await fetchSite().toPromise()
+
+            this.setState({
+                site,
+                error: undefined,
+                loading: false,
             })
+
+            this.setState({ saving: false })
+
+            return site.configuration.effectiveContents
+        } catch (error) {
+            this.setState({ error, loading: false })
+            throw error
+        }
     }
 
     private reloadSite = (): void => {


### PR DESCRIPTION
Removes unused `remoteUpdates` that was left from the pipe implementation.

## Test plan

Manual e2e tests.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-pjlast-settings-fix-follow-up.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-fvrhzxnreq.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
