### PR TITLE
perms: remove redundant `ListExternalAccounts` method

### DIFF
--- a/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
+++ b/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
@@ -669,8 +669,13 @@ func (s *PermsSyncer) syncUserPerms(ctx context.Context, userID int32, noPerms b
 		return errors.Wrap(err, "get user")
 	}
 
-	// Update tokens stored in external accounts:
-	accts, err := s.permsStore.ListExternalAccounts(ctx, user.ID)
+	// Update tokens stored in external accounts
+	accts, err := s.db.UserExternalAccounts().List(ctx,
+		database.ExternalAccountsListOptions{
+			UserID:         user.ID,
+			ExcludeExpired: true,
+		},
+	)
 	if err != nil {
 		return errors.Wrap(err, "list external accounts")
 	}

--- a/enterprise/cmd/repo-updater/internal/authz/perms_syncer_test.go
+++ b/enterprise/cmd/repo-updater/internal/authz/perms_syncer_test.go
@@ -149,7 +149,9 @@ func TestPermsSyncer_syncUserPerms(t *testing.T) {
 	externalServices.ListFunc.SetDefaultReturn([]*types.ExternalService{extService}, nil)
 
 	userEmails := database.NewMockUserEmailsStore()
+
 	externalAccounts := database.NewMockUserExternalAccountsStore()
+	externalAccounts.ListFunc.SetDefaultReturn([]*extsvc.Account{&extAccount}, nil)
 
 	db := database.NewMockDB()
 	db.UsersFunc.SetDefaultReturn(users)
@@ -165,7 +167,6 @@ func TestPermsSyncer_syncUserPerms(t *testing.T) {
 	reposStore.RepoStoreFunc.SetDefaultReturn(mockRepos)
 
 	perms := edb.NewMockPermsStore()
-	perms.ListExternalAccountsFunc.SetDefaultReturn([]*extsvc.Account{&extAccount}, nil)
 	perms.SetUserPermissionsFunc.SetDefaultHook(func(_ context.Context, p *authz.UserPermissions) error {
 		wantIDs := []int32{1, 2, 3, 4, 5}
 		assert.Equal(t, wantIDs, p.GenerateSortedIDsSlice())
@@ -243,6 +244,7 @@ func TestPermsSyncer_syncUserPerms_noPerms(t *testing.T) {
 
 	userEmails := database.NewMockUserEmailsStore()
 	externalAccounts := database.NewMockUserExternalAccountsStore()
+	externalAccounts.ListFunc.SetDefaultReturn([]*extsvc.Account{&extAccount}, nil)
 
 	db := database.NewMockDB()
 	db.UsersFunc.SetDefaultReturn(users)
@@ -257,7 +259,6 @@ func TestPermsSyncer_syncUserPerms_noPerms(t *testing.T) {
 	reposStore.ExternalServiceStoreFunc.SetDefaultReturn(externalServices)
 
 	perms := edb.NewMockPermsStore()
-	perms.ListExternalAccountsFunc.SetDefaultReturn([]*extsvc.Account{&extAccount}, nil)
 	perms.SetUserPermissionsFunc.SetDefaultHook(func(_ context.Context, p *authz.UserPermissions) error {
 		assert.Equal(t, int32(1), p.UserID)
 		assert.Equal(t, []int32{1}, p.GenerateSortedIDsSlice())
@@ -333,7 +334,9 @@ func TestPermsSyncer_syncUserPerms_tokenExpire(t *testing.T) {
 
 	externalServices := database.NewMockExternalServiceStore()
 	userEmails := database.NewMockUserEmailsStore()
+
 	externalAccounts := database.NewMockUserExternalAccountsStore()
+	externalAccounts.ListFunc.SetDefaultReturn([]*extsvc.Account{&extAccount}, nil)
 
 	db := database.NewMockDB()
 	db.UsersFunc.SetDefaultReturn(users)
@@ -345,7 +348,6 @@ func TestPermsSyncer_syncUserPerms_tokenExpire(t *testing.T) {
 	reposStore := repos.NewMockStore()
 
 	perms := edb.NewMockPermsStore()
-	perms.ListExternalAccountsFunc.SetDefaultReturn([]*extsvc.Account{&extAccount}, nil)
 	perms.UserIsMemberOfOrgHasCodeHostConnectionFunc.SetDefaultReturn(true, nil)
 
 	s := NewPermsSyncer(db, reposStore, perms, timeutil.Now, nil)
@@ -428,7 +430,9 @@ func TestPermsSyncer_syncUserPerms_prefixSpecs(t *testing.T) {
 
 	externalServices := database.NewMockExternalServiceStore()
 	userEmails := database.NewMockUserEmailsStore()
+
 	externalAccounts := database.NewMockUserExternalAccountsStore()
+	externalAccounts.ListFunc.SetDefaultReturn([]*extsvc.Account{&extAccount}, nil)
 
 	db := database.NewMockDB()
 	db.UsersFunc.SetDefaultReturn(users)
@@ -443,7 +447,6 @@ func TestPermsSyncer_syncUserPerms_prefixSpecs(t *testing.T) {
 	reposStore.ExternalServiceStoreFunc.SetDefaultReturn(externalServices)
 
 	perms := edb.NewMockPermsStore()
-	perms.ListExternalAccountsFunc.SetDefaultReturn([]*extsvc.Account{&extAccount}, nil)
 	perms.UserIsMemberOfOrgHasCodeHostConnectionFunc.SetDefaultReturn(true, nil)
 
 	s := NewPermsSyncer(db, reposStore, perms, timeutil.Now, nil)
@@ -495,7 +498,10 @@ func TestPermsSyncer_syncUserPerms_subRepoPermissions(t *testing.T) {
 
 	externalServices := database.NewMockExternalServiceStore()
 	userEmails := database.NewMockUserEmailsStore()
+
 	externalAccounts := database.NewMockUserExternalAccountsStore()
+	externalAccounts.ListFunc.SetDefaultReturn([]*extsvc.Account{&extAccount}, nil)
+
 	subRepoPerms := database.NewMockSubRepoPermsStore()
 
 	db := database.NewMockDB()
@@ -512,7 +518,6 @@ func TestPermsSyncer_syncUserPerms_subRepoPermissions(t *testing.T) {
 	reposStore.ExternalServiceStoreFunc.SetDefaultReturn(externalServices)
 
 	perms := edb.NewMockPermsStore()
-	perms.ListExternalAccountsFunc.SetDefaultReturn([]*extsvc.Account{&extAccount}, nil)
 	perms.UserIsMemberOfOrgHasCodeHostConnectionFunc.SetDefaultReturn(true, nil)
 
 	s := NewPermsSyncer(db, reposStore, perms, timeutil.Now, nil)

--- a/enterprise/internal/database/authz.go
+++ b/enterprise/internal/database/authz.go
@@ -43,7 +43,12 @@ func (s *authzStore) GrantPendingPermissions(ctx context.Context, args *database
 	}
 
 	// Gather external accounts associated to the user.
-	extAccounts, err := s.store.ListExternalAccounts(ctx, args.UserID)
+	extAccounts, err := database.ExternalAccountsWith(s.store).List(ctx,
+		database.ExternalAccountsListOptions{
+			UserID:         args.UserID,
+			ExcludeExpired: true,
+		},
+	)
 	if err != nil {
 		return errors.Wrap(err, "list external accounts")
 	}

--- a/enterprise/internal/database/integration_test.go
+++ b/enterprise/internal/database/integration_test.go
@@ -49,7 +49,6 @@ func TestIntegration_PermsStore(t *testing.T) {
 		{"DeleteAllUserPendingPermissions", testPermsStore_DeleteAllUserPendingPermissions(db)},
 		{"DatabaseDeadlocks", testPermsStore_DatabaseDeadlocks(db)},
 
-		{"ListExternalAccounts", testPermsStore_ListExternalAccounts(db)},
 		{"GetUserIDsByExternalAccounts", testPermsStore_GetUserIDsByExternalAccounts(db)},
 
 		{"UserIDsWithOutdatedPerms", testPermsStore_UserIDsWithOutdatedPerms(db)},

--- a/enterprise/internal/database/mocks.go
+++ b/enterprise/internal/database/mocks.go
@@ -11195,9 +11195,6 @@ type MockPermsStore struct {
 	// HandleFunc is an instance of a mock function object controlling the
 	// behavior of the method Handle.
 	HandleFunc *PermsStoreHandleFunc
-	// ListExternalAccountsFunc is an instance of a mock function object
-	// controlling the behavior of the method ListExternalAccounts.
-	ListExternalAccountsFunc *PermsStoreListExternalAccountsFunc
 	// ListPendingUsersFunc is an instance of a mock function object
 	// controlling the behavior of the method ListPendingUsers.
 	ListPendingUsersFunc *PermsStoreListPendingUsersFunc
@@ -11289,11 +11286,6 @@ func NewMockPermsStore() *MockPermsStore {
 		},
 		HandleFunc: &PermsStoreHandleFunc{
 			defaultHook: func() (r0 *basestore.TransactableHandle) {
-				return
-			},
-		},
-		ListExternalAccountsFunc: &PermsStoreListExternalAccountsFunc{
-			defaultHook: func(context.Context, int32) (r0 []*extsvc.Account, r1 error) {
 				return
 			},
 		},
@@ -11424,11 +11416,6 @@ func NewStrictMockPermsStore() *MockPermsStore {
 				panic("unexpected invocation of MockPermsStore.Handle")
 			},
 		},
-		ListExternalAccountsFunc: &PermsStoreListExternalAccountsFunc{
-			defaultHook: func(context.Context, int32) ([]*extsvc.Account, error) {
-				panic("unexpected invocation of MockPermsStore.ListExternalAccounts")
-			},
-		},
 		ListPendingUsersFunc: &PermsStoreListPendingUsersFunc{
 			defaultHook: func(context.Context, string, string) ([]string, error) {
 				panic("unexpected invocation of MockPermsStore.ListPendingUsers")
@@ -11543,9 +11530,6 @@ func NewMockPermsStoreFrom(i PermsStore) *MockPermsStore {
 		},
 		HandleFunc: &PermsStoreHandleFunc{
 			defaultHook: i.Handle,
-		},
-		ListExternalAccountsFunc: &PermsStoreListExternalAccountsFunc{
-			defaultHook: i.ListExternalAccounts,
 		},
 		ListPendingUsersFunc: &PermsStoreListPendingUsersFunc{
 			defaultHook: i.ListPendingUsers,
@@ -12241,116 +12225,6 @@ func (c PermsStoreHandleFuncCall) Args() []interface{} {
 // invocation.
 func (c PermsStoreHandleFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
-}
-
-// PermsStoreListExternalAccountsFunc describes the behavior when the
-// ListExternalAccounts method of the parent MockPermsStore instance is
-// invoked.
-type PermsStoreListExternalAccountsFunc struct {
-	defaultHook func(context.Context, int32) ([]*extsvc.Account, error)
-	hooks       []func(context.Context, int32) ([]*extsvc.Account, error)
-	history     []PermsStoreListExternalAccountsFuncCall
-	mutex       sync.Mutex
-}
-
-// ListExternalAccounts delegates to the next hook function in the queue and
-// stores the parameter and result values of this invocation.
-func (m *MockPermsStore) ListExternalAccounts(v0 context.Context, v1 int32) ([]*extsvc.Account, error) {
-	r0, r1 := m.ListExternalAccountsFunc.nextHook()(v0, v1)
-	m.ListExternalAccountsFunc.appendCall(PermsStoreListExternalAccountsFuncCall{v0, v1, r0, r1})
-	return r0, r1
-}
-
-// SetDefaultHook sets function that is called when the ListExternalAccounts
-// method of the parent MockPermsStore instance is invoked and the hook
-// queue is empty.
-func (f *PermsStoreListExternalAccountsFunc) SetDefaultHook(hook func(context.Context, int32) ([]*extsvc.Account, error)) {
-	f.defaultHook = hook
-}
-
-// PushHook adds a function to the end of hook queue. Each invocation of the
-// ListExternalAccounts method of the parent MockPermsStore instance invokes
-// the hook at the front of the queue and discards it. After the queue is
-// empty, the default hook function is invoked for any future action.
-func (f *PermsStoreListExternalAccountsFunc) PushHook(hook func(context.Context, int32) ([]*extsvc.Account, error)) {
-	f.mutex.Lock()
-	f.hooks = append(f.hooks, hook)
-	f.mutex.Unlock()
-}
-
-// SetDefaultReturn calls SetDefaultHook with a function that returns the
-// given values.
-func (f *PermsStoreListExternalAccountsFunc) SetDefaultReturn(r0 []*extsvc.Account, r1 error) {
-	f.SetDefaultHook(func(context.Context, int32) ([]*extsvc.Account, error) {
-		return r0, r1
-	})
-}
-
-// PushReturn calls PushHook with a function that returns the given values.
-func (f *PermsStoreListExternalAccountsFunc) PushReturn(r0 []*extsvc.Account, r1 error) {
-	f.PushHook(func(context.Context, int32) ([]*extsvc.Account, error) {
-		return r0, r1
-	})
-}
-
-func (f *PermsStoreListExternalAccountsFunc) nextHook() func(context.Context, int32) ([]*extsvc.Account, error) {
-	f.mutex.Lock()
-	defer f.mutex.Unlock()
-
-	if len(f.hooks) == 0 {
-		return f.defaultHook
-	}
-
-	hook := f.hooks[0]
-	f.hooks = f.hooks[1:]
-	return hook
-}
-
-func (f *PermsStoreListExternalAccountsFunc) appendCall(r0 PermsStoreListExternalAccountsFuncCall) {
-	f.mutex.Lock()
-	f.history = append(f.history, r0)
-	f.mutex.Unlock()
-}
-
-// History returns a sequence of PermsStoreListExternalAccountsFuncCall
-// objects describing the invocations of this function.
-func (f *PermsStoreListExternalAccountsFunc) History() []PermsStoreListExternalAccountsFuncCall {
-	f.mutex.Lock()
-	history := make([]PermsStoreListExternalAccountsFuncCall, len(f.history))
-	copy(history, f.history)
-	f.mutex.Unlock()
-
-	return history
-}
-
-// PermsStoreListExternalAccountsFuncCall is an object that describes an
-// invocation of method ListExternalAccounts on an instance of
-// MockPermsStore.
-type PermsStoreListExternalAccountsFuncCall struct {
-	// Arg0 is the value of the 1st argument passed to this method
-	// invocation.
-	Arg0 context.Context
-	// Arg1 is the value of the 2nd argument passed to this method
-	// invocation.
-	Arg1 int32
-	// Result0 is the value of the 1st result returned from this method
-	// invocation.
-	Result0 []*extsvc.Account
-	// Result1 is the value of the 2nd result returned from this method
-	// invocation.
-	Result1 error
-}
-
-// Args returns an interface slice containing the arguments of this
-// invocation.
-func (c PermsStoreListExternalAccountsFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
-}
-
-// Results returns an interface slice containing the results of this
-// invocation.
-func (c PermsStoreListExternalAccountsFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
 }
 
 // PermsStoreListPendingUsersFunc describes the behavior when the

--- a/enterprise/internal/database/perms_store.go
+++ b/enterprise/internal/database/perms_store.go
@@ -3,7 +3,6 @@ package database
 import (
 	"context"
 	"database/sql"
-	"encoding/json"
 	"sort"
 	"time"
 
@@ -14,10 +13,8 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
-	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
-	"github.com/sourcegraph/sourcegraph/internal/encryption/keyring"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
@@ -51,7 +48,7 @@ type PermsStore interface {
 	//     UserID: 1,
 	//     Perm: authz.Read,
 	//     Type: authz.PermRepos,
-	//     IDs: bitmap{1, 2},
+	//     IDs: {1, 2},
 	// }
 	//
 	// Table states for input:
@@ -73,11 +70,11 @@ type PermsStore interface {
 	// This method starts its own transaction for update consistency if the caller hasn't started one already.
 	//
 	// Example input:
-	// &RepoPermissions{
-	//     RepoID: 1,
-	//     Perm: authz.Read,
-	//     UserIDs: bitmap{1, 2},
-	// }
+	//  &RepoPermissions{
+	//      RepoID: 1,
+	//      Perm: authz.Read,
+	//      UserIDs: {1, 2},
+	//  }
 	//
 	// Table states for input:
 	// 	"user_permissions":
@@ -151,9 +148,6 @@ type PermsStore interface {
 	// "user_pending_permissions" table. It accepts list of bind IDs because a user
 	// has multiple bind IDs, e.g. username and email addresses.
 	DeleteAllUserPendingPermissions(ctx context.Context, accounts *extsvc.Accounts) error
-	// ListExternalAccounts returns all external accounts that are associated with
-	// given user.
-	ListExternalAccounts(ctx context.Context, userID int32) (accounts []*extsvc.Account, _ error)
 	// GetUserIDsByExternalAccounts returns all user IDs matched by given external
 	// account specs. The returned set has mapping relation as "account ID -> user
 	// ID". The number of results could be less than the candidate list due to some
@@ -161,7 +155,6 @@ type PermsStore interface {
 	GetUserIDsByExternalAccounts(ctx context.Context, accounts *extsvc.Accounts) (map[string]int32, error)
 	// UserIDsWithNoPerms returns a list of user IDs with no permissions found in the
 	// database.
-
 	UserIDsWithNoPerms(ctx context.Context) ([]int32, error)
 	// UserIDsWithOutdatedPerms returns a list of user IDs who have had repository
 	// syncing from either user or organization code host connection (that the user
@@ -655,14 +648,14 @@ func (s *permsStore) SetRepoPendingPermissions(ctx context.Context, accounts *ex
 	updatedAt := txs.clock()
 	p.UpdatedAt = updatedAt
 	if len(accounts.AccountIDs) > 0 {
-		// NOTE: The primary key of "user_pending_permissions" table is
-		//  auto-incremented, and it is monotonically growing even with upsert in
-		//  Postgres (i.e. the primary key is increased internally by one even if the row
-		//  exists). This means with large number of AccountIDs, the primary key will
-		//  grow very quickly every time we do an upsert, and soon reaching the largest
-		//  number an int4 (32-bit integer) can hold (2,147,483,647). Therefore, load
-		//  existing rows would help us only upsert rows that are newly discovered. See
-		//  NOTE in below for why we do upsert not insert.
+		// NOTE: The primary key of "user_pending_permissions" table is auto-incremented,
+		// and it is monotonically growing even with upsert in Postgres (i.e. the primary
+		// key is increased internally by one even if the row exists). This means with
+		// large number of AccountIDs, the primary key will grow very quickly every time
+		// we do an upsert, and not far from reaching the largest number an int8 (64-bit
+		// integer) can hold (9,223,372,036,854,775,807). Therefore, load existing rows
+		// would help us only upsert rows that are newly discovered. See NOTE in below
+		// for why we do upsert not insert.
 		q = loadExistingUserPendingPermissionsBatchQuery(accounts, p)
 		bindIDsToIDs, err := txs.loadExistingUserPendingPermissionsBatch(ctx, q)
 		if err != nil {
@@ -1408,83 +1401,6 @@ AND permission = %s
 	}
 
 	return id, ids, updatedAt, syncedAt, nil
-}
-
-func (s *permsStore) ListExternalAccounts(ctx context.Context, userID int32) (accounts []*extsvc.Account, err error) {
-	ctx, save := s.observe(ctx, "ListExternalAccounts", "")
-	defer func() { save(&err, otlog.Int32("userID", userID)) }()
-
-	q := sqlf.Sprintf(`
--- source: enterprise/internal/database/perms_store.go:PermsStore.ListExternalAccounts
-SELECT
-    id, user_id,
-    service_type, service_id, client_id, account_id,
-    auth_data, account_data,
-    created_at, updated_at,
-	  encryption_key_id
-FROM user_external_accounts
-WHERE
-    user_id = %s
-AND deleted_at IS NULL
-AND expired_at IS NULL
-ORDER BY id ASC
-`, userID)
-	rows, err := s.Query(ctx, q)
-	if err != nil {
-		return nil, err
-	}
-	defer func() { _ = rows.Close() }()
-
-	for rows.Next() {
-		var (
-			acct            extsvc.Account
-			authData, data  sql.NullString
-			encryptionKeyID string
-		)
-
-		if err := rows.Scan(
-			&acct.ID, &acct.UserID,
-			&acct.ServiceType, &acct.ServiceID, &acct.ClientID, &acct.AccountID,
-			&authData, &data,
-			&acct.CreatedAt, &acct.UpdatedAt,
-			&encryptionKeyID,
-		); err != nil {
-			return nil, err
-		}
-
-		if authData.Valid {
-			tmp, err := database.MaybeDecrypt(
-				ctx,
-				keyring.Default().UserExternalAccountKey,
-				authData.String,
-				encryptionKeyID,
-			)
-			if err != nil {
-				return nil, err
-			}
-			msg := json.RawMessage(tmp)
-			acct.AuthData = &msg
-		}
-		if data.Valid {
-			tmp, err := database.MaybeDecrypt(
-				ctx,
-				keyring.Default().UserExternalAccountKey,
-				data.String,
-				encryptionKeyID,
-			)
-			if err != nil {
-				return nil, err
-			}
-			msg := json.RawMessage(tmp)
-			acct.Data = &msg
-		}
-		accounts = append(accounts, &acct)
-	}
-	if err = rows.Err(); err != nil {
-		return nil, err
-	}
-
-	return accounts, nil
 }
 
 func (s *permsStore) GetUserIDsByExternalAccounts(ctx context.Context, accounts *extsvc.Accounts) (_ map[string]int32, err error) {

--- a/enterprise/internal/database/perms_store_test.go
+++ b/enterprise/internal/database/perms_store_test.go
@@ -3,7 +3,6 @@ package database
 import (
 	"context"
 	"database/sql"
-	"encoding/json"
 	"fmt"
 	"sort"
 	"sync"
@@ -2314,108 +2313,6 @@ func cleanupUsersTable(t *testing.T, s *permsStore) {
 	q := `TRUNCATE TABLE users RESTART IDENTITY CASCADE;`
 	if err := s.execute(context.Background(), sqlf.Sprintf(q)); err != nil {
 		t.Fatal(err)
-	}
-}
-
-func testPermsStore_ListExternalAccounts(db *sql.DB) func(*testing.T) {
-	return func(t *testing.T) {
-		s := perms(db, time.Now)
-		t.Cleanup(func() {
-			cleanupUsersTable(t, s)
-		})
-
-		ctx := context.Background()
-
-		// Set up test users and external accounts
-		extSQL := `
-INSERT INTO
-	user_external_accounts(user_id, service_type, service_id, account_id, client_id, auth_data, created_at, updated_at, deleted_at, expired_at)
-VALUES
-	(%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
-`
-		qs := []*sqlf.Query{
-			sqlf.Sprintf(`INSERT INTO users(username) VALUES('alice')`), // ID=1
-			sqlf.Sprintf(`INSERT INTO users(username) VALUES('bob')`),   // ID=2
-
-			sqlf.Sprintf(extSQL, 1, extsvc.TypeGitLab, "https://gitlab.com/", "alice_gitlab", "alice_gitlab_client_id", nil, clock(), clock(), nil, nil),                      // ID=1
-			sqlf.Sprintf(extSQL, 1, extsvc.TypeGitHub, "https://github.com/", "alice_github", "alice_github_client_id", `{"access_token":"123"}`, clock(), clock(), nil, nil), // ID=2
-			sqlf.Sprintf(extSQL, 2, extsvc.TypeGitLab, "https://gitlab.com/", "bob_gitlab", "bob_gitlab_client_id", nil, clock(), clock(), nil, nil),                          // ID=3
-			sqlf.Sprintf(extSQL, 2, extsvc.TypeGitHub, "https://github.com/", "bob_github", "bob_github_client_id", nil, clock(), clock(), clock(), nil),                      // ID=4
-			sqlf.Sprintf(extSQL, 1, extsvc.TypeGitHub, "https://github.com/", "expired", "expired_client_id", nil, clock(), clock(), nil, clock()),                            // ID=5
-		}
-		for _, q := range qs {
-			if err := s.execute(ctx, q); err != nil {
-				t.Fatal(err)
-			}
-		}
-
-		{
-			// Check external accounts for "alice"
-			accounts, err := s.ListExternalAccounts(ctx, 1)
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			aliceGitHubAuthData := json.RawMessage(`{"access_token":"123"}`)
-			expAccounts := []*extsvc.Account{
-				{
-					ID:     1,
-					UserID: 1,
-					AccountSpec: extsvc.AccountSpec{
-						ServiceType: extsvc.TypeGitLab,
-						ServiceID:   "https://gitlab.com/",
-						AccountID:   "alice_gitlab",
-						ClientID:    "alice_gitlab_client_id",
-					},
-					CreatedAt: clock(),
-					UpdatedAt: clock(),
-				},
-				{
-					ID:     2,
-					UserID: 1,
-					AccountSpec: extsvc.AccountSpec{
-						ServiceType: "github",
-						ServiceID:   "https://github.com/",
-						AccountID:   "alice_github",
-						ClientID:    "alice_github_client_id",
-					},
-					AccountData: extsvc.AccountData{
-						AuthData: &aliceGitHubAuthData,
-					},
-					CreatedAt: clock(),
-					UpdatedAt: clock(),
-				},
-			}
-			if diff := cmp.Diff(expAccounts, accounts); diff != "" {
-				t.Fatalf(diff)
-			}
-		}
-
-		{
-			// Check external accounts for "bob"
-			accounts, err := s.ListExternalAccounts(ctx, 2)
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			expAccounts := []*extsvc.Account{
-				{
-					ID:     3,
-					UserID: 2,
-					AccountSpec: extsvc.AccountSpec{
-						ServiceType: extsvc.TypeGitLab,
-						ServiceID:   "https://gitlab.com/",
-						AccountID:   "bob_gitlab",
-						ClientID:    "bob_gitlab_client_id",
-					},
-					CreatedAt: clock(),
-					UpdatedAt: clock(),
-				},
-			}
-			if diff := cmp.Diff(expAccounts, accounts); diff != "" {
-				t.Fatalf(diff)
-			}
-		}
 	}
 }
 


### PR DESCRIPTION
This method was copied from the `internal/database.UserExternalAccountsStore` before we have a unified DB interface as tech debt.

## Test plan

Unit tests
