### PR TITLE
[SG-34721] Accessibility: Add saved search" button on empty saved searches panel doesn't activate with spacebar 

### DIFF
--- a/client/web/src/search/panels/SavedSearchesPanel.tsx
+++ b/client/web/src/search/panels/SavedSearchesPanel.tsx
@@ -6,7 +6,17 @@ import PencilOutlineIcon from 'mdi-react/PencilOutlineIcon'
 import PlusIcon from 'mdi-react/PlusIcon'
 
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
-import { Button, ButtonGroup, Link, Menu, MenuButton, MenuList, MenuItem, Icon } from '@sourcegraph/wildcard'
+import {
+    Button,
+    ButtonGroup,
+    ButtonLink,
+    Link,
+    Menu,
+    MenuButton,
+    MenuList,
+    MenuItem,
+    Icon,
+} from '@sourcegraph/wildcard'
 
 import { AuthenticatedUser } from '../../auth'
 import { SavedSearchesPanelFragment } from '../../graphql-operations'
@@ -74,7 +84,7 @@ export const SavedSearchesPanel: React.FunctionComponent<React.PropsWithChildren
                 Use saved searches to alert you to uses of a favorite API, or changes to code you need to monitor.
             </small>
             {authenticatedUser && (
-                <Button
+                <ButtonLink
                     to={`/users/${authenticatedUser.username}/searches/add`}
                     onClick={logEvent('SavedSearchesPanelCreateButtonClicked', { source: 'empty view' })}
                     className="mt-2 align-self-center"
@@ -83,7 +93,7 @@ export const SavedSearchesPanel: React.FunctionComponent<React.PropsWithChildren
                 >
                     <Icon role="img" aria-hidden={true} as={PlusIcon} />
                     Create a saved search
-                </Button>
+                </ButtonLink>
             )}
         </EmptyPanelContainer>
     )


### PR DESCRIPTION
### Audit type

Keyboard navigation

### User journey audit issue
https://github.com/sourcegraph/sourcegraph/issues/https://github.com/sourcegraph/sourcegraph/issues/34189

### Problem description

Open Sourcegraph Server (not .com)
If the saved searches panel is not empty, delete any saved searches (both own and org)
Focus on the "+ Create a saved search" button
Press space, observe nothing happens
![description](https://user-images.githubusercontent.com/35596495/170594937-c59441e1-1f9a-4093-9f8b-9b6cd1b09288.png)


### Expected behavior

The button should activate

## Refs
[sourcegraph issue](https://github.com/sourcegraph/sourcegraph/issues/34721)
[Gitstart Ticket](https://app.gitstart.com/clients/sourcegraph/tickets/SG-34721)

## Test plan
Follow Problem description section above
Notice that when spacebar is clicked on create a saved search the button is now activated



## App preview:

- [Web](https://sg-web-contractors-sg-34721.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-sbdwdiyuoq.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
