### PR TITLE
web: revert sign-in `Input` layout change

### DIFF
--- a/client/web/src/auth/UsernamePasswordSignInForm.tsx
+++ b/client/web/src/auth/UsernamePasswordSignInForm.tsx
@@ -5,7 +5,7 @@ import * as H from 'history'
 
 import { Form } from '@sourcegraph/branded/src/components/Form'
 import { asError } from '@sourcegraph/common'
-import { Button, LoadingSpinner, Link, Text, Input } from '@sourcegraph/wildcard'
+import { Label, Button, LoadingSpinner, Link, Text, Input } from '@sourcegraph/wildcard'
 
 import { SourcegraphContext } from '../jscontext'
 import { eventLogger } from '../tracking/eventLogger'
@@ -110,21 +110,24 @@ export const UsernamePasswordSignInForm: React.FunctionComponent<React.PropsWith
                     autoComplete="username"
                 />
 
-                <PasswordInput
-                    onChange={onPasswordFieldChange}
-                    value={password}
-                    required={true}
-                    label={
-                        <div className="d-flex justify-content-between">
-                            <span>Password</span>
-                            {context.resetPasswordEnabled && <Link to="/password-reset">Forgot password?</Link>}
-                        </div>
-                    }
-                    disabled={loading}
-                    autoComplete="current-password"
-                    className="form-group"
-                    placeholder=" "
-                />
+                <div className="form-group d-flex flex-column align-content-start position-relative">
+                    <Label htmlFor="password" className="align-self-start">
+                        Password
+                    </Label>
+                    <PasswordInput
+                        onChange={onPasswordFieldChange}
+                        value={password}
+                        required={true}
+                        disabled={loading}
+                        autoComplete="current-password"
+                        placeholder=" "
+                    />
+                    {context.resetPasswordEnabled && (
+                        <small className="form-text text-muted align-self-end position-absolute">
+                            <Link to="/password-reset">Forgot password?</Link>
+                        </small>
+                    )}
+                </div>
 
                 <div
                     className={classNames('form-group', {

--- a/client/web/src/auth/__snapshots__/SignInPage.test.tsx.snap
+++ b/client/web/src/auth/__snapshots__/SignInPage.test.tsx.snap
@@ -79,26 +79,15 @@ exports[`SignInPage renders sign in page (cloud) 1`] = `
                 />
               </div>
             </label>
-            <label
-              class="label w-100 form-group"
+            <div
+              class="form-group d-flex flex-column align-content-start position-relative"
             >
-              <div
-                class="mb-2"
+              <label
+                class="label align-self-start"
+                for="password"
               >
-                <div
-                  class="d-flex justify-content-between"
-                >
-                  <span>
-                    Password
-                  </span>
-                  <a
-                    class="anchorLink"
-                    href="/password-reset"
-                  >
-                    Forgot password?
-                  </a>
-                </div>
-              </div>
+                Password
+              </label>
               <div
                 class="container loader-input loaderInput"
               >
@@ -113,7 +102,17 @@ exports[`SignInPage renders sign in page (cloud) 1`] = `
                   value=""
                 />
               </div>
-            </label>
+              <small
+                class="form-text text-muted align-self-end position-absolute"
+              >
+                <a
+                  class="anchorLink"
+                  href="/password-reset"
+                >
+                  Forgot password?
+                </a>
+              </small>
+            </div>
             <div
               class="form-group"
             >
@@ -251,26 +250,15 @@ exports[`SignInPage renders sign in page (server) 1`] = `
                 />
               </div>
             </label>
-            <label
-              class="label w-100 form-group"
+            <div
+              class="form-group d-flex flex-column align-content-start position-relative"
             >
-              <div
-                class="mb-2"
+              <label
+                class="label align-self-start"
+                for="password"
               >
-                <div
-                  class="d-flex justify-content-between"
-                >
-                  <span>
-                    Password
-                  </span>
-                  <a
-                    class="anchorLink"
-                    href="/password-reset"
-                  >
-                    Forgot password?
-                  </a>
-                </div>
-              </div>
+                Password
+              </label>
               <div
                 class="container loader-input loaderInput"
               >
@@ -285,7 +273,17 @@ exports[`SignInPage renders sign in page (server) 1`] = `
                   value=""
                 />
               </div>
-            </label>
+              <small
+                class="form-text text-muted align-self-end position-absolute"
+              >
+                <a
+                  class="anchorLink"
+                  href="/password-reset"
+                >
+                  Forgot password?
+                </a>
+              </small>
+            </div>
             <div
               class="form-group"
             >


### PR DESCRIPTION
## Context

The `Input` migration [introduced](https://github.com/sourcegraph/sourcegraph/pull/35526/files#diff-15d8f1faf3141ae6f00dbe4dfc1d09a45b2fee8ae7de0a6f1c8010108ceeac8eL117-L134) accessibility regression because of the layout change. When using a keyboard to navigate, the flow goes in this order:
1. Username Input
2. Forgot password? link
3. Password Input
4. Press enter and you are logged in

## Test plan

Ensure that the keyboard navigation flow works as expected:
1. Username Input
2. Password Input
3. Press enter and you are logged in.
4. You don’t get here -> Forgot password? link

## App preview:

- [Web](https://sg-web-vb-sign-in-input.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-tbjdtbmxxx.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
