### PR TITLE
extensions: recreate code viewer when settings change

### DIFF
--- a/client/web/src/codeintel/ReferencesPanel.tsx
+++ b/client/web/src/codeintel/ReferencesPanel.tsx
@@ -921,7 +921,6 @@ interface LocationLine {
 
 export const getLineContent = (location: Location): LocationLine => {
     const range = location.range
-    console.log(location)
     if (range !== undefined) {
         const line = location.lines[range.start.line]
 


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/36234

[Loom](https://www.loom.com/share/1e13801cc7e9454b8255e83339ca4120)

## Test plan

Follow the steps to reproduce from the original issue and ensure that git blame state is synced across multiple blob views.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
