### PR TITLE
Implement cleanup of repos that are cloned on the wrong shard

### DIFF
--- a/cmd/gitserver/server/cleanup.go
+++ b/cmd/gitserver/server/cleanup.go
@@ -161,7 +161,7 @@ func (s *Server) cleanupRepos(gitServerAddrs []string) {
 	defer func() {
 		// We want to set the gauge only when wrong shard clean-up is enabled
 		if wrongShardReposDeleteLimit > 0 {
-			wrongShardReposDeletedTotal.Add(float64(wrongShardReposDeleted))
+			wrongShardReposDeletedCounter.Add(float64(wrongShardReposDeleted))
 		}
 	}()
 

--- a/cmd/gitserver/server/cleanup.go
+++ b/cmd/gitserver/server/cleanup.go
@@ -161,7 +161,7 @@ func (s *Server) cleanupRepos(gitServerAddrs []string) {
 	defer func() {
 		// We want to set the gauge only when wrong shard clean-up is enabled
 		if wrongShardReposDeleteLimit > 0 {
-			wrongShardReposDeletedTotal.Set(float64(wrongShardRepoCount))
+			wrongShardReposDeletedTotal.Add(float64(wrongShardReposDeleted))
 		}
 	}()
 

--- a/cmd/gitserver/server/cleanup.go
+++ b/cmd/gitserver/server/cleanup.go
@@ -176,7 +176,7 @@ func (s *Server) cleanupRepos(gitServerAddrs []string) {
 			wrongShardRepoCount++
 			wrongShardRepoSize += size
 			if wrongShardReposDeleteLimit > 0 && wrongShardReposDeleted < int64(wrongShardReposDeleteLimit) {
-				s.Logger.Info("removing repo cloned on the wrong shard", log.String("repo", string(dir)), log.String("target-shard", addr), log.String("current-shard", s.Hostname), log.Int64("size-bytes", size))
+				s.Logger.Info("removing repo cloned on the wrong shard", log.String("dir", string(dir)), log.String("target-shard", addr), log.String("current-shard", s.Hostname), log.Int64("size-bytes", size))
 				if err := s.removeRepoDirectory(dir); err != nil {
 					return true, err
 				}

--- a/cmd/gitserver/server/cleanup_test.go
+++ b/cmd/gitserver/server/cleanup_test.go
@@ -37,6 +37,7 @@ func (s *Server) testSetup(t *testing.T) {
 	s.Handler() // Handler as a side-effect sets up Server
 	db := dbtest.NewDB(t)
 	s.DB = database.NewDB(db)
+	s.Hostname = "gitserver-0"
 }
 
 func TestCleanup_computeStats(t *testing.T) {
@@ -138,6 +139,69 @@ func TestCleanupInactive(t *testing.T) {
 	}
 	if _, err := os.Stat(repoC); err == nil {
 		t.Error("expected corrupt repoC to be removed during clean up")
+	}
+}
+
+func TestCleanupWrongShard_forced(t *testing.T) {
+	root := t.TempDir()
+	// should be allocated to shard gitserver-1
+	testRepoD := "testrepo-D"
+
+	repoA := path.Join(root, testRepoA, ".git")
+	cmd := exec.Command("git", "--bare", "init", repoA)
+	if err := cmd.Run(); err != nil {
+		t.Fatal(err)
+	}
+	repoD := path.Join(root, testRepoD, ".git")
+	cmdD := exec.Command("git", "--bare", "init", repoD)
+	if err := cmdD.Run(); err != nil {
+		t.Fatal(err)
+	}
+
+	s := &Server{ReposDir: root,
+		Logger: logtest.Scoped(t),
+	}
+	s.testSetup(t)
+	// force cleanup of repos
+	wrongShardReposDeleteLimit = 10
+	s.cleanupRepos([]string{"gitserver-0", "gitserver-1"})
+
+	if _, err := os.Stat(repoA); os.IsNotExist(err) {
+		t.Error("expected repoA not to be removed")
+	}
+	if _, err := os.Stat(repoD); !os.IsNotExist(err) {
+		t.Error("expected repoD assigned to different shard to be removed during clean up")
+	}
+}
+
+func TestCleanupWrongShard_cleanupDisabled(t *testing.T) {
+	root := t.TempDir()
+	// should be allocated to shard gitserver-1
+	testRepoD := "testrepo-D"
+
+	repoA := path.Join(root, testRepoA, ".git")
+	cmd := exec.Command("git", "--bare", "init", repoA)
+	if err := cmd.Run(); err != nil {
+		t.Fatal(err)
+	}
+	repoD := path.Join(root, testRepoD, ".git")
+	cmdD := exec.Command("git", "--bare", "init", repoD)
+	if err := cmdD.Run(); err != nil {
+		t.Fatal(err)
+	}
+
+	s := &Server{ReposDir: root,
+		Logger: logtest.Scoped(t),
+	}
+	s.testSetup(t)
+	wrongShardReposDeleteLimit = -1
+	s.cleanupRepos([]string{"gitserver-0", "gitserver-1"})
+
+	if _, err := os.Stat(repoA); os.IsNotExist(err) {
+		t.Error("expected repoA not to be removed")
+	}
+	if _, err := os.Stat(repoD); err != nil {
+		t.Error("expected repoD assigned to different shard not to be removed", err)
 	}
 }
 

--- a/cmd/gitserver/server/cleanup_test.go
+++ b/cmd/gitserver/server/cleanup_test.go
@@ -174,6 +174,39 @@ func TestCleanupWrongShard_forced(t *testing.T) {
 	}
 }
 
+func TestCleanupWrongShard_wrongShardName(t *testing.T) {
+	root := t.TempDir()
+	// should be allocated to shard gitserver-1
+	testRepoD := "testrepo-D"
+
+	repoA := path.Join(root, testRepoA, ".git")
+	cmd := exec.Command("git", "--bare", "init", repoA)
+	if err := cmd.Run(); err != nil {
+		t.Fatal(err)
+	}
+	repoD := path.Join(root, testRepoD, ".git")
+	cmdD := exec.Command("git", "--bare", "init", repoD)
+	if err := cmdD.Run(); err != nil {
+		t.Fatal(err)
+	}
+
+	s := &Server{ReposDir: root,
+		Logger: logtest.Scoped(t),
+	}
+	s.testSetup(t)
+	s.Hostname = "does-not-exist"
+	// force cleanup of repos
+	wrongShardReposDeleteLimit = 10
+	s.cleanupRepos([]string{"gitserver-0", "gitserver-1"})
+
+	if _, err := os.Stat(repoA); err != nil {
+		t.Error("expected repoA not to be removed")
+	}
+	if _, err := os.Stat(repoD); err != nil {
+		t.Error("expected repoD assigned to different shard not to be removed")
+	}
+}
+
 func TestCleanupWrongShard_cleanupDisabled(t *testing.T) {
 	root := t.TempDir()
 	// should be allocated to shard gitserver-1

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -546,6 +546,10 @@ var (
 		Name: "src_gitserver_repo_wrong_shard_bytes",
 		Help: "Size (in bytes) of repos that are on disk on the wrong shard",
 	})
+	wrongShardReposDeletedTotal = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "src_gitserver_repo_wrong_shard_deleted",
+		Help: "The number of repos that are on the wrong shard that we deleted",
+	})
 )
 
 func (s *Server) syncRepoState(gitServerAddrs gitserver.GitServerAddresses, batchSize, perSecond int, fullSync bool) error {

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -546,7 +546,7 @@ var (
 		Name: "src_gitserver_repo_wrong_shard_bytes",
 		Help: "Size (in bytes) of repos that are on disk on the wrong shard",
 	})
-	wrongShardReposDeletedTotal = promauto.NewCounter(prometheus.CounterOpts{
+	wrongShardReposDeletedCounter = promauto.NewCounter(prometheus.CounterOpts{
 		Name: "src_gitserver_repo_wrong_shard_deleted",
 		Help: "The number of repos that are on the wrong shard that we deleted",
 	})

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -546,7 +546,7 @@ var (
 		Name: "src_gitserver_repo_wrong_shard_bytes",
 		Help: "Size (in bytes) of repos that are on disk on the wrong shard",
 	})
-	wrongShardReposDeletedTotal = promauto.NewGauge(prometheus.GaugeOpts{
+	wrongShardReposDeletedTotal = promauto.NewCounter(prometheus.CounterOpts{
 		Name: "src_gitserver_repo_wrong_shard_deleted",
 		Help: "The number of repos that are on the wrong shard that we deleted",
 	})

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -548,7 +548,7 @@ var (
 	})
 	wrongShardReposDeletedCounter = promauto.NewCounter(prometheus.CounterOpts{
 		Name: "src_gitserver_repo_wrong_shard_deleted",
-		Help: "The number of repos that are on the wrong shard that we deleted",
+		Help: "The number of repos on the wrong shard that we deleted",
 	})
 )
 


### PR DESCRIPTION
Adds Janitor logic to delete repositories that are cloned on disk, but not assigned to the current gitserver shard.
Disabled by default, once enabled this will delete a configurable number of repositories in one run (and keep collecting stats without deletes beyond that).
Actual disk delete is performed by corrupt repos check.
```
[gitserver-0] INFO Server server/cleanup.go:178 removing repo cloned on the wrong shard {"repo": "/Users/rafal/.sourcegraph/repos/0/github.com/rafax/gojam/.git", "target-shard": "127.0.0.1:3502", "size-bytes": 991134, "deleted-this-run": 1, "deleted-limit": 10}
[gitserver-0] INFO Server server/cleanup.go:213 removing corrupt repo {"repo": "/Users/rafal/.sourcegraph/repos/0/github.com/rafax/gojam/.git", "reason": "missing-head"}
```
## Test plan

- Unit tests
- Disabled by default, will enable once we have enough baseline metrics
- Tested locally by running two gitserver replicas and copying repos into their GITDIR folders -> both replicas correctly clean up repos not belonging to them

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
