### PR TITLE
codemirror: Fix aria-label for search query input

### DIFF
--- a/client/search-ui/src/input/CodeMirrorQueryInput.tsx
+++ b/client/search-ui/src/input/CodeMirrorQueryInput.tsx
@@ -92,12 +92,6 @@ export const CodeMirrorMonacoFacade: React.FunctionComponent<React.PropsWithChil
 
     const editorCreated = useCallback(
         (editor: EditorView) => {
-            // `role` set to fix accessibility issues
-            // https://github.com/sourcegraph/sourcegraph/issues/34733
-            editor.contentDOM.setAttribute('role', 'textbox')
-            // `aria-label` to fix accessibility audit
-            editor.contentDOM.setAttribute('aria-label', ariaLabel)
-
             setEditor(editor)
             editorReference.current = editor
             onEditorCreated?.(editor)
@@ -121,6 +115,7 @@ export const CodeMirrorMonacoFacade: React.FunctionComponent<React.PropsWithChil
 
     const extensions = useMemo(() => {
         const extensions: Extension[] = [
+            EditorView.contentAttributes.of({ 'aria-label': ariaLabel }),
             EditorView.updateListener.of((update: ViewUpdate) => {
                 if (update.docChanged) {
                     onChange({
@@ -161,6 +156,7 @@ export const CodeMirrorMonacoFacade: React.FunctionComponent<React.PropsWithChil
         }
         return extensions
     }, [
+        ariaLabel,
         autocompletion,
         onBlur,
         onChange,

--- a/client/search-ui/src/input/CodeMirrorQueryInput.tsx
+++ b/client/search-ui/src/input/CodeMirrorQueryInput.tsx
@@ -96,7 +96,7 @@ export const CodeMirrorMonacoFacade: React.FunctionComponent<React.PropsWithChil
             editorReference.current = editor
             onEditorCreated?.(editor)
         },
-        [editorReference, onEditorCreated, ariaLabel]
+        [editorReference, onEditorCreated]
     )
 
     const autocompletion = useMemo(


### PR DESCRIPTION
In #36308 GitStart added 'aria-label' by mutating the DOM but the [documentation](https://codemirror.net/6/docs/ref/#view.EditorView.contentDOM) explicitly says that this shouldn't be done. Using the [`EditorView.contentAttributes` facet](https://codemirror.net/6/docs/ref/#view.EditorView^contentAttributes) is the way to go.

`role='textbox'` is already added by CodeMirror itself.



## Test plan

Inspected the DOM
<img width="568" alt="Screenshot 2022-06-02 at 13 29 55" src="https://user-images.githubusercontent.com/179026/171620562-e1500a4b-0006-465d-b6da-6dc5d7b743aa.png">

## App preview:

- [Web](https://sg-web-fkling-fix-queryinput-aria-label.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-ndnlijrzdh.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
