### PR TITLE
sg: use a cp them rm to avoid issues with FS

### DIFF
--- a/dev/sg/internal/download/download.go
+++ b/dev/sg/internal/download/download.go
@@ -3,6 +3,7 @@ package download
 import (
 	"bytes"
 	"context"
+	"io"
 	"io/fs"
 	"net/http"
 	"os"
@@ -89,7 +90,7 @@ func ArchivedExecutable(ctx context.Context, url, targetFile, fileInArchive stri
 		return errors.Newf("expected %s to exist in extracted archive at %s, but does not", fileInArchivePath, tmpDirName)
 	}
 
-	if err := os.Rename(fileInArchivePath, targetFile); err != nil {
+	if err := safeRename(fileInArchivePath, targetFile); err != nil {
 		return err
 	}
 
@@ -105,4 +106,26 @@ func fileExists(path string) (bool, error) {
 		return false, err
 	}
 	return true, nil
+}
+
+// safeRename copies src into dst before finally removing src.
+// This is needed because in some cause, the tmp folder is living
+// on a different filesystem.
+func safeRename(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	out, err := os.Create(dst)
+	if err != nil {
+		closeErr := in.Close()
+		return errors.Append(err, closeErr)
+	}
+	defer out.Close()
+	_, err = io.Copy(out, in)
+	closeErr := in.Close()
+	if err != nil {
+		return errors.Append(err, closeErr)
+	}
+	return os.Remove(src)
 }


### PR DESCRIPTION
When downloading mandatory binaries such as caddy, os.Rename can fail
because the temp folder is living in another partition. This change adds
a safeRename function that handles that edge case.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Tested locally. 
