### PR TITLE
Split large log lines up into smaller pieces

### DIFF
--- a/dev/sg/internal/loki/loki.go
+++ b/dev/sg/internal/loki/loki.go
@@ -130,9 +130,9 @@ func NewStreamFromJobLogs(log *bk.JobLogs) (*Stream, error) {
 				return nil, errors.Wrapf(err, "failed to split value entry into chunks")
 			}
 			values = append(values, chunkedEntries...)
+			previousTimestamp = ts
 		}
 
-		previousTimestamp = values[len(values)-1][0]
 	}
 
 	return &Stream{

--- a/dev/sg/internal/loki/loki.go
+++ b/dev/sg/internal/loki/loki.go
@@ -20,6 +20,7 @@ import (
 
 const pushEndpoint = "/loki/api/v1/push"
 
+// On Grafana cloud Loki rejects log entries that are longer that 65536 bytes.
 const maxEntrySize = math.MaxUint16
 
 // To point at a custom instance, e.g. one on Grafana Cloud, refer to:

--- a/dev/sg/internal/loki/loki.go
+++ b/dev/sg/internal/loki/loki.go
@@ -20,6 +20,8 @@ import (
 
 const pushEndpoint = "/loki/api/v1/push"
 
+const maxEntrySize = 65536
+
 // To point at a custom instance, e.g. one on Grafana Cloud, refer to:
 // https://grafana.com/orgs/sourcegraph/hosted-logs/85581#sending-logs
 // The URL should have the format https://85581:$TOKEN@logs-prod-us-central1.grafana.net
@@ -110,11 +112,12 @@ func NewStreamFromJobLogs(log *bk.JobLogs) (*Stream, error) {
 			previousTimestamp = ts
 		}
 
-		// An entry cannot be larger than 65536 bytes so if it is, we split into chunks of 65536 bytes.
+		// An entry cannot be larger than maxEntrySize i(65536) in bytes so if it is, we split into chunks
+		// of maxEntrySize bytes.
 		// To ensure that each chunked entry doesn't clash with a previous entry in Loki we increment
 		// the nanoseconds of the entry for each chunked entry.
-		if len(line) > 65536 {
-			chunkedEntries, err := chunkEntry(values[len(values)-1], 65536)
+		if len(line) > maxEntrySize {
+			chunkedEntries, err := chunkEntry(values[len(values)-1], maxEntrySize)
 			if err != nil {
 				return nil, errors.Newf("failed to split entry into chunks: %w")
 			}

--- a/dev/sg/internal/loki/loki_test.go
+++ b/dev/sg/internal/loki/loki_test.go
@@ -1,11 +1,86 @@
 package loki
 
 import (
+	"bytes"
+	"fmt"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/bk"
+	"github.com/sourcegraph/sourcegraph/internal/randstring"
 )
+
+func TestChunkEntry(t *testing.T) {
+	ts := time.Now().UnixNano()
+	line := "0123456789"
+	entry := [2]string{fmt.Sprintf("%d", ts), line}
+
+	results, err := chunkEntry(entry, 2)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if len(results) != len(line)/2 {
+		t.Errorf("Got %d chunks wanted %d", len(results), len(line)/2)
+	}
+
+	allLines := bytes.NewBuffer(nil)
+	for i := 0; i < len(results); i++ {
+		expectedTs := fmt.Sprintf("%d", ts+int64(i))
+		if results[i][0] != expectedTs {
+			t.Errorf("wrong timestamp at %d. Got %s wanted %s", i, results[i][0], expectedTs)
+		}
+		allLines.WriteString(results[i][1])
+	}
+
+	if allLines.String() != line {
+		t.Errorf("reconstructed chunked line differs from original line. Got %q wanted %q", allLines.String(), line)
+	}
+}
+
+func TestSplitIntoChunks(t *testing.T) {
+	t.Run("general split into chunks", func(t *testing.T) {
+		line := randstring.NewLen(100)
+
+		result := splitIntoChunks([]byte(line), 10)
+		if len(result) != 10 {
+			t.Errorf("expected string of size 100 to be split into 10 chunks. Got %d wanted %d", len(result), 10)
+		}
+	})
+
+	t.Run("chunk size larger than string", func(t *testing.T) {
+		line := randstring.NewLen(100)
+
+		result := splitIntoChunks([]byte(line), len(line)+1)
+		if len(result) != 1 {
+			t.Errorf("expected string of size 100 to be split into 10 chunks. Got %d wanted %d", len(result), 1)
+		}
+	})
+
+	t.Run("line size larger by 1 than chunk size", func(t *testing.T) {
+		line := randstring.NewLen(100)
+
+		result := splitIntoChunks([]byte(line), 99)
+		if len(result) != 2 {
+			t.Errorf("expected string of size 100 to be split into 10 chunks. Got %d wanted %d", len(result), 2)
+		}
+	})
+
+	t.Run("check chunk content", func(t *testing.T) {
+		line := "123456789"
+
+		result := splitIntoChunks([]byte(line), 5)
+
+		if bytes.Compare(result[0], []byte("12345")) != 0 {
+			t.Errorf("incorrect chunk content for 0 idx. Got %s wanted %s", string(result[0]), "12345")
+		}
+
+		if bytes.Compare(result[1], []byte("6789")) != 0 {
+			t.Errorf("incorrect chunk content for 0 idx. Got %s wanted %s", string(result[0]), "12345")
+		}
+	})
+}
 
 func TestNewStreamFromJobLogs(t *testing.T) {
 	type args struct {

--- a/dev/sg/internal/loki/loki_test.go
+++ b/dev/sg/internal/loki/loki_test.go
@@ -80,6 +80,18 @@ func TestSplitIntoChunks(t *testing.T) {
 			t.Errorf("incorrect chunk content for 0 idx. Got %s wanted %s", string(result[0]), "12345")
 		}
 	})
+
+	t.Run("chunk sizes", func(t *testing.T) {
+		line := randstring.NewLen(1337)
+
+		results := splitIntoChunks([]byte(line), 1024)
+
+		for i, r := range results {
+			if len(r) > 1024 {
+				t.Errorf("incorrect sized chunk found at %d with size %d", i, len(r))
+			}
+		}
+	})
 }
 
 func TestNewStreamFromJobLogs(t *testing.T) {


### PR DESCRIPTION
This addresses the following issue we were seeing on the pipeline
```
build 151159 job "0181205f-a064-4c8a-ae29-b4c8fc2acf48": unexpected status code 400: Max entry size '65536' bytes exceeded for stream '{app="buildkite", branch="main", build="151159", command="./tr dev/ci/yarn-web-integration.sh \"client/web/src/integration/batches.test.ts client/web/src/integration/blob-viewer.test.ts\"", component="build-logs", job="0181205f-a064-4c8a-ae29-b4c8fc2acf48", name=":puppeteer::electric_plug: Puppeteer tests chunk #1", queue="stateless,standard,default,job", retries_count="0", started_at="2022-06-01T17:51:40.783Z", state="failed", step_key="puppeteerelectricplugPuppeteertestschunk1", type="script"}' while adding an entry with length '563798' bytes]
```

1. After a line has been added to the stream values, we check whether we should split the line up into smaller pieces.
2. Each smaller piece has it's timestamp nanosecond value increased by 1 - this is safe todo, since the original Buildkite timestamps are in ms, so we on't override anything else (🙏🏼)
3. We  then replace the last value added with all the chunked pieces

Closes #36240
## Test plan
Unit Tests plus local loki instance

### Local Loki instance
Launch Loki with the following `docker-compose.yaml` which sets the `max_entry_line_size` to `1kb`
```
version: "3"

networks:
  loki:

services:
  loki:
    image: grafana/loki:2.5.0
    ports:
      - "3100:3100"
    command: -config.file=/etc/loki/local-config.yaml -distributor.max-line-size=1kb
    networks:
      - loki

  promtail:
    image: grafana/promtail:2.5.0
    volumes:
      - /var/log:/var/log
    command: -config.file=/etc/promtail/config.yml
    networks:
      - loki

  grafana:
    image: grafana/grafana:latest
    ports:
      - "3000:3000"
    networks:
      - loki
```

2. Launch it `docker-compose up -d`
3. Download build logs and push them to the local loki instance using the change in this PR
```
$ go run . ci logs --build 151159 -out http://127.0.0.1:3100
Fetching logs for https://buildkite.com/sourcegraph/sourcegraph/builds/151159 ...
Pushing to Loki instance at "127.0.0.1:3100"
✅ Pushed 1110 entries from 1 streams to Loki
```

### The error with current sg
```
ℹ️ Auto updating sg ...
✅ sg has been updated!
To see what's new, run 'sg version changelog'.
Fetching logs for https://buildkite.com/sourcegraph/sourcegraph/builds/151159 ...
Pushing to Loki instance at "127.0.0.1:3100"
❌ Failed to push 1 streams:
 - build 151159 job "0181205f-a064-4c8a-ae29-b4c8fc2acf48": unexpected status code 400: Max entry size '1024' bytes exceeded for stream '{app="buildkite", branch="", build="151159", command="./tr dev/ci/yarn-web-integration.sh \"client/web/src/integration/batches.test.ts client/web/src/integration/blob-viewer.test.ts\"", component="build-logs", exit_status="1", finished_at="2022-06-01T17:56:00.355Z", job="0181205f-a064-4c8a-ae29-b4c8fc2acf48", name=":puppeteer::electric_plug: Puppeteer tests chunk #1", queue="", retries_count="0", started_at="2022-06-01T17:51:40.783Z", state="failed", step_key="puppeteerelectricplugPuppeteertestschunk1", type="script"}' while adding an entry with length '1337' bytes
❌ failed to push all logs
```
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
