### PR TITLE
extsvc/bitbucketserver: add function which fetches all repos of a given Bitbucket project

### DIFF
--- a/internal/extsvc/bitbucketserver/client.go
+++ b/internal/extsvc/bitbucketserver/client.go
@@ -790,6 +790,27 @@ func (c *Client) LoadPullRequestBuildStatuses(ctx context.Context, pr *PullReque
 	return nil
 }
 
+// ProjectRepos returns all repos of a project with a given projectKey
+func (c *Client) ProjectRepos(ctx context.Context, projectKey string) (repos []*Repo, err error) {
+	if projectKey == "" {
+		return nil, errors.New("project key empty")
+	}
+
+	path := fmt.Sprintf("rest/api/1.0/projects/%s/repos", projectKey)
+
+	pageToken := &PageToken{Limit: 1000}
+
+	for pageToken.HasMore() {
+		var page []*Repo
+		if pageToken, err = c.page(ctx, path, nil, pageToken, &page); err != nil {
+			return nil, err
+		}
+		repos = append(repos, page...)
+	}
+
+	return repos, nil
+}
+
 func (c *Client) Repo(ctx context.Context, projectKey, repoSlug string) (*Repo, error) {
 	u := fmt.Sprintf("rest/api/1.0/projects/%s/repos/%s", projectKey, repoSlug)
 	req, err := http.NewRequest("GET", u, nil)

--- a/internal/extsvc/bitbucketserver/client_test.go
+++ b/internal/extsvc/bitbucketserver/client_test.go
@@ -1268,6 +1268,23 @@ func TestClient_CreateFork(t *testing.T) {
 	checkGolden(t, fixture, have)
 }
 
+func TestClient_ProjectRepos(t *testing.T) {
+	cli := NewTestClient(t, "ProjectRepos", *update)
+
+	// Empty project key should cause an error
+	repos, err := cli.ProjectRepos(context.Background(), "")
+	if err == nil {
+		t.Fatal("Empty projectKey should cause an error", err)
+	}
+
+	repos, err = cli.ProjectRepos(context.Background(), "SGDEMO")
+	if err != nil {
+		t.Fatal("Error during getting SGDEMO project repos", err)
+	}
+
+	checkGolden(t, "ProjectRepos", repos)
+}
+
 func TestMain(m *testing.M) {
 	flag.Parse()
 	if !testing.Verbose() {

--- a/internal/extsvc/bitbucketserver/client_test.go
+++ b/internal/extsvc/bitbucketserver/client_test.go
@@ -1272,12 +1272,12 @@ func TestClient_ProjectRepos(t *testing.T) {
 	cli := NewTestClient(t, "ProjectRepos", *update)
 
 	// Empty project key should cause an error
-	repos, err := cli.ProjectRepos(context.Background(), "")
+	_, err := cli.ProjectRepos(context.Background(), "")
 	if err == nil {
 		t.Fatal("Empty projectKey should cause an error", err)
 	}
 
-	repos, err = cli.ProjectRepos(context.Background(), "SGDEMO")
+	repos, err := cli.ProjectRepos(context.Background(), "SGDEMO")
 	if err != nil {
 		t.Fatal("Error during getting SGDEMO project repos", err)
 	}

--- a/internal/extsvc/bitbucketserver/testdata/golden/ProjectRepos
+++ b/internal/extsvc/bitbucketserver/testdata/golden/ProjectRepos
@@ -1,0 +1,254 @@
+[
+  {
+   "slug": "go",
+   "id": 10060,
+   "name": "go",
+   "scmId": "git",
+   "state": "AVAILABLE",
+   "statusMessage": "Available",
+   "forkable": true,
+   "origin": null,
+   "project": {
+    "key": "SGDEMO",
+    "id": 26,
+    "name": "Sourcegraph Demo",
+    "public": false,
+    "type": "NORMAL",
+    "links": {
+     "self": [
+      {
+       "href": "https://bitbucket.sgdev.org/projects/SGDEMO"
+      }
+     ]
+    }
+   },
+   "public": false,
+   "links": {
+    "clone": [
+     {
+      "href": "https://bitbucket.sgdev.org/scm/sgdemo/go.git",
+      "name": "http"
+     },
+     {
+      "href": "ssh://git@bitbucket.sgdev.org:7999/sgdemo/go.git",
+      "name": "ssh"
+     }
+    ],
+    "self": [
+     {
+      "href": "https://bitbucket.sgdev.org/projects/SGDEMO/repos/go/browse"
+     }
+    ]
+   }
+  },
+  {
+   "slug": "jenkins",
+   "id": 10056,
+   "name": "jenkins",
+   "scmId": "git",
+   "state": "AVAILABLE",
+   "statusMessage": "Available",
+   "forkable": true,
+   "origin": null,
+   "project": {
+    "key": "SGDEMO",
+    "id": 26,
+    "name": "Sourcegraph Demo",
+    "public": false,
+    "type": "NORMAL",
+    "links": {
+     "self": [
+      {
+       "href": "https://bitbucket.sgdev.org/projects/SGDEMO"
+      }
+     ]
+    }
+   },
+   "public": false,
+   "links": {
+    "clone": [
+     {
+      "href": "https://bitbucket.sgdev.org/scm/sgdemo/jenkins.git",
+      "name": "http"
+     },
+     {
+      "href": "ssh://git@bitbucket.sgdev.org:7999/sgdemo/jenkins.git",
+      "name": "ssh"
+     }
+    ],
+    "self": [
+     {
+      "href": "https://bitbucket.sgdev.org/projects/SGDEMO/repos/jenkins/browse"
+     }
+    ]
+   }
+  },
+  {
+   "slug": "mux",
+   "id": 10061,
+   "name": "mux",
+   "scmId": "git",
+   "state": "AVAILABLE",
+   "statusMessage": "Available",
+   "forkable": true,
+   "origin": null,
+   "project": {
+    "key": "SGDEMO",
+    "id": 26,
+    "name": "Sourcegraph Demo",
+    "public": false,
+    "type": "NORMAL",
+    "links": {
+     "self": [
+      {
+       "href": "https://bitbucket.sgdev.org/projects/SGDEMO"
+      }
+     ]
+    }
+   },
+   "public": false,
+   "links": {
+    "clone": [
+     {
+      "href": "ssh://git@bitbucket.sgdev.org:7999/sgdemo/mux.git",
+      "name": "ssh"
+     },
+     {
+      "href": "https://bitbucket.sgdev.org/scm/sgdemo/mux.git",
+      "name": "http"
+     }
+    ],
+    "self": [
+     {
+      "href": "https://bitbucket.sgdev.org/projects/SGDEMO/repos/mux/browse"
+     }
+    ]
+   }
+  },
+  {
+   "slug": "sentry",
+   "id": 10058,
+   "name": "sentry",
+   "scmId": "git",
+   "state": "AVAILABLE",
+   "statusMessage": "Available",
+   "forkable": true,
+   "origin": null,
+   "project": {
+    "key": "SGDEMO",
+    "id": 26,
+    "name": "Sourcegraph Demo",
+    "public": false,
+    "type": "NORMAL",
+    "links": {
+     "self": [
+      {
+       "href": "https://bitbucket.sgdev.org/projects/SGDEMO"
+      }
+     ]
+    }
+   },
+   "public": false,
+   "links": {
+    "clone": [
+     {
+      "href": "ssh://git@bitbucket.sgdev.org:7999/sgdemo/sentry.git",
+      "name": "ssh"
+     },
+     {
+      "href": "https://bitbucket.sgdev.org/scm/sgdemo/sentry.git",
+      "name": "http"
+     }
+    ],
+    "self": [
+     {
+      "href": "https://bitbucket.sgdev.org/projects/SGDEMO/repos/sentry/browse"
+     }
+    ]
+   }
+  },
+  {
+   "slug": "sinatra",
+   "id": 10059,
+   "name": "sinatra",
+   "scmId": "git",
+   "state": "AVAILABLE",
+   "statusMessage": "Available",
+   "forkable": true,
+   "origin": null,
+   "project": {
+    "key": "SGDEMO",
+    "id": 26,
+    "name": "Sourcegraph Demo",
+    "public": false,
+    "type": "NORMAL",
+    "links": {
+     "self": [
+      {
+       "href": "https://bitbucket.sgdev.org/projects/SGDEMO"
+      }
+     ]
+    }
+   },
+   "public": false,
+   "links": {
+    "clone": [
+     {
+      "href": "ssh://git@bitbucket.sgdev.org:7999/sgdemo/sinatra.git",
+      "name": "ssh"
+     },
+     {
+      "href": "https://bitbucket.sgdev.org/scm/sgdemo/sinatra.git",
+      "name": "http"
+     }
+    ],
+    "self": [
+     {
+      "href": "https://bitbucket.sgdev.org/projects/SGDEMO/repos/sinatra/browse"
+     }
+    ]
+   }
+  },
+  {
+   "slug": "sourcegraph",
+   "id": 10072,
+   "name": "sourcegraph",
+   "scmId": "git",
+   "state": "AVAILABLE",
+   "statusMessage": "Available",
+   "forkable": true,
+   "origin": null,
+   "project": {
+    "key": "SGDEMO",
+    "id": 26,
+    "name": "Sourcegraph Demo",
+    "public": false,
+    "type": "NORMAL",
+    "links": {
+     "self": [
+      {
+       "href": "https://bitbucket.sgdev.org/projects/SGDEMO"
+      }
+     ]
+    }
+   },
+   "public": false,
+   "links": {
+    "clone": [
+     {
+      "href": "https://bitbucket.sgdev.org/scm/sgdemo/sourcegraph.git",
+      "name": "http"
+     },
+     {
+      "href": "ssh://git@bitbucket.sgdev.org:7999/sgdemo/sourcegraph.git",
+      "name": "ssh"
+     }
+    ],
+    "self": [
+     {
+      "href": "https://bitbucket.sgdev.org/projects/SGDEMO/repos/sourcegraph/browse"
+     }
+    ]
+   }
+  }
+ ]

--- a/internal/extsvc/bitbucketserver/testdata/vcr/ProjectRepos.yaml
+++ b/internal/extsvc/bitbucketserver/testdata/vcr/ProjectRepos.yaml
@@ -1,0 +1,46 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    url: https://bitbucket.sgdev.org/rest/api/1.0/projects/SGDEMO/repos?limit=1000
+    method: GET
+  response:
+    body: '{"size":6,"limit":1000,"isLastPage":true,"values":[{"slug":"go","id":10060,"name":"go","hierarchyId":"d501682e55fecfa03127","scmId":"git","state":"AVAILABLE","statusMessage":"Available","forkable":true,"project":{"key":"SGDEMO","id":26,"name":"Sourcegraph
+      Demo","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SGDEMO"}]}},"public":false,"links":{"clone":[{"href":"https://bitbucket.sgdev.org/scm/sgdemo/go.git","name":"http"},{"href":"ssh://git@bitbucket.sgdev.org:7999/sgdemo/go.git","name":"ssh"}],"self":[{"href":"https://bitbucket.sgdev.org/projects/SGDEMO/repos/go/browse"}]}},{"slug":"jenkins","id":10056,"name":"jenkins","hierarchyId":"fb39a4ab2229a1dca749","scmId":"git","state":"AVAILABLE","statusMessage":"Available","forkable":true,"project":{"key":"SGDEMO","id":26,"name":"Sourcegraph
+      Demo","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SGDEMO"}]}},"public":false,"links":{"clone":[{"href":"https://bitbucket.sgdev.org/scm/sgdemo/jenkins.git","name":"http"},{"href":"ssh://git@bitbucket.sgdev.org:7999/sgdemo/jenkins.git","name":"ssh"}],"self":[{"href":"https://bitbucket.sgdev.org/projects/SGDEMO/repos/jenkins/browse"}]}},{"slug":"mux","id":10061,"name":"mux","hierarchyId":"0d4300690a86a5f092e8","scmId":"git","state":"AVAILABLE","statusMessage":"Available","forkable":true,"project":{"key":"SGDEMO","id":26,"name":"Sourcegraph
+      Demo","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SGDEMO"}]}},"public":false,"links":{"clone":[{"href":"ssh://git@bitbucket.sgdev.org:7999/sgdemo/mux.git","name":"ssh"},{"href":"https://bitbucket.sgdev.org/scm/sgdemo/mux.git","name":"http"}],"self":[{"href":"https://bitbucket.sgdev.org/projects/SGDEMO/repos/mux/browse"}]}},{"slug":"sentry","id":10058,"name":"sentry","hierarchyId":"1e9ccf2f27d0aefa3271","scmId":"git","state":"AVAILABLE","statusMessage":"Available","forkable":true,"project":{"key":"SGDEMO","id":26,"name":"Sourcegraph
+      Demo","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SGDEMO"}]}},"public":false,"links":{"clone":[{"href":"ssh://git@bitbucket.sgdev.org:7999/sgdemo/sentry.git","name":"ssh"},{"href":"https://bitbucket.sgdev.org/scm/sgdemo/sentry.git","name":"http"}],"self":[{"href":"https://bitbucket.sgdev.org/projects/SGDEMO/repos/sentry/browse"}]}},{"slug":"sinatra","id":10059,"name":"sinatra","hierarchyId":"f73beb33325ff3524a15","scmId":"git","state":"AVAILABLE","statusMessage":"Available","forkable":true,"project":{"key":"SGDEMO","id":26,"name":"Sourcegraph
+      Demo","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SGDEMO"}]}},"public":false,"links":{"clone":[{"href":"ssh://git@bitbucket.sgdev.org:7999/sgdemo/sinatra.git","name":"ssh"},{"href":"https://bitbucket.sgdev.org/scm/sgdemo/sinatra.git","name":"http"}],"self":[{"href":"https://bitbucket.sgdev.org/projects/SGDEMO/repos/sinatra/browse"}]}},{"slug":"sourcegraph","id":10072,"name":"sourcegraph","hierarchyId":"76ff9f89ef912cb3eed5","scmId":"git","state":"AVAILABLE","statusMessage":"Available","forkable":true,"project":{"key":"SGDEMO","id":26,"name":"Sourcegraph
+      Demo","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SGDEMO"}]}},"public":false,"links":{"clone":[{"href":"https://bitbucket.sgdev.org/scm/sgdemo/sourcegraph.git","name":"http"},{"href":"ssh://git@bitbucket.sgdev.org:7999/sgdemo/sourcegraph.git","name":"ssh"}],"self":[{"href":"https://bitbucket.sgdev.org/projects/SGDEMO/repos/sourcegraph/browse"}]}}],"start":0}'
+    headers:
+      Cache-Control:
+      - private, no-cache
+      - no-cache, no-transform
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Thu, 02 Jun 2022 13:18:04 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Caddy
+      Vary:
+      - x-ausername,x-auserid,cookie,accept-encoding
+      X-Arequestid:
+      - '@157E7ZCx798x1720546x0'
+      X-Asessionid:
+      - kavc8p
+      X-Auserid:
+      - "1"
+      X-Ausername:
+      - milton
+      X-Content-Type-Options:
+      - nosniff
+    status: 200 OK
+    code: 200
+    duration: ""


### PR DESCRIPTION
This is used to read all of the repos of a given Bitbucket Project, which is required as a part of https://github.com/sourcegraph/sourcegraph/issues/36355 effort

Closes https://github.com/sourcegraph/sourcegraph/issues/36372

## Test plan
New test added
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
