### PR TITLE
batches: allow code snippet display overflow

### DIFF
--- a/client/web/src/enterprise/batches/create/OldCreateBatchChangeContent.tsx
+++ b/client/web/src/enterprise/batches/create/OldCreateBatchChangeContent.tsx
@@ -87,7 +87,7 @@ export const OldBatchChangePageContent: React.FunctionComponent<React.PropsWithC
                         ))}
                     </SidebarGroup>
                 </div>
-                <Container className="ml-3 flex-grow-1">
+                <Container className="ml-3 flex-grow-1 overflow-auto">
                     <CodeSnippet code={selectedSample.file} language="yaml" className="mb-0" />
                 </Container>
             </div>


### PR DESCRIPTION
## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Ensure long snippets are displayed properly in Batch Change page.

#### Before
<img width="2114" alt="CleanShot 2022-06-02 at 15 28 04@2x" src="https://user-images.githubusercontent.com/25608335/171641081-91ea9c2d-c9fb-4c20-96a8-417bfce96b40.png">

#### After
<img width="2114" alt="CleanShot 2022-06-02 at 15 28 04@2x" src="https://user-images.githubusercontent.com/25608335/171641026-a91a0d00-3883-4b6c-9167-20563ef038dd.png">


## App preview:

- [Web](https://sg-web-bo-fix-batch-change-example.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-rthkxvliij.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

