### PR TITLE
Fix PGHOST env var in sg.config.yaml

### DIFF
--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -504,7 +504,7 @@ commands:
     # database:
     #
     #   env:
-    #       POSTGRES_HOST: localhost
+    #       PGHOST: localhost
     #       PGPASSWORD: sourcegraph
     #       PGUSER: sourcegraph
     #


### PR DESCRIPTION
POSTGRES_HOST doesn't seem to work when running `sg run redis-postgres`:

    $ POSTGRES_HOST=localhost PGPASSWORD=sourcegraph PGUSER=sourcegraph psql
    psql: error: connection to server on socket "/tmp/.s.PGSQL.5432" failed: No such file or directory
            Is the server running locally and accepting connections on that socket?

    $ PGHOST=localhost PGPASSWORD=sourcegraph PGUSER=sourcegraph psql
    Null display is "[NULL]".
    Expanded display is used automatically.
    psql (14.1, server 12.7)
    Type "help" for help.

    sourcegraph@localhost:5432 sourcegraph#

## Test plan

- See description
