### PR TITLE
Commit/diff search: remove limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Code Insights: Added warnings about adding `context:` and `repo:` filters in search query.
 - Batch Changes: The credentials of the last applying user will now be used to sync changesets when available. If unavailable, then the previous behaviour of using a site or code host configuration credential is retained. [#33413](https://github.com/sourcegraph/sourcegraph/issues/33413)
 - Gitserver: we disable automatic git-gc for invocations of git-fetch to avoid corruption of repositories by competing git-gc processes. [#36274](https://github.com/sourcegraph/sourcegraph/pull/36274)
+- Commit and diff search: The hard limit of 50 repositories has been removed, and long-running searches will continue running until the timeout is hit. [#36486](https://github.com/sourcegraph/sourcegraph/pull/36486)
 
 ### Fixed
 

--- a/internal/search/alert/observer_test.go
+++ b/internal/search/alert/observer_test.go
@@ -4,49 +4,15 @@ import (
 	"context"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
 
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/search"
-	"github.com/sourcegraph/sourcegraph/internal/search/commit"
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
 	"github.com/sourcegraph/sourcegraph/internal/search/run"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
-
-func TestAlertForDiffCommitSearchLimits(t *testing.T) {
-	cases := []struct {
-		name                 string
-		multiErr             error
-		wantAlertDescription string
-	}{
-		{
-			name:                 "diff_search_warns_on_repos_greater_than_search_limit",
-			multiErr:             errors.Append(nil, &commit.RepoLimitError{ResultType: "diff", Max: 50}),
-			wantAlertDescription: `Diff search can currently only handle searching across 50 repositories at a time. Try using the "repo:" filter to narrow down which repositories to search, or using 'after:"1 week ago"'.`,
-		},
-		{
-			name:                 "commit_search_warns_on_repos_greater_than_search_limit",
-			multiErr:             errors.Append(nil, &commit.RepoLimitError{ResultType: "commit", Max: 50}),
-			wantAlertDescription: `Commit search can currently only handle searching across 50 repositories at a time. Try using the "repo:" filter to narrow down which repositories to search, or using 'after:"1 week ago"'.`,
-		},
-		{
-			name:                 "commit_search_warns_on_repos_greater_than_search_limit_with_time_filter",
-			multiErr:             errors.Append(nil, &commit.TimeLimitError{ResultType: "commit", Max: 10000}),
-			wantAlertDescription: `Commit search can currently only handle searching across 10000 repositories at a time. Try using the "repo:" filter to narrow down which repositories to search.`,
-		},
-	}
-
-	for _, test := range cases {
-		alert, _ := (&Observer{}).errorToAlert(context.Background(), test.multiErr)
-		haveAlertDescription := alert.Description
-		if diff := cmp.Diff(test.wantAlertDescription, haveAlertDescription); diff != "" {
-			t.Fatalf("test %s, mismatched alert (-want, +got):\n%s", test.name, diff)
-		}
-	}
-}
 
 func TestErrorToAlertStructuralSearch(t *testing.T) {
 	cases := []struct {

--- a/internal/search/commit/commit.go
+++ b/internal/search/commit/commit.go
@@ -94,7 +94,7 @@ func (j *SearchJob) Run(ctx context.Context, clients job.RuntimeClients, stream 
 		return doSearch(args)
 	}
 
-	bounded := goroutine.NewBounded(8)
+	bounded := goroutine.NewBounded(4)
 	defer func() { err = errors.Append(err, bounded.Wait()) }()
 
 	repos := searchrepos.Resolver{DB: clients.DB, Opts: j.RepoOpts}

--- a/internal/search/commit/commit.go
+++ b/internal/search/commit/commit.go
@@ -30,7 +30,6 @@ type SearchJob struct {
 	RepoOpts             search.RepoOptions
 	Diff                 bool
 	Limit                int
-	CodeMonitorID        *int64
 	IncludeModifiedFiles bool
 
 	// CodeMonitorSearchWrapper, if set, will wrap the commit search with extra logic specific to code monitors.

--- a/internal/search/commit/commit.go
+++ b/internal/search/commit/commit.go
@@ -23,6 +23,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 type SearchJob struct {

--- a/internal/search/job/jobutil/job.go
+++ b/internal/search/job/jobutil/job.go
@@ -126,7 +126,6 @@ func NewBasicJob(inputs *run.SearchInputs, b query.Basic) (job.Job, error) {
 				Query:                commit.QueryToGitQuery(b, diff),
 				RepoOpts:             repoOptionsCopy,
 				Diff:                 diff,
-				HasTimeFilter:        b.Exists("after") || b.Exists("before"),
 				Limit:                int(fileMatchLimit),
 				IncludeModifiedFiles: authz.SubRepoEnabled(authz.DefaultSubRepoPermsChecker),
 			})


### PR DESCRIPTION
This removes all limits on the number of repositories searched from commit and diff search. Instead, we search repos in a paginated fashion, and continue searching until we hit a timeout.

The diff is a little messy, but each commit is pretty readable if you'd prefer to review more incrementally.

Some background: We currently have a hard cap of 50 repos for commit and diff search. This is because commit and diff search are not currently indexable, and diff search in particular is extremely expensive (diff search over just the sourcegraph/sourcegraph repo currently takes roughly 20s).

Then, a while ago, we added support for streaming the list of repos to search from the db. It adds a non-negligible amount of latency to resolve the full set of searchable repos, so instead, we do it 500 (by default) at a time which lets us start searching much sooner. 

However, because code monitors were so expensive, we still needed to enforce limits there in order to keep from overloading the system with bad monitors. Now that all users on sourcegraph.com are using repo-aware monitors, this is no longer a concern and we can just keep searching until we hit the timeout. 

## Test plan

Manually tested that we run commit and diff search for any number of repositories up to the configured timeout. Also am running backend integration tests on this branch. 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
