### PR TITLE
Fix FeatureFlagClient to handle race conditions calls

### DIFF
--- a/client/web/src/featureFlags/lib/FeatureFlagClient.test.ts
+++ b/client/web/src/featureFlags/lib/FeatureFlagClient.test.ts
@@ -1,0 +1,121 @@
+import { combineLatest, of } from 'rxjs'
+import sinon, { SinonSpy } from 'sinon'
+
+import { requestGraphQL } from '../../backend/graphql'
+import type { FeatureFlagName } from '../featureFlags'
+
+import { setFeatureFlagOverride } from './feature-flag-local-overrides'
+import { FeatureFlagClient } from './FeatureFlagClient'
+
+describe('FeatureFlagClient', () => {
+    const ENABLED_FLAG = 'enabled-flag' as FeatureFlagName
+    const DISABLED_FLAG = 'disabled-flag' as FeatureFlagName
+
+    const mockRequestGraphQL = sinon.spy(() =>
+        of({
+            data: {
+                viewerFeatureFlags: [
+                    {
+                        name: ENABLED_FLAG,
+                        value: true,
+                    },
+                    {
+                        name: DISABLED_FLAG,
+                        value: false,
+                    },
+                ],
+            },
+            errors: [],
+        })
+    ) as typeof requestGraphQL & SinonSpy
+
+    beforeEach(() => mockRequestGraphQL.resetHistory())
+
+    it('makes initial API call', () => {
+        new FeatureFlagClient(mockRequestGraphQL)
+        sinon.assert.calledOnce(mockRequestGraphQL)
+    })
+
+    it('returns [true] response from API call for feature flag evaluation', done => {
+        const client = new FeatureFlagClient(mockRequestGraphQL)
+        expect.assertions(1)
+
+        client.get(ENABLED_FLAG).subscribe(value => {
+            expect(value).toBe(true)
+            sinon.assert.calledOnce(mockRequestGraphQL)
+            done()
+        })
+    })
+
+    it('returns [false] response from API call for feature flag evaluation', done => {
+        const client = new FeatureFlagClient(mockRequestGraphQL)
+        expect.assertions(1)
+
+        client.get(DISABLED_FLAG).subscribe({
+            next: value => {
+                expect(value).toBe(false)
+                sinon.assert.calledOnce(mockRequestGraphQL)
+                done()
+            },
+            complete: () => {
+                throw new Error('Should not complete when passing refetch interval')
+            },
+        })
+    })
+
+    it('makes only single API call per feature flag evaluation', done => {
+        const client = new FeatureFlagClient(mockRequestGraphQL)
+        expect.assertions(2)
+
+        combineLatest([client.get(ENABLED_FLAG), client.get(DISABLED_FLAG)]).subscribe(([value1, value2]) => {
+            expect(value1).toBe(true)
+            expect(value2).toBe(false)
+            sinon.assert.calledOnce(mockRequestGraphQL)
+            done()
+        })
+    })
+
+    describe('local feature flag overrides', () => {
+        beforeEach(() => {
+            // remove local overrides
+            localStorage.clear()
+        })
+        it('returns [false] override if it exists', done => {
+            const client = new FeatureFlagClient(mockRequestGraphQL)
+            setFeatureFlagOverride(ENABLED_FLAG, false)
+            expect.assertions(1)
+
+            client.get(ENABLED_FLAG).subscribe(value => {
+                expect(value).toBe(false)
+                sinon.assert.calledOnce(mockRequestGraphQL)
+                done()
+            })
+        })
+
+        it('returns [true] override if it exists', done => {
+            const client = new FeatureFlagClient(mockRequestGraphQL)
+            setFeatureFlagOverride(DISABLED_FLAG, true)
+            expect.assertions(1)
+
+            client.get(DISABLED_FLAG).subscribe(value => {
+                expect(value).toBe(true)
+                sinon.assert.calledOnce(mockRequestGraphQL)
+                done()
+            })
+        })
+
+        it('does not use non-boolean override', done => {
+            const client = new FeatureFlagClient(mockRequestGraphQL)
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+            // @ts-ignore
+            setFeatureFlagOverride(DISABLED_FLAG, 'something else')
+            expect.assertions(1)
+
+            client.get(DISABLED_FLAG).subscribe(value => {
+                expect(value).toBe(false)
+                sinon.assert.calledOnce(mockRequestGraphQL)
+                done()
+            })
+        })
+    })
+})

--- a/client/web/src/featureFlags/useFeatureFlag.test.tsx
+++ b/client/web/src/featureFlags/useFeatureFlag.test.tsx
@@ -1,0 +1,72 @@
+import { renderHook } from '@testing-library/react-hooks'
+
+import { FeatureFlagName } from './featureFlags'
+import { MockedFeatureFlagsProvider } from './FeatureFlagsProvider'
+import { useFeatureFlag } from './useFeatureFlag'
+
+describe('useFeatureFlag', () => {
+    const ENABLED_FLAG = 'enabled-flag' as FeatureFlagName
+    const DISABLED_FLAG = 'disabled-flag' as FeatureFlagName
+    const setup = (initialFlagName: FeatureFlagName) =>
+        renderHook(({ flagName }) => useFeatureFlag(flagName), {
+            wrapper: function Wrapper({ children, overrides }) {
+                return (
+                    <MockedFeatureFlagsProvider
+                        overrides={
+                            new Map(
+                                Object.entries({ [ENABLED_FLAG]: true, ...overrides }) as [FeatureFlagName, boolean][]
+                            )
+                        }
+                    >
+                        {children}
+                    </MockedFeatureFlagsProvider>
+                )
+            },
+            initialProps: {
+                flagName: initialFlagName,
+                overrides: {
+                    [DISABLED_FLAG]: false,
+                },
+            },
+        })
+
+    it('returns [false] value correctly', () => {
+        const state = setup(DISABLED_FLAG)
+
+        expect(state.result.all[0]).toStrictEqual([false, 'initial', undefined])
+
+        expect(state.result.current).toStrictEqual([false, 'loaded', undefined])
+
+        expect(state.result.all.length).toBe(2)
+    })
+
+    it('returns [true] value correctly', () => {
+        const state = setup(ENABLED_FLAG)
+
+        expect(state.result.all[0]).toStrictEqual([false, 'initial', undefined])
+
+        expect(state.result.current).toStrictEqual([true, 'loaded', undefined])
+
+        expect(state.result.all.length).toBe(2)
+    })
+
+    it('updates when feature flag prop changes', () => {
+        const state = setup(ENABLED_FLAG)
+
+        expect(state.result.all[0]).toStrictEqual([false, 'initial', undefined])
+        expect(state.result.current).toStrictEqual([true, 'loaded', undefined])
+
+        state.rerender({ overrides: {}, flagName: DISABLED_FLAG })
+        expect(state.result.current).toStrictEqual([false, 'loaded', undefined])
+    })
+
+    it('returns "error" when no context parent', () => {
+        const state = renderHook(() => useFeatureFlag(ENABLED_FLAG))
+
+        expect(state.result.all[0]).toStrictEqual([false, 'initial', undefined])
+
+        expect(state.result.current).toEqual(expect.arrayContaining([false, 'error']))
+
+        expect(state.result.all.length).toBe(2)
+    })
+})

--- a/client/web/src/featureFlags/withFeatureFlag.test.tsx
+++ b/client/web/src/featureFlags/withFeatureFlag.test.tsx
@@ -1,0 +1,55 @@
+import { render } from '@testing-library/react'
+
+import { FeatureFlagName } from './featureFlags'
+import { MockedFeatureFlagsProvider } from './FeatureFlagsProvider'
+import { withFeatureFlag } from './withFeatureFlag'
+
+describe('withFeatureFlag', () => {
+    const TrueComponent = () => <div data-testid="true-component">rendered when flag is true</div>
+    const FalseComponent = () => <div data-testid="false-component">rendered when flag is false</div>
+    const Wrapper = withFeatureFlag('test-flag' as FeatureFlagName, TrueComponent, FalseComponent)
+
+    it('renders correctly when flagValue=true', () => {
+        const { getByTestId } = render(
+            <MockedFeatureFlagsProvider overrides={new Map([['test-flag' as FeatureFlagName, true]])}>
+                <Wrapper />
+            </MockedFeatureFlagsProvider>
+        )
+
+        expect(getByTestId('true-component')).toBeTruthy()
+    })
+
+    it('renders correctly when flagValue=false', () => {
+        const { getByTestId } = render(
+            <MockedFeatureFlagsProvider overrides={new Map([['test-flag' as FeatureFlagName, false]])}>
+                <Wrapper />
+            </MockedFeatureFlagsProvider>
+        )
+
+        expect(getByTestId('false-component')).toBeTruthy()
+    })
+
+    it('waits until flag value is resolved', () => {
+        const { queryByTestId } = render(
+            <MockedFeatureFlagsProvider
+                overrides={new Map([['test-flag' as FeatureFlagName, new Error('Failed to fetch')]])}
+            >
+                <Wrapper />
+            </MockedFeatureFlagsProvider>
+        )
+
+        expect(queryByTestId('false-component')).toBeFalsy()
+        expect(queryByTestId('true-component')).toBeFalsy()
+    })
+
+    it('renders correctly when flagValue=false and FalseComponent omitted', () => {
+        const LocalWrapper = withFeatureFlag('test-flag' as FeatureFlagName, TrueComponent)
+        const { container } = render(
+            <MockedFeatureFlagsProvider overrides={new Map([['test-flag' as FeatureFlagName, false]])}>
+                <LocalWrapper />
+            </MockedFeatureFlagsProvider>
+        )
+
+        expect(container.innerHTML).toBeFalsy()
+    })
+})

--- a/client/web/src/featureFlags/withFeatureFlag.tsx
+++ b/client/web/src/featureFlags/withFeatureFlag.tsx
@@ -7,13 +7,20 @@ import { useFeatureFlag } from './useFeatureFlag'
  * HOC. Renders component when a certain feature flag value equals to a desired value.
  */
 export const withFeatureFlag = <P extends object>(
-    Component: React.ComponentType<React.PropsWithChildren<P>>,
     flagName: FeatureFlagName,
-    flagValue: boolean = true
-) => (props: P): React.ReactElement | null => {
-    const [value] = useFeatureFlag(flagName)
-    if (value !== flagValue) {
-        return null
+    TrueComponent: React.ComponentType<React.PropsWithChildren<P>>,
+    FalseComponent?: React.ComponentType<React.PropsWithChildren<P>> | null
+) =>
+    function WithFeatureFlagHOC(props: P): React.ReactElement | null {
+        const [value, status] = useFeatureFlag(flagName)
+
+        if (status !== 'finished') {
+            return null
+        }
+
+        if (value === true) {
+            return <TrueComponent {...props} />
+        }
+
+        return FalseComponent ? <FalseComponent {...props} /> : null
     }
-    return <Component {...props} />
-}

--- a/client/web/src/featureFlags/withFeatureFlag.tsx
+++ b/client/web/src/featureFlags/withFeatureFlag.tsx
@@ -14,7 +14,7 @@ export const withFeatureFlag = <P extends object>(
     function WithFeatureFlagHOC(props: P): React.ReactElement | null {
         const [value, status] = useFeatureFlag(flagName)
 
-        if (status !== 'finished') {
+        if (status !== 'loaded') {
             return null
         }
 

--- a/client/web/src/tour/GettingStartedTour.tsx
+++ b/client/web/src/tour/GettingStartedTour.tsx
@@ -34,7 +34,7 @@ const TourWithErrorBoundary = withErrorBoundary(
 )
 
 // Show for enabled control group
-export const TourAuthenticated = withFeatureFlag(Tour, 'quick-start-tour-for-authenticated-users')
+export const TourAuthenticated = withFeatureFlag('quick-start-tour-for-authenticated-users', Tour)
 
 export const GettingStartedTour = Object.assign(TourWithErrorBoundary, {
     Info: TourInfo,


### PR DESCRIPTION
Part 2 of https://github.com/sourcegraph/sourcegraph/issues/35543. Follow-up https://github.com/sourcegraph/sourcegraph/pull/35531.

## Description
There are cases when initial calls to the `FeatureFlagClient` instance happen before the fetch request (which is called in the constructor) completes. This PR:
- Fixes it to always return fetched results
- Also, updates `useFeatureFlag` to use `useObservableWithStatus`
- Updates `withFeatureFlag` to allow rendering two components (when flag=true and when flag=false) and adds unit tests to 

## Test plan
- Unit tests added
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-erzhtor-fix-feature-flag-client.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-wutmgrduxy.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
