### PR TITLE
Add visitor tour with notebook links AB test

### DIFF
--- a/client/web/src/components/WebStory.tsx
+++ b/client/web/src/components/WebStory.tsx
@@ -9,6 +9,8 @@ import { MockedStoryProvider, MockedStoryProviderProps, usePrependStyles, useThe
 // eslint-disable-next-line no-restricted-imports
 import { DeprecatedTooltip, WildcardThemeContext } from '@sourcegraph/wildcard'
 
+import { MockedFeatureFlagsProvider } from '../featureFlags/FeatureFlagsProvider'
+
 import { BreadcrumbSetters, BreadcrumbsProps, useBreadcrumbs } from './Breadcrumbs'
 
 import webStyles from '../SourcegraphWebApp.scss'
@@ -40,14 +42,16 @@ export const WebStory: React.FunctionComponent<React.PropsWithChildren<WebStoryP
     return (
         <MockedStoryProvider mocks={mocks} useStrictMocking={useStrictMocking}>
             <WildcardThemeContext.Provider value={{ isBranded: true }}>
-                <MemoryRouter {...memoryRouterProps}>
-                    <DeprecatedTooltip />
-                    <Children
-                        {...breadcrumbSetters}
-                        isLightTheme={isLightTheme}
-                        telemetryService={NOOP_TELEMETRY_SERVICE}
-                    />
-                </MemoryRouter>
+                <MockedFeatureFlagsProvider overrides={{}}>
+                    <MemoryRouter {...memoryRouterProps}>
+                        <DeprecatedTooltip />
+                        <Children
+                            {...breadcrumbSetters}
+                            isLightTheme={isLightTheme}
+                            telemetryService={NOOP_TELEMETRY_SERVICE}
+                        />
+                    </MemoryRouter>
+                </MockedFeatureFlagsProvider>
             </WildcardThemeContext.Provider>
         </MockedStoryProvider>
     )

--- a/client/web/src/components/WebStory.tsx
+++ b/client/web/src/components/WebStory.tsx
@@ -9,8 +9,6 @@ import { MockedStoryProvider, MockedStoryProviderProps, usePrependStyles, useThe
 // eslint-disable-next-line no-restricted-imports
 import { DeprecatedTooltip, WildcardThemeContext } from '@sourcegraph/wildcard'
 
-import { MockedFeatureFlagsProvider } from '../featureFlags/FeatureFlagsProvider'
-
 import { BreadcrumbSetters, BreadcrumbsProps, useBreadcrumbs } from './Breadcrumbs'
 
 import webStyles from '../SourcegraphWebApp.scss'
@@ -42,16 +40,14 @@ export const WebStory: React.FunctionComponent<React.PropsWithChildren<WebStoryP
     return (
         <MockedStoryProvider mocks={mocks} useStrictMocking={useStrictMocking}>
             <WildcardThemeContext.Provider value={{ isBranded: true }}>
-                <MockedFeatureFlagsProvider overrides={{}}>
-                    <MemoryRouter {...memoryRouterProps}>
-                        <DeprecatedTooltip />
-                        <Children
-                            {...breadcrumbSetters}
-                            isLightTheme={isLightTheme}
-                            telemetryService={NOOP_TELEMETRY_SERVICE}
-                        />
-                    </MemoryRouter>
-                </MockedFeatureFlagsProvider>
+                <MemoryRouter {...memoryRouterProps}>
+                    <DeprecatedTooltip />
+                    <Children
+                        {...breadcrumbSetters}
+                        isLightTheme={isLightTheme}
+                        telemetryService={NOOP_TELEMETRY_SERVICE}
+                    />
+                </MemoryRouter>
             </WildcardThemeContext.Provider>
         </MockedStoryProvider>
     )

--- a/client/web/src/featureFlags/featureFlags.ts
+++ b/client/web/src/featureFlags/featureFlags.ts
@@ -8,7 +8,7 @@ export type FeatureFlagName =
     | 'open-beta-enabled'
     | 'quick-start-tour-for-authenticated-users'
     | 'new-repo-page'
-    | 'tour-visitors-notebook'
+    | 'ab-visitor-tour-with-notebooks'
 
 interface OrgFlagOverride {
     orgID: string

--- a/client/web/src/featureFlags/featureFlags.ts
+++ b/client/web/src/featureFlags/featureFlags.ts
@@ -4,7 +4,11 @@ import { OrgFeatureFlagOverridesResult, OrgFeatureFlagOverridesVariables } from 
 
 // A union of all feature flags we currently have.
 // If there are no feature flags at the moment, this should be `never`.
-export type FeatureFlagName = 'open-beta-enabled' | 'quick-start-tour-for-authenticated-users' | 'new-repo-page'
+export type FeatureFlagName =
+    | 'open-beta-enabled'
+    | 'quick-start-tour-for-authenticated-users'
+    | 'new-repo-page'
+    | 'tour-visitors-notebook'
 
 interface OrgFlagOverride {
     orgID: string

--- a/client/web/src/search/home/SearchPage.story.tsx
+++ b/client/web/src/search/home/SearchPage.story.tsx
@@ -14,6 +14,7 @@ import { extensionsController } from '@sourcegraph/shared/src/testing/searchTest
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
 
 import { WebStory } from '../../components/WebStory'
+import { MockedFeatureFlagsProvider } from '../../featureFlags/FeatureFlagsProvider'
 import { SourcegraphContext } from '../../jscontext'
 import { useExperimentalFeatures } from '../../stores'
 import { ThemePreference } from '../../stores/themeState'
@@ -157,7 +158,11 @@ add('Cloud with panels and collaborators', () => (
 
 add('Cloud marketing home', () => (
     <WebStory>
-        {webProps => <SearchPage {...defaultProps(webProps)} isSourcegraphDotCom={true} authenticatedUser={null} />}
+        {webProps => (
+            <MockedFeatureFlagsProvider overrides={{}}>
+                <SearchPage {...defaultProps(webProps)} isSourcegraphDotCom={true} authenticatedUser={null} />
+            </MockedFeatureFlagsProvider>
+        )}
     </WebStory>
 ))
 

--- a/client/web/src/tour/GettingStartedTour.tsx
+++ b/client/web/src/tour/GettingStartedTour.tsx
@@ -3,7 +3,32 @@ import { withFeatureFlag } from '../featureFlags/withFeatureFlag'
 import { Tour, TourProps } from './components/Tour/Tour'
 import { TourInfo } from './components/Tour/TourInfo'
 import { withErrorBoundary } from './components/withErrorBoundary'
-import { authenticatedExtraTask, authenticatedTasks, visitorsTasks } from './data'
+import {
+    authenticatedExtraTask,
+    authenticatedTasks,
+    visitorsTasks,
+    visitorsTasksWithNotebook,
+    visitorsTasksWithNotebookExtraTask,
+} from './data'
+
+function TourVisitorWithNotebook(props: Omit<TourProps, 'tasks' | 'id'>): JSX.Element {
+    return (
+        <Tour
+            {...props}
+            id="TourWithNotebook"
+            title="Code Search Basics"
+            keepCompletedTasks={true}
+            tasks={visitorsTasksWithNotebook}
+            extraTask={visitorsTasksWithNotebookExtraTask}
+        />
+    )
+}
+
+function TourVisitorRegular(props: Omit<TourProps, 'tasks' | 'id'>): JSX.Element {
+    return <Tour {...props} id="Tour" tasks={visitorsTasks} />
+}
+
+const TourVisitor = withFeatureFlag('tour-visitors-notebook', TourVisitorWithNotebook, TourVisitorRegular)
 
 type TourWithErrorBoundaryProps = Omit<TourProps, 'useStore' | 'eventPrefix' | 'tasks' | 'id'> & {
     isAuthenticated?: boolean
@@ -19,7 +44,7 @@ const TourWithErrorBoundary = withErrorBoundary(
 
         // Show visitors version
         if (!isAuthenticated) {
-            return <Tour {...props} id="Tour" tasks={visitorsTasks} />
+            return <TourVisitor {...props} />
         }
 
         return (

--- a/client/web/src/tour/GettingStartedTour.tsx
+++ b/client/web/src/tour/GettingStartedTour.tsx
@@ -28,7 +28,7 @@ function TourVisitorRegular(props: Omit<TourProps, 'tasks' | 'id'>): JSX.Element
     return <Tour {...props} id="Tour" tasks={visitorsTasks} />
 }
 
-const TourVisitor = withFeatureFlag('tour-visitors-notebook', TourVisitorWithNotebook, TourVisitorRegular)
+const TourVisitor = withFeatureFlag('ab-visitor-tour-with-notebooks', TourVisitorWithNotebook, TourVisitorRegular)
 
 type TourWithErrorBoundaryProps = Omit<TourProps, 'useStore' | 'eventPrefix' | 'tasks' | 'id'> & {
     isAuthenticated?: boolean

--- a/client/web/src/tour/components/Tour/Tour.module.scss
+++ b/client/web/src/tour/components/Tour/Tour.module.scss
@@ -174,3 +174,7 @@
     color: var(--icon-color);
     margin-right: 0.25rem;
 }
+
+.color-link {
+    color: var(--link-color);
+}

--- a/client/web/src/tour/components/Tour/Tour.module.scss
+++ b/client/web/src/tour/components/Tour/Tour.module.scss
@@ -89,6 +89,21 @@
     }
 }
 
+.no-title-task {
+    padding: 0.5rem 0 0 1rem;
+    position: relative;
+    &::after {
+        display: none !important;
+    }
+
+    &::before {
+        content: attr(data-order);
+        display: inline-block;
+        position: absolute;
+        left: 0;
+    }
+}
+
 .completed-items {
     flex-grow: 2 !important;
 

--- a/client/web/src/tour/components/Tour/Tour.tsx
+++ b/client/web/src/tour/components/Tour/Tour.tsx
@@ -13,7 +13,7 @@ export type TourProps = TelemetryProps & {
     id: string
     tasks: TourTaskType[]
     extraTask?: TourTaskType
-} & Pick<React.ComponentProps<typeof TourContent>, 'variant' | 'className' | 'height'>
+} & Pick<React.ComponentProps<typeof TourContent>, 'variant' | 'className' | 'height' | 'title' | 'keepCompletedTasks'>
 
 export const Tour: React.FunctionComponent<React.PropsWithChildren<TourProps>> = React.memo(
     ({ id: tourId, tasks, extraTask, telemetryService, ...props }) => {
@@ -113,7 +113,7 @@ export const Tour: React.FunctionComponent<React.PropsWithChildren<TourProps>> =
                     {...props}
                     onClose={onClose}
                     tasks={
-                        [...extendedTasks, status === 'completed' && extraTask].filter(Boolean) as (
+                        [status === 'completed' && extraTask, ...extendedTasks].filter(Boolean) as (
                             | TourTaskType
                             | TourTaskType
                         )[]
@@ -124,3 +124,5 @@ export const Tour: React.FunctionComponent<React.PropsWithChildren<TourProps>> =
         )
     }
 )
+
+Tour.displayName = 'Tour'

--- a/client/web/src/tour/components/Tour/TourContent.tsx
+++ b/client/web/src/tour/components/Tour/TourContent.tsx
@@ -15,6 +15,8 @@ import { TourTaskType } from './types'
 import styles from './Tour.module.scss'
 
 interface TourContentProps {
+    title?: string
+    keepCompletedTasks?: boolean
     tasks: (TourTaskType | TourTaskType)[]
     onClose: () => void
     variant?: 'horizontal'
@@ -22,16 +24,20 @@ interface TourContentProps {
     className?: string
 }
 
-const Header: React.FunctionComponent<React.PropsWithChildren<{ onClose: () => void }>> = ({ children, onClose }) => (
+const Header: React.FunctionComponent<{ onClose: () => void; title?: string }> = ({
+    children,
+    onClose,
+    title = 'Quick start',
+}) => (
     <div className="d-flex justify-content-between align-items-start">
-        <Text className={styles.title}>Quick start</Text>
+        <Text className={styles.title}>{title}</Text>
         <Button variant="icon" data-testid="tour-close-btn" onClick={onClose} aria-label="Close quick start">
             <Icon role="img" as={CloseIcon} aria-hidden={true} /> {children}
         </Button>
     </div>
 )
 
-const Footer: React.FunctionComponent<React.PropsWithChildren<{ completedCount: number; totalCount: number }>> = ({
+const Footer: React.FunctionComponent<{ completedCount: number; totalCount: number }> = ({
     completedCount,
     totalCount,
 }) => (
@@ -46,7 +52,7 @@ const Footer: React.FunctionComponent<React.PropsWithChildren<{ completedCount: 
     </Text>
 )
 
-const CompletedItem: React.FunctionComponent<React.PropsWithChildren<unknown>> = ({ children }) => (
+const CompletedItem: React.FunctionComponent = ({ children }) => (
     <li className="d-flex align-items-start">
         <Icon
             role="img"
@@ -59,15 +65,26 @@ const CompletedItem: React.FunctionComponent<React.PropsWithChildren<unknown>> =
     </li>
 )
 
-export const TourContent: React.FunctionComponent<React.PropsWithChildren<TourContentProps>> = ({
+export const TourContent: React.FunctionComponent<TourContentProps> = ({
     onClose,
     tasks,
     variant,
     className,
+    title,
+    keepCompletedTasks,
     height = 18,
 }) => {
     const { completedCount, totalCount, completedTasks, completedTaskChunks, ongoingTasks } = useMemo(() => {
         const completedTasks = tasks.filter(task => task.completed === 100)
+        if (keepCompletedTasks) {
+            return {
+                completedTasks: [],
+                ongoingTasks: tasks,
+                completedTaskChunks: [],
+                totalCount: tasks.filter(task => typeof task.completed === 'number').length,
+                completedCount: completedTasks.length,
+            }
+        }
         return {
             completedTasks,
             ongoingTasks: tasks.filter(task => task.completed !== 100),
@@ -75,17 +92,21 @@ export const TourContent: React.FunctionComponent<React.PropsWithChildren<TourCo
             totalCount: tasks.filter(task => typeof task.completed === 'number').length,
             completedCount: completedTasks.length,
         }
-    }, [tasks])
+    }, [keepCompletedTasks, tasks])
     const isHorizontal = variant === 'horizontal'
 
     return (
         <div className={className} data-testid="tour-content">
-            {isHorizontal && <Header onClose={onClose}>Don't show again</Header>}
+            {isHorizontal && (
+                <Header onClose={onClose} title={title}>
+                    Don't show again
+                </Header>
+            )}
             <MarketingBlock
                 wrapperClassName={classNames('w-100 d-flex', !isHorizontal && styles.marketingBlockWrapper)}
                 contentClassName={classNames(styles.marketingBlockContent, 'w-100 d-flex flex-column pt-3 pb-1')}
             >
-                {!isHorizontal && <Header onClose={onClose} />}
+                {!isHorizontal && <Header onClose={onClose} title={title} />}
                 <div
                     className={classNames(
                         styles.taskList,
@@ -100,8 +121,8 @@ export const TourContent: React.FunctionComponent<React.PropsWithChildren<TourCo
                             <div className={styles.completedItemsInner}>
                                 {completedTaskChunks.map((completedTaskChunk, index) => (
                                     <ul key={index} className="p-0 m-0 list-unstyled text-nowrap">
-                                        {completedTaskChunk.map(completedTask => (
-                                            <CompletedItem key={completedTask.title}>
+                                        {completedTaskChunk.map((completedTask, index) => (
+                                            <CompletedItem key={`${completedTask.title}-${index}`}>
                                                 {completedTask.title}
                                             </CompletedItem>
                                         ))}
@@ -110,13 +131,19 @@ export const TourContent: React.FunctionComponent<React.PropsWithChildren<TourCo
                             </div>
                         </div>
                     )}
-                    {ongoingTasks.map(task => (
-                        <TourTask key={task.title} {...task} variant={!isHorizontal ? 'small' : undefined} />
+                    {ongoingTasks.map((task, index) => (
+                        <TourTask
+                            key={`${task.title}-${index}`}
+                            {...task}
+                            variant={!isHorizontal ? 'small' : undefined}
+                        />
                     ))}
                     {!isHorizontal && completedTasks.length > 0 && (
                         <div>
-                            {completedTasks.map(completedTask => (
-                                <CompletedItem key={completedTask.title}>{completedTask.title}</CompletedItem>
+                            {completedTasks.map((completedTask, index) => (
+                                <CompletedItem key={`${completedTask.title}-${index}`}>
+                                    {completedTask.title}
+                                </CompletedItem>
                             ))}
                         </div>
                     )}

--- a/client/web/src/tour/components/Tour/TourTask.tsx
+++ b/client/web/src/tour/components/Tour/TourTask.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useContext, useState } from 'react'
+import React, { useCallback, useContext, useMemo, useState } from 'react'
 
 import classNames from 'classnames'
 import CheckCircleIcon from 'mdi-react/CheckCircleIcon'
@@ -30,6 +30,7 @@ export const TourTask: React.FunctionComponent<React.PropsWithChildren<TourTaskP
     completed,
     icon,
     variant,
+    dataAttributes = {},
 }) => {
     const [selectedStep, setSelectedStep] = useState<TourTaskStepType>()
     const [showLanguagePicker, setShowLanguagePicker] = useState(false)
@@ -76,6 +77,14 @@ export const TourTask: React.FunctionComponent<React.PropsWithChildren<TourTaskP
         },
         [onStepClick, onLanguageSelect, selectedStep, history]
     )
+    const attributes = useMemo(
+        () =>
+            Object.entries(dataAttributes).reduce(
+                (result, [key, value]) => ({ ...result, [`data-${key}`]: value }),
+                {}
+            ),
+        [dataAttributes]
+    )
 
     if (showLanguagePicker) {
         return (
@@ -91,25 +100,37 @@ export const TourTask: React.FunctionComponent<React.PropsWithChildren<TourTaskP
 
     const isMultiStep = steps.length > 1
     return (
-        <div className={classNames(icon && [styles.task, variant === 'small' && styles.isSmall])}>
+        <div
+            className={classNames(
+                icon && [styles.task, variant === 'small' && styles.isSmall],
+                !title && styles.noTitleTask
+            )}
+            {...attributes}
+        >
             {icon && variant !== 'small' && <span className={styles.taskIcon}>{icon}</span>}
             <div className={classNames('flex-grow-1', variant !== 'small' && 'h-100 d-flex flex-column')}>
-                <div className="d-flex justify-content-between position-relative">
-                    {icon && variant === 'small' && <span className={classNames(styles.taskIcon)}>{icon}</span>}
-                    <Text className={styles.title}>{title}</Text>
-                    {completed === 100 && (
-                        <Icon
-                            role="img"
-                            as={CheckCircleIcon}
-                            size="sm"
-                            className="text-success"
-                            aria-label="Completed"
-                        />
-                    )}
-                    {typeof completed === 'number' && completed < 100 && (
-                        <CircularProgressbar className={styles.progressBar} strokeWidth={10} value={completed || 0} />
-                    )}
-                </div>
+                {title && (
+                    <div className="d-flex justify-content-between position-relative">
+                        {icon && variant === 'small' && <span className={classNames(styles.taskIcon)}>{icon}</span>}
+                        <Text className={styles.title}>{title}</Text>
+                        {completed === 100 && (
+                            <Icon
+                                role="img"
+                                as={CheckCircleIcon}
+                                size="sm"
+                                className="text-success"
+                                aria-label="Completed"
+                            />
+                        )}
+                        {typeof completed === 'number' && completed < 100 && (
+                            <CircularProgressbar
+                                className={styles.progressBar}
+                                strokeWidth={10}
+                                value={completed || 0}
+                            />
+                        )}
+                    </div>
+                )}
                 <ul
                     className={classNames(
                         styles.stepList,
@@ -131,7 +152,10 @@ export const TourTask: React.FunctionComponent<React.PropsWithChildren<TourTaskP
                             )}
                             {step.action.type === 'new-tab-link' && (
                                 <Link
-                                    className="flex-grow-1"
+                                    className={classNames(
+                                        'flex-grow-1',
+                                        step.action.variant === 'button-primary' && 'btn btn-primary'
+                                    )}
                                     to={getTourTaskStepActionValue(step, language)}
                                     onClick={event => handleLinkClick(event, step)}
                                     target="_blank"
@@ -165,7 +189,7 @@ export const TourTask: React.FunctionComponent<React.PropsWithChildren<TourTaskP
                                     onToggle={isOpen => handleVideoToggle(isOpen, step)}
                                 />
                             )}
-                            {isMultiStep && step.isCompleted && (
+                            {(isMultiStep || !title) && step.isCompleted && (
                                 <Icon
                                     role="img"
                                     as={CheckCircleIcon}

--- a/client/web/src/tour/components/Tour/TourTask.tsx
+++ b/client/web/src/tour/components/Tour/TourTask.tsx
@@ -2,12 +2,13 @@ import React, { useCallback, useContext, useMemo, useState } from 'react'
 
 import classNames from 'classnames'
 import CheckCircleIcon from 'mdi-react/CheckCircleIcon'
+import HelpCircleOutlineIcon from 'mdi-react/HelpCircleOutlineIcon'
 import { CircularProgressbar } from 'react-circular-progressbar'
 import { useHistory } from 'react-router-dom'
 
 import { isExternalLink } from '@sourcegraph/common'
 import { ModalVideo } from '@sourcegraph/search-ui'
-import { Button, Icon, Link, Text } from '@sourcegraph/wildcard'
+import { Button, Icon, Link, Text, Tooltip } from '@sourcegraph/wildcard'
 
 import { ItemPicker } from '../ItemPicker'
 
@@ -140,7 +141,7 @@ export const TourTask: React.FunctionComponent<React.PropsWithChildren<TourTaskP
                     )}
                 >
                     {steps.map(step => (
-                        <li key={step.id} className={classNames(styles.stepListItem, 'd-flex align-items-start')}>
+                        <li key={step.id} className={classNames(styles.stepListItem, 'd-flex align-items-center')}>
                             {step.action.type === 'link' && (
                                 <Link
                                     className="flex-grow-1"
@@ -188,6 +189,17 @@ export const TourTask: React.FunctionComponent<React.PropsWithChildren<TourTaskP
                                     src={getTourTaskStepActionValue(step, language)}
                                     onToggle={isOpen => handleVideoToggle(isOpen, step)}
                                 />
+                            )}
+                            {step.tooltip && (
+                                <Tooltip content={step.tooltip}>
+                                    <Icon
+                                        as={HelpCircleOutlineIcon}
+                                        role="img"
+                                        size="sm"
+                                        className={classNames('ml-1', styles.colorLink)}
+                                        aria-label={step.tooltip}
+                                    />
+                                </Tooltip>
                             )}
                             {(isMultiStep || !title) && step.isCompleted && (
                                 <Icon

--- a/client/web/src/tour/components/Tour/types.ts
+++ b/client/web/src/tour/components/Tour/types.ts
@@ -15,7 +15,8 @@ export enum TourLanguage {
  * Tour task
  */
 export interface TourTaskType {
-    title: string
+    title?: string
+    dataAttributes?: {}
     icon?: React.ReactNode
     steps: TourTaskStepType[]
     /**
@@ -29,7 +30,12 @@ export interface TourTaskStepType {
     label: string
     action:
         | {
-              type: 'video' | 'link' | 'new-tab-link'
+              type: 'video'
+              value: string | Record<TourLanguage, string>
+          }
+        | {
+              type: 'link' | 'new-tab-link'
+              variant?: 'button-primary'
               value: string | Record<TourLanguage, string>
           }
         | {

--- a/client/web/src/tour/components/Tour/types.ts
+++ b/client/web/src/tour/components/Tour/types.ts
@@ -28,6 +28,7 @@ export interface TourTaskType {
 export interface TourTaskStepType {
     id: string
     label: string
+    tooltip?: string
     action:
         | {
               type: 'video'

--- a/client/web/src/tour/data/index.tsx
+++ b/client/web/src/tour/data/index.tsx
@@ -209,6 +209,91 @@ export const visitorsTasks: TourTaskType[] = [
 ]
 
 /**
+ * Tour tasks for non-authenticated users
+ */
+export const visitorsTasksWithNotebook: TourTaskType[] = [
+    {
+        dataAttributes: {
+            order: 1,
+        },
+        steps: [
+            {
+                id: 'FindAcrossYourReposNotebook',
+                label: 'Find Code Across All Your Repos',
+                action: {
+                    type: 'new-tab-link',
+                    value: 'https://sourcegraph.com/notebooks/Tm90ZWJvb2s6MTM=',
+                },
+            },
+        ],
+    },
+    {
+        dataAttributes: {
+            order: 2,
+        },
+        steps: [
+            {
+                id: 'SearchAndReviewCommitsNotebook',
+                label: 'Search & Review Commits',
+                action: {
+                    type: 'new-tab-link',
+                    value: 'https://sourcegraph.com/notebooks/Tm90ZWJvb2s6MTI=',
+                },
+            },
+        ],
+    },
+    {
+        dataAttributes: {
+            order: 3,
+        },
+        steps: [
+            {
+                id: 'RefineQueriesByFilteringNotebook',
+                label: 'Refine queries by filtering',
+                action: {
+                    type: 'new-tab-link',
+                    value: 'https://sourcegraph.com/notebooks/Tm90ZWJvb2s6MTQ=',
+                },
+            },
+        ],
+    },
+    {
+        dataAttributes: {
+            order: 4,
+        },
+        steps: [
+            {
+                id: 'StructuralSearchBasicsNotebook',
+                label: 'Structural search basics',
+                action: {
+                    type: 'new-tab-link',
+                    value: 'https://sourcegraph.com/notebooks/Tm90ZWJvb2s6Mzk4',
+                },
+            },
+        ],
+    },
+]
+
+export const visitorsTasksWithNotebookExtraTask: TourTaskType = {
+    title: 'All done!',
+    icon: <CheckCircleIcon size="2.3rem" className="text-success" />,
+    steps: [
+        {
+            id: 'InstallOrSignUp',
+            label: 'Install or Sign Up',
+            action: {
+                type: 'new-tab-link',
+                variant: 'button-primary',
+                value:
+                    'https://about.sourcegraph.com/get-started?utm_medium=inproduct&utm_source=quick-start-tour-notebooks&utm_campaign=inproduct-cta',
+            },
+            // This is done to mimic user creating an account, and signed in there is a different tour
+            completeAfterEvents: ['non-existing-event'],
+        },
+    ],
+}
+
+/**
  * Tour tasks for authenticated users. Extended/all use-cases.
  */
 export const authenticatedTasks: TourTaskType[] = [

--- a/client/web/src/tour/data/index.tsx
+++ b/client/web/src/tour/data/index.tsx
@@ -280,7 +280,9 @@ export const visitorsTasksWithNotebookExtraTask: TourTaskType = {
     steps: [
         {
             id: 'InstallOrSignUp',
-            label: 'Install or Sign Up',
+            label: 'Register for a Free Account',
+            tooltip:
+                'Registration unlocks additional features like IDE integrations, browser extensions, saved searches and more.',
             action: {
                 type: 'new-tab-link',
                 variant: 'button-primary',


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/36779.
## Tracking / event logs

<img width="475" alt="image" src="https://user-images.githubusercontent.com/6717049/171666318-569288ac-3157-4d3c-8f66-b4eff0510d64.png">

## Screenshots
<details>

| BEFORE | AFTER |
| --: | :-- |
| <img width="1149" alt="image" src="https://user-images.githubusercontent.com/6717049/171667870-86d54813-c66f-4600-b42b-a87f6f1a838c.png"> | <img width="1149" alt="image" src="https://user-images.githubusercontent.com/6717049/171667931-43643461-48ac-4f44-9740-b121e21d3d9e.png"> |
| <img width="290" alt="image" src="https://user-images.githubusercontent.com/6717049/171667688-9ffdeb4a-6c4a-4778-b21f-968b9955018d.png"> | <img width="290" alt="image" src="https://user-images.githubusercontent.com/6717049/171667775-7e047d81-4bf2-446b-a63f-a7e314ebe127.png"> |
| <img width="281" alt="image" src="https://user-images.githubusercontent.com/6717049/171668295-9aa80c88-2a6e-4218-ae5a-4b8f660b8a59.png"> | <img width="281" alt="image" src="https://user-images.githubusercontent.com/6717049/171668358-8f11e238-6467-4c89-bed0-950e8b5f1bfc.png"> |
| when all steps are completed/clicked |  <img width="281" alt="image" src="https://user-images.githubusercontent.com/6717049/171668516-1ab928df-b634-4af8-b93f-4cf4f027107e.png"> |

</details>

## Recording

https://www.loom.com/share/f01275f9a44d40dba54c4b35332605e9

## Test plan
- `sg start dotcom`
- Open https://sourcegraph.test:3443/search?feature-flag-key=tour-visitors-notebook&feature-flag-value=true as not signed in user
- Go through tour
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-erzhtor-visitors-tour-with.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-zfcjckwxzo.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
