### PR TITLE
Prevent IDE error message when closing a project

### DIFF
--- a/client/jetbrains/src/main/java/com/sourcegraph/find/FindPopupPanel.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/find/FindPopupPanel.java
@@ -77,5 +77,7 @@ public class FindPopupPanel extends JBPanel<FindPopupPanel> implements Disposabl
         if (browser != null) {
             browser.dispose();
         }
+
+        previewPanel.dispose();
     }
 }

--- a/client/jetbrains/src/main/java/com/sourcegraph/find/JCEFService.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/find/JCEFService.java
@@ -1,9 +1,10 @@
 package com.sourcegraph.find;
 
+import com.intellij.openapi.Disposable;
 import com.intellij.openapi.project.Project;
 import org.jetbrains.annotations.NotNull;
 
-public class JCEFService {
+public class JCEFService implements Disposable {
     private final SourcegraphWindow sourcegraphWindow;
 
     public JCEFService(@NotNull Project project) {
@@ -12,5 +13,10 @@ public class JCEFService {
 
     public SourcegraphWindow getSourcegraphWindow() {
         return this.sourcegraphWindow;
+    }
+
+    @Override
+    public void dispose() {
+        sourcegraphWindow.dispose();
     }
 }

--- a/client/jetbrains/src/main/java/com/sourcegraph/find/PreviewPanel.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/find/PreviewPanel.java
@@ -2,6 +2,7 @@ package com.sourcegraph.find;
 
 import com.intellij.codeInsight.daemon.DaemonCodeAnalyzer;
 import com.intellij.codeInsight.highlighting.HighlightManager;
+import com.intellij.openapi.Disposable;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.editor.*;
 import com.intellij.openapi.editor.colors.EditorColors;
@@ -25,12 +26,13 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Objects;
 
-public class PreviewPanel extends JBPanelWithEmptyText {
+public class PreviewPanel extends JBPanelWithEmptyText implements Disposable {
     private final Project project;
     private JComponent editorComponent;
 
     private PreviewContent previewContent;
     private VirtualFile virtualFile;
+    private Editor editor;
 
     public PreviewPanel(Project project) {
         super(new BorderLayout());
@@ -61,7 +63,7 @@ public class PreviewPanel extends JBPanelWithEmptyText {
             virtualFile = new LightVirtualFile(this.previewContent.getFileName(), fileContent);
             Document document = editorFactory.createDocument(fileContent);
             document.setReadOnly(true);
-            Editor editor = editorFactory.createEditor(document, project, virtualFile, true, EditorKind.MAIN_EDITOR);
+            editor = editorFactory.createEditor(document, project, virtualFile, true, EditorKind.MAIN_EDITOR);
 
             EditorSettings settings = editor.getSettings();
             settings.setLineMarkerAreaShown(true);
@@ -134,6 +136,13 @@ public class PreviewPanel extends JBPanelWithEmptyText {
                 editorComponent = null;
                 virtualFile = null;
             });
+        }
+    }
+
+    @Override
+    public void dispose() {
+        if (editor != null) {
+            EditorFactory.getInstance().releaseEditor(editor);
         }
     }
 }

--- a/client/jetbrains/src/main/java/com/sourcegraph/find/SourcegraphWindow.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/find/SourcegraphWindow.java
@@ -7,7 +7,6 @@ import com.intellij.openapi.ui.popup.ActiveIcon;
 import com.intellij.openapi.ui.popup.ComponentPopupBuilder;
 import com.intellij.openapi.ui.popup.JBPopup;
 import com.intellij.openapi.ui.popup.JBPopupFactory;
-import com.intellij.openapi.util.Disposer;
 import com.sourcegraph.Icons;
 import org.cef.browser.CefBrowser;
 import org.cef.handler.CefKeyboardHandler;
@@ -32,8 +31,6 @@ public class SourcegraphWindow implements Disposable {
 
         // Create main panel
         mainPanel = new FindPopupPanel(project);
-
-        Disposer.register(project, this);
     }
 
     synchronized public void showPopup() {
@@ -144,5 +141,7 @@ public class SourcegraphWindow implements Disposable {
         if (popup != null) {
             popup.dispose();
         }
+
+        mainPanel.dispose();
     }
 }


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/36294

Had to fix the disposing hierarchy.
@madppiper solved this in this PR: https://github.com/sourcegraph/sourcegraph/pull/36298, just it was in conflict with the current `main` so I re-created his solution in the current PR.
It was also a good way to properly understand what he was doing. I think I gained a better understanding of the disposing hierarchy.

## Test plan

- [47 sec Loom demoing that it works](https://www.loom.com/share/9935d98cdef948c092e24fb44c50107c)
- Check the code

## App preview:

- [Web](https://sg-web-dv-jetbrains-error-message-when.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-iewiekewws.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
