### PR TITLE
bump codenotify version in github workflow

### DIFF
--- a/.github/workflows/codenotify.yml
+++ b/.github/workflows/codenotify.yml
@@ -12,13 +12,13 @@ jobs:
       - uses: actions/checkout@v2
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-      - uses: sourcegraph/codenotify@v0.6.1
+      - uses: sourcegraph/codenotify@v0.6.2
         with:
           filename: 'CODENOTIFY'
           subscriber-threshold: '15'
         env:
           GITHUB_TOKEN: ${{ secrets.CODENOTIFY_GITHUB_TOKEN }}
-      - uses: sourcegraph/codenotify@v0.6.1
+      - uses: sourcegraph/codenotify@v0.6.2
         continue-on-error: true
         with:
           filename: 'OWNERS'


### PR DESCRIPTION
New version soft exits if we get rate limited by Github
## Test plan
Nothing
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
