### PR TITLE
Upgrade marked dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -424,7 +424,7 @@
     "linguist-languages": "^7.14.0",
     "lodash": "^4.17.20",
     "lru-cache": "^7.8.0",
-    "marked": "^4.0.0",
+    "marked": "4.0.16",
     "mdi-react": "^8.1.0",
     "minimatch": "^3.0.4",
     "monaco-editor": "^0.24.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -17860,10 +17860,10 @@ marked@1.0.0:
   resolved "https://registry.npmjs.org/marked/-/marked-1.0.0.tgz#d35784245a04871e5988a491e28867362e941693"
   integrity sha512-Wo+L1pWTVibfrSr+TTtMuiMfNzmZWiOPeO7rZsQUY5bgsxpHesBEcIWJloWVTFnrMXnf/TL30eTFSGJddmQAng==
 
-marked@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.npmjs.org/marked/-/marked-4.0.0.tgz#fd4ff16f6b99fbe6beb729f2077ea717d0ec4edb"
-  integrity sha512-K3C1JvtiXuXVLoxDQEJP4NMLBuThlTkthgUOCzqLghIpHfis1DIZZfPI3o4UgfFpQ0d+JvTql2h+szR9jQ1p1w==
+marked@4.0.16:
+  version "4.0.16"
+  resolved "https://registry.npmjs.org/marked/-/marked-4.0.16.tgz#9ec18fc1a723032eb28666100344d9428cf7a264"
+  integrity sha512-wahonIQ5Jnyatt2fn8KqF/nIqZM8mh3oRu2+l5EANGMhu6RFjiSG52QNE2eWzFMI94HqYSgN184NurgNG6CztA==
 
 marky@^1.2.0:
   version "1.2.2"


### PR DESCRIPTION
Bump to latest version to fix CVE-2022-21680
## Test plan
CI checks
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-andre-upgrade-marked.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-nyozytvomf.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
