### PR TITLE
JetBrains: Fix up GitUtil

### DIFF
--- a/client/jetbrains/src/main/java/com/sourcegraph/git/GitUtil.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/git/GitUtil.java
@@ -31,7 +31,7 @@ public class GitUtil {
             branchName = defaultBranchNameSetting != null ? defaultBranchNameSetting : getCurrentBranchName(repoRootPath);
             // If there’s no default branch name setting and the current branch doesn’t exist on the remote, use the default branch.
             if (!doesRemoteBranchExist(branchName, repoRootPath) && defaultBranchNameSetting == null) {
-                branchName = "master"; // TODO: Make this dynamic!
+                branchName = "main"; // TODO: Make this dynamic!
             }
 
             remoteUrl = getConfiguredRemoteUrl(repoRootPath);

--- a/client/jetbrains/src/main/java/com/sourcegraph/git/GitUtil.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/git/GitUtil.java
@@ -21,7 +21,8 @@ public class GitUtil {
         String branchName = "";
         try {
             String defaultBranchNameSetting = ConfigUtil.getDefaultBranchName(project);
-            String repoRootPath = getRepoRootPath(filePath);
+            String directoryPath = filePath.substring(0, filePath.lastIndexOf("/"));
+            String repoRootPath = getRepoRootPath(directoryPath);
 
             // Determine file path, relative to repository root.
             relativePath = filePath.substring(repoRootPath.length() + 1);

--- a/client/jetbrains/src/main/java/com/sourcegraph/git/GitUtil.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/git/GitUtil.java
@@ -27,11 +27,10 @@ public class GitUtil {
             // Determine file path, relative to repository root.
             relativePath = filePath.substring(repoRootPath.length() + 1);
 
-            // TODO: It’d make more sense to default to the current branch if it exists on the remote, and only fall back to the default branch if it doesn’t.
-            branchName = defaultBranchNameSetting != null ? defaultBranchNameSetting : getCurrentBranchName(repoRootPath);
-            // If there’s no default branch name setting and the current branch doesn’t exist on the remote, use the default branch.
-            if (!doesRemoteBranchExist(branchName, repoRootPath) && defaultBranchNameSetting == null) {
-                branchName = "main"; // TODO: Make this dynamic!
+            // If the current branch doesn’t exist on the remote, use the default branch.
+            branchName = getCurrentBranchName(repoRootPath);
+            if (!doesRemoteBranchExist(branchName, repoRootPath)) {
+                branchName = defaultBranchNameSetting != null ? defaultBranchNameSetting : "main";
             }
 
             remoteUrl = getConfiguredRemoteUrl(repoRootPath);


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/34570
Closes https://github.com/sourcegraph/sourcegraph/issues/34569

This PR is _not_ about the search feature, for a change. :)

Doing three things here:

1. **Bug fix:** Fixed a bug that actually prevented the use of the feature altogether. I introduced this bug about three weeks ago when I refactored the utils, and as we don‘t often use this feature in the sandboxed IDE, we didn’t notice the bug.

2. **Default branch name:** Changed the default branch name from “master” to “main” as “main” is becoming more common, and it’s more in line with our company culture.

3. **Priority change:** Making sure that when the user right-clicks the code and copies the URL or opens it in a browser tab, we’re linking to the most relevant branch.
The old order was: default (if set) > current (if exists on remote) > “master”
The new order is: **current (if exists on remote) > default (if set)** > “main”
Reasoning: As a team member, when I want to share a piece of code with a peer, I expect the link to point right to the code that I’m clicking on when creating the link. The most likely location of an up-to-date version of that code line is **the branch I'm on**. if the branch doesn’t exist on the remote, I’d like to fall back to the default branch, which is whatever branch we set up in Settings, or, in the lack of that, “main”. So I believe the altered version helps the user better.
@slimsag, I think you were the one who implemented the previous solution. Do you remember if there was a specific customer expectation for the behavior? Or perhaps you think that linking `main` is a better solution because it's less ephemeral than feature branches?

## Test plan

@philipp-spiess 
- Watch the Loom: https://www.loom.com/share/43ca9749e13c41bea0f9f025ec1f6524
- Check the code

@slimsag
- Read  point #3 and let me know your thoughts

## App preview:

- [Web](https://sg-web-dv-jetbrains-fix-open-on.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-pcgcwwvfnx.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
