### PR TITLE
edit mutation

### DIFF
--- a/enterprise/internal/insights/resolvers/insight_view_resolvers.go
+++ b/enterprise/internal/insights/resolvers/insight_view_resolvers.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
-	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/service"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/store"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/types"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
@@ -472,24 +471,12 @@ func (r *Resolver) CreateLineChartSearchInsight(ctx context.Context, args *graph
 
 	var scoped []types.InsightSeries
 	for _, series := range args.Input.DataSeries {
-		c, err := createAndAttachSeries(ctx, insightTx, view, series)
+		c, err := createAndAttachSeries(ctx, insightTx, r.backfiller, view, series)
 		if err != nil {
 			return nil, errors.Wrap(err, "createAndAttachSeries")
 		}
 		if len(c.Repositories) > 0 {
 			scoped = append(scoped, *c)
-		}
-	}
-
-	flags := featureflag.FromContext(ctx)
-	deprecateJustInTime := flags.GetBoolOr("code_insights_deprecate_jit", true)
-	if len(scoped) > 0 && deprecateJustInTime {
-		insightPermStore := store.NewInsightPermissionStore(r.postgresDB)
-		insightsStore := store.New(r.insightsDB, insightPermStore)
-		backfiller := background.NewScopedBackfiller(r.workerBaseStore, insightsStore)
-		err := backfiller.ScopedBackfill(ctx, scoped)
-		if err != nil {
-			return nil, err
 		}
 	}
 
@@ -575,7 +562,7 @@ func (r *Resolver) UpdateLineChartSearchInsight(ctx context.Context, args *graph
 
 	for _, series := range args.Input.DataSeries {
 		if series.SeriesId == nil {
-			_, err = createAndAttachSeries(ctx, tx, view, series)
+			_, err = createAndAttachSeries(ctx, tx, r.backfiller, view, series)
 			if err != nil {
 				return nil, errors.Wrap(err, "createAndAttachSeries")
 			}
@@ -598,7 +585,7 @@ func (r *Resolver) UpdateLineChartSearchInsight(ctx context.Context, args *graph
 				if err != nil {
 					return nil, errors.Wrap(err, "RemoveViewSeries")
 				}
-				_, err = createAndAttachSeries(ctx, tx, view, series)
+				_, err = createAndAttachSeries(ctx, tx, r.backfiller, view, series)
 				if err != nil {
 					return nil, errors.Wrap(err, "createAndAttachSeries")
 				}
@@ -661,7 +648,7 @@ func (r *Resolver) CreatePieChartSearchInsight(ctx context.Context, args *graphq
 		CreatedAt:          time.Now(),
 		Repositories:       repos,
 		SampleIntervalUnit: string(types.Month),
-		JustInTime:         service.IsJustInTime(repos),
+		JustInTime:         len(repos) > 0,
 		// one might ask themselves why is the generation method a language stats method if this mutation is search insight? The answer is that search is ultimately the
 		// driver behind language stats, but global language stats behave differently than standard search. Long term the vision is that
 		// search will power this, and we can iterate over repos just like any other search insight. But for now, this is just something weird that we will have to live with.
@@ -982,7 +969,7 @@ func validateUserDashboardPermissions(ctx context.Context, store store.Dashboard
 	return nil
 }
 
-func createAndAttachSeries(ctx context.Context, tx *store.InsightStore, view types.InsightView, series graphqlbackend.LineChartSearchInsightDataSeriesInput) (*types.InsightSeries, error) {
+func createAndAttachSeries(ctx context.Context, tx *store.InsightStore, scopedBackfiller *background.ScopedBackfiller, view types.InsightView, series graphqlbackend.LineChartSearchInsightDataSeriesInput) (*types.InsightSeries, error) {
 	var seriesToAdd, matchingSeries types.InsightSeries
 	var foundSeries bool
 	var err error
@@ -991,8 +978,8 @@ func createAndAttachSeries(ctx context.Context, tx *store.InsightStore, view typ
 		dynamic = *series.GeneratedFromCaptureGroups
 	}
 
-	// Don't try to match on just-in-time series, since they are not recorded
-	if !service.IsJustInTime(series.RepositoryScope.Repositories) {
+	// Don't try to match on non-global series, since they are always replaced
+	if len(series.RepositoryScope.Repositories) == 0 {
 		matchingSeries, foundSeries, err = tx.FindMatchingSeries(ctx, store.MatchSeriesArgs{
 			Query:                     series.Query,
 			StepIntervalUnit:          series.TimeScope.StepInterval.Unit,
@@ -1017,15 +1004,19 @@ func createAndAttachSeries(ctx context.Context, tx *store.InsightStore, view typ
 			SampleIntervalUnit:         series.TimeScope.StepInterval.Unit,
 			SampleIntervalValue:        int(series.TimeScope.StepInterval.Value),
 			GeneratedFromCaptureGroups: dynamic,
-			JustInTime:                 service.IsJustInTime(repos) && !deprecateJustInTime,
+			JustInTime:                 len(repos) > 0 && !deprecateJustInTime,
 			// JustInTime:       false,
 			GenerationMethod: searchGenerationMethod(series),
 		})
 		if err != nil {
 			return nil, errors.Wrap(err, "CreateSeries")
 		}
-		if len(seriesToAdd.Repositories) > 0 {
-			_, err := tx.StampBackfill(ctx, seriesToAdd)
+		if len(seriesToAdd.Repositories) > 0 && deprecateJustInTime {
+			err := scopedBackfiller.ScopedBackfill(ctx, []types.InsightSeries{seriesToAdd})
+			if err != nil {
+				return nil, errors.Wrap(err, "ScopedBackfill")
+			}
+			_, err = tx.StampBackfill(ctx, seriesToAdd) // note that this isn't transactional with the backfill above until the queue is migrated to the insights DB
 			if err != nil {
 				return nil, errors.Wrap(err, "StampBackfill")
 			}

--- a/enterprise/internal/insights/resolvers/resolver.go
+++ b/enterprise/internal/insights/resolvers/resolver.go
@@ -5,6 +5,8 @@ import (
 	"database/sql"
 	"time"
 
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/background"
+
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/types"
@@ -53,6 +55,7 @@ type Resolver struct {
 	timeSeriesStore      store.Interface
 	insightMetadataStore store.InsightMetadataStore
 	dataSeriesStore      store.DataSeriesStore
+	backfiller           *background.ScopedBackfiller
 
 	baseInsightResolver
 }
@@ -71,6 +74,7 @@ func newWithClock(db dbutil.DB, postgres database.DB, clock func() time.Time) *R
 		timeSeriesStore:      base.timeSeriesStore,
 		insightMetadataStore: base.insightStore,
 		dataSeriesStore:      base.insightStore,
+		backfiller:           background.NewScopedBackfiller(base.workerBaseStore, base.timeSeriesStore),
 	}
 }
 

--- a/enterprise/internal/insights/service/service.go
+++ b/enterprise/internal/insights/service/service.go
@@ -1,5 +1,0 @@
-package service
-
-func IsJustInTime(repositories []string) bool {
-	return len(repositories) != 0
-}


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/35655

This adds support for the edit mutation for the non-global backfill. One big caveat here is that _any_ edit will currently trigger a backfill (including superficial fields such as series label). This isn't ideal, but isn't technically blocking. I've opened https://github.com/sourcegraph/sourcegraph/issues/36499 to address this seperately.

## Test plan

Created an insight, let it backfill. Then edited it and watched it generate a new backfill.
