### PR TITLE
set scoped backfill to a higher than normal priority

### DIFF
--- a/enterprise/internal/insights/background/historical_enqueuer.go
+++ b/enterprise/internal/insights/background/historical_enqueuer.go
@@ -206,6 +206,7 @@ func (s *ScopedBackfiller) ScopedBackfill(ctx context.Context, definitions []ity
 
 	for _, job := range totalJobs {
 		// todo: fix this transactionality
+		job.Priority = int(priority.High)
 		err := s.enqueueQueryRunnerJob(ctx, job)
 		if err != nil {
 			return err


### PR DESCRIPTION
Set the priority of a scoped backfiller higher than standard backfills. This will cause all scoped queries to execute before all global queries.

## Test plan
Created a backfill and verified the priority was set appropriately
