### PR TITLE
Insights/compute/compute text client

### DIFF
--- a/enterprise/internal/compute/client/compute_text_client_test.go
+++ b/enterprise/internal/compute/client/compute_text_client_test.go
@@ -1,0 +1,55 @@
+package client
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/hexops/autogold"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/compute"
+	"github.com/sourcegraph/sourcegraph/internal/search/streaming/http"
+)
+
+func TestComputeTextStreamDecoder_ReadAll(t *testing.T) {
+	raw := `event: results
+data: [{"value":"github.com/EbookFoundation/free-programming-books\n","kind":"output"}]
+
+event: results
+data: [{"value":"github.com/ytdl-org/youtube-dl\n","kind":"output"},{"value":"github.com/angular/angular\n","kind":"output"}]
+
+event: alert
+data: {"title": "alert"}
+
+event: error
+data: {"message": "error"}
+
+event: done
+data: {}`
+
+	resultCount := 0
+	alertCount := 0
+	errorCount := 0
+	unknownCount := 0
+	decoder := ComputeTextStreamDecoder{
+		OnResult: func(results []compute.Text) {
+			resultCount += len(results)
+		},
+		OnAlert: func(event *http.EventAlert) {
+			alertCount++
+		},
+		OnError: func(event *http.EventError) {
+			errorCount++
+		},
+		OnUnknown: func(event, data []byte) {
+			unknownCount++
+		},
+	}
+
+	err := decoder.ReadAll(strings.NewReader(raw))
+	if err != nil {
+		t.Fatal(err)
+	}
+	autogold.Want("resultCount", int(3)).Equal(t, resultCount)
+	autogold.Want("alertCount", int(1)).Equal(t, alertCount)
+	autogold.Want("errorCount", int(1)).Equal(t, errorCount)
+	autogold.Want("unknownCount", int(0)).Equal(t, unknownCount)
+}

--- a/enterprise/internal/insights/query/streaming/search.go
+++ b/enterprise/internal/insights/query/streaming/search.go
@@ -2,6 +2,7 @@ package streaming
 
 import (
 	"context"
+	"io"
 
 	"github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/log"
@@ -60,8 +61,8 @@ func Search(ctx context.Context, query string, decoder streamhttp.FrontendStream
 	return err
 }
 
-func ComputeMatchContextStream(ctx context.Context, query string, decoder client.ComputeMatchContextStreamDecoder) (err error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "InsightsComputeStreamSearch")
+func genericComputeStream(ctx context.Context, handler func(io.Reader) error, query, operation string) (err error) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, operation)
 	defer func() {
 		span.LogFields(
 			log.Error(err),
@@ -90,9 +91,13 @@ func ComputeMatchContextStream(ctx context.Context, query string, decoder client
 	}
 	defer resp.Body.Close()
 
-	decErr := decoder.ReadAll(resp.Body)
-	if decErr != nil {
-		return decErr
-	}
-	return err
+	return handler(resp.Body)
+}
+
+func ComputeMatchContextStream(ctx context.Context, query string, decoder client.ComputeMatchContextStreamDecoder) (err error) {
+	return genericComputeStream(ctx, decoder.ReadAll, query, "InsightsComputeStreamSearch")
+}
+
+func ComputeTextStream(ctx context.Context, query string, decoder client.ComputeTextStreamDecoder) (err error) {
+	return genericComputeStream(ctx, decoder.ReadAll, query, "InsightsComputeTextSearch")
 }

--- a/enterprise/internal/insights/query/streaming/search.go
+++ b/enterprise/internal/insights/query/streaming/search.go
@@ -69,7 +69,7 @@ func ComputeMatchContextStream(ctx context.Context, query string, decoder client
 		span.Finish()
 	}()
 
-	req, err := client.NewMatchContextRequest(internalapi.Client.URL+"/.internal", query)
+	req, err := client.NewComputeStreamRequest(internalapi.Client.URL+"/.internal", query)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Adding the client for the ComputeText type similar to the MatchContext client. This isn't being used anywhere yet, just doing some plumbing in this small PR.

## Test plan

Verified the current compute query is working properly.
