### PR TITLE
search: make sequential job send unique results only

### DIFF
--- a/internal/search/job/jobutil/combinators.go
+++ b/internal/search/job/jobutil/combinators.go
@@ -2,12 +2,14 @@ package jobutil
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"github.com/opentracing/opentracing-go/log"
 
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/search/job"
+	"github.com/sourcegraph/sourcegraph/internal/search/result"
 	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
@@ -17,19 +19,23 @@ import (
 // This is used to implement logic where we might like to order independent
 // search operations, favoring results returns by jobs earlier in the list to
 // those appearing later in the list. If this job sees a cancellation for a
-// child job, it stops executing additional jobs and returns.
-func NewSequentialJob(children ...job.Job) job.Job {
+// child job, it stops executing additional jobs and returns. If ensureUnique is
+// true, this job ensures only unique results among all children are sent (if
+// two or more jobs send the same result, only the first unique result is sent,
+// subsequent similar results are ignored).
+func NewSequentialJob(ensureUnique bool, children ...job.Job) job.Job {
 	if len(children) == 0 {
 		return &NoopJob{}
 	}
 	if len(children) == 1 {
 		return children[0]
 	}
-	return &SequentialJob{children: children}
+	return &SequentialJob{children: children, ensureUnique: ensureUnique}
 }
 
 type SequentialJob struct {
-	children []job.Job
+	ensureUnique bool
+	children     []job.Job
 }
 
 func (s *SequentialJob) Name() string {
@@ -40,9 +46,32 @@ func (s *SequentialJob) Tags() []log.Field {
 	return []log.Field{}
 }
 
-func (s *SequentialJob) Run(ctx context.Context, clients job.RuntimeClients, stream streaming.Sender) (alert *search.Alert, err error) {
+func (s *SequentialJob) Run(ctx context.Context, clients job.RuntimeClients, parentStream streaming.Sender) (alert *search.Alert, err error) {
 	var maxAlerter search.MaxAlerter
 	var errs errors.MultiError
+
+	stream := parentStream
+	if s.ensureUnique {
+		var mux sync.Mutex
+		dedup := result.NewDeduper()
+
+		stream = streaming.StreamFunc(func(event streaming.SearchEvent) {
+			mux.Lock()
+
+			results := event.Results[:0]
+			for _, match := range event.Results {
+				seen := dedup.Seen(match)
+				if seen {
+					continue
+				}
+				dedup.Add(match)
+				results = append(results, match)
+			}
+			event.Results = results
+			mux.Unlock()
+			parentStream.Send(event)
+		})
+	}
 
 	for _, child := range s.children {
 		alert, err := child.Run(ctx, clients, stream)

--- a/internal/search/job/jobutil/combinators_test.go
+++ b/internal/search/job/jobutil/combinators_test.go
@@ -2,6 +2,7 @@ package jobutil
 
 import (
 	"context"
+	"strconv"
 	"testing"
 	"time"
 
@@ -186,7 +187,9 @@ func TestSequentialJob(t *testing.T) {
 			default:
 			}
 			s.Send(streaming.SearchEvent{
-				Results: []result.Match{&result.FileMatch{}},
+				Results: []result.Match{&result.FileMatch{
+					File: result.File{Path: strconv.Itoa(i)},
+				}},
 			})
 		}
 		return nil, nil
@@ -200,7 +203,7 @@ func TestSequentialJob(t *testing.T) {
 	// Setup: A child job that panics.
 	neverJob := mockjob.NewStrictMockJob()
 	t.Run("sequential job returns early after cancellation when limit job sees 5 events", func(t *testing.T) {
-		limitedSequentialJob := NewLimitJob(5, NewSequentialJob(mockJob, neverJob))
+		limitedSequentialJob := NewLimitJob(5, NewSequentialJob(true, mockJob, neverJob))
 		require.NotPanics(t, func() {
 			limitedSequentialJob.Run(context.Background(), job.RuntimeClients{}, stream)
 		})

--- a/internal/search/job/jobutil/job.go
+++ b/internal/search/job/jobutil/job.go
@@ -229,12 +229,12 @@ func orderSearcherJob(j job.Job) job.Job {
 			if pager, ok := current.(*repoPagerJob); ok {
 				if _, ok := pager.child.(*zoekt.RepoSubsetTextSearchJob); ok && !seenZoektRepoSearch {
 					seenZoektRepoSearch = true
-					return NewSequentialJob(current, pagedSearcherJob)
+					return NewSequentialJob(false, current, pagedSearcherJob)
 				}
 			}
 			if _, ok := current.(*zoekt.GlobalTextSearchJob); ok && !seenZoektGlobalSearch {
 				seenZoektGlobalSearch = true
-				return NewSequentialJob(current, pagedSearcherJob)
+				return NewSequentialJob(false, current, pagedSearcherJob)
 			}
 			return current
 		},

--- a/internal/search/job/jobutil/mapper.go
+++ b/internal/search/job/jobutil/mapper.go
@@ -164,7 +164,7 @@ func (m *Mapper) Map(j job.Job) job.Job {
 		if m.MapSequentialJob != nil {
 			children = m.MapSequentialJob(children)
 		}
-		return NewSequentialJob(children...)
+		return NewSequentialJob(false, children...)
 
 	case *TimeoutJob:
 		child := m.Map(j.child)


### PR DESCRIPTION
I'm close to releasing the "feeling lucky" search, which will opportunistically run queries in sequence under different interpretations. While testing, I realized that we don't guard against sending the same result twice, so this PR adds a deduper to the sequential job. While there _might_ be a reason to have a job not dedupe subsequent job results, I couldn't come up with a good one, and this change implements the intuitive (and now default) behavior that I think makes more sense.


All other current behavior that uses sequential job (i.e., recent "run Zoekt before searcher" is unaffected because we are guaranteed Zoekt/Searcher send unique results due to repo partitioning logic)

## Test plan
Updated test to cover this behavior.
