### PR TITLE
search: frontend scaffolding for 'Feeling Lucky' search mode

### DIFF
--- a/client/search-ui/src/input/toggles/Toggles.tsx
+++ b/client/search-ui/src/input/toggles/Toggles.tsx
@@ -1,8 +1,9 @@
-import React, { useCallback } from 'react'
+import React, { useCallback, useMemo } from 'react'
 
 import classNames from 'classnames'
 import CodeBracketsIcon from 'mdi-react/CodeBracketsIcon'
 import FormatLetterCaseIcon from 'mdi-react/FormatLetterCaseIcon'
+import LightningBoltIcon from 'mdi-react/LightningBoltIcon'
 import RegexIcon from 'mdi-react/RegexIcon'
 
 import { isErrorLike, isMacPlatform } from '@sourcegraph/common'
@@ -75,8 +76,18 @@ export const Toggles: React.FunctionComponent<React.PropsWithChildren<TogglesPro
         ...otherProps
     } = props
 
+    const defaultPatternTypeValue = useMemo(
+        () =>
+            settingsCascade.final &&
+            !isErrorLike(settingsCascade.final) &&
+            (settingsCascade.final['search.defaultPatternType'] as SearchPatternType),
+        [settingsCascade.final]
+    )
+
     const submitOnToggle = useCallback(
-        (args: { newPatternType: SearchPatternType } | { newCaseSensitivity: boolean }): void => {
+        (
+            args: { newPatternType: SearchPatternType } | { newCaseSensitivity: boolean } | { newPowerUser: boolean }
+        ): void => {
             submitSearch?.({
                 source: 'filter',
                 patternType: 'newPatternType' in args ? args.newPatternType : patternType,
@@ -102,90 +113,133 @@ export const Toggles: React.FunctionComponent<React.PropsWithChildren<TogglesPro
     }, [patternType, setPatternType, submitOnToggle])
 
     const toggleStructuralSearch = useCallback((): void => {
-        const cascadePatternTypeValue =
-            settingsCascade.final &&
-            !isErrorLike(settingsCascade.final) &&
-            (settingsCascade.final['search.defaultPatternType'] as SearchPatternType)
-
-        const defaultPatternType = cascadePatternTypeValue || SearchPatternType.literal
+        const defaultPatternType = defaultPatternTypeValue || SearchPatternType.literal
 
         const newPatternType: SearchPatternType =
             patternType !== SearchPatternType.structural ? SearchPatternType.structural : defaultPatternType
 
         setPatternType(newPatternType)
         submitOnToggle({ newPatternType })
-    }, [patternType, setPatternType, settingsCascade.final, submitOnToggle])
+    }, [defaultPatternTypeValue, patternType, setPatternType, submitOnToggle])
+
+    const toggleExpertMode = useCallback((): void => {
+        const newPatternType =
+            patternType === SearchPatternType.lucky ? SearchPatternType.literal : SearchPatternType.lucky
+
+        setPatternType(newPatternType)
+        submitOnToggle({ newPatternType })
+    }, [patternType, setPatternType, submitOnToggle])
+
+    const luckySearchEnabled = defaultPatternTypeValue === SearchPatternType.lucky
 
     const fullQuery = getFullQuery(navbarSearchQuery, selectedSearchContextSpec || '', caseSensitive, patternType)
 
+    const copyQueryButton = showCopyQueryButton && (
+        <>
+            <div className={styles.separator} />
+            <CopyQueryButton
+                fullQuery={fullQuery}
+                keyboardShortcutForFullCopy={KEYBOARD_SHORTCUT_COPY_FULL_QUERY}
+                isMacPlatform={isMacPlatform()}
+                className={classNames(styles.toggle, styles.copyQueryButton)}
+            />
+        </>
+    )
+
     return (
         <div className={classNames(className, styles.toggleContainer)} {...otherProps}>
-            <QueryInputToggle
-                title="Case sensitivity"
-                isActive={caseSensitive}
-                onToggle={toggleCaseSensitivity}
-                icon={FormatLetterCaseIcon}
-                interactive={props.interactive}
-                className="test-case-sensitivity-toggle"
-                activeClassName="test-case-sensitivity-toggle--active"
-                disableOn={[
-                    {
-                        condition: findFilter(navbarSearchQuery, 'case', FilterKind.Subexpression) !== undefined,
-                        reason: 'Query already contains one or more case subexpressions',
-                    },
-                    {
-                        condition: findFilter(navbarSearchQuery, 'patterntype', FilterKind.Subexpression) !== undefined,
-                        reason:
-                            'Query contains one or more patterntype subexpressions, cannot apply global case-sensitivity',
-                    },
-                    {
-                        condition: patternType === SearchPatternType.structural,
-                        reason: 'Structural search is always case sensitive',
-                    },
-                ]}
-            />
-            <QueryInputToggle
-                title="Regular expression"
-                isActive={patternType === SearchPatternType.regexp}
-                onToggle={toggleRegexp}
-                icon={RegexIcon}
-                interactive={props.interactive}
-                className="test-regexp-toggle"
-                activeClassName="test-regexp-toggle--active"
-                disableOn={[
-                    {
-                        condition: findFilter(navbarSearchQuery, 'patterntype', FilterKind.Subexpression) !== undefined,
-                        reason: 'Query already contains one or more patterntype subexpressions',
-                    },
-                ]}
-            />
-            {!structuralSearchDisabled && (
-                <QueryInputToggle
-                    title="Structural search"
-                    className="test-structural-search-toggle"
-                    activeClassName="test-structural-search-toggle--active"
-                    isActive={patternType === SearchPatternType.structural}
-                    onToggle={toggleStructuralSearch}
-                    icon={CodeBracketsIcon}
-                    interactive={props.interactive}
-                    disableOn={[
-                        {
-                            condition:
-                                findFilter(navbarSearchQuery, 'patterntype', FilterKind.Subexpression) !== undefined,
-                            reason: 'Query already contains one or more patterntype subexpressions',
-                        },
-                    ]}
-                />
-            )}
-            {showCopyQueryButton && (
+            {patternType === SearchPatternType.lucky ? (
                 <>
-                    <div className={styles.separator} />
-                    <CopyQueryButton
-                        fullQuery={fullQuery}
-                        keyboardShortcutForFullCopy={KEYBOARD_SHORTCUT_COPY_FULL_QUERY}
-                        isMacPlatform={isMacPlatform()}
-                        className={classNames(styles.toggle, styles.copyQueryButton)}
+                    <QueryInputToggle
+                        title="Expert mode"
+                        isActive={false}
+                        onToggle={toggleExpertMode}
+                        icon={LightningBoltIcon}
+                        interactive={props.interactive}
+                        className="test-expert-mode-toggle"
+                        activeClassName="test-expert-mode-toggle--active"
+                        disableOn={[]}
                     />
+                    {copyQueryButton}
+                </>
+            ) : (
+                <>
+                    <QueryInputToggle
+                        title="Case sensitivity"
+                        isActive={caseSensitive}
+                        onToggle={toggleCaseSensitivity}
+                        icon={FormatLetterCaseIcon}
+                        interactive={props.interactive}
+                        className="test-case-sensitivity-toggle"
+                        activeClassName="test-case-sensitivity-toggle--active"
+                        disableOn={[
+                            {
+                                condition:
+                                    findFilter(navbarSearchQuery, 'case', FilterKind.Subexpression) !== undefined,
+                                reason: 'Query already contains one or more case subexpressions',
+                            },
+                            {
+                                condition:
+                                    findFilter(navbarSearchQuery, 'patterntype', FilterKind.Subexpression) !==
+                                    undefined,
+                                reason:
+                                    'Query contains one or more patterntype subexpressions, cannot apply global case-sensitivity',
+                            },
+                            {
+                                condition: patternType === SearchPatternType.structural,
+                                reason: 'Structural search is always case sensitive',
+                            },
+                        ]}
+                    />
+                    <QueryInputToggle
+                        title="Regular expression"
+                        isActive={patternType === SearchPatternType.regexp}
+                        onToggle={toggleRegexp}
+                        icon={RegexIcon}
+                        interactive={props.interactive}
+                        className="test-regexp-toggle"
+                        activeClassName="test-regexp-toggle--active"
+                        disableOn={[
+                            {
+                                condition:
+                                    findFilter(navbarSearchQuery, 'patterntype', FilterKind.Subexpression) !==
+                                    undefined,
+                                reason: 'Query already contains one or more patterntype subexpressions',
+                            },
+                        ]}
+                    />
+                    {!structuralSearchDisabled && (
+                        <QueryInputToggle
+                            title="Structural search"
+                            className="test-structural-search-toggle"
+                            activeClassName="test-structural-search-toggle--active"
+                            isActive={patternType === SearchPatternType.structural}
+                            onToggle={toggleStructuralSearch}
+                            icon={CodeBracketsIcon}
+                            interactive={props.interactive}
+                            disableOn={[
+                                {
+                                    condition:
+                                        findFilter(navbarSearchQuery, 'patterntype', FilterKind.Subexpression) !==
+                                        undefined,
+                                    reason: 'Query already contains one or more patterntype subexpressions',
+                                },
+                            ]}
+                        />
+                    )}
+                    {luckySearchEnabled && (
+                        <QueryInputToggle
+                            title="Expert mode"
+                            isActive={true}
+                            onToggle={toggleExpertMode}
+                            icon={LightningBoltIcon}
+                            interactive={props.interactive}
+                            className="test-expert-mode-toggle"
+                            activeClassName="test-expert-mode-toggle--active"
+                            disableOn={[]}
+                        />
+                    )}
+                    {copyQueryButton}
                 </>
             )}
         </div>

--- a/client/shared/src/search/query/scanner.ts
+++ b/client/shared/src/search/query/scanner.ts
@@ -489,6 +489,11 @@ export const scanSearchQuery = (
         case SearchPatternType.structural:
             patternKind = PatternKind.Structural
             break
+        case SearchPatternType.lucky:
+            // A `lucky` search pattern can be interpreted in multiple ways
+            // (e.g., literal _or_ regexp), so effectively scan and label patterns as literals.
+            patternKind = PatternKind.Literal
+            break
     }
     const scanner = createScanner(patternKind, interpretComments)
     return scanner(query, 0)

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1852,6 +1852,7 @@ enum SearchPatternType {
     literal
     regexp
     structural
+    lucky
 }
 
 """

--- a/internal/search/query/query.go
+++ b/internal/search/query/query.go
@@ -99,6 +99,8 @@ func For(searchType SearchType) step {
 		processType = succeeds(escapeParensHeuristic, substituteConcat(fuzzyRegexp))
 	case SearchTypeStructural:
 		processType = succeeds(labelStructural, ellipsesForHoles, substituteConcat(space))
+	case SearchTypeLucky:
+		processType = succeeds(substituteConcat(space))
 	}
 	normalize := succeeds(LowercaseFieldNames, SubstituteAliases(searchType), SubstituteCountAll)
 	return sequence(normalize, processType)

--- a/internal/search/query/types.go
+++ b/internal/search/query/types.go
@@ -32,6 +32,7 @@ const (
 	SearchTypeRegex SearchType = iota
 	SearchTypeLiteralDefault
 	SearchTypeStructural
+	SearchTypeLucky
 )
 
 func (s SearchType) String() string {
@@ -42,6 +43,8 @@ func (s SearchType) String() string {
 		return "literal"
 	case SearchTypeStructural:
 		return "structural"
+	case SearchTypeLucky:
+		return "lucky"
 	default:
 		return fmt.Sprintf("unknown{%d}", s)
 	}

--- a/internal/search/run/run.go
+++ b/internal/search/run/run.go
@@ -113,11 +113,10 @@ func (e *QueryError) Error() string {
 	return fmt.Sprintf("invalid query %q: %s", e.Query, e.Err)
 }
 
-// detectSearchType returns the search type to perform ("regexp", or
-// "literal"). The search type derives from three sources: the version and
-// patternType parameters passed to the search endpoint (literal search is the
-// default in V2), and the `patternType:` filter in the input query string which
-// overrides the searchType, if present.
+// detectSearchType returns the search type to perform. The search type derives
+// from three sources: the version and patternType parameters passed to the
+// search endpoint (literal search is the default in V2), and the `patternType:`
+// filter in the input query string which overrides the searchType, if present.
 func detectSearchType(version string, patternType *string) (query.SearchType, error) {
 	var searchType query.SearchType
 	if patternType != nil {
@@ -128,6 +127,8 @@ func detectSearchType(version string, patternType *string) (query.SearchType, er
 			searchType = query.SearchTypeRegex
 		case "structural":
 			searchType = query.SearchTypeStructural
+		case "lucky":
+			searchType = query.SearchTypeLucky
 		default:
 			return -1, errors.Errorf("unrecognized patternType %q", *patternType)
 		}
@@ -160,6 +161,8 @@ func overrideSearchType(input string, searchType query.SearchType) query.SearchT
 			searchType = query.SearchTypeLiteralDefault
 		case "structural":
 			searchType = query.SearchTypeStructural
+		case "lucky":
+			searchType = query.SearchTypeLucky
 		}
 	})
 	return searchType

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1676,7 +1676,7 @@ type Settings struct {
 	SearchContextLines int `json:"search.contextLines,omitempty"`
 	// SearchDefaultCaseSensitive description: Whether query patterns are treated case sensitively. Patterns are case insensitive by default.
 	SearchDefaultCaseSensitive bool `json:"search.defaultCaseSensitive,omitempty"`
-	// SearchDefaultPatternType description: The default pattern type (literal or regexp) that search queries will be intepreted as.
+	// SearchDefaultPatternType description: The default pattern type (literal or regexp) that search queries will be intepreted as. `lucky` is an experimental mode that will interpret the query in multiple ways.
 	SearchDefaultPatternType string `json:"search.defaultPatternType,omitempty"`
 	// SearchGlobbing description: REMOVED. Previously an experimental setting to interpret file and repo patterns as glob syntax.
 	SearchGlobbing *bool `json:"search.globbing,omitempty"`

--- a/schema/settings.schema.json
+++ b/schema/settings.schema.json
@@ -417,9 +417,9 @@
       "default": 1
     },
     "search.defaultPatternType": {
-      "description": "The default pattern type (literal or regexp) that search queries will be intepreted as.",
+      "description": "The default pattern type (literal or regexp) that search queries will be intepreted as. `lucky` is an experimental mode that will interpret the query in multiple ways.",
       "type": "string",
-      "pattern": "literal|regexp"
+      "pattern": "literal|regexp|lucky"
     },
     "search.defaultCaseSensitive": {
       "description": "Whether query patterns are treated case sensitively. Patterns are case insensitive by default.",


### PR DESCRIPTION
This is the frontend part (and minimal backend part) for the "Feeling Lucky" search mode I'd like to merge. [Context](https://sourcegraph.slack.com/archives/C020S8AT3LN/p1651721822320569).

This PR adds a feature-flagged toggle:


https://user-images.githubusercontent.com/888624/171751372-d7af4253-3849-4cc2-8bd6-f34e76ba2973.mp4



I don't want to go into the search behavior of this mode in this PR, I will do that in the backend changes (just know that, it's worth having, and it's worth having as an experimental feature--see the PR for the backend changes here: https://github.com/sourcegraph/sourcegraph/pull/36519). This PR just gets into the details of how the feature affects the frontend (toggle buttons and how it's enabled).

The way it's enabled is by setting the default search pattern setting to `lucky` (open to other ideas, `lucky` works well enough for me). We don't have a good mechanism to create and separate "alternative default search pattern that is experimental", because of our GQL definitions and setting, so I found it much much easier to just modify this setting slightly, and recognize this as a new `patterntype`. I have tried other things (feature flagging with experimental settings) but it requires _extremely_ invasive changes to the frontend and adds the need for another field to be set in all the prop drilling, etc.

When the flag is on, the default pattern becomes a `lucky` one, and a toggle with lightning bolt appears. The lightning bolt expands to the usual toggles when clicked, and collapses it on disable. I've called the hover on this button "Expert user", and how bounced around with "Power user" or "Advanced usage" or "Strict mode" something like that, I'm open to ideas and comments here but the exact wording is also low stakes at this point IMO, so would not bike shed on it.

Note: there's no special wording around "Feeling Lucky" signaled to the user, this is just an internal name for the addition. From the user's perspective, it's "just the default way Sourcegraph works", and the other (current) modes are the expert/advanced/precise/power user search modes.

## Test plan
Scaffolding, manually tested, it's an experimental extension and not enabled.
