### PR TITLE
dev/sg: rework lint package to allow FixableLinter and -fix

### DIFF
--- a/dev/sg/internal/lint/lint.go
+++ b/dev/sg/internal/lint/lint.go
@@ -20,6 +20,9 @@ type Target struct {
 // or anything you want, and should return a report with helpful feedback for the user to
 // act upon.
 //
+// To build a linter that can be fixed as well by 'sg lint -fix', you can implement the
+// FixableLinter interface.
+//
 // Linter can be tested by providing a mock state with repo.NewMockState().
 type Linter interface {
 	Check(context.Context, *repo.State) *Report

--- a/dev/sg/internal/lint/runners.go
+++ b/dev/sg/internal/lint/runners.go
@@ -1,0 +1,43 @@
+package lint
+
+import (
+	"context"
+
+	"github.com/sourcegraph/run"
+
+	"github.com/sourcegraph/sourcegraph/dev/sg/internal/repo"
+	"github.com/sourcegraph/sourcegraph/dev/sg/root"
+)
+
+type scriptRunner struct {
+	header string
+	script string
+}
+
+// ScriptCheck runs the given script from the root of sourcegraph/sourcegraph as a check.
+func ScriptCheck(header string, script string) Linter {
+	return &scriptRunner{header: header, script: script}
+}
+
+func (s *scriptRunner) Check(ctx context.Context, state *repo.State) *Report {
+	out, err := root.Run(run.Bash(ctx, s.script)).String()
+	return &Report{
+		Header: s.header,
+		Output: out,
+		Err:    err,
+	}
+}
+
+// CheckFunc can be used to build simple linter checks.
+type CheckFunc func(ctx context.Context, state *repo.State) *Report
+
+type checkFuncRunner struct{ check CheckFunc }
+
+// FuncCheck is a Linter that executes the given runner as a check.
+func FuncCheck(check CheckFunc) Linter {
+	return &checkFuncRunner{check: check}
+}
+
+func (f *checkFuncRunner) Check(ctx context.Context, state *repo.State) *Report {
+	return f.check(ctx, state)
+}

--- a/dev/sg/linters/client.go
+++ b/dev/sg/linters/client.go
@@ -10,10 +10,10 @@ import (
 )
 
 var (
-	inlineTemplates = lint.RunScript("Inline templates", "dev/check/template-inlines.sh")
+	inlineTemplates = lint.ScriptCheck("Inline templates", "dev/check/template-inlines.sh")
 )
 
-func checkUnversionedDocsLinks() lint.Runner {
+func checkUnversionedDocsLinks() lint.CheckFunc {
 	const header = "Literal unversioned docs links"
 
 	return func(ctx context.Context, s *repo.State) *lint.Report {

--- a/dev/sg/linters/dockerfiles.go
+++ b/dev/sg/linters/dockerfiles.go
@@ -13,7 +13,7 @@ import (
 )
 
 // customDockerfileLinters runs custom Sourcegraph Dockerfile linters
-func customDockerfileLinters() lint.Runner {
+func customDockerfileLinters() lint.CheckFunc {
 	return func(ctx context.Context, _ *repo.State) *lint.Report {
 		var combinedErrors error
 		for _, dir := range []string{

--- a/dev/sg/linters/enterprise.go
+++ b/dev/sg/linters/enterprise.go
@@ -3,6 +3,6 @@ package linters
 import "github.com/sourcegraph/sourcegraph/dev/sg/internal/lint"
 
 var (
-	goEnterpriseImport = lint.RunScript("Go enterprise imports in OSS", "dev/check/go-enterprise-import.sh")
-	tsEnterpriseImport = lint.RunScript("Typescript imports in OSS", "dev/check/ts-enterprise-import.sh")
+	goEnterpriseImport = lint.ScriptCheck("Go enterprise imports in OSS", "dev/check/go-enterprise-import.sh")
+	tsEnterpriseImport = lint.ScriptCheck("Typescript imports in OSS", "dev/check/ts-enterprise-import.sh")
 )

--- a/dev/sg/linters/go_checks.go
+++ b/dev/sg/linters/go_checks.go
@@ -15,11 +15,11 @@ import (
 )
 
 var (
-	goFmt          = lint.RunScript("Go format", "dev/check/gofmt.sh")
-	goDBConnImport = lint.RunScript("Go pkg/database/dbconn", "dev/check/go-dbconn-import.sh")
+	goFmt          = lint.ScriptCheck("Go format", "dev/check/gofmt.sh")
+	goDBConnImport = lint.ScriptCheck("Go pkg/database/dbconn", "dev/check/go-dbconn-import.sh")
 )
 
-func goLint() lint.Runner {
+func goLint() lint.CheckFunc {
 	return func(ctx context.Context, _ *repo.State) *lint.Report {
 		var dst bytes.Buffer
 		err := root.Run(run.Bash(ctx, "dev/check/go-lint.sh")).
@@ -40,7 +40,7 @@ func goLint() lint.Runner {
 	}
 }
 
-func lintSGExit() lint.Runner {
+func lintSGExit() lint.CheckFunc {
 	const header = "Lint dev/sg exit signals"
 
 	return func(ctx context.Context, s *repo.State) *lint.Report {

--- a/dev/sg/linters/gogenerate.go
+++ b/dev/sg/linters/gogenerate.go
@@ -64,7 +64,6 @@ func (l *goGenerateLinter) Check(ctx context.Context, state *repo.State) *lint.R
 			reportOut.Writef("Failed to pretty print diff: %s, dumping output instead:", err.Error())
 			reportOut.Write(diffOutput)
 		}
-		reportOut.WriteSuggestionf("To fix this, run 'sg generate'.")
 		r.Output = sb.String()
 	}
 

--- a/dev/sg/linters/gomod.go
+++ b/dev/sg/linters/gomod.go
@@ -11,69 +11,61 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
-func goModGuards() lint.Runner {
+type goModVersionsLinter struct {
+	maxVersions map[string]*semver.Version
+}
+
+func (l *goModVersionsLinter) Check(ctx context.Context, state *repo.State) *lint.Report {
 	const header = "go.mod version guards"
 
-	var maxVersions = map[string]*semver.Version{
-		// Any version past this version is not yet released in any version of Alertmanager,
-		// and causes incompatibility in prom-wrapper.
-		//
-		// https://github.com/sourcegraph/zoekt/pull/330#issuecomment-1116857568
-		"github.com/prometheus/common": semver.MustParse("v0.32.1"),
+	if len(l.maxVersions) == 0 {
+		return &lint.Report{Header: header, Output: "No guards currently defined"}
 	}
 
-	if len(maxVersions) == 0 {
-		return func(ctx context.Context, s *repo.State) *lint.Report {
-			return &lint.Report{Header: header, Output: "No guards currently defined"}
-		}
+	diff, err := state.GetDiff("go.mod")
+	if err != nil {
+		return &lint.Report{Header: header, Err: err}
+	}
+	if len(diff) == 0 {
+		return &lint.Report{Header: header, Output: "No go.mod changes detected!"}
 	}
 
-	return func(ctx context.Context, s *repo.State) *lint.Report {
-		diff, err := s.GetDiff("go.mod")
-		if err != nil {
-			return &lint.Report{Header: header, Err: err}
-		}
-		if len(diff) == 0 {
-			return &lint.Report{Header: header, Output: "No go.mod changes detected!"}
-		}
-
-		var errs error
-		for _, hunk := range diff["go.mod"] {
-			for _, l := range hunk.AddedLines {
-				parts := strings.Split(strings.TrimSpace(l), " ")
-				if len(parts) != 2 {
+	var errs error
+	for _, hunk := range diff["go.mod"] {
+		for _, line := range hunk.AddedLines {
+			parts := strings.Split(strings.TrimSpace(line), " ")
+			if len(parts) != 2 {
+				continue
+			}
+			var (
+				lib     = parts[0]
+				version = parts[1]
+			)
+			if !strings.HasPrefix(version, "v") {
+				continue
+			}
+			if maxVersion := l.maxVersions[lib]; maxVersion != nil {
+				v, err := semver.NewVersion(version)
+				if err != nil {
+					errs = errors.Append(errs, errors.Wrapf(err, "dependency %s has invalid version", lib))
 					continue
 				}
-				var (
-					lib     = parts[0]
-					version = parts[1]
-				)
-				if !strings.HasPrefix(version, "v") {
-					continue
-				}
-				if maxVersion := maxVersions[lib]; maxVersion != nil {
-					v, err := semver.NewVersion(version)
-					if err != nil {
-						errs = errors.Append(errs, errors.Wrapf(err, "dependency %s has invalid version", lib))
-						continue
-					}
-					if v.GreaterThan(maxVersion) {
-						errs = errors.Append(errs, errors.Newf("dependency %s must not exceed version %s",
-							lib, maxVersion))
-					}
+				if v.GreaterThan(maxVersion) {
+					errs = errors.Append(errs, errors.Newf("dependency %s must not exceed version %s",
+						lib, maxVersion))
 				}
 			}
 		}
+	}
 
-		return &lint.Report{
-			Header: header,
-			Output: func() string {
-				if errs != nil {
-					return strings.TrimSpace(errs.Error())
-				}
-				return ""
-			}(),
-			Err: errs,
-		}
+	return &lint.Report{
+		Header: header,
+		Output: func() string {
+			if errs != nil {
+				return strings.TrimSpace(errs.Error())
+			}
+			return ""
+		}(),
+		Err: errs,
 	}
 }

--- a/dev/sg/linters/hadolint.go
+++ b/dev/sg/linters/hadolint.go
@@ -16,7 +16,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
-func hadolint() lint.Runner {
+func hadolint() lint.CheckFunc {
 	const header = "Hadolint"
 	const hadolintVersion = "v2.10.0"
 	hadolintBinary := fmt.Sprintf("./.bin/hadolint-%s", hadolintVersion)

--- a/dev/sg/linters/liblog_test.go
+++ b/dev/sg/linters/liblog_test.go
@@ -10,10 +10,10 @@ import (
 )
 
 func TestLibLogLinter(t *testing.T) {
-	lint := lintLoggingLibraries()
+	linter := newLoggingLibraryLinter()
 
 	t.Run("no false positives", func(t *testing.T) {
-		report := lint(context.Background(), repo.NewMockState(repo.Diff{
+		report := linter.Check(context.Background(), repo.NewMockState(repo.Diff{
 			"cmd/foobar/command.go": []repo.DiffHunk{
 				{
 					AddedLines: []string{
@@ -27,7 +27,7 @@ func TestLibLogLinter(t *testing.T) {
 	})
 
 	t.Run("catch imports", func(t *testing.T) {
-		report := lint(context.Background(), repo.NewMockState(repo.Diff{
+		report := linter.Check(context.Background(), repo.NewMockState(repo.Diff{
 			"cmd/foobar/command.go": []repo.DiffHunk{
 				{
 					AddedLines: []string{

--- a/dev/sg/linters/misc.go
+++ b/dev/sg/linters/misc.go
@@ -3,6 +3,6 @@ package linters
 import "github.com/sourcegraph/sourcegraph/dev/sg/internal/lint"
 
 var (
-	noLocalHost = lint.RunScript("Check for localhost usage", "dev/check/no-localhost-guard.sh") // CI:LOCALHOST_OK
-	submodules  = lint.RunScript("Check submodules", "dev/check/submodule.sh")
+	noLocalHost = lint.ScriptCheck("Check for localhost usage", "dev/check/no-localhost-guard.sh") // CI:LOCALHOST_OK
+	submodules  = lint.ScriptCheck("Check submodules", "dev/check/submodule.sh")
 )

--- a/dev/sg/linters/shell.go
+++ b/dev/sg/linters/shell.go
@@ -3,7 +3,7 @@ package linters
 import "github.com/sourcegraph/sourcegraph/dev/sg/internal/lint"
 
 var (
-	bashSyntax = lint.RunScript("Validate bash syntax", "dev/check/bash-syntax.sh")
-	shFmt      = lint.RunScript("Shell formatting", "dev/check/shfmt.sh")
-	shellCheck = lint.RunScript("Shell lint", "dev/check/shellcheck.sh")
+	bashSyntax = lint.ScriptCheck("Validate bash syntax", "dev/check/bash-syntax.sh")
+	shFmt      = lint.ScriptCheck("Shell formatting", "dev/check/shfmt.sh")
+	shellCheck = lint.ScriptCheck("Shell lint", "dev/check/shellcheck.sh")
 )

--- a/dev/sg/linters/svg.go
+++ b/dev/sg/linters/svg.go
@@ -14,7 +14,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
-func checkSVGCompression() lint.Runner {
+func checkSVGCompression() lint.CheckFunc {
 	const header = "SVG Compression"
 
 	return func(ctx context.Context, s *repo.State) *lint.Report {

--- a/dev/sg/sg_lint.go
+++ b/dev/sg/sg_lint.go
@@ -235,11 +235,11 @@ func runCheckScriptsAndReport(ctx context.Context, dst io.Writer, fix bool, lns 
 		}
 	} else if fixableErrors > 0 {
 		// indicate some errors might be fixable!
-		suggestion := "One or more of the failed linters are fixable - try 'sg lint --fix'."
+		suggestion := "One or more of the failed linters can be fixed with `sg lint --fix`."
 		out.WriteSuggestionf(suggestion)
 
 		if lintGenerateAnnotations {
-			writeAnnotation("Some linter issues are fixable", suggestion, true)
+			writeAnnotation("Some linter issues are automatically fixable!", suggestion, true)
 		}
 	}
 


### PR DESCRIPTION
Refactors the `lint` package to now export two main ways to build linters:

- `Linter`, which implements a `Check(...)`
- `FixableLinter`, which also implements a `Fix(...)`

Using this, `sg lint` now:

- on normal `sg lint`, runs checks and suggests that users run `sg lint -fix` if any of the failed linters implement `FixableLinter`
- on `sg lint -fix`, runs all checks, but if a linter implements `FixableLinter`, also runs that

To enable this:

- `repo.State` now parses the full diff up-front, so that linters do not interfere with each other
- the `go generate` check now resets the workspace in `Check`
- fix an issue with `sg lint [target] -h` to allow us to surface hints that a target has fixable linters

For back-compat, we have:

- `lint.ScriptCheck`, which is more or less the same as the old `lint.Script`
- `lint.FuncCheck`, which can wrap the old `lint.Runner` interface

To demonstrate the new API and features, this PR:

- Creates a new `go generate` linter implementation that implements `FixableLinter`
- Migrates some linters that have configuration (logging library linter, go mod version linter) to implement the `Linter` interface directly, because the struct func approach gives a better home for configuration

Closes https://github.com/sourcegraph/sourcegraph/issues/35396

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

`go run ./dev/sg lint` with a generate issue will suggest that it is fixable, and leave no diff in the workspace:

<img width="570" alt="image" src="https://user-images.githubusercontent.com/23356519/171759706-4e5ea359-a8b7-4762-b052-5dca8cab3881.png">

`go run ./dv/sg lint go -h` indicates this target has linters that are fixable:

<img width="719" alt="image" src="https://user-images.githubusercontent.com/23356519/171760848-d2c479e2-de84-4eca-922b-4c8b853604f5.png">

With `-fix`:

<img width="568" alt="image" src="https://user-images.githubusercontent.com/23356519/171761870-fa66b094-5158-4824-aeca-67b083a67bf5.png">
