### PR TITLE
search: export ZoektGlobalQuery fields

### DIFF
--- a/internal/search/zoekt/indexed_search.go
+++ b/internal/search/zoekt/indexed_search.go
@@ -602,9 +602,9 @@ func (*GlobalTextSearchJob) Name() string {
 
 func (t *GlobalTextSearchJob) Tags() []log.Field {
 	return []log.Field{
-		trace.Stringer("query", t.GlobalZoektQuery.query),
-		trace.Printf("repoScope", "%q", t.GlobalZoektQuery.repoScope),
-		log.Bool("includePrivate", t.GlobalZoektQuery.includePrivate),
+		trace.Stringer("query", t.GlobalZoektQuery.Query),
+		trace.Printf("repoScope", "%q", t.GlobalZoektQuery.RepoScope),
+		log.Bool("includePrivate", t.GlobalZoektQuery.IncludePrivate),
 		log.String("type", string(t.ZoektArgs.Typ)),
 		log.Int32("fileMatchLimit", t.ZoektArgs.FileMatchLimit),
 		trace.Stringer("select", t.ZoektArgs.Select),

--- a/internal/search/zoekt/symbol_search.go
+++ b/internal/search/zoekt/symbol_search.go
@@ -106,9 +106,9 @@ func (*GlobalSymbolSearchJob) Name() string {
 
 func (s *GlobalSymbolSearchJob) Tags() []log.Field {
 	return []log.Field{
-		trace.Stringer("query", s.GlobalZoektQuery.query),
-		trace.Printf("repoScope", "%q", s.GlobalZoektQuery.repoScope),
-		log.Bool("includePrivate", s.GlobalZoektQuery.includePrivate),
+		trace.Stringer("query", s.GlobalZoektQuery.Query),
+		trace.Printf("repoScope", "%q", s.GlobalZoektQuery.RepoScope),
+		log.Bool("includePrivate", s.GlobalZoektQuery.IncludePrivate),
 		log.String("type", string(s.ZoektArgs.Typ)),
 		log.Int32("fileMatchLimit", s.ZoektArgs.FileMatchLimit),
 		trace.Stringer("select", s.ZoektArgs.Select),

--- a/internal/search/zoekt/zoekt_global.go
+++ b/internal/search/zoekt/zoekt_global.go
@@ -48,9 +48,9 @@ func DefaultGlobalQueryScope(repoOptions search.RepoOptions) (zoektquery.Q, erro
 // ensure repo privacy filters). A `Generate` method converts the object to a
 // Zoekt query that ensures appropriate repo privacy scopes.
 type GlobalZoektQuery struct {
-	query          zoektquery.Q
-	repoScope      []zoektquery.Q
-	includePrivate bool
+	Query          zoektquery.Q
+	RepoScope      []zoektquery.Q
+	IncludePrivate bool
 }
 
 func NewGlobalZoektQuery(query zoektquery.Q, scope zoektquery.Q, includePrivate bool) *GlobalZoektQuery {
@@ -59,9 +59,9 @@ func NewGlobalZoektQuery(query zoektquery.Q, scope zoektquery.Q, includePrivate 
 		repoScope = append(repoScope, scope)
 	}
 	return &GlobalZoektQuery{
-		query:          query,
-		repoScope:      repoScope,
-		includePrivate: includePrivate,
+		Query:          query,
+		RepoScope:      repoScope,
+		IncludePrivate: includePrivate,
 	}
 }
 
@@ -71,12 +71,12 @@ func NewGlobalZoektQuery(query zoektquery.Q, scope zoektquery.Q, includePrivate 
 // construction of a GlobalZoektQuery was permitted to includePrivate
 // repositories.
 func (q *GlobalZoektQuery) ApplyPrivateFilter(userPrivateRepos []types.MinimalRepo) {
-	if q.includePrivate && len(userPrivateRepos) > 0 {
+	if q.IncludePrivate && len(userPrivateRepos) > 0 {
 		ids := make([]uint32, 0, len(userPrivateRepos))
 		for _, r := range userPrivateRepos {
 			ids = append(ids, uint32(r.ID))
 		}
-		q.repoScope = append(q.repoScope, zoektquery.NewSingleBranchesRepos("HEAD", ids...))
+		q.RepoScope = append(q.RepoScope, zoektquery.NewSingleBranchesRepos("HEAD", ids...))
 	}
 }
 
@@ -84,5 +84,5 @@ func (q *GlobalZoektQuery) ApplyPrivateFilter(userPrivateRepos []types.MinimalRe
 // scope (i.e., whether to either exclusively public, exclusively private, or
 // either public or private repositories)
 func (q *GlobalZoektQuery) Generate() zoektquery.Q {
-	return zoektquery.Simplify(zoektquery.NewAnd(q.query, zoektquery.NewOr(q.repoScope...)))
+	return zoektquery.Simplify(zoektquery.NewAnd(q.Query, zoektquery.NewOr(q.RepoScope...)))
 }


### PR DESCRIPTION
Stacked on https://github.com/sourcegraph/sourcegraph/pull/36514.

The global Zoekt query values (like `pattern`) are not output when printed because the fields are unexported. These are pretty important test values for upcoming lucky search and I can't easily check correctness without exporting these.

## Test plan
Semantics-preserving.