### PR TITLE
search: add rule transformation and unquoting to lucky search

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -378,6 +378,8 @@ func LogSearchLatency(ctx context.Context, db database.DB, wg *sync.WaitGroup, s
 				types = append(types, "literal")
 			case si.PatternType == query.SearchTypeRegex:
 				types = append(types, "regexp")
+			case si.PatternType == query.SearchTypeLucky:
+				types = append(types, "lucky")
 			}
 		}
 	}

--- a/internal/search/alert.go
+++ b/internal/search/alert.go
@@ -60,6 +60,8 @@ func (q *ProposedQuery) QueryString() string {
 			return q.Query + " patternType:literal"
 		case query.SearchTypeStructural:
 			return q.Query + " patternType:structural"
+		case query.SearchTypeLucky:
+			return q.Query + " patternType:lucky"
 		default:
 			panic("unreachable")
 		}

--- a/internal/search/job/jobutil/feeling_lucky_search_job.go
+++ b/internal/search/job/jobutil/feeling_lucky_search_job.go
@@ -1,0 +1,121 @@
+package jobutil
+
+import (
+	"github.com/sourcegraph/sourcegraph/internal/search/job"
+	"github.com/sourcegraph/sourcegraph/internal/search/query"
+	"github.com/sourcegraph/sourcegraph/internal/search/run"
+)
+
+// NewFeelingLuckySearchJob generates opportunistic search queries by applying
+// various rules in sequence, transforming the original input plan into various
+// queries that alter its interpretation (e.g., search literally for quotes or
+// not, attempt to search the pattern as a regexp, and so on).
+//
+// Generated queries return a resulting list of jobs. The application order of
+// rules is deterministic. This means the query order, and therefore runtime
+// execution, outputs the same search results for the same inputs. I.e., there
+// is no random choice when applying a rule.
+func NewFeelingLuckySearchJob(inputs *run.SearchInputs, plan query.Plan) []job.Job {
+	children := make([]job.Job, 0, len(plan))
+	for _, b := range plan {
+		for _, newBasic := range applyRulesList(b, rulesList...) {
+			child, err := NewBasicJob(inputs, newBasic)
+			if err != nil {
+				return nil
+			}
+			children = append(children, child)
+		}
+	}
+	return children
+}
+
+var rulesList = [][]rule{
+	{unquotePatterns},
+}
+
+// rule represents a transformation function on a Basic query. Applying rules
+// cannot fail: either they apply and produce a valid, non-nil, Basic query, or
+// they cannot apply, in which case they return nil. See the `unquotePatterns`
+// rule for an example.
+type rule func(query.Basic) *query.Basic
+
+// applyRulesList takes a list of lists of rules. The order of rules in the inner
+// lists represent rule composition. Each list of rules in the outer list
+// represent one possible query production, if the sequence of the rules in this
+// list apply successfully. Example:
+//
+// If we have input rule list  [ [ R1, R2 ], [ R2 ] ] and input query B0, then:
+//
+// - If both inner lists apply, we get an output [ B1, B2] where B1 is generated
+//   from applying R1 then R2, and B2 is generated from just applying R2.
+// - If only the first inner list applies, R1 then R2, we get the output [ B1 ]
+// - If only the second inner list applies, R2 on its own, we get the output [ B2 ]
+func applyRulesList(b query.Basic, rulesList ...[]rule) []query.Basic {
+	bs := []query.Basic{}
+	for _, l := range rulesList {
+		if generated := applyRules(b, l...); generated != nil {
+			bs = append(bs, *generated)
+		}
+	}
+	return bs
+}
+
+// applyRules applies every rule in sequence to `b`. If any rule does not apply, it returns nil.
+func applyRules(b query.Basic, rules ...rule) *query.Basic {
+	for _, rule := range rules {
+		res := rule(b)
+		if res == nil {
+			return nil
+		}
+		b = *res
+	}
+	return &b
+}
+
+// unquotePatterns is a rule that unquotes all patterns in the input query (it
+// removes quotes, and honors escape sequences inside quoted values).
+func unquotePatterns(b query.Basic) *query.Basic {
+	// Go back all the way to the raw tree representation :-). We just parse
+	// the string as regex, since parsing with regex annotates quoted
+	// patterns.
+	rawParseTree, err := query.Parse(query.StringHuman(b.ToParseTree()), query.SearchTypeRegex)
+	if err != nil {
+		return nil
+	}
+
+	changed := false // track whether we've successfully changed any pattern, which means this rule applies.
+	newParseTree := query.MapPattern(rawParseTree, func(value string, negated bool, annotation query.Annotation) query.Node {
+		if annotation.Labels.IsSet(query.Quoted) {
+			changed = true
+			annotation.Labels.Unset(query.Quoted)
+			annotation.Labels.Set(query.Literal)
+			return query.Pattern{
+				Value:      value,
+				Negated:    negated,
+				Annotation: annotation,
+			}
+		}
+		return query.Pattern{
+			Value:      value,
+			Negated:    negated,
+			Annotation: annotation,
+		}
+	})
+
+	if !changed {
+		// No unquoting happened, so we don't run the search.
+		return nil
+	}
+
+	newNodes, err := query.Sequence(query.For(query.SearchTypeLiteralDefault))(newParseTree)
+	if err != nil {
+		return nil
+	}
+
+	newBasic, err := query.ToBasicQuery(newNodes)
+	if err != nil {
+		return nil
+	}
+
+	return &newBasic
+}

--- a/internal/search/job/jobutil/feeling_lucky_search_job_test.go
+++ b/internal/search/job/jobutil/feeling_lucky_search_job_test.go
@@ -1,0 +1,28 @@
+package jobutil
+
+import (
+	"testing"
+
+	"github.com/hexops/autogold"
+	"github.com/sourcegraph/sourcegraph/internal/search"
+	"github.com/sourcegraph/sourcegraph/internal/search/query"
+	"github.com/sourcegraph/sourcegraph/internal/search/run"
+	"github.com/sourcegraph/sourcegraph/schema"
+)
+
+func TestNewFeelingLuckySearchJob(t *testing.T) {
+	test := func(q string) string {
+		inputs := &run.SearchInputs{
+			UserSettings: &schema.Settings{},
+			Protocol:     search.Streaming,
+			PatternType:  query.SearchTypeLucky,
+		}
+		plan, _ := query.Pipeline(query.InitLiteral(q))
+		job, _ := NewPlanJob(inputs, plan)
+		return PrettyJSONVerbose(job)
+	}
+
+	t.Run("default rules", func(t *testing.T) {
+		autogold.Equal(t, autogold.Raw(test(`"lucky"`)))
+	})
+}

--- a/internal/search/job/jobutil/job.go
+++ b/internal/search/job/jobutil/job.go
@@ -39,7 +39,18 @@ func NewPlanJob(inputs *run.SearchInputs, plan query.Plan) (job.Job, error) {
 		}
 		children = append(children, child)
 	}
-	return NewAlertJob(inputs, NewOrJob(children...)), nil
+
+	jobTree := NewOrJob(children...)
+
+	if inputs.PatternType == query.SearchTypeLucky {
+		// generate opportunistic queries and run them after the usual jobTree
+		generatedChildren := NewFeelingLuckySearchJob(inputs, plan)
+		if len(generatedChildren) > 0 {
+			jobTree = NewSequentialJob(true, append([]job.Job{jobTree}, generatedChildren...)...)
+		}
+	}
+
+	return NewAlertJob(inputs, jobTree), nil
 }
 
 // NewBasicJob converts a query.Basic into its job tree representation.

--- a/internal/search/job/jobutil/testdata/TestNewFeelingLuckySearchJob/default_rules.golden
+++ b/internal/search/job/jobutil/testdata/TestNewFeelingLuckySearchJob/default_rules.golden
@@ -1,0 +1,308 @@
+{
+  "ALERT": {
+    "SEQUENTIAL": [
+      {
+        "TIMEOUT": {
+          "LIMIT": {
+            "PARALLEL": [
+              {
+                "ZoektGlobalTextSearchJob": {
+                  "GlobalZoektQuery": {
+                    "Query": {
+                      "Pattern": "\"lucky\"",
+                      "CaseSensitive": false,
+                      "FileName": false,
+                      "Content": false
+                    },
+                    "RepoScope": [
+                      {
+                        "Children": [
+                          {
+                            "Pattern": "HEAD",
+                            "Exact": true
+                          },
+                          41
+                        ]
+                      }
+                    ],
+                    "IncludePrivate": true
+                  },
+                  "ZoektArgs": {
+                    "Query": null,
+                    "Typ": "text",
+                    "FileMatchLimit": 500,
+                    "Select": []
+                  },
+                  "RepoOpts": {
+                    "RepoFilters": null,
+                    "MinusRepoFilters": null,
+                    "Dependencies": null,
+                    "Dependents": null,
+                    "CaseSensitiveRepoFilters": false,
+                    "SearchContextSpec": "",
+                    "CommitAfter": "",
+                    "Visibility": "Any",
+                    "Limit": 0,
+                    "Cursors": null,
+                    "ForkSet": false,
+                    "NoForks": true,
+                    "OnlyForks": false,
+                    "OnlyCloned": false,
+                    "ArchivedSet": false,
+                    "NoArchived": true,
+                    "OnlyArchived": false
+                  }
+                }
+              },
+              {
+                "ReposComputeExcludedJob": {
+                  "RepoOpts": {
+                    "RepoFilters": null,
+                    "MinusRepoFilters": null,
+                    "Dependencies": null,
+                    "Dependents": null,
+                    "CaseSensitiveRepoFilters": false,
+                    "SearchContextSpec": "",
+                    "CommitAfter": "",
+                    "Visibility": "Any",
+                    "Limit": 0,
+                    "Cursors": null,
+                    "ForkSet": false,
+                    "NoForks": true,
+                    "OnlyForks": false,
+                    "OnlyCloned": false,
+                    "ArchivedSet": false,
+                    "NoArchived": true,
+                    "OnlyArchived": false
+                  }
+                }
+              },
+              {
+                "PARALLEL": [
+                  {
+                    "REPOPAGER": {
+                      "SearcherTextSearchJob": {
+                        "PatternInfo": {
+                          "Pattern": "\"lucky\"",
+                          "IsNegated": false,
+                          "IsRegExp": true,
+                          "IsStructuralPat": false,
+                          "CombyRule": "",
+                          "IsWordMatch": false,
+                          "IsCaseSensitive": false,
+                          "FileMatchLimit": 500,
+                          "Index": "yes",
+                          "Select": [],
+                          "IncludePatterns": null,
+                          "ExcludePattern": "",
+                          "FilePatternsReposMustInclude": null,
+                          "FilePatternsReposMustExclude": null,
+                          "PathPatternsAreCaseSensitive": false,
+                          "PatternMatchesContent": true,
+                          "PatternMatchesPath": true,
+                          "Languages": null
+                        },
+                        "Repos": null,
+                        "Indexed": false,
+                        "UseFullDeadline": true,
+                        "Features": {
+                          "ContentBasedLangFilters": false,
+                          "HybridSearch": false
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "RepoSearchJob": {
+                      "RepoOpts": {
+                        "RepoFilters": [
+                          "\"lucky\""
+                        ],
+                        "MinusRepoFilters": null,
+                        "Dependencies": null,
+                        "Dependents": null,
+                        "CaseSensitiveRepoFilters": false,
+                        "SearchContextSpec": "",
+                        "CommitAfter": "",
+                        "Visibility": "Any",
+                        "Limit": 0,
+                        "Cursors": null,
+                        "ForkSet": false,
+                        "NoForks": true,
+                        "OnlyForks": false,
+                        "OnlyCloned": false,
+                        "ArchivedSet": false,
+                        "NoArchived": true,
+                        "OnlyArchived": false
+                      },
+                      "FilePatternsReposMustInclude": null,
+                      "FilePatternsReposMustExclude": null,
+                      "Features": {
+                        "ContentBasedLangFilters": false,
+                        "HybridSearch": false
+                      },
+                      "Mode": 1
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "value": 500
+        },
+        "value": "20s"
+      },
+      {
+        "TIMEOUT": {
+          "LIMIT": {
+            "PARALLEL": [
+              {
+                "ZoektGlobalTextSearchJob": {
+                  "GlobalZoektQuery": {
+                    "Query": {
+                      "Pattern": "lucky",
+                      "CaseSensitive": false,
+                      "FileName": false,
+                      "Content": false
+                    },
+                    "RepoScope": [
+                      {
+                        "Children": [
+                          {
+                            "Pattern": "HEAD",
+                            "Exact": true
+                          },
+                          41
+                        ]
+                      }
+                    ],
+                    "IncludePrivate": true
+                  },
+                  "ZoektArgs": {
+                    "Query": null,
+                    "Typ": "text",
+                    "FileMatchLimit": 500,
+                    "Select": []
+                  },
+                  "RepoOpts": {
+                    "RepoFilters": null,
+                    "MinusRepoFilters": null,
+                    "Dependencies": null,
+                    "Dependents": null,
+                    "CaseSensitiveRepoFilters": false,
+                    "SearchContextSpec": "",
+                    "CommitAfter": "",
+                    "Visibility": "Any",
+                    "Limit": 0,
+                    "Cursors": null,
+                    "ForkSet": false,
+                    "NoForks": true,
+                    "OnlyForks": false,
+                    "OnlyCloned": false,
+                    "ArchivedSet": false,
+                    "NoArchived": true,
+                    "OnlyArchived": false
+                  }
+                }
+              },
+              {
+                "ReposComputeExcludedJob": {
+                  "RepoOpts": {
+                    "RepoFilters": null,
+                    "MinusRepoFilters": null,
+                    "Dependencies": null,
+                    "Dependents": null,
+                    "CaseSensitiveRepoFilters": false,
+                    "SearchContextSpec": "",
+                    "CommitAfter": "",
+                    "Visibility": "Any",
+                    "Limit": 0,
+                    "Cursors": null,
+                    "ForkSet": false,
+                    "NoForks": true,
+                    "OnlyForks": false,
+                    "OnlyCloned": false,
+                    "ArchivedSet": false,
+                    "NoArchived": true,
+                    "OnlyArchived": false
+                  }
+                }
+              },
+              {
+                "PARALLEL": [
+                  {
+                    "REPOPAGER": {
+                      "SearcherTextSearchJob": {
+                        "PatternInfo": {
+                          "Pattern": "lucky",
+                          "IsNegated": false,
+                          "IsRegExp": true,
+                          "IsStructuralPat": false,
+                          "CombyRule": "",
+                          "IsWordMatch": false,
+                          "IsCaseSensitive": false,
+                          "FileMatchLimit": 500,
+                          "Index": "yes",
+                          "Select": [],
+                          "IncludePatterns": null,
+                          "ExcludePattern": "",
+                          "FilePatternsReposMustInclude": null,
+                          "FilePatternsReposMustExclude": null,
+                          "PathPatternsAreCaseSensitive": false,
+                          "PatternMatchesContent": true,
+                          "PatternMatchesPath": true,
+                          "Languages": null
+                        },
+                        "Repos": null,
+                        "Indexed": false,
+                        "UseFullDeadline": true,
+                        "Features": {
+                          "ContentBasedLangFilters": false,
+                          "HybridSearch": false
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "RepoSearchJob": {
+                      "RepoOpts": {
+                        "RepoFilters": [
+                          "lucky"
+                        ],
+                        "MinusRepoFilters": null,
+                        "Dependencies": null,
+                        "Dependents": null,
+                        "CaseSensitiveRepoFilters": false,
+                        "SearchContextSpec": "",
+                        "CommitAfter": "",
+                        "Visibility": "Any",
+                        "Limit": 0,
+                        "Cursors": null,
+                        "ForkSet": false,
+                        "NoForks": true,
+                        "OnlyForks": false,
+                        "OnlyCloned": false,
+                        "ArchivedSet": false,
+                        "NoArchived": true,
+                        "OnlyArchived": false
+                      },
+                      "FilePatternsReposMustInclude": null,
+                      "FilePatternsReposMustExclude": null,
+                      "Features": {
+                        "ContentBasedLangFilters": false,
+                        "HybridSearch": false
+                      },
+                      "Mode": 1
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "value": 500
+        },
+        "value": "20s"
+      }
+    ]
+  }
+}

--- a/internal/search/query/labels.go
+++ b/internal/search/query/labels.go
@@ -37,11 +37,11 @@ func (l *labels) IsSet(label labels) bool {
 	return *l&label != 0
 }
 
-func (l *labels) set(label labels) {
+func (l *labels) Set(label labels) {
 	*l |= label
 }
 
-func (l *labels) unset(label labels) {
+func (l *labels) Unset(label labels) {
 	*l &^= label
 }
 

--- a/internal/search/query/mapper.go
+++ b/internal/search/query/mapper.go
@@ -39,7 +39,7 @@ func (*BaseMapper) MapNodes(mapper Mapper, nodes []Node) []Node {
 
 // Base mapper for Operators. Reduces operands if changed.
 func (*BaseMapper) MapOperator(mapper Mapper, kind operatorKind, operands []Node) []Node {
-	return newOperator(mapper.MapNodes(mapper, operands), kind)
+	return NewOperator(mapper.MapNodes(mapper, operands), kind)
 }
 
 // Base mapper for Parameters. It is the identity function.
@@ -63,7 +63,7 @@ type OperatorMapper struct {
 // MapOperator implements OperatorMapper by overriding the BaseMapper's value to
 // substitute a node computed by the callback. It reduces any substituted node.
 func (s *OperatorMapper) MapOperator(mapper Mapper, kind operatorKind, operands []Node) []Node {
-	return newOperator(s.callback(kind, operands), And)
+	return NewOperator(s.callback(kind, operands), And)
 }
 
 // ParameterMapper is a helper mapper that only maps parameters in a query. It

--- a/internal/search/query/mapper_test.go
+++ b/internal/search/query/mapper_test.go
@@ -18,7 +18,7 @@ func TestMapOperator(t *testing.T) {
 	}
 	want := input
 	got := MapOperator(input, func(kind operatorKind, operands []Node) []Node {
-		return newOperator(newOperator(newOperator(operands, kind), And), Or)
+		return NewOperator(NewOperator(NewOperator(operands, kind), And), Or)
 	})
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Fatal(diff)

--- a/internal/search/query/parser.go
+++ b/internal/search/query/parser.go
@@ -834,7 +834,7 @@ func (p *parser) ParsePattern(label labels) Pattern {
 		value, advance = ScanAnyPattern(p.buf[p.pos:])
 	}
 	if isSet(p.heuristics, allowDanglingParens) {
-		label.set(HeuristicDanglingParens)
+		label.Set(HeuristicDanglingParens)
 	}
 	p.pos += advance
 	return newPattern(value, label, newRange(start, p.pos))
@@ -891,10 +891,10 @@ func partitionParameters(nodes []Node) []Node {
 		}
 	}
 	if len(patterns) > 1 {
-		orderedPatterns := newOperator(patterns, Concat)
-		return newOperator(append(unorderedParams, orderedPatterns...), And)
+		orderedPatterns := NewOperator(patterns, Concat)
+		return NewOperator(append(unorderedParams, orderedPatterns...), And)
 	}
-	return newOperator(append(unorderedParams, patterns...), And)
+	return NewOperator(append(unorderedParams, patterns...), And)
 }
 
 // parseLeaves scans for consecutive leaf nodes and applies
@@ -915,7 +915,7 @@ loop:
 			if isSet(p.heuristics, parensAsPatterns) {
 				if value, advance, ok := ScanBalancedPattern(p.buf[p.pos:]); ok {
 					if label.IsSet(Literal) {
-						label.set(HeuristicParensAsPatterns)
+						label.Set(HeuristicParensAsPatterns)
 					}
 					pattern := newPattern(value, label, newRange(p.pos, p.pos+advance))
 					p.pos += advance
@@ -1048,9 +1048,9 @@ func reduce(left, right []Node, kind operatorKind) ([]Node, bool) {
 	return append(left, right...), false
 }
 
-// newOperator constructs a new node of kind operatorKind with operands nodes,
+// NewOperator constructs a new node of kind operatorKind with operands nodes,
 // reducing nodes as needed.
-func newOperator(nodes []Node, kind operatorKind) []Node {
+func NewOperator(nodes []Node, kind operatorKind) []Node {
 	if len(nodes) == 0 {
 		return nil
 	} else if len(nodes) == 1 {
@@ -1059,7 +1059,7 @@ func newOperator(nodes []Node, kind operatorKind) []Node {
 
 	reduced, changed := reduce([]Node{nodes[0]}, nodes[1:], kind)
 	if changed {
-		return newOperator(reduced, kind)
+		return NewOperator(reduced, kind)
 	}
 	return []Node{Operator{Kind: kind, Operands: reduced}}
 }
@@ -1086,7 +1086,7 @@ func (p *parser) parseAnd() ([]Node, error) {
 	if err != nil {
 		return nil, err
 	}
-	return newOperator(append(left, right...), And), nil
+	return NewOperator(append(left, right...), And), nil
 }
 
 // parseOr parses or-expressions. Or operators have lower precedence than And
@@ -1106,7 +1106,7 @@ func (p *parser) parseOr() ([]Node, error) {
 	if err != nil {
 		return nil, err
 	}
-	return newOperator(append(left, right...), Or), nil
+	return NewOperator(append(left, right...), Or), nil
 }
 
 func (p *parser) tryFallbackParser(in string) ([]Node, error) {
@@ -1120,9 +1120,9 @@ func (p *parser) tryFallbackParser(in string) ([]Node, error) {
 		return nil, err
 	}
 	if hoistedNodes, err := Hoist(nodes); err == nil {
-		return newOperator(hoistedNodes, And), nil
+		return NewOperator(hoistedNodes, And), nil
 	}
-	return newOperator(nodes, And), nil
+	return NewOperator(nodes, And), nil
 }
 
 // Parse parses a raw input string into a parse tree comprising Nodes.
@@ -1170,7 +1170,7 @@ func Parse(in string, searchType SearchType) ([]Node, error) {
 			return nil, err
 		}
 	}
-	return newOperator(nodes, And), nil
+	return NewOperator(nodes, And), nil
 }
 
 func ParseSearchType(in string, searchType SearchType) (Q, error) {

--- a/internal/search/query/parser_test.go
+++ b/internal/search/query/parser_test.go
@@ -291,7 +291,7 @@ func parseAndOrGrammar(in string) ([]Node, error) {
 	if parser.balanced != 0 {
 		return nil, errors.New("unbalanced expression: unmatched closing parenthesis )")
 	}
-	return newOperator(nodes, And), nil
+	return NewOperator(nodes, And), nil
 }
 
 func TestParse(t *testing.T) {
@@ -743,7 +743,7 @@ func Test_newOperator(t *testing.T) {
 			q, err := ParseRegexp(tc.query)
 			require.NoError(t, err)
 
-			got := newOperator(q, And)
+			got := NewOperator(q, And)
 			tc.want.Equal(t, Q(got).String())
 		})
 	}

--- a/internal/search/query/query.go
+++ b/internal/search/query/query.go
@@ -16,8 +16,8 @@ type step func([]Node) ([]Node, error)
 // A pass is a step that never fails.
 type pass func([]Node) []Node
 
-// sequence sequences zero or more steps to create a single step.
-func sequence(steps ...step) step {
+// Sequence sequences zero or more steps to create a single step.
+func Sequence(steps ...step) step {
 	return func(nodes []Node) ([]Node, error) {
 		var err error
 		for _, step := range steps {
@@ -103,7 +103,7 @@ func For(searchType SearchType) step {
 		processType = succeeds(substituteConcat(space))
 	}
 	normalize := succeeds(LowercaseFieldNames, SubstituteAliases(searchType), SubstituteCountAll)
-	return sequence(normalize, processType)
+	return Sequence(normalize, processType)
 }
 
 // Init creates a step from an input string and search type. It parses the
@@ -112,7 +112,7 @@ func Init(in string, searchType SearchType) step {
 	parser := func([]Node) ([]Node, error) {
 		return Parse(in, searchType)
 	}
-	return sequence(parser, For(searchType))
+	return Sequence(parser, For(searchType))
 }
 
 // InitLiteral is Init where SearchType is Literal.
@@ -159,7 +159,7 @@ func MapPlan(plan Plan, pass BasicPass) Plan {
 // Pipeline processes zero or more steps to produce a query. The first step must
 // be Init, otherwise this function is a no-op.
 func Pipeline(steps ...step) (Plan, error) {
-	nodes, err := sequence(steps...)(nil)
+	nodes, err := Sequence(steps...)(nil)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/search/query/transformer.go
+++ b/internal/search/query/transformer.go
@@ -17,15 +17,15 @@ func SubstituteAliases(searchType SearchType) func(nodes []Node) []Node {
 		return MapParameter(nodes, func(field, value string, negated bool, annotation Annotation) Node {
 			if field == "content" {
 				if searchType == SearchTypeRegex {
-					annotation.Labels.set(Regexp)
+					annotation.Labels.Set(Regexp)
 				} else {
-					annotation.Labels.set(Literal)
+					annotation.Labels.Set(Literal)
 				}
-				annotation.Labels.set(IsAlias)
+				annotation.Labels.Set(IsAlias)
 				return Pattern{Value: value, Negated: negated, Annotation: annotation}
 			}
 			if canonical, ok := aliases[field]; ok {
-				annotation.Labels.set(IsAlias)
+				annotation.Labels.Set(IsAlias)
 				field = canonical
 			}
 			return Parameter{Field: field, Value: value, Negated: negated, Annotation: annotation}
@@ -424,7 +424,7 @@ func Hoist(nodes []Node) ([]Node, error) {
 		annotation.Labels |= HeuristicHoisted
 		return Pattern{Value: value, Negated: negated, Annotation: annotation}
 	})
-	return append(toNodes(scopeParameters), newOperator(pattern, expression.Kind)...), nil
+	return append(toNodes(scopeParameters), NewOperator(pattern, expression.Kind)...), nil
 }
 
 // partition partitions nodes into left and right groups. A node is put in the
@@ -501,7 +501,7 @@ func conjunction(left, right Basic) Basic {
 	} else if right.Pattern == nil {
 		pattern = left.Pattern
 	} else if left.Pattern != nil && right.Pattern != nil {
-		pattern = newOperator([]Node{left.Pattern, right.Pattern}, And)[0]
+		pattern = NewOperator([]Node{left.Pattern, right.Pattern}, And)[0]
 	}
 	return Basic{
 		// Deep copy parameters to avoid appending multiple times to the same backing array.
@@ -547,10 +547,10 @@ func substituteOrForRegexp(nodes []Node) []Node {
 				newNode = append(newNode, Pattern{Value: valueString})
 				if len(rest) > 0 {
 					rest = substituteOrForRegexp(rest)
-					newNode = newOperator(append(newNode, rest...), Or)
+					newNode = NewOperator(append(newNode, rest...), Or)
 				}
 			} else {
-				newNode = append(newNode, newOperator(substituteOrForRegexp(v.Operands), v.Kind)...)
+				newNode = append(newNode, NewOperator(substituteOrForRegexp(v.Operands), v.Kind)...)
 			}
 		case Parameter, Pattern:
 			newNode = append(newNode, node)
@@ -645,7 +645,7 @@ func substituteConcat(callback func([]Pattern) Pattern) func(nodes []Node) []Nod
 						newNode = append(newNode, callback(ps))
 					}
 				} else {
-					newNode = append(newNode, newOperator(substituteNodes(v.Operands), v.Kind)...)
+					newNode = append(newNode, NewOperator(substituteNodes(v.Operands), v.Kind)...)
 				}
 			}
 		}
@@ -763,8 +763,8 @@ func ConcatRevFilters(b Basic) Basic {
 // a postprocessing step to keep the parser lean.
 func labelStructural(nodes []Node) []Node {
 	return MapPattern(nodes, func(value string, negated bool, annotation Annotation) Node {
-		annotation.Labels.unset(Literal)
-		annotation.Labels.set(Structural)
+		annotation.Labels.Unset(Literal)
+		annotation.Labels.Set(Structural)
 		return Pattern{
 			Value:      value,
 			Negated:    negated,
@@ -817,7 +817,7 @@ func AddRegexpField(q Q, field, pattern string) string {
 
 	if !modified {
 		// use newOperator to reduce And nodes when adding a parameter to the query toplevel.
-		q = newOperator(append(q, Parameter{Field: field, Value: pattern}), And)
+		q = NewOperator(append(q, Parameter{Field: field, Value: pattern}), And)
 	}
 	return StringHuman(q)
 }

--- a/internal/search/query/transformer_test.go
+++ b/internal/search/query/transformer_test.go
@@ -202,7 +202,7 @@ func TestHoist(t *testing.T) {
 					leafParser: SearchTypeRegex,
 				}
 				nodes, _ := parser.parseOr()
-				return newOperator(nodes, And)
+				return NewOperator(nodes, And)
 			}
 			query := parse(c.input)
 			hoistedQuery, err := Hoist(query)

--- a/internal/search/query/types.go
+++ b/internal/search/query/types.go
@@ -189,9 +189,9 @@ func (p Plan) ToQ() Q {
 	nodes := make([]Node, 0, len(p))
 	for _, basic := range p {
 		operands := basic.ToParseTree()
-		nodes = append(nodes, newOperator(operands, And)...)
+		nodes = append(nodes, NewOperator(operands, And)...)
 	}
-	return Q(newOperator(nodes, Or))
+	return Q(NewOperator(nodes, Or))
 }
 
 // Basic represents a leaf expression to evaluate in our search engine. A basic

--- a/internal/search/query/validate_test.go
+++ b/internal/search/query/validate_test.go
@@ -314,7 +314,7 @@ func TestContainsRefGlobs(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.input, func(t *testing.T) {
-			query, err := Run(sequence(
+			query, err := Run(Sequence(
 				Init(c.input, SearchTypeLiteralDefault),
 				Globbing,
 			))


### PR DESCRIPTION
Stacked on https://github.com/sourcegraph/sourcegraph/pull/36518.

This adds basic scaffolding for applying rules and generating queries under a "lucky" search. See doc comments for vocabulary (what are "rules", etc).

I added one `unquote` rule in this PR as a first step (there are more, but let's keep this PR on its own). `unquote` attempts to unquote a pattern like `"foo"`, and will search for the unquoted pattern `foo` after searching for `"foo"`.

In general, how this lucky search behavior works:

- The input query is always treated "as usual" first: all syntax filters are honored, and the pattern is searched literally (Sourcegraph's current default). You can of course force the pattern to be searched regexp, with `patterntype:regexp`. None of the initial behavior changes. We run that query and we return results.

- If, after running the above query, we've returned less than 500 results, things get interesting: we apply a list of rules to transform the query, and interpret it in different ways. As a first step, I added an `unquote` rule, which fires when we detect quoted values in literal search, like `"foo"`, and which are then searched as `foo`. The user will get results for `foo`, if they exist. The idea is that, these rules surface results that are better than "no results". We will discover and think of more useful rules as we go along.

### Next rules and directions:

(1) I have rules on the burner that will treat all patterns as unordered (so it will automatically apply `x AND y` after searching for `x y`). Things like unquoting and toggling regexp or using explicit operators is all going to suddenly disappear, and hopefully, give you a much better experience. In fact, there is a side effect of running the `unquote` rule, that it will also treat patterns as regexp, which is probably quite OK right now :-).

(2) An important piece to this behavior is _informing the user of what had been done_ when we return results for generated queries. For example, if they entered `x y` and we don't find results for `x y`, but do for `x AND y`, then we return an alert that says "your query for `x y` didn't find any results, but we found results for `x AND y`. I will be adding this alerting to this code, later.

## Test plan
Added a test covering the basic end-to-end flow for rule application and unquote transformation.