### PR TITLE
database: make SetRepoPermissionsUnrestricted accept more than 65535 repo IDs

### DIFF
--- a/enterprise/internal/database/perms_store.go
+++ b/enterprise/internal/database/perms_store.go
@@ -503,14 +503,9 @@ func (s *permsStore) SetRepoPermissionsUnrestricted(ctx context.Context, ids []i
 	const format = `
 UPDATE repo_permissions
 SET unrestricted = %s
-WHERE repo_id IN (%s)
+WHERE repo_id = ANY (%s::int[])
 `
-	idqs := make([]*sqlf.Query, len(ids))
-	for i := range ids {
-		idqs[i] = sqlf.Sprintf("%s", ids[i])
-	}
-
-	q := sqlf.Sprintf(format, unrestricted, sqlf.Join(idqs, ","))
+	q := sqlf.Sprintf(format, unrestricted, pq.Array(ids))
 
 	return errors.Wrap(s.Exec(ctx, q), "setting unrestricted flag")
 }

--- a/enterprise/internal/database/perms_store_test.go
+++ b/enterprise/internal/database/perms_store_test.go
@@ -585,8 +585,12 @@ func testPermsStore_SetRepoPermissionsUnrestricted(db *sql.DB) func(*testing.T) 
 			assertUnrestricted(ctx, t, s, 1, true)
 			assertUnrestricted(ctx, t, s, 2, true)
 
-			// Set them back to false again
-			if err := s.SetRepoPermissionsUnrestricted(ctx, []int32{1, 2}, false); err != nil {
+			// Set them back to false again, also checking that more than 65535 IDs
+			// can be processed without an error
+			var ids [66000]int32
+			ids[0] = 1
+			ids[65900] = 2
+			if err := s.SetRepoPermissionsUnrestricted(ctx, ids[:], false); err != nil {
 				t.Fatal(err)
 			}
 			assertUnrestricted(ctx, t, s, 1, false)


### PR DESCRIPTION
Just using `ANY` with an array instead of `IN` with enumeration

Closes https://github.com/sourcegraph/sourcegraph/issues/36451

## Test plan
Existing integration test retrofitted to test new changes more thoroughly
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
