### PR TITLE
Update eslint-config

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
     "@pollyjs/core": "^5.1.0",
     "@pollyjs/persister-fs": "^5.0.0",
     "@slack/web-api": "^5.10.0",
-    "@sourcegraph/eslint-config": "0.30.0",
+    "@sourcegraph/eslint-config": "0.31.0",
     "@sourcegraph/eslint-plugin-sourcegraph": "^1.0.5",
     "@sourcegraph/eslint-plugin-wildcard": "1.0.0",
     "@sourcegraph/prettierrc": "^3.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4169,10 +4169,10 @@
     "@sourcegraph/codemod-toolkit-packages" "1.0.1"
     "@sourcegraph/codemod-toolkit-ts" "1.0.1"
 
-"@sourcegraph/eslint-config@0.30.0":
-  version "0.30.0"
-  resolved "https://registry.npmjs.org/@sourcegraph/eslint-config/-/eslint-config-0.30.0.tgz#43d3d120a50c489d25834d903476098b3ed3c87e"
-  integrity sha512-LqHeGNOrHKcHHgZ6bqsax7UMcqfW5zgIzUrOPgnebg9l+r1amB2aiUo5ia4njY46Of6mnVxAgOkohxjoqDM4Ig==
+"@sourcegraph/eslint-config@0.31.0":
+  version "0.31.0"
+  resolved "https://registry.npmjs.org/@sourcegraph/eslint-config/-/eslint-config-0.31.0.tgz#d6508841a340b52ba2b1ece35b054d89df7ab38d"
+  integrity sha512-a4MthnWhw37z/t94lnXZyH/zTAbG2IIXyGKi3du5PUNrF+B2E1KITRbhIUrv7kSfGADVkuV0t2imNEwXQcCgMQ==
   dependencies:
     "@sourcegraph/prettierrc" "^3.0.3"
     "@typescript-eslint/eslint-plugin" "^5.20.0"


### PR DESCRIPTION
Following up from https://github.com/sourcegraph/eslint-config/pull/255, this PR applies the latest version.

## Test plan

Look at the diff and verify if CI still runs through.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
