### PR TITLE
gomod: bump pgtype version for hstore fixes

### DIFF
--- a/enterprise/internal/database/code_monitor_queries_test.go
+++ b/enterprise/internal/database/code_monitor_queries_test.go
@@ -33,8 +33,8 @@ func TestSetQueryTriggerNextRun(t *testing.T) {
 	require.Len(t, triggerJobs, 1)
 	triggerJobID := triggerJobs[0].ID
 
-	wantLatestResult := s.Now().Add(time.Minute)
-	wantNextRun := s.Now().Add(time.Hour)
+	wantLatestResult := s.Now().UTC().Add(time.Minute)
+	wantNextRun := s.Now().UTC().Add(time.Hour)
 
 	err = s.SetQueryTriggerNextRun(ctx, 1, wantNextRun, wantLatestResult)
 	require.NoError(t, err)
@@ -51,7 +51,7 @@ func TestSetQueryTriggerNextRun(t *testing.T) {
 		NextRun:      wantNextRun,
 		LatestResult: &wantLatestResult,
 		ChangedBy:    id,
-		ChangedAt:    s.Now(),
+		ChangedAt:    s.Now().UTC(),
 	}
 	require.Equal(t, want, got)
 }
@@ -71,7 +71,7 @@ func TestResetTriggerQueryTimestamps(t *testing.T) {
 		ID:           fixtures.query.ID,
 		Monitor:      fixtures.monitor.ID,
 		QueryString:  fixtures.query.QueryString,
-		NextRun:      s.Now(),
+		NextRun:      s.Now().UTC(),
 		LatestResult: nil,
 		CreatedBy:    fixtures.query.CreatedBy,
 		CreatedAt:    fixtures.query.CreatedAt,

--- a/enterprise/internal/insights/store/store_test.go
+++ b/enterprise/internal/insights/store/store_test.go
@@ -127,7 +127,6 @@ SELECT time,
 			t.Errorf("unexpected results from include list: %v", diff)
 		}
 	})
-
 }
 
 func TestCountData(t *testing.T) {

--- a/enterprise/internal/insights/store/testdata/TestDeleteSnapshots.golden
+++ b/enterprise/internal/insights/store/testdata/TestDeleteSnapshots.golden
@@ -1,10 +1,5 @@
 []store.SeriesPoint{{
 	SeriesID: "one",
-	Time: time.Time{
-		ext: 63766868400,
-		loc: &time.Location{
-			name: "UTC",
-		},
-	},
-	Value: 1.1,
+	Time:     time.Time{ext: 63766868400},
+	Value:    1.1,
 }}

--- a/go.mod
+++ b/go.mod
@@ -308,7 +308,7 @@ require (
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgproto3/v2 v2.2.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20200714003250-2b9c44734f2b // indirect
-	github.com/jackc/pgtype v1.9.1 // indirect
+	github.com/jackc/pgtype v1.11.1-0.20220425133820-53266f029fbb // indirect
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/jonboulle/clockwork v0.2.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1468,8 +1468,9 @@ github.com/jackc/pgtype v1.3.1-0.20200606141011-f6355165a91c/go.mod h1:cvk9Bgu/V
 github.com/jackc/pgtype v1.4.2/go.mod h1:JCULISAZBFGrHaOXIIFiyfzW5VY0GRitRr8NeJsrdig=
 github.com/jackc/pgtype v1.8.1-0.20210724151600-32e20a603178/go.mod h1:C516IlIV9NKqfsMCXTdChteoXmwgUceqaLfjg2e3NlM=
 github.com/jackc/pgtype v1.9.0/go.mod h1:LUMuVrfsFfdKGLw+AFFVv6KtHOFMwRgDDzBt76IqCA4=
-github.com/jackc/pgtype v1.9.1 h1:MJc2s0MFS8C3ok1wQTdQxWuXQcB6+HwAm5x1CzW7mf0=
 github.com/jackc/pgtype v1.9.1/go.mod h1:LUMuVrfsFfdKGLw+AFFVv6KtHOFMwRgDDzBt76IqCA4=
+github.com/jackc/pgtype v1.11.1-0.20220425133820-53266f029fbb h1:MRSWOsXwvdLExF8roCltbid5ADD917dy1S3fgI+OHVE=
+github.com/jackc/pgtype v1.11.1-0.20220425133820-53266f029fbb/go.mod h1:LUMuVrfsFfdKGLw+AFFVv6KtHOFMwRgDDzBt76IqCA4=
 github.com/jackc/pgx/v4 v4.0.0-20190420224344-cc3461e65d96/go.mod h1:mdxmSJJuR08CZQyj1PVQBHy9XOp5p8/SHH6a0psbY9Y=
 github.com/jackc/pgx/v4 v4.0.0-20190421002000-1b8f0016e912/go.mod h1:no/Y67Jkk/9WuGR0JG/JseM9irFbnEPbuWV2EELPNuM=
 github.com/jackc/pgx/v4 v4.0.0-pre1.0.20190824185557-6972a5742186/go.mod h1:X+GQnOEnf1dqHGpw7JmHqHc1NxDoalibchSk9/RWuDc=

--- a/internal/database/repos_test.go
+++ b/internal/database/repos_test.go
@@ -555,8 +555,8 @@ func TestRepoStore_Metadata(t *testing.T) {
 	r := db.Repos()
 	require.NoError(t, r.Create(ctx, repos...))
 
-	d1 := time.Unix(1627945150, 0)
-	d2 := time.Unix(1628945150, 0)
+	d1 := time.Unix(1627945150, 0).UTC()
+	d2 := time.Unix(1628945150, 0).UTC()
 	gitserverRepos := []*types.GitserverRepo{
 		{
 			RepoID:      1,


### PR DESCRIPTION
Bumps jackc/pgtype to v1.11 due to fixes to `hstore` deserializing required for https://github.com/sourcegraph/sourcegraph/pull/36306/. Some tests had to be updated due to the change in handling of `time.Time`'s `time.Location` property as per https://github.com/jackc/pgtype/pull/94/

## Test plan

Relevant tests that were affected have been updated, existing tests should catch remaining issues. Dry-run will also be performed ([LINK HERE](https://buildkite.com/sourcegraph/sourcegraph/builds/151987))
