### PR TITLE
Fix highlighting fallback to plain text on error

### DIFF
--- a/cmd/frontend/internal/highlight/highlight.go
+++ b/cmd/frontend/internal/highlight/highlight.go
@@ -431,9 +431,9 @@ func Code(ctx context.Context, p Params) (response *HighlightedCode, aborted boo
 		errCollector.Collect(&err)
 		plainResponse, tableErr := generatePlainTable(code)
 		if tableErr != nil {
-			return nil, true, errors.CombineErrors(err, tableErr)
+			return nil, false, errors.CombineErrors(err, tableErr)
 		}
-		return plainResponse, false, err
+		return plainResponse, true, nil
 	}
 
 	if ctx.Err() == context.DeadlineExceeded {
@@ -450,7 +450,10 @@ func Code(ctx context.Context, p Params) (response *HighlightedCode, aborted boo
 
 		// Timeout, so render plain table.
 		plainResponse, err := generatePlainTable(code)
-		return plainResponse, true, err
+		if err != nil {
+			return nil, false, err
+		}
+		return plainResponse, true, nil
 	} else if err != nil {
 		log15.Error(
 			"syntax highlighting failed (this is a bug, please report it)",


### PR DESCRIPTION
I was wondering why I increasingly often saw highlighting errors in the past few weeks. I've pinned it down to these lines, somehow the return values seem to have gotten mixed up.
We now properly return plain text results and aborted: true, and only return errors when we hard failed (like anticipated by [the PR](https://github.com/sourcegraph/sourcegraph/pull/35907), afaict).

## Test plan

Tested locally that the issue I was seeing where highlighting would often hard fail no longer happens.
