### PR TITLE
lib/log: add IncreaseLevel to make a quieter child logger

### DIFF
--- a/lib/log/logger.go
+++ b/lib/log/logger.go
@@ -61,6 +61,12 @@ type Logger interface {
 	// building wrappers around the Logger, supplying this Option prevents the Logger from
 	// always reporting the wrapper code as the caller.
 	AddCallerSkip(int) Logger
+	// IncreaseLevel creates a logger that only logs at or above the given level for the given
+	// scope. To disable all output, you can use LogLevelNone.
+	//
+	// IncreaseLevel is only allowed to increase the level the Logger was initialized at -
+	// it has no affect if the preset level is higher than the inidcated level.
+	IncreaseLevel(scope string, description string, level Level) Logger
 }
 
 // Scoped returns the global logger and sets it up with the given scope and OpenTelemetry
@@ -116,7 +122,7 @@ func (z *zapAdapter) Scoped(scope string, description string) Logger {
 	if z.fullScope == "" {
 		newFullScope = scope
 	} else {
-		newFullScope = fmt.Sprintf("%s.%s", z.fullScope, scope)
+		newFullScope = createScope(z.fullScope, scope)
 	}
 	scopedLogger := &zapAdapter{
 		// name -> scope in OT
@@ -193,4 +199,24 @@ func (z *zapAdapter) WithCore(f func(c zapcore.Core) zapcore.Core) Logger {
 		fullScope:  z.fullScope,
 		attributes: z.attributes,
 	}
+}
+
+func (z *zapAdapter) IncreaseLevel(scope string, description string, level Level) Logger {
+	z.AddCallerSkip(1).Debug("logger.IncreaseLevel",
+		Object("scope",
+			String("scope", createScope(z.fullScope, scope)),
+			String("description", description)),
+		String("level", string(level)))
+
+	opt := zap.IncreaseLevel(level.Parse())
+	return &zapAdapter{
+		Logger:     z.Logger.WithOptions(opt),
+		rootLogger: z.rootLogger.WithOptions(opt),
+		fullScope:  z.fullScope,
+		attributes: z.attributes,
+	}
+}
+
+func createScope(parent, child string) string {
+	return fmt.Sprintf("%s.%s", parent, child)
 }

--- a/lib/log/logger.go
+++ b/lib/log/logger.go
@@ -181,6 +181,22 @@ func (z *zapAdapter) AddCallerSkip(skip int) Logger {
 	}
 }
 
+func (z *zapAdapter) IncreaseLevel(scope string, description string, level Level) Logger {
+	z.AddCallerSkip(1).Debug("logger.IncreaseLevel",
+		Object("scope",
+			String("scope", createScope(z.fullScope, scope)),
+			String("description", description)),
+		String("level", string(level)))
+
+	opt := zap.IncreaseLevel(level.Parse())
+	return &zapAdapter{
+		Logger:     z.Logger.WithOptions(opt),
+		rootLogger: z.rootLogger.WithOptions(opt),
+		fullScope:  z.fullScope,
+		attributes: z.attributes,
+	}
+}
+
 // WithCore is an internal API used to allow packages like logtest to hook into
 // underlying zap logger's core.
 //
@@ -196,22 +212,6 @@ func (z *zapAdapter) WithCore(f func(c zapcore.Core) zapcore.Core) Logger {
 	return &zapAdapter{
 		Logger:     newLogger,
 		rootLogger: newRootLogger,
-		fullScope:  z.fullScope,
-		attributes: z.attributes,
-	}
-}
-
-func (z *zapAdapter) IncreaseLevel(scope string, description string, level Level) Logger {
-	z.AddCallerSkip(1).Debug("logger.IncreaseLevel",
-		Object("scope",
-			String("scope", createScope(z.fullScope, scope)),
-			String("description", description)),
-		String("level", string(level)))
-
-	opt := zap.IncreaseLevel(level.Parse())
-	return &zapAdapter{
-		Logger:     z.Logger.WithOptions(opt),
-		rootLogger: z.rootLogger.WithOptions(opt),
 		fullScope:  z.fullScope,
 		attributes: z.attributes,
 	}

--- a/lib/log/logtest/logtest.go
+++ b/lib/log/logtest/logtest.go
@@ -137,15 +137,6 @@ func Captured(t testing.TB) (logger log.Logger, exportLogs func() []CapturedLog)
 }
 
 // NoOp returns a no-op Logger, useful for silencing all output in a specific test.
-func NoOp() log.Logger {
-	return &noopAdapter{zap.NewNop()}
+func NoOp(t *testing.T) log.Logger {
+	return Scoped(t).IncreaseLevel("noop", "no-op logger", log.LevelNone)
 }
-
-type noopAdapter struct{ *zap.Logger }
-
-var _ log.Logger = &noopAdapter{}
-
-func (n *noopAdapter) Scoped(string, string) log.Logger      { return n }
-func (n *noopAdapter) With(...log.Field) log.Logger          { return n }
-func (n *noopAdapter) WithTrace(log.TraceContext) log.Logger { return n }
-func (n *noopAdapter) AddCallerSkip(int) log.Logger          { return n }


### PR DESCRIPTION
Addresses this use case: https://github.com/sourcegraph/sourcegraph/commit/33eb4af6394c7ebc7fcf7ac3a851336d77059952#diff-131e98c60f40a8485b5d19a455d41ddb05c97f2dbda8ded9b2094abb8af60668L146

Now loggers can use `IncreaseLevel` to indicate a component of the codebase that they are opting to make quieter.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

n/a, it's a very thin wrapper over existing Zap APIs
