### PR TITLE
[iam] Add allowGroups filter to SAML auth provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Extensions: Added site config parameter `extensions.allowOnlySourcegraphAuthoredExtensions`. When enabled only extensions authored by Sourcegraph will be able to be viewed and installed. For more information check out the [docs](https://docs.sourcegraph.com/admin/extensions##allow-only-extensions-authored-by-sourcegraph). [#35054](https://github.com/sourcegraph/sourcegraph/pull/35054)
 - Batch Changes Credentials can now be manually validated. [#35948](https://github.com/sourcegraph/sourcegraph/pull/35948)
 - Zoekt-indexserver has a new debug landing page, `/debug`, which now exposes information about the queue, the list of indexed repositories, and the list of assigned repositories. Admins can reach the debug landing page by selecting Instrumentation > indexed-search-indexer from the site admin view. The debug page is linked at the top. [#346](https://github.com/sourcegraph/zoekt/pull/346)
-- SAML authentication provider has a new configuration that allows filtering users by group membership. [#36555](https://github.com/sourcegraph/sourcegraph/pull/36555)
+- SAML authentication provider has a new site configuration `allowGroups` that allows filtering users by group membership. [#36555](https://github.com/sourcegraph/sourcegraph/pull/36555)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Extensions: Added site config parameter `extensions.allowOnlySourcegraphAuthoredExtensions`. When enabled only extensions authored by Sourcegraph will be able to be viewed and installed. For more information check out the [docs](https://docs.sourcegraph.com/admin/extensions##allow-only-extensions-authored-by-sourcegraph). [#35054](https://github.com/sourcegraph/sourcegraph/pull/35054)
 - Batch Changes Credentials can now be manually validated. [#35948](https://github.com/sourcegraph/sourcegraph/pull/35948)
 - Zoekt-indexserver has a new debug landing page, `/debug`, which now exposes information about the queue, the list of indexed repositories, and the list of assigned repositories. Admins can reach the debug landing page by selecting Instrumentation > indexed-search-indexer from the site admin view. The debug page is linked at the top. [#346](https://github.com/sourcegraph/zoekt/pull/346)
+- SAML authentication provider has a new configuration that allows filtering users by group membership. [#36555](https://github.com/sourcegraph/sourcegraph/pull/36555)
 
 ### Changed
 

--- a/enterprise/cmd/frontend/internal/auth/saml/config.go
+++ b/enterprise/cmd/frontend/internal/auth/saml/config.go
@@ -5,7 +5,6 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
-	"fmt"
 	"log"
 	"net/http"
 	"path"
@@ -74,17 +73,6 @@ func validateConfig(c conftypes.SiteConfigQuerier) (problems conf.Problems) {
 		if p.Saml != nil && c.SiteConfig().ExternalURL == "" && !loggedNeedsExternalURL {
 			problems = append(problems, conf.NewSiteProblem("saml auth provider requires `externalURL` to be set to the external URL of your site (example: https://sourcegraph.example.com)"))
 			loggedNeedsExternalURL = true
-		}
-	}
-
-	seen := map[schema.SAMLAuthProvider]int{}
-	for i, p := range c.SiteConfig().AuthProviders {
-		if p.Saml != nil {
-			if j, ok := seen[*p.Saml]; ok {
-				problems = append(problems, conf.NewSiteProblem(fmt.Sprintf("SAML auth provider at index %d is duplicate of index %d, ignoring", i, j)))
-			} else {
-				seen[*p.Saml] = i
-			}
 		}
 	}
 

--- a/enterprise/cmd/frontend/internal/auth/saml/middleware.go
+++ b/enterprise/cmd/frontend/internal/auth/saml/middleware.go
@@ -142,7 +142,7 @@ func samlSPHandler(db database.DB) func(w http.ResponseWriter, r *http.Request) 
 			}
 
 			if !allowSignin(p, info.groups) {
-				log15.Warn("Error authorizing SAML-authenticated user.", "Expected groups", p.config.AllowGroups, "Got", info.groups)
+				log15.Warn("Error authorizing SAML-authenticated user.", "AccountID", info.spec.AccountID, "Expected groups", p.config.AllowGroups, "Got", info.groups)
 				http.Error(w, "Error authorizing SAML-authenticated user. The user does not belong to one of the configured groups.", http.StatusForbidden)
 				return
 			}
@@ -282,7 +282,7 @@ func (s *relayState) decode(encoded string) {
 }
 
 func allowSignin(p *provider, groups map[string]bool) bool {
-	if len(p.config.AllowGroups) == 0 {
+	if p.config.AllowGroups == nil {
 		return true
 	}
 

--- a/enterprise/cmd/frontend/internal/auth/saml/middleware.go
+++ b/enterprise/cmd/frontend/internal/auth/saml/middleware.go
@@ -141,7 +141,12 @@ func samlSPHandler(db database.DB) func(w http.ResponseWriter, r *http.Request) 
 				return
 			}
 
-			allowSignup := p.config.AllowSignup == nil || *p.config.AllowSignup
+			if !allowSignin(p, info.groups) {
+				log15.Warn("Error authorizing SAML-authenticated user.", "Expected groups", p.config.AllowGroups, "Got", info.groups)
+				http.Error(w, "Error authorizing SAML-authenticated user. The user does not belong to one of the configured groups.", http.StatusForbidden)
+				return
+			}
+			allowSignup := (p.config.AllowSignup == nil || *p.config.AllowSignup)
 			actor, safeErrMsg, err := getOrCreateUser(r.Context(), db, allowSignup, info)
 			if err != nil {
 				log15.Error("Error looking up SAML-authenticated user.", "err", err, "userErr", safeErrMsg)
@@ -274,4 +279,17 @@ func (s *relayState) decode(encoded string) {
 	}
 
 	s.ProviderID, s.ReturnToURL = "", ""
+}
+
+func allowSignin(p *provider, groups map[string]bool) bool {
+	if p.config.AllowGroups == nil {
+		return true
+	}
+
+	for _, group := range p.config.AllowGroups {
+		if groups[group] {
+			return true
+		}
+	}
+	return false
 }

--- a/enterprise/cmd/frontend/internal/auth/saml/middleware.go
+++ b/enterprise/cmd/frontend/internal/auth/saml/middleware.go
@@ -282,7 +282,7 @@ func (s *relayState) decode(encoded string) {
 }
 
 func allowSignin(p *provider, groups map[string]bool) bool {
-	if p.config.AllowGroups == nil {
+	if len(p.config.AllowGroups) == 0 {
 		return true
 	}
 

--- a/enterprise/cmd/frontend/internal/auth/saml/user.go
+++ b/enterprise/cmd/frontend/internal/auth/saml/user.go
@@ -19,6 +19,7 @@ type authnResponseInfo struct {
 	spec                 extsvc.AccountSpec
 	email, displayName   string
 	unnormalizedUsername string
+	groups               map[string]bool
 	accountData          any
 }
 
@@ -58,6 +59,10 @@ func readAuthnResponse(p *provider, encodedResp string) (*authnResponseInfo, err
 	if pn := attr.Get("eduPersonPrincipalName"); email == "" && mightBeEmail(pn) {
 		email = pn
 	}
+	groupsAttr := "groups"
+	if p.config.GroupsAttributeName != "" {
+		groupsAttr = p.config.GroupsAttributeName
+	}
 	info := authnResponseInfo{
 		spec: extsvc.AccountSpec{
 			ServiceType: providerType,
@@ -68,6 +73,7 @@ func readAuthnResponse(p *provider, encodedResp string) (*authnResponseInfo, err
 		email:                email,
 		unnormalizedUsername: firstNonempty(attr.Get("login"), attr.Get("uid"), attr.Get("username"), attr.Get("http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name"), email),
 		displayName:          firstNonempty(attr.Get("displayName"), attr.Get("givenName")+" "+attr.Get("surname"), attr.Get("http://schemas.xmlsoap.org/claims/CommonName"), attr.Get("http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname")),
+		groups:               attr.GetMap(groupsAttr),
 		accountData:          assertions,
 	}
 	if assertions.NameID == "" {
@@ -125,4 +131,17 @@ func (v samlAssertionValues) Get(key string) string {
 		}
 	}
 	return ""
+}
+
+func (v samlAssertionValues) GetMap(key string) map[string]bool {
+	for _, a := range v {
+		if a.Name == key || a.FriendlyName == key {
+			output := make(map[string]bool)
+			for _, v := range a.Values {
+				output[v.Value] = true
+			}
+			return output
+		}
+	}
+	return nil
 }

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1528,14 +1528,14 @@ type RustRateLimit struct {
 //
 // Note: if you are using IdP-initiated login, you must have *at most one* SAMLAuthProvider in the `auth.providers` array.
 type SAMLAuthProvider struct {
-	// AllowSignup description: Allows new visitors to sign up for accounts via SAML authentication. If false, users signing in via SAML must have an existing Sourcegraph account, which will be linked to their SAML identity after sign-in.
-	AllowSignup *bool `json:"allowSignup,omitempty"`
 	// AllowGroups description: Restrict login to members of these groups
 	AllowGroups []string `json:"allowGroups,omitempty"`
+	// AllowSignup description: Allows new visitors to sign up for accounts via SAML authentication. If false, users signing in via SAML must have an existing Sourcegraph account, which will be linked to their SAML identity after sign-in.
+	AllowSignup *bool `json:"allowSignup,omitempty"`
 	// ConfigID description: An identifier that can be used to reference this authentication provider in other parts of the config. For example, in configuration for a code host, you may want to designate this authentication provider as the identity provider for the code host.
 	ConfigID    string `json:"configID,omitempty"`
 	DisplayName string `json:"displayName,omitempty"`
-	// Name of the SAML assertion attribute that holds group membership for AllowGroups setting
+	// GroupsAttributeName description: Name of the SAML assertion attribute that holds group membership for allowGroups setting
 	GroupsAttributeName string `json:"groupsAttributeName,omitempty"`
 	// IdentityProviderMetadata description: The SAML Identity Provider metadata XML contents (for static configuration of the SAML Service Provider). The value of this field should be an XML document whose root element is `<EntityDescriptor>` or `<EntityDescriptors>`. To escape the value into a JSON string, you may want to use a tool like https://json-escape-text.now.sh.
 	IdentityProviderMetadata string `json:"identityProviderMetadata,omitempty"`

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1530,9 +1530,13 @@ type RustRateLimit struct {
 type SAMLAuthProvider struct {
 	// AllowSignup description: Allows new visitors to sign up for accounts via SAML authentication. If false, users signing in via SAML must have an existing Sourcegraph account, which will be linked to their SAML identity after sign-in.
 	AllowSignup *bool `json:"allowSignup,omitempty"`
+	// AllowGroups description: Restrict login to members of these groups
+	AllowGroups []string `json:"allowGroups,omitempty"`
 	// ConfigID description: An identifier that can be used to reference this authentication provider in other parts of the config. For example, in configuration for a code host, you may want to designate this authentication provider as the identity provider for the code host.
 	ConfigID    string `json:"configID,omitempty"`
 	DisplayName string `json:"displayName,omitempty"`
+	// Name of the SAML assertion attribute that holds group membership for AllowGroups setting
+	GroupsAttributeName string `json:"groupsAttributeName,omitempty"`
 	// IdentityProviderMetadata description: The SAML Identity Provider metadata XML contents (for static configuration of the SAML Service Provider). The value of this field should be an XML document whose root element is `<EntityDescriptor>` or `<EntityDescriptors>`. To escape the value into a JSON string, you may want to use a tool like https://json-escape-text.now.sh.
 	IdentityProviderMetadata string `json:"identityProviderMetadata,omitempty"`
 	// IdentityProviderMetadataURL description: The SAML Identity Provider metadata URL (for dynamic configuration of the SAML Service Provider).

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -1730,6 +1730,19 @@
           "description": "Allows new visitors to sign up for accounts via SAML authentication. If false, users signing in via SAML must have an existing Sourcegraph account, which will be linked to their SAML identity after sign-in.",
           "type": "boolean",
           "!go": { "pointer": true }
+        },
+        "allowGroups": {
+          "description": "Restrict login to members of these groups",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "groupsAttributeName": {
+          "description": "Name of the SAML assertion attribute that holds group membership for allowGroups setting",
+          "type": "string",
+          "default": "groups"
         }
       }
     },


### PR DESCRIPTION
# Description

This enables customers to only allow login/sign up for users that
belong to specific groups.

# Related
#34918

# Video

https://user-images.githubusercontent.com/9974711/171881330-a0854b13-b7c6-4bc9-96c4-b2bef72e52a5.mp4

# TODO
Add another unit test to test the whole flow, not just the new method that I added.

## Test plan

Tested manually, tested with unit tests

# Testing locally
To test locally, make sure to configure your local instance accordingly:
https://docs.google.com/document/d/1aZD9Ccl_9p6Ctzlyhbz1mZoJfsvx-wRU4JHohGJjkIE