### PR TITLE
JetBrains: Force the popup into persistent mode and manually detect clicks into the main IDE window

### DIFF
--- a/client/jetbrains/src/main/java/com/sourcegraph/find/SourcegraphWindow.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/find/SourcegraphWindow.java
@@ -8,6 +8,8 @@ import com.intellij.openapi.ui.popup.ActiveIcon;
 import com.intellij.openapi.ui.popup.ComponentPopupBuilder;
 import com.intellij.openapi.ui.popup.JBPopup;
 import com.intellij.openapi.ui.popup.JBPopupFactory;
+import com.intellij.openapi.wm.ex.WindowManagerEx;
+import com.intellij.util.ui.UIUtil;
 import com.sourcegraph.Icons;
 import org.cef.browser.CefBrowser;
 import org.cef.handler.CefKeyboardHandler;
@@ -16,6 +18,8 @@ import org.jetbrains.annotations.NotNull;
 
 import java.awt.*;
 import java.awt.event.KeyEvent;
+import java.awt.event.WindowEvent;
+import java.awt.event.WindowFocusListener;
 
 import static java.awt.event.InputEvent.ALT_DOWN_MASK;
 
@@ -36,6 +40,7 @@ public class SourcegraphWindow implements Disposable {
         if (popup == null || popup.isDisposed()) {
             popup = createPopup();
             popup.showCenteredInCurrentWindow(project);
+            registerOutsideClickListener();
         }
 
         popup.setUiVisible(true);
@@ -56,21 +61,19 @@ public class SourcegraphWindow implements Disposable {
         ComponentPopupBuilder builder = JBPopupFactory.getInstance().createComponentPopupBuilder(mainPanel, mainPanel)
             .setTitle("Sourcegraph")
             .setTitleIcon(new ActiveIcon(Icons.Logo))
-            .setCancelOnClickOutside(true)
-            .setResizable(true)
+            .setProject(project)
             .setModalContext(false)
+            .setCancelOnClickOutside(true)
             .setRequestFocus(true)
-            .setFocusable(true)
+            .setCancelKeyEnabled(false)
+            .setResizable(true)
             .setMovable(true)
+            .setLocateWithinScreenBounds(false)
+            .setFocusable(true)
+            .setCancelOnWindowDeactivation(false)
+            .setCancelOnClickOutside(true)
             .setBelongsToGlobalPopupStack(true)
-            .setCancelOnOtherWindowOpen(true)
-            .setCancelKeyEnabled(true)
-            .setNormalWindowLevel(true)
-            .setCancelCallback(() -> {
-                hidePopup();
-                // We return false to prevent the default cancellation behavior.
-                return false;
-            });
+            .setNormalWindowLevel(true);
 
         // For some reason, adding a cancelCallback will prevent the cancel event to fire when using the escape key. To
         // work around this, we add a manual listener to both the global key handler (since the editor component seems
@@ -133,6 +136,30 @@ public class SourcegraphWindow implements Disposable {
         }
 
         return false;
+    }
+
+    private void registerOutsideClickListener() {
+        getParentWindow().addWindowFocusListener(new WindowFocusListener() {
+            public void windowGainedFocus(WindowEvent e) {
+                hidePopup();
+            }
+
+            public void windowLostFocus(WindowEvent e) {
+            }
+        });
+    }
+
+    // https://sourcegraph.com/github.com/JetBrains/intellij-community@27fee7320a01c58309a742341dd61deae57c9005/-/blob/platform/platform-impl/src/com/intellij/ui/popup/AbstractPopup.java?L475-493
+    private Window getParentWindow() {
+        Window window = null;
+        Component parent = UIUtil.findUltimateParent(WindowManagerEx.getInstanceEx().getFocusedComponent(project));
+        if (parent instanceof Window) {
+            window = (Window) parent;
+        }
+        if (window == null) {
+            window = KeyboardFocusManager.getCurrentKeyboardFocusManager().getFocusedWindow();
+        }
+        return window;
     }
 
     @Override


### PR DESCRIPTION
Closes #34969

Note: @madppiper and me have been looking into [#34969](https://github.com/sourcegraph/sourcegraph/issues/34969)  today. This PR is a potential workaround (I wanted to persist this idea until after the long weekend). This is not intended to be merged like this. 

We noticed that the default JBPopup implementation has a "persisted" mode which, when enabled, uses a different implementation for the popup. One that is intended to stay active for longer.

In this PR we create a popup with this mode so that there is no automatic handling for deactivating the popup enabled at all (hats off to @madppiper for discovering this).

With this behavior, we need to manually add the triggers for hiding the popover. We have already done this for `esc` and there is currently only one second closing method that we want: Closing when the IDE window behind the popup is clicked. 

I've taken a very stupid and hacky attempt at doing this in this PR. It's a hack built on top of another hack and is likely causing more headache in the long-run, but it also unblocks the problem to some extend 🙈 .

I also already discovered an issue with this method: When the focus inside the project jumps to _another_ popover (e.g. when you open find everywhere), we don't have a focus event on the main window and our modal stays open. We probably instead want to add a focus handler for every window in the project (if this is possible somehow?) and detect if anything outside our popup is focused. 

## Test plan

Manual testing including jumping to other JetBrains project and non JetBrains applications:

https://user-images.githubusercontent.com/458591/172340419-9c927aa1-1b40-48b8-890b-7ef281baf428.mov

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-jetbrains-manual-close-window.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-oznpgsfmrg.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

