### PR TITLE
dev/ci: remove set -x in all tests

### DIFF
--- a/dev/ci/go-test.sh
+++ b/dev/ci/go-test.sh
@@ -56,7 +56,6 @@ function go_test() {
 
   # Create annotation from test failure
   if [ "$test_exit_code" -ne 0 ]; then
-    set -x
     echo "~~~ Creating test failures anotation"
     RICHGO_CONFIG="./.richstyle.yml"
     cp "$REPO_ROOT/dev/ci/go-test-failures.richstyle.yml" $RICHGO_CONFIG

--- a/dev/ci/integration/backend/test.sh
+++ b/dev/ci/integration/backend/test.sh
@@ -3,7 +3,7 @@
 # This script runs the backend integration tests against a running server.
 
 cd "$(dirname "${BASH_SOURCE[0]}")/../../../.."
-set -ex
+set -e
 
 URL="${1:-"http://localhost:7080"}"
 

--- a/dev/ci/integration/cluster/test.sh
+++ b/dev/ci/integration/cluster/test.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euxo pipefail
+set -euo pipefail
 
 # setup DIR for easier pathing test dir
 test_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)""
@@ -85,7 +85,7 @@ function test_setup() {
   set +x +u
   # shellcheck disable=SC1091
   source /root/.sg_envrc
-  set -x -u
+  set -u
 
   echo "--- TEST: Checking Sourcegraph instance is accessible"
 

--- a/dev/ci/integration/code-intel/test.sh
+++ b/dev/ci/integration/code-intel/test.sh
@@ -5,7 +5,7 @@
 
 cd "$(dirname "${BASH_SOURCE[0]}")/../../../.."
 root_dir=$(pwd)
-set -ex
+set -e
 
 export SOURCEGRAPH_BASE_URL="${1:-"http://localhost:7080"}"
 
@@ -21,7 +21,6 @@ pushd dev/ci/integration/code-intel || exit 1
 set +x
 # shellcheck disable=SC1091
 source /root/.sg_envrc
-set -x
 "${root_dir}/init-sg" addRepos -config repos.json
 popd || exit 1
 

--- a/dev/ci/integration/e2e/test.sh
+++ b/dev/ci/integration/e2e/test.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 cd "$(dirname "${BASH_SOURCE[0]}")/../../../.."
-set -ex
+set -e
 
 URL="${1:-"http://localhost:7080"}"
 

--- a/dev/ci/integration/qa/test.sh
+++ b/dev/ci/integration/qa/test.sh
@@ -6,7 +6,7 @@ export SOURCEGRAPH_BASE_URL="${1:-"http://localhost:7080"}"
 source /root/.profile
 cd "$(dirname "${BASH_SOURCE[0]}")/../../../.."
 
-set -ex
+set -e
 
 echo "--- init sourcegraph"
 pushd internal/cmd/init-sg
@@ -17,7 +17,6 @@ popd
 set +x
 # shellcheck disable=SC1091
 source /root/.sg_envrc
-set -x
 
 echo "--- TEST: Checking Sourcegraph instance is accessible"
 curl -f http://localhost:7080

--- a/dev/ci/integration/upgrade/test.sh
+++ b/dev/ci/integration/upgrade/test.sh
@@ -4,7 +4,7 @@
 source /root/.profile
 cd "$(dirname "${BASH_SOURCE[0]}")/../../../.."
 root_dir=$(pwd)
-set -ex
+set -e
 
 URL="${1:-"http://localhost:7080"}"
 
@@ -31,11 +31,8 @@ pushd internal/cmd/init-sg
 go build
 ./init-sg initSG
 popd
-# Load variables set up by init-server, disabling `-x` to avoid printing variables
-set +x
 # shellcheck disable=SC1091
 source /root/.sg_envrc
-set -x
 
 # Stop old Sourcegraph release
 docker container stop "$CONTAINER"

--- a/dev/ci/reset-test-db.sh
+++ b/dev/ci/reset-test-db.sh
@@ -2,6 +2,6 @@
 
 cd "$(dirname "${BASH_SOURCE[0]}")"/../..
 
-set -ex
+set -e
 
 psql -d sourcegraph-test-db -c 'drop schema public cascade; create schema public;'


### PR DESCRIPTION
IMO the utility of these are quite debatable, and they [make CI output quite difficult to read](https://sourcegraph.slack.com/archives/C01N83PS4TU/p1654244105960479). Things we can do instead:

- Just add `set -x` when you're debugging something
- Add better messages with `echo`
- Move things to `sg` where we might be able to add a `-debug` mode one day

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

`main-dry-run`: https://buildkite.com/sourcegraph/sourcegraph/builds/152078