### PR TITLE
insights: Add support to sort all series

### DIFF
--- a/enterprise/internal/insights/resolvers/insight_series_resolver.go
+++ b/enterprise/internal/insights/resolvers/insight_series_resolver.go
@@ -4,10 +4,8 @@ import (
 	"context"
 	"fmt"
 	"sort"
-	"strings"
 	"time"
 
-	"github.com/Masterminds/semver"
 	"github.com/inconshreveable/log15"
 
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
@@ -250,13 +248,13 @@ func (p *precalculatedInsightSeriesResolver) DirtyMetadata(ctx context.Context) 
 }
 
 type insightSeriesResolverGenerator interface {
-	Generate(ctx context.Context, series types.InsightViewSeries, baseResolver baseInsightResolver, filters types.InsightViewFilters, seriesOptions types.SeriesDisplayOptions) ([]graphqlbackend.InsightSeriesResolver, error)
+	Generate(ctx context.Context, series types.InsightViewSeries, baseResolver baseInsightResolver, filters types.InsightViewFilters) ([]graphqlbackend.InsightSeriesResolver, error)
 	handles(series types.InsightViewSeries) bool
 	SetNext(nextGenerator insightSeriesResolverGenerator)
 }
 
 type handleSeriesFunc func(series types.InsightViewSeries) bool
-type resolverGenerator func(ctx context.Context, series types.InsightViewSeries, baseResolver baseInsightResolver, filters types.InsightViewFilters, seriesOptions types.SeriesDisplayOptions) ([]graphqlbackend.InsightSeriesResolver, error)
+type resolverGenerator func(ctx context.Context, series types.InsightViewSeries, baseResolver baseInsightResolver, filters types.InsightViewFilters) ([]graphqlbackend.InsightSeriesResolver, error)
 
 type seriesResolverGenerator struct {
 	next             insightSeriesResolverGenerator
@@ -275,12 +273,12 @@ func (j *seriesResolverGenerator) SetNext(nextGenerator insightSeriesResolverGen
 	j.next = nextGenerator
 }
 
-func (j *seriesResolverGenerator) Generate(ctx context.Context, series types.InsightViewSeries, baseResolver baseInsightResolver, filters types.InsightViewFilters, seriesOptions types.SeriesDisplayOptions) ([]graphqlbackend.InsightSeriesResolver, error) {
+func (j *seriesResolverGenerator) Generate(ctx context.Context, series types.InsightViewSeries, baseResolver baseInsightResolver, filters types.InsightViewFilters) ([]graphqlbackend.InsightSeriesResolver, error) {
 	if j.handles(series) {
-		return j.generateResolver(ctx, series, baseResolver, filters, seriesOptions)
+		return j.generateResolver(ctx, series, baseResolver, filters)
 	}
 	if j.next != nil {
-		return j.next.Generate(ctx, series, baseResolver, filters, seriesOptions)
+		return j.next.Generate(ctx, series, baseResolver, filters)
 	} else {
 		log15.Error("no generator for insight series", "seriesID", series.SeriesID)
 		return nil, errors.New("no resolvers for insights series")
@@ -337,7 +335,7 @@ func getRecordedSeriesPointOpts(ctx context.Context, db dbutil.DB, definition ty
 	return opts, nil
 }
 
-func recordedSeries(ctx context.Context, definition types.InsightViewSeries, r baseInsightResolver, filters types.InsightViewFilters, seriesOptions types.SeriesDisplayOptions) ([]graphqlbackend.InsightSeriesResolver, error) {
+func recordedSeries(ctx context.Context, definition types.InsightViewSeries, r baseInsightResolver, filters types.InsightViewFilters) ([]graphqlbackend.InsightSeriesResolver, error) {
 	opts, err := getRecordedSeriesPointOpts(ctx, r.workerBaseStore.Handle().DB(), definition, filters)
 	if err != nil {
 		return nil, errors.Wrap(err, "getRecordedSeriesPointOpts")
@@ -370,7 +368,7 @@ func recordedSeries(ctx context.Context, definition types.InsightViewSeries, r b
 	return resolvers, nil
 }
 
-func expandCaptureGroupSeriesRecorded(ctx context.Context, definition types.InsightViewSeries, r baseInsightResolver, filters types.InsightViewFilters, seriesOptions types.SeriesDisplayOptions) ([]graphqlbackend.InsightSeriesResolver, error) {
+func expandCaptureGroupSeriesRecorded(ctx context.Context, definition types.InsightViewSeries, r baseInsightResolver, filters types.InsightViewFilters) ([]graphqlbackend.InsightSeriesResolver, error) {
 	opts, err := getRecordedSeriesPointOpts(ctx, r.workerBaseStore.Handle().DB(), definition, filters)
 	if err != nil {
 		return nil, errors.Wrap(err, "getRecordedSeriesPointOpts")
@@ -397,10 +395,8 @@ func expandCaptureGroupSeriesRecorded(ctx context.Context, definition types.Insi
 	}
 	statusResolver := NewStatusResolver(status, definition.BackfillQueuedAt)
 
-	sortedCaptureGroups, limit := getSortedCaptureGroups(seriesOptions, definition, groupedByCapture)
 	var resolvers []graphqlbackend.InsightSeriesResolver
-	for _, capturedValue := range sortedCaptureGroups[0:limit] {
-		points := groupedByCapture[capturedValue]
+	for capturedValue, points := range groupedByCapture {
 		sort.Slice(points, func(i, j int) bool {
 			return points[i].Time.Before(points[j].Time)
 		})
@@ -439,7 +435,7 @@ func expandCaptureGroupSeriesRecorded(ctx context.Context, definition types.Insi
 	return resolvers, nil
 }
 
-func expandCaptureGroupSeriesJustInTime(ctx context.Context, definition types.InsightViewSeries, r baseInsightResolver, filters types.InsightViewFilters, seriesOptions types.SeriesDisplayOptions) ([]graphqlbackend.InsightSeriesResolver, error) {
+func expandCaptureGroupSeriesJustInTime(ctx context.Context, definition types.InsightViewSeries, r baseInsightResolver, filters types.InsightViewFilters) ([]graphqlbackend.InsightSeriesResolver, error) {
 	executor := query.NewCaptureGroupExecutor(r.postgresDB, time.Now)
 	interval := timeseries.TimeInterval{
 		Unit:  types.IntervalUnit(definition.SampleIntervalUnit),
@@ -457,45 +453,15 @@ func expandCaptureGroupSeriesJustInTime(ctx context.Context, definition types.In
 		return nil, errors.Wrap(err, "CaptureGroupExecutor.Execute")
 	}
 
-	groupedByCapture := make(map[string][]store.SeriesPoint)
-	var allPoints []store.SeriesPoint
-	for i := range generatedSeries {
-		for _, point := range generatedSeries[i].Points {
-			allPoints = append(allPoints, store.SeriesPoint{
-				SeriesID: generatedSeries[i].SeriesId,
-				Time:     point.Time,
-				Value:    float64(point.Count),
-				Capture:  &generatedSeries[i].Label,
-			})
-		}
-	}
-	for i := range allPoints {
-		point := allPoints[i]
-		if point.Capture == nil {
-			// skip nil values, this shouldn't be a real possibility
-			continue
-		}
-		groupedByCapture[*point.Capture] = append(groupedByCapture[*point.Capture], point)
-	}
-
-	sortedCaptureGroups, limit := getSortedCaptureGroups(seriesOptions, definition, groupedByCapture)
 	var resolvers []graphqlbackend.InsightSeriesResolver
-	for _, capture := range sortedCaptureGroups[0:limit] {
-		var series query.GeneratedTimeSeries
-		for i := range generatedSeries {
-			if generatedSeries[i].Label == capture {
-				series = generatedSeries[i]
-				break
-			}
-		}
-
-		resolvers = append(resolvers, &dynamicInsightSeriesResolver{generated: &series})
+	for i := range generatedSeries {
+		resolvers = append(resolvers, &dynamicInsightSeriesResolver{generated: &generatedSeries[i]})
 	}
 
 	return resolvers, nil
 }
 
-func streamingSeriesJustInTime(ctx context.Context, definition types.InsightViewSeries, r baseInsightResolver, filters types.InsightViewFilters, seriesOptions types.SeriesDisplayOptions) ([]graphqlbackend.InsightSeriesResolver, error) {
+func streamingSeriesJustInTime(ctx context.Context, definition types.InsightViewSeries, r baseInsightResolver, filters types.InsightViewFilters) ([]graphqlbackend.InsightSeriesResolver, error) {
 	executor := query.NewStreamingExecutor(r.postgresDB, time.Now)
 	interval := timeseries.TimeInterval{
 		Unit:  types.IntervalUnit(definition.SampleIntervalUnit),
@@ -519,116 +485,4 @@ func streamingSeriesJustInTime(ctx context.Context, definition types.InsightView
 	}
 
 	return resolvers, nil
-}
-
-func getSortedCaptureGroups(seriesOptions types.SeriesDisplayOptions, definition types.InsightViewSeries, captureGroups map[string][]store.SeriesPoint) ([]string, int32) {
-	var sortMode types.SeriesSortMode
-	var sortDirection types.SeriesSortDirection
-	var limit int32
-	if seriesOptions.SortOptions != nil {
-		sortMode = seriesOptions.SortOptions.Mode
-		sortDirection = seriesOptions.SortOptions.Direction
-	} else {
-		if definition.SeriesSortMode != nil {
-			sortMode = *definition.SeriesSortMode
-		} else {
-			sortMode = types.ResultCount
-		}
-		if definition.SeriesSortDirection != nil {
-			sortDirection = *definition.SeriesSortDirection
-		} else {
-			sortDirection = types.Desc
-		}
-	}
-
-	orderedCaptureGroups := make([][]store.SeriesPoint, 0, len(captureGroups))
-	for _, value := range captureGroups {
-		orderedCaptureGroups = append(orderedCaptureGroups, value)
-	}
-
-	getMostRecentValue := func(points []store.SeriesPoint) float64 {
-		return points[len(points)-1].Value
-	}
-
-	ascLexSort := func(s1 string, s2 string) (hasSemVar bool, result bool) {
-		version1, err1 := semver.NewVersion(s1)
-		version2, err2 := semver.NewVersion(s2)
-		if err1 == nil && err2 == nil {
-			return true, version1.Compare(version2) < 0
-		}
-		if err1 != nil && err2 == nil {
-			return true, false
-		}
-		if err1 == nil && err2 != nil {
-			return true, true
-		}
-		return false, false
-	}
-
-	// First sort lexicographically (ascending) to make sure the ordering is consistent even if some result counts are equal.
-	sort.SliceStable(orderedCaptureGroups, func(i, j int) bool {
-		hasSemVar, result := ascLexSort(*orderedCaptureGroups[i][0].Capture, *orderedCaptureGroups[j][0].Capture)
-		if hasSemVar == true {
-			return result
-		}
-		return strings.Compare(*orderedCaptureGroups[i][0].Capture, *orderedCaptureGroups[j][0].Capture) < 0
-	})
-
-	switch sortMode {
-	case types.ResultCount:
-		if sortDirection == types.Asc {
-			sort.SliceStable(orderedCaptureGroups, func(i, j int) bool {
-				return getMostRecentValue(orderedCaptureGroups[i]) < getMostRecentValue(orderedCaptureGroups[j])
-			})
-		} else {
-			sort.SliceStable(orderedCaptureGroups, func(i, j int) bool {
-				return getMostRecentValue(orderedCaptureGroups[i]) > getMostRecentValue(orderedCaptureGroups[j])
-			})
-		}
-	case types.Lexicographical:
-		if sortDirection == types.Asc {
-			// Already pre-sorted by default
-		} else {
-			sort.SliceStable(orderedCaptureGroups, func(i, j int) bool {
-				hasSemVar, result := ascLexSort(*orderedCaptureGroups[i][0].Capture, *orderedCaptureGroups[j][0].Capture)
-				if hasSemVar == true {
-					return !result
-				}
-				return strings.Compare(*orderedCaptureGroups[i][0].Capture, *orderedCaptureGroups[j][0].Capture) > 0
-			})
-		}
-	case types.DateAdded:
-		if sortDirection == types.Asc {
-			sort.SliceStable(orderedCaptureGroups, func(i, j int) bool {
-				return orderedCaptureGroups[i][0].Time.Before(orderedCaptureGroups[j][0].Time)
-			})
-		} else {
-			sort.SliceStable(orderedCaptureGroups, func(i, j int) bool {
-				return orderedCaptureGroups[i][0].Time.After(orderedCaptureGroups[j][0].Time)
-			})
-		}
-	}
-
-	groupNames := []string{}
-	for _, group := range orderedCaptureGroups {
-		groupNames = append(groupNames, *group[0].Capture)
-	}
-
-	if seriesOptions.Limit != nil {
-		limit = *seriesOptions.Limit
-	} else if definition.SeriesLimit != nil {
-		limit = *definition.SeriesLimit
-	} else {
-		limit = 20
-	}
-	limit = minInt(int(limit), len(groupNames))
-
-	return groupNames, limit
-}
-
-func minInt(a, b int) int32 {
-	if a < b {
-		return int32(a)
-	}
-	return int32(b)
 }

--- a/enterprise/internal/insights/resolvers/insight_view_resolvers.go
+++ b/enterprise/internal/insights/resolvers/insight_view_resolvers.go
@@ -3,9 +3,12 @@ package resolvers
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/Masterminds/semver"
 
 	"github.com/sourcegraph/sourcegraph/internal/featureflag"
 
@@ -189,20 +192,31 @@ func (i *insightViewResolver) DataSeries(ctx context.Context) ([]graphqlbackend.
 		filters = &i.view.Filters
 	}
 
-	var seriesOptions *types.SeriesDisplayOptions
+	var seriesOptions types.SeriesDisplayOptions
 	if i.overrideSeriesOptions != nil {
-		seriesOptions = i.overrideSeriesOptions
+		seriesOptions = *i.overrideSeriesOptions
 	} else {
-		seriesOptions = &i.view.SeriesOptions
+		seriesOptions = i.view.SeriesOptions
 	}
 
 	for _, current := range i.view.Series {
-		seriesResolvers, err := i.dataSeriesGenerator.Generate(ctx, current, i.baseInsightResolver, *filters, *seriesOptions)
+		seriesResolvers, err := i.dataSeriesGenerator.Generate(ctx, current, i.baseInsightResolver, *filters)
 		if err != nil {
 			return nil, errors.Wrapf(err, "generate for seriesID: %s", current.SeriesID)
 		}
 		resolvers = append(resolvers, seriesResolvers...)
 	}
+
+	// Avoid sorting user-defined series unless they have set explicit sort options.
+	isCaptureGroup := i.dataSeriesGenerator.handles(types.InsightViewSeries{GeneratedFromCaptureGroups: true}) || i.dataSeriesGenerator.handles(types.InsightViewSeries{GeneratedFromCaptureGroups: true, JustInTime: true})
+	if seriesOptions.Limit != nil || seriesOptions.SortOptions != nil || isCaptureGroup {
+		sortedAndLimitedResovlers, err := sortSeriesResolvers(ctx, seriesOptions, resolvers)
+		if err != nil {
+			return nil, errors.Wrapf(err, "sortSeriesResolvers for insightViewID: %s", i.view.UniqueID)
+		}
+		return sortedAndLimitedResovlers, nil
+	}
+
 	return resolvers, nil
 }
 
@@ -1130,4 +1144,109 @@ func filtersFromInput(input *graphqlbackend.InsightViewFiltersInput) types.Insig
 		}
 	}
 	return filters
+}
+
+func sortSeriesResolvers(ctx context.Context, seriesOptions types.SeriesDisplayOptions, resolvers []graphqlbackend.InsightSeriesResolver) ([]graphqlbackend.InsightSeriesResolver, error) {
+	var sortMode types.SeriesSortMode = types.ResultCount
+	var sortDirection types.SeriesSortDirection = types.Desc
+	var limit int32 = 20
+
+	sortMode = types.ResultCount
+	sortDirection = types.Desc
+
+	if seriesOptions.SortOptions != nil {
+		sortMode = seriesOptions.SortOptions.Mode
+		sortDirection = seriesOptions.SortOptions.Direction
+	}
+	if seriesOptions.Limit != nil {
+		limit = *seriesOptions.Limit
+	}
+
+	// All the points are already loaded from their source at this point db or by executing queries
+	// Make a map for faster lookup and to deal with possible errors once
+	resolverPoints := make(map[string][]graphqlbackend.InsightsDataPointResolver, len(resolvers))
+	for _, resolver := range resolvers {
+		points, err := resolver.Points(ctx, nil)
+		if err != nil {
+			return nil, err
+		}
+		resolverPoints[resolver.SeriesId()] = points
+	}
+
+	getMostRecentValue := func(points []graphqlbackend.InsightsDataPointResolver) float64 {
+		return points[len(points)-1].Value()
+	}
+
+	ascLexSort := func(s1 string, s2 string) (hasSemVar bool, result bool) {
+		version1, err1 := semver.NewVersion(s1)
+		version2, err2 := semver.NewVersion(s2)
+		if err1 == nil && err2 == nil {
+			return true, version1.Compare(version2) < 0
+		}
+		if err1 != nil && err2 == nil {
+			return true, false
+		}
+		if err1 == nil && err2 != nil {
+			return true, true
+		}
+		return false, false
+	}
+
+	// First sort lexicographically (ascending) to make sure the ordering is consistent even if some result counts are equal.
+	sort.SliceStable(resolvers, func(i, j int) bool {
+		hasSemVar, result := ascLexSort(resolvers[i].Label(), resolvers[j].Label())
+		if hasSemVar == true {
+			return result
+		}
+		return strings.Compare(resolvers[i].Label(), resolvers[j].Label()) < 0
+	})
+
+	switch sortMode {
+	case types.ResultCount:
+
+		if sortDirection == types.Asc {
+			sort.SliceStable(resolvers, func(i, j int) bool {
+				return getMostRecentValue(resolverPoints[resolvers[i].SeriesId()]) < getMostRecentValue(resolverPoints[resolvers[j].SeriesId()])
+			})
+		} else {
+			sort.SliceStable(resolvers, func(i, j int) bool {
+				return getMostRecentValue(resolverPoints[resolvers[i].SeriesId()]) > getMostRecentValue(resolverPoints[resolvers[j].SeriesId()])
+			})
+		}
+	case types.Lexicographical:
+		if sortDirection == types.Asc {
+			// Already pre-sorted by default
+		} else {
+			sort.SliceStable(resolvers, func(i, j int) bool {
+				hasSemVar, result := ascLexSort(resolvers[i].Label(), resolvers[j].Label())
+				if hasSemVar == true {
+					return !result
+				}
+				return strings.Compare(resolvers[i].Label(), resolvers[j].Label()) > 0
+			})
+		}
+	case types.DateAdded:
+		if sortDirection == types.Asc {
+			sort.SliceStable(resolvers, func(i, j int) bool {
+				iPoints := resolverPoints[resolvers[i].SeriesId()]
+				jPoints := resolverPoints[resolvers[j].SeriesId()]
+				return iPoints[0].DateTime().Time.Before(jPoints[0].DateTime().Time)
+			})
+		} else {
+			sort.SliceStable(resolvers, func(i, j int) bool {
+				iPoints := resolverPoints[resolvers[i].SeriesId()]
+				jPoints := resolverPoints[resolvers[j].SeriesId()]
+				return iPoints[0].DateTime().Time.After(jPoints[0].DateTime().Time)
+			})
+		}
+	}
+
+	return resolvers[:minInt(int32(len(resolvers)), limit)], nil
+}
+
+func minInt(a, b int32) int32 {
+	if a < b {
+		return int32(a)
+	}
+	return int32(b)
 }


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/35711
Builds on https://github.com/sourcegraph/sourcegraph/pull/35873

WIP todo:
- [ ] Fix tests
- [ ] Check with FE about default options being passed in

## Description

This moves the sorting step such that all series can be sorted.

One point to call out is that we don't want to sort user-defined series (non-capture group series,) unless explicit sorting options have been set via the UI. At first I began to add in a `NONE` value for `series_sort_mode` that we could use for these series, but I think that is more complex than we need at this time. Instead, I added in a check right before the sorting step to see if the series need to be sorted, based on the options and the generation method. I think this will work best for now, but let me know what you think!

## Test plan

I tested this out via the UI. Verified that
- Capture group insights are still sorting as expected
- Non-capture group insights can also be sorted