### PR TITLE
Search backend: fix issues with null and zero-length offsetAndLength

### DIFF
--- a/internal/search/result/file.go
+++ b/internal/search/result/file.go
@@ -211,7 +211,7 @@ func (h ChunkMatch) MatchedContent() []string {
 // LineMatch representation for clients without breaking backwards compatibility.
 func (h ChunkMatch) AsLineMatches() []*LineMatch {
 	lines := strings.Split(h.Content, "\n")
-	lineMatches := make([]*LineMatch, len(lines))
+	lineMatches := make([]*LineMatch, 0, len(lines))
 	for i, line := range lines {
 		lineNumber := h.ContentStart.Line + i
 		var offsetAndLengths [][2]int32
@@ -228,14 +228,19 @@ func (h ChunkMatch) AsLineMatches() []*LineMatch {
 						end = rr.End.Column
 					}
 
-					offsetAndLengths = append(offsetAndLengths, [2]int32{int32(start), int32(end - start)})
+					if start != end {
+						offsetAndLengths = append(offsetAndLengths, [2]int32{int32(start), int32(end - start)})
+					}
 				}
 			}
 		}
-		lineMatches[i] = &LineMatch{
-			Preview:          line,
-			LineNumber:       int32(lineNumber),
-			OffsetAndLengths: offsetAndLengths,
+
+		if len(offsetAndLengths) > 0 {
+			lineMatches = append(lineMatches, &LineMatch{
+				Preview:          line,
+				LineNumber:       int32(lineNumber),
+				OffsetAndLengths: offsetAndLengths,
+			})
 		}
 	}
 	return lineMatches

--- a/internal/search/result/file.go
+++ b/internal/search/result/file.go
@@ -211,10 +211,10 @@ func (h ChunkMatch) MatchedContent() []string {
 // LineMatch representation for clients without breaking backwards compatibility.
 func (h ChunkMatch) AsLineMatches() []*LineMatch {
 	lines := strings.Split(h.Content, "\n")
-	lineMatches := make([]*LineMatch, 0, len(lines))
+	lineMatches := make([]*LineMatch, len(lines))
 	for i, line := range lines {
 		lineNumber := h.ContentStart.Line + i
-		var offsetAndLengths [][2]int32
+		offsetAndLengths := [][2]int32{}
 		for _, rr := range h.Ranges {
 			for rangeLine := rr.Start.Line; rangeLine <= rr.End.Line; rangeLine++ {
 				if rangeLine == lineNumber {
@@ -234,13 +234,10 @@ func (h ChunkMatch) AsLineMatches() []*LineMatch {
 				}
 			}
 		}
-
-		if len(offsetAndLengths) > 0 {
-			lineMatches = append(lineMatches, &LineMatch{
-				Preview:          line,
-				LineNumber:       int32(lineNumber),
-				OffsetAndLengths: offsetAndLengths,
-			})
+		lineMatches[i] = &LineMatch{
+			Preview:          line,
+			LineNumber:       int32(lineNumber),
+			OffsetAndLengths: offsetAndLengths,
 		}
 	}
 	return lineMatches

--- a/internal/search/result/file_test.go
+++ b/internal/search/result/file_test.go
@@ -83,6 +83,10 @@ func TestConvertMatches(t *testing.T) {
 				Preview:          "line1",
 				LineNumber:       1,
 				OffsetAndLengths: [][2]int32{{0, 5}},
+			}, {
+				Preview:          "line2",
+				LineNumber:       2,
+				OffsetAndLengths: [][2]int32{},
 			}},
 		}}
 

--- a/internal/search/result/file_test.go
+++ b/internal/search/result/file_test.go
@@ -65,13 +65,25 @@ func TestConvertMatches(t *testing.T) {
 					End:   Location{1, 1, 3},
 				}},
 			},
-			output: []*LineMatch{
-				{
-					Preview:          "line1",
-					LineNumber:       1,
-					OffsetAndLengths: [][2]int32{{1, 2}},
-				},
+			output: []*LineMatch{{
+				Preview:          "line1",
+				LineNumber:       1,
+				OffsetAndLengths: [][2]int32{{1, 2}},
+			}},
+		}, {
+			input: ChunkMatch{
+				Content:      "line1\nline2",
+				ContentStart: Location{Line: 1},
+				Ranges: Ranges{{
+					Start: Location{0, 1, 0},
+					End:   Location{6, 2, 0},
+				}},
 			},
+			output: []*LineMatch{{
+				Preview:          "line1",
+				LineNumber:       1,
+				OffsetAndLengths: [][2]int32{{0, 5}},
+			}},
 		}}
 
 		for _, tc := range cases {


### PR DESCRIPTION
The code that converts ChunkMatch into []LineMatch treats zero-length
matches as valid, which they are. However, it's not expected that a
LineMatch has zero-length or nil offsetAndLengths. To maintain backwards
compatibility, I've udpated the conversion function to stop generating
line matches like this.

## Test plan

Added a test case for this. Also tested manually that it fixed the browser crash from null offsetAndLength.


Proof that it fixes the issue:
<img width="943" alt="Screen Shot 2022-06-03 at 15 28 03" src="https://user-images.githubusercontent.com/12631702/171955529-92c653f9-633b-4c79-9378-3c8c75586fa8.png">


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
