### PR TITLE
Insights/fix-drilldown-ux

### DIFF
--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/DrillDownFilters.story.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/DrillDownFilters.story.tsx
@@ -1,5 +1,7 @@
-import { Meta, Story } from '@storybook/react'
 import { useRef } from 'react'
+
+import { Meta, Story } from '@storybook/react'
+
 import { WebStory } from '../../../../../../../../components/WebStory'
 import { SeriesSortDirection, SeriesSortMode } from '../../../../../../../../graphql-operations'
 import { BackendInsight, InsightExecutionType, InsightFilters, InsightType } from '../../../../../../core'
@@ -56,8 +58,10 @@ export const DrillDownPopover: Story = () => {
     )
 }
 
+// eslint-disable-next-line arrow-body-style
 const log = (methodName: string) => {
     return function (args: unknown) {
+        // eslint-disable-next-line prefer-rest-params
         console.log(methodName, [...arguments])
     }
 }

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/DrillDownFilters.story.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/DrillDownFilters.story.tsx
@@ -15,7 +15,7 @@ export default defaultStory
 export const DrillDownPopover: Story = () => {
     const exampleReference = useRef(null)
     const initialFiltersValue: InsightFilters = {
-        excludeRepoRegexp: '',
+        excludeRepoRegexp: 'EXCLUDE',
         includeRepoRegexp: '',
         context: '',
     }
@@ -28,11 +28,7 @@ export const DrillDownPopover: Story = () => {
         step: {},
         isFrozen: false,
         query: '',
-        filters: {
-            excludeRepoRegexp: '',
-            includeRepoRegexp: '',
-            context: '',
-        },
+        filters: initialFiltersValue,
         dashboardReferenceCount: 0,
         dashboards: [],
     }

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/DrillDownFilters.story.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/DrillDownFilters.story.tsx
@@ -60,4 +60,8 @@ export const DrillDownPopover: Story = () => {
     )
 }
 
-const log = (methodName: string) => (args: unknown): void => console.log(methodName, args)
+const log = (methodName: string) => {
+    return function (args: unknown) {
+        console.log(methodName, [...arguments])
+    }
+}

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/DrillDownFilters.story.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/DrillDownFilters.story.tsx
@@ -1,0 +1,63 @@
+import { Meta, Story } from '@storybook/react'
+import { useRef } from 'react'
+import { WebStory } from '../../../../../../../../components/WebStory'
+import { SeriesSortDirection, SeriesSortMode } from '../../../../../../../../graphql-operations'
+import { BackendInsight, InsightExecutionType, InsightFilters, InsightType } from '../../../../../../core'
+import { DrillDownFiltersPopover } from '../drill-down-filters-popover/DrillDownFiltersPopover'
+
+const defaultStory: Meta = {
+    title: 'DrillDownFilters',
+    decorators: [story => <WebStory>{() => story()}</WebStory>],
+}
+
+export default defaultStory
+
+export const DrillDownPopover: Story = () => {
+    const exampleReference = useRef(null)
+    const initialFiltersValue: InsightFilters = {
+        excludeRepoRegexp: '',
+        includeRepoRegexp: '',
+        context: '',
+    }
+    const insight: BackendInsight = {
+        id: 'example',
+        title: 'Example Insight',
+        repositories: [],
+        type: InsightType.CaptureGroup,
+        executionType: InsightExecutionType.Backend,
+        step: {},
+        isFrozen: false,
+        query: '',
+        filters: {
+            excludeRepoRegexp: '',
+            includeRepoRegexp: '',
+            context: '',
+        },
+        dashboardReferenceCount: 0,
+        dashboards: [],
+    }
+
+    return (
+        <DrillDownFiltersPopover
+            isOpen={true}
+            anchor={exampleReference}
+            initialFiltersValue={initialFiltersValue}
+            originalFiltersValue={initialFiltersValue}
+            insight={insight}
+            onFilterChange={log('onFilterChange')}
+            onFilterSave={log('onFilterSave')}
+            onInsightCreate={log('onInsightCreate')}
+            onVisibilityChange={log('onVisibilityChange')}
+            originalSeriesDisplayOptions={{
+                limit: 20,
+                sortOptions: {
+                    direction: SeriesSortDirection.DESC,
+                    mode: SeriesSortMode.RESULT_COUNT,
+                },
+            }}
+            onSeriesDisplayOptionsChange={log('onSeriesDisplayOptionsChange')}
+        />
+    )
+}
+
+const log = (methodName: string) => (args: unknown): void => console.log(methodName, args)

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/drill-down-filters/DrillDownInsightFilters.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/drill-down-filters/DrillDownInsightFilters.tsx
@@ -12,6 +12,7 @@ import { Button, Icon, Link, H4 } from '@sourcegraph/wildcard'
 
 import { LoaderButton } from '../../../../../../../../../components/LoaderButton'
 import { SeriesDisplayOptionsInput } from '../../../../../../../../../graphql-operations'
+import { DEFAULT_SERIES_DISPLAY_OPTIONS } from '../../../../../../../core'
 import { SeriesDisplayOptionsInputRequired } from '../../../../../../../core/types/insight/common'
 import { useField } from '../../../../../../form/hooks/useField'
 import { FormChangeEvent, SubmissionResult, useForm, FORM_ERROR } from '../../../../../../form/hooks/useForm'
@@ -123,7 +124,7 @@ export const DrillDownInsightFilters: FunctionComponent<DrillDownInsightFilters>
 
     const currentRepositoriesFilters = { include: includeRegex.input.value, exclude: excludeRegex.input.value }
     const hasFiltersChanged = !isEqual(originalValues, values)
-    const hasSeriesDisplayOptionsChanged = !isEqual(originalSeriesDisplayOptions, seriesDisplayOptions)
+    const hasSeriesDisplayOptionsChanged = !isEqual(DEFAULT_SERIES_DISPLAY_OPTIONS, seriesDisplayOptions)
     const hasAppliedFilters = hasActiveFilters(originalValues) && !hasFiltersChanged && !hasSeriesDisplayOptionsChanged
 
     const handleCollapseState = (section: FilterSection, opened: boolean): void => {

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/drill-down-filters/DrillDownInsightFilters.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/drill-down-filters/DrillDownInsightFilters.tsx
@@ -202,10 +202,7 @@ export const DrillDownInsightFilters: FunctionComponent<DrillDownInsightFilters>
                         open={isHorizontalMode || activeSection === FilterSection.SortFilter}
                         title="Sort & Limit"
                         preview={getSortPreview(parseSeriesDisplayOptions(seriesDisplayOptions))}
-                        hasActiveFilter={hasActiveSeriesDisplayOptions(
-                            seriesDisplayOptions,
-                            originalSeriesDisplayOptions
-                        )}
+                        hasActiveFilter={hasSeriesDisplayOptionsChanged}
                         withSeparators={!isHorizontalMode}
                         onOpenChange={opened => handleCollapseState(FilterSection.SortFilter, opened)}
                     >
@@ -324,7 +321,11 @@ export const DrillDownInsightFilters: FunctionComponent<DrillDownInsightFilters>
                         loading={formAPI.submitting}
                         label={getSubmitButtonText({ submitting: formAPI.submitting, hasAppliedFilters })}
                         type="submit"
-                        disabled={!formAPI.valid || formAPI.submitting || !hasFiltersChanged}
+                        disabled={
+                            !formAPI.valid ||
+                            formAPI.submitting ||
+                            (!hasFiltersChanged && !hasSeriesDisplayOptionsChanged)
+                        }
                         variant="secondary"
                         size="sm"
                         outline={true}
@@ -354,17 +355,6 @@ export function hasActiveFilters(filters: DrillDownFiltersFormValues): boolean {
 }
 
 const hasActiveUnaryFilter = (filter: string): boolean => filter.trim() !== ''
-
-const hasActiveSeriesDisplayOptions = (
-    seriesDisplayOptions: SeriesDisplayOptionsInput,
-    originalSeriesDisplayOptions: SeriesDisplayOptionsInput
-): boolean => {
-    return (
-        seriesDisplayOptions.limit !== originalSeriesDisplayOptions.limit ||
-        seriesDisplayOptions.sortOptions?.direction !== originalSeriesDisplayOptions.sortOptions?.direction ||
-        seriesDisplayOptions.sortOptions?.mode !== originalSeriesDisplayOptions.sortOptions?.mode
-    )
-}
 
 interface SubmitButtonTextProps {
     submitting: boolean

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/drill-down-filters/DrillDownInsightFilters.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/drill-down-filters/DrillDownInsightFilters.tsx
@@ -202,7 +202,10 @@ export const DrillDownInsightFilters: FunctionComponent<DrillDownInsightFilters>
                         open={isHorizontalMode || activeSection === FilterSection.SortFilter}
                         title="Sort & Limit"
                         preview={getSortPreview(parseSeriesDisplayOptions(seriesDisplayOptions))}
-                        hasActiveFilter={false}
+                        hasActiveFilter={hasActiveSeriesDisplayOptions(
+                            seriesDisplayOptions,
+                            originalSeriesDisplayOptions
+                        )}
                         withSeparators={!isHorizontalMode}
                         onOpenChange={opened => handleCollapseState(FilterSection.SortFilter, opened)}
                     >
@@ -351,6 +354,17 @@ export function hasActiveFilters(filters: DrillDownFiltersFormValues): boolean {
 }
 
 const hasActiveUnaryFilter = (filter: string): boolean => filter.trim() !== ''
+
+const hasActiveSeriesDisplayOptions = (
+    seriesDisplayOptions: SeriesDisplayOptionsInput,
+    originalSeriesDisplayOptions: SeriesDisplayOptionsInput
+): boolean => {
+    return (
+        seriesDisplayOptions.limit !== originalSeriesDisplayOptions.limit ||
+        seriesDisplayOptions.sortOptions?.direction !== originalSeriesDisplayOptions.sortOptions?.direction ||
+        seriesDisplayOptions.sortOptions?.mode !== originalSeriesDisplayOptions.sortOptions?.mode
+    )
+}
 
 interface SubmitButtonTextProps {
     submitting: boolean

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/drill-down-filters/DrillDownInsightFilters.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/drill-down-filters/DrillDownInsightFilters.tsx
@@ -93,6 +93,7 @@ export const DrillDownInsightFilters: FunctionComponent<DrillDownInsightFilters>
 
     const [activeSection, setActiveSection] = useState<FilterSection | null>(FilterSection.RegularExpressions)
     const [seriesDisplayOptions, setSeriesDisplayOptions] = useState(originalSeriesDisplayOptions)
+    const [seriesDisplayOptionsDirty, setSeriesDisplayOptionsDirty] = useState(false)
 
     const { ref, formAPI, handleSubmit, values } = useForm<DrillDownFiltersFormValues>({
         initialValues,
@@ -123,8 +124,8 @@ export const DrillDownInsightFilters: FunctionComponent<DrillDownInsightFilters>
 
     const currentRepositoriesFilters = { include: includeRegex.input.value, exclude: excludeRegex.input.value }
     const hasFiltersChanged = !isEqual(originalValues, values)
-    const hasAppliedFilters = hasActiveFilters(originalValues) && !hasFiltersChanged
     const hasSeriesDisplayOptionsChanged = !isEqual(originalSeriesDisplayOptions, seriesDisplayOptions)
+    const hasAppliedFilters = hasActiveFilters(originalValues) && !hasFiltersChanged && !hasSeriesDisplayOptionsChanged
 
     const handleCollapseState = (section: FilterSection, opened: boolean): void => {
         if (!opened) {
@@ -138,11 +139,13 @@ export const DrillDownInsightFilters: FunctionComponent<DrillDownInsightFilters>
         contexts.input.onChange('')
         includeRegex.input.onChange('')
         excludeRegex.input.onChange('')
+        setSeriesDisplayOptionsDirty(false)
         setSeriesDisplayOptions(originalSeriesDisplayOptions)
         onSeriesDisplayOptionsChange(originalSeriesDisplayOptions)
     }
 
     const handleSeriesDisplayOptionsChange = (options: SeriesDisplayOptionsInputRequired): void => {
+        setSeriesDisplayOptionsDirty(true)
         setSeriesDisplayOptions(options)
         onSeriesDisplayOptionsChange(options)
     }
@@ -202,7 +205,7 @@ export const DrillDownInsightFilters: FunctionComponent<DrillDownInsightFilters>
                         open={isHorizontalMode || activeSection === FilterSection.SortFilter}
                         title="Sort & Limit"
                         preview={getSortPreview(parseSeriesDisplayOptions(seriesDisplayOptions))}
-                        hasActiveFilter={hasSeriesDisplayOptionsChanged}
+                        hasActiveFilter={true}
                         withSeparators={!isHorizontalMode}
                         onOpenChange={opened => handleCollapseState(FilterSection.SortFilter, opened)}
                     >

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/drill-down-filters/DrillDownInsightFilters.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/drill-down-filters/DrillDownInsightFilters.tsx
@@ -93,7 +93,6 @@ export const DrillDownInsightFilters: FunctionComponent<DrillDownInsightFilters>
 
     const [activeSection, setActiveSection] = useState<FilterSection | null>(FilterSection.RegularExpressions)
     const [seriesDisplayOptions, setSeriesDisplayOptions] = useState(originalSeriesDisplayOptions)
-    const [seriesDisplayOptionsDirty, setSeriesDisplayOptionsDirty] = useState(false)
 
     const { ref, formAPI, handleSubmit, values } = useForm<DrillDownFiltersFormValues>({
         initialValues,
@@ -139,13 +138,11 @@ export const DrillDownInsightFilters: FunctionComponent<DrillDownInsightFilters>
         contexts.input.onChange('')
         includeRegex.input.onChange('')
         excludeRegex.input.onChange('')
-        setSeriesDisplayOptionsDirty(false)
         setSeriesDisplayOptions(originalSeriesDisplayOptions)
         onSeriesDisplayOptionsChange(originalSeriesDisplayOptions)
     }
 
     const handleSeriesDisplayOptionsChange = (options: SeriesDisplayOptionsInputRequired): void => {
-        setSeriesDisplayOptionsDirty(true)
         setSeriesDisplayOptions(options)
         onSeriesDisplayOptionsChange(options)
     }

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/drill-down-filters/DrillDownInsightFilters.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/drill-down-filters/DrillDownInsightFilters.tsx
@@ -202,7 +202,7 @@ export const DrillDownInsightFilters: FunctionComponent<DrillDownInsightFilters>
                         open={isHorizontalMode || activeSection === FilterSection.SortFilter}
                         title="Sort & Limit"
                         preview={getSortPreview(parseSeriesDisplayOptions(seriesDisplayOptions))}
-                        hasActiveFilter={true}
+                        hasActiveFilter={hasSeriesDisplayOptionsChanged}
                         withSeparators={!isHorizontalMode}
                         onOpenChange={opened => handleCollapseState(FilterSection.SortFilter, opened)}
                     >


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/36286

## Test plan

- Open storybook
- Go to Drill Down Popover
- Sort & Limit should show a purple dot when changed
- "Default filters applied" should hide when changing any filter, including Sort & Limit
- "Save default filters" should enable when changing anything in Sort & Limit

## App preview:

- [Web](https://sg-web-insights-fix-drilldown-ux.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-kumbdlxqly.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

