### PR TITLE
dev/sg/usershell: refactor for clarity, add a way to get run.Output

### DIFF
--- a/dev/sg/internal/usershell/usershell.go
+++ b/dev/sg/internal/usershell/usershell.go
@@ -11,6 +11,8 @@ import (
 	"runtime"
 	"strings"
 
+	"github.com/sourcegraph/run"
+
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
@@ -98,20 +100,31 @@ func Context(ctx context.Context) (context.Context, error) {
 	return context.WithValue(ctx, key{}, userCtx), nil
 }
 
-// Cmd returns a command wrapped in a new shell process, enabling
-// changes added by various checks to be run. This negates the new to ask the
-// user to restart sg for many checks.
-func Cmd(ctx context.Context, cmd string) *exec.Cmd {
-	var wrapped *exec.Cmd
+type Wrapped struct {
+	ShellPath  string
+	ShellFlags []string
+	Command    string
+	Environ    []string
+}
+
+// Wrap builds a wrapping for executing the given command in a new shell process.
+func Wrap(ctx context.Context, cmd string) Wrapped {
+	// Defaults
+	w := Wrapped{
+		ShellPath:  ShellPath(ctx),
+		ShellFlags: []string{"-c"},
+		Command:    cmd,
+		Environ:    os.Environ(),
+	}
 
 	switch {
 	case os.Getenv("SG_DEV_NO_RELOAD_ENV") != "":
 		// If the user does not want the auto env reloading mechanism, just
 		// perform a standard command.
-		wrapped = exec.CommandContext(ctx, ShellPath(ctx), "-c", cmd)
+
 	case ShellType(ctx) == FishShell:
-		command := fmt.Sprintf("fish || true; %s", cmd)
-		wrapped = exec.CommandContext(ctx, ShellPath(ctx), "-c", command)
+		w.Command = fmt.Sprintf("fish || true; %s", cmd)
+
 	case runtime.GOOS == "linux":
 		// The default Ubuntu bashrc comes with a caveat that prevents the bashrc to be
 		// reloaded unless the shell is interactive. Therefore, we need to request for an
@@ -120,24 +133,34 @@ func Cmd(ctx context.Context, cmd string) *exec.Cmd {
 		// But because we are running an interactive shell, we also need to exit explictly.
 		// To avoid messing up with the output checking that depends on this function,
 		// we silence the exit commands, which otherwise, prints "exit".
-		command := fmt.Sprintf("%s; \nexit $? 2>/dev/null", strings.TrimSpace(cmd))
-		wrapped = exec.CommandContext(ctx, ShellPath(ctx), "-c", "-i", command)
+		w.Command = fmt.Sprintf("%s; \nexit $? 2>/dev/null", strings.TrimSpace(cmd))
+		w.ShellFlags = append(w.ShellFlags, "-i")
+
 	default:
 		// The above interactive shell approach fails on OSX because the default shell configuration
 		// prints sessions restoration informations that will mess with the output. So we fall back
 		// to manually reloading the shell configuration.
-		command := fmt.Sprintf("source %s || true; %s", ShellConfigPath(ctx), cmd)
-		wrapped = exec.CommandContext(ctx, ShellPath(ctx), "-c", command)
+		w.Command = fmt.Sprintf("source %s || true; %s", ShellConfigPath(ctx), cmd)
 	}
 
 	if ShellType(ctx) == ZshShell {
 		// Set this env var for oh-my-zsh users so that oh-my-zsh does not try to
 		// auto-update itself when we're restarting the shell.
-		wrapped.Env = os.Environ()
-		wrapped.Env = append(wrapped.Env, "DISABLE_AUTO_UPDATE=true")
+		w.Environ = append(w.Environ, "DISABLE_AUTO_UPDATE=true")
 	}
 
-	return wrapped
+	return w
+}
+
+// Cmd returns a command wrapped in a new shell process, enabling
+// changes added by various checks to be run. This negates the new to ask the
+// user to restart sg for many checks.
+func Cmd(ctx context.Context, cmd string) *exec.Cmd {
+	w := Wrap(ctx, cmd)
+
+	wrappedCmd := exec.CommandContext(ctx, w.ShellPath, append(w.ShellFlags, w.Command)...)
+	wrappedCmd.Env = w.Environ
+	return wrappedCmd
 }
 
 // CombinedExec runs a command in a fresh shell environment, and returns
@@ -147,6 +170,14 @@ func CombinedExec(ctx context.Context, cmd string) ([]byte, error) {
 		return nil, errors.Errorf("can't execute empty command")
 	}
 	return Cmd(ctx, cmd).CombinedOutput()
+}
+
+// Run runs a command in a fresh shell environment, and returns run.Output for easy usage.
+func Run(ctx context.Context, cmd string) run.Output {
+	w := Wrap(ctx, cmd)
+	return run.Cmd(ctx, fmt.Sprintf("%s %s %s",
+		w.ShellPath, strings.Join(w.ShellFlags, " "), run.Arg(w.Command))).
+		Run()
 }
 
 // IsSupportedShell returns true if the given shell is supported by sg-cli


### PR DESCRIPTION
Took a while for me to understand what kinds of things `usershell.Cmd` was doing, so this PR refactors the wrapping into `usershell.Wrap`, which clearly returns exactly what gets changed and provided, and updates `usershell.Cmd` to use that instead.

This also allows us to add a convenience adapter to `run.Output` instead.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
