### PR TITLE
lib/output: add WriteBytes convenience function

### DIFF
--- a/lib/output/output.go
+++ b/lib/output/output.go
@@ -176,6 +176,11 @@ func (o *Output) WriteLine(line FancyLine) {
 	line.write(o.w, o.caps)
 }
 
+// WriteBytes writes bytes as a string line. It can be provided to run.Cmd(...).StreamLines()
+func (o *Output) WriteBytes(b []byte) {
+	o.Write(string(b))
+}
+
 // Block starts a new block context. This should not be invoked if there is an
 // active Pending or Progress context.
 func (o *Output) Block(summary FancyLine) *Block {


### PR DESCRIPTION
Adds a `WriteBytes` convenience function, which also nicely fits in with the `run` library's `StreamLines`, so you can get:

```go
cmd.Run(ctx, `brew install git`).StreamLines(std.Out.WriteBytes)
```

Normally we could write to an `io.Writer`, but `output.Write` does not implement it

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

n/a