### PR TITLE
web: fix `input` width

### DIFF
--- a/client/web/src/extensions/ExtensionRegistry.tsx
+++ b/client/web/src/extensions/ExtensionRegistry.tsx
@@ -340,23 +340,21 @@ export const ExtensionRegistry: React.FunctionComponent<React.PropsWithChildren<
                                     in one place on Sourcegraph.
                                 </span>
                             </div>
-                            <Form onSubmit={preventDefault} className="form-inline">
-                                <div className="shadow flex-grow-1">
-                                    <Input
-                                        data-testid="test-extension-registry-input"
-                                        className="w-100"
-                                        type="search"
-                                        placeholder="Search extensions..."
-                                        name="query"
-                                        value={query}
-                                        onChange={onQueryChangeEvent}
-                                        autoFocus={true}
-                                        autoComplete="off"
-                                        autoCorrect="off"
-                                        autoCapitalize="off"
-                                        spellCheck={false}
-                                    />
-                                </div>
+                            <Form onSubmit={preventDefault}>
+                                <Input
+                                    data-testid="test-extension-registry-input"
+                                    className="w-100 shadow"
+                                    type="search"
+                                    placeholder="Search extensions..."
+                                    name="query"
+                                    value={query}
+                                    onChange={onQueryChangeEvent}
+                                    autoFocus={true}
+                                    autoComplete="off"
+                                    autoCorrect="off"
+                                    autoCapitalize="off"
+                                    spellCheck={false}
+                                />
                             </Form>
                             {!authenticatedUser && (
                                 <Alert className="my-4" variant="info">

--- a/client/web/src/extensions/ExtensionRegistrySidenav.tsx
+++ b/client/web/src/extensions/ExtensionRegistrySidenav.tsx
@@ -97,22 +97,12 @@ export const ExtensionRegistrySidenav: React.FunctionComponent<
 
                     <MenuDivider />
 
-                    <MenuItem
-                        // Hack: clicking <label> inside <MenuItem> doesn't affect checked state,
-                        // so use a <span> for which click events are handled by <MenuItem>.
-                        onSelect={toggleExperimentalExtensions}
-                    >
-                        <div className="d-flex align-items-center">
-                            <Checkbox
-                                checked={showExperimentalExtensions}
-                                onChange={toggleExperimentalExtensions}
-                                className=""
-                                aria-labelledby="show-experimental-extensions"
-                            />
-                            <span className="m-0 pl-2" id="show-experimental-extensions">
-                                Show experimental extensions
-                            </span>
-                        </div>
+                    <MenuItem onSelect={toggleExperimentalExtensions}>
+                        <Checkbox
+                            id="show-experimental-extensions"
+                            checked={showExperimentalExtensions}
+                            label="Show experimental extensions"
+                        />
                     </MenuItem>
                 </MenuList>
             </Menu>


### PR DESCRIPTION
## Context

Visual regression caused by the Wildcard migration.

| Before | After |
| -- | -- |
| <img width="1145" alt="Screen Shot 2022-06-04 at 10 46 39" src="https://user-images.githubusercontent.com/3846380/171975945-08f69ff6-1b41-4431-a2bb-aa368b98917f.png"> | <img width="1124" alt="Screen Shot 2022-06-04 at 10 46 50" src="https://user-images.githubusercontent.com/3846380/171975998-8d73d334-8d69-405b-87c5-6ba61b81acc2.png"> |

## Test plan

Ensure that `Filter extensions` take the entire width of the page.

## App preview:

- [Web](https://sg-web-vb-extensions-input.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-xrwpcjefyg.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

