### PR TITLE
Code Insights: Fix drill down input font family styles

### DIFF
--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/drill-down-input/DrillDownInput.module.scss
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/drill-down-input/DrillDownInput.module.scss
@@ -20,6 +20,7 @@
     font-size: inherit;
     border-top-left-radius: 0;
     border-bottom-left-radius: 0;
+    font-family: var(--monospace-font-family);
 }
 
 .label {

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/search-context/DrillDownSearchContextFilter.module.scss
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/search-context/DrillDownSearchContextFilter.module.scss
@@ -4,7 +4,6 @@
 
 .input {
     margin-bottom: 0.75rem;
-    font-family: var(--monospace-font-family);
 }
 
 .seperator {


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/36595

| First Header  | Second Header |
| ------------- | ------------- |
| <img width="537" alt="Screenshot 2022-06-04 at 12 24 48" src="https://user-images.githubusercontent.com/18492575/171982660-5a878e4d-b046-450c-820f-10a5e51707c2.png"> | <img width="459" alt="Screenshot 2022-06-04 at 12 24 26" src="https://user-images.githubusercontent.com/18492575/171982668-fcb52fcb-6634-488a-89d5-a9bc98af8aad.png"> |

## Test plan
- Make sure that all inputs in the drill-down panel have the right font family styles (monospace)

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vk-fix-drilldown-input-font-family.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-lovqlxyswp.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
