### PR TITLE
Code Insights: Add integration test for dashboard crud operations

### DIFF
--- a/client/web/src/enterprise/insights/pages/CodeInsightsRootPage.tsx
+++ b/client/web/src/enterprise/insights/pages/CodeInsightsRootPage.tsx
@@ -95,7 +95,7 @@ export const CodeInsightsRootPage: React.FunctionComponent<
                             to="/insights/add-dashboard"
                             variant="secondary"
                             className="mr-2"
-                            data-testid="AddDashboardButton"
+                            aria-label="add dashboard button"
                         >
                             <Icon role="img" aria-hidden={true} as={PlusIcon} /> Add dashboard
                         </Button>

--- a/client/web/src/enterprise/insights/pages/CodeInsightsRootPage.tsx
+++ b/client/web/src/enterprise/insights/pages/CodeInsightsRootPage.tsx
@@ -90,7 +90,13 @@ export const CodeInsightsRootPage: React.FunctionComponent<
                 path={[{ icon: CodeInsightsIcon, text: 'Insights' }]}
                 actions={
                     <>
-                        <Button as={Link} to="/insights/add-dashboard" variant="secondary" className="mr-2">
+                        <Button
+                            as={Link}
+                            to="/insights/add-dashboard"
+                            variant="secondary"
+                            className="mr-2"
+                            data-testid="AddDashboardButton"
+                        >
                             <Icon role="img" aria-hidden={true} as={PlusIcon} /> Add dashboard
                         </Button>
                         <Button

--- a/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/DashboardsContentPage.test.tsx
+++ b/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/DashboardsContentPage.test.tsx
@@ -165,7 +165,7 @@ const renderDashboardsContent = (
 
 const triggerDashboardMenuItem = async (screen: RenderWithBrandedContextResult & { user: UserEvent }, name: RegExp) => {
     const { user } = screen
-    const dashboardMenu = await waitFor(() => screen.getByRole('button', { name: /Dashboard options/ }))
+    const dashboardMenu = await waitFor(() => screen.getByRole('button', { name: /dashboard context menu/ }))
     user.click(dashboardMenu)
 
     const dashboardMenuItem = screen.getByRole('menuitem', { name })
@@ -218,14 +218,14 @@ describe('DashboardsContent', () => {
 
         const { history } = screen
 
-        await triggerDashboardMenuItem(screen, /Configure dashboard/)
+        await triggerDashboardMenuItem(screen, /configure dashboard/)
 
         expect(history.location.pathname).toEqual('/insights/dashboards/foo/edit')
     })
 
     it('opens add insight modal', async () => {
         const screen = renderDashboardsContent()
-        const addInsightsButton = await waitFor(() => screen.getByRole('button', { name: /Add or remove insights/ }))
+        const addInsightsButton = await waitFor(() => screen.getByRole('button', { name: /add or remove insights/ }))
 
         userEvent.click(addInsightsButton)
 

--- a/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/dashboard-menu/DashboardMenu.tsx
+++ b/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/dashboard-menu/DashboardMenu.tsx
@@ -41,6 +41,7 @@ export const DashboardMenu: React.FunctionComponent<React.PropsWithChildren<Dash
                 variant="icon"
                 outline={true}
                 className={classNames(className, styles.triggerButton)}
+                data-testid="dashboard-context-menu"
             >
                 <VisuallyHidden>Dashboard options</VisuallyHidden>
                 <DotsVerticalIcon size={16} />
@@ -50,12 +51,13 @@ export const DashboardMenu: React.FunctionComponent<React.PropsWithChildren<Dash
                 {menuPermissions.configure.display && (
                     <MenuItem
                         as={Button}
+                        outline={true}
                         disabled={menuPermissions.configure.disabled}
                         data-tooltip={menuPermissions.configure.tooltip}
                         data-placement="right"
                         className={styles.menuItem}
+                        data-testid="ConfigureDashboardButton"
                         onSelect={() => onSelect(DashboardMenuAction.Configure)}
-                        outline={true}
                     >
                         Configure dashboard
                     </MenuItem>

--- a/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/dashboard-menu/DashboardMenu.tsx
+++ b/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/dashboard-menu/DashboardMenu.tsx
@@ -41,7 +41,7 @@ export const DashboardMenu: React.FunctionComponent<React.PropsWithChildren<Dash
                 variant="icon"
                 outline={true}
                 className={classNames(className, styles.triggerButton)}
-                data-testid="dashboard-context-menu"
+                aria-label="dashboard context menu"
             >
                 <VisuallyHidden>Dashboard options</VisuallyHidden>
                 <DotsVerticalIcon size={16} />
@@ -56,7 +56,7 @@ export const DashboardMenu: React.FunctionComponent<React.PropsWithChildren<Dash
                         data-tooltip={menuPermissions.configure.tooltip}
                         data-placement="right"
                         className={styles.menuItem}
-                        data-testid="ConfigureDashboardButton"
+                        aria-label="configure dashboard"
                         onSelect={() => onSelect(DashboardMenuAction.Configure)}
                     >
                         Configure dashboard

--- a/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/dashboard-select/DashboardSelect.tsx
+++ b/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/dashboard-select/DashboardSelect.tsx
@@ -85,7 +85,10 @@ export const DashboardSelect: React.FunctionComponent<React.PropsWithChildren<Da
                 <MenuButton dashboards={rawDashboards} />
 
                 <ListboxPopover className={classNames(styles.popover)} portal={true}>
-                    <ListboxList className={classNames(styles.list, 'dropdown-menu')}>
+                    <ListboxList
+                        id="insights-dashboard-select-content"
+                        className={classNames(styles.list, 'dropdown-menu')}
+                    >
                         <Input
                             name="filter"
                             value={filter}

--- a/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/dashboard-select/components/menu-button/MenuButton.tsx
+++ b/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/dashboard-select/components/menu-button/MenuButton.tsx
@@ -24,7 +24,7 @@ export const MenuButton: React.FunctionComponent<React.PropsWithChildren<MenuBut
     const { dashboards, className } = props
 
     return (
-        <ListboxButton className={classNames(styles.button, className)}>
+        <ListboxButton id="insight-dashboard-select-button" className={classNames(styles.button, className)}>
             {({ value, isExpanded }) => {
                 const dashboard = dashboards.find(dashboard => dashboard.id === value)
 

--- a/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/dashboards-content/DashboardsContent.tsx
+++ b/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/dashboards-content/DashboardsContent.tsx
@@ -118,7 +118,7 @@ export const DashboardsContent: React.FunctionComponent<React.PropsWithChildren<
                     disabled={addRemovePermissions.disabled}
                     data-tooltip={addRemovePermissions.tooltip}
                     data-placement="bottom"
-                    aria-label="add remove insights button"
+                    aria-label="add or remove insights"
                     onClick={() => handleSelect(DashboardMenuAction.AddRemoveInsights)}
                 >
                     Add or remove insights

--- a/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/dashboards-content/DashboardsContent.tsx
+++ b/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/dashboards-content/DashboardsContent.tsx
@@ -118,7 +118,7 @@ export const DashboardsContent: React.FunctionComponent<React.PropsWithChildren<
                     disabled={addRemovePermissions.disabled}
                     data-tooltip={addRemovePermissions.tooltip}
                     data-placement="bottom"
-                    data-testid="AddRemoveInsightsButton"
+                    aria-label="add remove insights button"
                     onClick={() => handleSelect(DashboardMenuAction.AddRemoveInsights)}
                 >
                     Add or remove insights

--- a/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/dashboards-content/DashboardsContent.tsx
+++ b/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/dashboards-content/DashboardsContent.tsx
@@ -118,6 +118,7 @@ export const DashboardsContent: React.FunctionComponent<React.PropsWithChildren<
                     disabled={addRemovePermissions.disabled}
                     data-tooltip={addRemovePermissions.tooltip}
                     data-placement="bottom"
+                    data-testid="AddRemoveInsightsButton"
                     onClick={() => handleSelect(DashboardMenuAction.AddRemoveInsights)}
                 >
                     Add or remove insights

--- a/client/web/src/integration/insights/fixtures/insights-metadata.ts
+++ b/client/web/src/integration/insights/fixtures/insights-metadata.ts
@@ -9,12 +9,13 @@ const DEFAULT_SERIES_DISPLAY_OPTIONS = {
 }
 
 interface InsightOptions {
+    id?: string
     type: 'calculated' | 'just-in-time'
 }
 
 export const createJITMigrationToGQLInsightMetadataFixture = (options: InsightOptions): InsightViewNode => ({
     __typename: 'InsightView',
-    id: '001',
+    id: options.id ?? '001',
     appliedSeriesDisplayOptions: DEFAULT_SERIES_DISPLAY_OPTIONS,
     defaultSeriesDisplayOptions: DEFAULT_SERIES_DISPLAY_OPTIONS,
     dashboardReferenceCount: 0,

--- a/client/web/src/integration/insights/insight-dashboard.test.ts
+++ b/client/web/src/integration/insights/insight-dashboard.test.ts
@@ -286,7 +286,7 @@ describe('[Code Insight] Dashboard', () => {
 
         expect(driver.page.url()).toBe(`${driver.sourcegraphBaseUrl}/insights/dashboards/codeInsightDashboard001`)
 
-        await driver.page.click('[aria-label="add remove insights button"]')
+        await driver.page.click('[aria-label="add or remove insights"]')
         await driver.page.waitForSelector('form')
 
         await driver.page.click('input[value="insight_003"]')

--- a/client/web/src/integration/insights/insight-dashboard.test.ts
+++ b/client/web/src/integration/insights/insight-dashboard.test.ts
@@ -164,8 +164,8 @@ describe('[Code Insight] Dashboard', () => {
 
         await driver.page.goto(driver.sourcegraphBaseUrl + '/insights/dashboards/all')
 
-        await driver.page.waitForSelector('[data-testid="AddDashboardButton"]')
-        await driver.page.click('[data-testid="AddDashboardButton"]')
+        await driver.page.waitForSelector('[aria-label="add dashboard button"]')
+        await driver.page.click('[aria-label="add dashboard button"]')
         await driver.page.waitForSelector('form')
 
         await driver.page.type('[name="name"]', 'New test dashboard')
@@ -248,9 +248,9 @@ describe('[Code Insight] Dashboard', () => {
         })
 
         await driver.page.goto(driver.sourcegraphBaseUrl + '/insights/dashboards/codeInsightDashboard001')
-        await driver.page.waitForSelector('[data-testid="dashboard-context-menu"]')
-        await driver.page.click('[data-testid="dashboard-context-menu"]')
-        await driver.page.click('[data-testid="ConfigureDashboardButton"]')
+        await driver.page.waitForSelector('[aria-label="dashboard context menu"]')
+        await driver.page.click('[aria-label="dashboard context menu"]')
+        await driver.page.click('[aria-label="configure dashboard"]')
 
         await driver.page.waitForSelector('form')
 
@@ -286,7 +286,7 @@ describe('[Code Insight] Dashboard', () => {
 
         expect(driver.page.url()).toBe(`${driver.sourcegraphBaseUrl}/insights/dashboards/codeInsightDashboard001`)
 
-        await driver.page.click('[data-testid="AddRemoveInsightsButton"]')
+        await driver.page.click('[aria-label="add remove insights button"]')
         await driver.page.waitForSelector('form')
 
         await driver.page.click('input[value="insight_003"]')

--- a/client/web/src/integration/insights/insight-dashboard.test.ts
+++ b/client/web/src/integration/insights/insight-dashboard.test.ts
@@ -1,0 +1,307 @@
+import assert from 'assert'
+
+import expect from 'expect'
+
+import { createDriverForTest, Driver } from '@sourcegraph/shared/src/testing/driver'
+import { afterEachSaveScreenshotIfFailed } from '@sourcegraph/shared/src/testing/screenshotReporter'
+
+import { createWebIntegrationTestContext, WebIntegrationTestContext } from '../context'
+
+import { MIGRATION_TO_GQL_INSIGHT_DATA_FIXTURE } from './fixtures/calculated-insights'
+import { createJITMigrationToGQLInsightMetadataFixture } from './fixtures/insights-metadata'
+import { overrideInsightsGraphQLApi } from './utils/override-insights-graphql-api'
+
+describe('[Code Insight] Dashboard', () => {
+    let driver: Driver
+    let testContext: WebIntegrationTestContext
+
+    before(async () => {
+        driver = await createDriverForTest({ devtools: true })
+    })
+
+    beforeEach(async function () {
+        testContext = await createWebIntegrationTestContext({
+            driver,
+            currentTest: this.currentTest!,
+            directory: __dirname,
+            customContext: {
+                // Enforce using a new gql API for code insights pages
+                codeInsightsGqlApiEnabled: true,
+            },
+        })
+    })
+
+    after(() => driver?.close())
+    afterEach(() => testContext?.dispose())
+    afterEachSaveScreenshotIfFailed(() => driver.page)
+
+    beforeEach(() => {
+        overrideInsightsGraphQLApi({
+            testContext,
+            overrides: {
+                GetDashboardInsights: () => ({
+                    insightsDashboards: {
+                        nodes: [
+                            {
+                                __typename: 'InsightsDashboard',
+                                id: 'codeInsightDashboard001',
+                                views: {
+                                    nodes: [
+                                        createJITMigrationToGQLInsightMetadataFixture({
+                                            id: 'insight_001',
+                                            type: 'calculated',
+                                        }),
+                                        createJITMigrationToGQLInsightMetadataFixture({
+                                            id: 'insight_002',
+                                            type: 'calculated',
+                                        }),
+                                    ],
+                                },
+                            },
+                        ],
+                    },
+                }),
+                GetInsightView: () => ({
+                    __typename: 'Query',
+                    insightViews: {
+                        __typename: 'InsightViewConnection',
+                        nodes: [MIGRATION_TO_GQL_INSIGHT_DATA_FIXTURE],
+                    },
+                }),
+                GetAccessibleInsightsList: () => ({
+                    insightViews: {
+                        nodes: [
+                            {
+                                __typename: 'InsightView',
+                                id: 'insight_001',
+                                presentation: {
+                                    __typename: 'LineChartInsightViewPresentation',
+                                    title: 'First Insight',
+                                },
+                            },
+                            {
+                                __typename: 'InsightView',
+                                id: 'insight_002',
+                                presentation: {
+                                    __typename: 'LineChartInsightViewPresentation',
+                                    title: 'Second Insight',
+                                },
+                            },
+                            {
+                                __typename: 'InsightView',
+                                id: 'insight_003',
+                                presentation: {
+                                    __typename: 'LineChartInsightViewPresentation',
+                                    title: 'Third Insight',
+                                },
+                            },
+                        ],
+                    },
+                }),
+                InsightsDashboards: () => ({
+                    currentUser: {
+                        __typename: 'User',
+                        id: 'user001',
+                        organizations: { nodes: [] },
+                    },
+                    insightsDashboards: {
+                        nodes: [
+                            {
+                                __typename: 'InsightsDashboard',
+                                id: 'codeInsightDashboard001',
+                                title: 'Dashboard 001',
+                                views: { nodes: [] },
+                                grants: {
+                                    users: [],
+                                    organizations: [],
+                                    global: true,
+                                },
+                            },
+                        ],
+                    },
+                }),
+                AddInsightViewToDashboard: () => ({
+                    addInsightViewToDashboard: {
+                        dashboard: { id: 'codeInsightDashboard001' },
+                    },
+                }),
+            },
+        })
+    })
+
+    it('creates dashboard through dashboard creation UI', async () => {
+        overrideInsightsGraphQLApi({
+            testContext,
+            overrides: {
+                ...testContext.overrideGraphQL,
+                InsightSubjects: () => ({
+                    currentUser: {
+                        __typename: 'User',
+                        id: 'user_001',
+                        organizations: { nodes: [] },
+                    },
+                    site: { __typename: 'Site', id: 'site_id' },
+                }),
+                UpdateDashboard: () => ({
+                    updateInsightsDashboard: {
+                        __typename: 'InsightsDashboardPayload',
+                        dashboard: {
+                            __typename: 'InsightsDashboard',
+                            id: '001',
+                            title: '',
+                            views: { nodes: [] },
+                            grants: {
+                                __typename: 'InsightsPermissionGrants',
+                                users: [],
+                                organizations: [],
+                                global: true,
+                            },
+                        },
+                    },
+                }),
+            },
+        })
+
+        await driver.page.goto(driver.sourcegraphBaseUrl + '/insights/dashboards/all')
+
+        await driver.page.waitForSelector('[data-testid="AddDashboardButton"]')
+        await driver.page.click('[data-testid="AddDashboardButton"]')
+        await driver.page.waitForSelector('form')
+
+        await driver.page.type('[name="name"]', 'New test dashboard')
+        await driver.page.click('[name="visibility"][value="site_id"]')
+
+        const variables = await testContext.waitForGraphQLRequest(async () => {
+            const [button] = await driver.page.$x("//button[contains(., 'Add dashboard')]")
+
+            if (button) {
+                await button.click()
+            }
+        }, 'CreateDashboard')
+
+        assert.deepStrictEqual(variables, {
+            input: {
+                title: 'New test dashboard',
+                grants: {
+                    users: [],
+                    organizations: [],
+                    global: true,
+                },
+            },
+        })
+    })
+
+    it('updates existing dashboard properly', async () => {
+        overrideInsightsGraphQLApi({
+            testContext,
+            overrides: {
+                ...testContext.overrideGraphQL,
+                InsightsDashboards: () => ({
+                    currentUser: {
+                        __typename: 'User',
+                        id: 'user001',
+                        organizations: { nodes: [] },
+                    },
+                    insightsDashboards: {
+                        nodes: [
+                            {
+                                __typename: 'InsightsDashboard',
+                                id: 'codeInsightDashboard001',
+                                title: 'Dashboard 001',
+                                views: { nodes: [] },
+                                grants: {
+                                    __typename: 'InsightsPermissionGrants',
+                                    users: [],
+                                    organizations: [],
+                                    global: true,
+                                },
+                            },
+                        ],
+                    },
+                }),
+                InsightSubjects: () => ({
+                    currentUser: {
+                        __typename: 'User',
+                        id: 'user_001',
+                        organizations: { nodes: [] },
+                    },
+                    site: { __typename: 'Site', id: 'site_id' },
+                }),
+                UpdateDashboard: () => ({
+                    updateInsightsDashboard: {
+                        __typename: 'InsightsDashboardPayload',
+                        dashboard: {
+                            __typename: 'InsightsDashboard',
+                            id: '001',
+                            title: '',
+                            views: { nodes: [] },
+                            grants: {
+                                __typename: 'InsightsPermissionGrants',
+                                users: [],
+                                organizations: [],
+                                global: true,
+                            },
+                        },
+                    },
+                }),
+            },
+        })
+
+        await driver.page.goto(driver.sourcegraphBaseUrl + '/insights/dashboards/codeInsightDashboard001')
+        await driver.page.waitForSelector('[data-testid="dashboard-context-menu"]')
+        await driver.page.click('[data-testid="dashboard-context-menu"]')
+        await driver.page.click('[data-testid="ConfigureDashboardButton"]')
+
+        await driver.page.waitForSelector('form')
+
+        await driver.page.type('[name="name"]', ' Edited test dashboard title')
+        await driver.page.click('[name="visibility"][value="user_001"]')
+
+        const variables = await testContext.waitForGraphQLRequest(async () => {
+            const [button] = await driver.page.$x("//button[contains(., 'Save changes')]")
+
+            if (button) {
+                await button.click()
+            }
+        }, 'UpdateDashboard')
+
+        assert.deepStrictEqual(variables, {
+            id: 'codeInsightDashboard001',
+            input: {
+                title: 'Dashboard 001 Edited test dashboard title',
+                grants: {
+                    users: ['user_001'],
+                    organizations: [],
+                    global: false,
+                },
+            },
+        })
+    })
+
+    it('"add" and "remove" insight mutation work properly', async () => {
+        await driver.page.goto(driver.sourcegraphBaseUrl + '/insights/dashboards/all')
+        await driver.page.waitForSelector('[data-reach-listbox-input]')
+        await driver.page.click('[data-reach-listbox-input]')
+        await driver.page.click('[data-value="codeInsightDashboard001"]')
+
+        expect(driver.page.url()).toBe(`${driver.sourcegraphBaseUrl}/insights/dashboards/codeInsightDashboard001`)
+
+        await driver.page.click('[data-testid="AddRemoveInsightsButton"]')
+        await driver.page.waitForSelector('form')
+
+        await driver.page.click('input[value="insight_003"]')
+
+        const variables = await testContext.waitForGraphQLRequest(async () => {
+            const [button] = await driver.page.$x("//button[contains(., 'Save')]")
+
+            if (button) {
+                await button.click()
+            }
+        }, 'AddInsightViewToDashboard')
+
+        assert.deepStrictEqual(variables, {
+            dashboardId: 'codeInsightDashboard001',
+            insightViewId: 'insight_003',
+        })
+    })
+})

--- a/client/web/src/integration/insights/insight-dashboard.test.ts
+++ b/client/web/src/integration/insights/insight-dashboard.test.ts
@@ -16,7 +16,7 @@ describe('[Code Insight] Dashboard', () => {
     let testContext: WebIntegrationTestContext
 
     before(async () => {
-        driver = await createDriverForTest({ devtools: true })
+        driver = await createDriverForTest()
     })
 
     beforeEach(async function () {
@@ -142,8 +142,8 @@ describe('[Code Insight] Dashboard', () => {
                     },
                     site: { __typename: 'Site', id: 'site_id' },
                 }),
-                UpdateDashboard: () => ({
-                    updateInsightsDashboard: {
+                CreateDashboard: () => ({
+                    createInsightsDashboard: {
                         __typename: 'InsightsDashboardPayload',
                         dashboard: {
                             __typename: 'InsightsDashboard',


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/34001

In this PR we cover the dashboard test with integration tests. We didn't use unit test because our units at the moment are strictly bound to concrete implementation and it might be a problem in future when we will have a big shift in GQL/API paradigm in the near future. I wish we had more unit tests tooling around code insights logic but unfortunately, we don't have it at the moment. 
 
## Test plan
- Make sure that CI is green and the integration tests work properly

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vk-add-integration-test-for.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-yhalyifrrs.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
