### PR TITLE
symbols: Better debug page

### DIFF
--- a/cmd/symbols/squirrel/http_handlers.go
+++ b/cmd/symbols/squirrel/http_handlers.go
@@ -161,7 +161,8 @@ func DebugLocalCodeIntelHandler(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintf(w, "failed to generate local code intel payload: %s\n\n", err)
 	} else {
 		for ix := range payload.Symbols {
-			symbolIxToColor[ix] = fmt.Sprintf("hsla(%d, 100%%, 50%%, 0.5)", rand.Intn(360))
+			nonRed := []int{100, 120, 140, 160, 180, 200, 220, 240, 260}
+			symbolIxToColor[ix] = fmt.Sprintf("hsla(%d, 100%%, 50%%, 0.5)", sample(nonRed))
 		}
 
 		for ix, symbol := range payload.Symbols {
@@ -178,43 +179,74 @@ func DebugLocalCodeIntelHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	fmt.Fprintf(w, `
+		<style>
+			span:hover {
+				outline: 2px solid red;
+			}
+		</style>
+	`)
+
 	fmt.Fprintf(w, "<h3>Parsing as %s from file on disk %s</h3>\n", ext, fileToRead)
 
-	nodeToHtml := func(n *sitter.Node, contents []byte) string {
-		color := "hsla(0, 0%, 0%, 0.1)"
+	var nodeToHtml func(*sitter.Node, string) string
+	nodeToHtml = func(n *sitter.Node, stack string) string {
+
+		thisStack := stack + ">" + n.Type()
+
+		// Pick color
+		color := ""
 		if n.Type() == "ERROR" {
 			color = "hsla(0, 100%, 50%, 0.2)"
-		}
-		if ix, ok := rangeToSymbolIx[nodeToRange(n)]; ok {
+		} else if ix, ok := rangeToSymbolIx[nodeToRange(n)]; ok {
 			if c, ok := symbolIxToColor[ix]; ok {
 				color = c
 			}
+		} else {
+			color = "hsla(0, 0%, 0%, 0.0)"
 		}
-		title := fmt.Sprintf("%s %d:%d-%d:%d", html.EscapeString(n.Type()), n.StartPoint().Row, n.StartPoint().Column, n.EndPoint().Row, n.EndPoint().Column)
 
-		return fmt.Sprintf(
-			`<span style="background-color: %s", title="%s">%s</span>`,
-			color,
-			title,
-			html.EscapeString(string(contents[n.StartByte():n.EndByte()])),
-		)
+		// Tooltip
+		title := fmt.Sprintf("%s %d:%d-%d:%d", thisStack, n.StartPoint().Row, n.StartPoint().Column, n.EndPoint().Row, n.EndPoint().Column)
+
+		if n.ChildCount() == 0 {
+
+			// Base case: no children
+
+			// Render
+			return fmt.Sprintf(
+				`<span style="background-color: %s", title="%s">%s</span>`,
+				color,
+				title,
+				html.EscapeString(string(node.Contents[n.StartByte():n.EndByte()])),
+			)
+		} else {
+
+			// Recursive case: with children
+
+			// Concatenate children
+			b := n.StartByte()
+			inner := &strings.Builder{}
+			for i := 0; i < int(n.ChildCount()); i++ {
+				inner.WriteString(html.EscapeString(string(node.Contents[b:n.Child(i).StartByte()])))
+				inner.WriteString(nodeToHtml(n.Child(i), thisStack))
+				b = n.Child(i).EndByte()
+			}
+			inner.WriteString(html.EscapeString(string(node.Contents[b:n.EndByte()])))
+
+			// Render
+			return fmt.Sprintf(
+				`<span style="background-color: %s", title="%s">%s</span>`,
+				color,
+				title,
+				inner.String(),
+			)
+		}
 	}
 
-	fmt.Fprint(w, "<pre>")
+	fmt.Fprint(w, "<pre>"+nodeToHtml(node.Node, "")+"</pre>")
+}
 
-	prev := uint32(0)
-	walkFilter(node.Node, func(n *sitter.Node) bool {
-		if n.Type() != "ERROR" && n.ChildCount() > 0 {
-			return true
-		}
-
-		fmt.Fprint(w, html.EscapeString(string(node.Contents[prev:n.StartByte()])))
-		fmt.Fprint(w, nodeToHtml(n, node.Contents))
-
-		prev = n.EndByte()
-
-		return false
-	})
-
-	fmt.Fprint(w, "</pre>")
+func sample[T any](xs []T) T {
+	return xs[rand.Intn(len(xs))]
 }


### PR DESCRIPTION
On the debug page at http://localhost:3184/debugLocalCodeIntel?ext=py this will:

- Outlines nodes on hover
- Highlights errors in shades of red, deeper red for deeper errors

![CleanShot 2022-06-04 at 14 22 14](https://user-images.githubusercontent.com/1387653/172024448-789d924f-4566-45f1-9ef8-ca4bb8a7a651.png)

## Test plan

Manual