### PR TITLE
alerts: Do not alert on long transactions in codeintel-db

### DIFF
--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -6021,7 +6021,7 @@ To see this panel, visit `/-/debug/grafana/d/postgres/postgres?viewPanel=100002`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (job) (pg_stat_activity_max_tx_duration{datname!~"template.*|postgres|cloudsqladmin"}) OR sum by (job) (pg_stat_activity_max_tx_duration{job="codeinsights-db", datname!~"template.*|cloudsqladmin"})`
+Query: `sum by (job) (pg_stat_activity_max_tx_duration{datname!~"template.*|postgres|cloudsqladmin",job!="codeintel-db"}) OR sum by (job) (pg_stat_activity_max_tx_duration{job="codeinsights-db", datname!~"template.*|cloudsqladmin"})`
 
 </details>
 

--- a/monitoring/definitions/postgres.go
+++ b/monitoring/definitions/postgres.go
@@ -53,7 +53,7 @@ func Postgres() *monitoring.Dashboard {
 						Description:   "maximum transaction durations",
 						Owner:         monitoring.ObservableOwnerDevOps,
 						DataMustExist: false, // not deployed on docker-compose
-						Query:         `sum by (job) (pg_stat_activity_max_tx_duration{datname!~"template.*|postgres|cloudsqladmin"}) OR sum by (job) (pg_stat_activity_max_tx_duration{job="codeinsights-db", datname!~"template.*|cloudsqladmin"})`,
+						Query:         `sum by (job) (pg_stat_activity_max_tx_duration{datname!~"template.*|postgres|cloudsqladmin",job!="codeintel-db"}) OR sum by (job) (pg_stat_activity_max_tx_duration{job="codeinsights-db", datname!~"template.*|cloudsqladmin"})`,
 						Panel:         monitoring.Panel().LegendFormat("{{datname}}").Unit(monitoring.Seconds),
 						Warning:       monitoring.Alert().GreaterOrEqual(0.3).For(5 * time.Minute),
 						NextSteps:     "none",

--- a/monitoring/definitions/postgres.go
+++ b/monitoring/definitions/postgres.go
@@ -53,10 +53,12 @@ func Postgres() *monitoring.Dashboard {
 						Description:   "maximum transaction durations",
 						Owner:         monitoring.ObservableOwnerDevOps,
 						DataMustExist: false, // not deployed on docker-compose
-						Query:         `sum by (job) (pg_stat_activity_max_tx_duration{datname!~"template.*|postgres|cloudsqladmin",job!="codeintel-db"}) OR sum by (job) (pg_stat_activity_max_tx_duration{job="codeinsights-db", datname!~"template.*|cloudsqladmin"})`,
-						Panel:         monitoring.Panel().LegendFormat("{{datname}}").Unit(monitoring.Seconds),
-						Warning:       monitoring.Alert().GreaterOrEqual(0.3).For(5 * time.Minute),
-						NextSteps:     "none",
+						// Ignore in codeintel-db because Rockskip processing involves long transactions
+						// during normal operation.
+						Query:     `sum by (job) (pg_stat_activity_max_tx_duration{datname!~"template.*|postgres|cloudsqladmin",job!="codeintel-db"}) OR sum by (job) (pg_stat_activity_max_tx_duration{job="codeinsights-db", datname!~"template.*|cloudsqladmin"})`,
+						Panel:     monitoring.Panel().LegendFormat("{{datname}}").Unit(monitoring.Seconds),
+						Warning:   monitoring.Alert().GreaterOrEqual(0.3).For(5 * time.Minute),
+						NextSteps: "none",
 					},
 				},
 				},


### PR DESCRIPTION
During normal Rockskip indexing, some transactions that update big hops can take tens of minutes to finish. It would be nice if we could selectively ignore Rockskip transactions while still alerting on other `codeintel-db` transactions. Any idea how to do that easily? This PR omits `codeintel-db` from the check to at least stop the spurious alerts.

![CleanShot 2022-06-05 at 19 46 08](https://user-images.githubusercontent.com/1387653/172081227-cbe5a5ab-09d0-42ae-8605-055f0b2e1f82.png)

From https://github.com/sourcegraph/customer/issues/976#issuecomment-1145369932

## Test plan

Ran in Grafana
