### PR TITLE
[SG-35158] Accessibility: Code monitoring logs: wrong usage of heading elements

### DIFF
--- a/client/web/src/enterprise/code-monitoring/CodeMonitoringPage.tsx
+++ b/client/web/src/enterprise/code-monitoring/CodeMonitoringPage.tsx
@@ -95,12 +95,6 @@ export const CodeMonitoringPage: React.FunctionComponent<React.PropsWithChildren
         <div className="code-monitoring-page" data-testid="code-monitoring-page">
             <PageTitle title="Code Monitoring" />
             <PageHeader
-                path={[
-                    {
-                        icon: CodeMonitoringLogo,
-                        text: 'Code monitoring',
-                    },
-                ]}
                 actions={
                     authenticatedUser && (
                         <Button to="/code-monitoring/new" variant="primary" as={Link}>
@@ -120,7 +114,11 @@ export const CodeMonitoringPage: React.FunctionComponent<React.PropsWithChildren
                     )
                 }
                 className="mb-3"
-            />
+            >
+                <PageHeader.Heading as="h2" styleAs="h1">
+                    <PageHeader.Breadcrumb icon={CodeMonitoringLogo}>Code monitoring</PageHeader.Breadcrumb>
+                </PageHeader.Heading>
+            </PageHeader>
 
             {userHasCodeMonitors === 'loading' ? (
                 <LoadingSpinner inline={false} />

--- a/client/web/src/enterprise/code-monitoring/components/logs/CodeMonitorLogsHeader.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/logs/CodeMonitorLogsHeader.tsx
@@ -8,7 +8,11 @@ import styles from './CodeMonitorLogsHeader.module.scss'
 
 export const CodeMonitorLogsHeader: React.FunctionComponent<React.PropsWithChildren<{}>> = () => (
     <>
-        <H5 className={classNames(styles.nameColumn, 'text-uppercase text-nowrap')}>Monitor name</H5>
-        <H5 className="text-uppercase text-nowrap">Last run</H5>
+        <H5 as="div" aria-hidden={true} className={classNames(styles.nameColumn, 'text-uppercase text-nowrap')}>
+            Monitor name
+        </H5>
+        <H5 as="div" aria-hidden={true} className="text-uppercase text-nowrap">
+            Last run
+        </H5>
     </>
 )


### PR DESCRIPTION

### Audit type
ARC Toolkit

### User journey audit issue
[#34194](https://github.com/sourcegraph/sourcegraph/issues/34194)

### Problem description

- Navigate to https://sourcegraph.com/code-monitoring?visible=4

- Witness "Code Monitoring" header is an h1 (should be h2)

- Witness "Monitor name", "last run" elements are h5 (skips heading levels)


### Expected behavior

- "Code Monitoring" header is an h2

- "MONITOR NAME" & "LAST RUN" elements should be styled as h5, but implemented using div or span with aria-hidden="true" so that they do not appear for screen readers.

## Refs
[Sourcegraph Issue](https://github.com/sourcegraph/sourcegraph/issues/35158)
[Gitstart Ticket](https://app.gitstart.com/clients/sourcegraph/tickets/SG-35158)

## Description: Short description about changes on this PR

- Changed "Code Monitoring" header from H1 (default) to an H2

- Implemented "MONITOR NAME" & "LAST RUN" elements using span with aria-hidden="true" so that they do not appear for screen readers


## Test plan

- "Code Monitoring" header should be an h2

- "MONITOR NAME" & "LAST RUN" elements shouldn't appear for screen readers


<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "## Test plan" header.
-->



## App preview:

- [Web](https://sg-web-contractors-sg-35158.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-kesoghrkws.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
