### PR TITLE
[SG-35155] Code monitoring ARC checklist issues

### DIFF
--- a/client/web/src/enterprise/code-monitoring/CodeMonitoringPage.tsx
+++ b/client/web/src/enterprise/code-monitoring/CodeMonitoringPage.tsx
@@ -95,12 +95,6 @@ export const CodeMonitoringPage: React.FunctionComponent<React.PropsWithChildren
         <div className="code-monitoring-page" data-testid="code-monitoring-page">
             <PageTitle title="Code Monitoring" />
             <PageHeader
-                path={[
-                    {
-                        icon: CodeMonitoringLogo,
-                        text: 'Code monitoring',
-                    },
-                ]}
                 actions={
                     authenticatedUser && (
                         <Button to="/code-monitoring/new" variant="primary" as={Link}>
@@ -120,7 +114,11 @@ export const CodeMonitoringPage: React.FunctionComponent<React.PropsWithChildren
                     )
                 }
                 className="mb-3"
-            />
+            >
+                <PageHeader.Heading as="h2" styleAs="h1">
+                    <PageHeader.Breadcrumb icon={CodeMonitoringLogo}>Code monitoring</PageHeader.Breadcrumb>
+                </PageHeader.Heading>
+            </PageHeader>
 
             {userHasCodeMonitors === 'loading' ? (
                 <LoadingSpinner inline={false} />

--- a/client/wildcard/src/components/PageHeader/Breadcrumb/Breadcrumb.tsx
+++ b/client/wildcard/src/components/PageHeader/Breadcrumb/Breadcrumb.tsx
@@ -6,7 +6,7 @@ import { LinkOrSpan } from '@sourcegraph/shared/src/components/LinkOrSpan'
 
 import styles from './Breadcrumb.module.scss'
 
-export type BreadcrumbIcon = React.ComponentType<{ className?: string }>
+export type BreadcrumbIcon = React.ComponentType<{ className?: string; role?: React.AriaRole }>
 export type BreadcrumbText = React.ReactNode
 
 type BreadcrumbProps = React.HTMLAttributes<HTMLSpanElement> & {
@@ -33,7 +33,7 @@ export const Breadcrumb: React.FunctionComponent<BreadcrumbProps> = ({
 }) => (
     <span className={classNames(styles.wrapper, className)} {...rest}>
         <LinkOrSpan className={styles.path} to={to} aria-label={ariaLabel}>
-            {Icon && <Icon className={styles.icon} aria-hidden={true} />}
+            {Icon && <Icon role="img" className={styles.icon} aria-hidden={true} />}
             {children && <span className={styles.text}>{children}</span>}
         </LinkOrSpan>
     </span>

--- a/client/wildcard/src/components/PageHeader/__snapshots__/PageHeader.test.tsx.snap
+++ b/client/wildcard/src/components/PageHeader/__snapshots__/PageHeader.test.tsx.snap
@@ -22,6 +22,7 @@ exports[`PageHeader renders correctly 1`] = `
                 class="mdi-icon icon"
                 fill="currentColor"
                 height="24"
+                role="img"
                 viewBox="0 0 24 24"
                 width="24"
               >


### PR DESCRIPTION
closes https://github.com/sourcegraph/sourcegraph/issues/35156

## Description

- Change Code Monitoring header to use H2 (instead of H1)
- Add role=img for `Icon` in page header breadcrumb.


## Refs

[SoureGraph Issue](https://github.com/sourcegraph/sourcegraph/issues/35155)
[GitStart Link](https://app.gitstart.com/clients/sourcegraph/tickets/SG-35155)

## Test plan

- Confirm checks in description are available on Code Monitor page
- Confirm there are no UI changes

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan hereafter the "## Test plan" header.
-->



## App preview:

- [Web](https://sg-web-contractors-sg-35155.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-uceyckmmwx.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
