### PR TITLE
Prevent search input auto focus on touch device

### DIFF
--- a/client/web/src/search/home/SearchPageInput.tsx
+++ b/client/web/src/search/home/SearchPageInput.tsx
@@ -38,14 +38,14 @@ import styles from './SearchPageInput.module.scss'
 
 interface Props
     extends SettingsCascadeProps<Settings>,
-    ThemeProps,
-    ThemePreferenceProps,
-    ActivationProps,
-    KeyboardShortcutsProps,
-    TelemetryProps,
-    PlatformContextProps<'forceUpdateTooltip' | 'settings' | 'sourcegraphURL' | 'requestGraphQL'>,
-    Pick<SubmitSearchParameters, 'source'>,
-    SearchContextInputProps {
+        ThemeProps,
+        ThemePreferenceProps,
+        ActivationProps,
+        KeyboardShortcutsProps,
+        TelemetryProps,
+        PlatformContextProps<'forceUpdateTooltip' | 'settings' | 'sourcegraphURL' | 'requestGraphQL'>,
+        Pick<SubmitSearchParameters, 'source'>,
+        SearchContextInputProps {
     authenticatedUser: AuthenticatedUser | null
     location: H.Location
     history: H.History
@@ -160,7 +160,13 @@ export const SearchPageInput: React.FunctionComponent<React.PropsWithChildren<Pr
                         queryState={userQueryState}
                         onChange={setUserQueryState}
                         onSubmit={onSubmit}
-                        autoFocus={props.showOnboardingTour ? shouldFocusQueryInput : isTouchDevice ? false : props.autoFocus !== false}
+                        autoFocus={
+                            props.showOnboardingTour
+                                ? shouldFocusQueryInput
+                                : isTouchDevice
+                                ? false
+                                : props.autoFocus !== false
+                        }
                         isExternalServicesUserModeAll={window.context.externalServicesUserMode === 'all'}
                         structuralSearchDisabled={window.context?.experimentalFeatures?.structuralSearch === 'disabled'}
                     />

--- a/client/web/src/search/home/SearchPageInput.tsx
+++ b/client/web/src/search/home/SearchPageInput.tsx
@@ -163,9 +163,7 @@ export const SearchPageInput: React.FunctionComponent<React.PropsWithChildren<Pr
                         autoFocus={
                             props.showOnboardingTour
                                 ? shouldFocusQueryInput
-                                : isTouchDevice
-                                ? false
-                                : props.autoFocus !== false
+                                : !isTouchDevice && props.autoFocus !== false
                         }
                         isExternalServicesUserModeAll={window.context.externalServicesUserMode === 'all'}
                         structuralSearchDisabled={window.context?.experimentalFeatures?.structuralSearch === 'disabled'}

--- a/client/web/src/search/home/SearchPageInput.tsx
+++ b/client/web/src/search/home/SearchPageInput.tsx
@@ -134,10 +134,12 @@ export const SearchPageInput: React.FunctionComponent<React.PropsWithChildren<Pr
         [submitSearchOnChange]
     )
 
-    // We want to prevent autofocus by default on touch screens as it results
-    // in the device keyboard not showing until the input loses focus and
-    // gets focused by the user again.
-    const isTouchDevice = window?.ontouchstart !== undefined
+    // We want to prevent autofocus by default on devices with touch as their only input method.
+    // Touch only devices result in the onscreen keyboard not showing until the input loses focus and
+    // gets focused again by the user. The logic is not fool proof, but should rule out majority of cases
+    // where a touch enabled device has a physical keyboard by relying on detection of a fine pointer with hover ability.
+    const isTouchOnlyDevice =
+        !window.matchMedia('(any-pointer:fine)').matches && window.matchMedia('(any-hover:none)').matches
 
     return (
         <div className="d-flex flex-row flex-shrink-past-contents">
@@ -163,7 +165,7 @@ export const SearchPageInput: React.FunctionComponent<React.PropsWithChildren<Pr
                         autoFocus={
                             props.showOnboardingTour
                                 ? shouldFocusQueryInput
-                                : !isTouchDevice && props.autoFocus !== false
+                                : !isTouchOnlyDevice && props.autoFocus !== false
                         }
                         isExternalServicesUserModeAll={window.context.externalServicesUserMode === 'all'}
                         structuralSearchDisabled={window.context?.experimentalFeatures?.structuralSearch === 'disabled'}

--- a/client/web/src/search/home/SearchPageInput.tsx
+++ b/client/web/src/search/home/SearchPageInput.tsx
@@ -38,14 +38,14 @@ import styles from './SearchPageInput.module.scss'
 
 interface Props
     extends SettingsCascadeProps<Settings>,
-        ThemeProps,
-        ThemePreferenceProps,
-        ActivationProps,
-        KeyboardShortcutsProps,
-        TelemetryProps,
-        PlatformContextProps<'forceUpdateTooltip' | 'settings' | 'sourcegraphURL' | 'requestGraphQL'>,
-        Pick<SubmitSearchParameters, 'source'>,
-        SearchContextInputProps {
+    ThemeProps,
+    ThemePreferenceProps,
+    ActivationProps,
+    KeyboardShortcutsProps,
+    TelemetryProps,
+    PlatformContextProps<'forceUpdateTooltip' | 'settings' | 'sourcegraphURL' | 'requestGraphQL'>,
+    Pick<SubmitSearchParameters, 'source'>,
+    SearchContextInputProps {
     authenticatedUser: AuthenticatedUser | null
     location: H.Location
     history: H.History
@@ -134,6 +134,11 @@ export const SearchPageInput: React.FunctionComponent<React.PropsWithChildren<Pr
         [submitSearchOnChange]
     )
 
+    // We want to prevent autofocus by default on touch screens as it results
+    // in the device keyboard not showing until the input loses focus and
+    // gets focused by the user again.
+    const isTouchDevice = window?.ontouchstart !== undefined
+
     return (
         <div className="d-flex flex-row flex-shrink-past-contents">
             <Form className="flex-grow-1 flex-shrink-past-contents" onSubmit={onSubmit}>
@@ -155,7 +160,7 @@ export const SearchPageInput: React.FunctionComponent<React.PropsWithChildren<Pr
                         queryState={userQueryState}
                         onChange={setUserQueryState}
                         onSubmit={onSubmit}
-                        autoFocus={props.showOnboardingTour ? shouldFocusQueryInput : props.autoFocus !== false}
+                        autoFocus={props.showOnboardingTour ? shouldFocusQueryInput : isTouchDevice ? false : props.autoFocus !== false}
                         isExternalServicesUserModeAll={window.context.externalServicesUserMode === 'all'}
                         structuralSearchDisabled={window.context?.experimentalFeatures?.structuralSearch === 'disabled'}
                     />


### PR DESCRIPTION
We want to prevent autofocus by default on touch screens as it results in the device keyboard not showing until the input loses focus and gets focused by the user again.

Relates to [conversation](https://sourcegraph.slack.com/archives/C03CSAER9LK/p1654503967344779) in #feedback-dogfood

## Test plan

1. Go to `/search` on mobile device (or put Developer Tools in mobile mode).
1. When loading the page the search input should not be focused automatically.


## App preview:

- [Web](https://sg-web-jeanduplessis-search-autofocus.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-nexlopmycd.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
