### PR TITLE
Accessibility: Improve fuzzy finder description

### DIFF
--- a/client/web/src/components/fuzzyFinder/FuzzyModal.tsx
+++ b/client/web/src/components/fuzzyFinder/FuzzyModal.tsx
@@ -23,7 +23,6 @@ import styles from './FuzzyModal.module.scss'
 // - case-insensitive search is almost unusable in the chromium/chromium repo (360k files)
 const DEFAULT_CASE_INSENSITIVE_FILE_COUNT_THRESHOLD = 80000
 
-const FUZZY_MODAL_TITLE = 'fuzzy-modal-title'
 const FUZZY_MODAL_RESULTS = 'fuzzy-modal-results'
 
 // Cache for the last fuzzy query. This value is only used to avoid redoing the
@@ -234,13 +233,11 @@ export const FuzzyModal: React.FunctionComponent<React.PropsWithChildren<FuzzyMo
             position="center"
             className={styles.modal}
             onDismiss={() => props.onClose()}
-            aria-labelledby={FUZZY_MODAL_TITLE}
+            aria-label="Fuzzy finder: Find file"
         >
             <div className={styles.content}>
                 <div className={styles.header}>
-                    <H3 className="mb-0" id={FUZZY_MODAL_TITLE}>
-                        Find file
-                    </H3>
+                    <H3 className="mb-0">Find file</H3>
                     <Button variant="icon" onClick={() => props.onClose()} aria-label="Close">
                         <Icon role="img" className={styles.closeIcon} as={CloseIcon} aria-hidden={true} />
                     </Button>


### PR DESCRIPTION
## Description

Closes https://github.com/sourcegraph/sourcegraph/issues/35247

Just updates the description to make it clear that this is the fuzzy finder - as there's not an obvious action that opens it (could be triggered through keyboard press)

## Test plan

Tested locally with a screen reader

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
