### PR TITLE
Fix sidebar collapse icon color

### DIFF
--- a/client/web/src/repo/RepoRevisionSidebar.module.scss
+++ b/client/web/src/repo/RepoRevisionSidebar.module.scss
@@ -4,7 +4,7 @@
 }
 
 .close-icon {
-    color: var(--link-color);
+    color: var(--body-color);
 }
 
 .toggle {
@@ -17,7 +17,7 @@
     isolation: isolate;
     border-bottom-left-radius: 0;
     border-top-left-radius: 0;
-    color: var(--icon-color);
+    color: var(--body-color);
     background-color: var(--body-bg);
 
     &:hover {

--- a/client/web/src/repo/RepoRevisionSidebar.module.scss
+++ b/client/web/src/repo/RepoRevisionSidebar.module.scss
@@ -4,7 +4,7 @@
 }
 
 .close-icon {
-    color: var(--body-color);
+    color: var(--icon-color);
 }
 
 .toggle {
@@ -17,7 +17,7 @@
     isolation: isolate;
     border-bottom-left-radius: 0;
     border-top-left-radius: 0;
-    color: var(--body-color);
+    color: var(--icon-color);
     background-color: var(--body-bg);
 
     &:hover {


### PR DESCRIPTION
There was a [minor regression with the color of the expand/collapse icon](https://github.com/sourcegraph/sourcegraph/issues/36551) in the sidebar.

This PR addresses the issue.

## Design
As per our [design system](https://www.figma.com/file/NIsN34NH7lPu04olBzddTw/%E2%9C%B3%EF%B8%8F-Wildcard-Design-System?node-id=955%3A664), the icon should be `--body-color` to match the designs in both light and dark modes.

### In Design System
|Light|Dark|
|---|---|
|<img width="291" alt="Screenshot 2022-06-06 at 13 32 18" src="https://user-images.githubusercontent.com/2196347/172144597-4f90a71b-a7ec-4b88-942f-c435d2bc5429.png">|<img width="282" alt="Screenshot 2022-06-06 at 13 32 10" src="https://user-images.githubusercontent.com/2196347/172144566-d5bae956-e22a-4753-b17a-97072c231754.png">|

### After the Change
|Light|Dark|
|---|---|
|<img width="258" alt="Screenshot 2022-06-06 at 13 33 14" src="https://user-images.githubusercontent.com/2196347/172144700-481587dc-c07c-4a37-9154-b73e3a095ce4.png">|<img width="255" alt="Screenshot 2022-06-06 at 13 33 21" src="https://user-images.githubusercontent.com/2196347/172144727-8d3ad07e-a732-4605-ae16-79fda6cde9c2.png">|

## Test plan

1. pull the branch
2. run the app
3. ensure that colors match

## App preview:

- [Web](https://sg-web-og-fix-sidebar-icon-color.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-qagebwbkgt.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
