### PR TITLE
fix(ci): pin rust protobuf codegen on 3.39

### DIFF
--- a/dev/proto-generate.sh
+++ b/dev/proto-generate.sh
@@ -9,7 +9,7 @@ echo "--- yarn in root"
 yarn --mutex network --frozen-lockfile --network-timeout 60000
 
 echo "--- cargo install rust-protobuf"
-which ./.bin/bin/protoc-gen-rust || cargo install --root .bin protobuf-codegen
+which ./.bin/bin/protoc-gen-rust || cargo install --root .bin --version 2.27.1 protobuf-codegen
 
 echo "--- buf"
 


### PR DESCRIPTION
3.0+ of protobuf-codegen fails see [build 152198](https://buildkite.com/sourcegraph/sourcegraph/builds/152198#0181312f-91c6-44c7-b2fa-b101fd3135af)

## Test plan
executed `./dev/proto-generate.sh` locally
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
