### PR TITLE
Accessibility: Update FilteredConnection to support better usage of labels

### DIFF
--- a/client/web/src/components/FilteredConnection/FilteredConnection.tsx
+++ b/client/web/src/components/FilteredConnection/FilteredConnection.tsx
@@ -484,6 +484,7 @@ export class FilteredConnection<
         //     this.props.hideControlsWhenEmpty
 
         const inputPlaceholder = this.props.inputPlaceholder || `Search ${this.props.pluralNoun}...`
+
         return (
             <ConnectionContainer compact={this.props.compact} className={this.props.className}>
                 {

--- a/client/web/src/components/FilteredConnection/FilteredConnection.tsx
+++ b/client/web/src/components/FilteredConnection/FilteredConnection.tsx
@@ -483,6 +483,7 @@ export class FilteredConnection<
         //     this.state.connectionOrError.nodes.length > 0 &&
         //     this.props.hideControlsWhenEmpty
 
+        const inputPlaceholder = this.props.inputPlaceholder || `Search ${this.props.pluralNoun}...`
         return (
             <ConnectionContainer compact={this.props.compact} className={this.props.className}>
                 {
@@ -491,8 +492,8 @@ export class FilteredConnection<
                             ref={this.setFilterRef}
                             hideSearch={this.props.hideSearch}
                             inputClassName={this.props.inputClassName}
-                            inputPlaceholder={this.props.inputPlaceholder || `Search ${this.props.pluralNoun}...`}
-                            inputAriaLabel={this.props.inputAriaLabel}
+                            inputPlaceholder={inputPlaceholder}
+                            inputAriaLabel={this.props.inputAriaLabel || inputPlaceholder}
                             inputValue={this.state.query}
                             onInputChange={this.onChange}
                             autoFocus={this.props.autoFocus}

--- a/client/web/src/notebooks/notebookPage/NotebookPage.tsx
+++ b/client/web/src/notebooks/notebookPage/NotebookPage.tsx
@@ -276,11 +276,6 @@ export const NotebookPage: React.FunctionComponent<React.PropsWithChildren<Noteb
                                     )}
                                     {isNotebookLoaded(latestNotebook) && (
                                         <>
-                                            <Icon
-                                                role="img"
-                                                as={CheckCircleIcon}
-                                                className={classNames('text-success m-1', styles.autoSaveIndicator)}
-                                            />
                                             <CheckCircleIcon
                                                 className={classNames('text-success m-1', styles.autoSaveIndicator)}
                                             />

--- a/client/web/src/notebooks/notebookPage/NotebookPage.tsx
+++ b/client/web/src/notebooks/notebookPage/NotebookPage.tsx
@@ -276,6 +276,11 @@ export const NotebookPage: React.FunctionComponent<React.PropsWithChildren<Noteb
                                     )}
                                     {isNotebookLoaded(latestNotebook) && (
                                         <>
+                                            <Icon
+                                                role="img"
+                                                as={CheckCircleIcon}
+                                                className={classNames('text-success m-1', styles.autoSaveIndicator)}
+                                            />
                                             <CheckCircleIcon
                                                 className={classNames('text-success m-1', styles.autoSaveIndicator)}
                                             />

--- a/client/web/src/repo/releases/__snapshots__/RepositoryReleasesTagsPage.test.tsx.snap
+++ b/client/web/src/repo/releases/__snapshots__/RepositoryReleasesTagsPage.test.tsx.snap
@@ -16,6 +16,7 @@ exports[`RepositoryReleasesTagsPage renders 1`] = `
           class="container loader-input loaderInput input"
         >
           <input
+            aria-label="Search tags..."
             autocapitalize="off"
             autocomplete="off"
             autocorrect="off"


### PR DESCRIPTION
## Description

We typically rely on the `placeholder` for accessible labels in a lot of places, e.g.: 
<img width="589" alt="image" src="https://user-images.githubusercontent.com/9516420/172157475-31a0c41e-fe99-4c1c-8690-8107ffc0de2c.png">

For further reading, see [placeholders are not accessible](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#additional_features). Tl;dr - placeholders aren't accessible to screen readers and are only useful before the user has entered text

> **Note**
> We likely want this to enforce this for all `<Input />` elements. There's not a clear solution here yet (as there's so many ways to label an element). The simplest solution is to always enforce that we have _some_ label on these elements, issue here for that: https://github.com/sourcegraph/sourcegraph/issues/36645

## Test plan

Tested locally with a screen reader

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-tr-filtered-connection-placeholder.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-mkkdvvzmcb.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

closes https://github.com/sourcegraph/sourcegraph/issues/35463
closes https://github.com/sourcegraph/sourcegraph/issues/35468
