### PR TITLE
fix buildchecker cron schedule

### DIFF
--- a/.github/workflows/buildchecker-history.yml
+++ b/.github/workflows/buildchecker-history.yml
@@ -2,7 +2,7 @@
 name: buildchecker-history
 on:
   schedule:
-  - cron: '* * * * SUN'
+  - cron: '0 0 * * SUN'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
stops the buildchecker history report spamming the #ci-reports slack channel. 

@bobheadxi does this mess with the previous honeycomb stats? Is there a reason this was running every minute on a Sunday? 

## Test plan

Just altering a schedule, the code is unchanged. 