### PR TITLE
Filter search_result_paths for workspaces

### DIFF
--- a/enterprise/internal/batches/service/workspace_resolver.go
+++ b/enterprise/internal/batches/service/workspace_resolver.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path"
 	"sort"
+	"strings"
 	"sync"
 
 	"github.com/gobwas/glob"
@@ -688,10 +689,22 @@ func findWorkspaces(
 				fetchWorkspace = false
 			}
 
+			// Filter file matches by workspace. Only include paths that are
+			// _within_ the directory.
+			paths := []string{}
+			for _, probe := range workspace.RepoRevision.FileMatches {
+				if strings.HasPrefix(probe, path) {
+					paths = append(paths, probe)
+				}
+			}
+
+			repoRevision := *workspace.RepoRevision
+			repoRevision.FileMatches = paths
+
 			steps, err := stepsForRepo(spec, template.Repository{
-				Name:        string(workspace.Repo.Name),
-				Branch:      workspace.Branch,
-				FileMatches: workspace.FileMatches,
+				Name:        string(repoRevision.Repo.Name),
+				Branch:      repoRevision.Branch,
+				FileMatches: repoRevision.FileMatches,
 			})
 			if err != nil {
 				return nil, err
@@ -703,7 +716,7 @@ func findWorkspaces(
 			}
 
 			workspaces = append(workspaces, &RepoWorkspace{
-				RepoRevision:       workspace.RepoRevision,
+				RepoRevision:       &repoRevision,
 				Path:               path,
 				OnlyFetchWorkspace: fetchWorkspace,
 			})

--- a/enterprise/internal/batches/service/workspace_resolver_test.go
+++ b/enterprise/internal/batches/service/workspace_resolver_test.go
@@ -479,9 +479,17 @@ type defaultBranch struct {
 
 func TestFindWorkspaces(t *testing.T) {
 	repoRevs := []*RepoRevision{
-		{Repo: &types.Repo{ID: 1, Name: "github.com/sourcegraph/automation-testing"}},
-		{Repo: &types.Repo{ID: 2, Name: "github.com/sourcegraph/sourcegraph"}},
-		{Repo: &types.Repo{ID: 3, Name: "bitbucket.sgdev.org/SOUR/automation-testing"}},
+		{Repo: &types.Repo{ID: 1, Name: "github.com/sourcegraph/automation-testing"}, FileMatches: []string{}},
+		{Repo: &types.Repo{ID: 2, Name: "github.com/sourcegraph/sourcegraph"}, FileMatches: []string{}},
+		{Repo: &types.Repo{ID: 3, Name: "bitbucket.sgdev.org/SOUR/automation-testing"}, FileMatches: []string{}},
+		// This one has file matches.
+		{
+			Repo: &types.Repo{
+				ID:   4,
+				Name: "github.com/sourcegraph/src-cli",
+			},
+			FileMatches: []string{"a/b", "a/b/c", "d/e/f"},
+		},
 	}
 	steps := []batcheslib.Step{{Run: "echo 1"}}
 
@@ -502,6 +510,7 @@ func TestFindWorkspaces(t *testing.T) {
 				{RepoRevision: repoRevs[0], Path: ""},
 				{RepoRevision: repoRevs[1], Path: ""},
 				{RepoRevision: repoRevs[2], Path: ""},
+				{RepoRevision: repoRevs[3], Path: ""},
 			},
 		},
 
@@ -517,6 +526,7 @@ func TestFindWorkspaces(t *testing.T) {
 				{RepoRevision: repoRevs[0], Path: ""},
 				{RepoRevision: repoRevs[1], Path: ""},
 				{RepoRevision: repoRevs[2], Path: ""},
+				{RepoRevision: repoRevs[3], Path: ""},
 			},
 		},
 
@@ -533,6 +543,7 @@ func TestFindWorkspaces(t *testing.T) {
 			},
 			wantWorkspaces: []*RepoWorkspace{
 				{RepoRevision: repoRevs[1], Path: ""},
+				{RepoRevision: repoRevs[3], Path: ""},
 			},
 		},
 
@@ -555,6 +566,7 @@ func TestFindWorkspaces(t *testing.T) {
 				{RepoRevision: repoRevs[2], Path: "a/b"},
 				{RepoRevision: repoRevs[2], Path: "a/b/c"},
 				{RepoRevision: repoRevs[2], Path: "d/e/f"},
+				{RepoRevision: repoRevs[3], Path: ""},
 			},
 		},
 
@@ -581,8 +593,10 @@ func TestFindWorkspaces(t *testing.T) {
 				{RepoRevision: repoRevs[2], Path: "a/b", OnlyFetchWorkspace: true},
 				{RepoRevision: repoRevs[2], Path: "a/b/c", OnlyFetchWorkspace: true},
 				{RepoRevision: repoRevs[2], Path: "d/e/f", OnlyFetchWorkspace: true},
+				{RepoRevision: repoRevs[3], Path: ""},
 			},
 		},
+
 		"workspace configuration without 'in' matches all": {
 			spec: &batcheslib.BatchSpec{
 				Steps: steps,
@@ -619,6 +633,27 @@ func TestFindWorkspaces(t *testing.T) {
 				repoRevs[0].Key(): {"a/b"},
 			},
 			wantErr: errors.New(`repository github.com/sourcegraph/automation-testing matches multiple workspaces.in globs in the batch spec. glob: "github.com/sourcegraph/automation-testing"`),
+		},
+		"workspace gets subset of search_result_paths": {
+			spec: &batcheslib.BatchSpec{
+				Steps: steps,
+				Workspaces: []batcheslib.WorkspaceConfiguration{
+					{
+						In:               "*src-cli",
+						RootAtLocationOf: "package.json",
+					},
+				},
+			},
+			finderResults: finderResults{
+				repoRevs[3].Key(): {"a/b", "d"},
+			},
+			wantWorkspaces: []*RepoWorkspace{
+				{RepoRevision: repoRevs[0], Path: ""},
+				{RepoRevision: repoRevs[1], Path: ""},
+				{RepoRevision: repoRevs[2], Path: ""},
+				{RepoRevision: &RepoRevision{Repo: repoRevs[3].Repo, Branch: repoRevs[3].Branch, Commit: repoRevs[3].Commit, FileMatches: []string{"a/b", "a/b/c"}}, Path: "a/b"},
+				{RepoRevision: &RepoRevision{Repo: repoRevs[3].Repo, Branch: repoRevs[3].Branch, Commit: repoRevs[3].Commit, FileMatches: []string{"d/e/f"}}, Path: "d"},
+			},
 		},
 	}
 


### PR DESCRIPTION
If we decide to adopt this, we need to port this fix to src-cli as well. For details, see the ticket.

For the src-cli PR that does the same change to the local resolution algorithm see here: https://github.com/sourcegraph/src-cli/pull/779 (Warning it might be boring to read)

Closes https://github.com/sourcegraph/sourcegraph/issues/36620

## Test plan

Wrote a test for this, and manually verified that the spec from the ticket works correctly now.
