### PR TITLE
vscode: use deprecated tooltip

### DIFF
--- a/client/vscode/src/webview/platform/context.ts
+++ b/client/vscode/src/webview/platform/context.ts
@@ -9,7 +9,7 @@ import { wrapRemoteObservable } from '@sourcegraph/shared/src/api/client/api/com
 import { AuthenticatedUser } from '@sourcegraph/shared/src/auth'
 import { PlatformContext } from '@sourcegraph/shared/src/platform/context'
 import { SettingsCascadeOrError } from '@sourcegraph/shared/src/settings/settings'
-import { TooltipController } from '@sourcegraph/wildcard'
+import { DeprecatedTooltipController } from '@sourcegraph/wildcard'
 
 import { ExtensionCoreAPI } from '../../contract'
 
@@ -62,7 +62,7 @@ export function createPlatformContext(extensionCoreAPI: Comlink.Remote<Extension
         sideloadedExtensionURL: new BehaviorSubject<string | null>(null),
         clientApplication: 'other', // TODO add 'vscode-extension' to `clientApplication`,
         getScriptURLForExtension: () => undefined,
-        forceUpdateTooltip: () => TooltipController.forceUpdate(),
+        forceUpdateTooltip: () => DeprecatedTooltipController.forceUpdate(),
         // TODO showInputBox
         // TODO showMessage
     }

--- a/client/vscode/src/webview/search-panel/index.tsx
+++ b/client/vscode/src/webview/search-panel/index.tsx
@@ -16,7 +16,7 @@ import {
     WildcardThemeContext,
     // This is the root Tooltip usage
     // eslint-disable-next-line no-restricted-imports
-    Tooltip,
+    DeprecatedTooltip,
 } from '@sourcegraph/wildcard'
 
 import { ExtensionCoreAPI } from '../../contract'
@@ -124,7 +124,7 @@ render(
             <MemoryRouter>
                 <Main />
             </MemoryRouter>
-            <Tooltip key={1} className="sourcegraph-tooltip" />
+            <DeprecatedTooltip key={1} className="sourcegraph-tooltip" />
         </WildcardThemeContext.Provider>
     </ShortcutProvider>,
     document.querySelector('#root')

--- a/client/vscode/src/webview/sidebars/search/index.tsx
+++ b/client/vscode/src/webview/sidebars/search/index.tsx
@@ -11,7 +11,13 @@ import { useDeepCompareEffectNoCheck } from 'use-deep-compare-effect'
 import { wrapRemoteObservable } from '@sourcegraph/shared/src/api/client/api/common'
 import { Filter } from '@sourcegraph/shared/src/search/stream'
 // eslint-disable-next-line no-restricted-imports
-import { AnchorLink, setLinkComponent, useObservable, WildcardThemeContext, Tooltip } from '@sourcegraph/wildcard'
+import {
+    AnchorLink,
+    setLinkComponent,
+    useObservable,
+    WildcardThemeContext,
+    DeprecatedTooltip,
+} from '@sourcegraph/wildcard'
 
 import { ExtensionCoreAPI } from '../../../contract'
 import { createEndpointsForWebToNode } from '../../comlink/webviewEndpoint'
@@ -123,7 +129,7 @@ render(
     <ShortcutProvider>
         <WildcardThemeContext.Provider value={{ isBranded: true }}>
             <Main />
-            <Tooltip key={1} className="sourcegraph-tooltip" />
+            <DeprecatedTooltip key={1} className="sourcegraph-tooltip" />
         </WildcardThemeContext.Provider>
     </ShortcutProvider>,
     document.querySelector('#root')


### PR DESCRIPTION
Temporarily use deprecated tooltip. We should migrate to the new accessible [tooltip in `wildcard`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@main/-/blob/client/wildcard/src/components/Tooltip/Tooltip.tsx?L34).

## Test plan

Observe that tooltips work in manual test. Integration test passes as well.