### PR TITLE
CI: Fix Tooltip imports causing TS build to fail

### DIFF
--- a/client/vscode/src/webview/platform/context.ts
+++ b/client/vscode/src/webview/platform/context.ts
@@ -9,7 +9,7 @@ import { wrapRemoteObservable } from '@sourcegraph/shared/src/api/client/api/com
 import { AuthenticatedUser } from '@sourcegraph/shared/src/auth'
 import { PlatformContext } from '@sourcegraph/shared/src/platform/context'
 import { SettingsCascadeOrError } from '@sourcegraph/shared/src/settings/settings'
-import { TooltipController } from '@sourcegraph/wildcard'
+import { DeprecatedTooltipController } from '@sourcegraph/wildcard'
 
 import { ExtensionCoreAPI } from '../../contract'
 
@@ -62,7 +62,7 @@ export function createPlatformContext(extensionCoreAPI: Comlink.Remote<Extension
         sideloadedExtensionURL: new BehaviorSubject<string | null>(null),
         clientApplication: 'other', // TODO add 'vscode-extension' to `clientApplication`,
         getScriptURLForExtension: () => undefined,
-        forceUpdateTooltip: () => TooltipController.forceUpdate(),
+        forceUpdateTooltip: () => DeprecatedTooltipController.forceUpdate(),
         // TODO showInputBox
         // TODO showMessage
     }

--- a/client/vscode/src/webview/search-panel/index.tsx
+++ b/client/vscode/src/webview/search-panel/index.tsx
@@ -16,7 +16,7 @@ import {
     WildcardThemeContext,
     // This is the root Tooltip usage
     // eslint-disable-next-line no-restricted-imports
-    Tooltip,
+    DeprecatedTooltip,
 } from '@sourcegraph/wildcard'
 
 import { ExtensionCoreAPI } from '../../contract'
@@ -124,7 +124,7 @@ render(
             <MemoryRouter>
                 <Main />
             </MemoryRouter>
-            <Tooltip key={1} className="sourcegraph-tooltip" />
+            <DeprecatedTooltip key={1} className="sourcegraph-tooltip" />
         </WildcardThemeContext.Provider>
     </ShortcutProvider>,
     document.querySelector('#root')

--- a/client/vscode/src/webview/sidebars/search/index.tsx
+++ b/client/vscode/src/webview/sidebars/search/index.tsx
@@ -10,8 +10,14 @@ import { useDeepCompareEffectNoCheck } from 'use-deep-compare-effect'
 
 import { wrapRemoteObservable } from '@sourcegraph/shared/src/api/client/api/common'
 import { Filter } from '@sourcegraph/shared/src/search/stream'
-// eslint-disable-next-line no-restricted-imports
-import { AnchorLink, setLinkComponent, useObservable, WildcardThemeContext, Tooltip } from '@sourcegraph/wildcard'
+import {
+    AnchorLink,
+    setLinkComponent,
+    useObservable,
+    WildcardThemeContext,
+    // eslint-disable-next-line no-restricted-imports
+    DeprecatedTooltip,
+} from '@sourcegraph/wildcard'
 
 import { ExtensionCoreAPI } from '../../../contract'
 import { createEndpointsForWebToNode } from '../../comlink/webviewEndpoint'
@@ -123,7 +129,7 @@ render(
     <ShortcutProvider>
         <WildcardThemeContext.Provider value={{ isBranded: true }}>
             <Main />
-            <Tooltip key={1} className="sourcegraph-tooltip" />
+            <DeprecatedTooltip key={1} className="sourcegraph-tooltip" />
         </WildcardThemeContext.Provider>
     </ShortcutProvider>,
     document.querySelector('#root')

--- a/tsconfig.all.json
+++ b/tsconfig.all.json
@@ -24,5 +24,7 @@
     { "path": "schema" },
     { "path": "client/codeintellify" },
     { "path": "client/client-api" },
+    { "path": "client/vscode" },
+    { "path": "client/jetbrains" },
   ],
 }


### PR DESCRIPTION
## Description

See these failures: https://buildkite.com/sourcegraph/sourcegraph/builds/152214#0181365a-7dbc-4223-8eb8-df405a79a9a2/150-258

Worried that something seems wrong in our CI setup, as these TS errors should block merging

## Test plan

N/A - Fixing CI builds

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-tr-fix-tooltip-ts-build.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-bqdpugffni.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
