### PR TITLE
Janitor fixes

### DIFF
--- a/cmd/gitserver/server/cleanup.go
+++ b/cmd/gitserver/server/cleanup.go
@@ -116,8 +116,9 @@ var (
 		Help: "whether git prune was a success (true/false) and whether it was skipped (true/false)",
 	}, []string{"success", "skipped"})
 	janitorTimer = promauto.NewHistogram(prometheus.HistogramOpts{
-		Name: "src_gitserver_janitor_duration_seconds",
-		Help: "Duration of gitserver janitor background job",
+		Name:    "src_gitserver_janitor_duration_seconds",
+		Help:    "Duration of gitserver janitor background job",
+		Buckets: []float64{0.1, 1, 10, 60, 300, 3600, 7200},
 	})
 )
 

--- a/cmd/gitserver/server/cleanup.go
+++ b/cmd/gitserver/server/cleanup.go
@@ -187,7 +187,7 @@ func (s *Server) cleanupRepos(gitServerAddrs []string) {
 			wrongShardRepoSize += size
 			if wrongShardReposDeleteLimit > 0 && wrongShardReposDeleted < int64(wrongShardReposDeleteLimit) {
 				if _, ok := gitServerAddressSet[s.Hostname]; !ok {
-					s.Logger.Warn("current shard is not included in the list of known gitserver shards, skipping", log.String("dir", string(dir)), log.String("current-shard", addr), log.Strings("all-shards", gitServerAddrs))
+					s.Logger.Warn("current shard is not included in the list of known gitserver shards, skipping", log.String("dir", string(dir)), log.String("current-hostname", s.Hostname), log.String("target-shard", addr), log.Strings("all-shards", gitServerAddrs))
 					return false, nil
 				}
 				s.Logger.Info("removing repo cloned on the wrong shard", log.String("dir", string(dir)), log.String("target-shard", addr), log.String("current-shard", s.Hostname), log.Int64("size-bytes", size))


### PR DESCRIPTION
In prod, hostname of a gitserver is not directly included in the list of known gitserver addresses ([evidence](https://console.cloud.google.com/logs/query;cursorTimestamp=2022-06-06T14:12:15.272126589Z;query=resource.type%3D%22k8s_container%22%0Aresource.labels.project_id%3D%22sourcegraph-dev%22%0Aresource.labels.location%3D%22us-central1-f%22%0Aresource.labels.cluster_name%3D%22cloud%22%0Aresource.labels.namespace_name%3D%22prod%22%0Alabels.k8s-pod%2Fapp%3D%22gitserver%22%20severity%3E%3DDEFAULT%0Atimestamp%3D%222022-06-06T14:12:15.272126589Z%22%0AinsertId%3D%22982t0zqltz9c9bmw%22?project=sourcegraph-dev))- extend logging to find out how to construct a list that will allow for cheap "set membership" checks.

Also change janitor run duration buckets to capture times >10s.
## Test plan

- Modifies logging and metric collection, tested locally
