### PR TITLE
cmd/gitserver: Initialise logger for vcsDependenciesSyncer

### DIFF
--- a/cmd/gitserver/server/vcs_syncer_go_modules.go
+++ b/cmd/gitserver/server/vcs_syncer_go_modules.go
@@ -31,7 +31,7 @@ func NewGoModulesSyncer(
 	}
 
 	return &vcsDependenciesSyncer{
-		logger:      log.Scoped("vcs syncer", "csDependenciesSyncer implements the VCSSyncer interface for dependency repos"),
+		logger:      log.Scoped("vcs syncer", "vcsDependenciesSyncer implements the VCSSyncer interface for dependency repos"),
 		typ:         "go_modules",
 		scheme:      dependencies.GoModulesScheme,
 		placeholder: placeholder,

--- a/cmd/gitserver/server/vcs_syncer_jvm_packages.go
+++ b/cmd/gitserver/server/vcs_syncer_jvm_packages.go
@@ -44,7 +44,7 @@ func NewJVMPackagesSyncer(connection *schema.JVMPackagesConnection, svc *depende
 	}
 
 	return &vcsDependenciesSyncer{
-		logger:      log.Scoped("vcs syncer", "csDependenciesSyncer implements the VCSSyncer interface for dependency repos"),
+		logger:      log.Scoped("vcs syncer", "vcsDependenciesSyncer implements the VCSSyncer interface for dependency repos"),
 		typ:         "jvm_packages",
 		scheme:      dependencies.JVMPackagesScheme,
 		placeholder: placeholder,

--- a/cmd/gitserver/server/vcs_syncer_npm_packages.go
+++ b/cmd/gitserver/server/vcs_syncer_npm_packages.go
@@ -30,7 +30,7 @@ func NewNpmPackagesSyncer(
 	}
 
 	return &vcsDependenciesSyncer{
-		logger:      log.Scoped("vcs syncer", "csDependenciesSyncer implements the VCSSyncer interface for dependency repos"),
+		logger:      log.Scoped("vcs syncer", "vcsDependenciesSyncer implements the VCSSyncer interface for dependency repos"),
 		typ:         "npm_packages",
 		scheme:      dependencies.NpmPackagesScheme,
 		placeholder: placeholder,

--- a/cmd/gitserver/server/vcs_syncer_python_packages.go
+++ b/cmd/gitserver/server/vcs_syncer_python_packages.go
@@ -35,7 +35,7 @@ func NewPythonPackagesSyncer(
 	placeholder := assertPythonParsesPlaceholder()
 
 	return &vcsDependenciesSyncer{
-		logger:      log.Scoped("vcs syncer", "csDependenciesSyncer implements the VCSSyncer interface for dependency repos"),
+		logger:      log.Scoped("vcs syncer", "vcsDependenciesSyncer implements the VCSSyncer interface for dependency repos"),
 		typ:         "python_packages",
 		scheme:      dependencies.PythonPackagesScheme,
 		placeholder: placeholder,

--- a/cmd/gitserver/server/vcs_syncer_rust_packages.go
+++ b/cmd/gitserver/server/vcs_syncer_rust_packages.go
@@ -12,6 +12,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/conf/reposource"
 	"github.com/sourcegraph/sourcegraph/internal/unpack"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"github.com/sourcegraph/sourcegraph/lib/log"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
@@ -32,6 +33,7 @@ func NewRustPackagesSyncer(
 	placeholder := assertRustParsesPlaceholder()
 
 	return &vcsDependenciesSyncer{
+		logger:      log.Scoped("vcs syncer", "vcsDependenciesSyncer implements the VCSSyncer interface for dependency repos"),
 		typ:         "rust_packages",
 		scheme:      dependencies.RustPackagesScheme,
 		placeholder: placeholder,


### PR DESCRIPTION
This is causing a panic because of a nil logger.

Also fixed a typo in the logger's description.

Error seen here: https://console.cloud.google.com/errors/detail/CJHhhqOpysjPVQ;time=P30D?project=sourcegraph-dev

Full error log:

```
runtime error: invalid memory address or nil pointer dereference [signal SIGSEGV: segmentation violation code=0x1 addr=0x50 pc=0x11dd51c]
at github.com/sourcegraph/sourcegraph/cmd/gitserver/server.(*vcsDependenciesSyncer).Fetch ( [github.com/sourcegraph/sourcegraph/cmd/gitserver/server/vcs_dependencies_syncer.go:110](https://console.cloud.google.com/debug?referrer=fromlog&file=github.com%2Fsourcegraph%2Fsourcegraph%2Fcmd%2Fgitserver%2Fserver%2Fvcs_dependencies_syncer.go&line=110&project=sourcegraph-dev) )
at github.com/sourcegraph/sourcegraph/cmd/gitserver/server.(*vcsDependenciesSyncer).CloneCommand ( [github.com/sourcegraph/sourcegraph/cmd/gitserver/server/vcs_dependencies_syncer.go:82](https://console.cloud.google.com/debug?referrer=fromlog&file=github.com%2Fsourcegraph%2Fsourcegraph%2Fcmd%2Fgitserver%2Fserver%2Fvcs_dependencies_syncer.go&line=82&project=sourcegraph-dev) )
at github.com/sourcegraph/sourcegraph/cmd/gitserver/server.(*Server).doClone ( [github.com/sourcegraph/sourcegraph/cmd/gitserver/server/server.go:2016](https://console.cloud.google.com/debug?referrer=fromlog&file=github.com%2Fsourcegraph%2Fsourcegraph%2Fcmd%2Fgitserver%2Fserver%2Fserver.go&line=2016&project=sourcegraph-dev) )
at github.com/sourcegraph/sourcegraph/cmd/gitserver/server.(*Server).cloneJobConsumer.func1 ( [github.com/sourcegraph/sourcegraph/cmd/gitserver/server/server.go:507](https://console.cloud.google.com/debug?referrer=fromlog&file=github.com%2Fsourcegraph%2Fsourcegraph%2Fcmd%2Fgitserver%2Fserver%2Fserver.go&line=507&project=sourcegraph-dev) )
```


## Test plan

Existing tests should pass. 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
