### PR TITLE
Search backend: add tracing to SequentialJob

### DIFF
--- a/internal/search/job/jobutil/combinators.go
+++ b/internal/search/job/jobutil/combinators.go
@@ -43,10 +43,15 @@ func (s *SequentialJob) Name() string {
 }
 
 func (s *SequentialJob) Tags() []log.Field {
-	return []log.Field{}
+	return []log.Field{
+		log.Bool("ensureUnique", s.ensureUnique),
+	}
 }
 
 func (s *SequentialJob) Run(ctx context.Context, clients job.RuntimeClients, parentStream streaming.Sender) (alert *search.Alert, err error) {
+	_, ctx, parentStream, finish := job.StartSpan(ctx, parentStream, s)
+	defer func() { finish(alert, err) }()
+
 	var maxAlerter search.MaxAlerter
 	var errs errors.MultiError
 


### PR DESCRIPTION
This just adds trace hooks because it wasn't showing up in the traces, which was very confusing when trying to debug a perf regression.

## Test plan

Tested that it shows up in traces locally.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
