### PR TITLE
Code monitors: add --glob and --exclude to git rev-parse allowlist

### DIFF
--- a/internal/gitserver/gitdomain/exec.go
+++ b/internal/gitserver/gitdomain/exec.go
@@ -17,7 +17,7 @@ var (
 		"blame":  {"--root", "--incremental", "-w", "-p", "--porcelain", "--"},
 		"branch": {"-r", "-a", "--contains", "--merged", "--format"},
 
-		"rev-parse":    {"--abbrev-ref", "--symbolic-full-name"},
+		"rev-parse":    {"--abbrev-ref", "--symbolic-full-name", "--glob", "--exclude"},
 		"rev-list":     {"--first-parent", "--max-parents", "--reverse", "--max-count", "--count", "--after", "--before", "--", "-n", "--date-order", "--skip", "--left-right"},
 		"ls-remote":    {"--get-url"},
 		"symbolic-ref": {"--short"},

--- a/internal/gitserver/gitdomain/exec_test.go
+++ b/internal/gitserver/gitdomain/exec_test.go
@@ -1,0 +1,26 @@
+package gitdomain
+
+import (
+	"testing"
+
+	"github.com/sourcegraph/sourcegraph/lib/log/logtest"
+)
+
+func TestIsAllowedGitCmd(t *testing.T) {
+	allowed := [][]string{
+		// Required for code monitors
+		{"rev-parse", "HEAD"},
+		{"rev-parse", "83838383"},
+		{"rev-parse", "--glob=refs/heads/*"},
+		{"rev-parse", "--glob=refs/heads/*", "--exclude=refs/heads/cc/*"},
+	}
+
+	logger := logtest.Scoped(t)
+	for _, args := range allowed {
+		t.Run("", func(t *testing.T) {
+			if !IsAllowedGitCmd(logger, args) {
+				t.Fatalf("expected args to be allowed: %q", args)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This adds --glob and --exclude to the allowlist for git rev-parse
arguments. Their absence was causing failures when we'd attempt to
create a code monitor that tracks a globbed set of branches.

Fixes #https://github.com/sourcegraph/sourcegraph/issues/36661

## Test plan

Manually tested that creating a monitor locally works now and does not error. 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
