### PR TITLE
batches: disable chromatic snapshot checking for `ExecutionWorkspaces`

### DIFF
--- a/client/web/src/enterprise/batches/batch-spec/execute/workspaces/ExecutionWorkspaces.story.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/execute/workspaces/ExecutionWorkspaces.story.tsx
@@ -20,17 +20,11 @@ import { BATCH_SPEC_WORKSPACES, BATCH_SPEC_WORKSPACE_BY_ID, FETCH_BATCH_SPEC_EXE
 
 import { ExecutionWorkspaces } from './ExecutionWorkspaces'
 
-const { add } = storiesOf('web/batches/batch-spec/execute/ExecutionWorkspaces', module)
-    .addDecorator(story => (
-        <div className="p-3 d-flex" style={{ height: '95vh', width: '100%' }}>
-            {story()}
-        </div>
-    ))
-    .addParameters({
-        chromatic: {
-            disableSnapshot: false,
-        },
-    })
+const { add } = storiesOf('web/batches/batch-spec/execute/ExecutionWorkspaces', module).addDecorator(story => (
+    <div className="p-3 d-flex" style={{ height: '95vh', width: '100%' }}>
+        {story()}
+    </div>
+))
 
 const MOCKS = new WildcardMockLink([
     {


### PR DESCRIPTION
This storybook story was not intended to be checked by Chromatic and was [causing flakes](https://github.com/sourcegraph/sourcegraph/pull/36390/commits/475243a291f2ef60377c792a01c6da0711a4723d) as a result. While Adam fixed the flakes by providing more mock query data (🙇‍♀️), I still wanted to disable the snapshots. I considered reverting the mock query changes since they aren't integral to the story, but they're fairly unintrusive and harmless, and the storybook stories probably look better with them anyway. 🙂


## Test plan

Just changes the Chromatic configuration for a component storybook story.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-kr-disable-snapshots-on-stories.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-crjswdxxdx.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
