### PR TITLE
Update team notified by team/delivery label

### DIFF
--- a/.github/workflows/label-notify.yml
+++ b/.github/workflows/label-notify.yml
@@ -18,8 +18,7 @@ jobs:
                   team/search-product=@benvenker @lguychard
                   team/search-core=@sourcegraph/search-core
                   team/code-insights=@joelkw @felixfbecker @vovakulikov @unclejustin
-                  team/distribution=@dan-mckean
-                  team/delivery=@caugustus-sourcegraph @kevinwojo @michaellzc
+                  team/delivery=@sourcegraph/delivery
                   team/security=@dcomas
                   team/dev-experience=@jhchabran @kstretch9
                   team/frontend-platform=@taylorsperry @jasongornall


### PR DESCRIPTION
Also remove distribution team since it no longer exists

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
Test that Delivery is still notified about issues tagged with team/delivery