### PR TITLE
Revert "lib/output: add WriteBytes convenience function"

### DIFF
--- a/lib/output/output.go
+++ b/lib/output/output.go
@@ -176,11 +176,6 @@ func (o *Output) WriteLine(line FancyLine) {
 	line.write(o.w, o.caps)
 }
 
-// WriteBytes writes bytes as a string line. It can be provided to run.Cmd(...).StreamLines()
-func (o *Output) WriteBytes(b []byte) {
-	o.Write(string(b))
-}
-
 // Block starts a new block context. This should not be invoked if there is an
 // active Pending or Progress context.
 func (o *Output) Block(summary FancyLine) *Block {


### PR DESCRIPTION
Reverts sourcegraph/sourcegraph#36594, in favour of https://github.com/sourcegraph/run/pull/41

Test plan: N/A, unused function