### PR TITLE
Fix small styling issues on workspace page

### DIFF
--- a/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspaceDetails.module.scss
+++ b/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspaceDetails.module.scss
@@ -71,9 +71,17 @@
 }
 
 .step-diff-stat {
-    border-right: 1px solid var(--border-color);
     padding: 0 0.5rem;
     margin: 0 0.5rem;
+
+    &:not(:last-child) {
+        border-right: 1px solid var(--border-color);
+    }
+
+    &:last-child {
+        padding-right: 0;
+        margin-right: 0;
+    }
 
     strong {
         line-height: 1rem;

--- a/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspaceDetails.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspaceDetails.tsx
@@ -119,7 +119,11 @@ const WorkspaceHeader: React.FunctionComponent<React.PropsWithChildren<Workspace
     <>
         <div className="d-flex align-items-center justify-content-between mb-2">
             <H3 className={styles.workspaceName}>
-                <WorkspaceStateIcon cachedResultFound={workspace.cachedResultFound} state={workspace.state} />{' '}
+                <WorkspaceStateIcon
+                    cachedResultFound={workspace.cachedResultFound}
+                    state={workspace.state}
+                    className="flex-shrink-0"
+                />{' '}
                 {workspace.__typename === 'VisibleBatchSpecWorkspace'
                     ? workspace.repository.name
                     : 'Workspace in hidden repository'}

--- a/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspaceDetails.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspaceDetails.tsx
@@ -18,6 +18,7 @@ import TimerSandIcon from 'mdi-react/TimerSandIcon'
 import { useHistory } from 'react-router'
 
 import { ErrorAlert } from '@sourcegraph/branded/src/components/alerts'
+import { Maybe } from '@sourcegraph/shared/src/graphql-operations'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
 import {
     Badge,
@@ -494,9 +495,11 @@ const WorkspaceStep: React.FunctionComponent<React.PropsWithChildren<WorkspaceSt
                     {step.diffStat && (
                         <DiffStat className={styles.stepDiffStat} {...step.diffStat} expandedCounts={true} />
                     )}
-                    <span className={classNames('text-monospace text-muted', styles.stepTime)}>
-                        <StepTimer step={step} />
-                    </span>
+                    {step.startedAt && (
+                        <span className={classNames('text-monospace text-muted', styles.stepTime)}>
+                            <StepTimer startedAt={step.startedAt} finishedAt={step.finishedAt} />
+                        </span>
+                    )}
                 </>
             }
         >
@@ -589,7 +592,7 @@ const StepStateIcon: React.FunctionComponent<React.PropsWithChildren<StepStateIc
         return (
             <Icon
                 role="img"
-                className="text-success"
+                className="text-success flex-shrink-0"
                 aria-label="A cached result for this step has been found"
                 data-tooltip="A cached result for this step has been found"
                 as={ContentSaveIcon}
@@ -600,7 +603,7 @@ const StepStateIcon: React.FunctionComponent<React.PropsWithChildren<StepStateIc
         return (
             <Icon
                 role="img"
-                className="text-muted"
+                className="text-muted flex-shrink-0"
                 aria-label="The step has been skipped"
                 data-tooltip="The step has been skipped"
                 as={LinkVariantRemoveIcon}
@@ -611,7 +614,7 @@ const StepStateIcon: React.FunctionComponent<React.PropsWithChildren<StepStateIc
         return (
             <Icon
                 role="img"
-                className="text-muted"
+                className="text-muted flex-shrink-0"
                 aria-label="This step is waiting to be processed"
                 data-tooltip="This step is waiting to be processed"
                 as={TimerSandIcon}
@@ -622,7 +625,7 @@ const StepStateIcon: React.FunctionComponent<React.PropsWithChildren<StepStateIc
         return (
             <Icon
                 role="img"
-                className="text-muted"
+                className="text-muted flex-shrink-0"
                 aria-label="This step is currently running"
                 data-tooltip="This step is currently running"
                 as={LoadingSpinner}
@@ -633,7 +636,7 @@ const StepStateIcon: React.FunctionComponent<React.PropsWithChildren<StepStateIc
         return (
             <Icon
                 role="img"
-                className="text-success"
+                className="text-success flex-shrink-0"
                 aria-label="This step ran successfully"
                 data-tooltip="This step ran successfully"
                 as={CheckBoldIcon}
@@ -643,7 +646,7 @@ const StepStateIcon: React.FunctionComponent<React.PropsWithChildren<StepStateIc
     return (
         <Icon
             role="img"
-            className="text-danger"
+            className="text-danger flex-shrink-0"
             aria-label={`This step failed with exit code ${String(step.exitCode)}`}
             data-tooltip={`This step failed with exit code ${String(step.exitCode)}`}
             as={AlertCircleIcon}
@@ -651,14 +654,10 @@ const StepStateIcon: React.FunctionComponent<React.PropsWithChildren<StepStateIc
     )
 }
 
-const StepTimer: React.FunctionComponent<React.PropsWithChildren<{ step: BatchSpecWorkspaceStepFields }>> = ({
-    step,
-}) => {
-    if (!step.startedAt) {
-        return null
-    }
-    return <Duration start={step.startedAt} end={step.finishedAt ?? undefined} />
-}
+const StepTimer: React.FunctionComponent<React.PropsWithChildren<{ startedAt: string; finishedAt: Maybe<string> }>> = ({
+    startedAt,
+    finishedAt,
+}) => <Duration start={startedAt} end={finishedAt ?? undefined} />
 
 interface WorkspaceStepFileDiffConnectionProps extends ThemeProps {
     workspaceID: Scalars['ID']

--- a/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspaceStateIcon.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspaceStateIcon.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 
+import classNames from 'classnames'
 import AlertCircleIcon from 'mdi-react/AlertCircleIcon'
 import CancelIcon from 'mdi-react/CancelIcon'
 import CheckBoldIcon from 'mdi-react/CheckBoldIcon'
@@ -14,11 +15,13 @@ import { BatchSpecWorkspaceState } from '../../../../../graphql-operations'
 export interface WorkspaceStateIconProps {
     state: BatchSpecWorkspaceState
     cachedResultFound: boolean
+    className?: string
 }
 
 export const WorkspaceStateIcon: React.FunctionComponent<React.PropsWithChildren<WorkspaceStateIconProps>> = ({
     state,
     cachedResultFound,
+    className,
 }) => {
     switch (state) {
         case BatchSpecWorkspaceState.PENDING:
@@ -27,7 +30,7 @@ export const WorkspaceStateIcon: React.FunctionComponent<React.PropsWithChildren
             return (
                 <Icon
                     role="img"
-                    className="text-muted"
+                    className={classNames('text-muted', className)}
                     data-tooltip="This workspace is queued for execution."
                     aria-label="This workspace is queued for execution."
                     as={TimerSandIcon}
@@ -37,7 +40,7 @@ export const WorkspaceStateIcon: React.FunctionComponent<React.PropsWithChildren
             return (
                 <Icon
                     role="img"
-                    className="text-muted"
+                    className={classNames('text-muted', className)}
                     data-tooltip="This workspace is currently executing."
                     aria-label="This workspace is currently executing."
                     as={LoadingSpinner}
@@ -47,7 +50,7 @@ export const WorkspaceStateIcon: React.FunctionComponent<React.PropsWithChildren
             return (
                 <Icon
                     role="img"
-                    className="text-muted"
+                    className={classNames('text-muted', className)}
                     data-tooltip="This workspace was skipped."
                     aria-label="This workspace was skipped."
                     as={LinkVariantRemoveIcon}
@@ -57,7 +60,7 @@ export const WorkspaceStateIcon: React.FunctionComponent<React.PropsWithChildren
             return (
                 <Icon
                     role="img"
-                    className="text-muted"
+                    className={classNames('text-muted', className)}
                     data-tooltip="The execution for this workspace was canceled."
                     aria-label="The execution for this workspace was canceled."
                     as={CancelIcon}
@@ -67,7 +70,7 @@ export const WorkspaceStateIcon: React.FunctionComponent<React.PropsWithChildren
             return (
                 <Icon
                     role="img"
-                    className="text-muted"
+                    className={classNames('text-muted', className)}
                     data-tooltip="The execution for this workspace is being canceled."
                     aria-label="The execution for this workspace is being canceled."
                     as={CancelIcon}


### PR DESCRIPTION
- Fixes a stray border right of the diff stat when no timer is shown
- Aligns the diff stats properly
- Fixes the icons shrinking on smaller screens

Closes https://github.com/sourcegraph/sourcegraph/issues/36613

## Test plan

Verified manually the expected changes did happen.

## App preview:

- [Web](https://sg-web-es-fix-style-workspace-details.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-wvjoarguuq.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
