### PR TITLE
Revert gologin version change

### DIFF
--- a/enterprise/cmd/frontend/internal/auth/githuboauth/config.go
+++ b/enterprise/cmd/frontend/internal/auth/githuboauth/config.go
@@ -1,7 +1,7 @@
 package githuboauth
 
 import (
-	"github.com/dghubble/gologin/v2"
+	"github.com/dghubble/gologin"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/auth/providers"
 	"github.com/sourcegraph/sourcegraph/internal/conf"

--- a/enterprise/cmd/frontend/internal/auth/githuboauth/middleware_test.go
+++ b/enterprise/cmd/frontend/internal/auth/githuboauth/middleware_test.go
@@ -24,7 +24,7 @@ import (
 // TestMiddleware exercises the Middleware with requests that simulate the OAuth 2 login flow on
 // GitHub. This tests the logic between the client-issued HTTP requests and the responses from the
 // various endpoints, but does NOT cover the logic that is contained within `golang.org/x/oauth2`
-// and `github.com/dghubble/gologin/v2` which ensures the correctness of the `/callback` handler.
+// and `github.com/dghubble/gologin` which ensures the correctness of the `/callback` handler.
 func TestMiddleware(t *testing.T) {
 	cleanup := session.ResetMockSessionStore(t)
 	defer cleanup()

--- a/enterprise/cmd/frontend/internal/auth/githuboauth/provider.go
+++ b/enterprise/cmd/frontend/internal/auth/githuboauth/provider.go
@@ -5,9 +5,9 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/dghubble/gologin/v2"
-	"github.com/dghubble/gologin/v2/github"
-	goauth2 "github.com/dghubble/gologin/v2/oauth2"
+	"github.com/dghubble/gologin"
+	"github.com/dghubble/gologin/github"
+	goauth2 "github.com/dghubble/gologin/oauth2"
 	"github.com/inconshreveable/log15"
 	"golang.org/x/oauth2"
 

--- a/enterprise/cmd/frontend/internal/auth/githuboauth/session.go
+++ b/enterprise/cmd/frontend/internal/auth/githuboauth/session.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/dghubble/gologin/v2/github"
+	"github.com/dghubble/gologin/github"
 	"github.com/inconshreveable/log15"
 	"golang.org/x/oauth2"
 

--- a/enterprise/cmd/frontend/internal/auth/githuboauth/session_test.go
+++ b/enterprise/cmd/frontend/internal/auth/githuboauth/session_test.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/davecgh/go-spew/spew"
-	githublogin "github.com/dghubble/gologin/v2/github"
+	githublogin "github.com/dghubble/gologin/github"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-github/github"
 	"github.com/stretchr/testify/assert"

--- a/enterprise/cmd/frontend/internal/auth/gitlaboauth/login.go
+++ b/enterprise/cmd/frontend/internal/auth/gitlaboauth/login.go
@@ -4,8 +4,8 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/dghubble/gologin/v2"
-	oauth2Login "github.com/dghubble/gologin/v2/oauth2"
+	"github.com/dghubble/gologin"
+	oauth2Login "github.com/dghubble/gologin/oauth2"
 	"golang.org/x/oauth2"
 
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"

--- a/enterprise/cmd/frontend/internal/auth/gitlaboauth/middleware_test.go
+++ b/enterprise/cmd/frontend/internal/auth/gitlaboauth/middleware_test.go
@@ -25,7 +25,7 @@ import (
 // TestMiddleware exercises the Middleware with requests that simulate the OAuth 2 login flow on
 // GitLab. This tests the logic between the client-issued HTTP requests and the responses from the
 // various endpoints, but does NOT cover the logic that is contained within `golang.org/x/oauth2`
-// and `github.com/dghubble/gologin/v2` which ensures the correctness of the `/callback` handler.
+// and `github.com/dghubble/gologin` which ensures the correctness of the `/callback` handler.
 func TestMiddleware(t *testing.T) {
 	cleanup := session.ResetMockSessionStore(t)
 	defer cleanup()

--- a/enterprise/cmd/frontend/internal/auth/gitlaboauth/provider.go
+++ b/enterprise/cmd/frontend/internal/auth/gitlaboauth/provider.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/dghubble/gologin/v2"
+	"github.com/dghubble/gologin"
 	"golang.org/x/oauth2"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/auth/oauth"

--- a/enterprise/cmd/frontend/internal/auth/oauth/cookie.go
+++ b/enterprise/cmd/frontend/internal/auth/oauth/cookie.go
@@ -4,11 +4,11 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/dghubble/gologin/v2"
+	"github.com/dghubble/gologin"
 )
 
 /*
-This code is copied from https://sourcegraph.com/github.com/dghubble/gologin/v2/-/blob/internal/cookie.go
+This code is copied from https://sourcegraph.com/github.com/dghubble/gologin/-/blob/internal/cookie.go
 */
 
 // NewCookie returns a new http.Cookie with the given value and CookieConfig

--- a/enterprise/cmd/frontend/internal/auth/oauth/provider.go
+++ b/enterprise/cmd/frontend/internal/auth/oauth/provider.go
@@ -9,8 +9,8 @@ import (
 	"net/url"
 	"path"
 
-	"github.com/dghubble/gologin/v2"
-	goauth2 "github.com/dghubble/gologin/v2/oauth2"
+	"github.com/dghubble/gologin"
+	goauth2 "github.com/dghubble/gologin/oauth2"
 	"github.com/inconshreveable/log15"
 	"golang.org/x/oauth2"
 

--- a/enterprise/cmd/frontend/internal/auth/oauth/session.go
+++ b/enterprise/cmd/frontend/internal/auth/oauth/session.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"time"
 
-	goauth2 "github.com/dghubble/gologin/v2/oauth2"
+	goauth2 "github.com/dghubble/gologin/oauth2"
 	"github.com/inconshreveable/log15"
 	"golang.org/x/oauth2"
 

--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/daviddengcn/go-colortext v1.0.0
 	github.com/derision-test/glock v1.0.0
 	github.com/derision-test/go-mockgen v1.2.0
-	github.com/dghubble/gologin/v2 v2.3.0
+	github.com/dghubble/gologin v2.2.0+incompatible
 	github.com/dgraph-io/ristretto v0.1.0
 	github.com/dineshappavoo/basex v0.0.0-20170425072625-481a6f6dc663
 	github.com/distribution/distribution/v3 v3.0.0-20220128175647-b60926597a1b
@@ -445,6 +445,7 @@ replace (
 // =================================
 // These entries indicate replace directives that are defined for unknown reasons.
 replace (
+	github.com/dghubble/gologin => github.com/sourcegraph/gologin v1.0.2-0.20181110030308-c6f1b62954d8
 	github.com/golang/lint => golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f
 	github.com/mattn/goreman => github.com/sourcegraph/goreman v0.1.2-0.20180928223752-6e9a2beb830d
 	github.com/russellhaering/gosaml2 => github.com/sourcegraph/gosaml2 v0.6.1-0.20210128133756-84151d087b10

--- a/go.sum
+++ b/go.sum
@@ -410,7 +410,6 @@ github.com/caarlos0/ctrlc v1.0.0/go.mod h1:CdXpj4rmq0q/1Eb44M9zi2nKB0QraNKuRGYGr
 github.com/campoy/unique v0.0.0-20180121183637-88950e537e7e/go.mod h1:9IOqJGCPMSc6E5ydlp5NIonxObaeu/Iub/X03EKPVYo=
 github.com/cavaliercoder/go-cpio v0.0.0-20180626203310-925f9528c45e/go.mod h1:oDpT4efm8tSYHXV5tHSdRvBet/b/QzxZ+XyyPehvm3A=
 github.com/cenkalti/backoff v1.1.1-0.20171020064038-309aa717adbf/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
-github.com/cenkalti/backoff v2.1.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/cenkalti/backoff/v4 v4.1.1/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
@@ -629,11 +628,6 @@ github.com/derision-test/glock v1.0.0/go.mod h1:jKtLdBMrF+XQatqvg46wiWdDfDSSDjdh
 github.com/derision-test/go-mockgen v1.2.0 h1:SCF7p4FuO6IZId3CMjSHH9K0SMDVXNz7jc3AOeJaBd8=
 github.com/derision-test/go-mockgen v1.2.0/go.mod h1:/TXUePlhtHmDDCaDAi/a4g6xOHqMDz3Wf0r2NPGskB4=
 github.com/devigned/tab v0.1.1/go.mod h1:XG9mPq0dFghrYvoBF3xdRrJzSTX1b7IQrvaL9mzjeJY=
-github.com/dghubble/go-twitter v0.0.0-20190719072343-39e5462e111f/go.mod h1:xfg4uS5LEzOj8PgZV7SQYRHbG7jPUnelEiaAVJxmhJE=
-github.com/dghubble/gologin/v2 v2.3.0 h1:SMHahscgKmgrv4X+OAwFCJCuJ6mbLxOqB+FAVU+tOSA=
-github.com/dghubble/gologin/v2 v2.3.0/go.mod h1:qGAUHuIYV0WP3kwoPjLhG+YIlGqy8O13YjItosCBKdo=
-github.com/dghubble/oauth1 v0.6.0/go.mod h1:8pFdfPkv/jr8mkChVbNVuJ0suiHe278BtWI4Tk1ujxk=
-github.com/dghubble/sling v1.3.0/go.mod h1:XXShWaBWKzNLhu2OxikSNFrlsvowtz4kyRuXUG7oQKY=
 github.com/dgraph-io/badger v1.6.0/go.mod h1:zwt7syl517jmP8s94KqSxTlM6IMsdhYy6psNgSztDR4=
 github.com/dgraph-io/ristretto v0.1.0 h1:Jv3CGQHp9OjuMBSne1485aDpUkTKEcUqF+jm/LuerPI=
 github.com/dgraph-io/ristretto v0.1.0/go.mod h1:fux0lOrBhrVCJd3lcTHsIJhq1T2rokOu6v9Vcb3Q9ug=
@@ -2159,6 +2153,8 @@ github.com/sourcegraph/go-lsp v0.0.0-20200429204803-219e11d77f5d h1:afLbh+ltiygT
 github.com/sourcegraph/go-lsp v0.0.0-20200429204803-219e11d77f5d/go.mod h1:SULmZY7YNBsvNiQbrb/BEDdEJ84TGnfyUQxaHt8t8rY=
 github.com/sourcegraph/go-rendezvous v0.0.0-20210910070954-ef39ade5591d h1:uBLhh66Nf4BcRnvCkMVEuYZ/bQ9ok0rOlEJhfVUpJj4=
 github.com/sourcegraph/go-rendezvous v0.0.0-20210910070954-ef39ade5591d/go.mod h1:IhIP+gIbf0TKVMjcEEwUBjomZRjrPnlZbzT2Wac7XA0=
+github.com/sourcegraph/gologin v1.0.2-0.20181110030308-c6f1b62954d8 h1:K7hzuWsJGoU8ILHJzrXxsuvXvLHpP/g4iUk7VFj2lY8=
+github.com/sourcegraph/gologin v1.0.2-0.20181110030308-c6f1b62954d8/go.mod h1:0VfoEApmSPgPhnePllwhrB4vwCUkI0K0w8aueOgoJQI=
 github.com/sourcegraph/gosaml2 v0.6.1-0.20210128133756-84151d087b10 h1:lLSG41QZ5I81jSOakWLB1qEXZhJ65spo81f4SEd8Z20=
 github.com/sourcegraph/gosaml2 v0.6.1-0.20210128133756-84151d087b10/go.mod h1:CAOGXqoL6YYtu7kCSx69SZlbNZWbwUchYzOacZatJ3s=
 github.com/sourcegraph/httpgzip v0.0.0-20211015085752-0bad89b3b4df h1:VaS8k40GiNVUxVx0ZUilU38NU6tWUHNQOX342DWtZUM=


### PR DESCRIPTION
Resolves: https://github.com/sourcegraph/customer/issues/1005

@mollylogue and I found that the following commits: https://github.com/sourcegraph/sourcegraph/commit/e92627d195d07a9286c1ab2218d77a07d8a3865a, https://github.com/sourcegraph/sourcegraph/commit/865d0efe71a4424998a76c4b6f6812d6803697df, have unintentionally caused issues when trying to use OAuth login with a Github code host.

This PR seeks to unblock customers by reverting the change to the gologin library that is causing the OAuth issues we are seeing in the issue linked above. We would address re-updating the gologin library to a more current version in a separate issue.

## Test plan
Previous to this change, testing locally had a broken OAuth flow (identical to the linked issue), post fix the OAuth flow behaves as expected.