### PR TITLE
Add indicator for step cache results in preview

### DIFF
--- a/client/web/src/enterprise/batches/batch-spec/batch-spec.mock.ts
+++ b/client/web/src/enterprise/batches/batch-spec/batch-spec.mock.ts
@@ -197,6 +197,7 @@ export const mockPreviewWorkspace = (
     path: '/',
     searchResultPaths: ['/first-path'],
     cachedResultFound: false,
+    stepCacheResultCount: 0,
     ignored: false,
     unsupported: false,
     ...fields,

--- a/client/web/src/enterprise/batches/batch-spec/edit/workspaces-preview/WorkspacesPreviewListItem.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/edit/workspaces-preview/WorkspacesPreviewListItem.tsx
@@ -8,7 +8,7 @@ import {
     PreviewHiddenBatchSpecWorkspaceFields,
     PreviewVisibleBatchSpecWorkspaceFields,
 } from '../../../../../graphql-operations'
-import { CachedIcon, Descriptor, ExcludeIcon, ListItem } from '../../../workspaces-list'
+import { CachedIcon, Descriptor, ExcludeIcon, ListItem, PartiallyCachedIcon } from '../../../workspaces-list'
 
 import styles from './WorkspacesPreviewListItem.module.scss'
 
@@ -35,10 +35,18 @@ export const WorkspacesPreviewListItem: React.FunctionComponent<
         exclude(workspace.repository.name, workspace.branch.displayName)
     }, [exclude, workspace])
 
-    const statusIndicator = useMemo(
-        () => (toBeExcluded ? <ExcludeIcon /> : workspace.cachedResultFound ? <CachedIcon /> : undefined),
-        [toBeExcluded, workspace.cachedResultFound]
-    )
+    const statusIndicator = useMemo(() => {
+        if (toBeExcluded) {
+            return <ExcludeIcon />
+        }
+        if (workspace.cachedResultFound) {
+            return <CachedIcon />
+        }
+        if (workspace.stepCacheResultCount > 0) {
+            return <PartiallyCachedIcon count={workspace.stepCacheResultCount} />
+        }
+        return undefined
+    }, [toBeExcluded, workspace.cachedResultFound, workspace.stepCacheResultCount])
 
     return (
         <ListItem className={!isReadOnly && isStale ? styles.stale : undefined}>

--- a/client/web/src/enterprise/batches/create/backend.ts
+++ b/client/web/src/enterprise/batches/create/backend.ts
@@ -152,6 +152,7 @@ export const WORKSPACES = gql`
         ignored
         unsupported
         cachedResultFound
+        stepCacheResultCount
     }
 
     fragment PreviewVisibleBatchSpecWorkspaceFields on VisibleBatchSpecWorkspace {

--- a/client/web/src/enterprise/batches/workspaces-list/Icons.module.scss
+++ b/client/web/src/enterprise/batches/workspaces-list/Icons.module.scss
@@ -1,0 +1,3 @@
+.partially-cached-icon {
+    color: var(--text-muted);
+}

--- a/client/web/src/enterprise/batches/workspaces-list/Icons.tsx
+++ b/client/web/src/enterprise/batches/workspaces-list/Icons.tsx
@@ -3,7 +3,10 @@ import React from 'react'
 import ContentSaveIcon from 'mdi-react/ContentSaveIcon'
 import DeleteIcon from 'mdi-react/DeleteIcon'
 
+import { pluralize } from '@sourcegraph/common'
 import { Icon } from '@sourcegraph/wildcard'
+
+import styles from './Icons.module.scss'
 
 export const CachedIcon: React.FunctionComponent<React.PropsWithChildren<unknown>> = () => (
     <Icon
@@ -13,6 +16,19 @@ export const CachedIcon: React.FunctionComponent<React.PropsWithChildren<unknown
         as={ContentSaveIcon}
     />
 )
+
+export const PartiallyCachedIcon: React.FunctionComponent<React.PropsWithChildren<{ count: number }>> = ({ count }) => {
+    const label = `A partial cache result was found for ${count} ${pluralize('step', count)} in this workspace.`
+    return (
+        <Icon
+            role="img"
+            className={styles.partiallyCachedIcon}
+            data-tooltip={label}
+            aria-label={label}
+            as={ContentSaveIcon}
+        />
+    )
+}
 
 export const ExcludeIcon: React.FunctionComponent<React.PropsWithChildren<unknown>> = () => (
     <Icon

--- a/client/web/src/enterprise/batches/workspaces-list/index.ts
+++ b/client/web/src/enterprise/batches/workspaces-list/index.ts
@@ -1,4 +1,4 @@
 export { ListItem } from './ListItem'
 export { Descriptor } from './Descriptor'
-export { ExcludeIcon, CachedIcon } from './Icons'
+export { ExcludeIcon, PartiallyCachedIcon, CachedIcon } from './Icons'
 export { Header } from './Header'

--- a/cmd/frontend/graphqlbackend/batches.go
+++ b/cmd/frontend/graphqlbackend/batches.go
@@ -805,6 +805,7 @@ type BatchSpecWorkspaceResolver interface {
 	StartedAt() *DateTime
 	FinishedAt() *DateTime
 	CachedResultFound() bool
+	StepCacheResultCount() int32
 	BatchSpec(ctx context.Context) (BatchSpecResolver, error)
 	OnlyFetchWorkspace() bool
 	Ignored() bool

--- a/cmd/frontend/graphqlbackend/batches.graphql
+++ b/cmd/frontend/graphqlbackend/batches.graphql
@@ -2097,6 +2097,11 @@ interface BatchSpecWorkspace {
     cachedResultFound: Boolean!
 
     """
+    How many steps had a cached result.
+    """
+    stepCacheResultCount: Int!
+
+    """
     The time when the workspace was enqueued for processing. Null, if not yet enqueued.
     """
     queuedAt: DateTime
@@ -2179,6 +2184,11 @@ type VisibleBatchSpecWorkspace implements BatchSpecWorkspace & Node {
     Whether we found a task cache result.
     """
     cachedResultFound: Boolean!
+
+    """
+    How many steps had a cached result.
+    """
+    stepCacheResultCount: Int!
 
     """
     Executor stages of running in this workspace. Null, if the execution hasn't
@@ -2288,6 +2298,11 @@ type HiddenBatchSpecWorkspace implements BatchSpecWorkspace & Node {
     Whether we found a task cache result.
     """
     cachedResultFound: Boolean!
+
+    """
+    How many steps had a cached result.
+    """
+    stepCacheResultCount: Int!
 
     """
     The time when the workspace was enqueued for processing. Null, if not yet enqueued.

--- a/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec_workspace.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec_workspace.go
@@ -224,6 +224,16 @@ func (r *batchSpecWorkspaceResolver) CachedResultFound() bool {
 	return r.workspace.CachedResultFound
 }
 
+func (r *batchSpecWorkspaceResolver) StepCacheResultCount() (count int32) {
+	for idx := range r.batchSpec.Steps {
+		if _, ok := r.workspace.StepCacheResult(idx + 1); ok {
+			count++
+		}
+	}
+
+	return count
+}
+
 func (r *batchSpecWorkspaceResolver) Stages() graphqlbackend.BatchSpecWorkspaceStagesResolver {
 	if r.execution == nil {
 		return nil


### PR DESCRIPTION
Previously, we wouldn't show anything and it made me think that step caching doesn't work multiple times. I've now added an API field and a state icon for it. Small papercut, but an annoying one :) 


## Test plan

Made sure this works correctly by hand.
