### PR TITLE
search: parse 'lucky' patterntype value in url

### DIFF
--- a/client/web/src/search/index.tsx
+++ b/client/web/src/search/index.tsx
@@ -27,14 +27,14 @@ export function parseSearchURLQuery(query: string): string | undefined {
 export function parseSearchURLPatternType(query: string): SearchPatternType | undefined {
     const searchParameters = new URLSearchParams(query)
     const patternType = searchParameters.get('patternType')
-    if (
-        patternType !== SearchPatternType.literal &&
-        patternType !== SearchPatternType.regexp &&
-        patternType !== SearchPatternType.structural
-    ) {
-        return undefined
+    switch (patternType) {
+        case SearchPatternType.literal:
+        case SearchPatternType.regexp:
+        case SearchPatternType.structural:
+        case SearchPatternType.lucky:
+            return patternType
     }
-    return patternType
+    return undefined
 }
 
 function searchURLIsCaseSensitive(query: string): boolean {


### PR DESCRIPTION
Noticed power user toggle state didn't follow URL values, this fixes it.

## Test plan
Tested manually, no existing tests here (should probably get some).

## App preview:

- [Web](https://sg-web-rvt-parse-url-patterntype-lucky.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-lkadtgxeld.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
