### PR TITLE
Check per janitor run

### DIFF
--- a/cmd/gitserver/server/cleanup_test.go
+++ b/cmd/gitserver/server/cleanup_test.go
@@ -142,133 +142,132 @@ func TestCleanupInactive(t *testing.T) {
 	}
 }
 
-func TestCleanupWrongShard_forced(t *testing.T) {
-	root := t.TempDir()
-	// should be allocated to shard gitserver-1
-	testRepoD := "testrepo-D"
+func TestCleanupWrongShard(t *testing.T) {
+	t.Run("wrongShardName", func(t *testing.T) {
+		root := t.TempDir()
+		// should be allocated to shard gitserver-1
+		testRepoD := "testrepo-D"
 
-	repoA := path.Join(root, testRepoA, ".git")
-	cmd := exec.Command("git", "--bare", "init", repoA)
-	if err := cmd.Run(); err != nil {
-		t.Fatal(err)
-	}
-	repoD := path.Join(root, testRepoD, ".git")
-	cmdD := exec.Command("git", "--bare", "init", repoD)
-	if err := cmdD.Run(); err != nil {
-		t.Fatal(err)
-	}
+		repoA := path.Join(root, testRepoA, ".git")
+		cmd := exec.Command("git", "--bare", "init", repoA)
+		if err := cmd.Run(); err != nil {
+			t.Fatal(err)
+		}
+		repoD := path.Join(root, testRepoD, ".git")
+		cmdD := exec.Command("git", "--bare", "init", repoD)
+		if err := cmdD.Run(); err != nil {
+			t.Fatal(err)
+		}
 
-	s := &Server{ReposDir: root,
-		Logger: logtest.Scoped(t),
-	}
-	s.testSetup(t)
-	// force cleanup of repos
-	wrongShardReposDeleteLimit = 10
-	s.cleanupRepos([]string{"gitserver-0", "gitserver-1"})
+		s := &Server{ReposDir: root,
+			Logger: logtest.Scoped(t),
+		}
+		s.testSetup(t)
+		s.Hostname = "does-not-exist"
+		// force cleanup of repos
+		wrongShardReposDeleteLimit = 10
+		s.cleanupRepos([]string{"gitserver-0", "gitserver-1"})
 
-	if _, err := os.Stat(repoA); os.IsNotExist(err) {
-		t.Error("expected repoA not to be removed")
-	}
-	if _, err := os.Stat(repoD); !os.IsNotExist(err) {
-		t.Error("expected repoD assigned to different shard to be removed during clean up")
-	}
-}
+		if _, err := os.Stat(repoA); err != nil {
+			t.Error("expected repoA not to be removed")
+		}
+		if _, err := os.Stat(repoD); err != nil {
+			t.Error("expected repoD assigned to different shard not to be removed")
+		}
+	})
+	t.Run("forced", func(t *testing.T) {
+		root := t.TempDir()
+		// should be allocated to shard gitserver-1
+		testRepoD := "testrepo-D"
 
-func TestCleanupWrongShard_wrongShardName(t *testing.T) {
-	root := t.TempDir()
-	// should be allocated to shard gitserver-1
-	testRepoD := "testrepo-D"
+		repoA := path.Join(root, testRepoA, ".git")
+		cmd := exec.Command("git", "--bare", "init", repoA)
+		if err := cmd.Run(); err != nil {
+			t.Fatal(err)
+		}
+		repoD := path.Join(root, testRepoD, ".git")
+		cmdD := exec.Command("git", "--bare", "init", repoD)
+		if err := cmdD.Run(); err != nil {
+			t.Fatal(err)
+		}
 
-	repoA := path.Join(root, testRepoA, ".git")
-	cmd := exec.Command("git", "--bare", "init", repoA)
-	if err := cmd.Run(); err != nil {
-		t.Fatal(err)
-	}
-	repoD := path.Join(root, testRepoD, ".git")
-	cmdD := exec.Command("git", "--bare", "init", repoD)
-	if err := cmdD.Run(); err != nil {
-		t.Fatal(err)
-	}
+		s := &Server{ReposDir: root,
+			Logger: logtest.Scoped(t),
+		}
+		s.testSetup(t)
+		// force cleanup of repos
+		wrongShardReposDeleteLimit = 10
+		s.cleanupRepos([]string{"gitserver-0", "gitserver-1"})
 
-	s := &Server{ReposDir: root,
-		Logger: logtest.Scoped(t),
-	}
-	s.testSetup(t)
-	s.Hostname = "does-not-exist"
-	// force cleanup of repos
-	wrongShardReposDeleteLimit = 10
-	s.cleanupRepos([]string{"gitserver-0", "gitserver-1"})
+		if _, err := os.Stat(repoA); os.IsNotExist(err) {
+			t.Error("expected repoA not to be removed")
+		}
+		if _, err := os.Stat(repoD); !os.IsNotExist(err) {
+			t.Error("expected repoD assigned to different shard to be removed during clean up")
+		}
+	})
+	t.Run("substringShardName", func(t *testing.T) {
+		root := t.TempDir()
+		// should be allocated to shard gitserver-1
+		testRepoD := "testrepo-D"
 
-	if _, err := os.Stat(repoA); err != nil {
-		t.Error("expected repoA not to be removed")
-	}
-	if _, err := os.Stat(repoD); err != nil {
-		t.Error("expected repoD assigned to different shard not to be removed")
-	}
-}
+		repoA := path.Join(root, testRepoA, ".git")
+		cmd := exec.Command("git", "--bare", "init", repoA)
+		if err := cmd.Run(); err != nil {
+			t.Fatal(err)
+		}
+		repoD := path.Join(root, testRepoD, ".git")
+		cmdD := exec.Command("git", "--bare", "init", repoD)
+		if err := cmdD.Run(); err != nil {
+			t.Fatal(err)
+		}
 
-func TestCleanupWrongShard_substringShardName(t *testing.T) {
-	root := t.TempDir()
-	// should be allocated to shard gitserver-1
-	testRepoD := "testrepo-D"
+		s := &Server{ReposDir: root,
+			Logger: logtest.Scoped(t),
+		}
+		s.testSetup(t)
+		s.Hostname = "gitserver-0"
+		// force cleanup of repos
+		wrongShardReposDeleteLimit = 10
+		s.cleanupRepos([]string{"gitserver-0.cluster.local:3178", "gitserver-1.cluster.local:3178"})
 
-	repoA := path.Join(root, testRepoA, ".git")
-	cmd := exec.Command("git", "--bare", "init", repoA)
-	if err := cmd.Run(); err != nil {
-		t.Fatal(err)
-	}
-	repoD := path.Join(root, testRepoD, ".git")
-	cmdD := exec.Command("git", "--bare", "init", repoD)
-	if err := cmdD.Run(); err != nil {
-		t.Fatal(err)
-	}
+		if _, err := os.Stat(repoA); err != nil {
+			t.Error("expected repoA not to be removed")
+		}
+		if _, err := os.Stat(repoD); !os.IsNotExist(err) {
+			t.Error("expected repoD assigned to different shard to be removed")
+		}
+	})
+	t.Run("cleanupDisabled", func(t *testing.T) {
+		root := t.TempDir()
+		// should be allocated to shard gitserver-1
+		testRepoD := "testrepo-D"
 
-	s := &Server{ReposDir: root,
-		Logger: logtest.Scoped(t),
-	}
-	s.testSetup(t)
-	s.Hostname = "gitserver-0"
-	// force cleanup of repos
-	wrongShardReposDeleteLimit = 10
-	s.cleanupRepos([]string{"gitserver-0.cluster.local:3178", "gitserver-1.cluster.local:3178"})
+		repoA := path.Join(root, testRepoA, ".git")
+		cmd := exec.Command("git", "--bare", "init", repoA)
+		if err := cmd.Run(); err != nil {
+			t.Fatal(err)
+		}
+		repoD := path.Join(root, testRepoD, ".git")
+		cmdD := exec.Command("git", "--bare", "init", repoD)
+		if err := cmdD.Run(); err != nil {
+			t.Fatal(err)
+		}
 
-	if _, err := os.Stat(repoA); err != nil {
-		t.Error("expected repoA not to be removed")
-	}
-	if _, err := os.Stat(repoD); !os.IsNotExist(err) {
-		t.Error("expected repoD assigned to different shard to be removed")
-	}
-}
+		s := &Server{ReposDir: root,
+			Logger: logtest.Scoped(t),
+		}
+		s.testSetup(t)
+		wrongShardReposDeleteLimit = -1
+		s.cleanupRepos([]string{"gitserver-0", "gitserver-1"})
 
-func TestCleanupWrongShard_cleanupDisabled(t *testing.T) {
-	root := t.TempDir()
-	// should be allocated to shard gitserver-1
-	testRepoD := "testrepo-D"
-
-	repoA := path.Join(root, testRepoA, ".git")
-	cmd := exec.Command("git", "--bare", "init", repoA)
-	if err := cmd.Run(); err != nil {
-		t.Fatal(err)
-	}
-	repoD := path.Join(root, testRepoD, ".git")
-	cmdD := exec.Command("git", "--bare", "init", repoD)
-	if err := cmdD.Run(); err != nil {
-		t.Fatal(err)
-	}
-
-	s := &Server{ReposDir: root,
-		Logger: logtest.Scoped(t),
-	}
-	s.testSetup(t)
-	wrongShardReposDeleteLimit = -1
-	s.cleanupRepos([]string{"gitserver-0", "gitserver-1"})
-
-	if _, err := os.Stat(repoA); os.IsNotExist(err) {
-		t.Error("expected repoA not to be removed")
-	}
-	if _, err := os.Stat(repoD); err != nil {
-		t.Error("expected repoD assigned to different shard not to be removed", err)
-	}
+		if _, err := os.Stat(repoA); os.IsNotExist(err) {
+			t.Error("expected repoA not to be removed")
+		}
+		if _, err := os.Stat(repoD); err != nil {
+			t.Error("expected repoD assigned to different shard not to be removed", err)
+		}
+	})
 }
 
 // Note that the exact values (e.g. 50 commits) below are related to git's


### PR DESCRIPTION
Do one "is the right shard" check per janitor run (instead of one per repo) to:

- do less work
- log less failures (this error case is not really repo specific)
- have an easy way of checking match between hostname and full Kubernetes endpoint address

Also, group wrongShard tests.
## Test plan

- unit tests
- local testing with 2 gitserver replicas

