### PR TITLE
ci: fix adr how-to link

### DIFF
--- a/doc/dev/adr/index.md
+++ b/doc/dev/adr/index.md
@@ -4,7 +4,7 @@
 
 This page is an ADR log. Read the first entry to learn about the reasoning and context behind the adoption of ADRs.
 
-Are you considering adding an ADR? Check out the [How-to page](how-to.md)!
+Are you considering adding an ADR? Check out the [How-to page](./how-to.md)!
 
 To preserve order, individual documents are prefixed by the **current epoch Unix timestamp**.
 


### PR DESCRIPTION
Fix linter issue that is blocking the `main` branch. 

Need to check why this flew unnoticed. 

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

green `sg lint docs` 
