### PR TITLE
database: remove dbutil-based constructors

### DIFF
--- a/cmd/frontend/graphqlbackend/webhook_logs.go
+++ b/cmd/frontend/graphqlbackend/webhook_logs.go
@@ -119,7 +119,7 @@ func newWebhookLogConnectionResolver(
 	return &webhookLogConnectionResolver{
 		args:              args,
 		externalServiceID: externalServiceID,
-		store:             database.WebhookLogs(db, keyring.Default().WebhookLogKey),
+		store:             db.WebhookLogs(keyring.Default().WebhookLogKey),
 	}, nil
 }
 
@@ -203,7 +203,7 @@ func webhookLogByID(ctx context.Context, db database.DB, gqlID graphql.ID) (*web
 		return nil, err
 	}
 
-	log, err := database.WebhookLogs(db, keyring.Default().WebhookLogKey).GetByID(ctx, id)
+	log, err := db.WebhookLogs(keyring.Default().WebhookLogKey).GetByID(ctx, id)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/internal/httpapi/httpapi.go
+++ b/cmd/frontend/internal/httpapi/httpapi.go
@@ -82,7 +82,7 @@ func NewHandler(
 
 	webhookhandlers.Init(db, &gh)
 	webhookMiddleware := webhooks.NewLogMiddleware(
-		database.WebhookLogs(db, keyring.Default().WebhookLogKey),
+		db.WebhookLogs(keyring.Default().WebhookLogKey),
 	)
 
 	handlers.GitHubWebhook.Register(&gh)

--- a/cmd/worker/internal/webhooks/janitor.go
+++ b/cmd/worker/internal/webhooks/janitor.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/worker/job"
 	workerdb "github.com/sourcegraph/sourcegraph/cmd/worker/shared/init/db"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/encryption/keyring"
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
@@ -43,7 +44,7 @@ func (j *janitor) Routines(ctx context.Context, logger log.Logger) ([]goroutine.
 		// operation more frequently than that, given it's purely a debugging
 		// tool.
 		goroutine.NewPeriodicGoroutine(context.Background(), 1*time.Hour, &handler{
-			store: db.WebhookLogs(keyring.Default().WebhookLogKey),
+			store: database.NewDB(db).WebhookLogs(keyring.Default().WebhookLogKey),
 		}),
 	}, nil
 }

--- a/cmd/worker/internal/webhooks/janitor.go
+++ b/cmd/worker/internal/webhooks/janitor.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/worker/job"
 	workerdb "github.com/sourcegraph/sourcegraph/cmd/worker/shared/init/db"
-	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/encryption/keyring"
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
@@ -44,7 +43,7 @@ func (j *janitor) Routines(ctx context.Context, logger log.Logger) ([]goroutine.
 		// operation more frequently than that, given it's purely a debugging
 		// tool.
 		goroutine.NewPeriodicGoroutine(context.Background(), 1*time.Hour, &handler{
-			store: database.WebhookLogs(db, keyring.Default().WebhookLogKey),
+			store: db.WebhookLogs(keyring.Default().WebhookLogKey),
 		}),
 	}, nil
 }

--- a/internal/database/webhook_logs.go
+++ b/internal/database/webhook_logs.go
@@ -2,7 +2,6 @@ package database
 
 import (
 	"context"
-	"database/sql"
 	"encoding/json"
 	"time"
 
@@ -32,13 +31,6 @@ type webhookLogStore struct {
 }
 
 var _ WebhookLogStore = &webhookLogStore{}
-
-func WebhookLogs(db dbutil.DB, key encryption.Key) *webhookLogStore {
-	return &webhookLogStore{
-		Store: basestore.NewWithDB(db, sql.TxOptions{}),
-		key:   key,
-	}
-}
 
 func WebhookLogsWith(other basestore.ShareableStore, key encryption.Key) *webhookLogStore {
 	return &webhookLogStore{


### PR DESCRIPTION
Remove a few dbutil-based constructors in our database package, as they are not mockable in our tests.

This is the result of a time-boxed effort.

## Test plan

Unit tests

---

Part of https://github.com/sourcegraph/sourcegraph/issues/26113