### PR TITLE
web: Fix blob view border

### DIFF
--- a/client/web/src/repo/blob/BlobPage.module.scss
+++ b/client/web/src/repo/blob/BlobPage.module.scss
@@ -1,16 +1,17 @@
-.placeholder {
-    background-color: var(--code-bg);
-    flex: 1 1 50%;
-}
-
-.blob {
-    flex: 1;
-    position: relative;
-}
-
 .border {
     border: 1px solid var(--border-color);
     border-top-left-radius: 0.1875rem;
     border-top-right-radius: 0.1875rem;
     border-bottom: none;
+}
+
+.placeholder {
+    background-color: var(--code-bg);
+    flex: 1 1 50%;
+    @extend .border;
+}
+
+.blob {
+    flex: 1;
+    position: relative;
 }

--- a/client/web/src/repo/blob/BlobPage.module.scss
+++ b/client/web/src/repo/blob/BlobPage.module.scss
@@ -7,3 +7,10 @@
     flex: 1;
     position: relative;
 }
+
+.border {
+    border: 1px solid var(--border-color);
+    border-top-left-radius: 0.1875rem;
+    border-top-right-radius: 0.1875rem;
+    border-bottom: none;
+}

--- a/client/web/src/repo/blob/BlobPage.tsx
+++ b/client/web/src/repo/blob/BlobPage.tsx
@@ -342,6 +342,7 @@ export const BlobPage: React.FunctionComponent<React.PropsWithChildren<Props>> =
                     onCopyNotebook={onCopyNotebook}
                     showSearchContext={showSearchContext}
                     exportedFileName={basename(blobInfoOrError.filePath)}
+                    className={styles.border}
                 />
             )}
             {!isSearchNotebook && blobInfoOrError.richHTML && renderMode === 'rendered' && (

--- a/client/web/src/repo/blob/BlobPage.tsx
+++ b/client/web/src/repo/blob/BlobPage.tsx
@@ -345,7 +345,11 @@ export const BlobPage: React.FunctionComponent<React.PropsWithChildren<Props>> =
                 />
             )}
             {!isSearchNotebook && blobInfoOrError.richHTML && renderMode === 'rendered' && (
-                <RenderedFile dangerousInnerHTML={blobInfoOrError.richHTML} location={props.location} />
+                <RenderedFile
+                    dangerousInnerHTML={blobInfoOrError.richHTML}
+                    location={props.location}
+                    className={styles.border}
+                />
             )}
             {!blobInfoOrError.richHTML && blobInfoOrError.aborted && (
                 <div>
@@ -360,7 +364,7 @@ export const BlobPage: React.FunctionComponent<React.PropsWithChildren<Props>> =
             {/* Render the (unhighlighted) blob also in the case highlighting timed out */}
             {renderMode === 'code' && (
                 <Blob
-                    className={classNames('test-repo-blob', styles.blob)}
+                    className={classNames('test-repo-blob', styles.blob, styles.border)}
                     blobInfo={blobInfoOrError}
                     wrapCode={wrapCode}
                     platformContext={props.platformContext}

--- a/client/web/src/repo/blob/RenderedNotebookMarkdown.tsx
+++ b/client/web/src/repo/blob/RenderedNotebookMarkdown.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo } from 'react'
 
+import classNames from 'classnames'
 import { noop } from 'lodash'
 import * as uuid from 'uuid'
 
@@ -12,17 +13,18 @@ export const SEARCH_NOTEBOOK_FILE_EXTENSION = '.snb.md'
 
 interface RenderedNotebookMarkdownProps extends Omit<NotebookComponentProps, 'onSerializeBlocks' | 'blocks'> {
     markdown: string
+    className?: string
 }
 
 export const RenderedNotebookMarkdown: React.FunctionComponent<
     React.PropsWithChildren<RenderedNotebookMarkdownProps>
-> = ({ markdown, ...props }) => {
+> = ({ markdown, className, ...props }) => {
     // Generate fresh block IDs, since we do not store them in Markdown.
     const blocks = useMemo(() => convertMarkdownToBlocks(markdown).map(block => ({ id: uuid.v4(), ...block })), [
         markdown,
     ])
     return (
-        <div className={styles.renderedSearchNotebookMarkdownWrapper}>
+        <div className={classNames(styles.renderedSearchNotebookMarkdownWrapper, className)}>
             <div className={styles.renderedSearchNotebookMarkdown}>
                 <NotebookComponent isReadOnly={true} blocks={blocks} {...props} onSerializeBlocks={noop} />
             </div>

--- a/client/web/src/repo/blob/ui/BlobStatusBarContainer.module.scss
+++ b/client/web/src/repo/blob/ui/BlobStatusBarContainer.module.scss
@@ -20,14 +20,4 @@
     min-width: 0;
 
     background-color: var(--body-bg);
-
-    // Add border to repo revision container content
-    // but enable variable margin-bottom (by setting it on child div)
-    // without having to repeat border styles.
-    > div:first-of-type {
-        border: 1px solid var(--border-color);
-        border-top-left-radius: 0.1875rem;
-        border-top-right-radius: 0.1875rem;
-        border-bottom: none;
-    }
 }


### PR DESCRIPTION
## Description

Changes the border around the blob/tree view from targeting **the first div** to being applied to the relevant elements.

This fixes a few bugs I noticed when a different div element was inserted before the code (e.g. the tour info, an alert, etc)

### Before
<img width="302" alt="image" src="https://user-images.githubusercontent.com/9516420/172370364-9bdb69ed-3607-40da-9e17-24705b53f10f.png"> <img width="244" alt="image" src="https://user-images.githubusercontent.com/9516420/172370780-128d9ecb-ea5b-4adf-af75-c6350fda05b4.png">

### After
<img width="266" alt="image" src="https://user-images.githubusercontent.com/9516420/172370970-fa2bbaee-4689-452b-accf-2dd4d9f448ab.png"> <img width="325" alt="image" src="https://user-images.githubusercontent.com/9516420/172370855-3464cbd3-09c2-4abf-8943-5a5dc2a064a4.png">


## Test plan

Tested locally by navigating directly to a blob view and enabling different states.
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-tr-fix-code-border.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-sbjdmrfrcm.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
