### PR TITLE
Stop running linters concurrently

### DIFF
--- a/dev/adr-docs/index.md.tmpl
+++ b/dev/adr-docs/index.md.tmpl
@@ -2,7 +2,7 @@
 
 This page is an ADR log. Read the first entry to learn about the reasoning and context behind the adoption of ADRs.
 
-Are you considering adding an ADR? Check out the [How-to page](./how-to.md)!
+Are you considering adding an ADR? Check out the [How-to page](how-to.md)!
 
 To preserve order, individual documents are prefixed by the **current epoch Unix timestamp**.
 {{""}}

--- a/dev/adr-docs/main.go
+++ b/dev/adr-docs/main.go
@@ -65,7 +65,7 @@ func main() {
 				adrs = append(adrs, adr{
 					Title:  title,
 					Number: number,
-					Path:   "./" + entry.Name(),
+					Path:   entry.Name(),
 					Date:   time.Unix(int64(ts), 0).Format("2006-01-02"),
 				})
 				break

--- a/dev/sg/sg_lint.go
+++ b/dev/sg/sg_lint.go
@@ -126,12 +126,14 @@ func runCheckScriptsAndReport(ctx context.Context, dst io.Writer, fns ...lint.Ru
 	// want to allow linters to take any longer.
 	linterTimeout := 5 * time.Minute
 	runnerCtx, cancelRunners := context.WithTimeout(ctx, linterTimeout)
-	for _, fn := range fns {
-		go func(fn lint.Runner) {
+	go func() {
+		for _, fn := range fns {
+			// go func(fn lint.Runner) {
 			reportsCh <- fn(runnerCtx, repoState)
 			wg.Done()
-		}(fn)
-	}
+			// }(fn)
+		}
+	}()
 	go func() {
 		wg.Wait()
 		close(reportsCh)

--- a/doc/dev/adr/index.md
+++ b/doc/dev/adr/index.md
@@ -4,9 +4,9 @@
 
 This page is an ADR log. Read the first entry to learn about the reasoning and context behind the adoption of ADRs.
 
-Are you considering adding an ADR? Check out the [How-to page](./how-to.md)!
+Are you considering adding an ADR? Check out the [How-to page](how-to.md)!
 
 To preserve order, individual documents are prefixed by the **current epoch Unix timestamp**.
 
-1. _2022-04-26_ [Record architecture decisions](./1650968652-record-architecture-decisions.md)
-2. _2022-05-13_ [Use Go for scripting purposes](./1652433602-use-go-for-scripting.md)
+1. _2022-04-26_ [Record architecture decisions](1650968652-record-architecture-decisions.md)
+2. _2022-05-13_ [Use Go for scripting purposes](1652433602-use-go-for-scripting.md)


### PR DESCRIPTION
It causes a race in between the generators in the docs and the docsite linter. 


## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Green build