### PR TITLE
ci: disable output detection for pre-exit log push

### DIFF
--- a/.buildkite/hooks/pre-exit
+++ b/.buildkite/hooks/pre-exit
@@ -7,27 +7,27 @@
 set -e # Not -u because $SOFT_FAIL_EXIT_CODES may not be bound
 
 if [[ "$BUILDKITE_PIPELINE_NAME" != "sourcegraph" ]]; then
-  exit 0
+    exit 0
 fi
 
 if [ "$BUILDKITE_BRANCH" == "main" ]; then
-  # It's possible for the exit status to be unset, in the case of an earlier hook failed, so we need to
-  # account for that. 
-  if [ -n "$BUILDKITE_COMMAND_EXIT_STATUS" ] && [ "$BUILDKITE_COMMAND_EXIT_STATUS" -eq "0" ]; then
-    # If the job exit code is either 0 or a soft failt exit code defined by that step, do nothing.
-    exit 0
-  fi
-
-  # Turn the string of exit codes "1 2 3 4" into an array of strings
-  IFS=' ' read -ra codes <<<"$SOFT_FAIL_EXIT_CODES"
-  for code in "${codes[@]}"; do
-    if [ "$code" == "$BUILDKITE_COMMAND_EXIT_STATUS" ]; then
-      # If the Buildkite exit code is a soft fail, do nothing either.
-      exit 0
+    # It's possible for the exit status to be unset, in the case of an earlier hook failed, so we need to
+    # account for that.
+    if [ -n "$BUILDKITE_COMMAND_EXIT_STATUS" ] && [ "$BUILDKITE_COMMAND_EXIT_STATUS" -eq "0" ]; then
+        # If the job exit code is either 0 or a soft failt exit code defined by that step, do nothing.
+        exit 0
     fi
-  done
 
-  # Non-zero exit code and not a soft fail: upload the logs.
-  echo "--- Uploading build logs: this only runs if your build has already failed, check the logs above, NOT below!"
-  ./enterprise/dev/ci/scripts/upload-build-logs.sh
+    # Turn the string of exit codes "1 2 3 4" into an array of strings
+    IFS=' ' read -ra codes <<<"$SOFT_FAIL_EXIT_CODES"
+    for code in "${codes[@]}"; do
+        if [ "$code" == "$BUILDKITE_COMMAND_EXIT_STATUS" ]; then
+            # If the Buildkite exit code is a soft fail, do nothing either.
+            exit 0
+        fi
+    done
+
+    # Non-zero exit code and not a soft fail: upload the logs.
+    echo "--- Uploading build logs: this only runs if your build has already failed, check the logs above, NOT below!"
+    ./enterprise/dev/ci/scripts/upload-build-logs.sh
 fi

--- a/enterprise/dev/ci/scripts/upload-build-logs.sh
+++ b/enterprise/dev/ci/scripts/upload-build-logs.sh
@@ -38,6 +38,7 @@ echo "~~~ :file_cabinet: Uploading logs"
 # Because we are running this script in the buildkite post-exit hook, the state of the job is still "running".
 # Passing --state="" just overrides the default. It's not set to any specific state because this script caller
 # is responsible of making sure the job has failed.
+export SG_DISBALE_OUTPUT_DETECTION=true
 ./enterprise/dev/ci/scripts/sentry-capture.sh ./sg ci logs --out="$BUILD_LOGS_LOKI_URL" --state="" --overwrite-state="failed" --build="$BUILDKITE_BUILD_NUMBER" --job="$BUILDKITE_JOB_ID"
 local_exit_code=$?
 if [[ $local_exit_code -ne 0 ]]; then


### PR DESCRIPTION
Removes terminal autodetection as this is buggy with buildkite and the moby/term lib we use

## Test plan
No more getwinsize errors:

🗄️ Uploading logs | 0s
-- | --
  | Fetching logs for https://buildkite.com/sourcegraph/sourcegraph/builds/152630 ...
  | Pushing to Loki instance at "logs-prod-us-central1.grafana.net"
  | ✅ Pushed 379 entries from 1 streams to Loki

