### PR TITLE
ci: disable terminal auto detect

### DIFF
--- a/enterprise/dev/ci/scripts/upload-build-logs.sh
+++ b/enterprise/dev/ci/scripts/upload-build-logs.sh
@@ -38,6 +38,7 @@ echo "~~~ :file_cabinet: Uploading logs"
 # Because we are running this script in the buildkite post-exit hook, the state of the job is still "running".
 # Passing --state="" just overrides the default. It's not set to any specific state because this script caller
 # is responsible of making sure the job has failed.
+export SG_DISBALE_OUTPUT_DETECTION=true
 ./enterprise/dev/ci/scripts/sentry-capture.sh ./sg ci logs --out="$BUILD_LOGS_LOKI_URL" --state="" --overwrite-state="failed" --build="$BUILDKITE_BUILD_NUMBER" --job="$BUILDKITE_JOB_ID"
 local_exit_code=$?
 if [[ $local_exit_code -ne 0 ]]; then


### PR DESCRIPTION
fixes GetWinSize terminal error due to a bug between buildkite and moby/term

## Test plan


🗄️ Uploading logs | 0s
-- | --
  | Fetching logs for https://buildkite.com/sourcegraph/sourcegraph/builds/152630 ...
  | Pushing to Loki instance at "logs-prod-us-central1.grafana.net"
  | ✅ Pushed 379 entries from 1 streams to Loki

