### PR TITLE
ci: re-enable concurrent linting

### DIFF
--- a/dev/sg/sg_lint.go
+++ b/dev/sg/sg_lint.go
@@ -126,14 +126,12 @@ func runCheckScriptsAndReport(ctx context.Context, dst io.Writer, fns ...lint.Ru
 	// want to allow linters to take any longer.
 	linterTimeout := 5 * time.Minute
 	runnerCtx, cancelRunners := context.WithTimeout(ctx, linterTimeout)
-	go func() {
-		for _, fn := range fns {
-			// go func(fn lint.Runner) {
+	for _, fn := range fns {
+		go func(fn lint.Runner) {
 			reportsCh <- fn(runnerCtx, repoState)
 			wg.Done()
-			// }(fn)
-		}
-	}()
+		}(fn)
+	}
 	go func() {
 		wg.Wait()
 		close(reportsCh)


### PR DESCRIPTION
Fix a dumb mistake. 

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

n/a 