### PR TITLE
codemirror: Properly handle line breaks in singleline mode

### DIFF
--- a/client/search-ui/src/input/CodeMirrorQueryInput.tsx
+++ b/client/search-ui/src/input/CodeMirrorQueryInput.tsx
@@ -49,7 +49,7 @@ import { MonacoQueryInputProps } from './MonacoQueryInput'
 
 import styles from './CodeMirrorQueryInput.module.scss'
 
-const replacePattern = /[\n\r↵]/g
+const replacePattern = /[\n\r↵]+/g
 
 /**
  * This component provides a drop-in replacement for MonacoQueryInput. It
@@ -379,10 +379,10 @@ const singleLine = EditorState.transactionFilter.of(transaction => {
     while ((match = lineBreakPattern.exec(newText))) {
         // Insert space for line breaks following non-whitespace characters
         if (match.index > 0 && !/\s/.test(newText[match.index - 1])) {
-            changes.push({ from: match.index, to: match.index + 1, insert: ' ' })
+            changes.push({ from: match.index, to: match.index + match[0].length, insert: ' ' })
         } else {
             // Otherwise remove it
-            changes.push({ from: match.index, to: match.index + 1 })
+            changes.push({ from: match.index, to: match.index + match[0].length })
         }
     }
 

--- a/client/search-ui/src/input/CodeMirrorQueryInput.tsx
+++ b/client/search-ui/src/input/CodeMirrorQueryInput.tsx
@@ -12,6 +12,7 @@ import {
     Prec,
     RangeSetBuilder,
     MapMode,
+    ChangeSpec,
 } from '@codemirror/state'
 import {
     EditorView,
@@ -358,9 +359,35 @@ const CodeMirrorQueryInput: React.FunctionComponent<React.PropsWithChildren<Code
 // Sometimes it's not always obvious which type of extension to use to achieve a
 // certain goal (and I don't claim that the implementation below is optimal).
 
-// Enforces that the input won't split over multiple lines (basically prevents
-// Enter from inserting a new line)
-const singleLine = EditorState.transactionFilter.of(transaction => (transaction.newDoc.lines > 1 ? [] : transaction))
+// Enforces that the input won't span over multiple lines by replacing or
+// removing line breaks.
+// NOTE: If a submit handler is assigned to the query input then the pressing
+// enter won't insert a line break anyway. In that case, this filter ensures
+// that line breaks are stripped from pasted input.
+const singleLine = EditorState.transactionFilter.of(transaction => {
+    if (!transaction.docChanged) {
+        return transaction
+    }
+
+    const newText = transaction.newDoc.sliceString(0)
+    const changes: ChangeSpec[] = []
+
+    // new RegExp(...) creates a copy of the regular expression so that we have
+    // our own stateful copy for using `exec` below.
+    const lineBreakPattern = new RegExp(replacePattern)
+    let match: RegExpExecArray | null = null
+    while ((match = lineBreakPattern.exec(newText))) {
+        // Insert space for line breaks following non-whitespace characters
+        if (match.index > 0 && !/\s/.test(newText[match.index - 1])) {
+            changes.push({ from: match.index, to: match.index + 1, insert: ' ' })
+        } else {
+            // Otherwise remove it
+            changes.push({ from: match.index, to: match.index + 1 })
+        }
+    }
+
+    return changes.length > 0 ? [transaction, { changes, sequential: true }] : transaction
+})
 
 // Binds a function to the Enter key. Instead of using keymap directly, this is
 // configured via a state field that contains the event handler. This way the

--- a/client/web/src/integration/search.test.ts
+++ b/client/web/src/integration/search.test.ts
@@ -249,6 +249,8 @@ describe('Search', () => {
             await driver.page.goBack()
             expect(await getSearchFieldValue(driver)).toStrictEqual('foo')
         })
+
+        // TODO: Add test for line break handling (https://github.com/sourcegraph/sourcegraph/issues/36725)
     })
 
     describe('Case sensitivity toggle', () => {


### PR DESCRIPTION
Camden discovered that pasting a search query containing a line break isn't possible because we simply ignore all transactions that contain a line break (which results in ignore the pasted content).

With this change we are now removing/replacing line breaks instead.


## Test plan

Manually tested. I'll add an integration tests once #36044 is merged.


https://user-images.githubusercontent.com/179026/172418019-911938d3-c458-4265-8353-9942b21e8b15.mp4


## App preview:

- [Web](https://sg-web-fkling-cm-query-input-linebreak.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-ekgcuxvqlr.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
