### PR TITLE
Search API: experimentally expose ChunkMatches over GraphQL

### DIFF
--- a/cmd/frontend/graphqlbackend/file_match.go
+++ b/cmd/frontend/graphqlbackend/file_match.go
@@ -64,6 +64,14 @@ func (fm *FileMatchResolver) LineMatches() []lineMatchResolver {
 	return r
 }
 
+func (fm *FileMatchResolver) ChunkMatches() []chunkMatchResolver {
+	r := make([]chunkMatchResolver, 0, len(fm.FileMatch.ChunkMatches))
+	for _, cm := range fm.FileMatch.ChunkMatches {
+		r = append(r, chunkMatchResolver{cm})
+	}
+	return r
+}
+
 func (fm *FileMatchResolver) LimitHit() bool {
 	return fm.FileMatch.LimitHit
 }
@@ -96,4 +104,48 @@ func (lm lineMatchResolver) OffsetAndLengths() [][]int32 {
 
 func (lm lineMatchResolver) LimitHit() bool {
 	return false
+}
+
+type chunkMatchResolver struct {
+	result.ChunkMatch
+}
+
+func (c chunkMatchResolver) Content() string {
+	return c.ChunkMatch.Content
+}
+
+func (c chunkMatchResolver) ContentStart() searchPositionResolver {
+	return searchPositionResolver{c.ChunkMatch.ContentStart}
+}
+
+func (c chunkMatchResolver) Ranges() []searchRangeResolver {
+	res := make([]searchRangeResolver, 0, len(c.ChunkMatch.Ranges))
+	for _, r := range c.ChunkMatch.Ranges {
+		res = append(res, searchRangeResolver{r})
+	}
+	return res
+}
+
+type searchPositionResolver struct {
+	result.Location
+}
+
+func (l searchPositionResolver) Line() int32 {
+	return int32(l.Location.Line)
+}
+
+func (l searchPositionResolver) Character() int32 {
+	return int32(l.Location.Column)
+}
+
+type searchRangeResolver struct {
+	result.Range
+}
+
+func (r searchRangeResolver) Start() searchPositionResolver {
+	return searchPositionResolver{r.Range.Start}
+}
+
+func (r searchRangeResolver) End() searchPositionResolver {
+	return searchPositionResolver{r.Range.End}
 }

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -4467,6 +4467,11 @@ type FileMatch {
     """
     lineMatches: [LineMatch!]!
     """
+    EXPERIMENTAL: This field is experimental and may be unstable.
+    The chunk matches.
+    """
+    chunkMatches: [ChunkMatch!]!
+    """
     Whether or not the limit was hit.
     """
     limitHit: Boolean!
@@ -4493,6 +4498,24 @@ type LineMatch {
     Whether or not the limit was hit.
     """
     limitHit: Boolean! @deprecated(reason: "will always be false")
+}
+
+"""
+A set of matched ranges contained in a chunk of contiguous lines.
+"""
+type ChunkMatch {
+    """
+    The contiguous set of full lines which contain the matches in ranges.
+    """
+    content: String!
+    """
+    The location of the beginning of content.
+    """
+    contentStart: Position!
+    """
+    The set of ranges within the content that matched the search query.
+    """
+    ranges: [Range!]!
 }
 
 """


### PR DESCRIPTION
This experimentally adds `ChunkMatches` to our search resolvers which enables returning multiline matches from the GraphQL API. This is marked as experimental because I haven't hooked it up to anything and the field might still change after trying to use it. 

Note that Zoekt still does not return multiline matches, but we convert all our matches into `ChunkMatches` even if they have been split up into multiple lines. Using this new API should be at least as powerful as the `lineMatch` API since we do return multiline matches for things like unindexed search and structural search. 

I reused the Code Intel `Range` and `Position` GraphQL types for this, but a notable difference is that `Position` does not expose the byte offset. I think this fine since we don't actually need this in any of our clients, but it does somewhat limit the flexibility of the API. 

## Test plan

Not updating tests until I've also implemented this for the streaming API. It's not used, so backend integration tests should still pass (running for this PR). I'll update tests as I migrate things to use the new API.

However, a screenshot to prove this passes manual smoke tests: 


<img width="1808" alt="Screen Shot 2022-06-07 at 11 07 37" src="https://user-images.githubusercontent.com/12631702/172441645-e1331111-61e8-4c18-86b0-e0cb5bb80c80.png">



<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
