### PR TITLE
worker/codemonitors: correctly propagate logger for scope

### DIFF
--- a/enterprise/cmd/worker/internal/codemonitors/codemonitor_job.go
+++ b/enterprise/cmd/worker/internal/codemonitors/codemonitor_job.go
@@ -33,5 +33,5 @@ func (j *codeMonitorJob) Routines(ctx context.Context, logger log.Logger) ([]gor
 		return nil, err
 	}
 
-	return background.NewBackgroundJobs(edb.NewEnterpriseDB(database.NewDB(sqlDB))), nil
+	return background.NewBackgroundJobs(logger, edb.NewEnterpriseDB(database.NewDB(sqlDB))), nil
 }

--- a/enterprise/internal/codemonitors/background/background.go
+++ b/enterprise/internal/codemonitors/background/background.go
@@ -5,13 +5,16 @@ import (
 
 	edb "github.com/sourcegraph/sourcegraph/enterprise/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
+	"github.com/sourcegraph/sourcegraph/lib/log"
 )
 
-func NewBackgroundJobs(db edb.EnterpriseDB) []goroutine.BackgroundRoutine {
+func NewBackgroundJobs(logger log.Logger, db edb.EnterpriseDB) []goroutine.BackgroundRoutine {
+	logger = logger.Scoped("BackgroundJobs", "code monitors background jobs")
+
 	codeMonitorsStore := db.CodeMonitors()
 
-	triggerMetrics := newMetricsForTriggerQueries()
-	actionMetrics := newActionMetrics()
+	triggerMetrics := newMetricsForTriggerQueries(logger)
+	actionMetrics := newActionMetrics(logger)
 
 	// Create a new context. Each background routine will wrap this with
 	// a cancellable context that is canceled when Stop() is called.

--- a/enterprise/internal/codemonitors/background/metrics.go
+++ b/enterprise/internal/codemonitors/background/metrics.go
@@ -17,9 +17,9 @@ type codeMonitorsMetrics struct {
 	errors        prometheus.Counter
 }
 
-func newMetricsForTriggerQueries() codeMonitorsMetrics {
+func newMetricsForTriggerQueries(logger log.Logger) codeMonitorsMetrics {
 	observationContext := &observation.Context{
-		Logger:     log.Scoped("triggers", "code monitor triggers"),
+		Logger:     logger.Scoped("triggers", "code monitor triggers"),
 		Tracer:     &trace.Tracer{Tracer: opentracing.GlobalTracer()},
 		Registerer: prometheus.DefaultRegisterer,
 	}
@@ -50,9 +50,9 @@ func newMetricsForTriggerQueries() codeMonitorsMetrics {
 	}
 }
 
-func newActionMetrics() codeMonitorsMetrics {
+func newActionMetrics(logger log.Logger) codeMonitorsMetrics {
 	observationContext := &observation.Context{
-		Logger:     log.Scoped("actions", "code monitors actions"),
+		Logger:     logger.Scoped("actions", "code monitors actions"),
 		Tracer:     &trace.Tracer{Tracer: opentracing.GlobalTracer()},
 		Registerer: prometheus.DefaultRegisterer,
 	}


### PR DESCRIPTION


## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Before:

<img width="1102" alt="image" src="https://user-images.githubusercontent.com/23356519/172447577-ff24a91d-e865-4991-8b5c-70c7b745e5fa.png">

After:

<img width="1339" alt="image" src="https://user-images.githubusercontent.com/23356519/172447783-95cbe77d-aa8d-4702-9b53-341025581bda.png">
