### PR TITLE
sg generate: Run concurrently; better progress reporting

### DIFF
--- a/dev/sg/internal/generate/golang/golang.go
+++ b/dev/sg/internal/generate/golang/golang.go
@@ -9,10 +9,14 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"runtime"
+	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/sourcegraph/run"
+	"golang.org/x/sync/semaphore"
 
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/generate"
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/std"
@@ -30,10 +34,6 @@ const (
 )
 
 func Generate(ctx context.Context, args []string, progressBar bool, verbosity OutputVerbosityType) *generate.Report {
-	start := time.Now()
-	var sb strings.Builder
-	reportOut := std.NewOutput(&sb, false)
-
 	// Save working directory
 	cwd, err := os.Getwd()
 	if err != nil {
@@ -42,52 +42,217 @@ func Generate(ctx context.Context, args []string, progressBar bool, verbosity Ou
 	defer func() {
 		os.Chdir(cwd)
 	}()
-	rootDir, err := root.RepositoryRoot()
+
+	var (
+		start     = time.Now()
+		sb        strings.Builder
+		reportOut = std.NewOutput(&sb, false)
+	)
+
+	// Run go generate [./...]
+	if err := runGoGenerate(ctx, args, progressBar, verbosity, reportOut, &sb); err != nil {
+		return &generate.Report{Output: sb.String(), Err: err}
+	}
+
+	// Run goimports -w
+	if err := runGoImports(ctx, verbosity, reportOut, &sb); err != nil {
+		return &generate.Report{Output: sb.String(), Err: err}
+	}
+
+	// Run go mod tidy
+	if err := runGoModTidy(ctx, verbosity, reportOut, &sb); err != nil {
+		return &generate.Report{Output: sb.String(), Err: err}
+	}
+
+	return &generate.Report{
+		Output:   sb.String(),
+		Duration: time.Since(start),
+	}
+}
+
+var goGeneratePattern = regexp.MustCompile(`^//go:generate (.+)$`)
+
+func findFilepathsWithGenerate(dir string) ([]string, error) {
+	entries, err := os.ReadDir(dir)
 	if err != nil {
-		return &generate.Report{Err: err}
+		return nil, err
+	}
+
+	pathMap := map[string]struct{}{}
+	for _, entry := range entries {
+		path := filepath.Join(dir, entry.Name())
+
+		if entry.IsDir() {
+			paths, err := findFilepathsWithGenerate(path)
+			if err != nil {
+				return nil, err
+			}
+
+			for _, path := range paths {
+				pathMap[path] = struct{}{}
+			}
+		} else if filepath.Ext(entry.Name()) == ".go" {
+			contents, err := os.ReadFile(path)
+			if err != nil {
+				return nil, err
+			}
+
+			for _, line := range bytes.Split(contents, []byte{'\n'}) {
+				if goGeneratePattern.Match(line) {
+					pathMap[path] = struct{}{}
+					break
+				}
+			}
+		}
+	}
+
+	paths := make([]string, 0, len(pathMap))
+	for path := range pathMap {
+		paths = append(paths, path)
+	}
+
+	return paths, nil
+}
+
+func runGoGenerate(ctx context.Context, args []string, progressBar bool, verbosity OutputVerbosityType, reportOut *std.Output, w io.Writer) (err error) {
+	// Use the given packages.
+	if len(args) != 0 {
+		if verbosity != QuietOutput {
+			reportOut.WriteLine(output.Linef(output.EmojiInfo, output.StyleBold, "go generate %s", strings.Join(args, " ")))
+		}
+		if err := runGoGenerateOnPaths(ctx, args, progressBar, verbosity, reportOut, w); err != nil {
+			return errors.Wrap(err, "go generate")
+		}
+
+		return nil
 	}
 
 	wd, err := os.Getwd()
 	if err != nil {
-		return &generate.Report{Err: err}
+		return err
 	}
 
-	// Run go generate on the packages list
-	if len(args) == 0 {
-		// Grab the packages list
-		pkgPaths, err := findPackagesWithGenerate(wd, wd)
-		if err != nil {
-			return &generate.Report{Err: err}
-		}
+	// If no packages are given, go for everything except doc/cli/references.
+	// We cut down on the number of files we have to generate by looking for a
+	// go:generate directive by hand first.
+	paths, err := findFilepathsWithGenerate(wd)
+	if err != nil {
+		return err
+	}
+	filtered := make([]string, 0, len(paths))
+	for _, pkgPath := range paths {
+		pkgPath = pkgPath[len(wd)+1:]
 
-		// If no packages are given, go for everything but the exception.
-		filtered := make([]string, 0, len(pkgPaths))
-		for _, pkgPath := range pkgPaths {
-			if !strings.Contains(pkgPath, "doc/cli/references") {
-				filtered = append(filtered, pkgPath)
+		if !strings.HasPrefix(pkgPath, "doc/cli/references") {
+			filtered = append(filtered, pkgPath)
+		}
+	}
+
+	if verbosity != QuietOutput {
+		reportOut.WriteLine(output.Linef(output.EmojiInfo, output.StyleBold, "go generate ./... (excluding doc/cli/references)"))
+	}
+	if err := runGoGenerateOnPaths(ctx, filtered, progressBar, verbosity, reportOut, w); err != nil {
+		return errors.Wrap(err, "go generate")
+	}
+
+	return nil
+}
+
+// For debugging
+const showTimings = false
+
+func runGoGenerateOnPaths(ctx context.Context, pkgPaths []string, progressBar bool, verbosity OutputVerbosityType, reportOut *std.Output, w io.Writer) (err error) {
+	var (
+		done     = 0.0
+		total    = float64(len(pkgPaths))
+		progress output.Progress
+		timings  = map[string]time.Duration{}
+	)
+
+	defer func() {
+		if showTimings && verbosity == VerboseOutput {
+			names := make([]string, 0, len(timings))
+			for k := range timings {
+				names = append(names, k)
+			}
+
+			sort.Slice(names, func(i, j int) bool {
+				return timings[names[j]] < timings[names[i]]
+			})
+
+			progress.Write("\nDuration\tPackage")
+			for _, name := range names {
+				progress.Writef("%6dms\t%s", int(timings[name]/time.Millisecond), name)
 			}
 		}
-		if verbosity != QuietOutput {
-			reportOut.WriteLine(output.Linef(output.EmojiInfo, output.StyleBold, "go generate ./... (excluding doc/cli/references)"))
-		}
-		err = runGoGenerate(ctx, filtered, progressBar, verbosity, &sb)
-		if err != nil {
-			return &generate.Report{Output: sb.String(), Err: errors.Wrap(err, "go generate")}
-		}
-	} else {
-		// Use the given packages.
-		if verbosity != QuietOutput {
-			reportOut.WriteLine(output.Linef(output.EmojiInfo, output.StyleBold, "go generate %s", strings.Join(args, " ")))
-		}
-		err = runGoGenerate(ctx, args, progressBar, verbosity, &sb)
-		if err != nil {
-			return &generate.Report{Output: sb.String(), Err: errors.Wrap(err, "go generate")}
-		}
+	}()
+
+	if progressBar {
+		progress = std.Out.Progress([]output.ProgressBar{
+			{Label: fmt.Sprintf("go generating %d packages", len(pkgPaths)), Max: total},
+		}, nil)
+
+		defer func() {
+			if err != nil {
+				progress.Destroy()
+			} else {
+				progress.Complete()
+			}
+		}()
 	}
 
-	// Run goimports -w
+	var (
+		m   sync.Mutex
+		g   = errors.Group{}
+		sem = semaphore.NewWeighted(int64(runtime.GOMAXPROCS(0)))
+	)
+
+	for _, pkgPath := range pkgPaths {
+		if err := sem.Acquire(ctx, 1); err != nil {
+			return err
+		}
+
+		// Do not capture loop variable in goroutine below
+		pkgPath := pkgPath
+
+		g.Go(func() error {
+			defer sem.Release(1)
+
+			if verbosity == VerboseOutput {
+				progress.Writef("Generating %s...", pkgPath)
+			}
+
+			start := time.Now()
+			if err := root.Run(run.Cmd(ctx, "go", "generate", pkgPath)).Wait(); err != nil {
+				return err
+			}
+			duration := time.Since(start)
+
+			m.Lock()
+			defer m.Unlock()
+
+			if progress != nil {
+				done += 1.0
+				progress.SetValue(0, done)
+				progress.SetLabelAndRecalc(0, fmt.Sprintf("%d/%d packages generated", int(done), int(total)))
+			}
+
+			timings[pkgPath] = duration
+			return nil
+		})
+	}
+
+	return g.Wait()
+}
+
+func runGoImports(ctx context.Context, verbosity OutputVerbosityType, reportOut *std.Output, w io.Writer) error {
 	if verbosity != QuietOutput {
 		reportOut.WriteLine(output.Linef(output.EmojiInfo, output.StyleBold, "goimports -w"))
+	}
+
+	rootDir, err := root.RepositoryRoot()
+	if err != nil {
+		return err
 	}
 
 	// Determine which goimports we can use
@@ -101,12 +266,9 @@ func Generate(ctx context.Context, args []string, progressBar bool, verbosity Ou
 				"GOBIN": filepath.Join(rootDir, ".bin"),
 			}).
 			Run().
-			Stream(&sb)
+			Stream(w)
 		if err != nil {
-			return &generate.Report{
-				Output: sb.String(),
-				Err:    errors.Wrap(err, "go install golang.org/x/tools/cmd/goimports returned an error"),
-			}
+			return errors.Wrap(err, "go install golang.org/x/tools/cmd/goimports returned an error")
 		}
 
 		goimportsBinary = "./.bin/goimports"
@@ -114,126 +276,21 @@ func Generate(ctx context.Context, args []string, progressBar bool, verbosity Ou
 		goimportsBinary = "goimports"
 	}
 
-	err = root.Run(run.Cmd(ctx, goimportsBinary, "-w")).Stream(&sb)
-	if err != nil {
-		return &generate.Report{
-			Output: sb.String(),
-			Err:    errors.Wrap(err, "goimports -w"),
-		}
+	if err := root.Run(run.Cmd(ctx, goimportsBinary, "-w")).Stream(w); err != nil {
+		return errors.Wrap(err, "goimports -w")
 	}
 
-	// Run go mod tidy
+	return nil
+}
+
+func runGoModTidy(ctx context.Context, verbosity OutputVerbosityType, reportOut *std.Output, w io.Writer) error {
 	if verbosity != QuietOutput {
 		reportOut.WriteLine(output.Linef(output.EmojiInfo, output.StyleBold, "go mod tidy"))
 	}
 
-	err = root.Run(run.Cmd(ctx, "go", "mod", "tidy")).Stream(&sb)
-	if err != nil {
-		return &generate.Report{Output: sb.String(), Err: errors.Wrap(err, "go mod tidy")}
+	if err := root.Run(run.Cmd(ctx, "go", "mod", "tidy")).Stream(w); err != nil {
+		return errors.Wrap(err, "go mod tidy")
 	}
 
-	return &generate.Report{
-		Output:   sb.String(),
-		Duration: time.Since(start),
-	}
-}
-
-var goGeneratePattern = regexp.MustCompile(`^//go:generate (.+)$`)
-
-func findPackagesWithGenerate(root, dir string) (packages []string, _ error) {
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		return nil, err
-	}
-
-	for _, entry := range entries {
-		path := filepath.Join(dir, entry.Name())
-
-		if entry.IsDir() {
-			pkgs, err := findPackagesWithGenerate(root, path)
-			if err != nil {
-				return nil, err
-			}
-
-			packages = append(packages, pkgs...)
-		} else if filepath.Ext(entry.Name()) == ".go" {
-			contents, err := os.ReadFile(path)
-			if err != nil {
-				return nil, err
-			}
-
-			for _, line := range bytes.Split(contents, []byte{'\n'}) {
-				if goGeneratePattern.Match(line) {
-					packages = append(packages, "github.com/sourcegraph/sourcegraph"+dir[len(root):])
-				}
-			}
-		}
-	}
-
-	return packages, nil
-}
-
-func runGoGenerate(ctx context.Context, pkgPaths []string, progressBar bool, verbosity OutputVerbosityType, out io.Writer) (err error) {
-	args := []string{"go", "generate"}
-	if verbosity == VerboseOutput {
-		args = append(args, "-x")
-	}
-	if progressBar {
-		// If we want to display a progress bar we want the verbose output of `go
-		// generate` so we can check which package has been generated.
-		args = append(args, "-v")
-	}
-	args = append(args, pkgPaths...)
-
-	if !progressBar {
-		// If we don't want to display a progress bar we stream output to `out`
-		// and are done.
-		return root.Run(run.Cmd(ctx, args...)).Stream(out)
-	}
-
-	done := 0.0
-	total := float64(len(pkgPaths))
-	progress := std.Out.Progress([]output.ProgressBar{
-		{Label: fmt.Sprintf("go generating %d packages", len(pkgPaths)), Max: total},
-	}, nil)
-	defer func() {
-		if err != nil {
-			progress.Destroy()
-		} else {
-			// We often get stuck on something like (7/21 packages generated) and a complete
-			// progress bar. This is a short hack to get around that; maybe we should ensure
-			// that progress bars (in general) account for all of their subtasks before being
-			// marked as complete.
-			done = total
-			progress.SetValue(0, done)
-			progress.SetLabelAndRecalc(0, fmt.Sprintf("%d/%d packages generated", int(total), int(total)))
-
-			progress.Complete()
-		}
-	}()
-
-	pkgMap := make(map[string]bool, len(pkgPaths))
-	for _, pkg := range pkgPaths {
-		pkgMap[strings.TrimPrefix(pkg, "github.com/sourcegraph/sourcegraph/")] = false
-	}
-
-	return root.Run(run.Cmd(ctx, args...)).StreamLines(func(line []byte) {
-		if !bytes.HasSuffix(line, []byte(".go")) {
-			return
-		}
-
-		dir := filepath.Dir(string(line))
-
-		if current, ok := pkgMap[dir]; ok && !current {
-			pkgMap[dir] = true
-
-			if verbosity == VerboseOutput {
-				progress.Writef("Generating %s...", dir)
-			}
-
-			done += 1.0
-			progress.SetValue(0, done)
-			progress.SetLabelAndRecalc(0, fmt.Sprintf("%d/%d packages generated", int(done), int(total)))
-		}
-	})
+	return nil
 }


### PR DESCRIPTION
This PR adds better progress reporting (and a nice speed boost) to go generate commands. Previously we were passing very long lists of package names. Since this requires go to re-parse the packages, we get a small speed boost by passing the individual file names with a go generate directive. More importantly, this allows us to run each file individually (and now concurrently) so that we know when processing of the file starts and stops. We were trying to rely on heuristics in the "verbose" go generate output previously to achieve the same thing.

## Test plan

Tested locally.