### PR TITLE
Insights/fix-series-toggle

### DIFF
--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/BackendInsight.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/BackendInsight.tsx
@@ -23,7 +23,6 @@ import {
     DrillDownInsightCreationFormValues,
     BackendInsightChart,
 } from './components'
-import { useSeriesToggle } from './components/backend-insight-chart/use-series-toggle'
 import { parseSeriesDisplayOptions } from './components/drill-down-filters-panel/drill-down-filters/utils'
 
 import styles from './BackendInsight.module.scss'
@@ -45,7 +44,6 @@ export const BackendInsightView: React.FunctionComponent<React.PropsWithChildren
 
     const { currentDashboard, dashboards } = useContext(InsightContext)
     const { getBackendInsightData, createInsight, updateInsight } = useContext(CodeInsightsBackendContext)
-    const { toggle, isSeriesSelected, isSeriesHovered, setHoveredId } = useSeriesToggle()
 
     // Visual line chart settings
     const [zeroYAxisMin, setZeroYAxisMin] = useState(false)
@@ -198,11 +196,7 @@ export const BackendInsightView: React.FunctionComponent<React.PropsWithChildren
                     {...state.data}
                     locked={insight.isFrozen}
                     zeroYAxisMin={zeroYAxisMin}
-                    isSeriesSelected={isSeriesSelected}
-                    isSeriesHovered={isSeriesHovered}
                     onDatumClick={trackDatumClicks}
-                    onLegendItemClick={toggle}
-                    setHoveredId={setHoveredId}
                 />
             )}
             {

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/backend-insight-chart/BackendInsightChart.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/backend-insight-chart/BackendInsightChart.tsx
@@ -1,4 +1,4 @@
-import React, { Dispatch, SetStateAction } from 'react'
+import React from 'react'
 
 import { ParentSize } from '@visx/responsive'
 import classNames from 'classnames'
@@ -10,6 +10,8 @@ import { getLineColor, LegendItem, LegendList, ScrollBox } from '../../../../../
 import { BackendInsightData } from '../../../../../../core'
 import { SeriesBasedChartTypes, SeriesChart } from '../../../../../views'
 import { BackendAlertOverlay } from '../backend-insight-alerts/BackendInsightAlerts'
+
+import { useSeriesToggle } from './use-series-toggle'
 
 import styles from './BackendInsightChart.module.scss'
 
@@ -41,28 +43,15 @@ export const MINIMAL_SERIES_FOR_ASIDE_LEGEND = 3
 interface BackendInsightChartProps<Datum> extends BackendInsightData {
     locked: boolean
     zeroYAxisMin: boolean
-    isSeriesSelected: (id: string) => boolean
-    isSeriesHovered: (id: string) => boolean
     className?: string
-    onLegendItemClick: (id: string) => void
     onDatumClick: () => void
-    setHoveredId: Dispatch<SetStateAction<string | undefined>>
 }
 
 export function BackendInsightChart<Datum>(props: BackendInsightChartProps<Datum>): React.ReactElement {
-    const {
-        locked,
-        isFetchingHistoricalData,
-        content,
-        zeroYAxisMin,
-        isSeriesSelected,
-        isSeriesHovered,
-        className,
-        onDatumClick,
-        onLegendItemClick,
-        setHoveredId,
-    } = props
+    const { locked, isFetchingHistoricalData, content, zeroYAxisMin, className, onDatumClick } = props
     const { ref, width = 0 } = useDebounce(useResizeObserver(), 100)
+
+    const { toggle, isSeriesSelected, isSeriesHovered, setHoveredId } = useSeriesToggle()
 
     const hasViewManySeries = content.series.length > MINIMAL_SERIES_FOR_ASIDE_LEGEND
     const hasEnoughXSpace = width >= MINIMAL_HORIZONTAL_LAYOUT_WIDTH
@@ -112,7 +101,7 @@ export function BackendInsightChart<Datum>(props: BackendInsightChartProps<Datum
                                     selected={isSeriesSelected(`${series.id}`)}
                                     hovered={isSeriesHovered(`${series.id}`)}
                                     className={styles.legendListItem}
-                                    onClick={() => onLegendItemClick(`${series.id}`)}
+                                    onClick={() => toggle(`${series.id}`)}
                                     onMouseEnter={() => setHoveredId(`${series.id}`)}
                                     // prevent accidental dragging events
                                     onMouseDown={event => event.stopPropagation()}

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/backend-insight-chart/BackendInsightChart.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/backend-insight-chart/BackendInsightChart.tsx
@@ -50,8 +50,9 @@ interface BackendInsightChartProps<Datum> extends BackendInsightData {
 export function BackendInsightChart<Datum>(props: BackendInsightChartProps<Datum>): React.ReactElement {
     const { locked, isFetchingHistoricalData, content, zeroYAxisMin, className, onDatumClick } = props
     const { ref, width = 0 } = useDebounce(useResizeObserver(), 100)
+    const availableSeriesIds = props.content.series.map(series => `${series.id}`)
 
-    const { toggle, isSeriesSelected, isSeriesHovered, setHoveredId } = useSeriesToggle()
+    const { toggle, isSeriesSelected, isSeriesHovered, setHoveredId } = useSeriesToggle(availableSeriesIds)
 
     const hasViewManySeries = content.series.length > MINIMAL_SERIES_FOR_ASIDE_LEGEND
     const hasEnoughXSpace = width >= MINIMAL_HORIZONTAL_LAYOUT_WIDTH

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/backend-insight-chart/use-series-toggle.test.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/backend-insight-chart/use-series-toggle.test.tsx
@@ -6,20 +6,20 @@ import userEvent from '@testing-library/user-event'
 import { useSeriesToggle } from './use-series-toggle'
 
 const UseSeriesToggleExample: React.FunctionComponent = () => {
-    const { toggle, selectedSeriesIds, isSeriesHovered, isSeriesSelected, setHoveredId } = useSeriesToggle()
+    const availableSeriesIds = ['foo', 'bar', 'baz']
+    const { toggle, selectedSeriesIds, isSeriesHovered, isSeriesSelected, setHoveredId } = useSeriesToggle(
+        availableSeriesIds
+    )
 
     return (
         <div>
-            <div onMouseEnter={() => setHoveredId('foo')}>
-                {isSeriesSelected('foo') && <span>Foo is selected</span>}
-                {isSeriesHovered('foo') && <span>Foo is hovered</span>}
-                <button onClick={() => toggle('foo')}>Foo</button>
-            </div>
-            <div onMouseEnter={() => setHoveredId('bar')}>
-                {isSeriesSelected('bar') && <span>Bar is selected</span>}
-                {isSeriesHovered('bar') && <span>Bar is hovered</span>}
-                <button onClick={() => toggle('bar')}>Bar</button>
-            </div>
+            {availableSeriesIds.map(id => (
+                <div key={id} onMouseEnter={() => setHoveredId(id)}>
+                    {isSeriesSelected(id) && <span>{id} is selected</span>}
+                    {isSeriesHovered(id) && <span>{id} is hovered</span>}
+                    <button onClick={() => toggle(id)}>{id}</button>
+                </div>
+            ))}
 
             <div>Selected series: {selectedSeriesIds.join(',')}</div>
         </div>
@@ -30,42 +30,54 @@ describe('useSeriesToggle', () => {
     it('renders all series when none are selected', () => {
         render(<UseSeriesToggleExample />)
 
-        expect(screen.getByText('Foo is selected')).toBeInTheDocument()
-        expect(screen.getByText('Bar is selected')).toBeInTheDocument()
+        expect(screen.getByText('foo is selected')).toBeInTheDocument()
+        expect(screen.getByText('bar is selected')).toBeInTheDocument()
     })
 
-    it('renders only Foo series when Foo is selected', () => {
+    it('renders only foo series when foo is selected', () => {
         render(<UseSeriesToggleExample />)
-        userEvent.click(screen.getByRole('button', { name: 'Foo' }))
+        userEvent.click(screen.getByRole('button', { name: 'foo' }))
 
-        expect(screen.getByText('Foo is selected')).toBeInTheDocument()
-        expect(screen.queryByText('Bar is selected')).not.toBeInTheDocument()
+        expect(screen.getByText('foo is selected')).toBeInTheDocument()
+        expect(screen.queryByText('bar is selected')).not.toBeInTheDocument()
         expect(screen.getByText('Selected series: foo')).toBeInTheDocument()
     })
 
-    it('renders only Foo & Bar series when Foo & Bar are selected', () => {
+    it('renders only foo & bar series when foo & bar are selected', () => {
         render(<UseSeriesToggleExample />)
-        userEvent.click(screen.getByRole('button', { name: 'Foo' }))
-        userEvent.click(screen.getByRole('button', { name: 'Bar' }))
+        userEvent.click(screen.getByRole('button', { name: 'foo' }))
+        userEvent.click(screen.getByRole('button', { name: 'bar' }))
 
-        expect(screen.getByText('Foo is selected')).toBeInTheDocument()
-        expect(screen.getByText('Bar is selected')).toBeInTheDocument()
+        expect(screen.getByText('foo is selected')).toBeInTheDocument()
+        expect(screen.getByText('bar is selected')).toBeInTheDocument()
         expect(screen.getByText('Selected series: foo,bar')).toBeInTheDocument()
     })
 
-    it('renders "Foo is hovered"', () => {
+    it('renders "foo is hovered"', () => {
         render(<UseSeriesToggleExample />)
-        userEvent.hover(screen.getByRole('button', { name: 'Foo' }))
+        userEvent.hover(screen.getByRole('button', { name: 'foo' }))
 
-        expect(screen.getByText('Foo is hovered')).toBeInTheDocument()
+        expect(screen.getByText('foo is hovered')).toBeInTheDocument()
     })
 
-    it('renders "Bar is hovered"', () => {
+    it('renders "bar is hovered"', () => {
         render(<UseSeriesToggleExample />)
-        userEvent.hover(screen.getByRole('button', { name: 'Foo' }))
-        userEvent.hover(screen.getByRole('button', { name: 'Bar' }))
+        userEvent.hover(screen.getByRole('button', { name: 'foo' }))
+        userEvent.hover(screen.getByRole('button', { name: 'bar' }))
 
-        expect(screen.queryByText('Foo is hovered')).not.toBeInTheDocument()
-        expect(screen.getByText('Bar is hovered')).toBeInTheDocument()
+        expect(screen.queryByText('foo is hovered')).not.toBeInTheDocument()
+        expect(screen.getByText('bar is hovered')).toBeInTheDocument()
+    })
+
+    it('deslects all series after user selects every series available', () => {
+        render(<UseSeriesToggleExample />)
+        userEvent.click(screen.getByRole('button', { name: 'foo' }))
+        userEvent.click(screen.getByRole('button', { name: 'bar' }))
+        userEvent.click(screen.getByRole('button', { name: 'baz' }))
+
+        expect(screen.getByText('foo is selected')).toBeInTheDocument()
+        expect(screen.getByText('bar is selected')).toBeInTheDocument()
+        expect(screen.getByText('baz is selected')).toBeInTheDocument()
+        expect(screen.queryByText('Selected series: foo,bar,baz')).not.toBeInTheDocument()
     })
 })

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/backend-insight-chart/use-series-toggle.ts
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/backend-insight-chart/use-series-toggle.ts
@@ -14,15 +14,24 @@ interface UseSeriesToggleReturn {
 
 // Used when clicking legend items in a line chart. This hook manages the currently
 // selected data series as well as the currently hovered legend item.
-export const useSeriesToggle = (): UseSeriesToggleReturn => {
+/**
+ * @param availableSeriesIds {string[]} List of series ids that can be selected
+ * @returns helper tools for managing the currently selected and hovered series
+ */
+export const useSeriesToggle = (availableSeriesIds: string[]): UseSeriesToggleReturn => {
     const [selectedSeriesIds, setSelectedSeriesIds] = useState<string[]>([])
     const [hoveredId, setHoveredId] = useState<string | undefined>()
 
     const selectSeries = (seriesId: string): void => setSelectedSeriesIds([...selectedSeriesIds, seriesId])
     const deselectSeries = (seriesId: string): void =>
         setSelectedSeriesIds(selectedSeriesIds.filter(id => id !== seriesId))
-    const toggle = (seriesId: string): void =>
-        selectedSeriesIds.includes(seriesId) ? deselectSeries(seriesId) : selectSeries(seriesId)
+    const toggle = (seriesId: string): void => {
+        // Reset the selected series if the user is about to select all of them
+        if (selectedSeriesIds.length === availableSeriesIds.length - 1) {
+            return setSelectedSeriesIds([])
+        }
+        return selectedSeriesIds.includes(seriesId) ? deselectSeries(seriesId) : selectSeries(seriesId)
+    }
     const isSelected = (seriesId: string): boolean => {
         // Return true for all series if no series are selected
         // This is because we only want to hide series if something is

--- a/client/web/src/enterprise/insights/pages/insights/insight/components/standalone-backend-insight/StandaloneBackendInsight.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/insight/components/standalone-backend-insight/StandaloneBackendInsight.tsx
@@ -19,7 +19,6 @@ import {
     DrillDownFiltersFormValues,
     DrillDownInsightCreationFormValues,
 } from '../../../../../components/insights-view-grid/components/backend-insight/components'
-import { useSeriesToggle } from '../../../../../components/insights-view-grid/components/backend-insight/components/backend-insight-chart/use-series-toggle'
 import { useInsightData } from '../../../../../components/insights-view-grid/hooks/use-insight-data'
 import {
     ALL_INSIGHTS_DASHBOARD,
@@ -44,7 +43,6 @@ export const StandaloneBackendInsight: React.FunctionComponent<StandaloneBackend
     const { telemetryService, insight, className } = props
     const history = useHistory()
     const { getBackendInsightData, createInsight, updateInsight } = useContext(CodeInsightsBackendContext)
-    const { toggle, isSeriesSelected, isSeriesHovered, setHoveredId } = useSeriesToggle()
 
     // Visual line chart settings
     const [zeroYAxisMin, setZeroYAxisMin] = useState(false)
@@ -169,11 +167,7 @@ export const StandaloneBackendInsight: React.FunctionComponent<StandaloneBackend
                         {...state.data}
                         locked={insight.isFrozen}
                         zeroYAxisMin={zeroYAxisMin}
-                        isSeriesSelected={isSeriesSelected}
-                        isSeriesHovered={isSeriesHovered}
                         onDatumClick={trackDatumClicks}
-                        onLegendItemClick={toggle}
-                        setHoveredId={setHoveredId}
                     />
                 )}
             </InsightCard>


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/36461

Before this PR clicking on all series toggled them to "on" but then clicking a series again toggle just that series "off". This felt misleading because clicking all fo the series "on" implies resetting the chart to the default state. Such that clicking a series from here, should only display that series.

This PR clears out the selections when all series have been "toggled on" so that the default state is reset correctly.

## Test plan

- Added unit test confirming deselecting of series when all series have been selected
- Open storybook
- Go to "Smart Insights View Grid Example"
- Use "Backend insight #2"
- Click first legend item
- Only that series is shown
- Click second legend item
- Both series are shown
- Click third legend item
- All three series shown
- Click first legend item again
- Only that series shown