### PR TITLE
ssbc: Don't keep execution results, recreate from steps

### DIFF
--- a/enterprise/cmd/worker/internal/batches/workers/batch_spec_resolution_worker.go
+++ b/enterprise/cmd/worker/internal/batches/workers/batch_spec_resolution_worker.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"time"
 
+	"github.com/sourcegraph/log"
+
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/store"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/workerutil"
@@ -19,7 +21,10 @@ func NewBatchSpecResolutionWorker(
 	workerStore dbworkerstore.Store,
 	observationContext *observation.Context,
 ) *workerutil.Worker {
-	e := &batchSpecWorkspaceCreator{store: s}
+	e := &batchSpecWorkspaceCreator{
+		store:  s,
+		logger: log.Scoped("batch-spec-workspace-creator", "The background worker running workspace resolutions for batch changes"),
+	}
 
 	options := workerutil.WorkerOptions{
 		Name:              "batch_changes_batch_spec_resolution_worker",

--- a/enterprise/cmd/worker/internal/batches/workers/batch_spec_workspace_creator.go
+++ b/enterprise/cmd/worker/internal/batches/workers/batch_spec_workspace_creator.go
@@ -216,6 +216,8 @@ func (r *batchSpecWorkspaceCreator) process(
 		}
 
 		// Validate there is anything to run. If not, we skip execution.
+		// TODO: In the future, move this to a separate field, so we can
+		// tell the two cases apart.
 		if len(spec.Spec.Steps) == len(workspace.skippedSteps) {
 			workspace.dbWorkspace.CachedResultFound = true
 			continue

--- a/enterprise/cmd/worker/internal/batches/workers/batch_spec_workspace_creator.go
+++ b/enterprise/cmd/worker/internal/batches/workers/batch_spec_workspace_creator.go
@@ -237,8 +237,8 @@ func (r *batchSpecWorkspaceCreator) process(
 
 		res, found := workspace.dbWorkspace.StepCacheResult(latestStepIdx + 1)
 		if !found {
-			// It's been set above, this should never happen. This is a bug.
-			return errors.New("step cache result not found in set")
+			// There is no cache result available, proceed.
+			continue
 		}
 
 		changes, err := git.ChangesInDiff([]byte(res.Value.Diff))

--- a/enterprise/cmd/worker/internal/batches/workers/batch_spec_workspace_creator_test.go
+++ b/enterprise/cmd/worker/internal/batches/workers/batch_spec_workspace_creator_test.go
@@ -1,12 +1,15 @@
 package workers
 
 import (
+	"bytes"
 	"context"
 	"testing"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+
+	"github.com/sourcegraph/log/logtest"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/service"
@@ -34,7 +37,12 @@ func TestBatchSpecWorkspaceCreatorProcess(t *testing.T) {
 
 	s := store.New(db, &observation.TestContext, nil)
 
-	batchSpec := &btypes.BatchSpec{UserID: user.ID, NamespaceUserID: user.ID, RawSpec: ct.TestRawBatchSpecYAML}
+	batchSpec, err := btypes.NewBatchSpecFromRaw(ct.TestRawBatchSpecYAML)
+	if err != nil {
+		t.Fatal(err)
+	}
+	batchSpec.UserID = user.ID
+	batchSpec.NamespaceUserID = user.ID
 	if err := s.CreateBatchSpec(context.Background(), batchSpec); err != nil {
 		t.Fatal(err)
 	}
@@ -98,7 +106,7 @@ func TestBatchSpecWorkspaceCreatorProcess(t *testing.T) {
 		},
 	}
 
-	creator := &batchSpecWorkspaceCreator{store: s}
+	creator := &batchSpecWorkspaceCreator{store: s, logger: logtest.Scoped(t)}
 	if err := creator.process(context.Background(), s, resolver.DummyBuilder, job); err != nil {
 		t.Fatalf("proces failed: %s", err)
 	}
@@ -173,7 +181,7 @@ func TestBatchSpecWorkspaceCreatorProcess_Caching(t *testing.T) {
 	clock := func() time.Time { return now }
 	s := store.NewWithClock(db, &observation.TestContext, nil, clock)
 
-	creator := &batchSpecWorkspaceCreator{store: s}
+	creator := &batchSpecWorkspaceCreator{store: s, logger: logtest.Scoped(t)}
 
 	buildWorkspace := func(commit string) *service.RepoWorkspace {
 		return &service.RepoWorkspace{
@@ -190,14 +198,20 @@ func TestBatchSpecWorkspaceCreatorProcess_Caching(t *testing.T) {
 		}
 	}
 
-	executionResult := &execution.Result{
-		Diff:         testDiff,
-		ChangedFiles: &git.Changes{Modified: []string{"README.md", "urls.txt"}},
-		Outputs:      map[string]any{},
+	executionResult := &execution.AfterStepResult{
+		Diff:      testDiff,
+		StepIndex: 0,
+		// todo: required? step 0 should not have this.
+		PreviousStepResult: execution.StepResult{
+			Files:  &git.Changes{Modified: []string{"README.md", "urls.txt"}},
+			Stdout: bytes.NewBufferString("asdf2"),
+			Stderr: bytes.NewBufferString("asdf"),
+		},
+		Outputs: map[string]any{},
 	}
 
-	createBatchSpec := func(t *testing.T, noCache bool) *btypes.BatchSpec {
-		batchSpec, err := btypes.NewBatchSpecFromRaw(ct.TestRawBatchSpecYAML)
+	createBatchSpec := func(t *testing.T, noCache bool, spec string) *btypes.BatchSpec {
+		batchSpec, err := btypes.NewBatchSpecFromRaw(spec)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -210,10 +224,10 @@ func TestBatchSpecWorkspaceCreatorProcess_Caching(t *testing.T) {
 		return batchSpec
 	}
 
-	createCacheEntry := func(t *testing.T, batchSpec *btypes.BatchSpec, workspace *service.RepoWorkspace, result *execution.Result) *btypes.BatchSpecExecutionCacheEntry {
+	createCacheEntry := func(t *testing.T, batchSpec *btypes.BatchSpec, workspace *service.RepoWorkspace, result *execution.AfterStepResult) *btypes.BatchSpecExecutionCacheEntry {
 		t.Helper()
 
-		key := cache.KeyForWorkspace(
+		execKey := cache.KeyForWorkspace(
 			&template.BatchChangeAttributes{
 				Name:        batchSpec.Spec.Name,
 				Description: batchSpec.Spec.Description,
@@ -229,6 +243,10 @@ func TestBatchSpecWorkspaceCreatorProcess_Caching(t *testing.T) {
 			workspace.OnlyFetchWorkspace,
 			batchSpec.Spec.Steps,
 		)
+		key := cache.StepsCacheKey{
+			ExecutionKey: &execKey,
+			StepIndex:    0,
+		}
 		rawKey, err := key.Key()
 		if err != nil {
 			t.Fatal(err)
@@ -247,7 +265,7 @@ func TestBatchSpecWorkspaceCreatorProcess_Caching(t *testing.T) {
 	t.Run("caching enabled", func(t *testing.T) {
 		workspace := buildWorkspace("caching-enabled")
 
-		batchSpec := createBatchSpec(t, false)
+		batchSpec := createBatchSpec(t, false, ct.TestRawBatchSpecYAML)
 		entry := createCacheEntry(t, batchSpec, workspace, executionResult)
 
 		resolver := &dummyWorkspaceResolver{workspaces: []*service.RepoWorkspace{workspace}}
@@ -272,6 +290,12 @@ func TestBatchSpecWorkspaceCreatorProcess_Caching(t *testing.T) {
 				Path:               "",
 				OnlyFetchWorkspace: true,
 				CachedResultFound:  true,
+				StepCacheResults: map[int]btypes.StepCacheResult{
+					1: {
+						Key:   entry.Key,
+						Value: executionResult,
+					},
+				},
 			},
 		})
 
@@ -309,10 +333,117 @@ func TestBatchSpecWorkspaceCreatorProcess_Caching(t *testing.T) {
 		}
 	})
 
+	t.Run("only step is statically skipped", func(t *testing.T) {
+		workspace := buildWorkspace("no-step-after-eval")
+
+		spec := `
+name: my-unique-name
+description: My description
+on:
+- repository: github.com/sourcegraph/src-cli
+steps:
+- run: echo 'foobar'
+  container: alpine
+  if: ${{ eq repository.name "not the repo" }}
+changesetTemplate:
+  title: Hello World
+  body: My first batch change!
+  branch: hello-world
+  commit:
+    message: Append Hello World to all README.md files
+`
+		batchSpec := createBatchSpec(t, false, spec)
+
+		resolver := &dummyWorkspaceResolver{workspaces: []*service.RepoWorkspace{workspace}}
+		job := &btypes.BatchSpecResolutionJob{BatchSpecID: batchSpec.ID}
+		if err := creator.process(context.Background(), s, resolver.DummyBuilder, job); err != nil {
+			t.Fatalf("proces failed: %s", err)
+		}
+
+		have, _, err := s.ListBatchSpecWorkspaces(context.Background(), store.ListBatchSpecWorkspacesOpts{BatchSpecID: batchSpec.ID})
+		if err != nil {
+			t.Fatalf("listing workspaces failed: %s", err)
+		}
+
+		assertWorkspacesEqual(t, have, []*btypes.BatchSpecWorkspace{
+			{
+				RepoID:             repos[0].ID,
+				BatchSpecID:        batchSpec.ID,
+				ChangesetSpecIDs:   []int64{},
+				Branch:             "refs/heads/main",
+				Commit:             "no-step-after-eval",
+				FileMatches:        []string{},
+				Path:               "",
+				OnlyFetchWorkspace: true,
+				CachedResultFound:  true,
+			},
+		})
+
+		changesetSpecIDs := have[0].ChangesetSpecIDs
+		if len(changesetSpecIDs) != 0 {
+			t.Fatal("BatchSpecWorkspace has changeset specs, even though nothing ran")
+		}
+	})
+
+	t.Run("all steps are statically skipped", func(t *testing.T) {
+		workspace := buildWorkspace("no-steps-after-eval")
+
+		spec := `
+name: my-unique-name
+description: My description
+on:
+- repository: github.com/sourcegraph/src-cli
+steps:
+- run: echo 'foobar'
+  container: alpine
+  if: ${{ eq repository.name "not the repo" }}
+- run: echo 'foobar'
+  container: alpine
+  if: ${{ eq repository.name "not the repo" }}
+changesetTemplate:
+  title: Hello World
+  body: My first batch change!
+  branch: hello-world
+  commit:
+    message: Append Hello World to all README.md files
+`
+		batchSpec := createBatchSpec(t, false, spec)
+
+		resolver := &dummyWorkspaceResolver{workspaces: []*service.RepoWorkspace{workspace}}
+		job := &btypes.BatchSpecResolutionJob{BatchSpecID: batchSpec.ID}
+		if err := creator.process(context.Background(), s, resolver.DummyBuilder, job); err != nil {
+			t.Fatalf("proces failed: %s", err)
+		}
+
+		have, _, err := s.ListBatchSpecWorkspaces(context.Background(), store.ListBatchSpecWorkspacesOpts{BatchSpecID: batchSpec.ID})
+		if err != nil {
+			t.Fatalf("listing workspaces failed: %s", err)
+		}
+
+		assertWorkspacesEqual(t, have, []*btypes.BatchSpecWorkspace{
+			{
+				RepoID:             repos[0].ID,
+				BatchSpecID:        batchSpec.ID,
+				ChangesetSpecIDs:   []int64{},
+				Branch:             "refs/heads/main",
+				Commit:             "no-steps-after-eval",
+				FileMatches:        []string{},
+				Path:               "",
+				OnlyFetchWorkspace: true,
+				CachedResultFound:  true,
+			},
+		})
+
+		changesetSpecIDs := have[0].ChangesetSpecIDs
+		if len(changesetSpecIDs) != 0 {
+			t.Fatal("BatchSpecWorkspace has changeset specs, even though nothing ran")
+		}
+	})
+
 	t.Run("caching enabled but no diff in cache entry", func(t *testing.T) {
 		workspace := buildWorkspace("caching-enabled-no-diff")
 
-		batchSpec := createBatchSpec(t, false)
+		batchSpec := createBatchSpec(t, false, ct.TestRawBatchSpecYAML)
 
 		resultWithoutDiff := *executionResult
 		resultWithoutDiff.Diff = ""
@@ -354,7 +485,7 @@ func TestBatchSpecWorkspaceCreatorProcess_Caching(t *testing.T) {
 	t.Run("caching disabled", func(t *testing.T) {
 		workspace := buildWorkspace("caching-disabled")
 
-		batchSpec := createBatchSpec(t, true)
+		batchSpec := createBatchSpec(t, true, ct.TestRawBatchSpecYAML)
 		entry := createCacheEntry(t, batchSpec, workspace, executionResult)
 
 		resolver := &dummyWorkspaceResolver{workspaces: []*service.RepoWorkspace{workspace}}
@@ -402,7 +533,7 @@ func TestBatchSpecWorkspaceCreatorProcess_Caching(t *testing.T) {
 		workspace := buildWorkspace("caching-enabled-ignored")
 		workspace.Ignored = true
 
-		batchSpec := createBatchSpec(t, false)
+		batchSpec := createBatchSpec(t, false, ct.TestRawBatchSpecYAML)
 
 		entry := createCacheEntry(t, batchSpec, workspace, executionResult)
 
@@ -432,7 +563,7 @@ func TestBatchSpecWorkspaceCreatorProcess_Caching(t *testing.T) {
 		workspace := buildWorkspace("caching-enabled-ignored")
 		workspace.Unsupported = true
 
-		batchSpec := createBatchSpec(t, false)
+		batchSpec := createBatchSpec(t, false, ct.TestRawBatchSpecYAML)
 
 		entry := createCacheEntry(t, batchSpec, workspace, executionResult)
 
@@ -487,7 +618,7 @@ importChangesets:
 
 	resolver := &dummyWorkspaceResolver{}
 
-	creator := &batchSpecWorkspaceCreator{store: s}
+	creator := &batchSpecWorkspaceCreator{store: s, logger: logtest.Scoped(t)}
 	if err := creator.process(context.Background(), s, resolver.DummyBuilder, job); err != nil {
 		t.Fatalf("proces failed: %s", err)
 	}
@@ -546,7 +677,7 @@ importChangesets:
 
 	resolver := &dummyWorkspaceResolver{}
 
-	creator := &batchSpecWorkspaceCreator{store: s}
+	creator := &batchSpecWorkspaceCreator{store: s, logger: logtest.Scoped(t)}
 	if err := creator.process(context.Background(), s, resolver.DummyBuilder, job); err != nil {
 		t.Fatalf("proces failed: %s", err)
 	}
@@ -615,6 +746,7 @@ func assertWorkspacesEqual(t *testing.T, have, want []*btypes.BatchSpecWorkspace
 
 	opts := []cmp.Option{
 		cmpopts.IgnoreFields(btypes.BatchSpecWorkspace{}, "ID", "CreatedAt", "UpdatedAt"),
+		cmpopts.IgnoreUnexported(bytes.Buffer{}),
 	}
 	if diff := cmp.Diff(want, have, opts...); diff != "" {
 		t.Fatalf("wrong diff: %s", diff)

--- a/enterprise/cmd/worker/internal/batches/workers/batch_spec_workspace_creator_test.go
+++ b/enterprise/cmd/worker/internal/batches/workers/batch_spec_workspace_creator_test.go
@@ -201,10 +201,10 @@ func TestBatchSpecWorkspaceCreatorProcess_Caching(t *testing.T) {
 	executionResult := &execution.AfterStepResult{
 		Diff:      testDiff,
 		StepIndex: 0,
-		PreviousStepResult: execution.StepResult{
+		StepResult: execution.StepResult{
 			Files:  &git.Changes{Modified: []string{"README.md", "urls.txt"}},
-			Stdout: bytes.NewBufferString("asdf2"),
-			Stderr: bytes.NewBufferString("asdf"),
+			Stdout: "asdf2",
+			Stderr: "asdf",
 		},
 		Outputs: map[string]any{},
 	}

--- a/enterprise/cmd/worker/internal/batches/workers/batch_spec_workspace_creator_test.go
+++ b/enterprise/cmd/worker/internal/batches/workers/batch_spec_workspace_creator_test.go
@@ -201,7 +201,6 @@ func TestBatchSpecWorkspaceCreatorProcess_Caching(t *testing.T) {
 	executionResult := &execution.AfterStepResult{
 		Diff:      testDiff,
 		StepIndex: 0,
-		// todo: required? step 0 should not have this.
 		PreviousStepResult: execution.StepResult{
 			Files:  &git.Changes{Modified: []string{"README.md", "urls.txt"}},
 			Stdout: bytes.NewBufferString("asdf2"),

--- a/enterprise/internal/batches/service/workspace_resolver.go
+++ b/enterprise/internal/batches/service/workspace_resolver.go
@@ -365,6 +365,7 @@ func (wr *workspaceResolver) resolveRepositoriesMatchingQuery(ctx context.Contex
 		for path := range repoFileMatches[repo.ID] {
 			fileMatches = append(fileMatches, path)
 		}
+		// Sort file matches so cache results always match.
 		sort.Strings(fileMatches)
 		rev, err := repoToRepoRevisionWithDefaultBranch(ctx, database.NewDBWith(wr.store), repo, fileMatches)
 		if err != nil {

--- a/enterprise/internal/batches/store/worker_workspace_execution_test.go
+++ b/enterprise/internal/batches/store/worker_workspace_execution_test.go
@@ -43,7 +43,6 @@ func TestBatchSpecWorkspaceExecutionWorkerStore_MarkComplete(t *testing.T) {
 
 	// See the `output` var below
 	cacheEntryKeys := []string{
-		"Nsw12JxoLSHN4ta6D3G7FQ",
 		"JkC7Q0OOCZZ3Acv79QfwSA-step-0",
 		"0ydsSXJ77syIPdwNrsGlzQ-step-1",
 		"utgLpuQ3njDtLe3eztArAQ-step-2",
@@ -53,7 +52,6 @@ func TestBatchSpecWorkspaceExecutionWorkerStore_MarkComplete(t *testing.T) {
 
 	// Log entries with cache entries that'll be used to build the changeset specs.
 	output := `
-stdout: {"operation":"CACHE_RESULT","timestamp":"2021-11-04T12:43:19.551Z","status":"SUCCESS","metadata":{"key":"Nsw12JxoLSHN4ta6D3G7FQ","value":{"diff":"diff --git README.md README.md\nindex 1914491..d6782d3 100644\n--- README.md\n+++ README.md\n@@ -3,4 +3,7 @@ This repository is used to test opening and closing pull request with Automation\n \n (c) Copyright Sourcegraph 2013-2020.\n (c) Copyright Sourcegraph 2013-2020.\n-(c) Copyright Sourcegraph 2013-2020.\n\\ No newline at end of file\n+(c) Copyright Sourcegraph 2013-2020.this is step 2\n+this is step 3\n+this is step 4\n+previous_step.modified_files=[README.md]\ndiff --git README.txt README.txt\nnew file mode 100644\nindex 0000000..888e1ec\n--- /dev/null\n+++ README.txt\n@@ -0,0 +1 @@\n+this is step 1\ndiff --git my-output.txt my-output.txt\nnew file mode 100644\nindex 0000000..257ae8e\n--- /dev/null\n+++ my-output.txt\n@@ -0,0 +1 @@\n+this is step 5\n","changedFiles":{"modified":["README.md"],"added":["README.txt","my-output.txt"],"deleted":null,"renamed":null},"outputs":{"myOutput":"my-output.txt"},"Path":""}}}
 stdout: {"operation":"CACHE_AFTER_STEP_RESULT","timestamp":"2021-11-04T12:43:19.551Z","status":"SUCCESS","metadata":{"key":"JkC7Q0OOCZZ3Acv79QfwSA-step-0","value":{"stepIndex":0,"diff":"ZGlmZiAtLWdpdCBSRUFETUUudHh0IFJFQURNRS50eHQKbmV3IGZpbGUgbW9kZSAxMDA2NDQKaW5kZXggMDAwMDAwMC4uODg4ZTFlYwotLS0gL2Rldi9udWxsCisrKyBSRUFETUUudHh0CkBAIC0wLDAgKzEgQEAKK3RoaXMgaXMgc3RlcCAxCg==","outputs":{},"previousStepResult":{"Files":null,"Stdout":null,"Stderr":null}}}}
 stdout: {"operation":"CACHE_AFTER_STEP_RESULT","timestamp":"2021-11-04T12:43:19.551Z","status":"SUCCESS","metadata":{"key":"0ydsSXJ77syIPdwNrsGlzQ-step-1","value":{"stepIndex":1,"diff":"ZGlmZiAtLWdpdCBSRUFETUUubWQgUkVBRE1FLm1kCmluZGV4IDE5MTQ0OTEuLjVjMmI3MmQgMTAwNjQ0Ci0tLSBSRUFETUUubWQKKysrIFJFQURNRS5tZApAQCAtMyw0ICszLDQgQEAgVGhpcyByZXBvc2l0b3J5IGlzIHVzZWQgdG8gdGVzdCBvcGVuaW5nIGFuZCBjbG9zaW5nIHB1bGwgcmVxdWVzdCB3aXRoIEF1dG9tYXRpb24KIAogKGMpIENvcHlyaWdodCBTb3VyY2VncmFwaCAyMDEzLTIwMjAuCiAoYykgQ29weXJpZ2h0IFNvdXJjZWdyYXBoIDIwMTMtMjAyMC4KLShjKSBDb3B5cmlnaHQgU291cmNlZ3JhcGggMjAxMy0yMDIwLgpcIE5vIG5ld2xpbmUgYXQgZW5kIG9mIGZpbGUKKyhjKSBDb3B5cmlnaHQgU291cmNlZ3JhcGggMjAxMy0yMDIwLnRoaXMgaXMgc3RlcCAyCmRpZmYgLS1naXQgUkVBRE1FLnR4dCBSRUFETUUudHh0Cm5ldyBmaWxlIG1vZGUgMTAwNjQ0CmluZGV4IDAwMDAwMDAuLjg4OGUxZWMKLS0tIC9kZXYvbnVsbAorKysgUkVBRE1FLnR4dApAQCAtMCwwICsxIEBACit0aGlzIGlzIHN0ZXAgMQo=","outputs":{},"previousStepResult":{"Files":{"modified":null,"added":["README.txt"],"deleted":null,"renamed":null},"Stdout":{},"Stderr":{}}}}}
 stdout: {"operation":"CACHE_AFTER_STEP_RESULT","timestamp":"2021-11-04T12:43:19.551Z","status":"SUCCESS","metadata":{"key":"utgLpuQ3njDtLe3eztArAQ-step-2","value":{"stepIndex":2,"diff":"ZGlmZiAtLWdpdCBSRUFETUUubWQgUkVBRE1FLm1kCmluZGV4IDE5MTQ0OTEuLmNkMmNjYmYgMTAwNjQ0Ci0tLSBSRUFETUUubWQKKysrIFJFQURNRS5tZApAQCAtMyw0ICszLDUgQEAgVGhpcyByZXBvc2l0b3J5IGlzIHVzZWQgdG8gdGVzdCBvcGVuaW5nIGFuZCBjbG9zaW5nIHB1bGwgcmVxdWVzdCB3aXRoIEF1dG9tYXRpb24KIAogKGMpIENvcHlyaWdodCBTb3VyY2VncmFwaCAyMDEzLTIwMjAuCiAoYykgQ29weXJpZ2h0IFNvdXJjZWdyYXBoIDIwMTMtMjAyMC4KLShjKSBDb3B5cmlnaHQgU291cmNlZ3JhcGggMjAxMy0yMDIwLgpcIE5vIG5ld2xpbmUgYXQgZW5kIG9mIGZpbGUKKyhjKSBDb3B5cmlnaHQgU291cmNlZ3JhcGggMjAxMy0yMDIwLnRoaXMgaXMgc3RlcCAyCit0aGlzIGlzIHN0ZXAgMwpkaWZmIC0tZ2l0IFJFQURNRS50eHQgUkVBRE1FLnR4dApuZXcgZmlsZSBtb2RlIDEwMDY0NAppbmRleCAwMDAwMDAwLi44ODhlMWVjCi0tLSAvZGV2L251bGwKKysrIFJFQURNRS50eHQKQEAgLTAsMCArMSBAQAordGhpcyBpcyBzdGVwIDEK","outputs":{"myOutput":"my-output.txt"},"previousStepResult":{"Files":{"modified":["README.md"],"added":["README.txt"],"deleted":null,"renamed":null},"Stdout":{},"Stderr":{}}}}}
@@ -203,7 +201,7 @@ stdout: {"operation":"CACHE_AFTER_STEP_RESULT","timestamp":"2021-11-04T12:43:19.
 			}
 			entry := entries[0]
 
-			var cachedExecutionResult *execution.Result
+			var cachedExecutionResult *execution.AfterStepResult
 			if err := json.Unmarshal([]byte(entry.Value), &cachedExecutionResult); err != nil {
 				t.Fatal(err)
 			}
@@ -320,7 +318,6 @@ func TestBatchSpecWorkspaceExecutionWorkerStore_MarkFailed(t *testing.T) {
 
 	// See the `output` var below
 	cacheEntryKeys := []string{
-		"Nsw12JxoLSHN4ta6D3G7FQ",
 		"JkC7Q0OOCZZ3Acv79QfwSA-step-0",
 		"0ydsSXJ77syIPdwNrsGlzQ-step-1",
 		"utgLpuQ3njDtLe3eztArAQ-step-2",
@@ -330,7 +327,6 @@ func TestBatchSpecWorkspaceExecutionWorkerStore_MarkFailed(t *testing.T) {
 
 	// Log entries with cache entries that'll be used to build the changeset specs.
 	output := `
-stdout: {"operation":"CACHE_RESULT","timestamp":"2021-11-04T12:43:19.551Z","status":"SUCCESS","metadata":{"key":"Nsw12JxoLSHN4ta6D3G7FQ","value":{"diff":"diff --git README.md README.md\nindex 1914491..d6782d3 100644\n--- README.md\n+++ README.md\n@@ -3,4 +3,7 @@ This repository is used to test opening and closing pull request with Automation\n \n (c) Copyright Sourcegraph 2013-2020.\n (c) Copyright Sourcegraph 2013-2020.\n-(c) Copyright Sourcegraph 2013-2020.\n\\ No newline at end of file\n+(c) Copyright Sourcegraph 2013-2020.this is step 2\n+this is step 3\n+this is step 4\n+previous_step.modified_files=[README.md]\ndiff --git README.txt README.txt\nnew file mode 100644\nindex 0000000..888e1ec\n--- /dev/null\n+++ README.txt\n@@ -0,0 +1 @@\n+this is step 1\ndiff --git my-output.txt my-output.txt\nnew file mode 100644\nindex 0000000..257ae8e\n--- /dev/null\n+++ my-output.txt\n@@ -0,0 +1 @@\n+this is step 5\n","changedFiles":{"modified":["README.md"],"added":["README.txt","my-output.txt"],"deleted":null,"renamed":null},"outputs":{"myOutput":"my-output.txt"},"Path":""}}}
 stdout: {"operation":"CACHE_AFTER_STEP_RESULT","timestamp":"2021-11-04T12:43:19.551Z","status":"SUCCESS","metadata":{"key":"JkC7Q0OOCZZ3Acv79QfwSA-step-0","value":{"stepIndex":0,"diff":"ZGlmZiAtLWdpdCBSRUFETUUudHh0IFJFQURNRS50eHQKbmV3IGZpbGUgbW9kZSAxMDA2NDQKaW5kZXggMDAwMDAwMC4uODg4ZTFlYwotLS0gL2Rldi9udWxsCisrKyBSRUFETUUudHh0CkBAIC0wLDAgKzEgQEAKK3RoaXMgaXMgc3RlcCAxCg==","outputs":{},"previousStepResult":{"Files":null,"Stdout":null,"Stderr":null}}}}
 stdout: {"operation":"CACHE_AFTER_STEP_RESULT","timestamp":"2021-11-04T12:43:19.551Z","status":"SUCCESS","metadata":{"key":"0ydsSXJ77syIPdwNrsGlzQ-step-1","value":{"stepIndex":1,"diff":"ZGlmZiAtLWdpdCBSRUFETUUubWQgUkVBRE1FLm1kCmluZGV4IDE5MTQ0OTEuLjVjMmI3MmQgMTAwNjQ0Ci0tLSBSRUFETUUubWQKKysrIFJFQURNRS5tZApAQCAtMyw0ICszLDQgQEAgVGhpcyByZXBvc2l0b3J5IGlzIHVzZWQgdG8gdGVzdCBvcGVuaW5nIGFuZCBjbG9zaW5nIHB1bGwgcmVxdWVzdCB3aXRoIEF1dG9tYXRpb24KIAogKGMpIENvcHlyaWdodCBTb3VyY2VncmFwaCAyMDEzLTIwMjAuCiAoYykgQ29weXJpZ2h0IFNvdXJjZWdyYXBoIDIwMTMtMjAyMC4KLShjKSBDb3B5cmlnaHQgU291cmNlZ3JhcGggMjAxMy0yMDIwLgpcIE5vIG5ld2xpbmUgYXQgZW5kIG9mIGZpbGUKKyhjKSBDb3B5cmlnaHQgU291cmNlZ3JhcGggMjAxMy0yMDIwLnRoaXMgaXMgc3RlcCAyCmRpZmYgLS1naXQgUkVBRE1FLnR4dCBSRUFETUUudHh0Cm5ldyBmaWxlIG1vZGUgMTAwNjQ0CmluZGV4IDAwMDAwMDAuLjg4OGUxZWMKLS0tIC9kZXYvbnVsbAorKysgUkVBRE1FLnR4dApAQCAtMCwwICsxIEBACit0aGlzIGlzIHN0ZXAgMQo=","outputs":{},"previousStepResult":{"Files":{"modified":null,"added":["README.txt"],"deleted":null,"renamed":null},"Stdout":{},"Stderr":{}}}}}
 stdout: {"operation":"CACHE_AFTER_STEP_RESULT","timestamp":"2021-11-04T12:43:19.551Z","status":"SUCCESS","metadata":{"key":"utgLpuQ3njDtLe3eztArAQ-step-2","value":{"stepIndex":2,"diff":"ZGlmZiAtLWdpdCBSRUFETUUubWQgUkVBRE1FLm1kCmluZGV4IDE5MTQ0OTEuLmNkMmNjYmYgMTAwNjQ0Ci0tLSBSRUFETUUubWQKKysrIFJFQURNRS5tZApAQCAtMyw0ICszLDUgQEAgVGhpcyByZXBvc2l0b3J5IGlzIHVzZWQgdG8gdGVzdCBvcGVuaW5nIGFuZCBjbG9zaW5nIHB1bGwgcmVxdWVzdCB3aXRoIEF1dG9tYXRpb24KIAogKGMpIENvcHlyaWdodCBTb3VyY2VncmFwaCAyMDEzLTIwMjAuCiAoYykgQ29weXJpZ2h0IFNvdXJjZWdyYXBoIDIwMTMtMjAyMC4KLShjKSBDb3B5cmlnaHQgU291cmNlZ3JhcGggMjAxMy0yMDIwLgpcIE5vIG5ld2xpbmUgYXQgZW5kIG9mIGZpbGUKKyhjKSBDb3B5cmlnaHQgU291cmNlZ3JhcGggMjAxMy0yMDIwLnRoaXMgaXMgc3RlcCAyCit0aGlzIGlzIHN0ZXAgMwpkaWZmIC0tZ2l0IFJFQURNRS50eHQgUkVBRE1FLnR4dApuZXcgZmlsZSBtb2RlIDEwMDY0NAppbmRleCAwMDAwMDAwLi44ODhlMWVjCi0tLSAvZGV2L251bGwKKysrIFJFQURNRS50eHQKQEAgLTAsMCArMSBAQAordGhpcyBpcyBzdGVwIDEK","outputs":{"myOutput":"my-output.txt"},"previousStepResult":{"Files":{"modified":["README.md"],"added":["README.txt"],"deleted":null,"renamed":null},"Stdout":{},"Stderr":{}}}}}
@@ -425,7 +421,7 @@ stdout: {"operation":"CACHE_AFTER_STEP_RESULT","timestamp":"2021-11-04T12:43:19.
 			}
 			entry := entries[0]
 
-			var cachedExecutionResult *execution.Result
+			var cachedExecutionResult *execution.AfterStepResult
 			if err := json.Unmarshal([]byte(entry.Value), &cachedExecutionResult); err != nil {
 				t.Fatal(err)
 			}
@@ -531,11 +527,10 @@ func TestBatchSpecWorkspaceExecutionWorkerStore_MarkComplete_EmptyDiff(t *testin
 		t.Fatal(err)
 	}
 
-	cacheEntryKeys := []string{"Nsw12JxoLSHN4ta6D3G7FQ", "JkC7Q0OOCZZ3Acv79QfwSA-step-0"}
+	cacheEntryKeys := []string{"JkC7Q0OOCZZ3Acv79QfwSA-step-0"}
 
 	// Log entries with cache entries that'll be used to build the changeset specs.
 	output := `
-stdout: {"operation":"CACHE_RESULT","timestamp":"2021-11-04T12:43:19.551Z","status":"SUCCESS","metadata":{"key":"Nsw12JxoLSHN4ta6D3G7FQ","value":{"diff":"","changedFiles":{"modified":null,"added":null,"deleted":null,"renamed":null},"outputs":{},"Path":""}}}
 stdout: {"operation":"CACHE_AFTER_STEP_RESULT","timestamp":"2021-11-04T12:43:19.551Z","status":"SUCCESS","metadata":{"key":"JkC7Q0OOCZZ3Acv79QfwSA-step-0","value":{"stepIndex":0,"diff":"","outputs":{},"previousStepResult":{"Files":null,"Stdout":null,"Stderr":null}}}}`
 
 	entry := workerutil.ExecutionLogEntry{
@@ -551,7 +546,11 @@ stdout: {"operation":"CACHE_AFTER_STEP_RESULT","timestamp":"2021-11-04T12:43:19.
 		t.Fatal(err)
 	}
 
-	executionStore := &batchSpecWorkspaceExecutionWorkerStore{Store: workStore, observationContext: &observation.TestContext, accessTokenDeleterForTX: func(tx *Store) accessTokenHardDeleter { return tx.DatabaseDB().AccessTokens().HardDeleteByID }}
+	executionStore := &batchSpecWorkspaceExecutionWorkerStore{
+		Store:                   workStore,
+		observationContext:      &observation.TestContext,
+		accessTokenDeleterForTX: func(tx *Store) accessTokenHardDeleter { return tx.DatabaseDB().AccessTokens().HardDeleteByID },
+	}
 	opts := dbworkerstore.MarkFinalOptions{WorkerHostname: "worker-1"}
 
 	attachAccessToken := func(t *testing.T) int64 {

--- a/lib/batches/batch_spec.go
+++ b/lib/batches/batch_spec.go
@@ -94,8 +94,7 @@ type Step struct {
 	Files     map[string]string `json:"files,omitempty" yaml:"files,omitempty"`
 	Outputs   Outputs           `json:"outputs,omitempty" yaml:"outputs,omitempty"`
 	Mount     []Mount           `json:"mount,omitempty" yaml:"mount,omitempty"`
-
-	If any `json:"if,omitempty" yaml:"if,omitempty"`
+	If        any               `json:"if,omitempty" yaml:"if,omitempty"`
 }
 
 func (s *Step) IfCondition() string {
@@ -247,7 +246,7 @@ func SkippedStepsForRepo(spec *BatchSpec, repoName string, fileMatches []string)
 	skipped = map[int32]struct{}{}
 
 	for idx, step := range spec.Steps {
-		// If no if condition is given, just go ahead and add the step to the list.
+		// If no if condition is set the step is always run.
 		if step.IfCondition() == "" {
 			continue
 		}

--- a/lib/batches/execution/cache/cache.go
+++ b/lib/batches/execution/cache/cache.go
@@ -100,25 +100,13 @@ func resolveStepsEnvironment(globalEnv []string, steps []batches.Step) ([]map[st
 	return envs, nil
 }
 
-type cacheKey struct {
-	*ExecutionKey
-	Environments [][]string
-}
-
 func marshalAndHash(key *ExecutionKey, envs []map[string]string) (string, error) {
-	// TODO: Is this required? Marshal should be stable.
-	stringStepEnvs := [][]string{}
-	for _, stepEnv := range envs {
-		stepEnvs := []string{}
-		for k, v := range stepEnv {
-			stepEnvs = append(stepEnvs, fmt.Sprintf("%s=%s", k, v))
-		}
-		sort.Strings(stepEnvs)
-		stringStepEnvs = append(stringStepEnvs, stepEnvs)
-	}
-	raw, err := json.Marshal(cacheKey{
+	raw, err := json.Marshal(struct {
+		*ExecutionKey
+		Environments []map[string]string
+	}{
 		ExecutionKey: key,
-		Environments: stringStepEnvs,
+		Environments: envs,
 	})
 	if err != nil {
 		return "", err

--- a/lib/batches/json_logs.go
+++ b/lib/batches/json_logs.go
@@ -75,10 +75,6 @@ func (l *LogEvent) UnmarshalJSON(data []byte) error {
 		l.Metadata = new(TaskPreparingStepMetadata)
 	case LogEventOperationTaskStep:
 		l.Metadata = new(TaskStepMetadata)
-	case LogEventOperationTaskCalculatingDiff:
-		l.Metadata = new(TaskCalculatingDiffMetadata)
-	case LogEventOperationCacheResult:
-		l.Metadata = new(CacheResultMetadata)
 	case LogEventOperationCacheAfterStepResult:
 		l.Metadata = new(CacheAfterStepResultMetadata)
 	default:
@@ -118,8 +114,6 @@ const (
 	LogEventOperationTaskStepSkipped           LogEventOperation = "TASK_STEP_SKIPPED"
 	LogEventOperationTaskPreparingStep         LogEventOperation = "TASK_PREPARING_STEP"
 	LogEventOperationTaskStep                  LogEventOperation = "TASK_STEP"
-	LogEventOperationTaskCalculatingDiff       LogEventOperation = "TASK_CALCULATING_DIFF"
-	LogEventOperationCacheResult               LogEventOperation = "CACHE_RESULT"
 	LogEventOperationCacheAfterStepResult      LogEventOperation = "CACHE_AFTER_STEP_RESULT"
 )
 
@@ -245,15 +239,12 @@ type TaskStepMetadata struct {
 
 	Out string `json:"out,omitempty"`
 
+	// TODO: This doesn't need to be here, right? What about other fields here?
 	Diff    string         `json:"diff,omitempty"`
 	Outputs map[string]any `json:"outputs,omitempty"`
 
 	ExitCode int    `json:"exitCode,omitempty"`
 	Error    string `json:"error,omitempty"`
-}
-
-type TaskCalculatingDiffMetadata struct {
-	TaskID string `json:"taskID,omitempty"`
 }
 
 type CacheResultMetadata struct {

--- a/lib/batches/json_logs.go
+++ b/lib/batches/json_logs.go
@@ -247,11 +247,6 @@ type TaskStepMetadata struct {
 	Error    string `json:"error,omitempty"`
 }
 
-type CacheResultMetadata struct {
-	Key   string           `json:"key,omitempty"`
-	Value execution.Result `json:"value,omitempty"`
-}
-
 type CacheAfterStepResultMetadata struct {
 	Key   string                    `json:"key,omitempty"`
 	Value execution.AfterStepResult `json:"value,omitempty"`

--- a/lib/batches/json_logs.go
+++ b/lib/batches/json_logs.go
@@ -239,7 +239,6 @@ type TaskStepMetadata struct {
 
 	Out string `json:"out,omitempty"`
 
-	// TODO: This doesn't need to be here, right? What about other fields here?
 	Diff    string         `json:"diff,omitempty"`
 	Outputs map[string]any `json:"outputs,omitempty"`
 


### PR DESCRIPTION
This drops execution cache results from SSBC entirely (not step results, just execution) and only uses step cache results instead. The cache LRU swaps them out eventually so we don't need a costly migration. This is accomplished, by porting the logic to convert a step cache result into changeset specs into the backend. No executor run is required for the scenario where we have all step entries but no execution result anymore due to cache eviction, and we reduce data duplication in the database.
Most notably, check that I adjusted the test to not include a cache entry log line anymore, but all the changeset specs are still generated, just as before.

As a side-effect, this closes https://github.com/sourcegraph/sourcegraph/issues/36540.

## Test plan

Removed code and tests still pass! Also, I tested manually to double-check.