### PR TITLE
ssbc: Clarify caching UI

### DIFF
--- a/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspaceDetails.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspaceDetails.tsx
@@ -562,7 +562,11 @@ const WorkspaceStep: React.FunctionComponent<React.PropsWithChildren<WorkspaceSt
                         <Text className="mb-0">
                             <strong>
                                 Step has been skipped
-                                {cachedResultFound && <> because a cached result was found for this workspace</>}.
+                                {cachedResultFound && <> because a cached result was found for this workspace</>}
+                                {!cachedResultFound && step.cachedResultFound && (
+                                    <> because a cached result was found for this step</>
+                                )}
+                                .
                             </strong>
                         </Text>
                     )}


### PR DESCRIPTION
Before, it would just say "Step skipped", since we also have a concept of skipping steps using `if`, this felt a bit misleading, so adjusted the wording to be extra clear.



## Test plan

Validated the label appears as expected.

## App preview:

- [Web](https://sg-web-es-clear-caching-label.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-buzeuxqspo.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
