### PR TITLE
executor: Implement shallow clones and sparse checkouts

### DIFF
--- a/enterprise/cmd/executor/internal/command/observability.go
+++ b/enterprise/cmd/executor/internal/command/observability.go
@@ -10,14 +10,18 @@ import (
 )
 
 type Operations struct {
-	SetupGitInit              *observation.Operation
-	SetupGitFetch             *observation.Operation
-	SetupAddRemote            *observation.Operation
-	SetupGitCheckout          *observation.Operation
-	SetupFirecrackerStart     *observation.Operation
-	SetupStartupScript        *observation.Operation
-	TeardownFirecrackerRemove *observation.Operation
-	Exec                      *observation.Operation
+	SetupGitInit                 *observation.Operation
+	SetupAddRemote               *observation.Operation
+	SetupGitDisableGC            *observation.Operation
+	SetupGitFetch                *observation.Operation
+	SetupGitSparseCheckoutConfig *observation.Operation
+	SetupGitSparseCheckoutSet    *observation.Operation
+	SetupGitCheckout             *observation.Operation
+	SetupGitSetRemoteUrl         *observation.Operation
+	SetupFirecrackerStart        *observation.Operation
+	SetupStartupScript           *observation.Operation
+	TeardownFirecrackerRemove    *observation.Operation
+	Exec                         *observation.Operation
 
 	RunLockWaitTotal prometheus.Counter
 	RunLockHeldTotal prometheus.Counter
@@ -52,14 +56,18 @@ func NewOperations(observationContext *observation.Context) *Operations {
 	observationContext.Registerer.MustRegister(runLockHeldTotal)
 
 	return &Operations{
-		SetupGitInit:              op("setup.git.init"),
-		SetupGitFetch:             op("setup.git.fetch"),
-		SetupAddRemote:            op("setup.git.add-remote"),
-		SetupGitCheckout:          op("setup.git.checkout"),
-		SetupFirecrackerStart:     op("setup.firecracker.start"),
-		SetupStartupScript:        op("setup.startup-script"),
-		TeardownFirecrackerRemove: op("teardown.firecracker.remove"),
-		Exec:                      op("exec"),
+		SetupGitInit:                 op("setup.git.init"),
+		SetupAddRemote:               op("setup.git.add-remote"),
+		SetupGitDisableGC:            op("setup.git.disable-gc"),
+		SetupGitFetch:                op("setup.git.fetch"),
+		SetupGitSparseCheckoutConfig: op("setup.git.sparse-checkout-config"),
+		SetupGitSparseCheckoutSet:    op("setup.git.sparse-checkout-set"),
+		SetupGitCheckout:             op("setup.git.checkout"),
+		SetupGitSetRemoteUrl:         op("setup.git.set-remote"),
+		SetupFirecrackerStart:        op("setup.firecracker.start"),
+		SetupStartupScript:           op("setup.startup-script"),
+		TeardownFirecrackerRemove:    op("teardown.firecracker.remove"),
+		Exec:                         op("exec"),
 
 		RunLockWaitTotal: runLockWaitTotal,
 		RunLockHeldTotal: runLockHeldTotal,

--- a/enterprise/cmd/executor/internal/worker/handler_test.go
+++ b/enterprise/cmd/executor/internal/worker/handler_test.go
@@ -19,6 +19,10 @@ import (
 func TestHandle(t *testing.T) {
 	testDir := "/tmp/codeintel"
 	makeTempDir = func() (string, error) { return testDir, nil }
+	t.Cleanup(func() {
+		makeTempDir = makeTemporaryDirectory
+	})
+
 	if err := os.MkdirAll(filepath.Join(testDir, command.ScriptsPath), os.ModePerm); err != nil {
 		t.Fatalf("unexpected error creating workspace: %s", err)
 	}

--- a/enterprise/cmd/executor/internal/worker/workspace.go
+++ b/enterprise/cmd/executor/internal/worker/workspace.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/executor/internal/command"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
@@ -13,11 +14,14 @@ import (
 
 const SchemeExecutorToken = "token-executor"
 
+// These env vars should be set for git commands. We want to make sure it never hangs on interactive input.
+var gitStdEnv = []string{"GIT_TERMINAL_PROMPT=0"}
+
 // prepareWorkspace creates and returns a temporary director in which acts the workspace
 // while processing a single job. It is up to the caller to ensure that this directory is
 // removed after the job has finished processing. If a repository name is supplied, then
 // that repository will be cloned (through the frontend API) into the workspace.
-func (h *handler) prepareWorkspace(ctx context.Context, commandRunner command.Runner, repositoryName, commit string) (_ string, err error) {
+func (h *handler) prepareWorkspace(ctx context.Context, commandRunner command.Runner, repositoryName, repositoryDirectory, commit string, fetchTags bool, shallowClone bool, sparseCheckout []string) (_ string, err error) {
 	tempDir, err := makeTempDir()
 	if err != nil {
 		return "", err
@@ -29,6 +33,19 @@ func (h *handler) prepareWorkspace(ctx context.Context, commandRunner command.Ru
 	}()
 
 	if repositoryName != "" {
+		repoPath := tempDir
+		if repositoryDirectory != "" {
+			repoPath = filepath.Join(tempDir, repositoryDirectory)
+
+			if !strings.HasPrefix(repoPath, tempDir) {
+				return "", errors.Newf("invalid repo path %q not a subdirectory of %q", repoPath, tempDir)
+			}
+
+			if err := os.MkdirAll(repoPath, os.ModePerm); err != nil {
+				return "", errors.Wrap(err, "creating repo directory")
+			}
+		}
+
 		cloneURL, err := makeRelativeURL(
 			h.options.ClientOptions.EndpointOptions.URL,
 			h.options.GitServicePath,
@@ -44,12 +61,111 @@ func (h *handler) prepareWorkspace(ctx context.Context, commandRunner command.Ru
 			h.options.ClientOptions.EndpointOptions.Token,
 		)
 
-		gitCommands := []command.CommandSpec{
-			{Key: "setup.git.init", Command: []string{"git", "-C", tempDir, "init"}, Operation: h.operations.SetupGitInit},
-			{Key: "setup.git.fetch", Command: []string{"git", "-C", tempDir, "-c", "protocol.version=2", "-c", authorizationOption, "-c", "http.extraHeader=X-Sourcegraph-Actor-UID: internal", "fetch", cloneURL.String(), "-t", commit}, Operation: h.operations.SetupGitFetch},
-			{Key: "setup.git.add-remote", Command: []string{"git", "-C", tempDir, "remote", "add", "origin", repositoryName}, Operation: h.operations.SetupAddRemote},
-			{Key: "setup.git.checkout", Command: []string{"git", "-C", tempDir, "checkout", commit}, Operation: h.operations.SetupGitCheckout},
+		fetchCommand := []string{
+			"git",
+			"-C", repoPath,
+			"-c", "protocol.version=2",
+			"-c", authorizationOption,
+			"-c", "http.extraHeader=X-Sourcegraph-Actor-UID: internal",
+			"fetch",
+			"--progress",
+			"--no-recurse-submodules",
+			"origin",
+			commit,
 		}
+
+		appendFetchArg := func(arg string) {
+			l := len(fetchCommand)
+			insertPos := l - 2
+			fetchCommand = append(fetchCommand[:insertPos+1], fetchCommand[insertPos:]...)
+			fetchCommand[insertPos] = arg
+		}
+
+		if fetchTags {
+			appendFetchArg("--tags")
+		}
+
+		if shallowClone {
+			if !fetchTags {
+				appendFetchArg("--no-tags")
+			}
+			appendFetchArg("--depth=1")
+		}
+
+		// For a sparse checkout, we want to add a blob filter so we only fetch the minimum set of files initially.
+		if len(sparseCheckout) > 0 {
+			appendFetchArg("--filter=blob:none")
+		}
+
+		gitCommands := []command.CommandSpec{
+			{Key: "setup.git.init", Env: gitStdEnv, Command: []string{"git", "-C", repoPath, "init"}, Operation: h.operations.SetupGitInit},
+			{Key: "setup.git.add-remote", Env: gitStdEnv, Command: []string{"git", "-C", repoPath, "remote", "add", "origin", cloneURL.String()}, Operation: h.operations.SetupAddRemote},
+			// Disable gc, this can improve performance and should never run for executor clones.
+			{Key: "setup.git.disable-gc", Env: gitStdEnv, Command: []string{"git", "-C", repoPath, "config", "--local", "gc.auto", "0"}, Operation: h.operations.SetupGitDisableGC},
+			{Key: "setup.git.fetch", Env: gitStdEnv, Command: fetchCommand, Operation: h.operations.SetupGitFetch},
+		}
+
+		if len(sparseCheckout) > 0 {
+			gitCommands = append(gitCommands, command.CommandSpec{
+				Key:       "setup.git.sparse-checkout-config",
+				Env:       gitStdEnv,
+				Command:   []string{"git", "-C", repoPath, "config", "--local", "core.sparseCheckout", "1"},
+				Operation: h.operations.SetupGitSparseCheckoutConfig,
+			})
+			gitCommands = append(gitCommands, command.CommandSpec{
+				Key:       "setup.git.sparse-checkout-set",
+				Env:       gitStdEnv,
+				Command:   append([]string{"git", "-C", repoPath, "sparse-checkout", "set", "--no-cone", "--"}, sparseCheckout...),
+				Operation: h.operations.SetupGitSparseCheckoutSet,
+			})
+		}
+
+		checkoutCommand := []string{
+			"git",
+			"-C", repoPath,
+			"checkout",
+			"--progress",
+			"--force",
+			commit,
+		}
+
+		// Sparse checkouts need to fetch additional blobs, so we need to add
+		// auth config here.
+		if len(sparseCheckout) > 0 {
+			checkoutCommand = []string{
+				"git",
+				"-C", repoPath,
+				"-c", "protocol.version=2", "-c", authorizationOption, "-c", "http.extraHeader=X-Sourcegraph-Actor-UID: internal",
+				"checkout",
+				"--progress",
+				"--force",
+				commit,
+			}
+		}
+
+		gitCommands = append(gitCommands, command.CommandSpec{
+			Key:       "setup.git.checkout",
+			Env:       gitStdEnv,
+			Command:   checkoutCommand,
+			Operation: h.operations.SetupGitCheckout,
+		})
+
+		// This is for LSIF, it relies on the origin being set to the upstream repo
+		// for indexing.
+		gitCommands = append(gitCommands, command.CommandSpec{
+			Key: "setup.git.set-remote",
+			Env: gitStdEnv,
+			Command: []string{
+				"git",
+				"-C", repoPath,
+				"remote",
+				"set-url",
+				"origin",
+				repositoryName,
+			},
+			Operation: h.operations.SetupGitSetRemoteUrl,
+		})
+
 		for _, spec := range gitCommands {
 			if err := commandRunner.Run(ctx, spec); err != nil {
 				return "", errors.Wrap(err, fmt.Sprintf("failed %s", spec.Key))
@@ -57,8 +173,9 @@ func (h *handler) prepareWorkspace(ctx context.Context, commandRunner command.Ru
 		}
 	}
 
+	// Create the scripts path.
 	if err := os.MkdirAll(filepath.Join(tempDir, command.ScriptsPath), os.ModePerm); err != nil {
-		return "", err
+		return "", errors.Wrap(err, "creating script path")
 	}
 
 	return tempDir, nil

--- a/enterprise/cmd/executor/internal/worker/workspace_test.go
+++ b/enterprise/cmd/executor/internal/worker/workspace_test.go
@@ -3,6 +3,7 @@ package worker
 import (
 	"context"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -12,7 +13,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 )
 
-func TestPrepareWorkspace(t *testing.T) {
+func TestPrepareWorkspace_Clone(t *testing.T) {
 	options := Options{
 		ClientOptions: apiclient.Options{
 			EndpointOptions: apiclient.EndpointOptions{
@@ -28,14 +29,14 @@ func TestPrepareWorkspace(t *testing.T) {
 		operations: command.NewOperations(&observation.TestContext),
 	}
 
-	dir, err := handler.prepareWorkspace(context.Background(), runner, "torvalds/linux", "deadbeef")
+	dir, err := handler.prepareWorkspace(context.Background(), runner, "torvalds/linux", "", "deadbeef", true, false, []string{})
 	if err != nil {
 		t.Fatalf("unexpected error preparing workspace: %s", err)
 	}
 	defer os.RemoveAll(dir)
 
-	if value := len(runner.RunFunc.History()); value != 4 {
-		t.Fatalf("unexpected number of calls to Run. want=%d have=%d", 4, value)
+	if value := len(runner.RunFunc.History()); value != 6 {
+		t.Fatalf("unexpected number of calls to Run. want=%d have=%d", 6, value)
 	}
 
 	var commands [][]string
@@ -45,16 +46,154 @@ func TestPrepareWorkspace(t *testing.T) {
 
 	expectedCommands := [][]string{
 		{"git", "-C", dir, "init"},
-		{"git", "-C", dir, "-c", "protocol.version=2", "-c", "http.extraHeader=Authorization: token-executor hunter2", "-c", "http.extraHeader=X-Sourcegraph-Actor-UID: internal", "fetch", "https://executor@test.io/internal/git/torvalds/linux", "-t", "deadbeef"},
-		{"git", "-C", dir, "remote", "add", "origin", "torvalds/linux"},
-		{"git", "-C", dir, "checkout", "deadbeef"},
+		{"git", "-C", dir, "remote", "add", "origin", "https://executor@test.io/internal/git/torvalds/linux"},
+		{"git", "-C", dir, "config", "--local", "gc.auto", "0"},
+		{"git", "-C", dir, "-c", "protocol.version=2", "-c", "http.extraHeader=Authorization: token-executor hunter2", "-c", "http.extraHeader=X-Sourcegraph-Actor-UID: internal", "fetch", "--progress", "--no-recurse-submodules", "--tags", "origin", "deadbeef"},
+		{"git", "-C", dir, "checkout", "--progress", "--force", "deadbeef"},
+		{"git", "-C", dir, "remote", "set-url", "origin", "torvalds/linux"},
 	}
 	if diff := cmp.Diff(expectedCommands, commands); diff != "" {
 		t.Errorf("unexpected commands (-want +got):\n%s", diff)
 	}
 }
 
-func TestPrepareWorkspaceNoRepository(t *testing.T) {
+func TestPrepareWorkspace_Clone_Subdirectory(t *testing.T) {
+	options := Options{
+		ClientOptions: apiclient.Options{
+			EndpointOptions: apiclient.EndpointOptions{
+				URL:   "https://test.io",
+				Token: "hunter2",
+			},
+		},
+		GitServicePath: "/internal/git",
+	}
+	runner := NewMockRunner()
+	handler := &handler{
+		options:    options,
+		operations: command.NewOperations(&observation.TestContext),
+	}
+
+	dir, err := handler.prepareWorkspace(context.Background(), runner, "torvalds/linux", "subdirectory", "deadbeef", false, false, []string{})
+	if err != nil {
+		t.Fatalf("unexpected error preparing workspace: %s", err)
+	}
+	defer os.RemoveAll(dir)
+
+	repoDir := filepath.Join(dir, "subdirectory")
+
+	if value := len(runner.RunFunc.History()); value != 6 {
+		t.Fatalf("unexpected number of calls to Run. want=%d have=%d", 6, value)
+	}
+
+	var commands [][]string
+	for _, call := range runner.RunFunc.History() {
+		commands = append(commands, call.Arg1.Command)
+	}
+
+	expectedCommands := [][]string{
+		{"git", "-C", repoDir, "init"},
+		{"git", "-C", repoDir, "remote", "add", "origin", "https://executor@test.io/internal/git/torvalds/linux"},
+		{"git", "-C", repoDir, "config", "--local", "gc.auto", "0"},
+		{"git", "-C", repoDir, "-c", "protocol.version=2", "-c", "http.extraHeader=Authorization: token-executor hunter2", "-c", "http.extraHeader=X-Sourcegraph-Actor-UID: internal", "fetch", "--progress", "--no-recurse-submodules", "origin", "deadbeef"},
+		{"git", "-C", repoDir, "checkout", "--progress", "--force", "deadbeef"},
+		{"git", "-C", repoDir, "remote", "set-url", "origin", "torvalds/linux"},
+	}
+	if diff := cmp.Diff(expectedCommands, commands); diff != "" {
+		t.Errorf("unexpected commands (-want +got):\n%s", diff)
+	}
+}
+
+func TestPrepareWorkspace_ShallowClone(t *testing.T) {
+	options := Options{
+		ClientOptions: apiclient.Options{
+			EndpointOptions: apiclient.EndpointOptions{
+				URL:   "https://test.io",
+				Token: "hunter2",
+			},
+		},
+		GitServicePath: "/internal/git",
+	}
+	runner := NewMockRunner()
+	handler := &handler{
+		options:    options,
+		operations: command.NewOperations(&observation.TestContext),
+	}
+
+	dir, err := handler.prepareWorkspace(context.Background(), runner, "torvalds/linux", "", "deadbeef", false, true, []string{})
+	if err != nil {
+		t.Fatalf("unexpected error preparing workspace: %s", err)
+	}
+	defer os.RemoveAll(dir)
+
+	if value := len(runner.RunFunc.History()); value != 6 {
+		t.Fatalf("unexpected number of calls to Run. want=%d have=%d", 6, value)
+	}
+
+	var commands [][]string
+	for _, call := range runner.RunFunc.History() {
+		commands = append(commands, call.Arg1.Command)
+	}
+
+	expectedCommands := [][]string{
+		{"git", "-C", dir, "init"},
+		{"git", "-C", dir, "remote", "add", "origin", "https://executor@test.io/internal/git/torvalds/linux"},
+		{"git", "-C", dir, "config", "--local", "gc.auto", "0"},
+		{"git", "-C", dir, "-c", "protocol.version=2", "-c", "http.extraHeader=Authorization: token-executor hunter2", "-c", "http.extraHeader=X-Sourcegraph-Actor-UID: internal", "fetch", "--progress", "--no-recurse-submodules", "--no-tags", "--depth=1", "origin", "deadbeef"},
+		{"git", "-C", dir, "checkout", "--progress", "--force", "deadbeef"},
+		{"git", "-C", dir, "remote", "set-url", "origin", "torvalds/linux"},
+	}
+	if diff := cmp.Diff(expectedCommands, commands); diff != "" {
+		t.Errorf("unexpected commands (-want +got):\n%s", diff)
+	}
+}
+
+func TestPrepareWorkspace_SparseCheckout(t *testing.T) {
+	options := Options{
+		ClientOptions: apiclient.Options{
+			EndpointOptions: apiclient.EndpointOptions{
+				URL:   "https://test.io",
+				Token: "hunter2",
+			},
+		},
+		GitServicePath: "/internal/git",
+	}
+	runner := NewMockRunner()
+	handler := &handler{
+		options:    options,
+		operations: command.NewOperations(&observation.TestContext),
+	}
+
+	dir, err := handler.prepareWorkspace(context.Background(), runner, "torvalds/linux", "", "deadbeef", false, true, []string{"kernel"})
+	if err != nil {
+		t.Fatalf("unexpected error preparing workspace: %s", err)
+	}
+	defer os.RemoveAll(dir)
+
+	if value := len(runner.RunFunc.History()); value != 8 {
+		t.Fatalf("unexpected number of calls to Run. want=%d have=%d", 8, value)
+	}
+
+	var commands [][]string
+	for _, call := range runner.RunFunc.History() {
+		commands = append(commands, call.Arg1.Command)
+	}
+
+	expectedCommands := [][]string{
+		{"git", "-C", dir, "init"},
+		{"git", "-C", dir, "remote", "add", "origin", "https://executor@test.io/internal/git/torvalds/linux"},
+		{"git", "-C", dir, "config", "--local", "gc.auto", "0"},
+		{"git", "-C", dir, "-c", "protocol.version=2", "-c", "http.extraHeader=Authorization: token-executor hunter2", "-c", "http.extraHeader=X-Sourcegraph-Actor-UID: internal", "fetch", "--progress", "--no-recurse-submodules", "--no-tags", "--depth=1", "--filter=blob:none", "origin", "deadbeef"},
+		{"git", "-C", dir, "config", "--local", "core.sparseCheckout", "1"},
+		{"git", "-C", dir, "sparse-checkout", "set", "--no-cone", "--", "kernel"},
+		{"git", "-C", dir, "-c", "protocol.version=2", "-c", "http.extraHeader=Authorization: token-executor hunter2", "-c", "http.extraHeader=X-Sourcegraph-Actor-UID: internal", "checkout", "--progress", "--force", "deadbeef"},
+		{"git", "-C", dir, "remote", "set-url", "origin", "torvalds/linux"},
+	}
+	if diff := cmp.Diff(expectedCommands, commands); diff != "" {
+		t.Errorf("unexpected commands (-want +got):\n%s", diff)
+	}
+}
+
+func TestPrepareWorkspace_NoRepository(t *testing.T) {
 	options := Options{}
 	runner := NewMockRunner()
 	handler := &handler{
@@ -62,7 +201,7 @@ func TestPrepareWorkspaceNoRepository(t *testing.T) {
 		operations: command.NewOperations(&observation.TestContext),
 	}
 
-	dir, err := handler.prepareWorkspace(context.Background(), runner, "", "")
+	dir, err := handler.prepareWorkspace(context.Background(), runner, "", "", "", false, false, []string{})
 	if err != nil {
 		t.Fatalf("unexpected error preparing workspace: %s", err)
 	}

--- a/enterprise/cmd/frontend/internal/executorqueue/queues/codeintel/transform.go
+++ b/enterprise/cmd/frontend/internal/executorqueue/queues/codeintel/transform.go
@@ -52,6 +52,7 @@ func transformRecord(index store.Index, accessToken string) (apiclient.Job, erro
 		ID:             index.ID,
 		Commit:         index.Commit,
 		RepositoryName: index.RepositoryName,
+		FetchTags:      true,
 		DockerSteps:    dockerSteps,
 		CliSteps: []apiclient.CliStep{
 			{

--- a/enterprise/cmd/frontend/internal/executorqueue/queues/codeintel/transform_test.go
+++ b/enterprise/cmd/frontend/internal/executorqueue/queues/codeintel/transform_test.go
@@ -42,6 +42,7 @@ func TestTransformRecord(t *testing.T) {
 		ID:                  42,
 		Commit:              "deadbeef",
 		RepositoryName:      "linux",
+		FetchTags:           true,
 		VirtualMachineFiles: nil,
 		DockerSteps: []apiclient.DockerStep{
 			{
@@ -120,6 +121,7 @@ func TestTransformRecordWithoutIndexer(t *testing.T) {
 		ID:                  42,
 		Commit:              "deadbeef",
 		RepositoryName:      "linux",
+		FetchTags:           true,
 		VirtualMachineFiles: nil,
 		DockerSteps: []apiclient.DockerStep{
 			{

--- a/enterprise/internal/executor/client_types.go
+++ b/enterprise/internal/executor/client_types.go
@@ -12,11 +12,27 @@ type Job struct {
 	// workspace prior to job execution.
 	RepositoryName string `json:"repositoryName"`
 
+	// RepositoryDirectory is the relative path to which the repo is cloned. If
+	// unset, defaults to the workspace root.
+	RepositoryDirectory string `json:"repositoryDirectory"`
+
 	// Commit is the revhash that should be checked out prior to job execution.
 	Commit string `json:"commit"`
 
+	// FetchTags, when true also fetches tags from the remote.
+	FetchTags bool `json:"fetchTags"`
+
+	// ShallowClone, when true speeds up repo cloning by fetching only the target commit
+	// and no tags.
+	ShallowClone bool `json:"shallowClone"`
+
+	// SparseCheckout denotes the path patterns to check out. This can be used to fetch
+	// only a part of a repository.
+	SparseCheckout []string `json:"sparseCheckout"`
+
 	// VirtualMachineFiles is a map from file names to content. Each entry in
 	// this map will be written into the workspace prior to job execution.
+	// The file paths must be relative and within the working directory.
 	VirtualMachineFiles map[string]string `json:"files"`
 
 	// DockerSteps describe a series of docker run commands to be invoked in the


### PR DESCRIPTION
To improve performance, we now offer these two new clone modes. They will be used in a follow-up PR by SSBC to replace repo zip archive fetching with proper clones that are faster because git can stream, unlike zip.

This also adds a flag to change how local workspaces are set up: the repo can now be cloned into a subdirectory so the script and other additional files don't clutter the repo content. 

Does the new way we use git break auto indexing in any way I can't predict? It works properly locally.
Also, I think I heard you say that you need full clones for LSIF so code intel doesn't benefit too much from this yet, but maybe there's potential in the future to use shallow clones and sparse checkouts too? Or we can find a way to get it to work without the entire repo; this brings down network traffic for sg/sg from ~800MB to ~52MB, one of the big limitations on our executors in prod today (network and disk IO).

## Test plan

Manually checked SSBC and auto-indexing still seem to work. The two new modes aren't used yet in this PR, so this will mostly be an invisible change until we make use of it in a follow-up PR.