### PR TITLE
search: return alert for lucky alternate queries

### DIFF
--- a/internal/search/alert/observer.go
+++ b/internal/search/alert/observer.go
@@ -242,6 +242,7 @@ func (o *Observer) errorToAlert(ctx context.Context, err error) (*search.Alert, 
 	var (
 		mErr *searchrepos.MissingRepoRevsError
 		oErr *errOverRepoLimit
+		lErr *ErrLuckyQueries
 	)
 
 	if errors.HasType(err, authz.ErrStalePermissions{}) {
@@ -278,6 +279,15 @@ func (o *Observer) errorToAlert(ctx context.Context, err error) (*search.Alert, 
 		}
 		a.Priority = 6
 		return a, nil
+	}
+
+	if errors.As(err, &lErr) {
+		return &search.Alert{
+			PrometheusType:  "lucky_search_notice",
+			Title:           "Showing additional results for similar queries",
+			Description:     "We returned all the results for your query. We also added results you might be interested in for similar queries. Below are similar queries we ran.",
+			ProposedQueries: lErr.ProposedQueries,
+		}, nil
 	}
 
 	if strings.Contains(err.Error(), "Worker_oomed") || strings.Contains(err.Error(), "Worker_exited_abnormally") {
@@ -353,6 +363,14 @@ type errOverRepoLimit struct {
 
 func (e *errOverRepoLimit) Error() string {
 	return "Too many matching repositories"
+}
+
+type ErrLuckyQueries struct {
+	ProposedQueries []*search.ProposedQuery
+}
+
+func (e *ErrLuckyQueries) Error() string {
+	return "We were able to find more results by slightly modifying your query"
 }
 
 // isContextError returns true if ctx.Err() is not nil or if err

--- a/internal/search/job/jobutil/mapper.go
+++ b/internal/search/job/jobutil/mapper.go
@@ -31,6 +31,9 @@ type Mapper struct {
 
 	// Repo pager Job (pre-step for some Search Jobs)
 	MapRepoPagerJob func(*repoPagerJob) *repoPagerJob
+	// A job that exposes information of alternate queries for consumers
+	// (e.g., for generated queries). Does not return results.
+	MapAlternateQueriesAlertJob func(*alternateQueriesAlertJob) *alternateQueriesAlertJob
 
 	// Expression Jobs
 	MapAndJob func(children []job.Job) []job.Job
@@ -115,6 +118,12 @@ func (m *Mapper) Map(j job.Job) job.Job {
 	case *repos.ComputeExcludedJob:
 		if m.MapReposComputeExcludedJob != nil {
 			j = m.MapReposComputeExcludedJob(j)
+		}
+		return j
+
+	case *alternateQueriesAlertJob:
+		if m.MapAlternateQueriesAlertJob != nil {
+			j = m.MapAlternateQueriesAlertJob(j)
 		}
 		return j
 

--- a/internal/search/job/jobutil/printers.go
+++ b/internal/search/job/jobutil/printers.go
@@ -50,6 +50,7 @@ func SexpFormat(j job.Job, sep, indent string) string {
 			*commit.SearchJob,
 			*zoekt.GlobalSymbolSearchJob,
 			*repos.ComputeExcludedJob,
+			*alternateQueriesAlertJob,
 			*NoopJob:
 			b.WriteString(j.Name())
 
@@ -210,6 +211,7 @@ func PrettyMermaid(j job.Job) string {
 			*commit.SearchJob,
 			*zoekt.GlobalSymbolSearchJob,
 			*repos.ComputeExcludedJob,
+			*alternateQueriesAlertJob,
 			*NoopJob:
 			writeNode(b, depth, RoundedStyle, &id, j.Name())
 
@@ -328,6 +330,7 @@ func toJSON(j job.Job, verbose bool) any {
 			*commit.SearchJob,
 			*zoekt.GlobalSymbolSearchJob,
 			*repos.ComputeExcludedJob,
+			*alternateQueriesAlertJob,
 			*NoopJob:
 			if verbose {
 				return map[string]any{j.Name(): j}

--- a/internal/search/job/jobutil/testdata/TestNewFeelingLuckySearchJob/trigger_unordered_patterns.golden
+++ b/internal/search/job/jobutil/testdata/TestNewFeelingLuckySearchJob/trigger_unordered_patterns.golden
@@ -153,6 +153,17 @@
         "value": "20s"
       },
       {
+        "AlternateQueriesAlertJob": {
+          "AlternateQueries": [
+            {
+              "Description": "AND patterns together",
+              "Query": "(parse and func)",
+              "PatternType": 1
+            }
+          ]
+        }
+      },
+      {
         "TIMEOUT": {
           "LIMIT": {
             "PARALLEL": [

--- a/internal/search/job/jobutil/testdata/TestNewFeelingLuckySearchJob/trigger_unquoted_rule.golden
+++ b/internal/search/job/jobutil/testdata/TestNewFeelingLuckySearchJob/trigger_unquoted_rule.golden
@@ -153,6 +153,17 @@
         "value": "20s"
       },
       {
+        "AlternateQueriesAlertJob": {
+          "AlternateQueries": [
+            {
+              "Description": "unquote patterns",
+              "Query": "lucky",
+              "PatternType": 1
+            }
+          ]
+        }
+      },
+      {
         "TIMEOUT": {
           "LIMIT": {
             "PARALLEL": [

--- a/internal/search/job/jobutil/types.go
+++ b/internal/search/job/jobutil/types.go
@@ -24,6 +24,7 @@ var allJobs = []job.Job{
 	&NoopJob{},
 
 	&repoPagerJob{},
+	&alternateQueriesAlertJob{},
 
 	&AndJob{},
 	&OrJob{},


### PR DESCRIPTION
This propagates err/alerting so you see this for lucky search:

![Screen Shot 2022-06-07 at 6 44 09 PM](https://user-images.githubusercontent.com/888624/172513962-f5b55fe1-78e5-49d5-bc8f-27bc4add0669.png)

The alert isn't perfect, I'm using our "proposed queries" logic, and would probably like something a bit more fit for purpose. I also don't like that it's SO HUGE. Something more subtle like Google's "did you mean" would be better for this lucky search application. Wonder if @limitedmage has a sense for how we could make the layout of this notification more snazzy, it could go a long way I think!

Re backend: I ran into one annoying thing in the implementation, which is: It's easy to have every generated query/job return it's attempted query, but this will result in a frontend _alert_ for each job, but I want to actually group all attempted queries into one list of "proposed queries" i.e., alternate queries, like you see in the screenie.

I found it difficult to shape the code to collect proposed queries as-jobs-run, and especially challenging to then just propagate one alert/error. I thought to change the Sequential job itself, to collect these, but this starts to get overly specific to "Lucky Search" and not "general sequential primitive". So in the end, I created a new job to serve this role, which, when Run, sends the alternate queries err, and this job is always run _first_ before any generated queries (and doesn't actually return results). This works well enough, just a bit annoying and pollutes the size of different kinds of jobs we have. Another consequence of not really having notifications/alerting as a real first class thing. Work for another day.


## Test plan
Updated unit tests.