### PR TITLE
batches: make viewing the details of a locally-executed spec less weird

### DIFF
--- a/client/web/src/enterprise/batches/batch-spec/TabBar.story.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/TabBar.story.tsx
@@ -78,3 +78,22 @@ add('previewing an execution result', () => (
         )}
     </WebStory>
 ))
+
+const LOCAL_TABS: TabsConfig[] = [
+    { key: 'configuration', isEnabled: true, handler: { type: 'link' } },
+    { key: 'spec', isEnabled: true, handler: { type: 'link' } },
+    { key: 'execution', isEnabled: false },
+    { key: 'preview', isEnabled: true, handler: { type: 'link' } },
+]
+
+add('for a locally-executed spec', () => (
+    <WebStory>
+        {props => (
+            <TabBar
+                {...props}
+                tabsConfig={LOCAL_TABS}
+                activeTabKey={select('Active tab', ['configuration', 'spec', 'preview'], 'preview')}
+            />
+        )}
+    </WebStory>
+))

--- a/client/web/src/enterprise/batches/batch-spec/batch-spec.mock.ts
+++ b/client/web/src/enterprise/batches/batch-spec/batch-spec.mock.ts
@@ -2,6 +2,7 @@ import { subDays, subHours, subMinutes } from 'date-fns'
 import { MATCH_ANY_PARAMETERS, MockedResponses, WildcardMockedResponse } from 'wildcard-mock-link'
 
 import { getDocumentNode } from '@sourcegraph/http-client'
+import { BatchSpecSource } from '@sourcegraph/shared/src/schema'
 
 import {
     BatchSpecWorkspaceResolutionState,
@@ -24,7 +25,6 @@ import {
 import { EXECUTORS, IMPORTING_CHANGESETS, WORKSPACES, WORKSPACE_RESOLUTION_STATUS } from '../create/backend'
 
 import helloWorldSample from './edit/library/hello-world.batch.yaml'
-import { BatchSpecSource } from '@sourcegraph/shared/src/schema'
 
 const now = new Date()
 

--- a/client/web/src/enterprise/batches/batch-spec/batch-spec.mock.ts
+++ b/client/web/src/enterprise/batches/batch-spec/batch-spec.mock.ts
@@ -24,6 +24,7 @@ import {
 import { EXECUTORS, IMPORTING_CHANGESETS, WORKSPACES, WORKSPACE_RESOLUTION_STATUS } from '../create/backend'
 
 import helloWorldSample from './edit/library/hello-world.batch.yaml'
+import { BatchSpecSource } from '@sourcegraph/shared/src/schema'
 
 const now = new Date()
 
@@ -70,6 +71,7 @@ export const mockFullBatchSpec = (batchSpec?: Partial<BatchSpecExecutionFields>)
     __typename: 'BatchSpec',
     id: '1',
     state: BatchSpecState.PENDING,
+    source: BatchSpecSource.REMOTE,
     originalInput: 'name: my-batch-change',
     createdAt: now.toISOString(),
     startedAt: null,

--- a/client/web/src/enterprise/batches/batch-spec/edit/DownloadSpecModal.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/edit/DownloadSpecModal.tsx
@@ -48,7 +48,7 @@ export const DownloadSpecModal: React.FunctionComponent<React.PropsWithChildren<
         <div className={styles.container}>
             <div className={styles.left}>
                 <Text>
-                    Use the <Link to="https://docs.sourcegraph.com/cli">Sourcegraph CLI (src) </Link>
+                    Use the <Link to="/help/cli">Sourcegraph CLI (src)</Link>
                     to run this batch change locally.
                 </Text>
 

--- a/client/web/src/enterprise/batches/batch-spec/edit/EditBatchSpecPage.story.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/edit/EditBatchSpecPage.story.tsx
@@ -60,7 +60,19 @@ const FIRST_TIME_MOCKS = new WildcardMockLink([
             query: getDocumentNode(GET_BATCH_CHANGE_TO_EDIT),
             variables: MATCH_ANY_PARAMETERS,
         },
-        result: { data: { batchChange: mockBatchChange() } },
+        result: {
+            data: {
+                batchChange: mockBatchChange({
+                    batchSpecs: {
+                        nodes: [
+                            mockBatchSpec({
+                                originalInput: insertNameIntoLibraryItem(goImportsSample, 'my-batch-change'),
+                            }),
+                        ],
+                    },
+                }),
+            },
+        },
         nMatches: Number.POSITIVE_INFINITY,
     },
     ACTIVE_EXECUTORS_MOCK,

--- a/client/web/src/enterprise/batches/batch-spec/edit/EditBatchSpecPage.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/edit/EditBatchSpecPage.tsx
@@ -104,7 +104,13 @@ type MemoizedEditBatchSpecPageContentProps = EditBatchSpecPageContentProps &
 
 const MemoizedEditBatchSpecPageContent: React.FunctionComponent<
     React.PropsWithChildren<MemoizedEditBatchSpecPageContentProps>
-> = React.memo(({ settingsCascade, isLightTheme, batchChange, editor, errors }) => {
+> = React.memo(function MemoizedEditBatchSpecPageContent({
+    settingsCascade,
+    isLightTheme,
+    batchChange,
+    editor,
+    errors,
+}) {
     const { insightTitle } = useInsightTemplates(settingsCascade)
 
     const [activeTabKey, setActiveTabKey] = useState<TabKey>('spec')

--- a/client/web/src/enterprise/batches/batch-spec/edit/workspaces-preview/WorkspacesPreview.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/edit/workspaces-preview/WorkspacesPreview.tsx
@@ -71,7 +71,7 @@ type MemoizedWorkspacesPreviewProps = WorkspacesPreviewProps &
 
 const MemoizedWorkspacesPreview: React.FunctionComponent<
     React.PropsWithChildren<MemoizedWorkspacesPreviewProps>
-> = React.memo(({ isReadOnly, batchSpec, editor, workspacesPreview }) => {
+> = React.memo(function MemoizedWorkspacesPreview({ isReadOnly, batchSpec, editor, workspacesPreview }) {
     const { debouncedCode, excludeRepo, isServerStale } = editor
     const {
         resolutionState,

--- a/client/web/src/enterprise/batches/batch-spec/execute/ActionsMenu.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/execute/ActionsMenu.tsx
@@ -45,7 +45,7 @@ export const ActionsMenu: React.FunctionComponent<React.PropsWithChildren<{}>> =
 
 const MemoizedActionsMenu: React.FunctionComponent<
     React.PropsWithChildren<Pick<BatchSpecContextState, 'batchChange' | 'batchSpec' | 'setActionsError'>>
-> = React.memo(({ batchChange, batchSpec, setActionsError }) => {
+> = React.memo(function MemoizedActionsMenu({ batchChange, batchSpec, setActionsError }) {
     const history = useHistory()
     const location = useLocation()
 

--- a/client/web/src/enterprise/batches/batch-spec/execute/ExecuteBatchSpecPage.story.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/execute/ExecuteBatchSpecPage.story.tsx
@@ -3,6 +3,7 @@ import { addMinutes } from 'date-fns'
 import { MATCH_ANY_PARAMETERS, MockedResponses, WildcardMockLink } from 'wildcard-mock-link'
 
 import { getDocumentNode } from '@sourcegraph/http-client'
+import { BatchSpecSource } from '@sourcegraph/shared/src/schema'
 import {
     EMPTY_SETTINGS_CASCADE,
     SettingsOrgSubject,
@@ -25,6 +26,7 @@ import {
     EXECUTING_BATCH_SPEC,
     FAILED_BATCH_SPEC,
     mockBatchChange,
+    mockFullBatchSpec,
     mockWorkspaceResolutionStatus,
     mockWorkspaces,
 } from '../batch-spec.mock'
@@ -193,6 +195,24 @@ add('completed with errors', () => (
                     {...props}
                     batchSpecID="spec1234"
                     batchChange={{ name: 'my-batch-change', namespace: 'user1234' }}
+                    authenticatedUser={mockAuthenticatedUser}
+                    settingsCascade={SETTINGS_CASCADE}
+                />
+            </MockedTestProvider>
+        )}
+    </WebStory>
+))
+
+const LOCAL_MOCKS = buildMocks(mockFullBatchSpec({ source: BatchSpecSource.LOCAL }))
+
+add('for a locally-executed spec', () => (
+    <WebStory>
+        {props => (
+            <MockedTestProvider link={new WildcardMockLink(LOCAL_MOCKS)}>
+                <ExecuteBatchSpecPage
+                    {...props}
+                    batchSpecID="spec1234"
+                    batchChange={{ name: 'my-local-batch-change', namespace: 'user1234' }}
                     authenticatedUser={mockAuthenticatedUser}
                     settingsCascade={SETTINGS_CASCADE}
                 />

--- a/client/web/src/enterprise/batches/batch-spec/execute/ExecuteBatchSpecPage.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/execute/ExecuteBatchSpecPage.tsx
@@ -12,7 +12,7 @@ import { LinkOrSpan } from '@sourcegraph/shared/src/components/LinkOrSpan'
 import { Settings, SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
-import { Icon, LoadingSpinner } from '@sourcegraph/wildcard'
+import { Badge, Icon, LoadingSpinner } from '@sourcegraph/wildcard'
 
 import { withAuthenticatedUser } from '../../../../auth/withAuthenticatedUser'
 import { HeroPage } from '../../../../components/HeroPage'
@@ -126,133 +126,147 @@ type MemoizedExecuteBatchSpecContentProps = ExecuteBatchSpecPageContentProps &
 
 const MemoizedExecuteBatchSpecContent: React.FunctionComponent<
     React.PropsWithChildren<MemoizedExecuteBatchSpecContentProps>
-> = React.memo(
-    ({ isLightTheme, match, settingsCascade, telemetryService, authenticatedUser, batchChange, batchSpec, errors }) => {
-        const { executionURL, workspaceResolution } = batchSpec
+> = React.memo(function MemoizedExecuteBatchSpecContent({
+    isLightTheme,
+    match,
+    settingsCascade,
+    telemetryService,
+    authenticatedUser,
+    batchChange,
+    batchSpec,
+    errors,
+}) {
+    const { executionURL, workspaceResolution, source, applyURL } = batchSpec
 
-        const tabsConfig = useMemo<TabsConfig[]>(
-            () => [
-                { key: 'configuration', isEnabled: true, handler: { type: 'link' } },
-                { key: 'spec', isEnabled: true, handler: { type: 'link' } },
-                { key: 'execution', isEnabled: true, handler: { type: 'link' } },
-                { key: 'preview', isEnabled: batchSpec.applyURL !== null, handler: { type: 'link' } },
-            ],
-            [batchSpec.applyURL]
-        )
+    const tabsConfig = useMemo<TabsConfig[]>(
+        () => [
+            { key: 'configuration', isEnabled: true, handler: { type: 'link' } },
+            { key: 'spec', isEnabled: true, handler: { type: 'link' } },
+            { key: 'execution', isEnabled: source === 'REMOTE', handler: { type: 'link' } },
+            { key: 'preview', isEnabled: applyURL !== null, handler: { type: 'link' } },
+        ],
+        [applyURL, source]
+    )
 
-        return (
-            <div className={layoutStyles.pageContainer}>
-                <div className={layoutStyles.headerContainer}>
-                    <BatchChangeHeader
-                        namespace={{
-                            to: `${batchChange.namespace.url}/batch-changes`,
-                            text: batchChange.namespace.namespaceName,
-                        }}
-                        title={{ to: batchChange.url, text: batchChange.name }}
-                        description={
-                            <>
-                                Created <Timestamp date={batchSpec.createdAt} /> by{' '}
-                                <LinkOrSpan to={batchSpec.creator?.url}>
-                                    {batchSpec.creator?.displayName || batchSpec.creator?.username || 'a deleted user'}
-                                </LinkOrSpan>
-                            </>
-                        }
-                    />
-                    <div className="d-flex align-items-center mb-1">
+    return (
+        <div className={layoutStyles.pageContainer}>
+            <div className={layoutStyles.headerContainer}>
+                <BatchChangeHeader
+                    namespace={{
+                        to: `${batchChange.namespace.url}/batch-changes`,
+                        text: batchChange.namespace.namespaceName,
+                    }}
+                    title={{ to: batchChange.url, text: batchChange.name }}
+                    description={
+                        <>
+                            Created <Timestamp date={batchSpec.createdAt} /> by{' '}
+                            <LinkOrSpan to={batchSpec.creator?.url}>
+                                {batchSpec.creator?.displayName || batchSpec.creator?.username || 'a deleted user'}
+                            </LinkOrSpan>
+                        </>
+                    }
+                />
+                <div className="d-flex align-items-center mb-1">
+                    {batchSpec.source === 'REMOTE' ? (
                         <BatchSpecStateBadge state={batchSpec.state} className="mr-2" />
-                        {batchSpec.startedAt && (
-                            <ExecutionStat>
-                                <ProgressClockIcon />
-                                <Duration start={batchSpec.startedAt} end={batchSpec.finishedAt ?? undefined} />
-                            </ExecutionStat>
-                        )}
-                        {workspaceResolution && <ExecutionStatsBar {...workspaceResolution.workspaces.stats} />}
-                    </div>
-
-                    <ActionButtons className="ml-2">
-                        <ActionsMenu />
-                    </ActionButtons>
+                    ) : (
+                        <Badge
+                            className="mr-2"
+                            variant="secondary"
+                            tooltip="This batch spec was executed with src-cli."
+                        >
+                            LOCAL
+                        </Badge>
+                    )}
+                    {batchSpec.startedAt && (
+                        <ExecutionStat>
+                            <ProgressClockIcon />
+                            <Duration start={batchSpec.startedAt} end={batchSpec.finishedAt ?? undefined} />
+                        </ExecutionStat>
+                    )}
+                    {workspaceResolution && <ExecutionStatsBar {...workspaceResolution.workspaces.stats} />}
                 </div>
 
-                {errors.actions && <ErrorMessage error={errors.actions} key={String(errors.actions)} />}
-
-                <Switch>
-                    <Route render={() => <Redirect to={`${match.url}/execution`} />} path={match.url} exact={true} />
-                    <Route
-                        path={`${match.url}/configuration`}
-                        render={() => (
-                            <>
-                                <TabBar activeTabKey="configuration" tabsConfig={tabsConfig} matchURL={executionURL} />
-                                <ConfigurationForm
-                                    isReadOnly={true}
-                                    batchChange={batchChange}
-                                    settingsCascade={settingsCascade}
-                                />
-                            </>
-                        )}
-                        exact={true}
-                    />
-                    <Route
-                        path={`${match.url}/spec`}
-                        render={() => (
-                            <>
-                                <TabBar activeTabKey="spec" tabsConfig={tabsConfig} matchURL={executionURL} />
-                                <ReadOnlyBatchSpecForm isLightTheme={isLightTheme} />
-                            </>
-                        )}
-                        exact={true}
-                    />
-                    <Route
-                        path={`${match.url}/execution/workspaces/:workspaceID`}
-                        render={({ match }: RouteComponentProps<{ workspaceID: string }>) => (
-                            <>
-                                <TabBar activeTabKey="execution" tabsConfig={tabsConfig} matchURL={executionURL} />
-                                <ExecutionWorkspaces
-                                    selectedWorkspaceID={match.params.workspaceID}
-                                    isLightTheme={isLightTheme}
-                                />
-                            </>
-                        )}
-                    />
-                    <Route
-                        path={`${match.url}/execution`}
-                        render={() => (
-                            <>
-                                <TabBar activeTabKey="execution" tabsConfig={tabsConfig} matchURL={executionURL} />
-                                <ExecutionWorkspaces isLightTheme={isLightTheme} />
-                            </>
-                        )}
-                    />
-                    {batchSpec.applyURL ? (
-                        <Route
-                            path={`${match.url}/preview`}
-                            render={() => (
-                                <>
-                                    <TabBar
-                                        activeTabKey="preview"
-                                        tabsConfig={tabsConfig}
-                                        matchURL={executionURL}
-                                        className="mb-4"
-                                    />
-                                    <NewBatchChangePreviewPage
-                                        authenticatedUser={authenticatedUser}
-                                        telemetryService={telemetryService}
-                                        isLightTheme={isLightTheme}
-                                        batchSpecID={batchSpec.id}
-                                    />
-                                </>
-                            )}
-                            exact={true}
-                        />
-                    ) : null}
-                    <Route
-                        component={() => <HeroPage icon={MapSearchIcon} title="404: Not Found" />}
-                        key="hardcoded-key"
-                    />
-                </Switch>
+                <ActionButtons className="ml-2">
+                    <ActionsMenu />
+                </ActionButtons>
             </div>
-        )
-    }
-)
+
+            {errors.actions && <ErrorMessage error={errors.actions} key={String(errors.actions)} />}
+
+            <Switch>
+                <Route render={() => <Redirect to={`${match.url}/execution`} />} path={match.url} exact={true} />
+                <Route
+                    path={`${match.url}/configuration`}
+                    render={() => (
+                        <>
+                            <TabBar activeTabKey="configuration" tabsConfig={tabsConfig} matchURL={executionURL} />
+                            <ConfigurationForm
+                                isReadOnly={true}
+                                batchChange={batchChange}
+                                settingsCascade={settingsCascade}
+                            />
+                        </>
+                    )}
+                    exact={true}
+                />
+                <Route
+                    path={`${match.url}/spec`}
+                    render={() => (
+                        <>
+                            <TabBar activeTabKey="spec" tabsConfig={tabsConfig} matchURL={executionURL} />
+                            <ReadOnlyBatchSpecForm isLightTheme={isLightTheme} />
+                        </>
+                    )}
+                    exact={true}
+                />
+                <Route
+                    path={`${match.url}/execution/workspaces/:workspaceID`}
+                    render={({ match }: RouteComponentProps<{ workspaceID: string }>) => (
+                        <>
+                            <TabBar activeTabKey="execution" tabsConfig={tabsConfig} matchURL={executionURL} />
+                            <ExecutionWorkspaces
+                                selectedWorkspaceID={match.params.workspaceID}
+                                isLightTheme={isLightTheme}
+                            />
+                        </>
+                    )}
+                />
+                <Route
+                    path={`${match.url}/execution`}
+                    render={() => (
+                        <>
+                            <TabBar activeTabKey="execution" tabsConfig={tabsConfig} matchURL={executionURL} />
+                            <ExecutionWorkspaces isLightTheme={isLightTheme} />
+                        </>
+                    )}
+                />
+                {batchSpec.applyURL ? (
+                    <Route
+                        path={`${match.url}/preview`}
+                        render={() => (
+                            <>
+                                <TabBar
+                                    activeTabKey="preview"
+                                    tabsConfig={tabsConfig}
+                                    matchURL={executionURL}
+                                    className="mb-4"
+                                />
+                                <NewBatchChangePreviewPage
+                                    authenticatedUser={authenticatedUser}
+                                    telemetryService={telemetryService}
+                                    isLightTheme={isLightTheme}
+                                    batchSpecID={batchSpec.id}
+                                />
+                            </>
+                        )}
+                        exact={true}
+                    />
+                ) : null}
+                <Route component={() => <HeroPage icon={MapSearchIcon} title="404: Not Found" />} key="hardcoded-key" />
+            </Switch>
+        </div>
+    )
+})
 
 export const ExecuteBatchSpecPage = withAuthenticatedUser(AuthenticatedExecuteBatchSpecPage)

--- a/client/web/src/enterprise/batches/batch-spec/execute/ExecuteBatchSpecPage.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/execute/ExecuteBatchSpecPage.tsx
@@ -9,6 +9,7 @@ import { ErrorMessage } from '@sourcegraph/branded/src/components/alerts'
 import { useQuery } from '@sourcegraph/http-client'
 import { AuthenticatedUser } from '@sourcegraph/shared/src/auth'
 import { LinkOrSpan } from '@sourcegraph/shared/src/components/LinkOrSpan'
+import { BatchSpecSource } from '@sourcegraph/shared/src/schema'
 import { Settings, SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
@@ -142,7 +143,7 @@ const MemoizedExecuteBatchSpecContent: React.FunctionComponent<
         () => [
             { key: 'configuration', isEnabled: true, handler: { type: 'link' } },
             { key: 'spec', isEnabled: true, handler: { type: 'link' } },
-            { key: 'execution', isEnabled: source === 'REMOTE', handler: { type: 'link' } },
+            { key: 'execution', isEnabled: source === BatchSpecSource.REMOTE, handler: { type: 'link' } },
             { key: 'preview', isEnabled: applyURL !== null, handler: { type: 'link' } },
         ],
         [applyURL, source]
@@ -167,7 +168,7 @@ const MemoizedExecuteBatchSpecContent: React.FunctionComponent<
                     }
                 />
                 <div className="d-flex align-items-center mb-1">
-                    {batchSpec.source === 'REMOTE' ? (
+                    {batchSpec.source === BatchSpecSource.REMOTE ? (
                         <BatchSpecStateBadge state={batchSpec.state} className="mr-2" />
                     ) : (
                         <Badge

--- a/client/web/src/enterprise/batches/batch-spec/execute/ReadOnlyBatchSpecAlert.story.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/execute/ReadOnlyBatchSpecAlert.story.tsx
@@ -1,0 +1,25 @@
+import { storiesOf } from '@storybook/react'
+
+import { Button } from '@sourcegraph/wildcard'
+
+import { WebStory } from '../../../../components/WebStory'
+
+import { ReadOnlyBatchSpecAlert } from './ReadOnlyBatchSpecAlert'
+
+storiesOf('web/batches/batch-spec/execute', module)
+    .addDecorator(story => <div className="container p-3">{story()}</div>)
+    .add('ReadOnlyBatchSpecAlert', () => (
+        <WebStory>
+            {props => (
+                <ReadOnlyBatchSpecAlert
+                    {...props}
+                    className="d-flex align-items-center pr-3"
+                    variant="info"
+                    header="This spec is read-only"
+                    message="We've preserved the original batch spec from this execution for you to inspect."
+                >
+                    <Button variant="primary">Edit spec</Button>
+                </ReadOnlyBatchSpecAlert>
+            )}
+        </WebStory>
+    ))

--- a/client/web/src/enterprise/batches/batch-spec/execute/ReadOnlyBatchSpecAlert.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/execute/ReadOnlyBatchSpecAlert.tsx
@@ -1,0 +1,26 @@
+import React from 'react'
+
+import { Alert, AlertProps, H4 } from '@sourcegraph/wildcard'
+
+interface ReadOnlyBatchSpecAlertProps {
+    className?: string
+    variant: AlertProps['variant']
+    header: string
+    message: React.ReactNode
+}
+
+export const ReadOnlyBatchSpecAlert: React.FunctionComponent<React.PropsWithChildren<ReadOnlyBatchSpecAlertProps>> = ({
+    className,
+    children,
+    variant,
+    header,
+    message,
+}) => (
+    <Alert variant={variant} className={className}>
+        <div className="flex-grow-1 pr-3">
+            <H4>{header}</H4>
+            {message}
+        </div>
+        {children}
+    </Alert>
+)

--- a/client/web/src/enterprise/batches/batch-spec/execute/ReadOnlyBatchSpecForm.story.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/execute/ReadOnlyBatchSpecForm.story.tsx
@@ -1,5 +1,6 @@
 import { select } from '@storybook/addon-knobs'
 import { storiesOf } from '@storybook/react'
+import { BatchSpecSource } from '@sourcegraph/shared/src/schema'
 
 import { WebStory } from '../../../../components/WebStory'
 import { BatchSpecState } from '../../../../graphql-operations'
@@ -51,6 +52,19 @@ add('after execution finishes', () => (
                         BatchSpecState.COMPLETED
                     ),
                 })}
+            >
+                <ReadOnlyBatchSpecForm {...props} />
+            </BatchSpecContextProvider>
+        )}
+    </WebStory>
+))
+
+add('for a locally-executed spec', () => (
+    <WebStory>
+        {props => (
+            <BatchSpecContextProvider
+                batchChange={mockBatchChange()}
+                batchSpec={mockFullBatchSpec({ source: BatchSpecSource.LOCAL })}
             >
                 <ReadOnlyBatchSpecForm {...props} />
             </BatchSpecContextProvider>

--- a/client/web/src/enterprise/batches/batch-spec/execute/ReadOnlyBatchSpecForm.story.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/execute/ReadOnlyBatchSpecForm.story.tsx
@@ -1,5 +1,6 @@
 import { select } from '@storybook/addon-knobs'
 import { storiesOf } from '@storybook/react'
+
 import { BatchSpecSource } from '@sourcegraph/shared/src/schema'
 
 import { WebStory } from '../../../../components/WebStory'

--- a/client/web/src/enterprise/batches/batch-spec/execute/ReadOnlyBatchSpecForm.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/execute/ReadOnlyBatchSpecForm.tsx
@@ -71,7 +71,7 @@ const MemoizedReadOnlyBatchSpecForm: React.FunctionComponent<
                     message={
                         <>
                             This spec is read-only because it was created and executed locally with the{' '}
-                            <Link to="https://docs.sourcegraph.com/cli">Sourcegraph CLI (src)</Link>.
+                            <Link to="/help/cli">Sourcegraph CLI (src)</Link>.
                         </>
                     }
                 >

--- a/client/web/src/enterprise/batches/batch-spec/execute/ReadOnlyBatchSpecForm.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/execute/ReadOnlyBatchSpecForm.tsx
@@ -3,6 +3,7 @@ import React, { useState } from 'react'
 import { useHistory } from 'react-router'
 
 import { useMutation } from '@sourcegraph/http-client'
+import { BatchSpecSource } from '@sourcegraph/shared/src/schema'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
 import { Alert, Button, H4, Text } from '@sourcegraph/wildcard'
 
@@ -98,7 +99,7 @@ const MemoizedReadOnlyBatchSpecForm: React.FunctionComponent<
                 />
             </div>
             {/* Hide the workspaces preview panel for locally-executed batch specs. */}
-            {batchSpec.source === 'REMOTE' && <WorkspacesPreviewPanel isReadOnly={true} />}
+            {batchSpec.source === BatchSpecSource.REMOTE && <WorkspacesPreviewPanel isReadOnly={true} />}
             <CancelExecutionModal
                 isOpen={showCancelModal}
                 onCancel={() => setShowCancelModal(false)}

--- a/client/web/src/enterprise/batches/batch-spec/execute/ReadOnlyBatchSpecForm.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/execute/ReadOnlyBatchSpecForm.tsx
@@ -97,7 +97,8 @@ const MemoizedReadOnlyBatchSpecForm: React.FunctionComponent<
                     originalInput={batchSpec.originalInput}
                 />
             </div>
-            <WorkspacesPreviewPanel isReadOnly={true} />
+            {/* Hide the workspaces preview panel for locally-executed batch specs. */}
+            {batchSpec.source === 'REMOTE' && <WorkspacesPreviewPanel isReadOnly={true} />}
             <CancelExecutionModal
                 isOpen={showCancelModal}
                 onCancel={() => setShowCancelModal(false)}

--- a/client/web/src/enterprise/batches/batch-spec/execute/ReadOnlyBatchSpecForm.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/execute/ReadOnlyBatchSpecForm.tsx
@@ -43,7 +43,7 @@ type MemoizedReadOnlyBatchSpecFormProps = ReadOnlyBatchSpecFormProps &
 
 const MemoizedReadOnlyBatchSpecForm: React.FunctionComponent<
     React.PropsWithChildren<MemoizedReadOnlyBatchSpecFormProps>
-> = React.memo(({ isLightTheme, batchChange, batchSpec, setActionsError }) => {
+> = React.memo(function MemoizedReadOnlyBatchSpecForm({ isLightTheme, batchChange, batchSpec, setActionsError }) {
     const history = useHistory()
 
     const [showCancelModal, setShowCancelModal] = useState(false)

--- a/client/web/src/enterprise/batches/batch-spec/execute/backend.ts
+++ b/client/web/src/enterprise/batches/batch-spec/execute/backend.ts
@@ -177,6 +177,7 @@ export const batchSpecExecutionFieldsFragment = gql`
     fragment BatchSpecExecutionFields on BatchSpec {
         id
         originalInput
+        source
         state
         description {
             name

--- a/client/web/src/enterprise/batches/batch-spec/execute/workspaces/ExecutionWorkspaces.story.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/execute/workspaces/ExecutionWorkspaces.story.tsx
@@ -3,6 +3,7 @@ import { of } from 'rxjs'
 import { MATCH_ANY_PARAMETERS, WildcardMockLink } from 'wildcard-mock-link'
 
 import { getDocumentNode } from '@sourcegraph/http-client'
+import { BatchSpecSource } from '@sourcegraph/shared/src/schema'
 import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
 
 import { WebStory } from '../../../../../components/WebStory'
@@ -93,6 +94,27 @@ add('with workspace selected', () => (
                         selectedWorkspaceID="spec1234"
                         queryChangesetSpecFileDiffs={queryEmptyFileDiffs}
                     />
+                </BatchSpecContextProvider>
+            </MockedTestProvider>
+        )}
+    </WebStory>
+))
+
+add('for a locally-executed spec', () => (
+    <WebStory>
+        {props => (
+            <MockedTestProvider link={MOCKS}>
+                <BatchSpecContextProvider
+                    batchChange={mockBatchChange()}
+                    batchSpec={mockFullBatchSpec({ source: BatchSpecSource.LOCAL })}
+                >
+                    <div className="container">
+                        <ExecutionWorkspaces
+                            {...props}
+                            selectedWorkspaceID="spec1234"
+                            queryChangesetSpecFileDiffs={queryEmptyFileDiffs}
+                        />
+                    </div>
                 </BatchSpecContextProvider>
             </MockedTestProvider>
         )}

--- a/client/web/src/enterprise/batches/batch-spec/execute/workspaces/ExecutionWorkspaces.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/execute/workspaces/ExecutionWorkspaces.tsx
@@ -5,6 +5,7 @@ import CloseIcon from 'mdi-react/CloseIcon'
 import { useHistory } from 'react-router'
 
 import { ErrorAlert } from '@sourcegraph/branded/src/components/alerts'
+import { BatchSpecSource } from '@sourcegraph/shared/src/schema'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
 import { Card, CardBody, Panel, H3, H1, Icon, Text, Code } from '@sourcegraph/wildcard'
 
@@ -32,7 +33,7 @@ export const ExecutionWorkspaces: React.FunctionComponent<
 > = props => {
     const { batchSpec, errors } = useBatchSpecContext<BatchSpecExecutionFields>()
 
-    if (batchSpec.source === 'LOCAL') {
+    if (batchSpec.source === BatchSpecSource.LOCAL) {
         return (
             <>
                 <H1 className="text-center text-muted mt-5">

--- a/client/web/src/enterprise/batches/batch-spec/execute/workspaces/ExecutionWorkspaces.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/execute/workspaces/ExecutionWorkspaces.tsx
@@ -1,10 +1,12 @@
 import React, { useCallback } from 'react'
 
+import VisuallyHidden from '@reach/visually-hidden'
+import CloseIcon from 'mdi-react/CloseIcon'
 import { useHistory } from 'react-router'
 
 import { ErrorAlert } from '@sourcegraph/branded/src/components/alerts'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
-import { Card, CardBody, Panel, H3 } from '@sourcegraph/wildcard'
+import { Card, CardBody, Panel, H3, H1, Icon, Text, Code } from '@sourcegraph/wildcard'
 
 import { BatchSpecExecutionFields } from '../../../../../graphql-operations'
 import { queryChangesetSpecFileDiffs as _queryChangesetSpecFileDiffs } from '../../../preview/list/backend'
@@ -30,6 +32,20 @@ export const ExecutionWorkspaces: React.FunctionComponent<
 > = props => {
     const { batchSpec, errors } = useBatchSpecContext<BatchSpecExecutionFields>()
 
+    if (batchSpec.source === 'LOCAL') {
+        return (
+            <>
+                <H1 className="text-center text-muted mt-5">
+                    <Icon role="img" aria-hidden={true} as={CloseIcon} />
+                    <VisuallyHidden>No Execution</VisuallyHidden>
+                </H1>
+                <Text alignment="center">
+                    This batch spec was executed locally with <Code>src-cli</Code>.
+                </Text>
+            </>
+        )
+    }
+
     return <MemoizedExecutionWorkspaces {...props} batchSpec={batchSpec} errors={errors} />
 }
 
@@ -37,59 +53,48 @@ type MemoizedExecutionWorkspacesProps = ExecutionWorkspacesProps & Pick<BatchSpe
 
 const MemoizedExecutionWorkspaces: React.FunctionComponent<
     React.PropsWithChildren<MemoizedExecutionWorkspacesProps>
-> = React.memo(
-    ({
-        selectedWorkspaceID,
-        isLightTheme,
-        batchSpec,
-        errors,
-        queryBatchSpecWorkspaceStepFileDiffs,
-        queryChangesetSpecFileDiffs,
-    }) => {
-        const history = useHistory()
+> = React.memo(function MemoizedExecutionWorkspaces({
+    selectedWorkspaceID,
+    isLightTheme,
+    batchSpec,
+    errors,
+    queryBatchSpecWorkspaceStepFileDiffs,
+    queryChangesetSpecFileDiffs,
+}) {
+    const history = useHistory()
 
-        const deselectWorkspace = useCallback(() => history.push(batchSpec.executionURL), [
-            batchSpec.executionURL,
-            history,
-        ])
+    const deselectWorkspace = useCallback(() => history.push(batchSpec.executionURL), [batchSpec.executionURL, history])
 
-        return (
-            <div className={styles.container}>
-                {errors.execute && <ErrorAlert error={errors.execute} className={styles.errors} />}
-                <div className={styles.inner}>
-                    <Panel
-                        defaultSize={500}
-                        minSize={405}
-                        maxSize={1400}
-                        position="left"
-                        storageKey={WORKSPACES_LIST_SIZE}
-                    >
-                        <Workspaces
-                            batchSpecID={batchSpec.id}
-                            selectedNode={selectedWorkspaceID}
-                            executionURL={batchSpec.executionURL}
-                        />
-                    </Panel>
-                    <Card className="w-100 overflow-auto flex-grow-1">
-                        {/* This is necessary to prevent the margin collapse on `Card` */}
-                        <div className="w-100">
-                            <CardBody>
-                                {selectedWorkspaceID ? (
-                                    <WorkspaceDetails
-                                        id={selectedWorkspaceID}
-                                        isLightTheme={isLightTheme}
-                                        deselectWorkspace={deselectWorkspace}
-                                        queryBatchSpecWorkspaceStepFileDiffs={queryBatchSpecWorkspaceStepFileDiffs}
-                                        queryChangesetSpecFileDiffs={queryChangesetSpecFileDiffs}
-                                    />
-                                ) : (
-                                    <H3 className="text-center my-3">Select a workspace to view details.</H3>
-                                )}
-                            </CardBody>
-                        </div>
-                    </Card>
-                </div>
+    return (
+        <div className={styles.container}>
+            {errors.execute && <ErrorAlert error={errors.execute} className={styles.errors} />}
+            <div className={styles.inner}>
+                <Panel defaultSize={500} minSize={405} maxSize={1400} position="left" storageKey={WORKSPACES_LIST_SIZE}>
+                    <Workspaces
+                        batchSpecID={batchSpec.id}
+                        selectedNode={selectedWorkspaceID}
+                        executionURL={batchSpec.executionURL}
+                    />
+                </Panel>
+                <Card className="w-100 overflow-auto flex-grow-1">
+                    {/* This is necessary to prevent the margin collapse on `Card` */}
+                    <div className="w-100">
+                        <CardBody>
+                            {selectedWorkspaceID ? (
+                                <WorkspaceDetails
+                                    id={selectedWorkspaceID}
+                                    isLightTheme={isLightTheme}
+                                    deselectWorkspace={deselectWorkspace}
+                                    queryBatchSpecWorkspaceStepFileDiffs={queryBatchSpecWorkspaceStepFileDiffs}
+                                    queryChangesetSpecFileDiffs={queryChangesetSpecFileDiffs}
+                                />
+                            ) : (
+                                <H3 className="text-center my-3">Select a workspace to view details.</H3>
+                            )}
+                        </CardBody>
+                    </div>
+                </Card>
             </div>
-        )
-    }
-)
+        </div>
+    )
+})

--- a/cmd/frontend/graphqlbackend/batches.go
+++ b/cmd/frontend/graphqlbackend/batches.go
@@ -354,6 +354,8 @@ type BatchSpecResolver interface {
 	AllowUnsupported() *bool
 
 	ViewerCanRetry(context.Context) (bool, error)
+
+	Source() string
 }
 
 type BatchChangeDescriptionResolver interface {

--- a/cmd/frontend/graphqlbackend/batches.graphql
+++ b/cmd/frontend/graphqlbackend/batches.graphql
@@ -2847,6 +2847,22 @@ enum BatchSpecState {
 }
 
 """
+The possible sources of a batch spec.
+"""
+enum BatchSpecSource {
+    """
+    The spec was created from the local src-cli workflow.
+    """
+    LOCAL
+
+    """
+    This spec was created for remote server-side execution, e.g. from the web UI editor,
+    or with src batch remote.
+    """
+    REMOTE
+}
+
+"""
 A list of batch specs.
 """
 type BatchSpecConnection {
@@ -3092,6 +3108,12 @@ type BatchSpec implements Node {
     retryBatchSpecExecution.
     """
     viewerCanRetry: Boolean!
+
+    """
+    Whether the batch spec was created from the local src-cli workflow or remotely for
+    server-side execution.
+    """
+    source: BatchSpecSource!
 }
 
 """

--- a/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec.go
@@ -511,6 +511,13 @@ func (r *batchSpecResolver) ViewerCanRetry(ctx context.Context) (bool, error) {
 	return state.Finished(), nil
 }
 
+func (r *batchSpecResolver) Source() string {
+	if r.batchSpec.CreatedFromRaw {
+		return btypes.BatchSpecSourceRemote.ToGraphQL()
+	}
+	return btypes.BatchSpecSourceLocal.ToGraphQL()
+}
+
 func (r *batchSpecResolver) computeNamespace(ctx context.Context) (*graphqlbackend.NamespaceResolver, error) {
 	r.namespaceOnce.Do(func() {
 		if r.preloadedNamespace != nil {

--- a/enterprise/internal/batches/types/batch_spec.go
+++ b/enterprise/internal/batches/types/batch_spec.go
@@ -184,3 +184,15 @@ func ComputeBatchSpecState(spec *BatchSpec, stats BatchSpecStats) BatchSpecState
 
 	return "INVALID"
 }
+
+// BatchSpecSource defines the possible sources for creating a BatchSpec. Client-side
+// batch specs (created with src-cli) are said to have the "local" source, and batch specs
+// created for server-side execution are said to have the "remote" source.
+type BatchSpecSource string
+
+const (
+	BatchSpecSourceLocal  BatchSpecState = "local"
+	BatchSpecSourceRemote BatchSpecState = "remote"
+)
+
+func (s BatchSpecSource) ToGraphQL() string { return strings.ToUpper(string(s)) }


### PR DESCRIPTION
Although we're hiding locally-executed specs from the execution list views, it's still possible (and, in fact, likely) to pull up the details for one such batch spec from the batch changes list page if, for example, a user executes a spec locally but leaves it unapplied. For local specs, the experience in the execution UI was a little weird. This just makes it slightly less disorienting:

<img width="1315" alt="Screen Shot 2022-06-07 at 6 40 42 PM" src="https://user-images.githubusercontent.com/8942601/172514267-00e79ec8-3c9a-4f88-bf8a-7517d105388b.png">

- The "Execution" tab will be disabled for locally-executed specs, since there's nothing to view there.
- The workspaces preview panel will be hidden, since there's no workspaces resolution to show.
- The execution stats will be hidden, and the state badge will show a special indicator, "LOCAL", to indicate the state is not really reflected from this page for locally-executed specs.

If someone does manually try to navigate to `/execute`, there will just be a message that there is no execution to show for this spec. I suppose I could also just conditionally disable the routes, but I thought this would be slightly more helpful.

<img width="1318" alt="Screen Shot 2022-06-07 at 6 41 14 PM" src="https://user-images.githubusercontent.com/8942601/172514591-d130ab1e-9ae9-4c1f-aaa9-7ab3e49f3bb7.png">

Unrelated, but there was apparently an eslint configuration change recently that now requires names for the functions passed to `React.memo`, so I updated those places for the SSBC components to get rid of the warning. For that reason I would recommend reviewing with the "don't show whitespace changes" option enabled, since a bunch of stuff got re-indented as a result.

## Test plan

Tested locally with specs run from src-cli. Added additional storybook coverage for the components impacted.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
