### PR TITLE
Code Insights Revert typography changes in the insight title

### DIFF
--- a/client/web/src/enterprise/insights/components/views/card/InsightCard.tsx
+++ b/client/web/src/enterprise/insights/components/views/card/InsightCard.tsx
@@ -3,7 +3,7 @@ import React, { forwardRef, HTMLAttributes, ReactNode } from 'react'
 import classNames from 'classnames'
 import { useLocation } from 'react-router-dom'
 
-import { Card, ForwardReferenceComponent, H2, LoadingSpinner } from '@sourcegraph/wildcard'
+import { Card, ForwardReferenceComponent, H2, H4, LoadingSpinner } from '@sourcegraph/wildcard'
 
 import { getLineColor, LegendItem, LegendList, Series } from '../../../../../charts'
 import { ErrorBoundary } from '../../../../../components/ErrorBoundary'
@@ -39,7 +39,14 @@ const InsightCardHeader = forwardRef((props, reference) => {
     return (
         <Component {...attributes} ref={reference} className={classNames(styles.header, className)}>
             <div className={styles.headerContent}>
-                <H2 className={styles.title}>{title}</H2>
+                <H4
+                    // We have to cast this element to H2 because having h4 without h3 and h2
+                    // higher in the hierarchy violates a11y rules about headings structure.
+                    as={H2}
+                    className={styles.title}
+                >
+                    {title}
+                </H4>
 
                 {children && (
                     // eslint-disable-next-line jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/36765

| Before  | After |
| ------------- | ------------- |
| <img width="1149" alt="Screenshot 2022-06-08 at 11 10 52" src="https://user-images.githubusercontent.com/18492575/172526163-b1636e7c-1773-4807-ab5a-cb4f87a2d946.png"> | <img width="1174" alt="Screenshot 2022-06-08 at 11 34 08" src="https://user-images.githubusercontent.com/18492575/172526187-700a53fa-f298-41bd-9cbc-912b425acfab.png"> |

## Test plan
- Make sure that all headings look correct in the insight card titles 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vk-fix-insight-card-title.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-epmxhhoyqe.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
