### PR TITLE
worker: add Bitbucket Project worker

### DIFF
--- a/cmd/worker/internal/permissions/bitbucket_projects.go
+++ b/cmd/worker/internal/permissions/bitbucket_projects.go
@@ -1,0 +1,250 @@
+package permissions
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"encoding/json"
+	"time"
+
+	"github.com/keegancsmith/sqlf"
+	"github.com/lib/pq"
+	"github.com/opentracing/opentracing-go"
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/sourcegraph/sourcegraph/cmd/worker/job"
+	workerdb "github.com/sourcegraph/sourcegraph/cmd/worker/shared/init/db"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
+	"github.com/sourcegraph/sourcegraph/internal/env"
+	"github.com/sourcegraph/sourcegraph/internal/goroutine"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
+	"github.com/sourcegraph/sourcegraph/internal/trace"
+	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/internal/workerutil"
+	"github.com/sourcegraph/sourcegraph/internal/workerutil/dbworker"
+	dbworkerstore "github.com/sourcegraph/sourcegraph/internal/workerutil/dbworker/store"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"github.com/sourcegraph/sourcegraph/lib/log"
+)
+
+// bitbucketProjectPermissionsJob implements the job.Job interface. It is used by the worker service
+// to spawn a new background worker.
+type bitbucketProjectPermissionsJob struct{}
+
+// NewBitbucketProjectPermissionsJob creates a new job for applying explicit permissions
+// to all the repositories of a Bitbucket Project.
+func NewBitbucketProjectPermissionsJob() job.Job {
+	return &bitbucketProjectPermissionsJob{}
+}
+
+func (j *bitbucketProjectPermissionsJob) Description() string {
+	return "Applies explicit permissions to all the repositories of a Bitbucket Project."
+}
+
+// TODO(asdine): Load environment variables from here if needed.
+func (j *bitbucketProjectPermissionsJob) Config() []env.Config {
+	return []env.Config{}
+}
+
+// Routines is called by the worker service to start the worker.
+// It returns a list of goroutines that the worker service should start and manage.
+func (j *bitbucketProjectPermissionsJob) Routines(ctx context.Context, logger log.Logger) ([]goroutine.BackgroundRoutine, error) {
+	wdb, err := workerdb.Init()
+	if err != nil {
+		return nil, err
+	}
+	db := database.NewDB(wdb)
+
+	bbProjectMetrics := newMetricsForBitbucketProjectPermissionsQueries(logger)
+
+	return []goroutine.BackgroundRoutine{
+		newBitbucketProjectPermissionsWorker(db, bbProjectMetrics),
+		newBitbucketProjectPermissionsResetter(db, bbProjectMetrics),
+	}, nil
+}
+
+// bitbucketProjectPermissionsHandler handles the execution of a single explicit_permissions_bitbucket_projects_jobs record.
+type bitbucketProjectPermissionsHandler struct{}
+
+// Handle implements the workerutil.Handler interface.
+func (h *bitbucketProjectPermissionsHandler) Handle(ctx context.Context, logger log.Logger, record workerutil.Record) (err error) {
+	defer func() {
+		if err != nil {
+			logger.Error("bitbucketProjectPermissionsHandler.Handle", log.Error(err))
+		}
+	}()
+
+	// TODO: handle the job
+	return nil
+}
+
+// newBitbucketProjectPermissionsWorker creates a worker that reads the explicit_permissions_bitbucket_projects_jobs table and
+// executes the jobs.
+// TODO(asdine): Fine tune the retry strategy and make some parameters configurable.
+func newBitbucketProjectPermissionsWorker(db database.DB, metrics bitbucketProjectPermissionsMetrics) *workerutil.Worker {
+	options := workerutil.WorkerOptions{
+		Name:              "explicit_permissions_bitbucket_projects_jobs_worker",
+		NumHandlers:       3,
+		Interval:          1 * time.Second,
+		HeartbeatInterval: 15 * time.Second,
+		Metrics:           metrics.workerMetrics,
+	}
+
+	return dbworker.NewWorker(context.Background(), createBitbucketProjectPermissionsStore(db), &bitbucketProjectPermissionsHandler{}, options)
+}
+
+// newBitbucketProjectPermissionsResetter implements resetter for the explicit_permissions_bitbucket_projects_jobs table.
+// See resetter documentation for more details. https://docs.sourcegraph.com/dev/background-information/workers#dequeueing-and-resetting-jobs
+func newBitbucketProjectPermissionsResetter(db database.DB, metrics bitbucketProjectPermissionsMetrics) *dbworker.Resetter {
+	s := db.GitserverLocalClone()
+	workerStore := createBitbucketProjectPermissionsStore(s)
+
+	options := dbworker.ResetterOptions{
+		Name:     "explicit_permissions_bitbucket_projects_jobs_worker_resetter",
+		Interval: 1 * time.Minute,
+		Metrics: dbworker.ResetterMetrics{
+			Errors:              metrics.errors,
+			RecordResetFailures: metrics.resetFailures,
+			RecordResets:        metrics.resets,
+		},
+	}
+	return dbworker.NewResetter(workerStore, options)
+}
+
+// createLocalCloneStore creates a store that reads and writes to the explicit_permissions_bitbucket_projects_jobs table.
+// It is used by the worker and resetter.
+// TODO(asdine): Fine tune the retry strategy and make some parameters configurable.
+func createBitbucketProjectPermissionsStore(s basestore.ShareableStore) dbworkerstore.Store {
+	return dbworkerstore.New(s.Handle(), dbworkerstore.Options{
+		Name:      "explicit_permissions_bitbucket_projects_jobs_store",
+		TableName: "explicit_permissions_bitbucket_projects_jobs j",
+		ColumnExpressions: []*sqlf.Query{
+			sqlf.Sprintf("j.id"),
+			sqlf.Sprintf("j.state"),
+			sqlf.Sprintf("j.failure_message"),
+			sqlf.Sprintf("j.queued_at"),
+			sqlf.Sprintf("j.started_at"),
+			sqlf.Sprintf("j.finished_at"),
+			sqlf.Sprintf("j.process_after"),
+			sqlf.Sprintf("j.num_resets"),
+			sqlf.Sprintf("j.num_failures"),
+			sqlf.Sprintf("j.last_heartbeat_at"),
+			sqlf.Sprintf("j.execution_logs"),
+			sqlf.Sprintf("j.worker_hostname"),
+			sqlf.Sprintf("j.project_key"),
+			sqlf.Sprintf("j.external_service_id"),
+			sqlf.Sprintf("j.permissions"),
+			sqlf.Sprintf("j.unrestricted"),
+		},
+		Scan:              scanFirstBitbucketProjectPermissionsJob,
+		StalledMaxAge:     60 * time.Second,
+		RetryAfter:        10 * time.Second,
+		MaxNumRetries:     5,
+		OrderByExpression: sqlf.Sprintf("id"),
+	})
+}
+
+// scanFirstBitbucketProjectPermissionsJob scans a single job from the return value of `*Store.query`.
+func scanFirstBitbucketProjectPermissionsJob(rows *sql.Rows, queryErr error) (_ workerutil.Record, exists bool, err error) {
+	if queryErr != nil {
+		return nil, false, queryErr
+	}
+	defer func() { err = basestore.CloseRows(rows, err) }()
+
+	if rows.Next() {
+		var job types.BitbucketProjectPermissionJob
+		var executionLogs []dbworkerstore.ExecutionLogEntry
+		var permissions []userPermission
+
+		if err := rows.Scan(
+			&job.ID,
+			&job.State,
+			&job.FailureMessage,
+			&job.QueuedAt,
+			&job.StartedAt,
+			&job.FinishedAt,
+			&job.ProcessAfter,
+			&job.NumResets,
+			&job.NumFailures,
+			&job.LastHeartbeatAt,
+			pq.Array(&executionLogs),
+			&job.WorkerHostname,
+			&job.ProjectKey,
+			&job.ExternalServiceID,
+			pq.Array(&permissions),
+			&job.Unrestricted,
+		); err != nil {
+			return nil, false, err
+		}
+
+		for _, entry := range executionLogs {
+			job.ExecutionLogs = append(job.ExecutionLogs, workerutil.ExecutionLogEntry(entry))
+		}
+
+		for _, perm := range permissions {
+			job.Permissions = append(job.Permissions, types.UserPermission(perm))
+		}
+
+		return &job, true, nil
+	}
+
+	return nil, false, nil
+}
+
+type userPermission types.UserPermission
+
+func (p *userPermission) Scan(value any) error {
+	b, ok := value.([]byte)
+	if !ok {
+		return errors.Errorf("value is not []byte: %T", value)
+	}
+
+	return json.Unmarshal(b, &p)
+}
+
+func (p userPermission) Value() (driver.Value, error) {
+	return json.Marshal(p)
+}
+
+// These are the metrics that are used by the worker and resetter.
+// They are required by the workerutil package for automatic metrics collection.
+type bitbucketProjectPermissionsMetrics struct {
+	workerMetrics workerutil.WorkerMetrics
+	resets        prometheus.Counter
+	resetFailures prometheus.Counter
+	errors        prometheus.Counter
+}
+
+func newMetricsForBitbucketProjectPermissionsQueries(logger log.Logger) bitbucketProjectPermissionsMetrics {
+	observationContext := &observation.Context{
+		Logger:     logger.Scoped("routines", "bitbucket projects explicit permissions job routines"),
+		Tracer:     &trace.Tracer{Tracer: opentracing.GlobalTracer()},
+		Registerer: prometheus.DefaultRegisterer,
+	}
+
+	resetFailures := prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "src_explicit_permissions_bitbucket_project_query_reset_failures_total",
+		Help: "The number of reset failures.",
+	})
+	observationContext.Registerer.MustRegister(resetFailures)
+
+	resets := prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "src_explicit_permissions_bitbucket_project_query_resets_total",
+		Help: "The number of records reset.",
+	})
+	observationContext.Registerer.MustRegister(resets)
+
+	errors := prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "src_explicit_permissions_bitbucket_project_query_errors_total",
+		Help: "The number of errors that occur during job.",
+	})
+	observationContext.Registerer.MustRegister(errors)
+
+	return bitbucketProjectPermissionsMetrics{
+		workerMetrics: workerutil.NewMetrics(observationContext, "explicit_permissions_bitbucket_project_queries"),
+		resets:        resets,
+		resetFailures: resetFailures,
+		errors:        errors,
+	}
+}

--- a/cmd/worker/internal/permissions/bitbucket_projects.go
+++ b/cmd/worker/internal/permissions/bitbucket_projects.go
@@ -97,8 +97,7 @@ func newBitbucketProjectPermissionsWorker(db database.DB, metrics bitbucketProje
 // newBitbucketProjectPermissionsResetter implements resetter for the explicit_permissions_bitbucket_projects_jobs table.
 // See resetter documentation for more details. https://docs.sourcegraph.com/dev/background-information/workers#dequeueing-and-resetting-jobs
 func newBitbucketProjectPermissionsResetter(db database.DB, metrics bitbucketProjectPermissionsMetrics) *dbworker.Resetter {
-	s := db.GitserverLocalClone()
-	workerStore := createBitbucketProjectPermissionsStore(s)
+	workerStore := createBitbucketProjectPermissionsStore(db)
 
 	options := dbworker.ResetterOptions{
 		Name:     "explicit_permissions_bitbucket_projects_jobs_worker_resetter",
@@ -112,7 +111,7 @@ func newBitbucketProjectPermissionsResetter(db database.DB, metrics bitbucketPro
 	return dbworker.NewResetter(workerStore, options)
 }
 
-// createLocalCloneStore creates a store that reads and writes to the explicit_permissions_bitbucket_projects_jobs table.
+// createBitbucketProjectPermissionsStore creates a store that reads and writes to the explicit_permissions_bitbucket_projects_jobs table.
 // It is used by the worker and resetter.
 // TODO(asdine): Fine tune the retry strategy and make some parameters configurable.
 func createBitbucketProjectPermissionsStore(s basestore.ShareableStore) dbworkerstore.Store {

--- a/cmd/worker/internal/permissions/bitbucket_projects.go
+++ b/cmd/worker/internal/permissions/bitbucket_projects.go
@@ -39,7 +39,7 @@ func NewBitbucketProjectPermissionsJob() job.Job {
 }
 
 func (j *bitbucketProjectPermissionsJob) Description() string {
-	return "Applies explicit permissions to all the repositories of a Bitbucket Project."
+	return "Applies explicit permissions to all repositories of a Bitbucket Project."
 }
 
 // TODO(asdine): Load environment variables from here if needed.
@@ -140,7 +140,7 @@ func createBitbucketProjectPermissionsStore(s basestore.ShareableStore) dbworker
 		StalledMaxAge:     60 * time.Second,
 		RetryAfter:        10 * time.Second,
 		MaxNumRetries:     5,
-		OrderByExpression: sqlf.Sprintf("id"),
+		OrderByExpression: sqlf.Sprintf("j.id"),
 	})
 }
 

--- a/cmd/worker/internal/permissions/bitbucket_projects_test.go
+++ b/cmd/worker/internal/permissions/bitbucket_projects_test.go
@@ -1,0 +1,105 @@
+package permissions
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
+	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/internal/workerutil"
+)
+
+func TestScanFirstBitbucketProjectPermissionsJob(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	t.Parallel()
+	db := database.NewDB(dbtest.NewDB(t))
+
+	ctx := context.Background()
+	_, err := db.ExecContext(ctx, `--sql
+		INSERT INTO explicit_permissions_bitbucket_projects_jobs
+		(
+			id,
+			state,
+			failure_message,
+			queued_at,
+			started_at,
+			finished_at,
+			process_after,
+			num_resets,
+			num_failures,
+			last_heartbeat_at,
+			execution_logs,
+			worker_hostname,
+			project_key,
+			external_service_id,
+			permissions,
+			unrestricted
+		) VALUES (
+			1,
+			'queued',
+			'failure message',
+			'2020-01-01',
+			'2020-01-02',
+			'2020-01-03',
+			'2020-01-04',
+			1,
+			2,
+			'2020-01-05',
+			E'{"{\\"key\\": \\"key\\", \\"command\\": [\\"command\\"], \\"startTime\\": \\"2020-01-06T00:00:00Z\\", \\"exitCode\\": 1, \\"out\\": \\"out\\", \\"durationMs\\": 1}"}'::json[],
+			'worker-hostname',
+			'project-key',
+			1,
+			E'{"{\\"permission\\": \\"read\\", \\"bindID\\": \\"omar@sourcegraph.com\\"}"}'::json[],
+			false
+		);
+	`)
+	require.NoError(t, err)
+
+	rows, err := db.QueryContext(ctx, `SELECT * FROM explicit_permissions_bitbucket_projects_jobs WHERE id = 1`)
+	require.NoError(t, err)
+
+	record, ok, err := scanFirstBitbucketProjectPermissionsJob(rows, nil)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, &types.BitbucketProjectPermissionJob{
+		ID:                1,
+		State:             "queued",
+		FailureMessage:    stringPtr("failure message"),
+		QueuedAt:          mustParseTime("2020-01-01"),
+		StartedAt:         timePtr(mustParseTime("2020-01-02")),
+		FinishedAt:        timePtr(mustParseTime("2020-01-03")),
+		ProcessAfter:      timePtr(mustParseTime("2020-01-04")),
+		NumResets:         1,
+		NumFailures:       2,
+		LastHeartbeatAt:   mustParseTime("2020-01-05"),
+		ExecutionLogs:     []workerutil.ExecutionLogEntry{{Key: "key", Command: []string{"command"}, StartTime: mustParseTime("2020-01-06"), ExitCode: intPtr(1), Out: "out", DurationMs: intPtr(1)}},
+		WorkerHostname:    "worker-hostname",
+		ProjectKey:        "project-key",
+		ExternalServiceID: 1,
+		Permissions:       []types.UserPermission{{Permission: "read", BindID: "omar@sourcegraph.com"}},
+		Unrestricted:      false,
+	}, record)
+
+	store := createBitbucketProjectPermissionsStore(db)
+	count, err := store.QueuedCount(ctx, true, nil)
+	require.NoError(t, err)
+	require.Equal(t, 1, count)
+}
+
+func intPtr(v int) *int              { return &v }
+func stringPtr(v string) *string     { return &v }
+func timePtr(v time.Time) *time.Time { return &v }
+
+func mustParseTime(v string) time.Time {
+	t, err := time.Parse("2006-01-02", v)
+	if err != nil {
+		panic(err)
+	}
+	return t
+}

--- a/internal/types/bitbucket_permissions.go
+++ b/internal/types/bitbucket_permissions.go
@@ -1,0 +1,42 @@
+package types
+
+import (
+	"time"
+
+	"github.com/sourcegraph/sourcegraph/internal/workerutil"
+)
+
+// BitbucketProjectPermissionJob TODO
+type BitbucketProjectPermissionJob struct {
+	ID              int
+	State           string
+	FailureMessage  *string
+	QueuedAt        time.Time
+	StartedAt       *time.Time
+	FinishedAt      *time.Time
+	ProcessAfter    *time.Time
+	NumResets       int
+	NumFailures     int
+	LastHeartbeatAt time.Time
+	ExecutionLogs   []workerutil.ExecutionLogEntry
+	WorkerHostname  string
+
+	// Name of the Bitbucket Project
+	ProjectKey string
+	// ID of the external service that contains the Bitbucket address and credentials
+	ExternalServiceID int64
+	// List of user permissions for the Bitbucket Project
+	Permissions []UserPermission
+	// Whether all of the repos of the project are unrestricted
+	Unrestricted bool
+}
+
+// RecordID implements workerutil.Record.
+func (g *BitbucketProjectPermissionJob) RecordID() int {
+	return g.ID
+}
+
+type UserPermission struct {
+	BindID     string `json:"bindID"`
+	Permission string `json:"permission"`
+}

--- a/internal/types/bitbucket_permissions.go
+++ b/internal/types/bitbucket_permissions.go
@@ -6,7 +6,8 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/workerutil"
 )
 
-// BitbucketProjectPermissionJob TODO
+// BitbucketProjectPermissionJob represents a task to apply a set of permissions
+// to all the repos of the given Bitbucket project.
 type BitbucketProjectPermissionJob struct {
 	ID              int
 	State           string


### PR DESCRIPTION
This adds a worker for Bitbucket Project Permissions.
The handler is still empty and most of the code contains hardcoded values 
that will be handled later (please ignore the TODOs, they will be updated later).

## Test plan

Added a unit test to validate the scan is working properly.

Fixes #36370