### PR TITLE
ci: make executor hash script stable

### DIFF
--- a/enterprise/cmd/executor/hash.sh
+++ b/enterprise/cmd/executor/hash.sh
@@ -11,7 +11,7 @@ trap cleanup EXIT
 # Do not embed build flags to produce a stable output
 pkg="github.com/sourcegraph/sourcegraph/enterprise/cmd/executor"
 artifact="$OUTPUT/$(basename $pkg)"
-go build -trimpath -buildmode exe -tags dist -o "$artifact" "$pkg"
+go build -buildvcs=false -trimpath -buildmode exe -tags dist -o "$artifact" "$pkg"
 
 # Generate hash for build artifact
 md5sum <"$artifact"


### PR DESCRIPTION
The executor image was built on every CI run for a while, which became apparent as we started investigating some build issues this morning. We found out that the hash.sh script was not working as intended, probably since the update to go 1.18. 

Kudos to @burmudar for finding the flag that was added recently.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

tested locally, new build flag made the binary stable across HEAD and HEAD^ 