### PR TITLE
symbols: add retry option to deal with IPV6 issues on WSL2

### DIFF
--- a/cmd/symbols/ctags-install-alpine.sh
+++ b/cmd/symbols/ctags-install-alpine.sh
@@ -35,7 +35,7 @@ apk --no-cache add jansson
 NUMCPUS=$(grep -c '^processor' /proc/cpuinfo)
 
 # Installation
-curl "https://codeload.github.com/universal-ctags/ctags/tar.gz/$CTAGS_VERSION" | tar xz -C /tmp
+curl --retry 5 "https://codeload.github.com/universal-ctags/ctags/tar.gz/$CTAGS_VERSION" | tar xz -C /tmp
 cd /tmp/ctags-$CTAGS_VERSION
 ./autogen.sh
 ./configure --program-prefix=universal- --enable-json


### PR DESCRIPTION
When running sg on WSL2, the enterprise-symbols step fails with the following error:

```
...
#7 20.92 + curl https://codeload.github.com/universal-ctags/ctags/tar.gz/f95bb3497f53748c2b6afc7f298cff218103ab90
#7 20.99   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#7 20.99                                  Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:--  0:00:04 --:--:--     0curl: (6) Could not resolve host: codeload.github.com
...
```

After some research it seems related to the way Docker on Windows deals with IP V6 addresses. Adding a retry seems to fix the issue

## Test plan

I have been using it for a week now and everything seems fine.