### PR TITLE
ci: pin executor image used to build it

### DIFF
--- a/enterprise/cmd/executor/image/executor.json
+++ b/enterprise/cmd/executor/image/executor.json
@@ -13,7 +13,7 @@
       "type": "googlecompute",
       "project_id": "sourcegraph-ci",
       "source_image_project_id": "ubuntu-os-cloud",
-      "source_image_family": "ubuntu-2004-lts",
+      "source_image": "ubuntu-2004-focal-v20220606",
       "disk_size": "10",
       "ssh_username": "packer",
       "zone": "us-central1-c",


### PR DESCRIPTION
See https://bugs.launchpad.net/ubuntu/+source/linux-aws/+bug/1977919

Basically, today's build causes a kernel panic when using Docker.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Ran the build script locally, it passed with the image pinned to yesterday's version. 