### PR TITLE
insights: Fix lang stats insight title

### DIFF
--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/built-in-insight/BuiltInInsight.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/built-in-insight/BuiltInInsight.tsx
@@ -78,7 +78,7 @@ export function BuiltInInsight(props: BuiltInInsightProps): React.ReactElement {
             <InsightCardHeader
                 title={
                     <Link to={shareableUrl} target="_blank" rel="noopener noreferrer">
-                        insight.title
+                        {insight.title}
                     </Link>
                 }
             >


### PR DESCRIPTION
display lang stats insight title
## Test plan
Visual check that lang stats title appears.
<img width="390" alt="Screen Shot 2022-06-08 at 8 13 56 AM" src="https://user-images.githubusercontent.com/6098507/172613484-bac909c8-f4d2-48bb-841f-7c04295770f7.png">

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->



## App preview:

- [Web](https://sg-web-cw-fix-code-stats-title.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-vcyxpkiohe.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
