### PR TITLE
release: update `release-config.jsonc` and paths to GitHub issues templates

### DIFF
--- a/dev/release/release-config.jsonc
+++ b/dev/release/release-config.jsonc
@@ -10,16 +10,16 @@
  */
 {
     // Captain information
-    "captainSlackUsername": "bolaji",
-    "captainGitHubUsername": "BolajiOlajide",
+    "captainSlackUsername": "Alex Ostrikov",
+    "captainGitHubUsername": "sashaostrikov",
     // Release versions
     "previousRelease": "3.40.1",
     "upcomingRelease": "3.40.2",
     // Release dates
-    "oneWorkingWeekBeforeRelease": "15 June 2022 10:00 PST",
-    "oneWorkingDayBeforeRelease": "21 June 2022 10:00 PST",
-    "releaseDate": "22 June 2022 10:00 PST",
-    "oneWorkingDayAfterRelease": "23 June 2022 10:00 PST",
+    "oneWorkingWeekBeforeRelease": "2 June 2022 10:00 PST",
+    "oneWorkingDayBeforeRelease": "8 June 2022 10:00 PST",
+    "releaseDate": "9 June 2022 10:00 PST",
+    "oneWorkingDayAfterRelease": "10 June 2022 10:00 PST",
     // Channel where messages from the tooling are posted
     "slackAnnounceChannel": "prod-eng-announce",
     // Email for preparing calendar events

--- a/dev/release/release-config.jsonc
+++ b/dev/release/release-config.jsonc
@@ -21,7 +21,7 @@
     "releaseDate": "9 June 2022 10:00 PST",
     "oneWorkingDayAfterRelease": "10 June 2022 10:00 PST",
     // Channel where messages from the tooling are posted
-    "slackAnnounceChannel": "prod-eng-announce",
+    "slackAnnounceChannel": "eng-announce",
     // Email for preparing calendar events
     "teamEmail": "team@sourcegraph.com",
     // Enable dry-running for certain features - useful for testing or sanity-checking.

--- a/dev/release/src/github.ts
+++ b/dev/release/src/github.ts
@@ -103,28 +103,28 @@ const getTemplates = () => {
     const releaseIssue: IssueTemplate = {
         owner: 'sourcegraph',
         repo: 'handbook',
-        path: 'content/departments/product-engineering/engineering/process/releases/release_issue_template.md',
+        path: 'content/departments/engineering/dev/process/releases/release_issue_template.md',
         titleSuffix: IssueTitleSuffix.RELEASE_TRACKING,
         labels: [IssueLabel.RELEASE_TRACKING, IssueLabel.RELEASE],
     }
     const patchReleaseIssue: IssueTemplate = {
         owner: 'sourcegraph',
         repo: 'handbook',
-        path: 'content/departments/product-engineering/engineering/process/releases/patch_release_issue_template.md',
+        path: 'content/departments/engineering/dev/process/releases/patch_release_issue_template.md',
         titleSuffix: IssueTitleSuffix.PATCH_TRACKING,
         labels: [IssueLabel.RELEASE_TRACKING, IssueLabel.PATCH],
     }
     const upgradeManagedInstanceIssue: IssueTemplate = {
         owner: 'sourcegraph',
         repo: 'handbook',
-        path: 'content/departments/product-engineering/engineering/process/releases/upgrade_managed_issue_template.md',
+        path: 'content/departments/engineering/dev/process/releases/upgrade_managed_issue_template.md',
         titleSuffix: IssueTitleSuffix.MANAGED_TRACKING,
         labels: [IssueLabel.RELEASE_TRACKING, IssueLabel.MANAGED, IssueLabel.DEVOPS_TEAM],
     }
     const securityAssessmentIssue: IssueTemplate = {
         owner: 'sourcegraph',
         repo: 'handbook',
-        path: 'content/departments/product-engineering/engineering/process/releases/security_assessment.md',
+        path: 'content/departments/engineering/dev/process/releases/security_assessment.md',
         titleSuffix: IssueTitleSuffix.SECURITY_TRACKING,
         labels: [IssueLabel.RELEASE_TRACKING, IssueLabel.SECURITY_TEAM, IssueLabel.RELEASE_BLOCKER],
     }


### PR DESCRIPTION
Changing release dates, captain info and fixing the paths to GH issues templates which were broken due to some handbook pages rearrangement.

## Test plan
Hit this fixed URL and see that there is no 404 anymore: https://api.github.com/repos/sourcegraph/handbook/contents/content%2Fdepartments%2Fengineering%2Fdev%2Fprocess%2Freleases%2Fpatch_release_issue_template.md
 
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
