### PR TITLE
codeintel: dedupe reference and impls ranges on client-side (temporary)

### DIFF
--- a/client/web/src/codeintel/useCodeIntel.ts
+++ b/client/web/src/codeintel/useCodeIntel.ts
@@ -221,7 +221,10 @@ export const useCodeIntel = ({
                 definitions: previousData.definitions,
                 references: {
                     endCursor: newReferenceData.pageInfo.endCursor,
-                    nodes: [...previousData.references.nodes, ...newReferenceData.nodes.map(buildPreciseLocation)],
+                    nodes: dedupeLocations([
+                        ...previousData.references.nodes,
+                        ...newReferenceData.nodes.map(buildPreciseLocation),
+                    ]),
                 },
             })
 
@@ -251,10 +254,10 @@ export const useCodeIntel = ({
                 definitions: previousData.definitions,
                 implementations: {
                     endCursor: newImplementationsData.pageInfo.endCursor,
-                    nodes: [
+                    nodes: dedupeLocations([
                         ...previousData.implementations.nodes,
                         ...newImplementationsData.nodes.map(buildPreciseLocation),
-                    ],
+                    ]),
                 },
             })
         },
@@ -326,15 +329,27 @@ const getLsifData = ({
     return {
         implementations: {
             endCursor: lsif.implementations.pageInfo.endCursor,
-            nodes: lsif.implementations.nodes.map(buildPreciseLocation),
+            nodes: dedupeLocations(lsif.implementations.nodes).map(buildPreciseLocation),
         },
         references: {
             endCursor: lsif.references.pageInfo.endCursor,
-            nodes: lsif.references.nodes.map(buildPreciseLocation),
+            nodes: dedupeLocations(lsif.references.nodes).map(buildPreciseLocation),
         },
         definitions: {
             endCursor: lsif.definitions.pageInfo.endCursor,
             nodes: lsif.definitions.nodes.map(buildPreciseLocation),
         },
     }
+}
+
+const dedupeLocations = <L extends { url: string }>(locations: L[]): L[] => {
+    const deduped = []
+    const seenURLs = new Set<string>()
+    for (const location of locations) {
+        if (!seenURLs.has(location.url)) {
+            deduped.push(location)
+            seenURLs.add(location.url)
+        }
+    }
+    return deduped
 }


### PR DESCRIPTION
Provides a (temporary?) patch for https://github.com/sourcegraph/sourcegraph/issues/36634 by simple set lookup deduplication

<details>
<summary><b>After</b></summary>

![image](https://user-images.githubusercontent.com/18282288/172625345-8e7f1529-75fb-49ef-a29c-d645f0d6fd2c.png)

</details>

<details>
<summary><b>Before</b></summary>

![image](https://user-images.githubusercontent.com/18282288/172625759-d5fe48dc-d8ef-42ea-9e84-d59a1fb736a2.png)

</details>

## Test plan

Tested manually using the same upload setup as was demonstrated in https://github.com/sourcegraph/sourcegraph/issues/36634, with `lsif-tsc` and `scip-typescript` uploads servicing the same request

## App preview:

- [Web](https://sg-web-nsc-dedupe-locations-refpanel.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-bttezkrffa.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
