### PR TITLE
Add ability for Bitbucket clients to specify repos by projectKey

### DIFF
--- a/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
+++ b/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
@@ -273,7 +273,7 @@ func (s *PermsSyncer) maybeRefreshGitLabOAuthTokenFromAccount(ctx context.Contex
 		break
 	}
 	if oauthConfig == nil {
-		log15.Warn("PermsSyncer.maybeRefreshGitLabOAuthToken, external account has no auth.provider",
+		log15.Warn("PermsSyncer.maybeRefreshGitLabOAuthTokenFromAccount, external account has no auth.provider",
 			"externalAccountID", acct.ID,
 		)
 		return nil

--- a/internal/extsvc/bitbucketserver/client.go
+++ b/internal/extsvc/bitbucketserver/client.go
@@ -927,6 +927,9 @@ func (c *Client) do(ctx context.Context, req *http.Request, result any) (*http.R
 		req.Header.Set("Content-Type", "application/json; charset=utf-8")
 	}
 
+	fmt.Println("HTTP C.DO")
+	fmt.Printf("%+v\n", req)
+
 	req, ht := nethttp.TraceRequest(ot.GetTracer(ctx),
 		req.WithContext(ctx),
 		nethttp.OperationName("Bitbucket Server"),

--- a/internal/extsvc/bitbucketserver/client.go
+++ b/internal/extsvc/bitbucketserver/client.go
@@ -808,24 +808,8 @@ func (c *Client) Repos(ctx context.Context, pageToken *PageToken, searchQueries 
 	}
 
 	var repos []*Repo
-
-	emptyPageToken := PageToken{
-		Size:          0,
-		Limit:         1000,
-		IsLastPage:    true,
-		Start:         0,
-		NextPageStart: 0,
-	}
-
-	if _, ok := qry["projectName"]; ok || len(qry) == 0 {
-		next, err := c.page(ctx, "rest/api/1.0/repos", qry, pageToken, &repos)
-		return repos, next, err
-	} else if projectKey, ok := qry["projectKey"]; ok {
-		next, err := c.page(ctx, "rest/api/1.0/projects/"+projectKey[0]+"/repos", nil, pageToken, &repos)
-		return repos, next, err
-	}
-	return repos, &emptyPageToken, err
-
+	next, err := c.page(ctx, "rest/api/1.0/repos", qry, pageToken, &repos)
+	return repos, next, err
 }
 
 func (c *Client) LabeledRepos(ctx context.Context, pageToken *PageToken, label string) ([]*Repo, *PageToken, error) {

--- a/internal/extsvc/bitbucketserver/client.go
+++ b/internal/extsvc/bitbucketserver/client.go
@@ -906,8 +906,8 @@ func (c *Client) page(ctx context.Context, path string, qry url.Values, token *P
 
 	var next PageToken
 	_, err = c.do(ctx, req, &struct {
-		*PageToken `json:"pageToken"`
-		Values     any `json:"values"`
+		*PageToken
+		Values any `json:"values"`
 	}{
 		PageToken: &next,
 		Values:    results,

--- a/internal/extsvc/bitbucketserver/client.go
+++ b/internal/extsvc/bitbucketserver/client.go
@@ -876,13 +876,10 @@ func (c *Client) page(ctx context.Context, path string, qry url.Values, token *P
 	fmt.Println("Query:", qry)
 	if qry == nil {
 		qry = make(url.Values)
-		fmt.Println("No query, new query is", qry)
 	}
 
 	for k, vs := range token.Values() {
-		fmt.Println("k:", k)
 		qry[k] = append(qry[k], vs...)
-		fmt.Println("query[k]:", qry[k])
 	}
 
 	u := url.URL{Path: path, RawQuery: qry.Encode()}
@@ -961,16 +958,9 @@ func (c *Client) do(ctx context.Context, req *http.Request, result any) (*http.R
 
 	defer resp.Body.Close()
 
-	fmt.Println("READING FROM RESP BODY")
 	bs, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
-	}
-	fmt.Println("bs:", bs)
-
-	fmt.Println("FOR LOOP")
-	for data := range bs {
-		fmt.Println("Data:", data)
 	}
 
 	fmt.Println("StatusCode:", resp.StatusCode)

--- a/internal/extsvc/bitbucketserver/client.go
+++ b/internal/extsvc/bitbucketserver/client.go
@@ -872,14 +872,17 @@ func (c *Client) Fork(ctx context.Context, projectKey, repoSlug string, input Cr
 }
 
 func (c *Client) page(ctx context.Context, path string, qry url.Values, token *PageToken, results any) (*PageToken, error) {
+	fmt.Println("IN CLIENT.page()")
 	fmt.Println("Query:", qry)
 	if qry == nil {
 		qry = make(url.Values)
+		fmt.Println("No query, new query is", qry)
 	}
 
 	for k, vs := range token.Values() {
 		fmt.Println("k:", k)
 		qry[k] = append(qry[k], vs...)
+		fmt.Println("query[k]:", qry[k])
 	}
 
 	u := url.URL{Path: path, RawQuery: qry.Encode()}
@@ -927,18 +930,17 @@ func (c *Client) send(ctx context.Context, method, path string, qry url.Values, 
 }
 
 func (c *Client) do(ctx context.Context, req *http.Request, result any) (*http.Response, error) {
+	fmt.Println("IN CLIENT.do()")
+
 	req.URL = c.URL.ResolveReference(req.URL)
 	if req.Header.Get("Content-Type") == "" {
 		req.Header.Set("Content-Type", "application/json; charset=utf-8")
 	}
 
-	fmt.Println("HTTP C.DO")
-
 	req, ht := nethttp.TraceRequest(ot.GetTracer(ctx),
 		req.WithContext(ctx),
 		nethttp.OperationName("Bitbucket Server"),
 		nethttp.ClientTrace(false))
-	fmt.Println("ht:", ht)
 	defer ht.Finish()
 	fmt.Println("Passed finish")
 
@@ -950,7 +952,7 @@ func (c *Client) do(ctx context.Context, req *http.Request, result any) (*http.R
 		return nil, err
 	}
 
-	fmt.Printf("REQ:%+v\n", req)
+	fmt.Println("REQ:", req.URL)
 	resp, err := c.httpClient.Do(req)
 	fmt.Println("ERROR:", err)
 	if err != nil {
@@ -964,6 +966,7 @@ func (c *Client) do(ctx context.Context, req *http.Request, result any) (*http.R
 	if err != nil {
 		return nil, err
 	}
+	fmt.Println("bs:", bs)
 
 	fmt.Println("FOR LOOP")
 	for data := range bs {

--- a/internal/extsvc/bitbucketserver/client.go
+++ b/internal/extsvc/bitbucketserver/client.go
@@ -808,8 +808,24 @@ func (c *Client) Repos(ctx context.Context, pageToken *PageToken, searchQueries 
 	}
 
 	var repos []*Repo
-	next, err := c.page(ctx, "rest/api/1.0/repos", qry, pageToken, &repos)
-	return repos, next, err
+
+	emptyPageToken := PageToken{
+		Size:          0,
+		Limit:         1000,
+		IsLastPage:    true,
+		Start:         0,
+		NextPageStart: 0,
+	}
+
+	if _, ok := qry["projectName"]; ok || len(qry) == 0 {
+		next, err := c.page(ctx, "rest/api/1.0/repos", qry, pageToken, &repos)
+		return repos, next, err
+	} else if projectKey, ok := qry["projectKey"]; ok {
+		next, err := c.page(ctx, "rest/api/1.0/projects/"+projectKey[0]+"/repos", nil, pageToken, &repos)
+		return repos, next, err
+	}
+	return repos, &emptyPageToken, err
+
 }
 
 func (c *Client) LabeledRepos(ctx context.Context, pageToken *PageToken, label string) ([]*Repo, *PageToken, error) {

--- a/internal/repos/bitbucketserver.go
+++ b/internal/repos/bitbucketserver.go
@@ -298,9 +298,9 @@ func (s *BitbucketServerSource) listAllLabeledRepos(ctx context.Context, label s
 	next := &bitbucketserver.PageToken{Limit: 1000}
 	for next.HasMore() {
 		repos, page, err := s.client.LabeledRepos(ctx, next, label)
-		// if page == nil {
-		// 	break
-		// }
+		if page == nil {
+			break
+		}
 		if err != nil {
 			// If the instance doesn't have the label then no repos are
 			// labeled. Older versions of bitbucket do not support labels, so

--- a/internal/repos/bitbucketserver.go
+++ b/internal/repos/bitbucketserver.go
@@ -111,7 +111,6 @@ func (s BitbucketServerSource) WithAuthenticator(a auth.Authenticator) (Source, 
 
 // ExternalServices returns a singleton slice containing the external service.
 func (s BitbucketServerSource) ExternalServices() types.ExternalServices {
-	fmt.Println("Hi")
 	return types.ExternalServices{s.svc}
 }
 
@@ -226,7 +225,6 @@ func (s *BitbucketServerSource) listAllRepos(ctx context.Context, results chan S
 			}
 
 			projectKey, repoSlug := ps[0], ps[1]
-			fmt.Println("ProjectKey:", projectKey, ", RepoSlug:", repoSlug)
 			repo, err := s.client.Repo(ctx, projectKey, repoSlug)
 			if err != nil {
 				// TODO(tsenart): When implementing dry-run, reconsider alternatives to return
@@ -259,6 +257,10 @@ func (s *BitbucketServerSource) listAllRepos(ctx context.Context, results chan S
 			for next.HasMore() {
 				repos, page, err := s.client.Repos(ctx, next, q)
 				// fmt.Println("Repos:", (*repos[0]).Name)
+				// fmt.Println("q:", q)
+				// for _, r := range repos {
+				// fmt.Println("REPO:", r)
+				// }
 				if err != nil {
 					ch <- batch{err: errors.Wrapf(err, "bitbucketserver.repositoryQuery: query=%q, page=%+v", q, next)}
 					break
@@ -277,7 +279,7 @@ func (s *BitbucketServerSource) listAllRepos(ctx context.Context, results chan S
 
 	seen := make(map[int]bool)
 	for r := range ch {
-		fmt.Println("Batch:", (r.repos[0].Name))
+		// fmt.Println("=== NEW BATCH ===")
 		if r.err != nil {
 			results <- SourceResult{Source: s, Err: r.err}
 			continue
@@ -285,6 +287,7 @@ func (s *BitbucketServerSource) listAllRepos(ctx context.Context, results chan S
 
 		for _, repo := range r.repos {
 			// fmt.Println("Repo:", repo.Name)
+			// fmt.Printf("Repo:%+v\n", repo)
 			// fmt.Println("Seen:", seen[repo.ID])
 			// fmt.Println("Excludes:", s.excludes(repo))
 			if !seen[repo.ID] && !s.excludes(repo) {
@@ -294,7 +297,6 @@ func (s *BitbucketServerSource) listAllRepos(ctx context.Context, results chan S
 			}
 		}
 	}
-	// fmt.Println(<-results)
 	fmt.Println("DONE WITH listAllRepos")
 }
 

--- a/internal/repos/bitbucketserver.go
+++ b/internal/repos/bitbucketserver.go
@@ -298,9 +298,9 @@ func (s *BitbucketServerSource) listAllLabeledRepos(ctx context.Context, label s
 	next := &bitbucketserver.PageToken{Limit: 1000}
 	for next.HasMore() {
 		repos, page, err := s.client.LabeledRepos(ctx, next, label)
-		if page == nil {
-			break
-		}
+		// if page == nil {
+		// 	break
+		// }
 		if err != nil {
 			// If the instance doesn't have the label then no repos are
 			// labeled. Older versions of bitbucket do not support labels, so

--- a/internal/repos/bitbucketserver.go
+++ b/internal/repos/bitbucketserver.go
@@ -195,7 +195,6 @@ func (s *BitbucketServerSource) excludes(r *bitbucketserver.Repo) bool {
 }
 
 func (s *BitbucketServerSource) listAllRepos(ctx context.Context, results chan SourceResult) {
-	fmt.Println("listAllRepos starting...")
 	// "archived" label is a convention used at some customers for indicating a
 	// repository is archived (like github's archived state). This is not returned in
 	// the normal repository listing endpoints, so we need to fetch it separately.
@@ -204,7 +203,6 @@ func (s *BitbucketServerSource) listAllRepos(ctx context.Context, results chan S
 		results <- SourceResult{Source: s, Err: errors.Wrap(err, "failed to list repos with archived label")}
 		return
 	}
-	fmt.Println("batch struct")
 
 	type batch struct {
 		repos []*bitbucketserver.Repo
@@ -231,6 +229,7 @@ func (s *BitbucketServerSource) listAllRepos(ctx context.Context, results chan S
 			}
 
 			projectKey, repoSlug := ps[0], ps[1]
+			fmt.Println("ProjectKey:", projectKey, ", RepoSlug:", repoSlug)
 			repo, err := s.client.Repo(ctx, projectKey, repoSlug)
 			if err != nil {
 				// TODO(tsenart): When implementing dry-run, reconsider alternatives to return
@@ -301,19 +300,11 @@ func (s *BitbucketServerSource) listAllRepos(ctx context.Context, results chan S
 }
 
 func (s *BitbucketServerSource) listAllLabeledRepos(ctx context.Context, label string) (map[int]struct{}, error) {
-	fmt.Printf("Client URL: %+v\n", s.client.URL)
-	fmt.Println("listAllLabeledRepos starting...")
 	ids := map[int]struct{}{}
 	next := &bitbucketserver.PageToken{Limit: 1000}
 	for next.HasMore() {
-		fmt.Println("Starting LabeledRepos")
-		fmt.Println("Label:", label)
-		fmt.Printf("Next: %+v\n", next)
 		repos, page, err := s.client.LabeledRepos(ctx, next, label)
-		fmt.Println("repos:", repos)
 		fmt.Println("Done with LabeledRepos")
-		fmt.Println("next:", next)
-		fmt.Println("page:", page)
 		if page == nil {
 			break
 		}

--- a/internal/repos/bitbucketserver.go
+++ b/internal/repos/bitbucketserver.go
@@ -113,7 +113,7 @@ func (s BitbucketServerSource) WithAuthenticator(a auth.Authenticator) (Source, 
 
 // ExternalServices returns a singleton slice containing the external service.
 func (s BitbucketServerSource) ExternalServices() types.ExternalServices {
-    fmt.Println("Hi")
+	fmt.Println("Hi")
 	return types.ExternalServices{s.svc}
 }
 
@@ -306,7 +306,7 @@ func (s *BitbucketServerSource) listAllLabeledRepos(ctx context.Context, label s
 	next := &bitbucketserver.PageToken{Limit: 1000}
 	for next.HasMore() {
 		fmt.Println("Starting LabeledRepos")
-		fmt.Println(label)
+		fmt.Println("Label:", label)
 		fmt.Printf("%+v\n", next)
 		repos, page, err := s.client.LabeledRepos(ctx, next, label)
 		fmt.Println("Done with LabeledRepos")

--- a/internal/repos/bitbucketserver.go
+++ b/internal/repos/bitbucketserver.go
@@ -249,6 +249,7 @@ func (s *BitbucketServerSource) listAllRepos(ctx context.Context, results chan S
 
 	fmt.Println("Starting queries...")
 	for _, q := range s.config.RepositoryQuery {
+		fmt.Println("QUERY:", q)
 		switch q {
 		case "none":
 			continue
@@ -300,16 +301,22 @@ func (s *BitbucketServerSource) listAllRepos(ctx context.Context, results chan S
 }
 
 func (s *BitbucketServerSource) listAllLabeledRepos(ctx context.Context, label string) (map[int]struct{}, error) {
-	fmt.Printf("%+v\n", s.client.URL)
+	fmt.Printf("Client URL: %+v\n", s.client.URL)
 	fmt.Println("listAllLabeledRepos starting...")
 	ids := map[int]struct{}{}
 	next := &bitbucketserver.PageToken{Limit: 1000}
 	for next.HasMore() {
 		fmt.Println("Starting LabeledRepos")
 		fmt.Println("Label:", label)
-		fmt.Printf("%+v\n", next)
+		fmt.Printf("Next: %+v\n", next)
 		repos, page, err := s.client.LabeledRepos(ctx, next, label)
+		fmt.Println("repos:", repos)
 		fmt.Println("Done with LabeledRepos")
+		fmt.Println("next:", next)
+		fmt.Println("page:", page)
+		if page == nil {
+			break
+		}
 		if err != nil {
 			// If the instance doesn't have the label then no repos are
 			// labeled. Older versions of bitbucket do not support labels, so

--- a/internal/repos/bitbucketserver_test.go
+++ b/internal/repos/bitbucketserver_test.go
@@ -224,7 +224,126 @@ func TestBitbucketServerSource_WithAuthenticator(t *testing.T) {
 	})
 }
 
-func TestListRepos(t *testing.T) {
+func TestBitbucketServerSource_ListRepos(t *testing.T) {
+	TestBitbucketServerSource_ListByReposOnly(t)
+	TestBitbucketServerSource_ListByRepositoryQuery(t)
+	TestBitbucketServerSource_ListByProjectKey(t)
+}
+
+func TestBitbucketServerSource_ListByReposOnly(t *testing.T) {
+	fmt.Println("Listing config repos")
+	b, err := os.ReadFile(filepath.Join("testdata", "bitbucketserver-repos.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var repos []bitbucketserver.Repo
+	if err := json.Unmarshal(b, &repos); err != nil {
+		t.Fatal(err)
+	}
+
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/rest/api/1.0/projects/", func(w http.ResponseWriter, r *http.Request) {
+		pathArr := strings.Split(r.URL.Path, "/")
+		projectKey := pathArr[5]
+		repoSlug := pathArr[7]
+
+		for _, repo := range repos {
+			if repo.Project.Key == projectKey && repo.Slug == repoSlug {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				json.NewEncoder(w).Encode(repo)
+			}
+		}
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	cases := map[string]*schema.BitbucketServerConnection{
+		"simple": {
+			Url:   server.URL,
+			Token: "secret",
+		},
+		"ssh": {
+			Url:                         server.URL,
+			Token:                       "secret",
+			InitialRepositoryEnablement: true,
+			GitURLType:                  "ssh",
+		},
+		"path-pattern": {
+			Url:                   server.URL,
+			Token:                 "secret",
+			RepositoryPathPattern: "bb/{projectKey}/{repositorySlug}",
+		},
+		"username": {
+			Url:                   server.URL,
+			Username:              "foo",
+			Token:                 "secret",
+			RepositoryPathPattern: "bb/{projectKey}/{repositorySlug}",
+		},
+	}
+
+	svc := types.ExternalService{ID: 1, Kind: extsvc.KindBitbucketServer}
+
+	for name, config := range cases {
+		fmt.Println("Name:", name)
+
+		s, err := newBitbucketServerSource(&svc, config, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		s.config.Repos = []string{
+			"SG/go-langserver",
+			"SG/python-langserver",
+			"SG/python-langserver-fork",
+			"~KEEGAN/rgp",
+			"~KEEGAN/rgp-unavailable",
+		}
+
+		ctxWithTimeout, cancelFunction := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancelFunction()
+
+		results := make(chan SourceResult, 10)
+		defer close(results)
+
+		s.ListRepos(ctxWithTimeout, results)
+
+		repoNameMap := map[string]struct{}{
+			"SG/go-langserver":          {},
+			"SG/python-langserver":      {},
+			"SG/python-langserver-fork": {},
+			"~KEEGAN/rgp":               {},
+			"~KEEGAN/rgp-unavailable":   {},
+		}
+
+	verify:
+		for {
+			select {
+			case res := <-results:
+				repoNameArr := strings.Split(string(res.Repo.Name), "/")
+				repoName := repoNameArr[1] + "/" + repoNameArr[2]
+				fmt.Print("Repo:", repoName, ", ")
+				if _, ok := repoNameMap[repoName]; ok {
+					fmt.Println("verified")
+				} else {
+					t.Fatal(err)
+				}
+			case <-ctxWithTimeout.Done():
+				fmt.Println("Timeout")
+				t.Fatal(err)
+			default:
+				break verify
+			}
+		}
+	}
+
+}
+
+func TestBitbucketServerSource_ListByRepositoryQuery(t *testing.T) {
+	fmt.Println("Listing repos by repository query")
 	b, err := os.ReadFile(filepath.Join("testdata", "bitbucketserver-repos.json"))
 	if err != nil {
 		t.Fatal(err)
@@ -248,30 +367,24 @@ func TestListRepos(t *testing.T) {
 		NextPageStart: 1,
 	}
 
-	sendToWriter := func(w http.ResponseWriter, values any) {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		json.NewEncoder(w).Encode(values)
-	}
-
 	mux := http.NewServeMux()
-
-	mux.HandleFunc("/rest/api/1.0/labels/archived/labeled", func(w http.ResponseWriter, r *http.Request) {
-		// fmt.Println("LABELED ENDPOINT HIT")
-	})
 
 	mux.HandleFunc("/rest/api/1.0/repos", func(w http.ResponseWriter, r *http.Request) {
 		projectName := r.URL.Query().Get("projectName")
 
 		if projectName == "" {
-			sendToWriter(w, Results{
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(Results{
 				PageToken: &pageToken,
 				Values:    repos,
 			})
 		} else {
 			for _, repo := range repos {
 				if projectName == repo.Name {
-					sendToWriter(w, Results{
+					w.Header().Set("Content-Type", "application/json")
+					w.WriteHeader(http.StatusOK)
+					json.NewEncoder(w).Encode(Results{
 						PageToken: &pageToken,
 						Values:    []bitbucketserver.Repo{repo},
 					})
@@ -280,133 +393,214 @@ func TestListRepos(t *testing.T) {
 		}
 	})
 
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	cases := map[string]*schema.BitbucketServerConnection{
+		"simple": {
+			Url:   server.URL,
+			Token: "secret",
+		},
+		"ssh": {
+			Url:                         server.URL,
+			Token:                       "secret",
+			InitialRepositoryEnablement: true,
+			GitURLType:                  "ssh",
+		},
+		"path-pattern": {
+			Url:                   server.URL,
+			Token:                 "secret",
+			RepositoryPathPattern: "bb/{projectKey}/{repositorySlug}",
+		},
+		"username": {
+			Url:                   server.URL,
+			Username:              "foo",
+			Token:                 "secret",
+			RepositoryPathPattern: "bb/{projectKey}/{repositorySlug}",
+		},
+	}
+
+	svc := types.ExternalService{ID: 1, Kind: extsvc.KindBitbucketServer}
+
+	for name, config := range cases {
+		fmt.Println("Name:", name)
+
+		s, err := newBitbucketServerSource(&svc, config, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		s.config.RepositoryQuery = []string{
+			"?projectName=go-langserver",
+			"?projectName=python-langserver",
+			"?projectName=python-langserver-fork",
+			"?projectName=rgp",
+			"?projectName=rgp-unavailable",
+			"none",
+			"all",
+		}
+
+		ctxWithTimeout, cancelFunction := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancelFunction()
+
+		results := make(chan SourceResult, 20)
+		defer close(results)
+
+		s.ListRepos(ctxWithTimeout, results)
+
+		repoNameMap := map[string]struct{}{
+			"SG/go-langserver":          {},
+			"SG/python-langserver":      {},
+			"SG/python-langserver-fork": {},
+			"~KEEGAN/rgp":               {},
+			"~KEEGAN/rgp-unavailable":   {},
+		}
+
+	verify:
+		for {
+			select {
+			case res := <-results:
+				repoNameArr := strings.Split(string(res.Repo.Name), "/")
+				repoName := repoNameArr[1] + "/" + repoNameArr[2]
+				fmt.Print("Repo:", repoName, ", ")
+				if _, ok := repoNameMap[repoName]; ok {
+					fmt.Println("verified")
+				} else {
+					t.Fatal(err)
+				}
+			case <-ctxWithTimeout.Done():
+				fmt.Println("Timeout")
+				t.Fatal(err)
+			default:
+				break verify
+			}
+		}
+	}
+
+}
+func TestBitbucketServerSource_ListByProjectKey(t *testing.T) {
+	fmt.Println("Listing repos by project key")
+	b, err := os.ReadFile(filepath.Join("testdata", "bitbucketserver-repos.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var repos []bitbucketserver.Repo
+	if err := json.Unmarshal(b, &repos); err != nil {
+		t.Fatal(err)
+	}
+
+	type Results struct {
+		*bitbucketserver.PageToken `json:"pageToken"`
+		Values                     any `json:"values"`
+	}
+
+	pageToken := bitbucketserver.PageToken{
+		Size:          1,
+		Limit:         1000,
+		IsLastPage:    true,
+		Start:         1,
+		NextPageStart: 1,
+	}
+
+	mux := http.NewServeMux()
+
 	mux.HandleFunc("/rest/api/1.0/projects/", func(w http.ResponseWriter, r *http.Request) {
 		pathArr := strings.Split(r.URL.Path, "/")
 		projectKey := pathArr[5]
+		values := make([]bitbucketserver.Repo, 0)
 
-		if len(pathArr) <= 7 {
-			var values []bitbucketserver.Repo
-			for _, repo := range repos {
-				if repo.Project.Key == projectKey {
-					values = append(values, repo)
-				}
-			}
-			sendToWriter(w, Results{
-				PageToken: &pageToken,
-				Values:    values,
-			})
-		} else {
-			repoSlug := pathArr[7]
-			for _, repo := range repos {
-				if repo.Project.Key == projectKey && repo.Slug == repoSlug {
-					sendToWriter(w, repo)
-				}
+		for _, repo := range repos {
+			if repo.Project.Key == projectKey {
+				values = append(values, repo)
 			}
 		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(Results{
+			PageToken: &pageToken,
+			Values:    values,
+		})
+
 	})
 
 	server := httptest.NewServer(mux)
 	defer server.Close()
 
-	simpleConfig := &schema.BitbucketServerConnection{
-		Url:   server.URL,
-		Token: "secret",
+	cases := map[string]*schema.BitbucketServerConnection{
+		"simple": {
+			Url:   server.URL,
+			Token: "secret",
+		},
+		"ssh": {
+			Url:                         server.URL,
+			Token:                       "secret",
+			InitialRepositoryEnablement: true,
+			GitURLType:                  "ssh",
+		},
+		"path-pattern": {
+			Url:                   server.URL,
+			Token:                 "secret",
+			RepositoryPathPattern: "bb/{projectKey}/{repositorySlug}",
+		},
+		"username": {
+			Url:                   server.URL,
+			Username:              "foo",
+			Token:                 "secret",
+			RepositoryPathPattern: "bb/{projectKey}/{repositorySlug}",
+		},
 	}
 
-	svc := types.ExternalService{
-		ID:   1,
-		Kind: extsvc.KindBitbucketServer,
-	}
+	svc := types.ExternalService{ID: 1, Kind: extsvc.KindBitbucketServer}
 
-	s, err := newBitbucketServerSource(&svc, simpleConfig, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	for name, config := range cases {
+		fmt.Println("Name:", name)
 
-	s.config.Repos = []string{
-		"SG/go-langserver",
-		"SG/python-langserver",
-		"SG/python-langserver-fork",
-		"~KEEGAN/rgp",
-		"~KEEGAN/rgp-unavailable",
-	}
-
-	s.config.RepositoryQuery = []string{
-		"?projectName=go-langserver",
-		"?projectName=python-langserver",
-		"?projectName=python-langserver-fork",
-		"?projectName=rgp",
-		"?projectName=rgp-unavailable",
-		"none",
-		"all",
-		"?projectKey=SG",
-		"?projectKey=~KEEGAN",
-	}
-
-	ctxWithTimeout, cancelFunction := context.WithTimeout(context.Background(), 5*time.Second)
-	fmt.Println(cancelFunction)
-
-	results := make(chan SourceResult, 20)
-	defer close(results)
-
-	s.ListRepos(ctxWithTimeout, results)
-
-	// go func() {
-	// 	fmt.Println("Printing", len(results), "results...")
-	// 	for res := range results {
-	// 		fmt.Printf("%+v\n", (res.Repo))
-	// 	}
-	// }()
-
-	repoNameMap := map[string]struct{}{
-		"SG/go-langserver":          {},
-		"SG/python-langserver":      {},
-		"SG/python-langserver-fork": {},
-		"~KEEGAN/rgp":               {},
-		"~KEEGAN/rgp-unavailable":   {},
-	}
-
-	for {
-		select {
-		case res := <-results:
-			repoNameArr := strings.Split(string(res.Repo.Name), "/")
-			repoName := repoNameArr[1] + "/" + repoNameArr[2]
-			fmt.Println("Repo:", repoName)
-			if _, ok := repoNameMap[repoName]; ok {
-				fmt.Println("Verified")
-			}
-		case <-ctxWithTimeout.Done():
-			fmt.Println("Timeout")
-			cancelFunction()
+		s, err := newBitbucketServerSource(&svc, config, nil)
+		if err != nil {
 			t.Fatal(err)
-		default:
-			return
+		}
+
+		s.config.ProjectKeys = []string{
+			"SG",
+			"~KEEGAN",
+		}
+
+		ctxWithTimeout, cancelFunction := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancelFunction()
+
+		results := make(chan SourceResult, 20)
+		defer close(results)
+
+		s.ListRepos(ctxWithTimeout, results)
+
+		repoNameMap := map[string]struct{}{
+			"SG/go-langserver":          {},
+			"SG/python-langserver":      {},
+			"SG/python-langserver-fork": {},
+			"~KEEGAN/rgp":               {},
+			"~KEEGAN/rgp-unavailable":   {},
+		}
+
+	verify:
+		for {
+			select {
+			case res := <-results:
+				repoNameArr := strings.Split(string(res.Repo.Name), "/")
+				repoName := repoNameArr[1] + "/" + repoNameArr[2]
+				fmt.Print("Repo:", repoName, ", ")
+				if _, ok := repoNameMap[repoName]; ok {
+					fmt.Println("verified")
+				} else {
+					t.Fatal(err)
+				}
+			case <-ctxWithTimeout.Done():
+				fmt.Println("Timeout")
+				t.Fatal(err)
+			default:
+				break verify
+			}
 		}
 	}
 
 }
-
-// func TestListReposv1(t *testing.T) {
-
-// 	fmt.Println("Making results...")
-// 	results := make(chan SourceResult)
-// 	client.s.ListRepos(context.Background(), results)
-
-// 	repoNameMap := map[string]struct{}{
-// 		"python-langserver-fork": {},
-// 		"python-langserver":      {},
-// 		"golang-langserver":      {},
-// 	}
-
-// 	ctx, _ := context.WithTimeout(context.Background(), 5*time.Second)
-
-// 	for i := 0; i < len(repoNameMap); i++ {
-// 		select {
-// 		case r := <-results:
-// 			//verify result is in repoNameMap
-// 		case <-ctx.Done():
-// 			//fail test
-// 			//break
-// 		}
-// 	}
-// }

--- a/internal/repos/bitbucketserver_test.go
+++ b/internal/repos/bitbucketserver_test.go
@@ -339,8 +339,8 @@ func TestListRepos(t *testing.T) {
 		"?projectName=rgp-unavailable",
 		"none",
 		"all",
-		"?projectKey=SG",
-		"?projectKey=~KEEGAN",
+		// "?projectKey=SG",
+		// "?projectKey=~KEEGAN",
 	}
 
 	ctxWithTimeout, cancelFunction := context.WithTimeout(context.Background(), 5*time.Second)

--- a/internal/repos/bitbucketserver_test.go
+++ b/internal/repos/bitbucketserver_test.go
@@ -1,7 +1,9 @@
 package repos
 
 import (
+	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -207,4 +209,36 @@ func TestBitbucketServerSource_WithAuthenticator(t *testing.T) {
 			})
 		}
 	})
+}
+
+func TestListRepos(t *testing.T) {
+	fmt.Println("TestListRepos called...")
+
+	config := map[string]*schema.BitbucketServerConnection{
+		"simple": {
+			Url:   "https://bitbucket.example.com",
+			Token: "secret",
+		},
+	}
+	fmt.Println("Done with config")
+
+	svc := types.ExternalService{ID: 1, Kind: extsvc.KindBitbucketServer}
+	fmt.Println("Done with svc")
+
+	s, err := newBitbucketServerSource(&svc, config["simple"], nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("simple", func(t *testing.T) {
+		results := make(chan SourceResult)
+		fmt.Println("Done making results channel")
+		s.ListRepos(context.Background(), results)
+		fmt.Println("Done ListRepos, printing results")
+
+		r := <-results
+		fmt.Println(r)
+		fmt.Println("Done printing r")
+	})
+
 }

--- a/internal/repos/bitbucketserver_test.go
+++ b/internal/repos/bitbucketserver_test.go
@@ -339,8 +339,8 @@ func TestListRepos(t *testing.T) {
 		"?projectName=rgp-unavailable",
 		"none",
 		"all",
-		// "?projectKey=SG",
-		// "?projectKey=~KEEGAN",
+		"?projectKey=SG",
+		"?projectKey=~KEEGAN",
 	}
 
 	ctxWithTimeout, cancelFunction := context.WithTimeout(context.Background(), 5*time.Second)

--- a/internal/repos/bitbucketserver_test.go
+++ b/internal/repos/bitbucketserver_test.go
@@ -55,13 +55,17 @@ func TestBitbucketServerSource_MakeRepo(t *testing.T) {
 
 	for name, config := range cases {
 		t.Run(name, func(t *testing.T) {
+			fmt.Println("Name:", name)
+			// fmt.Printf("Config: %+v\n", config)
 			s, err := newBitbucketServerSource(&svc, config, nil)
 			if err != nil {
 				t.Fatal(err)
 			}
 
 			var got []*types.Repo
+			fmt.Println("Repos:")
 			for _, r := range repos {
+				fmt.Println("R:", r)
 				got = append(got, s.makeRepo(r, false))
 			}
 
@@ -216,7 +220,7 @@ func TestListRepos(t *testing.T) {
 
 	config := map[string]*schema.BitbucketServerConnection{
 		"simple": {
-			Url:   "https://bitbucket.example.com",
+			Url:   "https:/example.com/",
 			Token: "secret",
 		},
 	}

--- a/internal/repos/bitbucketserver_test.go
+++ b/internal/repos/bitbucketserver_test.go
@@ -355,8 +355,8 @@ func TestBitbucketServerSource_ListByRepositoryQuery(t *testing.T) {
 	}
 
 	type Results struct {
-		*bitbucketserver.PageToken `json:"pageToken"`
-		Values                     any `json:"values"`
+		*bitbucketserver.PageToken
+		Values any `json:"values"`
 	}
 
 	pageToken := bitbucketserver.PageToken{
@@ -491,8 +491,8 @@ func TestBitbucketServerSource_ListByProjectKey(t *testing.T) {
 	}
 
 	type Results struct {
-		*bitbucketserver.PageToken `json:"pageToken"`
-		Values                     any `json:"values"`
+		*bitbucketserver.PageToken
+		Values any `json:"values"`
 	}
 
 	pageToken := bitbucketserver.PageToken{

--- a/schema/bitbucket_server.schema.json
+++ b/schema/bitbucket_server.schema.json
@@ -155,6 +155,13 @@
       },
       "examples": [["myproject/myrepo", "myproject/myotherrepo", "~USER/theirrepo"]]
     },
+    "projectKeys": {
+      "description": "An array of project key strings that defines a collection of repositories related to their associated project keys",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
     "exclude": {
       "description": "A list of repositories to never mirror from this Bitbucket Server / Bitbucket Data Center instance. Takes precedence over \"repos\" and \"repositoryQuery\".\n\nSupports excluding by name ({\"name\": \"projectKey/repositorySlug\"}) or by ID ({\"id\": 42}).",
       "type": "array",

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -267,6 +267,8 @@ type BitbucketServerConnection struct {
 	Password string `json:"password,omitempty"`
 	// Plugin description: Configuration for Bitbucket Server / Bitbucket Data Center Sourcegraph plugin
 	Plugin *BitbucketServerPlugin `json:"plugin,omitempty"`
+	// ProjectKeys description: An array of project key strings that defines a collection of repositories related to their associated project keys
+	ProjectKeys []string `json:"projectKeys,omitempty"`
 	// RateLimit description: Rate limit applied when making background API requests to BitbucketServer.
 	RateLimit *BitbucketServerRateLimit `json:"rateLimit,omitempty"`
 	// Repos description: An array of repository "projectKey/repositorySlug" strings specifying repositories to mirror on Sourcegraph.


### PR DESCRIPTION
Previously Bitbucket clients could only specify repos by projectName. Now, if projectKeys are specified in s.config.ProjectKeys, then those repos would be returned as well.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

go test -run TestBitbucketServerSource_ListRepos \\ to list all repos
go test -run TestBitbucketServerSource_ListByRepos only \\ to list repos in the config
go test -run TestBitbucketServerSource_ListByRepositoryQueryDefault \\ to list repos by projectName
go test -run TestBitbucketServerSource_ListByRepositoryQueryAll \\ using all as the query
go test -run TestBitbucketServerSource_ListByRepositoryQueryNone \\ using none as the query
go test -run TestBitbucketServerSource_ListByProjectKey \\ to list repos by projectKey
