### PR TITLE
[Wildcard Migration] New Tooltip within search-ui

### DIFF
--- a/client/search-ui/src/components/CodeHostIcon.tsx
+++ b/client/search-ui/src/components/CodeHostIcon.tsx
@@ -5,7 +5,7 @@ import BitbucketIcon from 'mdi-react/BitbucketIcon'
 import GithubIcon from 'mdi-react/GithubIcon'
 import GitlabIcon from 'mdi-react/GitlabIcon'
 
-import { Icon } from '@sourcegraph/wildcard'
+import { Icon, Tooltip } from '@sourcegraph/wildcard'
 
 /**
  * Returns the icon for the repository's code host
@@ -24,7 +24,11 @@ export const CodeHostIcon: React.FunctionComponent<
     const CodehostIcon: React.ComponentType<React.PropsWithChildren<MdiReactIconProps>> | undefined = iconMap[hostName]
 
     if (CodehostIcon) {
-        return <Icon role="img" aria-label={hostName} data-tooltip={hostName} className={className} as={CodehostIcon} />
+        return (
+            <Tooltip content={hostName}>
+                <Icon role="img" aria-label={hostName} className={className} as={CodehostIcon} />
+            </Tooltip>
+        )
     }
 
     return null

--- a/client/search-ui/src/components/CommitSearchResult.tsx
+++ b/client/search-ui/src/components/CommitSearchResult.tsx
@@ -7,7 +7,7 @@ import { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
 import { CommitMatch, getCommitMatchUrl, getRepositoryUrl } from '@sourcegraph/shared/src/search/stream'
 // eslint-disable-next-line no-restricted-imports
 import { Timestamp } from '@sourcegraph/web/src/components/time/Timestamp'
-import { Link, Code, useIsTruncated } from '@sourcegraph/wildcard'
+import { Link, Code, useIsTruncated, Tooltip } from '@sourcegraph/wildcard'
 
 import { CommitSearchResultMatch } from './CommitSearchResultMatch'
 import { ResultContainer } from './ResultContainer'
@@ -38,20 +38,21 @@ export const CommitSearchResult: React.FunctionComponent<Props> = ({
 
     const renderTitle = (): JSX.Element => (
         <div className={styles.title}>
-            <span
-                onMouseEnter={checkTruncation}
-                className="test-search-result-label ml-1 flex-shrink-past-contents text-truncate"
-                ref={titleReference}
-                data-tooltip={(truncated && `${result.authorName}: ${result.message.split('\n', 1)[0]}`) || null}
-            >
-                <>
-                    <Link to={getRepositoryUrl(result.repository)}>{displayRepoName(result.repository)}</Link>
-                    {' › '}
-                    <Link to={getCommitMatchUrl(result)}>{result.authorName}</Link>
-                    {': '}
-                    <Link to={getCommitMatchUrl(result)}>{result.message.split('\n', 1)[0]}</Link>
-                </>
-            </span>
+            <Tooltip content={(truncated && `${result.authorName}: ${result.message.split('\n', 1)[0]}`) || null}>
+                <span
+                    onMouseEnter={checkTruncation}
+                    className="test-search-result-label ml-1 flex-shrink-past-contents text-truncate"
+                    ref={titleReference}
+                >
+                    <>
+                        <Link to={getRepositoryUrl(result.repository)}>{displayRepoName(result.repository)}</Link>
+                        {' › '}
+                        <Link to={getCommitMatchUrl(result)}>{result.authorName}</Link>
+                        {': '}
+                        <Link to={getCommitMatchUrl(result)}>{result.message.split('\n', 1)[0]}</Link>
+                    </>
+                </span>
+            </Tooltip>
             <span className={styles.spacer} />
             <Link to={getCommitMatchUrl(result)}>
                 <Code className={styles.commitOid}>{result.oid.slice(0, 7)}</Code>{' '}

--- a/client/search-ui/src/components/LastSyncedIcon.tsx
+++ b/client/search-ui/src/components/LastSyncedIcon.tsx
@@ -4,7 +4,7 @@ import classNames from 'classnames'
 import format from 'date-fns/format'
 import WeatherCloudyClockIcon from 'mdi-react/WeatherCloudyClockIcon'
 
-import { Icon } from '@sourcegraph/wildcard'
+import { Icon, Tooltip } from '@sourcegraph/wildcard'
 
 import styles from './LastSyncedIcon.module.scss'
 
@@ -17,13 +17,14 @@ export const LastSyncedIcon: React.FunctionComponent<React.PropsWithChildren<Pro
     const formattedTime = format(Date.parse(props.lastSyncedTime), "yyyy-MM-dd'T'HH:mm:ss")
 
     return (
-        <Icon
-            role="img"
-            tabIndex={0}
-            className={classNames(props.className, styles.lastSyncedIcon, 'text-muted')}
-            data-tooltip={`Last synced: ${formattedTime}`}
-            as={WeatherCloudyClockIcon}
-            aria-label={`Last synced: ${formattedTime}`}
-        />
+        <Tooltip content={`Last synced: ${formattedTime}`}>
+            <Icon
+                role="img"
+                tabIndex={0}
+                className={classNames(props.className, styles.lastSyncedIcon, 'text-muted')}
+                as={WeatherCloudyClockIcon}
+                aria-label={`Last synced: ${formattedTime}`}
+            />
+        </Tooltip>
     )
 }

--- a/client/search-ui/src/components/RepoFileLink.tsx
+++ b/client/search-ui/src/components/RepoFileLink.tsx
@@ -4,7 +4,7 @@ import classNames from 'classnames'
 
 import { appendSubtreeQueryParameter } from '@sourcegraph/common'
 import { displayRepoName, splitPath } from '@sourcegraph/shared/src/components/RepoLink'
-import { useIsTruncated, Link } from '@sourcegraph/wildcard'
+import { useIsTruncated, Link, Tooltip } from '@sourcegraph/wildcard'
 
 interface Props {
     repoName: string
@@ -36,17 +36,14 @@ export const RepoFileLink: React.FunctionComponent<React.PropsWithChildren<Props
     const [titleReference, truncated, checkTruncation] = useIsTruncated()
 
     return (
-        <div
-            ref={titleReference}
-            onMouseEnter={checkTruncation}
-            className={classNames(className)}
-            data-tooltip={truncated ? (fileBase ? `${fileBase}/${fileName}` : fileName) : null}
-        >
-            <Link to={repoURL}>{repoDisplayName || displayRepoName(repoName)}</Link> ›{' '}
-            <Link to={appendSubtreeQueryParameter(fileURL)}>
-                {fileBase ? `${fileBase}/` : null}
-                <strong>{fileName}</strong>
-            </Link>
-        </div>
+        <Tooltip content={truncated ? (fileBase ? `${fileBase}/${fileName}` : fileName) : null}>
+            <div ref={titleReference} onMouseEnter={checkTruncation} className={classNames(className)}>
+                <Link to={repoURL}>{repoDisplayName || displayRepoName(repoName)}</Link> ›{' '}
+                <Link to={appendSubtreeQueryParameter(fileURL)}>
+                    {fileBase ? `${fileBase}/` : null}
+                    <strong>{fileName}</strong>
+                </Link>
+            </div>
+        </Tooltip>
     )
 }

--- a/client/search-ui/src/components/RepoSearchResult.tsx
+++ b/client/search-ui/src/components/RepoSearchResult.tsx
@@ -8,7 +8,7 @@ import SourceRepositoryIcon from 'mdi-react/SourceRepositoryIcon'
 
 import { displayRepoName } from '@sourcegraph/shared/src/components/RepoLink'
 import { getRepoMatchLabel, getRepoMatchUrl, RepositoryMatch } from '@sourcegraph/shared/src/search/stream'
-import { Icon, Link, useIsTruncated } from '@sourcegraph/wildcard'
+import { Icon, Link, Tooltip, useIsTruncated } from '@sourcegraph/wildcard'
 
 import { LastSyncedIcon } from './LastSyncedIcon'
 import { ResultContainer } from './ResultContainer'
@@ -35,14 +35,15 @@ export const RepoSearchResult: React.FunctionComponent<RepoSearchResultProps> = 
 
     const renderTitle = (): JSX.Element => (
         <div className={styles.title}>
-            <span
-                onMouseEnter={checkTruncation}
-                className="test-search-result-label ml-1 flex-shrink-past-contents text-truncate"
-                ref={titleReference}
-                data-tooltip={(truncated && displayRepoName(getRepoMatchLabel(result))) || null}
-            >
-                <Link to={getRepoMatchUrl(result)}>{displayRepoName(getRepoMatchLabel(result))}</Link>
-            </span>
+            <Tooltip content={(truncated && displayRepoName(getRepoMatchLabel(result))) || null}>
+                <span
+                    onMouseEnter={checkTruncation}
+                    className="test-search-result-label ml-1 flex-shrink-past-contents text-truncate"
+                    ref={titleReference}
+                >
+                    <Link to={getRepoMatchUrl(result)}>{displayRepoName(getRepoMatchLabel(result))}</Link>
+                </span>
+            </Tooltip>
         </div>
     )
 

--- a/client/search-ui/src/input/SearchContextDropdown.test.tsx
+++ b/client/search-ui/src/input/SearchContextDropdown.test.tsx
@@ -75,19 +75,16 @@ describe('SearchContextDropdown', () => {
     it('should be enabled if query is empty', () => {
         render(<SearchContextDropdown {...defaultProps} />)
         expect(screen.getByTestId('dropdown-toggle')).toBeEnabled()
-        expect(screen.getByTestId('dropdown-toggle')).toHaveAttribute('data-tooltip', '')
     })
 
     it('should be enabled if query does not contain context filter', () => {
         render(<SearchContextDropdown {...defaultProps} query="test (repo:foo or repo:python)" />)
         expect(screen.getByTestId('dropdown-toggle')).toBeEnabled()
-        expect(screen.getByTestId('dropdown-toggle')).toHaveAttribute('data-tooltip', '')
     })
 
     it('should be disabled if query contains context filter', () => {
         render(<SearchContextDropdown {...defaultProps} query="test (context:foo or repo:python)" />)
         expect(screen.getByTestId('dropdown-toggle')).toBeDisabled()
-        expect(screen.getByTestId('dropdown-toggle')).toHaveAttribute('data-tooltip', 'Overridden by query')
     })
 
     it('should submit search on item click', () => {

--- a/client/search-ui/src/input/SearchContextDropdown.tsx
+++ b/client/search-ui/src/input/SearchContextDropdown.tsx
@@ -11,7 +11,7 @@ import { FilterType } from '@sourcegraph/shared/src/search/query/filters'
 import { filterExists } from '@sourcegraph/shared/src/search/query/validate'
 import { useTemporarySetting } from '@sourcegraph/shared/src/settings/temporary/useTemporarySetting'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
-import { Code } from '@sourcegraph/wildcard'
+import { Code, Tooltip } from '@sourcegraph/wildcard'
 
 import { SearchContextCtaPrompt } from './SearchContextCtaPrompt'
 import { SearchContextMenu } from './SearchContextMenu'
@@ -63,7 +63,7 @@ export const SearchContextDropdown: React.FunctionComponent<
 
     const isContextFilterInQuery = useMemo(() => filterExists(query, FilterType.context), [query])
 
-    const disabledTooltipText = isContextFilterInQuery ? 'Overridden by query' : ''
+    const disabledTooltipText = isContextFilterInQuery ? 'Overridden by query' : null
 
     const selectSearchContextSpec = useCallback(
         (spec: string): void => {
@@ -115,36 +115,37 @@ export const SearchContextDropdown: React.FunctionComponent<
             a11y={false} /* Override default keyboard events in reactstrap */
             className={className}
         >
-            <DropdownToggle
-                className={classNames(
-                    styles.button,
-                    'dropdown-toggle',
-                    'test-search-context-dropdown',
-                    isOpen && styles.buttonOpen
-                )}
-                data-testid="dropdown-toggle"
-                color="link"
-                disabled={isContextFilterInQuery}
-                data-tooltip={disabledTooltipText}
-            >
-                <Code className={classNames('test-selected-search-context-spec', styles.buttonContent)}>
-                    {
-                        // a11y-ignore
-                        // Rule: "color-contrast" (Elements must have sufficient color contrast)
-                        // GitHub issue: https://github.com/sourcegraph/sourcegraph/issues/33343
-                    }
-                    <span className="a11y-ignore search-filter-keyword">context</span>
-                    <span className="search-filter-separator">:</span>
-                    {selectedSearchContextSpec?.startsWith('@') ? (
-                        <>
-                            <span className="search-keyword">@</span>
-                            {selectedSearchContextSpec?.slice(1)}
-                        </>
-                    ) : (
-                        selectedSearchContextSpec
+            <Tooltip content={disabledTooltipText}>
+                <DropdownToggle
+                    className={classNames(
+                        styles.button,
+                        'dropdown-toggle',
+                        'test-search-context-dropdown',
+                        isOpen && styles.buttonOpen
                     )}
-                </Code>
-            </DropdownToggle>
+                    data-testid="dropdown-toggle"
+                    color="link"
+                    disabled={isContextFilterInQuery}
+                >
+                    <Code className={classNames('test-selected-search-context-spec', styles.buttonContent)}>
+                        {
+                            // a11y-ignore
+                            // Rule: "color-contrast" (Elements must have sufficient color contrast)
+                            // GitHub issue: https://github.com/sourcegraph/sourcegraph/issues/33343
+                        }
+                        <span className="a11y-ignore search-filter-keyword">context</span>
+                        <span className="search-filter-separator">:</span>
+                        {selectedSearchContextSpec?.startsWith('@') ? (
+                            <>
+                                <span className="search-keyword">@</span>
+                                {selectedSearchContextSpec?.slice(1)}
+                            </>
+                        ) : (
+                            selectedSearchContextSpec
+                        )}
+                    </Code>
+                </DropdownToggle>
+            </Tooltip>
             {/*
                a11y-ignore
                Rule: "aria-required-children" (Certain ARIA roles must contain particular children)

--- a/client/search-ui/src/input/toggles/CopyQueryButton.tsx
+++ b/client/search-ui/src/input/toggles/CopyQueryButton.tsx
@@ -8,7 +8,7 @@ import { Observable, merge, of } from 'rxjs'
 import { tap, switchMapTo, startWith, delay } from 'rxjs/operators'
 
 import { KeyboardShortcut } from '@sourcegraph/shared/src/keyboardShortcuts'
-import { Button, Icon, DeprecatedTooltipController, useEventObservable } from '@sourcegraph/wildcard'
+import { Button, Icon, DeprecatedTooltipController, useEventObservable, Tooltip } from '@sourcegraph/wildcard'
 
 interface Props {
     fullQuery: string
@@ -45,12 +45,11 @@ export const CopyQueryButton: React.FunctionComponent<React.PropsWithChildren<Pr
 
     const copyFullQueryTooltip = `Copy full query\n${props.isMacPlatform ? '⌘' : 'Ctrl'}+⇧+C`
     return (
-        <>
+        <Tooltip content={copied ? 'Copied!' : copyFullQueryTooltip}>
             <Button
                 className={classNames('btn-icon', props.className)}
                 variant="icon"
                 size="sm"
-                data-tooltip={copied ? 'Copied!' : copyFullQueryTooltip}
                 aria-label={copied ? 'Copied!' : copyFullQueryTooltip}
                 aria-live="polite"
                 onClick={nextClick}
@@ -60,6 +59,6 @@ export const CopyQueryButton: React.FunctionComponent<React.PropsWithChildren<Pr
             {props.keyboardShortcutForFullCopy.keybindings.map((keybinding, index) => (
                 <Shortcut key={index} {...keybinding} onMatch={copyFullQuery} allowDefault={false} ignoreInput={true} />
             ))}
-        </>
+        </Tooltip>
     )
 }

--- a/client/search-ui/src/input/toggles/QueryInputToggle.tsx
+++ b/client/search-ui/src/input/toggles/QueryInputToggle.tsx
@@ -5,7 +5,7 @@ import { fromEvent } from 'rxjs'
 import { filter } from 'rxjs/operators'
 import { Key } from 'ts-key-enum'
 
-import { Button, Icon } from '@sourcegraph/wildcard'
+import { Button, Icon, Tooltip } from '@sourcegraph/wildcard'
 
 import styles from './Toggles.module.scss'
 
@@ -76,31 +76,32 @@ export const QueryInputToggle: React.FunctionComponent<React.PropsWithChildren<T
         ? {
               tabIndex: 0,
               'aria-label': `${props.title} toggle`,
-              'data-tooltip': tooltipValue,
               onClick: onCheckboxToggled,
           }
-        : { tabIndex: -1, 'aria-hidden': true, 'data-tooltip': tooltipValue }
+        : { tabIndex: -1, 'aria-hidden': true }
 
     return (
         // Click events here are defined in useEffect
-        <Button
-            as="div"
-            ref={toggleCheckbox}
-            className={classNames(
-                styles.toggle,
-                props.className,
-                !!disabledRule && styles.disabled,
-                isActive && styles.toggleActive,
-                !interactive && styles.toggleNonInteractive,
-                props.activeClassName
-            )}
-            role="checkbox"
-            variant="icon"
-            aria-disabled={!!disabledRule}
-            aria-checked={isActive}
-            {...interactiveProps}
-        >
-            <Icon role="img" aria-hidden={true} as={props.icon} />
-        </Button>
+        <Tooltip content={tooltipValue}>
+            <Button
+                as="div"
+                ref={toggleCheckbox}
+                className={classNames(
+                    styles.toggle,
+                    props.className,
+                    !!disabledRule && styles.disabled,
+                    isActive && styles.toggleActive,
+                    !interactive && styles.toggleNonInteractive,
+                    props.activeClassName
+                )}
+                role="checkbox"
+                variant="icon"
+                aria-disabled={!!disabledRule}
+                aria-checked={isActive}
+                {...interactiveProps}
+            >
+                <Icon role="img" aria-hidden={true} as={props.icon} />
+            </Button>
+        </Tooltip>
     )
 }

--- a/client/search-ui/src/results/progress/StreamingProgressCount.tsx
+++ b/client/search-ui/src/results/progress/StreamingProgressCount.tsx
@@ -6,7 +6,7 @@ import InformationOutlineIcon from 'mdi-react/InformationOutlineIcon'
 
 import { pluralize } from '@sourcegraph/common'
 import { Progress } from '@sourcegraph/shared/src/search/stream'
-import { Link, Icon } from '@sourcegraph/wildcard'
+import { Link, Icon, Tooltip } from '@sourcegraph/wildcard'
 
 import { StreamingProgressProps } from './StreamingProgress'
 
@@ -44,22 +44,25 @@ export const StreamingProgressCount: React.FunctionComponent<
             {limitHit(progress) ? '+' : ''} {pluralize('result', progress.matchCount)} in{' '}
             {(progress.durationMs / 1000).toFixed(2)}s
             {progress.repositoriesCount !== undefined && (
-                <Icon
-                    role="img"
-                    className="ml-1"
-                    data-tooltip={`From ${abbreviateNumber(progress.repositoriesCount)} ${pluralize(
+                <Tooltip
+                    content={`From ${abbreviateNumber(progress.repositoriesCount)} ${pluralize(
                         'repository',
                         progress.repositoriesCount,
                         'repositories'
                     )}`}
-                    as={InformationOutlineIcon}
-                    tabIndex={0}
-                    aria-label={`From ${abbreviateNumber(progress.repositoriesCount)} ${pluralize(
-                        'repository',
-                        progress.repositoriesCount,
-                        'repositories'
-                    )}`}
-                />
+                >
+                    <Icon
+                        role="img"
+                        className="ml-1"
+                        as={InformationOutlineIcon}
+                        tabIndex={0}
+                        aria-label={`From ${abbreviateNumber(progress.repositoriesCount)} ${pluralize(
+                            'repository',
+                            progress.repositoriesCount,
+                            'repositories'
+                        )}`}
+                    />
+                </Tooltip>
             )}
         </small>
         {showTrace && progress.trace && (

--- a/client/search-ui/src/results/sidebar/QuickLink.tsx
+++ b/client/search-ui/src/results/sidebar/QuickLink.tsx
@@ -4,7 +4,7 @@ import LinkIcon from 'mdi-react/LinkIcon'
 
 import { Settings } from '@sourcegraph/shared/src/schema/settings.schema'
 import { isSettingsValid, SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
-import { Link, Icon } from '@sourcegraph/wildcard'
+import { Link, Icon, Tooltip } from '@sourcegraph/wildcard'
 
 import styles from './SearchSidebarSection.module.scss'
 
@@ -12,18 +12,18 @@ export const getQuickLinks = (settingsCascade: SettingsCascadeProps['settingsCas
     const quickLinks = (isSettingsValid<Settings>(settingsCascade) && settingsCascade.final.quicklinks) || []
 
     return quickLinks.map((quickLink, index) => (
-        <Link
+        <Tooltip
             // Can't guarantee that URL, name, or description are unique, so use index as key.
             // This is safe since this list will only be updated when settings change.
             // eslint-disable-next-line react/no-array-index-key
             key={index}
-            to={quickLink.url}
-            data-tooltip={quickLink.description}
-            data-placement="right"
-            className={styles.sidebarSectionListItem}
+            content={quickLink.description ?? null}
+            placement="right"
         >
-            <Icon role="img" aria-hidden={true} className="pr-1 flex-shrink-0" as={LinkIcon} />
-            {quickLink.name}
-        </Link>
+            <Link to={quickLink.url} className={styles.sidebarSectionListItem}>
+                <Icon role="img" aria-hidden={true} className="pr-1 flex-shrink-0" as={LinkIcon} />
+                {quickLink.name}
+            </Link>
+        </Tooltip>
     ))
 }


### PR DESCRIPTION
Migrates uses of `data-tooltip` to the new Wildcard `<Tooltip>` component within the `client/search-ui` directory.

## Test plan

Visual confirmation that replacements still look and behave correctly.
