### PR TITLE
squirrel: adding functionality to use tree-sitter for csharp navigation 

### DIFF
--- a/cmd/symbols/squirrel/lang_csharp.go
+++ b/cmd/symbols/squirrel/lang_csharp.go
@@ -1,0 +1,651 @@
+package squirrel
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+
+	"github.com/sourcegraph/sourcegraph/internal/types"
+)
+
+func (squirrel *SquirrelService) getDefCsharp(ctx context.Context, node Node) (ret *Node, err error) {
+	defer squirrel.onCall(node, String(node.Type()), lazyNodeStringer(&ret))()
+
+	switch node.Type() {
+	case "identifier":
+		ident := node.Content(node.Contents)
+
+		cur := node.Node
+
+	outer:
+		for {
+			prev := cur
+			cur = cur.Parent()
+			if cur == nil {
+				squirrel.breadcrumb(node, "getDefCsharp: ran out of parents")
+				return nil, nil
+			}
+
+			switch cur.Type() {
+
+			case "program":
+				return squirrel.getDefInImportsOrCurrentPackageCsharp(ctx, swapNode(node, cur), ident)
+
+			case "import_declaration":
+				program := cur.Parent()
+				if program == nil {
+					squirrel.breadcrumb(node, "getDefCsharp: expected parent for import_declaration")
+					return nil, nil
+				}
+				if program.Type() != "program" {
+					squirrel.breadcrumb(node, "getDefCsharp: expected parent of import_declaration to be program")
+				}
+				root, err := getProjectRoot(swapNode(node, program))
+				if err != nil {
+					return nil, err
+				}
+				allComponents, err := getPath(swapNode(node, cur))
+				if err != nil {
+					return nil, err
+				}
+				components, err := getPathUpTo(swapNode(node, cur), node.Node)
+				if err != nil {
+					return nil, err
+				}
+				if len(components) == len(allComponents) {
+					return squirrel.symbolSearchOne(
+						ctx,
+						node.RepoCommitPath.Repo,
+						node.RepoCommitPath.Commit,
+						[]string{fmt.Sprintf("^%s/%s", filepath.Join(root...), filepath.Join(components[:len(components)-1]...))},
+						ident,
+					)
+				}
+				dir := filepath.Join(append(root, components...)...)
+				return &Node{
+					RepoCommitPath: types.RepoCommitPath{
+						Repo:   node.RepoCommitPath.Repo,
+						Commit: node.RepoCommitPath.Commit,
+						Path:   dir,
+					},
+					Node:     nil,
+					Contents: node.Contents,
+					LangSpec: node.LangSpec,
+				}, nil
+
+			// Check for field access
+			case "field_access":
+				object := cur.ChildByFieldName("object")
+				if object != nil && nodeId(prev) == nodeId(object) {
+					continue
+				}
+				field := cur.ChildByFieldName("field")
+				if field != nil {
+					found, err := squirrel.getFieldCsharp(ctx, swapNode(node, object), field.Content(node.Contents))
+					if err != nil {
+						return nil, err
+					}
+					if found != nil {
+						return found, nil
+					}
+				}
+				continue
+
+			case "method_invocation":
+				object := cur.ChildByFieldName("object")
+				if object == nil {
+					continue
+				}
+				if nodeId(prev) == nodeId(object) {
+					continue
+				}
+				args := cur.ChildByFieldName("arguments")
+				if args == nil {
+					continue
+				}
+				if nodeId(prev) == nodeId(args) {
+					continue
+				}
+				name := cur.ChildByFieldName("name")
+				if name != nil {
+					found, err := squirrel.getFieldCsharp(ctx, swapNode(node, object), name.Content(node.Contents))
+					if err != nil {
+						return nil, err
+					}
+					if found != nil {
+						return found, nil
+					}
+				}
+				continue
+
+			// Check nodes that might have bindings:
+			case "constructor_body":
+				fallthrough
+			case "block":
+				blockChild := prev
+				for {
+					blockChild = blockChild.PrevNamedSibling()
+					if blockChild == nil {
+						continue outer
+					}
+					query := "(local_declaration_statement (variable_declaration (variable_declarator (identifier) @ident)))"
+					captures, err := allCaptures(query, swapNode(node, blockChild))
+					if err != nil {
+						return nil, err
+					}
+					for _, capture := range captures {
+						if capture.Content(capture.Contents) == ident {
+							return swapNodePtr(node, capture.Node), nil
+						}
+					}
+				}
+
+			case "constructor_declaration": // DONE
+				query := `[
+					(constructor_declaration parameters: (parameter_list (parameter name: (identifier) @ident)))
+					(constructor_declaration parameters: (parameter_list (parameter_array (identifier) @ident)))
+				]`
+				captures, err := allCaptures(query, swapNode(node, cur))
+				if err != nil {
+					return nil, err
+				}
+				for _, capture := range captures {
+					if capture.Content(capture.Contents) == ident {
+						return swapNodePtr(node, capture.Node), nil
+					}
+				}
+				continue
+
+			case "method_declaration": // DONE
+				query := `[
+					(method_declaration name: (identifier) @ident)
+					(method_declaration parameters: (parameter_list (parameter name: (identifier) @ident)))
+					(method_declaration parameters: (parameter_list (parameter_array (identifier) @ident)))
+				]`
+				captures, err := allCaptures(query, swapNode(node, cur))
+				if err != nil {
+					return nil, err
+				}
+				for _, capture := range captures {
+					if capture.Content(capture.Contents) == ident {
+						return swapNodePtr(node, capture.Node), nil
+					}
+				}
+				continue
+
+			case "class_declaration":
+				name := cur.ChildByFieldName("name")
+				if name != nil {
+					if name.Content(node.Contents) == ident {
+						return swapNodePtr(node, name), nil
+					}
+				}
+				found, err := squirrel.lookupFieldCsharp(ctx, ClassType{def: swapNode(node, cur)}, ident)
+				if err != nil {
+					return nil, err
+				}
+				if found != nil {
+					return found, nil
+				}
+				super := getSuperclassCsharp(swapNode(node, cur))
+				if super != nil {
+					found, err := squirrel.getFieldCsharp(ctx, *super, ident)
+					if err != nil {
+						return nil, err
+					}
+					if found != nil {
+						return found, nil
+					}
+				}
+				continue
+
+			case "lambda_expression":
+				query := `[
+					(lambda_expression parameters: (identifier) @ident)
+					(lambda_expression parameters: (formal_parameters (formal_parameter name: (identifier) @ident)))
+					(lambda_expression parameters: (formal_parameters (spread_parameter (variable_declarator name: (identifier) @ident))))
+					(lambda_expression parameters: (inferred_parameters (identifier) @ident))
+				]`
+				captures, err := allCaptures(query, swapNode(node, cur))
+				if err != nil {
+					return nil, err
+				}
+				for _, capture := range captures {
+					if capture.Content(capture.Contents) == ident {
+						return swapNodePtr(node, capture.Node), nil
+					}
+				}
+				continue
+
+			case "catch_clause":
+				query := `(catch_clause (catch_formal_parameter name: (identifier) @ident))`
+				captures, err := allCaptures(query, swapNode(node, cur))
+				if err != nil {
+					return nil, err
+				}
+				for _, capture := range captures {
+					if capture.Content(capture.Contents) == ident {
+						return swapNodePtr(node, capture.Node), nil
+					}
+				}
+				continue
+
+			case "for_statement":
+				query := `(for_statement init: (local_variable_declaration declarator: (variable_declarator name: (identifier) @ident)))`
+				captures, err := allCaptures(query, swapNode(node, cur))
+				if err != nil {
+					return nil, err
+				}
+				for _, capture := range captures {
+					if capture.Content(capture.Contents) == ident {
+						return swapNodePtr(node, capture.Node), nil
+					}
+				}
+				continue
+
+			case "enhanced_for_statement":
+				query := `(enhanced_for_statement name: (identifier) @ident)`
+				captures, err := allCaptures(query, swapNode(node, cur))
+				if err != nil {
+					return nil, err
+				}
+				for _, capture := range captures {
+					if capture.Content(capture.Contents) == ident {
+						return swapNodePtr(node, capture.Node), nil
+					}
+				}
+				continue
+
+			case "method_reference":
+				if cur.NamedChildCount() == 0 {
+					return nil, nil
+				}
+				object := cur.NamedChild(0)
+				if nodeId(object) == nodeId(prev) {
+					continue
+				}
+				if ident == "new" {
+					return squirrel.getDefCsharp(ctx, swapNode(node, object))
+				}
+				return squirrel.getFieldCsharp(ctx, swapNode(node, object), ident)
+
+			// Skip all other nodes
+			default:
+				continue
+			}
+		}
+
+	case "type_identifier":
+		ident := node.Content(node.Contents)
+
+		cur := node.Node
+
+		for {
+			prev := cur
+			cur = cur.Parent()
+			if cur == nil {
+				squirrel.breadcrumb(node, "getDefCsharp: ran out of parents")
+				return nil, nil
+			}
+
+			switch cur.Type() {
+			case "program":
+				query := `[
+					(program (class_declaration name: (identifier) @ident))
+					(program (enum_declaration name: (identifier) @ident))
+					(program (interface_declaration name: (identifier) @ident))
+				]`
+				captures, err := allCaptures(query, swapNode(node, cur))
+				if err != nil {
+					return nil, err
+				}
+				for _, capture := range captures {
+					if capture.Content(capture.Contents) == ident {
+						return swapNodePtr(node, capture.Node), nil
+					}
+				}
+				return squirrel.getDefInImportsOrCurrentPackageCsharp(ctx, swapNode(node, cur), ident)
+			case "class_declaration":
+				query := `[
+					(class_declaration name: (identifier) @ident)
+					(class_declaration body: (class_body (class_declaration name: (identifier) @ident)))
+					(class_declaration body: (class_body (enum_declaration name: (identifier) @ident)))
+					(class_declaration body: (class_body (interface_declaration name: (identifier) @ident)))
+				]`
+				captures, err := allCaptures(query, swapNode(node, cur))
+				if err != nil {
+					return nil, err
+				}
+				for _, capture := range captures {
+					if capture.Content(capture.Contents) == ident {
+						return swapNodePtr(node, capture.Node), nil
+					}
+				}
+				continue
+			case "scoped_type_identifier":
+				object := cur.NamedChild(0)
+				if object != nil && nodeId(prev) == nodeId(object) {
+					continue
+				}
+				field := cur.NamedChild(int(cur.NamedChildCount()) - 1)
+				if field != nil {
+					found, err := squirrel.getFieldCsharp(ctx, swapNode(node, object), field.Content(node.Contents))
+					if err != nil {
+						return nil, err
+					}
+					if found != nil {
+						return found, nil
+					}
+				}
+				continue
+			default:
+				continue
+			}
+		}
+
+	case "this":
+		cur := node.Node
+		for cur != nil {
+			switch cur.Type() {
+			case "class_declaration":
+				fallthrough
+			case "interface_declaration":
+				name := cur.ChildByFieldName("name")
+				if name == nil {
+					return nil, nil
+				}
+				return swapNodePtr(node, name), nil
+			}
+			cur = cur.Parent()
+		}
+		return nil, nil
+
+	case "super":
+		cur := node.Node
+		for cur != nil {
+			switch cur.Type() {
+			case "class_declaration":
+				fallthrough
+			case "interface_declaration":
+				super := getSuperclassCsharp(swapNode(node, cur))
+				if super == nil {
+					return nil, nil
+				}
+				return squirrel.getDefCsharp(ctx, *super)
+			}
+			cur = cur.Parent()
+		}
+		return nil, nil
+
+	// No other nodes have a definition
+	default:
+		return nil, nil
+	}
+}
+
+func (squirrel *SquirrelService) getDefInImportsOrCurrentPackageCsharp(ctx context.Context, program Node, ident string) (ret *Node, err error) {
+	defer squirrel.onCall(program, &Tuple{String(program.Type()), String(ident)}, lazyNodeStringer(&ret))()
+
+	// Determine project root
+	root, err := getProjectRoot(program)
+	if err != nil {
+		return nil, err
+	}
+
+	// Collect imports
+	imports := [][]string{}
+	for _, importNode := range children(program.Node) {
+		if importNode.Type() != "import_declaration" {
+			continue
+		}
+		path, err := getPath(swapNode(program, importNode))
+		if err != nil {
+			return nil, err
+		}
+		for _, child := range children(importNode) {
+			if child.Type() == "asterisk" {
+				path = append(path, "*")
+				break
+			}
+		}
+		if len(path) == 0 {
+			continue
+		}
+		imports = append(imports, path)
+	}
+
+	// Check explicit imports (faster) before running symbol searches (slower)
+	for _, importPath := range imports {
+		last := importPath[len(importPath)-1]
+		if last == "*" {
+			continue
+		}
+		if last == ident {
+			return squirrel.symbolSearchOne(
+				ctx,
+				program.RepoCommitPath.Repo,
+				program.RepoCommitPath.Commit,
+				[]string{fmt.Sprintf("^%s/%s", filepath.Join(root...), filepath.Join(importPath[:len(importPath)-1]...))},
+				ident,
+			)
+		}
+	}
+
+	// Search in current package
+	found, err := squirrel.symbolSearchOne(
+		ctx,
+		program.RepoCommitPath.Repo,
+		program.RepoCommitPath.Commit,
+		[]string{filepath.Dir(program.RepoCommitPath.Path)},
+		ident,
+	)
+	if err != nil {
+		return nil, err
+	}
+	if found != nil {
+		return found, nil
+	}
+
+	// Search in packages imported with an asterisk
+	for _, importPath := range imports {
+		if importPath[len(importPath)-1] != "*" {
+			continue
+		}
+
+		found, err := squirrel.symbolSearchOne(
+			ctx,
+			program.RepoCommitPath.Repo,
+			program.RepoCommitPath.Commit,
+			[]string{fmt.Sprintf("^%s/%s", filepath.Join(root...), filepath.Join(importPath[:len(importPath)-1]...))},
+			ident,
+		)
+		if err != nil {
+			return nil, err
+		}
+		if found != nil {
+			return found, nil
+		}
+	}
+
+	return nil, nil
+}
+
+func (squirrel *SquirrelService) getFieldCsharp(ctx context.Context, object Node, field string) (ret *Node, err error) {
+	defer squirrel.onCall(object, &Tuple{String(object.Type()), String(field)}, lazyNodeStringer(&ret))()
+
+	ty, err := squirrel.getTypeDefCsharp(ctx, object)
+	if err != nil {
+		return nil, err
+	}
+	if ty == nil {
+		return nil, nil
+	}
+	return squirrel.lookupFieldCsharp(ctx, ty, field)
+}
+
+func (squirrel *SquirrelService) getTypeDefCsharp(ctx context.Context, node Node) (ret Type, err error) {
+	defer squirrel.onCall(node, String(node.Type()), lazyTypeStringer(&ret))()
+
+	switch node.Type() {
+	case "type_identifier":
+		fallthrough
+	case "this":
+		fallthrough
+	case "super":
+		fallthrough
+	case "identifier":
+		found, err := squirrel.getDefCsharp(ctx, node)
+		if err != nil {
+			return nil, err
+		}
+		if found == nil {
+			return nil, nil
+		}
+		return squirrel.defToType(ctx, *found)
+	case "field_access":
+		object := node.ChildByFieldName("object")
+		if object == nil {
+			return nil, nil
+		}
+		field := node.ChildByFieldName("field")
+		if field == nil {
+			return nil, nil
+		}
+		objectType, err := squirrel.getTypeDefCsharp(ctx, swapNode(node, object))
+		if err != nil {
+			return nil, err
+		}
+		if objectType == nil {
+			return nil, nil
+		}
+		found, err := squirrel.lookupFieldCsharp(ctx, objectType, field.Content(node.Contents))
+		if err != nil {
+			return nil, err
+		}
+		if found == nil {
+			return nil, nil
+		}
+		return squirrel.defToType(ctx, *found)
+	case "method_invocation":
+		name := node.ChildByFieldName("name")
+		if name == nil {
+			return nil, nil
+		}
+		ty, err := squirrel.getTypeDefCsharp(ctx, swapNode(node, name))
+		if err != nil {
+			return nil, err
+		}
+		if ty == nil {
+			return nil, nil
+		}
+		switch ty2 := ty.(type) {
+		case FnType:
+			return ty2.ret, nil
+		default:
+			squirrel.breadcrumb(ty.node(), fmt.Sprintf("getTypeDefCsharp: expected method, got %q", ty.variant()))
+			return nil, nil
+		}
+	case "generic_type":
+		for _, child := range children(node.Node) {
+			if child.Type() == "type_identifier" || child.Type() == "scoped_type_identifier" {
+				return squirrel.getTypeDefCsharp(ctx, swapNode(node, child))
+			}
+		}
+		squirrel.breadcrumb(node, "getTypeDefCsharp: expected an identifier")
+		return nil, nil
+	case "scoped_type_identifier":
+		for i := int(node.NamedChildCount()) - 1; i >= 0; i-- {
+			child := node.NamedChild(i)
+			if child.Type() == "type_identifier" {
+				return squirrel.getTypeDefCsharp(ctx, swapNode(node, child))
+			}
+		}
+		return nil, nil
+	case "void_type":
+		return PrimType{noad: node, varient: "void"}, nil
+	case "integral_type":
+		return PrimType{noad: node, varient: "integral"}, nil
+	case "floating_point_type":
+		return PrimType{noad: node, varient: "floating"}, nil
+	case "boolean_type":
+		return PrimType{noad: node, varient: "boolean"}, nil
+	default:
+		squirrel.breadcrumb(node, fmt.Sprintf("getTypeDefCsharp: unrecognized node type %q", node.Type()))
+		return nil, nil
+	}
+}
+
+func (squirrel *SquirrelService) lookupFieldCsharp(ctx context.Context, ty Type, field string) (ret *Node, err error) {
+	defer squirrel.onCall(ty.node(), &Tuple{String(ty.variant()), String(field)}, lazyNodeStringer(&ret))()
+
+	switch ty2 := ty.(type) {
+	case ClassType:
+		body := ty2.def.ChildByFieldName("body")
+		if body == nil {
+			return nil, nil
+		}
+		for _, child := range children(body) {
+			switch child.Type() {
+			case "method_declaration":
+				name := child.ChildByFieldName("name")
+				if name == nil {
+					continue
+				}
+				if name.Content(ty2.def.Contents) == field {
+					return swapNodePtr(ty2.def, name), nil
+				}
+			case "class_declaration":
+				name := child.ChildByFieldName("name")
+				if name == nil {
+					continue
+				}
+				if name.Content(ty2.def.Contents) == field {
+					return swapNodePtr(ty2.def, name), nil
+				}
+			case "field_declaration":
+				query := "(field_declaration (variable_declaration (variable_declarator (identifier) @ident)))"
+				captures, err := allCaptures(query, swapNode(ty2.def, child))
+				if err != nil {
+					return nil, err
+				}
+				for _, capture := range captures {
+					if capture.Content(capture.Contents) == field {
+						return swapNodePtr(ty2.def, capture.Node), nil
+					}
+				}
+			}
+		}
+		super := getSuperclassCsharp(ty2.def)
+		if super != nil {
+			found, err := squirrel.getFieldCsharp(ctx, *super, field)
+			if err != nil {
+				return nil, err
+			}
+			if found != nil {
+				return found, nil
+			}
+		}
+		return nil, nil
+	case FnType:
+		squirrel.breadcrumb(ty.node(), fmt.Sprintf("lookupFieldCsharp: unexpected object type %s", ty.variant()))
+		return nil, nil
+	case PrimType:
+		squirrel.breadcrumb(ty.node(), fmt.Sprintf("lookupFieldCsharp: unexpected object type %s", ty.variant()))
+		return nil, nil
+	default:
+		squirrel.breadcrumb(ty.node(), fmt.Sprintf("lookupFieldCsharp: unrecognized type variant %q", ty.variant()))
+		return nil, nil
+	}
+}
+
+func getSuperclassCsharp(declaration Node) *Node {
+	super := declaration.ChildByFieldName("superclass")
+	if super == nil {
+		return nil
+	}
+	class := super.NamedChild(0)
+	if class == nil {
+		return nil
+	}
+	return swapNodePtr(declaration, class)
+}

--- a/cmd/symbols/squirrel/service.go
+++ b/cmd/symbols/squirrel/service.go
@@ -155,7 +155,8 @@ func (squirrel *SquirrelService) getDef(ctx context.Context, node Node) (*Node, 
 	case "java":
 		return squirrel.getDefJava(ctx, node)
 	// case "go":
-	// case "csharp":
+	case "csharp":
+		return squirrel.getDefCsharp(ctx, node)
 	// case "python":
 	// case "javascript":
 	// case "typescript":

--- a/cmd/symbols/squirrel/test_repos/csharp/helloworld.cs
+++ b/cmd/symbols/squirrel/test_repos/csharp/helloworld.cs
@@ -17,7 +17,7 @@ namespace HelloWorld
         }
 
         //                   vv cs.p1 def
-        static void Main(int p1)
+        static void Main(int p1, params int[] p2)
         {
             //  vv cs.l1 def
             int l1;
@@ -39,8 +39,35 @@ namespace HelloWorld
         //  vv cs.l1 ref
         //            vv cs.l2 ref
         //                 vv cs.l3 ref
-            l1 = f2 + l2 + l3;
+        //                      vv cs.C2 ref
+            l1 = f2 + l2 + l3 + C2.g1;
+
+            //                       v cs.e def
+            //                                           v cs.e ref
+            try { } catch (Exception e) { Exception e2 = e; }
+
+            //       v cs.for.i def
+            //              v cs.for.i ref
+            for (int i = 0; i < 5; i++) { }
+
+            //           v cs.enhanced_for.i def
+            //                           v cs.enhanced_for.i ref
+            foreach (int i in p2) { p1 = i; }
+
+            C2 c2; // < "C2" cs.C2 ref
+
+            //    vv cs.C2 ref
+            Hello.C2 c12; // < "Hello" cs.Hello ref
+
+            //          vv cs.C2.g1 ref
+            int f1 = c2.g1;
         }
+    }
+
+    //    vv cs.C2 def
+    class C2 {
+        //         vv cs.C2.g1 def
+        static int g1;
 
     }
 }

--- a/cmd/symbols/squirrel/test_repos/csharp/helloworld.cs
+++ b/cmd/symbols/squirrel/test_repos/csharp/helloworld.cs
@@ -1,0 +1,46 @@
+// Hello World! program
+namespace HelloWorld
+{
+    //    vvvvv Hello cs.Hello def
+    class Hello {
+
+        //         vv cs.f1 def
+        static int f1 = 5;
+
+        //     vv cs.f4 def
+        //                      vv cs.f6 def
+        C2(int f4, params int[] f6) {
+            //       vv cs.f4 ref
+            int f5 = f4;
+            //         vv cs.f6 ref
+            int[] f7 = f6;
+        }
+
+        //                   vv cs.p1 def
+        static void Main(int p1)
+        {
+            //  vv cs.l1 def
+            int l1;
+
+            //  vv cs.f2 def
+            //       vv cs.p1 ref
+            int f2 = p1;
+
+            //       vv cs.f2 ref
+            //            vv cs.f1 ref
+            int f3 = f2 + f1;
+
+            Hello h; // < "Hello" cs.Hello ref
+
+            //  vv cs.l2 def
+            //      vv cs.l3 def
+            int l2, l3 = 0;
+
+        //  vv cs.l1 ref
+        //            vv cs.l2 ref
+        //                 vv cs.l3 ref
+            l1 = f2 + l2 + l3;
+        }
+
+    }
+}


### PR DESCRIPTION
Expanding on Squirrel by adding C# to the repertoire of languages it can navigate.

## Test plan
Added tests.
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
