### PR TITLE
dev/sg: do not use .zprofile, add compdef

### DIFF
--- a/dev/sg/internal/usershell/usershell.go
+++ b/dev/sg/internal/usershell/usershell.go
@@ -4,11 +4,8 @@ package usershell
 import (
 	"context"
 	"os"
-	"path"
 	"path/filepath"
 	"strings"
-
-	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 type key struct{}
@@ -72,13 +69,7 @@ func GuessUserShell() (shellPath string, shellrc string, shell Shell, error erro
 		shellrc = ".bashrc"
 		shell = BashShell
 	case strings.Contains(shellPath, "zsh"):
-		if _, err := os.Stat(path.Join(home, ".zshrc")); errors.Is(err, os.ErrNotExist) {
-			// A fresh mac installation with standard homebrew will tell the user to append
-			// the configuration in .zprofile, not .zshrc.
-			shellrc = ".zprofile"
-		} else {
-			shellrc = ".zshrc"
-		}
+		shellrc = ".zshrc"
 		shell = ZshShell
 	case strings.Contains(shellPath, "fish"):
 		shellrc = ".config/fish/config.fish"

--- a/dev/sg/sg_setup_shared.go
+++ b/dev/sg/sg_setup_shared.go
@@ -52,6 +52,7 @@ var dependencyCategoryAdditionalSgConfiguration = dependencyCategory{
 
 				var commands []string
 
+				// Write completions script to disk
 				shell := usershell.ShellType(ctx)
 				if shell == "" {
 					return "echo 'Failed to detect shell type' && exit 1"
@@ -62,6 +63,7 @@ var dependencyCategoryAdditionalSgConfiguration = dependencyCategory{
 					fmt.Sprintf(`echo "Writing autocomplete script to %s"`, autocompletePath),
 					fmt.Sprintf(`echo '%s' > %s`, autocompleteScript, autocompletePath))
 
+				// Now prepare to update the shell config
 				shellConfig := usershell.ShellConfigPath(ctx)
 				if shellConfig == "" {
 					return "echo 'Failed to detect shell config path' && exit 1"
@@ -70,6 +72,18 @@ var dependencyCategoryAdditionalSgConfiguration = dependencyCategory{
 				if err != nil {
 					return fmt.Sprintf("echo %s && exit 1", err.Error())
 				}
+
+				// Compinit needs to be initialized
+				if shell == usershell.ZshShell {
+					if !strings.Contains(string(conf), "compinit") {
+						commands = append(commands,
+							fmt.Sprintf(`echo "Adding compinit to %s"`, shellConfig),
+							fmt.Sprintf(`echo "autoload -Uz compinit" >> %s`, shellConfig),
+							fmt.Sprintf(`echo "compinit" >> %s`, shellConfig))
+					}
+				}
+
+				// Then we add completions
 				if !strings.Contains(string(conf), autocompletePath) {
 					commands = append(commands,
 						fmt.Sprintf(`echo "Adding configuration to %s"`, shellConfig),


### PR DESCRIPTION
The only thing in my `.zprofile` was some brew stuff. I moved to `.zshrc` and it worked fine, so let's just put everything in `.zshrc` instead of splitting things.

compdef magically works for me, but some StackOverflow threads mention it might need to be explicitly initialized in `.zshrc`, so this PR adds it

Closes https://github.com/sourcegraph/sourcegraph/pull/36814

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Will be testing with @jwayman  who is running into issues with the completions setup as is

Update - ran him through a setup on this branch and it worked 🆗 