### PR TITLE
schema: Add `executor.frontendURL`

### DIFF
--- a/enterprise/cmd/frontend/internal/executorqueue/queues/batches/transform.go
+++ b/enterprise/cmd/frontend/internal/executorqueue/queues/batches/transform.go
@@ -79,7 +79,7 @@ func transformRecord(ctx context.Context, s BatchesStore, job *btypes.BatchSpecW
 		},
 	}
 
-	frontendURL := conf.Get().ExternalURL
+	frontendURL := conf.ExecutorsFrontendURL()
 
 	srcEndpoint, err := makeURL(frontendURL, accessToken)
 	if err != nil {

--- a/enterprise/cmd/frontend/internal/executorqueue/queues/codeintel/transform.go
+++ b/enterprise/cmd/frontend/internal/executorqueue/queues/codeintel/transform.go
@@ -34,12 +34,7 @@ func transformRecord(index store.Index, accessToken string) (apiclient.Job, erro
 		})
 	}
 
-	c := conf.Get()
-	frontendURL := c.ExecutorsFrontendURL
-	if frontendURL == "" {
-		frontendURL = c.ExternalURL
-	}
-
+	frontendURL := conf.ExecutorsFrontendURL()
 	authorizationHeader := makeAuthHeaderValue(accessToken)
 	redactedAuthorizationHeader := makeAuthHeaderValue("REDACTED")
 

--- a/enterprise/cmd/frontend/internal/executorqueue/queues/codeintel/transform.go
+++ b/enterprise/cmd/frontend/internal/executorqueue/queues/codeintel/transform.go
@@ -34,7 +34,11 @@ func transformRecord(index store.Index, accessToken string) (apiclient.Job, erro
 		})
 	}
 
-	frontendURL := conf.Get().ExternalURL
+	c := conf.Get()
+	frontendURL := c.ExecutorsFrontendURL
+	if frontendURL == "" {
+		frontendURL = c.ExternalURL
+	}
 
 	authorizationHeader := makeAuthHeaderValue(accessToken)
 	redactedAuthorizationHeader := makeAuthHeaderValue("REDACTED")

--- a/internal/conf/computed.go
+++ b/internal/conf/computed.go
@@ -155,6 +155,15 @@ func ExecutorsEnabled() bool {
 	return Get().ExecutorsAccessToken != ""
 }
 
+func ExecutorsFrontendURL() string {
+	current := Get()
+	if current.ExecutorsFrontendURL != "" {
+		return current.ExecutorsFrontendURL
+	}
+
+	return current.ExternalURL
+}
+
 func CodeIntelAutoIndexingEnabled() bool {
 	if enabled := Get().CodeIntelAutoIndexingEnabled; enabled != nil {
 		return *enabled

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1889,6 +1889,8 @@ type SiteConfiguration struct {
 	EncryptionKeys *EncryptionKeys `json:"encryption.keys,omitempty"`
 	// ExecutorsAccessToken description: The shared secret between Sourcegraph and executors.
 	ExecutorsAccessToken string `json:"executors.accessToken,omitempty"`
+	// ExecutorsFrontendURL description: The frontend URL for Sourcegraph. Only root URLs are allowed. If not set, falls back to externalURL
+	ExecutorsFrontendURL string `json:"executors.frontendURL,omitempty"`
 	// ExperimentalFeatures description: Experimental features to enable or disable. Features that are now enabled by default are marked as deprecated.
 	ExperimentalFeatures *ExperimentalFeatures `json:"experimentalFeatures,omitempty"`
 	// Extensions description: Configures Sourcegraph extensions.

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -991,6 +991,11 @@
       "group": "Email",
       "default": "noreply@sourcegraph.com"
     },
+    "executors.frontendURL": {
+      "description": "The frontend URL for Sourcegraph. Only root URLs are allowed. If not set, falls back to externalURL",
+      "type": "string",
+      "examples": ["https://sourcegraph.example.com"]
+    },
     "executors.accessToken": {
       "description": "The shared secret between Sourcegraph and executors.",
       "type": "string",


### PR DESCRIPTION
Add a new `executor.frontendURL` configuration value that can change the target URL executors will hit to clone repos and upload results.

## Test plan

Tested locally.