### PR TITLE
search: keep filter nodes for unordered lucky rule

### DIFF
--- a/internal/search/job/jobutil/feeling_lucky_search_job.go
+++ b/internal/search/job/jobutil/feeling_lucky_search_job.go
@@ -175,21 +175,21 @@ func mapConcat(q []query.Node) ([]query.Node, bool) {
 		if n, ok := node.(query.Operator); ok {
 			if n.Kind != query.Concat {
 				// recurse
-				operands, changed := mapConcat(n.Operands)
-				return []query.Node{
-					query.Operator{
-						Kind:     n.Kind,
-						Operands: operands,
-					},
-				}, changed
+				operands, newChanged := mapConcat(n.Operands)
+				mapped = append(mapped, query.Operator{
+					Kind:     n.Kind,
+					Operands: operands,
+				})
+				changed = changed || newChanged
+				continue
 			}
-			// No need to recurse: `concat` nodes only have patterns.
-			return []query.Node{
-				query.Operator{
-					Kind:     query.And,
-					Operands: n.Operands,
-				},
-			}, true
+			// no need to recurse: `concat` nodes only have patterns.
+			mapped = append(mapped, query.Operator{
+				Kind:     query.And,
+				Operands: n.Operands,
+			})
+			changed = true
+			continue
 		}
 		mapped = append(mapped, node)
 	}

--- a/internal/search/job/jobutil/testdata/TestNewFeelingLuckySearchJob/trigger_unordered_patterns.golden
+++ b/internal/search/job/jobutil/testdata/TestNewFeelingLuckySearchJob/trigger_unordered_patterns.golden
@@ -157,7 +157,7 @@
           "AlternateQueries": [
             {
               "Description": "AND patterns together",
-              "Query": "(parse AND func)",
+              "Query": "context:global (parse AND func)",
               "PatternType": 1
             }
           ]
@@ -211,7 +211,7 @@
                     "Dependencies": null,
                     "Dependents": null,
                     "CaseSensitiveRepoFilters": false,
-                    "SearchContextSpec": "",
+                    "SearchContextSpec": "global",
                     "CommitAfter": "",
                     "Visibility": "Any",
                     "Limit": 0,
@@ -234,7 +234,7 @@
                     "Dependencies": null,
                     "Dependents": null,
                     "CaseSensitiveRepoFilters": false,
-                    "SearchContextSpec": "",
+                    "SearchContextSpec": "global",
                     "CommitAfter": "",
                     "Visibility": "Any",
                     "Limit": 0,
@@ -297,7 +297,7 @@
                               "Dependencies": null,
                               "Dependents": null,
                               "CaseSensitiveRepoFilters": false,
-                              "SearchContextSpec": "",
+                              "SearchContextSpec": "global",
                               "CommitAfter": "",
                               "Visibility": "Any",
                               "Limit": 0,
@@ -369,7 +369,7 @@
                               "Dependencies": null,
                               "Dependents": null,
                               "CaseSensitiveRepoFilters": false,
-                              "SearchContextSpec": "",
+                              "SearchContextSpec": "global",
                               "CommitAfter": "",
                               "Visibility": "Any",
                               "Limit": 0,


### PR DESCRIPTION
Stacked on https://github.com/sourcegraph/sourcegraph/pull/36763.

Fixes wrong mapper for concat nodes that would early return and sometimes throw away filters depending on the order of terms.

## Test plan
Updated test