### PR TITLE
executors: Install src and rename firecracker variables

### DIFF
--- a/enterprise/cmd/executor/config.go
+++ b/enterprise/cmd/executor/config.go
@@ -27,8 +27,8 @@ type Config struct {
 	VMStartupScriptPath        string
 	VMPrefix                   string
 	UseFirecracker             bool
-	FirecrackerNumCPUs         int
-	FirecrackerMemory          string
+	JobNumCPUs                 int
+	JobMemory                  string
 	FirecrackerDiskSpace       string
 	MaximumRuntimePerJob       time.Duration
 	CleanupTaskInterval        time.Duration
@@ -47,9 +47,9 @@ func (c *Config) Load() {
 	c.FirecrackerImage = c.Get("EXECUTOR_FIRECRACKER_IMAGE", "sourcegraph/ignite-ubuntu:insiders", "The base image to use for virtual machines.")
 	c.VMStartupScriptPath = c.GetOptional("EXECUTOR_VM_STARTUP_SCRIPT_PATH", "A path to a file on the host that is loaded into a fresh virtual machine and executed on startup.")
 	c.VMPrefix = c.Get("EXECUTOR_VM_PREFIX", "executor", "A name prefix for virtual machines controlled by this instance.")
-	c.FirecrackerNumCPUs = c.GetInt("EXECUTOR_FIRECRACKER_NUM_CPUS", "4", "How many CPUs to allocate to each virtual machine or container.")
-	c.FirecrackerMemory = c.Get("EXECUTOR_FIRECRACKER_MEMORY", "12G", "How much memory to allocate to each virtual machine or container.")
-	c.FirecrackerDiskSpace = c.Get("EXECUTOR_FIRECRACKER_DISK_SPACE", "20G", "How much disk space to allocate to each virtual machine or container.")
+	c.JobNumCPUs = c.GetInt(env.ChooseFallbackVariableName("EXECUTOR_JOB_NUM_CPUS", "EXECUTOR_FIRECRACKER_NUM_CPUS"), "4", "How many CPUs to allocate to each virtual machine or container.")
+	c.JobMemory = c.Get(env.ChooseFallbackVariableName("EXECUTOR_JOB_MEMORY", "EXECUTOR_FIRECRACKER_MEMORY"), "12G", "How much memory to allocate to each virtual machine or container.")
+	c.FirecrackerDiskSpace = c.Get("EXECUTOR_FIRECRACKER_DISK_SPACE", "20G", "How much disk space to allocate to each virtual machine.")
 	c.MaximumRuntimePerJob = c.GetInterval("EXECUTOR_MAXIMUM_RUNTIME_PER_JOB", "30m", "The maximum wall time that can be spent on a single job.")
 	c.CleanupTaskInterval = c.GetInterval("EXECUTOR_CLEANUP_TASK_INTERVAL", "1m", "The frequency with which to run periodic cleanup tasks.")
 	c.NumTotalJobs = c.GetInt("EXECUTOR_NUM_TOTAL_JOBS", "0", "The maximum number of jobs that will be dequeued by the worker.")
@@ -61,9 +61,9 @@ func (c *Config) Load() {
 }
 
 func (c *Config) Validate() error {
-	if c.FirecrackerNumCPUs != 1 && c.FirecrackerNumCPUs%2 != 0 {
+	if c.JobNumCPUs != 1 && c.JobNumCPUs%2 != 0 && c.UseFirecracker {
 		// Required by Firecracker: The vCPU number is invalid! The vCPU number can only be 1 or an even number when hyperthreading is enabled
-		c.AddError(errors.Newf("EXECUTOR_FIRECRACKER_NUM_CPUS must be 1 or an even number"))
+		c.AddError(errors.Newf("EXECUTOR_JOB_NUM_CPUS must be 1 or an even number"))
 	}
 
 	return c.BaseConfig.Validate()
@@ -110,8 +110,8 @@ func (c *Config) FirecrackerOptions() command.FirecrackerOptions {
 
 func (c *Config) ResourceOptions() command.ResourceOptions {
 	return command.ResourceOptions{
-		NumCPUs:   c.FirecrackerNumCPUs,
-		Memory:    c.FirecrackerMemory,
+		NumCPUs:   c.JobNumCPUs,
+		Memory:    c.JobMemory,
 		DiskSpace: c.FirecrackerDiskSpace,
 	}
 }

--- a/enterprise/cmd/executor/vm-image/install.sh
+++ b/enterprise/cmd/executor/vm-image/install.sh
@@ -205,6 +205,15 @@ EOF
   systemctl enable exporter_exporter
 }
 
+# Install src-cli to the host system. It's needed for src steps outside of firecracker.
+function install_src_cli() {
+  curl -f -L -o src-cli.tar.gz "https://github.com/sourcegraph/src-cli/releases/download/${SRC_CLI_VERSION}/src-cli_${SRC_CLI_VERSION}_linux_amd64.tar.gz"
+  tar -xvzf src-cli.tar.gz src
+  mv src /usr/local/bin/src
+  chmod +x /usr/local/bin/src
+  rm -rf src-cli.tar.gz
+}
+
 ## Build the ignite-ubuntu image for use in firecracker.
 ## Set SRC_CLI_VERSION to the minimum required version in internal/src-cli/consts.go
 function generate_ignite_base_image() {
@@ -237,6 +246,7 @@ else
 fi
 install_docker
 install_git
+install_src_cli
 install_ignite
 
 # Services


### PR DESCRIPTION
They are actually applying to both containers and VMs so let's change the name. Also, src is required in the environment the executor is executing in. So far we only installed it in the firecracker VM base image.

## Test plan

We are testing this after the image is built in dogfood.