### PR TITLE
search: disable integration test for structural search alerts

### DIFF
--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -711,36 +711,6 @@ func testSearchClient(t *testing.T, client searchClient) {
 				name:  `Structural search quotes are interpreted literally`,
 				query: `repo:^github\.com/sgtest/sourcegraph-typescript$ file:^README\.md "basic :[_] access :[_]" patterntype:structural`,
 			},
-			{
-				name:       `Alert to activate structural search mode for :[...] syntax`,
-				query:      `repo:^github\.com/sgtest/go-diff$ patterntype:literal i can't :[believe] it's not butter`,
-				zeroResult: true,
-				wantAlert: &gqltestutil.SearchAlert{
-					Title:       "No results",
-					Description: "It looks like you're trying to run a structural search, but it is not enabled using the patterntype keyword or UI toggle.",
-					ProposedQueries: []gqltestutil.ProposedQuery{
-						{
-							Description: "Activate structural search",
-							Query:       `repo:^github\.com/sgtest/go-diff$ patterntype:literal i can't :[believe] it's not butter patternType:structural`,
-						},
-					},
-				},
-			},
-			{
-				name:       `Alert to activate structural search mode for ... syntax`,
-				query:      `no results for { ... } raises alert repo:^github\.com/sgtest/go-diff$`,
-				zeroResult: true,
-				wantAlert: &gqltestutil.SearchAlert{
-					Title:       "No results",
-					Description: "It looks like you're trying to run a structural search, but it is not enabled using the patterntype keyword or UI toggle.",
-					ProposedQueries: []gqltestutil.ProposedQuery{
-						{
-							Description: "Activate structural search",
-							Query:       `no results for { ... } raises alert repo:^github\.com/sgtest/go-diff$ patternType:structural`,
-						},
-					},
-				},
-			},
 		}
 		for _, test := range tests {
 			t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
This is confirmed flake. I think it might be a combination of racing/priority for alerts (?). This test specifically is probably also better as a unit test/static test now.

Red in: https://buildkite.com/sourcegraph/sourcegraph/builds/153113#018144cb-c641-4005-b816-c100039fb466

Green in commit after: https://buildkite.com/sourcegraph/sourcegraph/builds/153117

## Test plan
Remove flake.
