### PR TITLE
Backend: add argument to `fileDiffs` to filter diffs to a file or directory

### DIFF
--- a/cmd/frontend/graphqlbackend/git_commit.go
+++ b/cmd/frontend/graphqlbackend/git_commit.go
@@ -327,6 +327,21 @@ func (r *GitCommitResolver) Ancestors(ctx context.Context, args *struct {
 	}, nil
 }
 
+func (r *GitCommitResolver) Diff(ctx context.Context, args *struct {
+	Base *string
+}) (*RepositoryComparisonResolver, error) {
+	oidString := string(r.oid)
+	base := oidString + "~"
+	if args.Base != nil {
+		base = *args.Base
+	}
+	return NewRepositoryComparison(ctx, r.db, r.repoResolver, &RepositoryComparisonInput{
+		Base:         &base,
+		Head:         &oidString,
+		FetchMissing: false,
+	})
+}
+
 func (r *GitCommitResolver) BehindAhead(ctx context.Context, args *struct {
 	Revspec string
 }) (*behindAheadCountsResolver, error) {

--- a/cmd/frontend/graphqlbackend/repository_comparison.go
+++ b/cmd/frontend/graphqlbackend/repository_comparison.go
@@ -33,6 +33,7 @@ type RepositoryComparisonInput struct {
 type FileDiffsConnectionArgs struct {
 	First *int32
 	After *string
+	Paths *[]string
 }
 
 type RepositoryComparisonInterface interface {
@@ -226,12 +227,18 @@ func computeRepositoryComparisonDiff(cmp *RepositoryComparisonResolver) ComputeD
 				base = string(cmp.base.OID())
 			}
 
+			var paths []string
+			if args.Paths != nil {
+				paths = *args.Paths
+			}
+
 			var iter *gitserver.DiffFileIterator
 			iter, err = gitserver.NewClient(cmp.db).Diff(ctx, gitserver.DiffOptions{
 				Repo:      cmp.repo.RepoName(),
 				Base:      base,
 				Head:      string(cmp.head.OID()),
 				RangeType: cmp.rangeType,
+				Paths:     paths,
 			})
 			if err != nil {
 				return
@@ -293,6 +300,7 @@ func NewFileDiffConnectionResolver(
 		head:    head,
 		first:   args.First,
 		after:   args.After,
+		paths:   args.Paths,
 		compute: compute,
 		newFile: newFileFunc,
 	}
@@ -304,12 +312,13 @@ type fileDiffConnectionResolver struct {
 	head    *GitCommitResolver
 	first   *int32
 	after   *string
+	paths   *[]string
 	compute ComputeDiffFunc
 	newFile NewFileFunc
 }
 
 func (r *fileDiffConnectionResolver) Nodes(ctx context.Context) ([]FileDiff, error) {
-	fileDiffs, afterIdx, _, err := r.compute(ctx, &FileDiffsConnectionArgs{First: r.first, After: r.after})
+	fileDiffs, afterIdx, _, err := r.compute(ctx, &FileDiffsConnectionArgs{First: r.first, After: r.after, Paths: r.paths})
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/graphqlbackend/repository_comparison_test.go
+++ b/cmd/frontend/graphqlbackend/repository_comparison_test.go
@@ -87,6 +87,9 @@ func TestRepositoryComparison(t *testing.T) {
 		if len(args) < 1 && args[0] != "diff" {
 			t.Fatalf("gitserver.ExecReader received wrong args: %v", args)
 		}
+		if args[len(args)-1] == "JOKES.md" {
+			return io.NopCloser(strings.NewReader(testDiffJokesOnly)), nil
+		}
 		return io.NopCloser(strings.NewReader(testDiff + testCopyDiff)), nil
 	}
 	t.Cleanup(func() { gitserver.Mocks.ExecReader = nil })
@@ -204,6 +207,32 @@ func TestRepositoryComparison(t *testing.T) {
 			want := "2 added, 7 changed, 1 deleted"
 			if have := fmt.Sprintf("%d added, %d changed, %d deleted", diffStat.Added(), diffStat.Changed(), diffStat.Deleted()); have != want {
 				t.Fatalf("wrong diffstat. want=%q, have=%q", want, have)
+			}
+		})
+
+		t.Run("LimitedPaths", func(t *testing.T) {
+			paths := []string{"JOKES.md"}
+			diffConnection, err := comp.FileDiffs(ctx, &FileDiffsConnectionArgs{Paths: &paths})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			nodes, err := diffConnection.Nodes(ctx)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if len(nodes) != 1 {
+				t.Fatalf("expected 1 file node, got %d", len(nodes))
+			}
+
+			oldPath := nodes[0].OldPath()
+			if oldPath == nil {
+				t.Fatalf("expected non-nil oldPath")
+			}
+
+			if *oldPath != "JOKES.md" {
+				t.Fatalf("expected JOKES.md, got %s", *oldPath)
 			}
 		})
 
@@ -731,6 +760,27 @@ const testDiffFirstHunk = ` Line 1
 +Foobar Line 8
  Line 9
  Line 10
+`
+
+const testDiffJokesOnly = `
+diff --git JOKES.md JOKES.md
+index ea80abf..1b86505 100644
+--- JOKES.md
++++ JOKES.md
+@@ -4,10 +4,10 @@ Joke #1
+ Joke #2
+ Joke #3
+ Joke #4
+-Joke #5
++This is not funny: Joke #5
+ Joke #6
+-Joke #7
++This one is good: Joke #7
+ Joke #8
+-Joke #9
++Waffle: Joke #9
+ Joke #10
+ Joke #11
 `
 
 func TestFileDiffHighlighter(t *testing.T) {

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -2975,6 +2975,10 @@ type PreviewRepositoryComparison {
         Return file diffs after the given cursor.
         """
         after: String
+        """
+        A list of paths or directories used to filter the diffs
+        """
+        paths: [String!]
     ): FileDiffConnection!
 }
 
@@ -3019,6 +3023,10 @@ type RepositoryComparison {
         Return file diffs after the given cursor.
         """
         after: String
+        """
+        A list of paths or directories used to filter the diffs
+        """
+        paths: [String!]
     ): FileDiffConnection!
 }
 

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -3880,6 +3880,13 @@ type GitCommit implements Node {
         """
         includePatterns: [String!]
     ): SymbolConnection!
+
+    diff(
+        """
+        The base commit to compare to. Defaults to the commit's first parent.
+        """
+        base: String
+    ): RepositoryComparison!
 }
 
 """

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -3881,6 +3881,9 @@ type GitCommit implements Node {
         includePatterns: [String!]
     ): SymbolConnection!
 
+    """
+    Returns the comparison with another revision.
+    """
     diff(
         """
         The base commit to compare to. Defaults to the commit's first parent.

--- a/internal/gitserver/commands.go
+++ b/internal/gitserver/commands.go
@@ -47,6 +47,8 @@ type DiffOptions struct {
 	// RangeType to be used for computing the diff: one of ".." or "..." (or unset: "").
 	// For a nice visual explanation of ".." vs "...", see https://stackoverflow.com/a/46345364/2682729
 	RangeType string
+
+	Paths []string
 }
 
 // Diff returns an iterator that can be used to access the diff between two
@@ -68,7 +70,7 @@ func (c *ClientImplementor) Diff(ctx context.Context, opts DiffOptions) (*DiffFi
 		return nil, errors.Errorf("invalid diff range argument: %q", rangeSpec)
 	}
 
-	rdr, err := c.execReader(ctx, opts.Repo, []string{
+	rdr, err := c.execReader(ctx, opts.Repo, append([]string{
 		"diff",
 		"--find-renames",
 		// TODO(eseliger): Enable once we have support for copy detection in go-diff
@@ -80,7 +82,7 @@ func (c *ClientImplementor) Diff(ctx context.Context, opts DiffOptions) (*DiffFi
 		"--no-prefix",
 		rangeSpec,
 		"--",
-	})
+	}, opts.Paths...))
 	if err != nil {
 		return nil, errors.Wrap(err, "executing git diff")
 	}


### PR DESCRIPTION
This adds an argument to `fileDiffs` so that we can filter the resulting diffs to a set of files or directories. This should be the extent of the backend changes required to implement a view of the changes for a single file as described [here](https://github.com/sourcegraph/sourcegraph/issues/13411)

Examples: 

<details>
<summary>Get change in `dev/gqltest/search_test.go` over the last 50 commits</summary>

```graphql
{
  repository(name: "github.com/sourcegraph/sourcegraph") {
    name
    comparison(base:"HEAD~50", head:"HEAD") {
      fileDiffs(paths:["dev/gqltest/search_test.go"]){
        nodes{
          hunks {
            body
          }
        }
      }
    }
  }
}
```

</details>

<details>
<summary>Get all commits that touch the directory `internal/search/job/jobutil` and the diff associated with them</summary>

```graphql
{
	repository(name:"github.com/sourcegraph/sourcegraph") {
    commit(rev:"HEAD"){
      ancestors(path:"internal/search/job/jobutil") {
        nodes {
          diff{
            fileDiffs(paths:["internal/search/job/jobutil"]){
              nodes{
                hunks {
                  body
                }
              }
            }
          }
        }
      }
    }
  }
}
```

</details>

## Test plan

Added unit test, tested manually to make sure git stuff works as expected.


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
