### PR TITLE
Reminder to keep architecture diagram in-sync

### DIFF
--- a/cmd/README.md
+++ b/cmd/README.md
@@ -1,0 +1,3 @@
+This directory contains Sourcegraph services and binaries.
+
+When a services is added, removed, or when a service's dependencies change, update [our architecture diagram](../doc/dev/background-information/architecture/index.md).

--- a/enterprise/cmd/README.md
+++ b/enterprise/cmd/README.md
@@ -1,0 +1,3 @@
+This directory contains Sourcegraph services and binaries.
+
+When a services is added, removed, or when a service's dependencies change, update [our architecture diagram](../doc/dev/background-information/architecture/index.md).


### PR DESCRIPTION
This change adds a reminder to update our architecture diagram when services are added/removed/changed.

## Test plan

This change just updates documentation so there is nothing new/changed to test