### PR TITLE
git-combine: attempt to clean up stale git lockfiles from crashed processes

### DIFF
--- a/internal/cmd/git-combine/git-combine.go
+++ b/internal/cmd/git-combine/git-combine.go
@@ -478,6 +478,10 @@ func cleanupStaleLockFiles(gitDir string, logger *log.Logger) error {
 
 	// discover lock files that look like refs/remotes/origin/main.lock
 	err := filepath.WalkDir(refsDir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
 		if d.IsDir() || !strings.HasSuffix(path, ".lock") {
 			return nil
 		}

--- a/internal/cmd/git-combine/git-combine.go
+++ b/internal/cmd/git-combine/git-combine.go
@@ -487,7 +487,7 @@ func cleanupStaleLockFiles(gitDir string, logger *log.Logger) error {
 	})
 
 	if err != nil {
-		return errors.Wrapf(err, "finding stale lockfiles in %q: %w", refsDir)
+		return errors.Wrapf(err, "finding stale lockfiles in %q", refsDir)
 	}
 
 	// remove all stale lock files

--- a/internal/cmd/git-combine/git-combine.go
+++ b/internal/cmd/git-combine/git-combine.go
@@ -462,12 +462,15 @@ func cleanupStaleLockFiles(gitDir string, logger *log.Logger) error {
 		"gc.pid.lock", // created when git starts a garbage collection run
 		"index.lock",  // created when running "git add" / "git commit"
 
-		// from cmd/gitserver/server/cleanup\.go
+		// from cmd/gitserver/server/cleanup.go
 		"config.lock",
 		"packed-refs.lock",
 	} {
 		lockFiles = append(lockFiles, filepath.Join(gitDir, f))
 	}
+
+	// from cmd/gitserver/server/cleanup.go
+	lockFiles = append(lockFiles, filepath.Join(gitDir, "objects", "info", "commit-graph.lock"))
 
 	refsDir := filepath.Join(gitDir, "refs")
 

--- a/internal/cmd/git-combine/git-combine.go
+++ b/internal/cmd/git-combine/git-combine.go
@@ -462,14 +462,16 @@ func cleanupStaleLockFiles(gitDir string, logger *log.Logger) error {
 		"gc.pid.lock", // created when git starts a garbage collection run
 		"index.lock",  // created when running "git add" / "git commit"
 
-		// from cmd/gitserver/server/cleanup.go
+		// from cmd/gitserver/server/cleanup.go, see
+		// https://github.com/sourcegraph/sourcegraph/blob/55d83e8111d4dfea480ad94813e07d58068fec9c/cmd/gitserver/server/cleanup.go#L325-L359
 		"config.lock",
 		"packed-refs.lock",
 	} {
 		lockFiles = append(lockFiles, filepath.Join(gitDir, f))
 	}
 
-	// from cmd/gitserver/server/cleanup.go
+	// from cmd/gitserver/server/cleanup.go, see
+	// https://github.com/sourcegraph/sourcegraph/blob/55d83e8111d4dfea480ad94813e07d58068fec9c/cmd/gitserver/server/cleanup.go#L325-L359
 	lockFiles = append(lockFiles, filepath.Join(gitDir, "objects", "info", "commit-graph.lock"))
 
 	refsDir := filepath.Join(gitDir, "refs")


### PR DESCRIPTION
If git-combined crashes/restarts in the middle of a git operation, it can leave behind stale lockfiles (like index.lock, `refs/remotes/origin/main.lock`, etc. that can prevent git from running properly when the pod restarts:

```bash
/data/repos/gigarepo/.git # git gc
^Z[1]+  Stopped                    git gc
/data/repos/gigarepo/.git # kill %1
/data/repos/gigarepo/.git # git gc
fatal: gc is already running on machine 'git-combine-0' pid 10968 (use --force if not)
```

This PR attempts to remove all such "stale" git lockfiles when the daemon first starts, so that the pod avoids an endless crash loop. 

## Test plan

This is a PR for a utility command outside of the sourcegraph/sourcegraph codebase. 