### PR TITLE
rockskip: Remove "Rockskip" from user-facing error message

### DIFF
--- a/enterprise/internal/rockskip/search.go
+++ b/enterprise/internal/rockskip/search.go
@@ -41,11 +41,11 @@ func (s *Service) Search(ctx context.Context, args search.SymbolsParameters) (_ 
 				return
 			}
 
-			err = errors.Newf("Processing symbols with [Rockskip](https://docs.sourcegraph.com/code_intelligence/explanations/rockskip) is taking a while, try again later.")
+			err = errors.Newf("Processing symbols is taking a while, try again later ([more details](https://docs.sourcegraph.com/code_intelligence/explanations/rockskip)).")
 			for _, status := range s.status.threadIdToThreadStatus {
 				fmt.Println(status.Name, fmt.Sprintf("indexing %s", args.Repo))
 				if strings.HasPrefix(status.Name, fmt.Sprintf("indexing %s", args.Repo)) {
-					err = errors.Newf("[Rockskip](https://docs.sourcegraph.com/code_intelligence/explanations/rockskip) is currently processing symbols. Estimated completion: %s.", status.Remaining())
+					err = errors.Newf("Still processing symbols ([more details](https://docs.sourcegraph.com/code_intelligence/explanations/rockskip)). Estimated completion: %s.", status.Remaining())
 				}
 			}
 			return


### PR DESCRIPTION
![CleanShot 2022-06-08 at 17 57 02](https://user-images.githubusercontent.com/1387653/172736669-0c3ac807-2e0b-42a9-927f-cb146864dfaf.png)

## Test plan

Ran locally
