### PR TITLE
Logging: fix panic from unset logger in CommitSearcher

### DIFF
--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -1128,6 +1128,7 @@ func (s *Server) search(ctx context.Context, args *protocol.SearchRequest, match
 		}
 
 		searcher := &search.CommitSearcher{
+			Logger:               s.Logger,
 			RepoDir:              dir.Path(),
 			Revisions:            args.Revisions,
 			Query:                mt,

--- a/internal/gitserver/search/search.go
+++ b/internal/gitserver/search/search.go
@@ -81,9 +81,9 @@ const (
 )
 
 type CommitSearcher struct {
-	// logger is a standardized, strongly-typed, and structured logging interface
-	// Production output from this logger (SRC_LOG_FORMAT=json) complies with the OpenTelemetry log data model
-	logger               log.Logger
+	// Logger is a standardized, strongly-typed, and structured logging interface
+	// Production output from this Logger (SRC_LOG_FORMAT=json) complies with the OpenTelemetry log data model
+	Logger               log.Logger
 	RepoDir              string
 	Query                MatchTree
 	Revisions            []protocol.RevisionSpecifier
@@ -156,7 +156,7 @@ func (cs *CommitSearcher) feedBatches(ctx context.Context, jobs chan job, result
 	defer func() {
 		// Always call cmd.Wait to avoid leaving zombie processes around.
 		if e := cmd.Wait(); e != nil {
-			err = errors.Append(err, tryInterpretErrorWithStderr(ctx, err, stderrBuf.String(), cs.logger))
+			err = errors.Append(err, tryInterpretErrorWithStderr(ctx, err, stderrBuf.String(), cs.Logger))
 		}
 	}()
 


### PR DESCRIPTION
Looks like a logger was added to `CommitSearcher` in https://github.com/sourcegraph/sourcegraph/pull/36005, but was never set.
This is causing panics whenever it would be used.

## Test plan

Didn't test, just added the field. 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
