### PR TITLE
Code monitors: fix issues with concurrent access to transactions

### DIFF
--- a/enterprise/internal/codemonitors/search.go
+++ b/enterprise/internal/codemonitors/search.go
@@ -210,11 +210,30 @@ func Snapshot(ctx context.Context, db database.DB, query string, monitorID int64
 		return err
 	}
 
+	// HACK(camdencheek): limit the concurrency of the commit search job
+	// because the db passed into this function might actually be a transaction
+	// and transactions cannot be used concurrently.
+	planJob = limitConcurrency(planJob)
+
 	_, err = planJob.Run(ctx, clients, streaming.NewNullStream())
 	return err
 }
 
 var ErrInvalidMonitorQuery = errors.New("code monitor cannot use different patterns for different repos")
+
+func limitConcurrency(in job.Job) job.Job {
+	return jobutil.MapAtom(in, func(atom job.Job) job.Job {
+		switch typedAtom := atom.(type) {
+		case *commit.SearchJob:
+			jobCopy := *typedAtom
+			jobCopy.Concurrency = 1
+			return &jobCopy
+		default:
+			return atom
+		}
+	})
+
+}
 
 func addCodeMonitorHook(in job.Job, hook commit.CodeMonitorHook) (_ job.Job, err error) {
 	commitSearchJobCount := 0
@@ -229,8 +248,9 @@ func addCodeMonitorHook(in job.Job, hook commit.CodeMonitorHook) (_ job.Job, err
 			jobCopy.CodeMonitorSearchWrapper = hook
 			return &jobCopy
 		case *repos.ComputeExcludedJob, *jobutil.NoopJob:
-			// ComputeExcludedJob is fine for code monitor jobs
-			return atom
+			// ComputeExcludedJob is fine for code monitor jobs, but should be
+			// removed since it's not used
+			return jobutil.NewNoopJob()
 		default:
 			if err == nil {
 				err = errors.Errorf("found invalid atom job type %T for code monitor search", atom)

--- a/internal/search/job/jobutil/job.go
+++ b/internal/search/job/jobutil/job.go
@@ -139,6 +139,7 @@ func NewBasicJob(inputs *run.SearchInputs, b query.Basic) (job.Job, error) {
 				Diff:                 diff,
 				Limit:                int(fileMatchLimit),
 				IncludeModifiedFiles: authz.SubRepoEnabled(authz.DefaultSubRepoPermsChecker),
+				Concurrency:          4,
 			})
 		}
 


### PR DESCRIPTION
This is a super hacky fix for the fact that creating a code monitor
executes in a transaction which must not be used concurrently.

Honestly, this is a really scary problem across the whole codebase.
We have no idea whether the database handles we are using are
actually transactions, so we have no idea whether we can use them
concurrently.

I plan to spend some time immediately on fixing this problem because
I expect I'm not the only one who hits this.

## Test plan

Manually tested that creating a code monitor for a bunch of repos succeeds. 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
