### PR TITLE
Added Descriptive Labels to Branch List on Branches page and Tags List on Tags Page

### DIFF
--- a/client/web/src/components/FilteredConnection/ConnectionNodes.tsx
+++ b/client/web/src/components/FilteredConnection/ConnectionNodes.tsx
@@ -4,7 +4,7 @@ import * as H from 'history'
 
 import { Connection } from './ConnectionType'
 import { ConnectionList, ShowMoreButton, SummaryContainer, ConnectionSummary } from './ui'
-import { hasID, hasNextPage } from './utils'
+import { hasID, hasNextPage, hasDisplayName } from './utils'
 
 /**
  * Props for the FilteredConnection component's result nodes and associated summary/pagination controls.
@@ -83,7 +83,8 @@ export interface ConnectionNodesDisplayProps {
 
     withCenteredSummary?: boolean
 
-    ariaLabelFunction?: string
+    /** A function that generates an aria label given a node display name */
+    ariaLabelFunction?: (displayName: string) => string
 }
 
 interface ConnectionNodesProps<C extends Connection<N>, N, NP = {}, HP = {}>
@@ -119,6 +120,7 @@ export const getTotalCount = <N,>({ totalCount, nodes, pageInfo }: Connection<N>
 export const ConnectionNodes = <C extends Connection<N>, N, NP = {}, HP = {}>({
     nodeComponent: NodeComponent,
     nodeComponentProps,
+    ariaLabelFunction,
     listComponent = 'ul',
     listClassName,
     summaryClassName,
@@ -159,11 +161,10 @@ export const ConnectionNodes = <C extends Connection<N>, N, NP = {}, HP = {}>({
     )
 
     const nodes = connection.nodes.map((node, index) => (
-        // console.log(node)
         <NodeComponent
             key={hasID(node) ? node.id : index}
             node={node}
-            ariaLabel={nodeComponentProps?.ariaLabelFunction && nodeComponentProps?.ariaLabelFunction(node.displayName)}
+            ariaLabel={hasDisplayName(node) && ariaLabelFunction?.(node.displayName)}
             {...nodeComponentProps!}
         />
     ))

--- a/client/web/src/components/FilteredConnection/ConnectionNodes.tsx
+++ b/client/web/src/components/FilteredConnection/ConnectionNodes.tsx
@@ -155,9 +155,20 @@ export const ConnectionNodes = <C extends Connection<N>, N, NP = {}, HP = {}>({
             centered={withCenteredSummary}
         />
     )
-    {console.log(nodeComponentProps)}
+    {
+        console.log(nodeComponentProps)
+    }
     const nodes = connection.nodes.map((node, index) => (
-        <NodeComponent key={hasID(node) ? node.id : index} node={node} ariaLabel={nodeComponentProps && nodeComponentProps.ariaLabelFunction && nodeComponentProps.ariaLabelFunction(node.displayName)} {...nodeComponentProps!} />
+        <NodeComponent
+            key={hasID(node) ? node.id : index}
+            node={node}
+            ariaLabel={
+                nodeComponentProps &&
+                nodeComponentProps.ariaLabelFunction &&
+                nodeComponentProps.ariaLabelFunction(node.displayName)
+            }
+            {...nodeComponentProps!}
+        />
         //
     ))
 

--- a/client/web/src/components/FilteredConnection/ConnectionNodes.tsx
+++ b/client/web/src/components/FilteredConnection/ConnectionNodes.tsx
@@ -155,9 +155,10 @@ export const ConnectionNodes = <C extends Connection<N>, N, NP = {}, HP = {}>({
             centered={withCenteredSummary}
         />
     )
-
+    {console.log(nodeComponentProps)}
     const nodes = connection.nodes.map((node, index) => (
-        <NodeComponent key={hasID(node) ? node.id : index} node={node} {...nodeComponentProps!} />
+        <NodeComponent key={hasID(node) ? node.id : index} node={node} ariaLabel={nodeComponentProps && nodeComponentProps.ariaLabelFunction && nodeComponentProps.ariaLabelFunction(node.displayName)} {...nodeComponentProps!} />
+        //
     ))
 
     return (

--- a/client/web/src/components/FilteredConnection/ConnectionNodes.tsx
+++ b/client/web/src/components/FilteredConnection/ConnectionNodes.tsx
@@ -82,6 +82,8 @@ export interface ConnectionNodesDisplayProps {
     compact?: boolean
 
     withCenteredSummary?: boolean
+
+    ariaLabelFunction?: string
 }
 
 interface ConnectionNodesProps<C extends Connection<N>, N, NP = {}, HP = {}>
@@ -155,21 +157,15 @@ export const ConnectionNodes = <C extends Connection<N>, N, NP = {}, HP = {}>({
             centered={withCenteredSummary}
         />
     )
-    {
-        console.log(nodeComponentProps)
-    }
+
     const nodes = connection.nodes.map((node, index) => (
+        // console.log(node)
         <NodeComponent
             key={hasID(node) ? node.id : index}
             node={node}
-            ariaLabel={
-                nodeComponentProps &&
-                nodeComponentProps.ariaLabelFunction &&
-                nodeComponentProps.ariaLabelFunction(node.displayName)
-            }
+            ariaLabel={nodeComponentProps?.ariaLabelFunction && nodeComponentProps?.ariaLabelFunction(node.displayName)}
             {...nodeComponentProps!}
         />
-        //
     ))
 
     return (

--- a/client/web/src/components/FilteredConnection/FilteredConnection.tsx
+++ b/client/web/src/components/FilteredConnection/FilteredConnection.tsx
@@ -535,7 +535,7 @@ export class FilteredConnection<
                         withCenteredSummary={this.props.withCenteredSummary}
                     />
                 )}
-                {console.log(this.props)}
+                {/* {console.log(this.props)} */}
                 {this.state.loading && (
                     <ConnectionLoading compact={this.props.compact} className={this.props.loaderClassName} />
                 )}

--- a/client/web/src/components/FilteredConnection/FilteredConnection.tsx
+++ b/client/web/src/components/FilteredConnection/FilteredConnection.tsx
@@ -533,7 +533,6 @@ export class FilteredConnection<
                         emptyElement={this.props.emptyElement}
                         totalCountSummaryComponent={this.props.totalCountSummaryComponent}
                         withCenteredSummary={this.props.withCenteredSummary}
-
                     />
                 )}
                 {console.log(this.props)}

--- a/client/web/src/components/FilteredConnection/FilteredConnection.tsx
+++ b/client/web/src/components/FilteredConnection/FilteredConnection.tsx
@@ -507,6 +507,7 @@ export class FilteredConnection<
                     )
                 }
                 {errors.length > 0 && <ConnectionError errors={errors} compact={this.props.compact} />}
+
                 {this.state.connectionOrError && !isErrorLike(this.state.connectionOrError) && (
                     <ConnectionNodes
                         connection={this.state.connectionOrError}
@@ -532,8 +533,10 @@ export class FilteredConnection<
                         emptyElement={this.props.emptyElement}
                         totalCountSummaryComponent={this.props.totalCountSummaryComponent}
                         withCenteredSummary={this.props.withCenteredSummary}
+
                     />
                 )}
+                {console.log(this.props)}
                 {this.state.loading && (
                     <ConnectionLoading compact={this.props.compact} className={this.props.loaderClassName} />
                 )}

--- a/client/web/src/components/FilteredConnection/FilteredConnection.tsx
+++ b/client/web/src/components/FilteredConnection/FilteredConnection.tsx
@@ -75,6 +75,9 @@ interface FilteredConnectionDisplayProps extends ConnectionNodesDisplayProps, Co
      * by the user.
      */
     querySubject?: Subject<string>
+
+    /** A function that generates an aria label given a node display name */
+    ariaLabelFunction?: (displayName: string) => string
 }
 
 /**
@@ -533,6 +536,7 @@ export class FilteredConnection<
                         emptyElement={this.props.emptyElement}
                         totalCountSummaryComponent={this.props.totalCountSummaryComponent}
                         withCenteredSummary={this.props.withCenteredSummary}
+                        ariaLabelFunction={this.props.ariaLabelFunction}
                     />
                 )}
                 {/* {console.log(this.props)} */}

--- a/client/web/src/components/FilteredConnection/FilteredConnection.tsx
+++ b/client/web/src/components/FilteredConnection/FilteredConnection.tsx
@@ -539,7 +539,7 @@ export class FilteredConnection<
                         ariaLabelFunction={this.props.ariaLabelFunction}
                     />
                 )}
-                {/* {console.log(this.props)} */}
+
                 {this.state.loading && (
                     <ConnectionLoading compact={this.props.compact} className={this.props.loaderClassName} />
                 )}

--- a/client/web/src/components/FilteredConnection/utils.ts
+++ b/client/web/src/components/FilteredConnection/utils.ts
@@ -13,6 +13,12 @@ import type { FilteredConnectionFilter, FilteredConnectionFilterValue } from './
 export const hasID = (value: unknown): value is { id: Scalars['ID'] } =>
     typeof value === 'object' && value !== null && hasProperty('id')(value) && typeof value.id === 'string'
 
+export const hasDisplayName = (value: unknown): value is { displayName: Scalars['String'] } =>
+    typeof value === 'object' &&
+    value !== null &&
+    hasProperty('displayName')(value) &&
+    typeof value.displayName === 'string'
+
 export const getFilterFromURL = (
     searchParameters: URLSearchParams,
     filters: FilteredConnectionFilter[] | undefined

--- a/client/web/src/repo/GitReference.tsx
+++ b/client/web/src/repo/GitReference.tsx
@@ -39,6 +39,8 @@ export interface GitReferenceNodeProps {
 
     onClick?: React.MouseEventHandler<HTMLAnchorElement>
     nodeLinkClassName?: string
+
+    ariaLabel?: string
 }
 
 export const GitReferenceNode: React.FunctionComponent<React.PropsWithChildren<GitReferenceNodeProps>> = ({
@@ -50,6 +52,7 @@ export const GitReferenceNode: React.FunctionComponent<React.PropsWithChildren<G
     onClick,
     icon: ReferenceIcon,
     nodeLinkClassName,
+    ariaLabel,
 }) => {
     const mostRecentSig =
         node.target.commit &&
@@ -63,9 +66,11 @@ export const GitReferenceNode: React.FunctionComponent<React.PropsWithChildren<G
         <li key={node.id} className={classNames('d-block list-group-item', styles.gitRefNode, className)}>
             <LinkOrSpan
                 className={classNames(styles.gitRefNodeLink, nodeLinkClassName)}
+
                 to={!ancestorIsLink ? url : undefined}
                 onClick={onClick}
                 data-testid="git-ref-node"
+                aria-label= {ariaLabel}
             >
                 <span className="d-flex align-items-center">
                     {ReferenceIcon && <Icon role="img" className="mr-1" as={ReferenceIcon} aria-hidden={true} />}

--- a/client/web/src/repo/GitReference.tsx
+++ b/client/web/src/repo/GitReference.tsx
@@ -66,11 +66,10 @@ export const GitReferenceNode: React.FunctionComponent<React.PropsWithChildren<G
         <li key={node.id} className={classNames('d-block list-group-item', styles.gitRefNode, className)}>
             <LinkOrSpan
                 className={classNames(styles.gitRefNodeLink, nodeLinkClassName)}
-
                 to={!ancestorIsLink ? url : undefined}
                 onClick={onClick}
                 data-testid="git-ref-node"
-                aria-label= {ariaLabel}
+                aria-label={ariaLabel}
             >
                 <span className="d-flex align-items-center">
                     {ReferenceIcon && <Icon role="img" className="mr-1" as={ReferenceIcon} aria-hidden={true} />}

--- a/client/web/src/repo/branches/RepositoryBranchesAllPage.tsx
+++ b/client/web/src/repo/branches/RepositoryBranchesAllPage.tsx
@@ -30,10 +30,12 @@ export class RepositoryBranchesAllPage extends React.PureComponent<Props> {
                     pluralNoun="branches"
                     queryConnection={this.queryBranches}
                     nodeComponent={GitReferenceNode}
+                    nodeComponentProps={{ariaLabelFunction: (branchDisplayName : string) => `View this repository using ${branchDisplayName} as the selected revision`}}
                     defaultFirst={20}
                     autoFocus={true}
                     history={this.props.history}
                     location={this.props.location}
+                    // ariaLabel={{ariaLabelFunction: (branchDisplayName : string) => `View this repository using ${branchDisplayName} as the selected revision`}}
                 />
             </div>
         )

--- a/client/web/src/repo/branches/RepositoryBranchesAllPage.tsx
+++ b/client/web/src/repo/branches/RepositoryBranchesAllPage.tsx
@@ -30,10 +30,9 @@ export class RepositoryBranchesAllPage extends React.PureComponent<Props> {
                     pluralNoun="branches"
                     queryConnection={this.queryBranches}
                     nodeComponent={GitReferenceNode}
-                    nodeComponentProps={{
-                        ariaLabelFunction: (branchDisplayName: string) =>
-                            `View this repository using ${branchDisplayName} as the selected revision`,
-                    }}
+                    ariaLabelFunction={(branchDisplayName: string) =>
+                        `View this repository using ${branchDisplayName} as the selected revision`
+                    }
                     defaultFirst={20}
                     autoFocus={true}
                     history={this.props.history}

--- a/client/web/src/repo/branches/RepositoryBranchesAllPage.tsx
+++ b/client/web/src/repo/branches/RepositoryBranchesAllPage.tsx
@@ -30,12 +30,14 @@ export class RepositoryBranchesAllPage extends React.PureComponent<Props> {
                     pluralNoun="branches"
                     queryConnection={this.queryBranches}
                     nodeComponent={GitReferenceNode}
-                    nodeComponentProps={{ariaLabelFunction: (branchDisplayName : string) => `View this repository using ${branchDisplayName} as the selected revision`}}
+                    nodeComponentProps={{
+                        ariaLabelFunction: (branchDisplayName: string) =>
+                            `View this repository using ${branchDisplayName} as the selected revision`,
+                    }}
                     defaultFirst={20}
                     autoFocus={true}
                     history={this.props.history}
                     location={this.props.location}
-                    // ariaLabel={{ariaLabelFunction: (branchDisplayName : string) => `View this repository using ${branchDisplayName} as the selected revision`}}
                 />
             </div>
         )

--- a/client/web/src/repo/branches/RepositoryBranchesOverviewPage.tsx
+++ b/client/web/src/repo/branches/RepositoryBranchesOverviewPage.tsx
@@ -133,7 +133,7 @@ export class RepositoryBranchesOverviewPage extends React.PureComponent<Props, S
                             <Card className={styles.card}>
                                 <CardHeader>Default branch</CardHeader>
                                 <ul className="list-group list-group-flush">
-                                    <GitReferenceNode node={this.state.dataOrError.defaultBranch} />
+                                    <GitReferenceNode node={this.state.dataOrError.defaultBranch} ariaLabel={`View this repository using ${this.state.dataOrError.defaultBranch.displayName} as the selected revision`}/>
                                 </ul>
                             </Card>
                         )}
@@ -142,7 +142,7 @@ export class RepositoryBranchesOverviewPage extends React.PureComponent<Props, S
                                 <CardHeader>Active branches</CardHeader>
                                 <ul className="list-group list-group-flush" data-testid="active-branches-list">
                                     {this.state.dataOrError.activeBranches.map((gitReference, index) => (
-                                        <GitReferenceNode key={index} node={gitReference} />
+                                        <GitReferenceNode key={index} node={gitReference} ariaLabel={`View this repository using ${gitReference.displayName} as the selected revision`}/>
                                     ))}
                                     {this.state.dataOrError.hasMoreActiveBranches && (
                                         <Link

--- a/client/web/src/repo/branches/RepositoryBranchesOverviewPage.tsx
+++ b/client/web/src/repo/branches/RepositoryBranchesOverviewPage.tsx
@@ -133,7 +133,10 @@ export class RepositoryBranchesOverviewPage extends React.PureComponent<Props, S
                             <Card className={styles.card}>
                                 <CardHeader>Default branch</CardHeader>
                                 <ul className="list-group list-group-flush">
-                                    <GitReferenceNode node={this.state.dataOrError.defaultBranch} ariaLabel={`View this repository using ${this.state.dataOrError.defaultBranch.displayName} as the selected revision`}/>
+                                    <GitReferenceNode
+                                        node={this.state.dataOrError.defaultBranch}
+                                        ariaLabel={`View this repository using ${this.state.dataOrError.defaultBranch.displayName} as the selected revision`}
+                                    />
                                 </ul>
                             </Card>
                         )}
@@ -142,7 +145,11 @@ export class RepositoryBranchesOverviewPage extends React.PureComponent<Props, S
                                 <CardHeader>Active branches</CardHeader>
                                 <ul className="list-group list-group-flush" data-testid="active-branches-list">
                                     {this.state.dataOrError.activeBranches.map((gitReference, index) => (
-                                        <GitReferenceNode key={index} node={gitReference} ariaLabel={`View this repository using ${gitReference.displayName} as the selected revision`}/>
+                                        <GitReferenceNode
+                                            key={index}
+                                            node={gitReference}
+                                            ariaLabel={`View this repository using ${gitReference.displayName} as the selected revision`}
+                                        />
                                     ))}
                                     {this.state.dataOrError.hasMoreActiveBranches && (
                                         <Link

--- a/client/web/src/repo/releases/RepositoryReleasesTagsPage.tsx
+++ b/client/web/src/repo/releases/RepositoryReleasesTagsPage.tsx
@@ -50,6 +50,9 @@ export const RepositoryReleasesTagsPage: React.FunctionComponent<React.PropsWith
                 pluralNoun="tags"
                 queryConnection={queryTags}
                 nodeComponent={GitReferenceNode}
+                ariaLabelFunction={(tagDisplayName: string) =>
+                    `View this repository using ${tagDisplayName} as the selected revision`
+                }
                 defaultFirst={20}
                 autoFocus={true}
                 history={history}


### PR DESCRIPTION
There are errors in the ComponentNodes.tsx file on the ariaLabel prop however, the file runs and performs as desired. I tested it with the VoiceOver screen reader, and all of the branches on the "Overview" and "All branches" pages were read as desired.


## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-lm-branchlistlabels.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-rwduoeyqwr.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
