### PR TITLE
Backend: remove uses of `basestore.NewWithDB()`

### DIFF
--- a/cmd/repo-updater/repoupdater/server_test.go
+++ b/cmd/repo-updater/repoupdater/server_test.go
@@ -3,7 +3,6 @@ package repoupdater
 import (
 	"bytes"
 	"context"
-	"database/sql"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -163,7 +162,7 @@ func TestServer_EnqueueRepoUpdate(t *testing.T) {
 	}
 
 	initStore := func(db database.DB) repos.Store {
-		store := repos.NewStore(logtest.Scoped(t), db, sql.TxOptions{})
+		store := repos.NewStore(logtest.Scoped(t), db)
 		if err := store.ExternalServiceStore().Upsert(ctx, &svc); err != nil {
 			t.Fatal(err)
 		}
@@ -238,7 +237,7 @@ func TestServer_EnqueueRepoUpdate(t *testing.T) {
 
 func TestServer_RepoLookup(t *testing.T) {
 	db := dbtest.NewDB(t)
-	store := repos.NewStore(logtest.Scoped(t), database.NewDB(db), sql.TxOptions{})
+	store := repos.NewStore(logtest.Scoped(t), database.NewDB(db))
 	ctx := context.Background()
 	clock := timeutil.NewFakeClock(time.Now(), 0)
 	now := clock.Now()

--- a/cmd/repo-updater/shared/main.go
+++ b/cmd/repo-updater/shared/main.go
@@ -2,7 +2,6 @@ package shared
 
 import (
 	"context"
-	"database/sql"
 	_ "embed"
 	"encoding/json"
 	"fmt"
@@ -122,7 +121,7 @@ func Main(enterpriseInit EnterpriseInit) {
 
 	repos.MustRegisterMetrics(db, envvar.SourcegraphDotComMode())
 
-	store := repos.NewStore(logger.Scoped("store", "repo store"), db, sql.TxOptions{Isolation: sql.LevelDefault})
+	store := repos.NewStore(logger.Scoped("store", "repo store"), db)
 	{
 		m := repos.NewStoreMetrics()
 		m.MustRegister(prometheus.DefaultRegisterer)

--- a/cmd/worker/internal/migrations/migrators/external_accounts_migrator.go
+++ b/cmd/worker/internal/migrations/migrators/external_accounts_migrator.go
@@ -2,13 +2,11 @@ package migrators
 
 import (
 	"context"
-	"database/sql"
 
 	"github.com/keegancsmith/sqlf"
 
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/encryption/keyring"
 	"github.com/sourcegraph/sourcegraph/internal/oobmigration"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
@@ -34,8 +32,8 @@ func NewExternalAccountsMigrator(store *basestore.Store) *ExternalAccountsMigrat
 	return &ExternalAccountsMigrator{store: store, BatchSize: 50}
 }
 
-func NewExternalAccountsMigratorWithDB(db dbutil.DB) *ExternalAccountsMigrator {
-	return NewExternalAccountsMigrator(basestore.NewWithDB(db, sql.TxOptions{}))
+func NewExternalAccountsMigratorWithDB(db database.DB) *ExternalAccountsMigrator {
+	return NewExternalAccountsMigrator(basestore.NewWithHandle(db.Handle()))
 }
 
 // ID of the migration row in the out_of_band_migrations table.

--- a/cmd/worker/internal/migrations/migrators/extsvc_config_migrator.go
+++ b/cmd/worker/internal/migrations/migrators/extsvc_config_migrator.go
@@ -2,12 +2,11 @@ package migrators
 
 import (
 	"context"
-	"database/sql"
 
 	"github.com/keegancsmith/sqlf"
 
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/encryption/keyring"
 	"github.com/sourcegraph/sourcegraph/internal/oobmigration"
 	"github.com/sourcegraph/sourcegraph/internal/types"
@@ -34,8 +33,8 @@ func NewExternalServiceConfigMigrator(store *basestore.Store) *ExternalServiceCo
 	return &ExternalServiceConfigMigrator{store: store, BatchSize: 50}
 }
 
-func NewExternalServiceConfigMigratorWithDB(db dbutil.DB) *ExternalServiceConfigMigrator {
-	return NewExternalServiceConfigMigrator(basestore.NewWithDB(db, sql.TxOptions{}))
+func NewExternalServiceConfigMigratorWithDB(db database.DB) *ExternalServiceConfigMigrator {
+	return NewExternalServiceConfigMigrator(basestore.NewWithHandle(db.Handle()))
 }
 
 // ID of the migration row in in the out_of_band_migrations table.

--- a/cmd/worker/internal/migrations/migrators/extsvc_webhook_migrator.go
+++ b/cmd/worker/internal/migrations/migrators/extsvc_webhook_migrator.go
@@ -2,13 +2,11 @@ package migrators
 
 import (
 	"context"
-	"database/sql"
 
 	"github.com/keegancsmith/sqlf"
 
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/oobmigration"
 )
 
@@ -27,8 +25,8 @@ func NewExternalServiceWebhookMigrator(store *basestore.Store) *ExternalServiceW
 	return &ExternalServiceWebhookMigrator{store: store, BatchSize: 50}
 }
 
-func NewExternalServiceWebhookMigratorWithDB(db dbutil.DB) *ExternalServiceWebhookMigrator {
-	return NewExternalServiceWebhookMigrator(basestore.NewWithDB(db, sql.TxOptions{}))
+func NewExternalServiceWebhookMigratorWithDB(db database.DB) *ExternalServiceWebhookMigrator {
+	return NewExternalServiceWebhookMigrator(basestore.NewWithHandle(db.Handle()))
 }
 
 // ID returns the migration row ID in the out_of_band_migrations table.

--- a/cmd/worker/internal/migrations/migrators/extsvc_webhook_migrator_test.go
+++ b/cmd/worker/internal/migrations/migrators/extsvc_webhook_migrator_test.go
@@ -2,7 +2,6 @@ package migrators
 
 import (
 	"context"
-	"database/sql"
 	"encoding/json"
 	"testing"
 
@@ -12,7 +11,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/schema"
@@ -29,7 +27,7 @@ func TestExternalServiceWebhookMigrator(t *testing.T) {
 		var svcs []*types.ExternalService
 
 		es := db.ExternalServices()
-		basestore := basestore.NewWithDB(db, sql.TxOptions{})
+		basestore := basestore.NewWithHandle(db.Handle())
 
 		// Create a trivial external service of each kind, as well as duplicate
 		// services for the external service kinds that support webhooks.
@@ -149,10 +147,10 @@ func TestExternalServiceWebhookMigrator(t *testing.T) {
 		return svcs
 	}
 
-	clearHasWebhooks := func(t *testing.T, ctx context.Context, db dbutil.DB) {
+	clearHasWebhooks := func(t *testing.T, ctx context.Context, db database.DB) {
 		t.Helper()
 
-		basestore := basestore.NewWithDB(db, sql.TxOptions{})
+		basestore := basestore.NewWithHandle(db.Handle())
 		if err := basestore.Exec(
 			ctx,
 			sqlf.Sprintf("UPDATE external_services SET has_webhooks = NULL"),

--- a/cmd/worker/shared/init/codeintel/dbstore.go
+++ b/cmd/worker/shared/init/codeintel/dbstore.go
@@ -31,7 +31,7 @@ var initDBStore = memo.NewMemoizedConstructor(func() (*dbstore.Store, error) {
 		return nil, err
 	}
 
-	return dbstore.NewWithDB(db, observationContext), nil
+	return dbstore.NewWithDB(database.NewDB(db), observationContext), nil
 })
 
 // InitDependencySyncingStore initializes and returns a dependency index store.

--- a/cmd/worker/shared/init/codeintel/dbstore.go
+++ b/cmd/worker/shared/init/codeintel/dbstore.go
@@ -9,6 +9,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/worker/memo"
 	workerdb "github.com/sourcegraph/sourcegraph/cmd/worker/shared/init/db"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/stores/dbstore"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 	dbworkerstore "github.com/sourcegraph/sourcegraph/internal/workerutil/dbworker/store"

--- a/enterprise/cmd/frontend/internal/batches/resolvers/resolver_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/resolver_test.go
@@ -40,7 +40,7 @@ import (
 func TestNullIDResilience(t *testing.T) {
 	ct.MockRSAKeygen(t)
 
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	sr := New(store.New(db, &observation.TestContext, nil))
 
 	s, err := newSchema(database.NewDB(db), sr)

--- a/enterprise/cmd/frontend/internal/batches/webhooks/bitbucketcloud_test.go
+++ b/enterprise/cmd/frontend/internal/batches/webhooks/bitbucketcloud_test.go
@@ -424,7 +424,7 @@ func bitbucketCloudTestSetup(t *testing.T, db *sql.DB) *bstore.Store {
 
 	// Note that tx is wrapped in nestedTx to effectively neuter further use of
 	// transactions within the test.
-	return bstore.NewWithClock(&nestedTx{tx}, &observation.TestContext, nil, clock.Now)
+	return bstore.NewWithClock(database.NewDB(&nestedTx{tx}), &observation.TestContext, nil, clock.Now)
 }
 
 // createBitbucketCloudExternalService creates a mock Bitbucket Cloud service

--- a/enterprise/cmd/frontend/internal/batches/webhooks/gitlab_test.go
+++ b/enterprise/cmd/frontend/internal/batches/webhooks/gitlab_test.go
@@ -542,7 +542,7 @@ func testGitLabWebhook(db *sql.DB) func(*testing.T) {
 			// We can induce an error with a broken database connection.
 			s := gitLabTestSetup(t, db)
 			h := NewGitLabWebhook(s)
-			h.Store = store.NewWithClock(&brokenDB{errors.New("foo")}, &observation.TestContext, nil, s.Clock())
+			h.Store = store.NewWithClock(database.NewDB(&brokenDB{errors.New("foo")}), &observation.TestContext, nil, s.Clock())
 
 			es, err := h.getExternalServiceFromRawID(ctx, "12345")
 			if es != nil {
@@ -602,7 +602,7 @@ func testGitLabWebhook(db *sql.DB) func(*testing.T) {
 				}
 
 				// We can induce an error with a broken database connection.
-				h.Store = store.NewWithClock(&brokenDB{errors.New("foo")}, &observation.TestContext, nil, s.Clock())
+				h.Store = store.NewWithClock(database.NewDB(&brokenDB{errors.New("foo")}), &observation.TestContext, nil, s.Clock())
 
 				err := h.handleEvent(ctx, es, event)
 				if err == nil {
@@ -622,7 +622,7 @@ func testGitLabWebhook(db *sql.DB) func(*testing.T) {
 				}
 
 				// We can induce an error with a broken database connection.
-				h.Store = store.NewWithClock(&brokenDB{errors.New("foo")}, &observation.TestContext, nil, s.Clock())
+				h.Store = store.NewWithClock(database.NewDB(&brokenDB{errors.New("foo")}), &observation.TestContext, nil, s.Clock())
 
 				err := h.handleEvent(ctx, es, event)
 				if err == nil {
@@ -896,7 +896,7 @@ func gitLabTestSetup(t *testing.T, db *sql.DB) *store.Store {
 
 	// Note that tx is wrapped in nestedTx to effectively neuter further use of
 	// transactions within the test.
-	return store.NewWithClock(&nestedTx{tx}, &observation.TestContext, nil, c.Now)
+	return store.NewWithClock(database.NewDB(&nestedTx{tx}), &observation.TestContext, nil, c.Now)
 }
 
 // assertBodyIncludes checks for a specific substring within the given response

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/exists_test.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/exists_test.go
@@ -8,6 +8,7 @@ import (
 
 	store "github.com/sourcegraph/sourcegraph/internal/codeintel/stores/dbstore"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/stores/gitserver"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 )
@@ -41,7 +42,7 @@ func TestFindClosestDumps(t *testing.T) {
 		return
 	})
 
-	resolver := newResolver(mockDBStore, mockLSIFStore, mockGitserverClient, nil, nil, nil, nil, 50, &observation.TestContext, nil)
+	resolver := newResolver(mockDBStore, mockLSIFStore, mockGitserverClient, nil, nil, nil, nil, 50, &observation.TestContext, database.NewMockDB())
 	dumps, err := resolver.findClosestDumps(context.Background(), commitChecker, 42, "deadbeef", "s1/main.go", true, "idx")
 	if err != nil {
 		t.Fatalf("unexpected error finding closest dumps: %s", err)
@@ -101,7 +102,7 @@ func TestFindClosestDumpsInfersClosestUploads(t *testing.T) {
 		return false, nil
 	})
 
-	resolver := newResolver(mockDBStore, mockLSIFStore, mockGitserverClient, nil, nil, nil, nil, 50, &observation.TestContext, nil)
+	resolver := newResolver(mockDBStore, mockLSIFStore, mockGitserverClient, nil, nil, nil, nil, 50, &observation.TestContext, database.NewMockDB())
 	dumps, err := resolver.findClosestDumps(context.Background(), commitChecker, 42, "deadbeef", "s1/main.go", true, "idx")
 	if err != nil {
 		t.Fatalf("unexpected error finding closest dumps: %s", err)
@@ -140,7 +141,7 @@ func TestFindClosestDumpsDoesNotInferClosestUploadForUnknownRepository(t *testin
 	mockGitserverClient := NewMockGitserverClient()
 	commitChecker := newCachedCommitChecker(mockGitserverClient)
 
-	resolver := newResolver(mockDBStore, mockLSIFStore, mockGitserverClient, nil, nil, nil, nil, 50, &observation.TestContext, nil)
+	resolver := newResolver(mockDBStore, mockLSIFStore, mockGitserverClient, nil, nil, nil, nil, 50, &observation.TestContext, database.NewMockDB())
 	dumps, err := resolver.findClosestDumps(context.Background(), commitChecker, 42, "deadbeef", "s1/main.go", true, "idx")
 	if err != nil {
 		t.Fatalf("unexpected error finding closest dumps: %s", err)

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/resolver_test.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/resolver_test.go
@@ -26,7 +26,7 @@ func TestDeleteLSIFUpload(t *testing.T) {
 	users := database.NewStrictMockUserStore()
 	users.GetByCurrentAuthUserFunc.SetDefaultReturn(&types.User{SiteAdmin: true}, nil)
 
-	db := database.NewStrictMockDB()
+	db := database.NewMockDB()
 	db.UsersFunc.SetDefaultReturn(users)
 
 	id := graphql.ID(base64.StdEncoding.EncodeToString([]byte("LSIFUpload:42")))

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/resolver_test.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/resolver_test.go
@@ -6,6 +6,7 @@ import (
 
 	gql "github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
@@ -15,7 +16,7 @@ func TestQueryResolver(t *testing.T) {
 	mockLSIFStore := NewMockLSIFStore()
 	mockGitserverClient := NewMockGitserverClient()
 
-	resolver := NewResolver(mockDBStore, mockLSIFStore, mockGitserverClient, nil, nil, nil, nil, 50, &observation.TestContext, nil)
+	resolver := NewResolver(mockDBStore, mockLSIFStore, mockGitserverClient, nil, nil, nil, nil, 50, &observation.TestContext, database.NewMockDB())
 	queryResolver, err := resolver.QueryResolver(context.Background(), &gql.GitBlobLSIFDataArgs{
 		Repo:      &types.Repo{ID: 50},
 		Commit:    api.CommitID("deadbeef"),

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/upload_retention_test.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/upload_retention_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/stores/dbstore"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 )
@@ -18,7 +19,7 @@ func TestRetentionPolicyOverview(t *testing.T) {
 	mockLSIFStore := NewMockLSIFStore()
 	mockGitserverClient := NewMockGitserverClient()
 
-	resolver := NewResolver(mockDBStore, mockLSIFStore, mockGitserverClient, nil, nil, nil, nil, 50, &observation.TestContext, nil)
+	resolver := NewResolver(mockDBStore, mockLSIFStore, mockGitserverClient, nil, nil, nil, nil, 50, &observation.TestContext, database.NewMockDB())
 
 	mockClock := glock.NewMockClock()
 
@@ -217,7 +218,7 @@ func TestRetentionPolicyOverview_ByVisibility(t *testing.T) {
 	mockLSIFStore := NewMockLSIFStore()
 	mockGitserverClient := NewMockGitserverClient()
 
-	resolver := NewResolver(mockDBStore, mockLSIFStore, mockGitserverClient, nil, nil, nil, nil, 50, &observation.TestContext, nil)
+	resolver := NewResolver(mockDBStore, mockLSIFStore, mockGitserverClient, nil, nil, nil, nil, 50, &observation.TestContext, database.NewMockDB())
 
 	mockClock := glock.NewMockClock()
 

--- a/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers_test.go
+++ b/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers_test.go
@@ -1260,7 +1260,8 @@ func TestTriggerTestEmailAction(t *testing.T) {
 	}
 
 	ctx := actor.WithInternalActor(context.Background())
-	r := newTestResolver(t, nil)
+	db := database.NewDB(dbtest.NewDB(t))
+	r := newTestResolver(t, db)
 
 	namespaceID := relay.MarshalID("User", actor.FromContext(ctx).UID)
 

--- a/enterprise/cmd/frontend/internal/executorqueue/queues/codeintel/queue.go
+++ b/enterprise/cmd/frontend/internal/executorqueue/queues/codeintel/queue.go
@@ -2,7 +2,6 @@ package codeintel
 
 import (
 	"context"
-	"database/sql"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/executorqueue/handler"
 	apiclient "github.com/sourcegraph/sourcegraph/enterprise/internal/executor"
@@ -20,7 +19,7 @@ func QueueOptions(db database.DB, accessToken func() string, observationContext 
 
 	return handler.QueueOptions{
 		Name:              "codeintel",
-		Store:             store.WorkerutilIndexStore(basestore.NewWithDB(db, sql.TxOptions{}), observationContext),
+		Store:             store.WorkerutilIndexStore(basestore.NewWithHandle(db.Handle()), observationContext),
 		RecordTransformer: recordTransformer,
 	}
 }

--- a/enterprise/cmd/frontend/internal/registry/stores/extensions.go
+++ b/enterprise/cmd/frontend/internal/registry/stores/extensions.go
@@ -13,7 +13,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
@@ -126,8 +125,8 @@ type extensionStore struct {
 var _ ExtensionStore = (*extensionStore)(nil)
 
 // Extensions instantiates and returns a new ExtensionsStore with prepared statements.
-func Extensions(db dbutil.DB) ExtensionStore {
-	return &extensionStore{Store: basestore.NewWithDB(db, sql.TxOptions{})}
+func Extensions(db database.DB) ExtensionStore {
+	return &extensionStore{Store: basestore.NewWithHandle(db.Handle())}
 }
 
 // ExtensionsWith instantiates and returns a new ExtensionsStore using the other store handle.

--- a/enterprise/cmd/frontend/internal/registry/stores/extensions_test.go
+++ b/enterprise/cmd/frontend/internal/registry/stores/extensions_test.go
@@ -2,7 +2,6 @@ package stores
 
 import (
 	"context"
-	"database/sql"
 	"encoding/json"
 	"reflect"
 	"testing"
@@ -422,7 +421,7 @@ func TestFeaturedExtensions(t *testing.T) {
 	ctx := context.Background()
 
 	releases := Releases(db)
-	s := &extensionStore{Store: basestore.NewWithDB(db, sql.TxOptions{})}
+	s := &extensionStore{Store: basestore.NewWithHandle(db.Handle())}
 
 	user, err := db.Users().Create(ctx, database.NewUser{Username: "u"})
 	if err != nil {

--- a/enterprise/cmd/frontend/internal/registry/stores/releases.go
+++ b/enterprise/cmd/frontend/internal/registry/stores/releases.go
@@ -10,8 +10,8 @@ import (
 	"github.com/keegancsmith/sqlf"
 	"github.com/lib/pq"
 
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
@@ -70,8 +70,8 @@ type releaseStore struct {
 var _ ReleaseStore = (*releaseStore)(nil)
 
 // Releases instantiates and returns a new ReleasesStore with prepared statements.
-func Releases(db dbutil.DB) ReleaseStore {
-	return &releaseStore{Store: basestore.NewWithDB(db, sql.TxOptions{})}
+func Releases(db database.DB) ReleaseStore {
+	return &releaseStore{Store: basestore.NewWithHandle(db.Handle())}
 }
 
 // ReleasesWith instantiates and returns a new ReleasesStore using the other store handle.

--- a/enterprise/cmd/repo-updater/internal/authz/integration_test.go
+++ b/enterprise/cmd/repo-updater/internal/authz/integration_test.go
@@ -2,7 +2,6 @@ package authz
 
 import (
 	"context"
-	"database/sql"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -14,7 +13,6 @@ import (
 	"github.com/grafana/regexp"
 
 	"github.com/sourcegraph/log/logtest"
-
 	authzGitHub "github.com/sourcegraph/sourcegraph/enterprise/internal/authz/github"
 	edb "github.com/sourcegraph/sourcegraph/enterprise/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
@@ -92,7 +90,7 @@ func TestIntegration_GitHubPermissions(t *testing.T) {
 			testDB := database.NewDB(dbtest.NewDB(t))
 			ctx := actor.WithInternalActor(context.Background())
 
-			reposStore := repos.NewStore(logtest.Scoped(t), database.NewDB(testDB), sql.TxOptions{})
+			reposStore := repos.NewStore(logtest.Scoped(t), database.NewDB(testDB))
 
 			err = reposStore.ExternalServiceStore().Upsert(ctx, &svc)
 			if err != nil {
@@ -173,7 +171,7 @@ func TestIntegration_GitHubPermissions(t *testing.T) {
 			testDB := database.NewDB(dbtest.NewDB(t))
 			ctx := actor.WithInternalActor(context.Background())
 
-			reposStore := repos.NewStore(logtest.Scoped(t), database.NewDB(testDB), sql.TxOptions{})
+			reposStore := repos.NewStore(logtest.Scoped(t), database.NewDB(testDB))
 
 			err = reposStore.ExternalServiceStore().Upsert(ctx, &svc)
 			if err != nil {
@@ -277,7 +275,7 @@ func TestIntegration_GitHubPermissions(t *testing.T) {
 			testDB := database.NewDB(dbtest.NewDB(t))
 			ctx := actor.WithInternalActor(context.Background())
 
-			reposStore := repos.NewStore(logtest.Scoped(t), database.NewDB(testDB), sql.TxOptions{})
+			reposStore := repos.NewStore(logtest.Scoped(t), database.NewDB(testDB))
 
 			err = reposStore.ExternalServiceStore().Upsert(ctx, &svc)
 			if err != nil {
@@ -361,7 +359,7 @@ func TestIntegration_GitHubPermissions(t *testing.T) {
 			testDB := database.NewDB(dbtest.NewDB(t))
 			ctx := actor.WithInternalActor(context.Background())
 
-			reposStore := repos.NewStore(logtest.Scoped(t), database.NewDB(testDB), sql.TxOptions{})
+			reposStore := repos.NewStore(logtest.Scoped(t), database.NewDB(testDB))
 
 			err = reposStore.ExternalServiceStore().Upsert(ctx, &svc)
 			if err != nil {

--- a/enterprise/cmd/repo-updater/internal/authz/perms_syncer_test.go
+++ b/enterprise/cmd/repo-updater/internal/authz/perms_syncer_test.go
@@ -2,7 +2,6 @@ package authz
 
 import (
 	"context"
-	"database/sql"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -16,7 +15,6 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/sourcegraph/log/logtest"
-
 	eauthz "github.com/sourcegraph/sourcegraph/enterprise/internal/authz"
 	edb "github.com/sourcegraph/sourcegraph/enterprise/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/api"
@@ -161,7 +159,7 @@ func TestPermsSyncer_syncUserPerms(t *testing.T) {
 	db.UserEmailsFunc.SetDefaultReturn(userEmails)
 	db.UserExternalAccountsFunc.SetDefaultReturn(externalAccounts)
 
-	reposStore := repos.NewMockStoreFrom(repos.NewStore(logtest.Scoped(t), db, sql.TxOptions{}))
+	reposStore := repos.NewMockStoreFrom(repos.NewStore(logtest.Scoped(t), db))
 	reposStore.ListExternalServiceUserIDsByRepoIDFunc.SetDefaultReturn([]int32{1}, nil)
 	reposStore.ListExternalServicePrivateRepoIDsByUserIDFunc.SetDefaultReturn([]api.RepoID{2, 3, 4}, nil)
 	reposStore.ExternalServiceStoreFunc.SetDefaultReturn(externalServices)
@@ -254,7 +252,7 @@ func TestPermsSyncer_syncUserPerms_noPerms(t *testing.T) {
 	db.UserEmailsFunc.SetDefaultReturn(userEmails)
 	db.UserExternalAccountsFunc.SetDefaultReturn(externalAccounts)
 
-	reposStore := repos.NewMockStoreFrom(repos.NewStore(logtest.Scoped(t), db, sql.TxOptions{}))
+	reposStore := repos.NewMockStoreFrom(repos.NewStore(logtest.Scoped(t), db))
 	reposStore.ListExternalServicePrivateRepoIDsByUserIDFunc.SetDefaultReturn([]api.RepoID{}, nil)
 	reposStore.RepoStoreFunc.SetDefaultReturn(mockRepos)
 	reposStore.ExternalServiceStoreFunc.SetDefaultReturn(externalServices)
@@ -442,7 +440,7 @@ func TestPermsSyncer_syncUserPerms_prefixSpecs(t *testing.T) {
 	db.UserEmailsFunc.SetDefaultReturn(userEmails)
 	db.UserExternalAccountsFunc.SetDefaultReturn(externalAccounts)
 
-	reposStore := repos.NewMockStoreFrom(repos.NewStore(logtest.Scoped(t), db, sql.TxOptions{}))
+	reposStore := repos.NewMockStoreFrom(repos.NewStore(logtest.Scoped(t), db))
 	reposStore.ListExternalServicePrivateRepoIDsByUserIDFunc.SetDefaultReturn([]api.RepoID{}, nil)
 	reposStore.RepoStoreFunc.SetDefaultReturn(mockRepos)
 	reposStore.ExternalServiceStoreFunc.SetDefaultReturn(externalServices)
@@ -513,7 +511,7 @@ func TestPermsSyncer_syncUserPerms_subRepoPermissions(t *testing.T) {
 	db.UserExternalAccountsFunc.SetDefaultReturn(externalAccounts)
 	db.SubRepoPermsFunc.SetDefaultReturn(subRepoPerms)
 
-	reposStore := repos.NewMockStoreFrom(repos.NewStore(logtest.Scoped(t), db, sql.TxOptions{}))
+	reposStore := repos.NewMockStoreFrom(repos.NewStore(logtest.Scoped(t), db))
 	reposStore.ListExternalServicePrivateRepoIDsByUserIDFunc.SetDefaultReturn([]api.RepoID{}, nil)
 	reposStore.RepoStoreFunc.SetDefaultReturn(mockRepos)
 	reposStore.ExternalServiceStoreFunc.SetDefaultReturn(externalServices)
@@ -575,7 +573,7 @@ func TestPermsSyncer_syncRepoPerms(t *testing.T) {
 			nil,
 		)
 
-		reposStore := repos.NewMockStoreFrom(repos.NewStore(logtest.Scoped(t), db, sql.TxOptions{}))
+		reposStore := repos.NewMockStoreFrom(repos.NewStore(logtest.Scoped(t), db))
 		reposStore.ListExternalServiceUserIDsByRepoIDFunc.SetDefaultReturn([]int32{}, nil)
 		reposStore.RepoStoreFunc.SetDefaultReturn(mockRepos)
 
@@ -629,7 +627,7 @@ func TestPermsSyncer_syncRepoPerms(t *testing.T) {
 			nil,
 		)
 
-		reposStore := repos.NewMockStoreFrom(repos.NewStore(logtest.Scoped(t), db, sql.TxOptions{}))
+		reposStore := repos.NewMockStoreFrom(repos.NewStore(logtest.Scoped(t), db))
 		reposStore.ListExternalServiceUserIDsByRepoIDFunc.SetDefaultReturn([]int32{}, nil)
 		reposStore.RepoStoreFunc.SetDefaultReturn(mockRepos)
 
@@ -661,7 +659,7 @@ func TestPermsSyncer_syncRepoPerms(t *testing.T) {
 			nil,
 		)
 
-		reposStore := repos.NewMockStoreFrom(repos.NewStore(logtest.Scoped(t), db, sql.TxOptions{}))
+		reposStore := repos.NewMockStoreFrom(repos.NewStore(logtest.Scoped(t), db))
 		reposStore.ListExternalServiceUserIDsByRepoIDFunc.SetDefaultReturn([]int32{1}, nil)
 		reposStore.RepoStoreFunc.SetDefaultReturn(mockRepos)
 
@@ -707,7 +705,7 @@ func TestPermsSyncer_syncRepoPerms(t *testing.T) {
 		nil,
 	)
 
-	reposStore := repos.NewMockStoreFrom(repos.NewStore(logtest.Scoped(t), db, sql.TxOptions{}))
+	reposStore := repos.NewMockStoreFrom(repos.NewStore(logtest.Scoped(t), db))
 	reposStore.ListExternalServiceUserIDsByRepoIDFunc.SetDefaultReturn([]int32{}, nil)
 	reposStore.RepoStoreFunc.SetDefaultReturn(mockRepos)
 

--- a/enterprise/cmd/worker/internal/batches/dbstore.go
+++ b/enterprise/cmd/worker/internal/batches/dbstore.go
@@ -11,6 +11,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/worker/memo"
 	workerdb "github.com/sourcegraph/sourcegraph/cmd/worker/shared/init/db"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/store"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/encryption/keyring"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
@@ -35,7 +36,7 @@ var initStore = memo.NewMemoizedConstructor(func() (*store.Store, error) {
 		return nil, err
 	}
 
-	return store.New(db, observationContext, keyring.Default().BatchChangesCredentialKey), nil
+	return store.New(database.NewDB(db), observationContext, keyring.Default().BatchChangesCredentialKey), nil
 })
 
 // InitReconcilerWorkerStore initializes and returns a dbworker.Store instance for the reconciler worker.

--- a/enterprise/cmd/worker/internal/batches/migrations/site_credential_migrator_test.go
+++ b/enterprise/cmd/worker/internal/batches/migrations/site_credential_migrator_test.go
@@ -19,7 +19,7 @@ import (
 
 func TestSiteCredentialMigrator(t *testing.T) {
 	ctx := context.Background()
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 
 	cstore := store.New(db, &observation.TestContext, et.TestKey{})
 

--- a/enterprise/cmd/worker/internal/executors/janitor_job.go
+++ b/enterprise/cmd/worker/internal/executors/janitor_job.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/worker/job"
 	workerdb "github.com/sourcegraph/sourcegraph/cmd/worker/shared/init/db"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
 	"github.com/sourcegraph/sourcegraph/internal/services/executors"
@@ -34,7 +35,7 @@ func (j *janitorJob) Routines(ctx context.Context, logger log.Logger) ([]gorouti
 
 	routines := []goroutine.BackgroundRoutine{
 		goroutine.NewPeriodicGoroutine(context.Background(), janitorConfigInst.CleanupTaskInterval, goroutine.HandlerFunc(func(ctx context.Context) error {
-			return executors.New(db).DeleteInactiveHeartbeats(ctx, janitorConfigInst.HeartbeatRecordsMaxAge)
+			return executors.New(database.NewDB(db)).DeleteInactiveHeartbeats(ctx, janitorConfigInst.HeartbeatRecordsMaxAge)
 		})),
 	}
 

--- a/enterprise/cmd/worker/internal/insights/job.go
+++ b/enterprise/cmd/worker/internal/insights/job.go
@@ -48,7 +48,7 @@ func (s *insightsJob) Routines(ctx context.Context, logger log.Logger) ([]gorout
 		return nil, err
 	}
 
-	return background.GetBackgroundJobs(context.Background(), logger, mainAppDb, insightsDB), nil
+	return background.GetBackgroundJobs(context.Background(), logger, database.NewDB(mainAppDb), insightsDB), nil
 }
 
 func NewInsightsJob() job.Job {

--- a/enterprise/cmd/worker/internal/insights/query_runner_job.go
+++ b/enterprise/cmd/worker/internal/insights/query_runner_job.go
@@ -62,7 +62,7 @@ func (s *insightsQueryRunnerJob) Routines(ctx context.Context, logger log.Logger
 		return nil, err
 	}
 
-	return background.GetBackgroundQueryRunnerJob(context.Background(), logger, mainAppDb, insightsDB), nil
+	return background.GetBackgroundQueryRunnerJob(context.Background(), logger, database.NewDB(mainAppDb), insightsDB), nil
 }
 
 func NewInsightsQueryRunnerJob() job.Job {

--- a/enterprise/internal/batches/processor/bulk_processor_test.go
+++ b/enterprise/internal/batches/processor/bulk_processor_test.go
@@ -25,7 +25,7 @@ func TestBulkProcessor(t *testing.T) {
 	sqlDB := dbtest.NewDB(t)
 	tx := dbtest.NewTx(t, sqlDB)
 	db := database.NewDB(sqlDB)
-	bstore := store.New(tx, &observation.TestContext, nil)
+	bstore := store.New(database.NewDB(tx), &observation.TestContext, nil)
 	user := ct.CreateTestUser(t, db, true)
 	repo, _ := ct.CreateTestRepo(t, ctx, db)
 	ct.CreateTestSiteCredential(t, bstore, repo)

--- a/enterprise/internal/batches/store/store.go
+++ b/enterprise/internal/batches/store/store.go
@@ -69,17 +69,16 @@ type Store struct {
 	observationContext *observation.Context
 }
 
-
 // New returns a new Store backed by the given database.
-func New(db dbutil.DB, observationContext *observation.Context, key encryption.Key) *Store {
+func New(db database.DB, observationContext *observation.Context, key encryption.Key) *Store {
 	return NewWithClock(db, observationContext, key, timeutil.Now)
 }
 
 // NewWithClock returns a new Store backed by the given database and
 // clock for timestamps.
-func NewWithClock(db dbutil.DB, observationContext *observation.Context, key encryption.Key, clock func() time.Time) *Store {
+func NewWithClock(db database.DB, observationContext *observation.Context, key encryption.Key, clock func() time.Time) *Store {
 	return &Store{
-		Store:              basestore.NewWithDB(db, sql.TxOptions{}),
+		Store:              basestore.NewWithHandle(db.Handle()),
 		key:                key,
 		now:                clock,
 		operations:         newOperations(observationContext),

--- a/enterprise/internal/batches/store/store.go
+++ b/enterprise/internal/batches/store/store.go
@@ -98,13 +98,9 @@ func (s *Store) Clock() func() time.Time { return s.now }
 // instantiated with.
 // It's here for legacy reason to pass the database.DB to a repos.Store while
 // repos.Store doesn't accept a basestore.TransactableHandle yet.
-func (s *Store) DatabaseDB() database.DB { return database.NewDB(s.Handle().DB()) }
+func (s *Store) DatabaseDB() database.DB { return database.NewDBWith(s) }
 
 var _ basestore.ShareableStore = &Store{}
-
-// Handle returns the underlying transactable database handle.
-// Needed to implement the ShareableStore interface.
-func (s *Store) Handle() *basestore.TransactableHandle { return s.Store.Handle() }
 
 // With creates a new Store with the given basestore.Shareable store as the
 // underlying basestore.Store.

--- a/enterprise/internal/batches/store/store.go
+++ b/enterprise/internal/batches/store/store.go
@@ -69,6 +69,7 @@ type Store struct {
 	observationContext *observation.Context
 }
 
+
 // New returns a new Store backed by the given database.
 func New(db dbutil.DB, observationContext *observation.Context, key encryption.Key) *Store {
 	return NewWithClock(db, observationContext, key, timeutil.Now)

--- a/enterprise/internal/batches/store/store_test.go
+++ b/enterprise/internal/batches/store/store_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	ct "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/testing"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/encryption"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
@@ -24,7 +25,7 @@ func storeTest(db *sql.DB, key encryption.Key, f storeTestFunc) func(*testing.T)
 		// of the tests, so that foreign key constraints can be deferred and we
 		// don't need to insert a lot of dependencies into the DB (users,
 		// repos, ...) to setup the tests.
-		tx := dbtest.NewTx(t, db)
+		tx := database.NewDB(dbtest.NewTx(t, db))
 		s := NewWithClock(tx, &observation.TestContext, key, c.Now)
 
 		f(t, context.Background(), s, c)

--- a/enterprise/internal/batches/store/worker_workspace_execution.go
+++ b/enterprise/internal/batches/store/worker_workspace_execution.go
@@ -87,7 +87,7 @@ type batchSpecWorkspaceExecutionWorkerStore struct {
 }
 
 func (s *batchSpecWorkspaceExecutionWorkerStore) FetchCanceled(ctx context.Context, executorName string) (canceledIDs []int, err error) {
-	batchesStore := New(s.Store.Handle().DB(), s.observationContext, nil)
+	batchesStore := New(database.NewDBWith(s.Store), s.observationContext, nil)
 
 	t := true
 	cs, err := batchesStore.ListBatchSpecWorkspaceExecutionJobs(ctx, ListBatchSpecWorkspaceExecutionJobsOpts{
@@ -121,7 +121,7 @@ func deleteAccessToken(ctx context.Context, deleteToken accessTokenHardDeleter, 
 type markFinal func(ctx context.Context, tx dbworkerstore.Store) (_ bool, err error)
 
 func (s *batchSpecWorkspaceExecutionWorkerStore) markFinal(ctx context.Context, id int, fn markFinal) (ok bool, err error) {
-	batchesStore := New(s.Store.Handle().DB(), s.observationContext, nil)
+	batchesStore := New(database.NewDBWith(s.Store), s.observationContext, nil)
 	tx, err := batchesStore.Transact(ctx)
 	if err != nil {
 		return false, err
@@ -191,7 +191,7 @@ func (s *batchSpecWorkspaceExecutionWorkerStore) MarkFailed(ctx context.Context,
 }
 
 func (s *batchSpecWorkspaceExecutionWorkerStore) MarkComplete(ctx context.Context, id int, options dbworkerstore.MarkFinalOptions) (_ bool, err error) {
-	batchesStore := New(s.Store.Handle().DB(), s.observationContext, nil)
+	batchesStore := New(database.NewDBWith(s.Store), s.observationContext, nil)
 
 	tx, err := batchesStore.Transact(ctx)
 	if err != nil {

--- a/enterprise/internal/codemonitors/background/workers_test.go
+++ b/enterprise/internal/codemonitors/background/workers_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/sourcegraph/log/logtest"
 
 	edb "github.com/sourcegraph/sourcegraph/enterprise/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
 )
@@ -39,7 +40,7 @@ func TestActionRunner(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			db := dbtest.NewDB(t)
+			db := database.NewDB(dbtest.NewDB(t))
 			testQuery := "test patternType:literal"
 			externalURL := "https://www.sourcegraph.com"
 

--- a/enterprise/internal/database/authz.go
+++ b/enterprise/internal/database/authz.go
@@ -8,13 +8,12 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 // NewAuthzStore returns an OSS database.AuthzStore set with enterprise implementation.
-func NewAuthzStore(db dbutil.DB, clock func() time.Time) database.AuthzStore {
+func NewAuthzStore(db database.DB, clock func() time.Time) database.AuthzStore {
 	return &authzStore{
 		store: Perms(db, clock),
 	}

--- a/enterprise/internal/database/integration_test.go
+++ b/enterprise/internal/database/integration_test.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"testing"
 
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 )
 
@@ -28,7 +29,7 @@ func TestIntegration_PermsStore(t *testing.T) {
 
 	t.Parallel()
 
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 
 	for _, tc := range []struct {
 		name string

--- a/enterprise/internal/database/perms_store.go
+++ b/enterprise/internal/database/perms_store.go
@@ -13,6 +13,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
@@ -193,12 +194,12 @@ type permsStore struct {
 var _ PermsStore = (*permsStore)(nil)
 
 // Perms returns a new PermsStore with given parameters.
-func Perms(db dbutil.DB, clock func() time.Time) PermsStore {
+func Perms(db database.DB, clock func() time.Time) PermsStore {
 	return perms(db, clock)
 }
 
-func perms(db dbutil.DB, clock func() time.Time) *permsStore {
-	return &permsStore{Store: basestore.NewWithDB(db, sql.TxOptions{}), clock: clock}
+func perms(db database.DB, clock func() time.Time) *permsStore {
+	return &permsStore{Store: basestore.NewWithHandle(db.Handle()), clock: clock}
 }
 
 func PermsWith(other basestore.ShareableStore, clock func() time.Time) PermsStore {

--- a/enterprise/internal/insights/background/background.go
+++ b/enterprise/internal/insights/background/background.go
@@ -7,20 +7,16 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/sourcegraph/log"
-
-	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/background/pings"
-	"github.com/sourcegraph/sourcegraph/internal/database"
-
-	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/discovery"
-
-	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/compression"
-
 	"github.com/opentracing/opentracing-go"
 	"github.com/prometheus/client_golang/prometheus"
 
+	"github.com/sourcegraph/log"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/background/pings"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/background/queryrunner"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/compression"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/discovery"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/store"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
@@ -31,13 +27,13 @@ import (
 
 // GetBackgroundJobs is the main entrypoint which starts background jobs for code insights. It is
 // called from the worker service.
-func GetBackgroundJobs(ctx context.Context, logger log.Logger, mainAppDB *sql.DB, insightsDB *sql.DB) []goroutine.BackgroundRoutine {
+func GetBackgroundJobs(ctx context.Context, logger log.Logger, mainAppDB database.DB, insightsDB *sql.DB) []goroutine.BackgroundRoutine {
 	insightPermStore := store.NewInsightPermissionStore(mainAppDB)
 	insightsStore := store.New(insightsDB, insightPermStore)
 
 	// Create a base store to be used for storing worker state. We store this in the main app Postgres
 	// DB, not the insights DB (which we use only for storing insights data.)
-	workerBaseStore := basestore.NewWithDB(mainAppDB, sql.TxOptions{})
+	workerBaseStore := basestore.NewWithHandle(mainAppDB.Handle())
 
 	// Create basic metrics for recording information about background jobs.
 	observationContext := &observation.Context{
@@ -87,13 +83,13 @@ func GetBackgroundJobs(ctx context.Context, logger log.Logger, mainAppDB *sql.DB
 
 // GetBackgroundQueryRunnerJob is the main entrypoint for starting the background jobs for code
 // insights query runner. It is called from the worker service.
-func GetBackgroundQueryRunnerJob(ctx context.Context, logger log.Logger, mainAppDB *sql.DB, insightsDB *sql.DB) []goroutine.BackgroundRoutine {
+func GetBackgroundQueryRunnerJob(ctx context.Context, logger log.Logger, mainAppDB database.DB, insightsDB *sql.DB) []goroutine.BackgroundRoutine {
 	insightPermStore := store.NewInsightPermissionStore(mainAppDB)
 	insightsStore := store.New(insightsDB, insightPermStore)
 
 	// Create a base store to be used for storing worker state. We store this in the main app Postgres
 	// DB, not the insights DB (which we use only for storing insights data.)
-	workerBaseStore := basestore.NewWithDB(mainAppDB, sql.TxOptions{})
+	workerBaseStore := basestore.NewWithHandle(mainAppDB.Handle())
 	repoStore := database.NewDB(mainAppDB).Repos()
 
 	// Create basic metrics for recording information about background jobs.

--- a/enterprise/internal/insights/background/data_prune.go
+++ b/enterprise/internal/insights/background/data_prune.go
@@ -2,23 +2,21 @@ package background
 
 import (
 	"context"
-	"database/sql"
 	"time"
 
-	"github.com/keegancsmith/sqlf"
-	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
-
 	"github.com/inconshreveable/log15"
-	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"github.com/keegancsmith/sqlf"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/store"
-
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 // NewInsightsDataPrunerJob will periodically delete recorded data series that have been marked `deleted`.
-func NewInsightsDataPrunerJob(ctx context.Context, postgres dbutil.DB, insightsdb dbutil.DB) goroutine.BackgroundRoutine {
+func NewInsightsDataPrunerJob(ctx context.Context, postgres database.DB, insightsdb dbutil.DB) goroutine.BackgroundRoutine {
 	interval := time.Minute * 60
 
 	return goroutine.NewPeriodicGoroutine(ctx, interval,
@@ -27,7 +25,7 @@ func NewInsightsDataPrunerJob(ctx context.Context, postgres dbutil.DB, insightsd
 		}))
 }
 
-func performPurge(ctx context.Context, postgres dbutil.DB, insightsdb dbutil.DB, deletedBefore time.Time) (err error) {
+func performPurge(ctx context.Context, postgres database.DB, insightsdb dbutil.DB, deletedBefore time.Time) (err error) {
 	insightStore := store.NewInsightStore(insightsdb)
 	timeseriesStore := store.New(insightsdb, store.NewInsightPermissionStore(postgres))
 
@@ -72,8 +70,8 @@ func performPurge(ctx context.Context, postgres dbutil.DB, insightsdb dbutil.DB,
 	return err
 }
 
-func deleteQueuedRecords(ctx context.Context, postgres dbutil.DB, seriesId string) error {
-	queueStore := basestore.NewWithDB(postgres, sql.TxOptions{})
+func deleteQueuedRecords(ctx context.Context, postgres database.DB, seriesId string) error {
+	queueStore := basestore.NewWithHandle(postgres.Handle())
 	return queueStore.Exec(ctx, sqlf.Sprintf(deleteQueuedForSeries, seriesId))
 }
 

--- a/enterprise/internal/insights/background/data_prune_test.go
+++ b/enterprise/internal/insights/background/data_prune_test.go
@@ -2,21 +2,17 @@ package background
 
 import (
 	"context"
-	"database/sql"
 	"testing"
 	"time"
 
-	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/background/queryrunner"
-
 	"github.com/keegancsmith/sqlf"
 
-	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
-
-	"github.com/sourcegraph/sourcegraph/internal/api"
-
-	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/types"
-
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/background/queryrunner"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/store"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/types"
+	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/timeutil"
 )
@@ -29,11 +25,11 @@ func TestPerformPurge(t *testing.T) {
 	ctx := context.Background()
 	clock := timeutil.Now
 	insightsDB := dbtest.NewInsightsDB(t)
-	postgres := dbtest.NewDB(t)
+	postgres := database.NewDB(dbtest.NewDB(t))
 	permStore := store.NewInsightPermissionStore(postgres)
 	timeseriesStore := store.NewWithClock(insightsDB, permStore, clock)
 	insightStore := store.NewInsightStore(insightsDB)
-	workerBaseStore := basestore.NewWithDB(postgres, sql.TxOptions{})
+	workerBaseStore := basestore.NewWithHandle(postgres.Handle())
 
 	getTimeSeriesCountForSeries := func(ctx context.Context, seriesId string) int {
 		q := sqlf.Sprintf("select count(*) from series_points where series_id = %s;", seriesId)

--- a/enterprise/internal/insights/background/queryrunner/worker.go
+++ b/enterprise/internal/insights/background/queryrunner/worker.go
@@ -78,7 +78,7 @@ func NewWorker(ctx context.Context, logger log.Logger, workerStore dbworkerstore
 	}))
 
 	return dbworker.NewWorker(ctx, workerStore, &workHandler{
-		baseWorkerStore: basestore.NewWithDB(workerStore.Handle().DB(), sql.TxOptions{}),
+		baseWorkerStore: basestore.NewWithHandle(workerStore.Handle()),
 		insightsStore:   insightsStore,
 		repoStore:       repoStore,
 		limiter:         limiter,

--- a/enterprise/internal/insights/background/queryrunner/worker_test.go
+++ b/enterprise/internal/insights/background/queryrunner/worker_test.go
@@ -2,33 +2,30 @@ package queryrunner
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
 	"testing"
 	"time"
 
-	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/compression"
-
-	"github.com/sourcegraph/sourcegraph/internal/insights/priority"
-
-	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/store"
-
 	"github.com/hexops/autogold"
 
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/compression"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/store"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
+	"github.com/sourcegraph/sourcegraph/internal/insights/priority"
 )
 
 // TestJobQueue tests that EnqueueJob and dequeueJob work mutually to transfer jobs to/from the
 // database.
 func TestJobQueue(t *testing.T) {
 	t.Parallel()
-	mainAppDB := dbtest.NewDB(t)
+	mainAppDB := database.NewDB(dbtest.NewDB(t))
 
 	ctx := actor.WithInternalActor(context.Background())
 
-	workerBaseStore := basestore.NewWithDB(mainAppDB, sql.TxOptions{})
+	workerBaseStore := basestore.NewWithHandle(mainAppDB.Handle())
 
 	// Check we get no dequeued job first.
 	recordID := 0
@@ -75,10 +72,10 @@ func TestJobQueue(t *testing.T) {
 
 func TestJobQueueDependencies(t *testing.T) {
 	t.Parallel()
-	mainAppDB := dbtest.NewDB(t)
+	mainAppDB := database.NewDB(dbtest.NewDB(t))
 
 	ctx := actor.WithInternalActor(context.Background())
-	workerBaseStore := basestore.NewWithDB(mainAppDB, sql.TxOptions{})
+	workerBaseStore := basestore.NewWithHandle(mainAppDB.Handle())
 
 	t.Run("enqueue without dependencies, get none back", func(t *testing.T) {
 		id, err := EnqueueJob(ctx, workerBaseStore, &Job{

--- a/enterprise/internal/insights/migration/migration.go
+++ b/enterprise/internal/insights/migration/migration.go
@@ -49,7 +49,7 @@ func NewMigrator(insightsDB dbutil.DB, postgresDB database.DB) oobmigration.Migr
 		insightStore:               store.NewInsightStore(insightsDB),
 		dashboardStore:             store.NewDashboardStore(insightsDB),
 		orgStore:                   postgresDB.Orgs(),
-		workerBaseStore:            basestore.NewWithDB(postgresDB, sql.TxOptions{}),
+		workerBaseStore:            basestore.NewWithHandle(postgresDB.Handle()),
 	}
 }
 

--- a/enterprise/internal/insights/resolvers/insight_view_resolvers_test.go
+++ b/enterprise/internal/insights/resolvers/insight_view_resolvers_test.go
@@ -2,7 +2,6 @@ package resolvers
 
 import (
 	"context"
-	"database/sql"
 	"sort"
 	"testing"
 
@@ -174,7 +173,7 @@ func TestFrozenInsightDataSeriesResolver(t *testing.T) {
 			insightStore:    store.NewInsightStore(insightsDB),
 			dashboardStore:  store.NewDashboardStore(insightsDB),
 			insightsDB:      insightsDB,
-			workerBaseStore: basestore.NewWithDB(postgres, sql.TxOptions{}),
+			workerBaseStore: basestore.NewWithHandle(postgres.Handle()),
 			postgresDB:      postgres,
 			timeSeriesStore: timeseriesStore,
 		}

--- a/enterprise/internal/insights/resolvers/resolver.go
+++ b/enterprise/internal/insights/resolvers/resolver.go
@@ -2,7 +2,6 @@ package resolvers
 
 import (
 	"context"
-	"database/sql"
 	"time"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/background"
@@ -38,7 +37,7 @@ func WithBase(insightsDB dbutil.DB, primaryDB database.DB, clock func() time.Tim
 	insightStore := store.NewInsightStore(insightsDB)
 	timeSeriesStore := store.NewWithClock(insightsDB, store.NewInsightPermissionStore(primaryDB), clock)
 	dashboardStore := store.NewDashboardStore(insightsDB)
-	workerBaseStore := basestore.NewWithDB(primaryDB, sql.TxOptions{})
+	workerBaseStore := basestore.NewWithHandle(primaryDB.Handle())
 
 	return &baseInsightResolver{
 		insightStore:    insightStore,

--- a/enterprise/internal/insights/store/permissions.go
+++ b/enterprise/internal/insights/store/permissions.go
@@ -9,7 +9,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
@@ -52,9 +51,9 @@ const fetchUnauthorizedReposSql = `
 -- source: enterprise/internal/insights/resolver/permissions.go:FetchUnauthorizedRepos
 	SELECT id FROM repo WHERE NOT`
 
-func NewInsightPermissionStore(db dbutil.DB) *InsightPermStore {
+func NewInsightPermissionStore(db database.DB) *InsightPermStore {
 	return &InsightPermStore{
-		Store: basestore.NewWithDB(db, sql.TxOptions{}),
+		Store: basestore.NewWithHandle(db.Handle()),
 	}
 }
 

--- a/enterprise/internal/insights/store/settings_migration_jobs_store.go
+++ b/enterprise/internal/insights/store/settings_migration_jobs_store.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/keegancsmith/sqlf"
 
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 )
 
 type SettingsMigrationJob struct {
@@ -28,8 +28,8 @@ type DBSettingsMigrationJobsStore struct {
 	Now func() time.Time
 }
 
-func NewSettingsMigrationJobsStore(db dbutil.DB) *DBSettingsMigrationJobsStore {
-	return &DBSettingsMigrationJobsStore{Store: basestore.NewWithDB(db, sql.TxOptions{}), Now: time.Now}
+func NewSettingsMigrationJobsStore(db database.DB) *DBSettingsMigrationJobsStore {
+	return &DBSettingsMigrationJobsStore{Store: basestore.NewWithHandle(db.Handle()), Now: time.Now}
 }
 
 func (s *DBSettingsMigrationJobsStore) Handle() *basestore.TransactableHandle {

--- a/enterprise/internal/insights/store/store_test.go
+++ b/enterprise/internal/insights/store/store_test.go
@@ -5,19 +5,15 @@ import (
 	"testing"
 	"time"
 
-	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
-
-	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/types"
-
+	"github.com/google/go-cmp/cmp"
+	"github.com/hexops/autogold"
 	"github.com/keegancsmith/sqlf"
 
-	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
-
-	"github.com/google/go-cmp/cmp"
-
-	"github.com/hexops/autogold"
-
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/types"
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/timeutil"
 )
 
@@ -30,7 +26,7 @@ func TestSeriesPoints(t *testing.T) {
 	clock := timeutil.Now
 	insightsDB := dbtest.NewInsightsDB(t)
 
-	postgres := dbtest.NewDB(t)
+	postgres := database.NewDB(dbtest.NewDB(t))
 	permStore := NewInsightPermissionStore(postgres)
 	store := NewWithClock(insightsDB, permStore, clock)
 
@@ -137,7 +133,7 @@ func TestCountData(t *testing.T) {
 	ctx := context.Background()
 	clock := timeutil.Now
 	insightsDB := dbtest.NewInsightsDB(t)
-	postgres := dbtest.NewDB(t)
+	postgres := database.NewDB(dbtest.NewDB(t))
 	permStore := NewInsightPermissionStore(postgres)
 	store := NewWithClock(insightsDB, permStore, clock)
 
@@ -234,7 +230,7 @@ func TestRecordSeriesPoints(t *testing.T) {
 	ctx := context.Background()
 	clock := timeutil.Now
 	insightsDB := dbtest.NewInsightsDB(t)
-	postgres := dbtest.NewDB(t)
+	postgres := database.NewDB(dbtest.NewDB(t))
 	permStore := NewInsightPermissionStore(postgres)
 	store := NewWithClock(insightsDB, permStore, clock)
 
@@ -337,7 +333,7 @@ func TestRecordSeriesPointsSnapshotOnly(t *testing.T) {
 	ctx := context.Background()
 	clock := timeutil.Now
 	insightsDB := dbtest.NewInsightsDB(t)
-	postgres := dbtest.NewDB(t)
+	postgres := database.NewDB(dbtest.NewDB(t))
 	permStore := NewInsightPermissionStore(postgres)
 	store := NewWithClock(insightsDB, permStore, clock)
 
@@ -402,7 +398,7 @@ func TestRecordSeriesPointsRecordingOnly(t *testing.T) {
 	ctx := context.Background()
 	clock := timeutil.Now
 	insightsDB := dbtest.NewInsightsDB(t)
-	postgres := dbtest.NewDB(t)
+	postgres := database.NewDB(dbtest.NewDB(t))
 	permStore := NewInsightPermissionStore(postgres)
 	store := NewWithClock(insightsDB, permStore, clock)
 
@@ -467,7 +463,7 @@ func TestDeleteSnapshots(t *testing.T) {
 	ctx := context.Background()
 	clock := timeutil.Now
 	insightsDB := dbtest.NewInsightsDB(t)
-	postgres := dbtest.NewDB(t)
+	postgres := database.NewDB(dbtest.NewDB(t))
 	permStore := NewInsightPermissionStore(postgres)
 	store := NewWithClock(insightsDB, permStore, clock)
 
@@ -552,7 +548,7 @@ func TestDelete(t *testing.T) {
 	repoName := "reallygreatrepo"
 	repoId := api.RepoID(5)
 
-	postgres := dbtest.NewDB(t)
+	postgres := database.NewDB(dbtest.NewDB(t))
 	permStore := NewInsightPermissionStore(postgres)
 	timeseriesStore := NewWithClock(insightsdb, permStore, clock)
 

--- a/enterprise/internal/notebooks/store.go
+++ b/enterprise/internal/notebooks/store.go
@@ -11,6 +11,7 @@ import (
 	"github.com/keegancsmith/sqlf"
 
 	"github.com/sourcegraph/sourcegraph/internal/actor"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
@@ -61,8 +62,8 @@ func (blocks *NotebookBlocks) Scan(value any) error {
 	return json.Unmarshal(b, &blocks)
 }
 
-func Notebooks(db dbutil.DB) NotebooksStore {
-	store := basestore.NewWithDB(db, sql.TxOptions{})
+func Notebooks(db database.DB) NotebooksStore {
+	store := basestore.NewWithHandle(db.Handle())
 	return &notebooksStore{store}
 }
 

--- a/internal/codeintel/autoindexing/internal/store/store.go
+++ b/internal/codeintel/autoindexing/internal/store/store.go
@@ -2,14 +2,13 @@ package store
 
 import (
 	"context"
-	"database/sql"
 
 	"github.com/keegancsmith/sqlf"
 	"github.com/opentracing/opentracing-go/log"
 
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/autoindexing/shared"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
@@ -26,9 +25,9 @@ type store struct {
 }
 
 // New returns a new autoindexing store.
-func New(db dbutil.DB, observationContext *observation.Context) Store {
+func New(db database.DB, observationContext *observation.Context) Store {
 	return &store{
-		db:         basestore.NewWithDB(db, sql.TxOptions{}),
+		db:         basestore.NewWithHandle(db.Handle()),
 		operations: newOperations(observationContext),
 	}
 }

--- a/internal/codeintel/dependencies/internal/store/store.go
+++ b/internal/codeintel/dependencies/internal/store/store.go
@@ -2,7 +2,6 @@ package store
 
 import (
 	"context"
-	"database/sql"
 	"time"
 
 	"github.com/keegancsmith/sqlf"
@@ -12,6 +11,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/dependencies/shared"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/types"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/database/batch"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
@@ -39,9 +39,9 @@ type store struct {
 }
 
 // New returns a new store.
-func New(db dbutil.DB, op *observation.Context) *store {
+func New(db database.DB, op *observation.Context) *store {
 	return &store{
-		db:         basestore.NewWithDB(db, sql.TxOptions{}),
+		db:         basestore.NewWithHandle(db.Handle()),
 		operations: newOperations(op),
 	}
 }

--- a/internal/codeintel/documents/internal/store/store.go
+++ b/internal/codeintel/documents/internal/store/store.go
@@ -2,14 +2,13 @@ package store
 
 import (
 	"context"
-	"database/sql"
 
 	"github.com/keegancsmith/sqlf"
 	"github.com/opentracing/opentracing-go/log"
 
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/documents/shared"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
@@ -26,9 +25,9 @@ type store struct {
 }
 
 // New returns a new documents store.
-func New(db dbutil.DB, observationContext *observation.Context) Store {
+func New(db database.DB, observationContext *observation.Context) Store {
 	return &store{
-		db:         basestore.NewWithDB(db, sql.TxOptions{}),
+		db:         basestore.NewWithHandle(db.Handle()),
 		operations: newOperations(observationContext),
 	}
 }

--- a/internal/codeintel/policies/internal/store/store.go
+++ b/internal/codeintel/policies/internal/store/store.go
@@ -2,14 +2,13 @@ package store
 
 import (
 	"context"
-	"database/sql"
 
 	"github.com/keegancsmith/sqlf"
 	"github.com/opentracing/opentracing-go/log"
 
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/policies/shared"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
@@ -26,9 +25,9 @@ type store struct {
 }
 
 // New returns a new policies store.
-func New(db dbutil.DB, observationContext *observation.Context) *store {
+func New(db database.DB, observationContext *observation.Context) *store {
 	return &store{
-		db:         basestore.NewWithDB(db, sql.TxOptions{}),
+		db:         basestore.NewWithHandle(db.Handle()),
 		operations: newOperations(observationContext),
 	}
 }

--- a/internal/codeintel/stores/dbstore/audit_logs_test.go
+++ b/internal/codeintel/stores/dbstore/audit_logs_test.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"testing"
 
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 )
 
 func TestUploadAuditLogs(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	store := testStore(db)
 
 	insertUploads(t, db, Upload{ID: 1})

--- a/internal/codeintel/stores/dbstore/commits_test.go
+++ b/internal/codeintel/stores/dbstore/commits_test.go
@@ -18,12 +18,13 @@ import (
 	"github.com/keegancsmith/sqlf"
 
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/commitgraph"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 )
 
 func TestHasRepository(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	store := testStore(db)
 
 	testCases := []struct {
@@ -54,7 +55,7 @@ func TestHasRepository(t *testing.T) {
 }
 
 func TestHasCommit(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	store := testStore(db)
 
 	testCases := []struct {
@@ -86,7 +87,7 @@ func TestHasCommit(t *testing.T) {
 }
 
 func TestMarkRepositoryAsDirty(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	store := testStore(db)
 
 	for _, id := range []int{50, 51, 52} {
@@ -116,7 +117,7 @@ func TestMarkRepositoryAsDirty(t *testing.T) {
 }
 
 func TestMaxStaleAge(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	store := testStore(db)
 
 	for _, id := range []int{50, 51, 52} {
@@ -149,7 +150,7 @@ func TestMaxStaleAge(t *testing.T) {
 }
 
 func TestSkipsDeletedRepositories(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	store := testStore(db)
 
 	insertRepo(t, db, 50, "should not be dirty")
@@ -224,7 +225,7 @@ func TestCommitGraphMetadata(t *testing.T) {
 }
 
 func TestCalculateVisibleUploads(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	store := testStore(db)
 
 	// This database has the following commit graph:
@@ -282,7 +283,7 @@ func TestCalculateVisibleUploads(t *testing.T) {
 }
 
 func TestCalculateVisibleUploadsAlternateCommitGraph(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	store := testStore(db)
 
 	// This database has the following commit graph:
@@ -334,7 +335,7 @@ func TestCalculateVisibleUploadsAlternateCommitGraph(t *testing.T) {
 }
 
 func TestCalculateVisibleUploadsDistinctRoots(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	store := testStore(db)
 
 	// This database has the following commit graph:
@@ -376,7 +377,7 @@ func TestCalculateVisibleUploadsDistinctRoots(t *testing.T) {
 }
 
 func TestCalculateVisibleUploadsOverlappingRoots(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	store := testStore(db)
 
 	// This database has the following commit graph:
@@ -450,7 +451,7 @@ func TestCalculateVisibleUploadsOverlappingRoots(t *testing.T) {
 }
 
 func TestCalculateVisibleUploadsIndexerName(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	store := testStore(db)
 
 	// This database has the following commit graph:
@@ -505,7 +506,7 @@ func TestCalculateVisibleUploadsIndexerName(t *testing.T) {
 }
 
 func TestCalculateVisibleUploadsResetsDirtyFlag(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	store := testStore(db)
 
 	uploads := []Upload{
@@ -571,7 +572,7 @@ func TestCalculateVisibleUploadsResetsDirtyFlag(t *testing.T) {
 }
 
 func TestCalculateVisibleUploadsResetsDirtyFlagTransactionTimestamp(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	store := testStore(db)
 
 	uploads := []Upload{
@@ -605,7 +606,7 @@ func TestCalculateVisibleUploadsResetsDirtyFlagTransactionTimestamp(t *testing.T
 }
 
 func TestCalculateVisibleUploadsNonDefaultBranches(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	store := testStore(db)
 
 	// This database has the following commit graph:
@@ -697,7 +698,7 @@ func TestCalculateVisibleUploadsNonDefaultBranches(t *testing.T) {
 }
 
 func TestCalculateVisibleUploadsNonDefaultBranchesWithCustomRetentionConfiguration(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	store := testStore(db)
 
 	// This database has the following commit graph:
@@ -737,7 +738,7 @@ func TestCalculateVisibleUploadsNonDefaultBranchesWithCustomRetentionConfigurati
 			3600
 		)
 	`
-	if _, err := db.Exec(retentionConfigurationQuery); err != nil {
+	if _, err := db.ExecContext(context.Background(), retentionConfigurationQuery); err != nil {
 		t.Fatalf("unexpected error inserting retention configuration: %s", err)
 	}
 
@@ -856,7 +857,7 @@ func keysOf(m map[string][]int) (keys []string) {
 //
 
 func BenchmarkCalculateVisibleUploads(b *testing.B) {
-	db := dbtest.NewDB(b)
+	db := database.NewDB(dbtest.NewDB(b))
 	store := testStore(db)
 
 	graph, err := readBenchmarkCommitGraph()

--- a/internal/codeintel/stores/dbstore/commits_test.go
+++ b/internal/codeintel/stores/dbstore/commits_test.go
@@ -183,7 +183,7 @@ func TestSkipsDeletedRepositories(t *testing.T) {
 }
 
 func TestCommitGraphMetadata(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	store := testStore(db)
 
 	if err := store.MarkRepositoryAsDirty(context.Background(), 50); err != nil {

--- a/internal/codeintel/stores/dbstore/configuration_policies_test.go
+++ b/internal/codeintel/stores/dbstore/configuration_policies_test.go
@@ -376,7 +376,7 @@ func TestUpdateProtectedConfigurationPolicy(t *testing.T) {
 	}
 
 	// Mark configuration policy as protected (no other way to do so outside of migrations)
-	if _, err := db.Exec("UPDATE lsif_configuration_policies SET protected = true"); err != nil {
+	if _, err := db.ExecContext(context.Background(), "UPDATE lsif_configuration_policies SET protected = true"); err != nil {
 		t.Fatalf("unexpected error marking configuration policy as protected: %s", err)
 	}
 
@@ -527,7 +527,7 @@ func TestDeleteConfigurationProtectedPolicy(t *testing.T) {
 	}
 
 	// Mark configuration policy as protected (no other way to do so outside of migrations)
-	if _, err := db.Exec("UPDATE lsif_configuration_policies SET protected = true"); err != nil {
+	if _, err := db.ExecContext(context.Background(), "UPDATE lsif_configuration_policies SET protected = true"); err != nil {
 		t.Fatalf("unexpected error marking configuration policy as protected: %s", err)
 	}
 

--- a/internal/codeintel/stores/dbstore/configuration_policies_test.go
+++ b/internal/codeintel/stores/dbstore/configuration_policies_test.go
@@ -148,7 +148,7 @@ func TestGetConfigurationPolicies(t *testing.T) {
 }
 
 func TestGetConfigurationPolicyByID(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	store := testStoreWithoutConfigurationPolicies(t, db)
 	ctx := context.Background()
 
@@ -223,7 +223,7 @@ func TestGetConfigurationPolicyByID(t *testing.T) {
 }
 
 func TestGetConfigurationPolicyByIDUnknownID(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	store := testStoreWithoutConfigurationPolicies(t, db)
 
 	_, ok, err := store.GetConfigurationPolicyByID(context.Background(), 15)
@@ -236,7 +236,7 @@ func TestGetConfigurationPolicyByIDUnknownID(t *testing.T) {
 }
 
 func TestCreateConfigurationPolicy(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	store := testStoreWithoutConfigurationPolicies(t, db)
 
 	repositoryID := 42
@@ -283,7 +283,7 @@ func TestCreateConfigurationPolicy(t *testing.T) {
 }
 
 func TestUpdateConfigurationPolicy(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	store := testStoreWithoutConfigurationPolicies(t, db)
 
 	repositoryID := 42
@@ -345,7 +345,7 @@ func TestUpdateConfigurationPolicy(t *testing.T) {
 }
 
 func TestUpdateProtectedConfigurationPolicy(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	store := testStoreWithoutConfigurationPolicies(t, db)
 
 	repositoryID := 42
@@ -454,7 +454,7 @@ func TestUpdateProtectedConfigurationPolicy(t *testing.T) {
 }
 
 func TestDeleteConfigurationPolicyByID(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	store := testStoreWithoutConfigurationPolicies(t, db)
 
 	repositoryID := 42
@@ -497,7 +497,7 @@ func TestDeleteConfigurationPolicyByID(t *testing.T) {
 }
 
 func TestDeleteConfigurationProtectedPolicy(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	store := testStoreWithoutConfigurationPolicies(t, db)
 
 	repositoryID := 42
@@ -545,7 +545,7 @@ func TestDeleteConfigurationProtectedPolicy(t *testing.T) {
 }
 
 func TestSelectPoliciesForRepositoryMembershipUpdate(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	store := testStoreWithoutConfigurationPolicies(t, db)
 	ctx := context.Background()
 

--- a/internal/codeintel/stores/dbstore/configuration_policies_test.go
+++ b/internal/codeintel/stores/dbstore/configuration_policies_test.go
@@ -10,12 +10,13 @@ import (
 	"github.com/google/go-cmp/cmp"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/globals"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
 func TestGetConfigurationPolicies(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	store := testStoreWithoutConfigurationPolicies(t, db)
 	ctx := context.Background()
 

--- a/internal/codeintel/stores/dbstore/configuration_test.go
+++ b/internal/codeintel/stores/dbstore/configuration_test.go
@@ -7,11 +7,12 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/keegancsmith/sqlf"
 
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 )
 
 func TestGetIndexConfigurationByRepositoryID(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	store := testStore(db)
 
 	expectedConfigurationData := []byte(`{
@@ -24,7 +25,7 @@ func TestGetIndexConfigurationByRepositoryID(t *testing.T) {
 		42,
 		"github.com/baz/honk",
 	)
-	if _, err := db.Exec(query.Query(sqlf.PostgresBindVar), query.Args()...); err != nil {
+	if _, err := db.ExecContext(context.Background(), query.Query(sqlf.PostgresBindVar), query.Args()...); err != nil {
 		t.Fatalf("unexpected error inserting repo: %s", err)
 	}
 
@@ -34,7 +35,7 @@ func TestGetIndexConfigurationByRepositoryID(t *testing.T) {
 		42,
 		expectedConfigurationData,
 	)
-	if _, err := db.Exec(query.Query(sqlf.PostgresBindVar), query.Args()...); err != nil {
+	if _, err := db.ExecContext(context.Background(), query.Query(sqlf.PostgresBindVar), query.Args()...); err != nil {
 		t.Fatalf("unexpected error inserting repo: %s", err)
 	}
 
@@ -52,7 +53,7 @@ func TestGetIndexConfigurationByRepositoryID(t *testing.T) {
 }
 
 func TestUpdateIndexConfigurationByRepositoryID(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	store := testStore(db)
 
 	query := sqlf.Sprintf(
@@ -60,7 +61,7 @@ func TestUpdateIndexConfigurationByRepositoryID(t *testing.T) {
 		42,
 		"github.com/baz/honk",
 	)
-	if _, err := db.Exec(query.Query(sqlf.PostgresBindVar), query.Args()...); err != nil {
+	if _, err := db.ExecContext(context.Background(), query.Query(sqlf.PostgresBindVar), query.Args()...); err != nil {
 		t.Fatalf("unexpected error inserting repo: %s", err)
 	}
 

--- a/internal/codeintel/stores/dbstore/dependency_index_test.go
+++ b/internal/codeintel/stores/dbstore/dependency_index_test.go
@@ -5,11 +5,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 )
 
 func TestInsertDependencySyncingJob(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	store := testStore(db)
 
 	insertRepo(t, db, 50, "")
@@ -39,7 +40,7 @@ func TestInsertDependencySyncingJob(t *testing.T) {
 }
 
 func TestInsertDependencyIndexingJob(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	store := testStore(db)
 
 	insertRepo(t, db, 50, "")

--- a/internal/codeintel/stores/dbstore/dumps_test.go
+++ b/internal/codeintel/stores/dbstore/dumps_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestGetDumpsByIDs(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	store := testStore(db)
 
 	// Dumps do not exist initially
@@ -86,7 +86,7 @@ func TestGetDumpsByIDs(t *testing.T) {
 }
 
 func TestFindClosestDumps(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	store := testStore(db)
 
 	// This database has the following commit graph:
@@ -151,7 +151,7 @@ func TestFindClosestDumps(t *testing.T) {
 }
 
 func TestFindClosestDumpsAlternateCommitGraph(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	store := testStore(db)
 
 	// This database has the following commit graph:
@@ -210,7 +210,7 @@ func TestFindClosestDumpsAlternateCommitGraph(t *testing.T) {
 }
 
 func TestFindClosestDumpsAlternateCommitGraphWithOverwrittenVisibleUploads(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	store := testStore(db)
 
 	// This database has the following commit graph:
@@ -262,7 +262,7 @@ func TestFindClosestDumpsAlternateCommitGraphWithOverwrittenVisibleUploads(t *te
 }
 
 func TestFindClosestDumpsDistinctRoots(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	store := testStore(db)
 
 	// This database has the following commit graph:
@@ -311,7 +311,7 @@ func TestFindClosestDumpsDistinctRoots(t *testing.T) {
 }
 
 func TestFindClosestDumpsOverlappingRoots(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	store := testStore(db)
 
 	// This database has the following commit graph:
@@ -390,7 +390,7 @@ func TestFindClosestDumpsOverlappingRoots(t *testing.T) {
 }
 
 func TestFindClosestDumpsIndexerName(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	store := testStore(db)
 
 	// This database has the following commit graph:
@@ -478,7 +478,7 @@ func TestFindClosestDumpsIndexerName(t *testing.T) {
 }
 
 func TestFindClosestDumpsIntersectingPath(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	store := testStore(db)
 
 	// This database has the following commit graph:
@@ -521,7 +521,7 @@ func TestFindClosestDumpsIntersectingPath(t *testing.T) {
 }
 
 func TestFindClosestDumpsFromGraphFragment(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	store := testStore(db)
 
 	// This database has the following commit graph:
@@ -691,7 +691,7 @@ func TestDeleteOverlappingDumps(t *testing.T) {
 	db := database.NewDB(sqlDB)
 	store := testStore(db)
 
-	insertUploads(t, sqlDB, Upload{
+	insertUploads(t, db, Upload{
 		ID:      1,
 		Commit:  makeCommit(1),
 		Root:    "cmd/",
@@ -716,7 +716,7 @@ func TestDeleteOverlappingDumpsNoMatches(t *testing.T) {
 	db := database.NewDB(sqlDB)
 	store := testStore(db)
 
-	insertUploads(t, sqlDB, Upload{
+	insertUploads(t, db, Upload{
 		ID:      1,
 		Commit:  makeCommit(1),
 		Root:    "cmd/",
@@ -753,7 +753,7 @@ func TestDeleteOverlappingDumpsIgnoresIncompleteUploads(t *testing.T) {
 	db := database.NewDB(sqlDB)
 	store := testStore(db)
 
-	insertUploads(t, sqlDB, Upload{
+	insertUploads(t, db, Upload{
 		ID:      1,
 		Commit:  makeCommit(1),
 		Root:    "cmd/",

--- a/internal/codeintel/stores/dbstore/indexes_test.go
+++ b/internal/codeintel/stores/dbstore/indexes_test.go
@@ -505,7 +505,7 @@ func TestDeleteIndexByID(t *testing.T) {
 }
 
 func TestDeleteIndexByIDMissingRow(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	store := testStore(db)
 
 	if found, err := store.DeleteIndexByID(context.Background(), 1); err != nil {
@@ -560,7 +560,7 @@ func TestDeleteIndexesWithoutRepository(t *testing.T) {
 }
 
 func TestLastIndexScanForRepository(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	store := testStore(db)
 	ctx := context.Background()
 

--- a/internal/codeintel/stores/dbstore/indexes_test.go
+++ b/internal/codeintel/stores/dbstore/indexes_test.go
@@ -11,13 +11,14 @@ import (
 	"github.com/keegancsmith/sqlf"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/globals"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/workerutil"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
 func TestGetIndexByID(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	store := testStore(db)
 	ctx := context.Background()
 
@@ -90,7 +91,7 @@ func TestGetIndexByID(t *testing.T) {
 }
 
 func TestGetQueuedIndexRank(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	store := testStore(db)
 
 	t1 := time.Unix(1587396557, 0).UTC()
@@ -139,7 +140,7 @@ func TestGetQueuedIndexRank(t *testing.T) {
 }
 
 func TestGetIndexesByIDs(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	store := testStore(db)
 	ctx := context.Background()
 
@@ -201,7 +202,7 @@ func TestGetIndexesByIDs(t *testing.T) {
 }
 
 func TestGetIndexes(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	store := testStore(db)
 	ctx := context.Background()
 
@@ -320,7 +321,7 @@ func TestGetIndexes(t *testing.T) {
 }
 
 func TestIsQueued(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	store := testStore(db)
 
 	insertIndexes(t, db, Index{ID: 1, RepositoryID: 1, Commit: makeCommit(1)})
@@ -357,7 +358,7 @@ func TestIsQueued(t *testing.T) {
 }
 
 func TestInsertIndexes(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	store := testStore(db)
 	ctx := context.Background()
 
@@ -482,7 +483,7 @@ func TestInsertIndexes(t *testing.T) {
 }
 
 func TestDeleteIndexByID(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	store := testStore(db)
 
 	insertIndexes(t, db,
@@ -515,7 +516,7 @@ func TestDeleteIndexByIDMissingRow(t *testing.T) {
 }
 
 func TestDeleteIndexesWithoutRepository(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	store := testStore(db)
 
 	var indexes []Index
@@ -538,7 +539,7 @@ func TestDeleteIndexesWithoutRepository(t *testing.T) {
 	for repositoryID, deletedAt := range deletions {
 		query := sqlf.Sprintf(`UPDATE repo SET deleted_at=%s WHERE id=%s`, deletedAt, repositoryID)
 
-		if _, err := db.Query(query.Query(sqlf.PostgresBindVar), query.Args()...); err != nil {
+		if _, err := db.QueryContext(context.Background(), query.Query(sqlf.PostgresBindVar), query.Args()...); err != nil {
 			t.Fatalf("Failed to update repository: %s", err)
 		}
 	}
@@ -591,7 +592,7 @@ func TestLastIndexScanForRepository(t *testing.T) {
 }
 
 func TestRecentIndexesSummary(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	store := testStore(db)
 	ctx := context.Background()
 

--- a/internal/codeintel/stores/dbstore/janitor_test.go
+++ b/internal/codeintel/stores/dbstore/janitor_test.go
@@ -18,14 +18,14 @@ func TestStaleSourcedCommits(t *testing.T) {
 
 	now := time.Unix(1587396557, 0).UTC()
 
-	insertUploads(t, sqlDB,
+	insertUploads(t, db,
 		Upload{ID: 1, RepositoryID: 50, Commit: makeCommit(1)},
 		Upload{ID: 2, RepositoryID: 50, Commit: makeCommit(1), Root: "sub/"},
 		Upload{ID: 3, RepositoryID: 51, Commit: makeCommit(4)},
 		Upload{ID: 4, RepositoryID: 51, Commit: makeCommit(5)},
 		Upload{ID: 5, RepositoryID: 52, Commit: makeCommit(7)},
 	)
-	insertIndexes(t, sqlDB,
+	insertIndexes(t, db,
 		Index{ID: 1, RepositoryID: 50, Commit: makeCommit(1)},
 		Index{ID: 2, RepositoryID: 50, Commit: makeCommit(2)},
 		Index{ID: 3, RepositoryID: 50, Commit: makeCommit(3)},
@@ -75,7 +75,7 @@ func TestUpdateSourcedCommits(t *testing.T) {
 
 	now := time.Unix(1587396557, 0).UTC()
 
-	insertUploads(t, sqlDB,
+	insertUploads(t, db,
 		Upload{ID: 1, RepositoryID: 50, Commit: makeCommit(1)},
 		Upload{ID: 2, RepositoryID: 50, Commit: makeCommit(1), Root: "sub/"},
 		Upload{ID: 3, RepositoryID: 51, Commit: makeCommit(4)},
@@ -83,7 +83,7 @@ func TestUpdateSourcedCommits(t *testing.T) {
 		Upload{ID: 5, RepositoryID: 52, Commit: makeCommit(7)},
 		Upload{ID: 6, RepositoryID: 52, Commit: makeCommit(7), State: "uploading"},
 	)
-	insertIndexes(t, sqlDB,
+	insertIndexes(t, db,
 		Index{ID: 1, RepositoryID: 50, Commit: makeCommit(3)},
 		Index{ID: 2, RepositoryID: 50, Commit: makeCommit(2)},
 		Index{ID: 3, RepositoryID: 52, Commit: makeCommit(7)},
@@ -141,7 +141,7 @@ func TestDeleteSourcedCommits(t *testing.T) {
 
 	now := time.Unix(1587396557, 0).UTC()
 
-	insertUploads(t, sqlDB,
+	insertUploads(t, db,
 		Upload{ID: 1, RepositoryID: 50, Commit: makeCommit(1)},
 		Upload{ID: 2, RepositoryID: 50, Commit: makeCommit(1), Root: "sub/"},
 		Upload{ID: 3, RepositoryID: 51, Commit: makeCommit(4)},
@@ -150,7 +150,7 @@ func TestDeleteSourcedCommits(t *testing.T) {
 		Upload{ID: 6, RepositoryID: 52, Commit: makeCommit(7), State: "uploading", UploadedAt: now.Add(-time.Minute * 90)},
 		Upload{ID: 7, RepositoryID: 52, Commit: makeCommit(7), State: "queued", UploadedAt: now.Add(-time.Minute * 30)},
 	)
-	insertIndexes(t, sqlDB,
+	insertIndexes(t, db,
 		Index{ID: 1, RepositoryID: 50, Commit: makeCommit(3)},
 		Index{ID: 2, RepositoryID: 50, Commit: makeCommit(2)},
 		Index{ID: 3, RepositoryID: 52, Commit: makeCommit(7)},

--- a/internal/codeintel/stores/dbstore/migration/committed_at_test.go
+++ b/internal/codeintel/stores/dbstore/migration/committed_at_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/keegancsmith/sqlf"
 
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/stores/dbstore"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
@@ -18,7 +19,7 @@ import (
 )
 
 func TestCommittedAtMigrator(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	store := dbstore.NewWithDB(db, &observation.TestContext)
 	gitserverClient := NewMockGitserverClient()
 	migrator := NewCommittedAtMigrator(store, gitserverClient, 250)
@@ -108,7 +109,7 @@ func TestCommittedAtMigrator(t *testing.T) {
 }
 
 func TestCommittedAtMigratorUnknownRepository(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	store := dbstore.NewWithDB(db, &observation.TestContext)
 	gitserverClient := NewMockGitserverClient()
 	migrator := NewCommittedAtMigrator(store, gitserverClient, 250)

--- a/internal/codeintel/stores/dbstore/migration/committed_at_test.go
+++ b/internal/codeintel/stores/dbstore/migration/committed_at_test.go
@@ -209,7 +209,7 @@ func TestCommittedAtMigratorUnknownRepository(t *testing.T) {
 }
 
 func TestCommittedAtMigratorUnknownCommits(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	store := dbstore.NewWithDB(db, &observation.TestContext)
 	gitserverClient := NewMockGitserverClient()
 	migrator := NewCommittedAtMigrator(store, gitserverClient, 250)

--- a/internal/codeintel/stores/dbstore/migration/reference_count_test.go
+++ b/internal/codeintel/stores/dbstore/migration/reference_count_test.go
@@ -9,13 +9,14 @@ import (
 	"github.com/keegancsmith/sqlf"
 
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/stores/dbstore"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 )
 
 func TestReferenceCountMigrator(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	store := dbstore.NewWithDB(db, &observation.TestContext)
 	migrator := NewReferenceCountMigrator(store, 75)
 

--- a/internal/codeintel/stores/dbstore/packages_test.go
+++ b/internal/codeintel/stores/dbstore/packages_test.go
@@ -42,7 +42,7 @@ func TestUpdatePackages(t *testing.T) {
 }
 
 func TestUpdatePackagesEmpty(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	store := testStore(db)
 
 	if err := store.UpdatePackages(context.Background(), 0, nil); err != nil {

--- a/internal/codeintel/stores/dbstore/packages_test.go
+++ b/internal/codeintel/stores/dbstore/packages_test.go
@@ -4,13 +4,14 @@ import (
 	"context"
 	"testing"
 
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/lib/codeintel/precise"
 )
 
 func TestUpdatePackages(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	store := testStore(db)
 
 	// for foreign key relation
@@ -31,7 +32,7 @@ func TestUpdatePackages(t *testing.T) {
 		t.Fatalf("unexpected error updating packages: %s", err)
 	}
 
-	count, _, err := basestore.ScanFirstInt(db.Query("SELECT COUNT(*) FROM lsif_packages"))
+	count, _, err := basestore.ScanFirstInt(db.QueryContext(context.Background(), "SELECT COUNT(*) FROM lsif_packages"))
 	if err != nil {
 		t.Fatalf("unexpected error checking package count: %s", err)
 	}

--- a/internal/codeintel/stores/dbstore/packages_test.go
+++ b/internal/codeintel/stores/dbstore/packages_test.go
@@ -49,7 +49,7 @@ func TestUpdatePackagesEmpty(t *testing.T) {
 		t.Fatalf("unexpected error updating packages: %s", err)
 	}
 
-	count, _, err := basestore.ScanFirstInt(db.Query("SELECT COUNT(*) FROM lsif_packages"))
+	count, _, err := basestore.ScanFirstInt(db.QueryContext(context.Background(), "SELECT COUNT(*) FROM lsif_packages"))
 	if err != nil {
 		t.Fatalf("unexpected error checking package count: %s", err)
 	}

--- a/internal/codeintel/stores/dbstore/references_test.go
+++ b/internal/codeintel/stores/dbstore/references_test.go
@@ -4,13 +4,14 @@ import (
 	"context"
 	"testing"
 
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/lib/codeintel/precise"
 )
 
 func TestUpdatePackageReferences(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	store := testStore(db)
 
 	// for foreign key relation
@@ -31,7 +32,7 @@ func TestUpdatePackageReferences(t *testing.T) {
 		t.Fatalf("unexpected error updating references: %s", err)
 	}
 
-	count, _, err := basestore.ScanFirstInt(db.Query("SELECT COUNT(*) FROM lsif_references"))
+	count, _, err := basestore.ScanFirstInt(db.QueryContext(context.Background(), "SELECT COUNT(*) FROM lsif_references"))
 	if err != nil {
 		t.Fatalf("unexpected error checking reference count: %s", err)
 	}
@@ -58,7 +59,7 @@ func TestUpdatePackageReferencesEmpty(t *testing.T) {
 }
 
 func TestUpdatePackageReferencesWithDuplicates(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	store := testStore(db)
 
 	// for foreign key relation
@@ -86,7 +87,7 @@ func TestUpdatePackageReferencesWithDuplicates(t *testing.T) {
 		t.Fatalf("unexpected error updating references: %s", err)
 	}
 
-	count, _, err := basestore.ScanFirstInt(db.Query("SELECT COUNT(*) FROM lsif_references"))
+	count, _, err := basestore.ScanFirstInt(db.QueryContext(context.Background(), "SELECT COUNT(*) FROM lsif_references"))
 	if err != nil {
 		t.Fatalf("unexpected error checking reference count: %s", err)
 	}

--- a/internal/codeintel/stores/dbstore/references_test.go
+++ b/internal/codeintel/stores/dbstore/references_test.go
@@ -49,7 +49,7 @@ func TestUpdatePackageReferencesEmpty(t *testing.T) {
 		t.Fatalf("unexpected error updating references: %s", err)
 	}
 
-	count, _, err := basestore.ScanFirstInt(db.Query("SELECT COUNT(*) FROM lsif_references"))
+	count, _, err := basestore.ScanFirstInt(db.QueryContext(context.Background(), "SELECT COUNT(*) FROM lsif_references"))
 	if err != nil {
 		t.Fatalf("unexpected error checking reference count: %s", err)
 	}

--- a/internal/codeintel/stores/dbstore/references_test.go
+++ b/internal/codeintel/stores/dbstore/references_test.go
@@ -42,7 +42,7 @@ func TestUpdatePackageReferences(t *testing.T) {
 }
 
 func TestUpdatePackageReferencesEmpty(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	store := testStore(db)
 
 	if err := store.UpdatePackageReferences(context.Background(), 0, nil); err != nil {

--- a/internal/codeintel/stores/dbstore/repo_test.go
+++ b/internal/codeintel/stores/dbstore/repo_test.go
@@ -10,13 +10,14 @@ import (
 	"github.com/google/go-cmp/cmp"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/globals"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
 func TestRepoNames(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	store := testStore(db)
 	ctx := context.Background()
 
@@ -44,7 +45,7 @@ func TestRepoNames(t *testing.T) {
 }
 
 func TestRepoIDsByGlobPatterns(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	store := testStore(db)
 	ctx := context.Background()
 
@@ -115,7 +116,7 @@ func TestRepoIDsByGlobPatterns(t *testing.T) {
 }
 
 func TestUpdateReposMatchingPatterns(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	store := testStore(db)
 	ctx := context.Background()
 
@@ -181,7 +182,7 @@ func TestUpdateReposMatchingPatterns(t *testing.T) {
 }
 
 func TestUpdateReposMatchingPatternsOverLimit(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	store := testStore(db)
 	ctx := context.Background()
 

--- a/internal/codeintel/stores/dbstore/store.go
+++ b/internal/codeintel/stores/dbstore/store.go
@@ -2,12 +2,11 @@ package dbstore
 
 import (
 	"context"
-	"database/sql"
 
 	"github.com/keegancsmith/sqlf"
 
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/metrics"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 )
@@ -17,7 +16,7 @@ type Store struct {
 	operations *operations
 }
 
-func NewWithDB(db dbutil.DB, observationContext *observation.Context) *Store {
+func NewWithDB(db database.DB, observationContext *observation.Context) *Store {
 	operationsMetrics := metrics.NewREDMetrics(
 		observationContext.Registerer,
 		"codeintel_dbstore",
@@ -26,7 +25,7 @@ func NewWithDB(db dbutil.DB, observationContext *observation.Context) *Store {
 	)
 
 	return &Store{
-		Store:      basestore.NewWithDB(db, sql.TxOptions{}),
+		Store:      basestore.NewWithHandle(db.Handle()),
 		operations: newOperations(observationContext, operationsMetrics),
 	}
 }

--- a/internal/codeintel/stores/dbstore/store_test.go
+++ b/internal/codeintel/stores/dbstore/store_test.go
@@ -4,16 +4,16 @@ import (
 	"context"
 	"testing"
 
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 )
 
-func testStore(db dbutil.DB) *Store {
+func testStore(db database.DB) *Store {
 	return NewWithDB(db, &observation.TestContext)
 }
 
 // removes default configuration policies
-func testStoreWithoutConfigurationPolicies(t *testing.T, db dbutil.DB) *Store {
+func testStoreWithoutConfigurationPolicies(t *testing.T, db database.DB) *Store {
 	if _, err := db.ExecContext(context.Background(), `TRUNCATE lsif_configuration_policies`); err != nil {
 		t.Fatalf("unexpected error while inserting configuration policies: %s", err)
 	}

--- a/internal/codeintel/stores/dbstore/uploads_test.go
+++ b/internal/codeintel/stores/dbstore/uploads_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 func TestGetUploadByID(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	store := testStore(db)
 	ctx := context.Background()
 
@@ -84,7 +84,7 @@ func TestGetUploadByID(t *testing.T) {
 }
 
 func TestGetUploadByIDDeleted(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	store := testStore(db)
 
 	// Upload does not exist initially
@@ -125,7 +125,7 @@ func TestGetUploadByIDDeleted(t *testing.T) {
 }
 
 func TestGetQueuedUploadRank(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	store := testStore(db)
 
 	t1 := time.Unix(1587396557, 0).UTC()
@@ -174,7 +174,7 @@ func TestGetQueuedUploadRank(t *testing.T) {
 }
 
 func TestGetUploadsByIDs(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	store := testStore(db)
 	ctx := context.Background()
 
@@ -227,7 +227,7 @@ func TestGetUploadsByIDs(t *testing.T) {
 }
 
 func TestDeleteUploadsStuckUploading(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	store := testStore(db)
 
 	t1 := time.Unix(1587396557, 0).UTC()
@@ -274,7 +274,7 @@ func TestDeleteUploadsStuckUploading(t *testing.T) {
 }
 
 func TestGetUploads(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	store := testStore(db)
 	ctx := context.Background()
 
@@ -461,7 +461,7 @@ func TestGetUploads(t *testing.T) {
 }
 
 func TestInsertUploadUploading(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	store := testStore(db)
 
 	insertRepo(t, db, 50, "")
@@ -510,7 +510,7 @@ func TestInsertUploadUploading(t *testing.T) {
 }
 
 func TestInsertUploadQueued(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	store := testStore(db)
 
 	insertRepo(t, db, 50, "")
@@ -562,7 +562,7 @@ func TestInsertUploadQueued(t *testing.T) {
 }
 
 func TestInsertUploadWithAssociatedIndexID(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	store := testStore(db)
 
 	insertRepo(t, db, 50, "")
@@ -618,7 +618,7 @@ func TestInsertUploadWithAssociatedIndexID(t *testing.T) {
 }
 
 func TestMarkQueued(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	store := testStore(db)
 
 	insertUploads(t, db, Upload{ID: 1, State: "uploading"})
@@ -644,7 +644,7 @@ func TestMarkQueued(t *testing.T) {
 }
 
 func TestMarkFailed(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	store := testStore(db)
 
 	insertUploads(t, db, Upload{ID: 1, State: "uploading"})
@@ -672,7 +672,7 @@ func TestMarkFailed(t *testing.T) {
 }
 
 func TestAddUploadPart(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	store := testStore(db)
 
 	insertUploads(t, db, Upload{ID: 1, State: "uploading"})
@@ -695,7 +695,7 @@ func TestAddUploadPart(t *testing.T) {
 }
 
 func TestDeleteUploadByID(t *testing.T) {
-	sqlDB := dbtest.NewDB(t)
+	sqlDB := database.NewDB(dbtest.NewDB(t))
 	db := database.NewDB(sqlDB)
 	store := testStore(db)
 
@@ -733,7 +733,7 @@ func TestDeleteUploadByID(t *testing.T) {
 }
 
 func TestDeleteUploadByIDNotCompleted(t *testing.T) {
-	sqlDB := dbtest.NewDB(t)
+	sqlDB := database.NewDB(dbtest.NewDB(t))
 	db := database.NewDB(sqlDB)
 	store := testStore(db)
 
@@ -782,7 +782,7 @@ func TestDeleteUploadByIDMissingRow(t *testing.T) {
 }
 
 func TestDeleteUploadsWithoutRepository(t *testing.T) {
-	sqlDB := dbtest.NewDB(t)
+	sqlDB := database.NewDB(dbtest.NewDB(t))
 	db := database.NewDB(sqlDB)
 	store := testStore(db)
 
@@ -853,7 +853,7 @@ func TestDeleteUploadsWithoutRepository(t *testing.T) {
 }
 
 func TestHardDeleteUploadByID(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	store := testStore(db)
 
 	insertUploads(t, db,
@@ -895,7 +895,7 @@ func TestHardDeleteUploadByID(t *testing.T) {
 }
 
 func TestHardDeleteUploadByIDPackageProvider(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	store := testStore(db)
 
 	insertUploads(t, db,
@@ -937,7 +937,7 @@ func TestHardDeleteUploadByIDPackageProvider(t *testing.T) {
 }
 
 func TestHardDeleteUploadByIDDuplicatePackageProvider(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	store := testStore(db)
 
 	insertUploads(t, db,
@@ -985,7 +985,7 @@ func TestHardDeleteUploadByIDDuplicatePackageProvider(t *testing.T) {
 }
 
 func TestSelectRepositoriesForIndexScan(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	store := testStoreWithoutConfigurationPolicies(t, db)
 
 	now := timeutil.Now()
@@ -1071,7 +1071,7 @@ func TestSelectRepositoriesForIndexScan(t *testing.T) {
 }
 
 func TestSelectRepositoriesForIndexScanWithGlobalPolicy(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	store := testStoreWithoutConfigurationPolicies(t, db)
 
 	now := timeutil.Now()
@@ -1141,7 +1141,7 @@ func TestSelectRepositoriesForIndexScanWithGlobalPolicy(t *testing.T) {
 }
 
 func TestSelectRepositoriesForIndexScanInDifferentTable(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	store := testStoreWithoutConfigurationPolicies(t, db)
 
 	now := timeutil.Now()
@@ -1218,7 +1218,7 @@ func TestSelectRepositoriesForIndexScanInDifferentTable(t *testing.T) {
 }
 
 func TestSelectRepositoriesForRetentionScan(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	store := testStore(db)
 
 	insertUploads(t, db,
@@ -1273,7 +1273,7 @@ func TestSelectRepositoriesForRetentionScan(t *testing.T) {
 	}
 
 	// Make repository 5 newly visible
-	if _, err := db.Exec(`UPDATE lsif_uploads SET state = 'completed' WHERE id = 5`); err != nil {
+	if _, err := db.ExecContext(context.Background(), `UPDATE lsif_uploads SET state = 'completed' WHERE id = 5`); err != nil {
 		t.Fatalf("unexpected error updating upload: %s", err)
 	}
 
@@ -1286,7 +1286,7 @@ func TestSelectRepositoriesForRetentionScan(t *testing.T) {
 }
 
 func TestUpdateUploadRetention(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	store := testStore(db)
 
 	insertUploads(t, db,
@@ -1303,7 +1303,7 @@ func TestUpdateUploadRetention(t *testing.T) {
 		t.Fatalf("unexpected error marking uploads as expired: %s", err)
 	}
 
-	count, _, err := basestore.ScanFirstInt(db.Query(`SELECT COUNT(*) FROM lsif_uploads WHERE expired`))
+	count, _, err := basestore.ScanFirstInt(db.QueryContext(context.Background(), `SELECT COUNT(*) FROM lsif_uploads WHERE expired`))
 	if err != nil {
 		t.Fatalf("unexpected error counting uploads: %s", err)
 	}
@@ -1314,7 +1314,7 @@ func TestUpdateUploadRetention(t *testing.T) {
 }
 
 func TestUpdateReferenceCounts(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	store := testStore(db)
 
 	insertUploads(t, db,
@@ -1435,7 +1435,7 @@ func TestSoftDeleteExpiredUploads(t *testing.T) {
 	db := database.NewDB(sqlDB)
 	store := testStore(db)
 
-	insertUploads(t, sqlDB,
+	insertUploads(t, db,
 		Upload{ID: 50, State: "completed"},
 		Upload{ID: 51, State: "completed"},
 		Upload{ID: 52, State: "completed"},
@@ -1513,7 +1513,7 @@ func TestSoftDeleteExpiredUploads(t *testing.T) {
 }
 
 func TestGetOldestCommitDate(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	store := testStore(db)
 
 	t1 := time.Unix(1587396557, 0).UTC()
@@ -1532,7 +1532,7 @@ func TestGetOldestCommitDate(t *testing.T) {
 		Upload{ID: 8, State: "completed", RepositoryID: 51},
 	)
 
-	if _, err := db.Exec("UPDATE lsif_uploads SET committed_at = '-infinity' WHERE id = 3"); err != nil {
+	if _, err := db.ExecContext(context.Background(), "UPDATE lsif_uploads SET committed_at = '-infinity' WHERE id = 3"); err != nil {
 		t.Fatalf("unexpected error updating commit date %s", err)
 	}
 
@@ -1571,7 +1571,7 @@ func TestGetOldestCommitDate(t *testing.T) {
 }
 
 func TestUpdateCommitedAt(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	store := testStore(db)
 
 	t1 := time.Unix(1587396557, 0).UTC()
@@ -1601,7 +1601,7 @@ func TestUpdateCommitedAt(t *testing.T) {
 		}
 	}
 
-	commitDates, err := basestore.ScanTimes(db.Query("SELECT committed_at FROM lsif_uploads WHERE id IN (1, 2, 4, 6) ORDER BY id"))
+	commitDates, err := basestore.ScanTimes(db.QueryContext(context.Background(), "SELECT committed_at FROM lsif_uploads WHERE id IN (1, 2, 4, 6) ORDER BY id"))
 	if err != nil {
 		t.Fatalf("unexpected error querying commit dates: %s", err)
 	}
@@ -1642,7 +1642,7 @@ func TestLastUploadRetentionScanForRepository(t *testing.T) {
 }
 
 func TestRecentUploadsSummary(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	store := testStore(db)
 	ctx := context.Background()
 

--- a/internal/codeintel/stores/dbstore/uploads_test.go
+++ b/internal/codeintel/stores/dbstore/uploads_test.go
@@ -771,7 +771,7 @@ func TestDeleteUploadByIDNotCompleted(t *testing.T) {
 }
 
 func TestDeleteUploadByIDMissingRow(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	store := testStore(db)
 
 	if found, err := store.DeleteUploadByID(context.Background(), 1); err != nil {
@@ -1611,7 +1611,7 @@ func TestUpdateCommitedAt(t *testing.T) {
 }
 
 func TestLastUploadRetentionScanForRepository(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	store := testStore(db)
 	ctx := context.Background()
 

--- a/internal/codeintel/stores/dbstore/xrepo_test.go
+++ b/internal/codeintel/stores/dbstore/xrepo_test.go
@@ -11,13 +11,14 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/globals"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/commitgraph"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/stores/shared"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/lib/codeintel/precise"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
 func TestDefinitionDumps(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	store := testStore(db)
 
 	moniker1 := precise.QualifiedMonikerData{
@@ -154,7 +155,7 @@ func TestDefinitionDumps(t *testing.T) {
 }
 
 func TestReferenceIDs(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	store := testStore(db)
 
 	insertUploads(t, db,
@@ -274,7 +275,7 @@ func TestReferenceIDs(t *testing.T) {
 }
 
 func TestReferenceIDsVisibility(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	store := testStore(db)
 
 	insertUploads(t, db,
@@ -337,7 +338,7 @@ func TestReferenceIDsVisibility(t *testing.T) {
 }
 
 func TestReferenceIDsRemoteVisibility(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	store := testStore(db)
 
 	insertUploads(t, db,
@@ -406,7 +407,7 @@ func TestReferenceIDsRemoteVisibility(t *testing.T) {
 }
 
 func TestReferencesForUpload(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	store := testStore(db)
 
 	insertUploads(t, db,

--- a/internal/codeintel/symbols/internal/store/store.go
+++ b/internal/codeintel/symbols/internal/store/store.go
@@ -2,14 +2,13 @@ package store
 
 import (
 	"context"
-	"database/sql"
 
 	"github.com/keegancsmith/sqlf"
 	"github.com/opentracing/opentracing-go/log"
 
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/symbols/shared"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
@@ -26,9 +25,9 @@ type store struct {
 }
 
 // New returns a new symbols store.
-func New(db dbutil.DB, observationContext *observation.Context) Store {
+func New(db database.DB, observationContext *observation.Context) Store {
 	return &store{
-		db:         basestore.NewWithDB(db, sql.TxOptions{}),
+		db:         basestore.NewWithHandle(db.Handle()),
 		operations: newOperations(observationContext),
 	}
 }

--- a/internal/codeintel/uploads/internal/store/store.go
+++ b/internal/codeintel/uploads/internal/store/store.go
@@ -2,14 +2,13 @@ package store
 
 import (
 	"context"
-	"database/sql"
 
 	"github.com/keegancsmith/sqlf"
 	"github.com/opentracing/opentracing-go/log"
 
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/uploads/shared"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
@@ -26,9 +25,9 @@ type store struct {
 }
 
 // New returns a new uploads store.
-func New(db dbutil.DB, observationContext *observation.Context) Store {
+func New(db database.DB, observationContext *observation.Context) Store {
 	return &store{
-		db:         basestore.NewWithDB(db, sql.TxOptions{}),
+		db:         basestore.NewWithHandle(db.Handle()),
 		operations: newOperations(observationContext),
 	}
 }

--- a/internal/database/event_logs_test.go
+++ b/internal/database/event_logs_test.go
@@ -78,7 +78,7 @@ func TestEventLogs_CountUsersWithSetting(t *testing.T) {
 
 	usersStore := db.Users()
 	settingsStore := db.TemporarySettings()
-	eventLogsStore := &eventLogStore{Store: basestore.NewWithDB(db, sql.TxOptions{})}
+	eventLogsStore := &eventLogStore{Store: basestore.NewWithHandle(db.Handle())}
 
 	for i := 0; i < 24; i++ {
 		user, err := usersStore.Create(ctx, NewUser{Username: fmt.Sprintf("u%d", i)})
@@ -322,7 +322,7 @@ func TestEventLogs_SiteUsage(t *testing.T) {
 		}
 	}
 
-	el := &eventLogStore{Store: basestore.NewWithDB(db, sql.TxOptions{})}
+	el := &eventLogStore{Store: basestore.NewWithHandle(db.Handle())}
 	summary, err := el.siteUsage(ctx, now)
 	if err != nil {
 		t.Fatal(err)
@@ -407,7 +407,7 @@ func TestEventLogs_codeIntelligenceWeeklyUsersCount(t *testing.T) {
 		"codeintel.searchReferences",
 	}
 
-	el := &eventLogStore{Store: basestore.NewWithDB(db, sql.TxOptions{})}
+	el := &eventLogStore{Store: basestore.NewWithHandle(db.Handle())}
 	count, err := el.codeIntelligenceWeeklyUsersCount(ctx, eventNames, now)
 	if err != nil {
 		t.Fatal(err)
@@ -617,7 +617,7 @@ func TestEventLogs_CodeIntelligenceSettingsPageViewCounts(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	el := &eventLogStore{Store: basestore.NewWithDB(db, sql.TxOptions{})}
+	el := &eventLogStore{Store: basestore.NewWithHandle(db.Handle())}
 	count, err := el.codeIntelligenceSettingsPageViewCount(ctx, now)
 	if err != nil {
 		t.Fatal(err)
@@ -681,7 +681,7 @@ func TestEventLogs_AggregatedCodeIntelEvents(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	el := &eventLogStore{Store: basestore.NewWithDB(db, sql.TxOptions{})}
+	el := &eventLogStore{Store: basestore.NewWithHandle(db.Handle())}
 	events, err := el.aggregatedCodeIntelEvents(ctx, now)
 	if err != nil {
 		t.Fatal(err)
@@ -735,7 +735,7 @@ func TestEventLogs_AggregatedSparseCodeIntelEvents(t *testing.T) {
 		}
 	}
 
-	el := &eventLogStore{Store: basestore.NewWithDB(db, sql.TxOptions{})}
+	el := &eventLogStore{Store: basestore.NewWithHandle(db.Handle())}
 	events, err := el.aggregatedCodeIntelEvents(ctx, now)
 	if err != nil {
 		t.Fatal(err)
@@ -815,7 +815,7 @@ func TestEventLogs_AggregatedCodeIntelInvestigationEvents(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	el := &eventLogStore{Store: basestore.NewWithDB(db, sql.TxOptions{})}
+	el := &eventLogStore{Store: basestore.NewWithHandle(db.Handle())}
 	events, err := el.aggregatedCodeIntelInvestigationEvents(ctx, now)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/database/feature_flags_test.go
+++ b/internal/database/feature_flags_test.go
@@ -2,7 +2,6 @@ package database
 
 import (
 	"context"
-	"database/sql"
 	"testing"
 	"time"
 
@@ -110,7 +109,8 @@ func testNewFeatureFlagRoundtrip(t *testing.T) {
 
 func testListFeatureFlags(t *testing.T) {
 	t.Parallel()
-	flagStore := &featureFlagStore{Store: basestore.NewWithDB(dbtest.NewDB(t), sql.TxOptions{})}
+	db := NewDB(dbtest.NewDB(t))
+	flagStore := &featureFlagStore{Store: basestore.NewWithHandle(db.Handle())}
 	ctx := actor.WithInternalActor(context.Background())
 
 	flag1 := &ff.FeatureFlag{Name: "bool_true", Bool: &ff.FeatureFlagBool{Value: true}}
@@ -194,7 +194,7 @@ func testNewOverrideRoundtrip(t *testing.T) {
 func testListUserOverrides(t *testing.T) {
 	t.Parallel()
 	db := NewDB(dbtest.NewDB(t))
-	flagStore := &featureFlagStore{Store: basestore.NewWithDB(db, sql.TxOptions{})}
+	flagStore := &featureFlagStore{Store: basestore.NewWithHandle(db.Handle())}
 	users := db.Users()
 	ctx := actor.WithInternalActor(context.Background())
 
@@ -273,7 +273,7 @@ func testListUserOverrides(t *testing.T) {
 func testListOrgOverrides(t *testing.T) {
 	t.Parallel()
 	db := NewDB(dbtest.NewDB(t))
-	flagStore := &featureFlagStore{Store: basestore.NewWithDB(db, sql.TxOptions{})}
+	flagStore := &featureFlagStore{Store: basestore.NewWithHandle(db.Handle())}
 	users := db.Users()
 	orgs := db.Orgs()
 	orgMembers := db.OrgMembers()

--- a/internal/database/gitserver_repos_test.go
+++ b/internal/database/gitserver_repos_test.go
@@ -2,7 +2,6 @@ package database
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
 	"strings"
 	"testing"
@@ -463,7 +462,7 @@ func TestGitserverReposGetByNames(t *testing.T) {
 	}
 
 	repoIdx := 0
-	gitserverRepoStore := &gitserverRepoStore{Store: basestore.NewWithDB(db, sql.TxOptions{})}
+	gitserverRepoStore := &gitserverRepoStore{Store: basestore.NewWithHandle(db.Handle())}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			// Creating tc.reposNumber repos

--- a/internal/database/survey_responses.go
+++ b/internal/database/survey_responses.go
@@ -9,7 +9,6 @@ import (
 	"github.com/keegancsmith/sqlf"
 
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
@@ -23,8 +22,8 @@ type SurveyResponseStore struct {
 }
 
 // SurveyResponses instantiates and returns a new SurveyResponseStore with prepared statements.
-func SurveyResponses(db dbutil.DB) *SurveyResponseStore {
-	return &SurveyResponseStore{Store: basestore.NewWithDB(db, sql.TxOptions{})}
+func SurveyResponses(db DB) *SurveyResponseStore {
+	return &SurveyResponseStore{Store: basestore.NewWithHandle(db.Handle())}
 }
 
 // NewSurveyResponseStoreWithDB instantiates and returns a new SurveyResponseStore using the other store handle.

--- a/internal/repos/integration_test.go
+++ b/internal/repos/integration_test.go
@@ -1,7 +1,6 @@
 package repos_test
 
 import (
-	"database/sql"
 	"testing"
 
 	"github.com/opentracing/opentracing-go"
@@ -54,7 +53,7 @@ func TestIntegration(t *testing.T) {
 		{"Syncer/SyncReposWithLastErrorsHitRateLimit", testSyncReposWithLastErrorsHitsRateLimiter},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			store := repos.NewStore(logtest.Scoped(t), database.NewDB(dbtest.NewDB(t)), sql.TxOptions{Isolation: sql.LevelReadCommitted})
+			store := repos.NewStore(logtest.Scoped(t), database.NewDB(dbtest.NewDB(t)))
 
 			store.SetMetrics(repos.NewStoreMetrics())
 			store.SetTracer(trace.Tracer{Tracer: opentracing.GlobalTracer()})

--- a/internal/repos/status_messages_test.go
+++ b/internal/repos/status_messages_test.go
@@ -2,7 +2,6 @@ package repos
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
 	"strings"
 	"testing"
@@ -30,7 +29,7 @@ func TestStatusMessages(t *testing.T) {
 	}
 	ctx := context.Background()
 	db := database.NewDB(dbtest.NewDB(t))
-	store := NewStore(logtest.Scoped(t), database.NewDB(db), sql.TxOptions{})
+	store := NewStore(logtest.Scoped(t), database.NewDB(db))
 
 	admin, err := db.Users().Create(ctx, database.NewUser{
 		Email:                 "a1@example.com",

--- a/internal/repos/store.go
+++ b/internal/repos/store.go
@@ -111,8 +111,8 @@ type store struct {
 }
 
 // NewStore instantiates and returns a new Store with given database handle.
-func NewStore(logger log.Logger, db database.DB, txOpts sql.TxOptions) Store {
-	s := basestore.NewWithDB(db, txOpts)
+func NewStore(logger log.Logger, db database.DB) Store {
+	s := basestore.NewWithHandle(db.Handle())
 	return &store{
 		Store:  s,
 		Logger: logger,

--- a/internal/services/executors/service.go
+++ b/internal/services/executors/service.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"time"
 
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/services/executors/store"
 	postgres "github.com/sourcegraph/sourcegraph/internal/services/executors/store/db"
 	"github.com/sourcegraph/sourcegraph/internal/types"
@@ -18,7 +18,7 @@ type Executor interface {
 	GetByHostname(ctx context.Context, hostname string) (types.Executor, bool, error)
 }
 
-func New(db dbutil.DB) Executor {
+func New(db database.DB) Executor {
 	return &executorService{store: postgres.New(db)}
 }
 

--- a/internal/services/executors/store/db/db.go
+++ b/internal/services/executors/store/db/db.go
@@ -1,10 +1,8 @@
 package db
 
 import (
-	"database/sql"
-
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/services/executors/store"
 )
 
@@ -16,6 +14,6 @@ type ExecutorStore struct {
 }
 
 // New instantiates and returns a new ExecutorStore with prepared statements.
-func New(db dbutil.DB) *ExecutorStore {
-	return &ExecutorStore{db: basestore.NewWithDB(db, sql.TxOptions{})}
+func New(db database.DB) *ExecutorStore {
+	return &ExecutorStore{db: basestore.NewWithHandle(db.Handle())}
 }

--- a/internal/services/executors/store/db/db_executors_test.go
+++ b/internal/services/executors/store/db/db_executors_test.go
@@ -10,13 +10,14 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/keegancsmith/sqlf"
 
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	pgs "github.com/sourcegraph/sourcegraph/internal/services/executors/store"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
 func TestExecutorsList(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	store := New(db)
 	ctx := context.Background()
 

--- a/internal/services/executors/store/db/db_executors_test.go
+++ b/internal/services/executors/store/db/db_executors_test.go
@@ -129,7 +129,7 @@ func TestExecutorsList(t *testing.T) {
 }
 
 func TestExecutorsGetByID(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	store := New(db)
 	ctx := context.Background()
 
@@ -188,7 +188,7 @@ func TestExecutorsGetByID(t *testing.T) {
 }
 
 func TestExecutorsGetByHostname(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	store := New(db)
 	ctx := context.Background()
 
@@ -249,7 +249,7 @@ func TestExecutorsGetByHostname(t *testing.T) {
 }
 
 func TestExecutorsDeleteInactiveHeartbeats(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	store := New(db)
 	ctx := context.Background()
 

--- a/internal/services/executors/transport/graphql/resolver.go
+++ b/internal/services/executors/transport/graphql/resolver.go
@@ -7,7 +7,7 @@ import (
 	"github.com/graph-gophers/graphql-go/relay"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/services/executors"
 )
 
@@ -21,7 +21,7 @@ type resolver struct {
 	svc executors.Executor
 }
 
-func New(db dbutil.DB) Resolver {
+func New(db database.DB) Resolver {
 	return &resolver{
 		svc: executors.New(db),
 	}


### PR DESCRIPTION
This removes most uses of `basestore.NewWithDB()` from our backend. The only instances remaining are uses where the input `dbutil.DB` is neither a frontend DB (typed as `database.DB`) nor can it be easily converted to a `TransactableHandle`. The next step will be to migrate the remaining callers to pass around either a `TransactableHandle` or raw `sql.DB`.

The goal here is to get rid of `dbutil.DB`, and this the next step in a very long process. The problem with `dbutil.DB` is that it can be a `frontend` db, it can be a `codeinsights` db, it can be a `*sql.DB`, it can be a `*sql.Tx`, or it can be any number of semi-opaque wrappers we have for those types.

You might say "but isn't that the point of a good interface?" and I'd say "Yes, but..." and go on to talk about how `dbutil.DB` is a very leaky abstraction because in almost every case, we do actually care about the underlying type. We need to know whether the database handle we are using is pointing to db with the frontend schema or the code insights schema. We need to know whether the handle we're using is a transaction because _transactions cannot be used concurrently_. To know these things, we resort to [hacky interface unwraps](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@47e9edaed554dbce33943ca99fba49ada33b3ae7/-/blob/internal/database/basestore/handle.go?L32-34) that break in subtle and sneaky ways.

It can get better. I promise. 

Part of https://github.com/sourcegraph/sourcegraph/issues/26113 in spirit.



## Test plan

The changes should be semantics-preserving. I'm depending heavily on tests.
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

bump PR auditor