### PR TITLE
database: update dbutil-based constructors

### DIFF
--- a/cmd/gitserver/server/servermetrics.go
+++ b/cmd/gitserver/server/servermetrics.go
@@ -10,12 +10,12 @@ import (
 
 	"github.com/sourcegraph/log"
 
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/metrics"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 )
 
-func (s *Server) RegisterMetrics(db dbutil.DB, observationContext *observation.Context) {
+func (s *Server) RegisterMetrics(db database.DB, observationContext *observation.Context) {
 	// test the latency of exec, which may increase under certain memory
 	// conditions
 	echoDuration := prometheus.NewGauge(prometheus.GaugeOpts{

--- a/enterprise/cmd/frontend/internal/batches/resolvers/resolver_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/resolver_test.go
@@ -40,7 +40,7 @@ import (
 func TestNullIDResilience(t *testing.T) {
 	ct.MockRSAKeygen(t)
 
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	sr := New(store.New(db, &observation.TestContext, nil))
 
 	s, err := newSchema(database.NewDB(db), sr)

--- a/enterprise/cmd/frontend/internal/batches/webhooks/bitbucketcloud_test.go
+++ b/enterprise/cmd/frontend/internal/batches/webhooks/bitbucketcloud_test.go
@@ -424,7 +424,7 @@ func bitbucketCloudTestSetup(t *testing.T, db *sql.DB) *bstore.Store {
 
 	// Note that tx is wrapped in nestedTx to effectively neuter further use of
 	// transactions within the test.
-	return bstore.NewWithClock(&nestedTx{tx}, &observation.TestContext, nil, clock.Now)
+	return bstore.NewWithClock(database.NewDB(&nestedTx{tx}), &observation.TestContext, nil, clock.Now)
 }
 
 // createBitbucketCloudExternalService creates a mock Bitbucket Cloud service

--- a/enterprise/cmd/frontend/internal/batches/webhooks/gitlab_test.go
+++ b/enterprise/cmd/frontend/internal/batches/webhooks/gitlab_test.go
@@ -542,7 +542,7 @@ func testGitLabWebhook(db *sql.DB) func(*testing.T) {
 			// We can induce an error with a broken database connection.
 			s := gitLabTestSetup(t, db)
 			h := NewGitLabWebhook(s)
-			h.Store = store.NewWithClock(&brokenDB{errors.New("foo")}, &observation.TestContext, nil, s.Clock())
+			h.Store = store.NewWithClock(database.NewDB(&brokenDB{errors.New("foo")}), &observation.TestContext, nil, s.Clock())
 
 			es, err := h.getExternalServiceFromRawID(ctx, "12345")
 			if es != nil {
@@ -602,7 +602,7 @@ func testGitLabWebhook(db *sql.DB) func(*testing.T) {
 				}
 
 				// We can induce an error with a broken database connection.
-				h.Store = store.NewWithClock(&brokenDB{errors.New("foo")}, &observation.TestContext, nil, s.Clock())
+				h.Store = store.NewWithClock(database.NewDB(&brokenDB{errors.New("foo")}), &observation.TestContext, nil, s.Clock())
 
 				err := h.handleEvent(ctx, es, event)
 				if err == nil {
@@ -622,7 +622,7 @@ func testGitLabWebhook(db *sql.DB) func(*testing.T) {
 				}
 
 				// We can induce an error with a broken database connection.
-				h.Store = store.NewWithClock(&brokenDB{errors.New("foo")}, &observation.TestContext, nil, s.Clock())
+				h.Store = store.NewWithClock(database.NewDB(&brokenDB{errors.New("foo")}), &observation.TestContext, nil, s.Clock())
 
 				err := h.handleEvent(ctx, es, event)
 				if err == nil {
@@ -896,7 +896,7 @@ func gitLabTestSetup(t *testing.T, db *sql.DB) *store.Store {
 
 	// Note that tx is wrapped in nestedTx to effectively neuter further use of
 	// transactions within the test.
-	return store.NewWithClock(&nestedTx{tx}, &observation.TestContext, nil, c.Now)
+	return store.NewWithClock(database.NewDB(&nestedTx{tx}), &observation.TestContext, nil, c.Now)
 }
 
 // assertBodyIncludes checks for a specific substring within the given response

--- a/enterprise/cmd/worker/internal/batches/dbstore.go
+++ b/enterprise/cmd/worker/internal/batches/dbstore.go
@@ -11,6 +11,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/worker/memo"
 	workerdb "github.com/sourcegraph/sourcegraph/cmd/worker/shared/init/db"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/store"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/encryption/keyring"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
@@ -35,7 +36,7 @@ var initStore = memo.NewMemoizedConstructor(func() (*store.Store, error) {
 		return nil, err
 	}
 
-	return store.New(db, observationContext, keyring.Default().BatchChangesCredentialKey), nil
+	return store.New(database.NewDB(db), observationContext, keyring.Default().BatchChangesCredentialKey), nil
 })
 
 // InitReconcilerWorkerStore initializes and returns a dbworker.Store instance for the reconciler worker.

--- a/enterprise/cmd/worker/internal/batches/migrations/site_credential_migrator_test.go
+++ b/enterprise/cmd/worker/internal/batches/migrations/site_credential_migrator_test.go
@@ -19,7 +19,7 @@ import (
 
 func TestSiteCredentialMigrator(t *testing.T) {
 	ctx := context.Background()
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 
 	cstore := store.New(db, &observation.TestContext, et.TestKey{})
 

--- a/enterprise/cmd/worker/internal/insights/job.go
+++ b/enterprise/cmd/worker/internal/insights/job.go
@@ -48,7 +48,7 @@ func (s *insightsJob) Routines(ctx context.Context, logger log.Logger) ([]gorout
 		return nil, err
 	}
 
-	return background.GetBackgroundJobs(context.Background(), logger, mainAppDb, insightsDB), nil
+	return background.GetBackgroundJobs(context.Background(), logger, database.NewDB(mainAppDb), database.NewDB(insightsDB)), nil
 }
 
 func NewInsightsJob() job.Job {

--- a/enterprise/internal/batches/processor/bulk_processor_test.go
+++ b/enterprise/internal/batches/processor/bulk_processor_test.go
@@ -25,7 +25,7 @@ func TestBulkProcessor(t *testing.T) {
 	sqlDB := dbtest.NewDB(t)
 	tx := dbtest.NewTx(t, sqlDB)
 	db := database.NewDB(sqlDB)
-	bstore := store.New(tx, &observation.TestContext, nil)
+	bstore := store.New(database.NewDB(tx), &observation.TestContext, nil)
 	user := ct.CreateTestUser(t, db, true)
 	repo, _ := ct.CreateTestRepo(t, ctx, db)
 	ct.CreateTestSiteCredential(t, bstore, repo)

--- a/enterprise/internal/batches/store/store.go
+++ b/enterprise/internal/batches/store/store.go
@@ -70,13 +70,13 @@ type Store struct {
 }
 
 // New returns a new Store backed by the given database.
-func New(db dbutil.DB, observationContext *observation.Context, key encryption.Key) *Store {
+func New(db database.DB, observationContext *observation.Context, key encryption.Key) *Store {
 	return NewWithClock(db, observationContext, key, timeutil.Now)
 }
 
 // NewWithClock returns a new Store backed by the given database and
 // clock for timestamps.
-func NewWithClock(db dbutil.DB, observationContext *observation.Context, key encryption.Key, clock func() time.Time) *Store {
+func NewWithClock(db database.DB, observationContext *observation.Context, key encryption.Key, clock func() time.Time) *Store {
 	return &Store{
 		Store:              basestore.NewWithDB(db, sql.TxOptions{}),
 		key:                key,

--- a/enterprise/internal/batches/store/store_test.go
+++ b/enterprise/internal/batches/store/store_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	ct "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/testing"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/encryption"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
@@ -25,7 +26,7 @@ func storeTest(db *sql.DB, key encryption.Key, f storeTestFunc) func(*testing.T)
 		// don't need to insert a lot of dependencies into the DB (users,
 		// repos, ...) to setup the tests.
 		tx := dbtest.NewTx(t, db)
-		s := NewWithClock(tx, &observation.TestContext, key, c.Now)
+		s := NewWithClock(database.NewDB(tx), &observation.TestContext, key, c.Now)
 
 		f(t, context.Background(), s, c)
 	}

--- a/enterprise/internal/batches/store/worker_workspace_execution.go
+++ b/enterprise/internal/batches/store/worker_workspace_execution.go
@@ -87,7 +87,7 @@ type batchSpecWorkspaceExecutionWorkerStore struct {
 }
 
 func (s *batchSpecWorkspaceExecutionWorkerStore) FetchCanceled(ctx context.Context, executorName string) (canceledIDs []int, err error) {
-	batchesStore := New(s.Store.Handle().DB(), s.observationContext, nil)
+	batchesStore := New(database.NewDBWith(s.Store), s.observationContext, nil)
 
 	t := true
 	cs, err := batchesStore.ListBatchSpecWorkspaceExecutionJobs(ctx, ListBatchSpecWorkspaceExecutionJobsOpts{
@@ -121,7 +121,7 @@ func deleteAccessToken(ctx context.Context, deleteToken accessTokenHardDeleter, 
 type markFinal func(ctx context.Context, tx dbworkerstore.Store) (_ bool, err error)
 
 func (s *batchSpecWorkspaceExecutionWorkerStore) markFinal(ctx context.Context, id int, fn markFinal) (ok bool, err error) {
-	batchesStore := New(s.Store.Handle().DB(), s.observationContext, nil)
+	batchesStore := New(database.NewDBWith(s.Store), s.observationContext, nil)
 	tx, err := batchesStore.Transact(ctx)
 	if err != nil {
 		return false, err
@@ -191,7 +191,7 @@ func (s *batchSpecWorkspaceExecutionWorkerStore) MarkFailed(ctx context.Context,
 }
 
 func (s *batchSpecWorkspaceExecutionWorkerStore) MarkComplete(ctx context.Context, id int, options dbworkerstore.MarkFinalOptions) (_ bool, err error) {
-	batchesStore := New(s.Store.Handle().DB(), s.observationContext, nil)
+	batchesStore := New(database.NewDBWith(s.Store), s.observationContext, nil)
 
 	tx, err := batchesStore.Transact(ctx)
 	if err != nil {

--- a/enterprise/internal/insights/background/data_prune.go
+++ b/enterprise/internal/insights/background/data_prune.go
@@ -5,20 +5,19 @@ import (
 	"database/sql"
 	"time"
 
-	"github.com/keegancsmith/sqlf"
-	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
-
 	"github.com/inconshreveable/log15"
-	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"github.com/keegancsmith/sqlf"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/store"
-
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 // NewInsightsDataPrunerJob will periodically delete recorded data series that have been marked `deleted`.
-func NewInsightsDataPrunerJob(ctx context.Context, postgres dbutil.DB, insightsdb dbutil.DB) goroutine.BackgroundRoutine {
+func NewInsightsDataPrunerJob(ctx context.Context, postgres dbutil.DB, insightsdb database.DB) goroutine.BackgroundRoutine {
 	interval := time.Minute * 60
 
 	return goroutine.NewPeriodicGoroutine(ctx, interval,
@@ -27,7 +26,7 @@ func NewInsightsDataPrunerJob(ctx context.Context, postgres dbutil.DB, insightsd
 		}))
 }
 
-func performPurge(ctx context.Context, postgres dbutil.DB, insightsdb dbutil.DB, deletedBefore time.Time) (err error) {
+func performPurge(ctx context.Context, postgres dbutil.DB, insightsdb database.DB, deletedBefore time.Time) (err error) {
 	insightStore := store.NewInsightStore(insightsdb)
 	timeseriesStore := store.New(insightsdb, store.NewInsightPermissionStore(postgres))
 

--- a/enterprise/internal/insights/background/data_prune_test.go
+++ b/enterprise/internal/insights/background/data_prune_test.go
@@ -6,17 +6,14 @@ import (
 	"testing"
 	"time"
 
-	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/background/queryrunner"
-
 	"github.com/keegancsmith/sqlf"
 
-	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
-
-	"github.com/sourcegraph/sourcegraph/internal/api"
-
-	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/types"
-
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/background/queryrunner"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/store"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/types"
+	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/timeutil"
 )
@@ -28,7 +25,7 @@ func TestPerformPurge(t *testing.T) {
 
 	ctx := context.Background()
 	clock := timeutil.Now
-	insightsDB := dbtest.NewInsightsDB(t)
+	insightsDB := database.NewDB(dbtest.NewInsightsDB(t))
 	postgres := dbtest.NewDB(t)
 	permStore := store.NewInsightPermissionStore(postgres)
 	timeseriesStore := store.NewWithClock(insightsDB, permStore, clock)

--- a/enterprise/internal/insights/background/license_check.go
+++ b/enterprise/internal/insights/background/license_check.go
@@ -8,13 +8,13 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/store"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/licensing"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 // NewLicenseCheckJob will periodically check for the existence of a Code Insights license and ensure the correct set of insights is frozen.
-func NewLicenseCheckJob(ctx context.Context, postgres dbutil.DB, insightsdb dbutil.DB) goroutine.BackgroundRoutine {
+func NewLicenseCheckJob(ctx context.Context, insightsdb database.DB) goroutine.BackgroundRoutine {
 	interval := time.Minute * 15
 
 	return goroutine.NewPeriodicGoroutine(ctx, interval,
@@ -23,7 +23,7 @@ func NewLicenseCheckJob(ctx context.Context, postgres dbutil.DB, insightsdb dbut
 		}))
 }
 
-func checkAndEnforceLicense(ctx context.Context, insightsdb dbutil.DB) (err error) {
+func checkAndEnforceLicense(ctx context.Context, insightsdb database.DB) (err error) {
 	insightStore := store.NewInsightStore(insightsdb)
 	dashboardStore := store.NewDashboardStore(insightsdb)
 	insightTx, err := insightStore.Transact(ctx)

--- a/enterprise/internal/insights/background/queryrunner/work_handler_test.go
+++ b/enterprise/internal/insights/background/queryrunner/work_handler_test.go
@@ -1349,7 +1349,7 @@ func mockComputeSearch(results []computeSearch) func(context.Context, string) ([
 }
 
 func TestGetSeries(t *testing.T) {
-	insightsDB := dbtest.NewInsightsDB(t)
+	insightsDB := database.NewDB(dbtest.NewInsightsDB(t))
 	now := time.Date(2021, 12, 1, 0, 0, 0, 0, time.UTC).Truncate(time.Microsecond).Round(0)
 	metadataStore := store.NewInsightStore(insightsDB)
 	metadataStore.Now = func() time.Time {

--- a/enterprise/internal/insights/background/queryrunner/worker.go
+++ b/enterprise/internal/insights/background/queryrunner/worker.go
@@ -19,6 +19,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/store"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/types"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/insights/priority"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
@@ -82,7 +83,7 @@ func NewWorker(ctx context.Context, logger log.Logger, workerStore dbworkerstore
 		insightsStore:   insightsStore,
 		repoStore:       repoStore,
 		limiter:         limiter,
-		metadadataStore: store.NewInsightStore(insightsStore.Handle().DB()),
+		metadadataStore: store.NewInsightStore(database.NewDBWith(insightsStore)),
 		seriesCache:     sharedCache,
 		search:          query.Search,
 		searchStream: func(ctx context.Context, query string) (*streaming.TabulationResult, error) {

--- a/enterprise/internal/insights/discovery/discovery.go
+++ b/enterprise/internal/insights/discovery/discovery.go
@@ -126,12 +126,12 @@ func filterByIds(ids []string, insight []insights.SearchInsight) []insights.Sear
 
 type settingMigrator struct {
 	base     database.DB
-	insights dbutil.DB
+	insights database.DB
 }
 
 // NewMigrateSettingInsightsJob will migrate insights from settings into the database. This is a job that will be
 // deprecated as soon as this functionality is available over an API.
-func NewMigrateSettingInsightsJob(ctx context.Context, base database.DB, insights dbutil.DB) goroutine.BackgroundRoutine {
+func NewMigrateSettingInsightsJob(ctx context.Context, base, insights database.DB) goroutine.BackgroundRoutine {
 	interval := time.Minute * 10
 	m := settingMigrator{
 		base:     base,

--- a/enterprise/internal/insights/insights.go
+++ b/enterprise/internal/insights/insights.go
@@ -52,7 +52,7 @@ func Init(ctx context.Context, postgres database.DB, _ conftypes.UnifiedWatchabl
 	if err != nil {
 		return err
 	}
-	enterpriseServices.InsightsResolver = resolvers.New(db, postgres)
+	enterpriseServices.InsightsResolver = resolvers.New(database.NewDB(db), postgres)
 
 	return nil
 }
@@ -83,7 +83,7 @@ func RegisterMigrations(db database.DB, outOfBandMigrationRunner *oobmigration.R
 		return err
 	}
 
-	insightsMigrator := migration.NewMigrator(insightsDB, db)
+	insightsMigrator := migration.NewMigrator(database.NewDB(insightsDB), db)
 
 	// This id (14) was defined arbitrarily in this migration file: 1528395945_settings_migration_out_of_band.up.sql.
 	if err := outOfBandMigrationRunner.Register(14, insightsMigrator, oobmigration.MigratorOptions{Interval: 10 * time.Second}); err != nil {

--- a/enterprise/internal/insights/migration/migration.go
+++ b/enterprise/internal/insights/migration/migration.go
@@ -40,7 +40,7 @@ type migrator struct {
 	workerBaseStore            *basestore.Store
 }
 
-func NewMigrator(insightsDB dbutil.DB, postgresDB database.DB) oobmigration.Migrator {
+func NewMigrator(insightsDB, postgresDB database.DB) oobmigration.Migrator {
 	return &migrator{
 		insightsDB:                 insightsDB,
 		postgresDB:                 postgresDB,

--- a/enterprise/internal/insights/migration/migration_test.go
+++ b/enterprise/internal/insights/migration/migration_test.go
@@ -4,14 +4,13 @@ import (
 	"context"
 	"testing"
 
-	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/types"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
-
+	"github.com/google/go-cmp/cmp"
 	"github.com/hexops/autogold"
 
-	"github.com/google/go-cmp/cmp"
-
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/store"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/types"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 )
 
 func TestBuildUniqueIdCondition(t *testing.T) {
@@ -48,7 +47,7 @@ func TestToInsightUniqueIdQuery(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	insightsDB := dbtest.NewInsightsDB(t)
+	insightsDB := database.NewDB(dbtest.NewInsightsDB(t))
 
 	migrator := migrator{insightStore: store.NewInsightStore(insightsDB)}
 
@@ -60,7 +59,7 @@ func TestToInsightUniqueIdQuery(t *testing.T) {
 			orgIds: []int{3},
 		}
 
-		_, err := insightsDB.Exec("insert into insight_view (unique_id) values ($1);", want)
+		_, err := insightsDB.ExecContext(ctx, "insert into insight_view (unique_id) values ($1);", want)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -84,7 +83,7 @@ func TestToInsightUniqueIdQuery(t *testing.T) {
 			userId: 1,
 		}
 
-		_, err := insightsDB.Exec("insert into insight_view (unique_id) values ($1);", want)
+		_, err := insightsDB.ExecContext(ctx, "insert into insight_view (unique_id) values ($1);", want)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -108,12 +107,12 @@ func TestToInsightUniqueIdQuery(t *testing.T) {
 			orgIds: []int{3},
 		}
 
-		_, err := insightsDB.Exec("insert into insight_view (unique_id) values ($1);", want)
+		_, err := insightsDB.ExecContext(ctx, "insert into insight_view (unique_id) values ($1);", want)
 		if err != nil {
 			t.Fatal(err)
 		}
 		// this one should NOT match
-		_, err = insightsDB.Exec("insert into insight_view (unique_id) values ($1);", "myInsight3-org-5")
+		_, err = insightsDB.ExecContext(ctx, "insert into insight_view (unique_id) values ($1);", "myInsight3-org-5")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -154,11 +153,11 @@ func TestCreateSpecialCaseDashboard(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	insightsDB := dbtest.NewInsightsDB(t)
+	insightsDB := database.NewDB(dbtest.NewInsightsDB(t))
 	migrator := migrator{insightStore: store.NewInsightStore(insightsDB), dashboardStore: store.NewDashboardStore(insightsDB)}
 
 	newView := func(insightId string) {
-		_, err := insightsDB.Exec("insert into insight_view (unique_id) values ($1);", insightId)
+		_, err := insightsDB.ExecContext(ctx, "insert into insight_view (unique_id) values ($1);", insightId)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/enterprise/internal/insights/resolvers/insight_connection_resolver_test.go
+++ b/enterprise/internal/insights/resolvers/insight_connection_resolver_test.go
@@ -31,7 +31,7 @@ func TestResolver_InsightConnection(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	insightsDB := dbtest.NewInsightsDB(t)
+	insightsDB := database.NewDB(dbtest.NewInsightsDB(t))
 
 	testSetup := func(t *testing.T) (context.Context, graphqlbackend.InsightConnectionResolver) {
 		// Setup the GraphQL resolver.
@@ -121,7 +121,7 @@ func TestResolver_InsightsRepoPermissions(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	insightsDB := dbtest.NewInsightsDB(t)
+	insightsDB := database.NewDB(dbtest.NewInsightsDB(t))
 	postgres := database.NewDB(dbtest.NewDB(t))
 
 	ctx := context.Background()
@@ -186,14 +186,14 @@ func TestResolver_InsightsRepoPermissions(t *testing.T) {
 	}
 
 	for i := 0; i < 3; i++ {
-		_, err = insightsDB.Exec(`INSERT INTO repo_names (name) VALUES ($1);`, fmt.Sprint("ignore-me-", i))
+		_, err = insightsDB.ExecContext(ctx, `INSERT INTO repo_names (name) VALUES ($1);`, fmt.Sprint("ignore-me-", i))
 		if err != nil {
 			t.Fatal(err)
 		}
 	}
 
 	// Create some timeseries data, one row in each repository
-	_, err = insightsDB.Exec(`
+	_, err = insightsDB.ExecContext(ctx, `
 		INSERT INTO series_points (series_id, "time", "value", metadata_id, repo_id, repo_name_id, original_repo_name_id)
 		VALUES
 			('s:087855E6A24440837303FD8A252E9893E8ABDFECA55B61AC83DA1B521906626E', $1, 5.0, null, 1, 3, 3),

--- a/enterprise/internal/insights/resolvers/insight_series_resolver_test.go
+++ b/enterprise/internal/insights/resolvers/insight_series_resolver_test.go
@@ -23,7 +23,7 @@ func TestResolver_InsightSeries(t *testing.T) {
 		ctx := actor.WithInternalActor(context.Background())
 		now := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC).Truncate(time.Microsecond)
 		clock := func() time.Time { return now }
-		insightsDB := dbtest.NewInsightsDB(t)
+		insightsDB := database.NewDB(dbtest.NewInsightsDB(t))
 		postgres := database.NewDB(dbtest.NewDB(t))
 		resolver := newWithClock(insightsDB, postgres, clock)
 

--- a/enterprise/internal/insights/resolvers/insight_view_resolvers_test.go
+++ b/enterprise/internal/insights/resolvers/insight_view_resolvers_test.go
@@ -165,7 +165,7 @@ func TestFrozenInsightDataSeriesResolver(t *testing.T) {
 		}
 	})
 	t.Run("insight_is_not_frozen_returns_real_resolvers", func(t *testing.T) {
-		insightsDB := dbtest.NewInsightsDB(t)
+		insightsDB := database.NewDB(dbtest.NewInsightsDB(t))
 		postgres := database.NewDB(dbtest.NewDB(t))
 		permStore := store.NewInsightPermissionStore(postgres)
 		clock := timeutil.Now
@@ -229,7 +229,7 @@ func TestInsightViewDashboardConnections(t *testing.T) {
 	a := actor.FromUser(1)
 	ctx := actor.WithActor(context.Background(), a)
 
-	insightsDB := dbtest.NewInsightsDB(t)
+	insightsDB := database.NewDB(dbtest.NewInsightsDB(t))
 	postgresDB := database.NewDB(dbtest.NewDB(t))
 	base := baseInsightResolver{
 		insightStore:   store.NewInsightStore(insightsDB),

--- a/enterprise/internal/insights/resolvers/resolver.go
+++ b/enterprise/internal/insights/resolvers/resolver.go
@@ -34,7 +34,7 @@ type baseInsightResolver struct {
 	postgresDB database.DB
 }
 
-func WithBase(insightsDB dbutil.DB, primaryDB database.DB, clock func() time.Time) *baseInsightResolver {
+func WithBase(insightsDB, primaryDB database.DB, clock func() time.Time) *baseInsightResolver {
 	insightStore := store.NewInsightStore(insightsDB)
 	timeSeriesStore := store.NewWithClock(insightsDB, store.NewInsightPermissionStore(primaryDB), clock)
 	dashboardStore := store.NewDashboardStore(insightsDB)
@@ -61,13 +61,13 @@ type Resolver struct {
 }
 
 // New returns a new Resolver whose store uses the given Postgres DBs.
-func New(db dbutil.DB, postgres database.DB) graphqlbackend.InsightsResolver {
+func New(db, postgres database.DB) graphqlbackend.InsightsResolver {
 	return newWithClock(db, postgres, timeutil.Now)
 }
 
 // newWithClock returns a new Resolver whose store uses the given Postgres DBs and the given clock
 // for timestamps.
-func newWithClock(db dbutil.DB, postgres database.DB, clock func() time.Time) *Resolver {
+func newWithClock(db, postgres database.DB, clock func() time.Time) *Resolver {
 	base := WithBase(db, postgres, clock)
 	return &Resolver{
 		baseInsightResolver:  *base,

--- a/enterprise/internal/insights/resolvers/resolver_test.go
+++ b/enterprise/internal/insights/resolvers/resolver_test.go
@@ -18,7 +18,7 @@ func TestResolver_Insights(t *testing.T) {
 	ctx := actor.WithInternalActor(context.Background())
 	now := time.Now().UTC().Truncate(time.Microsecond)
 	clock := func() time.Time { return now }
-	insightsDB := dbtest.NewInsightsDB(t)
+	insightsDB := database.NewDB(dbtest.NewInsightsDB(t))
 	postgres := database.NewDB(dbtest.NewDB(t))
 	resolver := newWithClock(insightsDB, postgres, clock)
 

--- a/enterprise/internal/insights/store/dashboard_store_test.go
+++ b/enterprise/internal/insights/store/dashboard_store_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hexops/valast"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/types"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 )
 
@@ -397,11 +398,11 @@ func TestRestoreDashboard(t *testing.T) {
 }
 
 func TestAddViewsToDashboard(t *testing.T) {
-	insightsDB := dbtest.NewInsightsDB(t)
+	insightsDB := database.NewDB(dbtest.NewInsightsDB(t))
 	now := time.Now().Truncate(time.Microsecond).Round(0)
 	ctx := context.Background()
 
-	_, err := insightsDB.Exec(`
+	_, err := insightsDB.ExecContext(ctx, `
 		INSERT INTO dashboard (id, title)
 		VALUES (1, 'test dashboard 1'), (2, 'test dashboard 2');
 		INSERT INTO dashboard_grants (dashboard_id, global)
@@ -459,7 +460,7 @@ func TestAddViewsToDashboard(t *testing.T) {
 }
 
 func TestRemoveViewsFromDashboard(t *testing.T) {
-	insightsDB := dbtest.NewInsightsDB(t)
+	insightsDB := database.NewDB(dbtest.NewInsightsDB(t))
 	now := time.Now().Truncate(time.Microsecond).Round(0)
 	ctx := context.Background()
 

--- a/enterprise/internal/insights/store/insight_store.go
+++ b/enterprise/internal/insights/store/insight_store.go
@@ -11,8 +11,8 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/timeseries"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/types"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
@@ -22,7 +22,7 @@ type InsightStore struct {
 }
 
 // NewInsightStore returns a new InsightStore backed by the given Postgres db.
-func NewInsightStore(db dbutil.DB) *InsightStore {
+func NewInsightStore(db database.DB) *InsightStore {
 	return &InsightStore{Store: basestore.NewWithDB(db, sql.TxOptions{}), Now: time.Now}
 }
 


### PR DESCRIPTION
Updates a few dbutil-based constructors to accept `datbase.DB` instead, as they are not mockable in our tests.

Subscribed team please let me know if some `dbutil.DB`s are on purpose and can break if not using it.

This is the result of a time-boxed effort.

## Test plan

Unit tests

---

Part of https://github.com/sourcegraph/sourcegraph/issues/26113