### PR TITLE
batch changes: Fix percy snapshots in batch integration tests

### DIFF
--- a/client/web/src/integration/batches.test.ts
+++ b/client/web/src/integration/batches.test.ts
@@ -568,7 +568,7 @@ describe('Batches', () => {
                 await driver.page.goto(driver.sourcegraphBaseUrl + namespaceURL + '/batch-changes/test-batch-change')
                 // View overview page.
                 await driver.page.waitForSelector('.test-batch-change-details-page')
-                await percySnapshotWithVariants(driver.page, 'Batch change details page')
+                await percySnapshotWithVariants(driver.page, `Batch change details page ${entityType}`)
                 await accessibilityAudit(driver.page)
 
                 // Expand one changeset.
@@ -818,7 +818,7 @@ describe('Batches', () => {
                 await driver.page.goto(driver.sourcegraphBaseUrl + namespaceURL + '/batch-changes/apply/spec123')
                 // View overview page.
                 await driver.page.waitForSelector('.test-batch-change-apply-page')
-                await percySnapshotWithVariants(driver.page, 'Batch change preview page')
+                await percySnapshotWithVariants(driver.page, `Batch change preview page ${entityType}`)
                 await accessibilityAudit(driver.page)
 
                 // Expand one changeset.


### PR DESCRIPTION
While working on search integration tests I noticed [this warning](https://buildkite.com/sourcegraph/sourcegraph/builds/153109#018144c6-3e71-4827-80af-2a44a6a94c4d/6-8891):

> [percy] Encountered an error uploading snapshot: Batch change details page - dark theme
> [percy] Error: The name of each snapshot must be unique, and this name already exists in the build: 'Batch change details page - dark theme' -- You can fix this by passing a 'name' param when creating the snapshot. See the docs for more info on identifying snapshots for your specific client: https://percy.io/docs

This PR should resolve that issue.



## Test plan

CI

## App preview:

- [Web](https://sg-web-fkling-batch-integration-tests.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-txqremtyjq.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
