### PR TITLE
release: improve version confirmation prompt

### DIFF
--- a/dev/release/src/config.ts
+++ b/dev/release/src/config.ts
@@ -71,7 +71,7 @@ export async function releaseVersions(
     const now = new Date()
     const cachedVersionResponse = `${cacheFolder}/current_release_${now.getUTCFullYear()}_${getWeekNumber(now)}.txt`
     const confirmVersion = await readLine(
-        `Please confirm the upcoming release version configured in '${configPath}' (currently '${config.upcomingRelease}'): `,
+        `Please confirm the upcoming release version configured in '${configPath}' (currently '${config.upcomingRelease}') by entering it again: `,
         cachedVersionResponse
     )
     const parsedConfirmed = semver.parse(confirmVersion, parseOptions)


### PR DESCRIPTION
When I was asked `Please confirm the upcoming release version configured in 'release-config.jsonc' (currently '3.40.0')`, I got twice wrong... had no idea what type of input it was asking for.

## Test plan

Just a line of change in release tooling

---

Derived from my [retro notes for the 3.40 release](https://docs.google.com/document/d/1VHBqsWocffw9W8NRGhw4lLzyaoqgc1fiNdmTMMaVLxM/edit#).