### PR TITLE
Add installDocsite func to sg

### DIFF
--- a/dev/sg/internal/download/download.go
+++ b/dev/sg/internal/download/download.go
@@ -17,8 +17,12 @@ import (
 
 // Executable downloads a binary from the given URL, updates the given path if different, and
 // makes the downloaded file executable.
-func Executable(url string, path string) error {
-	resp, err := http.Get(url)
+func Executable(ctx context.Context, url string, path string) error {
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return err
+	}
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return err
 	}
@@ -37,7 +41,7 @@ func Executable(url string, path string) error {
 		return errors.Wrapf(err, "saving to %q", path)
 	}
 	if updated {
-		return exec.Command("chmod", "+x", path).Run()
+		return exec.CommandContext(ctx, "chmod", "+x", path).Run()
 	}
 
 	return nil
@@ -94,7 +98,7 @@ func ArchivedExecutable(ctx context.Context, url, targetFile, fileInArchive stri
 		return err
 	}
 
-	return exec.Command("chmod", "+x", targetFile).Run()
+	return exec.CommandContext(ctx, "chmod", "+x", targetFile).Run()
 }
 
 func fileExists(path string) (bool, error) {

--- a/dev/sg/internal/run/run.go
+++ b/dev/sg/internal/run/run.go
@@ -332,6 +332,20 @@ var installFuncs = map[string]installFunc{
 
 		return download.ArchivedExecutable(ctx, url, target, fmt.Sprintf("%s/jaeger-all-in-one", archiveName))
 	},
+	"installDocsite": func(ctx context.Context, env map[string]string) error {
+		version := env["DOCSITE_VERSION"]
+		if version == "" {
+			return errors.New("could not find DOCSITE_VERSION in env")
+		}
+		root, err := root.RepositoryRoot()
+		if err != nil {
+			return err
+		}
+		archiveName := fmt.Sprintf("docsite_%s_%s_%s", version, runtime.GOOS, runtime.GOARCH)
+		url := fmt.Sprintf("https://github.com/sourcegraph/docsite/releases/download/%s/%s", version, archiveName)
+		target := filepath.Join(root, fmt.Sprintf(".bin/docsite_%s", version))
+		return download.Executable(ctx, url, target)
+	},
 }
 
 func runWatch(

--- a/dev/sg/linters/hadolint.go
+++ b/dev/sg/linters/hadolint.go
@@ -78,7 +78,7 @@ func hadolint() lint.Runner {
 		// Download
 		os.MkdirAll("./.bin", os.ModePerm)
 		std.Out.WriteNoticef("Downloading hadolint from %s", url)
-		if err := download.Executable(url, hadolintBinary); err != nil {
+		if err := download.Executable(ctx, url, hadolintBinary); err != nil {
 			return &lint.Report{
 				Header: header,
 				Err:    errors.Wrap(err, "downloading hadolint"),

--- a/dev/sg/sg_update.go
+++ b/dev/sg/sg_update.go
@@ -57,7 +57,7 @@ func updateToPrebuiltSG(ctx context.Context) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	if err := download.Executable(downloadURL, currentExecPath); err != nil {
+	if err := download.Executable(ctx, downloadURL, currentExecPath); err != nil {
 		return "", err
 	}
 	return currentExecPath, nil

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -333,12 +333,7 @@ commands:
 
   docsite:
     cmd: .bin/docsite_${DOCSITE_VERSION} -config doc/docsite.json serve -http=localhost:5080
-    install: |
-      if [ ! -x .bin/docsite_${DOCSITE_VERSION} ]; then
-        curl -sS -L -f \
-        "https://github.com/sourcegraph/docsite/releases/download/${DOCSITE_VERSION}/docsite_${DOCSITE_VERSION}_$(go env GOOS)_$(go env GOARCH)" \
-        -o .bin/docsite_${DOCSITE_VERSION} && chmod +x .bin/docsite_${DOCSITE_VERSION}
-      fi
+    install_func: "installDocsite"
     env:
       DOCSITE_VERSION: v1.8.7 # Update DOCSITE_VERSION in all places (including outside this repo)
 


### PR DESCRIPTION
This extracts another piece of bash from `sg.config.yaml`. 

Some `context.Context` were missing so I added them along the way. 

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

<img width="831" alt="CleanShot 2022-06-09 at 10 17 42@2x" src="https://user-images.githubusercontent.com/10151/172799728-e6cec8fe-3f43-4f21-9bbd-bb48966abdfb.png">
