### PR TITLE
release: add "Test plan" to changelog cut PR

### DIFF
--- a/dev/release/src/release.ts
+++ b/dev/release/src/release.ts
@@ -231,7 +231,7 @@ ${trackingIssues.map(index => `- ${slackURL(index.title, index.url)}`).join('\n'
                         base: 'main',
                         head: `changelog-${release.version}`,
                         title: prMessage,
-                        commitMessage: prMessage,
+                        commitMessage: prMessage + '\n\n ## Test plan\n\nn/a',
                         edits: [
                             (directory: string) => {
                                 console.log(`Updating '${changelogFile} for ${release.format()}'`)


### PR DESCRIPTION
The least thing a release captain wanna see is a check failure :)

I couldn't find a better place to update PR body, if you know please LMK!

## Test plan

Only changes to release tooling

---

Derived from my [retro notes for the 3.40 release](https://docs.google.com/document/d/1VHBqsWocffw9W8NRGhw4lLzyaoqgc1fiNdmTMMaVLxM/edit#).