### PR TITLE
search: Fix React errors about unsupported DOM props

### DIFF
--- a/client/search-ui/src/input/SearchBox.tsx
+++ b/client/search-ui/src/input/SearchBox.tsx
@@ -114,10 +114,17 @@ export const SearchBox: React.FunctionComponent<React.PropsWithChildren<SearchBo
                         placeholder="Enter search query..."
                     />
                     <Toggles
-                        {...props}
+                        patternType={props.patternType}
+                        setPatternType={props.setPatternType}
+                        caseSensitive={props.caseSensitive}
+                        setCaseSensitivity={props.setCaseSensitivity}
+                        settingsCascade={props.settingsCascade}
                         submitSearch={props.submitSearchOnToggle}
                         navbarSearchQuery={queryState.query}
                         className={styles.searchBoxToggles}
+                        showCopyQueryButton={props.showCopyQueryButton}
+                        structuralSearchDisabled={props.structuralSearchDisabled}
+                        selectedSearchContextSpec={props.selectedSearchContextSpec}
                     />
                 </div>
             </div>

--- a/client/search-ui/src/input/toggles/Toggles.tsx
+++ b/client/search-ui/src/input/toggles/Toggles.tsx
@@ -73,7 +73,6 @@ export const Toggles: React.FunctionComponent<React.PropsWithChildren<TogglesPro
         submitSearch,
         showCopyQueryButton = true,
         structuralSearchDisabled,
-        ...otherProps
     } = props
 
     const defaultPatternTypeValue = useMemo(
@@ -147,7 +146,7 @@ export const Toggles: React.FunctionComponent<React.PropsWithChildren<TogglesPro
     )
 
     return (
-        <div className={classNames(className, styles.toggleContainer)} {...otherProps}>
+        <div className={classNames(className, styles.toggleContainer)}>
             {patternType === SearchPatternType.lucky ? (
                 <>
                     <QueryInputToggle


### PR DESCRIPTION
[#36204](https://github.com/sourcegraph/sourcegraph/pull/36204/files) added a change to add all "rest" props to a `<div>` element, which had the effect that a lot of component specific props have been added to the DOM element, and React complains about that (there are ~ 70 errors about that):

<img width="959" alt="2022-06-09_09-54" src="https://user-images.githubusercontent.com/179026/172821620-39121483-8056-4b5b-9429-1c56b9a1d9c7.png">


This commit fixes this in two ways: Only the props required by `<Toggles>` are passed and the rest props spread is removed (it's not clear to me why this was needed in the first place).


## Test plan

Loaded https://sourcegraph.test:3443/search and the errors were gone.

## App preview:

- [Web](https://sg-web-fkling-search-input-errors.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-toarksbvzl.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
