### PR TITLE
Backward compatible migrate to non-nullable user_id field

### DIFF
--- a/internal/database/schema.json
+++ b/internal/database/schema.json
@@ -1966,7 +1966,7 @@
           "Name": "user_id",
           "Index": 18,
           "TypeName": "integer",
-          "IsNullable": true,
+          "IsNullable": false,
           "Default": "",
           "CharacterMaximumLength": 0,
           "IsIdentity": false,

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -147,7 +147,7 @@ Foreign-key constraints:
  updated_at              | timestamp with time zone |           | not null | now()
  cancel                  | boolean                  |           | not null | false
  queued_at               | timestamp with time zone |           |          | now()
- user_id                 | integer                  |           |          | 
+ user_id                 | integer                  |           | not null | 
 Indexes:
     "batch_spec_workspace_execution_jobs_pkey" PRIMARY KEY, btree (id)
     "batch_spec_workspace_execution_jobs_batch_spec_workspace_id" btree (batch_spec_workspace_id)

--- a/migrations/frontend/1654770608/down.sql
+++ b/migrations/frontend/1654770608/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE batch_spec_workspace_execution_jobs ALTER COLUMN user_id DROP NOT NULL;

--- a/migrations/frontend/1654770608/metadata.yaml
+++ b/migrations/frontend/1654770608/metadata.yaml
@@ -1,0 +1,2 @@
+name: workspace_user_id_non_nullable
+parents: [1654116265, 1654168174, 1653524883]

--- a/migrations/frontend/1654770608/up.sql
+++ b/migrations/frontend/1654770608/up.sql
@@ -1,0 +1,8 @@
+UPDATE batch_spec_workspace_execution_jobs exec SET user_id = (
+    SELECT spec.user_id
+    FROM batch_spec_workspaces AS workspace
+    JOIN batch_specs spec ON spec.id = workspace.batch_spec_id
+    WHERE workspace.id = exec.batch_spec_workspace_id
+);
+
+ALTER TABLE batch_spec_workspace_execution_jobs ALTER COLUMN user_id SET NOT NULL;

--- a/migrations/frontend/squashed.sql
+++ b/migrations/frontend/squashed.sql
@@ -630,7 +630,7 @@ CREATE TABLE batch_spec_workspace_execution_jobs (
     updated_at timestamp with time zone DEFAULT now() NOT NULL,
     cancel boolean DEFAULT false NOT NULL,
     queued_at timestamp with time zone DEFAULT now(),
-    user_id integer
+    user_id integer NOT NULL
 );
 
 CREATE SEQUENCE batch_spec_workspace_execution_jobs_id_seq


### PR DESCRIPTION
This can only be merged after 3.41 is released. See https://github.com/sourcegraph/sourcegraph/pull/36059 for the original change.

## Test plan

Validated with our DB test suite.