### PR TITLE
add support of default printing for Maven dependencies

### DIFF
--- a/cmd/gitserver/server/vcs_dependencies_syncer.go
+++ b/cmd/gitserver/server/vcs_dependencies_syncer.go
@@ -150,7 +150,7 @@ func (s *vcsDependenciesSyncer) Fetch(ctx context.Context, remoteURL *vcs.URL, d
 			continue
 		}
 		if err := s.gitPushDependencyTag(ctx, string(dir), dependency); err != nil {
-			return errors.Wrapf(err, "error pushing dependency %q", dependency.PackageManagerSyntax())
+			return errors.Wrapf(err, "error pushing dependency %q", dependency)
 		}
 	}
 

--- a/cmd/gitserver/server/vcs_syncer_jvm_packages.go
+++ b/cmd/gitserver/server/vcs_syncer_jvm_packages.go
@@ -91,7 +91,7 @@ func (s *jvmPackagesSyncer) Download(ctx context.Context, dir string, dep reposo
 	// commitJar creates a git commit in the given working directory that adds all the file contents of the given jar file.
 	// A `*.jar` file works the same way as a `*.zip` file, it can even be uncompressed with the `unzip` command-line tool.
 	if err := unzipJarFile(sourceCodeJarPath, dir); err != nil {
-		return errors.Wrapf(err, "failed to unzip jar file for %s to %v", dep.PackageManagerSyntax(), sourceCodeJarPath)
+		return errors.Wrapf(err, "failed to unzip jar file for %s to %v", dep, sourceCodeJarPath)
 	}
 
 	file, err := os.Create(filepath.Join(dir, "lsif-java.json"))

--- a/cmd/gitserver/server/vcs_syncer_npm_packages.go
+++ b/cmd/gitserver/server/vcs_syncer_npm_packages.go
@@ -81,7 +81,7 @@ func (s *npmPackagesSyncer) Download(ctx context.Context, dir string, dep reposo
 	defer tgz.Close()
 
 	if err = decompressTgz(tgz, dir); err != nil {
-		return errors.Wrapf(err, "failed to decompress gzipped tarball for %s", dep.PackageManagerSyntax())
+		return errors.Wrapf(err, "failed to decompress gzipped tarball for %s", dep)
 	}
 
 	return nil

--- a/internal/conf/reposource/jvm_packages.go
+++ b/internal/conf/reposource/jvm_packages.go
@@ -69,25 +69,29 @@ type MavenDependency struct {
 	Version string
 }
 
-func (m *MavenDependency) Equal(o *MavenDependency) bool {
-	return m == o || (m != nil && o != nil &&
-		m.MavenModule.Equal(o.MavenModule) &&
-		m.Version == o.Version)
+func (d *MavenDependency) Equal(o *MavenDependency) bool {
+	return d == o || (d != nil && o != nil &&
+		d.MavenModule.Equal(o.MavenModule) &&
+		d.Version == o.Version)
 }
 
-func (m *MavenDependency) Less(other PackageDependency) bool {
+func (d *MavenDependency) Less(other PackageDependency) bool {
 	o := other.(*MavenDependency)
 
-	if m.MavenModule.Equal(o.MavenModule) {
-		return versionGreaterThan(m.Version, o.Version)
+	if d.MavenModule.Equal(o.MavenModule) {
+		return versionGreaterThan(d.Version, o.Version)
 	}
 
 	// TODO: This SortText method is quite inefficient and allocates.
-	return m.SortText() > o.SortText()
+	return d.SortText() > o.SortText()
 }
 
 func (d *MavenDependency) PackageManagerSyntax() string {
 	return fmt.Sprintf("%s:%s", d.PackageSyntax(), d.Version)
+}
+
+func (d *MavenDependency) String() string {
+	return d.PackageManagerSyntax()
 }
 
 func (d *MavenDependency) PackageVersion() string {


### PR DESCRIPTION
This is intended to fix such [log entries](https://console.cloud.google.com/logs/query;query=resource.type%3D%22k8s_container%22%0Aresource.labels.cluster_name%3D%22cloud%22%0Aresource.labels.container_name%3D%22gitserver%22%0Aresource.labels.namespace_name%3D%22prod%22%0A%22performing%20background%20repo%20update%22%0A--%20jsonPayload.Attributes.error!~%22Access%20denied%22%20%0A--%20and%20jsonPayload.Attributes.error!~%22Repository%20not%20found%22%20%0A--%20and%20jsonPayload.Attributes.error!~%22IP%20allow%20list%20enabled%22%0A--%20jsonPayload.Attributes.error!~%22Authentication%20failed%20for%22%0AjsonPayload.Attributes.error%3D~%22error%20pushing%20dependency%22%0Atimestamp%3D%222022-06-08T18:17:16.728639418Z%22%0AinsertId%3D%22dmk81z5tupei16if%22;timeRange=2022-06-08T05:51:09.602Z%2F2022-06-08T18:51:09.602Z;summaryFields=jsonPayload%252FAttributes%252Ferror:false:32:beginning:false;lfeCustomFields=resource%252Flabels%252Fcontainer_name;cursorTimestamp=2022-06-08T18:17:16.728639418Z?project=sourcegraph-dev)

I decided to override `String()` function instead of fixing [such usages](https://sourcegraph.com/-/editor?remote_url=https%3A%2F%2Fgithub.com%2Fsourcegraph%2Fsourcegraph.git&branch=ao%2Fjvm-dep-support-string-method&file=internal%2Fextsvc%2Fjvmpackages%2Fcoursier%2Fcoursier.go&editor=JetBrains&version=v1.2.2&start_row=118&start_col=76&end_row=118&end_col=76) with adding of `.PackageManagerSyntax()` because it is easier for logging purpose to just pass an object which already knows how to print themself.

## Test plan
logging change, no tests needed
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
