### PR TITLE
fix(repoupdater): only log when there is an error

### DIFF
--- a/internal/repos/observability.go
+++ b/internal/repos/observability.go
@@ -129,7 +129,9 @@ func (o *observedSource) GetRepo(ctx context.Context, path string) (sourced *typ
 	defer func(began time.Time) {
 		secs := time.Since(began).Seconds()
 		o.metrics.GetRepo.Observe(secs, 1, &err)
-		o.logger.Error("source.get-repo", log.Error(err))
+		if err != nil {
+			o.logger.Error("source.get-repo", log.Error(err))
+		}
 	}(time.Now())
 
 	return rg.GetRepo(ctx, path)


### PR DESCRIPTION
rogue log line that logged errors even though they're nil
## Test plan
unit tests
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
