### PR TITLE
Add ability for Bitbucket clients to use projectKeys

### DIFF
--- a/internal/extsvc/bitbucketserver/client.go
+++ b/internal/extsvc/bitbucketserver/client.go
@@ -790,6 +790,27 @@ func (c *Client) LoadPullRequestBuildStatuses(ctx context.Context, pr *PullReque
 	return nil
 }
 
+// ProjectRepos returns all repos of a project with a given projectKey
+func (c *Client) ProjectRepos(ctx context.Context, projectKey string) (repos []*Repo, err error) {
+	if projectKey == "" {
+		return nil, errors.New("project key empty")
+	}
+
+	path := fmt.Sprintf("rest/api/1.0/projects/%s/repos", projectKey)
+
+	pageToken := &PageToken{Limit: 1000}
+
+	for pageToken.HasMore() {
+		var page []*Repo
+		if pageToken, err = c.page(ctx, path, nil, pageToken, &page); err != nil {
+			return nil, err
+		}
+		repos = append(repos, page...)
+	}
+
+	return repos, nil
+}
+
 func (c *Client) Repo(ctx context.Context, projectKey, repoSlug string) (*Repo, error) {
 	u := fmt.Sprintf("rest/api/1.0/projects/%s/repos/%s", projectKey, repoSlug)
 	req, err := http.NewRequest("GET", u, nil)

--- a/internal/repos/bitbucketserver.go
+++ b/internal/repos/bitbucketserver.go
@@ -265,6 +265,20 @@ func (s *BitbucketServerSource) listAllRepos(ctx context.Context, results chan S
 		}(q)
 	}
 
+	for _, q := range s.config.ProjectKeys {
+		wg.Add(1)
+		go func(q string) {
+			defer wg.Done()
+
+			repos, err := s.client.ProjectRepos(ctx, q)
+			if err != nil {
+				ch <- batch{err: errors.Wrapf(err, "bitbucketserver.projectKeys: query=%q", q)}
+			}
+
+			ch <- batch{repos: repos}
+		}(q)
+	}
+
 	go func() {
 		wg.Wait()
 		close(ch)

--- a/internal/repos/bitbucketserver_test.go
+++ b/internal/repos/bitbucketserver_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 func TestBitbucketServerSource_MakeRepo(t *testing.T) {
-	repos := GetReposFromTestdata(t)
+	repos := GetReposFromTestdata(t, "bitbucketserver-repos.json")
 
 	cases := map[string]*schema.BitbucketServerConnection{
 		"simple": {
@@ -209,7 +209,7 @@ func TestBitbucketServerSource_WithAuthenticator(t *testing.T) {
 }
 
 func TestBitbucketServerSource_ListByReposOnly(t *testing.T) {
-	repos := GetReposFromTestdata(t)
+	repos := GetReposFromTestdata(t, "bitbucketserver-repos.json")
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/rest/api/1.0/projects/", func(w http.ResponseWriter, r *http.Request) {
@@ -258,7 +258,7 @@ func TestBitbucketServerSource_ListByReposOnly(t *testing.T) {
 }
 
 func TestBitbucketServerSource_ListByRepositoryQuery(t *testing.T) {
-	repos := GetReposFromTestdata(t)
+	repos := GetReposFromTestdata(t, "bitbucketserver-repos.json")
 
 	type Results struct {
 		*bitbucketserver.PageToken
@@ -357,7 +357,7 @@ func TestBitbucketServerSource_ListByRepositoryQuery(t *testing.T) {
 }
 
 func TestBitbucketServerSource_ListByProjectKeyMock(t *testing.T) {
-	repos := GetReposFromTestdata(t)
+	repos := GetReposFromTestdata(t, "bitbucketserver-repos.json")
 
 	type Results struct {
 		*bitbucketserver.PageToken
@@ -475,8 +475,8 @@ func TestBitbucketServerSource_ListByProjectKeyAuthentic(t *testing.T) {
 
 }
 
-func GetReposFromTestdata(t *testing.T) []*bitbucketserver.Repo {
-	b, err := os.ReadFile(filepath.Join("testdata", "bitbucketserver-repos.json"))
+func GetReposFromTestdata(t *testing.T, filename string) []*bitbucketserver.Repo {
+	b, err := os.ReadFile(filepath.Join("testdata", filename))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/repos/bitbucketserver_test.go
+++ b/internal/repos/bitbucketserver_test.go
@@ -421,16 +421,9 @@ func TestBitbucketServerSource_ListByProjectKeyMock(t *testing.T) {
 
 func TestBitbucketServerSource_ListByProjectKeyAuthentic(t *testing.T) {
 	url := "https://bitbucket.sgdev.org"
-	TOKEN := os.Getenv("BITBUCKET_SERVER_TOKEN")
+	token := os.Getenv("BITBUCKET_SERVER_TOKEN")
 
-	var update bool
-	if TOKEN == "" {
-		update = false
-	} else {
-		update = true
-	}
-
-	cases, svc := GetConfig(t, url, TOKEN)
+	cases, svc := GetConfig(t, url, token)
 
 	for name, config := range cases {
 		t.Run(name, func(t *testing.T) {
@@ -438,7 +431,7 @@ func TestBitbucketServerSource_ListByProjectKeyAuthentic(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			cli := bitbucketserver.NewTestClient(t, name, update)
+			cli := bitbucketserver.NewTestClient(t, name, update(name))
 			s.client = cli
 
 			s.config.ProjectKeys = []string{
@@ -455,7 +448,6 @@ func TestBitbucketServerSource_ListByProjectKeyAuthentic(t *testing.T) {
 
 			var got []*types.Repo
 
-		verify:
 			for {
 				select {
 				case res := <-results:
@@ -465,8 +457,8 @@ func TestBitbucketServerSource_ListByProjectKeyAuthentic(t *testing.T) {
 				default:
 					if len(got) == 1 {
 						path := filepath.Join("testdata/authentic", "bitbucketserver-repos-"+name+".golden")
-						testutil.AssertGolden(t, path, update, got)
-						break verify
+						testutil.AssertGolden(t, path, update(name), got)
+						return
 					}
 				}
 			}

--- a/internal/repos/bitbucketserver_test.go
+++ b/internal/repos/bitbucketserver_test.go
@@ -1,10 +1,16 @@
 package repos
 
 import (
+	"context"
 	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/auth"
@@ -207,4 +213,299 @@ func TestBitbucketServerSource_WithAuthenticator(t *testing.T) {
 			})
 		}
 	})
+}
+
+func TestBitbucketServerSource_ListByReposOnly(t *testing.T) {
+	repos := GetReposFromTestdata(t)
+
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/rest/api/1.0/projects/", func(w http.ResponseWriter, r *http.Request) {
+		pathArr := strings.Split(r.URL.Path, "/")
+		projectKey := pathArr[5]
+		repoSlug := pathArr[7]
+
+		for _, repo := range repos {
+			if repo.Project.Key == projectKey && repo.Slug == repoSlug {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				json.NewEncoder(w).Encode(repo)
+			}
+		}
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	cases, svc := GetConfig(t, server)
+	for name, config := range cases {
+		t.Run(name, func(t *testing.T) {
+			s, err := newBitbucketServerSource(&svc, config, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			s.config.Repos = []string{
+				"SG/go-langserver",
+				"SG/python-langserver",
+				"SG/python-langserver-fork",
+				"~KEEGAN/rgp",
+				"~KEEGAN/rgp-unavailable",
+			}
+
+			ctxWithTimeout, cancelFunction := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancelFunction()
+
+			results := make(chan SourceResult, 10)
+			defer close(results)
+
+			s.ListRepos(ctxWithTimeout, results)
+			VerifyData(t, ctxWithTimeout, 4, results)
+		})
+	}
+}
+
+func TestBitbucketServerSource_ListByRepositoryQuery(t *testing.T) {
+	repos := GetReposFromTestdata(t)
+
+	type Results struct {
+		*bitbucketserver.PageToken
+		Values any `json:"values"`
+	}
+
+	pageToken := bitbucketserver.PageToken{
+		Size:          1,
+		Limit:         1000,
+		IsLastPage:    true,
+		Start:         1,
+		NextPageStart: 1,
+	}
+
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/rest/api/1.0/repos", func(w http.ResponseWriter, r *http.Request) {
+		projectName := r.URL.Query().Get("projectName")
+
+		if projectName == "" {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(Results{
+				PageToken: &pageToken,
+				Values:    repos,
+			})
+		} else {
+			for _, repo := range repos {
+				if projectName == repo.Name {
+					w.Header().Set("Content-Type", "application/json")
+					w.WriteHeader(http.StatusOK)
+					json.NewEncoder(w).Encode(Results{
+						PageToken: &pageToken,
+						Values:    []bitbucketserver.Repo{repo},
+					})
+				}
+			}
+		}
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	cases, svc := GetConfig(t, server)
+
+	tcs := []struct {
+		queries []string
+		exp     int
+	}{
+		{
+			[]string{
+				"?projectName=go-langserver",
+				"?projectName=python-langserver",
+				"?projectName=python-langserver-fork",
+				"?projectName=rgp",
+				"?projectName=rgp-unavailable",
+			},
+			4,
+		},
+		{
+			[]string{
+				"all",
+			},
+			4,
+		},
+		{
+			[]string{
+				"none",
+			},
+			0,
+		},
+	}
+
+	for _, tc := range tcs {
+		tc := tc
+		for name, config := range cases {
+			t.Run(name, func(t *testing.T) {
+				s, err := newBitbucketServerSource(&svc, config, nil)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				s.config.RepositoryQuery = tc.queries
+
+				ctxWithTimeout, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+				defer cancel()
+
+				results := make(chan SourceResult, 10)
+				defer close(results)
+
+				s.ListRepos(ctxWithTimeout, results)
+				VerifyData(t, ctxWithTimeout, tc.exp, results)
+			})
+		}
+	}
+
+}
+
+func TestBitbucketServerSource_ListByProjectKey(t *testing.T) {
+	repos := GetReposFromTestdata(t)
+
+	type Results struct {
+		*bitbucketserver.PageToken
+		Values any `json:"values"`
+	}
+
+	pageToken := bitbucketserver.PageToken{
+		Size:          1,
+		Limit:         1000,
+		IsLastPage:    true,
+		Start:         1,
+		NextPageStart: 1,
+	}
+
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/rest/api/1.0/projects/", func(w http.ResponseWriter, r *http.Request) {
+		pathArr := strings.Split(r.URL.Path, "/")
+		projectKey := pathArr[5]
+		values := make([]bitbucketserver.Repo, 0)
+
+		for _, repo := range repos {
+			if repo.Project.Key == projectKey {
+				values = append(values, repo)
+			}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(Results{
+			PageToken: &pageToken,
+			Values:    values,
+		})
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	cases, svc := GetConfig(t, server)
+	for name, config := range cases {
+		t.Run(name, func(t *testing.T) {
+			s, err := newBitbucketServerSource(&svc, config, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			s.config.ProjectKeys = []string{
+				"SG",
+				"~KEEGAN",
+			}
+
+			ctxWithTimeout, cancelFunction := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancelFunction()
+
+			results := make(chan SourceResult, 20)
+			defer close(results)
+
+			s.ListRepos(ctxWithTimeout, results)
+			VerifyData(t, ctxWithTimeout, 4, results)
+		})
+	}
+}
+
+func GetReposFromTestdata(t *testing.T) []bitbucketserver.Repo {
+	b, err := os.ReadFile(filepath.Join("testdata", "bitbucketserver-repos.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var repos []bitbucketserver.Repo
+	if err := json.Unmarshal(b, &repos); err != nil {
+		t.Fatal(err)
+	}
+
+	return repos
+}
+
+func GetConfig(t *testing.T, server *httptest.Server) (map[string]*schema.BitbucketServerConnection, types.ExternalService) {
+	cases := map[string]*schema.BitbucketServerConnection{
+		"simple": {
+			Url:   server.URL,
+			Token: "secret",
+		},
+		"ssh": {
+			Url:                         server.URL,
+			Token:                       "secret",
+			InitialRepositoryEnablement: true,
+			GitURLType:                  "ssh",
+		},
+		"path-pattern": {
+			Url:                   server.URL,
+			Token:                 "secret",
+			RepositoryPathPattern: "bb/{projectKey}/{repositorySlug}",
+		},
+		"username": {
+			Url:                   server.URL,
+			Username:              "foo",
+			Token:                 "secret",
+			RepositoryPathPattern: "bb/{projectKey}/{repositorySlug}",
+		},
+	}
+
+	svc := types.ExternalService{ID: 1, Kind: extsvc.KindBitbucketServer}
+
+	return cases, svc
+}
+
+func VerifyData(t *testing.T, ctx context.Context, numExpectedResults int, results chan SourceResult) {
+	numTotalResults := len(results)
+	numReceivedFromResults := 0
+
+	if numTotalResults != numExpectedResults {
+		fmt.Println("numTotalResults:", numTotalResults, ", numExpectedResults:", numExpectedResults)
+		t.Fatal(errors.New("wrong number of results"))
+	}
+
+	repoNameMap := map[string]struct{}{
+		"SG/go-langserver":          {},
+		"SG/python-langserver":      {},
+		"SG/python-langserver-fork": {},
+		"~KEEGAN/rgp":               {},
+		"~KEEGAN/rgp-unavailable":   {},
+	}
+
+	for {
+		select {
+		case res := <-results:
+			repoNameArr := strings.Split(string(res.Repo.Name), "/")
+			repoName := repoNameArr[1] + "/" + repoNameArr[2]
+			if _, ok := repoNameMap[repoName]; ok {
+				numReceivedFromResults++
+			} else {
+				t.Fatal(errors.New("wrong repo returned"))
+			}
+		case <-ctx.Done():
+			t.Fatal(errors.New("timeout!"))
+		default:
+			if numReceivedFromResults == numExpectedResults {
+				return
+			}
+		}
+	}
 }

--- a/internal/repos/bitbucketserver_test.go
+++ b/internal/repos/bitbucketserver_test.go
@@ -22,14 +22,7 @@ import (
 )
 
 func TestBitbucketServerSource_MakeRepo(t *testing.T) {
-	b, err := os.ReadFile(filepath.Join("testdata", "bitbucketserver-repos.json"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	var repos []*bitbucketserver.Repo
-	if err := json.Unmarshal(b, &repos); err != nil {
-		t.Fatal(err)
-	}
+	repos := GetReposFromTestdata(t)
 
 	cases := map[string]*schema.BitbucketServerConnection{
 		"simple": {
@@ -219,7 +212,6 @@ func TestBitbucketServerSource_ListByReposOnly(t *testing.T) {
 	repos := GetReposFromTestdata(t)
 
 	mux := http.NewServeMux()
-
 	mux.HandleFunc("/rest/api/1.0/projects/", func(w http.ResponseWriter, r *http.Request) {
 		pathArr := strings.Split(r.URL.Path, "/")
 		projectKey := pathArr[5]
@@ -282,7 +274,6 @@ func TestBitbucketServerSource_ListByRepositoryQuery(t *testing.T) {
 	}
 
 	mux := http.NewServeMux()
-
 	mux.HandleFunc("/rest/api/1.0/repos", func(w http.ResponseWriter, r *http.Request) {
 		projectName := r.URL.Query().Get("projectName")
 
@@ -300,7 +291,7 @@ func TestBitbucketServerSource_ListByRepositoryQuery(t *testing.T) {
 					w.WriteHeader(http.StatusOK)
 					json.NewEncoder(w).Encode(Results{
 						PageToken: &pageToken,
-						Values:    []bitbucketserver.Repo{repo},
+						Values:    []*bitbucketserver.Repo{repo},
 					})
 				}
 			}
@@ -382,11 +373,10 @@ func TestBitbucketServerSource_ListByProjectKeyMock(t *testing.T) {
 	}
 
 	mux := http.NewServeMux()
-
 	mux.HandleFunc("/rest/api/1.0/projects/", func(w http.ResponseWriter, r *http.Request) {
 		pathArr := strings.Split(r.URL.Path, "/")
 		projectKey := pathArr[5]
-		values := make([]bitbucketserver.Repo, 0)
+		values := make([]*bitbucketserver.Repo, 0)
 
 		for _, repo := range repos {
 			if repo.Project.Key == projectKey {
@@ -432,6 +422,7 @@ func TestBitbucketServerSource_ListByProjectKeyMock(t *testing.T) {
 func TestBitbucketServerSource_ListByProjectKeyAuthentic(t *testing.T) {
 	url := "https://bitbucket.sgdev.org"
 	TOKEN := os.Getenv("BITBUCKET_SERVER_TOKEN")
+
 	var update bool
 	if TOKEN == "" {
 		update = false
@@ -484,13 +475,13 @@ func TestBitbucketServerSource_ListByProjectKeyAuthentic(t *testing.T) {
 
 }
 
-func GetReposFromTestdata(t *testing.T) []bitbucketserver.Repo {
+func GetReposFromTestdata(t *testing.T) []*bitbucketserver.Repo {
 	b, err := os.ReadFile(filepath.Join("testdata", "bitbucketserver-repos.json"))
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	var repos []bitbucketserver.Repo
+	var repos []*bitbucketserver.Repo
 	if err := json.Unmarshal(b, &repos); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/repos/testdata/authentic/bitbucketserver-repos-path-pattern.golden
+++ b/internal/repos/testdata/authentic/bitbucketserver-repos-path-pattern.golden
@@ -1,0 +1,67 @@
+[
+  {
+   "ID": 0,
+   "Name": "bb/SOURCEGRAPH/jsonrpc2",
+   "URI": "bitbucket.sgdev.org/SOURCEGRAPH/jsonrpc2",
+   "Description": "jsonrpc2",
+   "Fork": false,
+   "Archived": false,
+   "Private": true,
+   "CreatedAt": "0001-01-01T00:00:00Z",
+   "UpdatedAt": "0001-01-01T00:00:00Z",
+   "DeletedAt": "0001-01-01T00:00:00Z",
+   "ExternalRepo": {
+    "ID": "10066",
+    "ServiceType": "bitbucketServer",
+    "ServiceID": "https://bitbucket.sgdev.org/"
+   },
+   "Sources": {
+    "extsvc:bitbucketserver:1": {
+     "ID": "extsvc:bitbucketserver:1",
+     "CloneURL": "https://bitbucket.sgdev.org/scm/sourcegraph/jsonrpc2.git"
+    }
+   },
+   "Metadata": {
+    "slug": "jsonrpc2",
+    "id": 10066,
+    "name": "jsonrpc2",
+    "scmId": "git",
+    "state": "AVAILABLE",
+    "statusMessage": "Available",
+    "forkable": true,
+    "origin": null,
+    "project": {
+     "key": "SOURCEGRAPH",
+     "id": 28,
+     "name": "Sourcegraph e2e testing",
+     "public": false,
+     "type": "NORMAL",
+     "links": {
+      "self": [
+       {
+        "href": "https://bitbucket.sgdev.org/projects/SOURCEGRAPH"
+       }
+      ]
+     }
+    },
+    "public": false,
+    "links": {
+     "clone": [
+      {
+       "href": "ssh://git@bitbucket.sgdev.org:7999/sourcegraph/jsonrpc2.git",
+       "name": "ssh"
+      },
+      {
+       "href": "https://bitbucket.sgdev.org/scm/sourcegraph/jsonrpc2.git",
+       "name": "http"
+      }
+     ],
+     "self": [
+      {
+       "href": "https://bitbucket.sgdev.org/projects/SOURCEGRAPH/repos/jsonrpc2/browse"
+      }
+     ]
+    }
+   }
+  }
+ ]

--- a/internal/repos/testdata/authentic/bitbucketserver-repos-simple.golden
+++ b/internal/repos/testdata/authentic/bitbucketserver-repos-simple.golden
@@ -1,0 +1,67 @@
+[
+  {
+   "ID": 0,
+   "Name": "bitbucket.sgdev.org/SOURCEGRAPH/jsonrpc2",
+   "URI": "bitbucket.sgdev.org/SOURCEGRAPH/jsonrpc2",
+   "Description": "jsonrpc2",
+   "Fork": false,
+   "Archived": false,
+   "Private": true,
+   "CreatedAt": "0001-01-01T00:00:00Z",
+   "UpdatedAt": "0001-01-01T00:00:00Z",
+   "DeletedAt": "0001-01-01T00:00:00Z",
+   "ExternalRepo": {
+    "ID": "10066",
+    "ServiceType": "bitbucketServer",
+    "ServiceID": "https://bitbucket.sgdev.org/"
+   },
+   "Sources": {
+    "extsvc:bitbucketserver:1": {
+     "ID": "extsvc:bitbucketserver:1",
+     "CloneURL": "https://bitbucket.sgdev.org/scm/sourcegraph/jsonrpc2.git"
+    }
+   },
+   "Metadata": {
+    "slug": "jsonrpc2",
+    "id": 10066,
+    "name": "jsonrpc2",
+    "scmId": "git",
+    "state": "AVAILABLE",
+    "statusMessage": "Available",
+    "forkable": true,
+    "origin": null,
+    "project": {
+     "key": "SOURCEGRAPH",
+     "id": 28,
+     "name": "Sourcegraph e2e testing",
+     "public": false,
+     "type": "NORMAL",
+     "links": {
+      "self": [
+       {
+        "href": "https://bitbucket.sgdev.org/projects/SOURCEGRAPH"
+       }
+      ]
+     }
+    },
+    "public": false,
+    "links": {
+     "clone": [
+      {
+       "href": "ssh://git@bitbucket.sgdev.org:7999/sourcegraph/jsonrpc2.git",
+       "name": "ssh"
+      },
+      {
+       "href": "https://bitbucket.sgdev.org/scm/sourcegraph/jsonrpc2.git",
+       "name": "http"
+      }
+     ],
+     "self": [
+      {
+       "href": "https://bitbucket.sgdev.org/projects/SOURCEGRAPH/repos/jsonrpc2/browse"
+      }
+     ]
+    }
+   }
+  }
+ ]

--- a/internal/repos/testdata/authentic/bitbucketserver-repos-ssh.golden
+++ b/internal/repos/testdata/authentic/bitbucketserver-repos-ssh.golden
@@ -1,0 +1,67 @@
+[
+  {
+   "ID": 0,
+   "Name": "bitbucket.sgdev.org/SOURCEGRAPH/jsonrpc2",
+   "URI": "bitbucket.sgdev.org/SOURCEGRAPH/jsonrpc2",
+   "Description": "jsonrpc2",
+   "Fork": false,
+   "Archived": false,
+   "Private": true,
+   "CreatedAt": "0001-01-01T00:00:00Z",
+   "UpdatedAt": "0001-01-01T00:00:00Z",
+   "DeletedAt": "0001-01-01T00:00:00Z",
+   "ExternalRepo": {
+    "ID": "10066",
+    "ServiceType": "bitbucketServer",
+    "ServiceID": "https://bitbucket.sgdev.org/"
+   },
+   "Sources": {
+    "extsvc:bitbucketserver:1": {
+     "ID": "extsvc:bitbucketserver:1",
+     "CloneURL": "ssh://git@bitbucket.sgdev.org:7999/sourcegraph/jsonrpc2.git"
+    }
+   },
+   "Metadata": {
+    "slug": "jsonrpc2",
+    "id": 10066,
+    "name": "jsonrpc2",
+    "scmId": "git",
+    "state": "AVAILABLE",
+    "statusMessage": "Available",
+    "forkable": true,
+    "origin": null,
+    "project": {
+     "key": "SOURCEGRAPH",
+     "id": 28,
+     "name": "Sourcegraph e2e testing",
+     "public": false,
+     "type": "NORMAL",
+     "links": {
+      "self": [
+       {
+        "href": "https://bitbucket.sgdev.org/projects/SOURCEGRAPH"
+       }
+      ]
+     }
+    },
+    "public": false,
+    "links": {
+     "clone": [
+      {
+       "href": "ssh://git@bitbucket.sgdev.org:7999/sourcegraph/jsonrpc2.git",
+       "name": "ssh"
+      },
+      {
+       "href": "https://bitbucket.sgdev.org/scm/sourcegraph/jsonrpc2.git",
+       "name": "http"
+      }
+     ],
+     "self": [
+      {
+       "href": "https://bitbucket.sgdev.org/projects/SOURCEGRAPH/repos/jsonrpc2/browse"
+      }
+     ]
+    }
+   }
+  }
+ ]

--- a/internal/repos/testdata/authentic/bitbucketserver-repos-username.golden
+++ b/internal/repos/testdata/authentic/bitbucketserver-repos-username.golden
@@ -1,0 +1,67 @@
+[
+  {
+   "ID": 0,
+   "Name": "bb/SOURCEGRAPH/jsonrpc2",
+   "URI": "bitbucket.sgdev.org/SOURCEGRAPH/jsonrpc2",
+   "Description": "jsonrpc2",
+   "Fork": false,
+   "Archived": false,
+   "Private": true,
+   "CreatedAt": "0001-01-01T00:00:00Z",
+   "UpdatedAt": "0001-01-01T00:00:00Z",
+   "DeletedAt": "0001-01-01T00:00:00Z",
+   "ExternalRepo": {
+    "ID": "10066",
+    "ServiceType": "bitbucketServer",
+    "ServiceID": "https://bitbucket.sgdev.org/"
+   },
+   "Sources": {
+    "extsvc:bitbucketserver:1": {
+     "ID": "extsvc:bitbucketserver:1",
+     "CloneURL": "https://foo@bitbucket.sgdev.org/scm/sourcegraph/jsonrpc2.git"
+    }
+   },
+   "Metadata": {
+    "slug": "jsonrpc2",
+    "id": 10066,
+    "name": "jsonrpc2",
+    "scmId": "git",
+    "state": "AVAILABLE",
+    "statusMessage": "Available",
+    "forkable": true,
+    "origin": null,
+    "project": {
+     "key": "SOURCEGRAPH",
+     "id": 28,
+     "name": "Sourcegraph e2e testing",
+     "public": false,
+     "type": "NORMAL",
+     "links": {
+      "self": [
+       {
+        "href": "https://bitbucket.sgdev.org/projects/SOURCEGRAPH"
+       }
+      ]
+     }
+    },
+    "public": false,
+    "links": {
+     "clone": [
+      {
+       "href": "ssh://git@bitbucket.sgdev.org:7999/sourcegraph/jsonrpc2.git",
+       "name": "ssh"
+      },
+      {
+       "href": "https://bitbucket.sgdev.org/scm/sourcegraph/jsonrpc2.git",
+       "name": "http"
+      }
+     ],
+     "self": [
+      {
+       "href": "https://bitbucket.sgdev.org/projects/SOURCEGRAPH/repos/jsonrpc2/browse"
+      }
+     ]
+    }
+   }
+  }
+ ]

--- a/internal/repos/testdata/vcr/path-pattern.yaml
+++ b/internal/repos/testdata/vcr/path-pattern.yaml
@@ -1,0 +1,78 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    url: https://bitbucket.sgdev.org/rest/api/1.0/labels/archived/labeled?REPOSITORY=&limit=1000
+    method: GET
+  response:
+    body: '{"size":1,"limit":1000,"isLastPage":true,"values":[{"slug":"archived-repo","id":10073,"name":"archived-repo","hierarchyId":"05788c1a4ffadf0ff5d8","scmId":"git","state":"AVAILABLE","statusMessage":"Available","forkable":true,"project":{"key":"PUBLIC","id":4,"name":"Public","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/PUBLIC"}]}},"public":false,"labelableType":"REPOSITORY","links":{"clone":[{"href":"ssh://git@bitbucket.sgdev.org:7999/public/archived-repo.git","name":"ssh"},{"href":"https://bitbucket.sgdev.org/scm/public/archived-repo.git","name":"http"}],"self":[{"href":"https://bitbucket.sgdev.org/projects/PUBLIC/repos/archived-repo/browse"}]}}],"start":0}'
+    headers:
+      Cache-Control:
+      - private, no-cache
+      - no-cache, no-transform
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Sun, 12 Jun 2022 12:51:47 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Caddy
+      Vary:
+      - x-ausername,x-auserid,cookie,accept-encoding
+      X-Arequestid:
+      - '@157E7ZCx771x3281105x0'
+      X-Asessionid:
+      - sud047
+      X-Auserid:
+      - "1"
+      X-Ausername:
+      - milton
+      X-Content-Type-Options:
+      - nosniff
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    url: https://bitbucket.sgdev.org/rest/api/1.0/projects/SOURCEGRAPH/repos?limit=1000
+    method: GET
+  response:
+    body: '{"size":1,"limit":1000,"isLastPage":true,"values":[{"slug":"jsonrpc2","id":10066,"name":"jsonrpc2","hierarchyId":"baae97879aa9c31e1fe9","scmId":"git","state":"AVAILABLE","statusMessage":"Available","forkable":true,"project":{"key":"SOURCEGRAPH","id":28,"name":"Sourcegraph
+      e2e testing","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOURCEGRAPH"}]}},"public":false,"links":{"clone":[{"href":"ssh://git@bitbucket.sgdev.org:7999/sourcegraph/jsonrpc2.git","name":"ssh"},{"href":"https://bitbucket.sgdev.org/scm/sourcegraph/jsonrpc2.git","name":"http"}],"self":[{"href":"https://bitbucket.sgdev.org/projects/SOURCEGRAPH/repos/jsonrpc2/browse"}]}}],"start":0}'
+    headers:
+      Cache-Control:
+      - private, no-cache
+      - no-cache, no-transform
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Sun, 12 Jun 2022 12:51:47 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Caddy
+      Vary:
+      - x-ausername,x-auserid,cookie,accept-encoding
+      X-Arequestid:
+      - '@157E7ZCx771x3281106x0'
+      X-Asessionid:
+      - vsid3m
+      X-Auserid:
+      - "1"
+      X-Ausername:
+      - milton
+      X-Content-Type-Options:
+      - nosniff
+    status: 200 OK
+    code: 200
+    duration: ""

--- a/internal/repos/testdata/vcr/simple.yaml
+++ b/internal/repos/testdata/vcr/simple.yaml
@@ -1,0 +1,78 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    url: https://bitbucket.sgdev.org/rest/api/1.0/labels/archived/labeled?REPOSITORY=&limit=1000
+    method: GET
+  response:
+    body: '{"size":1,"limit":1000,"isLastPage":true,"values":[{"slug":"archived-repo","id":10073,"name":"archived-repo","hierarchyId":"05788c1a4ffadf0ff5d8","scmId":"git","state":"AVAILABLE","statusMessage":"Available","forkable":true,"project":{"key":"PUBLIC","id":4,"name":"Public","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/PUBLIC"}]}},"public":false,"labelableType":"REPOSITORY","links":{"clone":[{"href":"ssh://git@bitbucket.sgdev.org:7999/public/archived-repo.git","name":"ssh"},{"href":"https://bitbucket.sgdev.org/scm/public/archived-repo.git","name":"http"}],"self":[{"href":"https://bitbucket.sgdev.org/projects/PUBLIC/repos/archived-repo/browse"}]}}],"start":0}'
+    headers:
+      Cache-Control:
+      - private, no-cache
+      - no-cache, no-transform
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Sun, 12 Jun 2022 12:51:45 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Caddy
+      Vary:
+      - x-ausername,x-auserid,cookie,accept-encoding
+      X-Arequestid:
+      - '@157E7ZCx771x3281101x0'
+      X-Asessionid:
+      - 1dxymu3
+      X-Auserid:
+      - "1"
+      X-Ausername:
+      - milton
+      X-Content-Type-Options:
+      - nosniff
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    url: https://bitbucket.sgdev.org/rest/api/1.0/projects/SOURCEGRAPH/repos?limit=1000
+    method: GET
+  response:
+    body: '{"size":1,"limit":1000,"isLastPage":true,"values":[{"slug":"jsonrpc2","id":10066,"name":"jsonrpc2","hierarchyId":"baae97879aa9c31e1fe9","scmId":"git","state":"AVAILABLE","statusMessage":"Available","forkable":true,"project":{"key":"SOURCEGRAPH","id":28,"name":"Sourcegraph
+      e2e testing","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOURCEGRAPH"}]}},"public":false,"links":{"clone":[{"href":"ssh://git@bitbucket.sgdev.org:7999/sourcegraph/jsonrpc2.git","name":"ssh"},{"href":"https://bitbucket.sgdev.org/scm/sourcegraph/jsonrpc2.git","name":"http"}],"self":[{"href":"https://bitbucket.sgdev.org/projects/SOURCEGRAPH/repos/jsonrpc2/browse"}]}}],"start":0}'
+    headers:
+      Cache-Control:
+      - private, no-cache
+      - no-cache, no-transform
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Sun, 12 Jun 2022 12:51:45 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Caddy
+      Vary:
+      - x-ausername,x-auserid,cookie,accept-encoding
+      X-Arequestid:
+      - '@157E7ZCx771x3281102x0'
+      X-Asessionid:
+      - y9tkp6
+      X-Auserid:
+      - "1"
+      X-Ausername:
+      - milton
+      X-Content-Type-Options:
+      - nosniff
+    status: 200 OK
+    code: 200
+    duration: ""

--- a/internal/repos/testdata/vcr/ssh.yaml
+++ b/internal/repos/testdata/vcr/ssh.yaml
@@ -1,0 +1,78 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    url: https://bitbucket.sgdev.org/rest/api/1.0/labels/archived/labeled?REPOSITORY=&limit=1000
+    method: GET
+  response:
+    body: '{"size":1,"limit":1000,"isLastPage":true,"values":[{"slug":"archived-repo","id":10073,"name":"archived-repo","hierarchyId":"05788c1a4ffadf0ff5d8","scmId":"git","state":"AVAILABLE","statusMessage":"Available","forkable":true,"project":{"key":"PUBLIC","id":4,"name":"Public","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/PUBLIC"}]}},"public":false,"labelableType":"REPOSITORY","links":{"clone":[{"href":"ssh://git@bitbucket.sgdev.org:7999/public/archived-repo.git","name":"ssh"},{"href":"https://bitbucket.sgdev.org/scm/public/archived-repo.git","name":"http"}],"self":[{"href":"https://bitbucket.sgdev.org/projects/PUBLIC/repos/archived-repo/browse"}]}}],"start":0}'
+    headers:
+      Cache-Control:
+      - private, no-cache
+      - no-cache, no-transform
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Sun, 12 Jun 2022 12:51:45 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Caddy
+      Vary:
+      - x-ausername,x-auserid,cookie,accept-encoding
+      X-Arequestid:
+      - '@157E7ZCx771x3281103x0'
+      X-Asessionid:
+      - 81jid2
+      X-Auserid:
+      - "1"
+      X-Ausername:
+      - milton
+      X-Content-Type-Options:
+      - nosniff
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    url: https://bitbucket.sgdev.org/rest/api/1.0/projects/SOURCEGRAPH/repos?limit=1000
+    method: GET
+  response:
+    body: '{"size":1,"limit":1000,"isLastPage":true,"values":[{"slug":"jsonrpc2","id":10066,"name":"jsonrpc2","hierarchyId":"baae97879aa9c31e1fe9","scmId":"git","state":"AVAILABLE","statusMessage":"Available","forkable":true,"project":{"key":"SOURCEGRAPH","id":28,"name":"Sourcegraph
+      e2e testing","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOURCEGRAPH"}]}},"public":false,"links":{"clone":[{"href":"ssh://git@bitbucket.sgdev.org:7999/sourcegraph/jsonrpc2.git","name":"ssh"},{"href":"https://bitbucket.sgdev.org/scm/sourcegraph/jsonrpc2.git","name":"http"}],"self":[{"href":"https://bitbucket.sgdev.org/projects/SOURCEGRAPH/repos/jsonrpc2/browse"}]}}],"start":0}'
+    headers:
+      Cache-Control:
+      - private, no-cache
+      - no-cache, no-transform
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Sun, 12 Jun 2022 12:51:45 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Caddy
+      Vary:
+      - x-ausername,x-auserid,cookie,accept-encoding
+      X-Arequestid:
+      - '@157E7ZCx771x3281104x0'
+      X-Asessionid:
+      - bozo50
+      X-Auserid:
+      - "1"
+      X-Ausername:
+      - milton
+      X-Content-Type-Options:
+      - nosniff
+    status: 200 OK
+    code: 200
+    duration: ""

--- a/internal/repos/testdata/vcr/username.yaml
+++ b/internal/repos/testdata/vcr/username.yaml
@@ -1,0 +1,78 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    url: https://bitbucket.sgdev.org/rest/api/1.0/labels/archived/labeled?REPOSITORY=&limit=1000
+    method: GET
+  response:
+    body: '{"size":1,"limit":1000,"isLastPage":true,"values":[{"slug":"archived-repo","id":10073,"name":"archived-repo","hierarchyId":"05788c1a4ffadf0ff5d8","scmId":"git","state":"AVAILABLE","statusMessage":"Available","forkable":true,"project":{"key":"PUBLIC","id":4,"name":"Public","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/PUBLIC"}]}},"public":false,"labelableType":"REPOSITORY","links":{"clone":[{"href":"ssh://git@bitbucket.sgdev.org:7999/public/archived-repo.git","name":"ssh"},{"href":"https://bitbucket.sgdev.org/scm/public/archived-repo.git","name":"http"}],"self":[{"href":"https://bitbucket.sgdev.org/projects/PUBLIC/repos/archived-repo/browse"}]}}],"start":0}'
+    headers:
+      Cache-Control:
+      - private, no-cache
+      - no-cache, no-transform
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Sun, 12 Jun 2022 12:51:47 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Caddy
+      Vary:
+      - x-ausername,x-auserid,cookie,accept-encoding
+      X-Arequestid:
+      - '@157E7ZCx771x3281107x0'
+      X-Asessionid:
+      - 1rj1qkq
+      X-Auserid:
+      - "1"
+      X-Ausername:
+      - milton
+      X-Content-Type-Options:
+      - nosniff
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    url: https://bitbucket.sgdev.org/rest/api/1.0/projects/SOURCEGRAPH/repos?limit=1000
+    method: GET
+  response:
+    body: '{"size":1,"limit":1000,"isLastPage":true,"values":[{"slug":"jsonrpc2","id":10066,"name":"jsonrpc2","hierarchyId":"baae97879aa9c31e1fe9","scmId":"git","state":"AVAILABLE","statusMessage":"Available","forkable":true,"project":{"key":"SOURCEGRAPH","id":28,"name":"Sourcegraph
+      e2e testing","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOURCEGRAPH"}]}},"public":false,"links":{"clone":[{"href":"ssh://git@bitbucket.sgdev.org:7999/sourcegraph/jsonrpc2.git","name":"ssh"},{"href":"https://bitbucket.sgdev.org/scm/sourcegraph/jsonrpc2.git","name":"http"}],"self":[{"href":"https://bitbucket.sgdev.org/projects/SOURCEGRAPH/repos/jsonrpc2/browse"}]}}],"start":0}'
+    headers:
+      Cache-Control:
+      - private, no-cache
+      - no-cache, no-transform
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Sun, 12 Jun 2022 12:51:47 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Caddy
+      Vary:
+      - x-ausername,x-auserid,cookie,accept-encoding
+      X-Arequestid:
+      - '@157E7ZCx771x3281108x0'
+      X-Asessionid:
+      - 1kqp3jk
+      X-Auserid:
+      - "1"
+      X-Ausername:
+      - milton
+      X-Content-Type-Options:
+      - nosniff
+    status: 200 OK
+    code: 200
+    duration: ""

--- a/schema/bitbucket_server.schema.json
+++ b/schema/bitbucket_server.schema.json
@@ -155,6 +155,13 @@
       },
       "examples": [["myproject/myrepo", "myproject/myotherrepo", "~USER/theirrepo"]]
     },
+    "projectKeys": {
+      "description": "An array of project key strings that defines a collection of repositories related to their associated project keys",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
     "exclude": {
       "description": "A list of repositories to never mirror from this Bitbucket Server / Bitbucket Data Center instance. Takes precedence over \"repos\" and \"repositoryQuery\".\n\nSupports excluding by name ({\"name\": \"projectKey/repositorySlug\"}) or by ID ({\"id\": 42}).",
       "type": "array",

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -267,6 +267,8 @@ type BitbucketServerConnection struct {
 	Password string `json:"password,omitempty"`
 	// Plugin description: Configuration for Bitbucket Server / Bitbucket Data Center Sourcegraph plugin
 	Plugin *BitbucketServerPlugin `json:"plugin,omitempty"`
+	// ProjectKeys description: An array of project key strings that defines a collection of repositories related to their associated project keys
+	ProjectKeys []string `json:"projectKeys,omitempty"`
 	// RateLimit description: Rate limit applied when making background API requests to BitbucketServer.
 	RateLimit *BitbucketServerRateLimit `json:"rateLimit,omitempty"`
 	// Repos description: An array of repository "projectKey/repositorySlug" strings specifying repositories to mirror on Sourcegraph.


### PR DESCRIPTION
Previously Bitbucket clients could only specify repos by projectName. Now, if projectKeys are specified in s.config.ProjectKeys, then those repos would be returned as well.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

go test -run TestBitbucketServerSource_ListByReposOnly \\\ to list repos in the config
go test -run TestBitbucketServerSource_ListByRepositoryQuery \\\ to list repos by projectName
go test -run TestBitbucketServerSource_ListByProjectKeyMock \\\ to list repos by projectKey
go test -run TestBitbucketServerSource_ListByProjectKeyAuthentic \\\ to list repos by projectKey as an authentic request