### PR TITLE
extensions: add decorations column background color

### DIFF
--- a/client/web/src/repo/blob/Blob.module.scss
+++ b/client/web/src/repo/blob/Blob.module.scss
@@ -25,6 +25,11 @@
         user-select: none;
         vertical-align: top;
         color: var(--line-number-color);
+
+        :global(.top-spacer),
+        :global(.bottom-spacer) {
+            margin: 0 -0.5rem;
+        }
     }
 
     tr {
@@ -33,25 +38,27 @@
             background: var(--code-selection-bg);
         }
 
-        &:first-child {
-            vertical-align: bottom;
+        &:first-child td:global(.line) {
+            // place bottom spacer below the line number set with ::before pseudo-element
+            display: flex;
+            flex-direction: column-reverse;
+        }
+    }
 
-            td {
-                padding-top: 0.5rem;
-            }
+    td {
+        :global(.top-spacer),
+        :global(.bottom-spacer) {
+            background: var(--code-bg);
         }
 
-        &:last-child {
-            vertical-align: top;
+        :global(.top-spacer) {
+            height: 0.5rem;
+        }
 
+        :global(.bottom-spacer) {
             // Give room to view the last few lines of code
             // without the floating status bar getting in the way.
-            &::after {
-                content: '';
-                display: block;
-                height: calc(var(--blob-status-bar-height) + var(--blob-status-bar-vertical-gap) + 1.5rem);
-                background: green;
-            }
+            height: calc(var(--blob-status-bar-height) + var(--blob-status-bar-vertical-gap) + 1.5rem);
         }
     }
 
@@ -73,6 +80,12 @@
             span::before {
                 content: attr(data-contents);
             }
+        }
+
+        :global(.top-spacer),
+        :global(.bottom-spacer) {
+            margin: 0 0 0 -1rem;
+            display: block;
         }
     }
 

--- a/client/web/src/repo/blob/Blob.module.scss
+++ b/client/web/src/repo/blob/Blob.module.scss
@@ -1,7 +1,6 @@
 .blob {
     position: relative;
     overflow: auto;
-    padding-top: 0.5rem;
     tab-size: 4;
     display: flex;
     background-color: var(--code-bg);
@@ -12,15 +11,6 @@
 
     table {
         border-collapse: collapse;
-
-        // Give room to view the last few lines of code
-        // without the floating status bar getting in the way.
-        &::after {
-            content: '';
-            display: inline-block;
-            padding-bottom: calc(var(--blob-status-bar-height) + var(--blob-status-bar-vertical-gap) + 0.5rem);
-            // Extra 0.5rem padding on top of the minimum required to expose code;
-        }
     }
 
     td:global(.line) {
@@ -38,12 +28,30 @@
     }
 
     tr {
-        &:global(.selected) {
+        &:global(.selected),
+        &:global(.highlighted) {
             background: var(--code-selection-bg);
         }
 
-        &:global(.highlighted) {
-            background: var(--code-selection-bg);
+        &:first-child {
+            vertical-align: bottom;
+
+            td {
+                padding-top: 0.5rem;
+            }
+        }
+
+        &:last-child {
+            vertical-align: top;
+
+            // Give room to view the last few lines of code
+            // without the floating status bar getting in the way.
+            &::after {
+                content: '';
+                display: block;
+                height: calc(var(--blob-status-bar-height) + var(--blob-status-bar-vertical-gap) + 1.5rem);
+                background: green;
+            }
         }
     }
 

--- a/client/web/src/repo/blob/Blob.module.scss
+++ b/client/web/src/repo/blob/Blob.module.scss
@@ -45,23 +45,6 @@
         }
     }
 
-    td {
-        :global(.top-spacer),
-        :global(.bottom-spacer) {
-            background: var(--code-bg);
-        }
-
-        :global(.top-spacer) {
-            height: 0.5rem;
-        }
-
-        :global(.bottom-spacer) {
-            // Give room to view the last few lines of code
-            // without the floating status bar getting in the way.
-            height: calc(var(--blob-status-bar-height) + var(--blob-status-bar-vertical-gap) + 1.5rem);
-        }
-    }
-
     td:global(.line),
     td:global(.code) {
         padding: 0;
@@ -87,6 +70,21 @@
             margin: 0 0 0 -1rem;
             display: block;
         }
+    }
+
+    :global(.top-spacer),
+    :global(.bottom-spacer) {
+        background: var(--code-bg);
+    }
+
+    :global(.top-spacer) {
+        height: 0.5rem;
+    }
+
+    :global(.bottom-spacer) {
+        // Give room to view the last few lines of code
+        // without the floating status bar getting in the way.
+        height: calc(var(--blob-status-bar-height) + var(--blob-status-bar-vertical-gap) + 1.5rem);
     }
 
     &--wrapped {

--- a/client/web/src/repo/blob/Blob.tsx
+++ b/client/web/src/repo/blob/Blob.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import classNames from 'classnames'
 import { Remote } from 'comlink'
@@ -754,12 +754,7 @@ export const Blob: React.FunctionComponent<React.PropsWithChildren<BlobProps>> =
         ]
     )
 
-    // `ColumnDecorator` uses `useLayoutEffect` instead of `useEffect` in order to synchronously re-render
-    // after mount/decoration updates, but before the browser has painted DOM updates.
-    // This prevents users from seeing inconsistent states where changes handled by React have been
-    // painted, but DOM manipulation handled by these effects are painted on the next tick.
-
-    useLayoutEffect(() => {
+    useEffect(() => {
         const subscription = codeViewElements.subscribe(codeView => {
             if (codeView) {
                 const table = codeView.firstElementChild as HTMLTableElement

--- a/client/web/src/repo/blob/Blob.tsx
+++ b/client/web/src/repo/blob/Blob.tsx
@@ -754,6 +754,7 @@ export const Blob: React.FunctionComponent<React.PropsWithChildren<BlobProps>> =
         ]
     )
 
+    // Add top and bottom spacers to improve code readability.
     useEffect(() => {
         const subscription = codeViewElements.subscribe(codeView => {
             if (codeView) {

--- a/client/web/src/repo/blob/ColumnDecorator.module.scss
+++ b/client/web/src/repo/blob/ColumnDecorator.module.scss
@@ -1,12 +1,20 @@
 .decoration {
-    display: contents;
+    max-width: 240px;
+    padding: 0 0.75rem;
+    background-color: var(--body-bg);
+}
+
+tr:global(.selected),
+tr:global(.highlighted) {
+    .decoration {
+        background: none;
+    }
 }
 
 .wrapper {
-    display: flex;
-    max-width: 220px;
-    padding-right: 0.75rem;
-    padding-left: 0.75rem;
+    > * {
+        max-width: 100%;
+    }
 }
 
 .item {

--- a/client/web/src/repo/blob/ColumnDecorator.module.scss
+++ b/client/web/src/repo/blob/ColumnDecorator.module.scss
@@ -1,7 +1,13 @@
 .decoration {
     max-width: 240px;
     padding: 0 0.75rem;
-    background-color: var(--body-bg);
+    background: var(--body-bg);
+
+    :global(.top-spacer),
+    :global(.bottom-spacer) {
+        background: var(--body-bg) !important;
+        margin: 0 -0.75rem;
+    }
 }
 
 tr:global(.selected),
@@ -12,6 +18,8 @@ tr:global(.highlighted) {
 }
 
 .wrapper {
+    height: 1rem;
+
     > * {
         max-width: 100%;
     }

--- a/client/web/src/repo/blob/ColumnDecorator.tsx
+++ b/client/web/src/repo/blob/ColumnDecorator.tsx
@@ -85,9 +85,17 @@ export const ColumnDecorator = React.memo<LineDecoratorProps>(
                             // add line number cell extra horizontal padding
                             row.querySelector('td.line')?.classList.add('px-2')
 
+                            // add decorations wrapper
                             const wrapper = document.createElement('div')
                             wrapper.classList.add(styles.wrapper)
-                            cell.prepend(wrapper)
+                            cell.append(wrapper)
+
+                            // add extra spacers to first and last rows
+                            if (index === 0 || index === table.rows.length - 1) {
+                                const spacer = document.createElement('div')
+                                spacer.classList.add(index === 0 ? 'top-spacer' : 'bottom-spacer')
+                                cell[index === 0 ? 'prepend' : 'append'](spacer)
+                            }
                         }
 
                         const currentLineDecorations = decorations.get(index + 1)
@@ -128,6 +136,7 @@ export const ColumnDecorator = React.memo<LineDecoratorProps>(
                                             portalRoot.dataset.line ?? ''
                                         }`}
                                         content={attachment.hoverMessage || null}
+                                        placement="top"
                                     >
                                         <LinkOrSpan
                                             className={styles.item}
@@ -156,7 +165,7 @@ export const ColumnDecorator = React.memo<LineDecoratorProps>(
                                     </Tooltip>
                                 )
                             }),
-                            portalRoot.firstChild as HTMLDivElement
+                            portalRoot.querySelector(`.${styles.wrapper}`) as HTMLDivElement
                         )
                     )
                     .toArray()}

--- a/client/web/src/repo/blob/ColumnDecorator.tsx
+++ b/client/web/src/repo/blob/ColumnDecorator.tsx
@@ -13,6 +13,7 @@ import {
 } from '@sourcegraph/shared/src/api/extension/api/decorations'
 import { LinkOrSpan } from '@sourcegraph/shared/src/components/LinkOrSpan'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
+import { Tooltip } from '@sourcegraph/wildcard'
 
 import styles from './ColumnDecorator.module.scss'
 
@@ -54,7 +55,14 @@ export const ColumnDecorator = React.memo<LineDecoratorProps>(
             const cleanup = (): void => {
                 // remove added cells
                 for (const [cell] of addedCells) {
+                    const row = cell.closest('tr')
                     cell.remove()
+
+                    // if no other columns with decorations
+                    if (!row?.querySelector(`.${styles.decoration}`)) {
+                        // remove line number cell extra horizontal padding
+                        row?.querySelector('td.line')?.classList.remove('px-2')
+                    }
                 }
 
                 // reset state
@@ -73,6 +81,9 @@ export const ColumnDecorator = React.memo<LineDecoratorProps>(
                         if (!cell) {
                             cell = row.insertCell(1)
                             cell.classList.add(styles.decoration, className)
+
+                            // add line number cell extra horizontal padding
+                            row.querySelector('td.line')?.classList.add('px-2')
 
                             const wrapper = document.createElement('div')
                             wrapper.classList.add(styles.wrapper)
@@ -112,34 +123,37 @@ export const ColumnDecorator = React.memo<LineDecoratorProps>(
                                 const style = decorationAttachmentStyleForTheme(attachment, isLightTheme)
 
                                 return (
-                                    <LinkOrSpan
+                                    <Tooltip
                                         key={`${decoration.after.contentText ?? decoration.after.hoverMessage ?? ''}-${
                                             portalRoot.dataset.line ?? ''
                                         }`}
-                                        className={styles.item}
-                                        // eslint-disable-next-line react/forbid-dom-props
-                                        style={{ color: style.color }}
-                                        data-tooltip={attachment.hoverMessage}
-                                        to={attachment.linkURL}
-                                        // Use target to open external URLs
-                                        target={
-                                            attachment.linkURL && isAbsoluteUrl(attachment.linkURL)
-                                                ? '_blank'
-                                                : undefined
-                                        }
-                                        // Avoid leaking referrer URLs (which contain repository and path names, etc.) to external sites.
-                                        rel="noreferrer noopener"
-                                        onMouseEnter={selectRow}
-                                        onMouseLeave={deselectRow}
-                                        onFocus={selectRow}
-                                        onBlur={deselectRow}
+                                        content={attachment.hoverMessage || null}
                                     >
-                                        <span
-                                            className={styles.contents}
-                                            data-line-decoration-attachment-content={true}
-                                            data-contents={attachment.contentText || ''}
-                                        />
-                                    </LinkOrSpan>
+                                        <LinkOrSpan
+                                            className={styles.item}
+                                            // eslint-disable-next-line react/forbid-dom-props
+                                            style={{ color: style.color }}
+                                            to={attachment.linkURL}
+                                            // Use target to open external URLs
+                                            target={
+                                                attachment.linkURL && isAbsoluteUrl(attachment.linkURL)
+                                                    ? '_blank'
+                                                    : undefined
+                                            }
+                                            // Avoid leaking referrer URLs (which contain repository and path names, etc.) to external sites.
+                                            rel="noreferrer noopener"
+                                            onMouseEnter={selectRow}
+                                            onMouseLeave={deselectRow}
+                                            onFocus={selectRow}
+                                            onBlur={deselectRow}
+                                        >
+                                            <span
+                                                className={styles.contents}
+                                                data-line-decoration-attachment-content={true}
+                                                data-contents={attachment.contentText || ''}
+                                            />
+                                        </LinkOrSpan>
+                                    </Tooltip>
                                 )
                             }),
                             portalRoot.firstChild as HTMLDivElement

--- a/client/web/src/repo/blob/LineDecorator.tsx
+++ b/client/web/src/repo/blob/LineDecorator.tsx
@@ -12,7 +12,6 @@ import {
 } from '@sourcegraph/shared/src/api/extension/api/decorations'
 import { LinkOrSpan } from '@sourcegraph/shared/src/components/LinkOrSpan'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
-import { Tooltip } from '@sourcegraph/wildcard'
 
 import styles from './LineDecorator.module.scss'
 
@@ -140,37 +139,32 @@ export const LineDecorator = React.memo<LineDecoratorProps>(
                 const style = decorationAttachmentStyleForTheme(attachment, isLightTheme)
 
                 return (
-                    <Tooltip
+                    <LinkOrSpan
+                        // Key by content, use index to remove possibility of duplicate keys
                         key={`${decoration.after.contentText ?? decoration.after.hoverMessage ?? ''}-${index}`}
-                        content={attachment.hoverMessage || null}
+                        className={styles.lineDecorationAttachment}
+                        data-line-decoration-attachment={true}
+                        to={attachment.linkURL}
+                        data-tooltip={attachment.hoverMessage}
+                        // Use target to open external URLs
+                        target={attachment.linkURL && isAbsoluteUrl(attachment.linkURL) ? '_blank' : undefined}
+                        // Avoid leaking referrer URLs (which contain repository and path names, etc.) to external sites.
+                        rel="noreferrer noopener"
                     >
-                        <LinkOrSpan
-                            // Key by content, use index to remove possibility of duplicate keys
-                            className={styles.lineDecorationAttachment}
-                            data-line-decoration-attachment={true}
-                            to={attachment.linkURL}
-                            // Use target to open external URLs
-                            target={attachment.linkURL && isAbsoluteUrl(attachment.linkURL) ? '_blank' : undefined}
-                            // Avoid leaking referrer URLs (which contain repository and path names, etc.) to external sites.
-                            rel="noreferrer noopener"
-                        >
-                            <span
-                                className={styles.contents}
-                                data-line-decoration-attachment-content={true}
-                                // eslint-disable-next-line react/forbid-dom-props
-                                style={{
-                                    color: style.color,
-                                    backgroundColor: style.backgroundColor,
-                                }}
-                                data-contents={attachment.contentText || ''}
-                            />
-                        </LinkOrSpan>
-                    </Tooltip>
+                        <span
+                            className={styles.contents}
+                            data-line-decoration-attachment-content={true}
+                            // eslint-disable-next-line react/forbid-dom-props
+                            style={{
+                                color: style.color,
+                                backgroundColor: style.backgroundColor,
+                            }}
+                            data-contents={attachment.contentText || ''}
+                        />
+                    </LinkOrSpan>
                 )
             }),
             portalNode
         )
     }
 )
-
-LineDecorator.displayName = 'LineDecorator'

--- a/client/web/src/repo/blob/LineDecorator.tsx
+++ b/client/web/src/repo/blob/LineDecorator.tsx
@@ -12,6 +12,7 @@ import {
 } from '@sourcegraph/shared/src/api/extension/api/decorations'
 import { LinkOrSpan } from '@sourcegraph/shared/src/components/LinkOrSpan'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
+import { Tooltip } from '@sourcegraph/wildcard'
 
 import styles from './LineDecorator.module.scss'
 
@@ -139,32 +140,37 @@ export const LineDecorator = React.memo<LineDecoratorProps>(
                 const style = decorationAttachmentStyleForTheme(attachment, isLightTheme)
 
                 return (
-                    <LinkOrSpan
-                        // Key by content, use index to remove possibility of duplicate keys
+                    <Tooltip
                         key={`${decoration.after.contentText ?? decoration.after.hoverMessage ?? ''}-${index}`}
-                        className={styles.lineDecorationAttachment}
-                        data-line-decoration-attachment={true}
-                        to={attachment.linkURL}
-                        data-tooltip={attachment.hoverMessage}
-                        // Use target to open external URLs
-                        target={attachment.linkURL && isAbsoluteUrl(attachment.linkURL) ? '_blank' : undefined}
-                        // Avoid leaking referrer URLs (which contain repository and path names, etc.) to external sites.
-                        rel="noreferrer noopener"
+                        content={attachment.hoverMessage || null}
                     >
-                        <span
-                            className={styles.contents}
-                            data-line-decoration-attachment-content={true}
-                            // eslint-disable-next-line react/forbid-dom-props
-                            style={{
-                                color: style.color,
-                                backgroundColor: style.backgroundColor,
-                            }}
-                            data-contents={attachment.contentText || ''}
-                        />
-                    </LinkOrSpan>
+                        <LinkOrSpan
+                            // Key by content, use index to remove possibility of duplicate keys
+                            className={styles.lineDecorationAttachment}
+                            data-line-decoration-attachment={true}
+                            to={attachment.linkURL}
+                            // Use target to open external URLs
+                            target={attachment.linkURL && isAbsoluteUrl(attachment.linkURL) ? '_blank' : undefined}
+                            // Avoid leaking referrer URLs (which contain repository and path names, etc.) to external sites.
+                            rel="noreferrer noopener"
+                        >
+                            <span
+                                className={styles.contents}
+                                data-line-decoration-attachment-content={true}
+                                // eslint-disable-next-line react/forbid-dom-props
+                                style={{
+                                    color: style.color,
+                                    backgroundColor: style.backgroundColor,
+                                }}
+                                data-contents={attachment.contentText || ''}
+                            />
+                        </LinkOrSpan>
+                    </Tooltip>
                 )
             }),
             portalNode
         )
     }
 )
+
+LineDecorator.displayName = 'LineDecorator'


### PR DESCRIPTION
Adds background to decoration columns in the blob view.

[Design](https://www.figma.com/file/MzN5BUNI0OJ4gQyrKqT7Nw/Improve-git-blame-readability?node-id=1843%3A23474)

| Dark | Light |
| -- | -- |
| ![image](https://user-images.githubusercontent.com/25318659/173039870-847edeab-5b85-4452-aabb-249e5f7dcb52.png) | ![image](https://user-images.githubusercontent.com/25318659/173039953-c5ca5f12-6a41-4a36-9850-477a5cb3a15a.png) |



##### Note on implementation
Extra vertical padding added to `.blob` and `table` to improve code readability was replaced by adding `.top-spacer` and `.bottom-spacer` to the first and last table rows cells. It was made to make the column background cover the whole column height including mentioned vertical spacing.
| Problem | Solution |
| -- | -- |
|![image](https://user-images.githubusercontent.com/25318659/173042326-c5a0b960-01ab-45c4-ab73-71fa70279de6.png) |![image](https://user-images.githubusercontent.com/25318659/173042724-e1e16b91-aeed-4efe-905e-5b25a3dbcff7.png) |
|![image](https://user-images.githubusercontent.com/25318659/173042452-31b219a0-0af9-4b93-b2aa-4c9912d68d63.png)|![image](https://user-images.githubusercontent.com/25318659/173042822-38741a48-1d2b-4726-bbba-88f5d29f65d8.png)|



These cells spacers were given negative margins to overflow the table cell padding and the same background as the hosting table cell in its normal state (not selected or highlighted). This was made to avoid highlighting (on hover or line selection) the whole first and last rows which are taller than the rest rows. 
| Problem | Solution |
| -- | -- |
|![image](https://user-images.githubusercontent.com/25318659/173040748-37d49c90-bca3-409c-81a3-f96ba4d203f6.png) |![image](https://user-images.githubusercontent.com/25318659/173040542-fca3663f-0b97-425a-ad7c-46ee6eed1e24.png) |
|![image](https://user-images.githubusercontent.com/25318659/173040923-d235dfb7-362c-4f45-85f0-ebf8970a955e.png) |![image](https://user-images.githubusercontent.com/25318659/173041154-ec49b650-7dca-4eeb-8f3c-1a65b5174d7e.png)|

I'm not a big fan of adding elements just for styling purposes, but I couldn't come up with a more elegant solution. Any feedback/suggestions are highly appreciated!

## Test plan

- `sg start web-standalone`
- sideload git-extras extension
- enable `enableExtensionsDecorationsColumnView` experimental feature
- enable file blame decorations and ensure it has background specified in design for both light and dark themes

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-taras-yemets-add-decoration.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-uwmsvyusnr.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
