### PR TITLE
fix syncer error when dependency is not found

### DIFF
--- a/cmd/gitserver/server/vcs_dependencies_syncer.go
+++ b/cmd/gitserver/server/vcs_dependencies_syncer.go
@@ -209,7 +209,14 @@ func (s *vcsDependenciesSyncer) gitPushDependencyTag(ctx context.Context, bareGi
 	defer os.RemoveAll(workDir)
 
 	err = s.source.Download(ctx, workDir, dep)
-	if err != nil {
+	// We should not return err when dependency is not found
+	if err != nil && errcode.IsNotFound(err) {
+		s.logger.With(
+			log.String("dependency", dep.PackageManagerSyntax()),
+			log.String("error", err.Error()),
+		).Warn("Error during dependency download")
+		return nil
+	} else if err != nil {
 		return err
 	}
 

--- a/cmd/gitserver/server/vcs_dependencies_syncer_test.go
+++ b/cmd/gitserver/server/vcs_dependencies_syncer_test.go
@@ -132,6 +132,17 @@ func TestVcsDependenciesSyncer_Fetch(t *testing.T) {
 
 		s.assertRefs(t, dir, map[string]string{})
 	})
+
+	depsSource.download["org.springframework.boot:spring-boot:3.0"] = notFoundError{errors.New("Please contact Josh Long")}
+
+	t.Run("trying to download non-existent Maven dependency", func(t *testing.T) {
+		springBootDep, err := reposource.ParseMavenDependency("org.springframework.boot:spring-boot:3.0")
+		if err != nil {
+			t.Fatal("Cannot parse Maven dependency")
+		}
+		err = s.gitPushDependencyTag(ctx, string(dir), springBootDep)
+		require.NoError(t, err)
+	})
 }
 
 type fakeDepsService struct {
@@ -202,10 +213,6 @@ func (s *fakeDepsSource) Get(ctx context.Context, name, version string) (reposou
 
 	return dep, nil
 }
-
-type notFoundError struct{ error }
-
-func (e notFoundError) NotFound() bool { return true }
 
 func (s *fakeDepsSource) Download(ctx context.Context, dir string, dep reposource.PackageDependency) error {
 	err := s.download[dep.PackageManagerSyntax()]

--- a/cmd/gitserver/server/vcs_syncer.go
+++ b/cmd/gitserver/server/vcs_syncer.go
@@ -22,3 +22,7 @@ type VCSSyncer interface {
 	// RemoteShowCommand returns the command to be executed for showing remote.
 	RemoteShowCommand(ctx context.Context, remoteURL *vcs.URL) (cmd *exec.Cmd, err error)
 }
+
+type notFoundError struct{ error }
+
+func (e notFoundError) NotFound() bool { return true }

--- a/cmd/gitserver/server/vcs_syncer_jvm_packages.go
+++ b/cmd/gitserver/server/vcs_syncer_jvm_packages.go
@@ -85,7 +85,7 @@ func (s *jvmPackagesSyncer) Download(ctx context.Context, dir string, dep reposo
 	mavenDep := dep.(*reposource.MavenDependency)
 	sourceCodeJarPath, err := s.fetch(ctx, s.config, mavenDep)
 	if err != nil {
-		return errors.Wrap(err, "fetch jar")
+		return notFoundError{errors.Errorf("%s not found", dep)}
 	}
 
 	// commitJar creates a git commit in the given working directory that adds all the file contents of the given jar file.


### PR DESCRIPTION
This should fix lots of gitserver errors and resulting alerting.

"It should not be a hard error if we can't download jars or sources because they are optional" (c) Olaf

## Test plan
Existing tests should pass + added 1 new test case
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
