### PR TITLE
[Fix] Query Toggle Styles

### DIFF
--- a/client/search-ui/src/input/toggles/QueryInputToggle.tsx
+++ b/client/search-ui/src/input/toggles/QueryInputToggle.tsx
@@ -83,19 +83,21 @@ export const QueryInputToggle: React.FunctionComponent<React.PropsWithChildren<T
     return (
         // Click events here are defined in useEffect
         <Tooltip
-            className={classNames(
-                styles.toggle,
-                props.className,
-                !!disabledRule && styles.disabled,
-                isActive && styles.toggleActive,
-                !interactive && styles.toggleNonInteractive,
-                props.activeClassName
-            )}
+            // For now, Tooltip wraps the child element in a <span>, so make sure that gets styled to space the toggles correctly
+            className={styles.toggleWrapper}
             content={tooltipValue}
             placement="bottom"
         >
             <Button
                 as="div"
+                className={classNames(
+                    styles.toggle,
+                    props.className,
+                    !!disabledRule && styles.disabled,
+                    isActive && styles.toggleActive,
+                    !interactive && styles.toggleNonInteractive,
+                    props.activeClassName
+                )}
                 ref={toggleCheckbox}
                 role="checkbox"
                 variant="icon"

--- a/client/search-ui/src/input/toggles/Toggles.module.scss
+++ b/client/search-ui/src/input/toggles/Toggles.module.scss
@@ -16,15 +16,17 @@
     padding: 0.125rem;
 }
 
+.toggle-wrapper {
+    &:not(:last-child) {
+        margin-right: 0.125rem;
+    }
+}
+
 .toggle {
     display: flex;
     cursor: pointer;
     border-radius: 4px;
     border: 2px solid transparent;
-
-    &:not(:last-child) {
-        margin-right: 0.125rem;
-    }
 
     &:hover {
         background-color: var(--color-bg-2);

--- a/client/search-ui/src/input/toggles/__snapshots__/Toggles.test.tsx.snap
+++ b/client/search-ui/src/input/toggles/__snapshots__/Toggles.test.tsx.snap
@@ -6,7 +6,7 @@ Array [
     aria-checked="false"
     aria-disabled="true"
     aria-label="Case sensitivity toggle"
-    class="btn btnIcon"
+    class="btn btnIcon toggle test-case-sensitivity-toggle disabled test-case-sensitivity-toggle--active"
     role="checkbox"
     tabindex="0"
   >
@@ -33,7 +33,7 @@ Array [
     aria-checked="false"
     aria-disabled="true"
     aria-label="Case sensitivity toggle"
-    class="btn btnIcon"
+    class="btn btnIcon toggle test-case-sensitivity-toggle disabled test-case-sensitivity-toggle--active"
     role="checkbox"
     tabindex="0"
   >
@@ -60,7 +60,7 @@ Array [
     aria-checked="false"
     aria-disabled="true"
     aria-label="Regular expression toggle"
-    class="btn btnIcon"
+    class="btn btnIcon toggle test-regexp-toggle disabled test-regexp-toggle--active"
     role="checkbox"
     tabindex="0"
   >


### PR DESCRIPTION
Uses proper styling/class names for these elements, per [this comment](https://github.com/sourcegraph/sourcegraph/pull/36810#discussion_r893741508) (thank you!).

## Test plan

Confirm no regression in Percy, double check visual styles in app.

## App preview:

- [Web](https://sg-web-lrh-fix-query-toggle-styles.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-dzquyakkpa.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
