### PR TITLE
executor: Respect `DOCKER_HOST` envvar

### DIFF
--- a/enterprise/cmd/executor/internal/command/run.go
+++ b/enterprise/cmd/executor/internal/command/run.go
@@ -143,7 +143,7 @@ func prepCommand(ctx context.Context, command command) (cmd *exec.Cmd, stdout, s
 // forwardedHostEnvVars is a list of environment variable names that are inherited
 // when executing a command on the host. These are commonly required by programs
 // we shell out to, such a docker.
-var forwardedHostEnvVars = []string{"HOME", "PATH", "USER"}
+var forwardedHostEnvVars = []string{"HOME", "PATH", "USER", "DOCKER_HOST"}
 
 func readProcessPipes(logWriter io.WriteCloser, stdout, stderr io.Reader) *errgroup.Group {
 	eg := &errgroup.Group{}


### PR DESCRIPTION
This envvar was not making its way to the docker command in the executor. Blocks being able to use a DinD sidecar in k8s.

## Test plan

Will run locally with a k8s cluster once the new image is built.