### PR TITLE
fix(ui): Traverse left-to-right also when finding line number in cell

### DIFF
--- a/client/web/src/repo/compare/dom-functions.ts
+++ b/client/web/src/repo/compare/dom-functions.ts
@@ -19,19 +19,17 @@ export const diffDomFunctions: DOMFunctions = {
     },
 
     getLineNumberFromCodeElement: (codeCell: HTMLElement): number => {
-        const closestTd = codeCell.closest('td')
-        if (closestTd) {
-            // First search right-to-left for a line number using `previousElementSibling`
-            // If not found, search left-to-right for a line number using `nextElementSibling`
-            const siblings = ['previousElementSibling', 'nextElementSibling'] as const
-            for (const sibling of siblings) {
-                let cell = closestTd[sibling] as HTMLTableCellElement
-                while (cell) {
-                    if (cell.dataset.line) {
-                        return parseInt(cell.dataset.line, 10)
-                    }
-                    cell = cell[sibling] as HTMLTableCellElement
-                }
+        // Find all line number cells in this row
+        const lineNumberCells = codeCell
+            .closest('tr')
+            ?.querySelectorAll('td[data-line]') as NodeListOf<HTMLTableCellElement>
+        // If there are line numbers...
+        if (lineNumberCells?.length) {
+            // Pick the second (last, using `pop`) line number cell, since code-intel will
+            // position the popover on the second line number cell
+            const cell = [...lineNumberCells].pop()
+            if (cell?.dataset.line) {
+                return parseInt(cell.dataset.line, 10)
             }
         }
         throw new Error('Could not find a line number in any cell')

--- a/client/web/src/repo/compare/dom-functions.ts
+++ b/client/web/src/repo/compare/dom-functions.ts
@@ -19,12 +19,20 @@ export const diffDomFunctions: DOMFunctions = {
     },
 
     getLineNumberFromCodeElement: (codeCell: HTMLElement): number => {
-        let cell = codeCell.closest('td')!.previousElementSibling as HTMLTableCellElement
-        while (cell) {
-            if (cell.dataset.line) {
-                return parseInt(cell.dataset.line, 10)
+        const closestTd = codeCell.closest('td')
+        if (closestTd) {
+            // First search right-to-left for a line number using `previousElementSibling`
+            // If not found, search left-to-right for a line number using `nextElementSibling`
+            const siblings = ['previousElementSibling', 'nextElementSibling'] as const
+            for (const sibling of siblings) {
+                let cell = closestTd[sibling] as HTMLTableCellElement
+                while (cell) {
+                    if (cell.dataset.line) {
+                        return parseInt(cell.dataset.line, 10)
+                    }
+                    cell = cell[sibling] as HTMLTableCellElement
+                }
             }
-            cell = cell.previousElementSibling as HTMLTableCellElement
         }
         throw new Error('Could not find a line number in any cell')
     },


### PR DESCRIPTION
With this PR, the search for the cell containing the line-number also traverses left-to-right through the elements, relative to the hovered cell. The crash-causing bug happened when the cursor would hover over the left-most cells, to the left of the "add"/"green" lines. Since the original traversal was only right-to-left, no line number would be found to the left of the hovered cells, which would invoke the error.

![Google Chrome 2022-06-09 at 23 26 33 000089@2x](https://user-images.githubusercontent.com/31861755/172913459-01285786-1a3a-4ef4-96c4-249dce4b0445.png)

Closes #36253

## Test plan

- Click [this diff view](https://sourcegraph.com/github.com/sourcegraph/sourcegraph-code-discussions/-/commit/37873123e6fdf7706e6404f66d6a151e7d9a0cfa?visible=1#diff-b0678b51723ef8450026fa0f6967216fR22) and hover over the green area marked by the rectangle in the above image
- No crash this time

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-mihir-diff-line-number-hover-bug.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-qmawzkkvhs.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
