### PR TITLE
Backend: remove `basestore.NewWithDB`

### DIFF
--- a/cmd/symbols/internal/database/store/store.go
+++ b/cmd/symbols/internal/database/store/store.go
@@ -43,7 +43,7 @@ func NewStore(dbFile string) (Store, error) {
 
 	return &store{
 		db:    db,
-		Store: basestore.NewWithDB(db, sql.TxOptions{}),
+		Store: basestore.NewWithHandle(basestore.NewHandleWithDB(db, sql.TxOptions{})),
 	}, nil
 }
 

--- a/enterprise/cmd/frontend/internal/codeintel/services.go
+++ b/enterprise/cmd/frontend/internal/codeintel/services.go
@@ -63,7 +63,7 @@ func NewServices(ctx context.Context, config *Config, siteConfig conftypes.Watch
 
 	// Initialize stores
 	dbStore := store.NewWithDB(db, observationContext)
-	locker := locker.NewWithDB(db, "codeintel")
+	locker := locker.NewWith(db, "codeintel")
 	lsifStore := lsifstore.NewStore(codeIntelDB, siteConfig, observationContext)
 	uploadStore, err := lsifuploadstore.New(context.Background(), config.LSIFUploadStoreConfig, observationContext)
 	if err != nil {

--- a/enterprise/cmd/worker/internal/codeintel/fresh/commitgraph_updater_job.go
+++ b/enterprise/cmd/worker/internal/codeintel/fresh/commitgraph_updater_job.go
@@ -12,6 +12,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/worker/shared/init/codeintel"
 	workerdb "github.com/sourcegraph/sourcegraph/cmd/worker/shared/init/db"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/uploads/background/commitgraph"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/locker"
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
@@ -52,7 +53,7 @@ func (j *commitGraphUpdaterJob) Routines(ctx context.Context, logger log.Logger)
 	if err != nil {
 		return nil, err
 	}
-	locker := locker.NewWithDB(workerDb, "codeintel")
+	locker := locker.NewWith(database.NewDB(workerDb), "codeintel")
 
 	gitserverClient, err := codeintel.InitGitserverClient()
 	if err != nil {

--- a/enterprise/internal/batches/service/service_apply_batch_change.go
+++ b/enterprise/internal/batches/service/service_apply_batch_change.go
@@ -106,7 +106,7 @@ func (s *Service) ApplyBatchChange(
 	}
 	defer func() { err = tx.Done(err) }()
 
-	l := locker.NewWithDB(nil, "batches_apply").With(tx)
+	l := locker.NewWith(tx, "batches_apply")
 	locked, err := l.LockInTransaction(ctx, int32(batchChange.ID), false)
 	if err != nil {
 		return nil, err

--- a/enterprise/internal/database/database.go
+++ b/enterprise/internal/database/database.go
@@ -51,6 +51,10 @@ func NewInsightsDB(inner dbutil.DB) InsightsDB {
 	return &insightsDB{basestore.NewWithDB(inner, sql.TxOptions{})}
 }
 
+func NewInsightsDBWith(other basestore.ShareableStore) InsightsDB {
+	return &insightsDB{basestore.NewWithHandle(other.Handle())}
+}
+
 type insightsDB struct {
 	*basestore.Store
 }

--- a/enterprise/internal/database/database.go
+++ b/enterprise/internal/database/database.go
@@ -48,7 +48,7 @@ type InsightsDB interface {
 }
 
 func NewInsightsDB(inner dbutil.DB) InsightsDB {
-	return &insightsDB{basestore.NewWithDB(inner, sql.TxOptions{})}
+	return &insightsDB{basestore.NewWithHandle(basestore.NewHandleWithDB(inner, sql.TxOptions{}))}
 }
 
 func NewInsightsDBWith(other basestore.ShareableStore) InsightsDB {

--- a/enterprise/internal/insights/compression/commits.go
+++ b/enterprise/internal/insights/compression/commits.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/keegancsmith/sqlf"
 
+	edb "github.com/sourcegraph/sourcegraph/enterprise/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
@@ -27,7 +28,7 @@ type CommitStore interface {
 	InsertCommits(ctx context.Context, id api.RepoID, commits []*gitdomain.Commit, indexedThrough time.Time, debugInfo string) error
 }
 
-func NewCommitStore(db dbutil.DB) *DBCommitStore {
+func NewCommitStore(db edb.InsightsDB) *DBCommitStore {
 	return &DBCommitStore{
 		Store: basestore.NewWithDB(db, sql.TxOptions{}),
 	}

--- a/enterprise/internal/insights/compression/commits.go
+++ b/enterprise/internal/insights/compression/commits.go
@@ -2,7 +2,6 @@ package compression
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
 	"time"
 
@@ -30,7 +29,7 @@ type CommitStore interface {
 
 func NewCommitStore(db edb.InsightsDB) *DBCommitStore {
 	return &DBCommitStore{
-		Store: basestore.NewWithDB(db, sql.TxOptions{}),
+		Store: basestore.NewWithHandle(db.Handle()),
 	}
 }
 

--- a/enterprise/internal/insights/compression/commits_test.go
+++ b/enterprise/internal/insights/compression/commits_test.go
@@ -8,13 +8,14 @@ import (
 
 	"github.com/hexops/autogold"
 
+	edb "github.com/sourcegraph/sourcegraph/enterprise/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 )
 
 func TestInsertCommits(t *testing.T) {
-	insightsDB := dbtest.NewInsightsDB(t)
+	insightsDB := edb.NewInsightsDB(dbtest.NewInsightsDB(t))
 	commitStore := NewCommitStore(insightsDB)
 
 	commit1 := makeCommit("abc123", time.Date(2021, time.April, 21, 1, 1, 0, 0, time.UTC))

--- a/enterprise/internal/insights/compression/compression.go
+++ b/enterprise/internal/insights/compression/compression.go
@@ -26,7 +26,6 @@ import (
 	"time"
 
 	"github.com/inconshreveable/log15"
-
 	edb "github.com/sourcegraph/sourcegraph/enterprise/internal/database"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/store"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/types"

--- a/enterprise/internal/insights/compression/compression.go
+++ b/enterprise/internal/insights/compression/compression.go
@@ -25,13 +25,12 @@ import (
 	"strings"
 	"time"
 
-	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/types"
-
-	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/store"
-
 	"github.com/inconshreveable/log15"
+
+	edb "github.com/sourcegraph/sourcegraph/enterprise/internal/database"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/store"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/types"
 	"github.com/sourcegraph/sourcegraph/internal/api"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 )
 
 type CommitFilter struct {
@@ -46,7 +45,7 @@ type DataFrameFilter interface {
 	FilterFrames(ctx context.Context, frames []types.Frame, id api.RepoID) BackfillPlan
 }
 
-func NewHistoricalFilter(enabled bool, maxHistorical time.Time, db dbutil.DB) DataFrameFilter {
+func NewHistoricalFilter(enabled bool, maxHistorical time.Time, db edb.InsightsDB) DataFrameFilter {
 	if enabled {
 		return &CommitFilter{
 			store:         NewCommitStore(db),

--- a/enterprise/internal/insights/compression/worker.go
+++ b/enterprise/internal/insights/compression/worker.go
@@ -11,13 +11,13 @@ import (
 	"golang.org/x/time/rate"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
+	edb "github.com/sourcegraph/sourcegraph/enterprise/internal/database"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/discovery"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbcache"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
@@ -42,7 +42,7 @@ type CommitIndexer struct {
 	clock             func() time.Time
 }
 
-func NewCommitIndexer(background context.Context, base database.DB, insights dbutil.DB, clock func() time.Time, observationContext *observation.Context) *CommitIndexer {
+func NewCommitIndexer(background context.Context, base database.DB, insights edb.InsightsDB, clock func() time.Time, observationContext *observation.Context) *CommitIndexer {
 	//TODO(insights): add a setting for historical index length
 	startTime := time.Now().AddDate(-1, 0, 0)
 
@@ -81,7 +81,7 @@ func NewCommitIndexer(background context.Context, base database.DB, insights dbu
 	return &indexer
 }
 
-func NewCommitIndexerWorker(ctx context.Context, base database.DB, insights dbutil.DB, clock func() time.Time, observationContext *observation.Context) goroutine.BackgroundRoutine {
+func NewCommitIndexerWorker(ctx context.Context, base database.DB, insights edb.InsightsDB, clock func() time.Time, observationContext *observation.Context) goroutine.BackgroundRoutine {
 	indexer := NewCommitIndexer(ctx, base, insights, clock, observationContext)
 
 	return indexer.Handler(ctx, observationContext)

--- a/enterprise/internal/insights/migration/discovery.go
+++ b/enterprise/internal/insights/migration/discovery.go
@@ -11,6 +11,7 @@ import (
 	"github.com/inconshreveable/log15"
 	"github.com/segmentio/ksuid"
 
+	edb "github.com/sourcegraph/sourcegraph/enterprise/internal/database"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/discovery"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/store"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/types"
@@ -365,7 +366,7 @@ func migrateSeries(ctx context.Context, insightStore *store.InsightStore, worker
 
 				// Also match/replace old series_points ids with the new series id
 				oldId := discovery.Encode(timeSeries)
-				countUpdated, silentErr := updateTimeSeriesReferences(tx.Handle().DB(), ctx, oldId, temp.SeriesID)
+				countUpdated, silentErr := updateTimeSeriesReferences(edb.NewInsightsDBWith(tx), ctx, oldId, temp.SeriesID)
 				if silentErr != nil {
 					// If the find-replace fails, it's not a big deal. It will just need to be calcuated again.
 					log15.Error("error updating series_id for series_points", "series_id", temp.SeriesID, "err", silentErr)

--- a/enterprise/internal/insights/migration/migration.go
+++ b/enterprise/internal/insights/migration/migration.go
@@ -2,7 +2,6 @@ package migration
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
 	"strings"
 
@@ -417,7 +416,7 @@ func (m *migrator) migrateDashboard(ctx context.Context, from insights.SettingDa
 	return nil
 }
 
-func updateTimeSeriesReferences(handle dbutil.DB, ctx context.Context, oldId, newId string) (int, error) {
+func updateTimeSeriesReferences(handle edb.InsightsDB, ctx context.Context, oldId, newId string) (int, error) {
 	q := sqlf.Sprintf(`
 		WITH updated AS (
 			UPDATE series_points sp
@@ -427,7 +426,7 @@ func updateTimeSeriesReferences(handle dbutil.DB, ctx context.Context, oldId, ne
 		)
 		SELECT count(*) FROM updated;
 	`, newId, oldId)
-	tempStore := basestore.NewWithDB(handle, sql.TxOptions{})
+	tempStore := basestore.NewWithHandle(handle.Handle())
 	count, _, err := basestore.ScanFirstInt(tempStore.Query(ctx, q))
 	if err != nil {
 		return 0, errors.Wrap(err, "updateTimeSeriesReferences")

--- a/enterprise/internal/insights/store/dashboard_store.go
+++ b/enterprise/internal/insights/store/dashboard_store.go
@@ -23,7 +23,7 @@ type DBDashboardStore struct {
 
 // NewDashboardStore returns a new DBDashboardStore backed by the given Postgres db.
 func NewDashboardStore(db edb.InsightsDB) *DBDashboardStore {
-	return &DBDashboardStore{Store: basestore.NewWithDB(db, sql.TxOptions{}), Now: time.Now}
+	return &DBDashboardStore{Store: basestore.NewWithHandle(db.Handle()), Now: time.Now}
 }
 
 // Handle returns the underlying transactable database handle.

--- a/enterprise/internal/insights/store/dashboard_store.go
+++ b/enterprise/internal/insights/store/dashboard_store.go
@@ -9,9 +9,9 @@ import (
 	"github.com/keegancsmith/sqlf"
 	"github.com/lib/pq"
 
+	edb "github.com/sourcegraph/sourcegraph/enterprise/internal/database"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/types"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/insights"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
@@ -22,7 +22,7 @@ type DBDashboardStore struct {
 }
 
 // NewDashboardStore returns a new DBDashboardStore backed by the given Postgres db.
-func NewDashboardStore(db dbutil.DB) *DBDashboardStore {
+func NewDashboardStore(db edb.InsightsDB) *DBDashboardStore {
 	return &DBDashboardStore{Store: basestore.NewWithDB(db, sql.TxOptions{}), Now: time.Now}
 }
 

--- a/enterprise/internal/insights/store/dashboard_store_test.go
+++ b/enterprise/internal/insights/store/dashboard_store_test.go
@@ -14,10 +14,10 @@ import (
 )
 
 func TestGetDashboard(t *testing.T) {
-	insightsDB := dbtest.NewInsightsDB(t)
+	insightsDB := edb.NewInsightsDB(dbtest.NewInsightsDB(t))
 	now := time.Now().Truncate(time.Microsecond).Round(0)
 
-	_, err := insightsDB.Exec(`
+	_, err := insightsDB.ExecContext(context.Background(), `
 		INSERT INTO dashboard (id, title)
 		VALUES (1, 'test dashboard'), (2, 'private dashboard for user 3'), (3, 'private dashbord for org 1');`)
 	if err != nil {
@@ -27,24 +27,24 @@ func TestGetDashboard(t *testing.T) {
 	ctx := context.Background()
 
 	// assign some global grants just so the test can immediately fetch the created dashboard
-	_, err = insightsDB.Exec(`INSERT INTO dashboard_grants (dashboard_id, global) VALUES (1, true)`)
+	_, err = insightsDB.ExecContext(context.Background(), `INSERT INTO dashboard_grants (dashboard_id, global) VALUES (1, true)`)
 	if err != nil {
 		t.Fatal(err)
 	}
 	// assign a private user grant
-	_, err = insightsDB.Exec(`INSERT INTO dashboard_grants (dashboard_id, user_id) VALUES (2, 3)`)
+	_, err = insightsDB.ExecContext(context.Background(), `INSERT INTO dashboard_grants (dashboard_id, user_id) VALUES (2, 3)`)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// assign a private org grant
-	_, err = insightsDB.Exec(`INSERT INTO dashboard_grants (dashboard_id, org_id) VALUES (3, 1)`)
+	_, err = insightsDB.ExecContext(context.Background(), `INSERT INTO dashboard_grants (dashboard_id, org_id) VALUES (3, 1)`)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// create some views to assign to the dashboards
-	_, err = insightsDB.Exec(`INSERT INTO insight_view (id, title, description, unique_id)
+	_, err = insightsDB.ExecContext(context.Background(), `INSERT INTO insight_view (id, title, description, unique_id)
 									VALUES
 										(1, 'my view', 'my description', 'unique1234'),
 										(2, 'private view', 'private description', 'private1234'),
@@ -54,7 +54,7 @@ func TestGetDashboard(t *testing.T) {
 	}
 
 	// assign views to dashboards
-	_, err = insightsDB.Exec(`INSERT INTO dashboard_insight_view (dashboard_id, insight_view_id)
+	_, err = insightsDB.ExecContext(context.Background(), `INSERT INTO dashboard_insight_view (dashboard_id, insight_view_id)
 									VALUES
 										(1, 1),
 										(1, 3),
@@ -159,7 +159,7 @@ func TestGetDashboard(t *testing.T) {
 }
 
 func TestCreateDashboard(t *testing.T) {
-	insightsDB := dbtest.NewInsightsDB(t)
+	insightsDB := edb.NewInsightsDB(dbtest.NewInsightsDB(t))
 	now := time.Now().Truncate(time.Microsecond).Round(0)
 	ctx := context.Background()
 	store := NewDashboardStore(insightsDB)
@@ -207,7 +207,7 @@ func TestCreateDashboard(t *testing.T) {
 }
 
 func TestUpdateDashboard(t *testing.T) {
-	insightsDB := dbtest.NewInsightsDB(t)
+	insightsDB := edb.NewInsightsDB(dbtest.NewInsightsDB(t))
 	now := time.Now().Truncate(time.Microsecond).Round(0)
 	ctx := context.Background()
 	store := NewDashboardStore(insightsDB)
@@ -215,7 +215,7 @@ func TestUpdateDashboard(t *testing.T) {
 		return now
 	}
 
-	_, err := insightsDB.Exec(`
+	_, err := insightsDB.ExecContext(context.Background(), `
 	INSERT INTO dashboard (id, title)
 	VALUES (1, 'test dashboard 1'), (2, 'test dashboard 2');
 	INSERT INTO dashboard_grants (dashboard_id, global)
@@ -278,11 +278,11 @@ func TestUpdateDashboard(t *testing.T) {
 }
 
 func TestDeleteDashboard(t *testing.T) {
-	insightsDB := dbtest.NewInsightsDB(t)
+	insightsDB := edb.NewInsightsDB(dbtest.NewInsightsDB(t))
 	now := time.Now().Truncate(time.Microsecond).Round(0)
 	ctx := context.Background()
 
-	_, err := insightsDB.Exec(`
+	_, err := insightsDB.ExecContext(context.Background(), `
 		INSERT INTO dashboard (id, title)
 		VALUES (1, 'test dashboard 1'), (2, 'test dashboard 2');
 		INSERT INTO dashboard_grants (dashboard_id, global)
@@ -337,11 +337,11 @@ func TestDeleteDashboard(t *testing.T) {
 }
 
 func TestRestoreDashboard(t *testing.T) {
-	insightsDB := dbtest.NewInsightsDB(t)
+	insightsDB := edb.NewInsightsDB(dbtest.NewInsightsDB(t))
 	now := time.Now().Truncate(time.Microsecond).Round(0)
 	ctx := context.Background()
 
-	_, err := insightsDB.Exec(`
+	_, err := insightsDB.ExecContext(context.Background(), `
 		INSERT INTO dashboard (id, title, deleted_at)
 		VALUES (1, 'test dashboard 1', NULL), (2, 'test dashboard 2', NOW());
 		INSERT INTO dashboard_grants (dashboard_id, global)
@@ -551,7 +551,7 @@ func TestRemoveViewsFromDashboard(t *testing.T) {
 }
 
 func TestHasDashboardPermission(t *testing.T) {
-	insightsDB := dbtest.NewInsightsDB(t)
+	insightsDB := edb.NewInsightsDB(dbtest.NewInsightsDB(t))
 	now := time.Date(2021, 12, 1, 0, 0, 0, 0, time.UTC).Truncate(time.Microsecond).Round(0)
 	ctx := context.Background()
 	store := NewDashboardStore(insightsDB)

--- a/enterprise/internal/insights/store/insight_store.go
+++ b/enterprise/internal/insights/store/insight_store.go
@@ -23,7 +23,7 @@ type InsightStore struct {
 
 // NewInsightStore returns a new InsightStore backed by the given Postgres db.
 func NewInsightStore(db edb.InsightsDB) *InsightStore {
-	return &InsightStore{Store: basestore.NewWithDB(db, sql.TxOptions{}), Now: time.Now}
+	return &InsightStore{Store: basestore.NewWithHandle(db.Handle()), Now: time.Now}
 }
 
 // NewInsightStoreWith returns a new InsightStore backed by the given Postgres db.

--- a/internal/database/basestore/store.go
+++ b/internal/database/basestore/store.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/keegancsmith/sqlf"
 
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 

--- a/internal/database/basestore/store.go
+++ b/internal/database/basestore/store.go
@@ -54,11 +54,6 @@ type ShareableStore interface {
 
 var _ ShareableStore = &Store{}
 
-// NewWithDB returns a new base store connected to the given connection.
-func NewWithDB(db dbutil.DB, txOptions sql.TxOptions) *Store {
-	return NewWithHandle(NewHandleWithDB(db, txOptions))
-}
-
 // NewWithHandle returns a new base store using the given database handle.
 func NewWithHandle(handle *TransactableHandle) *Store {
 	return &Store{handle: handle}

--- a/internal/database/basestore/store_test.go
+++ b/internal/database/basestore/store_test.go
@@ -156,8 +156,8 @@ func recurSavepoints(t *testing.T, store *Store, index, rollbackAt int) {
 	recurSavepoints(t, tx, index-1, rollbackAt)
 }
 
-func testStore(db dbutil.DB) *Store {
-	return NewWithDB(db, sql.TxOptions{})
+func testStore(db *sql.DB) *Store {
+	return NewWithHandle(NewHandleWithDB(db, sql.TxOptions{}))
 }
 
 func assertCounts(t *testing.T, db dbutil.DB, expectedCounts map[int]int) {

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -56,7 +56,7 @@ var _ DB = (*db)(nil)
 // NewDB creates a new DB from a dbutil.DB, providing a thin wrapper
 // that has constructor methods for the more specialized stores.
 func NewDB(inner dbutil.DB) DB {
-	return &db{basestore.NewWithDB(inner, sql.TxOptions{})}
+	return &db{basestore.NewWithHandle(basestore.NewHandleWithDB(inner, sql.TxOptions{}))}
 }
 
 func NewDBWith(other basestore.ShareableStore) DB {

--- a/internal/database/locker/locker.go
+++ b/internal/database/locker/locker.go
@@ -2,14 +2,12 @@ package locker
 
 import (
 	"context"
-	"database/sql"
 	"math"
 
 	"github.com/keegancsmith/sqlf"
 	"github.com/segmentio/fasthash/fnv1"
 
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
@@ -28,10 +26,10 @@ type Locker struct {
 	namespace int32
 }
 
-// NewWithDB creates a new Locker with the given namespace and dbutil.DB.
-func NewWithDB(db dbutil.DB, namespace string) *Locker {
+// NewWith creates a new Locker with the given namespace and ShareableStore
+func NewWith(other basestore.ShareableStore, namespace string) *Locker {
 	return &Locker{
-		Store:     basestore.NewWithDB(db, sql.TxOptions{}),
+		Store:     basestore.NewWithHandle(other.Handle()),
 		namespace: StringKey(namespace),
 	}
 }

--- a/internal/database/locker/locker_test.go
+++ b/internal/database/locker/locker_test.go
@@ -2,10 +2,12 @@ package locker
 
 import (
 	"context"
+	"database/sql"
 	"math/rand"
 	"testing"
 	"time"
 
+	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 )
 
@@ -14,7 +16,8 @@ func TestLock(t *testing.T) {
 		t.Skip()
 	}
 	db := dbtest.NewDB(t)
-	locker := NewWithDB(db, "test")
+	handle := basestore.NewWithHandle(basestore.NewHandleWithDB(db, sql.TxOptions{}))
+	locker := NewWith(handle, "test")
 
 	key := rand.Int31n(1000)
 
@@ -56,7 +59,8 @@ func TestLockBlockingAcquire(t *testing.T) {
 		t.Skip()
 	}
 	db := dbtest.NewDB(t)
-	locker := NewWithDB(db, "test")
+	handle := basestore.NewWithHandle(basestore.NewHandleWithDB(db, sql.TxOptions{}))
+	locker := NewWith(handle, "test")
 
 	key := rand.Int31n(1000)
 
@@ -112,7 +116,8 @@ func TestLockBadTransactionState(t *testing.T) {
 		t.Skip()
 	}
 	db := dbtest.NewDB(t)
-	locker := NewWithDB(db, "test")
+	handle := basestore.NewWithHandle(basestore.NewHandleWithDB(db, sql.TxOptions{}))
+	locker := NewWith(handle, "test")
 
 	key := rand.Int31n(1000)
 

--- a/internal/database/migration/store/store.go
+++ b/internal/database/migration/store/store.go
@@ -9,7 +9,6 @@ import (
 	"github.com/opentracing/opentracing-go/log"
 
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/database/locker"
 	"github.com/sourcegraph/sourcegraph/internal/database/migration/definition"
 	"github.com/sourcegraph/sourcegraph/internal/database/migration/storetypes"
@@ -23,9 +22,9 @@ type Store struct {
 	operations *Operations
 }
 
-func NewWithDB(db dbutil.DB, migrationsTable string, operations *Operations) *Store {
+func NewWithDB(db *sql.DB, migrationsTable string, operations *Operations) *Store {
 	return &Store{
-		Store:      basestore.NewWithDB(db, sql.TxOptions{}),
+		Store:      basestore.NewWithHandle(basestore.NewHandleWithDB(db, sql.TxOptions{})),
 		schemaName: migrationsTable,
 		operations: operations,
 	}

--- a/internal/database/migration/store/store_test.go
+++ b/internal/database/migration/store/store_test.go
@@ -567,11 +567,11 @@ retryLoop:
 
 const defaultTestTableName = "test_migrations_table"
 
-func testStore(db dbutil.DB) *Store {
+func testStore(db *sql.DB) *Store {
 	return testStoreWithName(db, defaultTestTableName)
 }
 
-func testStoreWithName(db dbutil.DB, name string) *Store {
+func testStoreWithName(db *sql.DB, name string) *Store {
 	return NewWithDB(db, name, NewOperations(&observation.TestContext))
 }
 

--- a/internal/oobmigration/runner.go
+++ b/internal/oobmigration/runner.go
@@ -13,7 +13,7 @@ import (
 	"github.com/opentracing/opentracing-go/log"
 
 	"github.com/sourcegraph/sourcegraph/internal/actor"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
@@ -39,7 +39,7 @@ type migratorAndOption struct {
 
 var _ goroutine.BackgroundRoutine = &Runner{}
 
-func NewRunnerWithDB(db dbutil.DB, refreshInterval time.Duration, observationContext *observation.Context) *Runner {
+func NewRunnerWithDB(db database.DB, refreshInterval time.Duration, observationContext *observation.Context) *Runner {
 	return newRunner(NewStoreWithDB(db), glock.NewRealTicker(refreshInterval), observationContext)
 }
 

--- a/internal/oobmigration/store.go
+++ b/internal/oobmigration/store.go
@@ -119,7 +119,7 @@ type Store struct {
 
 // NewStoreWithDB creates a new Store with the given database connection.
 func NewStoreWithDB(db database.DB) *Store {
-	return &Store{Store: basestore.NewWithDB(db, sql.TxOptions{})}
+	return &Store{Store: basestore.NewWithHandle(db.Handle())}
 }
 
 var _ basestore.ShareableStore = &Store{}

--- a/internal/oobmigration/store.go
+++ b/internal/oobmigration/store.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/keegancsmith/sqlf"
 
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 )
@@ -117,7 +118,7 @@ type Store struct {
 }
 
 // NewStoreWithDB creates a new Store with the given database connection.
-func NewStoreWithDB(db dbutil.DB) *Store {
+func NewStoreWithDB(db database.DB) *Store {
 	return &Store{Store: basestore.NewWithDB(db, sql.TxOptions{})}
 }
 

--- a/internal/oobmigration/store_test.go
+++ b/internal/oobmigration/store_test.go
@@ -11,14 +11,14 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/keegancsmith/sqlf"
 
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 )
 
 func TestList(t *testing.T) {
 	t.Parallel()
 
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	store := testStore(t, db)
 
 	migrations, err := store.List(context.Background())
@@ -38,7 +38,7 @@ func TestList(t *testing.T) {
 }
 
 func TestListEnterprise(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	store := testStore(t, db)
 
 	ReturnEnterpriseMigrations = true
@@ -63,7 +63,7 @@ func TestListEnterprise(t *testing.T) {
 
 func TestUpdateDirection(t *testing.T) {
 	t.Parallel()
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	store := testStore(t, db)
 
 	if err := store.UpdateDirection(context.Background(), 3, true); err != nil {
@@ -89,7 +89,7 @@ func TestUpdateDirection(t *testing.T) {
 func TestUpdateProgress(t *testing.T) {
 	t.Parallel()
 	now := testTime.Add(time.Hour * 7)
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	store := testStore(t, db)
 
 	if err := store.updateProgress(context.Background(), 3, 0.7, now); err != nil {
@@ -116,7 +116,7 @@ func TestUpdateProgress(t *testing.T) {
 func TestUpdateMetadata(t *testing.T) {
 	t.Parallel()
 	now := testTime.Add(time.Hour * 7)
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	store := testStore(t, db)
 
 	type sampleMeta = struct {
@@ -164,7 +164,7 @@ func TestUpdateMetadata(t *testing.T) {
 func TestAddError(t *testing.T) {
 	t.Parallel()
 	now := testTime.Add(time.Hour * 8)
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	store := testStore(t, db)
 
 	if err := store.addError(context.Background(), 2, "oops", now); err != nil {
@@ -196,7 +196,7 @@ func TestAddErrorBounded(t *testing.T) {
 	t.Parallel()
 
 	now := testTime.Add(time.Hour * 9)
-	db := dbtest.NewDB(t)
+	db := database.NewDB(dbtest.NewDB(t))
 	store := testStore(t, db)
 
 	var expectedErrors []MigrationError
@@ -335,7 +335,7 @@ func newVersionPtr(major, minor int) *Version {
 	return &v
 }
 
-func testStore(t *testing.T, db dbutil.DB) *Store {
+func testStore(t *testing.T, db database.DB) *Store {
 	store := NewStoreWithDB(db)
 
 	if _, err := db.ExecContext(context.Background(), "DELETE FROM out_of_band_migrations CASCADE"); err != nil {


### PR DESCRIPTION
This replaces the last instances of `basestore.NewWithDB()` and removes the function. Instead of constructing stores from a `dbutil.DB` interface, now we construct stores using other shareable handles or from transactable handles directly. 

Depends on https://github.com/sourcegraph/sourcegraph/pull/36924 (sorry for the weird dependency. I had a couple of branches going. Will rebase once that's merged)

## Test plan

Unit tests. 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
