### PR TITLE
batches: Prevent batch spec with mounts for SSBC

### DIFF
--- a/enterprise/internal/batches/service/service.go
+++ b/enterprise/internal/batches/service/service.go
@@ -251,8 +251,8 @@ func (s *Service) CreateBatchSpec(ctx context.Context, opts CreateBatchSpecOpts)
 	}
 	spec.NamespaceOrgID = opts.NamespaceOrgID
 	spec.NamespaceUserID = opts.NamespaceUserID
-	actor := actor.FromContext(ctx)
-	spec.UserID = actor.UID
+	a := actor.FromContext(ctx)
+	spec.UserID = a.UID
 
 	if len(opts.ChangesetSpecRandIDs) == 0 {
 		return spec, s.store.CreateBatchSpec(ctx, spec)
@@ -593,8 +593,8 @@ func (s *Service) UpsertBatchSpecInput(ctx context.Context, opts UpsertBatchSpec
 	spec.NamespaceOrgID = opts.NamespaceOrgID
 	spec.NamespaceUserID = opts.NamespaceUserID
 	// Actor is guaranteed to be set here, because CheckNamespaceAccess above enforces it.
-	actor := actor.FromContext(ctx)
-	spec.UserID = actor.UID
+	a := actor.FromContext(ctx)
+	spec.UserID = a.UID
 
 	// Start transaction.
 	tx, err := s.store.Transact(ctx)
@@ -607,7 +607,7 @@ func (s *Service) UpsertBatchSpecInput(ctx context.Context, opts UpsertBatchSpec
 	old, err := s.store.GetNewestBatchSpec(ctx, store.GetNewestBatchSpecOpts{
 		NamespaceUserID: opts.NamespaceUserID,
 		NamespaceOrgID:  opts.NamespaceOrgID,
-		UserID:          actor.UID,
+		UserID:          a.UID,
 		Name:            spec.Spec.Name,
 	})
 	if err != nil && err != store.ErrNoResults {

--- a/enterprise/internal/batches/service/service.go
+++ b/enterprise/internal/batches/service/service.go
@@ -335,7 +335,7 @@ func (s *Service) CreateBatchSpecFromRaw(ctx context.Context, opts CreateBatchSp
 
 	// Temporarily prevent mounts for server-side processing.
 	if hasMount(spec) {
-		return nil, errors.Newf("mounts are not allowed for server-side processing")
+		return nil, errors.New("mounts are not allowed for server-side processing")
 	}
 
 	// Check whether the current user has access to either one of the namespaces.
@@ -582,7 +582,7 @@ func (s *Service) UpsertBatchSpecInput(ctx context.Context, opts UpsertBatchSpec
 
 	// Temporarily prevent mounts for server-side processing.
 	if hasMount(spec) {
-		return nil, errors.Newf("mounts are not allowed for server-side processing")
+		return nil, errors.New("mounts are not allowed for server-side processing")
 	}
 
 	// Check whether the current user has access to either one of the namespaces.

--- a/enterprise/internal/batches/service/service_test.go
+++ b/enterprise/internal/batches/service/service_test.go
@@ -1498,6 +1498,31 @@ func TestService(t *testing.T) {
 			assertNoChangesetSpecs(t, newSpec.ID)
 			assertNoChangesetSpecs(t, spec.ID)
 		})
+
+		t.Run("mount error", func(t *testing.T) {
+			spec := createBatchSpecWithWorkspacesAndChangesetSpecs(t)
+
+			_, err := svc.ReplaceBatchSpecInput(adminCtx, ReplaceBatchSpecInputOpts{
+				BatchSpecRandID: spec.RandID,
+				RawSpec: `
+name: test-spec
+description: A test spec
+steps:
+  - run: /tmp/sample.sh
+    container: alpine:3
+    mount:
+      - path: /some/path/sample.sh
+        mountpoint: /tmp/sample.sh
+changesetTemplate:
+  title: Test Mount
+  body: Test a mounted path
+  branch: test
+  commit:
+    message: Test
+`,
+			})
+			assert.Equal(t, "mounts are not allowed for server-side processing", err.Error())
+		})
 	})
 
 	t.Run("CreateBatchSpecFromRaw", func(t *testing.T) {

--- a/enterprise/internal/batches/service/service_test.go
+++ b/enterprise/internal/batches/service/service_test.go
@@ -1551,6 +1551,29 @@ func TestService(t *testing.T) {
 				t.Fatalf("wrong error message: %s", err)
 			}
 		})
+
+		t.Run("mount error", func(t *testing.T) {
+			_, err := svc.CreateBatchSpecFromRaw(adminCtx, CreateBatchSpecFromRawOpts{
+				RawSpec: `
+name: test-spec
+description: A test spec
+steps:
+  - run: /tmp/sample.sh
+    container: alpine:3
+    mount:
+      - path: /some/path/sample.sh
+        mountpoint: /tmp/sample.sh
+changesetTemplate:
+  title: Test Mount
+  body: Test a mounted path
+  branch: test
+  commit:
+    message: Test
+`,
+				NamespaceUserID: admin.ID,
+			})
+			assert.Equal(t, "mounts are not allowed for server-side processing", err.Error())
+		})
 	})
 
 	t.Run("UpsertBatchSpecInput", func(t *testing.T) {
@@ -1593,6 +1616,29 @@ func TestService(t *testing.T) {
 				ID: oldSpec.ID,
 			})
 			assert.Equal(t, store.ErrNoResults, err)
+		})
+
+		t.Run("mount error", func(t *testing.T) {
+			_, err := svc.UpsertBatchSpecInput(adminCtx, UpsertBatchSpecInputOpts{
+				RawSpec: `
+name: test-spec
+description: A test spec
+steps:
+  - run: /tmp/sample.sh
+    container: alpine:3
+    mount:
+      - path: /some/path/sample.sh
+        mountpoint: /tmp/sample.sh
+changesetTemplate:
+  title: Test Mount
+  body: Test a mounted path
+  branch: test
+  commit:
+    message: Test
+`,
+				NamespaceUserID: admin.ID,
+			})
+			assert.Equal(t, "mounts are not allowed for server-side processing", err.Error())
 		})
 	})
 


### PR DESCRIPTION
Part of #31790.

Adds checks to prevent a batch spec with a `mount` in a `step` from being processed when running server-side batch changes.

* `CreateBatchSpecFromRaw` called from UI SSBC
* `UpsertBatchSpecInput` called from `src batch remote` command

## Test plan

Go unit tests and manual testing.