### PR TITLE
Improve testing with Tooltips

### DIFF
--- a/client/branded/src/components/panel/views/__snapshots__/HierarchicalLocationsView.test.tsx.snap
+++ b/client/branded/src/components/panel/views/__snapshots__/HierarchicalLocationsView.test.tsx.snap
@@ -70,6 +70,7 @@ exports[`<HierarchicalLocationsView /> displays a single location when complete 
               <span
                 class="tooltip"
                 data-state="closed"
+                data-test-content="github.com"
                 role="presentation"
               >
                 <svg
@@ -333,6 +334,7 @@ exports[`<HierarchicalLocationsView /> displays multiple locations grouped by fi
               <span
                 class="tooltip"
                 data-state="closed"
+                data-test-content="github.com"
                 role="presentation"
               >
                 <svg
@@ -552,6 +554,7 @@ exports[`<HierarchicalLocationsView /> displays partial locations before complet
               <span
                 class="tooltip"
                 data-state="closed"
+                data-test-content="github.com"
                 role="presentation"
               >
                 <svg

--- a/client/search-ui/src/input/SearchContextDropdown.test.tsx
+++ b/client/search-ui/src/input/SearchContextDropdown.test.tsx
@@ -75,16 +75,19 @@ describe('SearchContextDropdown', () => {
     it('should be enabled if query is empty', () => {
         render(<SearchContextDropdown {...defaultProps} />)
         expect(screen.getByTestId('dropdown-toggle')).toBeEnabled()
+        expect(screen.getByTestId('dropdown-tooltip')).toHaveAttribute('data-test-content', '')
     })
 
     it('should be enabled if query does not contain context filter', () => {
         render(<SearchContextDropdown {...defaultProps} query="test (repo:foo or repo:python)" />)
         expect(screen.getByTestId('dropdown-toggle')).toBeEnabled()
+        expect(screen.getByTestId('dropdown-tooltip')).toHaveAttribute('data-test-content', '')
     })
 
     it('should be disabled if query contains context filter', () => {
         render(<SearchContextDropdown {...defaultProps} query="test (context:foo or repo:python)" />)
         expect(screen.getByTestId('dropdown-toggle')).toBeDisabled()
+        expect(screen.getByTestId('dropdown-tooltip')).toHaveAttribute('data-test-content', 'Overridden by query')
     })
 
     it('should submit search on item click', () => {

--- a/client/search-ui/src/input/SearchContextDropdown.tsx
+++ b/client/search-ui/src/input/SearchContextDropdown.tsx
@@ -63,7 +63,7 @@ export const SearchContextDropdown: React.FunctionComponent<
 
     const isContextFilterInQuery = useMemo(() => filterExists(query, FilterType.context), [query])
 
-    const disabledTooltipText = isContextFilterInQuery ? 'Overridden by query' : null
+    const disabledTooltipText = isContextFilterInQuery ? 'Overridden by query' : ''
 
     const selectSearchContextSpec = useCallback(
         (spec: string): void => {
@@ -115,7 +115,7 @@ export const SearchContextDropdown: React.FunctionComponent<
             a11y={false} /* Override default keyboard events in reactstrap */
             className={className}
         >
-            <Tooltip content={disabledTooltipText}>
+            <Tooltip content={disabledTooltipText} data-testid="dropdown-tooltip">
                 <DropdownToggle
                     className={classNames(
                         styles.button,

--- a/client/search-ui/src/results/progress/__snapshots__/StreamingProgressCount.test.tsx.snap
+++ b/client/search-ui/src/results/progress/__snapshots__/StreamingProgressCount.test.tsx.snap
@@ -32,6 +32,7 @@ exports[`StreamingProgressCount should render correctly for 0 repositories 1`] =
     <span
       class="tooltip"
       data-state="closed"
+      data-test-content="From 0 repositories"
       role="presentation"
     >
       <svg
@@ -63,6 +64,7 @@ exports[`StreamingProgressCount should render correctly for 1 item complete 1`] 
     <span
       class="tooltip"
       data-state="closed"
+      data-test-content="From 1 repository"
       role="presentation"
     >
       <svg
@@ -94,6 +96,7 @@ exports[`StreamingProgressCount should render correctly for 123 items complete 1
     <span
       class="tooltip"
       data-state="closed"
+      data-test-content="From 500 repositories"
       role="presentation"
     >
       <svg
@@ -125,6 +128,7 @@ exports[`StreamingProgressCount should render correctly for big numbers complete
     <span
       class="tooltip"
       data-state="closed"
+      data-test-content="From 8.9k repositories"
       role="presentation"
     >
       <svg
@@ -156,6 +160,7 @@ exports[`StreamingProgressCount should render correctly for limithit 1`] = `
     <span
       class="tooltip"
       data-state="closed"
+      data-test-content="From 500 repositories"
       role="presentation"
     >
       <svg

--- a/client/search-ui/src/results/sidebar/__snapshots__/FilterLink.test.tsx.snap
+++ b/client/search-ui/src/results/sidebar/__snapshots__/FilterLink.test.tsx.snap
@@ -123,6 +123,7 @@ exports[`FilterLink should have correct links for repos 1`] = `
         <span
           class="tooltip"
           data-state="closed"
+          data-test-content="gitlab.com"
           role="presentation"
         >
           <svg
@@ -169,6 +170,7 @@ exports[`FilterLink should have correct links for repos 1`] = `
         <span
           class="tooltip"
           data-state="closed"
+          data-test-content="github.com"
           role="presentation"
         >
           <svg
@@ -249,6 +251,7 @@ exports[`FilterLink should have show icons for repos on cloud 1`] = `
         <span
           class="tooltip"
           data-state="closed"
+          data-test-content="gitlab.com"
           role="presentation"
         >
           <svg
@@ -295,6 +298,7 @@ exports[`FilterLink should have show icons for repos on cloud 1`] = `
         <span
           class="tooltip"
           data-state="closed"
+          data-test-content="github.com"
           role="presentation"
         >
           <svg

--- a/client/search-ui/src/results/sidebar/__snapshots__/QuickLink.test.tsx.snap
+++ b/client/search-ui/src/results/sidebar/__snapshots__/QuickLink.test.tsx.snap
@@ -30,6 +30,7 @@ exports[`QuickLink should have correct links when quicklinks present 1`] = `
   <span
     class="tooltip"
     data-state="closed"
+    data-test-content="Example QuickLink"
     role="presentation"
   >
     <a

--- a/client/wildcard/src/components/Tooltip/Tooltip.tsx
+++ b/client/wildcard/src/components/Tooltip/Tooltip.tsx
@@ -16,6 +16,8 @@ interface TooltipProps {
     placement?: TooltipPrimitive.TooltipContentProps['side']
     /** Class name to apply to the wrapping span */
     className?: string
+    /** An optional test ID that will be applied to the Tooltip wrapper */
+    ['data-testid']?: string
 }
 
 /** Arrow width in pixels */
@@ -40,6 +42,8 @@ function onPointerDownOutside(event: Event): void {
  * - Not include interactive content (you probably want a `<Popover>` instead).
  *
  * Related accessibility documentation: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/tooltip_role
+ *
+ * To test for the correct content in test suites where the tooltip won't be opened, please use the `data-test-content` p
  */
 export const Tooltip: React.FunctionComponent<TooltipProps> = ({
     children,
@@ -47,6 +51,7 @@ export const Tooltip: React.FunctionComponent<TooltipProps> = ({
     className,
     defaultOpen = false,
     placement = 'right',
+    'data-testid': dataTestId,
 }) => (
     // NOTE: We plan to consolidate this logic with our Popover component in the future, but chose Radix first to support short-term accessibility needs.
     // GitHub issue: https://github.com/sourcegraph/sourcegraph/issues/36080
@@ -57,6 +62,8 @@ export const Tooltip: React.FunctionComponent<TooltipProps> = ({
                 role="presentation"
                 className={classNames(styles.tooltip, className)}
                 onClick={event => event.preventDefault()}
+                data-testid={dataTestId}
+                data-test-content={content}
             >
                 {children}
 


### PR DESCRIPTION
Adds support for `data-testid` on the tooltip wrapping element. Also adds `data-test-content` to that element for unit and snapshot testing to pick up that the correct content was passed to a tooltip component.

Adding because of [this set of feedback](https://github.com/sourcegraph/sourcegraph/pull/36810#discussion_r893740461) - thank you!

## Test plan

Unit tests were added using the new functionality, and snapshots were updated.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-lrh-add-test-prop-to-tooltip.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-fkbuwegpyx.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
