### PR TITLE
Revert "[Wildcard Migration] New Tooltip within additional `client/` directories"

### DIFF
--- a/client/branded/src/components/panel/TabbedPanelContent.tsx
+++ b/client/branded/src/components/panel/TabbedPanelContent.tsx
@@ -25,7 +25,7 @@ import { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
 import { useTemporarySetting } from '@sourcegraph/shared/src/settings/temporary/useTemporarySetting'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
-import { Button, useObservable, Tab, TabList, TabPanel, TabPanels, Tabs, Icon, Tooltip } from '@sourcegraph/wildcard'
+import { Button, useObservable, Tab, TabList, TabPanel, TabPanels, Tabs, Icon } from '@sourcegraph/wildcard'
 
 import { registerPanelToolbarContributions } from './views/contributions'
 import { EmptyPanelView } from './views/EmptyPanelView'
@@ -325,16 +325,16 @@ export const TabbedPanelContent = React.memo<TabbedPanelContentProps>(props => {
                                 />
                             </>
                         )}
-                        <Tooltip content="Close panel" placement="left">
-                            <Button
-                                onClick={handlePanelClose}
-                                variant="icon"
-                                className={classNames('ml-2', styles.dismissButton)}
-                                title="Close panel"
-                            >
-                                <Icon as={CloseIcon} aria-hidden={true} />
-                            </Button>
-                        </Tooltip>
+                        <Button
+                            onClick={handlePanelClose}
+                            variant="icon"
+                            className={classNames('ml-2', styles.dismissButton)}
+                            title="Close panel"
+                            data-tooltip="Close panel"
+                            data-placement="left"
+                        >
+                            <Icon as={CloseIcon} aria-hidden={true} />
+                        </Button>
                     </div>
                 }
             >

--- a/client/shared/src/actions/ActionItem.tsx
+++ b/client/shared/src/actions/ActionItem.tsx
@@ -8,7 +8,7 @@ import { catchError, map, mapTo, mergeMap, startWith, tap } from 'rxjs/operators
 
 import { ActionContribution, Evaluated } from '@sourcegraph/client-api'
 import { asError, ErrorLike, isErrorLike, isExternalLink } from '@sourcegraph/common'
-import { LoadingSpinner, ButtonLink, ButtonLinkProps, WildcardThemeContext, Tooltip } from '@sourcegraph/wildcard'
+import { LoadingSpinner, ButtonLink, ButtonLinkProps, WildcardThemeContext } from '@sourcegraph/wildcard'
 
 import { ExecuteCommandParameters } from '../api/client/mainthread-api'
 import { urlForOpenPanel } from '../commands/commands'
@@ -222,16 +222,14 @@ export class ActionItem extends React.PureComponent<ActionItemProps, State, type
         // Simple display if the action is a noop.
         if (!this.props.action.command) {
             return (
-                <Tooltip content={tooltip}>
-                    <span
-                        aria-label={tooltip}
-                        data-content={this.props.dataContent}
-                        className={this.props.className}
-                        tabIndex={this.props.tabIndex}
-                    >
-                        {content}
-                    </span>
-                </Tooltip>
+                <span
+                    data-tooltip={tooltip}
+                    data-content={this.props.dataContent}
+                    className={this.props.className}
+                    tabIndex={this.props.tabIndex}
+                >
+                    {content}
+                </span>
             )
         }
 
@@ -260,51 +258,48 @@ export class ActionItem extends React.PureComponent<ActionItemProps, State, type
               }
             : {}
 
-        const actionTooltip =
-            this.props.showInlineError && isErrorLike(this.state.actionOrError)
-                ? `Error: ${this.state.actionOrError.message}`
-                : tooltip
-
         return (
-            <Tooltip content={actionTooltip}>
-                <ButtonLink
-                    aria-label={actionTooltip}
-                    data-content={this.props.dataContent}
-                    disabled={
-                        !this.props.active ||
-                        ((this.props.disabledDuringExecution || this.props.showLoadingSpinnerDuringExecution) &&
-                            this.state.actionOrError === LOADING) ||
-                        this.props.disabledWhen
-                    }
-                    disabledClassName={this.props.inactiveClassName}
-                    data-action-item-pressed={pressed}
-                    className={classNames(
-                        'test-action-item',
-                        this.props.className,
-                        showLoadingSpinner && styles.actionItemLoading,
-                        pressed && [this.props.pressedClassName],
-                        buttonLinkProps.variant === 'link' && styles.actionItemLink
-                    )}
-                    pressed={pressed}
-                    onSelect={this.runAction}
-                    // If the command is 'open' or 'openXyz' (builtin commands), render it as a link. Otherwise render
-                    // it as a button that executes the command.
-                    to={to}
-                    {...newTabProps}
-                    {...buttonLinkProps}
-                    tabIndex={this.props.tabIndex}
-                >
-                    {content}{' '}
-                    {!this.props.hideExternalLinkIcon && primaryTo && isExternalLink(primaryTo) && (
-                        <OpenInNewIcon className={this.props.iconClassName} />
-                    )}
-                    {showLoadingSpinner && (
-                        <div className={styles.loader} data-testid="action-item-spinner">
-                            <LoadingSpinner inline={false} className={this.props.iconClassName} />
-                        </div>
-                    )}
-                </ButtonLink>
-            </Tooltip>
+            <ButtonLink
+                data-tooltip={
+                    this.props.showInlineError && isErrorLike(this.state.actionOrError)
+                        ? `Error: ${this.state.actionOrError.message}`
+                        : tooltip
+                }
+                data-content={this.props.dataContent}
+                disabled={
+                    !this.props.active ||
+                    ((this.props.disabledDuringExecution || this.props.showLoadingSpinnerDuringExecution) &&
+                        this.state.actionOrError === LOADING) ||
+                    this.props.disabledWhen
+                }
+                disabledClassName={this.props.inactiveClassName}
+                data-action-item-pressed={pressed}
+                className={classNames(
+                    'test-action-item',
+                    this.props.className,
+                    showLoadingSpinner && styles.actionItemLoading,
+                    pressed && [this.props.pressedClassName],
+                    buttonLinkProps.variant === 'link' && styles.actionItemLink
+                )}
+                pressed={pressed}
+                onSelect={this.runAction}
+                // If the command is 'open' or 'openXyz' (builtin commands), render it as a link. Otherwise render
+                // it as a button that executes the command.
+                to={to}
+                {...newTabProps}
+                {...buttonLinkProps}
+                tabIndex={this.props.tabIndex}
+            >
+                {content}{' '}
+                {!this.props.hideExternalLinkIcon && primaryTo && isExternalLink(primaryTo) && (
+                    <OpenInNewIcon className={this.props.iconClassName} />
+                )}
+                {showLoadingSpinner && (
+                    <div className={styles.loader} data-testid="action-item-spinner">
+                        <LoadingSpinner inline={false} className={this.props.iconClassName} />
+                    </div>
+                )}
+            </ButtonLink>
         )
     }
 

--- a/client/shared/src/actions/__snapshots__/ActionItem.test.tsx.snap
+++ b/client/shared/src/actions/__snapshots__/ActionItem.test.tsx.snap
@@ -2,282 +2,217 @@
 
 exports[`ActionItem "open" command renders as link 1`] = `
 <DocumentFragment>
-  <span
-    class="tooltip"
-    data-state="closed"
-    role="presentation"
+  <a
+    class="anchorLink btn btnLink test-action-item actionItemLink"
+    href="https://example.com/bar"
+    tabindex="0"
   >
-    <a
-      class="anchorLink btn btnLink test-action-item actionItemLink"
-      href="https://example.com/bar"
-      tabindex="0"
-    >
-       t 
-    </a>
-  </span>
+     t 
+  </a>
 </DocumentFragment>
 `;
 
 exports[`ActionItem "open" command renders as link that opens in a new tab, but without icon for a different origin as the alt action and a primary action defined 1`] = `
 <DocumentFragment>
-  <span
-    class="tooltip"
-    data-state="closed"
-    role="presentation"
+  <a
+    class="anchorLink btn btnLink test-action-item actionItemLink"
+    href="https://other.com/foo"
+    rel="noopener noreferrer"
+    tabindex="0"
+    target="_blank"
   >
-    <a
-      class="anchorLink btn btnLink test-action-item actionItemLink"
-      href="https://other.com/foo"
-      rel="noopener noreferrer"
-      tabindex="0"
-      target="_blank"
-    >
-       primary 
-    </a>
-  </span>
+     primary 
+  </a>
 </DocumentFragment>
 `;
 
 exports[`ActionItem "open" command renders as link with icon and opens a new tab for a different origin 1`] = `
 <DocumentFragment>
-  <span
-    class="tooltip"
-    data-state="closed"
-    role="presentation"
+  <a
+    class="anchorLink btn btnLink test-action-item actionItemLink"
+    href="https://other.com/foo"
+    rel="noopener noreferrer"
+    tabindex="0"
+    target="_blank"
   >
-    <a
-      class="anchorLink btn btnLink test-action-item actionItemLink"
-      href="https://other.com/foo"
-      rel="noopener noreferrer"
-      tabindex="0"
-      target="_blank"
-    >
-       t 
-      <openinnewicon />
-    </a>
-  </span>
+     t 
+    <openinnewicon />
+  </a>
 </DocumentFragment>
 `;
 
 exports[`ActionItem actionItem variant 1`] = `
 <DocumentFragment>
-  <span
-    class="tooltip"
-    data-state="closed"
-    role="presentation"
+  <a
+    aria-label="d"
+    class="test-action-item"
+    data-tooltip="d"
+    href=""
+    role="button"
+    tabindex="0"
   >
-    <a
-      aria-label="d"
-      class="test-action-item"
-      href=""
-      role="button"
-      tabindex="0"
-    >
-      <img
-        alt="d"
-        src="u"
-      />
-       g: t 
-    </a>
-  </span>
+    <img
+      alt="d"
+      src="u"
+    />
+     g: t 
+  </a>
 </DocumentFragment>
 `;
 
 exports[`ActionItem non-actionItem variant 1`] = `
 <DocumentFragment>
-  <span
-    class="tooltip"
-    data-state="closed"
-    role="presentation"
+  <a
+    aria-label="d"
+    class="test-action-item"
+    data-tooltip="d"
+    href=""
+    role="button"
+    tabindex="0"
   >
-    <a
-      aria-label="d"
-      class="test-action-item"
-      href=""
-      role="button"
-      tabindex="0"
-    >
-      <img
-        alt="d"
-        src="u"
-      />
-       g: t 
-    </a>
-  </span>
+    <img
+      alt="d"
+      src="u"
+    />
+     g: t 
+  </a>
 </DocumentFragment>
 `;
 
 exports[`ActionItem non-pressed actionItem 1`] = `
 <DocumentFragment>
-  <span
-    class="tooltip"
-    data-state="closed"
-    role="presentation"
+  <a
+    aria-pressed="false"
+    class="test-action-item"
+    data-action-item-pressed="false"
+    href=""
+    role="button"
+    tabindex="0"
   >
-    <a
-      aria-pressed="false"
-      class="test-action-item"
-      data-action-item-pressed="false"
-      href=""
-      role="button"
-      tabindex="0"
-    >
-       b 
-    </a>
-  </span>
+     b 
+  </a>
 </DocumentFragment>
 `;
 
 exports[`ActionItem noop command 1`] = `
 <DocumentFragment>
   <span
-    class="tooltip"
-    data-state="closed"
-    role="presentation"
+    data-tooltip="d"
   >
-    <span
-      aria-label="d"
-    >
-      <img
-        alt="d"
-        src="u"
-      />
-       g: t
-    </span>
+    <img
+      alt="d"
+      src="u"
+    />
+     g: t
   </span>
 </DocumentFragment>
 `;
 
 exports[`ActionItem pressed toggle actionItem 1`] = `
 <DocumentFragment>
-  <span
-    class="tooltip"
-    data-state="closed"
-    role="presentation"
+  <a
+    aria-pressed="true"
+    class="test-action-item"
+    data-action-item-pressed="true"
+    href=""
+    role="button"
+    tabindex="0"
   >
-    <a
-      aria-pressed="true"
-      class="test-action-item"
-      data-action-item-pressed="true"
-      href=""
-      role="button"
-      tabindex="0"
-    >
-       b 
-    </a>
-  </span>
+     b 
+  </a>
 </DocumentFragment>
 `;
 
 exports[`ActionItem run command 1`] = `
 <DocumentFragment>
-  <span
-    class="tooltip"
-    data-state="closed"
-    role="presentation"
+  <a
+    aria-label="d"
+    class="test-action-item"
+    data-tooltip="d"
+    href=""
+    role="button"
+    tabindex="0"
   >
-    <a
-      aria-label="d"
-      class="test-action-item"
-      href=""
-      role="button"
-      tabindex="0"
-    >
-      <img
-        alt="d"
-        src="u"
-      />
-       g: t 
-    </a>
-  </span>
+    <img
+      alt="d"
+      src="u"
+    />
+     g: t 
+  </a>
 </DocumentFragment>
 `;
 
 exports[`ActionItem run command 2`] = `
 <DocumentFragment>
-  <span
-    class="tooltip"
-    data-state="closed"
-    role="presentation"
+  <a
+    aria-label="d"
+    class="test-action-item"
+    data-tooltip="d"
+    href=""
+    role="button"
+    tabindex="0"
   >
-    <a
-      aria-label="d"
-      class="test-action-item"
-      href=""
-      role="button"
-      tabindex="0"
-    >
-      <img
-        alt="d"
-        src="u"
-      />
-       g: t 
-    </a>
-  </span>
+    <img
+      alt="d"
+      src="u"
+    />
+     g: t 
+  </a>
 </DocumentFragment>
 `;
 
 exports[`ActionItem run command with error 1`] = `
 <DocumentFragment>
-  <span
-    aria-describedby="radix-8"
-    class="tooltip"
-    data-state="delayed-open"
-    role="presentation"
+  <a
+    aria-label="d"
+    class="test-action-item"
+    data-tooltip="d"
+    href=""
+    role="button"
+    tabindex="0"
   >
-    <a
-      aria-label="d"
-      class="test-action-item"
-      href=""
-      role="button"
-      tabindex="0"
-    >
-      <img
-        alt="d"
-        src="u"
-      />
-       g: t 
-    </a>
-  </span>
+    <img
+      alt="d"
+      src="u"
+    />
+     g: t 
+  </a>
 </DocumentFragment>
 `;
 
 exports[`ActionItem run command with error with showInlineError 1`] = `
 <DocumentFragment>
-  <span
-    aria-describedby="radix-9"
-    class="tooltip"
-    data-state="delayed-open"
-    role="presentation"
+  <a
+    aria-label="Error: x"
+    class="test-action-item"
+    data-tooltip="Error: x"
+    href=""
+    role="button"
+    tabindex="0"
   >
-    <a
-      aria-label="Error: x"
-      class="test-action-item"
-      href=""
-      role="button"
-      tabindex="0"
-    >
-      <img
-        alt="d"
-        src="u"
-      />
-       g: t 
-    </a>
-  </span>
+    <img
+      alt="d"
+      src="u"
+    />
+     g: t 
+  </a>
 </DocumentFragment>
 `;
 
 exports[`ActionItem run command with showLoadingSpinnerDuringExecution 1`] = `
 <DocumentFragment>
-  <span
-    aria-describedby="radix-7"
-    class="tooltip"
-    data-state="delayed-open"
-    role="presentation"
+  <div
+    class="container"
   >
+    <div
+      class="disabledTooltip"
+      data-tooltip="d"
+      tabindex="0"
+    />
     <a
       aria-label="d"
       class="test-action-item actionItemLoading disabled"
+      data-tooltip="d"
       disabled=""
       href=""
       role="button"
@@ -297,54 +232,43 @@ exports[`ActionItem run command with showLoadingSpinnerDuringExecution 1`] = `
         />
       </div>
     </a>
-  </span>
+  </div>
 </DocumentFragment>
 `;
 
 exports[`ActionItem run command with showLoadingSpinnerDuringExecution 2`] = `
 <DocumentFragment>
-  <span
-    aria-describedby="radix-7"
-    class="tooltip"
-    data-state="delayed-open"
-    role="presentation"
+  <a
+    aria-label="d"
+    class="test-action-item"
+    data-tooltip="d"
+    href=""
+    role="button"
+    tabindex="0"
   >
-    <a
-      aria-label="d"
-      class="test-action-item"
-      href=""
-      role="button"
-      tabindex="0"
-    >
-      <img
-        alt="d"
-        src="u"
-      />
-       g: t 
-    </a>
-  </span>
+    <img
+      alt="d"
+      src="u"
+    />
+     g: t 
+  </a>
 </DocumentFragment>
 `;
 
 exports[`ActionItem title element 1`] = `
 <DocumentFragment>
-  <span
-    class="tooltip"
-    data-state="closed"
-    role="presentation"
+  <a
+    aria-label="d"
+    class="test-action-item"
+    data-tooltip="d"
+    href=""
+    role="button"
+    tabindex="0"
   >
-    <a
-      aria-label="d"
-      class="test-action-item"
-      href=""
-      role="button"
-      tabindex="0"
-    >
-      <span>
-        t2
-      </span>
-       
-    </a>
-  </span>
+    <span>
+      t2
+    </span>
+     
+  </a>
 </DocumentFragment>
 `;

--- a/client/shared/src/actions/__snapshots__/ActionsNavItems.test.tsx.snap
+++ b/client/shared/src/actions/__snapshots__/ActionsNavItems.test.tsx.snap
@@ -5,16 +5,10 @@ exports[`ActionItem Renders contributed action items 1`] = `
    
   <li>
     <span
-      class="tooltip"
-      data-state="closed"
-      role="presentation"
+      class="actionItem"
+      data-tooltip="This is Action A"
     >
-      <span
-        aria-label="This is Action A"
-        class="actionItem"
-      >
-         Action A
-      </span>
+       Action A
     </span>
   </li>
 </DocumentFragment>

--- a/client/shared/src/components/icons.tsx
+++ b/client/shared/src/components/icons.tsx
@@ -5,6 +5,7 @@ import classNames from 'classnames'
 export interface IconProps {
     className?: string
     size?: number
+    'data-tooltip'?: string
 }
 
 function sizeProps(props: IconProps): { width: number; height: number; viewBox: string } {

--- a/client/shared/src/hover/__snapshots__/HoverOverlay.test.tsx.snap
+++ b/client/shared/src/hover/__snapshots__/HoverOverlay.test.tsx.snap
@@ -107,20 +107,14 @@ exports[`HoverOverlay actions and hover present 1`] = `
         <div
           class="actionsInner"
         >
-          <span
-            class="tooltip"
-            data-state="closed"
-            role="presentation"
+          <a
+            class="test-action-item action test-tooltip-untitled"
+            href=""
+            role="button"
+            tabindex="0"
           >
-            <a
-              class="test-action-item action test-tooltip-untitled"
-              href=""
-              role="button"
-              tabindex="0"
-            >
-                
-            </a>
-          </span>
+              
+          </a>
         </div>
       </div>
     </div>
@@ -217,20 +211,14 @@ exports[`HoverOverlay actions present 1`] = `
         <div
           class="actionsInner"
         >
-          <span
-            class="tooltip"
-            data-state="closed"
-            role="presentation"
+          <a
+            class="test-action-item action test-tooltip-some-title"
+            href=""
+            role="button"
+            tabindex="0"
           >
-            <a
-              class="test-action-item action test-tooltip-some-title"
-              href=""
-              role="button"
-              tabindex="0"
-            >
-               Some title 
-            </a>
-          </span>
+             Some title 
+          </a>
         </div>
       </div>
     </div>
@@ -266,20 +254,14 @@ exports[`HoverOverlay actions present, hover loading 1`] = `
         <div
           class="actionsInner"
         >
-          <span
-            class="tooltip"
-            data-state="closed"
-            role="presentation"
+          <a
+            class="test-action-item action test-tooltip-untitled"
+            href=""
+            role="button"
+            tabindex="0"
           >
-            <a
-              class="test-action-item action test-tooltip-untitled"
-              href=""
-              role="button"
-              tabindex="0"
-            >
-                
-            </a>
-          </span>
+              
+          </a>
         </div>
       </div>
     </div>
@@ -355,20 +337,14 @@ exports[`HoverOverlay actions, hover and alert present 1`] = `
         <div
           class="actionsInner"
         >
-          <span
-            class="tooltip"
-            data-state="closed"
-            role="presentation"
+          <a
+            class="test-action-item action test-tooltip-untitled"
+            href=""
+            role="button"
+            tabindex="0"
           >
-            <a
-              class="test-action-item action test-tooltip-untitled"
-              href=""
-              role="button"
-              tabindex="0"
-            >
-                
-            </a>
-          </span>
+              
+          </a>
         </div>
       </div>
     </div>
@@ -432,20 +408,14 @@ exports[`HoverOverlay hover error, actions present 1`] = `
         <div
           class="actionsInner"
         >
-          <span
-            class="tooltip"
-            data-state="closed"
-            role="presentation"
+          <a
+            class="test-action-item action test-tooltip-untitled"
+            href=""
+            role="button"
+            tabindex="0"
           >
-            <a
-              class="test-action-item action test-tooltip-untitled"
-              href=""
-              role="button"
-              tabindex="0"
-            >
-                
-            </a>
-          </span>
+              
+          </a>
         </div>
       </div>
     </div>

--- a/client/shared/src/symbols/SymbolIcon.tsx
+++ b/client/shared/src/symbols/SymbolIcon.tsx
@@ -28,7 +28,7 @@ import TimetableIcon from 'mdi-react/TimetableIcon'
 import WebIcon from 'mdi-react/WebIcon'
 import WrenchIcon from 'mdi-react/WrenchIcon'
 
-import { Icon, Tooltip } from '@sourcegraph/wildcard'
+import { Icon } from '@sourcegraph/wildcard'
 
 import { SymbolKind } from '../graphql-operations'
 
@@ -111,11 +111,10 @@ export const SymbolIcon: React.FunctionComponent<React.PropsWithChildren<SymbolI
     kind,
     className = '',
 }) => (
-    <Tooltip content={kind.toLowerCase()}>
-        <Icon
-            className={classNames(getSymbolIconClassName(kind), className)}
-            as={getSymbolIconComponent(kind)}
-            aria-label={kind.toLowerCase()}
-        />
-    </Tooltip>
+    <Icon
+        className={classNames(getSymbolIconClassName(kind), className)}
+        data-tooltip={kind.toLowerCase()}
+        as={getSymbolIconComponent(kind)}
+        aria-label={kind.toLowerCase()}
+    />
 )

--- a/client/vscode/src/webview/search-panel/alias/RepoFileLink.tsx
+++ b/client/vscode/src/webview/search-panel/alias/RepoFileLink.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 
 import { parseRepoRevision } from '@sourcegraph/shared/src/util/url'
-import { Tooltip, useIsTruncated } from '@sourcegraph/wildcard'
+import { useIsTruncated } from '@sourcegraph/wildcard'
 
 import { useOpenSearchResultsContext } from '../MatchHandlersContext'
 
@@ -86,23 +86,21 @@ export const RepoFileLink: React.FunctionComponent<React.PropsWithChildren<Props
         openFile(repoName, { path: filePath, revision })
     }
 
-    let tooltip: string | undefined
-    if (truncated) {
-        tooltip = fileBase ? `${fileBase}/${fileName}` : fileName
-    }
-
     return (
-        <Tooltip content={tooltip}>
-            <div ref={titleReference} className={className} onMouseEnter={checkTruncation}>
-                <button onClick={onRepoClick} type="button" className="btn btn-text-link">
-                    {repoDisplayName || displayRepoName(repoName)}
-                </button>{' '}
-                ›{' '}
-                <button onClick={onFileClick} type="button" className="btn btn-text-link">
-                    {fileBase ? `${fileBase}/` : null}
-                    <strong>{fileName}</strong>
-                </button>
-            </div>
-        </Tooltip>
+        <div
+            ref={titleReference}
+            className={className}
+            onMouseEnter={checkTruncation}
+            data-tooltip={truncated ? (fileBase ? `${fileBase}/${fileName}` : fileName) : null}
+        >
+            <button onClick={onRepoClick} type="button" className="btn btn-text-link">
+                {repoDisplayName || displayRepoName(repoName)}
+            </button>{' '}
+            ›{' '}
+            <button onClick={onFileClick} type="button" className="btn btn-text-link">
+                {fileBase ? `${fileBase}/` : null}
+                <strong>{fileName}</strong>
+            </button>
+        </div>
     )
 }

--- a/client/vscode/src/webview/search-panel/components/SearchResultsInfoBar.tsx
+++ b/client/vscode/src/webview/search-panel/components/SearchResultsInfoBar.tsx
@@ -7,7 +7,7 @@ import LinkIcon from 'mdi-react/LinkIcon'
 
 import { SearchPatternType } from '@sourcegraph/shared/src/schema'
 import { FilterKind, findFilter } from '@sourcegraph/shared/src/search/query/query'
-import { Icon, Tooltip } from '@sourcegraph/wildcard'
+import { Icon } from '@sourcegraph/wildcard'
 
 import { WebviewPageProps } from '../../platform/context'
 
@@ -68,14 +68,15 @@ const QuotesInterpretedLiterallyNotice: React.FunctionComponent<
     React.PropsWithChildren<SearchResultsInfoBarProps>
 > = props =>
     props.patternType === SearchPatternType.literal && props.fullQuery && props.fullQuery.includes('"') ? (
-        <Tooltip content="Your search query is interpreted literally, including the quotes. Use the .* toggle to switch between literal and regular expression search.">
-            <small className={styles.notice}>
-                <span>
-                    <Icon aria-hidden={true} className="mr-1" as={FormatQuoteOpenIcon} />
-                    Searching literally <strong>(including quotes)</strong>
-                </span>
-            </small>
-        </Tooltip>
+        <small
+            className={styles.notice}
+            data-tooltip="Your search query is interpreted literally, including the quotes. Use the .* toggle to switch between literal and regular expression search."
+        >
+            <span>
+                <Icon aria-hidden={true} className="mr-1" as={FormatQuoteOpenIcon} />
+                Searching literally <strong>(including quotes)</strong>
+            </span>
+        </small>
     ) : null
 
 export const SearchResultsInfoBar: React.FunctionComponent<
@@ -136,35 +137,32 @@ export const SearchResultsInfoBar: React.FunctionComponent<
         searchParameters.set('trigger-query', `${fullQuery} patternType:${patternType}`)
         return (
             <li className={classNames('mr-2', styles.navItem)}>
-                <Tooltip
-                    content={
+                <ExperimentalActionButton
+                    extensionCoreAPI={extensionCoreAPI}
+                    showExperimentalVersion={showActionButtonExperimentalVersion}
+                    onNonExperimentalLinkClick={onCreateCodeMonitorButtonClick}
+                    className="test-save-search-link"
+                    data-tooltip={
                         !canCreateMonitorFromQuery
                             ? 'Code monitors only support type:diff or type:commit searches.'
-                            : null
+                            : undefined
                     }
-                >
-                    <ExperimentalActionButton
-                        extensionCoreAPI={extensionCoreAPI}
-                        showExperimentalVersion={showActionButtonExperimentalVersion}
-                        onNonExperimentalLinkClick={onCreateCodeMonitorButtonClick}
-                        className="test-save-search-link"
-                        button={
-                            <>
-                                <Icon aria-hidden={true} className="mr-1" as={CodeMonitoringLogo} />
-                                Monitor
-                            </>
-                        }
-                        icon={<BookmarkRadialGradientIcon />}
-                        title="Monitor code for changes"
-                        copyText="Create a monitor and get notified when your code changes. Free for registered users."
-                        source="CodeMonitor"
-                        viewEventName="VSCECodeMonitorCTAShown"
-                        returnTo={`/code-monitoring/new?${searchParameters.toString()}`}
-                        telemetryService={platformContext.telemetryService}
-                        isNonExperimentalLinkDisabled={!canCreateMonitorFromQuery}
-                        instanceURL={instanceURL}
-                    />
-                </Tooltip>
+                    button={
+                        <>
+                            <Icon aria-hidden={true} className="mr-1" as={CodeMonitoringLogo} />
+                            Monitor
+                        </>
+                    }
+                    icon={<BookmarkRadialGradientIcon />}
+                    title="Monitor code for changes"
+                    copyText="Create a monitor and get notified when your code changes. Free for registered users."
+                    source="CodeMonitor"
+                    viewEventName="VSCECodeMonitorCTAShown"
+                    returnTo={`/code-monitoring/new?${searchParameters.toString()}`}
+                    telemetryService={platformContext.telemetryService}
+                    isNonExperimentalLinkDisabled={!canCreateMonitorFromQuery}
+                    instanceURL={instanceURL}
+                />
             </li>
         )
     }, [
@@ -218,18 +216,16 @@ export const SearchResultsInfoBar: React.FunctionComponent<
 
     const ShareLinkButton = useMemo(
         () => (
-            <Tooltip className="mr-2" content="Share results link">
-                <li className={classNames('mr-2', styles.navItem)}>
-                    <button
-                        type="button"
-                        className="btn btn-sm btn-outline-secondary text-decoration-none"
-                        onClick={onShareResultsClick}
-                    >
-                        <Icon aria-hidden={true} className="mr-1" as={LinkIcon} />
-                        Share
-                    </button>
-                </li>
-            </Tooltip>
+            <li className={classNames('mr-2', styles.navItem)} data-tooltip="Share results link">
+                <button
+                    type="button"
+                    className="btn btn-sm btn-outline-secondary text-decoration-none"
+                    onClick={onShareResultsClick}
+                >
+                    <Icon aria-hidden={true} className="mr-1" as={LinkIcon} />
+                    Share
+                </button>
+            </li>
         ),
         [onShareResultsClick]
     )

--- a/client/wildcard/src/components/Tooltip/Tooltip.tsx
+++ b/client/wildcard/src/components/Tooltip/Tooltip.tsx
@@ -2,7 +2,6 @@ import React, { ReactNode } from 'react'
 
 import * as TooltipPrimitive from '@radix-ui/react-tooltip'
 import classNames from 'classnames'
-import { isEmpty } from 'lodash'
 
 import styles from './Tooltip.module.scss'
 
@@ -10,7 +9,7 @@ interface TooltipProps {
     /** A single child element that will trigger the Tooltip to open on hover. */
     children: ReactNode
     /** The text that will be displayed in the Tooltip. If `null`, no Tooltip will be rendered, allowing for Tooltips to be shown conditionally. */
-    content: string | null | undefined
+    content: string | null
     /** The open state of the tooltip when it is initially rendered. Defaults to `false`. */
     defaultOpen?: boolean
     /** The preferred side of the trigger to render against when open. Will be reversed if a collision is detected. Defaults to `right`. */
@@ -70,7 +69,7 @@ export const Tooltip: React.FunctionComponent<TooltipProps> = ({
 
                 {
                     // The rest of the Tooltip components still need to be rendered for the content to correctly be shown conditionally.
-                    isEmpty(content) ? null : (
+                    content === null ? null : (
                         /*
                          * Rendering the Content within the Trigger is a workaround to support being able to hover over the Tooltip content itself.
                          * Refrence: https://github.com/radix-ui/primitives/issues/620#issuecomment-1079147761


### PR DESCRIPTION
Reverts sourcegraph/sourcegraph#36870, this change appears to have caused CI to fail. https://sourcegraph.slack.com/archives/C02FLQDD3TQ/p1654812160790659?thread_ts=1654812107.711209&cid=C02FLQDD3TQ

## App preview:

- [Web](https://sg-web-revert-36870-lrh-tooltip-migrate.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-hjhgrmvsql.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

## Test plan

CI passes