### PR TITLE
extsvc/github: remove unused explicit repos cache

### DIFF
--- a/internal/extsvc/github/v3.go
+++ b/internal/extsvc/github/v3.go
@@ -9,7 +9,6 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/google/go-github/v41/github"
 
@@ -19,7 +18,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/auth"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/internal/ratelimit"
-	"github.com/sourcegraph/sourcegraph/internal/rcache"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
@@ -195,26 +193,6 @@ func (c *V3Client) request(ctx context.Context, req *http.Request, result any) (
 	}
 
 	return doRequest(ctx, c.log, c.apiURL, c.auth, c.rateLimitMonitor, c.httpClient, req, result)
-}
-
-// newRepoCache creates a new cache for GitHub repository metadata. The backing
-// store is Redis. A checksum of the authenticator and API URL are used as a
-// Redis key prefix to prevent collisions with caches for different
-// authentication and API URLs.
-func newRepoCache(apiURL *url.URL, a auth.Authenticator) *rcache.Cache {
-	var cacheTTL time.Duration
-	if urlIsGitHubDotCom(apiURL) {
-		cacheTTL = 10 * time.Minute
-	} else {
-		// GitHub Enterprise
-		cacheTTL = 30 * time.Second
-	}
-
-	key := ""
-	if a != nil {
-		key = a.Hash()
-	}
-	return rcache.NewWithTTL("gh_repo:"+key, int(cacheTTL/time.Second))
 }
 
 // APIError is an error type returned by Client when the GitHub API responds with

--- a/internal/extsvc/github/v3_test.go
+++ b/internal/extsvc/github/v3_test.go
@@ -35,39 +35,6 @@ func newTestClientWithAuthenticator(t *testing.T, auth auth.Authenticator, cli h
 	return NewV3Client(logtest.Scoped(t), "Test", apiURL, auth, cli)
 }
 
-func TestNewRepoCache(t *testing.T) {
-	cmpOpts := cmp.AllowUnexported(rcache.Cache{})
-	t.Run("GitHub.com", func(t *testing.T) {
-		url, _ := url.Parse("https://www.github.com")
-		token := &auth.OAuthBearerToken{Token: "asdf"}
-
-		// github.com caches should:
-		// (1) use githubProxyURL for the prefix hash rather than the given url
-		// (2) have a TTL of 10 minutes
-		prefix := "gh_repo:" + token.Hash()
-		got := newRepoCache(url, token)
-		want := rcache.NewWithTTL(prefix, 600)
-		if diff := cmp.Diff(want, got, cmpOpts); diff != "" {
-			t.Fatal(diff)
-		}
-	})
-
-	t.Run("GitHub Enterprise", func(t *testing.T) {
-		url, _ := url.Parse("https://www.sourcegraph.com")
-		token := &auth.OAuthBearerToken{Token: "asdf"}
-
-		// GitHub Enterprise caches should:
-		// (1) use the given URL for the prefix hash
-		// (2) have a TTL of 30 seconds
-		prefix := "gh_repo:" + token.Hash()
-		got := newRepoCache(url, token)
-		want := rcache.NewWithTTL(prefix, 30)
-		if diff := cmp.Diff(want, got, cmpOpts); diff != "" {
-			t.Fatal(diff)
-		}
-	})
-}
-
 func TestListAffiliatedRepositories(t *testing.T) {
 	tests := []struct {
 		name         string


### PR DESCRIPTION
All explicit caching has been removed in favour of implicit etags-based caching via `httpcli`. There are no usages of this function outside of unit tests for the cache itself, so we remove it entirely.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

CI passes