### PR TITLE
[SG-34726] Accessibility: Search context management misc keyboard bugs

### DIFF
--- a/client/search-ui/src/input/SearchContextMenu.tsx
+++ b/client/search-ui/src/input/SearchContextMenu.tsx
@@ -21,7 +21,7 @@ import { AuthenticatedUser } from '@sourcegraph/shared/src/auth'
 import { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
 import { ISearchContext } from '@sourcegraph/shared/src/schema'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
-import { Badge, Button, useObservable, Link, Icon, Input } from '@sourcegraph/wildcard'
+import { Badge, Button, useObservable, Icon, Input, ButtonLink } from '@sourcegraph/wildcard'
 
 import { HighlightedSearchContextSpec } from './HighlightedSearchContextSpec'
 
@@ -379,16 +379,15 @@ export const SearchContextMenu: React.FunctionComponent<React.PropsWithChildren<
                 </Button>
                 <span className="flex-grow-1" />
                 {showSearchContextManagement && (
-                    <Button
+                    <ButtonLink
                         to="/contexts"
                         className={styles.footerButton}
                         onClick={() => closeMenu()}
                         variant="link"
                         size="sm"
-                        as={Link}
                     >
                         Manage contexts
-                    </Button>
+                    </ButtonLink>
                 )}
             </div>
         </div>

--- a/client/wildcard/src/components/ButtonLink/ButtonLink.tsx
+++ b/client/wildcard/src/components/ButtonLink/ButtonLink.tsx
@@ -75,9 +75,9 @@ export const ButtonLink = React.forwardRef((props, reference) => {
     const buttonReference = useRef<HTMLAnchorElement>(null)
     const mergedbuttonReference = useMergeRefs([buttonReference, reference])
 
-    // We need to set up a keypress listener because <a onclick> doesn't get
+    // We need to set up a keydown listener because <a onclick> doesn't get
     // triggered by enter.
-    const handleKeyPress = (event: React.KeyboardEvent<HTMLElement>): void => {
+    const handleKeyDown = (event: React.KeyboardEvent<HTMLElement>): void => {
         if (disabled || !isSelectKeyPress(event)) {
             return
         }
@@ -105,7 +105,8 @@ export const ButtonLink = React.forwardRef((props, reference) => {
         'aria-pressed': pressed,
         tabIndex: isDefined(tabIndex) ? tabIndex : disabled ? -1 : 0,
         onClick: onSelect,
-        onKeyPress: handleKeyPress,
+        // We need `onKeyDown` instead `onKeyPress` to make ButtonLink works inside reactstrap Dropdown
+        onKeyDown: handleKeyDown,
         id,
         ref: mergedbuttonReference,
         disabled,


### PR DESCRIPTION
## Description
This PR is all about search context management misc keyboard bugs

## Audit type
Keyboard navigation

## User journey audit issue
[34191](https://github.com/sourcegraph/sourcegraph/issues/34191)

## Problem description
- [x] "Manage context" link in search contexts dropdown cannot be activated with keyboard (neither space nor enter work)

## Expected behavior
Both issues should be fixed

## Ref 
[Sourcegraph Issue](https://github.com/sourcegraph/sourcegraph/issues/34726)
[Gitstart Ticket](https://app.gitstart.com/clients/sourcegraph/tickets/SG-34726)

## Test plan
 - As shown on the issue link [here](https://github.com/sourcegraph/sourcegraph/issues/34726), run the app on this branch, open `search contexts dropdown` as shown in the image, the `Manage context` link should be activated by `space` or `Enter` keyboard keys

## App preview:

- [Web](https://sg-web-contractors-sg-34726.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-tkeqmquoxm.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
