### PR TITLE
db: prevent duplicate jobs

### DIFF
--- a/internal/database/bitbucket_project_permissions.go
+++ b/internal/database/bitbucket_project_permissions.go
@@ -65,7 +65,7 @@ func (s *bitbucketProjectPermissionsStore) Done(err error) error {
 // Enqueue a job to apply permissions to a Bitbucket project.
 // The job will be enqueued to the BitbucketProjectPermissions worker.
 // If a non-empty permissions slice is passed, unrestricted has to be false, and vice versa.
-func (s *bitbucketProjectPermissionsStore) Enqueue(ctx context.Context, projectKey string, externalServiceID int64, permissions []types.UserPermission, unrestricted bool) (int, error) {
+func (s *bitbucketProjectPermissionsStore) Enqueue(ctx context.Context, projectKey string, externalServiceID int64, permissions []types.UserPermission, unrestricted bool) (jobID int, err error) {
 	if len(permissions) > 0 && unrestricted {
 		return 0, errors.New("cannot specify permissions when unrestricted is true")
 	}
@@ -78,8 +78,22 @@ func (s *bitbucketProjectPermissionsStore) Enqueue(ctx context.Context, projectK
 		perms = append(perms, userPermission(perm))
 	}
 
-	var jobID int
-	err := s.QueryRow(ctx, sqlf.Sprintf(`
+	tx, err := s.transact(ctx)
+	if err != nil {
+		return 0, err
+	}
+	defer func() { err = tx.Done(err) }()
+
+	// ensure we don't enqueue a job for the same project twice
+	err = tx.Exec(ctx, sqlf.Sprintf(`--sql
+-- source: internal/database/bitbucket_project_permissions.go:BitbucketProjectPermissionsStore.Enqueue
+DELETE FROM explicit_permissions_bitbucket_projects_jobs WHERE project_key = %s AND external_service_id = %s AND state = 'queued'
+`, projectKey, externalServiceID))
+	if err != nil && err != sql.ErrNoRows {
+		return 0, err
+	}
+
+	err = s.QueryRow(ctx, sqlf.Sprintf(`--sql
 -- source: internal/database/bitbucket_project_permissions.go:BitbucketProjectPermissionsStore.Enqueue
 INSERT INTO
 	explicit_permissions_bitbucket_projects_jobs (project_key, external_service_id, permissions, unrestricted)

--- a/internal/database/bitbucket_project_permissions.go
+++ b/internal/database/bitbucket_project_permissions.go
@@ -93,7 +93,7 @@ DELETE FROM explicit_permissions_bitbucket_projects_jobs WHERE project_key = %s 
 		return 0, err
 	}
 
-	err = s.QueryRow(ctx, sqlf.Sprintf(`--sql
+	err = tx.QueryRow(ctx, sqlf.Sprintf(`--sql
 -- source: internal/database/bitbucket_project_permissions.go:BitbucketProjectPermissionsStore.Enqueue
 INSERT INTO
 	explicit_permissions_bitbucket_projects_jobs (project_key, external_service_id, permissions, unrestricted)

--- a/internal/database/bitbucket_project_permissions_test.go
+++ b/internal/database/bitbucket_project_permissions_test.go
@@ -21,7 +21,7 @@ func TestBitbucketProjectPermissionsEnqueue(t *testing.T) {
 	db := NewDB(dbtest.NewDB(t))
 	ctx := context.Background()
 
-	check := func(jobID int, permissions []types.UserPermission, unrestricted bool) {
+	check := func(jobID int, projectKey string, permissions []types.UserPermission, unrestricted bool) {
 		rows, err := db.QueryContext(ctx, `SELECT * FROM explicit_permissions_bitbucket_projects_jobs WHERE id = $1`, jobID)
 		require.NoError(t, err)
 
@@ -29,7 +29,7 @@ func TestBitbucketProjectPermissionsEnqueue(t *testing.T) {
 		require.NoError(t, err)
 		require.True(t, ok)
 		require.Equal(t, "queued", job.State)
-		require.Equal(t, "project", job.ProjectKey)
+		require.Equal(t, projectKey, job.ProjectKey)
 		require.Equal(t, int64(1), job.ExternalServiceID)
 		require.Equal(t, permissions, job.Permissions)
 		require.Equal(t, unrestricted, job.Unrestricted)
@@ -40,24 +40,62 @@ func TestBitbucketProjectPermissionsEnqueue(t *testing.T) {
 		{BindID: "user1", Permission: "read"},
 		{BindID: "user2", Permission: "admin"},
 	}
-	jobid, err := db.BitbucketProjectPermissions().Enqueue(ctx, "project", 1, perms, false)
+	jobID, err := db.BitbucketProjectPermissions().Enqueue(ctx, "project 1", 1, perms, false)
 	require.NoError(t, err)
-	require.NotZero(t, jobid)
-	check(jobid, perms, false)
+	require.NotZero(t, jobID)
+	check(jobID, "project 1", perms, false)
 
 	// Enqueue a job with unrestricted only
-	jobid, err = db.BitbucketProjectPermissions().Enqueue(ctx, "project", 1, nil, true)
+	jobID, err = db.BitbucketProjectPermissions().Enqueue(ctx, "project 2", 1, nil, true)
 	require.NoError(t, err)
-	require.NotZero(t, jobid)
-	check(jobid, nil, true)
+	require.NotZero(t, jobID)
+	check(jobID, "project 2", nil, true)
 
 	// Enqueue a job with both unrestricted and perms
-	_, err = db.BitbucketProjectPermissions().Enqueue(ctx, "project", 1, perms, true)
+	_, err = db.BitbucketProjectPermissions().Enqueue(ctx, "project 3", 1, perms, true)
 	require.Error(t, err)
 
 	// Enqueue a job with neither unrestricted or perms
-	_, err = db.BitbucketProjectPermissions().Enqueue(ctx, "project", 1, nil, false)
+	_, err = db.BitbucketProjectPermissions().Enqueue(ctx, "project 4", 1, nil, false)
 	require.Error(t, err)
+
+	// Enqueue two jobs for the same project
+	_, err = db.BitbucketProjectPermissions().Enqueue(ctx, "project 5", 1, perms, false)
+	require.NoError(t, err)
+	jobID2, err := db.BitbucketProjectPermissions().Enqueue(ctx, "project 5", 1, perms, false)
+	require.NoError(t, err)
+
+	var count int
+	err = db.QueryRowContext(ctx, `SELECT COUNT(*) FROM explicit_permissions_bitbucket_projects_jobs WHERE project_key = 'project 5'`).Scan(&count)
+	require.NoError(t, err)
+	require.Equal(t, 1, count)
+
+	err = db.QueryRowContext(ctx, `SELECT id FROM explicit_permissions_bitbucket_projects_jobs WHERE project_key = 'project 5'`).Scan(&jobID)
+	require.NoError(t, err)
+	require.Equal(t, jobID2, jobID)
+
+	// Enqueue two jobs for the same project with different external services
+	_, err = db.BitbucketProjectPermissions().Enqueue(ctx, "project 6", 1, perms, false)
+	require.NoError(t, err)
+	jobID2, err = db.BitbucketProjectPermissions().Enqueue(ctx, "project 6", 2, perms, false)
+	require.NoError(t, err)
+
+	err = db.QueryRowContext(ctx, `SELECT COUNT(*) FROM explicit_permissions_bitbucket_projects_jobs WHERE project_key = 'project 6'`).Scan(&count)
+	require.NoError(t, err)
+	require.Equal(t, 2, count)
+
+	// Enqueue two jobs for the same project with different states
+	jobID, err = db.BitbucketProjectPermissions().Enqueue(ctx, "project 7", 1, perms, false)
+	require.NoError(t, err)
+	_, err = db.Handle().DB().ExecContext(ctx, `UPDATE explicit_permissions_bitbucket_projects_jobs SET state = 'failed' WHERE id = $1`, jobID)
+	require.NoError(t, err)
+
+	jobID2, err = db.BitbucketProjectPermissions().Enqueue(ctx, "project 7", 1, perms, false)
+	require.NoError(t, err)
+
+	err = db.QueryRowContext(ctx, `SELECT COUNT(*) FROM explicit_permissions_bitbucket_projects_jobs WHERE project_key = 'project 7'`).Scan(&count)
+	require.NoError(t, err)
+	require.Equal(t, 2, count)
 }
 
 func TestScanFirstBitbucketProjectPermissionsJob(t *testing.T) {

--- a/internal/database/bitbucket_project_permissions_test.go
+++ b/internal/database/bitbucket_project_permissions_test.go
@@ -77,7 +77,7 @@ func TestBitbucketProjectPermissionsEnqueue(t *testing.T) {
 	// Enqueue two jobs for the same project with different external services
 	_, err = db.BitbucketProjectPermissions().Enqueue(ctx, "project 6", 1, perms, false)
 	require.NoError(t, err)
-	jobID2, err = db.BitbucketProjectPermissions().Enqueue(ctx, "project 6", 2, perms, false)
+	_, err = db.BitbucketProjectPermissions().Enqueue(ctx, "project 6", 2, perms, false)
 	require.NoError(t, err)
 
 	err = db.QueryRowContext(ctx, `SELECT COUNT(*) FROM explicit_permissions_bitbucket_projects_jobs WHERE project_key = 'project 6'`).Scan(&count)
@@ -90,7 +90,7 @@ func TestBitbucketProjectPermissionsEnqueue(t *testing.T) {
 	_, err = db.Handle().DB().ExecContext(ctx, `UPDATE explicit_permissions_bitbucket_projects_jobs SET state = 'failed' WHERE id = $1`, jobID)
 	require.NoError(t, err)
 
-	jobID2, err = db.BitbucketProjectPermissions().Enqueue(ctx, "project 7", 1, perms, false)
+	_, err = db.BitbucketProjectPermissions().Enqueue(ctx, "project 7", 1, perms, false)
 	require.NoError(t, err)
 
 	err = db.QueryRowContext(ctx, `SELECT COUNT(*) FROM explicit_permissions_bitbucket_projects_jobs WHERE project_key = 'project 7'`).Scan(&count)


### PR DESCRIPTION
When enqueueing a job we make sure to replace queued job with the new one
if they are for the same couple project / external service id.

~Note: We will probably need an index, I will add one in another PR.~ Index added here https://github.com/sourcegraph/sourcegraph/pull/36986

Related to #36450

## Test plan

Improved a unit test