### PR TITLE
Enable wrong shard cleanup by default

### DIFF
--- a/cmd/gitserver/server/cleanup.go
+++ b/cmd/gitserver/server/cleanup.go
@@ -85,7 +85,7 @@ var sgmRetries, _ = strconv.Atoi(env.Get("SRC_SGM_RETRIES", "-1", "the maximum n
 var enableSGMaintenance, _ = strconv.ParseBool(env.Get("SRC_ENABLE_SG_MAINTENANCE", "true", "Use sg maintenance during janitorial cleanup phases"))
 
 // The limit of repos cloned on the wrong shard to delete in one janitor run - value <=0 disables delete.
-var wrongShardReposDeleteLimit, _ = strconv.Atoi(env.Get("SRC_WRONG_SHARD_DELETE_LIMIT", "0", "the maximum number of repos not assigned to this shard we delete in one run"))
+var wrongShardReposDeleteLimit, _ = strconv.Atoi(env.Get("SRC_WRONG_SHARD_DELETE_LIMIT", "10", "the maximum number of repos not assigned to this shard we delete in one run"))
 
 var (
 	reposRemoved = promauto.NewCounterVec(prometheus.CounterOpts{

--- a/cmd/gitserver/server/cleanup_test.go
+++ b/cmd/gitserver/server/cleanup_test.go
@@ -165,8 +165,6 @@ func TestCleanupWrongShard(t *testing.T) {
 		}
 		s.testSetup(t)
 		s.Hostname = "does-not-exist"
-		// force cleanup of repos
-		wrongShardReposDeleteLimit = 10
 		s.cleanupRepos([]string{"gitserver-0", "gitserver-1"})
 
 		if _, err := os.Stat(repoA); err != nil {
@@ -174,37 +172,6 @@ func TestCleanupWrongShard(t *testing.T) {
 		}
 		if _, err := os.Stat(repoD); err != nil {
 			t.Error("expected repoD assigned to different shard not to be removed")
-		}
-	})
-	t.Run("forced", func(t *testing.T) {
-		root := t.TempDir()
-		// should be allocated to shard gitserver-1
-		testRepoD := "testrepo-D"
-
-		repoA := path.Join(root, testRepoA, ".git")
-		cmd := exec.Command("git", "--bare", "init", repoA)
-		if err := cmd.Run(); err != nil {
-			t.Fatal(err)
-		}
-		repoD := path.Join(root, testRepoD, ".git")
-		cmdD := exec.Command("git", "--bare", "init", repoD)
-		if err := cmdD.Run(); err != nil {
-			t.Fatal(err)
-		}
-
-		s := &Server{ReposDir: root,
-			Logger: logtest.Scoped(t),
-		}
-		s.testSetup(t)
-		// force cleanup of repos
-		wrongShardReposDeleteLimit = 10
-		s.cleanupRepos([]string{"gitserver-0", "gitserver-1"})
-
-		if _, err := os.Stat(repoA); os.IsNotExist(err) {
-			t.Error("expected repoA not to be removed")
-		}
-		if _, err := os.Stat(repoD); !os.IsNotExist(err) {
-			t.Error("expected repoD assigned to different shard to be removed during clean up")
 		}
 	})
 	t.Run("substringShardName", func(t *testing.T) {
@@ -228,8 +195,6 @@ func TestCleanupWrongShard(t *testing.T) {
 		}
 		s.testSetup(t)
 		s.Hostname = "gitserver-0"
-		// force cleanup of repos
-		wrongShardReposDeleteLimit = 10
 		s.cleanupRepos([]string{"gitserver-0.cluster.local:3178", "gitserver-1.cluster.local:3178"})
 
 		if _, err := os.Stat(repoA); err != nil {


### PR DESCRIPTION
This has been enabled on DotCom for a week now, enabling by default at smaller rate. 
## Test plan

- ran in DotCom for a week at much higher rate
- unit tests