### PR TITLE
batches: use logtest for logging in test

### DIFF
--- a/enterprise/cmd/frontend/internal/executorqueue/queues/batches/transform_test.go
+++ b/enterprise/cmd/frontend/internal/executorqueue/queues/batches/transform_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 
 	"github.com/sourcegraph/log"
+	"github.com/sourcegraph/log/logtest"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	btypes "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
@@ -113,7 +114,7 @@ func TestTransformRecord(t *testing.T) {
 	}
 
 	t.Run("with cache entry", func(t *testing.T) {
-		job, err := transformRecord(context.Background(), log.Scoped("test", "test logger"), store, workspaceExecutionJob, "hunter2")
+		job, err := transformRecord(context.Background(), logtest.Scoped(t), store, workspaceExecutionJob, "hunter2")
 		if err != nil {
 			t.Fatalf("unexpected error transforming record: %s", err)
 		}


### PR DESCRIPTION

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
Scoped log is reflected in the test