### PR TITLE
fix(a11y): Spread `rest` props to DropdownToggle button component

### DIFF
--- a/client/web/src/repo/components/RepoHeaderActions/RepoHeaderActions.tsx
+++ b/client/web/src/repo/components/RepoHeaderActions/RepoHeaderActions.tsx
@@ -21,11 +21,10 @@ export const RepoHeaderActionButtonLink: React.FunctionComponent<
     </ButtonLink>
 )
 
-export const RepoHeaderActionDropdownToggle: React.FunctionComponent<React.PropsWithChildren<unknown>> = ({
-    children,
-    ...rest
-}) => (
-    <Button as={MenuButton} className={classNames('btn-icon', styles.action)} {...rest}>
+export const RepoHeaderActionDropdownToggle: React.FunctionComponent<
+    React.PropsWithChildren<Pick<React.AriaAttributes, 'aria-label'>>
+> = ({ children, ...ariaAttributes }) => (
+    <Button as={MenuButton} className={classNames('btn-icon', styles.action)} {...ariaAttributes}>
         {children}
     </Button>
 )

--- a/client/web/src/repo/components/RepoHeaderActions/RepoHeaderActions.tsx
+++ b/client/web/src/repo/components/RepoHeaderActions/RepoHeaderActions.tsx
@@ -23,8 +23,9 @@ export const RepoHeaderActionButtonLink: React.FunctionComponent<
 
 export const RepoHeaderActionDropdownToggle: React.FunctionComponent<React.PropsWithChildren<unknown>> = ({
     children,
+    ...rest
 }) => (
-    <Button as={MenuButton} className={classNames('btn-icon', styles.action)}>
+    <Button as={MenuButton} className={classNames('btn-icon', styles.action)} {...rest}>
         {children}
     </Button>
 )


### PR DESCRIPTION
This PR spreads all supplied props sent to `RepoHeaderActionDropdownToggle` component, to the `Button` component, thereby sending attributes like `aria-label` too.

Closes #35852

## Test plan

- Tested using a screen reader
- Checked via Dev Tools that the `aria-label="Repository Actions"` attribute is now present on the toggle button.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-mihir-35852-file-actions-menu.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-eajixownyc.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
