### PR TITLE
db: add index ON explicit_permissions_bitbucket_projects_jobs (project_key, external_service_id, state)

### DIFF
--- a/internal/database/schema.json
+++ b/internal/database/schema.json
@@ -7279,6 +7279,16 @@
           "IndexDefinition": "CREATE UNIQUE INDEX explicit_permissions_bitbucket_projects_jobs_pkey ON explicit_permissions_bitbucket_projects_jobs USING btree (id)",
           "ConstraintType": "p",
           "ConstraintDefinition": "PRIMARY KEY (id)"
+        },
+        {
+          "Name": "explicit_permissions_bitbucket_projects_jobs_project_key_extern",
+          "IsPrimaryKey": false,
+          "IsUnique": false,
+          "IsExclusion": false,
+          "IsDeferrable": false,
+          "IndexDefinition": "CREATE INDEX explicit_permissions_bitbucket_projects_jobs_project_key_extern ON explicit_permissions_bitbucket_projects_jobs USING btree (project_key, external_service_id, state)",
+          "ConstraintType": "",
+          "ConstraintDefinition": ""
         }
       ],
       "Constraints": [

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -955,6 +955,7 @@ Tracks the most recent activity of executors attached to this Sourcegraph instan
  unrestricted        | boolean                  |           | not null | false
 Indexes:
     "explicit_permissions_bitbucket_projects_jobs_pkey" PRIMARY KEY, btree (id)
+    "explicit_permissions_bitbucket_projects_jobs_project_key_extern" btree (project_key, external_service_id, state)
 Check constraints:
     "explicit_permissions_bitbucket_projects_jobs_check" CHECK (permissions IS NOT NULL AND unrestricted IS FALSE OR permissions IS NULL AND unrestricted IS TRUE)
 

--- a/migrations/frontend/1654848945/down.sql
+++ b/migrations/frontend/1654848945/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS explicit_permissions_bitbucket_projects_jobs_project_key_external_service_id_state_idx;

--- a/migrations/frontend/1654848945/metadata.yaml
+++ b/migrations/frontend/1654848945/metadata.yaml
@@ -1,0 +1,2 @@
+name: add_explicit_permissions_bitbucket_projects_jobs_index
+parents: [1654116265, 1654168174, 1653524883]

--- a/migrations/frontend/1654848945/up.sql
+++ b/migrations/frontend/1654848945/up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX IF NOT EXISTS explicit_permissions_bitbucket_projects_jobs_project_key_external_service_id_state_idx ON explicit_permissions_bitbucket_projects_jobs (project_key, external_service_id, state);

--- a/migrations/frontend/squashed.sql
+++ b/migrations/frontend/squashed.sql
@@ -3556,6 +3556,8 @@ CREATE INDEX event_logs_timestamp_at_utc ON event_logs USING btree (date(timezon
 
 CREATE INDEX event_logs_user_id ON event_logs USING btree (user_id);
 
+CREATE INDEX explicit_permissions_bitbucket_projects_jobs_project_key_extern ON explicit_permissions_bitbucket_projects_jobs USING btree (project_key, external_service_id, state);
+
 CREATE INDEX external_service_repos_clone_url_idx ON external_service_repos USING btree (clone_url);
 
 CREATE INDEX external_service_repos_idx ON external_service_repos USING btree (external_service_id, repo_id);


### PR DESCRIPTION
We add an index to speed up the duplication of jobs when adding a new job for the same
couple project key / code host id.
The index can also be used to query jobs by project key in https://github.com/sourcegraph/sourcegraph/issues/36453


## Test plan

sg migration up and undo
