### PR TITLE
ci: fix adr docs gen and re-enable docsite linter

### DIFF
--- a/dev/adr-docs/index.md.tmpl
+++ b/dev/adr-docs/index.md.tmpl
@@ -1,3 +1,5 @@
+<!-- DO NOT EDIT: generated via: go generate ./dev/adr-docs -->
+
 # Usage of Architecture Decision Records (ADRs)
 
 This page is an ADR log. Read the first entry to learn about the reasoning and context behind the adoption of ADRs.

--- a/dev/adr-docs/main.go
+++ b/dev/adr-docs/main.go
@@ -24,8 +24,7 @@ type templateData struct {
 	Adrs []adr
 }
 
-//go:generate sh -c "cd ../.. && echo '<!-- DO NOT EDIT: generated via: go generate ./dev/adr-docs -->\n' > doc/dev/adr/index.md"
-//go:generate sh -c "cd ../.. && go run ./dev/adr-docs/main.go >> doc/dev/adr/index.md"
+//go:generate go run .
 func main() {
 	repoRoot, err := root.RepositoryRoot()
 	if err != nil {
@@ -77,7 +76,12 @@ func main() {
 		Adrs: adrs,
 	}
 
-	err = tmpl.Execute(os.Stdout, &presenter)
+	f, err := os.Create(filepath.Join(repoRoot, "doc", "dev", "adr", "index.md"))
+	if err != nil {
+		panic(err)
+	}
+	defer f.Close()
+	err = tmpl.Execute(f, &presenter)
 	if err != nil {
 		panic(err)
 	}

--- a/dev/sg/linters/linters.go
+++ b/dev/sg/linters/linters.go
@@ -36,8 +36,7 @@ var Targets = []lint.Target{
 		Name: "docs",
 		Help: "Documentation checks",
 		Linters: []lint.Runner{
-			// lint.RunScript("Docsite lint", "dev/docsite.sh check"),
-			lint.RunScript("Docsite lint", "echo 'disabled for now'"),
+			lint.RunScript("Docsite lint", "dev/docsite.sh check"),
 		},
 	},
 	{


### PR DESCRIPTION
Fix a very bad mistake and re-enable the docsite linter. 

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Green build in CI, with the docsite linter enabled. 