### PR TITLE
JetBrains: Bump min version to 2020.2

### DIFF
--- a/client/jetbrains/gradle.properties
+++ b/client/jetbrains/gradle.properties
@@ -6,7 +6,8 @@ pluginName=Sourcegraph
 pluginVersion=1.2.4
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
-pluginSinceBuild=162.0
+# 2020.2 was the first version to have JCEF enabled by default -> https://plugins.jetbrains.com/docs/intellij/jcef.html
+pluginSinceBuild=202.0
 # IntelliJ Platform Properties -> https://github.com/JetBrains/gradle-intellij-plugin#intellij-platform-properties
 platformType=IC
 platformVersion=2022.1


### PR DESCRIPTION
I stumble across this property. 2020.2 was the first version to include JCEF by default so we should use this at a minimum now:

https://plugins.jetbrains.com/docs/intellij/jcef.html

## Test plan

```
α jetbrains (ps/jetbrains-bump-min-version) ./gradlew list

> Configure project :
[gradle-intellij-plugin :Sourcegraph] Gradle IntelliJ Plugin is outdated: 1.5.3. Update `org.jetbrains.intellij` to: 1.6.0

> Task :listProductsReleases
IC-2022.1.3
IC-2021.3.3
IC-2021.2.4
IC-2021.1.3
IC-2020.3.4
IC-2020.2.4
BUILD SUCCESSFUL in 1s
1 actionable task: 1 executed
```

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-jetbrains-bump-min-version.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-pnrbozuwwn.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
