### PR TITLE
JetBrains: Upgrade dependencies

### DIFF
--- a/client/jetbrains/build.gradle.kts
+++ b/client/jetbrains/build.gradle.kts
@@ -5,8 +5,8 @@ fun properties(key: String) = project.findProperty(key).toString()
 
 plugins {
     id("java")
-    id("org.jetbrains.kotlin.jvm") version "1.6.10"
-    id("org.jetbrains.intellij") version "1.5.3"
+    id("org.jetbrains.kotlin.jvm") version "1.7.0"
+    id("org.jetbrains.intellij") version "1.6.0"
     id("org.jetbrains.changelog") version "1.3.1"
 }
 


### PR DESCRIPTION
This PR upgrades two gradle dependencies:

- org.jetbrains.intellij: [Changelog](https://github.com/JetBrains/gradle-intellij-plugin/releases/tag/v1.6.0)
- org.jetbrains.kotlin.jvm: [Changelog](https://blog.jetbrains.com/kotlin/2022/06/kotlin-1-7-0-released/?_gl=1*9kdcw2*_ga*MTAwMTg5ODg1LjE2NTQ4NTgwNDE.*_ga_9J976DJZ68*MTY1NDg1ODA0MS4xLjEuMTY1NDg1ODA2OC4w&_ga=2.30965370.496242621.1654858041-100189885.1654858041)

## Test plan

There are no breaking changes in `org.jetbrains.intellij` that affect us and we only use Kotlin for the configuration file which still works.

```
α jetbrains (ps/jetbrains-upgrade-dependencies)✗ ./gradlew list

> Task :listProductsReleases
IC-2022.1.3
IC-2021.3.3
IC-2021.2.4
IC-2019.2.4
IC-2021.1.3
IC-2020.3.4
IC-2019.1.4
IC-2018.3.6
IC-2020.2.4
IC-2020.1.4
IC-2019.3.5
IC-2018.2.8
IC-2018.1.8
IC-2017.3.7
IC-2017.2.7
IC-2017.1.6
IC-2016.3.8
IC-2016.2.5
BUILD SUCCESSFUL in 480ms
1 actionable task: 1 executed
```

Also manually ran `./gradlew runIde` to confirm it still works.
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-jetbrains-upgrade-dependencies.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-jzmohmixem.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
