### PR TITLE
JetBrains: Mention internal mode in the debugging web view section

### DIFF
--- a/client/jetbrains/README.md
+++ b/client/jetbrains/README.md
@@ -105,8 +105,8 @@ See [`CHANGELOG.md`](https://github.com/sourcegraph/sourcegraph/blob/main/client
 
 Parts of this extension rely on the [JCEF](https://plugins.jetbrains.com/docs/intellij/jcef.html) web view features built into the JetBrains platform. To enable debugging tools for this view, please follow these steps:
 
-1. Open Search Everywhere: (On macOS via `cmd+shift+o`)
-2. Select the "Actions" tab
+1. [Enable JetBrains internal mode](https://plugins.jetbrains.com/docs/intellij/enabling-internal.html)
+2. Open Search Everywhere and the "Actions" tab: (On macOS via `cmd+shift+a`)
 3. Search for "Registry..." and open it
 4. Search for an option called `ide.browser.jcef.debug.port`
 5. Change the default value to an open port (e.g. `9222`)


### PR DESCRIPTION
Closes #36232

I noticed that when the internal mode is turned on, the web view debugging works on the latest release so I mention this in the README as well.

## Test plan

Tested this locally on my macOS latest version of IntelliJ.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
