### PR TITLE
JetBrains: Use symbol indexes instead of names and calculate offsets from URL

### DIFF
--- a/client/jetbrains/webview/src/search/App.tsx
+++ b/client/jetbrains/webview/src/search/App.tsx
@@ -40,9 +40,9 @@ interface Props {
     instanceURL: string
     isGlobbingEnabled: boolean
     accessToken: string | null
-    onPreviewChange: (match: SearchMatch, lineMatchIndexOrSymbolIndex?: number) => Promise<void>
+    onPreviewChange: (match: SearchMatch, lineOrSymbolMatchIndex?: number) => Promise<void>
     onPreviewClear: () => Promise<void>
-    onOpen: (match: SearchMatch, lineMatchIndexOrSymbolIndex?: number) => Promise<void>
+    onOpen: (match: SearchMatch, lineOrSymbolMatchIndex?: number) => Promise<void>
     initialSearch: Search | null
     initialAuthenticatedUser: AuthenticatedUser | null
 }

--- a/client/jetbrains/webview/src/search/js-to-java-bridge.ts
+++ b/client/jetbrains/webview/src/search/js-to-java-bridge.ts
@@ -100,9 +100,9 @@ export async function indicateFinishedLoading(): Promise<void> {
     }
 }
 
-export async function onPreviewChange(match: SearchMatch, lineMatchIndexOrSymbolIndex?: number): Promise<void> {
+export async function onPreviewChange(match: SearchMatch, lineOrSymbolMatchIndex?: number): Promise<void> {
     try {
-        await callJava({ action: 'preview', arguments: await createPreviewContent(match, lineMatchIndexOrSymbolIndex) })
+        await callJava({ action: 'preview', arguments: await createPreviewContent(match, lineOrSymbolMatchIndex) })
     } catch (error) {
         console.error(`Failed to preview match: ${(error as Error).message}`)
     }
@@ -116,9 +116,9 @@ export async function onPreviewClear(): Promise<void> {
     }
 }
 
-export async function onOpen(match: SearchMatch, lineMatchIndexOrSymbolIndex?: number): Promise<void> {
+export async function onOpen(match: SearchMatch, lineOrSymbolMatchIndex?: number): Promise<void> {
     try {
-        await callJava({ action: 'open', arguments: await createPreviewContent(match, lineMatchIndexOrSymbolIndex) })
+        await callJava({ action: 'open', arguments: await createPreviewContent(match, lineOrSymbolMatchIndex) })
     } catch (error) {
         console.error(`Failed to open match: ${(error as Error).message}`)
     }
@@ -149,7 +149,7 @@ async function callJava(request: Request): Promise<object> {
 
 export async function createPreviewContent(
     match: SearchMatch,
-    lineMatchIndexOrSymbolIndex: number | undefined
+    lineOrSymbolMatchIndex: number | undefined
 ): Promise<PreviewContent> {
     if (match.type === 'commit') {
         const content = prepareContent(
@@ -168,7 +168,7 @@ export async function createPreviewContent(
     }
 
     if (match.type === 'content') {
-        return createPreviewContentForContentMatch(match, lineMatchIndexOrSymbolIndex as number)
+        return createPreviewContentForContentMatch(match, lineOrSymbolMatchIndex as number)
     }
 
     if (match.type === 'path') {
@@ -187,7 +187,7 @@ export async function createPreviewContent(
     }
 
     if (match.type === 'symbol') {
-        return createPreviewContentForSymbolMatch(match)
+        return createPreviewContentForSymbolMatch(match, lineOrSymbolMatchIndex as number)
     }
 
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -240,16 +240,22 @@ async function createPreviewContentForPathMatch(match: PathMatch): Promise<Previ
     }
 }
 
-async function createPreviewContentForSymbolMatch(match: SymbolMatch): Promise<PreviewContent> {
+async function createPreviewContentForSymbolMatch(
+    match: SymbolMatch,
+    sybolMatchIndex: number
+): Promise<PreviewContent> {
     const fileName = splitPath(match.path)[1]
     const content = await loadContent(match)
+    const symbolMatch = match.symbols[sybolMatchIndex]
+
+    console.log(symbolMatch)
 
     return {
         fileName,
         path: match.path,
         content: prepareContent(content),
-        lineNumber: -1,
-        absoluteOffsetAndLengths: [],
+        lineNumber: getLineFromSourcegraphUrl(symbolMatch.url),
+        absoluteOffsetAndLengths: getAbsoluteOffsetAndLengthsFromSourcegraphUrl(symbolMatch.url, content),
         relativeUrl: '',
     }
 }
@@ -284,4 +290,51 @@ function getCharacterCountUntilLine(content: string | null, lineNumber: number):
 
 function getAbsoluteOffsetAndLengths(offsetAndLengths: number[][], characterCountUntilLine: number): number[][] {
     return offsetAndLengths.map(offsetAndLength => [offsetAndLength[0] + characterCountUntilLine, offsetAndLength[1]])
+}
+
+function getLineFromSourcegraphUrl(url: string): number {
+    const offsets = extractStartAndEndOffsetsFromSourcegraphUrl(url)
+    if (offsets === null) {
+        return -1
+    }
+    return offsets.start.line
+}
+
+function getAbsoluteOffsetAndLengthsFromSourcegraphUrl(url: string, content: string | null): number[][] {
+    const offsets = extractStartAndEndOffsetsFromSourcegraphUrl(url)
+    if (offsets === null) {
+        return []
+    }
+    const absoluteStart = getCharacterCountUntilLine(content, offsets.start.line) + offsets.start.col
+    const absoluteEnd = getCharacterCountUntilLine(content, offsets.end.line) + offsets.end.col
+    return [[absoluteStart, absoluteEnd - absoluteStart]]
+}
+
+// Parses a Sourcegraph URL and extracts the offsets from it. E.g.:
+//
+//     /github.com/apache/kafka/-/blob/streams/src/main/j…ls/graph/SourceGraphNode.java?L28:23-28:38
+//
+// Will be parsed into:
+//
+//    {
+//      start: {
+//        line: 28,
+//        column: 23
+//      },
+//      end: {
+//         line: 28,
+//         column: 38
+//       }
+//    }
+function extractStartAndEndOffsetsFromSourcegraphUrl(
+    url: string
+): null | { start: { line: number; col: number }; end: { line: number; col: number } } {
+    const match = url.match(/L(\d+):(\d+)-(\d+):(\d+)$/)
+    if (match === null) {
+        return null
+    }
+    return {
+        start: { line: parseInt(match[1], 10) - 1, col: parseInt(match[2], 10) - 1 },
+        end: { line: parseInt(match[3], 10) - 1, col: parseInt(match[4], 10) - 1 },
+    }
 }

--- a/client/jetbrains/webview/src/search/results/FileSearchResult.tsx
+++ b/client/jetbrains/webview/src/search/results/FileSearchResult.tsx
@@ -23,7 +23,7 @@ interface Props {
     match: ContentMatch | SymbolMatch
 }
 
-function getResultElementsForContentMatch(
+function renderResultElementsForContentMatch(
     match: ContentMatch,
     selectResult: (resultId: string) => void,
     selectedResult: string | null
@@ -31,7 +31,7 @@ function getResultElementsForContentMatch(
     return match.lineMatches.map(line => (
         <SelectableSearchResult
             key={getResultId(match, line)}
-            lineMatchOrSymbolName={line}
+            lineOrSymbolMatch={line}
             match={match}
             selectedResult={selectedResult}
             selectResult={selectResult}
@@ -45,15 +45,15 @@ function getResultElementsForContentMatch(
     ))
 }
 
-function getResultElementsForSymbolMatch(
+function renderResultElementsForSymbolMatch(
     match: SymbolMatch,
     selectResult: (resultId: string) => void,
     selectedResult: string | null
 ): JSX.Element[] {
     return match.symbols.map(symbol => (
         <SelectableSearchResult
-            key={getResultId(match, symbol.name)}
-            lineMatchOrSymbolName={symbol.name}
+            key={getResultId(match, symbol)}
+            lineOrSymbolMatch={symbol}
             match={match}
             selectedResult={selectedResult}
             selectResult={selectResult}
@@ -71,8 +71,8 @@ function getResultElementsForSymbolMatch(
 export const FileSearchResult: React.FunctionComponent<Props> = ({ match, selectedResult, selectResult }: Props) => {
     const lines =
         match.type === 'content'
-            ? getResultElementsForContentMatch(match, selectResult, selectedResult)
-            : getResultElementsForSymbolMatch(match, selectResult, selectedResult)
+            ? renderResultElementsForContentMatch(match, selectResult, selectedResult)
+            : renderResultElementsForSymbolMatch(match, selectResult, selectedResult)
 
     const formattedRepositoryStarCount = formatRepositoryStarCount(match.repoStars)
 

--- a/client/jetbrains/webview/src/search/results/SearchResultList.tsx
+++ b/client/jetbrains/webview/src/search/results/SearchResultList.tsx
@@ -8,7 +8,7 @@ import { PathSearchResult } from './PathSearchResult'
 import { RepoSearchResult } from './RepoSearchResult'
 import {
     getFirstResultId,
-    getLineMatchIndexOrSymbolIndexForFileResult,
+    getLineOrSymbolMatchIndexForFileResult,
     getMatchId,
     getMatchIdForResult,
     getSearchResultElement,
@@ -18,9 +18,9 @@ import {
 import styles from './SearchResultList.module.scss'
 
 interface Props {
-    onPreviewChange: (match: SearchMatch, lineMatchIndexOrSymbolIndex?: number) => Promise<void>
+    onPreviewChange: (match: SearchMatch, lineOrSymbolMatchIndex?: number) => Promise<void>
     onPreviewClear: () => Promise<void>
-    onOpen: (match: SearchMatch, lineMatchIndexOrSymbolIndex?: number) => Promise<void>
+    onOpen: (match: SearchMatch, lineOrSymbolMatchIndex?: number) => Promise<void>
     matches: SearchMatch[]
 }
 
@@ -53,7 +53,7 @@ export const SearchResultList: React.FunctionComponent<Props> = ({
                     onPreviewChange(
                         match,
                         match.type === 'content' || match.type === 'symbol'
-                            ? getLineMatchIndexOrSymbolIndexForFileResult(resultId)
+                            ? getLineOrSymbolMatchIndexForFileResult(resultId)
                             : undefined
                     )
                         .then(() => {})
@@ -111,7 +111,7 @@ export const SearchResultList: React.FunctionComponent<Props> = ({
                     onOpen(
                         match,
                         match.type === 'content' || match.type === 'symbol'
-                            ? getLineMatchIndexOrSymbolIndexForFileResult(selectedResultId)
+                            ? getLineOrSymbolMatchIndexForFileResult(selectedResultId)
                             : undefined
                     )
                         .then(() => {})

--- a/client/jetbrains/webview/src/search/results/SelectableSearchResult.tsx
+++ b/client/jetbrains/webview/src/search/results/SelectableSearchResult.tsx
@@ -1,14 +1,14 @@
 import React, { useCallback } from 'react'
 
-import { ContentMatch, SearchMatch } from '@sourcegraph/shared/src/search/stream'
+import { SearchMatch } from '@sourcegraph/shared/src/search/stream'
 
-import { getResultId } from './utils'
+import { getResultId, LineMatchItem, SymbolMatchItem } from './utils'
 
 import styles from './SelectableSearchResult.module.scss'
 
 interface Props {
     children: (isActive: boolean) => React.ReactNode
-    lineMatchOrSymbolName?: ContentMatch['lineMatches'][0] | string
+    lineOrSymbolMatch?: LineMatchItem | SymbolMatchItem
     match: SearchMatch
     selectedResult: null | string
     selectResult: (id: string) => void
@@ -16,12 +16,12 @@ interface Props {
 
 export const SelectableSearchResult: React.FunctionComponent<Props> = ({
     children,
-    lineMatchOrSymbolName,
+    lineOrSymbolMatch,
     match,
     selectedResult,
     selectResult,
 }: Props) => {
-    const resultId = getResultId(match, lineMatchOrSymbolName)
+    const resultId = getResultId(match, lineOrSymbolMatch)
     const onClick = useCallback((): void => selectResult(resultId), [selectResult, resultId])
     const isActive = resultId === selectedResult
 


### PR DESCRIPTION
Fixes #36797
Part-of #36222

This PR attempts to do two things:

1. We currently use the symbol name to identify a symbol within a `SymbolMatch`.  The problem with this is that a file can define multiple symbols with the same name. This currently breaks navigation since we won't be able to find the next sibling if multiple elements have the same names resulting in a loop. To fix this, we apply the same fix that we also use for line matches. Instead of using the symbol name, we use the offset inside the `symbol` array.  
2. For symbols we did not have offsets for search highlight displays before. The data we have comes with a URL though that has the offset encoded (e.g. `'/github.com/gitlabhq/gitlabhq/-/blob/app/controllers/concerns/sourcegraph_decorator.rb?L29:7-29:27`). I've added code to parse this offset information and properly forward it to the JS->Java bridge. Works like a charm 🙂 

## Test plan

Manual testing:

https://user-images.githubusercontent.com/458591/173071065-ad8a13a6-944b-44fd-83e9-3893fa53c292.mov



<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-jetbrains-symbol-offsets.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-heuvwadzun.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
