### PR TITLE
search: Fix empty search context hover tooltip

### DIFF
--- a/client/wildcard/src/components/Tooltip/Tooltip.tsx
+++ b/client/wildcard/src/components/Tooltip/Tooltip.tsx
@@ -2,6 +2,7 @@ import React, { ReactNode } from 'react'
 
 import * as TooltipPrimitive from '@radix-ui/react-tooltip'
 import classNames from 'classnames'
+import { isEmpty } from 'lodash'
 
 import styles from './Tooltip.module.scss'
 
@@ -69,7 +70,7 @@ export const Tooltip: React.FunctionComponent<TooltipProps> = ({
 
                 {
                     // The rest of the Tooltip components still need to be rendered for the content to correctly be shown conditionally.
-                    content === null ? null : (
+                    isEmpty(content) ? null : (
                         /*
                          * Rendering the Content within the Trigger is a workaround to support being able to hover over the Tooltip content itself.
                          * Refrence: https://github.com/radix-ui/primitives/issues/620#issuecomment-1079147761


### PR DESCRIPTION
This is a quick fix for an empty tooltip currently rendered for the search context dropdown:

<img width="211" alt="2022-06-10_13-14" src="https://user-images.githubusercontent.com/179026/173072396-75656ad0-e89b-4e10-b0bc-246326ab80d3.png">

This came to happen because #36931 depended on #36870, but that got reverted in #36971.


## Test plan

Hovering over search context doesn't render tooltip.

## App preview:

- [Web](https://sg-web-fkling-search-context-tooltip.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-jgegbayfyy.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
