### PR TITLE
Fix "verify email" alert AB test to show only on dotcom

### DIFF
--- a/client/web/src/Layout.tsx
+++ b/client/web/src/Layout.tsx
@@ -210,7 +210,11 @@ export const Layout: React.FunctionComponent<React.PropsWithChildren<LayoutProps
                 keyboardShortcutForShow={KEYBOARD_SHORTCUT_SHOW_HELP}
                 keyboardShortcuts={props.keyboardShortcuts}
             />
-            <GlobalAlerts authenticatedUser={props.authenticatedUser} settingsCascade={props.settingsCascade} />
+            <GlobalAlerts
+                authenticatedUser={props.authenticatedUser}
+                settingsCascade={props.settingsCascade}
+                isSourcegraphDotCom={props.isSourcegraphDotCom}
+            />
             {!isSiteInit && <SurveyToast />}
             {!isSiteInit && !isSignInOrUp && (
                 <GlobalNavbar

--- a/client/web/src/global/GlobalAlerts.tsx
+++ b/client/web/src/global/GlobalAlerts.tsx
@@ -44,7 +44,7 @@ export const GlobalAlerts: React.FunctionComponent<Props> = ({
             return
         }
         return {
-            emails: authenticatedUser?.emails.filter(({ verified }) => !verified).map(({ email }) => email),
+            emails: authenticatedUser.emails.filter(({ verified }) => !verified).map(({ email }) => email),
             settingsURL: authenticatedUser.settingsURL as string,
         }
     }, [authenticatedUser, isSourcegraphDotCom])

--- a/client/web/src/global/GlobalAlerts.tsx
+++ b/client/web/src/global/GlobalAlerts.tsx
@@ -1,19 +1,17 @@
-import * as React from 'react'
+import React, { useMemo } from 'react'
 
 import classNames from 'classnames'
 import { parseISO } from 'date-fns'
 import differenceInDays from 'date-fns/differenceInDays'
-import { Subscription } from 'rxjs'
 
 import { renderMarkdown } from '@sourcegraph/common'
 import { Markdown } from '@sourcegraph/shared/src/components/Markdown'
 import { Settings } from '@sourcegraph/shared/src/schema/settings.schema'
 import { isSettingsValid, SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
-import { Link } from '@sourcegraph/wildcard'
+import { Link, useObservable } from '@sourcegraph/wildcard'
 
 import { AuthenticatedUser } from '../auth'
 import { DismissibleAlert } from '../components/DismissibleAlert'
-import { SiteFlags } from '../site'
 import { siteFlags } from '../site/backend'
 import { CodeHostScopeAlerts, GitLabScopeAlert } from '../site/CodeHostScopeAlerts/CodeHostScopeAlerts'
 import { DockerForMacAlert } from '../site/DockerForMacAlert'
@@ -28,109 +26,100 @@ import styles from './GlobalAlerts.module.scss'
 
 interface Props extends SettingsCascadeProps {
     authenticatedUser: AuthenticatedUser | null
-}
-
-interface State {
-    siteFlags?: SiteFlags
+    isSourcegraphDotCom: boolean
 }
 
 /**
  * Fetches and displays relevant global alerts at the top of the page
  */
-export class GlobalAlerts extends React.PureComponent<Props, State> {
-    public state: State = {}
+export const GlobalAlerts: React.FunctionComponent<Props> = ({
+    authenticatedUser,
+    settingsCascade,
+    isSourcegraphDotCom,
+}) => {
+    const siteFlagsValue = useObservable(siteFlags)
 
-    private subscriptions = new Subscription()
-
-    public componentDidMount(): void {
-        this.subscriptions.add(siteFlags.subscribe(siteFlags => this.setState({ siteFlags })))
-    }
-
-    public componentWillUnmount(): void {
-        this.subscriptions.unsubscribe()
-    }
-
-    public render(): JSX.Element | null {
-        return (
-            <div className={classNames('test-global-alert', styles.globalAlerts)}>
-                {this.state.siteFlags && (
-                    <>
-                        {this.state.siteFlags.needsRepositoryConfiguration && (
-                            <NeedsRepositoryConfigurationAlert className={styles.alert} />
-                        )}
-                        {this.state.siteFlags.freeUsersExceeded && (
-                            <FreeUsersExceededAlert
-                                noLicenseWarningUserCount={
-                                    this.state.siteFlags.productSubscription.noLicenseWarningUserCount
-                                }
-                                className={styles.alert}
-                            />
-                        )}
-                        {/* Only show if the user has already added repositories; if not yet, the user wouldn't experience any Docker for Mac perf issues anyway. */}
-                        {window.context.likelyDockerOnMac && window.context.deployType === 'docker-container' && (
-                            <DockerForMacAlert className={styles.alert} />
-                        )}
-                        {window.context.sourcegraphDotComMode && (
-                            <CodeHostScopeAlerts authenticatedUser={this.props.authenticatedUser} />
-                        )}
-                        {window.context.sourcegraphDotComMode && (
-                            <GitLabScopeAlert authenticatedUser={this.props.authenticatedUser} />
-                        )}
-                        {this.state.siteFlags.alerts.map((alert, index) => (
-                            <GlobalAlert key={index} alert={alert} className={styles.alert} />
-                        ))}
-                        {this.state.siteFlags.productSubscription.license &&
-                            (() => {
-                                const expiresAt = parseISO(this.state.siteFlags.productSubscription.license.expiresAt)
-                                return (
-                                    differenceInDays(expiresAt, Date.now()) <= 7 && (
-                                        <LicenseExpirationAlert
-                                            expiresAt={expiresAt}
-                                            daysLeft={Math.floor(differenceInDays(expiresAt, Date.now()))}
-                                            className={styles.alert}
-                                        />
-                                    )
-                                )
-                            })()}
-                    </>
-                )}
-                {isSettingsValid<Settings>(this.props.settingsCascade) &&
-                    this.props.settingsCascade.final.motd &&
-                    Array.isArray(this.props.settingsCascade.final.motd) &&
-                    this.props.settingsCascade.final.motd.map(motd => (
-                        <DismissibleAlert
-                            key={motd}
-                            partialStorageKey={`motd.${motd}`}
-                            variant="info"
+    const verifyEmailProps = useMemo(() => {
+        if (!authenticatedUser || !isSourcegraphDotCom) {
+            return
+        }
+        return {
+            emails: authenticatedUser?.emails.filter(({ verified }) => !verified).map(({ email }) => email),
+            settingsURL: authenticatedUser.settingsURL as string,
+        }
+    }, [authenticatedUser, isSourcegraphDotCom])
+    return (
+        <div className={classNames('test-global-alert', styles.globalAlerts)}>
+            {siteFlagsValue && (
+                <>
+                    {siteFlagsValue.needsRepositoryConfiguration && (
+                        <NeedsRepositoryConfigurationAlert className={styles.alert} />
+                    )}
+                    {siteFlagsValue.freeUsersExceeded && (
+                        <FreeUsersExceededAlert
+                            noLicenseWarningUserCount={siteFlagsValue.productSubscription.noLicenseWarningUserCount}
                             className={styles.alert}
-                        >
-                            <Markdown dangerousInnerHTML={renderMarkdown(motd)} />
-                        </DismissibleAlert>
+                        />
+                    )}
+                    {/* Only show if the user has already added repositories; if not yet, the user wouldn't experience any Docker for Mac perf issues anyway. */}
+                    {window.context.likelyDockerOnMac && window.context.deployType === 'docker-container' && (
+                        <DockerForMacAlert className={styles.alert} />
+                    )}
+                    {window.context.sourcegraphDotComMode && (
+                        <CodeHostScopeAlerts authenticatedUser={authenticatedUser} />
+                    )}
+                    {window.context.sourcegraphDotComMode && <GitLabScopeAlert authenticatedUser={authenticatedUser} />}
+                    {siteFlagsValue.alerts.map((alert, index) => (
+                        <GlobalAlert key={index} alert={alert} className={styles.alert} />
                     ))}
-                {process.env.SOURCEGRAPH_API_URL && (
+                    {siteFlagsValue.productSubscription.license &&
+                        (() => {
+                            const expiresAt = parseISO(siteFlagsValue.productSubscription.license.expiresAt)
+                            return (
+                                differenceInDays(expiresAt, Date.now()) <= 7 && (
+                                    <LicenseExpirationAlert
+                                        expiresAt={expiresAt}
+                                        daysLeft={Math.floor(differenceInDays(expiresAt, Date.now()))}
+                                        className={styles.alert}
+                                    />
+                                )
+                            )
+                        })()}
+                </>
+            )}
+            {isSettingsValid<Settings>(settingsCascade) &&
+                settingsCascade.final.motd &&
+                Array.isArray(settingsCascade.final.motd) &&
+                settingsCascade.final.motd.map(motd => (
                     <DismissibleAlert
-                        key="dev-web-server-alert"
-                        partialStorageKey="dev-web-server-alert"
-                        variant="danger"
+                        key={motd}
+                        partialStorageKey={`motd.${motd}`}
+                        variant="info"
                         className={styles.alert}
                     >
-                        <div>
-                            <strong>Warning!</strong> This build uses data from the proxied API:{' '}
-                            <Link target="__blank" to={process.env.SOURCEGRAPH_API_URL}>
-                                {process.env.SOURCEGRAPH_API_URL}
-                            </Link>
-                        </div>
-                        .
+                        <Markdown dangerousInnerHTML={renderMarkdown(motd)} />
                     </DismissibleAlert>
-                )}
-                <Notices alertClassName={styles.alert} location="top" settingsCascade={this.props.settingsCascade} />
-                {this.props.authenticatedUser && (
-                    <VerifyEmailNotices
-                        alertClassName={styles.alert}
-                        authenticatedUser={this.props.authenticatedUser}
-                    />
-                )}
-            </div>
-        )
-    }
+                ))}
+            {process.env.SOURCEGRAPH_API_URL && (
+                <DismissibleAlert
+                    key="dev-web-server-alert"
+                    partialStorageKey="dev-web-server-alert"
+                    variant="danger"
+                    className={styles.alert}
+                >
+                    <div>
+                        <strong>Warning!</strong> This build uses data from the proxied API:{' '}
+                        <Link target="__blank" to={process.env.SOURCEGRAPH_API_URL}>
+                            {process.env.SOURCEGRAPH_API_URL}
+                        </Link>
+                    </div>
+                    .
+                </DismissibleAlert>
+            )}
+            <Notices alertClassName={styles.alert} location="top" settingsCascade={settingsCascade} />
+            {!!verifyEmailProps?.emails.length && (
+                <VerifyEmailNotices alertClassName={styles.alert} {...verifyEmailProps} />
+            )}
+        </div>
+    )
 }

--- a/client/web/src/global/Notices.tsx
+++ b/client/web/src/global/Notices.tsx
@@ -8,7 +8,6 @@ import { Notice, Settings } from '@sourcegraph/shared/src/schema/settings.schema
 import { isSettingsValid, SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
 import { Alert, AlertProps } from '@sourcegraph/wildcard'
 
-import { AuthenticatedUser } from '../auth'
 import { DismissibleAlert } from '../components/DismissibleAlert'
 import { useFeatureFlag } from '../featureFlags/useFeatureFlag'
 
@@ -90,7 +89,8 @@ interface VerifyEmailNoticesProps {
     className?: string
     /** Apply this class name to each notice (alongside .alert). */
     alertClassName?: string
-    authenticatedUser: AuthenticatedUser
+    emails: string[]
+    settingsURL: string
 }
 
 /**
@@ -99,7 +99,8 @@ interface VerifyEmailNoticesProps {
 export const VerifyEmailNotices: React.FunctionComponent<VerifyEmailNoticesProps> = ({
     className,
     alertClassName,
-    authenticatedUser,
+    emails,
+    settingsURL,
 }) => {
     const [isEmailVerificationAlertEnabled, status] = useFeatureFlag('ab-email-verification-alert')
 
@@ -107,18 +108,16 @@ export const VerifyEmailNotices: React.FunctionComponent<VerifyEmailNoticesProps
         if (status !== 'loaded' || !isEmailVerificationAlertEnabled) {
             return []
         }
-        return authenticatedUser.emails
-            .filter(({ verified }) => !verified)
-            .map(
-                ({ email }): Notice => ({
-                    message: `Please, <a href="${
-                        authenticatedUser?.settingsURL as string
-                    }/emails">verify your email</a> <strong>${(email as string).split('@').join('\\@')}</strong>.`,
-                    location: 'top',
-                    dismissible: false,
-                })
-            ) as Notice[]
-    }, [authenticatedUser, isEmailVerificationAlertEnabled, status])
+        return emails.map(
+            (email): Notice => ({
+                message: `Please, <a href="${settingsURL}/emails">verify your email</a> <strong>${email
+                    .split('@')
+                    .join('\\@')}</strong>`,
+                location: 'top',
+                dismissible: false,
+            })
+        )
+    }, [emails, isEmailVerificationAlertEnabled, settingsURL, status])
 
     if (notices.length === 0) {
         return null


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/34603. Follow-up https://github.com/sourcegraph/sourcegraph/pull/34605.

## Description

This PR:
- Fixes the "verify email" alert AB test to show only on dotcom mode
- Converts `GlobalAlerts` to function component

## Test plan
- connect locally to Postgres and update `user_emails.verified_at` to `NULL` to your current local user
- `sg start dotcom`
- Open https://sourcegraph.test:3443/search?feature-flag-key=ab-email-verification-alert&feature-flag-value=true
- Check that verify email alert shows on top of navbar
- re-run in another mode (ex: `sg start enterprise`) and make sure the alert doesn't show up
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-erzhtor-fix-verify-email-ab-test.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-rmroutwiyu.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

