### PR TITLE
JetBrains: Show repo description for repo results

### DIFF
--- a/client/jetbrains/webview/src/search/results/RepoSearchResult.tsx
+++ b/client/jetbrains/webview/src/search/results/RepoSearchResult.tsx
@@ -36,7 +36,7 @@ export const RepoSearchResult: React.FunctionComponent<RepoSearchResultProps> = 
                     }
                     isActive={isActive}
                 >
-                    <RepoName repoName={match.repository} />
+                    <RepoName repoName={match.repository} suffix={match.description} />
                 </SearchResultLayout>
             )}
         </SelectableSearchResult>


### PR DESCRIPTION
This is a minor improvement to repo search results. I noticed that we have the GitHub repo description (mostly a few words) that we could also show inline.

Note that the padding between the star number and the repo description is bigger than expected in this screen. This is because all other search result types show additional data on the right and we need a unified min width for this column. Repo results can also appear together with other results in a row so this makes sense IMO.

## Test plan

![Screenshot 2022-06-10 at 15 59 14](https://user-images.githubusercontent.com/458591/173082299-0284bf72-2d96-496e-9925-e08afe97a23b.png)


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
