### PR TITLE
executor: Add mount path prefix

### DIFF
--- a/enterprise/cmd/executor/config.go
+++ b/enterprise/cmd/executor/config.go
@@ -30,6 +30,7 @@ type Config struct {
 	JobNumCPUs                 int
 	JobMemory                  string
 	FirecrackerDiskSpace       string
+	MountPathPrefix            string
 	MaximumRuntimePerJob       time.Duration
 	CleanupTaskInterval        time.Duration
 	NumTotalJobs               int
@@ -50,6 +51,7 @@ func (c *Config) Load() {
 	c.JobNumCPUs = c.GetInt(env.ChooseFallbackVariableName("EXECUTOR_JOB_NUM_CPUS", "EXECUTOR_FIRECRACKER_NUM_CPUS"), "4", "How many CPUs to allocate to each virtual machine or container. A value of zero sets no resource bound (in Docker, but not VMs).")
 	c.JobMemory = c.Get(env.ChooseFallbackVariableName("EXECUTOR_JOB_MEMORY", "EXECUTOR_FIRECRACKER_MEMORY"), "12G", "How much memory to allocate to each virtual machine or container. A value of zero sets no resource bound (in Docker, but not VMs).")
 	c.FirecrackerDiskSpace = c.Get("EXECUTOR_FIRECRACKER_DISK_SPACE", "20G", "How much disk space to allocate to each virtual machine.")
+	c.MountPathPrefix = c.Get("EXECUTOR_MOUNT_PATH_PREFIX", "", "A host-side path prefix used in Docker volume mounts.")
 	c.MaximumRuntimePerJob = c.GetInterval("EXECUTOR_MAXIMUM_RUNTIME_PER_JOB", "30m", "The maximum wall time that can be spent on a single job.")
 	c.CleanupTaskInterval = c.GetInterval("EXECUTOR_CLEANUP_TASK_INTERVAL", "1m", "The frequency with which to run periodic cleanup tasks.")
 	c.NumTotalJobs = c.GetInt("EXECUTOR_NUM_TOTAL_JOBS", "0", "The maximum number of jobs that will be dequeued by the worker.")
@@ -110,9 +112,10 @@ func (c *Config) FirecrackerOptions() command.FirecrackerOptions {
 
 func (c *Config) ResourceOptions() command.ResourceOptions {
 	return command.ResourceOptions{
-		NumCPUs:   c.JobNumCPUs,
-		Memory:    c.JobMemory,
-		DiskSpace: c.FirecrackerDiskSpace,
+		NumCPUs:         c.JobNumCPUs,
+		Memory:          c.JobMemory,
+		DiskSpace:       c.FirecrackerDiskSpace,
+		MountPathPrefix: c.MountPathPrefix,
 	}
 }
 

--- a/enterprise/cmd/executor/internal/command/docker.go
+++ b/enterprise/cmd/executor/internal/command/docker.go
@@ -31,7 +31,7 @@ func formatRawOrDockerCommand(spec CommandSpec, dir string, options Options) com
 		Command: flatten(
 			"docker", "run", "--rm",
 			dockerResourceFlags(options.ResourceOptions),
-			dockerVolumeFlags(dir),
+			dockerVolumeFlags(filepath.Join(options.ResourceOptions.MountPathPrefix, dir)),
 			dockerWorkingdirectoryFlags(spec.Dir),
 			// If the env vars will be part of the command line args, we need to quote them
 			dockerEnvFlags(quoteEnv(spec.Env)),

--- a/enterprise/cmd/executor/internal/command/runner.go
+++ b/enterprise/cmd/executor/internal/command/runner.go
@@ -67,6 +67,11 @@ type ResourceOptions struct {
 
 	// DiskSpace is the maximum amount of disk a container or VM can use.
 	DiskSpace string
+
+	// MountPathPrefix is attached to the left-hand side of volume mounts for Docker containers.
+	// This option is used when running privilegled executors in k8s using docker-desktop.
+	// Because there's a mismatch between host and VM paths, we need to add a small shim here.
+	MountPathPrefix string
 }
 
 // NewRunner creates a new runner with the given options.


### PR DESCRIPTION
Docker-desktop does not mount host paths directly in root. This gives us a shim to be able to align MacOS/k8s node/raw container shared mounts.

## Test plan

Will test locally on k8s cluster using docker-desktop.