### PR TITLE
npm: Bump rate limit.

### DIFF
--- a/internal/extsvc/types.go
+++ b/internal/extsvc/types.go
@@ -497,7 +497,7 @@ func GetLimitFromConfig(kind string, config any) (rate.Limit, error) {
 			limit = limitOrInf(c.RateLimit.Enabled, c.RateLimit.RequestsPerHour)
 		}
 	case *schema.NpmPackagesConnection:
-		limit = rate.Limit(3000 / 3600.0) // Same as the default in npm-packages.schema.json
+		limit = rate.Limit(6000 / 3600.0) // Same as the default in npm-packages.schema.json
 		if c != nil && c.RateLimit != nil {
 			limit = limitOrInf(c.RateLimit.Enabled, c.RateLimit.RequestsPerHour)
 		}

--- a/schema/npm-packages.schema.json
+++ b/schema/npm-packages.schema.json
@@ -34,13 +34,13 @@
         "requestsPerHour": {
           "description": "Requests per hour permitted. This is an average, calculated per second. Internally, the burst limit is set to 100, which implies that for a requests per hour limit as low as 1, users will continue to be able to send a maximum of 100 requests immediately, provided that the complexity cost of each request is 1.",
           "type": "number",
-          "default": 3000,
+          "default": 6000,
           "minimum": 0
         }
       },
       "default": {
         "enabled": true,
-        "requestsPerHour": 3000
+        "requestsPerHour": 6000
       }
     },
     "dependencies": {


### PR DESCRIPTION
It is still under 7k/hour, which is the NPM fair use limit.
See https://docs.npmjs.com/policies/open-source-terms#acceptable-use

## Test plan

n/a