### PR TITLE
ssbc: Fix slow cascading deletes

### DIFF
--- a/enterprise/internal/batches/service/service.go
+++ b/enterprise/internal/batches/service/service.go
@@ -628,6 +628,7 @@ func replaceBatchSpec(ctx context.Context, tx *store.Store, oldSpec, newSpec *bt
 	// Delete the previous batch spec, which should delete
 	// - batch_spec_resolution_jobs
 	// - batch_spec_workspaces
+	// - batch_spec_workspace_execution_jobs
 	// - changeset_specs
 	// associated with it
 	if err := tx.DeleteBatchSpec(ctx, oldSpec.ID); err != nil {

--- a/internal/database/schema.json
+++ b/internal/database/schema.json
@@ -2010,6 +2010,16 @@
           "ConstraintDefinition": "PRIMARY KEY (id)"
         },
         {
+          "Name": "batch_spec_workspace_execution_jobs_batch_spec_workspace_id",
+          "IsPrimaryKey": false,
+          "IsUnique": false,
+          "IsExclusion": false,
+          "IsDeferrable": false,
+          "IndexDefinition": "CREATE INDEX batch_spec_workspace_execution_jobs_batch_spec_workspace_id ON batch_spec_workspace_execution_jobs USING btree (batch_spec_workspace_id)",
+          "ConstraintType": "",
+          "ConstraintDefinition": ""
+        },
+        {
           "Name": "batch_spec_workspace_execution_jobs_cancel",
           "IsPrimaryKey": false,
           "IsUnique": false,
@@ -2281,6 +2291,16 @@
           "IndexDefinition": "CREATE UNIQUE INDEX batch_spec_workspaces_pkey ON batch_spec_workspaces USING btree (id)",
           "ConstraintType": "p",
           "ConstraintDefinition": "PRIMARY KEY (id)"
+        },
+        {
+          "Name": "batch_spec_workspaces_batch_spec_id",
+          "IsPrimaryKey": false,
+          "IsUnique": false,
+          "IsExclusion": false,
+          "IsDeferrable": false,
+          "IndexDefinition": "CREATE INDEX batch_spec_workspaces_batch_spec_id ON batch_spec_workspaces USING btree (batch_spec_id)",
+          "ConstraintType": "",
+          "ConstraintDefinition": ""
         }
       ],
       "Constraints": [
@@ -3204,6 +3224,16 @@
           "IndexDefinition": "CREATE UNIQUE INDEX changeset_specs_pkey ON changeset_specs USING btree (id)",
           "ConstraintType": "p",
           "ConstraintDefinition": "PRIMARY KEY (id)"
+        },
+        {
+          "Name": "changeset_specs_batch_spec_id",
+          "IsPrimaryKey": false,
+          "IsUnique": false,
+          "IsExclusion": false,
+          "IsDeferrable": false,
+          "IndexDefinition": "CREATE INDEX changeset_specs_batch_spec_id ON changeset_specs USING btree (batch_spec_id)",
+          "ConstraintType": "",
+          "ConstraintDefinition": ""
         },
         {
           "Name": "changeset_specs_external_id",

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -153,6 +153,7 @@ Foreign-key constraints:
  user_id                 | integer                  |           |          | 
 Indexes:
     "batch_spec_workspace_execution_jobs_pkey" PRIMARY KEY, btree (id)
+    "batch_spec_workspace_execution_jobs_batch_spec_workspace_id" btree (batch_spec_workspace_id)
     "batch_spec_workspace_execution_jobs_cancel" btree (cancel)
     "batch_spec_workspace_execution_jobs_state" btree (state)
     "batch_spec_workspace_execution_jobs_user_id" btree (user_id)
@@ -184,6 +185,7 @@ Foreign-key constraints:
  step_cache_results   | jsonb                    |           | not null | '{}'::jsonb
 Indexes:
     "batch_spec_workspaces_pkey" PRIMARY KEY, btree (id)
+    "batch_spec_workspaces_batch_spec_id" btree (batch_spec_id)
 Foreign-key constraints:
     "batch_spec_workspaces_batch_spec_id_fkey" FOREIGN KEY (batch_spec_id) REFERENCES batch_specs(id) ON DELETE CASCADE DEFERRABLE
     "batch_spec_workspaces_repo_id_fkey" FOREIGN KEY (repo_id) REFERENCES repo(id) DEFERRABLE
@@ -305,6 +307,7 @@ Foreign-key constraints:
  fork_namespace    | citext                   |           |          | 
 Indexes:
     "changeset_specs_pkey" PRIMARY KEY, btree (id)
+    "changeset_specs_batch_spec_id" btree (batch_spec_id)
     "changeset_specs_external_id" btree (external_id)
     "changeset_specs_head_ref" btree (head_ref)
     "changeset_specs_rand_id" btree (rand_id)

--- a/migrations/frontend/1654872407/down.sql
+++ b/migrations/frontend/1654872407/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS changeset_specs_batch_spec_id;

--- a/migrations/frontend/1654872407/metadata.yaml
+++ b/migrations/frontend/1654872407/metadata.yaml
@@ -1,0 +1,3 @@
+name: fast_cascade_delete_batch_specs_1
+parents: [1654848945]
+createIndexConcurrently: true

--- a/migrations/frontend/1654872407/up.sql
+++ b/migrations/frontend/1654872407/up.sql
@@ -1,0 +1,2 @@
+-- Create index for foreign key reverse lookups. This is required for cascading deletes.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS changeset_specs_batch_spec_id ON changeset_specs (batch_spec_id);

--- a/migrations/frontend/1654874148/down.sql
+++ b/migrations/frontend/1654874148/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS batch_spec_workspaces_batch_spec_id;

--- a/migrations/frontend/1654874148/metadata.yaml
+++ b/migrations/frontend/1654874148/metadata.yaml
@@ -1,0 +1,3 @@
+name: fast_cascade_delete_batch_specs_2
+parents: [1654872407]
+createIndexConcurrently: true

--- a/migrations/frontend/1654874148/up.sql
+++ b/migrations/frontend/1654874148/up.sql
@@ -1,0 +1,2 @@
+-- Create index for foreign key reverse lookups. This is required for cascading deletes.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS batch_spec_workspaces_batch_spec_id ON batch_spec_workspaces (batch_spec_id);

--- a/migrations/frontend/1654874153/down.sql
+++ b/migrations/frontend/1654874153/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS batch_spec_workspace_execution_jobs_batch_spec_workspace_id;

--- a/migrations/frontend/1654874153/metadata.yaml
+++ b/migrations/frontend/1654874153/metadata.yaml
@@ -1,0 +1,3 @@
+name: fast_cascade_delete_batch_specs_3
+parents: [1654874148]
+createIndexConcurrently: true

--- a/migrations/frontend/1654874153/up.sql
+++ b/migrations/frontend/1654874153/up.sql
@@ -1,0 +1,2 @@
+-- Create index for foreign key reverse lookups. This is required for cascading deletes.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS batch_spec_workspace_execution_jobs_batch_spec_workspace_id ON batch_spec_workspace_execution_jobs (batch_spec_workspace_id);

--- a/migrations/frontend/squashed.sql
+++ b/migrations/frontend/squashed.sql
@@ -3478,17 +3478,23 @@ CREATE UNIQUE INDEX batch_changes_unique_org_id ON batch_changes USING btree (na
 
 CREATE UNIQUE INDEX batch_changes_unique_user_id ON batch_changes USING btree (name, namespace_user_id) WHERE (namespace_user_id IS NOT NULL);
 
+CREATE INDEX batch_spec_workspace_execution_jobs_batch_spec_workspace_id ON batch_spec_workspace_execution_jobs USING btree (batch_spec_workspace_id);
+
 CREATE INDEX batch_spec_workspace_execution_jobs_cancel ON batch_spec_workspace_execution_jobs USING btree (cancel);
 
 CREATE INDEX batch_spec_workspace_execution_jobs_state ON batch_spec_workspace_execution_jobs USING btree (state);
 
 CREATE INDEX batch_spec_workspace_execution_jobs_user_id ON batch_spec_workspace_execution_jobs USING btree (user_id);
 
+CREATE INDEX batch_spec_workspaces_batch_spec_id ON batch_spec_workspaces USING btree (batch_spec_id);
+
 CREATE INDEX batch_specs_rand_id ON batch_specs USING btree (rand_id);
 
 CREATE INDEX changeset_jobs_bulk_group_idx ON changeset_jobs USING btree (bulk_group);
 
 CREATE INDEX changeset_jobs_state_idx ON changeset_jobs USING btree (state);
+
+CREATE INDEX changeset_specs_batch_spec_id ON changeset_specs USING btree (batch_spec_id);
 
 CREATE INDEX changeset_specs_external_id ON changeset_specs USING btree (external_id);
 


### PR DESCRIPTION
This brings down a delete query on k8s from 625353s to 201ms. Foreign keys don't automatically have a reverse index to look up with.

Closes https://github.com/sourcegraph/sourcegraph/issues/36863

## Test plan

Tested this on k8s where I was seeing the issue.
