### PR TITLE
Update alpine image

### DIFF
--- a/docker-images/alpine-3.14/Dockerfile
+++ b/docker-images/alpine-3.14/Dockerfile
@@ -27,7 +27,7 @@ RUN apk update && apk add --no-cache \
     bind-tools \
     busybox \
     ca-certificates \
-    curl \
+    curl=7.79.1-r1 \
     mailcap \
     tini \
     wget

--- a/docker-images/alpine-3.14/Dockerfile
+++ b/docker-images/alpine-3.14/Dockerfile
@@ -27,7 +27,7 @@ RUN apk update && apk add --no-cache \
     bind-tools \
     busybox \
     ca-certificates \
-    curl=7.79.1-r1 \
+    'curl>=7.79.1-r1' \
     mailcap \
     tini \
     wget
@@ -36,4 +36,4 @@ RUN apk update && apk add --no-cache \
 # Issue: https://github.com/sourcegraph/sourcegraph/issues/32679
 # PR: https://github.com/sourcegraph/sourcegraph/pull/32682
 # @TODO: Remove this with the next release of Alpine
-RUN apk add --upgrade --no-cache libcrypto1.1>=1.1.1n-r0 libssl1.1>=1.1.1n-r0
+RUN apk add --upgrade --no-cache 'libcrypto1.1>=1.1.1n-r0' 'libssl1.1>=1.1.1n-r0'


### PR DESCRIPTION
This pr updates curl and pins the version to deal with CVE-2022-22576. We are not currently affected by the CVE, this is out of good hygiene. 
## Test plan
CI checks
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
