### PR TITLE
executor: Add additional flags to control docker operations

### DIFF
--- a/enterprise/cmd/executor/config.go
+++ b/enterprise/cmd/executor/config.go
@@ -32,7 +32,6 @@ type Config struct {
 	JobNumCPUs                 int
 	JobMemory                  string
 	FirecrackerDiskSpace       string
-	MountPathPrefix            string
 	MaximumRuntimePerJob       time.Duration
 	CleanupTaskInterval        time.Duration
 	NumTotalJobs               int
@@ -55,7 +54,6 @@ func (c *Config) Load() {
 	c.JobNumCPUs = c.GetInt(env.ChooseFallbackVariableName("EXECUTOR_JOB_NUM_CPUS", "EXECUTOR_FIRECRACKER_NUM_CPUS"), "4", "How many CPUs to allocate to each virtual machine or container. A value of zero sets no resource bound (in Docker, but not VMs).")
 	c.JobMemory = c.Get(env.ChooseFallbackVariableName("EXECUTOR_JOB_MEMORY", "EXECUTOR_FIRECRACKER_MEMORY"), "12G", "How much memory to allocate to each virtual machine or container. A value of zero sets no resource bound (in Docker, but not VMs).")
 	c.FirecrackerDiskSpace = c.Get("EXECUTOR_FIRECRACKER_DISK_SPACE", "20G", "How much disk space to allocate to each virtual machine.")
-	c.MountPathPrefix = c.Get("EXECUTOR_MOUNT_PATH_PREFIX", "", "A host-side path prefix used in Docker volume mounts.")
 	c.MaximumRuntimePerJob = c.GetInterval("EXECUTOR_MAXIMUM_RUNTIME_PER_JOB", "30m", "The maximum wall time that can be spent on a single job.")
 	c.CleanupTaskInterval = c.GetInterval("EXECUTOR_CLEANUP_TASK_INTERVAL", "1m", "The frequency with which to run periodic cleanup tasks.")
 	c.NumTotalJobs = c.GetInt("EXECUTOR_NUM_TOTAL_JOBS", "0", "The maximum number of jobs that will be dequeued by the worker.")

--- a/enterprise/cmd/executor/config.go
+++ b/enterprise/cmd/executor/config.go
@@ -26,6 +26,8 @@ type Config struct {
 	FirecrackerImage           string
 	VMStartupScriptPath        string
 	VMPrefix                   string
+	KeepWorkspaces             bool
+	DockerHostMountPath        string
 	UseFirecracker             bool
 	JobNumCPUs                 int
 	JobMemory                  string
@@ -48,6 +50,8 @@ func (c *Config) Load() {
 	c.FirecrackerImage = c.Get("EXECUTOR_FIRECRACKER_IMAGE", "sourcegraph/ignite-ubuntu:insiders", "The base image to use for virtual machines.")
 	c.VMStartupScriptPath = c.GetOptional("EXECUTOR_VM_STARTUP_SCRIPT_PATH", "A path to a file on the host that is loaded into a fresh virtual machine and executed on startup.")
 	c.VMPrefix = c.Get("EXECUTOR_VM_PREFIX", "executor", "A name prefix for virtual machines controlled by this instance.")
+	c.KeepWorkspaces = c.GetBool("EXECUTOR_KEEP_WORKSPACES", "false", "Whether to skip deletion of workspaces after a job completes (or fails).")
+	c.DockerHostMountPath = c.GetOptional("EXECUTOR_DOCKER_HOST_MOUNT_PATH", "The target workspace as it resides on the Docker host (used to enable Docker-in-Docker).")
 	c.JobNumCPUs = c.GetInt(env.ChooseFallbackVariableName("EXECUTOR_JOB_NUM_CPUS", "EXECUTOR_FIRECRACKER_NUM_CPUS"), "4", "How many CPUs to allocate to each virtual machine or container. A value of zero sets no resource bound (in Docker, but not VMs).")
 	c.JobMemory = c.Get(env.ChooseFallbackVariableName("EXECUTOR_JOB_MEMORY", "EXECUTOR_FIRECRACKER_MEMORY"), "12G", "How much memory to allocate to each virtual machine or container. A value of zero sets no resource bound (in Docker, but not VMs).")
 	c.FirecrackerDiskSpace = c.Get("EXECUTOR_FIRECRACKER_DISK_SPACE", "20G", "How much disk space to allocate to each virtual machine.")
@@ -74,6 +78,7 @@ func (c *Config) Validate() error {
 func (c *Config) APIWorkerOptions(telemetryOptions apiclient.TelemetryOptions) apiworker.Options {
 	return apiworker.Options{
 		VMPrefix:           c.VMPrefix,
+		KeepWorkspaces:     c.KeepWorkspaces,
 		QueueName:          c.QueueName,
 		WorkerOptions:      c.WorkerOptions(),
 		FirecrackerOptions: c.FirecrackerOptions(),
@@ -112,10 +117,10 @@ func (c *Config) FirecrackerOptions() command.FirecrackerOptions {
 
 func (c *Config) ResourceOptions() command.ResourceOptions {
 	return command.ResourceOptions{
-		NumCPUs:         c.JobNumCPUs,
-		Memory:          c.JobMemory,
-		DiskSpace:       c.FirecrackerDiskSpace,
-		MountPathPrefix: c.MountPathPrefix,
+		NumCPUs:             c.JobNumCPUs,
+		Memory:              c.JobMemory,
+		DiskSpace:           c.FirecrackerDiskSpace,
+		DockerHostMountPath: c.DockerHostMountPath,
 	}
 }
 

--- a/enterprise/cmd/executor/internal/command/docker.go
+++ b/enterprise/cmd/executor/internal/command/docker.go
@@ -26,12 +26,17 @@ func formatRawOrDockerCommand(spec CommandSpec, dir string, options Options) com
 		}
 	}
 
+	hostDir := dir
+	if options.ResourceOptions.DockerHostMountPath != "" {
+		hostDir = filepath.Join(options.ResourceOptions.DockerHostMountPath, filepath.Base(dir))
+	}
+
 	return command{
 		Key: spec.Key,
 		Command: flatten(
 			"docker", "run", "--rm",
 			dockerResourceFlags(options.ResourceOptions),
-			dockerVolumeFlags(filepath.Join(options.ResourceOptions.MountPathPrefix, dir)),
+			dockerVolumeFlags(hostDir),
 			dockerWorkingdirectoryFlags(spec.Dir),
 			// If the env vars will be part of the command line args, we need to quote them
 			dockerEnvFlags(quoteEnv(spec.Env)),

--- a/enterprise/cmd/executor/internal/command/runner.go
+++ b/enterprise/cmd/executor/internal/command/runner.go
@@ -68,10 +68,11 @@ type ResourceOptions struct {
 	// DiskSpace is the maximum amount of disk a container or VM can use.
 	DiskSpace string
 
-	// MountPathPrefix is attached to the left-hand side of volume mounts for Docker containers.
-	// This option is used when running privilegled executors in k8s using docker-desktop.
-	// Because there's a mismatch between host and VM paths, we need to add a small shim here.
-	MountPathPrefix string
+	// DockerHostMountPath, if supplied, replaces the workspace parent directory in the
+	// volume mounts of Docker containers. This option is used when running privilegled
+	// executors in k8s or docker-compose without requiring the host and node paths to
+	// be identical.
+	DockerHostMountPath string
 }
 
 // NewRunner creates a new runner with the given options.

--- a/enterprise/cmd/executor/internal/worker/handler.go
+++ b/enterprise/cmd/executor/internal/worker/handler.go
@@ -105,7 +105,9 @@ func (h *handler) Handle(ctx context.Context, logger log.Logger, record workerut
 		return errors.Wrap(err, "failed to prepare workspace")
 	}
 	defer func() {
-		_ = os.RemoveAll(workingDirectory)
+		if !h.options.KeepWorkspaces {
+			_ = os.RemoveAll(workingDirectory)
+		}
 	}()
 
 	vmNameSuffix, err := uuid.NewRandom()

--- a/enterprise/cmd/executor/internal/worker/worker.go
+++ b/enterprise/cmd/executor/internal/worker/worker.go
@@ -28,6 +28,11 @@ type Options struct {
 	// (as in dev) will allow the janitors not to see each other's jobs as orphans.
 	VMPrefix string
 
+	// KeepWorkspaces prevents deletion of a workspace after a job completes. Setting
+	// this value to true will continually use more and more disk, so it should only
+	// be used as a debugging mechanism.
+	KeepWorkspaces bool
+
 	// QueueName is the name of the queue to process work from. Having this configurable
 	// allows us to have multiple worker pools with different resource requirements and
 	// horizontal scaling factors while still uniformly processing events.


### PR DESCRIPTION
Add a few flags to:

- keep workspaces (not on by default, but useful for debugging)
- indicate the entire workspace mount path on the host (not just a prefix)

## Test plan

Tested locally via docker-compose and k8s.