### PR TITLE
Code monitors: remove `repo:` filter requirement for code monitor queries

### DIFF
--- a/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.test.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.test.tsx
@@ -19,10 +19,25 @@ describe('FormTriggerArea', () => {
     })
 
     const testCases = [
-        { query: '', patternTypeChecked: true, typeChecked: false, repoChecked: false, validChecked: false },
-        { query: 'test', patternTypeChecked: true, typeChecked: false, repoChecked: false, validChecked: true },
+        {
+            query: '',
+            isSourcegraphDotCom: true,
+            patternTypeChecked: true,
+            typeChecked: false,
+            repoChecked: false,
+            validChecked: false,
+        },
+        {
+            query: 'test',
+            isSourcegraphDotCom: true,
+            patternTypeChecked: true,
+            typeChecked: false,
+            repoChecked: false,
+            validChecked: true,
+        },
         {
             query: 'test patternType:literal',
+            isSourcegraphDotCom: true,
             patternTypeChecked: true,
             typeChecked: false,
             repoChecked: false,
@@ -30,6 +45,7 @@ describe('FormTriggerArea', () => {
         },
         {
             query: 'test patternType:regexp',
+            isSourcegraphDotCom: true,
             patternTypeChecked: true,
             typeChecked: false,
             repoChecked: false,
@@ -37,6 +53,7 @@ describe('FormTriggerArea', () => {
         },
         {
             query: 'test patternType:structural',
+            isSourcegraphDotCom: true,
             patternTypeChecked: false,
             typeChecked: false,
             repoChecked: false,
@@ -44,6 +61,7 @@ describe('FormTriggerArea', () => {
         },
         {
             query: 'test type:repo',
+            isSourcegraphDotCom: true,
             patternTypeChecked: true,
             typeChecked: false,
             repoChecked: false,
@@ -51,6 +69,7 @@ describe('FormTriggerArea', () => {
         },
         {
             query: 'test type:diff',
+            isSourcegraphDotCom: true,
             patternTypeChecked: true,
             typeChecked: true,
             repoChecked: false,
@@ -58,6 +77,7 @@ describe('FormTriggerArea', () => {
         },
         {
             query: 'test type:commit',
+            isSourcegraphDotCom: true,
             patternTypeChecked: true,
             typeChecked: true,
             repoChecked: false,
@@ -65,6 +85,7 @@ describe('FormTriggerArea', () => {
         },
         {
             query: 'test repo:test',
+            isSourcegraphDotCom: true,
             patternTypeChecked: true,
             typeChecked: false,
             repoChecked: true,
@@ -72,6 +93,7 @@ describe('FormTriggerArea', () => {
         },
         {
             query: 'test repo:test type:diff',
+            isSourcegraphDotCom: true,
             patternTypeChecked: true,
             typeChecked: true,
             repoChecked: true,
@@ -89,7 +111,7 @@ describe('FormTriggerArea', () => {
                     setTriggerCompleted={sinon.spy()}
                     startExpanded={false}
                     isLightTheme={true}
-                    isSourcegraphDotCom={false}
+                    isSourcegraphDotCom={testCase.isSourcegraphDotCom}
                 />
             )
             userEvent.click(screen.getByTestId('trigger-button'))
@@ -112,10 +134,15 @@ describe('FormTriggerArea', () => {
             }
 
             const repoCheckbox = screen.getByTestId('repo-checkbox')
-            if (testCase.repoChecked) {
-                expect(repoCheckbox).toBeChecked()
+            if (testCase.isSourcegraphDotCom) {
+                const repoCheckbox = screen.getByTestId('repo-checkbox')
+                if (testCase.repoChecked) {
+                    expect(repoCheckbox).toBeChecked()
+                } else {
+                    expect(repoCheckbox).not.toBeChecked()
+                }
             } else {
-                expect(repoCheckbox).not.toBeChecked()
+                expect(repoCheckbox).not.toBeInTheDocument()
             }
 
             const validCheckbox = screen.getByTestId('valid-checkbox')

--- a/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.tsx
@@ -109,7 +109,11 @@ export const FormTriggerArea: React.FunctionComponent<React.PropsWithChildren<Tr
     const [hasPatternTypeFilter, setHasPatternTypeFilter] = useState(false)
     const [hasValidPatternTypeFilter, setHasValidPatternTypeFilter] = useState(true)
     const isTriggerQueryComplete = useMemo(
-        () => isValidQuery && hasTypeDiffOrCommitFilter && hasRepoFilter && hasValidPatternTypeFilter,
+        () =>
+            isValidQuery &&
+            hasTypeDiffOrCommitFilter &&
+            (!isSourcegraphDotCom || hasRepoFilter) &&
+            hasValidPatternTypeFilter,
         [hasRepoFilter, hasTypeDiffOrCommitFilter, hasValidPatternTypeFilter, isValidQuery]
     )
 
@@ -276,15 +280,18 @@ export const FormTriggerArea: React.FunctionComponent<React.PropsWithChildren<Tr
                                     Contains a <Code>type:diff</Code> or <Code>type:commit</Code> filter
                                 </ValidQueryChecklistItem>
                             </li>
-                            <li>
-                                <ValidQueryChecklistItem
-                                    checked={hasRepoFilter}
-                                    hint="Code monitors can watch a maximum of 50 repos at a time. Target your query with repo: filters to narrow down your search."
-                                    dataTestid="repo-checkbox"
-                                >
-                                    Contains a <Code>repo:</Code> filter
-                                </ValidQueryChecklistItem>
-                            </li>
+                            {/* Enforce repo filter on sourcegraph.com because otherwise it's too easy to generate a lot of load */}
+                            {isSourcegraphDotCom && (
+                                <li>
+                                    <ValidQueryChecklistItem
+                                        checked={hasRepoFilter}
+                                        hint="Code monitors can watch a maximum of 50 repos at a time. Target your query with repo: filters to narrow down your search."
+                                        dataTestid="repo-checkbox"
+                                    >
+                                        Contains a <Code>repo:</Code> filter
+                                    </ValidQueryChecklistItem>
+                                </li>
+                            )}
                             <li>
                                 <ValidQueryChecklistItem checked={isValidQuery} dataTestid="valid-checkbox">
                                     Is a valid search query

--- a/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.tsx
@@ -114,7 +114,7 @@ export const FormTriggerArea: React.FunctionComponent<React.PropsWithChildren<Tr
             hasTypeDiffOrCommitFilter &&
             (!isSourcegraphDotCom || hasRepoFilter) &&
             hasValidPatternTypeFilter,
-        [hasRepoFilter, hasTypeDiffOrCommitFilter, hasValidPatternTypeFilter, isValidQuery]
+        [hasRepoFilter, hasTypeDiffOrCommitFilter, hasValidPatternTypeFilter, isValidQuery, isSourcegraphDotCom]
     )
 
     const [queryState, setQueryState] = useState<QueryState>({ query: query || '' })

--- a/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.tsx
@@ -285,7 +285,7 @@ export const FormTriggerArea: React.FunctionComponent<React.PropsWithChildren<Tr
                                 <li>
                                     <ValidQueryChecklistItem
                                         checked={hasRepoFilter}
-                                        hint="Code monitors can watch a maximum of 50 repos at a time. Target your query with repo: filters to narrow down your search."
+                                        hint="The repo: filter is required to narrow down your search."
                                         dataTestid="repo-checkbox"
                                     >
                                         Contains a <Code>repo:</Code> filter

--- a/client/web/src/integration/code-monitoring.test.ts
+++ b/client/web/src/integration/code-monitoring.test.ts
@@ -140,9 +140,6 @@ describe('Code monitoring', () => {
             await driver.page.waitForSelector('.test-is-invalid')
 
             await driver.page.type('.test-trigger-input', ' type:diff')
-            await driver.page.waitForSelector('.test-is-invalid')
-
-            await driver.page.type('.test-trigger-input', ' repo:test')
             await driver.page.waitForSelector('.test-is-valid')
             await driver.page.waitForSelector('.test-preview-link')
             expect(


### PR DESCRIPTION
Closes #31943
Closes #31941

This removes the repo: filter requirement for code monitors everywhere
except on sourcegraph.com. I think it's best to keep in place on
sourcegraph.com because it's a bit too easy to accidentally create a
code monitor that hits every repo on sourcegraph.com, which will cause
unnecessary load.

## Test plan

Tested behavior with `sg start` and `sg start dotcom`

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-cc-remove-repo-filter.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-fuuccclqfs.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

