### PR TITLE
update pr-auditor to run on ready to review

### DIFF
--- a/.github/workflows/pr-auditor.yml
+++ b/.github/workflows/pr-auditor.yml
@@ -2,7 +2,7 @@
 name: pr-auditor
 on:
   pull_request:
-    types: [ closed, edited, opened, synchronize ]
+    types: [ closed, edited, opened, synchronize, ready_for_review ]
 jobs:
     pr-auditor:
       runs-on: ubuntu-latest


### PR DESCRIPTION
updates the auditor to run when a PR to moved from draft to ready to review.

Anecdotally I've seen a bunch of PR's ready for review without a pr-auditor status because they were initially submitted as drafts. 

Still an on going effort to resolve https://github.com/sourcegraph/sourcegraph/issues/35635


## Test plan

a green run on this PR