### PR TITLE
dev/sg: include error details in baseline events

### DIFF
--- a/dev/sg/internal/analytics/context.go
+++ b/dev/sg/internal/analytics/context.go
@@ -41,12 +41,10 @@ func getStore(ctx context.Context) *eventStore {
 //
 // Events are automatically created with a duration relative to the provided start time,
 // and persisted to disk at the end of command execution.
-func LogEvent(ctx context.Context, category string, labels []string, startedAt time.Time, events ...string) {
-	store := getStore(ctx)
-	if store == nil {
-		return
-	}
-
+//
+// It returns the event that was created so that you can add additional metadata if
+// desired - use sparingly.
+func LogEvent(ctx context.Context, category string, labels []string, startedAt time.Time, events ...string) *okay.Event {
 	metrics := map[string]okay.Metric{
 		"duration": okay.Duration(time.Since(startedAt)),
 	}
@@ -54,7 +52,7 @@ func LogEvent(ctx context.Context, category string, labels []string, startedAt t
 		metrics[event] = okay.Count(1)
 	}
 
-	store.events = append(store.events, &okay.Event{
+	event := &okay.Event{
 		Name:      category,
 		Labels:    labels,
 		Timestamp: startedAt, // Timestamp as start of event
@@ -63,5 +61,13 @@ func LogEvent(ctx context.Context, category string, labels []string, startedAt t
 		Properties: map[string]string{
 			"event_id": uuid.NewString(),
 		},
-	})
+	}
+
+	// Set to store
+	store := getStore(ctx)
+	if store != nil {
+		store.events = append(store.events, event)
+	}
+
+	return event
 }

--- a/dev/sg/main.go
+++ b/dev/sg/main.go
@@ -153,7 +153,8 @@ var sg = &cli.App{
 					message := fmt.Sprintf("%v:\n%s", p, getRelevantStack())
 					err = cli.NewExitError(message, 1)
 
-					analytics.LogEvent(cmd.Context, "sg_before", nil, start, "panic")
+					event := analytics.LogEvent(cmd.Context, "sg_before", nil, start, "panic")
+					event.Properties["error_details"] = err.Error()
 					analytics.Persist(cmd.Context, "sg", cmd.FlagNames())
 				}
 			}()


### PR DESCRIPTION
Right now we only log an abstract 'error happened' event - it might be useful to include the specifics.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

```
go run ./dev/sg --disable-analytics=false ci logs 
sg analytics view --raw
```