### PR TITLE
Code monitors: enable repo-aware monitors by default

### DIFF
--- a/enterprise/cmd/frontend/internal/codemonitors/resolvers/main_test.go
+++ b/enterprise/cmd/frontend/internal/codemonitors/resolvers/main_test.go
@@ -118,7 +118,7 @@ func (r *Resolver) insertTestMonitorWithOpts(ctx context.Context, t *testing.T, 
 			Description: "test monitor",
 			Enabled:     true,
 		},
-		Trigger: &graphqlbackend.CreateTriggerArgs{Query: "repo:foo"},
+		Trigger: &graphqlbackend.CreateTriggerArgs{Query: "repo:foo type:commit"},
 		Actions: options.actions,
 	})
 	if err != nil {

--- a/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers.go
+++ b/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers.go
@@ -147,7 +147,7 @@ func (r *Resolver) CreateCodeMonitor(ctx context.Context, args *graphqlbackend.C
 		return nil, err
 	}
 
-	if featureflag.FromContext(ctx).GetBoolOr("cc-repo-aware-monitors", false) {
+	if featureflag.FromContext(ctx).GetBoolOr("cc-repo-aware-monitors", true) {
 		settings, err := graphqlbackend.DecodedViewerFinalSettings(ctx, tx.db)
 		if err != nil {
 			return nil, err
@@ -528,7 +528,7 @@ func (r *Resolver) updateCodeMonitor(ctx context.Context, args *graphqlbackend.U
 		return nil, err
 	}
 
-	if featureflag.FromContext(ctx).GetBoolOr("cc-repo-aware-monitors", false) {
+	if featureflag.FromContext(ctx).GetBoolOr("cc-repo-aware-monitors", true) {
 		currentTrigger, err := r.db.CodeMonitors().GetQueryTriggerForMonitor(ctx, monitorID)
 		if err != nil {
 			return nil, err

--- a/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers_test.go
+++ b/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers_test.go
@@ -21,12 +21,15 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
 	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/schema"
 )
 
 func TestCreateCodeMonitor(t *testing.T) {
 	ctx := actor.WithInternalActor(context.Background())
 	db := database.NewDB(dbtest.NewDB(t))
 	r := newTestResolver(t, db)
+
+	graphqlbackend.MockDecodedViewerFinalSettings = &schema.Settings{}
 
 	user := insertTestUser(t, db, "cm-user1", true)
 

--- a/enterprise/internal/codemonitors/background/workers.go
+++ b/enterprise/internal/codemonitors/background/workers.go
@@ -181,7 +181,7 @@ func (r *queryRunner) Handle(ctx context.Context, logger log.Logger, record work
 	}
 
 	query := q.QueryString
-	if !featureflag.FromContext(ctx).GetBoolOr("cc-repo-aware-monitors", false) {
+	if !featureflag.FromContext(ctx).GetBoolOr("cc-repo-aware-monitors", true) {
 		// Only add an after filter when repo-aware monitors is disabled
 		query = newQueryWithAfterFilter(q)
 	}

--- a/enterprise/internal/codemonitors/search.go
+++ b/enterprise/internal/codemonitors/search.go
@@ -126,7 +126,7 @@ func Search(ctx context.Context, db database.DB, query string, monitorID int64, 
 		return nil, errcode.MakeNonRetryable(err)
 	}
 
-	if featureflag.FromContext(ctx).GetBoolOr("cc-repo-aware-monitors", false) {
+	if featureflag.FromContext(ctx).GetBoolOr("cc-repo-aware-monitors", true) {
 		hook := func(ctx context.Context, db database.DB, gs commit.GitserverClient, args *gitprotocol.SearchRequest, repoID api.RepoID, doSearch commit.DoSearchFunc) error {
 			return hookWithID(ctx, db, gs, monitorID, repoID, args, doSearch)
 		}


### PR DESCRIPTION
This enables the cc-repo-aware-monitors flag by default if it is not
set. This will make it so when customers update, they will be using
repo-aware monitors. I intend to leave the feature flag in place until
after the release cut so we have an emergency escape hatch, but I don't
expect we'll need it.

## Test plan

This has been enabled on sourcegraph.com for weeks. We should be good.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
