### PR TITLE
dev/ci: proc Go checks on sg.config.yaml

### DIFF
--- a/enterprise/dev/ci/internal/ci/changed/diff.go
+++ b/enterprise/dev/ci/internal/ci/changed/diff.go
@@ -71,6 +71,11 @@ func ParseDiff(files []string) (diff Diff) {
 				diff |= Go
 			}
 		}
+		if p == "sg.config.yaml" {
+			// sg config affects generated output and potentially tests and checks that we
+			// run in the future, so we consider this to have affected Go.
+			diff |= Go
+		}
 
 		// Client
 		if !strings.HasSuffix(p, ".md") && (isRootClientFile(p) || strings.HasPrefix(p, "client/")) {


### PR DESCRIPTION
Resolves https://sourcegraph.slack.com/archives/C01N83PS4TU/p1654847045848989 , where a change to `sg.config.yaml` did not proc the generate check, since we generate some docs from it (`sg` reference). It's a bit heavy-handed, but we don't change `sg.config.yaml` that often and this might be useful in the future as we move testing into a `sg test` command as well.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

n/a