### PR TITLE
Don't delete user session cookie if redis connection errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 - A common source of searcher evictions on kubernetes when running large structural searches. [#34828](https://github.com/sourcegraph/sourcegraph/issues/34828)
 - An issue with permissions evaluation for saved searches
+- An authorization check while Redis is down will now result in an internal server error, instead of clearing a valid session from the user's cookies [#37016](https://github.com/sourcegraph/sourcegraph/issues/37016)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 - A common source of searcher evictions on kubernetes when running large structural searches. [#34828](https://github.com/sourcegraph/sourcegraph/issues/34828)
 - An issue with permissions evaluation for saved searches
-- An authorization check while Redis is down will now result in an internal server error, instead of clearing a valid session from the user's cookies [#37016](https://github.com/sourcegraph/sourcegraph/issues/37016)
+- An authorization check while Redis is down will now result in an internal server error, instead of clearing a valid session from the user's cookies. [#37016](https://github.com/sourcegraph/sourcegraph/issues/37016)
 
 ### Removed
 

--- a/cmd/frontend/internal/session/session.go
+++ b/cmd/frontend/internal/session/session.go
@@ -344,8 +344,9 @@ func authenticateByCookie(db database.DB, r *http.Request, w http.ResponseWriter
 	if err := GetData(r, "actor", &info); err != nil {
 		if strings.Contains(err.Error(), "connect: connection refused") {
 			// If fetching session info failed because of a Redis error, return empty Context
-			// without deleting the session cookie. This prevents background requests
-			// made by off-screen tabs from signing the user out during a server update.
+			// without deleting the session cookie and throw an internal server error.
+			// This prevents background requests made by off-screen tabs from signing
+			// the user out during a server update.
 			w.WriteHeader(http.StatusInternalServerError)
 			return r.Context()
 		}

--- a/cmd/frontend/internal/session/session.go
+++ b/cmd/frontend/internal/session/session.go
@@ -342,6 +342,12 @@ func authenticateByCookie(db database.DB, r *http.Request, w http.ResponseWriter
 
 	var info *sessionInfo
 	if err := GetData(r, "actor", &info); err != nil {
+		if strings.Contains(err.Error(), "connect: connection refused") {
+			// If fetching session info failed because of a Redis error, return empty Context
+			// without deleting the session cookie. This prevents background requests
+			// made by off-screen tabs from signing the user out during a server update.
+			return r.Context()
+		}
 		if !strings.Contains(err.Error(), "illegal base64 data at input byte 36") {
 			// Skip log if the error message indicates the cookie value was a JWT (which almost
 			// certainly means that the cookie was a pre-2.8 SAML cookie, so this error will only

--- a/cmd/frontend/internal/session/session.go
+++ b/cmd/frontend/internal/session/session.go
@@ -346,6 +346,7 @@ func authenticateByCookie(db database.DB, r *http.Request, w http.ResponseWriter
 			// If fetching session info failed because of a Redis error, return empty Context
 			// without deleting the session cookie. This prevents background requests
 			// made by off-screen tabs from signing the user out during a server update.
+			w.WriteHeader(http.StatusInternalServerError)
 			return r.Context()
 		}
 		if !strings.Contains(err.Error(), "illegal base64 data at input byte 36") {


### PR DESCRIPTION
If Redis is unavailable due to something like a server restart, this prevents the user session cookie from being deleted. It is still a valid session, and will be valid as soon as Redis is available again.

This addresses https://github.com/sourcegraph/sourcegraph/issues/37016 , where off-screen tabs that perform a request in the background can cause a user session to be ended during a server update, which happens frequently on the k8s dogfood deployment.

## Test plan
Manual testing as its a strange redis availability issue.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
