### PR TITLE
insights: fix empty repo checks

### DIFF
--- a/enterprise/internal/insights/discovery/first_commit.go
+++ b/enterprise/internal/insights/discovery/first_commit.go
@@ -1,0 +1,40 @@
+package discovery
+
+import (
+	"context"
+	"strings"
+
+	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/authz"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
+	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+var (
+	EmptyRepoErr = errors.New("empty repository")
+)
+
+const emptyRepoErrMessage = `git command [rev-list --reverse --date-order --max-parents=0 HEAD] failed (output: ""): exit status 129`
+
+func isFirstCommitEmptyRepoError(err error) bool {
+	if strings.Contains(err.Error(), emptyRepoErrMessage) {
+		return true
+	}
+	unwrappedErr := errors.Unwrap(err)
+	if unwrappedErr != nil {
+		return isFirstCommitEmptyRepoError(unwrappedErr)
+	}
+	return false
+}
+
+func GitFirstEverCommit(ctx context.Context, db database.DB, repoName api.RepoName) (*gitdomain.Commit, error) {
+	commit, err := git.FirstEverCommit(ctx, db, repoName, authz.DefaultSubRepoPermsChecker)
+	if err != nil {
+		if isFirstCommitEmptyRepoError(err) {
+			return nil, errors.Newf("%s: %w", err.Error(), EmptyRepoErr)
+		}
+	}
+	return commit, err
+}

--- a/enterprise/internal/insights/discovery/first_commit.go
+++ b/enterprise/internal/insights/discovery/first_commit.go
@@ -31,10 +31,8 @@ func isFirstCommitEmptyRepoError(err error) bool {
 
 func GitFirstEverCommit(ctx context.Context, db database.DB, repoName api.RepoName) (*gitdomain.Commit, error) {
 	commit, err := git.FirstEverCommit(ctx, db, repoName, authz.DefaultSubRepoPermsChecker)
-	if err != nil {
-		if isFirstCommitEmptyRepoError(err) {
-			return nil, errors.Newf("%s: %w", err.Error(), EmptyRepoErr)
-		}
+	if err != nil && isFirstCommitEmptyRepoError(err) {
+		return nil, errors.Wrap(EmptyRepoErr, err.Error())
 	}
 	return commit, err
 }

--- a/enterprise/internal/insights/discovery/first_commit_test.go
+++ b/enterprise/internal/insights/discovery/first_commit_test.go
@@ -1,0 +1,45 @@
+package discovery
+
+import (
+	"testing"
+
+	"github.com/hexops/autogold"
+
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+func Test_IsEmptyRepoError(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		err  error
+		want autogold.Value
+	}{
+		{
+			err:  errors.New(emptyRepoErrMessage),
+			want: autogold.Want("EmptyRepo", true),
+		},
+		{
+			err:  errors.Newf("Another message: %w", errors.New(emptyRepoErrMessage)),
+			want: autogold.Want("NestedEmptyRepoError", true),
+		},
+		{
+			err:  errors.Newf("Another message: %w", errors.Newf("Deep nested: %w", errors.New(emptyRepoErrMessage))),
+			want: autogold.Want("DeepNestedError", true),
+		},
+		{
+			err:  errors.Newf("Another message: %w", errors.New("Not an empty repo")),
+			want: autogold.Want("NestedNotEmptyRepoError", false),
+		},
+		{
+			err:  errors.New("A different error"),
+			want: autogold.Want("NotEmptyRepo", false),
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.want.Name(), func(t *testing.T) {
+			got := isFirstCommitEmptyRepoError(tc.err)
+			tc.want.Equal(t, got)
+		})
+	}
+}

--- a/internal/vcs/git/commits_test.go
+++ b/internal/vcs/git/commits_test.go
@@ -320,7 +320,7 @@ func TestRepository_FirstEverCommit(t *testing.T) {
 		}
 	})
 
-	// Added for awareness if this error changes. Insights skip empty repos and check against error
+	// Added for awareness if this error message changes. Insights skip over empty repos and check against error message
 	t.Run("empty repo", func(t *testing.T) {
 		repo := MakeGitRepository(t)
 		_, err := FirstEverCommit(ctx, db, repo, nil)

--- a/internal/vcs/git/commits_test.go
+++ b/internal/vcs/git/commits_test.go
@@ -320,6 +320,16 @@ func TestRepository_FirstEverCommit(t *testing.T) {
 		}
 	})
 
+	// Added for awareness if this error changes. Insights skip empty repos and check against error
+	t.Run("empty repo", func(t *testing.T) {
+		repo := MakeGitRepository(t)
+		_, err := FirstEverCommit(ctx, db, repo, nil)
+		wantErr := `git command [rev-list --reverse --date-order --max-parents=0 HEAD] failed (output: ""): exit status 129`
+		if err.Error() != wantErr {
+			t.Errorf("expected :%s, got :%s", wantErr, err)
+		}
+	})
+
 	t.Run("with sub-repo permissions", func(t *testing.T) {
 		checkerWithoutAccessFirstCommit := getTestSubRepoPermsChecker("file0")
 		checkerWithAccessFirstCommit := getTestSubRepoPermsChecker("file1")


### PR DESCRIPTION
Consolidates logic for getting first git commit and making it easier to deal with empty repos.

related to https://github.com/sourcegraph/sourcegraph/issues/35450
## Test plan
unit tests pass
Manually verified insight creation with & without empty repos
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
