### PR TITLE
sg: use 1pass instead of dev-private

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -177,3 +177,7 @@ go.work.sum
 
 # binary
 /sg
+
+# dev-private
+enterprise/dev/site-config.json
+enterprise/dev/external-services-config.json

--- a/dev/sg/sg_secret.go
+++ b/dev/sg/sg_secret.go
@@ -2,15 +2,12 @@ package main
 
 import (
 	"encoding/json"
-	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/urfave/cli/v2"
 
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/secrets"
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/std"
-	"github.com/sourcegraph/sourcegraph/dev/sg/root"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 	"github.com/sourcegraph/sourcegraph/lib/output"
 )
@@ -30,12 +27,6 @@ sg secret reset buildkite
 `,
 		Category: CategoryEnv,
 		Subcommands: []*cli.Command{
-			{
-				Name:      "download-config",
-				ArgsUsage: "",
-				Usage:     "TODO",
-				Action:    downloadDevPrivate,
-			},
 			{
 				Name:      "reset",
 				ArgsUsage: "<...key>",
@@ -59,53 +50,6 @@ sg secret reset buildkite
 		},
 	}
 )
-
-var (
-	siteConfig = secrets.ExternalSecret{
-		Provider: secrets.ExternalProvider1Pass,
-		Project:  "Shared",
-		Name:     "DevPrivate",
-		Field:    "site-config.json",
-	}
-
-	externalServicesConfig = secrets.ExternalSecret{
-		Provider: secrets.ExternalProvider1Pass,
-		Project:  "Shared",
-		Name:     "DevPrivate",
-		Field:    "external-services-config.json",
-	}
-)
-
-func downloadDevPrivate(ctx *cli.Context) error {
-	store, err := secrets.FromContext(ctx.Context)
-	if err != nil {
-		return err
-	}
-
-	root, err := root.RepositoryRoot()
-	if err != nil {
-		return err
-	}
-
-	s, err := store.GetExternal(ctx.Context, siteConfig)
-	if err != nil {
-		return err
-	}
-	err = os.WriteFile(filepath.Join(root, "enterprise", "dev", "site-config.json"), []byte(s), 0600)
-	if err != nil {
-		return err
-	}
-	s, err = store.GetExternal(ctx.Context, externalServicesConfig)
-	if err != nil {
-		return err
-	}
-	err = os.WriteFile(filepath.Join(root, "enterprise", "dev", "external-services-config.json"), []byte(s), 0600)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
 
 func resetSecretExec(ctx *cli.Context) error {
 	args := ctx.Args().Slice()

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -132,8 +132,6 @@ commands:
 
   enterprise-frontend:
     cmd: |
-      # TODO: This should be fixed
-      export SOURCEGRAPH_LICENSE_GENERATION_KEY=$(cat ../dev-private/enterprise/dev/test-license-generation-key.pem)
       .bin/enterprise-frontend
     install: |
       if [ -n "$DELVE" ]; then
@@ -141,12 +139,18 @@ commands:
       fi
       go build -gcflags="$GCFLAGS" -o .bin/enterprise-frontend github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend
     checkBinary: .bin/enterprise-frontend
+    external_secrets:
+      SOURCEGRAPH_LICENSE_GENERATION_KEY:
+        provider: "1pass"
+        project: "Shared"
+        name: "DevPrivate"
+        field: "test-license-generation.pem"
     env:
       CONFIGURATION_MODE: server
       USE_ENHANCED_LANGUAGE_DETECTION: false
       ENTERPRISE: 1
-      SITE_CONFIG_FILE: '../dev-private/enterprise/dev/site-config.json'
-      EXTSVC_CONFIG_FILE: '../dev-private/enterprise/dev/external-services-config.json'
+      SITE_CONFIG_FILE: 'enterprise/dev/site-config.json'
+      EXTSVC_CONFIG_FILE: 'enterprise/dev/external-services-config.json'
       SITE_CONFIG_ESCAPE_HATCH_PATH: '$HOME/.sourcegraph/site-config.json'
       # frontend processes need this to be so that the paths to the assets are rendered correctly
       WEBPACK_DEV_SERVER: 1
@@ -201,13 +205,18 @@ commands:
 
   enterprise-worker:
     cmd: |
-      export SOURCEGRAPH_LICENSE_GENERATION_KEY=$(cat ../dev-private/enterprise/dev/test-license-generation-key.pem)
       .bin/worker
     install: |
       if [ -n "$DELVE" ]; then
         export GCFLAGS='all=-N -l'
       fi
       go build -gcflags="$GCFLAGS" -o .bin/worker github.com/sourcegraph/sourcegraph/enterprise/cmd/worker
+    external_secrets:
+      SOURCEGRAPH_LICENSE_GENERATION_KEY:
+        provider: "1pass"
+        project: "Shared"
+        name: "DevPrivate"
+        field: "test-license-generation.pem"
     watch:
       - lib
       - internal
@@ -690,7 +699,6 @@ commandsets:
       - zoekt-webserver-1
 
   enterprise: &enterprise_set
-    requiresDevPrivate: true
     checks:
       - docker
       - redis
@@ -724,9 +732,19 @@ commandsets:
     <<: *enterprise_set
     env:
       SOURCEGRAPHDOTCOM_MODE: true
+    external_secrets:
+      STRIPE_SECRET_KEY:
+        provider: "1pass"
+        project: "Shared"
+        name: "DevPrivate"
+        field: "STRIPE_SECRET_KEY"
+      STRIPE_PUBLISHABLE_KEY:
+        provider: "1pass"
+        project: "Shared"
+        name: "DevPrivate"
+        field: "STRIPE_PUBLISHABLE_KEY"
 
   codeintel: &codeintel_set
-    requiresDevPrivate: true
     checks:
       - docker
       - redis
@@ -759,7 +777,6 @@ commandsets:
     <<: *codeintel_set
 
   enterprise-codeinsights:
-    requiresDevPrivate: true
     checks:
       - docker
       - redis
@@ -786,7 +803,6 @@ commandsets:
       DISABLE_CODE_INSIGHTS: false
 
   api-only:
-    requiresDevPrivate: true
     checks:
       - docker
       - redis
@@ -806,7 +822,6 @@ commandsets:
       - zoekt-webserver-1
 
   batches:
-    requiresDevPrivate: true
     checks:
       - docker
       - redis
@@ -831,7 +846,6 @@ commandsets:
       - batches-executor
 
   iam:
-    requiresDevPrivate: true
     checks:
       - docker
       - redis

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -133,18 +133,24 @@ commands:
   enterprise-frontend:
     cmd: |
       .bin/enterprise-frontend
-    install: |
-      if [ -n "$DELVE" ]; then
-        export GCFLAGS='all=-N -l'
-      fi
-      go build -gcflags="$GCFLAGS" -o .bin/enterprise-frontend github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend
-    checkBinary: .bin/enterprise-frontend
+    install_func: installEnterpriseFrontend
+    #checkBinary: .bin/enterprise-frontend
     external_secrets:
       SOURCEGRAPH_LICENSE_GENERATION_KEY:
         provider: "1pass"
         project: "Shared"
         name: "DevPrivate"
         field: "test-license-generation.pem"
+      PRIVATE_SITECONFIG_DATA:
+        provider: "1pass"
+        project: "Shared"
+        name: "DevPrivate"
+        field: "site-config.json"
+      PRIVATE_EXTSVC_DATA:
+        provider: "1pass"
+        project: "Shared"
+        name: "DevPrivate"
+        field: "external-services-config.json"
     env:
       CONFIGURATION_MODE: server
       USE_ENHANCED_LANGUAGE_DETECTION: false


### PR DESCRIPTION
Drop dev-private entirely in favour of 1password. 

Fixes https://github.com/sourcegraph/sourcegraph/issues/29640 

- [ ] Find a better name for `sg secret download-config` 
- [ ] Provide a better error when running enteprise code without having ran the command
- Maybe plug the `requires_dev_private: true` field to call `sg secret download-config`'s code automatically ? 
## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

- deleted `../dev-private` 
- ran `sg secret download-config` (with 1pass from `sg setup` configured) 
- ran `sg start` and got it working, with the right site-config and license. 