### PR TITLE
symbols: Remove useless ParserPool interface

### DIFF
--- a/cmd/symbols/parser/parser.go
+++ b/cmd/symbols/parser/parser.go
@@ -31,7 +31,7 @@ type SymbolOrError struct {
 }
 
 type parser struct {
-	parserPool         ParserPool
+	parserPool         *parserPool
 	repositoryFetcher  fetcher.RepositoryFetcher
 	requestBufferSize  int
 	numParserProcesses int
@@ -39,7 +39,7 @@ type parser struct {
 }
 
 func NewParser(
-	parserPool ParserPool,
+	parserPool *parserPool,
 	repositoryFetcher fetcher.RepositoryFetcher,
 	requestBufferSize int,
 	numParserProcesses int,

--- a/cmd/symbols/parser/parser_pool.go
+++ b/cmd/symbols/parser/parser_pool.go
@@ -8,17 +8,12 @@ import (
 
 type ParserFactory func() (ctags.Parser, error)
 
-type ParserPool interface {
-	Get(ctx context.Context) (ctags.Parser, error)
-	Done(parser ctags.Parser)
-}
-
 type parserPool struct {
 	newParser ParserFactory
 	pool      chan ctags.Parser
 }
 
-func NewParserPool(newParser ParserFactory, numParserProcesses int) (ParserPool, error) {
+func NewParserPool(newParser ParserFactory, numParserProcesses int) (*parserPool, error) {
 	pool := make(chan ctags.Parser, numParserProcesses)
 	for i := 0; i < numParserProcesses; i++ {
 		parser, err := newParser()


### PR DESCRIPTION
`ParserPool` was not really being used.

## Test plan

Type checker
