### PR TITLE
code monitors: enable webhooks for everyone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Extensions: Added `enableExtensionsDecorationsColumnView` user setting as [experimental feature](https://docs.sourcegraph.com/admin/beta_and_experimental_features#experimental-features). When enabled decorations of the extensions supporting column decorations (currently only git-extras extension does: [sourcegraph-git-extras/pull/276](https://github.com/sourcegraph/sourcegraph-git-extras/pull/276)) will be displayed in separate columns on the blob page. [#36007](https://github.com/sourcegraph/sourcegraph/pull/36007)
 - SAML authentication provider has a new site configuration `allowGroups` that allows filtering users by group membership. [#36555](https://github.com/sourcegraph/sourcegraph/pull/36555)
 - A new [templating](https://docs.sourcegraph.com/campaigns/references/batch_spec_templating) variable, `batch_change_link` has been added for more control over where the "Created by Sourcegraph batch change ..." message appears in the published changeset description. [#491](https://github.com/sourcegraph/sourcegraph/pull/35319)
+- Code Monitoring: Slack notifications and webhooks are now enabled for everyone by default as a beta feature. []()
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Extensions: Added `enableExtensionsDecorationsColumnView` user setting as [experimental feature](https://docs.sourcegraph.com/admin/beta_and_experimental_features#experimental-features). When enabled decorations of the extensions supporting column decorations (currently only git-extras extension does: [sourcegraph-git-extras/pull/276](https://github.com/sourcegraph/sourcegraph-git-extras/pull/276)) will be displayed in separate columns on the blob page. [#36007](https://github.com/sourcegraph/sourcegraph/pull/36007)
 - SAML authentication provider has a new site configuration `allowGroups` that allows filtering users by group membership. [#36555](https://github.com/sourcegraph/sourcegraph/pull/36555)
 - A new [templating](https://docs.sourcegraph.com/campaigns/references/batch_spec_templating) variable, `batch_change_link` has been added for more control over where the "Created by Sourcegraph batch change ..." message appears in the published changeset description. [#491](https://github.com/sourcegraph/sourcegraph/pull/35319)
-- Code Monitoring: Slack notifications and webhooks are now enabled for everyone by default as a beta feature. []()
+- Code Monitoring: Notifications via Slack and generic webhooks are now enabled for everyone by default as a beta feature. [#37037](https://github.com/sourcegraph/sourcegraph/pull/37037)
 
 ### Changed
 

--- a/client/web/src/components/WebStory.tsx
+++ b/client/web/src/components/WebStory.tsx
@@ -9,7 +9,7 @@ import { MockedStoryProvider, MockedStoryProviderProps, usePrependStyles, useThe
 // eslint-disable-next-line no-restricted-imports
 import { DeprecatedTooltip, WildcardThemeContext } from '@sourcegraph/wildcard'
 
-import { setExperimentalFeaturesFromSettings } from '../stores'
+import { setExperimentalFeaturesForTesting } from '../stores/experimentalFeatures'
 
 import { BreadcrumbSetters, BreadcrumbsProps, useBreadcrumbs } from './Breadcrumbs'
 
@@ -38,7 +38,7 @@ export const WebStory: React.FunctionComponent<React.PropsWithChildren<WebStoryP
     const Children = useMemo(() => withRouter(children), [children])
 
     usePrependStyles('web-styles', webStyles)
-    setExperimentalFeaturesFromSettings({ subjects: null, final: null })
+    setExperimentalFeaturesForTesting()
 
     return (
         <MockedStoryProvider mocks={mocks} useStrictMocking={useStrictMocking}>

--- a/client/web/src/components/WebStory.tsx
+++ b/client/web/src/components/WebStory.tsx
@@ -9,6 +9,8 @@ import { MockedStoryProvider, MockedStoryProviderProps, usePrependStyles, useThe
 // eslint-disable-next-line no-restricted-imports
 import { DeprecatedTooltip, WildcardThemeContext } from '@sourcegraph/wildcard'
 
+import { setExperimentalFeaturesFromSettings } from '../stores'
+
 import { BreadcrumbSetters, BreadcrumbsProps, useBreadcrumbs } from './Breadcrumbs'
 
 import webStyles from '../SourcegraphWebApp.scss'
@@ -36,6 +38,7 @@ export const WebStory: React.FunctionComponent<React.PropsWithChildren<WebStoryP
     const Children = useMemo(() => withRouter(children), [children])
 
     usePrependStyles('web-styles', webStyles)
+    setExperimentalFeaturesFromSettings({ subjects: null, final: null })
 
     return (
         <MockedStoryProvider mocks={mocks} useStrictMocking={useStrictMocking}>

--- a/client/web/src/enterprise/code-monitoring/ManageCodeMonitorPage.story.tsx
+++ b/client/web/src/enterprise/code-monitoring/ManageCodeMonitorPage.story.tsx
@@ -1,6 +1,6 @@
 import { storiesOf } from '@storybook/react'
 import { NEVER, of } from 'rxjs'
-import sinon from 'sinon'
+import { fake } from 'sinon'
 
 import { WebStory } from '../../components/WebStory'
 
@@ -22,9 +22,9 @@ add('ManageCodeMonitorPage', () => (
             <ManageCodeMonitorPage
                 {...props}
                 authenticatedUser={{ ...mockUser, id: 'foobar', username: 'alice', email: 'alice@alice.com' }}
-                updateCodeMonitor={sinon.fake()}
-                fetchCodeMonitor={sinon.fake((id: string) => of(mockCodeMonitor))}
-                deleteCodeMonitor={sinon.fake((id: string) => NEVER)}
+                updateCodeMonitor={fake()}
+                fetchCodeMonitor={fake(() => of(mockCodeMonitor))}
+                deleteCodeMonitor={fake(() => NEVER)}
                 isSourcegraphDotCom={false}
             />
         )}

--- a/client/web/src/enterprise/code-monitoring/components/actions/SlackWebhookAction.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/actions/SlackWebhookAction.tsx
@@ -103,7 +103,7 @@ export const SlackWebhookAction: React.FunctionComponent<React.PropsWithChildren
         <ActionEditor
             title={
                 <div className="d-flex align-items-center">
-                    Send Slack message to channel <ProductStatusBadge className="ml-1" status="experimental" />{' '}
+                    Send Slack message to channel <ProductStatusBadge className="ml-1" status="beta" />{' '}
                 </div>
             }
             label="Send Slack message to channel"

--- a/client/web/src/enterprise/code-monitoring/components/actions/WebhookAction.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/actions/WebhookAction.tsx
@@ -102,7 +102,7 @@ export const WebhookAction: React.FunctionComponent<React.PropsWithChildren<Acti
         <ActionEditor
             title={
                 <div className="d-flex align-items-center">
-                    Call a webhook <ProductStatusBadge className="ml-1" status="experimental" />{' '}
+                    Call a webhook <ProductStatusBadge className="ml-1" status="beta" />{' '}
                 </div>
             }
             label="Call a webhook"

--- a/client/web/src/stores/experimentalFeatures.ts
+++ b/client/web/src/stores/experimentalFeatures.ts
@@ -30,6 +30,11 @@ export function setExperimentalFeaturesFromSettings(settingsCascade: SettingsCas
     useExperimentalFeatures.setState({ ...defaultSettings, ...experimentalFeatures }, true)
 }
 
+// For testing purposes only. Initializes the feature flags with the default values.
+export function setExperimentalFeaturesForTesting(): void {
+    useExperimentalFeatures.setState(defaultSettings, true)
+}
+
 /**
  * This is a helper function to hide the fact that experimental feature flags
  * are backed by a Zustand store

--- a/client/web/src/stores/experimentalFeatures.ts
+++ b/client/web/src/stores/experimentalFeatures.ts
@@ -16,7 +16,7 @@ const defaultSettings: SettingsExperimentalFeatures = {
     showSearchContextManagement: true,
     showSearchNotebook: true,
     showComputeComponent: false,
-    codeMonitoringWebHooks: false,
+    codeMonitoringWebHooks: true,
     showCodeMonitoringLogs: true,
 }
 

--- a/doc/code_monitoring/explanations/best_practices.md
+++ b/doc/code_monitoring/explanations/best_practices.md
@@ -7,3 +7,13 @@ There are some best practices we recommend when creating code monitors.
 ### Do not include confidential information in monitor names
 
 Every code monitor has a name that will be shown wherever the monitor is referenced. In notification actions this name is likely to be the only information about the event, so it’s important for identifying what was triggered, but also has to be “safe” to expose in plain text emails.
+
+### Do not include results when the notification destination untrusted
+
+Each code monitor action has the ability to include the result contents when sending a notification. This is often convenient because it lets you immediately see which results triggered the notification. However, because the result contents include the code that matched the search query, they may contain sensitive information. Care should be taken to only send result contents if the destination is secure.
+
+For example, if sending the results to a Slack channel, every user that can view that channel will also be able to view the notification messages. The channel should be properly restricted to users who should be able to view that code.
+
+## Scale
+
+Code monitors have been designed to be performant even for large Sourcegraph instances. There are no hard limits on the number of monitors or the volume of code monitored. However, depending on a number of factors such as the number of code monitors, the number of repos monitored, the frequency of commits, and the resources allocated to your instance, it's still possible to hit soft limits. If this happens, your code monitor will continue to work reliably, but it may execute more infrequently.

--- a/doc/code_monitoring/explanations/core_concepts.md
+++ b/doc/code_monitoring/explanations/core_concepts.md
@@ -8,7 +8,7 @@ Code monitors are made up of two main elements: **Triggers** and **Actions**.
 
 A _trigger_ is an event which causes execution of an action. Currently, code monitoring supports one kind of trigger: "When new search results are detected" for a particular search query. When creating a code monitor, users will be asked to specify a query as part of the trigger.
 
-Sourcegraph will run the search query periodically, and when new results for the query are detected, a trigger event is executed. In response to the trigger event, any _actions_ attached to the code monitor will be executed.
+Sourcegraph will run the search query over every new commit for the searched repositories, and when new results for the query are detected, a trigger event is emitted. In response to the trigger event, any _actions_ attached to the code monitor will be executed.
 
 **Query requirements**
 
@@ -16,9 +16,11 @@ A query used in a "When new search results are detected" trigger must be a diff 
 
 ## Actions
 
-An _action_ is executed in response to a trigger event. Currently, code monitoring supports one kind of action: sending a notification email to the owner of the code monitor.
+An _action_ is executed in response to a trigger event. Currently, code monitoring supports three different actions:
 
-In response to a trigger event, Sourcegraph will send an email containing a link to the newly detected results to the owner of the code monitor.
+* Sending a notification email to the owner of the code monitor
+* <span class="badge badge-beta">Beta</span> Sending a Slack message to a preconfigured channel
+* <span class="badge badge-beta">Beta</span> Sending a webhook event to an endpoint of your choosing
 
 ## Current flow
 
@@ -28,6 +30,6 @@ A user creates a code monitor, which consists of:
 
   * a name for the monitor
   * a trigger, which consists of a search query to run periodically,
-  * and an action, which is sending an email to the user when new results appear
+  * and an action, which is sending an email, sending a Slack message, or sending a webhook event
 
-Sourcegraph runs the query periodically. When new results are detected, an email is sent to the user that created the monitor. The email contains a link to the newly detected search results.
+Sourcegraph runs the query periodically over new commits. When new results are detected, a notification will be sent with the configured action. It will either contain a link to the search that provided new results, or if the "Include results" setting is enabled, it will include the result contents.

--- a/doc/code_monitoring/how-tos/index.md
+++ b/doc/code_monitoring/how-tos/index.md
@@ -1,5 +1,5 @@
 # How-tos
 
 * [Starting points](starting_points.md)
-* <span class="badge badge-experimental">Experimental</span> [Setting up Slack notifications](slack.md)
-* <span class="badge badge-experimental">Experimental</span> [Setting up Webhook notifications](webhook.md)
+* <span class="badge badge-beta">Beta</span> [Setting up Slack notifications](slack.md)
+* <span class="badge badge-beta">Beta</span> [Setting up Webhook notifications](webhook.md)

--- a/doc/code_monitoring/how-tos/slack.md
+++ b/doc/code_monitoring/how-tos/slack.md
@@ -1,8 +1,8 @@
 # Setting up Slack notifications
 
-<aside class="experimental">
+<aside class="note">
 <p>
-<span class="badge badge-experimental">Experimental</span> This feature is experimental and might change or be removed in the future. We've released it as an experimental feature to provide a preview of functionality we're working on.
+<span class="badge badge-beta">Beta</span> This feature is currently in beta and may change in the future.
 </p>
 
 <p><b>We're very much looking for input and feedback on this feature.</b> You can either <a href="https://about.sourcegraph.com/contact">contact us directly</a>, <a href="https://github.com/sourcegraph/sourcegraph">file an issue</a>, or <a href="https://twitter.com/sourcegraph">tweet at us</a>.</p>
@@ -16,7 +16,7 @@ use that webhook's URL.
 
 ## Prerequisites
 
-- You must have the experimental feature flag `  "experimentalFeatures": { "codeMonitoringWebHooks": true } ` set in your user, org, or global settings.
+- You must not have have the setting `experimentalFeatures.codeMonitoringWebHooks` disabled in your user, org, or global settings.
 - You must have permission to create apps inside of your organization's Slack workspace
 
 ## Creating a Slack webhook

--- a/doc/code_monitoring/how-tos/webhook.md
+++ b/doc/code_monitoring/how-tos/webhook.md
@@ -1,8 +1,8 @@
 # Setting up Webhook notifications
 
-<aside class="experimental">
+<aside class="note">
 <p>
-<span class="badge badge-experimental">Experimental</span> This feature is experimental and might change or be removed in the future. We've released it as an experimental feature to provide a preview of functionality we're working on.
+<span class="badge badge-beta">Beta</span> This feature is currently in beta and may change in the future.
 </p>
 
 <p><b>We're very much looking for input and feedback on this feature.</b> You can either <a href="https://about.sourcegraph.com/contact">contact us directly</a>, <a href="https://github.com/sourcegraph/sourcegraph">file an issue</a>, or <a href="https://twitter.com/sourcegraph">tweet at us</a>.</p>
@@ -14,7 +14,7 @@ by Sourcegraph, and contains all the information available about the cause of th
 
 ## Prerequisites
 
-- You must have the experimental feature flag `experimentalFeatures.codeMonitoringWebHooks` set to `true` in your Sourcegraph settings
+- You must not have have the setting `experimentalFeatures.codeMonitoringWebHooks` disabled in your user, org, or global settings.
 - You must have a service running that can accept the POST request triggered by the webhook notification
 
 ## Creating a webhook receiver

--- a/doc/code_monitoring/index.md
+++ b/doc/code_monitoring/index.md
@@ -63,8 +63,8 @@ Watch your code with code monitors and trigger actions to run automatically in r
 
 ## [How-tos](how-tos/index.md)
 - [Starting points and ideas](how-tos/starting_points.md)
-- <span class="badge badge-experimental">Experimental</span> [Setting up Slack notifications](how-tos/slack.md)
-- <span class="badge badge-experimental">Experimental</span> [Setting up Webhook notifications](how-tos/webhook.md)
+- <span class="badge badge-beta">Beta</span> [Setting up Slack notifications](how-tos/slack.md)
+- <span class="badge badge-beta">Beta</span> [Setting up Webhook notifications](how-tos/webhook.md)
 
 
 ## Questions & Feedback


### PR DESCRIPTION
Closes #32221
Closes #10212

- [x] Add Beta label to feature in product
- [x] Enable feature flag
- [x] Update changelog
- [x] Update docs with feature as Beta


## Test plan

- All existing CI should pass. 
- Chromatic should show Slack and Webhook sections in code monitoring form storybook tests.

## App preview:

- [Web](https://sg-web-jp-enablewebhooks.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-cazjxgepta.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
