### PR TITLE
Code monitoring: update docs for webhooks and repo-aware monitors

### DIFF
--- a/doc/code_monitoring/explanations/best_practices.md
+++ b/doc/code_monitoring/explanations/best_practices.md
@@ -7,3 +7,13 @@ There are some best practices we recommend when creating code monitors.
 ### Do not include confidential information in monitor names
 
 Every code monitor has a name that will be shown wherever the monitor is referenced. In notification actions this name is likely to be the only information about the event, so it’s important for identifying what was triggered, but also has to be “safe” to expose in plain text emails.
+
+### Do not include results when the notification destination untrusted
+
+Each code monitor action has the ability to include the result contents when sending a notification. This is often convenient because it lets you immediately see which results triggered the notification. However, because the result contents include the code that matched the search query, they may contain sensitive information. Care should be taken to only send result contents if the destination is secure.
+
+For example, if sending the results to a Slack channel, every user that can view that channel will also be able to view the notification messages. The channel should be properly restricted to users who should be able to view that code.
+
+## Scale
+
+Code monitors have been designed to be performant even for large Sourcegraph instances. There are no hard limits on the number of monitors or the volume of code monitored. However, depending on a number of factors such as the number of code monitors, the number of repos monitored, the frequency of commits, and the resources allocated to your instance, it's still possible to hit soft limits. If this happens, your code monitor will continue to work reliably, but it may execute more infrequently.

--- a/doc/code_monitoring/explanations/core_concepts.md
+++ b/doc/code_monitoring/explanations/core_concepts.md
@@ -8,7 +8,7 @@ Code monitors are made up of two main elements: **Triggers** and **Actions**.
 
 A _trigger_ is an event which causes execution of an action. Currently, code monitoring supports one kind of trigger: "When new search results are detected" for a particular search query. When creating a code monitor, users will be asked to specify a query as part of the trigger.
 
-Sourcegraph will run the search query periodically, and when new results for the query are detected, a trigger event is executed. In response to the trigger event, any _actions_ attached to the code monitor will be executed.
+Sourcegraph will run the search query over every new commit for the searched repositories, and when new results for the query are detected, a trigger event is emitted. In response to the trigger event, any _actions_ attached to the code monitor will be executed.
 
 **Query requirements**
 
@@ -16,9 +16,10 @@ A query used in a "When new search results are detected" trigger must be a diff 
 
 ## Actions
 
-An _action_ is executed in response to a trigger event. Currently, code monitoring supports one kind of action: sending a notification email to the owner of the code monitor.
-
-In response to a trigger event, Sourcegraph will send an email containing a link to the newly detected results to the owner of the code monitor.
+An _action_ is executed in response to a trigger event. Currently, code monitoring supports three different actions:
+- Sending a notification email to the owner of the code monitor
+- <span class="badge badge-beta">Beta</span> Sending a Slack message to a preconfigured channel
+- <span class="badge badge-beta">Beta</span> Sending a webhook event to an endpoint of your choosing
 
 ## Current flow
 
@@ -28,6 +29,6 @@ A user creates a code monitor, which consists of:
 
   * a name for the monitor
   * a trigger, which consists of a search query to run periodically,
-  * and an action, which is sending an email to the user when new results appear
+  * and an action, which is sending an email, sending a Slack message, or sending a webhook event
 
-Sourcegraph runs the query periodically. When new results are detected, an email is sent to the user that created the monitor. The email contains a link to the newly detected search results.
+Sourcegraph runs the query periodically over new commits. When new results are detected, a notification will be sent with the configured action. It will either contain a link to the search that provided new results, or if the "Include results" setting is enabled, it will include the result contents.

--- a/doc/code_monitoring/explanations/core_concepts.md
+++ b/doc/code_monitoring/explanations/core_concepts.md
@@ -17,9 +17,10 @@ A query used in a "When new search results are detected" trigger must be a diff 
 ## Actions
 
 An _action_ is executed in response to a trigger event. Currently, code monitoring supports three different actions:
-- Sending a notification email to the owner of the code monitor
-- <span class="badge badge-beta">Beta</span> Sending a Slack message to a preconfigured channel
-- <span class="badge badge-beta">Beta</span> Sending a webhook event to an endpoint of your choosing
+
+* Sending a notification email to the owner of the code monitor
+* <span class="badge badge-beta">Beta</span> Sending a Slack message to a preconfigured channel
+* <span class="badge badge-beta">Beta</span> Sending a webhook event to an endpoint of your choosing
 
 ## Current flow
 


### PR DESCRIPTION
This updates some documentation associated with the release of repo-aware monitors and webhooks.

Stacked on https://github.com/sourcegraph/sourcegraph/pull/37037

## Test plan

Checked locally that it looks right.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-cc-code-monitoring-docs.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-qkrhzjmibz.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
