### PR TITLE
dev/sg: fix asdf setup when plugin already added

### DIFF
--- a/dev/sg/dependencies/helpers.go
+++ b/dev/sg/dependencies/helpers.go
@@ -364,3 +364,11 @@ func check1password() check.CheckFunc {
 		check.WrapErrMessage(check.InPath("op"), "The 1password CLI, 'op', is required"),
 		check.CommandOutputContains("op account list", "team-sourcegraph.1password.com"))
 }
+
+func forceASDFPluginAdd(ctx context.Context, plugin string, source string) error {
+	err := usershell.Run(ctx, "asdf plugin-add", plugin, source).Wait()
+	if strings.Contains(err.Error(), "already added") {
+		return nil
+	}
+	return err
+}

--- a/dev/sg/dependencies/helpers.go
+++ b/dev/sg/dependencies/helpers.go
@@ -367,7 +367,7 @@ func check1password() check.CheckFunc {
 
 func forceASDFPluginAdd(ctx context.Context, plugin string, source string) error {
 	err := usershell.Run(ctx, "asdf plugin-add", plugin, source).Wait()
-	if strings.Contains(err.Error(), "already added") {
+	if err != nil && strings.Contains(err.Error(), "already added") {
 		return nil
 	}
 	return err

--- a/dev/sg/dependencies/mac.go
+++ b/dev/sg/dependencies/mac.go
@@ -121,6 +121,12 @@ var Mac = []category{
 					).Wait()
 				},
 			},
+			{
+				Name:        "gpg",
+				Description: "Required for yarn installation.",
+				Check:       checkAction(check.InPath("gpg")),
+				Fix:         cmdFix("brew install gpg"),
+			},
 		},
 	},
 	categoryCloneRepositories(),
@@ -131,36 +137,45 @@ var Mac = []category{
 			{
 				Name:  "go",
 				Check: checkGoVersion,
-				Fix: cmdFixes(
-					"asdf plugin-add golang https://github.com/kennyp/asdf-golang.git",
-					"asdf install golang",
-				),
+				Fix: func(ctx context.Context, cio check.IO, args CheckArgs) error {
+					if err := forceASDFPluginAdd(ctx, "golang", "https://github.com/kennyp/asdf-golang.git"); err != nil {
+						return err
+					}
+					return root.Run(usershell.Command(ctx, "asdf install golang")).StreamLines(cio.Verbose)
+				},
 			},
 			{
 				Name:  "yarn",
 				Check: checkYarnVersion,
-				Fix: cmdFixes(
-					"brew install gpg",
-					"asdf plugin-add yarn",
-					"asdf install yarn",
-				),
+				Fix: func(ctx context.Context, cio check.IO, args CheckArgs) error {
+					if err := forceASDFPluginAdd(ctx, "yarn", ""); err != nil {
+						return err
+					}
+					return root.Run(usershell.Command(ctx, "asdf install yarn")).StreamLines(cio.Verbose)
+				},
 			},
 			{
 				Name:  "node",
 				Check: checkNodeVersion,
-				Fix: cmdFixes(
-					"asdf plugin add nodejs https://github.com/asdf-vm/asdf-nodejs.git",
-					`grep -s "legacy_version_file = yes" ~/.asdfrc >/dev/null || echo 'legacy_version_file = yes' >> ~/.asdfrc`,
-					"asdf install nodejs",
-				),
+				Fix: func(ctx context.Context, cio check.IO, args CheckArgs) error {
+					if err := forceASDFPluginAdd(ctx, "nodejs", "https://github.com/asdf-vm/asdf-nodejs.git"); err != nil {
+						return err
+					}
+					return cmdFixes(
+						`grep -s "legacy_version_file = yes" ~/.asdfrc >/dev/null || echo 'legacy_version_file = yes' >> ~/.asdfrc`,
+						"asdf install nodejs",
+					)(ctx, cio, args)
+				},
 			},
 			{
 				Name:  "rust",
 				Check: checkRustVersion,
-				Fix: cmdFixes(
-					"asdf plugin-add rust https://github.com/asdf-community/asdf-rust.git",
-					"asdf install rust",
-				),
+				Fix: func(ctx context.Context, cio check.IO, args CheckArgs) error {
+					if err := forceASDFPluginAdd(ctx, "rust", "https://github.com/asdf-community/asdf-rust.git"); err != nil {
+						return err
+					}
+					return root.Run(usershell.Command(ctx, "asdf install rust")).StreamLines(cio.Verbose)
+				},
 			},
 		},
 	},


### PR DESCRIPTION
Fixes issues like:

```
Trying my hardest to fix "Programming languages & tooling" automatically...
✱ Fixing "go"...
Plugin named golang already added
❗️ Failed to fix "go": exit status 2: Plugin named golang already added
✱ Fixing "yarn"...
Running `brew update --auto-update`...
Warning: gnupg 2.3.6 is already installed and up-to-date.
To reinstall 2.3.6, run:
  brew reinstall gnupg
updating plugin repository...HEAD is now at a1c0673 chore: format README.md
Plugin named yarn already added
❗️ Failed to fix "yarn": exit status 2: Plugin named yarn already added
✱ Fixing "node"...
Plugin named nodejs already added
❗️ Failed to fix "node": exit status 2: Plugin named nodejs already added
✱ Fixing "rust"...
Plugin named rust already added
❗️ Failed to fix "rust": exit status 2: Plugin named rust already added
❌ 3. Programming languages & tooling - Some checks are still not satisfied
❌ Programming languages & tooling: failed to fix category automatically
```

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

for @burmudar  to try 😋 