### PR TITLE
codemirror: Add support for missing Monaco props

### DIFF
--- a/client/search-ui/src/input/CodeMirrorQueryInput.tsx
+++ b/client/search-ui/src/input/CodeMirrorQueryInput.tsx
@@ -39,7 +39,7 @@ import { toHover } from '@sourcegraph/shared/src/search/query/hover'
 import { createCancelableFetchSuggestions } from '@sourcegraph/shared/src/search/query/providers'
 import { Filter } from '@sourcegraph/shared/src/search/query/token'
 import { appendContextFilter } from '@sourcegraph/shared/src/search/query/transformer'
-import { fetchStreamSuggestions } from '@sourcegraph/shared/src/search/suggestions'
+import { fetchStreamSuggestions as defaultFetchStreamSuggestions } from '@sourcegraph/shared/src/search/suggestions'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
 import { isInputElement } from '@sourcegraph/shared/src/util/dom'
 
@@ -68,6 +68,7 @@ export const CodeMirrorMonacoFacade: React.FunctionComponent<React.PropsWithChil
     onChange,
     onSubmit,
     autoFocus,
+    onFocus,
     onBlur,
     isSourcegraphDotCom,
     globbing,
@@ -80,6 +81,15 @@ export const CodeMirrorMonacoFacade: React.FunctionComponent<React.PropsWithChil
     placeholder,
     editorOptions,
     ariaLabel = 'Search query',
+    // Used by the VSCode extension (which doesn't use this component directly,
+    // but added for future compatibility)
+    fetchStreamSuggestions = defaultFetchStreamSuggestions,
+    onCompletionItemSelected,
+    onSuggestionsInitialized,
+    // Not supported:
+    // editorClassName: This only seems to be used by MonacoField to position
+    // placeholder text properly. CodeMirror has built-in support for
+    // placeholders.
 }) => {
     const value = preventNewLine ? queryState.query.replace(replacePattern, '') : queryState.query
     // We use both, state and a ref, for the editor instance because we need to
@@ -96,6 +106,9 @@ export const CodeMirrorMonacoFacade: React.FunctionComponent<React.PropsWithChil
             setEditor(editor)
             editorReference.current = editor
             onEditorCreated?.(editor)
+            onSuggestionsInitialized?.({
+                trigger: () => startCompletion(editor),
+            })
         },
         [editorReference, onEditorCreated]
     )
@@ -111,7 +124,7 @@ export const CodeMirrorMonacoFacade: React.FunctionComponent<React.PropsWithChil
                     isSourcegraphDotCom,
                 })
             ),
-        [selectedSearchContextSpec, globbing, isSourcegraphDotCom]
+        [selectedSearchContextSpec, globbing, isSourcegraphDotCom, fetchStreamSuggestions]
     )
 
     const extensions = useMemo(() => {
@@ -126,8 +139,20 @@ export const CodeMirrorMonacoFacade: React.FunctionComponent<React.PropsWithChil
                         changeSource: QueryChangeSource.userInput,
                     })
                 }
-                if (onBlur && update.focusChanged && !update.view.hasFocus) {
-                    onBlur()
+                if (update.focusChanged) {
+                    if (onFocus && update.view.hasFocus) {
+                        onFocus()
+                    }
+                    if (onBlur && !update.view.hasFocus) {
+                        onBlur()
+                    }
+                }
+                // See https://codemirror.net/docs/ref/#state.Transaction^userEvent
+                if (
+                    onCompletionItemSelected &&
+                    update.transactions.some(transaction => transaction.isUserEvent('input.complete'))
+                ) {
+                    onCompletionItemSelected()
                 }
             }),
             autocompletion,
@@ -159,9 +184,11 @@ export const CodeMirrorMonacoFacade: React.FunctionComponent<React.PropsWithChil
     }, [
         ariaLabel,
         autocompletion,
+        onFocus,
         onBlur,
         onChange,
         onHandleFuzzyFinder,
+        onCompletionItemSelected,
         hasSubmitHandler,
         placeholder,
         preventNewLine,

--- a/client/search-ui/src/input/CodeMirrorQueryInput.tsx
+++ b/client/search-ui/src/input/CodeMirrorQueryInput.tsx
@@ -85,7 +85,6 @@ export const CodeMirrorMonacoFacade: React.FunctionComponent<React.PropsWithChil
     // but added for future compatibility)
     fetchStreamSuggestions = defaultFetchStreamSuggestions,
     onCompletionItemSelected,
-    onSuggestionsInitialized,
     // Not supported:
     // editorClassName: This only seems to be used by MonacoField to position
     // placeholder text properly. CodeMirror has built-in support for
@@ -105,9 +104,13 @@ export const CodeMirrorMonacoFacade: React.FunctionComponent<React.PropsWithChil
         (editor: EditorView) => {
             setEditor(editor)
             editorReference.current = editor
-            onEditorCreated?.(editor)
-            onSuggestionsInitialized?.({
-                trigger: () => startCompletion(editor),
+            onEditorCreated?.({
+                focus() {
+                    editor.focus()
+                },
+                showSuggestions() {
+                    startCompletion(editor)
+                },
             })
         },
         [editorReference, onEditorCreated]

--- a/client/search-ui/src/input/LazyMonacoQueryInput.tsx
+++ b/client/search-ui/src/input/LazyMonacoQueryInput.tsx
@@ -15,6 +15,7 @@ import styles from './LazyMonacoQueryInput.module.scss'
  */
 export interface IEditor {
     focus(): void
+    showSuggestions(): void
 }
 
 const MonacoQueryInput = lazyComponent(() => import('./MonacoQueryInput'), 'MonacoQueryInput')

--- a/client/search-ui/src/input/MonacoQueryInput.tsx
+++ b/client/search-ui/src/input/MonacoQueryInput.tsx
@@ -70,7 +70,6 @@ export interface MonacoQueryInputProps
     onFocus?: () => void
     onBlur?: () => void
     onCompletionItemSelected?: () => void
-    onSuggestionsInitialized?: (actions: { trigger: () => void }) => void
     onEditorCreated?: (editor: IEditor) => void
     fetchStreamSuggestions?: typeof defaultFetchStreamSuggestions // Alternate implementation is used in the VS Code extension.
     autoFocus?: boolean
@@ -160,7 +159,6 @@ export const MonacoQueryInput: React.FunctionComponent<React.PropsWithChildren<M
     onBlur,
     onChange,
     onSubmit = noop,
-    onSuggestionsInitialized,
     onCompletionItemSelected,
     fetchStreamSuggestions = defaultFetchStreamSuggestions,
     autoFocus,
@@ -191,7 +189,14 @@ export const MonacoQueryInput: React.FunctionComponent<React.PropsWithChildren<M
             editor.getDomNode()?.setAttribute('aria-label', ariaLabel)
 
             setEditor(editor)
-            onEditorCreatedCallback?.(editor)
+            onEditorCreatedCallback?.({
+                focus() {
+                    editor.focus()
+                },
+                showSuggestions() {
+                    editor.trigger('triggerSuggestions', 'editor.action.triggerSuggest', {})
+                },
+            })
         },
         [setEditor, onEditorCreatedCallback, ariaLabel]
     )
@@ -224,15 +229,6 @@ export const MonacoQueryInput: React.FunctionComponent<React.PropsWithChildren<M
     })
 
     useQueryDiagnostics(editor, { patternType, interpretComments })
-
-    // Register suggestions handle
-    useEffect(() => {
-        if (editor) {
-            onSuggestionsInitialized?.({
-                trigger: () => editor.trigger('triggerSuggestions', 'editor.action.triggerSuggest', {}),
-            })
-        }
-    }, [editor, onSuggestionsInitialized])
 
     // Register onCompletionSelected handler
     useEffect(() => {

--- a/client/search-ui/src/input/SearchBox.tsx
+++ b/client/search-ui/src/input/SearchBox.tsx
@@ -36,7 +36,6 @@ export interface SearchBoxProps
     onFocus?: () => void
     fetchStreamSuggestions?: typeof defaultFetchStreamSuggestions // Alternate implementation is used in the VS Code extension.
     onCompletionItemSelected?: () => void
-    onSuggestionsInitialized?: (actions: { trigger: () => void }) => void
     autoFocus?: boolean
     keyboardShortcutForFocus?: KeyboardShortcut
     className?: string

--- a/client/web/src/search/input/SearchOnboardingTour.tsx
+++ b/client/web/src/search/input/SearchOnboardingTour.tsx
@@ -11,7 +11,7 @@ import Tour from 'shepherd.js/src/types/tour'
 
 import { isMacPlatform } from '@sourcegraph/common'
 import { QueryState } from '@sourcegraph/search'
-import { MonacoQueryInputProps } from '@sourcegraph/search-ui'
+import { IEditor, MonacoQueryInputProps } from '@sourcegraph/search-ui'
 import { ALL_LANGUAGES } from '@sourcegraph/shared/src/search/query/languageFilter'
 import { scanSearchQuery } from '@sourcegraph/shared/src/search/query/scanner'
 import { Token } from '@sourcegraph/shared/src/search/query/token'
@@ -342,7 +342,7 @@ interface UseSearchOnboardingTourOptions {
  * The subset of MonacoQueryInput props should be passed down to the input component.
  */
 interface UseSearchOnboardingTourReturnValue
-    extends Pick<MonacoQueryInputProps, 'onCompletionItemSelected' | 'onSuggestionsInitialized' | 'onFocus'> {
+    extends Pick<MonacoQueryInputProps, 'onCompletionItemSelected' | 'onEditorCreated' | 'onFocus'> {
     /**
      * Whether the query input should be focused by default
      * (`false` on the search homepage when the tour is active).
@@ -412,7 +412,7 @@ export const useSearchOnboardingTour = ({
     }, [tour, shouldShowTour])
 
     // A handle allowing to trigger display of the MonacoQueryInput suggestions widget.
-    const [suggestions, onSuggestionsInitialized] = useState<{ trigger: () => void }>()
+    const [editor, setEditor] = useState<IEditor | null>(null)
 
     // On query or step changes, advance the Tour if appropriate.
     const currentStep = useCurrentStep(tour)
@@ -425,13 +425,13 @@ export const useSearchOnboardingTour = ({
             return
         }
         if (shouldTriggerSuggestions(currentStep, queryTokens)) {
-            suggestions?.trigger()
+            editor?.showSuggestions()
         } else if (shouldAdvanceLangOrRepoStep(currentStep, queryTokens)) {
             tour.show('add-query-term')
         } else if (shouldShowSubmitSearch(currentStep, queryTokens)) {
             tour.show('submit-search')
         }
-    }, [suggestions, queryTokens, tour, currentStep])
+    }, [editor, queryTokens, tour, currentStep])
 
     // When a completion item is selected,
     // advance the repo or lang step if appropriate.
@@ -444,7 +444,7 @@ export const useSearchOnboardingTour = ({
     return {
         onCompletionItemSelected,
         onFocus,
-        onSuggestionsInitialized,
+        onEditorCreated: setEditor,
         shouldFocusQueryInput: !shouldShowTour,
     }
 }


### PR DESCRIPTION
Closes #36524

This PR adds support for optional props defined in the Monaco editor interface but not considered in the CodeMirror implementation (see issue for list).

Some notes:

- `editorClassName` is not supported because it appears to be used for handling placeholder values only, which CodeMirror handles out of the box.
- I refactored how `onSuggestionsInitialized` works. Instead of passing this as a separate function, this is now a method on the `IEditor` interface provided to the callback of the `onEditorCreated` prop. Having a single interface for directly controlling editor behavior seemed cleaner to me.


## Test plan

`onFocus`, `onCompletionItemSelected` and `onSuggestionInitiated` (now `editor.showSuggestions()`) are all used by the onboarding tour. The existing integration test passes for Monaco (verifies that `onSuggestionsInitialized` migration works) and I was able to get most of the onboarding tour to work with CodeMirror (see also the [Percy build of this PR](https://percy.io/Sourcegraph/Sourcegraph/builds/18816174/changed/1055767409?browser=chrome&browser_ids=23&subcategories=unreviewed%2Cchanges_requested&viewLayout=side-by-side&viewMode=new&width=1920&widths=1920), but the integration test seem to need some tweaking to make it work properly with CodeMirror so I'll do this in a separate PR.

## App preview:

- [Web](https://sg-web-fkling-codemirror-props.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-cfrxlzsygt.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

