### PR TITLE
migration: Improve drift schema fetching

### DIFF
--- a/cmd/migrator/main.go
+++ b/cmd/migrator/main.go
@@ -3,11 +3,8 @@ package main
 import (
 	"context"
 	"database/sql"
-	"encoding/json"
 	"fmt"
-	"net/http"
 	"os"
-	"regexp"
 
 	"github.com/opentracing/opentracing-go"
 	"github.com/prometheus/client_golang/prometheus"
@@ -17,7 +14,6 @@ import (
 
 	connections "github.com/sourcegraph/sourcegraph/internal/database/connections/live"
 	"github.com/sourcegraph/sourcegraph/internal/database/migration/cliutil"
-	descriptions "github.com/sourcegraph/sourcegraph/internal/database/migration/schemas"
 	"github.com/sourcegraph/sourcegraph/internal/database/migration/store"
 	"github.com/sourcegraph/sourcegraph/internal/database/postgresdsn"
 	"github.com/sourcegraph/sourcegraph/internal/env"
@@ -25,7 +21,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/internal/version"
-	"github.com/sourcegraph/sourcegraph/lib/errors"
 	"github.com/sourcegraph/sourcegraph/lib/output"
 )
 
@@ -61,28 +56,6 @@ func mainErr(ctx context.Context, args []string) error {
 
 	runnerFactory := newRunnerFactory()
 	outputFactory := func() *output.Output { return out }
-	expectedSchemaFactory := func(filename, version string) (descriptions.SchemaDescription, error) {
-		if !regexp.MustCompile(`(^v\d+\.\d+\.\d+$)|(^[A-Fa-f0-9]{40}$)`).MatchString(version) {
-			return descriptions.SchemaDescription{}, errors.Newf("failed to parse %q - expected a version of the form `vX.Y.Z` or a 40-character commit hash", version)
-		}
-
-		resp, err := http.Get(fmt.Sprintf("https://raw.githubusercontent.com/sourcegraph/sourcegraph/%s/%s", version, filename))
-		if err != nil {
-			return descriptions.SchemaDescription{}, err
-		}
-		defer resp.Body.Close()
-
-		if resp.StatusCode != http.StatusOK {
-			return descriptions.SchemaDescription{}, errors.Newf("unexpected status %d from github", resp.StatusCode)
-		}
-
-		var schemaDescription descriptions.SchemaDescription
-		if err := json.NewDecoder(resp.Body).Decode(&schemaDescription); err != nil {
-			return descriptions.SchemaDescription{}, err
-		}
-
-		return schemaDescription, nil
-	}
 
 	command := &cli.App{
 		Name:   appName,
@@ -94,7 +67,7 @@ func mainErr(ctx context.Context, args []string) error {
 			cliutil.DownTo(appName, runnerFactory, outputFactory, false),
 			cliutil.Validate(appName, runnerFactory, outputFactory),
 			cliutil.Describe(appName, runnerFactory, outputFactory),
-			cliutil.Drift(appName, runnerFactory, outputFactory, expectedSchemaFactory),
+			cliutil.Drift(appName, runnerFactory, outputFactory, cliutil.GCSExpectedSchemaFactory, cliutil.GitHubExpectedSchemaFactory),
 			cliutil.AddLog(logger, appName, runnerFactory, outputFactory),
 		},
 	}

--- a/dev/sg/sg_migration.go
+++ b/dev/sg/sg_migration.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/Masterminds/semver"
 	"github.com/sourcegraph/run"
@@ -87,28 +88,13 @@ var (
 	// at compile-time in sg.
 	outputFactory = func() *output.Output { return std.Out.Output }
 
-	// expectedSchemaFactory returns the description of the given schema at the given version via
-	// the local git clone. If the version is not resolvable as a git rev-like, then an error is
-	// returned.
-	expectedSchemaFactory = func(filename, version string) (descriptions.SchemaDescription, error) {
-		ctx := context.Background()
-		output := root.Run(run.Cmd(ctx, "git", "show", fmt.Sprintf("%s^:%s", version, filename)))
-
-		var schemaDescription descriptions.SchemaDescription
-		if err := json.NewDecoder(output).Decode(&schemaDescription); err != nil {
-			return schemaDescription, err
-		}
-
-		return schemaDescription, nil
-	}
-
 	upCommand       = cliutil.Up("sg migration", makeRunner, outputFactory, true)
 	upToCommand     = cliutil.UpTo("sg migration", makeRunner, outputFactory, true)
 	undoCommand     = cliutil.Undo("sg migration", makeRunner, outputFactory, true)
 	downToCommand   = cliutil.DownTo("sg migration", makeRunner, outputFactory, true)
 	validateCommand = cliutil.Validate("sg migration", makeRunner, outputFactory)
 	describeCommand = cliutil.Describe("sg migration", makeRunner, outputFactory)
-	driftCommand    = cliutil.Drift("sg migration", makeRunner, outputFactory, expectedSchemaFactory)
+	driftCommand    = cliutil.Drift("sg migration", makeRunner, outputFactory, cliutil.GCSExpectedSchemaFactory, localGitExpectedSchemaFactory)
 	addLogCommand   = cliutil.AddLog(logger, "sg migration", makeRunner, outputFactory)
 
 	leavesCommand = &cli.Command{
@@ -209,6 +195,47 @@ func makeRunner(ctx context.Context, schemaNames []string) (cliutil.Runner, erro
 	return cliutil.NewShim(r), nil
 }
 
+// localGitExpectedSchemaFactory returns the description of the given schema at the given version via the
+// (assumed) local git clone. If the version is not resolvable as a git rev-like, or if the file does not
+// exist at that revision, then a false valued-flag is returned. All other failures are reported as errors.
+func localGitExpectedSchemaFactory(filename, version string) (schemaDescription descriptions.SchemaDescription, _ bool, _ error) {
+	ctx := context.Background()
+	output := root.Run(run.Cmd(ctx, "git", "show", fmt.Sprintf("%s^:%s", version, filename)))
+
+	if err := output.Wait(); err != nil {
+		// See if there is an error indicating a missing object, but no other problems
+		return descriptions.SchemaDescription{}, false, filterLocalGitErrors(filename, version, err)
+	}
+
+	if err := json.NewDecoder(output).Decode(&schemaDescription); err != nil {
+		return descriptions.SchemaDescription{}, false, err
+	}
+
+	return schemaDescription, true, nil
+}
+
+func filterLocalGitErrors(filename, version string, err error) error {
+	if err == nil {
+		return nil
+	}
+
+	missingMessages := []string{
+		// unknown revision
+		fmt.Sprintf("fatal: invalid object name '%s^'", version),
+
+		// path unknown to the revision (regardless of repo state)
+		fmt.Sprintf("fatal: path '%s' does not exist in '%s^'", filename, version),
+		fmt.Sprintf("fatal: path '%s' exists on disk, but not in '%s^'", filename, version),
+	}
+	for _, missingMessage := range missingMessages {
+		if strings.Contains(err.Error(), missingMessage) {
+			return nil
+		}
+	}
+
+	return err
+}
+
 func getFilesystemSchemas() (schemas []*schemas.Schema, errs error) {
 	for _, name := range []string{"frontend", "codeintel", "codeinsights"} {
 		schema, err := resolveSchema(name)
@@ -254,6 +281,7 @@ func addExec(ctx *cli.Context) error {
 
 	return migration.Add(database, args[0])
 }
+
 func revertExec(ctx *cli.Context) error {
 	args := ctx.Args().Slice()
 	if len(args) == 0 {

--- a/internal/database/gen.sh
+++ b/internal/database/gen.sh
@@ -40,7 +40,6 @@ else
   export CODEINSIGHTS_PGDATASOURCE="postgres://${PGUSER}:${PGPASSWORD}@${PGHOST}:${PGPORT}/sg-squasher-codeinsights"
 fi
 
-
 # Output-psql formatted schema description
 ./tmp-sg migration describe -db frontend --format=psql -force -out internal/database/schema.md
 ./tmp-sg migration describe -db codeintel --format=psql -force -out internal/database/schema.codeintel.md

--- a/internal/database/migration/cliutil/drift_schema.go
+++ b/internal/database/migration/cliutil/drift_schema.go
@@ -12,7 +12,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
-type ExpectedSchemaFactory func(repoName, version string) (descriptions.SchemaDescription, bool, error)
+type ExpectedSchemaFactory func(filename, version string) (descriptions.SchemaDescription, bool, error)
 
 // GCSExpectedSchemaFactory reads schema definitions from a public GCS bucket that contains schema definitions for
 // a version of Sourcegraph that did not yet contain the squashed schema description file in-tree. These files

--- a/internal/database/migration/cliutil/drift_schema.go
+++ b/internal/database/migration/cliutil/drift_schema.go
@@ -1,0 +1,58 @@
+package cliutil
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"regexp"
+	"strings"
+
+	descriptions "github.com/sourcegraph/sourcegraph/internal/database/migration/schemas"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+type ExpectedSchemaFactory func(repoName, version string) (descriptions.SchemaDescription, bool, error)
+
+// GCSExpectedSchemaFactory reads schema definitions from a GCS bucket that contains schema definitions for
+// a version of Sourcegraph that did not yet contain the squashed schema description file in-tree. These files
+// have been backfilled to this bucket by hand. A false-valued flag is returned if the schema does not exist
+// for this version.
+func GCSExpectedSchemaFactory(filename, version string) (schemaDescription descriptions.SchemaDescription, _ bool, _ error) {
+	return fetchSchema(fmt.Sprintf("https://storage.googleapis.com/sourcegraph-assets/migrations/drift/%s-%s", version, strings.ReplaceAll(filename, "/", "_")))
+}
+
+// GitHubExpectedSchemaFactory reads schema definitions from the sourcegraph/sourcegraph repository via the
+// GitHub raw API. A false-valued flag is returned if the schema does not exist for this version.
+func GitHubExpectedSchemaFactory(filename, version string) (descriptions.SchemaDescription, bool, error) {
+	if !regexp.MustCompile(`(^v\d+\.\d+\.\d+$)|(^[A-Fa-f0-9]{40}$)`).MatchString(version) {
+		return descriptions.SchemaDescription{}, false, errors.Newf("failed to parse %q - expected a version of the form `vX.Y.Z` or a 40-character commit hash", version)
+	}
+
+	return fetchSchema(fmt.Sprintf("https://raw.githubusercontent.com/sourcegraph/sourcegraph/%s/%s", version, filename))
+}
+
+// fetchSchema makes an HTTP GET request to the given URL and reads the schema description from the response
+// body. If the URL is well-formed but does not point to an existing file, a false-valued flag is returned.
+func fetchSchema(url string) (schemaDescription descriptions.SchemaDescription, _ bool, _ error) {
+	resp, err := http.Get(url)
+	if err != nil {
+		return descriptions.SchemaDescription{}, false, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		if resp.StatusCode == http.StatusNotFound {
+			return descriptions.SchemaDescription{}, false, nil
+		}
+
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 200))
+		return descriptions.SchemaDescription{}, false, errors.Newf("unexpected status %d from %s: %s", resp.StatusCode, url, body)
+	}
+
+	if err := json.NewDecoder(resp.Body).Decode(&schemaDescription); err != nil {
+		return descriptions.SchemaDescription{}, false, err
+	}
+
+	return schemaDescription, true, err
+}

--- a/internal/database/migration/cliutil/drift_schema.go
+++ b/internal/database/migration/cliutil/drift_schema.go
@@ -14,7 +14,7 @@ import (
 
 type ExpectedSchemaFactory func(repoName, version string) (descriptions.SchemaDescription, bool, error)
 
-// GCSExpectedSchemaFactory reads schema definitions from a GCS bucket that contains schema definitions for
+// GCSExpectedSchemaFactory reads schema definitions from a public GCS bucket that contains schema definitions for
 // a version of Sourcegraph that did not yet contain the squashed schema description file in-tree. These files
 // have been backfilled to this bucket by hand. A false-valued flag is returned if the schema does not exist
 // for this version.


### PR DESCRIPTION
This PR adds support for checking a public GCS bucket for migration descriptions so that we can support drift on older versions (the required file is only in-tree from 3.42.0 onwards). I've squashed/described each patch release between 3.38-3.41 and added these to the buckets.

## Test plan

Tested locally.