### PR TITLE
rockskip: Remember to close the ctags.Parser

### DIFF
--- a/enterprise/internal/rockskip/index.go
+++ b/enterprise/internal/rockskip/index.go
@@ -74,10 +74,11 @@ func (s *Service) Index(ctx context.Context, db database.DB, repo, givenCommit s
 		return nil
 	}
 
-	parse, err := s.createParser()
+	parser, err := s.createParser()
 	if err != nil {
 		return errors.Wrap(err, "createParser")
 	}
+	defer parser.Close()
 
 	symbolCache := lru.New(s.symbolsCacheSize)
 	pathSymbolsCache := lru.New(s.pathSymbolsCacheSize)
@@ -168,7 +169,7 @@ func (s *Service) Index(ctx context.Context, db database.DB, repo, givenCommit s
 				defer tasklog.Continue("ArchiveEach")
 
 				tasklog.Start("parse")
-				symbols, err := parse(path, contents)
+				symbols, err := parser.Parse(path, contents)
 				if err != nil {
 					return errors.Wrap(err, "parse")
 				}

--- a/enterprise/internal/rockskip/server.go
+++ b/enterprise/internal/rockskip/server.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 
 	"github.com/inconshreveable/log15"
-
+	"github.com/sourcegraph/go-ctags"
 	"github.com/sourcegraph/log"
 
 	"github.com/sourcegraph/sourcegraph/internal/database"
@@ -21,15 +21,13 @@ type Symbol struct {
 	Line   int    `json:"line"`
 }
 
-type ParseSymbolsFunc func(path string, bytes []byte) (symbols []Symbol, err error)
-
 const NULL CommitId = 0
 
 type Service struct {
 	logger               log.Logger
 	db                   *sql.DB
 	git                  Git
-	createParser         func() (ParseSymbolsFunc, error)
+	createParser         func() (ctags.Parser, error)
 	status               *ServiceStatus
 	repoUpdates          chan struct{}
 	maxRepos             int
@@ -44,7 +42,7 @@ type Service struct {
 func NewService(
 	db *sql.DB,
 	git Git,
-	createParser func() (ParseSymbolsFunc, error),
+	createParser func() (ctags.Parser, error),
 	maxConcurrentlyIndexing int,
 	maxRepos int,
 	logQueries bool,

--- a/enterprise/internal/rockskip/server_test.go
+++ b/enterprise/internal/rockskip/server_test.go
@@ -14,7 +14,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-
+	"github.com/sourcegraph/go-ctags"
 	"github.com/sourcegraph/log/logtest"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
@@ -26,20 +26,24 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
-// simpleParse converts each line into a symbol.
-func simpleParse(path string, bytes []byte) ([]Symbol, error) {
-	symbols := []Symbol{}
+// mockParser converts each line to a symbol.
+type mockParser struct{}
+
+func (mockParser) Parse(path string, bytes []byte) ([]*ctags.Entry, error) {
+	symbols := []*ctags.Entry{}
 
 	for _, line := range strings.Split(string(bytes), "\n") {
 		if line == "" {
 			continue
 		}
 
-		symbols = append(symbols, Symbol{Name: line})
+		symbols = append(symbols, &ctags.Entry{Name: line})
 	}
 
 	return symbols, nil
 }
+
+func (mockParser) Close() {}
 
 func TestIndex(t *testing.T) {
 	fatalIfError := func(err error, message string) {
@@ -86,7 +90,7 @@ func TestIndex(t *testing.T) {
 	add := func(filename string, contents string) {
 		fatalIfError(os.WriteFile(path.Join(gitDir, filename), []byte(contents), 0644), "os.WriteFile")
 		gitRun("add", filename)
-		symbols, err := simpleParse(filename, []byte(contents))
+		symbols, err := mockParser{}.Parse(filename, []byte(contents))
 		fatalIfError(err, "simpleParse")
 		state[filename] = []string{}
 		for _, symbol := range symbols {
@@ -108,7 +112,7 @@ func TestIndex(t *testing.T) {
 	db := dbtest.NewDB(logger, t)
 	defer db.Close()
 
-	createParser := func() (ParseSymbolsFunc, error) { return simpleParse, nil }
+	createParser := func() (ctags.Parser, error) { return mockParser{}, nil }
 
 	service, err := NewService(db, git, createParser, 1, 1, false, 1, 1, 1)
 	fatalIfError(err, "NewService")

--- a/enterprise/internal/rockskip/server_test.go
+++ b/enterprise/internal/rockskip/server_test.go
@@ -32,12 +32,12 @@ type mockParser struct{}
 func (mockParser) Parse(path string, bytes []byte) ([]*ctags.Entry, error) {
 	symbols := []*ctags.Entry{}
 
-	for _, line := range strings.Split(string(bytes), "\n") {
+	for lineNumber, line := range strings.Split(string(bytes), "\n") {
 		if line == "" {
 			continue
 		}
 
-		symbols = append(symbols, &ctags.Entry{Name: line})
+		symbols = append(symbols, &ctags.Entry{Name: line, Line: lineNumber + 1})
 	}
 
 	return symbols, nil


### PR DESCRIPTION
I forgot to call `parser.Close()`, so ctags processes would pile up and eventually run OOM with Rockskip.

The problem still won't be fixed until https://github.com/sourcegraph/go-ctags/pull/9 gets included in sourcegraph/sourcegraph.

## Test plan

Ran locally
