### PR TITLE
insights: nice error message when attempting to live preview empty repos

### DIFF
--- a/enterprise/internal/insights/resolvers/live_preview_resolvers.go
+++ b/enterprise/internal/insights/resolvers/live_preview_resolvers.go
@@ -76,10 +76,17 @@ func (r *Resolver) SearchInsightPreview(ctx context.Context, args graphqlbackend
 		resolvers = append(resolvers, &searchInsightLivePreviewSeriesResolver{series: &generatedSeries[i]})
 	}
 	if !foundData {
-		return nil, errors.New("Data for these repositories not found")
+		return nil, errors.Newf("Data for %s not found", pluralize("this repository", "these repositories", len(repos)))
 	}
 
 	return resolvers, nil
+}
+
+func pluralize(singular, plural string, n int) string {
+	if n == 1 {
+		return singular
+	}
+	return plural
 }
 
 type searchInsightLivePreviewSeriesResolver struct {

--- a/enterprise/internal/insights/resolvers/live_preview_resolvers.go
+++ b/enterprise/internal/insights/resolvers/live_preview_resolvers.go
@@ -70,8 +70,13 @@ func (r *Resolver) SearchInsightPreview(ctx context.Context, args graphqlbackend
 		generatedSeries = append(generatedSeries, series...)
 	}
 
+	foundData := false
 	for i := range generatedSeries {
+		foundData = foundData || len(generatedSeries[i].Points) > 0
 		resolvers = append(resolvers, &searchInsightLivePreviewSeriesResolver{series: &generatedSeries[i]})
+	}
+	if !foundData {
+		return nil, errors.New("Data for these repositories not found")
 	}
 
 	return resolvers, nil


### PR DESCRIPTION
Return the error message that the UI previously showed when repos where empty during live preview.  Error will only display if __all__ repos are empty.  

resolves https://github.com/sourcegraph/sourcegraph/issues/35450 for search insights.  Opened https://github.com/sourcegraph/sourcegraph/issues/37047 for language stats.


## Test plan
<img width="976" alt="Screen Shot 2022-06-10 at 3 16 19 PM" src="https://user-images.githubusercontent.com/6098507/173135207-234ef20e-6656-4587-94c9-4eb7e0c869cd.png">
<img width="985" alt="Screen Shot 2022-06-10 at 3 17 15 PM" src="https://user-images.githubusercontent.com/6098507/173135208-c1019a7f-172e-4eb9-9707-5db14de0f897.png">

