### PR TITLE
batches: Add Mount to YAML Reference Docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Extensions: Added `enableExtensionsDecorationsColumnView` user setting as [experimental feature](https://docs.sourcegraph.com/admin/beta_and_experimental_features#experimental-features). When enabled decorations of the extensions supporting column decorations (currently only git-extras extension does: [sourcegraph-git-extras/pull/276](https://github.com/sourcegraph/sourcegraph-git-extras/pull/276)) will be displayed in separate columns on the blob page. [#36007](https://github.com/sourcegraph/sourcegraph/pull/36007)
 - SAML authentication provider has a new site configuration `allowGroups` that allows filtering users by group membership. [#36555](https://github.com/sourcegraph/sourcegraph/pull/36555)
 - A new [templating](https://docs.sourcegraph.com/campaigns/references/batch_spec_templating) variable, `batch_change_link` has been added for more control over where the "Created by Sourcegraph batch change ..." message appears in the published changeset description. [#491](https://github.com/sourcegraph/sourcegraph/pull/35319)
+- Batch Change Specs can now mount local files in a Docker Container when using [Sourcegraph CLI](https://docs.sourcegraph.com/cli). [#31790](https://github.com/sourcegraph/sourcegraph/issues/31790)
 
 ### Changed
 

--- a/doc/batch_changes/references/batch_spec_yaml_reference.md
+++ b/doc/batch_changes/references/batch_spec_yaml_reference.md
@@ -418,6 +418,60 @@ steps:
     container: golang
 ```
 
+## [`steps.mount`](#steps-mount)
+
+> NOTE: This feature is only available for <a href="https://github.com/sourcegraph/src-cli">Sourcegraph CLI</a> 3.xx.x and later.
+
+Mounts a local path to a path in a Docker container. Mounted paths are accessible to the step's `run` command.
+
+A `path` can point to a file or a directory. The `path` can be an absolute path or a relative path. Regardless if the 
+path is absolute or relative, the path must be within the same directory as the batch spec that is being ran (the batch 
+spec directory is considered the "working directory").
+
+### Examples
+
+```yaml
+# Mount a Python script and run the script
+steps:
+  run: python /tmp/some-script.py # execute the script located at the mountpoint
+  container: python:latest
+  mount:
+    - path: ./some-script.py # or absolute path /my/local/path/some-script.py
+      mountpoint: /tmp/some-script.py
+```
+
+```yaml
+# Mount a binary and run the binary
+steps:
+  run: /tmp/some-binary # execute the binary located at the mountpoint
+  container: alpine:latest
+  mount:
+    - path: ./some-binary # or absolute path /my/local/path/some-binary
+      mountpoint: /tmp/some-binary
+```
+
+```yaml
+# Mount a directory containing scripts and run a script from the directory
+steps:
+  run: python /tmp/scripts/some-script.py
+  container: python:latest
+  mount:
+    - path: ./scripts # or absolute path /my/local/path/scripts
+      mountpoint: /tmp/scripts
+```
+
+```yaml
+# Mount a Python script and a directory with supporting files for the script and run the script
+steps:
+  run: python /tmp/some-script.py
+  container: python:latest
+  mount:
+    - path: ./some-script.py # or absolute path /my/local/path/some-script.py
+      mountpoint: /tmp/some-script.py
+    - path: ./supporting-files # or absolute path /my/local/path/supporting-files
+      mountpoint: /tmp/supporting-files
+```
+
 ## [`importChangesets`](#importchangesets)
 
 An array describing which already-existing changesets should be imported from the code host into the batch change.


### PR DESCRIPTION
Part of #31790.

Update the Batch Spec YAML Reference Docs with the `mount` field. Included examples and a note about the feature.

## Test plan

Ran the Docs site locally to validate the changes.