### PR TITLE
Backend: make `database.NewDB` take a `*sql.DB`

### DIFF
--- a/cmd/frontend/graphqlbackend/repository_text_search_index_test.go
+++ b/cmd/frontend/graphqlbackend/repository_text_search_index_test.go
@@ -53,7 +53,7 @@ func TestRetrievingAndDeduplicatingIndexedRefs(t *testing.T) {
 	defer git.ResetMocks()
 
 	repoIndexResolver := &repositoryTextSearchIndexResolver{
-		repo:   NewRepositoryResolver(database.NewDB(db), &types.Repo{Name: "alice/repo"}),
+		repo:   NewRepositoryResolver(db, &types.Repo{Name: "alice/repo"}),
 		client: &repoListerMock{},
 	}
 	refs, err := repoIndexResolver.Refs(context.Background())

--- a/cmd/frontend/graphqlbackend/webhook_logs.go
+++ b/cmd/frontend/graphqlbackend/webhook_logs.go
@@ -130,7 +130,7 @@ func (r *webhookLogConnectionResolver) Nodes(ctx context.Context) ([]*webhookLog
 	}
 
 	nodes := make([]*webhookLogResolver, len(logs))
-	db := database.NewDB(r.store.Handle().DB())
+	db := database.NewDBWith(r.store)
 	for i, log := range logs {
 		nodes[i] = &webhookLogResolver{
 			db:  db,

--- a/cmd/repo-updater/repoupdater/server.go
+++ b/cmd/repo-updater/repoupdater/server.go
@@ -203,7 +203,7 @@ func (s *Server) handleExternalServiceSync(w http.ResponseWriter, r *http.Reques
 
 	var sourcer repos.Sourcer
 	if sourcer = s.Sourcer; sourcer == nil {
-		db := database.NewDB(s.Handle().DB())
+		db := database.NewDBWith(s)
 		depsSvc := livedependencies.GetService(db, nil)
 		sourcer = repos.NewSourcer(db, httpcli.ExternalClientFactory, repos.WithDependenciesService(depsSvc))
 	}

--- a/enterprise/cmd/frontend/internal/batches/resolvers/batch_change_connection_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/batch_change_connection_test.go
@@ -76,7 +76,7 @@ func TestBatchChangeConnectionResolver(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	s, err := graphqlbackend.NewSchema(database.NewDB(db), &Resolver{store: cstore}, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	s, err := graphqlbackend.NewSchema(db, &Resolver{store: cstore}, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -187,7 +187,7 @@ func TestBatchChangesListing(t *testing.T) {
 	store := store.New(db, &observation.TestContext, nil)
 
 	r := &Resolver{store: store}
-	s, err := graphqlbackend.NewSchema(database.NewDB(db), r, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	s, err := graphqlbackend.NewSchema(db, r, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/cmd/frontend/internal/batches/resolvers/batch_change_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/batch_change_test.go
@@ -59,7 +59,7 @@ func TestBatchChangeResolver(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	s, err := graphqlbackend.NewSchema(database.NewDB(db), &Resolver{store: cstore}, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	s, err := graphqlbackend.NewSchema(db, &Resolver{store: cstore}, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -153,7 +153,7 @@ func TestBatchChangeResolver_BatchSpecs(t *testing.T) {
 	clock := func() time.Time { return now }
 	cstore := store.NewWithClock(db, &observation.TestContext, nil, clock)
 
-	s, err := graphqlbackend.NewSchema(database.NewDB(db), &Resolver{store: cstore}, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	s, err := graphqlbackend.NewSchema(db, &Resolver{store: cstore}, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec_test.go
@@ -84,7 +84,7 @@ func TestBatchSpecResolver(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	s, err := graphqlbackend.NewSchema(database.NewDB(db), &Resolver{store: cstore}, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	s, err := graphqlbackend.NewSchema(db, &Resolver{store: cstore}, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -287,7 +287,7 @@ func TestBatchSpecResolver_BatchSpecCreatedFromRaw(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	s, err := graphqlbackend.NewSchema(database.NewDB(db), &Resolver{store: bstore}, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	s, err := graphqlbackend.NewSchema(db, &Resolver{store: bstore}, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec_workspace_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec_workspace_test.go
@@ -75,7 +75,7 @@ func TestBatchSpecWorkspaceResolver(t *testing.T) {
 	}
 	apiID := string(marshalBatchSpecWorkspaceID(workspace.ID))
 
-	s, err := graphqlbackend.NewSchema(database.NewDB(db), &Resolver{store: bstore}, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	s, err := graphqlbackend.NewSchema(db, &Resolver{store: bstore}, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/cmd/frontend/internal/batches/resolvers/bulk_operation_connection_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/bulk_operation_connection_test.go
@@ -81,7 +81,7 @@ func TestBulkOperationConnectionResolver(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	s, err := graphqlbackend.NewSchema(database.NewDB(db), New(cstore), nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	s, err := graphqlbackend.NewSchema(db, New(cstore), nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/cmd/frontend/internal/batches/resolvers/bulk_operation_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/bulk_operation_test.go
@@ -99,7 +99,7 @@ func TestBulkOperationResolver(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	s, err := graphqlbackend.NewSchema(database.NewDB(db), New(cstore), nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	s, err := graphqlbackend.NewSchema(db, New(cstore), nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/cmd/frontend/internal/batches/resolvers/changeset_apply_preview_connection_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/changeset_apply_preview_connection_test.go
@@ -74,7 +74,7 @@ func TestChangesetApplyPreviewConnectionResolver(t *testing.T) {
 		changesetSpecs = append(changesetSpecs, s)
 	}
 
-	s, err := graphqlbackend.NewSchema(database.NewDB(db), &Resolver{store: cstore}, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	s, err := graphqlbackend.NewSchema(db, &Resolver{store: cstore}, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/cmd/frontend/internal/batches/resolvers/changeset_apply_preview_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/changeset_apply_preview_test.go
@@ -106,7 +106,7 @@ func TestChangesetApplyPreviewResolver(t *testing.T) {
 		OwnedByBatchChange: batchChange.ID,
 	})
 
-	s, err := graphqlbackend.NewSchema(database.NewDB(db), &Resolver{store: cstore}, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	s, err := graphqlbackend.NewSchema(db, &Resolver{store: cstore}, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -270,7 +270,7 @@ func TestChangesetApplyPreviewResolverWithPublicationStates(t *testing.T) {
 	repo := newGitHubTestRepo("github.com/sourcegraph/test", newGitHubExternalService(t, esStore))
 	require.Nil(t, repoStore.Create(ctx, repo))
 
-	s, err := graphqlbackend.NewSchema(database.NewDB(db), &Resolver{store: bstore}, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	s, err := graphqlbackend.NewSchema(db, &Resolver{store: bstore}, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	require.Nil(t, err)
 
 	// To make it easier to assert against the operations in a preview node,

--- a/enterprise/cmd/frontend/internal/batches/resolvers/changeset_connection_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/changeset_connection_test.go
@@ -109,7 +109,7 @@ func TestChangesetConnectionResolver(t *testing.T) {
 	addChangeset(t, ctx, cstore, changeset3, batchChange.ID)
 	addChangeset(t, ctx, cstore, changeset4, batchChange.ID)
 
-	s, err := graphqlbackend.NewSchema(database.NewDB(db), &Resolver{store: cstore}, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	s, err := graphqlbackend.NewSchema(db, &Resolver{store: cstore}, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/cmd/frontend/internal/batches/resolvers/changeset_counts_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/changeset_counts_test.go
@@ -179,7 +179,7 @@ func TestChangesetCountsOverTimeIntegration(t *testing.T) {
 		}
 	}
 
-	s, err := graphqlbackend.NewSchema(database.NewDB(db), New(cstore), nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	s, err := graphqlbackend.NewSchema(db, New(cstore), nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/cmd/frontend/internal/batches/resolvers/changeset_event_connection_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/changeset_event_connection_test.go
@@ -98,7 +98,7 @@ func TestChangesetEventConnectionResolver(t *testing.T) {
 
 	addChangeset(t, ctx, cstore, changeset, batchChange.ID)
 
-	s, err := graphqlbackend.NewSchema(database.NewDB(db), &Resolver{store: cstore}, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	s, err := graphqlbackend.NewSchema(db, &Resolver{store: cstore}, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/cmd/frontend/internal/batches/resolvers/changeset_spec_connection_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/changeset_spec_connection_test.go
@@ -70,7 +70,7 @@ func TestChangesetSpecConnectionResolver(t *testing.T) {
 		changesetSpecs = append(changesetSpecs, s)
 	}
 
-	s, err := graphqlbackend.NewSchema(database.NewDB(db), &Resolver{store: cstore}, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	s, err := graphqlbackend.NewSchema(db, &Resolver{store: cstore}, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/cmd/frontend/internal/batches/resolvers/changeset_spec_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/changeset_spec_test.go
@@ -64,7 +64,7 @@ func TestChangesetSpecResolver(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	s, err := graphqlbackend.NewSchema(database.NewDB(db), &Resolver{store: cstore}, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	s, err := graphqlbackend.NewSchema(db, &Resolver{store: cstore}, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/cmd/frontend/internal/batches/resolvers/changeset_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/changeset_test.go
@@ -212,7 +212,7 @@ func TestChangesetResolver(t *testing.T) {
 	// Associate the changeset with a batch change, so it's considered in syncer logic.
 	addChangeset(t, ctx, cstore, syncedGitHubChangeset, batchChange.ID)
 
-	s, err := graphqlbackend.NewSchema(database.NewDB(db), &Resolver{store: cstore}, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	s, err := graphqlbackend.NewSchema(db, &Resolver{store: cstore}, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/cmd/frontend/internal/batches/resolvers/code_host_connection_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/code_host_connection_test.go
@@ -42,7 +42,7 @@ func TestCodeHostConnectionResolver(t *testing.T) {
 	bbsRepos, _ := ct.CreateBbsTestRepos(t, ctx, db, 1)
 	bbsRepo := bbsRepos[0]
 
-	s, err := graphqlbackend.NewSchema(database.NewDB(db), &Resolver{store: cstore}, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	s, err := graphqlbackend.NewSchema(db, &Resolver{store: cstore}, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/cmd/frontend/internal/batches/resolvers/permissions_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/permissions_test.go
@@ -45,7 +45,7 @@ func TestPermissionLevels(t *testing.T) {
 
 	cstore := store.New(db, &observation.TestContext, key)
 	sr := New(cstore)
-	s, err := graphqlbackend.NewSchema(database.NewDB(db), sr, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	s, err := graphqlbackend.NewSchema(db, sr, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1271,7 +1271,7 @@ func TestRepositoryPermissions(t *testing.T) {
 
 	bstore := store.New(db, &observation.TestContext, nil)
 	sr := &Resolver{store: bstore}
-	s, err := graphqlbackend.NewSchema(database.NewDB(db), sr, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	s, err := graphqlbackend.NewSchema(db, sr, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/cmd/frontend/internal/batches/resolvers/resolver_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/resolver_test.go
@@ -43,7 +43,7 @@ func TestNullIDResilience(t *testing.T) {
 	db := database.NewDB(dbtest.NewDB(t))
 	sr := New(store.New(db, &observation.TestContext, nil))
 
-	s, err := newSchema(database.NewDB(db), sr)
+	s, err := newSchema(db, sr)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -150,7 +150,7 @@ func TestCreateBatchSpec(t *testing.T) {
 	}
 
 	r := &Resolver{store: cstore}
-	s, err := newSchema(database.NewDB(db), r)
+	s, err := newSchema(db, r)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -316,7 +316,7 @@ func TestCreateChangesetSpec(t *testing.T) {
 	}
 
 	r := &Resolver{store: cstore}
-	s, err := newSchema(database.NewDB(db), r)
+	s, err := newSchema(db, r)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -432,7 +432,7 @@ func TestApplyBatchChange(t *testing.T) {
 	}
 
 	r := &Resolver{store: cstore}
-	s, err := newSchema(database.NewDB(db), r)
+	s, err := newSchema(db, r)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -547,7 +547,7 @@ func TestCreateEmptyBatchChange(t *testing.T) {
 	cstore := store.New(db, &observation.TestContext, nil)
 
 	r := &Resolver{store: cstore}
-	s, err := newSchema(database.NewDB(db), r)
+	s, err := newSchema(db, r)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -647,7 +647,7 @@ func TestCreateBatchChange(t *testing.T) {
 	}
 
 	r := &Resolver{store: cstore}
-	s, err := newSchema(database.NewDB(db), r)
+	s, err := newSchema(db, r)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -718,7 +718,7 @@ func TestApplyOrCreateBatchSpecWithPublicationStates(t *testing.T) {
 	}
 
 	r := &Resolver{store: cstore}
-	s, err := newSchema(database.NewDB(db), r)
+	s, err := newSchema(db, r)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -910,7 +910,7 @@ func TestMoveBatchChange(t *testing.T) {
 	}
 
 	r := &Resolver{store: cstore}
-	s, err := newSchema(database.NewDB(db), r)
+	s, err := newSchema(db, r)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1180,7 +1180,7 @@ func TestCreateBatchChangesCredential(t *testing.T) {
 	cstore := store.New(db, &observation.TestContext, nil)
 
 	r := &Resolver{store: cstore}
-	s, err := newSchema(database.NewDB(db), r)
+	s, err := newSchema(db, r)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1328,7 +1328,7 @@ func TestDeleteBatchChangesCredential(t *testing.T) {
 	}
 
 	r := &Resolver{store: cstore}
-	s, err := newSchema(database.NewDB(db), r)
+	s, err := newSchema(db, r)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1411,7 +1411,7 @@ func TestCreateChangesetComments(t *testing.T) {
 	})
 
 	r := &Resolver{store: cstore}
-	s, err := newSchema(database.NewDB(db), r)
+	s, err := newSchema(db, r)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1519,7 +1519,7 @@ func TestReenqueueChangesets(t *testing.T) {
 	})
 
 	r := &Resolver{store: cstore}
-	s, err := newSchema(database.NewDB(db), r)
+	s, err := newSchema(db, r)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1629,7 +1629,7 @@ func TestMergeChangesets(t *testing.T) {
 	})
 
 	r := &Resolver{store: cstore}
-	s, err := newSchema(database.NewDB(db), r)
+	s, err := newSchema(db, r)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1739,7 +1739,7 @@ func TestCloseChangesets(t *testing.T) {
 	})
 
 	r := &Resolver{store: cstore}
-	s, err := newSchema(database.NewDB(db), r)
+	s, err := newSchema(db, r)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1865,7 +1865,7 @@ func TestPublishChangesets(t *testing.T) {
 	})
 
 	r := &Resolver{store: cstore}
-	s, err := newSchema(database.NewDB(db), r)
+	s, err := newSchema(db, r)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1963,7 +1963,7 @@ func TestCheckBatchChangesCredential(t *testing.T) {
 	}
 
 	r := &Resolver{store: cstore}
-	s, err := newSchema(database.NewDB(db), r)
+	s, err := newSchema(db, r)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2058,7 +2058,7 @@ func TestListBatchSpecs(t *testing.T) {
 	}
 
 	r := &Resolver{store: cstore}
-	s, err := newSchema(database.NewDB(db), r)
+	s, err := newSchema(db, r)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/cmd/frontend/internal/batches/webhooks/bitbucketcloud_test.go
+++ b/enterprise/cmd/frontend/internal/batches/webhooks/bitbucketcloud_test.go
@@ -424,7 +424,7 @@ func bitbucketCloudTestSetup(t *testing.T, db *sql.DB) *bstore.Store {
 
 	// Note that tx is wrapped in nestedTx to effectively neuter further use of
 	// transactions within the test.
-	return bstore.NewWithClock(database.NewDB(&nestedTx{tx}), &observation.TestContext, nil, clock.Now)
+	return bstore.NewWithClock(database.NewUntypedDB(&nestedTx{tx}), &observation.TestContext, nil, clock.Now)
 }
 
 // createBitbucketCloudExternalService creates a mock Bitbucket Cloud service

--- a/enterprise/cmd/frontend/internal/batches/webhooks/github_test.go
+++ b/enterprise/cmd/frontend/internal/batches/webhooks/github_test.go
@@ -73,7 +73,7 @@ func testGitHubWebhook(db database.DB, userID int32) func(*testing.T) {
 			t.Fatal(t)
 		}
 
-		githubSrc, err := repos.NewGithubSource(database.NewDB(db).ExternalServices(), extSvc, cf)
+		githubSrc, err := repos.NewGithubSource(db.ExternalServices(), extSvc, cf)
 		if err != nil {
 			t.Fatal(t)
 		}

--- a/enterprise/cmd/frontend/internal/batches/webhooks/gitlab_test.go
+++ b/enterprise/cmd/frontend/internal/batches/webhooks/gitlab_test.go
@@ -543,7 +543,7 @@ func testGitLabWebhook(db *sql.DB) func(*testing.T) {
 			// We can induce an error with a broken database connection.
 			s := gitLabTestSetup(t, db)
 			h := NewGitLabWebhook(s)
-			h.Store = store.NewWithClock(database.NewDB(&brokenDB{errors.New("foo")}), &observation.TestContext, nil, s.Clock())
+			h.Store = store.NewWithClock(database.NewUntypedDB(&brokenDB{errors.New("foo")}), &observation.TestContext, nil, s.Clock())
 
 			es, err := h.getExternalServiceFromRawID(ctx, "12345")
 			if es != nil {
@@ -603,7 +603,7 @@ func testGitLabWebhook(db *sql.DB) func(*testing.T) {
 				}
 
 				// We can induce an error with a broken database connection.
-				h.Store = store.NewWithClock(database.NewDB(&brokenDB{errors.New("foo")}), &observation.TestContext, nil, s.Clock())
+				h.Store = store.NewWithClock(database.NewUntypedDB(&brokenDB{errors.New("foo")}), &observation.TestContext, nil, s.Clock())
 
 				err := h.handleEvent(ctx, es, event)
 				if err == nil {
@@ -623,7 +623,7 @@ func testGitLabWebhook(db *sql.DB) func(*testing.T) {
 				}
 
 				// We can induce an error with a broken database connection.
-				h.Store = store.NewWithClock(database.NewDB(&brokenDB{errors.New("foo")}), &observation.TestContext, nil, s.Clock())
+				h.Store = store.NewWithClock(database.NewUntypedDB(&brokenDB{errors.New("foo")}), &observation.TestContext, nil, s.Clock())
 
 				err := h.handleEvent(ctx, es, event)
 				if err == nil {
@@ -733,7 +733,7 @@ func testGitLabWebhook(db *sql.DB) func(*testing.T) {
 			// Again, we're going to set up a poisoned store database that will
 			// error if a transaction is started.
 			s := gitLabTestSetup(t, db)
-			store := store.NewWithClock(database.NewDB(&noNestingTx{s.Handle().DB()}), &observation.TestContext, nil, s.Clock())
+			store := store.NewWithClock(database.NewUntypedDB(&noNestingTx{s.Handle().DB()}), &observation.TestContext, nil, s.Clock())
 			h := NewGitLabWebhook(store)
 
 			t.Run("missing merge request", func(t *testing.T) {
@@ -897,7 +897,7 @@ func gitLabTestSetup(t *testing.T, db *sql.DB) *store.Store {
 
 	// Note that tx is wrapped in nestedTx to effectively neuter further use of
 	// transactions within the test.
-	return store.NewWithClock(database.NewDB(&nestedTx{tx}), &observation.TestContext, nil, c.Now)
+	return store.NewWithClock(database.NewUntypedDB(&nestedTx{tx}), &observation.TestContext, nil, c.Now)
 }
 
 // assertBodyIncludes checks for a specific substring within the given response

--- a/enterprise/cmd/frontend/internal/dotcom/productsubscription/licenses_graphql.go
+++ b/enterprise/cmd/frontend/internal/dotcom/productsubscription/licenses_graphql.go
@@ -52,7 +52,7 @@ func productLicenseByDBID(ctx context.Context, db database.DB, id string) (*prod
 	if err != nil {
 		return nil, err
 	}
-	if err := backend.CheckSiteAdminOrSameUser(ctx, database.NewDB(db), sub.v.UserID); err != nil {
+	if err := backend.CheckSiteAdminOrSameUser(ctx, db, sub.v.UserID); err != nil {
 		return nil, err
 	}
 

--- a/enterprise/cmd/frontend/internal/dotcom/productsubscription/subscriptions_graphql.go
+++ b/enterprise/cmd/frontend/internal/dotcom/productsubscription/subscriptions_graphql.go
@@ -56,10 +56,10 @@ func productSubscriptionByDBID(ctx context.Context, db database.DB, id string) (
 		return nil, err
 	}
 	// 🚨 SECURITY: Only site admins and the subscription account's user may view a product subscription.
-	if err := backend.CheckSiteAdminOrSameUser(ctx, database.NewDB(db), v.UserID); err != nil {
+	if err := backend.CheckSiteAdminOrSameUser(ctx, db, v.UserID); err != nil {
 		return nil, err
 	}
-	return &productSubscription{v: v, db: database.NewDB(db)}, nil
+	return &productSubscription{v: v, db: db}, nil
 }
 
 func (r *productSubscription) ID() graphql.ID {
@@ -140,7 +140,7 @@ func (r *productSubscription) ActiveLicense(ctx context.Context) (graphqlbackend
 func (r *productSubscription) ProductLicenses(ctx context.Context, args *graphqlutil.ConnectionArgs) (graphqlbackend.ProductLicenseConnection, error) {
 	// 🚨 SECURITY: Only site admins may list historical product licenses (to reduce confusion
 	// around old license reuse). Other viewers should use ProductSubscription.activeLicense.
-	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, database.NewDB(r.db)); err != nil {
+	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
 		return nil, err
 	}
 
@@ -166,7 +166,7 @@ func (r *productSubscription) URL(ctx context.Context) (string, error) {
 func (r *productSubscription) URLForSiteAdmin(ctx context.Context) *string {
 	// 🚨 SECURITY: Only site admins may see this URL. Currently it does not contain any sensitive
 	// info, but there is no need to show it to non-site admins.
-	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, database.NewDB(r.db)); err != nil {
+	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
 		return nil
 	}
 	u := fmt.Sprintf("/site-admin/dotcom/product/subscriptions/%s", r.v.ID)
@@ -175,7 +175,7 @@ func (r *productSubscription) URLForSiteAdmin(ctx context.Context) *string {
 
 func (r *productSubscription) URLForSiteAdminBilling(ctx context.Context) (*string, error) {
 	// 🚨 SECURITY: Only site admins may see this URL, which might contain the subscription's billing ID.
-	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, database.NewDB(r.db)); err != nil {
+	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
 		return nil, err
 	}
 	if id := r.v.BillingSubscriptionID; id != nil {
@@ -544,7 +544,7 @@ func (r *productSubscriptionConnection) Nodes(ctx context.Context) ([]graphqlbac
 
 	var l []graphqlbackend.ProductSubscription
 	for _, result := range results {
-		l = append(l, &productSubscription{db: database.NewDB(r.db), v: result})
+		l = append(l, &productSubscription{db: r.db, v: result})
 	}
 	return l, nil
 }

--- a/enterprise/cmd/frontend/internal/licensing/enforcement/users_test.go
+++ b/enterprise/cmd/frontend/internal/licensing/enforcement/users_test.go
@@ -163,7 +163,7 @@ func TestEnforcement_AfterCreateUser(t *testing.T) {
 
 			hook := NewAfterCreateUserHook()
 			if hook != nil {
-				err := NewAfterCreateUserHook()(context.Background(), database.NewDB(db), user)
+				err := NewAfterCreateUserHook()(context.Background(), database.NewUntypedDB(db), user)
 				if err != nil {
 					t.Fatal(err)
 				}

--- a/enterprise/cmd/frontend/internal/notebooks/resolvers/resolvers_test.go
+++ b/enterprise/cmd/frontend/internal/notebooks/resolvers/resolvers_test.go
@@ -179,8 +179,7 @@ func compareNotebookAPIResponses(t *testing.T, wantNotebookResponse notebooksapi
 
 func TestSingleNotebookCRUD(t *testing.T) {
 	internalCtx := actor.WithInternalActor(context.Background())
-	testdb := database.NewDB(dbtest.NewDB(t))
-	db := database.NewDB(testdb)
+	db := database.NewDB(dbtest.NewDB(t))
 	u := db.Users()
 	o := db.Orgs()
 	om := db.OrgMembers()
@@ -597,8 +596,7 @@ func TestListNotebooks(t *testing.T) {
 		return ids
 	}
 
-	database := database.NewDB(db)
-	schema, err := graphqlbackend.NewSchema(database, nil, nil, nil, nil, nil, nil, nil, nil, nil, NewResolver(database), nil)
+	schema, err := graphqlbackend.NewSchema(db, nil, nil, nil, nil, nil, nil, nil, nil, nil, NewResolver(db), nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/cmd/frontend/internal/notebooks/resolvers/stars_resolvers_test.go
+++ b/enterprise/cmd/frontend/internal/notebooks/resolvers/stars_resolvers_test.go
@@ -76,8 +76,7 @@ func TestCreateAndDeleteNotebookStars(t *testing.T) {
 
 	createdNotebooks := createNotebooks(t, db, []*notebooks.Notebook{userNotebookFixture(user1.ID, true), userNotebookFixture(user1.ID, false)})
 
-	database := database.NewDB(db)
-	schema, err := graphqlbackend.NewSchema(database, nil, nil, nil, nil, nil, nil, nil, nil, nil, NewResolver(database), nil)
+	schema, err := graphqlbackend.NewSchema(db, nil, nil, nil, nil, nil, nil, nil, nil, nil, NewResolver(db), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -153,8 +152,7 @@ func TestListNotebookStars(t *testing.T) {
 		t.Fatalf("Expected no error, got %s", err)
 	}
 
-	database := database.NewDB(db)
-	schema, err := graphqlbackend.NewSchema(database, nil, nil, nil, nil, nil, nil, nil, nil, nil, NewResolver(database), nil)
+	schema, err := graphqlbackend.NewSchema(db, nil, nil, nil, nil, nil, nil, nil, nil, nil, NewResolver(db), nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/cmd/frontend/internal/registry/extension_graphql.go
+++ b/enterprise/cmd/frontend/internal/registry/extension_graphql.go
@@ -39,7 +39,7 @@ func (r *extensionDBResolver) ExtensionIDWithoutRegistry() string {
 }
 
 func (r *extensionDBResolver) Publisher(ctx context.Context) (graphqlbackend.RegistryPublisher, error) {
-	return getRegistryPublisher(ctx, database.NewDB(r.db), r.v.Publisher)
+	return getRegistryPublisher(ctx, r.db, r.v.Publisher)
 }
 
 func (r *extensionDBResolver) Name() string { return r.v.Name }

--- a/enterprise/cmd/frontend/internal/registry/publisher_connection_graphql.go
+++ b/enterprise/cmd/frontend/internal/registry/publisher_connection_graphql.go
@@ -54,7 +54,7 @@ func (r *registryPublisherConnection) Nodes(ctx context.Context) ([]graphqlbacke
 
 	var l []graphqlbackend.RegistryPublisher
 	for _, publisher := range publishers {
-		p, err := getRegistryPublisher(ctx, database.NewDB(r.db), *publisher)
+		p, err := getRegistryPublisher(ctx, r.db, *publisher)
 		if err != nil {
 			return nil, err
 		}

--- a/enterprise/cmd/frontend/internal/registry/publisher_graphql.go
+++ b/enterprise/cmd/frontend/internal/registry/publisher_graphql.go
@@ -27,7 +27,7 @@ func extensionRegistryViewerPublishers(ctx context.Context, db database.DB) ([]g
 	}
 
 	var publishers []graphqlbackend.RegistryPublisher
-	user, err := graphqlbackend.CurrentUser(ctx, database.NewDB(db))
+	user, err := graphqlbackend.CurrentUser(ctx, db)
 	if err != nil || user == nil {
 		return nil, err
 	}
@@ -38,7 +38,7 @@ func extensionRegistryViewerPublishers(ctx context.Context, db database.DB) ([]g
 		return nil, err
 	}
 	for _, org := range orgs {
-		publishers = append(publishers, &registryPublisher{org: graphqlbackend.NewOrg(database.NewDB(db), org)})
+		publishers = append(publishers, &registryPublisher{org: graphqlbackend.NewOrg(db, org)})
 	}
 	return publishers, nil
 }

--- a/enterprise/cmd/repo-updater/internal/authz/integration_test.go
+++ b/enterprise/cmd/repo-updater/internal/authz/integration_test.go
@@ -90,7 +90,7 @@ func TestIntegration_GitHubPermissions(t *testing.T) {
 			testDB := database.NewDB(dbtest.NewDB(t))
 			ctx := actor.WithInternalActor(context.Background())
 
-			reposStore := repos.NewStore(logtest.Scoped(t), database.NewDB(testDB))
+			reposStore := repos.NewStore(logtest.Scoped(t), testDB)
 
 			err = reposStore.ExternalServiceStore().Upsert(ctx, &svc)
 			if err != nil {
@@ -132,9 +132,8 @@ func TestIntegration_GitHubPermissions(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			db := database.NewDB(testDB)
 			permsStore := edb.Perms(testDB, timeutil.Now)
-			syncer := NewPermsSyncer(logtest.Scoped(t), db, reposStore, permsStore, timeutil.Now, nil)
+			syncer := NewPermsSyncer(logtest.Scoped(t), testDB, reposStore, permsStore, timeutil.Now, nil)
 
 			err = syncer.syncRepoPerms(ctx, repo.ID, false, authz.FetchPermsOptions{})
 			if err != nil {
@@ -171,7 +170,7 @@ func TestIntegration_GitHubPermissions(t *testing.T) {
 			testDB := database.NewDB(dbtest.NewDB(t))
 			ctx := actor.WithInternalActor(context.Background())
 
-			reposStore := repos.NewStore(logtest.Scoped(t), database.NewDB(testDB))
+			reposStore := repos.NewStore(logtest.Scoped(t), testDB)
 
 			err = reposStore.ExternalServiceStore().Upsert(ctx, &svc)
 			if err != nil {
@@ -213,9 +212,8 @@ func TestIntegration_GitHubPermissions(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			db := database.NewDB(testDB)
 			permsStore := edb.Perms(testDB, timeutil.Now)
-			syncer := NewPermsSyncer(logtest.Scoped(t), db, reposStore, permsStore, timeutil.Now, nil)
+			syncer := NewPermsSyncer(logtest.Scoped(t), testDB, reposStore, permsStore, timeutil.Now, nil)
 
 			err = syncer.syncRepoPerms(ctx, repo.ID, false, authz.FetchPermsOptions{})
 			if err != nil {
@@ -275,7 +273,7 @@ func TestIntegration_GitHubPermissions(t *testing.T) {
 			testDB := database.NewDB(dbtest.NewDB(t))
 			ctx := actor.WithInternalActor(context.Background())
 
-			reposStore := repos.NewStore(logtest.Scoped(t), database.NewDB(testDB))
+			reposStore := repos.NewStore(logtest.Scoped(t), testDB)
 
 			err = reposStore.ExternalServiceStore().Upsert(ctx, &svc)
 			if err != nil {
@@ -320,9 +318,8 @@ func TestIntegration_GitHubPermissions(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			db := database.NewDB(testDB)
 			permsStore := edb.Perms(testDB, timeutil.Now)
-			syncer := NewPermsSyncer(logtest.Scoped(t), db, reposStore, permsStore, timeutil.Now, nil)
+			syncer := NewPermsSyncer(logtest.Scoped(t), testDB, reposStore, permsStore, timeutil.Now, nil)
 
 			err = syncer.syncUserPerms(ctx, userID, false, authz.FetchPermsOptions{})
 			if err != nil {
@@ -359,7 +356,7 @@ func TestIntegration_GitHubPermissions(t *testing.T) {
 			testDB := database.NewDB(dbtest.NewDB(t))
 			ctx := actor.WithInternalActor(context.Background())
 
-			reposStore := repos.NewStore(logtest.Scoped(t), database.NewDB(testDB))
+			reposStore := repos.NewStore(logtest.Scoped(t), testDB)
 
 			err = reposStore.ExternalServiceStore().Upsert(ctx, &svc)
 			if err != nil {
@@ -404,9 +401,8 @@ func TestIntegration_GitHubPermissions(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			db := database.NewDB(testDB)
 			permsStore := edb.Perms(testDB, timeutil.Now)
-			syncer := NewPermsSyncer(logtest.Scoped(t), db, reposStore, permsStore, timeutil.Now, nil)
+			syncer := NewPermsSyncer(logtest.Scoped(t), testDB, reposStore, permsStore, timeutil.Now, nil)
 
 			err = syncer.syncUserPerms(ctx, userID, false, authz.FetchPermsOptions{})
 			if err != nil {

--- a/enterprise/internal/batches/processor/bulk_processor_test.go
+++ b/enterprise/internal/batches/processor/bulk_processor_test.go
@@ -25,7 +25,7 @@ func TestBulkProcessor(t *testing.T) {
 	sqlDB := dbtest.NewDB(t)
 	tx := dbtest.NewTx(t, sqlDB)
 	db := database.NewDB(sqlDB)
-	bstore := store.New(database.NewDB(tx), &observation.TestContext, nil)
+	bstore := store.New(database.NewUntypedDB(tx), &observation.TestContext, nil)
 	user := ct.CreateTestUser(t, db, true)
 	repo, _ := ct.CreateTestRepo(t, ctx, db)
 	ct.CreateTestSiteCredential(t, bstore, repo)

--- a/enterprise/internal/batches/service/service.go
+++ b/enterprise/internal/batches/service/service.go
@@ -976,9 +976,9 @@ func (s *Service) CheckNamespaceAccess(ctx context.Context, namespaceUserID, nam
 
 func (s *Service) checkNamespaceAccessWithDB(ctx context.Context, db database.DB, namespaceUserID, namespaceOrgID int32) (err error) {
 	if namespaceOrgID != 0 {
-		return backend.CheckOrgAccessOrSiteAdmin(ctx, database.NewDB(db), namespaceOrgID)
+		return backend.CheckOrgAccessOrSiteAdmin(ctx, db, namespaceOrgID)
 	} else if namespaceUserID != 0 {
-		return backend.CheckSiteAdminOrSameUser(ctx, database.NewDB(db), namespaceUserID)
+		return backend.CheckSiteAdminOrSameUser(ctx, db, namespaceUserID)
 	} else {
 		return ErrNoNamespace
 	}

--- a/enterprise/internal/batches/store/batch_changes.go
+++ b/enterprise/internal/batches/store/batch_changes.go
@@ -173,7 +173,7 @@ func (s *Store) CountBatchChanges(ctx context.Context, opts CountBatchChangesOpt
 	ctx, _, endObservation := s.operations.countBatchChanges.With(ctx, &err, observation.Args{})
 	defer endObservation(1, observation.Args{})
 
-	repoAuthzConds, err := database.AuthzQueryConds(ctx, database.NewDB(s.Handle().DB()))
+	repoAuthzConds, err := database.AuthzQueryConds(ctx, database.NewDBWith(s))
 	if err != nil {
 		return 0, errors.Wrap(err, "CountBatchChanges generating authz query conds")
 	}
@@ -358,7 +358,7 @@ func (s *Store) GetBatchChangeDiffStat(ctx context.Context, opts GetBatchChangeD
 	}})
 	defer endObservation(1, observation.Args{})
 
-	authzConds, err := database.AuthzQueryConds(ctx, database.NewDB(s.Handle().DB()))
+	authzConds, err := database.AuthzQueryConds(ctx, database.NewDBWith(s))
 	if err != nil {
 		return nil, errors.Wrap(err, "GetBatchChangeDiffStat generating authz query conds")
 	}
@@ -401,7 +401,7 @@ func (s *Store) GetRepoDiffStat(ctx context.Context, repoID api.RepoID) (stat *d
 	}})
 	defer endObservation(1, observation.Args{})
 
-	authzConds, err := database.AuthzQueryConds(ctx, database.NewDB(s.Handle().DB()))
+	authzConds, err := database.AuthzQueryConds(ctx, database.NewDBWith(s))
 	if err != nil {
 		return nil, errors.Wrap(err, "GetRepoDiffStat generating authz query conds")
 	}
@@ -460,7 +460,7 @@ func (s *Store) ListBatchChanges(ctx context.Context, opts ListBatchChangesOpts)
 	ctx, _, endObservation := s.operations.listBatchChanges.With(ctx, &err, observation.Args{})
 	defer endObservation(1, observation.Args{})
 
-	repoAuthzConds, err := database.AuthzQueryConds(ctx, database.NewDB(s.Handle().DB()))
+	repoAuthzConds, err := database.AuthzQueryConds(ctx, database.NewDBWith(s))
 	if err != nil {
 		return nil, 0, errors.Wrap(err, "ListBatchChanges generating authz query conds")
 	}

--- a/enterprise/internal/batches/store/changesets.go
+++ b/enterprise/internal/batches/store/changesets.go
@@ -270,7 +270,7 @@ func (s *Store) CountChangesets(ctx context.Context, opts CountChangesetsOpts) (
 	ctx, _, endObservation := s.operations.countChangesets.With(ctx, &err, observation.Args{})
 	defer endObservation(1, observation.Args{})
 
-	authzConds, err := database.AuthzQueryConds(ctx, database.NewDB(s.Handle().DB()))
+	authzConds, err := database.AuthzQueryConds(ctx, database.NewDBWith(s))
 	if err != nil {
 		return 0, errors.Wrap(err, "CountChangesets generating authz query conds")
 	}
@@ -532,7 +532,7 @@ func (s *Store) ListChangesets(ctx context.Context, opts ListChangesetsOpts) (cs
 	ctx, _, endObservation := s.operations.listChangesets.With(ctx, &err, observation.Args{})
 	defer endObservation(1, observation.Args{})
 
-	authzConds, err := database.AuthzQueryConds(ctx, database.NewDB(s.Handle().DB()))
+	authzConds, err := database.AuthzQueryConds(ctx, database.NewDBWith(s))
 	if err != nil {
 		return nil, 0, errors.Wrap(err, "ListChangesets generating authz query conds")
 	}
@@ -1271,7 +1271,7 @@ func (s *Store) GetRepoChangesetsStats(ctx context.Context, repoID api.RepoID) (
 	}})
 	defer endObservation(1, observation.Args{})
 
-	authzConds, err := database.AuthzQueryConds(ctx, database.NewDB(s.Handle().DB()))
+	authzConds, err := database.AuthzQueryConds(ctx, database.NewDBWith(s))
 	if err != nil {
 		return nil, errors.Wrap(err, "GetRepoChangesetsStats generating authz query conds")
 	}

--- a/enterprise/internal/batches/store/store_test.go
+++ b/enterprise/internal/batches/store/store_test.go
@@ -25,7 +25,7 @@ func storeTest(db *sql.DB, key encryption.Key, f storeTestFunc) func(*testing.T)
 		// of the tests, so that foreign key constraints can be deferred and we
 		// don't need to insert a lot of dependencies into the DB (users,
 		// repos, ...) to setup the tests.
-		tx := database.NewDB(dbtest.NewTx(t, db))
+		tx := database.NewUntypedDB(dbtest.NewTx(t, db))
 		s := NewWithClock(tx, &observation.TestContext, key, c.Now)
 
 		f(t, context.Background(), s, c)

--- a/enterprise/internal/database/perms_store_test.go
+++ b/enterprise/internal/database/perms_store_test.go
@@ -2858,7 +2858,6 @@ WHERE repo_id = 2`, clock().AddDate(-1, 0, 0))
 
 func testPermsStore_UserIsMemberOfOrgHasCodeHostConnection(db database.DB) func(*testing.T) {
 	return func(t *testing.T) {
-		db := database.NewDB(db)
 		s := perms(db, clock)
 		ctx := context.Background()
 		t.Cleanup(func() {

--- a/enterprise/internal/insights/background/historical_enqueuer.go
+++ b/enterprise/internal/insights/background/historical_enqueuer.go
@@ -82,8 +82,7 @@ func newInsightHistoricalEnqueuer(ctx context.Context, workerBaseStore *basestor
 		Metrics: metrics,
 	})
 
-	db := workerBaseStore.Handle().DB()
-	repoStore := database.NewDB(db).Repos()
+	repoStore := database.NewDBWith(workerBaseStore).Repos()
 
 	iterator := discovery.NewAllReposIterator(
 		dbcache.NewIndexableReposLister(repoStore),
@@ -170,7 +169,7 @@ func (s *ScopedBackfiller) ScopedBackfill(ctx context.Context, definitions []ity
 		}
 	}
 
-	frontend := database.NewDB(s.workerBaseStore.Handle().DB())
+	frontend := database.NewDBWith(s.workerBaseStore)
 	iterator, err := discovery.NewScopedRepoIterator(ctx, repositories, frontend.Repos())
 	if err != nil {
 		return errors.Wrap(err, "NewScopedRepoIterator")
@@ -235,8 +234,7 @@ func baseAnalyzer(frontend database.DB, statistics statistics) backfillAnalyzer 
 }
 
 func globalBackfiller(workerBaseStore *basestore.Store, dataSeriesStore store.DataSeriesStore, insightsStore *store.Store) *historicalEnqueuer {
-	db := workerBaseStore.Handle().DB()
-	dbConn := database.NewDB(db)
+	dbConn := database.NewDBWith(workerBaseStore)
 
 	statistics := make(statistics)
 

--- a/enterprise/internal/insights/background/pings/insights_ping_emitter.go
+++ b/enterprise/internal/insights/background/pings/insights_ping_emitter.go
@@ -204,7 +204,7 @@ func (e *InsightsPingEmitter) emitInsightsPerDashboard(ctx context.Context) erro
 }
 
 func (e *InsightsPingEmitter) SaveEvent(ctx context.Context, name string, argument json.RawMessage) error {
-	store := database.NewDB(e.postgresDb).EventLogs()
+	store := database.NewUntypedDB(e.postgresDb).EventLogs()
 
 	err := store.Insert(ctx, &database.Event{
 		Name:            name,

--- a/enterprise/internal/insights/query/capture_group_executor.go
+++ b/enterprise/internal/insights/query/capture_group_executor.go
@@ -32,7 +32,7 @@ type CaptureGroupExecutor struct {
 func NewCaptureGroupExecutor(postgres database.DB, clock func() time.Time) *CaptureGroupExecutor {
 	executor := CaptureGroupExecutor{
 		justInTimeExecutor: justInTimeExecutor{
-			db:        database.NewDB(postgres),
+			db:        postgres,
 			repoStore: postgres.Repos(),
 			// filter:    compression.NewHistoricalFilter(true, clock().Add(time.Hour*24*365*-1), insightsDb),
 			filter: &compression.NoopFilter{},

--- a/enterprise/internal/insights/query/streaming_query_executor.go
+++ b/enterprise/internal/insights/query/streaming_query_executor.go
@@ -26,7 +26,7 @@ type StreamingQueryExecutor struct {
 func NewStreamingExecutor(postgres database.DB, clock func() time.Time) *StreamingQueryExecutor {
 	return &StreamingQueryExecutor{
 		justInTimeExecutor: justInTimeExecutor{
-			db:        database.NewDB(postgres),
+			db:        postgres,
 			repoStore: postgres.Repos(),
 			filter:    &compression.NoopFilter{},
 			clock:     clock,

--- a/enterprise/internal/insights/resolvers/admin_resolver.go
+++ b/enterprise/internal/insights/resolvers/admin_resolver.go
@@ -9,7 +9,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/store"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/types"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
-	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
@@ -19,7 +18,7 @@ var _ graphqlbackend.InsightSeriesQueryStatusResolver = &insightSeriesQueryStatu
 
 func (r *Resolver) UpdateInsightSeries(ctx context.Context, args *graphqlbackend.UpdateInsightSeriesArgs) (graphqlbackend.InsightSeriesMetadataPayloadResolver, error) {
 	actr := actor.FromContext(ctx)
-	if err := backend.CheckUserIsSiteAdmin(ctx, database.NewDB(r.postgresDB), actr.UID); err != nil {
+	if err := backend.CheckUserIsSiteAdmin(ctx, r.postgresDB, actr.UID); err != nil {
 		return nil, err
 	}
 
@@ -42,7 +41,7 @@ func (r *Resolver) UpdateInsightSeries(ctx context.Context, args *graphqlbackend
 
 func (r *Resolver) InsightSeriesQueryStatus(ctx context.Context) ([]graphqlbackend.InsightSeriesQueryStatusResolver, error) {
 	actr := actor.FromContext(ctx)
-	if err := backend.CheckUserIsSiteAdmin(ctx, database.NewDB(r.postgresDB), actr.UID); err != nil {
+	if err := backend.CheckUserIsSiteAdmin(ctx, r.postgresDB, actr.UID); err != nil {
 		return nil, err
 	}
 

--- a/enterprise/internal/insights/resolvers/dashboard_resolvers.go
+++ b/enterprise/internal/insights/resolvers/dashboard_resolvers.go
@@ -240,7 +240,7 @@ func (r *Resolver) CreateInsightsDashboard(ctx context.Context, args *graphqlbac
 		return nil, errors.New("dashboard must be created with at least one grant")
 	}
 
-	userIds, orgIds, err := getUserPermissions(ctx, database.NewDB(r.workerBaseStore.Handle().DB()).Orgs())
+	userIds, orgIds, err := getUserPermissions(ctx, database.NewDBWith(r.workerBaseStore).Orgs())
 	if err != nil {
 		return nil, errors.Wrap(err, "getUserPermissions")
 	}

--- a/enterprise/internal/insights/resolvers/insight_series_resolver.go
+++ b/enterprise/internal/insights/resolvers/insight_series_resolver.go
@@ -116,7 +116,7 @@ type scLoader struct {
 }
 
 func (l *scLoader) GetByName(ctx context.Context, name string) (*sctypes.SearchContext, error) {
-	db := database.NewDB(l.primary)
+	db := database.NewUntypedDB(l.primary)
 	return searchcontexts.ResolveSearchContextSpec(ctx, db, name)
 }
 

--- a/enterprise/internal/insights/resolvers/resolver.go
+++ b/enterprise/internal/insights/resolvers/resolver.go
@@ -89,7 +89,7 @@ func (r *Resolver) Insights(ctx context.Context, args *graphqlbackend.InsightsAr
 		workerBaseStore:      r.workerBaseStore,
 		insightMetadataStore: r.insightMetadataStore,
 		ids:                  idList,
-		orgStore:             database.NewDB(r.workerBaseStore.Handle().DB()).Orgs(),
+		orgStore:             database.NewDBWith(r.workerBaseStore).Orgs(),
 	}, nil
 }
 

--- a/enterprise/internal/insights/store/permissions.go
+++ b/enterprise/internal/insights/store/permissions.go
@@ -21,7 +21,7 @@ type InsightPermStore struct {
 // code insights in the timeseries database. This approach makes the assumption that most users have access to most
 // repos - which is highly likely given the public / private model that repos use today.
 func (i *InsightPermStore) GetUnauthorizedRepoIDs(ctx context.Context) (results []api.RepoID, err error) {
-	db := database.NewDB(i.Store.Handle().DB())
+	db := database.NewDBWith(i.Store)
 	store := db.Repos()
 	conds, err := database.AuthzQueryConds(ctx, db)
 	if err != nil {

--- a/internal/codeintel/stores/dbstore/audit_logs.go
+++ b/internal/codeintel/stores/dbstore/audit_logs.go
@@ -64,7 +64,7 @@ var scanUploadAuditLogs = basestore.NewSliceScanner(scanUploadAuditLog)
 // GetAuditLogsForUpload returns all the audit logs for the given upload ID in order of entry
 // from oldest to newest, according to the auto-incremented internal sequence field.
 func (s *Store) GetAuditLogsForUpload(ctx context.Context, uploadID int) (_ []UploadLog, err error) {
-	authzConds, err := database.AuthzQueryConds(ctx, database.NewDB(s.Store.Handle().DB()))
+	authzConds, err := database.AuthzQueryConds(ctx, database.NewDBWith(s.Store))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/codeintel/stores/dbstore/configuration_policies.go
+++ b/internal/codeintel/stores/dbstore/configuration_policies.go
@@ -231,7 +231,7 @@ func (s *Store) GetConfigurationPolicyByID(ctx context.Context, id int) (_ Confi
 	}})
 	defer endObservation(1, observation.Args{})
 
-	authzConds, err := database.AuthzQueryConds(ctx, database.NewDB(s.Store.Handle().DB()))
+	authzConds, err := database.AuthzQueryConds(ctx, database.NewDBWith(s.Store))
 	if err != nil {
 		return ConfigurationPolicy{}, false, err
 	}

--- a/internal/codeintel/stores/dbstore/indexes.go
+++ b/internal/codeintel/stores/dbstore/indexes.go
@@ -140,7 +140,7 @@ func (s *Store) GetIndexByID(ctx context.Context, id int) (_ Index, _ bool, err 
 	}})
 	defer endObservation(1, observation.Args{})
 
-	authzConds, err := database.AuthzQueryConds(ctx, database.NewDB(s.Store.Handle().DB()))
+	authzConds, err := database.AuthzQueryConds(ctx, database.NewDBWith(s.Store))
 	if err != nil {
 		return Index{}, false, err
 	}
@@ -205,7 +205,7 @@ func (s *Store) GetIndexesByIDs(ctx context.Context, ids ...int) (_ []Index, err
 		return nil, nil
 	}
 
-	authzConds, err := database.AuthzQueryConds(ctx, database.NewDB(s.Store.Handle().DB()))
+	authzConds, err := database.AuthzQueryConds(ctx, database.NewDBWith(s.Store))
 	if err != nil {
 		return nil, err
 	}
@@ -287,7 +287,7 @@ func (s *Store) GetIndexes(ctx context.Context, opts GetIndexesOptions) (_ []Ind
 		conds = append(conds, makeStateCondition(opts.State))
 	}
 
-	authzConds, err := database.AuthzQueryConds(ctx, database.NewDB(tx.Store.Handle().DB()))
+	authzConds, err := database.AuthzQueryConds(ctx, database.NewDBWith(tx.Store))
 	if err != nil {
 		return nil, 0, err
 	}

--- a/internal/codeintel/stores/dbstore/repo.go
+++ b/internal/codeintel/stores/dbstore/repo.go
@@ -103,7 +103,7 @@ func (s *Store) RepoIDsByGlobPatterns(ctx context.Context, patterns []string, li
 	}
 	defer func() { err = tx.Done(err) }()
 
-	authzConds, err := database.AuthzQueryConds(ctx, database.NewDB(tx.Handle().DB()))
+	authzConds, err := database.AuthzQueryConds(ctx, database.NewDBWith(tx))
 	if err != nil {
 		return nil, 0, err
 	}

--- a/internal/codeintel/stores/dbstore/uploads.go
+++ b/internal/codeintel/stores/dbstore/uploads.go
@@ -166,7 +166,7 @@ func (s *Store) GetUploadByID(ctx context.Context, id int) (_ Upload, _ bool, er
 	}})
 	defer endObservation(1, observation.Args{})
 
-	authzConds, err := database.AuthzQueryConds(ctx, database.NewDB(s.Store.Handle().DB()))
+	authzConds, err := database.AuthzQueryConds(ctx, database.NewDBWith(s.Store))
 	if err != nil {
 		return Upload{}, false, err
 	}
@@ -227,7 +227,7 @@ func (s *Store) GetUploadsByIDs(ctx context.Context, ids ...int) (_ []Upload, er
 		return nil, nil
 	}
 
-	authzConds, err := database.AuthzQueryConds(ctx, database.NewDB(s.Store.Handle().DB()))
+	authzConds, err := database.AuthzQueryConds(ctx, database.NewDBWith(s.Store))
 	if err != nil {
 		return nil, err
 	}
@@ -430,7 +430,7 @@ func (s *Store) GetUploads(ctx context.Context, opts GetUploadsOptions) (_ []Upl
 		conds = append(conds, sqlf.Sprintf("repo.deleted_at IS NULL"))
 	}
 
-	authzConds, err := database.AuthzQueryConds(ctx, database.NewDB(tx.Store.Handle().DB()))
+	authzConds, err := database.AuthzQueryConds(ctx, database.NewDBWith(tx.Store))
 	if err != nil {
 		return nil, 0, err
 	}

--- a/internal/codeintel/stores/dbstore/uploads_test.go
+++ b/internal/codeintel/stores/dbstore/uploads_test.go
@@ -695,11 +695,10 @@ func TestAddUploadPart(t *testing.T) {
 }
 
 func TestDeleteUploadByID(t *testing.T) {
-	sqlDB := database.NewDB(dbtest.NewDB(t))
-	db := database.NewDB(sqlDB)
+	db := database.NewDB(dbtest.NewDB(t))
 	store := testStore(db)
 
-	insertUploads(t, sqlDB,
+	insertUploads(t, db,
 		Upload{ID: 1, RepositoryID: 50},
 	)
 
@@ -733,11 +732,10 @@ func TestDeleteUploadByID(t *testing.T) {
 }
 
 func TestDeleteUploadByIDNotCompleted(t *testing.T) {
-	sqlDB := database.NewDB(dbtest.NewDB(t))
-	db := database.NewDB(sqlDB)
+	db := database.NewDB(dbtest.NewDB(t))
 	store := testStore(db)
 
-	insertUploads(t, sqlDB,
+	insertUploads(t, db,
 		Upload{ID: 1, RepositoryID: 50, State: "uploading"},
 	)
 
@@ -782,8 +780,7 @@ func TestDeleteUploadByIDMissingRow(t *testing.T) {
 }
 
 func TestDeleteUploadsWithoutRepository(t *testing.T) {
-	sqlDB := database.NewDB(dbtest.NewDB(t))
-	db := database.NewDB(sqlDB)
+	db := database.NewDB(dbtest.NewDB(t))
 	store := testStore(db)
 
 	var uploads []Upload
@@ -792,7 +789,7 @@ func TestDeleteUploadsWithoutRepository(t *testing.T) {
 			uploads = append(uploads, Upload{ID: len(uploads) + 1, RepositoryID: 50 + i})
 		}
 	}
-	insertUploads(t, sqlDB, uploads...)
+	insertUploads(t, db, uploads...)
 
 	t1 := time.Unix(1587396557, 0).UTC()
 	t2 := t1.Add(-DeletedRepositoryGracePeriod + time.Minute)

--- a/internal/codeintel/stores/dbstore/xrepo.go
+++ b/internal/codeintel/stores/dbstore/xrepo.go
@@ -36,7 +36,7 @@ func (s *Store) DefinitionDumps(ctx context.Context, monikers []precise.Qualifie
 		qs = append(qs, sqlf.Sprintf("(%s, %s, %s)", moniker.Scheme, moniker.Name, moniker.Version))
 	}
 
-	authzConds, err := database.AuthzQueryConds(ctx, database.NewDB(s.Store.Handle().DB()))
+	authzConds, err := database.AuthzQueryConds(ctx, database.NewDBWith(s.Store))
 	if err != nil {
 		return nil, err
 	}
@@ -145,7 +145,7 @@ func (s *Store) ReferenceIDs(ctx context.Context, repositoryID int, commit strin
 
 	visibleUploadsQuery := makeVisibleUploadsQuery(repositoryID, commit)
 
-	authzConds, err := database.AuthzQueryConds(ctx, database.NewDB(s.Store.Handle().DB()))
+	authzConds, err := database.AuthzQueryConds(ctx, database.NewDBWith(s.Store))
 	if err != nil {
 		return nil, 0, err
 	}

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -55,7 +55,11 @@ var _ DB = (*db)(nil)
 
 // NewDB creates a new DB from a dbutil.DB, providing a thin wrapper
 // that has constructor methods for the more specialized stores.
-func NewDB(inner dbutil.DB) DB {
+func NewDB(inner *sql.DB) DB {
+	return &db{basestore.NewWithHandle(basestore.NewHandleWithDB(inner, sql.TxOptions{}))}
+}
+
+func NewUntypedDB(inner dbutil.DB) DB {
 	return &db{basestore.NewWithHandle(basestore.NewHandleWithDB(inner, sql.TxOptions{}))}
 }
 

--- a/internal/database/database_test.go
+++ b/internal/database/database_test.go
@@ -224,7 +224,7 @@ func TestDBTransactions(t *testing.T) {
 		db := NewDB(sqlDB)
 		// this ill-advised, but possible, so make sure we can handle it.
 		// In the future, this ideally not be possible by typing this more strictly.
-		db = NewDB(db)
+		db = NewUntypedDB(db)
 
 		// Lifetime of tx
 		{

--- a/internal/database/external_accounts.go
+++ b/internal/database/external_accounts.go
@@ -271,7 +271,7 @@ func (s *userExternalAccountsStore) CreateUserAndSave(ctx context.Context, newUs
 
 	err = tx.Insert(ctx, createdUser.ID, spec, data)
 	if err == nil {
-		logAccountCreatedEvent(ctx, s.Handle().DB(), createdUser, spec.ServiceType)
+		logAccountCreatedEvent(ctx, NewDBWith(s), createdUser, spec.ServiceType)
 	}
 	return createdUser.ID, err
 }

--- a/internal/database/external_services.go
+++ b/internal/database/external_services.go
@@ -611,7 +611,7 @@ func (e *externalServiceStore) Create(ctx context.Context, confGet func() *conf.
 
 	// Prior to saving the record, run a validation hook.
 	if BeforeCreateExternalService != nil {
-		if err := BeforeCreateExternalService(ctx, NewDB(e.Store.Handle().DB()).ExternalServices()); err != nil {
+		if err := BeforeCreateExternalService(ctx, NewDBWith(e.Store).ExternalServices()); err != nil {
 			return err
 		}
 	}

--- a/internal/database/search_contexts.go
+++ b/internal/database/search_contexts.go
@@ -494,7 +494,7 @@ WHERE sc.search_context_id = %d
 `
 
 func (s *searchContextsStore) GetSearchContextRepositoryRevisions(ctx context.Context, searchContextID int64) ([]*types.SearchContextRepositoryRevisions, error) {
-	authzConds, err := AuthzQueryConds(ctx, NewDB(s.Handle().DB()))
+	authzConds, err := AuthzQueryConds(ctx, NewDBWith(s))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/database/users.go
+++ b/internal/database/users.go
@@ -213,7 +213,7 @@ func (u *userStore) Create(ctx context.Context, info NewUser) (newUser *types.Us
 	defer func() { err = tx.Done(err) }()
 	newUser, err = tx.CreateInTransaction(ctx, info)
 	if err == nil {
-		logAccountCreatedEvent(ctx, u.Handle().DB(), newUser, "")
+		logAccountCreatedEvent(ctx, NewDBWith(u), newUser, "")
 	}
 	return newUser, err
 }
@@ -278,7 +278,7 @@ func (u *userStore) CreateInTransaction(ctx context.Context, info NewUser) (newU
 
 	// Run BeforeCreateUser hook.
 	if BeforeCreateUser != nil {
-		if err := BeforeCreateUser(ctx, NewDB(u.Store.Handle().DB())); err != nil {
+		if err := BeforeCreateUser(ctx, NewDBWith(u.Store)); err != nil {
 			return nil, errors.Wrap(err, "pre create user hook")
 		}
 	}
@@ -365,7 +365,7 @@ func (u *userStore) CreateInTransaction(ctx context.Context, info NewUser) (newU
 
 		// Run AfterCreateUser hook
 		if AfterCreateUser != nil {
-			if err := AfterCreateUser(ctx, NewDB(u.Store.Handle().DB()), user); err != nil {
+			if err := AfterCreateUser(ctx, NewDBWith(u.Store), user); err != nil {
 				return nil, errors.Wrap(err, "after create user hook")
 			}
 		}
@@ -374,7 +374,7 @@ func (u *userStore) CreateInTransaction(ctx context.Context, info NewUser) (newU
 	return user, nil
 }
 
-func logAccountCreatedEvent(ctx context.Context, db dbutil.DB, u *types.User, serviceType string) {
+func logAccountCreatedEvent(ctx context.Context, db DB, u *types.User, serviceType string) {
 	a := actor.FromContext(ctx)
 	arg, _ := json.Marshal(struct {
 		Creator     int32  `json:"creator"`
@@ -396,7 +396,7 @@ func logAccountCreatedEvent(ctx context.Context, db dbutil.DB, u *types.User, se
 		Timestamp:       time.Now(),
 	}
 
-	NewDB(db).SecurityEventLogs().LogEvent(ctx, event)
+	db.SecurityEventLogs().LogEvent(ctx, event)
 }
 
 // orgsForAllUsersToJoin returns the list of org names that all users should be joined to. The second return value
@@ -528,7 +528,7 @@ func (u *userStore) Delete(ctx context.Context, id int32) (err error) {
 		return err
 	}
 
-	logUserDeletionEvent(ctx, u.Handle().DB(), id, SecurityEventNameAccountDeleted)
+	logUserDeletionEvent(ctx, NewDBWith(u), id, SecurityEventNameAccountDeleted)
 
 	return nil
 }
@@ -598,12 +598,12 @@ func (u *userStore) HardDelete(ctx context.Context, id int32) (err error) {
 		return userNotFoundErr{args: []any{id}}
 	}
 
-	logUserDeletionEvent(ctx, u.Handle().DB(), id, SecurityEventNameAccountNuked)
+	logUserDeletionEvent(ctx, NewDBWith(u), id, SecurityEventNameAccountNuked)
 
 	return nil
 }
 
-func logUserDeletionEvent(ctx context.Context, db dbutil.DB, id int32, name SecurityEventName) {
+func logUserDeletionEvent(ctx context.Context, db DB, id int32, name SecurityEventName) {
 	// The actor deleting the user could be a different user, for example a site
 	// admin
 	a := actor.FromContext(ctx)
@@ -623,7 +623,7 @@ func logUserDeletionEvent(ctx context.Context, db dbutil.DB, id int32, name Secu
 		Timestamp:       time.Now(),
 	}
 
-	NewDB(db).SecurityEventLogs().LogEvent(ctx, event)
+	db.SecurityEventLogs().LogEvent(ctx, event)
 }
 
 // SetIsSiteAdmin sets the user with the given ID to be or not to be the site admin.
@@ -1040,12 +1040,12 @@ func (u *userStore) RandomizePasswordAndClearPasswordResetRateLimit(ctx context.
 	// can't be reused, and so a new valid reset code can be generated afterward.
 	err = u.Exec(ctx, sqlf.Sprintf("UPDATE users SET passwd_reset_code=NULL, passwd_reset_time=NULL, passwd=%s WHERE id=%s", passwd, id))
 	if err == nil {
-		LogPasswordEvent(ctx, u.Handle().DB(), nil, SecurityEventNamPasswordRandomized, id)
+		LogPasswordEvent(ctx, NewDBWith(u), nil, SecurityEventNamPasswordRandomized, id)
 	}
 	return err
 }
 
-func LogPasswordEvent(ctx context.Context, db dbutil.DB, r *http.Request, name SecurityEventName, userID int32) {
+func LogPasswordEvent(ctx context.Context, db DB, r *http.Request, name SecurityEventName, userID int32) {
 	a := actor.FromContext(ctx)
 	args, _ := json.Marshal(struct {
 		Requester int32 `json:"requester"`
@@ -1067,7 +1067,7 @@ func LogPasswordEvent(ctx context.Context, db dbutil.DB, r *http.Request, name S
 	}
 	event.AnonymousUserID, _ = cookie.AnonymousUID(r)
 
-	NewDB(db).SecurityEventLogs().LogEvent(ctx, event)
+	db.SecurityEventLogs().LogEvent(ctx, event)
 }
 
 func hashPassword(password string) (sql.NullString, error) {

--- a/internal/database/webhook_logs_test.go
+++ b/internal/database/webhook_logs_test.go
@@ -141,7 +141,7 @@ func TestWebhookLogStore(t *testing.T) {
 		assert.Nil(t, err)
 		defer func() { _ = tx.Done(errors.New("rollback")) }()
 
-		esStore := NewDB(tx).ExternalServices()
+		esStore := tx.ExternalServices()
 		es := &types.ExternalService{
 			Kind:        extsvc.KindGitLab,
 			DisplayName: "GitLab",
@@ -257,7 +257,7 @@ func TestWebhookLogStore(t *testing.T) {
 		assert.Nil(t, err)
 		defer func() { _ = tx.Done(errors.New("rollback")) }()
 
-		esStore := NewDB(tx).ExternalServices()
+		esStore := tx.ExternalServices()
 		es := &types.ExternalService{
 			Kind:        extsvc.KindGitLab,
 			DisplayName: "GitLab",

--- a/internal/repos/status_messages_test.go
+++ b/internal/repos/status_messages_test.go
@@ -29,7 +29,7 @@ func TestStatusMessages(t *testing.T) {
 	}
 	ctx := context.Background()
 	db := database.NewDB(dbtest.NewDB(t))
-	store := NewStore(logtest.Scoped(t), database.NewDB(db))
+	store := NewStore(logtest.Scoped(t), db)
 
 	admin, err := db.Users().Create(ctx, database.NewUser{
 		Email:                 "a1@example.com",
@@ -309,7 +309,7 @@ func TestStatusMessages(t *testing.T) {
 				Now:    clock.Now,
 			}
 
-			mockDB := database.NewMockDBFrom(database.NewDB(db))
+			mockDB := database.NewMockDBFrom(db)
 			if tc.sourcerErr != nil {
 				sourcer := NewFakeSourcer(tc.sourcerErr, NewFakeSource(siteLevelService, nil))
 				syncer.Sourcer = sourcer

--- a/internal/search/alert/observer_test.go
+++ b/internal/search/alert/observer_test.go
@@ -68,7 +68,7 @@ func TestAlertForNoResolvedReposWithNonGlobalSearchContext(t *testing.T) {
 		t.Fatal(err)
 	}
 	sr := Observer{
-		Db: database.NewDB(db),
+		Db: db,
 		SearchInputs: &run.SearchInputs{
 			OriginalQuery: searchQuery,
 			Query:         q,


### PR DESCRIPTION
This updates `database.NewDB` to take a `*sql.DB` directly. Not all callsites can be trivially converted, so I renamed the original form of the function to `database.NewUntypedDB()` and will work on cleaning up the rest of those call sites in followup PRs, but I wanted to make this PR all trivial changes (it's large, but very mechanical). 

The goal continues to be to reduce our dependency on `dbutil.DB` until I can get rid of it entirely. This is a big step because it makes it clear exactly how many places I need to touch up. 

## Test plan

Every change was done with the help of `gopls`, so there should be no breakages here. Depending on unit tests though. 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
