### PR TITLE
search: lucky rule interprets patterns as lang

### DIFF
--- a/internal/search/job/jobutil/feeling_lucky_search_job.go
+++ b/internal/search/job/jobutil/feeling_lucky_search_job.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"sync"
 
+	"github.com/go-enry/go-enry/v2"
 	"github.com/opentracing/opentracing-go/log"
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	alertobserver "github.com/sourcegraph/sourcegraph/internal/search/alert"
@@ -198,6 +199,10 @@ var rules = []rule{
 		transform:   transform{unquotePatterns},
 	},
 	{
+		description: "apply language filter for pattern",
+		transform:   transform{langPatterns},
+	},
+	{
 		description: "AND patterns together",
 		transform:   transform{unorderedPatterns},
 	},
@@ -318,6 +323,51 @@ func mapConcat(q []query.Node) ([]query.Node, bool) {
 		mapped = append(mapped, node)
 	}
 	return mapped, changed
+}
+
+func langPatterns(b query.Basic) *query.Basic {
+	rawPatternTree, err := query.Parse(query.StringHuman([]query.Node{b.Pattern}), query.SearchTypeLiteralDefault)
+	if err != nil {
+		return nil
+	}
+
+	changed := false
+	var lang string // store the first pattern that matches a recognized language.
+	newPattern := query.MapPattern(rawPatternTree, func(value string, negated bool, annotation query.Annotation) query.Node {
+		langAlias, ok := enry.GetLanguageByAlias(value)
+		if !ok || changed {
+			return query.Pattern{
+				Value:      value,
+				Negated:    negated,
+				Annotation: annotation,
+			}
+		}
+		changed = true
+		lang = langAlias
+		// remove this node
+		return nil
+	})
+
+	if !changed {
+		return nil
+	}
+
+	langParam := query.Parameter{
+		Field:      query.FieldLang,
+		Value:      lang,
+		Negated:    false,
+		Annotation: query.Annotation{},
+	}
+
+	var pattern query.Node
+	if len(newPattern) > 0 {
+		pattern = newPattern[0]
+	}
+
+	return &query.Basic{
+		Parameters: append(b.Parameters, langParam),
+		Pattern:    pattern,
+	}
 }
 
 type generatedSearchJob struct {

--- a/internal/search/job/jobutil/feeling_lucky_search_job_test.go
+++ b/internal/search/job/jobutil/feeling_lucky_search_job_test.go
@@ -53,4 +53,12 @@ func TestNewFeelingLuckySearchJob(t *testing.T) {
 	t.Run("two basic jobs", func(t *testing.T) {
 		autogold.Equal(t, autogold.Raw(test(`context:global ((type:file parse func) or (type:commit parse func))`)))
 	})
+
+	t.Run("single pattern as lang", func(t *testing.T) {
+		autogold.Equal(t, autogold.Raw(test(`context:global python`)))
+	})
+
+	t.Run("one of many patterns as lang", func(t *testing.T) {
+		autogold.Equal(t, autogold.Raw(test(`context:global parse python`)))
+	})
 }

--- a/internal/search/job/jobutil/testdata/TestNewFeelingLuckySearchJob/one_of_many_patterns_as_lang.golden
+++ b/internal/search/job/jobutil/testdata/TestNewFeelingLuckySearchJob/one_of_many_patterns_as_lang.golden
@@ -1,0 +1,24 @@
+{
+  "OR": [
+    {
+      "GeneratedSearchJob": {
+        "Child": {},
+        "ProposedQuery": {
+          "Description": "apply language filter for pattern",
+          "Query": "context:global lang:Python parse",
+          "PatternType": 1
+        }
+      }
+    },
+    {
+      "GeneratedSearchJob": {
+        "Child": {},
+        "ProposedQuery": {
+          "Description": "AND patterns together",
+          "Query": "context:global (parse AND python)",
+          "PatternType": 1
+        }
+      }
+    }
+  ]
+}

--- a/internal/search/job/jobutil/testdata/TestNewFeelingLuckySearchJob/single_pattern_as_lang.golden
+++ b/internal/search/job/jobutil/testdata/TestNewFeelingLuckySearchJob/single_pattern_as_lang.golden
@@ -1,0 +1,10 @@
+{
+  "GeneratedSearchJob": {
+    "Child": {},
+    "ProposedQuery": {
+      "Description": "apply language filter for pattern",
+      "Query": "context:global lang:Python",
+      "PatternType": 1
+    }
+  }
+}


### PR DESCRIPTION
Examples:
![Screen Shot 2022-06-10 at 4 06 20 PM](https://user-images.githubusercontent.com/888624/173161114-cebe949c-3056-4f6b-b01b-39b776c8756d.png)

![Screen Shot 2022-06-10 at 4 06 34 PM](https://user-images.githubusercontent.com/888624/173161120-563fbf3f-1628-48bb-82f8-362da6c66853.png)




Neither of these searches previously returned results. Useful yes? :-3


## Test plan
Added unit tests.
