### PR TITLE
observation: disable SRC_TRACE_LOG by default

### DIFF
--- a/internal/observation/observation.go
+++ b/internal/observation/observation.go
@@ -23,10 +23,10 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
-// enableTraceLog toggles whether TraceLogger.Log events should be logged at info level.
-// This is useful in dev environments, or in environments where OpenTracing/OpenTelemetry
-// logs/events are supported (i.e. not Datadog).
-var enableTraceLog = os.Getenv("SRC_TRACE_LOG") != "false"
+// enableTraceLog toggles whether TraceLogger.Log events should be logged at info level,
+// which is useful in environments like Datadog that don't support OpenTrace/OpenTelemetry
+// trace log events.
+var enableTraceLog = os.Getenv("SRC_TRACE_LOG") == "true"
 
 // Context carries context about where to send logs, trace spans, and register
 // metrics. It should be created once on service startup, and passed around to


### PR DESCRIPTION
See https://github.com/sourcegraph/sourcegraph/pull/34456#discussion_r894935250 . In hindsight this should be only-optin since we risk spamming log output.

PR to enable this explicitly in Cloud for Datadog: https://github.com/sourcegraph/deploy-sourcegraph-cloud/pull/16872

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

n/a