### PR TITLE
search: lucky rule interprets patterns as type

### DIFF
--- a/internal/search/job/jobutil/feeling_lucky_search_job_test.go
+++ b/internal/search/job/jobutil/feeling_lucky_search_job_test.go
@@ -61,4 +61,16 @@ func TestNewFeelingLuckySearchJob(t *testing.T) {
 	t.Run("one of many patterns as lang", func(t *testing.T) {
 		autogold.Equal(t, autogold.Raw(test(`context:global parse python`)))
 	})
+
+	t.Run("pattern as type", func(t *testing.T) {
+		autogold.Equal(t, autogold.Raw(test(`context:global fix commit`)))
+	})
+
+	t.Run("pattern as type multi patterns", func(t *testing.T) {
+		autogold.Equal(t, autogold.Raw(test(`context:global code monitor commit`)))
+	})
+
+	t.Run("pattern as type with expression", func(t *testing.T) {
+		autogold.Equal(t, autogold.Raw(test(`context:global code or monitor commit`)))
+	})
 }

--- a/internal/search/job/jobutil/testdata/TestNewFeelingLuckySearchJob/pattern_as_type.golden
+++ b/internal/search/job/jobutil/testdata/TestNewFeelingLuckySearchJob/pattern_as_type.golden
@@ -1,0 +1,24 @@
+{
+  "OR": [
+    {
+      "GeneratedSearchJob": {
+        "Child": {},
+        "ProposedQuery": {
+          "Description": "apply search type for pattern",
+          "Query": "context:global type:commit fix",
+          "PatternType": 1
+        }
+      }
+    },
+    {
+      "GeneratedSearchJob": {
+        "Child": {},
+        "ProposedQuery": {
+          "Description": "AND patterns together",
+          "Query": "context:global (fix AND commit)",
+          "PatternType": 1
+        }
+      }
+    }
+  ]
+}

--- a/internal/search/job/jobutil/testdata/TestNewFeelingLuckySearchJob/pattern_as_type_multi_patterns.golden
+++ b/internal/search/job/jobutil/testdata/TestNewFeelingLuckySearchJob/pattern_as_type_multi_patterns.golden
@@ -1,0 +1,24 @@
+{
+  "OR": [
+    {
+      "GeneratedSearchJob": {
+        "Child": {},
+        "ProposedQuery": {
+          "Description": "apply search type for pattern",
+          "Query": "context:global type:commit code monitor",
+          "PatternType": 1
+        }
+      }
+    },
+    {
+      "GeneratedSearchJob": {
+        "Child": {},
+        "ProposedQuery": {
+          "Description": "AND patterns together",
+          "Query": "context:global (code AND monitor AND commit)",
+          "PatternType": 1
+        }
+      }
+    }
+  ]
+}

--- a/internal/search/job/jobutil/testdata/TestNewFeelingLuckySearchJob/pattern_as_type_with_expression.golden
+++ b/internal/search/job/jobutil/testdata/TestNewFeelingLuckySearchJob/pattern_as_type_with_expression.golden
@@ -1,0 +1,24 @@
+{
+  "OR": [
+    {
+      "GeneratedSearchJob": {
+        "Child": {},
+        "ProposedQuery": {
+          "Description": "apply search type for pattern",
+          "Query": "context:global type:commit (code OR monitor)",
+          "PatternType": 1
+        }
+      }
+    },
+    {
+      "GeneratedSearchJob": {
+        "Child": {},
+        "ProposedQuery": {
+          "Description": "AND patterns together",
+          "Query": "context:global (code OR (monitor AND commit))",
+          "PatternType": 1
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Stacked on https://github.com/sourcegraph/sourcegraph/pull/37057.

Now you just type something like `commit` or `symbol` in the query and it will search for that `type`.


## Test plan
Added test.
