### PR TITLE
Backend: convert TransactableHandle to an interface

### DIFF
--- a/cmd/frontend/graphqlbackend/webhook_logs_test.go
+++ b/cmd/frontend/graphqlbackend/webhook_logs_test.go
@@ -2,6 +2,7 @@ package graphqlbackend
 
 import (
 	"context"
+	"database/sql"
 	"testing"
 	"time"
 
@@ -137,14 +138,10 @@ func TestWebhookLogConnectionResolver(t *testing.T) {
 		logs = append(logs, &types.WebhookLog{})
 	}
 
-	// We also need a fake TransactableHandle to be able to construct
-	// webhookLogResolvers.
-	db := &basestore.OldTransactableHandle{}
-
 	createMockStore := func(logs []*types.WebhookLog, next int64, err error) *database.MockWebhookLogStore {
 		store := database.NewMockWebhookLogStore()
 		store.ListFunc.SetDefaultReturn(logs, next, err)
-		store.HandleFunc.SetDefaultReturn(db)
+		store.HandleFunc.SetDefaultReturn(basestore.NewHandleWithDB(nil, sql.TxOptions{}))
 
 		return store
 	}

--- a/cmd/frontend/graphqlbackend/webhook_logs_test.go
+++ b/cmd/frontend/graphqlbackend/webhook_logs_test.go
@@ -139,7 +139,7 @@ func TestWebhookLogConnectionResolver(t *testing.T) {
 
 	// We also need a fake TransactableHandle to be able to construct
 	// webhookLogResolvers.
-	db := &basestore.TransactableHandle{}
+	db := &basestore.OldTransactableHandle{}
 
 	createMockStore := func(logs []*types.WebhookLog, next int64, err error) *database.MockWebhookLogStore {
 		store := database.NewMockWebhookLogStore()

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/mocks_test.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/mocks_test.go
@@ -4605,7 +4605,7 @@ func NewMockEnqueuerDBStore() *MockEnqueuerDBStore {
 			},
 		},
 		HandleFunc: &EnqueuerDBStoreHandleFunc{
-			defaultHook: func() (r0 *basestore.TransactableHandle) {
+			defaultHook: func() (r0 *basestore.OldTransactableHandle) {
 				return
 			},
 		},
@@ -4657,7 +4657,7 @@ func NewStrictMockEnqueuerDBStore() *MockEnqueuerDBStore {
 			},
 		},
 		HandleFunc: &EnqueuerDBStoreHandleFunc{
-			defaultHook: func() *basestore.TransactableHandle {
+			defaultHook: func() *basestore.OldTransactableHandle {
 				panic("unexpected invocation of MockEnqueuerDBStore.Handle")
 			},
 		},
@@ -5166,15 +5166,15 @@ func (c EnqueuerDBStoreGetIndexesByIDsFuncCall) Results() []interface{} {
 // EnqueuerDBStoreHandleFunc describes the behavior when the Handle method
 // of the parent MockEnqueuerDBStore instance is invoked.
 type EnqueuerDBStoreHandleFunc struct {
-	defaultHook func() *basestore.TransactableHandle
-	hooks       []func() *basestore.TransactableHandle
+	defaultHook func() *basestore.OldTransactableHandle
+	hooks       []func() *basestore.OldTransactableHandle
 	history     []EnqueuerDBStoreHandleFuncCall
 	mutex       sync.Mutex
 }
 
 // Handle delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockEnqueuerDBStore) Handle() *basestore.TransactableHandle {
+func (m *MockEnqueuerDBStore) Handle() *basestore.OldTransactableHandle {
 	r0 := m.HandleFunc.nextHook()()
 	m.HandleFunc.appendCall(EnqueuerDBStoreHandleFuncCall{r0})
 	return r0
@@ -5183,7 +5183,7 @@ func (m *MockEnqueuerDBStore) Handle() *basestore.TransactableHandle {
 // SetDefaultHook sets function that is called when the Handle method of the
 // parent MockEnqueuerDBStore instance is invoked and the hook queue is
 // empty.
-func (f *EnqueuerDBStoreHandleFunc) SetDefaultHook(hook func() *basestore.TransactableHandle) {
+func (f *EnqueuerDBStoreHandleFunc) SetDefaultHook(hook func() *basestore.OldTransactableHandle) {
 	f.defaultHook = hook
 }
 
@@ -5191,7 +5191,7 @@ func (f *EnqueuerDBStoreHandleFunc) SetDefaultHook(hook func() *basestore.Transa
 // Handle method of the parent MockEnqueuerDBStore instance invokes the hook
 // at the front of the queue and discards it. After the queue is empty, the
 // default hook function is invoked for any future action.
-func (f *EnqueuerDBStoreHandleFunc) PushHook(hook func() *basestore.TransactableHandle) {
+func (f *EnqueuerDBStoreHandleFunc) PushHook(hook func() *basestore.OldTransactableHandle) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -5199,20 +5199,20 @@ func (f *EnqueuerDBStoreHandleFunc) PushHook(hook func() *basestore.Transactable
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *EnqueuerDBStoreHandleFunc) SetDefaultReturn(r0 *basestore.TransactableHandle) {
-	f.SetDefaultHook(func() *basestore.TransactableHandle {
+func (f *EnqueuerDBStoreHandleFunc) SetDefaultReturn(r0 *basestore.OldTransactableHandle) {
+	f.SetDefaultHook(func() *basestore.OldTransactableHandle {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *EnqueuerDBStoreHandleFunc) PushReturn(r0 *basestore.TransactableHandle) {
-	f.PushHook(func() *basestore.TransactableHandle {
+func (f *EnqueuerDBStoreHandleFunc) PushReturn(r0 *basestore.OldTransactableHandle) {
+	f.PushHook(func() *basestore.OldTransactableHandle {
 		return r0
 	})
 }
 
-func (f *EnqueuerDBStoreHandleFunc) nextHook() func() *basestore.TransactableHandle {
+func (f *EnqueuerDBStoreHandleFunc) nextHook() func() *basestore.OldTransactableHandle {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -5247,7 +5247,7 @@ func (f *EnqueuerDBStoreHandleFunc) History() []EnqueuerDBStoreHandleFuncCall {
 type EnqueuerDBStoreHandleFuncCall struct {
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 *basestore.TransactableHandle
+	Result0 *basestore.OldTransactableHandle
 }
 
 // Args returns an interface slice containing the arguments of this

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/mocks_test.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/mocks_test.go
@@ -4605,7 +4605,7 @@ func NewMockEnqueuerDBStore() *MockEnqueuerDBStore {
 			},
 		},
 		HandleFunc: &EnqueuerDBStoreHandleFunc{
-			defaultHook: func() (r0 *basestore.OldTransactableHandle) {
+			defaultHook: func() (r0 basestore.TransactableHandle) {
 				return
 			},
 		},
@@ -4657,7 +4657,7 @@ func NewStrictMockEnqueuerDBStore() *MockEnqueuerDBStore {
 			},
 		},
 		HandleFunc: &EnqueuerDBStoreHandleFunc{
-			defaultHook: func() *basestore.OldTransactableHandle {
+			defaultHook: func() basestore.TransactableHandle {
 				panic("unexpected invocation of MockEnqueuerDBStore.Handle")
 			},
 		},
@@ -5166,15 +5166,15 @@ func (c EnqueuerDBStoreGetIndexesByIDsFuncCall) Results() []interface{} {
 // EnqueuerDBStoreHandleFunc describes the behavior when the Handle method
 // of the parent MockEnqueuerDBStore instance is invoked.
 type EnqueuerDBStoreHandleFunc struct {
-	defaultHook func() *basestore.OldTransactableHandle
-	hooks       []func() *basestore.OldTransactableHandle
+	defaultHook func() basestore.TransactableHandle
+	hooks       []func() basestore.TransactableHandle
 	history     []EnqueuerDBStoreHandleFuncCall
 	mutex       sync.Mutex
 }
 
 // Handle delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockEnqueuerDBStore) Handle() *basestore.OldTransactableHandle {
+func (m *MockEnqueuerDBStore) Handle() basestore.TransactableHandle {
 	r0 := m.HandleFunc.nextHook()()
 	m.HandleFunc.appendCall(EnqueuerDBStoreHandleFuncCall{r0})
 	return r0
@@ -5183,7 +5183,7 @@ func (m *MockEnqueuerDBStore) Handle() *basestore.OldTransactableHandle {
 // SetDefaultHook sets function that is called when the Handle method of the
 // parent MockEnqueuerDBStore instance is invoked and the hook queue is
 // empty.
-func (f *EnqueuerDBStoreHandleFunc) SetDefaultHook(hook func() *basestore.OldTransactableHandle) {
+func (f *EnqueuerDBStoreHandleFunc) SetDefaultHook(hook func() basestore.TransactableHandle) {
 	f.defaultHook = hook
 }
 
@@ -5191,7 +5191,7 @@ func (f *EnqueuerDBStoreHandleFunc) SetDefaultHook(hook func() *basestore.OldTra
 // Handle method of the parent MockEnqueuerDBStore instance invokes the hook
 // at the front of the queue and discards it. After the queue is empty, the
 // default hook function is invoked for any future action.
-func (f *EnqueuerDBStoreHandleFunc) PushHook(hook func() *basestore.OldTransactableHandle) {
+func (f *EnqueuerDBStoreHandleFunc) PushHook(hook func() basestore.TransactableHandle) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -5199,20 +5199,20 @@ func (f *EnqueuerDBStoreHandleFunc) PushHook(hook func() *basestore.OldTransacta
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *EnqueuerDBStoreHandleFunc) SetDefaultReturn(r0 *basestore.OldTransactableHandle) {
-	f.SetDefaultHook(func() *basestore.OldTransactableHandle {
+func (f *EnqueuerDBStoreHandleFunc) SetDefaultReturn(r0 basestore.TransactableHandle) {
+	f.SetDefaultHook(func() basestore.TransactableHandle {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *EnqueuerDBStoreHandleFunc) PushReturn(r0 *basestore.OldTransactableHandle) {
-	f.PushHook(func() *basestore.OldTransactableHandle {
+func (f *EnqueuerDBStoreHandleFunc) PushReturn(r0 basestore.TransactableHandle) {
+	f.PushHook(func() basestore.TransactableHandle {
 		return r0
 	})
 }
 
-func (f *EnqueuerDBStoreHandleFunc) nextHook() func() *basestore.OldTransactableHandle {
+func (f *EnqueuerDBStoreHandleFunc) nextHook() func() basestore.TransactableHandle {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -5247,7 +5247,7 @@ func (f *EnqueuerDBStoreHandleFunc) History() []EnqueuerDBStoreHandleFuncCall {
 type EnqueuerDBStoreHandleFuncCall struct {
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 *basestore.OldTransactableHandle
+	Result0 basestore.TransactableHandle
 }
 
 // Args returns an interface slice containing the arguments of this

--- a/enterprise/cmd/frontend/internal/registry/stores/dbmocks/mocks_temp.go
+++ b/enterprise/cmd/frontend/internal/registry/stores/dbmocks/mocks_temp.go
@@ -116,7 +116,7 @@ func NewMockExtensionStore() *MockExtensionStore {
 			},
 		},
 		HandleFunc: &ExtensionStoreHandleFunc{
-			defaultHook: func() (r0 *basestore.OldTransactableHandle) {
+			defaultHook: func() (r0 basestore.TransactableHandle) {
 				return
 			},
 		},
@@ -198,7 +198,7 @@ func NewStrictMockExtensionStore() *MockExtensionStore {
 			},
 		},
 		HandleFunc: &ExtensionStoreHandleFunc{
-			defaultHook: func() *basestore.OldTransactableHandle {
+			defaultHook: func() basestore.TransactableHandle {
 				panic("unexpected invocation of MockExtensionStore.Handle")
 			},
 		},
@@ -1265,15 +1265,15 @@ func (c ExtensionStoreGetPublisherFuncCall) Results() []interface{} {
 // ExtensionStoreHandleFunc describes the behavior when the Handle method of
 // the parent MockExtensionStore instance is invoked.
 type ExtensionStoreHandleFunc struct {
-	defaultHook func() *basestore.OldTransactableHandle
-	hooks       []func() *basestore.OldTransactableHandle
+	defaultHook func() basestore.TransactableHandle
+	hooks       []func() basestore.TransactableHandle
 	history     []ExtensionStoreHandleFuncCall
 	mutex       sync.Mutex
 }
 
 // Handle delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockExtensionStore) Handle() *basestore.OldTransactableHandle {
+func (m *MockExtensionStore) Handle() basestore.TransactableHandle {
 	r0 := m.HandleFunc.nextHook()()
 	m.HandleFunc.appendCall(ExtensionStoreHandleFuncCall{r0})
 	return r0
@@ -1282,7 +1282,7 @@ func (m *MockExtensionStore) Handle() *basestore.OldTransactableHandle {
 // SetDefaultHook sets function that is called when the Handle method of the
 // parent MockExtensionStore instance is invoked and the hook queue is
 // empty.
-func (f *ExtensionStoreHandleFunc) SetDefaultHook(hook func() *basestore.OldTransactableHandle) {
+func (f *ExtensionStoreHandleFunc) SetDefaultHook(hook func() basestore.TransactableHandle) {
 	f.defaultHook = hook
 }
 
@@ -1290,7 +1290,7 @@ func (f *ExtensionStoreHandleFunc) SetDefaultHook(hook func() *basestore.OldTran
 // Handle method of the parent MockExtensionStore instance invokes the hook
 // at the front of the queue and discards it. After the queue is empty, the
 // default hook function is invoked for any future action.
-func (f *ExtensionStoreHandleFunc) PushHook(hook func() *basestore.OldTransactableHandle) {
+func (f *ExtensionStoreHandleFunc) PushHook(hook func() basestore.TransactableHandle) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -1298,20 +1298,20 @@ func (f *ExtensionStoreHandleFunc) PushHook(hook func() *basestore.OldTransactab
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *ExtensionStoreHandleFunc) SetDefaultReturn(r0 *basestore.OldTransactableHandle) {
-	f.SetDefaultHook(func() *basestore.OldTransactableHandle {
+func (f *ExtensionStoreHandleFunc) SetDefaultReturn(r0 basestore.TransactableHandle) {
+	f.SetDefaultHook(func() basestore.TransactableHandle {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *ExtensionStoreHandleFunc) PushReturn(r0 *basestore.OldTransactableHandle) {
-	f.PushHook(func() *basestore.OldTransactableHandle {
+func (f *ExtensionStoreHandleFunc) PushReturn(r0 basestore.TransactableHandle) {
+	f.PushHook(func() basestore.TransactableHandle {
 		return r0
 	})
 }
 
-func (f *ExtensionStoreHandleFunc) nextHook() func() *basestore.OldTransactableHandle {
+func (f *ExtensionStoreHandleFunc) nextHook() func() basestore.TransactableHandle {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -1346,7 +1346,7 @@ func (f *ExtensionStoreHandleFunc) History() []ExtensionStoreHandleFuncCall {
 type ExtensionStoreHandleFuncCall struct {
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 *basestore.OldTransactableHandle
+	Result0 basestore.TransactableHandle
 }
 
 // Args returns an interface slice containing the arguments of this
@@ -1946,7 +1946,7 @@ func NewMockReleaseStore() *MockReleaseStore {
 			},
 		},
 		HandleFunc: &ReleaseStoreHandleFunc{
-			defaultHook: func() (r0 *basestore.OldTransactableHandle) {
+			defaultHook: func() (r0 basestore.TransactableHandle) {
 				return
 			},
 		},
@@ -1988,7 +1988,7 @@ func NewStrictMockReleaseStore() *MockReleaseStore {
 			},
 		},
 		HandleFunc: &ReleaseStoreHandleFunc{
-			defaultHook: func() *basestore.OldTransactableHandle {
+			defaultHook: func() basestore.TransactableHandle {
 				panic("unexpected invocation of MockReleaseStore.Handle")
 			},
 		},
@@ -2483,15 +2483,15 @@ func (c ReleaseStoreGetLatestBatchFuncCall) Results() []interface{} {
 // ReleaseStoreHandleFunc describes the behavior when the Handle method of
 // the parent MockReleaseStore instance is invoked.
 type ReleaseStoreHandleFunc struct {
-	defaultHook func() *basestore.OldTransactableHandle
-	hooks       []func() *basestore.OldTransactableHandle
+	defaultHook func() basestore.TransactableHandle
+	hooks       []func() basestore.TransactableHandle
 	history     []ReleaseStoreHandleFuncCall
 	mutex       sync.Mutex
 }
 
 // Handle delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockReleaseStore) Handle() *basestore.OldTransactableHandle {
+func (m *MockReleaseStore) Handle() basestore.TransactableHandle {
 	r0 := m.HandleFunc.nextHook()()
 	m.HandleFunc.appendCall(ReleaseStoreHandleFuncCall{r0})
 	return r0
@@ -2499,7 +2499,7 @@ func (m *MockReleaseStore) Handle() *basestore.OldTransactableHandle {
 
 // SetDefaultHook sets function that is called when the Handle method of the
 // parent MockReleaseStore instance is invoked and the hook queue is empty.
-func (f *ReleaseStoreHandleFunc) SetDefaultHook(hook func() *basestore.OldTransactableHandle) {
+func (f *ReleaseStoreHandleFunc) SetDefaultHook(hook func() basestore.TransactableHandle) {
 	f.defaultHook = hook
 }
 
@@ -2507,7 +2507,7 @@ func (f *ReleaseStoreHandleFunc) SetDefaultHook(hook func() *basestore.OldTransa
 // Handle method of the parent MockReleaseStore instance invokes the hook at
 // the front of the queue and discards it. After the queue is empty, the
 // default hook function is invoked for any future action.
-func (f *ReleaseStoreHandleFunc) PushHook(hook func() *basestore.OldTransactableHandle) {
+func (f *ReleaseStoreHandleFunc) PushHook(hook func() basestore.TransactableHandle) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -2515,20 +2515,20 @@ func (f *ReleaseStoreHandleFunc) PushHook(hook func() *basestore.OldTransactable
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *ReleaseStoreHandleFunc) SetDefaultReturn(r0 *basestore.OldTransactableHandle) {
-	f.SetDefaultHook(func() *basestore.OldTransactableHandle {
+func (f *ReleaseStoreHandleFunc) SetDefaultReturn(r0 basestore.TransactableHandle) {
+	f.SetDefaultHook(func() basestore.TransactableHandle {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *ReleaseStoreHandleFunc) PushReturn(r0 *basestore.OldTransactableHandle) {
-	f.PushHook(func() *basestore.OldTransactableHandle {
+func (f *ReleaseStoreHandleFunc) PushReturn(r0 basestore.TransactableHandle) {
+	f.PushHook(func() basestore.TransactableHandle {
 		return r0
 	})
 }
 
-func (f *ReleaseStoreHandleFunc) nextHook() func() *basestore.OldTransactableHandle {
+func (f *ReleaseStoreHandleFunc) nextHook() func() basestore.TransactableHandle {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -2563,7 +2563,7 @@ func (f *ReleaseStoreHandleFunc) History() []ReleaseStoreHandleFuncCall {
 type ReleaseStoreHandleFuncCall struct {
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 *basestore.OldTransactableHandle
+	Result0 basestore.TransactableHandle
 }
 
 // Args returns an interface slice containing the arguments of this

--- a/enterprise/cmd/frontend/internal/registry/stores/dbmocks/mocks_temp.go
+++ b/enterprise/cmd/frontend/internal/registry/stores/dbmocks/mocks_temp.go
@@ -116,7 +116,7 @@ func NewMockExtensionStore() *MockExtensionStore {
 			},
 		},
 		HandleFunc: &ExtensionStoreHandleFunc{
-			defaultHook: func() (r0 *basestore.TransactableHandle) {
+			defaultHook: func() (r0 *basestore.OldTransactableHandle) {
 				return
 			},
 		},
@@ -198,7 +198,7 @@ func NewStrictMockExtensionStore() *MockExtensionStore {
 			},
 		},
 		HandleFunc: &ExtensionStoreHandleFunc{
-			defaultHook: func() *basestore.TransactableHandle {
+			defaultHook: func() *basestore.OldTransactableHandle {
 				panic("unexpected invocation of MockExtensionStore.Handle")
 			},
 		},
@@ -1265,15 +1265,15 @@ func (c ExtensionStoreGetPublisherFuncCall) Results() []interface{} {
 // ExtensionStoreHandleFunc describes the behavior when the Handle method of
 // the parent MockExtensionStore instance is invoked.
 type ExtensionStoreHandleFunc struct {
-	defaultHook func() *basestore.TransactableHandle
-	hooks       []func() *basestore.TransactableHandle
+	defaultHook func() *basestore.OldTransactableHandle
+	hooks       []func() *basestore.OldTransactableHandle
 	history     []ExtensionStoreHandleFuncCall
 	mutex       sync.Mutex
 }
 
 // Handle delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockExtensionStore) Handle() *basestore.TransactableHandle {
+func (m *MockExtensionStore) Handle() *basestore.OldTransactableHandle {
 	r0 := m.HandleFunc.nextHook()()
 	m.HandleFunc.appendCall(ExtensionStoreHandleFuncCall{r0})
 	return r0
@@ -1282,7 +1282,7 @@ func (m *MockExtensionStore) Handle() *basestore.TransactableHandle {
 // SetDefaultHook sets function that is called when the Handle method of the
 // parent MockExtensionStore instance is invoked and the hook queue is
 // empty.
-func (f *ExtensionStoreHandleFunc) SetDefaultHook(hook func() *basestore.TransactableHandle) {
+func (f *ExtensionStoreHandleFunc) SetDefaultHook(hook func() *basestore.OldTransactableHandle) {
 	f.defaultHook = hook
 }
 
@@ -1290,7 +1290,7 @@ func (f *ExtensionStoreHandleFunc) SetDefaultHook(hook func() *basestore.Transac
 // Handle method of the parent MockExtensionStore instance invokes the hook
 // at the front of the queue and discards it. After the queue is empty, the
 // default hook function is invoked for any future action.
-func (f *ExtensionStoreHandleFunc) PushHook(hook func() *basestore.TransactableHandle) {
+func (f *ExtensionStoreHandleFunc) PushHook(hook func() *basestore.OldTransactableHandle) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -1298,20 +1298,20 @@ func (f *ExtensionStoreHandleFunc) PushHook(hook func() *basestore.TransactableH
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *ExtensionStoreHandleFunc) SetDefaultReturn(r0 *basestore.TransactableHandle) {
-	f.SetDefaultHook(func() *basestore.TransactableHandle {
+func (f *ExtensionStoreHandleFunc) SetDefaultReturn(r0 *basestore.OldTransactableHandle) {
+	f.SetDefaultHook(func() *basestore.OldTransactableHandle {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *ExtensionStoreHandleFunc) PushReturn(r0 *basestore.TransactableHandle) {
-	f.PushHook(func() *basestore.TransactableHandle {
+func (f *ExtensionStoreHandleFunc) PushReturn(r0 *basestore.OldTransactableHandle) {
+	f.PushHook(func() *basestore.OldTransactableHandle {
 		return r0
 	})
 }
 
-func (f *ExtensionStoreHandleFunc) nextHook() func() *basestore.TransactableHandle {
+func (f *ExtensionStoreHandleFunc) nextHook() func() *basestore.OldTransactableHandle {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -1346,7 +1346,7 @@ func (f *ExtensionStoreHandleFunc) History() []ExtensionStoreHandleFuncCall {
 type ExtensionStoreHandleFuncCall struct {
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 *basestore.TransactableHandle
+	Result0 *basestore.OldTransactableHandle
 }
 
 // Args returns an interface slice containing the arguments of this
@@ -1946,7 +1946,7 @@ func NewMockReleaseStore() *MockReleaseStore {
 			},
 		},
 		HandleFunc: &ReleaseStoreHandleFunc{
-			defaultHook: func() (r0 *basestore.TransactableHandle) {
+			defaultHook: func() (r0 *basestore.OldTransactableHandle) {
 				return
 			},
 		},
@@ -1988,7 +1988,7 @@ func NewStrictMockReleaseStore() *MockReleaseStore {
 			},
 		},
 		HandleFunc: &ReleaseStoreHandleFunc{
-			defaultHook: func() *basestore.TransactableHandle {
+			defaultHook: func() *basestore.OldTransactableHandle {
 				panic("unexpected invocation of MockReleaseStore.Handle")
 			},
 		},
@@ -2483,15 +2483,15 @@ func (c ReleaseStoreGetLatestBatchFuncCall) Results() []interface{} {
 // ReleaseStoreHandleFunc describes the behavior when the Handle method of
 // the parent MockReleaseStore instance is invoked.
 type ReleaseStoreHandleFunc struct {
-	defaultHook func() *basestore.TransactableHandle
-	hooks       []func() *basestore.TransactableHandle
+	defaultHook func() *basestore.OldTransactableHandle
+	hooks       []func() *basestore.OldTransactableHandle
 	history     []ReleaseStoreHandleFuncCall
 	mutex       sync.Mutex
 }
 
 // Handle delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockReleaseStore) Handle() *basestore.TransactableHandle {
+func (m *MockReleaseStore) Handle() *basestore.OldTransactableHandle {
 	r0 := m.HandleFunc.nextHook()()
 	m.HandleFunc.appendCall(ReleaseStoreHandleFuncCall{r0})
 	return r0
@@ -2499,7 +2499,7 @@ func (m *MockReleaseStore) Handle() *basestore.TransactableHandle {
 
 // SetDefaultHook sets function that is called when the Handle method of the
 // parent MockReleaseStore instance is invoked and the hook queue is empty.
-func (f *ReleaseStoreHandleFunc) SetDefaultHook(hook func() *basestore.TransactableHandle) {
+func (f *ReleaseStoreHandleFunc) SetDefaultHook(hook func() *basestore.OldTransactableHandle) {
 	f.defaultHook = hook
 }
 
@@ -2507,7 +2507,7 @@ func (f *ReleaseStoreHandleFunc) SetDefaultHook(hook func() *basestore.Transacta
 // Handle method of the parent MockReleaseStore instance invokes the hook at
 // the front of the queue and discards it. After the queue is empty, the
 // default hook function is invoked for any future action.
-func (f *ReleaseStoreHandleFunc) PushHook(hook func() *basestore.TransactableHandle) {
+func (f *ReleaseStoreHandleFunc) PushHook(hook func() *basestore.OldTransactableHandle) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -2515,20 +2515,20 @@ func (f *ReleaseStoreHandleFunc) PushHook(hook func() *basestore.TransactableHan
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *ReleaseStoreHandleFunc) SetDefaultReturn(r0 *basestore.TransactableHandle) {
-	f.SetDefaultHook(func() *basestore.TransactableHandle {
+func (f *ReleaseStoreHandleFunc) SetDefaultReturn(r0 *basestore.OldTransactableHandle) {
+	f.SetDefaultHook(func() *basestore.OldTransactableHandle {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *ReleaseStoreHandleFunc) PushReturn(r0 *basestore.TransactableHandle) {
-	f.PushHook(func() *basestore.TransactableHandle {
+func (f *ReleaseStoreHandleFunc) PushReturn(r0 *basestore.OldTransactableHandle) {
+	f.PushHook(func() *basestore.OldTransactableHandle {
 		return r0
 	})
 }
 
-func (f *ReleaseStoreHandleFunc) nextHook() func() *basestore.TransactableHandle {
+func (f *ReleaseStoreHandleFunc) nextHook() func() *basestore.OldTransactableHandle {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -2563,7 +2563,7 @@ func (f *ReleaseStoreHandleFunc) History() []ReleaseStoreHandleFuncCall {
 type ReleaseStoreHandleFuncCall struct {
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 *basestore.TransactableHandle
+	Result0 *basestore.OldTransactableHandle
 }
 
 // Args returns an interface slice containing the arguments of this

--- a/enterprise/cmd/precise-code-intel-worker/internal/worker/mocks_test.go
+++ b/enterprise/cmd/precise-code-intel-worker/internal/worker/mocks_test.go
@@ -82,7 +82,7 @@ func NewMockDBStore() *MockDBStore {
 			},
 		},
 		HandleFunc: &DBStoreHandleFunc{
-			defaultHook: func() (r0 *basestore.TransactableHandle) {
+			defaultHook: func() (r0 *basestore.OldTransactableHandle) {
 				return
 			},
 		},
@@ -154,7 +154,7 @@ func NewStrictMockDBStore() *MockDBStore {
 			},
 		},
 		HandleFunc: &DBStoreHandleFunc{
-			defaultHook: func() *basestore.TransactableHandle {
+			defaultHook: func() *basestore.OldTransactableHandle {
 				panic("unexpected invocation of MockDBStore.Handle")
 			},
 		},
@@ -477,15 +477,15 @@ func (c DBStoreDoneFuncCall) Results() []interface{} {
 // DBStoreHandleFunc describes the behavior when the Handle method of the
 // parent MockDBStore instance is invoked.
 type DBStoreHandleFunc struct {
-	defaultHook func() *basestore.TransactableHandle
-	hooks       []func() *basestore.TransactableHandle
+	defaultHook func() *basestore.OldTransactableHandle
+	hooks       []func() *basestore.OldTransactableHandle
 	history     []DBStoreHandleFuncCall
 	mutex       sync.Mutex
 }
 
 // Handle delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockDBStore) Handle() *basestore.TransactableHandle {
+func (m *MockDBStore) Handle() *basestore.OldTransactableHandle {
 	r0 := m.HandleFunc.nextHook()()
 	m.HandleFunc.appendCall(DBStoreHandleFuncCall{r0})
 	return r0
@@ -493,7 +493,7 @@ func (m *MockDBStore) Handle() *basestore.TransactableHandle {
 
 // SetDefaultHook sets function that is called when the Handle method of the
 // parent MockDBStore instance is invoked and the hook queue is empty.
-func (f *DBStoreHandleFunc) SetDefaultHook(hook func() *basestore.TransactableHandle) {
+func (f *DBStoreHandleFunc) SetDefaultHook(hook func() *basestore.OldTransactableHandle) {
 	f.defaultHook = hook
 }
 
@@ -501,7 +501,7 @@ func (f *DBStoreHandleFunc) SetDefaultHook(hook func() *basestore.TransactableHa
 // Handle method of the parent MockDBStore instance invokes the hook at the
 // front of the queue and discards it. After the queue is empty, the default
 // hook function is invoked for any future action.
-func (f *DBStoreHandleFunc) PushHook(hook func() *basestore.TransactableHandle) {
+func (f *DBStoreHandleFunc) PushHook(hook func() *basestore.OldTransactableHandle) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -509,20 +509,20 @@ func (f *DBStoreHandleFunc) PushHook(hook func() *basestore.TransactableHandle) 
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *DBStoreHandleFunc) SetDefaultReturn(r0 *basestore.TransactableHandle) {
-	f.SetDefaultHook(func() *basestore.TransactableHandle {
+func (f *DBStoreHandleFunc) SetDefaultReturn(r0 *basestore.OldTransactableHandle) {
+	f.SetDefaultHook(func() *basestore.OldTransactableHandle {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *DBStoreHandleFunc) PushReturn(r0 *basestore.TransactableHandle) {
-	f.PushHook(func() *basestore.TransactableHandle {
+func (f *DBStoreHandleFunc) PushReturn(r0 *basestore.OldTransactableHandle) {
+	f.PushHook(func() *basestore.OldTransactableHandle {
 		return r0
 	})
 }
 
-func (f *DBStoreHandleFunc) nextHook() func() *basestore.TransactableHandle {
+func (f *DBStoreHandleFunc) nextHook() func() *basestore.OldTransactableHandle {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -557,7 +557,7 @@ func (f *DBStoreHandleFunc) History() []DBStoreHandleFuncCall {
 type DBStoreHandleFuncCall struct {
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 *basestore.TransactableHandle
+	Result0 *basestore.OldTransactableHandle
 }
 
 // Args returns an interface slice containing the arguments of this
@@ -3295,7 +3295,7 @@ func NewMockWorkerStore() *MockWorkerStore {
 			},
 		},
 		HandleFunc: &WorkerStoreHandleFunc{
-			defaultHook: func() (r0 *basestore.TransactableHandle) {
+			defaultHook: func() (r0 *basestore.OldTransactableHandle) {
 				return
 			},
 		},
@@ -3367,7 +3367,7 @@ func NewStrictMockWorkerStore() *MockWorkerStore {
 			},
 		},
 		HandleFunc: &WorkerStoreHandleFunc{
-			defaultHook: func() *basestore.TransactableHandle {
+			defaultHook: func() *basestore.OldTransactableHandle {
 				panic("unexpected invocation of MockWorkerStore.Handle")
 			},
 		},
@@ -3705,15 +3705,15 @@ func (c WorkerStoreDequeueFuncCall) Results() []interface{} {
 // WorkerStoreHandleFunc describes the behavior when the Handle method of
 // the parent MockWorkerStore instance is invoked.
 type WorkerStoreHandleFunc struct {
-	defaultHook func() *basestore.TransactableHandle
-	hooks       []func() *basestore.TransactableHandle
+	defaultHook func() *basestore.OldTransactableHandle
+	hooks       []func() *basestore.OldTransactableHandle
 	history     []WorkerStoreHandleFuncCall
 	mutex       sync.Mutex
 }
 
 // Handle delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockWorkerStore) Handle() *basestore.TransactableHandle {
+func (m *MockWorkerStore) Handle() *basestore.OldTransactableHandle {
 	r0 := m.HandleFunc.nextHook()()
 	m.HandleFunc.appendCall(WorkerStoreHandleFuncCall{r0})
 	return r0
@@ -3721,7 +3721,7 @@ func (m *MockWorkerStore) Handle() *basestore.TransactableHandle {
 
 // SetDefaultHook sets function that is called when the Handle method of the
 // parent MockWorkerStore instance is invoked and the hook queue is empty.
-func (f *WorkerStoreHandleFunc) SetDefaultHook(hook func() *basestore.TransactableHandle) {
+func (f *WorkerStoreHandleFunc) SetDefaultHook(hook func() *basestore.OldTransactableHandle) {
 	f.defaultHook = hook
 }
 
@@ -3729,7 +3729,7 @@ func (f *WorkerStoreHandleFunc) SetDefaultHook(hook func() *basestore.Transactab
 // Handle method of the parent MockWorkerStore instance invokes the hook at
 // the front of the queue and discards it. After the queue is empty, the
 // default hook function is invoked for any future action.
-func (f *WorkerStoreHandleFunc) PushHook(hook func() *basestore.TransactableHandle) {
+func (f *WorkerStoreHandleFunc) PushHook(hook func() *basestore.OldTransactableHandle) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -3737,20 +3737,20 @@ func (f *WorkerStoreHandleFunc) PushHook(hook func() *basestore.TransactableHand
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *WorkerStoreHandleFunc) SetDefaultReturn(r0 *basestore.TransactableHandle) {
-	f.SetDefaultHook(func() *basestore.TransactableHandle {
+func (f *WorkerStoreHandleFunc) SetDefaultReturn(r0 *basestore.OldTransactableHandle) {
+	f.SetDefaultHook(func() *basestore.OldTransactableHandle {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *WorkerStoreHandleFunc) PushReturn(r0 *basestore.TransactableHandle) {
-	f.PushHook(func() *basestore.TransactableHandle {
+func (f *WorkerStoreHandleFunc) PushReturn(r0 *basestore.OldTransactableHandle) {
+	f.PushHook(func() *basestore.OldTransactableHandle {
 		return r0
 	})
 }
 
-func (f *WorkerStoreHandleFunc) nextHook() func() *basestore.TransactableHandle {
+func (f *WorkerStoreHandleFunc) nextHook() func() *basestore.OldTransactableHandle {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -3785,7 +3785,7 @@ func (f *WorkerStoreHandleFunc) History() []WorkerStoreHandleFuncCall {
 type WorkerStoreHandleFuncCall struct {
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 *basestore.TransactableHandle
+	Result0 *basestore.OldTransactableHandle
 }
 
 // Args returns an interface slice containing the arguments of this

--- a/enterprise/cmd/precise-code-intel-worker/internal/worker/mocks_test.go
+++ b/enterprise/cmd/precise-code-intel-worker/internal/worker/mocks_test.go
@@ -82,7 +82,7 @@ func NewMockDBStore() *MockDBStore {
 			},
 		},
 		HandleFunc: &DBStoreHandleFunc{
-			defaultHook: func() (r0 *basestore.OldTransactableHandle) {
+			defaultHook: func() (r0 basestore.TransactableHandle) {
 				return
 			},
 		},
@@ -154,7 +154,7 @@ func NewStrictMockDBStore() *MockDBStore {
 			},
 		},
 		HandleFunc: &DBStoreHandleFunc{
-			defaultHook: func() *basestore.OldTransactableHandle {
+			defaultHook: func() basestore.TransactableHandle {
 				panic("unexpected invocation of MockDBStore.Handle")
 			},
 		},
@@ -477,15 +477,15 @@ func (c DBStoreDoneFuncCall) Results() []interface{} {
 // DBStoreHandleFunc describes the behavior when the Handle method of the
 // parent MockDBStore instance is invoked.
 type DBStoreHandleFunc struct {
-	defaultHook func() *basestore.OldTransactableHandle
-	hooks       []func() *basestore.OldTransactableHandle
+	defaultHook func() basestore.TransactableHandle
+	hooks       []func() basestore.TransactableHandle
 	history     []DBStoreHandleFuncCall
 	mutex       sync.Mutex
 }
 
 // Handle delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockDBStore) Handle() *basestore.OldTransactableHandle {
+func (m *MockDBStore) Handle() basestore.TransactableHandle {
 	r0 := m.HandleFunc.nextHook()()
 	m.HandleFunc.appendCall(DBStoreHandleFuncCall{r0})
 	return r0
@@ -493,7 +493,7 @@ func (m *MockDBStore) Handle() *basestore.OldTransactableHandle {
 
 // SetDefaultHook sets function that is called when the Handle method of the
 // parent MockDBStore instance is invoked and the hook queue is empty.
-func (f *DBStoreHandleFunc) SetDefaultHook(hook func() *basestore.OldTransactableHandle) {
+func (f *DBStoreHandleFunc) SetDefaultHook(hook func() basestore.TransactableHandle) {
 	f.defaultHook = hook
 }
 
@@ -501,7 +501,7 @@ func (f *DBStoreHandleFunc) SetDefaultHook(hook func() *basestore.OldTransactabl
 // Handle method of the parent MockDBStore instance invokes the hook at the
 // front of the queue and discards it. After the queue is empty, the default
 // hook function is invoked for any future action.
-func (f *DBStoreHandleFunc) PushHook(hook func() *basestore.OldTransactableHandle) {
+func (f *DBStoreHandleFunc) PushHook(hook func() basestore.TransactableHandle) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -509,20 +509,20 @@ func (f *DBStoreHandleFunc) PushHook(hook func() *basestore.OldTransactableHandl
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *DBStoreHandleFunc) SetDefaultReturn(r0 *basestore.OldTransactableHandle) {
-	f.SetDefaultHook(func() *basestore.OldTransactableHandle {
+func (f *DBStoreHandleFunc) SetDefaultReturn(r0 basestore.TransactableHandle) {
+	f.SetDefaultHook(func() basestore.TransactableHandle {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *DBStoreHandleFunc) PushReturn(r0 *basestore.OldTransactableHandle) {
-	f.PushHook(func() *basestore.OldTransactableHandle {
+func (f *DBStoreHandleFunc) PushReturn(r0 basestore.TransactableHandle) {
+	f.PushHook(func() basestore.TransactableHandle {
 		return r0
 	})
 }
 
-func (f *DBStoreHandleFunc) nextHook() func() *basestore.OldTransactableHandle {
+func (f *DBStoreHandleFunc) nextHook() func() basestore.TransactableHandle {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -557,7 +557,7 @@ func (f *DBStoreHandleFunc) History() []DBStoreHandleFuncCall {
 type DBStoreHandleFuncCall struct {
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 *basestore.OldTransactableHandle
+	Result0 basestore.TransactableHandle
 }
 
 // Args returns an interface slice containing the arguments of this
@@ -3295,7 +3295,7 @@ func NewMockWorkerStore() *MockWorkerStore {
 			},
 		},
 		HandleFunc: &WorkerStoreHandleFunc{
-			defaultHook: func() (r0 *basestore.OldTransactableHandle) {
+			defaultHook: func() (r0 basestore.TransactableHandle) {
 				return
 			},
 		},
@@ -3367,7 +3367,7 @@ func NewStrictMockWorkerStore() *MockWorkerStore {
 			},
 		},
 		HandleFunc: &WorkerStoreHandleFunc{
-			defaultHook: func() *basestore.OldTransactableHandle {
+			defaultHook: func() basestore.TransactableHandle {
 				panic("unexpected invocation of MockWorkerStore.Handle")
 			},
 		},
@@ -3705,15 +3705,15 @@ func (c WorkerStoreDequeueFuncCall) Results() []interface{} {
 // WorkerStoreHandleFunc describes the behavior when the Handle method of
 // the parent MockWorkerStore instance is invoked.
 type WorkerStoreHandleFunc struct {
-	defaultHook func() *basestore.OldTransactableHandle
-	hooks       []func() *basestore.OldTransactableHandle
+	defaultHook func() basestore.TransactableHandle
+	hooks       []func() basestore.TransactableHandle
 	history     []WorkerStoreHandleFuncCall
 	mutex       sync.Mutex
 }
 
 // Handle delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockWorkerStore) Handle() *basestore.OldTransactableHandle {
+func (m *MockWorkerStore) Handle() basestore.TransactableHandle {
 	r0 := m.HandleFunc.nextHook()()
 	m.HandleFunc.appendCall(WorkerStoreHandleFuncCall{r0})
 	return r0
@@ -3721,7 +3721,7 @@ func (m *MockWorkerStore) Handle() *basestore.OldTransactableHandle {
 
 // SetDefaultHook sets function that is called when the Handle method of the
 // parent MockWorkerStore instance is invoked and the hook queue is empty.
-func (f *WorkerStoreHandleFunc) SetDefaultHook(hook func() *basestore.OldTransactableHandle) {
+func (f *WorkerStoreHandleFunc) SetDefaultHook(hook func() basestore.TransactableHandle) {
 	f.defaultHook = hook
 }
 
@@ -3729,7 +3729,7 @@ func (f *WorkerStoreHandleFunc) SetDefaultHook(hook func() *basestore.OldTransac
 // Handle method of the parent MockWorkerStore instance invokes the hook at
 // the front of the queue and discards it. After the queue is empty, the
 // default hook function is invoked for any future action.
-func (f *WorkerStoreHandleFunc) PushHook(hook func() *basestore.OldTransactableHandle) {
+func (f *WorkerStoreHandleFunc) PushHook(hook func() basestore.TransactableHandle) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -3737,20 +3737,20 @@ func (f *WorkerStoreHandleFunc) PushHook(hook func() *basestore.OldTransactableH
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *WorkerStoreHandleFunc) SetDefaultReturn(r0 *basestore.OldTransactableHandle) {
-	f.SetDefaultHook(func() *basestore.OldTransactableHandle {
+func (f *WorkerStoreHandleFunc) SetDefaultReturn(r0 basestore.TransactableHandle) {
+	f.SetDefaultHook(func() basestore.TransactableHandle {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *WorkerStoreHandleFunc) PushReturn(r0 *basestore.OldTransactableHandle) {
-	f.PushHook(func() *basestore.OldTransactableHandle {
+func (f *WorkerStoreHandleFunc) PushReturn(r0 basestore.TransactableHandle) {
+	f.PushHook(func() basestore.TransactableHandle {
 		return r0
 	})
 }
 
-func (f *WorkerStoreHandleFunc) nextHook() func() *basestore.OldTransactableHandle {
+func (f *WorkerStoreHandleFunc) nextHook() func() basestore.TransactableHandle {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -3785,7 +3785,7 @@ func (f *WorkerStoreHandleFunc) History() []WorkerStoreHandleFuncCall {
 type WorkerStoreHandleFuncCall struct {
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 *basestore.OldTransactableHandle
+	Result0 basestore.TransactableHandle
 }
 
 // Args returns an interface slice containing the arguments of this

--- a/enterprise/cmd/worker/internal/codeintel/indexing/mocks_test.go
+++ b/enterprise/cmd/worker/internal/codeintel/indexing/mocks_test.go
@@ -3564,7 +3564,7 @@ func NewMockWorkerStore() *MockWorkerStore {
 			},
 		},
 		HandleFunc: &WorkerStoreHandleFunc{
-			defaultHook: func() (r0 *basestore.TransactableHandle) {
+			defaultHook: func() (r0 *basestore.OldTransactableHandle) {
 				return
 			},
 		},
@@ -3636,7 +3636,7 @@ func NewStrictMockWorkerStore() *MockWorkerStore {
 			},
 		},
 		HandleFunc: &WorkerStoreHandleFunc{
-			defaultHook: func() *basestore.TransactableHandle {
+			defaultHook: func() *basestore.OldTransactableHandle {
 				panic("unexpected invocation of MockWorkerStore.Handle")
 			},
 		},
@@ -3974,15 +3974,15 @@ func (c WorkerStoreDequeueFuncCall) Results() []interface{} {
 // WorkerStoreHandleFunc describes the behavior when the Handle method of
 // the parent MockWorkerStore instance is invoked.
 type WorkerStoreHandleFunc struct {
-	defaultHook func() *basestore.TransactableHandle
-	hooks       []func() *basestore.TransactableHandle
+	defaultHook func() *basestore.OldTransactableHandle
+	hooks       []func() *basestore.OldTransactableHandle
 	history     []WorkerStoreHandleFuncCall
 	mutex       sync.Mutex
 }
 
 // Handle delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockWorkerStore) Handle() *basestore.TransactableHandle {
+func (m *MockWorkerStore) Handle() *basestore.OldTransactableHandle {
 	r0 := m.HandleFunc.nextHook()()
 	m.HandleFunc.appendCall(WorkerStoreHandleFuncCall{r0})
 	return r0
@@ -3990,7 +3990,7 @@ func (m *MockWorkerStore) Handle() *basestore.TransactableHandle {
 
 // SetDefaultHook sets function that is called when the Handle method of the
 // parent MockWorkerStore instance is invoked and the hook queue is empty.
-func (f *WorkerStoreHandleFunc) SetDefaultHook(hook func() *basestore.TransactableHandle) {
+func (f *WorkerStoreHandleFunc) SetDefaultHook(hook func() *basestore.OldTransactableHandle) {
 	f.defaultHook = hook
 }
 
@@ -3998,7 +3998,7 @@ func (f *WorkerStoreHandleFunc) SetDefaultHook(hook func() *basestore.Transactab
 // Handle method of the parent MockWorkerStore instance invokes the hook at
 // the front of the queue and discards it. After the queue is empty, the
 // default hook function is invoked for any future action.
-func (f *WorkerStoreHandleFunc) PushHook(hook func() *basestore.TransactableHandle) {
+func (f *WorkerStoreHandleFunc) PushHook(hook func() *basestore.OldTransactableHandle) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -4006,20 +4006,20 @@ func (f *WorkerStoreHandleFunc) PushHook(hook func() *basestore.TransactableHand
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *WorkerStoreHandleFunc) SetDefaultReturn(r0 *basestore.TransactableHandle) {
-	f.SetDefaultHook(func() *basestore.TransactableHandle {
+func (f *WorkerStoreHandleFunc) SetDefaultReturn(r0 *basestore.OldTransactableHandle) {
+	f.SetDefaultHook(func() *basestore.OldTransactableHandle {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *WorkerStoreHandleFunc) PushReturn(r0 *basestore.TransactableHandle) {
-	f.PushHook(func() *basestore.TransactableHandle {
+func (f *WorkerStoreHandleFunc) PushReturn(r0 *basestore.OldTransactableHandle) {
+	f.PushHook(func() *basestore.OldTransactableHandle {
 		return r0
 	})
 }
 
-func (f *WorkerStoreHandleFunc) nextHook() func() *basestore.TransactableHandle {
+func (f *WorkerStoreHandleFunc) nextHook() func() *basestore.OldTransactableHandle {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -4054,7 +4054,7 @@ func (f *WorkerStoreHandleFunc) History() []WorkerStoreHandleFuncCall {
 type WorkerStoreHandleFuncCall struct {
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 *basestore.TransactableHandle
+	Result0 *basestore.OldTransactableHandle
 }
 
 // Args returns an interface slice containing the arguments of this

--- a/enterprise/cmd/worker/internal/codeintel/indexing/mocks_test.go
+++ b/enterprise/cmd/worker/internal/codeintel/indexing/mocks_test.go
@@ -3564,7 +3564,7 @@ func NewMockWorkerStore() *MockWorkerStore {
 			},
 		},
 		HandleFunc: &WorkerStoreHandleFunc{
-			defaultHook: func() (r0 *basestore.OldTransactableHandle) {
+			defaultHook: func() (r0 basestore.TransactableHandle) {
 				return
 			},
 		},
@@ -3636,7 +3636,7 @@ func NewStrictMockWorkerStore() *MockWorkerStore {
 			},
 		},
 		HandleFunc: &WorkerStoreHandleFunc{
-			defaultHook: func() *basestore.OldTransactableHandle {
+			defaultHook: func() basestore.TransactableHandle {
 				panic("unexpected invocation of MockWorkerStore.Handle")
 			},
 		},
@@ -3974,15 +3974,15 @@ func (c WorkerStoreDequeueFuncCall) Results() []interface{} {
 // WorkerStoreHandleFunc describes the behavior when the Handle method of
 // the parent MockWorkerStore instance is invoked.
 type WorkerStoreHandleFunc struct {
-	defaultHook func() *basestore.OldTransactableHandle
-	hooks       []func() *basestore.OldTransactableHandle
+	defaultHook func() basestore.TransactableHandle
+	hooks       []func() basestore.TransactableHandle
 	history     []WorkerStoreHandleFuncCall
 	mutex       sync.Mutex
 }
 
 // Handle delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockWorkerStore) Handle() *basestore.OldTransactableHandle {
+func (m *MockWorkerStore) Handle() basestore.TransactableHandle {
 	r0 := m.HandleFunc.nextHook()()
 	m.HandleFunc.appendCall(WorkerStoreHandleFuncCall{r0})
 	return r0
@@ -3990,7 +3990,7 @@ func (m *MockWorkerStore) Handle() *basestore.OldTransactableHandle {
 
 // SetDefaultHook sets function that is called when the Handle method of the
 // parent MockWorkerStore instance is invoked and the hook queue is empty.
-func (f *WorkerStoreHandleFunc) SetDefaultHook(hook func() *basestore.OldTransactableHandle) {
+func (f *WorkerStoreHandleFunc) SetDefaultHook(hook func() basestore.TransactableHandle) {
 	f.defaultHook = hook
 }
 
@@ -3998,7 +3998,7 @@ func (f *WorkerStoreHandleFunc) SetDefaultHook(hook func() *basestore.OldTransac
 // Handle method of the parent MockWorkerStore instance invokes the hook at
 // the front of the queue and discards it. After the queue is empty, the
 // default hook function is invoked for any future action.
-func (f *WorkerStoreHandleFunc) PushHook(hook func() *basestore.OldTransactableHandle) {
+func (f *WorkerStoreHandleFunc) PushHook(hook func() basestore.TransactableHandle) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -4006,20 +4006,20 @@ func (f *WorkerStoreHandleFunc) PushHook(hook func() *basestore.OldTransactableH
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *WorkerStoreHandleFunc) SetDefaultReturn(r0 *basestore.OldTransactableHandle) {
-	f.SetDefaultHook(func() *basestore.OldTransactableHandle {
+func (f *WorkerStoreHandleFunc) SetDefaultReturn(r0 basestore.TransactableHandle) {
+	f.SetDefaultHook(func() basestore.TransactableHandle {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *WorkerStoreHandleFunc) PushReturn(r0 *basestore.OldTransactableHandle) {
-	f.PushHook(func() *basestore.OldTransactableHandle {
+func (f *WorkerStoreHandleFunc) PushReturn(r0 basestore.TransactableHandle) {
+	f.PushHook(func() basestore.TransactableHandle {
 		return r0
 	})
 }
 
-func (f *WorkerStoreHandleFunc) nextHook() func() *basestore.OldTransactableHandle {
+func (f *WorkerStoreHandleFunc) nextHook() func() basestore.TransactableHandle {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -4054,7 +4054,7 @@ func (f *WorkerStoreHandleFunc) History() []WorkerStoreHandleFuncCall {
 type WorkerStoreHandleFuncCall struct {
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 *basestore.OldTransactableHandle
+	Result0 basestore.TransactableHandle
 }
 
 // Args returns an interface slice containing the arguments of this

--- a/enterprise/cmd/worker/internal/codeintel/janitor/iface.go
+++ b/enterprise/cmd/worker/internal/codeintel/janitor/iface.go
@@ -12,7 +12,6 @@ import (
 type DBStore interface {
 	basestore.ShareableStore
 
-	Handle() *basestore.OldTransactableHandle
 	Transact(ctx context.Context) (DBStore, error)
 	Done(err error) error
 

--- a/enterprise/cmd/worker/internal/codeintel/janitor/iface.go
+++ b/enterprise/cmd/worker/internal/codeintel/janitor/iface.go
@@ -12,7 +12,7 @@ import (
 type DBStore interface {
 	basestore.ShareableStore
 
-	Handle() *basestore.TransactableHandle
+	Handle() *basestore.OldTransactableHandle
 	Transact(ctx context.Context) (DBStore, error)
 	Done(err error) error
 

--- a/enterprise/cmd/worker/internal/codeintel/janitor/mocks_test.go
+++ b/enterprise/cmd/worker/internal/codeintel/janitor/mocks_test.go
@@ -135,7 +135,7 @@ func NewMockDBStore() *MockDBStore {
 			},
 		},
 		HandleFunc: &DBStoreHandleFunc{
-			defaultHook: func() (r0 *basestore.OldTransactableHandle) {
+			defaultHook: func() (r0 basestore.TransactableHandle) {
 				return
 			},
 		},
@@ -232,7 +232,7 @@ func NewStrictMockDBStore() *MockDBStore {
 			},
 		},
 		HandleFunc: &DBStoreHandleFunc{
-			defaultHook: func() *basestore.OldTransactableHandle {
+			defaultHook: func() basestore.TransactableHandle {
 				panic("unexpected invocation of MockDBStore.Handle")
 			},
 		},
@@ -1457,15 +1457,15 @@ func (c DBStoreGetUploadsFuncCall) Results() []interface{} {
 // DBStoreHandleFunc describes the behavior when the Handle method of the
 // parent MockDBStore instance is invoked.
 type DBStoreHandleFunc struct {
-	defaultHook func() *basestore.OldTransactableHandle
-	hooks       []func() *basestore.OldTransactableHandle
+	defaultHook func() basestore.TransactableHandle
+	hooks       []func() basestore.TransactableHandle
 	history     []DBStoreHandleFuncCall
 	mutex       sync.Mutex
 }
 
 // Handle delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockDBStore) Handle() *basestore.OldTransactableHandle {
+func (m *MockDBStore) Handle() basestore.TransactableHandle {
 	r0 := m.HandleFunc.nextHook()()
 	m.HandleFunc.appendCall(DBStoreHandleFuncCall{r0})
 	return r0
@@ -1473,7 +1473,7 @@ func (m *MockDBStore) Handle() *basestore.OldTransactableHandle {
 
 // SetDefaultHook sets function that is called when the Handle method of the
 // parent MockDBStore instance is invoked and the hook queue is empty.
-func (f *DBStoreHandleFunc) SetDefaultHook(hook func() *basestore.OldTransactableHandle) {
+func (f *DBStoreHandleFunc) SetDefaultHook(hook func() basestore.TransactableHandle) {
 	f.defaultHook = hook
 }
 
@@ -1481,7 +1481,7 @@ func (f *DBStoreHandleFunc) SetDefaultHook(hook func() *basestore.OldTransactabl
 // Handle method of the parent MockDBStore instance invokes the hook at the
 // front of the queue and discards it. After the queue is empty, the default
 // hook function is invoked for any future action.
-func (f *DBStoreHandleFunc) PushHook(hook func() *basestore.OldTransactableHandle) {
+func (f *DBStoreHandleFunc) PushHook(hook func() basestore.TransactableHandle) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -1489,20 +1489,20 @@ func (f *DBStoreHandleFunc) PushHook(hook func() *basestore.OldTransactableHandl
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *DBStoreHandleFunc) SetDefaultReturn(r0 *basestore.OldTransactableHandle) {
-	f.SetDefaultHook(func() *basestore.OldTransactableHandle {
+func (f *DBStoreHandleFunc) SetDefaultReturn(r0 basestore.TransactableHandle) {
+	f.SetDefaultHook(func() basestore.TransactableHandle {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *DBStoreHandleFunc) PushReturn(r0 *basestore.OldTransactableHandle) {
-	f.PushHook(func() *basestore.OldTransactableHandle {
+func (f *DBStoreHandleFunc) PushReturn(r0 basestore.TransactableHandle) {
+	f.PushHook(func() basestore.TransactableHandle {
 		return r0
 	})
 }
 
-func (f *DBStoreHandleFunc) nextHook() func() *basestore.OldTransactableHandle {
+func (f *DBStoreHandleFunc) nextHook() func() basestore.TransactableHandle {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -1537,7 +1537,7 @@ func (f *DBStoreHandleFunc) History() []DBStoreHandleFuncCall {
 type DBStoreHandleFuncCall struct {
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 *basestore.OldTransactableHandle
+	Result0 basestore.TransactableHandle
 }
 
 // Args returns an interface slice containing the arguments of this

--- a/enterprise/cmd/worker/internal/codeintel/janitor/mocks_test.go
+++ b/enterprise/cmd/worker/internal/codeintel/janitor/mocks_test.go
@@ -135,7 +135,7 @@ func NewMockDBStore() *MockDBStore {
 			},
 		},
 		HandleFunc: &DBStoreHandleFunc{
-			defaultHook: func() (r0 *basestore.TransactableHandle) {
+			defaultHook: func() (r0 *basestore.OldTransactableHandle) {
 				return
 			},
 		},
@@ -232,7 +232,7 @@ func NewStrictMockDBStore() *MockDBStore {
 			},
 		},
 		HandleFunc: &DBStoreHandleFunc{
-			defaultHook: func() *basestore.TransactableHandle {
+			defaultHook: func() *basestore.OldTransactableHandle {
 				panic("unexpected invocation of MockDBStore.Handle")
 			},
 		},
@@ -1457,15 +1457,15 @@ func (c DBStoreGetUploadsFuncCall) Results() []interface{} {
 // DBStoreHandleFunc describes the behavior when the Handle method of the
 // parent MockDBStore instance is invoked.
 type DBStoreHandleFunc struct {
-	defaultHook func() *basestore.TransactableHandle
-	hooks       []func() *basestore.TransactableHandle
+	defaultHook func() *basestore.OldTransactableHandle
+	hooks       []func() *basestore.OldTransactableHandle
 	history     []DBStoreHandleFuncCall
 	mutex       sync.Mutex
 }
 
 // Handle delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockDBStore) Handle() *basestore.TransactableHandle {
+func (m *MockDBStore) Handle() *basestore.OldTransactableHandle {
 	r0 := m.HandleFunc.nextHook()()
 	m.HandleFunc.appendCall(DBStoreHandleFuncCall{r0})
 	return r0
@@ -1473,7 +1473,7 @@ func (m *MockDBStore) Handle() *basestore.TransactableHandle {
 
 // SetDefaultHook sets function that is called when the Handle method of the
 // parent MockDBStore instance is invoked and the hook queue is empty.
-func (f *DBStoreHandleFunc) SetDefaultHook(hook func() *basestore.TransactableHandle) {
+func (f *DBStoreHandleFunc) SetDefaultHook(hook func() *basestore.OldTransactableHandle) {
 	f.defaultHook = hook
 }
 
@@ -1481,7 +1481,7 @@ func (f *DBStoreHandleFunc) SetDefaultHook(hook func() *basestore.TransactableHa
 // Handle method of the parent MockDBStore instance invokes the hook at the
 // front of the queue and discards it. After the queue is empty, the default
 // hook function is invoked for any future action.
-func (f *DBStoreHandleFunc) PushHook(hook func() *basestore.TransactableHandle) {
+func (f *DBStoreHandleFunc) PushHook(hook func() *basestore.OldTransactableHandle) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -1489,20 +1489,20 @@ func (f *DBStoreHandleFunc) PushHook(hook func() *basestore.TransactableHandle) 
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *DBStoreHandleFunc) SetDefaultReturn(r0 *basestore.TransactableHandle) {
-	f.SetDefaultHook(func() *basestore.TransactableHandle {
+func (f *DBStoreHandleFunc) SetDefaultReturn(r0 *basestore.OldTransactableHandle) {
+	f.SetDefaultHook(func() *basestore.OldTransactableHandle {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *DBStoreHandleFunc) PushReturn(r0 *basestore.TransactableHandle) {
-	f.PushHook(func() *basestore.TransactableHandle {
+func (f *DBStoreHandleFunc) PushReturn(r0 *basestore.OldTransactableHandle) {
+	f.PushHook(func() *basestore.OldTransactableHandle {
 		return r0
 	})
 }
 
-func (f *DBStoreHandleFunc) nextHook() func() *basestore.TransactableHandle {
+func (f *DBStoreHandleFunc) nextHook() func() *basestore.OldTransactableHandle {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -1537,7 +1537,7 @@ func (f *DBStoreHandleFunc) History() []DBStoreHandleFuncCall {
 type DBStoreHandleFuncCall struct {
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 *basestore.TransactableHandle
+	Result0 *basestore.OldTransactableHandle
 }
 
 // Args returns an interface slice containing the arguments of this

--- a/enterprise/internal/batches/store/worker_batch_spec_resolution.go
+++ b/enterprise/internal/batches/store/worker_batch_spec_resolution.go
@@ -40,6 +40,6 @@ var batchSpecResolutionWorkerOpts = dbworkerstore.Options{
 	MaxNumRetries: batchSpecResolutionMaxNumRetries,
 }
 
-func NewBatchSpecResolutionWorkerStore(handle *basestore.TransactableHandle, observationContext *observation.Context) dbworkerstore.Store {
+func NewBatchSpecResolutionWorkerStore(handle *basestore.OldTransactableHandle, observationContext *observation.Context) dbworkerstore.Store {
 	return dbworkerstore.NewWithMetrics(handle, batchSpecResolutionWorkerOpts, observationContext)
 }

--- a/enterprise/internal/batches/store/worker_batch_spec_resolution.go
+++ b/enterprise/internal/batches/store/worker_batch_spec_resolution.go
@@ -40,6 +40,6 @@ var batchSpecResolutionWorkerOpts = dbworkerstore.Options{
 	MaxNumRetries: batchSpecResolutionMaxNumRetries,
 }
 
-func NewBatchSpecResolutionWorkerStore(handle *basestore.OldTransactableHandle, observationContext *observation.Context) dbworkerstore.Store {
+func NewBatchSpecResolutionWorkerStore(handle basestore.TransactableHandle, observationContext *observation.Context) dbworkerstore.Store {
 	return dbworkerstore.NewWithMetrics(handle, batchSpecResolutionWorkerOpts, observationContext)
 }

--- a/enterprise/internal/batches/store/worker_bulk_operations.go
+++ b/enterprise/internal/batches/store/worker_bulk_operations.go
@@ -38,6 +38,6 @@ var bulkOperationWorkerStoreOpts = dbworkerstore.Options{
 	MaxNumRetries: bulkProcessorMaxNumRetries,
 }
 
-func NewBulkOperationWorkerStore(handle *basestore.OldTransactableHandle, observationContext *observation.Context) dbworkerstore.Store {
+func NewBulkOperationWorkerStore(handle basestore.TransactableHandle, observationContext *observation.Context) dbworkerstore.Store {
 	return dbworkerstore.NewWithMetrics(handle, bulkOperationWorkerStoreOpts, observationContext)
 }

--- a/enterprise/internal/batches/store/worker_bulk_operations.go
+++ b/enterprise/internal/batches/store/worker_bulk_operations.go
@@ -38,6 +38,6 @@ var bulkOperationWorkerStoreOpts = dbworkerstore.Options{
 	MaxNumRetries: bulkProcessorMaxNumRetries,
 }
 
-func NewBulkOperationWorkerStore(handle *basestore.TransactableHandle, observationContext *observation.Context) dbworkerstore.Store {
+func NewBulkOperationWorkerStore(handle *basestore.OldTransactableHandle, observationContext *observation.Context) dbworkerstore.Store {
 	return dbworkerstore.NewWithMetrics(handle, bulkOperationWorkerStoreOpts, observationContext)
 }

--- a/enterprise/internal/batches/store/worker_reconciler.go
+++ b/enterprise/internal/batches/store/worker_reconciler.go
@@ -43,6 +43,6 @@ var reconcilerWorkerStoreOpts = dbworkerstore.Options{
 	MaxNumRetries: reconcilerMaxNumRetries,
 }
 
-func NewReconcilerWorkerStore(handle *basestore.OldTransactableHandle, observationContext *observation.Context) dbworkerstore.Store {
+func NewReconcilerWorkerStore(handle basestore.TransactableHandle, observationContext *observation.Context) dbworkerstore.Store {
 	return dbworkerstore.NewWithMetrics(handle, reconcilerWorkerStoreOpts, observationContext)
 }

--- a/enterprise/internal/batches/store/worker_reconciler.go
+++ b/enterprise/internal/batches/store/worker_reconciler.go
@@ -43,6 +43,6 @@ var reconcilerWorkerStoreOpts = dbworkerstore.Options{
 	MaxNumRetries: reconcilerMaxNumRetries,
 }
 
-func NewReconcilerWorkerStore(handle *basestore.TransactableHandle, observationContext *observation.Context) dbworkerstore.Store {
+func NewReconcilerWorkerStore(handle *basestore.OldTransactableHandle, observationContext *observation.Context) dbworkerstore.Store {
 	return dbworkerstore.NewWithMetrics(handle, reconcilerWorkerStoreOpts, observationContext)
 }

--- a/enterprise/internal/batches/store/worker_workspace_execution.go
+++ b/enterprise/internal/batches/store/worker_workspace_execution.go
@@ -63,7 +63,7 @@ type BatchSpecWorkspaceExecutionWorkerStore interface {
 
 // NewBatchSpecWorkspaceExecutionWorkerStore creates a dbworker store that
 // wraps the batch_spec_workspace_execution_jobs table.
-func NewBatchSpecWorkspaceExecutionWorkerStore(handle *basestore.TransactableHandle, observationContext *observation.Context) BatchSpecWorkspaceExecutionWorkerStore {
+func NewBatchSpecWorkspaceExecutionWorkerStore(handle *basestore.OldTransactableHandle, observationContext *observation.Context) BatchSpecWorkspaceExecutionWorkerStore {
 	return &batchSpecWorkspaceExecutionWorkerStore{
 		Store:              dbworkerstore.NewWithMetrics(handle, batchSpecWorkspaceExecutionWorkerStoreOptions, observationContext),
 		observationContext: observationContext,

--- a/enterprise/internal/batches/store/worker_workspace_execution.go
+++ b/enterprise/internal/batches/store/worker_workspace_execution.go
@@ -63,7 +63,7 @@ type BatchSpecWorkspaceExecutionWorkerStore interface {
 
 // NewBatchSpecWorkspaceExecutionWorkerStore creates a dbworker store that
 // wraps the batch_spec_workspace_execution_jobs table.
-func NewBatchSpecWorkspaceExecutionWorkerStore(handle *basestore.OldTransactableHandle, observationContext *observation.Context) BatchSpecWorkspaceExecutionWorkerStore {
+func NewBatchSpecWorkspaceExecutionWorkerStore(handle basestore.TransactableHandle, observationContext *observation.Context) BatchSpecWorkspaceExecutionWorkerStore {
 	return &batchSpecWorkspaceExecutionWorkerStore{
 		Store:              dbworkerstore.NewWithMetrics(handle, batchSpecWorkspaceExecutionWorkerStoreOptions, observationContext),
 		observationContext: observationContext,

--- a/enterprise/internal/database/mocks_temp.go
+++ b/enterprise/internal/database/mocks_temp.go
@@ -369,7 +369,7 @@ func NewMockCodeMonitorStore() *MockCodeMonitorStore {
 			},
 		},
 		HandleFunc: &CodeMonitorStoreHandleFunc{
-			defaultHook: func() (r0 *basestore.OldTransactableHandle) {
+			defaultHook: func() (r0 basestore.TransactableHandle) {
 				return
 			},
 		},
@@ -646,7 +646,7 @@ func NewStrictMockCodeMonitorStore() *MockCodeMonitorStore {
 			},
 		},
 		HandleFunc: &CodeMonitorStoreHandleFunc{
-			defaultHook: func() *basestore.OldTransactableHandle {
+			defaultHook: func() basestore.TransactableHandle {
 				panic("unexpected invocation of MockCodeMonitorStore.Handle")
 			},
 		},
@@ -4598,15 +4598,15 @@ func (c CodeMonitorStoreGetWebhookActionFuncCall) Results() []interface{} {
 // CodeMonitorStoreHandleFunc describes the behavior when the Handle method
 // of the parent MockCodeMonitorStore instance is invoked.
 type CodeMonitorStoreHandleFunc struct {
-	defaultHook func() *basestore.OldTransactableHandle
-	hooks       []func() *basestore.OldTransactableHandle
+	defaultHook func() basestore.TransactableHandle
+	hooks       []func() basestore.TransactableHandle
 	history     []CodeMonitorStoreHandleFuncCall
 	mutex       sync.Mutex
 }
 
 // Handle delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockCodeMonitorStore) Handle() *basestore.OldTransactableHandle {
+func (m *MockCodeMonitorStore) Handle() basestore.TransactableHandle {
 	r0 := m.HandleFunc.nextHook()()
 	m.HandleFunc.appendCall(CodeMonitorStoreHandleFuncCall{r0})
 	return r0
@@ -4615,7 +4615,7 @@ func (m *MockCodeMonitorStore) Handle() *basestore.OldTransactableHandle {
 // SetDefaultHook sets function that is called when the Handle method of the
 // parent MockCodeMonitorStore instance is invoked and the hook queue is
 // empty.
-func (f *CodeMonitorStoreHandleFunc) SetDefaultHook(hook func() *basestore.OldTransactableHandle) {
+func (f *CodeMonitorStoreHandleFunc) SetDefaultHook(hook func() basestore.TransactableHandle) {
 	f.defaultHook = hook
 }
 
@@ -4623,7 +4623,7 @@ func (f *CodeMonitorStoreHandleFunc) SetDefaultHook(hook func() *basestore.OldTr
 // Handle method of the parent MockCodeMonitorStore instance invokes the
 // hook at the front of the queue and discards it. After the queue is empty,
 // the default hook function is invoked for any future action.
-func (f *CodeMonitorStoreHandleFunc) PushHook(hook func() *basestore.OldTransactableHandle) {
+func (f *CodeMonitorStoreHandleFunc) PushHook(hook func() basestore.TransactableHandle) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -4631,20 +4631,20 @@ func (f *CodeMonitorStoreHandleFunc) PushHook(hook func() *basestore.OldTransact
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *CodeMonitorStoreHandleFunc) SetDefaultReturn(r0 *basestore.OldTransactableHandle) {
-	f.SetDefaultHook(func() *basestore.OldTransactableHandle {
+func (f *CodeMonitorStoreHandleFunc) SetDefaultReturn(r0 basestore.TransactableHandle) {
+	f.SetDefaultHook(func() basestore.TransactableHandle {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *CodeMonitorStoreHandleFunc) PushReturn(r0 *basestore.OldTransactableHandle) {
-	f.PushHook(func() *basestore.OldTransactableHandle {
+func (f *CodeMonitorStoreHandleFunc) PushReturn(r0 basestore.TransactableHandle) {
+	f.PushHook(func() basestore.TransactableHandle {
 		return r0
 	})
 }
 
-func (f *CodeMonitorStoreHandleFunc) nextHook() func() *basestore.OldTransactableHandle {
+func (f *CodeMonitorStoreHandleFunc) nextHook() func() basestore.TransactableHandle {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -4679,7 +4679,7 @@ func (f *CodeMonitorStoreHandleFunc) History() []CodeMonitorStoreHandleFuncCall 
 type CodeMonitorStoreHandleFuncCall struct {
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 *basestore.OldTransactableHandle
+	Result0 basestore.TransactableHandle
 }
 
 // Args returns an interface slice containing the arguments of this
@@ -7120,7 +7120,7 @@ func NewMockEnterpriseDB() *MockEnterpriseDB {
 			},
 		},
 		HandleFunc: &EnterpriseDBHandleFunc{
-			defaultHook: func() (r0 *basestore.OldTransactableHandle) {
+			defaultHook: func() (r0 basestore.TransactableHandle) {
 				return
 			},
 		},
@@ -7312,7 +7312,7 @@ func NewStrictMockEnterpriseDB() *MockEnterpriseDB {
 			},
 		},
 		HandleFunc: &EnterpriseDBHandleFunc{
-			defaultHook: func() *basestore.OldTransactableHandle {
+			defaultHook: func() basestore.TransactableHandle {
 				panic("unexpected invocation of MockEnterpriseDB.Handle")
 			},
 		},
@@ -8870,15 +8870,15 @@ func (c EnterpriseDBGlobalStateFuncCall) Results() []interface{} {
 // EnterpriseDBHandleFunc describes the behavior when the Handle method of
 // the parent MockEnterpriseDB instance is invoked.
 type EnterpriseDBHandleFunc struct {
-	defaultHook func() *basestore.OldTransactableHandle
-	hooks       []func() *basestore.OldTransactableHandle
+	defaultHook func() basestore.TransactableHandle
+	hooks       []func() basestore.TransactableHandle
 	history     []EnterpriseDBHandleFuncCall
 	mutex       sync.Mutex
 }
 
 // Handle delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockEnterpriseDB) Handle() *basestore.OldTransactableHandle {
+func (m *MockEnterpriseDB) Handle() basestore.TransactableHandle {
 	r0 := m.HandleFunc.nextHook()()
 	m.HandleFunc.appendCall(EnterpriseDBHandleFuncCall{r0})
 	return r0
@@ -8886,7 +8886,7 @@ func (m *MockEnterpriseDB) Handle() *basestore.OldTransactableHandle {
 
 // SetDefaultHook sets function that is called when the Handle method of the
 // parent MockEnterpriseDB instance is invoked and the hook queue is empty.
-func (f *EnterpriseDBHandleFunc) SetDefaultHook(hook func() *basestore.OldTransactableHandle) {
+func (f *EnterpriseDBHandleFunc) SetDefaultHook(hook func() basestore.TransactableHandle) {
 	f.defaultHook = hook
 }
 
@@ -8894,7 +8894,7 @@ func (f *EnterpriseDBHandleFunc) SetDefaultHook(hook func() *basestore.OldTransa
 // Handle method of the parent MockEnterpriseDB instance invokes the hook at
 // the front of the queue and discards it. After the queue is empty, the
 // default hook function is invoked for any future action.
-func (f *EnterpriseDBHandleFunc) PushHook(hook func() *basestore.OldTransactableHandle) {
+func (f *EnterpriseDBHandleFunc) PushHook(hook func() basestore.TransactableHandle) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -8902,20 +8902,20 @@ func (f *EnterpriseDBHandleFunc) PushHook(hook func() *basestore.OldTransactable
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *EnterpriseDBHandleFunc) SetDefaultReturn(r0 *basestore.OldTransactableHandle) {
-	f.SetDefaultHook(func() *basestore.OldTransactableHandle {
+func (f *EnterpriseDBHandleFunc) SetDefaultReturn(r0 basestore.TransactableHandle) {
+	f.SetDefaultHook(func() basestore.TransactableHandle {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *EnterpriseDBHandleFunc) PushReturn(r0 *basestore.OldTransactableHandle) {
-	f.PushHook(func() *basestore.OldTransactableHandle {
+func (f *EnterpriseDBHandleFunc) PushReturn(r0 basestore.TransactableHandle) {
+	f.PushHook(func() basestore.TransactableHandle {
 		return r0
 	})
 }
 
-func (f *EnterpriseDBHandleFunc) nextHook() func() *basestore.OldTransactableHandle {
+func (f *EnterpriseDBHandleFunc) nextHook() func() basestore.TransactableHandle {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -8950,7 +8950,7 @@ func (f *EnterpriseDBHandleFunc) History() []EnterpriseDBHandleFuncCall {
 type EnterpriseDBHandleFuncCall struct {
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 *basestore.OldTransactableHandle
+	Result0 basestore.TransactableHandle
 }
 
 // Args returns an interface slice containing the arguments of this
@@ -11413,7 +11413,7 @@ func NewMockPermsStore() *MockPermsStore {
 			},
 		},
 		HandleFunc: &PermsStoreHandleFunc{
-			defaultHook: func() (r0 *basestore.OldTransactableHandle) {
+			defaultHook: func() (r0 basestore.TransactableHandle) {
 				return
 			},
 		},
@@ -11545,7 +11545,7 @@ func NewStrictMockPermsStore() *MockPermsStore {
 			},
 		},
 		HandleFunc: &PermsStoreHandleFunc{
-			defaultHook: func() *basestore.OldTransactableHandle {
+			defaultHook: func() basestore.TransactableHandle {
 				panic("unexpected invocation of MockPermsStore.Handle")
 			},
 		},
@@ -12273,15 +12273,15 @@ func (c PermsStoreGrantPendingPermissionsFuncCall) Results() []interface{} {
 // PermsStoreHandleFunc describes the behavior when the Handle method of the
 // parent MockPermsStore instance is invoked.
 type PermsStoreHandleFunc struct {
-	defaultHook func() *basestore.OldTransactableHandle
-	hooks       []func() *basestore.OldTransactableHandle
+	defaultHook func() basestore.TransactableHandle
+	hooks       []func() basestore.TransactableHandle
 	history     []PermsStoreHandleFuncCall
 	mutex       sync.Mutex
 }
 
 // Handle delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockPermsStore) Handle() *basestore.OldTransactableHandle {
+func (m *MockPermsStore) Handle() basestore.TransactableHandle {
 	r0 := m.HandleFunc.nextHook()()
 	m.HandleFunc.appendCall(PermsStoreHandleFuncCall{r0})
 	return r0
@@ -12289,7 +12289,7 @@ func (m *MockPermsStore) Handle() *basestore.OldTransactableHandle {
 
 // SetDefaultHook sets function that is called when the Handle method of the
 // parent MockPermsStore instance is invoked and the hook queue is empty.
-func (f *PermsStoreHandleFunc) SetDefaultHook(hook func() *basestore.OldTransactableHandle) {
+func (f *PermsStoreHandleFunc) SetDefaultHook(hook func() basestore.TransactableHandle) {
 	f.defaultHook = hook
 }
 
@@ -12297,7 +12297,7 @@ func (f *PermsStoreHandleFunc) SetDefaultHook(hook func() *basestore.OldTransact
 // Handle method of the parent MockPermsStore instance invokes the hook at
 // the front of the queue and discards it. After the queue is empty, the
 // default hook function is invoked for any future action.
-func (f *PermsStoreHandleFunc) PushHook(hook func() *basestore.OldTransactableHandle) {
+func (f *PermsStoreHandleFunc) PushHook(hook func() basestore.TransactableHandle) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -12305,20 +12305,20 @@ func (f *PermsStoreHandleFunc) PushHook(hook func() *basestore.OldTransactableHa
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *PermsStoreHandleFunc) SetDefaultReturn(r0 *basestore.OldTransactableHandle) {
-	f.SetDefaultHook(func() *basestore.OldTransactableHandle {
+func (f *PermsStoreHandleFunc) SetDefaultReturn(r0 basestore.TransactableHandle) {
+	f.SetDefaultHook(func() basestore.TransactableHandle {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *PermsStoreHandleFunc) PushReturn(r0 *basestore.OldTransactableHandle) {
-	f.PushHook(func() *basestore.OldTransactableHandle {
+func (f *PermsStoreHandleFunc) PushReturn(r0 basestore.TransactableHandle) {
+	f.PushHook(func() basestore.TransactableHandle {
 		return r0
 	})
 }
 
-func (f *PermsStoreHandleFunc) nextHook() func() *basestore.OldTransactableHandle {
+func (f *PermsStoreHandleFunc) nextHook() func() basestore.TransactableHandle {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -12353,7 +12353,7 @@ func (f *PermsStoreHandleFunc) History() []PermsStoreHandleFuncCall {
 type PermsStoreHandleFuncCall struct {
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 *basestore.OldTransactableHandle
+	Result0 basestore.TransactableHandle
 }
 
 // Args returns an interface slice containing the arguments of this

--- a/enterprise/internal/database/mocks_temp.go
+++ b/enterprise/internal/database/mocks_temp.go
@@ -369,7 +369,7 @@ func NewMockCodeMonitorStore() *MockCodeMonitorStore {
 			},
 		},
 		HandleFunc: &CodeMonitorStoreHandleFunc{
-			defaultHook: func() (r0 *basestore.TransactableHandle) {
+			defaultHook: func() (r0 *basestore.OldTransactableHandle) {
 				return
 			},
 		},
@@ -646,7 +646,7 @@ func NewStrictMockCodeMonitorStore() *MockCodeMonitorStore {
 			},
 		},
 		HandleFunc: &CodeMonitorStoreHandleFunc{
-			defaultHook: func() *basestore.TransactableHandle {
+			defaultHook: func() *basestore.OldTransactableHandle {
 				panic("unexpected invocation of MockCodeMonitorStore.Handle")
 			},
 		},
@@ -4598,15 +4598,15 @@ func (c CodeMonitorStoreGetWebhookActionFuncCall) Results() []interface{} {
 // CodeMonitorStoreHandleFunc describes the behavior when the Handle method
 // of the parent MockCodeMonitorStore instance is invoked.
 type CodeMonitorStoreHandleFunc struct {
-	defaultHook func() *basestore.TransactableHandle
-	hooks       []func() *basestore.TransactableHandle
+	defaultHook func() *basestore.OldTransactableHandle
+	hooks       []func() *basestore.OldTransactableHandle
 	history     []CodeMonitorStoreHandleFuncCall
 	mutex       sync.Mutex
 }
 
 // Handle delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockCodeMonitorStore) Handle() *basestore.TransactableHandle {
+func (m *MockCodeMonitorStore) Handle() *basestore.OldTransactableHandle {
 	r0 := m.HandleFunc.nextHook()()
 	m.HandleFunc.appendCall(CodeMonitorStoreHandleFuncCall{r0})
 	return r0
@@ -4615,7 +4615,7 @@ func (m *MockCodeMonitorStore) Handle() *basestore.TransactableHandle {
 // SetDefaultHook sets function that is called when the Handle method of the
 // parent MockCodeMonitorStore instance is invoked and the hook queue is
 // empty.
-func (f *CodeMonitorStoreHandleFunc) SetDefaultHook(hook func() *basestore.TransactableHandle) {
+func (f *CodeMonitorStoreHandleFunc) SetDefaultHook(hook func() *basestore.OldTransactableHandle) {
 	f.defaultHook = hook
 }
 
@@ -4623,7 +4623,7 @@ func (f *CodeMonitorStoreHandleFunc) SetDefaultHook(hook func() *basestore.Trans
 // Handle method of the parent MockCodeMonitorStore instance invokes the
 // hook at the front of the queue and discards it. After the queue is empty,
 // the default hook function is invoked for any future action.
-func (f *CodeMonitorStoreHandleFunc) PushHook(hook func() *basestore.TransactableHandle) {
+func (f *CodeMonitorStoreHandleFunc) PushHook(hook func() *basestore.OldTransactableHandle) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -4631,20 +4631,20 @@ func (f *CodeMonitorStoreHandleFunc) PushHook(hook func() *basestore.Transactabl
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *CodeMonitorStoreHandleFunc) SetDefaultReturn(r0 *basestore.TransactableHandle) {
-	f.SetDefaultHook(func() *basestore.TransactableHandle {
+func (f *CodeMonitorStoreHandleFunc) SetDefaultReturn(r0 *basestore.OldTransactableHandle) {
+	f.SetDefaultHook(func() *basestore.OldTransactableHandle {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *CodeMonitorStoreHandleFunc) PushReturn(r0 *basestore.TransactableHandle) {
-	f.PushHook(func() *basestore.TransactableHandle {
+func (f *CodeMonitorStoreHandleFunc) PushReturn(r0 *basestore.OldTransactableHandle) {
+	f.PushHook(func() *basestore.OldTransactableHandle {
 		return r0
 	})
 }
 
-func (f *CodeMonitorStoreHandleFunc) nextHook() func() *basestore.TransactableHandle {
+func (f *CodeMonitorStoreHandleFunc) nextHook() func() *basestore.OldTransactableHandle {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -4679,7 +4679,7 @@ func (f *CodeMonitorStoreHandleFunc) History() []CodeMonitorStoreHandleFuncCall 
 type CodeMonitorStoreHandleFuncCall struct {
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 *basestore.TransactableHandle
+	Result0 *basestore.OldTransactableHandle
 }
 
 // Args returns an interface slice containing the arguments of this
@@ -7120,7 +7120,7 @@ func NewMockEnterpriseDB() *MockEnterpriseDB {
 			},
 		},
 		HandleFunc: &EnterpriseDBHandleFunc{
-			defaultHook: func() (r0 *basestore.TransactableHandle) {
+			defaultHook: func() (r0 *basestore.OldTransactableHandle) {
 				return
 			},
 		},
@@ -7312,7 +7312,7 @@ func NewStrictMockEnterpriseDB() *MockEnterpriseDB {
 			},
 		},
 		HandleFunc: &EnterpriseDBHandleFunc{
-			defaultHook: func() *basestore.TransactableHandle {
+			defaultHook: func() *basestore.OldTransactableHandle {
 				panic("unexpected invocation of MockEnterpriseDB.Handle")
 			},
 		},
@@ -8870,15 +8870,15 @@ func (c EnterpriseDBGlobalStateFuncCall) Results() []interface{} {
 // EnterpriseDBHandleFunc describes the behavior when the Handle method of
 // the parent MockEnterpriseDB instance is invoked.
 type EnterpriseDBHandleFunc struct {
-	defaultHook func() *basestore.TransactableHandle
-	hooks       []func() *basestore.TransactableHandle
+	defaultHook func() *basestore.OldTransactableHandle
+	hooks       []func() *basestore.OldTransactableHandle
 	history     []EnterpriseDBHandleFuncCall
 	mutex       sync.Mutex
 }
 
 // Handle delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockEnterpriseDB) Handle() *basestore.TransactableHandle {
+func (m *MockEnterpriseDB) Handle() *basestore.OldTransactableHandle {
 	r0 := m.HandleFunc.nextHook()()
 	m.HandleFunc.appendCall(EnterpriseDBHandleFuncCall{r0})
 	return r0
@@ -8886,7 +8886,7 @@ func (m *MockEnterpriseDB) Handle() *basestore.TransactableHandle {
 
 // SetDefaultHook sets function that is called when the Handle method of the
 // parent MockEnterpriseDB instance is invoked and the hook queue is empty.
-func (f *EnterpriseDBHandleFunc) SetDefaultHook(hook func() *basestore.TransactableHandle) {
+func (f *EnterpriseDBHandleFunc) SetDefaultHook(hook func() *basestore.OldTransactableHandle) {
 	f.defaultHook = hook
 }
 
@@ -8894,7 +8894,7 @@ func (f *EnterpriseDBHandleFunc) SetDefaultHook(hook func() *basestore.Transacta
 // Handle method of the parent MockEnterpriseDB instance invokes the hook at
 // the front of the queue and discards it. After the queue is empty, the
 // default hook function is invoked for any future action.
-func (f *EnterpriseDBHandleFunc) PushHook(hook func() *basestore.TransactableHandle) {
+func (f *EnterpriseDBHandleFunc) PushHook(hook func() *basestore.OldTransactableHandle) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -8902,20 +8902,20 @@ func (f *EnterpriseDBHandleFunc) PushHook(hook func() *basestore.TransactableHan
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *EnterpriseDBHandleFunc) SetDefaultReturn(r0 *basestore.TransactableHandle) {
-	f.SetDefaultHook(func() *basestore.TransactableHandle {
+func (f *EnterpriseDBHandleFunc) SetDefaultReturn(r0 *basestore.OldTransactableHandle) {
+	f.SetDefaultHook(func() *basestore.OldTransactableHandle {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *EnterpriseDBHandleFunc) PushReturn(r0 *basestore.TransactableHandle) {
-	f.PushHook(func() *basestore.TransactableHandle {
+func (f *EnterpriseDBHandleFunc) PushReturn(r0 *basestore.OldTransactableHandle) {
+	f.PushHook(func() *basestore.OldTransactableHandle {
 		return r0
 	})
 }
 
-func (f *EnterpriseDBHandleFunc) nextHook() func() *basestore.TransactableHandle {
+func (f *EnterpriseDBHandleFunc) nextHook() func() *basestore.OldTransactableHandle {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -8950,7 +8950,7 @@ func (f *EnterpriseDBHandleFunc) History() []EnterpriseDBHandleFuncCall {
 type EnterpriseDBHandleFuncCall struct {
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 *basestore.TransactableHandle
+	Result0 *basestore.OldTransactableHandle
 }
 
 // Args returns an interface slice containing the arguments of this
@@ -11413,7 +11413,7 @@ func NewMockPermsStore() *MockPermsStore {
 			},
 		},
 		HandleFunc: &PermsStoreHandleFunc{
-			defaultHook: func() (r0 *basestore.TransactableHandle) {
+			defaultHook: func() (r0 *basestore.OldTransactableHandle) {
 				return
 			},
 		},
@@ -11545,7 +11545,7 @@ func NewStrictMockPermsStore() *MockPermsStore {
 			},
 		},
 		HandleFunc: &PermsStoreHandleFunc{
-			defaultHook: func() *basestore.TransactableHandle {
+			defaultHook: func() *basestore.OldTransactableHandle {
 				panic("unexpected invocation of MockPermsStore.Handle")
 			},
 		},
@@ -12273,15 +12273,15 @@ func (c PermsStoreGrantPendingPermissionsFuncCall) Results() []interface{} {
 // PermsStoreHandleFunc describes the behavior when the Handle method of the
 // parent MockPermsStore instance is invoked.
 type PermsStoreHandleFunc struct {
-	defaultHook func() *basestore.TransactableHandle
-	hooks       []func() *basestore.TransactableHandle
+	defaultHook func() *basestore.OldTransactableHandle
+	hooks       []func() *basestore.OldTransactableHandle
 	history     []PermsStoreHandleFuncCall
 	mutex       sync.Mutex
 }
 
 // Handle delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockPermsStore) Handle() *basestore.TransactableHandle {
+func (m *MockPermsStore) Handle() *basestore.OldTransactableHandle {
 	r0 := m.HandleFunc.nextHook()()
 	m.HandleFunc.appendCall(PermsStoreHandleFuncCall{r0})
 	return r0
@@ -12289,7 +12289,7 @@ func (m *MockPermsStore) Handle() *basestore.TransactableHandle {
 
 // SetDefaultHook sets function that is called when the Handle method of the
 // parent MockPermsStore instance is invoked and the hook queue is empty.
-func (f *PermsStoreHandleFunc) SetDefaultHook(hook func() *basestore.TransactableHandle) {
+func (f *PermsStoreHandleFunc) SetDefaultHook(hook func() *basestore.OldTransactableHandle) {
 	f.defaultHook = hook
 }
 
@@ -12297,7 +12297,7 @@ func (f *PermsStoreHandleFunc) SetDefaultHook(hook func() *basestore.Transactabl
 // Handle method of the parent MockPermsStore instance invokes the hook at
 // the front of the queue and discards it. After the queue is empty, the
 // default hook function is invoked for any future action.
-func (f *PermsStoreHandleFunc) PushHook(hook func() *basestore.TransactableHandle) {
+func (f *PermsStoreHandleFunc) PushHook(hook func() *basestore.OldTransactableHandle) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -12305,20 +12305,20 @@ func (f *PermsStoreHandleFunc) PushHook(hook func() *basestore.TransactableHandl
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *PermsStoreHandleFunc) SetDefaultReturn(r0 *basestore.TransactableHandle) {
-	f.SetDefaultHook(func() *basestore.TransactableHandle {
+func (f *PermsStoreHandleFunc) SetDefaultReturn(r0 *basestore.OldTransactableHandle) {
+	f.SetDefaultHook(func() *basestore.OldTransactableHandle {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *PermsStoreHandleFunc) PushReturn(r0 *basestore.TransactableHandle) {
-	f.PushHook(func() *basestore.TransactableHandle {
+func (f *PermsStoreHandleFunc) PushReturn(r0 *basestore.OldTransactableHandle) {
+	f.PushHook(func() *basestore.OldTransactableHandle {
 		return r0
 	})
 }
 
-func (f *PermsStoreHandleFunc) nextHook() func() *basestore.TransactableHandle {
+func (f *PermsStoreHandleFunc) nextHook() func() *basestore.OldTransactableHandle {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -12353,7 +12353,7 @@ func (f *PermsStoreHandleFunc) History() []PermsStoreHandleFuncCall {
 type PermsStoreHandleFuncCall struct {
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 *basestore.TransactableHandle
+	Result0 *basestore.OldTransactableHandle
 }
 
 // Args returns an interface slice containing the arguments of this

--- a/enterprise/internal/insights/store/dashboard_store.go
+++ b/enterprise/internal/insights/store/dashboard_store.go
@@ -26,10 +26,6 @@ func NewDashboardStore(db edb.InsightsDB) *DBDashboardStore {
 	return &DBDashboardStore{Store: basestore.NewWithHandle(db.Handle()), Now: time.Now}
 }
 
-// Handle returns the underlying transactable database handle.
-// Needed to implement the ShareableStore interface.
-func (s *DBDashboardStore) Handle() *basestore.OldTransactableHandle { return s.Store.Handle() }
-
 // With creates a new DBDashboardStore with the given basestore. Shareable store as the underlying basestore.Store.
 // Needed to implement the basestore.Store interface
 func (s *DBDashboardStore) With(other basestore.ShareableStore) *DBDashboardStore {

--- a/enterprise/internal/insights/store/dashboard_store.go
+++ b/enterprise/internal/insights/store/dashboard_store.go
@@ -28,7 +28,7 @@ func NewDashboardStore(db edb.InsightsDB) *DBDashboardStore {
 
 // Handle returns the underlying transactable database handle.
 // Needed to implement the ShareableStore interface.
-func (s *DBDashboardStore) Handle() *basestore.TransactableHandle { return s.Store.Handle() }
+func (s *DBDashboardStore) Handle() *basestore.OldTransactableHandle { return s.Store.Handle() }
 
 // With creates a new DBDashboardStore with the given basestore. Shareable store as the underlying basestore.Store.
 // Needed to implement the basestore.Store interface

--- a/enterprise/internal/insights/store/insight_store.go
+++ b/enterprise/internal/insights/store/insight_store.go
@@ -33,7 +33,7 @@ func NewInsightStoreWith(other basestore.ShareableStore) *InsightStore {
 
 // Handle returns the underlying transactable database handle.
 // Needed to implement the ShareableStore interface.
-func (s *InsightStore) Handle() *basestore.TransactableHandle { return s.Store.Handle() }
+func (s *InsightStore) Handle() *basestore.OldTransactableHandle { return s.Store.Handle() }
 
 // With creates a new InsightStore with the given basestore.Shareable store as the underlying basestore.Store.
 // Needed to implement the basestore.Store interface

--- a/enterprise/internal/insights/store/insight_store.go
+++ b/enterprise/internal/insights/store/insight_store.go
@@ -31,10 +31,6 @@ func NewInsightStoreWith(other basestore.ShareableStore) *InsightStore {
 	return &InsightStore{Store: basestore.NewWithHandle(other.Handle()), Now: time.Now}
 }
 
-// Handle returns the underlying transactable database handle.
-// Needed to implement the ShareableStore interface.
-func (s *InsightStore) Handle() *basestore.OldTransactableHandle { return s.Store.Handle() }
-
 // With creates a new InsightStore with the given basestore.Shareable store as the underlying basestore.Store.
 // Needed to implement the basestore.Store interface
 func (s *InsightStore) With(other basestore.ShareableStore) *InsightStore {

--- a/enterprise/internal/insights/store/settings_migration_jobs_store.go
+++ b/enterprise/internal/insights/store/settings_migration_jobs_store.go
@@ -32,10 +32,6 @@ func NewSettingsMigrationJobsStore(db database.DB) *DBSettingsMigrationJobsStore
 	return &DBSettingsMigrationJobsStore{Store: basestore.NewWithHandle(db.Handle()), Now: time.Now}
 }
 
-func (s *DBSettingsMigrationJobsStore) Handle() *basestore.OldTransactableHandle {
-	return s.Store.Handle()
-}
-
 func (s *DBSettingsMigrationJobsStore) With(other basestore.ShareableStore) *DBSettingsMigrationJobsStore {
 	return &DBSettingsMigrationJobsStore{Store: s.Store.With(other), Now: s.Now}
 }

--- a/enterprise/internal/insights/store/settings_migration_jobs_store.go
+++ b/enterprise/internal/insights/store/settings_migration_jobs_store.go
@@ -32,7 +32,7 @@ func NewSettingsMigrationJobsStore(db database.DB) *DBSettingsMigrationJobsStore
 	return &DBSettingsMigrationJobsStore{Store: basestore.NewWithHandle(db.Handle()), Now: time.Now}
 }
 
-func (s *DBSettingsMigrationJobsStore) Handle() *basestore.TransactableHandle {
+func (s *DBSettingsMigrationJobsStore) Handle() *basestore.OldTransactableHandle {
 	return s.Store.Handle()
 }
 

--- a/enterprise/internal/insights/store/store.go
+++ b/enterprise/internal/insights/store/store.go
@@ -64,7 +64,7 @@ var _ basestore.ShareableStore = &Store{}
 
 // Handle returns the underlying transactable database handle.
 // Needed to implement the ShareableStore interface.
-func (s *Store) Handle() *basestore.TransactableHandle { return s.Store.Handle() }
+func (s *Store) Handle() *basestore.OldTransactableHandle { return s.Store.Handle() }
 
 // With creates a new Store with the given basestore.Shareable store as the
 // underlying basestore.Store.

--- a/enterprise/internal/insights/store/store.go
+++ b/enterprise/internal/insights/store/store.go
@@ -62,10 +62,6 @@ func NewWithClock(db edb.InsightsDB, permStore InsightPermissionStore, clock fun
 
 var _ basestore.ShareableStore = &Store{}
 
-// Handle returns the underlying transactable database handle.
-// Needed to implement the ShareableStore interface.
-func (s *Store) Handle() *basestore.OldTransactableHandle { return s.Store.Handle() }
-
 // With creates a new Store with the given basestore.Shareable store as the
 // underlying basestore.Store.
 // Needed to implement the basestore.Store interface

--- a/internal/codeintel/autoindexing/iface.go
+++ b/internal/codeintel/autoindexing/iface.go
@@ -15,7 +15,7 @@ import (
 type DBStore interface {
 	basestore.ShareableStore
 
-	Handle() *basestore.TransactableHandle
+	Handle() *basestore.OldTransactableHandle
 	Transact(ctx context.Context) (DBStore, error)
 	Done(err error) error
 

--- a/internal/codeintel/autoindexing/iface.go
+++ b/internal/codeintel/autoindexing/iface.go
@@ -15,7 +15,6 @@ import (
 type DBStore interface {
 	basestore.ShareableStore
 
-	Handle() *basestore.OldTransactableHandle
 	Transact(ctx context.Context) (DBStore, error)
 	Done(err error) error
 

--- a/internal/codeintel/autoindexing/mocks_test.go
+++ b/internal/codeintel/autoindexing/mocks_test.go
@@ -78,7 +78,7 @@ func NewMockDBStore() *MockDBStore {
 			},
 		},
 		HandleFunc: &DBStoreHandleFunc{
-			defaultHook: func() (r0 *basestore.OldTransactableHandle) {
+			defaultHook: func() (r0 basestore.TransactableHandle) {
 				return
 			},
 		},
@@ -130,7 +130,7 @@ func NewStrictMockDBStore() *MockDBStore {
 			},
 		},
 		HandleFunc: &DBStoreHandleFunc{
-			defaultHook: func() *basestore.OldTransactableHandle {
+			defaultHook: func() basestore.TransactableHandle {
 				panic("unexpected invocation of MockDBStore.Handle")
 			},
 		},
@@ -631,15 +631,15 @@ func (c DBStoreGetIndexesByIDsFuncCall) Results() []interface{} {
 // DBStoreHandleFunc describes the behavior when the Handle method of the
 // parent MockDBStore instance is invoked.
 type DBStoreHandleFunc struct {
-	defaultHook func() *basestore.OldTransactableHandle
-	hooks       []func() *basestore.OldTransactableHandle
+	defaultHook func() basestore.TransactableHandle
+	hooks       []func() basestore.TransactableHandle
 	history     []DBStoreHandleFuncCall
 	mutex       sync.Mutex
 }
 
 // Handle delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockDBStore) Handle() *basestore.OldTransactableHandle {
+func (m *MockDBStore) Handle() basestore.TransactableHandle {
 	r0 := m.HandleFunc.nextHook()()
 	m.HandleFunc.appendCall(DBStoreHandleFuncCall{r0})
 	return r0
@@ -647,7 +647,7 @@ func (m *MockDBStore) Handle() *basestore.OldTransactableHandle {
 
 // SetDefaultHook sets function that is called when the Handle method of the
 // parent MockDBStore instance is invoked and the hook queue is empty.
-func (f *DBStoreHandleFunc) SetDefaultHook(hook func() *basestore.OldTransactableHandle) {
+func (f *DBStoreHandleFunc) SetDefaultHook(hook func() basestore.TransactableHandle) {
 	f.defaultHook = hook
 }
 
@@ -655,7 +655,7 @@ func (f *DBStoreHandleFunc) SetDefaultHook(hook func() *basestore.OldTransactabl
 // Handle method of the parent MockDBStore instance invokes the hook at the
 // front of the queue and discards it. After the queue is empty, the default
 // hook function is invoked for any future action.
-func (f *DBStoreHandleFunc) PushHook(hook func() *basestore.OldTransactableHandle) {
+func (f *DBStoreHandleFunc) PushHook(hook func() basestore.TransactableHandle) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -663,20 +663,20 @@ func (f *DBStoreHandleFunc) PushHook(hook func() *basestore.OldTransactableHandl
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *DBStoreHandleFunc) SetDefaultReturn(r0 *basestore.OldTransactableHandle) {
-	f.SetDefaultHook(func() *basestore.OldTransactableHandle {
+func (f *DBStoreHandleFunc) SetDefaultReturn(r0 basestore.TransactableHandle) {
+	f.SetDefaultHook(func() basestore.TransactableHandle {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *DBStoreHandleFunc) PushReturn(r0 *basestore.OldTransactableHandle) {
-	f.PushHook(func() *basestore.OldTransactableHandle {
+func (f *DBStoreHandleFunc) PushReturn(r0 basestore.TransactableHandle) {
+	f.PushHook(func() basestore.TransactableHandle {
 		return r0
 	})
 }
 
-func (f *DBStoreHandleFunc) nextHook() func() *basestore.OldTransactableHandle {
+func (f *DBStoreHandleFunc) nextHook() func() basestore.TransactableHandle {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -711,7 +711,7 @@ func (f *DBStoreHandleFunc) History() []DBStoreHandleFuncCall {
 type DBStoreHandleFuncCall struct {
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 *basestore.OldTransactableHandle
+	Result0 basestore.TransactableHandle
 }
 
 // Args returns an interface slice containing the arguments of this

--- a/internal/codeintel/autoindexing/mocks_test.go
+++ b/internal/codeintel/autoindexing/mocks_test.go
@@ -78,7 +78,7 @@ func NewMockDBStore() *MockDBStore {
 			},
 		},
 		HandleFunc: &DBStoreHandleFunc{
-			defaultHook: func() (r0 *basestore.TransactableHandle) {
+			defaultHook: func() (r0 *basestore.OldTransactableHandle) {
 				return
 			},
 		},
@@ -130,7 +130,7 @@ func NewStrictMockDBStore() *MockDBStore {
 			},
 		},
 		HandleFunc: &DBStoreHandleFunc{
-			defaultHook: func() *basestore.TransactableHandle {
+			defaultHook: func() *basestore.OldTransactableHandle {
 				panic("unexpected invocation of MockDBStore.Handle")
 			},
 		},
@@ -631,15 +631,15 @@ func (c DBStoreGetIndexesByIDsFuncCall) Results() []interface{} {
 // DBStoreHandleFunc describes the behavior when the Handle method of the
 // parent MockDBStore instance is invoked.
 type DBStoreHandleFunc struct {
-	defaultHook func() *basestore.TransactableHandle
-	hooks       []func() *basestore.TransactableHandle
+	defaultHook func() *basestore.OldTransactableHandle
+	hooks       []func() *basestore.OldTransactableHandle
 	history     []DBStoreHandleFuncCall
 	mutex       sync.Mutex
 }
 
 // Handle delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockDBStore) Handle() *basestore.TransactableHandle {
+func (m *MockDBStore) Handle() *basestore.OldTransactableHandle {
 	r0 := m.HandleFunc.nextHook()()
 	m.HandleFunc.appendCall(DBStoreHandleFuncCall{r0})
 	return r0
@@ -647,7 +647,7 @@ func (m *MockDBStore) Handle() *basestore.TransactableHandle {
 
 // SetDefaultHook sets function that is called when the Handle method of the
 // parent MockDBStore instance is invoked and the hook queue is empty.
-func (f *DBStoreHandleFunc) SetDefaultHook(hook func() *basestore.TransactableHandle) {
+func (f *DBStoreHandleFunc) SetDefaultHook(hook func() *basestore.OldTransactableHandle) {
 	f.defaultHook = hook
 }
 
@@ -655,7 +655,7 @@ func (f *DBStoreHandleFunc) SetDefaultHook(hook func() *basestore.TransactableHa
 // Handle method of the parent MockDBStore instance invokes the hook at the
 // front of the queue and discards it. After the queue is empty, the default
 // hook function is invoked for any future action.
-func (f *DBStoreHandleFunc) PushHook(hook func() *basestore.TransactableHandle) {
+func (f *DBStoreHandleFunc) PushHook(hook func() *basestore.OldTransactableHandle) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -663,20 +663,20 @@ func (f *DBStoreHandleFunc) PushHook(hook func() *basestore.TransactableHandle) 
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *DBStoreHandleFunc) SetDefaultReturn(r0 *basestore.TransactableHandle) {
-	f.SetDefaultHook(func() *basestore.TransactableHandle {
+func (f *DBStoreHandleFunc) SetDefaultReturn(r0 *basestore.OldTransactableHandle) {
+	f.SetDefaultHook(func() *basestore.OldTransactableHandle {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *DBStoreHandleFunc) PushReturn(r0 *basestore.TransactableHandle) {
-	f.PushHook(func() *basestore.TransactableHandle {
+func (f *DBStoreHandleFunc) PushReturn(r0 *basestore.OldTransactableHandle) {
+	f.PushHook(func() *basestore.OldTransactableHandle {
 		return r0
 	})
 }
 
-func (f *DBStoreHandleFunc) nextHook() func() *basestore.TransactableHandle {
+func (f *DBStoreHandleFunc) nextHook() func() *basestore.OldTransactableHandle {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -711,7 +711,7 @@ func (f *DBStoreHandleFunc) History() []DBStoreHandleFuncCall {
 type DBStoreHandleFuncCall struct {
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 *basestore.TransactableHandle
+	Result0 *basestore.OldTransactableHandle
 }
 
 // Args returns an interface slice containing the arguments of this

--- a/internal/codeintel/uploads/background/cleanup/iface.go
+++ b/internal/codeintel/uploads/background/cleanup/iface.go
@@ -12,7 +12,6 @@ import (
 type DBStore interface {
 	basestore.ShareableStore
 
-	Handle() *basestore.OldTransactableHandle
 	Transact(ctx context.Context) (DBStore, error)
 	Done(err error) error
 

--- a/internal/codeintel/uploads/background/cleanup/iface.go
+++ b/internal/codeintel/uploads/background/cleanup/iface.go
@@ -12,7 +12,7 @@ import (
 type DBStore interface {
 	basestore.ShareableStore
 
-	Handle() *basestore.TransactableHandle
+	Handle() *basestore.OldTransactableHandle
 	Transact(ctx context.Context) (DBStore, error)
 	Done(err error) error
 

--- a/internal/codeintel/uploads/background/cleanup/mocks_test.go
+++ b/internal/codeintel/uploads/background/cleanup/mocks_test.go
@@ -104,7 +104,7 @@ func NewMockDBStore() *MockDBStore {
 			},
 		},
 		HandleFunc: &DBStoreHandleFunc{
-			defaultHook: func() (r0 *basestore.OldTransactableHandle) {
+			defaultHook: func() (r0 basestore.TransactableHandle) {
 				return
 			},
 		},
@@ -176,7 +176,7 @@ func NewStrictMockDBStore() *MockDBStore {
 			},
 		},
 		HandleFunc: &DBStoreHandleFunc{
-			defaultHook: func() *basestore.OldTransactableHandle {
+			defaultHook: func() basestore.TransactableHandle {
 				panic("unexpected invocation of MockDBStore.Handle")
 			},
 		},
@@ -1038,15 +1038,15 @@ func (c DBStoreGetUploadsFuncCall) Results() []interface{} {
 // DBStoreHandleFunc describes the behavior when the Handle method of the
 // parent MockDBStore instance is invoked.
 type DBStoreHandleFunc struct {
-	defaultHook func() *basestore.OldTransactableHandle
-	hooks       []func() *basestore.OldTransactableHandle
+	defaultHook func() basestore.TransactableHandle
+	hooks       []func() basestore.TransactableHandle
 	history     []DBStoreHandleFuncCall
 	mutex       sync.Mutex
 }
 
 // Handle delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockDBStore) Handle() *basestore.OldTransactableHandle {
+func (m *MockDBStore) Handle() basestore.TransactableHandle {
 	r0 := m.HandleFunc.nextHook()()
 	m.HandleFunc.appendCall(DBStoreHandleFuncCall{r0})
 	return r0
@@ -1054,7 +1054,7 @@ func (m *MockDBStore) Handle() *basestore.OldTransactableHandle {
 
 // SetDefaultHook sets function that is called when the Handle method of the
 // parent MockDBStore instance is invoked and the hook queue is empty.
-func (f *DBStoreHandleFunc) SetDefaultHook(hook func() *basestore.OldTransactableHandle) {
+func (f *DBStoreHandleFunc) SetDefaultHook(hook func() basestore.TransactableHandle) {
 	f.defaultHook = hook
 }
 
@@ -1062,7 +1062,7 @@ func (f *DBStoreHandleFunc) SetDefaultHook(hook func() *basestore.OldTransactabl
 // Handle method of the parent MockDBStore instance invokes the hook at the
 // front of the queue and discards it. After the queue is empty, the default
 // hook function is invoked for any future action.
-func (f *DBStoreHandleFunc) PushHook(hook func() *basestore.OldTransactableHandle) {
+func (f *DBStoreHandleFunc) PushHook(hook func() basestore.TransactableHandle) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -1070,20 +1070,20 @@ func (f *DBStoreHandleFunc) PushHook(hook func() *basestore.OldTransactableHandl
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *DBStoreHandleFunc) SetDefaultReturn(r0 *basestore.OldTransactableHandle) {
-	f.SetDefaultHook(func() *basestore.OldTransactableHandle {
+func (f *DBStoreHandleFunc) SetDefaultReturn(r0 basestore.TransactableHandle) {
+	f.SetDefaultHook(func() basestore.TransactableHandle {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *DBStoreHandleFunc) PushReturn(r0 *basestore.OldTransactableHandle) {
-	f.PushHook(func() *basestore.OldTransactableHandle {
+func (f *DBStoreHandleFunc) PushReturn(r0 basestore.TransactableHandle) {
+	f.PushHook(func() basestore.TransactableHandle {
 		return r0
 	})
 }
 
-func (f *DBStoreHandleFunc) nextHook() func() *basestore.OldTransactableHandle {
+func (f *DBStoreHandleFunc) nextHook() func() basestore.TransactableHandle {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -1118,7 +1118,7 @@ func (f *DBStoreHandleFunc) History() []DBStoreHandleFuncCall {
 type DBStoreHandleFuncCall struct {
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 *basestore.OldTransactableHandle
+	Result0 basestore.TransactableHandle
 }
 
 // Args returns an interface slice containing the arguments of this

--- a/internal/codeintel/uploads/background/cleanup/mocks_test.go
+++ b/internal/codeintel/uploads/background/cleanup/mocks_test.go
@@ -104,7 +104,7 @@ func NewMockDBStore() *MockDBStore {
 			},
 		},
 		HandleFunc: &DBStoreHandleFunc{
-			defaultHook: func() (r0 *basestore.TransactableHandle) {
+			defaultHook: func() (r0 *basestore.OldTransactableHandle) {
 				return
 			},
 		},
@@ -176,7 +176,7 @@ func NewStrictMockDBStore() *MockDBStore {
 			},
 		},
 		HandleFunc: &DBStoreHandleFunc{
-			defaultHook: func() *basestore.TransactableHandle {
+			defaultHook: func() *basestore.OldTransactableHandle {
 				panic("unexpected invocation of MockDBStore.Handle")
 			},
 		},
@@ -1038,15 +1038,15 @@ func (c DBStoreGetUploadsFuncCall) Results() []interface{} {
 // DBStoreHandleFunc describes the behavior when the Handle method of the
 // parent MockDBStore instance is invoked.
 type DBStoreHandleFunc struct {
-	defaultHook func() *basestore.TransactableHandle
-	hooks       []func() *basestore.TransactableHandle
+	defaultHook func() *basestore.OldTransactableHandle
+	hooks       []func() *basestore.OldTransactableHandle
 	history     []DBStoreHandleFuncCall
 	mutex       sync.Mutex
 }
 
 // Handle delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockDBStore) Handle() *basestore.TransactableHandle {
+func (m *MockDBStore) Handle() *basestore.OldTransactableHandle {
 	r0 := m.HandleFunc.nextHook()()
 	m.HandleFunc.appendCall(DBStoreHandleFuncCall{r0})
 	return r0
@@ -1054,7 +1054,7 @@ func (m *MockDBStore) Handle() *basestore.TransactableHandle {
 
 // SetDefaultHook sets function that is called when the Handle method of the
 // parent MockDBStore instance is invoked and the hook queue is empty.
-func (f *DBStoreHandleFunc) SetDefaultHook(hook func() *basestore.TransactableHandle) {
+func (f *DBStoreHandleFunc) SetDefaultHook(hook func() *basestore.OldTransactableHandle) {
 	f.defaultHook = hook
 }
 
@@ -1062,7 +1062,7 @@ func (f *DBStoreHandleFunc) SetDefaultHook(hook func() *basestore.TransactableHa
 // Handle method of the parent MockDBStore instance invokes the hook at the
 // front of the queue and discards it. After the queue is empty, the default
 // hook function is invoked for any future action.
-func (f *DBStoreHandleFunc) PushHook(hook func() *basestore.TransactableHandle) {
+func (f *DBStoreHandleFunc) PushHook(hook func() *basestore.OldTransactableHandle) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -1070,20 +1070,20 @@ func (f *DBStoreHandleFunc) PushHook(hook func() *basestore.TransactableHandle) 
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *DBStoreHandleFunc) SetDefaultReturn(r0 *basestore.TransactableHandle) {
-	f.SetDefaultHook(func() *basestore.TransactableHandle {
+func (f *DBStoreHandleFunc) SetDefaultReturn(r0 *basestore.OldTransactableHandle) {
+	f.SetDefaultHook(func() *basestore.OldTransactableHandle {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *DBStoreHandleFunc) PushReturn(r0 *basestore.TransactableHandle) {
-	f.PushHook(func() *basestore.TransactableHandle {
+func (f *DBStoreHandleFunc) PushReturn(r0 *basestore.OldTransactableHandle) {
+	f.PushHook(func() *basestore.OldTransactableHandle {
 		return r0
 	})
 }
 
-func (f *DBStoreHandleFunc) nextHook() func() *basestore.TransactableHandle {
+func (f *DBStoreHandleFunc) nextHook() func() *basestore.OldTransactableHandle {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -1118,7 +1118,7 @@ func (f *DBStoreHandleFunc) History() []DBStoreHandleFuncCall {
 type DBStoreHandleFuncCall struct {
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 *basestore.TransactableHandle
+	Result0 *basestore.OldTransactableHandle
 }
 
 // Args returns an interface slice containing the arguments of this

--- a/internal/codeintel/uploads/background/expiration/iface.go
+++ b/internal/codeintel/uploads/background/expiration/iface.go
@@ -12,7 +12,6 @@ import (
 type DBStore interface {
 	basestore.ShareableStore
 
-	Handle() *basestore.OldTransactableHandle
 	Transact(ctx context.Context) (DBStore, error)
 	Done(err error) error
 

--- a/internal/codeintel/uploads/background/expiration/iface.go
+++ b/internal/codeintel/uploads/background/expiration/iface.go
@@ -12,7 +12,7 @@ import (
 type DBStore interface {
 	basestore.ShareableStore
 
-	Handle() *basestore.TransactableHandle
+	Handle() *basestore.OldTransactableHandle
 	Transact(ctx context.Context) (DBStore, error)
 	Done(err error) error
 

--- a/internal/codeintel/uploads/background/expiration/mocks_test.go
+++ b/internal/codeintel/uploads/background/expiration/mocks_test.go
@@ -73,7 +73,7 @@ func NewMockDBStore() *MockDBStore {
 			},
 		},
 		HandleFunc: &DBStoreHandleFunc{
-			defaultHook: func() (r0 *basestore.OldTransactableHandle) {
+			defaultHook: func() (r0 basestore.TransactableHandle) {
 				return
 			},
 		},
@@ -120,7 +120,7 @@ func NewStrictMockDBStore() *MockDBStore {
 			},
 		},
 		HandleFunc: &DBStoreHandleFunc{
-			defaultHook: func() *basestore.OldTransactableHandle {
+			defaultHook: func() basestore.TransactableHandle {
 				panic("unexpected invocation of MockDBStore.Handle")
 			},
 		},
@@ -620,15 +620,15 @@ func (c DBStoreGetUploadsFuncCall) Results() []interface{} {
 // DBStoreHandleFunc describes the behavior when the Handle method of the
 // parent MockDBStore instance is invoked.
 type DBStoreHandleFunc struct {
-	defaultHook func() *basestore.OldTransactableHandle
-	hooks       []func() *basestore.OldTransactableHandle
+	defaultHook func() basestore.TransactableHandle
+	hooks       []func() basestore.TransactableHandle
 	history     []DBStoreHandleFuncCall
 	mutex       sync.Mutex
 }
 
 // Handle delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockDBStore) Handle() *basestore.OldTransactableHandle {
+func (m *MockDBStore) Handle() basestore.TransactableHandle {
 	r0 := m.HandleFunc.nextHook()()
 	m.HandleFunc.appendCall(DBStoreHandleFuncCall{r0})
 	return r0
@@ -636,7 +636,7 @@ func (m *MockDBStore) Handle() *basestore.OldTransactableHandle {
 
 // SetDefaultHook sets function that is called when the Handle method of the
 // parent MockDBStore instance is invoked and the hook queue is empty.
-func (f *DBStoreHandleFunc) SetDefaultHook(hook func() *basestore.OldTransactableHandle) {
+func (f *DBStoreHandleFunc) SetDefaultHook(hook func() basestore.TransactableHandle) {
 	f.defaultHook = hook
 }
 
@@ -644,7 +644,7 @@ func (f *DBStoreHandleFunc) SetDefaultHook(hook func() *basestore.OldTransactabl
 // Handle method of the parent MockDBStore instance invokes the hook at the
 // front of the queue and discards it. After the queue is empty, the default
 // hook function is invoked for any future action.
-func (f *DBStoreHandleFunc) PushHook(hook func() *basestore.OldTransactableHandle) {
+func (f *DBStoreHandleFunc) PushHook(hook func() basestore.TransactableHandle) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -652,20 +652,20 @@ func (f *DBStoreHandleFunc) PushHook(hook func() *basestore.OldTransactableHandl
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *DBStoreHandleFunc) SetDefaultReturn(r0 *basestore.OldTransactableHandle) {
-	f.SetDefaultHook(func() *basestore.OldTransactableHandle {
+func (f *DBStoreHandleFunc) SetDefaultReturn(r0 basestore.TransactableHandle) {
+	f.SetDefaultHook(func() basestore.TransactableHandle {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *DBStoreHandleFunc) PushReturn(r0 *basestore.OldTransactableHandle) {
-	f.PushHook(func() *basestore.OldTransactableHandle {
+func (f *DBStoreHandleFunc) PushReturn(r0 basestore.TransactableHandle) {
+	f.PushHook(func() basestore.TransactableHandle {
 		return r0
 	})
 }
 
-func (f *DBStoreHandleFunc) nextHook() func() *basestore.OldTransactableHandle {
+func (f *DBStoreHandleFunc) nextHook() func() basestore.TransactableHandle {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -700,7 +700,7 @@ func (f *DBStoreHandleFunc) History() []DBStoreHandleFuncCall {
 type DBStoreHandleFuncCall struct {
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 *basestore.OldTransactableHandle
+	Result0 basestore.TransactableHandle
 }
 
 // Args returns an interface slice containing the arguments of this

--- a/internal/codeintel/uploads/background/expiration/mocks_test.go
+++ b/internal/codeintel/uploads/background/expiration/mocks_test.go
@@ -73,7 +73,7 @@ func NewMockDBStore() *MockDBStore {
 			},
 		},
 		HandleFunc: &DBStoreHandleFunc{
-			defaultHook: func() (r0 *basestore.TransactableHandle) {
+			defaultHook: func() (r0 *basestore.OldTransactableHandle) {
 				return
 			},
 		},
@@ -120,7 +120,7 @@ func NewStrictMockDBStore() *MockDBStore {
 			},
 		},
 		HandleFunc: &DBStoreHandleFunc{
-			defaultHook: func() *basestore.TransactableHandle {
+			defaultHook: func() *basestore.OldTransactableHandle {
 				panic("unexpected invocation of MockDBStore.Handle")
 			},
 		},
@@ -620,15 +620,15 @@ func (c DBStoreGetUploadsFuncCall) Results() []interface{} {
 // DBStoreHandleFunc describes the behavior when the Handle method of the
 // parent MockDBStore instance is invoked.
 type DBStoreHandleFunc struct {
-	defaultHook func() *basestore.TransactableHandle
-	hooks       []func() *basestore.TransactableHandle
+	defaultHook func() *basestore.OldTransactableHandle
+	hooks       []func() *basestore.OldTransactableHandle
 	history     []DBStoreHandleFuncCall
 	mutex       sync.Mutex
 }
 
 // Handle delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockDBStore) Handle() *basestore.TransactableHandle {
+func (m *MockDBStore) Handle() *basestore.OldTransactableHandle {
 	r0 := m.HandleFunc.nextHook()()
 	m.HandleFunc.appendCall(DBStoreHandleFuncCall{r0})
 	return r0
@@ -636,7 +636,7 @@ func (m *MockDBStore) Handle() *basestore.TransactableHandle {
 
 // SetDefaultHook sets function that is called when the Handle method of the
 // parent MockDBStore instance is invoked and the hook queue is empty.
-func (f *DBStoreHandleFunc) SetDefaultHook(hook func() *basestore.TransactableHandle) {
+func (f *DBStoreHandleFunc) SetDefaultHook(hook func() *basestore.OldTransactableHandle) {
 	f.defaultHook = hook
 }
 
@@ -644,7 +644,7 @@ func (f *DBStoreHandleFunc) SetDefaultHook(hook func() *basestore.TransactableHa
 // Handle method of the parent MockDBStore instance invokes the hook at the
 // front of the queue and discards it. After the queue is empty, the default
 // hook function is invoked for any future action.
-func (f *DBStoreHandleFunc) PushHook(hook func() *basestore.TransactableHandle) {
+func (f *DBStoreHandleFunc) PushHook(hook func() *basestore.OldTransactableHandle) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -652,20 +652,20 @@ func (f *DBStoreHandleFunc) PushHook(hook func() *basestore.TransactableHandle) 
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *DBStoreHandleFunc) SetDefaultReturn(r0 *basestore.TransactableHandle) {
-	f.SetDefaultHook(func() *basestore.TransactableHandle {
+func (f *DBStoreHandleFunc) SetDefaultReturn(r0 *basestore.OldTransactableHandle) {
+	f.SetDefaultHook(func() *basestore.OldTransactableHandle {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *DBStoreHandleFunc) PushReturn(r0 *basestore.TransactableHandle) {
-	f.PushHook(func() *basestore.TransactableHandle {
+func (f *DBStoreHandleFunc) PushReturn(r0 *basestore.OldTransactableHandle) {
+	f.PushHook(func() *basestore.OldTransactableHandle {
 		return r0
 	})
 }
 
-func (f *DBStoreHandleFunc) nextHook() func() *basestore.TransactableHandle {
+func (f *DBStoreHandleFunc) nextHook() func() *basestore.OldTransactableHandle {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -700,7 +700,7 @@ func (f *DBStoreHandleFunc) History() []DBStoreHandleFuncCall {
 type DBStoreHandleFuncCall struct {
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 *basestore.TransactableHandle
+	Result0 *basestore.OldTransactableHandle
 }
 
 // Args returns an interface slice containing the arguments of this

--- a/internal/database/basestore/handle.go
+++ b/internal/database/basestore/handle.go
@@ -18,7 +18,7 @@ type OldTransactableHandle struct {
 }
 
 // NewHandleWithDB returns a new transactable database handle using the given database connection.
-func NewHandleWithDB(db dbutil.DB, txOptions sql.TxOptions) *OldTransactableHandle {
+func NewHandleWithDB(db dbutil.DB, txOptions sql.TxOptions) TransactableHandle {
 	return &OldTransactableHandle{db: db, txOptions: txOptions}
 }
 
@@ -42,7 +42,7 @@ func (h *OldTransactableHandle) InTransaction() bool {
 // Because we support properly nested transactions via savepoints, calling Transact from two different
 // goroutines on the same handle will not be deterministic: either transaction could nest the other one,
 // and calling Done in one goroutine may not finalize the expected unit of work.
-func (h *OldTransactableHandle) Transact(ctx context.Context) (*OldTransactableHandle, error) {
+func (h *OldTransactableHandle) Transact(ctx context.Context) (TransactableHandle, error) {
 	db := tryUnwrap(h.db)
 
 	if h.InTransaction() {

--- a/internal/database/basestore/handle_interface.go
+++ b/internal/database/basestore/handle_interface.go
@@ -9,10 +9,11 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
-// Transactible is a wrapper around a database connection that provides nested
-// transactions through registration and finalization of savepoints. A
+// TransactableHandle is a wrapper around a database connection that provides
+// nested transactions through registration and finalization of savepoints. A
 // transactable database handler can be shared by multiple stores.
 type TransactableHandle interface {
+	// DB returns the underlying dbutil.DB, which is usually a *sql.DB or a *sql.Tx
 	DB() dbutil.DB
 	InTransaction() bool
 	Transact(context.Context) (TransactableHandle, error)
@@ -24,7 +25,8 @@ var (
 	_ TransactableHandle = (*txHandle)(nil)
 	_ TransactableHandle = (*savepointHandle)(nil)
 
-	// The old transactible handle
+	// The old transactible handle satisfies this interface, but will
+	// eventually be phased out.
 	_ TransactableHandle = (*oldTransactableHandle)(nil)
 )
 

--- a/internal/database/basestore/handle_interface.go
+++ b/internal/database/basestore/handle_interface.go
@@ -15,8 +15,21 @@ import (
 type TransactableHandle interface {
 	// DB returns the underlying dbutil.DB, which is usually a *sql.DB or a *sql.Tx
 	DB() dbutil.DB
+
+	// InTransaction returns whether the handle represents a handle to a transaction.
 	InTransaction() bool
+
+	// Transact returns a new transactional database handle whose methods operate within the context of
+	// a new transaction or a new savepoint.
+	//
+	// Note that it is not safe to use transactions from multiple goroutines.
 	Transact(context.Context) (TransactableHandle, error)
+
+	// Done performs a commit or rollback of the underlying transaction/savepoint depending
+	// on the value of the error parameter. The resulting error value is a multierror containing
+	// the error parameter along with any error that occurs during commit or rollback of the
+	// transaction/savepoint. If the store does not wrap a transaction the original error value
+	// is returned unchanged.
 	Done(error) error
 }
 

--- a/internal/database/basestore/handle_interface.go
+++ b/internal/database/basestore/handle_interface.go
@@ -1,0 +1,123 @@
+package basestore
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+type ITransactableHandle interface {
+	DB() dbutil.DB
+	InTransaction() bool
+	Transact(context.Context) (ITransactableHandle, error)
+	Done(error) error
+}
+
+var (
+	_ ITransactableHandle = (*dbHandle)(nil)
+	_ ITransactableHandle = (*txHandle)(nil)
+	_ ITransactableHandle = (*savepointHandle)(nil)
+)
+
+type dbHandle struct {
+	db        *sql.DB
+	txOptions sql.TxOptions
+}
+
+func (h *dbHandle) DB() dbutil.DB {
+	return h.db
+}
+
+func (h *dbHandle) InTransaction() bool {
+	return false
+}
+
+func (h *dbHandle) Transact(ctx context.Context) (ITransactableHandle, error) {
+	tx, err := h.db.BeginTx(ctx, &h.txOptions)
+	if err != nil {
+		return nil, err
+	}
+	return &txHandle{tx: tx, txOptions: h.txOptions}, nil
+}
+
+func (h *dbHandle) Done(err error) error {
+	return errors.Append(err, ErrNotInTransaction)
+}
+
+type txHandle struct {
+	tx        *sql.Tx
+	txOptions sql.TxOptions
+}
+
+func (h *txHandle) DB() dbutil.DB {
+	return h.tx
+}
+
+func (h *txHandle) InTransaction() bool {
+	return true
+}
+
+func (h *txHandle) Transact(ctx context.Context) (ITransactableHandle, error) {
+	savepointID, err := newTxSavepoint(ctx, h.tx)
+	if err != nil {
+		return nil, err
+	}
+
+	return &savepointHandle{tx: h.tx, savepointID: savepointID}, nil
+}
+
+func (h *txHandle) Done(err error) error {
+	if err == nil {
+		return h.tx.Commit()
+	}
+	return errors.Append(err, h.tx.Rollback())
+}
+
+type savepointHandle struct {
+	tx          *sql.Tx
+	savepointID string
+}
+
+func (h *savepointHandle) DB() dbutil.DB {
+	return h.tx
+}
+
+func (h *savepointHandle) InTransaction() bool {
+	return true
+}
+
+func (h *savepointHandle) Transact(ctx context.Context) (ITransactableHandle, error) {
+	savepointID, err := newTxSavepoint(ctx, h.tx)
+	if err != nil {
+		return nil, err
+	}
+
+	return &savepointHandle{tx: h.tx, savepointID: savepointID}, nil
+}
+
+func (h *savepointHandle) Done(err error) error {
+	if err == nil {
+		_, execErr := h.tx.Exec(fmt.Sprintf(commitSavepointQuery, h.savepointID))
+		return execErr
+	}
+
+	_, execErr := h.tx.Exec(fmt.Sprintf(rollbackSavepointQuery, h.savepointID))
+	return errors.Append(err, execErr)
+}
+
+func newTxSavepoint(ctx context.Context, tx *sql.Tx) (string, error) {
+	savepointID, err := makeSavepointID()
+	if err != nil {
+		return "", err
+	}
+
+	_, err = tx.ExecContext(ctx, fmt.Sprintf(savepointQuery, savepointID))
+	if err != nil {
+		return "", err
+	}
+
+	return savepointID, nil
+}

--- a/internal/database/basestore/handle_interface.go
+++ b/internal/database/basestore/handle_interface.go
@@ -9,6 +9,9 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
+// Transactible is a wrapper around a database connection that provides nested
+// transactions through registration and finalization of savepoints. A
+// transactable database handler can be shared by multiple stores.
 type TransactableHandle interface {
 	DB() dbutil.DB
 	InTransaction() bool
@@ -20,6 +23,9 @@ var (
 	_ TransactableHandle = (*dbHandle)(nil)
 	_ TransactableHandle = (*txHandle)(nil)
 	_ TransactableHandle = (*savepointHandle)(nil)
+
+	// The old transactible handle
+	_ TransactableHandle = (*oldTransactableHandle)(nil)
 )
 
 type dbHandle struct {

--- a/internal/database/basestore/store.go
+++ b/internal/database/basestore/store.go
@@ -40,7 +40,7 @@ import (
 //         return &SprocketStore{Store: txBase}, err
 //     }
 type Store struct {
-	handle *TransactableHandle
+	handle *OldTransactableHandle
 }
 
 // ShareableStore is implemented by stores to explicitly allow distinct store instances
@@ -48,18 +48,18 @@ type Store struct {
 // multiple stores. See `Store.With` for additional details.
 type ShareableStore interface {
 	// Handle returns the underlying transactable database handle.
-	Handle() *TransactableHandle
+	Handle() *OldTransactableHandle
 }
 
 var _ ShareableStore = &Store{}
 
 // NewWithHandle returns a new base store using the given database handle.
-func NewWithHandle(handle *TransactableHandle) *Store {
+func NewWithHandle(handle *OldTransactableHandle) *Store {
 	return &Store{handle: handle}
 }
 
 // Handle returns the underlying transactable database handle.
-func (s *Store) Handle() *TransactableHandle {
+func (s *Store) Handle() *OldTransactableHandle {
 	return s.handle
 }
 

--- a/internal/database/basestore/store.go
+++ b/internal/database/basestore/store.go
@@ -40,7 +40,7 @@ import (
 //         return &SprocketStore{Store: txBase}, err
 //     }
 type Store struct {
-	handle *OldTransactableHandle
+	handle TransactableHandle
 }
 
 // ShareableStore is implemented by stores to explicitly allow distinct store instances
@@ -48,18 +48,18 @@ type Store struct {
 // multiple stores. See `Store.With` for additional details.
 type ShareableStore interface {
 	// Handle returns the underlying transactable database handle.
-	Handle() *OldTransactableHandle
+	Handle() TransactableHandle
 }
 
 var _ ShareableStore = &Store{}
 
 // NewWithHandle returns a new base store using the given database handle.
-func NewWithHandle(handle *OldTransactableHandle) *Store {
+func NewWithHandle(handle TransactableHandle) *Store {
 	return &Store{handle: handle}
 }
 
 // Handle returns the underlying transactable database handle.
-func (s *Store) Handle() *OldTransactableHandle {
+func (s *Store) Handle() TransactableHandle {
 	return s.handle
 }
 
@@ -83,13 +83,13 @@ func (s *Store) With(other ShareableStore) *Store {
 
 // Query performs QueryContext on the underlying connection.
 func (s *Store) Query(ctx context.Context, query *sqlf.Query) (*sql.Rows, error) {
-	rows, err := s.handle.db.QueryContext(ctx, query.Query(sqlf.PostgresBindVar), query.Args()...)
+	rows, err := s.handle.DB().QueryContext(ctx, query.Query(sqlf.PostgresBindVar), query.Args()...)
 	return rows, s.wrapError(query, err)
 }
 
 // QueryRow performs QueryRowContext on the underlying connection.
 func (s *Store) QueryRow(ctx context.Context, query *sqlf.Query) *sql.Row {
-	return s.handle.db.QueryRowContext(ctx, query.Query(sqlf.PostgresBindVar), query.Args()...)
+	return s.handle.DB().QueryRowContext(ctx, query.Query(sqlf.PostgresBindVar), query.Args()...)
 }
 
 // Exec performs a query without returning any rows.
@@ -101,7 +101,7 @@ func (s *Store) Exec(ctx context.Context, query *sqlf.Query) error {
 // ExecResult performs a query without returning any rows, but includes the
 // result of the execution.
 func (s *Store) ExecResult(ctx context.Context, query *sqlf.Query) (sql.Result, error) {
-	res, err := s.handle.db.ExecContext(ctx, query.Query(sqlf.PostgresBindVar), query.Args()...)
+	res, err := s.handle.DB().ExecContext(ctx, query.Query(sqlf.PostgresBindVar), query.Args()...)
 	return res, s.wrapError(query, err)
 }
 

--- a/internal/database/basestore/store_test.go
+++ b/internal/database/basestore/store_test.go
@@ -45,8 +45,8 @@ func TestTransaction(t *testing.T) {
 
 	// Check what's visible pre-commit/rollback
 	assertCounts(t, db, map[int]int{1: 42})
-	assertCounts(t, tx1.handle.db, map[int]int{1: 42, 2: 43})
-	assertCounts(t, tx2.handle.db, map[int]int{1: 42, 3: 44})
+	assertCounts(t, tx1.handle.DB(), map[int]int{1: 42, 2: 43})
+	assertCounts(t, tx2.handle.DB(), map[int]int{1: 42, 3: 44})
 
 	// Finalize transactions
 	rollbackErr := errors.New("rollback")

--- a/internal/database/mocks_temp.go
+++ b/internal/database/mocks_temp.go
@@ -113,7 +113,7 @@ func NewMockAccessTokenStore() *MockAccessTokenStore {
 			},
 		},
 		HandleFunc: &AccessTokenStoreHandleFunc{
-			defaultHook: func() (r0 *basestore.TransactableHandle) {
+			defaultHook: func() (r0 *basestore.OldTransactableHandle) {
 				return
 			},
 		},
@@ -185,7 +185,7 @@ func NewStrictMockAccessTokenStore() *MockAccessTokenStore {
 			},
 		},
 		HandleFunc: &AccessTokenStoreHandleFunc{
-			defaultHook: func() *basestore.TransactableHandle {
+			defaultHook: func() *basestore.OldTransactableHandle {
 				panic("unexpected invocation of MockAccessTokenStore.Handle")
 			},
 		},
@@ -1045,15 +1045,15 @@ func (c AccessTokenStoreGetByTokenFuncCall) Results() []interface{} {
 // AccessTokenStoreHandleFunc describes the behavior when the Handle method
 // of the parent MockAccessTokenStore instance is invoked.
 type AccessTokenStoreHandleFunc struct {
-	defaultHook func() *basestore.TransactableHandle
-	hooks       []func() *basestore.TransactableHandle
+	defaultHook func() *basestore.OldTransactableHandle
+	hooks       []func() *basestore.OldTransactableHandle
 	history     []AccessTokenStoreHandleFuncCall
 	mutex       sync.Mutex
 }
 
 // Handle delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockAccessTokenStore) Handle() *basestore.TransactableHandle {
+func (m *MockAccessTokenStore) Handle() *basestore.OldTransactableHandle {
 	r0 := m.HandleFunc.nextHook()()
 	m.HandleFunc.appendCall(AccessTokenStoreHandleFuncCall{r0})
 	return r0
@@ -1062,7 +1062,7 @@ func (m *MockAccessTokenStore) Handle() *basestore.TransactableHandle {
 // SetDefaultHook sets function that is called when the Handle method of the
 // parent MockAccessTokenStore instance is invoked and the hook queue is
 // empty.
-func (f *AccessTokenStoreHandleFunc) SetDefaultHook(hook func() *basestore.TransactableHandle) {
+func (f *AccessTokenStoreHandleFunc) SetDefaultHook(hook func() *basestore.OldTransactableHandle) {
 	f.defaultHook = hook
 }
 
@@ -1070,7 +1070,7 @@ func (f *AccessTokenStoreHandleFunc) SetDefaultHook(hook func() *basestore.Trans
 // Handle method of the parent MockAccessTokenStore instance invokes the
 // hook at the front of the queue and discards it. After the queue is empty,
 // the default hook function is invoked for any future action.
-func (f *AccessTokenStoreHandleFunc) PushHook(hook func() *basestore.TransactableHandle) {
+func (f *AccessTokenStoreHandleFunc) PushHook(hook func() *basestore.OldTransactableHandle) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -1078,20 +1078,20 @@ func (f *AccessTokenStoreHandleFunc) PushHook(hook func() *basestore.Transactabl
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *AccessTokenStoreHandleFunc) SetDefaultReturn(r0 *basestore.TransactableHandle) {
-	f.SetDefaultHook(func() *basestore.TransactableHandle {
+func (f *AccessTokenStoreHandleFunc) SetDefaultReturn(r0 *basestore.OldTransactableHandle) {
+	f.SetDefaultHook(func() *basestore.OldTransactableHandle {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *AccessTokenStoreHandleFunc) PushReturn(r0 *basestore.TransactableHandle) {
-	f.PushHook(func() *basestore.TransactableHandle {
+func (f *AccessTokenStoreHandleFunc) PushReturn(r0 *basestore.OldTransactableHandle) {
+	f.PushHook(func() *basestore.OldTransactableHandle {
 		return r0
 	})
 }
 
-func (f *AccessTokenStoreHandleFunc) nextHook() func() *basestore.TransactableHandle {
+func (f *AccessTokenStoreHandleFunc) nextHook() func() *basestore.OldTransactableHandle {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -1126,7 +1126,7 @@ func (f *AccessTokenStoreHandleFunc) History() []AccessTokenStoreHandleFuncCall 
 type AccessTokenStoreHandleFuncCall struct {
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 *basestore.TransactableHandle
+	Result0 *basestore.OldTransactableHandle
 }
 
 // Args returns an interface slice containing the arguments of this
@@ -2114,7 +2114,7 @@ func NewMockBitbucketProjectPermissionsStore() *MockBitbucketProjectPermissionsS
 			},
 		},
 		HandleFunc: &BitbucketProjectPermissionsStoreHandleFunc{
-			defaultHook: func() (r0 *basestore.TransactableHandle) {
+			defaultHook: func() (r0 *basestore.OldTransactableHandle) {
 				return
 			},
 		},
@@ -2152,7 +2152,7 @@ func NewStrictMockBitbucketProjectPermissionsStore() *MockBitbucketProjectPermis
 			},
 		},
 		HandleFunc: &BitbucketProjectPermissionsStoreHandleFunc{
-			defaultHook: func() *basestore.TransactableHandle {
+			defaultHook: func() *basestore.OldTransactableHandle {
 				panic("unexpected invocation of MockBitbucketProjectPermissionsStore.Handle")
 			},
 		},
@@ -2431,15 +2431,15 @@ func (c BitbucketProjectPermissionsStoreEnqueueFuncCall) Results() []interface{}
 // the Handle method of the parent MockBitbucketProjectPermissionsStore
 // instance is invoked.
 type BitbucketProjectPermissionsStoreHandleFunc struct {
-	defaultHook func() *basestore.TransactableHandle
-	hooks       []func() *basestore.TransactableHandle
+	defaultHook func() *basestore.OldTransactableHandle
+	hooks       []func() *basestore.OldTransactableHandle
 	history     []BitbucketProjectPermissionsStoreHandleFuncCall
 	mutex       sync.Mutex
 }
 
 // Handle delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockBitbucketProjectPermissionsStore) Handle() *basestore.TransactableHandle {
+func (m *MockBitbucketProjectPermissionsStore) Handle() *basestore.OldTransactableHandle {
 	r0 := m.HandleFunc.nextHook()()
 	m.HandleFunc.appendCall(BitbucketProjectPermissionsStoreHandleFuncCall{r0})
 	return r0
@@ -2448,7 +2448,7 @@ func (m *MockBitbucketProjectPermissionsStore) Handle() *basestore.TransactableH
 // SetDefaultHook sets function that is called when the Handle method of the
 // parent MockBitbucketProjectPermissionsStore instance is invoked and the
 // hook queue is empty.
-func (f *BitbucketProjectPermissionsStoreHandleFunc) SetDefaultHook(hook func() *basestore.TransactableHandle) {
+func (f *BitbucketProjectPermissionsStoreHandleFunc) SetDefaultHook(hook func() *basestore.OldTransactableHandle) {
 	f.defaultHook = hook
 }
 
@@ -2457,7 +2457,7 @@ func (f *BitbucketProjectPermissionsStoreHandleFunc) SetDefaultHook(hook func() 
 // invokes the hook at the front of the queue and discards it. After the
 // queue is empty, the default hook function is invoked for any future
 // action.
-func (f *BitbucketProjectPermissionsStoreHandleFunc) PushHook(hook func() *basestore.TransactableHandle) {
+func (f *BitbucketProjectPermissionsStoreHandleFunc) PushHook(hook func() *basestore.OldTransactableHandle) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -2465,20 +2465,20 @@ func (f *BitbucketProjectPermissionsStoreHandleFunc) PushHook(hook func() *bases
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *BitbucketProjectPermissionsStoreHandleFunc) SetDefaultReturn(r0 *basestore.TransactableHandle) {
-	f.SetDefaultHook(func() *basestore.TransactableHandle {
+func (f *BitbucketProjectPermissionsStoreHandleFunc) SetDefaultReturn(r0 *basestore.OldTransactableHandle) {
+	f.SetDefaultHook(func() *basestore.OldTransactableHandle {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *BitbucketProjectPermissionsStoreHandleFunc) PushReturn(r0 *basestore.TransactableHandle) {
-	f.PushHook(func() *basestore.TransactableHandle {
+func (f *BitbucketProjectPermissionsStoreHandleFunc) PushReturn(r0 *basestore.OldTransactableHandle) {
+	f.PushHook(func() *basestore.OldTransactableHandle {
 		return r0
 	})
 }
 
-func (f *BitbucketProjectPermissionsStoreHandleFunc) nextHook() func() *basestore.TransactableHandle {
+func (f *BitbucketProjectPermissionsStoreHandleFunc) nextHook() func() *basestore.OldTransactableHandle {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -2515,7 +2515,7 @@ func (f *BitbucketProjectPermissionsStoreHandleFunc) History() []BitbucketProjec
 type BitbucketProjectPermissionsStoreHandleFuncCall struct {
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 *basestore.TransactableHandle
+	Result0 *basestore.OldTransactableHandle
 }
 
 // Args returns an interface slice containing the arguments of this
@@ -2888,7 +2888,7 @@ func NewMockConfStore() *MockConfStore {
 			},
 		},
 		HandleFunc: &ConfStoreHandleFunc{
-			defaultHook: func() (r0 *basestore.TransactableHandle) {
+			defaultHook: func() (r0 *basestore.OldTransactableHandle) {
 				return
 			},
 		},
@@ -2920,7 +2920,7 @@ func NewStrictMockConfStore() *MockConfStore {
 			},
 		},
 		HandleFunc: &ConfStoreHandleFunc{
-			defaultHook: func() *basestore.TransactableHandle {
+			defaultHook: func() *basestore.OldTransactableHandle {
 				panic("unexpected invocation of MockConfStore.Handle")
 			},
 		},
@@ -3068,15 +3068,15 @@ func (c ConfStoreDoneFuncCall) Results() []interface{} {
 // ConfStoreHandleFunc describes the behavior when the Handle method of the
 // parent MockConfStore instance is invoked.
 type ConfStoreHandleFunc struct {
-	defaultHook func() *basestore.TransactableHandle
-	hooks       []func() *basestore.TransactableHandle
+	defaultHook func() *basestore.OldTransactableHandle
+	hooks       []func() *basestore.OldTransactableHandle
 	history     []ConfStoreHandleFuncCall
 	mutex       sync.Mutex
 }
 
 // Handle delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockConfStore) Handle() *basestore.TransactableHandle {
+func (m *MockConfStore) Handle() *basestore.OldTransactableHandle {
 	r0 := m.HandleFunc.nextHook()()
 	m.HandleFunc.appendCall(ConfStoreHandleFuncCall{r0})
 	return r0
@@ -3084,7 +3084,7 @@ func (m *MockConfStore) Handle() *basestore.TransactableHandle {
 
 // SetDefaultHook sets function that is called when the Handle method of the
 // parent MockConfStore instance is invoked and the hook queue is empty.
-func (f *ConfStoreHandleFunc) SetDefaultHook(hook func() *basestore.TransactableHandle) {
+func (f *ConfStoreHandleFunc) SetDefaultHook(hook func() *basestore.OldTransactableHandle) {
 	f.defaultHook = hook
 }
 
@@ -3092,7 +3092,7 @@ func (f *ConfStoreHandleFunc) SetDefaultHook(hook func() *basestore.Transactable
 // Handle method of the parent MockConfStore instance invokes the hook at
 // the front of the queue and discards it. After the queue is empty, the
 // default hook function is invoked for any future action.
-func (f *ConfStoreHandleFunc) PushHook(hook func() *basestore.TransactableHandle) {
+func (f *ConfStoreHandleFunc) PushHook(hook func() *basestore.OldTransactableHandle) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -3100,20 +3100,20 @@ func (f *ConfStoreHandleFunc) PushHook(hook func() *basestore.TransactableHandle
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *ConfStoreHandleFunc) SetDefaultReturn(r0 *basestore.TransactableHandle) {
-	f.SetDefaultHook(func() *basestore.TransactableHandle {
+func (f *ConfStoreHandleFunc) SetDefaultReturn(r0 *basestore.OldTransactableHandle) {
+	f.SetDefaultHook(func() *basestore.OldTransactableHandle {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *ConfStoreHandleFunc) PushReturn(r0 *basestore.TransactableHandle) {
-	f.PushHook(func() *basestore.TransactableHandle {
+func (f *ConfStoreHandleFunc) PushReturn(r0 *basestore.OldTransactableHandle) {
+	f.PushHook(func() *basestore.OldTransactableHandle {
 		return r0
 	})
 }
 
-func (f *ConfStoreHandleFunc) nextHook() func() *basestore.TransactableHandle {
+func (f *ConfStoreHandleFunc) nextHook() func() *basestore.OldTransactableHandle {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -3148,7 +3148,7 @@ func (f *ConfStoreHandleFunc) History() []ConfStoreHandleFuncCall {
 type ConfStoreHandleFuncCall struct {
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 *basestore.TransactableHandle
+	Result0 *basestore.OldTransactableHandle
 }
 
 // Args returns an interface slice containing the arguments of this
@@ -3662,7 +3662,7 @@ func NewMockDB() *MockDB {
 			},
 		},
 		HandleFunc: &DBHandleFunc{
-			defaultHook: func() (r0 *basestore.TransactableHandle) {
+			defaultHook: func() (r0 *basestore.OldTransactableHandle) {
 				return
 			},
 		},
@@ -3844,7 +3844,7 @@ func NewStrictMockDB() *MockDB {
 			},
 		},
 		HandleFunc: &DBHandleFunc{
-			defaultHook: func() *basestore.TransactableHandle {
+			defaultHook: func() *basestore.OldTransactableHandle {
 				panic("unexpected invocation of MockDB.Handle")
 			},
 		},
@@ -5280,15 +5280,15 @@ func (c DBGlobalStateFuncCall) Results() []interface{} {
 // DBHandleFunc describes the behavior when the Handle method of the parent
 // MockDB instance is invoked.
 type DBHandleFunc struct {
-	defaultHook func() *basestore.TransactableHandle
-	hooks       []func() *basestore.TransactableHandle
+	defaultHook func() *basestore.OldTransactableHandle
+	hooks       []func() *basestore.OldTransactableHandle
 	history     []DBHandleFuncCall
 	mutex       sync.Mutex
 }
 
 // Handle delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockDB) Handle() *basestore.TransactableHandle {
+func (m *MockDB) Handle() *basestore.OldTransactableHandle {
 	r0 := m.HandleFunc.nextHook()()
 	m.HandleFunc.appendCall(DBHandleFuncCall{r0})
 	return r0
@@ -5296,7 +5296,7 @@ func (m *MockDB) Handle() *basestore.TransactableHandle {
 
 // SetDefaultHook sets function that is called when the Handle method of the
 // parent MockDB instance is invoked and the hook queue is empty.
-func (f *DBHandleFunc) SetDefaultHook(hook func() *basestore.TransactableHandle) {
+func (f *DBHandleFunc) SetDefaultHook(hook func() *basestore.OldTransactableHandle) {
 	f.defaultHook = hook
 }
 
@@ -5304,7 +5304,7 @@ func (f *DBHandleFunc) SetDefaultHook(hook func() *basestore.TransactableHandle)
 // Handle method of the parent MockDB instance invokes the hook at the front
 // of the queue and discards it. After the queue is empty, the default hook
 // function is invoked for any future action.
-func (f *DBHandleFunc) PushHook(hook func() *basestore.TransactableHandle) {
+func (f *DBHandleFunc) PushHook(hook func() *basestore.OldTransactableHandle) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -5312,20 +5312,20 @@ func (f *DBHandleFunc) PushHook(hook func() *basestore.TransactableHandle) {
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *DBHandleFunc) SetDefaultReturn(r0 *basestore.TransactableHandle) {
-	f.SetDefaultHook(func() *basestore.TransactableHandle {
+func (f *DBHandleFunc) SetDefaultReturn(r0 *basestore.OldTransactableHandle) {
+	f.SetDefaultHook(func() *basestore.OldTransactableHandle {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *DBHandleFunc) PushReturn(r0 *basestore.TransactableHandle) {
-	f.PushHook(func() *basestore.TransactableHandle {
+func (f *DBHandleFunc) PushReturn(r0 *basestore.OldTransactableHandle) {
+	f.PushHook(func() *basestore.OldTransactableHandle {
 		return r0
 	})
 }
 
-func (f *DBHandleFunc) nextHook() func() *basestore.TransactableHandle {
+func (f *DBHandleFunc) nextHook() func() *basestore.OldTransactableHandle {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -5360,7 +5360,7 @@ func (f *DBHandleFunc) History() []DBHandleFuncCall {
 type DBHandleFuncCall struct {
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 *basestore.TransactableHandle
+	Result0 *basestore.OldTransactableHandle
 }
 
 // Args returns an interface slice containing the arguments of this
@@ -7843,7 +7843,7 @@ func NewMockEventLogStore() *MockEventLogStore {
 			},
 		},
 		HandleFunc: &EventLogStoreHandleFunc{
-			defaultHook: func() (r0 *basestore.TransactableHandle) {
+			defaultHook: func() (r0 *basestore.OldTransactableHandle) {
 				return
 			},
 		},
@@ -8030,7 +8030,7 @@ func NewStrictMockEventLogStore() *MockEventLogStore {
 			},
 		},
 		HandleFunc: &EventLogStoreHandleFunc{
-			defaultHook: func() *basestore.TransactableHandle {
+			defaultHook: func() *basestore.OldTransactableHandle {
 				panic("unexpected invocation of MockEventLogStore.Handle")
 			},
 		},
@@ -10893,15 +10893,15 @@ func (c EventLogStoreDoneFuncCall) Results() []interface{} {
 // EventLogStoreHandleFunc describes the behavior when the Handle method of
 // the parent MockEventLogStore instance is invoked.
 type EventLogStoreHandleFunc struct {
-	defaultHook func() *basestore.TransactableHandle
-	hooks       []func() *basestore.TransactableHandle
+	defaultHook func() *basestore.OldTransactableHandle
+	hooks       []func() *basestore.OldTransactableHandle
 	history     []EventLogStoreHandleFuncCall
 	mutex       sync.Mutex
 }
 
 // Handle delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockEventLogStore) Handle() *basestore.TransactableHandle {
+func (m *MockEventLogStore) Handle() *basestore.OldTransactableHandle {
 	r0 := m.HandleFunc.nextHook()()
 	m.HandleFunc.appendCall(EventLogStoreHandleFuncCall{r0})
 	return r0
@@ -10909,7 +10909,7 @@ func (m *MockEventLogStore) Handle() *basestore.TransactableHandle {
 
 // SetDefaultHook sets function that is called when the Handle method of the
 // parent MockEventLogStore instance is invoked and the hook queue is empty.
-func (f *EventLogStoreHandleFunc) SetDefaultHook(hook func() *basestore.TransactableHandle) {
+func (f *EventLogStoreHandleFunc) SetDefaultHook(hook func() *basestore.OldTransactableHandle) {
 	f.defaultHook = hook
 }
 
@@ -10917,7 +10917,7 @@ func (f *EventLogStoreHandleFunc) SetDefaultHook(hook func() *basestore.Transact
 // Handle method of the parent MockEventLogStore instance invokes the hook
 // at the front of the queue and discards it. After the queue is empty, the
 // default hook function is invoked for any future action.
-func (f *EventLogStoreHandleFunc) PushHook(hook func() *basestore.TransactableHandle) {
+func (f *EventLogStoreHandleFunc) PushHook(hook func() *basestore.OldTransactableHandle) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -10925,20 +10925,20 @@ func (f *EventLogStoreHandleFunc) PushHook(hook func() *basestore.TransactableHa
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *EventLogStoreHandleFunc) SetDefaultReturn(r0 *basestore.TransactableHandle) {
-	f.SetDefaultHook(func() *basestore.TransactableHandle {
+func (f *EventLogStoreHandleFunc) SetDefaultReturn(r0 *basestore.OldTransactableHandle) {
+	f.SetDefaultHook(func() *basestore.OldTransactableHandle {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *EventLogStoreHandleFunc) PushReturn(r0 *basestore.TransactableHandle) {
-	f.PushHook(func() *basestore.TransactableHandle {
+func (f *EventLogStoreHandleFunc) PushReturn(r0 *basestore.OldTransactableHandle) {
+	f.PushHook(func() *basestore.OldTransactableHandle {
 		return r0
 	})
 }
 
-func (f *EventLogStoreHandleFunc) nextHook() func() *basestore.TransactableHandle {
+func (f *EventLogStoreHandleFunc) nextHook() func() *basestore.OldTransactableHandle {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -10973,7 +10973,7 @@ func (f *EventLogStoreHandleFunc) History() []EventLogStoreHandleFuncCall {
 type EventLogStoreHandleFuncCall struct {
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 *basestore.TransactableHandle
+	Result0 *basestore.OldTransactableHandle
 }
 
 // Args returns an interface slice containing the arguments of this
@@ -12283,7 +12283,7 @@ func NewMockExternalServiceStore() *MockExternalServiceStore {
 			},
 		},
 		HandleFunc: &ExternalServiceStoreHandleFunc{
-			defaultHook: func() (r0 *basestore.TransactableHandle) {
+			defaultHook: func() (r0 *basestore.OldTransactableHandle) {
 				return
 			},
 		},
@@ -12381,7 +12381,7 @@ func NewStrictMockExternalServiceStore() *MockExternalServiceStore {
 			},
 		},
 		HandleFunc: &ExternalServiceStoreHandleFunc{
-			defaultHook: func() *basestore.TransactableHandle {
+			defaultHook: func() *basestore.OldTransactableHandle {
 				panic("unexpected invocation of MockExternalServiceStore.Handle")
 			},
 		},
@@ -13464,15 +13464,15 @@ func (c ExternalServiceStoreGetSyncJobsFuncCall) Results() []interface{} {
 // ExternalServiceStoreHandleFunc describes the behavior when the Handle
 // method of the parent MockExternalServiceStore instance is invoked.
 type ExternalServiceStoreHandleFunc struct {
-	defaultHook func() *basestore.TransactableHandle
-	hooks       []func() *basestore.TransactableHandle
+	defaultHook func() *basestore.OldTransactableHandle
+	hooks       []func() *basestore.OldTransactableHandle
 	history     []ExternalServiceStoreHandleFuncCall
 	mutex       sync.Mutex
 }
 
 // Handle delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockExternalServiceStore) Handle() *basestore.TransactableHandle {
+func (m *MockExternalServiceStore) Handle() *basestore.OldTransactableHandle {
 	r0 := m.HandleFunc.nextHook()()
 	m.HandleFunc.appendCall(ExternalServiceStoreHandleFuncCall{r0})
 	return r0
@@ -13481,7 +13481,7 @@ func (m *MockExternalServiceStore) Handle() *basestore.TransactableHandle {
 // SetDefaultHook sets function that is called when the Handle method of the
 // parent MockExternalServiceStore instance is invoked and the hook queue is
 // empty.
-func (f *ExternalServiceStoreHandleFunc) SetDefaultHook(hook func() *basestore.TransactableHandle) {
+func (f *ExternalServiceStoreHandleFunc) SetDefaultHook(hook func() *basestore.OldTransactableHandle) {
 	f.defaultHook = hook
 }
 
@@ -13489,7 +13489,7 @@ func (f *ExternalServiceStoreHandleFunc) SetDefaultHook(hook func() *basestore.T
 // Handle method of the parent MockExternalServiceStore instance invokes the
 // hook at the front of the queue and discards it. After the queue is empty,
 // the default hook function is invoked for any future action.
-func (f *ExternalServiceStoreHandleFunc) PushHook(hook func() *basestore.TransactableHandle) {
+func (f *ExternalServiceStoreHandleFunc) PushHook(hook func() *basestore.OldTransactableHandle) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -13497,20 +13497,20 @@ func (f *ExternalServiceStoreHandleFunc) PushHook(hook func() *basestore.Transac
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *ExternalServiceStoreHandleFunc) SetDefaultReturn(r0 *basestore.TransactableHandle) {
-	f.SetDefaultHook(func() *basestore.TransactableHandle {
+func (f *ExternalServiceStoreHandleFunc) SetDefaultReturn(r0 *basestore.OldTransactableHandle) {
+	f.SetDefaultHook(func() *basestore.OldTransactableHandle {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *ExternalServiceStoreHandleFunc) PushReturn(r0 *basestore.TransactableHandle) {
-	f.PushHook(func() *basestore.TransactableHandle {
+func (f *ExternalServiceStoreHandleFunc) PushReturn(r0 *basestore.OldTransactableHandle) {
+	f.PushHook(func() *basestore.OldTransactableHandle {
 		return r0
 	})
 }
 
-func (f *ExternalServiceStoreHandleFunc) nextHook() func() *basestore.TransactableHandle {
+func (f *ExternalServiceStoreHandleFunc) nextHook() func() *basestore.OldTransactableHandle {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -13545,7 +13545,7 @@ func (f *ExternalServiceStoreHandleFunc) History() []ExternalServiceStoreHandleF
 type ExternalServiceStoreHandleFuncCall struct {
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 *basestore.TransactableHandle
+	Result0 *basestore.OldTransactableHandle
 }
 
 // Args returns an interface slice containing the arguments of this
@@ -14581,7 +14581,7 @@ func NewMockFeatureFlagStore() *MockFeatureFlagStore {
 			},
 		},
 		HandleFunc: &FeatureFlagStoreHandleFunc{
-			defaultHook: func() (r0 *basestore.TransactableHandle) {
+			defaultHook: func() (r0 *basestore.OldTransactableHandle) {
 				return
 			},
 		},
@@ -14693,7 +14693,7 @@ func NewStrictMockFeatureFlagStore() *MockFeatureFlagStore {
 			},
 		},
 		HandleFunc: &FeatureFlagStoreHandleFunc{
-			defaultHook: func() *basestore.TransactableHandle {
+			defaultHook: func() *basestore.OldTransactableHandle {
 				panic("unexpected invocation of MockFeatureFlagStore.Handle")
 			},
 		},
@@ -16571,15 +16571,15 @@ func (c FeatureFlagStoreGetUserOverridesFuncCall) Results() []interface{} {
 // FeatureFlagStoreHandleFunc describes the behavior when the Handle method
 // of the parent MockFeatureFlagStore instance is invoked.
 type FeatureFlagStoreHandleFunc struct {
-	defaultHook func() *basestore.TransactableHandle
-	hooks       []func() *basestore.TransactableHandle
+	defaultHook func() *basestore.OldTransactableHandle
+	hooks       []func() *basestore.OldTransactableHandle
 	history     []FeatureFlagStoreHandleFuncCall
 	mutex       sync.Mutex
 }
 
 // Handle delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockFeatureFlagStore) Handle() *basestore.TransactableHandle {
+func (m *MockFeatureFlagStore) Handle() *basestore.OldTransactableHandle {
 	r0 := m.HandleFunc.nextHook()()
 	m.HandleFunc.appendCall(FeatureFlagStoreHandleFuncCall{r0})
 	return r0
@@ -16588,7 +16588,7 @@ func (m *MockFeatureFlagStore) Handle() *basestore.TransactableHandle {
 // SetDefaultHook sets function that is called when the Handle method of the
 // parent MockFeatureFlagStore instance is invoked and the hook queue is
 // empty.
-func (f *FeatureFlagStoreHandleFunc) SetDefaultHook(hook func() *basestore.TransactableHandle) {
+func (f *FeatureFlagStoreHandleFunc) SetDefaultHook(hook func() *basestore.OldTransactableHandle) {
 	f.defaultHook = hook
 }
 
@@ -16596,7 +16596,7 @@ func (f *FeatureFlagStoreHandleFunc) SetDefaultHook(hook func() *basestore.Trans
 // Handle method of the parent MockFeatureFlagStore instance invokes the
 // hook at the front of the queue and discards it. After the queue is empty,
 // the default hook function is invoked for any future action.
-func (f *FeatureFlagStoreHandleFunc) PushHook(hook func() *basestore.TransactableHandle) {
+func (f *FeatureFlagStoreHandleFunc) PushHook(hook func() *basestore.OldTransactableHandle) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -16604,20 +16604,20 @@ func (f *FeatureFlagStoreHandleFunc) PushHook(hook func() *basestore.Transactabl
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *FeatureFlagStoreHandleFunc) SetDefaultReturn(r0 *basestore.TransactableHandle) {
-	f.SetDefaultHook(func() *basestore.TransactableHandle {
+func (f *FeatureFlagStoreHandleFunc) SetDefaultReturn(r0 *basestore.OldTransactableHandle) {
+	f.SetDefaultHook(func() *basestore.OldTransactableHandle {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *FeatureFlagStoreHandleFunc) PushReturn(r0 *basestore.TransactableHandle) {
-	f.PushHook(func() *basestore.TransactableHandle {
+func (f *FeatureFlagStoreHandleFunc) PushReturn(r0 *basestore.OldTransactableHandle) {
+	f.PushHook(func() *basestore.OldTransactableHandle {
 		return r0
 	})
 }
 
-func (f *FeatureFlagStoreHandleFunc) nextHook() func() *basestore.TransactableHandle {
+func (f *FeatureFlagStoreHandleFunc) nextHook() func() *basestore.OldTransactableHandle {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -16652,7 +16652,7 @@ func (f *FeatureFlagStoreHandleFunc) History() []FeatureFlagStoreHandleFuncCall 
 type FeatureFlagStoreHandleFuncCall struct {
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 *basestore.TransactableHandle
+	Result0 *basestore.OldTransactableHandle
 }
 
 // Args returns an interface slice containing the arguments of this
@@ -17131,7 +17131,7 @@ func NewMockGitserverLocalCloneStore() *MockGitserverLocalCloneStore {
 			},
 		},
 		HandleFunc: &GitserverLocalCloneStoreHandleFunc{
-			defaultHook: func() (r0 *basestore.TransactableHandle) {
+			defaultHook: func() (r0 *basestore.OldTransactableHandle) {
 				return
 			},
 		},
@@ -17154,7 +17154,7 @@ func NewStrictMockGitserverLocalCloneStore() *MockGitserverLocalCloneStore {
 			},
 		},
 		HandleFunc: &GitserverLocalCloneStoreHandleFunc{
-			defaultHook: func() *basestore.TransactableHandle {
+			defaultHook: func() *basestore.OldTransactableHandle {
 				panic("unexpected invocation of MockGitserverLocalCloneStore.Handle")
 			},
 		},
@@ -17306,15 +17306,15 @@ func (c GitserverLocalCloneStoreEnqueueFuncCall) Results() []interface{} {
 // GitserverLocalCloneStoreHandleFunc describes the behavior when the Handle
 // method of the parent MockGitserverLocalCloneStore instance is invoked.
 type GitserverLocalCloneStoreHandleFunc struct {
-	defaultHook func() *basestore.TransactableHandle
-	hooks       []func() *basestore.TransactableHandle
+	defaultHook func() *basestore.OldTransactableHandle
+	hooks       []func() *basestore.OldTransactableHandle
 	history     []GitserverLocalCloneStoreHandleFuncCall
 	mutex       sync.Mutex
 }
 
 // Handle delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockGitserverLocalCloneStore) Handle() *basestore.TransactableHandle {
+func (m *MockGitserverLocalCloneStore) Handle() *basestore.OldTransactableHandle {
 	r0 := m.HandleFunc.nextHook()()
 	m.HandleFunc.appendCall(GitserverLocalCloneStoreHandleFuncCall{r0})
 	return r0
@@ -17323,7 +17323,7 @@ func (m *MockGitserverLocalCloneStore) Handle() *basestore.TransactableHandle {
 // SetDefaultHook sets function that is called when the Handle method of the
 // parent MockGitserverLocalCloneStore instance is invoked and the hook
 // queue is empty.
-func (f *GitserverLocalCloneStoreHandleFunc) SetDefaultHook(hook func() *basestore.TransactableHandle) {
+func (f *GitserverLocalCloneStoreHandleFunc) SetDefaultHook(hook func() *basestore.OldTransactableHandle) {
 	f.defaultHook = hook
 }
 
@@ -17331,7 +17331,7 @@ func (f *GitserverLocalCloneStoreHandleFunc) SetDefaultHook(hook func() *basesto
 // Handle method of the parent MockGitserverLocalCloneStore instance invokes
 // the hook at the front of the queue and discards it. After the queue is
 // empty, the default hook function is invoked for any future action.
-func (f *GitserverLocalCloneStoreHandleFunc) PushHook(hook func() *basestore.TransactableHandle) {
+func (f *GitserverLocalCloneStoreHandleFunc) PushHook(hook func() *basestore.OldTransactableHandle) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -17339,20 +17339,20 @@ func (f *GitserverLocalCloneStoreHandleFunc) PushHook(hook func() *basestore.Tra
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *GitserverLocalCloneStoreHandleFunc) SetDefaultReturn(r0 *basestore.TransactableHandle) {
-	f.SetDefaultHook(func() *basestore.TransactableHandle {
+func (f *GitserverLocalCloneStoreHandleFunc) SetDefaultReturn(r0 *basestore.OldTransactableHandle) {
+	f.SetDefaultHook(func() *basestore.OldTransactableHandle {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *GitserverLocalCloneStoreHandleFunc) PushReturn(r0 *basestore.TransactableHandle) {
-	f.PushHook(func() *basestore.TransactableHandle {
+func (f *GitserverLocalCloneStoreHandleFunc) PushReturn(r0 *basestore.OldTransactableHandle) {
+	f.PushHook(func() *basestore.OldTransactableHandle {
 		return r0
 	})
 }
 
-func (f *GitserverLocalCloneStoreHandleFunc) nextHook() func() *basestore.TransactableHandle {
+func (f *GitserverLocalCloneStoreHandleFunc) nextHook() func() *basestore.OldTransactableHandle {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -17388,7 +17388,7 @@ func (f *GitserverLocalCloneStoreHandleFunc) History() []GitserverLocalCloneStor
 type GitserverLocalCloneStoreHandleFuncCall struct {
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 *basestore.TransactableHandle
+	Result0 *basestore.OldTransactableHandle
 }
 
 // Args returns an interface slice containing the arguments of this
@@ -17584,7 +17584,7 @@ func NewMockGitserverRepoStore() *MockGitserverRepoStore {
 			},
 		},
 		HandleFunc: &GitserverRepoStoreHandleFunc{
-			defaultHook: func() (r0 *basestore.TransactableHandle) {
+			defaultHook: func() (r0 *basestore.OldTransactableHandle) {
 				return
 			},
 		},
@@ -17672,7 +17672,7 @@ func NewStrictMockGitserverRepoStore() *MockGitserverRepoStore {
 			},
 		},
 		HandleFunc: &GitserverRepoStoreHandleFunc{
-			defaultHook: func() *basestore.TransactableHandle {
+			defaultHook: func() *basestore.OldTransactableHandle {
 				panic("unexpected invocation of MockGitserverRepoStore.Handle")
 			},
 		},
@@ -18130,15 +18130,15 @@ func (c GitserverRepoStoreGetByNamesFuncCall) Results() []interface{} {
 // GitserverRepoStoreHandleFunc describes the behavior when the Handle
 // method of the parent MockGitserverRepoStore instance is invoked.
 type GitserverRepoStoreHandleFunc struct {
-	defaultHook func() *basestore.TransactableHandle
-	hooks       []func() *basestore.TransactableHandle
+	defaultHook func() *basestore.OldTransactableHandle
+	hooks       []func() *basestore.OldTransactableHandle
 	history     []GitserverRepoStoreHandleFuncCall
 	mutex       sync.Mutex
 }
 
 // Handle delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockGitserverRepoStore) Handle() *basestore.TransactableHandle {
+func (m *MockGitserverRepoStore) Handle() *basestore.OldTransactableHandle {
 	r0 := m.HandleFunc.nextHook()()
 	m.HandleFunc.appendCall(GitserverRepoStoreHandleFuncCall{r0})
 	return r0
@@ -18147,7 +18147,7 @@ func (m *MockGitserverRepoStore) Handle() *basestore.TransactableHandle {
 // SetDefaultHook sets function that is called when the Handle method of the
 // parent MockGitserverRepoStore instance is invoked and the hook queue is
 // empty.
-func (f *GitserverRepoStoreHandleFunc) SetDefaultHook(hook func() *basestore.TransactableHandle) {
+func (f *GitserverRepoStoreHandleFunc) SetDefaultHook(hook func() *basestore.OldTransactableHandle) {
 	f.defaultHook = hook
 }
 
@@ -18155,7 +18155,7 @@ func (f *GitserverRepoStoreHandleFunc) SetDefaultHook(hook func() *basestore.Tra
 // Handle method of the parent MockGitserverRepoStore instance invokes the
 // hook at the front of the queue and discards it. After the queue is empty,
 // the default hook function is invoked for any future action.
-func (f *GitserverRepoStoreHandleFunc) PushHook(hook func() *basestore.TransactableHandle) {
+func (f *GitserverRepoStoreHandleFunc) PushHook(hook func() *basestore.OldTransactableHandle) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -18163,20 +18163,20 @@ func (f *GitserverRepoStoreHandleFunc) PushHook(hook func() *basestore.Transacta
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *GitserverRepoStoreHandleFunc) SetDefaultReturn(r0 *basestore.TransactableHandle) {
-	f.SetDefaultHook(func() *basestore.TransactableHandle {
+func (f *GitserverRepoStoreHandleFunc) SetDefaultReturn(r0 *basestore.OldTransactableHandle) {
+	f.SetDefaultHook(func() *basestore.OldTransactableHandle {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *GitserverRepoStoreHandleFunc) PushReturn(r0 *basestore.TransactableHandle) {
-	f.PushHook(func() *basestore.TransactableHandle {
+func (f *GitserverRepoStoreHandleFunc) PushReturn(r0 *basestore.OldTransactableHandle) {
+	f.PushHook(func() *basestore.OldTransactableHandle {
 		return r0
 	})
 }
 
-func (f *GitserverRepoStoreHandleFunc) nextHook() func() *basestore.TransactableHandle {
+func (f *GitserverRepoStoreHandleFunc) nextHook() func() *basestore.OldTransactableHandle {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -18211,7 +18211,7 @@ func (f *GitserverRepoStoreHandleFunc) History() []GitserverRepoStoreHandleFuncC
 type GitserverRepoStoreHandleFuncCall struct {
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 *basestore.TransactableHandle
+	Result0 *basestore.OldTransactableHandle
 }
 
 // Args returns an interface slice containing the arguments of this
@@ -19989,7 +19989,7 @@ func NewMockNamespaceStore() *MockNamespaceStore {
 			},
 		},
 		HandleFunc: &NamespaceStoreHandleFunc{
-			defaultHook: func() (r0 *basestore.TransactableHandle) {
+			defaultHook: func() (r0 *basestore.OldTransactableHandle) {
 				return
 			},
 		},
@@ -20021,7 +20021,7 @@ func NewStrictMockNamespaceStore() *MockNamespaceStore {
 			},
 		},
 		HandleFunc: &NamespaceStoreHandleFunc{
-			defaultHook: func() *basestore.TransactableHandle {
+			defaultHook: func() *basestore.OldTransactableHandle {
 				panic("unexpected invocation of MockNamespaceStore.Handle")
 			},
 		},
@@ -20283,15 +20283,15 @@ func (c NamespaceStoreGetByNameFuncCall) Results() []interface{} {
 // NamespaceStoreHandleFunc describes the behavior when the Handle method of
 // the parent MockNamespaceStore instance is invoked.
 type NamespaceStoreHandleFunc struct {
-	defaultHook func() *basestore.TransactableHandle
-	hooks       []func() *basestore.TransactableHandle
+	defaultHook func() *basestore.OldTransactableHandle
+	hooks       []func() *basestore.OldTransactableHandle
 	history     []NamespaceStoreHandleFuncCall
 	mutex       sync.Mutex
 }
 
 // Handle delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockNamespaceStore) Handle() *basestore.TransactableHandle {
+func (m *MockNamespaceStore) Handle() *basestore.OldTransactableHandle {
 	r0 := m.HandleFunc.nextHook()()
 	m.HandleFunc.appendCall(NamespaceStoreHandleFuncCall{r0})
 	return r0
@@ -20300,7 +20300,7 @@ func (m *MockNamespaceStore) Handle() *basestore.TransactableHandle {
 // SetDefaultHook sets function that is called when the Handle method of the
 // parent MockNamespaceStore instance is invoked and the hook queue is
 // empty.
-func (f *NamespaceStoreHandleFunc) SetDefaultHook(hook func() *basestore.TransactableHandle) {
+func (f *NamespaceStoreHandleFunc) SetDefaultHook(hook func() *basestore.OldTransactableHandle) {
 	f.defaultHook = hook
 }
 
@@ -20308,7 +20308,7 @@ func (f *NamespaceStoreHandleFunc) SetDefaultHook(hook func() *basestore.Transac
 // Handle method of the parent MockNamespaceStore instance invokes the hook
 // at the front of the queue and discards it. After the queue is empty, the
 // default hook function is invoked for any future action.
-func (f *NamespaceStoreHandleFunc) PushHook(hook func() *basestore.TransactableHandle) {
+func (f *NamespaceStoreHandleFunc) PushHook(hook func() *basestore.OldTransactableHandle) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -20316,20 +20316,20 @@ func (f *NamespaceStoreHandleFunc) PushHook(hook func() *basestore.TransactableH
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *NamespaceStoreHandleFunc) SetDefaultReturn(r0 *basestore.TransactableHandle) {
-	f.SetDefaultHook(func() *basestore.TransactableHandle {
+func (f *NamespaceStoreHandleFunc) SetDefaultReturn(r0 *basestore.OldTransactableHandle) {
+	f.SetDefaultHook(func() *basestore.OldTransactableHandle {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *NamespaceStoreHandleFunc) PushReturn(r0 *basestore.TransactableHandle) {
-	f.PushHook(func() *basestore.TransactableHandle {
+func (f *NamespaceStoreHandleFunc) PushReturn(r0 *basestore.OldTransactableHandle) {
+	f.PushHook(func() *basestore.OldTransactableHandle {
 		return r0
 	})
 }
 
-func (f *NamespaceStoreHandleFunc) nextHook() func() *basestore.TransactableHandle {
+func (f *NamespaceStoreHandleFunc) nextHook() func() *basestore.OldTransactableHandle {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -20364,7 +20364,7 @@ func (f *NamespaceStoreHandleFunc) History() []NamespaceStoreHandleFuncCall {
 type NamespaceStoreHandleFuncCall struct {
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 *basestore.TransactableHandle
+	Result0 *basestore.OldTransactableHandle
 }
 
 // Args returns an interface slice containing the arguments of this
@@ -20671,7 +20671,7 @@ func NewMockOrgInvitationStore() *MockOrgInvitationStore {
 			},
 		},
 		HandleFunc: &OrgInvitationStoreHandleFunc{
-			defaultHook: func() (r0 *basestore.TransactableHandle) {
+			defaultHook: func() (r0 *basestore.OldTransactableHandle) {
 				return
 			},
 		},
@@ -20749,7 +20749,7 @@ func NewStrictMockOrgInvitationStore() *MockOrgInvitationStore {
 			},
 		},
 		HandleFunc: &OrgInvitationStoreHandleFunc{
-			defaultHook: func() *basestore.TransactableHandle {
+			defaultHook: func() *basestore.OldTransactableHandle {
 				panic("unexpected invocation of MockOrgInvitationStore.Handle")
 			},
 		},
@@ -21514,15 +21514,15 @@ func (c OrgInvitationStoreGetPendingByOrgIDFuncCall) Results() []interface{} {
 // OrgInvitationStoreHandleFunc describes the behavior when the Handle
 // method of the parent MockOrgInvitationStore instance is invoked.
 type OrgInvitationStoreHandleFunc struct {
-	defaultHook func() *basestore.TransactableHandle
-	hooks       []func() *basestore.TransactableHandle
+	defaultHook func() *basestore.OldTransactableHandle
+	hooks       []func() *basestore.OldTransactableHandle
 	history     []OrgInvitationStoreHandleFuncCall
 	mutex       sync.Mutex
 }
 
 // Handle delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockOrgInvitationStore) Handle() *basestore.TransactableHandle {
+func (m *MockOrgInvitationStore) Handle() *basestore.OldTransactableHandle {
 	r0 := m.HandleFunc.nextHook()()
 	m.HandleFunc.appendCall(OrgInvitationStoreHandleFuncCall{r0})
 	return r0
@@ -21531,7 +21531,7 @@ func (m *MockOrgInvitationStore) Handle() *basestore.TransactableHandle {
 // SetDefaultHook sets function that is called when the Handle method of the
 // parent MockOrgInvitationStore instance is invoked and the hook queue is
 // empty.
-func (f *OrgInvitationStoreHandleFunc) SetDefaultHook(hook func() *basestore.TransactableHandle) {
+func (f *OrgInvitationStoreHandleFunc) SetDefaultHook(hook func() *basestore.OldTransactableHandle) {
 	f.defaultHook = hook
 }
 
@@ -21539,7 +21539,7 @@ func (f *OrgInvitationStoreHandleFunc) SetDefaultHook(hook func() *basestore.Tra
 // Handle method of the parent MockOrgInvitationStore instance invokes the
 // hook at the front of the queue and discards it. After the queue is empty,
 // the default hook function is invoked for any future action.
-func (f *OrgInvitationStoreHandleFunc) PushHook(hook func() *basestore.TransactableHandle) {
+func (f *OrgInvitationStoreHandleFunc) PushHook(hook func() *basestore.OldTransactableHandle) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -21547,20 +21547,20 @@ func (f *OrgInvitationStoreHandleFunc) PushHook(hook func() *basestore.Transacta
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *OrgInvitationStoreHandleFunc) SetDefaultReturn(r0 *basestore.TransactableHandle) {
-	f.SetDefaultHook(func() *basestore.TransactableHandle {
+func (f *OrgInvitationStoreHandleFunc) SetDefaultReturn(r0 *basestore.OldTransactableHandle) {
+	f.SetDefaultHook(func() *basestore.OldTransactableHandle {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *OrgInvitationStoreHandleFunc) PushReturn(r0 *basestore.TransactableHandle) {
-	f.PushHook(func() *basestore.TransactableHandle {
+func (f *OrgInvitationStoreHandleFunc) PushReturn(r0 *basestore.OldTransactableHandle) {
+	f.PushHook(func() *basestore.OldTransactableHandle {
 		return r0
 	})
 }
 
-func (f *OrgInvitationStoreHandleFunc) nextHook() func() *basestore.TransactableHandle {
+func (f *OrgInvitationStoreHandleFunc) nextHook() func() *basestore.OldTransactableHandle {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -21595,7 +21595,7 @@ func (f *OrgInvitationStoreHandleFunc) History() []OrgInvitationStoreHandleFuncC
 type OrgInvitationStoreHandleFuncCall struct {
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 *basestore.TransactableHandle
+	Result0 *basestore.OldTransactableHandle
 }
 
 // Args returns an interface slice containing the arguments of this
@@ -22441,7 +22441,7 @@ func NewMockOrgMemberStore() *MockOrgMemberStore {
 			},
 		},
 		HandleFunc: &OrgMemberStoreHandleFunc{
-			defaultHook: func() (r0 *basestore.TransactableHandle) {
+			defaultHook: func() (r0 *basestore.OldTransactableHandle) {
 				return
 			},
 		},
@@ -22503,7 +22503,7 @@ func NewStrictMockOrgMemberStore() *MockOrgMemberStore {
 			},
 		},
 		HandleFunc: &OrgMemberStoreHandleFunc{
-			defaultHook: func() *basestore.TransactableHandle {
+			defaultHook: func() *basestore.OldTransactableHandle {
 				panic("unexpected invocation of MockOrgMemberStore.Handle")
 			},
 		},
@@ -23239,15 +23239,15 @@ func (c OrgMemberStoreGetByUserIDFuncCall) Results() []interface{} {
 // OrgMemberStoreHandleFunc describes the behavior when the Handle method of
 // the parent MockOrgMemberStore instance is invoked.
 type OrgMemberStoreHandleFunc struct {
-	defaultHook func() *basestore.TransactableHandle
-	hooks       []func() *basestore.TransactableHandle
+	defaultHook func() *basestore.OldTransactableHandle
+	hooks       []func() *basestore.OldTransactableHandle
 	history     []OrgMemberStoreHandleFuncCall
 	mutex       sync.Mutex
 }
 
 // Handle delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockOrgMemberStore) Handle() *basestore.TransactableHandle {
+func (m *MockOrgMemberStore) Handle() *basestore.OldTransactableHandle {
 	r0 := m.HandleFunc.nextHook()()
 	m.HandleFunc.appendCall(OrgMemberStoreHandleFuncCall{r0})
 	return r0
@@ -23256,7 +23256,7 @@ func (m *MockOrgMemberStore) Handle() *basestore.TransactableHandle {
 // SetDefaultHook sets function that is called when the Handle method of the
 // parent MockOrgMemberStore instance is invoked and the hook queue is
 // empty.
-func (f *OrgMemberStoreHandleFunc) SetDefaultHook(hook func() *basestore.TransactableHandle) {
+func (f *OrgMemberStoreHandleFunc) SetDefaultHook(hook func() *basestore.OldTransactableHandle) {
 	f.defaultHook = hook
 }
 
@@ -23264,7 +23264,7 @@ func (f *OrgMemberStoreHandleFunc) SetDefaultHook(hook func() *basestore.Transac
 // Handle method of the parent MockOrgMemberStore instance invokes the hook
 // at the front of the queue and discards it. After the queue is empty, the
 // default hook function is invoked for any future action.
-func (f *OrgMemberStoreHandleFunc) PushHook(hook func() *basestore.TransactableHandle) {
+func (f *OrgMemberStoreHandleFunc) PushHook(hook func() *basestore.OldTransactableHandle) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -23272,20 +23272,20 @@ func (f *OrgMemberStoreHandleFunc) PushHook(hook func() *basestore.TransactableH
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *OrgMemberStoreHandleFunc) SetDefaultReturn(r0 *basestore.TransactableHandle) {
-	f.SetDefaultHook(func() *basestore.TransactableHandle {
+func (f *OrgMemberStoreHandleFunc) SetDefaultReturn(r0 *basestore.OldTransactableHandle) {
+	f.SetDefaultHook(func() *basestore.OldTransactableHandle {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *OrgMemberStoreHandleFunc) PushReturn(r0 *basestore.TransactableHandle) {
-	f.PushHook(func() *basestore.TransactableHandle {
+func (f *OrgMemberStoreHandleFunc) PushReturn(r0 *basestore.OldTransactableHandle) {
+	f.PushHook(func() *basestore.OldTransactableHandle {
 		return r0
 	})
 }
 
-func (f *OrgMemberStoreHandleFunc) nextHook() func() *basestore.TransactableHandle {
+func (f *OrgMemberStoreHandleFunc) nextHook() func() *basestore.OldTransactableHandle {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -23320,7 +23320,7 @@ func (f *OrgMemberStoreHandleFunc) History() []OrgMemberStoreHandleFuncCall {
 type OrgMemberStoreHandleFuncCall struct {
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 *basestore.TransactableHandle
+	Result0 *basestore.OldTransactableHandle
 }
 
 // Args returns an interface slice containing the arguments of this
@@ -23863,7 +23863,7 @@ func NewMockOrgStore() *MockOrgStore {
 			},
 		},
 		HandleFunc: &OrgStoreHandleFunc{
-			defaultHook: func() (r0 *basestore.TransactableHandle) {
+			defaultHook: func() (r0 *basestore.OldTransactableHandle) {
 				return
 			},
 		},
@@ -23950,7 +23950,7 @@ func NewStrictMockOrgStore() *MockOrgStore {
 			},
 		},
 		HandleFunc: &OrgStoreHandleFunc{
-			defaultHook: func() *basestore.TransactableHandle {
+			defaultHook: func() *basestore.OldTransactableHandle {
 				panic("unexpected invocation of MockOrgStore.Handle")
 			},
 		},
@@ -25013,15 +25013,15 @@ func (c OrgStoreGetOrgsWithRepositoriesByUserIDFuncCall) Results() []interface{}
 // OrgStoreHandleFunc describes the behavior when the Handle method of the
 // parent MockOrgStore instance is invoked.
 type OrgStoreHandleFunc struct {
-	defaultHook func() *basestore.TransactableHandle
-	hooks       []func() *basestore.TransactableHandle
+	defaultHook func() *basestore.OldTransactableHandle
+	hooks       []func() *basestore.OldTransactableHandle
 	history     []OrgStoreHandleFuncCall
 	mutex       sync.Mutex
 }
 
 // Handle delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockOrgStore) Handle() *basestore.TransactableHandle {
+func (m *MockOrgStore) Handle() *basestore.OldTransactableHandle {
 	r0 := m.HandleFunc.nextHook()()
 	m.HandleFunc.appendCall(OrgStoreHandleFuncCall{r0})
 	return r0
@@ -25029,7 +25029,7 @@ func (m *MockOrgStore) Handle() *basestore.TransactableHandle {
 
 // SetDefaultHook sets function that is called when the Handle method of the
 // parent MockOrgStore instance is invoked and the hook queue is empty.
-func (f *OrgStoreHandleFunc) SetDefaultHook(hook func() *basestore.TransactableHandle) {
+func (f *OrgStoreHandleFunc) SetDefaultHook(hook func() *basestore.OldTransactableHandle) {
 	f.defaultHook = hook
 }
 
@@ -25037,7 +25037,7 @@ func (f *OrgStoreHandleFunc) SetDefaultHook(hook func() *basestore.TransactableH
 // Handle method of the parent MockOrgStore instance invokes the hook at the
 // front of the queue and discards it. After the queue is empty, the default
 // hook function is invoked for any future action.
-func (f *OrgStoreHandleFunc) PushHook(hook func() *basestore.TransactableHandle) {
+func (f *OrgStoreHandleFunc) PushHook(hook func() *basestore.OldTransactableHandle) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -25045,20 +25045,20 @@ func (f *OrgStoreHandleFunc) PushHook(hook func() *basestore.TransactableHandle)
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *OrgStoreHandleFunc) SetDefaultReturn(r0 *basestore.TransactableHandle) {
-	f.SetDefaultHook(func() *basestore.TransactableHandle {
+func (f *OrgStoreHandleFunc) SetDefaultReturn(r0 *basestore.OldTransactableHandle) {
+	f.SetDefaultHook(func() *basestore.OldTransactableHandle {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *OrgStoreHandleFunc) PushReturn(r0 *basestore.TransactableHandle) {
-	f.PushHook(func() *basestore.TransactableHandle {
+func (f *OrgStoreHandleFunc) PushReturn(r0 *basestore.OldTransactableHandle) {
+	f.PushHook(func() *basestore.OldTransactableHandle {
 		return r0
 	})
 }
 
-func (f *OrgStoreHandleFunc) nextHook() func() *basestore.TransactableHandle {
+func (f *OrgStoreHandleFunc) nextHook() func() *basestore.OldTransactableHandle {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -25093,7 +25093,7 @@ func (f *OrgStoreHandleFunc) History() []OrgStoreHandleFuncCall {
 type OrgStoreHandleFuncCall struct {
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 *basestore.TransactableHandle
+	Result0 *basestore.OldTransactableHandle
 }
 
 // Args returns an interface slice containing the arguments of this
@@ -25799,7 +25799,7 @@ func NewMockPhabricatorStore() *MockPhabricatorStore {
 			},
 		},
 		HandleFunc: &PhabricatorStoreHandleFunc{
-			defaultHook: func() (r0 *basestore.TransactableHandle) {
+			defaultHook: func() (r0 *basestore.OldTransactableHandle) {
 				return
 			},
 		},
@@ -25841,7 +25841,7 @@ func NewStrictMockPhabricatorStore() *MockPhabricatorStore {
 			},
 		},
 		HandleFunc: &PhabricatorStoreHandleFunc{
-			defaultHook: func() *basestore.TransactableHandle {
+			defaultHook: func() *basestore.OldTransactableHandle {
 				panic("unexpected invocation of MockPhabricatorStore.Handle")
 			},
 		},
@@ -26345,15 +26345,15 @@ func (c PhabricatorStoreGetByNameFuncCall) Results() []interface{} {
 // PhabricatorStoreHandleFunc describes the behavior when the Handle method
 // of the parent MockPhabricatorStore instance is invoked.
 type PhabricatorStoreHandleFunc struct {
-	defaultHook func() *basestore.TransactableHandle
-	hooks       []func() *basestore.TransactableHandle
+	defaultHook func() *basestore.OldTransactableHandle
+	hooks       []func() *basestore.OldTransactableHandle
 	history     []PhabricatorStoreHandleFuncCall
 	mutex       sync.Mutex
 }
 
 // Handle delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockPhabricatorStore) Handle() *basestore.TransactableHandle {
+func (m *MockPhabricatorStore) Handle() *basestore.OldTransactableHandle {
 	r0 := m.HandleFunc.nextHook()()
 	m.HandleFunc.appendCall(PhabricatorStoreHandleFuncCall{r0})
 	return r0
@@ -26362,7 +26362,7 @@ func (m *MockPhabricatorStore) Handle() *basestore.TransactableHandle {
 // SetDefaultHook sets function that is called when the Handle method of the
 // parent MockPhabricatorStore instance is invoked and the hook queue is
 // empty.
-func (f *PhabricatorStoreHandleFunc) SetDefaultHook(hook func() *basestore.TransactableHandle) {
+func (f *PhabricatorStoreHandleFunc) SetDefaultHook(hook func() *basestore.OldTransactableHandle) {
 	f.defaultHook = hook
 }
 
@@ -26370,7 +26370,7 @@ func (f *PhabricatorStoreHandleFunc) SetDefaultHook(hook func() *basestore.Trans
 // Handle method of the parent MockPhabricatorStore instance invokes the
 // hook at the front of the queue and discards it. After the queue is empty,
 // the default hook function is invoked for any future action.
-func (f *PhabricatorStoreHandleFunc) PushHook(hook func() *basestore.TransactableHandle) {
+func (f *PhabricatorStoreHandleFunc) PushHook(hook func() *basestore.OldTransactableHandle) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -26378,20 +26378,20 @@ func (f *PhabricatorStoreHandleFunc) PushHook(hook func() *basestore.Transactabl
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *PhabricatorStoreHandleFunc) SetDefaultReturn(r0 *basestore.TransactableHandle) {
-	f.SetDefaultHook(func() *basestore.TransactableHandle {
+func (f *PhabricatorStoreHandleFunc) SetDefaultReturn(r0 *basestore.OldTransactableHandle) {
+	f.SetDefaultHook(func() *basestore.OldTransactableHandle {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *PhabricatorStoreHandleFunc) PushReturn(r0 *basestore.TransactableHandle) {
-	f.PushHook(func() *basestore.TransactableHandle {
+func (f *PhabricatorStoreHandleFunc) PushReturn(r0 *basestore.OldTransactableHandle) {
+	f.PushHook(func() *basestore.OldTransactableHandle {
 		return r0
 	})
 }
 
-func (f *PhabricatorStoreHandleFunc) nextHook() func() *basestore.TransactableHandle {
+func (f *PhabricatorStoreHandleFunc) nextHook() func() *basestore.OldTransactableHandle {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -26426,7 +26426,7 @@ func (f *PhabricatorStoreHandleFunc) History() []PhabricatorStoreHandleFuncCall 
 type PhabricatorStoreHandleFuncCall struct {
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 *basestore.TransactableHandle
+	Result0 *basestore.OldTransactableHandle
 }
 
 // Args returns an interface slice containing the arguments of this
@@ -26767,7 +26767,7 @@ func NewMockRepoStore() *MockRepoStore {
 			},
 		},
 		HandleFunc: &RepoStoreHandleFunc{
-			defaultHook: func() (r0 *basestore.TransactableHandle) {
+			defaultHook: func() (r0 *basestore.OldTransactableHandle) {
 				return
 			},
 		},
@@ -26869,7 +26869,7 @@ func NewStrictMockRepoStore() *MockRepoStore {
 			},
 		},
 		HandleFunc: &RepoStoreHandleFunc{
-			defaultHook: func() *basestore.TransactableHandle {
+			defaultHook: func() *basestore.OldTransactableHandle {
 				panic("unexpected invocation of MockRepoStore.Handle")
 			},
 		},
@@ -28075,15 +28075,15 @@ func (c RepoStoreGetReposSetByIDsFuncCall) Results() []interface{} {
 // RepoStoreHandleFunc describes the behavior when the Handle method of the
 // parent MockRepoStore instance is invoked.
 type RepoStoreHandleFunc struct {
-	defaultHook func() *basestore.TransactableHandle
-	hooks       []func() *basestore.TransactableHandle
+	defaultHook func() *basestore.OldTransactableHandle
+	hooks       []func() *basestore.OldTransactableHandle
 	history     []RepoStoreHandleFuncCall
 	mutex       sync.Mutex
 }
 
 // Handle delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockRepoStore) Handle() *basestore.TransactableHandle {
+func (m *MockRepoStore) Handle() *basestore.OldTransactableHandle {
 	r0 := m.HandleFunc.nextHook()()
 	m.HandleFunc.appendCall(RepoStoreHandleFuncCall{r0})
 	return r0
@@ -28091,7 +28091,7 @@ func (m *MockRepoStore) Handle() *basestore.TransactableHandle {
 
 // SetDefaultHook sets function that is called when the Handle method of the
 // parent MockRepoStore instance is invoked and the hook queue is empty.
-func (f *RepoStoreHandleFunc) SetDefaultHook(hook func() *basestore.TransactableHandle) {
+func (f *RepoStoreHandleFunc) SetDefaultHook(hook func() *basestore.OldTransactableHandle) {
 	f.defaultHook = hook
 }
 
@@ -28099,7 +28099,7 @@ func (f *RepoStoreHandleFunc) SetDefaultHook(hook func() *basestore.Transactable
 // Handle method of the parent MockRepoStore instance invokes the hook at
 // the front of the queue and discards it. After the queue is empty, the
 // default hook function is invoked for any future action.
-func (f *RepoStoreHandleFunc) PushHook(hook func() *basestore.TransactableHandle) {
+func (f *RepoStoreHandleFunc) PushHook(hook func() *basestore.OldTransactableHandle) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -28107,20 +28107,20 @@ func (f *RepoStoreHandleFunc) PushHook(hook func() *basestore.TransactableHandle
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *RepoStoreHandleFunc) SetDefaultReturn(r0 *basestore.TransactableHandle) {
-	f.SetDefaultHook(func() *basestore.TransactableHandle {
+func (f *RepoStoreHandleFunc) SetDefaultReturn(r0 *basestore.OldTransactableHandle) {
+	f.SetDefaultHook(func() *basestore.OldTransactableHandle {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *RepoStoreHandleFunc) PushReturn(r0 *basestore.TransactableHandle) {
-	f.PushHook(func() *basestore.TransactableHandle {
+func (f *RepoStoreHandleFunc) PushReturn(r0 *basestore.OldTransactableHandle) {
+	f.PushHook(func() *basestore.OldTransactableHandle {
 		return r0
 	})
 }
 
-func (f *RepoStoreHandleFunc) nextHook() func() *basestore.TransactableHandle {
+func (f *RepoStoreHandleFunc) nextHook() func() *basestore.OldTransactableHandle {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -28155,7 +28155,7 @@ func (f *RepoStoreHandleFunc) History() []RepoStoreHandleFuncCall {
 type RepoStoreHandleFuncCall struct {
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 *basestore.TransactableHandle
+	Result0 *basestore.OldTransactableHandle
 }
 
 // Args returns an interface slice containing the arguments of this
@@ -29091,7 +29091,7 @@ func NewMockSavedSearchStore() *MockSavedSearchStore {
 			},
 		},
 		HandleFunc: &SavedSearchStoreHandleFunc{
-			defaultHook: func() (r0 *basestore.TransactableHandle) {
+			defaultHook: func() (r0 *basestore.OldTransactableHandle) {
 				return
 			},
 		},
@@ -29153,7 +29153,7 @@ func NewStrictMockSavedSearchStore() *MockSavedSearchStore {
 			},
 		},
 		HandleFunc: &SavedSearchStoreHandleFunc{
-			defaultHook: func() *basestore.TransactableHandle {
+			defaultHook: func() *basestore.OldTransactableHandle {
 				panic("unexpected invocation of MockSavedSearchStore.Handle")
 			},
 		},
@@ -29560,15 +29560,15 @@ func (c SavedSearchStoreGetByIDFuncCall) Results() []interface{} {
 // SavedSearchStoreHandleFunc describes the behavior when the Handle method
 // of the parent MockSavedSearchStore instance is invoked.
 type SavedSearchStoreHandleFunc struct {
-	defaultHook func() *basestore.TransactableHandle
-	hooks       []func() *basestore.TransactableHandle
+	defaultHook func() *basestore.OldTransactableHandle
+	hooks       []func() *basestore.OldTransactableHandle
 	history     []SavedSearchStoreHandleFuncCall
 	mutex       sync.Mutex
 }
 
 // Handle delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockSavedSearchStore) Handle() *basestore.TransactableHandle {
+func (m *MockSavedSearchStore) Handle() *basestore.OldTransactableHandle {
 	r0 := m.HandleFunc.nextHook()()
 	m.HandleFunc.appendCall(SavedSearchStoreHandleFuncCall{r0})
 	return r0
@@ -29577,7 +29577,7 @@ func (m *MockSavedSearchStore) Handle() *basestore.TransactableHandle {
 // SetDefaultHook sets function that is called when the Handle method of the
 // parent MockSavedSearchStore instance is invoked and the hook queue is
 // empty.
-func (f *SavedSearchStoreHandleFunc) SetDefaultHook(hook func() *basestore.TransactableHandle) {
+func (f *SavedSearchStoreHandleFunc) SetDefaultHook(hook func() *basestore.OldTransactableHandle) {
 	f.defaultHook = hook
 }
 
@@ -29585,7 +29585,7 @@ func (f *SavedSearchStoreHandleFunc) SetDefaultHook(hook func() *basestore.Trans
 // Handle method of the parent MockSavedSearchStore instance invokes the
 // hook at the front of the queue and discards it. After the queue is empty,
 // the default hook function is invoked for any future action.
-func (f *SavedSearchStoreHandleFunc) PushHook(hook func() *basestore.TransactableHandle) {
+func (f *SavedSearchStoreHandleFunc) PushHook(hook func() *basestore.OldTransactableHandle) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -29593,20 +29593,20 @@ func (f *SavedSearchStoreHandleFunc) PushHook(hook func() *basestore.Transactabl
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *SavedSearchStoreHandleFunc) SetDefaultReturn(r0 *basestore.TransactableHandle) {
-	f.SetDefaultHook(func() *basestore.TransactableHandle {
+func (f *SavedSearchStoreHandleFunc) SetDefaultReturn(r0 *basestore.OldTransactableHandle) {
+	f.SetDefaultHook(func() *basestore.OldTransactableHandle {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *SavedSearchStoreHandleFunc) PushReturn(r0 *basestore.TransactableHandle) {
-	f.PushHook(func() *basestore.TransactableHandle {
+func (f *SavedSearchStoreHandleFunc) PushReturn(r0 *basestore.OldTransactableHandle) {
+	f.PushHook(func() *basestore.OldTransactableHandle {
 		return r0
 	})
 }
 
-func (f *SavedSearchStoreHandleFunc) nextHook() func() *basestore.TransactableHandle {
+func (f *SavedSearchStoreHandleFunc) nextHook() func() *basestore.OldTransactableHandle {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -29641,7 +29641,7 @@ func (f *SavedSearchStoreHandleFunc) History() []SavedSearchStoreHandleFuncCall 
 type SavedSearchStoreHandleFuncCall struct {
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 *basestore.TransactableHandle
+	Result0 *basestore.OldTransactableHandle
 }
 
 // Args returns an interface slice containing the arguments of this
@@ -30509,7 +30509,7 @@ func NewMockSearchContextsStore() *MockSearchContextsStore {
 			},
 		},
 		HandleFunc: &SearchContextsStoreHandleFunc{
-			defaultHook: func() (r0 *basestore.TransactableHandle) {
+			defaultHook: func() (r0 *basestore.OldTransactableHandle) {
 				return
 			},
 		},
@@ -30587,7 +30587,7 @@ func NewStrictMockSearchContextsStore() *MockSearchContextsStore {
 			},
 		},
 		HandleFunc: &SearchContextsStoreHandleFunc{
-			defaultHook: func() *basestore.TransactableHandle {
+			defaultHook: func() *basestore.OldTransactableHandle {
 				panic("unexpected invocation of MockSearchContextsStore.Handle")
 			},
 		},
@@ -31658,15 +31658,15 @@ func (c SearchContextsStoreGetSearchContextRepositoryRevisionsFuncCall) Results(
 // SearchContextsStoreHandleFunc describes the behavior when the Handle
 // method of the parent MockSearchContextsStore instance is invoked.
 type SearchContextsStoreHandleFunc struct {
-	defaultHook func() *basestore.TransactableHandle
-	hooks       []func() *basestore.TransactableHandle
+	defaultHook func() *basestore.OldTransactableHandle
+	hooks       []func() *basestore.OldTransactableHandle
 	history     []SearchContextsStoreHandleFuncCall
 	mutex       sync.Mutex
 }
 
 // Handle delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockSearchContextsStore) Handle() *basestore.TransactableHandle {
+func (m *MockSearchContextsStore) Handle() *basestore.OldTransactableHandle {
 	r0 := m.HandleFunc.nextHook()()
 	m.HandleFunc.appendCall(SearchContextsStoreHandleFuncCall{r0})
 	return r0
@@ -31675,7 +31675,7 @@ func (m *MockSearchContextsStore) Handle() *basestore.TransactableHandle {
 // SetDefaultHook sets function that is called when the Handle method of the
 // parent MockSearchContextsStore instance is invoked and the hook queue is
 // empty.
-func (f *SearchContextsStoreHandleFunc) SetDefaultHook(hook func() *basestore.TransactableHandle) {
+func (f *SearchContextsStoreHandleFunc) SetDefaultHook(hook func() *basestore.OldTransactableHandle) {
 	f.defaultHook = hook
 }
 
@@ -31683,7 +31683,7 @@ func (f *SearchContextsStoreHandleFunc) SetDefaultHook(hook func() *basestore.Tr
 // Handle method of the parent MockSearchContextsStore instance invokes the
 // hook at the front of the queue and discards it. After the queue is empty,
 // the default hook function is invoked for any future action.
-func (f *SearchContextsStoreHandleFunc) PushHook(hook func() *basestore.TransactableHandle) {
+func (f *SearchContextsStoreHandleFunc) PushHook(hook func() *basestore.OldTransactableHandle) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -31691,20 +31691,20 @@ func (f *SearchContextsStoreHandleFunc) PushHook(hook func() *basestore.Transact
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *SearchContextsStoreHandleFunc) SetDefaultReturn(r0 *basestore.TransactableHandle) {
-	f.SetDefaultHook(func() *basestore.TransactableHandle {
+func (f *SearchContextsStoreHandleFunc) SetDefaultReturn(r0 *basestore.OldTransactableHandle) {
+	f.SetDefaultHook(func() *basestore.OldTransactableHandle {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *SearchContextsStoreHandleFunc) PushReturn(r0 *basestore.TransactableHandle) {
-	f.PushHook(func() *basestore.TransactableHandle {
+func (f *SearchContextsStoreHandleFunc) PushReturn(r0 *basestore.OldTransactableHandle) {
+	f.PushHook(func() *basestore.OldTransactableHandle {
 		return r0
 	})
 }
 
-func (f *SearchContextsStoreHandleFunc) nextHook() func() *basestore.TransactableHandle {
+func (f *SearchContextsStoreHandleFunc) nextHook() func() *basestore.OldTransactableHandle {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -31739,7 +31739,7 @@ func (f *SearchContextsStoreHandleFunc) History() []SearchContextsStoreHandleFun
 type SearchContextsStoreHandleFuncCall struct {
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 *basestore.TransactableHandle
+	Result0 *basestore.OldTransactableHandle
 }
 
 // Args returns an interface slice containing the arguments of this
@@ -32228,7 +32228,7 @@ type MockSecurityEventLogsStore struct {
 func NewMockSecurityEventLogsStore() *MockSecurityEventLogsStore {
 	return &MockSecurityEventLogsStore{
 		HandleFunc: &SecurityEventLogsStoreHandleFunc{
-			defaultHook: func() (r0 *basestore.TransactableHandle) {
+			defaultHook: func() (r0 *basestore.OldTransactableHandle) {
 				return
 			},
 		},
@@ -32251,7 +32251,7 @@ func NewMockSecurityEventLogsStore() *MockSecurityEventLogsStore {
 func NewStrictMockSecurityEventLogsStore() *MockSecurityEventLogsStore {
 	return &MockSecurityEventLogsStore{
 		HandleFunc: &SecurityEventLogsStoreHandleFunc{
-			defaultHook: func() *basestore.TransactableHandle {
+			defaultHook: func() *basestore.OldTransactableHandle {
 				panic("unexpected invocation of MockSecurityEventLogsStore.Handle")
 			},
 		},
@@ -32288,15 +32288,15 @@ func NewMockSecurityEventLogsStoreFrom(i SecurityEventLogsStore) *MockSecurityEv
 // SecurityEventLogsStoreHandleFunc describes the behavior when the Handle
 // method of the parent MockSecurityEventLogsStore instance is invoked.
 type SecurityEventLogsStoreHandleFunc struct {
-	defaultHook func() *basestore.TransactableHandle
-	hooks       []func() *basestore.TransactableHandle
+	defaultHook func() *basestore.OldTransactableHandle
+	hooks       []func() *basestore.OldTransactableHandle
 	history     []SecurityEventLogsStoreHandleFuncCall
 	mutex       sync.Mutex
 }
 
 // Handle delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockSecurityEventLogsStore) Handle() *basestore.TransactableHandle {
+func (m *MockSecurityEventLogsStore) Handle() *basestore.OldTransactableHandle {
 	r0 := m.HandleFunc.nextHook()()
 	m.HandleFunc.appendCall(SecurityEventLogsStoreHandleFuncCall{r0})
 	return r0
@@ -32305,7 +32305,7 @@ func (m *MockSecurityEventLogsStore) Handle() *basestore.TransactableHandle {
 // SetDefaultHook sets function that is called when the Handle method of the
 // parent MockSecurityEventLogsStore instance is invoked and the hook queue
 // is empty.
-func (f *SecurityEventLogsStoreHandleFunc) SetDefaultHook(hook func() *basestore.TransactableHandle) {
+func (f *SecurityEventLogsStoreHandleFunc) SetDefaultHook(hook func() *basestore.OldTransactableHandle) {
 	f.defaultHook = hook
 }
 
@@ -32313,7 +32313,7 @@ func (f *SecurityEventLogsStoreHandleFunc) SetDefaultHook(hook func() *basestore
 // Handle method of the parent MockSecurityEventLogsStore instance invokes
 // the hook at the front of the queue and discards it. After the queue is
 // empty, the default hook function is invoked for any future action.
-func (f *SecurityEventLogsStoreHandleFunc) PushHook(hook func() *basestore.TransactableHandle) {
+func (f *SecurityEventLogsStoreHandleFunc) PushHook(hook func() *basestore.OldTransactableHandle) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -32321,20 +32321,20 @@ func (f *SecurityEventLogsStoreHandleFunc) PushHook(hook func() *basestore.Trans
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *SecurityEventLogsStoreHandleFunc) SetDefaultReturn(r0 *basestore.TransactableHandle) {
-	f.SetDefaultHook(func() *basestore.TransactableHandle {
+func (f *SecurityEventLogsStoreHandleFunc) SetDefaultReturn(r0 *basestore.OldTransactableHandle) {
+	f.SetDefaultHook(func() *basestore.OldTransactableHandle {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *SecurityEventLogsStoreHandleFunc) PushReturn(r0 *basestore.TransactableHandle) {
-	f.PushHook(func() *basestore.TransactableHandle {
+func (f *SecurityEventLogsStoreHandleFunc) PushReturn(r0 *basestore.OldTransactableHandle) {
+	f.PushHook(func() *basestore.OldTransactableHandle {
 		return r0
 	})
 }
 
-func (f *SecurityEventLogsStoreHandleFunc) nextHook() func() *basestore.TransactableHandle {
+func (f *SecurityEventLogsStoreHandleFunc) nextHook() func() *basestore.OldTransactableHandle {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -32369,7 +32369,7 @@ func (f *SecurityEventLogsStoreHandleFunc) History() []SecurityEventLogsStoreHan
 type SecurityEventLogsStoreHandleFuncCall struct {
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 *basestore.TransactableHandle
+	Result0 *basestore.OldTransactableHandle
 }
 
 // Args returns an interface slice containing the arguments of this
@@ -32648,7 +32648,7 @@ func NewMockSettingsStore() *MockSettingsStore {
 			},
 		},
 		HandleFunc: &SettingsStoreHandleFunc{
-			defaultHook: func() (r0 *basestore.TransactableHandle) {
+			defaultHook: func() (r0 *basestore.OldTransactableHandle) {
 				return
 			},
 		},
@@ -32695,7 +32695,7 @@ func NewStrictMockSettingsStore() *MockSettingsStore {
 			},
 		},
 		HandleFunc: &SettingsStoreHandleFunc{
-			defaultHook: func() *basestore.TransactableHandle {
+			defaultHook: func() *basestore.OldTransactableHandle {
 				panic("unexpected invocation of MockSettingsStore.Handle")
 			},
 		},
@@ -33192,15 +33192,15 @@ func (c SettingsStoreGetLatestFuncCall) Results() []interface{} {
 // SettingsStoreHandleFunc describes the behavior when the Handle method of
 // the parent MockSettingsStore instance is invoked.
 type SettingsStoreHandleFunc struct {
-	defaultHook func() *basestore.TransactableHandle
-	hooks       []func() *basestore.TransactableHandle
+	defaultHook func() *basestore.OldTransactableHandle
+	hooks       []func() *basestore.OldTransactableHandle
 	history     []SettingsStoreHandleFuncCall
 	mutex       sync.Mutex
 }
 
 // Handle delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockSettingsStore) Handle() *basestore.TransactableHandle {
+func (m *MockSettingsStore) Handle() *basestore.OldTransactableHandle {
 	r0 := m.HandleFunc.nextHook()()
 	m.HandleFunc.appendCall(SettingsStoreHandleFuncCall{r0})
 	return r0
@@ -33208,7 +33208,7 @@ func (m *MockSettingsStore) Handle() *basestore.TransactableHandle {
 
 // SetDefaultHook sets function that is called when the Handle method of the
 // parent MockSettingsStore instance is invoked and the hook queue is empty.
-func (f *SettingsStoreHandleFunc) SetDefaultHook(hook func() *basestore.TransactableHandle) {
+func (f *SettingsStoreHandleFunc) SetDefaultHook(hook func() *basestore.OldTransactableHandle) {
 	f.defaultHook = hook
 }
 
@@ -33216,7 +33216,7 @@ func (f *SettingsStoreHandleFunc) SetDefaultHook(hook func() *basestore.Transact
 // Handle method of the parent MockSettingsStore instance invokes the hook
 // at the front of the queue and discards it. After the queue is empty, the
 // default hook function is invoked for any future action.
-func (f *SettingsStoreHandleFunc) PushHook(hook func() *basestore.TransactableHandle) {
+func (f *SettingsStoreHandleFunc) PushHook(hook func() *basestore.OldTransactableHandle) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -33224,20 +33224,20 @@ func (f *SettingsStoreHandleFunc) PushHook(hook func() *basestore.TransactableHa
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *SettingsStoreHandleFunc) SetDefaultReturn(r0 *basestore.TransactableHandle) {
-	f.SetDefaultHook(func() *basestore.TransactableHandle {
+func (f *SettingsStoreHandleFunc) SetDefaultReturn(r0 *basestore.OldTransactableHandle) {
+	f.SetDefaultHook(func() *basestore.OldTransactableHandle {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *SettingsStoreHandleFunc) PushReturn(r0 *basestore.TransactableHandle) {
-	f.PushHook(func() *basestore.TransactableHandle {
+func (f *SettingsStoreHandleFunc) PushReturn(r0 *basestore.OldTransactableHandle) {
+	f.PushHook(func() *basestore.OldTransactableHandle {
 		return r0
 	})
 }
 
-func (f *SettingsStoreHandleFunc) nextHook() func() *basestore.TransactableHandle {
+func (f *SettingsStoreHandleFunc) nextHook() func() *basestore.OldTransactableHandle {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -33272,7 +33272,7 @@ func (f *SettingsStoreHandleFunc) History() []SettingsStoreHandleFuncCall {
 type SettingsStoreHandleFuncCall struct {
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 *basestore.TransactableHandle
+	Result0 *basestore.OldTransactableHandle
 }
 
 // Args returns an interface slice containing the arguments of this
@@ -34786,7 +34786,7 @@ func NewMockTemporarySettingsStore() *MockTemporarySettingsStore {
 			},
 		},
 		HandleFunc: &TemporarySettingsStoreHandleFunc{
-			defaultHook: func() (r0 *basestore.TransactableHandle) {
+			defaultHook: func() (r0 *basestore.OldTransactableHandle) {
 				return
 			},
 		},
@@ -34814,7 +34814,7 @@ func NewStrictMockTemporarySettingsStore() *MockTemporarySettingsStore {
 			},
 		},
 		HandleFunc: &TemporarySettingsStoreHandleFunc{
-			defaultHook: func() *basestore.TransactableHandle {
+			defaultHook: func() *basestore.OldTransactableHandle {
 				panic("unexpected invocation of MockTemporarySettingsStore.Handle")
 			},
 		},
@@ -35073,15 +35073,15 @@ func (c TemporarySettingsStoreGetTemporarySettingsFuncCall) Results() []interfac
 // TemporarySettingsStoreHandleFunc describes the behavior when the Handle
 // method of the parent MockTemporarySettingsStore instance is invoked.
 type TemporarySettingsStoreHandleFunc struct {
-	defaultHook func() *basestore.TransactableHandle
-	hooks       []func() *basestore.TransactableHandle
+	defaultHook func() *basestore.OldTransactableHandle
+	hooks       []func() *basestore.OldTransactableHandle
 	history     []TemporarySettingsStoreHandleFuncCall
 	mutex       sync.Mutex
 }
 
 // Handle delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockTemporarySettingsStore) Handle() *basestore.TransactableHandle {
+func (m *MockTemporarySettingsStore) Handle() *basestore.OldTransactableHandle {
 	r0 := m.HandleFunc.nextHook()()
 	m.HandleFunc.appendCall(TemporarySettingsStoreHandleFuncCall{r0})
 	return r0
@@ -35090,7 +35090,7 @@ func (m *MockTemporarySettingsStore) Handle() *basestore.TransactableHandle {
 // SetDefaultHook sets function that is called when the Handle method of the
 // parent MockTemporarySettingsStore instance is invoked and the hook queue
 // is empty.
-func (f *TemporarySettingsStoreHandleFunc) SetDefaultHook(hook func() *basestore.TransactableHandle) {
+func (f *TemporarySettingsStoreHandleFunc) SetDefaultHook(hook func() *basestore.OldTransactableHandle) {
 	f.defaultHook = hook
 }
 
@@ -35098,7 +35098,7 @@ func (f *TemporarySettingsStoreHandleFunc) SetDefaultHook(hook func() *basestore
 // Handle method of the parent MockTemporarySettingsStore instance invokes
 // the hook at the front of the queue and discards it. After the queue is
 // empty, the default hook function is invoked for any future action.
-func (f *TemporarySettingsStoreHandleFunc) PushHook(hook func() *basestore.TransactableHandle) {
+func (f *TemporarySettingsStoreHandleFunc) PushHook(hook func() *basestore.OldTransactableHandle) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -35106,20 +35106,20 @@ func (f *TemporarySettingsStoreHandleFunc) PushHook(hook func() *basestore.Trans
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *TemporarySettingsStoreHandleFunc) SetDefaultReturn(r0 *basestore.TransactableHandle) {
-	f.SetDefaultHook(func() *basestore.TransactableHandle {
+func (f *TemporarySettingsStoreHandleFunc) SetDefaultReturn(r0 *basestore.OldTransactableHandle) {
+	f.SetDefaultHook(func() *basestore.OldTransactableHandle {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *TemporarySettingsStoreHandleFunc) PushReturn(r0 *basestore.TransactableHandle) {
-	f.PushHook(func() *basestore.TransactableHandle {
+func (f *TemporarySettingsStoreHandleFunc) PushReturn(r0 *basestore.OldTransactableHandle) {
+	f.PushHook(func() *basestore.OldTransactableHandle {
 		return r0
 	})
 }
 
-func (f *TemporarySettingsStoreHandleFunc) nextHook() func() *basestore.TransactableHandle {
+func (f *TemporarySettingsStoreHandleFunc) nextHook() func() *basestore.OldTransactableHandle {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -35154,7 +35154,7 @@ func (f *TemporarySettingsStoreHandleFunc) History() []TemporarySettingsStoreHan
 type TemporarySettingsStoreHandleFuncCall struct {
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 *basestore.TransactableHandle
+	Result0 *basestore.OldTransactableHandle
 }
 
 // Args returns an interface slice containing the arguments of this
@@ -35342,7 +35342,7 @@ func NewMockUserCredentialsStore() *MockUserCredentialsStore {
 			},
 		},
 		HandleFunc: &UserCredentialsStoreHandleFunc{
-			defaultHook: func() (r0 *basestore.TransactableHandle) {
+			defaultHook: func() (r0 *basestore.OldTransactableHandle) {
 				return
 			},
 		},
@@ -35395,7 +35395,7 @@ func NewStrictMockUserCredentialsStore() *MockUserCredentialsStore {
 			},
 		},
 		HandleFunc: &UserCredentialsStoreHandleFunc{
-			defaultHook: func() *basestore.TransactableHandle {
+			defaultHook: func() *basestore.OldTransactableHandle {
 				panic("unexpected invocation of MockUserCredentialsStore.Handle")
 			},
 		},
@@ -35894,15 +35894,15 @@ func (c UserCredentialsStoreGetByScopeFuncCall) Results() []interface{} {
 // UserCredentialsStoreHandleFunc describes the behavior when the Handle
 // method of the parent MockUserCredentialsStore instance is invoked.
 type UserCredentialsStoreHandleFunc struct {
-	defaultHook func() *basestore.TransactableHandle
-	hooks       []func() *basestore.TransactableHandle
+	defaultHook func() *basestore.OldTransactableHandle
+	hooks       []func() *basestore.OldTransactableHandle
 	history     []UserCredentialsStoreHandleFuncCall
 	mutex       sync.Mutex
 }
 
 // Handle delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockUserCredentialsStore) Handle() *basestore.TransactableHandle {
+func (m *MockUserCredentialsStore) Handle() *basestore.OldTransactableHandle {
 	r0 := m.HandleFunc.nextHook()()
 	m.HandleFunc.appendCall(UserCredentialsStoreHandleFuncCall{r0})
 	return r0
@@ -35911,7 +35911,7 @@ func (m *MockUserCredentialsStore) Handle() *basestore.TransactableHandle {
 // SetDefaultHook sets function that is called when the Handle method of the
 // parent MockUserCredentialsStore instance is invoked and the hook queue is
 // empty.
-func (f *UserCredentialsStoreHandleFunc) SetDefaultHook(hook func() *basestore.TransactableHandle) {
+func (f *UserCredentialsStoreHandleFunc) SetDefaultHook(hook func() *basestore.OldTransactableHandle) {
 	f.defaultHook = hook
 }
 
@@ -35919,7 +35919,7 @@ func (f *UserCredentialsStoreHandleFunc) SetDefaultHook(hook func() *basestore.T
 // Handle method of the parent MockUserCredentialsStore instance invokes the
 // hook at the front of the queue and discards it. After the queue is empty,
 // the default hook function is invoked for any future action.
-func (f *UserCredentialsStoreHandleFunc) PushHook(hook func() *basestore.TransactableHandle) {
+func (f *UserCredentialsStoreHandleFunc) PushHook(hook func() *basestore.OldTransactableHandle) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -35927,20 +35927,20 @@ func (f *UserCredentialsStoreHandleFunc) PushHook(hook func() *basestore.Transac
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *UserCredentialsStoreHandleFunc) SetDefaultReturn(r0 *basestore.TransactableHandle) {
-	f.SetDefaultHook(func() *basestore.TransactableHandle {
+func (f *UserCredentialsStoreHandleFunc) SetDefaultReturn(r0 *basestore.OldTransactableHandle) {
+	f.SetDefaultHook(func() *basestore.OldTransactableHandle {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *UserCredentialsStoreHandleFunc) PushReturn(r0 *basestore.TransactableHandle) {
-	f.PushHook(func() *basestore.TransactableHandle {
+func (f *UserCredentialsStoreHandleFunc) PushReturn(r0 *basestore.OldTransactableHandle) {
+	f.PushHook(func() *basestore.OldTransactableHandle {
 		return r0
 	})
 }
 
-func (f *UserCredentialsStoreHandleFunc) nextHook() func() *basestore.TransactableHandle {
+func (f *UserCredentialsStoreHandleFunc) nextHook() func() *basestore.OldTransactableHandle {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -35975,7 +35975,7 @@ func (f *UserCredentialsStoreHandleFunc) History() []UserCredentialsStoreHandleF
 type UserCredentialsStoreHandleFuncCall struct {
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 *basestore.TransactableHandle
+	Result0 *basestore.OldTransactableHandle
 }
 
 // Args returns an interface slice containing the arguments of this
@@ -36510,7 +36510,7 @@ func NewMockUserEmailsStore() *MockUserEmailsStore {
 			},
 		},
 		HandleFunc: &UserEmailsStoreHandleFunc{
-			defaultHook: func() (r0 *basestore.TransactableHandle) {
+			defaultHook: func() (r0 *basestore.OldTransactableHandle) {
 				return
 			},
 		},
@@ -36597,7 +36597,7 @@ func NewStrictMockUserEmailsStore() *MockUserEmailsStore {
 			},
 		},
 		HandleFunc: &UserEmailsStoreHandleFunc{
-			defaultHook: func() *basestore.TransactableHandle {
+			defaultHook: func() *basestore.OldTransactableHandle {
 				panic("unexpected invocation of MockUserEmailsStore.Handle")
 			},
 		},
@@ -37485,15 +37485,15 @@ func (c UserEmailsStoreGetVerifiedEmailsFuncCall) Results() []interface{} {
 // UserEmailsStoreHandleFunc describes the behavior when the Handle method
 // of the parent MockUserEmailsStore instance is invoked.
 type UserEmailsStoreHandleFunc struct {
-	defaultHook func() *basestore.TransactableHandle
-	hooks       []func() *basestore.TransactableHandle
+	defaultHook func() *basestore.OldTransactableHandle
+	hooks       []func() *basestore.OldTransactableHandle
 	history     []UserEmailsStoreHandleFuncCall
 	mutex       sync.Mutex
 }
 
 // Handle delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockUserEmailsStore) Handle() *basestore.TransactableHandle {
+func (m *MockUserEmailsStore) Handle() *basestore.OldTransactableHandle {
 	r0 := m.HandleFunc.nextHook()()
 	m.HandleFunc.appendCall(UserEmailsStoreHandleFuncCall{r0})
 	return r0
@@ -37502,7 +37502,7 @@ func (m *MockUserEmailsStore) Handle() *basestore.TransactableHandle {
 // SetDefaultHook sets function that is called when the Handle method of the
 // parent MockUserEmailsStore instance is invoked and the hook queue is
 // empty.
-func (f *UserEmailsStoreHandleFunc) SetDefaultHook(hook func() *basestore.TransactableHandle) {
+func (f *UserEmailsStoreHandleFunc) SetDefaultHook(hook func() *basestore.OldTransactableHandle) {
 	f.defaultHook = hook
 }
 
@@ -37510,7 +37510,7 @@ func (f *UserEmailsStoreHandleFunc) SetDefaultHook(hook func() *basestore.Transa
 // Handle method of the parent MockUserEmailsStore instance invokes the hook
 // at the front of the queue and discards it. After the queue is empty, the
 // default hook function is invoked for any future action.
-func (f *UserEmailsStoreHandleFunc) PushHook(hook func() *basestore.TransactableHandle) {
+func (f *UserEmailsStoreHandleFunc) PushHook(hook func() *basestore.OldTransactableHandle) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -37518,20 +37518,20 @@ func (f *UserEmailsStoreHandleFunc) PushHook(hook func() *basestore.Transactable
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *UserEmailsStoreHandleFunc) SetDefaultReturn(r0 *basestore.TransactableHandle) {
-	f.SetDefaultHook(func() *basestore.TransactableHandle {
+func (f *UserEmailsStoreHandleFunc) SetDefaultReturn(r0 *basestore.OldTransactableHandle) {
+	f.SetDefaultHook(func() *basestore.OldTransactableHandle {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *UserEmailsStoreHandleFunc) PushReturn(r0 *basestore.TransactableHandle) {
-	f.PushHook(func() *basestore.TransactableHandle {
+func (f *UserEmailsStoreHandleFunc) PushReturn(r0 *basestore.OldTransactableHandle) {
+	f.PushHook(func() *basestore.OldTransactableHandle {
 		return r0
 	})
 }
 
-func (f *UserEmailsStoreHandleFunc) nextHook() func() *basestore.TransactableHandle {
+func (f *UserEmailsStoreHandleFunc) nextHook() func() *basestore.OldTransactableHandle {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -37566,7 +37566,7 @@ func (f *UserEmailsStoreHandleFunc) History() []UserEmailsStoreHandleFuncCall {
 type UserEmailsStoreHandleFuncCall struct {
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 *basestore.TransactableHandle
+	Result0 *basestore.OldTransactableHandle
 }
 
 // Args returns an interface slice containing the arguments of this
@@ -38555,7 +38555,7 @@ func NewMockUserExternalAccountsStore() *MockUserExternalAccountsStore {
 			},
 		},
 		HandleFunc: &UserExternalAccountsStoreHandleFunc{
-			defaultHook: func() (r0 *basestore.TransactableHandle) {
+			defaultHook: func() (r0 *basestore.OldTransactableHandle) {
 				return
 			},
 		},
@@ -38653,7 +38653,7 @@ func NewStrictMockUserExternalAccountsStore() *MockUserExternalAccountsStore {
 			},
 		},
 		HandleFunc: &UserExternalAccountsStoreHandleFunc{
-			defaultHook: func() *basestore.TransactableHandle {
+			defaultHook: func() *basestore.OldTransactableHandle {
 				panic("unexpected invocation of MockUserExternalAccountsStore.Handle")
 			},
 		},
@@ -39548,15 +39548,15 @@ func (c UserExternalAccountsStoreGetFuncCall) Results() []interface{} {
 // Handle method of the parent MockUserExternalAccountsStore instance is
 // invoked.
 type UserExternalAccountsStoreHandleFunc struct {
-	defaultHook func() *basestore.TransactableHandle
-	hooks       []func() *basestore.TransactableHandle
+	defaultHook func() *basestore.OldTransactableHandle
+	hooks       []func() *basestore.OldTransactableHandle
 	history     []UserExternalAccountsStoreHandleFuncCall
 	mutex       sync.Mutex
 }
 
 // Handle delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockUserExternalAccountsStore) Handle() *basestore.TransactableHandle {
+func (m *MockUserExternalAccountsStore) Handle() *basestore.OldTransactableHandle {
 	r0 := m.HandleFunc.nextHook()()
 	m.HandleFunc.appendCall(UserExternalAccountsStoreHandleFuncCall{r0})
 	return r0
@@ -39565,7 +39565,7 @@ func (m *MockUserExternalAccountsStore) Handle() *basestore.TransactableHandle {
 // SetDefaultHook sets function that is called when the Handle method of the
 // parent MockUserExternalAccountsStore instance is invoked and the hook
 // queue is empty.
-func (f *UserExternalAccountsStoreHandleFunc) SetDefaultHook(hook func() *basestore.TransactableHandle) {
+func (f *UserExternalAccountsStoreHandleFunc) SetDefaultHook(hook func() *basestore.OldTransactableHandle) {
 	f.defaultHook = hook
 }
 
@@ -39574,7 +39574,7 @@ func (f *UserExternalAccountsStoreHandleFunc) SetDefaultHook(hook func() *basest
 // invokes the hook at the front of the queue and discards it. After the
 // queue is empty, the default hook function is invoked for any future
 // action.
-func (f *UserExternalAccountsStoreHandleFunc) PushHook(hook func() *basestore.TransactableHandle) {
+func (f *UserExternalAccountsStoreHandleFunc) PushHook(hook func() *basestore.OldTransactableHandle) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -39582,20 +39582,20 @@ func (f *UserExternalAccountsStoreHandleFunc) PushHook(hook func() *basestore.Tr
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *UserExternalAccountsStoreHandleFunc) SetDefaultReturn(r0 *basestore.TransactableHandle) {
-	f.SetDefaultHook(func() *basestore.TransactableHandle {
+func (f *UserExternalAccountsStoreHandleFunc) SetDefaultReturn(r0 *basestore.OldTransactableHandle) {
+	f.SetDefaultHook(func() *basestore.OldTransactableHandle {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *UserExternalAccountsStoreHandleFunc) PushReturn(r0 *basestore.TransactableHandle) {
-	f.PushHook(func() *basestore.TransactableHandle {
+func (f *UserExternalAccountsStoreHandleFunc) PushReturn(r0 *basestore.OldTransactableHandle) {
+	f.PushHook(func() *basestore.OldTransactableHandle {
 		return r0
 	})
 }
 
-func (f *UserExternalAccountsStoreHandleFunc) nextHook() func() *basestore.TransactableHandle {
+func (f *UserExternalAccountsStoreHandleFunc) nextHook() func() *basestore.OldTransactableHandle {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -39631,7 +39631,7 @@ func (f *UserExternalAccountsStoreHandleFunc) History() []UserExternalAccountsSt
 type UserExternalAccountsStoreHandleFuncCall struct {
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 *basestore.TransactableHandle
+	Result0 *basestore.OldTransactableHandle
 }
 
 // Args returns an interface slice containing the arguments of this
@@ -40763,7 +40763,7 @@ type MockUserPublicRepoStore struct {
 func NewMockUserPublicRepoStore() *MockUserPublicRepoStore {
 	return &MockUserPublicRepoStore{
 		HandleFunc: &UserPublicRepoStoreHandleFunc{
-			defaultHook: func() (r0 *basestore.TransactableHandle) {
+			defaultHook: func() (r0 *basestore.OldTransactableHandle) {
 				return
 			},
 		},
@@ -40791,7 +40791,7 @@ func NewMockUserPublicRepoStore() *MockUserPublicRepoStore {
 func NewStrictMockUserPublicRepoStore() *MockUserPublicRepoStore {
 	return &MockUserPublicRepoStore{
 		HandleFunc: &UserPublicRepoStoreHandleFunc{
-			defaultHook: func() *basestore.TransactableHandle {
+			defaultHook: func() *basestore.OldTransactableHandle {
 				panic("unexpected invocation of MockUserPublicRepoStore.Handle")
 			},
 		},
@@ -40836,15 +40836,15 @@ func NewMockUserPublicRepoStoreFrom(i UserPublicRepoStore) *MockUserPublicRepoSt
 // UserPublicRepoStoreHandleFunc describes the behavior when the Handle
 // method of the parent MockUserPublicRepoStore instance is invoked.
 type UserPublicRepoStoreHandleFunc struct {
-	defaultHook func() *basestore.TransactableHandle
-	hooks       []func() *basestore.TransactableHandle
+	defaultHook func() *basestore.OldTransactableHandle
+	hooks       []func() *basestore.OldTransactableHandle
 	history     []UserPublicRepoStoreHandleFuncCall
 	mutex       sync.Mutex
 }
 
 // Handle delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockUserPublicRepoStore) Handle() *basestore.TransactableHandle {
+func (m *MockUserPublicRepoStore) Handle() *basestore.OldTransactableHandle {
 	r0 := m.HandleFunc.nextHook()()
 	m.HandleFunc.appendCall(UserPublicRepoStoreHandleFuncCall{r0})
 	return r0
@@ -40853,7 +40853,7 @@ func (m *MockUserPublicRepoStore) Handle() *basestore.TransactableHandle {
 // SetDefaultHook sets function that is called when the Handle method of the
 // parent MockUserPublicRepoStore instance is invoked and the hook queue is
 // empty.
-func (f *UserPublicRepoStoreHandleFunc) SetDefaultHook(hook func() *basestore.TransactableHandle) {
+func (f *UserPublicRepoStoreHandleFunc) SetDefaultHook(hook func() *basestore.OldTransactableHandle) {
 	f.defaultHook = hook
 }
 
@@ -40861,7 +40861,7 @@ func (f *UserPublicRepoStoreHandleFunc) SetDefaultHook(hook func() *basestore.Tr
 // Handle method of the parent MockUserPublicRepoStore instance invokes the
 // hook at the front of the queue and discards it. After the queue is empty,
 // the default hook function is invoked for any future action.
-func (f *UserPublicRepoStoreHandleFunc) PushHook(hook func() *basestore.TransactableHandle) {
+func (f *UserPublicRepoStoreHandleFunc) PushHook(hook func() *basestore.OldTransactableHandle) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -40869,20 +40869,20 @@ func (f *UserPublicRepoStoreHandleFunc) PushHook(hook func() *basestore.Transact
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *UserPublicRepoStoreHandleFunc) SetDefaultReturn(r0 *basestore.TransactableHandle) {
-	f.SetDefaultHook(func() *basestore.TransactableHandle {
+func (f *UserPublicRepoStoreHandleFunc) SetDefaultReturn(r0 *basestore.OldTransactableHandle) {
+	f.SetDefaultHook(func() *basestore.OldTransactableHandle {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *UserPublicRepoStoreHandleFunc) PushReturn(r0 *basestore.TransactableHandle) {
-	f.PushHook(func() *basestore.TransactableHandle {
+func (f *UserPublicRepoStoreHandleFunc) PushReturn(r0 *basestore.OldTransactableHandle) {
+	f.PushHook(func() *basestore.OldTransactableHandle {
 		return r0
 	})
 }
 
-func (f *UserPublicRepoStoreHandleFunc) nextHook() func() *basestore.TransactableHandle {
+func (f *UserPublicRepoStoreHandleFunc) nextHook() func() *basestore.OldTransactableHandle {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -40917,7 +40917,7 @@ func (f *UserPublicRepoStoreHandleFunc) History() []UserPublicRepoStoreHandleFun
 type UserPublicRepoStoreHandleFuncCall struct {
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 *basestore.TransactableHandle
+	Result0 *basestore.OldTransactableHandle
 }
 
 // Args returns an interface slice containing the arguments of this
@@ -45431,7 +45431,7 @@ func NewMockWebhookLogStore() *MockWebhookLogStore {
 			},
 		},
 		HandleFunc: &WebhookLogStoreHandleFunc{
-			defaultHook: func() (r0 *basestore.TransactableHandle) {
+			defaultHook: func() (r0 *basestore.OldTransactableHandle) {
 				return
 			},
 		},
@@ -45468,7 +45468,7 @@ func NewStrictMockWebhookLogStore() *MockWebhookLogStore {
 			},
 		},
 		HandleFunc: &WebhookLogStoreHandleFunc{
-			defaultHook: func() *basestore.TransactableHandle {
+			defaultHook: func() *basestore.OldTransactableHandle {
 				panic("unexpected invocation of MockWebhookLogStore.Handle")
 			},
 		},
@@ -45935,15 +45935,15 @@ func (c WebhookLogStoreGetByIDFuncCall) Results() []interface{} {
 // WebhookLogStoreHandleFunc describes the behavior when the Handle method
 // of the parent MockWebhookLogStore instance is invoked.
 type WebhookLogStoreHandleFunc struct {
-	defaultHook func() *basestore.TransactableHandle
-	hooks       []func() *basestore.TransactableHandle
+	defaultHook func() *basestore.OldTransactableHandle
+	hooks       []func() *basestore.OldTransactableHandle
 	history     []WebhookLogStoreHandleFuncCall
 	mutex       sync.Mutex
 }
 
 // Handle delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockWebhookLogStore) Handle() *basestore.TransactableHandle {
+func (m *MockWebhookLogStore) Handle() *basestore.OldTransactableHandle {
 	r0 := m.HandleFunc.nextHook()()
 	m.HandleFunc.appendCall(WebhookLogStoreHandleFuncCall{r0})
 	return r0
@@ -45952,7 +45952,7 @@ func (m *MockWebhookLogStore) Handle() *basestore.TransactableHandle {
 // SetDefaultHook sets function that is called when the Handle method of the
 // parent MockWebhookLogStore instance is invoked and the hook queue is
 // empty.
-func (f *WebhookLogStoreHandleFunc) SetDefaultHook(hook func() *basestore.TransactableHandle) {
+func (f *WebhookLogStoreHandleFunc) SetDefaultHook(hook func() *basestore.OldTransactableHandle) {
 	f.defaultHook = hook
 }
 
@@ -45960,7 +45960,7 @@ func (f *WebhookLogStoreHandleFunc) SetDefaultHook(hook func() *basestore.Transa
 // Handle method of the parent MockWebhookLogStore instance invokes the hook
 // at the front of the queue and discards it. After the queue is empty, the
 // default hook function is invoked for any future action.
-func (f *WebhookLogStoreHandleFunc) PushHook(hook func() *basestore.TransactableHandle) {
+func (f *WebhookLogStoreHandleFunc) PushHook(hook func() *basestore.OldTransactableHandle) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -45968,20 +45968,20 @@ func (f *WebhookLogStoreHandleFunc) PushHook(hook func() *basestore.Transactable
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *WebhookLogStoreHandleFunc) SetDefaultReturn(r0 *basestore.TransactableHandle) {
-	f.SetDefaultHook(func() *basestore.TransactableHandle {
+func (f *WebhookLogStoreHandleFunc) SetDefaultReturn(r0 *basestore.OldTransactableHandle) {
+	f.SetDefaultHook(func() *basestore.OldTransactableHandle {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *WebhookLogStoreHandleFunc) PushReturn(r0 *basestore.TransactableHandle) {
-	f.PushHook(func() *basestore.TransactableHandle {
+func (f *WebhookLogStoreHandleFunc) PushReturn(r0 *basestore.OldTransactableHandle) {
+	f.PushHook(func() *basestore.OldTransactableHandle {
 		return r0
 	})
 }
 
-func (f *WebhookLogStoreHandleFunc) nextHook() func() *basestore.TransactableHandle {
+func (f *WebhookLogStoreHandleFunc) nextHook() func() *basestore.OldTransactableHandle {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -46016,7 +46016,7 @@ func (f *WebhookLogStoreHandleFunc) History() []WebhookLogStoreHandleFuncCall {
 type WebhookLogStoreHandleFuncCall struct {
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 *basestore.TransactableHandle
+	Result0 *basestore.OldTransactableHandle
 }
 
 // Args returns an interface slice containing the arguments of this

--- a/internal/database/mocks_temp.go
+++ b/internal/database/mocks_temp.go
@@ -113,7 +113,7 @@ func NewMockAccessTokenStore() *MockAccessTokenStore {
 			},
 		},
 		HandleFunc: &AccessTokenStoreHandleFunc{
-			defaultHook: func() (r0 *basestore.OldTransactableHandle) {
+			defaultHook: func() (r0 basestore.TransactableHandle) {
 				return
 			},
 		},
@@ -185,7 +185,7 @@ func NewStrictMockAccessTokenStore() *MockAccessTokenStore {
 			},
 		},
 		HandleFunc: &AccessTokenStoreHandleFunc{
-			defaultHook: func() *basestore.OldTransactableHandle {
+			defaultHook: func() basestore.TransactableHandle {
 				panic("unexpected invocation of MockAccessTokenStore.Handle")
 			},
 		},
@@ -1045,15 +1045,15 @@ func (c AccessTokenStoreGetByTokenFuncCall) Results() []interface{} {
 // AccessTokenStoreHandleFunc describes the behavior when the Handle method
 // of the parent MockAccessTokenStore instance is invoked.
 type AccessTokenStoreHandleFunc struct {
-	defaultHook func() *basestore.OldTransactableHandle
-	hooks       []func() *basestore.OldTransactableHandle
+	defaultHook func() basestore.TransactableHandle
+	hooks       []func() basestore.TransactableHandle
 	history     []AccessTokenStoreHandleFuncCall
 	mutex       sync.Mutex
 }
 
 // Handle delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockAccessTokenStore) Handle() *basestore.OldTransactableHandle {
+func (m *MockAccessTokenStore) Handle() basestore.TransactableHandle {
 	r0 := m.HandleFunc.nextHook()()
 	m.HandleFunc.appendCall(AccessTokenStoreHandleFuncCall{r0})
 	return r0
@@ -1062,7 +1062,7 @@ func (m *MockAccessTokenStore) Handle() *basestore.OldTransactableHandle {
 // SetDefaultHook sets function that is called when the Handle method of the
 // parent MockAccessTokenStore instance is invoked and the hook queue is
 // empty.
-func (f *AccessTokenStoreHandleFunc) SetDefaultHook(hook func() *basestore.OldTransactableHandle) {
+func (f *AccessTokenStoreHandleFunc) SetDefaultHook(hook func() basestore.TransactableHandle) {
 	f.defaultHook = hook
 }
 
@@ -1070,7 +1070,7 @@ func (f *AccessTokenStoreHandleFunc) SetDefaultHook(hook func() *basestore.OldTr
 // Handle method of the parent MockAccessTokenStore instance invokes the
 // hook at the front of the queue and discards it. After the queue is empty,
 // the default hook function is invoked for any future action.
-func (f *AccessTokenStoreHandleFunc) PushHook(hook func() *basestore.OldTransactableHandle) {
+func (f *AccessTokenStoreHandleFunc) PushHook(hook func() basestore.TransactableHandle) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -1078,20 +1078,20 @@ func (f *AccessTokenStoreHandleFunc) PushHook(hook func() *basestore.OldTransact
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *AccessTokenStoreHandleFunc) SetDefaultReturn(r0 *basestore.OldTransactableHandle) {
-	f.SetDefaultHook(func() *basestore.OldTransactableHandle {
+func (f *AccessTokenStoreHandleFunc) SetDefaultReturn(r0 basestore.TransactableHandle) {
+	f.SetDefaultHook(func() basestore.TransactableHandle {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *AccessTokenStoreHandleFunc) PushReturn(r0 *basestore.OldTransactableHandle) {
-	f.PushHook(func() *basestore.OldTransactableHandle {
+func (f *AccessTokenStoreHandleFunc) PushReturn(r0 basestore.TransactableHandle) {
+	f.PushHook(func() basestore.TransactableHandle {
 		return r0
 	})
 }
 
-func (f *AccessTokenStoreHandleFunc) nextHook() func() *basestore.OldTransactableHandle {
+func (f *AccessTokenStoreHandleFunc) nextHook() func() basestore.TransactableHandle {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -1126,7 +1126,7 @@ func (f *AccessTokenStoreHandleFunc) History() []AccessTokenStoreHandleFuncCall 
 type AccessTokenStoreHandleFuncCall struct {
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 *basestore.OldTransactableHandle
+	Result0 basestore.TransactableHandle
 }
 
 // Args returns an interface slice containing the arguments of this
@@ -2114,7 +2114,7 @@ func NewMockBitbucketProjectPermissionsStore() *MockBitbucketProjectPermissionsS
 			},
 		},
 		HandleFunc: &BitbucketProjectPermissionsStoreHandleFunc{
-			defaultHook: func() (r0 *basestore.OldTransactableHandle) {
+			defaultHook: func() (r0 basestore.TransactableHandle) {
 				return
 			},
 		},
@@ -2152,7 +2152,7 @@ func NewStrictMockBitbucketProjectPermissionsStore() *MockBitbucketProjectPermis
 			},
 		},
 		HandleFunc: &BitbucketProjectPermissionsStoreHandleFunc{
-			defaultHook: func() *basestore.OldTransactableHandle {
+			defaultHook: func() basestore.TransactableHandle {
 				panic("unexpected invocation of MockBitbucketProjectPermissionsStore.Handle")
 			},
 		},
@@ -2431,15 +2431,15 @@ func (c BitbucketProjectPermissionsStoreEnqueueFuncCall) Results() []interface{}
 // the Handle method of the parent MockBitbucketProjectPermissionsStore
 // instance is invoked.
 type BitbucketProjectPermissionsStoreHandleFunc struct {
-	defaultHook func() *basestore.OldTransactableHandle
-	hooks       []func() *basestore.OldTransactableHandle
+	defaultHook func() basestore.TransactableHandle
+	hooks       []func() basestore.TransactableHandle
 	history     []BitbucketProjectPermissionsStoreHandleFuncCall
 	mutex       sync.Mutex
 }
 
 // Handle delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockBitbucketProjectPermissionsStore) Handle() *basestore.OldTransactableHandle {
+func (m *MockBitbucketProjectPermissionsStore) Handle() basestore.TransactableHandle {
 	r0 := m.HandleFunc.nextHook()()
 	m.HandleFunc.appendCall(BitbucketProjectPermissionsStoreHandleFuncCall{r0})
 	return r0
@@ -2448,7 +2448,7 @@ func (m *MockBitbucketProjectPermissionsStore) Handle() *basestore.OldTransactab
 // SetDefaultHook sets function that is called when the Handle method of the
 // parent MockBitbucketProjectPermissionsStore instance is invoked and the
 // hook queue is empty.
-func (f *BitbucketProjectPermissionsStoreHandleFunc) SetDefaultHook(hook func() *basestore.OldTransactableHandle) {
+func (f *BitbucketProjectPermissionsStoreHandleFunc) SetDefaultHook(hook func() basestore.TransactableHandle) {
 	f.defaultHook = hook
 }
 
@@ -2457,7 +2457,7 @@ func (f *BitbucketProjectPermissionsStoreHandleFunc) SetDefaultHook(hook func() 
 // invokes the hook at the front of the queue and discards it. After the
 // queue is empty, the default hook function is invoked for any future
 // action.
-func (f *BitbucketProjectPermissionsStoreHandleFunc) PushHook(hook func() *basestore.OldTransactableHandle) {
+func (f *BitbucketProjectPermissionsStoreHandleFunc) PushHook(hook func() basestore.TransactableHandle) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -2465,20 +2465,20 @@ func (f *BitbucketProjectPermissionsStoreHandleFunc) PushHook(hook func() *bases
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *BitbucketProjectPermissionsStoreHandleFunc) SetDefaultReturn(r0 *basestore.OldTransactableHandle) {
-	f.SetDefaultHook(func() *basestore.OldTransactableHandle {
+func (f *BitbucketProjectPermissionsStoreHandleFunc) SetDefaultReturn(r0 basestore.TransactableHandle) {
+	f.SetDefaultHook(func() basestore.TransactableHandle {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *BitbucketProjectPermissionsStoreHandleFunc) PushReturn(r0 *basestore.OldTransactableHandle) {
-	f.PushHook(func() *basestore.OldTransactableHandle {
+func (f *BitbucketProjectPermissionsStoreHandleFunc) PushReturn(r0 basestore.TransactableHandle) {
+	f.PushHook(func() basestore.TransactableHandle {
 		return r0
 	})
 }
 
-func (f *BitbucketProjectPermissionsStoreHandleFunc) nextHook() func() *basestore.OldTransactableHandle {
+func (f *BitbucketProjectPermissionsStoreHandleFunc) nextHook() func() basestore.TransactableHandle {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -2515,7 +2515,7 @@ func (f *BitbucketProjectPermissionsStoreHandleFunc) History() []BitbucketProjec
 type BitbucketProjectPermissionsStoreHandleFuncCall struct {
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 *basestore.OldTransactableHandle
+	Result0 basestore.TransactableHandle
 }
 
 // Args returns an interface slice containing the arguments of this
@@ -2888,7 +2888,7 @@ func NewMockConfStore() *MockConfStore {
 			},
 		},
 		HandleFunc: &ConfStoreHandleFunc{
-			defaultHook: func() (r0 *basestore.OldTransactableHandle) {
+			defaultHook: func() (r0 basestore.TransactableHandle) {
 				return
 			},
 		},
@@ -2920,7 +2920,7 @@ func NewStrictMockConfStore() *MockConfStore {
 			},
 		},
 		HandleFunc: &ConfStoreHandleFunc{
-			defaultHook: func() *basestore.OldTransactableHandle {
+			defaultHook: func() basestore.TransactableHandle {
 				panic("unexpected invocation of MockConfStore.Handle")
 			},
 		},
@@ -3068,15 +3068,15 @@ func (c ConfStoreDoneFuncCall) Results() []interface{} {
 // ConfStoreHandleFunc describes the behavior when the Handle method of the
 // parent MockConfStore instance is invoked.
 type ConfStoreHandleFunc struct {
-	defaultHook func() *basestore.OldTransactableHandle
-	hooks       []func() *basestore.OldTransactableHandle
+	defaultHook func() basestore.TransactableHandle
+	hooks       []func() basestore.TransactableHandle
 	history     []ConfStoreHandleFuncCall
 	mutex       sync.Mutex
 }
 
 // Handle delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockConfStore) Handle() *basestore.OldTransactableHandle {
+func (m *MockConfStore) Handle() basestore.TransactableHandle {
 	r0 := m.HandleFunc.nextHook()()
 	m.HandleFunc.appendCall(ConfStoreHandleFuncCall{r0})
 	return r0
@@ -3084,7 +3084,7 @@ func (m *MockConfStore) Handle() *basestore.OldTransactableHandle {
 
 // SetDefaultHook sets function that is called when the Handle method of the
 // parent MockConfStore instance is invoked and the hook queue is empty.
-func (f *ConfStoreHandleFunc) SetDefaultHook(hook func() *basestore.OldTransactableHandle) {
+func (f *ConfStoreHandleFunc) SetDefaultHook(hook func() basestore.TransactableHandle) {
 	f.defaultHook = hook
 }
 
@@ -3092,7 +3092,7 @@ func (f *ConfStoreHandleFunc) SetDefaultHook(hook func() *basestore.OldTransacta
 // Handle method of the parent MockConfStore instance invokes the hook at
 // the front of the queue and discards it. After the queue is empty, the
 // default hook function is invoked for any future action.
-func (f *ConfStoreHandleFunc) PushHook(hook func() *basestore.OldTransactableHandle) {
+func (f *ConfStoreHandleFunc) PushHook(hook func() basestore.TransactableHandle) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -3100,20 +3100,20 @@ func (f *ConfStoreHandleFunc) PushHook(hook func() *basestore.OldTransactableHan
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *ConfStoreHandleFunc) SetDefaultReturn(r0 *basestore.OldTransactableHandle) {
-	f.SetDefaultHook(func() *basestore.OldTransactableHandle {
+func (f *ConfStoreHandleFunc) SetDefaultReturn(r0 basestore.TransactableHandle) {
+	f.SetDefaultHook(func() basestore.TransactableHandle {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *ConfStoreHandleFunc) PushReturn(r0 *basestore.OldTransactableHandle) {
-	f.PushHook(func() *basestore.OldTransactableHandle {
+func (f *ConfStoreHandleFunc) PushReturn(r0 basestore.TransactableHandle) {
+	f.PushHook(func() basestore.TransactableHandle {
 		return r0
 	})
 }
 
-func (f *ConfStoreHandleFunc) nextHook() func() *basestore.OldTransactableHandle {
+func (f *ConfStoreHandleFunc) nextHook() func() basestore.TransactableHandle {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -3148,7 +3148,7 @@ func (f *ConfStoreHandleFunc) History() []ConfStoreHandleFuncCall {
 type ConfStoreHandleFuncCall struct {
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 *basestore.OldTransactableHandle
+	Result0 basestore.TransactableHandle
 }
 
 // Args returns an interface slice containing the arguments of this
@@ -3662,7 +3662,7 @@ func NewMockDB() *MockDB {
 			},
 		},
 		HandleFunc: &DBHandleFunc{
-			defaultHook: func() (r0 *basestore.OldTransactableHandle) {
+			defaultHook: func() (r0 basestore.TransactableHandle) {
 				return
 			},
 		},
@@ -3844,7 +3844,7 @@ func NewStrictMockDB() *MockDB {
 			},
 		},
 		HandleFunc: &DBHandleFunc{
-			defaultHook: func() *basestore.OldTransactableHandle {
+			defaultHook: func() basestore.TransactableHandle {
 				panic("unexpected invocation of MockDB.Handle")
 			},
 		},
@@ -5280,15 +5280,15 @@ func (c DBGlobalStateFuncCall) Results() []interface{} {
 // DBHandleFunc describes the behavior when the Handle method of the parent
 // MockDB instance is invoked.
 type DBHandleFunc struct {
-	defaultHook func() *basestore.OldTransactableHandle
-	hooks       []func() *basestore.OldTransactableHandle
+	defaultHook func() basestore.TransactableHandle
+	hooks       []func() basestore.TransactableHandle
 	history     []DBHandleFuncCall
 	mutex       sync.Mutex
 }
 
 // Handle delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockDB) Handle() *basestore.OldTransactableHandle {
+func (m *MockDB) Handle() basestore.TransactableHandle {
 	r0 := m.HandleFunc.nextHook()()
 	m.HandleFunc.appendCall(DBHandleFuncCall{r0})
 	return r0
@@ -5296,7 +5296,7 @@ func (m *MockDB) Handle() *basestore.OldTransactableHandle {
 
 // SetDefaultHook sets function that is called when the Handle method of the
 // parent MockDB instance is invoked and the hook queue is empty.
-func (f *DBHandleFunc) SetDefaultHook(hook func() *basestore.OldTransactableHandle) {
+func (f *DBHandleFunc) SetDefaultHook(hook func() basestore.TransactableHandle) {
 	f.defaultHook = hook
 }
 
@@ -5304,7 +5304,7 @@ func (f *DBHandleFunc) SetDefaultHook(hook func() *basestore.OldTransactableHand
 // Handle method of the parent MockDB instance invokes the hook at the front
 // of the queue and discards it. After the queue is empty, the default hook
 // function is invoked for any future action.
-func (f *DBHandleFunc) PushHook(hook func() *basestore.OldTransactableHandle) {
+func (f *DBHandleFunc) PushHook(hook func() basestore.TransactableHandle) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -5312,20 +5312,20 @@ func (f *DBHandleFunc) PushHook(hook func() *basestore.OldTransactableHandle) {
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *DBHandleFunc) SetDefaultReturn(r0 *basestore.OldTransactableHandle) {
-	f.SetDefaultHook(func() *basestore.OldTransactableHandle {
+func (f *DBHandleFunc) SetDefaultReturn(r0 basestore.TransactableHandle) {
+	f.SetDefaultHook(func() basestore.TransactableHandle {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *DBHandleFunc) PushReturn(r0 *basestore.OldTransactableHandle) {
-	f.PushHook(func() *basestore.OldTransactableHandle {
+func (f *DBHandleFunc) PushReturn(r0 basestore.TransactableHandle) {
+	f.PushHook(func() basestore.TransactableHandle {
 		return r0
 	})
 }
 
-func (f *DBHandleFunc) nextHook() func() *basestore.OldTransactableHandle {
+func (f *DBHandleFunc) nextHook() func() basestore.TransactableHandle {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -5360,7 +5360,7 @@ func (f *DBHandleFunc) History() []DBHandleFuncCall {
 type DBHandleFuncCall struct {
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 *basestore.OldTransactableHandle
+	Result0 basestore.TransactableHandle
 }
 
 // Args returns an interface slice containing the arguments of this
@@ -7843,7 +7843,7 @@ func NewMockEventLogStore() *MockEventLogStore {
 			},
 		},
 		HandleFunc: &EventLogStoreHandleFunc{
-			defaultHook: func() (r0 *basestore.OldTransactableHandle) {
+			defaultHook: func() (r0 basestore.TransactableHandle) {
 				return
 			},
 		},
@@ -8030,7 +8030,7 @@ func NewStrictMockEventLogStore() *MockEventLogStore {
 			},
 		},
 		HandleFunc: &EventLogStoreHandleFunc{
-			defaultHook: func() *basestore.OldTransactableHandle {
+			defaultHook: func() basestore.TransactableHandle {
 				panic("unexpected invocation of MockEventLogStore.Handle")
 			},
 		},
@@ -10893,15 +10893,15 @@ func (c EventLogStoreDoneFuncCall) Results() []interface{} {
 // EventLogStoreHandleFunc describes the behavior when the Handle method of
 // the parent MockEventLogStore instance is invoked.
 type EventLogStoreHandleFunc struct {
-	defaultHook func() *basestore.OldTransactableHandle
-	hooks       []func() *basestore.OldTransactableHandle
+	defaultHook func() basestore.TransactableHandle
+	hooks       []func() basestore.TransactableHandle
 	history     []EventLogStoreHandleFuncCall
 	mutex       sync.Mutex
 }
 
 // Handle delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockEventLogStore) Handle() *basestore.OldTransactableHandle {
+func (m *MockEventLogStore) Handle() basestore.TransactableHandle {
 	r0 := m.HandleFunc.nextHook()()
 	m.HandleFunc.appendCall(EventLogStoreHandleFuncCall{r0})
 	return r0
@@ -10909,7 +10909,7 @@ func (m *MockEventLogStore) Handle() *basestore.OldTransactableHandle {
 
 // SetDefaultHook sets function that is called when the Handle method of the
 // parent MockEventLogStore instance is invoked and the hook queue is empty.
-func (f *EventLogStoreHandleFunc) SetDefaultHook(hook func() *basestore.OldTransactableHandle) {
+func (f *EventLogStoreHandleFunc) SetDefaultHook(hook func() basestore.TransactableHandle) {
 	f.defaultHook = hook
 }
 
@@ -10917,7 +10917,7 @@ func (f *EventLogStoreHandleFunc) SetDefaultHook(hook func() *basestore.OldTrans
 // Handle method of the parent MockEventLogStore instance invokes the hook
 // at the front of the queue and discards it. After the queue is empty, the
 // default hook function is invoked for any future action.
-func (f *EventLogStoreHandleFunc) PushHook(hook func() *basestore.OldTransactableHandle) {
+func (f *EventLogStoreHandleFunc) PushHook(hook func() basestore.TransactableHandle) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -10925,20 +10925,20 @@ func (f *EventLogStoreHandleFunc) PushHook(hook func() *basestore.OldTransactabl
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *EventLogStoreHandleFunc) SetDefaultReturn(r0 *basestore.OldTransactableHandle) {
-	f.SetDefaultHook(func() *basestore.OldTransactableHandle {
+func (f *EventLogStoreHandleFunc) SetDefaultReturn(r0 basestore.TransactableHandle) {
+	f.SetDefaultHook(func() basestore.TransactableHandle {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *EventLogStoreHandleFunc) PushReturn(r0 *basestore.OldTransactableHandle) {
-	f.PushHook(func() *basestore.OldTransactableHandle {
+func (f *EventLogStoreHandleFunc) PushReturn(r0 basestore.TransactableHandle) {
+	f.PushHook(func() basestore.TransactableHandle {
 		return r0
 	})
 }
 
-func (f *EventLogStoreHandleFunc) nextHook() func() *basestore.OldTransactableHandle {
+func (f *EventLogStoreHandleFunc) nextHook() func() basestore.TransactableHandle {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -10973,7 +10973,7 @@ func (f *EventLogStoreHandleFunc) History() []EventLogStoreHandleFuncCall {
 type EventLogStoreHandleFuncCall struct {
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 *basestore.OldTransactableHandle
+	Result0 basestore.TransactableHandle
 }
 
 // Args returns an interface slice containing the arguments of this
@@ -12283,7 +12283,7 @@ func NewMockExternalServiceStore() *MockExternalServiceStore {
 			},
 		},
 		HandleFunc: &ExternalServiceStoreHandleFunc{
-			defaultHook: func() (r0 *basestore.OldTransactableHandle) {
+			defaultHook: func() (r0 basestore.TransactableHandle) {
 				return
 			},
 		},
@@ -12381,7 +12381,7 @@ func NewStrictMockExternalServiceStore() *MockExternalServiceStore {
 			},
 		},
 		HandleFunc: &ExternalServiceStoreHandleFunc{
-			defaultHook: func() *basestore.OldTransactableHandle {
+			defaultHook: func() basestore.TransactableHandle {
 				panic("unexpected invocation of MockExternalServiceStore.Handle")
 			},
 		},
@@ -13464,15 +13464,15 @@ func (c ExternalServiceStoreGetSyncJobsFuncCall) Results() []interface{} {
 // ExternalServiceStoreHandleFunc describes the behavior when the Handle
 // method of the parent MockExternalServiceStore instance is invoked.
 type ExternalServiceStoreHandleFunc struct {
-	defaultHook func() *basestore.OldTransactableHandle
-	hooks       []func() *basestore.OldTransactableHandle
+	defaultHook func() basestore.TransactableHandle
+	hooks       []func() basestore.TransactableHandle
 	history     []ExternalServiceStoreHandleFuncCall
 	mutex       sync.Mutex
 }
 
 // Handle delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockExternalServiceStore) Handle() *basestore.OldTransactableHandle {
+func (m *MockExternalServiceStore) Handle() basestore.TransactableHandle {
 	r0 := m.HandleFunc.nextHook()()
 	m.HandleFunc.appendCall(ExternalServiceStoreHandleFuncCall{r0})
 	return r0
@@ -13481,7 +13481,7 @@ func (m *MockExternalServiceStore) Handle() *basestore.OldTransactableHandle {
 // SetDefaultHook sets function that is called when the Handle method of the
 // parent MockExternalServiceStore instance is invoked and the hook queue is
 // empty.
-func (f *ExternalServiceStoreHandleFunc) SetDefaultHook(hook func() *basestore.OldTransactableHandle) {
+func (f *ExternalServiceStoreHandleFunc) SetDefaultHook(hook func() basestore.TransactableHandle) {
 	f.defaultHook = hook
 }
 
@@ -13489,7 +13489,7 @@ func (f *ExternalServiceStoreHandleFunc) SetDefaultHook(hook func() *basestore.O
 // Handle method of the parent MockExternalServiceStore instance invokes the
 // hook at the front of the queue and discards it. After the queue is empty,
 // the default hook function is invoked for any future action.
-func (f *ExternalServiceStoreHandleFunc) PushHook(hook func() *basestore.OldTransactableHandle) {
+func (f *ExternalServiceStoreHandleFunc) PushHook(hook func() basestore.TransactableHandle) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -13497,20 +13497,20 @@ func (f *ExternalServiceStoreHandleFunc) PushHook(hook func() *basestore.OldTran
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *ExternalServiceStoreHandleFunc) SetDefaultReturn(r0 *basestore.OldTransactableHandle) {
-	f.SetDefaultHook(func() *basestore.OldTransactableHandle {
+func (f *ExternalServiceStoreHandleFunc) SetDefaultReturn(r0 basestore.TransactableHandle) {
+	f.SetDefaultHook(func() basestore.TransactableHandle {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *ExternalServiceStoreHandleFunc) PushReturn(r0 *basestore.OldTransactableHandle) {
-	f.PushHook(func() *basestore.OldTransactableHandle {
+func (f *ExternalServiceStoreHandleFunc) PushReturn(r0 basestore.TransactableHandle) {
+	f.PushHook(func() basestore.TransactableHandle {
 		return r0
 	})
 }
 
-func (f *ExternalServiceStoreHandleFunc) nextHook() func() *basestore.OldTransactableHandle {
+func (f *ExternalServiceStoreHandleFunc) nextHook() func() basestore.TransactableHandle {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -13545,7 +13545,7 @@ func (f *ExternalServiceStoreHandleFunc) History() []ExternalServiceStoreHandleF
 type ExternalServiceStoreHandleFuncCall struct {
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 *basestore.OldTransactableHandle
+	Result0 basestore.TransactableHandle
 }
 
 // Args returns an interface slice containing the arguments of this
@@ -14581,7 +14581,7 @@ func NewMockFeatureFlagStore() *MockFeatureFlagStore {
 			},
 		},
 		HandleFunc: &FeatureFlagStoreHandleFunc{
-			defaultHook: func() (r0 *basestore.OldTransactableHandle) {
+			defaultHook: func() (r0 basestore.TransactableHandle) {
 				return
 			},
 		},
@@ -14693,7 +14693,7 @@ func NewStrictMockFeatureFlagStore() *MockFeatureFlagStore {
 			},
 		},
 		HandleFunc: &FeatureFlagStoreHandleFunc{
-			defaultHook: func() *basestore.OldTransactableHandle {
+			defaultHook: func() basestore.TransactableHandle {
 				panic("unexpected invocation of MockFeatureFlagStore.Handle")
 			},
 		},
@@ -16571,15 +16571,15 @@ func (c FeatureFlagStoreGetUserOverridesFuncCall) Results() []interface{} {
 // FeatureFlagStoreHandleFunc describes the behavior when the Handle method
 // of the parent MockFeatureFlagStore instance is invoked.
 type FeatureFlagStoreHandleFunc struct {
-	defaultHook func() *basestore.OldTransactableHandle
-	hooks       []func() *basestore.OldTransactableHandle
+	defaultHook func() basestore.TransactableHandle
+	hooks       []func() basestore.TransactableHandle
 	history     []FeatureFlagStoreHandleFuncCall
 	mutex       sync.Mutex
 }
 
 // Handle delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockFeatureFlagStore) Handle() *basestore.OldTransactableHandle {
+func (m *MockFeatureFlagStore) Handle() basestore.TransactableHandle {
 	r0 := m.HandleFunc.nextHook()()
 	m.HandleFunc.appendCall(FeatureFlagStoreHandleFuncCall{r0})
 	return r0
@@ -16588,7 +16588,7 @@ func (m *MockFeatureFlagStore) Handle() *basestore.OldTransactableHandle {
 // SetDefaultHook sets function that is called when the Handle method of the
 // parent MockFeatureFlagStore instance is invoked and the hook queue is
 // empty.
-func (f *FeatureFlagStoreHandleFunc) SetDefaultHook(hook func() *basestore.OldTransactableHandle) {
+func (f *FeatureFlagStoreHandleFunc) SetDefaultHook(hook func() basestore.TransactableHandle) {
 	f.defaultHook = hook
 }
 
@@ -16596,7 +16596,7 @@ func (f *FeatureFlagStoreHandleFunc) SetDefaultHook(hook func() *basestore.OldTr
 // Handle method of the parent MockFeatureFlagStore instance invokes the
 // hook at the front of the queue and discards it. After the queue is empty,
 // the default hook function is invoked for any future action.
-func (f *FeatureFlagStoreHandleFunc) PushHook(hook func() *basestore.OldTransactableHandle) {
+func (f *FeatureFlagStoreHandleFunc) PushHook(hook func() basestore.TransactableHandle) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -16604,20 +16604,20 @@ func (f *FeatureFlagStoreHandleFunc) PushHook(hook func() *basestore.OldTransact
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *FeatureFlagStoreHandleFunc) SetDefaultReturn(r0 *basestore.OldTransactableHandle) {
-	f.SetDefaultHook(func() *basestore.OldTransactableHandle {
+func (f *FeatureFlagStoreHandleFunc) SetDefaultReturn(r0 basestore.TransactableHandle) {
+	f.SetDefaultHook(func() basestore.TransactableHandle {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *FeatureFlagStoreHandleFunc) PushReturn(r0 *basestore.OldTransactableHandle) {
-	f.PushHook(func() *basestore.OldTransactableHandle {
+func (f *FeatureFlagStoreHandleFunc) PushReturn(r0 basestore.TransactableHandle) {
+	f.PushHook(func() basestore.TransactableHandle {
 		return r0
 	})
 }
 
-func (f *FeatureFlagStoreHandleFunc) nextHook() func() *basestore.OldTransactableHandle {
+func (f *FeatureFlagStoreHandleFunc) nextHook() func() basestore.TransactableHandle {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -16652,7 +16652,7 @@ func (f *FeatureFlagStoreHandleFunc) History() []FeatureFlagStoreHandleFuncCall 
 type FeatureFlagStoreHandleFuncCall struct {
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 *basestore.OldTransactableHandle
+	Result0 basestore.TransactableHandle
 }
 
 // Args returns an interface slice containing the arguments of this
@@ -17131,7 +17131,7 @@ func NewMockGitserverLocalCloneStore() *MockGitserverLocalCloneStore {
 			},
 		},
 		HandleFunc: &GitserverLocalCloneStoreHandleFunc{
-			defaultHook: func() (r0 *basestore.OldTransactableHandle) {
+			defaultHook: func() (r0 basestore.TransactableHandle) {
 				return
 			},
 		},
@@ -17154,7 +17154,7 @@ func NewStrictMockGitserverLocalCloneStore() *MockGitserverLocalCloneStore {
 			},
 		},
 		HandleFunc: &GitserverLocalCloneStoreHandleFunc{
-			defaultHook: func() *basestore.OldTransactableHandle {
+			defaultHook: func() basestore.TransactableHandle {
 				panic("unexpected invocation of MockGitserverLocalCloneStore.Handle")
 			},
 		},
@@ -17306,15 +17306,15 @@ func (c GitserverLocalCloneStoreEnqueueFuncCall) Results() []interface{} {
 // GitserverLocalCloneStoreHandleFunc describes the behavior when the Handle
 // method of the parent MockGitserverLocalCloneStore instance is invoked.
 type GitserverLocalCloneStoreHandleFunc struct {
-	defaultHook func() *basestore.OldTransactableHandle
-	hooks       []func() *basestore.OldTransactableHandle
+	defaultHook func() basestore.TransactableHandle
+	hooks       []func() basestore.TransactableHandle
 	history     []GitserverLocalCloneStoreHandleFuncCall
 	mutex       sync.Mutex
 }
 
 // Handle delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockGitserverLocalCloneStore) Handle() *basestore.OldTransactableHandle {
+func (m *MockGitserverLocalCloneStore) Handle() basestore.TransactableHandle {
 	r0 := m.HandleFunc.nextHook()()
 	m.HandleFunc.appendCall(GitserverLocalCloneStoreHandleFuncCall{r0})
 	return r0
@@ -17323,7 +17323,7 @@ func (m *MockGitserverLocalCloneStore) Handle() *basestore.OldTransactableHandle
 // SetDefaultHook sets function that is called when the Handle method of the
 // parent MockGitserverLocalCloneStore instance is invoked and the hook
 // queue is empty.
-func (f *GitserverLocalCloneStoreHandleFunc) SetDefaultHook(hook func() *basestore.OldTransactableHandle) {
+func (f *GitserverLocalCloneStoreHandleFunc) SetDefaultHook(hook func() basestore.TransactableHandle) {
 	f.defaultHook = hook
 }
 
@@ -17331,7 +17331,7 @@ func (f *GitserverLocalCloneStoreHandleFunc) SetDefaultHook(hook func() *basesto
 // Handle method of the parent MockGitserverLocalCloneStore instance invokes
 // the hook at the front of the queue and discards it. After the queue is
 // empty, the default hook function is invoked for any future action.
-func (f *GitserverLocalCloneStoreHandleFunc) PushHook(hook func() *basestore.OldTransactableHandle) {
+func (f *GitserverLocalCloneStoreHandleFunc) PushHook(hook func() basestore.TransactableHandle) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -17339,20 +17339,20 @@ func (f *GitserverLocalCloneStoreHandleFunc) PushHook(hook func() *basestore.Old
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *GitserverLocalCloneStoreHandleFunc) SetDefaultReturn(r0 *basestore.OldTransactableHandle) {
-	f.SetDefaultHook(func() *basestore.OldTransactableHandle {
+func (f *GitserverLocalCloneStoreHandleFunc) SetDefaultReturn(r0 basestore.TransactableHandle) {
+	f.SetDefaultHook(func() basestore.TransactableHandle {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *GitserverLocalCloneStoreHandleFunc) PushReturn(r0 *basestore.OldTransactableHandle) {
-	f.PushHook(func() *basestore.OldTransactableHandle {
+func (f *GitserverLocalCloneStoreHandleFunc) PushReturn(r0 basestore.TransactableHandle) {
+	f.PushHook(func() basestore.TransactableHandle {
 		return r0
 	})
 }
 
-func (f *GitserverLocalCloneStoreHandleFunc) nextHook() func() *basestore.OldTransactableHandle {
+func (f *GitserverLocalCloneStoreHandleFunc) nextHook() func() basestore.TransactableHandle {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -17388,7 +17388,7 @@ func (f *GitserverLocalCloneStoreHandleFunc) History() []GitserverLocalCloneStor
 type GitserverLocalCloneStoreHandleFuncCall struct {
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 *basestore.OldTransactableHandle
+	Result0 basestore.TransactableHandle
 }
 
 // Args returns an interface slice containing the arguments of this
@@ -17584,7 +17584,7 @@ func NewMockGitserverRepoStore() *MockGitserverRepoStore {
 			},
 		},
 		HandleFunc: &GitserverRepoStoreHandleFunc{
-			defaultHook: func() (r0 *basestore.OldTransactableHandle) {
+			defaultHook: func() (r0 basestore.TransactableHandle) {
 				return
 			},
 		},
@@ -17672,7 +17672,7 @@ func NewStrictMockGitserverRepoStore() *MockGitserverRepoStore {
 			},
 		},
 		HandleFunc: &GitserverRepoStoreHandleFunc{
-			defaultHook: func() *basestore.OldTransactableHandle {
+			defaultHook: func() basestore.TransactableHandle {
 				panic("unexpected invocation of MockGitserverRepoStore.Handle")
 			},
 		},
@@ -18130,15 +18130,15 @@ func (c GitserverRepoStoreGetByNamesFuncCall) Results() []interface{} {
 // GitserverRepoStoreHandleFunc describes the behavior when the Handle
 // method of the parent MockGitserverRepoStore instance is invoked.
 type GitserverRepoStoreHandleFunc struct {
-	defaultHook func() *basestore.OldTransactableHandle
-	hooks       []func() *basestore.OldTransactableHandle
+	defaultHook func() basestore.TransactableHandle
+	hooks       []func() basestore.TransactableHandle
 	history     []GitserverRepoStoreHandleFuncCall
 	mutex       sync.Mutex
 }
 
 // Handle delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockGitserverRepoStore) Handle() *basestore.OldTransactableHandle {
+func (m *MockGitserverRepoStore) Handle() basestore.TransactableHandle {
 	r0 := m.HandleFunc.nextHook()()
 	m.HandleFunc.appendCall(GitserverRepoStoreHandleFuncCall{r0})
 	return r0
@@ -18147,7 +18147,7 @@ func (m *MockGitserverRepoStore) Handle() *basestore.OldTransactableHandle {
 // SetDefaultHook sets function that is called when the Handle method of the
 // parent MockGitserverRepoStore instance is invoked and the hook queue is
 // empty.
-func (f *GitserverRepoStoreHandleFunc) SetDefaultHook(hook func() *basestore.OldTransactableHandle) {
+func (f *GitserverRepoStoreHandleFunc) SetDefaultHook(hook func() basestore.TransactableHandle) {
 	f.defaultHook = hook
 }
 
@@ -18155,7 +18155,7 @@ func (f *GitserverRepoStoreHandleFunc) SetDefaultHook(hook func() *basestore.Old
 // Handle method of the parent MockGitserverRepoStore instance invokes the
 // hook at the front of the queue and discards it. After the queue is empty,
 // the default hook function is invoked for any future action.
-func (f *GitserverRepoStoreHandleFunc) PushHook(hook func() *basestore.OldTransactableHandle) {
+func (f *GitserverRepoStoreHandleFunc) PushHook(hook func() basestore.TransactableHandle) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -18163,20 +18163,20 @@ func (f *GitserverRepoStoreHandleFunc) PushHook(hook func() *basestore.OldTransa
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *GitserverRepoStoreHandleFunc) SetDefaultReturn(r0 *basestore.OldTransactableHandle) {
-	f.SetDefaultHook(func() *basestore.OldTransactableHandle {
+func (f *GitserverRepoStoreHandleFunc) SetDefaultReturn(r0 basestore.TransactableHandle) {
+	f.SetDefaultHook(func() basestore.TransactableHandle {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *GitserverRepoStoreHandleFunc) PushReturn(r0 *basestore.OldTransactableHandle) {
-	f.PushHook(func() *basestore.OldTransactableHandle {
+func (f *GitserverRepoStoreHandleFunc) PushReturn(r0 basestore.TransactableHandle) {
+	f.PushHook(func() basestore.TransactableHandle {
 		return r0
 	})
 }
 
-func (f *GitserverRepoStoreHandleFunc) nextHook() func() *basestore.OldTransactableHandle {
+func (f *GitserverRepoStoreHandleFunc) nextHook() func() basestore.TransactableHandle {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -18211,7 +18211,7 @@ func (f *GitserverRepoStoreHandleFunc) History() []GitserverRepoStoreHandleFuncC
 type GitserverRepoStoreHandleFuncCall struct {
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 *basestore.OldTransactableHandle
+	Result0 basestore.TransactableHandle
 }
 
 // Args returns an interface slice containing the arguments of this
@@ -19989,7 +19989,7 @@ func NewMockNamespaceStore() *MockNamespaceStore {
 			},
 		},
 		HandleFunc: &NamespaceStoreHandleFunc{
-			defaultHook: func() (r0 *basestore.OldTransactableHandle) {
+			defaultHook: func() (r0 basestore.TransactableHandle) {
 				return
 			},
 		},
@@ -20021,7 +20021,7 @@ func NewStrictMockNamespaceStore() *MockNamespaceStore {
 			},
 		},
 		HandleFunc: &NamespaceStoreHandleFunc{
-			defaultHook: func() *basestore.OldTransactableHandle {
+			defaultHook: func() basestore.TransactableHandle {
 				panic("unexpected invocation of MockNamespaceStore.Handle")
 			},
 		},
@@ -20283,15 +20283,15 @@ func (c NamespaceStoreGetByNameFuncCall) Results() []interface{} {
 // NamespaceStoreHandleFunc describes the behavior when the Handle method of
 // the parent MockNamespaceStore instance is invoked.
 type NamespaceStoreHandleFunc struct {
-	defaultHook func() *basestore.OldTransactableHandle
-	hooks       []func() *basestore.OldTransactableHandle
+	defaultHook func() basestore.TransactableHandle
+	hooks       []func() basestore.TransactableHandle
 	history     []NamespaceStoreHandleFuncCall
 	mutex       sync.Mutex
 }
 
 // Handle delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockNamespaceStore) Handle() *basestore.OldTransactableHandle {
+func (m *MockNamespaceStore) Handle() basestore.TransactableHandle {
 	r0 := m.HandleFunc.nextHook()()
 	m.HandleFunc.appendCall(NamespaceStoreHandleFuncCall{r0})
 	return r0
@@ -20300,7 +20300,7 @@ func (m *MockNamespaceStore) Handle() *basestore.OldTransactableHandle {
 // SetDefaultHook sets function that is called when the Handle method of the
 // parent MockNamespaceStore instance is invoked and the hook queue is
 // empty.
-func (f *NamespaceStoreHandleFunc) SetDefaultHook(hook func() *basestore.OldTransactableHandle) {
+func (f *NamespaceStoreHandleFunc) SetDefaultHook(hook func() basestore.TransactableHandle) {
 	f.defaultHook = hook
 }
 
@@ -20308,7 +20308,7 @@ func (f *NamespaceStoreHandleFunc) SetDefaultHook(hook func() *basestore.OldTran
 // Handle method of the parent MockNamespaceStore instance invokes the hook
 // at the front of the queue and discards it. After the queue is empty, the
 // default hook function is invoked for any future action.
-func (f *NamespaceStoreHandleFunc) PushHook(hook func() *basestore.OldTransactableHandle) {
+func (f *NamespaceStoreHandleFunc) PushHook(hook func() basestore.TransactableHandle) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -20316,20 +20316,20 @@ func (f *NamespaceStoreHandleFunc) PushHook(hook func() *basestore.OldTransactab
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *NamespaceStoreHandleFunc) SetDefaultReturn(r0 *basestore.OldTransactableHandle) {
-	f.SetDefaultHook(func() *basestore.OldTransactableHandle {
+func (f *NamespaceStoreHandleFunc) SetDefaultReturn(r0 basestore.TransactableHandle) {
+	f.SetDefaultHook(func() basestore.TransactableHandle {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *NamespaceStoreHandleFunc) PushReturn(r0 *basestore.OldTransactableHandle) {
-	f.PushHook(func() *basestore.OldTransactableHandle {
+func (f *NamespaceStoreHandleFunc) PushReturn(r0 basestore.TransactableHandle) {
+	f.PushHook(func() basestore.TransactableHandle {
 		return r0
 	})
 }
 
-func (f *NamespaceStoreHandleFunc) nextHook() func() *basestore.OldTransactableHandle {
+func (f *NamespaceStoreHandleFunc) nextHook() func() basestore.TransactableHandle {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -20364,7 +20364,7 @@ func (f *NamespaceStoreHandleFunc) History() []NamespaceStoreHandleFuncCall {
 type NamespaceStoreHandleFuncCall struct {
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 *basestore.OldTransactableHandle
+	Result0 basestore.TransactableHandle
 }
 
 // Args returns an interface slice containing the arguments of this
@@ -20671,7 +20671,7 @@ func NewMockOrgInvitationStore() *MockOrgInvitationStore {
 			},
 		},
 		HandleFunc: &OrgInvitationStoreHandleFunc{
-			defaultHook: func() (r0 *basestore.OldTransactableHandle) {
+			defaultHook: func() (r0 basestore.TransactableHandle) {
 				return
 			},
 		},
@@ -20749,7 +20749,7 @@ func NewStrictMockOrgInvitationStore() *MockOrgInvitationStore {
 			},
 		},
 		HandleFunc: &OrgInvitationStoreHandleFunc{
-			defaultHook: func() *basestore.OldTransactableHandle {
+			defaultHook: func() basestore.TransactableHandle {
 				panic("unexpected invocation of MockOrgInvitationStore.Handle")
 			},
 		},
@@ -21514,15 +21514,15 @@ func (c OrgInvitationStoreGetPendingByOrgIDFuncCall) Results() []interface{} {
 // OrgInvitationStoreHandleFunc describes the behavior when the Handle
 // method of the parent MockOrgInvitationStore instance is invoked.
 type OrgInvitationStoreHandleFunc struct {
-	defaultHook func() *basestore.OldTransactableHandle
-	hooks       []func() *basestore.OldTransactableHandle
+	defaultHook func() basestore.TransactableHandle
+	hooks       []func() basestore.TransactableHandle
 	history     []OrgInvitationStoreHandleFuncCall
 	mutex       sync.Mutex
 }
 
 // Handle delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockOrgInvitationStore) Handle() *basestore.OldTransactableHandle {
+func (m *MockOrgInvitationStore) Handle() basestore.TransactableHandle {
 	r0 := m.HandleFunc.nextHook()()
 	m.HandleFunc.appendCall(OrgInvitationStoreHandleFuncCall{r0})
 	return r0
@@ -21531,7 +21531,7 @@ func (m *MockOrgInvitationStore) Handle() *basestore.OldTransactableHandle {
 // SetDefaultHook sets function that is called when the Handle method of the
 // parent MockOrgInvitationStore instance is invoked and the hook queue is
 // empty.
-func (f *OrgInvitationStoreHandleFunc) SetDefaultHook(hook func() *basestore.OldTransactableHandle) {
+func (f *OrgInvitationStoreHandleFunc) SetDefaultHook(hook func() basestore.TransactableHandle) {
 	f.defaultHook = hook
 }
 
@@ -21539,7 +21539,7 @@ func (f *OrgInvitationStoreHandleFunc) SetDefaultHook(hook func() *basestore.Old
 // Handle method of the parent MockOrgInvitationStore instance invokes the
 // hook at the front of the queue and discards it. After the queue is empty,
 // the default hook function is invoked for any future action.
-func (f *OrgInvitationStoreHandleFunc) PushHook(hook func() *basestore.OldTransactableHandle) {
+func (f *OrgInvitationStoreHandleFunc) PushHook(hook func() basestore.TransactableHandle) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -21547,20 +21547,20 @@ func (f *OrgInvitationStoreHandleFunc) PushHook(hook func() *basestore.OldTransa
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *OrgInvitationStoreHandleFunc) SetDefaultReturn(r0 *basestore.OldTransactableHandle) {
-	f.SetDefaultHook(func() *basestore.OldTransactableHandle {
+func (f *OrgInvitationStoreHandleFunc) SetDefaultReturn(r0 basestore.TransactableHandle) {
+	f.SetDefaultHook(func() basestore.TransactableHandle {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *OrgInvitationStoreHandleFunc) PushReturn(r0 *basestore.OldTransactableHandle) {
-	f.PushHook(func() *basestore.OldTransactableHandle {
+func (f *OrgInvitationStoreHandleFunc) PushReturn(r0 basestore.TransactableHandle) {
+	f.PushHook(func() basestore.TransactableHandle {
 		return r0
 	})
 }
 
-func (f *OrgInvitationStoreHandleFunc) nextHook() func() *basestore.OldTransactableHandle {
+func (f *OrgInvitationStoreHandleFunc) nextHook() func() basestore.TransactableHandle {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -21595,7 +21595,7 @@ func (f *OrgInvitationStoreHandleFunc) History() []OrgInvitationStoreHandleFuncC
 type OrgInvitationStoreHandleFuncCall struct {
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 *basestore.OldTransactableHandle
+	Result0 basestore.TransactableHandle
 }
 
 // Args returns an interface slice containing the arguments of this
@@ -22441,7 +22441,7 @@ func NewMockOrgMemberStore() *MockOrgMemberStore {
 			},
 		},
 		HandleFunc: &OrgMemberStoreHandleFunc{
-			defaultHook: func() (r0 *basestore.OldTransactableHandle) {
+			defaultHook: func() (r0 basestore.TransactableHandle) {
 				return
 			},
 		},
@@ -22503,7 +22503,7 @@ func NewStrictMockOrgMemberStore() *MockOrgMemberStore {
 			},
 		},
 		HandleFunc: &OrgMemberStoreHandleFunc{
-			defaultHook: func() *basestore.OldTransactableHandle {
+			defaultHook: func() basestore.TransactableHandle {
 				panic("unexpected invocation of MockOrgMemberStore.Handle")
 			},
 		},
@@ -23239,15 +23239,15 @@ func (c OrgMemberStoreGetByUserIDFuncCall) Results() []interface{} {
 // OrgMemberStoreHandleFunc describes the behavior when the Handle method of
 // the parent MockOrgMemberStore instance is invoked.
 type OrgMemberStoreHandleFunc struct {
-	defaultHook func() *basestore.OldTransactableHandle
-	hooks       []func() *basestore.OldTransactableHandle
+	defaultHook func() basestore.TransactableHandle
+	hooks       []func() basestore.TransactableHandle
 	history     []OrgMemberStoreHandleFuncCall
 	mutex       sync.Mutex
 }
 
 // Handle delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockOrgMemberStore) Handle() *basestore.OldTransactableHandle {
+func (m *MockOrgMemberStore) Handle() basestore.TransactableHandle {
 	r0 := m.HandleFunc.nextHook()()
 	m.HandleFunc.appendCall(OrgMemberStoreHandleFuncCall{r0})
 	return r0
@@ -23256,7 +23256,7 @@ func (m *MockOrgMemberStore) Handle() *basestore.OldTransactableHandle {
 // SetDefaultHook sets function that is called when the Handle method of the
 // parent MockOrgMemberStore instance is invoked and the hook queue is
 // empty.
-func (f *OrgMemberStoreHandleFunc) SetDefaultHook(hook func() *basestore.OldTransactableHandle) {
+func (f *OrgMemberStoreHandleFunc) SetDefaultHook(hook func() basestore.TransactableHandle) {
 	f.defaultHook = hook
 }
 
@@ -23264,7 +23264,7 @@ func (f *OrgMemberStoreHandleFunc) SetDefaultHook(hook func() *basestore.OldTran
 // Handle method of the parent MockOrgMemberStore instance invokes the hook
 // at the front of the queue and discards it. After the queue is empty, the
 // default hook function is invoked for any future action.
-func (f *OrgMemberStoreHandleFunc) PushHook(hook func() *basestore.OldTransactableHandle) {
+func (f *OrgMemberStoreHandleFunc) PushHook(hook func() basestore.TransactableHandle) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -23272,20 +23272,20 @@ func (f *OrgMemberStoreHandleFunc) PushHook(hook func() *basestore.OldTransactab
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *OrgMemberStoreHandleFunc) SetDefaultReturn(r0 *basestore.OldTransactableHandle) {
-	f.SetDefaultHook(func() *basestore.OldTransactableHandle {
+func (f *OrgMemberStoreHandleFunc) SetDefaultReturn(r0 basestore.TransactableHandle) {
+	f.SetDefaultHook(func() basestore.TransactableHandle {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *OrgMemberStoreHandleFunc) PushReturn(r0 *basestore.OldTransactableHandle) {
-	f.PushHook(func() *basestore.OldTransactableHandle {
+func (f *OrgMemberStoreHandleFunc) PushReturn(r0 basestore.TransactableHandle) {
+	f.PushHook(func() basestore.TransactableHandle {
 		return r0
 	})
 }
 
-func (f *OrgMemberStoreHandleFunc) nextHook() func() *basestore.OldTransactableHandle {
+func (f *OrgMemberStoreHandleFunc) nextHook() func() basestore.TransactableHandle {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -23320,7 +23320,7 @@ func (f *OrgMemberStoreHandleFunc) History() []OrgMemberStoreHandleFuncCall {
 type OrgMemberStoreHandleFuncCall struct {
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 *basestore.OldTransactableHandle
+	Result0 basestore.TransactableHandle
 }
 
 // Args returns an interface slice containing the arguments of this
@@ -23863,7 +23863,7 @@ func NewMockOrgStore() *MockOrgStore {
 			},
 		},
 		HandleFunc: &OrgStoreHandleFunc{
-			defaultHook: func() (r0 *basestore.OldTransactableHandle) {
+			defaultHook: func() (r0 basestore.TransactableHandle) {
 				return
 			},
 		},
@@ -23950,7 +23950,7 @@ func NewStrictMockOrgStore() *MockOrgStore {
 			},
 		},
 		HandleFunc: &OrgStoreHandleFunc{
-			defaultHook: func() *basestore.OldTransactableHandle {
+			defaultHook: func() basestore.TransactableHandle {
 				panic("unexpected invocation of MockOrgStore.Handle")
 			},
 		},
@@ -25013,15 +25013,15 @@ func (c OrgStoreGetOrgsWithRepositoriesByUserIDFuncCall) Results() []interface{}
 // OrgStoreHandleFunc describes the behavior when the Handle method of the
 // parent MockOrgStore instance is invoked.
 type OrgStoreHandleFunc struct {
-	defaultHook func() *basestore.OldTransactableHandle
-	hooks       []func() *basestore.OldTransactableHandle
+	defaultHook func() basestore.TransactableHandle
+	hooks       []func() basestore.TransactableHandle
 	history     []OrgStoreHandleFuncCall
 	mutex       sync.Mutex
 }
 
 // Handle delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockOrgStore) Handle() *basestore.OldTransactableHandle {
+func (m *MockOrgStore) Handle() basestore.TransactableHandle {
 	r0 := m.HandleFunc.nextHook()()
 	m.HandleFunc.appendCall(OrgStoreHandleFuncCall{r0})
 	return r0
@@ -25029,7 +25029,7 @@ func (m *MockOrgStore) Handle() *basestore.OldTransactableHandle {
 
 // SetDefaultHook sets function that is called when the Handle method of the
 // parent MockOrgStore instance is invoked and the hook queue is empty.
-func (f *OrgStoreHandleFunc) SetDefaultHook(hook func() *basestore.OldTransactableHandle) {
+func (f *OrgStoreHandleFunc) SetDefaultHook(hook func() basestore.TransactableHandle) {
 	f.defaultHook = hook
 }
 
@@ -25037,7 +25037,7 @@ func (f *OrgStoreHandleFunc) SetDefaultHook(hook func() *basestore.OldTransactab
 // Handle method of the parent MockOrgStore instance invokes the hook at the
 // front of the queue and discards it. After the queue is empty, the default
 // hook function is invoked for any future action.
-func (f *OrgStoreHandleFunc) PushHook(hook func() *basestore.OldTransactableHandle) {
+func (f *OrgStoreHandleFunc) PushHook(hook func() basestore.TransactableHandle) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -25045,20 +25045,20 @@ func (f *OrgStoreHandleFunc) PushHook(hook func() *basestore.OldTransactableHand
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *OrgStoreHandleFunc) SetDefaultReturn(r0 *basestore.OldTransactableHandle) {
-	f.SetDefaultHook(func() *basestore.OldTransactableHandle {
+func (f *OrgStoreHandleFunc) SetDefaultReturn(r0 basestore.TransactableHandle) {
+	f.SetDefaultHook(func() basestore.TransactableHandle {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *OrgStoreHandleFunc) PushReturn(r0 *basestore.OldTransactableHandle) {
-	f.PushHook(func() *basestore.OldTransactableHandle {
+func (f *OrgStoreHandleFunc) PushReturn(r0 basestore.TransactableHandle) {
+	f.PushHook(func() basestore.TransactableHandle {
 		return r0
 	})
 }
 
-func (f *OrgStoreHandleFunc) nextHook() func() *basestore.OldTransactableHandle {
+func (f *OrgStoreHandleFunc) nextHook() func() basestore.TransactableHandle {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -25093,7 +25093,7 @@ func (f *OrgStoreHandleFunc) History() []OrgStoreHandleFuncCall {
 type OrgStoreHandleFuncCall struct {
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 *basestore.OldTransactableHandle
+	Result0 basestore.TransactableHandle
 }
 
 // Args returns an interface slice containing the arguments of this
@@ -25799,7 +25799,7 @@ func NewMockPhabricatorStore() *MockPhabricatorStore {
 			},
 		},
 		HandleFunc: &PhabricatorStoreHandleFunc{
-			defaultHook: func() (r0 *basestore.OldTransactableHandle) {
+			defaultHook: func() (r0 basestore.TransactableHandle) {
 				return
 			},
 		},
@@ -25841,7 +25841,7 @@ func NewStrictMockPhabricatorStore() *MockPhabricatorStore {
 			},
 		},
 		HandleFunc: &PhabricatorStoreHandleFunc{
-			defaultHook: func() *basestore.OldTransactableHandle {
+			defaultHook: func() basestore.TransactableHandle {
 				panic("unexpected invocation of MockPhabricatorStore.Handle")
 			},
 		},
@@ -26345,15 +26345,15 @@ func (c PhabricatorStoreGetByNameFuncCall) Results() []interface{} {
 // PhabricatorStoreHandleFunc describes the behavior when the Handle method
 // of the parent MockPhabricatorStore instance is invoked.
 type PhabricatorStoreHandleFunc struct {
-	defaultHook func() *basestore.OldTransactableHandle
-	hooks       []func() *basestore.OldTransactableHandle
+	defaultHook func() basestore.TransactableHandle
+	hooks       []func() basestore.TransactableHandle
 	history     []PhabricatorStoreHandleFuncCall
 	mutex       sync.Mutex
 }
 
 // Handle delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockPhabricatorStore) Handle() *basestore.OldTransactableHandle {
+func (m *MockPhabricatorStore) Handle() basestore.TransactableHandle {
 	r0 := m.HandleFunc.nextHook()()
 	m.HandleFunc.appendCall(PhabricatorStoreHandleFuncCall{r0})
 	return r0
@@ -26362,7 +26362,7 @@ func (m *MockPhabricatorStore) Handle() *basestore.OldTransactableHandle {
 // SetDefaultHook sets function that is called when the Handle method of the
 // parent MockPhabricatorStore instance is invoked and the hook queue is
 // empty.
-func (f *PhabricatorStoreHandleFunc) SetDefaultHook(hook func() *basestore.OldTransactableHandle) {
+func (f *PhabricatorStoreHandleFunc) SetDefaultHook(hook func() basestore.TransactableHandle) {
 	f.defaultHook = hook
 }
 
@@ -26370,7 +26370,7 @@ func (f *PhabricatorStoreHandleFunc) SetDefaultHook(hook func() *basestore.OldTr
 // Handle method of the parent MockPhabricatorStore instance invokes the
 // hook at the front of the queue and discards it. After the queue is empty,
 // the default hook function is invoked for any future action.
-func (f *PhabricatorStoreHandleFunc) PushHook(hook func() *basestore.OldTransactableHandle) {
+func (f *PhabricatorStoreHandleFunc) PushHook(hook func() basestore.TransactableHandle) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -26378,20 +26378,20 @@ func (f *PhabricatorStoreHandleFunc) PushHook(hook func() *basestore.OldTransact
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *PhabricatorStoreHandleFunc) SetDefaultReturn(r0 *basestore.OldTransactableHandle) {
-	f.SetDefaultHook(func() *basestore.OldTransactableHandle {
+func (f *PhabricatorStoreHandleFunc) SetDefaultReturn(r0 basestore.TransactableHandle) {
+	f.SetDefaultHook(func() basestore.TransactableHandle {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *PhabricatorStoreHandleFunc) PushReturn(r0 *basestore.OldTransactableHandle) {
-	f.PushHook(func() *basestore.OldTransactableHandle {
+func (f *PhabricatorStoreHandleFunc) PushReturn(r0 basestore.TransactableHandle) {
+	f.PushHook(func() basestore.TransactableHandle {
 		return r0
 	})
 }
 
-func (f *PhabricatorStoreHandleFunc) nextHook() func() *basestore.OldTransactableHandle {
+func (f *PhabricatorStoreHandleFunc) nextHook() func() basestore.TransactableHandle {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -26426,7 +26426,7 @@ func (f *PhabricatorStoreHandleFunc) History() []PhabricatorStoreHandleFuncCall 
 type PhabricatorStoreHandleFuncCall struct {
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 *basestore.OldTransactableHandle
+	Result0 basestore.TransactableHandle
 }
 
 // Args returns an interface slice containing the arguments of this
@@ -26767,7 +26767,7 @@ func NewMockRepoStore() *MockRepoStore {
 			},
 		},
 		HandleFunc: &RepoStoreHandleFunc{
-			defaultHook: func() (r0 *basestore.OldTransactableHandle) {
+			defaultHook: func() (r0 basestore.TransactableHandle) {
 				return
 			},
 		},
@@ -26869,7 +26869,7 @@ func NewStrictMockRepoStore() *MockRepoStore {
 			},
 		},
 		HandleFunc: &RepoStoreHandleFunc{
-			defaultHook: func() *basestore.OldTransactableHandle {
+			defaultHook: func() basestore.TransactableHandle {
 				panic("unexpected invocation of MockRepoStore.Handle")
 			},
 		},
@@ -28075,15 +28075,15 @@ func (c RepoStoreGetReposSetByIDsFuncCall) Results() []interface{} {
 // RepoStoreHandleFunc describes the behavior when the Handle method of the
 // parent MockRepoStore instance is invoked.
 type RepoStoreHandleFunc struct {
-	defaultHook func() *basestore.OldTransactableHandle
-	hooks       []func() *basestore.OldTransactableHandle
+	defaultHook func() basestore.TransactableHandle
+	hooks       []func() basestore.TransactableHandle
 	history     []RepoStoreHandleFuncCall
 	mutex       sync.Mutex
 }
 
 // Handle delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockRepoStore) Handle() *basestore.OldTransactableHandle {
+func (m *MockRepoStore) Handle() basestore.TransactableHandle {
 	r0 := m.HandleFunc.nextHook()()
 	m.HandleFunc.appendCall(RepoStoreHandleFuncCall{r0})
 	return r0
@@ -28091,7 +28091,7 @@ func (m *MockRepoStore) Handle() *basestore.OldTransactableHandle {
 
 // SetDefaultHook sets function that is called when the Handle method of the
 // parent MockRepoStore instance is invoked and the hook queue is empty.
-func (f *RepoStoreHandleFunc) SetDefaultHook(hook func() *basestore.OldTransactableHandle) {
+func (f *RepoStoreHandleFunc) SetDefaultHook(hook func() basestore.TransactableHandle) {
 	f.defaultHook = hook
 }
 
@@ -28099,7 +28099,7 @@ func (f *RepoStoreHandleFunc) SetDefaultHook(hook func() *basestore.OldTransacta
 // Handle method of the parent MockRepoStore instance invokes the hook at
 // the front of the queue and discards it. After the queue is empty, the
 // default hook function is invoked for any future action.
-func (f *RepoStoreHandleFunc) PushHook(hook func() *basestore.OldTransactableHandle) {
+func (f *RepoStoreHandleFunc) PushHook(hook func() basestore.TransactableHandle) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -28107,20 +28107,20 @@ func (f *RepoStoreHandleFunc) PushHook(hook func() *basestore.OldTransactableHan
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *RepoStoreHandleFunc) SetDefaultReturn(r0 *basestore.OldTransactableHandle) {
-	f.SetDefaultHook(func() *basestore.OldTransactableHandle {
+func (f *RepoStoreHandleFunc) SetDefaultReturn(r0 basestore.TransactableHandle) {
+	f.SetDefaultHook(func() basestore.TransactableHandle {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *RepoStoreHandleFunc) PushReturn(r0 *basestore.OldTransactableHandle) {
-	f.PushHook(func() *basestore.OldTransactableHandle {
+func (f *RepoStoreHandleFunc) PushReturn(r0 basestore.TransactableHandle) {
+	f.PushHook(func() basestore.TransactableHandle {
 		return r0
 	})
 }
 
-func (f *RepoStoreHandleFunc) nextHook() func() *basestore.OldTransactableHandle {
+func (f *RepoStoreHandleFunc) nextHook() func() basestore.TransactableHandle {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -28155,7 +28155,7 @@ func (f *RepoStoreHandleFunc) History() []RepoStoreHandleFuncCall {
 type RepoStoreHandleFuncCall struct {
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 *basestore.OldTransactableHandle
+	Result0 basestore.TransactableHandle
 }
 
 // Args returns an interface slice containing the arguments of this
@@ -29091,7 +29091,7 @@ func NewMockSavedSearchStore() *MockSavedSearchStore {
 			},
 		},
 		HandleFunc: &SavedSearchStoreHandleFunc{
-			defaultHook: func() (r0 *basestore.OldTransactableHandle) {
+			defaultHook: func() (r0 basestore.TransactableHandle) {
 				return
 			},
 		},
@@ -29153,7 +29153,7 @@ func NewStrictMockSavedSearchStore() *MockSavedSearchStore {
 			},
 		},
 		HandleFunc: &SavedSearchStoreHandleFunc{
-			defaultHook: func() *basestore.OldTransactableHandle {
+			defaultHook: func() basestore.TransactableHandle {
 				panic("unexpected invocation of MockSavedSearchStore.Handle")
 			},
 		},
@@ -29560,15 +29560,15 @@ func (c SavedSearchStoreGetByIDFuncCall) Results() []interface{} {
 // SavedSearchStoreHandleFunc describes the behavior when the Handle method
 // of the parent MockSavedSearchStore instance is invoked.
 type SavedSearchStoreHandleFunc struct {
-	defaultHook func() *basestore.OldTransactableHandle
-	hooks       []func() *basestore.OldTransactableHandle
+	defaultHook func() basestore.TransactableHandle
+	hooks       []func() basestore.TransactableHandle
 	history     []SavedSearchStoreHandleFuncCall
 	mutex       sync.Mutex
 }
 
 // Handle delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockSavedSearchStore) Handle() *basestore.OldTransactableHandle {
+func (m *MockSavedSearchStore) Handle() basestore.TransactableHandle {
 	r0 := m.HandleFunc.nextHook()()
 	m.HandleFunc.appendCall(SavedSearchStoreHandleFuncCall{r0})
 	return r0
@@ -29577,7 +29577,7 @@ func (m *MockSavedSearchStore) Handle() *basestore.OldTransactableHandle {
 // SetDefaultHook sets function that is called when the Handle method of the
 // parent MockSavedSearchStore instance is invoked and the hook queue is
 // empty.
-func (f *SavedSearchStoreHandleFunc) SetDefaultHook(hook func() *basestore.OldTransactableHandle) {
+func (f *SavedSearchStoreHandleFunc) SetDefaultHook(hook func() basestore.TransactableHandle) {
 	f.defaultHook = hook
 }
 
@@ -29585,7 +29585,7 @@ func (f *SavedSearchStoreHandleFunc) SetDefaultHook(hook func() *basestore.OldTr
 // Handle method of the parent MockSavedSearchStore instance invokes the
 // hook at the front of the queue and discards it. After the queue is empty,
 // the default hook function is invoked for any future action.
-func (f *SavedSearchStoreHandleFunc) PushHook(hook func() *basestore.OldTransactableHandle) {
+func (f *SavedSearchStoreHandleFunc) PushHook(hook func() basestore.TransactableHandle) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -29593,20 +29593,20 @@ func (f *SavedSearchStoreHandleFunc) PushHook(hook func() *basestore.OldTransact
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *SavedSearchStoreHandleFunc) SetDefaultReturn(r0 *basestore.OldTransactableHandle) {
-	f.SetDefaultHook(func() *basestore.OldTransactableHandle {
+func (f *SavedSearchStoreHandleFunc) SetDefaultReturn(r0 basestore.TransactableHandle) {
+	f.SetDefaultHook(func() basestore.TransactableHandle {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *SavedSearchStoreHandleFunc) PushReturn(r0 *basestore.OldTransactableHandle) {
-	f.PushHook(func() *basestore.OldTransactableHandle {
+func (f *SavedSearchStoreHandleFunc) PushReturn(r0 basestore.TransactableHandle) {
+	f.PushHook(func() basestore.TransactableHandle {
 		return r0
 	})
 }
 
-func (f *SavedSearchStoreHandleFunc) nextHook() func() *basestore.OldTransactableHandle {
+func (f *SavedSearchStoreHandleFunc) nextHook() func() basestore.TransactableHandle {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -29641,7 +29641,7 @@ func (f *SavedSearchStoreHandleFunc) History() []SavedSearchStoreHandleFuncCall 
 type SavedSearchStoreHandleFuncCall struct {
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 *basestore.OldTransactableHandle
+	Result0 basestore.TransactableHandle
 }
 
 // Args returns an interface slice containing the arguments of this
@@ -30509,7 +30509,7 @@ func NewMockSearchContextsStore() *MockSearchContextsStore {
 			},
 		},
 		HandleFunc: &SearchContextsStoreHandleFunc{
-			defaultHook: func() (r0 *basestore.OldTransactableHandle) {
+			defaultHook: func() (r0 basestore.TransactableHandle) {
 				return
 			},
 		},
@@ -30587,7 +30587,7 @@ func NewStrictMockSearchContextsStore() *MockSearchContextsStore {
 			},
 		},
 		HandleFunc: &SearchContextsStoreHandleFunc{
-			defaultHook: func() *basestore.OldTransactableHandle {
+			defaultHook: func() basestore.TransactableHandle {
 				panic("unexpected invocation of MockSearchContextsStore.Handle")
 			},
 		},
@@ -31658,15 +31658,15 @@ func (c SearchContextsStoreGetSearchContextRepositoryRevisionsFuncCall) Results(
 // SearchContextsStoreHandleFunc describes the behavior when the Handle
 // method of the parent MockSearchContextsStore instance is invoked.
 type SearchContextsStoreHandleFunc struct {
-	defaultHook func() *basestore.OldTransactableHandle
-	hooks       []func() *basestore.OldTransactableHandle
+	defaultHook func() basestore.TransactableHandle
+	hooks       []func() basestore.TransactableHandle
 	history     []SearchContextsStoreHandleFuncCall
 	mutex       sync.Mutex
 }
 
 // Handle delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockSearchContextsStore) Handle() *basestore.OldTransactableHandle {
+func (m *MockSearchContextsStore) Handle() basestore.TransactableHandle {
 	r0 := m.HandleFunc.nextHook()()
 	m.HandleFunc.appendCall(SearchContextsStoreHandleFuncCall{r0})
 	return r0
@@ -31675,7 +31675,7 @@ func (m *MockSearchContextsStore) Handle() *basestore.OldTransactableHandle {
 // SetDefaultHook sets function that is called when the Handle method of the
 // parent MockSearchContextsStore instance is invoked and the hook queue is
 // empty.
-func (f *SearchContextsStoreHandleFunc) SetDefaultHook(hook func() *basestore.OldTransactableHandle) {
+func (f *SearchContextsStoreHandleFunc) SetDefaultHook(hook func() basestore.TransactableHandle) {
 	f.defaultHook = hook
 }
 
@@ -31683,7 +31683,7 @@ func (f *SearchContextsStoreHandleFunc) SetDefaultHook(hook func() *basestore.Ol
 // Handle method of the parent MockSearchContextsStore instance invokes the
 // hook at the front of the queue and discards it. After the queue is empty,
 // the default hook function is invoked for any future action.
-func (f *SearchContextsStoreHandleFunc) PushHook(hook func() *basestore.OldTransactableHandle) {
+func (f *SearchContextsStoreHandleFunc) PushHook(hook func() basestore.TransactableHandle) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -31691,20 +31691,20 @@ func (f *SearchContextsStoreHandleFunc) PushHook(hook func() *basestore.OldTrans
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *SearchContextsStoreHandleFunc) SetDefaultReturn(r0 *basestore.OldTransactableHandle) {
-	f.SetDefaultHook(func() *basestore.OldTransactableHandle {
+func (f *SearchContextsStoreHandleFunc) SetDefaultReturn(r0 basestore.TransactableHandle) {
+	f.SetDefaultHook(func() basestore.TransactableHandle {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *SearchContextsStoreHandleFunc) PushReturn(r0 *basestore.OldTransactableHandle) {
-	f.PushHook(func() *basestore.OldTransactableHandle {
+func (f *SearchContextsStoreHandleFunc) PushReturn(r0 basestore.TransactableHandle) {
+	f.PushHook(func() basestore.TransactableHandle {
 		return r0
 	})
 }
 
-func (f *SearchContextsStoreHandleFunc) nextHook() func() *basestore.OldTransactableHandle {
+func (f *SearchContextsStoreHandleFunc) nextHook() func() basestore.TransactableHandle {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -31739,7 +31739,7 @@ func (f *SearchContextsStoreHandleFunc) History() []SearchContextsStoreHandleFun
 type SearchContextsStoreHandleFuncCall struct {
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 *basestore.OldTransactableHandle
+	Result0 basestore.TransactableHandle
 }
 
 // Args returns an interface slice containing the arguments of this
@@ -32228,7 +32228,7 @@ type MockSecurityEventLogsStore struct {
 func NewMockSecurityEventLogsStore() *MockSecurityEventLogsStore {
 	return &MockSecurityEventLogsStore{
 		HandleFunc: &SecurityEventLogsStoreHandleFunc{
-			defaultHook: func() (r0 *basestore.OldTransactableHandle) {
+			defaultHook: func() (r0 basestore.TransactableHandle) {
 				return
 			},
 		},
@@ -32251,7 +32251,7 @@ func NewMockSecurityEventLogsStore() *MockSecurityEventLogsStore {
 func NewStrictMockSecurityEventLogsStore() *MockSecurityEventLogsStore {
 	return &MockSecurityEventLogsStore{
 		HandleFunc: &SecurityEventLogsStoreHandleFunc{
-			defaultHook: func() *basestore.OldTransactableHandle {
+			defaultHook: func() basestore.TransactableHandle {
 				panic("unexpected invocation of MockSecurityEventLogsStore.Handle")
 			},
 		},
@@ -32288,15 +32288,15 @@ func NewMockSecurityEventLogsStoreFrom(i SecurityEventLogsStore) *MockSecurityEv
 // SecurityEventLogsStoreHandleFunc describes the behavior when the Handle
 // method of the parent MockSecurityEventLogsStore instance is invoked.
 type SecurityEventLogsStoreHandleFunc struct {
-	defaultHook func() *basestore.OldTransactableHandle
-	hooks       []func() *basestore.OldTransactableHandle
+	defaultHook func() basestore.TransactableHandle
+	hooks       []func() basestore.TransactableHandle
 	history     []SecurityEventLogsStoreHandleFuncCall
 	mutex       sync.Mutex
 }
 
 // Handle delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockSecurityEventLogsStore) Handle() *basestore.OldTransactableHandle {
+func (m *MockSecurityEventLogsStore) Handle() basestore.TransactableHandle {
 	r0 := m.HandleFunc.nextHook()()
 	m.HandleFunc.appendCall(SecurityEventLogsStoreHandleFuncCall{r0})
 	return r0
@@ -32305,7 +32305,7 @@ func (m *MockSecurityEventLogsStore) Handle() *basestore.OldTransactableHandle {
 // SetDefaultHook sets function that is called when the Handle method of the
 // parent MockSecurityEventLogsStore instance is invoked and the hook queue
 // is empty.
-func (f *SecurityEventLogsStoreHandleFunc) SetDefaultHook(hook func() *basestore.OldTransactableHandle) {
+func (f *SecurityEventLogsStoreHandleFunc) SetDefaultHook(hook func() basestore.TransactableHandle) {
 	f.defaultHook = hook
 }
 
@@ -32313,7 +32313,7 @@ func (f *SecurityEventLogsStoreHandleFunc) SetDefaultHook(hook func() *basestore
 // Handle method of the parent MockSecurityEventLogsStore instance invokes
 // the hook at the front of the queue and discards it. After the queue is
 // empty, the default hook function is invoked for any future action.
-func (f *SecurityEventLogsStoreHandleFunc) PushHook(hook func() *basestore.OldTransactableHandle) {
+func (f *SecurityEventLogsStoreHandleFunc) PushHook(hook func() basestore.TransactableHandle) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -32321,20 +32321,20 @@ func (f *SecurityEventLogsStoreHandleFunc) PushHook(hook func() *basestore.OldTr
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *SecurityEventLogsStoreHandleFunc) SetDefaultReturn(r0 *basestore.OldTransactableHandle) {
-	f.SetDefaultHook(func() *basestore.OldTransactableHandle {
+func (f *SecurityEventLogsStoreHandleFunc) SetDefaultReturn(r0 basestore.TransactableHandle) {
+	f.SetDefaultHook(func() basestore.TransactableHandle {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *SecurityEventLogsStoreHandleFunc) PushReturn(r0 *basestore.OldTransactableHandle) {
-	f.PushHook(func() *basestore.OldTransactableHandle {
+func (f *SecurityEventLogsStoreHandleFunc) PushReturn(r0 basestore.TransactableHandle) {
+	f.PushHook(func() basestore.TransactableHandle {
 		return r0
 	})
 }
 
-func (f *SecurityEventLogsStoreHandleFunc) nextHook() func() *basestore.OldTransactableHandle {
+func (f *SecurityEventLogsStoreHandleFunc) nextHook() func() basestore.TransactableHandle {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -32369,7 +32369,7 @@ func (f *SecurityEventLogsStoreHandleFunc) History() []SecurityEventLogsStoreHan
 type SecurityEventLogsStoreHandleFuncCall struct {
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 *basestore.OldTransactableHandle
+	Result0 basestore.TransactableHandle
 }
 
 // Args returns an interface slice containing the arguments of this
@@ -32648,7 +32648,7 @@ func NewMockSettingsStore() *MockSettingsStore {
 			},
 		},
 		HandleFunc: &SettingsStoreHandleFunc{
-			defaultHook: func() (r0 *basestore.OldTransactableHandle) {
+			defaultHook: func() (r0 basestore.TransactableHandle) {
 				return
 			},
 		},
@@ -32695,7 +32695,7 @@ func NewStrictMockSettingsStore() *MockSettingsStore {
 			},
 		},
 		HandleFunc: &SettingsStoreHandleFunc{
-			defaultHook: func() *basestore.OldTransactableHandle {
+			defaultHook: func() basestore.TransactableHandle {
 				panic("unexpected invocation of MockSettingsStore.Handle")
 			},
 		},
@@ -33192,15 +33192,15 @@ func (c SettingsStoreGetLatestFuncCall) Results() []interface{} {
 // SettingsStoreHandleFunc describes the behavior when the Handle method of
 // the parent MockSettingsStore instance is invoked.
 type SettingsStoreHandleFunc struct {
-	defaultHook func() *basestore.OldTransactableHandle
-	hooks       []func() *basestore.OldTransactableHandle
+	defaultHook func() basestore.TransactableHandle
+	hooks       []func() basestore.TransactableHandle
 	history     []SettingsStoreHandleFuncCall
 	mutex       sync.Mutex
 }
 
 // Handle delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockSettingsStore) Handle() *basestore.OldTransactableHandle {
+func (m *MockSettingsStore) Handle() basestore.TransactableHandle {
 	r0 := m.HandleFunc.nextHook()()
 	m.HandleFunc.appendCall(SettingsStoreHandleFuncCall{r0})
 	return r0
@@ -33208,7 +33208,7 @@ func (m *MockSettingsStore) Handle() *basestore.OldTransactableHandle {
 
 // SetDefaultHook sets function that is called when the Handle method of the
 // parent MockSettingsStore instance is invoked and the hook queue is empty.
-func (f *SettingsStoreHandleFunc) SetDefaultHook(hook func() *basestore.OldTransactableHandle) {
+func (f *SettingsStoreHandleFunc) SetDefaultHook(hook func() basestore.TransactableHandle) {
 	f.defaultHook = hook
 }
 
@@ -33216,7 +33216,7 @@ func (f *SettingsStoreHandleFunc) SetDefaultHook(hook func() *basestore.OldTrans
 // Handle method of the parent MockSettingsStore instance invokes the hook
 // at the front of the queue and discards it. After the queue is empty, the
 // default hook function is invoked for any future action.
-func (f *SettingsStoreHandleFunc) PushHook(hook func() *basestore.OldTransactableHandle) {
+func (f *SettingsStoreHandleFunc) PushHook(hook func() basestore.TransactableHandle) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -33224,20 +33224,20 @@ func (f *SettingsStoreHandleFunc) PushHook(hook func() *basestore.OldTransactabl
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *SettingsStoreHandleFunc) SetDefaultReturn(r0 *basestore.OldTransactableHandle) {
-	f.SetDefaultHook(func() *basestore.OldTransactableHandle {
+func (f *SettingsStoreHandleFunc) SetDefaultReturn(r0 basestore.TransactableHandle) {
+	f.SetDefaultHook(func() basestore.TransactableHandle {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *SettingsStoreHandleFunc) PushReturn(r0 *basestore.OldTransactableHandle) {
-	f.PushHook(func() *basestore.OldTransactableHandle {
+func (f *SettingsStoreHandleFunc) PushReturn(r0 basestore.TransactableHandle) {
+	f.PushHook(func() basestore.TransactableHandle {
 		return r0
 	})
 }
 
-func (f *SettingsStoreHandleFunc) nextHook() func() *basestore.OldTransactableHandle {
+func (f *SettingsStoreHandleFunc) nextHook() func() basestore.TransactableHandle {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -33272,7 +33272,7 @@ func (f *SettingsStoreHandleFunc) History() []SettingsStoreHandleFuncCall {
 type SettingsStoreHandleFuncCall struct {
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 *basestore.OldTransactableHandle
+	Result0 basestore.TransactableHandle
 }
 
 // Args returns an interface slice containing the arguments of this
@@ -34786,7 +34786,7 @@ func NewMockTemporarySettingsStore() *MockTemporarySettingsStore {
 			},
 		},
 		HandleFunc: &TemporarySettingsStoreHandleFunc{
-			defaultHook: func() (r0 *basestore.OldTransactableHandle) {
+			defaultHook: func() (r0 basestore.TransactableHandle) {
 				return
 			},
 		},
@@ -34814,7 +34814,7 @@ func NewStrictMockTemporarySettingsStore() *MockTemporarySettingsStore {
 			},
 		},
 		HandleFunc: &TemporarySettingsStoreHandleFunc{
-			defaultHook: func() *basestore.OldTransactableHandle {
+			defaultHook: func() basestore.TransactableHandle {
 				panic("unexpected invocation of MockTemporarySettingsStore.Handle")
 			},
 		},
@@ -35073,15 +35073,15 @@ func (c TemporarySettingsStoreGetTemporarySettingsFuncCall) Results() []interfac
 // TemporarySettingsStoreHandleFunc describes the behavior when the Handle
 // method of the parent MockTemporarySettingsStore instance is invoked.
 type TemporarySettingsStoreHandleFunc struct {
-	defaultHook func() *basestore.OldTransactableHandle
-	hooks       []func() *basestore.OldTransactableHandle
+	defaultHook func() basestore.TransactableHandle
+	hooks       []func() basestore.TransactableHandle
 	history     []TemporarySettingsStoreHandleFuncCall
 	mutex       sync.Mutex
 }
 
 // Handle delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockTemporarySettingsStore) Handle() *basestore.OldTransactableHandle {
+func (m *MockTemporarySettingsStore) Handle() basestore.TransactableHandle {
 	r0 := m.HandleFunc.nextHook()()
 	m.HandleFunc.appendCall(TemporarySettingsStoreHandleFuncCall{r0})
 	return r0
@@ -35090,7 +35090,7 @@ func (m *MockTemporarySettingsStore) Handle() *basestore.OldTransactableHandle {
 // SetDefaultHook sets function that is called when the Handle method of the
 // parent MockTemporarySettingsStore instance is invoked and the hook queue
 // is empty.
-func (f *TemporarySettingsStoreHandleFunc) SetDefaultHook(hook func() *basestore.OldTransactableHandle) {
+func (f *TemporarySettingsStoreHandleFunc) SetDefaultHook(hook func() basestore.TransactableHandle) {
 	f.defaultHook = hook
 }
 
@@ -35098,7 +35098,7 @@ func (f *TemporarySettingsStoreHandleFunc) SetDefaultHook(hook func() *basestore
 // Handle method of the parent MockTemporarySettingsStore instance invokes
 // the hook at the front of the queue and discards it. After the queue is
 // empty, the default hook function is invoked for any future action.
-func (f *TemporarySettingsStoreHandleFunc) PushHook(hook func() *basestore.OldTransactableHandle) {
+func (f *TemporarySettingsStoreHandleFunc) PushHook(hook func() basestore.TransactableHandle) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -35106,20 +35106,20 @@ func (f *TemporarySettingsStoreHandleFunc) PushHook(hook func() *basestore.OldTr
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *TemporarySettingsStoreHandleFunc) SetDefaultReturn(r0 *basestore.OldTransactableHandle) {
-	f.SetDefaultHook(func() *basestore.OldTransactableHandle {
+func (f *TemporarySettingsStoreHandleFunc) SetDefaultReturn(r0 basestore.TransactableHandle) {
+	f.SetDefaultHook(func() basestore.TransactableHandle {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *TemporarySettingsStoreHandleFunc) PushReturn(r0 *basestore.OldTransactableHandle) {
-	f.PushHook(func() *basestore.OldTransactableHandle {
+func (f *TemporarySettingsStoreHandleFunc) PushReturn(r0 basestore.TransactableHandle) {
+	f.PushHook(func() basestore.TransactableHandle {
 		return r0
 	})
 }
 
-func (f *TemporarySettingsStoreHandleFunc) nextHook() func() *basestore.OldTransactableHandle {
+func (f *TemporarySettingsStoreHandleFunc) nextHook() func() basestore.TransactableHandle {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -35154,7 +35154,7 @@ func (f *TemporarySettingsStoreHandleFunc) History() []TemporarySettingsStoreHan
 type TemporarySettingsStoreHandleFuncCall struct {
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 *basestore.OldTransactableHandle
+	Result0 basestore.TransactableHandle
 }
 
 // Args returns an interface slice containing the arguments of this
@@ -35342,7 +35342,7 @@ func NewMockUserCredentialsStore() *MockUserCredentialsStore {
 			},
 		},
 		HandleFunc: &UserCredentialsStoreHandleFunc{
-			defaultHook: func() (r0 *basestore.OldTransactableHandle) {
+			defaultHook: func() (r0 basestore.TransactableHandle) {
 				return
 			},
 		},
@@ -35395,7 +35395,7 @@ func NewStrictMockUserCredentialsStore() *MockUserCredentialsStore {
 			},
 		},
 		HandleFunc: &UserCredentialsStoreHandleFunc{
-			defaultHook: func() *basestore.OldTransactableHandle {
+			defaultHook: func() basestore.TransactableHandle {
 				panic("unexpected invocation of MockUserCredentialsStore.Handle")
 			},
 		},
@@ -35894,15 +35894,15 @@ func (c UserCredentialsStoreGetByScopeFuncCall) Results() []interface{} {
 // UserCredentialsStoreHandleFunc describes the behavior when the Handle
 // method of the parent MockUserCredentialsStore instance is invoked.
 type UserCredentialsStoreHandleFunc struct {
-	defaultHook func() *basestore.OldTransactableHandle
-	hooks       []func() *basestore.OldTransactableHandle
+	defaultHook func() basestore.TransactableHandle
+	hooks       []func() basestore.TransactableHandle
 	history     []UserCredentialsStoreHandleFuncCall
 	mutex       sync.Mutex
 }
 
 // Handle delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockUserCredentialsStore) Handle() *basestore.OldTransactableHandle {
+func (m *MockUserCredentialsStore) Handle() basestore.TransactableHandle {
 	r0 := m.HandleFunc.nextHook()()
 	m.HandleFunc.appendCall(UserCredentialsStoreHandleFuncCall{r0})
 	return r0
@@ -35911,7 +35911,7 @@ func (m *MockUserCredentialsStore) Handle() *basestore.OldTransactableHandle {
 // SetDefaultHook sets function that is called when the Handle method of the
 // parent MockUserCredentialsStore instance is invoked and the hook queue is
 // empty.
-func (f *UserCredentialsStoreHandleFunc) SetDefaultHook(hook func() *basestore.OldTransactableHandle) {
+func (f *UserCredentialsStoreHandleFunc) SetDefaultHook(hook func() basestore.TransactableHandle) {
 	f.defaultHook = hook
 }
 
@@ -35919,7 +35919,7 @@ func (f *UserCredentialsStoreHandleFunc) SetDefaultHook(hook func() *basestore.O
 // Handle method of the parent MockUserCredentialsStore instance invokes the
 // hook at the front of the queue and discards it. After the queue is empty,
 // the default hook function is invoked for any future action.
-func (f *UserCredentialsStoreHandleFunc) PushHook(hook func() *basestore.OldTransactableHandle) {
+func (f *UserCredentialsStoreHandleFunc) PushHook(hook func() basestore.TransactableHandle) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -35927,20 +35927,20 @@ func (f *UserCredentialsStoreHandleFunc) PushHook(hook func() *basestore.OldTran
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *UserCredentialsStoreHandleFunc) SetDefaultReturn(r0 *basestore.OldTransactableHandle) {
-	f.SetDefaultHook(func() *basestore.OldTransactableHandle {
+func (f *UserCredentialsStoreHandleFunc) SetDefaultReturn(r0 basestore.TransactableHandle) {
+	f.SetDefaultHook(func() basestore.TransactableHandle {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *UserCredentialsStoreHandleFunc) PushReturn(r0 *basestore.OldTransactableHandle) {
-	f.PushHook(func() *basestore.OldTransactableHandle {
+func (f *UserCredentialsStoreHandleFunc) PushReturn(r0 basestore.TransactableHandle) {
+	f.PushHook(func() basestore.TransactableHandle {
 		return r0
 	})
 }
 
-func (f *UserCredentialsStoreHandleFunc) nextHook() func() *basestore.OldTransactableHandle {
+func (f *UserCredentialsStoreHandleFunc) nextHook() func() basestore.TransactableHandle {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -35975,7 +35975,7 @@ func (f *UserCredentialsStoreHandleFunc) History() []UserCredentialsStoreHandleF
 type UserCredentialsStoreHandleFuncCall struct {
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 *basestore.OldTransactableHandle
+	Result0 basestore.TransactableHandle
 }
 
 // Args returns an interface slice containing the arguments of this
@@ -36510,7 +36510,7 @@ func NewMockUserEmailsStore() *MockUserEmailsStore {
 			},
 		},
 		HandleFunc: &UserEmailsStoreHandleFunc{
-			defaultHook: func() (r0 *basestore.OldTransactableHandle) {
+			defaultHook: func() (r0 basestore.TransactableHandle) {
 				return
 			},
 		},
@@ -36597,7 +36597,7 @@ func NewStrictMockUserEmailsStore() *MockUserEmailsStore {
 			},
 		},
 		HandleFunc: &UserEmailsStoreHandleFunc{
-			defaultHook: func() *basestore.OldTransactableHandle {
+			defaultHook: func() basestore.TransactableHandle {
 				panic("unexpected invocation of MockUserEmailsStore.Handle")
 			},
 		},
@@ -37485,15 +37485,15 @@ func (c UserEmailsStoreGetVerifiedEmailsFuncCall) Results() []interface{} {
 // UserEmailsStoreHandleFunc describes the behavior when the Handle method
 // of the parent MockUserEmailsStore instance is invoked.
 type UserEmailsStoreHandleFunc struct {
-	defaultHook func() *basestore.OldTransactableHandle
-	hooks       []func() *basestore.OldTransactableHandle
+	defaultHook func() basestore.TransactableHandle
+	hooks       []func() basestore.TransactableHandle
 	history     []UserEmailsStoreHandleFuncCall
 	mutex       sync.Mutex
 }
 
 // Handle delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockUserEmailsStore) Handle() *basestore.OldTransactableHandle {
+func (m *MockUserEmailsStore) Handle() basestore.TransactableHandle {
 	r0 := m.HandleFunc.nextHook()()
 	m.HandleFunc.appendCall(UserEmailsStoreHandleFuncCall{r0})
 	return r0
@@ -37502,7 +37502,7 @@ func (m *MockUserEmailsStore) Handle() *basestore.OldTransactableHandle {
 // SetDefaultHook sets function that is called when the Handle method of the
 // parent MockUserEmailsStore instance is invoked and the hook queue is
 // empty.
-func (f *UserEmailsStoreHandleFunc) SetDefaultHook(hook func() *basestore.OldTransactableHandle) {
+func (f *UserEmailsStoreHandleFunc) SetDefaultHook(hook func() basestore.TransactableHandle) {
 	f.defaultHook = hook
 }
 
@@ -37510,7 +37510,7 @@ func (f *UserEmailsStoreHandleFunc) SetDefaultHook(hook func() *basestore.OldTra
 // Handle method of the parent MockUserEmailsStore instance invokes the hook
 // at the front of the queue and discards it. After the queue is empty, the
 // default hook function is invoked for any future action.
-func (f *UserEmailsStoreHandleFunc) PushHook(hook func() *basestore.OldTransactableHandle) {
+func (f *UserEmailsStoreHandleFunc) PushHook(hook func() basestore.TransactableHandle) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -37518,20 +37518,20 @@ func (f *UserEmailsStoreHandleFunc) PushHook(hook func() *basestore.OldTransacta
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *UserEmailsStoreHandleFunc) SetDefaultReturn(r0 *basestore.OldTransactableHandle) {
-	f.SetDefaultHook(func() *basestore.OldTransactableHandle {
+func (f *UserEmailsStoreHandleFunc) SetDefaultReturn(r0 basestore.TransactableHandle) {
+	f.SetDefaultHook(func() basestore.TransactableHandle {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *UserEmailsStoreHandleFunc) PushReturn(r0 *basestore.OldTransactableHandle) {
-	f.PushHook(func() *basestore.OldTransactableHandle {
+func (f *UserEmailsStoreHandleFunc) PushReturn(r0 basestore.TransactableHandle) {
+	f.PushHook(func() basestore.TransactableHandle {
 		return r0
 	})
 }
 
-func (f *UserEmailsStoreHandleFunc) nextHook() func() *basestore.OldTransactableHandle {
+func (f *UserEmailsStoreHandleFunc) nextHook() func() basestore.TransactableHandle {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -37566,7 +37566,7 @@ func (f *UserEmailsStoreHandleFunc) History() []UserEmailsStoreHandleFuncCall {
 type UserEmailsStoreHandleFuncCall struct {
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 *basestore.OldTransactableHandle
+	Result0 basestore.TransactableHandle
 }
 
 // Args returns an interface slice containing the arguments of this
@@ -38555,7 +38555,7 @@ func NewMockUserExternalAccountsStore() *MockUserExternalAccountsStore {
 			},
 		},
 		HandleFunc: &UserExternalAccountsStoreHandleFunc{
-			defaultHook: func() (r0 *basestore.OldTransactableHandle) {
+			defaultHook: func() (r0 basestore.TransactableHandle) {
 				return
 			},
 		},
@@ -38653,7 +38653,7 @@ func NewStrictMockUserExternalAccountsStore() *MockUserExternalAccountsStore {
 			},
 		},
 		HandleFunc: &UserExternalAccountsStoreHandleFunc{
-			defaultHook: func() *basestore.OldTransactableHandle {
+			defaultHook: func() basestore.TransactableHandle {
 				panic("unexpected invocation of MockUserExternalAccountsStore.Handle")
 			},
 		},
@@ -39548,15 +39548,15 @@ func (c UserExternalAccountsStoreGetFuncCall) Results() []interface{} {
 // Handle method of the parent MockUserExternalAccountsStore instance is
 // invoked.
 type UserExternalAccountsStoreHandleFunc struct {
-	defaultHook func() *basestore.OldTransactableHandle
-	hooks       []func() *basestore.OldTransactableHandle
+	defaultHook func() basestore.TransactableHandle
+	hooks       []func() basestore.TransactableHandle
 	history     []UserExternalAccountsStoreHandleFuncCall
 	mutex       sync.Mutex
 }
 
 // Handle delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockUserExternalAccountsStore) Handle() *basestore.OldTransactableHandle {
+func (m *MockUserExternalAccountsStore) Handle() basestore.TransactableHandle {
 	r0 := m.HandleFunc.nextHook()()
 	m.HandleFunc.appendCall(UserExternalAccountsStoreHandleFuncCall{r0})
 	return r0
@@ -39565,7 +39565,7 @@ func (m *MockUserExternalAccountsStore) Handle() *basestore.OldTransactableHandl
 // SetDefaultHook sets function that is called when the Handle method of the
 // parent MockUserExternalAccountsStore instance is invoked and the hook
 // queue is empty.
-func (f *UserExternalAccountsStoreHandleFunc) SetDefaultHook(hook func() *basestore.OldTransactableHandle) {
+func (f *UserExternalAccountsStoreHandleFunc) SetDefaultHook(hook func() basestore.TransactableHandle) {
 	f.defaultHook = hook
 }
 
@@ -39574,7 +39574,7 @@ func (f *UserExternalAccountsStoreHandleFunc) SetDefaultHook(hook func() *basest
 // invokes the hook at the front of the queue and discards it. After the
 // queue is empty, the default hook function is invoked for any future
 // action.
-func (f *UserExternalAccountsStoreHandleFunc) PushHook(hook func() *basestore.OldTransactableHandle) {
+func (f *UserExternalAccountsStoreHandleFunc) PushHook(hook func() basestore.TransactableHandle) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -39582,20 +39582,20 @@ func (f *UserExternalAccountsStoreHandleFunc) PushHook(hook func() *basestore.Ol
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *UserExternalAccountsStoreHandleFunc) SetDefaultReturn(r0 *basestore.OldTransactableHandle) {
-	f.SetDefaultHook(func() *basestore.OldTransactableHandle {
+func (f *UserExternalAccountsStoreHandleFunc) SetDefaultReturn(r0 basestore.TransactableHandle) {
+	f.SetDefaultHook(func() basestore.TransactableHandle {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *UserExternalAccountsStoreHandleFunc) PushReturn(r0 *basestore.OldTransactableHandle) {
-	f.PushHook(func() *basestore.OldTransactableHandle {
+func (f *UserExternalAccountsStoreHandleFunc) PushReturn(r0 basestore.TransactableHandle) {
+	f.PushHook(func() basestore.TransactableHandle {
 		return r0
 	})
 }
 
-func (f *UserExternalAccountsStoreHandleFunc) nextHook() func() *basestore.OldTransactableHandle {
+func (f *UserExternalAccountsStoreHandleFunc) nextHook() func() basestore.TransactableHandle {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -39631,7 +39631,7 @@ func (f *UserExternalAccountsStoreHandleFunc) History() []UserExternalAccountsSt
 type UserExternalAccountsStoreHandleFuncCall struct {
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 *basestore.OldTransactableHandle
+	Result0 basestore.TransactableHandle
 }
 
 // Args returns an interface slice containing the arguments of this
@@ -40763,7 +40763,7 @@ type MockUserPublicRepoStore struct {
 func NewMockUserPublicRepoStore() *MockUserPublicRepoStore {
 	return &MockUserPublicRepoStore{
 		HandleFunc: &UserPublicRepoStoreHandleFunc{
-			defaultHook: func() (r0 *basestore.OldTransactableHandle) {
+			defaultHook: func() (r0 basestore.TransactableHandle) {
 				return
 			},
 		},
@@ -40791,7 +40791,7 @@ func NewMockUserPublicRepoStore() *MockUserPublicRepoStore {
 func NewStrictMockUserPublicRepoStore() *MockUserPublicRepoStore {
 	return &MockUserPublicRepoStore{
 		HandleFunc: &UserPublicRepoStoreHandleFunc{
-			defaultHook: func() *basestore.OldTransactableHandle {
+			defaultHook: func() basestore.TransactableHandle {
 				panic("unexpected invocation of MockUserPublicRepoStore.Handle")
 			},
 		},
@@ -40836,15 +40836,15 @@ func NewMockUserPublicRepoStoreFrom(i UserPublicRepoStore) *MockUserPublicRepoSt
 // UserPublicRepoStoreHandleFunc describes the behavior when the Handle
 // method of the parent MockUserPublicRepoStore instance is invoked.
 type UserPublicRepoStoreHandleFunc struct {
-	defaultHook func() *basestore.OldTransactableHandle
-	hooks       []func() *basestore.OldTransactableHandle
+	defaultHook func() basestore.TransactableHandle
+	hooks       []func() basestore.TransactableHandle
 	history     []UserPublicRepoStoreHandleFuncCall
 	mutex       sync.Mutex
 }
 
 // Handle delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockUserPublicRepoStore) Handle() *basestore.OldTransactableHandle {
+func (m *MockUserPublicRepoStore) Handle() basestore.TransactableHandle {
 	r0 := m.HandleFunc.nextHook()()
 	m.HandleFunc.appendCall(UserPublicRepoStoreHandleFuncCall{r0})
 	return r0
@@ -40853,7 +40853,7 @@ func (m *MockUserPublicRepoStore) Handle() *basestore.OldTransactableHandle {
 // SetDefaultHook sets function that is called when the Handle method of the
 // parent MockUserPublicRepoStore instance is invoked and the hook queue is
 // empty.
-func (f *UserPublicRepoStoreHandleFunc) SetDefaultHook(hook func() *basestore.OldTransactableHandle) {
+func (f *UserPublicRepoStoreHandleFunc) SetDefaultHook(hook func() basestore.TransactableHandle) {
 	f.defaultHook = hook
 }
 
@@ -40861,7 +40861,7 @@ func (f *UserPublicRepoStoreHandleFunc) SetDefaultHook(hook func() *basestore.Ol
 // Handle method of the parent MockUserPublicRepoStore instance invokes the
 // hook at the front of the queue and discards it. After the queue is empty,
 // the default hook function is invoked for any future action.
-func (f *UserPublicRepoStoreHandleFunc) PushHook(hook func() *basestore.OldTransactableHandle) {
+func (f *UserPublicRepoStoreHandleFunc) PushHook(hook func() basestore.TransactableHandle) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -40869,20 +40869,20 @@ func (f *UserPublicRepoStoreHandleFunc) PushHook(hook func() *basestore.OldTrans
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *UserPublicRepoStoreHandleFunc) SetDefaultReturn(r0 *basestore.OldTransactableHandle) {
-	f.SetDefaultHook(func() *basestore.OldTransactableHandle {
+func (f *UserPublicRepoStoreHandleFunc) SetDefaultReturn(r0 basestore.TransactableHandle) {
+	f.SetDefaultHook(func() basestore.TransactableHandle {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *UserPublicRepoStoreHandleFunc) PushReturn(r0 *basestore.OldTransactableHandle) {
-	f.PushHook(func() *basestore.OldTransactableHandle {
+func (f *UserPublicRepoStoreHandleFunc) PushReturn(r0 basestore.TransactableHandle) {
+	f.PushHook(func() basestore.TransactableHandle {
 		return r0
 	})
 }
 
-func (f *UserPublicRepoStoreHandleFunc) nextHook() func() *basestore.OldTransactableHandle {
+func (f *UserPublicRepoStoreHandleFunc) nextHook() func() basestore.TransactableHandle {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -40917,7 +40917,7 @@ func (f *UserPublicRepoStoreHandleFunc) History() []UserPublicRepoStoreHandleFun
 type UserPublicRepoStoreHandleFuncCall struct {
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 *basestore.OldTransactableHandle
+	Result0 basestore.TransactableHandle
 }
 
 // Args returns an interface slice containing the arguments of this
@@ -45431,7 +45431,7 @@ func NewMockWebhookLogStore() *MockWebhookLogStore {
 			},
 		},
 		HandleFunc: &WebhookLogStoreHandleFunc{
-			defaultHook: func() (r0 *basestore.OldTransactableHandle) {
+			defaultHook: func() (r0 basestore.TransactableHandle) {
 				return
 			},
 		},
@@ -45468,7 +45468,7 @@ func NewStrictMockWebhookLogStore() *MockWebhookLogStore {
 			},
 		},
 		HandleFunc: &WebhookLogStoreHandleFunc{
-			defaultHook: func() *basestore.OldTransactableHandle {
+			defaultHook: func() basestore.TransactableHandle {
 				panic("unexpected invocation of MockWebhookLogStore.Handle")
 			},
 		},
@@ -45935,15 +45935,15 @@ func (c WebhookLogStoreGetByIDFuncCall) Results() []interface{} {
 // WebhookLogStoreHandleFunc describes the behavior when the Handle method
 // of the parent MockWebhookLogStore instance is invoked.
 type WebhookLogStoreHandleFunc struct {
-	defaultHook func() *basestore.OldTransactableHandle
-	hooks       []func() *basestore.OldTransactableHandle
+	defaultHook func() basestore.TransactableHandle
+	hooks       []func() basestore.TransactableHandle
 	history     []WebhookLogStoreHandleFuncCall
 	mutex       sync.Mutex
 }
 
 // Handle delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockWebhookLogStore) Handle() *basestore.OldTransactableHandle {
+func (m *MockWebhookLogStore) Handle() basestore.TransactableHandle {
 	r0 := m.HandleFunc.nextHook()()
 	m.HandleFunc.appendCall(WebhookLogStoreHandleFuncCall{r0})
 	return r0
@@ -45952,7 +45952,7 @@ func (m *MockWebhookLogStore) Handle() *basestore.OldTransactableHandle {
 // SetDefaultHook sets function that is called when the Handle method of the
 // parent MockWebhookLogStore instance is invoked and the hook queue is
 // empty.
-func (f *WebhookLogStoreHandleFunc) SetDefaultHook(hook func() *basestore.OldTransactableHandle) {
+func (f *WebhookLogStoreHandleFunc) SetDefaultHook(hook func() basestore.TransactableHandle) {
 	f.defaultHook = hook
 }
 
@@ -45960,7 +45960,7 @@ func (f *WebhookLogStoreHandleFunc) SetDefaultHook(hook func() *basestore.OldTra
 // Handle method of the parent MockWebhookLogStore instance invokes the hook
 // at the front of the queue and discards it. After the queue is empty, the
 // default hook function is invoked for any future action.
-func (f *WebhookLogStoreHandleFunc) PushHook(hook func() *basestore.OldTransactableHandle) {
+func (f *WebhookLogStoreHandleFunc) PushHook(hook func() basestore.TransactableHandle) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -45968,20 +45968,20 @@ func (f *WebhookLogStoreHandleFunc) PushHook(hook func() *basestore.OldTransacta
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *WebhookLogStoreHandleFunc) SetDefaultReturn(r0 *basestore.OldTransactableHandle) {
-	f.SetDefaultHook(func() *basestore.OldTransactableHandle {
+func (f *WebhookLogStoreHandleFunc) SetDefaultReturn(r0 basestore.TransactableHandle) {
+	f.SetDefaultHook(func() basestore.TransactableHandle {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *WebhookLogStoreHandleFunc) PushReturn(r0 *basestore.OldTransactableHandle) {
-	f.PushHook(func() *basestore.OldTransactableHandle {
+func (f *WebhookLogStoreHandleFunc) PushReturn(r0 basestore.TransactableHandle) {
+	f.PushHook(func() basestore.TransactableHandle {
 		return r0
 	})
 }
 
-func (f *WebhookLogStoreHandleFunc) nextHook() func() *basestore.OldTransactableHandle {
+func (f *WebhookLogStoreHandleFunc) nextHook() func() basestore.TransactableHandle {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -46016,7 +46016,7 @@ func (f *WebhookLogStoreHandleFunc) History() []WebhookLogStoreHandleFuncCall {
 type WebhookLogStoreHandleFuncCall struct {
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 *basestore.OldTransactableHandle
+	Result0 basestore.TransactableHandle
 }
 
 // Args returns an interface slice containing the arguments of this

--- a/internal/repos/mocks_temp.go
+++ b/internal/repos/mocks_temp.go
@@ -136,7 +136,7 @@ func NewMockStore() *MockStore {
 			},
 		},
 		HandleFunc: &StoreHandleFunc{
-			defaultHook: func() (r0 *basestore.TransactableHandle) {
+			defaultHook: func() (r0 *basestore.OldTransactableHandle) {
 				return
 			},
 		},
@@ -238,7 +238,7 @@ func NewStrictMockStore() *MockStore {
 			},
 		},
 		HandleFunc: &StoreHandleFunc{
-			defaultHook: func() *basestore.TransactableHandle {
+			defaultHook: func() *basestore.OldTransactableHandle {
 				panic("unexpected invocation of MockStore.Handle")
 			},
 		},
@@ -1312,15 +1312,15 @@ func (c StoreGitserverReposStoreFuncCall) Results() []interface{} {
 // StoreHandleFunc describes the behavior when the Handle method of the
 // parent MockStore instance is invoked.
 type StoreHandleFunc struct {
-	defaultHook func() *basestore.TransactableHandle
-	hooks       []func() *basestore.TransactableHandle
+	defaultHook func() *basestore.OldTransactableHandle
+	hooks       []func() *basestore.OldTransactableHandle
 	history     []StoreHandleFuncCall
 	mutex       sync.Mutex
 }
 
 // Handle delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockStore) Handle() *basestore.TransactableHandle {
+func (m *MockStore) Handle() *basestore.OldTransactableHandle {
 	r0 := m.HandleFunc.nextHook()()
 	m.HandleFunc.appendCall(StoreHandleFuncCall{r0})
 	return r0
@@ -1328,7 +1328,7 @@ func (m *MockStore) Handle() *basestore.TransactableHandle {
 
 // SetDefaultHook sets function that is called when the Handle method of the
 // parent MockStore instance is invoked and the hook queue is empty.
-func (f *StoreHandleFunc) SetDefaultHook(hook func() *basestore.TransactableHandle) {
+func (f *StoreHandleFunc) SetDefaultHook(hook func() *basestore.OldTransactableHandle) {
 	f.defaultHook = hook
 }
 
@@ -1336,7 +1336,7 @@ func (f *StoreHandleFunc) SetDefaultHook(hook func() *basestore.TransactableHand
 // Handle method of the parent MockStore instance invokes the hook at the
 // front of the queue and discards it. After the queue is empty, the default
 // hook function is invoked for any future action.
-func (f *StoreHandleFunc) PushHook(hook func() *basestore.TransactableHandle) {
+func (f *StoreHandleFunc) PushHook(hook func() *basestore.OldTransactableHandle) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -1344,20 +1344,20 @@ func (f *StoreHandleFunc) PushHook(hook func() *basestore.TransactableHandle) {
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *StoreHandleFunc) SetDefaultReturn(r0 *basestore.TransactableHandle) {
-	f.SetDefaultHook(func() *basestore.TransactableHandle {
+func (f *StoreHandleFunc) SetDefaultReturn(r0 *basestore.OldTransactableHandle) {
+	f.SetDefaultHook(func() *basestore.OldTransactableHandle {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *StoreHandleFunc) PushReturn(r0 *basestore.TransactableHandle) {
-	f.PushHook(func() *basestore.TransactableHandle {
+func (f *StoreHandleFunc) PushReturn(r0 *basestore.OldTransactableHandle) {
+	f.PushHook(func() *basestore.OldTransactableHandle {
 		return r0
 	})
 }
 
-func (f *StoreHandleFunc) nextHook() func() *basestore.TransactableHandle {
+func (f *StoreHandleFunc) nextHook() func() *basestore.OldTransactableHandle {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -1392,7 +1392,7 @@ func (f *StoreHandleFunc) History() []StoreHandleFuncCall {
 type StoreHandleFuncCall struct {
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 *basestore.TransactableHandle
+	Result0 *basestore.OldTransactableHandle
 }
 
 // Args returns an interface slice containing the arguments of this

--- a/internal/repos/mocks_temp.go
+++ b/internal/repos/mocks_temp.go
@@ -136,7 +136,7 @@ func NewMockStore() *MockStore {
 			},
 		},
 		HandleFunc: &StoreHandleFunc{
-			defaultHook: func() (r0 *basestore.OldTransactableHandle) {
+			defaultHook: func() (r0 basestore.TransactableHandle) {
 				return
 			},
 		},
@@ -238,7 +238,7 @@ func NewStrictMockStore() *MockStore {
 			},
 		},
 		HandleFunc: &StoreHandleFunc{
-			defaultHook: func() *basestore.OldTransactableHandle {
+			defaultHook: func() basestore.TransactableHandle {
 				panic("unexpected invocation of MockStore.Handle")
 			},
 		},
@@ -1312,15 +1312,15 @@ func (c StoreGitserverReposStoreFuncCall) Results() []interface{} {
 // StoreHandleFunc describes the behavior when the Handle method of the
 // parent MockStore instance is invoked.
 type StoreHandleFunc struct {
-	defaultHook func() *basestore.OldTransactableHandle
-	hooks       []func() *basestore.OldTransactableHandle
+	defaultHook func() basestore.TransactableHandle
+	hooks       []func() basestore.TransactableHandle
 	history     []StoreHandleFuncCall
 	mutex       sync.Mutex
 }
 
 // Handle delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockStore) Handle() *basestore.OldTransactableHandle {
+func (m *MockStore) Handle() basestore.TransactableHandle {
 	r0 := m.HandleFunc.nextHook()()
 	m.HandleFunc.appendCall(StoreHandleFuncCall{r0})
 	return r0
@@ -1328,7 +1328,7 @@ func (m *MockStore) Handle() *basestore.OldTransactableHandle {
 
 // SetDefaultHook sets function that is called when the Handle method of the
 // parent MockStore instance is invoked and the hook queue is empty.
-func (f *StoreHandleFunc) SetDefaultHook(hook func() *basestore.OldTransactableHandle) {
+func (f *StoreHandleFunc) SetDefaultHook(hook func() basestore.TransactableHandle) {
 	f.defaultHook = hook
 }
 
@@ -1336,7 +1336,7 @@ func (f *StoreHandleFunc) SetDefaultHook(hook func() *basestore.OldTransactableH
 // Handle method of the parent MockStore instance invokes the hook at the
 // front of the queue and discards it. After the queue is empty, the default
 // hook function is invoked for any future action.
-func (f *StoreHandleFunc) PushHook(hook func() *basestore.OldTransactableHandle) {
+func (f *StoreHandleFunc) PushHook(hook func() basestore.TransactableHandle) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -1344,20 +1344,20 @@ func (f *StoreHandleFunc) PushHook(hook func() *basestore.OldTransactableHandle)
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *StoreHandleFunc) SetDefaultReturn(r0 *basestore.OldTransactableHandle) {
-	f.SetDefaultHook(func() *basestore.OldTransactableHandle {
+func (f *StoreHandleFunc) SetDefaultReturn(r0 basestore.TransactableHandle) {
+	f.SetDefaultHook(func() basestore.TransactableHandle {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *StoreHandleFunc) PushReturn(r0 *basestore.OldTransactableHandle) {
-	f.PushHook(func() *basestore.OldTransactableHandle {
+func (f *StoreHandleFunc) PushReturn(r0 basestore.TransactableHandle) {
+	f.PushHook(func() basestore.TransactableHandle {
 		return r0
 	})
 }
 
-func (f *StoreHandleFunc) nextHook() func() *basestore.OldTransactableHandle {
+func (f *StoreHandleFunc) nextHook() func() basestore.TransactableHandle {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -1392,7 +1392,7 @@ func (f *StoreHandleFunc) History() []StoreHandleFuncCall {
 type StoreHandleFuncCall struct {
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 *basestore.OldTransactableHandle
+	Result0 basestore.TransactableHandle
 }
 
 // Args returns an interface slice containing the arguments of this

--- a/internal/workerutil/dbworker/store/mocks/mocks_temp.go
+++ b/internal/workerutil/dbworker/store/mocks/mocks_temp.go
@@ -78,7 +78,7 @@ func NewMockStore() *MockStore {
 			},
 		},
 		HandleFunc: &StoreHandleFunc{
-			defaultHook: func() (r0 *basestore.OldTransactableHandle) {
+			defaultHook: func() (r0 basestore.TransactableHandle) {
 				return
 			},
 		},
@@ -150,7 +150,7 @@ func NewStrictMockStore() *MockStore {
 			},
 		},
 		HandleFunc: &StoreHandleFunc{
-			defaultHook: func() *basestore.OldTransactableHandle {
+			defaultHook: func() basestore.TransactableHandle {
 				panic("unexpected invocation of MockStore.Handle")
 			},
 		},
@@ -483,15 +483,15 @@ func (c StoreDequeueFuncCall) Results() []interface{} {
 // StoreHandleFunc describes the behavior when the Handle method of the
 // parent MockStore instance is invoked.
 type StoreHandleFunc struct {
-	defaultHook func() *basestore.OldTransactableHandle
-	hooks       []func() *basestore.OldTransactableHandle
+	defaultHook func() basestore.TransactableHandle
+	hooks       []func() basestore.TransactableHandle
 	history     []StoreHandleFuncCall
 	mutex       sync.Mutex
 }
 
 // Handle delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockStore) Handle() *basestore.OldTransactableHandle {
+func (m *MockStore) Handle() basestore.TransactableHandle {
 	r0 := m.HandleFunc.nextHook()()
 	m.HandleFunc.appendCall(StoreHandleFuncCall{r0})
 	return r0
@@ -499,7 +499,7 @@ func (m *MockStore) Handle() *basestore.OldTransactableHandle {
 
 // SetDefaultHook sets function that is called when the Handle method of the
 // parent MockStore instance is invoked and the hook queue is empty.
-func (f *StoreHandleFunc) SetDefaultHook(hook func() *basestore.OldTransactableHandle) {
+func (f *StoreHandleFunc) SetDefaultHook(hook func() basestore.TransactableHandle) {
 	f.defaultHook = hook
 }
 
@@ -507,7 +507,7 @@ func (f *StoreHandleFunc) SetDefaultHook(hook func() *basestore.OldTransactableH
 // Handle method of the parent MockStore instance invokes the hook at the
 // front of the queue and discards it. After the queue is empty, the default
 // hook function is invoked for any future action.
-func (f *StoreHandleFunc) PushHook(hook func() *basestore.OldTransactableHandle) {
+func (f *StoreHandleFunc) PushHook(hook func() basestore.TransactableHandle) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -515,20 +515,20 @@ func (f *StoreHandleFunc) PushHook(hook func() *basestore.OldTransactableHandle)
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *StoreHandleFunc) SetDefaultReturn(r0 *basestore.OldTransactableHandle) {
-	f.SetDefaultHook(func() *basestore.OldTransactableHandle {
+func (f *StoreHandleFunc) SetDefaultReturn(r0 basestore.TransactableHandle) {
+	f.SetDefaultHook(func() basestore.TransactableHandle {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *StoreHandleFunc) PushReturn(r0 *basestore.OldTransactableHandle) {
-	f.PushHook(func() *basestore.OldTransactableHandle {
+func (f *StoreHandleFunc) PushReturn(r0 basestore.TransactableHandle) {
+	f.PushHook(func() basestore.TransactableHandle {
 		return r0
 	})
 }
 
-func (f *StoreHandleFunc) nextHook() func() *basestore.OldTransactableHandle {
+func (f *StoreHandleFunc) nextHook() func() basestore.TransactableHandle {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -563,7 +563,7 @@ func (f *StoreHandleFunc) History() []StoreHandleFuncCall {
 type StoreHandleFuncCall struct {
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 *basestore.OldTransactableHandle
+	Result0 basestore.TransactableHandle
 }
 
 // Args returns an interface slice containing the arguments of this

--- a/internal/workerutil/dbworker/store/mocks/mocks_temp.go
+++ b/internal/workerutil/dbworker/store/mocks/mocks_temp.go
@@ -78,7 +78,7 @@ func NewMockStore() *MockStore {
 			},
 		},
 		HandleFunc: &StoreHandleFunc{
-			defaultHook: func() (r0 *basestore.TransactableHandle) {
+			defaultHook: func() (r0 *basestore.OldTransactableHandle) {
 				return
 			},
 		},
@@ -150,7 +150,7 @@ func NewStrictMockStore() *MockStore {
 			},
 		},
 		HandleFunc: &StoreHandleFunc{
-			defaultHook: func() *basestore.TransactableHandle {
+			defaultHook: func() *basestore.OldTransactableHandle {
 				panic("unexpected invocation of MockStore.Handle")
 			},
 		},
@@ -483,15 +483,15 @@ func (c StoreDequeueFuncCall) Results() []interface{} {
 // StoreHandleFunc describes the behavior when the Handle method of the
 // parent MockStore instance is invoked.
 type StoreHandleFunc struct {
-	defaultHook func() *basestore.TransactableHandle
-	hooks       []func() *basestore.TransactableHandle
+	defaultHook func() *basestore.OldTransactableHandle
+	hooks       []func() *basestore.OldTransactableHandle
 	history     []StoreHandleFuncCall
 	mutex       sync.Mutex
 }
 
 // Handle delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockStore) Handle() *basestore.TransactableHandle {
+func (m *MockStore) Handle() *basestore.OldTransactableHandle {
 	r0 := m.HandleFunc.nextHook()()
 	m.HandleFunc.appendCall(StoreHandleFuncCall{r0})
 	return r0
@@ -499,7 +499,7 @@ func (m *MockStore) Handle() *basestore.TransactableHandle {
 
 // SetDefaultHook sets function that is called when the Handle method of the
 // parent MockStore instance is invoked and the hook queue is empty.
-func (f *StoreHandleFunc) SetDefaultHook(hook func() *basestore.TransactableHandle) {
+func (f *StoreHandleFunc) SetDefaultHook(hook func() *basestore.OldTransactableHandle) {
 	f.defaultHook = hook
 }
 
@@ -507,7 +507,7 @@ func (f *StoreHandleFunc) SetDefaultHook(hook func() *basestore.TransactableHand
 // Handle method of the parent MockStore instance invokes the hook at the
 // front of the queue and discards it. After the queue is empty, the default
 // hook function is invoked for any future action.
-func (f *StoreHandleFunc) PushHook(hook func() *basestore.TransactableHandle) {
+func (f *StoreHandleFunc) PushHook(hook func() *basestore.OldTransactableHandle) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -515,20 +515,20 @@ func (f *StoreHandleFunc) PushHook(hook func() *basestore.TransactableHandle) {
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *StoreHandleFunc) SetDefaultReturn(r0 *basestore.TransactableHandle) {
-	f.SetDefaultHook(func() *basestore.TransactableHandle {
+func (f *StoreHandleFunc) SetDefaultReturn(r0 *basestore.OldTransactableHandle) {
+	f.SetDefaultHook(func() *basestore.OldTransactableHandle {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *StoreHandleFunc) PushReturn(r0 *basestore.TransactableHandle) {
-	f.PushHook(func() *basestore.TransactableHandle {
+func (f *StoreHandleFunc) PushReturn(r0 *basestore.OldTransactableHandle) {
+	f.PushHook(func() *basestore.OldTransactableHandle {
 		return r0
 	})
 }
 
-func (f *StoreHandleFunc) nextHook() func() *basestore.TransactableHandle {
+func (f *StoreHandleFunc) nextHook() func() *basestore.OldTransactableHandle {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -563,7 +563,7 @@ func (f *StoreHandleFunc) History() []StoreHandleFuncCall {
 type StoreHandleFuncCall struct {
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 *basestore.TransactableHandle
+	Result0 *basestore.OldTransactableHandle
 }
 
 // Args returns an interface slice containing the arguments of this

--- a/internal/workerutil/dbworker/store/store.go
+++ b/internal/workerutil/dbworker/store/store.go
@@ -267,15 +267,15 @@ type Options struct {
 type RecordScanFn func(rows *sql.Rows, err error) (workerutil.Record, bool, error)
 
 // New creates a new store with the given database handle and options.
-func New(handle *basestore.TransactableHandle, options Options) Store {
+func New(handle *basestore.OldTransactableHandle, options Options) Store {
 	return NewWithMetrics(handle, options, &observation.TestContext)
 }
 
-func NewWithMetrics(handle *basestore.TransactableHandle, options Options, observationContext *observation.Context) Store {
+func NewWithMetrics(handle *basestore.OldTransactableHandle, options Options, observationContext *observation.Context) Store {
 	return newStore(handle, options, observationContext)
 }
 
-func newStore(handle *basestore.TransactableHandle, options Options, observationContext *observation.Context) *store {
+func newStore(handle *basestore.OldTransactableHandle, options Options, observationContext *observation.Context) *store {
 	if options.Name == "" {
 		panic("no name supplied to github.com/sourcegraph/sourcegraph/internal/dbworker/store:newStore")
 	}

--- a/internal/workerutil/dbworker/store/store.go
+++ b/internal/workerutil/dbworker/store/store.go
@@ -267,15 +267,15 @@ type Options struct {
 type RecordScanFn func(rows *sql.Rows, err error) (workerutil.Record, bool, error)
 
 // New creates a new store with the given database handle and options.
-func New(handle *basestore.OldTransactableHandle, options Options) Store {
+func New(handle basestore.TransactableHandle, options Options) Store {
 	return NewWithMetrics(handle, options, &observation.TestContext)
 }
 
-func NewWithMetrics(handle *basestore.OldTransactableHandle, options Options, observationContext *observation.Context) Store {
+func NewWithMetrics(handle basestore.TransactableHandle, options Options, observationContext *observation.Context) Store {
 	return newStore(handle, options, observationContext)
 }
 
-func newStore(handle *basestore.OldTransactableHandle, options Options, observationContext *observation.Context) *store {
+func newStore(handle basestore.TransactableHandle, options Options, observationContext *observation.Context) *store {
 	if options.Name == "" {
 		panic("no name supplied to github.com/sourcegraph/sourcegraph/internal/dbworker/store:newStore")
 	}

--- a/migrations/codeinsights/squashed.sql
+++ b/migrations/codeinsights/squashed.sql
@@ -514,6 +514,3 @@ ALTER TABLE ONLY series_points
 
 ALTER TABLE ONLY series_points
     ADD CONSTRAINT series_points_repo_name_id_fkey FOREIGN KEY (repo_name_id) REFERENCES repo_names(id) ON DELETE CASCADE DEFERRABLE;
-
-REVOKE USAGE ON SCHEMA public FROM PUBLIC;
-GRANT ALL ON SCHEMA public TO PUBLIC;

--- a/migrations/codeinsights/squashed.sql
+++ b/migrations/codeinsights/squashed.sql
@@ -514,3 +514,6 @@ ALTER TABLE ONLY series_points
 
 ALTER TABLE ONLY series_points
     ADD CONSTRAINT series_points_repo_name_id_fkey FOREIGN KEY (repo_name_id) REFERENCES repo_names(id) ON DELETE CASCADE DEFERRABLE;
+
+REVOKE USAGE ON SCHEMA public FROM PUBLIC;
+GRANT ALL ON SCHEMA public TO PUBLIC;

--- a/migrations/codeintel/squashed.sql
+++ b/migrations/codeintel/squashed.sql
@@ -1070,6 +1070,9 @@ ALTER TABLE ONLY lsif_data_docs_search_public
 ALTER TABLE ONLY lsif_data_docs_search_public
     ADD CONSTRAINT lsif_data_docs_search_public_tags_id_fk FOREIGN KEY (tags_id) REFERENCES lsif_data_docs_search_tags_public(id);
 
+REVOKE USAGE ON SCHEMA public FROM PUBLIC;
+GRANT ALL ON SCHEMA public TO PUBLIC;
+
 INSERT INTO lsif_data_apidocs_num_dumps VALUES (0);
 INSERT INTO lsif_data_apidocs_num_dumps_indexed VALUES (0);
 INSERT INTO lsif_data_apidocs_num_pages VALUES (0);

--- a/migrations/codeintel/squashed.sql
+++ b/migrations/codeintel/squashed.sql
@@ -1070,9 +1070,6 @@ ALTER TABLE ONLY lsif_data_docs_search_public
 ALTER TABLE ONLY lsif_data_docs_search_public
     ADD CONSTRAINT lsif_data_docs_search_public_tags_id_fk FOREIGN KEY (tags_id) REFERENCES lsif_data_docs_search_tags_public(id);
 
-REVOKE USAGE ON SCHEMA public FROM PUBLIC;
-GRANT ALL ON SCHEMA public TO PUBLIC;
-
 INSERT INTO lsif_data_apidocs_num_dumps VALUES (0);
 INSERT INTO lsif_data_apidocs_num_dumps_indexed VALUES (0);
 INSERT INTO lsif_data_apidocs_num_pages VALUES (0);

--- a/migrations/frontend/squashed.sql
+++ b/migrations/frontend/squashed.sql
@@ -4134,9 +4134,6 @@ ALTER TABLE ONLY user_public_repos
 ALTER TABLE ONLY webhook_logs
     ADD CONSTRAINT webhook_logs_external_service_id_fkey FOREIGN KEY (external_service_id) REFERENCES external_services(id) ON UPDATE CASCADE ON DELETE CASCADE;
 
-REVOKE USAGE ON SCHEMA public FROM PUBLIC;
-GRANT ALL ON SCHEMA public TO PUBLIC;
-
 INSERT INTO out_of_band_migrations VALUES (3, 'core-application', 'frontend-db.external-services', 'Encrypt configuration', 0, '2021-10-08 16:09:36.889968+00', NULL, true, false, false, 3, 26, NULL, NULL, '{}');
 INSERT INTO out_of_band_migrations VALUES (6, 'core-application', 'frontend-db.external-accounts', 'Encrypt auth data', 0, '2021-10-08 16:09:36.986936+00', NULL, true, false, false, 3, 26, NULL, NULL, '{}');
 INSERT INTO out_of_band_migrations VALUES (1, 'code-intelligence', 'codeintel-db.lsif_data_documents', 'Populate num_diagnostics from gob-encoded payload', 0, '2021-06-03 23:21:34.031614+00', NULL, true, false, true, 3, 25, NULL, NULL, '{}');

--- a/migrations/frontend/squashed.sql
+++ b/migrations/frontend/squashed.sql
@@ -4134,6 +4134,9 @@ ALTER TABLE ONLY user_public_repos
 ALTER TABLE ONLY webhook_logs
     ADD CONSTRAINT webhook_logs_external_service_id_fkey FOREIGN KEY (external_service_id) REFERENCES external_services(id) ON UPDATE CASCADE ON DELETE CASCADE;
 
+REVOKE USAGE ON SCHEMA public FROM PUBLIC;
+GRANT ALL ON SCHEMA public TO PUBLIC;
+
 INSERT INTO out_of_band_migrations VALUES (3, 'core-application', 'frontend-db.external-services', 'Encrypt configuration', 0, '2021-10-08 16:09:36.889968+00', NULL, true, false, false, 3, 26, NULL, NULL, '{}');
 INSERT INTO out_of_band_migrations VALUES (6, 'core-application', 'frontend-db.external-accounts', 'Encrypt auth data', 0, '2021-10-08 16:09:36.986936+00', NULL, true, false, false, 3, 26, NULL, NULL, '{}');
 INSERT INTO out_of_band_migrations VALUES (1, 'code-intelligence', 'codeintel-db.lsif_data_documents', 'Populate num_diagnostics from gob-encoded payload', 0, '2021-06-03 23:21:34.031614+00', NULL, true, false, true, 3, 25, NULL, NULL, '{}');


### PR DESCRIPTION
This converts `TransactableHandle` to an interface and mints three new implementors of the interface: `dbHandle`, `txHandle`, and `savepointHandle`. 

The general concept here is to create a `TransactableHandle` at startup, then it's a completely opaque type (not strictly yet, but that's the goal). Then, `dbHandle.Transact()` returns `txHandle`, `txHandle.Transact()` returns `savepointHandle`, and `savepointHandle.Transact()` returns another `savepointHandle`. 

This design allows us to maintain concrete access to the underlying `*sql.DB` and `sql.Tx` handles while still providing the opportunity to mock the handle. Additionally, this design completely removes all the required interface casting, unwrapping, and mutation that has been a frequent cause of headaches for people looking at this code (me in particular). 

Another thing this will enable is reporting when a transaction is used concurrently. Previously, we would get a random selection of `conn busy`, `bad connection`, or a panic that was very difficult to debug. This will allow me to lock a transaction during execution and report when a caller tries to use a transaction concurrently. 

The new handle types are not constructible yet (unexported and not returned by any public methods). This is intentional because I want this PR to be generally about the design of the new handles and not about implementing their usage. I will migrate tests when I start using them.

Stacked on #37056 

## Test plan

The new types are unused. Depending on unit tests to verify the correctness of the `gopls` renames.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
