### PR TITLE
search: compose lucky rules for lang, type, unordered

### DIFF
--- a/internal/search/job/jobutil/feeling_lucky_search_job.go
+++ b/internal/search/job/jobutil/feeling_lucky_search_job.go
@@ -200,12 +200,28 @@ var rules = []rule{
 		transform:   transform{unquotePatterns},
 	},
 	{
+		description: "apply search type and language filter for patterns",
+		transform:   transform{typePatterns, langPatterns},
+	},
+	{
 		description: "apply search type for pattern",
 		transform:   transform{typePatterns},
 	},
 	{
 		description: "apply language filter for pattern",
 		transform:   transform{langPatterns},
+	},
+	{
+		description: "apply search type and language filter for patterns with AND patterns",
+		transform:   transform{typePatterns, langPatterns, unorderedPatterns},
+	},
+	{
+		description: "apply search type with AND patterns",
+		transform:   transform{typePatterns, unorderedPatterns},
+	},
+	{
+		description: "apply language filter with AND patterns",
+		transform:   transform{langPatterns, unorderedPatterns},
 	},
 	{
 		description: "AND patterns together",
@@ -368,7 +384,12 @@ func langPatterns(b query.Basic) *query.Basic {
 
 	var pattern query.Node
 	if len(newPattern) > 0 {
-		pattern = newPattern[0]
+		// Process concat nodes
+		nodes, err := query.Sequence(query.For(query.SearchTypeLiteralDefault))(newPattern)
+		if err != nil {
+			return nil
+		}
+		pattern = nodes[0] // guaranteed root at first node
 	}
 
 	return &query.Basic{

--- a/internal/search/job/jobutil/feeling_lucky_search_job_test.go
+++ b/internal/search/job/jobutil/feeling_lucky_search_job_test.go
@@ -73,4 +73,8 @@ func TestNewFeelingLuckySearchJob(t *testing.T) {
 	t.Run("pattern as type with expression", func(t *testing.T) {
 		autogold.Equal(t, autogold.Raw(test(`context:global code or monitor commit`)))
 	})
+
+	t.Run("type and lang multi rule", func(t *testing.T) {
+		autogold.Equal(t, autogold.Raw(test(`context:global go commit monitor code`)))
+	})
 }

--- a/internal/search/job/jobutil/testdata/TestNewFeelingLuckySearchJob/pattern_as_type_multi_patterns.golden
+++ b/internal/search/job/jobutil/testdata/TestNewFeelingLuckySearchJob/pattern_as_type_multi_patterns.golden
@@ -14,6 +14,16 @@
       "GeneratedSearchJob": {
         "Child": {},
         "ProposedQuery": {
+          "Description": "apply search type with AND patterns",
+          "Query": "context:global type:commit (code AND monitor)",
+          "PatternType": 1
+        }
+      }
+    },
+    {
+      "GeneratedSearchJob": {
+        "Child": {},
+        "ProposedQuery": {
           "Description": "AND patterns together",
           "Query": "context:global (code AND monitor AND commit)",
           "PatternType": 1

--- a/internal/search/job/jobutil/testdata/TestNewFeelingLuckySearchJob/type_and_lang_multi_rule.golden
+++ b/internal/search/job/jobutil/testdata/TestNewFeelingLuckySearchJob/type_and_lang_multi_rule.golden
@@ -1,0 +1,74 @@
+{
+  "OR": [
+    {
+      "GeneratedSearchJob": {
+        "Child": {},
+        "ProposedQuery": {
+          "Description": "apply search type and language filter for patterns",
+          "Query": "context:global type:commit lang:Go monitor code",
+          "PatternType": 1
+        }
+      }
+    },
+    {
+      "GeneratedSearchJob": {
+        "Child": {},
+        "ProposedQuery": {
+          "Description": "apply search type for pattern",
+          "Query": "context:global type:commit go monitor code",
+          "PatternType": 1
+        }
+      }
+    },
+    {
+      "GeneratedSearchJob": {
+        "Child": {},
+        "ProposedQuery": {
+          "Description": "apply language filter for pattern",
+          "Query": "context:global lang:Go commit monitor code",
+          "PatternType": 1
+        }
+      }
+    },
+    {
+      "GeneratedSearchJob": {
+        "Child": {},
+        "ProposedQuery": {
+          "Description": "apply search type and language filter for patterns with AND patterns",
+          "Query": "context:global type:commit lang:Go (monitor AND code)",
+          "PatternType": 1
+        }
+      }
+    },
+    {
+      "GeneratedSearchJob": {
+        "Child": {},
+        "ProposedQuery": {
+          "Description": "apply search type with AND patterns",
+          "Query": "context:global type:commit (go AND monitor AND code)",
+          "PatternType": 1
+        }
+      }
+    },
+    {
+      "GeneratedSearchJob": {
+        "Child": {},
+        "ProposedQuery": {
+          "Description": "apply language filter with AND patterns",
+          "Query": "context:global lang:Go (commit AND monitor AND code)",
+          "PatternType": 1
+        }
+      }
+    },
+    {
+      "GeneratedSearchJob": {
+        "Child": {},
+        "ProposedQuery": {
+          "Description": "AND patterns together",
+          "Query": "context:global (go AND commit AND monitor AND code)",
+          "PatternType": 1
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Stacked on https://github.com/sourcegraph/sourcegraph/pull/37059

This statically composes some of the previous rules, so that you can get pretty nice and complex interpretations for a query like:

`go commit monitor code` runs as any of (in priority):

- usual literal search
- `type:commit lang:Go monitor code` (trigger `type` and `lang` rules)
- `type:commit go monitor code` (trigger `type` rule)
- `lang:Go commit monitor code` (trigger `lang` rule)
- `type:commit lang:Go (monitor AND code)` (trigger `lang` rule and `commit` rule, then unorder)
- etc.

In the ideal solution, we don't want to enumerate the composition of these rules statically like I'm doing here, but generate them based on their properties. But I don't yet know what properties play well and what combinators will be useful for generating, so see this as me exploring that direction and making observations. 

Observations so far: 

- There is an either/or/both strategy where ordering of rule application doesn't matter, and the rules are disjoint. For example, applying `lang` and `type` rules are disjoint, and their application order doesn't matter. We prefer to run a search where both applies, before attempting the either/or property.
- I haven't thought deeply about it, but I believe the either/or/both strategy ensures unique results (important characteristic, if we want to minimize the deduplication).
- There is a general multi-pattern strategy that composes on top of disjoint rules that turn patterns into parameters--one example is interpreting `unordered` patterns / rule. 
- It seems pretty clear that the multi-pattern strategy is prone to duplication.

## Test plan
Updated tests.