### PR TITLE
Always return indexes regardless of limit for inferred config and manual enqueues

### DIFF
--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/iface.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/iface.go
@@ -82,8 +82,8 @@ type LSIFStore interface {
 }
 
 type IndexEnqueuer interface {
-	QueueIndexes(ctx context.Context, repositoryID int, rev, configuration string, force bool) ([]dbstore.Index, error)
-	InferIndexConfiguration(ctx context.Context, repositoryID int, commit string) (*config.IndexConfiguration, []config.IndexJobHint, error)
+	QueueIndexes(ctx context.Context, repositoryID int, rev, configuration string, force, bypassLimit bool) ([]dbstore.Index, error)
+	InferIndexConfiguration(ctx context.Context, repositoryID int, commit string, bypassLimit bool) (*config.IndexConfiguration, []config.IndexJobHint, error)
 }
 
 type (

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/resolver.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/resolver.go
@@ -185,7 +185,7 @@ func (r *resolver) GetUploadDocumentsForPath(ctx context.Context, uploadID int, 
 }
 
 func (r *resolver) QueueAutoIndexJobsForRepo(ctx context.Context, repositoryID int, rev, configuration string) ([]dbstore.Index, error) {
-	return r.indexEnqueuer.QueueIndexes(ctx, repositoryID, rev, configuration, true)
+	return r.indexEnqueuer.QueueIndexes(ctx, repositoryID, rev, configuration, true, true)
 }
 
 const slowQueryResolverRequestThreshold = time.Second
@@ -305,7 +305,7 @@ func (r *resolver) IndexConfiguration(ctx context.Context, repositoryID int) ([]
 }
 
 func (r *resolver) InferedIndexConfiguration(ctx context.Context, repositoryID int, commit string) (*config.IndexConfiguration, bool, error) {
-	maybeConfig, _, err := r.indexEnqueuer.InferIndexConfiguration(ctx, repositoryID, commit)
+	maybeConfig, _, err := r.indexEnqueuer.InferIndexConfiguration(ctx, repositoryID, commit, true)
 	if err != nil || maybeConfig == nil {
 		return nil, false, err
 	}
@@ -314,7 +314,7 @@ func (r *resolver) InferedIndexConfiguration(ctx context.Context, repositoryID i
 }
 
 func (r *resolver) InferedIndexConfigurationHints(ctx context.Context, repositoryID int, commit string) ([]config.IndexJobHint, error) {
-	_, hints, err := r.indexEnqueuer.InferIndexConfiguration(ctx, repositoryID, commit)
+	_, hints, err := r.indexEnqueuer.InferIndexConfiguration(ctx, repositoryID, commit, true)
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/cmd/worker/internal/codeintel/indexing/iface.go
+++ b/enterprise/cmd/worker/internal/codeintel/indexing/iface.go
@@ -66,7 +66,7 @@ type GitserverClient interface {
 }
 
 type IndexEnqueuer interface {
-	QueueIndexes(ctx context.Context, repositoryID int, rev, configuration string, force bool) ([]dbstore.Index, error)
+	QueueIndexes(ctx context.Context, repositoryID int, rev, configuration string, force, bypassLimit bool) ([]dbstore.Index, error)
 	QueueIndexesForPackage(ctx context.Context, pkg precise.Package) error
 }
 

--- a/enterprise/cmd/worker/internal/codeintel/indexing/mocks_test.go
+++ b/enterprise/cmd/worker/internal/codeintel/indexing/mocks_test.go
@@ -2195,7 +2195,7 @@ type MockIndexEnqueuer struct {
 func NewMockIndexEnqueuer() *MockIndexEnqueuer {
 	return &MockIndexEnqueuer{
 		QueueIndexesFunc: &IndexEnqueuerQueueIndexesFunc{
-			defaultHook: func(context.Context, int, string, string, bool) (r0 []dbstore.Index, r1 error) {
+			defaultHook: func(context.Context, int, string, string, bool, bool) (r0 []dbstore.Index, r1 error) {
 				return
 			},
 		},
@@ -2212,7 +2212,7 @@ func NewMockIndexEnqueuer() *MockIndexEnqueuer {
 func NewStrictMockIndexEnqueuer() *MockIndexEnqueuer {
 	return &MockIndexEnqueuer{
 		QueueIndexesFunc: &IndexEnqueuerQueueIndexesFunc{
-			defaultHook: func(context.Context, int, string, string, bool) ([]dbstore.Index, error) {
+			defaultHook: func(context.Context, int, string, string, bool, bool) ([]dbstore.Index, error) {
 				panic("unexpected invocation of MockIndexEnqueuer.QueueIndexes")
 			},
 		},
@@ -2241,24 +2241,24 @@ func NewMockIndexEnqueuerFrom(i IndexEnqueuer) *MockIndexEnqueuer {
 // IndexEnqueuerQueueIndexesFunc describes the behavior when the
 // QueueIndexes method of the parent MockIndexEnqueuer instance is invoked.
 type IndexEnqueuerQueueIndexesFunc struct {
-	defaultHook func(context.Context, int, string, string, bool) ([]dbstore.Index, error)
-	hooks       []func(context.Context, int, string, string, bool) ([]dbstore.Index, error)
+	defaultHook func(context.Context, int, string, string, bool, bool) ([]dbstore.Index, error)
+	hooks       []func(context.Context, int, string, string, bool, bool) ([]dbstore.Index, error)
 	history     []IndexEnqueuerQueueIndexesFuncCall
 	mutex       sync.Mutex
 }
 
 // QueueIndexes delegates to the next hook function in the queue and stores
 // the parameter and result values of this invocation.
-func (m *MockIndexEnqueuer) QueueIndexes(v0 context.Context, v1 int, v2 string, v3 string, v4 bool) ([]dbstore.Index, error) {
-	r0, r1 := m.QueueIndexesFunc.nextHook()(v0, v1, v2, v3, v4)
-	m.QueueIndexesFunc.appendCall(IndexEnqueuerQueueIndexesFuncCall{v0, v1, v2, v3, v4, r0, r1})
+func (m *MockIndexEnqueuer) QueueIndexes(v0 context.Context, v1 int, v2 string, v3 string, v4 bool, v5 bool) ([]dbstore.Index, error) {
+	r0, r1 := m.QueueIndexesFunc.nextHook()(v0, v1, v2, v3, v4, v5)
+	m.QueueIndexesFunc.appendCall(IndexEnqueuerQueueIndexesFuncCall{v0, v1, v2, v3, v4, v5, r0, r1})
 	return r0, r1
 }
 
 // SetDefaultHook sets function that is called when the QueueIndexes method
 // of the parent MockIndexEnqueuer instance is invoked and the hook queue is
 // empty.
-func (f *IndexEnqueuerQueueIndexesFunc) SetDefaultHook(hook func(context.Context, int, string, string, bool) ([]dbstore.Index, error)) {
+func (f *IndexEnqueuerQueueIndexesFunc) SetDefaultHook(hook func(context.Context, int, string, string, bool, bool) ([]dbstore.Index, error)) {
 	f.defaultHook = hook
 }
 
@@ -2266,7 +2266,7 @@ func (f *IndexEnqueuerQueueIndexesFunc) SetDefaultHook(hook func(context.Context
 // QueueIndexes method of the parent MockIndexEnqueuer instance invokes the
 // hook at the front of the queue and discards it. After the queue is empty,
 // the default hook function is invoked for any future action.
-func (f *IndexEnqueuerQueueIndexesFunc) PushHook(hook func(context.Context, int, string, string, bool) ([]dbstore.Index, error)) {
+func (f *IndexEnqueuerQueueIndexesFunc) PushHook(hook func(context.Context, int, string, string, bool, bool) ([]dbstore.Index, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -2275,19 +2275,19 @@ func (f *IndexEnqueuerQueueIndexesFunc) PushHook(hook func(context.Context, int,
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
 func (f *IndexEnqueuerQueueIndexesFunc) SetDefaultReturn(r0 []dbstore.Index, r1 error) {
-	f.SetDefaultHook(func(context.Context, int, string, string, bool) ([]dbstore.Index, error) {
+	f.SetDefaultHook(func(context.Context, int, string, string, bool, bool) ([]dbstore.Index, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
 func (f *IndexEnqueuerQueueIndexesFunc) PushReturn(r0 []dbstore.Index, r1 error) {
-	f.PushHook(func(context.Context, int, string, string, bool) ([]dbstore.Index, error) {
+	f.PushHook(func(context.Context, int, string, string, bool, bool) ([]dbstore.Index, error) {
 		return r0, r1
 	})
 }
 
-func (f *IndexEnqueuerQueueIndexesFunc) nextHook() func(context.Context, int, string, string, bool) ([]dbstore.Index, error) {
+func (f *IndexEnqueuerQueueIndexesFunc) nextHook() func(context.Context, int, string, string, bool, bool) ([]dbstore.Index, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -2335,6 +2335,9 @@ type IndexEnqueuerQueueIndexesFuncCall struct {
 	// Arg4 is the value of the 5th argument passed to this method
 	// invocation.
 	Arg4 bool
+	// Arg5 is the value of the 6th argument passed to this method
+	// invocation.
+	Arg5 bool
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 []dbstore.Index
@@ -2346,7 +2349,7 @@ type IndexEnqueuerQueueIndexesFuncCall struct {
 // Args returns an interface slice containing the arguments of this
 // invocation.
 func (c IndexEnqueuerQueueIndexesFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4}
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4, c.Arg5}
 }
 
 // Results returns an interface slice containing the results of this

--- a/internal/codeintel/autoindexing/background/scheduler/index_scheduler.go
+++ b/internal/codeintel/autoindexing/background/scheduler/index_scheduler.go
@@ -98,7 +98,7 @@ func (s *scheduler) handleRepository(
 			}
 
 			// Attempt to queue an index if one does not exist for each of the matching commits
-			if _, err := s.autoindexingSvc.QueueIndexes(ctx, repositoryID, commit, "", false); err != nil {
+			if _, err := s.autoindexingSvc.QueueIndexes(ctx, repositoryID, commit, "", false, false); err != nil {
 				if errors.HasType(err, &gitdomain.RevisionNotFoundError{}) {
 					continue
 				}

--- a/internal/codeintel/autoindexing/enqueuer_test.go
+++ b/internal/codeintel/autoindexing/enqueuer_test.go
@@ -67,7 +67,7 @@ func TestQueueIndexesExplicit(t *testing.T) {
 	inferenceService := NewMockInferenceService()
 
 	scheduler := newService(nil, mockDBStore, mockGitserverClient, nil, inferenceService, &observation.TestContext)
-	_, _ = scheduler.QueueIndexes(context.Background(), 42, "HEAD", config, false)
+	_, _ = scheduler.QueueIndexes(context.Background(), 42, "HEAD", config, false, false)
 
 	if len(mockDBStore.IsQueuedFunc.History()) != 1 {
 		t.Errorf("unexpected number of calls to IsQueued. want=%d have=%d", 1, len(mockDBStore.IsQueuedFunc.History()))
@@ -179,7 +179,7 @@ func TestQueueIndexesInDatabase(t *testing.T) {
 	inferenceService := NewMockInferenceService()
 
 	scheduler := newService(nil, mockDBStore, mockGitserverClient, nil, inferenceService, &observation.TestContext)
-	_, _ = scheduler.QueueIndexes(context.Background(), 42, "HEAD", "", false)
+	_, _ = scheduler.QueueIndexes(context.Background(), 42, "HEAD", "", false, false)
 
 	if len(mockDBStore.GetIndexConfigurationByRepositoryIDFunc.History()) != 1 {
 		t.Errorf("unexpected number of calls to GetIndexConfigurationByRepositoryID. want=%d have=%d", 1, len(mockDBStore.GetIndexConfigurationByRepositoryIDFunc.History()))
@@ -297,7 +297,7 @@ func TestQueueIndexesInRepository(t *testing.T) {
 
 	scheduler := newService(nil, mockDBStore, mockGitserverClient, nil, inferenceService, &observation.TestContext)
 
-	if _, err := scheduler.QueueIndexes(context.Background(), 42, "HEAD", "", false); err != nil {
+	if _, err := scheduler.QueueIndexes(context.Background(), 42, "HEAD", "", false, false); err != nil {
 		t.Fatalf("unexpected error performing update: %s", err)
 	}
 
@@ -398,7 +398,7 @@ func TestQueueIndexesInferred(t *testing.T) {
 	scheduler := newService(nil, mockDBStore, mockGitserverClient, nil, inferenceService, &observation.TestContext)
 
 	for _, id := range []int{41, 42, 43, 44} {
-		if _, err := scheduler.QueueIndexes(context.Background(), id, "HEAD", "", false); err != nil {
+		if _, err := scheduler.QueueIndexes(context.Background(), id, "HEAD", "", false, false); err != nil {
 			t.Fatalf("unexpected error performing update: %s", err)
 		}
 	}
@@ -461,7 +461,7 @@ func TestQueueIndexesInferredTooLarge(t *testing.T) {
 	maximumIndexJobsPerInferredConfiguration = 20
 	scheduler := newService(nil, mockDBStore, mockGitserverClient, nil, inferenceService, &observation.TestContext)
 
-	if _, err := scheduler.QueueIndexes(context.Background(), 42, "HEAD", "", false); err != nil {
+	if _, err := scheduler.QueueIndexes(context.Background(), 42, "HEAD", "", false, false); err != nil {
 		t.Fatalf("unexpected error performing update: %s", err)
 	}
 

--- a/internal/codeintel/autoindexing/init.go
+++ b/internal/codeintel/autoindexing/init.go
@@ -25,7 +25,7 @@ var (
 var (
 	maximumRepositoriesInspectedPerSecond    = toRate(env.MustGetInt("PRECISE_CODE_INTEL_AUTO_INDEX_MAXIMUM_REPOSITORIES_INSPECTED_PER_SECOND", 0, "The maximum number of repositories inspected for auto-indexing per second. Set to zero to disable limit."))
 	maximumRepositoriesUpdatedPerSecond      = toRate(env.MustGetInt("PRECISE_CODE_INTEL_AUTO_INDEX_MAXIMUM_REPOSITORIES_UPDATED_PER_SECOND", 0, "The maximum number of repositories cloned or fetched for auto-indexing per second. Set to zero to disable limit."))
-	maximumIndexJobsPerInferredConfiguration = env.MustGetInt("PRECISE_CODE_INTEL_AUTO_INDEX_MAXIMUM_INDEX_JOBS_PER_INFERRED_CONFIGURATION", 25, "Repositories with a number of inferred auto-index jobs exceeding this threshold will be auto-indexed.")
+	maximumIndexJobsPerInferredConfiguration = env.MustGetInt("PRECISE_CODE_INTEL_AUTO_INDEX_MAXIMUM_INDEX_JOBS_PER_INFERRED_CONFIGURATION", 25, "Repositories with a number of inferred auto-index jobs exceeding this threshold will not be auto-indexed.")
 )
 
 // GetService creates or returns an already-initialized autoindexing service. If the service is


### PR DESCRIPTION
This PR adds an internal mechanism to ignore the limit used when inferring config for a repo in auto-indexing.
- The "Enqueue" button in the UI now doesn't mysteriously show 0 enqueued anymore, instead it just goes ahead and creates the indexes. It's a user triggered action so it's likely they wanted to enqueue all the jobs.
- The "Infer config for repo" button in the config editor now returns the config regardless of the setting, so users can manually remove workspaces as needed, instead of just hiding the button.

## Test plan

Verified manually the above changes are achieved by this change. Let me know if this needs some other form of testing, not my codebase :) 