### PR TITLE
Fix style of code search nav item

### DIFF
--- a/client/web/src/nav/NavBar/NavDropdown.module.scss
+++ b/client/web/src/nav/NavBar/NavDropdown.module.scss
@@ -21,6 +21,9 @@
     }
 
     &-link {
+        &:hover{
+            text-decoration: none;
+        }
         --link-hover-color: inherit;
         --link-hover-decoration: none;
 

--- a/client/web/src/nav/NavBar/NavDropdown.module.scss
+++ b/client/web/src/nav/NavBar/NavDropdown.module.scss
@@ -21,9 +21,6 @@
     }
 
     &-link {
-        &:hover{
-            text-decoration: none;
-        }
         --link-hover-color: inherit;
         --link-hover-decoration: none;
 
@@ -31,6 +28,10 @@
         display: flex;
         align-items: center;
         z-index: 1;
+
+        &:hover {
+            text-decoration: none;
+        }
     }
     &-icon-button {
         // - we show this button under the actual link


### PR DESCRIPTION
It had an underline decoration that didn't look nice.

<img width="265" alt="Screenshot 2022-06-12 at 14 29 24@2x" src="https://user-images.githubusercontent.com/19534377/173233254-d70f8f81-5310-447c-bfdc-12ed1f4a5d8d.png">

## Test plan

Tested it's not underlined anymore.

## App preview:

- [Web](https://sg-web-es-no-underline-search-nav.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-jwxtdxduye.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
