### PR TITLE
Improve performance of changeset spec expirer

### DIFF
--- a/enterprise/cmd/worker/internal/batches/janitor/spec_expire.go
+++ b/enterprise/cmd/worker/internal/batches/janitor/spec_expire.go
@@ -11,17 +11,17 @@ import (
 
 const specExpireInteral = 2 * time.Minute
 
-func NewSpecExpirer(ctx context.Context, cstore *store.Store) goroutine.BackgroundRoutine {
+func NewSpecExpirer(ctx context.Context, bstore *store.Store) goroutine.BackgroundRoutine {
 	return goroutine.NewPeriodicGoroutine(
 		ctx,
 		specExpireInteral,
 		goroutine.NewHandlerWithErrorMessage("expire batch changes specs", func(ctx context.Context) error {
 			// Delete all unattached, expired ChangesetSpecs...
-			if err := cstore.DeleteExpiredChangesetSpecs(ctx); err != nil {
+			if err := bstore.DeleteExpiredChangesetSpecs(ctx); err != nil {
 				return errors.Wrap(err, "DeleteExpiredChangesetSpecs")
 			}
 			// ... and then the BatchSpecs, that are expired.
-			if err := cstore.DeleteExpiredBatchSpecs(ctx); err != nil {
+			if err := bstore.DeleteExpiredBatchSpecs(ctx); err != nil {
 				return errors.Wrap(err, "DeleteExpiredBatchSpecs")
 			}
 			return nil

--- a/enterprise/internal/batches/store/changeset_specs.go
+++ b/enterprise/internal/batches/store/changeset_specs.go
@@ -465,7 +465,7 @@ OR
   AND
   -- and it is not created by SSBC
   NOT (SELECT created_from_raw FROM batch_specs WHERE id = cspecs.batch_spec_id)
-);`
+)`
 
 type DeleteChangesetSpecsOpts struct {
 	BatchSpecID int64

--- a/internal/database/schema.json
+++ b/internal/database/schema.json
@@ -3236,6 +3236,16 @@
           "ConstraintDefinition": ""
         },
         {
+          "Name": "changeset_specs_created_at",
+          "IsPrimaryKey": false,
+          "IsUnique": false,
+          "IsExclusion": false,
+          "IsDeferrable": false,
+          "IndexDefinition": "CREATE INDEX changeset_specs_created_at ON changeset_specs USING btree (created_at)",
+          "ConstraintType": "",
+          "ConstraintDefinition": ""
+        },
+        {
           "Name": "changeset_specs_external_id",
           "IsPrimaryKey": false,
           "IsUnique": false,
@@ -3851,6 +3861,16 @@
           "IsExclusion": false,
           "IsDeferrable": false,
           "IndexDefinition": "CREATE INDEX changesets_bitbucket_cloud_metadata_source_commit_idx ON changesets USING btree ((((metadata -\u003e 'source'::text) -\u003e 'commit'::text) -\u003e\u003e 'hash'::text))",
+          "ConstraintType": "",
+          "ConstraintDefinition": ""
+        },
+        {
+          "Name": "changesets_changeset_specs",
+          "IsPrimaryKey": false,
+          "IsUnique": false,
+          "IsExclusion": false,
+          "IsDeferrable": false,
+          "IndexDefinition": "CREATE INDEX changesets_changeset_specs ON changesets USING btree (current_spec_id, previous_spec_id)",
           "ConstraintType": "",
           "ConstraintDefinition": ""
         },

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -308,6 +308,7 @@ Foreign-key constraints:
 Indexes:
     "changeset_specs_pkey" PRIMARY KEY, btree (id)
     "changeset_specs_batch_spec_id" btree (batch_spec_id)
+    "changeset_specs_created_at" btree (created_at)
     "changeset_specs_external_id" btree (external_id)
     "changeset_specs_head_ref" btree (head_ref)
     "changeset_specs_rand_id" btree (rand_id)
@@ -370,6 +371,7 @@ Indexes:
     "changesets_repo_external_id_unique" UNIQUE CONSTRAINT, btree (repo_id, external_id)
     "changesets_batch_change_ids" gin (batch_change_ids)
     "changesets_bitbucket_cloud_metadata_source_commit_idx" btree ((((metadata -> 'source'::text) -> 'commit'::text) ->> 'hash'::text))
+    "changesets_changeset_specs" btree (current_spec_id, previous_spec_id)
     "changesets_external_state_idx" btree (external_state)
     "changesets_external_title_idx" btree (external_title)
     "changesets_publication_state_idx" btree (publication_state)

--- a/migrations/frontend/1655037388/down.sql
+++ b/migrations/frontend/1655037388/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS changeset_specs_created_at;

--- a/migrations/frontend/1655037388/metadata.yaml
+++ b/migrations/frontend/1655037388/metadata.yaml
@@ -1,0 +1,3 @@
+name: faster_changeset_spec_cleanup_1
+parents: [1654874153]
+createIndexConcurrently: true

--- a/migrations/frontend/1655037388/up.sql
+++ b/migrations/frontend/1655037388/up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS changeset_specs_created_at ON changeset_specs (created_at);

--- a/migrations/frontend/1655037391/down.sql
+++ b/migrations/frontend/1655037391/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS changesets_changeset_specs;

--- a/migrations/frontend/1655037391/metadata.yaml
+++ b/migrations/frontend/1655037391/metadata.yaml
@@ -1,0 +1,3 @@
+name: faster_changeset_spec_cleanup_2
+parents: [1655037388]
+createIndexConcurrently: true

--- a/migrations/frontend/1655037391/up.sql
+++ b/migrations/frontend/1655037391/up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS changesets_changeset_specs ON changesets (current_spec_id, previous_spec_id);

--- a/migrations/frontend/squashed.sql
+++ b/migrations/frontend/squashed.sql
@@ -3496,6 +3496,8 @@ CREATE INDEX changeset_jobs_state_idx ON changeset_jobs USING btree (state);
 
 CREATE INDEX changeset_specs_batch_spec_id ON changeset_specs USING btree (batch_spec_id);
 
+CREATE INDEX changeset_specs_created_at ON changeset_specs USING btree (created_at);
+
 CREATE INDEX changeset_specs_external_id ON changeset_specs USING btree (external_id);
 
 CREATE INDEX changeset_specs_head_ref ON changeset_specs USING btree (head_ref);
@@ -3507,6 +3509,8 @@ CREATE INDEX changeset_specs_title ON changeset_specs USING btree (title);
 CREATE INDEX changesets_batch_change_ids ON changesets USING gin (batch_change_ids);
 
 CREATE INDEX changesets_bitbucket_cloud_metadata_source_commit_idx ON changesets USING btree (((((metadata -> 'source'::text) -> 'commit'::text) ->> 'hash'::text)));
+
+CREATE INDEX changesets_changeset_specs ON changesets USING btree (current_spec_id, previous_spec_id);
 
 CREATE INDEX changesets_external_state_idx ON changesets USING btree (external_state);
 


### PR DESCRIPTION
Noticed this query was very slow in prod. Made it somewhat better, from 27s to 3.5s. Since slow queries can cause major instability to instances, I think this is a good fix.

Notebook:

Query (modified to not actually delete):
```
explain analyze SELECT id FROM
  changeset_specs cspecs
WHERE
(
  created_at < NOW() - interval '2 day'
  AND
  batch_spec_id IS NULL
)
OR
(
  created_at < NOW() - interval '7 day'
  AND
  NOT EXISTS (SELECT 1 FROM batch_changes WHERE batch_spec_id = cspecs.batch_spec_id)
  AND
  NOT EXISTS (SELECT 1 FROM changesets WHERE current_spec_id = cspecs.id OR previous_spec_id = cspecs.id)
  AND
  NOT (SELECT created_from_raw FROM batch_specs WHERE id = cspecs.batch_spec_id)
);
```

Current query plan:
```
QUERY PLAN
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Seq Scan on changeset_specs cspecs  (cost=0.00..16720972.07 rows=24960 width=8) (actual time=27301.444..27301.448 rows=0 loops=1)
   Filter: (((created_at < (now() - '2 days'::interval)) AND (batch_spec_id IS NULL)) OR ((created_at < (now() - '7 days'::interval)) AND (NOT (alternatives: SubPlan 1 or hashed SubPlan 2)) AND (NOT (SubPlan 3)) AND (NOT (SubPlan 4))))
   Rows Removed by Filter: 232317
   SubPlan 1
     ->  Seq Scan on batch_changes  (cost=0.00..6.78 rows=1 width=0) (never executed)
           Filter: (batch_spec_id = cspecs.batch_spec_id)
   SubPlan 2
     ->  Seq Scan on batch_changes batch_changes_1  (cost=0.00..6.22 rows=222 width=8) (actual time=26.121..26.167 rows=228 loops=1)
   SubPlan 3
     ->  Seq Scan on changesets  (cost=0.00..125.10 rows=2 width=0) (actual time=0.143..0.143 rows=0 loops=182428)
           Filter: ((current_spec_id = cspecs.id) OR (previous_spec_id = cspecs.id))
           Rows Removed by Filter: 1139
   SubPlan 4
     ->  Index Scan using batch_specs_pkey on batch_specs  (cost=0.28..2.49 rows=1 width=1) (actual time=0.001..0.001 rows=1 loops=181961)
           Index Cond: (id = cspecs.batch_spec_id)
 Planning Time: 0.317 ms
 JIT:
   Functions: 33
   Options: Inlining true, Optimization true, Expressions true, Deforming true
   Timing: Generation 9.374 ms, Inlining 77.607 ms, Optimization 213.145 ms, Emission 138.279 ms, Total 438.405 ms
 Execution Time: 27310.578 ms
(21 rows)
```

Proposed indexes:
```
create index on changesets (current_spec_id, previous_spec_id);

create index erik_test2 on changeset_specs (created_at);
```

New result:
```
QUERY PLAN
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Bitmap Heap Scan on changeset_specs cspecs  (cost=2118.15..5685332.74 rows=24960 width=8) (actual time=3529.156..3529.160 rows=0 loops=1)
   Recheck Cond: ((batch_spec_id IS NULL) OR (created_at < (now() - '7 days'::interval)))
   Filter: (((created_at < (now() - '2 days'::interval)) AND (batch_spec_id IS NULL)) OR ((created_at < (now() - '7 days'::interval)) AND (NOT (alternatives: SubPlan 1 or hashed SubPlan 2)) AND (NOT (SubPlan 3)) AND (NOT (SubPlan 4))))
   Rows Removed by Filter: 183141
   Heap Blocks: exact=26966
   ->  BitmapOr  (cost=2118.15..2118.15 rows=199682 width=0) (actual time=393.099..393.101 rows=0 loops=1)
         ->  Bitmap Index Scan on changeset_specs_batch_spec_id  (cost=0.00..1.53 rows=1 width=0) (actual time=0.009..0.009 rows=0 loops=1)
               Index Cond: (batch_spec_id IS NULL)
         ->  Bitmap Index Scan on erik_test2  (cost=0.00..2104.14 rows=199682 width=0) (actual time=393.089..393.089 rows=183141 loops=1)
               Index Cond: (created_at < (now() - '7 days'::interval))
   SubPlan 1
     ->  Seq Scan on batch_changes  (cost=0.00..6.78 rows=1 width=0) (never executed)
           Filter: (batch_spec_id = cspecs.batch_spec_id)
   SubPlan 2
     ->  Seq Scan on batch_changes batch_changes_1  (cost=0.00..6.22 rows=222 width=8) (actual time=27.133..27.174 rows=228 loops=1)
   SubPlan 3
     ->  Bitmap Heap Scan on changesets  (cost=17.91..20.12 rows=2 width=0) (actual time=0.014..0.014 rows=0 loops=182428)
           Recheck Cond: ((current_spec_id = cspecs.id) OR (previous_spec_id = cspecs.id))
           Heap Blocks: exact=467
           ->  BitmapOr  (cost=17.91..17.91 rows=2 width=0) (actual time=0.014..0.014 rows=0 loops=182428)
                 ->  Bitmap Index Scan on changesets_current_spec_id_previous_spec_id_idx  (cost=0.00..1.39 rows=1 width=0) (actual time=0.001..0.001 rows=0 loops=182428)
                       Index Cond: (current_spec_id = cspecs.id)
                 ->  Bitmap Index Scan on changesets_current_spec_id_previous_spec_id_idx  (cost=0.00..16.53 rows=1 width=0) (actual time=0.013..0.013 rows=0 loops=182428)
                       Index Cond: (previous_spec_id = cspecs.id)
   SubPlan 4
     ->  Index Scan using batch_specs_pkey on batch_specs  (cost=0.28..2.49 rows=1 width=1) (actual time=0.001..0.001 rows=1 loops=181961)
           Index Cond: (id = cspecs.batch_spec_id)
 Planning Time: 0.318 ms
 JIT:
   Functions: 38
   Options: Inlining true, Optimization true, Expressions true, Deforming true
   Timing: Generation 6.551 ms, Inlining 16.569 ms, Optimization 227.673 ms, Emission 163.927 ms, Total 414.720 ms
 Execution Time: 3535.557 ms
(33 rows)
```

Closes https://github.com/sourcegraph/sourcegraph/issues/37072

## Test plan

See description, tested in dogfood.