### PR TITLE
release: return comment HTML URL instead of API URL

### DIFF
--- a/dev/release/src/github.ts
+++ b/dev/release/src/github.ts
@@ -353,7 +353,7 @@ export async function commentOnIssue(client: Octokit, issue: Issue, body: string
         owner: issue.owner,
         repo: issue.repo,
     })
-    return comment.data.url
+    return comment.data.html_url
 }
 
 async function closeIssue(client: Octokit, issue: Issue): Promise<void> {


### PR DESCRIPTION
Don't think pointing to the API URL is the intention.

## Test plan

Only changes to release tooling

---

Derived from my [retro notes for the 3.40 release](https://docs.google.com/document/d/1VHBqsWocffw9W8NRGhw4lLzyaoqgc1fiNdmTMMaVLxM/edit#).