### PR TITLE
fix(a11y): Fix unreadable description when tabbing through Revision Popover

### DIFF
--- a/client/web/src/repo/RevisionsPopover/components/ConnectionPopoverNodeLink/ConnectionPopoverNodeLink.module.scss
+++ b/client/web/src/repo/RevisionsPopover/components/ConnectionPopoverNodeLink/ConnectionPopoverNodeLink.module.scss
@@ -21,8 +21,7 @@
     align-items: center;
     color: inherit;
 
-    &:hover,
-    &:focus {
+    &:hover {
         color: var(--light-text);
         text-decoration: none;
     }


### PR DESCRIPTION
This PR removes extra CSS rules for `:focus` on the revision popover's item's link, to prevent the text becoming unreadable when having tab-focus.

Closes #37094 

## Test plan

Tabbing through the revision popover's items now has readable text throughout.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-mihir-37094-revision-popover.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-syvgamzkot.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
