### PR TITLE
[Wildcard] Remove Tooltip component click handler

### DIFF
--- a/client/wildcard/src/components/Tooltip/Tooltip.tsx
+++ b/client/wildcard/src/components/Tooltip/Tooltip.tsx
@@ -62,7 +62,6 @@ export const Tooltip: React.FunctionComponent<TooltipProps> = ({
             <span
                 role="presentation"
                 className={classNames(styles.tooltip, className)}
-                onClick={event => event.preventDefault()}
                 data-testid={dataTestId}
                 data-test-content={content}
             >


### PR DESCRIPTION
Make `Tooltip` component not intercept clicks on child nodes.

Previously when a link was wrapped with the `Tooltip` component mouse clicks and keyboard presses to navigate to its URL were ignored.

## Test plan

Visual testing via Storybook. Unit testing of the Tooltip behavior and automatic aria support.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
