### PR TITLE
notebooks list: side filters

### DIFF
--- a/client/web/src/integration/notebook.test.ts
+++ b/client/web/src/integration/notebook.test.ts
@@ -767,10 +767,11 @@ https://sourcegraph.test:3443/github.com/sourcegraph/sourcegraph@branch/-/blob/c
         // The "Title 2" heading in the outline should be highlighted
         expect(await getHighlightedOutlineHeading()).toEqual('title-2-id-1')
     })
-    it('Notebook explore page should be accessible', async () => {
-        await driver.page.goto(driver.sourcegraphBaseUrl + '/notebooks?tab=explore')
+
+    it('Notebooks list page should be accessible', async () => {
+        await driver.page.goto(driver.sourcegraphBaseUrl + '/notebooks?tab=notebooks')
         await driver.page.waitForSelector('[data-testid="filtered-connection-nodes"]', { visible: true })
-        await percySnapshotWithVariants(driver.page, 'Explore notebooks')
+        await percySnapshotWithVariants(driver.page, 'Notebooks list')
         await accessibilityAudit(driver.page)
     })
 })

--- a/client/web/src/notebooks/backend.ts
+++ b/client/web/src/notebooks/backend.ts
@@ -159,7 +159,7 @@ export function fetchNotebooks({
         starredByUserID: starredByUserID ?? null,
         namespace: namespace ?? null,
         orderBy: orderBy ?? GQL.NotebooksOrderBy.NOTEBOOK_UPDATED_AT,
-        descending: descending ?? false,
+        descending: descending ?? true,
     }).pipe(
         map(dataOrThrowErrors),
         map(data => data.notebooks)

--- a/client/web/src/notebooks/listPage/NotebooksList.module.scss
+++ b/client/web/src/notebooks/listPage/NotebooksList.module.scss
@@ -1,3 +1,3 @@
 .filter-input {
-    width: 30%;
+    width: 35%;
 }

--- a/client/web/src/notebooks/listPage/NotebooksList.tsx
+++ b/client/web/src/notebooks/listPage/NotebooksList.tsx
@@ -3,6 +3,7 @@ import React, { useCallback, useEffect } from 'react'
 import { useHistory, useLocation } from 'react-router'
 
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
+import { H3 } from '@sourcegraph/wildcard'
 
 import { FilteredConnection, FilteredConnectionFilter } from '../../components/FilteredConnection'
 import { ListNotebooksResult, ListNotebooksVariables, NotebookFields, NotebooksOrderBy } from '../../graphql-operations'
@@ -12,9 +13,10 @@ import { NotebookNode, NotebookNodeProps } from './NotebookNode'
 
 import styles from './NotebooksList.module.scss'
 
-interface NotebooksListProps extends TelemetryProps {
+export interface NotebooksListProps extends TelemetryProps {
+    title: string
     logEventName: string
-    filters: FilteredConnectionFilter[]
+    orderOptions: FilteredConnectionFilter[]
     creatorUserID?: string
     starredByUserID?: string
     namespace?: string
@@ -22,8 +24,9 @@ interface NotebooksListProps extends TelemetryProps {
 }
 
 export const NotebooksList: React.FunctionComponent<React.PropsWithChildren<NotebooksListProps>> = ({
+    title,
     logEventName,
-    filters,
+    orderOptions,
     creatorUserID,
     starredByUserID,
     namespace,
@@ -38,8 +41,8 @@ export const NotebooksList: React.FunctionComponent<React.PropsWithChildren<Note
     const queryConnection = useCallback(
         (args: Partial<ListNotebooksVariables>) => {
             const { orderBy, descending } = args as {
-                orderBy: NotebooksOrderBy
-                descending: boolean
+                orderBy: NotebooksOrderBy | undefined
+                descending: boolean | undefined
             }
 
             return fetchNotebooks({
@@ -61,13 +64,14 @@ export const NotebooksList: React.FunctionComponent<React.PropsWithChildren<Note
 
     return (
         <div>
+            <H3 className="mb-3">{title}</H3>
             <FilteredConnection<NotebookFields, Omit<NotebookNodeProps, 'node'>, ListNotebooksResult['notebooks']>
                 history={history}
                 location={location}
                 defaultFirst={10}
                 compact={false}
                 queryConnection={queryConnection}
-                filters={filters}
+                filters={orderOptions}
                 hideSearch={false}
                 nodeComponent={NotebookNode}
                 nodeComponentProps={{
@@ -80,6 +84,7 @@ export const NotebooksList: React.FunctionComponent<React.PropsWithChildren<Note
                 cursorPaging={true}
                 inputClassName={styles.filterInput}
                 inputPlaceholder="Search notebooks by title and content"
+                useURLQuery={false}
             />
         </div>
     )

--- a/client/web/src/notebooks/listPage/NotebooksList.tsx
+++ b/client/web/src/notebooks/listPage/NotebooksList.tsx
@@ -3,7 +3,7 @@ import React, { useCallback, useEffect } from 'react'
 import { useHistory, useLocation } from 'react-router'
 
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
-import { H3 } from '@sourcegraph/wildcard'
+import { H2 } from '@sourcegraph/wildcard'
 
 import { FilteredConnection, FilteredConnectionFilter } from '../../components/FilteredConnection'
 import { ListNotebooksResult, ListNotebooksVariables, NotebookFields, NotebooksOrderBy } from '../../graphql-operations'
@@ -64,7 +64,7 @@ export const NotebooksList: React.FunctionComponent<React.PropsWithChildren<Note
 
     return (
         <div>
-            <H3 className="mb-3">{title}</H3>
+            <H2 className="mb-3">{title}</H2>
             <FilteredConnection<NotebookFields, Omit<NotebookNodeProps, 'node'>, ListNotebooksResult['notebooks']>
                 history={history}
                 location={location}

--- a/client/web/src/notebooks/listPage/NotebooksListPage.tsx
+++ b/client/web/src/notebooks/listPage/NotebooksListPage.tsx
@@ -10,7 +10,6 @@ import { catchError, startWith, switchMap } from 'rxjs/operators'
 import { asError, ErrorLike, isErrorLike } from '@sourcegraph/common'
 import { useTemporarySetting } from '@sourcegraph/shared/src/settings/temporary/useTemporarySetting'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
-import { buildGetStartedURL } from '@sourcegraph/shared/src/util/url'
 import { PageHeader, Link, Button, useEventObservable, Alert } from '@sourcegraph/wildcard'
 
 import { AuthenticatedUser } from '../../auth'
@@ -21,10 +20,8 @@ import { PageRoutes } from '../../routes.constants'
 import { fetchNotebooks as _fetchNotebooks, createNotebook as _createNotebook } from '../backend'
 
 import { NotebooksGettingStartedTab } from './NotebooksGettingStartedTab'
-import { NotebooksList } from './NotebooksList'
+import { NotebooksList, NotebooksListProps } from './NotebooksList'
 import { NotebooksListPageHeader } from './NotebooksListPageHeader'
-
-import styles from './NotebooksListPage.module.scss'
 
 export interface NotebooksListPageProps extends TelemetryProps {
     authenticatedUser: AuthenticatedUser | null
@@ -32,59 +29,40 @@ export interface NotebooksListPageProps extends TelemetryProps {
     createNotebook?: typeof _createNotebook
 }
 
-type NotebooksTab =
-    | { type: 'my' }
-    | { type: 'explore' }
-    | { type: 'starred' }
-    | { type: 'org'; name: string; id: string }
-    | { type: 'getting-started' }
+type NotebooksTab = 'notebooks' | 'getting-started'
 
-type Tabs = { tab: NotebooksTab; title: string; isActive: boolean; logName: string }[]
+type Tabs = { tab: NotebooksTab; title: string; isActive: boolean; logEventName: string }[]
 
 function getSelectedTabFromLocation(locationSearch: string, authenticatedUser: AuthenticatedUser | null): NotebooksTab {
     if (!authenticatedUser) {
-        return { type: 'getting-started' }
+        return 'getting-started'
     }
 
     const urlParameters = new URLSearchParams(locationSearch)
     switch (urlParameters.get('tab')) {
-        case 'my':
-            return { type: 'my' }
-        case 'explore':
-            return { type: 'explore' }
-        case 'starred':
-            return { type: 'starred' }
+        case 'notebooks':
+            return 'notebooks'
         case 'getting-started':
-            return { type: 'getting-started' }
+            return 'getting-started'
     }
-
-    const orgName = urlParameters.get('org')
-    const org = orgName && authenticatedUser.organizations.nodes.find(org => org.name === orgName)
-    if (org) {
-        return { type: 'org', name: org.name, id: org.id }
-    }
-
-    return { type: 'my' }
+    return 'notebooks'
 }
 
 function setSelectedLocationTab(location: H.Location, history: H.History, selectedTab: NotebooksTab): void {
     const urlParameters = new URLSearchParams(location.search)
-    // Reset FilteredConnection URL params when switching between tabs
-    for (const parameter of ['visible', 'query', 'order', 'org', 'tab']) {
-        urlParameters.delete(parameter)
-    }
-
-    if (selectedTab.type === 'org') {
-        urlParameters.set('org', selectedTab.name)
-    } else {
-        urlParameters.set('tab', selectedTab.type)
-    }
+    urlParameters.set('tab', selectedTab)
     if (location.search !== urlParameters.toString()) {
         history.replace({ ...location, search: urlParameters.toString() })
     }
 }
 
 const LOADING = 'loading' as const
+
+interface NotebooksFilter extends Pick<NotebooksListProps, 'creatorUserID' | 'starredByUserID' | 'namespace'> {
+    id: string
+    label: string
+    logEventName: string
+}
 
 export const NotebooksListPage: React.FunctionComponent<React.PropsWithChildren<NotebooksListPageProps>> = ({
     authenticatedUser,
@@ -103,12 +81,13 @@ export const NotebooksListPage: React.FunctionComponent<React.PropsWithChildren<
     const [selectedTab, setSelectedTab] = useState<NotebooksTab>(
         getSelectedTabFromLocation(location.search, authenticatedUser)
     )
+    const [selectedFilter, setSelectedFilter] = useState<NotebooksFilter>()
 
     const [hasSeenGettingStartedTab] = useTemporarySetting('search.notebooks.gettingStartedTabSeen', false)
 
     useEffect(() => {
         if (typeof hasSeenGettingStartedTab !== 'undefined' && !hasSeenGettingStartedTab) {
-            setSelectedTab({ type: 'getting-started' })
+            setSelectedTab('getting-started')
         }
     }, [hasSeenGettingStartedTab, setSelectedTab])
 
@@ -121,29 +100,13 @@ export const NotebooksListPage: React.FunctionComponent<React.PropsWithChildren<
         [history, location, setSelectedTab, telemetryService]
     )
 
-    const filters: FilteredConnectionFilter[] = [
+    const orderOptions: FilteredConnectionFilter[] = [
         {
             label: 'Order by',
             type: 'select',
             id: 'order',
             tooltip: 'Order notebooks',
             values: [
-                {
-                    value: 'stars-desc',
-                    label: 'Stars (descending)',
-                    args: {
-                        orderBy: NotebooksOrderBy.NOTEBOOK_STAR_COUNT,
-                        descending: true,
-                    },
-                },
-                {
-                    value: 'stars-asc',
-                    label: 'Stars (ascending)',
-                    args: {
-                        orderBy: NotebooksOrderBy.NOTEBOOK_STAR_COUNT,
-                        descending: false,
-                    },
-                },
                 {
                     value: 'updated-at-desc',
                     label: 'Last update (descending)',
@@ -157,6 +120,22 @@ export const NotebooksListPage: React.FunctionComponent<React.PropsWithChildren<
                     label: 'Last update (ascending)',
                     args: {
                         orderBy: NotebooksOrderBy.NOTEBOOK_UPDATED_AT,
+                        descending: false,
+                    },
+                },
+                {
+                    value: 'stars-desc',
+                    label: 'Stars (descending)',
+                    args: {
+                        orderBy: NotebooksOrderBy.NOTEBOOK_STAR_COUNT,
+                        descending: true,
+                    },
+                },
+                {
+                    value: 'stars-asc',
+                    label: 'Stars (ascending)',
+                    args: {
+                        orderBy: NotebooksOrderBy.NOTEBOOK_STAR_COUNT,
                         descending: false,
                     },
                 },
@@ -180,47 +159,65 @@ export const NotebooksListPage: React.FunctionComponent<React.PropsWithChildren<
         },
     ]
 
-    const orgTabs: Tabs | undefined = useMemo(
+    const orgFilters: NotebooksFilter[] | undefined = useMemo(
         () =>
             authenticatedUser?.organizations.nodes.map(org => ({
-                tab: { type: 'org', name: org.name, id: org.id },
-                title: `${org.name} Notebooks`,
-                isActive: selectedTab.type === 'org' && selectedTab.id === org.id,
-                logName: 'OrgNotebooks',
+                id: `org-${org.id}-notebooks`,
+                label: `${org.displayName} notebooks`,
+                logEventName: 'OrgNotebooks',
+                namespace: org.id,
             })),
-        [authenticatedUser, selectedTab]
+        [authenticatedUser]
     )
 
     const tabs: Tabs = useMemo(
         () => [
             {
-                tab: { type: 'my' },
-                title: 'My Notebooks',
-                isActive: selectedTab.type === 'my',
-                logName: 'MyNotebooks',
+                tab: 'notebooks',
+                title: 'Notebooks',
+                isActive: selectedTab === 'notebooks',
+                logEventName: 'Notebooks',
             },
             {
-                tab: { type: 'starred' },
-                title: 'Starred Notebooks',
-                isActive: selectedTab.type === 'starred',
-                logName: 'StarredNotebooks',
-            },
-            ...(orgTabs ?? []),
-            {
-                tab: { type: 'explore' },
-                title: 'Explore Notebooks',
-                isActive: selectedTab.type === 'explore',
-                logName: 'ExploreNotebooks',
-            },
-            {
-                tab: { type: 'getting-started' },
+                tab: 'getting-started',
                 title: 'Getting Started',
-                isActive: selectedTab.type === 'getting-started',
-                logName: 'GettingStarted',
+                isActive: selectedTab === 'getting-started',
+                logEventName: 'GettingStarted',
             },
         ],
-        [selectedTab, orgTabs]
+        [selectedTab]
     )
+
+    const filters: NotebooksFilter[] = useMemo(
+        () =>
+            [
+                authenticatedUser && {
+                    id: 'my-notebooks',
+                    label: 'Created by me',
+                    creatorUserID: authenticatedUser.id,
+                    logEventName: 'MyNotebooks',
+                },
+                authenticatedUser && {
+                    id: 'starred-notebooks',
+                    label: 'Starred',
+                    starredByUserID: authenticatedUser.id,
+                    logEventName: 'StarredNotebooks',
+                },
+                {
+                    id: 'all-notebooks',
+                    label: 'All notebooks',
+                    logEventName: 'ExploreNotebooks',
+                },
+                ...(orgFilters || []),
+            ].filter((filter): filter is NotebooksFilter => !!filter),
+        [authenticatedUser, orgFilters]
+    )
+
+    useEffect(() => {
+        if (!selectedFilter) {
+            setSelectedFilter(filters[0])
+        }
+    }, [selectedFilter, filters, setSelectedFilter])
 
     const [importNotebook, importedNotebookOrError] = useEventObservable(
         useCallback(
@@ -269,14 +266,14 @@ export const NotebooksListPage: React.FunctionComponent<React.PropsWithChildren<
                 )}
                 <div className="mb-4">
                     <div className="nav nav-tabs">
-                        {tabs.map(({ tab, title, isActive, logName }) => (
-                            <div className="nav-item" key={`${tab.type}-${tab.type === 'org' && tab.id}`}>
+                        {tabs.map(({ tab, title, isActive, logEventName }) => (
+                            <div className="nav-item" key={tab}>
                                 <Link
                                     to=""
                                     role="button"
                                     onClick={event => {
                                         event.preventDefault()
-                                        onSelectTab(tab, `SearchNotebooks${logName}TabClick`)
+                                        onSelectTab(tab, `SearchNotebooks${logEventName}TabClick`)
                                     }}
                                     className={classNames('nav-link', isActive && 'active')}
                                 >
@@ -288,91 +285,43 @@ export const NotebooksListPage: React.FunctionComponent<React.PropsWithChildren<
                         ))}
                     </div>
                 </div>
-                {selectedTab.type === 'my' && authenticatedUser && (
-                    <NotebooksList
-                        logEventName="MyNotebooks"
-                        fetchNotebooks={fetchNotebooks}
-                        filters={filters}
-                        creatorUserID={authenticatedUser.id}
-                        telemetryService={telemetryService}
-                    />
+
+                {selectedTab === 'notebooks' && (
+                    <div className="row mb-5">
+                        <div className="d-flex flex-column col-sm-2 mr-2">
+                            {filters.map(filter => (
+                                <Button
+                                    key={filter.id}
+                                    className="text-left"
+                                    onClick={() => setSelectedFilter(filter)}
+                                    variant={selectedFilter?.id === filter.id ? 'primary' : undefined}
+                                >
+                                    {filter.label}
+                                </Button>
+                            ))}
+                        </div>
+                        <div className="d-flex flex-column w-100 col">
+                            {selectedFilter && (
+                                <NotebooksList
+                                    key={selectedFilter.id}
+                                    title={selectedFilter.label}
+                                    logEventName={selectedFilter.logEventName}
+                                    fetchNotebooks={fetchNotebooks}
+                                    orderOptions={orderOptions}
+                                    creatorUserID={selectedFilter.creatorUserID}
+                                    starredByUserID={selectedFilter.starredByUserID}
+                                    namespace={selectedFilter.namespace}
+                                    telemetryService={telemetryService}
+                                />
+                            )}
+                        </div>
+                    </div>
                 )}
-                {selectedTab.type === 'starred' && authenticatedUser && (
-                    <NotebooksList
-                        logEventName="StarredNotebooks"
-                        fetchNotebooks={fetchNotebooks}
-                        starredByUserID={authenticatedUser.id}
-                        filters={filters}
-                        telemetryService={telemetryService}
-                    />
-                )}
-                {selectedTab.type === 'org' && (
-                    <NotebooksList
-                        logEventName="OrgNotebooks"
-                        fetchNotebooks={fetchNotebooks}
-                        namespace={selectedTab.id}
-                        filters={filters}
-                        telemetryService={telemetryService}
-                    />
-                )}
-                {(selectedTab.type === 'my' || selectedTab.type === 'starred') && !authenticatedUser && (
-                    <UnauthenticatedNotebooksSection
-                        cta={
-                            selectedTab.type === 'my'
-                                ? 'Get started creating notebooks'
-                                : 'Get started starring notebooks'
-                        }
-                        telemetryService={telemetryService}
-                        onSelectExploreNotebooks={() =>
-                            onSelectTab({ type: 'explore' }, 'SearchNotebooksExploreNotebooksTabClick')
-                        }
-                    />
-                )}
-                {selectedTab.type === 'explore' && (
-                    <NotebooksList
-                        logEventName="ExploreNotebooks"
-                        fetchNotebooks={fetchNotebooks}
-                        filters={filters}
-                        telemetryService={telemetryService}
-                    />
-                )}
-                {selectedTab.type === 'getting-started' && (
+
+                {selectedTab === 'getting-started' && (
                     <NotebooksGettingStartedTab telemetryService={telemetryService} />
                 )}
             </Page>
-        </div>
-    )
-}
-
-interface UnauthenticatedMyNotebooksSectionProps extends TelemetryProps {
-    cta: string
-    onSelectExploreNotebooks: () => void
-}
-
-const UnauthenticatedNotebooksSection: React.FunctionComponent<
-    React.PropsWithChildren<UnauthenticatedMyNotebooksSectionProps>
-> = ({ telemetryService, cta, onSelectExploreNotebooks }) => {
-    const onClick = (): void => {
-        telemetryService.log('SearchNotebooksSignUpToCreateNotebooksClick')
-    }
-
-    return (
-        <div className="d-flex justify-content-center align-items-center flex-column p-3">
-            <Button
-                as={Link}
-                onClick={onClick}
-                to={buildGetStartedURL('search-notebooks', '/notebooks')}
-                variant="primary"
-            >
-                {cta}
-            </Button>
-            <span className="my-3 text-muted">or</span>
-            <span className={classNames('d-flex align-items-center', styles.explorePublicNotebooks)}>
-                <Button className="p-1" variant="link" onClick={onSelectExploreNotebooks}>
-                    explore
-                </Button>{' '}
-                public notebooks
-            </span>
         </div>
     )
 }


### PR DESCRIPTION
## Demo


https://user-images.githubusercontent.com/6417322/173319442-eed4722f-a6c2-4ff5-ae1c-28764c9b2fb0.mov



## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

* Go to `/notebooks` page
* Click on the side filters, and the notebooks list should be pre-filtered to the appropriate notebooks
* Check that querying and ordering works



## App preview:

- [Web](https://sg-web-rn-notebooks-side-filters.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-mpjqyedxsp.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
