### PR TITLE
Add notification to set project URL

### DIFF
--- a/client/jetbrains/src/main/java/com/sourcegraph/config/ConfigUtil.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/ConfigUtil.java
@@ -124,6 +124,15 @@ public class ConfigUtil {
         SourcegraphApplicationService.getInstance().isInstallEventLogged = value;
     }
 
+    public static boolean isUrlNotificationDismissed(@NotNull Project project) {
+        return getProjectLevelConfig(project).isUrlNotificationDismissed();
+    }
+
+    public static void setUrlNotificationDismissed(@NotNull Project project, boolean value) {
+        SourcegraphConfig settings = getProjectLevelConfig(project);
+        settings.isUrlNotificationDismissed = value;
+    }
+
     @NotNull
     private static SourcegraphApplicationService getApplicationLevelConfig() {
         return Objects.requireNonNull(SourcegraphApplicationService.getInstance());

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/ConfigUtil.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/ConfigUtil.java
@@ -124,13 +124,12 @@ public class ConfigUtil {
         SourcegraphApplicationService.getInstance().isInstallEventLogged = value;
     }
 
-    public static boolean isUrlNotificationDismissed(@NotNull Project project) {
-        return getProjectLevelConfig(project).isUrlNotificationDismissed();
+    public static boolean isUrlNotificationDismissed() {
+        return SourcegraphApplicationService.getInstance().isUrlNotificationDismissed();
     }
 
-    public static void setUrlNotificationDismissed(@NotNull Project project, boolean value) {
-        SourcegraphConfig settings = getProjectLevelConfig(project);
-        settings.isUrlNotificationDismissed = value;
+    public static void setUrlNotificationDismissed(boolean value) {
+        SourcegraphApplicationService.getInstance().isUrlNotificationDismissed = value;
     }
 
     @NotNull

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/NotificationActivity.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/NotificationActivity.java
@@ -16,7 +16,7 @@ public class NotificationActivity implements StartupActivity.DumbAware {
     @Override
     public void runActivity(@NotNull Project project) {
         String url = ConfigUtil.getSourcegraphUrl(project);
-        if (ConfigUtil.isUrlNotificationDismissed(project) || (url.length() != 0 && !url.startsWith("https://sourcegraph.com"))) {
+        if (ConfigUtil.isUrlNotificationDismissed() || (url.length() != 0 && !url.startsWith("https://sourcegraph.com"))) {
             return;
         }
         // Display notification
@@ -38,7 +38,7 @@ public class NotificationActivity implements StartupActivity.DumbAware {
             @Override
             public void actionPerformed(@NotNull AnActionEvent anActionEvent) {
                 notification.expire();
-                ConfigUtil.setUrlNotificationDismissed(project, true);
+                ConfigUtil.setUrlNotificationDismissed(true);
             }
         };
         notification.setIcon(Icons.Logo);

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/NotificationActivity.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/NotificationActivity.java
@@ -1,0 +1,50 @@
+package com.sourcegraph.config;
+
+import com.intellij.notification.Notification;
+import com.intellij.notification.NotificationType;
+import com.intellij.notification.Notifications;
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.options.ShowSettingsUtil;
+import com.intellij.openapi.project.DumbAwareAction;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.startup.StartupActivity;
+import com.sourcegraph.Icons;
+import org.jetbrains.annotations.NotNull;
+
+public class NotificationActivity implements StartupActivity.DumbAware {
+    @Override
+    public void runActivity(@NotNull Project project) {
+        String url = ConfigUtil.getSourcegraphUrl(project);
+        if (ConfigUtil.isUrlNotificationDismissed(project) || (url.length() != 0 && !url.startsWith("https://sourcegraph.com"))) {
+            return;
+        }
+        // Display notification
+        Notification notification = new Notification("Sourcegraph", "Sourcegraph",
+            "A custom Sourcegraph URL is not set for this project. You can only access public repos. Do you want to set your custom URL?", NotificationType.INFORMATION);
+        AnAction setUrlAction = new DumbAwareAction("Set URL") {
+            @Override
+            public void actionPerformed(@NotNull AnActionEvent anActionEvent) {
+                ShowSettingsUtil.getInstance().showSettingsDialog(project, SettingsConfigurable.class);
+            }
+        };
+        AnAction cancelAction = new DumbAwareAction("Do not Set") {
+            @Override
+            public void actionPerformed(@NotNull AnActionEvent anActionEvent) {
+                notification.expire();
+            }
+        };
+        AnAction neverShowAgainAction = new DumbAwareAction("Never Show Again") {
+            @Override
+            public void actionPerformed(@NotNull AnActionEvent anActionEvent) {
+                notification.expire();
+                ConfigUtil.setUrlNotificationDismissed(project, true);
+            }
+        };
+        notification.setIcon(Icons.Logo);
+        notification.addAction(setUrlAction);
+        notification.addAction(cancelAction);
+        notification.addAction(neverShowAgainAction);
+        Notifications.Bus.notify(notification);
+    }
+}

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/NotificationActivity.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/NotificationActivity.java
@@ -28,7 +28,7 @@ public class NotificationActivity implements StartupActivity.DumbAware {
                 ShowSettingsUtil.getInstance().showSettingsDialog(project, SettingsConfigurable.class);
             }
         };
-        AnAction cancelAction = new DumbAwareAction("Do not Set") {
+        AnAction cancelAction = new DumbAwareAction("Do Not Set") {
             @Override
             public void actionPerformed(@NotNull AnActionEvent anActionEvent) {
                 notification.expire();

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsComponent.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsComponent.java
@@ -19,6 +19,7 @@ public class SettingsComponent {
     private final JBTextField defaultBranchNameTextField;
     private final JBTextField remoteUrlReplacementsTextField;
     private final JBCheckBox globbingCheckBox;
+    private final JBCheckBox isUrlNotificationDismissedCheckBox;
 
     public SettingsComponent() {
         JBLabel sourcegraphUrlLabel = new JBLabel("Sourcegraph URL:");
@@ -50,12 +51,15 @@ public class SettingsComponent {
 
         globbingCheckBox = new JBCheckBox("Enable globbing");
 
+        isUrlNotificationDismissedCheckBox = new JBCheckBox("Never show the \"No Sourcegraph URL set\" notification for this project");
+
         panel = FormBuilder.createFormBuilder()
             .addLabeledComponent(sourcegraphUrlLabel, sourcegraphUrlTextField, 1, false)
             .addLabeledComponent(accessTokenLabel, accessTokenTextField, 1, false)
             .addLabeledComponent(defaultBranchNameLabel, defaultBranchNameTextField, 1, false)
             .addLabeledComponent(remoteUrlReplacementsLabel, remoteUrlReplacementsTextField, 1, false)
             .addComponent(globbingCheckBox, 1)
+            .addComponent(isUrlNotificationDismissedCheckBox, 1)
             .addComponentFillVertically(new JPanel(), 0)
             .getPanel();
     }
@@ -112,4 +116,11 @@ public class SettingsComponent {
         globbingCheckBox.setSelected(value);
     }
 
+    public boolean isUrlNotificationDismissed() {
+        return isUrlNotificationDismissedCheckBox.isSelected();
+    }
+
+    public void setUrlNotificationDismissedEnabled(boolean value) {
+        isUrlNotificationDismissedCheckBox.setSelected(value);
+    }
 }

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsConfigurable.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsConfigurable.java
@@ -104,7 +104,7 @@ public class SettingsConfigurable implements Configurable {
         String remoteUrlReplacements = ConfigUtil.getRemoteUrlReplacements(project);
         mySettingsComponent.setRemoteUrlReplacements(remoteUrlReplacements);
         mySettingsComponent.setGlobbingEnabled(ConfigUtil.isGlobbingEnabled(project));
-        mySettingsComponent.setUrlNotificationDismissedEnabled(settings.isUrlNotificationDismissed());
+        mySettingsComponent.setUrlNotificationDismissedEnabled(ConfigUtil.isUrlNotificationDismissed());
     }
 
     @Override

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsConfigurable.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsConfigurable.java
@@ -43,7 +43,8 @@ public class SettingsConfigurable implements Configurable {
             || !mySettingsComponent.getAccessToken().equals(ConfigUtil.getAccessToken(project))
             || !mySettingsComponent.getDefaultBranchName().equals(ConfigUtil.getDefaultBranchName(project))
             || !mySettingsComponent.getRemoteUrlReplacements().equals(ConfigUtil.getRemoteUrlReplacements(project))
-            || mySettingsComponent.isGlobbingEnabled() != ConfigUtil.isGlobbingEnabled(project);
+            || mySettingsComponent.isGlobbingEnabled() != ConfigUtil.isGlobbingEnabled(project)
+            || mySettingsComponent.isUrlNotificationDismissed() != ConfigUtil.isUrlNotificationDismissed();
     }
 
     @Override
@@ -88,6 +89,7 @@ public class SettingsConfigurable implements Configurable {
         } else {
             aSettings.isGlobbingEnabled = mySettingsComponent.isGlobbingEnabled();
         }
+        aSettings.isUrlNotificationDismissed = mySettingsComponent.isUrlNotificationDismissed();
 
         publisher.afterAction(context);
     }
@@ -102,6 +104,7 @@ public class SettingsConfigurable implements Configurable {
         String remoteUrlReplacements = ConfigUtil.getRemoteUrlReplacements(project);
         mySettingsComponent.setRemoteUrlReplacements(remoteUrlReplacements);
         mySettingsComponent.setGlobbingEnabled(ConfigUtil.isGlobbingEnabled(project));
+        mySettingsComponent.setUrlNotificationDismissedEnabled(settings.isUrlNotificationDismissed());
     }
 
     @Override

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/SourcegraphApplicationService.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/SourcegraphApplicationService.java
@@ -23,6 +23,7 @@ public class SourcegraphApplicationService implements PersistentStateComponent<S
     @Nullable
     public String anonymousUserId;
     public boolean isInstallEventLogged;
+    public boolean isUrlNotificationDismissed;
 
     @NotNull
     public static SourcegraphApplicationService getInstance() {
@@ -63,6 +64,10 @@ public class SourcegraphApplicationService implements PersistentStateComponent<S
         return isInstallEventLogged;
     }
 
+    public boolean isUrlNotificationDismissed() {
+        return isUrlNotificationDismissed;
+    }
+
     @Nullable
     @Override
     public SourcegraphApplicationService getState() {
@@ -77,5 +82,6 @@ public class SourcegraphApplicationService implements PersistentStateComponent<S
         this.remoteUrlReplacements = settings.remoteUrlReplacements;
         this.isGlobbingEnabled = settings.isGlobbingEnabled;
         this.anonymousUserId = settings.anonymousUserId;
+        this.isUrlNotificationDismissed = settings.isUrlNotificationDismissed;
     }
 }

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/SourcegraphProjectService.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/SourcegraphProjectService.java
@@ -29,6 +29,8 @@ public class SourcegraphProjectService implements PersistentStateComponent<Sourc
     public String lastSearchPatternType;
     @Nullable
     public String lastSearchContextSpec;
+    public boolean isGlobbingEnabled;
+    public boolean isUrlNotificationDismissed;
 
     @NotNull
     public static SourcegraphProjectService getInstance(@NotNull Project project) {
@@ -69,6 +71,10 @@ public class SourcegraphProjectService implements PersistentStateComponent<Sourc
         }
     }
 
+    public boolean isUrlNotificationDismissed() {
+        return this.isUrlNotificationDismissed;
+    }
+
     @Nullable
     @Override
     public SourcegraphProjectService getState() {
@@ -86,5 +92,6 @@ public class SourcegraphProjectService implements PersistentStateComponent<Sourc
         this.lastSearchCaseSensitive = settings.lastSearchCaseSensitive;
         this.lastSearchPatternType = settings.lastSearchPatternType != null ? settings.lastSearchPatternType : "literal";
         this.lastSearchContextSpec = settings.lastSearchContextSpec != null ? settings.lastSearchContextSpec : "global";
+        this.isUrlNotificationDismissed = settings.isUrlNotificationDismissed;
     }
 }

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/SourcegraphProjectService.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/SourcegraphProjectService.java
@@ -29,8 +29,6 @@ public class SourcegraphProjectService implements PersistentStateComponent<Sourc
     public String lastSearchPatternType;
     @Nullable
     public String lastSearchContextSpec;
-    public boolean isGlobbingEnabled;
-    public boolean isUrlNotificationDismissed;
 
     @NotNull
     public static SourcegraphProjectService getInstance(@NotNull Project project) {
@@ -71,10 +69,6 @@ public class SourcegraphProjectService implements PersistentStateComponent<Sourc
         }
     }
 
-    public boolean isUrlNotificationDismissed() {
-        return this.isUrlNotificationDismissed;
-    }
-
     @Nullable
     @Override
     public SourcegraphProjectService getState() {
@@ -92,6 +86,5 @@ public class SourcegraphProjectService implements PersistentStateComponent<Sourc
         this.lastSearchCaseSensitive = settings.lastSearchCaseSensitive;
         this.lastSearchPatternType = settings.lastSearchPatternType != null ? settings.lastSearchPatternType : "literal";
         this.lastSearchContextSpec = settings.lastSearchContextSpec != null ? settings.lastSearchContextSpec : "global";
-        this.isUrlNotificationDismissed = settings.isUrlNotificationDismissed;
     }
 }

--- a/client/jetbrains/src/main/resources/META-INF/plugin.xml
+++ b/client/jetbrains/src/main/resources/META-INF/plugin.xml
@@ -21,6 +21,7 @@
         <notificationGroup id="Sourcegraph" displayType="BALLOON"/>
         <projectService id="sourcegraph.findService" serviceImplementation="com.sourcegraph.find.FindService"/>
         <postStartupActivity implementation="com.sourcegraph.telemetry.PostStartupActivity"/>
+        <postStartupActivity implementation="com.sourcegraph.config.NotificationActivity"/>
     </extensions>
 
     <actions>


### PR DESCRIPTION
Notification opens at each project load, unless it's dismissed.
Dismissal can be cleared in the plugin settings window.

Screenshots and details:

[Screen 1](https://share.cleanshot.com/hom3B3): This is what we could display at each project load when a custom URL is not set (and the notification hasn’t been dismissed) for the project.
Notification content is limited to two lines including the title plus actions, so the end of the sentence is hidden.
[Screen 2](https://share.cleanshot.com/KcF0FC): This is how it’d look when expanded
[Screen 3](https://share.cleanshot.com/KwqlHd): The “Set URL” link currently opens our Settings page, but it’s not necessarily the best action, we could also open a URL with some helpful instructions.

## Test plan

Tested in this [2-min Loom](https://www.loom.com/share/4dc0d7467c834b6a89f5143d8e7c9a00)

## App preview:

- [Web](https://sg-web-dv-jetbrains-add-custom-url.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-cwfatbsvhs.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
