### PR TITLE
db: add method to list Bitbucket Projects permissions sync jobs

### DIFF
--- a/internal/database/bitbucket_project_permissions.go
+++ b/internal/database/bitbucket_project_permissions.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"encoding/json"
+	"fmt"
 
 	"github.com/keegancsmith/sqlf"
 	"github.com/lib/pq"
@@ -25,6 +26,7 @@ type BitbucketProjectPermissionsStore interface {
 	Enqueue(ctx context.Context, projectKey string, externalServiceID int64, permissions []types.UserPermission, unrestricted bool) (int, error)
 	Transact(ctx context.Context) (BitbucketProjectPermissionsStore, error)
 	Done(err error) error
+	ListWorkerJobs(ctx context.Context, opt ListWorkerJobsOptions) ([]*types.BitbucketProjectPermissionJob, error)
 }
 
 type bitbucketProjectPermissionsStore struct {
@@ -116,43 +118,124 @@ func ScanFirstBitbucketProjectPermissionsJob(rows *sql.Rows, queryErr error) (_ 
 	defer func() { err = basestore.CloseRows(rows, err) }()
 
 	if rows.Next() {
-		var job types.BitbucketProjectPermissionJob
-		var executionLogs []dbworkerstore.ExecutionLogEntry
-		var permissions []userPermission
-
-		if err := rows.Scan(
-			&job.ID,
-			&job.State,
-			&job.FailureMessage,
-			&job.QueuedAt,
-			&job.StartedAt,
-			&job.FinishedAt,
-			&job.ProcessAfter,
-			&job.NumResets,
-			&job.NumFailures,
-			&dbutil.NullTime{Time: &job.LastHeartbeatAt},
-			pq.Array(&executionLogs),
-			&job.WorkerHostname,
-			&job.ProjectKey,
-			&job.ExternalServiceID,
-			pq.Array(&permissions),
-			&job.Unrestricted,
-		); err != nil {
+		job, err := scanOneJob(rows)
+		if err != nil {
 			return nil, false, err
 		}
 
-		for _, entry := range executionLogs {
-			job.ExecutionLogs = append(job.ExecutionLogs, workerutil.ExecutionLogEntry(entry))
-		}
-
-		for _, perm := range permissions {
-			job.Permissions = append(job.Permissions, types.UserPermission(perm))
-		}
-
-		return &job, true, nil
+		return job, true, nil
 	}
 
 	return nil, false, nil
+}
+
+type ListWorkerJobsOptions struct {
+	ProjectKey string
+	Status     string
+	Count      int
+}
+
+// ListWorkerJobs returns a list of types.BitbucketProjectPermissionJob for a given set
+// of query options: ListWorkerJobsOptions
+func (s *bitbucketProjectPermissionsStore) ListWorkerJobs(
+	ctx context.Context,
+	opt ListWorkerJobsOptions,
+) (jobs []*types.BitbucketProjectPermissionJob, err error) {
+	query := listWorkerJobsQuery(opt)
+
+	rows, err := s.Query(ctx, query)
+
+	if err != nil {
+		return nil, err
+	}
+
+	defer func() { err = basestore.CloseRows(rows, err) }()
+
+	for rows.Next() {
+		var job *types.BitbucketProjectPermissionJob
+		job, err = scanOneJob(rows)
+		if err != nil {
+			return nil, err
+		}
+
+		jobs = append(jobs, job)
+	}
+
+	return
+}
+
+func scanOneJob(rows *sql.Rows) (*types.BitbucketProjectPermissionJob, error) {
+	var job types.BitbucketProjectPermissionJob
+	var executionLogs []dbworkerstore.ExecutionLogEntry
+	var permissions []userPermission
+
+	if err := rows.Scan(
+		&job.ID,
+		&job.State,
+		&job.FailureMessage,
+		&job.QueuedAt,
+		&job.StartedAt,
+		&job.FinishedAt,
+		&job.ProcessAfter,
+		&job.NumResets,
+		&job.NumFailures,
+		&dbutil.NullTime{Time: &job.LastHeartbeatAt},
+		pq.Array(&executionLogs),
+		&job.WorkerHostname,
+		&job.ProjectKey,
+		&job.ExternalServiceID,
+		pq.Array(&permissions),
+		&job.Unrestricted,
+	); err != nil {
+		return nil, err
+	}
+
+	for _, entry := range executionLogs {
+		job.ExecutionLogs = append(job.ExecutionLogs, workerutil.ExecutionLogEntry(entry))
+	}
+
+	for _, perm := range permissions {
+		job.Permissions = append(job.Permissions, types.UserPermission(perm))
+	}
+	return &job, nil
+}
+
+const maxJobsCount = 10000
+
+func listWorkerJobsQuery(opt ListWorkerJobsOptions) *sqlf.Query {
+	var where []*sqlf.Query
+
+	q := `
+-- source: internal/database/bitbucket_project_permissions.go:BitbucketProjectPermissionsStore.listWorkerJobsQuery
+SELECT id, state, failure_message, queued_at, started_at, finished_at, process_after, num_resets, num_failures, last_heartbeat_at, execution_logs, worker_hostname, project_key, external_services_id, permissions, unrestricted
+FROM explicit_permissions_bitbucket_project_jobs
+%%s
+ORDER BY queued_at DESC
+LIMIT %d
+`
+
+	if opt.ProjectKey != "" {
+		where = append(where, sqlf.Sprintf("project_key = %s", opt.ProjectKey))
+	}
+
+	if opt.Status != "" {
+		where = append(where, sqlf.Sprintf("status = %s", opt.Status))
+	}
+
+	whereClause := sqlf.Sprintf("")
+	if len(where) != 0 {
+		whereClause = sqlf.Sprintf("WHERE %s", sqlf.Join(where, " AND"))
+	}
+
+	limitNum := 100
+
+	if opt.Count > 0 && opt.Count < maxJobsCount {
+		limitNum = opt.Count
+	} else if opt.Count >= maxJobsCount {
+		limitNum = maxJobsCount
+	}
+
+	return sqlf.Sprintf(fmt.Sprintf(q, limitNum), whereClause)
 }
 
 type userPermission types.UserPermission

--- a/internal/database/bitbucket_project_permissions_test.go
+++ b/internal/database/bitbucket_project_permissions_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/keegancsmith/sqlf"
 	"github.com/stretchr/testify/require"
 
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
@@ -170,6 +171,45 @@ func TestScanFirstBitbucketProjectPermissionsJob(t *testing.T) {
 		Permissions:       []types.UserPermission{{Permission: "read", BindID: "omar@sourcegraph.com"}},
 		Unrestricted:      false,
 	}, record)
+}
+
+func TestListWorkerJobsQuery(t *testing.T) {
+	t.Run("no options set", func(t *testing.T) {
+		got := listWorkerJobsQuery(ListWorkerJobsOptions{})
+		gotString := got.Query(sqlf.PostgresBindVar)
+
+		want := `
+-- source: internal/database/bitbucket_project_permissions.go:BitbucketProjectPermissionsStore.listWorkerJobsQuery
+SELECT id, state, failure_message, queued_at, started_at, finished_at, process_after, num_resets, num_failures, last_heartbeat_at, execution_logs, worker_hostname, project_key, external_services_id, permissions, unrestricted
+FROM explicit_permissions_bitbucket_project_jobs
+
+ORDER BY queued_at DESC
+LIMIT 100
+`
+
+		require.Equal(t, want, gotString)
+	})
+	t.Run("all options set", func(t *testing.T) {
+		got := listWorkerJobsQuery(ListWorkerJobsOptions{
+			ProjectKey: "123",
+			Status:     "completed",
+			Count:      1337,
+		})
+
+		gotString := got.Query(sqlf.PostgresBindVar)
+		want := `
+-- source: internal/database/bitbucket_project_permissions.go:BitbucketProjectPermissionsStore.listWorkerJobsQuery
+SELECT id, state, failure_message, queued_at, started_at, finished_at, process_after, num_resets, num_failures, last_heartbeat_at, execution_logs, worker_hostname, project_key, external_services_id, permissions, unrestricted
+FROM explicit_permissions_bitbucket_project_jobs
+WHERE project_key = $1  AND status = $2
+ORDER BY queued_at DESC
+LIMIT 1337
+`
+
+		require.Equal(t, want, gotString)
+		require.Equal(t, got.Args()[0], "123")
+		require.Equal(t, got.Args()[1], "completed")
+	})
 }
 
 func intPtr(v int) *int          { return &v }

--- a/internal/database/bitbucket_project_permissions_test.go
+++ b/internal/database/bitbucket_project_permissions_test.go
@@ -175,7 +175,7 @@ func TestScanFirstBitbucketProjectPermissionsJob(t *testing.T) {
 
 func TestListWorkerJobsQuery(t *testing.T) {
 	t.Run("no options set", func(t *testing.T) {
-		got := listWorkerJobsQuery(ListWorkerJobsOptions{})
+		got := listWorkerJobsQuery(ListJobsOptions{})
 		gotString := got.Query(sqlf.PostgresBindVar)
 
 		want := `
@@ -190,7 +190,7 @@ LIMIT 100
 		require.Equal(t, want, gotString)
 	})
 	t.Run("all options set", func(t *testing.T) {
-		got := listWorkerJobsQuery(ListWorkerJobsOptions{
+		got := listWorkerJobsQuery(ListJobsOptions{
 			ProjectKey: "123",
 			Status:     "completed",
 			Count:      1337,

--- a/internal/database/bitbucket_project_permissions_test.go
+++ b/internal/database/bitbucket_project_permissions_test.go
@@ -193,7 +193,7 @@ LIMIT 100
 		got := listWorkerJobsQuery(ListJobsOptions{
 			ProjectKey: "123",
 			Status:     "completed",
-			Count:      1337,
+			Count:      337,
 		})
 
 		gotString := got.Query(sqlf.PostgresBindVar)
@@ -203,7 +203,7 @@ SELECT id, state, failure_message, queued_at, started_at, finished_at, process_a
 FROM explicit_permissions_bitbucket_project_jobs
 WHERE project_key = $1  AND status = $2
 ORDER BY queued_at DESC
-LIMIT 1337
+LIMIT 337
 `
 
 		require.Equal(t, want, gotString)

--- a/internal/database/mocks_temp.go
+++ b/internal/database/mocks_temp.go
@@ -2087,6 +2087,9 @@ type MockBitbucketProjectPermissionsStore struct {
 	// HandleFunc is an instance of a mock function object controlling the
 	// behavior of the method Handle.
 	HandleFunc *BitbucketProjectPermissionsStoreHandleFunc
+	// ListWorkerJobsFunc is an instance of a mock function object
+	// controlling the behavior of the method ListWorkerJobs.
+	ListWorkerJobsFunc *BitbucketProjectPermissionsStoreListWorkerJobsFunc
 	// TransactFunc is an instance of a mock function object controlling the
 	// behavior of the method Transact.
 	TransactFunc *BitbucketProjectPermissionsStoreTransactFunc
@@ -2112,6 +2115,11 @@ func NewMockBitbucketProjectPermissionsStore() *MockBitbucketProjectPermissionsS
 		},
 		HandleFunc: &BitbucketProjectPermissionsStoreHandleFunc{
 			defaultHook: func() (r0 *basestore.TransactableHandle) {
+				return
+			},
+		},
+		ListWorkerJobsFunc: &BitbucketProjectPermissionsStoreListWorkerJobsFunc{
+			defaultHook: func(context.Context, ListWorkerJobsOptions) (r0 []*types.BitbucketProjectPermissionJob, r1 error) {
 				return
 			},
 		},
@@ -2148,6 +2156,11 @@ func NewStrictMockBitbucketProjectPermissionsStore() *MockBitbucketProjectPermis
 				panic("unexpected invocation of MockBitbucketProjectPermissionsStore.Handle")
 			},
 		},
+		ListWorkerJobsFunc: &BitbucketProjectPermissionsStoreListWorkerJobsFunc{
+			defaultHook: func(context.Context, ListWorkerJobsOptions) ([]*types.BitbucketProjectPermissionJob, error) {
+				panic("unexpected invocation of MockBitbucketProjectPermissionsStore.ListWorkerJobs")
+			},
+		},
 		TransactFunc: &BitbucketProjectPermissionsStoreTransactFunc{
 			defaultHook: func(context.Context) (BitbucketProjectPermissionsStore, error) {
 				panic("unexpected invocation of MockBitbucketProjectPermissionsStore.Transact")
@@ -2174,6 +2187,9 @@ func NewMockBitbucketProjectPermissionsStoreFrom(i BitbucketProjectPermissionsSt
 		},
 		HandleFunc: &BitbucketProjectPermissionsStoreHandleFunc{
 			defaultHook: i.Handle,
+		},
+		ListWorkerJobsFunc: &BitbucketProjectPermissionsStoreListWorkerJobsFunc{
+			defaultHook: i.ListWorkerJobs,
 		},
 		TransactFunc: &BitbucketProjectPermissionsStoreTransactFunc{
 			defaultHook: i.Transact,
@@ -2512,6 +2528,118 @@ func (c BitbucketProjectPermissionsStoreHandleFuncCall) Args() []interface{} {
 // invocation.
 func (c BitbucketProjectPermissionsStoreHandleFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
+}
+
+// BitbucketProjectPermissionsStoreListWorkerJobsFunc describes the behavior
+// when the ListWorkerJobs method of the parent
+// MockBitbucketProjectPermissionsStore instance is invoked.
+type BitbucketProjectPermissionsStoreListWorkerJobsFunc struct {
+	defaultHook func(context.Context, ListWorkerJobsOptions) ([]*types.BitbucketProjectPermissionJob, error)
+	hooks       []func(context.Context, ListWorkerJobsOptions) ([]*types.BitbucketProjectPermissionJob, error)
+	history     []BitbucketProjectPermissionsStoreListWorkerJobsFuncCall
+	mutex       sync.Mutex
+}
+
+// ListWorkerJobs delegates to the next hook function in the queue and
+// stores the parameter and result values of this invocation.
+func (m *MockBitbucketProjectPermissionsStore) ListWorkerJobs(v0 context.Context, v1 ListWorkerJobsOptions) ([]*types.BitbucketProjectPermissionJob, error) {
+	r0, r1 := m.ListWorkerJobsFunc.nextHook()(v0, v1)
+	m.ListWorkerJobsFunc.appendCall(BitbucketProjectPermissionsStoreListWorkerJobsFuncCall{v0, v1, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the ListWorkerJobs
+// method of the parent MockBitbucketProjectPermissionsStore instance is
+// invoked and the hook queue is empty.
+func (f *BitbucketProjectPermissionsStoreListWorkerJobsFunc) SetDefaultHook(hook func(context.Context, ListWorkerJobsOptions) ([]*types.BitbucketProjectPermissionJob, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// ListWorkerJobs method of the parent MockBitbucketProjectPermissionsStore
+// instance invokes the hook at the front of the queue and discards it.
+// After the queue is empty, the default hook function is invoked for any
+// future action.
+func (f *BitbucketProjectPermissionsStoreListWorkerJobsFunc) PushHook(hook func(context.Context, ListWorkerJobsOptions) ([]*types.BitbucketProjectPermissionJob, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *BitbucketProjectPermissionsStoreListWorkerJobsFunc) SetDefaultReturn(r0 []*types.BitbucketProjectPermissionJob, r1 error) {
+	f.SetDefaultHook(func(context.Context, ListWorkerJobsOptions) ([]*types.BitbucketProjectPermissionJob, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *BitbucketProjectPermissionsStoreListWorkerJobsFunc) PushReturn(r0 []*types.BitbucketProjectPermissionJob, r1 error) {
+	f.PushHook(func(context.Context, ListWorkerJobsOptions) ([]*types.BitbucketProjectPermissionJob, error) {
+		return r0, r1
+	})
+}
+
+func (f *BitbucketProjectPermissionsStoreListWorkerJobsFunc) nextHook() func(context.Context, ListWorkerJobsOptions) ([]*types.BitbucketProjectPermissionJob, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *BitbucketProjectPermissionsStoreListWorkerJobsFunc) appendCall(r0 BitbucketProjectPermissionsStoreListWorkerJobsFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of
+// BitbucketProjectPermissionsStoreListWorkerJobsFuncCall objects describing
+// the invocations of this function.
+func (f *BitbucketProjectPermissionsStoreListWorkerJobsFunc) History() []BitbucketProjectPermissionsStoreListWorkerJobsFuncCall {
+	f.mutex.Lock()
+	history := make([]BitbucketProjectPermissionsStoreListWorkerJobsFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// BitbucketProjectPermissionsStoreListWorkerJobsFuncCall is an object that
+// describes an invocation of method ListWorkerJobs on an instance of
+// MockBitbucketProjectPermissionsStore.
+type BitbucketProjectPermissionsStoreListWorkerJobsFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 ListWorkerJobsOptions
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 []*types.BitbucketProjectPermissionJob
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c BitbucketProjectPermissionsStoreListWorkerJobsFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c BitbucketProjectPermissionsStoreListWorkerJobsFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
 }
 
 // BitbucketProjectPermissionsStoreTransactFunc describes the behavior when

--- a/internal/database/mocks_temp.go
+++ b/internal/database/mocks_temp.go
@@ -2119,7 +2119,7 @@ func NewMockBitbucketProjectPermissionsStore() *MockBitbucketProjectPermissionsS
 			},
 		},
 		ListWorkerJobsFunc: &BitbucketProjectPermissionsStoreListWorkerJobsFunc{
-			defaultHook: func(context.Context, ListWorkerJobsOptions) (r0 []*types.BitbucketProjectPermissionJob, r1 error) {
+			defaultHook: func(context.Context, ListJobsOptions) (r0 []*types.BitbucketProjectPermissionJob, r1 error) {
 				return
 			},
 		},
@@ -2157,8 +2157,8 @@ func NewStrictMockBitbucketProjectPermissionsStore() *MockBitbucketProjectPermis
 			},
 		},
 		ListWorkerJobsFunc: &BitbucketProjectPermissionsStoreListWorkerJobsFunc{
-			defaultHook: func(context.Context, ListWorkerJobsOptions) ([]*types.BitbucketProjectPermissionJob, error) {
-				panic("unexpected invocation of MockBitbucketProjectPermissionsStore.ListWorkerJobs")
+			defaultHook: func(context.Context, ListJobsOptions) ([]*types.BitbucketProjectPermissionJob, error) {
+				panic("unexpected invocation of MockBitbucketProjectPermissionsStore.ListJobs")
 			},
 		},
 		TransactFunc: &BitbucketProjectPermissionsStoreTransactFunc{
@@ -2189,7 +2189,7 @@ func NewMockBitbucketProjectPermissionsStoreFrom(i BitbucketProjectPermissionsSt
 			defaultHook: i.Handle,
 		},
 		ListWorkerJobsFunc: &BitbucketProjectPermissionsStoreListWorkerJobsFunc{
-			defaultHook: i.ListWorkerJobs,
+			defaultHook: i.ListJobs,
 		},
 		TransactFunc: &BitbucketProjectPermissionsStoreTransactFunc{
 			defaultHook: i.Transact,
@@ -2531,36 +2531,36 @@ func (c BitbucketProjectPermissionsStoreHandleFuncCall) Results() []interface{} 
 }
 
 // BitbucketProjectPermissionsStoreListWorkerJobsFunc describes the behavior
-// when the ListWorkerJobs method of the parent
+// when the ListJobs method of the parent
 // MockBitbucketProjectPermissionsStore instance is invoked.
 type BitbucketProjectPermissionsStoreListWorkerJobsFunc struct {
-	defaultHook func(context.Context, ListWorkerJobsOptions) ([]*types.BitbucketProjectPermissionJob, error)
-	hooks       []func(context.Context, ListWorkerJobsOptions) ([]*types.BitbucketProjectPermissionJob, error)
+	defaultHook func(context.Context, ListJobsOptions) ([]*types.BitbucketProjectPermissionJob, error)
+	hooks       []func(context.Context, ListJobsOptions) ([]*types.BitbucketProjectPermissionJob, error)
 	history     []BitbucketProjectPermissionsStoreListWorkerJobsFuncCall
 	mutex       sync.Mutex
 }
 
 // ListWorkerJobs delegates to the next hook function in the queue and
 // stores the parameter and result values of this invocation.
-func (m *MockBitbucketProjectPermissionsStore) ListWorkerJobs(v0 context.Context, v1 ListWorkerJobsOptions) ([]*types.BitbucketProjectPermissionJob, error) {
+func (m *MockBitbucketProjectPermissionsStore) ListJobs(v0 context.Context, v1 ListJobsOptions) ([]*types.BitbucketProjectPermissionJob, error) {
 	r0, r1 := m.ListWorkerJobsFunc.nextHook()(v0, v1)
 	m.ListWorkerJobsFunc.appendCall(BitbucketProjectPermissionsStoreListWorkerJobsFuncCall{v0, v1, r0, r1})
 	return r0, r1
 }
 
-// SetDefaultHook sets function that is called when the ListWorkerJobs
+// SetDefaultHook sets function that is called when the ListJobs
 // method of the parent MockBitbucketProjectPermissionsStore instance is
 // invoked and the hook queue is empty.
-func (f *BitbucketProjectPermissionsStoreListWorkerJobsFunc) SetDefaultHook(hook func(context.Context, ListWorkerJobsOptions) ([]*types.BitbucketProjectPermissionJob, error)) {
+func (f *BitbucketProjectPermissionsStoreListWorkerJobsFunc) SetDefaultHook(hook func(context.Context, ListJobsOptions) ([]*types.BitbucketProjectPermissionJob, error)) {
 	f.defaultHook = hook
 }
 
 // PushHook adds a function to the end of hook queue. Each invocation of the
-// ListWorkerJobs method of the parent MockBitbucketProjectPermissionsStore
+// ListJobs method of the parent MockBitbucketProjectPermissionsStore
 // instance invokes the hook at the front of the queue and discards it.
 // After the queue is empty, the default hook function is invoked for any
 // future action.
-func (f *BitbucketProjectPermissionsStoreListWorkerJobsFunc) PushHook(hook func(context.Context, ListWorkerJobsOptions) ([]*types.BitbucketProjectPermissionJob, error)) {
+func (f *BitbucketProjectPermissionsStoreListWorkerJobsFunc) PushHook(hook func(context.Context, ListJobsOptions) ([]*types.BitbucketProjectPermissionJob, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -2569,19 +2569,19 @@ func (f *BitbucketProjectPermissionsStoreListWorkerJobsFunc) PushHook(hook func(
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
 func (f *BitbucketProjectPermissionsStoreListWorkerJobsFunc) SetDefaultReturn(r0 []*types.BitbucketProjectPermissionJob, r1 error) {
-	f.SetDefaultHook(func(context.Context, ListWorkerJobsOptions) ([]*types.BitbucketProjectPermissionJob, error) {
+	f.SetDefaultHook(func(context.Context, ListJobsOptions) ([]*types.BitbucketProjectPermissionJob, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
 func (f *BitbucketProjectPermissionsStoreListWorkerJobsFunc) PushReturn(r0 []*types.BitbucketProjectPermissionJob, r1 error) {
-	f.PushHook(func(context.Context, ListWorkerJobsOptions) ([]*types.BitbucketProjectPermissionJob, error) {
+	f.PushHook(func(context.Context, ListJobsOptions) ([]*types.BitbucketProjectPermissionJob, error) {
 		return r0, r1
 	})
 }
 
-func (f *BitbucketProjectPermissionsStoreListWorkerJobsFunc) nextHook() func(context.Context, ListWorkerJobsOptions) ([]*types.BitbucketProjectPermissionJob, error) {
+func (f *BitbucketProjectPermissionsStoreListWorkerJobsFunc) nextHook() func(context.Context, ListJobsOptions) ([]*types.BitbucketProjectPermissionJob, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -2613,7 +2613,7 @@ func (f *BitbucketProjectPermissionsStoreListWorkerJobsFunc) History() []Bitbuck
 }
 
 // BitbucketProjectPermissionsStoreListWorkerJobsFuncCall is an object that
-// describes an invocation of method ListWorkerJobs on an instance of
+// describes an invocation of method ListJobs on an instance of
 // MockBitbucketProjectPermissionsStore.
 type BitbucketProjectPermissionsStoreListWorkerJobsFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
@@ -2621,7 +2621,7 @@ type BitbucketProjectPermissionsStoreListWorkerJobsFuncCall struct {
 	Arg0 context.Context
 	// Arg1 is the value of the 2nd argument passed to this method
 	// invocation.
-	Arg1 ListWorkerJobsOptions
+	Arg1 ListJobsOptions
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 []*types.BitbucketProjectPermissionJob

--- a/internal/database/mocks_temp.go
+++ b/internal/database/mocks_temp.go
@@ -2087,9 +2087,9 @@ type MockBitbucketProjectPermissionsStore struct {
 	// HandleFunc is an instance of a mock function object controlling the
 	// behavior of the method Handle.
 	HandleFunc *BitbucketProjectPermissionsStoreHandleFunc
-	// ListWorkerJobsFunc is an instance of a mock function object
-	// controlling the behavior of the method ListWorkerJobs.
-	ListWorkerJobsFunc *BitbucketProjectPermissionsStoreListWorkerJobsFunc
+	// ListJobsFunc is an instance of a mock function object controlling the
+	// behavior of the method ListJobs.
+	ListJobsFunc *BitbucketProjectPermissionsStoreListJobsFunc
 	// TransactFunc is an instance of a mock function object controlling the
 	// behavior of the method Transact.
 	TransactFunc *BitbucketProjectPermissionsStoreTransactFunc
@@ -2118,7 +2118,7 @@ func NewMockBitbucketProjectPermissionsStore() *MockBitbucketProjectPermissionsS
 				return
 			},
 		},
-		ListWorkerJobsFunc: &BitbucketProjectPermissionsStoreListWorkerJobsFunc{
+		ListJobsFunc: &BitbucketProjectPermissionsStoreListJobsFunc{
 			defaultHook: func(context.Context, ListJobsOptions) (r0 []*types.BitbucketProjectPermissionJob, r1 error) {
 				return
 			},
@@ -2156,7 +2156,7 @@ func NewStrictMockBitbucketProjectPermissionsStore() *MockBitbucketProjectPermis
 				panic("unexpected invocation of MockBitbucketProjectPermissionsStore.Handle")
 			},
 		},
-		ListWorkerJobsFunc: &BitbucketProjectPermissionsStoreListWorkerJobsFunc{
+		ListJobsFunc: &BitbucketProjectPermissionsStoreListJobsFunc{
 			defaultHook: func(context.Context, ListJobsOptions) ([]*types.BitbucketProjectPermissionJob, error) {
 				panic("unexpected invocation of MockBitbucketProjectPermissionsStore.ListJobs")
 			},
@@ -2188,7 +2188,7 @@ func NewMockBitbucketProjectPermissionsStoreFrom(i BitbucketProjectPermissionsSt
 		HandleFunc: &BitbucketProjectPermissionsStoreHandleFunc{
 			defaultHook: i.Handle,
 		},
-		ListWorkerJobsFunc: &BitbucketProjectPermissionsStoreListWorkerJobsFunc{
+		ListJobsFunc: &BitbucketProjectPermissionsStoreListJobsFunc{
 			defaultHook: i.ListJobs,
 		},
 		TransactFunc: &BitbucketProjectPermissionsStoreTransactFunc{
@@ -2530,28 +2530,28 @@ func (c BitbucketProjectPermissionsStoreHandleFuncCall) Results() []interface{} 
 	return []interface{}{c.Result0}
 }
 
-// BitbucketProjectPermissionsStoreListWorkerJobsFunc describes the behavior
-// when the ListJobs method of the parent
-// MockBitbucketProjectPermissionsStore instance is invoked.
-type BitbucketProjectPermissionsStoreListWorkerJobsFunc struct {
+// BitbucketProjectPermissionsStoreListJobsFunc describes the behavior when
+// the ListJobs method of the parent MockBitbucketProjectPermissionsStore
+// instance is invoked.
+type BitbucketProjectPermissionsStoreListJobsFunc struct {
 	defaultHook func(context.Context, ListJobsOptions) ([]*types.BitbucketProjectPermissionJob, error)
 	hooks       []func(context.Context, ListJobsOptions) ([]*types.BitbucketProjectPermissionJob, error)
-	history     []BitbucketProjectPermissionsStoreListWorkerJobsFuncCall
+	history     []BitbucketProjectPermissionsStoreListJobsFuncCall
 	mutex       sync.Mutex
 }
 
-// ListWorkerJobs delegates to the next hook function in the queue and
-// stores the parameter and result values of this invocation.
+// ListJobs delegates to the next hook function in the queue and stores the
+// parameter and result values of this invocation.
 func (m *MockBitbucketProjectPermissionsStore) ListJobs(v0 context.Context, v1 ListJobsOptions) ([]*types.BitbucketProjectPermissionJob, error) {
-	r0, r1 := m.ListWorkerJobsFunc.nextHook()(v0, v1)
-	m.ListWorkerJobsFunc.appendCall(BitbucketProjectPermissionsStoreListWorkerJobsFuncCall{v0, v1, r0, r1})
+	r0, r1 := m.ListJobsFunc.nextHook()(v0, v1)
+	m.ListJobsFunc.appendCall(BitbucketProjectPermissionsStoreListJobsFuncCall{v0, v1, r0, r1})
 	return r0, r1
 }
 
-// SetDefaultHook sets function that is called when the ListJobs
-// method of the parent MockBitbucketProjectPermissionsStore instance is
-// invoked and the hook queue is empty.
-func (f *BitbucketProjectPermissionsStoreListWorkerJobsFunc) SetDefaultHook(hook func(context.Context, ListJobsOptions) ([]*types.BitbucketProjectPermissionJob, error)) {
+// SetDefaultHook sets function that is called when the ListJobs method of
+// the parent MockBitbucketProjectPermissionsStore instance is invoked and
+// the hook queue is empty.
+func (f *BitbucketProjectPermissionsStoreListJobsFunc) SetDefaultHook(hook func(context.Context, ListJobsOptions) ([]*types.BitbucketProjectPermissionJob, error)) {
 	f.defaultHook = hook
 }
 
@@ -2560,7 +2560,7 @@ func (f *BitbucketProjectPermissionsStoreListWorkerJobsFunc) SetDefaultHook(hook
 // instance invokes the hook at the front of the queue and discards it.
 // After the queue is empty, the default hook function is invoked for any
 // future action.
-func (f *BitbucketProjectPermissionsStoreListWorkerJobsFunc) PushHook(hook func(context.Context, ListJobsOptions) ([]*types.BitbucketProjectPermissionJob, error)) {
+func (f *BitbucketProjectPermissionsStoreListJobsFunc) PushHook(hook func(context.Context, ListJobsOptions) ([]*types.BitbucketProjectPermissionJob, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -2568,20 +2568,20 @@ func (f *BitbucketProjectPermissionsStoreListWorkerJobsFunc) PushHook(hook func(
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *BitbucketProjectPermissionsStoreListWorkerJobsFunc) SetDefaultReturn(r0 []*types.BitbucketProjectPermissionJob, r1 error) {
+func (f *BitbucketProjectPermissionsStoreListJobsFunc) SetDefaultReturn(r0 []*types.BitbucketProjectPermissionJob, r1 error) {
 	f.SetDefaultHook(func(context.Context, ListJobsOptions) ([]*types.BitbucketProjectPermissionJob, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *BitbucketProjectPermissionsStoreListWorkerJobsFunc) PushReturn(r0 []*types.BitbucketProjectPermissionJob, r1 error) {
+func (f *BitbucketProjectPermissionsStoreListJobsFunc) PushReturn(r0 []*types.BitbucketProjectPermissionJob, r1 error) {
 	f.PushHook(func(context.Context, ListJobsOptions) ([]*types.BitbucketProjectPermissionJob, error) {
 		return r0, r1
 	})
 }
 
-func (f *BitbucketProjectPermissionsStoreListWorkerJobsFunc) nextHook() func(context.Context, ListJobsOptions) ([]*types.BitbucketProjectPermissionJob, error) {
+func (f *BitbucketProjectPermissionsStoreListJobsFunc) nextHook() func(context.Context, ListJobsOptions) ([]*types.BitbucketProjectPermissionJob, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -2594,28 +2594,28 @@ func (f *BitbucketProjectPermissionsStoreListWorkerJobsFunc) nextHook() func(con
 	return hook
 }
 
-func (f *BitbucketProjectPermissionsStoreListWorkerJobsFunc) appendCall(r0 BitbucketProjectPermissionsStoreListWorkerJobsFuncCall) {
+func (f *BitbucketProjectPermissionsStoreListJobsFunc) appendCall(r0 BitbucketProjectPermissionsStoreListJobsFuncCall) {
 	f.mutex.Lock()
 	f.history = append(f.history, r0)
 	f.mutex.Unlock()
 }
 
 // History returns a sequence of
-// BitbucketProjectPermissionsStoreListWorkerJobsFuncCall objects describing
-// the invocations of this function.
-func (f *BitbucketProjectPermissionsStoreListWorkerJobsFunc) History() []BitbucketProjectPermissionsStoreListWorkerJobsFuncCall {
+// BitbucketProjectPermissionsStoreListJobsFuncCall objects describing the
+// invocations of this function.
+func (f *BitbucketProjectPermissionsStoreListJobsFunc) History() []BitbucketProjectPermissionsStoreListJobsFuncCall {
 	f.mutex.Lock()
-	history := make([]BitbucketProjectPermissionsStoreListWorkerJobsFuncCall, len(f.history))
+	history := make([]BitbucketProjectPermissionsStoreListJobsFuncCall, len(f.history))
 	copy(history, f.history)
 	f.mutex.Unlock()
 
 	return history
 }
 
-// BitbucketProjectPermissionsStoreListWorkerJobsFuncCall is an object that
+// BitbucketProjectPermissionsStoreListJobsFuncCall is an object that
 // describes an invocation of method ListJobs on an instance of
 // MockBitbucketProjectPermissionsStore.
-type BitbucketProjectPermissionsStoreListWorkerJobsFuncCall struct {
+type BitbucketProjectPermissionsStoreListJobsFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.
 	Arg0 context.Context
@@ -2632,13 +2632,13 @@ type BitbucketProjectPermissionsStoreListWorkerJobsFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c BitbucketProjectPermissionsStoreListWorkerJobsFuncCall) Args() []interface{} {
+func (c BitbucketProjectPermissionsStoreListJobsFuncCall) Args() []interface{} {
 	return []interface{}{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c BitbucketProjectPermissionsStoreListWorkerJobsFuncCall) Results() []interface{} {
+func (c BitbucketProjectPermissionsStoreListJobsFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 


### PR DESCRIPTION
This is a first part of finishing off the https://github.com/sourcegraph/sourcegraph/issues/36453 which adds a more generic way of getting jobs from the database:

- We get full entities as is instead of a trimmed versions which final structure is TBD
- We probably miss some required options
- `ProjectKey` and `Status` are not slices, but single values -- will be updated in next commit
- Only the test checking the query itself is written, more real test with fetching data from DB will be added as soon as output (endpoint response) structure is finalised

Part of https://github.com/sourcegraph/sourcegraph/issues/36453

## Test plan
Unit test added, all existing tests should pass
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
