### PR TITLE
pr-auditor: add a flag to pass additional context

### DIFF
--- a/dev/pr-auditor/issue.go
+++ b/dev/pr-auditor/issue.go
@@ -10,7 +10,7 @@ const (
 	testPlanDocs = "https://docs.sourcegraph.com/dev/background-information/testing_principles#test-plans"
 )
 
-func generateExceptionIssue(payload *EventPayload, result *checkResult) *github.IssueRequest {
+func generateExceptionIssue(payload *EventPayload, result *checkResult, additionalContext string) *github.IssueRequest {
 	// 🚨 SECURITY: Do not reference other potentially sensitive fields of pull requests
 	prTitle := payload.PullRequest.Title
 	if payload.Repository.Private {
@@ -50,6 +50,10 @@ func generateExceptionIssue(payload *EventPayload, result *checkResult) *github.
 
 	if result.ProtectedBranch {
 		issueBody += fmt.Sprintf("\n\nThe base branch %q is protected and should not have direct pull requests to it.", payload.PullRequest.Base.Ref)
+	}
+
+	if additionalContext != "" {
+		issueBody += fmt.Sprintf("\n\n%s", additionalContext)
 	}
 
 	user := payload.PullRequest.MergedBy.Login

--- a/dev/pr-auditor/issue_test.go
+++ b/dev/pr-auditor/issue_test.go
@@ -79,7 +79,7 @@ func TestGenerateExceptionIssue(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := generateExceptionIssue(&tt.payload, &tt.result)
+			got := generateExceptionIssue(&tt.payload, &tt.result, "")
 			t.Log(got.GetTitle(), "\n", got.GetBody())
 			assert.Equal(t, tt.wantAssignees, got.GetAssignees())
 			assert.Equal(t, tt.wantLabels, got.GetLabels())


### PR DESCRIPTION
Partly fixes 37121 
## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
