### PR TITLE
[SG-36511] Accessibility: Notepad ARC toolkit issues

### DIFF
--- a/client/web/src/search/Notepad.tsx
+++ b/client/web/src/search/Notepad.tsx
@@ -564,7 +564,10 @@ const NotepadEntryComponent: React.FunctionComponent<React.PropsWithChildren<Not
             <div className="d-flex">
                 <span className="flex-shrink-0 text-muted mr-1">{icon}</span>
                 <span className="flex-1">
-                    <Link to={typeof location === 'string' ? location : createLinkUrl(location)} className="p-0">
+                    <Link
+                        to={typeof location === 'string' ? location : createLinkUrl(location)}
+                        className="text-monospace search-query-link"
+                    >
                         {title}
                     </Link>
                 </span>
@@ -633,7 +636,7 @@ function getUIComponentsForEntry(
     switch (entry.type) {
         case 'search':
             return {
-                icon: <Icon aria-hidden={true} as={SearchIcon} />,
+                icon: <Icon aria-label="Search" as={SearchIcon} />,
                 title: <SyntaxHighlightedSearchQuery query={entry.query} />,
                 location: {
                     pathname: '/search',
@@ -647,7 +650,7 @@ function getUIComponentsForEntry(
             }
         case 'file':
             return {
-                icon: <Icon aria-hidden={true} as={entry.lineRange ? CodeBracketsIcon : FileDocumentOutlineIcon} />,
+                icon: <Icon aria-label="File" as={entry.lineRange ? CodeBracketsIcon : FileDocumentOutlineIcon} />,
                 title: (
                     <span title={entry.path}>
                         {fileName(entry.path)}


### PR DESCRIPTION
## Audit type
ARC Toolkit
### User journey audit issue
[#34198](https://github.com/sourcegraph/sourcegraph/issues/34198)
### Problem description
- File and search icons should be labelled instead of hidden
- File items in notepad have insufficient color contrast. They should be made to look the same as search items.
![alt tex](https://user-images.githubusercontent.com/206864/171748163-341882f2-35c7-4be6-b24f-728e65d93523.png)
### Expected behavior
Issues are fixed as described above.
### Refs
[Sourcegraph issue](https://github.com/sourcegraph/sourcegraph/issues/36511)
[Gitstart ticket](https://app.gitstart.com/clients/sourcegraph/tickets/SG-36511)
### Test plan
Note: Notepad needs to be enabled. It can be enabled by going to the "Notebooks" page and clicking on "Enable Notepad" at the top next to the title. It will then appear on the bottom right of the screen.
![alt text](https://user-images.githubusercontent.com/206864/171747833-1f71c476-db20-4007-8e29-4ef64bdf5aa3.png)
![alt text](https://user-images.githubusercontent.com/206864/171747876-f6003e4b-7671-4416-af3d-cbbdb001a437.png)
Items can be added to it by running a search or viewing a file, and then opening the notepad to add the current item.

- File and search icons on the above picture should be labeled instead of hidden
- File items in the notepad list at the bottom right should have the same color as search items on the main search page

## App preview:

- [Web](https://sg-web-contractors-sg-36511.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-sjjxqiyovb.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
