### PR TITLE
VSCE: fix default branch behavior

### DIFF
--- a/client/vscode/CHANGELOG.md
+++ b/client/vscode/CHANGELOG.md
@@ -2,15 +2,28 @@
 
 The Sourcegraph extension uses major.EVEN_NUMBER.patch (eg. 2.0.1) for release versions and major.ODD_NUMBER.patch (eg. 2.1.1) for pre-release versions.
 
-## Next Release
+## Unreleased
 
 ### Changes
 
-- Import Sourcegraph Access token automatically after completing authentication in the browser for Sourcegraph Cloud users [issues/28311](https://github.com/sourcegraph/sourcegraph/issues/28311)
+-
 
 ### Fixes
 
-- Optimize build size [issues/36192](https://github.com/sourcegraph/sourcegraph/issues/36192)
+-
+
+### Plans
+
+- Import Sourcegraph Access token automatically after completing authentication in the browser for Sourcegraph Cloud users [issues/28311](https://github.com/sourcegraph/sourcegraph/issues/28311)
+
+## 2.2.4
+
+### Changes
+
+- Optimize package size [issues/36192](https://github.com/sourcegraph/sourcegraph/issues/36192)
+
+### Fixes
+
 - Check if default branch exists when opening files [issues/36743](https://github.com/sourcegraph/sourcegraph/issues/36743)
 
 ## 2.2.3

--- a/client/vscode/CHANGELOG.md
+++ b/client/vscode/CHANGELOG.md
@@ -11,6 +11,7 @@ The Sourcegraph extension uses major.EVEN_NUMBER.patch (eg. 2.0.1) for release v
 ### Fixes
 
 - Optimize build size [issues/36192](https://github.com/sourcegraph/sourcegraph/issues/36192)
+- Check if default branch exists when opening files [issues/36743](https://github.com/sourcegraph/sourcegraph/issues/36743)
 
 ## 2.2.3
 

--- a/client/vscode/package.json
+++ b/client/vscode/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "@sourcegraph/vscode",
   "displayName": "Sourcegraph",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "description": "Sourcegraph for VS Code",
   "publisher": "sourcegraph",
   "sideEffects": true,

--- a/client/vscode/src/link-commands/browserActionsNode.ts
+++ b/client/vscode/src/link-commands/browserActionsNode.ts
@@ -32,12 +32,11 @@ export async function browserActions(action: string, logRedirectEvent: (uri: str
         }
         let { remoteURL, branch, fileRelative } = repositoryInfo
         // construct sourcegraph url for current file
-        // set branch as 'HEAD' if user wants to open file in main
-        // else use the branch we have retreive from the repository info
-        // which will set branch as default or 'HEAD' if current branch does not exist
+        // Ask if user want to open file in HEAD instead if set current branch or default branch
+        // do not exist on Sourcegraph
         if (!branch) {
             const userChoice = await vscode.window.showInformationMessage(
-                'Current branch does not exist on Sourcegraph. Publish your branch or continue to main branch.',
+                'Current (or default) branch does not exist on Sourcegraph. Publish your branch or continue to main branch.',
                 'Continue to main',
                 'Cancel'
             )

--- a/client/vscode/src/link-commands/git-helpers.ts
+++ b/client/vscode/src/link-commands/git-helpers.ts
@@ -49,8 +49,8 @@ export async function repoInfo(filePath: string): Promise<RepositoryInfo | undef
         const fileRelative = filePath.slice(repoRoot.length + 1).replace(/\\/g, '/')
         let { branch, remoteName } = await gitRemoteNameAndBranch(repoRoot, gitHelpers, log)
         const remoteURL = await gitRemoteUrlWithReplacements(repoRoot, remoteName, gitHelpers, log)
-        // check if branch exist remotely
-        branch = getDefaultBranch() || (await isOnSourcegraph(remoteURL, branch)) ? branch : ''
+        // check if the default branch or branch exist remotely
+        branch = (await isOnSourcegraph(remoteURL, getDefaultBranch() || branch)) ? branch : ''
         return { remoteURL, branch, fileRelative, remoteName }
     } catch {
         return undefined

--- a/client/vscode/src/link-commands/git-helpers.ts
+++ b/client/vscode/src/link-commands/git-helpers.ts
@@ -50,7 +50,7 @@ export async function repoInfo(filePath: string): Promise<RepositoryInfo | undef
         let { branch, remoteName } = await gitRemoteNameAndBranch(repoRoot, gitHelpers, log)
         const remoteURL = await gitRemoteUrlWithReplacements(repoRoot, remoteName, gitHelpers, log)
         // check if the default branch or branch exist remotely
-        branch = (await isOnSourcegraph(remoteURL, getDefaultBranch() || branch)) ? branch : ''
+        branch = (await isOnSourcegraph(remoteURL, getDefaultBranch() || branch)) ? getDefaultBranch() || branch : ''
         return { remoteURL, branch, fileRelative, remoteName }
     } catch {
         return undefined


### PR DESCRIPTION
# Summary 

close https://github.com/sourcegraph/sourcegraph/issues/36743

## Current Behavior

If a user has configured to always open files with their default branch, we will always open the default branch without checking if it exists on Sourcegraph. A bug has been located that current branch will still be used even if default branch is set: ([link to code](https://github.com/sourcegraph/sourcegraph/blob/main/client/vscode/src/link-commands/git-helpers.ts#L53))

## Solution

Check if the default branch also exists on Sourcegraph, and display a message to let the user know the default branch does not exist on Sourcegraph accordingly ([link to code](https://github.com/sourcegraph/sourcegraph/blob/46a04f404a022393f7856ed39f6dad09a29dc7be/client/vscode/src/link-commands/git-helpers.ts#L53)). IF default branch exists, open default branch

## Screenshots

Situation: When no default branch is set, and the current branch does not exist on Sourcegraph.
Behavior: Display a message to let users know the branch does not exist on Sourcegraph:
![image](https://user-images.githubusercontent.com/68532117/173421547-e1d39d3e-101c-4adf-95ca-4021f15dbe0b.png)

Situation: When the default branch is set to `master`, and the current branch does not exist on Sourcegraph.
Behavior: Open file on default branch:
![image](https://user-images.githubusercontent.com/68532117/173421725-a5253d6d-f3c6-46a1-a0fe-121ca3735cb5.png)

Situation: When the default branch is set to `master`, and the current branch exists on Sourcegraph.
Behavior: Open file on default branch:
![image](https://user-images.githubusercontent.com/68532117/173421725-a5253d6d-f3c6-46a1-a0fe-121ca3735cb5.png)



## Test plan
 
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

The integration test is passing:
```
❯ yarn test-integration
yarn run v1.22.17
warning @sourcegraph/vscode@2.2.3: The engine "vscode" appears to be invalid.
$ TS_NODE_PROJECT=tests/tsconfig.json mocha --parallel=$CI --retries=2 ./tests/**/*.test.ts


  VS Code extension
Downloading VS Code 1.68.0 from https://update.code.visualstudio.com/1.68.0/darwin-arm64/stable
Downloading VS Code [==============================] 100%Downloaded VS Code 1.68.0 into /Users/b/Dev/sourcegraph/client/vscode/.vscode-test/vscode-darwin-1.68.0
Starting VS Code {
  verbose: false,
  vscodeExecutablePath: '/Users/b/Dev/sourcegraph/client/vscode/.vscode-test/vscode-darwin-1.68.0/Vis'... 43 more characters,
  userDataDirectory: '/var/folders/g1/f24vdsfn2mb1z2_wwyl5vygh0000gn/T/vsce0Q7Abo',
  extensionsDirectory: '/var/folders/g1/f24vdsfn2mb1z2_wwyl5vygh0000gn/T/vscedQ7Ufz'
}
VSCode started in debug mode on http://127.0.0.1:29378
    ✓ works (9940ms)


  1 passing (45s)

✨  Done in 54.23s.
```

To run integration test:
1. `yarn && yarn generate` from root of the repo
2. `cd client/vscode`
3. `yarn build:test`
4. `yarn test-integration`

## App preview:

- [Web](https://sg-web-bee-vsce-default-branch.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-nmscxaysgj.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
