### PR TITLE
Add index for queued_at and state columns of explicit_permissions_bitbucket_projects_jobs table

### DIFF
--- a/internal/database/schema.json
+++ b/internal/database/schema.json
@@ -7319,6 +7319,26 @@
           "IndexDefinition": "CREATE INDEX explicit_permissions_bitbucket_projects_jobs_project_key_extern ON explicit_permissions_bitbucket_projects_jobs USING btree (project_key, external_service_id, state)",
           "ConstraintType": "",
           "ConstraintDefinition": ""
+        },
+        {
+          "Name": "explicit_permissions_bitbucket_projects_jobs_queued_at_idx",
+          "IsPrimaryKey": false,
+          "IsUnique": false,
+          "IsExclusion": false,
+          "IsDeferrable": false,
+          "IndexDefinition": "CREATE INDEX explicit_permissions_bitbucket_projects_jobs_queued_at_idx ON explicit_permissions_bitbucket_projects_jobs USING btree (queued_at)",
+          "ConstraintType": "",
+          "ConstraintDefinition": ""
+        },
+        {
+          "Name": "explicit_permissions_bitbucket_projects_jobs_state_idx",
+          "IsPrimaryKey": false,
+          "IsUnique": false,
+          "IsExclusion": false,
+          "IsDeferrable": false,
+          "IndexDefinition": "CREATE INDEX explicit_permissions_bitbucket_projects_jobs_state_idx ON explicit_permissions_bitbucket_projects_jobs USING btree (state)",
+          "ConstraintType": "",
+          "ConstraintDefinition": ""
         }
       ],
       "Constraints": [

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -959,6 +959,8 @@ Tracks the most recent activity of executors attached to this Sourcegraph instan
 Indexes:
     "explicit_permissions_bitbucket_projects_jobs_pkey" PRIMARY KEY, btree (id)
     "explicit_permissions_bitbucket_projects_jobs_project_key_extern" btree (project_key, external_service_id, state)
+    "explicit_permissions_bitbucket_projects_jobs_queued_at_idx" btree (queued_at)
+    "explicit_permissions_bitbucket_projects_jobs_state_idx" btree (state)
 Check constraints:
     "explicit_permissions_bitbucket_projects_jobs_check" CHECK (permissions IS NOT NULL AND unrestricted IS FALSE OR permissions IS NULL AND unrestricted IS TRUE)
 

--- a/migrations/frontend/1655128668/down.sql
+++ b/migrations/frontend/1655128668/down.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS explicit_permissions_bitbucket_projects_jobs_queued_at_idx;
+DROP INDEX IF EXISTS explicit_permissions_bitbucket_projects_jobs_state_idx;

--- a/migrations/frontend/1655128668/metadata.yaml
+++ b/migrations/frontend/1655128668/metadata.yaml
@@ -1,0 +1,2 @@
+name: add indices to explicit_permissions_bitbucket_projects_jobs table
+parents: [1654874153]

--- a/migrations/frontend/1655128668/up.sql
+++ b/migrations/frontend/1655128668/up.sql
@@ -1,0 +1,2 @@
+CREATE INDEX IF NOT EXISTS explicit_permissions_bitbucket_projects_jobs_queued_at_idx ON explicit_permissions_bitbucket_projects_jobs (queued_at);
+CREATE INDEX IF NOT EXISTS explicit_permissions_bitbucket_projects_jobs_state_idx ON explicit_permissions_bitbucket_projects_jobs (state);

--- a/migrations/frontend/squashed.sql
+++ b/migrations/frontend/squashed.sql
@@ -3564,6 +3564,10 @@ CREATE INDEX event_logs_user_id ON event_logs USING btree (user_id);
 
 CREATE INDEX explicit_permissions_bitbucket_projects_jobs_project_key_extern ON explicit_permissions_bitbucket_projects_jobs USING btree (project_key, external_service_id, state);
 
+CREATE INDEX explicit_permissions_bitbucket_projects_jobs_queued_at_idx ON explicit_permissions_bitbucket_projects_jobs USING btree (queued_at);
+
+CREATE INDEX explicit_permissions_bitbucket_projects_jobs_state_idx ON explicit_permissions_bitbucket_projects_jobs USING btree (state);
+
 CREATE INDEX external_service_repos_clone_url_idx ON external_service_repos USING btree (clone_url);
 
 CREATE INDEX external_service_repos_idx ON external_service_repos USING btree (external_service_id, repo_id);


### PR DESCRIPTION
Part of https://github.com/sourcegraph/sourcegraph/issues/36453

## Test plan
sg migration up-down-up
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
