### PR TITLE
dev/buildchecker: do not cc DevX support

### DIFF
--- a/dev/buildchecker/slack.go
+++ b/dev/buildchecker/slack.go
@@ -49,9 +49,7 @@ Please head over to %s for relevant discussion about this branch lock.
 
 For more, refer to the <https://handbook.sourcegraph.com/departments/product-engineering/engineering/process/incidents/playbooks/ci|CI incident playbook> for help.
 
-If unable to resolve the issue, please start an incident with the '/incident' Slack command.
-
-cc: @dev-experience-support`, branchStr, discussionChannel)
+If unable to resolve the issue, please start an incident with the '/incident' Slack command.`, branchStr, discussionChannel)
 	return message
 }
 


### PR DESCRIPTION
As discussed in [our last team sync](https://docs.google.com/document/d/1Lm6GT-F4v9OTa5wxa1-AKLtNwlDkORbbeGjqVd9kWPg/edit#bookmark=id.go9rmgv3rfgz), it's possible we might be setting the wrong expectation by including ourselves on the message. We generally are pretty proactive about checking #buildkite-main already so this doesn't serve _too_ much purpose for us, so let's just remove it for now and see how things go.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

n/a