### PR TITLE
DB Backend: create new `CodeIntelDB` type

### DIFF
--- a/cmd/worker/shared/init/codeintel/lsifstore.go
+++ b/cmd/worker/shared/init/codeintel/lsifstore.go
@@ -7,6 +7,7 @@ import (
 	"github.com/sourcegraph/log"
 
 	"github.com/sourcegraph/sourcegraph/cmd/worker/memo"
+	"github.com/sourcegraph/sourcegraph/internal/codeintel/stores"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/stores/lsifstore"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
@@ -30,5 +31,5 @@ var initLSFIStore = memo.NewMemoizedConstructor(func() (*lsifstore.Store, error)
 		return nil, err
 	}
 
-	return lsifstore.NewStore(db, conf.Get(), observationContext), nil
+	return lsifstore.NewStore(stores.NewCodeIntelDB(db), conf.Get(), observationContext), nil
 })

--- a/enterprise/cmd/frontend/internal/codeintel/services.go
+++ b/enterprise/cmd/frontend/internal/codeintel/services.go
@@ -2,7 +2,6 @@ package codeintel
 
 import (
 	"context"
-	"database/sql"
 	"net/http"
 
 	"github.com/opentracing/opentracing-go"
@@ -12,6 +11,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/codeintel/httpapi"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/autoindexing"
+	"github.com/sourcegraph/sourcegraph/internal/codeintel/stores"
 	store "github.com/sourcegraph/sourcegraph/internal/codeintel/stores/dbstore"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/stores/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/stores/lsifstore"
@@ -118,7 +118,7 @@ func NewServices(ctx context.Context, config *Config, siteConfig conftypes.Watch
 	}, nil
 }
 
-func mustInitializeCodeIntelDB(logger log.Logger) *sql.DB {
+func mustInitializeCodeIntelDB(logger log.Logger) stores.CodeIntelDB {
 	dsn := conf.GetServiceConnectionValueAndRestartOnChange(func(serviceConnections conftypes.ServiceConnections) string {
 		return serviceConnections.CodeIntelPostgresDSN
 	})
@@ -126,7 +126,7 @@ func mustInitializeCodeIntelDB(logger log.Logger) *sql.DB {
 	if err != nil {
 		logger.Fatal("Failed to connect to codeintel database", log.Error(err))
 	}
-	return db
+	return stores.NewCodeIntelDB(db)
 }
 
 func mustInitializeSentryHub(logger log.Logger, c conftypes.WatchableSiteConfig) *sentry.Hub {

--- a/enterprise/cmd/precise-code-intel-worker/main.go
+++ b/enterprise/cmd/precise-code-intel-worker/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/precise-code-intel-worker/internal/worker"
 	eiauthz "github.com/sourcegraph/sourcegraph/enterprise/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
+	"github.com/sourcegraph/sourcegraph/internal/codeintel/stores"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/stores/dbstore"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/stores/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/stores/lsifstore"
@@ -174,7 +175,7 @@ func mustInitializeDB() *sql.DB {
 	return sqlDB
 }
 
-func mustInitializeCodeIntelDB() *sql.DB {
+func mustInitializeCodeIntelDB() stores.CodeIntelDB {
 	dsn := conf.GetServiceConnectionValueAndRestartOnChange(func(serviceConnections conftypes.ServiceConnections) string {
 		return serviceConnections.CodeIntelPostgresDSN
 	})
@@ -184,7 +185,7 @@ func mustInitializeCodeIntelDB() *sql.DB {
 		logger.Fatal("Failed to connect to codeintel database", log.Error(err))
 	}
 
-	return db
+	return stores.NewCodeIntelDB(db)
 }
 
 func makeObservationContext(observationContext *observation.Context, withHoney bool) *observation.Context {

--- a/internal/codeintel/stores/db.go
+++ b/internal/codeintel/stores/db.go
@@ -1,0 +1,62 @@
+package stores
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
+)
+
+type CodeIntelDB interface {
+	dbutil.DB
+	basestore.ShareableStore
+
+	Transact(context.Context) (CodeIntelDB, error)
+	Done(error) error
+}
+
+func NewCodeIntelDB(inner *sql.DB) CodeIntelDB {
+	return &codeIntelDB{basestore.NewWithHandle(basestore.NewHandleWithDB(inner, sql.TxOptions{}))}
+}
+
+func NewCodeIntelDBWith(other basestore.ShareableStore) CodeIntelDB {
+	return &codeIntelDB{basestore.NewWithHandle(other.Handle())}
+}
+
+type codeIntelDB struct {
+	*basestore.Store
+}
+
+func (d *codeIntelDB) Transact(ctx context.Context) (CodeIntelDB, error) {
+	tx, err := d.Store.Transact(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &codeIntelDB{tx}, nil
+}
+
+func (d *codeIntelDB) Done(err error) error {
+	return d.Store.Done(err)
+}
+
+func (d *codeIntelDB) Unwrap() dbutil.DB {
+	// Recursively unwrap in case we ever call `NewInsightsDB()` with an `InsightsDB`
+	if unwrapper, ok := d.Handle().DB().(dbutil.Unwrapper); ok {
+		return unwrapper.Unwrap()
+	}
+	return d.Handle().DB()
+}
+
+func (d *codeIntelDB) QueryContext(ctx context.Context, q string, args ...any) (*sql.Rows, error) {
+	return d.Handle().DB().QueryContext(ctx, q, args...)
+}
+
+func (d *codeIntelDB) ExecContext(ctx context.Context, q string, args ...any) (sql.Result, error) {
+	return d.Handle().DB().ExecContext(ctx, q, args...)
+
+}
+
+func (d *codeIntelDB) QueryRowContext(ctx context.Context, q string, args ...any) *sql.Row {
+	return d.Handle().DB().QueryRowContext(ctx, q, args...)
+}

--- a/internal/codeintel/stores/lsifstore/migration/diagnostics_count_test.go
+++ b/internal/codeintel/stores/lsifstore/migration/diagnostics_count_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/keegancsmith/sqlf"
 
+	"github.com/sourcegraph/sourcegraph/internal/codeintel/stores"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/stores/lsifstore"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
@@ -17,7 +18,7 @@ import (
 )
 
 func TestDiagnosticsCountMigrator(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := stores.NewCodeIntelDB(dbtest.NewDB(t))
 	store := lsifstore.NewStore(db, conf.DefaultClient(), &observation.TestContext)
 	migrator := NewDiagnosticsCountMigrator(store, 250)
 	serializer := lsifstore.NewSerializer()

--- a/internal/codeintel/stores/lsifstore/migration/document_column_split_test.go
+++ b/internal/codeintel/stores/lsifstore/migration/document_column_split_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/keegancsmith/sqlf"
 
+	"github.com/sourcegraph/sourcegraph/internal/codeintel/stores"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/stores/lsifstore"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
@@ -19,7 +20,7 @@ import (
 )
 
 func TestDocumentColumnSplitMigrator(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := stores.NewCodeIntelDB(dbtest.NewDB(t))
 	store := lsifstore.NewStore(db, conf.DefaultClient(), &observation.TestContext)
 	migrator := NewDocumentColumnSplitMigrator(store, 250)
 	serializer := lsifstore.NewSerializer()

--- a/internal/codeintel/stores/lsifstore/migration/locations_count_test.go
+++ b/internal/codeintel/stores/lsifstore/migration/locations_count_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/keegancsmith/sqlf"
 
+	"github.com/sourcegraph/sourcegraph/internal/codeintel/stores"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/stores/lsifstore"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
@@ -17,7 +18,7 @@ import (
 )
 
 func TestLocationsCountMigrator(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := stores.NewCodeIntelDB(dbtest.NewDB(t))
 	store := lsifstore.NewStore(db, conf.DefaultClient(), &observation.TestContext)
 	migrator := NewLocationsCountMigrator(store, "lsif_data_definitions", 250)
 	serializer := lsifstore.NewSerializer()

--- a/internal/codeintel/stores/lsifstore/migration/migrator_test.go
+++ b/internal/codeintel/stores/lsifstore/migration/migrator_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/keegancsmith/sqlf"
 
+	"github.com/sourcegraph/sourcegraph/internal/codeintel/stores"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/stores/lsifstore"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
@@ -13,7 +14,7 @@ import (
 )
 
 func TestMigratorRemovesBoundsWithoutData(t *testing.T) {
-	db := dbtest.NewDB(t)
+	db := stores.NewCodeIntelDB(dbtest.NewDB(t))
 	store := lsifstore.NewStore(db, conf.DefaultClient(), &observation.TestContext)
 	driver := &testMigrationDriver{}
 	migrator := newMigrator(store, driver, migratorOptions{

--- a/internal/codeintel/stores/lsifstore/store.go
+++ b/internal/codeintel/stores/lsifstore/store.go
@@ -2,11 +2,10 @@ package lsifstore
 
 import (
 	"context"
-	"database/sql"
 
+	"github.com/sourcegraph/sourcegraph/internal/codeintel/stores"
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 )
 
@@ -17,9 +16,9 @@ type Store struct {
 	config     conftypes.SiteConfigQuerier
 }
 
-func NewStore(db dbutil.DB, siteConfig conftypes.SiteConfigQuerier, observationContext *observation.Context) *Store {
+func NewStore(db stores.CodeIntelDB, siteConfig conftypes.SiteConfigQuerier, observationContext *observation.Context) *Store {
 	return &Store{
-		Store:      basestore.NewWithHandle(basestore.NewHandleWithUntypedDB(db, sql.TxOptions{})),
+		Store:      basestore.NewWithHandle(db.Handle()),
 		serializer: NewSerializer(),
 		operations: newOperations(observationContext),
 		config:     siteConfig,


### PR DESCRIPTION
This mints a new `CodeIntelDB` interface that mirrors the pattern of `InsightsDB` and `database.DB` (which should probably be renamed `FrontendDB`). 

The goal here is just to have a type that 1) communicates with the type that this is a handle to a DB with the insights schema, and 2) embeds `basestore.ShareableStore` so that we can make db handles more standardized. 

Stacked on #37140 

side note: since `TransactableHandle` is still not type-protected by schema, it might be cool to have `TransactableHandle[T SchemaType]` so it can't be accidentally shared with the wrong store 🤔 

## Test plan

There should be no behavior change. I'm depending on existing tests to verify this, but the pattern is well-exercised at this point.


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
