### PR TITLE
batches: Add validation checks for invalid characters in the mount

### DIFF
--- a/lib/batches/batch_spec.go
+++ b/lib/batches/batch_spec.go
@@ -199,8 +199,21 @@ func parseBatchSpec(schema string, data []byte, opts ParseBatchSpecOptions) (*Ba
 		}
 	}
 
+	for i, step := range spec.Steps {
+		for _, mount := range step.Mount {
+			if strings.Contains(mount.Path, invalidMountCharacters) {
+				errs = errors.Append(errs, NewValidationError(errors.Newf("step %d mount path contains invalid characters", i+1)))
+			}
+			if strings.Contains(mount.Mountpoint, invalidMountCharacters) {
+				errs = errors.Append(errs, NewValidationError(errors.Newf("step %d mount mountpoint contains invalid characters", i+1)))
+			}
+		}
+	}
+
 	return &spec, errs
 }
+
+const invalidMountCharacters = ","
 
 func (on *OnQueryOrRepository) String() string {
 	if on.RepositoriesMatchingQuery != "" {

--- a/lib/batches/batch_spec_test.go
+++ b/lib/batches/batch_spec_test.go
@@ -199,6 +199,48 @@ changesetTemplate:
 			t.Fatalf("wrong error. want=%q, have=%q", wantErr, haveErr)
 		}
 	})
+
+	t.Run("mount path contains comma", func(t *testing.T) {
+		const spec = `
+name: test-spec
+description: A test spec
+steps:
+  - run: /tmp/sample.sh
+    container: alpine:3
+    mount:
+      - path: /foo,bar/
+        mountpoint: /tmp
+changesetTemplate:
+  title: Test Mount
+  body: Test a mounted path
+  branch: test
+  commit:
+    message: Test
+`
+		_, err := ParseBatchSpec([]byte(spec), ParseBatchSpecOptions{})
+		assert.Equal(t, "step 1 mount path contains invalid characters", err.Error())
+	})
+
+	t.Run("mount mountpoint contains comma", func(t *testing.T) {
+		const spec = `
+name: test-spec
+description: A test spec
+steps:
+  - run: /tmp/foo,bar/sample.sh
+    container: alpine:3
+    mount:
+      - path: /valid/sample.sh
+        mountpoint: /tmp/foo,bar/sample.sh
+changesetTemplate:
+  title: Test Mount
+  body: Test a mounted path
+  branch: test
+  commit:
+    message: Test
+`
+		_, err := ParseBatchSpec([]byte(spec), ParseBatchSpecOptions{})
+		assert.Equal(t, "step 1 mount mountpoint contains invalid characters", err.Error())
+	})
 }
 
 func TestOnQueryOrRepository_Branches(t *testing.T) {


### PR DESCRIPTION
Based on feedback from [#770](https://github.com/sourcegraph/src-cli/pull/770). Moved some static checks into the `batcheslib` `parseBatchSpec` function.

## Test plan

Go unit tests.