### PR TITLE
insights: flip default deprecateJustInTime feature flag 

### DIFF
--- a/enterprise/internal/insights/resolvers/insight_view_resolvers.go
+++ b/enterprise/internal/insights/resolvers/insight_view_resolvers.go
@@ -992,7 +992,7 @@ func createAndAttachSeries(ctx context.Context, tx *store.InsightStore, scopedBa
 	}
 
 	flags := featureflag.FromContext(ctx)
-	deprecateJustInTime := flags.GetBoolOr("code_insights_deprecate_jit", true)
+	deprecateJustInTime := flags.GetBoolOr("code_insights_deprecate_jit", false)
 
 	if !foundSeries {
 		repos := series.RepositoryScope.Repositories


### PR DESCRIPTION
To match the desired behavior for upcoming release, disabled new unify insights behavior by default, but allows any previously created non-jit insights over some repos to continue snapshots/future points.

## Test plan
tests pass.
Manually created new JIT and non-jit insights
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
