### PR TITLE
DB Backend: convert most handles to typed handles

### DIFF
--- a/enterprise/internal/database/database.go
+++ b/enterprise/internal/database/database.go
@@ -47,8 +47,8 @@ type InsightsDB interface {
 	Done(error) error
 }
 
-func NewInsightsDB(inner dbutil.DB) InsightsDB {
-	return &insightsDB{basestore.NewWithHandle(basestore.NewHandleWithUntypedDB(inner, sql.TxOptions{}))}
+func NewInsightsDB(inner *sql.DB) InsightsDB {
+	return &insightsDB{basestore.NewWithHandle(basestore.NewHandleWithDB(inner, sql.TxOptions{}))}
 }
 
 func NewInsightsDBWith(other basestore.ShareableStore) InsightsDB {

--- a/internal/repos/sync_worker_test.go
+++ b/internal/repos/sync_worker_test.go
@@ -51,7 +51,7 @@ func testSyncWorkerPlumbing(repoStore repos.Store) func(t *testing.T) {
 		h := &fakeRepoSyncHandler{
 			jobChan: jobChan,
 		}
-		worker, resetter := repos.NewSyncWorker(ctx, repoStore.Handle().DB(), h, repos.SyncWorkerOptions{
+		worker, resetter := repos.NewSyncWorker(ctx, repoStore.Handle(), h, repos.SyncWorkerOptions{
 			NumHandlers:    1,
 			WorkerInterval: 1 * time.Millisecond,
 		})

--- a/internal/repos/syncer.go
+++ b/internal/repos/syncer.go
@@ -80,7 +80,7 @@ func (s *Syncer) Run(ctx context.Context, store Store, opts RunOptions) error {
 		s.initialUnmodifiedDiffFromStore(ctx, store)
 	}
 
-	worker, resetter := NewSyncWorker(ctx, store.Handle().DB(), &syncHandler{
+	worker, resetter := NewSyncWorker(ctx, store.Handle(), &syncHandler{
 		syncer:          s,
 		store:           store,
 		minSyncInterval: opts.MinSyncInterval,

--- a/internal/workerutil/dbworker/store/helpers_test.go
+++ b/internal/workerutil/dbworker/store/helpers_test.go
@@ -11,13 +11,12 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/workerutil"
 )
 
-func testStore(db dbutil.DB, options Options) *store {
-	return newStore(basestore.NewHandleWithUntypedDB(db, sql.TxOptions{}), options, &observation.TestContext)
+func testStore(db *sql.DB, options Options) *store {
+	return newStore(basestore.NewHandleWithDB(db, sql.TxOptions{}), options, &observation.TestContext)
 }
 
 type TestRecord struct {
@@ -104,7 +103,7 @@ func testScanFirstRecordRetry(rows *sql.Rows, queryErr error) (v workerutil.Reco
 	return nil, false, nil
 }
 
-func setupStoreTest(t *testing.T) dbutil.DB {
+func setupStoreTest(t *testing.T) *sql.DB {
 	db := dbtest.NewDB(t)
 
 	if _, err := db.Exec(`

--- a/internal/workerutil/dbworker/store/store_test.go
+++ b/internal/workerutil/dbworker/store/store_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/keegancsmith/sqlf"
 
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/workerutil"
 )
 
@@ -966,7 +965,7 @@ func TestStoreResetStalled(t *testing.T) {
 		t.Fatalf("unexpected error inserting records: %s", err)
 	}
 
-	tx, err := db.(dbutil.TxBeginner).BeginTx(context.Background(), nil)
+	tx, err := db.BeginTx(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This builds on some of my previous PRs and converts more `TransactableHandle` instances to use the well-typed handles. After this PR, there is exactly one usage remaining of `NewHandleWithUntypedDB()`, which is used by `database.NewUntypedDB()`, which is still used in a handful of places. I will work on converting the rest of the call sites in the next PR, but this one just handles a couple of easier instances.

Stacked on https://github.com/sourcegraph/sourcegraph/pull/37155

## Test plan

No change in semantics. Relying on unit tests. 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
