### PR TITLE
dev/sg: more lenient postgres check

### DIFF
--- a/dev/sg/dependencies/helpers.go
+++ b/dev/sg/dependencies/helpers.go
@@ -206,7 +206,19 @@ func checkSourcegraphDatabase(ctx context.Context, out *std.Output, args CheckAr
 		return errors.Wrapf(err, "failed to connect to Soucegraph Postgres database at %s. Please check the settings in sg.config.yml (see https://docs.sourcegraph.com/dev/background-information/sg#changing-database-configuration)", dsn)
 	}
 	defer conn.Close(ctx)
-	return conn.Ping(ctx)
+	for {
+		err := conn.Ping(ctx)
+		if err != nil {
+			// If database is starting up we keep waiting
+			if strings.Contains(err.Error(), "database system is starting up") {
+				time.Sleep(5 * time.Millisecond)
+				continue
+			}
+			return errors.Wrapf(err, "failed to ping Sourcegraph Postgres database at %s", dsn)
+		} else {
+			return nil
+		}
+	}
 }
 
 func checkRedisConnection(context.Context) error {


### PR DESCRIPTION
Spotted in https://github.com/sourcegraph/sourcegraph/runs/6867084149?check_suite_focus=true#step:4:357, where it seems we just aren't waiting long enough for the database to come online.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Integration tests