### PR TITLE
DB Backend: embed `dbutil.DB` in `TransactableHandle`

### DIFF
--- a/cmd/symbols/internal/database/store/symbols.go
+++ b/cmd/symbols/internal/database/store/symbols.go
@@ -109,7 +109,7 @@ func (s *store) WriteSymbols(ctx context.Context, symbolOrErrors <-chan parser.S
 	group.Go(func() error {
 		return batch.InsertValues(
 			ctx,
-			s.Handle().DB(),
+			s.Handle().DBUtilDB(),
 			"symbols",
 			batch.MaxNumSQLiteParameters,
 			[]string{

--- a/cmd/symbols/internal/database/store/symbols.go
+++ b/cmd/symbols/internal/database/store/symbols.go
@@ -109,7 +109,7 @@ func (s *store) WriteSymbols(ctx context.Context, symbolOrErrors <-chan parser.S
 	group.Go(func() error {
 		return batch.InsertValues(
 			ctx,
-			s.Handle().DBUtilDB(),
+			s.Handle(),
 			"symbols",
 			batch.MaxNumSQLiteParameters,
 			[]string{

--- a/cmd/worker/internal/migrations/migrators/extsvc_migrator_test.go
+++ b/cmd/worker/internal/migrations/migrators/extsvc_migrator_test.go
@@ -136,7 +136,7 @@ func TestExternalServiceConfigMigrator(t *testing.T) {
 		}
 
 		// was the config actually encrypted?
-		rows, err := db.Handle().DBUtilDB().QueryContext(ctx, "SELECT config, encryption_key_id FROM external_services ORDER BY id")
+		rows, err := db.Handle().QueryContext(ctx, "SELECT config, encryption_key_id FROM external_services ORDER BY id")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -209,7 +209,7 @@ func TestExternalServiceConfigMigrator(t *testing.T) {
 		}
 
 		// was the config actually reverted?
-		rows, err := db.Handle().DBUtilDB().QueryContext(ctx, "SELECT config, encryption_key_id FROM external_services ORDER BY id")
+		rows, err := db.Handle().QueryContext(ctx, "SELECT config, encryption_key_id FROM external_services ORDER BY id")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -301,7 +301,7 @@ func TestExternalServiceConfigMigrator(t *testing.T) {
 		}
 
 		// was the config actually reverted?
-		rows, err := db.Handle().DBUtilDB().QueryContext(ctx, "SELECT config, encryption_key_id FROM external_services ORDER BY id")
+		rows, err := db.Handle().QueryContext(ctx, "SELECT config, encryption_key_id FROM external_services ORDER BY id")
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/cmd/worker/internal/migrations/migrators/extsvc_migrator_test.go
+++ b/cmd/worker/internal/migrations/migrators/extsvc_migrator_test.go
@@ -136,7 +136,7 @@ func TestExternalServiceConfigMigrator(t *testing.T) {
 		}
 
 		// was the config actually encrypted?
-		rows, err := db.Handle().DB().QueryContext(ctx, "SELECT config, encryption_key_id FROM external_services ORDER BY id")
+		rows, err := db.Handle().DBUtilDB().QueryContext(ctx, "SELECT config, encryption_key_id FROM external_services ORDER BY id")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -209,7 +209,7 @@ func TestExternalServiceConfigMigrator(t *testing.T) {
 		}
 
 		// was the config actually reverted?
-		rows, err := db.Handle().DB().QueryContext(ctx, "SELECT config, encryption_key_id FROM external_services ORDER BY id")
+		rows, err := db.Handle().DBUtilDB().QueryContext(ctx, "SELECT config, encryption_key_id FROM external_services ORDER BY id")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -301,7 +301,7 @@ func TestExternalServiceConfigMigrator(t *testing.T) {
 		}
 
 		// was the config actually reverted?
-		rows, err := db.Handle().DB().QueryContext(ctx, "SELECT config, encryption_key_id FROM external_services ORDER BY id")
+		rows, err := db.Handle().DBUtilDB().QueryContext(ctx, "SELECT config, encryption_key_id FROM external_services ORDER BY id")
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/enterprise/cmd/frontend/internal/batches/webhooks/bitbucketcloud_test.go
+++ b/enterprise/cmd/frontend/internal/batches/webhooks/bitbucketcloud_test.go
@@ -20,6 +20,7 @@ import (
 	btypes "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/bitbucketcloud"
@@ -418,13 +419,15 @@ func testBitbucketCloudWebhook(db *sql.DB) func(*testing.T) {
 // bitbucketCloudTestSetup instantiates the stores and a clock for use within
 // tests. Any changes made to the stores will be rolled back after the test is
 // complete.
-func bitbucketCloudTestSetup(t *testing.T, db *sql.DB) *bstore.Store {
+func bitbucketCloudTestSetup(t *testing.T, sqlDB *sql.DB) *bstore.Store {
 	clock := &bt.TestClock{Time: timeutil.Now()}
-	tx := dbtest.NewTx(t, db)
+	tx := dbtest.NewTx(t, sqlDB)
 
 	// Note that tx is wrapped in nestedTx to effectively neuter further use of
 	// transactions within the test.
-	return bstore.NewWithClock(database.NewUntypedDB(&nestedTx{tx}), &observation.TestContext, nil, clock.Now)
+	db := database.NewDBWith(basestore.NewWithHandle(&nestedTx{basestore.NewHandleWithTx(tx, sql.TxOptions{})}))
+
+	return bstore.NewWithClock(db, &observation.TestContext, nil, clock.Now)
 }
 
 // createBitbucketCloudExternalService creates a mock Bitbucket Cloud service

--- a/enterprise/cmd/frontend/internal/batches/webhooks/gitlab_test.go
+++ b/enterprise/cmd/frontend/internal/batches/webhooks/gitlab_test.go
@@ -733,7 +733,7 @@ func testGitLabWebhook(db *sql.DB) func(*testing.T) {
 			// Again, we're going to set up a poisoned store database that will
 			// error if a transaction is started.
 			s := gitLabTestSetup(t, db)
-			store := store.NewWithClock(database.NewUntypedDB(&noNestingTx{s.Handle().DBUtilDB()}), &observation.TestContext, nil, s.Clock())
+			store := store.NewWithClock(database.NewUntypedDB(&noNestingTx{s.Handle()}), &observation.TestContext, nil, s.Clock())
 			h := NewGitLabWebhook(store)
 
 			t.Run("missing merge request", func(t *testing.T) {

--- a/enterprise/cmd/frontend/internal/batches/webhooks/gitlab_test.go
+++ b/enterprise/cmd/frontend/internal/batches/webhooks/gitlab_test.go
@@ -733,7 +733,7 @@ func testGitLabWebhook(db *sql.DB) func(*testing.T) {
 			// Again, we're going to set up a poisoned store database that will
 			// error if a transaction is started.
 			s := gitLabTestSetup(t, db)
-			store := store.NewWithClock(database.NewUntypedDB(&noNestingTx{s.Handle().DB()}), &observation.TestContext, nil, s.Clock())
+			store := store.NewWithClock(database.NewUntypedDB(&noNestingTx{s.Handle().DBUtilDB()}), &observation.TestContext, nil, s.Clock())
 			h := NewGitLabWebhook(store)
 
 			t.Run("missing merge request", func(t *testing.T) {

--- a/enterprise/cmd/frontend/internal/batches/webhooks/gitlab_test.go
+++ b/enterprise/cmd/frontend/internal/batches/webhooks/gitlab_test.go
@@ -19,6 +19,7 @@ import (
 	btypes "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
@@ -874,11 +875,10 @@ func (br *brokenReader) Read(p []byte) (int, error) {
 // It would be theoretically possible to use savepoints to implement something
 // resembling the semantics of a true nested transaction, but that's
 // unnecessary for these tests.
-type nestedTx struct{ *sql.Tx }
+type nestedTx struct{ basestore.TransactableHandle }
 
-func (ntx *nestedTx) Rollback() error                                        { return nil }
-func (ntx *nestedTx) Commit() error                                          { return nil }
-func (ntx *nestedTx) BeginTx(ctx context.Context, opts *sql.TxOptions) error { return nil }
+func (ntx *nestedTx) Done(error) error                                               { return nil }
+func (ntx *nestedTx) Transact(context.Context) (basestore.TransactableHandle, error) { return ntx, nil }
 
 // noNestingTx is another transaction wrapper that always returns an error when
 // a transaction is attempted.
@@ -891,13 +891,17 @@ func (nntx *noNestingTx) BeginTx(ctx context.Context, opts *sql.TxOptions) error
 // gitLabTestSetup instantiates the stores and a clock for use within tests.
 // Any changes made to the stores will be rolled back after the test is
 // complete.
-func gitLabTestSetup(t *testing.T, db *sql.DB) *store.Store {
+func gitLabTestSetup(t *testing.T, sqlDB *sql.DB) *store.Store {
 	c := &ct.TestClock{Time: timeutil.Now()}
-	tx := dbtest.NewTx(t, db)
+	tx := dbtest.NewTx(t, sqlDB)
 
 	// Note that tx is wrapped in nestedTx to effectively neuter further use of
 	// transactions within the test.
-	return store.NewWithClock(database.NewUntypedDB(&nestedTx{tx}), &observation.TestContext, nil, c.Now)
+	db := database.NewDBWith(basestore.NewWithHandle(&nestedTx{basestore.NewHandleWithTx(tx, sql.TxOptions{})}))
+
+	// Note that tx is wrapped in nestedTx to effectively neuter further use of
+	// transactions within the test.
+	return store.NewWithClock(db, &observation.TestContext, nil, c.Now)
 }
 
 // assertBodyIncludes checks for a specific substring within the given response

--- a/enterprise/internal/batches/store/batch_spec_workspaces.go
+++ b/enterprise/internal/batches/store/batch_spec_workspaces.go
@@ -129,7 +129,7 @@ func (s *Store) CreateBatchSpecWorkspace(ctx context.Context, ws ...*btypes.Batc
 	i := -1
 	return batch.WithInserterWithReturn(
 		ctx,
-		s.Handle().DBUtilDB(),
+		s.Handle(),
 		"batch_spec_workspaces",
 		batch.MaxNumPostgresParameters,
 		batchSpecWorkspaceInsertColumns,

--- a/enterprise/internal/batches/store/batch_spec_workspaces.go
+++ b/enterprise/internal/batches/store/batch_spec_workspaces.go
@@ -129,7 +129,7 @@ func (s *Store) CreateBatchSpecWorkspace(ctx context.Context, ws ...*btypes.Batc
 	i := -1
 	return batch.WithInserterWithReturn(
 		ctx,
-		s.Handle().DB(),
+		s.Handle().DBUtilDB(),
 		"batch_spec_workspaces",
 		batch.MaxNumPostgresParameters,
 		batchSpecWorkspaceInsertColumns,

--- a/enterprise/internal/batches/store/changeset_jobs.go
+++ b/enterprise/internal/batches/store/changeset_jobs.go
@@ -105,7 +105,7 @@ func (s *Store) CreateChangesetJob(ctx context.Context, cs ...*btypes.ChangesetJ
 	i := -1
 	return batch.WithInserterWithReturn(
 		ctx,
-		s.Handle().DBUtilDB(),
+		s.Handle(),
 		"changeset_jobs",
 		batch.MaxNumPostgresParameters,
 		changesetJobInsertColumns,

--- a/enterprise/internal/batches/store/changeset_jobs.go
+++ b/enterprise/internal/batches/store/changeset_jobs.go
@@ -105,7 +105,7 @@ func (s *Store) CreateChangesetJob(ctx context.Context, cs ...*btypes.ChangesetJ
 	i := -1
 	return batch.WithInserterWithReturn(
 		ctx,
-		s.Handle().DB(),
+		s.Handle().DBUtilDB(),
 		"changeset_jobs",
 		batch.MaxNumPostgresParameters,
 		changesetJobInsertColumns,

--- a/enterprise/internal/batches/store/changeset_specs.go
+++ b/enterprise/internal/batches/store/changeset_specs.go
@@ -127,7 +127,7 @@ func (s *Store) CreateChangesetSpec(ctx context.Context, cs ...*btypes.Changeset
 	i := -1
 	return batch.WithInserterWithReturn(
 		ctx,
-		s.Handle().DB(),
+		s.Handle().DBUtilDB(),
 		"changeset_specs",
 		batch.MaxNumPostgresParameters,
 		changesetSpecInsertColumns,

--- a/enterprise/internal/batches/store/changeset_specs.go
+++ b/enterprise/internal/batches/store/changeset_specs.go
@@ -127,7 +127,7 @@ func (s *Store) CreateChangesetSpec(ctx context.Context, cs ...*btypes.Changeset
 	i := -1
 	return batch.WithInserterWithReturn(
 		ctx,
-		s.Handle().DBUtilDB(),
+		s.Handle(),
 		"changeset_specs",
 		batch.MaxNumPostgresParameters,
 		changesetSpecInsertColumns,

--- a/enterprise/internal/batches/testing/batch_spec_workspace_execution_jobs.go
+++ b/enterprise/internal/batches/testing/batch_spec_workspace_execution_jobs.go
@@ -82,7 +82,7 @@ func CreateBatchSpecWorkspaceExecutionJob(ctx context.Context, s createBatchSpec
 	i := -1
 	return batch.WithInserterWithReturn(
 		ctx,
-		s.Handle().DBUtilDB(),
+		s.Handle(),
 		"batch_spec_workspace_execution_jobs",
 		batch.MaxNumPostgresParameters,
 		[]string{"batch_spec_workspace_id", "user_id", "created_at", "updated_at"},

--- a/enterprise/internal/batches/testing/batch_spec_workspace_execution_jobs.go
+++ b/enterprise/internal/batches/testing/batch_spec_workspace_execution_jobs.go
@@ -82,7 +82,7 @@ func CreateBatchSpecWorkspaceExecutionJob(ctx context.Context, s createBatchSpec
 	i := -1
 	return batch.WithInserterWithReturn(
 		ctx,
-		s.Handle().DB(),
+		s.Handle().DBUtilDB(),
 		"batch_spec_workspace_execution_jobs",
 		batch.MaxNumPostgresParameters,
 		[]string{"batch_spec_workspace_id", "user_id", "created_at", "updated_at"},

--- a/enterprise/internal/database/database.go
+++ b/enterprise/internal/database/database.go
@@ -73,21 +73,21 @@ func (d *insightsDB) Done(err error) error {
 
 func (d *insightsDB) Unwrap() dbutil.DB {
 	// Recursively unwrap in case we ever call `NewInsightsDB()` with an `InsightsDB`
-	if unwrapper, ok := d.Handle().DB().(dbutil.Unwrapper); ok {
+	if unwrapper, ok := d.Handle().DBUtilDB().(dbutil.Unwrapper); ok {
 		return unwrapper.Unwrap()
 	}
-	return d.Handle().DB()
+	return d.Handle().DBUtilDB()
 }
 
 func (d *insightsDB) QueryContext(ctx context.Context, q string, args ...any) (*sql.Rows, error) {
-	return d.Handle().DB().QueryContext(ctx, q, args...)
+	return d.Handle().DBUtilDB().QueryContext(ctx, q, args...)
 }
 
 func (d *insightsDB) ExecContext(ctx context.Context, q string, args ...any) (sql.Result, error) {
-	return d.Handle().DB().ExecContext(ctx, q, args...)
+	return d.Handle().DBUtilDB().ExecContext(ctx, q, args...)
 
 }
 
 func (d *insightsDB) QueryRowContext(ctx context.Context, q string, args ...any) *sql.Row {
-	return d.Handle().DB().QueryRowContext(ctx, q, args...)
+	return d.Handle().DBUtilDB().QueryRowContext(ctx, q, args...)
 }

--- a/enterprise/internal/database/database.go
+++ b/enterprise/internal/database/database.go
@@ -73,21 +73,21 @@ func (d *insightsDB) Done(err error) error {
 
 func (d *insightsDB) Unwrap() dbutil.DB {
 	// Recursively unwrap in case we ever call `NewInsightsDB()` with an `InsightsDB`
-	if unwrapper, ok := d.Handle().DBUtilDB().(dbutil.Unwrapper); ok {
+	if unwrapper, ok := d.Handle().(dbutil.Unwrapper); ok {
 		return unwrapper.Unwrap()
 	}
-	return d.Handle().DBUtilDB()
+	return d.Handle()
 }
 
 func (d *insightsDB) QueryContext(ctx context.Context, q string, args ...any) (*sql.Rows, error) {
-	return d.Handle().DBUtilDB().QueryContext(ctx, q, args...)
+	return d.Handle().QueryContext(ctx, q, args...)
 }
 
 func (d *insightsDB) ExecContext(ctx context.Context, q string, args ...any) (sql.Result, error) {
-	return d.Handle().DBUtilDB().ExecContext(ctx, q, args...)
+	return d.Handle().ExecContext(ctx, q, args...)
 
 }
 
 func (d *insightsDB) QueryRowContext(ctx context.Context, q string, args ...any) *sql.Row {
-	return d.Handle().DBUtilDB().QueryRowContext(ctx, q, args...)
+	return d.Handle().QueryRowContext(ctx, q, args...)
 }

--- a/enterprise/internal/database/perms_store_test.go
+++ b/enterprise/internal/database/perms_store_test.go
@@ -258,7 +258,7 @@ func testPermsStore_LoadRepoPermissions(db database.DB) func(*testing.T) {
 }
 
 func checkRegularPermsTable(s *permsStore, sql string, expects map[int32][]uint32) error {
-	rows, err := s.Handle().DB().QueryContext(context.Background(), sql)
+	rows, err := s.Handle().DBUtilDB().QueryContext(context.Background(), sql)
 	if err != nil {
 		return err
 	}
@@ -1026,7 +1026,7 @@ func checkUserPendingPermsTable(
 	err error,
 ) {
 	q := `SELECT id, service_type, service_id, bind_id, object_ids_ints FROM user_pending_permissions`
-	rows, err := s.Handle().DB().QueryContext(ctx, q)
+	rows, err := s.Handle().DBUtilDB().QueryContext(ctx, q)
 	if err != nil {
 		return nil, err
 	}
@@ -1076,7 +1076,7 @@ func checkRepoPendingPermsTable(
 	idToSpecs map[int32]extsvc.AccountSpec,
 	expects map[int32][]extsvc.AccountSpec,
 ) error {
-	rows, err := s.Handle().DB().QueryContext(ctx, `SELECT repo_id, user_ids_ints FROM repo_pending_permissions`)
+	rows, err := s.Handle().DBUtilDB().QueryContext(ctx, `SELECT repo_id, user_ids_ints FROM repo_pending_permissions`)
 	if err != nil {
 		return err
 	}

--- a/enterprise/internal/database/perms_store_test.go
+++ b/enterprise/internal/database/perms_store_test.go
@@ -258,7 +258,7 @@ func testPermsStore_LoadRepoPermissions(db database.DB) func(*testing.T) {
 }
 
 func checkRegularPermsTable(s *permsStore, sql string, expects map[int32][]uint32) error {
-	rows, err := s.Handle().DBUtilDB().QueryContext(context.Background(), sql)
+	rows, err := s.Handle().QueryContext(context.Background(), sql)
 	if err != nil {
 		return err
 	}
@@ -1026,7 +1026,7 @@ func checkUserPendingPermsTable(
 	err error,
 ) {
 	q := `SELECT id, service_type, service_id, bind_id, object_ids_ints FROM user_pending_permissions`
-	rows, err := s.Handle().DBUtilDB().QueryContext(ctx, q)
+	rows, err := s.Handle().QueryContext(ctx, q)
 	if err != nil {
 		return nil, err
 	}
@@ -1076,7 +1076,7 @@ func checkRepoPendingPermsTable(
 	idToSpecs map[int32]extsvc.AccountSpec,
 	expects map[int32][]extsvc.AccountSpec,
 ) error {
-	rows, err := s.Handle().DBUtilDB().QueryContext(ctx, `SELECT repo_id, user_ids_ints FROM repo_pending_permissions`)
+	rows, err := s.Handle().QueryContext(ctx, `SELECT repo_id, user_ids_ints FROM repo_pending_permissions`)
 	if err != nil {
 		return err
 	}

--- a/enterprise/internal/insights/resolvers/insight_connection_resolver_test.go
+++ b/enterprise/internal/insights/resolvers/insight_connection_resolver_test.go
@@ -146,7 +146,7 @@ func TestResolver_InsightsRepoPermissions(t *testing.T) {
 	// Create three repositories -
 	// 1) private repo that will be assigned to user 1
 	// 2 & 3) public repos
-	_, err = postgres.Handle().DB().ExecContext(ctx, `
+	_, err = postgres.Handle().DBUtilDB().ExecContext(ctx, `
 		INSERT INTO repo (id, name, description, fork, created_at, updated_at, external_id, external_service_type,
 					  external_service_id, archived, uri, deleted_at, metadata, private, stars)
 		VALUES
@@ -173,7 +173,7 @@ func TestResolver_InsightsRepoPermissions(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = postgres.Handle().DB().ExecContext(ctx, `
+	_, err = postgres.Handle().DBUtilDB().ExecContext(ctx, `
 		INSERT INTO external_service_repos (external_service_id, repo_id, clone_url)
 		VALUES
 		       ($1, 1, ''),

--- a/enterprise/internal/insights/resolvers/insight_connection_resolver_test.go
+++ b/enterprise/internal/insights/resolvers/insight_connection_resolver_test.go
@@ -146,7 +146,7 @@ func TestResolver_InsightsRepoPermissions(t *testing.T) {
 	// Create three repositories -
 	// 1) private repo that will be assigned to user 1
 	// 2 & 3) public repos
-	_, err = postgres.Handle().DBUtilDB().ExecContext(ctx, `
+	_, err = postgres.Handle().ExecContext(ctx, `
 		INSERT INTO repo (id, name, description, fork, created_at, updated_at, external_id, external_service_type,
 					  external_service_id, archived, uri, deleted_at, metadata, private, stars)
 		VALUES
@@ -173,7 +173,7 @@ func TestResolver_InsightsRepoPermissions(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = postgres.Handle().DBUtilDB().ExecContext(ctx, `
+	_, err = postgres.Handle().ExecContext(ctx, `
 		INSERT INTO external_service_repos (external_service_id, repo_id, clone_url)
 		VALUES
 		       ($1, 1, ''),

--- a/enterprise/internal/insights/resolvers/insight_series_resolver.go
+++ b/enterprise/internal/insights/resolvers/insight_series_resolver.go
@@ -85,7 +85,7 @@ func (r *insightSeriesResolver) Points(ctx context.Context, _ *graphqlbackend.In
 		excludeRepo(*r.filters.ExcludeRepoRegex)
 	}
 
-	scLoader := &scLoader{primary: r.workerBaseStore.Handle().DBUtilDB()}
+	scLoader := &scLoader{primary: r.workerBaseStore.Handle()}
 	inc, exc, err := unwrapSearchContexts(ctx, scLoader, r.filters.SearchContexts)
 	if err != nil {
 		return nil, errors.Wrap(err, "unwrapSearchContexts")
@@ -338,7 +338,7 @@ func getRecordedSeriesPointOpts(ctx context.Context, db dbutil.DB, definition ty
 }
 
 func recordedSeries(ctx context.Context, definition types.InsightViewSeries, r baseInsightResolver, filters types.InsightViewFilters, seriesOptions types.SeriesDisplayOptions) ([]graphqlbackend.InsightSeriesResolver, error) {
-	opts, err := getRecordedSeriesPointOpts(ctx, r.workerBaseStore.Handle().DBUtilDB(), definition, filters)
+	opts, err := getRecordedSeriesPointOpts(ctx, r.workerBaseStore.Handle(), definition, filters)
 	if err != nil {
 		return nil, errors.Wrap(err, "getRecordedSeriesPointOpts")
 	}
@@ -371,7 +371,7 @@ func recordedSeries(ctx context.Context, definition types.InsightViewSeries, r b
 }
 
 func expandCaptureGroupSeriesRecorded(ctx context.Context, definition types.InsightViewSeries, r baseInsightResolver, filters types.InsightViewFilters, seriesOptions types.SeriesDisplayOptions) ([]graphqlbackend.InsightSeriesResolver, error) {
-	opts, err := getRecordedSeriesPointOpts(ctx, r.workerBaseStore.Handle().DBUtilDB(), definition, filters)
+	opts, err := getRecordedSeriesPointOpts(ctx, r.workerBaseStore.Handle(), definition, filters)
 	if err != nil {
 		return nil, errors.Wrap(err, "getRecordedSeriesPointOpts")
 	}

--- a/enterprise/internal/insights/resolvers/insight_series_resolver.go
+++ b/enterprise/internal/insights/resolvers/insight_series_resolver.go
@@ -85,7 +85,7 @@ func (r *insightSeriesResolver) Points(ctx context.Context, _ *graphqlbackend.In
 		excludeRepo(*r.filters.ExcludeRepoRegex)
 	}
 
-	scLoader := &scLoader{primary: r.workerBaseStore.Handle().DB()}
+	scLoader := &scLoader{primary: r.workerBaseStore.Handle().DBUtilDB()}
 	inc, exc, err := unwrapSearchContexts(ctx, scLoader, r.filters.SearchContexts)
 	if err != nil {
 		return nil, errors.Wrap(err, "unwrapSearchContexts")
@@ -338,7 +338,7 @@ func getRecordedSeriesPointOpts(ctx context.Context, db dbutil.DB, definition ty
 }
 
 func recordedSeries(ctx context.Context, definition types.InsightViewSeries, r baseInsightResolver, filters types.InsightViewFilters, seriesOptions types.SeriesDisplayOptions) ([]graphqlbackend.InsightSeriesResolver, error) {
-	opts, err := getRecordedSeriesPointOpts(ctx, r.workerBaseStore.Handle().DB(), definition, filters)
+	opts, err := getRecordedSeriesPointOpts(ctx, r.workerBaseStore.Handle().DBUtilDB(), definition, filters)
 	if err != nil {
 		return nil, errors.Wrap(err, "getRecordedSeriesPointOpts")
 	}
@@ -371,7 +371,7 @@ func recordedSeries(ctx context.Context, definition types.InsightViewSeries, r b
 }
 
 func expandCaptureGroupSeriesRecorded(ctx context.Context, definition types.InsightViewSeries, r baseInsightResolver, filters types.InsightViewFilters, seriesOptions types.SeriesDisplayOptions) ([]graphqlbackend.InsightSeriesResolver, error) {
-	opts, err := getRecordedSeriesPointOpts(ctx, r.workerBaseStore.Handle().DB(), definition, filters)
+	opts, err := getRecordedSeriesPointOpts(ctx, r.workerBaseStore.Handle().DBUtilDB(), definition, filters)
 	if err != nil {
 		return nil, errors.Wrap(err, "getRecordedSeriesPointOpts")
 	}

--- a/internal/codeintel/dependencies/internal/store/store.go
+++ b/internal/codeintel/dependencies/internal/store/store.go
@@ -187,7 +187,7 @@ func (s *store) UpsertLockfileDependencies(ctx context.Context, repoName, commit
 
 	if err := batch.InsertValues(
 		ctx,
-		tx.db.Handle().DBUtilDB(),
+		tx.db.Handle(),
 		"t_codeintel_lockfile_references",
 		batch.MaxNumPostgresParameters,
 		[]string{"repository_name", "revspec", "package_scheme", "package_name", "package_version"},
@@ -512,7 +512,7 @@ func (s *store) UpsertDependencyRepos(ctx context.Context, deps []shared.Repo) (
 
 	err = batch.WithInserterWithReturn(
 		ctx,
-		s.db.Handle().DBUtilDB(),
+		s.db.Handle(),
 		"lsif_dependency_repos",
 		batch.MaxNumPostgresParameters,
 		[]string{"scheme", "name", "version"},

--- a/internal/codeintel/dependencies/internal/store/store.go
+++ b/internal/codeintel/dependencies/internal/store/store.go
@@ -187,7 +187,7 @@ func (s *store) UpsertLockfileDependencies(ctx context.Context, repoName, commit
 
 	if err := batch.InsertValues(
 		ctx,
-		tx.db.Handle().DB(),
+		tx.db.Handle().DBUtilDB(),
 		"t_codeintel_lockfile_references",
 		batch.MaxNumPostgresParameters,
 		[]string{"repository_name", "revspec", "package_scheme", "package_name", "package_version"},
@@ -512,7 +512,7 @@ func (s *store) UpsertDependencyRepos(ctx context.Context, deps []shared.Repo) (
 
 	err = batch.WithInserterWithReturn(
 		ctx,
-		s.db.Handle().DB(),
+		s.db.Handle().DBUtilDB(),
 		"lsif_dependency_repos",
 		batch.MaxNumPostgresParameters,
 		[]string{"scheme", "name", "version"},

--- a/internal/codeintel/stores/db.go
+++ b/internal/codeintel/stores/db.go
@@ -42,21 +42,21 @@ func (d *codeIntelDB) Done(err error) error {
 
 func (d *codeIntelDB) Unwrap() dbutil.DB {
 	// Recursively unwrap in case we ever call `NewInsightsDB()` with an `InsightsDB`
-	if unwrapper, ok := d.Handle().DBUtilDB().(dbutil.Unwrapper); ok {
+	if unwrapper, ok := d.Handle().(dbutil.Unwrapper); ok {
 		return unwrapper.Unwrap()
 	}
-	return d.Handle().DBUtilDB()
+	return d.Handle()
 }
 
 func (d *codeIntelDB) QueryContext(ctx context.Context, q string, args ...any) (*sql.Rows, error) {
-	return d.Handle().DBUtilDB().QueryContext(ctx, q, args...)
+	return d.Handle().QueryContext(ctx, q, args...)
 }
 
 func (d *codeIntelDB) ExecContext(ctx context.Context, q string, args ...any) (sql.Result, error) {
-	return d.Handle().DBUtilDB().ExecContext(ctx, q, args...)
+	return d.Handle().ExecContext(ctx, q, args...)
 
 }
 
 func (d *codeIntelDB) QueryRowContext(ctx context.Context, q string, args ...any) *sql.Row {
-	return d.Handle().DBUtilDB().QueryRowContext(ctx, q, args...)
+	return d.Handle().QueryRowContext(ctx, q, args...)
 }

--- a/internal/codeintel/stores/db.go
+++ b/internal/codeintel/stores/db.go
@@ -42,21 +42,21 @@ func (d *codeIntelDB) Done(err error) error {
 
 func (d *codeIntelDB) Unwrap() dbutil.DB {
 	// Recursively unwrap in case we ever call `NewInsightsDB()` with an `InsightsDB`
-	if unwrapper, ok := d.Handle().DB().(dbutil.Unwrapper); ok {
+	if unwrapper, ok := d.Handle().DBUtilDB().(dbutil.Unwrapper); ok {
 		return unwrapper.Unwrap()
 	}
-	return d.Handle().DB()
+	return d.Handle().DBUtilDB()
 }
 
 func (d *codeIntelDB) QueryContext(ctx context.Context, q string, args ...any) (*sql.Rows, error) {
-	return d.Handle().DB().QueryContext(ctx, q, args...)
+	return d.Handle().DBUtilDB().QueryContext(ctx, q, args...)
 }
 
 func (d *codeIntelDB) ExecContext(ctx context.Context, q string, args ...any) (sql.Result, error) {
-	return d.Handle().DB().ExecContext(ctx, q, args...)
+	return d.Handle().DBUtilDB().ExecContext(ctx, q, args...)
 
 }
 
 func (d *codeIntelDB) QueryRowContext(ctx context.Context, q string, args ...any) *sql.Row {
-	return d.Handle().DB().QueryRowContext(ctx, q, args...)
+	return d.Handle().DBUtilDB().QueryRowContext(ctx, q, args...)
 }

--- a/internal/codeintel/stores/dbstore/commits.go
+++ b/internal/codeintel/stores/dbstore/commits.go
@@ -512,7 +512,7 @@ func (s *Store) writeVisibleUploads(ctx context.Context, sanitizedInput *sanitiz
 	nearestUploadsWriter := func() error {
 		return batch.InsertValues(
 			gctx,
-			s.Handle().DB(),
+			s.Handle().DBUtilDB(),
 			"t_lsif_nearest_uploads",
 			batch.MaxNumPostgresParameters,
 			[]string{"commit_bytea", "uploads"},
@@ -526,7 +526,7 @@ func (s *Store) writeVisibleUploads(ctx context.Context, sanitizedInput *sanitiz
 	nearestUploadsLinksWriter := func() error {
 		return batch.InsertValues(
 			gctx,
-			s.Handle().DB(),
+			s.Handle().DBUtilDB(),
 			"t_lsif_nearest_uploads_links",
 			batch.MaxNumPostgresParameters,
 			[]string{"commit_bytea", "ancestor_commit_bytea", "distance"},
@@ -539,7 +539,7 @@ func (s *Store) writeVisibleUploads(ctx context.Context, sanitizedInput *sanitiz
 	uploadsVisibleAtTipWriter := func() error {
 		return batch.InsertValues(
 			gctx,
-			s.Handle().DB(),
+			s.Handle().DBUtilDB(),
 			"t_lsif_uploads_visible_at_tip",
 			batch.MaxNumPostgresParameters,
 			[]string{"upload_id", "branch_or_tag_name", "is_default_branch"},

--- a/internal/codeintel/stores/dbstore/commits.go
+++ b/internal/codeintel/stores/dbstore/commits.go
@@ -512,7 +512,7 @@ func (s *Store) writeVisibleUploads(ctx context.Context, sanitizedInput *sanitiz
 	nearestUploadsWriter := func() error {
 		return batch.InsertValues(
 			gctx,
-			s.Handle().DBUtilDB(),
+			s.Handle(),
 			"t_lsif_nearest_uploads",
 			batch.MaxNumPostgresParameters,
 			[]string{"commit_bytea", "uploads"},
@@ -526,7 +526,7 @@ func (s *Store) writeVisibleUploads(ctx context.Context, sanitizedInput *sanitiz
 	nearestUploadsLinksWriter := func() error {
 		return batch.InsertValues(
 			gctx,
-			s.Handle().DBUtilDB(),
+			s.Handle(),
 			"t_lsif_nearest_uploads_links",
 			batch.MaxNumPostgresParameters,
 			[]string{"commit_bytea", "ancestor_commit_bytea", "distance"},
@@ -539,7 +539,7 @@ func (s *Store) writeVisibleUploads(ctx context.Context, sanitizedInput *sanitiz
 	uploadsVisibleAtTipWriter := func() error {
 		return batch.InsertValues(
 			gctx,
-			s.Handle().DBUtilDB(),
+			s.Handle(),
 			"t_lsif_uploads_visible_at_tip",
 			batch.MaxNumPostgresParameters,
 			[]string{"upload_id", "branch_or_tag_name", "is_default_branch"},

--- a/internal/codeintel/stores/dbstore/packages.go
+++ b/internal/codeintel/stores/dbstore/packages.go
@@ -36,7 +36,7 @@ func (s *Store) UpdatePackages(ctx context.Context, dumpID int, packages []preci
 	// Bulk insert all the unique column values into the temporary table
 	if err := batch.InsertValues(
 		ctx,
-		tx.Handle().DB(),
+		tx.Handle().DBUtilDB(),
 		"t_lsif_packages",
 		batch.MaxNumPostgresParameters,
 		[]string{"scheme", "name", "version"},

--- a/internal/codeintel/stores/dbstore/packages.go
+++ b/internal/codeintel/stores/dbstore/packages.go
@@ -36,7 +36,7 @@ func (s *Store) UpdatePackages(ctx context.Context, dumpID int, packages []preci
 	// Bulk insert all the unique column values into the temporary table
 	if err := batch.InsertValues(
 		ctx,
-		tx.Handle().DBUtilDB(),
+		tx.Handle(),
 		"t_lsif_packages",
 		batch.MaxNumPostgresParameters,
 		[]string{"scheme", "name", "version"},

--- a/internal/codeintel/stores/dbstore/references.go
+++ b/internal/codeintel/stores/dbstore/references.go
@@ -36,7 +36,7 @@ func (s *Store) UpdatePackageReferences(ctx context.Context, dumpID int, referen
 	// Bulk insert all the unique column values into the temporary table
 	if err := batch.InsertValues(
 		ctx,
-		tx.Handle().DBUtilDB(),
+		tx.Handle(),
 		"t_lsif_references",
 		batch.MaxNumPostgresParameters,
 		[]string{"scheme", "name", "version"},

--- a/internal/codeintel/stores/dbstore/references.go
+++ b/internal/codeintel/stores/dbstore/references.go
@@ -36,7 +36,7 @@ func (s *Store) UpdatePackageReferences(ctx context.Context, dumpID int, referen
 	// Bulk insert all the unique column values into the temporary table
 	if err := batch.InsertValues(
 		ctx,
-		tx.Handle().DB(),
+		tx.Handle().DBUtilDB(),
 		"t_lsif_references",
 		batch.MaxNumPostgresParameters,
 		[]string{"scheme", "name", "version"},

--- a/internal/codeintel/stores/lsifstore/data_write.go
+++ b/internal/codeintel/stores/lsifstore/data_write.go
@@ -83,7 +83,7 @@ func (s *Store) WriteDocuments(ctx context.Context, bundleID int, documents chan
 	// Bulk insert all the unique column values into the temporary table
 	if err := withBatchInserter(
 		ctx,
-		tx.Handle().DBUtilDB(),
+		tx.Handle(),
 		"t_lsif_data_documents",
 		[]string{
 			"path",
@@ -164,7 +164,7 @@ func (s *Store) WriteResultChunks(ctx context.Context, bundleID int, resultChunk
 	// Bulk insert all the unique column values into the temporary table
 	if err := withBatchInserter(
 		ctx,
-		tx.Handle().DBUtilDB(),
+		tx.Handle(),
 		"t_lsif_data_result_chunks",
 		[]string{"idx", "data"},
 		inserter,
@@ -255,7 +255,7 @@ func (s *Store) writeMonikers(ctx context.Context, bundleID int, tableName strin
 	// Bulk insert all the unique column values into the temporary table
 	if err := withBatchInserter(
 		ctx,
-		tx.Handle().DBUtilDB(),
+		tx.Handle(),
 		"t_"+tableName,
 		[]string{"scheme", "identifier", "data", "num_locations"},
 		inserter,

--- a/internal/codeintel/stores/lsifstore/data_write.go
+++ b/internal/codeintel/stores/lsifstore/data_write.go
@@ -83,7 +83,7 @@ func (s *Store) WriteDocuments(ctx context.Context, bundleID int, documents chan
 	// Bulk insert all the unique column values into the temporary table
 	if err := withBatchInserter(
 		ctx,
-		tx.Handle().DB(),
+		tx.Handle().DBUtilDB(),
 		"t_lsif_data_documents",
 		[]string{
 			"path",
@@ -164,7 +164,7 @@ func (s *Store) WriteResultChunks(ctx context.Context, bundleID int, resultChunk
 	// Bulk insert all the unique column values into the temporary table
 	if err := withBatchInserter(
 		ctx,
-		tx.Handle().DB(),
+		tx.Handle().DBUtilDB(),
 		"t_lsif_data_result_chunks",
 		[]string{"idx", "data"},
 		inserter,
@@ -255,7 +255,7 @@ func (s *Store) writeMonikers(ctx context.Context, bundleID int, tableName strin
 	// Bulk insert all the unique column values into the temporary table
 	if err := withBatchInserter(
 		ctx,
-		tx.Handle().DB(),
+		tx.Handle().DBUtilDB(),
 		"t_"+tableName,
 		[]string{"scheme", "identifier", "data", "num_locations"},
 		inserter,

--- a/internal/codeintel/stores/lsifstore/migration/migrator.go
+++ b/internal/codeintel/stores/lsifstore/migration/migrator.go
@@ -364,7 +364,7 @@ func (m *Migrator) updateBatch(ctx context.Context, tx *lsifstore.Store, dumpID,
 
 	if err := batch.InsertValues(
 		ctx,
-		tx.Handle().DB(),
+		tx.Handle().DBUtilDB(),
 		temporaryTableName,
 		batch.MaxNumPostgresParameters,
 		m.temporaryTableFieldNames,

--- a/internal/codeintel/stores/lsifstore/migration/migrator.go
+++ b/internal/codeintel/stores/lsifstore/migration/migrator.go
@@ -364,7 +364,7 @@ func (m *Migrator) updateBatch(ctx context.Context, tx *lsifstore.Store, dumpID,
 
 	if err := batch.InsertValues(
 		ctx,
-		tx.Handle().DBUtilDB(),
+		tx.Handle(),
 		temporaryTableName,
 		batch.MaxNumPostgresParameters,
 		m.temporaryTableFieldNames,

--- a/internal/database/access_tokens.go
+++ b/internal/database/access_tokens.go
@@ -164,7 +164,7 @@ func (s *accessTokenStore) createToken(ctx context.Context, subjectUserID int32,
 		return 0, "", errors.New("access tokens without scopes are not supported")
 	}
 
-	if err := s.Handle().DB().QueryRowContext(ctx,
+	if err := s.Handle().DBUtilDB().QueryRowContext(ctx,
 		// Include users table query (with "FOR UPDATE") to ensure that subject/creator users have
 		// not been deleted. If they were deleted, the query will return an error.
 		`
@@ -197,7 +197,7 @@ func (s *accessTokenStore) Lookup(ctx context.Context, tokenHexEncoded, required
 		return 0, errors.Wrap(err, "AccessTokens.Lookup")
 	}
 
-	if err := s.Handle().DB().QueryRowContext(ctx,
+	if err := s.Handle().DBUtilDB().QueryRowContext(ctx,
 		// Ensure that subject and creator users still exist.
 		`
 UPDATE access_tokens t SET last_used_at=now()

--- a/internal/database/access_tokens.go
+++ b/internal/database/access_tokens.go
@@ -164,7 +164,7 @@ func (s *accessTokenStore) createToken(ctx context.Context, subjectUserID int32,
 		return 0, "", errors.New("access tokens without scopes are not supported")
 	}
 
-	if err := s.Handle().DBUtilDB().QueryRowContext(ctx,
+	if err := s.Handle().QueryRowContext(ctx,
 		// Include users table query (with "FOR UPDATE") to ensure that subject/creator users have
 		// not been deleted. If they were deleted, the query will return an error.
 		`
@@ -197,7 +197,7 @@ func (s *accessTokenStore) Lookup(ctx context.Context, tokenHexEncoded, required
 		return 0, errors.Wrap(err, "AccessTokens.Lookup")
 	}
 
-	if err := s.Handle().DBUtilDB().QueryRowContext(ctx,
+	if err := s.Handle().QueryRowContext(ctx,
 		// Ensure that subject and creator users still exist.
 		`
 UPDATE access_tokens t SET last_used_at=now()

--- a/internal/database/basestore/handle.go
+++ b/internal/database/basestore/handle.go
@@ -25,7 +25,7 @@ func NewHandleWithDB(db *sql.DB, txOptions sql.TxOptions) TransactableHandle {
 }
 
 // DB returns the underlying database handle.
-func (h *oldTransactableHandle) DB() dbutil.DB {
+func (h *oldTransactableHandle) DBUtilDB() dbutil.DB {
 	return h.db
 }
 

--- a/internal/database/basestore/handle.go
+++ b/internal/database/basestore/handle.go
@@ -24,6 +24,11 @@ func NewHandleWithDB(db *sql.DB, txOptions sql.TxOptions) TransactableHandle {
 	return &dbHandle{DB: db, txOptions: txOptions}
 }
 
+// NewHandleWithTx returns a new transactable database handle using the given transaction.
+func NewHandleWithTx(tx *sql.Tx, txOptions sql.TxOptions) TransactableHandle {
+	return &txHandle{Tx: tx, txOptions: txOptions}
+}
+
 // InTransaction returns true if the underlying database handle is in a transaction.
 func (h *oldTransactableHandle) InTransaction() bool {
 	db := tryUnwrap(h.DB)

--- a/internal/database/basestore/handle.go
+++ b/internal/database/basestore/handle.go
@@ -24,11 +24,6 @@ func NewHandleWithDB(db *sql.DB, txOptions sql.TxOptions) TransactableHandle {
 	return &dbHandle{DB: db, txOptions: txOptions}
 }
 
-// DB returns the underlying database handle.
-func (h *oldTransactableHandle) DBUtilDB() dbutil.DB {
-	return h.DB
-}
-
 // InTransaction returns true if the underlying database handle is in a transaction.
 func (h *oldTransactableHandle) InTransaction() bool {
 	db := tryUnwrap(h.DB)

--- a/internal/database/basestore/handle_interface.go
+++ b/internal/database/basestore/handle_interface.go
@@ -15,9 +15,6 @@ import (
 type TransactableHandle interface {
 	dbutil.DB
 
-	// DBUtilDB returns the underlying dbutil.DBUtilDB, which is usually a *sql.DBUtilDB or a *sql.Tx
-	DBUtilDB() dbutil.DB
-
 	// InTransaction returns whether the handle represents a handle to a transaction.
 	InTransaction() bool
 

--- a/internal/database/basestore/handle_interface.go
+++ b/internal/database/basestore/handle_interface.go
@@ -13,8 +13,8 @@ import (
 // nested transactions through registration and finalization of savepoints. A
 // transactable database handler can be shared by multiple stores.
 type TransactableHandle interface {
-	// DB returns the underlying dbutil.DB, which is usually a *sql.DB or a *sql.Tx
-	DB() dbutil.DB
+	// DBUtilDB returns the underlying dbutil.DBUtilDB, which is usually a *sql.DBUtilDB or a *sql.Tx
+	DBUtilDB() dbutil.DB
 
 	// InTransaction returns whether the handle represents a handle to a transaction.
 	InTransaction() bool
@@ -48,7 +48,7 @@ type dbHandle struct {
 	txOptions sql.TxOptions
 }
 
-func (h *dbHandle) DB() dbutil.DB {
+func (h *dbHandle) DBUtilDB() dbutil.DB {
 	return h.db
 }
 
@@ -73,7 +73,7 @@ type txHandle struct {
 	txOptions sql.TxOptions
 }
 
-func (h *txHandle) DB() dbutil.DB {
+func (h *txHandle) DBUtilDB() dbutil.DB {
 	return h.tx
 }
 
@@ -102,7 +102,7 @@ type savepointHandle struct {
 	savepointID string
 }
 
-func (h *savepointHandle) DB() dbutil.DB {
+func (h *savepointHandle) DBUtilDB() dbutil.DB {
 	return h.tx
 }
 

--- a/internal/database/basestore/handle_interface.go
+++ b/internal/database/basestore/handle_interface.go
@@ -47,10 +47,6 @@ type dbHandle struct {
 	txOptions sql.TxOptions
 }
 
-func (h *dbHandle) DBUtilDB() dbutil.DB {
-	return h.DB
-}
-
 func (h *dbHandle) InTransaction() bool {
 	return false
 }
@@ -70,10 +66,6 @@ func (h *dbHandle) Done(err error) error {
 type txHandle struct {
 	*sql.Tx
 	txOptions sql.TxOptions
-}
-
-func (h *txHandle) DBUtilDB() dbutil.DB {
-	return h.Tx
 }
 
 func (h *txHandle) InTransaction() bool {
@@ -99,10 +91,6 @@ func (h *txHandle) Done(err error) error {
 type savepointHandle struct {
 	*sql.Tx
 	savepointID string
-}
-
-func (h *savepointHandle) DBUtilDB() dbutil.DB {
-	return h.Tx
 }
 
 func (h *savepointHandle) InTransaction() bool {

--- a/internal/database/basestore/store.go
+++ b/internal/database/basestore/store.go
@@ -83,13 +83,13 @@ func (s *Store) With(other ShareableStore) *Store {
 
 // Query performs QueryContext on the underlying connection.
 func (s *Store) Query(ctx context.Context, query *sqlf.Query) (*sql.Rows, error) {
-	rows, err := s.handle.DB().QueryContext(ctx, query.Query(sqlf.PostgresBindVar), query.Args()...)
+	rows, err := s.handle.DBUtilDB().QueryContext(ctx, query.Query(sqlf.PostgresBindVar), query.Args()...)
 	return rows, s.wrapError(query, err)
 }
 
 // QueryRow performs QueryRowContext on the underlying connection.
 func (s *Store) QueryRow(ctx context.Context, query *sqlf.Query) *sql.Row {
-	return s.handle.DB().QueryRowContext(ctx, query.Query(sqlf.PostgresBindVar), query.Args()...)
+	return s.handle.DBUtilDB().QueryRowContext(ctx, query.Query(sqlf.PostgresBindVar), query.Args()...)
 }
 
 // Exec performs a query without returning any rows.
@@ -101,7 +101,7 @@ func (s *Store) Exec(ctx context.Context, query *sqlf.Query) error {
 // ExecResult performs a query without returning any rows, but includes the
 // result of the execution.
 func (s *Store) ExecResult(ctx context.Context, query *sqlf.Query) (sql.Result, error) {
-	res, err := s.handle.DB().ExecContext(ctx, query.Query(sqlf.PostgresBindVar), query.Args()...)
+	res, err := s.handle.DBUtilDB().ExecContext(ctx, query.Query(sqlf.PostgresBindVar), query.Args()...)
 	return res, s.wrapError(query, err)
 }
 

--- a/internal/database/basestore/store.go
+++ b/internal/database/basestore/store.go
@@ -83,13 +83,13 @@ func (s *Store) With(other ShareableStore) *Store {
 
 // Query performs QueryContext on the underlying connection.
 func (s *Store) Query(ctx context.Context, query *sqlf.Query) (*sql.Rows, error) {
-	rows, err := s.handle.DBUtilDB().QueryContext(ctx, query.Query(sqlf.PostgresBindVar), query.Args()...)
+	rows, err := s.handle.QueryContext(ctx, query.Query(sqlf.PostgresBindVar), query.Args()...)
 	return rows, s.wrapError(query, err)
 }
 
 // QueryRow performs QueryRowContext on the underlying connection.
 func (s *Store) QueryRow(ctx context.Context, query *sqlf.Query) *sql.Row {
-	return s.handle.DBUtilDB().QueryRowContext(ctx, query.Query(sqlf.PostgresBindVar), query.Args()...)
+	return s.handle.QueryRowContext(ctx, query.Query(sqlf.PostgresBindVar), query.Args()...)
 }
 
 // Exec performs a query without returning any rows.
@@ -101,7 +101,7 @@ func (s *Store) Exec(ctx context.Context, query *sqlf.Query) error {
 // ExecResult performs a query without returning any rows, but includes the
 // result of the execution.
 func (s *Store) ExecResult(ctx context.Context, query *sqlf.Query) (sql.Result, error) {
-	res, err := s.handle.DBUtilDB().ExecContext(ctx, query.Query(sqlf.PostgresBindVar), query.Args()...)
+	res, err := s.handle.ExecContext(ctx, query.Query(sqlf.PostgresBindVar), query.Args()...)
 	return res, s.wrapError(query, err)
 }
 

--- a/internal/database/basestore/store_test.go
+++ b/internal/database/basestore/store_test.go
@@ -45,8 +45,8 @@ func TestTransaction(t *testing.T) {
 
 	// Check what's visible pre-commit/rollback
 	assertCounts(t, db, map[int]int{1: 42})
-	assertCounts(t, tx1.handle.DB(), map[int]int{1: 42, 2: 43})
-	assertCounts(t, tx2.handle.DB(), map[int]int{1: 42, 3: 44})
+	assertCounts(t, tx1.handle.DBUtilDB(), map[int]int{1: 42, 2: 43})
+	assertCounts(t, tx2.handle.DBUtilDB(), map[int]int{1: 42, 3: 44})
 
 	// Finalize transactions
 	rollbackErr := errors.New("rollback")

--- a/internal/database/basestore/store_test.go
+++ b/internal/database/basestore/store_test.go
@@ -45,8 +45,8 @@ func TestTransaction(t *testing.T) {
 
 	// Check what's visible pre-commit/rollback
 	assertCounts(t, db, map[int]int{1: 42})
-	assertCounts(t, tx1.handle.DBUtilDB(), map[int]int{1: 42, 2: 43})
-	assertCounts(t, tx2.handle.DBUtilDB(), map[int]int{1: 42, 3: 44})
+	assertCounts(t, tx1.handle, map[int]int{1: 42, 2: 43})
+	assertCounts(t, tx2.handle, map[int]int{1: 42, 3: 44})
 
 	// Finalize transactions
 	rollbackErr := errors.New("rollback")

--- a/internal/database/bitbucket_project_permissions_test.go
+++ b/internal/database/bitbucket_project_permissions_test.go
@@ -88,7 +88,7 @@ func TestBitbucketProjectPermissionsEnqueue(t *testing.T) {
 	// Enqueue two jobs for the same project with different states
 	jobID, err = db.BitbucketProjectPermissions().Enqueue(ctx, "project 7", 1, perms, false)
 	require.NoError(t, err)
-	_, err = db.Handle().DBUtilDB().ExecContext(ctx, `UPDATE explicit_permissions_bitbucket_projects_jobs SET state = 'failed' WHERE id = $1`, jobID)
+	_, err = db.Handle().ExecContext(ctx, `UPDATE explicit_permissions_bitbucket_projects_jobs SET state = 'failed' WHERE id = $1`, jobID)
 	require.NoError(t, err)
 
 	jobID2, err = db.BitbucketProjectPermissions().Enqueue(ctx, "project 7", 1, perms, false)

--- a/internal/database/bitbucket_project_permissions_test.go
+++ b/internal/database/bitbucket_project_permissions_test.go
@@ -88,7 +88,7 @@ func TestBitbucketProjectPermissionsEnqueue(t *testing.T) {
 	// Enqueue two jobs for the same project with different states
 	jobID, err = db.BitbucketProjectPermissions().Enqueue(ctx, "project 7", 1, perms, false)
 	require.NoError(t, err)
-	_, err = db.Handle().DB().ExecContext(ctx, `UPDATE explicit_permissions_bitbucket_projects_jobs SET state = 'failed' WHERE id = $1`, jobID)
+	_, err = db.Handle().DBUtilDB().ExecContext(ctx, `UPDATE explicit_permissions_bitbucket_projects_jobs SET state = 'failed' WHERE id = $1`, jobID)
 	require.NoError(t, err)
 
 	jobID2, err = db.BitbucketProjectPermissions().Enqueue(ctx, "project 7", 1, perms, false)

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -72,16 +72,16 @@ type db struct {
 }
 
 func (d *db) QueryContext(ctx context.Context, q string, args ...any) (*sql.Rows, error) {
-	return d.Handle().DBUtilDB().QueryContext(ctx, q, args...)
+	return d.Handle().QueryContext(ctx, q, args...)
 }
 
 func (d *db) ExecContext(ctx context.Context, q string, args ...any) (sql.Result, error) {
-	return d.Handle().DBUtilDB().ExecContext(ctx, q, args...)
+	return d.Handle().ExecContext(ctx, q, args...)
 
 }
 
 func (d *db) QueryRowContext(ctx context.Context, q string, args ...any) *sql.Row {
-	return d.Handle().DBUtilDB().QueryRowContext(ctx, q, args...)
+	return d.Handle().QueryRowContext(ctx, q, args...)
 }
 
 func (d *db) Transact(ctx context.Context) (DB, error) {
@@ -214,8 +214,8 @@ func (d *db) WebhookLogs(key encryption.Key) WebhookLogStore {
 
 func (d *db) Unwrap() dbutil.DB {
 	// Recursively unwrap in case we ever call `database.NewDB()` with a `database.DB`
-	if unwrapper, ok := d.Handle().DBUtilDB().(dbutil.Unwrapper); ok {
+	if unwrapper, ok := d.Handle().(dbutil.Unwrapper); ok {
 		return unwrapper.Unwrap()
 	}
-	return d.Handle().DBUtilDB()
+	return d.Handle()
 }

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -72,16 +72,16 @@ type db struct {
 }
 
 func (d *db) QueryContext(ctx context.Context, q string, args ...any) (*sql.Rows, error) {
-	return d.Handle().DB().QueryContext(ctx, q, args...)
+	return d.Handle().DBUtilDB().QueryContext(ctx, q, args...)
 }
 
 func (d *db) ExecContext(ctx context.Context, q string, args ...any) (sql.Result, error) {
-	return d.Handle().DB().ExecContext(ctx, q, args...)
+	return d.Handle().DBUtilDB().ExecContext(ctx, q, args...)
 
 }
 
 func (d *db) QueryRowContext(ctx context.Context, q string, args ...any) *sql.Row {
-	return d.Handle().DB().QueryRowContext(ctx, q, args...)
+	return d.Handle().DBUtilDB().QueryRowContext(ctx, q, args...)
 }
 
 func (d *db) Transact(ctx context.Context) (DB, error) {
@@ -214,8 +214,8 @@ func (d *db) WebhookLogs(key encryption.Key) WebhookLogStore {
 
 func (d *db) Unwrap() dbutil.DB {
 	// Recursively unwrap in case we ever call `database.NewDB()` with a `database.DB`
-	if unwrapper, ok := d.Handle().DB().(dbutil.Unwrapper); ok {
+	if unwrapper, ok := d.Handle().DBUtilDB().(dbutil.Unwrapper); ok {
 		return unwrapper.Unwrap()
 	}
-	return d.Handle().DB()
+	return d.Handle().DBUtilDB()
 }

--- a/internal/database/event_logs.go
+++ b/internal/database/event_logs.go
@@ -228,7 +228,7 @@ func (l *eventLogStore) BulkInsert(ctx context.Context, events []*Event) error {
 
 	return batch.InsertValues(
 		ctx,
-		l.Handle().DBUtilDB(),
+		l.Handle(),
 		"event_logs",
 		batch.MaxNumPostgresParameters,
 		[]string{
@@ -582,7 +582,7 @@ func (l *eventLogStore) countUniqueUsersBySQL(ctx context.Context, startDate, en
 }
 
 func (l *eventLogStore) ListUniqueUsersAll(ctx context.Context, startDate, endDate time.Time) ([]int32, error) {
-	rows, err := l.Handle().DBUtilDB().QueryContext(ctx, `SELECT user_id
+	rows, err := l.Handle().QueryContext(ctx, `SELECT user_id
 		FROM event_logs
 		WHERE user_id > 0 AND DATE(TIMEZONE('UTC'::text, timestamp)) >= $1 AND DATE(TIMEZONE('UTC'::text, timestamp)) <= $2
 		GROUP BY user_id`, startDate, endDate)
@@ -606,7 +606,7 @@ func (l *eventLogStore) ListUniqueUsersAll(ctx context.Context, startDate, endDa
 }
 
 func (l *eventLogStore) UsersUsageCounts(ctx context.Context) (counts []types.UserUsageCounts, err error) {
-	rows, err := l.Handle().DBUtilDB().QueryContext(ctx, usersUsageCountsQuery)
+	rows, err := l.Handle().QueryContext(ctx, usersUsageCountsQuery)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/database/event_logs.go
+++ b/internal/database/event_logs.go
@@ -228,7 +228,7 @@ func (l *eventLogStore) BulkInsert(ctx context.Context, events []*Event) error {
 
 	return batch.InsertValues(
 		ctx,
-		l.Handle().DB(),
+		l.Handle().DBUtilDB(),
 		"event_logs",
 		batch.MaxNumPostgresParameters,
 		[]string{
@@ -582,7 +582,7 @@ func (l *eventLogStore) countUniqueUsersBySQL(ctx context.Context, startDate, en
 }
 
 func (l *eventLogStore) ListUniqueUsersAll(ctx context.Context, startDate, endDate time.Time) ([]int32, error) {
-	rows, err := l.Handle().DB().QueryContext(ctx, `SELECT user_id
+	rows, err := l.Handle().DBUtilDB().QueryContext(ctx, `SELECT user_id
 		FROM event_logs
 		WHERE user_id > 0 AND DATE(TIMEZONE('UTC'::text, timestamp)) >= $1 AND DATE(TIMEZONE('UTC'::text, timestamp)) <= $2
 		GROUP BY user_id`, startDate, endDate)
@@ -606,7 +606,7 @@ func (l *eventLogStore) ListUniqueUsersAll(ctx context.Context, startDate, endDa
 }
 
 func (l *eventLogStore) UsersUsageCounts(ctx context.Context) (counts []types.UserUsageCounts, err error) {
-	rows, err := l.Handle().DB().QueryContext(ctx, usersUsageCountsQuery)
+	rows, err := l.Handle().DBUtilDB().QueryContext(ctx, usersUsageCountsQuery)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/database/event_logs_test.go
+++ b/internal/database/event_logs_test.go
@@ -445,7 +445,7 @@ func TestEventLogs_TestCodeIntelligenceRepositoryCounts(t *testing.T) {
 			repo.name,
 			repo.deletedAt,
 		)
-		if _, err := db.Handle().DBUtilDB().ExecContext(ctx, query.Query(sqlf.PostgresBindVar), query.Args()...); err != nil {
+		if _, err := db.Handle().ExecContext(ctx, query.Query(sqlf.PostgresBindVar), query.Args()...); err != nil {
 			t.Fatalf("unexpected error preparing database: %s", err.Error())
 		}
 	}
@@ -474,7 +474,7 @@ func TestEventLogs_TestCodeIntelligenceRepositoryCounts(t *testing.T) {
 			fmt.Sprintf("%040d", i),
 			uploadedAt,
 		)
-		if _, err := db.Handle().DBUtilDB().ExecContext(ctx, query.Query(sqlf.PostgresBindVar), query.Args()...); err != nil {
+		if _, err := db.Handle().ExecContext(ctx, query.Query(sqlf.PostgresBindVar), query.Args()...); err != nil {
 			t.Fatalf("unexpected error preparing database: %s", err.Error())
 		}
 
@@ -484,7 +484,7 @@ func TestEventLogs_TestCodeIntelligenceRepositoryCounts(t *testing.T) {
 	query := sqlf.Sprintf(
 		"INSERT INTO lsif_index_configuration (repository_id, data, autoindex_enabled) VALUES (1, '', true)",
 	)
-	if _, err := db.Handle().DBUtilDB().ExecContext(ctx, query.Query(sqlf.PostgresBindVar), query.Args()...); err != nil {
+	if _, err := db.Handle().ExecContext(ctx, query.Query(sqlf.PostgresBindVar), query.Args()...); err != nil {
 		t.Fatalf("unexpected error preparing database: %s", err.Error())
 	}
 
@@ -499,7 +499,7 @@ func TestEventLogs_TestCodeIntelligenceRepositoryCounts(t *testing.T) {
 		fmt.Sprintf("%040d", 2), time.Now().UTC().Add(-time.Hour*24*5), // 5 days
 		fmt.Sprintf("%040d", 3),
 	)
-	if _, err := db.Handle().DBUtilDB().ExecContext(ctx, query.Query(sqlf.PostgresBindVar), query.Args()...); err != nil {
+	if _, err := db.Handle().ExecContext(ctx, query.Query(sqlf.PostgresBindVar), query.Args()...); err != nil {
 		t.Fatalf("unexpected error preparing database: %s", err.Error())
 	}
 
@@ -1218,7 +1218,7 @@ func TestEventLogs_RequestsByLanguage(t *testing.T) {
 	db := NewDB(dbtest.NewDB(t))
 	ctx := context.Background()
 
-	if _, err := db.Handle().DBUtilDB().ExecContext(ctx, `
+	if _, err := db.Handle().ExecContext(ctx, `
 		INSERT INTO codeintel_langugage_support_requests (language_id, user_id)
 		VALUES
 			('foo', 1),

--- a/internal/database/event_logs_test.go
+++ b/internal/database/event_logs_test.go
@@ -445,7 +445,7 @@ func TestEventLogs_TestCodeIntelligenceRepositoryCounts(t *testing.T) {
 			repo.name,
 			repo.deletedAt,
 		)
-		if _, err := db.Handle().DB().ExecContext(ctx, query.Query(sqlf.PostgresBindVar), query.Args()...); err != nil {
+		if _, err := db.Handle().DBUtilDB().ExecContext(ctx, query.Query(sqlf.PostgresBindVar), query.Args()...); err != nil {
 			t.Fatalf("unexpected error preparing database: %s", err.Error())
 		}
 	}
@@ -474,7 +474,7 @@ func TestEventLogs_TestCodeIntelligenceRepositoryCounts(t *testing.T) {
 			fmt.Sprintf("%040d", i),
 			uploadedAt,
 		)
-		if _, err := db.Handle().DB().ExecContext(ctx, query.Query(sqlf.PostgresBindVar), query.Args()...); err != nil {
+		if _, err := db.Handle().DBUtilDB().ExecContext(ctx, query.Query(sqlf.PostgresBindVar), query.Args()...); err != nil {
 			t.Fatalf("unexpected error preparing database: %s", err.Error())
 		}
 
@@ -484,7 +484,7 @@ func TestEventLogs_TestCodeIntelligenceRepositoryCounts(t *testing.T) {
 	query := sqlf.Sprintf(
 		"INSERT INTO lsif_index_configuration (repository_id, data, autoindex_enabled) VALUES (1, '', true)",
 	)
-	if _, err := db.Handle().DB().ExecContext(ctx, query.Query(sqlf.PostgresBindVar), query.Args()...); err != nil {
+	if _, err := db.Handle().DBUtilDB().ExecContext(ctx, query.Query(sqlf.PostgresBindVar), query.Args()...); err != nil {
 		t.Fatalf("unexpected error preparing database: %s", err.Error())
 	}
 
@@ -499,7 +499,7 @@ func TestEventLogs_TestCodeIntelligenceRepositoryCounts(t *testing.T) {
 		fmt.Sprintf("%040d", 2), time.Now().UTC().Add(-time.Hour*24*5), // 5 days
 		fmt.Sprintf("%040d", 3),
 	)
-	if _, err := db.Handle().DB().ExecContext(ctx, query.Query(sqlf.PostgresBindVar), query.Args()...); err != nil {
+	if _, err := db.Handle().DBUtilDB().ExecContext(ctx, query.Query(sqlf.PostgresBindVar), query.Args()...); err != nil {
 		t.Fatalf("unexpected error preparing database: %s", err.Error())
 	}
 
@@ -1218,7 +1218,7 @@ func TestEventLogs_RequestsByLanguage(t *testing.T) {
 	db := NewDB(dbtest.NewDB(t))
 	ctx := context.Background()
 
-	if _, err := db.Handle().DB().ExecContext(ctx, `
+	if _, err := db.Handle().DBUtilDB().ExecContext(ctx, `
 		INSERT INTO codeintel_langugage_support_requests (language_id, user_id)
 		VALUES
 			('foo', 1),

--- a/internal/database/external_accounts.go
+++ b/internal/database/external_accounts.go
@@ -146,7 +146,7 @@ func (s *userExternalAccountsStore) LookupUserAndSave(ctx context.Context, spec 
 		data.Data = rawMessagePtr(encrypted)
 	}
 
-	err = s.Handle().DB().QueryRowContext(ctx, `
+	err = s.Handle().DBUtilDB().QueryRowContext(ctx, `
 -- source: internal/database/external_accounts.go:UserExternalAccountsStore.LookupUserAndSave
 UPDATE user_external_accounts
 SET
@@ -305,7 +305,7 @@ VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
 }
 
 func (s *userExternalAccountsStore) TouchExpired(ctx context.Context, id int32) error {
-	_, err := s.Handle().DB().ExecContext(ctx, `
+	_, err := s.Handle().DBUtilDB().ExecContext(ctx, `
 -- source: internal/database/external_accounts.go:UserExternalAccountsStore.TouchExpired
 UPDATE user_external_accounts
 SET expired_at = now()
@@ -315,7 +315,7 @@ WHERE id = $1
 }
 
 func (s *userExternalAccountsStore) TouchLastValid(ctx context.Context, id int32) error {
-	_, err := s.Handle().DB().ExecContext(ctx, `
+	_, err := s.Handle().DBUtilDB().ExecContext(ctx, `
 -- source: internal/database/external_accounts.go:UserExternalAccountsStore.TouchLastValid
 UPDATE user_external_accounts
 SET
@@ -327,7 +327,7 @@ WHERE id = $1
 }
 
 func (s *userExternalAccountsStore) Delete(ctx context.Context, id int32) error {
-	res, err := s.Handle().DB().ExecContext(ctx, "UPDATE user_external_accounts SET deleted_at=now() WHERE id=$1 AND deleted_at IS NULL", id)
+	res, err := s.Handle().DBUtilDB().ExecContext(ctx, "UPDATE user_external_accounts SET deleted_at=now() WHERE id=$1 AND deleted_at IS NULL", id)
 	if err != nil {
 		return err
 	}

--- a/internal/database/external_accounts.go
+++ b/internal/database/external_accounts.go
@@ -146,7 +146,7 @@ func (s *userExternalAccountsStore) LookupUserAndSave(ctx context.Context, spec 
 		data.Data = rawMessagePtr(encrypted)
 	}
 
-	err = s.Handle().DBUtilDB().QueryRowContext(ctx, `
+	err = s.Handle().QueryRowContext(ctx, `
 -- source: internal/database/external_accounts.go:UserExternalAccountsStore.LookupUserAndSave
 UPDATE user_external_accounts
 SET
@@ -305,7 +305,7 @@ VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
 }
 
 func (s *userExternalAccountsStore) TouchExpired(ctx context.Context, id int32) error {
-	_, err := s.Handle().DBUtilDB().ExecContext(ctx, `
+	_, err := s.Handle().ExecContext(ctx, `
 -- source: internal/database/external_accounts.go:UserExternalAccountsStore.TouchExpired
 UPDATE user_external_accounts
 SET expired_at = now()
@@ -315,7 +315,7 @@ WHERE id = $1
 }
 
 func (s *userExternalAccountsStore) TouchLastValid(ctx context.Context, id int32) error {
-	_, err := s.Handle().DBUtilDB().ExecContext(ctx, `
+	_, err := s.Handle().ExecContext(ctx, `
 -- source: internal/database/external_accounts.go:UserExternalAccountsStore.TouchLastValid
 UPDATE user_external_accounts
 SET
@@ -327,7 +327,7 @@ WHERE id = $1
 }
 
 func (s *userExternalAccountsStore) Delete(ctx context.Context, id int32) error {
-	res, err := s.Handle().DBUtilDB().ExecContext(ctx, "UPDATE user_external_accounts SET deleted_at=now() WHERE id=$1 AND deleted_at IS NULL", id)
+	res, err := s.Handle().ExecContext(ctx, "UPDATE user_external_accounts SET deleted_at=now() WHERE id=$1 AND deleted_at IS NULL", id)
 	if err != nil {
 		return err
 	}

--- a/internal/database/external_services.go
+++ b/internal/database/external_services.go
@@ -626,7 +626,7 @@ func (e *externalServiceStore) Create(ctx context.Context, confGet func() *conf.
 		return err
 	}
 
-	return e.Store.Handle().DBUtilDB().QueryRowContext(
+	return e.Store.Handle().QueryRowContext(
 		ctx,
 		"INSERT INTO external_services(kind, display_name, config, encryption_key_id, created_at, updated_at, namespace_user_id, namespace_org_id, unrestricted, cloud_default, has_webhooks) VALUES($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11) RETURNING id",
 		es.Kind, es.DisplayName, config, keyID, es.CreatedAt, es.UpdatedAt, nullInt32Column(es.NamespaceUserID), nullInt32Column(es.NamespaceOrgID), es.Unrestricted, es.CloudDefault, es.HasWebhooks,
@@ -968,7 +968,7 @@ func (e *externalServiceStore) Update(ctx context.Context, ps []schema.AuthProvi
 	}
 
 	q := sqlf.Sprintf("UPDATE external_services SET %s, updated_at = NOW() WHERE id = %d AND deleted_at IS NULL", sqlf.Join(updates, ","), id)
-	res, err := e.Store.Handle().DBUtilDB().ExecContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...)
+	res, err := e.Store.Handle().ExecContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...)
 	if err != nil {
 		return err
 	}

--- a/internal/database/external_services.go
+++ b/internal/database/external_services.go
@@ -626,7 +626,7 @@ func (e *externalServiceStore) Create(ctx context.Context, confGet func() *conf.
 		return err
 	}
 
-	return e.Store.Handle().DB().QueryRowContext(
+	return e.Store.Handle().DBUtilDB().QueryRowContext(
 		ctx,
 		"INSERT INTO external_services(kind, display_name, config, encryption_key_id, created_at, updated_at, namespace_user_id, namespace_org_id, unrestricted, cloud_default, has_webhooks) VALUES($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11) RETURNING id",
 		es.Kind, es.DisplayName, config, keyID, es.CreatedAt, es.UpdatedAt, nullInt32Column(es.NamespaceUserID), nullInt32Column(es.NamespaceOrgID), es.Unrestricted, es.CloudDefault, es.HasWebhooks,
@@ -968,7 +968,7 @@ func (e *externalServiceStore) Update(ctx context.Context, ps []schema.AuthProvi
 	}
 
 	q := sqlf.Sprintf("UPDATE external_services SET %s, updated_at = NOW() WHERE id = %d AND deleted_at IS NULL", sqlf.Join(updates, ","), id)
-	res, err := e.Store.Handle().DB().ExecContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...)
+	res, err := e.Store.Handle().DBUtilDB().ExecContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...)
 	if err != nil {
 		return err
 	}

--- a/internal/database/external_services_test.go
+++ b/internal/database/external_services_test.go
@@ -1066,7 +1066,7 @@ func TestExternalServicesStore_DeleteExtServiceWithManyRepos(t *testing.T) {
 		t.Fatal("External service is not deleted")
 	}
 
-	rows, err := db.Handle().DB().QueryContext(ctx, `select * from repo where deleted_at is null`)
+	rows, err := db.Handle().DBUtilDB().QueryContext(ctx, `select * from repo where deleted_at is null`)
 	if err != nil {
 		t.Fatal("Error during fetching repos from the DB")
 	}
@@ -1264,7 +1264,7 @@ func TestGetAffiliatedSyncErrors(t *testing.T) {
 
 	// Add two failures for the same service
 	failure1 := "oops"
-	_, err = db.Handle().DB().ExecContext(ctx, `
+	_, err = db.Handle().DBUtilDB().ExecContext(ctx, `
 INSERT INTO external_service_sync_jobs (external_service_id, state, finished_at, failure_message)
 VALUES ($1,'errored', now(), $2)
 `, siteLevel.ID, failure1)
@@ -1272,7 +1272,7 @@ VALUES ($1,'errored', now(), $2)
 		t.Fatal(err)
 	}
 	failure2 := "oops again"
-	_, err = db.Handle().DB().ExecContext(ctx, `
+	_, err = db.Handle().DBUtilDB().ExecContext(ctx, `
 INSERT INTO external_service_sync_jobs (external_service_id, state, finished_at, failure_message)
 VALUES ($1,'errored', now(), $2)
 `, siteLevel.ID, failure2)
@@ -1298,7 +1298,7 @@ VALUES ($1,'errored', now(), $2)
 	}
 
 	// Adding a second failing service
-	_, err = db.Handle().DB().ExecContext(ctx, `
+	_, err = db.Handle().DBUtilDB().ExecContext(ctx, `
 INSERT INTO external_service_sync_jobs (external_service_id, state, finished_at, failure_message)
 VALUES ($1,'errored', now(), $2)
 `, adminOwned.ID, failure1)
@@ -1333,7 +1333,7 @@ VALUES ($1,'errored', now(), $2)
 
 	// Add a failure to user service
 	failure3 := "user failure"
-	_, err = db.Handle().DB().ExecContext(ctx, `
+	_, err = db.Handle().DBUtilDB().ExecContext(ctx, `
 INSERT INTO external_service_sync_jobs (external_service_id, state, finished_at, failure_message)
 VALUES ($1,'errored', now(), $2)
 `, userOwned.ID, failure3)
@@ -1361,7 +1361,7 @@ VALUES ($1,'errored', now(), $2)
 	// Add a failure to org service
 	orgOwned := createService(nil, org1, "GITHUB Org owned")
 
-	_, err = db.Handle().DB().ExecContext(ctx, `
+	_, err = db.Handle().DBUtilDB().ExecContext(ctx, `
 INSERT INTO external_service_sync_jobs (external_service_id, state, finished_at, failure_message)
 VALUES ($1,'errored', now(), $2)
 `, orgOwned.ID, "org failure")
@@ -1426,7 +1426,7 @@ func TestGetLastSyncError(t *testing.T) {
 	}
 
 	// Could have failure message
-	_, err = db.Handle().DB().ExecContext(ctx, `
+	_, err = db.Handle().DBUtilDB().ExecContext(ctx, `
 INSERT INTO external_service_sync_jobs (external_service_id, state, finished_at)
 VALUES ($1,'errored', now())
 `, es.ID)
@@ -1445,7 +1445,7 @@ VALUES ($1,'errored', now())
 
 	// Add sync error
 	expectedError := "oops"
-	_, err = db.Handle().DB().ExecContext(ctx, `
+	_, err = db.Handle().DBUtilDB().ExecContext(ctx, `
 INSERT INTO external_service_sync_jobs (external_service_id, failure_message, state, finished_at)
 VALUES ($1,$2,'errored', now())
 `, es.ID, expectedError)
@@ -2037,7 +2037,7 @@ func TestExternalServiceStore_GetExternalServiceSyncJobs(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = db.Handle().DB().ExecContext(ctx, "INSERT INTO external_service_sync_jobs (external_service_id) VALUES ($1)", es.ID)
+	_, err = db.Handle().DBUtilDB().ExecContext(ctx, "INSERT INTO external_service_sync_jobs (external_service_id) VALUES ($1)", es.ID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2146,7 +2146,7 @@ func TestExternalServiceStore_SyncDue(t *testing.T) {
 	}
 
 	makeSyncJob := func(svcID int64, state string) {
-		_, err = db.Handle().DB().ExecContext(ctx, `
+		_, err = db.Handle().DBUtilDB().ExecContext(ctx, `
 INSERT INTO external_service_sync_jobs (external_service_id, state)
 VALUES ($1,$2)
 `, svcID, state)
@@ -2159,7 +2159,7 @@ VALUES ($1,$2)
 	assertDue(1*time.Second, true)
 
 	// next_sync_at in the future
-	_, err = db.Handle().DB().ExecContext(ctx, "UPDATE external_services SET next_sync_at = $1", now.Add(10*time.Minute))
+	_, err = db.Handle().DBUtilDB().ExecContext(ctx, "UPDATE external_services SET next_sync_at = $1", now.Add(10*time.Minute))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2172,7 +2172,7 @@ VALUES ($1,$2)
 	assertDue(1*time.Minute, true)
 
 	// Sync jobs not running
-	_, err = db.Handle().DB().ExecContext(ctx, "UPDATE external_service_sync_jobs SET state = 'completed'")
+	_, err = db.Handle().DBUtilDB().ExecContext(ctx, "UPDATE external_service_sync_jobs SET state = 'completed'")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/database/external_services_test.go
+++ b/internal/database/external_services_test.go
@@ -1066,7 +1066,7 @@ func TestExternalServicesStore_DeleteExtServiceWithManyRepos(t *testing.T) {
 		t.Fatal("External service is not deleted")
 	}
 
-	rows, err := db.Handle().DBUtilDB().QueryContext(ctx, `select * from repo where deleted_at is null`)
+	rows, err := db.Handle().QueryContext(ctx, `select * from repo where deleted_at is null`)
 	if err != nil {
 		t.Fatal("Error during fetching repos from the DB")
 	}
@@ -1264,7 +1264,7 @@ func TestGetAffiliatedSyncErrors(t *testing.T) {
 
 	// Add two failures for the same service
 	failure1 := "oops"
-	_, err = db.Handle().DBUtilDB().ExecContext(ctx, `
+	_, err = db.Handle().ExecContext(ctx, `
 INSERT INTO external_service_sync_jobs (external_service_id, state, finished_at, failure_message)
 VALUES ($1,'errored', now(), $2)
 `, siteLevel.ID, failure1)
@@ -1272,7 +1272,7 @@ VALUES ($1,'errored', now(), $2)
 		t.Fatal(err)
 	}
 	failure2 := "oops again"
-	_, err = db.Handle().DBUtilDB().ExecContext(ctx, `
+	_, err = db.Handle().ExecContext(ctx, `
 INSERT INTO external_service_sync_jobs (external_service_id, state, finished_at, failure_message)
 VALUES ($1,'errored', now(), $2)
 `, siteLevel.ID, failure2)
@@ -1298,7 +1298,7 @@ VALUES ($1,'errored', now(), $2)
 	}
 
 	// Adding a second failing service
-	_, err = db.Handle().DBUtilDB().ExecContext(ctx, `
+	_, err = db.Handle().ExecContext(ctx, `
 INSERT INTO external_service_sync_jobs (external_service_id, state, finished_at, failure_message)
 VALUES ($1,'errored', now(), $2)
 `, adminOwned.ID, failure1)
@@ -1333,7 +1333,7 @@ VALUES ($1,'errored', now(), $2)
 
 	// Add a failure to user service
 	failure3 := "user failure"
-	_, err = db.Handle().DBUtilDB().ExecContext(ctx, `
+	_, err = db.Handle().ExecContext(ctx, `
 INSERT INTO external_service_sync_jobs (external_service_id, state, finished_at, failure_message)
 VALUES ($1,'errored', now(), $2)
 `, userOwned.ID, failure3)
@@ -1361,7 +1361,7 @@ VALUES ($1,'errored', now(), $2)
 	// Add a failure to org service
 	orgOwned := createService(nil, org1, "GITHUB Org owned")
 
-	_, err = db.Handle().DBUtilDB().ExecContext(ctx, `
+	_, err = db.Handle().ExecContext(ctx, `
 INSERT INTO external_service_sync_jobs (external_service_id, state, finished_at, failure_message)
 VALUES ($1,'errored', now(), $2)
 `, orgOwned.ID, "org failure")
@@ -1426,7 +1426,7 @@ func TestGetLastSyncError(t *testing.T) {
 	}
 
 	// Could have failure message
-	_, err = db.Handle().DBUtilDB().ExecContext(ctx, `
+	_, err = db.Handle().ExecContext(ctx, `
 INSERT INTO external_service_sync_jobs (external_service_id, state, finished_at)
 VALUES ($1,'errored', now())
 `, es.ID)
@@ -1445,7 +1445,7 @@ VALUES ($1,'errored', now())
 
 	// Add sync error
 	expectedError := "oops"
-	_, err = db.Handle().DBUtilDB().ExecContext(ctx, `
+	_, err = db.Handle().ExecContext(ctx, `
 INSERT INTO external_service_sync_jobs (external_service_id, failure_message, state, finished_at)
 VALUES ($1,$2,'errored', now())
 `, es.ID, expectedError)
@@ -2037,7 +2037,7 @@ func TestExternalServiceStore_GetExternalServiceSyncJobs(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = db.Handle().DBUtilDB().ExecContext(ctx, "INSERT INTO external_service_sync_jobs (external_service_id) VALUES ($1)", es.ID)
+	_, err = db.Handle().ExecContext(ctx, "INSERT INTO external_service_sync_jobs (external_service_id) VALUES ($1)", es.ID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2146,7 +2146,7 @@ func TestExternalServiceStore_SyncDue(t *testing.T) {
 	}
 
 	makeSyncJob := func(svcID int64, state string) {
-		_, err = db.Handle().DBUtilDB().ExecContext(ctx, `
+		_, err = db.Handle().ExecContext(ctx, `
 INSERT INTO external_service_sync_jobs (external_service_id, state)
 VALUES ($1,$2)
 `, svcID, state)
@@ -2159,7 +2159,7 @@ VALUES ($1,$2)
 	assertDue(1*time.Second, true)
 
 	// next_sync_at in the future
-	_, err = db.Handle().DBUtilDB().ExecContext(ctx, "UPDATE external_services SET next_sync_at = $1", now.Add(10*time.Minute))
+	_, err = db.Handle().ExecContext(ctx, "UPDATE external_services SET next_sync_at = $1", now.Add(10*time.Minute))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2172,7 +2172,7 @@ VALUES ($1,$2)
 	assertDue(1*time.Minute, true)
 
 	// Sync jobs not running
-	_, err = db.Handle().DBUtilDB().ExecContext(ctx, "UPDATE external_service_sync_jobs SET state = 'completed'")
+	_, err = db.Handle().ExecContext(ctx, "UPDATE external_service_sync_jobs SET state = 'completed'")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/database/feature_flags_test.go
+++ b/internal/database/feature_flags_test.go
@@ -43,7 +43,7 @@ func cleanup(t *testing.T, db DB) func() {
 			// Retain content on failed tests
 			return
 		}
-		_, err := db.Handle().DBUtilDB().ExecContext(
+		_, err := db.Handle().ExecContext(
 			context.Background(),
 			`truncate feature_flags, feature_flag_overrides, users, orgs, org_members cascade;`,
 		)

--- a/internal/database/feature_flags_test.go
+++ b/internal/database/feature_flags_test.go
@@ -43,7 +43,7 @@ func cleanup(t *testing.T, db DB) func() {
 			// Retain content on failed tests
 			return
 		}
-		_, err := db.Handle().DB().ExecContext(
+		_, err := db.Handle().DBUtilDB().ExecContext(
 			context.Background(),
 			`truncate feature_flags, feature_flag_overrides, users, orgs, org_members cascade;`,
 		)

--- a/internal/database/gitserver_repos.go
+++ b/internal/database/gitserver_repos.go
@@ -622,7 +622,7 @@ func (s *gitserverRepoStore) UpdateRepoSizes(ctx context.Context, shardID string
 
 	if err := batch.WithInserterWithReturn(
 		ctx,
-		tx.Handle().DBUtilDB(),
+		tx.Handle(),
 		"gitserver_repos",
 		batch.MaxNumPostgresParameters,
 		[]string{"repo_id", "shard_id", "repo_size_bytes", "updated_at"},

--- a/internal/database/gitserver_repos.go
+++ b/internal/database/gitserver_repos.go
@@ -622,7 +622,7 @@ func (s *gitserverRepoStore) UpdateRepoSizes(ctx context.Context, shardID string
 
 	if err := batch.WithInserterWithReturn(
 		ctx,
-		tx.Handle().DB(),
+		tx.Handle().DBUtilDB(),
 		"gitserver_repos",
 		batch.MaxNumPostgresParameters,
 		[]string{"repo_id", "shard_id", "repo_size_bytes", "updated_at"},

--- a/internal/database/gitserver_repos_test.go
+++ b/internal/database/gitserver_repos_test.go
@@ -919,7 +919,7 @@ func TestGitserverRepoListReposWithoutSize(t *testing.T) {
 	if err := db.GitserverRepos().Upsert(ctx, gitserverRepo); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := db.Handle().DBUtilDB().ExecContext(ctx, fmt.Sprintf(
+	if _, err := db.Handle().ExecContext(ctx, fmt.Sprintf(
 		`update gitserver_repos set repo_size_bytes = null where repo_id = %d;`,
 		gitserverRepo.RepoID)); err != nil {
 		t.Fatalf("unexpected error while updating gitserver repo: %s", err)

--- a/internal/database/gitserver_repos_test.go
+++ b/internal/database/gitserver_repos_test.go
@@ -919,7 +919,7 @@ func TestGitserverRepoListReposWithoutSize(t *testing.T) {
 	if err := db.GitserverRepos().Upsert(ctx, gitserverRepo); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := db.Handle().DB().ExecContext(ctx, fmt.Sprintf(
+	if _, err := db.Handle().DBUtilDB().ExecContext(ctx, fmt.Sprintf(
 		`update gitserver_repos set repo_size_bytes = null where repo_id = %d;`,
 		gitserverRepo.RepoID)); err != nil {
 		t.Fatalf("unexpected error while updating gitserver repo: %s", err)

--- a/internal/database/org_invitations.go
+++ b/internal/database/org_invitations.go
@@ -136,7 +136,7 @@ func (s *orgInvitationStore) Create(ctx context.Context, orgID, senderUserID, re
 		return results[len(results)-1], nil
 	}
 
-	if err := s.Handle().DBUtilDB().QueryRowContext(
+	if err := s.Handle().QueryRowContext(
 		ctx,
 		fmt.Sprintf("INSERT INTO org_invitations(org_id, sender_user_id, %s, expires_at) VALUES($1, $2, $3, $4) RETURNING id, created_at", column),
 		orgID, senderUserID, value, expiryTime,
@@ -286,7 +286,7 @@ func (s *orgInvitationStore) Count(ctx context.Context, opt OrgInvitationsListOp
 // UpdateEmailSentTimestamp updates the email-sent timestam[ for the org invitation to the current
 // time.
 func (s *orgInvitationStore) UpdateEmailSentTimestamp(ctx context.Context, id int64) error {
-	res, err := s.Handle().DBUtilDB().ExecContext(ctx, "UPDATE org_invitations SET notified_at=now() WHERE id=$1 AND revoked_at IS NULL AND deleted_at IS NULL AND expires_at > now()", id)
+	res, err := s.Handle().ExecContext(ctx, "UPDATE org_invitations SET notified_at=now() WHERE id=$1 AND revoked_at IS NULL AND deleted_at IS NULL AND expires_at > now()", id)
 	if err != nil {
 		return err
 	}
@@ -304,7 +304,7 @@ func (s *orgInvitationStore) UpdateEmailSentTimestamp(ctx context.Context, id in
 // which the recipient was invited. If the recipient user ID given is incorrect, an
 // OrgInvitationNotFoundError error is returned.
 func (s *orgInvitationStore) Respond(ctx context.Context, id int64, recipientUserID int32, accept bool) (orgID int32, err error) {
-	if err := s.Handle().DBUtilDB().QueryRowContext(ctx, "UPDATE org_invitations SET responded_at=now(), response_type=$2 WHERE id=$1 AND responded_at IS NULL AND revoked_at IS NULL AND deleted_at IS NULL AND expires_at > now() RETURNING org_id", id, accept).Scan(&orgID); err == sql.ErrNoRows {
+	if err := s.Handle().QueryRowContext(ctx, "UPDATE org_invitations SET responded_at=now(), response_type=$2 WHERE id=$1 AND responded_at IS NULL AND revoked_at IS NULL AND deleted_at IS NULL AND expires_at > now() RETURNING org_id", id, accept).Scan(&orgID); err == sql.ErrNoRows {
 		return 0, OrgInvitationNotFoundError{[]any{fmt.Sprintf("id %d recipient %d", id, recipientUserID)}}
 	} else if err != nil {
 		return 0, err
@@ -315,7 +315,7 @@ func (s *orgInvitationStore) Respond(ctx context.Context, id int64, recipientUse
 // Revoke marks an org invitation as revoked. The recipient is forbidden from responding to it after
 // it has been revoked.
 func (s *orgInvitationStore) Revoke(ctx context.Context, id int64) error {
-	res, err := s.Handle().DBUtilDB().ExecContext(ctx, "UPDATE org_invitations SET revoked_at=now() WHERE id=$1 AND revoked_at IS NULL AND deleted_at IS NULL AND expires_at > now()", id)
+	res, err := s.Handle().ExecContext(ctx, "UPDATE org_invitations SET revoked_at=now() WHERE id=$1 AND revoked_at IS NULL AND deleted_at IS NULL AND expires_at > now()", id)
 	if err != nil {
 		return err
 	}
@@ -331,7 +331,7 @@ func (s *orgInvitationStore) Revoke(ctx context.Context, id int64) error {
 
 // UpdateExpiryTime updates the expiry time of the invitation.
 func (s *orgInvitationStore) UpdateExpiryTime(ctx context.Context, id int64, expiresAt time.Time) error {
-	res, err := s.Handle().DBUtilDB().ExecContext(ctx, "UPDATE org_invitations SET expires_at=$2 WHERE id=$1 AND revoked_at IS NULL AND deleted_at IS NULL AND expires_at > now()", id, expiresAt)
+	res, err := s.Handle().ExecContext(ctx, "UPDATE org_invitations SET expires_at=$2 WHERE id=$1 AND revoked_at IS NULL AND deleted_at IS NULL AND expires_at > now()", id, expiresAt)
 	if err != nil {
 		return err
 	}

--- a/internal/database/org_members.go
+++ b/internal/database/org_members.go
@@ -50,7 +50,7 @@ func (m *orgMemberStore) Create(ctx context.Context, orgID, userID int32) (*type
 		OrgID:  orgID,
 		UserID: userID,
 	}
-	err := m.Handle().DBUtilDB().QueryRowContext(
+	err := m.Handle().QueryRowContext(
 		ctx,
 		"INSERT INTO org_members(org_id, user_id) VALUES($1, $2) RETURNING id, created_at, updated_at",
 		om.OrgID, om.UserID).Scan(&om.ID, &om.CreatedAt, &om.UpdatedAt)
@@ -74,7 +74,7 @@ func (m *orgMemberStore) GetByOrgIDAndUserID(ctx context.Context, orgID, userID 
 
 func (m *orgMemberStore) MemberCount(ctx context.Context, orgID int32) (int, error) {
 	var memberCount int
-	err := m.Handle().DBUtilDB().QueryRowContext(ctx, `
+	err := m.Handle().QueryRowContext(ctx, `
 		SELECT COUNT(*)
 		FROM org_members INNER JOIN users ON org_members.user_id = users.id
 		WHERE org_id=$1 AND users.deleted_at IS NULL`, orgID).Scan(&memberCount)
@@ -85,7 +85,7 @@ func (m *orgMemberStore) MemberCount(ctx context.Context, orgID int32) (int, err
 }
 
 func (m *orgMemberStore) Remove(ctx context.Context, orgID, userID int32) error {
-	_, err := m.Handle().DBUtilDB().ExecContext(ctx, "DELETE FROM org_members WHERE (org_id=$1 AND user_id=$2)", orgID, userID)
+	_, err := m.Handle().ExecContext(ctx, "DELETE FROM org_members WHERE (org_id=$1 AND user_id=$2)", orgID, userID)
 	return err
 }
 
@@ -152,7 +152,7 @@ func (m *orgMemberStore) getOneBySQL(ctx context.Context, query string, args ...
 }
 
 func (m *orgMemberStore) getBySQL(ctx context.Context, query string, args ...any) ([]*types.OrgMembership, error) {
-	rows, err := m.Handle().DBUtilDB().QueryContext(ctx, "SELECT org_members.id, org_members.org_id, org_members.user_id, org_members.created_at, org_members.updated_at FROM org_members "+query, args...)
+	rows, err := m.Handle().QueryContext(ctx, "SELECT org_members.id, org_members.org_id, org_members.user_id, org_members.created_at, org_members.updated_at FROM org_members "+query, args...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/database/org_members.go
+++ b/internal/database/org_members.go
@@ -50,7 +50,7 @@ func (m *orgMemberStore) Create(ctx context.Context, orgID, userID int32) (*type
 		OrgID:  orgID,
 		UserID: userID,
 	}
-	err := m.Handle().DB().QueryRowContext(
+	err := m.Handle().DBUtilDB().QueryRowContext(
 		ctx,
 		"INSERT INTO org_members(org_id, user_id) VALUES($1, $2) RETURNING id, created_at, updated_at",
 		om.OrgID, om.UserID).Scan(&om.ID, &om.CreatedAt, &om.UpdatedAt)
@@ -74,7 +74,7 @@ func (m *orgMemberStore) GetByOrgIDAndUserID(ctx context.Context, orgID, userID 
 
 func (m *orgMemberStore) MemberCount(ctx context.Context, orgID int32) (int, error) {
 	var memberCount int
-	err := m.Handle().DB().QueryRowContext(ctx, `
+	err := m.Handle().DBUtilDB().QueryRowContext(ctx, `
 		SELECT COUNT(*)
 		FROM org_members INNER JOIN users ON org_members.user_id = users.id
 		WHERE org_id=$1 AND users.deleted_at IS NULL`, orgID).Scan(&memberCount)
@@ -85,7 +85,7 @@ func (m *orgMemberStore) MemberCount(ctx context.Context, orgID int32) (int, err
 }
 
 func (m *orgMemberStore) Remove(ctx context.Context, orgID, userID int32) error {
-	_, err := m.Handle().DB().ExecContext(ctx, "DELETE FROM org_members WHERE (org_id=$1 AND user_id=$2)", orgID, userID)
+	_, err := m.Handle().DBUtilDB().ExecContext(ctx, "DELETE FROM org_members WHERE (org_id=$1 AND user_id=$2)", orgID, userID)
 	return err
 }
 
@@ -152,7 +152,7 @@ func (m *orgMemberStore) getOneBySQL(ctx context.Context, query string, args ...
 }
 
 func (m *orgMemberStore) getBySQL(ctx context.Context, query string, args ...any) ([]*types.OrgMembership, error) {
-	rows, err := m.Handle().DB().QueryContext(ctx, "SELECT org_members.id, org_members.org_id, org_members.user_id, org_members.created_at, org_members.updated_at FROM org_members "+query, args...)
+	rows, err := m.Handle().DBUtilDB().QueryContext(ctx, "SELECT org_members.id, org_members.org_id, org_members.user_id, org_members.created_at, org_members.updated_at FROM org_members "+query, args...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/database/org_stats.go
+++ b/internal/database/org_stats.go
@@ -31,7 +31,7 @@ func (o *orgStatsStore) Upsert(ctx context.Context, orgID int32, codeHostRepoCou
 		OrgID:             orgID,
 		CodeHostRepoCount: codeHostRepoCount,
 	}
-	err := o.Handle().DBUtilDB().QueryRowContext(
+	err := o.Handle().QueryRowContext(
 		ctx,
 		"INSERT INTO org_stats(org_id, code_host_repo_count) VALUES($1, $2) ON CONFLICT (org_id) DO UPDATE SET code_host_repo_count = $2 RETURNING code_host_repo_count;",
 		newStatistic.OrgID, newStatistic.CodeHostRepoCount).Scan(&newStatistic.CodeHostRepoCount)

--- a/internal/database/org_stats.go
+++ b/internal/database/org_stats.go
@@ -31,7 +31,7 @@ func (o *orgStatsStore) Upsert(ctx context.Context, orgID int32, codeHostRepoCou
 		OrgID:             orgID,
 		CodeHostRepoCount: codeHostRepoCount,
 	}
-	err := o.Handle().DB().QueryRowContext(
+	err := o.Handle().DBUtilDB().QueryRowContext(
 		ctx,
 		"INSERT INTO org_stats(org_id, code_host_repo_count) VALUES($1, $2) ON CONFLICT (org_id) DO UPDATE SET code_host_repo_count = $2 RETURNING code_host_repo_count;",
 		newStatistic.OrgID, newStatistic.CodeHostRepoCount).Scan(&newStatistic.CodeHostRepoCount)

--- a/internal/database/orgs.go
+++ b/internal/database/orgs.go
@@ -98,7 +98,7 @@ func (o *orgStore) getByUserID(ctx context.Context, userID int32, onlyOrgsWithRe
 				LIMIT 1
 			)`
 	}
-	rows, err := o.Handle().DBUtilDB().QueryContext(ctx, queryString, userID)
+	rows, err := o.Handle().QueryContext(ctx, queryString, userID)
 	if err != nil {
 		return []*types.Org{}, err
 	}
@@ -179,7 +179,7 @@ func (*orgStore) listSQL(opt OrgsListOptions) *sqlf.Query {
 }
 
 func (o *orgStore) getBySQL(ctx context.Context, query string, args ...any) ([]*types.Org, error) {
-	rows, err := o.Handle().DBUtilDB().QueryContext(ctx, "SELECT id, name, display_name, created_at, updated_at FROM orgs "+query, args...)
+	rows, err := o.Handle().QueryContext(ctx, "SELECT id, name, display_name, created_at, updated_at FROM orgs "+query, args...)
 	if err != nil {
 		return nil, err
 	}
@@ -216,7 +216,7 @@ func (o *orgStore) Create(ctx context.Context, name string, displayName *string)
 	}
 	newOrg.CreatedAt = time.Now()
 	newOrg.UpdatedAt = newOrg.CreatedAt
-	err = tx.Handle().DBUtilDB().QueryRowContext(
+	err = tx.Handle().QueryRowContext(
 		ctx,
 		"INSERT INTO orgs(name, display_name, created_at, updated_at) VALUES($1, $2, $3, $4) RETURNING id",
 		newOrg.Name, newOrg.DisplayName, newOrg.CreatedAt, newOrg.UpdatedAt).Scan(&newOrg.ID)
@@ -237,7 +237,7 @@ func (o *orgStore) Create(ctx context.Context, name string, displayName *string)
 	}
 
 	// Reserve organization name in shared users+orgs namespace.
-	if _, err := tx.Handle().DBUtilDB().ExecContext(ctx, "INSERT INTO names(name, org_id) VALUES($1, $2)", newOrg.Name, newOrg.ID); err != nil {
+	if _, err := tx.Handle().ExecContext(ctx, "INSERT INTO names(name, org_id) VALUES($1, $2)", newOrg.Name, newOrg.ID); err != nil {
 		return nil, errOrgNameAlreadyExists
 	}
 
@@ -256,12 +256,12 @@ func (o *orgStore) Update(ctx context.Context, id int32, displayName *string) (*
 
 	if displayName != nil {
 		org.DisplayName = displayName
-		if _, err := o.Handle().DBUtilDB().ExecContext(ctx, "UPDATE orgs SET display_name=$1 WHERE id=$2 AND deleted_at IS NULL", org.DisplayName, id); err != nil {
+		if _, err := o.Handle().ExecContext(ctx, "UPDATE orgs SET display_name=$1 WHERE id=$2 AND deleted_at IS NULL", org.DisplayName, id); err != nil {
 			return nil, err
 		}
 	}
 	org.UpdatedAt = time.Now()
-	if _, err := o.Handle().DBUtilDB().ExecContext(ctx, "UPDATE orgs SET updated_at=$1 WHERE id=$2 AND deleted_at IS NULL", org.UpdatedAt, id); err != nil {
+	if _, err := o.Handle().ExecContext(ctx, "UPDATE orgs SET updated_at=$1 WHERE id=$2 AND deleted_at IS NULL", org.UpdatedAt, id); err != nil {
 		return nil, err
 	}
 
@@ -278,7 +278,7 @@ func (o *orgStore) Delete(ctx context.Context, id int32) (err error) {
 		err = tx.Done(err)
 	}()
 
-	res, err := tx.Handle().DBUtilDB().ExecContext(ctx, "UPDATE orgs SET deleted_at=now() WHERE id=$1 AND deleted_at IS NULL", id)
+	res, err := tx.Handle().ExecContext(ctx, "UPDATE orgs SET deleted_at=now() WHERE id=$1 AND deleted_at IS NULL", id)
 	if err != nil {
 		return err
 	}
@@ -291,14 +291,14 @@ func (o *orgStore) Delete(ctx context.Context, id int32) (err error) {
 	}
 
 	// Release the organization name so it can be used by another user or org.
-	if _, err := tx.Handle().DBUtilDB().ExecContext(ctx, "DELETE FROM names WHERE org_id=$1", id); err != nil {
+	if _, err := tx.Handle().ExecContext(ctx, "DELETE FROM names WHERE org_id=$1", id); err != nil {
 		return err
 	}
 
-	if _, err := tx.Handle().DBUtilDB().ExecContext(ctx, "UPDATE org_invitations SET deleted_at=now() WHERE deleted_at IS NULL AND org_id=$1", id); err != nil {
+	if _, err := tx.Handle().ExecContext(ctx, "UPDATE org_invitations SET deleted_at=now() WHERE deleted_at IS NULL AND org_id=$1", id); err != nil {
 		return err
 	}
-	if _, err := tx.Handle().DBUtilDB().ExecContext(ctx, "UPDATE registry_extensions SET deleted_at=now() WHERE deleted_at IS NULL AND publisher_org_id=$1", id); err != nil {
+	if _, err := tx.Handle().ExecContext(ctx, "UPDATE registry_extensions SET deleted_at=now() WHERE deleted_at IS NULL AND publisher_org_id=$1", id); err != nil {
 		return err
 	}
 
@@ -342,7 +342,7 @@ func (o *orgStore) HardDelete(ctx context.Context, id int32) (err error) {
 	for _, t := range tables {
 		query := sqlf.Sprintf(fmt.Sprintf("DELETE FROM %s WHERE %s=%d", t, tablesAndKeys[t], id))
 
-		_, err := tx.Handle().DBUtilDB().ExecContext(ctx, query.Query(sqlf.PostgresBindVar), query.Args()...)
+		_, err := tx.Handle().ExecContext(ctx, query.Query(sqlf.PostgresBindVar), query.Args()...)
 		if err != nil {
 			return err
 		}
@@ -354,13 +354,13 @@ func (o *orgStore) HardDelete(ctx context.Context, id int32) (err error) {
 func (o *orgStore) AddOrgsOpenBetaStats(ctx context.Context, userID int32, data string) (id string, err error) {
 	query := sqlf.Sprintf("INSERT INTO orgs_open_beta_stats(user_id, data) VALUES(%d, %s) RETURNING id;", userID, data)
 
-	err = o.Handle().DBUtilDB().QueryRowContext(ctx, query.Query(sqlf.PostgresBindVar), query.Args()...).Scan(&id)
+	err = o.Handle().QueryRowContext(ctx, query.Query(sqlf.PostgresBindVar), query.Args()...).Scan(&id)
 	return id, err
 }
 
 func (o *orgStore) UpdateOrgsOpenBetaStats(ctx context.Context, id string, orgID int32) error {
 	query := sqlf.Sprintf("UPDATE orgs_open_beta_stats SET org_id=%d WHERE id=%s;", orgID, id)
 
-	_, err := o.Handle().DBUtilDB().ExecContext(ctx, query.Query(sqlf.PostgresBindVar), query.Args()...)
+	_, err := o.Handle().ExecContext(ctx, query.Query(sqlf.PostgresBindVar), query.Args()...)
 	return err
 }

--- a/internal/database/phabricator.go
+++ b/internal/database/phabricator.go
@@ -59,7 +59,7 @@ func (p *phabricatorStore) Create(ctx context.Context, callsign string, name api
 		Name:     name,
 		URL:      phabURL,
 	}
-	err := p.Handle().DBUtilDB().QueryRowContext(
+	err := p.Handle().QueryRowContext(
 		ctx,
 		"INSERT INTO phabricator_repos(callsign, repo_name, url) VALUES($1, $2, $3) RETURNING id",
 		r.Callsign, r.Name, r.URL).Scan(&r.ID)
@@ -75,7 +75,7 @@ func (p *phabricatorStore) CreateOrUpdate(ctx context.Context, callsign string, 
 		Name:     name,
 		URL:      phabURL,
 	}
-	err := p.Handle().DBUtilDB().QueryRowContext(
+	err := p.Handle().QueryRowContext(
 		ctx,
 		"UPDATE phabricator_repos SET callsign=$1, url=$2, updated_at=now() WHERE repo_name=$3 RETURNING id",
 		r.Callsign, r.URL, r.Name).Scan(&r.ID)
@@ -100,7 +100,7 @@ func (p *phabricatorStore) CreateIfNotExists(ctx context.Context, callsign strin
 }
 
 func (p *phabricatorStore) getBySQL(ctx context.Context, query string, args ...any) ([]*types.PhabricatorRepo, error) {
-	rows, err := p.Handle().DBUtilDB().QueryContext(ctx, "SELECT id, callsign, repo_name, url FROM phabricator_repos "+query, args...)
+	rows, err := p.Handle().QueryContext(ctx, "SELECT id, callsign, repo_name, url FROM phabricator_repos "+query, args...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/database/phabricator.go
+++ b/internal/database/phabricator.go
@@ -59,7 +59,7 @@ func (p *phabricatorStore) Create(ctx context.Context, callsign string, name api
 		Name:     name,
 		URL:      phabURL,
 	}
-	err := p.Handle().DB().QueryRowContext(
+	err := p.Handle().DBUtilDB().QueryRowContext(
 		ctx,
 		"INSERT INTO phabricator_repos(callsign, repo_name, url) VALUES($1, $2, $3) RETURNING id",
 		r.Callsign, r.Name, r.URL).Scan(&r.ID)
@@ -75,7 +75,7 @@ func (p *phabricatorStore) CreateOrUpdate(ctx context.Context, callsign string, 
 		Name:     name,
 		URL:      phabURL,
 	}
-	err := p.Handle().DB().QueryRowContext(
+	err := p.Handle().DBUtilDB().QueryRowContext(
 		ctx,
 		"UPDATE phabricator_repos SET callsign=$1, url=$2, updated_at=now() WHERE repo_name=$3 RETURNING id",
 		r.Callsign, r.URL, r.Name).Scan(&r.ID)
@@ -100,7 +100,7 @@ func (p *phabricatorStore) CreateIfNotExists(ctx context.Context, callsign strin
 }
 
 func (p *phabricatorStore) getBySQL(ctx context.Context, query string, args ...any) ([]*types.PhabricatorRepo, error) {
-	rows, err := p.Handle().DB().QueryContext(ctx, "SELECT id, callsign, repo_name, url FROM phabricator_repos "+query, args...)
+	rows, err := p.Handle().DBUtilDB().QueryContext(ctx, "SELECT id, callsign, repo_name, url FROM phabricator_repos "+query, args...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/database/repos_db_test.go
+++ b/internal/database/repos_db_test.go
@@ -194,7 +194,7 @@ func upsertRepo(ctx context.Context, db DB, op InsertRepoOp) error {
 		return nil
 	}
 
-	_, err = s.Handle().DBUtilDB().ExecContext(
+	_, err = s.Handle().ExecContext(
 		ctx,
 		upsertSQL,
 		op.Name,
@@ -730,7 +730,7 @@ func TestRepos_List_LastChanged(t *testing.T) {
 	})
 
 	// Our test helpers don't do updated_at, so manually doing it.
-	_, err := db.Handle().DBUtilDB().ExecContext(ctx, "update repo set updated_at = $1", now.Add(-24*time.Hour))
+	_, err := db.Handle().ExecContext(ctx, "update repo set updated_at = $1", now.Add(-24*time.Hour))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -740,7 +740,7 @@ func TestRepos_List_LastChanged(t *testing.T) {
 		CloneStatus: types.CloneStatusCloned,
 		LastChanged: now.Add(-24 * time.Hour),
 	})
-	_, err = db.Handle().DBUtilDB().ExecContext(ctx, "update repo set updated_at = $1 where name = 'newMeta'", now)
+	_, err = db.Handle().ExecContext(ctx, "update repo set updated_at = $1 where name = 'newMeta'", now)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -770,7 +770,7 @@ func TestRepos_List_LastChanged(t *testing.T) {
 			}
 		}
 		mkSearchContext("old", ReposListOptions{})
-		_, err = db.Handle().DBUtilDB().ExecContext(ctx, "update search_contexts set updated_at = $1", now.Add(-24*time.Hour))
+		_, err = db.Handle().ExecContext(ctx, "update search_contexts set updated_at = $1", now.Add(-24*time.Hour))
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/database/repos_db_test.go
+++ b/internal/database/repos_db_test.go
@@ -194,7 +194,7 @@ func upsertRepo(ctx context.Context, db DB, op InsertRepoOp) error {
 		return nil
 	}
 
-	_, err = s.Handle().DB().ExecContext(
+	_, err = s.Handle().DBUtilDB().ExecContext(
 		ctx,
 		upsertSQL,
 		op.Name,
@@ -730,7 +730,7 @@ func TestRepos_List_LastChanged(t *testing.T) {
 	})
 
 	// Our test helpers don't do updated_at, so manually doing it.
-	_, err := db.Handle().DB().ExecContext(ctx, "update repo set updated_at = $1", now.Add(-24*time.Hour))
+	_, err := db.Handle().DBUtilDB().ExecContext(ctx, "update repo set updated_at = $1", now.Add(-24*time.Hour))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -740,7 +740,7 @@ func TestRepos_List_LastChanged(t *testing.T) {
 		CloneStatus: types.CloneStatusCloned,
 		LastChanged: now.Add(-24 * time.Hour),
 	})
-	_, err = db.Handle().DB().ExecContext(ctx, "update repo set updated_at = $1 where name = 'newMeta'", now)
+	_, err = db.Handle().DBUtilDB().ExecContext(ctx, "update repo set updated_at = $1 where name = 'newMeta'", now)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -770,7 +770,7 @@ func TestRepos_List_LastChanged(t *testing.T) {
 			}
 		}
 		mkSearchContext("old", ReposListOptions{})
-		_, err = db.Handle().DB().ExecContext(ctx, "update search_contexts set updated_at = $1", now.Add(-24*time.Hour))
+		_, err = db.Handle().DBUtilDB().ExecContext(ctx, "update search_contexts set updated_at = $1", now.Add(-24*time.Hour))
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/database/saved_searches.go
+++ b/internal/database/saved_searches.go
@@ -51,7 +51,7 @@ func (s *savedSearchStore) Transact(ctx context.Context) (SavedSearchStore, erro
 func (s *savedSearchStore) IsEmpty(ctx context.Context) (bool, error) {
 	q := `SELECT true FROM saved_searches LIMIT 1`
 	var isNotEmpty bool
-	err := s.Handle().DB().QueryRowContext(ctx, q).Scan(&isNotEmpty)
+	err := s.Handle().DBUtilDB().QueryRowContext(ctx, q).Scan(&isNotEmpty)
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return true, nil
@@ -121,7 +121,7 @@ func (s *savedSearchStore) ListAll(ctx context.Context) (savedSearches []api.Sav
 // only makes it to users with proper permissions to access the saved search.
 func (s *savedSearchStore) GetByID(ctx context.Context, id int32) (*api.SavedQuerySpecAndConfig, error) {
 	var sq api.SavedQuerySpecAndConfig
-	err := s.Handle().DB().QueryRowContext(ctx, `SELECT
+	err := s.Handle().DBUtilDB().QueryRowContext(ctx, `SELECT
 		id,
 		description,
 		query,
@@ -265,7 +265,7 @@ func (s *savedSearchStore) Create(ctx context.Context, newSavedSearch *types.Sav
 		OrgID:       newSavedSearch.OrgID,
 	}
 
-	err = s.Handle().DB().QueryRowContext(ctx, `INSERT INTO saved_searches(
+	err = s.Handle().DBUtilDB().QueryRowContext(ctx, `INSERT INTO saved_searches(
 			description,
 			query,
 			notify_owner,
@@ -337,6 +337,6 @@ func (s *savedSearchStore) Delete(ctx context.Context, id int32) (err error) {
 		tr.SetError(err)
 		tr.Finish()
 	}()
-	_, err = s.Handle().DB().ExecContext(ctx, `DELETE FROM saved_searches WHERE ID=$1`, id)
+	_, err = s.Handle().DBUtilDB().ExecContext(ctx, `DELETE FROM saved_searches WHERE ID=$1`, id)
 	return err
 }

--- a/internal/database/saved_searches.go
+++ b/internal/database/saved_searches.go
@@ -51,7 +51,7 @@ func (s *savedSearchStore) Transact(ctx context.Context) (SavedSearchStore, erro
 func (s *savedSearchStore) IsEmpty(ctx context.Context) (bool, error) {
 	q := `SELECT true FROM saved_searches LIMIT 1`
 	var isNotEmpty bool
-	err := s.Handle().DBUtilDB().QueryRowContext(ctx, q).Scan(&isNotEmpty)
+	err := s.Handle().QueryRowContext(ctx, q).Scan(&isNotEmpty)
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return true, nil
@@ -121,7 +121,7 @@ func (s *savedSearchStore) ListAll(ctx context.Context) (savedSearches []api.Sav
 // only makes it to users with proper permissions to access the saved search.
 func (s *savedSearchStore) GetByID(ctx context.Context, id int32) (*api.SavedQuerySpecAndConfig, error) {
 	var sq api.SavedQuerySpecAndConfig
-	err := s.Handle().DBUtilDB().QueryRowContext(ctx, `SELECT
+	err := s.Handle().QueryRowContext(ctx, `SELECT
 		id,
 		description,
 		query,
@@ -265,7 +265,7 @@ func (s *savedSearchStore) Create(ctx context.Context, newSavedSearch *types.Sav
 		OrgID:       newSavedSearch.OrgID,
 	}
 
-	err = s.Handle().DBUtilDB().QueryRowContext(ctx, `INSERT INTO saved_searches(
+	err = s.Handle().QueryRowContext(ctx, `INSERT INTO saved_searches(
 			description,
 			query,
 			notify_owner,
@@ -337,6 +337,6 @@ func (s *savedSearchStore) Delete(ctx context.Context, id int32) (err error) {
 		tr.SetError(err)
 		tr.Finish()
 	}()
-	_, err = s.Handle().DBUtilDB().ExecContext(ctx, `DELETE FROM saved_searches WHERE ID=$1`, id)
+	_, err = s.Handle().ExecContext(ctx, `DELETE FROM saved_searches WHERE ID=$1`, id)
 	return err
 }

--- a/internal/database/search_contexts.go
+++ b/internal/database/search_contexts.go
@@ -403,7 +403,7 @@ func createSearchContext(ctx context.Context, s SearchContextsStore, searchConte
 		nullInt32Column(searchContext.NamespaceOrgID),
 		nullStringColumn(searchContext.Query),
 	)
-	_, err := s.Handle().DBUtilDB().ExecContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...)
+	_, err := s.Handle().ExecContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...)
 	if err != nil {
 		return nil, err
 	}
@@ -423,7 +423,7 @@ func updateSearchContext(ctx context.Context, s SearchContextsStore, searchConte
 		nullStringColumn(searchContext.Query),
 		searchContext.ID,
 	)
-	_, err := s.Handle().DBUtilDB().ExecContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...)
+	_, err := s.Handle().ExecContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/database/search_contexts.go
+++ b/internal/database/search_contexts.go
@@ -403,7 +403,7 @@ func createSearchContext(ctx context.Context, s SearchContextsStore, searchConte
 		nullInt32Column(searchContext.NamespaceOrgID),
 		nullStringColumn(searchContext.Query),
 	)
-	_, err := s.Handle().DB().ExecContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...)
+	_, err := s.Handle().DBUtilDB().ExecContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...)
 	if err != nil {
 		return nil, err
 	}
@@ -423,7 +423,7 @@ func updateSearchContext(ctx context.Context, s SearchContextsStore, searchConte
 		nullStringColumn(searchContext.Query),
 		searchContext.ID,
 	)
-	_, err := s.Handle().DB().ExecContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...)
+	_, err := s.Handle().DBUtilDB().ExecContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/database/security_event_logs.go
+++ b/internal/database/security_event_logs.go
@@ -81,7 +81,7 @@ func (s *securityEventLogsStore) Insert(ctx context.Context, e *SecurityEvent) e
 		argument = []byte(`{}`)
 	}
 
-	_, err := s.Handle().DBUtilDB().ExecContext(
+	_, err := s.Handle().ExecContext(
 		ctx,
 		"INSERT INTO security_event_logs(name, url, user_id, anonymous_user_id, source, argument, version, timestamp) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)",
 		e.Name,

--- a/internal/database/security_event_logs.go
+++ b/internal/database/security_event_logs.go
@@ -81,7 +81,7 @@ func (s *securityEventLogsStore) Insert(ctx context.Context, e *SecurityEvent) e
 		argument = []byte(`{}`)
 	}
 
-	_, err := s.Handle().DB().ExecContext(
+	_, err := s.Handle().DBUtilDB().ExecContext(
 		ctx,
 		"INSERT INTO security_event_logs(name, url, user_id, anonymous_user_id, source, argument, version, timestamp) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)",
 		e.Name,

--- a/internal/database/settings.go
+++ b/internal/database/settings.go
@@ -86,7 +86,7 @@ func (o *settingsStore) CreateIfUpToDate(ctx context.Context, subject api.Settin
 
 	creatorIsUpToDate := latestSetting != nil && lastID != nil && latestSetting.ID == *lastID
 	if latestSetting == nil || creatorIsUpToDate {
-		err := tx.Handle().DBUtilDB().QueryRowContext(
+		err := tx.Handle().QueryRowContext(
 			ctx,
 			"INSERT INTO settings(org_id, user_id, author_user_id, contents) VALUES($1, $2, $3, $4) RETURNING id, created_at",
 			s.Subject.Org, s.Subject.User, s.AuthorUserID, s.Contents).Scan(&s.ID, &s.CreatedAt)

--- a/internal/database/settings.go
+++ b/internal/database/settings.go
@@ -86,7 +86,7 @@ func (o *settingsStore) CreateIfUpToDate(ctx context.Context, subject api.Settin
 
 	creatorIsUpToDate := latestSetting != nil && lastID != nil && latestSetting.ID == *lastID
 	if latestSetting == nil || creatorIsUpToDate {
-		err := tx.Handle().DB().QueryRowContext(
+		err := tx.Handle().DBUtilDB().QueryRowContext(
 			ctx,
 			"INSERT INTO settings(org_id, user_id, author_user_id, contents) VALUES($1, $2, $3, $4) RETURNING id, created_at",
 			s.Subject.Org, s.Subject.User, s.AuthorUserID, s.Contents).Scan(&s.ID, &s.CreatedAt)

--- a/internal/database/survey_responses.go
+++ b/internal/database/survey_responses.go
@@ -42,7 +42,7 @@ func (s *SurveyResponseStore) Transact(ctx context.Context) (*SurveyResponseStor
 
 // Create creates a survey response.
 func (s *SurveyResponseStore) Create(ctx context.Context, userID *int32, email *string, score int, reason *string, better *string) (id int64, err error) {
-	err = s.Handle().DB().QueryRowContext(ctx,
+	err = s.Handle().DBUtilDB().QueryRowContext(ctx,
 		"INSERT INTO survey_responses(user_id, email, score, reason, better) VALUES($1, $2, $3, $4, $5) RETURNING id",
 		userID, email, score, reason, better,
 	).Scan(&id)
@@ -50,7 +50,7 @@ func (s *SurveyResponseStore) Create(ctx context.Context, userID *int32, email *
 }
 
 func (s *SurveyResponseStore) getBySQL(ctx context.Context, query string, args ...any) ([]*types.SurveyResponse, error) {
-	rows, err := s.Handle().DB().QueryContext(ctx, "SELECT id, user_id, email, score, reason, better, created_at FROM survey_responses "+query, args...)
+	rows, err := s.Handle().DBUtilDB().QueryContext(ctx, "SELECT id, user_id, email, score, reason, better, created_at FROM survey_responses "+query, args...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/database/survey_responses.go
+++ b/internal/database/survey_responses.go
@@ -42,7 +42,7 @@ func (s *SurveyResponseStore) Transact(ctx context.Context) (*SurveyResponseStor
 
 // Create creates a survey response.
 func (s *SurveyResponseStore) Create(ctx context.Context, userID *int32, email *string, score int, reason *string, better *string) (id int64, err error) {
-	err = s.Handle().DBUtilDB().QueryRowContext(ctx,
+	err = s.Handle().QueryRowContext(ctx,
 		"INSERT INTO survey_responses(user_id, email, score, reason, better) VALUES($1, $2, $3, $4, $5) RETURNING id",
 		userID, email, score, reason, better,
 	).Scan(&id)
@@ -50,7 +50,7 @@ func (s *SurveyResponseStore) Create(ctx context.Context, userID *int32, email *
 }
 
 func (s *SurveyResponseStore) getBySQL(ctx context.Context, query string, args ...any) ([]*types.SurveyResponse, error) {
-	rows, err := s.Handle().DBUtilDB().QueryContext(ctx, "SELECT id, user_id, email, score, reason, better, created_at FROM survey_responses "+query, args...)
+	rows, err := s.Handle().QueryContext(ctx, "SELECT id, user_id, email, score, reason, better, created_at FROM survey_responses "+query, args...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/database/user_emails.go
+++ b/internal/database/user_emails.go
@@ -91,7 +91,7 @@ func (s *userEmailsStore) GetInitialSiteAdminInfo(ctx context.Context) (email st
 	if init, err := GlobalStateWith(s).SiteInitialized(ctx); err != nil || !init {
 		return "", false, err
 	}
-	if err := s.Handle().DB().QueryRowContext(ctx, "SELECT email, tos_accepted FROM user_emails JOIN users ON user_emails.user_id=users.id WHERE users.site_admin AND users.deleted_at IS NULL ORDER BY users.id ASC LIMIT 1").Scan(&email, &tosAccepted); err != nil {
+	if err := s.Handle().DBUtilDB().QueryRowContext(ctx, "SELECT email, tos_accepted FROM user_emails JOIN users ON user_emails.user_id=users.id WHERE users.site_admin AND users.deleted_at IS NULL ORDER BY users.id ASC LIMIT 1").Scan(&email, &tosAccepted); err != nil {
 		return "", false, errors.New("initial site admin email not found")
 	}
 	return email, tosAccepted, nil
@@ -100,7 +100,7 @@ func (s *userEmailsStore) GetInitialSiteAdminInfo(ctx context.Context) (email st
 // GetPrimaryEmail gets the oldest email associated with the user, preferring a verified email to an
 // unverified email.
 func (s *userEmailsStore) GetPrimaryEmail(ctx context.Context, id int32) (email string, verified bool, err error) {
-	if err := s.Handle().DB().QueryRowContext(ctx, "SELECT email, verified_at IS NOT NULL AS verified FROM user_emails WHERE user_id=$1 AND is_primary",
+	if err := s.Handle().DBUtilDB().QueryRowContext(ctx, "SELECT email, verified_at IS NOT NULL AS verified FROM user_emails WHERE user_id=$1 AND is_primary",
 		id,
 	).Scan(&email, &verified); err != nil {
 		return "", false, userEmailNotFoundError{[]any{fmt.Sprintf("id %d", id)}}
@@ -120,7 +120,7 @@ func (s *userEmailsStore) SetPrimaryEmail(ctx context.Context, userID int32, ema
 
 	// Get the email. It needs to exist and be verified.
 	var verified bool
-	if err := tx.Handle().DB().QueryRowContext(ctx, "SELECT verified_at IS NOT NULL AS verified FROM user_emails WHERE user_id=$1 AND email=$2",
+	if err := tx.Handle().DBUtilDB().QueryRowContext(ctx, "SELECT verified_at IS NOT NULL AS verified FROM user_emails WHERE user_id=$1 AND email=$2",
 		userID, email,
 	).Scan(&verified); err != nil {
 		return err
@@ -133,12 +133,12 @@ func (s *userEmailsStore) SetPrimaryEmail(ctx context.Context, userID int32, ema
 	// so that we don't violate our index.
 
 	// Set all as not primary
-	if _, err := tx.Handle().DB().ExecContext(ctx, "UPDATE user_emails SET is_primary = false WHERE user_id=$1", userID); err != nil {
+	if _, err := tx.Handle().DBUtilDB().ExecContext(ctx, "UPDATE user_emails SET is_primary = false WHERE user_id=$1", userID); err != nil {
 		return err
 	}
 
 	// Set selected as primary
-	if _, err := tx.Handle().DB().ExecContext(ctx, "UPDATE user_emails SET is_primary = true WHERE user_id=$1 AND email=$2", userID, email); err != nil {
+	if _, err := tx.Handle().DBUtilDB().ExecContext(ctx, "UPDATE user_emails SET is_primary = true WHERE user_id=$1 AND email=$2", userID, email); err != nil {
 		return err
 	}
 
@@ -147,7 +147,7 @@ func (s *userEmailsStore) SetPrimaryEmail(ctx context.Context, userID int32, ema
 
 // Get gets information about the user's associated email address.
 func (s *userEmailsStore) Get(ctx context.Context, userID int32, email string) (emailCanonicalCase string, verified bool, err error) {
-	if err := s.Handle().DB().QueryRowContext(ctx, "SELECT email, verified_at IS NOT NULL AS verified FROM user_emails WHERE user_id=$1 AND email=$2",
+	if err := s.Handle().DBUtilDB().QueryRowContext(ctx, "SELECT email, verified_at IS NOT NULL AS verified FROM user_emails WHERE user_id=$1 AND email=$2",
 		userID, email,
 	).Scan(&emailCanonicalCase, &verified); err != nil {
 		return "", false, userEmailNotFoundError{[]any{fmt.Sprintf("userID %d email %q", userID, email)}}
@@ -157,7 +157,7 @@ func (s *userEmailsStore) Get(ctx context.Context, userID int32, email string) (
 
 // Add adds new user email. When added, it is always unverified.
 func (s *userEmailsStore) Add(ctx context.Context, userID int32, email string, verificationCode *string) error {
-	_, err := s.Handle().DB().ExecContext(ctx, "INSERT INTO user_emails(user_id, email, verification_code) VALUES($1, $2, $3)", userID, email, verificationCode)
+	_, err := s.Handle().DBUtilDB().ExecContext(ctx, "INSERT INTO user_emails(user_id, email, verification_code) VALUES($1, $2, $3)", userID, email, verificationCode)
 	return err
 }
 
@@ -172,7 +172,7 @@ func (s *userEmailsStore) Remove(ctx context.Context, userID int32, email string
 
 	// Get the email. It needs to exist and be verified.
 	var isPrimary bool
-	if err := tx.Handle().DB().QueryRowContext(ctx, "SELECT is_primary FROM user_emails WHERE user_id=$1 AND email=$2",
+	if err := tx.Handle().DBUtilDB().QueryRowContext(ctx, "SELECT is_primary FROM user_emails WHERE user_id=$1 AND email=$2",
 		userID, email,
 	).Scan(&isPrimary); err != nil {
 		return errors.Errorf("fetching email address: %w", err)
@@ -181,7 +181,7 @@ func (s *userEmailsStore) Remove(ctx context.Context, userID int32, email string
 		return errors.New("can't delete primary email address")
 	}
 
-	_, err = tx.Handle().DB().ExecContext(ctx, "DELETE FROM user_emails WHERE user_id=$1 AND email=$2", userID, email)
+	_, err = tx.Handle().DBUtilDB().ExecContext(ctx, "DELETE FROM user_emails WHERE user_id=$1 AND email=$2", userID, email)
 	if err != nil {
 		return err
 	}
@@ -193,7 +193,7 @@ func (s *userEmailsStore) Remove(ctx context.Context, userID int32, email string
 // returns false.
 func (s *userEmailsStore) Verify(ctx context.Context, userID int32, email, code string) (bool, error) {
 	var dbCode sql.NullString
-	if err := s.Handle().DB().QueryRowContext(ctx, "SELECT verification_code FROM user_emails WHERE user_id=$1 AND email=$2", userID, email).Scan(&dbCode); err != nil {
+	if err := s.Handle().DBUtilDB().QueryRowContext(ctx, "SELECT verification_code FROM user_emails WHERE user_id=$1 AND email=$2", userID, email).Scan(&dbCode); err != nil {
 		return false, err
 	}
 	if !dbCode.Valid {
@@ -203,7 +203,7 @@ func (s *userEmailsStore) Verify(ctx context.Context, userID int32, email, code 
 	if len(dbCode.String) != len(code) || subtle.ConstantTimeCompare([]byte(dbCode.String), []byte(code)) != 1 {
 		return false, nil
 	}
-	if _, err := s.Handle().DB().ExecContext(ctx, "UPDATE user_emails SET verification_code=null, verified_at=now() WHERE user_id=$1 AND email=$2", userID, email); err != nil {
+	if _, err := s.Handle().DBUtilDB().ExecContext(ctx, "UPDATE user_emails SET verification_code=null, verified_at=now() WHERE user_id=$1 AND email=$2", userID, email); err != nil {
 		return false, err
 	}
 
@@ -217,10 +217,10 @@ func (s *userEmailsStore) SetVerified(ctx context.Context, userID int32, email s
 	var err error
 	if verified {
 		// Mark as verified.
-		res, err = s.Handle().DB().ExecContext(ctx, "UPDATE user_emails SET verification_code=null, verified_at=now() WHERE user_id=$1 AND email=$2", userID, email)
+		res, err = s.Handle().DBUtilDB().ExecContext(ctx, "UPDATE user_emails SET verification_code=null, verified_at=now() WHERE user_id=$1 AND email=$2", userID, email)
 	} else {
 		// Mark as unverified.
-		res, err = s.Handle().DB().ExecContext(ctx, "UPDATE user_emails SET verification_code=null, verified_at=null WHERE user_id=$1 AND email=$2", userID, email)
+		res, err = s.Handle().DBUtilDB().ExecContext(ctx, "UPDATE user_emails SET verification_code=null, verified_at=null WHERE user_id=$1 AND email=$2", userID, email)
 	}
 	if err != nil {
 		return err
@@ -237,7 +237,7 @@ func (s *userEmailsStore) SetVerified(ctx context.Context, userID int32, email s
 
 // SetLastVerification sets the "last_verification_sent_at" column to now() and updates the verification code for given email of the user.
 func (s *userEmailsStore) SetLastVerification(ctx context.Context, userID int32, email, code string) error {
-	res, err := s.Handle().DB().ExecContext(ctx, "UPDATE user_emails SET last_verification_sent_at=now(), verification_code = $3 WHERE user_id=$1 AND email=$2", userID, email, code)
+	res, err := s.Handle().DBUtilDB().ExecContext(ctx, "UPDATE user_emails SET last_verification_sent_at=now(), verification_code = $3 WHERE user_id=$1 AND email=$2", userID, email, code)
 	if err != nil {
 		return err
 	}
@@ -306,7 +306,7 @@ func (s *userEmailsStore) ListByUser(ctx context.Context, opt UserEmailsListOpti
 
 // getBySQL returns user emails matching the SQL query, if any exist.
 func (s *userEmailsStore) getBySQL(ctx context.Context, query string, args ...any) ([]*UserEmail, error) {
-	rows, err := s.Handle().DB().QueryContext(ctx,
+	rows, err := s.Handle().DBUtilDB().QueryContext(ctx,
 		`SELECT user_emails.user_id, user_emails.email, user_emails.created_at, user_emails.verification_code,
 				user_emails.verified_at, user_emails.last_verification_sent_at, user_emails.is_primary FROM user_emails `+query, args...)
 	if err != nil {

--- a/internal/repos/status_messages_test.go
+++ b/internal/repos/status_messages_test.go
@@ -276,7 +276,7 @@ func TestStatusMessages(t *testing.T) {
 			}
 			t.Cleanup(func() {
 				q := sqlf.Sprintf(`DELETE FROM gitserver_repos`)
-				_, err = store.Handle().DB().ExecContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...)
+				_, err = store.Handle().DBUtilDB().ExecContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...)
 				require.NoError(t, err)
 			})
 
@@ -291,12 +291,12 @@ func TestStatusMessages(t *testing.T) {
 						INSERT INTO external_service_repos(external_service_id, repo_id, user_id, clone_url)
 						VALUES (%s, %s, NULLIF(%s, 0), 'example.com')
 					`, svc.ID, repo.ID, svc.NamespaceUserID)
-					_, err = store.Handle().DB().ExecContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...)
+					_, err = store.Handle().DBUtilDB().ExecContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...)
 					require.NoError(t, err)
 
 					t.Cleanup(func() {
 						q := sqlf.Sprintf(`DELETE FROM external_service_repos WHERE external_service_id = %s`, svc.ID)
-						_, err = store.Handle().DB().ExecContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...)
+						_, err = store.Handle().DBUtilDB().ExecContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...)
 						require.NoError(t, err)
 					})
 				}

--- a/internal/repos/status_messages_test.go
+++ b/internal/repos/status_messages_test.go
@@ -276,7 +276,7 @@ func TestStatusMessages(t *testing.T) {
 			}
 			t.Cleanup(func() {
 				q := sqlf.Sprintf(`DELETE FROM gitserver_repos`)
-				_, err = store.Handle().DBUtilDB().ExecContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...)
+				_, err = store.Handle().ExecContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...)
 				require.NoError(t, err)
 			})
 
@@ -291,12 +291,12 @@ func TestStatusMessages(t *testing.T) {
 						INSERT INTO external_service_repos(external_service_id, repo_id, user_id, clone_url)
 						VALUES (%s, %s, NULLIF(%s, 0), 'example.com')
 					`, svc.ID, repo.ID, svc.NamespaceUserID)
-					_, err = store.Handle().DBUtilDB().ExecContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...)
+					_, err = store.Handle().ExecContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...)
 					require.NoError(t, err)
 
 					t.Cleanup(func() {
 						q := sqlf.Sprintf(`DELETE FROM external_service_repos WHERE external_service_id = %s`, svc.ID)
-						_, err = store.Handle().DBUtilDB().ExecContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...)
+						_, err = store.Handle().ExecContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...)
 						require.NoError(t, err)
 					})
 				}

--- a/internal/repos/store_test.go
+++ b/internal/repos/store_test.go
@@ -146,7 +146,7 @@ func testStoreEnqueueSyncJobs(store repos.Store) func(*testing.T) {
 			t.Run(tc.name, func(t *testing.T) {
 				t.Cleanup(func() {
 					q := sqlf.Sprintf("DELETE FROM external_service_sync_jobs;DELETE FROM external_services")
-					if _, err := store.Handle().DBUtilDB().ExecContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...); err != nil {
+					if _, err := store.Handle().ExecContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...); err != nil {
 						t.Fatal(err)
 					}
 				})
@@ -195,7 +195,7 @@ func testStoreEnqueueSingleSyncJob(store repos.Store) func(*testing.T) {
 		ctx := context.Background()
 		t.Cleanup(func() {
 			q := sqlf.Sprintf("DELETE FROM external_service_sync_jobs;DELETE FROM external_services")
-			if _, err := store.Handle().DBUtilDB().ExecContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...); err != nil {
+			if _, err := store.Handle().ExecContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...); err != nil {
 				t.Fatal(err)
 			}
 		})
@@ -220,7 +220,7 @@ func testStoreEnqueueSingleSyncJob(store repos.Store) func(*testing.T) {
 			t.Helper()
 			var count int
 			q := sqlf.Sprintf("SELECT COUNT(*) FROM external_service_sync_jobs")
-			if err := store.Handle().DBUtilDB().QueryRowContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...).Scan(&count); err != nil {
+			if err := store.Handle().QueryRowContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...).Scan(&count); err != nil {
 				t.Fatal(err)
 			}
 			if count != want {
@@ -244,7 +244,7 @@ func testStoreEnqueueSingleSyncJob(store repos.Store) func(*testing.T) {
 
 		// If we change status to processing it should not add a new row
 		q := sqlf.Sprintf("UPDATE external_service_sync_jobs SET state='processing'")
-		if _, err := store.Handle().DBUtilDB().ExecContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...); err != nil {
+		if _, err := store.Handle().ExecContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...); err != nil {
 			t.Fatal(err)
 		}
 		err = store.EnqueueSingleSyncJob(ctx, service.ID)
@@ -255,7 +255,7 @@ func testStoreEnqueueSingleSyncJob(store repos.Store) func(*testing.T) {
 
 		// If we change status to completed we should be able to enqueue another one
 		q = sqlf.Sprintf("UPDATE external_service_sync_jobs SET state='completed'")
-		if _, err = store.Handle().DBUtilDB().ExecContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...); err != nil {
+		if _, err = store.Handle().ExecContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...); err != nil {
 			t.Fatal(err)
 		}
 		err = store.EnqueueSingleSyncJob(ctx, service.ID)
@@ -266,7 +266,7 @@ func testStoreEnqueueSingleSyncJob(store repos.Store) func(*testing.T) {
 
 		// Test that cloud default external services don't get jobs enqueued (no-ops instead of errors)
 		q = sqlf.Sprintf("UPDATE external_service_sync_jobs SET state='completed'")
-		if _, err = store.Handle().DBUtilDB().ExecContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...); err != nil {
+		if _, err = store.Handle().ExecContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...); err != nil {
 			t.Fatal(err)
 		}
 
@@ -284,7 +284,7 @@ func testStoreEnqueueSingleSyncJob(store repos.Store) func(*testing.T) {
 
 		// Test that cloud default external services don't get jobs enqueued also when there are no job rows.
 		q = sqlf.Sprintf("DELETE FROM external_service_sync_jobs")
-		if _, err = store.Handle().DBUtilDB().ExecContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...); err != nil {
+		if _, err = store.Handle().ExecContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...); err != nil {
 			t.Fatal(err)
 		}
 
@@ -306,7 +306,7 @@ DELETE FROM external_services;
 DELETE FROM repo;
 DELETE FROM users;
 `)
-			if _, err := store.Handle().DBUtilDB().ExecContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...); err != nil {
+			if _, err := store.Handle().ExecContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...); err != nil {
 				t.Fatal(err)
 			}
 		})
@@ -347,7 +347,7 @@ INSERT INTO external_service_repos (external_service_id, repo_id, clone_url, use
 		`, svc.ID, svc.ID),
 		}
 		for _, q := range qs {
-			if _, err := store.Handle().DBUtilDB().ExecContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...); err != nil {
+			if _, err := store.Handle().ExecContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...); err != nil {
 				t.Fatal(err)
 			}
 		}
@@ -374,7 +374,7 @@ DELETE FROM external_services;
 DELETE FROM repo;
 DELETE FROM users;
 `)
-			if _, err := store.Handle().DBUtilDB().ExecContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...); err != nil {
+			if _, err := store.Handle().ExecContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...); err != nil {
 				t.Fatal(err)
 			}
 		})
@@ -417,7 +417,7 @@ VALUES
 		`, svc.ID, svc.ID, svc.ID),
 		}
 		for _, q := range qs {
-			if _, err := store.Handle().DBUtilDB().ExecContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...); err != nil {
+			if _, err := store.Handle().ExecContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...); err != nil {
 				t.Fatal(err)
 			}
 		}

--- a/internal/repos/store_test.go
+++ b/internal/repos/store_test.go
@@ -146,7 +146,7 @@ func testStoreEnqueueSyncJobs(store repos.Store) func(*testing.T) {
 			t.Run(tc.name, func(t *testing.T) {
 				t.Cleanup(func() {
 					q := sqlf.Sprintf("DELETE FROM external_service_sync_jobs;DELETE FROM external_services")
-					if _, err := store.Handle().DB().ExecContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...); err != nil {
+					if _, err := store.Handle().DBUtilDB().ExecContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...); err != nil {
 						t.Fatal(err)
 					}
 				})
@@ -195,7 +195,7 @@ func testStoreEnqueueSingleSyncJob(store repos.Store) func(*testing.T) {
 		ctx := context.Background()
 		t.Cleanup(func() {
 			q := sqlf.Sprintf("DELETE FROM external_service_sync_jobs;DELETE FROM external_services")
-			if _, err := store.Handle().DB().ExecContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...); err != nil {
+			if _, err := store.Handle().DBUtilDB().ExecContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...); err != nil {
 				t.Fatal(err)
 			}
 		})
@@ -220,7 +220,7 @@ func testStoreEnqueueSingleSyncJob(store repos.Store) func(*testing.T) {
 			t.Helper()
 			var count int
 			q := sqlf.Sprintf("SELECT COUNT(*) FROM external_service_sync_jobs")
-			if err := store.Handle().DB().QueryRowContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...).Scan(&count); err != nil {
+			if err := store.Handle().DBUtilDB().QueryRowContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...).Scan(&count); err != nil {
 				t.Fatal(err)
 			}
 			if count != want {
@@ -244,7 +244,7 @@ func testStoreEnqueueSingleSyncJob(store repos.Store) func(*testing.T) {
 
 		// If we change status to processing it should not add a new row
 		q := sqlf.Sprintf("UPDATE external_service_sync_jobs SET state='processing'")
-		if _, err := store.Handle().DB().ExecContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...); err != nil {
+		if _, err := store.Handle().DBUtilDB().ExecContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...); err != nil {
 			t.Fatal(err)
 		}
 		err = store.EnqueueSingleSyncJob(ctx, service.ID)
@@ -255,7 +255,7 @@ func testStoreEnqueueSingleSyncJob(store repos.Store) func(*testing.T) {
 
 		// If we change status to completed we should be able to enqueue another one
 		q = sqlf.Sprintf("UPDATE external_service_sync_jobs SET state='completed'")
-		if _, err = store.Handle().DB().ExecContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...); err != nil {
+		if _, err = store.Handle().DBUtilDB().ExecContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...); err != nil {
 			t.Fatal(err)
 		}
 		err = store.EnqueueSingleSyncJob(ctx, service.ID)
@@ -266,7 +266,7 @@ func testStoreEnqueueSingleSyncJob(store repos.Store) func(*testing.T) {
 
 		// Test that cloud default external services don't get jobs enqueued (no-ops instead of errors)
 		q = sqlf.Sprintf("UPDATE external_service_sync_jobs SET state='completed'")
-		if _, err = store.Handle().DB().ExecContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...); err != nil {
+		if _, err = store.Handle().DBUtilDB().ExecContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...); err != nil {
 			t.Fatal(err)
 		}
 
@@ -284,7 +284,7 @@ func testStoreEnqueueSingleSyncJob(store repos.Store) func(*testing.T) {
 
 		// Test that cloud default external services don't get jobs enqueued also when there are no job rows.
 		q = sqlf.Sprintf("DELETE FROM external_service_sync_jobs")
-		if _, err = store.Handle().DB().ExecContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...); err != nil {
+		if _, err = store.Handle().DBUtilDB().ExecContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...); err != nil {
 			t.Fatal(err)
 		}
 
@@ -306,7 +306,7 @@ DELETE FROM external_services;
 DELETE FROM repo;
 DELETE FROM users;
 `)
-			if _, err := store.Handle().DB().ExecContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...); err != nil {
+			if _, err := store.Handle().DBUtilDB().ExecContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...); err != nil {
 				t.Fatal(err)
 			}
 		})
@@ -347,7 +347,7 @@ INSERT INTO external_service_repos (external_service_id, repo_id, clone_url, use
 		`, svc.ID, svc.ID),
 		}
 		for _, q := range qs {
-			if _, err := store.Handle().DB().ExecContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...); err != nil {
+			if _, err := store.Handle().DBUtilDB().ExecContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...); err != nil {
 				t.Fatal(err)
 			}
 		}
@@ -374,7 +374,7 @@ DELETE FROM external_services;
 DELETE FROM repo;
 DELETE FROM users;
 `)
-			if _, err := store.Handle().DB().ExecContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...); err != nil {
+			if _, err := store.Handle().DBUtilDB().ExecContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...); err != nil {
 				t.Fatal(err)
 			}
 		})
@@ -417,7 +417,7 @@ VALUES
 		`, svc.ID, svc.ID, svc.ID),
 		}
 		for _, q := range qs {
-			if _, err := store.Handle().DB().ExecContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...); err != nil {
+			if _, err := store.Handle().DBUtilDB().ExecContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...); err != nil {
 				t.Fatal(err)
 			}
 		}

--- a/internal/repos/sync_worker.go
+++ b/internal/repos/sync_worker.go
@@ -126,7 +126,7 @@ func runJobCleaner(ctx context.Context, handle basestore.TransactableHandle, int
 	defer t.Stop()
 
 	for {
-		_, err := handle.DBUtilDB().ExecContext(ctx, `
+		_, err := handle.ExecContext(ctx, `
 -- source: internal/repos/sync_worker.go:runJobCleaner
 DELETE FROM external_service_sync_jobs
 WHERE

--- a/internal/repos/sync_worker.go
+++ b/internal/repos/sync_worker.go
@@ -126,7 +126,7 @@ func runJobCleaner(ctx context.Context, handle basestore.TransactableHandle, int
 	defer t.Stop()
 
 	for {
-		_, err := handle.DB().ExecContext(ctx, `
+		_, err := handle.DBUtilDB().ExecContext(ctx, `
 -- source: internal/repos/sync_worker.go:runJobCleaner
 DELETE FROM external_service_sync_jobs
 WHERE

--- a/internal/repos/sync_worker_test.go
+++ b/internal/repos/sync_worker_test.go
@@ -34,7 +34,7 @@ func testSyncWorkerPlumbing(repoStore repos.Store) func(t *testing.T) {
 
 		// Add item to queue
 		q := sqlf.Sprintf(`insert into external_service_sync_jobs (external_service_id) values (%s);`, testSvc.ID)
-		result, err := repoStore.Handle().DB().ExecContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...)
+		result, err := repoStore.Handle().DBUtilDB().ExecContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/repos/sync_worker_test.go
+++ b/internal/repos/sync_worker_test.go
@@ -34,7 +34,7 @@ func testSyncWorkerPlumbing(repoStore repos.Store) func(t *testing.T) {
 
 		// Add item to queue
 		q := sqlf.Sprintf(`insert into external_service_sync_jobs (external_service_id) values (%s);`, testSvc.ID)
-		result, err := repoStore.Handle().DBUtilDB().ExecContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...)
+		result, err := repoStore.Handle().ExecContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/repos/syncer_test.go
+++ b/internal/repos/syncer_test.go
@@ -148,7 +148,7 @@ func testSyncerSync(s repos.Store) func(*testing.T) {
 		}
 
 		q := sqlf.Sprintf(`INSERT INTO users (id, username) VALUES (1, 'u')`)
-		_, err := s.Handle().DBUtilDB().ExecContext(context.Background(), q.Query(sqlf.PostgresBindVar), q.Args()...)
+		_, err := s.Handle().ExecContext(context.Background(), q.Query(sqlf.PostgresBindVar), q.Args()...)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -711,7 +711,7 @@ func testSyncRepo(s repos.Store) func(*testing.T) {
 
 			t.Run(tc.name, func(t *testing.T) {
 				q := sqlf.Sprintf("DELETE FROM repo")
-				_, err := s.Handle().DBUtilDB().ExecContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...)
+				_, err := s.Handle().ExecContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...)
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -972,7 +972,7 @@ func testSyncerMultipleServices(store repos.Store) func(t *testing.T) {
 		var jobCount int
 		for i := 0; i < 10; i++ {
 			q := sqlf.Sprintf("SELECT COUNT(*) FROM external_service_sync_jobs")
-			if err := store.Handle().DBUtilDB().QueryRowContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...).Scan(&jobCount); err != nil {
+			if err := store.Handle().QueryRowContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...).Scan(&jobCount); err != nil {
 				t.Fatal(err)
 			}
 			if jobCount == len(services) {
@@ -1005,7 +1005,7 @@ func testSyncerMultipleServices(store repos.Store) func(t *testing.T) {
 		var jobsCompleted int
 		for i := 0; i < 10; i++ {
 			q := sqlf.Sprintf("SELECT COUNT(*) FROM external_service_sync_jobs where state = 'completed'")
-			if err := store.Handle().DBUtilDB().QueryRowContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...).Scan(&jobsCompleted); err != nil {
+			if err := store.Handle().QueryRowContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...).Scan(&jobsCompleted); err != nil {
 				t.Fatal(err)
 			}
 			if jobsCompleted == len(services) {
@@ -1439,7 +1439,7 @@ func testUserAddedRepos(store repos.Store) func(*testing.T) {
 
 		var userID int32
 		q := sqlf.Sprintf("INSERT INTO users (username) VALUES ('bbs-admin') RETURNING id")
-		err := store.Handle().DBUtilDB().QueryRowContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...).
+		err := store.Handle().QueryRowContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...).
 			Scan(&userID)
 		if err != nil {
 			t.Fatal(err)
@@ -1579,7 +1579,7 @@ func testUserAddedRepos(store repos.Store) func(*testing.T) {
 			pq.Array([]string{database.TagAllowUserExternalServicePrivate}),
 			userID,
 		)
-		_, err = store.Handle().DBUtilDB().ExecContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...)
+		_, err = store.Handle().ExecContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1600,7 +1600,7 @@ func testUserAddedRepos(store repos.Store) func(*testing.T) {
 		// Confirm that there are two relationships
 		assertSourceCount(ctx, t, store, 2)
 		q = sqlf.Sprintf("UPDATE users SET tags = '{}' WHERE id = %s", userID)
-		_, err = store.Handle().DBUtilDB().ExecContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...)
+		_, err = store.Handle().ExecContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -2085,7 +2085,7 @@ func assertSourceCount(ctx context.Context, t *testing.T, store repos.Store, wan
 	t.Helper()
 	var rowCount int
 	q := sqlf.Sprintf("SELECT COUNT(*) FROM external_service_repos")
-	if err := store.Handle().DBUtilDB().QueryRowContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...).Scan(&rowCount); err != nil {
+	if err := store.Handle().QueryRowContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...).Scan(&rowCount); err != nil {
 		t.Fatal(err)
 	}
 	if rowCount != want {
@@ -2097,7 +2097,7 @@ func assertDeletedRepoCount(ctx context.Context, t *testing.T, store repos.Store
 	t.Helper()
 	var rowCount int
 	q := sqlf.Sprintf("SELECT COUNT(*) FROM repo where deleted_at is not null")
-	if err := store.Handle().DBUtilDB().QueryRowContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...).Scan(&rowCount); err != nil {
+	if err := store.Handle().QueryRowContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...).Scan(&rowCount); err != nil {
 		t.Fatal(err)
 	}
 	if rowCount != want {

--- a/internal/repos/syncer_test.go
+++ b/internal/repos/syncer_test.go
@@ -148,7 +148,7 @@ func testSyncerSync(s repos.Store) func(*testing.T) {
 		}
 
 		q := sqlf.Sprintf(`INSERT INTO users (id, username) VALUES (1, 'u')`)
-		_, err := s.Handle().DB().ExecContext(context.Background(), q.Query(sqlf.PostgresBindVar), q.Args()...)
+		_, err := s.Handle().DBUtilDB().ExecContext(context.Background(), q.Query(sqlf.PostgresBindVar), q.Args()...)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -711,7 +711,7 @@ func testSyncRepo(s repos.Store) func(*testing.T) {
 
 			t.Run(tc.name, func(t *testing.T) {
 				q := sqlf.Sprintf("DELETE FROM repo")
-				_, err := s.Handle().DB().ExecContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...)
+				_, err := s.Handle().DBUtilDB().ExecContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...)
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -972,7 +972,7 @@ func testSyncerMultipleServices(store repos.Store) func(t *testing.T) {
 		var jobCount int
 		for i := 0; i < 10; i++ {
 			q := sqlf.Sprintf("SELECT COUNT(*) FROM external_service_sync_jobs")
-			if err := store.Handle().DB().QueryRowContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...).Scan(&jobCount); err != nil {
+			if err := store.Handle().DBUtilDB().QueryRowContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...).Scan(&jobCount); err != nil {
 				t.Fatal(err)
 			}
 			if jobCount == len(services) {
@@ -1005,7 +1005,7 @@ func testSyncerMultipleServices(store repos.Store) func(t *testing.T) {
 		var jobsCompleted int
 		for i := 0; i < 10; i++ {
 			q := sqlf.Sprintf("SELECT COUNT(*) FROM external_service_sync_jobs where state = 'completed'")
-			if err := store.Handle().DB().QueryRowContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...).Scan(&jobsCompleted); err != nil {
+			if err := store.Handle().DBUtilDB().QueryRowContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...).Scan(&jobsCompleted); err != nil {
 				t.Fatal(err)
 			}
 			if jobsCompleted == len(services) {
@@ -1439,7 +1439,7 @@ func testUserAddedRepos(store repos.Store) func(*testing.T) {
 
 		var userID int32
 		q := sqlf.Sprintf("INSERT INTO users (username) VALUES ('bbs-admin') RETURNING id")
-		err := store.Handle().DB().QueryRowContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...).
+		err := store.Handle().DBUtilDB().QueryRowContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...).
 			Scan(&userID)
 		if err != nil {
 			t.Fatal(err)
@@ -1579,7 +1579,7 @@ func testUserAddedRepos(store repos.Store) func(*testing.T) {
 			pq.Array([]string{database.TagAllowUserExternalServicePrivate}),
 			userID,
 		)
-		_, err = store.Handle().DB().ExecContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...)
+		_, err = store.Handle().DBUtilDB().ExecContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1600,7 +1600,7 @@ func testUserAddedRepos(store repos.Store) func(*testing.T) {
 		// Confirm that there are two relationships
 		assertSourceCount(ctx, t, store, 2)
 		q = sqlf.Sprintf("UPDATE users SET tags = '{}' WHERE id = %s", userID)
-		_, err = store.Handle().DB().ExecContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...)
+		_, err = store.Handle().DBUtilDB().ExecContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -2085,7 +2085,7 @@ func assertSourceCount(ctx context.Context, t *testing.T, store repos.Store, wan
 	t.Helper()
 	var rowCount int
 	q := sqlf.Sprintf("SELECT COUNT(*) FROM external_service_repos")
-	if err := store.Handle().DB().QueryRowContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...).Scan(&rowCount); err != nil {
+	if err := store.Handle().DBUtilDB().QueryRowContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...).Scan(&rowCount); err != nil {
 		t.Fatal(err)
 	}
 	if rowCount != want {
@@ -2097,7 +2097,7 @@ func assertDeletedRepoCount(ctx context.Context, t *testing.T, store repos.Store
 	t.Helper()
 	var rowCount int
 	q := sqlf.Sprintf("SELECT COUNT(*) FROM repo where deleted_at is not null")
-	if err := store.Handle().DB().QueryRowContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...).Scan(&rowCount); err != nil {
+	if err := store.Handle().DBUtilDB().QueryRowContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...).Scan(&rowCount); err != nil {
 		t.Fatal(err)
 	}
 	if rowCount != want {


### PR DESCRIPTION
Ths embeds `dbutil.DB` in `TransactableHandle` so it doesn't need to be unwrapped to a `dbutil.DB` before use. This enables two things:
1) It can be mocked. There are a couple of places where we override the behavior of `Transact` for the purpose of tests, so this makes it possible to keep this pattern with the new well-typed `TransactableHandles`. 
2) The `TransactableHandle` now has full control over all database calls, so it can now report when transactions are used concurrently.

Stacked on https://github.com/sourcegraph/sourcegraph/pull/37163

## Test plan

This just moves things to an embedding rather than a method and should be completely safe. Depending on gopls, but if tests pass I'm happy

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
