### PR TITLE
dev/ci: sanitize + from branch names for tag

### DIFF
--- a/enterprise/dev/ci/internal/ci/config.go
+++ b/enterprise/dev/ci/internal/ci/config.go
@@ -112,7 +112,7 @@ func NewConfig(now time.Time) Config {
 		tag = fmt.Sprintf("%05d_%10s_%.12s", buildNumber, now.Format("2006-01-02"), commit)
 	default:
 		// Encode branch inside build tag by default.
-		tag = fmt.Sprintf("%s_%05d_%10s_%.12s", strings.ReplaceAll(branch, "/", "-"), buildNumber, now.Format("2006-01-02"), commit)
+		tag = fmt.Sprintf("%s_%05d_%10s_%.12s", sanitizeBranchForDockerTag(branch), buildNumber, now.Format("2006-01-02"), commit)
 	}
 	if runType.Is(runtype.ImagePatch, runtype.ImagePatchNoTest, runtype.ExecutorPatchNoTest) {
 		// Add additional patch suffix
@@ -205,4 +205,10 @@ func parseMessageFlags(msg string) MessageFlags {
 		SkipHashCompare:     strings.Contains(msg, "[skip-hash-compare]"),
 		ForceReadyForReview: strings.Contains(msg, "[review-ready]"),
 	}
+}
+
+func sanitizeBranchForDockerTag(branch string) string {
+	branch = strings.ReplaceAll(branch, "/", "-")
+	branch = strings.ReplaceAll(branch, "+", "-")
+	return branch
 }


### PR DESCRIPTION
Fix for https://sourcegraph.slack.com/archives/C01N83PS4TU/p1655150576099319?thread_ts=1655145763.437259&cid=C01N83PS4TU

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

```
sg ci build docker-images-patch-notest jaeger-agent
```

https://buildkite.com/sourcegraph/sourcegraph/builds/154297