### PR TITLE
DB Backend: remove unused interfaces

### DIFF
--- a/enterprise/internal/database/database.go
+++ b/enterprise/internal/database/database.go
@@ -71,14 +71,6 @@ func (d *insightsDB) Done(err error) error {
 	return d.Store.Done(err)
 }
 
-func (d *insightsDB) Unwrap() dbutil.DB {
-	// Recursively unwrap in case we ever call `NewInsightsDB()` with an `InsightsDB`
-	if unwrapper, ok := d.Handle().(dbutil.Unwrapper); ok {
-		return unwrapper.Unwrap()
-	}
-	return d.Handle()
-}
-
 func (d *insightsDB) QueryContext(ctx context.Context, q string, args ...any) (*sql.Rows, error) {
 	return d.Handle().QueryContext(ctx, q, args...)
 }

--- a/internal/codeintel/stores/db.go
+++ b/internal/codeintel/stores/db.go
@@ -40,14 +40,6 @@ func (d *codeIntelDB) Done(err error) error {
 	return d.Store.Done(err)
 }
 
-func (d *codeIntelDB) Unwrap() dbutil.DB {
-	// Recursively unwrap in case we ever call `NewInsightsDB()` with an `InsightsDB`
-	if unwrapper, ok := d.Handle().(dbutil.Unwrapper); ok {
-		return unwrapper.Unwrap()
-	}
-	return d.Handle()
-}
-
 func (d *codeIntelDB) QueryContext(ctx context.Context, q string, args ...any) (*sql.Rows, error) {
 	return d.Handle().QueryContext(ctx, q, args...)
 }

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -207,11 +207,3 @@ func (d *db) Users() UserStore {
 func (d *db) WebhookLogs(key encryption.Key) WebhookLogStore {
 	return WebhookLogsWith(d.Store, key)
 }
-
-func (d *db) Unwrap() dbutil.DB {
-	// Recursively unwrap in case we ever call `database.NewDB()` with a `database.DB`
-	if unwrapper, ok := d.Handle().(dbutil.Unwrapper); ok {
-		return unwrapper.Unwrap()
-	}
-	return d.Handle()
-}

--- a/internal/database/dbutil/dbutil.go
+++ b/internal/database/dbutil/dbutil.go
@@ -13,31 +13,11 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
-// A DB captures the essential method of a sql.DB: QueryContext.
+// A DB captures the methods shared between a *sql.DB and a *sql.Tx
 type DB interface {
 	QueryContext(ctx context.Context, q string, args ...any) (*sql.Rows, error)
 	ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error)
 	QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row
-}
-
-// A Tx captures the essential methods of a sql.Tx.
-type Tx interface {
-	Rollback() error
-	Commit() error
-}
-
-// A TxBeginner captures BeginTx method of a sql.DB
-type TxBeginner interface {
-	BeginTx(context.Context, *sql.TxOptions) (*sql.Tx, error)
-}
-
-// An Unwrapper unwraps itself into its nested DB.
-// This is necessary because the concrete type of a dbutil.DB
-// is used to assert interfaces like `Tx` and `TxBeginner`, so
-// wrapping a dbutil.DB breaks those interface assertions.
-type Unwrapper interface {
-	// Unwrap returns the inner DB. If defined, it must return a valid DB (never nil).
-	Unwrap() DB
 }
 
 func IsPostgresError(err error, codename string) bool {


### PR DESCRIPTION
Now that we don't need to do interface casts for a bunch of transaction
operations, these interface definitions are unused and unneeded!

Stacked on https://github.com/sourcegraph/sourcegraph/pull/37167

## Test plan

Just deleting unused code

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
