### PR TITLE
Update server bundled postgres

### DIFF
--- a/cmd/server/Dockerfile
+++ b/cmd/server/Dockerfile
@@ -52,8 +52,8 @@ RUN apk add --no-cache --verbose \
     # You can't just bump the major version since that requires pgupgrade
     # between Sourcegraph releases.
     && apk add --no-cache --verbose \
-    postgresql=~12 \
-    postgresql-contrib=~12 \
+    'postgresql=>12.11' \
+    'postgresql-contrib=>12.11' \
     --repository=http://dl-cdn.alpinelinux.org/alpine/v3.12/main  \
     && apk add --no-cache --verbose \
     'bash>=5.0.17' \


### PR DESCRIPTION
This PR updates postgres to patch CVE-2022-1552. We are not actively affected. This patch is out of good hygiene.
## Test plan
CI checks.
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
