### PR TITLE
Add "managed docker compose" deploy type for managed instances

### DIFF
--- a/client/web/src/jscontext.ts
+++ b/client/web/src/jscontext.ts
@@ -1,6 +1,13 @@
 import { SiteConfiguration } from '@sourcegraph/shared/src/schema/site.schema'
 
-export type DeployType = 'kubernetes' | 'docker-container' | 'docker-compose' | 'pure-docker' | 'dev' | 'helm'
+export type DeployType =
+    | 'kubernetes'
+    | 'docker-container'
+    | 'docker-compose'
+    | 'managed-docker-compose'
+    | 'pure-docker'
+    | 'dev'
+    | 'helm'
 
 /**
  * Defined in cmd/frontend/internal/app/jscontext/jscontext.go JSContext struct

--- a/client/web/src/site-admin/SiteAdminPingsPage.tsx
+++ b/client/web/src/site-admin/SiteAdminPingsPage.tsx
@@ -94,8 +94,8 @@ export const SiteAdminPingsPage: React.FunctionComponent<React.PropsWithChildren
                 <li>Sourcegraph version string (e.g. "vX.X.X")</li>
                 <li>Dependency versions (e.g. "6.0.9" for Redis, or "13.0" for Postgres)</li>
                 <li>
-                    Deployment type (single Docker image, Docker Compose, Kubernetes cluster, Helm, or pure Docker
-                    cluster)
+                    Deployment type (single Docker image, Docker Compose, managed Docker Compose, Kubernetes cluster,
+                    Helm, or pure Docker cluster)
                 </li>
                 <li>License key associated with your Sourcegraph subscription</li>
                 <li>Aggregate count of current monthly users</li>

--- a/doc/admin/pings.md
+++ b/doc/admin/pings.md
@@ -10,7 +10,7 @@ Critical telemetry includes only the high-level data below required for billing,
 - The email address of the initial site installer (or if deleted, the first active site admin), to know who to contact regarding sales, product updates, security updates, and policy updates
 - Sourcegraph version string (e.g. "vX.X.X")
 - Dependency versions (e.g. "6.0.9" for Redis, or "13.0" for Postgres)
-- Deployment type (single Docker image, Docker Compose, Kubernetes cluster, Helm, or pure Docker cluster)
+- Deployment type (single Docker image, Docker Compose, managed Docker Compose, Kubernetes cluster, Helm, or pure Docker cluster)
 - License key associated with your Sourcegraph subscription
 - Aggregate count of current monthly users
 - Total count of existing user accounts

--- a/internal/conf/computed.go
+++ b/internal/conf/computed.go
@@ -19,7 +19,7 @@ import (
 func init() {
 	deployType := deploy.Type()
 	if !deploy.IsValidDeployType(deployType) {
-		log.Fatalf("The 'DEPLOY_TYPE' environment variable is invalid. Expected one of: %q, %q, %q, %q, %q, %q. Got: %q", deploy.Kubernetes, deploy.DockerCompose, deploy.PureDocker, deploy.SingleDocker, deploy.Dev, deploy.Helm, deployType)
+		log.Fatalf("The 'DEPLOY_TYPE' environment variable is invalid. Expected one of: %q, %q, %q, %q, %q, %q, %q. Got: %q", deploy.Kubernetes, deploy.DockerCompose, deploy.ManagedDockerCompose, deploy.PureDocker, deploy.SingleDocker, deploy.Dev, deploy.Helm, deployType)
 	}
 
 	confdefaults.Default = defaultConfigForDeployment()

--- a/internal/conf/deploy/deploytype.go
+++ b/internal/conf/deploy/deploytype.go
@@ -5,12 +5,13 @@ import "os"
 // Deploy type constants. Any changes here should be reflected in the DeployType type declared in client/web/src/jscontext.ts:
 // https://sourcegraph.com/search?q=r:github.com/sourcegraph/sourcegraph%24+%22type+DeployType%22
 const (
-	Kubernetes    = "kubernetes"
-	SingleDocker  = "docker-container"
-	DockerCompose = "docker-compose"
-	PureDocker    = "pure-docker"
-	Dev           = "dev"
-	Helm          = "helm"
+	Kubernetes           = "kubernetes"
+	SingleDocker         = "docker-container"
+	DockerCompose        = "docker-compose"
+	ManagedDockerCompose = "managed-docker-compose"
+	PureDocker           = "pure-docker"
+	Dev                  = "dev"
+	Helm                 = "helm"
 )
 
 // Type tells the deployment type.
@@ -38,7 +39,12 @@ func IsDeployTypeKubernetes(deployType string) bool {
 // IsDeployTypeDockerCompose tells if the given deployment type is the Docker Compose
 // deployment (and non-dev, not pure-docker, non-cluster, and non-single Docker image).
 func IsDeployTypeDockerCompose(deployType string) bool {
-	return deployType == DockerCompose
+	switch deployType {
+	case DockerCompose, ManagedDockerCompose:
+		return true
+	}
+
+	return false
 }
 
 // IsDeployTypePureDocker tells if the given deployment type is the pure Docker

--- a/internal/conf/deploy/deploytype.go
+++ b/internal/conf/deploy/deploytype.go
@@ -2,8 +2,9 @@ package deploy
 
 import "os"
 
-// Deploy type constants. Any changes here should be reflected in the DeployType type declared in client/web/src/jscontext.ts:
-// https://sourcegraph.com/search?q=r:github.com/sourcegraph/sourcegraph%24+%22type+DeployType%22
+// Deploy type constants. Changes here should be reflected in several other places. Mirror
+// the changes from this PR to make sure these places are consistent:
+// https://github.com/sourcegraph/sourcegraph/pull/32407/files
 const (
 	Kubernetes           = "kubernetes"
 	SingleDocker         = "docker-container"

--- a/internal/conf/deploy/deploytype.go
+++ b/internal/conf/deploy/deploytype.go
@@ -65,6 +65,11 @@ func IsDev(deployType string) bool {
 	return deployType == Dev
 }
 
+// IsManagedInstance tells if the given deployment type is one managed by Sourcegraph.
+func IsManagedInstance(deployType string) bool {
+	return deployType == ManagedDockerCompose
+}
+
 // IsValidDeployType returns true iff the given deployType is a Kubernetes deployment, a Docker Compose
 // deployment, a pure Docker deployment, a Docker deployment, or a local development environment.
 func IsValidDeployType(deployType string) bool {


### PR DESCRIPTION
Part 1 for https://github.com/sourcegraph/sourcegraph/issues/36920.

The Batch Changes team is interested in configuring a setting to be default `false` for managed instances but default `true` for everyone else.

This PR adds a new value for the `DEPLOY_TYPE` environment variable to indicate an instance is managed by Sourcegraph. Since today, managed instances are all run with docker-compose, the value is named as such: "managed-docker-compose." This gives us the flexibility to support additional environment types for managed instances in the future. A corresponding method, `IsManagedInstance`, is added to enable that all future types of managed instances can also be treated the same by the backend code when it makes sense to do so, such as for our team's use case.

All other changes made here are meant to mirror those from https://github.com/sourcegraph/sourcegraph/pull/32407.

## Test plan

I'm not very familiar with this part of the codebase and would appreciate recommendations for the best way to test this. 🙂

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
