### PR TITLE
Added Descriptive Aria-Labels to Branch/Tag/Commit Selector

### DIFF
--- a/client/web/src/repo/RevisionsPopover/RevisionsPopover.tsx
+++ b/client/web/src/repo/RevisionsPopover/RevisionsPopover.tsx
@@ -41,8 +41,6 @@ export interface RevisionsPopoverProps {
      * The selected revision node. Should be used to trigger side effects from clicking a node, e.g. calling `eventLogger`.
      */
     onSelect?: (node: GitRefFields | GitCommitAncestorFields) => void
-
-    // tabLabel?: string
 }
 
 type RevisionsPopoverTabID = 'branches' | 'tags' | 'commits'
@@ -120,7 +118,7 @@ export const RevisionsPopover: React.FunctionComponent<React.PropsWithChildren<R
                                 showSpeculativeResults={
                                     props.showSpeculativeResults && tab.type === GitRefType.GIT_BRANCH
                                 }
-                                tabLabel={tab.label}
+                                tabLabel={tab.id}
                             />
                         ) : (
                             <RevisionsPopoverCommits
@@ -132,7 +130,7 @@ export const RevisionsPopover: React.FunctionComponent<React.PropsWithChildren<R
                                 repo={props.repo}
                                 currentCommitID={props.currentCommitID}
                                 onSelect={props.onSelect}
-                                tabLabel={tab.label}
+                                tabLabel={tab.id}
                             />
                         )}
                     </TabPanel>

--- a/client/web/src/repo/RevisionsPopover/RevisionsPopover.tsx
+++ b/client/web/src/repo/RevisionsPopover/RevisionsPopover.tsx
@@ -41,6 +41,8 @@ export interface RevisionsPopoverProps {
      * The selected revision node. Should be used to trigger side effects from clicking a node, e.g. calling `eventLogger`.
      */
     onSelect?: (node: GitRefFields | GitCommitAncestorFields) => void
+
+    // tabLabel?: string
 }
 
 type RevisionsPopoverTabID = 'branches' | 'tags' | 'commits'
@@ -118,6 +120,7 @@ export const RevisionsPopover: React.FunctionComponent<React.PropsWithChildren<R
                                 showSpeculativeResults={
                                     props.showSpeculativeResults && tab.type === GitRefType.GIT_BRANCH
                                 }
+                                tabLabel={tab.label}
                             />
                         ) : (
                             <RevisionsPopoverCommits
@@ -129,6 +132,7 @@ export const RevisionsPopover: React.FunctionComponent<React.PropsWithChildren<R
                                 repo={props.repo}
                                 currentCommitID={props.currentCommitID}
                                 onSelect={props.onSelect}
+                                tabLabel={tab.label}
                             />
                         )}
                     </TabPanel>

--- a/client/web/src/repo/RevisionsPopover/RevisionsPopover.tsx
+++ b/client/web/src/repo/RevisionsPopover/RevisionsPopover.tsx
@@ -51,14 +51,35 @@ interface RevisionsPopoverTab {
     noun: string
     pluralNoun: string
     type?: GitRefType
+    description: string
 }
 
 const LAST_TAB_STORAGE_KEY = 'RevisionsPopover.lastTab'
 
 const TABS: RevisionsPopoverTab[] = [
-    { id: 'branches', label: 'Branches', noun: 'branch', pluralNoun: 'branches', type: GitRefType.GIT_BRANCH },
-    { id: 'tags', label: 'Tags', noun: 'tag', pluralNoun: 'tags', type: GitRefType.GIT_TAG },
-    { id: 'commits', label: 'Commits', noun: 'commit', pluralNoun: 'commits' },
+    {
+        id: 'branches',
+        label: 'Branches',
+        noun: 'branch',
+        pluralNoun: 'branches',
+        type: GitRefType.GIT_BRANCH,
+        description: 'Find a revision from the listed branches',
+    },
+    {
+        id: 'tags',
+        label: 'Tags',
+        noun: 'tag',
+        pluralNoun: 'tags',
+        type: GitRefType.GIT_TAG,
+        description: 'Find a revision from the listed tags',
+    },
+    {
+        id: 'commits',
+        label: 'Commits',
+        noun: 'commit',
+        pluralNoun: 'commits',
+        description: 'Find a revision from the listed commits',
+    },
 ]
 
 /**
@@ -118,7 +139,7 @@ export const RevisionsPopover: React.FunctionComponent<React.PropsWithChildren<R
                                 showSpeculativeResults={
                                     props.showSpeculativeResults && tab.type === GitRefType.GIT_BRANCH
                                 }
-                                tabLabel={tab.id}
+                                tabLabel={tab.description}
                             />
                         ) : (
                             <RevisionsPopoverCommits
@@ -130,7 +151,7 @@ export const RevisionsPopover: React.FunctionComponent<React.PropsWithChildren<R
                                 repo={props.repo}
                                 currentCommitID={props.currentCommitID}
                                 onSelect={props.onSelect}
-                                tabLabel={tab.id}
+                                tabLabel={tab.description}
                             />
                         )}
                     </TabPanel>

--- a/client/web/src/repo/RevisionsPopover/RevisionsPopoverCommits.tsx
+++ b/client/web/src/repo/RevisionsPopover/RevisionsPopoverCommits.tsx
@@ -116,7 +116,7 @@ interface RevisionsPopoverCommitsProps {
 
     onSelect?: (node: GitCommitAncestorFields) => void
 
-    tabLabel?: string
+    tabLabel: string
 }
 
 const BATCH_COUNT = 15

--- a/client/web/src/repo/RevisionsPopover/RevisionsPopoverCommits.tsx
+++ b/client/web/src/repo/RevisionsPopover/RevisionsPopoverCommits.tsx
@@ -115,13 +115,25 @@ interface RevisionsPopoverCommitsProps {
     currentCommitID?: string
 
     onSelect?: (node: GitCommitAncestorFields) => void
+
+    tabLabel?: string
 }
 
 const BATCH_COUNT = 15
 
 export const RevisionsPopoverCommits: React.FunctionComponent<
     React.PropsWithChildren<RevisionsPopoverCommitsProps>
-> = ({ repo, defaultBranch, getPathFromRevision, currentRev, noun, pluralNoun, currentCommitID, onSelect }) => {
+> = ({
+    repo,
+    defaultBranch,
+    getPathFromRevision,
+    currentRev,
+    noun,
+    pluralNoun,
+    currentCommitID,
+    onSelect,
+    tabLabel,
+}) => {
     const [searchValue, setSearchValue] = useState('')
     const query = useDebounce(searchValue, 200)
     const location = useLocation()
@@ -183,6 +195,7 @@ export const RevisionsPopoverCommits: React.FunctionComponent<
             summary={summary}
             inputValue={searchValue}
             onInputChange={setSearchValue}
+            inputAriaLabel={tabLabel}
         >
             {response.connection?.nodes?.map((node, index) => (
                 <GitCommitNode

--- a/client/web/src/repo/RevisionsPopover/RevisionsPopoverReferences.tsx
+++ b/client/web/src/repo/RevisionsPopover/RevisionsPopoverReferences.tsx
@@ -114,6 +114,8 @@ interface RevisionsPopoverReferencesProps {
     showSpeculativeResults?: boolean
 
     onSelect?: (node: GitRefFields) => void
+
+    tabLabel?: string
 }
 
 const BATCH_COUNT = 50
@@ -131,6 +133,7 @@ export const RevisionsPopoverReferences: React.FunctionComponent<
     pluralNoun,
     showSpeculativeResults,
     onSelect,
+    tabLabel,
 }) => {
     const [searchValue, setSearchValue] = useState('')
     const query = useDebounce(searchValue, 200)
@@ -176,6 +179,7 @@ export const RevisionsPopoverReferences: React.FunctionComponent<
             summary={summary}
             inputValue={searchValue}
             onInputChange={setSearchValue}
+            inputAriaLabel={tabLabel}
         >
             {response.connection?.nodes.map((node, index) => (
                 <GitReferencePopoverNode

--- a/client/web/src/repo/RevisionsPopover/RevisionsPopoverReferences.tsx
+++ b/client/web/src/repo/RevisionsPopover/RevisionsPopoverReferences.tsx
@@ -115,7 +115,7 @@ interface RevisionsPopoverReferencesProps {
 
     onSelect?: (node: GitRefFields) => void
 
-    tabLabel?: string
+    tabLabel: string
 }
 
 const BATCH_COUNT = 50

--- a/client/web/src/repo/RevisionsPopover/RevisionsPopoverTab.tsx
+++ b/client/web/src/repo/RevisionsPopover/RevisionsPopoverTab.tsx
@@ -38,7 +38,7 @@ export const RevisionsPopoverTab: React.FunctionComponent<React.PropsWithChildre
             autoFocus={true}
             inputPlaceholder="Find..."
             compact={true}
-            inputAriaLabel={`Find ${inputAriaLabel}`}
+            inputAriaLabel={inputAriaLabel}
         />
         <SummaryContainer compact={true}>{query && summary}</SummaryContainer>
         {error && <ConnectionError errors={[error.message]} compact={true} />}

--- a/client/web/src/repo/RevisionsPopover/RevisionsPopoverTab.tsx
+++ b/client/web/src/repo/RevisionsPopover/RevisionsPopoverTab.tsx
@@ -15,6 +15,7 @@ interface RevisionsPopoverTabProps extends UseConnectionResult<unknown> {
     onInputChange: (value: string) => void
     query: string
     summary?: JSX.Element
+    inputAriaLabel?: string
 }
 
 export const RevisionsPopoverTab: React.FunctionComponent<React.PropsWithChildren<RevisionsPopoverTabProps>> = ({
@@ -28,6 +29,7 @@ export const RevisionsPopoverTab: React.FunctionComponent<React.PropsWithChildre
     connection,
     hasNextPage,
     fetchMore,
+    inputAriaLabel,
 }) => (
     <ConnectionPopoverContainer>
         <ConnectionPopoverForm
@@ -36,6 +38,7 @@ export const RevisionsPopoverTab: React.FunctionComponent<React.PropsWithChildre
             autoFocus={true}
             inputPlaceholder="Find..."
             compact={true}
+            inputAriaLabel={`Find ${inputAriaLabel}`}
         />
         <SummaryContainer compact={true}>{query && summary}</SummaryContainer>
         {error && <ConnectionError errors={[error.message]} compact={true} />}

--- a/client/web/src/repo/RevisionsPopover/RevisionsPopoverTab.tsx
+++ b/client/web/src/repo/RevisionsPopover/RevisionsPopoverTab.tsx
@@ -15,7 +15,7 @@ interface RevisionsPopoverTabProps extends UseConnectionResult<unknown> {
     onInputChange: (value: string) => void
     query: string
     summary?: JSX.Element
-    inputAriaLabel?: string
+    inputAriaLabel: string
 }
 
 export const RevisionsPopoverTab: React.FunctionComponent<React.PropsWithChildren<RevisionsPopoverTabProps>> = ({


### PR DESCRIPTION
Regarding issue #35477 - [Accessibility]: Branch/Tag/Commit: 'Find...' input placeholders aren't descriptive.

I added descriptive aria-labels, as instructed in issue #35477, that corresponds to the tab that the user has selected. I tested the changes using the VoiceOver screen reader and the labels are read as desired however, the placeholder text is also being read. Hiding the placeholder text was not explicitly stated in the issue however, if there are some suggestions as to how to accomplish this, it would be appreciated.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-lm-branchestagscommitslabels.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-yjeibzsavx.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
