### PR TITLE
Backend RFC: use generics to constrain DB store schemas

### DIFF
--- a/enterprise/cmd/frontend/internal/codeintel/services.go
+++ b/enterprise/cmd/frontend/internal/codeintel/services.go
@@ -24,6 +24,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	connections "github.com/sourcegraph/sourcegraph/internal/database/connections/live"
 	"github.com/sourcegraph/sourcegraph/internal/database/locker"
+	"github.com/sourcegraph/sourcegraph/internal/database/migration/schemas"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/sentry"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
@@ -63,7 +64,7 @@ func NewServices(ctx context.Context, config *Config, siteConfig conftypes.Watch
 
 	// Initialize stores
 	dbStore := store.NewWithDB(db, observationContext)
-	locker := locker.NewWith(db, "codeintel")
+	locker := locker.NewWith[schemas.Any](db, "codeintel")
 	lsifStore := lsifstore.NewStore(codeIntelDB, siteConfig, observationContext)
 	uploadStore, err := lsifuploadstore.New(context.Background(), config.LSIFUploadStoreConfig, observationContext)
 	if err != nil {

--- a/enterprise/internal/batches/processor/bulk_processor_test.go
+++ b/enterprise/internal/batches/processor/bulk_processor_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
 	btypes "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/database/migration/schemas"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
@@ -24,8 +23,7 @@ func TestBulkProcessor(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	handle := dbtest.New[schemas.Production](t)
-	db := database.NewDBWith(basestore.NewWithHandle(handle))
+	db := database.NewDBWith(dbtest.New[schemas.Production](t))
 	bstore := store.New(db, &observation.TestContext, nil)
 
 	user := ct.CreateTestUser(t, db, true)

--- a/enterprise/internal/batches/processor/bulk_processor_test.go
+++ b/enterprise/internal/batches/processor/bulk_processor_test.go
@@ -2,7 +2,6 @@ package processor
 
 import (
 	"context"
-	"database/sql"
 	"testing"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/global"
@@ -14,6 +13,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
+	"github.com/sourcegraph/sourcegraph/internal/database/migration/schemas"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/github"
@@ -24,10 +24,10 @@ func TestBulkProcessor(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	sqlDB := dbtest.NewDB(t)
-	tx := dbtest.NewTx(t, sqlDB)
-	db := database.NewDB(sqlDB)
-	bstore := store.New(database.NewDBWith(basestore.NewWithHandle(basestore.NewHandleWithTx(tx, sql.TxOptions{}))), &observation.TestContext, nil)
+	handle := dbtest.New[schemas.Production](t)
+	db := database.NewDBWith(basestore.NewWithHandle(handle))
+	bstore := store.New(db, &observation.TestContext, nil)
+
 	user := ct.CreateTestUser(t, db, true)
 	repo, _ := ct.CreateTestRepo(t, ctx, db)
 	ct.CreateTestSiteCredential(t, bstore, repo)

--- a/enterprise/internal/batches/processor/bulk_processor_test.go
+++ b/enterprise/internal/batches/processor/bulk_processor_test.go
@@ -23,7 +23,7 @@ func TestBulkProcessor(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	db := database.NewDBWith(dbtest.New[schemas.Production](t))
+	db := database.NewDBWith(dbtest.New[schemas.Frontend](t))
 	bstore := store.New(db, &observation.TestContext, nil)
 
 	user := ct.CreateTestUser(t, db, true)

--- a/enterprise/internal/batches/store/store.go
+++ b/enterprise/internal/batches/store/store.go
@@ -18,6 +18,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
+	"github.com/sourcegraph/sourcegraph/internal/database/migration/schemas"
 	"github.com/sourcegraph/sourcegraph/internal/encryption"
 	"github.com/sourcegraph/sourcegraph/internal/metrics"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
@@ -62,7 +63,7 @@ func RandomID() (string, error) {
 // Store exposes methods to read and write batches domain models
 // from persistent storage.
 type Store struct {
-	*basestore.Store
+	*basestore.Store[schemas.Production]
 	key                encryption.Key
 	now                func() time.Time
 	operations         *operations

--- a/enterprise/internal/batches/store/store.go
+++ b/enterprise/internal/batches/store/store.go
@@ -63,7 +63,7 @@ func RandomID() (string, error) {
 // Store exposes methods to read and write batches domain models
 // from persistent storage.
 type Store struct {
-	*basestore.Store[schemas.Production]
+	*basestore.Store[schemas.Frontend]
 	key                encryption.Key
 	now                func() time.Time
 	operations         *operations

--- a/enterprise/internal/batches/store/store_test.go
+++ b/enterprise/internal/batches/store/store_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
+	"github.com/sourcegraph/sourcegraph/internal/database/migration/schemas"
 	"github.com/sourcegraph/sourcegraph/internal/encryption"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/timeutil"
@@ -26,7 +27,7 @@ func storeTest(db *sql.DB, key encryption.Key, f storeTestFunc) func(*testing.T)
 		// of the tests, so that foreign key constraints can be deferred and we
 		// don't need to insert a lot of dependencies into the DB (users,
 		// repos, ...) to setup the tests.
-		tx := database.NewDBWith(basestore.NewWithHandle(basestore.NewHandleWithTx(dbtest.NewTx(t, db), sql.TxOptions{})))
+		tx := database.NewDBWith(basestore.NewWithHandle(basestore.NewHandleWithTx(dbtest.NewTx[schemas.Production](t, db), sql.TxOptions{})))
 		s := NewWithClock(tx, &observation.TestContext, key, c.Now)
 
 		f(t, context.Background(), s, c)

--- a/enterprise/internal/database/code_monitors.go
+++ b/enterprise/internal/database/code_monitors.go
@@ -16,13 +16,14 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
+	"github.com/sourcegraph/sourcegraph/internal/database/migration/schemas"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
 	"github.com/sourcegraph/sourcegraph/internal/timeutil"
 )
 
 // CodeMonitorStore is an interface for interacting with the code monitor tables in the database
 type CodeMonitorStore interface {
-	basestore.ShareableStore
+	basestore.ShareableStore[schemas.Production]
 	Transact(context.Context) (CodeMonitorStore, error)
 	Done(error) error
 	Now() time.Time
@@ -94,7 +95,7 @@ type CodeMonitorStore interface {
 // codeMonitorStore exposes methods to read and write codemonitors domain models
 // from persistent storage.
 type codeMonitorStore struct {
-	*basestore.Store
+	*basestore.Store[schemas.Production]
 	now func() time.Time
 }
 

--- a/enterprise/internal/database/code_monitors.go
+++ b/enterprise/internal/database/code_monitors.go
@@ -23,7 +23,7 @@ import (
 
 // CodeMonitorStore is an interface for interacting with the code monitor tables in the database
 type CodeMonitorStore interface {
-	basestore.ShareableStore[schemas.Production]
+	basestore.ShareableStore[schemas.Frontend]
 	Transact(context.Context) (CodeMonitorStore, error)
 	Done(error) error
 	Now() time.Time
@@ -95,7 +95,7 @@ type CodeMonitorStore interface {
 // codeMonitorStore exposes methods to read and write codemonitors domain models
 // from persistent storage.
 type codeMonitorStore struct {
-	*basestore.Store[schemas.Production]
+	*basestore.Store[schemas.Frontend]
 	now func() time.Time
 }
 

--- a/enterprise/internal/database/database.go
+++ b/enterprise/internal/database/database.go
@@ -8,6 +8,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
+	"github.com/sourcegraph/sourcegraph/internal/database/migration/schemas"
 )
 
 type EnterpriseDB interface {
@@ -41,22 +42,22 @@ func (edb *enterpriseDB) Perms() PermsStore {
 
 type InsightsDB interface {
 	dbutil.DB
-	basestore.ShareableStore
+	basestore.ShareableStore[schemas.CodeInsights]
 
 	Transact(context.Context) (InsightsDB, error)
 	Done(error) error
 }
 
 func NewInsightsDB(inner *sql.DB) InsightsDB {
-	return &insightsDB{basestore.NewWithHandle(basestore.NewHandleWithDB(inner, sql.TxOptions{}))}
+	return &insightsDB{basestore.NewWithHandle(basestore.NewHandleWithDB[schemas.CodeInsights](inner, sql.TxOptions{}))}
 }
 
-func NewInsightsDBWith(other basestore.ShareableStore) InsightsDB {
+func NewInsightsDBWith(other basestore.ShareableStore[schemas.CodeInsights]) InsightsDB {
 	return &insightsDB{basestore.NewWithHandle(other.Handle())}
 }
 
 type insightsDB struct {
-	*basestore.Store
+	*basestore.Store[schemas.CodeInsights]
 }
 
 func (d *insightsDB) Transact(ctx context.Context) (InsightsDB, error) {

--- a/enterprise/internal/database/database.go
+++ b/enterprise/internal/database/database.go
@@ -71,14 +71,6 @@ func (d *insightsDB) Done(err error) error {
 	return d.Store.Done(err)
 }
 
-func (d *insightsDB) Unwrap() dbutil.DB {
-	// Recursively unwrap in case we ever call `NewInsightsDB()` with an `InsightsDB`
-	if unwrapper, ok := d.Handle().(dbutil.Unwrapper); ok {
-		return unwrapper.Unwrap()
-	}
-	return d.Handle()
-}
-
 func (d *insightsDB) QueryContext(ctx context.Context, q string, args ...any) (*sql.Rows, error) {
 	return d.Handle().QueryContext(ctx, q, args...)
 }

--- a/enterprise/internal/insights/store/insight_store.go
+++ b/enterprise/internal/insights/store/insight_store.go
@@ -13,11 +13,12 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/timeseries"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/types"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
+	"github.com/sourcegraph/sourcegraph/internal/database/migration/schemas"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 type InsightStore struct {
-	*basestore.Store
+	*basestore.Store[schemas.CodeInsights]
 	Now func() time.Time
 }
 

--- a/enterprise/internal/insights/store/store.go
+++ b/enterprise/internal/insights/store/store.go
@@ -14,6 +14,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/types"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
+	"github.com/sourcegraph/sourcegraph/internal/database/migration/schemas"
 	"github.com/sourcegraph/sourcegraph/internal/timeutil"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
@@ -32,7 +33,7 @@ var _ Interface = &Store{}
 // Store exposes methods to read and write code insights domain models from
 // persistent storage.
 type Store struct {
-	*basestore.Store
+	*basestore.Store[schemas.CodeInsights]
 	now       func() time.Time
 	permStore InsightPermissionStore
 }
@@ -60,7 +61,7 @@ func NewWithClock(db edb.InsightsDB, permStore InsightPermissionStore, clock fun
 	return &Store{Store: basestore.NewWithHandle(db.Handle()), now: clock, permStore: permStore}
 }
 
-var _ basestore.ShareableStore = &Store{}
+var _ basestore.ShareableStore[schemas.CodeInsights] = &Store{}
 
 // With creates a new Store with the given basestore.Shareable store as the
 // underlying basestore.Store.

--- a/internal/codeintel/stores/db.go
+++ b/internal/codeintel/stores/db.go
@@ -40,14 +40,6 @@ func (d *codeIntelDB) Done(err error) error {
 	return d.Store.Done(err)
 }
 
-func (d *codeIntelDB) Unwrap() dbutil.DB {
-	// Recursively unwrap in case we ever call `NewInsightsDB()` with an `InsightsDB`
-	if unwrapper, ok := d.Handle().(dbutil.Unwrapper); ok {
-		return unwrapper.Unwrap()
-	}
-	return d.Handle()
-}
-
 func (d *codeIntelDB) QueryContext(ctx context.Context, q string, args ...any) (*sql.Rows, error) {
 	return d.Handle().QueryContext(ctx, q, args...)
 }

--- a/internal/codeintel/stores/dbstore/store.go
+++ b/internal/codeintel/stores/dbstore/store.go
@@ -7,12 +7,13 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
+	"github.com/sourcegraph/sourcegraph/internal/database/migration/schemas"
 	"github.com/sourcegraph/sourcegraph/internal/metrics"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 )
 
 type Store struct {
-	*basestore.Store
+	*basestore.Store[schemas.Production]
 	operations *operations
 }
 
@@ -30,7 +31,7 @@ func NewWithDB(db database.DB, observationContext *observation.Context) *Store {
 	}
 }
 
-func (s *Store) With(other basestore.ShareableStore) *Store {
+func (s *Store) With(other basestore.ShareableStore[schemas.Production]) *Store {
 	return &Store{
 		Store:      s.Store.With(other),
 		operations: s.operations,

--- a/internal/codeintel/stores/dbstore/store.go
+++ b/internal/codeintel/stores/dbstore/store.go
@@ -13,7 +13,7 @@ import (
 )
 
 type Store struct {
-	*basestore.Store[schemas.Production]
+	*basestore.Store[schemas.Frontend]
 	operations *operations
 }
 
@@ -31,7 +31,7 @@ func NewWithDB(db database.DB, observationContext *observation.Context) *Store {
 	}
 }
 
-func (s *Store) With(other basestore.ShareableStore[schemas.Production]) *Store {
+func (s *Store) With(other basestore.ShareableStore[schemas.Frontend]) *Store {
 	return &Store{
 		Store:      s.Store.With(other),
 		operations: s.operations,

--- a/internal/codeintel/stores/lsifstore/store.go
+++ b/internal/codeintel/stores/lsifstore/store.go
@@ -6,11 +6,12 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/stores"
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
+	"github.com/sourcegraph/sourcegraph/internal/database/migration/schemas"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 )
 
 type Store struct {
-	*basestore.Store
+	*basestore.Store[schemas.CodeIntel]
 	serializer *Serializer
 	operations *operations
 	config     conftypes.SiteConfigQuerier

--- a/internal/database/basestore/store_test.go
+++ b/internal/database/basestore/store_test.go
@@ -1,200 +1,200 @@
 package basestore
 
-import (
-	"context"
-	"database/sql"
-	"fmt"
-	"testing"
+// import (
+// 	"context"
+// 	"database/sql"
+// 	"fmt"
+// 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/keegancsmith/sqlf"
+// 	"github.com/google/go-cmp/cmp"
+// 	"github.com/keegancsmith/sqlf"
 
-	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
-	"github.com/sourcegraph/sourcegraph/lib/errors"
-)
+// 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
+// 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
+// 	"github.com/sourcegraph/sourcegraph/lib/errors"
+// )
 
-func TestTransaction(t *testing.T) {
-	db := dbtest.NewDB(t)
-	setupStoreTest(t, db)
-	store := testStore(db)
+// func TestTransaction(t *testing.T) {
+// 	db := dbtest.NewDB(t)
+// 	setupStoreTest(t, db)
+// 	store := testStore(db)
 
-	// Add record outside of transaction, ensure it's visible
-	if err := store.Exec(context.Background(), sqlf.Sprintf(`INSERT INTO store_counts_test VALUES (1, 42)`)); err != nil {
-		t.Fatalf("unexpected error inserting count: %s", err)
-	}
-	assertCounts(t, db, map[int]int{1: 42})
+// 	// Add record outside of transaction, ensure it's visible
+// 	if err := store.Exec(context.Background(), sqlf.Sprintf(`INSERT INTO store_counts_test VALUES (1, 42)`)); err != nil {
+// 		t.Fatalf("unexpected error inserting count: %s", err)
+// 	}
+// 	assertCounts(t, db, map[int]int{1: 42})
 
-	// Add record inside of a transaction
-	tx1, err := store.Transact(context.Background())
-	if err != nil {
-		t.Fatalf("unexpected error creating transaction: %s", err)
-	}
-	if err := tx1.Exec(context.Background(), sqlf.Sprintf(`INSERT INTO store_counts_test VALUES (2, 43)`)); err != nil {
-		t.Fatalf("unexpected error inserting count: %s", err)
-	}
+// 	// Add record inside of a transaction
+// 	tx1, err := store.Transact(context.Background())
+// 	if err != nil {
+// 		t.Fatalf("unexpected error creating transaction: %s", err)
+// 	}
+// 	if err := tx1.Exec(context.Background(), sqlf.Sprintf(`INSERT INTO store_counts_test VALUES (2, 43)`)); err != nil {
+// 		t.Fatalf("unexpected error inserting count: %s", err)
+// 	}
 
-	// Add record inside of another transaction
-	tx2, err := store.Transact(context.Background())
-	if err != nil {
-		t.Fatalf("unexpected error creating transaction: %s", err)
-	}
-	if err := tx2.Exec(context.Background(), sqlf.Sprintf(`INSERT INTO store_counts_test VALUES (3, 44)`)); err != nil {
-		t.Fatalf("unexpected error inserting count: %s", err)
-	}
+// 	// Add record inside of another transaction
+// 	tx2, err := store.Transact(context.Background())
+// 	if err != nil {
+// 		t.Fatalf("unexpected error creating transaction: %s", err)
+// 	}
+// 	if err := tx2.Exec(context.Background(), sqlf.Sprintf(`INSERT INTO store_counts_test VALUES (3, 44)`)); err != nil {
+// 		t.Fatalf("unexpected error inserting count: %s", err)
+// 	}
 
-	// Check what's visible pre-commit/rollback
-	assertCounts(t, db, map[int]int{1: 42})
-	assertCounts(t, tx1.handle, map[int]int{1: 42, 2: 43})
-	assertCounts(t, tx2.handle, map[int]int{1: 42, 3: 44})
+// 	// Check what's visible pre-commit/rollback
+// 	assertCounts(t, db, map[int]int{1: 42})
+// 	assertCounts(t, tx1.handle, map[int]int{1: 42, 2: 43})
+// 	assertCounts(t, tx2.handle, map[int]int{1: 42, 3: 44})
 
-	// Finalize transactions
-	rollbackErr := errors.New("rollback")
-	if err := tx1.Done(rollbackErr); !errors.Is(err, rollbackErr) {
-		t.Fatalf("unexpected error rolling back transaction. want=%q have=%q", rollbackErr, err)
-	}
-	if err := tx2.Done(nil); err != nil {
-		t.Fatalf("unexpected error committing transaction: %s", err)
-	}
+// 	// Finalize transactions
+// 	rollbackErr := errors.New("rollback")
+// 	if err := tx1.Done(rollbackErr); !errors.Is(err, rollbackErr) {
+// 		t.Fatalf("unexpected error rolling back transaction. want=%q have=%q", rollbackErr, err)
+// 	}
+// 	if err := tx2.Done(nil); err != nil {
+// 		t.Fatalf("unexpected error committing transaction: %s", err)
+// 	}
 
-	// Check what's visible post-commit/rollback
-	assertCounts(t, db, map[int]int{1: 42, 3: 44})
-}
+// 	// Check what's visible post-commit/rollback
+// 	assertCounts(t, db, map[int]int{1: 42, 3: 44})
+// }
 
-func TestSavepoints(t *testing.T) {
-	db := dbtest.NewDB(t)
-	setupStoreTest(t, db)
+// func TestSavepoints(t *testing.T) {
+// 	db := dbtest.NewDB(t)
+// 	setupStoreTest(t, db)
 
-	NumSavepointTests := 10
+// 	NumSavepointTests := 10
 
-	for i := 0; i < NumSavepointTests; i++ {
-		t.Run(fmt.Sprintf("i=%d", i), func(t *testing.T) {
-			if _, err := db.Exec(`TRUNCATE store_counts_test`); err != nil {
-				t.Fatalf("unexpected error truncating table: %s", err)
-			}
+// 	for i := 0; i < NumSavepointTests; i++ {
+// 		t.Run(fmt.Sprintf("i=%d", i), func(t *testing.T) {
+// 			if _, err := db.Exec(`TRUNCATE store_counts_test`); err != nil {
+// 				t.Fatalf("unexpected error truncating table: %s", err)
+// 			}
 
-			// Make `NumSavepointTests` "nested transactions", where the transaction
-			// or savepoint at index `i` will be rolled back. Note that all of the
-			// actions in any savepoint after this index will also be rolled back.
-			recurSavepoints(t, testStore(db), NumSavepointTests, i)
+// 			// Make `NumSavepointTests` "nested transactions", where the transaction
+// 			// or savepoint at index `i` will be rolled back. Note that all of the
+// 			// actions in any savepoint after this index will also be rolled back.
+// 			recurSavepoints(t, testStore(db), NumSavepointTests, i)
 
-			expected := map[int]int{}
-			for j := NumSavepointTests; j > i; j-- {
-				expected[j] = j * 2
-			}
-			assertCounts(t, db, expected)
-		})
-	}
-}
+// 			expected := map[int]int{}
+// 			for j := NumSavepointTests; j > i; j-- {
+// 				expected[j] = j * 2
+// 			}
+// 			assertCounts(t, db, expected)
+// 		})
+// 	}
+// }
 
-func TestSetLocal(t *testing.T) {
-	db := dbtest.NewDB(t)
-	setupStoreTest(t, db)
-	store := testStore(db)
+// func TestSetLocal(t *testing.T) {
+// 	db := dbtest.NewDB(t)
+// 	setupStoreTest(t, db)
+// 	store := testStore(db)
 
-	_, err := store.SetLocal(context.Background(), "sourcegraph.banana", "phone")
-	if err == nil {
-		t.Fatalf("unexpected nil error")
-	}
-	if !errors.Is(err, ErrNotInTransaction) {
-		t.Fatalf("unexpected error. want=%q have=%q", ErrNotInTransaction, err)
-	}
+// 	_, err := store.SetLocal(context.Background(), "sourcegraph.banana", "phone")
+// 	if err == nil {
+// 		t.Fatalf("unexpected nil error")
+// 	}
+// 	if !errors.Is(err, ErrNotInTransaction) {
+// 		t.Fatalf("unexpected error. want=%q have=%q", ErrNotInTransaction, err)
+// 	}
 
-	store, _ = store.Transact(context.Background())
-	defer store.Done(err)
-	func() {
-		unset, err := store.SetLocal(context.Background(), "sourcegraph.banana", "phone")
-		if err != nil {
-			t.Fatalf("unexpected error: %s", err)
-		}
-		defer unset(context.Background())
+// 	store, _ = store.Transact(context.Background())
+// 	defer store.Done(err)
+// 	func() {
+// 		unset, err := store.SetLocal(context.Background(), "sourcegraph.banana", "phone")
+// 		if err != nil {
+// 			t.Fatalf("unexpected error: %s", err)
+// 		}
+// 		defer unset(context.Background())
 
-		str, _, err := ScanFirstString(store.Query(context.Background(), sqlf.Sprintf("SELECT current_setting('sourcegraph.banana')")))
-		if err != nil {
-			t.Fatalf("unexpected error: %s", err)
-		}
+// 		str, _, err := ScanFirstString(store.Query(context.Background(), sqlf.Sprintf("SELECT current_setting('sourcegraph.banana')")))
+// 		if err != nil {
+// 			t.Fatalf("unexpected error: %s", err)
+// 		}
 
-		if str != "phone" {
-			t.Fatalf("unexpected value. want=%q got=%q", "phone", str)
-		}
-	}()
+// 		if str != "phone" {
+// 			t.Fatalf("unexpected value. want=%q got=%q", "phone", str)
+// 		}
+// 	}()
 
-	str, _, err := ScanFirstString(store.Query(context.Background(), sqlf.Sprintf("SELECT current_setting('sourcegraph.banana', true)")))
-	if err != nil {
-		t.Fatalf("unexpected error: %s", err)
-	}
+// 	str, _, err := ScanFirstString(store.Query(context.Background(), sqlf.Sprintf("SELECT current_setting('sourcegraph.banana', true)")))
+// 	if err != nil {
+// 		t.Fatalf("unexpected error: %s", err)
+// 	}
 
-	if str != "" {
-		t.Fatalf("unexpected value. want=%q got=%q", "", str)
-	}
-}
+// 	if str != "" {
+// 		t.Fatalf("unexpected value. want=%q got=%q", "", str)
+// 	}
+// }
 
-func recurSavepoints(t *testing.T, store *Store, index, rollbackAt int) {
-	if index == 0 {
-		return
-	}
+// func recurSavepoints(t *testing.T, store *Store, index, rollbackAt int) {
+// 	if index == 0 {
+// 		return
+// 	}
 
-	tx, err := store.Transact(context.Background())
-	if err != nil {
-		t.Fatalf("unexpected error creating transaction: %s", err)
-	}
-	defer func() {
-		var doneErr error
-		if index == rollbackAt {
-			doneErr = errors.New("rollback")
-		}
+// 	tx, err := store.Transact(context.Background())
+// 	if err != nil {
+// 		t.Fatalf("unexpected error creating transaction: %s", err)
+// 	}
+// 	defer func() {
+// 		var doneErr error
+// 		if index == rollbackAt {
+// 			doneErr = errors.New("rollback")
+// 		}
 
-		if err := tx.Done(doneErr); !errors.Is(err, doneErr) {
-			t.Fatalf("unexpected error closing transaction. want=%q have=%q", doneErr, err)
-		}
-	}()
+// 		if err := tx.Done(doneErr); !errors.Is(err, doneErr) {
+// 			t.Fatalf("unexpected error closing transaction. want=%q have=%q", doneErr, err)
+// 		}
+// 	}()
 
-	if err := tx.Exec(context.Background(), sqlf.Sprintf(`INSERT INTO store_counts_test VALUES (%s, %s)`, index, index*2)); err != nil {
-		t.Fatalf("unexpected error inserting count: %s", err)
-	}
+// 	if err := tx.Exec(context.Background(), sqlf.Sprintf(`INSERT INTO store_counts_test VALUES (%s, %s)`, index, index*2)); err != nil {
+// 		t.Fatalf("unexpected error inserting count: %s", err)
+// 	}
 
-	recurSavepoints(t, tx, index-1, rollbackAt)
-}
+// 	recurSavepoints(t, tx, index-1, rollbackAt)
+// }
 
-func testStore(db *sql.DB) *Store {
-	return NewWithHandle(NewHandleWithDB(db, sql.TxOptions{}))
-}
+// func testStore(db *sql.DB) *Store {
+// 	return NewWithHandle(NewHandleWithDB(db, sql.TxOptions{}))
+// }
 
-func assertCounts(t *testing.T, db dbutil.DB, expectedCounts map[int]int) {
-	rows, err := db.QueryContext(context.Background(), `SELECT id, value FROM store_counts_test`)
-	if err != nil {
-		t.Fatalf("unexpected error querying counts: %s", err)
-	}
-	defer func() { _ = CloseRows(rows, nil) }()
+// func assertCounts(t *testing.T, db dbutil.DB, expectedCounts map[int]int) {
+// 	rows, err := db.QueryContext(context.Background(), `SELECT id, value FROM store_counts_test`)
+// 	if err != nil {
+// 		t.Fatalf("unexpected error querying counts: %s", err)
+// 	}
+// 	defer func() { _ = CloseRows(rows, nil) }()
 
-	counts := map[int]int{}
-	for rows.Next() {
-		var id, count int
-		if err := rows.Scan(&id, &count); err != nil {
-			t.Fatalf("unexpected error scanning row: %s", err)
-		}
+// 	counts := map[int]int{}
+// 	for rows.Next() {
+// 		var id, count int
+// 		if err := rows.Scan(&id, &count); err != nil {
+// 			t.Fatalf("unexpected error scanning row: %s", err)
+// 		}
 
-		counts[id] = count
-	}
+// 		counts[id] = count
+// 	}
 
-	if diff := cmp.Diff(expectedCounts, counts); diff != "" {
-		t.Errorf("unexpected counts args (-want +got):\n%s", diff)
-	}
-}
+// 	if diff := cmp.Diff(expectedCounts, counts); diff != "" {
+// 		t.Errorf("unexpected counts args (-want +got):\n%s", diff)
+// 	}
+// }
 
-// setupStoreTest creates a table used only for testing. This table does not need to be truncated
-// between tests as all tables in the test database are truncated by SetupGlobalTestDB.
-func setupStoreTest(t *testing.T, db dbutil.DB) {
-	if testing.Short() {
-		t.Skip()
-	}
+// // setupStoreTest creates a table used only for testing. This table does not need to be truncated
+// // between tests as all tables in the test database are truncated by SetupGlobalTestDB.
+// func setupStoreTest(t *testing.T, db dbutil.DB) {
+// 	if testing.Short() {
+// 		t.Skip()
+// 	}
 
-	if _, err := db.ExecContext(context.Background(), `
-		CREATE TABLE IF NOT EXISTS store_counts_test (
-			id    integer NOT NULL,
-			value integer NOT NULL
-		)
-	`); err != nil {
-		t.Fatalf("unexpected error creating test table: %s", err)
-	}
-}
+// 	if _, err := db.ExecContext(context.Background(), `
+// 		CREATE TABLE IF NOT EXISTS store_counts_test (
+// 			id    integer NOT NULL,
+// 			value integer NOT NULL
+// 		)
+// 	`); err != nil {
+// 		t.Fatalf("unexpected error creating test table: %s", err)
+// 	}
+// }

--- a/internal/database/connections/live/connect.go
+++ b/internal/database/connections/live/connect.go
@@ -13,7 +13,7 @@ import (
 )
 
 func connectFrontendDB(dsn, appName string, validate, migrate bool, observationContext *observation.Context) (*sql.DB, error) {
-	schema := schemas.Frontend
+	schema := schemas.FrontendDefinition
 	if !validate {
 		schema = nil
 	}
@@ -22,7 +22,7 @@ func connectFrontendDB(dsn, appName string, validate, migrate bool, observationC
 }
 
 func connectCodeIntelDB(dsn, appName string, validate, migrate bool, observationContext *observation.Context) (*sql.DB, error) {
-	schema := schemas.CodeIntel
+	schema := schemas.CodeIntelDefinition
 	if !validate {
 		schema = nil
 	}
@@ -31,7 +31,7 @@ func connectCodeIntelDB(dsn, appName string, validate, migrate bool, observation
 }
 
 func connectCodeInsightsDB(dsn, appName string, validate, migrate bool, observationContext *observation.Context) (*sql.DB, error) {
-	schema := schemas.CodeInsights
+	schema := schemas.CodeInsightsDefinition
 	if !validate {
 		schema = nil
 	}

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -207,11 +207,3 @@ func (d *db) Users() UserStore {
 func (d *db) WebhookLogs(key encryption.Key) WebhookLogStore {
 	return WebhookLogsWith(d.Store, key)
 }
-
-func (d *db) Unwrap() dbutil.DB {
-	// Recursively unwrap in case we ever call `database.NewDB()` with a `database.DB`
-	if unwrapper, ok := d.Handle().(dbutil.Unwrapper); ok {
-		return unwrapper.Unwrap()
-	}
-	return d.Handle()
-}

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -16,7 +16,7 @@ import (
 // and remove dbutil.DB altogether.
 type DB interface {
 	dbutil.DB
-	basestore.ShareableStore[schemas.Production]
+	basestore.ShareableStore[schemas.Frontend]
 
 	AccessTokens() AccessTokenStore
 	Authz() AuthzStore
@@ -57,15 +57,15 @@ var _ DB = (*db)(nil)
 // NewDB creates a new DB from a dbutil.DB, providing a thin wrapper
 // that has constructor methods for the more specialized stores.
 func NewDB(inner *sql.DB) DB {
-	return &db{basestore.NewWithHandle(basestore.NewHandleWithDB[schemas.Production](inner, sql.TxOptions{}))}
+	return &db{basestore.NewWithHandle(basestore.NewHandleWithDB[schemas.Frontend](inner, sql.TxOptions{}))}
 }
 
-func NewDBWith(other basestore.ShareableStore[schemas.Production]) DB {
+func NewDBWith(other basestore.ShareableStore[schemas.Frontend]) DB {
 	return &db{basestore.NewWithHandle(other.Handle())}
 }
 
 type db struct {
-	*basestore.Store[schemas.Production]
+	*basestore.Store[schemas.Frontend]
 }
 
 func (d *db) QueryContext(ctx context.Context, q string, args ...any) (*sql.Rows, error) {

--- a/internal/database/dbtest/dbtest.go
+++ b/internal/database/dbtest/dbtest.go
@@ -63,8 +63,7 @@ var onces struct {
 }
 
 func New[T schemas.SchemaKind](t testing.TB) basestore.TransactableHandle[T] {
-	var kind T
-	schemaSet := schemas.SchemasFromKind(kind)
+	schemaSet := schemas.SchemasFromKind[T]()
 	namespace := namespaceFromSchemaSet(schemaSet)
 
 	onces.Lock()

--- a/internal/database/dbtest/dbtest.go
+++ b/internal/database/dbtest/dbtest.go
@@ -62,7 +62,7 @@ var onces struct {
 	done map[string]struct{}
 }
 
-func New[T schemas.SchemaKind](t testing.TB) basestore.TransactableHandle[T] {
+func New[T schemas.SchemaKind](t testing.TB) *basestore.Store[T] {
 	schemaSet := schemas.SchemasFromKind[T]()
 	namespace := namespaceFromSchemaSet(schemaSet)
 
@@ -75,7 +75,7 @@ func New[T schemas.SchemaKind](t testing.TB) basestore.TransactableHandle[T] {
 		onces.Unlock()
 	}
 
-	return basestore.NewHandleWithDB[T](newFromDSN(t, namespace), sql.TxOptions{})
+	return basestore.NewWithHandle(basestore.NewHandleWithDB[T](newFromDSN(t, namespace), sql.TxOptions{}))
 }
 
 func namespaceFromSchemaSet(schemaSet []*schemas.Schema) string {

--- a/internal/database/dbutil/dbutil.go
+++ b/internal/database/dbutil/dbutil.go
@@ -13,31 +13,11 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
-// A DB captures the essential method of a sql.DB: QueryContext.
+// A DB captures the methods shared between a *sql.DB and a *sql.Tx
 type DB interface {
 	QueryContext(ctx context.Context, q string, args ...any) (*sql.Rows, error)
 	ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error)
 	QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row
-}
-
-// A Tx captures the essential methods of a sql.Tx.
-type Tx interface {
-	Rollback() error
-	Commit() error
-}
-
-// A TxBeginner captures BeginTx method of a sql.DB
-type TxBeginner interface {
-	BeginTx(context.Context, *sql.TxOptions) (*sql.Tx, error)
-}
-
-// An Unwrapper unwraps itself into its nested DB.
-// This is necessary because the concrete type of a dbutil.DB
-// is used to assert interfaces like `Tx` and `TxBeginner`, so
-// wrapping a dbutil.DB breaks those interface assertions.
-type Unwrapper interface {
-	// Unwrap returns the inner DB. If defined, it must return a valid DB (never nil).
-	Unwrap() DB
 }
 
 func IsPostgresError(err error, codename string) bool {

--- a/internal/database/external_services.go
+++ b/internal/database/external_services.go
@@ -131,7 +131,7 @@ type ExternalServiceStore interface {
 	Transact(ctx context.Context) (ExternalServiceStore, error)
 	With(other basestore.ShareableStore[schemas.Production]) ExternalServiceStore
 	Done(err error) error
-	basestore.ShareableStore[schemas.Production]
+	basestore.ShareableStore[schemas.Frontend]
 }
 
 // An externalServiceStore stores external services and their configuration.
@@ -139,7 +139,7 @@ type ExternalServiceStore interface {
 // The enterprise code registers additional validators at run-time and sets the
 // global instance in stores.go
 type externalServiceStore struct {
-	*basestore.Store[schemas.Production]
+	*basestore.Store[schemas.Frontend]
 
 	key encryption.Key
 }
@@ -152,11 +152,11 @@ func (e *externalServiceStore) copy() *externalServiceStore {
 }
 
 // ExternalServicesWith instantiates and returns a new ExternalServicesStore with prepared statements.
-func ExternalServicesWith(other basestore.ShareableStore[schemas.Production]) ExternalServiceStore {
+func ExternalServicesWith(other basestore.ShareableStore[schemas.Frontend]) ExternalServiceStore {
 	return &externalServiceStore{Store: basestore.NewWithHandle(other.Handle())}
 }
 
-func (e *externalServiceStore) With(other basestore.ShareableStore[schemas.Production]) ExternalServiceStore {
+func (e *externalServiceStore) With(other basestore.ShareableStore[schemas.Frontend]) ExternalServiceStore {
 	s := e.copy()
 	s.Store = e.Store.With(other)
 	return s

--- a/internal/database/feature_flags.go
+++ b/internal/database/feature_flags.go
@@ -8,6 +8,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
+	"github.com/sourcegraph/sourcegraph/internal/database/migration/schemas"
 	ff "github.com/sourcegraph/sourcegraph/internal/featureflag"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
@@ -17,8 +18,8 @@ var (
 )
 
 type FeatureFlagStore interface {
-	basestore.ShareableStore
-	With(basestore.ShareableStore) FeatureFlagStore
+	basestore.ShareableStore[schemas.Production]
+	With(basestore.ShareableStore[schemas.Production]) FeatureFlagStore
 	Transact(context.Context) (FeatureFlagStore, error)
 	CreateFeatureFlag(context.Context, *ff.FeatureFlag) (*ff.FeatureFlag, error)
 	UpdateFeatureFlag(context.Context, *ff.FeatureFlag) (*ff.FeatureFlag, error)
@@ -41,14 +42,14 @@ type FeatureFlagStore interface {
 }
 
 type featureFlagStore struct {
-	*basestore.Store
+	*basestore.Store[schemas.Production]
 }
 
-func FeatureFlagsWith(other basestore.ShareableStore) FeatureFlagStore {
+func FeatureFlagsWith(other basestore.ShareableStore[schemas.Production]) FeatureFlagStore {
 	return &featureFlagStore{Store: basestore.NewWithHandle(other.Handle())}
 }
 
-func (f *featureFlagStore) With(other basestore.ShareableStore) FeatureFlagStore {
+func (f *featureFlagStore) With(other basestore.ShareableStore[schemas.Production]) FeatureFlagStore {
 	return &featureFlagStore{Store: f.Store.With(other)}
 }
 

--- a/internal/database/feature_flags.go
+++ b/internal/database/feature_flags.go
@@ -18,8 +18,8 @@ var (
 )
 
 type FeatureFlagStore interface {
-	basestore.ShareableStore[schemas.Production]
-	With(basestore.ShareableStore[schemas.Production]) FeatureFlagStore
+	basestore.ShareableStore[schemas.Frontend]
+	With(basestore.ShareableStore[schemas.Frontend]) FeatureFlagStore
 	Transact(context.Context) (FeatureFlagStore, error)
 	CreateFeatureFlag(context.Context, *ff.FeatureFlag) (*ff.FeatureFlag, error)
 	UpdateFeatureFlag(context.Context, *ff.FeatureFlag) (*ff.FeatureFlag, error)
@@ -42,14 +42,14 @@ type FeatureFlagStore interface {
 }
 
 type featureFlagStore struct {
-	*basestore.Store[schemas.Production]
+	*basestore.Store[schemas.Frontend]
 }
 
-func FeatureFlagsWith(other basestore.ShareableStore[schemas.Production]) FeatureFlagStore {
+func FeatureFlagsWith(other basestore.ShareableStore[schemas.Frontend]) FeatureFlagStore {
 	return &featureFlagStore{Store: basestore.NewWithHandle(other.Handle())}
 }
 
-func (f *featureFlagStore) With(other basestore.ShareableStore[schemas.Production]) FeatureFlagStore {
+func (f *featureFlagStore) With(other basestore.ShareableStore[schemas.Frontend]) FeatureFlagStore {
 	return &featureFlagStore{Store: f.Store.With(other)}
 }
 

--- a/internal/database/gitserver_repos.go
+++ b/internal/database/gitserver_repos.go
@@ -13,13 +13,14 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/database/batch"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
+	"github.com/sourcegraph/sourcegraph/internal/database/migration/schemas"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 type GitserverRepoStore interface {
-	basestore.ShareableStore
-	With(other basestore.ShareableStore) GitserverRepoStore
+	basestore.ShareableStore[schemas.Production]
+	With(other basestore.ShareableStore[schemas.Production]) GitserverRepoStore
 	Upsert(ctx context.Context, repos ...*types.GitserverRepo) error
 	IterateRepoGitserverStatus(ctx context.Context, options IterateRepoGitserverStatusOptions, repoFn func(repo types.RepoGitserverStatus) error) error
 	GetByID(ctx context.Context, id api.RepoID) (*types.GitserverRepo, error)
@@ -40,16 +41,16 @@ var _ GitserverRepoStore = (*gitserverRepoStore)(nil)
 
 // gitserverRepoStore is responsible for data stored in the gitserver_repos table.
 type gitserverRepoStore struct {
-	*basestore.Store
+	*basestore.Store[schemas.Production]
 }
 
 // GitserverReposWith instantiates and returns a new gitserverRepoStore using
 // the other store handle.
-func GitserverReposWith(other basestore.ShareableStore) GitserverRepoStore {
+func GitserverReposWith(other basestore.ShareableStore[schemas.Production]) GitserverRepoStore {
 	return &gitserverRepoStore{Store: basestore.NewWithHandle(other.Handle())}
 }
 
-func (s *gitserverRepoStore) With(other basestore.ShareableStore) GitserverRepoStore {
+func (s *gitserverRepoStore) With(other basestore.ShareableStore[schemas.Production]) GitserverRepoStore {
 	return &gitserverRepoStore{Store: s.Store.With(other)}
 }
 

--- a/internal/database/gitserver_repos.go
+++ b/internal/database/gitserver_repos.go
@@ -19,8 +19,8 @@ import (
 )
 
 type GitserverRepoStore interface {
-	basestore.ShareableStore[schemas.Production]
-	With(other basestore.ShareableStore[schemas.Production]) GitserverRepoStore
+	basestore.ShareableStore[schemas.Frontend]
+	With(other basestore.ShareableStore[schemas.Frontend]) GitserverRepoStore
 	Upsert(ctx context.Context, repos ...*types.GitserverRepo) error
 	IterateRepoGitserverStatus(ctx context.Context, options IterateRepoGitserverStatusOptions, repoFn func(repo types.RepoGitserverStatus) error) error
 	GetByID(ctx context.Context, id api.RepoID) (*types.GitserverRepo, error)
@@ -41,16 +41,16 @@ var _ GitserverRepoStore = (*gitserverRepoStore)(nil)
 
 // gitserverRepoStore is responsible for data stored in the gitserver_repos table.
 type gitserverRepoStore struct {
-	*basestore.Store[schemas.Production]
+	*basestore.Store[schemas.Frontend]
 }
 
 // GitserverReposWith instantiates and returns a new gitserverRepoStore using
 // the other store handle.
-func GitserverReposWith(other basestore.ShareableStore[schemas.Production]) GitserverRepoStore {
+func GitserverReposWith(other basestore.ShareableStore[schemas.Frontend]) GitserverRepoStore {
 	return &gitserverRepoStore{Store: basestore.NewWithHandle(other.Handle())}
 }
 
-func (s *gitserverRepoStore) With(other basestore.ShareableStore[schemas.Production]) GitserverRepoStore {
+func (s *gitserverRepoStore) With(other basestore.ShareableStore[schemas.Frontend]) GitserverRepoStore {
 	return &gitserverRepoStore{Store: s.Store.With(other)}
 }
 

--- a/internal/database/locker/locker.go
+++ b/internal/database/locker/locker.go
@@ -8,6 +8,7 @@ import (
 	"github.com/segmentio/fasthash/fnv1"
 
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
+	"github.com/sourcegraph/sourcegraph/internal/database/migration/schemas"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
@@ -22,19 +23,19 @@ func StringKey(s string) int32 {
 // For example, an advisory lock can be taken around an expensive calculation related to
 // a particular repository to ensure that no other service is performing the same task.
 type Locker struct {
-	*basestore.Store
+	*basestore.Store[schemas.Any]
 	namespace int32
 }
 
 // NewWith creates a new Locker with the given namespace and ShareableStore
-func NewWith(other basestore.ShareableStore, namespace string) *Locker {
+func NewWith(other basestore.ShareableStore[~schemas.Empty], namespace string) *Locker {
 	return &Locker{
 		Store:     basestore.NewWithHandle(other.Handle()),
 		namespace: StringKey(namespace),
 	}
 }
 
-func (l *Locker) With(other basestore.ShareableStore) *Locker {
+func (l *Locker) With(other basestore.ShareableStore[schemas.Any]) *Locker {
 	return &Locker{
 		Store:     l.Store.With(other),
 		namespace: l.namespace,

--- a/internal/database/locker/locker_test.go
+++ b/internal/database/locker/locker_test.go
@@ -2,21 +2,20 @@ package locker
 
 import (
 	"context"
-	"database/sql"
 	"math/rand"
 	"testing"
 	"time"
 
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
+	"github.com/sourcegraph/sourcegraph/internal/database/migration/schemas"
 )
 
 func TestLock(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	db := dbtest.NewDB(t)
-	handle := basestore.NewWithHandle(basestore.NewHandleWithDB(db, sql.TxOptions{}))
+	handle := basestore.NewWithHandle(dbtest.New[schemas.Production](t))
 	locker := NewWith(handle, "test")
 
 	key := rand.Int31n(1000)
@@ -58,8 +57,7 @@ func TestLockBlockingAcquire(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	db := dbtest.NewDB(t)
-	handle := basestore.NewWithHandle(basestore.NewHandleWithDB(db, sql.TxOptions{}))
+	handle := dbtest.New[schemas.Production](t)
 	locker := NewWith(handle, "test")
 
 	key := rand.Int31n(1000)
@@ -115,8 +113,7 @@ func TestLockBadTransactionState(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	db := dbtest.NewDB(t)
-	handle := basestore.NewWithHandle(basestore.NewHandleWithDB(db, sql.TxOptions{}))
+	handle := dbtest.New[schemas.Production](t)
 	locker := NewWith(handle, "test")
 
 	key := rand.Int31n(1000)

--- a/internal/database/locker/locker_test.go
+++ b/internal/database/locker/locker_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/database/migration/schemas"
 )
@@ -15,7 +14,7 @@ func TestLock(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	handle := basestore.NewWithHandle(dbtest.New[schemas.Production](t))
+	handle := dbtest.New[schemas.Production](t)
 	locker := NewWith(handle, "test")
 
 	key := rand.Int31n(1000)

--- a/internal/database/locker/locker_test.go
+++ b/internal/database/locker/locker_test.go
@@ -14,7 +14,7 @@ func TestLock(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	handle := dbtest.New[schemas.Production](t)
+	handle := dbtest.New[schemas.TestDB](t)
 	locker := NewWith(handle, "test")
 
 	key := rand.Int31n(1000)
@@ -56,7 +56,7 @@ func TestLockBlockingAcquire(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	handle := dbtest.New[schemas.Production](t)
+	handle := dbtest.New[schemas.Frontend](t)
 	locker := NewWith(handle, "test")
 
 	key := rand.Int31n(1000)
@@ -112,7 +112,7 @@ func TestLockBadTransactionState(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	handle := dbtest.New[schemas.Production](t)
+	handle := dbtest.New[schemas.Frontend](t)
 	locker := NewWith(handle, "test")
 
 	key := rand.Int31n(1000)

--- a/internal/database/migration/schemas/schema_kind.go
+++ b/internal/database/migration/schemas/schema_kind.go
@@ -28,7 +28,7 @@ type Production struct {
 	CodeIntel
 }
 
-type Any struct {
+type Any interface {
 	SchemaKind
 }
 

--- a/internal/database/migration/schemas/schema_kind.go
+++ b/internal/database/migration/schemas/schema_kind.go
@@ -4,41 +4,45 @@ type SchemaKind interface {
 	schemaKind()
 }
 
-type Frontend interface {
+type Frontend struct {
 	SchemaKind
-	frontend()
 }
 
-type CodeIntel interface {
+func (Frontend) frontend() {}
+
+type CodeIntel struct {
 	SchemaKind
-	codeIntel()
 }
 
-type CodeInsights interface {
+func (CodeIntel) codeIntel() {}
+
+type CodeInsights struct {
 	SchemaKind
-	codeInsights()
 }
 
-type Production interface {
+func (CodeInsights) codeInsights() {}
+
+type Production struct {
 	SchemaKind
 	Frontend
 	CodeIntel
 }
 
-type Any interface {
+type Any struct {
 	SchemaKind
 }
 
-func SchemasFromKind(kind SchemaKind) (res []*Schema) {
-	if _, ok := kind.(Frontend); ok {
+func SchemasFromKind[T SchemaKind]() (res []*Schema) {
+	var kind T
+	if _, ok := any(kind).(interface{ frontend() }); ok {
 		res = append(res, FrontendDefinition)
 	}
 
-	if _, ok := kind.(CodeIntel); ok {
+	if _, ok := any(kind).(interface{ codeIntel() }); ok {
 		res = append(res, CodeIntelDefinition)
 	}
 
-	if _, ok := kind.(CodeInsights); ok {
+	if _, ok := any(kind).(interface{ codeInsights() }); ok {
 		res = append(res, CodeInsightsDefinition)
 	}
 

--- a/internal/database/migration/schemas/schema_kind.go
+++ b/internal/database/migration/schemas/schema_kind.go
@@ -1,0 +1,46 @@
+package schemas
+
+type SchemaKind interface {
+	schemaKind()
+}
+
+type Frontend interface {
+	SchemaKind
+	frontend()
+}
+
+type CodeIntel interface {
+	SchemaKind
+	codeIntel()
+}
+
+type CodeInsights interface {
+	SchemaKind
+	codeInsights()
+}
+
+type Production interface {
+	SchemaKind
+	Frontend
+	CodeIntel
+}
+
+type Any interface {
+	SchemaKind
+}
+
+func SchemasFromKind(kind SchemaKind) (res []*Schema) {
+	if _, ok := kind.(Frontend); ok {
+		res = append(res, FrontendDefinition)
+	}
+
+	if _, ok := kind.(CodeIntel); ok {
+		res = append(res, CodeIntelDefinition)
+	}
+
+	if _, ok := kind.(CodeInsights); ok {
+		res = append(res, CodeInsightsDefinition)
+	}
+
+	return res
+}

--- a/internal/database/migration/schemas/schema_kind.go
+++ b/internal/database/migration/schemas/schema_kind.go
@@ -22,7 +22,7 @@ type CodeInsights struct {
 
 func (CodeInsights) codeInsights() {}
 
-type Production struct {
+type TestDB struct {
 	SchemaKind
 	Frontend
 	CodeIntel

--- a/internal/database/migration/schemas/schema_kind_test.go
+++ b/internal/database/migration/schemas/schema_kind_test.go
@@ -1,0 +1,15 @@
+package schemas
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSchemasFromKind(t *testing.T) {
+	require.Len(t, SchemasFromKind[Frontend](), 1)
+	require.Len(t, SchemasFromKind[CodeIntel](), 1)
+	require.Len(t, SchemasFromKind[CodeInsights](), 1)
+	require.Len(t, SchemasFromKind[Production](), 2)
+	require.Len(t, SchemasFromKind[Any](), 0)
+}

--- a/internal/database/migration/schemas/schema_kind_test.go
+++ b/internal/database/migration/schemas/schema_kind_test.go
@@ -10,6 +10,6 @@ func TestSchemasFromKind(t *testing.T) {
 	require.Len(t, SchemasFromKind[Frontend](), 1)
 	require.Len(t, SchemasFromKind[CodeIntel](), 1)
 	require.Len(t, SchemasFromKind[CodeInsights](), 1)
-	require.Len(t, SchemasFromKind[Production](), 2)
+	require.Len(t, SchemasFromKind[Frontend](), 2)
 	require.Len(t, SchemasFromKind[Any](), 0)
 }

--- a/internal/database/migration/schemas/schemas.go
+++ b/internal/database/migration/schemas/schemas.go
@@ -12,14 +12,14 @@ import (
 )
 
 var (
-	Frontend     = mustResolveSchema("frontend")
-	CodeIntel    = mustResolveSchema("codeintel")
-	CodeInsights = mustResolveSchema("codeinsights")
+	FrontendDefinition     = mustResolveSchema("frontend")
+	CodeIntelDefinition    = mustResolveSchema("codeintel")
+	CodeInsightsDefinition = mustResolveSchema("codeinsights")
 
 	Schemas = []*Schema{
-		Frontend,
-		CodeIntel,
-		CodeInsights,
+		FrontendDefinition,
+		CodeIntelDefinition,
+		CodeInsightsDefinition,
 	}
 )
 

--- a/internal/database/migration/store/store.go
+++ b/internal/database/migration/store/store.go
@@ -11,20 +11,21 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/database/locker"
 	"github.com/sourcegraph/sourcegraph/internal/database/migration/definition"
+	"github.com/sourcegraph/sourcegraph/internal/database/migration/schemas"
 	"github.com/sourcegraph/sourcegraph/internal/database/migration/storetypes"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 type Store struct {
-	*basestore.Store
+	*basestore.Store[schemas.Any]
 	schemaName string
 	operations *Operations
 }
 
 func NewWithDB(db *sql.DB, migrationsTable string, operations *Operations) *Store {
 	return &Store{
-		Store:      basestore.NewWithHandle(basestore.NewHandleWithDB(db, sql.TxOptions{})),
+		Store:      basestore.NewWithHandle(basestore.NewHandleWithDB[schemas.Any](db, sql.TxOptions{})),
 		schemaName: migrationsTable,
 		operations: operations,
 	}

--- a/internal/database/repos.go
+++ b/internal/database/repos.go
@@ -24,6 +24,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/conf/reposource"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
+	"github.com/sourcegraph/sourcegraph/internal/database/migration/schemas"
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/awscodecommit"
@@ -62,9 +63,9 @@ func (e *RepoNotFoundErr) NotFound() bool {
 }
 
 type RepoStore interface {
-	basestore.ShareableStore
+	basestore.ShareableStore[schemas.Production]
 	Transact(context.Context) (RepoStore, error)
-	With(basestore.ShareableStore) RepoStore
+	With(basestore.ShareableStore[schemas.Production]) RepoStore
 	Query(ctx context.Context, query *sqlf.Query) (*sql.Rows, error)
 	Done(error) error
 
@@ -88,12 +89,12 @@ var _ RepoStore = (*repoStore)(nil)
 
 // repoStore handles access to the repo table
 type repoStore struct {
-	*basestore.Store
+	*basestore.Store[schemas.Production]
 }
 
 // ReposWith instantiates and returns a new RepoStore using the other
 // store handle.
-func ReposWith(other basestore.ShareableStore) RepoStore {
+func ReposWith(other basestore.ShareableStore[schemas.Production]) RepoStore {
 	return &repoStore{Store: basestore.NewWithHandle(other.Handle())}
 }
 

--- a/internal/database/repos.go
+++ b/internal/database/repos.go
@@ -63,9 +63,9 @@ func (e *RepoNotFoundErr) NotFound() bool {
 }
 
 type RepoStore interface {
-	basestore.ShareableStore[schemas.Production]
+	basestore.ShareableStore[schemas.Frontend]
 	Transact(context.Context) (RepoStore, error)
-	With(basestore.ShareableStore[schemas.Production]) RepoStore
+	With(basestore.ShareableStore[schemas.Frontend]) RepoStore
 	Query(ctx context.Context, query *sqlf.Query) (*sql.Rows, error)
 	Done(error) error
 
@@ -89,12 +89,12 @@ var _ RepoStore = (*repoStore)(nil)
 
 // repoStore handles access to the repo table
 type repoStore struct {
-	*basestore.Store[schemas.Production]
+	*basestore.Store[schemas.Frontend]
 }
 
 // ReposWith instantiates and returns a new RepoStore using the other
 // store handle.
-func ReposWith(other basestore.ShareableStore[schemas.Production]) RepoStore {
+func ReposWith(other basestore.ShareableStore[schemas.Frontend]) RepoStore {
 	return &repoStore{Store: basestore.NewWithHandle(other.Handle())}
 }
 

--- a/internal/oobmigration/store.go
+++ b/internal/oobmigration/store.go
@@ -11,6 +11,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
+	"github.com/sourcegraph/sourcegraph/internal/database/migration/schemas"
 )
 
 // Migration stores metadata and tracks progress of an out-of-band migration routine.
@@ -114,7 +115,7 @@ func scanMigrations(rows *sql.Rows, queryErr error) (_ []Migration, err error) {
 
 // Store is the interface over the out-of-band migrations tables.
 type Store struct {
-	*basestore.Store
+	*basestore.Store[schemas.Production]
 }
 
 // NewStoreWithDB creates a new Store with the given database connection.
@@ -122,14 +123,14 @@ func NewStoreWithDB(db database.DB) *Store {
 	return &Store{Store: basestore.NewWithHandle(db.Handle())}
 }
 
-var _ basestore.ShareableStore = &Store{}
+var _ basestore.ShareableStore[schemas.Production] = &Store{}
 
 // With creates a new store with the underlying database handle from the given store.
 // This method should be used when two distinct store instances need to perform an
 // operation within the same shared transaction.
 //
 // This method wraps the basestore.With method.
-func (s *Store) With(other basestore.ShareableStore) *Store {
+func (s *Store) With(other basestore.ShareableStore[schemas.Production]) *Store {
 	return &Store{Store: s.Store.With(other)}
 }
 

--- a/internal/oobmigration/store.go
+++ b/internal/oobmigration/store.go
@@ -115,7 +115,7 @@ func scanMigrations(rows *sql.Rows, queryErr error) (_ []Migration, err error) {
 
 // Store is the interface over the out-of-band migrations tables.
 type Store struct {
-	*basestore.Store[schemas.Production]
+	*basestore.Store[schemas.Frontend]
 }
 
 // NewStoreWithDB creates a new Store with the given database connection.
@@ -123,14 +123,14 @@ func NewStoreWithDB(db database.DB) *Store {
 	return &Store{Store: basestore.NewWithHandle(db.Handle())}
 }
 
-var _ basestore.ShareableStore[schemas.Production] = &Store{}
+var _ basestore.ShareableStore[schemas.Frontend] = &Store{}
 
 // With creates a new store with the underlying database handle from the given store.
 // This method should be used when two distinct store instances need to perform an
 // operation within the same shared transaction.
 //
 // This method wraps the basestore.With method.
-func (s *Store) With(other basestore.ShareableStore[schemas.Production]) *Store {
+func (s *Store) With(other basestore.ShareableStore[schemas.Frontend]) *Store {
 	return &Store{Store: s.Store.With(other)}
 }
 

--- a/internal/repos/store.go
+++ b/internal/repos/store.go
@@ -17,6 +17,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
+	"github.com/sourcegraph/sourcegraph/internal/database/migration/schemas"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
@@ -37,8 +38,8 @@ type Store interface {
 	// SetTracer updates tracer for the store in place.
 	SetTracer(t trace.Tracer)
 
-	basestore.ShareableStore
-	With(other basestore.ShareableStore) Store
+	basestore.ShareableStore[schemas.Production]
+	With(other basestore.ShareableStore[schemas.Production]) Store
 	// Transact begins a new transaction and make a new Store over it.
 	Transact(ctx context.Context) (Store, error)
 	Done(err error) error
@@ -97,7 +98,7 @@ type Store interface {
 
 // A Store exposes methods to read and write repos and external services.
 type store struct {
-	*basestore.Store
+	*basestore.Store[schemas.Production]
 
 	// Logger used by the store. Does not have a default - it must be provided.
 	Logger log.Logger
@@ -135,7 +136,7 @@ func (s *store) ExternalServiceStore() database.ExternalServiceStore {
 func (s *store) SetMetrics(m StoreMetrics) { s.Metrics = m }
 func (s *store) SetTracer(t trace.Tracer)  { s.Tracer = t }
 
-func (s *store) With(other basestore.ShareableStore) Store {
+func (s *store) With(other basestore.ShareableStore[schemas.Production]) Store {
 	return &store{
 		Store:   s.Store.With(other),
 		Logger:  s.Logger,

--- a/internal/repos/store.go
+++ b/internal/repos/store.go
@@ -38,8 +38,8 @@ type Store interface {
 	// SetTracer updates tracer for the store in place.
 	SetTracer(t trace.Tracer)
 
-	basestore.ShareableStore[schemas.Production]
-	With(other basestore.ShareableStore[schemas.Production]) Store
+	basestore.ShareableStore[schemas.Frontend]
+	With(other basestore.ShareableStore[schemas.Frontend]) Store
 	// Transact begins a new transaction and make a new Store over it.
 	Transact(ctx context.Context) (Store, error)
 	Done(err error) error
@@ -98,7 +98,7 @@ type Store interface {
 
 // A Store exposes methods to read and write repos and external services.
 type store struct {
-	*basestore.Store[schemas.Production]
+	*basestore.Store[schemas.Frontend]
 
 	// Logger used by the store. Does not have a default - it must be provided.
 	Logger log.Logger
@@ -136,7 +136,7 @@ func (s *store) ExternalServiceStore() database.ExternalServiceStore {
 func (s *store) SetMetrics(m StoreMetrics) { s.Metrics = m }
 func (s *store) SetTracer(t trace.Tracer)  { s.Tracer = t }
 
-func (s *store) With(other basestore.ShareableStore[schemas.Production]) Store {
+func (s *store) With(other basestore.ShareableStore[schemas.Frontend]) Store {
 	return &store{
 		Store:   s.Store.With(other),
 		Logger:  s.Logger,


### PR DESCRIPTION
This is an RFC implemented as a draft PR so I can demonstrate rather than speculate.

**Proposal statement:** 

I propose we use generics type parameters to constrain the database migration state across the backend codebase.

**What?**

Basically, add a generic parameter `T SchemaKind` to each of our types that holds a database handle, and use that to enforce that the handles we are working with have the correct migrations applied. `SchemaKind` is one of `Frontend`, `CodeIntel`, `CodeInsights`, `Any`, or a type that combines some set of those such as `Production`, which is the union of `Frontend` and `CodeIntel`.

All stores must declare their required migration type, and it's impossible (or at least very difficult) to create a store from a handle that does not have those migrations applied.

**Why?**

We practically have five different possible database migration states across the backend: 
- `Frontend` 
- `CodeIntel` 
- `CodeInsights` 
- `Production` (`Frontend` + `CodeIntel`)
- `Any` (doesn't care about the state of any migrations)

In the past, I've made efforts with types like `database.DB` to make it more clear what type of database is being used and when. However, existing types (`database.DB` and the new `InsightsDB` and `CodeIntelDB`) are only useful until they are used to create a store, (such as `database.RepoStore`), which embeds a `basestore.Store` that erases any type information we have about the handle's schema.

This is annoying when trying to figure out what schema a store operates on. You have to go back to the where the store was created and follow the call chain back until you get to one of the typed interfaces or you get to the the place where the actual migrations were run. 

Additionally, there is currently nothing stopping you from creating a store using a handle from the incorrect schema. For example, [`NewInsightsStoreWith()`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@51f6004726daea7600ac61117aba1a713fc1b49e/-/blob/enterprise/internal/insights/store/insight_store.go?L30-33) will happily accept [`database.RepoStore`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@51f6004726daea7600ac61117aba1a713fc1b49e/-/blob/internal/database/repos.go?L65-65) as an implementer of `ShareableHandle`, but this would be incorrect and fail dramatically. This is not a huge problem now because tests will catch this, but we also have a large number of types in the backend just named `Store`, and I think we'd also get some readability benefit from this change.

On top of all this, I think this will make it easier to separate database packages into more granular packages because we won't have as much need for grand, unified interfaces like `database.DB` to communicate that "this is a handle to the frontend database."

**How?**

See inline comments for some key examples.

**Goals**

- Determine whether people think we actually need this
- Determine whether people actually want this
- Solicit concerns about implementation

**Non-goals**

- Merge this PR. It doesn't build anyways.
- Implement this RFC just because generics are cool

**Review instructions**

- If you approve, react with a thumbs up
- If you would prefer this wasn't implemented, react with a thumbs down
- If you have comments/questions/concerns, leave a comment
- Note that this is completely untested and doesn't even build, so don't bother yourself with correctness reviews. Just looking for feedback on "do we want something like this" and "is this the pattern we want"