### PR TITLE
release: update dates to reflect agreed plan for 3.41

### DIFF
--- a/dev/release/release-config.jsonc
+++ b/dev/release/release-config.jsonc
@@ -16,10 +16,10 @@
     "previousRelease": "3.40.2",
     "upcomingRelease": "3.41.0",
     // Release dates
-    "oneWorkingWeekBeforeRelease": "15 June 2022 10:00 PST",
-    "oneWorkingDayBeforeRelease": "21 June 2022 10:00 PST",
-    "releaseDate": "22 June 2022 10:00 PST",
-    "oneWorkingDayAfterRelease": "23 June 2022 10:00 PST",
+    "oneWorkingWeekBeforeRelease": "13 June 2022 10:00 PST",
+    "oneWorkingDayBeforeRelease": "17 June 2022 10:00 PST",
+    "releaseDate": "20 June 2022 10:00 PST",
+    "oneWorkingDayAfterRelease": "21 June 2022 10:00 PST",
     // Channel where messages from the tooling are posted
     "slackAnnounceChannel": "eng-announce",
     // Email for preparing calendar events


### PR DESCRIPTION
We are not going to introduce 72-hour slack between the branch cut and the release date for 3.41.

## Test plan

n/a
