### PR TITLE
batches: make it clearer from `/edit` when there's an active execution

### DIFF
--- a/client/web/src/enterprise/batches/batch-spec/edit/useExecuteBatchSpec.ts
+++ b/client/web/src/enterprise/batches/batch-spec/edit/useExecuteBatchSpec.ts
@@ -38,7 +38,7 @@ export const useExecuteBatchSpec = (batchSpecID?: Scalars['ID']): UseExecuteBatc
         submitBatchSpec({ variables: { batchSpec: batchSpecID } })
             .then(({ data }) => {
                 if (data?.executeBatchSpec) {
-                    history.push(
+                    history.replace(
                         `${data.executeBatchSpec.namespace.url}/batch-changes/${data.executeBatchSpec.description.name}/executions/${data.executeBatchSpec.id}`
                     )
                 }


### PR DESCRIPTION
Potentially closes https://github.com/sourcegraph/sourcegraph/issues/37076. 🙂

- Uses `history.replace` to route to the execution page when you submit a batch spec for execution, so that using the browser back button doesn't take you back to `/edit`
- Shows a warning from `/edit` if there's an active execution for the latest batch spec

Demo:

https://user-images.githubusercontent.com/8942601/173489556-fe414c5d-e728-4ba8-b2d9-adcffd83a9dc.mov

## Test plan

Tested workflow manually, in attached video above.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-kr-edit-when-executing.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-tvcxupvnve.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
