### PR TITLE
batches: use custom style for instances of `Select`

### DIFF
--- a/client/web/src/enterprise/batches/ChangesetFilter.tsx
+++ b/client/web/src/enterprise/batches/ChangesetFilter.tsx
@@ -31,8 +31,9 @@ export const ChangesetFilter = <T extends string>({
         <>
             <Select
                 aria-label={label}
+                isCustomStyle={true}
                 id=""
-                selectClassName={classNames('form-control changeset-filter__dropdown', className)}
+                selectClassName={classNames('changeset-filter__dropdown', className)}
                 className="mb-0"
                 value={selected}
                 onChange={innerOnChange}

--- a/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspacesFilterRow.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspacesFilterRow.tsx
@@ -113,6 +113,7 @@ export const WorkspaceFilter = <T extends string>({
     return (
         <Select
             id="workspace-state"
+            isCustomStyle={true}
             className={className}
             value={selected}
             onChange={innerOnChange}

--- a/client/web/src/enterprise/batches/create/NamespaceSelector.tsx
+++ b/client/web/src/enterprise/batches/create/NamespaceSelector.tsx
@@ -41,7 +41,7 @@ export const NamespaceSelector: React.FunctionComponent<React.PropsWithChildren<
     return (
         <Select
             label={<strong className="text-nowrap mb-2">Namespace</strong>}
-            selectClassName="form-control"
+            isCustomStyle={true}
             id={NAMESPACE_SELECTOR_ID}
             value={selectedNamespace}
             onChange={onSelectNamespace}


### PR DESCRIPTION
Potentially fixes the "doesn't match Wildcard" part of https://github.com/sourcegraph/sourcegraph/issues/37116.

I don't claim to know why we have a "native" version of `Select`, nor do I know why it's the default, but the "custom" variant looks to be what we want to use to match Wildcard. Screenshots from Safari, like in @danielmarquespt's original report:

![Screen Shot 2022-06-13 at 10 10 43 PM](https://user-images.githubusercontent.com/8942601/173498256-1a6a5a78-a483-461b-95d1-a53d7f87fe9d.png)

![Screen Shot 2022-06-13 at 10 10 51 PM](https://user-images.githubusercontent.com/8942601/173498268-a894d827-75a3-4028-a34d-5ffe3abaeb6f.png)

![Screen Shot 2022-06-13 at 10 11 00 PM](https://user-images.githubusercontent.com/8942601/173498277-5ab862b3-b4fd-475d-93d3-5d2060de2e57.png)

## Test plan

Manually tested all three instances of `Select` in Chrome, Brave, and Safari. I think these instances are also covered by Storybook and should probably trigger a diff on Chromatic.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-kr-custom-select-style.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-payiscxibt.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
