### PR TITLE
batches: center connection summary and show more button

### DIFF
--- a/client/web/src/enterprise/batches/batch-spec/edit/workspaces-preview/ImportingChangesetsPreviewList.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/edit/workspaces-preview/ImportingChangesetsPreviewList.tsx
@@ -60,6 +60,7 @@ export const ImportingChangesetsPreviewList: React.FunctionComponent<
         {connection && (
             <SummaryContainer centered={true}>
                 <ConnectionSummary
+                    centered={true}
                     noSummaryIfAllNodesVisible={true}
                     first={CHANGESETS_PER_PAGE_COUNT}
                     connection={connection}
@@ -68,7 +69,7 @@ export const ImportingChangesetsPreviewList: React.FunctionComponent<
                     hasNextPage={hasNextPage}
                     emptyElement={null}
                 />
-                {hasNextPage && <ShowMoreButton onClick={fetchMore} />}
+                {hasNextPage && <ShowMoreButton centered={true} onClick={fetchMore} />}
             </SummaryContainer>
         )}
     </ConnectionContainer>

--- a/client/web/src/enterprise/batches/batch-spec/edit/workspaces-preview/WorkspacesPreviewList.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/edit/workspaces-preview/WorkspacesPreviewList.tsx
@@ -82,6 +82,7 @@ export const WorkspacesPreviewList: React.FunctionComponent<React.PropsWithChild
             {connectionOrCached && (
                 <SummaryContainer centered={true}>
                     <ConnectionSummary
+                        centered={true}
                         noSummaryIfAllNodesVisible={true}
                         first={WORKSPACES_PER_PAGE_COUNT}
                         connection={connectionOrCached}
@@ -90,7 +91,7 @@ export const WorkspacesPreviewList: React.FunctionComponent<React.PropsWithChild
                         hasNextPage={hasNextPage}
                         emptyElement={<span className="text-muted">No workspaces found</span>}
                     />
-                    {hasNextPage && <ShowMoreButton onClick={fetchMore} />}
+                    {hasNextPage && <ShowMoreButton centered={true} onClick={fetchMore} />}
                 </SummaryContainer>
             )}
         </ConnectionContainer>

--- a/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspacesList.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspacesList.tsx
@@ -53,6 +53,7 @@ export const WorkspacesList: React.FunctionComponent<React.PropsWithChildren<Wor
             {connection && (
                 <SummaryContainer centered={true}>
                     <ConnectionSummary
+                        centered={true}
                         noSummaryIfAllNodesVisible={true}
                         first={20}
                         connection={connection}

--- a/client/web/src/enterprise/batches/detail/BulkOperationsTab.tsx
+++ b/client/web/src/enterprise/batches/detail/BulkOperationsTab.tsx
@@ -50,6 +50,7 @@ export const BulkOperationsTab: React.FunctionComponent<React.PropsWithChildren<
                     <SummaryContainer centered={true}>
                         <ConnectionSummary
                             noSummaryIfAllNodesVisible={true}
+                            centered={true}
                             first={BATCH_COUNT}
                             connection={connection}
                             noun="bulk operation"
@@ -57,7 +58,7 @@ export const BulkOperationsTab: React.FunctionComponent<React.PropsWithChildren<
                             hasNextPage={hasNextPage}
                             emptyElement={<EmptyBulkOperationsListElement />}
                         />
-                        {hasNextPage && <ShowMoreButton onClick={fetchMore} />}
+                        {hasNextPage && <ShowMoreButton centered={true} onClick={fetchMore} />}
                     </SummaryContainer>
                 )}
             </ConnectionContainer>

--- a/client/web/src/enterprise/batches/detail/changesets/BatchChangeChangesets.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/BatchChangeChangesets.tsx
@@ -310,13 +310,14 @@ const BatchChangeChangesetsImpl: React.FunctionComponent<React.PropsWithChildren
                             <ConnectionSummary
                                 noSummaryIfAllNodesVisible={true}
                                 first={BATCH_COUNT}
+                                centered={true}
                                 connection={connection}
                                 noun="changeset"
                                 pluralNoun="changesets"
                                 hasNextPage={hasNextPage}
                                 emptyElement={emptyElement}
                             />
-                            {hasNextPage && <ShowMoreButton onClick={fetchMore} />}
+                            {hasNextPage && <ShowMoreButton centered={true} onClick={fetchMore} />}
                         </SummaryContainer>
                     )}
                 </ConnectionContainer>

--- a/client/web/src/enterprise/batches/list/BatchChangeListPage.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangeListPage.tsx
@@ -207,6 +207,7 @@ export const BatchChangeListPage: React.FunctionComponent<React.PropsWithChildre
                         {connection && (
                             <SummaryContainer centered={true}>
                                 <ConnectionSummary
+                                    centered={true}
                                     noSummaryIfAllNodesVisible={true}
                                     first={BATCH_CHANGES_PER_PAGE_COUNT}
                                     connection={connection}
@@ -217,7 +218,7 @@ export const BatchChangeListPage: React.FunctionComponent<React.PropsWithChildre
                                         <BatchChangeListEmptyElement canCreate={canCreate} location={location} />
                                     }
                                 />
-                                {hasNextPage && <ShowMoreButton onClick={fetchMore} />}
+                                {hasNextPage && <ShowMoreButton centered={true} onClick={fetchMore} />}
                             </SummaryContainer>
                         )}
                     </ConnectionContainer>

--- a/client/web/src/enterprise/batches/settings/CodeHostConnections.tsx
+++ b/client/web/src/enterprise/batches/settings/CodeHostConnections.tsx
@@ -68,12 +68,13 @@ const CodeHostConnections: React.FunctionComponent<React.PropsWithChildren<CodeH
                         <ConnectionSummary
                             noSummaryIfAllNodesVisible={true}
                             first={15}
+                            centered={true}
                             connection={connection}
                             noun="code host"
                             pluralNoun="code hosts"
                             hasNextPage={hasNextPage}
                         />
-                        {hasNextPage && <ShowMoreButton onClick={fetchMore} />}
+                        {hasNextPage && <ShowMoreButton centered={true} onClick={fetchMore} />}
                     </SummaryContainer>
                 )}
             </ConnectionContainer>


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/37118.

I wonder if the default changed at some point... Anyway, now we'll be explicit that we always want the connection summary and "show more" buttons to be centered in filtered connection UIs.

## Test plan

Manually verified a couple instances. Most of covered by Storybook and Chromatic.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-kr-center-show-more-button.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-uaftookvrb.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
