### PR TITLE
JetBrains: update JCEF when settings change

### DIFF
--- a/client/jetbrains/src/main/java/com/sourcegraph/browser/JSToJavaBridgeRequestHandler.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/browser/JSToJavaBridgeRequestHandler.java
@@ -100,6 +100,10 @@ public class JSToJavaBridgeRequestHandler {
     }
 
     @NotNull
+    public Project getProject() {
+        return project;
+    }
+
     public JBCefJSQuery.Response handleInvalidRequest(@NotNull Exception e) {
         return createErrorResponse("Invalid JSON passed to bridge. The error is: " + e.getClass() + ": " + e.getMessage(), convertStackTraceToString(e));
     }

--- a/client/jetbrains/src/main/java/com/sourcegraph/browser/JavaToJSBridge.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/browser/JavaToJSBridge.java
@@ -1,66 +1,93 @@
 package com.sourcegraph.browser;
 
+import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
+import com.google.gson.JsonSyntaxException;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.ui.jcef.JBCefBrowserBase;
 import com.intellij.ui.jcef.JBCefJSQuery;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
-import java.util.function.Consumer;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Function;
 
 public class JavaToJSBridge {
-    private final int QUERY_COUNT = 2;
     private final JBCefBrowserBase browser;
-    private final Logger logger = Logger.getInstance(JavaToJSBridge.class);
-    private final JBCefJSQuery[] queries = new JBCefJSQuery[QUERY_COUNT];
-    private final boolean[] isQueryRunning = new boolean[QUERY_COUNT];
+    private final JBCefJSQuery query;
+    private final Lock lock;
     private Function<String, JBCefJSQuery.Response> handler = null;
 
     public JavaToJSBridge(JBCefBrowserBase browser) {
         this.browser = browser;
-        this.queries[0] = JBCefJSQuery.create(browser);
-        this.isQueryRunning[0] = false;
-        this.queries[1] = JBCefJSQuery.create(browser);
-        this.isQueryRunning[1] = false;
+        this.query = JBCefJSQuery.create(browser);
+        this.lock = new ReentrantLock();
     }
 
-    public void callJS(String action, JsonObject arguments) {
+    public void callJS(@NotNull String action, @Nullable JsonObject arguments) {
         this.callJS(action, arguments, null);
     }
 
-    public void callJS(String action, JsonObject arguments, Consumer<JsonObject> callback) {
-        // Reason for the locking:
-        // JBCefJSQuery objects MUST be created before the browser is loaded, otherwise an error is thrown.
-        // As there is only one JBCefJSQuery object, and we need to wait for the result of the last execution,
-        // we can only run one query at a time.
-        // If this becomes a bottleneck, we can create a pool of JBCefJSQuery objects to bridge this,
-        // or find a different solution.
-        if (hasAvailableQuery()) {
-            int queryIndex = isQueryRunning[0] ? 1 : 0;
-            isQueryRunning[queryIndex] = true;
-            JBCefJSQuery query = queries[queryIndex];
+    /**
+     * @param result This is the way to get the result back to the caller from the thread started in this method.
+     */
+    public void callJS(@NotNull String action, @Nullable JsonObject arguments, @Nullable CompletableFuture<JsonObject> result) {
+        // A separate thread is needed because the response handling uses the main thread,
+        // so if we did the JS call in the main thread and then waited, the response handler
+        // would never be called.
+        new Thread(() -> {
+            Logger logger = Logger.getInstance(this.getClass());
+            // Reason for the locking:
+            // JBCefJSQuery objects MUST be created before the browser is loaded, otherwise an error is thrown.
+            // As there is only one JBCefJSQuery object, and we need to wait for the result of the last execution,
+            // we can only run one query at a time.
+            // If this ever becomes a bottleneck, we can create a pool of JBCefJSQuery objects and a counting semaphore.
+            lock.lock();
+
+            // This future is needed to communicate between this thread and the response handler thread.
+            CompletableFuture<Void> handlerCompletedFuture = new CompletableFuture<>();
+
             String js = "window.callJS('" + action + "', '" + (arguments != null ? arguments.toString() : "null") + "', (result) => {" +
                 "    " + query.inject("result") +
                 "});";
 
             handler = responseAsString -> {
-                if (callback != null) {
-                    callback.accept(JsonParser.parseString(responseAsString).getAsJsonObject());
-                }
                 query.removeHandler(handler);
                 handler = null;
-                isQueryRunning[queryIndex] = false;
+                try {
+                    JsonElement jsonElement = JsonParser.parseString(responseAsString);
+                    if (result != null) {
+                        result.complete(jsonElement.isJsonObject() ? jsonElement.getAsJsonObject() : null);
+                    }
+                } catch (JsonSyntaxException e) {
+                    logger.warn("Invalid JSON: " + responseAsString);
+                    logger.warn(e);
+                    if (result != null) {
+                        result.complete(null);
+                    }
+                } finally {
+                    handlerCompletedFuture.complete(null);
+                }
                 return null;
             };
             query.addHandler(handler);
             browser.getCefBrowser().executeJavaScript(js, browser.getCefBrowser().getURL(), 0);
-        } else {
-            logger.error("Query is already running, ignoring callJS");
-        }
-    }
 
-    public boolean hasAvailableQuery() {
-        return !(isQueryRunning[0] && isQueryRunning[1]);
+            try {
+                handlerCompletedFuture.get();
+            } catch (InterruptedException | ExecutionException e) {
+                logger.warn("Some problem occurred with the JS response thread.");
+                logger.warn(e);
+            } finally {
+                // It's only allowed to unlock the lock in the thread where it was locked.
+                // This is why `handlerCompletedFuture` is needed in the first place.
+                // Otherwise, the handler could simply unlock the lock, but that's not allowed in Java.
+                lock.unlock();
+            }
+        }).start();
     }
 }

--- a/client/jetbrains/src/main/java/com/sourcegraph/browser/SourcegraphJBCefBrowser.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/browser/SourcegraphJBCefBrowser.java
@@ -31,9 +31,7 @@ public class SourcegraphJBCefBrowser extends JBCefBrowser {
 
         UIManager.addPropertyChangeListener(propertyChangeEvent -> {
             if (propertyChangeEvent.getPropertyName().equals("lookAndFeel")) {
-                if (javaToJSBridge.hasAvailableQuery()) {
-                    javaToJSBridge.callJS("themeChanged", ThemeUtil.getCurrentThemeAsJson());
-                }
+                javaToJSBridge.callJS("themeChanged", ThemeUtil.getCurrentThemeAsJson());
             }
         });
     }

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/ConfigUtil.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/ConfigUtil.java
@@ -1,5 +1,6 @@
 package com.sourcegraph.config;
 
+import com.google.gson.JsonObject;
 import com.intellij.openapi.project.Project;
 import com.sourcegraph.find.Search;
 import org.jetbrains.annotations.Contract;
@@ -9,6 +10,14 @@ import org.jetbrains.annotations.Nullable;
 import java.util.Objects;
 
 public class ConfigUtil {
+    public static JsonObject getConfigAsJson(@NotNull Project project) {
+        JsonObject configAsJson = new JsonObject();
+        configAsJson.addProperty("instanceURL", ConfigUtil.getSourcegraphUrl(project));
+        configAsJson.addProperty("isGlobbingEnabled", ConfigUtil.isGlobbingEnabled(project));
+        configAsJson.addProperty("accessToken", ConfigUtil.getAccessToken(project));
+        return configAsJson;
+    }
+
     @Nullable
     public static String getDefaultBranchName(@NotNull Project project) {
         String defaultBranch = Objects.requireNonNull(SourcegraphConfig.getInstance(project)).getDefaultBranchName();

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/PluginSettingChangeActionNotifier.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/PluginSettingChangeActionNotifier.java
@@ -1,0 +1,12 @@
+package com.sourcegraph.config;
+
+import com.intellij.util.messages.Topic;
+
+public interface PluginSettingChangeActionNotifier {
+
+    Topic<PluginSettingChangeActionNotifier> TOPIC = Topic.create("Sourcegraph plugin settings have changed", PluginSettingChangeActionNotifier.class);
+
+    void beforeAction();
+
+    void afterAction();
+}

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsChangeListener.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsChangeListener.java
@@ -1,0 +1,36 @@
+package com.sourcegraph.config;
+
+import com.intellij.openapi.Disposable;
+import com.intellij.openapi.project.Project;
+import com.intellij.util.messages.MessageBus;
+import com.intellij.util.messages.MessageBusConnection;
+import com.sourcegraph.browser.JavaToJSBridge;
+import org.jetbrains.annotations.NotNull;
+
+public class SettingsChangeListener implements Disposable {
+    private final MessageBusConnection connection;
+
+    public SettingsChangeListener(@NotNull Project project, @NotNull JavaToJSBridge javaToJSBridge) {
+        MessageBus bus = project.getMessageBus();
+
+        connection = bus.connect();
+        connection.subscribe(PluginSettingChangeActionNotifier.TOPIC, new PluginSettingChangeActionNotifier() {
+            @Override
+            public void beforeAction() {
+                // Do nothing
+            }
+
+            @Override
+            public void afterAction() {
+                if (javaToJSBridge.hasAvailableQuery()) {
+                    javaToJSBridge.callJS("pluginSettingsChanged", ConfigUtil.getConfigAsJson(project));
+                }
+            }
+        });
+    }
+
+    @Override
+    public void dispose() {
+        connection.disconnect();
+    }
+}

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsChangeListener.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsChangeListener.java
@@ -22,9 +22,7 @@ public class SettingsChangeListener implements Disposable {
 
             @Override
             public void afterAction() {
-                if (javaToJSBridge.hasAvailableQuery()) {
-                    javaToJSBridge.callJS("pluginSettingsChanged", ConfigUtil.getConfigAsJson(project));
-                }
+                javaToJSBridge.callJS("pluginSettingsChanged", ConfigUtil.getConfigAsJson(project));
             }
         });
     }

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsConfigurable.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsConfigurable.java
@@ -2,6 +2,7 @@ package com.sourcegraph.config;
 
 import com.intellij.openapi.options.Configurable;
 import com.intellij.openapi.project.Project;
+import com.intellij.util.messages.MessageBus;
 import org.jetbrains.annotations.Nls;
 import org.jetbrains.annotations.Nullable;
 
@@ -48,12 +49,18 @@ public class SettingsConfigurable implements Configurable {
 
     @Override
     public void apply() {
+        MessageBus bus = project.getMessageBus();
+        PluginSettingChangeActionNotifier publisher = bus.syncPublisher(PluginSettingChangeActionNotifier.TOPIC);
+        publisher.beforeAction();
+
         SourcegraphConfig settings = SourcegraphConfig.getInstance(project);
         settings.url = mySettingsComponent.getSourcegraphUrl();
         settings.accessToken = mySettingsComponent.getAccessToken();
         settings.defaultBranch = mySettingsComponent.getDefaultBranchName();
         settings.remoteUrlReplacements = mySettingsComponent.getRemoteUrlReplacements();
         settings.isGlobbingEnabled = mySettingsComponent.isGlobbingEnabled();
+
+        publisher.afterAction();
     }
 
     @Override

--- a/client/jetbrains/webview/src/search/index.tsx
+++ b/client/jetbrains/webview/src/search/index.tsx
@@ -44,8 +44,6 @@ window.initializeSourcegraph = async () => {
         console.warn(`No initial authenticated user with access token “${accessToken}”`)
     }
 
-    polyfillEventSource(accessToken ? { Authorization: `token ${accessToken}` } : {})
-
     renderReactApp()
 
     await indicateFinishedLoading()
@@ -75,6 +73,7 @@ export function applyConfig(config: PluginConfig): void {
     instanceURL = config.instanceURL
     isGlobbingEnabled = config.isGlobbingEnabled || false
     accessToken = config.accessToken || null
+    polyfillEventSource(accessToken ? { Authorization: `token ${accessToken}` } : {})
 }
 
 export function applyTheme(theme: Theme): void {


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/36537

Notes:
- It uses the message bus.
- I've also extracted "getConfigAsJson" to ConfigUtil
- I've also made sure that the new listener connection is disposed of with the service.
- Made JavaToJSBridge pool use two queries, to make sure settings change can be applied at the same time as the theme change. It's because IF you change the theme from light to dark AND change plugin settings, then these need to be applied simultaneously when you press "OK" in Settings.

## Test plan

[2 min Loom demo](https://www.loom.com/share/3af288b1a656460c9c8697d56aebd373)

## App preview:

- [Web](https://sg-web-dv-jetbrains-update-jcef-when.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-wgzywerznm.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
