### PR TITLE
add enable check for only when in sg repo

### DIFF
--- a/dev/sg/dependencies/helpers.go
+++ b/dev/sg/dependencies/helpers.go
@@ -46,6 +46,13 @@ func cmdFixes(cmds ...string) check.FixAction[CheckArgs] {
 	}
 }
 
+func enableOnlyInSourcegraphRepo() check.EnableFunc[CheckArgs] {
+	return func(ctx context.Context, args CheckArgs) error {
+		_, err := root.RepositoryRoot()
+		return err
+	}
+}
+
 func enableForTeammatesOnly() check.EnableFunc[CheckArgs] {
 	return func(ctx context.Context, args CheckArgs) error {
 		if !args.Teammate {

--- a/dev/sg/dependencies/mac.go
+++ b/dev/sg/dependencies/mac.go
@@ -133,6 +133,7 @@ var Mac = []category{
 	{
 		Name:      "Programming languages & tooling",
 		DependsOn: []string{depsHomebrew, depsBaseUtilities},
+		Enabled:   enableOnlyInSourcegraphRepo(),
 		Checks: []*check.Check[CheckArgs]{
 			{
 				Name:  "go",

--- a/dev/sg/internal/check/runner.go
+++ b/dev/sg/internal/check/runner.go
@@ -173,7 +173,7 @@ func (r *Runner[Args]) runAllCategoryChecks(ctx context.Context, args Args) *run
 
 	var (
 		categoriesWg sync.WaitGroup
-		skipped      = map[int]struct{}{}
+		skipped      = map[int]error{}
 
 		// used for progress bar
 		checksDone           atomic.Float64
@@ -186,7 +186,7 @@ func (r *Runner[Args]) runAllCategoryChecks(ctx context.Context, args Args) *run
 		progress.StatusBarUpdatef(i, "Determining status...")
 
 		if err := category.CheckEnabled(ctx, args); err != nil {
-			skipped[i] = struct{}{}
+			skipped[i] = err
 			// Mark as done
 			progress.StatusBarCompletef(i, "Category skipped: %s", err.Error())
 			continue
@@ -242,8 +242,8 @@ func (r *Runner[Args]) runAllCategoryChecks(ctx context.Context, args Args) *run
 		idx := i + 1
 
 		if _, ok := skipped[i]; ok {
-			r.out.WriteSkippedf("%d. %s %s[SKIPPED]%s", idx, category.Name,
-				output.StyleBold, output.StyleReset)
+			r.out.WriteSkippedf("%d. %s %s[SKIPPED. Reason: %s]%s", idx, category.Name,
+				output.StyleBold, skipped[i], output.StyleReset)
 			results.skipped = append(results.skipped, i)
 			continue
 		}


### PR DESCRIPTION
Implements [#37040 comment](https://github.com/sourcegraph/sourcegraph/pull/37040#issuecomment-1154050101)

Disable the `Programming & Languages` category when we're not in the SG repository, otherwise we might install the wrong versions!

Also added the resaon why a category was skipped to the output
## Test plan
Manual testing
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
