### PR TITLE
searcher: do not log net.OpError

### DIFF
--- a/cmd/searcher/internal/search/store_test.go
+++ b/cmd/searcher/internal/search/store_test.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"context"
 	"io"
+	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -288,4 +289,13 @@ func emptyTar(t *testing.T) io.ReadCloser {
 		t.Fatal(err)
 	}
 	return io.NopCloser(bytes.NewReader(buf.Bytes()))
+}
+
+func TestIsNetOpError(t *testing.T) {
+	if !isNetOpError(&net.OpError{}) {
+		t.Fatal("should be net.OpError")
+	}
+	if isNetOpError(errors.New("hi")) {
+		t.Fatal("should not be net.OpError")
+	}
 }


### PR DESCRIPTION
I was watching searcher logs and noticed huge amounts of log spam when a
connection is closed. This is since we can try to find several matches
before we check if context is canceled. We then get a log message per
match informing us of something like:

  write tcp 10.164.18.30:3181->10.164.27.49:56316: write: broken pipe

Test Plan: To reproduce I made hybrid search in zoekt write ^10 more
matches, then added some timing which called ts.Config.Close(). This
reproduced the error. Additionally I think the error checking code is a
little tricky, so I introduced a test specifically for the helper.



## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
