### PR TITLE
db: mark Bitbucket project job as non-retryable when non-Bitbucket code host is provided

### DIFF
--- a/enterprise/cmd/worker/internal/permissions/bitbucket_projects.go
+++ b/enterprise/cmd/worker/internal/permissions/bitbucket_projects.go
@@ -11,6 +11,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/sourcegraph/log"
+	"github.com/sourcegraph/sourcegraph/internal/errcode"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/globals"
 	"github.com/sourcegraph/sourcegraph/cmd/worker/job"
@@ -92,6 +93,10 @@ func (h *bitbucketProjectPermissionsHandler) Handle(ctx context.Context, logger 
 	svc, err := h.db.ExternalServices().GetByID(ctx, job.ExternalServiceID)
 	if err != nil {
 		return errors.Wrapf(err, "failed to get external service %d", job.ExternalServiceID)
+	}
+
+	if svc.Kind != extsvc.KindBitbucketServer {
+		return errcode.MakeNonRetryable(errors.Newf("expected Bitbucket Server external service, got: %s", svc.Kind))
 	}
 
 	// get repos from the Bitbucket project

--- a/enterprise/cmd/worker/internal/permissions/bitbucket_projects_test.go
+++ b/enterprise/cmd/worker/internal/permissions/bitbucket_projects_test.go
@@ -263,7 +263,7 @@ func TestHandleRestricted(t *testing.T) {
 	}
 	// create an external service
 	err := db.ExternalServices().Create(ctx, confGet, &types.ExternalService{
-		Kind:        extsvc.KindBitbucketCloud,
+		Kind:        extsvc.KindBitbucketServer,
 		DisplayName: "Bitbucket #1",
 		Config:      `{"url": "https://bitbucket.com", "username": "username", "appPassword": "qwerty"}`,
 	})
@@ -362,7 +362,7 @@ func TestHandleUnrestricted(t *testing.T) {
 	}
 	// create an external service
 	err := db.ExternalServices().Create(ctx, confGet, &types.ExternalService{
-		Kind:        extsvc.KindBitbucketCloud,
+		Kind:        extsvc.KindBitbucketServer,
 		DisplayName: "Bitbucket #1",
 		Config:      `{"url": "https://bitbucket.com", "username": "username", "appPassword": "pwd"}`,
 	})

--- a/enterprise/cmd/worker/internal/permissions/bitbucket_projects_test.go
+++ b/enterprise/cmd/worker/internal/permissions/bitbucket_projects_test.go
@@ -265,7 +265,7 @@ func TestHandleRestricted(t *testing.T) {
 	err := db.ExternalServices().Create(ctx, confGet, &types.ExternalService{
 		Kind:        extsvc.KindBitbucketServer,
 		DisplayName: "Bitbucket #1",
-		Config:      `{"url": "https://bitbucket.com", "username": "username", "appPassword": "qwerty"}`,
+		Config:      `{"url": "https://bitbucket.com", "username": "username", "token": "qwerty", "repositoryQuery": ["none"]}`,
 	})
 	require.NoError(t, err)
 
@@ -364,7 +364,7 @@ func TestHandleUnrestricted(t *testing.T) {
 	err := db.ExternalServices().Create(ctx, confGet, &types.ExternalService{
 		Kind:        extsvc.KindBitbucketServer,
 		DisplayName: "Bitbucket #1",
-		Config:      `{"url": "https://bitbucket.com", "username": "username", "appPassword": "pwd"}`,
+		Config:      `{"url": "https://bitbucket.com", "username": "username", "token": "qwerty", "repositoryQuery": ["none"]}`,
 	})
 	require.NoError(t, err)
 


### PR DESCRIPTION
There is no way the job can finish successfully if code host is other that Bitbucket Server.

Also this PR removes skipping of 2 quick tests, which are skipped for now for short test loop.

Closes https://github.com/sourcegraph/sourcegraph/issues/37200

## Test plan
New test case added
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
