### PR TITLE
Replace explicit Sentry capture with logger call

### DIFF
--- a/enterprise/cmd/frontend/internal/auth/gitlaboauth/login.go
+++ b/enterprise/cmd/frontend/internal/auth/gitlaboauth/login.go
@@ -8,9 +8,9 @@ import (
 	oauth2Login "github.com/dghubble/gologin/oauth2"
 	"golang.org/x/oauth2"
 
+	"github.com/sourcegraph/log"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/gitlab"
-	"github.com/sourcegraph/sourcegraph/internal/sentry"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
@@ -24,6 +24,8 @@ func CallbackHandler(config *oauth2.Config, success, failure http.Handler) http.
 }
 
 func gitlabHandler(config *oauth2.Config, success, failure http.Handler) http.Handler {
+	logger := log.Scoped("gitlab-handler", "Gitlab Handler")
+
 	if failure == nil {
 		failure = gologin.DefaultFailureHandler
 	}
@@ -47,7 +49,7 @@ func gitlabHandler(config *oauth2.Config, success, failure http.Handler) http.Ha
 		if err != nil {
 			// TODO: Prefer a more general purpose fix, potentially
 			// https://github.com/sourcegraph/sourcegraph/pull/20000
-			sentry.CaptureError(err, map[string]string{})
+			logger.Warn("invalid response", log.Error(err))
 		}
 		if err != nil {
 			ctx = gologin.WithError(ctx, err)

--- a/enterprise/cmd/frontend/internal/auth/gitlaboauth/login.go
+++ b/enterprise/cmd/frontend/internal/auth/gitlaboauth/login.go
@@ -24,7 +24,7 @@ func CallbackHandler(config *oauth2.Config, success, failure http.Handler) http.
 }
 
 func gitlabHandler(config *oauth2.Config, success, failure http.Handler) http.Handler {
-	logger := log.Scoped("gitlab-handler", "Gitlab Handler")
+	logger := log.Scoped("GitlabOAuthHandler", "Gitlab OAuth Handler")
 
 	if failure == nil {
 		failure = gologin.DefaultFailureHandler


### PR DESCRIPTION
Part of https://github.com/sourcegraph/sourcegraph/issues/35846

Because we have Sentry sinks, the error will still be reported, on
environment where a sentry DSN is given in the site-config.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Ran tests locally, really small change. 
