### PR TITLE
Update docs with the correct name for SAML connector for OneLogin

### DIFF
--- a/doc/admin/auth/saml/one_login.md
+++ b/doc/admin/auth/saml/one_login.md
@@ -4,7 +4,7 @@
 
 1. Go to https://mycompany.onelogin.com/apps/find (replace "mycompany" with your company's OneLogin
    ID).
-1. Type "saml" in the search field and select `SAML Custom Connector (Advanced)`, which uses the SAML 2.2 version. Click "Save".
+1. Type "saml" in the search field and select `SAML Custom Connector (Advanced)`, which uses the SAML 2.0 version. Click "Save".
 1. Under the "Configuration" tab, set the following properties (replacing `https://sourcegraph.example.com` with your Sourcegraph URL):
    * `Audience`:  https://sourcegraph.example.com/.auth/saml/metadata
    * `Recipient`: https://sourcegraph.example.com/.auth/saml/acs

--- a/doc/admin/auth/saml/one_login.md
+++ b/doc/admin/auth/saml/one_login.md
@@ -4,7 +4,7 @@
 
 1. Go to https://mycompany.onelogin.com/apps/find (replace "mycompany" with your company's OneLogin
    ID).
-1. Select "SAML Test Connector (SP)" and click "Save".
+1. Type "saml" in the search field and select `SAML Custom Connector (Advanced)`, which uses the SAML 2.2 version. Click "Save".
 1. Under the "Configuration" tab, set the following properties (replacing `https://sourcegraph.example.com` with your Sourcegraph URL):
    * `Audience`:  https://sourcegraph.example.com/.auth/saml/metadata
    * `Recipient`: https://sourcegraph.example.com/.auth/saml/acs


### PR DESCRIPTION
A quick update in the docs because we are recommending our customers to use, during the SAML  auth setup for OneLogin, an old version of SAML  that we don't support.

Instead of recommending users to select `SAML Test Connector`, which uses SAML 1.1, we should instruct them to use 
SAML Custom Connector, which has version 2.2.

See image attached.

<img width="1488" alt="Screen Shot 2022-06-14 at 09 26 46" src="https://user-images.githubusercontent.com/1552863/173579449-542661e3-e83d-4abf-8a38-44bb3206eff4.png">

## Test plan
 I tested this in my local instance after creating an account in OneLogin and setting up SAML auth provider to be used with OneLogin.

Could confirm that if we use the SAML connecter recommended by our docs, it won't work and we will have a bunch of 500s. If we use SAML 2.2, it will work as expected.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
