### PR TITLE
Replace Sentry capture call in SecurityEventLogger with logger call

### DIFF
--- a/enterprise/cmd/frontend/internal/auth/gitlaboauth/login.go
+++ b/enterprise/cmd/frontend/internal/auth/gitlaboauth/login.go
@@ -8,9 +8,9 @@ import (
 	oauth2Login "github.com/dghubble/gologin/oauth2"
 	"golang.org/x/oauth2"
 
+	"github.com/sourcegraph/log"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/gitlab"
-	"github.com/sourcegraph/sourcegraph/internal/sentry"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
@@ -24,6 +24,8 @@ func CallbackHandler(config *oauth2.Config, success, failure http.Handler) http.
 }
 
 func gitlabHandler(config *oauth2.Config, success, failure http.Handler) http.Handler {
+	logger := log.Scoped("gitlab-handler", "Gitlab Handler")
+
 	if failure == nil {
 		failure = gologin.DefaultFailureHandler
 	}
@@ -47,7 +49,7 @@ func gitlabHandler(config *oauth2.Config, success, failure http.Handler) http.Ha
 		if err != nil {
 			// TODO: Prefer a more general purpose fix, potentially
 			// https://github.com/sourcegraph/sourcegraph/pull/20000
-			sentry.CaptureError(err, map[string]string{})
+			logger.Warn("invalid response", log.Error(err))
 		}
 		if err != nil {
 			ctx = gologin.WithError(ctx, err)

--- a/enterprise/cmd/frontend/internal/auth/gitlaboauth/login.go
+++ b/enterprise/cmd/frontend/internal/auth/gitlaboauth/login.go
@@ -24,7 +24,7 @@ func CallbackHandler(config *oauth2.Config, success, failure http.Handler) http.
 }
 
 func gitlabHandler(config *oauth2.Config, success, failure http.Handler) http.Handler {
-	logger := log.Scoped("gitlab-handler", "Gitlab Handler")
+	logger := log.Scoped("GitlabOAuthHandler", "Gitlab OAuth Handler")
 
 	if failure == nil {
 		failure = gologin.DefaultFailureHandler

--- a/internal/database/security_event_logs.go
+++ b/internal/database/security_event_logs.go
@@ -5,11 +5,9 @@ import (
 	"encoding/json"
 	"time"
 
-	"github.com/inconshreveable/log15"
-
+	"github.com/sourcegraph/log"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
-	"github.com/sourcegraph/sourcegraph/internal/sentry"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/internal/version"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
@@ -67,12 +65,14 @@ type SecurityEventLogsStore interface {
 
 type securityEventLogsStore struct {
 	*basestore.Store
+	logger log.Logger
 }
 
 // SecurityEventLogsWith instantiates and returns a new SecurityEventLogsStore
 // using the other store handle.
 func SecurityEventLogsWith(other basestore.ShareableStore) SecurityEventLogsStore {
-	return &securityEventLogsStore{Store: basestore.NewWithHandle(other.Handle())}
+	logger := log.Scoped("security_events", "Security events logs")
+	return &securityEventLogsStore{logger: logger, Store: basestore.NewWithHandle(other.Handle())}
 }
 
 func (s *securityEventLogsStore) Insert(ctx context.Context, e *SecurityEvent) error {
@@ -108,9 +108,6 @@ func (s *securityEventLogsStore) LogEvent(ctx context.Context, e *SecurityEvent)
 
 	if err := s.Insert(ctx, e); err != nil {
 		j, _ := json.Marshal(e)
-		log15.Error(string(e.Name), "event", string(j), "traceID", trace.ID(ctx), "error", err)
-		// We want to capture in sentry as it includes a stack trace which will allow us
-		// to track down the root cause.
-		sentry.CaptureError(err, map[string]string{})
+		s.logger.Error(string(e.Name), log.String("event", string(j)), log.String("traceID", trace.ID(ctx)), log.Error(err))
 	}
 }

--- a/internal/database/security_event_logs.go
+++ b/internal/database/security_event_logs.go
@@ -108,6 +108,6 @@ func (s *securityEventLogsStore) LogEvent(ctx context.Context, e *SecurityEvent)
 
 	if err := s.Insert(ctx, e); err != nil {
 		j, _ := json.Marshal(e)
-		s.logger.Error(string(e.Name), log.String("event", string(j)), log.String("traceID", trace.ID(ctx)), log.Error(err))
+		trace.Logger(ctx, s.logger).Error(string(e.Name), log.String("event", string(j)), log.Error(err))
 	}
 }

--- a/internal/database/security_event_logs.go
+++ b/internal/database/security_event_logs.go
@@ -71,7 +71,7 @@ type securityEventLogsStore struct {
 // SecurityEventLogsWith instantiates and returns a new SecurityEventLogsStore
 // using the other store handle.
 func SecurityEventLogsWith(other basestore.ShareableStore) SecurityEventLogsStore {
-	logger := log.Scoped("security_events", "Security events logs")
+	logger := log.Scoped("SecurityEvents", "Security events store")
 	return &securityEventLogsStore{logger: logger, Store: basestore.NewWithHandle(other.Handle())}
 }
 


### PR DESCRIPTION
This PR remove a combination of a log15 call and explicit capture in favour of our new logging api and implicitly capturing the error.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Rather trivial change, logging api has been tested exhaustively already. 