### PR TITLE
gomod: update zoekt

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -133,7 +133,7 @@ require (
 	github.com/smacker/go-tree-sitter v0.0.0-20220209044044-0d3022e933c3
 	github.com/snabb/sitemap v1.0.0
 	github.com/sourcegraph/ctxvfs v0.0.0-20180418081416-2b65f1b1ea81
-	github.com/sourcegraph/go-ctags v0.0.0-20220404085534-f974026334d7
+	github.com/sourcegraph/go-ctags v0.0.0-20220611154803-db463692f037
 	github.com/sourcegraph/go-diff v0.6.1
 	github.com/sourcegraph/go-jsonschema v0.0.0-20211011105148-2e30f7bacbe1
 	github.com/sourcegraph/go-langserver v2.0.1-0.20181108233942-4a51fa2e1238+incompatible
@@ -418,7 +418,7 @@ require (
 // or intentional forks.
 replace (
 	// We maintain our own fork of Zoekt. Update with ./dev/zoekt/update
-	github.com/google/zoekt => github.com/sourcegraph/zoekt v0.0.0-20220519151725-3bb00e7d99bf
+	github.com/google/zoekt => github.com/sourcegraph/zoekt v0.0.0-20220614124951-145fe8284adc
 	// We use a fork of Alertmanager to allow prom-wrapper to better manipulate Alertmanager configuration.
 	// See https://docs.sourcegraph.com/dev/background-information/observability/prometheus
 	github.com/prometheus/alertmanager => github.com/sourcegraph/alertmanager v0.21.1-0.20211110092431-863f5b1ee51b

--- a/go.sum
+++ b/go.sum
@@ -2141,8 +2141,8 @@ github.com/sourcegraph/annotate v0.0.0-20160123013949-f4cad6c6324d h1:yKm7XZV6j9
 github.com/sourcegraph/annotate v0.0.0-20160123013949-f4cad6c6324d/go.mod h1:UdhH50NIW0fCiwBSr0co2m7BnFLdv4fQTgdqdJTHFeE=
 github.com/sourcegraph/ctxvfs v0.0.0-20180418081416-2b65f1b1ea81 h1:v4/JVxZSPWifxmICRqgXK7khThjw03RfdGhyeA2S4EQ=
 github.com/sourcegraph/ctxvfs v0.0.0-20180418081416-2b65f1b1ea81/go.mod h1:xIvvI5FiHLxhv8prbzVpaMHaaGPFPFQSuTcxC91ryOo=
-github.com/sourcegraph/go-ctags v0.0.0-20220404085534-f974026334d7 h1:jl6zTZRCzF4V2ZjBBlrW2Sscd639mHKhGtMYKaBgEiQ=
-github.com/sourcegraph/go-ctags v0.0.0-20220404085534-f974026334d7/go.mod h1:ZYjpRXoJrRlxjU9ZfpaUKJkk62AjhJPffN3rlw2aqxM=
+github.com/sourcegraph/go-ctags v0.0.0-20220611154803-db463692f037 h1:gk2cs5tfGFtpZfaK5sKnn3Y4iyzrpCfdpncZhTKLz5E=
+github.com/sourcegraph/go-ctags v0.0.0-20220611154803-db463692f037/go.mod h1:ZYjpRXoJrRlxjU9ZfpaUKJkk62AjhJPffN3rlw2aqxM=
 github.com/sourcegraph/go-diff v0.5.1/go.mod h1:j2dHj3m8aZgQO8lMTcTnBcXkRRRqi34cd2MNlA9u1mE=
 github.com/sourcegraph/go-diff v0.5.3/go.mod h1:v9JDtjCE4HHHCZGId75rg8gkKKa98RVjBcBGsVmMmak=
 github.com/sourcegraph/go-diff v0.6.1 h1:hmA1LzxW0n1c3Q4YbrFgg4P99GSnebYa3x8gr0HZqLQ=
@@ -2175,8 +2175,8 @@ github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e h1:qpG
 github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e/go.mod h1:HuIsMU8RRBOtsCgI77wP899iHVBQpCmg4ErYMZB+2IA=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152 h1:z/MpntplPaW6QW95pzcAR/72Z5TWDyDnSo0EOcyij9o=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152/go.mod h1:GIjDIg/heH5DOkXY3YJ/wNhfHsQHoXGjl8G8amsYQ1I=
-github.com/sourcegraph/zoekt v0.0.0-20220519151725-3bb00e7d99bf h1:0ireQszy40RVun0I/jojRhOzDUEMyX1BgrEE+tnDG7w=
-github.com/sourcegraph/zoekt v0.0.0-20220519151725-3bb00e7d99bf/go.mod h1:rgFjt/X6KBEMkJj2X0FOPG+e3DcXN60zrr1e/zOdQkU=
+github.com/sourcegraph/zoekt v0.0.0-20220614124951-145fe8284adc h1:KCcn1cbmWxdqPijBN/Juz+CjcJkBZppgvM6ZMVQ8wqg=
+github.com/sourcegraph/zoekt v0.0.0-20220614124951-145fe8284adc/go.mod h1:9qNB665qu8LV0eEWJths45yv16IDrdo154kPRfBhbNI=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=
 github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=

--- a/internal/search/zoekt/regexp.go
+++ b/internal/search/zoekt/regexp.go
@@ -1,0 +1,67 @@
+package zoekt
+
+import (
+	"regexp/syntax"
+)
+
+// TODO(jac) This is copy pasta to fix tests. It accidently implements the
+// optimizations jac wants to share from zoekt, but by copying instead of
+// using zoekt - keegancsmith
+
+// optimizeRegexp converts capturing groups to non-capturing groups.
+// Returns original input if an error is encountered
+func optimizeRegexp(re *syntax.Regexp) *syntax.Regexp {
+	r := convertCapture(re)
+	return r.Simplify()
+}
+
+func convertCapture(re *syntax.Regexp) *syntax.Regexp {
+	if !hasCapture(re) {
+		return re
+	}
+
+	// Make a copy so in unlikely event of an error the original can be used as a fallback
+	r, err := syntax.Parse(re.String(), regexpFlags)
+	if err != nil {
+		return re
+	}
+
+	r = uncapture(r)
+
+	// Parse again for new structure to take effect
+	r, err = syntax.Parse(r.String(), regexpFlags)
+	if err != nil {
+		return re
+	}
+
+	return r
+}
+
+func hasCapture(r *syntax.Regexp) bool {
+	if r.Op == syntax.OpCapture {
+		return true
+	}
+
+	for _, s := range r.Sub {
+		if hasCapture(s) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func uncapture(r *syntax.Regexp) *syntax.Regexp {
+	if r.Op == syntax.OpCapture {
+		// Captures only have one subexpression
+		r.Op = syntax.OpConcat
+		r.Cap = 0
+		r.Name = ""
+	}
+
+	for i, s := range r.Sub {
+		r.Sub[i] = uncapture(s)
+	}
+
+	return r
+}

--- a/internal/search/zoekt/zoekt.go
+++ b/internal/search/zoekt/zoekt.go
@@ -31,13 +31,18 @@ func noOpAnyChar(re *syntax.Regexp) {
 	}
 }
 
+const regexpFlags = syntax.ClassNL | syntax.PerlX | syntax.UnicodeGroups
+
 func parseRe(pattern string, filenameOnly bool, contentOnly bool, queryIsCaseSensitive bool) (zoektquery.Q, error) {
 	// these are the flags used by zoekt, which differ to searcher.
-	re, err := syntax.Parse(pattern, syntax.ClassNL|syntax.PerlX|syntax.UnicodeGroups)
+	re, err := syntax.Parse(pattern, regexpFlags)
 	if err != nil {
 		return nil, err
 	}
 	noOpAnyChar(re)
+
+	re = optimizeRegexp(re)
+
 	// zoekt decides to use its literal optimization at the query parser
 	// level, so we check if our regex can just be a literal.
 	if re.Op == syntax.OpLiteral {


### PR DESCRIPTION
- https://github.com/sourcegraph/zoekt/commit/145fe82 Upgrade pcre2 package
- https://github.com/sourcegraph/zoekt/commit/b61c934 indexData: experimental ngram map via binary search
- https://github.com/sourcegraph/zoekt/commit/aacaf0c gomod: downgrade datadog
- https://github.com/sourcegraph/zoekt/commit/2eec411 gomod: bump ctags to avoid zombie procs
- https://github.com/sourcegraph/zoekt/commit/b744e52 Convert regexp capture groups to non-capture groups
- https://github.com/sourcegraph/zoekt/commit/a174ad6 fix inaccurate comment
- https://github.com/sourcegraph/zoekt/commit/7a91c48 Split `lineBounds` out into its own method
- https://github.com/sourcegraph/zoekt/commit/f846f01 Create `newlines` type
- https://github.com/sourcegraph/zoekt/commit/5c5f94b improve descriptions of entries on /debug endpoint
- https://github.com/sourcegraph/zoekt/commit/25fa2fa builder.go: have incremental builds update latest commit date information
- https://github.com/sourcegraph/zoekt/commit/15dc905 indexserver: remove debug commands
- https://github.com/sourcegraph/zoekt/commit/6c563dc tests: fix alignment for number hints like "--0123"
- https://github.com/sourcegraph/zoekt/commit/0cafd7b all: stop using the deprecated package io/ioutil
- https://github.com/sourcegraph/zoekt/commit/c16eb04 tests: replace ioutil.TempDir with testing.T.TempDir
- https://github.com/sourcegraph/zoekt/commit/6ca5909 go.mod: fix a cve in a transitive dependency to make Dependabot happy
- https://github.com/sourcegraph/zoekt/commit/f2bb82f debug: add debug score for line matches
- https://github.com/sourcegraph/zoekt/commit/a3e0a5f indexserver: support SG_PRIORITY file for FS fake
- https://github.com/sourcegraph/zoekt/commit/fce3356 indexserver: always cleanup if index fails
- https://github.com/sourcegraph/zoekt/commit/794ad6c debug: new pages for List and listIndexed
- https://github.com/sourcegraph/zoekt/commit/c85ca2f ranking: boost base filename matches

Test Plan: CI