### PR TITLE
match git@ as well in repo url

### DIFF
--- a/dev/ci/render-pr-preview.sh
+++ b/dev/ci/render-pr-preview.sh
@@ -51,8 +51,8 @@ while getopts 'b:r:d' flag; do
 done
 
 # Get `{owner}/{repo}` part from GitHub repository url
-if [[ "$repo_url" =~ ^(https|git):\/\/github\.com\/(.*)$ ]]; then
-  owner_and_repo="${BASH_REMATCH[2]//\.git/}"
+if [[ "$repo_url" =~ ^(https://|git://|git@)github\.com(:|\/)(.*)$ ]]; then
+  owner_and_repo="${BASH_REMATCH[3]//\.git/}"
 else
   echo "Couldn't find owner_and_repo"
   exit 1


### PR DESCRIPTION
The old regex only matched when there was a protocol. This changes it to accept the ssh format of a repo url as well

Example:
git@github.com:sourcegraph/sourcegraph.git
https://github.com/sourcegraph/sourcegraph
git://github.com/sourcegraph/sourcegraph

## Test plan
Manually tested
[green ci main-dry-run build](https://buildkite.com/sourcegraph/sourcegraph/builds?branch=main-dry-run%2Fwbezuide%2Fregex-build-test)
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
