### PR TITLE
search: link to skipped files on repo status page

### DIFF
--- a/client/web/src/repo/settings/RepoSettingsIndexPage.tsx
+++ b/client/web/src/repo/settings/RepoSettingsIndexPage.tsx
@@ -47,6 +47,10 @@ function fetchRepositoryTextSearchIndex(id: Scalars['ID']): Observable<GQL.IRepo
                                     displayName
                                     url
                                 }
+                                skippedIndexed {
+                                    count
+                                    query
+                                }
                                 indexed
                                 current
                                 indexedCommit {
@@ -102,6 +106,15 @@ const TextSearchIndexedReference: React.FunctionComponent<
                         </LinkOrSpan>
                     </Code>{' '}
                     {indexedRef.current ? '(up to date)' : '(index update in progress)'}
+                    {indexedRef.skippedIndexed && indexedRef.skippedIndexed.count > 0 ? (
+                        <span>
+                            .&nbsp;
+                            <Link to={'/search?q=' + encodeURIComponent(indexedRef.skippedIndexed.query)}>
+                                {indexedRef.skippedIndexed.count} files were not indexed
+                            </Link>
+                            .
+                        </span>
+                    ) : null}
                 </span>
             ) : (
                 <span>&nbsp;&mdash; initial indexing in progress</span>

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -2928,6 +2928,24 @@ type RepositoryTextSearchIndexedRef {
     indexed is false, this field's value is null.
     """
     indexedCommit: GitObject
+    """
+    EXPERIMENTAL: Information about the files that were not indexed.
+    """
+    skippedIndexed: SkippedIndexed
+}
+
+"""
+EXPERIMENTAL: Information about the files that were not indexed.
+"""
+type SkippedIndexed {
+    """
+    The count of files that were not indexed.
+    """
+    count: BigInt!
+    """
+    The query to retrieve the list of files that were not indexed.
+    """
+    query: String!
 }
 
 """


### PR DESCRIPTION
With this change we display the number of skipped files next to the indexed branch/revision on the repository's status page. The user can click on the text to display the list of skipped files. So far, this information was hidden from the admins, which led to many customer issues regarding "missing files". 

Background:
During indexing, Zoekt may decide to skip a document for various reasons. If a document is skipped, Zoekt replaces the content of the skipped document with "NOT-INDEXED: <reason>"

![not-indexed](https://user-images.githubusercontent.com/26413131/173792346-014488c1-4e7c-46a0-b656-005457c924bc.gif)

## Test plan
- existing tests
- manual testing
  - enabled multi-branch indexing and search on a local instance
```
"experimentalFeatures": {
    "searchMultipleRevisionsPerRepository": true,
    "search.index.branches": {
      "github.com/sourcegraph/sourcegraph": [
        "main",
        "fj/welcome",
      ],
    },
    "search.index.revisions": [
      {
        "name": "^github.com/sourcegraph/sourcegraph$",
        "revisions": [
          "3.39",
        ]
      }
    ]   
  }
```
  - tested the new link and compared the numbers to the stats displayed on the results pages
  - deleted an index from disk and made sure the status page doesn't break 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
