### PR TITLE
Revert "Update server bundled postgres (#37178)"

### DIFF
--- a/cmd/server/Dockerfile
+++ b/cmd/server/Dockerfile
@@ -52,8 +52,8 @@ RUN apk add --no-cache --verbose \
     # You can't just bump the major version since that requires pgupgrade
     # between Sourcegraph releases.
     && apk add --no-cache --verbose \
-    'postgresql=>12.11' \
-    'postgresql-contrib=>12.11' \
+    postgresql=~12 \
+    postgresql-contrib=~12 \
     --repository=http://dl-cdn.alpinelinux.org/alpine/v3.12/main  \
     && apk add --no-cache --verbose \
     'bash>=5.0.17' \


### PR DESCRIPTION
This reverts commit 46179457cca19eb5f337684b9dc2396e5ea3dfe6.

The server upgrade test is currently broken with the following error:
```
2022-06-14T14:02:42.223104733Z $ /usr/local/bin/migrator migrator up -db frontend
2022-06-14T14:02:42.236285241Z [0;32m14:02:42 postgres | [0m2022-06-14 14:02:42.234 UTC [25] FATAL:  database files are incompatible with server
2022-06-14T14:02:42.236304756Z [0;32m14:02:42 postgres | [0m2022-06-14 14:02:42.234 UTC [25] DETAIL:  The data directory was initialized by PostgreSQL version 12, which is not compatible with this version 13.7.
```


## Test plan

Green server upgrade integration test. 