### PR TITLE
update release tool to reflect 72 hour release cut in RFC 695

### DIFF
--- a/.github/ISSUE_TEMPLATE/request_patch_release.md
+++ b/.github/ISSUE_TEMPLATE/request_patch_release.md
@@ -51,7 +51,7 @@ I have read [when and why we perform patch releases](https://handbook.sourcegrap
     - [ ] Update [`dev/release/release-config.jsonc`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/dev/release/release-config.jsonc) and open a PR to `main` to update it
       - [ ] Change `upcomingRelease` to the current patch release
       - [ ] Change `previousRelease` to the previous patch release version
-      - [ ] Change `releaseDate` to the current date (time is optional) along with `oneWorkingDayAfterRelease` and `oneWorkingDayBeforeRelease`
+      - [ ] Change `releaseDate` to the current date (time is optional) along with `oneWorkingDayAfterRelease` and `threeWorkingDaysBeforeRelease`
       - [ ] Change `captainSlackUsername` and `captainGitHubUsername` accordingly
     - [ ] `yarn release tracking:issues` 
     - [ ] Add the listed commits alongside a link to this issue to the generated [release tracking issue](https://github.com/sourcegraph/sourcegraph/issues?q=is%3Aissue+label%3Arelease-tracking+)

--- a/dev/release/release-config.jsonc
+++ b/dev/release/release-config.jsonc
@@ -17,7 +17,7 @@
     "upcomingRelease": "3.41.0",
     // Release dates
     "oneWorkingWeekBeforeRelease": "13 June 2022 10:00 PST",
-    "oneWorkingDayBeforeRelease": "17 June 2022 10:00 PST",
+    "threeWorkingDaysBeforeRelease": "17 June 2022 10:00 PST",
     "releaseDate": "20 June 2022 10:00 PST",
     "oneWorkingDayAfterRelease": "21 June 2022 10:00 PST",
     // Channel where messages from the tooling are posted

--- a/dev/release/src/config.ts
+++ b/dev/release/src/config.ts
@@ -18,7 +18,7 @@ export interface Config {
     upcomingRelease: string
 
     oneWorkingWeekBeforeRelease: string
-    oneWorkingDayBeforeRelease: string
+    threeWorkingDaysBeforeRelease: string
     releaseDate: string
     oneWorkingDayAfterRelease: string
 

--- a/dev/release/src/github.ts
+++ b/dev/release/src/github.ts
@@ -82,7 +82,7 @@ interface IssueTemplateArguments {
     /**
      * Available as `$ONE_WORKING_DAY_BEFORE_RELEASE`
      */
-    oneWorkingDayBeforeRelease: Date
+    threeWorkingDaysBeforeRelease: Date
     /**
      * Available as `$RELEASE_DATE`
      */
@@ -138,7 +138,7 @@ function dateMarkdown(date: Date, name: string): string {
 async function execTemplate(
     octokit: Octokit,
     template: IssueTemplate,
-    { version, oneWorkingDayBeforeRelease, releaseDate, oneWorkingDayAfterRelease }: IssueTemplateArguments
+    { version, threeWorkingDaysBeforeRelease, releaseDate, oneWorkingDayAfterRelease }: IssueTemplateArguments
 ): Promise<string> {
     console.log(`Preparing issue from ${JSON.stringify(template)}`)
     const name = releaseName(version)
@@ -149,7 +149,7 @@ async function execTemplate(
         .replace(/\$PATCH/g, version.patch.toString())
         .replace(
             /\$ONE_WORKING_DAY_BEFORE_RELEASE/g,
-            dateMarkdown(oneWorkingDayBeforeRelease, `One working day before ${name} release`)
+            dateMarkdown(threeWorkingDaysBeforeRelease, `One working day before ${name} release`)
         )
         .replace(/\$RELEASE_DATE/g, dateMarkdown(releaseDate, `${name} release date`))
         .replace(
@@ -174,14 +174,14 @@ export async function ensureTrackingIssues({
     version,
     assignees,
     releaseDate,
-    oneWorkingDayBeforeRelease,
+    threeWorkingDaysBeforeRelease,
     oneWorkingDayAfterRelease,
     dryRun,
 }: {
     version: semver.SemVer
     assignees: string[]
     releaseDate: Date
-    oneWorkingDayBeforeRelease: Date
+    threeWorkingDaysBeforeRelease: Date
     oneWorkingDayAfterRelease: Date
     dryRun: boolean
 }): Promise<MaybeIssue[]> {
@@ -217,7 +217,7 @@ export async function ensureTrackingIssues({
         const body = await execTemplate(octokit, template, {
             version,
             releaseDate,
-            oneWorkingDayBeforeRelease,
+            threeWorkingDaysBeforeRelease,
             oneWorkingDayAfterRelease,
         })
         const issue = await ensureIssue(

--- a/dev/release/src/release.ts
+++ b/dev/release/src/release.ts
@@ -131,7 +131,7 @@ const steps: Step[] = [
                     anyoneCanAddSelf: true,
                     attendees: [config.teamEmail],
                     transparency: 'transparent',
-                    ...calendarTime(config.oneWorkingDayBeforeRelease),
+                    ...calendarTime(config.threeWorkingDaysBeforeRelease),
                 },
                 {
                     title: `Release Sourcegraph ${name}`,
@@ -169,7 +169,7 @@ const steps: Step[] = [
             const {
                 releaseDate,
                 captainGitHubUsername,
-                oneWorkingDayBeforeRelease,
+                threeWorkingDaysBeforeRelease,
                 oneWorkingDayAfterRelease,
                 captainSlackUsername,
                 slackAnnounceChannel,
@@ -183,7 +183,7 @@ const steps: Step[] = [
                 version: release,
                 assignees: [captainGitHubUsername],
                 releaseDate: date,
-                oneWorkingDayBeforeRelease: new Date(oneWorkingDayBeforeRelease),
+                threeWorkingDaysBeforeRelease: new Date(threeWorkingDaysBeforeRelease),
                 oneWorkingDayAfterRelease: new Date(oneWorkingDayAfterRelease),
                 dryRun: dryRun.trackingIssues || false,
             })


### PR DESCRIPTION
Updating the release tool to reflect the new release cut. This is a trivial PR that only changes the field name for future readers, and updates documentation.

## Test plan

Dry run of `yarn run release tracking:timeline` to ensure the fields are still appropriately assigned to the calendar API requests.

```
➜  sourcegraph git:(main) ✗ yarn run release tracking:timeline
yarn run v1.22.17
$ cd dev/release && yarn run release tracking:timeline
$ ts-node --transpile-only ./src/main.ts tracking:timeline
Using versions: { upcoming: 3.41.0, previous: 3.40.2 }
dryRun.calendar=true, skipping calendar event creation [
  {
    title: 'Security Team to Review Release Container Image Scans 3.41',
    description: '(This is not an actual event to attend, just a calendar marker.)',
    anyoneCanAddSelf: true,
    attendees: [ 'redacted@sourcegraph.com' ],
    transparency: 'transparent',
    startDateTime: '2022-06-13T18:00:00.000Z',
    endDateTime: '2022-06-13T18:01:00.000Z'
  },
  {
    title: 'Cut Sourcegraph 3.41',
    description: '(This is not an actual event to attend, just a calendar marker.)',
    anyoneCanAddSelf: true,
    attendees: [ 'redacted@sourcegraph.com' ],
    transparency: 'transparent',
    startDateTime: '2022-06-17T18:00:00.000Z',
    endDateTime: '2022-06-17T18:01:00.000Z'
  },
  {
    title: 'Release Sourcegraph 3.41',
    description: '(This is not an actual event to attend, just a calendar marker.)',
    anyoneCanAddSelf: true,
    attendees: [ 'redacted@sourcegraph.com' ],
    transparency: 'transparent',
    startDateTime: '2022-06-20T18:00:00.000Z',
    endDateTime: '2022-06-20T18:01:00.000Z'
  },
  {
    title: 'Deploy Sourcegraph 3.41 to managed instances',
    description: '(This is not an actual event to attend, just a calendar marker.)',
    anyoneCanAddSelf: true,
    attendees: [ 'team@sourcegraph.com' ],
    transparency: 'transparent',
    startDateTime: '2022-06-21T18:00:00.000Z',
    endDateTime: '2022-06-21T18:01:00.000Z'
  }
]
✨  Done in 4.16s.

```

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
