### PR TITLE
Upgrade server bundled postgres and pin version

### DIFF
--- a/cmd/server/Dockerfile
+++ b/cmd/server/Dockerfile
@@ -52,8 +52,8 @@ RUN apk add --no-cache --verbose \
     # You can't just bump the major version since that requires pgupgrade
     # between Sourcegraph releases.
     && apk add --no-cache --verbose \
-    postgresql=~12 \
-    postgresql-contrib=~12 \
+    postgresql=12.11 \
+    postgresql-contrib=12.11 \
     --repository=http://dl-cdn.alpinelinux.org/alpine/v3.12/main  \
     && apk add --no-cache --verbose \
     'bash>=5.0.17' \

--- a/cmd/server/Dockerfile
+++ b/cmd/server/Dockerfile
@@ -52,8 +52,8 @@ RUN apk add --no-cache --verbose \
     # You can't just bump the major version since that requires pgupgrade
     # between Sourcegraph releases.
     && apk add --no-cache --verbose \
-    postgresql=12.11 \
-    postgresql-contrib=12.11 \
+    postgresql=~12.11 \
+    postgresql-contrib=~12.11 \
     --repository=http://dl-cdn.alpinelinux.org/alpine/v3.12/main  \
     && apk add --no-cache --verbose \
     'bash>=5.0.17' \

--- a/cmd/server/Dockerfile
+++ b/cmd/server/Dockerfile
@@ -44,7 +44,7 @@ RUN apk add --no-cache --verbose \
     # We require git 2.34.1 because we use git-repack with flag --write-midx.
     'git>=2.34.1' \
     git-p4 \
-    --repository=http://dl-cdn.alpinelinux.org/alpine/v3.15/main  \
+    --repository=http://dl-cdn.alpinelinux.org/alpine/v3.14/main  \
     # NOTE that the Postgres version we run is different
     # from our *Minimum Supported Version* which alone dictates
     # the features we can depend on. See this link for more information:
@@ -54,7 +54,7 @@ RUN apk add --no-cache --verbose \
     && apk add --no-cache --verbose \
     postgresql=~12.11 \
     postgresql-contrib=~12.11 \
-    --repository=http://dl-cdn.alpinelinux.org/alpine/v3.12/main  \
+    --repository=http://dl-cdn.alpinelinux.org/alpine/v3.14/main  \
     && apk add --no-cache --verbose \
     'bash>=5.0.17' \
     'redis>=5.0' \

--- a/cmd/server/Dockerfile
+++ b/cmd/server/Dockerfile
@@ -39,12 +39,8 @@ LABEL org.opencontainers.image.created=${DATE}
 LABEL org.opencontainers.image.version=${VERSION}
 LABEL com.sourcegraph.github.url=https://github.com/sourcegraph/sourcegraph/commit/${COMMIT_SHA}
 
+# Misc. tools we can install from default repository
 RUN apk add --no-cache --verbose \
-    --repository=http://dl-cdn.alpinelinux.org/alpine/v3.14/main \
-    # [NOTE: git-version-min-requirement]
-    # We require git 2.34.1 because we use git-repack with flag --write-midx.
-    'git>=2.34.1' \
-    git-p4 \
     'bash>=5.0.17' \
     'redis>=5.0' \
     python2 \
@@ -59,6 +55,14 @@ RUN apk add --no-cache --verbose \
     # We require libstdc++ for p4-fusion
     libstdc++
 
+# [NOTE: git-version-min-requirement]
+# We require git 2.34.1 because we use git-repack with flag --write-midx. This must be
+# installed from 3.15+
+RUN apk add --no-cache --verbose \
+    --repository=http://dl-cdn.alpinelinux.org/alpine/v3.15/main \
+    'git>=2.34.1' \
+    git-p4
+
 # NOTE that the Postgres version we run is different
 # from our *Minimum Supported Version* which alone dictates
 # the features we can depend on. See this link for more information:
@@ -66,7 +70,7 @@ RUN apk add --no-cache --verbose \
 # You can't just bump the major version since that requires pgupgrade
 # between Sourcegraph releases.
 #
-# We require a separate 'apk add' from a different repository because of the lack of
+# We require a separate 'apk add' from the 3.15/community repository because of the lack of
 # availability on alpine main repositories.
 RUN apk add --no-cache --verbose \
     --repository=http://dl-cdn.alpinelinux.org/alpine/v3.15/community \

--- a/cmd/server/Dockerfile
+++ b/cmd/server/Dockerfile
@@ -44,7 +44,20 @@ RUN apk add --no-cache --verbose \
     # [NOTE: git-version-min-requirement]
     # We require git 2.34.1 because we use git-repack with flag --write-midx.
     'git>=2.34.1' \
-    git-p4
+    git-p4 \
+    'bash>=5.0.17' \
+    'redis>=5.0' \
+    python2 \
+    python3 \
+    'nginx>=1.18.0' \
+    openssh-client \
+    pcre \
+    sqlite-libs \
+    libev \
+    su-exec \
+    'nodejs-current>=14.5.0' \
+    # We require libstdc++ for p4-fusion
+    libstdc++
 
 # NOTE that the Postgres version we run is different
 # from our *Minimum Supported Version* which alone dictates
@@ -52,20 +65,13 @@ RUN apk add --no-cache --verbose \
 # https://github.com/sourcegraph/sourcegraph/blob/main/doc/dev/postgresql.md#version-requirements
 # You can't just bump the major version since that requires pgupgrade
 # between Sourcegraph releases.
+#
+# We require a separate 'apk add' from a different repository because of the lack of
+# availability on alpine main repositories.
 RUN apk add --no-cache --verbose \
-    --repository=http://dl-cdn.alpinelinux.org/alpine/v3.15/community  \
-    postgresql12>=12.11 \
-    postgresql12-contrib>=12.11
-
-RUN apk add --no-cache --verbose \
-    --repository=http://dl-cdn.alpinelinux.org/alpine/v3.14/main  \
-    'bash>=5.0.17' \
-    'redis>=5.0' \
-    python2 \
-    python3 \
-    'nginx>=1.18.0' openssh-client pcre sqlite-libs libev su-exec 'nodejs-current>=14.5.0' \
-    # We require libstdc++ for p4-fusion
-    libstdc++
+    --repository=http://dl-cdn.alpinelinux.org/alpine/v3.15/community \
+    'postgresql12>=12.11' \
+    'postgresql12-contrib>=12.11'
 
 # IMPORTANT: If you update the syntect_server version below, you MUST confirm
 # the ENV variables from its Dockerfile (https://github.com/sourcegraph/syntect_server/blob/master/Dockerfile)

--- a/cmd/server/Dockerfile
+++ b/cmd/server/Dockerfile
@@ -53,10 +53,12 @@ RUN apk add --no-cache --verbose \
 # You can't just bump the major version since that requires pgupgrade
 # between Sourcegraph releases.
 RUN apk add --no-cache --verbose \
+    --repository=http://dl-cdn.alpinelinux.org/alpine/v3.15/community  \
+    postgresql12>=12.11 \
+    postgresql12-contrib>=12.11
+
+RUN apk add --no-cache --verbose \
     --repository=http://dl-cdn.alpinelinux.org/alpine/v3.14/main  \
-    postgresql=~12.11 \
-    postgresql-contrib=~12.11 \
-    && apk add --no-cache --verbose \
     'bash>=5.0.17' \
     'redis>=5.0' \
     python2 \

--- a/cmd/server/Dockerfile
+++ b/cmd/server/Dockerfile
@@ -40,21 +40,22 @@ LABEL org.opencontainers.image.version=${VERSION}
 LABEL com.sourcegraph.github.url=https://github.com/sourcegraph/sourcegraph/commit/${COMMIT_SHA}
 
 RUN apk add --no-cache --verbose \
+    --repository=http://dl-cdn.alpinelinux.org/alpine/v3.14/main \
     # [NOTE: git-version-min-requirement]
     # We require git 2.34.1 because we use git-repack with flag --write-midx.
     'git>=2.34.1' \
-    git-p4 \
+    git-p4
+
+# NOTE that the Postgres version we run is different
+# from our *Minimum Supported Version* which alone dictates
+# the features we can depend on. See this link for more information:
+# https://github.com/sourcegraph/sourcegraph/blob/main/doc/dev/postgresql.md#version-requirements
+# You can't just bump the major version since that requires pgupgrade
+# between Sourcegraph releases.
+RUN apk add --no-cache --verbose \
     --repository=http://dl-cdn.alpinelinux.org/alpine/v3.14/main  \
-    # NOTE that the Postgres version we run is different
-    # from our *Minimum Supported Version* which alone dictates
-    # the features we can depend on. See this link for more information:
-    # https://github.com/sourcegraph/sourcegraph/blob/main/doc/dev/postgresql.md#version-requirements
-    # You can't just bump the major version since that requires pgupgrade
-    # between Sourcegraph releases.
-    && apk add --no-cache --verbose \
     postgresql=~12.11 \
     postgresql-contrib=~12.11 \
-    --repository=http://dl-cdn.alpinelinux.org/alpine/v3.14/main  \
     && apk add --no-cache --verbose \
     'bash>=5.0.17' \
     'redis>=5.0' \


### PR DESCRIPTION
A second attempt at upgrading Postgres to 12.11 and pinning the version so that
we are patched against CVE-2022-1552. We are not actively affected but are
upgrading regardless for completeness.

## Test plan

CI checks
