### PR TITLE
batches: add feature flag for hiding `Run Batch Spec` button

### DIFF
--- a/client/web/src/enterprise/batches/batch-spec/edit/EditBatchSpecPage.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/edit/EditBatchSpecPage.tsx
@@ -10,6 +10,7 @@ import { ThemeProps } from '@sourcegraph/shared/src/theme'
 import { Button, Icon, LoadingSpinner, H4, Alert } from '@sourcegraph/wildcard'
 
 import { HeroPage } from '../../../../components/HeroPage'
+import { useFeatureFlag } from '../../../../featureFlags/useFeatureFlag'
 import {
     CheckExecutorsAccessTokenResult,
     CheckExecutorsAccessTokenVariables,
@@ -158,6 +159,11 @@ const MemoizedEditBatchSpecPageContent: React.FunctionComponent<
         'batches.downloadSpecModalDismissed',
         false
     )
+    /**
+     * For managed instances we want to hide the `run server side` button by default. To do this we make use of a
+     * feature flag to ensure Managed Instances.
+     */
+    const [isRunBatchSpecButtonDisabled] = useFeatureFlag('hide-run-batch-spec-for-mi', false)
 
     const activeExecutorsActionButtons = (
         <>
@@ -202,9 +208,15 @@ const MemoizedEditBatchSpecPageContent: React.FunctionComponent<
                 </Button>
             )}
 
-            <Button className={styles.downloadLink} variant="link" onClick={() => setIsRunServerSideModalOpen(true)}>
-                or run server-side
-            </Button>
+            {isRunBatchSpecButtonDisabled ? (
+                <Button
+                    className={styles.downloadLink}
+                    variant="link"
+                    onClick={() => setIsRunServerSideModalOpen(true)}
+                >
+                    or run server-side
+                </Button>
+            ) : null}
         </>
     )
 

--- a/client/web/src/enterprise/batches/batch-spec/edit/EditBatchSpecPage.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/edit/EditBatchSpecPage.tsx
@@ -163,7 +163,7 @@ const MemoizedEditBatchSpecPageContent: React.FunctionComponent<
      * For managed instances we want to hide the `run server side` button by default. To do this we make use of a
      * feature flag to ensure Managed Instances.
      */
-    const [isRunBatchSpecButtonDisabled] = useFeatureFlag('hide-run-batch-spec-for-mi', false)
+    const [isRunBatchSpecButtonHidden] = useFeatureFlag('hide-run-batch-spec-for-mi', false)
 
     const activeExecutorsActionButtons = (
         <>
@@ -208,7 +208,7 @@ const MemoizedEditBatchSpecPageContent: React.FunctionComponent<
                 </Button>
             )}
 
-            {isRunBatchSpecButtonDisabled ? (
+            {!isRunBatchSpecButtonHidden && (
                 <Button
                     className={styles.downloadLink}
                     variant="link"
@@ -216,7 +216,7 @@ const MemoizedEditBatchSpecPageContent: React.FunctionComponent<
                 >
                     or run server-side
                 </Button>
-            ) : null}
+            )}
         </>
     )
 

--- a/client/web/src/featureFlags/featureFlags.ts
+++ b/client/web/src/featureFlags/featureFlags.ts
@@ -11,6 +11,7 @@ export type FeatureFlagName =
     | 'insight-polling-enabled'
     | 'ab-visitor-tour-with-notebooks'
     | 'ab-email-verification-alert'
+    | 'hide-run-batch-spec-for-mi'
 
 interface OrgFlagOverride {
     orgID: string


### PR DESCRIPTION
Part 1 #36920 

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
* Spin up a sourcegraph instance without any active executor
* Create a batch change 

<img width="2543" alt="CleanShot 2022-06-14 at 21 48 29@2x" src="https://user-images.githubusercontent.com/25608335/173685948-8e59eaef-78a2-450a-94f5-021c7d953771.png">

When the flag `'hide-run-batch-spec-for-mi'` is set to true, the `run server-side` button is hidden

## App preview:

- [Web](https://sg-web-bo-create-feature-flag-hide-run.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-hbqymuprzf.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
