### PR TITLE
Event logs: allow logging URLs from all sourcegraph domains in local event logs

### DIFF
--- a/internal/database/event_logs.go
+++ b/internal/database/event_logs.go
@@ -167,10 +167,10 @@ func SanitizeEventURL(raw string) string {
 
 	// Check if the URL belongs to the current site
 	normalized := u.String()
-	if !strings.HasPrefix(normalized, conf.ExternalURL()) {
-		return ""
+	if strings.HasPrefix(normalized, conf.ExternalURL()) || strings.HasSuffix(u.Host, "sourcegraph.com") {
+		return normalized
 	}
-	return normalized
+	return ""
 }
 
 // Event contains information needed for logging an event.


### PR DESCRIPTION
This updates the local event log URL redaction code to allow any URLs
ending in sourcegraph.com to be logged. Note that when sending event
logs to BigQuery, we redact all https://sourcegraph.com URLs so that
private information isn't leaving the cluster, however that isn't a
concern for local event logs.

## Test plan

Added unit test that documents a few cases of how this should work. 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
