### PR TITLE
batches: require additional workspaces preview when execution options change

### DIFF
--- a/client/web/src/enterprise/batches/batch-spec/BatchSpecContext.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/BatchSpecContext.tsx
@@ -1,5 +1,7 @@
 import React, { useCallback, useMemo, useState } from 'react'
 
+import { isEqual } from 'lodash'
+
 import {
     BatchSpecExecutionFields,
     BatchSpecState,
@@ -122,10 +124,42 @@ export const BatchSpecContextProvider = <BatchSpecFields extends MinimalBatchSpe
     const isBatchSpecApplied = useMemo(() => currentSpec.id === batchSpec.id, [currentSpec.id, batchSpec.id])
 
     const editor = useBatchSpecCode(batchSpec.originalInput, batchChange.name)
-    const { handleCodeChange, isValid, isServerStale } = editor
+    const { handleCodeChange, isValid, isServerStale: isServerBatchSpecYAMLStale } = editor
 
     const [filters, setFilters] = useState<WorkspacePreviewFilters>()
-    const [executionOptions, setExecutionOptions] = useState<ExecutionOptions>(DEFAULT_EXECUTION_OPTIONS)
+    const [executionOptions, _setExecutionOptions] = useState<ExecutionOptions>(DEFAULT_EXECUTION_OPTIONS)
+    // Currently, execution options are sent with the workspaces preview request,
+    // not the execution request. In other words, we only honor the currently selected
+    // execution options if you used them for your latest workspaces preview. To prevent
+    // confusion until after the API is updated, we keep track of the last execution
+    // options sent with a workspaces preview request, and if the current options differ,
+    // we mark the workspaces preview as stale to ensure the user triggers a new preview
+    // before trying to execute their batch spec.
+    // TODO: Once the API is updated and the execution mutation honors these options,
+    // this can be removed.
+    const [lastPreviewExecutionOptions, setLastPreviewExecutionOptions] = useState<ExecutionOptions>(
+        DEFAULT_EXECUTION_OPTIONS
+    )
+    const [didExecutionOptionsChange, setDidExecutionOptionsChange] = useState(false)
+
+    // When the user changes the execution options, also check if they differ from the
+    // last options sent with the workspaces preview, and mark the workspaces preview as
+    // stale if they do.
+    // TODO: Once the API is updated and the execution mutation honors execution options,
+    // this can be removed.
+    const setExecutionOptions: (options: ExecutionOptions) => void = useCallback(
+        (options: ExecutionOptions) => {
+            _setExecutionOptions(options)
+            if (isEqual(options, lastPreviewExecutionOptions)) {
+                setDidExecutionOptionsChange(false)
+            } else {
+                setDidExecutionOptionsChange(true)
+            }
+        },
+        [lastPreviewExecutionOptions]
+    )
+
+    const isServerStale = isServerBatchSpecYAMLStale || didExecutionOptionsChange
 
     // Manage the batch spec that was last submitted to the backend for the workspaces preview.
     const workspacesPreview = useWorkspacesPreview(batchSpec.id, {
@@ -141,7 +175,17 @@ export const BatchSpecContextProvider = <BatchSpecFields extends MinimalBatchSpe
         error: previewError,
         clearError: clearPreviewError,
         hasPreviewed,
+        preview: _preview,
     } = workspacesPreview
+
+    // TODO: Once the API is updated and the execution mutation honors execution options,
+    // this can be removed.
+    const preview: UseWorkspacesPreviewResult['preview'] = (code: string) =>
+        _preview(code).then(() => {
+            // Update for the execution options sent with the last preview.
+            setLastPreviewExecutionOptions(executionOptions)
+            setDidExecutionOptionsChange(false)
+        })
 
     // Disable triggering a new preview if the batch spec code is invalid or if we're
     // already processing a preview.
@@ -219,11 +263,13 @@ export const BatchSpecContextProvider = <BatchSpecFields extends MinimalBatchSpe
                     execute: executeBatchSpec,
                     isExecutionDisabled,
                     executionOptions,
+                    isServerStale,
                     setExecutionOptions,
                     ...testState?.editor,
                 },
                 workspacesPreview: {
                     ...workspacesPreview,
+                    preview,
                     filters,
                     setFilters,
                     isPreviewDisabled,

--- a/client/web/src/enterprise/batches/batch-spec/edit/RunBatchSpecButton.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/edit/RunBatchSpecButton.tsx
@@ -69,7 +69,8 @@ export const RunBatchSpecButton: React.FunctionComponent<React.PropsWithChildren
 
             <PopoverContent className={styles.menuList} position={Position.bottomEnd}>
                 <H3 className="pb-2 pt-3 pl-3 pr-3 m-0">Execution options</H3>
-                <ExecutionOption moreInfo="When this batch spec is executed, it will not use cached results from any previous execution.">
+                {/* TODO: Once the execution mutation honors execution options, this can be removed. */}
+                <ExecutionOption moreInfo="When this batch spec is executed, it will not use cached results from any previous execution. Currently, toggling this option also requires updating the workspaces preview.">
                     <Checkbox
                         name="run-without-cache"
                         id="run-without-cache"


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/37148.

The longer-term solution entails refactoring the execution API so that the workspaces are recomputed if the execution options change between the preview and it, but since we're addressing that more holistically post-beta, this is a more temporary fix that ensures we run another workspaces preview any time the user modifies the execution options.

Demo:

https://user-images.githubusercontent.com/8942601/173692222-150c38b1-b8e4-48c5-bc0c-bf4e41164105.mov

## Test plan

Manually tested stale workspaces preview behavior.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
