### PR TITLE
code monitoring: log frontend events

### DIFF
--- a/client/web/dev/mocks/mockEventLogger.ts
+++ b/client/web/dev/mocks/mockEventLogger.ts
@@ -3,5 +3,6 @@ jest.mock('@sourcegraph/web/src/tracking/eventLogger', () => ({
     eventLogger: {
         log: () => undefined,
         logViewEvent: () => undefined,
+        logPageView: () => undefined,
     },
 }))

--- a/client/web/src/enterprise/code-monitoring/CodeMonitoringGettingStarted.tsx
+++ b/client/web/src/enterprise/code-monitoring/CodeMonitoringGettingStarted.tsx
@@ -1,8 +1,9 @@
-import React from 'react'
+import React, { useCallback } from 'react'
 
 import classNames from 'classnames'
 import PlusIcon from 'mdi-react/PlusIcon'
 
+import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
 import { Link, Button, CardBody, Card, Icon, H2, H3, H4, Text } from '@sourcegraph/wildcard'
 
@@ -10,7 +11,7 @@ import { CodeMonitorSignUpLink } from './CodeMonitoringSignUpLink'
 
 import styles from './CodeMonitoringGettingStarted.module.scss'
 
-interface CodeMonitoringGettingStartedProps extends ThemeProps {
+interface CodeMonitoringGettingStartedProps extends ThemeProps, TelemetryProps {
     isSignedIn: boolean
 }
 
@@ -63,8 +64,12 @@ const createCodeMonitorUrl = (example: ExampleCodeMonitor): string => {
 
 export const CodeMonitoringGettingStarted: React.FunctionComponent<
     React.PropsWithChildren<CodeMonitoringGettingStartedProps>
-> = ({ isLightTheme, isSignedIn }) => {
+> = ({ isLightTheme, isSignedIn, telemetryService }) => {
     const assetsRoot = window.context?.assetsRoot || ''
+
+    const logExampleMonitorClicked = useCallback(() => {
+        telemetryService.log('CodeMonitoringExampleMonitorClicked')
+    }, [telemetryService])
 
     return (
         <div>
@@ -110,7 +115,9 @@ export const CodeMonitoringGettingStarted: React.FunctionComponent<
                                 <CardBody className="d-flex flex-column">
                                     <H3>{monitor.title}</H3>
                                     <Text className="text-muted flex-grow-1">{monitor.description}</Text>
-                                    <Link to={createCodeMonitorUrl(monitor)}>Create copy of monitor</Link>
+                                    <Link to={createCodeMonitorUrl(monitor)} onClick={logExampleMonitorClicked}>
+                                        Create copy of monitor
+                                    </Link>
                                 </CardBody>
                             </Card>
                         </div>

--- a/client/web/src/enterprise/code-monitoring/CodeMonitoringGettingStarted.tsx
+++ b/client/web/src/enterprise/code-monitoring/CodeMonitoringGettingStarted.tsx
@@ -3,15 +3,16 @@ import React, { useCallback } from 'react'
 import classNames from 'classnames'
 import PlusIcon from 'mdi-react/PlusIcon'
 
-import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
 import { Link, Button, CardBody, Card, Icon, H2, H3, H4, Text } from '@sourcegraph/wildcard'
+
+import { eventLogger } from '../../tracking/eventLogger'
 
 import { CodeMonitorSignUpLink } from './CodeMonitoringSignUpLink'
 
 import styles from './CodeMonitoringGettingStarted.module.scss'
 
-interface CodeMonitoringGettingStartedProps extends ThemeProps, TelemetryProps {
+interface CodeMonitoringGettingStartedProps extends ThemeProps {
     isSignedIn: boolean
 }
 
@@ -64,12 +65,12 @@ const createCodeMonitorUrl = (example: ExampleCodeMonitor): string => {
 
 export const CodeMonitoringGettingStarted: React.FunctionComponent<
     React.PropsWithChildren<CodeMonitoringGettingStartedProps>
-> = ({ isLightTheme, isSignedIn, telemetryService }) => {
+> = ({ isLightTheme, isSignedIn }) => {
     const assetsRoot = window.context?.assetsRoot || ''
 
     const logExampleMonitorClicked = useCallback(() => {
-        telemetryService.log('CodeMonitoringExampleMonitorClicked')
-    }, [telemetryService])
+        eventLogger.log('CodeMonitoringExampleMonitorClicked')
+    }, [])
 
     return (
         <div>

--- a/client/web/src/enterprise/code-monitoring/CodeMonitoringPage.tsx
+++ b/client/web/src/enterprise/code-monitoring/CodeMonitoringPage.tsx
@@ -1,9 +1,9 @@
-import React, { useMemo, useEffect, useState } from 'react'
+import React, { useMemo, useEffect, useState, useLayoutEffect } from 'react'
 
 import classNames from 'classnames'
 import PlusIcon from 'mdi-react/PlusIcon'
 import { of } from 'rxjs'
-import { catchError, map, startWith } from 'rxjs/operators'
+import { catchError, map } from 'rxjs/operators'
 
 import { asError, isErrorLike } from '@sourcegraph/common'
 import { Settings } from '@sourcegraph/shared/src/schema/settings.schema'
@@ -49,8 +49,6 @@ export const CodeMonitoringPage: React.FunctionComponent<React.PropsWithChildren
     isLightTheme,
     testForceTab,
 }) => {
-    const LOADING = 'loading' as const
-
     const userHasCodeMonitors = useObservable(
         useMemo(
             () =>
@@ -61,7 +59,6 @@ export const CodeMonitoringPage: React.FunctionComponent<React.PropsWithChildren
                           after: null,
                       }).pipe(
                           map(monitors => monitors.nodes.length > 0),
-                          startWith(LOADING),
                           catchError(error => [asError(error)])
                       )
                     : of(false),
@@ -69,38 +66,43 @@ export const CodeMonitoringPage: React.FunctionComponent<React.PropsWithChildren
         )
     )
 
-    const [currentTab, setCurrentTab] = useState<'list' | 'getting-started' | 'logs'>('list')
+    const [currentTab, setCurrentTab] = useState<'list' | 'getting-started' | 'logs' | null>(null)
 
-    // If user has no code monitors, default to the getting started tab after loading
-    useEffect(() => {
-        if (userHasCodeMonitors === false) {
+    // Select the appropriate tab after loading:
+    // - If the user has code monitors, show the list tab
+    // - If the user has no code monitors, show the getting started tab
+    useLayoutEffect(() => {
+        if (userHasCodeMonitors === true) {
+            setCurrentTab('list')
+        } else if (userHasCodeMonitors === false) {
             setCurrentTab('getting-started')
         }
     }, [userHasCodeMonitors])
 
     // Force tab for testing
-    useEffect(() => {
+    useLayoutEffect(() => {
         if (testForceTab && testForceTab !== currentTab) {
             setCurrentTab(testForceTab)
         }
     }, [currentTab, testForceTab])
 
-    // Log page view and selected tab
-    useEffect(() => eventLogger.logPageView('CodeMonitoring'), [])
+    // Log page view of selected tab
     useEffect(() => {
-        if (userHasCodeMonitors !== LOADING) {
+        if (userHasCodeMonitors !== undefined) {
             switch (currentTab) {
                 case 'getting-started':
-                    eventLogger.log('CodeMoitoringGettingStartedPageViewed')
+                    eventLogger.logPageView('CodeMonitoringGettingStartedPage')
                     break
                 case 'logs':
-                    eventLogger.log('CodeMoitoringLogsPageViewed')
+                    eventLogger.logPageView('CodeMonitoringLogsPage')
                     break
+                case 'list':
+                    eventLogger.logPageView('CodeMonitoringPage')
             }
         }
     }, [currentTab, userHasCodeMonitors])
 
-    const showList = userHasCodeMonitors !== 'loading' && !isErrorLike(userHasCodeMonitors) && currentTab === 'list'
+    const showList = userHasCodeMonitors !== undefined && !isErrorLike(userHasCodeMonitors) && currentTab === 'list'
 
     const showLogsTab = useExperimentalFeatures(features => features.showCodeMonitoringLogs)
 
@@ -116,14 +118,7 @@ export const CodeMonitoringPage: React.FunctionComponent<React.PropsWithChildren
                     )
                 }
                 description={
-                    userHasCodeMonitors &&
-                    userHasCodeMonitors !== 'loading' &&
-                    !isErrorLike(userHasCodeMonitors) && (
-                        <>
-                            Watch your code for changes and trigger actions to get notifications, send webhooks, and
-                            more.
-                        </>
-                    )
+                    <>Watch your code for changes and trigger actions to get notifications, send webhooks, and more.</>
                 }
                 className="mb-3"
             >
@@ -132,7 +127,7 @@ export const CodeMonitoringPage: React.FunctionComponent<React.PropsWithChildren
                 </PageHeader.Heading>
             </PageHeader>
 
-            {userHasCodeMonitors === 'loading' ? (
+            {userHasCodeMonitors === undefined ? (
                 <LoadingSpinner inline={false} />
             ) : (
                 <div className="d-flex flex-column">

--- a/client/web/src/enterprise/code-monitoring/CodeMonitoringPage.tsx
+++ b/client/web/src/enterprise/code-monitoring/CodeMonitoringPage.tsx
@@ -49,10 +49,7 @@ export const CodeMonitoringPage: React.FunctionComponent<React.PropsWithChildren
     toggleCodeMonitorEnabled = _toggleCodeMonitorEnabled,
     isLightTheme,
     testForceTab,
-    telemetryService,
 }) => {
-    useEffect(() => eventLogger.logPageView('CodeMonitoring'), [])
-
     const LOADING = 'loading' as const
 
     const userHasCodeMonitors = useObservable(
@@ -89,19 +86,20 @@ export const CodeMonitoringPage: React.FunctionComponent<React.PropsWithChildren
         }
     }, [currentTab, testForceTab])
 
-    // Log selected tab
+    // Log page view and selected tab
+    useEffect(() => eventLogger.logPageView('CodeMonitoring'), [])
     useEffect(() => {
         if (userHasCodeMonitors !== LOADING) {
             switch (currentTab) {
                 case 'getting-started':
-                    telemetryService.log('CodeMoitoringGettingStartedPageViewed')
+                    eventLogger.log('CodeMoitoringGettingStartedPageViewed')
                     break
                 case 'logs':
-                    telemetryService.log('CodeMoitoringLogsPageViewed')
+                    eventLogger.log('CodeMoitoringLogsPageViewed')
                     break
             }
         }
-    }, [currentTab, telemetryService, userHasCodeMonitors])
+    }, [currentTab, userHasCodeMonitors])
 
     const showList = userHasCodeMonitors !== 'loading' && !isErrorLike(userHasCodeMonitors) && currentTab === 'list'
 
@@ -196,11 +194,7 @@ export const CodeMonitoringPage: React.FunctionComponent<React.PropsWithChildren
                     </div>
 
                     {currentTab === 'getting-started' && (
-                        <CodeMonitoringGettingStarted
-                            telemetryService={telemetryService}
-                            isLightTheme={isLightTheme}
-                            isSignedIn={!!authenticatedUser}
-                        />
+                        <CodeMonitoringGettingStarted isLightTheme={isLightTheme} isSignedIn={!!authenticatedUser} />
                     )}
 
                     {currentTab === 'logs' && <CodeMonitoringLogs />}

--- a/client/web/src/enterprise/code-monitoring/CodeMonitoringPage.tsx
+++ b/client/web/src/enterprise/code-monitoring/CodeMonitoringPage.tsx
@@ -196,7 +196,11 @@ export const CodeMonitoringPage: React.FunctionComponent<React.PropsWithChildren
                     </div>
 
                     {currentTab === 'getting-started' && (
-                        <CodeMonitoringGettingStarted isLightTheme={isLightTheme} isSignedIn={!!authenticatedUser} />
+                        <CodeMonitoringGettingStarted
+                            telemetryService={telemetryService}
+                            isLightTheme={isLightTheme}
+                            isSignedIn={!!authenticatedUser}
+                        />
                     )}
 
                     {currentTab === 'logs' && <CodeMonitoringLogs />}

--- a/client/web/src/enterprise/code-monitoring/CodeMonitoringPage.tsx
+++ b/client/web/src/enterprise/code-monitoring/CodeMonitoringPage.tsx
@@ -8,7 +8,6 @@ import { catchError, map, startWith } from 'rxjs/operators'
 import { asError, isErrorLike } from '@sourcegraph/common'
 import { Settings } from '@sourcegraph/shared/src/schema/settings.schema'
 import { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
-import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
 import {
     PageHeader,
@@ -34,7 +33,7 @@ import { CodeMonitoringGettingStarted } from './CodeMonitoringGettingStarted'
 import { CodeMonitoringLogs } from './CodeMonitoringLogs'
 import { CodeMonitorList } from './CodeMonitorList'
 
-export interface CodeMonitoringPageProps extends SettingsCascadeProps<Settings>, ThemeProps, TelemetryProps {
+export interface CodeMonitoringPageProps extends SettingsCascadeProps<Settings>, ThemeProps {
     authenticatedUser: AuthenticatedUser | null
     fetchUserCodeMonitors?: typeof _fetchUserCodeMonitors
     toggleCodeMonitorEnabled?: typeof _toggleCodeMonitorEnabled

--- a/client/web/src/enterprise/code-monitoring/CreateCodeMonitorPage.tsx
+++ b/client/web/src/enterprise/code-monitoring/CreateCodeMonitorPage.tsx
@@ -4,7 +4,6 @@ import VisuallyHidden from '@reach/visually-hidden'
 import * as H from 'history'
 import { Observable } from 'rxjs'
 
-import { TelemetryService } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
 import { PageHeader, Link } from '@sourcegraph/wildcard'
 
@@ -19,7 +18,7 @@ import { convertActionsForCreate } from './action-converters'
 import { createCodeMonitor as _createCodeMonitor } from './backend'
 import { CodeMonitorForm } from './components/CodeMonitorForm'
 
-interface CreateCodeMonitorPageProps extends ThemeProps, TelemetryService {
+interface CreateCodeMonitorPageProps extends ThemeProps {
     location: H.Location
     history: H.History
     authenticatedUser: AuthenticatedUser

--- a/client/web/src/enterprise/code-monitoring/CreateCodeMonitorPage.tsx
+++ b/client/web/src/enterprise/code-monitoring/CreateCodeMonitorPage.tsx
@@ -4,6 +4,7 @@ import VisuallyHidden from '@reach/visually-hidden'
 import * as H from 'history'
 import { Observable } from 'rxjs'
 
+import { TelemetryService } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
 import { PageHeader, Link } from '@sourcegraph/wildcard'
 
@@ -18,7 +19,7 @@ import { convertActionsForCreate } from './action-converters'
 import { createCodeMonitor as _createCodeMonitor } from './backend'
 import { CodeMonitorForm } from './components/CodeMonitorForm'
 
-interface CreateCodeMonitorPageProps extends ThemeProps {
+interface CreateCodeMonitorPageProps extends ThemeProps, TelemetryService {
     location: H.Location
     history: H.History
     authenticatedUser: AuthenticatedUser
@@ -48,7 +49,7 @@ const AuthenticatedCreateCodeMonitorPage: React.FunctionComponent<
 
     useEffect(
         () =>
-            eventLogger.logViewEvent('CreateCodeMonitorPage', {
+            eventLogger.logPageView('CreateCodeMonitorPage', {
                 hasTriggerQuery: !!triggerQuery,
                 hasDescription: !!description,
             }),

--- a/client/web/src/enterprise/code-monitoring/ManageCodeMonitorPage.tsx
+++ b/client/web/src/enterprise/code-monitoring/ManageCodeMonitorPage.tsx
@@ -53,7 +53,7 @@ const AuthenticatedManageCodeMonitorPage: React.FunctionComponent<
 }) => {
     const LOADING = 'loading' as const
 
-    useEffect(() => eventLogger.logViewEvent('ManageCodeMonitorPage'), [])
+    useEffect(() => eventLogger.logPageView('ManageCodeMonitorPage'), [])
 
     const [codeMonitorState, setCodeMonitorState] = React.useState<CodeMonitorFields>({
         id: '',
@@ -80,8 +80,9 @@ const AuthenticatedManageCodeMonitorPage: React.FunctionComponent<
     )
 
     const updateMonitorRequest = React.useCallback(
-        (codeMonitor: CodeMonitorFields): Observable<Partial<CodeMonitorFields>> =>
-            updateCodeMonitor(
+        (codeMonitor: CodeMonitorFields): Observable<Partial<CodeMonitorFields>> => {
+            eventLogger.log('ManageCodeMonitorFormSubmitted')
+            return updateCodeMonitor(
                 {
                     id: match.params.id,
                     update: {
@@ -92,8 +93,17 @@ const AuthenticatedManageCodeMonitorPage: React.FunctionComponent<
                 },
                 { id: codeMonitor.trigger.id, update: { query: codeMonitor.trigger.query } },
                 convertActionsForUpdate(codeMonitor.actions.nodes, authenticatedUser.id)
-            ),
+            )
+        },
         [authenticatedUser.id, match.params.id, updateCodeMonitor]
+    )
+
+    const deleteMonitorRequest = React.useCallback(
+        (id: string): Observable<void> => {
+            eventLogger.log('ManageCodeMonitorDeleteSubmitted')
+            return deleteCodeMonitor(id)
+        },
+        [deleteCodeMonitor]
     )
 
     return (
@@ -118,7 +128,7 @@ const AuthenticatedManageCodeMonitorPage: React.FunctionComponent<
                         history={history}
                         location={location}
                         authenticatedUser={authenticatedUser}
-                        deleteCodeMonitor={deleteCodeMonitor}
+                        deleteCodeMonitor={deleteMonitorRequest}
                         onSubmit={updateMonitorRequest}
                         codeMonitor={codeMonitorState}
                         submitButtonLabel="Save"


### PR DESCRIPTION
Log frontend events as described in [RFC 700](https://docs.google.com/document/d/1QpB2tAginNjvprW51A4F7bT8kHU0SqceBIuGXEN22zk/edit#heading=h.yltlv6dgwggx).

| Event description | Logged event name | Notes |
|---|---|---|
| Code monitoring homepage viewed | `CodeMonitoringViewed` | Pre-existing event, not outlined in RFC 700. Previously called `ViewCodeMonitoringPage` |
| Code monitor getting started page viewed | `CodeMonitoringGettingStartedPageViewed` | |
| Code monitor library item clicked | `CodeMonitoringExampleMonitorClicked` | |
| Code monitor creation started | `CreateCodeMonitorPageViewed` | Pre-existing event, previously `ViewCreateCodeMonitorPage` |
| Code monitor created | `CreateCodeMonitorFormSubmitted` | Pre-existing event |
| Code monitor update started | `ManageCodeMonitorPageViewed` | Pre-existing event, previously `ViewManageCodeMonitorPage` |
| Code monitor updated | `ManageCodeMonitorFormSubmitted` | |
| Code monitor deleted | `ManageCodeMonitorDeleteSubmitted` | |
| Logs page viewed | `CodeMonitoringLogsPageViewed` | |

## Test plan

Trigger the events listed and verify they are being sent to the server by analyzing the network tab in the browser's dev tools.

## App preview:

- [Web](https://sg-web-jp-cmlogevents.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-sbuozvhbtz.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
