### PR TITLE
Enforce min width on `MultiSelect`

### DIFF
--- a/client/wildcard/src/components/Form/MultiSelect/MultiSelect.module.scss
+++ b/client/wildcard/src/components/Form/MultiSelect/MultiSelect.module.scss
@@ -1,4 +1,6 @@
 .multi-select {
+    min-width: 6.5rem;
+
     :global(.theme-light) & {
         --react-select-neutral0: var(--white);
         --react-select-neutral5: var(--gray-01);


### PR DESCRIPTION
Part 2, closes https://github.com/sourcegraph/sourcegraph/issues/37116.

We're the only consumers of this component at the moment so this feels like a reasonable change at the Wildcard component level.

## Test plan

Manually verified, tested at different screen widths. Component also has Storybook coverage.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-kr-multi-select-min-width.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-qmkpvjjltd.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
