### PR TITLE
Fix step caching

### DIFF
--- a/enterprise/cmd/frontend/internal/executorqueue/queues/batches/transform_test.go
+++ b/enterprise/cmd/frontend/internal/executorqueue/queues/batches/transform_test.go
@@ -77,6 +77,7 @@ func TestTransformRecord(t *testing.T) {
 	workspaceExecutionJob := &btypes.BatchSpecWorkspaceExecutionJob{
 		ID:                   42,
 		BatchSpecWorkspaceID: workspace.ID,
+		UserID:               123,
 	}
 
 	store := NewMockBatchesStore()
@@ -123,7 +124,7 @@ func TestTransformRecord(t *testing.T) {
 			ID: int(workspaceExecutionJob.ID),
 			VirtualMachineFiles: map[string]string{
 				"input.json":        string(marshaledInput),
-				"testcachekey.json": `{"stepIndex":0,"diff":"123","outputs":null,"previousStepResult":{"Files":null,"Stdout":null,"Stderr":null}}`,
+				"testcachekey.json": `{"stepIndex":0,"diff":"123","outputs":null,"stepResult":{"Files":null,"Stdout":"","Stderr":""}}`,
 			},
 			CliSteps: []apiclient.CliStep{
 				{

--- a/lib/batches/execution/results.go
+++ b/lib/batches/execution/results.go
@@ -1,8 +1,6 @@
 package execution
 
 import (
-	"bytes"
-
 	"github.com/sourcegraph/sourcegraph/lib/batches/git"
 )
 
@@ -11,9 +9,9 @@ type StepResult struct {
 	// Files are the changes made to Files by the step.
 	Files *git.Changes
 	// Stdout is the output produced by the step on standard out.
-	Stdout *bytes.Buffer
+	Stdout string
 	// Stderr is the output produced by the step on standard error.
-	Stderr *bytes.Buffer
+	Stderr string
 }
 
 // ModifiedFiles returns the files modified by a step.
@@ -57,9 +55,8 @@ type AfterStepResult struct {
 	Diff string `json:"diff"`
 	// Outputs is a copy of the Outputs after executing the Step.
 	Outputs map[string]any `json:"outputs"`
-	// PreviousStepResult is the StepResult of the step before Step, if
-	// StepIndex != 0.
-	PreviousStepResult StepResult `json:"previousStepResult"`
+	// StepResult is the StepResult of this step.
+	StepResult StepResult `json:"stepResult"`
 }
 
 // Result is the result of executing all executable steps in a workspace.

--- a/lib/batches/template/templating.go
+++ b/lib/batches/template/templating.go
@@ -142,14 +142,8 @@ func (stepCtx *StepContext) ToFuncMap() template.FuncMap {
 		m["added_files"] = res.AddedFiles()
 		m["deleted_files"] = res.DeletedFiles()
 		m["renamed_files"] = res.RenamedFiles()
-
-		if res.Stdout != nil {
-			m["stdout"] = res.Stdout.String()
-		}
-
-		if res.Stderr != nil {
-			m["stderr"] = res.Stderr.String()
-		}
+		m["stdout"] = res.Stdout
+		m["stderr"] = res.Stderr
 
 		return m
 	}

--- a/lib/batches/template/templating_test.go
+++ b/lib/batches/template/templating_test.go
@@ -26,8 +26,8 @@ func TestEvalStepCondition(t *testing.T) {
 		},
 		PreviousStep: execution.StepResult{
 			Files:  testChanges,
-			Stdout: bytes.NewBufferString("this is previous step's stdout"),
-			Stderr: bytes.NewBufferString("this is previous step's stderr"),
+			Stdout: "this is previous step's stdout",
+			Stderr: "this is previous step's stderr",
 		},
 		Steps: StepsContext{
 			Changes: testChanges,
@@ -91,8 +91,8 @@ func TestRenderStepTemplate(t *testing.T) {
 		},
 		PreviousStep: execution.StepResult{
 			Files:  testChanges,
-			Stdout: bytes.NewBufferString("this is previous step's stdout"),
-			Stderr: bytes.NewBufferString("this is previous step's stderr"),
+			Stdout: "this is previous step's stdout",
+			Stderr: "this is previous step's stderr",
 		},
 		Outputs: map[string]any{
 			"lastLine": "lastLine is this",
@@ -100,8 +100,8 @@ func TestRenderStepTemplate(t *testing.T) {
 		},
 		Step: execution.StepResult{
 			Files:  testChanges,
-			Stdout: bytes.NewBufferString("this is current step's stdout"),
-			Stderr: bytes.NewBufferString("this is current step's stderr"),
+			Stdout: "this is current step's stdout",
+			Stderr: "this is current step's stderr",
 		},
 		Steps:      StepsContext{Changes: testChanges, Path: "sub/directory/of/repo"},
 		Repository: *testRepo1,
@@ -235,8 +235,8 @@ func TestRenderStepMap(t *testing.T) {
 	stepCtx := &StepContext{
 		PreviousStep: execution.StepResult{
 			Files:  testChanges,
-			Stdout: bytes.NewBufferString("this is previous step's stdout"),
-			Stderr: bytes.NewBufferString("this is previous step's stderr"),
+			Stdout: "this is previous step's stdout",
+			Stderr: "this is previous step's stderr",
 		},
 		Outputs:    map[string]any{},
 		Repository: *testRepo1,


### PR DESCRIPTION
This fixes two things, that I found today:
- It changes Stdout and Stderr on the StepResult struct to string, it is part of the marshalled cache result and *bytes.Buffer cannot be marshalled into JSON. This caused stdout/stderr to always be empty, thus breaking executions where `${{ previous_step.stdout }}` is used.
- It fixes a misconception of the `PreviousStepResult`. When running the actual execution, it will eventually _become_ the result of the previous step, but from the perspective of that particular cache result, it has to be the result from THAT step execution. Otherwise caching would only work from step 2 on and skip 1 step still.

This will follow a PR on the src side to make use of it and properly populate the step result.

Note that I intentionally changed the json key of step result, to invalidate all step caches that had this broken state stored.

## Test plan

Validated with the src side change that it has the desired effect.