### PR TITLE
batches: show actions menu with preview + retry options when spec completes with errors

### DIFF
--- a/client/web/src/enterprise/batches/batch-spec/batch-spec.mock.ts
+++ b/client/web/src/enterprise/batches/batch-spec/batch-spec.mock.ts
@@ -135,7 +135,8 @@ export const COMPLETED_WITH_ERRORS_BATCH_SPEC = mockFullBatchSpec({
     startedAt: subHours(now, 1).toISOString(),
     finishedAt: subMinutes(now, 4).toISOString(),
     applyURL: '/some/preview/url',
-    failureMessage: 'Something went wrong.',
+    failureMessage:
+        "Oh no something went wrong. This is a longer error message to demonstrate how this might take up a decent portion of screen real estate but hopefully it's still helpful information so it's worth the cost. Here's a long error message with some bullets:\n  * This is a bullet\n  * This is another bullet\n  * This is a third bullet and it's also the most important one so it's longer than all the others wow look at that.",
     workspaceResolution: {
         __typename: 'BatchSpecWorkspaceResolution',
         workspaces: {

--- a/client/web/src/enterprise/batches/batch-spec/batch-spec.mock.ts
+++ b/client/web/src/enterprise/batches/batch-spec/batch-spec.mock.ts
@@ -135,6 +135,7 @@ export const COMPLETED_WITH_ERRORS_BATCH_SPEC = mockFullBatchSpec({
     startedAt: subHours(now, 1).toISOString(),
     finishedAt: subMinutes(now, 4).toISOString(),
     applyURL: '/some/preview/url',
+    failureMessage: 'Something went wrong.',
     workspaceResolution: {
         __typename: 'BatchSpecWorkspaceResolution',
         workspaces: {
@@ -146,27 +147,6 @@ export const COMPLETED_WITH_ERRORS_BATCH_SPEC = mockFullBatchSpec({
                 queued: 0,
                 processing: 0,
                 completed: 22,
-            },
-        },
-    },
-})
-
-export const FAILED_BATCH_SPEC = mockFullBatchSpec({
-    state: BatchSpecState.FAILED,
-    startedAt: subHours(now, 1).toISOString(),
-    finishedAt: now.toISOString(),
-    failureMessage: 'Something went wrong.',
-    workspaceResolution: {
-        __typename: 'BatchSpecWorkspaceResolution',
-        workspaces: {
-            __typename: 'BatchSpecWorkspaceConnection',
-            stats: {
-                __typename: 'BatchSpecWorkspacesStats',
-                errored: 10,
-                ignored: 0,
-                queued: 14,
-                processing: 7,
-                completed: 21,
             },
         },
     },

--- a/client/web/src/enterprise/batches/batch-spec/execute/ActionsMenu.story.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/execute/ActionsMenu.story.tsx
@@ -26,10 +26,10 @@ add('executing', () => (
     </WebStory>
 ))
 
-add('failed', () => (
+add('completed with errors', () => (
     <WebStory>
         {props => (
-            <BatchSpecContextProvider batchChange={mockBatchChange()} batchSpec={FAILED_BATCH_SPEC}>
+            <BatchSpecContextProvider batchChange={mockBatchChange()} batchSpec={COMPLETED_WITH_ERRORS_BATCH_SPEC}>
                 <ActionsMenu {...props} />
             </BatchSpecContextProvider>
         )}
@@ -40,16 +40,6 @@ add('completed', () => (
     <WebStory>
         {props => (
             <BatchSpecContextProvider batchChange={mockBatchChange()} batchSpec={COMPLETED_BATCH_SPEC}>
-                <ActionsMenu {...props} />
-            </BatchSpecContextProvider>
-        )}
-    </WebStory>
-))
-
-add('completed with errors', () => (
-    <WebStory>
-        {props => (
-            <BatchSpecContextProvider batchChange={mockBatchChange()} batchSpec={COMPLETED_WITH_ERRORS_BATCH_SPEC}>
                 <ActionsMenu {...props} />
             </BatchSpecContextProvider>
         )}

--- a/client/web/src/enterprise/batches/batch-spec/execute/ActionsMenu.story.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/execute/ActionsMenu.story.tsx
@@ -5,7 +5,6 @@ import {
     COMPLETED_BATCH_SPEC,
     COMPLETED_WITH_ERRORS_BATCH_SPEC,
     EXECUTING_BATCH_SPEC,
-    FAILED_BATCH_SPEC,
     mockBatchChange,
 } from '../batch-spec.mock'
 import { BatchSpecContextProvider } from '../BatchSpecContext'

--- a/client/web/src/enterprise/batches/batch-spec/execute/ActionsMenu.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/execute/ActionsMenu.tsx
@@ -88,8 +88,8 @@ const MemoizedActionsMenu: React.FunctionComponent<
         setShowCancelModal(true)
     }, [])
 
-    const showPreviewButton = !location.pathname.endsWith('preview') && !!batchSpec.applyURL
-    const failed = state === BatchSpecState.FAILED
+    const showPreviewButton = !location.pathname.endsWith('preview') && state === BatchSpecState.COMPLETED
+    const showPreviewMenuItem = !location.pathname.endsWith('preview') && state === BatchSpecState.FAILED
 
     // The actions menu button is wider than the "Preview" button, so to prevent layout
     // shift, we apply the width of the actions menu button to the "Preview" button
@@ -101,17 +101,11 @@ const MemoizedActionsMenu: React.FunctionComponent<
             {showPreviewButton && (
                 <Button
                     to={`${batchSpec.executionURL}/preview`}
-                    variant={failed ? 'warning' : 'primary'}
+                    variant="primary"
                     as={Link}
                     className={styles.previewButton}
-                    style={{ width: failed ? undefined : menuWidth }}
-                    data-tooltip={
-                        failed
-                            ? "Execution didn't finish successfully in all workspaces. Some changesets may be missing in preview."
-                            : undefined
-                    }
+                    style={{ width: menuWidth }}
                 >
-                    {failed && <Icon aria-hidden={true} className="mr-1" as={AlertCircleIcon} />}
                     Preview
                 </Button>
             )}
@@ -123,6 +117,11 @@ const MemoizedActionsMenu: React.FunctionComponent<
                     </MenuButton>
                 </div>
                 <MenuList position={Position.bottomEnd}>
+                    {showPreviewMenuItem && (
+                        <MenuItem onSelect={() => history.push(`${batchSpec.executionURL}/preview`)}>
+                            <Icon aria-hidden={true} as={AlertCircleIcon} /> Preview with errors
+                        </MenuItem>
+                    )}
                     <MenuItem onSelect={onSelectEdit}>
                         <Icon aria-hidden={true} as={PencilIcon} /> Edit spec{isExecuting ? '...' : ''}
                     </MenuItem>

--- a/client/web/src/enterprise/batches/batch-spec/execute/BatchSpecStateBadge.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/execute/BatchSpecStateBadge.tsx
@@ -14,7 +14,7 @@ const getProps = (state: BatchSpecState): [variant: BadgeVariantType, tooltip: s
         case BatchSpecState.PENDING:
             return ['secondary', 'Execution has not been started.']
         case BatchSpecState.QUEUED:
-            return ['secondary', 'Waiting for next available executor.']
+            return ['secondary', 'Waiting for the next available executor.']
         case BatchSpecState.PROCESSING:
             return ['secondary', 'The batch spec is actively being executed.']
         case BatchSpecState.CANCELED:

--- a/client/web/src/enterprise/batches/batch-spec/execute/BatchSpecStateBadge.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/execute/BatchSpecStateBadge.tsx
@@ -12,19 +12,22 @@ export interface BatchSpecStateBadgeProps {
 const getProps = (state: BatchSpecState): [variant: BadgeVariantType, tooltip: string] => {
     switch (state) {
         case BatchSpecState.PENDING:
-            return ['secondary', 'Not started']
+            return ['secondary', 'Execution has not been started.']
         case BatchSpecState.QUEUED:
-            return ['secondary', 'Waiting for executor']
+            return ['secondary', 'Waiting for next available executor.']
         case BatchSpecState.PROCESSING:
-            return ['secondary', 'Currently executing']
+            return ['secondary', 'The batch spec is actively being executed.']
         case BatchSpecState.CANCELED:
-            return ['secondary', 'Execution has been canceled']
+            return ['secondary', 'Execution of this batch spec has been canceled.']
         case BatchSpecState.CANCELING:
-            return ['secondary', 'Canceling execution']
+            return ['secondary', 'Execution of this batch spec is being canceled.']
         case BatchSpecState.FAILED:
-            return ['danger', 'Execution failed']
+            return [
+                'danger',
+                "Execution didn't finish successfully in all workspaces. Some changesets may be missing in preview.",
+            ]
         case BatchSpecState.COMPLETED:
-            return ['success', 'Execution finished successfully']
+            return ['success', 'Execution finished successfully in all workspaces.']
     }
 }
 

--- a/client/web/src/enterprise/batches/batch-spec/execute/ExecuteBatchSpecPage.story.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/execute/ExecuteBatchSpecPage.story.tsx
@@ -24,7 +24,6 @@ import {
     COMPLETED_BATCH_SPEC,
     COMPLETED_WITH_ERRORS_BATCH_SPEC,
     EXECUTING_BATCH_SPEC,
-    FAILED_BATCH_SPEC,
     mockBatchChange,
     mockFullBatchSpec,
     mockWorkspaceResolutionStatus,
@@ -137,33 +136,6 @@ add('executing', () => (
         }}
     </WebStory>
 ))
-
-const FAILED_MOCKS = buildMocks(FAILED_BATCH_SPEC, { state: BatchSpecWorkspaceState.FAILED, failureMessage: 'Uh oh!' })
-
-add('failed', () => {
-    console.log(mockWorkspaces(50, { state: BatchSpecWorkspaceState.FAILED, failureMessage: 'Uh oh!' }))
-    return (
-        <WebStory>
-            {props => (
-                <MockedTestProvider link={new WildcardMockLink(FAILED_MOCKS)}>
-                    <ExecuteBatchSpecPage
-                        {...props}
-                        batchSpecID="spec1234"
-                        batchChange={{ name: 'my-batch-change', namespace: 'user1234' }}
-                        testContextState={{
-                            errors: {
-                                execute:
-                                    "Oh no something went wrong. This is a longer error message to demonstrate how this might take up a decent portion of screen real estate but hopefully it's still helpful information so it's worth the cost. Here's a long error message with some bullets:\n  * This is a bullet\n  * This is another bullet\n  * This is a third bullet and it's also the most important one so it's longer than all the others wow look at that.",
-                            },
-                        }}
-                        authenticatedUser={mockAuthenticatedUser}
-                        settingsCascade={SETTINGS_CASCADE}
-                    />
-                </MockedTestProvider>
-            )}
-        </WebStory>
-    )
-})
 
 const COMPLETED_MOCKS = buildMocks(COMPLETED_BATCH_SPEC, { state: BatchSpecWorkspaceState.COMPLETED })
 

--- a/client/web/src/enterprise/batches/batch-spec/execute/ExecuteBatchSpecPage.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/execute/ExecuteBatchSpecPage.tsx
@@ -188,7 +188,7 @@ const MemoizedExecuteBatchSpecContent: React.FunctionComponent<
                     {workspaceResolution && <ExecutionStatsBar {...workspaceResolution.workspaces.stats} />}
                 </div>
 
-                <ActionButtons className="ml-2">
+                <ActionButtons className="ml-2 flex-shrink-0">
                     <ActionsMenu />
                 </ActionButtons>
             </div>

--- a/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec.go
@@ -510,6 +510,11 @@ func (r *batchSpecResolver) ViewerCanRetry(ctx context.Context) (bool, error) {
 		return false, err
 	}
 
+	// If the spec finished successfully, there's nothing to retry.
+	if state == btypes.BatchSpecStateCompleted {
+		return false, nil
+	}
+
 	return state.Finished(), nil
 }
 

--- a/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec_test.go
@@ -389,7 +389,8 @@ func TestBatchSpecResolver_BatchSpecCreatedFromRaw(t *testing.T) {
 	want.State = "COMPLETED"
 	want.ApplyURL = &applyUrl
 	want.FinishedAt = graphqlbackend.DateTime{Time: jobs[0].FinishedAt}
-	want.ViewerCanRetry = true
+	// Nothing to retry
+	want.ViewerCanRetry = false
 	queryAndAssertBatchSpec(t, userCtx, s, apiID, want)
 
 	// 1/3 jobs is failed, 2/3 completed


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/37084.

- Makes `viewerCanRetry` false if there's nothing to retry, aka if the batch spec completed successfully.
- Improves tooltip text for batch spec state badge.
- Prevents text wrap on Actions menu.
- Shows Actions menu instead of Preview button with warning when batch spec completes but with errors. The actions menu has options to "Preview with errors", "Retry failed workspaces", and "Edit spec". The preview option takes you to Step 4 as before.

Demo:

https://user-images.githubusercontent.com/8942601/173707813-88955d5a-24d2-4a54-b962-78cc2c08d87a.mov


## Test plan

Manually tested behavior, see video above. Component has storybook story coverage, which I also validated.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
