### PR TITLE
Bump src-cli to 3.40.10

### DIFF
--- a/internal/src-cli/consts.go
+++ b/internal/src-cli/consts.go
@@ -6,4 +6,4 @@ package srccli
 // as the suggested download with this instance.
 //
 // At the time of a Sourcegraph release, this is always the latest src-cli version.
-const MinimumVersion = "3.40.2"
+const MinimumVersion = "3.40.10"


### PR DESCRIPTION
## Test plan

Bumps src-cli in the executors, will be tested once those are live on dogfood.