### PR TITLE
insights: Remove series from view before deleting insight

### DIFF
--- a/enterprise/internal/insights/resolvers/insight_view_resolvers.go
+++ b/enterprise/internal/insights/resolvers/insight_view_resolvers.go
@@ -1080,6 +1080,18 @@ func (r *Resolver) DeleteInsightView(ctx context.Context, args *graphqlbackend.D
 		return nil, err
 	}
 
+	insights, err := r.insightStore.GetMapped(ctx, store.InsightQueryArgs{WithoutAuthorization: true, UniqueID: viewId})
+	if len(insights) != 1 {
+		return nil, errors.New("Insight not found.")
+	}
+
+	for _, series := range insights[0].Series {
+		err = r.insightStore.RemoveSeriesFromView(ctx, series.SeriesID, insights[0].ViewID)
+		if err != nil {
+			return nil, errors.Wrap(err, "RemoveSeriesFromView")
+		}
+	}
+
 	err = r.insightStore.DeleteViewByUniqueID(ctx, viewId)
 	if err != nil {
 		return nil, errors.Wrap(err, "DeleteView")


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/29050, https://github.com/sourcegraph/sourcegraph/issues/35882

## Description

When an insight was deleted, the corresponding series were not being marked as deleted. This made it so that our background cleanup job never cleaned those series up. Explicitly removing the series from the view makes use of the logic to mark series as deleted when they are no longer attached to any view.

## Test plan

1. Before this fix: I created a new insight with several series, deleted it, and verified that its series were not marked as deleted.
2. After this fix: Same, but verified that the series are now being marked as deleted. Upon restarting the service they are cleaned up by the background job as expected.
