### PR TITLE
feat(lint): Add ESLint rule to warn against spreading props

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -188,6 +188,11 @@ See https://handbook.sourcegraph.com/community/faq#is-all-of-sourcegraph-open-so
         message:
           'The use of data-tooltip has been deprecated. Please wrap your trigger element with the <Tooltip> component from Wildcard instead. If there are problems using the new <Tooltip>, please contact the Frontend Platform Team.',
       },
+      {
+        selector: 'JSXSpreadAttribute[argument.name=/^(props|rest)$/]',
+        message:
+          "Spreading props can be unsafe. Prefer destructuring the props object, or continue only if you're sure.",
+      },
     ],
     // https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html#eslint
     'react/jsx-uses-react': 'off',


### PR DESCRIPTION
This PR adds an ESLint rule to warn against spreading ambiguously-named props (`props` and `rest`) into components.

**Bad code:**

```tsx
<MyComponent {...rest} />
```

**OK code:**

```tsx
<MyComponent {...ariaAttributes} />
```

**Bonus amazing code:**

```tsx
const { prop_one, prop_two } = props
<MyComponent prop_one={prop_one} prop_two={prop_two} />
```

## Test plan

Tested on VS Code by implementing the unsafe patterns and observing eslint warning showing up.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
