### PR TITLE
gitlab: Refresh expired accounts

### DIFF
--- a/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
+++ b/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
@@ -269,8 +269,8 @@ func (s *PermsSyncer) maybeRefreshGitLabOAuthTokenFromAccount(ctx context.Contex
 			continue
 		}
 		oauthConfig = oauth2ConfigFromGitLabProvider(authProvider.Gitlab)
-		if authProvider.Gitlab.TokenExpiryWindowMinutes > 0 {
-			expiryWindow = time.Duration(authProvider.Gitlab.TokenExpiryWindowMinutes) * time.Minute
+		if authProvider.Gitlab.TokenRefreshWindowMinutes > 0 {
+			expiryWindow = time.Duration(authProvider.Gitlab.TokenRefreshWindowMinutes) * time.Minute
 		}
 		break
 	}

--- a/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
+++ b/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
@@ -398,7 +398,9 @@ func (s *PermsSyncer) fetchUserPermsViaExternalAccounts(ctx context.Context, use
 
 		logger.Debug("maybe refresh account token", log.Int32("accountID", acct.ID))
 		if err := s.maybeRefreshGitLabOAuthTokenFromAccount(ctx, acct); err != nil {
-			return nil, nil, errors.Wrapf(err, "refreshing GitLab OAuth token for account: %s", acct.AccountID)
+			// This should not be a fatal error, we should still try to sync from other accounts
+			acctLogger.Warn("failed to refresh GitLab token", log.Error(err))
+			continue
 		}
 
 		extPerms, err := provider.FetchUserPerms(ctx, acct, fetchOpts)

--- a/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
+++ b/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
@@ -512,7 +512,7 @@ func (s *PermsSyncer) fetchUserPermsViaExternalAccounts(ctx context.Context, use
 // fetchUserPermsViaExternalServices uses user code connections to list all
 // accessible private repositories on code hosts for the given user.
 func (s *PermsSyncer) fetchUserPermsViaExternalServices(ctx context.Context, userID int32, fetchOpts authz.FetchPermsOptions) (repoIDs []uint32, err error) {
-	logger := s.logger.Scoped("fetchUserPermsViaExternalAccounts", "sync permissions using code host connections").With(log.Int32("userID", userID))
+	logger := s.logger.Scoped("fetchUserPermsViaExternalServices", "sync permissions using code host connections").With(log.Int32("userID", userID))
 
 	has, err := s.permsStore.UserIsMemberOfOrgHasCodeHostConnection(ctx, userID)
 	if err != nil {

--- a/enterprise/cmd/repo-updater/internal/authz/perms_syncer_test.go
+++ b/enterprise/cmd/repo-updater/internal/authz/perms_syncer_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/sourcegraph/log/logtest"
+
 	eauthz "github.com/sourcegraph/sourcegraph/enterprise/internal/authz"
 	edb "github.com/sourcegraph/sourcegraph/enterprise/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/api"

--- a/internal/database/external_accounts.go
+++ b/internal/database/external_accounts.go
@@ -346,7 +346,11 @@ type ExternalAccountsListOptions struct {
 	UserID                           int32
 	ServiceType, ServiceID, ClientID string
 	AccountID                        int64
-	ExcludeExpired                   bool
+
+	// Only one of these should be set
+	ExcludeExpired bool
+	OnlyExpired    bool
+
 	*LimitOffset
 }
 
@@ -460,6 +464,9 @@ func (s *userExternalAccountsStore) listSQL(opt ExternalAccountsListOptions) (co
 	}
 	if opt.ExcludeExpired {
 		conds = append(conds, sqlf.Sprintf("expired_at IS NULL"))
+	}
+	if opt.OnlyExpired {
+		conds = append(conds, sqlf.Sprintf("expired_at IS NOT NULL"))
 	}
 
 	return conds

--- a/internal/database/external_accounts.go
+++ b/internal/database/external_accounts.go
@@ -31,7 +31,7 @@ func (err userExternalAccountNotFoundError) NotFound() bool {
 	return true
 }
 
-// userExternalAccountsStore provides access to the `user_external_accounts` table.
+// UserExternalAccountsStore provides access to the `user_external_accounts` table.
 type UserExternalAccountsStore interface {
 	// AssociateUserAndSave is used for linking a new, additional external account with an existing
 	// Sourcegraph account.

--- a/internal/database/external_accounts.go
+++ b/internal/database/external_accounts.go
@@ -446,8 +446,14 @@ func (s *userExternalAccountsStore) listSQL(opt ExternalAccountsListOptions) (co
 	if opt.UserID != 0 {
 		conds = append(conds, sqlf.Sprintf("user_id=%d", opt.UserID))
 	}
-	if opt.ServiceType != "" || opt.ServiceID != "" || opt.ClientID != "" {
-		conds = append(conds, sqlf.Sprintf("(service_type=%s AND service_id=%s AND client_id=%s)", opt.ServiceType, opt.ServiceID, opt.ClientID))
+	if opt.ServiceType != "" {
+		conds = append(conds, sqlf.Sprintf("service_type=%s", opt.ServiceType))
+	}
+	if opt.ServiceID != "" {
+		conds = append(conds, sqlf.Sprintf("service_id=%s", opt.ServiceID))
+	}
+	if opt.ClientID != "" {
+		conds = append(conds, sqlf.Sprintf("client_id=%s", opt.ClientID))
 	}
 	if opt.AccountID != 0 {
 		conds = append(conds, sqlf.Sprintf("account_id=%d", strconv.Itoa(int(opt.AccountID))))

--- a/internal/database/external_accounts_test.go
+++ b/internal/database/external_accounts_test.go
@@ -274,6 +274,27 @@ func TestExternalAccounts_List(t *testing.T) {
 			},
 		},
 		{
+			name:        "ListByServiceTypeOnly",
+			expectedIDs: []int32{userIDs[0], userIDs[1]},
+			args: ExternalAccountsListOptions{
+				ServiceType: "xa",
+			},
+		},
+		{
+			name:        "ListByServiceIDOnly",
+			expectedIDs: []int32{userIDs[0], userIDs[1]},
+			args: ExternalAccountsListOptions{
+				ServiceID: "xb",
+			},
+		},
+		{
+			name:        "ListByClientIDOnly",
+			expectedIDs: []int32{userIDs[2]},
+			args: ExternalAccountsListOptions{
+				ClientID: "yc",
+			},
+		},
+		{
 			name:        "ListByServiceNotFound",
 			expectedIDs: []int32{},
 			args: ExternalAccountsListOptions{

--- a/internal/database/external_accounts_test.go
+++ b/internal/database/external_accounts_test.go
@@ -469,6 +469,25 @@ func TestExternalAccounts_expiredAt(t *testing.T) {
 		}
 	})
 
+	t.Run("Include expired", func(t *testing.T) {
+		err := db.UserExternalAccounts().TouchExpired(ctx, acct.ID)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		accts, err := db.UserExternalAccounts().List(ctx, ExternalAccountsListOptions{
+			UserID:      userID,
+			OnlyExpired: true,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if len(accts) == 0 {
+			t.Fatalf("Want external accounts but got 0")
+		}
+	})
+
 	t.Run("LookupUserAndSave should set expired_at to NULL", func(t *testing.T) {
 		err := db.UserExternalAccounts().TouchExpired(ctx, acct.ID)
 		if err != nil {

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -841,7 +841,9 @@ type GitLabAuthProvider struct {
 	// ClientSecret description: The Client Secret of the GitLab OAuth app, accessible from https://gitlab.com/oauth/applications (or the same path on your private GitLab instance).
 	ClientSecret string `json:"clientSecret"`
 	DisplayName  string `json:"displayName,omitempty"`
-	Type         string `json:"type"`
+	// TokenExpiryWindowMinutes description: Time in minutes before token expiry when we should attempt to refresh it
+	TokenExpiryWindowMinutes int    `json:"tokenExpiryWindowMinutes,omitempty"`
+	Type                     string `json:"type"`
 	// Url description: URL of the GitLab instance, such as https://gitlab.com or https://gitlab.example.com.
 	Url string `json:"url,omitempty"`
 }

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -841,9 +841,9 @@ type GitLabAuthProvider struct {
 	// ClientSecret description: The Client Secret of the GitLab OAuth app, accessible from https://gitlab.com/oauth/applications (or the same path on your private GitLab instance).
 	ClientSecret string `json:"clientSecret"`
 	DisplayName  string `json:"displayName,omitempty"`
-	// TokenExpiryWindowMinutes description: Time in minutes before token expiry when we should attempt to refresh it
-	TokenExpiryWindowMinutes int    `json:"tokenExpiryWindowMinutes,omitempty"`
-	Type                     string `json:"type"`
+	// TokenRefreshWindowMinutes description: Time in minutes before token expiry when we should attempt to refresh it
+	TokenRefreshWindowMinutes int    `json:"tokenRefreshWindowMinutes,omitempty"`
+	Type                      string `json:"type"`
 	// Url description: URL of the GitLab instance, such as https://gitlab.com or https://gitlab.example.com.
 	Url string `json:"url,omitempty"`
 }

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -1896,7 +1896,7 @@
           },
           "examples": [["group", "group/subgroup", "group/subgroup/subgroup"]]
         },
-        "tokenExpiryWindowMinutes": {
+        "tokenRefreshWindowMinutes": {
           "description": "Time in minutes before token expiry when we should attempt to refresh it",
           "default": 10,
           "type": "integer"

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -1895,6 +1895,11 @@
             "minLength": 1
           },
           "examples": [["group", "group/subgroup", "group/subgroup/subgroup"]]
+        },
+        "tokenExpiryWindowMinutes": {
+          "description": "Time in minutes before token expiry when we should attempt to refresh it",
+          "default": 10,
+          "type": "integer"
         }
       }
     },


### PR DESCRIPTION
We ensure that even if a GitLab token expires, we still try to refresh it. 
 
It was possible in the previous code that we would attempt to refresh the token
with a small 10 second grace period and then it would take us more than 10
seconds to actually use the token. This could cause the token to be expired by
the time we use it which would then cause us to mark the account as expired and
never try to refresh it again.

Closes https://github.com/sourcegraph/sourcegraph/issues/37145, but not in the planned way.

The assumption in the above issue was that once a token had expired, *repo*
syncing would no longer grant access to the user associated with the token. 
This was incorrect, the user sill has access it's just the one specific token
(of which they may have many) that expired.

## Test plan

Unit tests added
