### PR TITLE
fix(ui): Make diff line-number links relative to the diff page

### DIFF
--- a/client/web/src/components/diff/DiffHunk.tsx
+++ b/client/web/src/components/diff/DiffHunk.tsx
@@ -102,7 +102,10 @@ export const DiffHunk: React.FunctionComponent<React.PropsWithChildren<DiffHunkP
                                         data-hunk-num=" "
                                     >
                                         {persistLines && (
-                                            <Link className={styles.numLine} to={createLinkUrl({ hash: oldAnchor })}>
+                                            <Link
+                                                className={styles.numLine}
+                                                to={createLinkUrl({ ...location, hash: oldAnchor })}
+                                            >
                                                 {oldLine - 1}
                                             </Link>
                                         )}
@@ -120,7 +123,10 @@ export const DiffHunk: React.FunctionComponent<React.PropsWithChildren<DiffHunkP
                                         data-hunk-num=" "
                                     >
                                         {persistLines && (
-                                            <Link className={styles.numLine} to={createLinkUrl({ hash: newAnchor })}>
+                                            <Link
+                                                className={styles.numLine}
+                                                to={createLinkUrl({ ...location, hash: newAnchor })}
+                                            >
                                                 {newLine - 1}
                                             </Link>
                                         )}

--- a/client/web/src/components/diff/Lines.tsx
+++ b/client/web/src/components/diff/Lines.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 
 import classNames from 'classnames'
+import { useLocation } from 'react-router'
 import { DecorationAttachmentRenderOptions, ThemableDecorationStyle } from 'sourcegraph'
 
 import { TextDocumentDecoration } from '@sourcegraph/extension-api-types'
@@ -77,6 +78,7 @@ export const Line: React.FunctionComponent<React.PropsWithChildren<Line>> = ({
     isLightTheme,
 }) => {
     const hunkStyles = lineType(kind)
+    const location = useLocation()
 
     return (
         <>
@@ -89,7 +91,10 @@ export const Line: React.FunctionComponent<React.PropsWithChildren<Line>> = ({
                     data-hunk-num=" "
                 >
                     {persistLines && (
-                        <RouterLink className={diffHunkStyles.numLine} to={createLinkUrl({ hash: anchor })}>
+                        <RouterLink
+                            className={diffHunkStyles.numLine}
+                            to={createLinkUrl({ ...location, hash: anchor })}
+                        >
                             {lineNumber}
                         </RouterLink>
                     )}


### PR DESCRIPTION
This PR spreads the entire `location` object into the `createLinkUrl()` function along with the hash/id of the line. Through this, since the pathname is also supplied along with any query params, the link's URL is now correctly pointing to the diff page, rather than the base URL `/`.

Closes #37261

## Test plan

Manually tested by checking rendered links.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-mihir-37261-diff-line-number-links.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-ksnlvnqzon.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
