### PR TITLE
Revert "WIP Router V6 migration: update Link component (#36285)"

### DIFF
--- a/client/branded/src/components/BrandedStory.tsx
+++ b/client/branded/src/components/BrandedStory.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 
 import { MemoryRouter, MemoryRouterProps } from 'react-router'
-import { CompatRouter } from 'react-router-dom-v5-compat'
 
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
 import { MockedStoryProvider, MockedStoryProviderProps, usePrependStyles, useTheme } from '@sourcegraph/storybook'
@@ -34,10 +33,8 @@ export const BrandedStory: React.FunctionComponent<React.PropsWithChildren<Brand
         <MockedStoryProvider mocks={mocks} useStrictMocking={useStrictMocking}>
             <WildcardThemeContext.Provider value={{ isBranded: true }}>
                 <MemoryRouter {...memoryRouterProps}>
-                    <CompatRouter>
-                        <DeprecatedTooltip />
-                        <Children isLightTheme={isLightTheme} />
-                    </CompatRouter>
+                    <DeprecatedTooltip />
+                    <Children isLightTheme={isLightTheme} />
                 </MemoryRouter>
             </WildcardThemeContext.Provider>
         </MockedStoryProvider>

--- a/client/shared/src/hover/HoverOverlay.story.tsx
+++ b/client/shared/src/hover/HoverOverlay.story.tsx
@@ -2,7 +2,6 @@ import bitbucketStyles from '@atlassian/aui/dist/aui/css/aui.css'
 import { DecoratorFn, Meta, Story } from '@storybook/react'
 import classNames from 'classnames'
 import { BrowserRouter } from 'react-router-dom'
-import { CompatRouter } from 'react-router-dom-v5-compat'
 
 // eslint-disable-next-line no-restricted-imports
 import browserExtensionStyles from '@sourcegraph/browser/src/app.scss'
@@ -54,18 +53,16 @@ const BITBUCKET_CLASS_PROPS: HoverOverlayClassProps = {
 
 export const BitbucketStyles: Story = props => (
     <BrowserRouter>
-        <CompatRouter>
-            <HoverOverlay
-                {...commonProps()}
-                {...BITBUCKET_CLASS_PROPS}
-                {...props}
-                hoverOrError={{
-                    contents: [FIXTURE_CONTENT],
-                    aggregatedBadges: [FIXTURE_SEMANTIC_BADGE],
-                }}
-                actionsOrError={FIXTURE_ACTIONS}
-            />
-        </CompatRouter>
+        <HoverOverlay
+            {...commonProps()}
+            {...BITBUCKET_CLASS_PROPS}
+            {...props}
+            hoverOrError={{
+                contents: [FIXTURE_CONTENT],
+                aggregatedBadges: [FIXTURE_SEMANTIC_BADGE],
+            }}
+            actionsOrError={FIXTURE_ACTIONS}
+        />
     </BrowserRouter>
 )
 BitbucketStyles.storyName = 'Bitbucket styles'

--- a/client/shared/src/testing/render-with-branded-context.tsx
+++ b/client/shared/src/testing/render-with-branded-context.tsx
@@ -3,7 +3,6 @@ import { ReactNode } from 'react'
 import { RenderResult, render } from '@testing-library/react'
 import { MemoryHistory, createMemoryHistory } from 'history'
 import { Router } from 'react-router-dom'
-import { CompatRouter } from 'react-router-dom-v5-compat'
 
 import { WildcardThemeContext, WildcardTheme } from '@sourcegraph/wildcard'
 
@@ -22,9 +21,7 @@ export function renderWithBrandedContext(
     return {
         ...render(
             <WildcardThemeContext.Provider value={wildcardTheme}>
-                <Router history={history}>
-                    <CompatRouter>{children}</CompatRouter>
-                </Router>
+                <Router history={history}>{children}</Router>
             </WildcardThemeContext.Provider>
         ),
         history,

--- a/client/vscode/src/webview/search-panel/index.tsx
+++ b/client/vscode/src/webview/search-panel/index.tsx
@@ -7,7 +7,6 @@ import { VSCodeProgressRing } from '@vscode/webview-ui-toolkit/react'
 import * as Comlink from 'comlink'
 import { render } from 'react-dom'
 import { MemoryRouter } from 'react-router'
-import { CompatRouter } from 'react-router-dom-v5-compat'
 
 import { wrapRemoteObservable } from '@sourcegraph/shared/src/api/client/api/common'
 import {
@@ -16,6 +15,7 @@ import {
     useObservable,
     WildcardThemeContext,
     // This is the root Tooltip usage
+    // eslint-disable-next-line no-restricted-imports
     DeprecatedTooltip,
 } from '@sourcegraph/wildcard'
 
@@ -122,9 +122,7 @@ render(
         <WildcardThemeContext.Provider value={{ isBranded: true }}>
             {/* Required for shared components that depend on `location`. */}
             <MemoryRouter>
-                <CompatRouter>
-                    <Main />
-                </CompatRouter>
+                <Main />
             </MemoryRouter>
             <DeprecatedTooltip key={1} className="sourcegraph-tooltip" />
         </WildcardThemeContext.Provider>

--- a/client/web/src/IdeExtensionTracker.test.tsx
+++ b/client/web/src/IdeExtensionTracker.test.tsx
@@ -1,6 +1,5 @@
 import { cleanup, render } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
-import { CompatRouter } from 'react-router-dom-v5-compat'
 
 import { TemporarySettings } from '@sourcegraph/shared/src/settings/temporary/TemporarySettings'
 import { MockTemporarySettings } from '@sourcegraph/shared/src/settings/temporary/testUtils'
@@ -12,18 +11,18 @@ describe('IdeExtensionTracker', () => {
 
     const cases: [string, null | 'vscode' | 'jetbrains'][] = [
         [
-            '/-/editor?remote_url=git%40github.com%3Asourcegraph%2Fsourcegraph-jetbrains.git&branch=main&file=src%2Fmain%2Fjava%2FOpenRevisionAction.java&editor=JetBrains&version=v1.2.2&start_row=68&start_col=26&end_row=68&end_col=26&utm_product_name=IntelliJ+IDEA&utm_product_version=2021.3.2',
+            'https://sourcegraph.com/-/editor?remote_url=git%40github.com%3Asourcegraph%2Fsourcegraph-jetbrains.git&branch=main&file=src%2Fmain%2Fjava%2FOpenRevisionAction.java&editor=JetBrains&version=v1.2.2&start_row=68&start_col=26&end_row=68&end_col=26&utm_product_name=IntelliJ+IDEA&utm_product_version=2021.3.2',
             'jetbrains',
         ],
         [
-            '/-/editor?remote_url=git@github.com:sourcegraph/sourcegraph.git&branch=ps/detect-ide-extensions&file=client/web/src/tracking/util.ts&editor=VSCode&version=2.0.9&start_row=13&start_col=22&end_row=13&end_col=22&utm_campaign=vscode-extension&utm_medium=direct_traffic&utm_source=vscode-extension&utm_content=vsce-commands',
+            'https://sourcegraph.com/-/editor?remote_url=git@github.com:sourcegraph/sourcegraph.git&branch=ps/detect-ide-extensions&file=client/web/src/tracking/util.ts&editor=VSCode&version=2.0.9&start_row=13&start_col=22&end_row=13&end_col=22&utm_campaign=vscode-extension&utm_medium=direct_traffic&utm_source=vscode-extension&utm_content=vsce-commands',
             'vscode',
         ],
         [
-            '/sign-up?editor=vscode&utm_medium=VSCODE&utm_source=sidebar&utm_campaign=vsce-sign-up&utm_content=sign-up',
+            'https://sourcegraph.com/sign-up?editor=vscode&utm_medium=VSCODE&utm_source=sidebar&utm_campaign=vsce-sign-up&utm_content=sign-up',
             'vscode',
         ],
-        ['/?something=different', null],
+        ['https://sourcegraph.com/?something=different', null],
     ]
     test.each(cases)('Detects the proper extension for %p', (url, expectedResult) => {
         let latestSettings: TemporarySettings = {}
@@ -31,11 +30,9 @@ describe('IdeExtensionTracker', () => {
 
         render(
             <MemoryRouter initialEntries={[url]}>
-                <CompatRouter>
-                    <MockTemporarySettings settings={{}} onSettingsChanged={onSettingsChanged}>
-                        <IdeExtensionTracker />
-                    </MockTemporarySettings>
-                </CompatRouter>
+                <MockTemporarySettings settings={{}} onSettingsChanged={onSettingsChanged}>
+                    <IdeExtensionTracker />
+                </MockTemporarySettings>
             </MemoryRouter>
         )
 

--- a/client/web/src/Layout.test.tsx
+++ b/client/web/src/Layout.test.tsx
@@ -1,7 +1,6 @@
 import { render } from '@testing-library/react'
 import { createBrowserHistory } from 'history'
 import { BrowserRouter } from 'react-router-dom'
-import { CompatRouter } from 'react-router-dom-v5-compat'
 import { NEVER } from 'rxjs'
 
 import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
@@ -59,9 +58,7 @@ describe('Layout', () => {
         render(
             <MockedTestProvider>
                 <BrowserRouter>
-                    <CompatRouter>
-                        <Layout {...defaultProps} history={history} location={history.location} />
-                    </CompatRouter>
+                    <Layout {...defaultProps} history={history} location={history.location} />
                 </BrowserRouter>
             </MockedTestProvider>
         )
@@ -78,9 +75,7 @@ describe('Layout', () => {
         render(
             <MockedTestProvider>
                 <BrowserRouter>
-                    <CompatRouter>
-                        <Layout {...defaultProps} history={history} location={history.location} />
-                    </CompatRouter>
+                    <Layout {...defaultProps} history={history} location={history.location} />
                 </BrowserRouter>
             </MockedTestProvider>
         )
@@ -97,9 +92,7 @@ describe('Layout', () => {
         render(
             <MockedTestProvider>
                 <BrowserRouter>
-                    <CompatRouter>
-                        <Layout {...defaultProps} history={history} location={history.location} />
-                    </CompatRouter>
+                    <Layout {...defaultProps} history={history} location={history.location} />
                 </BrowserRouter>
             </MockedTestProvider>
         )
@@ -116,9 +109,7 @@ describe('Layout', () => {
         render(
             <MockedTestProvider>
                 <BrowserRouter>
-                    <CompatRouter>
-                        <Layout {...defaultProps} history={history} location={history.location} />
-                    </CompatRouter>
+                    <Layout {...defaultProps} history={history} location={history.location} />
                 </BrowserRouter>
             </MockedTestProvider>
         )

--- a/client/web/src/SourcegraphWebApp.tsx
+++ b/client/web/src/SourcegraphWebApp.tsx
@@ -7,7 +7,6 @@ import { ShortcutProvider } from '@slimsag/react-shortcuts'
 import { createBrowserHistory } from 'history'
 import ServerIcon from 'mdi-react/ServerIcon'
 import { Route, Router } from 'react-router'
-import { CompatRouter } from 'react-router-dom-v5-compat'
 import { ScrollManager } from 'react-scroll-manager'
 import { combineLatest, from, Subscription, fromEvent, of, Subject, Observable } from 'rxjs'
 import { catchError, distinctUntilChanged, map, startWith, switchMap } from 'rxjs/operators'
@@ -392,88 +391,80 @@ export class SourcegraphWebApp extends React.Component<SourcegraphWebAppProps, S
                                         <SearchQueryStateStoreProvider useSearchQueryState={useNavbarQueryState}>
                                             <ScrollManager history={history}>
                                                 <Router history={history} key={0}>
-                                                    <CompatRouter>
-                                                        <Route
-                                                            path="/"
-                                                            render={routeComponentProps => (
-                                                                <CodeHostScopeProvider
+                                                    <Route
+                                                        path="/"
+                                                        render={routeComponentProps => (
+                                                            <CodeHostScopeProvider
+                                                                authenticatedUser={authenticatedUser}
+                                                            >
+                                                                <LayoutWithActivation
+                                                                    {...props}
+                                                                    {...routeComponentProps}
                                                                     authenticatedUser={authenticatedUser}
-                                                                >
-                                                                    <LayoutWithActivation
-                                                                        {...props}
-                                                                        {...routeComponentProps}
-                                                                        authenticatedUser={authenticatedUser}
-                                                                        viewerSubject={this.state.viewerSubject}
-                                                                        settingsCascade={this.state.settingsCascade}
-                                                                        batchChangesEnabled={
-                                                                            this.props.batchChangesEnabled
-                                                                        }
-                                                                        batchChangesExecutionEnabled={isBatchChangesExecutionEnabled(
-                                                                            this.state.settingsCascade
-                                                                        )}
-                                                                        batchChangesWebhookLogsEnabled={
-                                                                            window.context
-                                                                                .batchChangesWebhookLogsEnabled
-                                                                        }
-                                                                        // Search query
-                                                                        fetchHighlightedFileLineRanges={
-                                                                            this.fetchHighlightedFileLineRanges
-                                                                        }
-                                                                        // Extensions
-                                                                        platformContext={this.platformContext}
-                                                                        extensionsController={this.extensionsController}
-                                                                        telemetryService={eventLogger}
-                                                                        isSourcegraphDotCom={
-                                                                            window.context.sourcegraphDotComMode
-                                                                        }
-                                                                        searchContextsEnabled={
-                                                                            this.props.searchContextsEnabled
-                                                                        }
-                                                                        hasUserAddedRepositories={this.hasUserAddedRepositories()}
-                                                                        hasUserAddedExternalServices={
-                                                                            this.state.hasUserAddedExternalServices
-                                                                        }
-                                                                        selectedSearchContextSpec={this.getSelectedSearchContextSpec()}
-                                                                        setSelectedSearchContextSpec={
-                                                                            this.setSelectedSearchContextSpec
-                                                                        }
-                                                                        getUserSearchContextNamespaces={
-                                                                            getUserSearchContextNamespaces
-                                                                        }
-                                                                        fetchAutoDefinedSearchContexts={
-                                                                            fetchAutoDefinedSearchContexts
-                                                                        }
-                                                                        fetchSearchContexts={fetchSearchContexts}
-                                                                        fetchSearchContextBySpec={
-                                                                            fetchSearchContextBySpec
-                                                                        }
-                                                                        fetchSearchContext={fetchSearchContext}
-                                                                        createSearchContext={createSearchContext}
-                                                                        updateSearchContext={updateSearchContext}
-                                                                        deleteSearchContext={deleteSearchContext}
-                                                                        isSearchContextSpecAvailable={
-                                                                            isSearchContextSpecAvailable
-                                                                        }
-                                                                        defaultSearchContextSpec={
-                                                                            this.state.defaultSearchContextSpec
-                                                                        }
-                                                                        globbing={this.state.globbing}
-                                                                        streamSearch={aggregateStreamingSearch}
-                                                                        onUserExternalServicesOrRepositoriesUpdate={
-                                                                            this
-                                                                                .onUserExternalServicesOrRepositoriesUpdate
-                                                                        }
-                                                                        onSyncedPublicRepositoriesUpdate={
-                                                                            this.onSyncedPublicRepositoriesUpdate
-                                                                        }
-                                                                    />
-                                                                </CodeHostScopeProvider>
-                                                            )}
-                                                        />
-                                                        <NotepadContainer onCreateNotebook={this.onCreateNotebook} />
-                                                        <IdeExtensionTracker />
-                                                        <BrowserExtensionTracker />
-                                                    </CompatRouter>
+                                                                    viewerSubject={this.state.viewerSubject}
+                                                                    settingsCascade={this.state.settingsCascade}
+                                                                    batchChangesEnabled={this.props.batchChangesEnabled}
+                                                                    batchChangesExecutionEnabled={isBatchChangesExecutionEnabled(
+                                                                        this.state.settingsCascade
+                                                                    )}
+                                                                    batchChangesWebhookLogsEnabled={
+                                                                        window.context.batchChangesWebhookLogsEnabled
+                                                                    }
+                                                                    // Search query
+                                                                    fetchHighlightedFileLineRanges={
+                                                                        this.fetchHighlightedFileLineRanges
+                                                                    }
+                                                                    // Extensions
+                                                                    platformContext={this.platformContext}
+                                                                    extensionsController={this.extensionsController}
+                                                                    telemetryService={eventLogger}
+                                                                    isSourcegraphDotCom={
+                                                                        window.context.sourcegraphDotComMode
+                                                                    }
+                                                                    searchContextsEnabled={
+                                                                        this.props.searchContextsEnabled
+                                                                    }
+                                                                    hasUserAddedRepositories={this.hasUserAddedRepositories()}
+                                                                    hasUserAddedExternalServices={
+                                                                        this.state.hasUserAddedExternalServices
+                                                                    }
+                                                                    selectedSearchContextSpec={this.getSelectedSearchContextSpec()}
+                                                                    setSelectedSearchContextSpec={
+                                                                        this.setSelectedSearchContextSpec
+                                                                    }
+                                                                    getUserSearchContextNamespaces={
+                                                                        getUserSearchContextNamespaces
+                                                                    }
+                                                                    fetchAutoDefinedSearchContexts={
+                                                                        fetchAutoDefinedSearchContexts
+                                                                    }
+                                                                    fetchSearchContexts={fetchSearchContexts}
+                                                                    fetchSearchContextBySpec={fetchSearchContextBySpec}
+                                                                    fetchSearchContext={fetchSearchContext}
+                                                                    createSearchContext={createSearchContext}
+                                                                    updateSearchContext={updateSearchContext}
+                                                                    deleteSearchContext={deleteSearchContext}
+                                                                    isSearchContextSpecAvailable={
+                                                                        isSearchContextSpecAvailable
+                                                                    }
+                                                                    defaultSearchContextSpec={
+                                                                        this.state.defaultSearchContextSpec
+                                                                    }
+                                                                    globbing={this.state.globbing}
+                                                                    streamSearch={aggregateStreamingSearch}
+                                                                    onUserExternalServicesOrRepositoriesUpdate={
+                                                                        this.onUserExternalServicesOrRepositoriesUpdate
+                                                                    }
+                                                                    onSyncedPublicRepositoriesUpdate={
+                                                                        this.onSyncedPublicRepositoriesUpdate
+                                                                    }
+                                                                />
+                                                            </CodeHostScopeProvider>
+                                                        )}
+                                                    />
+                                                    <NotepadContainer onCreateNotebook={this.onCreateNotebook} />
+                                                    <IdeExtensionTracker />
+                                                    <BrowserExtensionTracker />
                                                 </Router>
                                             </ScrollManager>
                                             <DeprecatedTooltip key={1} />

--- a/client/web/src/codeintel/ReferencesPanel.tsx
+++ b/client/web/src/codeintel/ReferencesPanel.tsx
@@ -8,7 +8,6 @@ import ChevronDownIcon from 'mdi-react/ChevronDownIcon'
 import ChevronRightIcon from 'mdi-react/ChevronRightIcon'
 import FilterOutlineIcon from 'mdi-react/FilterOutlineIcon'
 import { MemoryRouter, useHistory, useLocation } from 'react-router'
-import { CompatRouter } from 'react-router-dom-v5-compat'
 
 import { HoveredToken } from '@sourcegraph/codeintellify'
 import {
@@ -98,9 +97,7 @@ export const ReferencesPanelWithMemoryRouter: React.FunctionComponent<
         key={`${props.externalLocation.pathname}${props.externalLocation.search}${props.externalLocation.hash}`}
         initialEntries={[props.externalLocation]}
     >
-        <CompatRouter>
-            <ReferencesPanel {...props} />
-        </CompatRouter>
+        <ReferencesPanel {...props} />
     </MemoryRouter>
 )
 

--- a/client/web/src/components/WebStory.tsx
+++ b/client/web/src/components/WebStory.tsx
@@ -1,12 +1,12 @@
 import React, { useMemo } from 'react'
 
 import { MemoryRouter, MemoryRouterProps, RouteComponentProps, withRouter } from 'react-router'
-import { CompatRouter } from 'react-router-dom-v5-compat'
 
 import { NOOP_TELEMETRY_SERVICE, TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
 import { MockedStoryProvider, MockedStoryProviderProps, usePrependStyles, useTheme } from '@sourcegraph/storybook'
 // Add root Tooltip for Storybook
+// eslint-disable-next-line no-restricted-imports
 import { DeprecatedTooltip, WildcardThemeContext } from '@sourcegraph/wildcard'
 
 import { setExperimentalFeaturesForTesting } from '../stores/experimentalFeatures'
@@ -44,14 +44,12 @@ export const WebStory: React.FunctionComponent<React.PropsWithChildren<WebStoryP
         <MockedStoryProvider mocks={mocks} useStrictMocking={useStrictMocking}>
             <WildcardThemeContext.Provider value={{ isBranded: true }}>
                 <MemoryRouter {...memoryRouterProps}>
-                    <CompatRouter>
-                        <DeprecatedTooltip />
-                        <Children
-                            {...breadcrumbSetters}
-                            isLightTheme={isLightTheme}
-                            telemetryService={NOOP_TELEMETRY_SERVICE}
-                        />
-                    </CompatRouter>
+                    <DeprecatedTooltip />
+                    <Children
+                        {...breadcrumbSetters}
+                        isLightTheme={isLightTheme}
+                        telemetryService={NOOP_TELEMETRY_SERVICE}
+                    />
                 </MemoryRouter>
             </WildcardThemeContext.Provider>
         </MockedStoryProvider>

--- a/client/web/src/components/diff/DiffHunk.test.tsx
+++ b/client/web/src/components/diff/DiffHunk.test.tsx
@@ -1,7 +1,6 @@
 import { render } from '@testing-library/react'
 import { createMemoryHistory } from 'history'
 import { Router } from 'react-router-dom'
-import { CompatRouter } from 'react-router-dom-v5-compat'
 
 import { Range } from '@sourcegraph/extension-api-classes'
 import { TextDocumentDecoration } from '@sourcegraph/extension-api-types'
@@ -61,19 +60,17 @@ describe('DiffHunk', () => {
         expect(
             render(
                 <Router history={history}>
-                    <CompatRouter>
-                        <table>
-                            <tbody>
-                                <DiffHunk
-                                    hunk={hunk}
-                                    decorations={{ head: new Map(), base: new Map() }}
-                                    lineNumbers={true}
-                                    isLightTheme={true}
-                                    fileDiffAnchor="anchor_"
-                                />
-                            </tbody>
-                        </table>
-                    </CompatRouter>
+                    <table>
+                        <tbody>
+                            <DiffHunk
+                                hunk={hunk}
+                                decorations={{ head: new Map(), base: new Map() }}
+                                lineNumbers={true}
+                                isLightTheme={true}
+                                fileDiffAnchor="anchor_"
+                            />
+                        </tbody>
+                    </table>
                 </Router>
             ).asFragment()
         ).toMatchSnapshot()
@@ -122,19 +119,17 @@ describe('DiffHunk', () => {
         expect(
             render(
                 <Router history={history}>
-                    <CompatRouter>
-                        <table>
-                            <tbody>
-                                <DiffHunk
-                                    hunk={hunk}
-                                    decorations={decorations}
-                                    lineNumbers={true}
-                                    isLightTheme={true}
-                                    fileDiffAnchor="anchor_"
-                                />
-                            </tbody>
-                        </table>
-                    </CompatRouter>
+                    <table>
+                        <tbody>
+                            <DiffHunk
+                                hunk={hunk}
+                                decorations={decorations}
+                                lineNumbers={true}
+                                isLightTheme={true}
+                                fileDiffAnchor="anchor_"
+                            />
+                        </tbody>
+                    </table>
                 </Router>
             ).asFragment()
         ).toMatchSnapshot()
@@ -144,19 +139,17 @@ describe('DiffHunk', () => {
         expect(
             render(
                 <Router history={history}>
-                    <CompatRouter>
-                        <table>
-                            <tbody>
-                                <DiffHunk
-                                    hunk={hunk}
-                                    decorations={decorations}
-                                    lineNumbers={true}
-                                    isLightTheme={false}
-                                    fileDiffAnchor="anchor_"
-                                />
-                            </tbody>
-                        </table>
-                    </CompatRouter>
+                    <table>
+                        <tbody>
+                            <DiffHunk
+                                hunk={hunk}
+                                decorations={decorations}
+                                lineNumbers={true}
+                                isLightTheme={false}
+                                fileDiffAnchor="anchor_"
+                            />
+                        </tbody>
+                    </table>
                 </Router>
             ).asFragment()
         ).toMatchSnapshot()

--- a/client/web/src/components/diff/DiffSplitHunk.test.tsx
+++ b/client/web/src/components/diff/DiffSplitHunk.test.tsx
@@ -1,7 +1,6 @@
 import { cleanup, fireEvent, render, RenderResult } from '@testing-library/react'
 import { createMemoryHistory } from 'history'
 import { Router } from 'react-router'
-import { CompatRouter } from 'react-router-dom-v5-compat'
 
 import { DiffHunkLineType, FileDiffHunkFields } from '../../graphql-operations'
 
@@ -60,13 +59,11 @@ describe('DiffSplitHunk', () => {
     const renderWithProps = (props: DiffHunkProps): RenderResult =>
         render(
             <Router history={history}>
-                <CompatRouter>
-                    <table>
-                        <tbody>
-                            <DiffSplitHunk {...props} />
-                        </tbody>
-                    </table>
-                </CompatRouter>
+                <table>
+                    <tbody>
+                        <DiffSplitHunk {...props} />
+                    </tbody>
+                </table>
             </Router>
         )
 

--- a/client/web/src/enterprise/code-monitoring/CodeMonitoringPage.test.tsx
+++ b/client/web/src/enterprise/code-monitoring/CodeMonitoringPage.test.tsx
@@ -1,6 +1,5 @@
 import { render, fireEvent } from '@testing-library/react'
 import { MemoryRouter } from 'react-router'
-import { CompatRouter } from 'react-router-dom-v5-compat'
 import { of } from 'rxjs'
 import sinon from 'sinon'
 
@@ -44,9 +43,7 @@ describe('CodeMonitoringListPage', () => {
     test('Clicking enabled toggle calls toggleCodeMonitorEnabled', () => {
         const component = render(
             <MemoryRouter initialEntries={['/code-monitoring']}>
-                <CompatRouter>
-                    <CodeMonitoringPage {...additionalProps} fetchUserCodeMonitors={generateMockFetchMonitors(1)} />
-                </CompatRouter>
+                <CodeMonitoringPage {...additionalProps} fetchUserCodeMonitors={generateMockFetchMonitors(1)} />
             </MemoryRouter>
         )
         const toggle = component.getByTestId('toggle-monitor-enabled')
@@ -57,9 +54,7 @@ describe('CodeMonitoringListPage', () => {
     test('Switching tabs from getting started to empty list works', () => {
         const component = render(
             <MemoryRouter initialEntries={['/code-monitoring']}>
-                <CompatRouter>
-                    <CodeMonitoringPage {...additionalProps} fetchUserCodeMonitors={generateMockFetchMonitors(0)} />
-                </CompatRouter>
+                <CodeMonitoringPage {...additionalProps} fetchUserCodeMonitors={generateMockFetchMonitors(0)} />
             </MemoryRouter>
         )
         const codeMonitorsButton = component.getByRole('button', { name: 'Code monitors' })
@@ -72,9 +67,7 @@ describe('CodeMonitoringListPage', () => {
     test('Switching tabs from list to getting started works', () => {
         const component = render(
             <MemoryRouter initialEntries={['/code-monitoring']}>
-                <CompatRouter>
-                    <CodeMonitoringPage {...additionalProps} fetchUserCodeMonitors={generateMockFetchMonitors(0)} />
-                </CompatRouter>
+                <CodeMonitoringPage {...additionalProps} fetchUserCodeMonitors={generateMockFetchMonitors(0)} />
             </MemoryRouter>
         )
         const gettingStartedButton = component.getByRole('button', { name: 'Getting started' })

--- a/client/web/src/enterprise/embed/EmbeddedWebApp.tsx
+++ b/client/web/src/enterprise/embed/EmbeddedWebApp.tsx
@@ -1,7 +1,6 @@
 import React, { Suspense, useEffect } from 'react'
 
 import { BrowserRouter, Route, RouteComponentProps, Switch } from 'react-router-dom'
-import { CompatRouter } from 'react-router-dom-v5-compat'
 
 import { lazyComponent } from '@sourcegraph/shared/src/util/lazyComponent'
 import { Alert, LoadingSpinner, setLinkComponent, WildcardTheme, WildcardThemeContext } from '@sourcegraph/wildcard'
@@ -56,44 +55,42 @@ export const EmbeddedWebApp: React.FunctionComponent<React.PropsWithChildren<unk
     // IMPORTANT: Please consult with the security team if you are unsure whether your changes could introduce security exploits.
     return (
         <BrowserRouter>
-            <CompatRouter>
-                <WildcardThemeContext.Provider value={WILDCARD_THEME}>
-                    <div className={styles.body}>
-                        <Suspense
-                            fallback={
-                                <div className="d-flex justify-content-center p-3">
-                                    <LoadingSpinner />
-                                </div>
-                            }
-                        >
-                            <Switch>
-                                <Route
-                                    path="/embed/notebooks/:notebookId"
-                                    render={(props: RouteComponentProps<{ notebookId: string }>) => (
-                                        <EmbeddedNotebookPage
-                                            notebookId={props.match.params.notebookId}
-                                            searchContextsEnabled={true}
-                                            showSearchContext={true}
-                                            isSourcegraphDotCom={window.context.sourcegraphDotComMode}
-                                            authenticatedUser={null}
-                                            isLightTheme={isLightTheme}
-                                            settingsCascade={EMPTY_SETTINGS_CASCADE}
-                                        />
-                                    )}
-                                />
-                                <Route
-                                    path="*"
-                                    render={() => (
-                                        <Alert variant="danger">
-                                            Invalid embedding route, please check the embedding URL.
-                                        </Alert>
-                                    )}
-                                />
-                            </Switch>
-                        </Suspense>
-                    </div>
-                </WildcardThemeContext.Provider>
-            </CompatRouter>
+            <WildcardThemeContext.Provider value={WILDCARD_THEME}>
+                <div className={styles.body}>
+                    <Suspense
+                        fallback={
+                            <div className="d-flex justify-content-center p-3">
+                                <LoadingSpinner />
+                            </div>
+                        }
+                    >
+                        <Switch>
+                            <Route
+                                path="/embed/notebooks/:notebookId"
+                                render={(props: RouteComponentProps<{ notebookId: string }>) => (
+                                    <EmbeddedNotebookPage
+                                        notebookId={props.match.params.notebookId}
+                                        searchContextsEnabled={true}
+                                        showSearchContext={true}
+                                        isSourcegraphDotCom={window.context.sourcegraphDotComMode}
+                                        authenticatedUser={null}
+                                        isLightTheme={isLightTheme}
+                                        settingsCascade={EMPTY_SETTINGS_CASCADE}
+                                    />
+                                )}
+                            />
+                            <Route
+                                path="*"
+                                render={() => (
+                                    <Alert variant="danger">
+                                        Invalid embedding route, please check the embedding URL.
+                                    </Alert>
+                                )}
+                            />
+                        </Switch>
+                    </Suspense>
+                </div>
+            </WildcardThemeContext.Provider>
         </BrowserRouter>
     )
 }

--- a/client/web/src/enterprise/insights/pages/CodeInsightsRootPage.test.tsx
+++ b/client/web/src/enterprise/insights/pages/CodeInsightsRootPage.test.tsx
@@ -6,7 +6,6 @@ import userEvent from '@testing-library/user-event'
 import * as H from 'history'
 import { MemoryRouter } from 'react-router'
 import { Route } from 'react-router-dom'
-import { CompatRouter } from 'react-router-dom-v5-compat'
 import { of } from 'rxjs'
 import sinon from 'sinon'
 
@@ -68,17 +67,15 @@ const renderWithBrandedContext = (component: React.ReactElement, { route = '/', 
             <MockedTestProvider>
                 <Wrapper api={api}>
                     <MemoryRouter initialEntries={[route]}>
-                        <CompatRouter>
-                            {component}
-                            <Route
-                                path="*"
-                                render={({ history, location }) => {
-                                    routerSettings.testHistory = history
-                                    routerSettings.testLocation = location
-                                    return null
-                                }}
-                            />
-                        </CompatRouter>
+                        {component}
+                        <Route
+                            path="*"
+                            render={({ history, location }) => {
+                                routerSettings.testHistory = history
+                                routerSettings.testLocation = location
+                                return null
+                            }}
+                        />
                     </MemoryRouter>
                 </Wrapper>
             </MockedTestProvider>

--- a/client/web/src/enterprise/search/stats/SearchStatsLanguages.test.tsx
+++ b/client/web/src/enterprise/search/stats/SearchStatsLanguages.test.tsx
@@ -1,6 +1,5 @@
 import { render } from '@testing-library/react'
 import { MemoryRouter } from 'react-router'
-import { CompatRouter } from 'react-router-dom-v5-compat'
 
 import { SearchStatsLanguages, summarizeSearchResultsStatsLanguages } from './SearchStatsLanguages'
 
@@ -8,23 +7,21 @@ describe('SearchStatsLanguages', () => {
     test('renders', () => {
         const component = render(
             <MemoryRouter>
-                <CompatRouter>
-                    <SearchStatsLanguages
-                        query="abc"
-                        stats={{
-                            __typename: 'SearchResultsStats',
-                            approximateResultCount: '123',
-                            sparkline: [],
-                            languages: [
-                                { __typename: 'LanguageStatistics', name: 'A', totalBytes: 0, totalLines: 100 },
-                                { __typename: 'LanguageStatistics', name: 'B', totalBytes: 0, totalLines: 50 },
-                                { __typename: 'LanguageStatistics', name: 'C', totalBytes: 0, totalLines: 10 },
-                                { __typename: 'LanguageStatistics', name: 'D', totalBytes: 0, totalLines: 5 },
-                                { __typename: 'LanguageStatistics', name: '', totalBytes: 0, totalLines: 35 },
-                            ],
-                        }}
-                    />
-                </CompatRouter>
+                <SearchStatsLanguages
+                    query="abc"
+                    stats={{
+                        __typename: 'SearchResultsStats',
+                        approximateResultCount: '123',
+                        sparkline: [],
+                        languages: [
+                            { __typename: 'LanguageStatistics', name: 'A', totalBytes: 0, totalLines: 100 },
+                            { __typename: 'LanguageStatistics', name: 'B', totalBytes: 0, totalLines: 50 },
+                            { __typename: 'LanguageStatistics', name: 'C', totalBytes: 0, totalLines: 10 },
+                            { __typename: 'LanguageStatistics', name: 'D', totalBytes: 0, totalLines: 5 },
+                            { __typename: 'LanguageStatistics', name: '', totalBytes: 0, totalLines: 35 },
+                        ],
+                    }}
+                />
             </MemoryRouter>
         )
         expect(component.asFragment()).toMatchSnapshot()

--- a/client/web/src/enterprise/search/stats/SearchStatsPage.test.tsx
+++ b/client/web/src/enterprise/search/stats/SearchStatsPage.test.tsx
@@ -1,7 +1,6 @@
 import { render, act } from '@testing-library/react'
 import * as H from 'history'
 import { MemoryRouter } from 'react-router'
-import { CompatRouter } from 'react-router-dom-v5-compat'
 import { of } from 'rxjs'
 
 import * as GQL from '@sourcegraph/shared/src/schema'
@@ -12,27 +11,25 @@ describe('SearchStatsPage', () => {
     test('renders', () => {
         const component = render(
             <MemoryRouter>
-                <CompatRouter>
-                    <SearchStatsPage
-                        location={H.createLocation({ pathname: '/stats', search: 'q=abc' })}
-                        history={H.createMemoryHistory()}
-                        _querySearchResultsStats={() =>
-                            of<GQL.ISearchResultsStats & { limitHit: boolean }>({
-                                __typename: 'SearchResultsStats',
-                                approximateResultCount: '123',
-                                sparkline: [],
-                                languages: [
-                                    { __typename: 'LanguageStatistics', name: 'A', totalBytes: 0, totalLines: 100 },
-                                    { __typename: 'LanguageStatistics', name: 'B', totalBytes: 0, totalLines: 50 },
-                                    { __typename: 'LanguageStatistics', name: 'C', totalBytes: 0, totalLines: 10 },
-                                    { __typename: 'LanguageStatistics', name: 'D', totalBytes: 0, totalLines: 5 },
-                                    { __typename: 'LanguageStatistics', name: '', totalBytes: 0, totalLines: 35 },
-                                ],
-                                limitHit: false,
-                            })
-                        }
-                    />
-                </CompatRouter>
+                <SearchStatsPage
+                    location={H.createLocation({ pathname: '/stats', search: 'q=abc' })}
+                    history={H.createMemoryHistory()}
+                    _querySearchResultsStats={() =>
+                        of<GQL.ISearchResultsStats & { limitHit: boolean }>({
+                            __typename: 'SearchResultsStats',
+                            approximateResultCount: '123',
+                            sparkline: [],
+                            languages: [
+                                { __typename: 'LanguageStatistics', name: 'A', totalBytes: 0, totalLines: 100 },
+                                { __typename: 'LanguageStatistics', name: 'B', totalBytes: 0, totalLines: 50 },
+                                { __typename: 'LanguageStatistics', name: 'C', totalBytes: 0, totalLines: 10 },
+                                { __typename: 'LanguageStatistics', name: 'D', totalBytes: 0, totalLines: 5 },
+                                { __typename: 'LanguageStatistics', name: '', totalBytes: 0, totalLines: 35 },
+                            ],
+                            limitHit: false,
+                        })
+                    }
+                />
             </MemoryRouter>
         )
         act(() => undefined) // wait for _querySearchResultsStats to emit
@@ -42,23 +39,21 @@ describe('SearchStatsPage', () => {
     test('limitHit', () => {
         const component = render(
             <MemoryRouter>
-                <CompatRouter>
-                    <SearchStatsPage
-                        location={H.createLocation({ pathname: '/stats', search: 'q=abc' })}
-                        history={H.createMemoryHistory()}
-                        _querySearchResultsStats={() =>
-                            of<GQL.ISearchResultsStats & { limitHit: boolean }>({
-                                __typename: 'SearchResultsStats',
-                                approximateResultCount: '123',
-                                sparkline: [],
-                                languages: [
-                                    { __typename: 'LanguageStatistics', name: 'A', totalBytes: 0, totalLines: 100 },
-                                ],
-                                limitHit: true,
-                            })
-                        }
-                    />
-                </CompatRouter>
+                <SearchStatsPage
+                    location={H.createLocation({ pathname: '/stats', search: 'q=abc' })}
+                    history={H.createMemoryHistory()}
+                    _querySearchResultsStats={() =>
+                        of<GQL.ISearchResultsStats & { limitHit: boolean }>({
+                            __typename: 'SearchResultsStats',
+                            approximateResultCount: '123',
+                            sparkline: [],
+                            languages: [
+                                { __typename: 'LanguageStatistics', name: 'A', totalBytes: 0, totalLines: 100 },
+                            ],
+                            limitHit: true,
+                        })
+                    }
+                />
             </MemoryRouter>
         )
         act(() => undefined) // wait for _querySearchResultsStats to emit

--- a/client/web/src/extensions/ExtensionCard.test.tsx
+++ b/client/web/src/extensions/ExtensionCard.test.tsx
@@ -1,6 +1,5 @@
 import { render } from '@testing-library/react'
 import { MemoryRouter } from 'react-router'
-import { CompatRouter } from 'react-router-dom-v5-compat'
 
 import { PlatformContext } from '@sourcegraph/shared/src/platform/context'
 
@@ -22,47 +21,45 @@ describe('ExtensionCard', () => {
         expect(
             render(
                 <MemoryRouter>
-                    <CompatRouter>
-                        <ExtensionCard
-                            node={{
-                                id: 'x/y',
-                                manifest: {
-                                    activationEvents: ['*'],
-                                    description: 'd',
-                                    url: 'https://example.com',
-                                    icon: 'data:image/png,abcd',
-                                },
-                                registryExtension: {
-                                    id: 'abcd1234',
-                                    extensionIDWithoutRegistry: 'x/y',
-                                    url: 'extensions/x/y',
-                                    isWorkInProgress: false,
-                                    viewerCanAdminister: false,
-                                },
-                            }}
-                            subject={{ id: 'u', viewerCanAdminister: false }}
-                            viewerSubject={{
-                                __typename: 'User',
-                                username: 'u',
-                                displayName: 'u',
-                                id: 'u',
+                    <ExtensionCard
+                        node={{
+                            id: 'x/y',
+                            manifest: {
+                                activationEvents: ['*'],
+                                description: 'd',
+                                url: 'https://example.com',
+                                icon: 'data:image/png,abcd',
+                            },
+                            registryExtension: {
+                                id: 'abcd1234',
+                                extensionIDWithoutRegistry: 'x/y',
+                                url: 'extensions/x/y',
+                                isWorkInProgress: false,
                                 viewerCanAdminister: false,
-                            }}
-                            siteSubject={{
-                                __typename: 'Site',
-                                id: 's',
-                                viewerCanAdminister: true,
-                                allowSiteSettingsEdits: true,
-                            }}
-                            settingsCascade={{ final: null, subjects: null }}
-                            platformContext={NOOP_PLATFORM_CONTEXT}
-                            enabled={false}
-                            enabledForAllUsers={false}
-                            isLightTheme={false}
-                            settingsURL="/settings/foobar"
-                            authenticatedUser={mockUser}
-                        />
-                    </CompatRouter>
+                            },
+                        }}
+                        subject={{ id: 'u', viewerCanAdminister: false }}
+                        viewerSubject={{
+                            __typename: 'User',
+                            username: 'u',
+                            displayName: 'u',
+                            id: 'u',
+                            viewerCanAdminister: false,
+                        }}
+                        siteSubject={{
+                            __typename: 'Site',
+                            id: 's',
+                            viewerCanAdminister: true,
+                            allowSiteSettingsEdits: true,
+                        }}
+                        settingsCascade={{ final: null, subjects: null }}
+                        platformContext={NOOP_PLATFORM_CONTEXT}
+                        enabled={false}
+                        enabledForAllUsers={false}
+                        isLightTheme={false}
+                        settingsURL="/settings/foobar"
+                        authenticatedUser={mockUser}
+                    />
                 </MemoryRouter>
             ).asFragment()
         ).toMatchSnapshot()

--- a/client/web/src/nav/UserNavItem.test.tsx
+++ b/client/web/src/nav/UserNavItem.test.tsx
@@ -2,7 +2,6 @@ import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import * as H from 'history'
 import { MemoryRouter } from 'react-router'
-import { CompatRouter } from 'react-router-dom-v5-compat'
 import sinon from 'sinon'
 
 import { renderWithBrandedContext } from '@sourcegraph/shared/src/testing'
@@ -54,18 +53,16 @@ describe('UserNavItem', () => {
         expect(
             render(
                 <MemoryRouter>
-                    <CompatRouter>
-                        <UserNavItem
-                            showRepositorySection={true}
-                            isLightTheme={true}
-                            onThemePreferenceChange={() => undefined}
-                            themePreference={ThemePreference.Light}
-                            authenticatedUser={USER}
-                            showDotComMarketing={true}
-                            isExtensionAlertAnimating={false}
-                            codeHostIntegrationMessaging="browser-extension"
-                        />
-                    </CompatRouter>
+                    <UserNavItem
+                        showRepositorySection={true}
+                        isLightTheme={true}
+                        onThemePreferenceChange={() => undefined}
+                        themePreference={ThemePreference.Light}
+                        authenticatedUser={USER}
+                        showDotComMarketing={true}
+                        isExtensionAlertAnimating={false}
+                        codeHostIntegrationMessaging="browser-extension"
+                    />
                 </MemoryRouter>
             ).asFragment()
         ).toMatchSnapshot()

--- a/client/web/src/person/PersonLink.test.tsx
+++ b/client/web/src/person/PersonLink.test.tsx
@@ -1,6 +1,5 @@
 import { render } from '@testing-library/react'
 import { MemoryRouter } from 'react-router'
-import { CompatRouter } from 'react-router-dom-v5-compat'
 
 import { PersonLink } from './PersonLink'
 
@@ -20,17 +19,15 @@ describe('PersonLink', () => {
         expect(
             render(
                 <MemoryRouter>
-                    <CompatRouter>
-                        <PersonLink
-                            person={{
-                                displayName: 'Alice',
-                                email: 'alice@example.com',
-                                user: { username: 'alice', displayName: 'Alice Smith', url: 'u' },
-                            }}
-                            className="a"
-                            userClassName="b"
-                        />
-                    </CompatRouter>
+                    <PersonLink
+                        person={{
+                            displayName: 'Alice',
+                            email: 'alice@example.com',
+                            user: { username: 'alice', displayName: 'Alice Smith', url: 'u' },
+                        }}
+                        className="a"
+                        userClassName="b"
+                    />
                 </MemoryRouter>
             ).asFragment()
         ).toMatchSnapshot())

--- a/client/web/src/repo/RepositoriesPopover/RepositoriesPopover.test.tsx
+++ b/client/web/src/repo/RepositoriesPopover/RepositoriesPopover.test.tsx
@@ -9,7 +9,7 @@ import { MOCK_REQUESTS } from './RepositoriesPopover.mocks'
 
 const repo = {
     id: 'some-repo-id',
-    name: '/github.com/sourcegraph/sourcegraph',
+    name: 'github.com/sourcegraph/sourcegraph',
 }
 
 describe('RevisionsPopover', () => {

--- a/client/web/src/search/results/StreamingSearchResults.test.tsx
+++ b/client/web/src/search/results/StreamingSearchResults.test.tsx
@@ -4,7 +4,6 @@ import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { createBrowserHistory } from 'history'
 import { BrowserRouter } from 'react-router-dom'
-import { CompatRouter } from 'react-router-dom-v5-compat'
 import { EMPTY, NEVER, of } from 'rxjs'
 import sinon from 'sinon'
 
@@ -61,13 +60,11 @@ describe('StreamingSearchResults', () => {
     function renderWrapper(component: React.ReactElement<StreamingSearchResultsProps>) {
         return render(
             <BrowserRouter>
-                <CompatRouter>
-                    <MockedTestProvider mocks={revisionsMockResponses}>
-                        <SearchQueryStateStoreProvider useSearchQueryState={useNavbarQueryState}>
-                            {component}
-                        </SearchQueryStateStoreProvider>
-                    </MockedTestProvider>
-                </CompatRouter>
+                <MockedTestProvider mocks={revisionsMockResponses}>
+                    <SearchQueryStateStoreProvider useSearchQueryState={useNavbarQueryState}>
+                        {component}
+                    </SearchQueryStateStoreProvider>
+                </MockedTestProvider>
             </BrowserRouter>
         )
     }

--- a/client/web/src/tour/components/Tour/Tour.test.tsx
+++ b/client/web/src/tour/components/Tour/Tour.test.tsx
@@ -1,6 +1,5 @@
 import { render, cleanup, RenderResult, fireEvent, act } from '@testing-library/react'
 import { MemoryRouter } from 'react-router'
-import { CompatRouter } from 'react-router-dom-v5-compat'
 import sinon from 'sinon'
 
 import { MockTemporarySettings } from '@sourcegraph/shared/src/settings/temporary/testUtils'
@@ -61,11 +60,9 @@ const mockedTelemetryService = { ...NOOP_TELEMETRY_SERVICE, log: sinon.spy() }
 const setup = (overrideTasks?: TourTaskType[]): RenderResult =>
     render(
         <MemoryRouter initialEntries={['/']}>
-            <CompatRouter>
-                <MockTemporarySettings settings={{}}>
-                    <Tour telemetryService={mockedTelemetryService} id={TourId} tasks={overrideTasks ?? mockedTasks} />
-                </MockTemporarySettings>
-            </CompatRouter>
+            <MockTemporarySettings settings={{}}>
+                <Tour telemetryService={mockedTelemetryService} id={TourId} tasks={overrideTasks ?? mockedTasks} />
+            </MockTemporarySettings>
         </MemoryRouter>
     )
 

--- a/client/web/src/tracking/BrowserExtentionTracker.test.tsx
+++ b/client/web/src/tracking/BrowserExtentionTracker.test.tsx
@@ -3,7 +3,6 @@ import React from 'react'
 import { act, cleanup, render } from '@testing-library/react'
 import { renderHook, cleanup as hookCleanup } from '@testing-library/react-hooks'
 import { MemoryRouter } from 'react-router-dom'
-import { CompatRouter } from 'react-router-dom-v5-compat'
 
 import { BrowserExtensionTracker, useIsBrowserExtensionActiveUser } from './BrowserExtensionTracker'
 
@@ -26,19 +25,26 @@ describe('BrowserExtensionTracker', () => {
     })
 
     const cases: [string, string | null][] = [
-        ['/github.com/sourcegraph/sourcegraph?utm_source=chrome-extension&utm_campaign=view-on-sourcegraph', DATE_NOW],
-        ['/github.com/sourcegraph/sourcegraph?utm_source=firefox-extension&utm_campaign=view-on-sourcegraph', DATE_NOW],
-        ['/github.com/sourcegraph/sourcegraph?utm_source=safari-extension&utm_campaign=view-on-sourcegraph', DATE_NOW],
-        ['/?something=different', null],
+        [
+            'https://sourcegraph.com/github.com/sourcegraph/sourcegraph?utm_source=chrome-extension&utm_campaign=view-on-sourcegraph',
+            DATE_NOW,
+        ],
+        [
+            'https://sourcegraph.com/github.com/sourcegraph/sourcegraph?utm_source=firefox-extension&utm_campaign=view-on-sourcegraph',
+            DATE_NOW,
+        ],
+        [
+            'https://sourcegraph.com/github.com/sourcegraph/sourcegraph?utm_source=safari-extension&utm_campaign=view-on-sourcegraph',
+            DATE_NOW,
+        ],
+        ['https://sourcegraph.com/?something=different', null],
     ]
     test.each(cases)('Detects query parameters for %p', (url, expectedResult) => {
         expect(localStorage.getItem(BROWSER_EXTENSION_LAST_DETECTION_KEY)).toBeNull()
 
         render(
             <MemoryRouter initialEntries={[url]}>
-                <CompatRouter>
-                    <BrowserExtensionTracker />
-                </CompatRouter>
+                <BrowserExtensionTracker />
             </MemoryRouter>
         )
 
@@ -57,9 +63,7 @@ describe('BrowserExtensionTracker', () => {
         )
         render(
             <MemoryRouter>
-                <CompatRouter>
-                    <BrowserExtensionTracker />
-                </CompatRouter>
+                <BrowserExtensionTracker />
             </MemoryRouter>,
             { wrapper }
         )

--- a/client/web/src/user/settings/profile/UserSettingsProfilePage.test.tsx
+++ b/client/web/src/user/settings/profile/UserSettingsProfilePage.test.tsx
@@ -1,7 +1,6 @@
 import { MockedResponse } from '@apollo/client/testing'
 import { fireEvent, render, RenderResult, act } from '@testing-library/react'
 import { MemoryRouter } from 'react-router'
-import { CompatRouter } from 'react-router-dom-v5-compat'
 
 import { getDocumentNode } from '@sourcegraph/http-client'
 import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
@@ -55,9 +54,7 @@ describe('UserSettingsProfilePage', () => {
         queries = render(
             <MockedTestProvider mocks={mocks}>
                 <MemoryRouter>
-                    <CompatRouter>
-                        <UserSettingsProfilePage user={mockUser} />
-                    </CompatRouter>
+                    <UserSettingsProfilePage user={mockUser} />
                 </MemoryRouter>
             </MockedTestProvider>
         )

--- a/client/wildcard/src/components/Link/createLinkUrl.tsx
+++ b/client/wildcard/src/components/Link/createLinkUrl.tsx
@@ -1,7 +1,7 @@
-import { createPath, Location } from 'react-router-dom-v5-compat'
+import { createPath, LocationDescriptorObject } from 'history'
 
 /**
- * Convenience method provided for translating Location objects
+ * Convenience method provided for translation of History.LocationDescriptorObject's
  * into strings that are accepted by the RouterLink component.
  */
-export const createLinkUrl = (location: Partial<Location<unknown>>): string => createPath(location)
+export const createLinkUrl = (location: LocationDescriptorObject): string => createPath(location)

--- a/package.json
+++ b/package.json
@@ -449,7 +449,6 @@
     "react-grid-layout": "1.3.0",
     "react-router": "^5.2.0",
     "react-router-dom": "^5.2.0",
-    "react-router-dom-v5-compat": "^6.3.0",
     "react-scroll-manager": "^1.0.3",
     "react-select": "^5.2.2",
     "react-spring": "^9.4.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14555,7 +14555,7 @@ highlightjs-graphql@^1.0.2:
   resolved "https://registry.npmjs.org/highlightjs-graphql/-/highlightjs-graphql-1.0.2.tgz#841e26831e7da9f0a3d66f93e6ff98a0d1ad6f43"
   integrity sha512-jShTftpKQDwMXc+7OHOpHXRYSweT08EO2YOIcLbwU00e9yuwJMYXGLF1eiDO0aUPeQU4/5EjAh5HtPt3ly7rvg==
 
-history@4.5.1, history@^4.9.0, history@^5.2.0, history@^5.3.0:
+history@4.5.1, history@^4.9.0:
   version "4.5.1"
   resolved "https://registry.npmjs.org/history/-/history-4.5.1.tgz#44935a51021e3b8e67ebac267a35675732aba569"
   integrity sha1-RJNaUQIeO45n66wmejVnVzKrpWk=
@@ -20956,14 +20956,6 @@ react-resize-detector@^2.3.0:
     prop-types "^15.6.0"
     resize-observer-polyfill "^1.5.0"
 
-react-router-dom-v5-compat@^6.3.0:
-  version "6.3.0"
-  resolved "https://registry.npmjs.org/react-router-dom-v5-compat/-/react-router-dom-v5-compat-6.3.0.tgz#a6b1bf18a42e3c1b902711931c4b496920740815"
-  integrity sha512-lfnfDEAdfXf92VQQ692+aMFj9JKb73GZ7EbiQJeJT4sK+KUGvua3FGN2H8n2H5zSMaY1cvrihGiaI373cvv7OQ==
-  dependencies:
-    history "^5.3.0"
-    react-router "6.3.0"
-
 react-router-dom@^5.2.0:
   version "5.2.0"
   resolved "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.2.0.tgz#9e65a4d0c45e13289e66c7b17c7e175d0ea15662"
@@ -20992,13 +20984,6 @@ react-router@5.2.0, react-router@^5.2.0:
     react-is "^16.6.0"
     tiny-invariant "^1.0.2"
     tiny-warning "^1.0.0"
-
-react-router@6.3.0:
-  version "6.3.0"
-  resolved "https://registry.npmjs.org/react-router/-/react-router-6.3.0.tgz#3970cc64b4cb4eae0c1ea5203a80334fdd175557"
-  integrity sha512-7Wh1DzVQ+tlFjkeo+ujvjSqSJmkt1+8JO+T5xklPlgrh70y7ogx75ODRW0ThWhY7S+6yEDks8TYrtQe/aoboBQ==
-  dependencies:
-    history "^5.2.0"
 
 react-scroll-manager@^1.0.3:
   version "1.0.3"


### PR DESCRIPTION
This reverts commit 4cda7bf0b453d726bd9abf4205ab852e00711cd8 introduced
in #36285.

It breaks the new reference panel on sourcegraph.com
<img width="2461" alt="screenshot_2022-06-15_13 14 40@2x" src="https://user-images.githubusercontent.com/1185253/173814318-a9c3fd42-bac6-4681-a7a2-81c24d553d73.png">


## Test plan

- Noah + Chris confirmed that it fixes it locally
