### PR TITLE
worker: plug the Bitbucket Project Permissions worker to main

### DIFF
--- a/enterprise/cmd/worker/internal/permissions/bitbucket_projects.go
+++ b/enterprise/cmd/worker/internal/permissions/bitbucket_projects.go
@@ -80,6 +80,7 @@ type bitbucketProjectPermissionsHandler struct {
 
 // Handle implements the workerutil.Handler interface.
 func (h *bitbucketProjectPermissionsHandler) Handle(ctx context.Context, logger log.Logger, record workerutil.Record) (err error) {
+	logger = logger.Scoped("bitbucketProjectPermissionsHandler", "handles jobs to apply explicit permissions to all repositories of a Bitbucket Project")
 	defer func() {
 		if err != nil {
 			logger.Error("bitbucketProjectPermissionsHandler.Handle", log.Error(err))
@@ -105,7 +106,7 @@ func (h *bitbucketProjectPermissionsHandler) Handle(ctx context.Context, logger 
 	}
 
 	if job.Unrestricted {
-		return h.setReposUnrestricted(ctx, repos, job.ProjectKey)
+		return h.setReposUnrestricted(ctx, logger, repos, job.ProjectKey)
 	}
 
 	repoIDs := make([]api.RepoID, len(repos))
@@ -113,7 +114,7 @@ func (h *bitbucketProjectPermissionsHandler) Handle(ctx context.Context, logger 
 		repoIDs[i] = api.RepoID(repo.ID)
 	}
 
-	err = h.setPermissionsForUsers(ctx, job.Permissions, repoIDs)
+	err = h.setPermissionsForUsers(ctx, logger, job.Permissions, repoIDs, job.ProjectKey)
 	if err != nil {
 		return errors.Wrapf(err, "failed to set permissions for Bitbucket Project %q", job.ProjectKey)
 	}
@@ -146,7 +147,7 @@ func (h *bitbucketProjectPermissionsHandler) getBitbucketClient(ctx context.Cont
 	return bitbucketserver.NewClient(svc.URN(), &c, cli)
 }
 
-func (h *bitbucketProjectPermissionsHandler) setReposUnrestricted(ctx context.Context, repos []*bitbucketserver.Repo, projectKey string) error {
+func (h *bitbucketProjectPermissionsHandler) setReposUnrestricted(ctx context.Context, logger log.Logger, repos []*bitbucketserver.Repo, projectKey string) error {
 	sort.Slice(repos, func(i, j int) bool {
 		return repos[i].ID < repos[j].ID
 	})
@@ -154,6 +155,8 @@ func (h *bitbucketProjectPermissionsHandler) setReposUnrestricted(ctx context.Co
 	for i, repo := range repos {
 		repoIDs[i] = int32(repo.ID)
 	}
+
+	logger.Info("Setting bitbucket repositories to unrestricted", log.String("project_key", projectKey))
 
 	err := h.db.Perms().SetRepoPermissionsUnrestricted(ctx, repoIDs, true)
 	if err != nil {
@@ -168,7 +171,7 @@ func (h *bitbucketProjectPermissionsHandler) setReposUnrestricted(ctx context.Co
 // Each repo is processed atomically. In case of error, the task fails but doesn't rollback the committed changes
 // done on previous repos. This is fine because when the task is retried, previous repos won't incur any
 // additional writes.
-func (h *bitbucketProjectPermissionsHandler) setPermissionsForUsers(ctx context.Context, perms []types.UserPermission, repoIDs []api.RepoID) error {
+func (h *bitbucketProjectPermissionsHandler) setPermissionsForUsers(ctx context.Context, logger log.Logger, perms []types.UserPermission, repoIDs []api.RepoID, projectKey string) error {
 	sort.Slice(perms, func(i, j int) bool {
 		return perms[i].BindID < perms[j].BindID
 	})
@@ -203,6 +206,8 @@ func (h *bitbucketProjectPermissionsHandler) setPermissionsForUsers(ctx context.
 			pendingBindIDs = append(pendingBindIDs, bindID)
 		}
 	}
+
+	logger.Info("Applying permissions to Bitbucket project repositories", log.String("project_key", projectKey))
 
 	// apply the permissions for each repo
 	for _, repoID := range repoIDs {

--- a/enterprise/cmd/worker/internal/permissions/bitbucket_projects_test.go
+++ b/enterprise/cmd/worker/internal/permissions/bitbucket_projects_test.go
@@ -159,6 +159,7 @@ func TestSetPermissionsForUsers(t *testing.T) {
 	// set permissions for 3 users (2 existing, 1 pending) and 2 repos
 	err = h.setPermissionsForUsers(
 		ctx,
+		log.Scoped("test", "test"),
 		[]types.UserPermission{
 			{BindID: "pushpa@example.com", Permission: "read"},
 			{BindID: "igor@example.com", Permission: "read"},
@@ -168,6 +169,7 @@ func TestSetPermissionsForUsers(t *testing.T) {
 			1,
 			2,
 		},
+		"foo",
 	)
 	require.NoError(t, err)
 	check()
@@ -175,6 +177,7 @@ func TestSetPermissionsForUsers(t *testing.T) {
 	// run the same set of permissions again, shouldn't change anything
 	err = h.setPermissionsForUsers(
 		ctx,
+		log.Scoped("test", "test"),
 		[]types.UserPermission{
 			{BindID: "pushpa@example.com", Permission: "read"},
 			{BindID: "igor@example.com", Permission: "read"},
@@ -184,6 +187,7 @@ func TestSetPermissionsForUsers(t *testing.T) {
 			1,
 			2,
 		},
+		"foo",
 	)
 	require.NoError(t, err)
 	check()
@@ -191,6 +195,7 @@ func TestSetPermissionsForUsers(t *testing.T) {
 	// test with wrong bindids
 	err = h.setPermissionsForUsers(
 		ctx,
+		log.Scoped("test", "test"),
 		[]types.UserPermission{
 			{BindID: "pushpa", Permission: "read"},
 			{BindID: "igor", Permission: "read"},
@@ -200,6 +205,7 @@ func TestSetPermissionsForUsers(t *testing.T) {
 			1,
 			2,
 		},
+		"foo",
 	)
 	// should fail if the bind ids are wrong
 	require.Error(t, err)
@@ -211,6 +217,7 @@ func TestSetPermissionsForUsers(t *testing.T) {
 	// run the same set of permissions again
 	err = h.setPermissionsForUsers(
 		ctx,
+		log.Scoped("test", "test"),
 		[]types.UserPermission{
 			{BindID: "pushpa@example.com", Permission: "read"},
 			{BindID: "igor@example.com", Permission: "read"},
@@ -220,6 +227,7 @@ func TestSetPermissionsForUsers(t *testing.T) {
 			1,
 			2,
 		},
+		"foo",
 	)
 	require.NoError(t, err)
 	check()

--- a/enterprise/cmd/worker/main.go
+++ b/enterprise/cmd/worker/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/worker/internal/codemonitors"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/worker/internal/executors"
 	workerinsights "github.com/sourcegraph/sourcegraph/enterprise/cmd/worker/internal/insights"
+	"github.com/sourcegraph/sourcegraph/enterprise/cmd/worker/internal/permissions"
 	eiauthz "github.com/sourcegraph/sourcegraph/enterprise/internal/authz"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
@@ -40,16 +41,17 @@ func main() {
 	go setAuthzProviders()
 
 	additionalJobs := map[string]job.Job{
-		"codehost-version-syncing":   versions.NewSyncingJob(),
-		"insights-job":               workerinsights.NewInsightsJob(),
-		"insights-query-runner-job":  workerinsights.NewInsightsQueryRunnerJob(),
-		"batches-janitor":            batches.NewJanitorJob(),
-		"batches-scheduler":          batches.NewSchedulerJob(),
-		"batches-reconciler":         batches.NewReconcilerJob(),
-		"batches-bulk-processor":     batches.NewBulkOperationProcessorJob(),
-		"batches-workspace-resolver": batches.NewWorkspaceResolverJob(),
-		"executors-janitor":          executors.NewJanitorJob(),
-		"codemonitors-job":           codemonitors.NewCodeMonitorJob(),
+		"codehost-version-syncing":      versions.NewSyncingJob(),
+		"insights-job":                  workerinsights.NewInsightsJob(),
+		"insights-query-runner-job":     workerinsights.NewInsightsQueryRunnerJob(),
+		"batches-janitor":               batches.NewJanitorJob(),
+		"batches-scheduler":             batches.NewSchedulerJob(),
+		"batches-reconciler":            batches.NewReconcilerJob(),
+		"batches-bulk-processor":        batches.NewBulkOperationProcessorJob(),
+		"batches-workspace-resolver":    batches.NewWorkspaceResolverJob(),
+		"executors-janitor":             executors.NewJanitorJob(),
+		"codemonitors-job":              codemonitors.NewCodeMonitorJob(),
+		"bitbucket-project-permissions": permissions.NewBitbucketProjectPermissionsJob(),
 
 		// fresh
 		"codeintel-upload-janitor":         freshcodeintel.NewUploadJanitorJob(),


### PR DESCRIPTION
This enables the Bitbucket Project Permissions worker.
I also added a few log lines for visibility.

## Test plan

Tested manually:
- it works fine with no job in the table
- it works fine with jobs and dequeues them correctly