### PR TITLE
Issue 37264: allow turn on audit logs

### DIFF
--- a/cmd/frontend/envvar/envvar.go
+++ b/cmd/frontend/envvar/envvar.go
@@ -19,6 +19,7 @@ var HTTPAddrInternal = env.Get(
 )
 
 var sourcegraphDotComMode, _ = strconv.ParseBool(env.Get("SOURCEGRAPHDOTCOM_MODE", "false", "run as Sourcegraph.com, with add'l marketing and redirects"))
+var auditLogEnabled, _ = strconv.ParseBool(env.Get("AUDIT_LOG_ENABLED", "false", "enable audit log"))
 var openGraphPreviewServiceURL = env.Get("OPENGRAPH_PREVIEW_SERVICE_URL", "", "The URL of the OpenGraph preview image generating service")
 
 // SourcegraphDotComMode is true if this server is running Sourcegraph.com
@@ -35,4 +36,8 @@ func MockSourcegraphDotComMode(value bool) {
 
 func OpenGraphPreviewServiceURL() string {
 	return openGraphPreviewServiceURL
+}
+
+func AuditLogEnabled() bool {
+	return auditLogEnabled
 }

--- a/internal/database/security_event_logs.go
+++ b/internal/database/security_event_logs.go
@@ -101,8 +101,8 @@ func (s *securityEventLogsStore) Insert(ctx context.Context, e *SecurityEvent) e
 
 func (s *securityEventLogsStore) LogEvent(ctx context.Context, e *SecurityEvent) {
 	// We don't want to begin logging authentication or authorization events in
-	// on-premises installations yet.
-	if !envvar.SourcegraphDotComMode() {
+	// on-premises installations yet, but we allow to turn on this feature explicitly.
+	if !envvar.SourcegraphDotComMode() && !envvar.AuditLogEnabled() {
 		return
 	}
 

--- a/internal/database/security_event_logs_test.go
+++ b/internal/database/security_event_logs_test.go
@@ -3,7 +3,6 @@ package database
 import (
 	"context"
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -62,60 +61,6 @@ func TestSecurityEventLogs_ValidInfo(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			err := db.SecurityEventLogs().Insert(ctx, tc.event)
-			got := fmt.Sprintf("%v", err)
-			assert.Equal(t, tc.err, got)
-		})
-	}
-}
-
-func TestSecurityEventLogs_LogEvent_Enabling(t *testing.T) {
-	if testing.Short() {
-		t.Skip()
-	}
-	t.Parallel()
-	db := NewDB(dbtest.NewDB(t))
-	ctx := context.Background()
-	var testCases = []struct {
-		name            string
-		event           *SecurityEvent
-		err             string
-		dotComMode      string
-		auditLogEnabled string
-	}{
-		{
-			name:            "EmptyName",
-			event:           &SecurityEvent{UserID: 1, URL: "http://sourcegraph.com", Source: "WEB"},
-			err:             `INSERT: ERROR: new row for relation "security_event_logs" violates check constraint "security_event_logs_check_name_not_empty" (SQLSTATE 23514)`,
-			dotComMode:      "true",
-			auditLogEnabled: "true",
-		},
-		{
-			name:            "EmptyName",
-			event:           &SecurityEvent{UserID: 1, URL: "http://sourcegraph.com", Source: "WEB"},
-			err:             `INSERT: ERROR: new row for relation "security_event_logs" violates check constraint "security_event_logs_check_name_not_empty" (SQLSTATE 23514)`,
-			dotComMode:      "true",
-			auditLogEnabled: "false",
-		},
-		{
-			name:            "EmptyName",
-			event:           &SecurityEvent{UserID: 1, URL: "http://sourcegraph.com", Source: "WEB"},
-			err:             `INSERT: ERROR: new row for relation "security_event_logs" violates check constraint "security_event_logs_check_name_not_empty" (SQLSTATE 23514)`,
-			dotComMode:      "false",
-			auditLogEnabled: "true",
-		},
-		{
-			name:            "EmptyName",
-			event:           &SecurityEvent{UserID: 1, URL: "http://sourcegraph.com", Source: "WEB"},
-			err:             "<nil>",
-			dotComMode:      "false",
-			auditLogEnabled: "false",
-		},
-	}
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			os.Setenv("SOURCEGRAPHDOTCOM_MODE", tc.dotComMode)
-			os.Setenv("AUDIT_LOG_ENABLED", tc.auditLogEnabled)
 			err := db.SecurityEventLogs().Insert(ctx, tc.event)
 			got := fmt.Sprintf("%v", err)
 			assert.Equal(t, tc.err, got)

--- a/internal/database/security_event_logs_test.go
+++ b/internal/database/security_event_logs_test.go
@@ -3,6 +3,7 @@ package database
 import (
 	"context"
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -61,6 +62,60 @@ func TestSecurityEventLogs_ValidInfo(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			err := db.SecurityEventLogs().Insert(ctx, tc.event)
+			got := fmt.Sprintf("%v", err)
+			assert.Equal(t, tc.err, got)
+		})
+	}
+}
+
+func TestSecurityEventLogs_LogEvent_Enabling(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	t.Parallel()
+	db := NewDB(dbtest.NewDB(t))
+	ctx := context.Background()
+	var testCases = []struct {
+		name            string
+		event           *SecurityEvent
+		err             string
+		dotComMode      string
+		auditLogEnabled string
+	}{
+		{
+			name:            "EmptyName",
+			event:           &SecurityEvent{UserID: 1, URL: "http://sourcegraph.com", Source: "WEB"},
+			err:             `INSERT: ERROR: new row for relation "security_event_logs" violates check constraint "security_event_logs_check_name_not_empty" (SQLSTATE 23514)`,
+			dotComMode:      "true",
+			auditLogEnabled: "true",
+		},
+		{
+			name:            "EmptyName",
+			event:           &SecurityEvent{UserID: 1, URL: "http://sourcegraph.com", Source: "WEB"},
+			err:             `INSERT: ERROR: new row for relation "security_event_logs" violates check constraint "security_event_logs_check_name_not_empty" (SQLSTATE 23514)`,
+			dotComMode:      "true",
+			auditLogEnabled: "false",
+		},
+		{
+			name:            "EmptyName",
+			event:           &SecurityEvent{UserID: 1, URL: "http://sourcegraph.com", Source: "WEB"},
+			err:             `INSERT: ERROR: new row for relation "security_event_logs" violates check constraint "security_event_logs_check_name_not_empty" (SQLSTATE 23514)`,
+			dotComMode:      "false",
+			auditLogEnabled: "true",
+		},
+		{
+			name:            "EmptyName",
+			event:           &SecurityEvent{UserID: 1, URL: "http://sourcegraph.com", Source: "WEB"},
+			err:             "<nil>",
+			dotComMode:      "false",
+			auditLogEnabled: "false",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			os.Setenv("SOURCEGRAPHDOTCOM_MODE", tc.dotComMode)
+			os.Setenv("AUDIT_LOG_ENABLED", tc.auditLogEnabled)
 			err := db.SecurityEventLogs().Insert(ctx, tc.event)
 			got := fmt.Sprintf("%v", err)
 			assert.Equal(t, tc.err, got)


### PR DESCRIPTION
# Description

Part of [issue](https://github.com/sourcegraph/sourcegraph/issues/37264)

Allow enabling audit logs (`security_event_logs`) in any Sourcegraph instance via environment variable (required for audit managed instances): `AUDIT_LOG_ENABLED=true`.
Change is backward compatible, as flag `SOURCEGRAPHDOTCOM_MODE=true` also turns on `security_event_logs`.

## Test plan

Run unit tests. Tested on local SG dev.
