### PR TITLE
Code Insights: Refactor line chart series toggling logic

### DIFF
--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/backend-insight-chart/BackendInsightChart.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/backend-insight-chart/BackendInsightChart.tsx
@@ -92,7 +92,8 @@ export function BackendInsightChart<Datum>(props: BackendInsightChartProps<Datum
                                     className={styles.chart}
                                     onDatumClick={onDatumClick}
                                     zeroYAxisMin={zeroYAxisMin}
-                                    seriesToggleState={seriesToggleState}
+                                    isSeriesSelected={isSeriesSelected}
+                                    isSeriesHovered={isSeriesHovered}
                                     {...content}
                                 />
                             </>

--- a/client/web/src/enterprise/insights/components/views/chart/series/SeriesChart.tsx
+++ b/client/web/src/enterprise/insights/components/views/chart/series/SeriesChart.tsx
@@ -1,7 +1,6 @@
 import React, { SVGProps } from 'react'
 
 import { LineChart, SeriesLikeChart } from '../../../../../../charts'
-import { UseSeriesToggleReturn } from '../../../../../../insights/utils/use-series-toggle'
 import { SeriesBasedChartTypes } from '../../types'
 import { LockedChart } from '../locked/LockedChart'
 
@@ -11,15 +10,16 @@ export interface SeriesChartProps<D> extends SeriesLikeChart<D>, Omit<SVGProps<S
     height: number
     zeroYAxisMin?: boolean
     locked?: boolean
-    seriesToggleState: UseSeriesToggleReturn
+    isSeriesSelected?: (id: string) => boolean
+    isSeriesHovered?: (id: string) => boolean
 }
 
 export function SeriesChart<Datum>(props: SeriesChartProps<Datum>): React.ReactElement {
-    const { type, locked, ...otherProps } = props
+    const { type, locked, isSeriesSelected = () => true, isSeriesHovered = () => true, ...otherProps } = props
 
     if (locked) {
         return <LockedChart />
     }
 
-    return <LineChart {...otherProps} />
+    return <LineChart isSeriesSelected={isSeriesSelected} isSeriesHovered={isSeriesHovered} {...otherProps} />
 }

--- a/client/web/src/enterprise/insights/pages/insights/insight/components/standalone-backend-insight/StandaloneBackendInsight.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/insight/components/standalone-backend-insight/StandaloneBackendInsight.tsx
@@ -30,6 +30,7 @@ import {
 } from '../../../../../components/insights-view-grid/components/backend-insight/components'
 import { useVisibility } from '../../../../../components/insights-view-grid/hooks/use-insight-data'
 import {
+    BackendInsightData,
     ALL_INSIGHTS_DASHBOARD,
     BackendInsight,
     CodeInsightsBackendContext,
@@ -37,7 +38,6 @@ import {
     InsightFilters,
     InsightType,
 } from '../../../../../core'
-import { BackendInsightData } from '../../../../../core/backend/code-insights-backend-types'
 import { GET_INSIGHT_VIEW_GQL } from '../../../../../core/backend/gql-backend'
 import { createBackendInsightData } from '../../../../../core/backend/gql-backend/methods/get-backend-insight-data/deserializators'
 import { insightPollingInterval } from '../../../../../core/backend/gql-backend/utils/insight-polling'

--- a/client/web/src/insights/utils/use-series-toggle.ts
+++ b/client/web/src/insights/utils/use-series-toggle.ts
@@ -23,20 +23,32 @@ export const useSeriesToggle = (): UseSeriesToggleReturn => {
     const [selectedSeriesIds, setSelectedSeriesIds] = useState<string[]>([])
     const [hoveredId, setHoveredId] = useState<string | undefined>()
 
-    const selectSeries = (seriesId: string): void => setSelectedSeriesIds([...selectedSeriesIds, seriesId])
-    const deselectSeries = (seriesId: string): void =>
-        setSelectedSeriesIds(selectedSeriesIds.filter(id => id !== seriesId))
-    const toggle = (seriesId: string, availableSeriesIds: string[]): void => {
+    const selectSeries = (seriesId: string, availableSeriesIds: string[]): void => {
+        const nextSelectedSeriesIds = [...selectedSeriesIds, seriesId]
+
         // Reset the selected series if the user is about to select all of them
-        if (selectedSeriesIds.length === availableSeriesIds.length - 1) {
+        if (nextSelectedSeriesIds.length === availableSeriesIds.length) {
             return setSelectedSeriesIds([])
         }
-        return selectedSeriesIds.includes(seriesId) ? deselectSeries(seriesId) : selectSeries(seriesId)
+
+        setSelectedSeriesIds(nextSelectedSeriesIds)
     }
+
+    const deselectSeries = (seriesId: string): void =>
+        setSelectedSeriesIds(selectedSeriesIds.filter(id => id !== seriesId))
+
+    const toggle = (seriesId: string, availableSeriesIds: string[]): void => {
+        if (selectedSeriesIds.includes(seriesId)) {
+            return deselectSeries(seriesId)
+        }
+
+        selectSeries(seriesId, availableSeriesIds)
+    }
+
     const isSelected = (seriesId: string): boolean => {
         // Return true for all series if no series are selected
         // This is because we only want to hide series if something is
-        // specifically selected. Otherwise they should all be "highlighted"
+        // specifically selected. Otherwise, they should all be "highlighted"
         if (selectedSeriesIds.length === 0) {
             return true
         }


### PR DESCRIPTION
Based on https://github.com/sourcegraph/sourcegraph/pull/37224
Closes https://github.com/sourcegraph/sourcegraph/issues/36462
Closes https://github.com/sourcegraph/sourcegraph/issues/36325

## Test plan

- Open storybook
- Go to Smart View Grid
- Find any chart with multiple series
- Hover over legend item should dim all but that legend item
- Hover over series should dim all other series

More cases from @unclejustin 

Given three series A, B & C.

Scenario 1: No series selected, no series hovered

A, B & C: Rendered full color.

Scenario 2: No series selected, series A hovered

A: Rendered full color.
B & C: Rendered dimmed.

Scenario 3: Series A selected, no series hovered

A: Rendered full color.
B & C: Hidden.

Scenario 4: Series A selected, Series A hovered

A: Rendered full color.
B & C: Hidden.

Scenario 5: Series A selected, Series B hovered

A: Rendered full color.
B: Rendered dimmed.
C: Hidden.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vk-insights-fix-series-hover.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-jhtlxvvemi.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
