### PR TITLE
Sample sentry errors on frontend

### DIFF
--- a/cmd/frontend/internal/cli/serve_cmd.go
+++ b/cmd/frontend/internal/cli/serve_cmd.go
@@ -22,6 +22,7 @@ import (
 
 	sglog "github.com/sourcegraph/log"
 
+	sentrylib "github.com/getsentry/sentry-go"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/enterprise"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
@@ -131,7 +132,7 @@ func Main(enterpriseSetupHook func(db database.DB, c conftypes.UnifiedWatchable)
 		Name:       env.MyName,
 		Version:    version.Version(),
 		InstanceID: hostname.Get(),
-	}, sglog.NewSentrySink())
+	}, sglog.NewSentrySinkWithOptions(sentrylib.ClientOptions{SampleRate: 0.2}))
 	defer liblog.Sync()
 
 	logger := sglog.Scoped("server", "the frontend server program")

--- a/cmd/frontend/internal/cli/serve_cmd.go
+++ b/cmd/frontend/internal/cli/serve_cmd.go
@@ -132,7 +132,7 @@ func Main(enterpriseSetupHook func(db database.DB, c conftypes.UnifiedWatchable)
 		Name:       env.MyName,
 		Version:    version.Version(),
 		InstanceID: hostname.Get(),
-	}, sglog.NewSentrySinkWithOptions(sentrylib.ClientOptions{SampleRate: 0.2}))
+	}, sglog.NewSentrySinkWithOptions(sentrylib.ClientOptions{SampleRate: 0.2})) // Experimental: DevX is observing how sampling affects the errors signal
 	defer liblog.Sync()
 
 	logger := sglog.Scoped("server", "the frontend server program")


### PR DESCRIPTION
There are no reasons to have hundreds of occurrences of the same error being reported. By sampling them, we could avoid spending our quota too quickly while retaining the same signal. 

We probably would want this to be configurable, but before writing all that plumbing, I though we'd want to see how it affects the reports first.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Should pass CI, and the change itself is merely a parameter on the sentry client. 