### PR TITLE
Fixing LastSyncedIcon and Tooltip Positioning on Search Result Page

### DIFF
--- a/client/search-ui/src/components/CommitSearchResultMatch.tsx
+++ b/client/search-ui/src/components/CommitSearchResultMatch.tsx
@@ -121,9 +121,12 @@ export const CommitSearchResultMatch: React.FunctionComponent<CommitSearchResult
             offset={visibilitySensorOffset}
         >
             <div className={styles.commitSearchResultMatch}>
-                {item.repoLastFetched && (
-                    <LastSyncedIcon className={styles.lastSyncedIcon} lastSyncedTime={item.repoLastFetched} />
+                <div className="d-flex align-items-end flex-column p-2">
+                    {item.repoLastFetched && (
+                    <LastSyncedIcon lastSyncedTime={item.repoLastFetched} />
                 )}
+                </div>
+
                 {syntaxHighlighting !== undefined ? (
                     <Link
                         key={item.url}

--- a/client/search-ui/src/components/CommitSearchResultMatch.tsx
+++ b/client/search-ui/src/components/CommitSearchResultMatch.tsx
@@ -122,9 +122,7 @@ export const CommitSearchResultMatch: React.FunctionComponent<CommitSearchResult
         >
             <div className={styles.commitSearchResultMatch}>
                 <div className="d-flex align-items-end flex-column p-2">
-                    {item.repoLastFetched && (
-                    <LastSyncedIcon lastSyncedTime={item.repoLastFetched} />
-                )}
+                    {item.repoLastFetched && <LastSyncedIcon lastSyncedTime={item.repoLastFetched} />}
                 </div>
 
                 {syntaxHighlighting !== undefined ? (

--- a/client/search-ui/src/components/FileMatchChildren.tsx
+++ b/client/search-ui/src/components/FileMatchChildren.tsx
@@ -269,7 +269,10 @@ export const FileMatchChildren: React.FunctionComponent<React.PropsWithChildren<
 
     return (
         <div className={styles.fileMatchChildren} data-testid="file-match-children">
-            {result.repoLastFetched && <LastSyncedIcon lastSyncedTime={result.repoLastFetched} />}
+            <div className='d-flex align-items-end flex-column p-2'>
+               {result.repoLastFetched && <LastSyncedIcon lastSyncedTime={result.repoLastFetched}/>}
+            </div>
+
             {/* Path */}
             {result.type === 'path' && (
                 <div className={styles.item} data-testid="file-match-children-item">

--- a/client/search-ui/src/components/FileMatchChildren.tsx
+++ b/client/search-ui/src/components/FileMatchChildren.tsx
@@ -269,8 +269,8 @@ export const FileMatchChildren: React.FunctionComponent<React.PropsWithChildren<
 
     return (
         <div className={styles.fileMatchChildren} data-testid="file-match-children">
-            <div className='d-flex align-items-end flex-column p-2'>
-               {result.repoLastFetched && <LastSyncedIcon lastSyncedTime={result.repoLastFetched}/>}
+            <div className="d-flex align-items-end flex-column p-2">
+                {result.repoLastFetched && <LastSyncedIcon lastSyncedTime={result.repoLastFetched} />}
             </div>
 
             {/* Path */}

--- a/client/search-ui/src/components/LastSyncedIcon.tsx
+++ b/client/search-ui/src/components/LastSyncedIcon.tsx
@@ -6,8 +6,6 @@ import WeatherCloudyClockIcon from 'mdi-react/WeatherCloudyClockIcon'
 
 import { Icon, Tooltip } from '@sourcegraph/wildcard'
 
-import styles from './LastSyncedIcon.module.scss'
-
 interface Props {
     lastSyncedTime: string
     className?: string
@@ -20,7 +18,7 @@ export const LastSyncedIcon: React.FunctionComponent<React.PropsWithChildren<Pro
         <Tooltip content={`Last synced: ${formattedTime}`}>
             <Icon
                 tabIndex={0}
-                className={classNames(props.className, styles.lastSyncedIcon, 'text-muted')}
+                className={classNames(props.className, 'text-muted')}
                 as={WeatherCloudyClockIcon}
                 aria-label={`Last synced: ${formattedTime}`}
             />

--- a/client/search-ui/src/components/RepoSearchResult.tsx
+++ b/client/search-ui/src/components/RepoSearchResult.tsx
@@ -51,7 +51,6 @@ export const RepoSearchResult: React.FunctionComponent<RepoSearchResultProps> = 
         <div data-testid="search-repo-result">
             <div className={classNames(styles.searchResultMatch, 'p-2 flex-column')}>
                 <div className="d-flex align-items-center flex-row w-100">
-                    {/* <div className={classNames(styles.matchType, 'd-flex flex-row justify-content-between')}> */}
                     <div className="w-100 d-flex flex-row justify-content-between">
                         <small>Repository match</small>
                         {result.repoLastFetched && <LastSyncedIcon lastSyncedTime={result.repoLastFetched} />}

--- a/client/search-ui/src/components/RepoSearchResult.tsx
+++ b/client/search-ui/src/components/RepoSearchResult.tsx
@@ -50,10 +50,9 @@ export const RepoSearchResult: React.FunctionComponent<RepoSearchResultProps> = 
     const renderBody = (): JSX.Element => (
         <div data-testid="search-repo-result">
             <div className={classNames(styles.searchResultMatch, 'p-2 flex-column')}>
-
                 <div className="d-flex align-items-center flex-row w-100">
                     {/* <div className={classNames(styles.matchType, 'd-flex flex-row justify-content-between')}> */}
-                    <div className='w-100 d-flex flex-row justify-content-between'>
+                    <div className="w-100 d-flex flex-row justify-content-between">
                         <small>Repository match</small>
                         {result.repoLastFetched && <LastSyncedIcon lastSyncedTime={result.repoLastFetched} />}
                     </div>

--- a/client/search-ui/src/components/RepoSearchResult.tsx
+++ b/client/search-ui/src/components/RepoSearchResult.tsx
@@ -50,10 +50,12 @@ export const RepoSearchResult: React.FunctionComponent<RepoSearchResultProps> = 
     const renderBody = (): JSX.Element => (
         <div data-testid="search-repo-result">
             <div className={classNames(styles.searchResultMatch, 'p-2 flex-column')}>
-                {result.repoLastFetched && <LastSyncedIcon lastSyncedTime={result.repoLastFetched} />}
-                <div className="d-flex align-items-center flex-row">
-                    <div className={styles.matchType}>
+
+                <div className="d-flex align-items-center flex-row w-100">
+                    {/* <div className={classNames(styles.matchType, 'd-flex flex-row justify-content-between')}> */}
+                    <div className='w-100 d-flex flex-row justify-content-between'>
                         <small>Repository match</small>
+                        {result.repoLastFetched && <LastSyncedIcon lastSyncedTime={result.repoLastFetched} />}
                     </div>
                     {result.fork && (
                         <>

--- a/client/vscode/src/webview/search-panel/alias/RepoSearchResult.tsx
+++ b/client/vscode/src/webview/search-panel/alias/RepoSearchResult.tsx
@@ -44,10 +44,10 @@ export const RepoSearchResult: React.FunctionComponent<RepoSearchResultProps> = 
     const renderBody = (): JSX.Element => (
         <div data-testid="search-repo-result">
             <div className={classNames(styles.searchResultMatch, 'p-2 flex-column')}>
-                {result.repoLastFetched && <LastSyncedIcon lastSyncedTime={result.repoLastFetched} />}
-                <div className="d-flex align-items-center flex-row">
-                    <div className={styles.matchType}>
+                <div className="d-flex align-items-center flex-row w-100">
+                    <div className="w-100 d-flex flex-row justify-content-between">
                         <small>Repository match</small>
+                        {result.repoLastFetched && <LastSyncedIcon lastSyncedTime={result.repoLastFetched} />}
                     </div>
                     {result.fork && (
                         <>

--- a/client/web/src/repo/commits/RepositoryCommitsPage.tsx
+++ b/client/web/src/repo/commits/RepositoryCommitsPage.tsx
@@ -8,6 +8,9 @@ import { createAggregateError } from '@sourcegraph/common'
 import { gql } from '@sourcegraph/http-client'
 import * as GQL from '@sourcegraph/shared/src/schema'
 import { RevisionSpec, ResolvedRevisionSpec } from '@sourcegraph/shared/src/util/url'
+import {
+    H2
+} from '@sourcegraph/wildcard'
 
 import { queryGraphQL } from '../../backend/graphql'
 import { BreadcrumbSetters } from '../../components/Breadcrumbs'
@@ -141,6 +144,7 @@ export const RepositoryCommitsPage: React.FunctionComponent<React.PropsWithChild
     return (
         <div className={styles.repositoryCommitsPage} data-testid="commits-page">
             <PageTitle title="Commits" />
+            <H2>Commits</H2>
             <FilteredConnection<GitCommitFields, Pick<GitCommitNodeProps, 'className' | 'compact' | 'wrapperElement'>>
                 className={styles.content}
                 listClassName="list-group list-group-flush"

--- a/client/web/src/repo/commits/RepositoryCommitsPage.tsx
+++ b/client/web/src/repo/commits/RepositoryCommitsPage.tsx
@@ -8,9 +8,6 @@ import { createAggregateError } from '@sourcegraph/common'
 import { gql } from '@sourcegraph/http-client'
 import * as GQL from '@sourcegraph/shared/src/schema'
 import { RevisionSpec, ResolvedRevisionSpec } from '@sourcegraph/shared/src/util/url'
-import {
-    H2
-} from '@sourcegraph/wildcard'
 
 import { queryGraphQL } from '../../backend/graphql'
 import { BreadcrumbSetters } from '../../components/Breadcrumbs'
@@ -144,7 +141,6 @@ export const RepositoryCommitsPage: React.FunctionComponent<React.PropsWithChild
     return (
         <div className={styles.repositoryCommitsPage} data-testid="commits-page">
             <PageTitle title="Commits" />
-            <H2>Commits</H2>
             <FilteredConnection<GitCommitFields, Pick<GitCommitNodeProps, 'className' | 'compact' | 'wrapperElement'>>
                 className={styles.content}
                 listClassName="list-group list-group-flush"


### PR DESCRIPTION
I changed the positioning of the LastSyncedIcon by eliminating the absolute positioning. The absolute positioning was what was causing the tooltip to appear in the top left of the div. So, I positioned the icon where it was being called in RepoSearchResults.tsx and FileMatchChildren.tsx. There are two other files that call and utilize LastSyncedIcon so, those files may need to be modified as well.

## Test plan
Changes were made to the LastSyncedIcon on the search result page
- Enter a search query at the [Sourcegraph](https://sourcegraph.com/search) website
- This redirects you to the search result page
- The LastSyncedIcon should be on the top right of each search result container
- Hover over the icon to view the tooltip
- Test is successful if the icon is actually in the top right of each search result container and the tooltip appears directly next to the icon

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-lm-tooltippositioningfix.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-cmhzlzvjek.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

