### PR TITLE
Accessibility: Improve tips for crossing header styles

### DIFF
--- a/client/wildcard/src/components/Typography/Typography.story.tsx
+++ b/client/wildcard/src/components/Typography/Typography.story.tsx
@@ -4,14 +4,19 @@ import { DecoratorFn, Meta, Story } from '@storybook/react'
 import { BrandedStory } from '@sourcegraph/branded/src/components/BrandedStory'
 import webStyles from '@sourcegraph/web/src/SourcegraphWebApp.scss'
 
+import { Link } from '../Link'
+
 import { TYPOGRAPHY_ALIGNMENTS, TYPOGRAPHY_MODES } from './constants'
+import { Heading } from './Heading'
 
 import { Code, Label, H1, H2, H3, H4, H5, H6, Text } from '.'
 
-const decorator: DecoratorFn = story => <BrandedStory styles={webStyles}>{() => <div>{story()}</div>}</BrandedStory>
+const decorator: DecoratorFn = story => (
+    <BrandedStory styles={webStyles}>{() => <div className="container mt-3">{story()}</div>}</BrandedStory>
+)
 
 const config: Meta = {
-    title: 'wildcard/Typography/All',
+    title: 'wildcard/Typography',
 
     decorators: [decorator],
 
@@ -316,5 +321,48 @@ export const Simple: Story = () => (
                 </tr>
             </tbody>
         </table>
+    </>
+)
+
+export const CrossingStyles: Story = () => (
+    <>
+        <H1>Crossing Header Styles</H1>
+        <Text>
+            Sometimes we need, for example, an <Code>{'<h2>'}</Code> with the styles of an <Code>{'<h3>'}</Code> to
+            create a page structure that is both{' '}
+            <Link
+                target="_blank"
+                rel="noopener noreferrer"
+                to="https://docs.sourcegraph.com/dev/background-information/web/accessibility/detailed-checklist#headings"
+            >
+                accessible
+            </Link>{' '}
+            and visually-consistent with designs.
+        </Text>
+        <Text>
+            It is possible both to <strong>"downscale"</strong> crossing header styles (e.g. <Code>{'<h2>'}</Code> with
+            the styles of an <Code>{'<h3>'}</Code>) and <strong>"upscale"</strong> them (e.g. <Code>{'<h3>'}</Code> with
+            the styles of an <Code>{'<h2>'}</Code>), but due to CSS priority rules, the two directions require using
+            different APIs.
+        </Text>
+
+        <H2 className="mt-4 mb-3">Examples of downscaling</H2>
+
+        <H2>I'm a normal H2.</H2>
+        <H3 as={H2}>I'm an H2 with the style of an H3.</H3>
+        <H4 as={H2}>I'm an H2 with the style of an H4.</H4>
+        <H5 as={H2}>I'm an H2 with the style of an H5.</H5>
+
+        <H2 className="mt-5 mb-3">Examples of upscaling</H2>
+        <H4>I'm a normal H4.</H4>
+        <Heading as="h4" styleAs="h3">
+            I'm an H4 with the style of an H3.
+        </Heading>
+        <Heading as="h4" styleAs="h2">
+            I'm an H4 with the style of an H2.
+        </Heading>
+        <Heading as="h4" styleAs="h1">
+            I'm an H4 with the style of an H1.
+        </Heading>
     </>
 )

--- a/doc/dev/background-information/web/accessibility/detailed-checklist.md
+++ b/doc/dev/background-information/web/accessibility/detailed-checklist.md
@@ -31,8 +31,9 @@
 
 **Tips:**
 
-- If we have to use a `<h2>` but need the styles of a `<h3>`, we can easily select the correct styles using the [Wildcard `<Heading />` components](https://storybook.sgdev.org/?path=/story/wildcard-typography-all--simple).
-  - Example: `<H3 as={H2}>Hello</H3>`
+- If we have to use an `<h2>` but need the styles of an `<h3>`, we can easily cross styles with the [Wildcard `<Heading />` components](https://storybook.sgdev.org/?path=/story/wildcard-typography--crossing-styles). For example:
+  - `<H3 as={H2}>Hello</H3>` will _downscale_ a style, rendering an `<h2>` with the styles of an `<h3>`
+  - `<Heading as="h2" styleAs="h1">Hello</Heading>` will _upscale_ a style, rendering an `<h2>` with the styles of an `<h1>`
 - If you are still unsure about something, consult the [W3 guide on headings](https://www.w3.org/WAI/tutorials/page-structure/headings/).
 </details>
 


### PR DESCRIPTION
I ran into a situation with the same root problem as https://github.com/sourcegraph/sourcegraph/pull/35776, where I needed to "upscale" a header so that an `<h3>` has the styles of an `<h2>`, but I didn't realize `<H2 as={H3}>` doesn't work that direction and thought I had hit a bug. In this PR, I tried to clarify in the docs that we currently need to use a different API for upscaling vs. downscaling and added a Storybook story to demonstrate crossing styles both directions. 🙂

## Test plan

Just Storybook and docs changes.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-kr-header-styles.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-rpbirtbokq.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
