### PR TITLE
insights: default to retrying queries that error

### DIFF
--- a/enterprise/internal/insights/background/queryrunner/errors.go
+++ b/enterprise/internal/insights/background/queryrunner/errors.go
@@ -32,7 +32,7 @@ func stringifyStreamingError(messages []string, streamingType types.GenerationMe
 
 func classifiedError(messages []string, streamingType types.GenerationMethod) error {
 	for _, m := range messages {
-		if strings.Contains(m, "invalid query") || strings.Contains(m, "dial tcp") {
+		if strings.Contains(m, "invalid query") {
 			return TerminalStreamingError{Type: streamingType, Messages: messages}
 		}
 	}

--- a/enterprise/internal/insights/background/queryrunner/errors.go
+++ b/enterprise/internal/insights/background/queryrunner/errors.go
@@ -2,20 +2,39 @@ package queryrunner
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/types"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
-type StreamingError struct {
+type TerminalStreamingError struct {
 	Type     types.GenerationMethod
 	Messages []string
 }
 
-func (e StreamingError) Error() string {
-	if e.Type == types.SearchCompute {
-		return fmt.Sprintf("compute streaming search: errors: %v", e.Messages)
-	}
-	return fmt.Sprintf("streaming search: errors: %v", e.Messages)
+func (e TerminalStreamingError) Error() string {
+	return stringifyStreamingError(e.Messages, e.Type, true)
 }
 
-func (e StreamingError) NonRetryable() bool { return true }
+func (e TerminalStreamingError) NonRetryable() bool { return true }
+
+func stringifyStreamingError(messages []string, streamingType types.GenerationMethod, terminal bool) string {
+	retryable := ""
+	if terminal {
+		retryable = " terminal"
+	}
+	if streamingType == types.SearchCompute {
+		return fmt.Sprintf("compute streaming search:%s errors: %v", retryable, messages)
+	}
+	return fmt.Sprintf("streaming search:%s errors: %v", retryable, messages)
+}
+
+func classifiedError(messages []string, streamingType types.GenerationMethod) error {
+	for _, m := range messages {
+		if strings.Contains(m, "invalid query") || strings.Contains(m, "dial tcp") {
+			return TerminalStreamingError{Type: streamingType, Messages: messages}
+		}
+	}
+	return errors.Errorf(stringifyStreamingError(messages, streamingType, false))
+}

--- a/enterprise/internal/insights/background/queryrunner/work_handler.go
+++ b/enterprise/internal/insights/background/queryrunner/work_handler.go
@@ -182,7 +182,7 @@ func (r *workHandler) generateComputeRecordingsStream(ctx context.Context, job *
 		return nil, err
 	}
 	if len(streamResults.Errors) > 0 {
-		return nil, StreamingError{Type: types.SearchCompute, Messages: streamResults.Errors}
+		return nil, classifiedError(streamResults.Errors, types.SearchCompute)
 	}
 	if len(streamResults.Alerts) > 0 {
 		return nil, errors.Errorf("compute streaming search: alerts: %v", streamResults.Alerts)
@@ -306,7 +306,7 @@ func (r *workHandler) generateSearchRecordingsStream(ctx context.Context, job *J
 		log15.Error("insights query issue", "reasons", tr.SkippedReasons, "query", job.SearchQuery)
 	}
 	if len(tr.Errors) > 0 {
-		return nil, StreamingError{Messages: tr.Errors}
+		return nil, classifiedError(tr.Errors, types.Search)
 	}
 	if len(tr.Alerts) > 0 {
 		return nil, errors.Errorf("streaming search: alerts: %v", tr.Alerts)

--- a/enterprise/internal/insights/background/queryrunner/work_handler_test.go
+++ b/enterprise/internal/insights/background/queryrunner/work_handler_test.go
@@ -1190,7 +1190,7 @@ func TestGenerateSearchRecordingsStream(t *testing.T) {
 		mocked := func(context.Context, string) (*streaming.TabulationResult, error) {
 			return &streaming.TabulationResult{
 				StreamDecoderEvents: streaming.StreamDecoderEvents{
-					Errors: []string{"retryable event", "dial tcp"},
+					Errors: []string{"retryable event", "invalid query"},
 				},
 			}, nil
 		}

--- a/enterprise/internal/insights/background/queryrunner/work_handler_test.go
+++ b/enterprise/internal/insights/background/queryrunner/work_handler_test.go
@@ -694,7 +694,7 @@ func TestGenerateComputeRecordingsStream(t *testing.T) {
 		}
 	})
 
-	t.Run("compute stream job returns error event", func(t *testing.T) {
+	t.Run("compute stream job returns retryable error event", func(t *testing.T) {
 		date := time.Date(2021, 12, 1, 0, 0, 0, 0, time.UTC)
 		job := Job{
 			SeriesID:        "testseries1",
@@ -731,9 +731,51 @@ func TestGenerateComputeRecordingsStream(t *testing.T) {
 		if err == nil {
 			t.Error("Expected error but received nil")
 		}
-		var streamingErr StreamingError
-		if !errors.As(err, &streamingErr) {
-			t.Errorf("Expected StreamingError, got %v", err)
+		if strings.Contains(err.Error(), "terminal") {
+			t.Errorf("Expected retryable error, got %v", err)
+		}
+	})
+
+	t.Run("compute stream job returns terminal error event", func(t *testing.T) {
+		date := time.Date(2021, 12, 1, 0, 0, 0, 0, time.UTC)
+		job := Job{
+			SeriesID:        "testseries1",
+			SearchQuery:     "searchit",
+			RecordTime:      &date,
+			PersistMode:     "record",
+			DependentFrames: nil,
+			ID:              1,
+			State:           "queued",
+		}
+
+		mocked := func(context.Context, string) (*streaming.ComputeTabulationResult, error) {
+			return &streaming.ComputeTabulationResult{
+				StreamDecoderEvents: streaming.StreamDecoderEvents{
+					Errors: []string{"not terminal", "invalid query"},
+				},
+			}, nil
+		}
+
+		handler := workHandler{
+			baseWorkerStore:     nil,
+			insightsStore:       nil,
+			metadadataStore:     nil,
+			limiter:             nil,
+			mu:                  sync.RWMutex{},
+			seriesCache:         nil,
+			computeSearchStream: mocked,
+		}
+
+		recordings, err := handler.generateComputeRecordingsStream(context.Background(), &job, date)
+		if len(recordings) != 0 {
+			t.Error("No records should be returned as we errored on compute stream")
+		}
+		if err == nil {
+			t.Error("Expected error but received nil")
+		}
+		var terminalError TerminalStreamingError
+		if !errors.As(err, &terminalError) {
+			t.Errorf("Expected terminal error, got %v", err)
 		}
 	})
 
@@ -1091,7 +1133,7 @@ func TestGenerateSearchRecordingsStream(t *testing.T) {
 		}
 	})
 
-	t.Run("search stream job returns error event", func(t *testing.T) {
+	t.Run("search stream job returns retryable error event", func(t *testing.T) {
 		date := time.Date(2021, 12, 1, 0, 0, 0, 0, time.UTC)
 		job := Job{
 			SeriesID:        "testseries1",
@@ -1125,9 +1167,54 @@ func TestGenerateSearchRecordingsStream(t *testing.T) {
 		if len(recordings) != 0 {
 			t.Error("No records should be returned as we errored on stream")
 		}
-		var streamingErr StreamingError
-		if !errors.As(err, &streamingErr) {
-			t.Errorf("Expected StreamingError, got %v", err)
+		if err == nil {
+			t.Error("Expected error but received nil")
+		}
+		if strings.Contains(err.Error(), "terminal") {
+			t.Errorf("Expected retryable error, got %v", err)
+		}
+	})
+
+	t.Run("search stream job returns retryable error event", func(t *testing.T) {
+		date := time.Date(2021, 12, 1, 0, 0, 0, 0, time.UTC)
+		job := Job{
+			SeriesID:        "testseries1",
+			SearchQuery:     "searchit",
+			RecordTime:      &date,
+			PersistMode:     "record",
+			DependentFrames: nil,
+			ID:              1,
+			State:           "queued",
+		}
+
+		mocked := func(context.Context, string) (*streaming.TabulationResult, error) {
+			return &streaming.TabulationResult{
+				StreamDecoderEvents: streaming.StreamDecoderEvents{
+					Errors: []string{"retryable event", "dial tcp"},
+				},
+			}, nil
+		}
+
+		handler := workHandler{
+			baseWorkerStore: nil,
+			insightsStore:   nil,
+			metadadataStore: nil,
+			limiter:         nil,
+			mu:              sync.RWMutex{},
+			seriesCache:     nil,
+			searchStream:    mocked,
+		}
+
+		recordings, err := handler.generateSearchRecordingsStream(context.Background(), &job, nil, date)
+		if len(recordings) != 0 {
+			t.Error("No records should be returned as we errored on stream")
+		}
+		if err == nil {
+			t.Error("Expected error but received nil")
+		}
+		var terminalError TerminalStreamingError
+		if !errors.As(err, &terminalError) {
+			t.Errorf("Expected terminal error, got %v", err)
 		}
 	})
 


### PR DESCRIPTION
closes #37284 

## Test plan
Modified and added unit tests.

Artificially added retryable and non retryable error events in the decoder and observed insights react appropriately:
* observed error message for an insight on a list of repos
<img width="423" alt="Screenshot 2022-06-15 at 15 56 55" src="https://user-images.githubusercontent.com/29406849/173917608-c0d5a0c7-0272-4674-94cb-56cfb86abfa3.png">

* observed error message for a query that will be marked as errored (retryable)
<img width="878" alt="Screenshot 2022-06-15 at 15 58 19" src="https://user-images.githubusercontent.com/29406849/173917627-a8f21673-d7e2-4a61-9a84-dbd2b7416772.png">

* observed error message for a query that will be marked as failed (non-retryable)
<img width="1127" alt="Screenshot 2022-06-15 at 16 02 33" src="https://user-images.githubusercontent.com/29406849/173917648-10488188-1839-45b6-8db8-921c6a79f874.png">

