### PR TITLE
insights: Avoid a panic for the default sorting option when series have 0 points

### DIFF
--- a/enterprise/internal/insights/resolvers/insight_view_resolvers.go
+++ b/enterprise/internal/insights/resolvers/insight_view_resolvers.go
@@ -1203,6 +1203,9 @@ func sortSeriesResolvers(ctx context.Context, seriesOptions types.SeriesDisplayO
 	}
 
 	getMostRecentValue := func(points []graphqlbackend.InsightsDataPointResolver) float64 {
+		if len(points) == 0 {
+			return 0
+		}
 		return points[len(points)-1].Value()
 	}
 


### PR DESCRIPTION
## Description

Fix for a panic we're seeing when there are zero points in a series.

## Test plan

I was able to repro this bug locally by creating non-capture group insights with multiple series. After this change, there is no longer a panic while they backfill.