### PR TITLE
executors: Don't swallow error when writing to buffer

### DIFF
--- a/enterprise/cmd/executor/internal/command/run.go
+++ b/enterprise/cmd/executor/internal/command/run.go
@@ -156,7 +156,10 @@ func readProcessPipes(logWriter io.WriteCloser, stdout, stderr io.Reader) *errgr
 		// TODO: Tweak this value as needed.
 		scanner.Buffer(buf, 100*1024*1024)
 		for scanner.Scan() {
-			fmt.Fprintf(logWriter, "%s: %s\n", prefix, scanner.Text())
+			_, err := fmt.Fprintf(logWriter, "%s: %s\n", prefix, scanner.Text())
+			if err != nil {
+				return err
+			}
 		}
 		return scanner.Err()
 	}


### PR DESCRIPTION
This could swallow a buffer size exceeded error, and I was investigating such an issue (at least something that appeared to be that).

## Test plan

Verified it still works as before.