### PR TITLE
batches: refactor collapsibles

### DIFF
--- a/client/web/src/enterprise/batches/batch-spec/edit/RunBatchSpecButton.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/edit/RunBatchSpecButton.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react'
 
-import VisuallyHidden from '@reach/visually-hidden'
+import { VisuallyHidden } from '@reach/visually-hidden'
 import ChevronDownIcon from 'mdi-react/ChevronDownIcon'
 import InfoCircleOutlineIcon from 'mdi-react/InfoCircleOutlineIcon'
 import { animated } from 'react-spring'

--- a/client/web/src/enterprise/batches/batch-spec/execute/TimelineModal.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/execute/TimelineModal.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo } from 'react'
 
-import VisuallyHidden from '@reach/visually-hidden'
+import { VisuallyHidden } from '@reach/visually-hidden'
 import classNames from 'classnames'
 import AlertCircleIcon from 'mdi-react/AlertCircleIcon'
 import CheckIcon from 'mdi-react/CheckIcon'

--- a/client/web/src/enterprise/batches/batch-spec/execute/workspaces/ExecutionWorkspaces.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/execute/workspaces/ExecutionWorkspaces.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useRef } from 'react'
 
-import VisuallyHidden from '@reach/visually-hidden'
+import { VisuallyHidden } from '@reach/visually-hidden'
 import CloseIcon from 'mdi-react/CloseIcon'
 import { useHistory } from 'react-router'
 

--- a/client/web/src/enterprise/batches/batch-spec/execute/workspaces/StepStateIcon.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/execute/workspaces/StepStateIcon.tsx
@@ -32,14 +32,14 @@ const getProps = (
     if (step.exitCode === 0) {
         return ['text-success', CheckBoldIcon, 'This step finished running successfully.']
     }
-    return ['text-danger', AlertCircleIcon, `This step failed with exit code ${String(step.exitCode)}`]
+    return ['text-danger', AlertCircleIcon, `This step failed with exit code ${String(step.exitCode)}.`]
 }
 
 export const StepStateIcon: React.FunctionComponent<React.PropsWithChildren<StepStateIconProps>> = ({ step }) => {
     const [classNameVariant, IconElement, label] = getProps(step)
 
     return (
-        <div className="flex-shrink-0">
+        <div className="d-flex flex-shrink-0">
             <Tooltip content={label} placement="bottom">
                 <Icon className={classNameVariant} aria-label={label} as={IconElement} />
             </Tooltip>

--- a/client/web/src/enterprise/batches/batch-spec/execute/workspaces/StepStateIcon.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/execute/workspaces/StepStateIcon.tsx
@@ -1,0 +1,48 @@
+import React from 'react'
+
+import AlertCircleIcon from 'mdi-react/AlertCircleIcon'
+import CheckBoldIcon from 'mdi-react/CheckBoldIcon'
+import ContentSaveIcon from 'mdi-react/ContentSaveIcon'
+import LinkVariantRemoveIcon from 'mdi-react/LinkVariantRemoveIcon'
+import TimerSandIcon from 'mdi-react/TimerSandIcon'
+
+import { Icon, LoadingSpinner, Tooltip } from '@sourcegraph/wildcard'
+
+import { BatchSpecWorkspaceStepFields } from '../../../../../graphql-operations'
+
+interface StepStateIconProps {
+    step: BatchSpecWorkspaceStepFields
+}
+
+const getProps = (
+    step: BatchSpecWorkspaceStepFields
+): [classNameVariant: string, icon: React.ElementType, label: string] => {
+    if (step.cachedResultFound) {
+        return ['text-success', ContentSaveIcon, 'A cached result for this step has been found.']
+    }
+    if (step.skipped) {
+        return ['text-muted', LinkVariantRemoveIcon, 'This step has been skipped.']
+    }
+    if (!step.startedAt) {
+        return ['text-muted', TimerSandIcon, 'This step has not started yet.']
+    }
+    if (!step.finishedAt) {
+        return ['text-muted', LoadingSpinner, 'This step is currently running.']
+    }
+    if (step.exitCode === 0) {
+        return ['text-success', CheckBoldIcon, 'This step finished running successfully.']
+    }
+    return ['text-danger', AlertCircleIcon, `This step failed with exit code ${String(step.exitCode)}`]
+}
+
+export const StepStateIcon: React.FunctionComponent<React.PropsWithChildren<StepStateIconProps>> = ({ step }) => {
+    const [classNameVariant, IconElement, label] = getProps(step)
+
+    return (
+        <div className="flex-shrink-0">
+            <Tooltip content={label} placement="bottom">
+                <Icon className={classNameVariant} aria-label={label} as={IconElement} />
+            </Tooltip>
+        </div>
+    )
+}

--- a/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspaceDetails.module.scss
+++ b/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspaceDetails.module.scss
@@ -30,15 +30,7 @@
     background-color: var(--body-bg);
 }
 
-.collapsible {
-    flex: 1;
-    min-width: 0;
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-}
-
-.step-header {
+.collapse-header {
     display: flex;
     align-items: center;
     flex: 1;
@@ -57,18 +49,19 @@
     margin: 0 0.5rem;
 }
 
-.step-command {
+.step-command,
+.changeset-spec-branch {
     min-width: 0;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
     font-size: 0.75rem;
-    line-height: 0.75rem;
+    line-height: 0.7rem;
 }
 
 .step-time {
     font-size: 0.75rem;
-    line-height: 0.75rem;
+    line-height: 0.7rem;
 }
 
 .step-diff-stat {

--- a/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspaceDetails.module.scss
+++ b/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspaceDetails.module.scss
@@ -56,12 +56,12 @@
     overflow: hidden;
     text-overflow: ellipsis;
     font-size: 0.75rem;
-    line-height: 0.7rem;
+    line-height: 0.75rem;
 }
 
 .step-time {
     font-size: 0.75rem;
-    line-height: 0.7rem;
+    line-height: 0.75rem;
 }
 
 .step-diff-stat {

--- a/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspaceDetails.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspaceDetails.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useMemo, useState } from 'react'
 
-import VisuallyHidden from '@reach/visually-hidden'
+import { VisuallyHidden } from '@reach/visually-hidden'
 import classNames from 'classnames'
 import { cloneDeep } from 'lodash'
 import AlertCircleIcon from 'mdi-react/AlertCircleIcon'

--- a/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspaceDetails.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspaceDetails.tsx
@@ -5,6 +5,8 @@ import classNames from 'classnames'
 import { cloneDeep } from 'lodash'
 import AlertCircleIcon from 'mdi-react/AlertCircleIcon'
 import CheckBoldIcon from 'mdi-react/CheckBoldIcon'
+import ChevronDownIcon from 'mdi-react/ChevronDownIcon'
+import ChevronRightIcon from 'mdi-react/ChevronRightIcon'
 import CloseIcon from 'mdi-react/CloseIcon'
 import ContentSaveIcon from 'mdi-react/ContentSaveIcon'
 import ExternalLinkIcon from 'mdi-react/ExternalLinkIcon'
@@ -40,9 +42,12 @@ import {
     H4,
     Text,
     Alert,
+    CollapsePanel,
+    CollapseHeader,
+    Collapse,
+    Heading,
 } from '@sourcegraph/wildcard'
 
-import { Collapsible } from '../../../../../components/Collapsible'
 import { DiffStat } from '../../../../../components/diff/DiffStat'
 import { FileDiffConnection } from '../../../../../components/diff/FileDiffConnection'
 import { FileDiffNode } from '../../../../../components/diff/FileDiffNode'
@@ -157,7 +162,7 @@ const WorkspaceHeader: React.FunctionComponent<React.PropsWithChildren<Workspace
                 <span className={styles.workspaceDetail}>{workspace.path}</span>
             )}
             {workspace.__typename === 'VisibleBatchSpecWorkspace' && (
-                <span className={styles.workspaceDetail}>
+                <span className={classNames(styles.workspaceDetail, 'text-monospace')}>
                     <Icon aria-hidden={true} as={SourceBranchIcon} /> {workspace.branch.displayName}
                 </span>
             )}
@@ -351,6 +356,10 @@ const ChangesetSpecNode: React.FunctionComponent<React.PropsWithChildren<Changes
 }) => {
     const history = useHistory()
 
+    // TODO: Under what conditions should this be auto-expanded?
+    const [isExpanded, setIsExpanded] = useState(true)
+    const [areChangesExpanded, setAreChangesExpanded] = useState(true)
+
     // TODO: This should not happen. When the workspace is visibile, the changeset spec should be visible as well.
     if (node.__typename === 'HiddenChangesetSpec') {
         return (
@@ -368,53 +377,57 @@ const ChangesetSpecNode: React.FunctionComponent<React.PropsWithChildren<Changes
     }
 
     return (
-        <Collapsible
-            title={
-                <div className="d-flex justify-content-between">
-                    <div>
-                        <H4 className="mb-0 d-inline-block mr-2">
-                            <H3 className={styles.result}>Result</H3>
-                            {node.description.published !== null && (
-                                <Badge className="text-uppercase">
-                                    {publishBadgeLabel(node.description.published)}
-                                </Badge>
-                            )}{' '}
-                        </H4>
-                        <span className="text-muted">
-                            <Icon aria-hidden={true} as={SourceBranchIcon} /> {node.description.headRef}
-                        </span>
-                    </div>
-                    <DiffStat {...node.description.diffStat} expandedCounts={true} />
+        <Collapse isOpen={isExpanded} onOpenChange={setIsExpanded} openByDefault={true}>
+            <CollapseHeader as={Button} className="w-100 p-0 m-0 d-flex align-items-center justify-space-between">
+                <Icon aria-hidden={true} as={isExpanded ? ChevronDownIcon : ChevronRightIcon} className="mr-1" />
+                <div className={styles.collapseHeader}>
+                    <H4 className="mb-0 d-inline-block mr-2">
+                        <H3 className={styles.result}>Result</H3>
+                        {node.description.published !== null && (
+                            <Badge className="text-uppercase">{publishBadgeLabel(node.description.published)}</Badge>
+                        )}{' '}
+                    </H4>
+                    <Icon aria-hidden={true} className="text-muted mr-1 flex-shrink-0" as={SourceBranchIcon} />
+                    <span className={classNames('text-monospace text-muted', styles.changesetSpecBranch)}>
+                        {node.description.headRef}
+                    </span>
                 </div>
-            }
-            titleClassName="flex-grow-1"
-            // TODO: Under what conditions should this be auto-expanded?
-            defaultExpanded={true}
-        >
-            <Card className={classNames('mt-2', styles.resultCard)}>
-                <CardBody>
-                    <H3>Changeset template</H3>
-                    <H4>{node.description.title}</H4>
-                    <Text className="mb-0">{node.description.body}</Text>
-                    <Text>
-                        <strong>Published:</strong> <PublishedValue published={node.description.published} />
-                    </Text>
-                    <Collapsible
-                        title={<H3 className="mb-0">Changes</H3>}
-                        titleClassName="flex-grow-1"
-                        defaultExpanded={true}
-                    >
-                        <ChangesetSpecFileDiffConnection
-                            history={history}
-                            isLightTheme={isLightTheme}
-                            location={history.location}
-                            spec={node.id}
-                            queryChangesetSpecFileDiffs={queryChangesetSpecFileDiffs}
-                        />
-                    </Collapsible>
-                </CardBody>
-            </Card>
-        </Collapsible>
+                <DiffStat {...node.description.diffStat} expandedCounts={true} className="ml-3" />
+            </CollapseHeader>
+            <CollapsePanel>
+                <Card className={classNames('mt-2', styles.resultCard)}>
+                    <CardBody>
+                        <H3>Changeset template</H3>
+                        <H4>{node.description.title}</H4>
+                        <Text className="mb-0">{node.description.body}</Text>
+                        <Text>
+                            <strong>Published:</strong> <PublishedValue published={node.description.published} />
+                        </Text>
+                        <Collapse isOpen={areChangesExpanded} onOpenChange={setAreChangesExpanded} openByDefault={true}>
+                            <CollapseHeader as={Button} className="w-100 p-0 m-0 d-flex align-items-center">
+                                <Icon
+                                    aria-hidden={true}
+                                    as={areChangesExpanded ? ChevronDownIcon : ChevronRightIcon}
+                                    className="mr-1"
+                                />
+                                <Heading className="mb-0" as="h4" styleAs="h3">
+                                    Changes
+                                </Heading>
+                            </CollapseHeader>
+                            <CollapsePanel>
+                                <ChangesetSpecFileDiffConnection
+                                    history={history}
+                                    isLightTheme={isLightTheme}
+                                    location={history.location}
+                                    spec={node.id}
+                                    queryChangesetSpecFileDiffs={queryChangesetSpecFileDiffs}
+                                />
+                            </CollapsePanel>
+                        </Collapse>
+                    </CardBody>
+                </Card>
+            </CollapsePanel>
+        </Collapse>
     )
 }
 
@@ -456,6 +469,8 @@ const WorkspaceStep: React.FunctionComponent<React.PropsWithChildren<WorkspaceSt
     cachedResultFound,
     queryBatchSpecWorkspaceStepFileDiffs,
 }) => {
+    const [isExpanded, setIsExpanded] = useState(false)
+
     const outputLines = useMemo(() => {
         const outputLines = cloneDeep(step.outputLines)
         if (outputLines !== null) {
@@ -478,101 +493,105 @@ const WorkspaceStep: React.FunctionComponent<React.PropsWithChildren<WorkspaceSt
     }, [step.exitCode, step.outputLines])
 
     return (
-        <Collapsible
-            titleClassName={styles.collapsible}
-            title={
-                <>
-                    <div className={classNames(styles.stepHeader, step.skipped && 'text-muted')}>
-                        <StepStateIcon step={step} />
-                        <H3 className={styles.stepNumber}>Step {step.number}</H3>
-                        <span className={classNames('text-monospace text-muted', styles.stepCommand)}>{step.run}</span>
-                    </div>
-                    {step.diffStat && (
-                        <DiffStat className={styles.stepDiffStat} {...step.diffStat} expandedCounts={true} />
-                    )}
-                    {step.startedAt && (
-                        <span className={classNames('text-monospace text-muted', styles.stepTime)}>
-                            <StepTimer startedAt={step.startedAt} finishedAt={step.finishedAt} />
-                        </span>
-                    )}
-                </>
-            }
-        >
-            <Card className={classNames('mt-2', styles.stepCard)}>
-                <CardBody>
-                    {!step.skipped && (
-                        <Tabs size="small" behavior="forceRender">
-                            <TabList>
-                                <Tab key="logs">Logs</Tab>
-                                <Tab key="output-variables">Output variables</Tab>
-                                <Tab key="diff">Diff</Tab>
-                                <Tab key="files-env">Files / Env</Tab>
-                                <Tab key="command-container">Commands / Container</Tab>
-                            </TabList>
-                            <TabPanels>
-                                <TabPanel className="pt-2" key="logs">
-                                    {!step.startedAt && <Text className="text-muted mb-0">Step not started yet</Text>}
-                                    {step.startedAt && outputLines && <LogOutput text={outputLines.join('\n')} />}
-                                </TabPanel>
-                                <TabPanel className="pt-2" key="output-variables">
-                                    {!step.startedAt && <Text className="text-muted mb-0">Step not started yet</Text>}
-                                    {step.outputVariables?.length === 0 && (
-                                        <Text className="text-muted mb-0">No output variables specified</Text>
+        <Collapse isOpen={isExpanded} onOpenChange={setIsExpanded}>
+            <CollapseHeader as={Button} className="w-100 p-0 m-0 d-flex align-items-center justify-space-between">
+                <Icon aria-hidden={true} as={isExpanded ? ChevronDownIcon : ChevronRightIcon} className="mr-1" />
+                <div className={classNames(styles.collapseHeader, step.skipped && 'text-muted')}>
+                    <StepStateIcon step={step} />
+                    <H3 className={styles.stepNumber}>Step {step.number}</H3>
+                    <span className={classNames('text-monospace text-muted', styles.stepCommand)}>{step.run}</span>
+                </div>
+                {step.diffStat && <DiffStat className={styles.stepDiffStat} {...step.diffStat} expandedCounts={true} />}
+                {step.startedAt && (
+                    <span className={classNames('text-monospace text-muted', styles.stepTime)}>
+                        <StepTimer startedAt={step.startedAt} finishedAt={step.finishedAt} />
+                    </span>
+                )}
+            </CollapseHeader>
+            <CollapsePanel>
+                <Card className={classNames('mt-2', styles.stepCard)}>
+                    <CardBody>
+                        {!step.skipped && (
+                            <Tabs size="small" behavior="forceRender">
+                                <TabList>
+                                    <Tab key="logs">Logs</Tab>
+                                    <Tab key="output-variables">Output variables</Tab>
+                                    <Tab key="diff">Diff</Tab>
+                                    <Tab key="files-env">Files / Env</Tab>
+                                    <Tab key="command-container">Commands / Container</Tab>
+                                </TabList>
+                                <TabPanels>
+                                    <TabPanel className="pt-2" key="logs">
+                                        {!step.startedAt && (
+                                            <Text className="text-muted mb-0">Step not started yet</Text>
+                                        )}
+                                        {step.startedAt && outputLines && <LogOutput text={outputLines.join('\n')} />}
+                                    </TabPanel>
+                                    <TabPanel className="pt-2" key="output-variables">
+                                        {!step.startedAt && (
+                                            <Text className="text-muted mb-0">Step not started yet</Text>
+                                        )}
+                                        {step.outputVariables?.length === 0 && (
+                                            <Text className="text-muted mb-0">No output variables specified</Text>
+                                        )}
+                                        <ul className="mb-0">
+                                            {step.outputVariables?.map(variable => (
+                                                <li key={variable.name}>
+                                                    {variable.name}: {variable.value}
+                                                </li>
+                                            ))}
+                                        </ul>
+                                    </TabPanel>
+                                    <TabPanel className="pt-2" key="diff">
+                                        {!step.startedAt && (
+                                            <Text className="text-muted mb-0">Step not started yet</Text>
+                                        )}
+                                        {step.startedAt && (
+                                            <WorkspaceStepFileDiffConnection
+                                                isLightTheme={isLightTheme}
+                                                step={step.number}
+                                                workspaceID={workspaceID}
+                                                queryBatchSpecWorkspaceStepFileDiffs={
+                                                    queryBatchSpecWorkspaceStepFileDiffs
+                                                }
+                                            />
+                                        )}
+                                    </TabPanel>
+                                    <TabPanel className="pt-2" key="files-env">
+                                        {step.environment.length === 0 && (
+                                            <Text className="text-muted mb-0">No environment variables specified</Text>
+                                        )}
+                                        <ul className="mb-0">
+                                            {step.environment.map(variable => (
+                                                <li key={variable.name}>
+                                                    {variable.name}: {variable.value}
+                                                </li>
+                                            ))}
+                                        </ul>
+                                    </TabPanel>
+                                    <TabPanel className="pt-2" key="command-container">
+                                        {step.ifCondition !== null && (
+                                            <>
+                                                <H4>If condition</H4>
+                                                <LogOutput text={step.ifCondition} className="mb-2" />
+                                            </>
+                                        )}
+                                        <H4>Command</H4>
+                                        <LogOutput text={step.run} className="mb-2" />
+                                        <H4>Container</H4>
+                                        <Text className="text-monospace mb-0">{step.container}</Text>
+                                    </TabPanel>
+                                </TabPanels>
+                            </Tabs>
+                        )}
+                        {step.skipped && (
+                            <Text className="mb-0">
+                                <strong>
+                                    Step has been skipped
+                                    {cachedResultFound && <> because a cached result was found for this workspace</>}
+                                    {!cachedResultFound && step.cachedResultFound && (
+                                        <> because a cached result was found for this step</>
                                     )}
-                                    <ul className="mb-0">
-                                        {step.outputVariables?.map(variable => (
-                                            <li key={variable.name}>
-                                                {variable.name}: {variable.value}
-                                            </li>
-                                        ))}
-                                    </ul>
-                                </TabPanel>
-                                <TabPanel className="pt-2" key="diff">
-                                    {!step.startedAt && <Text className="text-muted mb-0">Step not started yet</Text>}
-                                    {step.startedAt && (
-                                        <WorkspaceStepFileDiffConnection
-                                            isLightTheme={isLightTheme}
-                                            step={step.number}
-                                            workspaceID={workspaceID}
-                                            queryBatchSpecWorkspaceStepFileDiffs={queryBatchSpecWorkspaceStepFileDiffs}
-                                        />
-                                    )}
-                                </TabPanel>
-                                <TabPanel className="pt-2" key="files-env">
-                                    {step.environment.length === 0 && (
-                                        <Text className="text-muted mb-0">No environment variables specified</Text>
-                                    )}
-                                    <ul className="mb-0">
-                                        {step.environment.map(variable => (
-                                            <li key={variable.name}>
-                                                {variable.name}: {variable.value}
-                                            </li>
-                                        ))}
-                                    </ul>
-                                </TabPanel>
-                                <TabPanel className="pt-2" key="command-container">
-                                    {step.ifCondition !== null && (
-                                        <>
-                                            <H4>If condition</H4>
-                                            <LogOutput text={step.ifCondition} className="mb-2" />
-                                        </>
-                                    )}
-                                    <H4>Command</H4>
-                                    <LogOutput text={step.run} className="mb-2" />
-                                    <H4>Container</H4>
-                                    <Text className="text-monospace mb-0">{step.container}</Text>
-                                </TabPanel>
-                            </TabPanels>
-                        </Tabs>
-                    )}
-                    {step.skipped && (
-                        <Text className="mb-0">
-                            <strong>
-                                Step has been skipped
-                                {cachedResultFound && <> because a cached result was found for this workspace</>}
-                                {!cachedResultFound && step.cachedResultFound && (
-                                    <> because a cached result was found for this step</>
-                                )}
                                 .
                             </strong>
                         </Text>

--- a/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspaceDetails.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspaceDetails.tsx
@@ -3,12 +3,9 @@ import React, { useCallback, useMemo, useState } from 'react'
 import { VisuallyHidden } from '@reach/visually-hidden'
 import classNames from 'classnames'
 import { cloneDeep } from 'lodash'
-import AlertCircleIcon from 'mdi-react/AlertCircleIcon'
-import CheckBoldIcon from 'mdi-react/CheckBoldIcon'
 import ChevronDownIcon from 'mdi-react/ChevronDownIcon'
 import ChevronRightIcon from 'mdi-react/ChevronRightIcon'
 import CloseIcon from 'mdi-react/CloseIcon'
-import ContentSaveIcon from 'mdi-react/ContentSaveIcon'
 import ExternalLinkIcon from 'mdi-react/ExternalLinkIcon'
 import EyeOffOutlineIcon from 'mdi-react/EyeOffOutlineIcon'
 import LinkVariantRemoveIcon from 'mdi-react/LinkVariantRemoveIcon'
@@ -16,7 +13,6 @@ import MapSearchIcon from 'mdi-react/MapSearchIcon'
 import SourceBranchIcon from 'mdi-react/SourceBranchIcon'
 import SyncIcon from 'mdi-react/SyncIcon'
 import TimelineClockOutlineIcon from 'mdi-react/TimelineClockOutlineIcon'
-import TimerSandIcon from 'mdi-react/TimerSandIcon'
 import indicator from 'ordinal/indicator'
 import { useHistory } from 'react-router'
 
@@ -72,6 +68,7 @@ import {
 } from '../backend'
 import { TimelineModal } from '../TimelineModal'
 
+import { StepStateIcon } from './StepStateIcon'
 import { WorkspaceStateIcon } from './WorkspaceStateIcon'
 
 import styles from './WorkspaceDetails.module.scss'
@@ -592,77 +589,14 @@ const WorkspaceStep: React.FunctionComponent<React.PropsWithChildren<WorkspaceSt
                                     {!cachedResultFound && step.cachedResultFound && (
                                         <> because a cached result was found for this step</>
                                     )}
-                                .
-                            </strong>
-                        </Text>
-                    )}
-                </CardBody>
-            </Card>
-        </Collapsible>
-    )
-}
-
-interface StepStateIconProps {
-    step: BatchSpecWorkspaceStepFields
-}
-const StepStateIcon: React.FunctionComponent<React.PropsWithChildren<StepStateIconProps>> = ({ step }) => {
-    if (step.cachedResultFound) {
-        return (
-            <Icon
-                className="text-success flex-shrink-0"
-                aria-label="A cached result for this step has been found"
-                data-tooltip="A cached result for this step has been found"
-                as={ContentSaveIcon}
-            />
-        )
-    }
-    if (step.skipped) {
-        return (
-            <Icon
-                className="text-muted flex-shrink-0"
-                aria-label="The step has been skipped"
-                data-tooltip="The step has been skipped"
-                as={LinkVariantRemoveIcon}
-            />
-        )
-    }
-    if (!step.startedAt) {
-        return (
-            <Icon
-                className="text-muted flex-shrink-0"
-                aria-label="This step is waiting to be processed"
-                data-tooltip="This step is waiting to be processed"
-                as={TimerSandIcon}
-            />
-        )
-    }
-    if (!step.finishedAt) {
-        return (
-            <Icon
-                className="text-muted flex-shrink-0"
-                aria-label="This step is currently running"
-                data-tooltip="This step is currently running"
-                as={LoadingSpinner}
-            />
-        )
-    }
-    if (step.exitCode === 0) {
-        return (
-            <Icon
-                className="text-success flex-shrink-0"
-                aria-label="This step ran successfully"
-                data-tooltip="This step ran successfully"
-                as={CheckBoldIcon}
-            />
-        )
-    }
-    return (
-        <Icon
-            className="text-danger flex-shrink-0"
-            aria-label={`This step failed with exit code ${String(step.exitCode)}`}
-            data-tooltip={`This step failed with exit code ${String(step.exitCode)}`}
-            as={AlertCircleIcon}
-        />
+                                    .
+                                </strong>
+                            </Text>
+                        )}
+                    </CardBody>
+                </Card>
+            </CollapsePanel>
+        </Collapse>
     )
 }
 

--- a/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspaceDetails.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspaceDetails.tsx
@@ -375,7 +375,10 @@ const ChangesetSpecNode: React.FunctionComponent<React.PropsWithChildren<Changes
 
     return (
         <Collapse isOpen={isExpanded} onOpenChange={setIsExpanded} openByDefault={true}>
-            <CollapseHeader as={Button} className="w-100 p-0 m-0 d-flex align-items-center justify-space-between">
+            <CollapseHeader
+                as={Button}
+                className="w-100 p-0 m-0 border-0 d-flex align-items-center justify-content-between"
+            >
                 <Icon aria-hidden={true} as={isExpanded ? ChevronDownIcon : ChevronRightIcon} className="mr-1" />
                 <div className={styles.collapseHeader}>
                     <H4 className="mb-0 d-inline-block mr-2">
@@ -401,7 +404,7 @@ const ChangesetSpecNode: React.FunctionComponent<React.PropsWithChildren<Changes
                             <strong>Published:</strong> <PublishedValue published={node.description.published} />
                         </Text>
                         <Collapse isOpen={areChangesExpanded} onOpenChange={setAreChangesExpanded} openByDefault={true}>
-                            <CollapseHeader as={Button} className="w-100 p-0 m-0 d-flex align-items-center">
+                            <CollapseHeader as={Button} className="w-100 p-0 m-0 border-0 d-flex align-items-center">
                                 <Icon
                                     aria-hidden={true}
                                     as={areChangesExpanded ? ChevronDownIcon : ChevronRightIcon}
@@ -491,7 +494,10 @@ const WorkspaceStep: React.FunctionComponent<React.PropsWithChildren<WorkspaceSt
 
     return (
         <Collapse isOpen={isExpanded} onOpenChange={setIsExpanded}>
-            <CollapseHeader as={Button} className="w-100 p-0 m-0 d-flex align-items-center justify-space-between">
+            <CollapseHeader
+                as={Button}
+                className="w-100 p-0 m-0 border-0 d-flex align-items-center justify-content-between"
+            >
                 <Icon aria-hidden={true} as={isExpanded ? ChevronDownIcon : ChevronRightIcon} className="mr-1" />
                 <div className={classNames(styles.collapseHeader, step.skipped && 'text-muted')}>
                     <StepStateIcon step={step} />

--- a/client/web/src/enterprise/batches/batch-spec/header/ActionButtons.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/header/ActionButtons.tsx
@@ -6,7 +6,9 @@ export const ActionButtons: React.FunctionComponent<React.PropsWithChildren<{ cl
     children,
     className,
 }) => (
-    <div className={classNames('d-flex flex-column flex-0 align-items-center justify-content-center', className)}>
+    <div
+        className={classNames('d-flex flex-column flex-shrink-0 align-items-center justify-content-center', className)}
+    >
         {children}
     </div>
 )

--- a/client/wildcard/src/components/Collapse/Collapse.tsx
+++ b/client/wildcard/src/components/Collapse/Collapse.tsx
@@ -29,7 +29,9 @@ const DEFAULT_CONTEXT_VALUE: CollapseContextData = {
 
 const CollapseContext = createContext<CollapseContextData>(DEFAULT_CONTEXT_VALUE)
 
-export const Collapse: React.FunctionComponent<React.PropsWithChildren<CollapseProps>> = React.memo(props => {
+export const Collapse: React.FunctionComponent<React.PropsWithChildren<CollapseProps>> = React.memo(function Collapse(
+    props
+) {
     const { children, isOpen, openByDefault, onOpenChange = noop } = props
     const [isInternalOpen, setInternalOpen] = useState<boolean>(Boolean(openByDefault))
     const isControlled = isOpen !== undefined
@@ -64,7 +66,7 @@ interface CollapseHeaderProps extends React.HTMLAttributes<HTMLButtonElement> {
     focusLocked?: boolean
 }
 
-export const CollapseHeader = React.forwardRef((props, reference) => {
+export const CollapseHeader = React.forwardRef(function CollapseHeader(props, reference) {
     const { children, className, as: Component = 'button', onClick = noop, focusLocked, ...attributes } = props
     const { setOpen, isOpen } = useContext(CollapseContext)
     const [focusLock, setFocusLock] = useState(false)
@@ -110,18 +112,19 @@ export const CollapseHeader = React.forwardRef((props, reference) => {
     )
 }) as ForwardReferenceComponent<'button', CollapseHeaderProps>
 
-export const CollapsePanel = React.forwardRef(
-    ({ children, className, as: Component = 'div', ...attributes }, reference) => {
-        const { isOpen } = useContext(CollapseContext)
+export const CollapsePanel = React.forwardRef(function CollapsePanel(
+    { children, className, as: Component = 'div', ...attributes },
+    reference
+) {
+    const { isOpen } = useContext(CollapseContext)
 
-        return (
-            <Component
-                className={classNames(styles.collapse, isOpen && styles.show, className)}
-                ref={reference}
-                {...attributes}
-            >
-                {children}
-            </Component>
-        )
-    }
-) as ForwardReferenceComponent<'div'>
+    return (
+        <Component
+            className={classNames(styles.collapse, isOpen && styles.show, className)}
+            ref={reference}
+            {...attributes}
+        >
+            {children}
+        </Component>
+    )
+}) as ForwardReferenceComponent<'div'>


### PR DESCRIPTION
I was going to go file a follow-up issue for the frontend platform team for https://github.com/sourcegraph/sourcegraph/issues/36799, but then as I was writing the ticket, I discovered that we actually maintain two separate implementations of a collapsible component: `Collapsible`, which we're using, and `Collapse`. I don't know why there's two, but `Collapse` is a part of Wildcard and `Collapsible` is not. `Collapse` also appears to me to have a better implementation, and it doesn't rely on `::after` for the button, which means it doesn't swallow hover events as I saw when investigating https://github.com/sourcegraph/sourcegraph/issues/36799.

So, in this PR, I've gone ahead and refactored our execution UI to use `Collapse` instead, which means we get our step state tooltips back! 🎉 Closes https://github.com/sourcegraph/sourcegraph/issues/36799!

![Screen Shot 2022-06-15 at 1 24 55 PM](https://user-images.githubusercontent.com/8942601/173921221-72df50fb-0137-479c-b5df-ea95fb1c0267.png)

While updating and testing the components, I fixed some issues with the collapsible header rows overflowing when the branch name is too long. Now it truncates the branch name text in the same way as we do for the step `run` command:

![Screen Shot 2022-06-15 at 1 25 46 PM](https://user-images.githubusercontent.com/8942601/173921640-84e9ed26-9340-44d5-8fd6-66e319b31d92.png)

I also took this opportunity to refactor to the new `Tooltip` component for `StepStateIcon` while I was there. And lastly, I fixed a few miscellaneous linter warnings here and there.

## Test plan

This component is covered by Storybook stories. I compared side-by-side with storybook.sgdev.org to ensure I wasn't introducing a visual regression.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-kr-fix-collapsible.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-qfcdjdtouq.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
