### PR TITLE
automatically fix any instances of tcp error introduced in 3.40

### DIFF
--- a/migrations/frontend/1655328928/down.sql
+++ b/migrations/frontend/1655328928/down.sql
@@ -1,0 +1,1 @@
+-- Nothing to do in this down migration.

--- a/migrations/frontend/1655328928/metadata.yaml
+++ b/migrations/frontend/1655328928/metadata.yaml
@@ -1,0 +1,2 @@
+name: fix_code_insights_failed_tcp_error
+parents: [1649253538, 1655037391, 1655067139, 1655128668]

--- a/migrations/frontend/1655328928/up.sql
+++ b/migrations/frontend/1655328928/up.sql
@@ -1,0 +1,4 @@
+-- In 3.40 one transient error was accidentally flagged as non-retryable and would terminally fail. This simply
+-- resets these jobs in the queue to try again after 3.41 ships.
+update insights_query_runner_jobs set state = 'queued', failure_message = null, num_failures = 0
+where state = 'failed' and failure_message like '%dial tcp%';


### PR DESCRIPTION
Introduces a migration to clean up any records that were terminally failed as a result of the dial tcp error getting skipped.

## Test plan

I ran this against k8s and reset something like 123,000 records back into the queued state.
