### PR TITLE
db: Back-compat remove access_token_id from SSBC

### DIFF
--- a/internal/database/schema.json
+++ b/internal/database/schema.json
@@ -1764,19 +1764,6 @@
       "Comment": "",
       "Columns": [
         {
-          "Name": "access_token_id",
-          "Index": 16,
-          "TypeName": "bigint",
-          "IsNullable": true,
-          "Default": "",
-          "CharacterMaximumLength": 0,
-          "IsIdentity": false,
-          "IdentityGeneration": "",
-          "IsGenerated": "NEVER",
-          "GenerationExpression": "",
-          "Comment": ""
-        },
-        {
           "Name": "batch_spec_workspace_id",
           "Index": 2,
           "TypeName": "integer",
@@ -2057,13 +2044,6 @@
           "RefTableName": "batch_spec_workspaces",
           "IsDeferrable": true,
           "ConstraintDefinition": "FOREIGN KEY (batch_spec_workspace_id) REFERENCES batch_spec_workspaces(id) ON DELETE CASCADE DEFERRABLE"
-        },
-        {
-          "Name": "batch_spec_workspace_execution_jobs_access_token_id_fkey",
-          "ConstraintType": "f",
-          "RefTableName": "access_tokens",
-          "IsDeferrable": true,
-          "ConstraintDefinition": "FOREIGN KEY (access_token_id) REFERENCES access_tokens(id) ON DELETE SET NULL DEFERRABLE"
         }
       ],
       "Triggers": []
@@ -17593,7 +17573,7 @@
   "Views": [
     {
       "Name": "batch_spec_workspace_execution_jobs_with_rank",
-      "Definition": " SELECT j.id,\n    j.batch_spec_workspace_id,\n    j.state,\n    j.failure_message,\n    j.started_at,\n    j.finished_at,\n    j.process_after,\n    j.num_resets,\n    j.num_failures,\n    j.execution_logs,\n    j.worker_hostname,\n    j.last_heartbeat_at,\n    j.created_at,\n    j.updated_at,\n    j.cancel,\n    j.access_token_id,\n    j.queued_at,\n    j.user_id,\n    q.place_in_global_queue,\n    q.place_in_user_queue\n   FROM (batch_spec_workspace_execution_jobs j\n     LEFT JOIN batch_spec_workspace_execution_queue q ON ((j.id = q.id)));"
+      "Definition": " SELECT j.id,\n    j.batch_spec_workspace_id,\n    j.state,\n    j.failure_message,\n    j.started_at,\n    j.finished_at,\n    j.process_after,\n    j.num_resets,\n    j.num_failures,\n    j.execution_logs,\n    j.worker_hostname,\n    j.last_heartbeat_at,\n    j.created_at,\n    j.updated_at,\n    j.cancel,\n    j.queued_at,\n    j.user_id,\n    q.place_in_global_queue,\n    q.place_in_user_queue\n   FROM (batch_spec_workspace_execution_jobs j\n     LEFT JOIN batch_spec_workspace_execution_queue q ON ((j.id = q.id)));"
     },
     {
       "Name": "batch_spec_workspace_execution_queue",

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -19,8 +19,6 @@ Indexes:
 Foreign-key constraints:
     "access_tokens_creator_user_id_fkey" FOREIGN KEY (creator_user_id) REFERENCES users(id)
     "access_tokens_subject_user_id_fkey" FOREIGN KEY (subject_user_id) REFERENCES users(id)
-Referenced by:
-    TABLE "batch_spec_workspace_execution_jobs" CONSTRAINT "batch_spec_workspace_execution_jobs_access_token_id_fkey" FOREIGN KEY (access_token_id) REFERENCES access_tokens(id) ON DELETE SET NULL DEFERRABLE
 
 ```
 
@@ -148,7 +146,6 @@ Foreign-key constraints:
  created_at              | timestamp with time zone |           | not null | now()
  updated_at              | timestamp with time zone |           | not null | now()
  cancel                  | boolean                  |           | not null | false
- access_token_id         | bigint                   |           |          | 
  queued_at               | timestamp with time zone |           |          | now()
  user_id                 | integer                  |           |          | 
 Indexes:
@@ -159,7 +156,6 @@ Indexes:
     "batch_spec_workspace_execution_jobs_state" btree (state)
 Foreign-key constraints:
     "batch_spec_workspace_execution_job_batch_spec_workspace_id_fkey" FOREIGN KEY (batch_spec_workspace_id) REFERENCES batch_spec_workspaces(id) ON DELETE CASCADE DEFERRABLE
-    "batch_spec_workspace_execution_jobs_access_token_id_fkey" FOREIGN KEY (access_token_id) REFERENCES access_tokens(id) ON DELETE SET NULL DEFERRABLE
 
 ```
 
@@ -2783,7 +2779,6 @@ Foreign-key constraints:
     j.created_at,
     j.updated_at,
     j.cancel,
-    j.access_token_id,
     j.queued_at,
     j.user_id,
     q.place_in_global_queue,

--- a/migrations/frontend/1655157509/down.sql
+++ b/migrations/frontend/1655157509/down.sql
@@ -1,0 +1,12 @@
+ALTER TABLE batch_spec_workspace_execution_jobs ADD COLUMN IF NOT EXISTS access_token_id integer REFERENCES access_tokens(id);
+
+DROP VIEW IF EXISTS batch_spec_workspace_execution_jobs_with_rank;
+CREATE VIEW batch_spec_workspace_execution_jobs_with_rank AS (
+    SELECT
+        j.*,
+        q.place_in_global_queue,
+        q.place_in_user_queue
+    FROM
+        batch_spec_workspace_execution_jobs j
+    LEFT JOIN batch_spec_workspace_execution_queue q ON j.id = q.id
+);

--- a/migrations/frontend/1655157509/metadata.yaml
+++ b/migrations/frontend/1655157509/metadata.yaml
@@ -1,0 +1,2 @@
+name: no_more_ssbc_access_tokens
+parents: [1649253538, 1654874153]

--- a/migrations/frontend/1655157509/up.sql
+++ b/migrations/frontend/1655157509/up.sql
@@ -1,0 +1,30 @@
+DELETE FROM access_tokens WHERE internal and note = 'batch-spec-execution';
+
+DROP VIEW IF EXISTS batch_spec_workspace_execution_jobs_with_rank;
+CREATE VIEW batch_spec_workspace_execution_jobs_with_rank AS (
+    SELECT
+        j.id,
+        j.batch_spec_workspace_id,
+        j.state,
+        j.failure_message,
+        j.started_at,
+        j.finished_at,
+        j.process_after,
+        j.num_resets,
+        j.num_failures,
+        j.execution_logs,
+        j.worker_hostname,
+        j.last_heartbeat_at,
+        j.created_at,
+        j.updated_at,
+        j.cancel,
+        j.queued_at,
+        j.user_id,
+        q.place_in_global_queue,
+        q.place_in_user_queue
+    FROM
+        batch_spec_workspace_execution_jobs j
+    LEFT JOIN batch_spec_workspace_execution_queue q ON j.id = q.id
+);
+
+ALTER TABLE batch_spec_workspace_execution_jobs DROP COLUMN IF EXISTS access_token_id;

--- a/migrations/frontend/squashed.sql
+++ b/migrations/frontend/squashed.sql
@@ -608,7 +608,6 @@ CREATE TABLE batch_spec_workspace_execution_jobs (
     created_at timestamp with time zone DEFAULT now() NOT NULL,
     updated_at timestamp with time zone DEFAULT now() NOT NULL,
     cancel boolean DEFAULT false NOT NULL,
-    access_token_id bigint,
     queued_at timestamp with time zone DEFAULT now(),
     user_id integer
 );
@@ -657,7 +656,6 @@ CREATE VIEW batch_spec_workspace_execution_jobs_with_rank AS
     j.created_at,
     j.updated_at,
     j.cancel,
-    j.access_token_id,
     j.queued_at,
     j.user_id,
     q.place_in_global_queue,
@@ -3838,9 +3836,6 @@ ALTER TABLE ONLY batch_spec_resolution_jobs
 
 ALTER TABLE ONLY batch_spec_workspace_execution_jobs
     ADD CONSTRAINT batch_spec_workspace_execution_job_batch_spec_workspace_id_fkey FOREIGN KEY (batch_spec_workspace_id) REFERENCES batch_spec_workspaces(id) ON DELETE CASCADE DEFERRABLE;
-
-ALTER TABLE ONLY batch_spec_workspace_execution_jobs
-    ADD CONSTRAINT batch_spec_workspace_execution_jobs_access_token_id_fkey FOREIGN KEY (access_token_id) REFERENCES access_tokens(id) ON DELETE SET NULL DEFERRABLE;
 
 ALTER TABLE ONLY batch_spec_workspaces
     ADD CONSTRAINT batch_spec_workspaces_batch_spec_id_fkey FOREIGN KEY (batch_spec_id) REFERENCES batch_specs(id) ON DELETE CASCADE DEFERRABLE;


### PR DESCRIPTION
This will get rid of the access_token_id column that we stopped using in https://github.com/sourcegraph/sourcegraph/pull/36230 in a backward-compatible fashion.

## Test plan

Covered by test suite.