### PR TITLE
Overhaul `Timeline`

### DIFF
--- a/client/web/src/components/Timeline.module.scss
+++ b/client/web/src/components/Timeline.module.scss
@@ -1,4 +1,5 @@
 .details {
+    // stylelint-disable-next-line declaration-property-unit-allowed-list
     border-left: 0.25rem solid var(--border-color);
     margin: -1rem 1rem;
     padding: 1rem 0 2rem 2rem;
@@ -25,6 +26,7 @@
 
 .separator {
     height: 2.25rem;
+    // stylelint-disable-next-line declaration-property-unit-allowed-list
     border-left: 0.25rem solid var(--border-color);
     margin-left: 1rem;
     margin-top: -1rem;

--- a/client/web/src/components/Timeline.module.scss
+++ b/client/web/src/components/Timeline.module.scss
@@ -1,19 +1,24 @@
-.executor-task-details {
-    border-left: 4px solid var(--border-color);
-    margin-left: 1.5rem;
-    margin-top: -1rem;
-    margin-bottom: -1rem;
+.details {
+    border-left: 0.25rem solid var(--border-color);
+    margin: -1rem 1rem;
     padding-left: 2rem;
     padding-top: 1rem;
     padding-bottom: 2rem;
+
+    &:last-child {
+        padding-bottom: 1rem;
+    }
 }
 
-.executor-task-icon {
+.icon {
     border-radius: 50%;
     width: 2.25rem;
     height: 2.25rem;
     color: #ffffff;
     padding-top: 0.375rem;
+    margin: 0.5rem 0.5rem 0.5rem 0;
+    isolation: isolate;
+    z-index: 2;
 
     svg {
         display: block;
@@ -21,10 +26,12 @@
     }
 }
 
-.executor-task-separator {
+.separator {
     height: 2.25rem;
-    border-left: 4px solid var(--border-color);
-    margin-left: 1.5rem;
+    border-left: 0.25rem solid var(--border-color);
+    margin-left: 1rem;
     margin-top: -1rem;
     margin-bottom: -1rem;
+    isolation: isolate;
+    z-index: 1;
 }

--- a/client/web/src/components/Timeline.module.scss
+++ b/client/web/src/components/Timeline.module.scss
@@ -1,9 +1,7 @@
 .details {
     border-left: 0.25rem solid var(--border-color);
     margin: -1rem 1rem;
-    padding-left: 2rem;
-    padding-top: 1rem;
-    padding-bottom: 2rem;
+    padding: 1rem 0 2rem 2rem;
 
     &:last-child {
         padding-bottom: 1rem;
@@ -18,7 +16,6 @@
     padding-top: 0.375rem;
     margin: 0.5rem 0.5rem 0.5rem 0;
     isolation: isolate;
-    z-index: 2;
 
     svg {
         display: block;
@@ -32,6 +29,4 @@
     margin-left: 1rem;
     margin-top: -1rem;
     margin-bottom: -1rem;
-    isolation: isolate;
-    z-index: 1;
 }

--- a/client/web/src/components/Timeline.story.tsx
+++ b/client/web/src/components/Timeline.story.tsx
@@ -8,9 +8,11 @@ import { Text } from '@sourcegraph/wildcard'
 import { Timeline } from './Timeline'
 import { WebStory } from './WebStory'
 
-const { add } = storiesOf('web/Timeline', module)
-
-add('Empty', () => <WebStory>{() => <Timeline stages={[]} />}</WebStory>)
+const { add } = storiesOf('web/Timeline', module).addDecorator(story => (
+    <div className="container mt-3" style={{ maxWidth: 600 }}>
+        {story()}
+    </div>
+))
 
 add('Basic', () => (
     <WebStory>
@@ -71,16 +73,54 @@ add('Details', () => (
                         className: 'bg-danger',
                         text: 'Second event description',
                         date: '2020-06-15T12:20:00+00:00',
-                        details: <Text>HELLO THERE</Text>,
-                        expanded: true,
+                        details: (
+                            <>
+                                <Text>HELLO THERE!</Text>
+                                <Text className="m-0">I opened automatically because I'm important.</Text>
+                            </>
+                        ),
+                        expandedByDefault: true,
                     },
                     {
                         icon: <CheckIcon />,
                         className: 'bg-success',
                         text: 'Third event description',
                         date: '2020-06-15T13:25:00+00:00',
-                        details: <Text>HELLO THERE</Text>,
-                        expanded: false,
+                        details: <Text className="m-0 p-0">HELLO THERE</Text>,
+                        expandedByDefault: false,
+                    },
+                ]}
+            />
+        )}
+    </WebStory>
+))
+
+add('Details, without durations', () => (
+    <WebStory>
+        {() => (
+            <Timeline
+                now={() => parseISO('2020-08-01T16:21:00+00:00')}
+                showDurations={false}
+                stages={[
+                    {
+                        icon: <CheckIcon />,
+                        className: 'bg-success',
+                        text: 'First event description',
+                        date: '2020-06-15T11:15:00+00:00',
+                    },
+                    {
+                        icon: <AlertCircleIcon />,
+                        className: 'bg-danger',
+                        text: 'Second event description',
+                        date: '2020-06-15T12:20:00+00:00',
+                        details: <Text className="m-0 p-0">HELLO THERE</Text>,
+                    },
+                    {
+                        icon: <CheckIcon />,
+                        className: 'bg-success',
+                        text: 'Third event description',
+                        date: '2020-06-15T13:25:00+00:00',
+                        details: <Text className="m-0 p-0">HELLO THERE</Text>,
                     },
                 ]}
             />

--- a/client/web/src/components/Timeline.tsx
+++ b/client/web/src/components/Timeline.tsx
@@ -1,9 +1,12 @@
-import { FunctionComponent, ReactNode } from 'react'
+import React, { FunctionComponent, ReactNode, useState } from 'react'
 
 import classNames from 'classnames'
 import { formatDistance } from 'date-fns/esm'
+import ChevronDownIcon from 'mdi-react/ChevronDownIcon'
+import ChevronRightIcon from 'mdi-react/ChevronRightIcon'
 
-import { Collapsible } from './Collapsible'
+import { Button, Collapse, CollapseHeader, CollapsePanel, Icon } from '@sourcegraph/wildcard'
+
 import { Timestamp } from './time/Timestamp'
 
 import styles from './Timeline.module.scss'
@@ -12,95 +15,79 @@ export interface TimelineStage {
     icon: ReactNode
     text: ReactNode
     details?: ReactNode
-    date?: string | null
+    date: string
     className?: string
-    expanded?: boolean
+    expandedByDefault?: boolean
 }
 
 export interface TimelineProps {
     stages: TimelineStage[]
-    withoutPreviousDate?: boolean
-    now?: () => Date
     className?: string
+    showDurations?: boolean
+    /** For testing only */
+    now?: () => Date
 }
 
 export const Timeline: FunctionComponent<React.PropsWithChildren<TimelineProps>> = ({
     stages,
     now,
     className,
-    withoutPreviousDate = false,
+    showDurations = true,
 }) => (
-    <div className={className}>
-        {stages.map((stage, stageIndex) => {
-            if (!stage.date) {
-                return null
-            }
-
-            const previousDate = stages
-                .map(stage => stage.date)
-                .filter((date, index) => !!date && index < stageIndex)
-                .reverse()?.[0]
-
-            const meta = <TimelineMeta stage={{ ...stage, date: stage.date }} now={now} />
-
-            return (
-                // Use index as key because the values in each step may not be unique. This is
-                // OK here because this list will not be updated during this component's lifetime.
-                /* eslint-disable react/no-array-index-key */
-                <div key={stageIndex}>
-                    {previousDate && (
-                        <div className="d-flex align-items-center">
-                            <div className="flex-0">
-                                <div className={styles.executorTaskSeparator} />
-                            </div>
-                            {!withoutPreviousDate && (
-                                <div className="flex-1">
-                                    <span className="text-muted ml-4">
-                                        {formatDistance(new Date(stage.date), new Date(previousDate))}
-                                    </span>
-                                </div>
-                            )}
-                        </div>
-                    )}
-
-                    {stage.details ? (
-                        <>
-                            <Collapsible
-                                title={meta}
-                                className="p-0 font-weight-normal"
-                                buttonClassName="mb-0"
-                                titleAtStart={true}
-                                defaultExpanded={stage.expanded}
-                            >
-                                <div className={styles.executorTaskDetails}>{stage.details}</div>
-                            </Collapsible>
-                        </>
-                    ) : (
-                        meta
-                    )}
-                </div>
-            )
-        })}
+    <div className={classNames('w-100', className)}>
+        {stages.map((stage, stageIndex) => (
+            <>
+                {stageIndex !== 0 && (
+                    <div className="d-flex align-items-center">
+                        <div className={styles.separator} />
+                        {showDurations && (
+                            <span className="flex-1 text-muted ml-4">
+                                {formatDistance(new Date(stage.date), new Date(stages[stageIndex - 1]?.date))}
+                            </span>
+                        )}
+                    </div>
+                )}
+                <TimelineStage key={`${stage.text}+${stage.date}`} stage={stage} now={now} />
+            </>
+        ))}
     </div>
 )
 
-export interface TimelineMetaProps {
-    stage: TimelineStage & { date: string }
+interface TimelineStageProps {
+    stage: TimelineStage
     now?: () => Date
 }
 
-export const TimelineMeta: FunctionComponent<React.PropsWithChildren<TimelineMetaProps>> = ({ stage, now }) => (
-    <>
+const TimelineStage: FunctionComponent<React.PropsWithChildren<TimelineStageProps>> = ({
+    stage: { className, details, date, expandedByDefault = false, icon, text },
+    now,
+}) => {
+    const [isExpanded, setIsExpanded] = useState(expandedByDefault)
+
+    const stageLabel = (
         <div className="d-flex align-items-center">
-            <div className="flex-0 m-2">
-                <div className={classNames(styles.executorTaskIcon, stage.className)}>{stage.icon}</div>
-            </div>
+            <div className={classNames(styles.icon, className)}>{icon}</div>
             <div className="flex-1">
-                {stage.text}{' '}
-                <span className="text-muted">
-                    <Timestamp date={stage.date} now={now} noAbout={true} />
+                {text}
+                <span className="text-muted ml-1">
+                    <Timestamp date={date} now={now} noAbout={true} />
                 </span>
             </div>
         </div>
-    </>
-)
+    )
+
+    return details ? (
+        <Collapse isOpen={isExpanded} onOpenChange={setIsExpanded} openByDefault={expandedByDefault}>
+            <CollapseHeader
+                as={Button}
+                className="p-0 m-0 border-0 w-100 font-weight-normal d-flex justify-content-between align-items-center"
+            >
+                {stageLabel}
+                <Icon aria-hidden={true} as={isExpanded ? ChevronDownIcon : ChevronRightIcon} className="mr-1" />
+            </CollapseHeader>
+            <CollapsePanel className={styles.details}>{details}</CollapsePanel>
+        </Collapse>
+    ) : (
+        stageLabel
+    )
+}

--- a/client/web/src/enterprise/batches/batch-spec/execute/TimelineModal.module.scss
+++ b/client/web/src/enterprise/batches/batch-spec/execute/TimelineModal.module.scss
@@ -19,7 +19,3 @@
     padding: 0 var(--modal-body-padding) var(--modal-body-padding) var(--modal-body-padding);
     width: 100%;
 }
-
-.timeline-margin {
-    margin-left: -0.5rem;
-}

--- a/client/web/src/enterprise/batches/batch-spec/execute/TimelineModal.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/execute/TimelineModal.tsx
@@ -1,7 +1,6 @@
 import React, { useMemo } from 'react'
 
 import { VisuallyHidden } from '@reach/visually-hidden'
-import classNames from 'classnames'
 import AlertCircleIcon from 'mdi-react/AlertCircleIcon'
 import CheckIcon from 'mdi-react/CheckIcon'
 import CloseIcon from 'mdi-react/CloseIcon'
@@ -53,49 +52,46 @@ interface ExecutionTimelineProps {
 
     /** For testing only. */
     now?: () => Date
-    expandStage?: string
+    expandedStage?: string
 }
 
 const ExecutionTimeline: React.FunctionComponent<React.PropsWithChildren<ExecutionTimelineProps>> = ({
     node,
     className,
     now,
-    expandStage,
+    expandedStage,
 }) => {
     const stages = useMemo(
-        () => [
-            { icon: <TimerSandIcon />, text: 'Queued', date: node.queuedAt, className: 'bg-success' },
-            {
-                icon: <CheckIcon />,
-                text: 'Began processing',
-                date: node.startedAt,
-                className: 'bg-success',
-            },
+        () =>
+            [
+                { icon: <TimerSandIcon />, text: 'Queued', date: node.queuedAt, className: 'bg-success' },
+                {
+                    icon: <CheckIcon />,
+                    text: 'Began processing',
+                    date: node.startedAt,
+                    className: 'bg-success',
+                },
 
-            setupStage(node, expandStage === 'setup', now),
-            batchPreviewStage(node, expandStage === 'srcPreview', now),
-            teardownStage(node, expandStage === 'teardown', now),
+                setupStage(node, expandedStage === 'setup', now),
+                batchPreviewStage(node, expandedStage === 'srcPreview', now),
+                teardownStage(node, expandedStage === 'teardown', now),
 
-            node.state === BatchSpecWorkspaceState.COMPLETED
-                ? { icon: <CheckIcon />, text: 'Finished', date: node.finishedAt, className: 'bg-success' }
-                : node.state === BatchSpecWorkspaceState.CANCELED
-                ? { icon: <AlertCircleIcon />, text: 'Canceled', date: node.finishedAt, className: 'bg-secondary' }
-                : { icon: <AlertCircleIcon />, text: 'Failed', date: node.finishedAt, className: 'bg-danger' },
-        ],
-        [expandStage, node, now]
+                node.state === BatchSpecWorkspaceState.COMPLETED
+                    ? { icon: <CheckIcon />, text: 'Finished', date: node.finishedAt, className: 'bg-success' }
+                    : node.state === BatchSpecWorkspaceState.CANCELED
+                    ? { icon: <AlertCircleIcon />, text: 'Canceled', date: node.finishedAt, className: 'bg-secondary' }
+                    : { icon: <AlertCircleIcon />, text: 'Failed', date: node.finishedAt, className: 'bg-danger' },
+            ]
+                .filter(isDefined)
+                .filter<TimelineStage>((stage): stage is TimelineStage => stage.date !== null),
+        [expandedStage, node, now]
     )
-    return (
-        <Timeline
-            stages={stages.filter(isDefined)}
-            now={now}
-            className={classNames(className, styles.timelineMargin)}
-        />
-    )
+    return <Timeline stages={stages} now={now} className={className} />
 }
 
 const setupStage = (
     execution: VisibleBatchSpecWorkspaceFields,
-    expand: boolean,
+    expandedByDefault: boolean,
     now?: () => Date
 ): TimelineStage | undefined => {
     if (execution.stages === null) {
@@ -108,13 +104,13 @@ const setupStage = (
               details: execution.stages.setup.map(logEntry => (
                   <ExecutionLogEntry key={logEntry.key} logEntry={logEntry} now={now} />
               )),
-              ...genericStage(execution.stages.setup, expand),
+              ...genericStage(execution.stages.setup, expandedByDefault),
           }
 }
 
 const batchPreviewStage = (
     execution: VisibleBatchSpecWorkspaceFields,
-    expand: boolean,
+    expandedByDefault: boolean,
     now?: () => Date
 ): TimelineStage | undefined => {
     if (execution.stages === null) {
@@ -127,13 +123,13 @@ const batchPreviewStage = (
               details: (
                   <ExecutionLogEntry key={execution.stages.srcExec.key} logEntry={execution.stages.srcExec} now={now} />
               ),
-              ...genericStage(execution.stages.srcExec, expand),
+              ...genericStage(execution.stages.srcExec, expandedByDefault),
           }
 }
 
 const teardownStage = (
     execution: VisibleBatchSpecWorkspaceFields,
-    expand: boolean,
+    expandedByDefault: boolean,
     now?: () => Date
 ): TimelineStage | undefined => {
     if (execution.stages === null) {
@@ -146,14 +142,14 @@ const teardownStage = (
               details: execution.stages.teardown.map(logEntry => (
                   <ExecutionLogEntry key={logEntry.key} logEntry={logEntry} now={now} />
               )),
-              ...genericStage(execution.stages.teardown, expand),
+              ...genericStage(execution.stages.teardown, expandedByDefault),
           }
 }
 
 const genericStage = <E extends { startTime: string; exitCode: number | null }>(
     value: E | E[],
-    expand: boolean
-): Pick<TimelineStage, 'icon' | 'date' | 'className' | 'expanded'> => {
+    expandedByDefault: boolean
+): Pick<TimelineStage, 'icon' | 'date' | 'className' | 'expandedByDefault'> => {
     const finished = Array.isArray(value)
         ? value.every(logEntry => logEntry.exitCode !== null)
         : value.exitCode !== null
@@ -163,6 +159,6 @@ const genericStage = <E extends { startTime: string; exitCode: number | null }>(
         icon: !finished ? <ProgressClockIcon /> : success ? <CheckIcon /> : <AlertCircleIcon />,
         date: Array.isArray(value) ? value[0].startTime : value.startTime,
         className: success || !finished ? 'bg-success' : 'bg-danger',
-        expanded: expand || !(success || !finished),
+        expandedByDefault: expandedByDefault || !(success || !finished),
     }
 }

--- a/client/web/src/enterprise/codeintel/indexes/components/CodeIntelIndexTimeline.tsx
+++ b/client/web/src/enterprise/codeintel/indexes/components/CodeIntelIndexTimeline.tsx
@@ -26,24 +26,27 @@ export const CodeIntelIndexTimeline: FunctionComponent<React.PropsWithChildren<C
     className,
 }) => {
     const stages = useMemo(
-        () => [
-            { icon: <TimerSandIcon />, text: 'Queued', date: index.queuedAt, className: 'bg-success' },
-            { icon: <CheckIcon />, text: 'Began processing', date: index.startedAt, className: 'bg-success' },
+        () =>
+            [
+                { icon: <TimerSandIcon />, text: 'Queued', date: index.queuedAt, className: 'bg-success' },
+                { icon: <CheckIcon />, text: 'Began processing', date: index.startedAt, className: 'bg-success' },
 
-            indexSetupStage(index, now),
-            indexPreIndexStage(index, now),
-            indexIndexStage(index, now),
-            indexUploadStage(index, now),
-            indexTeardownStage(index, now),
+                indexSetupStage(index, now),
+                indexPreIndexStage(index, now),
+                indexIndexStage(index, now),
+                indexUploadStage(index, now),
+                indexTeardownStage(index, now),
 
-            index.state === LSIFIndexState.COMPLETED
-                ? { icon: <CheckIcon />, text: 'Finished', date: index.finishedAt, className: 'bg-success' }
-                : { icon: <AlertCircleIcon />, text: 'Failed', date: index.finishedAt, className: 'bg-danger' },
-        ],
+                index.state === LSIFIndexState.COMPLETED
+                    ? { icon: <CheckIcon />, text: 'Finished', date: index.finishedAt, className: 'bg-success' }
+                    : { icon: <AlertCircleIcon />, text: 'Failed', date: index.finishedAt, className: 'bg-danger' },
+            ]
+                .filter(isDefined)
+                .filter<TimelineStage>((stage): stage is TimelineStage => stage.date !== null),
         [index, now]
     )
 
-    return <Timeline stages={stages.filter(isDefined)} now={now} className={className} />
+    return <Timeline stages={stages} now={now} className={className} />
 }
 
 const indexSetupStage = (index: LsifIndexFields, now?: () => Date): TimelineStage | undefined =>
@@ -127,7 +130,7 @@ const indexTeardownStage = (index: LsifIndexFields, now?: () => Date): TimelineS
 
 const genericStage = <E extends { startTime: string; exitCode: number | null }>(
     value: E | E[]
-): Pick<TimelineStage, 'icon' | 'date' | 'className' | 'expanded'> => {
+): Pick<TimelineStage, 'icon' | 'date' | 'className' | 'expandedByDefault'> => {
     const finished = Array.isArray(value)
         ? value.every(logEntry => logEntry.exitCode !== null)
         : value.exitCode !== null
@@ -137,6 +140,6 @@ const genericStage = <E extends { startTime: string; exitCode: number | null }>(
         icon: !finished ? <ProgressClockIcon /> : success ? <CheckIcon /> : <AlertCircleIcon />,
         date: Array.isArray(value) ? value[0].startTime : value.startTime,
         className: success || !finished ? 'bg-success' : 'bg-danger',
-        expanded: !(success || !finished),
+        expandedByDefault: !(success || !finished),
     }
 }

--- a/client/web/src/enterprise/codeintel/uploads/components/CodeIntelUploadTimeline.tsx
+++ b/client/web/src/enterprise/codeintel/uploads/components/CodeIntelUploadTimeline.tsx
@@ -35,9 +35,9 @@ export const CodeIntelUploadTimeline: FunctionComponent<React.PropsWithChildren<
 
     const stages = useMemo(
         () =>
-            [uploadStages, processingStages, terminalStages].flatMap(stageConstructor =>
-                stageConstructor(upload, failedStage)
-            ),
+            [uploadStages, processingStages, terminalStages]
+                .flatMap(stageConstructor => stageConstructor(upload, failedStage))
+                .filter(stage => stage.date !== null) as TimelineStage[],
         [upload, failedStage]
     )
 
@@ -64,7 +64,10 @@ const uploadStages = (upload: LsifUploadFields, failedStage: FailedStage | null)
     },
 ]
 
-const processingStages = (upload: LsifUploadFields, failedStage: FailedStage | null): TimelineStage[] => [
+const processingStages = (
+    upload: LsifUploadFields,
+    failedStage: FailedStage | null
+): (TimelineStage | { date: null })[] => [
     {
         icon: <ProgressClockIcon />,
         text:
@@ -82,7 +85,7 @@ const processingStages = (upload: LsifUploadFields, failedStage: FailedStage | n
     },
 ]
 
-const terminalStages = (upload: LsifUploadFields): TimelineStage[] =>
+const terminalStages = (upload: LsifUploadFields): (TimelineStage | { date: null })[] =>
     upload.state === LSIFUploadState.COMPLETED
         ? [
               {

--- a/client/web/src/enterprise/codeintel/uploads/components/UploadAuditLogTimeline.tsx
+++ b/client/web/src/enterprise/codeintel/uploads/components/UploadAuditLogTimeline.tsx
@@ -5,7 +5,7 @@ import DatabasePlusIcon from 'mdi-react/DatabasePlusIcon'
 
 import { Container } from '@sourcegraph/wildcard'
 
-import { Timeline } from '../../../../components/Timeline'
+import { Timeline, TimelineStage } from '../../../../components/Timeline'
 import { AuditLogOperation, LsifUploadsAuditLogsFields } from '../../../../graphql-operations'
 
 import styles from './UploadAuditLogTimeline.module.scss'
@@ -17,52 +17,54 @@ export interface UploadAuditLogTimelineProps {
 export const UploadAuditLogTimeline: FunctionComponent<React.PropsWithChildren<UploadAuditLogTimelineProps>> = ({
     logs,
 }) => {
-    const stages = logs?.map(log => ({
-        icon: log.operation === AuditLogOperation.CREATE ? <DatabasePlusIcon /> : <DatabaseEditIcon />,
-        text: stageText(log),
-        className: log.operation === AuditLogOperation.CREATE ? 'bg-success' : 'bg-warning',
-        expanded: true,
-        date: log.logTimestamp,
-        details: (
-            <>
-                {log.reason && (
-                    <>
-                        <Container>
-                            <b>Reason</b>: {log.reason}
-                        </Container>
-                        <br />
-                    </>
-                )}
-                <div className={styles.tableContainer}>
-                    <table className="table mb-0 table-striped">
-                        <thead>
-                            <tr>
-                                <th className={styles.dbColumnCol} scope="column">
-                                    Column
-                                </th>
-                                <th className={styles.dataColumnCol} scope="column">
-                                    Old
-                                </th>
-                                <th scope="column">New</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            {log.changedColumns.map((change, index) => (
-                                // eslint-disable-next-line react/no-array-index-key
-                                <tr key={index} className="overflow-scroll">
-                                    <td className="mr-2">{change.column}</td>
-                                    <td className="mr-2">{change.old || 'NULL'}</td>
-                                    <td className="mr-2">{change.new || 'NULL'}</td>
+    const stages = logs?.map(
+        (log): TimelineStage => ({
+            icon: log.operation === AuditLogOperation.CREATE ? <DatabasePlusIcon /> : <DatabaseEditIcon />,
+            text: stageText(log),
+            className: log.operation === AuditLogOperation.CREATE ? 'bg-success' : 'bg-warning',
+            expandedByDefault: true,
+            date: log.logTimestamp,
+            details: (
+                <>
+                    {log.reason && (
+                        <>
+                            <Container>
+                                <b>Reason</b>: {log.reason}
+                            </Container>
+                            <br />
+                        </>
+                    )}
+                    <div className={styles.tableContainer}>
+                        <table className="table mb-0 table-striped">
+                            <thead>
+                                <tr>
+                                    <th className={styles.dbColumnCol} scope="column">
+                                        Column
+                                    </th>
+                                    <th className={styles.dataColumnCol} scope="column">
+                                        Old
+                                    </th>
+                                    <th scope="column">New</th>
                                 </tr>
-                            ))}
-                        </tbody>
-                    </table>
-                </div>
-            </>
-        ),
-    }))
+                            </thead>
+                            <tbody>
+                                {log.changedColumns.map((change, index) => (
+                                    // eslint-disable-next-line react/no-array-index-key
+                                    <tr key={index} className="overflow-scroll">
+                                        <td className="mr-2">{change.column}</td>
+                                        <td className="mr-2">{change.old || 'NULL'}</td>
+                                        <td className="mr-2">{change.new || 'NULL'}</td>
+                                    </tr>
+                                ))}
+                            </tbody>
+                        </table>
+                    </div>
+                </>
+            ),
+        })
+    )
 
-    return <Timeline withoutPreviousDate={true} stages={stages} />
+    return <Timeline showDurations={false} stages={stages} />
 }
 
 function stageText(log: LsifUploadsAuditLogsFields): ReactNode {


### PR DESCRIPTION
This started out as "replace the `Collapsible` in the timeline so that the tooltips for the timestamps work again" and turned into "I don't understand half of what this component is doing, let's give it some love." 😄

- Cleaned up props
  - `Timeline.stages` now only accepts valid stages (i.e. stages with a date). Consumers should be responsible for filtering.
  - `Timeline.withoutPreviousDate` became `Timeline.showDurations`, because a) "previous date" was a weird description for a time distance between two items in the timeline sequence and b) I think positively-framed props ("show this thing") are easier to reason about than negatively-framed props ("don't show this thing")
  - `TimelineStage.expanded` became `TimelineStage.expandedByDefault`, to avoid any confusion over who is in control of the collapsible state
- Restructured component
  - `TimelineMeta` was a weird abstraction for part of the item label we show for each stage, so now it has become `TimelineStage` 
  - There was a lot of unnecessary `<div />` nesting, this has been flattened
- Refactored `Collapsible` to use `Collapse`
- Cleaned up styles
- Improved Storybook coverage

### Screenshots

#### Tooltip functionality restored!
![Screen Shot 2022-06-16 at 10 55 51 AM](https://user-images.githubusercontent.com/8942601/174135481-a6bb704e-7b01-46f5-950f-98d8dc533385.png)

#### Batch spec execution timeline
![Screen Shot 2022-06-16 at 10 55 47 AM](https://user-images.githubusercontent.com/8942601/174135512-fd8b42e9-0303-4c24-8509-73ad8c6fa371.png)

#### Code intel upload timeline
![Screen Shot 2022-06-16 at 10 52 37 AM](https://user-images.githubusercontent.com/8942601/174135571-c950b760-cfe1-45ac-8266-6dfddfc28d1c.png)

#### Code intel audit log timeline
![Screen Shot 2022-06-16 at 10 55 21 AM](https://user-images.githubusercontent.com/8942601/174135614-1e337d46-8219-4a10-94f3-ddb472175379.png)

## Test plan

Validated tooltips are visible again, manually tested timeline in the Batch Changes modal. There isn't Storybook coverage for the other instances of Timeline used across Code Intel, and I don't have Code Intel set up locally, but I was able to inspect some from the app preview and they still looked good!
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-kr-timeline.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-rqwvilwvry.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

