### PR TITLE
executors: Add teardown.fs log step

### DIFF
--- a/enterprise/cmd/executor/internal/worker/handler.go
+++ b/enterprise/cmd/executor/internal/worker/handler.go
@@ -106,7 +106,18 @@ func (h *handler) Handle(ctx context.Context, logger log.Logger, record workerut
 	}
 	defer func() {
 		if !h.options.KeepWorkspaces {
-			_ = os.RemoveAll(workspaceRoot)
+			handle := commandLogger.Log("teardown.fs", nil)
+
+			handle.Write([]byte(fmt.Sprintf("Removing %s\n", workspaceRoot)))
+
+			if rmErr := os.RemoveAll(workspaceRoot); rmErr != nil {
+				handle.Write([]byte(fmt.Sprintf("Operation failed: %s\n", rmErr.Error())))
+			}
+
+			// We always finish this with exit code 0 even if it errored, because workspace
+			// cleanup doesn't fail the execution job. We can deal with it separately.
+			handle.Finalize(0)
+			handle.Close()
 		}
 	}()
 


### PR DESCRIPTION
Can never have enough logging! We don't want to silently do "something" for more than a few ms, and for large workspaces this can take a short while.

## Test plan

Firecracker changes only in k8s, will check it out there :) 