### PR TITLE
extensions: use deprecated tooltip for decorations

### DIFF
--- a/client/web/src/repo/blob/ColumnDecorator.module.scss
+++ b/client/web/src/repo/blob/ColumnDecorator.module.scss
@@ -28,6 +28,7 @@ tr:global(.highlighted) {
 .item {
     overflow: hidden;
     text-overflow: ellipsis;
+    display: inline-block;
 }
 
 .contents {

--- a/client/web/src/repo/blob/ColumnDecorator.tsx
+++ b/client/web/src/repo/blob/ColumnDecorator.tsx
@@ -13,7 +13,6 @@ import {
 } from '@sourcegraph/shared/src/api/extension/api/decorations'
 import { LinkOrSpan } from '@sourcegraph/shared/src/components/LinkOrSpan'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
-import { Tooltip } from '@sourcegraph/wildcard'
 
 import styles from './ColumnDecorator.module.scss'
 
@@ -131,38 +130,34 @@ export const ColumnDecorator = React.memo<LineDecoratorProps>(
                                 const style = decorationAttachmentStyleForTheme(attachment, isLightTheme)
 
                                 return (
-                                    <Tooltip
+                                    <LinkOrSpan
                                         key={`${decoration.after.contentText ?? decoration.after.hoverMessage ?? ''}-${
                                             portalRoot.dataset.line ?? ''
                                         }`}
-                                        content={attachment.hoverMessage || null}
-                                        placement="top"
+                                        className={styles.item}
+                                        // eslint-disable-next-line react/forbid-dom-props
+                                        style={{ color: style.color }}
+                                        to={attachment.linkURL}
+                                        // Use target to open external URLs
+                                        target={
+                                            attachment.linkURL && isAbsoluteUrl(attachment.linkURL)
+                                                ? '_blank'
+                                                : undefined
+                                        }
+                                        // Avoid leaking referrer URLs (which contain repository and path names, etc.) to external sites.
+                                        rel="noreferrer noopener"
+                                        data-tooltip={attachment.hoverMessage || null}
+                                        onMouseEnter={selectRow}
+                                        onMouseLeave={deselectRow}
+                                        onFocus={selectRow}
+                                        onBlur={deselectRow}
                                     >
-                                        <LinkOrSpan
-                                            className={styles.item}
-                                            // eslint-disable-next-line react/forbid-dom-props
-                                            style={{ color: style.color }}
-                                            to={attachment.linkURL}
-                                            // Use target to open external URLs
-                                            target={
-                                                attachment.linkURL && isAbsoluteUrl(attachment.linkURL)
-                                                    ? '_blank'
-                                                    : undefined
-                                            }
-                                            // Avoid leaking referrer URLs (which contain repository and path names, etc.) to external sites.
-                                            rel="noreferrer noopener"
-                                            onMouseEnter={selectRow}
-                                            onMouseLeave={deselectRow}
-                                            onFocus={selectRow}
-                                            onBlur={deselectRow}
-                                        >
-                                            <span
-                                                className={styles.contents}
-                                                data-line-decoration-attachment-content={true}
-                                                data-contents={attachment.contentText || ''}
-                                            />
-                                        </LinkOrSpan>
-                                    </Tooltip>
+                                        <span
+                                            className={styles.contents}
+                                            data-line-decoration-attachment-content={true}
+                                            data-contents={attachment.contentText || ''}
+                                        />
+                                    </LinkOrSpan>
                                 )
                             }),
                             portalRoot.querySelector(`.${styles.wrapper}`) as HTMLDivElement


### PR DESCRIPTION
Roll back to using `data-tooltip` attribute to display tooltips for extensions decorations.
It's a temporary fix until the issue mentioned in https://github.com/sourcegraph/sourcegraph/pull/37106 is addressed.
The new wildcard `Tooltip` component blocks click events causing links not to work.

## Test plan
Tested locally: tooltips are displayed, and links are navigated from the keyboard (Enter, Ctrl+Enter) and via mouse clicks (left/right click, left click+Ctrl, left click + Shift).

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-taras-yemets-fix-decorations.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-vzyrgzyatw.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
