### PR TITLE
Code Insights: Fix standalone insight title copy

### DIFF
--- a/client/web/src/enterprise/insights/pages/insights/insight/CodeInsightIndependentPage.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/insight/CodeInsightIndependentPage.tsx
@@ -35,7 +35,7 @@ export const CodeInsightIndependentPage: FunctionComponent<CodeInsightIndependen
 
     return (
         <CodeInsightsPage className={styles.root}>
-            <PageTitle title={`Configure ${insight.title} - Code Insights`} />
+            <PageTitle title={`${insight.title} - Code Insights`} />
             <PageHeader
                 path={[{ to: '/insights/dashboards/all', icon: CodeInsightsIcon }, { text: insight.title }]}
                 actions={<CodeInsightIndependentPageActions insight={insight} />}


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/37281#issuecomment-1156772602

## Test plan
- Go to the standalone insight page 
- Make sure that the page title says - <insight name> - Code Insights (without wrong "Configure" at the beginning) 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
