### PR TITLE
chore: update GitHub automation for IAM team

### DIFF
--- a/.github/teams.yml
+++ b/.github/teams.yml
@@ -5,9 +5,9 @@ team/frontend-platform:
   - '@pdubroy'
   - '@oleggromov'
 
-team/iam-admin-experience:
+team/iam:
   - '@unknwon'
-  - '@RafLeszczynski'
+  - '@jplahn'
   - '@miveronese'
   - '@ryphil'
   - '@pietrorosa77'

--- a/.github/workflows/label-move.yml
+++ b/.github/workflows/label-move.yml
@@ -247,23 +247,23 @@ jobs:
               }
             }
           }' -f project=$PROJECT_ID -f node_id=$NODE_ID
-  iam-and-admin-exp-board:
+  iam-board:
     runs-on: ubuntu-latest
     env:
       PROJECT_ID: PN_kwDOADy5QM4ABlJF # https://github.com/orgs/sourcegraph/projects/259
       GITHUB_TOKEN: ${{ secrets.GH_PROJECTS_ACTION_TOKEN }}
     steps:
     - name: Get issue if relevant
-      if: ${{ contains(github.event.issue.labels.*.name, 'team/iam-admin-experience') }}
+      if: ${{ contains(github.event.issue.labels.*.name, 'team/iam') }}
       env:
         NODE_ID: ${{ github.event.issue.node_id }}
       run: echo 'NODE_ID='$NODE_ID >> $GITHUB_ENV
     - name: Get pull request if relevant
-      if: ${{ contains(github.event.pull_request.labels.*.name, 'team/iam-admin-experience') }}
+      if: ${{ contains(github.event.pull_request.labels.*.name, 'team/iam') }}
       env:
         NODE_ID: ${{ github.event.pull_request.node_id }}
       run: echo 'NODE_ID='$NODE_ID >> $GITHUB_ENV
-    - name: Add to IAM and Admin Exp board
+    - name: Add to IAM team board
       if: ${{ env.NODE_ID != '' }}
       run: |
         gh api graphql --header 'GraphQL-Features: projects_next_graphql' -f query='

--- a/.github/workflows/label-notify.yml
+++ b/.github/workflows/label-notify.yml
@@ -24,4 +24,4 @@ jobs:
                   team/frontend-platform=@taylorsperry @jasongornall
                   team/repo-management=@jplahn
                   team/devops=@sourcegraph/cloud-devops
-                  team/iam-admin-experience=@sourcegraph/iam-and-admin-experience
+                  team/iam=@sourcegraph/iam

--- a/.github/workflows/team-labeler.yml
+++ b/.github/workflows/team-labeler.yml
@@ -1,5 +1,7 @@
 name: team-label
-on: pull_request
+on:
+   pull_request:
+     types: [opened, reopened]
 jobs:
   team-labeler:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Three parts of GitHub automation have been updated for the IAM team:

1. `.github/teams.yml`: Automatically label the PR with the label `team/iam` if the author is one of the defined people.
	- Also only limited to pull requests "opened" and "reopened" events, give us a chance to transfer PR ownership or not intended to be going to the team board.
3. `.github/workflows/label-move.yml`: Automatically add issues and PRs with the label `team/iam` to the IAM GitHub project.
4. `.github/workflows/label-notify.yml`: Automatically tag `@sourcegraph/iam` team when an issue is labeled with `team/iam`


## Test plan

Not code related.