### PR TITLE
Code Insights: Fix filters layout section on the standalone insight page

### DIFF
--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/drill-down-filters/DrillDownInsightFilters.module.scss
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/drill-down-filters/DrillDownInsightFilters.module.scss
@@ -43,10 +43,8 @@
 }
 
 .panels {
-    display: grid;
-    grid-auto-flow: row;
-
     &--horizontal-mode {
+        display: flex;
         flex-wrap: wrap;
         flex-direction: row;
         padding-bottom: 1rem;
@@ -59,7 +57,7 @@
     flex-grow: 1;
 
     &--horizontal-mode {
-        flex-basis: 22rem;
+        flex-basis: 20rem;
     }
 }
 

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/drill-down-filters/DrillDownInsightFilters.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/drill-down-filters/DrillDownInsightFilters.tsx
@@ -196,7 +196,7 @@ export const DrillDownInsightFilters: FunctionComponent<DrillDownInsightFilters>
             </header>
             <hr className={styles.headerSeparator} />
 
-            <div className={classNames(styles.panels, { [styles.panelsHorizontalMode]: isHorizontalMode })}>
+            <div className={classNames({ [styles.panelsHorizontalMode]: isHorizontalMode })}>
                 {showSeriesDisplayOptions && (
                     <FilterCollapseSection
                         open={isHorizontalMode || activeSection === FilterSection.SortFilter}
@@ -205,6 +205,7 @@ export const DrillDownInsightFilters: FunctionComponent<DrillDownInsightFilters>
                         preview={getSortPreview(parseSeriesDisplayOptions(seriesDisplayOptions))}
                         hasActiveFilter={hasSeriesDisplayOptionsChanged}
                         withSeparators={!isHorizontalMode}
+                        className={classNames(styles.panel, { [styles.panelHorizontalMode]: isHorizontalMode })}
                         onOpenChange={opened => handleCollapseState(FilterSection.SortFilter, opened)}
                     >
                         <SortFilterSeriesPanel

--- a/client/web/src/enterprise/insights/pages/insights/insight/components/standalone-backend-insight/StandaloneBackendInsight.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/insight/components/standalone-backend-insight/StandaloneBackendInsight.tsx
@@ -30,6 +30,7 @@ import {
 import { useSeriesToggle } from '../../../../../components/insights-view-grid/components/backend-insight/components/backend-insight-chart/use-series-toggle'
 import { useVisibility } from '../../../../../components/insights-view-grid/hooks/use-insight-data'
 import {
+    BackendInsightData,
     ALL_INSIGHTS_DASHBOARD,
     BackendInsight,
     CodeInsightsBackendContext,
@@ -37,7 +38,6 @@ import {
     InsightFilters,
     InsightType,
 } from '../../../../../core'
-import { BackendInsightData } from '../../../../../core/backend/code-insights-backend-types'
 import { GET_INSIGHT_VIEW_GQL } from '../../../../../core/backend/gql-backend'
 import { createBackendInsightData } from '../../../../../core/backend/gql-backend/methods/get-backend-insight-data/deserializators'
 import { insightPollingInterval } from '../../../../../core/backend/gql-backend/utils/insight-polling'


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/36214

## Background
| Before  | After |
| ------------- | ------------- |
| <img width="1280" alt="Screenshot 2022-06-16 at 14 28 38" src="https://user-images.githubusercontent.com/18492575/174005915-34e65aaf-dd9e-45ec-82ad-e4c057d27574.png"> | <img width="788" alt="Screenshot 2022-06-16 at 14 27 42" src="https://user-images.githubusercontent.com/18492575/174005954-e55a6b9e-086a-436c-8cf9-ac4e3fce46e4.png"> |
| Same as above  | <img width="1305" alt="Screenshot 2022-06-16 at 14 27 28" src="https://user-images.githubusercontent.com/18492575/174005993-6fbac2f5-ae39-4d02-8c0e-257e81be7c46.png">  |

## For reviewers 
@AlicjaSuska I remember that we had a conversation that it would be better to have a collapsable panel for the mobile screen that we already have on the dashboard page. I agree with this but it turned out this requires more work than I'd expected originally. I propose to make this PR improvement first and include this fix in the 3.41 release after we can go back to this page and adopt a collapsable pattern there. 

## Test plan
- Go to the standalone insight page (for insight with and without sort and limit filters section)
- Make sure that layout works properly for desktop and mobile viewports)

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vk-fix-filters-layout-section.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-hxokplhqtj.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
