### PR TITLE
Enable adding overrides for rollout feature flags

### DIFF
--- a/client/web/src/site-admin/SiteAdminFeatureFlagConfigurationPage.tsx
+++ b/client/web/src/site-admin/SiteAdminFeatureFlagConfigurationPage.tsx
@@ -419,13 +419,11 @@ const FeatureFlagOverridesHeader: FunctionComponent<
 
     return (
         <>
-            {type === 'FeatureFlagBoolean' && (
-                <AddFeatureFlagOverride
-                    name={name}
-                    value={(value as FeatureFlagBooleanValue).value}
-                    onOverrideAdded={onOverrideAdded}
-                />
-            )}
+            <AddFeatureFlagOverride
+                name={name}
+                value={type === 'FeatureFlagBoolean' ? (value as FeatureFlagBooleanValue).value : false}
+                onOverrideAdded={onOverrideAdded}
+            />
             <div className="mr-auto">{count}</div>
         </>
     )

--- a/internal/database/feature_flags.go
+++ b/internal/database/feature_flags.go
@@ -508,18 +508,19 @@ func (f *featureFlagStore) GetUserFlags(ctx context.Context, userID int32) (map[
 	}
 
 	res := make(map[string]bool, len(flags))
+
 	for _, ff := range flags {
 		res[ff.Name] = ff.EvaluateForUser(userID)
+	}
 
-		// Org overrides are higher priority than default
-		for _, oo := range orgOverrides {
-			res[oo.FlagName] = oo.Value
-		}
+	// Org overrides are higher priority than default
+	for _, oo := range orgOverrides {
+		res[oo.FlagName] = oo.Value
+	}
 
-		// User overrides are higher priority than org overrides
-		for _, uo := range userOverrides {
-			res[uo.FlagName] = uo.Value
-		}
+	// User overrides are higher priority than org overrides
+	for _, uo := range userOverrides {
+		res[uo.FlagName] = uo.Value
 	}
 
 	return res, nil


### PR DESCRIPTION
closes: https://github.com/sourcegraph/sourcegraph/issues/35795

This PR enabled adding org/user overrides for rollout feature flags as well which was earlier restricted to boolean feature flags.

This also performs minor refactoring over the `GetUserFlags` method in the database store. There are nested loops present which need not be. 

<img width="1285" alt="CleanShot 2022-06-16 at 13 54 43@2x" src="https://user-images.githubusercontent.com/22571395/174026892-fd0fe395-dd4f-433b-a2d6-9df93462a71e.png">

## Test plan

1. Visit /site-admin/feature-flags
2. Create a new rollout feature flag
3. Add overrides for user id and org id
4. Use  [console](https://sourcegraph.test:3443/api/console#%7B%22query%22%3A%22%7B%5Cn%20%20evaluateFeatureFlag(flagName%3A%20%5C%22test%5C%22)%5Cn%20%20currentUser%20%7B%5Cn%20%20%20%20id%5Cn%20%20%20%20organizations%20%7B%5Cn%20%20%20%20%20%20nodes%20%7B%5Cn%20%20%20%20%20%20%20%20id%5Cn%20%20%20%20%20%20%7D%5Cn%20%20%20%20%7D%5Cn%20%20%7D%5Cn%7D%5Cn%22%7D) to verify working of overrides.
5. Test deleting overrides
