### PR TITLE
worker: make some parameters configurable

### DIFF
--- a/enterprise/cmd/worker/internal/permissions/bitbucket_projects.go
+++ b/enterprise/cmd/worker/internal/permissions/bitbucket_projects.go
@@ -11,6 +11,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/sourcegraph/log"
+
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/globals"
@@ -51,9 +52,8 @@ func (j *bitbucketProjectPermissionsJob) Description() string {
 	return "Applies explicit permissions to all repositories of a Bitbucket Project."
 }
 
-// TODO(asdine): Load environment variables from here if needed.
 func (j *bitbucketProjectPermissionsJob) Config() []env.Config {
-	return []env.Config{}
+	return []env.Config{ConfigInst}
 }
 
 // Routines is called by the worker service to start the worker.
@@ -68,8 +68,8 @@ func (j *bitbucketProjectPermissionsJob) Routines(ctx context.Context, logger lo
 	bbProjectMetrics := newMetricsForBitbucketProjectPermissionsQueries(logger)
 
 	return []goroutine.BackgroundRoutine{
-		newBitbucketProjectPermissionsWorker(db, bbProjectMetrics),
-		newBitbucketProjectPermissionsResetter(db, bbProjectMetrics),
+		newBitbucketProjectPermissionsWorker(db, ConfigInst, bbProjectMetrics),
+		newBitbucketProjectPermissionsResetter(db, ConfigInst, bbProjectMetrics),
 	}, nil
 }
 
@@ -272,23 +272,22 @@ func (h *bitbucketProjectPermissionsHandler) setRepoPermissions(ctx context.Cont
 
 // newBitbucketProjectPermissionsWorker creates a worker that reads the explicit_permissions_bitbucket_projects_jobs table and
 // executes the jobs.
-// TODO(asdine): Fine tune the retry strategy and make some parameters configurable.
-func newBitbucketProjectPermissionsWorker(db edb.EnterpriseDB, metrics bitbucketProjectPermissionsMetrics) *workerutil.Worker {
+func newBitbucketProjectPermissionsWorker(db edb.EnterpriseDB, cfg *config, metrics bitbucketProjectPermissionsMetrics) *workerutil.Worker {
 	options := workerutil.WorkerOptions{
 		Name:              "explicit_permissions_bitbucket_projects_jobs_worker",
-		NumHandlers:       3,
-		Interval:          1 * time.Second,
+		NumHandlers:       cfg.WorkerConcurrency,
+		Interval:          cfg.WorkerPollInterval,
 		HeartbeatInterval: 15 * time.Second,
 		Metrics:           metrics.workerMetrics,
 	}
 
-	return dbworker.NewWorker(context.Background(), createBitbucketProjectPermissionsStore(db), &bitbucketProjectPermissionsHandler{db: db}, options)
+	return dbworker.NewWorker(context.Background(), createBitbucketProjectPermissionsStore(db, cfg), &bitbucketProjectPermissionsHandler{db: db}, options)
 }
 
 // newBitbucketProjectPermissionsResetter implements resetter for the explicit_permissions_bitbucket_projects_jobs table.
 // See resetter documentation for more details. https://docs.sourcegraph.com/dev/background-information/workers#dequeueing-and-resetting-jobs
-func newBitbucketProjectPermissionsResetter(db edb.EnterpriseDB, metrics bitbucketProjectPermissionsMetrics) *dbworker.Resetter {
-	workerStore := createBitbucketProjectPermissionsStore(db)
+func newBitbucketProjectPermissionsResetter(db edb.EnterpriseDB, cfg *config, metrics bitbucketProjectPermissionsMetrics) *dbworker.Resetter {
+	workerStore := createBitbucketProjectPermissionsStore(db, cfg)
 
 	options := dbworker.ResetterOptions{
 		Name:     "explicit_permissions_bitbucket_projects_jobs_worker_resetter",
@@ -304,8 +303,7 @@ func newBitbucketProjectPermissionsResetter(db edb.EnterpriseDB, metrics bitbuck
 
 // createBitbucketProjectPermissionsStore creates a store that reads and writes to the explicit_permissions_bitbucket_projects_jobs table.
 // It is used by the worker and resetter.
-// TODO(asdine): Fine tune the retry strategy and make some parameters configurable.
-func createBitbucketProjectPermissionsStore(s basestore.ShareableStore) dbworkerstore.Store {
+func createBitbucketProjectPermissionsStore(s basestore.ShareableStore, cfg *config) dbworkerstore.Store {
 	return dbworkerstore.New(s.Handle(), dbworkerstore.Options{
 		Name:      "explicit_permissions_bitbucket_projects_jobs_store",
 		TableName: "explicit_permissions_bitbucket_projects_jobs",
@@ -332,7 +330,7 @@ func createBitbucketProjectPermissionsStore(s basestore.ShareableStore) dbworker
 			return j, ok, err
 		},
 		StalledMaxAge:     60 * time.Second,
-		RetryAfter:        10 * time.Second,
+		RetryAfter:        cfg.WorkerRetryInterval,
 		MaxNumRetries:     5,
 		OrderByExpression: sqlf.Sprintf("explicit_permissions_bitbucket_projects_jobs.id"),
 	})

--- a/enterprise/cmd/worker/internal/permissions/bitbucket_projects_test.go
+++ b/enterprise/cmd/worker/internal/permissions/bitbucket_projects_test.go
@@ -35,7 +35,7 @@ func TestStore(t *testing.T) {
 	require.NoError(t, err)
 	require.NotZero(t, jobID)
 
-	store := createBitbucketProjectPermissionsStore(db)
+	store := createBitbucketProjectPermissionsStore(db, &config{})
 	count, err := store.QueuedCount(ctx, true, nil)
 	require.NoError(t, err)
 	require.Equal(t, 1, count)

--- a/enterprise/cmd/worker/internal/permissions/config.go
+++ b/enterprise/cmd/worker/internal/permissions/config.go
@@ -1,0 +1,37 @@
+package permissions
+
+import (
+	"time"
+
+	"github.com/sourcegraph/sourcegraph/internal/env"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+type config struct {
+	env.BaseConfig
+
+	WorkerPollInterval  time.Duration
+	WorkerConcurrency   int
+	WorkerRetryInterval time.Duration
+}
+
+var ConfigInst = &config{}
+
+func (c *config) Load() {
+	c.WorkerPollInterval = c.GetInterval("BITBUCKET_PROJECT_PERMISSIONS_WORKER_POLL_INTERVAL", "1s", "How frequently to query the job queue")
+	c.WorkerConcurrency = c.GetInt("BITBUCKET_PROJECT_PERMISSIONS_WORKER_CONCURRENCY", "1", "The maximum number of projects that can be processed concurrently")
+	c.WorkerRetryInterval = c.GetInterval("BITBUCKET_PROJECT_PERMISSIONS_WORKER_RETRY_INTERVAL", "30s", "The minimum number of time to wait before retrying a failed job")
+}
+
+func (c *config) Validate() error {
+	var errs error
+	errs = errors.Append(errs, c.BaseConfig.Validate())
+	if c.WorkerPollInterval < 0 {
+		errs = errors.Append(errs, errors.New("BITBUCKET_PROJECT_PERMISSIONS_WORKER_POLL_INTERVAL must be greater than or equal to 0"))
+	}
+	if c.WorkerConcurrency < 1 {
+		errs = errors.Append(errs, errors.New("BITBUCKET_PROJECT_PERMISSIONS_WORKER_CONCURRENCY must be greater than 0"))
+	}
+
+	return errs
+}


### PR DESCRIPTION
This adds some very conservative defaults for the Bitbucket Project Permissions worker.
Because we had some deadlock issues, we are making the default concurrency to 1 and let
the user increase the value as needed.
In case of deadlock, one of the job will win and the other will retry after 30s.
The default retry interval has been set to 30s to avoid sending too many requests to Bitbucket.
Some parameters have been ignored as they are also ignored in other worker implementations.

## Test plan

Unit tests