### PR TITLE
remove stop docker compose step

### DIFF
--- a/doc/admin/updates/upgrade_docker-compose.md
+++ b/doc/admin/updates/upgrade_docker-compose.md
@@ -54,20 +54,12 @@ docker-compose pull --include-deps
 ```
 ## 3. Restart Sourcegraph and allow migrations to finish
 
-### Stop sourcegraph
+### Restart 
 
-Ensure that the current Sourcegraph instance is completely stopped:
-
-```bash
-docker-compose down --remove-orphans
-```
-
-### Restart Sourcegraph 
-
-**Once the instance has fully stopped**, you can then start Docker Compose again, now using the new minor version along with your customizations:
+Restart Docker Compose using the new minor version along with your customizations:
 
 ```bash
-docker-compose up -d
+docker-compose up -d ---remove-orphans
 ```
 ### Check on the status of migrations
 


### PR DESCRIPTION
Optimised workflow by removing uneccesary step of stopping docker compose before restarting it after upgrading. 
Issue: [Docker Compose Upgrade](https://github.com/sourcegraph/product-education/issues/35) 
## Test plan

technical check by @Delivery please. 
