### PR TITLE
Tooltip: Revert "Last Synced" icon to previous implementation

### DIFF
--- a/client/search-ui/src/components/LastSyncedIcon.tsx
+++ b/client/search-ui/src/components/LastSyncedIcon.tsx
@@ -4,7 +4,7 @@ import classNames from 'classnames'
 import format from 'date-fns/format'
 import WeatherCloudyClockIcon from 'mdi-react/WeatherCloudyClockIcon'
 
-import { Icon, Tooltip } from '@sourcegraph/wildcard'
+import { Icon } from '@sourcegraph/wildcard'
 
 import styles from './LastSyncedIcon.module.scss'
 
@@ -17,13 +17,12 @@ export const LastSyncedIcon: React.FunctionComponent<React.PropsWithChildren<Pro
     const formattedTime = format(Date.parse(props.lastSyncedTime), "yyyy-MM-dd'T'HH:mm:ss")
 
     return (
-        <Tooltip content={`Last synced: ${formattedTime}`}>
-            <Icon
-                tabIndex={0}
-                className={classNames(props.className, styles.lastSyncedIcon, 'text-muted')}
-                as={WeatherCloudyClockIcon}
-                aria-label={`Last synced: ${formattedTime}`}
-            />
-        </Tooltip>
+        <Icon
+            tabIndex={0}
+            className={classNames(props.className, styles.lastSyncedIcon, 'text-muted')}
+            as={WeatherCloudyClockIcon}
+            aria-label={`Last synced: ${formattedTime}`}
+            data-tooltip={`Last synced: ${formattedTime}`}
+        />
     )
 }


### PR DESCRIPTION
## Description

Reverts to previous tooltip implementation

Issue reported here: https://sourcegraph.slack.com/archives/C03CSAER9LK/p1655302729128599

**Reverting for now, working on an improved fix for this - as this has identified an unexpected edge case**

## Test plan

Verified this works locally.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
