### PR TITLE
graphqlbackend: add endpoint to list Bitbucket Projects permission sync jobs

### DIFF
--- a/cmd/frontend/graphqlbackend/authz.go
+++ b/cmd/frontend/graphqlbackend/authz.go
@@ -83,8 +83,8 @@ type BitbucketProjectPermissionJobsArgs struct {
 }
 
 type BitbucketProjectsPermissionJobsResolver interface {
-	Count() int32
-	Jobs() ([]BitbucketProjectsPermissionJobResolver, error)
+	TotalCount() int32
+	Nodes() ([]BitbucketProjectsPermissionJobResolver, error)
 }
 
 type BitbucketProjectsPermissionJobResolver interface {

--- a/cmd/frontend/graphqlbackend/authz.go
+++ b/cmd/frontend/graphqlbackend/authz.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/graph-gophers/graphql-go"
+
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
@@ -20,6 +21,7 @@ type AuthzResolver interface {
 	AuthorizedUserRepositories(ctx context.Context, args *AuthorizedRepoArgs) (RepositoryConnectionResolver, error)
 	UsersWithPendingPermissions(ctx context.Context) ([]string, error)
 	AuthorizedUsers(ctx context.Context, args *RepoAuthorizedUserArgs) (UserConnectionResolver, error)
+	BitbucketProjectPermissionJobs(ctx context.Context, args *BitbucketProjectPermissionJobsArgs) (BitbucketProjectsPermissionJobsResolver, error)
 
 	// Helpers
 	RepositoryPermissionsInfo(ctx context.Context, repoID graphql.ID) (PermissionsInfoResolver, error)
@@ -72,6 +74,38 @@ type RepoPermsBitbucketProjectArgs struct {
 	CodeHost        graphql.ID
 	UserPermissions []types.UserPermission
 	Unrestricted    *bool
+}
+
+type BitbucketProjectPermissionJobsArgs struct {
+	ProjectKeys *[]string
+	Status      *string
+	Count       *int32
+}
+
+type BitbucketProjectsPermissionJobsResolver interface {
+	Count() int32
+	Jobs() ([]BitbucketProjectsPermissionJobResolver, error)
+}
+
+type BitbucketProjectsPermissionJobResolver interface {
+	InternalJobID() int32
+	State() string
+	FailureMessage() *string
+	QueuedAt() DateTime
+	StartedAt() *DateTime
+	FinishedAt() *DateTime
+	ProcessAfter() *DateTime
+	NumResets() int32
+	NumFailures() int32
+	ProjectKey() string
+	ExternalServiceID() graphql.ID
+	Permissions() []UserPermissionResolver
+	Unrestricted() bool
+}
+
+type UserPermissionResolver interface {
+	BindID() string
+	Permission() string
 }
 
 type PermissionsInfoResolver interface {

--- a/cmd/frontend/graphqlbackend/authz.graphql
+++ b/cmd/frontend/graphqlbackend/authz.graphql
@@ -281,6 +281,9 @@ input FetchPermissionsOptions {
     invalidateCaches: Boolean
 }
 
+"""
+Information about Bitbucket Projects permission synchronization jobs.
+"""
 type BitbucketProjectPermissionJobs {
     """
     Number of jobs.
@@ -292,6 +295,9 @@ type BitbucketProjectPermissionJobs {
     jobs: [BitbucketProjectPermissionJob!]!
 }
 
+"""
+Information about a single Projects permission synchronization job.
+"""
 type BitbucketProjectPermissionJob {
     """
     Internal ID of the job.

--- a/cmd/frontend/graphqlbackend/authz.graphql
+++ b/cmd/frontend/graphqlbackend/authz.graphql
@@ -304,7 +304,7 @@ type BitbucketProjectPermissionJob {
     """
     InternalJobID: Int!
     """
-    State of the job (queued, processing, completed, errored, failed).
+    State of the job (queued, processing, completed, canceled, errored, failed).
     """
     State: String!
     """

--- a/cmd/frontend/graphqlbackend/authz.graphql
+++ b/cmd/frontend/graphqlbackend/authz.graphql
@@ -288,11 +288,11 @@ type BitbucketProjectPermissionJobs {
     """
     Number of jobs.
     """
-    count: Int!
+    totalCount: Int!
     """
     Bitbucket Projects permission sync jobs.
     """
-    jobs: [BitbucketProjectPermissionJob!]!
+    nodes: [BitbucketProjectPermissionJob!]!
 }
 
 """

--- a/cmd/frontend/graphqlbackend/authz.graphql
+++ b/cmd/frontend/graphqlbackend/authz.graphql
@@ -13,7 +13,7 @@ extend type Mutation {
         users who may view the repository. All users not included in the list will not be
         permitted to view the repository on Sourcegraph.
         """
-        userPermissions: [UserPermission!]!
+        userPermissions: [UserPermissionInput!]!
     ): EmptyResponse!
     """
     Set 'unrestricted' to true or false on a set of repositories. Repositories with
@@ -86,7 +86,7 @@ extend type Mutation {
         users who may view the repository. All users not included in the list will not be
         permitted to view the repository on Sourcegraph.
         """
-        userPermissions: [UserPermission!]!
+        userPermissions: [UserPermissionInput!]!
 
         """
         Flag to indicate if ALL repositories under the project will allow unrestricted access to all users who have access to the code host.
@@ -130,6 +130,24 @@ extend type Query {
     The returned list can be used to query authorizedUserRepositories for pending permissions.
     """
     usersWithPendingPermissions: [String!]!
+
+    """
+    Returns a list of Bitbucket Project permissions sync jobs for a given set of parameters.
+    """
+    bitbucketProjectPermissionJobs(
+        """
+        Bitbucket project keys which sync jobs are queried
+        """
+        projectKeys: [String!]
+        """
+        Job status, one of the following: queued, processing, completed, errored, failed.
+        """
+        status: String
+        """
+        Number of jobs returned. Maximum number of returned jobs is 500. 100 jobs are returned by default.
+        """
+        count: Int
+    ): BitbucketProjectPermissionJobs!
 }
 
 extend type Repository {
@@ -169,9 +187,9 @@ extend type User {
 }
 
 """
-A user (identified either by username or email address) with its repository permission.
+Input type of a user (identified either by username or email address) with its repository permission.
 """
-input UserPermission {
+input UserPermissionInput {
     """
     Depending on the bindID option in the permissions.userMapping site configuration property,
     the elements of the list are either all usernames (bindID of "username") or all email
@@ -182,6 +200,22 @@ input UserPermission {
     The highest level of repository permission.
     """
     permission: RepositoryPermission = READ
+}
+
+"""
+A user (identified either by username or email address) with its repository permission.
+"""
+type UserPermission {
+    """
+    Depending on the bindID option in the permissions.userMapping site configuration property,
+    the elements of the list are either all usernames (bindID of "username") or all email
+    addresses (bindID of "email").
+    """
+    bindID: String!
+    """
+    The highest level of repository permission.
+    """
+    permission: RepositoryPermission!
 }
 
 """
@@ -245,4 +279,70 @@ input FetchPermissionsOptions {
     sync should be invalidated.
     """
     invalidateCaches: Boolean
+}
+
+type BitbucketProjectPermissionJobs {
+    """
+    Number of jobs.
+    """
+    count: Int!
+    """
+    Bitbucket Projects permission sync jobs.
+    """
+    jobs: [BitbucketProjectPermissionJob!]!
+}
+
+type BitbucketProjectPermissionJob {
+    """
+    Internal ID of the job.
+    """
+    InternalJobID: Int!
+    """
+    State of the job (queued, processing, completed, errored, failed).
+    """
+    State: String!
+    """
+    Failure message in case of unsuccessful job execution.
+    """
+    FailureMessage: String
+    """
+    The time when the job was enqueued for processing.
+    """
+    QueuedAt: DateTime!
+    """
+    The time when the job started processing. Null, if not yet started.
+    """
+    StartedAt: DateTime
+    """
+    The time when the job finished processing. Null, if not yet finished.
+    """
+    FinishedAt: DateTime
+    """
+    Controls the time after which the job is visible for processing.
+    """
+    ProcessAfter: DateTime
+    """
+    The number of times when the job is moved back from failed to queued.
+    """
+    NumResets: Int!
+    """
+    The number of times when the job entered the errored state.
+    """
+    NumFailures: Int!
+    """
+    Bitbucket project key.
+    """
+    ProjectKey: String!
+    """
+    ID of external service which project is being synchronized.
+    """
+    ExternalServiceID: ID!
+    """
+    User permissions to be granted.
+    """
+    Permissions: [UserPermission!]!
+    """
+    Shows that current project is accessible by any user of the project.
+    """
+    Unrestricted: Boolean!
 }

--- a/enterprise/cmd/frontend/internal/authz/resolvers/bitbucket_projects_permission_jobs.go
+++ b/enterprise/cmd/frontend/internal/authz/resolvers/bitbucket_projects_permission_jobs.go
@@ -19,11 +19,11 @@ func NewBitbucketProjectsPermissionJobsResolver(jobs []*types.BitbucketProjectPe
 	}
 }
 
-func (b bitbucketProjectsPermissionJobsResolver) Count() int32 {
+func (b bitbucketProjectsPermissionJobsResolver) TotalCount() int32 {
 	return int32(len(b.jobs))
 }
 
-func (b bitbucketProjectsPermissionJobsResolver) Jobs() ([]graphqlbackend.BitbucketProjectsPermissionJobResolver, error) {
+func (b bitbucketProjectsPermissionJobsResolver) Nodes() ([]graphqlbackend.BitbucketProjectsPermissionJobResolver, error) {
 	resolvers := make([]graphqlbackend.BitbucketProjectsPermissionJobResolver, 0, len(b.jobs))
 	for _, job := range b.jobs {
 		resolvers = append(resolvers, convertJobToResolver(job))

--- a/enterprise/cmd/frontend/internal/authz/resolvers/bitbucket_projects_permission_jobs.go
+++ b/enterprise/cmd/frontend/internal/authz/resolvers/bitbucket_projects_permission_jobs.go
@@ -1,0 +1,120 @@
+package resolvers
+
+import (
+	"strings"
+
+	"github.com/graph-gophers/graphql-go"
+
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
+	"github.com/sourcegraph/sourcegraph/internal/types"
+)
+
+type bitbucketProjectsPermissionJobsResolver struct {
+	jobs []*types.BitbucketProjectPermissionJob
+}
+
+func NewBitbucketProjectsPermissionJobsResolver(jobs []*types.BitbucketProjectPermissionJob) graphqlbackend.BitbucketProjectsPermissionJobsResolver {
+	return &bitbucketProjectsPermissionJobsResolver{
+		jobs: jobs,
+	}
+}
+
+func (b bitbucketProjectsPermissionJobsResolver) Count() int32 {
+	return int32(len(b.jobs))
+}
+
+func (b bitbucketProjectsPermissionJobsResolver) Jobs() ([]graphqlbackend.BitbucketProjectsPermissionJobResolver, error) {
+	resolvers := make([]graphqlbackend.BitbucketProjectsPermissionJobResolver, 0, len(b.jobs))
+	for _, job := range b.jobs {
+		resolvers = append(resolvers, convertJobToResolver(job))
+	}
+	return resolvers, nil
+}
+
+func convertJobToResolver(job *types.BitbucketProjectPermissionJob) graphqlbackend.BitbucketProjectsPermissionJobResolver {
+	return bitbucketProjectsPermissionJobResolver{job: *job}
+}
+
+type bitbucketProjectsPermissionJobResolver struct {
+	job types.BitbucketProjectPermissionJob
+}
+
+func (j bitbucketProjectsPermissionJobResolver) InternalJobID() int32 {
+	return int32(j.job.ID)
+}
+
+func (j bitbucketProjectsPermissionJobResolver) State() string {
+	return j.job.State
+}
+
+func (j bitbucketProjectsPermissionJobResolver) FailureMessage() *string {
+	return j.job.FailureMessage
+}
+
+func (j bitbucketProjectsPermissionJobResolver) QueuedAt() graphqlbackend.DateTime {
+	return graphqlbackend.DateTime{Time: j.job.QueuedAt}
+}
+
+func (j bitbucketProjectsPermissionJobResolver) StartedAt() *graphqlbackend.DateTime {
+	return graphqlbackend.DateTimeOrNil(j.job.StartedAt)
+}
+
+func (j bitbucketProjectsPermissionJobResolver) FinishedAt() *graphqlbackend.DateTime {
+	return graphqlbackend.DateTimeOrNil(j.job.FinishedAt)
+}
+
+func (j bitbucketProjectsPermissionJobResolver) ProcessAfter() *graphqlbackend.DateTime {
+	return graphqlbackend.DateTimeOrNil(j.job.ProcessAfter)
+}
+
+func (j bitbucketProjectsPermissionJobResolver) NumResets() int32 {
+	return int32(j.job.NumResets)
+}
+
+func (j bitbucketProjectsPermissionJobResolver) NumFailures() int32 {
+	return int32(j.job.NumFailures)
+}
+
+func (j bitbucketProjectsPermissionJobResolver) ProjectKey() string {
+	return j.job.ProjectKey
+}
+
+func (j bitbucketProjectsPermissionJobResolver) ExternalServiceID() graphql.ID {
+	return graphqlbackend.MarshalExternalServiceID(j.job.ExternalServiceID)
+}
+
+func (j bitbucketProjectsPermissionJobResolver) Permissions() []graphqlbackend.UserPermissionResolver {
+	return permissionsToPermissionResolvers(j.job.Permissions)
+}
+
+func (j bitbucketProjectsPermissionJobResolver) Unrestricted() bool {
+	return j.job.Unrestricted
+}
+
+type userPermissionResolver struct {
+	bindID     string
+	permission string
+}
+
+func NewUserPermissionResolver(bindID, permission string) graphqlbackend.UserPermissionResolver {
+	return userPermissionResolver{
+		bindID:     bindID,
+		permission: permission,
+	}
+}
+
+func permissionsToPermissionResolvers(perms []types.UserPermission) []graphqlbackend.UserPermissionResolver {
+	resolvers := make([]graphqlbackend.UserPermissionResolver, 0, len(perms))
+	for _, perm := range perms {
+		resolvers = append(resolvers, NewUserPermissionResolver(perm.BindID, perm.Permission))
+	}
+	return resolvers
+}
+
+func (u userPermissionResolver) BindID() string {
+	return u.bindID
+}
+
+func (u userPermissionResolver) Permission() string {
+	return strings.ToUpper(u.permission)
+}

--- a/enterprise/cmd/frontend/internal/authz/resolvers/resolver.go
+++ b/enterprise/cmd/frontend/internal/authz/resolvers/resolver.go
@@ -428,6 +428,7 @@ var jobStatuses = map[string]bool{
 	"queued":     true,
 	"processing": true,
 	"completed":  true,
+	"canceled":   true,
 	"errored":    true,
 	"failed":     true,
 }
@@ -442,7 +443,7 @@ func (r *Resolver) BitbucketProjectPermissionJobs(ctx context.Context, args *gra
 	}
 	loweredAndTrimmedStatus := strings.ToLower(strings.TrimSpace(getOrDefault(args.Status)))
 	if loweredAndTrimmedStatus != "" && !jobStatuses[loweredAndTrimmedStatus] {
-		return nil, errors.New("Please provide one of the following job statuses: queued, processing, completed, errored, failed")
+		return nil, errors.New("Please provide one of the following job statuses: queued, processing, completed, canceled, errored, failed")
 	}
 	args.Status = &loweredAndTrimmedStatus
 

--- a/enterprise/cmd/frontend/internal/authz/resolvers/resolver.go
+++ b/enterprise/cmd/frontend/internal/authz/resolvers/resolver.go
@@ -424,6 +424,58 @@ func (r *Resolver) AuthorizedUsers(ctx context.Context, args *graphqlbackend.Rep
 	}, nil
 }
 
+var jobStatuses = map[string]bool{
+	"queued":     true,
+	"processing": true,
+	"completed":  true,
+	"errored":    true,
+	"failed":     true,
+}
+
+func (r *Resolver) BitbucketProjectPermissionJobs(ctx context.Context, args *graphqlbackend.BitbucketProjectPermissionJobsArgs) (graphqlbackend.BitbucketProjectsPermissionJobsResolver, error) {
+	if envvar.SourcegraphDotComMode() {
+		return nil, errDisabledSourcegraphDotCom
+	}
+	// 🚨 SECURITY: Only site admins can query repository permissions.
+	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
+		return nil, err
+	}
+	loweredAndTrimmedStatus := strings.ToLower(strings.TrimSpace(getOrDefault(args.Status)))
+	if loweredAndTrimmedStatus != "" && !jobStatuses[loweredAndTrimmedStatus] {
+		return nil, errors.New("Please provide one of the following job statuses: queued, processing, completed, errored, failed")
+	}
+	args.Status = &loweredAndTrimmedStatus
+
+	jobs, err := r.db.BitbucketProjectPermissions().ListJobs(ctx, convertJobsArgsToOpts(args))
+	if err != nil {
+		return nil, errors.Wrap(err, "getting a list of Bitbucket Projects permission sync jobs")
+	}
+	return NewBitbucketProjectsPermissionJobsResolver(jobs), nil
+}
+
+func convertJobsArgsToOpts(args *graphqlbackend.BitbucketProjectPermissionJobsArgs) database.ListJobsOptions {
+	if args == nil {
+		return database.ListJobsOptions{}
+	}
+
+	return database.ListJobsOptions{
+		ProjectKeys: getOrDefault(args.ProjectKeys),
+		State:       getOrDefault(args.Status),
+		Count:       getOrDefault(args.Count),
+	}
+}
+
+// getOrDefault accepts a pointer of a type T and returns dereferenced value if the pointer
+// is not nil, or zero-value for the given type otherwise
+func getOrDefault[T any](ptr *T) T {
+	var result T
+	if ptr == nil {
+		return result
+	} else {
+		return *ptr
+	}
+}
+
 type permissionsInfoResolver struct {
 	perms        authz.Perms
 	syncedAt     time.Time

--- a/enterprise/cmd/frontend/internal/authz/resolvers/resolver_test.go
+++ b/enterprise/cmd/frontend/internal/authz/resolvers/resolver_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/graph-gophers/graphql-go"
+	gqlerrors "github.com/graph-gophers/graphql-go/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -25,6 +26,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/repoupdater/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/timeutil"
 	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/internal/workerutil"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
@@ -1373,3 +1375,189 @@ func TestResolver_SetSubRepositoryPermissionsForUsers(t *testing.T) {
 		}
 	})
 }
+
+func TestResolver_BitbucketProjectPermissionJobs(t *testing.T) {
+	t.Run("disabled on dotcom", func(t *testing.T) {
+		envvar.MockSourcegraphDotComMode(true)
+
+		users := database.NewStrictMockUserStore()
+		users.GetByCurrentAuthUserFunc.SetDefaultReturn(&types.User{}, nil)
+
+		db := edb.NewStrictMockEnterpriseDB()
+		db.UsersFunc.SetDefaultReturn(users)
+
+		r := &Resolver{db: db}
+
+		ctx := actor.WithActor(context.Background(), &actor.Actor{UID: 1})
+		result, err := r.BitbucketProjectPermissionJobs(ctx, nil)
+
+		require.ErrorIs(t, err, errDisabledSourcegraphDotCom)
+		require.Nil(t, result)
+
+		// Reset the env var for other tests.
+		envvar.MockSourcegraphDotComMode(false)
+	})
+
+	t.Run("authenticated as non-admin", func(t *testing.T) {
+		users := database.NewStrictMockUserStore()
+		users.GetByCurrentAuthUserFunc.SetDefaultReturn(&types.User{}, nil)
+
+		db := edb.NewStrictMockEnterpriseDB()
+		db.UsersFunc.SetDefaultReturn(users)
+
+		r := &Resolver{db: db}
+
+		ctx := actor.WithActor(context.Background(), &actor.Actor{UID: 1})
+		result, err := r.BitbucketProjectPermissionJobs(ctx, nil)
+
+		require.ErrorIs(t, err, backend.ErrMustBeSiteAdmin)
+		require.Nil(t, result)
+	})
+
+	t.Run("incorrect job status", func(t *testing.T) {
+		users := database.NewStrictMockUserStore()
+		users.GetByCurrentAuthUserFunc.SetDefaultReturn(&types.User{SiteAdmin: true}, nil)
+
+		db := edb.NewStrictMockEnterpriseDB()
+		db.UsersFunc.SetDefaultReturn(users)
+
+		ctx := actor.WithActor(context.Background(), &actor.Actor{UID: 1})
+
+		test := &graphqlbackend.Test{
+			Context: ctx,
+			Schema:  mustParseGraphQLSchema(t, db),
+			Query: `
+query {
+  bitbucketProjectPermissionJobs(status:"queueueueud") {
+    count,
+    jobs {
+      InternalJobID,
+      State,
+      Unrestricted,
+      Permissions{
+        bindID,
+        permission
+      }
+    }
+  }
+}
+					`,
+			ExpectedResult: "null",
+			ExpectedErrors: []*gqlerrors.QueryError{
+				{
+					Message: "Please provide one of the following job statuses: queued, processing, completed, errored, failed",
+					Path:    []any{"bitbucketProjectPermissionJobs"},
+				},
+			},
+		}
+
+		graphqlbackend.RunTests(t, []*graphqlbackend.Test{test})
+	})
+
+	t.Run("all job fields successfully returned", func(t *testing.T) {
+		users := database.NewStrictMockUserStore()
+		users.GetByCurrentAuthUserFunc.SetDefaultReturn(&types.User{SiteAdmin: true}, nil)
+
+		db := edb.NewStrictMockEnterpriseDB()
+		db.UsersFunc.SetDefaultReturn(users)
+
+		bbProjects := database.NewMockBitbucketProjectPermissionsStore()
+		bbProjects.ListJobsFunc.SetDefaultReturn([]*types.BitbucketProjectPermissionJob{
+			{
+				ID:                1,
+				State:             "queued",
+				FailureMessage:    stringPtr("failure massage"),
+				QueuedAt:          mustParseTime("2020-01-01"),
+				StartedAt:         timePtr(mustParseTime("2020-01-01")),
+				FinishedAt:        timePtr(mustParseTime("2020-01-01")),
+				ProcessAfter:      timePtr(mustParseTime("2020-01-01")),
+				NumResets:         1,
+				NumFailures:       2,
+				LastHeartbeatAt:   mustParseTime("2020-01-05"),
+				ExecutionLogs:     []workerutil.ExecutionLogEntry{{Key: "key", Command: []string{"command"}, StartTime: mustParseTime("2020-01-06"), ExitCode: intPtr(1), Out: "out", DurationMs: intPtr(1)}},
+				WorkerHostname:    "worker-hostname",
+				ProjectKey:        "project-key",
+				ExternalServiceID: 1,
+				Permissions:       []types.UserPermission{{Permission: "read", BindID: "ayy@lmao.com"}},
+				Unrestricted:      false,
+			},
+		}, nil)
+		db.BitbucketProjectPermissionsFunc.SetDefaultReturn(bbProjects)
+
+		ctx := actor.WithActor(context.Background(), &actor.Actor{UID: 1})
+
+		test := &graphqlbackend.Test{
+			Context: ctx,
+			Schema:  mustParseGraphQLSchema(t, db),
+			Query: `
+query {
+  bitbucketProjectPermissionJobs(count:1) {
+    count,
+    jobs {
+      InternalJobID,
+      State,
+      StartedAt,
+      FailureMessage,
+      QueuedAt,
+      StartedAt,
+      FinishedAt,
+      ProcessAfter,
+      NumResets,
+      NumFailures,
+      ProjectKey,
+      ExternalServiceID,
+      Unrestricted,
+      Permissions{
+        bindID,
+        permission
+      }
+    }
+  }
+}
+					`,
+			ExpectedResult: `
+{
+  "bitbucketProjectPermissionJobs": {
+    "count": 1,
+    "jobs": [
+	  {
+	    "InternalJobID": 1,
+	    "State": "queued",
+	    "StartedAt": "2020-01-01T00:00:00Z",
+	    "FailureMessage": "failure massage",
+	    "QueuedAt": "2020-01-01T00:00:00Z",
+	    "FinishedAt": "2020-01-01T00:00:00Z",
+	    "ProcessAfter": "2020-01-01T00:00:00Z",
+	    "NumResets": 1,
+	    "NumFailures": 2,
+	    "ProjectKey": "project-key",
+	    "ExternalServiceID": "RXh0ZXJuYWxTZXJ2aWNlOjE=",
+	    "Unrestricted": false,
+	    "Permissions": [
+		  {
+		    "bindID": "ayy@lmao.com",
+		    "permission": "READ"
+		  }
+	    ]
+	  }
+    ]
+  }
+}
+`,
+		}
+
+		graphqlbackend.RunTests(t, []*graphqlbackend.Test{test})
+	})
+}
+
+func mustParseTime(v string) time.Time {
+	t, err := time.Parse("2006-01-02", v)
+	if err != nil {
+		panic(err)
+	}
+	return t
+}
+
+func intPtr(v int) *int              { return &v }
+func timePtr(v time.Time) *time.Time { return &v }
+func stringPtr(v string) *string     { return &v }

--- a/enterprise/cmd/frontend/internal/authz/resolvers/resolver_test.go
+++ b/enterprise/cmd/frontend/internal/authz/resolvers/resolver_test.go
@@ -1429,8 +1429,8 @@ func TestResolver_BitbucketProjectPermissionJobs(t *testing.T) {
 			Query: `
 query {
   bitbucketProjectPermissionJobs(status:"queueueueud") {
-    count,
-    jobs {
+    totalCount,
+    nodes {
       InternalJobID,
       State,
       Unrestricted,
@@ -1492,8 +1492,8 @@ query {
 			Query: `
 query {
   bitbucketProjectPermissionJobs(count:1) {
-    count,
-    jobs {
+    totalCount,
+    nodes {
       InternalJobID,
       State,
       StartedAt,
@@ -1518,8 +1518,8 @@ query {
 			ExpectedResult: `
 {
   "bitbucketProjectPermissionJobs": {
-    "count": 1,
-    "jobs": [
+    "totalCount": 1,
+    "nodes": [
 	  {
 	    "InternalJobID": 1,
 	    "State": "queued",

--- a/enterprise/cmd/frontend/internal/authz/resolvers/resolver_test.go
+++ b/enterprise/cmd/frontend/internal/authz/resolvers/resolver_test.go
@@ -1445,7 +1445,7 @@ query {
 			ExpectedResult: "null",
 			ExpectedErrors: []*gqlerrors.QueryError{
 				{
-					Message: "Please provide one of the following job statuses: queued, processing, completed, errored, failed",
+					Message: "Please provide one of the following job statuses: queued, processing, completed, canceled, errored, failed",
 					Path:    []any{"bitbucketProjectPermissionJobs"},
 				},
 			},

--- a/internal/database/bitbucket_project_permissions.go
+++ b/internal/database/bitbucket_project_permissions.go
@@ -132,7 +132,7 @@ func ScanFirstBitbucketProjectPermissionsJob(rows *sql.Rows, queryErr error) (_ 
 type ListJobsOptions struct {
 	ProjectKeys []string
 	State       string
-	Count       int
+	Count       int32
 }
 
 // ListJobs returns a list of types.BitbucketProjectPermissionJob for a given set
@@ -235,7 +235,7 @@ LIMIT %d
 		whereClause = sqlf.Sprintf("WHERE %s", sqlf.Join(where, "AND"))
 	}
 
-	limitNum := 100
+	var limitNum int32 = 100
 
 	if opt.Count > 0 && opt.Count < maxJobsCount {
 		limitNum = opt.Count

--- a/internal/types/bitbucket_permissions.go
+++ b/internal/types/bitbucket_permissions.go
@@ -28,7 +28,7 @@ type BitbucketProjectPermissionJob struct {
 	ExternalServiceID int64
 	// List of user permissions for the Bitbucket Project
 	Permissions []UserPermission
-	// Whether all of the repos of the project are unrestricted
+	// Whether all the repos of the project are unrestricted
 	Unrestricted bool
 }
 


### PR DESCRIPTION
Adding of a GraphQL endpoint which lists Bitbucket Projects permission sync jobs.

A small description of changes, which I hope helps in review:
- `authz.go` contains gql resolver interfaces and endpoint input args struct
- `bitbucket_projects_permission_jobs.go` contains gql resolvers implementation
- `resolver.go` contains endpoint logic (input validation + db queries)

Closes https://github.com/sourcegraph/sourcegraph/issues/36455

## Test plan
Added a unit test, tested manually on local sg instance with different input combinations.
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
