### PR TITLE
sg: automatically run Docker after installing it

### DIFF
--- a/dev/sg/sg_setup_mac.go
+++ b/dev/sg/sg_setup_mac.go
@@ -44,7 +44,7 @@ var macOSDependencies = []dependencyCategory{
 			{
 				name:                 "docker",
 				check:                getCheck("docker-installed"),
-				instructionsCommands: `brew install --cask docker`,
+				instructionsCommands: `brew install --cask docker; open -a Docker`,
 			},
 		},
 		autoFixing:             true,


### PR DESCRIPTION
This is not perfect, as the user needs to give Docker permissions in the app manually, and the check will be red until the user does it, but that's still an improvement. 

@bobheadxi We may want to consider in setup v2 prompting the user to confirm that he did so, making it more explicit. 

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Tested locally, after uninstalling Docker.