### PR TITLE
insights: add proper search default fork/archive params based on insight repos

### DIFF
--- a/enterprise/internal/insights/background/historical_enqueuer.go
+++ b/enterprise/internal/insights/background/historical_enqueuer.go
@@ -629,7 +629,7 @@ func (a *backfillAnalyzer) analyzeSeries(ctx context.Context, bctx *buildSeriesC
 	}
 
 	// Construct the search query that will generate data for this repository and time (revision) tuple.
-	modifiedQuery, err := querybuilder.SingleRepoQuery(query, repoName, revision)
+	modifiedQuery, err := querybuilder.SingleRepoQuery(query, repoName, revision, querybuilder.CodeInsightsQueryDefaults(len(bctx.series.Repositories) == 0))
 	if err != nil {
 		err = errors.Append(err, errors.Wrap(err, "SingleRepoQuery"))
 		return

--- a/enterprise/internal/insights/background/insight_enqueuer.go
+++ b/enterprise/internal/insights/background/insight_enqueuer.go
@@ -108,7 +108,7 @@ func enqueue(ctx context.Context, dataSeries []types.InsightSeries, mode store.P
 		uniqueSeries[seriesID] = series
 
 		// Construct the search query that will generate data for this repository and time (revision) tuple.
-		modifiedQuery, err := querybuilder.GlobalQuery(series.Query)
+		modifiedQuery, err := querybuilder.GlobalQuery(series.Query, querybuilder.CodeInsightsQueryDefaults(len(series.Repositories) == 0))
 		if err != nil {
 			multi = errors.Append(multi, errors.Wrapf(err, "GlobalQuery series_id:%s", seriesID))
 			continue

--- a/enterprise/internal/insights/query/capture_group_executor.go
+++ b/enterprise/internal/insights/query/capture_group_executor.go
@@ -115,7 +115,7 @@ func (c *CaptureGroupExecutor) Execute(ctx context.Context, query string, reposi
 				continue
 			}
 
-			modifiedQuery, err := querybuilder.SingleRepoQuery(query, repository, string(commits[0].ID))
+			modifiedQuery, err := querybuilder.SingleRepoQuery(query, repository, string(commits[0].ID), querybuilder.CodeInsightsQueryDefaults(false))
 			if err != nil {
 				return nil, errors.Wrap(err, "SingleRepoQuery")
 			}

--- a/enterprise/internal/insights/query/querybuilder/builder.go
+++ b/enterprise/internal/insights/query/querybuilder/builder.go
@@ -36,18 +36,22 @@ func withDefaults(inputQuery string, defaults searchquery.Parameters) (string, e
 	return searchquery.StringHuman(modified.ToQ()), nil
 }
 
-// codeInsightsQueryDefaults returns the default query parameters for a Code Insights generated Sourcegraph query.
-func codeInsightsQueryDefaults() searchquery.Parameters {
+// CodeInsightsQueryDefaults returns the default query parameters for a Code Insights generated Sourcegraph query.
+func CodeInsightsQueryDefaults(allReposInsight bool) searchquery.Parameters {
+	forkArchiveValue := searchquery.No
+	if !allReposInsight {
+		forkArchiveValue = searchquery.Yes
+	}
 	return []searchquery.Parameter{
 		{
 			Field:      searchquery.FieldFork,
-			Value:      string(searchquery.No),
+			Value:      string(forkArchiveValue),
 			Negated:    false,
 			Annotation: searchquery.Annotation{},
 		},
 		{
 			Field:      searchquery.FieldArchived,
-			Value:      string(searchquery.No),
+			Value:      string(forkArchiveValue),
 			Negated:    false,
 			Annotation: searchquery.Annotation{},
 		},
@@ -67,11 +71,11 @@ func forRepoRevision(query, repo, revision string) string {
 	return fmt.Sprintf("%s repo:^%s$@%s", query, regexp.QuoteMeta(repo), revision)
 }
 
-// SingleRepoQuery generates a Sourcegraph query with default values given a user specified query and a repository / revision target. The repository string
+// SingleRepoQuery generates a Sourcegraph query with the provided default values given a user specified query and a repository / revision target. The repository string
 // should be provided in plain text, and will be escaped for regexp before being added to the query.
-func SingleRepoQuery(query, repo, revision string) (string, error) {
+func SingleRepoQuery(query, repo, revision string, defaultParams searchquery.Parameters) (string, error) {
 	modified := withCountAll(query)
-	modified, err := withDefaults(modified, codeInsightsQueryDefaults())
+	modified, err := withDefaults(modified, defaultParams)
 	if err != nil {
 		return "", errors.Wrap(err, "WithDefaults")
 	}
@@ -80,10 +84,10 @@ func SingleRepoQuery(query, repo, revision string) (string, error) {
 	return modified, nil
 }
 
-// GlobalQuery generates a Sourcegraph query with default values given a user specified query. This query will be global (against all visible repositories).
-func GlobalQuery(query string) (string, error) {
+// GlobalQuery generates a Sourcegraph query with the provided default values given a user specified query. This query will be global (against all visible repositories).
+func GlobalQuery(query string, defaultParams searchquery.Parameters) (string, error) {
 	modified := withCountAll(query)
-	modified, err := withDefaults(modified, codeInsightsQueryDefaults())
+	modified, err := withDefaults(modified, defaultParams)
 	if err != nil {
 		return "", errors.Wrap(err, "WithDefaults")
 	}

--- a/enterprise/internal/insights/query/querybuilder/builder_test.go
+++ b/enterprise/internal/insights/query/querybuilder/builder_test.go
@@ -68,3 +68,52 @@ func TestWithDefaults(t *testing.T) {
 		})
 	}
 }
+
+func TestDefaults(t *testing.T) {
+	tests := []struct {
+		name  string
+		input bool
+		want  query.Parameters
+	}{
+		{
+			name:  "all repos",
+			input: true,
+			want: query.Parameters{{
+				Field:      query.FieldFork,
+				Value:      string(query.No),
+				Negated:    false,
+				Annotation: query.Annotation{},
+			}, {
+				Field:      query.FieldArchived,
+				Value:      string(query.No),
+				Negated:    false,
+				Annotation: query.Annotation{},
+			}},
+		},
+		{
+			name:  "some repos",
+			input: false,
+			want: query.Parameters{{
+				Field:      query.FieldFork,
+				Value:      string(query.Yes),
+				Negated:    false,
+				Annotation: query.Annotation{},
+			}, {
+				Field:      query.FieldArchived,
+				Value:      string(query.Yes),
+				Negated:    false,
+				Annotation: query.Annotation{},
+			}},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := CodeInsightsQueryDefaults(test.input)
+
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Fatalf("%s failed (want/got): %s", test.name, diff)
+			}
+		})
+	}
+}

--- a/enterprise/internal/insights/query/streaming_query_executor.go
+++ b/enterprise/internal/insights/query/streaming_query_executor.go
@@ -78,7 +78,7 @@ func (c *StreamingQueryExecutor) Execute(ctx context.Context, query string, seri
 				continue
 			}
 
-			modified, err := querybuilder.SingleRepoQuery(query, repository, string(commits[0].ID))
+			modified, err := querybuilder.SingleRepoQuery(query, repository, string(commits[0].ID), querybuilder.CodeInsightsQueryDefaults(false))
 			if err != nil {
 				return nil, errors.Wrap(err, "SingleRepoQuery")
 			}


### PR DESCRIPTION
Updated the default query parameters for insights to the following:

- `fork:no archive:no` for All Repos insights 
- `fork:yes archive:yes` for insights scoped to specific repos

resolves #37287
## Test plan
Created a fork of a repo and found a search query that returned 1 result in repo (and same 1 result in fork).
Created following insights and validated inclusion/exclusion of results from fork

Track Changes Insight:
<img width="774" alt="Screen Shot 2022-06-16 at 10 21 06 AM" src="https://user-images.githubusercontent.com/6098507/174096281-225b6ca7-3e35-4561-84d8-d683c0b4d96b.png">
<img width="747" alt="Screen Shot 2022-06-16 at 10 21 14 AM" src="https://user-images.githubusercontent.com/6098507/174096345-d5dc2d4f-a2a3-495d-bfdd-2d294c104a57.png">

Capture Group Insights:
<img width="1149" alt="Screen Shot 2022-06-16 at 10 34 30 AM" src="https://user-images.githubusercontent.com/6098507/174096565-e8a3c7ad-3a3c-4efd-b609-21a49204cedc.png">
<img width="1137" alt="Screen Shot 2022-06-16 at 10 37 01 AM" src="https://user-images.githubusercontent.com/6098507/174096609-f9f438ee-5e27-4375-97c4-e248d57a4946.png">




<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
