### PR TITLE
sg/check: only render first line of error in Runner checks

### DIFF
--- a/dev/sg/internal/check/runner.go
+++ b/dev/sg/internal/check/runner.go
@@ -239,7 +239,12 @@ func (r *Runner[Args]) runAllCategoryChecks(ctx context.Context, args Args) *run
 					// progress to discard.
 					var updateOutput strings.Builder
 					if err := check.Update(ctx, std.NewFixedOutput(&updateOutput, true), args); err != nil {
-						progress.StatusBarFailf(i, "Check %s failed: %s", check.Name, err.Error())
+						errParts := strings.SplitN(err.Error(), "\n", 2)
+						if len(errParts) > 2 {
+							// truncate to one line - writing multple lines causes some jank
+							errParts[0] += " ..."
+						}
+						progress.StatusBarFailf(i, "Check %s failed: %s", check.Name, errParts[0])
 						check.cachedCheckOutput = updateOutput.String()
 						didErr.Store(true)
 						event = "error"


### PR DESCRIPTION
Multi-line errors cause weirdness in the lint output, this is no good. No big blue box plz

We still render the full error later, this is just for the purposes of seeing issues fast

<img width="1106" alt="image" src="https://user-images.githubusercontent.com/23356519/174154626-73f7bf6d-bcdc-4c70-bcc5-352ecb706b18.png">


## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

```
go run ./dev/sg lint
```