### PR TITLE
batches: omit monaco editor from Chromatic/Percy snapshot comparisons

### DIFF
--- a/client/web/src/enterprise/batches/batch-spec/edit/editor/MonacoBatchSpecEditor.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/edit/editor/MonacoBatchSpecEditor.tsx
@@ -80,7 +80,7 @@ export class MonacoBatchSpecEditor extends React.PureComponent<Props, State> {
     public render(): JSX.Element | null {
         return (
             <MonacoEditor
-                className={classNames(styles.editor, this.props.className)}
+                className={classNames('percy-hide chromatic-ignore', styles.editor, this.props.className)}
                 language="yaml"
                 height="auto"
                 isLightTheme={this.props.isLightTheme}


### PR DESCRIPTION
See title. 🙂 We're not trying to test the Monaco editor, and it sometimes produces a diff with Chromatic and Percy.

## Test plan

Will review Percy/Chromatic runs to verify the editor is hidden.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-kr-omit-monaco-editor-in.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-ooluqucdyh.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
