### PR TITLE
insights: add index for finished_at and process_after on code insights queue

### DIFF
--- a/internal/database/schema.json
+++ b/internal/database/schema.json
@@ -9076,6 +9076,16 @@
           "ConstraintDefinition": "PRIMARY KEY (id)"
         },
         {
+          "Name": "finished_at_insights_query_runner_jobs_idx",
+          "IsPrimaryKey": false,
+          "IsUnique": false,
+          "IsExclusion": false,
+          "IsDeferrable": false,
+          "IndexDefinition": "CREATE INDEX finished_at_insights_query_runner_jobs_idx ON insights_query_runner_jobs USING btree (finished_at)",
+          "ConstraintType": "",
+          "ConstraintDefinition": ""
+        },
+        {
           "Name": "insights_query_runner_jobs_cost_idx",
           "IsPrimaryKey": false,
           "IsUnique": false,
@@ -9112,6 +9122,16 @@
           "IsExclusion": false,
           "IsDeferrable": false,
           "IndexDefinition": "CREATE INDEX insights_query_runner_jobs_state_btree ON insights_query_runner_jobs USING btree (state)",
+          "ConstraintType": "",
+          "ConstraintDefinition": ""
+        },
+        {
+          "Name": "process_after_insights_query_runner_jobs_idx",
+          "IsPrimaryKey": false,
+          "IsUnique": false,
+          "IsExclusion": false,
+          "IsDeferrable": false,
+          "IndexDefinition": "CREATE INDEX process_after_insights_query_runner_jobs_idx ON insights_query_runner_jobs USING btree (process_after)",
           "ConstraintType": "",
           "ConstraintDefinition": ""
         }

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -1203,10 +1203,12 @@ Indexes:
  queued_at         | timestamp with time zone |           |          | now()
 Indexes:
     "insights_query_runner_jobs_pkey" PRIMARY KEY, btree (id)
+    "finished_at_insights_query_runner_jobs_idx" btree (finished_at)
     "insights_query_runner_jobs_cost_idx" btree (cost)
     "insights_query_runner_jobs_priority_idx" btree (priority)
     "insights_query_runner_jobs_processable_priority_id" btree (priority, id) WHERE state = 'queued'::text OR state = 'errored'::text
     "insights_query_runner_jobs_state_btree" btree (state)
+    "process_after_insights_query_runner_jobs_idx" btree (process_after)
 Referenced by:
     TABLE "insights_query_runner_jobs_dependencies" CONSTRAINT "insights_query_runner_jobs_dependencies_fk_job_id" FOREIGN KEY (job_id) REFERENCES insights_query_runner_jobs(id) ON DELETE CASCADE
 

--- a/migrations/frontend/1655412173/down.sql
+++ b/migrations/frontend/1655412173/down.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS process_after_insights_query_runner_jobs_idx;
+DROP INDEX IF EXISTS process_after_insights_query_runner_jobs_idx;

--- a/migrations/frontend/1655412173/metadata.yaml
+++ b/migrations/frontend/1655412173/metadata.yaml
@@ -1,0 +1,2 @@
+name: code_insights_queue_missing_index
+parents: [1655328928]

--- a/migrations/frontend/1655412173/up.sql
+++ b/migrations/frontend/1655412173/up.sql
@@ -1,0 +1,5 @@
+CREATE INDEX IF NOT EXISTS process_after_insights_query_runner_jobs_idx
+    ON insights_query_runner_jobs (process_after);
+
+CREATE INDEX IF NOT EXISTS finished_at_insights_query_runner_jobs_idx
+    ON insights_query_runner_jobs (finished_at);

--- a/migrations/frontend/squashed.sql
+++ b/migrations/frontend/squashed.sql
@@ -3586,6 +3586,8 @@ CREATE INDEX feature_flag_overrides_org_id ON feature_flag_overrides USING btree
 
 CREATE INDEX feature_flag_overrides_user_id ON feature_flag_overrides USING btree (namespace_user_id) WHERE (namespace_user_id IS NOT NULL);
 
+CREATE INDEX finished_at_insights_query_runner_jobs_idx ON insights_query_runner_jobs USING btree (finished_at);
+
 CREATE INDEX gitserver_repos_cloned_status_idx ON gitserver_repos USING btree (repo_id) WHERE (clone_status = 'cloned'::text);
 
 CREATE INDEX gitserver_repos_cloning_status_idx ON gitserver_repos USING btree (repo_id) WHERE (clone_status = 'cloning'::text);
@@ -3669,6 +3671,8 @@ CREATE INDEX org_invitations_org_id ON org_invitations USING btree (org_id) WHER
 CREATE INDEX org_invitations_recipient_user_id ON org_invitations USING btree (recipient_user_id) WHERE (deleted_at IS NULL);
 
 CREATE UNIQUE INDEX orgs_name ON orgs USING btree (name) WHERE (deleted_at IS NULL);
+
+CREATE INDEX process_after_insights_query_runner_jobs_idx ON insights_query_runner_jobs USING btree (process_after);
 
 CREATE INDEX registry_extension_releases_registry_extension_id ON registry_extension_releases USING btree (registry_extension_id, release_tag, created_at DESC) WHERE (deleted_at IS NULL);
 


### PR DESCRIPTION
Part of https://github.com/sourcegraph/sourcegraph/issues/37351

Adds missing indices for columns that are now more important in the selection of worker records.

## Test plan

Ran the migration
