### PR TITLE
batches: disable button to permanently dismiss "Download for src-cli" modal

### DIFF
--- a/client/web/src/enterprise/batches/batch-spec/edit/DownloadSpecModal.story.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/edit/DownloadSpecModal.story.tsx
@@ -17,9 +17,9 @@ add('DownloadSpecModal', () => (
                 setIsDownloadSpecModalOpen={function (): void {
                     throw new Error('Function not implemented.')
                 }}
-                setDownloadSpecModalDismissed={function (): void {
-                    throw new Error('Function not implemented.')
-                }}
+                // setDownloadSpecModalDismissed={function (): void {
+                //     throw new Error('Function not implemented.')
+                // }}
                 {...props}
             />
         )}

--- a/client/web/src/enterprise/batches/batch-spec/edit/DownloadSpecModal.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/edit/DownloadSpecModal.tsx
@@ -10,12 +10,17 @@ import { BatchSpecDownloadLink, getFileName } from '../../BatchSpec'
 
 import styles from './DownloadSpecModal.module.scss'
 
+// TODO: Several lines have been commented out to disable the "Don't show this again"
+// functionality for "Download spec for src-cli" modal.
+// See https://github.com/sourcegraph/sourcegraph/issues/37360.
+// Uncomment all of these lines to restore it.
+
 export interface DownloadSpecModalProps {
     name: string
     originalInput: string
     isLightTheme: boolean
     setIsDownloadSpecModalOpen: (condition: boolean) => void
-    setDownloadSpecModalDismissed: (condition: boolean) => void
+    // setDownloadSpecModalDismissed: (condition: boolean) => void
 }
 
 export const DownloadSpecModal: React.FunctionComponent<React.PropsWithChildren<DownloadSpecModalProps>> = ({
@@ -23,7 +28,7 @@ export const DownloadSpecModal: React.FunctionComponent<React.PropsWithChildren<
     originalInput,
     isLightTheme,
     setIsDownloadSpecModalOpen,
-    setDownloadSpecModalDismissed,
+    // setDownloadSpecModalDismissed,
 }) => (
     <Modal
         onDismiss={() => {
@@ -76,10 +81,10 @@ export const DownloadSpecModal: React.FunctionComponent<React.PropsWithChildren<
             </div>
         </div>
         <div className="d-flex justify-content-between">
-            <Button className="p-0" onClick={() => setDownloadSpecModalDismissed(true)} variant="link">
+            {/* <Button className="p-0" onClick={() => setDownloadSpecModalDismissed(true)} variant="link">
                 Don't show this again
-            </Button>
-            <div>
+            </Button> */}
+            <div className="ml-auto">
                 <Button
                     className="mr-2"
                     outline={true}

--- a/client/web/src/enterprise/batches/batch-spec/edit/EditBatchSpecPage.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/edit/EditBatchSpecPage.tsx
@@ -5,7 +5,7 @@ import { useHistory } from 'react-router'
 
 import { useQuery } from '@sourcegraph/http-client'
 import { Settings, SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
-import { useTemporarySetting } from '@sourcegraph/shared/src/settings/temporary/useTemporarySetting'
+// import { useTemporarySetting } from '@sourcegraph/shared/src/settings/temporary/useTemporarySetting'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
 import { Button, Icon, LoadingSpinner, H4, Alert } from '@sourcegraph/wildcard'
 
@@ -18,7 +18,7 @@ import {
     GetBatchChangeToEditVariables,
     Scalars,
 } from '../../../../graphql-operations'
-import { BatchSpecDownloadLink } from '../../BatchSpec'
+// import { BatchSpecDownloadLink } from '../../BatchSpec'
 import { EXECUTORS, GET_BATCH_CHANGE_TO_EDIT } from '../../create/backend'
 import { ConfigurationForm } from '../../create/ConfigurationForm'
 import { InsightTemplatesBanner } from '../../create/InsightTemplatesBanner'
@@ -155,10 +155,13 @@ const MemoizedEditBatchSpecPageContent: React.FunctionComponent<
 
     const [isDownloadSpecModalOpen, setIsDownloadSpecModalOpen] = useState(false)
     const [isRunServerSideModalOpen, setIsRunServerSideModalOpen] = useState(false)
-    const [downloadSpecModalDismissed, setDownloadSpecModalDismissed] = useTemporarySetting(
-        'batches.downloadSpecModalDismissed',
-        false
-    )
+    // NOTE: Uncomment these lines to restore "Don't show this again" functionality for
+    // "Download spec for src-cli" modal.
+    // const [downloadSpecModalDismissed, setDownloadSpecModalDismissed] = useTemporarySetting(
+    //     'batches.downloadSpecModalDismissed',
+    //     false
+    // )
+
     /**
      * For managed instances we want to hide the `run server side` button by default. To do this we make use of a
      * feature flag to ensure Managed Instances.
@@ -173,6 +176,8 @@ const MemoizedEditBatchSpecPageContent: React.FunctionComponent<
                 options={editor.executionOptions}
                 onChangeOptions={editor.setExecutionOptions}
             />
+            {/* NOTE: Uncomment these lines to restore "Don't show this again" functionality
+            for "Download spec for src-cli" modal.
             {downloadSpecModalDismissed ? (
                 <BatchSpecDownloadLink
                     name={batchChange.name}
@@ -182,16 +187,18 @@ const MemoizedEditBatchSpecPageContent: React.FunctionComponent<
                 >
                     or download for src-cli
                 </BatchSpecDownloadLink>
-            ) : (
-                <Button className={styles.downloadLink} variant="link" onClick={() => setIsDownloadSpecModalOpen(true)}>
-                    or download for src-cli
-                </Button>
-            )}
+            ) : ( */}
+            <Button className={styles.downloadLink} variant="link" onClick={() => setIsDownloadSpecModalOpen(true)}>
+                or download for src-cli
+            </Button>
+            {/* )} */}
         </>
     )
 
     const noActiveExecutorsActionButtons = (
         <>
+            {/* NOTE: Uncomment these lines to restore "Don't show this again" functionality
+            for "Download spec for src-cli" modal.
             {downloadSpecModalDismissed ? (
                 <BatchSpecDownloadLink
                     name={batchChange.name}
@@ -202,11 +209,11 @@ const MemoizedEditBatchSpecPageContent: React.FunctionComponent<
                 >
                     Download for src-cli
                 </BatchSpecDownloadLink>
-            ) : (
-                <Button className="mb-2" variant="primary" onClick={() => setIsDownloadSpecModalOpen(true)}>
-                    Download for src-cli
-                </Button>
-            )}
+            ) : ( */}
+            <Button className="mb-2" variant="primary" onClick={() => setIsDownloadSpecModalOpen(true)}>
+                Download for src-cli
+            </Button>
+            {/* )} */}
 
             {!isRunBatchSpecButtonHidden && (
                 <Button
@@ -278,12 +285,14 @@ const MemoizedEditBatchSpecPageContent: React.FunctionComponent<
                 </div>
             )}
 
-            {isDownloadSpecModalOpen && !downloadSpecModalDismissed ? (
+            {isDownloadSpecModalOpen ? (
                 <DownloadSpecModal
                     name={batchChange.name}
                     originalInput={editor.code}
                     isLightTheme={isLightTheme}
-                    setDownloadSpecModalDismissed={setDownloadSpecModalDismissed}
+                    // NOTE: Uncomment this line to restore "Don't show this again"
+                    // functionality for "Download spec for src-cli" modal.
+                    // setDownloadSpecModalDismissed={setDownloadSpecModalDismissed}
                     setIsDownloadSpecModalOpen={setIsDownloadSpecModalOpen}
                 />
             ) : null}


### PR DESCRIPTION
It seems in the best interest of our new UI to disable the button that allows users to permanently dismiss the "Download for src-cli" modal that opens when you click the button to download your batch spec. Once the UI has had a bit more time to bake, we can consider restoring it. Follow-up ticket to track: https://github.com/sourcegraph/sourcegraph/issues/37360.

Users who have previously permanently dismissed the modal (aka a lot of us on k8s) will also be able to see it once more.

![image](https://user-images.githubusercontent.com/8942601/174162567-77bbde76-c4fb-4244-9cd2-50dc421099f9.png)

## Test plan

Just tested locally.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
