### PR TITLE
undoing link wrapped tooltips

### DIFF
--- a/client/branded/src/components/panel/views/__snapshots__/HierarchicalLocationsView.test.tsx.snap
+++ b/client/branded/src/components/panel/views/__snapshots__/HierarchicalLocationsView.test.tsx.snap
@@ -91,29 +91,23 @@ exports[`<HierarchicalLocationsView /> displays a single location when complete 
                 class="headerTitle test-search-result-label"
                 data-testid="result-container-header"
               >
-                <span
-                  class="tooltip"
-                  data-state="closed"
-                  role="presentation"
+                <div
+                  class="ml-1 flex-shrink-past-contents text-truncate"
                 >
-                  <div
-                    class="ml-1 flex-shrink-past-contents text-truncate"
+                  <a
+                    class="anchorLink"
+                    href="/github.com/foo/bar"
                   >
-                    <a
-                      class="anchorLink"
-                      href="/github.com/foo/bar"
-                    >
-                      foo/bar
-                    </a>
-                     › 
-                    <a
-                      class="anchorLink"
-                      href="/github.com/foo/bar/-/blob/?subtree=true"
-                    >
-                      <strong />
-                    </a>
-                  </div>
-                </span>
+                    foo/bar
+                  </a>
+                   › 
+                  <a
+                    class="anchorLink"
+                    href="/github.com/foo/bar/-/blob/?subtree=true"
+                  >
+                    <strong />
+                  </a>
+                </div>
                 <span
                   class="ml-2 headerDescription"
                 />
@@ -355,31 +349,25 @@ exports[`<HierarchicalLocationsView /> displays multiple locations grouped by fi
                 class="headerTitle test-search-result-label"
                 data-testid="result-container-header"
               >
-                <span
-                  class="tooltip"
-                  data-state="closed"
-                  role="presentation"
+                <div
+                  class="ml-1 flex-shrink-past-contents text-truncate"
                 >
-                  <div
-                    class="ml-1 flex-shrink-past-contents text-truncate"
+                  <a
+                    class="anchorLink"
+                    href="/github.com/foo/bar"
                   >
-                    <a
-                      class="anchorLink"
-                      href="/github.com/foo/bar"
-                    >
-                      foo/bar
-                    </a>
-                     › 
-                    <a
-                      class="anchorLink"
-                      href="/github.com/foo/bar/-/blob/file1.txt?subtree=true"
-                    >
-                      <strong>
-                        file1.txt
-                      </strong>
-                    </a>
-                  </div>
-                </span>
+                    foo/bar
+                  </a>
+                   › 
+                  <a
+                    class="anchorLink"
+                    href="/github.com/foo/bar/-/blob/file1.txt?subtree=true"
+                  >
+                    <strong>
+                      file1.txt
+                    </strong>
+                  </a>
+                </div>
                 <span
                   class="ml-2 headerDescription"
                 />
@@ -575,29 +563,23 @@ exports[`<HierarchicalLocationsView /> displays partial locations before complet
                 class="headerTitle test-search-result-label"
                 data-testid="result-container-header"
               >
-                <span
-                  class="tooltip"
-                  data-state="closed"
-                  role="presentation"
+                <div
+                  class="ml-1 flex-shrink-past-contents text-truncate"
                 >
-                  <div
-                    class="ml-1 flex-shrink-past-contents text-truncate"
+                  <a
+                    class="anchorLink"
+                    href="/github.com/foo/bar"
                   >
-                    <a
-                      class="anchorLink"
-                      href="/github.com/foo/bar"
-                    >
-                      foo/bar
-                    </a>
-                     › 
-                    <a
-                      class="anchorLink"
-                      href="/github.com/foo/bar/-/blob/?subtree=true"
-                    >
-                      <strong />
-                    </a>
-                  </div>
-                </span>
+                    foo/bar
+                  </a>
+                   › 
+                  <a
+                    class="anchorLink"
+                    href="/github.com/foo/bar/-/blob/?subtree=true"
+                  >
+                    <strong />
+                  </a>
+                </div>
                 <span
                   class="ml-2 headerDescription"
                 />

--- a/client/search-ui/src/components/CommitSearchResult.tsx
+++ b/client/search-ui/src/components/CommitSearchResult.tsx
@@ -7,7 +7,7 @@ import { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
 import { CommitMatch, getCommitMatchUrl, getRepositoryUrl } from '@sourcegraph/shared/src/search/stream'
 // eslint-disable-next-line no-restricted-imports
 import { Timestamp } from '@sourcegraph/web/src/components/time/Timestamp'
-import { Link, Code, useIsTruncated, Tooltip } from '@sourcegraph/wildcard'
+import { Link, Code, useIsTruncated } from '@sourcegraph/wildcard'
 
 import { CommitSearchResultMatch } from './CommitSearchResultMatch'
 import { ResultContainer } from './ResultContainer'
@@ -38,21 +38,20 @@ export const CommitSearchResult: React.FunctionComponent<Props> = ({
 
     const renderTitle = (): JSX.Element => (
         <div className={styles.title}>
-            <Tooltip content={(truncated && `${result.authorName}: ${result.message.split('\n', 1)[0]}`) || null}>
-                <span
-                    onMouseEnter={checkTruncation}
-                    className="test-search-result-label ml-1 flex-shrink-past-contents text-truncate"
-                    ref={titleReference}
-                >
-                    <>
-                        <Link to={getRepositoryUrl(result.repository)}>{displayRepoName(result.repository)}</Link>
-                        {' › '}
-                        <Link to={getCommitMatchUrl(result)}>{result.authorName}</Link>
-                        {': '}
-                        <Link to={getCommitMatchUrl(result)}>{result.message.split('\n', 1)[0]}</Link>
-                    </>
-                </span>
-            </Tooltip>
+            <span
+                onMouseEnter={checkTruncation}
+                className="test-search-result-label ml-1 flex-shrink-past-contents text-truncate"
+                ref={titleReference}
+                data-tooltip={(truncated && `${result.authorName}: ${result.message.split('\n', 1)[0]}`) || null}
+            >
+                <>
+                    <Link to={getRepositoryUrl(result.repository)}>{displayRepoName(result.repository)}</Link>
+                    {' › '}
+                    <Link to={getCommitMatchUrl(result)}>{result.authorName}</Link>
+                    {': '}
+                    <Link to={getCommitMatchUrl(result)}>{result.message.split('\n', 1)[0]}</Link>
+                </>
+            </span>
             <span className={styles.spacer} />
             <Link to={getCommitMatchUrl(result)}>
                 <Code className={styles.commitOid}>{result.oid.slice(0, 7)}</Code>{' '}

--- a/client/search-ui/src/components/RepoFileLink.tsx
+++ b/client/search-ui/src/components/RepoFileLink.tsx
@@ -4,7 +4,7 @@ import classNames from 'classnames'
 
 import { appendSubtreeQueryParameter } from '@sourcegraph/common'
 import { displayRepoName, splitPath } from '@sourcegraph/shared/src/components/RepoLink'
-import { useIsTruncated, Link, Tooltip } from '@sourcegraph/wildcard'
+import { useIsTruncated, Link } from '@sourcegraph/wildcard'
 
 interface Props {
     repoName: string
@@ -36,14 +36,17 @@ export const RepoFileLink: React.FunctionComponent<React.PropsWithChildren<Props
     const [titleReference, truncated, checkTruncation] = useIsTruncated()
 
     return (
-        <Tooltip content={truncated ? (fileBase ? `${fileBase}/${fileName}` : fileName) : null}>
-            <div ref={titleReference} onMouseEnter={checkTruncation} className={classNames(className)}>
-                <Link to={repoURL}>{repoDisplayName || displayRepoName(repoName)}</Link> ›{' '}
-                <Link to={appendSubtreeQueryParameter(fileURL)}>
-                    {fileBase ? `${fileBase}/` : null}
-                    <strong>{fileName}</strong>
-                </Link>
-            </div>
-        </Tooltip>
+        <div
+            ref={titleReference}
+            onMouseEnter={checkTruncation}
+            className={classNames(className)}
+            data-tooltip={truncated ? (fileBase ? `${fileBase}/${fileName}` : fileName) : null}
+        >
+            <Link to={repoURL}>{repoDisplayName || displayRepoName(repoName)}</Link> ›{' '}
+            <Link to={appendSubtreeQueryParameter(fileURL)}>
+                {fileBase ? `${fileBase}/` : null}
+                <strong>{fileName}</strong>
+            </Link>
+        </div>
     )
 }

--- a/client/search-ui/src/components/RepoSearchResult.tsx
+++ b/client/search-ui/src/components/RepoSearchResult.tsx
@@ -8,7 +8,7 @@ import SourceRepositoryIcon from 'mdi-react/SourceRepositoryIcon'
 
 import { displayRepoName } from '@sourcegraph/shared/src/components/RepoLink'
 import { getRepoMatchLabel, getRepoMatchUrl, RepositoryMatch } from '@sourcegraph/shared/src/search/stream'
-import { Icon, Link, Tooltip, useIsTruncated } from '@sourcegraph/wildcard'
+import { Icon, Link, useIsTruncated } from '@sourcegraph/wildcard'
 
 import { LastSyncedIcon } from './LastSyncedIcon'
 import { ResultContainer } from './ResultContainer'
@@ -35,15 +35,14 @@ export const RepoSearchResult: React.FunctionComponent<RepoSearchResultProps> = 
 
     const renderTitle = (): JSX.Element => (
         <div className={styles.title}>
-            <Tooltip content={(truncated && displayRepoName(getRepoMatchLabel(result))) || null}>
-                <span
-                    onMouseEnter={checkTruncation}
-                    className="test-search-result-label ml-1 flex-shrink-past-contents text-truncate"
-                    ref={titleReference}
-                >
-                    <Link to={getRepoMatchUrl(result)}>{displayRepoName(getRepoMatchLabel(result))}</Link>
-                </span>
-            </Tooltip>
+            <span
+                onMouseEnter={checkTruncation}
+                className="test-search-result-label ml-1 flex-shrink-past-contents text-truncate"
+                ref={titleReference}
+                data-tooltip={(truncated && displayRepoName(getRepoMatchLabel(result))) || null}
+            >
+                <Link to={getRepoMatchUrl(result)}>{displayRepoName(getRepoMatchLabel(result))}</Link>
+            </span>
         </div>
     )
 

--- a/client/search-ui/src/components/__snapshots__/RepoFileLink.test.tsx.snap
+++ b/client/search-ui/src/components/__snapshots__/RepoFileLink.test.tsx.snap
@@ -2,31 +2,25 @@
 
 exports[`RepoFileLink renders 1`] = `
 <DocumentFragment>
-  <span
-    class="tooltip"
-    data-state="closed"
-    role="presentation"
+  <div
+    class=""
   >
-    <div
-      class=""
+    <a
+      class="anchorLink"
+      href="https://example.com"
     >
-      <a
-        class="anchorLink"
-        href="https://example.com"
-      >
-        my/repo
-      </a>
-       › 
-      <a
-        class="anchorLink"
-        href="/file?subtree=true"
-      >
-        my/
-        <strong>
-          file
-        </strong>
-      </a>
-    </div>
-  </span>
+      my/repo
+    </a>
+     › 
+    <a
+      class="anchorLink"
+      href="/file?subtree=true"
+    >
+      my/
+      <strong>
+        file
+      </strong>
+    </a>
+  </div>
 </DocumentFragment>
 `;


### PR DESCRIPTION
## Test plan
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->


cmd click repo links and you should be able to open in new tab

![image](https://user-images.githubusercontent.com/6912393/174194487-3fb181e6-c600-4296-ba29-b08999bbf9a8.png)


check this [thread](https://sourcegraph.slack.com/archives/C0W2E592M/p1655421300270239?thread_ts=1655238774.999319&cid=C0W2E592M) for context
## App preview:

- [Web](https://sg-web-jg-revert-tooltip.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-heotibadky.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
