### PR TITLE
batches: prevent layout shift on workspace step tabs

### DIFF
--- a/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspaceDetails.module.scss
+++ b/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspaceDetails.module.scss
@@ -81,3 +81,28 @@
         line-height: 1rem;
     }
 }
+
+.step-tabs {
+    [data-reach-tab],
+    [data-reach-tab]:hover,
+    [data-reach-tab][data-selected] {
+        :global(.text-content) {
+            display: inline-flex;
+            align-items: center;
+            flex-direction: column;
+            justify-content: center;
+
+            // ::after used here for avoids the CLS when the font-weight change (see: https://css-tricks.com/bold-on-hover-without-the-layout-shift/)
+            &::after {
+                content: attr(data-tab-content);
+                height: 0;
+                text-transform: capitalize;
+                visibility: hidden; // a11y: avoid detection for voice over
+                overflow: hidden;
+                user-select: none;
+                pointer-events: none;
+                font-weight: 700;
+            }
+        }
+    }
+}

--- a/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspaceDetails.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspaceDetails.tsx
@@ -515,13 +515,33 @@ const WorkspaceStep: React.FunctionComponent<React.PropsWithChildren<WorkspaceSt
                 <Card className={classNames('mt-2', styles.stepCard)}>
                     <CardBody>
                         {!step.skipped && (
-                            <Tabs size="small" behavior="forceRender">
+                            <Tabs className={styles.stepTabs} size="small" behavior="forceRender">
                                 <TabList>
-                                    <Tab key="logs">Logs</Tab>
-                                    <Tab key="output-variables">Output variables</Tab>
-                                    <Tab key="diff">Diff</Tab>
-                                    <Tab key="files-env">Files / Env</Tab>
-                                    <Tab key="command-container">Commands / Container</Tab>
+                                    <Tab key="logs">
+                                        <span className="text-content" data-tab-content="Logs">
+                                            Logs
+                                        </span>
+                                    </Tab>
+                                    <Tab key="output-variables">
+                                        <span className="text-content" data-tab-content="Output variables">
+                                            Output variables
+                                        </span>
+                                    </Tab>
+                                    <Tab key="diff">
+                                        <span className="text-content" data-tab-content="Diff">
+                                            Diff
+                                        </span>
+                                    </Tab>
+                                    <Tab key="files-env">
+                                        <span className="text-content" data-tab-content="Files / Env">
+                                            Files / Env
+                                        </span>
+                                    </Tab>
+                                    <Tab key="command-container">
+                                        <span className="text-content" data-tab-content="Commands / Container">
+                                            Commands / Container
+                                        </span>
+                                    </Tab>
                                 </TabList>
                                 <TabPanels>
                                     <TabPanel className="pt-2" key="logs">


### PR DESCRIPTION
Uses the trick we use elsewhere with an `::after` element that renders the same contents of the tab but bolder to prevent the layout shift that normally happens when you click the tab and it turns bold.

Before | After
:------:|:-----:
<video src="https://user-images.githubusercontent.com/8942601/174195458-b58b15da-b975-407d-9495-386223b85ee2.mov" /> | <video src="https://user-images.githubusercontent.com/8942601/174195470-17a2d47b-4e2f-4bb9-9443-e9d93127eadb.mov" />

## Test plan

Tested locally, as shown in video recordings above.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-kr-no-tabs-cls.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-muvkmslmeb.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
