### PR TITLE
doc: explain how logging with Sentry sink works

### DIFF
--- a/doc/dev/how-to/add_logging.md
+++ b/doc/dev/how-to/add_logging.md
@@ -221,6 +221,17 @@ Guidance on when to use each log level is available on the docstrings of each re
 
 See [observability: logs](../../admin/observability/logs.md) in the administration docs.
 
+### Automatic error Reporting with Sentry
+
+If the optional sink [`log.NewSentrySink()`](https://doctree.org/github.com/sourcegraph/log/-/go/-//?id=NewSentrySink) is passed when initializing the logger, when an error is passed in a field to the logger with `log.Error(err)`, it will be reported to Sentry automatically if and only if the log level is above or equal to `Warn`.
+The log message and all fields will be used to annotate the error report and the logger scope will be used as a tag, which being indexed by Sentry, enables to group reports. 
+
+For example, the Sentry search query `is:unresolved scope:*codeintel*` will surface all error reports coming from errors that were logged by loggers whose scope includes `codeintel`.
+
+If multiple error fields are passed, an individual report will be created for each of them.
+
+The Sentry project to which the reports are sent is configured through the `log.sentry.backendDSN` site-config entry.
+
 ## Development usage
 
 With `SRC_DEVELOPMENT=true` and `SRC_LOG_FORMAT=condensed` or `SRC_LOG_FORMAT=console`, loggers will generate a human-readable summary format like the following:


### PR DESCRIPTION
Document how Sentry sink work. 

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Ran the docsite locally and checked the rendering. 