### PR TITLE
JetBrains: change metadata panel UI to match the designs

### DIFF
--- a/client/jetbrains/src/main/java/com/sourcegraph/browser/JSToJavaBridgeRequestHandler.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/browser/JSToJavaBridgeRequestHandler.java
@@ -76,36 +76,19 @@ public class JSToJavaBridgeRequestHandler {
                             Thread.sleep(300);
                         } catch (InterruptedException ignored) {
                         }
-                        ApplicationManager.getApplication().invokeLater(() -> {
-                            Date previewLoadingDate = Date.from(Instant.from(
-                                DateTimeFormatter.ISO_INSTANT.parse(arguments.get("timeAsISOString").getAsString())));
-                            if (findPopupPanel.getLastPreviewUpdate().before(previewLoadingDate)) {
-                                findPopupPanel.setLastPreviewUpdate(previewLoadingDate);
-                                findPopupPanel.indicateLoading();
-                            }
-                        });
+                        ApplicationManager.getApplication().invokeLater(() -> findPopupPanel.indicateLoadingIfInTime(Date.from(
+                            Instant.from(DateTimeFormatter.ISO_INSTANT.parse(arguments.get("timeAsISOString").getAsString())))));
                     }).start();
                     return createSuccessResponse(null);
                 case "preview":
                     arguments = request.getAsJsonObject("arguments");
                     previewContent = PreviewContent.fromJson(project, arguments);
-                    ApplicationManager.getApplication().invokeLater(() -> {
-                        if (findPopupPanel.getLastPreviewUpdate().before(previewContent.getReceivedDateTime())) {
-                            findPopupPanel.setLastPreviewUpdate(previewContent.getReceivedDateTime());
-                            findPopupPanel.setPreviewContent(previewContent);
-                        }
-                    });
+                    ApplicationManager.getApplication().invokeLater(() -> findPopupPanel.setPreviewContentIfInTime(previewContent));
                     return createSuccessResponse(null);
                 case "clearPreview":
                     arguments = request.getAsJsonObject("arguments");
-                    ApplicationManager.getApplication().invokeLater(() -> {
-                        Date clearPreviewDate = Date.from(Instant.from(
-                            DateTimeFormatter.ISO_INSTANT.parse(arguments.get("timeAsISOString").getAsString())));
-                        if (findPopupPanel.getLastPreviewUpdate().before(clearPreviewDate)) {
-                            findPopupPanel.setLastPreviewUpdate(clearPreviewDate);
-                            findPopupPanel.clearPreviewContent();
-                        }
-                    });
+                    ApplicationManager.getApplication().invokeLater(() -> findPopupPanel.clearPreviewContentIfInTime(Date.from(
+                        Instant.from(DateTimeFormatter.ISO_INSTANT.parse(arguments.get("timeAsISOString").getAsString())))));
                     return createSuccessResponse(null);
                 case "open":
                     arguments = request.getAsJsonObject("arguments");

--- a/client/jetbrains/src/main/java/com/sourcegraph/browser/JSToJavaBridgeRequestHandler.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/browser/JSToJavaBridgeRequestHandler.java
@@ -93,7 +93,6 @@ public class JSToJavaBridgeRequestHandler {
                         if (findPopupPanel.getLastPreviewUpdate().before(previewContent.getReceivedDateTime())) {
                             findPopupPanel.setLastPreviewUpdate(previewContent.getReceivedDateTime());
                             findPopupPanel.setPreviewContent(previewContent);
-                            findPopupPanel.setSelectionMetadataLabel(previewContent);
                         }
                     });
                     return createSuccessResponse(null);
@@ -105,7 +104,6 @@ public class JSToJavaBridgeRequestHandler {
                         if (findPopupPanel.getLastPreviewUpdate().before(clearPreviewDate)) {
                             findPopupPanel.setLastPreviewUpdate(clearPreviewDate);
                             findPopupPanel.clearPreviewContent();
-                            findPopupPanel.clearSelectionMetadataLabel();
                         }
                     });
                     return createSuccessResponse(null);

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/ThemeUtil.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/ThemeUtil.java
@@ -58,6 +58,7 @@ public class ThemeUtil {
 
     @NotNull
     public static String getPanelBackgroundColorHexString() {
+        //noinspection ConstantConditions - UIUtil.getPanelBackground() can't be null, so our return value can't be null.
         return getHexString(UIUtil.getPanelBackground());
     }
 

--- a/client/jetbrains/src/main/java/com/sourcegraph/find/FindPopupPanel.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/find/FindPopupPanel.java
@@ -58,6 +58,7 @@ public class FindPopupPanel extends JBPanel<FindPopupPanel> implements Disposabl
         BorderLayoutPanel topPanel = new BorderLayoutPanel();
         topPanel.setBorder(JBUI.Borders.empty(0, 4, 5, 4));
         topPanel.add(browserAndLoadingPanel, BorderLayout.CENTER);
+        topPanel.setMinimumSize(JBUI.size(750, 200));
 
         splitter.setFirstComponent(topPanel);
         splitter.setSecondComponent(bottomPanel);

--- a/client/jetbrains/src/main/java/com/sourcegraph/find/FindPopupPanel.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/find/FindPopupPanel.java
@@ -1,9 +1,6 @@
 package com.sourcegraph.find;
 
-import com.intellij.icons.AllIcons;
 import com.intellij.openapi.Disposable;
-import com.intellij.openapi.actionSystem.KeyboardShortcut;
-import com.intellij.openapi.keymap.KeymapUtil;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.Splitter;
 import com.intellij.ui.OnePixelSplitter;
@@ -18,12 +15,8 @@ import com.sourcegraph.browser.SourcegraphJBCefBrowser;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import javax.swing.*;
 import java.awt.*;
-import java.awt.event.InputEvent;
-import java.awt.event.KeyEvent;
 import java.util.Date;
-import java.util.Objects;
 
 /**
  * Inspired by <a href="https://sourcegraph.com/github.com/JetBrains/intellij-community/-/blob/platform/lang-impl/src/com/intellij/find/impl/FindPopupPanel.java">FindPopupPanel.java</a>
@@ -32,9 +25,7 @@ public class FindPopupPanel extends JBPanel<FindPopupPanel> implements Disposabl
     private final SourcegraphJBCefBrowser browser;
     private final PreviewPanel previewPanel;
     private final BrowserAndLoadingPanel browserAndLoadingPanel;
-    private JLabel selectionMetadataLabel;
-    private JLabel externalLinkLabel;
-    private JLabel openShortcutLabel;
+    private final SelectionMetadataPanel selectionMetadataPanel;
     private Date lastPreviewUpdate;
 
     public FindPopupPanel(@NotNull Project project) {
@@ -47,8 +38,12 @@ public class FindPopupPanel extends JBPanel<FindPopupPanel> implements Disposabl
         Splitter splitter = new OnePixelSplitter(true, 0.5f, 0.1f, 0.9f);
         add(splitter, BorderLayout.CENTER);
 
+        selectionMetadataPanel = new SelectionMetadataPanel();
         previewPanel = new PreviewPanel(project);
-        JPanel bottomPanel = createBottomPanel();
+
+        BorderLayoutPanel bottomPanel = new BorderLayoutPanel();
+        bottomPanel.add(selectionMetadataPanel, BorderLayout.NORTH);
+        bottomPanel.add(previewPanel, BorderLayout.CENTER);
 
         browserAndLoadingPanel = new BrowserAndLoadingPanel();
         JSToJavaBridgeRequestHandler requestHandler = new JSToJavaBridgeRequestHandler(project, this);
@@ -68,27 +63,6 @@ public class FindPopupPanel extends JBPanel<FindPopupPanel> implements Disposabl
         splitter.setSecondComponent(bottomPanel);
 
         lastPreviewUpdate = new Date();
-    }
-
-    @NotNull
-    private BorderLayoutPanel createBottomPanel() {
-        BorderLayoutPanel bottomPanel = new BorderLayoutPanel();
-        JPanel selectionMetadataPanel = new JPanel(new FlowLayout(FlowLayout.LEFT, 5, 10));
-
-        selectionMetadataLabel = new JLabel();
-        externalLinkLabel = new JLabel("", AllIcons.Ide.External_link_arrow, SwingConstants.LEFT);
-        externalLinkLabel.setVisible(false);
-        KeyboardShortcut altEnterShortcut = new KeyboardShortcut(KeyStroke.getKeyStroke(KeyEvent.VK_ENTER, InputEvent.ALT_DOWN_MASK), null);
-        String altEnterShortcutText = KeymapUtil.getShortcutText(altEnterShortcut);
-        openShortcutLabel = new JLabel(altEnterShortcutText);
-        openShortcutLabel.setVisible(false);
-
-        selectionMetadataPanel.add(selectionMetadataLabel);
-        selectionMetadataPanel.add(externalLinkLabel);
-        selectionMetadataPanel.add(openShortcutLabel);
-        bottomPanel.add(selectionMetadataPanel, BorderLayout.NORTH);
-        bottomPanel.add(previewPanel, BorderLayout.CENTER);
-        return bottomPanel;
     }
 
     @Nullable
@@ -120,52 +94,22 @@ public class FindPopupPanel extends JBPanel<FindPopupPanel> implements Disposabl
     }
 
     public void indicateLoading() {
+        selectionMetadataPanel.clearSelectionMetadataLabel();
         previewPanel.setLoading(true);
         previewPanel.clearContent();
-        clearSelectionMetadataLabel();
     }
 
     public void setPreviewContent(@NotNull PreviewContent previewContent) {
+        selectionMetadataPanel.setSelectionMetadataLabel(previewContent);
         previewPanel.setContent(previewContent);
     }
 
     public void clearPreviewContent() {
+        selectionMetadataPanel.clearSelectionMetadataLabel();
         previewPanel.setContent(null);
     }
 
     public void setBrowserVisible(boolean visible) {
         browserAndLoadingPanel.setBrowserVisible(visible);
-    }
-
-    public void clearSelectionMetadataLabel() {
-        selectionMetadataLabel.setText("");
-        externalLinkLabel.setVisible(false);
-        openShortcutLabel.setVisible(false);
-    }
-
-    public void setSelectionMetadataLabel(@NotNull PreviewContent previewContent) {
-        String metadataText = getMetadataText(previewContent);
-        selectionMetadataLabel.setText(metadataText);
-        externalLinkLabel.setVisible(!previewContent.opensInEditor());
-        openShortcutLabel.setToolTipText("Press " + openShortcutLabel.getText() + " to open the selected file" +
-            (previewContent.opensInEditor() ? " in the editor." : " in your browser."));
-        openShortcutLabel.setVisible(true);
-    }
-
-    @NotNull
-    private String getMetadataText(@NotNull PreviewContent previewContent) {
-        if (Objects.equals(previewContent.getResultType(), "file") || Objects.equals(previewContent.getResultType(), "path")) {
-            return previewContent.getRepoUrl() + ":" + previewContent.getPath();
-        } else if (Objects.equals(previewContent.getResultType(), "repo")) {
-            return previewContent.getRepoUrl();
-        } else if (Objects.equals(previewContent.getResultType(), "symbol")) {
-            return previewContent.getSymbolName() + " (" + previewContent.getSymbolContainerName() + ")";
-        } else if (Objects.equals(previewContent.getResultType(), "diff")) {
-            return previewContent.getCommitMessagePreview() != null ? previewContent.getCommitMessagePreview() : "";
-        } else if (Objects.equals(previewContent.getResultType(), "commit")) {
-            return previewContent.getCommitMessagePreview() != null ? previewContent.getCommitMessagePreview() : "";
-        } else {
-            return "";
-        }
     }
 }

--- a/client/jetbrains/src/main/java/com/sourcegraph/find/FindPopupPanel.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/find/FindPopupPanel.java
@@ -76,15 +76,6 @@ public class FindPopupPanel extends JBPanel<FindPopupPanel> implements Disposabl
         return previewPanel;
     }
 
-    @NotNull
-    public Date getLastPreviewUpdate() {
-        return lastPreviewUpdate;
-    }
-
-    public void setLastPreviewUpdate(@NotNull Date lastPreviewUpdate) {
-        this.lastPreviewUpdate = lastPreviewUpdate;
-    }
-
     @Override
     public void dispose() {
         if (browser != null) {
@@ -94,20 +85,28 @@ public class FindPopupPanel extends JBPanel<FindPopupPanel> implements Disposabl
         previewPanel.dispose();
     }
 
-    public void indicateLoading() {
-        selectionMetadataPanel.clearSelectionMetadataLabel();
-        previewPanel.setLoading(true);
-        previewPanel.clearContent();
+    public void indicateLoadingIfInTime(@NotNull Date date) {
+        if (lastPreviewUpdate.before(date)) {
+            selectionMetadataPanel.clearSelectionMetadataLabel();
+            previewPanel.setLoading(true);
+            previewPanel.clearContent();
+        }
     }
 
-    public void setPreviewContent(@NotNull PreviewContent previewContent) {
-        selectionMetadataPanel.setSelectionMetadataLabel(previewContent);
-        previewPanel.setContent(previewContent);
+    public void setPreviewContentIfInTime(@NotNull PreviewContent previewContent) {
+        if (lastPreviewUpdate.before(previewContent.getReceivedDateTime())) {
+            this.lastPreviewUpdate = previewContent.getReceivedDateTime();
+            selectionMetadataPanel.setSelectionMetadataLabel(previewContent);
+            previewPanel.setContent(previewContent);
+        }
     }
 
-    public void clearPreviewContent() {
-        selectionMetadataPanel.clearSelectionMetadataLabel();
-        previewPanel.setContent(null);
+    public void clearPreviewContentIfInTime(@NotNull Date date) {
+        if (lastPreviewUpdate.before(date)) {
+            this.lastPreviewUpdate = date;
+            selectionMetadataPanel.clearSelectionMetadataLabel();
+            previewPanel.setContent(null);
+        }
     }
 
     public void setBrowserVisible(boolean visible) {

--- a/client/jetbrains/src/main/java/com/sourcegraph/find/FindPopupPanel.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/find/FindPopupPanel.java
@@ -76,13 +76,8 @@ public class FindPopupPanel extends JBPanel<FindPopupPanel> implements Disposabl
         return previewPanel;
     }
 
-    @Override
-    public void dispose() {
-        if (browser != null) {
-            browser.dispose();
-        }
-
-        previewPanel.dispose();
+    public void setBrowserVisible(boolean visible) {
+        browserAndLoadingPanel.setBrowserVisible(visible);
     }
 
     public void indicateLoadingIfInTime(@NotNull Date date) {
@@ -109,7 +104,12 @@ public class FindPopupPanel extends JBPanel<FindPopupPanel> implements Disposabl
         }
     }
 
-    public void setBrowserVisible(boolean visible) {
-        browserAndLoadingPanel.setBrowserVisible(visible);
+    @Override
+    public void dispose() {
+        if (browser != null) {
+            browser.dispose();
+        }
+
+        previewPanel.dispose();
     }
 }

--- a/client/jetbrains/src/main/java/com/sourcegraph/find/FindService.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/find/FindService.java
@@ -77,6 +77,7 @@ public class FindService implements Disposable {
             .setCancelOnWindowDeactivation(false)
             .setCancelOnClickOutside(true)
             .setBelongsToGlobalPopupStack(true)
+            .setMinSize(new Dimension(750, 420))
             .setNormalWindowLevel(true);
 
         // For some reason, adding a cancelCallback will prevent the cancel event to fire when using the escape key. To

--- a/client/jetbrains/src/main/java/com/sourcegraph/find/SelectionMetadataPanel.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/find/SelectionMetadataPanel.java
@@ -27,6 +27,7 @@ public class SelectionMetadataPanel extends JPanel {
         String altEnterShortcutText = KeymapUtil.getShortcutText(altEnterShortcut);
         openShortcutLabel = new JLabel(altEnterShortcutText);
         openShortcutLabel.setBorder(BorderFactory.createEmptyBorder(0, 8, 0, 0));
+        openShortcutLabel.setEnabled(false);
         openShortcutLabel.setVisible(false);
 
         add(selectionMetadataLabel);

--- a/client/jetbrains/src/main/java/com/sourcegraph/find/SelectionMetadataPanel.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/find/SelectionMetadataPanel.java
@@ -1,0 +1,66 @@
+package com.sourcegraph.find;
+
+import com.intellij.icons.AllIcons;
+import com.intellij.openapi.actionSystem.KeyboardShortcut;
+import com.intellij.openapi.keymap.KeymapUtil;
+import org.jetbrains.annotations.NotNull;
+
+import javax.swing.*;
+import java.awt.*;
+import java.awt.event.InputEvent;
+import java.awt.event.KeyEvent;
+import java.util.Objects;
+
+public class SelectionMetadataPanel extends JPanel {
+    private final JLabel selectionMetadataLabel;
+    private final JLabel externalLinkLabel;
+    private final JLabel openShortcutLabel;
+
+    public SelectionMetadataPanel() {
+        super(new FlowLayout(FlowLayout.LEFT, 5, 10));
+
+        selectionMetadataLabel = new JLabel();
+        externalLinkLabel = new JLabel("", AllIcons.Ide.External_link_arrow, SwingConstants.LEFT);
+        externalLinkLabel.setVisible(false);
+        KeyboardShortcut altEnterShortcut = new KeyboardShortcut(KeyStroke.getKeyStroke(KeyEvent.VK_ENTER, InputEvent.ALT_DOWN_MASK), null);
+        String altEnterShortcutText = KeymapUtil.getShortcutText(altEnterShortcut);
+        openShortcutLabel = new JLabel(altEnterShortcutText);
+        openShortcutLabel.setVisible(false);
+
+        add(selectionMetadataLabel);
+        add(externalLinkLabel);
+        add(openShortcutLabel);
+    }
+
+    public void clearSelectionMetadataLabel() {
+        selectionMetadataLabel.setText("");
+        externalLinkLabel.setVisible(false);
+        openShortcutLabel.setVisible(false);
+    }
+
+    public void setSelectionMetadataLabel(@NotNull PreviewContent previewContent) {
+        String metadataText = getMetadataText(previewContent);
+        selectionMetadataLabel.setText(metadataText);
+        externalLinkLabel.setVisible(!previewContent.opensInEditor());
+        openShortcutLabel.setToolTipText("Press " + openShortcutLabel.getText() + " to open the selected file" +
+            (previewContent.opensInEditor() ? " in the editor." : " in your browser."));
+        openShortcutLabel.setVisible(true);
+    }
+
+    @NotNull
+    private String getMetadataText(@NotNull PreviewContent previewContent) {
+        if (Objects.equals(previewContent.getResultType(), "file") || Objects.equals(previewContent.getResultType(), "path")) {
+            return previewContent.getRepoUrl() + ":" + previewContent.getPath();
+        } else if (Objects.equals(previewContent.getResultType(), "repo")) {
+            return previewContent.getRepoUrl();
+        } else if (Objects.equals(previewContent.getResultType(), "symbol")) {
+            return previewContent.getSymbolName() + " (" + previewContent.getSymbolContainerName() + ")";
+        } else if (Objects.equals(previewContent.getResultType(), "diff")) {
+            return previewContent.getCommitMessagePreview() != null ? previewContent.getCommitMessagePreview() : "";
+        } else if (Objects.equals(previewContent.getResultType(), "commit")) {
+            return previewContent.getCommitMessagePreview() != null ? previewContent.getCommitMessagePreview() : "";
+        } else {
+            return "";
+        }
+    }
+}

--- a/client/jetbrains/src/main/java/com/sourcegraph/find/SelectionMetadataPanel.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/find/SelectionMetadataPanel.java
@@ -17,14 +17,16 @@ public class SelectionMetadataPanel extends JPanel {
     private final JLabel openShortcutLabel;
 
     public SelectionMetadataPanel() {
-        super(new FlowLayout(FlowLayout.LEFT, 5, 10));
+        super(new FlowLayout(FlowLayout.LEFT, 0, 8));
 
         selectionMetadataLabel = new JLabel();
+        selectionMetadataLabel.setBorder(BorderFactory.createEmptyBorder(0, 5, 0, 0));
         externalLinkLabel = new JLabel("", AllIcons.Ide.External_link_arrow, SwingConstants.LEFT);
         externalLinkLabel.setVisible(false);
         KeyboardShortcut altEnterShortcut = new KeyboardShortcut(KeyStroke.getKeyStroke(KeyEvent.VK_ENTER, InputEvent.ALT_DOWN_MASK), null);
         String altEnterShortcutText = KeymapUtil.getShortcutText(altEnterShortcut);
         openShortcutLabel = new JLabel(altEnterShortcutText);
+        openShortcutLabel.setBorder(BorderFactory.createEmptyBorder(0, 8, 0, 0));
         openShortcutLabel.setVisible(false);
 
         add(selectionMetadataLabel);

--- a/client/jetbrains/webview/src/search/StatusBar.module.scss
+++ b/client/jetbrains/webview/src/search/StatusBar.module.scss
@@ -5,6 +5,7 @@
     background-color: var(--subtle-bg);
     align-items: center;
     flex-shrink: 0;
+    cursor: default;
 
     border-bottom: 1px solid var(--jb-border-color);
     border-top: 1px solid var(--jb-border-color);


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/37280

The change is not only in the design but also in functionality: the component wasn't accessible with the mouse; now it is.

Also:
- Extracted the metadata panel to its own class to encapsulate that functionality. The interfaces got a lot cleaner as a result.
- Set a minimum size for the window and the web view because at lower widths, the search box started breaking and it looked bad. The minimum height for the web view also makes it less likely that the Monaco Editor suggestion box bug comes up for users.
- Set cursor: default on [status bar](https://share.cleanshot.com/LxJcBF) to get rid of this giveaway that we're in a web view.
- Tiny change: Suppressed a false warning with also including a comment on why it was false.

## Test plan

- Check out this [1-min Loom](https://www.loom.com/share/1139c97fbcd64bda91016fbea678ef49)
- Take a glance at the code. Might even be easier to go commit by commit; I've tried to make the commit messages pretty helpful.

## App preview:

- [Web](https://sg-web-dv-jetbrains-design-metadata.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-uklmlawpfi.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
