### PR TITLE
search: update index status page

### DIFF
--- a/client/web/src/repo/settings/RepoSettingsIndexPage.tsx
+++ b/client/web/src/repo/settings/RepoSettingsIndexPage.tsx
@@ -227,22 +227,22 @@ export class RepoSettingsIndexPage extends React.PureComponent<Props, State> {
                                                     <td>
                                                         {prettyBytesBigint(
                                                             BigInt(this.state.textSearchIndex.status.contentByteSize)
-                                                        )}{' '}
+                                                        )}
                                                     </td>
                                                 </tr>
                                                 <tr>
                                                     <th>Shards</th>
-                                                    <td>{this.state.textSearchIndex.status.indexShardsCount} </td>
+                                                    <td>{this.state.textSearchIndex.status.indexShardsCount}</td>
                                                 </tr>
 
                                                 <tr>
                                                     <th>Files</th>
-                                                    <td>{this.state.textSearchIndex.status.contentFilesCount} </td>
+                                                    <td>{this.state.textSearchIndex.status.contentFilesCount}</td>
                                                 </tr>
                                                 <tr>
                                                     <th>Index size</th>
                                                     <td>
-                                                        {prettyBytes(this.state.textSearchIndex.status.indexByteSize)}{' '}
+                                                        {prettyBytes(this.state.textSearchIndex.status.indexByteSize)}
                                                     </td>
                                                 </tr>
                                                 <tr>

--- a/client/web/src/repo/settings/RepoSettingsIndexPage.tsx
+++ b/client/web/src/repo/settings/RepoSettingsIndexPage.tsx
@@ -234,7 +234,6 @@ export class RepoSettingsIndexPage extends React.PureComponent<Props, State> {
                                                     <th>Shards</th>
                                                     <td>{this.state.textSearchIndex.status.indexShardsCount}</td>
                                                 </tr>
-
                                                 <tr>
                                                     <th>Files</th>
                                                     <td>{this.state.textSearchIndex.status.contentFilesCount}</td>

--- a/client/web/src/repo/settings/RepoSettingsIndexPage.tsx
+++ b/client/web/src/repo/settings/RepoSettingsIndexPage.tsx
@@ -110,7 +110,8 @@ const TextSearchIndexedReference: React.FunctionComponent<
                         <span>
                             .&nbsp;
                             <Link to={'/search?q=' + encodeURIComponent(indexedRef.skippedIndexed.query)}>
-                                {indexedRef.skippedIndexed.count} files were not indexed
+                                {indexedRef.skippedIndexed.count} {pluralize('file', indexedRef.skippedIndexed.count)}{' '}
+                                not indexed
                             </Link>
                             .
                         </span>
@@ -227,24 +228,21 @@ export class RepoSettingsIndexPage extends React.PureComponent<Props, State> {
                                                         {prettyBytesBigint(
                                                             BigInt(this.state.textSearchIndex.status.contentByteSize)
                                                         )}{' '}
-                                                        ({this.state.textSearchIndex.status.contentFilesCount}{' '}
-                                                        {pluralize(
-                                                            'file',
-                                                            this.state.textSearchIndex.status.contentFilesCount
-                                                        )}
-                                                        )
                                                     </td>
+                                                </tr>
+                                                <tr>
+                                                    <th>Shards</th>
+                                                    <td>{this.state.textSearchIndex.status.indexShardsCount} </td>
+                                                </tr>
+
+                                                <tr>
+                                                    <th>Files</th>
+                                                    <td>{this.state.textSearchIndex.status.contentFilesCount} </td>
                                                 </tr>
                                                 <tr>
                                                     <th>Index size</th>
                                                     <td>
-                                                        {prettyBytes(this.state.textSearchIndex.status.indexByteSize)} (
-                                                        {this.state.textSearchIndex.status.indexShardsCount}{' '}
-                                                        {pluralize(
-                                                            'shard',
-                                                            this.state.textSearchIndex.status.indexShardsCount
-                                                        )}
-                                                        )
+                                                        {prettyBytes(this.state.textSearchIndex.status.indexByteSize)}{' '}
                                                     </td>
                                                 </tr>
                                                 <tr>


### PR DESCRIPTION
This is a purely cosmetic refactor. Some data, such as "files" and "shards", were in parenthesis but
deserve their own row. We also update the pluralization for the unindexed files.

<img width="1279" alt="Screenshot 2022-06-17 at 14 00 00" src="https://user-images.githubusercontent.com/26413131/174294522-218ae9c7-0fac-4b5b-b599-703ab47e84c3.png">


## Test plan
- manual testing: I ran a local instance and inspected the page for several repos.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-sh-update-index-status-page.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-haersnrvab.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

