### PR TITLE
Add changelog entries for 3.41

### DIFF
--- a/client/web/src/enterprise/batches/list/BatchChangesChangelogAlert.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangesChangelogAlert.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 import classNames from 'classnames'
 
-import { CardBody, Card, H2, H4, Link } from '@sourcegraph/wildcard'
+import { CardBody, Card, H2, H4, Link, Code } from '@sourcegraph/wildcard'
 
 import { DismissibleAlert } from '../../../components/DismissibleAlert'
 
@@ -11,21 +11,50 @@ import styles from './BatchChangesListIntro.module.scss'
 export const BatchChangesChangelogAlert: React.FunctionComponent<React.PropsWithChildren<unknown>> = () => (
     <DismissibleAlert
         className={styles.batchChangesListIntroAlert}
-        partialStorageKey="batch-changes-list-intro-changelog-3.40"
+        partialStorageKey="batch-changes-list-intro-changelog-3.41"
     >
         <Card className={classNames(styles.batchChangesListIntroCard, 'h-100')}>
             <CardBody>
-                <H4 as={H2}>Batch Changes updates in version 3.40</H4>
+                <H4 as={H2}>Batch Changes updates in version 3.41</H4>
                 <ul className="mb-0 pl-3">
                     <li>
                         <Link
-                            to="https://docs.sourcegraph.com/batch_changes/explanations/introduction_to_batch_changes#supported-code-hosts-and-changeset-types"
+                            to="https://docs.sourcegraph.com/batch_changes/explanations/server_side"
                             rel="noopener"
                             target="_blank"
                         >
-                            Bitbucket Cloud is now supported with Batch Changes.
+                            🚀 Running batch changes server-side
+                        </Link>{' '}
+                        is now in beta! In addition to using src-cli to run batch changes locally, you can now run them
+                        server-side as well. This requires{' '}
+                        <Link to="https://docs.sourcegraph.com/admin/deploy_executors" rel="noopener" target="_blank">
+                            installing executors.
+                        </Link>
+                        While running server-side unlocks a new and improved UI experience, you can still use src-cli
+                        just like before.
+                    </li>
+                    <li>
+                        <Link
+                            to="https://docs.sourcegraph.com/batch_changes/references/batch_spec_yaml_reference#steps-mount"
+                            rel="noopener"
+                            target="_blank"
+                        >
+                            src-cli now allows to mount local files into step containers.
                         </Link>
                     </li>
+                    <li>It's now possible to start a batch change from search results.</li>
+                    <li>
+                        <Link
+                            to="https://docs.sourcegraph.com/batch_changes/references/batch_spec_templating"
+                            rel="noopener"
+                            target="_blank"
+                        >
+                            You can now control where the link to the batch change in the changeset body is rendered
+                            using {/* eslint-disable-next-line no-template-curly-in-string */}
+                            <Code>{'${{ batch_change_link }}'}</Code>.
+                        </Link>
+                    </li>
+                    <li>Viewing large batch changes is now significantly faster.</li>
                 </ul>
             </CardBody>
         </Card>

--- a/client/web/src/enterprise/batches/list/BatchChangesChangelogAlert.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangesChangelogAlert.tsx
@@ -18,16 +18,12 @@ export const BatchChangesChangelogAlert: React.FunctionComponent<React.PropsWith
                 <H4 as={H2}>Batch Changes updates in version 3.41</H4>
                 <ul className="mb-0 pl-3">
                     <li>
-                        <Link
-                            to="https://docs.sourcegraph.com/batch_changes/explanations/server_side"
-                            rel="noopener"
-                            target="_blank"
-                        >
+                        <Link to="/help/batch_changes/explanations/server_side" rel="noopener" target="_blank">
                             🚀 Running batch changes server-side
                         </Link>{' '}
                         is now in beta! In addition to using src-cli to run batch changes locally, you can now run them
                         server-side as well. This requires{' '}
-                        <Link to="https://docs.sourcegraph.com/admin/deploy_executors" rel="noopener" target="_blank">
+                        <Link to="/help/admin/deploy_executors" rel="noopener" target="_blank">
                             installing executors.
                         </Link>
                         While running server-side unlocks a new and improved UI experience, you can still use src-cli
@@ -35,7 +31,7 @@ export const BatchChangesChangelogAlert: React.FunctionComponent<React.PropsWith
                     </li>
                     <li>
                         <Link
-                            to="https://docs.sourcegraph.com/batch_changes/references/batch_spec_yaml_reference#steps-mount"
+                            to="/help/batch_changes/references/batch_spec_yaml_reference#steps-mount"
                             rel="noopener"
                             target="_blank"
                         >
@@ -44,11 +40,7 @@ export const BatchChangesChangelogAlert: React.FunctionComponent<React.PropsWith
                     </li>
                     <li>It's now possible to start a batch change from search results.</li>
                     <li>
-                        <Link
-                            to="https://docs.sourcegraph.com/batch_changes/references/batch_spec_templating"
-                            rel="noopener"
-                            target="_blank"
-                        >
+                        <Link to="/help/batch_changes/references/batch_spec_templating" rel="noopener" target="_blank">
                             You can now control where the link to the batch change in the changeset body is rendered
                             using {/* eslint-disable-next-line no-template-curly-in-string */}
                             <Code>{'${{ batch_change_link }}'}</Code>.


### PR DESCRIPTION

<img width="1146" alt="Screenshot 2022-06-17 at 14 05 34@2x" src="https://user-images.githubusercontent.com/19534377/174294963-0112030a-6255-4870-8a0b-177d5475453f.png">


## Test plan

Docs content, verified it looks good.

## App preview:

- [Web](https://sg-web-es-changelog-341.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-qjikxptolg.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
