### PR TITLE
JetBrains: make search input responsive 

### DIFF
--- a/client/jetbrains/webview/src/search/input/JetBrainsSearchBox.module.scss
+++ b/client/jetbrains/webview/src/search/input/JetBrainsSearchBox.module.scss
@@ -148,18 +148,21 @@
         the JetBrains SearchBox, override styles defined by MonacoQueryInput to ensure that
         suggestion item content fits the container.
     */
-    :global(.monaco-editor)
-        :global(.suggest-widget)
-        :global(.monaco-list)
-        :global(.monaco-list-row):global(.focused):global(.string-label)
-        > :global(.contents)
-        > :global(.main) {
-        max-height: 100%;
+    :global(.monaco-editor) {
+        width: 0 !important;
 
-        > :global(.right) {
-            &::after {
-                height: 100%;
-                margin-top: 0;
+        :global(.suggest-widget)
+            :global(.monaco-list)
+            :global(.monaco-list-row):global(.focused):global(.string-label)
+            > :global(.contents)
+            > :global(.main) {
+            max-height: 100%;
+
+            > :global(.right) {
+                &::after {
+                    height: 100%;
+                    margin-top: 0;
+                }
             }
         }
     }


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/35545

`.monaco-editor` and a lot of its ancestors recalculate their height on resizing. For some reason, height recalculation doesn't happen when the editor's container no longer fits in the page width and starts shrinking. The suggested weird hack (setting editors width to 0) triggers height recalculation even if there's not enough width for the editor's container.

[Loom](https://www.loom.com/share/434f11ec9d2244fc9b2fa75a7ab64cd9)

## Test plan
Run the JetBrains plugin in standalone mode and try to resize the window. The search input should remain responsive (check the Loom from the description). 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-taras-yemets-jetbrains-fix-search.onrender.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

