### PR TITLE
[Wildcard] Tooltip: fix long words display

### DIFF
--- a/client/wildcard/src/components/Tooltip/Tooltip.module.scss
+++ b/client/wildcard/src/components/Tooltip/Tooltip.module.scss
@@ -26,6 +26,7 @@
     color: var(--tooltip-color);
     padding: var(--tooltip-padding-y) var(--tooltip-padding-x);
     user-select: text;
+    word-wrap: break-word;
 }
 
 .tooltip-arrow {

--- a/client/wildcard/src/components/Tooltip/Tooltip.story.tsx
+++ b/client/wildcard/src/components/Tooltip/Tooltip.story.tsx
@@ -101,7 +101,7 @@ export const DisabledTrigger: Story = () => (
 export const LongContent: Story = () => (
     <Grid columnCount={1}>
         <div>
-            <Tooltip content="Nulla porttitor accumsan tincidunt. Proin eget tortor risus. Quisque velit nisi, pretium ut lacinia in, elementum id enim. Donec rutrum congue leo eget malesuada.">
+            <Tooltip content="Nulla porttitor accumsan tincidunt. IAmVeryLongTextWithNoBreaksAndIWantToBeWrappedInMultipleLines. Proin eget tortor risus. Quisque velit nisi, pretium ut lacinia in, elementum id enim. Donec rutrum congue leo eget malesuada.">
                 <Button variant="primary">Example</Button>
             </Tooltip>
         </div>


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/36813

Breaks long words in multiple lines.

| Before | After |
| -- | -- |
| ![image](https://user-images.githubusercontent.com/25318659/174325128-9f8626bf-5a14-44d3-839a-365ebf6df3a4.png) |<img width="628" alt="Screenshot 2022-06-17 at 18 06 35" src="https://user-images.githubusercontent.com/25318659/174325304-38727648-682a-4047-abf5-fe4d93113935.png">|


## Test plan
Visually tested using Storybook.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-taras-yemets-tooltip-break-long.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-belcliykkz.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
