### PR TITLE
dev/ci: update kubectl --dry-run flag, improve cluster test output

### DIFF
--- a/dev/ci/integration/cluster/test.sh
+++ b/dev/ci/integration/cluster/test.sh
@@ -33,7 +33,7 @@ function cluster_cleanup() {
 function cluster_setup() {
   gcloud container clusters get-credentials default-buildkite --zone=us-central1-c --project=sourcegraph-ci
 
-  kubectl create ns "$NAMESPACE" -oyaml --dry-run | kubectl apply -f -
+  kubectl create ns "$NAMESPACE" -oyaml --dry-run=client | kubectl apply -f -
   trap cluster_cleanup exit
   kubectl apply -f "$test_dir/storageClass.yaml"
   kubectl config set-context --current --namespace="$NAMESPACE"

--- a/dev/ci/integration/cluster/test.sh
+++ b/dev/ci/integration/cluster/test.sh
@@ -33,14 +33,19 @@ function cluster_cleanup() {
 function cluster_setup() {
   gcloud container clusters get-credentials default-buildkite --zone=us-central1-c --project=sourcegraph-ci
 
+  echo "--- create namespace"
   kubectl create ns "$NAMESPACE" -oyaml --dry-run=client | kubectl apply -f -
   trap cluster_cleanup exit
+
+  echo "--- create storageclass"
   kubectl apply -f "$test_dir/storageClass.yaml"
   kubectl config set-context --current --namespace="$NAMESPACE"
   kubectl config current-context
-  sleep 15 #wait for namespace to come up
+  echo "--- wait for namespace to come up and check pods"
+  sleep 15 # wait for namespace to come up
   kubectl get -n "$NAMESPACE" pods
 
+  echo "--- rewrite manifests"
   pushd "$test_dir/deploy-sourcegraph"
   set +e
   set +o pipefail


### PR DESCRIPTION
We don't have +x anymore so we add some more output

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

this branch is a main-dry-run