### PR TITLE
ssbc: Create index to speed up queue calculation

### DIFF
--- a/internal/database/schema.json
+++ b/internal/database/schema.json
@@ -2030,6 +2030,16 @@
           "ConstraintDefinition": ""
         },
         {
+          "Name": "batch_spec_workspace_execution_jobs_last_dequeue",
+          "IsPrimaryKey": false,
+          "IsUnique": false,
+          "IsExclusion": false,
+          "IsDeferrable": false,
+          "IndexDefinition": "CREATE INDEX batch_spec_workspace_execution_jobs_last_dequeue ON batch_spec_workspace_execution_jobs USING btree (user_id, started_at DESC)",
+          "ConstraintType": "",
+          "ConstraintDefinition": ""
+        },
+        {
           "Name": "batch_spec_workspace_execution_jobs_state",
           "IsPrimaryKey": false,
           "IsUnique": false,

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -155,6 +155,7 @@ Indexes:
     "batch_spec_workspace_execution_jobs_pkey" PRIMARY KEY, btree (id)
     "batch_spec_workspace_execution_jobs_batch_spec_workspace_id" btree (batch_spec_workspace_id)
     "batch_spec_workspace_execution_jobs_cancel" btree (cancel)
+    "batch_spec_workspace_execution_jobs_last_dequeue" btree (user_id, started_at DESC)
     "batch_spec_workspace_execution_jobs_state" btree (state)
     "batch_spec_workspace_execution_jobs_user_id" btree (user_id)
 Foreign-key constraints:

--- a/migrations/frontend/1655481894/down.sql
+++ b/migrations/frontend/1655481894/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS batch_spec_workspace_execution_jobsbatch_spec_workspace_execution_jobs_last_dequeue;

--- a/migrations/frontend/1655481894/metadata.yaml
+++ b/migrations/frontend/1655481894/metadata.yaml
@@ -1,0 +1,3 @@
+name: faster_ssbc_dequeue
+parents: [1655412173]
+createIndexConcurrently: true

--- a/migrations/frontend/1655481894/up.sql
+++ b/migrations/frontend/1655481894/up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS batch_spec_workspace_execution_jobs_last_dequeue ON batch_spec_workspace_execution_jobs (user_id, started_at DESC);

--- a/migrations/frontend/squashed.sql
+++ b/migrations/frontend/squashed.sql
@@ -3472,6 +3472,8 @@ CREATE INDEX batch_spec_workspace_execution_jobs_batch_spec_workspace_id ON batc
 
 CREATE INDEX batch_spec_workspace_execution_jobs_cancel ON batch_spec_workspace_execution_jobs USING btree (cancel);
 
+CREATE INDEX batch_spec_workspace_execution_jobs_last_dequeue ON batch_spec_workspace_execution_jobs USING btree (user_id, started_at DESC);
+
 CREATE INDEX batch_spec_workspace_execution_jobs_state ON batch_spec_workspace_execution_jobs USING btree (state);
 
 CREATE INDEX batch_spec_workspace_execution_jobs_user_id ON batch_spec_workspace_execution_jobs USING btree (user_id);


### PR DESCRIPTION
This makes it a bit faster to find candidate queues, on average about 50%. Under high load (many executors running and pulling from the same table) this reduces the runtime of such a query from 270ms down to 120ms.



## Test plan

Verified against k8s DB it has a positive effect.