### PR TITLE
Structural search: Stream to and from comby for indexed structural search

### DIFF
--- a/cmd/searcher/internal/search/search_structural.go
+++ b/cmd/searcher/internal/search/search_structural.go
@@ -384,7 +384,7 @@ func structuralSearch(ctx context.Context, inputType comby.Input, paths filePatt
 	}
 
 	switch combyInput := inputType.(type) {
-	case comby.TarInput:
+	case comby.Tar:
 		cmd, stdin, stdout, err := comby.SetupCmdWithPipes(ctx, args)
 		if err != nil {
 			return err

--- a/cmd/searcher/internal/search/search_structural.go
+++ b/cmd/searcher/internal/search/search_structural.go
@@ -419,7 +419,8 @@ func structuralSearch(ctx context.Context, inputType comby.Input, paths filePatt
 	case comby.ZipPath:
 		return runCombyWithCollection(ctx, args, combyInput, sender)
 	}
-	return nil
+
+	return errors.New("comby input must be either -tar or -zip for structural search")
 }
 
 // runCombyWithStreaming runs comby with the flags `-tar` and `-chunk-matches 0`. `-chunk-matches 0` instructs comby to return
@@ -481,16 +482,16 @@ func runCombyWithStreaming(ctx context.Context, args comby.Args, tarInput comby.
 // runCombyWithCollection runs comby with the flag `-zip`. It collects all matches that comby finds in the zip file, then
 // attempts to convert each of those to a protocol.FileMatch, sending it to the result stream if successful.
 func runCombyWithCollection(ctx context.Context, args comby.Args, zipPath comby.ZipPath, sender matchSender) (err error) {
+	combyMatches, err := comby.Matches(ctx, args)
+	if err != nil {
+		return err
+	}
+
 	zipReader, err := zip.OpenReader(string(zipPath))
 	if err != nil {
 		return err
 	}
 	defer zipReader.Close()
-
-	combyMatches, err := comby.Matches(ctx, args)
-	if err != nil {
-		return err
-	}
 
 	for _, combyMatch := range combyMatches {
 		fm, err := toFileMatch(&zipReader.Reader, combyMatch)

--- a/cmd/searcher/internal/search/search_structural_test.go
+++ b/cmd/searcher/internal/search/search_structural_test.go
@@ -1,7 +1,9 @@
 package search
 
 import (
+	"archive/tar"
 	"context"
+	"github.com/sourcegraph/sourcegraph/internal/comby"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -71,7 +73,7 @@ func foo(go string) {}
 
 				ctx, cancel, sender := newLimitedStreamCollector(context.Background(), 100000000)
 				defer cancel()
-				err := structuralSearch(ctx, zf, subset(p.IncludePatterns), "", p.Pattern, p.CombyRule, p.Languages, "repo_foo", sender)
+				err := structuralSearch(ctx, comby.ZipPath(zf), subset(p.IncludePatterns), "", p.Pattern, p.CombyRule, p.Languages, "repo_foo", sender)
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -128,7 +130,7 @@ func foo(go.txt) {}
 		extensionHint := filepath.Ext(filename)
 		ctx, cancel, sender := newLimitedStreamCollector(context.Background(), 1000000000)
 		defer cancel()
-		err := structuralSearch(ctx, zf, all, extensionHint, "foo(:[args])", "", languages, "repo_foo", sender)
+		err := structuralSearch(ctx, comby.ZipPath(zf), all, extensionHint, "foo(:[args])", "", languages, "repo_foo", sender)
 		if err != nil {
 			return "ERROR: " + err.Error()
 		}
@@ -321,7 +323,7 @@ func TestIncludePatterns(t *testing.T) {
 	}
 	ctx, cancel, sender := newLimitedStreamCollector(context.Background(), 1000000000)
 	defer cancel()
-	err = structuralSearch(ctx, zf, subset(p.IncludePatterns), "", p.Pattern, p.CombyRule, p.Languages, "foo", sender)
+	err = structuralSearch(ctx, comby.ZipPath(zf), subset(p.IncludePatterns), "", p.Pattern, p.CombyRule, p.Languages, "foo", sender)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -361,7 +363,7 @@ func TestRule(t *testing.T) {
 
 	ctx, cancel, sender := newLimitedStreamCollector(context.Background(), 1000000000)
 	defer cancel()
-	err = structuralSearch(ctx, zf, subset(p.IncludePatterns), "", p.Pattern, p.CombyRule, p.Languages, "repo", sender)
+	err = structuralSearch(ctx, comby.ZipPath(zf), subset(p.IncludePatterns), "", p.Pattern, p.CombyRule, p.Languages, "repo", sender)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -429,7 +431,7 @@ func bar() {
 		return func(t *testing.T) {
 			ctx, cancel, sender := newLimitedStreamCollector(context.Background(), limit)
 			defer cancel()
-			err := structuralSearch(ctx, zf, subset(p.IncludePatterns), "", p.Pattern, p.CombyRule, p.Languages, "repo_foo", sender)
+			err := structuralSearch(ctx, comby.ZipPath(zf), subset(p.IncludePatterns), "", p.Pattern, p.CombyRule, p.Languages, "repo_foo", sender)
 			require.NoError(t, err)
 
 			require.Equal(t, wantCount, count(sender.collected))
@@ -473,7 +475,7 @@ func bar() {
 	t.Run("Strutural search match count", func(t *testing.T) {
 		ctx, cancel, sender := newLimitedStreamCollector(context.Background(), 1000000000)
 		defer cancel()
-		err := structuralSearch(ctx, zf, subset(p.IncludePatterns), "", p.Pattern, p.CombyRule, p.Languages, "repo_foo", sender)
+		err := structuralSearch(ctx, comby.ZipPath(zf), subset(p.IncludePatterns), "", p.Pattern, p.CombyRule, p.Languages, "repo_foo", sender)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -517,7 +519,7 @@ func bar() {
 	t.Run("Strutural search match count", func(t *testing.T) {
 		ctx, cancel, sender := newLimitedStreamCollector(context.Background(), 1000000000)
 		defer cancel()
-		err := structuralSearch(ctx, zf, subset(p.IncludePatterns), "", p.Pattern, p.CombyRule, p.Languages, "repo_foo", sender)
+		err := structuralSearch(ctx, comby.ZipPath(zf), subset(p.IncludePatterns), "", p.Pattern, p.CombyRule, p.Languages, "repo_foo", sender)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -683,4 +685,66 @@ func Test_chunkRanges(t *testing.T) {
 			require.Equal(t, tc.output, got)
 		})
 	}
+}
+
+func TestTarInput(t *testing.T) {
+	// If we are not on CI skip the test.
+	if os.Getenv("CI") == "" {
+		t.Skip("Not on CI, skipping comby-dependent test")
+	}
+
+	input := map[string]string{
+		"main.go": `
+func foo() {
+    fmt.Println("foo")
+}
+
+func bar() {
+    fmt.Println("bar")
+}
+`,
+	}
+
+	p := &protocol.PatternInfo{Pattern: "{:[body]}"}
+
+	tarInputEventC := make(chan comby.TarInputEvent, 1)
+	hdr := tar.Header{
+		Name: "main.go",
+		Mode: 0600,
+		Size: int64(len(input["main.go"])),
+	}
+	tarInputEventC <- comby.TarInputEvent{
+		Header:  hdr,
+		Content: []byte(input["main.go"]),
+	}
+	close(tarInputEventC)
+
+	t.Run("Structural search tar input to comby", func(t *testing.T) {
+		ctx, cancel, sender := newLimitedStreamCollector(context.Background(), 1000000000)
+		defer cancel()
+		err := structuralSearch(ctx, comby.TarInput{TarInputEventC: tarInputEventC}, all, "", p.Pattern, p.CombyRule, p.Languages, "repo_foo", sender)
+		if err != nil {
+			t.Fatal(err)
+		}
+		matches := sender.collected
+		expected := []protocol.FileMatch{{
+			Path: "main.go",
+			ChunkMatches: []protocol.ChunkMatch{{
+				Content:      "func foo() {\n    fmt.Println(\"foo\")\n}",
+				ContentStart: protocol.Location{Offset: 1, Line: 1},
+				Ranges: []protocol.Range{{
+					Start: protocol.Location{Offset: 12, Line: 1, Column: 11},
+					End:   protocol.Location{Offset: 38, Line: 3, Column: 1},
+				}},
+			}, {
+				Content:      "func bar() {\n    fmt.Println(\"bar\")\n}",
+				ContentStart: protocol.Location{Offset: 40, Line: 5},
+				Ranges: []protocol.Range{{
+					Start: protocol.Location{Offset: 51, Line: 5, Column: 11},
+					End:   protocol.Location{Offset: 77, Line: 7, Column: 1},
+				}},
+			}},
+		}}
+		require.Equal(t, expected, matches)
+	})
 }

--- a/cmd/searcher/internal/search/search_structural_test.go
+++ b/cmd/searcher/internal/search/search_structural_test.go
@@ -722,7 +722,7 @@ func bar() {
 	t.Run("Structural search tar input to comby", func(t *testing.T) {
 		ctx, cancel, sender := newLimitedStreamCollector(context.Background(), 1000000000)
 		defer cancel()
-		err := structuralSearch(ctx, comby.TarInput{TarInputEventC: tarInputEventC}, all, "", p.Pattern, p.CombyRule, p.Languages, "repo_foo", sender)
+		err := structuralSearch(ctx, comby.Tar{TarInputEventC: tarInputEventC}, all, "", p.Pattern, p.CombyRule, p.Languages, "repo_foo", sender)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/cmd/searcher/internal/search/search_structural_test.go
+++ b/cmd/searcher/internal/search/search_structural_test.go
@@ -3,7 +3,6 @@ package search
 import (
 	"archive/tar"
 	"context"
-	"github.com/sourcegraph/sourcegraph/internal/comby"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -15,6 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/sourcegraph/sourcegraph/cmd/searcher/protocol"
+	"github.com/sourcegraph/sourcegraph/internal/comby"
 	"github.com/sourcegraph/sourcegraph/internal/search"
 )
 

--- a/cmd/searcher/internal/search/zoekt_search.go
+++ b/cmd/searcher/internal/search/zoekt_search.go
@@ -154,6 +154,7 @@ func zoektSearch(ctx context.Context, args *search.TextPatternInfo, branchRepos 
 
 	tarInputEventC := make(chan comby.TarInputEvent)
 	wg := sync.WaitGroup{}
+	defer wg.Wait()
 
 	wg.Add(1)
 	go func() {
@@ -187,7 +188,6 @@ func zoektSearch(ctx context.Context, args *search.TextPatternInfo, branchRepos 
 	if since(t0) >= searchOpts.MaxWallTime {
 		return errNoResultsInTimeout
 	}
-	wg.Wait()
 
 	return nil
 }

--- a/cmd/searcher/internal/search/zoekt_search.go
+++ b/cmd/searcher/internal/search/zoekt_search.go
@@ -1,9 +1,9 @@
 package search
 
 import (
-	"archive/zip"
+	"archive/tar"
 	"context"
-	"io"
+	"github.com/inconshreveable/log15"
 	"regexp/syntax" //nolint:depguard // zoekt requires this pkg
 	"sync"
 	"sync/atomic"
@@ -11,14 +11,11 @@ import (
 
 	"github.com/google/zoekt"
 	zoektquery "github.com/google/zoekt/query"
-	"github.com/opentracing/opentracing-go/log"
-
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/comby"
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/search/backend"
 	zoektutil "github.com/sourcegraph/sourcegraph/internal/search/zoekt"
-	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
@@ -121,19 +118,16 @@ const defaultMaxSearchResults = 30
 // Timeouts are reported through the context, and as a special case errNoResultsInTimeout
 // is returned if no results are found in the given timeout (instead of the more common
 // case of finding partial or full results in the given timeout).
-func zoektSearch(ctx context.Context, args *search.TextPatternInfo, branchRepos []zoektquery.BranchRepos, since func(t time.Time) time.Duration, endpoints []string, c chan<- zoektSearchStreamEvent) (fm []zoekt.FileMatch, limitHit bool, partial map[api.RepoID]struct{}, err error) {
+func zoektSearch(ctx context.Context, args *search.TextPatternInfo, branchRepos []zoektquery.BranchRepos, since func(t time.Time) time.Duration, endpoints []string, c chan<- zoektSearchStreamEvent, repo api.RepoName, sender matchSender) (err error) {
 	defer func() {
 		if c != nil {
 			c <- zoektSearchStreamEvent{
-				fm:       fm,
-				limitHit: limitHit,
-				partial:  partial,
-				err:      err,
+				err: err,
 			}
 		}
 	}()
 	if len(branchRepos) == 0 {
-		return nil, false, nil, nil
+		return nil
 	}
 
 	numRepos := 0
@@ -148,82 +142,51 @@ func zoektSearch(ctx context.Context, args *search.TextPatternInfo, branchRepos 
 
 	filePathPatterns, err := handleFilePathPatterns(args)
 	if err != nil {
-		return nil, false, nil, err
+		return err
 	}
 
 	t0 := time.Now()
-	q, err := buildQuery(args, branchRepos, filePathPatterns, true)
+	q, err := buildQuery(args, branchRepos, filePathPatterns, false)
 	if err != nil {
-		return nil, false, nil, err
+		return err
 	}
 
-	client := getZoektClient(endpoints)
-	resp, err := client.Search(ctx, q, &searchOpts)
-	if err != nil {
-		return nil, false, nil, err
-	}
-	if since(t0) >= searchOpts.MaxWallTime {
-		return nil, false, nil, errNoResultsInTimeout
-	}
+	tarInputEventC := make(chan comby.TarInputEvent)
+	wg := sync.WaitGroup{}
 
-	// We always return approximate results (limitHit true) unless we run the branch to perform a more complete search.
-	limitHit = true
-	// If the previous indexed search did not return a substantial number of matching file candidates or count was
-	// manually specified, run a more complete and expensive search.
-	if resp.FileCount < 10 || args.FileMatchLimit != defaultMaxSearchResults {
-		q, err = buildQuery(args, branchRepos, filePathPatterns, false)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		err = structuralSearch(ctx, comby.TarInput{TarInputEventC: tarInputEventC}, all, ".generic", args.Pattern, args.CombyRule, args.Languages, repo, sender)
 		if err != nil {
-			return nil, false, nil, err
+			log15.Error("error during structural search", err)
 		}
-		resp, err = client.Search(ctx, q, &searchOpts)
-		if err != nil {
-			return nil, false, nil, err
-		}
-		if since(t0) >= searchOpts.MaxWallTime {
-			return nil, false, nil, errNoResultsInTimeout
-		}
-		// This is the only place limitHit can be set false, meaning we covered everything.
-		limitHit = resp.FilesSkipped+resp.ShardsSkipped > 0
-	}
-
-	if len(resp.Files) == 0 {
-		return nil, false, nil, nil
-	}
-
-	maxLineMatches := 25 + k
-	for _, file := range resp.Files {
-		if len(file.LineMatches) > maxLineMatches {
-			file.LineMatches = file.LineMatches[:maxLineMatches]
-			limitHit = true
-		}
-	}
-
-	return resp.Files, limitHit, partial, nil
-}
-
-func writeZip(ctx context.Context, w io.Writer, fileMatches []zoekt.FileMatch) (err error) {
-	bytesWritten := 0
-	span, _ := ot.StartSpanFromContext(ctx, "WriteZip")
-	defer func() {
-		span.LogFields(log.Int("bytes_written", bytesWritten))
-		span.Finish()
 	}()
 
-	zw := zip.NewWriter(w)
-	defer zw.Close()
-
-	for _, match := range fileMatches {
-		mw, err := zw.Create(match.FileName)
-		if err != nil {
-			return err
+	client := getZoektClient(endpoints)
+	err = client.StreamSearch(ctx, q, &searchOpts, backend.ZoektStreamFunc(func(event *zoekt.SearchResult) {
+		for _, file := range event.Files {
+			hdr := tar.Header{
+				Name: file.FileName,
+				Mode: 0600,
+				Size: int64(len(file.Content)),
+			}
+			tarInput := comby.TarInputEvent{
+				Header:  hdr,
+				Content: file.Content,
+			}
+			tarInputEventC <- tarInput
 		}
+	}))
+	close(tarInputEventC)
 
-		n, err := mw.Write(match.Content)
-		if err != nil {
-			return err
-		}
-		bytesWritten += n
+	if err != nil {
+		return err
 	}
+	if since(t0) >= searchOpts.MaxWallTime {
+		return errNoResultsInTimeout
+	}
+	wg.Wait()
 
 	return nil
 }

--- a/cmd/searcher/internal/search/zoekt_search.go
+++ b/cmd/searcher/internal/search/zoekt_search.go
@@ -158,7 +158,7 @@ func zoektSearch(ctx context.Context, args *search.TextPatternInfo, branchRepos 
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		err = structuralSearch(ctx, comby.TarInput{TarInputEventC: tarInputEventC}, all, ".generic", args.Pattern, args.CombyRule, args.Languages, repo, sender)
+		err = structuralSearch(ctx, comby.Tar{TarInputEventC: tarInputEventC}, all, ".generic", args.Pattern, args.CombyRule, args.Languages, repo, sender)
 		if err != nil {
 			log.NamedError("structural search error", err)
 		}

--- a/cmd/searcher/internal/search/zoekt_search.go
+++ b/cmd/searcher/internal/search/zoekt_search.go
@@ -167,7 +167,7 @@ func zoektSearch(ctx context.Context, args *search.TextPatternInfo, branchRepos 
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		err = structuralSearch(ctx, comby.Tar{TarInputEventC: tarInputEventC}, all, extensionHint, args.Pattern, args.CombyRule, args.Languages, repo, sender)
+		err := structuralSearch(ctx, comby.Tar{TarInputEventC: tarInputEventC}, all, extensionHint, args.Pattern, args.CombyRule, args.Languages, repo, sender)
 		if err != nil {
 			log.NamedError("structural search error", err)
 		}

--- a/cmd/searcher/internal/search/zoekt_search.go
+++ b/cmd/searcher/internal/search/zoekt_search.go
@@ -3,7 +3,6 @@ package search
 import (
 	"archive/tar"
 	"context"
-	"github.com/inconshreveable/log15"
 	"regexp/syntax" //nolint:depguard // zoekt requires this pkg
 	"sync"
 	"sync/atomic"
@@ -11,6 +10,8 @@ import (
 
 	"github.com/google/zoekt"
 	zoektquery "github.com/google/zoekt/query"
+
+	"github.com/sourcegraph/log"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/comby"
 	"github.com/sourcegraph/sourcegraph/internal/search"
@@ -159,7 +160,7 @@ func zoektSearch(ctx context.Context, args *search.TextPatternInfo, branchRepos 
 		defer wg.Done()
 		err = structuralSearch(ctx, comby.TarInput{TarInputEventC: tarInputEventC}, all, ".generic", args.Pattern, args.CombyRule, args.Languages, repo, sender)
 		if err != nil {
-			log15.Error("error during structural search", err)
+			log.NamedError("structural search error", err)
 		}
 	}()
 

--- a/internal/comby/args.go
+++ b/internal/comby/args.go
@@ -45,6 +45,8 @@ func (args Args) String() string {
 		s = append(s, "-directory", string(i))
 	case FileContent:
 		s = append(s, fmt.Sprintf("<stdin content, length %d>", len(string(i))))
+	case Tar:
+		s = append(s, "-tar", "-chunk-matches", "0")
 	default:
 		s = append(s, fmt.Sprintf("~comby mccombyface is sad and can't handle type %T~", i))
 		log15.Error("unrecognized input type: %T", i)

--- a/internal/comby/args.go
+++ b/internal/comby/args.go
@@ -45,7 +45,7 @@ func (args Args) String() string {
 		s = append(s, "-directory", string(i))
 	case FileContent:
 		s = append(s, fmt.Sprintf("<stdin content, length %d>", len(string(i))))
-	case Tar:
+	case TarInput:
 		s = append(s, "-tar", "-chunk-matches", "0")
 	default:
 		s = append(s, fmt.Sprintf("~comby mccombyface is sad and can't handle type %T~", i))

--- a/internal/comby/args.go
+++ b/internal/comby/args.go
@@ -45,7 +45,7 @@ func (args Args) String() string {
 		s = append(s, "-directory", string(i))
 	case FileContent:
 		s = append(s, fmt.Sprintf("<stdin content, length %d>", len(string(i))))
-	case TarInput:
+	case Tar:
 		s = append(s, "-tar", "-chunk-matches", "0")
 	default:
 		s = append(s, fmt.Sprintf("~comby mccombyface is sad and can't handle type %T~", i))

--- a/internal/comby/comby.go
+++ b/internal/comby/comby.go
@@ -66,7 +66,7 @@ func rawArgs(args Args) (rawArgs []string) {
 		rawArgs = append(rawArgs, "-directory", string(i))
 	case FileContent:
 		rawArgs = append(rawArgs, "-stdin")
-	case TarInput:
+	case Tar:
 		rawArgs = append(rawArgs, "-tar", "-chunk-matches", "0")
 	default:
 		log15.Error("unrecognized input type", "type", i)

--- a/internal/comby/comby.go
+++ b/internal/comby/comby.go
@@ -66,7 +66,7 @@ func rawArgs(args Args) (rawArgs []string) {
 		rawArgs = append(rawArgs, "-directory", string(i))
 	case FileContent:
 		rawArgs = append(rawArgs, "-stdin")
-	case Tar:
+	case TarInput:
 		rawArgs = append(rawArgs, "-tar", "-chunk-matches", "0")
 	default:
 		log15.Error("unrecognized input type", "type", i)
@@ -77,6 +77,21 @@ func rawArgs(args Args) (rawArgs []string) {
 }
 
 type unmarshaller func([]byte) Result
+
+func ToCombyFileMatchWithChunks(b []byte) Result {
+	var m *FileMatchWithChunks
+	err := json.Unmarshal(b, &m)
+	if err == io.EOF {
+		log15.Info("reached EOF")
+		return nil
+	}
+	if err != nil {
+		log15.Info("bytes: " + string(b))
+		log15.Warn("ToCombyFileMatchWithChunks() comby error: skipping unmarshaling error", "err", err.Error())
+		return nil
+	}
+	return m
+}
 
 func toFileMatch(b []byte) Result {
 	var m *FileMatch

--- a/internal/comby/comby.go
+++ b/internal/comby/comby.go
@@ -80,13 +80,7 @@ type unmarshaller func([]byte) Result
 
 func ToCombyFileMatchWithChunks(b []byte) Result {
 	var m *FileMatchWithChunks
-	err := json.Unmarshal(b, &m)
-	if err == io.EOF {
-		log15.Info("reached EOF")
-		return nil
-	}
-	if err != nil {
-		log15.Info("bytes: " + string(b))
+	if err := json.Unmarshal(b, &m); err != nil {
 		log15.Warn("ToCombyFileMatchWithChunks() comby error: skipping unmarshaling error", "err", err.Error())
 		return nil
 	}
@@ -96,7 +90,7 @@ func ToCombyFileMatchWithChunks(b []byte) Result {
 func toFileMatch(b []byte) Result {
 	var m *FileMatch
 	if err := json.Unmarshal(b, &m); err != nil {
-		log15.Warn("comby error: skipping unmarshaling error", "err", err.Error())
+		log15.Warn("toFileMatch() comby error: skipping unmarshaling error", "err", err.Error())
 		return nil
 	}
 	return m
@@ -105,7 +99,7 @@ func toFileMatch(b []byte) Result {
 func toFileReplacement(b []byte) Result {
 	var r *FileReplacement
 	if err := json.Unmarshal(b, &r); err != nil {
-		log15.Warn("comby error: skipping unmarshaling error", "err", err.Error())
+		log15.Warn("toFileReplacement() comby error: skipping unmarshaling error", "err", err.Error())
 		return nil
 	}
 	return r

--- a/internal/comby/comby.go
+++ b/internal/comby/comby.go
@@ -66,6 +66,8 @@ func rawArgs(args Args) (rawArgs []string) {
 		rawArgs = append(rawArgs, "-directory", string(i))
 	case FileContent:
 		rawArgs = append(rawArgs, "-stdin")
+	case Tar:
+		rawArgs = append(rawArgs, "-tar", "-chunk-matches", "0")
 	default:
 		log15.Error("unrecognized input type", "type", i)
 		panic("unreachable")

--- a/internal/comby/types.go
+++ b/internal/comby/types.go
@@ -6,7 +6,7 @@ type Input interface {
 	input()
 }
 
-type TarInput struct {
+type Tar struct {
 	TarInputEventC chan TarInputEvent
 }
 
@@ -22,7 +22,7 @@ type FileContent []byte
 func (ZipPath) input()     {}
 func (DirPath) input()     {}
 func (FileContent) input() {}
-func (TarInput) input()    {}
+func (Tar) input()         {}
 
 type resultKind int
 

--- a/internal/comby/types.go
+++ b/internal/comby/types.go
@@ -7,10 +7,12 @@ type Input interface {
 type ZipPath string
 type DirPath string
 type FileContent []byte
+type Tar []byte
 
 func (ZipPath) input()     {}
 func (DirPath) input()     {}
 func (FileContent) input() {}
+func (Tar) input()         {}
 
 type resultKind int
 

--- a/internal/comby/types.go
+++ b/internal/comby/types.go
@@ -1,18 +1,28 @@
 package comby
 
+import "archive/tar"
+
 type Input interface {
 	input()
+}
+
+type TarInput struct {
+	TarInputEventC chan TarInputEvent
+}
+
+type TarInputEvent struct {
+	Header  tar.Header
+	Content []byte
 }
 
 type ZipPath string
 type DirPath string
 type FileContent []byte
-type Tar []byte
 
 func (ZipPath) input()     {}
 func (DirPath) input()     {}
 func (FileContent) input() {}
-func (Tar) input()         {}
+func (TarInput) input()    {}
 
 type resultKind int
 
@@ -72,21 +82,35 @@ type Match struct {
 	Matched string `json:"matched"`
 }
 
+type ChunkMatch struct {
+	Content string   `json:"content"`
+	Start   Location `json:"start"`
+	Ranges  []Range  `json:"ranges"`
+}
+
 type Result interface {
 	result()
 }
 
 var (
+	_ Result = (*FileMatchWithChunks)(nil)
 	_ Result = (*FileMatch)(nil)
 	_ Result = (*FileDiff)(nil)
 	_ Result = (*FileReplacement)(nil)
 	_ Result = (*Output)(nil)
 )
 
-func (*FileMatch) result()       {}
-func (*FileDiff) result()        {}
-func (*FileReplacement) result() {}
-func (*Output) result()          {}
+func (*FileMatchWithChunks) result() {}
+func (*FileMatch) result()           {}
+func (*FileDiff) result()            {}
+func (*FileReplacement) result()     {}
+func (*Output) result()              {}
+
+// FileMatchWithChunks represents all the chunk matches in a single file.
+type FileMatchWithChunks struct {
+	URI          string       `json:"uri"`
+	ChunkMatches []ChunkMatch `json:"matches"`
+}
 
 // FileMatch represents all the matches in a single file
 type FileMatch struct {


### PR DESCRIPTION
This PR builds on the changes in https://github.com/sourcegraph/sourcegraph/pull/37083 to implement streaming into and out of `comby` for indexed structural search, which noticeably improves performance. These changes depend on [this comby commit](https://github.com/comby-tools/comby/commit/1a48b2fb3d70ad78175eafd98bb9a7f8df41d1c6) which should be included in the next release (current version as of writing is 1.7.1).

Key changes:
- Introduce `TarInput` as an implementor of `comby.Input`
- comby now supports returning chunk matches for invocations with the `-tar` flag (commit linked above). Introduce the type `comby.FileMatchWithChunks` as the unmarshalled format of comby's output when returning chunk matches is active.
- `zoektSearch()` now calls `StreamSearch()` with a callback function that converts each candidate match to tar format and sends it to a channel. `structuralSearch()` receives on that channel and blocks until it's finished receiving.
- On the indexed search path, write candidate matches to comby's stdin as they are received from the channel, and stream out `protocol.FileMatch`es as output is read from comby's stdout.

FYI The original plan was to also include streaming results from comby for unindexed structural search, but I haven't gotten that working yet. It might make sense to treat unindexed search as its own issue and tackle it in a separate PR stacked on this one, especially since merging this PR is blocked until the next comby release anyways.

## Test plan
Added test for streaming tar input to comby via stdin. Manually tested indexed structural search. Ran backend integration tests https://buildkite.com/sourcegraph/sourcegraph/builds/156098