### PR TITLE
dbworker: Low-hanging fruit performance improvements

### DIFF
--- a/enterprise/cmd/executor/internal/worker/mocks_test.go
+++ b/enterprise/cmd/executor/internal/worker/mocks_test.go
@@ -461,7 +461,7 @@ func NewMockStore() *MockStore {
 			},
 		},
 		QueuedCountFunc: &StoreQueuedCountFunc{
-			defaultHook: func(context.Context, interface{}) (r0 int, r1 error) {
+			defaultHook: func(context.Context) (r0 int, r1 error) {
 				return
 			},
 		},
@@ -508,7 +508,7 @@ func NewStrictMockStore() *MockStore {
 			},
 		},
 		QueuedCountFunc: &StoreQueuedCountFunc{
-			defaultHook: func(context.Context, interface{}) (int, error) {
+			defaultHook: func(context.Context) (int, error) {
 				panic("unexpected invocation of MockStore.QueuedCount")
 			},
 		},
@@ -1212,23 +1212,23 @@ func (c StoreMarkFailedFuncCall) Results() []interface{} {
 // StoreQueuedCountFunc describes the behavior when the QueuedCount method
 // of the parent MockStore instance is invoked.
 type StoreQueuedCountFunc struct {
-	defaultHook func(context.Context, interface{}) (int, error)
-	hooks       []func(context.Context, interface{}) (int, error)
+	defaultHook func(context.Context) (int, error)
+	hooks       []func(context.Context) (int, error)
 	history     []StoreQueuedCountFuncCall
 	mutex       sync.Mutex
 }
 
 // QueuedCount delegates to the next hook function in the queue and stores
 // the parameter and result values of this invocation.
-func (m *MockStore) QueuedCount(v0 context.Context, v1 interface{}) (int, error) {
-	r0, r1 := m.QueuedCountFunc.nextHook()(v0, v1)
-	m.QueuedCountFunc.appendCall(StoreQueuedCountFuncCall{v0, v1, r0, r1})
+func (m *MockStore) QueuedCount(v0 context.Context) (int, error) {
+	r0, r1 := m.QueuedCountFunc.nextHook()(v0)
+	m.QueuedCountFunc.appendCall(StoreQueuedCountFuncCall{v0, r0, r1})
 	return r0, r1
 }
 
 // SetDefaultHook sets function that is called when the QueuedCount method
 // of the parent MockStore instance is invoked and the hook queue is empty.
-func (f *StoreQueuedCountFunc) SetDefaultHook(hook func(context.Context, interface{}) (int, error)) {
+func (f *StoreQueuedCountFunc) SetDefaultHook(hook func(context.Context) (int, error)) {
 	f.defaultHook = hook
 }
 
@@ -1236,7 +1236,7 @@ func (f *StoreQueuedCountFunc) SetDefaultHook(hook func(context.Context, interfa
 // QueuedCount method of the parent MockStore instance invokes the hook at
 // the front of the queue and discards it. After the queue is empty, the
 // default hook function is invoked for any future action.
-func (f *StoreQueuedCountFunc) PushHook(hook func(context.Context, interface{}) (int, error)) {
+func (f *StoreQueuedCountFunc) PushHook(hook func(context.Context) (int, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -1245,19 +1245,19 @@ func (f *StoreQueuedCountFunc) PushHook(hook func(context.Context, interface{}) 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
 func (f *StoreQueuedCountFunc) SetDefaultReturn(r0 int, r1 error) {
-	f.SetDefaultHook(func(context.Context, interface{}) (int, error) {
+	f.SetDefaultHook(func(context.Context) (int, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
 func (f *StoreQueuedCountFunc) PushReturn(r0 int, r1 error) {
-	f.PushHook(func(context.Context, interface{}) (int, error) {
+	f.PushHook(func(context.Context) (int, error) {
 		return r0, r1
 	})
 }
 
-func (f *StoreQueuedCountFunc) nextHook() func(context.Context, interface{}) (int, error) {
+func (f *StoreQueuedCountFunc) nextHook() func(context.Context) (int, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -1293,9 +1293,6 @@ type StoreQueuedCountFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.
 	Arg0 context.Context
-	// Arg1 is the value of the 2nd argument passed to this method
-	// invocation.
-	Arg1 interface{}
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 int
@@ -1307,7 +1304,7 @@ type StoreQueuedCountFuncCall struct {
 // Args returns an interface slice containing the arguments of this
 // invocation.
 func (c StoreQueuedCountFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
+	return []interface{}{c.Arg0}
 }
 
 // Results returns an interface slice containing the results of this

--- a/enterprise/cmd/executor/internal/worker/store.go
+++ b/enterprise/cmd/executor/internal/worker/store.go
@@ -25,7 +25,7 @@ type QueueStore interface {
 
 var _ workerutil.Store = &storeShim{}
 
-func (s *storeShim) QueuedCount(ctx context.Context, extraArguments any) (int, error) {
+func (s *storeShim) QueuedCount(ctx context.Context) (int, error) {
 	return 0, errors.New("unimplemented")
 }
 

--- a/enterprise/cmd/precise-code-intel-worker/internal/worker/mocks_test.go
+++ b/enterprise/cmd/precise-code-intel-worker/internal/worker/mocks_test.go
@@ -3325,7 +3325,7 @@ func NewMockWorkerStore() *MockWorkerStore {
 			},
 		},
 		QueuedCountFunc: &WorkerStoreQueuedCountFunc{
-			defaultHook: func(context.Context, bool, []*sqlf.Query) (r0 int, r1 error) {
+			defaultHook: func(context.Context, bool) (r0 int, r1 error) {
 				return
 			},
 		},
@@ -3397,7 +3397,7 @@ func NewStrictMockWorkerStore() *MockWorkerStore {
 			},
 		},
 		QueuedCountFunc: &WorkerStoreQueuedCountFunc{
-			defaultHook: func(context.Context, bool, []*sqlf.Query) (int, error) {
+			defaultHook: func(context.Context, bool) (int, error) {
 				panic("unexpected invocation of MockWorkerStore.QueuedCount")
 			},
 		},
@@ -4360,24 +4360,24 @@ func (c WorkerStoreMaxDurationInQueueFuncCall) Results() []interface{} {
 // WorkerStoreQueuedCountFunc describes the behavior when the QueuedCount
 // method of the parent MockWorkerStore instance is invoked.
 type WorkerStoreQueuedCountFunc struct {
-	defaultHook func(context.Context, bool, []*sqlf.Query) (int, error)
-	hooks       []func(context.Context, bool, []*sqlf.Query) (int, error)
+	defaultHook func(context.Context, bool) (int, error)
+	hooks       []func(context.Context, bool) (int, error)
 	history     []WorkerStoreQueuedCountFuncCall
 	mutex       sync.Mutex
 }
 
 // QueuedCount delegates to the next hook function in the queue and stores
 // the parameter and result values of this invocation.
-func (m *MockWorkerStore) QueuedCount(v0 context.Context, v1 bool, v2 []*sqlf.Query) (int, error) {
-	r0, r1 := m.QueuedCountFunc.nextHook()(v0, v1, v2)
-	m.QueuedCountFunc.appendCall(WorkerStoreQueuedCountFuncCall{v0, v1, v2, r0, r1})
+func (m *MockWorkerStore) QueuedCount(v0 context.Context, v1 bool) (int, error) {
+	r0, r1 := m.QueuedCountFunc.nextHook()(v0, v1)
+	m.QueuedCountFunc.appendCall(WorkerStoreQueuedCountFuncCall{v0, v1, r0, r1})
 	return r0, r1
 }
 
 // SetDefaultHook sets function that is called when the QueuedCount method
 // of the parent MockWorkerStore instance is invoked and the hook queue is
 // empty.
-func (f *WorkerStoreQueuedCountFunc) SetDefaultHook(hook func(context.Context, bool, []*sqlf.Query) (int, error)) {
+func (f *WorkerStoreQueuedCountFunc) SetDefaultHook(hook func(context.Context, bool) (int, error)) {
 	f.defaultHook = hook
 }
 
@@ -4385,7 +4385,7 @@ func (f *WorkerStoreQueuedCountFunc) SetDefaultHook(hook func(context.Context, b
 // QueuedCount method of the parent MockWorkerStore instance invokes the
 // hook at the front of the queue and discards it. After the queue is empty,
 // the default hook function is invoked for any future action.
-func (f *WorkerStoreQueuedCountFunc) PushHook(hook func(context.Context, bool, []*sqlf.Query) (int, error)) {
+func (f *WorkerStoreQueuedCountFunc) PushHook(hook func(context.Context, bool) (int, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -4394,19 +4394,19 @@ func (f *WorkerStoreQueuedCountFunc) PushHook(hook func(context.Context, bool, [
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
 func (f *WorkerStoreQueuedCountFunc) SetDefaultReturn(r0 int, r1 error) {
-	f.SetDefaultHook(func(context.Context, bool, []*sqlf.Query) (int, error) {
+	f.SetDefaultHook(func(context.Context, bool) (int, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
 func (f *WorkerStoreQueuedCountFunc) PushReturn(r0 int, r1 error) {
-	f.PushHook(func(context.Context, bool, []*sqlf.Query) (int, error) {
+	f.PushHook(func(context.Context, bool) (int, error) {
 		return r0, r1
 	})
 }
 
-func (f *WorkerStoreQueuedCountFunc) nextHook() func(context.Context, bool, []*sqlf.Query) (int, error) {
+func (f *WorkerStoreQueuedCountFunc) nextHook() func(context.Context, bool) (int, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -4445,9 +4445,6 @@ type WorkerStoreQueuedCountFuncCall struct {
 	// Arg1 is the value of the 2nd argument passed to this method
 	// invocation.
 	Arg1 bool
-	// Arg2 is the value of the 3rd argument passed to this method
-	// invocation.
-	Arg2 []*sqlf.Query
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 int
@@ -4459,7 +4456,7 @@ type WorkerStoreQueuedCountFuncCall struct {
 // Args returns an interface slice containing the arguments of this
 // invocation.
 func (c WorkerStoreQueuedCountFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+	return []interface{}{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this

--- a/enterprise/cmd/worker/internal/codeintel/indexing/mocks_test.go
+++ b/enterprise/cmd/worker/internal/codeintel/indexing/mocks_test.go
@@ -3594,7 +3594,7 @@ func NewMockWorkerStore() *MockWorkerStore {
 			},
 		},
 		QueuedCountFunc: &WorkerStoreQueuedCountFunc{
-			defaultHook: func(context.Context, bool, []*sqlf.Query) (r0 int, r1 error) {
+			defaultHook: func(context.Context, bool) (r0 int, r1 error) {
 				return
 			},
 		},
@@ -3666,7 +3666,7 @@ func NewStrictMockWorkerStore() *MockWorkerStore {
 			},
 		},
 		QueuedCountFunc: &WorkerStoreQueuedCountFunc{
-			defaultHook: func(context.Context, bool, []*sqlf.Query) (int, error) {
+			defaultHook: func(context.Context, bool) (int, error) {
 				panic("unexpected invocation of MockWorkerStore.QueuedCount")
 			},
 		},
@@ -4629,24 +4629,24 @@ func (c WorkerStoreMaxDurationInQueueFuncCall) Results() []interface{} {
 // WorkerStoreQueuedCountFunc describes the behavior when the QueuedCount
 // method of the parent MockWorkerStore instance is invoked.
 type WorkerStoreQueuedCountFunc struct {
-	defaultHook func(context.Context, bool, []*sqlf.Query) (int, error)
-	hooks       []func(context.Context, bool, []*sqlf.Query) (int, error)
+	defaultHook func(context.Context, bool) (int, error)
+	hooks       []func(context.Context, bool) (int, error)
 	history     []WorkerStoreQueuedCountFuncCall
 	mutex       sync.Mutex
 }
 
 // QueuedCount delegates to the next hook function in the queue and stores
 // the parameter and result values of this invocation.
-func (m *MockWorkerStore) QueuedCount(v0 context.Context, v1 bool, v2 []*sqlf.Query) (int, error) {
-	r0, r1 := m.QueuedCountFunc.nextHook()(v0, v1, v2)
-	m.QueuedCountFunc.appendCall(WorkerStoreQueuedCountFuncCall{v0, v1, v2, r0, r1})
+func (m *MockWorkerStore) QueuedCount(v0 context.Context, v1 bool) (int, error) {
+	r0, r1 := m.QueuedCountFunc.nextHook()(v0, v1)
+	m.QueuedCountFunc.appendCall(WorkerStoreQueuedCountFuncCall{v0, v1, r0, r1})
 	return r0, r1
 }
 
 // SetDefaultHook sets function that is called when the QueuedCount method
 // of the parent MockWorkerStore instance is invoked and the hook queue is
 // empty.
-func (f *WorkerStoreQueuedCountFunc) SetDefaultHook(hook func(context.Context, bool, []*sqlf.Query) (int, error)) {
+func (f *WorkerStoreQueuedCountFunc) SetDefaultHook(hook func(context.Context, bool) (int, error)) {
 	f.defaultHook = hook
 }
 
@@ -4654,7 +4654,7 @@ func (f *WorkerStoreQueuedCountFunc) SetDefaultHook(hook func(context.Context, b
 // QueuedCount method of the parent MockWorkerStore instance invokes the
 // hook at the front of the queue and discards it. After the queue is empty,
 // the default hook function is invoked for any future action.
-func (f *WorkerStoreQueuedCountFunc) PushHook(hook func(context.Context, bool, []*sqlf.Query) (int, error)) {
+func (f *WorkerStoreQueuedCountFunc) PushHook(hook func(context.Context, bool) (int, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -4663,19 +4663,19 @@ func (f *WorkerStoreQueuedCountFunc) PushHook(hook func(context.Context, bool, [
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
 func (f *WorkerStoreQueuedCountFunc) SetDefaultReturn(r0 int, r1 error) {
-	f.SetDefaultHook(func(context.Context, bool, []*sqlf.Query) (int, error) {
+	f.SetDefaultHook(func(context.Context, bool) (int, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
 func (f *WorkerStoreQueuedCountFunc) PushReturn(r0 int, r1 error) {
-	f.PushHook(func(context.Context, bool, []*sqlf.Query) (int, error) {
+	f.PushHook(func(context.Context, bool) (int, error) {
 		return r0, r1
 	})
 }
 
-func (f *WorkerStoreQueuedCountFunc) nextHook() func(context.Context, bool, []*sqlf.Query) (int, error) {
+func (f *WorkerStoreQueuedCountFunc) nextHook() func(context.Context, bool) (int, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -4714,9 +4714,6 @@ type WorkerStoreQueuedCountFuncCall struct {
 	// Arg1 is the value of the 2nd argument passed to this method
 	// invocation.
 	Arg1 bool
-	// Arg2 is the value of the 3rd argument passed to this method
-	// invocation.
-	Arg2 []*sqlf.Query
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 int
@@ -4728,7 +4725,7 @@ type WorkerStoreQueuedCountFuncCall struct {
 // Args returns an interface slice containing the arguments of this
 // invocation.
 func (c WorkerStoreQueuedCountFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+	return []interface{}{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this

--- a/enterprise/cmd/worker/internal/executorqueue/external_emitter.go
+++ b/enterprise/cmd/worker/internal/executorqueue/external_emitter.go
@@ -24,7 +24,7 @@ type reporter interface {
 }
 
 func (r *externalEmitter) Handle(ctx context.Context) error {
-	count, err := r.store.QueuedCount(context.Background(), true, nil)
+	count, err := r.store.QueuedCount(context.Background(), true)
 	if err != nil {
 		return errors.Wrap(err, "dbworkerstore.QueuedCount")
 	}

--- a/enterprise/cmd/worker/internal/permissions/bitbucket_projects_test.go
+++ b/enterprise/cmd/worker/internal/permissions/bitbucket_projects_test.go
@@ -36,7 +36,7 @@ func TestStore(t *testing.T) {
 	require.NotZero(t, jobID)
 
 	store := createBitbucketProjectPermissionsStore(db, &config{})
-	count, err := store.QueuedCount(ctx, true, nil)
+	count, err := store.QueuedCount(ctx, true)
 	require.NoError(t, err)
 	require.Equal(t, 1, count)
 }

--- a/enterprise/internal/insights/background/queryrunner/worker.go
+++ b/enterprise/internal/insights/background/queryrunner/worker.go
@@ -69,7 +69,7 @@ func NewWorker(ctx context.Context, logger log.Logger, workerStore dbworkerstore
 		Name: "src_insights_search_queue_total",
 		Help: "Total number of jobs in the queued state.",
 	}, func() float64 {
-		count, err := workerStore.QueuedCount(context.Background(), false, nil)
+		count, err := workerStore.QueuedCount(context.Background(), false)
 		if err != nil {
 			logger.Error("Failed to get queued job count", log.Error(err))
 		}

--- a/internal/workerutil/dbworker/metrics.go
+++ b/internal/workerutil/dbworker/metrics.go
@@ -23,7 +23,7 @@ func InitPrometheusMetric(observationContext *observation.Context, workerStore s
 		Help:        fmt.Sprintf("Total number of %s records in the queued state.", resource),
 		ConstLabels: constLabels,
 	}, func() float64 {
-		count, err := workerStore.QueuedCount(context.Background(), false, nil)
+		count, err := workerStore.QueuedCount(context.Background(), false)
 		if err != nil {
 			log15.Error("Failed to determine queue size", "error", err)
 			return 0

--- a/internal/workerutil/dbworker/store/store.go
+++ b/internal/workerutil/dbworker/store/store.go
@@ -376,7 +376,6 @@ func (s *store) QueuedCount(ctx context.Context, includeProcessing bool) (_ int,
 		queuedCountQuery,
 		quote(s.options.TableName),
 		sqlf.Join(stateQueries, ","),
-		s.options.MaxNumRetries,
 	)))
 
 	return count, err
@@ -521,7 +520,6 @@ func (s *store) Dequeue(ctx context.Context, workerHostname string, conditions [
 		retryAfter,
 		now,
 		retryAfter,
-		s.options.MaxNumRetries,
 		makeConditionSuffix(conditions),
 		s.options.OrderByExpression,
 		quote(s.options.TableName),

--- a/internal/workerutil/dbworker/store/store.go
+++ b/internal/workerutil/dbworker/store/store.go
@@ -78,8 +78,8 @@ type Store interface {
 	// handle of the other ShareableStore.
 	With(other basestore.ShareableStore) Store
 
-	// QueuedCount returns the number of queued records. If includeProcessing is true it returns the number of queued _and_
-	// processing records.
+	// QueuedCount returns the number of queued and errored records. If includeProcessing
+	// is true it returns the number of queued _and_ processing records.
 	QueuedCount(ctx context.Context, includeProcessing bool) (int, error)
 
 	// MaxDurationInQueue returns the maximum age of queued records in this store. Returns 0 if there are no queued records.

--- a/internal/workerutil/dbworker/store/store.go
+++ b/internal/workerutil/dbworker/store/store.go
@@ -78,8 +78,9 @@ type Store interface {
 	// handle of the other ShareableStore.
 	With(other basestore.ShareableStore) Store
 
-	// QueuedCount returns the number of queued records matching the given conditions.
-	QueuedCount(ctx context.Context, includeProcessing bool, conditions []*sqlf.Query) (int, error)
+	// QueuedCount returns the number of queued records. If includeProcessing is true it returns the number of queued _and_
+	// processing records.
+	QueuedCount(ctx context.Context, includeProcessing bool) (int, error)
 
 	// MaxDurationInQueue returns the maximum age of queued records in this store. Returns 0 if there are no queued records.
 	MaxDurationInQueue(ctx context.Context) (time.Duration, error)
@@ -361,22 +362,21 @@ var columnNames = []string{
 }
 
 // QueuedCount returns the number of queued records matching the given conditions.
-func (s *store) QueuedCount(ctx context.Context, includeProcessing bool, conditions []*sqlf.Query) (_ int, err error) {
+func (s *store) QueuedCount(ctx context.Context, includeProcessing bool) (_ int, err error) {
 	ctx, _, endObservation := s.operations.queuedCount.With(ctx, &err, observation.Args{})
 	defer endObservation(1, observation.Args{})
 
-	stateQueries := make([]*sqlf.Query, 0, 2)
-	stateQueries = append(stateQueries, sqlf.Sprintf("%s", "queued"))
+	stateQueries := make([]*sqlf.Query, 0, 3)
+	stateQueries = append(stateQueries, sqlf.Sprintf("%s", "queued"), sqlf.Sprintf("%s", "errored"))
 	if includeProcessing {
 		stateQueries = append(stateQueries, sqlf.Sprintf("%s", "processing"))
 	}
 
 	count, _, err := basestore.ScanFirstInt(s.Query(ctx, s.formatQuery(
 		queuedCountQuery,
-		quote(s.options.ViewName),
+		quote(s.options.TableName),
 		sqlf.Join(stateQueries, ","),
 		s.options.MaxNumRetries,
-		makeConditionSuffix(conditions),
 	)))
 
 	return count, err
@@ -384,10 +384,11 @@ func (s *store) QueuedCount(ctx context.Context, includeProcessing bool, conditi
 
 const queuedCountQuery = `
 -- source: internal/workerutil/store.go:QueuedCount
-SELECT COUNT(*) FROM %s WHERE (
-	{state} IN (%s) OR
-	({state} = 'errored' AND {num_failures} < %s)
-) %s
+SELECT
+	COUNT(*)
+FROM %s
+WHERE
+	{state} IN (%s)
 `
 
 // MaxDurationInQueue returns the longest duration for which a job associated with this store instance has
@@ -408,16 +409,15 @@ func (s *store) MaxDurationInQueue(ctx context.Context) (_ time.Duration, err er
 
 	ageInSeconds, ok, err := basestore.ScanFirstInt(s.Query(ctx, s.formatQuery(
 		maxDurationInQueueQuery,
-		// candidates
-		quote(s.options.ViewName),
 		// oldest_queued
+		quote(s.options.TableName),
 		now,
 		// oldest_retryable
 		retryAfter,
+		quote(s.options.TableName),
 		retryAfter,
 		now,
 		retryAfter,
-		s.options.MaxNumRetries,
 	)))
 	if err != nil {
 		return 0, err
@@ -432,14 +432,11 @@ func (s *store) MaxDurationInQueue(ctx context.Context) (_ time.Duration, err er
 const maxDurationInQueueQuery = `
 -- source: internal/workerutil/store.go:MaxDurationInQueue
 WITH
-candidates AS (
-	SELECT * FROM %s
-),
 oldest_queued AS (
 	SELECT
 		-- Select when the record was most recently dequeueable
 		GREATEST({queued_at}, {process_after}) AS last_queued_at
-	FROM candidates
+	FROM %s
 	WHERE
 		{state} = 'queued' AND
 		({process_after} IS NULL OR {process_after} <= %s)
@@ -448,12 +445,11 @@ oldest_retryable AS (
 	SELECT
 		-- Select when the record was most recently dequeueable
 		{finished_at} + (%s * '1 second'::interval) AS last_queued_at
-	FROM candidates
+	FROM %s
 	WHERE
 		%s > 0 AND
 		{state} = 'errored' AND
-		%s - {finished_at} > (%s * '1 second'::interval) AND
-		{num_failures} < %s
+		%s - {finished_at} > (%s * '1 second'::interval)
 ),
 oldest_record AS (
 	(
@@ -561,8 +557,7 @@ WITH potential_candidates AS (
 			) OR (
 				%s > 0 AND
 				{state} = 'errored' AND
-				%s - {finished_at} > (%s * '1 second'::interval) AND
-				{num_failures} < %s
+				%s - {finished_at} > (%s * '1 second'::interval)
 			)
 		)
 		%s
@@ -765,7 +760,7 @@ func (s *store) AddExecutionLogEntry(ctx context.Context, id int, entry workerut
 				"err", debugErr,
 			)
 		}
-		log15.Error("updateExecutionLogEntry failed and didn't match rows",
+		log15.Error("addExecutionLogEntry failed and didn't match rows",
 			"recordID", id,
 			"debug", debug,
 			"options.workerHostname", options.WorkerHostname,

--- a/internal/workerutil/dbworker/store/store_test.go
+++ b/internal/workerutil/dbworker/store/store_test.go
@@ -31,7 +31,7 @@ func TestStoreQueuedCount(t *testing.T) {
 		t.Fatalf("unexpected error inserting records: %s", err)
 	}
 
-	count, err := testStore(db, defaultTestStoreOptions(nil)).QueuedCount(context.Background(), false, nil)
+	count, err := testStore(db, defaultTestStoreOptions(nil)).QueuedCount(context.Background(), false)
 	if err != nil {
 		t.Fatalf("unexpected error getting queued count: %s", err)
 	}
@@ -55,7 +55,7 @@ func TestStoreQueuedCountIncludeProcessing(t *testing.T) {
 		t.Fatalf("unexpected error inserting records: %s", err)
 	}
 
-	count, err := testStore(db, defaultTestStoreOptions(nil)).QueuedCount(context.Background(), true, nil)
+	count, err := testStore(db, defaultTestStoreOptions(nil)).QueuedCount(context.Background(), true)
 	if err != nil {
 		t.Fatalf("unexpected error getting queued count: %s", err)
 	}
@@ -80,32 +80,7 @@ func TestStoreQueuedCountFailed(t *testing.T) {
 		t.Fatalf("unexpected error inserting records: %s", err)
 	}
 
-	count, err := testStore(db, defaultTestStoreOptions(nil)).QueuedCount(context.Background(), false, nil)
-	if err != nil {
-		t.Fatalf("unexpected error getting queued count: %s", err)
-	}
-	if count != 2 {
-		t.Errorf("unexpected count. want=%d have=%d", 2, count)
-	}
-}
-
-func TestStoreQueuedCountConditions(t *testing.T) {
-	db := setupStoreTest(t)
-
-	if _, err := db.ExecContext(context.Background(), `
-		INSERT INTO workerutil_test (id, state, created_at)
-		VALUES
-			(1, 'queued', NOW() - '1 minute'::interval),
-			(2, 'queued', NOW() - '2 minute'::interval),
-			(3, 'state2', NOW() - '3 minute'::interval),
-			(4, 'queued', NOW() - '4 minute'::interval),
-			(5, 'state2', NOW() - '5 minute'::interval)
-	`); err != nil {
-		t.Fatalf("unexpected error inserting records: %s", err)
-	}
-
-	conditions := []*sqlf.Query{sqlf.Sprintf("workerutil_test.id < 4")}
-	count, err := testStore(db, defaultTestStoreOptions(nil)).QueuedCount(context.Background(), false, conditions)
+	count, err := testStore(db, defaultTestStoreOptions(nil)).QueuedCount(context.Background(), false)
 	if err != nil {
 		t.Fatalf("unexpected error getting queued count: %s", err)
 	}

--- a/internal/workerutil/dbworker/store/store_test.go
+++ b/internal/workerutil/dbworker/store/store_test.go
@@ -84,8 +84,8 @@ func TestStoreQueuedCountFailed(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error getting queued count: %s", err)
 	}
-	if count != 2 {
-		t.Errorf("unexpected count. want=%d have=%d", 2, count)
+	if count != 3 {
+		t.Errorf("unexpected count. want=%d have=%d", 3, count)
 	}
 }
 
@@ -147,9 +147,8 @@ func TestStoreMaxDurationInQueueFailed(t *testing.T) {
 			(2, 'errored', NOW(),                          NOW() - '30 minutes'::interval, 2), -- oldest retryable error'd
 			(3, 'errored', NOW(),                          NOW() - '10 minutes'::interval, 2), -- retryable, but too young to be queued
 			(4, 'state2',  NOW() - '40 minutes'::interval, NULL,                           0), -- wrong state
-			(5, 'errored', NOW(),                          NOW() - '50 minutes'::interval, 3), -- non-retryable (max attempts exceeded)
-			(6, 'queued',  NOW() - '20 minutes'::interval, NULL,                           0), -- oldest queued
-			(7, 'failed',  NOW(),                          NOW() - '60 minutes'::interval, 1)  -- wrong state
+			(5, 'queued',  NOW() - '20 minutes'::interval, NULL,                           0), -- oldest queued
+			(6, 'failed',  NOW(),                          NOW() - '60 minutes'::interval, 1)  -- wrong state
 	`); err != nil {
 		t.Fatalf("unexpected error inserting records: %s", err)
 	}
@@ -358,7 +357,7 @@ func TestStoreDequeueRetryAfter(t *testing.T) {
 		VALUES
 			(1, 'errored', NOW() - '6 minute'::interval, 'error', 3, NOW() - '2 minutes'::interval),
 			(2, 'errored', NOW() - '4 minute'::interval, 'error', 0, NOW() - '3 minutes'::interval),
-			(3, 'errored', NOW() - '6 minute'::interval, 'error', 5, NOW() - '4 minutes'::interval),
+			(3, 'failed',  NOW() - '6 minute'::interval, 'error', 5, NOW() - '4 minutes'::interval),
 			(4, 'queued',                          NULL,    NULL, 0, NOW() - '1 minutes'::interval)
 	`); err != nil {
 		t.Fatalf("unexpected error inserting records: %s", err)

--- a/internal/workerutil/dbworker/store_shim.go
+++ b/internal/workerutil/dbworker/store_shim.go
@@ -27,13 +27,8 @@ func newStoreShim(store store.Store) workerutil.Store {
 }
 
 // QueuedCount calls into the inner store.
-func (s *storeShim) QueuedCount(ctx context.Context, extraArguments any) (int, error) {
-	conditions, err := convertArguments(extraArguments)
-	if err != nil {
-		return 0, err
-	}
-
-	return s.Store.QueuedCount(ctx, false, conditions)
+func (s *storeShim) QueuedCount(ctx context.Context) (int, error) {
+	return s.Store.QueuedCount(ctx, false)
 }
 
 // Dequeue calls into the inner store.

--- a/internal/workerutil/mocks_test.go
+++ b/internal/workerutil/mocks_test.go
@@ -228,7 +228,7 @@ func NewMockStore() *MockStore {
 			},
 		},
 		QueuedCountFunc: &StoreQueuedCountFunc{
-			defaultHook: func(context.Context, interface{}) (r0 int, r1 error) {
+			defaultHook: func(context.Context) (r0 int, r1 error) {
 				return
 			},
 		},
@@ -275,7 +275,7 @@ func NewStrictMockStore() *MockStore {
 			},
 		},
 		QueuedCountFunc: &StoreQueuedCountFunc{
-			defaultHook: func(context.Context, interface{}) (int, error) {
+			defaultHook: func(context.Context) (int, error) {
 				panic("unexpected invocation of MockStore.QueuedCount")
 			},
 		},
@@ -979,23 +979,23 @@ func (c StoreMarkFailedFuncCall) Results() []interface{} {
 // StoreQueuedCountFunc describes the behavior when the QueuedCount method
 // of the parent MockStore instance is invoked.
 type StoreQueuedCountFunc struct {
-	defaultHook func(context.Context, interface{}) (int, error)
-	hooks       []func(context.Context, interface{}) (int, error)
+	defaultHook func(context.Context) (int, error)
+	hooks       []func(context.Context) (int, error)
 	history     []StoreQueuedCountFuncCall
 	mutex       sync.Mutex
 }
 
 // QueuedCount delegates to the next hook function in the queue and stores
 // the parameter and result values of this invocation.
-func (m *MockStore) QueuedCount(v0 context.Context, v1 interface{}) (int, error) {
-	r0, r1 := m.QueuedCountFunc.nextHook()(v0, v1)
-	m.QueuedCountFunc.appendCall(StoreQueuedCountFuncCall{v0, v1, r0, r1})
+func (m *MockStore) QueuedCount(v0 context.Context) (int, error) {
+	r0, r1 := m.QueuedCountFunc.nextHook()(v0)
+	m.QueuedCountFunc.appendCall(StoreQueuedCountFuncCall{v0, r0, r1})
 	return r0, r1
 }
 
 // SetDefaultHook sets function that is called when the QueuedCount method
 // of the parent MockStore instance is invoked and the hook queue is empty.
-func (f *StoreQueuedCountFunc) SetDefaultHook(hook func(context.Context, interface{}) (int, error)) {
+func (f *StoreQueuedCountFunc) SetDefaultHook(hook func(context.Context) (int, error)) {
 	f.defaultHook = hook
 }
 
@@ -1003,7 +1003,7 @@ func (f *StoreQueuedCountFunc) SetDefaultHook(hook func(context.Context, interfa
 // QueuedCount method of the parent MockStore instance invokes the hook at
 // the front of the queue and discards it. After the queue is empty, the
 // default hook function is invoked for any future action.
-func (f *StoreQueuedCountFunc) PushHook(hook func(context.Context, interface{}) (int, error)) {
+func (f *StoreQueuedCountFunc) PushHook(hook func(context.Context) (int, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -1012,19 +1012,19 @@ func (f *StoreQueuedCountFunc) PushHook(hook func(context.Context, interface{}) 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
 func (f *StoreQueuedCountFunc) SetDefaultReturn(r0 int, r1 error) {
-	f.SetDefaultHook(func(context.Context, interface{}) (int, error) {
+	f.SetDefaultHook(func(context.Context) (int, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
 func (f *StoreQueuedCountFunc) PushReturn(r0 int, r1 error) {
-	f.PushHook(func(context.Context, interface{}) (int, error) {
+	f.PushHook(func(context.Context) (int, error) {
 		return r0, r1
 	})
 }
 
-func (f *StoreQueuedCountFunc) nextHook() func(context.Context, interface{}) (int, error) {
+func (f *StoreQueuedCountFunc) nextHook() func(context.Context) (int, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -1060,9 +1060,6 @@ type StoreQueuedCountFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.
 	Arg0 context.Context
-	// Arg1 is the value of the 2nd argument passed to this method
-	// invocation.
-	Arg1 interface{}
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 int
@@ -1074,7 +1071,7 @@ type StoreQueuedCountFuncCall struct {
 // Args returns an interface slice containing the arguments of this
 // invocation.
 func (c StoreQueuedCountFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
+	return []interface{}{c.Arg0}
 }
 
 // Results returns an interface slice containing the results of this

--- a/internal/workerutil/store.go
+++ b/internal/workerutil/store.go
@@ -13,9 +13,8 @@ type Record interface {
 
 // Store is the persistence layer for the workerutil package that handles worker-side operations.
 type Store interface {
-	// QueuedCount returns the number of records in the queued state. Any extra arguments supplied will be used in
-	// accordance with the concrete persistence layer (e.g. additional SQL conditions for a database layer).
-	QueuedCount(ctx context.Context, extraArguments any) (int, error)
+	// QueuedCount returns the number of records in the queued state.
+	QueuedCount(ctx context.Context) (int, error)
 
 	// Dequeue selects a record for processing. Any extra arguments supplied will be used in accordance with the
 	// concrete persistence layer (e.g. additional SQL conditions for a database layer). This method returns a boolean


### PR DESCRIPTION
tl;dr this PR does the following:
- Clean up conditions that are no longer relevant after we introduced the 'failed' state (errored && num_failures > max_failures)
- Don't use views where not required
- Drop the conditions field on QueuedCount, it isn't used and we also don't support it on the MaxDurationInQueue method, and both are meant for metrics. This makes it easier to use `TableName` over `ViewName`
- Reduces the execution time of QueuedCount by ~20ms on average
- Reduces the execution time of MaxDurationInQueue by ~600ms on average

```sql
SELECT COUNT(*) FROM batch_spec_workspace_execution_jobs_with_rank batch_spec_workspace_execution_jobs WHERE (
	state IN ('queued') OR
	(state = 'errored' AND num_failures < 0)
);
```

```
QUERY PLAN
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Aggregate  (cost=48604.02..48604.03 rows=1 width=8) (actual time=152.380..152.491 rows=1 loops=1)
   ->  Hash Left Join  (cost=32521.08..48527.65 rows=30546 width=0) (actual time=136.684..151.030 rows=30005 loops=1)
         Hash Cond: (j.id = q.id)
         ->  Bitmap Heap Scan on batch_spec_workspace_execution_jobs j  (cost=459.72..16323.97 rows=30546 width=8) (actual time=3.360..11.442 rows=30005 loops=1)
               Recheck Cond: ((state = 'queued'::text) OR (state = 'errored'::text))
               Filter: ((state = 'queued'::text) OR ((state = 'errored'::text) AND (num_failures < 0)))
               Heap Blocks: exact=1473
               ->  BitmapOr  (cost=459.72..459.72 rows=30546 width=0) (actual time=3.146..3.148 rows=0 loops=1)
                     ->  Bitmap Index Scan on batch_spec_workspace_execution_jobs_state  (cost=0.00..442.92 rows=30546 width=0) (actual time=3.114..3.114 rows=32261 loops=1)
                           Index Cond: (state = 'queued'::text)
                     ->  Bitmap Index Scan on batch_spec_workspace_execution_jobs_state  (cost=0.00..1.53 rows=1 width=0) (actual time=0.031..0.031 rows=0 loops=1)
                           Index Cond: (state = 'errored'::text)
         ->  Hash  (cost=31679.53..31679.53 rows=30546 width=8) (actual time=133.122..133.230 rows=30005 loops=1)
               Buckets: 32768  Batches: 1  Memory Usage: 1429kB
               ->  Subquery Scan on q  (cost=30992.25..31679.53 rows=30546 width=8) (actual time=120.698..128.160 rows=30005 loops=1)
                     ->  Subquery Scan on queue_candidates  (cost=30992.25..31374.07 rows=30546 width=24) (actual time=120.696..125.877 rows=30005 loops=1)
                           ->  Sort  (cost=30992.25..31068.61 rows=30546 width=36) (actual time=120.693..122.833 rows=30005 loops=1)
                                 Sort Key: (rank() OVER (?)), queue.latest_dequeue NULLS FIRST
                                 Sort Method: quicksort  Memory: 3113kB
                                 ->  WindowAgg  (cost=28029.48..28716.77 rows=30546 width=36) (actual time=96.197..114.483 rows=30005 loops=1)
                                       ->  Sort  (cost=28029.48..28105.85 rows=30546 width=28) (actual time=96.174..97.607 rows=30005 loops=1)
                                             Sort Key: queue.user_id, exec.created_at, exec.id
                                             Sort Method: quicksort  Memory: 3113kB
                                             ->  Hash Join  (cost=9944.42..25754.01 rows=30546 width=28) (actual time=63.052..77.568 rows=30005 loops=1)
                                                   Hash Cond: (exec.user_id = queue.user_id)
                                                   ->  Bitmap Heap Scan on batch_spec_workspace_execution_jobs exec  (cost=450.55..16162.07 rows=30546 width=20) (actual time=2.489..12.079 rows=30005 loops=1)
                                                         Recheck Cond: (state = 'queued'::text)
                                                         Heap Blocks: exact=1473
                                                         ->  Bitmap Index Scan on batch_spec_workspace_execution_jobs_state  (cost=0.00..442.92 rows=30546 width=0) (actual time=2.307..2.307 rows=32261 loops=1)
                                                               Index Cond: (state = 'queued'::text)
                                                   ->  Hash  (cost=9493.62..9493.62 rows=19 width=12) (actual time=60.513..60.616 rows=22 loops=1)
                                                         Buckets: 1024  Batches: 1  Memory Usage: 9kB
                                                         ->  Subquery Scan on queue  (cost=1000.48..9493.62 rows=19 width=12) (actual time=59.522..60.583 rows=22 loops=1)
                                                               ->  Finalize GroupAggregate  (cost=1000.48..9493.43 rows=19 width=12) (actual time=59.520..60.578 rows=22 loops=1)
                                                                     Group Key: exec_1.user_id
                                                                     ->  Gather Merge  (cost=1000.48..9492.86 rows=76 width=12) (actual time=59.354..60.559 rows=38 loops=1)
                                                                           Workers Planned: 4
                                                                           Workers Launched: 4
                                                                           ->  Partial GroupAggregate  (cost=0.42..8483.75 rows=19 width=12) (actual time=21.327..43.632 rows=8 loops=5)
                                                                                 Group Key: exec_1.user_id
                                                                                 ->  Parallel Index Only Scan using batch_spec_workspace_execution_jobs_last_dequeue on batch_spec_workspace_execution_jobs exec_1  (cost=0.42..8063.67 rows=83979 width=12) (actual time=0.043..37.672 rows=67183 loops=5)
                                                                                       Heap Fetches: 109359
 Planning Time: 2.136 ms
 Execution Time: 153.838 ms
(44 rows)
```

```sql
SELECT
	COUNT(*)
FROM batch_spec_workspace_execution_jobs_with_rank batch_spec_workspace_execution_jobs
WHERE
	state IN ('queued', 'errored')
```

```
QUERY PLAN
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Aggregate  (cost=49787.27..49787.28 rows=1 width=8) (actual time=134.689..134.795 rows=1 loops=1)
   ->  Hash Left Join  (cost=34113.84..49713.34 rows=29572 width=0) (actual time=121.297..133.427 rows=29675 loops=1)
         Hash Cond: (j.id = q.id)
         ->  Bitmap Heap Scan on batch_spec_workspace_execution_jobs j  (cost=429.13..15891.70 rows=29572 width=8) (actual time=2.360..8.445 rows=29675 loops=1)
               Recheck Cond: (state = ANY ('{queued,errored}'::text[]))
               Heap Blocks: exact=1460
               ->  Bitmap Index Scan on batch_spec_workspace_execution_jobs_state  (cost=0.00..421.74 rows=29572 width=0) (actual time=2.188..2.189 rows=32261 loops=1)
                     Index Cond: (state = ANY ('{queued,errored}'::text[]))
         ->  Hash  (cost=33315.06..33315.06 rows=29572 width=8) (actual time=118.756..118.860 rows=29675 loops=1)
               Buckets: 32768  Batches: 1  Memory Usage: 1416kB
               ->  Subquery Scan on q  (cost=32649.69..33315.06 rows=29572 width=8) (actual time=106.911..113.983 rows=29675 loops=1)
                     ->  Subquery Scan on queue_candidates  (cost=32649.69..33019.34 rows=29572 width=24) (actual time=106.910..111.908 rows=29675 loops=1)
                           ->  Sort  (cost=32649.69..32723.62 rows=29572 width=36) (actual time=106.907..108.955 rows=29675 loops=1)
                                 Sort Key: (rank() OVER (?)), queue.latest_dequeue NULLS FIRST
                                 Sort Method: quicksort  Memory: 3087kB
                                 ->  WindowAgg  (cost=29788.31..30453.68 rows=29572 width=36) (actual time=84.344..101.149 rows=29675 loops=1)
                                       ->  Sort  (cost=29788.31..29862.24 rows=29572 width=28) (actual time=84.326..85.692 rows=29675 loops=1)
                                             Sort Key: queue.user_id, exec.created_at, exec.id
                                             Sort Method: quicksort  Memory: 3087kB
                                             ->  Hash Join  (cost=12032.74..27592.30 rows=29572 width=28) (actual time=50.792..65.839 rows=29675 loops=1)
                                                   Hash Cond: (exec.user_id = queue.user_id)
                                                   ->  Bitmap Heap Scan on batch_spec_workspace_execution_jobs exec  (cost=436.41..15898.98 rows=29572 width=20) (actual time=2.156..11.845 rows=29675 loops=1)
                                                         Recheck Cond: (state = 'queued'::text)
                                                         Heap Blocks: exact=1460
                                                         ->  Bitmap Index Scan on batch_spec_workspace_execution_jobs_state  (cost=0.00..429.01 rows=29572 width=0) (actual time=1.988..1.988 rows=32261 loops=1)
                                                               Index Cond: (state = 'queued'::text)
                                                   ->  Hash  (cost=11596.13..11596.13 rows=17 width=12) (actual time=48.614..48.714 rows=22 loops=1)
                                                         Buckets: 1024  Batches: 1  Memory Usage: 9kB
                                                         ->  Subquery Scan on queue  (cost=1000.48..11596.13 rows=17 width=12) (actual time=6.056..48.681 rows=22 loops=1)
                                                               ->  Finalize GroupAggregate  (cost=1000.48..11595.96 rows=17 width=12) (actual time=6.055..48.674 rows=22 loops=1)
                                                                     Group Key: exec_1.user_id
                                                                     ->  Gather Merge  (cost=1000.48..11595.45 rows=68 width=12) (actual time=5.942..48.651 rows=41 loops=1)
                                                                           Workers Planned: 4
                                                                           Workers Launched: 4
                                                                           ->  Partial GroupAggregate  (cost=0.42..10587.29 rows=17 width=12) (actual time=0.271..42.824 rows=8 loops=5)
                                                                                 Group Key: exec_1.user_id
                                                                                 ->  Parallel Index Only Scan using batch_spec_workspace_execution_jobs_last_dequeue on batch_spec_workspace_execution_jobs exec_1  (cost=0.42..10167.22 rows=83979 width=12) (actual time=0.044..37.446 rows=67183 loops=5)
                                                                                       Heap Fetches: 114100
 Planning Time: 0.432 ms
 Execution Time: 135.907 ms
(40 rows)
```

```sql
WITH
candidates AS (
	SELECT * FROM batch_spec_workspace_execution_jobs_with_rank batch_spec_workspace_execution_jobs
),
oldest_queued AS (
	SELECT
		-- Select when the record was most recently dequeueable
		GREATEST(queued_at, process_after) AS last_queued_at
	FROM candidates
	WHERE
		state = 'queued' AND
		(process_after IS NULL OR process_after <= now())
),
oldest_retryable AS (
	SELECT
		-- Select when the record was most recently dequeueable
		finished_at + (15 * '1 second'::interval) AS last_queued_at
	FROM candidates
	WHERE
		0 > 0 AND
		state = 'errored' AND
		now() - finished_at > (0 * '1 second'::interval) AND
		num_failures < 0
),
oldest_record AS (
	(
		SELECT last_queued_at FROM oldest_queued
		UNION
		SELECT last_queued_at FROM oldest_retryable
	)
	ORDER BY last_queued_at
	LIMIT 1
)
SELECT EXTRACT(EPOCH FROM NOW() - last_queued_at)::integer AS age FROM oldest_record;
```

```
QUERY PLAN
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Subquery Scan on oldest_record  (cost=63607.37..63607.39 rows=1 width=4) (actual time=613.663..613.768 rows=1 loops=1)
   CTE candidates
     ->  Hash Left Join  (cost=34054.36..54349.91 rows=335915 width=235) (actual time=130.675..321.333 rows=335915 loops=1)
           Hash Cond: (j.id = q.id)
           ->  Seq Scan on batch_spec_workspace_execution_jobs j  (cost=0.00..18740.15 rows=335915 width=219) (actual time=0.009..106.792 rows=335915 loops=1)
           ->  Hash  (cost=33684.71..33684.71 rows=29572 width=24) (actual time=130.502..130.603 rows=29317 loops=1)
                 Buckets: 32768  Batches: 1  Memory Usage: 1860kB
                 ->  Subquery Scan on q  (cost=32649.69..33684.71 rows=29572 width=24) (actual time=110.406..124.656 rows=29317 loops=1)
                       ->  WindowAgg  (cost=32649.69..33388.99 rows=29572 width=24) (actual time=110.405..122.478 rows=29317 loops=1)
                             ->  Subquery Scan on queue_candidates  (cost=32649.69..33019.34 rows=29572 width=16) (actual time=110.402..115.123 rows=29317 loops=1)
                                   ->  Sort  (cost=32649.69..32723.62 rows=29572 width=36) (actual time=110.399..112.390 rows=29317 loops=1)
                                         Sort Key: (rank() OVER (?)), queue.latest_dequeue NULLS FIRST
                                         Sort Method: quicksort  Memory: 3059kB
                                         ->  WindowAgg  (cost=29788.31..30453.68 rows=29572 width=36) (actual time=87.649..104.705 rows=29317 loops=1)
                                               ->  Sort  (cost=29788.31..29862.24 rows=29572 width=28) (actual time=87.620..88.970 rows=29317 loops=1)
                                                     Sort Key: queue.user_id, exec.created_at, exec.id
                                                     Sort Method: quicksort  Memory: 3059kB
                                                     ->  Hash Join  (cost=12032.74..27592.30 rows=29572 width=28) (actual time=54.578..69.528 rows=29317 loops=1)
                                                           Hash Cond: (exec.user_id = queue.user_id)
                                                           ->  Bitmap Heap Scan on batch_spec_workspace_execution_jobs exec  (cost=436.41..15898.98 rows=29572 width=20) (actual time=2.606..12.281 rows=29317 loops=1)
                                                                 Recheck Cond: (state = 'queued'::text)
                                                                 Heap Blocks: exact=1447
                                                                 ->  Bitmap Index Scan on batch_spec_workspace_execution_jobs_state  (cost=0.00..429.01 rows=29572 width=0) (actual time=2.428..2.429 rows=32261 loops=1)
                                                                       Index Cond: (state = 'queued'::text)
                                                           ->  Hash  (cost=11596.13..11596.13 rows=17 width=12) (actual time=51.950..52.045 rows=22 loops=1)
                                                                 Buckets: 1024  Batches: 1  Memory Usage: 9kB
                                                                 ->  Subquery Scan on queue  (cost=1000.48..11596.13 rows=17 width=12) (actual time=51.285..52.013 rows=22 loops=1)
                                                                       ->  Finalize GroupAggregate  (cost=1000.48..11595.96 rows=17 width=12) (actual time=51.283..52.005 rows=22 loops=1)
                                                                             Group Key: exec_1.user_id
                                                                             ->  Gather Merge  (cost=1000.48..11595.45 rows=68 width=12) (actual time=51.175..51.985 rows=37 loops=1)
                                                                                   Workers Planned: 4
                                                                                   Workers Launched: 4
                                                                                   ->  Partial GroupAggregate  (cost=0.42..10587.29 rows=17 width=12) (actual time=9.245..37.100 rows=7 loops=5)
                                                                                         Group Key: exec_1.user_id
                                                                                         ->  Parallel Index Only Scan using batch_spec_workspace_execution_jobs_last_dequeue on batch_spec_workspace_execution_jobs exec_1  (cost=0.42..10167.22 rows=83979 width=12) (actual time=0.038..32.603 rows=67183 loops=5)
                                                                                               Heap Fetches: 118551
   ->  Limit  (cost=9257.46..9257.46 rows=1 width=8) (actual time=613.658..613.659 rows=1 loops=1)
         ->  Sort  (cost=9257.46..9258.88 rows=566 width=8) (actual time=613.657..613.658 rows=1 loops=1)
               Sort Key: (GREATEST(candidates.queued_at, candidates.process_after))
               Sort Method: quicksort  Memory: 25kB
               ->  HashAggregate  (cost=9248.97..9254.63 rows=566 width=8) (actual time=613.643..613.645 rows=1 loops=1)
                     Group Key: (GREATEST(candidates.queued_at, candidates.process_after))
                     ->  Append  (cost=0.00..9247.56 rows=566 width=8) (actual time=133.431..609.934 rows=29317 loops=1)
                           ->  CTE Scan on candidates  (cost=0.00..9239.08 rows=565 width=8) (actual time=133.430..608.122 rows=29317 loops=1)
                                 Filter: ((state = 'queued'::text) AND ((process_after IS NULL) OR (process_after <= now())))
                                 Rows Removed by Filter: 306598
                           ->  Result  (cost=0.00..0.00 rows=0 width=8) (actual time=0.001..0.001 rows=0 loops=1)
                                 One-Time Filter: false
 Planning Time: 0.555 ms
 Execution Time: 625.682 ms
(50 rows)
```

```sql
WITH
oldest_queued AS (
	SELECT
		-- Select when the record was most recently dequeueable
		GREATEST(queued_at, process_after) AS last_queued_at
	FROM batch_spec_workspace_execution_jobs
	WHERE
		state = 'queued' AND
		(process_after IS NULL OR process_after <= now())
),
oldest_retryable AS (
	SELECT
		-- Select when the record was most recently dequeueable
		finished_at + (15 * '1 second'::interval) AS last_queued_at
	FROM batch_spec_workspace_execution_jobs
	WHERE
		0 > 0 AND
		state = 'errored' AND
		now() - finished_at > (0 * '1 second'::interval)
),
oldest_record AS (
	(
		SELECT last_queued_at FROM oldest_queued
		UNION
		SELECT last_queued_at FROM oldest_retryable
	)
	ORDER BY last_queued_at
	LIMIT 1
)
SELECT EXTRACT(EPOCH FROM NOW() - last_queued_at)::integer AS age FROM oldest_record
```

```
QUERY PLAN
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Subquery Scan on oldest_record  (cost=17014.51..17014.53 rows=1 width=4) (actual time=17.366..17.368 rows=1 loops=1)
   ->  Limit  (cost=17014.51..17014.51 rows=1 width=8) (actual time=17.360..17.362 rows=1 loops=1)
         ->  Sort  (cost=17014.51..17087.91 rows=29360 width=8) (actual time=17.359..17.360 rows=1 loops=1)
               Sort Key: (GREATEST(batch_spec_workspace_execution_jobs.queued_at, batch_spec_workspace_execution_jobs.process_after))
               Sort Method: quicksort  Memory: 25kB
               ->  HashAggregate  (cost=16574.11..16867.71 rows=29360 width=8) (actual time=17.262..17.343 rows=1 loops=1)
                     Group Key: (GREATEST(batch_spec_workspace_execution_jobs.queued_at, batch_spec_workspace_execution_jobs.process_after))
                     ->  Append  (cost=432.55..16500.71 rows=29360 width=8) (actual time=3.646..13.890 rows=28919 loops=1)
                           ->  Bitmap Heap Scan on batch_spec_workspace_execution_jobs  (cost=432.55..16060.32 rows=29359 width=8) (actual time=3.646..12.142 rows=28919 loops=1)
                                 Recheck Cond: (state = 'queued'::text)
                                 Filter: ((process_after IS NULL) OR (process_after <= now()))
                                 Heap Blocks: exact=1433
                                 ->  Bitmap Index Scan on batch_spec_workspace_execution_jobs_state  (cost=0.00..425.22 rows=29359 width=0) (actual time=3.437..3.437 rows=32261 loops=1)
                                       Index Cond: (state = 'queued'::text)
                           ->  Result  (cost=0.00..0.00 rows=0 width=8) (actual time=0.001..0.002 rows=0 loops=1)
                                 One-Time Filter: false
 Planning Time: 0.441 ms
 Execution Time: 18.053 ms
 ```

## Test plan

test suite and query plans.