### PR TITLE
doc: update cla-bot workflow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,14 +22,14 @@ All interactions with the Sourcegraph open source project are governed by the
 ## How to contribute
 
 1. Select one of the issues labeled as [good first issue](https://github.com/orgs/sourcegraph/projects/210).
-2. Clone the repo: `git clone https://github.com/sourcegraph/sourcegraph/`.
-3. [Setup your development environment](https://docs.sourcegraph.com/dev/contributing) to run the project locally.
-4. Before creating a Pull Request ensure that [recommended checks](https://docs.sourcegraph.com/dev/contributing) pass locally. We're actively working on making our CI pipeline public to automate this step.
+2. Clone the repo: `git clone https://github.com/sourcegraph/sourcegraph`.
+3. [Set up your development environment](https://docs.sourcegraph.com/dev/contributing) to run the project locally.
+4. Before creating a pull request, ensure that [recommended checks](https://docs.sourcegraph.com/dev/contributing) pass locally. We're actively working on making our CI pipeline public to automate this step.
 5. **IMPORTANT:** Once you have a pull request ready to review, the 'verification/cla-signed' check will be flagged, and you will be prompted to sign the CLA with a link provided by our bot. Once you sign, add a comment tagging `@sourcegraph/contribution-reviewers`. After that your pull request will be ready for review.
-   - (For Sourcegraph team members, see [these notes](https://docs.sourcegraph.com/dev/contributing/accepting_contribution#cla-bot) for how to verify that the CLA has been signed.)
+   - For Sourcegraph team members, see [these notes](https://docs.sourcegraph.com/dev/contributing/accepting_contribution#cla-bot) for how to verify that the CLA has been signed.
 6. Once you've chosen an issue, **comment on it to announce that you will be working on it**, making it visible for others that this issue is being tackled. If you end up not creating a pull request for this issue, please delete your comment.
 7. If you have any questions, please [refer to the docs first](https://docs.sourcegraph.com/). If you don’t find any relevant information, mention the issue author.
-8. Issue author will try to provide guidance. Sourcegraph always works in async mode. We will try to answer as soon as possible, but please keep time zones differences in mind.
+8. The issue author will try to provide guidance. Sourcegraph always works in async mode. We will try to answer as soon as possible, but please keep time zones differences in mind.
 
 ## Can I pick up this issue?
 

--- a/doc/dev/contributing/accepting_contribution.md
+++ b/doc/dev/contributing/accepting_contribution.md
@@ -5,7 +5,7 @@ This page outlines how to accept a contribution to the [Sourcegraph repository](
 ## CLA-bot
 
 1. For external contributors only: ensure that that contributor signed the [CLA](https://docs.google.com/spreadsheets/d/1_iBZh9PJi-05vTnlQ3GVeeRe8H3Wq1_FZ49aYrsHGLQ/edit?usp=sharing). All fields should be filled with valid data to proceed with the pull request. (This does not apply for Sourcegraph teammates.)
-2. Update the CLA-bot configuration [here](https://github.com/sourcegraph/clabot-config/edit/main/.clabot) by adding a contributor name to the `contributors` field, preserving the alphabetical order.
+2. Wait up to 30 minutes for the form response to be synchronized to the [contributors list](https://github.com/sourcegraph/clabot-config).
 3. Comment on the pull request: `@cla-bot check`.
 4. The `verification/cla-signed` workflow should become green. 🎉
 


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/26992 , based on changes introduced in https://github.com/sourcegraph/clabot-config/pull/87 and https://github.com/sourcegraph/clabot-config/pull/86.

basically:

1. Contributor fills out CLA form
2. GitHub action in `clabot-config` repo runs on a cron, checking for responses that include GitHub handles that are not yet in `.clabot-config`'s contributors list. If there are any, the handles get added (https://github.com/sourcegraph/clabot-config/pull/87) and pushed (https://github.com/sourcegraph/clabot-config/pull/86)
3. cla-bot check will now pass

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

n/a