### PR TITLE
batches: change log output text

### DIFF
--- a/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspaceDetails.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspaceDetails.tsx
@@ -483,8 +483,9 @@ const WorkspaceStep: React.FunctionComponent<React.PropsWithChildren<WorkspaceSt
                             .trim() === ''
                 )
             ) {
-                outputLines.push('stderr: This command did not produce any logs')
+                outputLines.push('stdout: This step was completed successfully')
             }
+
             if (step.exitCode !== null) {
                 outputLines.push(`\nstdout: \nstdout: Command exited with status ${step.exitCode}`)
             }


### PR DESCRIPTION
closes: #37124

To address the fact that the absence of logs is being reflected as an error when it should not
## Test plan
tested a case where the step would not produce logs
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
