### PR TITLE
fix(sg): fix crash with output

### DIFF
--- a/dev/sg/main.go
+++ b/dev/sg/main.go
@@ -27,7 +27,8 @@ func main() {
 		batchCompletionMode = true
 	}
 	if err := sg.RunContext(context.Background(), os.Args); err != nil {
-		std.Out.WriteFailuref(err.Error())
+		out := std.NewOutput(os.Stdout, false)
+		out.WriteFailuref(err.Error())
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
While testing `sg feedback` we noticed help output crashing and tracked it down to this

## Test plan
manually tested
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
