### PR TITLE
Branded: Codemod `<Icon />` usage to `@mdi/react`

### DIFF
--- a/client/branded/src/components/panel/TabbedPanelContent.tsx
+++ b/client/branded/src/components/panel/TabbedPanelContent.tsx
@@ -1,8 +1,8 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
 
+import { mdiClose } from '@mdi/js'
 import classNames from 'classnames'
 import { Remote } from 'comlink'
-import CloseIcon from 'mdi-react/CloseIcon'
 import { useHistory, useLocation } from 'react-router'
 import { BehaviorSubject, from, Observable, combineLatest } from 'rxjs'
 import { map, switchMap } from 'rxjs/operators'
@@ -333,7 +333,7 @@ export const TabbedPanelContent = React.memo<TabbedPanelContentProps>(props => {
                             data-tooltip="Close panel"
                             data-placement="left"
                         >
-                            <Icon as={CloseIcon} aria-hidden={true} />
+                            <Icon aria-hidden={true} svgPath={mdiClose} />
                         </Button>
                     </div>
                 }

--- a/client/branded/src/components/panel/views/EmptyPanelView.tsx
+++ b/client/branded/src/components/panel/views/EmptyPanelView.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 
+import { mdiCancel } from '@mdi/js'
 import classNames from 'classnames'
-import CancelIcon from 'mdi-react/CancelIcon'
 
 import { Icon } from '@sourcegraph/wildcard'
 
@@ -18,7 +18,7 @@ export const EmptyPanelView: React.FunctionComponent<React.PropsWithChildren<Emp
         <div className={classNames(styles.emptyPanel, className)}>
             {children || (
                 <>
-                    <Icon className="mr-2" as={CancelIcon} aria-hidden={true} /> Nothing to show here
+                    <Icon className="mr-2" aria-hidden={true} svgPath={mdiCancel} /> Nothing to show here
                 </>
             )}
         </div>

--- a/client/branded/src/components/panel/views/ExtensionsLoadingView.tsx
+++ b/client/branded/src/components/panel/views/ExtensionsLoadingView.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import PuzzleIcon from 'mdi-react/PuzzleIcon'
+import { mdiPuzzle } from '@mdi/js'
 
 import { LoadingSpinner, Icon } from '@sourcegraph/wildcard'
 
@@ -19,7 +19,7 @@ export const ExtensionsLoadingPanelView: React.FunctionComponent<
         <EmptyPanelView className={className}>
             <LoadingSpinner inline={false} />
             <span className="mx-2">Loading Sourcegraph extensions</span>
-            <Icon as={PuzzleIcon} aria-hidden={true} />
+            <Icon aria-hidden={true} svgPath={mdiPuzzle} />
         </EmptyPanelView>
     )
 }

--- a/client/branded/src/components/panel/views/FileLocations.tsx
+++ b/client/branded/src/components/panel/views/FileLocations.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react'
 
+import { mdiMapSearch } from '@mdi/js'
 import classNames from 'classnames'
 import * as H from 'history'
 import { upperFirst } from 'lodash'
-import MapSearchIcon from 'mdi-react/MapSearchIcon'
 import { Observable, Subject, Subscription } from 'rxjs'
 import { catchError, distinctUntilChanged, map, startWith, switchMap } from 'rxjs/operators'
 import { Badged } from 'sourcegraph'
@@ -32,13 +32,13 @@ export const FileLocationsError: React.FunctionComponent<React.PropsWithChildren
 
 export const FileLocationsNotFound: React.FunctionComponent<React.PropsWithChildren<unknown>> = () => (
     <div className={classNames('m-2', styles.notFound)}>
-        <Icon as={MapSearchIcon} aria-hidden={true} /> No locations found
+        <Icon aria-hidden={true} svgPath={mdiMapSearch} /> No locations found
     </div>
 )
 
 export const FileLocationsNoGroupSelected: React.FunctionComponent<React.PropsWithChildren<unknown>> = () => (
     <div className="m-2">
-        <Icon as={MapSearchIcon} aria-hidden={true} /> No locations found in the current repository
+        <Icon aria-hidden={true} svgPath={mdiMapSearch} /> No locations found in the current repository
     </div>
 )
 


### PR DESCRIPTION
**Migration automated through codemod: https://github.com/sourcegraph/codemod/pull/140**

## Description

Migrates simple `<Icon />` usage from `mdi-react` to `@mdi/react`.

**Why?**

We've had numerous problems with `mdi-react` previously, and this library is better supported and gives us better control over our icons. See https://github.com/sourcegraph/sourcegraph/pull/37387 for more context.

## Test plan

Icon edge cases tested through https://github.com/sourcegraph/sourcegraph/pull/37387, this diff is tested through automated tests.

## App preview:

- [Web](https://sg-web-tr-icon-v2-branded.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-owxkgltvxs.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
