### PR TITLE
sg: justify commands output on sg run/start

### DIFF
--- a/dev/sg/internal/run/logger.go
+++ b/dev/sg/internal/run/logger.go
@@ -24,7 +24,10 @@ func newCmdLogger(ctx context.Context, name string, out *output.Output) *process
 		// we flush partial lines, we don't want to add a newline character. What
 		// we need to do: extend the `*output.Output` type to have a
 		// `WritefNoNewline` (yes, bad name) method.
-		out.Writef("%s%s[%s]%s %s", output.StyleBold, color, name, output.StyleReset, data)
+		//
+		// About the 30 chars text justify, the longest command is 29 chars.
+		// How to quickly check that: cue eval --out=json sg.config.yaml | jq '.commands | keys'
+		out.Writef("%s%s[%+30s]%s %s", output.StyleBold, color, name, output.StyleReset, data)
 	}
 
 	return process.NewLogger(ctx, sink)

--- a/dev/sg/sg_start_test.go
+++ b/dev/sg/sg_start_test.go
@@ -45,8 +45,8 @@ func TestStartCommandSet(t *testing.T) {
 		"✅ Everything installed! Booting up the system!",
 		"",
 		"Running test-cmd-1...",
-		"[test-cmd-1] horsegraph booted up. mount your horse.",
-		"[test-cmd-1] quitting. not horsing around anymore.",
+		"[                    test-cmd-1] horsegraph booted up. mount your horse.",
+		"[                    test-cmd-1] quitting. not horsing around anymore.",
 		"test-cmd-1 exited without error",
 	})
 }


### PR DESCRIPTION
It's nicer to read right? 

<img width="2060" alt="CleanShot 2022-06-20 at 11 56 38@2x" src="https://user-images.githubusercontent.com/10151/174577060-bd024a96-52ed-42c7-9735-5960db41e3b8.png">

We could probably refine this, like detect what's the longest command name possible with the current set, but this was so quick to do that we'd rather get this shipped rn. 

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Tested locally + checked manually what's the longest command we're running with 

```sh
 cue eval --out=json sg.config.yaml | jq '.commands | keys'
```