### PR TITLE
Wildcard: fix createLinkUrl implementation

### DIFF
--- a/client/web/src/components/diff/__snapshots__/DiffHunk.test.tsx.snap
+++ b/client/web/src/components/diff/__snapshots__/DiffHunk.test.tsx.snap
@@ -35,7 +35,7 @@ exports[`DiffHunk renders a unified diff view for the given diff hunk 1`] = `
         >
           <a
             class="numLine"
-            href="/#anchor_L159"
+            href="#anchor_L159"
           >
             159
           </a>
@@ -49,7 +49,7 @@ exports[`DiffHunk renders a unified diff view for the given diff hunk 1`] = `
         >
           <a
             class="numLine"
-            href="/#anchor_R159"
+            href="#anchor_R159"
           >
             159
           </a>
@@ -78,7 +78,7 @@ exports[`DiffHunk renders a unified diff view for the given diff hunk 1`] = `
         >
           <a
             class="numLine"
-            href="/#anchor_L160"
+            href="#anchor_L160"
           >
             160
           </a>
@@ -92,7 +92,7 @@ exports[`DiffHunk renders a unified diff view for the given diff hunk 1`] = `
         >
           <a
             class="numLine"
-            href="/#anchor_R160"
+            href="#anchor_R160"
           >
             160
           </a>
@@ -121,7 +121,7 @@ exports[`DiffHunk renders a unified diff view for the given diff hunk 1`] = `
         >
           <a
             class="numLine"
-            href="/#anchor_L161"
+            href="#anchor_L161"
           >
             161
           </a>
@@ -135,7 +135,7 @@ exports[`DiffHunk renders a unified diff view for the given diff hunk 1`] = `
         >
           <a
             class="numLine"
-            href="/#anchor_R161"
+            href="#anchor_R161"
           >
             161
           </a>
@@ -164,7 +164,7 @@ exports[`DiffHunk renders a unified diff view for the given diff hunk 1`] = `
         >
           <a
             class="numLine"
-            href="/#anchor_L162"
+            href="#anchor_L162"
           >
             162
           </a>
@@ -199,7 +199,7 @@ exports[`DiffHunk renders a unified diff view for the given diff hunk 1`] = `
         >
           <a
             class="numLine"
-            href="/#anchor_R162"
+            href="#anchor_R162"
           >
             162
           </a>
@@ -228,7 +228,7 @@ exports[`DiffHunk renders a unified diff view for the given diff hunk 1`] = `
         >
           <a
             class="numLine"
-            href="/#anchor_L163"
+            href="#anchor_L163"
           >
             163
           </a>
@@ -242,7 +242,7 @@ exports[`DiffHunk renders a unified diff view for the given diff hunk 1`] = `
         >
           <a
             class="numLine"
-            href="/#anchor_R163"
+            href="#anchor_R163"
           >
             163
           </a>
@@ -271,7 +271,7 @@ exports[`DiffHunk renders a unified diff view for the given diff hunk 1`] = `
         >
           <a
             class="numLine"
-            href="/#anchor_L164"
+            href="#anchor_L164"
           >
             164
           </a>
@@ -285,7 +285,7 @@ exports[`DiffHunk renders a unified diff view for the given diff hunk 1`] = `
         >
           <a
             class="numLine"
-            href="/#anchor_R164"
+            href="#anchor_R164"
           >
             164
           </a>
@@ -314,7 +314,7 @@ exports[`DiffHunk renders a unified diff view for the given diff hunk 1`] = `
         >
           <a
             class="numLine"
-            href="/#anchor_L165"
+            href="#anchor_L165"
           >
             165
           </a>
@@ -328,7 +328,7 @@ exports[`DiffHunk renders a unified diff view for the given diff hunk 1`] = `
         >
           <a
             class="numLine"
-            href="/#anchor_R165"
+            href="#anchor_R165"
           >
             165
           </a>
@@ -384,7 +384,7 @@ exports[`DiffHunk renders dark theme decorations if dark theme is active 1`] = `
         >
           <a
             class="numLine"
-            href="/#anchor_L159"
+            href="#anchor_L159"
           >
             159
           </a>
@@ -398,7 +398,7 @@ exports[`DiffHunk renders dark theme decorations if dark theme is active 1`] = `
         >
           <a
             class="numLine"
-            href="/#anchor_R159"
+            href="#anchor_R159"
           >
             159
           </a>
@@ -436,7 +436,7 @@ exports[`DiffHunk renders dark theme decorations if dark theme is active 1`] = `
         >
           <a
             class="numLine"
-            href="/#anchor_L160"
+            href="#anchor_L160"
           >
             160
           </a>
@@ -450,7 +450,7 @@ exports[`DiffHunk renders dark theme decorations if dark theme is active 1`] = `
         >
           <a
             class="numLine"
-            href="/#anchor_R160"
+            href="#anchor_R160"
           >
             160
           </a>
@@ -479,7 +479,7 @@ exports[`DiffHunk renders dark theme decorations if dark theme is active 1`] = `
         >
           <a
             class="numLine"
-            href="/#anchor_L161"
+            href="#anchor_L161"
           >
             161
           </a>
@@ -493,7 +493,7 @@ exports[`DiffHunk renders dark theme decorations if dark theme is active 1`] = `
         >
           <a
             class="numLine"
-            href="/#anchor_R161"
+            href="#anchor_R161"
           >
             161
           </a>
@@ -522,7 +522,7 @@ exports[`DiffHunk renders dark theme decorations if dark theme is active 1`] = `
         >
           <a
             class="numLine"
-            href="/#anchor_L162"
+            href="#anchor_L162"
           >
             162
           </a>
@@ -566,7 +566,7 @@ exports[`DiffHunk renders dark theme decorations if dark theme is active 1`] = `
         >
           <a
             class="numLine"
-            href="/#anchor_R162"
+            href="#anchor_R162"
           >
             162
           </a>
@@ -595,7 +595,7 @@ exports[`DiffHunk renders dark theme decorations if dark theme is active 1`] = `
         >
           <a
             class="numLine"
-            href="/#anchor_L163"
+            href="#anchor_L163"
           >
             163
           </a>
@@ -609,7 +609,7 @@ exports[`DiffHunk renders dark theme decorations if dark theme is active 1`] = `
         >
           <a
             class="numLine"
-            href="/#anchor_R163"
+            href="#anchor_R163"
           >
             163
           </a>
@@ -638,7 +638,7 @@ exports[`DiffHunk renders dark theme decorations if dark theme is active 1`] = `
         >
           <a
             class="numLine"
-            href="/#anchor_L164"
+            href="#anchor_L164"
           >
             164
           </a>
@@ -652,7 +652,7 @@ exports[`DiffHunk renders dark theme decorations if dark theme is active 1`] = `
         >
           <a
             class="numLine"
-            href="/#anchor_R164"
+            href="#anchor_R164"
           >
             164
           </a>
@@ -681,7 +681,7 @@ exports[`DiffHunk renders dark theme decorations if dark theme is active 1`] = `
         >
           <a
             class="numLine"
-            href="/#anchor_L165"
+            href="#anchor_L165"
           >
             165
           </a>
@@ -695,7 +695,7 @@ exports[`DiffHunk renders dark theme decorations if dark theme is active 1`] = `
         >
           <a
             class="numLine"
-            href="/#anchor_R165"
+            href="#anchor_R165"
           >
             165
           </a>
@@ -751,7 +751,7 @@ exports[`DiffHunk renders decorations if given 1`] = `
         >
           <a
             class="numLine"
-            href="/#anchor_L159"
+            href="#anchor_L159"
           >
             159
           </a>
@@ -765,7 +765,7 @@ exports[`DiffHunk renders decorations if given 1`] = `
         >
           <a
             class="numLine"
-            href="/#anchor_R159"
+            href="#anchor_R159"
           >
             159
           </a>
@@ -803,7 +803,7 @@ exports[`DiffHunk renders decorations if given 1`] = `
         >
           <a
             class="numLine"
-            href="/#anchor_L160"
+            href="#anchor_L160"
           >
             160
           </a>
@@ -817,7 +817,7 @@ exports[`DiffHunk renders decorations if given 1`] = `
         >
           <a
             class="numLine"
-            href="/#anchor_R160"
+            href="#anchor_R160"
           >
             160
           </a>
@@ -846,7 +846,7 @@ exports[`DiffHunk renders decorations if given 1`] = `
         >
           <a
             class="numLine"
-            href="/#anchor_L161"
+            href="#anchor_L161"
           >
             161
           </a>
@@ -860,7 +860,7 @@ exports[`DiffHunk renders decorations if given 1`] = `
         >
           <a
             class="numLine"
-            href="/#anchor_R161"
+            href="#anchor_R161"
           >
             161
           </a>
@@ -889,7 +889,7 @@ exports[`DiffHunk renders decorations if given 1`] = `
         >
           <a
             class="numLine"
-            href="/#anchor_L162"
+            href="#anchor_L162"
           >
             162
           </a>
@@ -933,7 +933,7 @@ exports[`DiffHunk renders decorations if given 1`] = `
         >
           <a
             class="numLine"
-            href="/#anchor_R162"
+            href="#anchor_R162"
           >
             162
           </a>
@@ -962,7 +962,7 @@ exports[`DiffHunk renders decorations if given 1`] = `
         >
           <a
             class="numLine"
-            href="/#anchor_L163"
+            href="#anchor_L163"
           >
             163
           </a>
@@ -976,7 +976,7 @@ exports[`DiffHunk renders decorations if given 1`] = `
         >
           <a
             class="numLine"
-            href="/#anchor_R163"
+            href="#anchor_R163"
           >
             163
           </a>
@@ -1005,7 +1005,7 @@ exports[`DiffHunk renders decorations if given 1`] = `
         >
           <a
             class="numLine"
-            href="/#anchor_L164"
+            href="#anchor_L164"
           >
             164
           </a>
@@ -1019,7 +1019,7 @@ exports[`DiffHunk renders decorations if given 1`] = `
         >
           <a
             class="numLine"
-            href="/#anchor_R164"
+            href="#anchor_R164"
           >
             164
           </a>
@@ -1048,7 +1048,7 @@ exports[`DiffHunk renders decorations if given 1`] = `
         >
           <a
             class="numLine"
-            href="/#anchor_L165"
+            href="#anchor_L165"
           >
             165
           </a>
@@ -1062,7 +1062,7 @@ exports[`DiffHunk renders decorations if given 1`] = `
         >
           <a
             class="numLine"
-            href="/#anchor_R165"
+            href="#anchor_R165"
           >
             165
           </a>

--- a/client/wildcard/src/components/Link/createLinkUrl.test.tsx
+++ b/client/wildcard/src/components/Link/createLinkUrl.test.tsx
@@ -1,0 +1,25 @@
+import { createLinkUrl } from './createLinkUrl'
+
+describe('createLinkUrl', () => {
+    it('generates full URL', () => {
+        expect(
+            createLinkUrl({
+                pathname: 'https://sourcegraph.com/search',
+                search: 'q=hello',
+                hash: 'h1',
+            })
+        ).toBe('https://sourcegraph.com/search?q=hello#h1')
+    })
+
+    it('generates relative URL', () => {
+        expect(createLinkUrl({ search: 's=123', hash: 'test-hash' })).toBe('?s=123#test-hash')
+        expect(createLinkUrl({ pathname: '', search: 's=123', hash: 'test-hash' })).toBe('?s=123#test-hash')
+    })
+
+    it('supports variations search and hash', () => {
+        expect(createLinkUrl({ search: 'q=param' })).toBe('?q=param')
+        expect(createLinkUrl({ search: '?q=param' })).toBe('?q=param')
+        expect(createLinkUrl({ hash: 'section' })).toBe('#section')
+        expect(createLinkUrl({ hash: '#section' })).toBe('#section')
+    })
+})

--- a/client/wildcard/src/components/Link/createLinkUrl.tsx
+++ b/client/wildcard/src/components/Link/createLinkUrl.tsx
@@ -1,7 +1,25 @@
-import { createPath, LocationDescriptorObject } from 'history'
+export interface LinkComponents {
+    pathname?: string
+    search?: string
+    hash?: string
+}
 
 /**
  * Convenience method provided for translation of History.LocationDescriptorObject's
  * into strings that are accepted by the RouterLink component.
  */
-export const createLinkUrl = (location: LocationDescriptorObject): string => createPath(location)
+export const createLinkUrl = (location: LinkComponents): string => {
+    const { pathname = '', search, hash } = location
+
+    const components = [pathname]
+
+    if (search?.length) {
+        components.push(search.startsWith('?') ? search : `?${search}`)
+    }
+
+    if (hash?.length) {
+        components.push(hash.startsWith('#') ? hash : `#${hash}`)
+    }
+
+    return components.join('')
+}

--- a/client/wildcard/src/components/Link/createLinkUrl.tsx
+++ b/client/wildcard/src/components/Link/createLinkUrl.tsx
@@ -1,14 +1,14 @@
-export interface LinkComponents {
+export interface URLComponents {
     pathname?: string
     search?: string
     hash?: string
 }
 
 /**
- * Convenience method provided for translation of History.LocationDescriptorObject's
+ * Convenience method provided for translation of URLComponents
  * into strings that are accepted by the RouterLink component.
  */
-export const createLinkUrl = (location: LinkComponents): string => {
+export const createLinkUrl = (location: URLComponents): string => {
     const { pathname = '', search, hash } = location
 
     const components = [pathname]


### PR DESCRIPTION
## Context
In a [recent PR](https://github.com/sourcegraph/sourcegraph/pull/36781) refactoring Link components we introduced `createLinkUrl` function so that Link users create URL strings themselves. This worked fine but unfortunately, led to bugs such [this one](https://github.com/sourcegraph/sourcegraph/issues/37261) because `history`'s implementation of `createPath` thinks that empty `pathname == '/'`. 

This isn't what we expect when there's no absolute path, similar to `<a href='#section'>...</a>`, which is a relative URL.

## Solution
Fix the createLinkUrl implementation and add tests.

## Test plan
1. Pull the branch
2. Launch the app `sg start web-standalone`
3. Open [a diff view](https://sourcegraph.test:3443/github.com/sourcegraph/sourcegraph/-/commit/24da09b7547fb59011eea5a4135bc2219ffcd9b6)
4. Check that line number URLs are not pointing to a `/#hash` but relative to the current page URL + hash.

## App preview:

- [Web](https://sg-web-og-create-link-url-fix.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-bnmfscfvoc.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
