### PR TITLE
VSCode: Codemod `<Icon />` to `@mdi/react`

### DIFF
--- a/client/vscode/src/webview/search-panel/RepoView.tsx
+++ b/client/vscode/src/webview/search-panel/RepoView.tsx
@@ -1,10 +1,8 @@
 import React, { useMemo, useState } from 'react'
 
+import { mdiArrowLeft, mdiFileDocumentOutline, mdiFolderOutline } from '@mdi/js'
 import { VSCodeProgressRing } from '@vscode/webview-ui-toolkit/react'
 import classNames from 'classnames'
-import ArrowLeftIcon from 'mdi-react/ArrowLeftIcon'
-import FileDocumentOutlineIcon from 'mdi-react/FileDocumentOutlineIcon'
-import FolderOutlineIcon from 'mdi-react/FolderOutlineIcon'
 import SourceRepositoryIcon from 'mdi-react/SourceRepositoryIcon'
 import { catchError } from 'rxjs/operators'
 
@@ -86,7 +84,7 @@ export const RepoView: React.FunctionComponent<React.PropsWithChildren<RepoViewP
                 onClick={onBackToSearchResults}
                 className="test-back-to-search-view-btn btn btn-sm btn-link btn-outline-secondary text-decoration-none border-0"
             >
-                <Icon aria-hidden={true} className="mr-1" as={ArrowLeftIcon} />
+                <Icon aria-hidden={true} className="mr-1" svgPath={mdiArrowLeft} />
                 Back to search view
             </button>
             {directoryStack.length > 0 && (
@@ -95,7 +93,7 @@ export const RepoView: React.FunctionComponent<React.PropsWithChildren<RepoViewP
                     onClick={onPreviousDirectory}
                     className="btn btn-sm btn-link btn-outline-secondary text-decoration-none border-0"
                 >
-                    <Icon aria-hidden={true} className="mr-1" as={ArrowLeftIcon} />
+                    <Icon aria-hidden={true} className="mr-1" svgPath={mdiArrowLeft} />
                     Back to previous directory
                 </button>
             )}
@@ -135,7 +133,7 @@ export const RepoView: React.FunctionComponent<React.PropsWithChildren<RepoViewP
                                         <Icon
                                             aria-label={entry.isDirectory ? 'Folder' : 'File'}
                                             className="mr-1 text-muted"
-                                            as={entry.isDirectory ? FolderOutlineIcon : FileDocumentOutlineIcon}
+                                            svgPath={entry.isDirectory ? mdiFolderOutline : mdiFileDocumentOutline}
                                         />
                                         {entry.name}
                                         {entry.isDirectory && '/'}

--- a/client/vscode/src/webview/search-panel/alias/RepoSearchResult.tsx
+++ b/client/vscode/src/webview/search-panel/alias/RepoSearchResult.tsx
@@ -1,9 +1,7 @@
 import React from 'react'
 
+import { mdiSourceFork, mdiArchive, mdiLock } from '@mdi/js'
 import classNames from 'classnames'
-import ArchiveIcon from 'mdi-react/ArchiveIcon'
-import LockIcon from 'mdi-react/LockIcon'
-import SourceForkIcon from 'mdi-react/SourceForkIcon'
 import SourceRepositoryIcon from 'mdi-react/SourceRepositoryIcon'
 
 import { SearchResultStyles as styles, LastSyncedIcon, ResultContainer } from '@sourcegraph/search-ui'
@@ -55,8 +53,8 @@ export const RepoSearchResult: React.FunctionComponent<RepoSearchResultProps> = 
                             <div>
                                 <Icon
                                     className={classNames('flex-shrink-0 text-muted', styles.icon)}
-                                    as={SourceForkIcon}
                                     aria-label="Forked repository"
+                                    svgPath={mdiSourceFork}
                                 />
                             </div>
                             <div>
@@ -70,8 +68,8 @@ export const RepoSearchResult: React.FunctionComponent<RepoSearchResultProps> = 
                             <div>
                                 <Icon
                                     className={classNames('flex-shrink-0 text-muted', styles.icon)}
-                                    as={ArchiveIcon}
                                     aria-label="Archived repository"
+                                    svgPath={mdiArchive}
                                 />
                             </div>
                             <div>
@@ -85,8 +83,8 @@ export const RepoSearchResult: React.FunctionComponent<RepoSearchResultProps> = 
                             <div>
                                 <Icon
                                     className={classNames('flex-shrink-0 text-muted', styles.icon)}
-                                    as={LockIcon}
                                     aria-label="Private repository"
+                                    svgPath={mdiLock}
                                 />
                             </div>
                             <div>

--- a/client/vscode/src/webview/search-panel/components/SavedSearchForm.tsx
+++ b/client/vscode/src/webview/search-panel/components/SavedSearchForm.tsx
@@ -1,8 +1,8 @@
 import React, { useMemo, useState } from 'react'
 
+import { mdiClose } from '@mdi/js'
 import { VSCodeButton } from '@vscode/webview-ui-toolkit/react'
 import classNames from 'classnames'
-import CloseIcon from 'mdi-react/CloseIcon'
 import { map } from 'rxjs/operators'
 import { Omit } from 'utility-types'
 
@@ -168,8 +168,8 @@ const SavedSearchForm: React.FunctionComponent<React.PropsWithChildren<SavedSear
                 className="position-absolute cursor-pointer"
                 style={{ top: '1rem', right: '1rem' }}
                 onClick={props.onComplete}
-                as={CloseIcon}
                 aria-label="Close"
+                svgPath={mdiClose}
             />
             <Form onSubmit={handleSubmit}>
                 <Container className={styles.container}>

--- a/client/vscode/src/webview/search-panel/components/SearchResultsInfoBar.tsx
+++ b/client/vscode/src/webview/search-panel/components/SearchResultsInfoBar.tsx
@@ -1,9 +1,7 @@
 import React, { useCallback, useMemo } from 'react'
 
+import { mdiFormatQuoteOpen, mdiBookmarkOutline, mdiLink } from '@mdi/js'
 import classNames from 'classnames'
-import BookmarkOutlineIcon from 'mdi-react/BookmarkOutlineIcon'
-import FormatQuoteOpenIcon from 'mdi-react/FormatQuoteOpenIcon'
-import LinkIcon from 'mdi-react/LinkIcon'
 
 import { SearchPatternType } from '@sourcegraph/shared/src/schema'
 import { FilterKind, findFilter } from '@sourcegraph/shared/src/search/query/query'
@@ -73,7 +71,7 @@ const QuotesInterpretedLiterallyNotice: React.FunctionComponent<
             data-tooltip="Your search query is interpreted literally, including the quotes. Use the .* toggle to switch between literal and regular expression search."
         >
             <span>
-                <Icon aria-hidden={true} className="mr-1" as={FormatQuoteOpenIcon} />
+                <Icon aria-hidden={true} className="mr-1" svgPath={mdiFormatQuoteOpen} />
                 Searching literally <strong>(including quotes)</strong>
             </span>
         </small>
@@ -186,7 +184,7 @@ export const SearchResultsInfoBar: React.FunctionComponent<
                     className="test-save-search-link"
                     button={
                         <>
-                            <Icon aria-hidden={true} className="mr-1" as={BookmarkOutlineIcon} />
+                            <Icon aria-hidden={true} className="mr-1" svgPath={mdiBookmarkOutline} />
                             Save search
                         </>
                     }
@@ -222,7 +220,7 @@ export const SearchResultsInfoBar: React.FunctionComponent<
                     className="btn btn-sm btn-outline-secondary text-decoration-none"
                     onClick={onShareResultsClick}
                 >
-                    <Icon aria-hidden={true} className="mr-1" as={LinkIcon} />
+                    <Icon aria-hidden={true} className="mr-1" svgPath={mdiLink} />
                     Share
                 </button>
             </li>

--- a/client/vscode/src/webview/sidebars/history/components/RecentFilesSection.tsx
+++ b/client/vscode/src/webview/sidebars/history/components/RecentFilesSection.tsx
@@ -1,8 +1,7 @@
 import React, { useMemo, useState } from 'react'
 
+import { mdiChevronDown, mdiChevronLeft } from '@mdi/js'
 import classNames from 'classnames'
-import ChevronDownIcon from 'mdi-react/ChevronDownIcon'
-import ChevronLeftIcon from 'mdi-react/ChevronLeftIcon'
 
 import { EventLogResult, fetchRecentFileViews } from '@sourcegraph/search'
 import { Icon, Link, H5, useObservable } from '@sourcegraph/wildcard'
@@ -62,7 +61,7 @@ export const RecentFilesSection: React.FunctionComponent<React.PropsWithChildren
                 aria-label={`${collapsed ? 'Expand' : 'Collapse'} recent files`}
             >
                 <H5 className="flex-grow-1">Recent Files</H5>
-                <Icon aria-hidden={true} className="mr-1" as={collapsed ? ChevronLeftIcon : ChevronDownIcon} />
+                <Icon aria-hidden={true} className="mr-1" svgPath={collapsed ? mdiChevronLeft : mdiChevronDown} />
             </button>
 
             {!collapsed && (

--- a/client/vscode/src/webview/sidebars/history/components/RecentRepositoriesSection.tsx
+++ b/client/vscode/src/webview/sidebars/history/components/RecentRepositoriesSection.tsx
@@ -1,8 +1,7 @@
 import React, { useMemo, useState } from 'react'
 
+import { mdiChevronDown, mdiChevronLeft } from '@mdi/js'
 import classNames from 'classnames'
-import ChevronDownIcon from 'mdi-react/ChevronDownIcon'
-import ChevronLeftIcon from 'mdi-react/ChevronLeftIcon'
 
 import { EventLogResult, fetchRecentSearches } from '@sourcegraph/search'
 import { SyntaxHighlightedSearchQuery } from '@sourcegraph/search-ui'
@@ -68,7 +67,7 @@ export const RecentRepositoriesSection: React.FunctionComponent<React.PropsWithC
                 aria-label={`${collapsed ? 'Expand' : 'Collapse'} recent files`}
             >
                 <H5 className="flex-grow-1">Recent Repositories</H5>
-                <Icon aria-hidden={true} className="mr-1" as={collapsed ? ChevronLeftIcon : ChevronDownIcon} />
+                <Icon aria-hidden={true} className="mr-1" svgPath={collapsed ? mdiChevronLeft : mdiChevronDown} />
             </button>
 
             {!collapsed && (

--- a/client/vscode/src/webview/sidebars/history/components/RecentSearchesSection.tsx
+++ b/client/vscode/src/webview/sidebars/history/components/RecentSearchesSection.tsx
@@ -1,8 +1,7 @@
 import React, { useMemo, useState } from 'react'
 
+import { mdiChevronDown, mdiChevronLeft } from '@mdi/js'
 import classNames from 'classnames'
-import ChevronDownIcon from 'mdi-react/ChevronDownIcon'
-import ChevronLeftIcon from 'mdi-react/ChevronLeftIcon'
 
 import { EventLogResult, fetchRecentSearches } from '@sourcegraph/search'
 import { SyntaxHighlightedSearchQuery } from '@sourcegraph/search-ui'
@@ -64,7 +63,7 @@ export const RecentSearchesSection: React.FunctionComponent<React.PropsWithChild
                 aria-label={`${collapsed ? 'Expand' : 'Collapse'} recent searches`}
             >
                 <H5 className="flex-grow-1">Recent Searches</H5>
-                <Icon className="mr-1" as={collapsed ? ChevronLeftIcon : ChevronDownIcon} aria-hidden={true} />
+                <Icon className="mr-1" svgPath={collapsed ? mdiChevronLeft : mdiChevronDown} aria-hidden={true} />
             </button>
 
             {!collapsed && (

--- a/client/vscode/src/webview/sidebars/history/components/SavedSearchesSection.tsx
+++ b/client/vscode/src/webview/sidebars/history/components/SavedSearchesSection.tsx
@@ -1,8 +1,7 @@
 import React, { useMemo, useState } from 'react'
 
+import { mdiChevronDown, mdiChevronLeft } from '@mdi/js'
 import classNames from 'classnames'
-import ChevronDownIcon from 'mdi-react/ChevronDownIcon'
-import ChevronLeftIcon from 'mdi-react/ChevronLeftIcon'
 import { catchError } from 'rxjs/operators'
 
 import { gql } from '@sourcegraph/http-client'
@@ -92,7 +91,7 @@ export const SavedSearchesSection: React.FunctionComponent<React.PropsWithChildr
                 aria-label={`${collapsed ? 'Expand' : 'Collapse'} saved searches`}
             >
                 <H5 className="flex-grow-1">Saved Searches</H5>
-                <Icon aria-hidden={true} className="mr-1" as={collapsed ? ChevronLeftIcon : ChevronDownIcon} />
+                <Icon aria-hidden={true} className="mr-1" svgPath={collapsed ? mdiChevronLeft : mdiChevronDown} />
             </button>
 
             {!collapsed && savedSearches && (


### PR DESCRIPTION
**Migration automated through codemod: https://github.com/sourcegraph/codemod/pull/140**

## Description

Migrates simple `<Icon />` usage from `mdi-react` to `@mdi/react`.

**Why?**

We've had numerous problems with `mdi-react` previously, and this library is better supported and gives us better control over our icons. See https://github.com/sourcegraph/sourcegraph/pull/37387 for more context.

## Test plan

Icon edge cases tested through https://github.com/sourcegraph/sourcegraph/pull/37387, this diff is tested through automated tests.

## App preview:

- [Web](https://sg-web-tr-icon-v2-vscode.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-qddejmprmc.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
