### PR TITLE
SSBC workspace resolver improvements

### DIFF
--- a/enterprise/cmd/worker/internal/batches/workers/batch_spec_workspace_creator.go
+++ b/enterprise/cmd/worker/internal/batches/workers/batch_spec_workspace_creator.go
@@ -30,7 +30,7 @@ type batchSpecWorkspaceCreator struct {
 	logger log.Logger
 }
 
-// HandlerFunc returns a workeruitl.HandlerFunc that can be passed to a
+// HandlerFunc returns a workerutil.HandlerFunc that can be passed to a
 // workerutil.Worker to process queued changesets.
 func (r *batchSpecWorkspaceCreator) HandlerFunc() workerutil.HandlerFunc {
 	return func(ctx context.Context, logger log.Logger, record workerutil.Record) (err error) {
@@ -52,6 +52,10 @@ type workspaceCacheKey struct {
 	skippedSteps  map[int32]struct{}
 }
 
+// process runs one workspace creation run for the given job utilizing the given
+// workspace resolver to find the workspaces. It creates a database transaction
+// to store all the entities in one transaction after the resolution process,
+// to prevent long running transactions.
 func (r *batchSpecWorkspaceCreator) process(
 	ctx context.Context,
 	newResolver service.WorkspaceResolverBuilder,

--- a/enterprise/cmd/worker/internal/batches/workers/batch_spec_workspace_creator_test.go
+++ b/enterprise/cmd/worker/internal/batches/workers/batch_spec_workspace_creator_test.go
@@ -108,7 +108,7 @@ func TestBatchSpecWorkspaceCreatorProcess(t *testing.T) {
 	}
 
 	creator := &batchSpecWorkspaceCreator{store: s, logger: logtest.Scoped(t)}
-	if err := creator.process(context.Background(), s, resolver.DummyBuilder, job); err != nil {
+	if err := creator.process(context.Background(), resolver.DummyBuilder, job); err != nil {
 		t.Fatalf("proces failed: %s", err)
 	}
 
@@ -271,7 +271,7 @@ func TestBatchSpecWorkspaceCreatorProcess_Caching(t *testing.T) {
 
 		resolver := &dummyWorkspaceResolver{workspaces: []*service.RepoWorkspace{workspace}}
 		job := &btypes.BatchSpecResolutionJob{BatchSpecID: batchSpec.ID}
-		if err := creator.process(context.Background(), s, resolver.DummyBuilder, job); err != nil {
+		if err := creator.process(context.Background(), resolver.DummyBuilder, job); err != nil {
 			t.Fatalf("proces failed: %s", err)
 		}
 
@@ -357,7 +357,7 @@ changesetTemplate:
 
 		resolver := &dummyWorkspaceResolver{workspaces: []*service.RepoWorkspace{workspace}}
 		job := &btypes.BatchSpecResolutionJob{BatchSpecID: batchSpec.ID}
-		if err := creator.process(context.Background(), s, resolver.DummyBuilder, job); err != nil {
+		if err := creator.process(context.Background(), resolver.DummyBuilder, job); err != nil {
 			t.Fatalf("proces failed: %s", err)
 		}
 
@@ -412,7 +412,7 @@ changesetTemplate:
 
 		resolver := &dummyWorkspaceResolver{workspaces: []*service.RepoWorkspace{workspace}}
 		job := &btypes.BatchSpecResolutionJob{BatchSpecID: batchSpec.ID}
-		if err := creator.process(context.Background(), s, resolver.DummyBuilder, job); err != nil {
+		if err := creator.process(context.Background(), resolver.DummyBuilder, job); err != nil {
 			t.Fatalf("proces failed: %s", err)
 		}
 
@@ -453,7 +453,7 @@ changesetTemplate:
 
 		resolver := &dummyWorkspaceResolver{workspaces: []*service.RepoWorkspace{workspace}}
 		job := &btypes.BatchSpecResolutionJob{BatchSpecID: batchSpec.ID}
-		if err := creator.process(context.Background(), s, resolver.DummyBuilder, job); err != nil {
+		if err := creator.process(context.Background(), resolver.DummyBuilder, job); err != nil {
 			t.Fatalf("proces failed: %s", err)
 		}
 
@@ -491,7 +491,7 @@ changesetTemplate:
 
 		resolver := &dummyWorkspaceResolver{workspaces: []*service.RepoWorkspace{workspace}}
 		job := &btypes.BatchSpecResolutionJob{BatchSpecID: batchSpec.ID}
-		if err := creator.process(context.Background(), s, resolver.DummyBuilder, job); err != nil {
+		if err := creator.process(context.Background(), resolver.DummyBuilder, job); err != nil {
 			t.Fatalf("proces failed: %s", err)
 		}
 
@@ -540,7 +540,7 @@ changesetTemplate:
 
 		resolver := &dummyWorkspaceResolver{workspaces: []*service.RepoWorkspace{workspace}}
 		job := &btypes.BatchSpecResolutionJob{BatchSpecID: batchSpec.ID}
-		if err := creator.process(context.Background(), s, resolver.DummyBuilder, job); err != nil {
+		if err := creator.process(context.Background(), resolver.DummyBuilder, job); err != nil {
 			t.Fatalf("proces failed: %s", err)
 		}
 
@@ -570,7 +570,7 @@ changesetTemplate:
 
 		resolver := &dummyWorkspaceResolver{workspaces: []*service.RepoWorkspace{workspace}}
 		job := &btypes.BatchSpecResolutionJob{BatchSpecID: batchSpec.ID}
-		if err := creator.process(context.Background(), s, resolver.DummyBuilder, job); err != nil {
+		if err := creator.process(context.Background(), resolver.DummyBuilder, job); err != nil {
 			t.Fatalf("proces failed: %s", err)
 		}
 
@@ -621,7 +621,7 @@ importChangesets:
 	resolver := &dummyWorkspaceResolver{}
 
 	creator := &batchSpecWorkspaceCreator{store: s, logger: logtest.Scoped(t)}
-	if err := creator.process(context.Background(), s, resolver.DummyBuilder, job); err != nil {
+	if err := creator.process(context.Background(), resolver.DummyBuilder, job); err != nil {
 		t.Fatalf("proces failed: %s", err)
 	}
 
@@ -681,7 +681,7 @@ importChangesets:
 	resolver := &dummyWorkspaceResolver{}
 
 	creator := &batchSpecWorkspaceCreator{store: s, logger: logtest.Scoped(t)}
-	if err := creator.process(context.Background(), s, resolver.DummyBuilder, job); err != nil {
+	if err := creator.process(context.Background(), resolver.DummyBuilder, job); err != nil {
 		t.Fatalf("proces failed: %s", err)
 	}
 

--- a/enterprise/internal/batches/service/workspace_resolver.go
+++ b/enterprise/internal/batches/service/workspace_resolver.go
@@ -69,12 +69,18 @@ type WorkspaceResolver interface {
 type WorkspaceResolverBuilder func(tx *store.Store) WorkspaceResolver
 
 func NewWorkspaceResolver(s *store.Store) WorkspaceResolver {
-	return &workspaceResolver{logger: log.Scoped("workspaceResolver", ""), store: s, frontendInternalURL: internalapi.Client.URL + "/.internal"}
+	return &workspaceResolver{
+		store:               s,
+		logger:              log.Scoped("batches.workspaceResolver", "The batch changes execution workspace resolver"),
+		gitserverClient:     gitserver.NewClient(s.DatabaseDB()),
+		frontendInternalURL: internalapi.Client.URL + "/.internal",
+	}
 }
 
 type workspaceResolver struct {
 	logger              log.Logger
 	store               *store.Store
+	gitserverClient     gitserver.Client
 	frontendInternalURL string
 }
 
@@ -85,7 +91,7 @@ func (wr *workspaceResolver) ResolveWorkspacesForBatchSpec(ctx context.Context, 
 		tr.Finish()
 	}()
 
-	// First, find all repositories that match the batch spec on definitions.
+	// First, find all repositories that match the batch spec `on` definitions.
 	// This list is filtered by permissions using database.Repos.List.
 	repos, err := wr.determineRepositories(ctx, batchSpec)
 	if err != nil {
@@ -93,12 +99,12 @@ func (wr *workspaceResolver) ResolveWorkspacesForBatchSpec(ctx context.Context, 
 	}
 
 	// Next, find the repos that are ignored through a .batchignore file.
-	ignored, err := findIgnoredRepositories(ctx, database.NewDBWith(wr.logger, wr.store), repos)
+	ignored, err := findIgnoredRepositories(ctx, wr.gitserverClient, repos)
 	if err != nil {
 		return nil, err
 	}
 
-	// Now build the workspaces for the list of repos
+	// Now build the workspaces for the list of repos.
 	workspaces, err = findWorkspaces(ctx, batchSpec, wr, repos)
 	if err != nil {
 		return nil, err
@@ -161,7 +167,11 @@ func (wr *workspaceResolver) determineRepositories(ctx context.Context, batchSpe
 	return repoRevs, errs
 }
 
-func findIgnoredRepositories(ctx context.Context, db database.DB, repos []*RepoRevision) (map[*types.Repo]struct{}, error) {
+// ignoredWorkspaceResolverConcurrency defines the maximum concurrency level at that
+// findIgnoredRepositories will hit gitserver for file info.
+const ignoredWorkspaceResolverConcurrency = 5
+
+func findIgnoredRepositories(ctx context.Context, gitserverClient gitserver.Client, repos []*RepoRevision) (map[*types.Repo]struct{}, error) {
 	type result struct {
 		repo           *RepoRevision
 		hasBatchIgnore bool
@@ -177,17 +187,19 @@ func findIgnoredRepositories(ctx context.Context, db database.DB, repos []*RepoR
 		wg sync.WaitGroup
 	)
 
-	for i := 0; i < 5; i++ {
+	// Spawn N workers.
+	for i := 0; i < ignoredWorkspaceResolverConcurrency; i++ {
 		wg.Add(1)
 		go func(in chan *RepoRevision, out chan result) {
 			defer wg.Done()
 			for repo := range in {
-				hasBatchIgnore, err := hasBatchIgnoreFile(ctx, db, repo)
+				hasBatchIgnore, err := hasBatchIgnoreFile(ctx, gitserverClient, repo)
 				out <- result{repo, hasBatchIgnore, err}
 			}
 		}(input, results)
 	}
 
+	// Queue all the repos for processing.
 	for _, repo := range repos {
 		input <- repo
 	}
@@ -273,7 +285,7 @@ func (wr *workspaceResolver) resolveRepositoryName(ctx context.Context, name str
 
 	return repoToRepoRevisionWithDefaultBranch(
 		ctx,
-		database.NewDBWith(wr.logger, wr.store),
+		wr.gitserverClient,
 		repo,
 		// Directly resolved repos don't have any file matches.
 		[]string{},
@@ -292,7 +304,7 @@ func (wr *workspaceResolver) resolveRepositoryNameAndBranch(ctx context.Context,
 		return nil, err
 	}
 
-	commit, err := gitserver.NewClient(database.NewDBWith(wr.logger, wr.store)).ResolveRevision(ctx, repo.Name, branch, gitserver.ResolveRevisionOptions{
+	commit, err := wr.gitserverClient.ResolveRevision(ctx, repo.Name, branch, gitserver.ResolveRevisionOptions{
 		NoEnsureRevision: true,
 	})
 	if err != nil && errors.HasType(err, &gitdomain.RevisionNotFoundError{}) {
@@ -370,7 +382,7 @@ func (wr *workspaceResolver) resolveRepositoriesMatchingQuery(ctx context.Contex
 		}
 		// Sort file matches so cache results always match.
 		sort.Strings(fileMatches)
-		rev, err := repoToRepoRevisionWithDefaultBranch(ctx, database.NewDBWith(wr.logger, wr.store), repo, fileMatches)
+		rev, err := repoToRepoRevisionWithDefaultBranch(ctx, wr.gitserverClient, repo, fileMatches)
 		if err != nil {
 			// There is an edge-case where a repo might be returned by a search query that does not exist in gitserver yet.
 			if errcode.IsNotFound(err) {
@@ -424,14 +436,14 @@ func (wr *workspaceResolver) runSearch(ctx context.Context, query string, onMatc
 	return err
 }
 
-func repoToRepoRevisionWithDefaultBranch(ctx context.Context, db database.DB, repo *types.Repo, fileMatches []string) (_ *RepoRevision, err error) {
+func repoToRepoRevisionWithDefaultBranch(ctx context.Context, gitserverClient gitserver.Client, repo *types.Repo, fileMatches []string) (_ *RepoRevision, err error) {
 	tr, ctx := trace.New(ctx, "repoToRepoRevision", "")
 	defer func() {
 		tr.SetError(err)
 		tr.Finish()
 	}()
 
-	branch, commit, err := gitserver.NewClient(db).GetDefaultBranch(ctx, repo.Name)
+	branch, commit, err := gitserverClient.GetDefaultBranch(ctx, repo.Name)
 	if err != nil {
 		return nil, err
 	}
@@ -445,7 +457,9 @@ func repoToRepoRevisionWithDefaultBranch(ctx context.Context, db database.DB, re
 	return repoRev, nil
 }
 
-func hasBatchIgnoreFile(ctx context.Context, db database.DB, r *RepoRevision) (_ bool, err error) {
+const batchIgnoreFilePath = ".batchignore"
+
+func hasBatchIgnoreFile(ctx context.Context, gitserverClient gitserver.Client, r *RepoRevision) (_ bool, err error) {
 	traceTitle := fmt.Sprintf("RepoID: %q", r.Repo.ID)
 	tr, ctx := trace.New(ctx, "hasBatchIgnoreFile", traceTitle)
 	defer func() {
@@ -453,16 +467,16 @@ func hasBatchIgnoreFile(ctx context.Context, db database.DB, r *RepoRevision) (_
 		tr.Finish()
 	}()
 
-	const path = ".batchignore"
-	stat, err := gitserver.NewClient(db).Stat(ctx, authz.DefaultSubRepoPermsChecker, r.Repo.Name, r.Commit, path)
+	stat, err := gitserverClient.Stat(ctx, authz.DefaultSubRepoPermsChecker, r.Repo.Name, r.Commit, batchIgnoreFilePath)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return false, nil
 		}
 		return false, err
 	}
+	// TODO: Should we really fail here? Just not ignoring it seems to be good enough.
 	if !stat.Mode().IsRegular() {
-		return false, errors.Errorf("not a blob: %q", path)
+		return false, errors.Errorf("not a blob: %q", batchIgnoreFilePath)
 	}
 	return true, nil
 }
@@ -479,6 +493,10 @@ func setDefaultQueryCount(query string) string {
 	return query + hardCodedCount
 }
 
+// findDirectoriesInReposConcurrency defines the maximum concurrency level at that
+// FindDirectoriesInRepos will run searches for file paths.
+const findDirectoriesInReposConcurrency = 10
+
 // FindDirectoriesInRepos returns a map of repositories and the locations of
 // files matching the given file name in the repository.
 // The locations are paths relative to the root of the directory.
@@ -486,17 +504,13 @@ func setDefaultQueryCount(query string) string {
 // A dot (".") represents the root directory.
 func (wr *workspaceResolver) FindDirectoriesInRepos(ctx context.Context, fileName string, repos ...*RepoRevision) (map[repoRevKey][]string, error) {
 	findForRepoRev := func(repoRev *RepoRevision) ([]string, error) {
-		query := fmt.Sprintf(`file:(^|/)%s$ repo:^%s$@%s type:path count:99999`, regexp.QuoteMeta(fileName), regexp.QuoteMeta(string(repoRev.Repo.Name)), repoRev.Commit)
+		query := fmt.Sprintf(`file:(^|/)%s$ repo:^%s$@%s type:path count:all`, regexp.QuoteMeta(fileName), regexp.QuoteMeta(string(repoRev.Repo.Name)), repoRev.Commit)
 
 		results := []string{}
 		err := wr.runSearch(ctx, query, func(matches []streamhttp.EventMatch) {
 			for _, match := range matches {
 				switch m := match.(type) {
 				case *streamhttp.EventPathMatch:
-					// We use path.Dir and not filepath.Dir here, because while
-					// src-cli might be executed on Windows, we need the paths to
-					// be Unix paths, since they will be used inside Docker
-					// containers.
 					dir := path.Dir(m.Path)
 
 					// "." means the path is root, but in the executor we use "" to signify root.
@@ -516,8 +530,8 @@ func (wr *workspaceResolver) FindDirectoriesInRepos(ctx context.Context, fileNam
 	}
 
 	// Limit concurrency.
-	sem := make(chan struct{}, 10)
-	for i := 0; i < 10; i++ {
+	sem := make(chan struct{}, findDirectoriesInReposConcurrency)
+	for i := 0; i < findDirectoriesInReposConcurrency; i++ {
 		sem <- struct{}{}
 	}
 
@@ -534,19 +548,19 @@ func (wr *workspaceResolver) FindDirectoriesInRepos(ctx context.Context, fileNam
 			}()
 
 			result, err := findForRepoRev(repoRev)
+
+			mu.Lock()
+			defer mu.Unlock()
 			if err != nil {
 				errs = errors.Append(errs, err)
 				return
 			}
-
-			mu.Lock()
 			results[repoRev.Key()] = result
-			mu.Unlock()
 		}(repoRev)
 	}
 
 	// Wait for all to finish.
-	for i := 0; i < 10; i++ {
+	for i := 0; i < findDirectoriesInReposConcurrency; i++ {
 		<-sem
 	}
 

--- a/enterprise/internal/batches/service/workspace_resolver.go
+++ b/enterprise/internal/batches/service/workspace_resolver.go
@@ -474,7 +474,6 @@ func hasBatchIgnoreFile(ctx context.Context, gitserverClient gitserver.Client, r
 		}
 		return false, err
 	}
-	// TODO: Should we really fail here? Just not ignoring it seems to be good enough.
 	if !stat.Mode().IsRegular() {
 		return false, errors.Errorf("not a blob: %q", batchIgnoreFilePath)
 	}
@@ -536,6 +535,7 @@ func (wr *workspaceResolver) FindDirectoriesInRepos(ctx context.Context, fileNam
 	}
 
 	var (
+		// mu protects both the errs variable and the results map from concurrent writes.
 		errs    error
 		mu      sync.Mutex
 		results = make(map[repoRevKey][]string)

--- a/internal/gitserver/client.go
+++ b/internal/gitserver/client.go
@@ -188,6 +188,13 @@ type Client interface {
 	// If possible, the error returned will be of type protocol.CreateCommitFromPatchError
 	CreateCommitFromPatch(context.Context, protocol.CreateCommitFromPatchRequest) (string, error)
 
+	// GetDefaultBranch returns the name of the default branch and the commit it's
+	// currently at from the given repository.
+	//
+	// If the repository is empty or currently being cloned, empty values and no
+	// error are returned.
+	GetDefaultBranch(ctx context.Context, repo api.RepoName) (refName string, commit api.CommitID, err error)
+
 	// GetObject fetches git object data in the supplied repo
 	GetObject(_ context.Context, _ api.RepoName, objectName string) (*gitdomain.GitObject, error)
 
@@ -268,6 +275,9 @@ type Client interface {
 	// it goes by calling onMatches with each set of results it receives in
 	// response.
 	Search(_ context.Context, _ *protocol.SearchRequest, onMatches func([]protocol.CommitMatch)) (limitHit bool, _ error)
+
+	// Stat returns a FileInfo describing the named file at commit.
+	Stat(ctx context.Context, checker authz.SubRepoPermissionChecker, repo api.RepoName, commit api.CommitID, path string) (fs.FileInfo, error)
 
 	// DiffPath returns a position-ordered slice of changes (additions or deletions)
 	// of the given path between the given source and target commits.


### PR DESCRIPTION
View commit by commit, this PR does the following:

- Use gitserver.Client in the workspace resolver
- Reduce the time in a database transaction while resolving workspaces

## Test plan

Test suite should cover all of these changes.