### PR TITLE
Drop unused index

### DIFF
--- a/internal/database/schema.json
+++ b/internal/database/schema.json
@@ -2048,16 +2048,6 @@
           "IndexDefinition": "CREATE INDEX batch_spec_workspace_execution_jobs_state ON batch_spec_workspace_execution_jobs USING btree (state)",
           "ConstraintType": "",
           "ConstraintDefinition": ""
-        },
-        {
-          "Name": "batch_spec_workspace_execution_jobs_user_id",
-          "IsPrimaryKey": false,
-          "IsUnique": false,
-          "IsExclusion": false,
-          "IsDeferrable": false,
-          "IndexDefinition": "CREATE INDEX batch_spec_workspace_execution_jobs_user_id ON batch_spec_workspace_execution_jobs USING btree (user_id)",
-          "ConstraintType": "",
-          "ConstraintDefinition": ""
         }
       ],
       "Constraints": [

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -157,7 +157,6 @@ Indexes:
     "batch_spec_workspace_execution_jobs_cancel" btree (cancel)
     "batch_spec_workspace_execution_jobs_last_dequeue" btree (user_id, started_at DESC)
     "batch_spec_workspace_execution_jobs_state" btree (state)
-    "batch_spec_workspace_execution_jobs_user_id" btree (user_id)
 Foreign-key constraints:
     "batch_spec_workspace_execution_job_batch_spec_workspace_id_fkey" FOREIGN KEY (batch_spec_workspace_id) REFERENCES batch_spec_workspaces(id) ON DELETE CASCADE DEFERRABLE
     "batch_spec_workspace_execution_jobs_access_token_id_fkey" FOREIGN KEY (access_token_id) REFERENCES access_tokens(id) ON DELETE SET NULL DEFERRABLE

--- a/migrations/frontend/1655737737/down.sql
+++ b/migrations/frontend/1655737737/down.sql
@@ -1,1 +1,1 @@
-CREATE INDEX batch_spec_workspace_execution_jobs_user_id ON batch_spec_workspace_execution_jobs (user_id);
+CREATE INDEX IF NOT EXISTS batch_spec_workspace_execution_jobs_user_id ON batch_spec_workspace_execution_jobs (user_id);

--- a/migrations/frontend/1655737737/down.sql
+++ b/migrations/frontend/1655737737/down.sql
@@ -1,0 +1,1 @@
+CREATE INDEX batch_spec_workspace_execution_jobs_user_id ON batch_spec_workspace_execution_jobs (user_id);

--- a/migrations/frontend/1655737737/metadata.yaml
+++ b/migrations/frontend/1655737737/metadata.yaml
@@ -1,0 +1,2 @@
+name: drop_unused_idx_batch_spec_workspace_execution_jobs_user_id
+parents: [1655481894]

--- a/migrations/frontend/1655737737/up.sql
+++ b/migrations/frontend/1655737737/up.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS batch_spec_workspace_execution_jobs_user_id;

--- a/migrations/frontend/squashed.sql
+++ b/migrations/frontend/squashed.sql
@@ -3476,8 +3476,6 @@ CREATE INDEX batch_spec_workspace_execution_jobs_last_dequeue ON batch_spec_work
 
 CREATE INDEX batch_spec_workspace_execution_jobs_state ON batch_spec_workspace_execution_jobs USING btree (state);
 
-CREATE INDEX batch_spec_workspace_execution_jobs_user_id ON batch_spec_workspace_execution_jobs USING btree (user_id);
-
 CREATE INDEX batch_spec_workspaces_batch_spec_id ON batch_spec_workspaces USING btree (batch_spec_id);
 
 CREATE INDEX batch_specs_rand_id ON batch_specs USING btree (rand_id);


### PR DESCRIPTION
Didn't realize this index existed when I added one on `(user_id, started_at DESC)` so this is not required.

@efritz Is anything needed to do `CONCURRENTLY` in the down migration?

## Test plan

Tests cover migrations.