### PR TITLE
Don't fetch costly rank in SSBC worker store

### DIFF
--- a/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec.go
@@ -412,7 +412,9 @@ func (r *batchSpecResolver) FailureMessage(ctx context.Context) (*string, error)
 	failedJobs, err := r.store.ListBatchSpecWorkspaceExecutionJobs(ctx, store.ListBatchSpecWorkspaceExecutionJobsOpts{
 		OnlyWithFailureMessage: true,
 		BatchSpecID:            r.batchSpec.ID,
-		Cancel:                 &f,
+		// Omit canceled, they don't contain useful error messages.
+		Cancel:      &f,
+		ExcludeRank: true,
 	})
 	if err != nil {
 		return nil, err

--- a/enterprise/internal/batches/store/batch_spec_workspace_execution_jobs_test.go
+++ b/enterprise/internal/batches/store/batch_spec_workspace_execution_jobs_test.go
@@ -82,6 +82,26 @@ func testStoreBatchSpecWorkspaceExecutionJobs(t *testing.T, ctx context.Context,
 			}
 		})
 
+		t.Run("GetWithoutRank", func(t *testing.T) {
+			for i, job := range jobs {
+				// Copy job so we can modify it
+				job := *job
+				t.Run(strconv.Itoa(i), func(t *testing.T) {
+					have, err := s.GetBatchSpecWorkspaceExecutionJob(ctx, GetBatchSpecWorkspaceExecutionJobOpts{ID: job.ID, ExcludeRank: true})
+					if err != nil {
+						t.Fatal(err)
+					}
+
+					job.PlaceInGlobalQueue = 0
+					job.PlaceInUserQueue = 0
+
+					if diff := cmp.Diff(have, &job); diff != "" {
+						t.Fatal(diff)
+					}
+				})
+			}
+		})
+
 		t.Run("NoResults", func(t *testing.T) {
 			opts := GetBatchSpecWorkspaceExecutionJobOpts{ID: 0xdeadbeef}
 

--- a/enterprise/internal/batches/store/batch_spec_workspace_execution_jobs_test.go
+++ b/enterprise/internal/batches/store/batch_spec_workspace_execution_jobs_test.go
@@ -224,6 +224,25 @@ func testStoreBatchSpecWorkspaceExecutionJobs(t *testing.T, ctx context.Context,
 			}
 		})
 
+		t.Run("ExcludeRank", func(t *testing.T) {
+			ranklessJobs := make([]*btypes.BatchSpecWorkspaceExecutionJob, 0, len(jobs))
+			for _, job := range jobs {
+				// Copy job so we can modify it
+				job := *job
+				job.PlaceInGlobalQueue = 0
+				job.PlaceInUserQueue = 0
+				ranklessJobs = append(ranklessJobs, &job)
+			}
+			have, err := s.ListBatchSpecWorkspaceExecutionJobs(ctx, ListBatchSpecWorkspaceExecutionJobsOpts{ExcludeRank: true})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if diff := cmp.Diff(have, ranklessJobs); diff != "" {
+				t.Fatal(diff)
+			}
+		})
+
 		t.Run("BatchSpecID", func(t *testing.T) {
 			workspaceIDByBatchSpecID := map[int64]int64{}
 			for i := 0; i < 3; i++ {

--- a/enterprise/internal/batches/store/worker_workspace_execution.go
+++ b/enterprise/internal/batches/store/worker_workspace_execution.go
@@ -131,7 +131,7 @@ func (s *batchSpecWorkspaceExecutionWorkerStore) markFinal(ctx context.Context, 
 		}
 	}()
 
-	job, err := tx.GetBatchSpecWorkspaceExecutionJob(ctx, GetBatchSpecWorkspaceExecutionJobOpts{ID: int64(id)})
+	job, err := tx.GetBatchSpecWorkspaceExecutionJob(ctx, GetBatchSpecWorkspaceExecutionJobOpts{ID: int64(id), ExcludeRank: true})
 	if err != nil {
 		return false, err
 	}
@@ -200,7 +200,7 @@ func (s *batchSpecWorkspaceExecutionWorkerStore) MarkComplete(ctx context.Contex
 		}
 	}()
 
-	job, err := tx.GetBatchSpecWorkspaceExecutionJob(ctx, GetBatchSpecWorkspaceExecutionJobOpts{ID: int64(id)})
+	job, err := tx.GetBatchSpecWorkspaceExecutionJob(ctx, GetBatchSpecWorkspaceExecutionJobOpts{ID: int64(id), ExcludeRank: true})
 	if err != nil {
 		return false, errors.Wrap(err, "loading batch spec workspace execution job")
 	}

--- a/enterprise/internal/batches/store/worker_workspace_execution.go
+++ b/enterprise/internal/batches/store/worker_workspace_execution.go
@@ -94,6 +94,7 @@ func (s *batchSpecWorkspaceExecutionWorkerStore) FetchCanceled(ctx context.Conte
 		Cancel:         &t,
 		State:          btypes.BatchSpecWorkspaceExecutionJobStateProcessing,
 		WorkerHostname: executorName,
+		ExcludeRank:    true,
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This makes it slower than it has to be so we can save some compute minutes here. Found in pghero.

## Test plan

Test suite adjusted.