### PR TITLE
dev/sg: do not overwrite existing std.Out on failure

### DIFF
--- a/dev/sg/main.go
+++ b/dev/sg/main.go
@@ -27,8 +27,11 @@ func main() {
 		batchCompletionMode = true
 	}
 	if err := sg.RunContext(context.Background(), os.Args); err != nil {
-		out := std.NewOutput(os.Stdout, false)
-		out.WriteFailuref(err.Error())
+		// Ensure std.Out is instantiated
+		if std.Out == nil {
+			std.Out = std.NewOutput(os.Stdout, false)
+		}
+		std.Out.WriteFailuref(err.Error())
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
This is a follow-up to the patch in https://github.com/sourcegraph/sourcegraph/pull/37406

Most notably in `disable-output-detection`, this configures a custom `std.Out` that should not be overwritten when writing a failure message. The scenario described in https://github.com/sourcegraph/sourcegraph/pull/37406 only happens when the error occurs before `std.Out` instantiation, which happens very early in the process, so in most cases `std.Out` will be set.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

`go  run ./dev/sg -disable-analytics=false start` with a `panic()` at various points in `Before` (before output and after output instantiaton)