### PR TITLE
search: Update search onboarding integration test to test CM

### DIFF
--- a/client/web/src/integration/search-onboarding.test.ts
+++ b/client/web/src/integration/search-onboarding.test.ts
@@ -6,8 +6,8 @@ import { Driver, createDriverForTest } from '@sourcegraph/shared/src/testing/dri
 import { afterEachSaveScreenshotIfFailed } from '@sourcegraph/shared/src/testing/screenshotReporter'
 
 import { WebIntegrationTestContext, createWebIntegrationTestContext } from './context'
-import { commonWebGraphQlResults } from './graphQlResults'
-import { siteID, siteGQLID } from './jscontext'
+import { commonWebGraphQlResults, createViewerSettingsGraphQLOverride } from './graphQlResults'
+import { createEditorAPI, EditorAPI, enableEditor, withSearchQueryInput } from './utils'
 
 describe('Search onboarding', () => {
     let driver: Driver
@@ -15,215 +15,194 @@ describe('Search onboarding', () => {
         driver = await createDriverForTest()
     })
     after(() => driver?.close())
-    let testContext: WebIntegrationTestContext
-    beforeEach(async function () {
-        testContext = await createWebIntegrationTestContext({
-            driver,
-            currentTest: this.currentTest!,
-            directory: __dirname,
-        })
-        testContext.overrideGraphQL({
-            ...commonWebGraphQlResults,
-            AutoDefinedSearchContexts: () => ({
-                autoDefinedSearchContexts: [],
-            }),
-            ViewerSettings: () => ({
-                viewerSettings: {
-                    __typename: 'SettingsCascade',
-                    subjects: [
-                        {
-                            __typename: 'DefaultSettings',
-                            settingsURL: null,
-                            viewerCanAdminister: false,
-                            latestSettings: {
-                                id: 0,
-                                contents: JSON.stringify({ experimentalFeatures: { showOnboardingTour: true } }),
-                            },
-                        },
-                        {
-                            __typename: 'Site',
-                            id: siteGQLID,
-                            siteID,
-                            latestSettings: {
-                                id: 470,
-                                contents: JSON.stringify({ experimentalFeatures: { showOnboardingTour: true } }),
-                            },
-                            settingsURL: '/site-admin/global-settings',
-                            viewerCanAdminister: true,
-                            allowSiteSettingsEdits: true,
-                        },
-                    ],
-                    final: JSON.stringify({}),
-                },
-            }),
-            SearchSidebarGitRefs: () => ({
-                repository: {
-                    __typename: 'Repository',
-                    id: 'repo',
-                    gitRefs: {
-                        __typename: 'GitRefConnection',
-                        nodes: [],
-                        pageInfo: {
-                            hasNextPage: false,
-                        },
-                        totalCount: 0,
-                    },
-                },
-            }),
-            GetTemporarySettings: () => ({
-                temporarySettings: {
-                    __typename: 'TemporarySettings',
-                    contents: JSON.stringify({
-                        'user.daysActiveCount': 1,
-                        'user.lastDayActive': new Date().toDateString(),
+
+    withSearchQueryInput((editorName, editorSelector) => {
+        describe(`Onboarding (${editorName})`, () => {
+            let editor: EditorAPI
+            let testContext: WebIntegrationTestContext
+
+            beforeEach(async function () {
+                editor = createEditorAPI(driver, editorName, editorSelector)
+
+                testContext = await createWebIntegrationTestContext({
+                    driver,
+                    currentTest: this.currentTest!,
+                    directory: __dirname,
+                })
+                testContext.overrideGraphQL({
+                    ...commonWebGraphQlResults,
+                    AutoDefinedSearchContexts: () => ({
+                        autoDefinedSearchContexts: [],
                     }),
-                },
-            }),
-        })
-        testContext.overrideSearchStreamEvents([
-            // Used for suggestions
-            {
-                type: 'matches',
-                data: [{ type: 'repo', repository: '^github\\.com/sourcegraph/sourcegraph$' }],
-            },
-            { type: 'done', data: {} },
-        ])
-    })
-    afterEachSaveScreenshotIfFailed(() => driver.page)
-    afterEach(() => testContext?.dispose())
+                    ...createViewerSettingsGraphQLOverride({
+                        user: {
+                            experimentalFeatures: {
+                                showOnboardingTour: true,
+                                ...enableEditor(editorName).experimentalFeatures,
+                            },
+                        },
+                    }),
+                    SearchSidebarGitRefs: () => ({
+                        repository: {
+                            __typename: 'Repository',
+                            id: 'repo',
+                            gitRefs: {
+                                __typename: 'GitRefConnection',
+                                nodes: [],
+                                pageInfo: {
+                                    hasNextPage: false,
+                                },
+                                totalCount: 0,
+                            },
+                        },
+                    }),
+                    GetTemporarySettings: () => ({
+                        temporarySettings: {
+                            __typename: 'TemporarySettings',
+                            contents: JSON.stringify({
+                                'user.daysActiveCount': 1,
+                                'user.lastDayActive': new Date().toDateString(),
+                            }),
+                        },
+                    }),
+                })
+                testContext.overrideSearchStreamEvents([
+                    // Used for suggestions
+                    {
+                        type: 'matches',
+                        data: [{ type: 'repo', repository: '^github\\.com/sourcegraph/sourcegraph$' }],
+                    },
+                    { type: 'done', data: {} },
+                ])
+            })
+            afterEachSaveScreenshotIfFailed(() => driver.page)
+            afterEach(() => testContext?.dispose())
 
-    const waitAndFocusInput = async () => {
-        await driver.page.waitForSelector('.monaco-editor .view-lines')
-        await driver.page.click('.monaco-editor .view-lines')
-    }
+            it('only diplay tour after input is focused', async () => {
+                await driver.page.goto(driver.sourcegraphBaseUrl + '/search')
+                let tourCard = await driver.page.evaluate(() => document.querySelector('.tour-card'))
+                expect(tourCard).toBeNull()
+                await editor.focus()
+                tourCard = await driver.page.evaluate(() => document.querySelector('.tour-card'))
+                expect(tourCard).toBeTruthy()
+            })
 
-    describe('Onboarding', () => {
-        it('only diplay tour after input is focused', async () => {
-            await driver.page.goto(driver.sourcegraphBaseUrl + '/search')
-            let tourCard = await driver.page.evaluate(() => document.querySelector('.tour-card'))
-            expect(tourCard).toBeNull()
-            await waitAndFocusInput()
-            tourCard = await driver.page.evaluate(() => document.querySelector('.tour-card'))
-            expect(tourCard).toBeTruthy()
-        })
+            it('displays all steps in the language onboarding flow', async () => {
+                await driver.page.goto(driver.sourcegraphBaseUrl + '/search')
+                await editor.focus()
+                await driver.page.waitForSelector('.tour-card')
+                await driver.page.waitForSelector('[data-testid="tour-language-button"]')
+                await driver.page.click('[data-testid="tour-language-button"]')
+                const inputContents = await editor.getValue()
+                assert.strictEqual(inputContents, 'lang:')
 
-        it('displays all steps in the language onboarding flow', async () => {
-            await driver.page.goto(driver.sourcegraphBaseUrl + '/search')
-            await waitAndFocusInput()
-            await driver.page.waitForSelector('.tour-card')
-            await driver.page.waitForSelector('[data-testid="tour-language-button"]')
-            await driver.page.click('[data-testid="tour-language-button"]')
-            await driver.page.waitForSelector('#monaco-query-input')
-            const inputContents = await driver.page.evaluate(
-                () => document.querySelector('#monaco-query-input .view-lines')?.textContent
-            )
-            assert.strictEqual(inputContents, 'lang:')
+                await driver.page.waitForSelector('.test-tour-step-2')
+                // Refocus editor after loosing focus from clicking the tour link
+                await editor.focus()
+                await driver.page.keyboard.type('typesc')
+                await editor.waitForSuggestion()
+                await driver.page.keyboard.press('Tab')
+                await driver.page.waitForSelector('.test-tour-step-3')
+                await driver.page.keyboard.press('Space')
+                await driver.page.keyboard.type('test')
 
-            await driver.page.waitForSelector('.test-tour-step-2')
-            await driver.page.keyboard.type('typesc')
-            await driver.page.waitForSelector('#monaco-query-input .suggest-widget.visible')
-            await driver.page.keyboard.press('Tab')
-            await driver.page.waitForSelector('.test-tour-step-3')
-            await driver.page.keyboard.press('Space')
-            await driver.page.keyboard.type('test')
+                await driver.page.waitForSelector('.test-tour-step-4')
+                await driver.page.click('.test-search-button')
+            })
 
-            await driver.page.waitForSelector('.test-tour-step-4')
-            await driver.page.click('.test-search-button')
-        })
+            it('displays all steps in the repo onboarding flow', async () => {
+                await driver.page.goto(driver.sourcegraphBaseUrl + '/search')
+                await editor.focus()
+                await driver.page.waitForSelector('.tour-card')
+                await driver.page.waitForSelector('[data-testid="tour-repo-button"]')
+                await driver.page.click('[data-testid="tour-repo-button"]')
+                const inputContents = await editor.getValue()
+                assert.strictEqual(inputContents, 'repo:')
 
-        it('displays all steps in the repo onboarding flow', async () => {
-            await driver.page.goto(driver.sourcegraphBaseUrl + '/search')
-            await waitAndFocusInput()
-            await driver.page.waitForSelector('.tour-card')
-            await driver.page.waitForSelector('[data-testid="tour-repo-button"]')
-            await driver.page.click('[data-testid="tour-repo-button"]')
-            await driver.page.waitForSelector('#monaco-query-input')
-            const inputContents = await driver.page.evaluate(
-                () => document.querySelector('#monaco-query-input .view-lines')?.textContent
-            )
-            assert.strictEqual(inputContents, 'repo:')
+                await driver.page.waitForSelector('.test-tour-step-2')
+                // Refocus editor after loosing focus from clicking the tour link
+                await editor.focus()
+                await driver.page.keyboard.type('sourcegraph ')
+                await driver.page.waitForSelector('.test-tour-step-3')
+                await driver.page.keyboard.type('test')
+                await driver.page.waitForSelector('.test-tour-step-4')
+                await driver.page.click('.test-search-button')
+            })
 
-            await driver.page.waitForSelector('.test-tour-step-2')
-            await driver.page.keyboard.type('sourcegraph ')
-            await driver.page.waitForSelector('.test-tour-step-3')
-            await driver.page.keyboard.type('test')
-            await driver.page.waitForSelector('.test-tour-step-4')
-            await driver.page.click('.test-search-button')
-        })
+            it('advances filter-lang when an autocomplete suggestion is selected', async () => {
+                await driver.page.goto(driver.sourcegraphBaseUrl + '/search')
+                await editor.focus()
+                await driver.page.waitForSelector('.tour-card')
+                await driver.page.waitForSelector('[data-testid="tour-language-button"]')
+                await driver.page.click('[data-testid="tour-language-button"]')
+                const inputContents = await editor.getValue()
+                assert.strictEqual(inputContents, 'lang:')
 
-        it('advances filter-lang when an autocomplete suggestion is selected', async () => {
-            await driver.page.goto(driver.sourcegraphBaseUrl + '/search')
-            await waitAndFocusInput()
-            await driver.page.waitForSelector('.tour-card')
-            await driver.page.waitForSelector('[data-testid="tour-language-button"]')
-            await driver.page.click('[data-testid="tour-language-button"]')
-            await driver.page.waitForSelector('#monaco-query-input')
-            const inputContents = await driver.page.evaluate(
-                () => document.querySelector('#monaco-query-input .view-lines')?.textContent
-            )
-            assert.strictEqual(inputContents, 'lang:')
-            await driver.page.waitForSelector('.test-tour-step-2')
-            await driver.page.keyboard.type('TypeScr')
-            await driver.page.waitForSelector('#monaco-query-input .suggest-widget.visible')
-            let tourStep2 = await driver.page.evaluate(() => document.querySelector('.test-tour-step-2'))
-            let tourStep3 = await driver.page.evaluate(() => document.querySelector('.test-tour-step-3'))
-            expect(tourStep2).toBeTruthy()
-            expect(tourStep3).toBeNull()
-            await driver.page.keyboard.press('Tab')
-            await driver.page.waitForSelector('.test-tour-step-3')
-            tourStep3 = await driver.page.evaluate(() => document.querySelector('.test-tour-step-3'))
-            tourStep2 = await driver.page.evaluate(() => document.querySelector('.test-tour-step-2'))
-            expect(tourStep3).toBeTruthy()
-        })
+                // Refocus editor after loosing focus from clicking the tour link
+                await editor.focus()
+                await driver.page.waitForSelector('.test-tour-step-2')
+                await driver.page.keyboard.type('TypeScr')
+                await editor.waitForSuggestion()
+                let tourStep2 = await driver.page.evaluate(() => document.querySelector('.test-tour-step-2'))
+                let tourStep3 = await driver.page.evaluate(() => document.querySelector('.test-tour-step-3'))
+                expect(tourStep2).toBeTruthy()
+                expect(tourStep3).toBeNull()
+                await driver.page.keyboard.press('Tab')
+                await driver.page.waitForSelector('.test-tour-step-3')
+                tourStep3 = await driver.page.evaluate(() => document.querySelector('.test-tour-step-3'))
+                tourStep2 = await driver.page.evaluate(() => document.querySelector('.test-tour-step-2'))
+                expect(tourStep3).toBeTruthy()
+            })
 
-        it('advances filter-repository when an autocomplete suggestion is selected', async () => {
-            await driver.page.goto(driver.sourcegraphBaseUrl + '/search')
-            await waitAndFocusInput()
-            await driver.page.waitForSelector('.tour-card')
-            await driver.page.waitForSelector('[data-testid="tour-repo-button"]')
-            await driver.page.click('[data-testid="tour-repo-button"]')
-            await driver.page.waitForSelector('#monaco-query-input')
-            const inputContents = await driver.page.evaluate(
-                () => document.querySelector('#monaco-query-input .view-lines')?.textContent
-            )
-            assert.strictEqual(inputContents, 'repo:')
-            await driver.page.waitForSelector('.test-tour-step-2')
-            await driver.page.keyboard.type('sourcegraph')
-            await driver.page.waitForSelector('#monaco-query-input .suggest-widget.visible')
-            let tourStep2 = await driver.page.evaluate(() => document.querySelector('.test-tour-step-2'))
-            let tourStep3 = await driver.page.evaluate(() => document.querySelector('.test-tour-step-3'))
-            expect(tourStep2).toBeTruthy()
-            expect(tourStep3).toBeNull()
-            await driver.page.keyboard.press('Tab')
-            await driver.page.waitForSelector('.test-tour-step-3')
-            tourStep3 = await driver.page.evaluate(() => document.querySelector('.test-tour-step-3'))
-            tourStep2 = await driver.page.evaluate(() => document.querySelector('.test-tour-step-2'))
-            expect(tourStep3).toBeTruthy()
-        })
+            it('advances filter-repository when an autocomplete suggestion is selected', async () => {
+                await driver.page.goto(driver.sourcegraphBaseUrl + '/search')
+                await editor.focus()
+                await driver.page.waitForSelector('.tour-card')
+                await driver.page.waitForSelector('[data-testid="tour-repo-button"]')
+                await driver.page.click('[data-testid="tour-repo-button"]')
+                const inputContents = await editor.getValue()
+                assert.strictEqual(inputContents, 'repo:')
 
-        it('advances filter-repository when a user types their own repository', async () => {
-            await driver.page.goto(driver.sourcegraphBaseUrl + '/search')
-            await waitAndFocusInput()
-            await driver.page.waitForSelector('.tour-card')
-            await driver.page.waitForSelector('[data-testid="tour-repo-button"]')
-            await driver.page.click('[data-testid="tour-repo-button"]')
-            await driver.page.waitForSelector('#monaco-query-input')
-            const inputContents = await driver.page.evaluate(
-                () => document.querySelector('#monaco-query-input .view-lines')?.textContent
-            )
-            assert.strictEqual(inputContents, 'repo:')
-            await driver.page.waitForSelector('.test-tour-step-2')
-            await driver.page.keyboard.type('sourcegraph/sourcegraph')
-            await driver.page.waitForSelector('#monaco-query-input .suggest-widget.visible')
-            let tourStep2 = await driver.page.evaluate(() => document.querySelector('.test-tour-step-2'))
-            let tourStep3 = await driver.page.evaluate(() => document.querySelector('.test-tour-step-3'))
-            expect(tourStep2).toBeTruthy()
-            expect(tourStep3).toBeNull()
-            await driver.page.keyboard.press('Space')
-            await driver.page.waitForSelector('.test-tour-step-3')
-            tourStep3 = await driver.page.evaluate(() => document.querySelector('.test-tour-step-3'))
-            tourStep2 = await driver.page.evaluate(() => document.querySelector('.test-tour-step-2'))
-            expect(tourStep3).toBeTruthy()
+                await driver.page.waitForSelector('.test-tour-step-2')
+                // Refocus editor after loosing focus from clicking the tour link
+                await editor.focus()
+                await driver.page.keyboard.type('sourcegraph')
+                await editor.waitForSuggestion()
+                let tourStep2 = await driver.page.evaluate(() => document.querySelector('.test-tour-step-2'))
+                let tourStep3 = await driver.page.evaluate(() => document.querySelector('.test-tour-step-3'))
+                expect(tourStep2).toBeTruthy()
+                expect(tourStep3).toBeNull()
+                await driver.page.keyboard.press('Tab')
+                await driver.page.waitForSelector('.test-tour-step-3')
+                tourStep3 = await driver.page.evaluate(() => document.querySelector('.test-tour-step-3'))
+                tourStep2 = await driver.page.evaluate(() => document.querySelector('.test-tour-step-2'))
+                expect(tourStep3).toBeTruthy()
+            })
+
+            it('advances filter-repository when a user types their own repository', async () => {
+                await driver.page.goto(driver.sourcegraphBaseUrl + '/search')
+                await editor.focus()
+                await driver.page.waitForSelector('.tour-card')
+                await driver.page.waitForSelector('[data-testid="tour-repo-button"]')
+                await driver.page.click('[data-testid="tour-repo-button"]')
+                const inputContents = await editor.getValue()
+                assert.strictEqual(inputContents, 'repo:')
+
+                await driver.page.waitForSelector('.test-tour-step-2')
+                // Refocus editor after loosing focus from clicking the tour link
+                await editor.focus()
+                await driver.page.keyboard.type('sourcegraph/sourcegraph')
+                await editor.waitForSuggestion()
+                let tourStep2 = await driver.page.evaluate(() => document.querySelector('.test-tour-step-2'))
+                let tourStep3 = await driver.page.evaluate(() => document.querySelector('.test-tour-step-3'))
+                expect(tourStep2).toBeTruthy()
+                expect(tourStep3).toBeNull()
+                await driver.page.keyboard.press('Space')
+                await driver.page.waitForSelector('.test-tour-step-3')
+                tourStep3 = await driver.page.evaluate(() => document.querySelector('.test-tour-step-3'))
+                tourStep2 = await driver.page.evaluate(() => document.querySelector('.test-tour-step-2'))
+                expect(tourStep3).toBeTruthy()
+            })
         })
     })
 })

--- a/client/web/src/integration/search.test.ts
+++ b/client/web/src/integration/search.test.ts
@@ -203,8 +203,6 @@ describe('Search', () => {
                 await editor.focus()
                 await driver.page.keyboard.type('file:jwtmi')
                 await editor.waitForSuggestion('jwtmiddleware.go')
-                // This timeout seems to be necessary for Tab to select the entry in Codemirror
-                await driver.page.waitForTimeout(100)
                 // NOTE: This test assumes that the first suggestion is the one
                 // to be selected.
                 // It doesn't seem to be possible to otherwise "select" a specific

--- a/client/web/src/integration/utils.ts
+++ b/client/web/src/integration/utils.ts
@@ -130,7 +130,7 @@ export const percySnapshotWithVariants = async (
 
 type Editor = NonNullable<SettingsExperimentalFeatures['editor']>
 
-interface EditorAPI {
+export interface EditorAPI {
     name: Editor
     /**
      * Wait for editor to appear in the DOM.
@@ -139,7 +139,7 @@ interface EditorAPI {
     /**
      * Wait for suggestion with provided label appears
      */
-    waitForSuggestion: (label: string) => Promise<void>
+    waitForSuggestion: (label?: string) => Promise<void>
     /**
      * Moves focus to the editor's root node.
      */
@@ -172,7 +172,7 @@ const editors: Record<Editor, (driver: Driver, rootSelector: string) => EditorAP
             },
             async focus() {
                 await api.waitForIt()
-                await driver.page.focus(rootSelector)
+                await driver.page.click(rootSelector)
             },
             getValue() {
                 return driver.page.evaluate(
@@ -187,12 +187,14 @@ const editors: Record<Editor, (driver: Driver, rootSelector: string) => EditorAP
                     enterTextMethod: 'type',
                 })
             },
-            async waitForSuggestion(suggestion: string) {
+            async waitForSuggestion(suggestion?: string) {
                 await driver.page.waitForSelector(completionSelector)
-                await driver.findElementWithText(suggestion, {
-                    selector: completionLabelSelector,
-                    wait: { timeout: 5000 },
-                })
+                if (suggestion !== undefined) {
+                    await driver.findElementWithText(suggestion, {
+                        selector: completionLabelSelector,
+                        wait: { timeout: 5000 },
+                    })
+                }
             },
             async selectSuggestion(suggestion: string) {
                 await driver.page.waitForSelector(completionSelector)
@@ -217,7 +219,7 @@ const editors: Record<Editor, (driver: Driver, rootSelector: string) => EditorAP
             },
             async focus() {
                 await api.waitForIt()
-                await driver.page.focus(rootSelector)
+                await driver.page.click(rootSelector)
             },
             getValue() {
                 return driver.page.evaluate(
@@ -232,12 +234,18 @@ const editors: Record<Editor, (driver: Driver, rootSelector: string) => EditorAP
                     enterTextMethod: 'type',
                 })
             },
-            async waitForSuggestion(suggestion: string) {
+            async waitForSuggestion(suggestion?: string) {
                 await driver.page.waitForSelector(completionSelector)
-                await driver.findElementWithText(suggestion, {
-                    selector: completionLabelSelector,
-                    wait: { timeout: 5000 },
-                })
+                if (suggestion !== undefined) {
+                    await driver.findElementWithText(suggestion, {
+                        selector: completionLabelSelector,
+                        wait: { timeout: 5000 },
+                    })
+                }
+                // It seems CodeMirror needs some additional time before it
+                // recognizes events on the suggestions element (such as
+                // selecting a suggestion via the Tab key)
+                await driver.page.waitForTimeout(100)
             },
             async selectSuggestion(suggestion: string) {
                 await driver.page.waitForSelector(completionSelector)


### PR DESCRIPTION
Closes: #36525

**NOTE:** Review with whitespace changes disabled

This PR updates the search onboarding integration test to test both Monaco and CodeMirror implementations. I had to make a couple of changes to make it work properly with CodeMirror:

- Both editors are now focused with `.click` instead of `.focus`. The tour card wouldn't be shown otherwise (in CodeMirror). My assumption is that `.focus` somehow didn't have an effect because the input is already focused (auto focus).
- I had to add `await editor.focus()` before the first typing simulation. Clicking on a link in a tour card will remove the focus from the search input, and so key presses are not going to the editor.
  Interestingly if I manually perform this action then Monaco looses focus as well. I don't know why it works differently for Monaco in the test environment.

## Test plan

Integration test passes.

## App preview:

- [Web](https://sg-web-fkling-cm-search-onboarding.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-kggxqsxtox.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
