### PR TITLE
batches: Faster workspace lookup

### DIFF
--- a/internal/database/schema.json
+++ b/internal/database/schema.json
@@ -2311,6 +2311,16 @@
           "IndexDefinition": "CREATE INDEX batch_spec_workspaces_batch_spec_id ON batch_spec_workspaces USING btree (batch_spec_id)",
           "ConstraintType": "",
           "ConstraintDefinition": ""
+        },
+        {
+          "Name": "batch_spec_workspaces_id_batch_spec_id",
+          "IsPrimaryKey": false,
+          "IsUnique": false,
+          "IsExclusion": false,
+          "IsDeferrable": false,
+          "IndexDefinition": "CREATE INDEX batch_spec_workspaces_id_batch_spec_id ON batch_spec_workspaces USING btree (id, batch_spec_id)",
+          "ConstraintType": "",
+          "ConstraintDefinition": ""
         }
       ],
       "Constraints": [

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -187,6 +187,7 @@ Foreign-key constraints:
 Indexes:
     "batch_spec_workspaces_pkey" PRIMARY KEY, btree (id)
     "batch_spec_workspaces_batch_spec_id" btree (batch_spec_id)
+    "batch_spec_workspaces_id_batch_spec_id" btree (id, batch_spec_id)
 Foreign-key constraints:
     "batch_spec_workspaces_batch_spec_id_fkey" FOREIGN KEY (batch_spec_id) REFERENCES batch_specs(id) ON DELETE CASCADE DEFERRABLE
     "batch_spec_workspaces_repo_id_fkey" FOREIGN KEY (repo_id) REFERENCES repo(id) DEFERRABLE

--- a/migrations/frontend/1655763641/down.sql
+++ b/migrations/frontend/1655763641/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS batch_spec_workspaces_id_batch_spec_id;

--- a/migrations/frontend/1655763641/metadata.yaml
+++ b/migrations/frontend/1655763641/metadata.yaml
@@ -1,0 +1,3 @@
+name: faster_workspace_batch_spec_lookup
+parents: [1655481894]
+createIndexConcurrently: true

--- a/migrations/frontend/1655763641/up.sql
+++ b/migrations/frontend/1655763641/up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS batch_spec_workspaces_id_batch_spec_id ON batch_spec_workspaces(id, batch_spec_id);

--- a/migrations/frontend/squashed.sql
+++ b/migrations/frontend/squashed.sql
@@ -3480,6 +3480,8 @@ CREATE INDEX batch_spec_workspace_execution_jobs_user_id ON batch_spec_workspace
 
 CREATE INDEX batch_spec_workspaces_batch_spec_id ON batch_spec_workspaces USING btree (batch_spec_id);
 
+CREATE INDEX batch_spec_workspaces_id_batch_spec_id ON batch_spec_workspaces USING btree (id, batch_spec_id);
+
 CREATE INDEX batch_specs_rand_id ON batch_specs USING btree (rand_id);
 
 CREATE INDEX changeset_jobs_bulk_group_idx ON changeset_jobs USING btree (bulk_group);


### PR DESCRIPTION
This index makes it faster to lookup workspaces in a batch spec.

```
sg=# explain analyze select * from batch_spec_workspaces join repo on repo.id = repo_id where batch_spec_id = 2023 and repo.deleted_at is null order by batch_spec_workspaces.id asc limit 50;
                                                                                 QUERY PLAN
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=0.71..85.03 rows=50 width=851) (actual time=154.062..154.261 rows=50 loops=1)
   ->  Nested Loop  (cost=0.71..81022.71 rows=48050 width=851) (actual time=154.061..154.256 rows=50 loops=1)
         ->  Index Scan using batch_spec_workspaces_pkey on batch_spec_workspaces  (cost=0.42..61220.80 rows=48124 width=257) (actual time=154.036..154.067 rows=50 loops=1)
               Filter: (batch_spec_id = 2023)
               Rows Removed by Filter: 592596
         ->  Index Scan using repo_pkey on repo  (cost=0.29..0.41 rows=1 width=586) (actual time=0.003..0.003 rows=1 loops=50)
               Index Cond: (id = batch_spec_workspaces.repo_id)
               Filter: (deleted_at IS NULL)
 Planning Time: 0.352 ms
 Execution Time: 154.354 ms
(10 rows)

sg=# create index on batch_spec_workspaces(id, batch_spec_id);
CREATE INDEX
sg=# explain analyze select * from batch_spec_workspaces join repo on repo.id = repo_id where batch_spec_id = 2023 and repo.deleted_at is null order by batch_spec_workspaces.id asc limit 50;
                                                                                        QUERY PLAN
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=0.71..50.10 rows=50 width=851) (actual time=17.969..18.174 rows=50 loops=1)
   ->  Nested Loop  (cost=0.71..47462.30 rows=48050 width=851) (actual time=17.967..18.169 rows=50 loops=1)
         ->  Index Scan using batch_spec_workspaces_id_batch_spec_id_idx on batch_spec_workspaces  (cost=0.42..27660.39 rows=48124 width=257) (actual time=17.949..17.982 rows=50 loops=1)
               Index Cond: (batch_spec_id = 2023)
         ->  Index Scan using repo_pkey on repo  (cost=0.29..0.41 rows=1 width=586) (actual time=0.003..0.003 rows=1 loops=50)
               Index Cond: (id = batch_spec_workspaces.repo_id)
               Filter: (deleted_at IS NULL)
 Planning Time: 0.413 ms
 Execution Time: 18.287 ms
(9 rows)
```


## Test plan

Index change, won't break anything and manually verified its impact.