### PR TITLE
batches/syncer: migrate to sourcegraph/log

### DIFF
--- a/enterprise/internal/batches/background.go
+++ b/enterprise/internal/batches/background.go
@@ -38,7 +38,7 @@ func InitBackgroundJobs(
 	ctx = actor.WithInternalActor(ctx)
 
 	observationContext := &observation.Context{
-		Logger:     log.Scoped("background", "batches background jobs"),
+		Logger:     log.Scoped("batches.background", "batches background jobs"),
 		Tracer:     &trace.Tracer{Tracer: opentracing.GlobalTracer()},
 		Registerer: prometheus.DefaultRegisterer,
 	}

--- a/enterprise/internal/batches/syncer/syncer_test.go
+++ b/enterprise/internal/batches/syncer/syncer_test.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/sourcegraph/log/logtest"
+
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/store"
 	btypes "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
 	"github.com/sourcegraph/sourcegraph/internal/api"
@@ -49,6 +51,7 @@ func TestSyncerRun(t *testing.T) {
 			return nil
 		}
 		syncer := &changesetSyncer{
+			logger:           logtest.Scoped(t),
 			syncStore:        syncStore,
 			scheduleInterval: 10 * time.Minute,
 			syncFunc:         syncFunc,
@@ -89,6 +92,7 @@ func TestSyncerRun(t *testing.T) {
 		}, nil)
 
 		syncer := &changesetSyncer{
+			logger:           logtest.Scoped(t),
 			syncStore:        syncStore,
 			scheduleInterval: 10 * time.Minute,
 			metrics:          makeMetrics(&observation.TestContext),
@@ -119,6 +123,7 @@ func TestSyncerRun(t *testing.T) {
 			return nil
 		}
 		syncer := &changesetSyncer{
+			logger:           logtest.Scoped(t),
 			syncStore:        syncStore,
 			scheduleInterval: 10 * time.Minute,
 			syncFunc:         syncFunc,
@@ -139,6 +144,7 @@ func TestSyncerRun(t *testing.T) {
 			return nil
 		}
 		syncer := &changesetSyncer{
+			logger:           logtest.Scoped(t),
 			syncStore:        newTestStore(),
 			scheduleInterval: 10 * time.Minute,
 			syncFunc:         syncFunc,
@@ -227,6 +233,7 @@ func TestSyncRegistry_EnqueueChangesetSyncs(t *testing.T) {
 	t.Cleanup(syncerCancel)
 
 	syncer := &changesetSyncer{
+		logger:      logtest.Scoped(t),
 		syncStore:   syncStore,
 		codeHostURL: codeHostURL,
 		syncFunc: func(ctx context.Context, id int64) error {


### PR DESCRIPTION
Mindless migration to end the day, spotted some un-migrated log entries showing up in `sg start`

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Tests pass, `sg start` works