### PR TITLE
usage stats: use "not available" instead of "never"

### DIFF
--- a/client/web/src/site-admin/SiteAdminUsageStatisticsPage.tsx
+++ b/client/web/src/site-admin/SiteAdminUsageStatisticsPage.tsx
@@ -145,14 +145,14 @@ class UserUsageStatisticsNode extends React.PureComponent<UserUsageStatisticsNod
                     {this.props.node.usageStatistics?.lastActiveTime ? (
                         <Timestamp date={this.props.node.usageStatistics.lastActiveTime} />
                     ) : (
-                        'never'
+                        'not available'
                     )}
                 </td>
                 <td className={styles.dateColumn}>
                     {this.props.node.usageStatistics?.lastActiveCodeHostIntegrationTime ? (
                         <Timestamp date={this.props.node.usageStatistics.lastActiveCodeHostIntegrationTime} />
                     ) : (
-                        'never'
+                        'not available'
                     )}
                 </td>
             </tr>


### PR DESCRIPTION
Use "not available" instead of "never" for usage stats because the former does not imply the user never had done anything, just present the truth that we don't think we have data.

Please see the [Slack thread](https://app.slack.com/client/T02FSM7DL/C03D4H7UBEV/thread/C03D4H7UBEV-1654871317.934219) for context.

## Test plan

CI

## App preview:

- [Web](https://sg-web-jc-usage-stats-not-avaiable.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-mqjbhfyxdn.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
