### PR TITLE
Spacebar Scroll Down Fix in Firefox

### DIFF
--- a/client/web/src/repo/RepoRevisionSidebar.module.scss
+++ b/client/web/src/repo/RepoRevisionSidebar.module.scss
@@ -1,6 +1,6 @@
 .tabpanels {
     margin-top: 0.25rem;
-    height: calc(100% - 2.25rem);
+    height: calc(99.9% - 2.25rem);
 }
 
 .close-icon {

--- a/client/web/src/repo/RepoRevisionSidebar.module.scss
+++ b/client/web/src/repo/RepoRevisionSidebar.module.scss
@@ -1,6 +1,6 @@
 .tabpanels {
     margin-top: 0.25rem;
-    height: calc(99.9% - 2.25rem);
+    flex-grow: 1;
 }
 
 .close-icon {

--- a/client/web/src/repo/RepoRevisionSidebar.tsx
+++ b/client/web/src/repo/RepoRevisionSidebar.tsx
@@ -98,7 +98,7 @@ export const RepoRevisionSidebar: React.FunctionComponent<React.PropsWithChildre
                     isSourcegraphDotCom={props.isSourcegraphDotCom}
                 />
                 <Tabs
-                    className="w-100 test-repo-revision-sidebar pr-3 h-25 flex-grow-1"
+                    className="w-100 test-repo-revision-sidebar pr-3 h-25 d-flex flex-column flex-grow-1"
                     defaultIndex={persistedTabIndex}
                     onChange={setPersistedTabIndex}
                     lazy={true}

--- a/client/web/src/repo/blob/Blob.tsx
+++ b/client/web/src/repo/blob/Blob.tsx
@@ -792,7 +792,7 @@ export const Blob: React.FunctionComponent<React.PropsWithChildren<BlobProps>> =
 
     return (
         <>
-            <div className={classNames(props.className, styles.blob)} ref={nextBlobElement}>
+            <div className={classNames(props.className, styles.blob)} ref={nextBlobElement} tabIndex={-1}>
                 <Code
                     className={classNames('test-blob', styles.blobCode, props.wrapCode && styles.blobCodeWrapped)}
                     ref={nextCodeViewElement}


### PR DESCRIPTION
Regarding issue #16728 - Space bar scroll down doesn't work as expected in Firefox

I came up with this solution by comparing it to the scrollable sidebar on the same page. The biggest difference between the two sections was the use of tabIndex on the left sidebar, whereas the BlobPage section did not use it. I added the tabIndex attribute in the Blob.tsx file. I'm not sure if this will affect other files where the Blob component is used, so I am open to suggestions and better strategies. 

## Test plan
Verified it worked locally on Firefox browser.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-lm-firefox-scrolling.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-papguksznh.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
