### PR TITLE
chore: Tell prettier to ignore Cargo's output target/ dir.

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -26,6 +26,7 @@ doc/
 GH2SG.bookmarklet.js
 docker-images/grafana/config/provisioning/dashboards/sourcegraph/
 docker-images/syntax-highlighter/crates/
+docker-images/syntax-highlighter/target/
 storybook-static/
 browser/code-intel-extensions/
 .buildkite-cache/


### PR DESCRIPTION
Formatting things in a gitignored directory is useless.

## Test plan

n/a
