### PR TITLE
`<Icon />`: Update component for more control over `<svg>` element

### DIFF
--- a/client/wildcard/src/components/Icon/Icon.story.tsx
+++ b/client/wildcard/src/components/Icon/Icon.story.tsx
@@ -48,7 +48,7 @@ export const Simple: Story = () => (
         <Icon as={CloseIcon} size="md" aria-label="Close" />
 
         <H3>
-            New <Code>@mdi/react</Code> Icon
+            New <Code>@mdi/js</Code> Icon
         </H3>
         <Icon svgPath={mdiClose} size="md" aria-label="Close" />
     </>

--- a/client/wildcard/src/components/Icon/Icon.test.tsx
+++ b/client/wildcard/src/components/Icon/Icon.test.tsx
@@ -31,7 +31,7 @@ describe('Icon', () => {
         })
     })
 
-    describe('new @mdi/react icons', () => {
+    describe('new @mdi/js icons', () => {
         it('renders a simple inline icon correctly', () => {
             const { asFragment } = render(<Icon svgPath={mdiClose} aria-hidden={true} />)
             expect(asFragment()).toMatchSnapshot()

--- a/client/wildcard/src/components/Icon/Icon.tsx
+++ b/client/wildcard/src/components/Icon/Icon.tsx
@@ -1,6 +1,5 @@
-import React, { AriaRole, ComponentType, ElementType } from 'react'
+import React, { AriaRole, ComponentType, ElementType, HTMLAttributes } from 'react'
 
-import MDIIcon from '@mdi/react'
 import classNames from 'classnames'
 import { MdiReactIconProps } from 'mdi-react'
 
@@ -10,7 +9,7 @@ import { ICON_SIZES } from './constants'
 
 import styles from './Icon.module.scss'
 
-interface BaseIconProps extends Omit<React.ComponentProps<typeof MDIIcon>, 'size' | 'path' | 'color'> {
+interface BaseIconProps extends HTMLAttributes<SVGSVGElement> {
     /**
      * Provide a custom `svgPath` to build an SVG.
      *
@@ -36,24 +35,29 @@ interface HiddenIconProps extends BaseIconProps {
 export type IconProps = HiddenIconProps | ScreenReaderIconProps
 
 // eslint-disable-next-line react/display-name
-export const Icon = React.forwardRef(({ children, className, size, ...props }, reference) => {
+export const Icon = React.forwardRef(({ children, className, size, role = 'img', ...props }, reference) => {
     const iconStyle = classNames(styles.iconInline, size === 'md' && styles.iconInlineMd, className)
 
     if (props.svgPath) {
-        const { svgPath, 'aria-label': ariaLabel, ...attributes } = props
+        const { svgPath, height = 24, width = 24, viewBox = '0 0 24 24', fill = 'currentColor', ...attributes } = props
 
         return (
-            <MDIIcon
+            <svg
                 ref={reference as React.RefObject<SVGSVGElement>}
-                path={svgPath}
                 className={iconStyle}
-                title={ariaLabel}
+                role={role}
+                height={height}
+                width={width}
+                viewBox={viewBox}
+                fill={fill}
                 {...attributes}
-            />
+            >
+                <path d={svgPath} />
+            </svg>
         )
     }
 
-    const { as: IconComponent = 'svg', role = 'img', ...attributes } = props
+    const { as: IconComponent = 'svg', ...attributes } = props
 
     return (
         <IconComponent ref={reference} className={iconStyle} role={role} {...attributes}>

--- a/client/wildcard/src/components/Icon/Icon.tsx
+++ b/client/wildcard/src/components/Icon/Icon.tsx
@@ -1,4 +1,4 @@
-import React, { AriaRole, ComponentType, ElementType, HTMLAttributes } from 'react'
+import React, { AriaRole, ComponentType, ElementType, SVGProps } from 'react'
 
 import classNames from 'classnames'
 import { MdiReactIconProps } from 'mdi-react'
@@ -9,7 +9,7 @@ import { ICON_SIZES } from './constants'
 
 import styles from './Icon.module.scss'
 
-interface BaseIconProps extends HTMLAttributes<SVGSVGElement> {
+interface BaseIconProps extends SVGProps<SVGSVGElement> {
     /**
      * Provide a custom `svgPath` to build an SVG.
      *
@@ -43,7 +43,7 @@ export const Icon = React.forwardRef(({ children, className, size, role = 'img',
 
         return (
             <svg
-                ref={reference as React.RefObject<SVGSVGElement>}
+                ref={reference}
                 className={iconStyle}
                 role={role}
                 height={height}

--- a/client/wildcard/src/components/Icon/__snapshots__/Icon.test.tsx.snap
+++ b/client/wildcard/src/components/Icon/__snapshots__/Icon.test.tsx.snap
@@ -91,18 +91,16 @@ exports[`Icon legacy mdi-react icons renders a simple inline icon correctly 1`] 
 exports[`Icon new @mdi/js icons renders a medium icon correctly 1`] = `
 <DocumentFragment>
   <svg
-    aria-labelledby="icon_labelledby_2"
+    aria-label="Checkmark"
     class="iconInline iconInlineMd"
+    fill="currentColor"
+    height="24"
+    role="img"
     viewBox="0 0 24 24"
+    width="24"
   >
-    <title
-      id="icon_labelledby_2"
-    >
-      Checkmark
-    </title>
     <path
       d="M19,6.41L17.59,5L12,10.59L6.41,5L5,6.41L10.59,12L5,17.59L6.41,19L12,13.41L17.59,19L19,17.59L13.41,12L19,6.41Z"
-      style="fill: currentColor;"
     />
   </svg>
 </DocumentFragment>
@@ -113,12 +111,14 @@ exports[`Icon new @mdi/js icons renders a simple inline icon correctly 1`] = `
   <svg
     aria-hidden="true"
     class="iconInline"
-    role="presentation"
+    fill="currentColor"
+    height="24"
+    role="img"
     viewBox="0 0 24 24"
+    width="24"
   >
     <path
       d="M19,6.41L17.59,5L12,10.59L6.41,5L5,6.41L10.59,12L5,17.59L6.41,19L12,13.41L17.59,19L19,17.59L13.41,12L19,6.41Z"
-      style="fill: currentColor;"
     />
   </svg>
 </DocumentFragment>

--- a/client/wildcard/src/components/Icon/__snapshots__/Icon.test.tsx.snap
+++ b/client/wildcard/src/components/Icon/__snapshots__/Icon.test.tsx.snap
@@ -88,7 +88,7 @@ exports[`Icon legacy mdi-react icons renders a simple inline icon correctly 1`] 
 </DocumentFragment>
 `;
 
-exports[`Icon new @mdi/react icons renders a medium icon correctly 1`] = `
+exports[`Icon new @mdi/js icons renders a medium icon correctly 1`] = `
 <DocumentFragment>
   <svg
     aria-labelledby="icon_labelledby_2"
@@ -108,7 +108,7 @@ exports[`Icon new @mdi/react icons renders a medium icon correctly 1`] = `
 </DocumentFragment>
 `;
 
-exports[`Icon new @mdi/react icons renders a simple inline icon correctly 1`] = `
+exports[`Icon new @mdi/js icons renders a simple inline icon correctly 1`] = `
 <DocumentFragment>
   <svg
     aria-hidden="true"

--- a/package.json
+++ b/package.json
@@ -363,7 +363,6 @@
     "@codemirror/view": "^0.20.4",
     "@lezer/highlight": "^0.16.0",
     "@mdi/js": "^6.7.96",
-    "@mdi/react": "^1.6.0",
     "@microsoft/fetch-event-source": "^2.0.1",
     "@radix-ui/react-tooltip": "^0.1.8 || 0.1.8-rc.2",
     "@reach/accordion": "^0.16.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2869,13 +2869,6 @@
   resolved "https://registry.npmjs.org/@mdi/js/-/js-6.7.96.tgz#6cd13ba64eeaf347c857feb3c328d31af3e75876"
   integrity sha512-vZvhFrNN9LQx+Awu3nU6ESfXXDpRA/CA4mwikzU5g8uf9NpAocK43ecQvVNntwiXlLKpyplas8d4lsfpqjtXLA==
 
-"@mdi/react@^1.6.0":
-  version "1.6.0"
-  resolved "https://registry.npmjs.org/@mdi/react/-/react-1.6.0.tgz#09b470c6b444a626206a1bd8901abcecf56bb3eb"
-  integrity sha512-FdeJ3Ee+m9nbBkZXW0XgSkDvevgOCloLRFrBlF6pRGWgT8v2U1M2aeXi8+uRM5FZ58o3dfVFduAtmCq7quclNA==
-  dependencies:
-    prop-types "^15.7.2"
-
 "@mdn/browser-compat-data@2.0.7":
   version "2.0.7"
   resolved "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-2.0.7.tgz#72ec37b9c1e00ce0b4e0309d753be18e2da12ee3"


### PR DESCRIPTION
## Description

We ran into some issues when migrating to use the `@mdi/react` `<Icon />` component:
- Color was set on `<path>` elements
- It wasn't possible to set the `height` and `width` attributes. The component doesn't support passing through normal SVG props.

We don't need to use this component now we have the paths through `@mdi/js`, we can just roll our own that is similar to our setup with `mdi-react`, but can also add some of the benefits that we'd get from `@mdi/react`.

> **Note**
> I haven't included the `title` and `description` logic. As we are using `role="img"` and `aria-label|hidden`, this isn't as important anymore. One of the issues I noticed is that `title` also gives a secondary tooltip on long hovers, which isn't intended (as opposed to our actual tooltip usage).

## Test plan

Tested locally and in Storybook. Visual regression tests to confirm no UX changes.

## App preview:

- [Web](https://sg-web-tr-icon-v2-custom.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-sqnaeasveo.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
