### PR TITLE
insights: improve efficiency snapshots/recordings over some repos

### DIFF
--- a/enterprise/internal/insights/background/insight_enqueuer.go
+++ b/enterprise/internal/insights/background/insight_enqueuer.go
@@ -108,7 +108,15 @@ func enqueue(ctx context.Context, dataSeries []types.InsightSeries, mode store.P
 		uniqueSeries[seriesID] = series
 
 		// Construct the search query that will generate data for this repository and time (revision) tuple.
-		modifiedQuery, err := querybuilder.GlobalQuery(series.Query, querybuilder.CodeInsightsQueryDefaults(len(series.Repositories) == 0))
+		defaultQueryParams := querybuilder.CodeInsightsQueryDefaults(len(series.Repositories) == 0)
+		var modifiedQuery string
+		var err error
+		if len(series.Repositories) > 0 {
+			modifiedQuery, err = querybuilder.MultiRepoQuery(series.Query, series.Repositories, defaultQueryParams)
+		} else {
+			modifiedQuery, err = querybuilder.GlobalQuery(series.Query, defaultQueryParams)
+		}
+
 		if err != nil {
 			multi = errors.Append(multi, errors.Wrapf(err, "GlobalQuery series_id:%s", seriesID))
 			continue

--- a/enterprise/internal/insights/background/queryrunner/work_handler.go
+++ b/enterprise/internal/insights/background/queryrunner/work_handler.go
@@ -384,6 +384,8 @@ func (r *workHandler) persistRecordings(ctx context.Context, job *Job, series *t
 		}
 	}
 
+	// Newly queued queries should be scoped to correct repos however leaving filtering
+	// in place to ensure any older queued jobs get filtered properly. It's a noop for global insights.
 	filteredRecordings, err := filterRecordingsBySeriesRepos(ctx, r.repoStore, series, recordings)
 	if err != nil {
 		return errors.Wrap(err, "filterRecordingsBySeriesRepos")

--- a/enterprise/internal/insights/query/querybuilder/builder_test.go
+++ b/enterprise/internal/insights/query/querybuilder/builder_test.go
@@ -69,6 +69,66 @@ func TestWithDefaults(t *testing.T) {
 	}
 }
 
+func TestMultiRepoQuery(t *testing.T) {
+	tests := []struct {
+		name     string
+		repos    []string
+		want     string
+		defaults query.Parameters
+	}{
+		{
+			name:     "single repo",
+			repos:    []string{"repo1"},
+			want:     `count:99999999 testquery repo:^(repo1)$`,
+			defaults: []query.Parameter{},
+		},
+		{
+			name:  "multiple repo",
+			repos: []string{"repo1", "repo2"},
+			want:  `archived:no fork:no count:99999999 testquery repo:^(repo1|repo2)$`,
+			defaults: []query.Parameter{{
+				Field:      query.FieldArchived,
+				Value:      string(query.No),
+				Negated:    false,
+				Annotation: query.Annotation{},
+			}, {
+				Field:      query.FieldFork,
+				Value:      string(query.No),
+				Negated:    false,
+				Annotation: query.Annotation{},
+			}},
+		},
+		{
+			name:  "multiple repo",
+			repos: []string{"github.com/myrepos/repo1", "github.com/myrepos/repo2"},
+			want:  `archived:no fork:no count:99999999 testquery repo:^(github\.com/myrepos/repo1|github\.com/myrepos/repo2)$`,
+			defaults: []query.Parameter{{
+				Field:      query.FieldArchived,
+				Value:      string(query.No),
+				Negated:    false,
+				Annotation: query.Annotation{},
+			}, {
+				Field:      query.FieldFork,
+				Value:      string(query.No),
+				Negated:    false,
+				Annotation: query.Annotation{},
+			}},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := MultiRepoQuery("testquery", test.repos, test.defaults)
+			if err != nil {
+				t.Fatal(err)
+			}
+			println(got)
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Fatalf("%s failed (want/got): %s", test.name, diff)
+			}
+		})
+	}
+}
+
 func TestDefaults(t *testing.T) {
 	tests := []struct {
 		name  string


### PR DESCRIPTION
Currently snapshots/recordings over some repos are running a global query and then filtering out results.  This appends a repo filter which is a OR of the named repos in the insight.  Same strategy of as the "preview results" of the insight creation UI.

resolves https://github.com/sourcegraph/sourcegraph/issues/36471
## Test plan
Unit tests pass
Matched new snapshot values for global and scoped insights to search results ensuring they are the same

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
