### PR TITLE
JetBrains: Add telemetry to the TypeScript side 

### DIFF
--- a/client/jetbrains/.eslintignore
+++ b/client/jetbrains/.eslintignore
@@ -1,2 +1,3 @@
 src/main/resources/dist/
 package.json
+webview/src/graphql-operations.ts

--- a/client/jetbrains/webview/src/search/App.tsx
+++ b/client/jetbrains/webview/src/search/App.tsx
@@ -21,11 +21,11 @@ import {
 } from '@sourcegraph/shared/src/search/stream'
 import { fetchStreamSuggestions } from '@sourcegraph/shared/src/search/suggestions'
 import { EMPTY_SETTINGS_CASCADE, SettingsCascadeOrError } from '@sourcegraph/shared/src/settings/settings'
-import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { useObservable, WildcardThemeContext } from '@sourcegraph/wildcard'
 
 import { getAuthenticatedUser } from '../sourcegraph-api-access/api-gateway'
 import { initializeSourcegraphSettings } from '../sourcegraphSettings'
+import { EventLogger } from '../telemetry/EventLogger'
 
 import { JetBrainsSearchBox } from './input/JetBrainsSearchBox'
 import { saveLastSearch } from './js-to-java-bridge'
@@ -64,6 +64,8 @@ export const App: React.FunctionComponent<React.PropsWithChildren<Props>> = ({
 }: Props) => {
     const [authState, setAuthState] = useState<'initial' | 'validating' | 'success' | 'failure'>('initial')
     const [authenticatedUser, setAuthenticatedUser] = useState<AuthenticatedUser | null>(initialAuthenticatedUser)
+
+    const telemetryService = useMemo(() => new EventLogger('anonid', { editor: 'jetbrains', version: '1.4.5' }), [])
 
     const requestGraphQL = useCallback<PlatformContext['requestGraphQL']>(
         args =>
@@ -178,8 +180,9 @@ export const App: React.FunctionComponent<React.PropsWithChildren<Props>> = ({
             setMatches([])
             setLastSearch(nextSearch)
             saveLastSearch(nextSearch)
+            telemetryService.log('IDESearchSubmitted')
         },
-        [lastSearch, userQueryState.query]
+        [lastSearch, userQueryState.query, telemetryService]
     )
 
     const [didInitialSubmit, setDidInitialSubmit] = useState(false)
@@ -256,7 +259,7 @@ export const App: React.FunctionComponent<React.PropsWithChildren<Props>> = ({
                             settingsCascade={settingsCascade}
                             globbing={isGlobbingEnabled}
                             isLightTheme={!isDarkTheme}
-                            telemetryService={NOOP_TELEMETRY_SERVICE} // TODO: Fix this, see VS Code's SearchResultsView.tsx
+                            telemetryService={telemetryService}
                             platformContext={platformContext}
                             className=""
                             containerClassName=""

--- a/client/jetbrains/webview/src/search/App.tsx
+++ b/client/jetbrains/webview/src/search/App.tsx
@@ -45,6 +45,7 @@ interface Props {
     onOpen: (match: SearchMatch, lineOrSymbolMatchIndex?: number) => Promise<void>
     initialSearch: Search | null
     initialAuthenticatedUser: AuthenticatedUser | null
+    telemetryService: EventLogger
 }
 
 function fetchStreamSuggestionsWithStaticUrl(query: string): Observable<SearchMatch[]> {
@@ -61,11 +62,10 @@ export const App: React.FunctionComponent<React.PropsWithChildren<Props>> = ({
     onOpen,
     initialSearch,
     initialAuthenticatedUser,
+    telemetryService,
 }: Props) => {
     const [authState, setAuthState] = useState<'initial' | 'validating' | 'success' | 'failure'>('initial')
     const [authenticatedUser, setAuthenticatedUser] = useState<AuthenticatedUser | null>(initialAuthenticatedUser)
-
-    const telemetryService = useMemo(() => new EventLogger('anonid', { editor: 'jetbrains', version: '1.4.5' }), [])
 
     const requestGraphQL = useCallback<PlatformContext['requestGraphQL']>(
         args =>

--- a/client/jetbrains/webview/src/search/index.tsx
+++ b/client/jetbrains/webview/src/search/index.tsx
@@ -110,3 +110,11 @@ function applyLastSearch(lastSearch: Search | null): void {
 function applyAuthenticatedUser(authenticatedUser: AuthenticatedUser | null): void {
     initialAuthenticatedUser = authenticatedUser
 }
+
+export function getAccessToken(): string | null {
+    return accessToken
+}
+
+export function getInstanceURL(): string {
+    return instanceURL
+}

--- a/client/jetbrains/webview/src/search/index.tsx
+++ b/client/jetbrains/webview/src/search/index.tsx
@@ -5,6 +5,7 @@ import polyfillEventSource from '@sourcegraph/shared/src/polyfills/vendor/eventS
 import { AnchorLink, setLinkComponent } from '@sourcegraph/wildcard'
 
 import { getAuthenticatedUser } from '../sourcegraph-api-access/api-gateway'
+import { EventLogger } from '../telemetry/EventLogger'
 
 import { App } from './App'
 import { handleRequest } from './java-to-js-bridge'
@@ -27,6 +28,7 @@ let isGlobbingEnabled = false
 let accessToken: string | null = null
 let initialSearch: Search | null = null
 let initialAuthenticatedUser: AuthenticatedUser | null
+let telemetryService: EventLogger
 
 window.initializeSourcegraph = async () => {
     const [theme, config, lastSearch, authenticatedUser] = await Promise.allSettled([
@@ -43,6 +45,8 @@ window.initializeSourcegraph = async () => {
     if (accessToken && authenticatedUser.status === 'rejected') {
         console.warn(`No initial authenticated user with access token “${accessToken}”`)
     }
+
+    telemetryService = new EventLogger('anonid', { editor: 'jetbrains', version: '1.4.5' })
 
     renderReactApp()
 
@@ -64,6 +68,7 @@ export function renderReactApp(): void {
             onPreviewChange={onPreviewChange}
             onPreviewClear={onPreviewClear}
             initialAuthenticatedUser={initialAuthenticatedUser}
+            telemetryService={telemetryService}
         />,
         node
     )

--- a/client/jetbrains/webview/src/search/lib/blob.ts
+++ b/client/jetbrains/webview/src/search/lib/blob.ts
@@ -1,8 +1,12 @@
-const cachedContentRequests = new Map<string, Promise<string | null>>()
-
+import { gql } from '@sourcegraph/http-client'
 import { ContentMatch, PathMatch, SymbolMatch } from '@sourcegraph/shared/src/search/stream'
 
+import { BlobContentResult, BlobContentVariables } from '../../graphql-operations'
 import { getMatchId } from '../results/utils'
+
+import { requestGraphQLFromJetBrains } from './requestGraphQl'
+
+const cachedContentRequests = new Map<string, Promise<string | null>>()
 
 export async function loadContent(match: ContentMatch | PathMatch | SymbolMatch): Promise<string | null> {
     const cacheKey = getMatchId(match)
@@ -21,33 +25,12 @@ export async function loadContent(match: ContentMatch | PathMatch | SymbolMatch)
 }
 
 async function fetchBlobContent(match: ContentMatch | PathMatch | SymbolMatch): Promise<string | null> {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-explicit-any
-    const response: any = await fetch('https://sourcegraph.com/.api/graphql', {
-        method: 'post',
-        body: JSON.stringify({
-            query: `
-                query Blob($repoName: String!, $commitID: String!, $filePath: String!) {
-                    repository(name: $repoName) {
-                        commit(rev: $commitID) {
-                            file(path: $filePath) {
-                                content
-                                // We include the highlight part here even though it is not used to get a server side
-                                // error when previewing binary files.
-                                highlight(disableTimeout: false) {
-                                    aborted
-                                }
-                            }
-                        }
-                    }
-                }`,
-            variables: {
-                commitID: match.commit,
-                filePath: match.path,
-                repoName: match.repository,
-            },
-        }),
-    }).then(response => response.json())
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment,@typescript-eslint/no-unsafe-member-access
+    const response = await requestGraphQLFromJetBrains<BlobContentResult, BlobContentVariables>(blobContentQuery, {
+        commitID: match.commit ?? '',
+        filePath: match.path,
+        repoName: match.repository,
+    })
+
     const content: undefined | string = response?.data?.repository?.commit?.file?.content
     if (content === undefined) {
         console.error('No content found in query response', response)
@@ -55,3 +38,20 @@ async function fetchBlobContent(match: ContentMatch | PathMatch | SymbolMatch): 
     }
     return content
 }
+
+const blobContentQuery = gql`
+    query BlobContent($repoName: String!, $commitID: String!, $filePath: String!) {
+        repository(name: $repoName) {
+            commit(rev: $commitID) {
+                file(path: $filePath) {
+                    content
+                    # We include the highlight part here even though it is not used to get a server side
+                    # error when previewing binary files.
+                    highlight(disableTimeout: false) {
+                        aborted
+                    }
+                }
+            }
+        }
+    }
+`

--- a/client/jetbrains/webview/src/search/lib/blob.ts
+++ b/client/jetbrains/webview/src/search/lib/blob.ts
@@ -4,7 +4,7 @@ import { ContentMatch, PathMatch, SymbolMatch } from '@sourcegraph/shared/src/se
 import { BlobContentResult, BlobContentVariables } from '../../graphql-operations'
 import { getMatchId } from '../results/utils'
 
-import { requestGraphQLFromJetBrains } from './requestGraphQl'
+import { requestGraphQL } from './requestGraphQl'
 
 const cachedContentRequests = new Map<string, Promise<string | null>>()
 
@@ -25,7 +25,7 @@ export async function loadContent(match: ContentMatch | PathMatch | SymbolMatch)
 }
 
 async function fetchBlobContent(match: ContentMatch | PathMatch | SymbolMatch): Promise<string | null> {
-    const response = await requestGraphQLFromJetBrains<BlobContentResult, BlobContentVariables>(blobContentQuery, {
+    const response = await requestGraphQL<BlobContentResult, BlobContentVariables>(blobContentQuery, {
         commitID: match.commit ?? '',
         filePath: match.path,
         repoName: match.repository,

--- a/client/jetbrains/webview/src/search/lib/requestGraphQl.ts
+++ b/client/jetbrains/webview/src/search/lib/requestGraphQl.ts
@@ -3,10 +3,7 @@ import { GraphQLResult, GRAPHQL_URI } from '@sourcegraph/http-client'
 
 import { getAccessToken, getInstanceURL } from '..'
 
-export const requestGraphQL = async <R, V = object>(
-    request: string,
-    variables: V
-): Promise<GraphQLResult<R>> => {
+export const requestGraphQL = async <R, V = object>(request: string, variables: V): Promise<GraphQLResult<R>> => {
     const instanceURL = getInstanceURL()
     const accessToken = getAccessToken()
 

--- a/client/jetbrains/webview/src/search/lib/requestGraphQl.ts
+++ b/client/jetbrains/webview/src/search/lib/requestGraphQl.ts
@@ -3,7 +3,7 @@ import { GraphQLResult, GRAPHQL_URI } from '@sourcegraph/http-client'
 
 import { getAccessToken, getInstanceURL } from '..'
 
-export const requestGraphQLFromJetBrains = async <R, V = object>(
+export const requestGraphQL = async <R, V = object>(
     request: string,
     variables: V
 ): Promise<GraphQLResult<R>> => {

--- a/client/jetbrains/webview/src/search/lib/requestGraphQl.ts
+++ b/client/jetbrains/webview/src/search/lib/requestGraphQl.ts
@@ -1,0 +1,38 @@
+import { asError } from '@sourcegraph/common'
+import { GraphQLResult, GRAPHQL_URI } from '@sourcegraph/http-client'
+
+import { getAccessToken, getInstanceURL } from '..'
+
+export const requestGraphQLFromJetBrains = async <R, V = object>(
+    request: string,
+    variables: V
+): Promise<GraphQLResult<R>> => {
+    const instanceURL = getInstanceURL()
+    const accessToken = getAccessToken()
+
+    const nameMatch = request.match(/^\s*(?:query|mutation)\s+(\w+)/)
+    const apiURL = `${GRAPHQL_URI}${nameMatch ? '?' + nameMatch[1] : ''}`
+
+    const headers = new Headers()
+    headers.set('Content-Type', 'application/json')
+    headers.set('X-Sourcegraph-Should-Trace', new URLSearchParams(window.location.search).get('trace') || 'false')
+    if (accessToken) {
+        headers.set('Authorization', `token ${accessToken}`)
+    }
+
+    try {
+        const url = new URL(apiURL, instanceURL).href
+        const response = await fetch(url, {
+            body: JSON.stringify({
+                query: request,
+                variables,
+            }),
+            method: 'POST',
+            headers,
+        })
+        // eslint-disable-next-line @typescript-eslint/return-await
+        return response.json() as Promise<GraphQLResult<any>>
+    } catch (error) {
+        throw asError(error)
+    }
+}

--- a/client/jetbrains/webview/src/telemetry/EventLogger.ts
+++ b/client/jetbrains/webview/src/telemetry/EventLogger.ts
@@ -74,8 +74,6 @@ function logEvent(eventVariable: Event): void {
     events.next(eventVariable)
 }
 
-// We keep a global event ID counter so that EventLoger can be creacretad without causing us to
-// reuse event identifiers
 let eventId = 1
 
 // Event Logger for VS Code Extension
@@ -91,33 +89,15 @@ export class EventLogger implements TelemetryService {
 
     /**
      * @deprecated use logPageView instead
-     *
-     * Log a pageview event (by sending it to the server).
      */
-    public logViewEvent(pageTitle: string, eventProperties?: any, publicArgument?: any, url?: string): void {
-        if (pageTitle) {
-            this.tracker(
-                `View${pageTitle}`,
-                { ...eventProperties, ...this.editorInfo },
-                { ...publicArgument, ...this.editorInfo },
-                url
-            )
-        }
+    public logViewEvent(): void {
+        throw new Error('This method is not supported on JetBrains. This extension does not use the deprecated method.')
     }
 
-    /**
-     * Log a pageview.
-     * Page titles should be specific and human-readable in pascal case, e.g. "SearchResults" or "Blob" or "NewOrg"
-     */
-    public logPageView(eventName: string, eventProperties?: any, publicArgument?: any, url?: string): void {
-        if (eventName) {
-            this.tracker(
-                `${eventName}Viewed`,
-                { ...eventProperties, ...this.editorInfo },
-                { ...publicArgument, ...this.editorInfo },
-                url
-            )
-        }
+    public logPageView(): void {
+        throw new Error(
+            'This method is not supported on JetBrains. This extension does not have the contept of a page.'
+        )
     }
 
     /**
@@ -154,7 +134,7 @@ export class EventLogger implements TelemetryService {
         return () => this.listeners.delete(callback)
     }
 
-    public tracker(eventName: string, eventProperties?: unknown, publicArgument?: unknown, uri?: string): void {
+    private tracker(eventName: string, eventProperties?: unknown, publicArgument?: unknown, uri?: string): void {
         for (const listener of this.listeners) {
             listener(eventName)
         }

--- a/client/jetbrains/webview/src/telemetry/EventLogger.ts
+++ b/client/jetbrains/webview/src/telemetry/EventLogger.ts
@@ -1,0 +1,178 @@
+import { Subject, EMPTY } from 'rxjs'
+import { bufferTime, catchError, concatMap } from 'rxjs/operators'
+
+import { gql } from '@sourcegraph/http-client'
+import { TelemetryService } from '@sourcegraph/shared/src/telemetry/telemetryService'
+
+import {
+    Event,
+    EventSource,
+    LogEventsResult,
+    LogEventsVariables,
+    LogLegacySearchUserEventResult,
+    LogLegacySearchUserEventVariables,
+} from '../graphql-operations'
+import { requestGraphQLFromJetBrains } from '../search/lib/requestGraphQl'
+
+// Log events in batches.
+const events = new Subject<Event>()
+
+events
+    .pipe(
+        bufferTime(1000),
+        concatMap(events => {
+            if (events.length > 0) {
+                console.log('sending events in batches bruh', events)
+
+                // For every IDESearchSubmitted, we also fire a legacy logUserEvent event. This is
+                // necessary since we only look at the latter to calculat some activity usage
+                // numbers.
+                //
+                // See sourcegraph/sourcegraph#35178
+                events
+                    .filter(event => event.event === 'IDESearchSubmitted')
+                    .map(event =>
+                        requestGraphQLFromJetBrains<LogLegacySearchUserEventResult, LogLegacySearchUserEventVariables>(
+                            logLegacySearchUserEventMutation,
+                            {
+                                userCookieID: event.deviceID ?? '',
+                            }
+                        )
+                    )
+
+                return requestGraphQLFromJetBrains<LogEventsResult, LogEventsVariables>(logEventsMutation, {
+                    events,
+                })
+            }
+            return EMPTY
+        }),
+        catchError(error => {
+            console.error('Error logging events:', error)
+            return []
+        })
+    )
+    // eslint-disable-next-line rxjs/no-ignored-subscription
+    .subscribe()
+
+const logEventsMutation = gql`
+    mutation LogEvents($events: [Event!]) {
+        logEvents(events: $events) {
+            alwaysNil
+        }
+    }
+`
+
+const logLegacySearchUserEventMutation = gql`
+    mutation LogLegacySearchUserEvent($userCookieID: String!) {
+        logUserEvent(event: SEARCHQUERY, userCookieID: $userCookieID) {
+            alwaysNil
+        }
+    }
+`
+
+function logEvent(eventVariable: Event): void {
+    events.next(eventVariable)
+}
+
+// We keep a global event ID counter so that EventLoger can be creacretad without causing us to
+// reuse event identifiers
+let eventId = 1
+
+// Event Logger for VS Code Extension
+export class EventLogger implements TelemetryService {
+    private anonymousUserId: string
+    private listeners: Set<(eventName: string) => void> = new Set()
+    private editorInfo: { editor: string; version: string }
+
+    constructor(anonymousUserId: string, editorInfo: { editor: string; version: string }) {
+        this.anonymousUserId = anonymousUserId
+        this.editorInfo = editorInfo
+    }
+
+    /**
+     * @deprecated use logPageView instead
+     *
+     * Log a pageview event (by sending it to the server).
+     */
+    public logViewEvent(pageTitle: string, eventProperties?: any, publicArgument?: any, url?: string): void {
+        if (pageTitle) {
+            this.tracker(
+                `View${pageTitle}`,
+                { ...eventProperties, ...this.editorInfo },
+                { ...publicArgument, ...this.editorInfo },
+                url
+            )
+        }
+    }
+
+    /**
+     * Log a pageview.
+     * Page titles should be specific and human-readable in pascal case, e.g. "SearchResults" or "Blob" or "NewOrg"
+     */
+    public logPageView(eventName: string, eventProperties?: any, publicArgument?: any, url?: string): void {
+        if (eventName) {
+            this.tracker(
+                `${eventName}Viewed`,
+                { ...eventProperties, ...this.editorInfo },
+                { ...publicArgument, ...this.editorInfo },
+                url
+            )
+        }
+    }
+
+    /**
+     * Log a user action or event.
+     * Event labels should be specific and follow a ${noun}${verb} structure in pascal case, e.g. "ButtonClicked" or "SignInInitiated"
+     *
+     * @param eventLabel: the event name.
+     * @param eventProperties: event properties. These get logged to our database, but do not get
+     * sent to our analytics systems. This may contain private info such as repository names or search queries.
+     * @param publicArgument: event properties that include only public information. Do NOT
+     * include any private information, such as full URLs that may contain private repo names or
+     * search queries. The contents of this parameter are sent to our analytics systems.
+     */
+    public log(eventLabel: string, eventProperties?: any, publicArgument?: any, uri?: string): void {
+        if (!eventLabel) {
+            return
+        }
+        this.tracker(
+            eventLabel,
+            { ...eventProperties, ...this.editorInfo },
+            { ...publicArgument, ...this.editorInfo },
+            uri
+        )
+    }
+
+    /**
+     * Event ID is used to deduplicate events in Amplitude.
+     * This is used in the case that multiple events with the same userID and timestamp
+     * are sent. https://developers.amplitude.com/docs/http-api-v2#optional-keys
+     */
+    public getEventId(): number {
+        return eventId++
+    }
+
+    public addEventLogListener(callback: (eventName: string) => void): () => void {
+        this.listeners.add(callback)
+        return () => this.listeners.delete(callback)
+    }
+
+    public tracker(eventName: string, eventProperties?: unknown, publicArgument?: unknown, uri?: string): void {
+        for (const listener of this.listeners) {
+            listener(eventName)
+        }
+
+        const event: Event = {
+            event: eventName,
+            userCookieID: this.anonymousUserId,
+            referrer: 'JETBRAINS',
+            url: uri || '',
+            source: EventSource.IDEEXTENSION,
+            argument: eventProperties ? JSON.stringify(eventProperties) : null,
+            publicArgument: JSON.stringify(publicArgument),
+            deviceID: this.anonymousUserId,
+            eventID: this.getEventId(),
+        }
+        logEvent(event)
+    }
+}

--- a/client/jetbrains/webview/src/telemetry/EventLogger.ts
+++ b/client/jetbrains/webview/src/telemetry/EventLogger.ts
@@ -132,9 +132,6 @@ export class EventLogger implements TelemetryService {
      * search queries. The contents of this parameter are sent to our analytics systems.
      */
     public log(eventLabel: string, eventProperties?: any, publicArgument?: any, uri?: string): void {
-        if (!eventLabel) {
-            return
-        }
         this.tracker(
             eventLabel,
             { ...eventProperties, ...this.editorInfo },

--- a/client/jetbrains/webview/src/telemetry/EventLogger.ts
+++ b/client/jetbrains/webview/src/telemetry/EventLogger.ts
@@ -12,7 +12,7 @@ import {
     LogLegacySearchUserEventResult,
     LogLegacySearchUserEventVariables,
 } from '../graphql-operations'
-import { requestGraphQLFromJetBrains } from '../search/lib/requestGraphQl'
+import { requestGraphQL } from '../search/lib/requestGraphQl'
 
 // Log events in batches.
 const events = new Subject<Event>()
@@ -32,7 +32,7 @@ events
                 events
                     .filter(event => event.event === 'IDESearchSubmitted')
                     .map(event =>
-                        requestGraphQLFromJetBrains<LogLegacySearchUserEventResult, LogLegacySearchUserEventVariables>(
+                        requestGraphQL<LogLegacySearchUserEventResult, LogLegacySearchUserEventVariables>(
                             logLegacySearchUserEventMutation,
                             {
                                 userCookieID: event.deviceID ?? '',
@@ -40,7 +40,7 @@ events
                         )
                     )
 
-                return requestGraphQLFromJetBrains<LogEventsResult, LogEventsVariables>(logEventsMutation, {
+                return requestGraphQL<LogEventsResult, LogEventsVariables>(logEventsMutation, {
                     events,
                 })
             }

--- a/client/jetbrains/webview/src/telemetry/EventLogger.ts
+++ b/client/jetbrains/webview/src/telemetry/EventLogger.ts
@@ -76,7 +76,7 @@ function logEvent(eventVariable: Event): void {
 
 let eventId = 1
 
-// Event Logger for VS Code Extension
+// Event Logger for the JetBrains Extension
 export class EventLogger implements TelemetryService {
     private anonymousUserId: string
     private listeners: Set<(eventName: string) => void> = new Set()
@@ -96,24 +96,24 @@ export class EventLogger implements TelemetryService {
 
     public logPageView(): void {
         throw new Error(
-            'This method is not supported on JetBrains. This extension does not have the contept of a page.'
+            'This method is not supported on JetBrains. This extension does not have the concept of a page.'
         )
     }
 
     /**
      * Log a user action or event.
-     * Event labels should be specific and follow a ${noun}${verb} structure in pascal case, e.g. "ButtonClicked" or "SignInInitiated"
+     * Event names should be specific and follow a ${noun}${verb} structure in pascal case, e.g. "ButtonClicked" or "SignInInitiated"
      *
-     * @param eventLabel: the event name.
+     * @param eventName: the event name.
      * @param eventProperties: event properties. These get logged to our database, but do not get
      * sent to our analytics systems. This may contain private info such as repository names or search queries.
      * @param publicArgument: event properties that include only public information. Do NOT
      * include any private information, such as full URLs that may contain private repo names or
      * search queries. The contents of this parameter are sent to our analytics systems.
      */
-    public log(eventLabel: string, eventProperties?: any, publicArgument?: any, uri?: string): void {
+    public log(eventName: string, eventProperties?: any, publicArgument?: any, uri?: string): void {
         this.tracker(
-            eventLabel,
+            eventName,
             { ...eventProperties, ...this.editorInfo },
             { ...publicArgument, ...this.editorInfo },
             uri

--- a/client/shared/dev/generateGraphQlOperations.js
+++ b/client/shared/dev/generateGraphQlOperations.js
@@ -11,6 +11,7 @@ const BROWSER_FOLDER = path.resolve(ROOT_FOLDER, './client/browser')
 const SHARED_FOLDER = path.resolve(ROOT_FOLDER, './client/shared')
 const SEARCH_FOLDER = path.resolve(ROOT_FOLDER, './client/search')
 const VSCODE_FOLDER = path.resolve(ROOT_FOLDER, './client/vscode')
+const JETBRAINS_FOLDER = path.resolve(ROOT_FOLDER, './client/jetbrains')
 const SCHEMA_PATH = path.join(ROOT_FOLDER, './cmd/frontend/graphqlbackend/*.graphql')
 
 const SHARED_DOCUMENTS_GLOB = [
@@ -35,6 +36,8 @@ const SEARCH_DOCUMENTS_GLOB = [`${SEARCH_FOLDER}/src/**/*.{ts,tsx}`]
 
 const VSCODE_DOCUMENTS_GLOB = [`${VSCODE_FOLDER}/src/**/*.{ts,tsx}`]
 
+const JETBRAINS_DOCUMENTS_GLOB = [`${JETBRAINS_FOLDER}/webview/src/**/*.{ts,tsx}`]
+
 // Define ALL_DOCUMENTS_GLOB as the union of the previous glob arrays.
 const ALL_DOCUMENTS_GLOB = [
   ...new Set([
@@ -43,6 +46,7 @@ const ALL_DOCUMENTS_GLOB = [
     ...BROWSER_DOCUMENTS_GLOB,
     ...SEARCH_DOCUMENTS_GLOB,
     ...VSCODE_DOCUMENTS_GLOB,
+    ...JETBRAINS_DOCUMENTS_GLOB,
   ]),
 ]
 
@@ -139,6 +143,17 @@ async function generateGraphQlOperations() {
             noExport: false,
             enumValues: '@sourcegraph/shared/src/graphql-operations',
             interfaceNameForOperations: 'VSCodeGraphQlOperations',
+          },
+          plugins: SHARED_PLUGINS,
+        },
+
+        [path.join(JETBRAINS_FOLDER, './webview/src/graphql-operations.ts')]: {
+          documents: JETBRAINS_DOCUMENTS_GLOB,
+          config: {
+            onlyOperationTypes: true,
+            noExport: false,
+            enumValues: '@sourcegraph/shared/src/graphql-operations',
+            interfaceNameForOperations: 'JetBrainsGraphQlOperations',
           },
           plugins: SHARED_PLUGINS,
         },


### PR DESCRIPTION
Part of #35178 

This PR creates a telemetry backend in TypeScript that we can use to log events inside the web view. There were a couple of considerations going into this:

1. I started by cleaning up the GraphQL operations script. This allows us to generate proper TypeScript types for GraphQL queries that are used in the JetBrains project. I wanted to do this for the new log endpoints but also other APIs that we already use, e.g. blob content loading.
2. We're creating a new graphQL interface that can be accessed from anywhere inside the JetBrains code and will load the correct auth token and endpoint URL
3. Based on the implementation from VSCode, we've enabled event batching when writing log events over the wire.
4. We have special cased `IDESearchSubmited` to also emit a legacy user event for every search. This is necessary to fix the [issues pointed out by @erzhtor here](https://sourcegraph.slack.com/archives/C03D4H7UBEV/p1655199781227029?thread_ts=1654871317.934219&cid=C03D4H7UBEV). 

## Test plan

The process was to inspect the network request to ensure the right payloads are sent and also verify that the event log tab on sourcegraph.com contains the search events. I created a quick loom to better explain the testing approach:

https://www.loom.com/share/bdaa0df3a2734a908f5a4cdc736e65f3 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-jetbrains-client-telemetry.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-hsloofzsbw.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
