### PR TITLE
[SG-34732] Accessibility: Search box screen reader issues

### DIFF
--- a/client/search-ui/src/input/toggles/CopyQueryButton.tsx
+++ b/client/search-ui/src/input/toggles/CopyQueryButton.tsx
@@ -53,6 +53,7 @@ export const CopyQueryButton: React.FunctionComponent<React.PropsWithChildren<Pr
                     className={classNames('btn-icon', props.className)}
                     variant="icon"
                     size="sm"
+                    aria-label={copyFullQueryTooltip}
                     onClick={nextClick}
                 >
                     <Icon aria-hidden={true} as={ClipboardOutlineIcon} />


### PR DESCRIPTION
## Description
For these two pages ([here](https://sourcegraph.com/search?q=context:global+hello+world&patternType=literal) and [here](https://sourcegraph.com/search)):

- [ ]  Running a search doesn't announce anything (should announce to the user that a search is being executed)

- [x]  When using the coy query button next to the input, "Copied" is read twice (should only read it once)

## Refs
[SourceGraph Issue](https://github.com/sourcegraph/sourcegraph/issues/34732)
[GitStart ticket](https://app.gitstart.com/clients/sourcegraph/tickets/SG-34732)

## Test plan
- Ensure integration tests have accessibility audit and that those tests pass.
- Use screen readers ([check here how](https://docs.sourcegraph.com/dev/background-information/web/accessibility/how-to-screen-reader)) to go through the changes and it should read as expected.


## App preview:

- [Web](https://sg-web-contractors-sg-34732.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-fmmgpfjqyl.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
