### PR TITLE
Include test plan on default PR body

### DIFF
--- a/dev/release/src/release.ts
+++ b/dev/release/src/release.ts
@@ -387,7 +387,12 @@ ${trackingIssues.map(index => `- ${slackURL(index.title, index.url)}`).join('\n'
 ${customMessage || ''}
 
 * [Release batch change](${batchChangeURL})
-* ${trackingIssue ? `[Tracking issue](${trackingIssue.url})` : 'No tracking issue exists for this release'}`
+* ${trackingIssue ? `[Tracking issue](${trackingIssue.url})` : 'No tracking issue exists for this release'}
+
+### Test plan
+
+CI checks in this repository should pass, and a manual review should confirm if the generated changes are correct.`
+
                 if (!actionItems || actionItems.length === 0) {
                     return { draft: false, body: defaultBody }
                 }
@@ -403,9 +408,6 @@ ${actionItems.map(item => `- [ ] ${item}`).join('\n')}
 
 cc @${config.captainGitHubUsername}
 
-### Test plan
-
-CI checks in this repository should pass, and a manual review should confirm if the generated changes are correct.
 `,
                 }
             }


### PR DESCRIPTION
During the release batch change, test plans were only being added when additional actions were required. Now they'll be included on all PR's. It's not strictly required everywhere, but doesn't hurt!

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
Local dry-run, confirmed test plan is added to both standard PR's and those with additional actions.