### PR TITLE
extensions: add focus status bar and notification commands

### DIFF
--- a/client/web/src/repo/blob/Blob.tsx
+++ b/client/web/src/repo/blob/Blob.tsx
@@ -849,6 +849,7 @@ export const Blob: React.FunctionComponent<React.PropsWithChildren<BlobProps>> =
                     className={styles.blobStatusBarBody}
                     statusBarRef={nextStatusBarElement}
                     hideWhileInitializing={true}
+                    isBlobPage={true}
                 />
             )}
         </>


### PR DESCRIPTION
Part of #36751.
Closes #36753 and #36849.

We currently don't have any built in command palette actions. To ensure minimal changes to command palette code (e.g. adding abstraction for built in commands), my approach was to use the same APIs as extensions to add actions to the command palette. 

![cmd-pal-exts](https://user-images.githubusercontent.com/37420160/174870682-840b76dd-1be5-44d7-8cc9-bbb7623c8c88.png)

So, we call `registerCommand` and `registerContributions` on the extension host + main thread APIs from the status bar and notifications components.

## Test plan

- Existing automated tests pass
- Ensure focus works through manual testing
  - Status bar (on blob page)
    - Activate command palette with the `ctrl` + `p` shortcut
    - Search for `Focus status bar` command
    - Press enter/return and observe focus on first status bar item
  - Notifications (on search results page with `search-export` extension enabled)
    - Click `Export search results` button
    - Activate command palette with the `ctrl` + `p` shortcut
    - Search for `Focus notifications` command
    - Press enter/return and observe focus on first notification

## App preview:

- [Web](https://sg-web-tjk-focus-thru-cmd.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-tumyeextmb.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

