### PR TITLE
search: Refactor onboarding tour <-> query input interaction

### DIFF
--- a/client/search-ui/src/input/LazyMonacoQueryInput.tsx
+++ b/client/search-ui/src/input/LazyMonacoQueryInput.tsx
@@ -15,7 +15,6 @@ import styles from './LazyMonacoQueryInput.module.scss'
  */
 export interface IEditor {
     focus(): void
-    showSuggestions(): void
 }
 
 const MonacoQueryInput = lazyComponent(() => import('./MonacoQueryInput'), 'MonacoQueryInput')

--- a/client/search-ui/src/input/MonacoQueryInput.tsx
+++ b/client/search-ui/src/input/MonacoQueryInput.tsx
@@ -11,6 +11,7 @@ import {
     CaseSensitivityProps,
     SearchPatternTypeProps,
     SearchContextProps,
+    EditorHint,
 } from '@sourcegraph/search'
 import { MonacoEditor } from '@sourcegraph/shared/src/components/MonacoEditor'
 import { KeyboardShortcut } from '@sourcegraph/shared/src/keyboardShortcuts'
@@ -189,14 +190,7 @@ export const MonacoQueryInput: React.FunctionComponent<React.PropsWithChildren<M
             editor.getDomNode()?.setAttribute('aria-label', ariaLabel)
 
             setEditor(editor)
-            onEditorCreatedCallback?.({
-                focus() {
-                    editor.focus()
-                },
-                showSuggestions() {
-                    editor.trigger('triggerSuggestions', 'editor.action.triggerSuggest', {})
-                },
-            })
+            onEditorCreatedCallback?.(editor)
         },
         [setEditor, onEditorCreatedCallback, ariaLabel]
     )
@@ -305,37 +299,40 @@ export const MonacoQueryInput: React.FunctionComponent<React.PropsWithChildren<M
             return
         }
 
-        switch (queryState.changeSource) {
-            case QueryChangeSource.userInput:
-                // Don't react to user input
-                break
-            case QueryChangeSource.searchTypes:
-            case QueryChangeSource.searchReference: {
-                const textModel = editor.getModel()
-                if (textModel) {
-                    const selectionRange = toMonacoSelection(toMonacoRange(queryState.selectionRange, textModel))
-                    editor.setSelection(selectionRange)
-                    if (queryState.showSuggestions) {
-                        editor.trigger('triggerSuggestions', 'editor.action.triggerSuggest', {})
-                    }
-                    // For some reason this has to come *after* triggering the
-                    // suggestion, otherwise the suggestion box will be shown
-                    // and the filter is not scrolled into view.
-                    editor.revealRange(toMonacoRange(queryState.revealRange, textModel))
-                }
+        if (queryState.changeSource === QueryChangeSource.userInput) {
+            // Don't react to user input
+            return
+        }
+
+        const textModel = editor.getModel()
+
+        if (textModel && queryState.selectionRange) {
+            editor.setSelection(toMonacoSelection(toMonacoRange(queryState.selectionRange, textModel)))
+        } else if (!queryState.selectionRange) {
+            // Place the cursor at the end of the query.
+            const position = {
+                // +2 as Monaco is 1-indexed.
+                column: editor.getValue().length + 2,
+                lineNumber: 1,
+            }
+            editor.setPosition(position)
+            editor.revealPosition(position)
+        }
+
+        if (queryState.hint) {
+            if ((queryState.hint & EditorHint.Focus) === EditorHint.Focus) {
                 editor.focus()
-                break
             }
-            default: {
-                // Place the cursor at the end of the query.
-                const position = {
-                    // +2 as Monaco is 1-indexed.
-                    column: editor.getValue().length + 2,
-                    lineNumber: 1,
-                }
-                editor.setPosition(position)
-                editor.revealPosition(position)
+            if ((queryState.hint & EditorHint.ShowSuggestions) === EditorHint.ShowSuggestions) {
+                editor.trigger('triggerSuggestions', 'editor.action.triggerSuggest', {})
             }
+        }
+
+        if (textModel && queryState.revealRange) {
+            // For some reason this has to come *after* triggering the
+            // suggestion, otherwise the suggestion box will be shown
+            // but the filter won't be scrolled into view.
+            editor.revealRange(toMonacoRange(queryState.revealRange, textModel))
         }
     }, [editor, queryState])
 

--- a/client/search-ui/src/results/sidebar/SearchReference.tsx
+++ b/client/search-ui/src/results/sidebar/SearchReference.tsx
@@ -8,11 +8,11 @@ import ExternalLinkIcon from 'mdi-react/ExternalLinkIcon'
 
 import { renderMarkdown } from '@sourcegraph/common'
 import {
-    QueryChangeSource,
     SearchQueryState,
     createQueryExampleFromString,
     updateQueryWithFilterAndExample,
     QueryExample,
+    EditorHint,
 } from '@sourcegraph/search'
 import { Markdown } from '@sourcegraph/shared/src/components/Markdown'
 import { SearchPatternType } from '@sourcegraph/shared/src/graphql-operations'
@@ -537,11 +537,12 @@ const SearchReference = React.memo(
                         }
                     )
                     return {
-                        changeSource: QueryChangeSource.searchReference,
                         query: updatedQuery.query,
                         selectionRange: updatedQuery.placeholderRange,
                         revealRange: updatedQuery.filterRange,
-                        showSuggestions: shouldShowSuggestions(searchReference),
+                        hint:
+                            (shouldShowSuggestions(searchReference) ? EditorHint.ShowSuggestions : 0) |
+                            EditorHint.Focus,
                     }
                 })
             },

--- a/client/search-ui/src/results/sidebar/SearchTypeLink.tsx
+++ b/client/search-ui/src/results/sidebar/SearchTypeLink.tsx
@@ -4,11 +4,11 @@ import classNames from 'classnames'
 
 import {
     BuildSearchQueryURLParameters,
-    QueryChangeSource,
     QueryState,
     SearchContextProps,
     createQueryExampleFromString,
     updateQueryWithFilterAndExample,
+    EditorHint,
 } from '@sourcegraph/search'
 import { FilterType } from '@sourcegraph/shared/src/search/query/filters'
 import { updateFilter } from '@sourcegraph/shared/src/search/query/transformer'
@@ -32,6 +32,7 @@ export interface SearchTypeLinksProps extends Pick<SearchContextProps, 'selected
 interface SearchTypeLinkProps extends SearchTypeLinksProps {
     type: SearchType
     children: string
+    'data-testid'?: string
 }
 
 /**
@@ -44,6 +45,7 @@ const SearchTypeLink: React.FunctionComponent<React.PropsWithChildren<SearchType
     selectedSearchContextSpec,
     children,
     buildSearchURLQueryFromQueryState,
+    'data-testid': dataTestID,
 }) => {
     const builtURLQuery = buildSearchURLQueryFromQueryState({
         query: updateFilter(query, FilterType.type, type as string),
@@ -54,6 +56,7 @@ const SearchTypeLink: React.FunctionComponent<React.PropsWithChildren<SearchType
         <Link
             to={createLinkUrl({ pathname: '/search', search: builtURLQuery })}
             className={styles.sidebarSectionListItem}
+            data-testid={dataTestID}
         >
             {children}
         </Link>
@@ -63,6 +66,7 @@ const SearchTypeLink: React.FunctionComponent<React.PropsWithChildren<SearchType
 interface SearchTypeButtonProps {
     children: string
     onClick: () => void
+    'data-testid'?: string
 }
 
 /**
@@ -72,12 +76,14 @@ interface SearchTypeButtonProps {
 const SearchTypeButton: React.FunctionComponent<React.PropsWithChildren<SearchTypeButtonProps>> = ({
     children,
     onClick,
+    'data-testid': dataTestID,
 }) => (
     <Button
         className={classNames(styles.sidebarSectionListItem, styles.sidebarSectionButtonLink, 'flex-1')}
         value={children}
         onClick={onClick}
         variant="link"
+        data-testid={dataTestID}
     >
         {children}
     </Button>
@@ -120,11 +126,10 @@ export const getSearchTypeLinks = (props: SearchTypeLinksProps): ReactElement[] 
             emptyValue: true,
         })
         props.onNavbarQueryChange({
-            changeSource: QueryChangeSource.searchTypes,
             query: updatedQuery.query,
             selectionRange: updatedQuery.placeholderRange,
             revealRange: updatedQuery.filterRange,
-            showSuggestions: true,
+            hint: EditorHint.ShowSuggestions,
         })
     }
 
@@ -135,11 +140,9 @@ export const getSearchTypeLinks = (props: SearchTypeLinksProps): ReactElement[] 
             emptyValue: false,
         })
         props.onNavbarQueryChange({
-            changeSource: QueryChangeSource.searchTypes,
             query: updatedQuery.query,
             selectionRange: updatedQuery.placeholderRange,
             revealRange: updatedQuery.filterRange,
-            showSuggestions: false,
         })
     }
 
@@ -153,7 +156,7 @@ export const getSearchTypeLinks = (props: SearchTypeLinksProps): ReactElement[] 
     }
 
     return [
-        <SearchTypeButton onClick={updateQueryWithRepoExample} key="repo">
+        <SearchTypeButton onClick={updateQueryWithRepoExample} key="repo" data-testid="search-type-suggest">
             Search repos by org or name
         </SearchTypeButton>,
         <SearchTypeButton onClick={updateQueryWithRepoDependenciesExample} key="repo-dependencies">
@@ -165,7 +168,13 @@ export const getSearchTypeLinks = (props: SearchTypeLinksProps): ReactElement[] 
         <SearchTypeLinkOrButton {...props} type="diff" key="diff" onClick={() => updateQueryWithType('diff')}>
             Search diffs
         </SearchTypeLinkOrButton>,
-        <SearchTypeLinkOrButton {...props} type="commit" key="commit" onClick={() => updateQueryWithType('commit')}>
+        <SearchTypeLinkOrButton
+            {...props}
+            type="commit"
+            key="commit"
+            onClick={() => updateQueryWithType('commit')}
+            data-testid="search-type-submit"
+        >
             Search commit messages
         </SearchTypeLinkOrButton>,
     ]

--- a/client/search/src/helpers.ts
+++ b/client/search/src/helpers.ts
@@ -11,8 +11,18 @@ export enum QueryChangeSource {
      * Prevents fetching/showing suggestions on every component update.
      */
     userInput,
-    searchReference,
-    searchTypes,
+}
+
+/**
+ * These hints instruct the editor to perform certain actions alongside updating
+ * its value.
+ */
+export enum EditorHint {
+    Focus = 1,
+    /**
+     * Showing suggestions also implies focusing the input.
+     */
+    ShowSuggestions = 2 | Focus,
 }
 
 /**
@@ -21,23 +31,21 @@ export enum QueryChangeSource {
  */
 export type QueryState =
     | {
-          /** Used to know how a change comes to be. This needs to be defined as
-           * optional so that unknown sources can make changes. */
-          changeSource?: QueryChangeSource.userInput
+          changeSource: QueryChangeSource.userInput
           query: string
       }
     | {
-          /** Changes from the search side bar */
-          changeSource: QueryChangeSource.searchReference | QueryChangeSource.searchTypes
+          changeSource?: undefined
           query: string
+          /** A bit field to instruct the editor to perform this action in
+           * response to updating its state
+           */
+          hint?: EditorHint
           /** The query input will apply this selection */
-          selectionRange: CharacterRange
-          /** Ensure that newly added or updated filters are completely visible in
-           * the query input. */
-          revealRange: CharacterRange
-          /** Whether or not to trigger the completion popover. The popover is
-           * triggered at the end of the selection. */
-          showSuggestions?: boolean
+          selectionRange?: CharacterRange
+          /** Can be used to ensure that newly added or updated filters are
+           * completely visible in the query input. */
+          revealRange?: CharacterRange
       }
 
 export interface SubmitSearchParameters

--- a/client/web/src/integration/search-onboarding.test.ts
+++ b/client/web/src/integration/search-onboarding.test.ts
@@ -97,8 +97,6 @@ describe('Search onboarding', () => {
                 assert.strictEqual(inputContents, 'lang:')
 
                 await driver.page.waitForSelector('.test-tour-step-2')
-                // Refocus editor after loosing focus from clicking the tour link
-                await editor.focus()
                 await driver.page.keyboard.type('typesc')
                 await editor.waitForSuggestion()
                 await driver.page.keyboard.press('Tab')
@@ -120,8 +118,6 @@ describe('Search onboarding', () => {
                 assert.strictEqual(inputContents, 'repo:')
 
                 await driver.page.waitForSelector('.test-tour-step-2')
-                // Refocus editor after loosing focus from clicking the tour link
-                await editor.focus()
                 await driver.page.keyboard.type('sourcegraph ')
                 await driver.page.waitForSelector('.test-tour-step-3')
                 await driver.page.keyboard.type('test')
@@ -138,8 +134,6 @@ describe('Search onboarding', () => {
                 const inputContents = await editor.getValue()
                 assert.strictEqual(inputContents, 'lang:')
 
-                // Refocus editor after loosing focus from clicking the tour link
-                await editor.focus()
                 await driver.page.waitForSelector('.test-tour-step-2')
                 await driver.page.keyboard.type('TypeScr')
                 await editor.waitForSuggestion()
@@ -164,8 +158,6 @@ describe('Search onboarding', () => {
                 assert.strictEqual(inputContents, 'repo:')
 
                 await driver.page.waitForSelector('.test-tour-step-2')
-                // Refocus editor after loosing focus from clicking the tour link
-                await editor.focus()
                 await driver.page.keyboard.type('sourcegraph')
                 await editor.waitForSuggestion()
                 let tourStep2 = await driver.page.evaluate(() => document.querySelector('.test-tour-step-2'))
@@ -189,8 +181,6 @@ describe('Search onboarding', () => {
                 assert.strictEqual(inputContents, 'repo:')
 
                 await driver.page.waitForSelector('.test-tour-step-2')
-                // Refocus editor after loosing focus from clicking the tour link
-                await editor.focus()
                 await driver.page.keyboard.type('sourcegraph/sourcegraph')
                 await editor.waitForSuggestion()
                 let tourStep2 = await driver.page.evaluate(() => document.querySelector('.test-tour-step-2'))

--- a/client/web/src/integration/search.test.ts
+++ b/client/web/src/integration/search.test.ts
@@ -22,7 +22,7 @@ import { WebGraphQlOperations } from '../graphql-operations'
 
 import { WebIntegrationTestContext, createWebIntegrationTestContext } from './context'
 import { commonWebGraphQlResults, createViewerSettingsGraphQLOverride } from './graphQlResults'
-import { createEditorAPI, enableEditor, percySnapshotWithVariants, withSearchQueryInput } from './utils'
+import { createEditorAPI, EditorAPI, enableEditor, percySnapshotWithVariants, withSearchQueryInput } from './utils'
 
 const mockDefaultStreamEvents: SearchEvent[] = [
     {
@@ -100,11 +100,6 @@ describe('Search', () => {
     })
     afterEachSaveScreenshotIfFailed(() => driver.page)
     afterEach(() => testContext?.dispose())
-
-    const waitAndFocusInput = async () => {
-        await driver.page.waitForSelector('.monaco-editor .view-lines')
-        await driver.page.click('.monaco-editor .view-lines')
-    }
 
     describe('Search filters', () => {
         test('Search filters are shown on search result pages and clicking them triggers a new search', async () => {
@@ -255,14 +250,22 @@ describe('Search', () => {
     })
 
     describe('Case sensitivity toggle', () => {
-        test('Clicking toggle turns on case sensitivity', async () => {
-            await driver.page.goto(driver.sourcegraphBaseUrl + '/search')
-            await driver.page.waitForSelector('.test-query-input', { visible: true })
-            await driver.page.waitForSelector('.test-case-sensitivity-toggle')
-            await waitAndFocusInput()
-            await driver.page.type('.test-query-input', 'test')
-            await driver.page.click('.test-case-sensitivity-toggle')
-            await driver.assertWindowLocation('/search?q=context:global+test&patternType=literal&case=yes')
+        withSearchQueryInput((editorName, editorSelector) => {
+            test(`Clicking toggle turns on case sensitivity (${editorName})`, async () => {
+                const editor = createEditorAPI(driver, editorName, editorSelector)
+                testContext.overrideGraphQL({
+                    ...commonSearchGraphQLResults,
+                    ...createViewerSettingsGraphQLOverride({ user: enableEditor(editorName) }),
+                })
+
+                await driver.page.goto(driver.sourcegraphBaseUrl + '/search')
+                await driver.page.waitForSelector('.test-query-input', { visible: true })
+                await driver.page.waitForSelector('.test-case-sensitivity-toggle')
+                await editor.focus()
+                await driver.page.type('.test-query-input', 'test')
+                await driver.page.click('.test-case-sensitivity-toggle')
+                await driver.assertWindowLocation('/search?q=context:global+test&patternType=literal&case=yes')
+            })
         })
 
         test('Clicking toggle turns off case sensitivity and removes case= URL parameter', async () => {
@@ -275,23 +278,38 @@ describe('Search', () => {
     })
 
     describe('Structural search toggle', () => {
-        test('Clicking toggle turns on structural search', async () => {
-            await driver.page.goto(driver.sourcegraphBaseUrl + '/search')
-            await driver.page.waitForSelector('.test-query-input', { visible: true })
-            await driver.page.waitForSelector('.test-structural-search-toggle')
-            await waitAndFocusInput()
-            await driver.page.type('.test-query-input', 'test')
-            await driver.page.click('.test-structural-search-toggle')
-            await driver.assertWindowLocation('/search?q=context:global+test&patternType=structural')
-        })
+        withSearchQueryInput((editorName, editorSelector) => {
+            describe(editorName, () => {
+                let editor: EditorAPI
 
-        test('Clicking toggle turns on structural search and removes existing patternType parameter', async () => {
-            await driver.page.goto(driver.sourcegraphBaseUrl + '/search?q=test&patternType=regexp')
-            await waitAndFocusInput()
-            await driver.page.waitForSelector('.test-query-input', { visible: true })
-            await driver.page.waitForSelector('.test-structural-search-toggle')
-            await driver.page.click('.test-structural-search-toggle')
-            await driver.assertWindowLocation('/search?q=context:global+test&patternType=structural')
+                beforeEach(() => {
+                    editor = createEditorAPI(driver, editorName, editorSelector)
+
+                    testContext.overrideGraphQL({
+                        ...commonSearchGraphQLResults,
+                        ...createViewerSettingsGraphQLOverride({ user: enableEditor(editorName) }),
+                    })
+                })
+
+                test('Clicking toggle turns on structural search', async () => {
+                    await driver.page.goto(driver.sourcegraphBaseUrl + '/search')
+                    await driver.page.waitForSelector('.test-query-input', { visible: true })
+                    await driver.page.waitForSelector('.test-structural-search-toggle')
+                    await editor.focus()
+                    await driver.page.type('.test-query-input', 'test')
+                    await driver.page.click('.test-structural-search-toggle')
+                    await driver.assertWindowLocation('/search?q=context:global+test&patternType=structural')
+                })
+
+                test('Clicking toggle turns on structural search and removes existing patternType parameter', async () => {
+                    await driver.page.goto(driver.sourcegraphBaseUrl + '/search?q=test&patternType=regexp')
+                    await editor.focus()
+                    await driver.page.waitForSelector('.test-query-input', { visible: true })
+                    await driver.page.waitForSelector('.test-structural-search-toggle')
+                    await driver.page.click('.test-structural-search-toggle')
+                    await driver.assertWindowLocation('/search?q=context:global+test&patternType=structural')
+                })
+            })
         })
 
         test('Clicking toggle turns off structural search and reverts to default pattern type', async () => {
@@ -550,6 +568,41 @@ describe('Search', () => {
             await driver.page.waitForSelector('[data-testid="saved-search-form"]')
             await percySnapshotWithVariants(driver.page, 'Saved search - Form')
             await accessibilityAudit(driver.page)
+        })
+    })
+
+    describe('Search sidebar', () => {
+        withSearchQueryInput((editorName, editorSelector) => {
+            describe(editorName, () => {
+                let editor: EditorAPI
+
+                beforeEach(() => {
+                    editor = createEditorAPI(driver, editorName, editorSelector)
+
+                    testContext.overrideGraphQL({
+                        ...commonSearchGraphQLResults,
+                        ...createViewerSettingsGraphQLOverride({ user: enableEditor(editorName) }),
+                    })
+                })
+
+                test('updates the query input and triggers suggestions', async () => {
+                    await driver.page.goto(driver.sourcegraphBaseUrl + '/search?q=test')
+                    await driver.page.waitForSelector('[data-testid="search-type-suggest"]')
+                    await driver.page.click('[data-testid="search-type-suggest"]')
+                    await editor.waitForSuggestion()
+                    expect(await editor.getValue()).toEqual('test repo:')
+                })
+            })
+        })
+
+        test('updates the query input and submits the query', async () => {
+            await driver.page.goto(driver.sourcegraphBaseUrl + '/search?q=test')
+            await driver.page.waitForSelector('[data-testid="search-type-submit"]')
+            await Promise.all([
+                driver.page.waitForNavigation(),
+                driver.page.click('[data-testid="search-type-submit"]'),
+            ])
+            expect(driver.page.url()).toContain('test+type:commit')
         })
     })
 })

--- a/client/web/src/integration/search.test.ts
+++ b/client/web/src/integration/search.test.ts
@@ -251,29 +251,36 @@ describe('Search', () => {
 
     describe('Case sensitivity toggle', () => {
         withSearchQueryInput((editorName, editorSelector) => {
-            test(`Clicking toggle turns on case sensitivity (${editorName})`, async () => {
-                const editor = createEditorAPI(driver, editorName, editorSelector)
-                testContext.overrideGraphQL({
-                    ...commonSearchGraphQLResults,
-                    ...createViewerSettingsGraphQLOverride({ user: enableEditor(editorName) }),
+            describe(editorName, () => {
+                let editor: EditorAPI
+
+                beforeEach(() => {
+                    editor = createEditorAPI(driver, editorName, editorSelector)
+
+                    testContext.overrideGraphQL({
+                        ...commonSearchGraphQLResults,
+                        ...createViewerSettingsGraphQLOverride({ user: enableEditor(editorName) }),
+                    })
                 })
 
-                await driver.page.goto(driver.sourcegraphBaseUrl + '/search')
-                await driver.page.waitForSelector('.test-query-input', { visible: true })
-                await driver.page.waitForSelector('.test-case-sensitivity-toggle')
-                await editor.focus()
-                await driver.page.type('.test-query-input', 'test')
-                await driver.page.click('.test-case-sensitivity-toggle')
-                await driver.assertWindowLocation('/search?q=context:global+test&patternType=literal&case=yes')
-            })
-        })
+                test('Clicking toggle turns on case sensitivity', async () => {
+                    await driver.page.goto(driver.sourcegraphBaseUrl + '/search')
+                    await editor.waitForIt()
+                    await driver.page.waitForSelector('.test-case-sensitivity-toggle')
+                    await editor.focus()
+                    await driver.page.keyboard.type('test')
+                    await driver.page.click('.test-case-sensitivity-toggle')
+                    await driver.assertWindowLocation('/search?q=context:global+test&patternType=literal&case=yes')
+                })
 
-        test('Clicking toggle turns off case sensitivity and removes case= URL parameter', async () => {
-            await driver.page.goto(driver.sourcegraphBaseUrl + '/search?q=test&patternType=literal&case=yes')
-            await driver.page.waitForSelector('.test-query-input', { visible: true })
-            await driver.page.waitForSelector('.test-case-sensitivity-toggle')
-            await driver.page.click('.test-case-sensitivity-toggle')
-            await driver.assertWindowLocation('/search?q=context:global+test&patternType=literal')
+                test('Clicking toggle turns off case sensitivity and removes case= URL parameter', async () => {
+                    await driver.page.goto(driver.sourcegraphBaseUrl + '/search?q=test&patternType=literal&case=yes')
+                    await editor.waitForIt()
+                    await driver.page.waitForSelector('.test-case-sensitivity-toggle')
+                    await driver.page.click('.test-case-sensitivity-toggle')
+                    await driver.assertWindowLocation('/search?q=context:global+test&patternType=literal')
+                })
+            })
         })
     })
 
@@ -293,10 +300,10 @@ describe('Search', () => {
 
                 test('Clicking toggle turns on structural search', async () => {
                     await driver.page.goto(driver.sourcegraphBaseUrl + '/search')
-                    await driver.page.waitForSelector('.test-query-input', { visible: true })
+                    await editor.waitForIt()
                     await driver.page.waitForSelector('.test-structural-search-toggle')
                     await editor.focus()
-                    await driver.page.type('.test-query-input', 'test')
+                    await driver.page.keyboard.type('test')
                     await driver.page.click('.test-structural-search-toggle')
                     await driver.assertWindowLocation('/search?q=context:global+test&patternType=structural')
                 })
@@ -304,20 +311,19 @@ describe('Search', () => {
                 test('Clicking toggle turns on structural search and removes existing patternType parameter', async () => {
                     await driver.page.goto(driver.sourcegraphBaseUrl + '/search?q=test&patternType=regexp')
                     await editor.focus()
-                    await driver.page.waitForSelector('.test-query-input', { visible: true })
                     await driver.page.waitForSelector('.test-structural-search-toggle')
                     await driver.page.click('.test-structural-search-toggle')
                     await driver.assertWindowLocation('/search?q=context:global+test&patternType=structural')
                 })
-            })
-        })
 
-        test('Clicking toggle turns off structural search and reverts to default pattern type', async () => {
-            await driver.page.goto(driver.sourcegraphBaseUrl + '/search?q=test&patternType=structural')
-            await driver.page.waitForSelector('.test-query-input', { visible: true })
-            await driver.page.waitForSelector('.test-structural-search-toggle')
-            await driver.page.click('.test-structural-search-toggle')
-            await driver.assertWindowLocation('/search?q=context:global+test&patternType=literal')
+                test('Clicking toggle turns off structural search and reverts to default pattern type', async () => {
+                    await driver.page.goto(driver.sourcegraphBaseUrl + '/search?q=test&patternType=structural')
+                    await editor.waitForIt()
+                    await driver.page.waitForSelector('.test-structural-search-toggle')
+                    await driver.page.click('.test-structural-search-toggle')
+                    await driver.assertWindowLocation('/search?q=context:global+test&patternType=literal')
+                })
+            })
         })
     })
 
@@ -602,7 +608,7 @@ describe('Search', () => {
                 driver.page.waitForNavigation(),
                 driver.page.click('[data-testid="search-type-submit"]'),
             ])
-            expect(driver.page.url()).toContain('test+type:commit')
+            await driver.assertWindowLocation('/search?q=context:global+test+type:commit&patternType=literal')
         })
     })
 })


### PR DESCRIPTION
This PR refactors how the search onboarding tour (and other code) interacts with the query state. In particular it changes how the tour triggers query input suggestions. I'm making this change to standardize on one solution for triggering suggestions.

Until now the tour used a direct reference to the query input to trigger suggestions. It would inspect the current query on every change and decide whether or not to trigger suggestions.

Since the tour was added we made changes to the query state that allows code to inform the query input to show suggestions. It was only used by the search sidebar so far.

Instead of introducing yet another change type, I'm only distinguishing between user changes and "other" changes. "Other" changes can specify a couple of optional fields, including whether or not the query input should show suggestions after a change. Another important change is that the editor will always receive focus when the suggestions are shown (edit: apparently Monaco does this automatically when showing suggestions, but not CodeMirror)

This way the tour can simply set that flag when it updates the query and doesn't have to implement it's own logic to determine whether or not it should trigger suggestions.



## Test plan

Integration tests pass. I added two more tests that verify the query input behavior via the search sidebar.

## App preview:

- [Web](https://sg-web-fkling-refactor-onboarding-tour.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-ngypylrjew.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
