### PR TITLE
Search backend: convert closures and channels to stream

### DIFF
--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -6,7 +6,6 @@ package search
 import (
 	"context"
 	"fmt"
-	"math"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -109,18 +108,13 @@ func (h *streamHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Display is the number of results we send down. If display is < 0 we
 	// want to send everything we find before hitting a limit. Otherwise we
 	// can only send up to limit results.
-	display := args.Display
+	displayLimit := args.Display
 	limit := inputs.MaxResults()
-	if display < 0 || display > limit {
-		display = limit
+	if displayLimit < 0 || displayLimit > limit {
+		displayLimit = limit
 	}
 
 	start := time.Now()
-
-	displayLimit := display
-	if display < 0 {
-		displayLimit = math.MaxInt32
-	}
 
 	progress := progressAggregator{
 		Start:        start,

--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -610,6 +610,8 @@ func (h *eventHandler) Send(event streaming.SearchEvent) {
 
 // Done cleans up any background tasks and flushes any buffered data to the stream
 func (h *eventHandler) Done() {
+	// cancel outside of the mutex so any requests
+	// that are holding the mutex stop immediately
 	h.cancel()
 
 	h.mu.Lock()


### PR DESCRIPTION
This modifies the stream-to-http code to fit into our normal `streaming.Sender` interface.

We jumped through a lot of hoops to convert a callback-based stream into a set of event channels, and it was honestly very confusing. This rewrites the code that handles converting events, populating metadata, and periodically flushing the results to the underlying stream into a type that implements `streaming.Sender`. This allows us to pass it directly into `search.Execute` and gets rid of a bunch of closures that implicitly capture a large amount of state. 

Additionally, this provides a nice `Done()` method that cleans up resources, so I can more easily implement things like concurrent DB requests to populate repo metadata. This will be particularly useful for streaming pre-highlighted code.

## Test plan

I audited this code carefully since `time.AfterFunc` can lead to some racy conditions. Depending on unit tests and backend integration tests to catch regressions, but also did some manual smoke tests.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
