### PR TITLE
extensions: improve action items bar accessibility

### DIFF
--- a/client/shared/src/actions/ActionItem.tsx
+++ b/client/shared/src/actions/ActionItem.tsx
@@ -257,11 +257,9 @@ export class ActionItem extends React.PureComponent<ActionItemProps, State, type
                   outline: this.props.actionItemStyleProps?.actionItemOutline,
               }
             : {}
-        const disabled =
-            !this.props.active ||
-            ((this.props.disabledDuringExecution || this.props.showLoadingSpinnerDuringExecution) &&
-                this.state.actionOrError === LOADING) ||
-            this.props.disabledWhen
+        const disabled = this.isDisabled()
+
+        // TODO don't run action when disabled
 
         return (
             <ButtonLink
@@ -312,6 +310,10 @@ export class ActionItem extends React.PureComponent<ActionItemProps, State, type
             return
         }
 
+        if (this.isDisabled()) {
+            return
+        }
+
         // Record action ID (but not args, which might leak sensitive data).
         this.props.telemetryService.log(action.id)
 
@@ -341,6 +343,12 @@ export class ActionItem extends React.PureComponent<ActionItemProps, State, type
             args: action.commandArguments,
         })
     }
+
+    private isDisabled = (): boolean | undefined =>
+        !this.props.active ||
+        ((this.props.disabledDuringExecution || this.props.showLoadingSpinnerDuringExecution) &&
+            this.state.actionOrError === LOADING) ||
+        this.props.disabledWhen
 }
 
 export function urlForClientCommandOpen(

--- a/client/shared/src/actions/ActionItem.tsx
+++ b/client/shared/src/actions/ActionItem.tsx
@@ -257,6 +257,11 @@ export class ActionItem extends React.PureComponent<ActionItemProps, State, type
                   outline: this.props.actionItemStyleProps?.actionItemOutline,
               }
             : {}
+        const disabled =
+            !this.props.active ||
+            ((this.props.disabledDuringExecution || this.props.showLoadingSpinnerDuringExecution) &&
+                this.state.actionOrError === LOADING) ||
+            this.props.disabledWhen
 
         return (
             <ButtonLink
@@ -266,20 +271,15 @@ export class ActionItem extends React.PureComponent<ActionItemProps, State, type
                         : tooltip
                 }
                 data-content={this.props.dataContent}
-                disabled={
-                    !this.props.active ||
-                    ((this.props.disabledDuringExecution || this.props.showLoadingSpinnerDuringExecution) &&
-                        this.state.actionOrError === LOADING) ||
-                    this.props.disabledWhen
-                }
-                disabledClassName={this.props.inactiveClassName}
+                aria-disabled={disabled}
                 data-action-item-pressed={pressed}
                 className={classNames(
                     'test-action-item',
                     this.props.className,
                     showLoadingSpinner && styles.actionItemLoading,
                     pressed && [this.props.pressedClassName],
-                    buttonLinkProps.variant === 'link' && styles.actionItemLink
+                    buttonLinkProps.variant === 'link' && styles.actionItemLink,
+                    disabled && this.props.inactiveClassName
                 )}
                 pressed={pressed}
                 onSelect={this.runAction}

--- a/client/shared/src/actions/__snapshots__/ActionItem.test.tsx.snap
+++ b/client/shared/src/actions/__snapshots__/ActionItem.test.tsx.snap
@@ -201,38 +201,29 @@ exports[`ActionItem run command with error with showInlineError 1`] = `
 
 exports[`ActionItem run command with showLoadingSpinnerDuringExecution 1`] = `
 <DocumentFragment>
-  <div
-    class="container"
+  <a
+    aria-disabled="true"
+    aria-label="d"
+    class="test-action-item actionItemLoading"
+    data-tooltip="d"
+    href=""
+    role="button"
+    tabindex="0"
   >
-    <div
-      class="disabledTooltip"
-      data-tooltip="d"
-      tabindex="0"
+    <img
+      alt="d"
+      src="u"
     />
-    <a
-      aria-label="d"
-      class="test-action-item actionItemLoading disabled"
-      data-tooltip="d"
-      disabled=""
-      href=""
-      role="button"
-      tabindex="-1"
+     g: t 
+    <div
+      class="loader"
+      data-testid="action-item-spinner"
     >
-      <img
-        alt="d"
-        src="u"
-      />
-       g: t 
       <div
-        class="loader"
-        data-testid="action-item-spinner"
-      >
-        <div
-          class="loadingSpinner"
-        />
-      </div>
-    </a>
-  </div>
+        class="loadingSpinner"
+      />
+    </div>
+  </a>
 </DocumentFragment>
 `;
 

--- a/client/web/src/extensions/components/ActionItemsBar.tsx
+++ b/client/web/src/extensions/components/ActionItemsBar.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
 
+import VisuallyHidden from '@reach/visually-hidden'
 import classNames from 'classnames'
 import * as H from 'history'
 import { head, last } from 'lodash'
@@ -328,7 +329,11 @@ export const ActionItemsToggle: React.FunctionComponent<React.PropsWithChildren<
                 <div className={classNames(styles.toggleContainer, isOpen && styles.toggleContainerOpen)}>
                     <ButtonLink
                         data-tooltip={`${isOpen ? 'Close' : 'Open'} extensions panel`}
-                        aria-label={`${isOpen ? 'Close' : 'Open'} extensions panel`}
+                        aria-label={
+                            isOpen
+                                ? 'Close extensions panel. Press the down arrow key to enter the extensions panel.'
+                                : 'Open extensions panel'
+                        }
                         className={classNames(actionItemClassName, styles.auxIcon, styles.actionToggle)}
                         onSelect={toggle}
                         ref={toggleReference}
@@ -340,6 +345,7 @@ export const ActionItemsToggle: React.FunctionComponent<React.PropsWithChildren<
                         ) : (
                             <Icon as={PuzzleOutlineIcon} aria-hidden={true} />
                         )}
+                        {haveExtensionsLoaded && <VisuallyHidden>Down arrow to enter</VisuallyHidden>}
                     </ButtonLink>
                 </div>
             </li>

--- a/client/web/src/extensions/components/ActionItemsBar.tsx
+++ b/client/web/src/extensions/components/ActionItemsBar.tsx
@@ -283,8 +283,8 @@ export const ActionItemsBar = React.memo<ActionItemsBarProps>(function ActionIte
                     </Button>
                 )}
                 {haveExtensionsLoaded && <ActionItemsDivider />}
-                <ul className="list-unstyled m-0">
-                    <li className={styles.listItem}>
+                <div className="list-unstyled m-0">
+                    <div className={styles.listItem}>
                         <Link
                             to="/extensions"
                             className={classNames(styles.listItem, styles.auxIcon, actionItemClassName)}
@@ -293,8 +293,8 @@ export const ActionItemsBar = React.memo<ActionItemsBarProps>(function ActionIte
                         >
                             <Icon as={PlusIcon} aria-hidden={true} />
                         </Link>
-                    </li>
-                </ul>
+                    </div>
+                </div>
             </ErrorBoundary>
         </div>
     )


### PR DESCRIPTION
Part of #36751.
Closes #36850, #36852, #36854, and #36855.

- Use `aria-disabled` instead of `disabled` for action items so they can retain focus when loading and so screen readers will read their labels.
- Use `<div>` instead of lists for single children.
- Add keyboard shortcut to enter action items bar to `aria-label` for toggle.

## Test plan

- Existing automated tests pass
- Navigate to action items bar toggle with keyboard w/ screen reader on
  - <img width="209" alt="Screen Shot 2022-06-21 at 3 52 52 PM" src="https://user-images.githubusercontent.com/37420160/174886131-b4de19d5-1c08-46ae-826f-3e224b84deb6.png">
  - Ensure that screen reader announces keyboard shortcut to enter panel
  - Press down/up arrow keys until you reach a disabled action item
    - Ensure that screen reader announces label.
   - Press down/up arrow keys until you reach an enabled action item with an asynchronous action (e.g. toggle git blame)
     - Press enter to run action
     - Ensure that focus stays on the action during and after execution

## App preview:

- [Web](https://sg-web-tjk-action-items-a11y.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-pwlvbhwotm.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

