### PR TITLE
Search backend: split up `(streamHandler).StreamHTTP()`

### DIFF
--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -56,23 +56,13 @@ type streamHandler struct {
 }
 
 func (h *streamHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	args, err := parseURLQuery(r.URL.Query())
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
-		return
-	}
-
-	tr, ctx := trace.New(r.Context(), "search.ServeStream", args.Query,
-		trace.Tag{Key: "version", Value: args.Version},
-		trace.Tag{Key: "pattern_type", Value: args.PatternType},
-	)
-	defer func() {
-		tr.SetError(err)
-		tr.Finish()
-	}()
+	tr, ctx := trace.New(r.Context(), "search.ServeStream", "")
+	defer tr.Finish()
+	r = r.WithContext(ctx)
 
 	streamWriter, err := streamhttp.NewWriter(w)
 	if err != nil {
+		tr.SetError(err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -80,15 +70,34 @@ func (h *streamHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	streamWriter.StatHook = eventStreamOTHook(tr.LogFields)
 
 	eventWriter := newEventWriter(streamWriter)
-
-	// Always send a final done event so clients know the stream is shutting
-	// down.
 	defer eventWriter.Done()
+
+	err = h.serveHTTP(r, tr, eventWriter)
+	if err != nil {
+		eventWriter.Error(err)
+		tr.SetError(err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+}
+
+func (h *streamHandler) serveHTTP(r *http.Request, tr *trace.Trace, eventWriter *eventWriter) (err error) {
+	ctx := r.Context()
+	start := time.Now()
+
+	args, err := parseURLQuery(r.URL.Query())
+	if err != nil {
+		return err
+	}
+	tr.TagFields(
+		otlog.String("query", args.Query),
+		otlog.String("version", args.Version),
+		otlog.String("pattern_type", args.PatternType),
+	)
 
 	settings, err := graphqlbackend.DecodedViewerFinalSettings(ctx, h.db)
 	if err != nil {
-		eventWriter.Error(err)
-		return
+		return err
 	}
 
 	inputs, err := h.searchClient.Plan(ctx, args.Version, strPtr(args.PatternType), args.Query, search.Streaming, settings, envvar.SourcegraphDotComMode())
@@ -96,10 +105,10 @@ func (h *streamHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		var queryErr *run.QueryError
 		if errors.As(err, &queryErr) {
 			eventWriter.Alert(search.AlertForQuery(queryErr.Query, queryErr.Err))
+			return nil
 		} else {
-			eventWriter.Error(err)
+			return err
 		}
-		return
 	}
 
 	// Display is the number of results we send down. If display is < 0 we
@@ -111,9 +120,7 @@ func (h *streamHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		displayLimit = limit
 	}
 
-	start := time.Now()
-
-	progress := progressAggregator{
+	progress := &progressAggregator{
 		Start:        start,
 		Limit:        inputs.MaxResults(),
 		Trace:        trace.URL(trace.ID(ctx), conf.ExternalURL(), conf.Tracer()),
@@ -144,19 +151,23 @@ func (h *streamHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		displayLimit,
 		logLatency,
 	)
+	defer eventHandler.Done()
+
 	batchedStream := streaming.NewBatchingStream(50*time.Millisecond, eventHandler)
+	defer batchedStream.Done()
+
 	alert, err := h.searchClient.Execute(ctx, batchedStream, inputs)
-	if err != nil {
-		eventWriter.Error(err)
-	}
 	if alert != nil {
 		eventWriter.Alert(alert)
 	}
-	batchedStream.Done()
-	eventHandler.Done()
+	logSearch(ctx, alert, err, start, inputs.OriginalQuery, progress)
+	return err
+}
 
-	var status, alertType string
-	status = graphqlbackend.DetermineStatusForLogs(alert, progress.Stats, err)
+func logSearch(ctx context.Context, alert *search.Alert, err error, start time.Time, originalQuery string, progress *progressAggregator) {
+	status := graphqlbackend.DetermineStatusForLogs(alert, progress.Stats, err)
+
+	var alertType string
 	if alert != nil {
 		alertType = alert.PrometheusType
 	}
@@ -164,7 +175,7 @@ func (h *streamHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	isSlow := time.Since(start) > searchlogs.LogSlowSearchesThreshold()
 	if honey.Enabled() || isSlow {
 		ev := searchhoney.SearchEvent(ctx, searchhoney.SearchEventArgs{
-			OriginalQuery: inputs.OriginalQuery,
+			OriginalQuery: originalQuery,
 			Typ:           "stream",
 			Source:        string(trace.RequestSource(ctx)),
 			Status:        status,
@@ -499,7 +510,7 @@ func newEventHandler(
 	ctx context.Context,
 	db database.DB,
 	eventWriter *eventWriter,
-	progress progressAggregator,
+	progress *progressAggregator,
 	flushInterval time.Duration,
 	progressInterval time.Duration,
 	displayLimit int,
@@ -552,7 +563,7 @@ type eventHandler struct {
 
 	matchesBuf *streamhttp.JSONArrayBuf
 	filters    *streaming.SearchFilters
-	progress   progressAggregator
+	progress   *progressAggregator
 
 	flushInterval    time.Duration
 	progressInterval time.Duration

--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -56,16 +56,13 @@ type streamHandler struct {
 }
 
 func (h *streamHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	ctx, cancel := context.WithCancel(r.Context())
-	defer cancel()
-
 	args, err := parseURLQuery(r.URL.Query())
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 
-	tr, ctx := trace.New(ctx, "search.ServeStream", args.Query,
+	tr, ctx := trace.New(r.Context(), "search.ServeStream", args.Query,
 		trace.Tag{Key: "version", Value: args.Version},
 		trace.Tag{Key: "pattern_type", Value: args.PatternType},
 	)


### PR DESCRIPTION
This splits `ServeHTTP` into three parts:
1) the outer `ServeHTTP`, which is responsible for starting a trace,
   creating an event writer around the raw `http.ResponseWrapper`, and
   handling any errors returned by serveHTTP
2) the inner `serveHTTP`, which is responsible for parsing the query,
   building the streams, and executing the search
3) `logSearch`, which is responsible for logging the timing and status
   results of an executed search.

~Stacked on https://github.com/sourcegraph/sourcegraph/pull/37509~

## Test plan

Backend integration tests, unit tests, and manual smoke tests.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
