### PR TITLE
search: introduce standard patterntype

### DIFF
--- a/client/shared/src/search/query/scanner.ts
+++ b/client/shared/src/search/query/scanner.ts
@@ -494,6 +494,9 @@ export const scanSearchQuery = (
             // (e.g., literal _or_ regexp), so effectively scan and label patterns as literals.
             patternKind = PatternKind.Literal
             break
+        case SearchPatternType.standard:
+            patternKind = PatternKind.Literal
+            break
     }
     const scanner = createScanner(patternKind, interpretComments)
     return scanner(query, 0)

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1855,6 +1855,7 @@ enum SearchVersion {
 The search pattern type.
 """
 enum SearchPatternType {
+    standard
     literal
     regexp
     structural

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -374,6 +374,8 @@ func LogSearchLatency(ctx context.Context, db database.DB, si *run.SearchInputs,
 			types = append(types, "file")
 		case "file":
 			switch {
+			case si.PatternType == query.SearchTypeStandard:
+				types = append(types, "standard")
 			case si.PatternType == query.SearchTypeStructural:
 				types = append(types, "structural")
 			case si.PatternType == query.SearchTypeLiteral:

--- a/internal/search/alert.go
+++ b/internal/search/alert.go
@@ -54,6 +54,8 @@ type ProposedQuery struct {
 func (q *ProposedQuery) QueryString() string {
 	if q.Description != "Remove quotes" {
 		switch q.PatternType {
+		case query.SearchTypeStandard:
+			return q.Query + " patternType:standard"
 		case query.SearchTypeRegex:
 			return q.Query + " patternType:regexp"
 		case query.SearchTypeLiteral:

--- a/internal/search/query/query.go
+++ b/internal/search/query/query.go
@@ -93,6 +93,8 @@ func SubstituteSearchContexts(lookupQueryString func(contextValue string) (strin
 func For(searchType SearchType) step {
 	var processType step
 	switch searchType {
+	case SearchTypeStandard:
+		processType = succeeds(substituteConcat(space))
 	case SearchTypeLiteral:
 		processType = succeeds(substituteConcat(space))
 	case SearchTypeRegex:

--- a/internal/search/query/types.go
+++ b/internal/search/query/types.go
@@ -33,10 +33,13 @@ const (
 	SearchTypeLiteral
 	SearchTypeStructural
 	SearchTypeLucky
+	SearchTypeStandard
 )
 
 func (s SearchType) String() string {
 	switch s {
+	case SearchTypeStandard:
+		return "standard"
 	case SearchTypeRegex:
 		return "regex"
 	case SearchTypeLiteral:

--- a/internal/search/run/run.go
+++ b/internal/search/run/run.go
@@ -121,6 +121,8 @@ func detectSearchType(version string, patternType *string) (query.SearchType, er
 	var searchType query.SearchType
 	if patternType != nil {
 		switch *patternType {
+		case "standard":
+			searchType = query.SearchTypeStandard
 		case "literal":
 			searchType = query.SearchTypeLiteral
 		case "regexp":
@@ -155,6 +157,8 @@ func overrideSearchType(input string, searchType query.SearchType) query.SearchT
 	}
 	query.VisitField(q, "patterntype", func(value string, _ bool, _ query.Annotation) {
 		switch value {
+		case "standard":
+			searchType = query.SearchTypeStandard
 		case "regex", "regexp":
 			searchType = query.SearchTypeRegex
 		case "literal":


### PR DESCRIPTION
As in title. This is for supporting `/.../` regex syntax alongside literal syntax, as per [RFC 675](https://docs.google.com/document/d/1KebTihO_jrPcLblgeT4X428kfgs42NkFz_3kCr8bT0M/edit#heading=h.trqab8y0kufp), and any future expansion or divergent query syntax from `literal`/`regexp`. In time the hope is that we can remove the need for `literal` or `regexp` entirely, but we are keeping them for backwards compatibility right now.

## Test plan
Unused, just scaffolding, no tests.
