### PR TITLE
Code monitors: fix issue with action/trigger perms checking

### DIFF
--- a/enterprise/internal/database/code_monitor_emails.go
+++ b/enterprise/internal/database/code_monitor_emails.go
@@ -32,7 +32,13 @@ SET enabled = %s,
 	header = %s,
 	changed_by = %s,
 	changed_at = %s
-WHERE id = %s
+WHERE
+	id = %s
+	AND EXISTS (
+		SELECT 1 FROM cm_monitors
+		WHERE cm_monitors.id = id
+			AND cm_monitors.namespace_user_id = %s
+	)
 RETURNING %s;
 `
 
@@ -54,6 +60,7 @@ func (s *codeMonitorStore) UpdateEmailAction(ctx context.Context, id int64, args
 		a.UID,
 		s.Now(),
 		id,
+		a.UID,
 		sqlf.Join(emailsColumns, ", "),
 	)
 

--- a/enterprise/internal/database/code_monitor_emails_test.go
+++ b/enterprise/internal/database/code_monitor_emails_test.go
@@ -1,0 +1,39 @@
+package database
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/sourcegraph/sourcegraph/internal/actor"
+)
+
+func TestUpdateEmail(t *testing.T) {
+	ctx, db, s := newTestStore(t)
+	uid1 := insertTestUser(ctx, t, db, "u1", false)
+	ctx1 := actor.WithActor(ctx, actor.FromUser(uid1))
+	uid2 := insertTestUser(ctx, t, db, "u2", false)
+	ctx2 := actor.WithActor(ctx, actor.FromUser(uid2))
+	fixtures := s.insertTestMonitor(ctx1, t)
+
+	ea, err := s.CreateEmailAction(ctx1, fixtures.monitor.ID, &EmailActionArgs{
+		Priority: "NORMAL",
+	})
+	require.NoError(t, err)
+
+	// User1 can update it
+	_, err = s.UpdateEmailAction(ctx1, ea.ID, &EmailActionArgs{
+		Priority: "CRITICAL",
+	})
+	require.NoError(t, err)
+
+	// User2 cannot update it
+	_, err = s.UpdateEmailAction(ctx2, ea.ID, &EmailActionArgs{
+		Priority: "NORMAL",
+	})
+	require.Error(t, err)
+
+	ea, err = s.GetEmailAction(ctx1, ea.ID)
+	require.NoError(t, err)
+	require.Equal(t, ea.Priority, "CRITICAL")
+}

--- a/enterprise/internal/database/code_monitor_monitors.go
+++ b/enterprise/internal/database/code_monitor_monitors.go
@@ -77,7 +77,9 @@ SET description = %s,
 	namespace_org_id = %s,
 	changed_by = %s,
 	changed_at = %s
-WHERE id = %s
+WHERE
+	id = %s
+	AND namespace_user_id = %s
 RETURNING %s; -- monitorColumns
 `
 
@@ -93,6 +95,7 @@ func (s *codeMonitorStore) UpdateMonitor(ctx context.Context, id int64, args Mon
 		a.UID,
 		s.Now(),
 		id,
+		a.UID,
 		sqlf.Join(monitorColumns, ", "),
 	)
 

--- a/enterprise/internal/database/code_monitor_slack_webhook.go
+++ b/enterprise/internal/database/code_monitor_slack_webhook.go
@@ -31,7 +31,13 @@ SET enabled = %s,
 	url = %s,
 	changed_by = %s,
 	changed_at = %s
-WHERE id = %s
+WHERE
+	id = %s
+	AND EXISTS (
+		SELECT 1 FROM cm_monitors
+		WHERE cm_monitors.id = id
+			AND cm_monitors.namespace_user_id = %s
+	)
 RETURNING %s;
 `
 
@@ -45,6 +51,7 @@ func (s *codeMonitorStore) UpdateSlackWebhookAction(ctx context.Context, id int6
 		a.UID,
 		s.Now(),
 		id,
+		a.UID,
 		sqlf.Join(slackWebhookActionColumns, ","),
 	)
 

--- a/enterprise/internal/database/code_monitor_webhook.go
+++ b/enterprise/internal/database/code_monitor_webhook.go
@@ -31,7 +31,13 @@ SET enabled = %s,
 	url = %s,
 	changed_by = %s,
 	changed_at = %s
-WHERE id = %s
+WHERE
+	id = %s
+	AND EXISTS (
+		SELECT 1 FROM cm_monitors
+		WHERE cm_monitors.id = id
+			AND cm_monitors.namespace_user_id = %s
+	)
 RETURNING %s;
 `
 
@@ -45,6 +51,7 @@ func (s *codeMonitorStore) UpdateWebhookAction(ctx context.Context, id int64, en
 		a.UID,
 		s.Now(),
 		id,
+		a.UID,
 		sqlf.Join(webhookActionColumns, ","),
 	)
 

--- a/enterprise/internal/database/code_monitor_webhook_test.go
+++ b/enterprise/internal/database/code_monitor_webhook_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/sourcegraph/log/logtest"
 
+	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 )
@@ -138,5 +139,29 @@ func TestCodeMonitorStoreWebhooks(t *testing.T) {
 		actions3, err := s.ListWebhookActions(ctx, ListActionsOpts{MonitorID: &fixtures.monitor.ID, First: &first})
 		require.NoError(t, err)
 		require.Len(t, actions3, 1)
+	})
+
+	t.Run("Update permissions", func(t *testing.T) {
+		ctx, db, s := newTestStore(t)
+		uid1 := insertTestUser(ctx, t, db, "u1", false)
+		ctx1 := actor.WithActor(ctx, actor.FromUser(uid1))
+		uid2 := insertTestUser(ctx, t, db, "u2", false)
+		ctx2 := actor.WithActor(ctx, actor.FromUser(uid2))
+		fixtures := s.insertTestMonitor(ctx1, t)
+
+		wa, err := s.CreateWebhookAction(ctx1, fixtures.monitor.ID, true, true, "https://true.com")
+		require.NoError(t, err)
+
+		// User1 can update it
+		_, err = s.UpdateWebhookAction(ctx1, wa.ID, true, true, "https://false.com")
+		require.NoError(t, err)
+
+		// User2 cannot update it
+		_, err = s.UpdateWebhookAction(ctx2, wa.ID, true, true, "https://truer.com")
+		require.Error(t, err)
+
+		wa, err = s.GetWebhookAction(ctx1, wa.ID)
+		require.NoError(t, err)
+		require.Equal(t, wa.URL, "https://false.com")
 	})
 }


### PR DESCRIPTION
This fixes [an issue](https://github.com/sourcegraph/security-issues/issues/279) that allows non-owner users to modify triggers and actions that they don't own. The fix here updates our DB access code to always check that the caller is also the owner of the monitor the trigger/action belongs to. 

## Test plan

Added tests. 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
