### PR TITLE
a11y: search context management mobile fixes

### DIFF
--- a/client/web/src/components/FilteredConnection/FilterControl.module.scss
+++ b/client/web/src/components/FilteredConnection/FilterControl.module.scss
@@ -1,7 +1,3 @@
-.select {
-    margin: 0 -0.25rem;
-}
-
 .filter-control {
     display: flex;
     align-items: center;

--- a/client/web/src/components/FilteredConnection/FilterControl.tsx
+++ b/client/web/src/components/FilteredConnection/FilterControl.tsx
@@ -85,10 +85,7 @@ export const FilterControl: React.FunctionComponent<React.PropsWithChildren<Filt
                 if (filter.type === 'select') {
                     const filterLabelId = `filtered-select-label-${filter.id}`
                     return (
-                        <div
-                            key={filter.id}
-                            className={classNames('d-inline-flex flex-row align-center flex-wrap', styles.select)}
-                        >
+                        <div key={filter.id} className={classNames('d-inline-flex flex-row align-center flex-wrap')}>
                             <div className="d-inline-flex flex-row mr-3 align-items-baseline">
                                 <Text className="text-xl-center text-nowrap mr-2" id={filterLabelId}>
                                     {filter.label}:

--- a/client/web/src/components/FilteredConnection/ui/ConnectionForm.module.scss
+++ b/client/web/src/components/FilteredConnection/ui/ConnectionForm.module.scss
@@ -1,3 +1,10 @@
+.form {
+    display: inline-flex;
+    flex-direction: row;
+    width: 100%;
+    justify-content: space-between;
+}
+
 .noncompact {
     margin-bottom: 0.5rem;
 }

--- a/client/web/src/components/FilteredConnection/ui/ConnectionForm.tsx
+++ b/client/web/src/components/FilteredConnection/ui/ConnectionForm.tsx
@@ -86,11 +86,7 @@ export const ConnectionForm = React.forwardRef<HTMLInputElement, ConnectionFormP
 
         return (
             <Form
-                className={classNames(
-                    'w-100 d-inline-flex justify-content-between flex-row',
-                    !compact && styles.noncompact,
-                    formClassName
-                )}
+                className={classNames(styles.form, !compact && styles.noncompact, formClassName)}
                 onSubmit={handleSubmit}
             >
                 {filters && onValueSelect && values && (

--- a/client/web/src/enterprise/searchContexts/CreateSearchContextPage.tsx
+++ b/client/web/src/enterprise/searchContexts/CreateSearchContextPage.tsx
@@ -57,7 +57,7 @@ export const AuthenticatedCreateSearchContextPage: React.FunctionComponent<
     return (
         <div className="w-100">
             <Page>
-                <div className="container col-8">
+                <div className="container col-sm-8">
                     <PageTitle title="Create context" />
                     <PageHeader
                         description={

--- a/client/web/src/enterprise/searchContexts/EditSearchContextPage.tsx
+++ b/client/web/src/enterprise/searchContexts/EditSearchContextPage.tsx
@@ -75,7 +75,7 @@ export const AuthenticatedEditSearchContextPage: React.FunctionComponent<
     return (
         <div className="w-100">
             <Page>
-                <div className="container col-8">
+                <div className="container col-sm-8">
                     <PageTitle title="Edit context" />
                     <PageHeader
                         className="mb-3"

--- a/client/web/src/enterprise/searchContexts/SearchContextForm.module.scss
+++ b/client/web/src/enterprise/searchContexts/SearchContextForm.module.scss
@@ -12,11 +12,13 @@
     }
 
     &__preview {
-        display: flex;
+        display: block;
         width: fit-content;
         padding: 0.25rem;
         border-radius: 0.25rem;
         background-color: var(--color-bg-2);
+        white-space: normal;
+        word-break: break-all;
     }
 
     &__visibility {

--- a/client/web/src/enterprise/searchContexts/SearchContextNode.module.scss
+++ b/client/web/src/enterprise/searchContexts/SearchContextNode.module.scss
@@ -1,13 +1,24 @@
+@import 'wildcard/src/global-styles/breakpoints';
+
 .search-context-node {
+    display: flex;
+    align-items: center;
+
     &:first-child {
         border-top: 1px solid var(--border-color-2);
     }
     border-bottom: 1px solid var(--border-color-2);
+
+    @media (--xs-breakpoint-down) {
+        flex-direction: column;
+        align-items: flex-start;
+    }
 }
 
 .left {
     /* Enables responsive ellipsis text truncation */
     min-width: 0;
+    max-width: 100%;
 
     &-description {
         white-space: nowrap;
@@ -20,4 +31,8 @@
     font-size: 0.75rem;
     margin-left: 1rem;
     flex-shrink: 0;
+
+    @media (--xs-breakpoint-down) {
+        margin-left: 0;
+    }
 }

--- a/client/web/src/enterprise/searchContexts/SearchContextNode.tsx
+++ b/client/web/src/enterprise/searchContexts/SearchContextNode.tsx
@@ -20,7 +20,7 @@ export interface SearchContextNodeProps {
 export const SearchContextNode: React.FunctionComponent<React.PropsWithChildren<SearchContextNodeProps>> = ({
     node,
 }: SearchContextNodeProps) => (
-    <li className={classNames('py-3 d-flex align-items-center', styles.searchContextNode)}>
+    <li className={classNames('py-3', styles.searchContextNode)}>
         <div className={classNames('flex-grow-1', styles.left)}>
             <div>
                 <Link to={`/contexts/${node.spec}`}>

--- a/client/web/src/enterprise/searchContexts/SearchContextPage.module.scss
+++ b/client/web/src/enterprise/searchContexts/SearchContextPage.module.scss
@@ -1,6 +1,12 @@
 .search-context-page {
+    &__title-spec {
+        word-break: break-all;
+    }
+
     &__private-badge {
         font-size: 0.625rem;
+        position: relative;
+        bottom: 0.25rem;
     }
 
     &__repo-revs-row {

--- a/client/web/src/enterprise/searchContexts/SearchContextPage.tsx
+++ b/client/web/src/enterprise/searchContexts/SearchContextPage.tsx
@@ -183,13 +183,20 @@ export const SearchContextPage: React.FunctionComponent<React.PropsWithChildren<
                                     <PageHeader.Breadcrumb icon={MagnifyIcon} to="/search" aria-label="Code Search" />
                                     <PageHeader.Breadcrumb to="/contexts">Contexts</PageHeader.Breadcrumb>
                                     <PageHeader.Breadcrumb>
-                                        <div className="d-flex align-items-center">
-                                            <span>{searchContextOrError.spec}</span>
+                                        <div>
+                                            <span
+                                                className={classNames(
+                                                    !searchContextOrError.public && 'mr-2',
+                                                    styles.searchContextPageTitleSpec
+                                                )}
+                                            >
+                                                {searchContextOrError.spec}
+                                            </span>
                                             {!searchContextOrError.public && (
                                                 <Badge
                                                     variant="secondary"
                                                     pill={true}
-                                                    className={classNames('ml-2', styles.searchContextPagePrivateBadge)}
+                                                    className={styles.searchContextPagePrivateBadge}
                                                     as="div"
                                                 >
                                                     Private

--- a/client/web/src/enterprise/searchContexts/SearchContextPage.tsx
+++ b/client/web/src/enterprise/searchContexts/SearchContextPage.tsx
@@ -155,7 +155,7 @@ export const SearchContextPage: React.FunctionComponent<React.PropsWithChildren<
     return (
         <div className="w-100">
             <Page>
-                <div className="container col-8">
+                <div className="container col-sm-8">
                     {searchContextOrError === LOADING && (
                         <div className="d-flex justify-content-center">
                             <LoadingSpinner inline={false} />

--- a/client/web/src/enterprise/searchContexts/SearchContextsListTab.module.scss
+++ b/client/web/src/enterprise/searchContexts/SearchContextsListTab.module.scss
@@ -1,13 +1,23 @@
+@import 'wildcard/src/global-styles/breakpoints';
+
 .auto-defined-search-contexts {
     display: grid;
     gap: 1rem;
 
     &--repeat-2 {
         grid-template-columns: repeat(2, 1fr);
+
+        @media (--xs-breakpoint-down) {
+            grid-template-columns: repeat(1, 1fr);
+        }
     }
 
     &--repeat-3 {
         grid-template-columns: repeat(3, 1fr);
+
+        @media (--xs-breakpoint-down) {
+            grid-template-columns: repeat(1, 1fr);
+        }
     }
 }
 
@@ -15,6 +25,17 @@
     cursor: default;
 }
 
+.filters-form {
+    @media (--xs-breakpoint-down) {
+        display: flex;
+        flex-direction: column;
+    }
+}
+
 .filter-input {
     max-width: 30%;
+
+    @media (--xs-breakpoint-down) {
+        max-width: 100%;
+    }
 }

--- a/client/web/src/enterprise/searchContexts/SearchContextsListTab.tsx
+++ b/client/web/src/enterprise/searchContexts/SearchContextsListTab.tsx
@@ -216,6 +216,7 @@ export const SearchContextsListTab: React.FunctionComponent<React.PropsWithChild
                 inputClassName={classNames(styles.filterInput)}
                 inputPlaceholder="Filter search contexts..."
                 inputAriaLabel="Filter search contexts"
+                formClassName={styles.filtersForm}
             />
         </>
     )


### PR DESCRIPTION
Closes #34730

| | Before | After |
|-|-|-|
| List page  | ![image](https://user-images.githubusercontent.com/206864/174908448-212f9947-cf6c-4806-a95c-7928bd5f1f57.png) | ![image](https://user-images.githubusercontent.com/206864/174906722-6651f931-01dd-497d-9ef2-8650179f475e.png) |
| Details page | ![image](https://user-images.githubusercontent.com/206864/174908508-c93f66bf-8f99-4a63-a6e7-3a64a1e224e7.png) | ![image](https://user-images.githubusercontent.com/206864/174908209-6e842ce3-cb37-4360-ba89-b021605cacff.png) |
| Edit page  | ![image](https://user-images.githubusercontent.com/206864/174908381-d818c252-a56b-4317-a82f-2c79ea1f7870.png) | ![image](https://user-images.githubusercontent.com/206864/174908260-d3684661-0034-4972-becc-ee7253304b6b.png) |

## Test plan

Verified search contexts list, details, create and edit pages are now usable at 320px width.
