### PR TITLE
search: alerts expose Kind field

### DIFF
--- a/client/shared/src/search/stream.ts
+++ b/client/shared/src/search/stream.ts
@@ -219,6 +219,7 @@ export interface Filter {
 interface Alert {
     title: string
     description?: string | null
+    kind?: string | null
     proposedQueries: ProposedQuery[] | null
 }
 

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -2126,6 +2126,10 @@ type SearchAlert {
     """
     description: String
     """
+    An identifier indicating the kind of alert
+    """
+    kind: String
+    """
     "Did you mean: ____" query proposals
     """
     proposedQueries: [SearchQueryDescription!]

--- a/cmd/frontend/graphqlbackend/search_alert.go
+++ b/cmd/frontend/graphqlbackend/search_alert.go
@@ -27,6 +27,13 @@ func (a searchAlertResolver) Description() *string {
 	return &a.alert.Description
 }
 
+func (a searchAlertResolver) Kind() *string {
+	if a.alert.Kind == "" {
+		return nil
+	}
+	return &a.alert.Kind
+}
+
 func (a searchAlertResolver) PrometheusType() string {
 	return a.alert.PrometheusType
 }

--- a/cmd/frontend/internal/search/event_writer.go
+++ b/cmd/frontend/internal/search/event_writer.go
@@ -62,6 +62,7 @@ func (e *eventWriter) Alert(alert *search.Alert) error {
 	return e.inner.Event("alert", streamhttp.EventAlert{
 		Title:           alert.Title,
 		Description:     alert.Description,
+		Kind:            alert.Kind,
 		ProposedQueries: pqs,
 	})
 }

--- a/internal/search/alert.go
+++ b/internal/search/alert.go
@@ -16,6 +16,7 @@ type Alert struct {
 	Title           string
 	Description     string
 	ProposedQueries []*ProposedQuery
+	Kind            string // An identifier indicating the kind of alert
 	// The higher the priority the more important is the alert.
 	Priority int
 }

--- a/internal/search/streaming/http/events.go
+++ b/internal/search/streaming/http/events.go
@@ -165,6 +165,7 @@ type EventFilter struct {
 type EventAlert struct {
 	Title           string          `json:"title"`
 	Description     string          `json:"description,omitempty"`
+	Kind            string          `json:"kind,omitempty"`
 	ProposedQueries []ProposedQuery `json:"proposedQueries"`
 }
 


### PR DESCRIPTION
This exposes a `Kind` field for alerts so clients have more descriptive ways of identifying kinds of alerts. The main motivation is to use a new client-side component for rendering suggested queries, that's different from an older component, and we want to distinguish between the two.

It could also be used indicate an error level or other information, but the contract here is loose: I don't see a need to use enums to enumerate `kind` here, because I don't know what a sensible enumeration looks like. It's useful to just have a string label and acknowledge that the value of `kind` is optional, and a loose contract until this becomes less foggy.

## Test plan
Intended to be semantics-preserving and unused. `backend-integration` added in case any code doesn't like this being undefined/empty.