### PR TITLE
codemirror: Fix multiline placeholder appearance in Chrome

### DIFF
--- a/client/search-ui/src/input/CodeMirrorQueryInput.module.scss
+++ b/client/search-ui/src/input/CodeMirrorQueryInput.module.scss
@@ -32,6 +32,22 @@
             padding: 0;
         }
 
+        :global(.cm-placeholder) {
+            // CodeMirror uses display: inline-block by default, but that causes
+            // Chrome to render a larger cursor if the placeholder holder spans
+            // multiple lines. Firefox doesn't have this problem (but
+            // setting display: inline doesn't seem to have a negative effect
+            // either)
+            display: inline;
+            // Once again, Chrome renders the placeholder differently than
+            // Firefox. CodeMirror sets 'word-break: break-word' (which is
+            // deprecated) and 'overflow-wrap: anywhere' but they don't seem to
+            // have an effect in Chrome (at least not in this instance).
+            // Setting 'word-break: break-all' explicitly makes appearances a
+            // bit better for example queries with long tokens.
+            word-break: break-all;
+        }
+
         :global(.cm-tooltip) {
             padding: 0.25rem;
             color: var(--search-query-text-color);


### PR DESCRIPTION
Fixes #33209

It looks like the "large" cursor issue only appears in Chrome (tested Firefox and Chrome). By making these CSS changes, Chrome also renders a "normal" sized cursor.

Chrome before:
<img width="414" alt="2022-06-22_09-00" src="https://user-images.githubusercontent.com/179026/174990218-8b04df5d-10c9-4c39-bf99-0390e9d60f7a.png">

Chrome after:
<img width="402" alt="2022-06-22_09-02" src="https://user-images.githubusercontent.com/179026/174990258-425e3c7a-0dde-4115-a6a9-ec7925eed974.png">


Firefox before:
<img width="394" alt="2022-06-22_09-01" src="https://user-images.githubusercontent.com/179026/174990276-d5683f2a-6732-4f8b-b856-fec18b7e2ce2.png">

Firefox after:
<img width="385" alt="2022-06-22_09-02_1" src="https://user-images.githubusercontent.com/179026/174990343-5a76ae3b-1236-4f57-874e-fde3bb397fc2.png">


## Test plan

- Start local dev server with code insights enabled
- Go to https://sourcegraph.test:3443/insights/create/search?dashboardId=all, in Firefox and Chrome
- Focus query input and inspect cursor

## App preview:

- [Web](https://sg-web-fkling-33209-multiline-placeholder.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-cgjyxvznds.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
