### PR TITLE
Index lockfiles and possibly persist as tree

### DIFF
--- a/client/web/src/enterprise/codeintel/configuration/components/LockfileIndexSettings.tsx
+++ b/client/web/src/enterprise/codeintel/configuration/components/LockfileIndexSettings.tsx
@@ -1,0 +1,75 @@
+import React, { FunctionComponent } from 'react'
+
+import { Alert, H3 } from '@sourcegraph/wildcard'
+
+import { RadioButtons } from '../../../../components/RadioButtons'
+import { CodeIntelligenceConfigurationPolicyFields } from '../../../../graphql-operations'
+import { nullPolicy } from '../hooks/types'
+
+// This uses the same styles as the RetentionSettings component to style radio buttons
+import styles from './RetentionSettings.module.scss'
+
+export interface LockfileIndexingSettingsProps {
+    policy: CodeIntelligenceConfigurationPolicyFields
+    repo?: { id: string }
+    setPolicy: (
+        updater: (
+            policy: CodeIntelligenceConfigurationPolicyFields | undefined
+        ) => CodeIntelligenceConfigurationPolicyFields
+    ) => void
+    allowGlobalPolicies?: boolean
+}
+
+export const LockfileIndexingSettings: FunctionComponent<React.PropsWithChildren<LockfileIndexingSettingsProps>> = ({
+    policy,
+    repo,
+    setPolicy,
+    allowGlobalPolicies = window.context?.codeIntelAutoIndexingAllowGlobalPolicies,
+}) => {
+    const updatePolicy = <K extends keyof CodeIntelligenceConfigurationPolicyFields>(
+        updates: { [P in K]: CodeIntelligenceConfigurationPolicyFields[P] }
+    ): void => {
+        setPolicy(policy => ({ ...(policy || nullPolicy), ...updates }))
+    }
+
+    const radioButtons = [
+        {
+            id: 'disable-lockfile-indexing',
+            label: 'Disable for this policy',
+        },
+        {
+            id: 'enable-lockfile-indexing',
+            label: 'Enable for this policy',
+        },
+    ]
+
+    const onChange = (event: React.ChangeEvent<HTMLInputElement>): void => {
+        const lockfileIndexingEnabled = event.target.value === 'enable-lockfile-indexing'
+        updatePolicy({ lockfileIndexingEnabled })
+    }
+
+    return (
+        <div className="form-group">
+            <H3>Lockfile-indexing</H3>
+            <div className="mb-4 form-group">
+                <RadioButtons
+                    nodes={radioButtons}
+                    name="toggle-lockfile-indexing"
+                    onChange={onChange}
+                    selected={policy.lockfileIndexingEnabled ? 'enable-lockfile-indexing' : 'disable-lockfile-indexing'}
+                    className={styles.radioButtons}
+                />
+
+                {!allowGlobalPolicies &&
+                    repo === undefined &&
+                    (policy.repositoryPatterns || []).length === 0 &&
+                    policy.lockfileIndexingEnabled && (
+                        <Alert variant="danger">
+                            This Sourcegraph instance has disabled global policies for lockfile-indexing. Create a more
+                            constrained policy targeting an explicit set of repositories to enable this policy.
+                        </Alert>
+                    )}
+            </div>
+        </div>
+    )
+}

--- a/client/web/src/enterprise/codeintel/configuration/components/LockfileIndexingPolicyDescription.tsx
+++ b/client/web/src/enterprise/codeintel/configuration/components/LockfileIndexingPolicyDescription.tsx
@@ -1,0 +1,16 @@
+import { FunctionComponent } from 'react'
+
+import { CodeIntelligenceConfigurationPolicyFields } from '../../../../graphql-operations'
+
+import { GitObjectTargetDescription } from './GitObjectTargetDescription'
+
+export const LockfileIndexingPolicyDescription: FunctionComponent<
+    React.PropsWithChildren<{ policy: CodeIntelligenceConfigurationPolicyFields }>
+> = ({ policy }) =>
+    policy.indexingEnabled ? (
+        <>
+            <strong>Lockfile indexing policy:</strong> index lockfiles <GitObjectTargetDescription policy={policy} />.
+        </>
+    ) : (
+        <span className="text-muted">Lockfile-indexing disabled.</span>
+    )

--- a/client/web/src/enterprise/codeintel/configuration/hooks/types.tsx
+++ b/client/web/src/enterprise/codeintel/configuration/hooks/types.tsx
@@ -17,6 +17,7 @@ export const nullPolicy = {
     indexCommitMaxAgeHours: null,
     indexIntermediateCommits: false,
     repository: null,
+    lockfileIndexingEnabled: false,
 }
 
 export const defaultCodeIntelligenceConfigurationPolicyFieldsFragment = gql`
@@ -38,5 +39,6 @@ export const defaultCodeIntelligenceConfigurationPolicyFieldsFragment = gql`
         indexingEnabled
         indexCommitMaxAgeHours
         indexIntermediateCommits
+        lockfileIndexingEnabled
     }
 `

--- a/client/web/src/enterprise/codeintel/configuration/hooks/usePolicyConfigurationById.tsx
+++ b/client/web/src/enterprise/codeintel/configuration/hooks/usePolicyConfigurationById.tsx
@@ -41,6 +41,7 @@ const emptyPolicy: CodeIntelligenceConfigurationPolicyFields = {
     indexingEnabled: false,
     indexCommitMaxAgeHours: null,
     indexIntermediateCommits: false,
+    lockfileIndexingEnabled: false,
 }
 
 export const usePolicyConfigurationByID = (id: string): UsePolicyConfigResult => {

--- a/client/web/src/enterprise/codeintel/configuration/hooks/useSavePolicyConfiguration.tsx
+++ b/client/web/src/enterprise/codeintel/configuration/hooks/useSavePolicyConfiguration.tsx
@@ -17,6 +17,7 @@ const CREATE_POLICY_CONFIGURATION = gql`
         $indexingEnabled: Boolean!
         $indexCommitMaxAgeHours: Int
         $indexIntermediateCommits: Boolean!
+        $lockfileIndexingEnabled: Boolean!
     ) {
         createCodeIntelligenceConfigurationPolicy(
             repository: $repositoryId
@@ -30,6 +31,7 @@ const CREATE_POLICY_CONFIGURATION = gql`
             indexingEnabled: $indexingEnabled
             indexCommitMaxAgeHours: $indexCommitMaxAgeHours
             indexIntermediateCommits: $indexIntermediateCommits
+            lockfileIndexingEnabled: $lockfileIndexingEnabled
         ) {
             id
         }
@@ -49,6 +51,7 @@ const UPDATE_POLICY_CONFIGURATION = gql`
         $indexingEnabled: Boolean!
         $indexCommitMaxAgeHours: Int
         $indexIntermediateCommits: Boolean!
+        $lockfileIndexingEnabled: Boolean!
     ) {
         updateCodeIntelligenceConfigurationPolicy(
             id: $id
@@ -62,6 +65,7 @@ const UPDATE_POLICY_CONFIGURATION = gql`
             indexingEnabled: $indexingEnabled
             indexCommitMaxAgeHours: $indexCommitMaxAgeHours
             indexIntermediateCommits: $indexIntermediateCommits
+            lockfileIndexingEnabled: $lockfileIndexingEnabled
         ) {
             alwaysNil
         }

--- a/client/web/src/enterprise/codeintel/configuration/pages/CodeIntelConfigurationPage.tsx
+++ b/client/web/src/enterprise/codeintel/configuration/pages/CodeIntelConfigurationPage.tsx
@@ -62,6 +62,7 @@ export interface CodeIntelConfigurationPageProps extends RouteComponentProps<{}>
     queryPolicies?: typeof defaultQueryPolicies
     repo?: { id: string }
     indexingEnabled?: boolean
+    lockfileIndexingEnabled?: boolean
     isLightTheme: boolean
     telemetryService: TelemetryService
 }
@@ -73,6 +74,7 @@ export const CodeIntelConfigurationPage: FunctionComponent<
     queryPolicies = defaultQueryPolicies,
     repo,
     indexingEnabled = window.context?.codeIntelAutoIndexingEnabled,
+    lockfileIndexingEnabled = window.context?.codeIntelLockfileIndexingEnabled,
     telemetryService,
     ...props
 }) => {
@@ -138,11 +140,13 @@ export const CodeIntelConfigurationPage: FunctionComponent<
 export interface PoliciesNodeProps {
     node: CodeIntelligenceConfigurationPolicyFields
     indexingEnabled?: boolean
+    lockfileIndexingEnabled?: boolean
 }
 
 export const PoliciesNode: FunctionComponent<React.PropsWithChildren<PoliciesNodeProps>> = ({
     node: policy,
     indexingEnabled = false,
+    lockfileIndexingEnabled = false,
 }) => (
     <>
         <span className={styles.separator} />

--- a/client/web/src/enterprise/codeintel/configuration/pages/CodeIntelConfigurationPolicyPage.story.tsx
+++ b/client/web/src/enterprise/codeintel/configuration/pages/CodeIntelConfigurationPolicyPage.story.tsx
@@ -30,6 +30,7 @@ const policy: CodeIntelligenceConfigurationPolicyFields = {
     indexCommitMaxAgeHours: 672,
     indexIntermediateCommits: true,
     repository: null,
+    lockfileIndexingEnabled: true,
 }
 
 const repoResult = {

--- a/client/web/src/enterprise/codeintel/configuration/pages/CodeIntelConfigurationPolicyPage.tsx
+++ b/client/web/src/enterprise/codeintel/configuration/pages/CodeIntelConfigurationPolicyPage.tsx
@@ -16,6 +16,7 @@ import { CodeIntelligenceConfigurationPolicyFields } from '../../../../graphql-o
 import { BranchTargetSettings } from '../components/BranchTargetSettings'
 import { FlashMessage } from '../components/FlashMessage'
 import { IndexingSettings } from '../components/IndexSettings'
+import { LockfileIndexingSettings } from '../components/LockfileIndexSettings'
 import { RetentionSettings } from '../components/RetentionSettings'
 import { useDeletePolicies } from '../hooks/useDeletePolicies'
 import { usePolicyConfigurationByID } from '../hooks/usePolicyConfigurationById'
@@ -28,6 +29,7 @@ export interface CodeIntelConfigurationPolicyPageProps
     repo?: { id: string }
     indexingEnabled?: boolean
     history: H.History
+    lockfileIndexingEnabled?: boolean
 }
 
 export const CodeIntelConfigurationPolicyPage: FunctionComponent<
@@ -40,6 +42,7 @@ export const CodeIntelConfigurationPolicyPage: FunctionComponent<
     indexingEnabled = window.context?.codeIntelAutoIndexingEnabled,
     history,
     telemetryService,
+    lockfileIndexingEnabled = window.context?.codeIntelLockfileIndexingEnabled,
 }) => {
     useEffect(() => telemetryService.logViewEvent('CodeIntelConfigurationPolicy'), [telemetryService])
 
@@ -144,7 +147,11 @@ export const CodeIntelConfigurationPolicyPage: FunctionComponent<
                             disabled={isSaving || isDeleting}
                             onClick={() => handleDelete(policy.id, policy.name)}
                             data-tooltip={`Deleting this policy may immediate affect data retention${
-                                indexingEnabled ? ' and auto-indexing' : ''
+                                indexingEnabled
+                                    ? ' and auto-indexing'
+                                    : lockfileIndexingEnabled
+                                    ? ' and lockfile-indexing'
+                                    : ''
                             }.`}
                         >
                             {!isDeleting && (
@@ -173,6 +180,9 @@ export const CodeIntelConfigurationPolicyPage: FunctionComponent<
                 <RetentionSettings policy={policy} setPolicy={setPolicy} />
 
                 {indexingEnabled && <IndexingSettings repo={repo} policy={policy} setPolicy={setPolicy} />}
+                {lockfileIndexingEnabled && (
+                    <LockfileIndexingSettings repo={repo} policy={policy} setPolicy={setPolicy} />
+                )}
             </Container>
 
             <div className="mb-3">
@@ -246,6 +256,7 @@ function comparePolicies(
         a.indexCommitMaxAgeHours === b.indexCommitMaxAgeHours,
         a.indexIntermediateCommits === b.indexIntermediateCommits,
         comparePatterns(a.repositoryPatterns, b.repositoryPatterns),
+        a.lockfileIndexingEnabled === b.lockfileIndexingEnabled,
     ]
 
     return equalityConditions.every(isEqual => isEqual)

--- a/client/web/src/jscontext.ts
+++ b/client/web/src/jscontext.ts
@@ -118,6 +118,9 @@ export interface SourcegraphContext extends Pick<Required<SiteConfiguration>, 'e
     /** Whether global policies are enabled for auto-indexing. */
     codeIntelAutoIndexingAllowGlobalPolicies: boolean
 
+    /** Whether the lockfile-indexer feature is enabled on the site. */
+    codeIntelLockfileIndexingEnabled: boolean
+
     /** Whether the new gql api for code insights is enabled. */
     codeInsightsGqlApiEnabled: boolean
 

--- a/cmd/frontend/graphqlbackend/codeintel.go
+++ b/cmd/frontend/graphqlbackend/codeintel.go
@@ -307,6 +307,7 @@ type CodeIntelConfigurationPolicy struct {
 	IndexingEnabled           bool
 	IndexCommitMaxAgeHours    *int32
 	IndexIntermediateCommits  bool
+	LockfileIndexingEnabled   bool
 }
 
 type CodeIntelligenceConfigurationPoliciesArgs struct {
@@ -406,6 +407,7 @@ type CodeIntelligenceConfigurationPolicyResolver interface {
 	IndexingEnabled() bool
 	IndexCommitMaxAgeHours() *int32
 	IndexIntermediateCommits() bool
+	LockfileIndexingEnabled() bool
 }
 
 type CodeIntelligenceRetentionPolicyMatchesConnectionResolver interface {

--- a/cmd/frontend/graphqlbackend/codeintel.graphql
+++ b/cmd/frontend/graphqlbackend/codeintel.graphql
@@ -24,6 +24,7 @@ extend type Mutation {
         indexingEnabled: Boolean!
         indexCommitMaxAgeHours: Int
         indexIntermediateCommits: Boolean!
+        lockfileIndexingEnabled: Boolean!
     ): CodeIntelligenceConfigurationPolicy!
 
     """
@@ -41,6 +42,7 @@ extend type Mutation {
         indexingEnabled: Boolean!
         indexCommitMaxAgeHours: Int
         indexIntermediateCommits: Boolean!
+        lockfileIndexingEnabled: Boolean!
     ): EmptyResponse
 
     """
@@ -363,6 +365,11 @@ type CodeIntelligenceConfigurationPolicy implements Node {
     only consider the tip of the branch.
     """
     indexIntermediateCommits: Boolean!
+
+    """
+    Whether or not this configuration policy affects lockfile-indexing schedules.
+    """
+    lockfileIndexingEnabled: Boolean!
 }
 
 """

--- a/cmd/frontend/internal/app/jscontext/jscontext.go
+++ b/cmd/frontend/internal/app/jscontext/jscontext.go
@@ -94,6 +94,7 @@ type JSContext struct {
 	ExecutorsEnabled                         bool `json:"executorsEnabled"`
 	CodeIntelAutoIndexingEnabled             bool `json:"codeIntelAutoIndexingEnabled"`
 	CodeIntelAutoIndexingAllowGlobalPolicies bool `json:"codeIntelAutoIndexingAllowGlobalPolicies"`
+	CodeIntelLockfileIndexingEnabled         bool `json:"codeIntelLockfileIndexingEnabled"`
 
 	CodeInsightsGQLApiEnabled bool `json:"codeInsightsGqlApiEnabled"`
 
@@ -216,6 +217,7 @@ func NewJSContextFromRequest(req *http.Request, db database.DB) JSContext {
 		ExecutorsEnabled:                         conf.ExecutorsEnabled(),
 		CodeIntelAutoIndexingEnabled:             conf.CodeIntelAutoIndexingEnabled(),
 		CodeIntelAutoIndexingAllowGlobalPolicies: conf.CodeIntelAutoIndexingAllowGlobalPolicies(),
+		CodeIntelLockfileIndexingEnabled:         conf.CodeIntelLockfileIndexingEnabled(),
 
 		CodeInsightsGQLApiEnabled: conf.CodeInsightsGQLApiEnabled(),
 

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/configuration_policy.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/configuration_policy.go
@@ -116,6 +116,10 @@ func (r *configurationPolicyResolver) IndexIntermediateCommits() bool {
 	return r.configurationPolicy.IndexIntermediateCommits
 }
 
+func (r *configurationPolicyResolver) LockfileIndexingEnabled() bool {
+	return r.configurationPolicy.LockfileIndexingEnabled
+}
+
 func toHours(duration *time.Duration) *int32 {
 	if duration == nil {
 		return nil

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/resolver.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/resolver.go
@@ -459,6 +459,7 @@ func (r *Resolver) CreateCodeIntelligenceConfigurationPolicy(ctx context.Context
 		IndexingEnabled:           args.IndexingEnabled,
 		IndexCommitMaxAge:         toDuration(args.IndexCommitMaxAgeHours),
 		IndexIntermediateCommits:  args.IndexIntermediateCommits,
+		LockfileIndexingEnabled:   args.LockfileIndexingEnabled,
 	})
 	if err != nil {
 		return nil, err
@@ -499,6 +500,7 @@ func (r *Resolver) UpdateCodeIntelligenceConfigurationPolicy(ctx context.Context
 		IndexingEnabled:           args.IndexingEnabled,
 		IndexCommitMaxAge:         toDuration(args.IndexCommitMaxAgeHours),
 		IndexIntermediateCommits:  args.IndexIntermediateCommits,
+		LockfileIndexingEnabled:   args.LockfileIndexingEnabled,
 	}); err != nil {
 		return nil, err
 	}

--- a/internal/codeintel/dependencies/background/indexer/iface.go
+++ b/internal/codeintel/dependencies/background/indexer/iface.go
@@ -11,7 +11,7 @@ import (
 type DBStore interface {
 	RepoName(ctx context.Context, repositoryID int) (string, error)
 	GetConfigurationPolicies(ctx context.Context, opts dbstore.GetConfigurationPoliciesOptions) ([]dbstore.ConfigurationPolicy, int, error)
-	SelectRepositoriesForIndexScan(ctx context.Context, table, column string, processDelay time.Duration, allowGlobalPolicies bool, repositoryMatchLimit *int, limit int) ([]int, error)
+	SelectRepositoriesForLockfileIndexScan(ctx context.Context, table, column string, processDelay time.Duration, allowGlobalPolicies bool, repositoryMatchLimit *int, limit int) ([]int, error)
 }
 
 type PolicyMatcher interface {

--- a/internal/codeintel/dependencies/iface.go
+++ b/internal/codeintel/dependencies/iface.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/dependencies/internal/lockfiles"
-	"github.com/sourcegraph/sourcegraph/internal/conf/reposource"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 )
 
@@ -19,7 +18,7 @@ type GitService interface {
 }
 
 type LockfilesService interface {
-	ListDependencies(ctx context.Context, repo api.RepoName, rev string) ([]reposource.PackageDependency, error)
+	ListDependencies(ctx context.Context, repo api.RepoName, rev string) ([]*lockfiles.Result, error)
 }
 
 type Syncer interface {

--- a/internal/codeintel/dependencies/internal/lockfiles/parser.go
+++ b/internal/codeintel/dependencies/internal/lockfiles/parser.go
@@ -7,14 +7,23 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 )
 
-type parser func(io.Reader) ([]reposource.PackageDependency, error)
+type parser func(io.Reader) ([]reposource.PackageDependency, *DependencyGraph, error)
+
+type nonGraphParser func(io.Reader) ([]reposource.PackageDependency, error)
+
+func wrapNonGraphParser(f nonGraphParser) parser {
+	return func(r io.Reader) ([]reposource.PackageDependency, *DependencyGraph, error) {
+		deps, err := f(r)
+		return deps, nil, err
+	}
+}
 
 var parsers = map[string]parser{
-	"package-lock.json": parsePackageLockFile,
-	"yarn.lock":         parseYarnLockFile,
-	"go.mod":            parseGoModFile,
-	"poetry.lock":       parsePoetryLockFile,
-	"Pipfile.lock":      parsePipfileLockFile,
+	"package-lock.json": wrapNonGraphParser(parsePackageLockFile),
+	"yarn.lock":         wrapNonGraphParser(parseYarnLockFile),
+	"go.mod":            wrapNonGraphParser(parseGoModFile),
+	"poetry.lock":       wrapNonGraphParser(parsePoetryLockFile),
+	"Pipfile.lock":      wrapNonGraphParser(parsePipfileLockFile),
 }
 
 // lockfilePathspecs is the list of git pathspecs that match lockfiles.

--- a/internal/codeintel/dependencies/internal/lockfiles/parser_test.go
+++ b/internal/codeintel/dependencies/internal/lockfiles/parser_test.go
@@ -30,7 +30,7 @@ func TestParse(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			deps, err := parse(lockFile, f)
+			deps, _, err := parse(lockFile, f)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/codeintel/dependencies/internal/lockfiles/service.go
+++ b/internal/codeintel/dependencies/internal/lockfiles/service.go
@@ -30,22 +30,35 @@ func newService(gitSvc GitService, observationContext *observation.Context) *Ser
 	}
 }
 
-func (s *Service) ListDependencies(ctx context.Context, repo api.RepoName, rev string) (deps []reposource.PackageDependency, err error) {
+type Result struct {
+	// Lockfile is the name of the lockfile that was parsed to get the list of
+	// Deps and, optionally, the DependencyGraph.
+	Lockfile string
+
+	// Deps is the flat list of all dependencies found in Lockfile.
+	Deps []reposource.PackageDependency
+	// Graph is the dependency graph found in the Lockfile. If no graph could
+	// be built (`package.json` without `yarn.lock` doesn't allow building a
+	// fully-resolved dependency graph).
+	Graph *DependencyGraph
+}
+
+func (s *Service) ListDependencies(ctx context.Context, repo api.RepoName, rev string) (results []*Result, err error) {
 	ctx, _, endObservation := s.operations.listDependencies.With(ctx, &err, observation.Args{LogFields: []log.Field{
 		log.String("repo", string(repo)),
 		log.String("rev", rev),
 	}})
 	defer endObservation(1, observation.Args{})
 
-	err = s.StreamDependencies(ctx, repo, rev, func(d reposource.PackageDependency) error {
-		deps = append(deps, d)
+	err = s.StreamDependencies(ctx, repo, rev, func(r *Result) error {
+		results = append(results, r)
 		return nil
 	})
 
-	return deps, err
+	return results, err
 }
 
-func (s *Service) StreamDependencies(ctx context.Context, repo api.RepoName, rev string, cb func(reposource.PackageDependency) error) (err error) {
+func (s *Service) StreamDependencies(ctx context.Context, repo api.RepoName, rev string, cb func(*Result) error) (err error) {
 	ctx, _, endObservation := s.operations.streamDependencies.With(ctx, &err, observation.Args{LogFields: []log.Field{
 		log.String("repo", string(repo)),
 		log.String("rev", rev),
@@ -96,50 +109,52 @@ func (s *Service) StreamDependencies(ctx context.Context, repo api.RepoName, rev
 		return err
 	}
 
-	set := map[string]struct{}{}
 	for _, f := range zr.File {
 		if f.Mode().IsDir() {
 			continue
 		}
 
-		ds, err := parseZipLockfile(f)
+		ds, graph, err := parseZipLockfile(f)
 		if err != nil {
 			return errors.Wrapf(err, "failed to parse %q", f.Name)
 		}
 
+		result := &Result{Lockfile: f.Name, Graph: graph}
+
+		set := make(map[string]struct{})
 		for _, d := range ds {
 			k := d.PackageManagerSyntax()
 			if _, ok := set[k]; !ok {
 				set[k] = struct{}{}
-				if err = cb(d); err != nil {
-					return err
-				}
+				result.Deps = append(result.Deps, d)
 			}
 		}
+
+		cb(result)
 	}
 
 	return nil
 }
 
-func parseZipLockfile(f *zip.File) ([]reposource.PackageDependency, error) {
+func parseZipLockfile(f *zip.File) ([]reposource.PackageDependency, *DependencyGraph, error) {
 	r, err := f.Open()
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	defer r.Close()
 
-	deps, err := parse(f.Name, r)
+	deps, graph, err := parse(f.Name, r)
 	if err != nil {
 		log15.Warn("failed to parse some lockfile dependencies", "error", err, "file", f.Name)
 	}
 
-	return deps, nil
+	return deps, graph, nil
 }
 
-func parse(file string, r io.Reader) ([]reposource.PackageDependency, error) {
+func parse(file string, r io.Reader) ([]reposource.PackageDependency, *DependencyGraph, error) {
 	parser, ok := parsers[path.Base(file)]
 	if !ok {
-		return nil, ErrUnsupported
+		return nil, nil, ErrUnsupported
 	}
 	return parser(r)
 }

--- a/internal/codeintel/dependencies/internal/lockfiles/testdata/svc/TestListDependencies/go.golden
+++ b/internal/codeintel/dependencies/internal/lockfiles/testdata/svc/TestListDependencies/go.golden
@@ -1,6 +1,19 @@
 [
-  "github.com/google/uuid@v1.0.0",
-  "github.com/pborman/uuid@v1.2.1",
-  "modernc.org/cc@v1.0.0",
-  "modernc.org/golex@v1.0.0"
+  {
+    "Deps": [
+      "github.com/google/uuid@v1.0.0",
+      "github.com/pborman/uuid@v1.2.1"
+    ],
+    "Lockfile": "go.mod",
+    "Graph": "NO-GRAPH"
+  },
+  {
+    "Deps": [
+      "github.com/google/uuid@v1.0.0",
+      "modernc.org/cc@v1.0.0",
+      "modernc.org/golex@v1.0.0"
+    ],
+    "Lockfile": "subpkg/go.mod",
+    "Graph": "NO-GRAPH"
+  }
 ]

--- a/internal/codeintel/dependencies/internal/lockfiles/testdata/svc/TestListDependencies/npm.golden
+++ b/internal/codeintel/dependencies/internal/lockfiles/testdata/svc/TestListDependencies/npm.golden
@@ -1,6 +1,25 @@
 [
-  "@octokit/request@5.6.2",
-  "asap@2.0.6",
-  "jquery@3.4.1",
-  "promise@8.0.3"
+  {
+    "Deps": [
+      "@octokit/request@5.6.2"
+    ],
+    "Lockfile": "client/package-lock.json",
+    "Graph": "NO-GRAPH"
+  },
+  {
+    "Deps": [
+      "promise@8.0.3"
+    ],
+    "Lockfile": "package-lock.json",
+    "Graph": "NO-GRAPH"
+  },
+  {
+    "Deps": [
+      "asap@2.0.6",
+      "jquery@3.4.1",
+      "promise@8.0.3"
+    ],
+    "Lockfile": "yarn.lock",
+    "Graph": "NO-GRAPH"
+  }
 ]

--- a/internal/codeintel/dependencies/internal/store/scan.go
+++ b/internal/codeintel/dependencies/internal/store/scan.go
@@ -1,6 +1,8 @@
 package store
 
 import (
+	"database/sql"
+
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/dependencies/shared"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/types"
@@ -60,3 +62,39 @@ func scanDependencyRepo(s dbutil.Scanner) (shared.Repo, error) {
 // Scans `[]shared.Repo`
 
 var scanDependencyRepos = basestore.NewSliceScanner(scanDependencyRepo)
+
+// scanIntString scans a int, string pair.
+func scanIntString(s dbutil.Scanner) (int, string, error) {
+	var (
+		i   int
+		str string
+	)
+
+	if err := s.Scan(&i, &str); err != nil {
+		return 0, "", err
+	}
+
+	return i, str, nil
+}
+
+func scanIdNames(rows *sql.Rows, queryErr error) (nameIDs map[string]int, ids []int, err error) {
+	if queryErr != nil {
+		return nil, nil, queryErr
+	}
+	defer func() { err = basestore.CloseRows(rows, err) }()
+
+	nameIDs = make(map[string]int)
+	ids = []int{}
+
+	for rows.Next() {
+		id, name, err := scanIntString(rows)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		nameIDs[name] = id
+		ids = append(ids, id)
+	}
+
+	return nameIDs, ids, nil
+}

--- a/internal/codeintel/dependencies/internal/store/store_test.go
+++ b/internal/codeintel/dependencies/internal/store/store_test.go
@@ -169,7 +169,255 @@ func TestPreciseDependenciesAndDependents(t *testing.T) {
 	})
 }
 
-func TestLockfileDependencies(t *testing.T) {
+func TestUpsertLockfileGraph(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
+	ctx := context.Background()
+	db := database.NewDB(dbtest.NewDB(t))
+	store := New(db, &observation.TestContext)
+
+	if _, err := db.ExecContext(ctx, `INSERT INTO repo (name) VALUES ('foo')`); err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	packageA := shared.TestPackageDependencyLiteral(api.RepoName("A"), "1", "2", "pkg-A", "4")
+	packageB := shared.TestPackageDependencyLiteral(api.RepoName("B"), "2", "3", "pkg-B", "5")
+	packageC := shared.TestPackageDependencyLiteral(api.RepoName("C"), "3", "4", "pkg-C", "6")
+	packageD := shared.TestPackageDependencyLiteral(api.RepoName("D"), "4", "5", "pkg-D", "7")
+	packageE := shared.TestPackageDependencyLiteral(api.RepoName("E"), "5", "6", "pkg-E", "8")
+	packageF := shared.TestPackageDependencyLiteral(api.RepoName("F"), "6", "7", "pkg-F", "9")
+
+	t.Run("with graph", func(t *testing.T) {
+		deps := []shared.PackageDependency{packageA, packageB, packageC, packageD, packageE, packageF}
+		//    -> b -> E
+		//   /
+		// a --> c
+		//   \
+		//    -> d -> F
+		graph := shared.TestDependencyGraphLiteral(
+			[]shared.PackageDependency{packageA},
+			[][]shared.PackageDependency{
+				// A
+				{packageA, packageB},
+				{packageA, packageC},
+				{packageA, packageD},
+				// B
+				{packageB, packageE},
+				// D
+				{packageD, packageF},
+			},
+		)
+		commit := "cafebabe"
+
+		if err := store.UpsertLockfileGraph(ctx, "foo", commit, "lock.file", deps, graph); err != nil {
+			t.Fatalf("error: %s", err)
+		}
+
+		// Now check whether the direct dependency was inserted
+		names, err := queryDirectDeps(t, ctx, store, "foo", commit, "lock.file")
+		if err != nil {
+			t.Fatalf("database query error: %s", err)
+		}
+
+		wantNames := []string{packageA.PackageSyntax()}
+		if diff := cmp.Diff(wantNames, names); diff != "" {
+			t.Errorf("unexpected lockfile packages (-want +got):\n%s", diff)
+		}
+
+		// Check that all packages have been inserted
+		names, err = queryLockfileReferences(t, ctx, store, "foo", commit)
+		if err != nil {
+			t.Fatalf("database query error: %s", err)
+		}
+		wantNames = []string{}
+		for _, pkg := range deps {
+			wantNames = append(wantNames, pkg.PackageSyntax())
+		}
+		if diff := cmp.Diff(wantNames, names); diff != "" {
+			t.Errorf("unexpected lockfile packages (-want +got):\n%s", diff)
+		}
+
+		// Upsert again to check idempotency
+		if err := store.UpsertLockfileGraph(ctx, "foo", commit, "lock.file", deps, graph); err != nil {
+			t.Fatalf("error: %s", err)
+		}
+		names, err = basestore.ScanStrings(store.db.Query(ctx, sqlf.Sprintf(`SELECT package_name FROM codeintel_lockfile_references ORDER BY package_name`)))
+		if err != nil {
+			t.Fatalf("database query error: %s", err)
+		}
+		if diff := cmp.Diff(wantNames, names); diff != "" {
+			t.Errorf("unexpected lockfile packages (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("without graph", func(t *testing.T) {
+		deps := []shared.PackageDependency{packageA, packageB, packageC, packageD, packageE, packageF}
+		nilGraph := shared.SerializeDependencyGraph(nil)
+		commit := "d34df00d"
+
+		if err := store.UpsertLockfileGraph(ctx, "foo", commit, "lock.file", deps, nilGraph); err != nil {
+			t.Fatalf("error: %s", err)
+		}
+
+		// Check that all dependencies have been inserted as direct dependencies
+		names, err := queryDirectDeps(t, ctx, store, "foo", commit, "lock.file")
+		if err != nil {
+			t.Fatalf("database query error: %s", err)
+		}
+
+		wantNames := make([]string, 0, len(deps))
+		for _, d := range deps {
+			wantNames = append(wantNames, d.PackageSyntax())
+		}
+		if diff := cmp.Diff(wantNames, names); diff != "" {
+			t.Errorf("unexpected direct dependencies (-want +got):\n%s", diff)
+		}
+
+		// Upsert again to check idempotency
+		if err := store.UpsertLockfileGraph(ctx, "foo", commit, "lock.file", deps, nilGraph); err != nil {
+			t.Fatalf("error: %s", err)
+		}
+		names, err = queryDirectDeps(t, ctx, store, "foo", commit, "lock.file")
+		if err != nil {
+			t.Fatalf("database query error: %s", err)
+		}
+		if diff := cmp.Diff(wantNames, names); diff != "" {
+			t.Errorf("unexpected lockfile packages (-want +got):\n%s", diff)
+		}
+
+	})
+
+	t.Run("multiple lockfiles", func(t *testing.T) {
+		results := []struct {
+			lockfile string
+			deps     []shared.PackageDependency
+			graph    shared.DependencyGraph
+		}{
+			{
+				lockfile: "lock1.file",
+				deps:     []shared.PackageDependency{packageA, packageB, packageC},
+				graph: shared.TestDependencyGraphLiteral(
+					[]shared.PackageDependency{packageA},
+					// a -> b -> c
+					[][]shared.PackageDependency{{packageA, packageB}, {packageB, packageC}},
+				),
+			},
+			{
+				lockfile: "lock2.file",
+				deps:     []shared.PackageDependency{packageD, packageE, packageF},
+				graph: shared.TestDependencyGraphLiteral(
+					[]shared.PackageDependency{packageD},
+					// d -> e -> f
+					[][]shared.PackageDependency{{packageD, packageE}, {packageE, packageF}},
+				),
+			},
+		}
+
+		commit := "d34dd00d"
+
+		for _, res := range results {
+			// Upsert twice to test idempotency
+			if err := store.UpsertLockfileGraph(ctx, "foo", commit, res.lockfile, res.deps, res.graph); err != nil {
+				t.Fatalf("error: %s", err)
+			}
+			if err := store.UpsertLockfileGraph(ctx, "foo", commit, res.lockfile, res.deps, res.graph); err != nil {
+				t.Fatalf("error: %s", err)
+			}
+		}
+
+		// Check that all packages have been inserted
+		names, err := queryLockfileReferences(t, ctx, store, "foo", commit)
+		if err != nil {
+			t.Fatalf("database query error: %s", err)
+		}
+		wantNames := []string{}
+		for _, res := range results {
+			for _, pkg := range res.deps {
+				wantNames = append(wantNames, pkg.PackageSyntax())
+			}
+		}
+		if diff := cmp.Diff(wantNames, names); diff != "" {
+			t.Errorf("unexpected lockfile packages (-want +got):\n%s", diff)
+		}
+
+		// Check per lockfile now
+		for _, res := range results {
+			// Now check whether the direct dependency was inserted
+			names, err := queryDirectDeps(t, ctx, store, "foo", commit, res.lockfile)
+			if err != nil {
+				t.Fatalf("database query error: %s", err)
+			}
+
+			wantNames := []string{}
+			for _, r := range res.graph.Roots() {
+				wantNames = append(wantNames, r.PackageSyntax())
+			}
+			if diff := cmp.Diff(wantNames, names); diff != "" {
+				t.Errorf("unexpected lockfile packages (-want +got):\n%s", diff)
+			}
+
+			// Check that packages have been inserted with right lockfile
+			names, err = basestore.ScanStrings(store.db.Query(ctx, sqlf.Sprintf(`SELECT package_name FROM codeintel_lockfile_references WHERE resolution_lockfile = %s ORDER BY package_name`, res.lockfile)))
+			if err != nil {
+				t.Fatalf("database query error: %s", err)
+			}
+			wantNames = []string{}
+			for _, pkg := range res.deps {
+				wantNames = append(wantNames, pkg.PackageSyntax())
+			}
+			if diff := cmp.Diff(wantNames, names); diff != "" {
+				t.Errorf("unexpected lockfile packages (-want +got):\n%s", diff)
+			}
+		}
+	})
+}
+
+func queryDirectDeps(t *testing.T, ctx context.Context, store *store, repoName, commit, lockfile string) ([]string, error) {
+	t.Helper()
+
+	q := sqlf.Sprintf(`
+	SELECT package_name
+	FROM codeintel_lockfile_references
+	WHERE (
+		SELECT codeintel_lockfile_reference_ids
+		FROM codeintel_lockfiles lf
+		JOIN repo r ON r.id = lf.repository_id
+		WHERE
+		r.name = %s AND
+		lf.commit_bytea = %s AND
+		lf.lockfile = %s
+	) @> ARRAY[id]
+	ORDER BY package_name;
+    `,
+		repoName,
+		dbutil.CommitBytea(commit),
+		lockfile,
+	)
+
+	return basestore.ScanStrings(store.db.Query(ctx, q))
+}
+
+func queryLockfileReferences(t *testing.T, ctx context.Context, store *store, repoName, commit string) ([]string, error) {
+	t.Helper()
+
+	q := sqlf.Sprintf(`
+	SELECT package_name
+	FROM codeintel_lockfile_references
+	WHERE
+	resolution_repository_id = (SELECT id FROM repo WHERE name = %s) AND
+	resolution_commit_bytea = %s
+	ORDER BY package_name
+`,
+		"foo",
+		dbutil.CommitBytea(commit),
+	)
+
+	return basestore.ScanStrings(store.db.Query(ctx, q))
+}
+
+func TestLockfileDependencies_SingleLockfile(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
@@ -183,54 +431,251 @@ func TestLockfileDependencies(t *testing.T) {
 		t.Fatalf(err.Error())
 	}
 
-	packageA := shared.TestPackageDependencyLiteral(api.RepoName("A"), "1", "2", "3", "4")
-	packageB := shared.TestPackageDependencyLiteral(api.RepoName("B"), "2", "3", "4", "5")
-	packageC := shared.TestPackageDependencyLiteral(api.RepoName("C"), "3", "4", "5", "6")
-	packageD := shared.TestPackageDependencyLiteral(api.RepoName("D"), "4", "5", "6", "7")
-	packageE := shared.TestPackageDependencyLiteral(api.RepoName("E"), "5", "6", "7", "8")
-	packageF := shared.TestPackageDependencyLiteral(api.RepoName("F"), "6", "7", "8", "9")
+	packageA := shared.TestPackageDependencyLiteral(api.RepoName("A"), "1", "2", "pkg-A", "4")
+	packageB := shared.TestPackageDependencyLiteral(api.RepoName("B"), "2", "3", "pkg-B", "5")
+	packageC := shared.TestPackageDependencyLiteral(api.RepoName("C"), "3", "4", "pkg-C", "6")
+	packageD := shared.TestPackageDependencyLiteral(api.RepoName("D"), "4", "5", "pkg-D", "7")
+	packageE := shared.TestPackageDependencyLiteral(api.RepoName("E"), "5", "6", "pkg-E", "8")
+	packageF := shared.TestPackageDependencyLiteral(api.RepoName("F"), "6", "7", "pkg-F", "9")
 
-	commits := map[string][]shared.PackageDependency{
-		"cafebabe": {packageA, packageB, packageC},
-		"deadbeef": {packageA, packageB, packageD, packageE},
-		"deadc0de": {packageB, packageF},
-		"deadd00d": nil,
+	lockfile := "lock.file"
+
+	depsAtCommit := map[string]struct {
+		list  []shared.PackageDependency
+		graph shared.DependencyGraph
+	}{
+		"cafebabe": {
+			list: []shared.PackageDependency{packageA, packageB, packageC},
+			graph:
+			// a -> b -> c
+			shared.DependencyGraphLiteral{
+				RootPkgs: []shared.PackageDependency{packageA},
+				Edges:    [][]shared.PackageDependency{{packageA, packageB}, {packageB, packageC}},
+			},
+		},
+		"deadbeef": {
+			list: []shared.PackageDependency{packageA, packageB, packageD, packageE},
+			//  / b
+			// a
+			//  \ d -> e
+			graph: shared.DependencyGraphLiteral{
+				RootPkgs: []shared.PackageDependency{packageA},
+				Edges: [][]shared.PackageDependency{
+					{packageA, packageB},
+					{packageA, packageD},
+					{packageD, packageE},
+				},
+			},
+		},
+		"deadc0de": {
+			list: []shared.PackageDependency{packageB, packageF},
+			graph: shared.DependencyGraphLiteral{
+				// both roots:
+				// b
+				// f
+				RootPkgs: []shared.PackageDependency{packageB, packageF},
+				Edges:    [][]shared.PackageDependency{},
+			},
+		},
+		// no list, no graph
+		"deadd00d": {list: nil, graph: nil},
+		// list, but no graph
+		"deadd002": {list: []shared.PackageDependency{packageA, packageB}, graph: nil},
 	}
 
-	for commit, deps := range commits {
-		if err := store.UpsertLockfileDependencies(ctx, "foo", commit, deps); err != nil {
+	for commit, deps := range depsAtCommit {
+		if err := store.UpsertLockfileGraph(ctx, "foo", commit, lockfile, deps.list, deps.graph); err != nil {
 			t.Fatalf("unexpected error upserting lockfile dependencies: %s", err)
 		}
 	}
 
 	// Update twice to show idempotency
-	for commit, expected := range commits {
-		if err := store.UpsertLockfileDependencies(ctx, "foo", commit, expected); err != nil {
+	for commit, deps := range depsAtCommit {
+		if err := store.UpsertLockfileGraph(ctx, "foo", commit, lockfile, deps.list, deps.graph); err != nil {
 			t.Fatalf("unexpected error upserting lockfile dependencies: %s", err)
 		}
 	}
 
-	for commit, expectedDeps := range commits {
-		deps, found, err := store.LockfileDependencies(ctx, "foo", commit)
+	t.Run("IncludeTransitive:false", func(t *testing.T) {
+		// Query direct dependencies
+		for commit, expectedDeps := range depsAtCommit {
+			directDeps, found, err := store.LockfileDependencies(ctx, LockfileDependenciesOpts{
+				RepoName:          "foo",
+				Commit:            commit,
+				IncludeTransitive: false,
+			})
+			if err != nil {
+				t.Fatalf("unexpected error querying lockfile dependencies of %s: %s", commit, err)
+			}
+			if !found {
+				t.Fatalf("expected dependencies to be cached for %s", commit)
+			}
+
+			var wantDirectDeps []shared.PackageDependency
+			if expectedDeps.graph == nil {
+				// If we don't have a graph we expect all deps to be direct deps
+				wantDirectDeps = expectedDeps.list
+			} else {
+				graph := expectedDeps.graph.(shared.DependencyGraphLiteral)
+				wantDirectDeps = graph.RootPkgs
+			}
+
+			if a, b := len(wantDirectDeps), len(directDeps); a != b {
+				t.Fatalf("unexpected len of dependencies for commit %s: want=%d, have=%d", commit, a, b)
+			}
+
+			if diff := cmp.Diff(wantDirectDeps, directDeps); diff != "" {
+				t.Fatalf("unexpected dependencies for commit %s (-have, +want): %s", commit, diff)
+			}
+		}
+	})
+
+	t.Run("IncludeTransitive:true", func(t *testing.T) {
+		// Query direct + transitive dependencies
+		for commit, expectedDeps := range depsAtCommit {
+			allDeps, found, err := store.LockfileDependencies(ctx, LockfileDependenciesOpts{
+				RepoName:          "foo",
+				Commit:            commit,
+				IncludeTransitive: true,
+			})
+			if err != nil {
+				t.Fatalf("unexpected error querying lockfile dependencies of %s: %s", commit, err)
+			}
+			if !found {
+				t.Fatalf("expected dependencies to be cached for %s", commit)
+			}
+
+			// With IncludeTransitive
+			if a, b := len(expectedDeps.list), len(allDeps); a != b {
+				t.Fatalf("unexpected len of dependencies for commit %s: want=%d, have=%d", commit, a, b)
+			}
+			if diff := cmp.Diff(expectedDeps.list, allDeps); diff != "" {
+				t.Fatalf("unexpected dependencies for commit %s (-have, +want): %s", commit, diff)
+			}
+		}
+	})
+
+	missingCommit := "d00dd00d"
+	_, found, err := store.LockfileDependencies(ctx, LockfileDependenciesOpts{
+		RepoName: "foo",
+		Commit:   missingCommit,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error querying lockfile dependencies: %s", err)
+	} else if found {
+		t.Fatalf("expected no dependencies to be cached for %s", missingCommit)
+	}
+}
+
+func TestLockfileDependencies_MultipleLockfiles(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
+	ctx := context.Background()
+	db := database.NewDB(dbtest.NewDB(t))
+	store := New(db, &observation.TestContext)
+
+	if _, err := db.ExecContext(ctx, `INSERT INTO repo (name) VALUES ('foo')`); err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	packageA := shared.TestPackageDependencyLiteral(api.RepoName("A"), "1", "2", "pkg-A", "4")
+	packageB := shared.TestPackageDependencyLiteral(api.RepoName("B"), "2", "3", "pkg-B", "5")
+	packageC := shared.TestPackageDependencyLiteral(api.RepoName("C"), "3", "4", "pkg-C", "6")
+	packageD := shared.TestPackageDependencyLiteral(api.RepoName("D"), "4", "5", "pkg-D", "7")
+	packageE := shared.TestPackageDependencyLiteral(api.RepoName("E"), "5", "6", "pkg-E", "8")
+	packageF := shared.TestPackageDependencyLiteral(api.RepoName("F"), "6", "7", "pkg-F", "9")
+
+	depsInLockfile := map[string]struct {
+		deps  []shared.PackageDependency
+		graph shared.DependencyGraph
+	}{
+		"lockfile.1": {
+			deps: []shared.PackageDependency{packageA, packageB, packageC},
+			graph:
+			// a -> b -> c
+			shared.DependencyGraphLiteral{
+				RootPkgs: []shared.PackageDependency{packageA},
+				Edges:    [][]shared.PackageDependency{{packageA, packageB}, {packageB, packageC}},
+			},
+		},
+		"lockfile.2": {
+			deps: []shared.PackageDependency{packageD, packageE, packageF},
+			// d -> e -> f
+			graph: shared.DependencyGraphLiteral{
+				RootPkgs: []shared.PackageDependency{packageD},
+				Edges: [][]shared.PackageDependency{
+					{packageD, packageE},
+					{packageE, packageF},
+				},
+			},
+		},
+	}
+
+	commit := "d34db33f"
+
+	for lockfile, result := range depsInLockfile {
+		if err := store.UpsertLockfileGraph(ctx, "foo", commit, lockfile, result.deps, result.graph); err != nil {
+			t.Fatalf("unexpected error upserting lockfile dependencies: %s", err)
+		}
+	}
+
+	// Update twice to show idempotency
+	for lockfile, result := range depsInLockfile {
+		if err := store.UpsertLockfileGraph(ctx, "foo", commit, lockfile, result.deps, result.graph); err != nil {
+			t.Fatalf("unexpected error upserting lockfile dependencies: %s", err)
+		}
+	}
+
+	// Query per lockfile
+	for lockfile, expectedDeps := range depsInLockfile {
+		directDeps, found, err := store.LockfileDependencies(ctx, LockfileDependenciesOpts{
+			RepoName:          "foo",
+			Commit:            commit,
+			IncludeTransitive: false,
+			Lockfile:          lockfile,
+		})
 		if err != nil {
 			t.Fatalf("unexpected error querying lockfile dependencies of %s: %s", commit, err)
 		}
 		if !found {
 			t.Fatalf("expected dependencies to be cached for %s", commit)
 		}
-		sort.Slice(deps, func(i, j int) bool { return deps[i].RepoName() < deps[j].RepoName() })
+		sort.Slice(directDeps, func(i, j int) bool { return directDeps[i].RepoName() < directDeps[j].RepoName() })
 
-		if diff := cmp.Diff(expectedDeps, deps); diff != "" {
+		graph := expectedDeps.graph.(shared.DependencyGraphLiteral)
+		wantDirectDeps := graph.RootPkgs
+
+		if a, b := len(wantDirectDeps), len(directDeps); a != b {
+			t.Fatalf("unexpected len of dependencies for commit %s: want=%d, have=%d", commit, a, b)
+		}
+
+		if diff := cmp.Diff(wantDirectDeps, directDeps); diff != "" {
 			t.Fatalf("unexpected dependencies for commit %s (-have, +want): %s", commit, diff)
 		}
 	}
 
-	missingCommit := "d00dd00d"
-	_, found, err := store.LockfileDependencies(ctx, "foo", missingCommit)
+	// Query without specifying lockfile
+	deps, found, err := store.LockfileDependencies(ctx, LockfileDependenciesOpts{
+		RepoName:          "foo",
+		Commit:            commit,
+		IncludeTransitive: false,
+	})
 	if err != nil {
-		t.Fatalf("unexpected error querying lockfile dependencies: %s", err)
-	} else if found {
-		t.Fatalf("expected no dependencies to be cached for %s", missingCommit)
+		t.Fatalf("unexpected error querying lockfile dependencies of %s: %s", commit, err)
+	}
+	if !found {
+		t.Fatalf("expected dependencies to be cached for %s", commit)
+	}
+
+	wantDirectDeps := []shared.PackageDependency{packageA, packageD}
+	if a, b := len(wantDirectDeps), len(deps); a != b {
+		t.Fatalf("unexpected len of dependencies for commit %s: want=%d, have=%d", commit, a, b)
+	}
+
+	if diff := cmp.Diff(wantDirectDeps, deps); diff != "" {
+		t.Fatalf("unexpected dependencies for commit %s (-have, +want): %s", commit, diff)
 	}
 }
 
@@ -357,7 +802,7 @@ func TestSelectRepoRevisionsToResolve(t *testing.T) {
 	repoName := "repo-1"
 	packages := []shared.PackageDependency{packageA, packageB, packageC, packageD, packageE}
 
-	if err := store.UpsertLockfileDependencies(ctx, repoName, commit, packages); err != nil {
+	if err := store.UpsertLockfileGraph(ctx, repoName, commit, "lock.file", packages, nil); err != nil {
 		t.Fatalf("unexpected error upserting lockfile dependencies: %s", err)
 	}
 
@@ -444,7 +889,7 @@ func TestUpdateResolvedRevisions(t *testing.T) {
 		packageD = shared.TestPackageDependencyLiteral(api.RepoName("pkg-4"), "v4", "5", "6", "7")
 	)
 
-	if err := store.UpsertLockfileDependencies(ctx, "repo-1", "cafebabe", []shared.PackageDependency{packageA, packageB, packageC, packageD}); err != nil {
+	if err := store.UpsertLockfileGraph(ctx, "repo-1", "cafebabe", "lock.file", []shared.PackageDependency{packageA, packageB, packageC, packageD}, nil); err != nil {
 		t.Fatalf("unexpected error upserting lockfile dependencies: %s", err)
 	}
 
@@ -503,13 +948,13 @@ func TestLockfileDependents(t *testing.T) {
 		packageD = shared.TestPackageDependencyLiteral(api.RepoName("pkg-4"), "v4", "5", "6", "7")
 	)
 
-	if err := store.UpsertLockfileDependencies(ctx, "repo-1", "cafebabe", []shared.PackageDependency{packageA, packageB, packageC, packageD}); err != nil {
+	if err := store.UpsertLockfileGraph(ctx, "repo-1", "cafebabe", "lock.file", []shared.PackageDependency{packageA, packageB, packageC, packageD}, nil); err != nil {
 		t.Fatalf("unexpected error upserting lockfile dependencies: %s", err)
 	}
-	if err := store.UpsertLockfileDependencies(ctx, "repo-2", "cafebeef", []shared.PackageDependency{packageB}); err != nil {
+	if err := store.UpsertLockfileGraph(ctx, "repo-2", "cafebeef", "lock.file", []shared.PackageDependency{packageB}, nil); err != nil {
 		t.Fatalf("unexpected error upserting lockfile dependencies: %s", err)
 	}
-	if err := store.UpsertLockfileDependencies(ctx, "repo-3", "d00dd00d", []shared.PackageDependency{packageC}); err != nil {
+	if err := store.UpsertLockfileGraph(ctx, "repo-3", "d00dd00d", "lock.file", []shared.PackageDependency{packageC}, nil); err != nil {
 		t.Fatalf("unexpected error upserting lockfile dependencies: %s", err)
 	}
 

--- a/internal/codeintel/dependencies/service.go
+++ b/internal/codeintel/dependencies/service.go
@@ -3,7 +3,6 @@ package dependencies
 import (
 	"context"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/inconshreveable/log15"
@@ -12,9 +11,11 @@ import (
 	"golang.org/x/sync/semaphore"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/codeintel/dependencies/internal/lockfiles"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/dependencies/internal/store"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/dependencies/shared"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/types"
+	"github.com/sourcegraph/sourcegraph/internal/conf/reposource"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
@@ -52,7 +53,7 @@ func newService(
 
 // Dependencies resolves the (transitive) dependencies for a set of repository and revisions.
 // Both the input repoRevs and the output dependencyRevs are a map from repository names to revspecs.
-func (s *Service) Dependencies(ctx context.Context, repoRevs map[api.RepoName]types.RevSpecSet) (dependencyRevs map[api.RepoName]types.RevSpecSet, err error) {
+func (s *Service) Dependencies(ctx context.Context, repoRevs map[api.RepoName]types.RevSpecSet, includeTransitive bool) (dependencyRevs map[api.RepoName]types.RevSpecSet, notFound map[api.RepoName]types.RevSpecSet, err error) {
 	ctx, _, endObservation := s.operations.dependencies.With(ctx, &err, observation.Args{LogFields: constructLogFields(repoRevs)})
 	defer func() {
 		endObservation(1, observation.Args{LogFields: []log.Field{
@@ -64,13 +65,13 @@ func (s *Service) Dependencies(ctx context.Context, repoRevs map[api.RepoName]ty
 	// TODO - Process unresolved commits.
 	repoCommits, _, err := s.resolveRepoCommits(ctx, repoRevs)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	// Parse lockfile contents for the given repository and revision pairs
-	deps, err := s.lockfileDependencies(ctx, repoCommits)
+	// Load lockfile dependencies for the given repository and revision pairs
+	deps, notFoundRepoCommits, err := s.resolveLockfileDependenciesFromStore(ctx, repoCommits, includeTransitive)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	// Populate return value map from the given information.
@@ -85,20 +86,31 @@ func (s *Service) Dependencies(ctx context.Context, repoRevs map[api.RepoName]ty
 		dependencyRevs[repo][rev] = struct{}{}
 	}
 
-	// Lazily sync all the repos that were newly added
-	if err := s.upsertAndSyncDependencies(ctx, deps); err != nil {
-		return nil, err
+	notFound = make(map[api.RepoName]types.RevSpecSet, len(notFoundRepoCommits))
+	for _, repoCommit := range notFoundRepoCommits {
+		repo := repoCommit.Repo
+		// TODO: This is wrong. what we want is to find out which revspec we
+		// couldn't find results for. So if the user is querying for
+		// dependencies of foo@v1 we want to tell user that we couldn't find
+		// anything for foo@v1 and not foo@d34db33f, if that is the commit that
+		// v1 resolved to.
+		rev := api.RevSpec(repoCommit.CommitID)
+
+		if _, ok := notFound[repo]; !ok {
+			notFound[repo] = types.RevSpecSet{}
+		}
+		notFound[repo][rev] = struct{}{}
 	}
 
 	if !enablePreciseQueries {
-		return dependencyRevs, nil
+		return dependencyRevs, notFound, nil
 	}
 
 	for _, repoCommit := range repoCommits {
 		// TODO - batch these requests in the store layer
 		preciseDeps, err := s.dependenciesStore.PreciseDependencies(ctx, string(repoCommit.Repo), repoCommit.ResolvedCommit)
 		if err != nil {
-			return nil, errors.Wrap(err, "store.PreciseDependencies")
+			return nil, nil, errors.Wrap(err, "store.PreciseDependencies")
 		}
 
 		for repoName, commits := range preciseDeps {
@@ -108,10 +120,17 @@ func (s *Service) Dependencies(ctx context.Context, repoRevs map[api.RepoName]ty
 			for commit := range commits {
 				dependencyRevs[repoName][commit] = struct{}{}
 			}
+
+			// TODO: See todo above, we need to clean this up properly
+			if notFoundRevs, ok := notFound[repoName]; ok {
+				for commit := range commits {
+					delete(notFoundRevs, commit)
+				}
+			}
 		}
 	}
 
-	return dependencyRevs, nil
+	return dependencyRevs, notFound, nil
 }
 
 type repoCommitResolvedCommit struct {
@@ -164,137 +183,85 @@ func (s *Service) resolveRepoCommits(ctx context.Context, repoRevs map[api.RepoN
 	return resolvedCommits, unresolvedCommits, nil
 }
 
-// lockfileDependencies returns a flattened list of package dependencies for every repo-commit pair.
-func (s *Service) lockfileDependencies(ctx context.Context, repoCommits []repoCommitResolvedCommit) (deps []shared.PackageDependency, _ error) {
-	// Do not destroy the caller's slice. The filtering/fallback mechanism used here is strictly an
-	// implementation detail and its semantics should not leak out of this function. We make a copy
-	// of the incoming slice here so we can manipulate a shallow copy.
-	repoCommitsCopy := make([]repoCommitResolvedCommit, len(repoCommits))
-	copy(repoCommitsCopy, repoCommits)
-	repoCommits = repoCommitsCopy
-
-	// resolverFunc describes internal functions that perform bulk queries to gather the dependencies of
-	// some portion of the input. It is expected that if there are any unqueried repo-commit pairs remain
-	// that they are moved to the front of the given slice, and the number of unqueried elements returned.
-	type resolverFunc func(ctx context.Context, repoCommits []repoCommitResolvedCommit) ([]shared.PackageDependency, int, error)
-
-	resolvers := []resolverFunc{
-		s.resolveLockfileDependenciesFromStore,
-		s.resolveLockfileDependenciesFromArchive,
-	}
-
-	for _, resolver := range resolvers {
-		resolvedDeps, n, err := resolver(ctx, repoCommits)
-		if err != nil {
-			return nil, err
-		}
-
-		deps = append(deps, resolvedDeps...)
-		repoCommits = repoCommits[:n]
-	}
-
-	return deps, nil
-}
-
 // resolveLockfileDependenciesFromStore returns a flattened list of package dependencies for each
 // of the given repo-commit pairs from the database. The given `repoCommits` slice is altered in-place.
 // The returned `numUnqueried` value is the number of elements at the prefix of the slice that had no data.
 // It is expected that the remaining elements be passed to the fallback dependencies resolver, if one is
 // registered.
-func (s *Service) resolveLockfileDependenciesFromStore(ctx context.Context, repoCommits []repoCommitResolvedCommit) (deps []shared.PackageDependency, numUnqueried int, err error) {
+func (s *Service) resolveLockfileDependenciesFromStore(ctx context.Context, repoCommits []repoCommitResolvedCommit, includeTransitive bool) (deps []shared.PackageDependency, notFound []repoCommitResolvedCommit, err error) {
 	ctx, _, endObservation := s.operations.resolveLockfileDependenciesFromStore.With(ctx, &err, observation.Args{})
 	defer func() {
 		endObservation(1, observation.Args{LogFields: []log.Field{
-			log.Int("numUnqueried", numUnqueried),
+			log.Int("notFound", len(notFound)),
 		}})
 	}()
 
-	// Filter in-place
-	unqueried := repoCommits[:0]
-
 	for _, repoCommit := range repoCommits {
 		// TODO - batch these requests in the store layer
-		if repoDeps, ok, err := s.dependenciesStore.LockfileDependencies(ctx, string(repoCommit.Repo), repoCommit.ResolvedCommit); err != nil {
-			return nil, 0, errors.Wrap(err, "store.LockfileDependencies")
+		if repoDeps, ok, err := s.dependenciesStore.LockfileDependencies(ctx, store.LockfileDependenciesOpts{
+			RepoName:          string(repoCommit.Repo),
+			Commit:            repoCommit.ResolvedCommit,
+			IncludeTransitive: includeTransitive,
+		}); err != nil {
+			return nil, notFound, errors.Wrap(err, "store.LockfileDependencies")
 		} else if !ok {
-			unqueried = append(unqueried, repoCommit)
+			notFound = append(notFound, repoCommit)
 		} else {
 			deps = append(deps, repoDeps...)
 		}
 	}
 
-	return deps, len(unqueried), nil
-}
-
-// resolveLockfileDependenciesFromArchive is a resolverFunc. It returns a flattened list of package dependencies
-// for each of the given repo-commit pairs from an archive of relevant files from the git repository. The returned
-// `numUnqueried` value is always zero as we make a request for every input, thus no fallback resolver will
-// ever be triggered.
-func (s *Service) resolveLockfileDependenciesFromArchive(ctx context.Context, repoCommits []repoCommitResolvedCommit) (deps []shared.PackageDependency, numUnqueried int, err error) {
-	ctx, _, endObservation := s.operations.resolveLockfileDependenciesFromArchive.With(ctx, &err, observation.Args{})
-	defer endObservation(1, observation.Args{})
-
-	ctx, cancel := context.WithCancel(ctx)
-	g, ctx := errgroup.WithContext(ctx)
-	defer cancel()
-
-	// Protects appending to deps
-	var mu sync.Mutex
-
-	for _, repoCommit := range repoCommits {
-		// Capture outside of goroutine below
-		repoCommit := repoCommit
-
-		// Acquire semaphore before spawning goroutine to ensure that we limit the total number
-		// of concurrent _routines_, whether they are actively processing lockfiles or not.
-		if err := s.lockfilesSemaphore.Acquire(ctx, 1); err != nil {
-			return nil, 0, errors.Wrap(err, "lockfiles semaphore")
-		}
-
-		g.Go(func() error {
-			defer s.lockfilesSemaphore.Release(1)
-
-			repoDeps, err := s.listAndPersistLockfileDependencies(ctx, repoCommit)
-			if err != nil {
-				return err
-			}
-
-			mu.Lock()
-			deps = append(deps, repoDeps...)
-			mu.Unlock()
-
-			return nil
-		})
-	}
-
-	if err := g.Wait(); err != nil {
-		return nil, 0, err
-	}
-
-	return deps, 0, nil
+	return deps, notFound, nil
 }
 
 // listAndPersistLockfileDependencies gathers dependencies from the lockfiles service for the
 // given repo-commit pair and persists the result to the database. This aids in both caching
 // and building an inverted index to power dependents search.
 func (s *Service) listAndPersistLockfileDependencies(ctx context.Context, repoCommit repoCommitResolvedCommit) ([]shared.PackageDependency, error) {
-	repoDeps, err := s.lockfilesSvc.ListDependencies(ctx, repoCommit.Repo, string(repoCommit.CommitID))
+	results, err := s.lockfilesSvc.ListDependencies(ctx, repoCommit.Repo, string(repoCommit.CommitID))
 	if err != nil {
 		return nil, errors.Wrap(err, "lockfiles.ListDependencies")
 	}
 
-	serializableRepoDeps := shared.SerializePackageDependencies(repoDeps)
-
-	if err := s.dependenciesStore.UpsertLockfileDependencies(
-		ctx,
-		string(repoCommit.Repo),
-		repoCommit.ResolvedCommit,
-		serializableRepoDeps,
-	); err != nil {
-		return nil, errors.Wrap(err, "store.UpsertLockfileDependencies")
+	if len(results) == 0 {
+		// If we haven't found anything in that repository, we still persist
+		// the result to make sure we can tell the user that we have or haven't
+		// indexed the repository.
+		// TODO: There should be a better solution for that.
+		results = append(results, &lockfiles.Result{Lockfile: "NOT-FOUND", Deps: []reposource.PackageDependency{}})
 	}
 
-	return serializableRepoDeps, nil
+	var (
+		allDeps []shared.PackageDependency
+		set     = make(map[string]struct{})
+	)
+
+	for _, result := range results {
+		serializableRepoDeps := shared.SerializePackageDependencies(result.Deps)
+		serializableGraph := shared.SerializeDependencyGraph(result.Graph)
+
+		err = s.dependenciesStore.UpsertLockfileGraph(
+			ctx,
+			string(repoCommit.Repo),
+			repoCommit.ResolvedCommit,
+			result.Lockfile,
+			serializableRepoDeps,
+			serializableGraph,
+		)
+		if err != nil {
+			return nil, errors.Wrap(err, "store.UpsertLockfileDependencies")
+		}
+
+		for _, d := range serializableRepoDeps {
+			k := d.PackageSyntax() + d.PackageVersion()
+			if _, ok := set[k]; !ok {
+				set[k] = struct{}{}
+				allDeps = append(allDeps, d)
+			}
+		}
+	}
+
+	return allDeps, nil
 }
 
 // sync invokes the Syncer for every repo in the supplied slice.
@@ -329,12 +296,12 @@ func (s *Service) sync(ctx context.Context, repos []api.RepoName) error {
 	return g.Wait()
 }
 
-// ResolveDependencies resolves the lockfile dependencies for a set of repository and revsisions
+// IndexLockfiles resolves the lockfile dependencies for a set of repository and revsisions
 // and writes them the database.
 //
 // This method is expected to be used only from background routines controlling lockfile indexing
 // scheduling. Additional users may impact the performance profile of the application as a whole.
-func (s *Service) ResolveDependencies(ctx context.Context, repoRevs map[api.RepoName]types.RevSpecSet) (err error) {
+func (s *Service) IndexLockfiles(ctx context.Context, repoRevs map[api.RepoName]types.RevSpecSet) (err error) {
 	if !lockfileIndexingEnabled() {
 		return nil
 	}

--- a/internal/codeintel/dependencies/shared/types.go
+++ b/internal/codeintel/dependencies/shared/types.go
@@ -2,6 +2,7 @@ package shared
 
 import (
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/codeintel/dependencies/internal/lockfiles"
 	"github.com/sourcegraph/sourcegraph/internal/conf/reposource"
 )
 
@@ -67,4 +68,49 @@ func SerializePackageDependency(dep reposource.PackageDependency) PackageDepende
 		PackageSyntaxValue:     dep.PackageSyntax(),
 		PackageVersionValue:    dep.PackageVersion(),
 	}
+}
+
+type DependencyGraph interface {
+	Roots() []PackageDependency
+	AllEdges() [][]PackageDependency
+	Empty() bool
+}
+
+var _ DependencyGraph = DependencyGraphLiteral{}
+
+func TestDependencyGraphLiteral(roots []PackageDependency, edges [][]PackageDependency) DependencyGraph {
+	return DependencyGraphLiteral{Edges: edges, RootPkgs: roots}
+}
+
+type DependencyGraphLiteral struct {
+	RootPkgs []PackageDependency
+	Edges    [][]PackageDependency
+}
+
+func (dg DependencyGraphLiteral) AllEdges() [][]PackageDependency { return dg.Edges }
+func (dg DependencyGraphLiteral) Roots() []PackageDependency      { return dg.RootPkgs }
+func (dg DependencyGraphLiteral) Empty() bool                     { return len(dg.RootPkgs) == 0 }
+
+func SerializeDependencyGraph(graph *lockfiles.DependencyGraph) DependencyGraph {
+	if graph == nil {
+		return nil
+	}
+
+	var (
+		edges [][]PackageDependency
+		roots []PackageDependency
+	)
+
+	for _, edge := range graph.AllEdges() {
+		edges = append(edges, []PackageDependency{
+			SerializePackageDependency(edge.Source),
+			SerializePackageDependency(edge.Target),
+		})
+	}
+
+	for _, root := range graph.Roots() {
+		roots = append(roots, SerializePackageDependency(root))
+	}
+
+	return DependencyGraphLiteral{RootPkgs: roots, Edges: edges}
 }

--- a/internal/codeintel/stores/dbstore/configuration_policies_test.go
+++ b/internal/codeintel/stores/dbstore/configuration_policies_test.go
@@ -36,17 +36,19 @@ func TestGetConfigurationPolicies(t *testing.T) {
 			retain_intermediate_commits,
 			indexing_enabled,
 			index_commit_max_age_hours,
-			index_intermediate_commits
+			index_intermediate_commits,
+			lockfile_indexing_enabled
 		) VALUES
-			(101, 42,   'policy 1 abc', 'GIT_TREE', '', null,              false, 0, false, true,  0, false),
-			(102, 42,   'policy 2 def', 'GIT_TREE', '', null,              true , 0, false, false, 0, false),
-			(103, 43,   'policy 3 bcd', 'GIT_TREE', '', null,              false, 0, false, true,  0, false),
-			(104, NULL, 'policy 4 abc', 'GIT_TREE', '', null,              true , 0, false, false, 0, false),
-			(105, NULL, 'policy 5 bcd', 'GIT_TREE', '', null,              false, 0, false, true,  0, false),
-			(106, NULL, 'policy 6 bcd', 'GIT_TREE', '', '{gitlab.com/*}',  true , 0, false, false, 0, false),
-			(107, NULL, 'policy 7 def', 'GIT_TREE', '', '{gitlab.com/*1}', false, 0, false, true,  0, false),
-			(108, NULL, 'policy 8 abc', 'GIT_TREE', '', '{gitlab.com/*2}', true , 0, false, false, 0, false),
-			(109, NULL, 'policy 9 def', 'GIT_TREE', '', '{github.com/*}',  false, 0, false, true,  0, false)
+			(101, 42,   'policy  1 abc', 'GIT_TREE', '', null,              false, 0, false, true,  0, false, false),
+			(102, 42,   'policy  2 def', 'GIT_TREE', '', null,              true , 0, false, false, 0, false, false),
+			(103, 43,   'policy  3 bcd', 'GIT_TREE', '', null,              false, 0, false, true,  0, false, false),
+			(104, NULL, 'policy  4 abc', 'GIT_TREE', '', null,              true , 0, false, false, 0, false, false),
+			(105, NULL, 'policy  5 bcd', 'GIT_TREE', '', null,              false, 0, false, true,  0, false, false),
+			(106, NULL, 'policy  6 bcd', 'GIT_TREE', '', '{gitlab.com/*}',  true , 0, false, false, 0, false, false),
+			(107, NULL, 'policy  7 def', 'GIT_TREE', '', '{gitlab.com/*1}', false, 0, false, true,  0, false, false),
+			(108, NULL, 'policy  8 abc', 'GIT_TREE', '', '{gitlab.com/*2}', true , 0, false, false, 0, false, false),
+			(109, NULL, 'policy  9 def', 'GIT_TREE', '', '{github.com/*}',  false, 0, false, true,  0, false, false),
+			(110, NULL, 'policy 10 def', 'GIT_TREE', '', '{github.com/*}',  false, 0, false, false, 0, false, true)
 	`
 	if _, err := db.ExecContext(ctx, query); err != nil {
 		t.Fatalf("unexpected error while inserting configuration policies: %s", err)
@@ -62,6 +64,7 @@ func TestGetConfigurationPolicies(t *testing.T) {
 		107: {"gitlab.com/*1"},
 		108: {"gitlab.com/*2"},
 		109: {"github.com/*"},
+		110: {"github.com/*"},
 	} {
 		if err := store.UpdateReposMatchingPatterns(ctx, patterns, policyID, nil); err != nil {
 			t.Fatalf("unexpected error while updating repositories matching patterns: %s", err)
@@ -69,16 +72,17 @@ func TestGetConfigurationPolicies(t *testing.T) {
 	}
 
 	type testCase struct {
-		repositoryID     int
-		term             string
-		forDataRetention bool
-		forIndexing      bool
-		expectedIDs      []int
+		repositoryID        int
+		term                string
+		forDataRetention    bool
+		forIndexing         bool
+		forLockfileIndexing bool
+		expectedIDs         []int
 	}
 	testCases := []testCase{
-		{expectedIDs: []int{101, 102, 103, 104, 105, 106, 107, 108, 109}},        // Any flags; all policies
+		{expectedIDs: []int{101, 102, 103, 104, 105, 106, 107, 108, 109, 110}},   // Any flags; all policies
 		{repositoryID: 41, expectedIDs: []int{104, 105, 106, 107}},               // Any flags; matches repo by patterns
-		{repositoryID: 42, expectedIDs: []int{101, 102, 104, 105, 109}},          // Any flags; matches repo by assignment and pattern
+		{repositoryID: 42, expectedIDs: []int{101, 102, 104, 105, 109, 110}},     // Any flags; matches repo by assignment and pattern
 		{repositoryID: 43, expectedIDs: []int{103, 104, 105}},                    // Any flags; matches repo by assignment
 		{repositoryID: 44, expectedIDs: []int{104, 105}},                         // Any flags; no matches by repo
 		{forDataRetention: true, expectedIDs: []int{102, 104, 106, 108}},         // For data retention; all policies
@@ -91,6 +95,7 @@ func TestGetConfigurationPolicies(t *testing.T) {
 		{forIndexing: true, repositoryID: 42, expectedIDs: []int{101, 105, 109}}, // For indexing; matches repo by assignment and pattern
 		{forIndexing: true, repositoryID: 43, expectedIDs: []int{103, 105}},      // For indexing; matches repo by assignment
 		{forIndexing: true, repositoryID: 44, expectedIDs: []int{105}},           // For indexing; no matches by repo
+		{forLockfileIndexing: true, expectedIDs: []int{110}},                     // For lockfile indexing; all policies
 
 		{term: "bc", expectedIDs: []int{101, 103, 104, 105, 106, 108}}, // Searches by name (multiple substring matches)
 		{term: "abcd", expectedIDs: []int{}},                           // Searches by name (no matches)
@@ -98,22 +103,24 @@ func TestGetConfigurationPolicies(t *testing.T) {
 
 	runTest := func(testCase testCase, lo, hi int) (errors int) {
 		name := fmt.Sprintf(
-			"repositoryID=%d term=%q forDataRetention=%v forIndexing=%v offset=%d",
+			"repositoryID=%d term=%q forDataRetention=%v forIndexing=%v forLockfileIndexing=%v offset=%d",
 			testCase.repositoryID,
 			testCase.term,
 			testCase.forDataRetention,
 			testCase.forIndexing,
+			testCase.forLockfileIndexing,
 			lo,
 		)
 
 		t.Run(name, func(t *testing.T) {
 			policies, totalCount, err := store.GetConfigurationPolicies(ctx, GetConfigurationPoliciesOptions{
-				RepositoryID:     testCase.repositoryID,
-				Term:             testCase.term,
-				ForDataRetention: testCase.forDataRetention,
-				ForIndexing:      testCase.forIndexing,
-				Limit:            3,
-				Offset:           lo,
+				RepositoryID:        testCase.repositoryID,
+				Term:                testCase.term,
+				ForDataRetention:    testCase.forDataRetention,
+				ForIndexing:         testCase.forIndexing,
+				ForLockfileIndexing: testCase.forLockfileIndexing,
+				Limit:               3,
+				Offset:              lo,
 			})
 			if err != nil {
 				t.Fatalf("unexpected error fetching configuration policies: %s", err)

--- a/internal/codeintel/stores/dbstore/uploads.go
+++ b/internal/codeintel/stores/dbstore/uploads.go
@@ -965,6 +965,105 @@ SET {column_name} = %s
 RETURNING repository_id
 `
 
+// SelectRepositoriesForLockfileIndexScan returns a set of repository identifiers that should be considered
+// for indexing jobs. Repositories that were returned previously from this call within the given
+// process delay are not returned.
+//
+// If allowGlobalPolicies is false, then configuration policies that define neither a repository id
+// nor a non-empty set of repository patterns wl be ignored. When true, such policies apply over all
+// repositories known to the instance.
+func (s *Store) SelectRepositoriesForLockfileIndexScan(ctx context.Context, table, column string, processDelay time.Duration, allowGlobalPolicies bool, repositoryMatchLimit *int, limit int) (_ []int, err error) {
+	return s.selectRepositoriesForLockfileIndexScan(ctx, table, column, processDelay, allowGlobalPolicies, repositoryMatchLimit, limit, timeutil.Now())
+}
+
+func (s *Store) selectRepositoriesForLockfileIndexScan(ctx context.Context, table, column string, processDelay time.Duration, allowGlobalPolicies bool, repositoryMatchLimit *int, limit int, now time.Time) (_ []int, err error) {
+	// ctx, _, endObservation := s.operations.selectRepositoriesForLockfileIndexScan.With(ctx, &err, observation.Args{LogFields: []log.Field{
+	// 	log.Bool("allowGlobalPolicies", allowGlobalPolicies),
+	// 	log.Int("limit", limit),
+	// }})
+	// defer endObservation(1, observation.Args{})
+
+	limitExpression := sqlf.Sprintf("")
+	if repositoryMatchLimit != nil {
+		limitExpression = sqlf.Sprintf("LIMIT %s", *repositoryMatchLimit)
+	}
+
+	replacer := strings.NewReplacer("{column_name}", column)
+	return basestore.ScanInts(s.Query(ctx, sqlf.Sprintf(
+		replacer.Replace(selectRepositoriesForLockfileIndexScanQuery),
+		allowGlobalPolicies,
+		limitExpression,
+		quote(table),
+		now,
+		int(processDelay/time.Second),
+		limit,
+		quote(table),
+		now,
+		now,
+	)))
+}
+
+const selectRepositoriesForLockfileIndexScanQuery = `
+-- source: internal/codeintel/stores/dbstore/uploads.go:selectRepositoriesForLockfileIndexScan
+WITH
+repositories_matching_policy AS (
+	(
+		SELECT r.id FROM repo r WHERE EXISTS (
+			SELECT 1
+			FROM lsif_configuration_policies p
+			WHERE
+				p.lockfile_indexing_enabled AND
+				p.repository_id IS NULL AND
+				p.repository_patterns IS NULL AND
+				%s -- completely enable or disable this query
+		)
+		ORDER BY stars DESC NULLS LAST, id
+		%s
+	)
+
+	UNION ALL
+
+	SELECT p.repository_id AS id
+	FROM lsif_configuration_policies p
+	WHERE
+		p.lockfile_indexing_enabled AND
+		p.repository_id IS NOT NULL
+
+	UNION ALL
+
+	SELECT rpl.repo_id AS id
+	FROM lsif_configuration_policies p
+	JOIN lsif_configuration_policies_repository_pattern_lookup rpl ON rpl.policy_id = p.id
+	WHERE p.lockfile_indexing_enabled
+),
+candidate_repositories AS (
+	SELECT r.id AS id
+	FROM repo r
+	WHERE
+		r.deleted_at IS NULL AND
+		r.blocked IS NULL AND
+		r.id IN (SELECT id FROM repositories_matching_policy)
+),
+repositories AS (
+	SELECT cr.id
+	FROM candidate_repositories cr
+	LEFT JOIN %s lrs ON lrs.repository_id = cr.id
+
+	-- Ignore records that have been checked recently. Note this condition is
+	-- true for a null {column_name} (which has never been checked).
+	WHERE (%s - lrs.{column_name} > (%s * '1 second'::interval)) IS DISTINCT FROM FALSE
+	ORDER BY
+		lrs.{column_name} NULLS FIRST,
+		cr.id -- tie breaker
+	LIMIT %s
+)
+INSERT INTO %s (repository_id, {column_name})
+SELECT r.id, %s::timestamp FROM repositories r
+ON CONFLICT (repository_id) DO UPDATE
+SET {column_name} = %s
+RETURNING repository_id
+`
+
 // SelectRepositoriesForRetentionScan returns a set of repository identifiers with live code intelligence
 // data and a fresh associated commit graph. Repositories that were returned previously from this call
 // within the  given process delay are not returned.

--- a/internal/codeintel/stores/dbstore/uploads_test.go
+++ b/internal/codeintel/stores/dbstore/uploads_test.go
@@ -1026,13 +1026,14 @@ func TestSelectRepositoriesForIndexScan(t *testing.T) {
 			retain_intermediate_commits,
 			indexing_enabled,
 			index_commit_max_age_hours,
-			index_intermediate_commits
+			index_intermediate_commits,
+			lockfile_indexing_enabled
 		) VALUES
-			(101, 50, 'policy 1', 'GIT_TREE', 'ab/', null, true, 0, false, true,  0, false),
-			(102, 51, 'policy 2', 'GIT_TREE', 'cd/', null, true, 0, false, true,  0, false),
-			(103, 52, 'policy 3', 'GIT_TREE', 'ef/', null, true, 0, false, true,  0, false),
-			(104, 53, 'policy 4', 'GIT_TREE', 'gh/', null, true, 0, false, true,  0, false),
-			(105, 54, 'policy 5', 'GIT_TREE', 'gh/', null, true, 0, false, false, 0, false)
+			(101, 50, 'policy 1', 'GIT_TREE', 'ab/', null, true, 0, false, true,  0, false, false),
+			(102, 51, 'policy 2', 'GIT_TREE', 'cd/', null, true, 0, false, true,  0, false, false),
+			(103, 52, 'policy 3', 'GIT_TREE', 'ef/', null, true, 0, false, true,  0, false, false),
+			(104, 53, 'policy 4', 'GIT_TREE', 'gh/', null, true, 0, false, true,  0, false, false),
+			(105, 54, 'policy 5', 'GIT_TREE', 'gh/', null, true, 0, false, false, 0, false, false)
 	`
 	if _, err := db.ExecContext(context.Background(), query); err != nil {
 		t.Fatalf("unexpected error while inserting configuration policies: %s", err)
@@ -1113,9 +1114,10 @@ func TestSelectRepositoriesForIndexScanWithGlobalPolicy(t *testing.T) {
 			retain_intermediate_commits,
 			indexing_enabled,
 			index_commit_max_age_hours,
-			index_intermediate_commits
+			index_intermediate_commits,
+			lockfile_indexing_enabled
 		) VALUES
-			(101, NULL, 'policy 1', 'GIT_TREE', 'ab/', null, true, 0, false, true, 0, false)
+			(101, NULL, 'policy 1', 'GIT_TREE', 'ab/', null, true, 0, false, true, 0, false, false)
 	`
 	if _, err := db.ExecContext(context.Background(), query); err != nil {
 		t.Fatalf("unexpected error while inserting configuration policies: %s", err)
@@ -1184,9 +1186,10 @@ func TestSelectRepositoriesForIndexScanInDifferentTable(t *testing.T) {
 			retain_intermediate_commits,
 			indexing_enabled,
 			index_commit_max_age_hours,
-			index_intermediate_commits
+			index_intermediate_commits,
+			lockfile_indexing_enabled
 		) VALUES
-			(101, NULL, 'policy 1', 'GIT_TREE', 'ab/', null, true, 0, false, true, 0, false)
+			(101, NULL, 'policy 1', 'GIT_TREE', 'ab/', null, true, 0, false, true, 0, false, false)
 	`
 	if _, err := db.ExecContext(context.Background(), query); err != nil {
 		t.Fatalf("unexpected error while inserting configuration policies: %s", err)

--- a/internal/database/basestore/rows.go
+++ b/internal/database/basestore/rows.go
@@ -4,6 +4,8 @@ import (
 	"database/sql"
 	"time"
 
+	"github.com/lib/pq"
+
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
@@ -197,6 +199,16 @@ func ScanNullInt64(s dbutil.Scanner) (int64, error) {
 	return value.Int64, nil
 }
 
+// ScanInt32Array scans a single int32 array from the given scanner.
+func ScanInt32Array(s dbutil.Scanner) ([]int32, error) {
+	var value pq.Int32Array
+	if err := s.Scan(&value); err != nil {
+		return nil, err
+	}
+
+	return []int32(value), nil
+}
+
 var (
 	ScanInt             = ScanAny[int]
 	ScanStrings         = NewSliceScanner(ScanAny[string])
@@ -215,4 +227,5 @@ var (
 	ScanFirstBool       = NewFirstScanner(ScanAny[bool])
 	ScanTimes           = NewSliceScanner(ScanAny[time.Time])
 	ScanFirstTime       = NewFirstScanner(ScanAny[time.Time])
+	ScanFirstInt32Array = NewFirstScanner(ScanInt32Array)
 )

--- a/internal/database/schema.json
+++ b/internal/database/schema.json
@@ -5592,6 +5592,19 @@
           "Comment": "The resolved 40-char revhash of the associated revspec, if it is resolvable on this instance."
         },
         {
+          "Name": "depends_on",
+          "Index": 10,
+          "TypeName": "integer[]",
+          "IsNullable": true,
+          "Default": "'{}'::integer[]",
+          "CharacterMaximumLength": 0,
+          "IsIdentity": false,
+          "IdentityGeneration": "",
+          "IsGenerated": "NEVER",
+          "GenerationExpression": "",
+          "Comment": "IDs of other `codeintel_lockfile_references` this package depends on in the context of this `codeintel_lockfile_references.resolution_id`."
+        },
+        {
           "Name": "id",
           "Index": 1,
           "TypeName": "integer",
@@ -5683,6 +5696,45 @@
           "Comment": "Encodes `reposource.PackageDependency.RepoName`. A name that is \"globally unique\" for a Sourcegraph instance. Used in `repo:...` queries."
         },
         {
+          "Name": "resolution_commit_bytea",
+          "Index": 13,
+          "TypeName": "bytea",
+          "IsNullable": true,
+          "Default": "",
+          "CharacterMaximumLength": 0,
+          "IsIdentity": false,
+          "IdentityGeneration": "",
+          "IsGenerated": "NEVER",
+          "GenerationExpression": "",
+          "Comment": "Commit at which lockfile was resolved. Corresponds to `codeintel_lockfiles.commit_bytea`."
+        },
+        {
+          "Name": "resolution_lockfile",
+          "Index": 11,
+          "TypeName": "text",
+          "IsNullable": true,
+          "Default": "",
+          "CharacterMaximumLength": 0,
+          "IsIdentity": false,
+          "IdentityGeneration": "",
+          "IsGenerated": "NEVER",
+          "GenerationExpression": "",
+          "Comment": "Relative path of lockfile in which this package was referenced. Corresponds to `codeintel_lockfiles.lockfile`."
+        },
+        {
+          "Name": "resolution_repository_id",
+          "Index": 12,
+          "TypeName": "integer",
+          "IsNullable": true,
+          "Default": "",
+          "CharacterMaximumLength": 0,
+          "IsIdentity": false,
+          "IdentityGeneration": "",
+          "IsGenerated": "NEVER",
+          "GenerationExpression": "",
+          "Comment": "ID of the repository in which lockfile was resolved. Corresponds to `codeintel_lockfiles.repository_id`."
+        },
+        {
           "Name": "revspec",
           "Index": 3,
           "TypeName": "text",
@@ -5708,12 +5760,12 @@
           "ConstraintDefinition": "PRIMARY KEY (id)"
         },
         {
-          "Name": "codeintel_lockfile_references_repository_name_revspec_package",
+          "Name": "codeintel_lockfile_references_repository_name_revspec_package_r",
           "IsPrimaryKey": false,
           "IsUnique": true,
           "IsExclusion": false,
           "IsDeferrable": false,
-          "IndexDefinition": "CREATE UNIQUE INDEX codeintel_lockfile_references_repository_name_revspec_package ON codeintel_lockfile_references USING btree (repository_name, revspec, package_scheme, package_name, package_version)",
+          "IndexDefinition": "CREATE UNIQUE INDEX codeintel_lockfile_references_repository_name_revspec_package_r ON codeintel_lockfile_references USING btree (repository_name, revspec, package_scheme, package_name, package_version, resolution_lockfile, resolution_repository_id, resolution_commit_bytea)",
           "ConstraintType": "",
           "ConstraintDefinition": ""
         },
@@ -5734,6 +5786,16 @@
           "IsExclusion": false,
           "IsDeferrable": false,
           "IndexDefinition": "CREATE INDEX codeintel_lockfile_references_repository_id_commit_bytea ON codeintel_lockfile_references USING btree (repository_id, commit_bytea) WHERE repository_id IS NOT NULL AND commit_bytea IS NOT NULL",
+          "ConstraintType": "",
+          "ConstraintDefinition": ""
+        },
+        {
+          "Name": "codeintel_lockfiles_references_depends_on",
+          "IsPrimaryKey": false,
+          "IsUnique": false,
+          "IsExclusion": false,
+          "IsDeferrable": false,
+          "IndexDefinition": "CREATE INDEX codeintel_lockfiles_references_depends_on ON codeintel_lockfile_references USING gin (depends_on gin__int_ops)",
           "ConstraintType": "",
           "ConstraintDefinition": ""
         }
@@ -5785,6 +5847,19 @@
           "Comment": ""
         },
         {
+          "Name": "lockfile",
+          "Index": 5,
+          "TypeName": "text",
+          "IsNullable": true,
+          "Default": "",
+          "CharacterMaximumLength": 0,
+          "IsIdentity": false,
+          "IdentityGeneration": "",
+          "IsGenerated": "NEVER",
+          "GenerationExpression": "",
+          "Comment": "Relative path of a lockfile in the given repository and the given commit."
+        },
+        {
           "Name": "repository_id",
           "Index": 2,
           "TypeName": "integer",
@@ -5810,12 +5885,12 @@
           "ConstraintDefinition": "PRIMARY KEY (id)"
         },
         {
-          "Name": "codeintel_lockfiles_repository_id_commit_bytea",
+          "Name": "codeintel_lockfiles_repository_id_commit_bytea_lockfile",
           "IsPrimaryKey": false,
           "IsUnique": true,
           "IsExclusion": false,
           "IsDeferrable": false,
-          "IndexDefinition": "CREATE UNIQUE INDEX codeintel_lockfiles_repository_id_commit_bytea ON codeintel_lockfiles USING btree (repository_id, commit_bytea)",
+          "IndexDefinition": "CREATE UNIQUE INDEX codeintel_lockfiles_repository_id_commit_bytea_lockfile ON codeintel_lockfiles USING btree (repository_id, commit_bytea, lockfile)",
           "ConstraintType": "",
           "ConstraintDefinition": ""
         },
@@ -9492,6 +9567,19 @@
           "IsGenerated": "NEVER",
           "GenerationExpression": "",
           "Comment": ""
+        },
+        {
+          "Name": "lockfile_indexing_enabled",
+          "Index": 15,
+          "TypeName": "boolean",
+          "IsNullable": false,
+          "Default": "false",
+          "CharacterMaximumLength": 0,
+          "IsIdentity": false,
+          "IdentityGeneration": "",
+          "IsGenerated": "NEVER",
+          "GenerationExpression": "",
+          "Comment": "Whether to index the lockfiles in the repositories matched by this policy"
         },
         {
           "Name": "name",

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -673,28 +673,35 @@ Indexes:
 
 # Table "public.codeintel_lockfile_references"
 ```
-     Column      |           Type           | Collation | Nullable |                          Default                          
------------------+--------------------------+-----------+----------+-----------------------------------------------------------
- id              | integer                  |           | not null | nextval('codeintel_lockfile_references_id_seq'::regclass)
- repository_name | text                     |           | not null | 
- revspec         | text                     |           | not null | 
- package_scheme  | text                     |           | not null | 
- package_name    | text                     |           | not null | 
- package_version | text                     |           | not null | 
- repository_id   | integer                  |           |          | 
- commit_bytea    | bytea                    |           |          | 
- last_check_at   | timestamp with time zone |           |          | 
+          Column          |           Type           | Collation | Nullable |                          Default                          
+--------------------------+--------------------------+-----------+----------+-----------------------------------------------------------
+ id                       | integer                  |           | not null | nextval('codeintel_lockfile_references_id_seq'::regclass)
+ repository_name          | text                     |           | not null | 
+ revspec                  | text                     |           | not null | 
+ package_scheme           | text                     |           | not null | 
+ package_name             | text                     |           | not null | 
+ package_version          | text                     |           | not null | 
+ repository_id            | integer                  |           |          | 
+ commit_bytea             | bytea                    |           |          | 
+ last_check_at            | timestamp with time zone |           |          | 
+ depends_on               | integer[]                |           |          | '{}'::integer[]
+ resolution_lockfile      | text                     |           |          | 
+ resolution_repository_id | integer                  |           |          | 
+ resolution_commit_bytea  | bytea                    |           |          | 
 Indexes:
     "codeintel_lockfile_references_pkey" PRIMARY KEY, btree (id)
-    "codeintel_lockfile_references_repository_name_revspec_package" UNIQUE, btree (repository_name, revspec, package_scheme, package_name, package_version)
+    "codeintel_lockfile_references_repository_name_revspec_package_r" UNIQUE, btree (repository_name, revspec, package_scheme, package_name, package_version, resolution_lockfile, resolution_repository_id, resolution_commit_bytea)
     "codeintel_lockfile_references_last_check_at" btree (last_check_at)
     "codeintel_lockfile_references_repository_id_commit_bytea" btree (repository_id, commit_bytea) WHERE repository_id IS NOT NULL AND commit_bytea IS NOT NULL
+    "codeintel_lockfiles_references_depends_on" gin (depends_on gin__int_ops)
 
 ```
 
 Tracks a lockfile dependency that might be resolvable to a specific repository-commit pair.
 
 **commit_bytea**: The resolved 40-char revhash of the associated revspec, if it is resolvable on this instance.
+
+**depends_on**: IDs of other `codeintel_lockfile_references` this package depends on in the context of this `codeintel_lockfile_references.resolution_id`.
 
 **last_check_at**: Timestamp when background job last checked this row for repository resolution
 
@@ -708,6 +715,12 @@ Tracks a lockfile dependency that might be resolvable to a specific repository-c
 
 **repository_name**: Encodes `reposource.PackageDependency.RepoName`. A name that is &#34;globally unique&#34; for a Sourcegraph instance. Used in `repo:...` queries.
 
+**resolution_commit_bytea**: Commit at which lockfile was resolved. Corresponds to `codeintel_lockfiles.commit_bytea`.
+
+**resolution_lockfile**: Relative path of lockfile in which this package was referenced. Corresponds to `codeintel_lockfiles.lockfile`.
+
+**resolution_repository_id**: ID of the repository in which lockfile was resolved. Corresponds to `codeintel_lockfiles.repository_id`.
+
 **revspec**: Encodes `reposource.PackageDependency.GitTagFromVersion`. Returns the git tag associated with the given dependency version, used in `rev:` or `repo:foo@rev` queries.
 
 # Table "public.codeintel_lockfiles"
@@ -718,9 +731,10 @@ Tracks a lockfile dependency that might be resolvable to a specific repository-c
  repository_id                    | integer   |           | not null | 
  commit_bytea                     | bytea     |           | not null | 
  codeintel_lockfile_reference_ids | integer[] |           | not null | 
+ lockfile                         | text      |           |          | 
 Indexes:
     "codeintel_lockfiles_pkey" PRIMARY KEY, btree (id)
-    "codeintel_lockfiles_repository_id_commit_bytea" UNIQUE, btree (repository_id, commit_bytea)
+    "codeintel_lockfiles_repository_id_commit_bytea_lockfile" UNIQUE, btree (repository_id, commit_bytea, lockfile)
     "codeintel_lockfiles_codeintel_lockfile_reference_ids" gin (codeintel_lockfile_reference_ids gin__int_ops)
 
 ```
@@ -730,6 +744,8 @@ Associates a repository-commit pair with the set of repository-level dependencie
 **codeintel_lockfile_reference_ids**: A key to a resolved repository name-revspec pair. Not all repository names and revspecs are resolvable.
 
 **commit_bytea**: A 40-char revhash. Note that this commit may not be resolvable in the future.
+
+**lockfile**: Relative path of a lockfile in the given repository and the given commit.
 
 # Table "public.configuration_policies_audit_logs"
 ```
@@ -1295,6 +1311,7 @@ Tracks the last time repository was checked for lockfile indexing.
  protected                   | boolean                  |           | not null | false
  repository_patterns         | text[]                   |           |          | 
  last_resolved_at            | timestamp with time zone |           |          | 
+ lockfile_indexing_enabled   | boolean                  |           | not null | false
 Indexes:
     "lsif_configuration_policies_pkey" PRIMARY KEY, btree (id)
     "lsif_configuration_policies_repository_id" btree (repository_id)
@@ -1310,6 +1327,8 @@ Triggers:
 **index_intermediate_commits**: If the matching Git object is a branch, setting this value to true will also index all commits on the matching branches. Setting this value to false will only consider the tip of the branch.
 
 **indexing_enabled**: Whether or not this configuration policy affects auto-indexing schedules.
+
+**lockfile_indexing_enabled**: Whether to index the lockfiles in the repositories matched by this policy
 
 **pattern**: A pattern used to match` names of the associated Git object type.
 

--- a/internal/search/alert/observer.go
+++ b/internal/search/alert/observer.go
@@ -281,6 +281,14 @@ func (o *Observer) errorToAlert(ctx context.Context, err error) (*search.Alert, 
 		return a, nil
 	}
 
+	var unindexedLockfile *searchrepos.MissingLockfileIndexing
+	if errors.As(err, &unindexedLockfile) {
+		repo := unindexedLockfile.RepoName()
+		revs := unindexedLockfile.RevNames()
+
+		return search.AlertForUnindexedLockfile(repo, revs), nil
+	}
+
 	if errors.As(err, &lErr) {
 		return &search.Alert{
 			PrometheusType:  "lucky_search_notice",

--- a/internal/search/repos/repos.go
+++ b/internal/search/repos/repos.go
@@ -120,12 +120,13 @@ func (r *Resolver) Resolve(ctx context.Context, op search.RepoOptions) (Resolved
 	}
 
 	var (
-		dependencyNames []string
-		dependencyRevs  = map[api.RepoName][]search.RevisionSpecifier{}
+		dependencyNames        []string
+		dependencyRevs         = map[api.RepoName][]search.RevisionSpecifier{}
+		dependencyNotFoundRevs = map[api.RepoName][]search.RevisionSpecifier{}
 	)
 
 	if len(op.Dependencies) > 0 {
-		depNames, depRevs, err := r.dependencies(ctx, &op)
+		depNames, depRevs, notFoundRevs, err := r.dependencies(ctx, &op)
 		if err != nil {
 			return Resolved{}, err
 		}
@@ -138,6 +139,8 @@ func (r *Resolver) Resolve(ctx context.Context, op search.RepoOptions) (Resolved
 				dependencyRevs[repo] = append(dependencyRevs[repo], revs...)
 			}
 		}
+
+		dependencyNotFoundRevs = notFoundRevs
 	}
 
 	if len(op.Dependents) > 0 {
@@ -414,6 +417,12 @@ func (r *Resolver) Resolve(ctx context.Context, op search.RepoOptions) (Resolved
 		err = errors.Append(err, &MissingRepoRevsError{Missing: res.MissingRepoRevs})
 	}
 
+	if len(dependencyNotFoundRevs) > 0 {
+		for repo, revs := range dependencyNotFoundRevs {
+			err = errors.Append(err, &MissingLockfileIndexing{repo: repo, revs: revs})
+		}
+	}
+
 	return res.Resolved, err
 }
 
@@ -522,9 +531,9 @@ func computeExcludedRepos(ctx context.Context, db database.DB, op search.RepoOpt
 //
 // 1. Expanding each `repo:dependencies(regex@revA:revB:...)` filter regex to a list of repositories that exist in the DB.
 // 2. For each of those (repo, rev) tuple, asking the code intelligence dependency API for their (transitive) dependencies.
-//    Calling this API also has the effect of triggering a sync of all discovered dependency repos.
+//    // TODO: ~~~Calling this API also has the effect of triggering a sync of all discovered dependency repos.~~
 // 3. Return those dependencies to the caller to be included in repository resolution.
-func (r *Resolver) dependencies(ctx context.Context, op *search.RepoOptions) (_ []string, _ map[api.RepoName][]search.RevisionSpecifier, err error) {
+func (r *Resolver) dependencies(ctx context.Context, op *search.RepoOptions) (_ []string, _ map[api.RepoName][]search.RevisionSpecifier, _ map[api.RepoName][]search.RevisionSpecifier, err error) {
 	tr, ctx := trace.New(ctx, "searchrepos.dependencies", "")
 	defer func() {
 		tr.LazyPrintf("deps: %v", op.Dependencies)
@@ -533,17 +542,25 @@ func (r *Resolver) dependencies(ctx context.Context, op *search.RepoOptions) (_ 
 	}()
 
 	if !conf.DependeciesSearchEnabled() {
-		return nil, nil, errors.Errorf("support for `repo:dependencies()` is disabled in site config (`experimentalFeatures.dependenciesSearch`)")
+		return nil, nil, nil, errors.Errorf("support for `repo:dependencies()` is disabled in site config (`experimentalFeatures.dependenciesSearch`)")
 	}
 
-	repoRevs, err := listDependencyRepos(ctx, r.DB.Repos(), op.Dependencies, op.CaseSensitiveRepoFilters)
+	includeTransitive := false
+	repoRevPatterns := make([]string, 0, len(op.Dependencies))
+	for _, depParam := range op.Dependencies {
+		repoRevPatterns = append(repoRevPatterns, depParam.Dependency)
+		if depParam.Transitive != nil && *depParam.Transitive == query.Yes {
+			includeTransitive = true
+		}
+	}
+	repoRevs, err := listDependencyRepos(ctx, r.DB.Repos(), repoRevPatterns, op.CaseSensitiveRepoFilters)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
-	dependencyRepoRevs, err := livedependencies.GetService(r.DB, livedependencies.NewSyncer()).Dependencies(ctx, repoRevs)
+	dependencyRepoRevs, notFound, err := livedependencies.GetService(r.DB, livedependencies.NewSyncer()).Dependencies(ctx, repoRevs, includeTransitive)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	depRevs := make(map[api.RepoName][]search.RevisionSpecifier, len(dependencyRepoRevs))
@@ -558,7 +575,17 @@ func (r *Resolver) dependencies(ctx context.Context, op *search.RepoOptions) (_ 
 		depRevs[repoName] = revSpecs
 	}
 
-	return depNames, depRevs, nil
+	notFoundRevs := make(map[api.RepoName][]search.RevisionSpecifier, len(notFound))
+	for repoName, revs := range notFound {
+		depNames = append(depNames, string(repoName))
+		revSpecs := make([]search.RevisionSpecifier, 0, len(revs))
+		for rev := range revs {
+			revSpecs = append(revSpecs, search.RevisionSpecifier{RevSpec: string(rev)})
+		}
+		notFoundRevs[repoName] = revSpecs
+	}
+
+	return depNames, depRevs, notFoundRevs, nil
 }
 
 func listDependencyRepos(ctx context.Context, repoStore database.RepoStore, revSpecPatterns []string, caseSensitive bool) (map[api.RepoName]codeintelTypes.RevSpecSet, error) {
@@ -789,6 +816,32 @@ type MissingRepoRevsError struct {
 }
 
 func (MissingRepoRevsError) Error() string { return "missing repo revs" }
+
+type MissingLockfileIndexing struct {
+	repo api.RepoName
+	revs []search.RevisionSpecifier
+}
+
+func (e MissingLockfileIndexing) RepoName() api.RepoName { return e.repo }
+func (e MissingLockfileIndexing) RevNames() (names []string) {
+	for _, r := range e.revs {
+		names = append(names, r.String())
+	}
+	return names
+}
+
+func (e MissingLockfileIndexing) Error() string {
+	var out strings.Builder
+	fmt.Fprintf(&out, "no index lockfiles found in %s at revision: ", e.repo)
+
+	var revs []string
+	for _, r := range e.revs {
+		revs = append(revs, r.String())
+	}
+
+	fmt.Fprintf(&out, "%s", strings.Join(revs, ","))
+	return out.String()
+}
 
 // Get all private repos for the the current actor. On sourcegraph.com, those are
 // only the repos directly added by the user. Otherwise it's all repos the user has

--- a/migrations/frontend/1655105391/down.sql
+++ b/migrations/frontend/1655105391/down.sql
@@ -1,0 +1,20 @@
+ALTER TABLE codeintel_lockfiles
+  DROP COLUMN IF EXISTS lockfile;
+
+DROP INDEX IF EXISTS codeintel_lockfiles_repository_id_commit_bytea_lockfile;
+CREATE UNIQUE INDEX IF NOT EXISTS codeintel_lockfiles_repository_id_commit_bytea ON codeintel_lockfiles USING btree (repository_id, commit_bytea);
+
+ALTER TABLE codeintel_lockfile_references
+  DROP COLUMN IF EXISTS depends_on,
+  DROP COLUMN IF EXISTS resolution_lockfile,
+  DROP COLUMN IF EXISTS resolution_repository_id,
+  DROP COLUMN IF EXISTS resolution_commit_bytea;
+
+DROP INDEX IF EXISTS codeintel_lockfile_references_repository_name_revspec_package_resolution;
+CREATE UNIQUE INDEX IF NOT EXISTS codeintel_lockfile_references_repository_name_revspec_package ON codeintel_lockfile_references USING btree (
+    repository_name,
+    revspec,
+    package_scheme,
+    package_name,
+    package_version
+);

--- a/migrations/frontend/1655105391/metadata.yaml
+++ b/migrations/frontend/1655105391/metadata.yaml
@@ -1,0 +1,2 @@
+name: lockfile_dependency_graph
+parents: [1654848945]

--- a/migrations/frontend/1655105391/up.sql
+++ b/migrations/frontend/1655105391/up.sql
@@ -1,0 +1,38 @@
+DELETE FROM codeintel_lockfiles;
+DELETE FROM codeintel_lockfile_references;
+
+ALTER TABLE codeintel_lockfiles
+  ADD COLUMN IF NOT EXISTS lockfile text;
+
+
+DROP INDEX IF EXISTS codeintel_lockfiles_repository_id_commit_bytea;
+CREATE UNIQUE INDEX IF NOT EXISTS codeintel_lockfiles_repository_id_commit_bytea_lockfile ON codeintel_lockfiles USING btree (repository_id, commit_bytea, lockfile);
+
+COMMENT ON COLUMN codeintel_lockfiles.lockfile IS 'Relative path of a lockfile in the given repository and the given commit.';
+
+ALTER TABLE codeintel_lockfile_references
+  -- We can't make them non-nullable to stay backwards compatible
+  ADD COLUMN IF NOT EXISTS depends_on integer[] DEFAULT '{}',
+  ADD COLUMN IF NOT EXISTS resolution_lockfile text,
+  ADD COLUMN IF NOT EXISTS resolution_repository_id integer,
+  ADD COLUMN IF NOT EXISTS resolution_commit_bytea bytea;
+
+COMMENT ON COLUMN codeintel_lockfile_references.depends_on IS 'IDs of other `codeintel_lockfile_references` this package depends on in the context of this `codeintel_lockfile_references.resolution_id`.';
+COMMENT ON COLUMN codeintel_lockfile_references.resolution_lockfile IS 'Relative path of lockfile in which this package was referenced. Corresponds to `codeintel_lockfiles.lockfile`.';
+COMMENT ON COLUMN codeintel_lockfile_references.resolution_repository_id IS 'ID of the repository in which lockfile was resolved. Corresponds to `codeintel_lockfiles.repository_id`.';
+COMMENT ON COLUMN codeintel_lockfile_references.resolution_commit_bytea IS 'Commit at which lockfile was resolved. Corresponds to `codeintel_lockfiles.commit_bytea`.';
+
+CREATE INDEX IF NOT EXISTS codeintel_lockfiles_references_depends_on
+ON codeintel_lockfile_references USING GIN (depends_on gin__int_ops);
+
+DROP INDEX IF EXISTS codeintel_lockfile_references_repository_name_revspec_package;
+CREATE UNIQUE INDEX IF NOT EXISTS codeintel_lockfile_references_repository_name_revspec_package_resolution ON codeintel_lockfile_references USING btree (
+    repository_name,
+    revspec,
+    package_scheme,
+    package_name,
+    package_version,
+    resolution_lockfile,
+    resolution_repository_id,
+    resolution_commit_bytea
+);

--- a/migrations/frontend/1655454264/down.sql
+++ b/migrations/frontend/1655454264/down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE lsif_configuration_policies
+  DROP COLUMN IF EXISTS lockfile_indexing_enabled;

--- a/migrations/frontend/1655454264/metadata.yaml
+++ b/migrations/frontend/1655454264/metadata.yaml
@@ -1,0 +1,2 @@
+name: add_lockfile_indexing_enabled_to_policy
+parents: [1655105391]

--- a/migrations/frontend/1655454264/up.sql
+++ b/migrations/frontend/1655454264/up.sql
@@ -1,0 +1,4 @@
+ALTER TABLE lsif_configuration_policies
+  ADD COLUMN IF NOT EXISTS lockfile_indexing_enabled boolean NOT NULL DEFAULT false;
+
+COMMENT ON COLUMN lsif_configuration_policies.lockfile_indexing_enabled IS 'Whether to index the lockfiles in the repositories matched by this policy';

--- a/migrations/frontend/squashed.sql
+++ b/migrations/frontend/squashed.sql
@@ -1152,7 +1152,11 @@ CREATE TABLE codeintel_lockfile_references (
     package_version text NOT NULL,
     repository_id integer,
     commit_bytea bytea,
-    last_check_at timestamp with time zone
+    last_check_at timestamp with time zone,
+    depends_on integer[] DEFAULT '{}'::integer[],
+    resolution_lockfile text,
+    resolution_repository_id integer,
+    resolution_commit_bytea bytea
 );
 
 COMMENT ON TABLE codeintel_lockfile_references IS 'Tracks a lockfile dependency that might be resolvable to a specific repository-commit pair.';
@@ -1173,6 +1177,14 @@ COMMENT ON COLUMN codeintel_lockfile_references.commit_bytea IS 'The resolved 40
 
 COMMENT ON COLUMN codeintel_lockfile_references.last_check_at IS 'Timestamp when background job last checked this row for repository resolution';
 
+COMMENT ON COLUMN codeintel_lockfile_references.depends_on IS 'IDs of other `codeintel_lockfile_references` this package depends on in the context of this `codeintel_lockfile_references.resolution_id`.';
+
+COMMENT ON COLUMN codeintel_lockfile_references.resolution_lockfile IS 'Relative path of lockfile in which this package was referenced. Corresponds to `codeintel_lockfiles.lockfile`.';
+
+COMMENT ON COLUMN codeintel_lockfile_references.resolution_repository_id IS 'ID of the repository in which lockfile was resolved. Corresponds to `codeintel_lockfiles.repository_id`.';
+
+COMMENT ON COLUMN codeintel_lockfile_references.resolution_commit_bytea IS 'Commit at which lockfile was resolved. Corresponds to `codeintel_lockfiles.commit_bytea`.';
+
 CREATE SEQUENCE codeintel_lockfile_references_id_seq
     AS integer
     START WITH 1
@@ -1187,7 +1199,8 @@ CREATE TABLE codeintel_lockfiles (
     id integer NOT NULL,
     repository_id integer NOT NULL,
     commit_bytea bytea NOT NULL,
-    codeintel_lockfile_reference_ids integer[] NOT NULL
+    codeintel_lockfile_reference_ids integer[] NOT NULL,
+    lockfile text
 );
 
 COMMENT ON TABLE codeintel_lockfiles IS 'Associates a repository-commit pair with the set of repository-level dependencies parsed from lockfiles.';
@@ -1195,6 +1208,8 @@ COMMENT ON TABLE codeintel_lockfiles IS 'Associates a repository-commit pair wit
 COMMENT ON COLUMN codeintel_lockfiles.commit_bytea IS 'A 40-char revhash. Note that this commit may not be resolvable in the future.';
 
 COMMENT ON COLUMN codeintel_lockfiles.codeintel_lockfile_reference_ids IS 'A key to a resolved repository name-revspec pair. Not all repository names and revspecs are resolvable.';
+
+COMMENT ON COLUMN codeintel_lockfiles.lockfile IS 'Relative path of a lockfile in the given repository and the given commit.';
 
 CREATE SEQUENCE codeintel_lockfiles_id_seq
     AS integer
@@ -1721,7 +1736,8 @@ CREATE TABLE lsif_configuration_policies (
     index_intermediate_commits boolean NOT NULL,
     protected boolean DEFAULT false NOT NULL,
     repository_patterns text[],
-    last_resolved_at timestamp with time zone
+    last_resolved_at timestamp with time zone,
+    lockfile_indexing_enabled boolean DEFAULT false NOT NULL
 );
 
 COMMENT ON COLUMN lsif_configuration_policies.repository_id IS 'The identifier of the repository to which this configuration policy applies. If absent, this policy is applied globally.';
@@ -1745,6 +1761,8 @@ COMMENT ON COLUMN lsif_configuration_policies.index_intermediate_commits IS 'If 
 COMMENT ON COLUMN lsif_configuration_policies.protected IS 'Whether or not this configuration policy is protected from modification of its data retention behavior (except for duration).';
 
 COMMENT ON COLUMN lsif_configuration_policies.repository_patterns IS 'The name pattern matching repositories to which this configuration policy applies. If absent, all repositories are matched.';
+
+COMMENT ON COLUMN lsif_configuration_policies.lockfile_indexing_enabled IS 'Whether to index the lockfiles in the repositories matched by this policy';
 
 CREATE SEQUENCE lsif_configuration_policies_id_seq
     AS integer
@@ -3522,11 +3540,13 @@ CREATE INDEX codeintel_lockfile_references_last_check_at ON codeintel_lockfile_r
 
 CREATE INDEX codeintel_lockfile_references_repository_id_commit_bytea ON codeintel_lockfile_references USING btree (repository_id, commit_bytea) WHERE ((repository_id IS NOT NULL) AND (commit_bytea IS NOT NULL));
 
-CREATE UNIQUE INDEX codeintel_lockfile_references_repository_name_revspec_package ON codeintel_lockfile_references USING btree (repository_name, revspec, package_scheme, package_name, package_version);
+CREATE UNIQUE INDEX codeintel_lockfile_references_repository_name_revspec_package_r ON codeintel_lockfile_references USING btree (repository_name, revspec, package_scheme, package_name, package_version, resolution_lockfile, resolution_repository_id, resolution_commit_bytea);
 
 CREATE INDEX codeintel_lockfiles_codeintel_lockfile_reference_ids ON codeintel_lockfiles USING gin (codeintel_lockfile_reference_ids gin__int_ops);
 
-CREATE UNIQUE INDEX codeintel_lockfiles_repository_id_commit_bytea ON codeintel_lockfiles USING btree (repository_id, commit_bytea);
+CREATE INDEX codeintel_lockfiles_references_depends_on ON codeintel_lockfile_references USING gin (depends_on gin__int_ops);
+
+CREATE UNIQUE INDEX codeintel_lockfiles_repository_id_commit_bytea_lockfile ON codeintel_lockfiles USING btree (repository_id, commit_bytea, lockfile);
 
 CREATE INDEX configuration_policies_audit_logs_policy_id ON configuration_policies_audit_logs USING btree (policy_id);
 
@@ -4155,8 +4175,8 @@ INSERT INTO out_of_band_migrations VALUES (14, 'code-insights', 'db.insights_set
 
 SELECT pg_catalog.setval('out_of_band_migrations_id_seq', 1, false);
 
-INSERT INTO lsif_configuration_policies VALUES (1, NULL, 'Default tip-of-branch retention policy', 'GIT_TREE', '*', true, 2016, false, false, 0, false, true, NULL, NULL);
-INSERT INTO lsif_configuration_policies VALUES (2, NULL, 'Default tag retention policy', 'GIT_TAG', '*', true, 8064, false, false, 0, false, true, NULL, NULL);
-INSERT INTO lsif_configuration_policies VALUES (3, NULL, 'Default commit retention policy', 'GIT_TREE', '*', true, 168, true, false, 0, false, true, NULL, NULL);
+INSERT INTO lsif_configuration_policies VALUES (1, NULL, 'Default tip-of-branch retention policy', 'GIT_TREE', '*', true, 2016, false, false, 0, false, true, NULL, NULL, false);
+INSERT INTO lsif_configuration_policies VALUES (2, NULL, 'Default tag retention policy', 'GIT_TAG', '*', true, 8064, false, false, 0, false, true, NULL, NULL, false);
+INSERT INTO lsif_configuration_policies VALUES (3, NULL, 'Default commit retention policy', 'GIT_TREE', '*', true, 168, true, false, 0, false, true, NULL, NULL, false);
 
 SELECT pg_catalog.setval('lsif_configuration_policies_id_seq', 3, true);


### PR DESCRIPTION
This is an extraction from #36481 and includes the backend/API changes necessary to switch to a model for dependency search where we *actively index lockfiles in the background* using code intel's policy mechanism.

It's the first of multiple PRs to implement [what I demoed here](https://sourcegraph.slack.com/archives/C03DWADAG8M/p1655471498313509).

In short, what this PR does:

* IMPORTANT: Change `dependencies.Service` to NOT parse lockfiles on demand anymore.
* Show search alert if a repository/commit hasn't been lockfile indexed.
* Change `dependencies.Service` to only query the previously persisted dependencies.
* Migrate the database to change `codeintel_lockfiles` and `codeintel_lockfile_references` so we can persist dependency trees (!), one per lockfile per repo/commit.
* Change `dependencies/internal/store` to work with the new database schema, adding ability to query dependencies per lockfile, transitive only, etc.
* Add `lockfile_indexing_enabled` to `lsif_configuration_policies`. @efritz: this is different from the tags-based approached we talked about, because I found it much easier to add a boolean now than to make sure I get all of the stored procedures right when migrating the existing data. I think we can still easily change this and migrate it.
* Change lockfile indexer to check for `lockfile_indexing_enabled` in the policies (vs. indexing).
* Change the code intel frontend to allow users to create lockfile-indexing policies.
* Hide everything behind the `codeIntelLockfileIndexingEnabled` setting flag.
* Introduce a `DependencyGraph` type to `lockfiles` and the `shared` package. This will be returned by different parsers, for example the `yarn.lock` parser I've built (but that's not included in this PR, see below). 
* Change the `service`/`store` layers to persist the graph.

What's *NOT* included:

* The `transitive:yes` predicate for search. I still need to clean this up and ask Search Product on how to implement this properly.
* The actual `yarn.lock` parser that builds a full dependency tree. I found a bug in my current implementation and it's non-trivial to fix (but fixable), so I want to get a review on this PR before diving further into the parser.

That means there's only two things from the user's perspective that change with this PR:

1. **IMPORTANT:** Repository need to be lockfile-indexed before `repo:deps()` will return something.
2. They can create a separate lockfile-indexing policy to enable that.

Since the `yarn.lock`-parser that produces a tree is *not* in this PR, no trees will be persisted yet. That will only happen with parsers supporting that. Until then, all dependencies are persisted as direct dependencies, just like before.

## TODOs/trade-offs:

This is just the first iteration. I haven't done any performance optimizations. I haven't cleaned up every TODO. I plan to do that in follow-up PRs.

But since dependency search is still behind a feature flag, I think that's fine in order to make continuous progress and have reviewable PRs.

## Test plan

- New and existing tests, manual testing, CI