### PR TITLE
chore: Mark __snapshots__ directories as generated.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,6 @@
 cmd/repo-updater/repos/testdata/** linguist-generated=true
 **/__fixtures__/** linguist-generated=true
+**/__snapshots__/** linguist-generated=true
 **/bindata.go linguist-generated=true
 **/Cargo.lock linguist-generated=true
 **/*.pb.go linguist-generated=true


### PR DESCRIPTION
Makes snapshot changes collapsed by default in PR diffs.

## Test plan

n/a
