### PR TITLE
Update git to 2.35.2 in docker images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Changed
 
--
+- Updated minimum required veresion of `git` to 2.35.2 in `gitserver` and `server` Docker image. This addresses a few vulnerabilities disclosed in https://github.blog/2022-04-12-git-security-vulnerability-announced/.
 
 ### Fixed
 

--- a/cmd/gitserver/Dockerfile
+++ b/cmd/gitserver/Dockerfile
@@ -37,8 +37,8 @@ LABEL org.opencontainers.image.version=${VERSION}
 LABEL com.sourcegraph.github.url=https://github.com/sourcegraph/sourcegraph/commit/${COMMIT_SHA}
 
 RUN apk add --no-cache \
-    # We require git 2.34.1 because we use git-repack with flag
-    # --write-midx.  We require git 2.35.2 to fix this vulnerability:
+    # We require git 2.34.1 because we use git-repack with flag --write-midx.
+    # We require git 2.35.2 to fix this vulnerability:
     # https://github.blog/2022-04-12-git-security-vulnerability-announced/
     'git>=2.35.2' --repository=http://dl-cdn.alpinelinux.org/alpine/v3.15/main  \
     git-p4 \

--- a/cmd/gitserver/Dockerfile
+++ b/cmd/gitserver/Dockerfile
@@ -37,8 +37,10 @@ LABEL org.opencontainers.image.version=${VERSION}
 LABEL com.sourcegraph.github.url=https://github.com/sourcegraph/sourcegraph/commit/${COMMIT_SHA}
 
 RUN apk add --no-cache \
-    # We require git 2.34.1 because we use git-repack with flag --write-midx.
-    'git>=2.34.1' --repository=http://dl-cdn.alpinelinux.org/alpine/v3.15/main  \
+    # We require git 2.34.1 because we use git-repack with flag
+    # --write-midx.  We require git 2.35.2 to fix this vulnerability:
+    # https://github.blog/2022-04-12-git-security-vulnerability-announced/
+    'git>=2.35.2' --repository=http://dl-cdn.alpinelinux.org/alpine/v3.15/main  \
     git-p4 \
     && apk add --no-cache  \
     openssh-client \

--- a/cmd/server/Dockerfile
+++ b/cmd/server/Dockerfile
@@ -42,7 +42,9 @@ LABEL com.sourcegraph.github.url=https://github.com/sourcegraph/sourcegraph/comm
 RUN apk add --no-cache --verbose \
     # [NOTE: git-version-min-requirement]
     # We require git 2.34.1 because we use git-repack with flag --write-midx.
-    'git>=2.34.1' \
+    # We require git 2.35.2 to fix this vulnerability:
+    # https://github.blog/2022-04-12-git-security-vulnerability-announced/
+    'git>=2.35.2' \
     git-p4 \
     --repository=http://dl-cdn.alpinelinux.org/alpine/v3.15/main  \
     # NOTE that the Postgres version we run is different


### PR DESCRIPTION
This addresses the vulnerabilities disclosed in https://github.blog/2022-04-12-git-security-vulnerability-announced/

This was originally brought to our attention on Slack [here](https://sourcegraph.slack.com/archives/C022SPMNR0W/p1655822423268479) earlier today.

## Test plan

Updates minor version of `git`. Builds should pass.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
