### PR TITLE
ci: fix jq error being swallowed by for loop

### DIFF
--- a/dev/ci/go-backcompat/test.sh
+++ b/dev/ci/go-backcompat/test.sh
@@ -124,7 +124,8 @@ if [ -f "${flakefile}" ]; then
   echo ""
   echo "Disabling tests listed in flakefile ${flakefile}"
 
-  for pair in $(jq -r '.[] | "\(.path):\(.prefix)"' <"${flakefile}"); do
+  pairs=$(jq -r '.[] | "\(.path):\(.prefix)"' <"${flakefile}")
+  for pair in $pairs; do
     IFS=' ' read -ra parts <<<"${pair/:/ }"
     disable_test_path "${parts[0]}" "${parts[1]}"
   done


### PR DESCRIPTION
The way the flakefile was parsed swallowed `jq` errors and led to https://sourcegraph.slack.com/archives/C01N83PS4TU/p1655902405822249 

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Manually triggered the error to make sure the script is failing properly

<img width="1220" alt="image" src="https://user-images.githubusercontent.com/10151/175044890-4a7bd797-c2ee-4e8c-8416-d49e7b598b1d.png">

https://buildkite.com/sourcegraph/sourcegraph/builds/155978#01818ba6-0569-46d1-b902-d0b127d762fc/117-146