### PR TITLE
Bug fix: Turn off overflow-x scroll for HoverOverlay

### DIFF
--- a/client/shared/src/hover/HoverOverlayContents.module.scss
+++ b/client/shared/src/hover/HoverOverlayContents.module.scss
@@ -5,7 +5,8 @@
     --hover-overlay-horizontal-padding: 1rem;
     --hover-overlay-separator-color: var(--border-color);
 
-    // Make very large MarkupContents scroll.
+    // Make very large MarkupContents scroll vertically.
+    overflow-x: hidden;
     overflow-y: auto;
     max-height: 10rem;
     padding-top: var(--hover-overlay-vertical-padding);

--- a/client/web/src/components/WebHoverOverlay/WebHoverOverlay.story.tsx
+++ b/client/web/src/components/WebHoverOverlay/WebHoverOverlay.story.tsx
@@ -261,3 +261,19 @@ export const MultipleMarkupContentsWithBadgesAndAlerts: Story = () => (
 )
 
 MultipleMarkupContentsWithBadgesAndAlerts.storyName = 'Multiple MarkupContents with badges and alerts'
+
+export const WithCloseButton: Story = () => (
+    <WebHoverOverlay
+        {...commonProps()}
+        hoverOrError={{
+            contents: [FIXTURE_CONTENT, FIXTURE_CONTENT, FIXTURE_CONTENT],
+            aggregatedBadges: [FIXTURE_SEMANTIC_BADGE],
+            alerts: [FIXTURE_SMALL_TEXT_MARKDOWN_ALERT, FIXTURE_WARNING_MARKDOWN_ALERT],
+        }}
+        actionsOrError={FIXTURE_ACTIONS}
+        onAlertDismissed={action('onAlertDismissed')}
+        pinOptions={{ showCloseButton: true }}
+    />
+)
+
+WithCloseButton.storyName = 'With close button'


### PR DESCRIPTION
## What's wrong
As per the [bug report](https://sourcegraph.slack.com/archives/C01LTKUHRL3/p1655906651580679) in Slack, we've got a horizontal scroll in the code intel popover. This is due to positioning the close button with `float: right`.

### Solution
The proper fix perhaps would be to renovate the popover's layout. However, since this is a quick bug fix, I am just applying the easiest possible solution.

We also add a story to capture this new behavior with a close button.

|Before|After|
|---|---|
| <img width="1512" alt="Screenshot 2022-06-22 at 19 58 30" src="https://user-images.githubusercontent.com/2196347/175095386-54908c55-56e1-42de-9d51-9d19d5a6c095.png"> | <img width="1512" alt="Screenshot 2022-06-22 at 19 58 39" src="https://user-images.githubusercontent.com/2196347/175095310-27d3a2f4-718d-474e-9417-97411e8dc506.png">|
## Test plan
1. Open storybook `yarn storybook`
2. Find WebHoverOverlay --> with close button
3. Ensure there's no scroll

Then locally,
1. Run sourcegraph `sg start web-standalone`
2. Make sure on you mac scrollbars are always shown (Preferences -> General -> Show scroll bars = always)
3. [Open a file](https://sourcegraph.test:3443/github.com/sourcegraph/go-diff/-/blob/diff/diff.go?L84) and hover over an identifier
4. You should see no scroll

## App preview:

- [Web](https://sg-web-og-fix-hover-overlay-overflow-x.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-elzbxzhake.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
