### PR TITLE
Commits page - Message alt text duplicate fix 

### DIFF
--- a/client/web/src/repo/RepoRevisionSidebar.module.scss
+++ b/client/web/src/repo/RepoRevisionSidebar.module.scss
@@ -1,6 +1,6 @@
 .tabpanels {
     margin-top: 0.25rem;
-    height: calc(99.9% - 2.25rem);
+    height: calc(100% - 2.25rem);
 }
 
 .close-icon {

--- a/client/web/src/repo/RepoRevisionSidebar.module.scss
+++ b/client/web/src/repo/RepoRevisionSidebar.module.scss
@@ -1,6 +1,6 @@
 .tabpanels {
     margin-top: 0.25rem;
-    height: calc(100% - 2.25rem);
+    height: calc(99.9% - 2.25rem);
 }
 
 .close-icon {

--- a/client/web/src/repo/commits/GitCommitNode.tsx
+++ b/client/web/src/repo/commits/GitCommitNode.tsx
@@ -110,7 +110,7 @@ export const GitCommitNode: React.FunctionComponent<React.PropsWithChildren<GitC
             <Link
                 to={node.canonicalURL}
                 className={classNames(messageSubjectClassName, styles.messageSubject)}
-                title={node.message}
+                title={node.subject}
                 data-testid="git-commit-node-message-subject"
             >
                 {node.subject}

--- a/client/web/src/repo/commits/GitCommitNode.tsx
+++ b/client/web/src/repo/commits/GitCommitNode.tsx
@@ -110,7 +110,6 @@ export const GitCommitNode: React.FunctionComponent<React.PropsWithChildren<GitC
             <Link
                 to={node.canonicalURL}
                 className={classNames(messageSubjectClassName, styles.messageSubject)}
-                title={node.subject}
                 data-testid="git-commit-node-message-subject"
             >
                 {node.subject}

--- a/client/web/src/repo/commits/GitCommitNode.tsx
+++ b/client/web/src/repo/commits/GitCommitNode.tsx
@@ -113,7 +113,6 @@ export const GitCommitNode: React.FunctionComponent<React.PropsWithChildren<GitC
                 data-testid="git-commit-node-message-subject"
             >
                 {node.subject}
-
             </Link>
             {node.body && !hideExpandCommitMessageBody && !expandCommitMessageBody && (
                 <Button

--- a/client/web/src/repo/commits/GitCommitNode.tsx
+++ b/client/web/src/repo/commits/GitCommitNode.tsx
@@ -113,6 +113,7 @@ export const GitCommitNode: React.FunctionComponent<React.PropsWithChildren<GitC
                 data-testid="git-commit-node-message-subject"
             >
                 {node.subject}
+
             </Link>
             {node.body && !hideExpandCommitMessageBody && !expandCommitMessageBody && (
                 <Button


### PR DESCRIPTION
Regarding issue #34976 - [Accessibility]: Commits page - Message alt text is duplicated

I changed the title of each link to be set to the commit's subject rather than its message. This change means the screen reader will only read the commit subject when reading the commit details, and the user can utilize the "..." button in order to read the commit message.

## Test plan
Verified it worked locally.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-lm-commitspagemsgalt.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-qmkyyxtoju.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
