### PR TITLE
codemirror: Fix token hover errors (caused by extensions derived from props)

### DIFF
--- a/client/search-ui/src/input/CodeMirrorQueryInput.tsx
+++ b/client/search-ui/src/input/CodeMirrorQueryInput.tsx
@@ -13,6 +13,7 @@ import {
     RangeSetBuilder,
     MapMode,
     ChangeSpec,
+    Compartment,
 } from '@codemirror/state'
 import {
     EditorView,
@@ -291,6 +292,7 @@ const CodeMirrorQueryInput: React.FunctionComponent<React.PropsWithChildren<Code
         // re-render when the ref is attached, but we need that so that
         // `useCodeMirror` is called again and the editor is actually created.
         const [container, setContainer] = useState<HTMLDivElement | null>(null)
+        const externalExtensions = useMemo(() => new Compartment(), [])
 
         const editor = useCodeMirror(
             container,
@@ -306,13 +308,15 @@ const CodeMirrorQueryInput: React.FunctionComponent<React.PropsWithChildren<Code
                     queryDiagnostic,
                     tokenInfo(),
                     highlightFocusedFilter,
-                    ...extensions,
+                    externalExtensions.of(extensions),
                 ],
                 // patternType and interpretComments are updated via a
                 // transaction since there is no need to re-initialize all
                 // extensions
+                // The extensions passed in via `extensions` are update via a
+                // compartment
                 // eslint-disable-next-line react-hooks/exhaustive-deps
-                [isLightTheme, extensions]
+                [isLightTheme, externalExtensions]
             )
         )
 
@@ -329,6 +333,11 @@ const CodeMirrorQueryInput: React.FunctionComponent<React.PropsWithChildren<Code
         useEffect(() => {
             editor?.dispatch({ effects: [setQueryParseOptions.of({ patternType, interpretComments })] })
         }, [editor, patternType, interpretComments])
+
+        // Update external extensions if they changed
+        useEffect(() => {
+            editor?.dispatch({ effects: [externalExtensions.reconfigure(extensions)] })
+        }, [editor, extensions])
 
         return (
             <div

--- a/client/search-ui/src/input/CodeMirrorQueryInput.tsx
+++ b/client/search-ui/src/input/CodeMirrorQueryInput.tsx
@@ -337,7 +337,7 @@ const CodeMirrorQueryInput: React.FunctionComponent<React.PropsWithChildren<Code
         // Update external extensions if they changed
         useEffect(() => {
             editor?.dispatch({ effects: [externalExtensions.reconfigure(extensions)] })
-        }, [editor, extensions])
+        }, [editor, externalExtensions, extensions])
 
         return (
             <div

--- a/client/search-ui/src/input/SearchBox.tsx
+++ b/client/search-ui/src/input/SearchBox.tsx
@@ -106,11 +106,27 @@ export const SearchBox: React.FunctionComponent<React.PropsWithChildren<SearchBo
                 */}
                 <div className={classNames(styles.searchBoxFocusContainer, 'flex-shrink-past-contents')} role="search">
                     <LazyMonacoQueryInput
-                        {...props}
-                        onHandleFuzzyFinder={props.onHandleFuzzyFinder}
                         className={styles.searchBoxInput}
                         onEditorCreated={onEditorCreated}
                         placeholder="Enter search query..."
+                        preventNewLine={true}
+                        autoFocus={props.autoFocus}
+                        caseSensitive={props.caseSensitive}
+                        editorComponent={props.editorComponent}
+                        fetchStreamSuggestions={props.fetchStreamSuggestions}
+                        globbing={props.globbing}
+                        interpretComments={props.interpretComments}
+                        isLightTheme={props.isLightTheme}
+                        isSourcegraphDotCom={props.isSourcegraphDotCom}
+                        keyboardShortcutForFocus={props.keyboardShortcutForFocus}
+                        onChange={props.onChange}
+                        onCompletionItemSelected={props.onCompletionItemSelected}
+                        onFocus={props.onFocus}
+                        onHandleFuzzyFinder={props.onHandleFuzzyFinder}
+                        onSubmit={props.onSubmit}
+                        patternType={props.patternType}
+                        queryState={props.queryState}
+                        selectedSearchContextSpec={props.selectedSearchContextSpec}
                     />
                     <Toggles
                         patternType={props.patternType}


### PR DESCRIPTION
While working on other CodeMirror query input related stuff, I came across this obscure issue: CodeMirror would throw a bunch of errors related to our own token highlighting extension.

> RangeError: Field is not present in this state

<img width="958" alt="2022-06-22_14-56_1" src="https://user-images.githubusercontent.com/179026/175115899-07365498-b205-4e7f-b7a6-cf5376956c48.png">

This would appear when hovering over query tokens after typing into the search query input. It didn't make much sense to me because the `highlightedTokenPosition` field [is clearly always present](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@cee56f089dbc60b7a9eef8468603b60ad6fd43dd/-/blob/client/search-ui/src/input/CodeMirrorQueryInput.tsx?L597-611). Luckily this doesn't seem to break the editor as a whole.

Eventually I looked into how often the whole `tokenInfo` extension was created and it turns out that it was created multiple times, more precisely the extension would be re-created on every key press. Even worse, it looks like the old DOM event handlers are not detached when the `tokenInfo` extension is replaced with a new version (this can be seen by the fact that the hover event triggers event handlers from two different extension instantiations):


https://user-images.githubusercontent.com/179026/175117671-ebb1f9ad-eba8-420b-84c1-96c1e999d1f1.mp4


This meant two things:

1. Some props that the extensions depend on change on every keypress.
2. There is either a bug in CodeMirror or how we create extenions that cause old DOM event handlers from staying around.

I first looked into which props changed and the culprit seems to be `onCompletionItemSelected`, which causes `extensions` to be recreated:

<img width="956" alt="2022-06-22_14-56" src="https://user-images.githubusercontent.com/179026/175117931-c71201a9-5032-458b-a248-d10c77465057.png">

There are a couple of ways to go about this. Ideally `onCompletionItemSelected` would be stable, and I implemented that in the second commit (bb2916b60484c47f50f6b04fd938a2a364f44274). This also includes a change to avoid parsing the query in the first place when the tour is not enabled.

But that fix alone would mean that people would still have to know to pass stable values to the query input to avoid this error. So ideally there is a way for the query input itself to deal with this problem.

I actually already implemented the `onSubmit` handler in such a way that it avoids recreating all extensions if just that handler changes (because that is a common) (tl;dr: The handler is stored in a state field and the field is updated via a transaction). But doing this for every callback function seemed cumbersome, and was still an abstraction level too high for my taste (and would have resulted in a lot of additional code).

Interestingly, CodeMirror has the concept of "compartments" which allows you to replace/update *a subset* of extensions. The "bad extension" came from `CodeMirrorMonacoFacade` but `tokenInfo` is provided by the lower level component `CodeMirrorQueryInput` (whether or not the current separation of extensions in two different components make sense is another topic).
So a simple fix was to compartmentalize all extensions passed from `CodeMirrorMonacoFacade` to `CodeMirrorQueryInput`, so that only the "higher level" extensions would be recreated but not `CodeMirrorQueryInput`'s own extensions (side note: I think that's a great solution for building layers of CodeMirror components).
This was implemented in the first commit.

## Test plan

- Open search page and dev tools.
- Type in query and hover over query tokens.
- No errors should be shown in the console.

Integration tests pass.

## App preview:

- [Web](https://sg-web-fkling-cm-extensions.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-ywjlcwmduh.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

