### PR TITLE
a11y: improve search results navigation with screen reader

### DIFF
--- a/client/search-ui/src/components/CommitSearchResult.tsx
+++ b/client/search-ui/src/components/CommitSearchResult.tsx
@@ -20,6 +20,8 @@ interface Props extends PlatformContextProps<'requestGraphQL'> {
     onSelect: () => void
     openInNewTab?: boolean
     containerClassName?: string
+    as?: React.ElementType
+    index: number
 }
 
 // This is a search result for types diff or commit.
@@ -29,6 +31,8 @@ export const CommitSearchResult: React.FunctionComponent<Props> = ({
     onSelect,
     openInNewTab,
     containerClassName,
+    as,
+    index,
 }) => {
     /**
      * Use the custom hook useIsTruncated to check if overflow: ellipsis is activated for the element
@@ -75,6 +79,7 @@ export const CommitSearchResult: React.FunctionComponent<Props> = ({
 
     return (
         <ResultContainer
+            index={index}
             icon={SourceCommitIcon}
             collapsible={false}
             defaultExpanded={true}
@@ -85,6 +90,7 @@ export const CommitSearchResult: React.FunctionComponent<Props> = ({
             repoName={result.repository}
             repoStars={result.repoStars}
             className={containerClassName}
+            as={as}
         />
     )
 }

--- a/client/search-ui/src/components/FileSearchResult.tsx
+++ b/client/search-ui/src/components/FileSearchResult.tsx
@@ -80,6 +80,9 @@ interface Props extends SettingsCascadeProps, TelemetryProps {
     extensionsController?: Pick<ExtensionsController, 'extHostAPI'>
 
     hoverifier?: Hoverifier<HoverContext, HoverMerged, ActionItemAction>
+
+    as?: React.ElementType
+    index: number
 }
 
 const sumHighlightRanges = (count: number, item: MatchItem): number => count + item.highlightRanges.length
@@ -227,6 +230,7 @@ export const FileSearchResult: React.FunctionComponent<React.PropsWithChildren<P
 
         if (props.showAllMatches) {
             containerProps = {
+                index: props.index,
                 collapsible: false,
                 defaultExpanded: props.expanded,
                 icon: props.icon,
@@ -246,6 +250,7 @@ export const FileSearchResult: React.FunctionComponent<React.PropsWithChildren<P
         } else {
             const hideCount = matchCount - limitedMatchCount
             containerProps = {
+                index: props.index,
                 collapsible: limitedMatchCount < matchCount,
                 defaultExpanded: props.expanded,
                 icon: props.icon,
@@ -267,6 +272,7 @@ export const FileSearchResult: React.FunctionComponent<React.PropsWithChildren<P
         }
     } else if (props.showAllMatches) {
         containerProps = {
+            index: props.index,
             collapsible: false,
             defaultExpanded: props.expanded,
             icon: props.icon,
@@ -285,6 +291,7 @@ export const FileSearchResult: React.FunctionComponent<React.PropsWithChildren<P
     } else {
         const length = highlightRangesCount - collapsedHighlightRangesCount
         containerProps = {
+            index: props.index,
             collapsible: items.length > collapsedMatchCount,
             defaultExpanded: props.expanded,
             icon: props.icon,
@@ -302,6 +309,7 @@ export const FileSearchResult: React.FunctionComponent<React.PropsWithChildren<P
             onResultClicked: props.onSelect,
             className: props.containerClassName,
             resultType: result.type,
+            as: props.as,
         }
     }
 

--- a/client/search-ui/src/components/RepoSearchResult.tsx
+++ b/client/search-ui/src/components/RepoSearchResult.tsx
@@ -8,7 +8,7 @@ import SourceRepositoryIcon from 'mdi-react/SourceRepositoryIcon'
 
 import { displayRepoName } from '@sourcegraph/shared/src/components/RepoLink'
 import { getRepoMatchLabel, getRepoMatchUrl, RepositoryMatch } from '@sourcegraph/shared/src/search/stream'
-import { Icon, Link, useIsTruncated } from '@sourcegraph/wildcard'
+import { Icon, Link, Tooltip, useIsTruncated } from '@sourcegraph/wildcard'
 
 import { LastSyncedIcon } from './LastSyncedIcon'
 import { ResultContainer } from './ResultContainer'
@@ -19,12 +19,16 @@ export interface RepoSearchResultProps {
     result: RepositoryMatch
     onSelect: () => void
     containerClassName?: string
+    as?: React.ElementType
+    index: number
 }
 
 export const RepoSearchResult: React.FunctionComponent<RepoSearchResultProps> = ({
     result,
     onSelect,
     containerClassName,
+    as,
+    index,
 }) => {
     /**
      * Use the custom hook useIsTruncated to check if overflow: ellipsis is activated for the element
@@ -35,14 +39,15 @@ export const RepoSearchResult: React.FunctionComponent<RepoSearchResultProps> = 
 
     const renderTitle = (): JSX.Element => (
         <div className={styles.title}>
-            <span
-                onMouseEnter={checkTruncation}
-                className="test-search-result-label ml-1 flex-shrink-past-contents text-truncate"
-                ref={titleReference}
-                data-tooltip={(truncated && displayRepoName(getRepoMatchLabel(result))) || null}
-            >
-                <Link to={getRepoMatchUrl(result)}>{displayRepoName(getRepoMatchLabel(result))}</Link>
-            </span>
+            <Tooltip content={(truncated && displayRepoName(getRepoMatchLabel(result))) || null} placement="bottom">
+                <span
+                    onMouseEnter={checkTruncation}
+                    className="test-search-result-label ml-1 flex-shrink-past-contents text-truncate"
+                    ref={titleReference}
+                >
+                    <Link to={getRepoMatchUrl(result)}>{displayRepoName(getRepoMatchLabel(result))}</Link>
+                </span>
+            </Tooltip>
         </div>
     )
 
@@ -116,6 +121,7 @@ export const RepoSearchResult: React.FunctionComponent<RepoSearchResultProps> = 
 
     return (
         <ResultContainer
+            index={index}
             icon={SourceRepositoryIcon}
             collapsible={false}
             defaultExpanded={true}
@@ -126,6 +132,7 @@ export const RepoSearchResult: React.FunctionComponent<RepoSearchResultProps> = 
             repoName={result.repository}
             repoStars={result.repoStars}
             className={containerClassName}
+            as={as}
         />
     )
 }

--- a/client/search-ui/src/components/ResultContainer.tsx
+++ b/client/search-ui/src/components/ResultContainer.tsx
@@ -111,6 +111,9 @@ export interface ResultContainerProps {
      * CSS class name to be applied to the component
      */
     className?: string
+
+    as?: React.ElementType
+    index: number
 }
 
 /**
@@ -134,6 +137,8 @@ export const ResultContainer: React.FunctionComponent<React.PropsWithChildren<Re
     onResultClicked,
     className,
     resultType,
+    as: Component = 'div',
+    index,
 }) => {
     const [expanded, setExpanded] = useState(allExpanded || defaultExpanded)
     const formattedRepositoryStarCount = formatRepositoryStarCount(repoStars)
@@ -152,15 +157,16 @@ export const ResultContainer: React.FunctionComponent<React.PropsWithChildren<Re
         }
     }
     return (
-        <div
+        <Component
             className={classNames('test-search-result', styles.resultContainer, className)}
             data-testid="result-container"
             data-result-type={resultType}
             data-expanded={allExpanded}
             onClick={trackReferencePanelClick}
-            role="none"
+            role="article"
+            aria-labelledby={`result-container-${index}`}
         >
-            <div className={styles.header}>
+            <div className={styles.header} id={`result-container-${index}`}>
                 <Icon
                     className="flex-shrink-0"
                     as={icon}
@@ -219,6 +225,6 @@ export const ResultContainer: React.FunctionComponent<React.PropsWithChildren<Re
             </div>
             {!expanded && collapsedChildren}
             {expanded && expandedChildren}
-        </div>
+        </Component>
     )
 }

--- a/client/search-ui/src/results/StreamingSearchResultsList.module.scss
+++ b/client/search-ui/src/results/StreamingSearchResultsList.module.scss
@@ -2,3 +2,8 @@
     max-width: 65rem;
     margin: auto;
 }
+
+.list {
+    list-style-type: none;
+    padding: 0;
+}

--- a/client/search-ui/src/results/StreamingSearchResultsList.tsx
+++ b/client/search-ui/src/results/StreamingSearchResultsList.tsx
@@ -112,6 +112,7 @@ export const StreamingSearchResultsList: React.FunctionComponent<
                 case 'symbol':
                     return (
                         <FileSearchResult
+                            index={index}
                             location={location}
                             telemetryService={telemetryService}
                             icon={getFileMatchIcon(result)}
@@ -127,24 +128,29 @@ export const StreamingSearchResultsList: React.FunctionComponent<
                             hoverifier={hoverifier}
                             openInNewTab={openMatchesInNewTab}
                             containerClassName={resultClassName}
+                            as="li"
                         />
                     )
                 case 'commit':
                     return (
                         <CommitSearchResult
+                            index={index}
                             result={result}
                             platformContext={platformContext}
                             onSelect={() => logSearchResultClicked(index, 'commit')}
                             openInNewTab={openMatchesInNewTab}
                             containerClassName={resultClassName}
+                            as="li"
                         />
                     )
                 case 'repo':
                     return (
                         <RepoSearchResult
+                            index={index}
                             result={result}
                             onSelect={() => logSearchResultClicked(index, 'repo')}
                             containerClassName={resultClassName}
+                            as="li"
                         />
                     )
             }
@@ -178,7 +184,9 @@ export const StreamingSearchResultsList: React.FunctionComponent<
                 </div>
             </div>
             <VirtualList<SearchMatch>
-                className="mt-2"
+                as="ol"
+                aria-label="Search results"
+                className={classNames('mt-2', styles.list)}
                 itemsToShow={itemsToShow}
                 onShowMoreItems={handleBottomHit}
                 items={results?.results || []}

--- a/client/search-ui/src/results/sidebar/SearchSidebar.tsx
+++ b/client/search-ui/src/results/sidebar/SearchSidebar.tsx
@@ -240,9 +240,9 @@ export const SearchSidebar: React.FunctionComponent<React.PropsWithChildren<Sear
     }
 
     return (
-        <div className={classNames(styles.searchSidebar, props.className)}>
+        <aside className={classNames(styles.searchSidebar, props.className)} role="region" aria-label="Search sidebar">
             {props.prefixContent}
             {body}
-        </div>
+        </aside>
     )
 }

--- a/client/search-ui/src/results/sidebar/SearchSidebarSection.tsx
+++ b/client/search-ui/src/results/sidebar/SearchSidebarSection.tsx
@@ -104,7 +104,10 @@ export const SearchSidebarSection: React.FunctionComponent<
         )
 
         return visible ? (
-            <div className={classNames(styles.sidebarSection, className)}>
+            <article
+                aria-labelledby={`search-sidebar-section-header-${sectionId}`}
+                className={classNames(styles.sidebarSection, className)}
+            >
                 <Collapse isOpen={isOpened} onOpenChange={handleOpenChange}>
                     <CollapseHeader
                         as={Button}
@@ -113,7 +116,7 @@ export const SearchSidebarSection: React.FunctionComponent<
                         outline={true}
                         variant="secondary"
                     >
-                        <H5 as={H2} className="flex-grow-1">
+                        <H5 as={H2} className="flex-grow-1" id={`search-sidebar-section-header-${sectionId}`}>
                             {header}
                         </H5>
                         <Icon aria-hidden={true} className="mr-1" as={isOpened ? ChevronDownIcon : ChevronLeftIcon} />
@@ -137,7 +140,8 @@ export const SearchSidebarSection: React.FunctionComponent<
                         </div>
                     </CollapsePanel>
                 </Collapse>
-            </div>
+            </article>
         ) : null
     }
 )
+SearchSidebarSection.displayName = 'SearchSidebarSection'

--- a/client/shared/src/components/VirtualList.tsx
+++ b/client/shared/src/components/VirtualList.tsx
@@ -33,6 +33,9 @@ interface Props<TItem, TExtraItemProps> {
     containment?: HTMLElement
 
     className?: string
+
+    as?: React.ElementType
+    'aria-label'?: string
 }
 
 interface State {}
@@ -52,8 +55,9 @@ export class VirtualList<TItem, TExtraItemProps = undefined> extends React.PureC
     }
 
     public render(): JSX.Element | null {
+        const Element = this.props.as || 'div'
         return (
-            <div className={this.props.className} ref={this.props.onRef}>
+            <Element className={this.props.className} ref={this.props.onRef} aria-label={this.props['aria-label']}>
                 {this.props.items.slice(0, this.props.itemsToShow).map((item, index) => (
                     <VisibilitySensor
                         onChange={isVisible => this.onChangeVisibility(isVisible, index)}
@@ -64,7 +68,7 @@ export class VirtualList<TItem, TExtraItemProps = undefined> extends React.PureC
                         {this.props.renderItem(item, index, this.props.itemProps)}
                     </VisibilitySensor>
                 ))}
-            </div>
+            </Element>
         )
     }
 }

--- a/client/web/src/search/results/SearchResultsInfoBar.tsx
+++ b/client/web/src/search/results/SearchResultsInfoBar.tsx
@@ -349,7 +349,12 @@ export const SearchResultsInfoBar: React.FunctionComponent<
     }
 
     return (
-        <div className={classNames(props.className, styles.searchResultsInfoBar)} data-testid="results-info-bar">
+        <aside
+            role="region"
+            aria-label="Search results information"
+            className={classNames(props.className, styles.searchResultsInfoBar)}
+            data-testid="results-info-bar"
+        >
             <div className={styles.row}>
                 <Button
                     className={classNames('d-flex d-lg-none', showFilters && 'active')}
@@ -460,6 +465,6 @@ export const SearchResultsInfoBar: React.FunctionComponent<
                     )}
                 </ul>
             </div>
-        </div>
+        </aside>
     )
 }


### PR DESCRIPTION
Closes #34722

This change significantly improves the navigation of the search results page for screen reader users by using semantic elements and the correct aria roles and labels to navigate the search results via landmarks. Watch the video below for more info.

https://user-images.githubusercontent.com/206864/175127866-287ec453-88e1-4fde-b183-8323159a1339.mp4

## Test plan

Tested with VoiceOver on Mac