### PR TITLE
Don't redact URLs during notebook event logging

### DIFF
--- a/client/web/src/tracking/util.ts
+++ b/client/web/src/tracking/util.ts
@@ -27,8 +27,11 @@ export function redactSensitiveInfoFromAppURL(url: string): string {
         return url
     }
 
-    // Ensure we do not leak repo and file names in the URL
-    sourceURL.pathname = '/redacted'
+    // Capture urls for notebook pages
+    if (!sourceURL.pathname.startsWith('/notebooks')) {
+        // Ensure we do not leak repo and file names in the URL
+        sourceURL.pathname = '/redacted'
+    }
 
     const marketingQueryParameters = new Set([
         'utm_source',

--- a/client/web/src/tracking/util.ts
+++ b/client/web/src/tracking/util.ts
@@ -28,10 +28,11 @@ export function redactSensitiveInfoFromAppURL(url: string): string {
     }
 
     // Capture urls for notebook pages
-    if (!sourceURL.pathname.startsWith('/notebooks')) {
-        // Ensure we do not leak repo and file names in the URL
-        sourceURL.pathname = '/redacted'
+    if (sourceURL.pathname.startsWith('/notebooks')) {
+        return url
     }
+    // Ensure we do not leak repo and file names in the URL
+    sourceURL.pathname = '/redacted'
 
     const marketingQueryParameters = new Set([
         'utm_source',


### PR DESCRIPTION

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-notebook-event-urls.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-lpzxxzdzcl.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
