### PR TITLE
Search API: expose chunk matches over the streaming API

### DIFF
--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -149,7 +149,7 @@ func (h *streamHandler) serveHTTP(r *http.Request, tr *trace.Trace, eventWriter 
 		h.flushTickerInternal,
 		h.pingTickerInterval,
 		displayLimit,
-		args.ChunkMatches,
+		args.EnableChunkMatches,
 		logLatency,
 	)
 	batchedStream := streaming.NewBatchingStream(50*time.Millisecond, eventHandler)
@@ -196,11 +196,11 @@ func logSearch(ctx context.Context, alert *search.Alert, err error, start time.T
 }
 
 type args struct {
-	Query        string
-	Version      string
-	PatternType  string
-	Display      int
-	ChunkMatches bool
+	Query              string
+	Version            string
+	PatternType        string
+	Display            int
+	EnableChunkMatches bool
 
 	// Optional decoration parameters for server-side rendering a result set
 	// or subset. Decorations may specify, e.g., highlighting results with
@@ -237,8 +237,8 @@ func parseURLQuery(q url.Values) (*args, error) {
 	}
 
 	chunkMatches := get("cm", "f")
-	if a.ChunkMatches, err = strconv.ParseBool(chunkMatches); err != nil {
-		return nil, errors.Errorf("chunk matches must be parseable as a boolean, got %q: w", chunkMatches, err)
+	if a.EnableChunkMatches, err = strconv.ParseBool(chunkMatches); err != nil {
+		return nil, errors.Errorf("chunk matches must be parseable as a boolean, got %q: %w", chunkMatches, err)
 	}
 
 	decorationLimit := get("dl", "0")

--- a/internal/search/streaming/http/events.go
+++ b/internal/search/streaming/http/events.go
@@ -77,7 +77,7 @@ type DecoratedContent struct {
 
 type ChunkMatch struct {
 	Content      string   `json:"content"`
-	ContentStart Location `json:"contentStart`
+	ContentStart Location `json:"contentStart"`
 	Ranges       []Range  `json:"ranges"`
 }
 

--- a/internal/search/streaming/http/events.go
+++ b/internal/search/streaming/http/events.go
@@ -28,6 +28,7 @@ type EventContentMatch struct {
 	Commit          string           `json:"commit,omitempty"`
 	Hunks           []DecoratedHunk  `json:"hunks"`
 	LineMatches     []EventLineMatch `json:"lineMatches"`
+	ChunkMatches    []ChunkMatch     `json:"chunkMatches"`
 }
 
 func (e *EventContentMatch) eventMatch() {}
@@ -72,6 +73,12 @@ type Location struct {
 type DecoratedContent struct {
 	Plaintext string `json:"plaintext,omitempty"`
 	HTML      string `json:"html,omitempty"`
+}
+
+type ChunkMatch struct {
+	Content      string   `json:"content"`
+	ContentStart Location `json:"contentStart`
+	Ranges       []Range  `json:"ranges"`
 }
 
 // EventLineMatch is a subset of zoekt.LineMatch for our Event API.

--- a/internal/search/streaming/http/events.go
+++ b/internal/search/streaming/http/events.go
@@ -27,8 +27,8 @@ type EventContentMatch struct {
 	Branches        []string         `json:"branches,omitempty"`
 	Commit          string           `json:"commit,omitempty"`
 	Hunks           []DecoratedHunk  `json:"hunks"`
-	LineMatches     []EventLineMatch `json:"lineMatches"`
-	ChunkMatches    []ChunkMatch     `json:"chunkMatches"`
+	LineMatches     []EventLineMatch `json:"lineMatches,omitempty"`
+	ChunkMatches    []ChunkMatch     `json:"chunkMatches,omitempty"`
 }
 
 func (e *EventContentMatch) eventMatch() {}


### PR DESCRIPTION
This exposes chunk matches on the streaming API the URL query param `cm=t`. 

It is currently unused, but I added a test to ensure chunk matches actually come through. Will experiment a bit to see how much work it will be to update the client side of things. 

Note that Zoekt still doesn't send chunk matches, and I probably won't flip the switch here until it does.

## Test plan

Added a unit test. Will be exercised more when the web client is updated to use it. 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
