### PR TITLE
search: use nicer component for lucky search suggestions

### DIFF
--- a/client/shared/src/search/stream.ts
+++ b/client/shared/src/search/stream.ts
@@ -216,10 +216,12 @@ export interface Filter {
     kind: string
 }
 
+export type AlertKind = 'lucky-search-queries'
+
 interface Alert {
     title: string
     description?: string | null
-    kind?: string | null
+    kind?: AlertKind | null
     proposedQueries: ProposedQuery[] | null
 }
 

--- a/client/web/src/search/results/StreamingSearchResults.tsx
+++ b/client/web/src/search/results/StreamingSearchResults.tsx
@@ -50,7 +50,7 @@ import { useIsBrowserExtensionActiveUser } from '../../tracking/BrowserExtension
 import { SearchUserNeedsCodeHost } from '../../user/settings/codeHosts/OrgUserNeedsCodeHost'
 import { submitSearch } from '../helpers'
 
-import { DidYouMean } from './DidYouMean'
+import { DidYouMean, ServerQueryAssist } from './DidYouMean'
 import { SearchAlert } from './SearchAlert'
 import { useCachedSearchResults } from './SearchResultsCacheProvider'
 import { SearchResultsInfoBar } from './SearchResultsInfoBar'
@@ -404,6 +404,8 @@ export const StreamingSearchResults: React.FunctionComponent<
                 selectedSearchContextSpec={props.selectedSearchContextSpec}
             />
 
+            {results?.alert?.kind && <ServerQueryAssist alert={results?.alert} />}
+
             <div className={styles.streamingSearchResultsContainer}>
                 <GettingStartedTour.Info className="mt-2 mr-3 mb-3" isSourcegraphDotCom={props.isSourcegraphDotCom} />
                 {showSavedSearchModal && (
@@ -415,7 +417,7 @@ export const StreamingSearchResults: React.FunctionComponent<
                         onDidCancel={onSaveQueryModalClose}
                     />
                 )}
-                {results?.alert && (
+                {results?.alert && !results?.alert.kind && (
                     <div className={classNames(styles.streamingSearchResultsContentCentered, 'mt-4')}>
                         <SearchAlert alert={results.alert} caseSensitive={caseSensitive} patternType={patternType} />
                     </div>

--- a/internal/search/alert/observer.go
+++ b/internal/search/alert/observer.go
@@ -229,6 +229,10 @@ func (o *Observer) Done() (*search.Alert, error) {
 	return o.alert, o.err
 }
 
+type alertKind string
+
+const luckySearchQueries alertKind = "lucky-search-queries"
+
 func (o *Observer) errorToAlert(ctx context.Context, err error) (*search.Alert, error) {
 	if err == nil {
 		return nil, nil
@@ -293,6 +297,7 @@ func (o *Observer) errorToAlert(ctx context.Context, err error) (*search.Alert, 
 		return &search.Alert{
 			PrometheusType:  "lucky_search_notice",
 			Title:           "Showing additional results for similar queries",
+			Kind:            string(luckySearchQueries),
 			Description:     "We returned all the results for your query. We also added results you might be interested in for similar queries. Below are similar queries we ran.",
 			ProposedQueries: lErr.ProposedQueries,
 		}, nil


### PR DESCRIPTION

![Screen Shot 2022-06-22 at 8 32 11 PM](https://user-images.githubusercontent.com/888624/175203554-b7bee808-b39b-41ea-b357-0afdcc600c74.png)

I want to rename the `DidYouMean` file to `QueryAssistance` (which will contain both the `DidYouMean` client component and the new `ServerAlert` component I'm adding here). Any objections? Happy to get feedback on client-side naming too.


## Test plan
Manual testing--this is behind a feature flag and minimal changes to reuse existing components.
