### PR TITLE
Search backend: move file match limit test to result package

### DIFF
--- a/internal/search/result/file_test.go
+++ b/internal/search/result/file_test.go
@@ -289,3 +289,91 @@ func TestChunkMatches_MatchedContent(t *testing.T) {
 		})
 	}
 }
+
+func TestFileMatch_Limit(t *testing.T) {
+	tests := []struct {
+		numHunkRanges       int
+		numSymbolMatches    int
+		limit               int
+		expNumHunkRanges    int
+		expNumSymbolMatches int
+		expRemainingLimit   int
+		wantLimitHit        bool
+	}{
+		{
+			numHunkRanges:     3,
+			numSymbolMatches:  0,
+			limit:             1,
+			expNumHunkRanges:  1,
+			expRemainingLimit: 0,
+			wantLimitHit:      true,
+		},
+		{
+			numHunkRanges:       0,
+			numSymbolMatches:    3,
+			limit:               1,
+			expNumSymbolMatches: 1,
+			expRemainingLimit:   0,
+			wantLimitHit:        true,
+		},
+		{
+			numHunkRanges:     3,
+			numSymbolMatches:  0,
+			limit:             5,
+			expNumHunkRanges:  3,
+			expRemainingLimit: 2,
+			wantLimitHit:      false,
+		},
+		{
+			numHunkRanges:       0,
+			numSymbolMatches:    3,
+			limit:               5,
+			expNumSymbolMatches: 3,
+			expRemainingLimit:   2,
+			wantLimitHit:        false,
+		},
+		{
+			numHunkRanges:     3,
+			numSymbolMatches:  0,
+			limit:             3,
+			expNumHunkRanges:  3,
+			expRemainingLimit: 0,
+			wantLimitHit:      false,
+		},
+		{
+			numHunkRanges:       0,
+			numSymbolMatches:    3,
+			limit:               3,
+			expNumSymbolMatches: 3,
+			expRemainingLimit:   0,
+			wantLimitHit:        false,
+		},
+		{
+			// An empty FileMatch should still count against the limit
+			numHunkRanges:       0,
+			numSymbolMatches:    0,
+			limit:               1,
+			expNumSymbolMatches: 0,
+			expNumHunkRanges:    0,
+			wantLimitHit:        false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run("", func(t *testing.T) {
+			fileMatch := &FileMatch{
+				File:         File{},
+				ChunkMatches: ChunkMatches{{Ranges: make(Ranges, tt.numHunkRanges)}},
+				Symbols:      make([]*SymbolMatch, tt.numSymbolMatches),
+				LimitHit:     false,
+			}
+
+			got := fileMatch.Limit(tt.limit)
+
+			require.Equal(t, tt.expNumHunkRanges, fileMatch.ChunkMatches.MatchCount())
+			require.Equal(t, tt.expNumSymbolMatches, len(fileMatch.Symbols))
+			require.Equal(t, tt.expRemainingLimit, got)
+			require.Equal(t, tt.wantLimitHit, fileMatch.LimitHit)
+		})
+	}
+}

--- a/internal/search/textsearch/textsearch_test.go
+++ b/internal/search/textsearch/textsearch_test.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
@@ -329,94 +328,6 @@ func mkRepos(names ...string) []types.MinimalRepo {
 		repos = append(repos, types.MinimalRepo{ID: id, Name: api.RepoName(name)})
 	}
 	return repos
-}
-
-func TestFileMatch_Limit(t *testing.T) {
-	tests := []struct {
-		numHunkRanges       int
-		numSymbolMatches    int
-		limit               int
-		expNumHunkRanges    int
-		expNumSymbolMatches int
-		expRemainingLimit   int
-		wantLimitHit        bool
-	}{
-		{
-			numHunkRanges:     3,
-			numSymbolMatches:  0,
-			limit:             1,
-			expNumHunkRanges:  1,
-			expRemainingLimit: 0,
-			wantLimitHit:      true,
-		},
-		{
-			numHunkRanges:       0,
-			numSymbolMatches:    3,
-			limit:               1,
-			expNumSymbolMatches: 1,
-			expRemainingLimit:   0,
-			wantLimitHit:        true,
-		},
-		{
-			numHunkRanges:     3,
-			numSymbolMatches:  0,
-			limit:             5,
-			expNumHunkRanges:  3,
-			expRemainingLimit: 2,
-			wantLimitHit:      false,
-		},
-		{
-			numHunkRanges:       0,
-			numSymbolMatches:    3,
-			limit:               5,
-			expNumSymbolMatches: 3,
-			expRemainingLimit:   2,
-			wantLimitHit:        false,
-		},
-		{
-			numHunkRanges:     3,
-			numSymbolMatches:  0,
-			limit:             3,
-			expNumHunkRanges:  3,
-			expRemainingLimit: 0,
-			wantLimitHit:      false,
-		},
-		{
-			numHunkRanges:       0,
-			numSymbolMatches:    3,
-			limit:               3,
-			expNumSymbolMatches: 3,
-			expRemainingLimit:   0,
-			wantLimitHit:        false,
-		},
-		{
-			// An empty FileMatch should still count against the limit
-			numHunkRanges:       0,
-			numSymbolMatches:    0,
-			limit:               1,
-			expNumSymbolMatches: 0,
-			expNumHunkRanges:    0,
-			wantLimitHit:        false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run("", func(t *testing.T) {
-			fileMatch := &result.FileMatch{
-				File:         result.File{},
-				ChunkMatches: result.ChunkMatches{{Ranges: make(result.Ranges, tt.numHunkRanges)}},
-				Symbols:      make([]*result.SymbolMatch, tt.numSymbolMatches),
-				LimitHit:     false,
-			}
-
-			got := fileMatch.Limit(tt.limit)
-
-			require.Equal(t, tt.expNumHunkRanges, fileMatch.ChunkMatches.MatchCount())
-			require.Equal(t, tt.expNumSymbolMatches, len(fileMatch.Symbols))
-			require.Equal(t, tt.expRemainingLimit, got)
-			require.Equal(t, tt.wantLimitHit, fileMatch.LimitHit)
-		})
-	}
 }
 
 // RunRepoSubsetTextSearch is a convenience function that simulates the RepoSubsetTextSearch job.


### PR DESCRIPTION
This moves `TestFileMatch_Limit` to the package that contains the type it
is actually testing.

Side note: there is literally nothing in the `textsearch` package except tests and an empty file. It looks like the existing tests are targeting behavior that doesn't actually exist anymore (we don't have a `textsearch` job), but it's not immediately clear to me that the behavior being tested is covered elsewhere. Otherwise I'd just blow the package away.

## Test plan

Just moving stuff around. 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
