### PR TITLE
search: don't populate lucky patterntype in alerts

### DIFF
--- a/internal/search/alert.go
+++ b/internal/search/alert.go
@@ -65,7 +65,7 @@ func (q *ProposedQuery) QueryString() string {
 		case query.SearchTypeStructural:
 			return q.Query + " patternType:structural"
 		case query.SearchTypeLucky:
-			return q.Query + " patternType:lucky"
+			return q.Query
 		default:
 			panic("unreachable")
 		}

--- a/internal/search/job/jobutil/feeling_lucky_search_job.go
+++ b/internal/search/job/jobutil/feeling_lucky_search_job.go
@@ -155,7 +155,7 @@ func NewGenerator(inputs *run.SearchInputs, seed query.Basic, rules []rule) next
 				ProposedQuery: &search.ProposedQuery{
 					Description: rules[i].description,
 					Query:       query.StringHuman(generated.ToParseTree()),
-					PatternType: query.SearchTypeLiteral,
+					PatternType: query.SearchTypeLucky,
 				},
 			}
 

--- a/internal/search/job/jobutil/testdata/TestNewFeelingLuckySearchJob/one_of_many_patterns_as_lang.golden
+++ b/internal/search/job/jobutil/testdata/TestNewFeelingLuckySearchJob/one_of_many_patterns_as_lang.golden
@@ -6,7 +6,7 @@
         "ProposedQuery": {
           "Description": "apply language filter for pattern",
           "Query": "context:global lang:Python parse",
-          "PatternType": 1
+          "PatternType": 3
         }
       }
     },
@@ -16,7 +16,7 @@
         "ProposedQuery": {
           "Description": "AND patterns together",
           "Query": "context:global (parse AND python)",
-          "PatternType": 1
+          "PatternType": 3
         }
       }
     }

--- a/internal/search/job/jobutil/testdata/TestNewFeelingLuckySearchJob/pattern_as_type.golden
+++ b/internal/search/job/jobutil/testdata/TestNewFeelingLuckySearchJob/pattern_as_type.golden
@@ -6,7 +6,7 @@
         "ProposedQuery": {
           "Description": "apply search type for pattern",
           "Query": "context:global type:commit fix",
-          "PatternType": 1
+          "PatternType": 3
         }
       }
     },
@@ -16,7 +16,7 @@
         "ProposedQuery": {
           "Description": "AND patterns together",
           "Query": "context:global (fix AND commit)",
-          "PatternType": 1
+          "PatternType": 3
         }
       }
     }

--- a/internal/search/job/jobutil/testdata/TestNewFeelingLuckySearchJob/pattern_as_type_multi_patterns.golden
+++ b/internal/search/job/jobutil/testdata/TestNewFeelingLuckySearchJob/pattern_as_type_multi_patterns.golden
@@ -6,7 +6,7 @@
         "ProposedQuery": {
           "Description": "apply search type for pattern",
           "Query": "context:global type:commit code monitor",
-          "PatternType": 1
+          "PatternType": 3
         }
       }
     },
@@ -16,7 +16,7 @@
         "ProposedQuery": {
           "Description": "apply search type with AND patterns",
           "Query": "context:global type:commit (code AND monitor)",
-          "PatternType": 1
+          "PatternType": 3
         }
       }
     },
@@ -26,7 +26,7 @@
         "ProposedQuery": {
           "Description": "AND patterns together",
           "Query": "context:global (code AND monitor AND commit)",
-          "PatternType": 1
+          "PatternType": 3
         }
       }
     }

--- a/internal/search/job/jobutil/testdata/TestNewFeelingLuckySearchJob/pattern_as_type_with_expression.golden
+++ b/internal/search/job/jobutil/testdata/TestNewFeelingLuckySearchJob/pattern_as_type_with_expression.golden
@@ -6,7 +6,7 @@
         "ProposedQuery": {
           "Description": "apply search type for pattern",
           "Query": "context:global type:commit (code OR monitor)",
-          "PatternType": 1
+          "PatternType": 3
         }
       }
     },
@@ -16,7 +16,7 @@
         "ProposedQuery": {
           "Description": "AND patterns together",
           "Query": "context:global (code OR (monitor AND commit))",
-          "PatternType": 1
+          "PatternType": 3
         }
       }
     }

--- a/internal/search/job/jobutil/testdata/TestNewFeelingLuckySearchJob/single_pattern_as_lang.golden
+++ b/internal/search/job/jobutil/testdata/TestNewFeelingLuckySearchJob/single_pattern_as_lang.golden
@@ -4,7 +4,7 @@
     "ProposedQuery": {
       "Description": "apply language filter for pattern",
       "Query": "context:global lang:Python",
-      "PatternType": 1
+      "PatternType": 3
     }
   }
 }

--- a/internal/search/job/jobutil/testdata/TestNewFeelingLuckySearchJob/trigger_unordered_patterns.golden
+++ b/internal/search/job/jobutil/testdata/TestNewFeelingLuckySearchJob/trigger_unordered_patterns.golden
@@ -4,7 +4,7 @@
     "ProposedQuery": {
       "Description": "AND patterns together",
       "Query": "context:global (parse AND func)",
-      "PatternType": 1
+      "PatternType": 3
     }
   }
 }

--- a/internal/search/job/jobutil/testdata/TestNewFeelingLuckySearchJob/trigger_unquoted_rule.golden
+++ b/internal/search/job/jobutil/testdata/TestNewFeelingLuckySearchJob/trigger_unquoted_rule.golden
@@ -6,7 +6,7 @@
         "ProposedQuery": {
           "Description": "unquote patterns",
           "Query": "repo:^github\\.com/sourcegraph/sourcegraph$ monitor *Monitor",
-          "PatternType": 1
+          "PatternType": 3
         }
       }
     },
@@ -16,7 +16,7 @@
         "ProposedQuery": {
           "Description": "AND patterns together",
           "Query": "repo:^github\\.com/sourcegraph/sourcegraph$ (\"monitor\" AND \"*Monitor\")",
-          "PatternType": 1
+          "PatternType": 3
         }
       }
     }

--- a/internal/search/job/jobutil/testdata/TestNewFeelingLuckySearchJob/two_basic_jobs.golden
+++ b/internal/search/job/jobutil/testdata/TestNewFeelingLuckySearchJob/two_basic_jobs.golden
@@ -6,7 +6,7 @@
         "ProposedQuery": {
           "Description": "AND patterns together",
           "Query": "context:global type:file (parse AND func)",
-          "PatternType": 1
+          "PatternType": 3
         }
       }
     },
@@ -16,7 +16,7 @@
         "ProposedQuery": {
           "Description": "AND patterns together",
           "Query": "context:global type:commit (parse AND func)",
-          "PatternType": 1
+          "PatternType": 3
         }
       }
     }

--- a/internal/search/job/jobutil/testdata/TestNewFeelingLuckySearchJob/type_and_lang_multi_rule.golden
+++ b/internal/search/job/jobutil/testdata/TestNewFeelingLuckySearchJob/type_and_lang_multi_rule.golden
@@ -6,7 +6,7 @@
         "ProposedQuery": {
           "Description": "apply search type and language filter for patterns",
           "Query": "context:global type:commit lang:Go monitor code",
-          "PatternType": 1
+          "PatternType": 3
         }
       }
     },
@@ -16,7 +16,7 @@
         "ProposedQuery": {
           "Description": "apply search type for pattern",
           "Query": "context:global type:commit go monitor code",
-          "PatternType": 1
+          "PatternType": 3
         }
       }
     },
@@ -26,7 +26,7 @@
         "ProposedQuery": {
           "Description": "apply language filter for pattern",
           "Query": "context:global lang:Go commit monitor code",
-          "PatternType": 1
+          "PatternType": 3
         }
       }
     },
@@ -36,7 +36,7 @@
         "ProposedQuery": {
           "Description": "apply search type and language filter for patterns with AND patterns",
           "Query": "context:global type:commit lang:Go (monitor AND code)",
-          "PatternType": 1
+          "PatternType": 3
         }
       }
     },
@@ -46,7 +46,7 @@
         "ProposedQuery": {
           "Description": "apply search type with AND patterns",
           "Query": "context:global type:commit (go AND monitor AND code)",
-          "PatternType": 1
+          "PatternType": 3
         }
       }
     },
@@ -56,7 +56,7 @@
         "ProposedQuery": {
           "Description": "apply language filter with AND patterns",
           "Query": "context:global lang:Go (commit AND monitor AND code)",
-          "PatternType": 1
+          "PatternType": 3
         }
       }
     },
@@ -66,7 +66,7 @@
         "ProposedQuery": {
           "Description": "AND patterns together",
           "Query": "context:global (go AND commit AND monitor AND code)",
-          "PatternType": 1
+          "PatternType": 3
         }
       }
     }


### PR DESCRIPTION
Stacked on https://github.com/sourcegraph/sourcegraph/pull/37588. Makes suggestions without populating `patternType` garbage:

![Screen Shot 2022-06-22 at 8 55 23 PM](https://user-images.githubusercontent.com/888624/175205758-1d1de075-5cf1-4aa6-b093-bcf372037111.png)

Because it's ugly and the way lucky search is constructed it "works" to keep the user in lucky mode, no need to redirect to literal or regexp or something.

## Test plan
Updated backed tests
