### PR TITLE
web: repo page integration test flake fix

### DIFF
--- a/client/web/src/integration/repository.test.ts
+++ b/client/web/src/integration/repository.test.ts
@@ -82,6 +82,7 @@ describe('Repository', () => {
             const shortRepositoryName = 'sourcegraph/jsonrpc2'
             const repositoryName = `github.com/${shortRepositoryName}`
             const repositorySourcegraphUrl = `/${repositoryName}`
+            const commitUrl = `${repositorySourcegraphUrl}/-/commit/15c2290dcb37731cc4ee5a2a1c1e5a25b4c28f81?visible=1`
             const clickedFileName = 'async.go'
             const clickedCommit = ''
             const fileEntries = ['jsonrpc2.go', clickedFileName]
@@ -136,10 +137,8 @@ describe('Repository', () => {
                                                     '/github.com/sourcegraph/jsonrpc2/-/commit/9e615b1c32cc519130575e8d10d0d0fee8a5eb6c',
                                             },
                                         ],
-                                        url:
-                                            '/github.com/sourcegraph/jsonrpc2/-/commit/15c2290dcb37731cc4ee5a2a1c1e5a25b4c28f81',
-                                        canonicalURL:
-                                            '/github.com/sourcegraph/jsonrpc2/-/commit/15c2290dcb37731cc4ee5a2a1c1e5a25b4c28f81',
+                                        url: commitUrl,
+                                        canonicalURL: commitUrl,
                                         externalURLs: [
                                             {
                                                 url:
@@ -312,9 +311,8 @@ describe('Repository', () => {
                                         '/github.com/sourcegraph/jsonrpc2/-/commit/9e615b1c32cc519130575e8d10d0d0fee8a5eb6c',
                                 },
                             ],
-                            url: '/github.com/sourcegraph/jsonrpc2/-/commit/15c2290dcb37731cc4ee5a2a1c1e5a25b4c28f81',
-                            canonicalURL:
-                                '/github.com/sourcegraph/jsonrpc2/-/commit/15c2290dcb37731cc4ee5a2a1c1e5a25b4c28f81',
+                            url: commitUrl,
+                            canonicalURL: commitUrl,
                             externalURLs: [
                                 {
                                     url:
@@ -436,7 +434,10 @@ describe('Repository', () => {
                 selector: '[data-testid="git-commit-node-oid"]',
                 action: 'click',
             })
+            await driver.page.waitForSelector('[data-testid="repository-commit-page"]')
             await driver.page.waitForSelector('[data-testid="git-commit-node-message-subject"]')
+            await driver.assertWindowLocation(commitUrl)
+
             await assertSelectorHasText(
                 '[data-testid="git-commit-node-message-subject"]',
                 'update LSIF indexing CI workflow'

--- a/client/web/src/repo/commit/RepositoryCommitPage.tsx
+++ b/client/web/src/repo/commit/RepositoryCommitPage.tsx
@@ -259,7 +259,11 @@ export class RepositoryCommitPage extends React.Component<Props, State> {
 
     public render(): JSX.Element | null {
         return (
-            <div className={classNames('p-3', styles.repositoryCommitPage)} ref={this.nextRepositoryCommitPageElement}>
+            <div
+                data-testid="repository-commit-page"
+                className={classNames('p-3', styles.repositoryCommitPage)}
+                ref={this.nextRepositoryCommitPageElement}
+            >
                 <PageTitle
                     title={
                         this.state.commitOrError && !isErrorLike(this.state.commitOrError)


### PR DESCRIPTION
## Context

Fixing [one of two flakes caused](https://buildkite.com/sourcegraph/sourcegraph/builds/152851) by using the same `data-testid` present on both pages.

## Test plan

Ensure that repo page integration tests are green on CI.

## App preview:

- [Web](https://sg-web-vb-repo-page-integration-test-fix.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-peslytnaxi.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

