### PR TITLE
Refactor Contributors page to use `useConnection` + Apollo

### DIFF
--- a/client/web/src/integration/repository.test.ts
+++ b/client/web/src/integration/repository.test.ts
@@ -1243,6 +1243,7 @@ describe('Repository', () => {
                                             email: 'alice@sourcegraph.test',
                                             avatarURL: null,
                                             user: null,
+                                            __typename: 'Person',
                                         },
                                         count: 1,
                                         commits: {
@@ -1253,9 +1254,12 @@ describe('Repository', () => {
                                                     url: `/${repositoryName}/-/commit/${'1'.repeat(40)}`,
                                                     subject: 'Commit message 1',
                                                     author: { date: subDays(new Date(), 1).toISOString() },
+                                                    __typename: 'GitCommit',
                                                 },
                                             ],
+                                            __typename: 'GitCommitConnection',
                                         },
+                                        __typename: 'RepositoryContributor',
                                     },
                                     {
                                         person: {
@@ -1264,6 +1268,7 @@ describe('Repository', () => {
                                             email: 'jack@sourcegraph.test',
                                             avatarURL: null,
                                             user: null,
+                                            __typename: 'Person',
                                         },
                                         count: 1,
                                         commits: {
@@ -1274,9 +1279,12 @@ describe('Repository', () => {
                                                     url: `/${repositoryName}/-/commit/${'2'.repeat(40)}`,
                                                     subject: 'Commit message 2',
                                                     author: { date: subDays(new Date(), 2).toISOString() },
+                                                    __typename: 'GitCommit',
                                                 },
                                             ],
+                                            __typename: 'GitCommitConnection',
                                         },
+                                        __typename: 'RepositoryContributor',
                                     },
                                     {
                                         person: {
@@ -1285,6 +1293,7 @@ describe('Repository', () => {
                                             email: 'jill@sourcegraph.test',
                                             avatarURL: null,
                                             user: null,
+                                            __typename: 'Person',
                                         },
                                         count: 1,
                                         commits: {
@@ -1295,14 +1304,19 @@ describe('Repository', () => {
                                                     url: `/${repositoryName}/-/commit/${'3'.repeat(40)}`,
                                                     subject: 'Commit message 3',
                                                     author: { date: subDays(new Date(), 3).toISOString() },
+                                                    __typename: 'GitCommit',
                                                 },
                                             ],
+                                            __typename: 'GitCommitConnection',
                                         },
+                                        __typename: 'RepositoryContributor',
                                     },
                                 ],
                                 totalCount: 3,
                                 pageInfo: { hasNextPage: false },
+                                __typename: 'RepositoryContributorConnection',
                             },
+                            __typename: 'Repository',
                         },
                     }),
                 })

--- a/client/web/src/repo/stats/RepositoryStatsContributorsPage.tsx
+++ b/client/web/src/repo/stats/RepositoryStatsContributorsPage.tsx
@@ -113,10 +113,16 @@ const RepositoryContributorNode: React.FunctionComponent<React.PropsWithChildren
 }
 
 const CONTRIBUTORS_QUERY = gql`
-    query RepositoryContributors($repo: ID!, $first: Int, $revisionRange: String, $after: String, $path: String) {
+    query RepositoryContributors(
+        $repo: ID!
+        $first: Int
+        $revisionRange: String
+        $shortlogAfter: String
+        $path: String
+    ) {
         node(id: $repo) {
             ... on Repository {
-                contributors(first: $first, revisionRange: $revisionRange, after: $after, path: $path) {
+                contributors(first: $first, revisionRange: $revisionRange, shortlogAfter: $shortlogAfter, path: $path) {
                     ...RepositoryContributorConnectionFields
                 }
             }
@@ -214,7 +220,7 @@ export const RepositoryStatsContributorsPage: React.FunctionComponent<Props> = (
             first: BATCH_COUNT,
             repo: repo.id,
             revisionRange: spec.revisionRange,
-            after: spec.after,
+            shortlogAfter: spec.after,
             path: spec.path,
         },
         getConnection: result => {

--- a/client/web/src/repo/stats/RepositoryStatsContributorsPage.tsx
+++ b/client/web/src/repo/stats/RepositoryStatsContributorsPage.tsx
@@ -113,16 +113,10 @@ const RepositoryContributorNode: React.FunctionComponent<React.PropsWithChildren
 }
 
 const CONTRIBUTORS_QUERY = gql`
-    query RepositoryContributors(
-        $repo: ID!
-        $first: Int
-        $revisionRange: String
-        $shortlogAfter: String
-        $path: String
-    ) {
+    query RepositoryContributors($repo: ID!, $first: Int, $revisionRange: String, $afterDate: String, $path: String) {
         node(id: $repo) {
             ... on Repository {
-                contributors(first: $first, revisionRange: $revisionRange, shortlogAfter: $shortlogAfter, path: $path) {
+                contributors(first: $first, revisionRange: $revisionRange, afterDate: $afterDate, path: $path) {
                     ...RepositoryContributorConnectionFields
                 }
             }
@@ -219,7 +213,7 @@ export const RepositoryStatsContributorsPage: React.FunctionComponent<Props> = (
             first: BATCH_COUNT,
             repo: repo.id,
             revisionRange: spec.revisionRange,
-            shortlogAfter: spec.after,
+            afterDate: spec.after,
             path: spec.path,
         },
         getConnection: result => {

--- a/cmd/frontend/graphqlbackend/repository_contributor.go
+++ b/cmd/frontend/graphqlbackend/repository_contributor.go
@@ -34,7 +34,7 @@ func (r *repositoryContributorResolver) Commits(args *struct {
 		revisionRange: revisionRange,
 		path:          r.args.Path,
 		author:        &r.email, // TODO(sqs): support when contributor resolves to user, and user has multiple emails
-		after:         r.args.After,
+		after:         r.args.ShortlogAfter,
 		first:         args.First,
 		repo:          r.repo,
 	}

--- a/cmd/frontend/graphqlbackend/repository_contributor.go
+++ b/cmd/frontend/graphqlbackend/repository_contributor.go
@@ -34,7 +34,7 @@ func (r *repositoryContributorResolver) Commits(args *struct {
 		revisionRange: revisionRange,
 		path:          r.args.Path,
 		author:        &r.email, // TODO(sqs): support when contributor resolves to user, and user has multiple emails
-		after:         r.args.ShortlogAfter,
+		after:         r.args.AfterDate,
 		first:         args.First,
 		repo:          r.repo,
 	}

--- a/cmd/frontend/graphqlbackend/repository_contributors.go
+++ b/cmd/frontend/graphqlbackend/repository_contributors.go
@@ -12,7 +12,7 @@ import (
 
 type repositoryContributorsArgs struct {
 	RevisionRange *string
-	ShortlogAfter *string
+	AfterDate     *string
 	Path          *string
 }
 
@@ -51,8 +51,8 @@ func (r *repositoryContributorConnectionResolver) compute(ctx context.Context) (
 		if r.args.Path != nil {
 			opt.Path = *r.args.Path
 		}
-		if r.args.ShortlogAfter != nil {
-			opt.After = *r.args.ShortlogAfter
+		if r.args.AfterDate != nil {
+			opt.After = *r.args.AfterDate
 		}
 		r.results, r.err = client.ShortLog(ctx, r.repo.RepoName(), opt)
 	})

--- a/cmd/frontend/graphqlbackend/repository_contributors.go
+++ b/cmd/frontend/graphqlbackend/repository_contributors.go
@@ -12,7 +12,7 @@ import (
 
 type repositoryContributorsArgs struct {
 	RevisionRange *string
-	After         *string
+	ShortlogAfter *string
 	Path          *string
 }
 
@@ -51,8 +51,8 @@ func (r *repositoryContributorConnectionResolver) compute(ctx context.Context) (
 		if r.args.Path != nil {
 			opt.Path = *r.args.Path
 		}
-		if r.args.After != nil {
-			opt.After = *r.args.After
+		if r.args.ShortlogAfter != nil {
+			opt.After = *r.args.ShortlogAfter
 		}
 		r.results, r.err = client.ShortLog(ctx, r.repo.RepoName(), opt)
 	})

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -2660,7 +2660,7 @@ type Repository implements Node & GenericSearchResultInterface {
         """
         The date after which to count contributions.
         """
-        after: String
+        shortlogAfter: String
         """
         Return contributors to files in this path.
         """

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -2660,7 +2660,7 @@ type Repository implements Node & GenericSearchResultInterface {
         """
         The date after which to count contributions.
         """
-        shortlogAfter: String
+        afterDate: String
         """
         Return contributors to files in this path.
         """


### PR DESCRIPTION
This PR refactors the Repository Contributors page to use the `useConnection` hook and explicitly render the `<Connection*>` components, rather than the `FilteredConnection` component.

Moreover, it introduces a potential fix for the `after` bug that by changing the variable name to `shortAfter` instead.

## Test plan

 - Manually tested using `sg start` as it includes backend changes.
 - Integration test has mocked data updated as per what Apollo would expect. (includes `__typename`).

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-mihir-contributors-use-connection.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-bdoozavmdv.chromatic.com)
