### PR TITLE
web: introduce `test-integration:debug` command

### DIFF
--- a/client/shared/src/testing/config.ts
+++ b/client/shared/src/testing/config.ts
@@ -32,6 +32,8 @@ export interface Config {
     useStandaloneWebServer: boolean
     bitbucketCloudUserBobAppPassword: string
     gitHubDotComToken: string
+    windowWidth: number
+    windowHeight: number
 }
 
 interface Field<T = string> {
@@ -217,6 +219,18 @@ const configFields: ConfigFields = {
         parser: parseBool,
         description: 'Rely on `sg start web-standalone` to load index.html and client assets.',
         defaultValue: false,
+    },
+    windowWidth: {
+        envVar: 'WINDOW_WIDTH',
+        parser: parseInt,
+        description: 'Browser window width.',
+        defaultValue: 1280,
+    },
+    windowHeight: {
+        envVar: 'WINDOW_HEIGHT',
+        parser: parseInt,
+        description: 'Browser window height.',
+        defaultValue: 1024,
     },
 }
 

--- a/client/shared/src/testing/config.ts
+++ b/client/shared/src/testing/config.ts
@@ -29,7 +29,7 @@ export interface Config {
     devtools: boolean
     headless: boolean
     keepBrowser: boolean
-    useStandaloneWebServer: boolean
+    disableAppAssetsMocking: boolean
     bitbucketCloudUserBobAppPassword: string
     gitHubDotComToken: string
     windowWidth: number
@@ -214,10 +214,10 @@ const configFields: ConfigFields = {
         description:
             'A Bitbucket Cloud app password associated with the Bitbucket Cloud user sg-e2e-regression-test-bob, that will be used to sync Bitbucket Cloud repositories.',
     },
-    useStandaloneWebServer: {
-        envVar: 'USE_STANDALONE_WEB_SERVER',
+    disableAppAssetsMocking: {
+        envVar: 'DISABLE_APP_ASSETS_MOCKING',
         parser: parseBool,
-        description: 'Rely on `sg start web-standalone` to load index.html and client assets.',
+        description: 'Disable index.html and client assets mocking.',
         defaultValue: false,
     },
     windowWidth: {

--- a/client/shared/src/testing/config.ts
+++ b/client/shared/src/testing/config.ts
@@ -29,6 +29,7 @@ export interface Config {
     devtools: boolean
     headless: boolean
     keepBrowser: boolean
+    useStandaloneWebServer: boolean
     bitbucketCloudUserBobAppPassword: string
     gitHubDotComToken: string
 }
@@ -210,6 +211,12 @@ const configFields: ConfigFields = {
         envVar: 'BITBUCKET_CLOUD_USER_BOB_APP_PASSWORD',
         description:
             'A Bitbucket Cloud app password associated with the Bitbucket Cloud user sg-e2e-regression-test-bob, that will be used to sync Bitbucket Cloud repositories.',
+    },
+    useStandaloneWebServer: {
+        envVar: 'USE_STANDALONE_WEB_SERVER',
+        parser: parseBool,
+        description: 'Rely on `sg start web-standalone` to load index.html and client assets.',
+        defaultValue: false,
     },
 }
 

--- a/client/shared/src/testing/driver.ts
+++ b/client/shared/src/testing/driver.ts
@@ -779,7 +779,16 @@ interface DriverOptions extends LaunchOptions, BrowserConnectOptions, BrowserLau
 }
 
 export async function createDriverForTest(options?: Partial<DriverOptions>): Promise<Driver> {
-    const config = getConfig('sourcegraphBaseUrl', 'headless', 'slowMo', 'keepBrowser', 'browser', 'devtools')
+    const config = getConfig(
+        'sourcegraphBaseUrl',
+        'headless',
+        'slowMo',
+        'keepBrowser',
+        'browser',
+        'devtools',
+        'windowWidth',
+        'windowHeight'
+    )
 
     // Apply defaults
     const resolvedOptions: typeof config & typeof options = {
@@ -830,7 +839,7 @@ export async function createDriverForTest(options?: Partial<DriverOptions>): Pro
         }
     } else {
         // Chrome
-        args.push('--window-size=1680,1050')
+        args.push(`--window-size=${config.windowWidth},${config.windowHeight}`)
         if (process.getuid() === 0) {
             // TODO don't run as root in CI
             console.warn('Running as root, disabling sandbox')

--- a/client/shared/src/testing/driver.ts
+++ b/client/shared/src/testing/driver.ts
@@ -830,7 +830,7 @@ export async function createDriverForTest(options?: Partial<DriverOptions>): Pro
         }
     } else {
         // Chrome
-        args.push('--window-size=1280,1024')
+        args.push('--window-size=1680,1050')
         if (process.getuid() === 0) {
             // TODO don't run as root in CI
             console.warn('Running as root, disabling sandbox')

--- a/client/shared/src/testing/integration/context.ts
+++ b/client/shared/src/testing/integration/context.ts
@@ -19,6 +19,7 @@ import { ErrorGraphQLResult, SuccessGraphQLResult } from '@sourcegraph/http-clie
 // eslint-disable-next-line no-restricted-imports
 import { SourcegraphContext } from '@sourcegraph/web/src/jscontext'
 
+import { getConfig } from '../config'
 import { recordCoverage } from '../coverage'
 import { Driver } from '../driver'
 import { readEnvironmentString } from '../utils'
@@ -114,6 +115,7 @@ export const createSharedIntegrationTestContext = async <
     currentTest,
     directory,
 }: IntegrationTestOptions): Promise<IntegrationTestContext<TGraphQlOperations, TGraphQlOperationNames>> => {
+    const config = getConfig('keepBrowser', 'useStandaloneWebServer')
     await driver.newPage()
     const recordingsDirectory = path.join(directory, '__fixtures__', snakeCase(currentTest.fullTitle()))
     if (pollyMode === 'record') {
@@ -172,30 +174,32 @@ export const createSharedIntegrationTestContext = async <
             .send('')
     })
 
-    // Serve assets from disk
-    server.get(new URL('/.assets/*path', driver.sourcegraphBaseUrl).href).intercept(async (request, response) => {
-        const asset = request.params.path
-        // Cache all responses for the entire lifetime of the test run
-        response.setHeader('Cache-Control', 'public, max-age=31536000, immutable')
-        try {
-            const content = await readFile(path.join(STATIC_ASSETS_PATH, asset), {
-                // Polly doesn't support Buffers or streams at the moment
-                encoding: 'utf-8',
-            })
-            const contentType = mime.contentType(path.basename(asset))
-            if (contentType) {
-                response.type(contentType)
+    if (!config.useStandaloneWebServer) {
+        // Serve assets from disk
+        server.get(new URL('/.assets/*path', driver.sourcegraphBaseUrl).href).intercept(async (request, response) => {
+            const asset = request.params.path
+            // Cache all responses for the entire lifetime of the test run
+            response.setHeader('Cache-Control', 'public, max-age=31536000, immutable')
+            try {
+                const content = await readFile(path.join(STATIC_ASSETS_PATH, asset), {
+                    // Polly doesn't support Buffers or streams at the moment
+                    encoding: 'utf-8',
+                })
+                const contentType = mime.contentType(path.basename(asset))
+                if (contentType) {
+                    response.type(contentType)
+                }
+                response.send(content)
+            } catch (error) {
+                if ((asError(error) as NodeJS.ErrnoException).code === 'ENOENT') {
+                    response.sendStatus(404)
+                } else {
+                    console.error(error)
+                    response.status(500).send(asError(error).message)
+                }
             }
-            response.send(content)
-        } catch (error) {
-            if ((asError(error) as NodeJS.ErrnoException).code === 'ENOENT') {
-                response.sendStatus(404)
-            } else {
-                console.error(error)
-                response.status(500).send(asError(error).message)
-            }
-        }
-    })
+        })
+    }
 
     // GraphQL requests are not handled by HARs, but configured per-test.
     interface GraphQLRequestEvent<O extends TGraphQlOperationNames> {
@@ -283,6 +287,10 @@ export const createSharedIntegrationTestContext = async <
             return variables
         },
         dispose: async () => {
+            if (config.keepBrowser) {
+                return
+            }
+
             subscriptions.unsubscribe()
             await pTimeout(
                 recordCoverage(driver.browser),

--- a/client/shared/src/testing/integration/context.ts
+++ b/client/shared/src/testing/integration/context.ts
@@ -115,7 +115,7 @@ export const createSharedIntegrationTestContext = async <
     currentTest,
     directory,
 }: IntegrationTestOptions): Promise<IntegrationTestContext<TGraphQlOperations, TGraphQlOperationNames>> => {
-    const config = getConfig('keepBrowser', 'useStandaloneWebServer')
+    const config = getConfig('keepBrowser', 'disableAppAssetsMocking')
     await driver.newPage()
     const recordingsDirectory = path.join(directory, '__fixtures__', snakeCase(currentTest.fullTitle()))
     if (pollyMode === 'record') {
@@ -174,7 +174,7 @@ export const createSharedIntegrationTestContext = async <
             .send('')
     })
 
-    if (!config.useStandaloneWebServer) {
+    if (!config.disableAppAssetsMocking) {
         // Serve assets from disk
         server.get(new URL('/.assets/*path', driver.sourcegraphBaseUrl).href).intercept(async (request, response) => {
             const asset = request.params.path

--- a/client/web/src/integration/blob-viewer.test.ts
+++ b/client/web/src/integration/blob-viewer.test.ts
@@ -598,7 +598,7 @@ describe('Blob viewer', () => {
             )
         })
 
-        it('sends the latest document to extensions', async () => {
+        it.only('sends the latest document to extensions', async () => {
             // This test is meant to prevent regression of
             // "extensions receive wrong text documents": https://github.com/sourcegraph/sourcegraph/issues/14965
 

--- a/client/web/src/integration/blob-viewer.test.ts
+++ b/client/web/src/integration/blob-viewer.test.ts
@@ -598,7 +598,7 @@ describe('Blob viewer', () => {
             )
         })
 
-        it.only('sends the latest document to extensions', async () => {
+        it('sends the latest document to extensions', async () => {
             // This test is meant to prevent regression of
             // "extensions receive wrong text documents": https://github.com/sourcegraph/sourcegraph/issues/14965
 

--- a/client/web/src/integration/context.ts
+++ b/client/web/src/integration/context.ts
@@ -6,6 +6,7 @@ import html from 'tagged-template-noop'
 import { SearchGraphQlOperations } from '@sourcegraph/search'
 import { SharedGraphQlOperations } from '@sourcegraph/shared/src/graphql-operations'
 import { SearchEvent } from '@sourcegraph/shared/src/search/stream'
+import { getConfig } from '@sourcegraph/shared/src/testing/config'
 import {
     createSharedIntegrationTestContext,
     IntegrationTestContext,
@@ -62,39 +63,44 @@ export const createWebIntegrationTestContext = async ({
     directory,
     customContext = {},
 }: IntegrationTestOptions): Promise<WebIntegrationTestContext> => {
+    const config = getConfig('useStandaloneWebServer')
+
     const sharedTestContext = await createSharedIntegrationTestContext<
         WebGraphQlOperations & SharedGraphQlOperations,
         string & keyof (WebGraphQlOperations & SharedGraphQlOperations)
     >({ driver, currentTest, directory })
+
     sharedTestContext.overrideGraphQL(commonWebGraphQlResults)
-
-    // On CI, we don't use `react-fast-refresh`, so we don't need the runtime bundle.
-    // This branching will be redundant after switching to production bundles for integration tests:
-    // https://github.com/sourcegraph/sourcegraph/issues/22831
-    const runtimeChunkScriptTag = isHotReloadEnabled ? `<script src=${getRuntimeAppBundle()}></script>` : ''
-
-    // Serve all requests for index.html (everything that does not match the handlers above) the same index.html
     let jsContext = createJsContext({ sourcegraphBaseUrl: driver.sourcegraphBaseUrl })
-    sharedTestContext.server
-        .get(new URL('/*path', driver.sourcegraphBaseUrl).href)
-        .filter(request => !request.pathname.startsWith('/-/'))
-        .intercept((request, response) => {
-            response.type('text/html').send(html`
-                <html lang="en">
-                    <head>
-                        <title>Sourcegraph Test</title>
-                    </head>
-                    <body>
-                        <div id="root"></div>
-                        <script>
-                            window.context = ${JSON.stringify({ ...jsContext, ...customContext })}
-                        </script>
-                        ${runtimeChunkScriptTag}
-                        <script src=${getAppBundle()}></script>
-                    </body>
-                </html>
-            `)
-        })
+
+    if (!config.useStandaloneWebServer) {
+        // On CI, we don't use `react-fast-refresh`, so we don't need the runtime bundle.
+        // This branching will be redundant after switching to production bundles for integration tests:
+        // https://github.com/sourcegraph/sourcegraph/issues/22831
+        const runtimeChunkScriptTag = isHotReloadEnabled ? `<script src=${getRuntimeAppBundle()}></script>` : ''
+
+        // Serve all requests for index.html (everything that does not match the handlers above) the same index.html
+        sharedTestContext.server
+            .get(new URL('/*path', driver.sourcegraphBaseUrl).href)
+            .filter(request => !request.pathname.startsWith('/-/'))
+            .intercept((request, response) => {
+                response.type('text/html').send(html`
+                    <html lang="en">
+                        <head>
+                            <title>Sourcegraph Test</title>
+                        </head>
+                        <body>
+                            <div id="root"></div>
+                            <script>
+                                window.context = ${JSON.stringify({ ...jsContext, ...customContext })}
+                            </script>
+                            ${runtimeChunkScriptTag}
+                            <script src=${getAppBundle()}></script>
+                        </body>
+                    </html>
+                `)
+            })
+    }
 
     let searchStreamEventOverrides: SearchEvent[] = []
     sharedTestContext.server

--- a/client/web/src/integration/context.ts
+++ b/client/web/src/integration/context.ts
@@ -63,7 +63,7 @@ export const createWebIntegrationTestContext = async ({
     directory,
     customContext = {},
 }: IntegrationTestOptions): Promise<WebIntegrationTestContext> => {
-    const config = getConfig('useStandaloneWebServer')
+    const config = getConfig('disableAppAssetsMocking')
 
     const sharedTestContext = await createSharedIntegrationTestContext<
         WebGraphQlOperations & SharedGraphQlOperations,
@@ -73,7 +73,7 @@ export const createWebIntegrationTestContext = async ({
     sharedTestContext.overrideGraphQL(commonWebGraphQlResults)
     let jsContext = createJsContext({ sourcegraphBaseUrl: driver.sourcegraphBaseUrl })
 
-    if (!config.useStandaloneWebServer) {
+    if (!config.disableAppAssetsMocking) {
         // On CI, we don't use `react-fast-refresh`, so we don't need the runtime bundle.
         // This branching will be redundant after switching to production bundles for integration tests:
         // https://github.com/sourcegraph/sourcegraph/issues/22831

--- a/doc/dev/how-to/testing.md
+++ b/doc/dev/how-to/testing.md
@@ -138,8 +138,8 @@ Our test driver accepts various environment variables that can be used to contro
 | `DEVTOOLS`                         | Whether to run all tests with the browser devtools open.                      |
 | `KEEP_BROWSER`                     | If `true`, browser window will remain open after tests ran.                   |
 | `USE_STANDALONE_WEB_SERVER`        | Rely on `sg start web-standalone` to load index.html and client assets.       |
-| `WINDOW_WIDTH`                     | Browser window width.                                                  |
-| `WINDOW_HEIGHT`                    | Browser window height.                                                 |
+| `WINDOW_WIDTH`                     | Browser window width.                                                         |
+| `WINDOW_HEIGHT`                    | Browser window height.                                                        |
 
 #### Filtering tests
 

--- a/doc/dev/how-to/testing.md
+++ b/doc/dev/how-to/testing.md
@@ -131,13 +131,15 @@ Our test driver accepts various environment variables that can be used to contro
 
 | Environment variable               | Purpose                                                                       |
 | ---------------------------------- | ----------------------------------------------------------------------------- |
-| `BROWSER`                          | Whether to run `firefox` or `chrome` (default)                                |
+| `BROWSER`                          | Whether to run `firefox` or `chrome` (default).                               |
 | `LOG_BROWSER_CONSOLE`              | Log the browser console output to the terminal (default `true`).              |
 | `SLOWMO`                           | Slow down each interaction by a delay (ms).                                   |
 | `HEADLESS`                         | Run the tests without a visible browser window.                               |
-| `DEVTOOLS`                         | Whether to run all tests with the browser devtools open                       |
-| `KEEP_BROWSER`                     | If `true`, browser window will remain open after tests ran                    |
+| `DEVTOOLS`                         | Whether to run all tests with the browser devtools open.                      |
+| `KEEP_BROWSER`                     | If `true`, browser window will remain open after tests ran.                   |
 | `USE_STANDALONE_WEB_SERVER`        | Rely on `sg start web-standalone` to load index.html and client assets.       |
+| `WINDOW_WIDTH`                     | Browser window width.                                                  |
+| `WINDOW_HEIGHT`                    | Browser window height.                                                 |
 
 #### Filtering tests
 

--- a/doc/dev/how-to/testing.md
+++ b/doc/dev/how-to/testing.md
@@ -137,7 +137,7 @@ Our test driver accepts various environment variables that can be used to contro
 | `HEADLESS`                         | Run the tests without a visible browser window.                               |
 | `DEVTOOLS`                         | Whether to run all tests with the browser devtools open.                      |
 | `KEEP_BROWSER`                     | If `true`, browser window will remain open after tests ran.                   |
-| `USE_STANDALONE_WEB_SERVER`        | Rely on `sg start web-standalone` to load index.html and client assets.       |
+| `DISABLE_APP_ASSETS_MOCKING`       | Disable `index.html` and client assets mocking.                               |
 | `WINDOW_WIDTH`                     | Browser window width.                                                         |
 | `WINDOW_HEIGHT`                    | Browser window height.                                                        |
 

--- a/doc/dev/how-to/testing.md
+++ b/doc/dev/how-to/testing.md
@@ -213,7 +213,7 @@ A Sourcegraph instance does not need to be running, because all backend interact
 To run a specific web app integration test in the debug mode:
 
 1. Run `sg start web-standalone` in the repository root to start serving the development version of the application.
-2. Run `yarn test-integration:debug PATH_TO_THE_TEST_FILE_TO_DEBUG`
+2. Run `yarn test-integration:debug PATH_TO_THE_TEST_FILE_TO_DEBUG`. With that command, the server is only used to serve `index.html` and client bundle assets, but the API responses should be mocked as usual.
 
 See the above sections for more details on how to debug the tests, which applies to both integration and end-to-end tests.
 

--- a/doc/dev/how-to/testing.md
+++ b/doc/dev/how-to/testing.md
@@ -98,7 +98,7 @@ This utility method will let you print a URL that will visually render the DOM o
     })
 ```
 
-This page also provides some additional functionality that can make it easier to identify the correct query to use to access a particular DOM element. 
+This page also provides some additional functionality that can make it easier to identify the correct query to use to access a particular DOM element.
 
 ## Browser-based tests
 
@@ -129,14 +129,15 @@ For end-to-end tests that failed in CI, a video of the session is available in t
 
 Our test driver accepts various environment variables that can be used to control Puppeteer's behavior:
 
-| Environment variable  | Purpose                                                          |
-| --------------------- | ---------------------------------------------------------------- |
-| `BROWSER`             | Whether to run `firefox` or `chrome` (default)                   |
-| `LOG_BROWSER_CONSOLE` | Log the browser console output to the terminal (default `true`). |
-| `SLOWMO`              | Slow down each interaction by a delay (ms).                      |
-| `HEADLESS`            | Run the tests without a visible browser window.                  |
-| `DEVTOOLS`            | Whether to run all tests with the browser devtools open          |
-| `KEEP_BROWSER`        | If `true`, browser window will remain open after tests ran       |
+| Environment variable               | Purpose                                                                       |
+| ---------------------------------- | ----------------------------------------------------------------------------- |
+| `BROWSER`                          | Whether to run `firefox` or `chrome` (default)                                |
+| `LOG_BROWSER_CONSOLE`              | Log the browser console output to the terminal (default `true`).              |
+| `SLOWMO`                           | Slow down each interaction by a delay (ms).                                   |
+| `HEADLESS`                         | Run the tests without a visible browser window.                               |
+| `DEVTOOLS`                         | Whether to run all tests with the browser devtools open                       |
+| `KEEP_BROWSER`                     | If `true`, browser window will remain open after tests ran                    |
+| `USE_STANDALONE_WEB_SERVER`        | Rely on `sg start web-standalone` to load index.html and client assets.       |
 
 #### Filtering tests
 
@@ -207,7 +208,12 @@ To run integration tests for the web app:
 
 A Sourcegraph instance does not need to be running, because all backend interactions are stubbed.
 
-See the above sections for how to debug the tests, which applies to both integration and end-to-end tests.
+To run a specific web app integration test for the debug mode:
+
+1. Run `sg start web-standalone` in the repository root to start serving the development version of the application.
+2. Run `yarn test-integration:debug PATH_TO_THE_TEST_FILE_TO_DEBUG`
+
+See the above sections for more details on how to debug the tests, which applies to both integration and end-to-end tests.
 
 #### Writing integration tests
 

--- a/doc/dev/how-to/testing.md
+++ b/doc/dev/how-to/testing.md
@@ -210,7 +210,7 @@ To run integration tests for the web app:
 
 A Sourcegraph instance does not need to be running, because all backend interactions are stubbed.
 
-To run a specific web app integration test for the debug mode:
+To run a specific web app integration test in the debug mode:
 
 1. Run `sg start web-standalone` in the repository root to start serving the development version of the application.
 2. Run `yarn test-integration:debug PATH_TO_THE_TEST_FILE_TO_DEBUG`

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "test": "jest --testPathIgnorePatterns end-to-end regression integration storybook /out/.*test.js",
     "_test-integration": "TS_NODE_PROJECT=client/web/src/integration/tsconfig.json mocha --parallel=$CI --retries=1 --jobs=2",
     "test-integration": "yarn _test-integration \"./client/web/src/integration/**/*.test.ts\"",
-    "test-integration:debug": "BROWSER=chrome KEEP_BROWSER=true DEVTOOLS=true USE_STANDALONE_WEB_SERVER=true WINDOW_WIDTH=1920 WINDOW_HEIGHT=1080 yarn _test-integration --retries=0 --jobs=1",
+    "test-integration:debug": "BROWSER=chrome KEEP_BROWSER=true DEVTOOLS=true DISABLE_APP_ASSETS_MOCKING=true WINDOW_WIDTH=1920 WINDOW_HEIGHT=1080 yarn _test-integration --retries=0 --jobs=1",
     "test-browser-integration": "yarn workspace @sourcegraph/browser run test-integration",
     "_cover-integration": "nyc --hook-require=false --silent yarn _test-integration",
     "cover-integration": "nyc --hook-require=false --silent yarn test-integration",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "test": "jest --testPathIgnorePatterns end-to-end regression integration storybook /out/.*test.js",
     "_test-integration": "TS_NODE_PROJECT=client/web/src/integration/tsconfig.json mocha --parallel=$CI --retries=1 --jobs=2",
     "test-integration": "yarn _test-integration \"./client/web/src/integration/**/*.test.ts\"",
+    "test-integration:debug": "BROWSER=chrome KEEP_BROWSER=true DEVTOOLS=true USE_STANDALONE_WEB_SERVER=true yarn _test-integration --retries=0 --jobs=1",
     "test-browser-integration": "yarn workspace @sourcegraph/browser run test-integration",
     "_cover-integration": "nyc --hook-require=false --silent yarn _test-integration",
     "cover-integration": "nyc --hook-require=false --silent yarn test-integration",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "test": "jest --testPathIgnorePatterns end-to-end regression integration storybook /out/.*test.js",
     "_test-integration": "TS_NODE_PROJECT=client/web/src/integration/tsconfig.json mocha --parallel=$CI --retries=1 --jobs=2",
     "test-integration": "yarn _test-integration \"./client/web/src/integration/**/*.test.ts\"",
-    "test-integration:debug": "BROWSER=chrome KEEP_BROWSER=true DEVTOOLS=true USE_STANDALONE_WEB_SERVER=true yarn _test-integration --retries=0 --jobs=1",
+    "test-integration:debug": "BROWSER=chrome KEEP_BROWSER=true DEVTOOLS=true USE_STANDALONE_WEB_SERVER=true WINDOW_WIDTH=1920 WINDOW_HEIGHT=1080 yarn _test-integration --retries=0 --jobs=1",
     "test-browser-integration": "yarn workspace @sourcegraph/browser run test-integration",
     "_cover-integration": "nyc --hook-require=false --silent yarn _test-integration",
     "cover-integration": "nyc --hook-require=false --silent yarn test-integration",


### PR DESCRIPTION
## Context

### Problem

According to [our developer docs](https://docs.sourcegraph.com/dev/how-to/testing#running-client-integration-tests), the recommended way to debug integration tests locally is by:

1. Building the web application with either `yarn watch-web` or `yarn build-web`.
2. Running integration tests that would utility static assets created in the previous step.

**This workflow is not optimized for fast iteration**. Usually, there's no reason to rebuild the whole application to verify changes in the application logic. 

### Solution

Ideally, we want to rely on incremental builds that would allow an almost instant feedback cycle after changing the web application source code. This PR enables such a mechanism by introducing an environment variable `DISABLE_APP_ASSETS_MOCKING`, which disables mocking of `index.html` and web application build assets. Instead, these requests can go directly to the `web-standalone` server, powered by the `webpack-dev-server` and incremental builds.

## Changes

1. `DISABLE_APP_ASSETS_MOCKING` added to the Puppeteer driver configuration.
2. `DISABLE_APP_ASSETS_MOCKING` is used to disable `index.html` and app assets mocking.
3. `yarn test-integration:debug` is added to ease the use of the new environment variable.
4. `WINDOW_WIDTH` and `WINDOW_HEIGHT` added to control browser window size for locally running integration tests.

Under the hood, the `yarn test-integration:debug` command uses several environment variables:

1. `KEEP_BROWSER=true` to keep browser and current tab open on test completion
2. `DEVTOOLS=true` to keep dev tools opened by default
3. `DISABLE_APP_ASSETS_MOCKING=true` to enable faster iteration with `webpack-dev-server`.
4. `WINDOW_WIDTH=1920 WINDOW_HEIGHT=1080` for bigger window size to account for opened dev tools.

## Test plan

Run `yarn test-integration:debug PATH_TO_THE_TEST_FILE_TO_DEBUG` locally along with `sg start web-standalone` to debug a specific integration test.

## App preview:

- [Web](https://sg-web-vb-test-integration-debug-cmd.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-hxikwqeekb.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
Closes https://github.com/sourcegraph/sourcegraph/issues/37661
