### PR TITLE
Make sure to install yarn dependencies before running JetBrains scripts

### DIFF
--- a/enterprise/dev/ci/internal/ci/operations.go
+++ b/enterprise/dev/ci/internal/ci/operations.go
@@ -294,6 +294,7 @@ func addBrowserExtensionUnitTests(pipeline *bk.Pipeline) {
 func addJetBrainsUnitTests(pipeline *bk.Pipeline) {
 	pipeline.AddStep(":jest::java: Test (client/jetbrains)",
 		withYarnCache(),
+		bk.Cmd("yarn --frozen-lockfile --network-timeout 60000"),
 		bk.Cmd("yarn generate"),
 		bk.Cmd("yarn --cwd client/jetbrains -s build"),
 	)


### PR DESCRIPTION
Fixes #37548

We never installed the yarn dependencies before we run yarn commands in the JetBrains part of the tests. This was causing builds to fail when the cache wasn't available.

I copied the yarn install line from our VSCode specific scripts.

## Test plan

Wait for CI to be all ✅

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
