### PR TITLE
Fix nil panic in worker due to uninitialized operations

### DIFF
--- a/internal/codeintel/stores/dbstore/observability.go
+++ b/internal/codeintel/stores/dbstore/observability.go
@@ -176,6 +176,7 @@ func newOperations(observationContext *observation.Context, metrics *metrics.RED
 		selectPoliciesForRepositoryMembershipUpdate: op("selectPoliciesForRepositoryMembershipUpdate"),
 		selectRepositoriesForIndexScan:              op("SelectRepositoriesForIndexScan"),
 		selectRepositoriesForRetentionScan:          op("SelectRepositoriesForRetentionScan"),
+		selectRepositoriesForLockfileIndexScan:      op("SelectRepositoriesForLockfileIndexScan"),
 		softDeleteExpiredUploads:                    op("SoftDeleteExpiredUploads"),
 		updateCommitedAt:                            op("UpdateCommitedAt"),
 		updateConfigurationPolicy:                   op("UpdateConfigurationPolicy"),


### PR DESCRIPTION
Ran into this locally after making last-minute changes in my other PR.

## Test plan

- Manually checked `worker` doesn't crash anymore.