### PR TITLE
add a separator between title and user title when providing feedback

### DIFF
--- a/dev/sg/sg_feedback.go
+++ b/dev/sg/sg_feedback.go
@@ -86,7 +86,7 @@ func gatherFeedback(ctx *cli.Context, out *std.Output, in io.Reader) (string, st
 		// if the userTitle matches anyone of these words, don't add it to the final title
 		break
 	default:
-		title = title + userTitle
+		title = title + " - " + userTitle
 	}
 
 	return title, strings.TrimSpace(string(body)), nil


### PR DESCRIPTION
Found this while recording the loom. When a user provides a title there is no spacing between the generated title and the user provided title 😱 
## Test plan
Manually tested
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
