### PR TITLE
HK: Update yarn.lock

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -17942,11 +17942,6 @@ micromatch@^4.0.0, micromatch@^4.0.2, micromatch@^4.0.4:
     braces "^3.0.1"
     picomatch "^2.2.3"
 
-mime-db@1.49.0:
-  version "1.49.0"
-  resolved "https://registry.npmjs.org/mime-db/-/mime-db-1.49.0.tgz#f3dfde60c99e9cf3bc9701d687778f537001cbed"
-  integrity sha512-CIc8j9URtOVApSFCQIF+VBkX1RwXp/oMMOrqdyXSBXq5RWNEsRfyj1kiRnQgmNXmHxPoFIxOroKA3zcU9P+nAA==
-
 mime-db@1.52.0, "mime-db@>= 1.43.0 < 2":
   version "1.52.0"
   resolved "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"


### PR DESCRIPTION
## What's up
After doing `yarn` on the current `main` (`294b8a0f28a90765a5d6ed089eb0cae2c814f82a`), there's no longer a `mime-db@1.49.0` in the `yarn.lock`.

I couldn't easily find by browsing change history what caused it but I am assuming some peer deps got updated and this change hasn't been committed.

This fixes it.

## Test plan

1. Pull the `main` branch
2. Run `yarn`
3. See that the dependency is indeed missing

## App preview:

- [Web](https://sg-web-og-update-yarn-lock.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-ycsdjbhyhr.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
