### PR TITLE
JetBrains: Use DialogWrapper instead of JBPopup

### DIFF
--- a/client/jetbrains/src/main/java/com/sourcegraph/find/FindPopupDialog.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/find/FindPopupDialog.java
@@ -9,6 +9,7 @@ import com.intellij.openapi.project.ProjectManagerListener;
 import com.intellij.openapi.ui.DialogWrapper;
 import com.intellij.openapi.ui.popup.ActiveIcon;
 import com.intellij.openapi.util.DimensionService;
+import com.intellij.openapi.util.WindowStateService;
 import com.intellij.openapi.wm.WindowManager;
 import com.intellij.openapi.wm.impl.IdeFrameImpl;
 import com.intellij.openapi.wm.impl.IdeGlassPaneImpl;
@@ -73,7 +74,7 @@ public class FindPopupDialog extends DialogWrapper {
         ApplicationManager.getApplication().getMessageBus().connect(this.getDisposable()).subscribe(ProjectManager.TOPIC, new ProjectManagerListener() {
             @Override
             public void projectClosed(@NotNull Project project) {
-                hide();
+                FindPopupDialog.this.doCancelAction();
             }
         });
 
@@ -160,7 +161,20 @@ public class FindPopupDialog extends DialogWrapper {
     }
 
     public void hide() {
+        saveSize();
         getPeer().getWindow().setVisible(false);
+    }
+
+    // The automatic size saving behavior for DialogWrapper does not work for us as it relies on disposing of the
+    // dialog to persist the changes. We need to manually implement this behavior instead.
+    private void saveSize() {
+        String serviceKey = this.getDimensionServiceKey();
+        WindowStateService windowStateService = WindowStateService.getInstance(project);
+
+        Point location = getLocation();
+        Dimension size = getSize();
+        windowStateService.putLocation(serviceKey, location);
+        windowStateService.putSize(serviceKey, size);
     }
 
     @Override

--- a/client/jetbrains/src/main/java/com/sourcegraph/find/FindPopupDialog.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/find/FindPopupDialog.java
@@ -176,25 +176,38 @@ public class FindPopupDialog extends DialogWrapper {
     }
 
     public void hide() {
-        saveSize();
+        saveDimensions();
         getPeer().getWindow().setVisible(false);
-    }
-
-    // The automatic size saving behavior for DialogWrapper does not work for us as it relies on disposing of the
-    // dialog to persist the changes. We need to manually implement this behavior instead.
-    private void saveSize() {
-        String serviceKey = this.getDimensionServiceKey();
-        WindowStateService windowStateService = WindowStateService.getInstance(project);
-
-        Point location = getLocation();
-        Dimension size = getSize();
-        windowStateService.putLocation(serviceKey, location);
-        windowStateService.putSize(serviceKey, size);
     }
 
     @Override
     public void show() {
         getPeer().getWindow().setVisible(true);
+
+        // When the dialog is forced to be visible again, it's dimensions are reset to what they were originally set
+        // when it first opened. Since we do have a snapshot of the locations saved from the time we hid it which was
+        // captured with the current state of the content, we can apply simply it.
+        applyDimensions();
+    }
+
+    // The automatic size saving behavior for DialogWrapper does not work for us as it relies on disposing of the
+    // dialog to persist the changes. We need to manually implement this behavior instead.
+    private void saveDimensions() {
+        WindowStateService windowStateService = WindowStateService.getInstance(project);
+
+        Point location = getLocation();
+        Dimension size = getSize();
+        windowStateService.putLocation(SERVICE_KEY, location);
+        windowStateService.putSize(SERVICE_KEY, size);
+    }
+
+    private void applyDimensions() {
+        WindowStateService windowStateService = WindowStateService.getInstance(project);
+
+        Point location = windowStateService.getLocation(SERVICE_KEY);
+        Dimension size = windowStateService.getSize(SERVICE_KEY);
+        setLocation(location);
+        setSize(size.width, size.height);
     }
 
     @Override

--- a/client/jetbrains/src/main/java/com/sourcegraph/find/FindPopupDialog.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/find/FindPopupDialog.java
@@ -1,0 +1,178 @@
+package com.sourcegraph.find;
+
+import com.intellij.ide.IdeEventQueue;
+import com.intellij.ide.ui.UISettings;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.project.ProjectManager;
+import com.intellij.openapi.project.ProjectManagerListener;
+import com.intellij.openapi.ui.DialogWrapper;
+import com.intellij.openapi.ui.popup.ActiveIcon;
+import com.intellij.openapi.util.DimensionService;
+import com.intellij.openapi.wm.WindowManager;
+import com.intellij.openapi.wm.impl.IdeFrameImpl;
+import com.intellij.openapi.wm.impl.IdeGlassPaneImpl;
+import com.intellij.ui.PopupBorder;
+import com.intellij.ui.TitlePanel;
+import com.intellij.ui.WindowMoveListener;
+import com.intellij.ui.WindowResizeListener;
+import com.intellij.ui.awt.RelativePoint;
+import com.intellij.util.ui.JBUI;
+import com.intellij.util.ui.UIUtil;
+import com.sourcegraph.Icons;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import javax.swing.*;
+import javax.swing.border.Border;
+import java.awt.*;
+
+public class FindPopupDialog extends DialogWrapper {
+    private static final String SERVICE_KEY = "sourcegraph.find.popup";
+    private final JComponent mainPanel;
+    private final Project project;
+
+    public FindPopupDialog(@Nullable Project project, JComponent myMainPanel) {
+        super(project, false);
+
+        this.project = project;
+        this.mainPanel = myMainPanel;
+
+        setTitle("Sourcegraph");
+        getWindow().setMinimumSize(new Dimension(750, 420));
+
+        init();
+        addNativeFindInFilesBehaviors();
+        show();
+    }
+
+
+//    // Overwrite the createPeer function that is being used in the super constructor so that we can create a new frame.
+//    // This is needed because ...
+//    @Override
+//    protected @NotNull DialogWrapperPeer createPeer(@Nullable Project project, boolean canBeParent, @NotNull IdeModalityType ideModalityType) {
+//        Frame frame = new Frame();
+//        return DialogWrapperPeerFactory.getInstance().createPeer(this, frame, canBeParent, ideModalityType);
+//    }
+
+    @Override
+    protected @Nullable JComponent createCenterPanel() {
+        TitlePanel titlePanel = new TitlePanel(new ActiveIcon(Icons.Logo).getRegular(), new ActiveIcon(Icons.Logo).getInactive());
+        titlePanel.setText(getTitle());
+
+        addMoveListeners(titlePanel);
+
+        // Adding the center panel
+        return JBUI.Panels.simplePanel()
+            .addToTop(titlePanel)
+            .addToCenter(mainPanel);
+    }
+
+    // This adds behaviors found in JetBrain's native FindPopupPanel:
+    // https://sourcegraph.com/github.com/JetBrains/intellij-community/-/blob/platform/lang-impl/src/com/intellij/find/impl/FindPopupPanel.java
+    private void addNativeFindInFilesBehaviors() {
+        this.setUndecorated(true);
+        ApplicationManager.getApplication().getMessageBus().connect(this.getDisposable()).subscribe(ProjectManager.TOPIC, new ProjectManagerListener() {
+            @Override
+            public void projectClosed(@NotNull Project project) {
+                doCancelAction();
+            }
+        });
+
+        Window window = WindowManager.getInstance().suggestParentWindow(project);
+        Component parent = UIUtil.findUltimateParent(window);
+        RelativePoint showPoint = null;
+        Point screenPoint = DimensionService.getInstance().getLocation(SERVICE_KEY, project);
+        if (screenPoint != null) {
+            if (parent != null) {
+                SwingUtilities.convertPointFromScreen(screenPoint, parent);
+                showPoint = new RelativePoint(parent, screenPoint);
+            } else {
+                showPoint = new RelativePoint(screenPoint);
+            }
+        }
+        if (parent != null && showPoint == null) {
+            int height = UISettings.getInstance().getShowNavigationBar() ? 135 : 115;
+            if (parent instanceof IdeFrameImpl && ((IdeFrameImpl) parent).isInFullScreen()) {
+                height -= 20;
+            }
+            showPoint = new RelativePoint(parent, new Point((parent.getSize().width - getPreferredSize().width) / 2, height));
+        }
+
+        addMoveListeners(this.mainPanel);
+
+        Dimension panelSize = getPreferredSize();
+        Dimension prev = DimensionService.getInstance().getSize(SERVICE_KEY, project);
+        if (prev != null && prev.height < panelSize.height) prev.height = panelSize.height;
+        Window dialogWindow = this.getPeer().getWindow();
+        JRootPane root = ((RootPaneContainer) dialogWindow).getRootPane();
+
+        IdeGlassPaneImpl glass = (IdeGlassPaneImpl) this.getRootPane().getGlassPane();
+        WindowResizeListener resizeListener = new WindowResizeListener(
+            root,
+            JBUI.insets(4),
+            null) {
+            private Cursor myCursor;
+
+            @Override
+            protected void setCursor(@NotNull Component content, Cursor cursor) {
+                if (myCursor != cursor || myCursor != Cursor.getDefaultCursor()) {
+                    glass.setCursor(cursor, this);
+                    myCursor = cursor;
+
+                    if (content instanceof JComponent) {
+                        IdeGlassPaneImpl.savePreProcessedCursor((JComponent) content, content.getCursor());
+                    }
+                    super.setCursor(content, cursor);
+                }
+            }
+        };
+        glass.addMousePreprocessor(resizeListener, myDisposable);
+        glass.addMouseMotionPreprocessor(resizeListener, myDisposable);
+
+        root.setWindowDecorationStyle(JRootPane.NONE);
+        root.setBorder(PopupBorder.Factory.create(true, true));
+        UIUtil.markAsPossibleOwner((Dialog) dialogWindow);
+        dialogWindow.setBackground(UIUtil.getPanelBackground());
+        dialogWindow.setMinimumSize(panelSize);
+        dialogWindow.setSize(prev != null ? prev : panelSize);
+
+        IdeEventQueue.getInstance().getPopupManager().closeAllPopups(false);
+        if (showPoint != null) {
+            this.setLocation(showPoint.getScreenPoint());
+        } else {
+            dialogWindow.setLocationRelativeTo(null);
+        }
+    }
+
+    private void addMoveListeners(Component component) {
+        WindowMoveListener windowListener = new WindowMoveListener(component);
+        component.addMouseListener(windowListener);
+        component.addMouseMotionListener(windowListener);
+    }
+
+    @Override
+    protected JComponent createSouthPanel() {
+        return null;
+    }
+
+    @Override
+    protected @Nullable Border createContentPaneBorder() {
+        return null;
+    }
+
+    public void hide() {
+        System.out.println("hide or no>");
+        getPeer().getWindow().setVisible(false);
+    }
+
+    @Override
+    public void show() {
+        super.show();
+    }
+
+    @Override
+    protected String getDimensionServiceKey() {
+        return SERVICE_KEY;
+    }
+}

--- a/client/jetbrains/src/main/java/com/sourcegraph/find/FindPopupDialog.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/find/FindPopupDialog.java
@@ -43,17 +43,15 @@ public class FindPopupDialog extends DialogWrapper {
 
         init();
         addNativeFindInFilesBehaviors();
-        show();
+
+        // Avoid the show method to be blocking
+        this.setModal(false);
+        // Prevent the dialog from being cancelable by any default behaviors
+        myCancelAction.setEnabled(false);
+
+        super.show();
     }
 
-
-//    // Overwrite the createPeer function that is being used in the super constructor so that we can create a new frame.
-//    // This is needed because ...
-//    @Override
-//    protected @NotNull DialogWrapperPeer createPeer(@Nullable Project project, boolean canBeParent, @NotNull IdeModalityType ideModalityType) {
-//        Frame frame = new Frame();
-//        return DialogWrapperPeerFactory.getInstance().createPeer(this, frame, canBeParent, ideModalityType);
-//    }
 
     @Override
     protected @Nullable JComponent createCenterPanel() {
@@ -75,7 +73,7 @@ public class FindPopupDialog extends DialogWrapper {
         ApplicationManager.getApplication().getMessageBus().connect(this.getDisposable()).subscribe(ProjectManager.TOPIC, new ProjectManagerListener() {
             @Override
             public void projectClosed(@NotNull Project project) {
-                doCancelAction();
+                hide();
             }
         });
 
@@ -162,13 +160,12 @@ public class FindPopupDialog extends DialogWrapper {
     }
 
     public void hide() {
-        System.out.println("hide or no>");
         getPeer().getWindow().setVisible(false);
     }
 
     @Override
     public void show() {
-        super.show();
+        getPeer().getWindow().setVisible(true);
     }
 
     @Override

--- a/client/jetbrains/src/main/java/com/sourcegraph/find/FindService.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/find/FindService.java
@@ -6,14 +6,8 @@ import com.intellij.openapi.actionSystem.*;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
-import com.intellij.openapi.ui.popup.ActiveIcon;
-import com.intellij.openapi.ui.popup.ComponentPopupBuilder;
-import com.intellij.openapi.ui.popup.JBPopup;
-import com.intellij.openapi.ui.popup.JBPopupFactory;
 import com.intellij.openapi.wm.ex.WindowManagerEx;
-import com.intellij.ui.popup.AbstractPopup;
 import com.intellij.util.ui.UIUtil;
-import com.sourcegraph.Icons;
 import org.cef.browser.CefBrowser;
 import org.cef.handler.CefKeyboardHandler;
 import org.cef.misc.BoolRef;
@@ -29,7 +23,7 @@ import static java.awt.event.WindowEvent.WINDOW_GAINED_FOCUS;
 public class FindService implements Disposable {
     private final Project project;
     private final FindPopupPanel mainPanel;
-    private JBPopup popup;
+    private FindPopupDialog popup;
     private static final Logger logger = Logger.getInstance(FindService.class);
 
     public FindService(@NotNull Project project) {
@@ -40,13 +34,11 @@ public class FindService implements Disposable {
     }
 
     synchronized public void showPopup() {
-        if (popup == null || popup.isDisposed()) {
-            popup = createPopup();
-            popup.showCenteredInCurrentWindow(project);
-            registerOutsideClickListener();
-        } else {
-            popup.setUiVisible(true);
+        if (popup != null && popup.isDisposed()) {
+            System.out.println("DEADDEADDEADDEADDEADDEADDEADDEAD");
         }
+
+        createOrShowPopup();
 
         // If the popup is already shown, hitting alt + a gain should behave the same as the native find in files
         // feature and focus the search field.
@@ -56,44 +48,35 @@ public class FindService implements Disposable {
     }
 
     public void hidePopup() {
-        popup.setUiVisible(false);
+        popup.hide();
         hideMaterialUiOverlay();
     }
 
     @NotNull
-    private JBPopup createPopup() {
-        ComponentPopupBuilder builder = JBPopupFactory.getInstance().createComponentPopupBuilder(mainPanel, mainPanel)
-            .setTitle("Sourcegraph")
-            .setTitleIcon(new ActiveIcon(Icons.Logo))
-            .setProject(project)
-            .setModalContext(false)
-            .setCancelOnClickOutside(true)
-            .setRequestFocus(true)
-            .setCancelKeyEnabled(false)
-            .setResizable(true)
-            .setMovable(true)
-            .setLocateWithinScreenBounds(false)
-            .setFocusable(true)
-            .setCancelOnWindowDeactivation(false)
-            .setCancelOnClickOutside(true)
-            .setBelongsToGlobalPopupStack(true)
-            .setMinSize(new Dimension(750, 420))
-            .setNormalWindowLevel(true);
+    private void createOrShowPopup() {
+        if (popup != null && !popup.isDisposed()) {
+            popup.show();
+        }
+        if (popup == null || popup.isDisposed()) {
+            if (popup != null && popup.isDisposed()) {
+                System.out.println("???????");
+            }
+            popup = new FindPopupDialog(project, mainPanel);
 
-        // For some reason, adding a cancelCallback will prevent the cancel event to fire when using the escape key. To
-        // work around this, we add a manual listener to both the global key handler (since the editor component seems
-        // to work around the default swing event hands long) and the browser panel which seems to handle events in a
-        // separate queue.
-        registerGlobalKeyListeners();
-        registerJBCefClientKeyListeners();
-
-        return builder.createPopup();
+            // For some reason, adding a cancelCallback will prevent the cancel event to fire when using the escape key. To
+            // work around this, we add a manual listener to both the global key handler (since the editor component seems
+            // to work around the default swing event hands long) and the browser panel which seems to handle events in a
+            // separate queue.
+            registerGlobalKeyListeners();
+            registerJBCefClientKeyListeners();
+            registerOutsideClickListener();
+        }
     }
 
     private void registerGlobalKeyListeners() {
         KeyboardFocusManager.getCurrentKeyboardFocusManager()
             .addKeyEventDispatcher(e -> {
-                if (e.getID() != KeyEvent.KEY_PRESSED || popup.isDisposed() || !popup.isVisible() || !popup.isFocused()) {
+                if (e.getID() != KeyEvent.KEY_PRESSED || popup != null && (popup.isDisposed() || !popup.isVisible())) {
                     return false;
                 }
 
@@ -147,6 +130,7 @@ public class FindService implements Disposable {
         Window projectParentWindow = getParentWindow(null);
 
         Toolkit.getDefaultToolkit().addAWTEventListener(event -> {
+            System.out.println(event);
             if (event instanceof WindowEvent) {
                 WindowEvent windowEvent = (WindowEvent) event;
 
@@ -155,18 +139,38 @@ public class FindService implements Disposable {
                     return;
                 }
 
-                // Detect if we're focusing the Sourcegraph popup
-                if (popup instanceof AbstractPopup) {
-                    Window sourcegraphPopupWindow = ((AbstractPopup) popup).getPopupWindow();
+                // We only care for these events when the popup is shown
+//                if (!this.popup.isVisible()) {
+//                    return;
+//                }
 
-                    if (windowEvent.getWindow().equals(sourcegraphPopupWindow)) {
-                        return;
-                    }
+                System.out.println("-----------------------------------------------");
+                System.out.println("getComponent(): " + windowEvent.getComponent().toString());
+//                System.out.println(windowEvent.getComponent());
+                System.out.println("projectParentWindow: " + projectParentWindow.toString());
+//                System.out.println(projectParentWindow);
+                System.out.println("getWindow(): " + this.popup.getWindow().toString());
+//                System.out.println(this.popup.getWindow());
+
+                // Detect if we're focusing the Sourcegraph popup
+                if (windowEvent.getComponent().equals(this.popup.getWindow())) {
+                    System.out.println("windowEvent.getComponent().equals(this.popup.getWindow())");
+                    return;
                 }
+//                if (popup instanceof AbstractPopup) {
+//                    Window sourcegraphPopupWindow = ((AbstractPopup) popup).getPopupWindow();
+//
+//                    if (windowEvent.getWindow().equals(sourcegraphPopupWindow)) {
+//                        return;
+//                    }
+//                }
 
                 // Detect if the newly focused window is a parent of the project root window
                 Window currentProjectParentWindow = getParentWindow(windowEvent.getComponent());
+                System.out.println("currentProjectParentWindow(): " + currentProjectParentWindow.toString());
+//                System.out.println(currentProjectParentWindow);
                 if (currentProjectParentWindow.equals(projectParentWindow)) {
+                    System.out.println("currentProjectParentWindow.equals(projectParentWindow)");
                     hidePopup();
                 }
             }
@@ -189,7 +193,7 @@ public class FindService implements Disposable {
     @Override
     public void dispose() {
         if (popup != null) {
-            popup.dispose();
+            popup.getWindow().dispose();
         }
 
         mainPanel.dispose();

--- a/client/jetbrains/src/main/java/com/sourcegraph/find/FindService.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/find/FindService.java
@@ -54,13 +54,10 @@ public class FindService implements Disposable {
 
     @NotNull
     private void createOrShowPopup() {
-        if (popup != null && !popup.isDisposed()) {
+        if (popup != null) {
             popup.show();
         }
-        if (popup == null || popup.isDisposed()) {
-            if (popup != null && popup.isDisposed()) {
-                System.out.println("???????");
-            }
+        if (popup == null) {
             popup = new FindPopupDialog(project, mainPanel);
 
             // For some reason, adding a cancelCallback will prevent the cancel event to fire when using the escape key. To
@@ -104,6 +101,7 @@ public class FindService implements Disposable {
     }
 
     private boolean handleKeyPress(boolean isWebView, int keyCode, int modifiers) {
+        System.out.println("handleKeyPress");
         if (keyCode == KeyEvent.VK_ESCAPE && modifiers == 0) {
             ApplicationManager.getApplication().invokeLater(this::hidePopup);
             return true;

--- a/client/jetbrains/src/main/java/com/sourcegraph/find/FindService.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/find/FindService.java
@@ -54,8 +54,7 @@ public class FindService implements Disposable {
             if (!popup.isVisible()) {
                 popup.show();
             }
-        }
-        if (popup == null) {
+        } else {
             popup = new FindPopupDialog(project, mainPanel);
 
             // We add a manual listener to both the global key handler (since the editor component seems to work around

--- a/client/jetbrains/src/main/java/com/sourcegraph/find/FindService.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/find/FindService.java
@@ -139,7 +139,6 @@ public class FindService implements Disposable {
 
                 // Detect if we're focusing the Sourcegraph popup
                 if (windowEvent.getComponent().equals(this.popup.getWindow())) {
-                    System.out.println("windowEvent.getComponent().equals(this.popup.getWindow())");
                     return;
                 }
 

--- a/client/jetbrains/src/main/java/com/sourcegraph/find/FindService.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/find/FindService.java
@@ -34,10 +34,6 @@ public class FindService implements Disposable {
     }
 
     synchronized public void showPopup() {
-        if (popup != null && popup.isDisposed()) {
-            System.out.println("DEADDEADDEADDEADDEADDEADDEADDEAD");
-        }
-
         createOrShowPopup();
 
         // If the popup is already shown, hitting alt + a gain should behave the same as the native find in files
@@ -129,7 +125,6 @@ public class FindService implements Disposable {
         Window projectParentWindow = getParentWindow(null);
 
         Toolkit.getDefaultToolkit().addAWTEventListener(event -> {
-            System.out.println(event);
             if (event instanceof WindowEvent) {
                 WindowEvent windowEvent = (WindowEvent) event;
 
@@ -138,33 +133,19 @@ public class FindService implements Disposable {
                     return;
                 }
 
-                System.out.println("-----------------------------------------------");
-                System.out.println("getComponent(): " + windowEvent.getComponent().toString());
-//                System.out.println(windowEvent.getComponent());
-                System.out.println("projectParentWindow: " + projectParentWindow.toString());
-//                System.out.println(projectParentWindow);
-                System.out.println("getWindow(): " + this.popup.getWindow().toString());
-//                System.out.println(this.popup.getWindow());
+                if (!this.popup.isVisible()) {
+                    return;
+                }
 
                 // Detect if we're focusing the Sourcegraph popup
                 if (windowEvent.getComponent().equals(this.popup.getWindow())) {
                     System.out.println("windowEvent.getComponent().equals(this.popup.getWindow())");
                     return;
                 }
-//                if (popup instanceof AbstractPopup) {
-//                    Window sourcegraphPopupWindow = ((AbstractPopup) popup).getPopupWindow();
-//
-//                    if (windowEvent.getWindow().equals(sourcegraphPopupWindow)) {
-//                        return;
-//                    }
-//                }
 
                 // Detect if the newly focused window is a parent of the project root window
                 Window currentProjectParentWindow = getParentWindow(windowEvent.getComponent());
-                System.out.println("currentProjectParentWindow(): " + currentProjectParentWindow.toString());
-//                System.out.println(currentProjectParentWindow);
                 if (currentProjectParentWindow.equals(projectParentWindow)) {
-                    System.out.println("currentProjectParentWindow.equals(projectParentWindow)");
                     hidePopup();
                 }
             }


### PR DESCRIPTION
Closes #37322
Closes #34967

This PR rewrites the way we handle the popover inside Java to use the DialogWrapper (the same primitive that is underneath the native Find in Files dialog) instead of a JBPopup.

There are many considerations that went into this with a lot of trial and error but I will try to recap this as good as possible:

- The `DialogWrapper` makes the modal behave like it's own window which means that if another process is brought into the forgeround on macOS, it will not be rendered on top of it (Our main motivation for creating this work, c.f. #37322)
- It does by default also look like a native window (with the app close icons etc.). We have to completely opt-out of this behavior via `setUndercorated(true`).
- Undecorated modals do not have any behavior to them. E.g. they won't close if you do anything, they won't have resize listeners, nothing. Thus, we had to re-implement all these behaviors manually. Most of that is inspired by the [native find in files implementation](https://sourcegraph.com/github.com/JetBrains/intellij-community/-/blob/platform/lang-impl/src/com/intellij/find/impl/FindPopupPanel.java) and was moved to `addNativeFindInFilesBehaviors()`.
  - This method is applying all "tweaks" that the native find in files component is also doing. It also has special code to handle restoring of window dimensions that are saved under special considerations (e.g. different screen resolutions), so it is probably a good win for us to rely on that logic and not have to find the same mistakes over time. 
- There are two main changes that we are applying:
  - We don't dispose the window if we no longer need it because of the web view disappearance issue. Instead, we only hide it visually. This needed some special handling to persist the window size as the default behavior only triggers when the window is disposed (which it no longer is). 
  -  We want the window to close when another window gets focus. This needs to be scoped per-project as multiple JetBrains project can be open in the same Application. For that, we could reuse the previous `registerOutsideClickListener` logic.

I’m sorry for the mess in the commit history. Prior to coming back to this approach where we subclass the `DialogWrapper` I worked on [an approach similar to the native find in files](https://github.com/sourcegraph/sourcegraph/tree/ps/jetbrains-find-in-files-fork). I've taken the results and learnings from this work and applied it here in one go so you don't see the individual stages of API surgery that I did before, lol. Here's a quick history of the historical changes: https://github.com/sourcegraph/sourcegraph/commits/ps/jetbrains-find-in-files-fork

## Test plan

_A lot_ of manual testing but I need more help! Here are just some of the cases that I tried:

https://drive.google.com/file/d/1elpP1wF4JtEpDZw07qgRo20NItFYP5Wh/view?usp=sharing

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-jetbrains-dialogwrapper.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-tnsxpzgckv.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
